### PR TITLE
bgpd: #if ENABLE_BGP_VNC -> #ifdef ENABLE_BGP_VNC

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -87,7 +87,7 @@ struct bgp_attr_encap_subtlv {
 	uint8_t value[0]; /* will be extended */
 };
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 /*
  * old rfp<->rfapi representation
  */
@@ -233,7 +233,7 @@ struct attr {
 	uint16_t encap_tunneltype;		     /* grr */
 	struct bgp_attr_encap_subtlv *encap_subtlvs; /* rfc5512 */
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	struct bgp_attr_encap_subtlv *vnc_subtlvs; /* VNC-specific */
 #endif
 	/* EVPN */

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -228,7 +228,7 @@ static __attribute__((__noreturn__)) void bgp_exit(int status)
 	community_list_terminate(bgp_clist);
 
 	bgp_vrf_terminate();
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	vnc_zebra_destroy();
 #endif
 	bgp_zebra_destroy();
@@ -275,7 +275,7 @@ static int bgp_vrf_enable(struct vrf *vrf)
 			XFREE(MTYPE_BGP, bgp->name_pretty);
 			bgp->name_pretty = XSTRDUP(MTYPE_BGP, "VRF default");
 			bgp->inst_type = BGP_INSTANCE_TYPE_DEFAULT;
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 			if (!bgp->rfapi) {
 				bgp->rfapi = bgp_rfapi_new(bgp);
 				assert(bgp->rfapi);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -48,7 +48,7 @@
 #include "bgpd/bgp_nht.h"
 #include "bgpd/bgp_evpn.h"
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/rfapi_backend.h"
 #endif
 
@@ -214,7 +214,7 @@ int bgp_nlri_parse_vpn(struct peer *peer, struct attr *attr,
 			decode_rd_ip(pnt + 5, &rd_ip);
 			break;
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		case RD_TYPE_VNC_ETH:
 			break;
 #endif
@@ -1282,7 +1282,7 @@ void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,	    /* from */
 		zlog_debug("%s: start (path_vpn=%p)", __func__, path_vpn);
 
 	if (!path_vpn->net) {
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		/* BGP_ROUTE_RFP routes do not have path_vpn->net set (yet) */
 		if (path_vpn->type == ZEBRA_ROUTE_BGP
 		    && path_vpn->sub_type == BGP_ROUTE_RFP) {

--- a/bgpd/bgp_rd.c
+++ b/bgpd/bgp_rd.c
@@ -33,7 +33,7 @@
 #include "bgpd/bgp_rd.h"
 #include "bgpd/bgp_attr.h"
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/rfapi_backend.h"
 #endif
 
@@ -42,7 +42,7 @@ uint16_t decode_rd_type(const uint8_t *pnt)
 	uint16_t v;
 
 	v = ((uint16_t)*pnt++ << 8);
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	/*
 	 * VNC L2 stores LHI in lower byte, so omit it
 	 */
@@ -85,7 +85,7 @@ void decode_rd_ip(const uint8_t *pnt, struct rd_ip *rd_ip)
 	rd_ip->val |= (uint16_t)*pnt;
 }
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 /* type == RD_TYPE_VNC_ETH */
 void decode_rd_vnc_eth(const uint8_t *pnt, struct rd_vnc_eth *rd_vnc_eth)
 {
@@ -186,7 +186,7 @@ char *prefix_rd2str(const struct prefix_rd *prd, char *buf, size_t size)
 			 rd_ip.val);
 		return buf;
 	}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	else if (type == RD_TYPE_VNC_ETH) {
 		snprintf(buf, size, "LHI:%d, %02x:%02x:%02x:%02x:%02x:%02x",
 			 *(pnt + 1), /* LHI */

--- a/bgpd/bgp_rd.h
+++ b/bgpd/bgp_rd.h
@@ -28,7 +28,7 @@
 #define RD_TYPE_IP      1
 #define RD_TYPE_AS4     2
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 #define RD_TYPE_VNC_ETH	0xff00  /* VNC L2VPN */
 #endif
 
@@ -46,7 +46,7 @@ struct rd_ip {
 	uint16_t val;
 };
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 struct rd_vnc_eth {
 	uint16_t type;
 	uint8_t local_nve_id;
@@ -60,7 +60,7 @@ extern void encode_rd_type(uint16_t, uint8_t *);
 extern void decode_rd_as(const uint8_t *pnt, struct rd_as *rd_as);
 extern void decode_rd_as4(const uint8_t *pnt, struct rd_as *rd_as);
 extern void decode_rd_ip(const uint8_t *pnt, struct rd_ip *rd_ip);
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 extern void decode_rd_vnc_eth(const uint8_t *pnt,
 			      struct rd_vnc_eth *rd_vnc_eth);
 #endif

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -71,7 +71,7 @@
 #include "bgpd/bgp_mac.h"
 #include "bgpd/bgp_network.h"
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/rfapi_backend.h"
 #include "bgpd/rfapi/vnc_import_bgp.h"
 #include "bgpd/rfapi/vnc_export_bgp.h"
@@ -1577,7 +1577,7 @@ bool subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 	piattr = bgp_path_info_mpath_count(pi) ? bgp_path_info_mpath_attr(pi)
 					       : pi->attr;
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (((afi == AFI_IP) || (afi == AFI_IP6)) && (safi == SAFI_MPLS_VPN)
 	    && ((pi->type == ZEBRA_ROUTE_BGP_DIRECT)
 		|| (pi->type == ZEBRA_ROUTE_BGP_DIRECT_EXT))) {
@@ -2547,7 +2547,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 	    && !CHECK_FLAG(old_select->flags, BGP_PATH_ATTR_CHANGED)
 	    && !bgp_addpath_is_addpath_used(&bgp->tx_addpath, afi, safi)) {
 		if (bgp_zebra_has_route_changed(rn, old_select)) {
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 			vnc_import_bgp_add_route(bgp, p, old_select);
 			vnc_import_bgp_exterior_add_route(bgp, p, old_select);
 #endif
@@ -2615,7 +2615,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 		UNSET_FLAG(new_select->flags, BGP_PATH_MULTIPATH_CHG);
 	}
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if ((afi == AFI_IP || afi == AFI_IP6) && (safi == SAFI_UNICAST)) {
 		if (old_select != new_select) {
 			if (old_select) {
@@ -3090,7 +3090,7 @@ static void bgp_rib_withdraw(struct bgp_node *rn, struct bgp_path_info *pi,
 			return;
 		}
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (safi == SAFI_MPLS_VPN) {
 		struct bgp_node *prn = NULL;
 		struct bgp_table *table = NULL;
@@ -3277,7 +3277,7 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	uint8_t pi_type = 0;
 	uint8_t pi_sub_type = 0;
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	int vnc_implicit_withdraw = 0;
 #endif
 	int same_attr = 0;
@@ -3577,7 +3577,7 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			if (!CHECK_FLAG(pi->flags, BGP_PATH_HISTORY))
 				bgp_damp_withdraw(pi, rn, afi, safi, 1);
 		}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		if (safi == SAFI_MPLS_VPN) {
 			struct bgp_node *prn = NULL;
 			struct bgp_table *table = NULL;
@@ -3667,7 +3667,7 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			}
 		}
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		if ((afi == AFI_IP || afi == AFI_IP6)
 		    && (safi == SAFI_UNICAST)) {
 			if (vnc_implicit_withdraw) {
@@ -3750,7 +3750,7 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		} else
 			bgp_path_info_set_flag(rn, pi, BGP_PATH_VALID);
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		if (safi == SAFI_MPLS_VPN) {
 			struct bgp_node *prn = NULL;
 			struct bgp_table *table = NULL;
@@ -3801,7 +3801,7 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			vpn_leak_to_vrf_update(bgp, pi);
 		}
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		if (SAFI_MPLS_VPN == safi) {
 			mpls_label_t label_decoded = decode_label(label);
 
@@ -3910,7 +3910,7 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	/* route_node_get lock */
 	bgp_unlock_node(rn);
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (safi == SAFI_MPLS_VPN) {
 		struct bgp_node *prn = NULL;
 		struct bgp_table *table = NULL;
@@ -3950,7 +3950,7 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 
 		vpn_leak_to_vrf_update(bgp, new);
 	}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (SAFI_MPLS_VPN == safi) {
 		mpls_label_t label_decoded = decode_label(label);
 
@@ -4007,7 +4007,7 @@ filtered:
 
 	bgp_unlock_node(rn);
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	/*
 	 * Filtered update is treated as an implicit withdrawal (see
 	 * bgp_rib_remove()
@@ -4032,7 +4032,7 @@ int bgp_withdraw(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	struct bgp_node *rn;
 	struct bgp_path_info *pi;
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if ((SAFI_MPLS_VPN == safi) || (SAFI_ENCAP == safi)) {
 		rfapiProcessWithdraw(peer, NULL, p, prd, NULL, afi, safi, type,
 				     0);
@@ -4530,7 +4530,7 @@ void bgp_clear_route_all(struct peer *peer)
 	FOREACH_AFI_SAFI (afi, safi)
 		bgp_clear_route(peer, afi, safi);
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	rfapiProcessPeerDown(peer);
 #endif
 }
@@ -4918,7 +4918,7 @@ void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 	struct attr attr;
 	struct attr *attr_new;
 	route_map_result_t ret;
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	int vnc_implicit_withdraw = 0;
 #endif
 
@@ -5000,7 +5000,7 @@ void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 				bgp_path_info_restore(rn, pi);
 			else
 				bgp_aggregate_decrement(bgp, p, pi, afi, safi);
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 			if ((afi == AFI_IP || afi == AFI_IP6)
 			    && (safi == SAFI_UNICAST)) {
 				if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED)) {
@@ -5019,7 +5019,7 @@ void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 			bgp_attr_unintern(&pi->attr);
 			pi->attr = attr_new;
 			pi->uptime = bgp_clock();
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 			if ((afi == AFI_IP || afi == AFI_IP6)
 			    && (safi == SAFI_UNICAST)) {
 				if (vnc_implicit_withdraw) {
@@ -5188,7 +5188,7 @@ static void bgp_static_withdraw_safi(struct bgp *bgp, const struct prefix *p,
 
 	/* Withdraw static BGP route from routing table. */
 	if (pi) {
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		rfapiProcessWithdraw(
 			pi->peer, NULL, p, prd, pi->attr, afi, safi, pi->type,
 			1); /* Kill, since it is an administrative change */
@@ -5215,7 +5215,7 @@ static void bgp_static_update_safi(struct bgp *bgp, const struct prefix *p,
 	struct attr *attr_new;
 	struct attr attr = {0};
 	struct bgp_path_info *pi;
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	mpls_label_t label = 0;
 #endif
 	uint32_t num_labels = 0;
@@ -5317,7 +5317,7 @@ static void bgp_static_update_safi(struct bgp *bgp, const struct prefix *p,
 			bgp_attr_unintern(&pi->attr);
 			pi->attr = attr_new;
 			pi->uptime = bgp_clock();
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 			if (pi->extra)
 				label = decode_label(&pi->extra->label[0]);
 #endif
@@ -5330,7 +5330,7 @@ static void bgp_static_update_safi(struct bgp *bgp, const struct prefix *p,
 			    && bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) {
 				vpn_leak_to_vrf_update(bgp, pi);
 			}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 			rfapiProcessUpdate(pi->peer, NULL, p, &bgp_static->prd,
 					   pi->attr, afi, safi, pi->type,
 					   pi->sub_type, &label);
@@ -5351,7 +5351,7 @@ static void bgp_static_update_safi(struct bgp *bgp, const struct prefix *p,
 		new->extra->label[0] = bgp_static->label;
 		new->extra->num_labels = num_labels;
 	}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	label = decode_label(&bgp_static->label);
 #endif
 
@@ -5370,7 +5370,7 @@ static void bgp_static_update_safi(struct bgp *bgp, const struct prefix *p,
 	    && bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) {
 		vpn_leak_to_vrf_update(bgp, new);
 	}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	rfapiProcessUpdate(new->peer, NULL, p, &bgp_static->prd, new->attr, afi,
 			   safi, new->type, new->sub_type, &label);
 #endif
@@ -7936,7 +7936,7 @@ void route_vty_out(struct vty *vty, const struct prefix *p,
 			vty_out(vty, "%s\n", attr->ecommunity->str);
 		}
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		/* prints an additional line, indented, with VNC info, if
 		 * present */
 		if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP))

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -125,7 +125,7 @@ struct bgp_path_info_extra {
 	struct in6_addr sid[BGP_MAX_SIDS];
 	uint32_t num_sids;
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	union {
 
 		struct {

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -64,7 +64,7 @@
 #include "bgpd/bgp_flowspec_util.h"
 #include "bgpd/bgp_encap_types.h"
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/bgp_rfapi_cfg.h"
 #endif
 
@@ -3749,7 +3749,7 @@ static void bgp_route_map_process_update_cb(char *rmap_name)
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
 		bgp_route_map_process_update(bgp, rmap_name, 1);
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		/* zlog_debug("%s: calling vnc_routemap_update", __func__); */
 		vnc_routemap_update(bgp, __func__);
 #endif
@@ -3793,7 +3793,7 @@ static void bgp_route_map_mark_update(const char *rmap_name)
 	} else {
 		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp))
 			bgp_route_map_process_update(bgp, rmap_name, 0);
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		zlog_debug("%s: calling vnc_routemap_update", __func__);
 		vnc_routemap_update(bgp, __func__);
 #endif

--- a/bgpd/bgp_vnc_types.h
+++ b/bgpd/bgp_vnc_types.h
@@ -19,7 +19,7 @@
 #ifndef _QUAGGA_BGP_VNC_TYPES_H
 #define _QUAGGA_BGP_VNC_TYPES_H
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 typedef enum {
 	BGP_VNC_SUBTLV_TYPE_LIFETIME = 1,
 	BGP_VNC_SUBTLV_TYPE_RFPOPTION = 2, /* deprecated */

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -155,7 +155,7 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 				uint16_t type;
 				struct rd_as rd_as = {0};
 				struct rd_ip rd_ip = {0};
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 				struct rd_vnc_eth rd_vnc_eth = {0};
 #endif
 				const uint8_t *pnt;
@@ -171,7 +171,7 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 					decode_rd_as4(pnt + 2, &rd_as);
 				else if (type == RD_TYPE_IP)
 					decode_rd_ip(pnt + 2, &rd_ip);
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 				else if (type == RD_TYPE_VNC_ETH)
 					decode_rd_vnc_eth(pnt, &rd_vnc_eth);
 #endif
@@ -200,7 +200,7 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 						vty_out(vty, "%s:%d",
 							inet_ntoa(rd_ip.ip),
 							rd_ip.val);
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 					else if (type == RD_TYPE_VNC_ETH)
 						vty_out(vty,
 							"%u:%02x:%02x:%02x:%02x:%02x:%02x",

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -68,7 +68,7 @@
 #include "bgpd/bgp_addpath.h"
 #include "bgpd/bgp_mac.h"
 #include "bgpd/bgp_flowspec.h"
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/bgp_rfapi_cfg.h"
 #endif
 
@@ -15272,7 +15272,7 @@ int bgp_config_write(struct vty *vty)
 
 		hook_call(bgp_inst_config_write, bgp, vty);
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		bgp_rfapi_cfg_write(vty, bgp);
 #endif
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -51,7 +51,7 @@
 #include "bgpd/bgp_nht.h"
 #include "bgpd/bgp_bfd.h"
 #include "bgpd/bgp_label.h"
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/rfapi_backend.h"
 #include "bgpd/rfapi/vnc_export_bgp.h"
 #endif
@@ -1605,7 +1605,7 @@ int bgp_redistribute_set(struct bgp *bgp, afi_t afi, int type,
 		if (vrf_bitmap_check(zclient->redist[afi][type], bgp->vrf_id))
 			return CMD_WARNING;
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		if (EVPN_ENABLED(bgp) && type == ZEBRA_ROUTE_VNC_DIRECT) {
 			vnc_export_bgp_enable(
 				bgp, afi); /* only enables if mode bits cfg'd */
@@ -1766,7 +1766,7 @@ int bgp_redistribute_unset(struct bgp *bgp, afi_t afi, int type,
  * they operate within bgpd irrespective of zebra connection
  * status. red lookup fails if there is no zebra connection.
  */
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (EVPN_ENABLED(bgp) && type == ZEBRA_ROUTE_VNC_DIRECT) {
 		vnc_export_bgp_disable(bgp, afi);
 	}

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -65,7 +65,7 @@
 #include "bgpd/bgp_nexthop.h"
 #include "bgpd/bgp_damp.h"
 #include "bgpd/bgp_mplsvpn.h"
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/bgp_rfapi_cfg.h"
 #include "bgpd/rfapi/rfapi_backend.h"
 #endif
@@ -2976,7 +2976,7 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 
 	bgp->as = *as;
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (inst_type != BGP_INSTANCE_TYPE_VRF) {
 		bgp->rfapi = bgp_rfapi_new(bgp);
 		assert(bgp->rfapi);
@@ -3375,7 +3375,7 @@ int bgp_delete(struct bgp *bgp)
 
 /* TODO - Other memory may need to be freed - e.g., NHT */
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	rfapi_delete(bgp);
 #endif
 	bgp_cleanup_routes(bgp);
@@ -5800,7 +5800,7 @@ static void peer_distribute_update(struct access_list *access)
 				}
 			}
 		}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		vnc_prefix_list_update(bgp);
 #endif
 	}
@@ -7036,7 +7036,7 @@ void bgp_init(unsigned short instance)
 	/* Init zebra. */
 	bgp_zebra_init(bm->master, instance);
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	vnc_zebra_init(bm->master);
 #endif
 
@@ -7051,7 +7051,7 @@ void bgp_init(unsigned short instance)
 	bgp_route_map_init();
 	bgp_scan_vty_init();
 	bgp_mplsvpn_init();
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	rfapi_init();
 #endif
 	bgp_ethernetvpn_init();

--- a/bgpd/rfapi/bgp_rfapi_cfg.h
+++ b/bgpd/rfapi/bgp_rfapi_cfg.h
@@ -24,7 +24,7 @@
 #include "lib/table.h"
 #include "lib/routemap.h"
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 #include "rfapi.h"
 
 struct rfapi_l2_group_cfg {

--- a/bgpd/rfapi/rfapi.h
+++ b/bgpd/rfapi/rfapi.h
@@ -21,7 +21,7 @@
 #ifndef _QUAGGA_BGP_RFAPI_H
 #define _QUAGGA_BGP_RFAPI_H
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 
 #include <stdint.h>
 #include <netinet/in.h>

--- a/bgpd/rfapi/rfapi_backend.h
+++ b/bgpd/rfapi/rfapi_backend.h
@@ -21,7 +21,7 @@
 #ifndef _QUAGGA_BGP_RFAPI_BACKEND_H
 #define _QUAGGA_BGP_RFAPI_BACKEND_H
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 
 #include "bgpd/bgp_route.h"
 #include "bgpd/bgp_nexthop.h"

--- a/bgpd/rfapi/vnc_debug.h
+++ b/bgpd/rfapi/vnc_debug.h
@@ -20,7 +20,7 @@
 #ifndef _QUAGGA_BGP_VNC_DEBUG_H
 #define _QUAGGA_BGP_VNC_DEBUG_H
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 
 /*
  * debug state storage


### PR DESCRIPTION
This macro is undefined if vnc is disabled, and while it defaults to 0,
this is still wrong and causes issues with -Werror

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>