### PR TITLE
vtysh: don't warn when saving conf the first time

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2877,13 +2877,12 @@ static void backup_config_file(const char *fbackup)
 	strlcat(integrate_sav, CONF_BACKUP_EXT, integrate_sav_sz);
 
 	/* Move current configuration file to backup config file. */
-	if (unlink(integrate_sav) != 0) {
-		vty_out(vty, "Warning: %s unlink failed\n", integrate_sav);
-	}
-	if (rename(fbackup, integrate_sav) != 0) {
-		vty_out(vty, "Error renaming %s to %s\n", fbackup,
-			integrate_sav);
-	}
+	if (unlink(integrate_sav) != 0 && errno != ENOENT)
+		vty_out(vty, "Unlink failed for %s: %s\n", integrate_sav,
+			strerror(errno));
+	if (rename(fbackup, integrate_sav) != 0 && errno != ENOENT)
+		vty_out(vty, "Error renaming %s to %s: %s\n", fbackup,
+			integrate_sav, strerror(errno));
 	free(integrate_sav);
 }
 


### PR DESCRIPTION
Currently a user is presented with a worrisome warning message when writing the config file for the first time:
```
leaf01(config-router)# do wr
Note: this version of vtysh never writes vtysh.conf
Building Configuration...
Warning: /etc/frr/frr.conf.sav unlink failed
Integrated configuration saved to /etc/frr/frr.conf
[OK]
```
This happens because the unlink fails for the backup file when it doesn't already exist.

This patch ensures a warning is not presented to the user when backup_config_file() fails because the file doesn't exist, and ensures both a warning and error string are provided to the user if ENOENT is not seen.

Manual testing involved removing /etc/frr/frr.conf and /etc/frr/frr.conf.sav before getting into vtysh. Filesystem was remounted read-only after starting vtysh so a different errno was returned.
Output from testing below.

errno == 2:
```
ubuntu16-04# wr
Note: this version of vtysh never writes vtysh.conf
Building Configuration...
Integrated configuration saved to /etc/frr/frr.conf
[OK]
```
errno != 2:
```
ubuntu16-04# wr
Note: this version of vtysh never writes vtysh.conf
Building Configuration...
Unlink failed for /etc/frr/frr.conf.sav: Read-only file system
Error renaming /etc/frr/frr.conf to /etc/frr/frr.conf.sav: Read-only file system
% Error: failed to open configuration file /etc/frr/frr.conf: Read-only file system
% Configuration write failed.
```