### PR TITLE
lib: yang northbound wrappers - type empty nexthop type2str

### DIFF
--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -22,6 +22,7 @@
 #include "log.h"
 #include "lib_errors.h"
 #include "northbound.h"
+#include "nexthop.h"
 
 static const char *yang_get_default_value(const char *xpath)
 {
@@ -1134,4 +1135,31 @@ struct yang_data *yang_data_new_mac(const char *xpath,
 void yang_str2mac(const char *value, struct ethaddr *mac)
 {
     (void)prefix_str2mac(value, mac);
+}
+
+const char *yang_nexthop_type2str(uint32_t ntype)
+{
+	switch (ntype) {
+	case NEXTHOP_TYPE_IFINDEX:
+		return "ifindex";
+		break;
+	case NEXTHOP_TYPE_IPV4:
+		return "ip4";
+		break;
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		return "ip4-ifindex";
+		break;
+	case NEXTHOP_TYPE_IPV6:
+		return "ip6";
+		break;
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		return "ip6-ifindex";
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+		return "blackhole";
+		break;
+	default:
+		return "unknown";
+		break;
+	}
 }

--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -782,6 +782,14 @@ void yang_get_default_string_buf(char *buf, size_t size, const char *xpath_fmt,
 }
 
 /*
+ * Primitive type: empty.
+ */
+struct yang_data *yang_data_new_empty(const char *xpath)
+{
+	return yang_data_new(xpath, NULL);
+}
+
+/*
  * Derived type: IP prefix.
  */
 void yang_str2prefix(const char *value, union prefixptr prefix)

--- a/lib/yang_wrappers.h
+++ b/lib/yang_wrappers.h
@@ -180,4 +180,6 @@ extern struct yang_data *yang_data_new_mac(const char *xpath,
 					   const struct ethaddr *mac);
 extern void yang_str2mac(const char *value, struct ethaddr *mac);
 
+extern const char *yang_nexthop_type2str(uint32_t ntype);
+
 #endif /* _FRR_NORTHBOUND_WRAPPERS_H_ */

--- a/lib/yang_wrappers.h
+++ b/lib/yang_wrappers.h
@@ -114,6 +114,9 @@ extern const char *yang_get_default_string(const char *xpath_fmt, ...);
 extern void yang_get_default_string_buf(char *buf, size_t size,
 					const char *xpath_fmt, ...);
 
+/* empty */
+extern struct yang_data *yang_data_new_empty(const char *xpath);
+
 /* ip prefix */
 extern void yang_str2prefix(const char *value, union prefixptr prefix);
 extern struct yang_data *yang_data_new_prefix(const char *xpath,


### PR DESCRIPTION
Two yang wrappers:
1) type empty
    lib: add yang wrapper for type empty
2) nexhtop type to string 
   lib: yang wrapper nexthop type to str

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com