### PR TITLE
pimd: Implement watermark warning for igmp group count and add igmp group count

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -173,6 +173,14 @@ Certain signals have special meanings to *pimd*.
    the existing IGMP general query timer.If no version is provided in the cli,
    it will be considered as default v2 query.This is a hidden command.
 
+.. index:: [no] ip igmp watermark-warn (10-60000)
+.. clicmd:: [no] ip igmp watermark-warn (10-60000)
+
+   Configure watermark warning generation for an igmp group limit. Generates
+   warning once the configured group limit is reached while adding new groups.
+   'no' form of the command disables the warning generation. This command is
+   vrf aware. To configure per vrf, enter vrf submode.
+   
 .. _pim-interface-configuration:
 
 PIM Interface Configuration

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3415,7 +3415,8 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 	time_t now;
 	json_object *json = NULL;
 	json_object *json_iface = NULL;
-	json_object *json_row = NULL;
+	json_object *json_group = NULL;
+	json_object *json_groups = NULL;
 
 	now = pim_time_monotonic_sec();
 
@@ -3478,37 +3479,44 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 						json_object_object_add(
 							json, ifp->name,
 							json_iface);
+						json_groups =
+							json_object_new_array();
+						json_object_object_add(
+								json_iface,
+								"groups",
+								json_groups);
 					}
 
-					json_row = json_object_new_object();
-					json_object_string_add(
-						json_row, "source", ifaddr_str);
-					json_object_string_add(
-						json_row, "group", group_str);
+					json_group = json_object_new_object();
+					json_object_string_add(json_group,
+							       "source",
+							       ifaddr_str);
+					json_object_string_add(json_group,
+							       "group",
+							       group_str);
 
 					if (grp->igmp_version == 3)
 						json_object_string_add(
-							json_row, "mode",
+							json_group, "mode",
 							grp->group_filtermode_isexcl
 								? "EXCLUDE"
 								: "INCLUDE");
 
-					json_object_string_add(json_row,
+					json_object_string_add(json_group,
 							       "timer", hhmmss);
 					json_object_int_add(
-						json_row, "sourcesCount",
+						json_group, "sourcesCount",
 						grp->group_source_list
 							? listcount(
 								  grp->group_source_list)
 							: 0);
-					json_object_int_add(json_row, "version",
-							    grp->igmp_version);
+					json_object_int_add(
+							json_group, "version",
+							grp->igmp_version);
 					json_object_string_add(
-						json_row, "uptime", uptime);
-					json_object_object_add(json_iface,
-							       group_str,
-							       json_row);
-
+						json_group, "uptime", uptime);
+					json_object_array_add(json_groups,
+							      json_group);
 				} else {
 					vty_out(vty,
 						"%-16s %-15s %-15s %4s %8s %4d %d %8s\n",

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -753,6 +753,39 @@ static void igmp_group_free(struct igmp_group *group)
 	XFREE(MTYPE_PIM_IGMP_GROUP, group);
 }
 
+static void igmp_group_count_incr(struct igmp_sock *igmp)
+{
+	struct pim_interface *pim_ifp = igmp->interface->info;
+
+	if (!pim_ifp)
+		return;
+
+	++pim_ifp->pim->igmp_group_count;
+	if (pim_ifp->pim->igmp_group_count
+	    == pim_ifp->pim->igmp_watermark_limit) {
+		zlog_warn(
+			"IGMP group count reached watermark limit: %u(vrf: %s)",
+			pim_ifp->pim->igmp_group_count,
+			VRF_LOGNAME(pim_ifp->pim->vrf));
+	}
+}
+
+static void igmp_group_count_decr(struct igmp_sock *igmp)
+{
+	struct pim_interface *pim_ifp = igmp->interface->info;
+
+	if (!pim_ifp)
+		return;
+
+	if (pim_ifp->pim->igmp_group_count == 0) {
+		zlog_warn("Cannot decrement igmp group count below 0(vrf: %s)",
+			  VRF_LOGNAME(pim_ifp->pim->vrf));
+		return;
+	}
+
+	--pim_ifp->pim->igmp_group_count;
+}
+
 void igmp_group_delete(struct igmp_group *group)
 {
 	struct listnode *src_node;
@@ -778,6 +811,7 @@ void igmp_group_delete(struct igmp_group *group)
 	}
 
 	group_timer_off(group);
+	igmp_group_count_decr(group->group_igmp_sock);
 	listnode_delete(group->group_igmp_sock->igmp_group_list, group);
 	hash_release(group->group_igmp_sock->igmp_group_hash, group);
 
@@ -1157,6 +1191,8 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 			"Creating new IGMP group %s on socket %d interface %s",
 			group_str, igmp->fd, igmp->interface->name);
 	}
+
+	igmp_group_count_incr(igmp);
 
 	/*
 	  RFC 3376: 6.2.2. Definition of Group Timers

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -178,6 +178,8 @@ struct pim_instance {
 	struct list *ssmpingd_list;
 	struct in_addr ssmpingd_group_addr;
 
+	unsigned int igmp_group_count;
+	unsigned int igmp_watermark_limit;
 	unsigned int keep_alive_time;
 	unsigned int rp_keep_alive_time;
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -239,6 +239,13 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 		vty_out(vty, "%sip pim ecmp\n", spaces);
 		++writes;
 	}
+
+	if (pim->igmp_watermark_limit != 0) {
+		vty_out(vty, "%sip igmp watermark-warn %u\n", spaces,
+			pim->igmp_watermark_limit);
+		++writes;
+	}
+
 	if (pim->ssmpingd_list) {
 		struct listnode *node;
 		struct ssmpingd_sock *ss;


### PR DESCRIPTION
This CLI will allow user to configure a igmp group limit which will generate
a watermark warning when reached.
Though watermark may not make sense without setting a limit, this
implementation shall serve as a base to implementing limit in future and helps
tracking a particular scale currently.

Testing:
=======

ip igmp watermark-warn <10-60000>

on reaching the configured number of group, pim will issue warning

2019/09/18 18:30:55 PIM: SCALE ALERT: igmp group count reached watermak limit: 210(vrf: default)

Also added group count and watermark limit configured on cli - show ip igmp groups [json]

<snip>

Sw3# sh ip igmp groups json
{
  "Total Groups":221,  <=====
  "Watermark limit":210, <=========
  "ens224":{
    "name":"ens224",
    "state":"up",
    "address":"40.0.0.1",
    "index":6,
    "flagMulticast":true,
    "flagBroadcast":true,
    "lanDelayEnabled":true,
    "groups":[
      {
        "source":"40.0.0.1",
        "group":"225.1.1.122",
        "timer":"00:03:56",
        "sourcesCount":1,
        "version":2,
        "uptime":"00:00:24"

<\snip>

<snip>

Sw3(config)# do sh ip igmp group
Total IGMP groups: 221
Watermark warn limit(Set) : 210
Interface        Address         Group           Mode Timer    Srcs V Uptime
ens224           40.0.0.1        225.1.1.122     ---- 00:04:06    1 2 00:13:22
ens224           40.0.0.1        225.1.1.144     ---- 00:04:02    1 2 00:13:22
ens224           40.0.0.1        225.1.1.57      ---- 00:04:01    1 2 00:13:22
ens224           40.0.0.1        225.1.1.210     ---- 00:04:06    1 2 00:13:22

<\snip>

Signed-off-by: Saravanan K <saravanank@vmware.com>