### PR TITLE
ospf6d: Recent changes in our build cause const to be respected

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -1427,7 +1427,7 @@ void install_element_ospf6_debug_abr(void)
 	install_element(CONFIG_NODE, &no_debug_ospf6_abr_cmd);
 }
 
-static const struct ospf6_lsa_handler inter_prefix_handler = {
+static struct ospf6_lsa_handler inter_prefix_handler = {
 	.lh_type = OSPF6_LSTYPE_INTER_PREFIX,
 	.lh_name = "Inter-Prefix",
 	.lh_short_name = "IAP",
@@ -1435,7 +1435,7 @@ static const struct ospf6_lsa_handler inter_prefix_handler = {
 	.lh_get_prefix_str = ospf6_inter_area_prefix_lsa_get_prefix_str,
 	.lh_debug = 0};
 
-static const struct ospf6_lsa_handler inter_router_handler = {
+static struct ospf6_lsa_handler inter_router_handler = {
 	.lh_type = OSPF6_LSTYPE_INTER_ROUTER,
 	.lh_name = "Inter-Router",
 	.lh_short_name = "IAR",

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1853,7 +1853,7 @@ DEFUN (show_ipv6_ospf6_redistribute,
 	return CMD_SUCCESS;
 }
 
-static const struct ospf6_lsa_handler as_external_handler = {
+static struct ospf6_lsa_handler as_external_handler = {
 	.lh_type = OSPF6_LSTYPE_AS_EXTERNAL,
 	.lh_name = "AS-External",
 	.lh_short_name = "ASE",

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -2235,7 +2235,7 @@ void ospf6_intra_brouter_calculation(struct ospf6_area *oa)
 			  __func__, oa->name);
 }
 
-static const struct ospf6_lsa_handler router_handler = {
+static struct ospf6_lsa_handler router_handler = {
 	.lh_type = OSPF6_LSTYPE_ROUTER,
 	.lh_name = "Router",
 	.lh_short_name = "Rtr",
@@ -2243,7 +2243,7 @@ static const struct ospf6_lsa_handler router_handler = {
 	.lh_get_prefix_str = ospf6_router_lsa_get_nbr_id,
 	.lh_debug = 0};
 
-static const struct ospf6_lsa_handler network_handler = {
+static struct ospf6_lsa_handler network_handler = {
 	.lh_type = OSPF6_LSTYPE_NETWORK,
 	.lh_name = "Network",
 	.lh_short_name = "Net",
@@ -2251,7 +2251,7 @@ static const struct ospf6_lsa_handler network_handler = {
 	.lh_get_prefix_str = ospf6_network_lsa_get_ar_id,
 	.lh_debug = 0};
 
-static const struct ospf6_lsa_handler link_handler = {
+static struct ospf6_lsa_handler link_handler = {
 	.lh_type = OSPF6_LSTYPE_LINK,
 	.lh_name = "Link",
 	.lh_short_name = "Lnk",
@@ -2259,7 +2259,7 @@ static const struct ospf6_lsa_handler link_handler = {
 	.lh_get_prefix_str = ospf6_link_lsa_get_prefix_str,
 	.lh_debug = 0};
 
-static const struct ospf6_lsa_handler intra_prefix_handler = {
+static struct ospf6_lsa_handler intra_prefix_handler = {
 	.lh_type = OSPF6_LSTYPE_INTRA_PREFIX,
 	.lh_name = "Intra-Prefix",
 	.lh_short_name = "INP",

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -77,16 +77,16 @@ static struct ospf6_lsa_handler unknown_handler = {
 	.lh_debug = 0 /* No default debug */
 };
 
-void ospf6_install_lsa_handler(const struct ospf6_lsa_handler *handler)
+void ospf6_install_lsa_handler(struct ospf6_lsa_handler *handler)
 {
 	/* type in handler is host byte order */
 	int index = handler->lh_type & OSPF6_LSTYPE_FCODE_MASK;
 	vector_set_index(ospf6_lsa_handler_vector, index, (void *)handler);
 }
 
-const struct ospf6_lsa_handler *ospf6_get_lsa_handler(uint16_t type)
+struct ospf6_lsa_handler *ospf6_get_lsa_handler(uint16_t type)
 {
-	const struct ospf6_lsa_handler *handler = NULL;
+	struct ospf6_lsa_handler *handler = NULL;
 	unsigned int index = ntohs(type) & OSPF6_LSTYPE_FCODE_MASK;
 
 	if (index >= vector_active(ospf6_lsa_handler_vector))

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -237,8 +237,8 @@ extern int ospf6_lsa_checksum_valid(struct ospf6_lsa_header *);
 extern int ospf6_lsa_prohibited_duration(uint16_t type, uint32_t id,
 					 uint32_t adv_router, void *scope);
 
-extern void ospf6_install_lsa_handler(const struct ospf6_lsa_handler *handler);
-extern const struct ospf6_lsa_handler *ospf6_get_lsa_handler(uint16_t type);
+extern void ospf6_install_lsa_handler(struct ospf6_lsa_handler *handler);
+extern struct ospf6_lsa_handler *ospf6_get_lsa_handler(uint16_t type);
 
 extern void ospf6_lsa_init(void);
 extern void ospf6_lsa_terminate(void);


### PR DESCRIPTION
We are seeing this crash:

New LWP 7673]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/usr/lib/frr/ospf6d -d -F datacenter -M snmp -A ::1'.
Program terminated with signal SIGABRT, Aborted.
(gdb) bt
    vtysh=vtysh@entry=0) at lib/command.c:1288
(gdb)

The command entered is `debug ospf6 lsa inter-router examin`.  Code
inspection leads us to the fact that FRR is declaring the data as
const but we are attempting to modify it, causing the crash.

Remvoe the const of this set/get and let things work.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>