### PR TITLE
zebra: free unhashable (dup) NHEs via ID table cleanup

### DIFF
--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -223,10 +223,11 @@ void zebra_router_terminate(void)
 	zebra_vxlan_disable();
 	zebra_mlag_terminate();
 
-	hash_clean(zrouter.nhgs, zebra_nhg_hash_free);
-	hash_free(zrouter.nhgs);
-	hash_clean(zrouter.nhgs_id, NULL);
+	/* Free NHE in ID table only since it has unhashable entries as well */
+	hash_clean(zrouter.nhgs_id, zebra_nhg_hash_free);
 	hash_free(zrouter.nhgs_id);
+	hash_clean(zrouter.nhgs, NULL);
+	hash_free(zrouter.nhgs);
 
 	hash_clean(zrouter.rules_hash, zebra_pbr_rules_free);
 	hash_free(zrouter.rules_hash);


### PR DESCRIPTION
Free unhashable (duplicate NHEs from the kernel) via ID table
cleanup. Since the NHE ID hash table contains extra entries,
that's the one we need to be calling zebra_nhg_hash_free()
on, otherwise we will never free the unhashable NHEs.

This was found via a memleak:
```
==1478713== HEAP SUMMARY:
==1478713==     in use at exit: 10,267 bytes in 46 blocks
==1478713==   total heap usage: 76,810 allocs, 76,764 frees, 3,901,237 bytes allocated
==1478713==
==1478713== 208 (88 direct, 120 indirect) bytes in 1 blocks are definitely lost in loss record 35 of 41
==1478713==    at 0x483BB1A: calloc (vg_replace_malloc.c:762)
==1478713==    by 0x48E35E8: qcalloc (memory.c:110)
==1478713==    by 0x451CCB: zebra_nhg_alloc (zebra_nhg.c:369)
==1478713==    by 0x453DE3: zebra_nhg_copy (zebra_nhg.c:379)
==1478713==    by 0x452670: nhg_ctx_process_new (zebra_nhg.c:1143)
==1478713==    by 0x4523A8: nhg_ctx_process (zebra_nhg.c:1234)
==1478713==    by 0x452A2D: zebra_nhg_kernel_find (zebra_nhg.c:1294)
==1478713==    by 0x4326E0: netlink_nexthop_change (rt_netlink.c:2433)
==1478713==    by 0x427320: netlink_parse_info (kernel_netlink.c:945)
==1478713==    by 0x432DAD: netlink_nexthop_read (rt_netlink.c:2488)
==1478713==    by 0x41B600: interface_list (if_netlink.c:1486)
==1478713==    by 0x457275: zebra_ns_enable (zebra_ns.c:127)
```

Repro with:
```
ip next add id 1 blackhole
ip next add id 2 blackhole
```
```
valgrind /usr/lib/frr/zebra
```

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>