### PR TITLE
tests: More cbit extensions

### DIFF
--- a/tests/topotests/bfd-bgp-cbit-topo3/test_bfd_bgp_cbit_topo3.py
+++ b/tests/topotests/bfd-bgp-cbit-topo3/test_bfd_bgp_cbit_topo3.py
@@ -142,7 +142,7 @@ def test_bfd_connection():
 
         test_func = partial(topotest.router_json_cmp,
                             router, 'show bfd peers json', expected)
-        _, result = topotest.run_and_expect(test_func, None, count=16, wait=0.5)
+        _, result = topotest.run_and_expect(test_func, None, count=32, wait=0.5)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 
@@ -173,7 +173,7 @@ def test_bfd_loss_intermediate():
 
         test_func = partial(topotest.router_json_cmp,
                             router, 'show bfd peers json', expected)
-        _, result = topotest.run_and_expect(test_func, None, count=16, wait=0.5)
+        _, result = topotest.run_and_expect(test_func, None, count=32, wait=0.5)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 


### PR DESCRIPTION
We are still seeing cbit test failures in the ci system.  I am
gonna try extending the timeout a bit more as that 8 seconds
doesn't seem to be long enough.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>