### PR TITLE
bgpd: Allow using LOCAL_PREF for eBGP sessions if explicitly enabled

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -583,7 +583,8 @@ const char *const peer_down_str[] = {"",
 			       "No AFI/SAFI activated for peer",
 			       "AS Set config change",
 			       "Waiting for peer OPEN",
-			       "Reached received prefix count"};
+			       "Reached received prefix count",
+			       "Changed eBGP LOCAL_PREF treatment"};
 
 static int bgp_graceful_restart_timer_expire(struct thread *thread)
 {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1778,8 +1778,12 @@ bool subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 	/* For modify attribute, copy it to temporary structure. */
 	*attr = *piattr;
 
-	/* If local-preference is not set. */
-	if ((peer->sort == BGP_PEER_IBGP || peer->sort == BGP_PEER_CONFED)
+	/* If local-preference is not set.
+	 * This could be allowed for external neighbor only
+	 * if enabled `neighbor ebgp-allow-local-preference`.
+	 */
+	if ((peer->sort == BGP_PEER_IBGP || peer->sort == BGP_PEER_CONFED
+	     || CHECK_FLAG(peer->flags, PEER_FLAG_EBGP_ALLOW_LOCAL_PREF))
 	    && (!(attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)))) {
 		attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF);
 		attr->local_pref = bgp->default_local_pref;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3873,6 +3873,7 @@ static const struct peer_flag_action peer_flag_action_list[] = {
 	{PEER_FLAG_LOCAL_AS_NO_PREPEND, 0, peer_change_none},
 	{PEER_FLAG_LOCAL_AS_REPLACE_AS, 0, peer_change_none},
 	{PEER_FLAG_UPDATE_SOURCE, 0, peer_change_none},
+	{PEER_FLAG_EBGP_ALLOW_LOCAL_PREF, 0, peer_change_none},
 	{0, 0, 0}};
 
 static const struct peer_flag_action peer_af_flag_action_list[] = {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1095,6 +1095,8 @@ struct peer {
 #define PEER_FLAG_GRACEFUL_RESTART          (1 << 24) /* Graceful Restart */
 #define PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT (1 << 25) /* Global-Inherit */
 
+#define PEER_FLAG_EBGP_ALLOW_LOCAL_PREF (1 << 26) /* eBGP local-preference */
+
 	/*
 	 *GR-Disabled mode means unset PEER_FLAG_GRACEFUL_RESTART
 	 *& PEER_FLAG_GRACEFUL_RESTART_HELPER
@@ -1381,6 +1383,7 @@ struct peer {
 #define PEER_DOWN_AS_SETS_REJECT        31 /* Reject routes with AS_SET */
 #define PEER_DOWN_WAITING_OPEN          32 /* Waiting for open to succeed */
 #define PEER_DOWN_PFX_COUNT             33 /* Reached received prefix count */
+#define PEER_DOWN_EBGP_ALLOW_LOCAL_PREF 34 /* ebgp-allow-local-preference */
 	/*
 	 * Remember to update peer_down_str in bgp_fsm.c when you add
 	 * a new value to the last_reset reason

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1283,6 +1283,12 @@ Configuring Peers
 
    Sets a maximum number of prefixes we can send to a given peer.
 
+.. index:: [no] neighbor PEER ebgp-allow-local-preference
+.. clicmd:: [no] neighbor PEER ebgp-allow-local-preference
+
+   Allow using local-preference attribute for this neighbor even if
+   it's an external neighbor.
+
 .. index:: [no] neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
 .. clicmd:: [no] neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
 

--- a/tests/topotests/bgp_ebgp_local_preference/r1/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_local_preference/r1/bgpd.conf
@@ -1,0 +1,12 @@
+!
+router bgp 65001
+  neighbor 192.168.255.1 remote-as external
+  neighbor 192.168.255.1 ebgp-allow-local-preference
+  address-family ipv4 unicast
+    redistribute connected route-map local_pref
+  exit-address-family
+  !
+!
+route-map local_pref permit 10
+  set local-preference 123
+!

--- a/tests/topotests/bgp_ebgp_local_preference/r1/zebra.conf
+++ b/tests/topotests/bgp_ebgp_local_preference/r1/zebra.conf
@@ -1,0 +1,9 @@
+!
+interface lo
+ ip address 172.16.255.254/32
+!
+interface r1-eth0
+ ip address 192.168.255.2/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_ebgp_local_preference/r2/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_local_preference/r2/bgpd.conf
@@ -1,0 +1,5 @@
+!
+router bgp 65002
+  neighbor 192.168.255.2 remote-as external
+  neighbor 192.168.255.2 ebgp-allow-local-preference
+!

--- a/tests/topotests/bgp_ebgp_local_preference/r2/zebra.conf
+++ b/tests/topotests/bgp_ebgp_local_preference/r2/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r2-eth0
+ ip address 192.168.255.1/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_ebgp_local_preference/test_bgp_ebgp_local_preference.py
+++ b/tests/topotests/bgp_ebgp_local_preference/test_bgp_ebgp_local_preference.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_ebgp_local_preference.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2020 by
+# Donatas Abraitis <donatas.abraitis@gmail.com>
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+Test `neighbor ebgp-allow-local-preference`.
+This should allow using LOCAL_PREF for external neighbors.
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../'))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from mininet.topo import Topo
+
+class TemplateTopo(Topo):
+    def build(self, *_args, **_opts):
+        tgen = get_topogen(self)
+
+        for routern in range(1, 3):
+            tgen.add_router('r{}'.format(routern))
+
+        switch = tgen.add_switch('s1')
+        switch.add_link(tgen.gears['r1'])
+        switch.add_link(tgen.gears['r2'])
+
+def setup_module(mod):
+    tgen = Topogen(TemplateTopo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA,
+            os.path.join(CWD, '{}/zebra.conf'.format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP,
+            os.path.join(CWD, '{}/bgpd.conf'.format(rname))
+        )
+
+    tgen.start_router()
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_bgp_ebgp_local_preference():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears['r2']
+
+    def _bgp_converge(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp neighbor 192.168.255.2 json"))
+        expected = {
+            '192.168.255.2': {
+                'bgpState': 'Established',
+                'addressFamilyInfo': {
+                    'ipv4Unicast': {
+                        'acceptedPrefixCounter': 2
+                    }
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_has_local_pref_for_external_neighbor(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp 172.16.255.254/32 json"))
+        expected = {
+            'paths': [
+                {
+                    'localpref': 123
+                }
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge, router)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+
+    assert result is None, 'Failed bgp convergence in "{}"'.format(router)
+
+    test_func = functools.partial(_bgp_has_local_pref_for_external_neighbor, router)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+
+    assert result is None, 'Failed to see LOCAL_PREF in "{}"'.format(router)
+
+if __name__ == '__main__':
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Reading https://www.rfc-editor.org/rfc/rfc7938.html it makes sense
to enable LOCAL_PREF for external neighbors to allow controlling traffic
between leaves and spines.

This would even be cool when using routing-on-the-host scenarios.
The server just lowers LOCAL_PREF to say the upstream that I don't
wanna see the traffic but just keep the session up.

This does not break iBGP behavior.