### PR TITLE
lib: defer grpc plugin initialization to post fork

### DIFF
--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -884,7 +884,14 @@ static int frr_grpc_finish(void)
 	return 0;
 }
 
-static int frr_grpc_module_late_init(struct thread_master *tm)
+/*
+ * This is done this way because module_init and module_late_init are both
+ * called during daemon pre-fork initialization. Because the GRPC library
+ * spawns threads internally, we need to delay initializing it until after
+ * fork. This is done by scheduling this init function as an event task, since
+ * the event loop doesn't run until after fork.
+ */
+static int frr_grpc_module_very_late_init(struct thread *thread)
 {
 	static unsigned long port = GRPC_DEFAULT_PORT;
 	const char *args = THIS_MODULE->load_args;
@@ -910,13 +917,17 @@ static int frr_grpc_module_late_init(struct thread_master *tm)
 	if (frr_grpc_init(&port) < 0)
 		goto error;
 
-	hook_register(frr_fini, frr_grpc_finish);
-
-	return 0;
-
 error:
 	flog_err(EC_LIB_GRPC_INIT, "failed to initialize the gRPC module");
 	return -1;
+}
+
+static int frr_grpc_module_late_init(struct thread_master *tm)
+{
+	thread_add_event(tm, frr_grpc_module_very_late_init, NULL, 0, NULL);
+	hook_register(frr_fini, frr_grpc_finish);
+
+	return 0;
 }
 
 static int frr_grpc_module_init(void)


### PR DESCRIPTION
When using the GRPC northbound plugin, initialization occurs at the
frr_late_init hook. This is called before fork() when daemonizing (using
-d). Because the GRPC library internally creates threads, this means our
threads go away in the child process, so GRPC doesn't work when used
with -d. Rectify this situation by deferring plugin init to after fork
by scheduling a task on the threadmaster, since those are executed by
the child.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>