### PR TITLE
lib,zebra: convert LSP nhlfe lists to use typesafe lists

### DIFF
--- a/doc/developer/building-frr-for-archlinux.rst
+++ b/doc/developer/building-frr-for-archlinux.rst
@@ -67,7 +67,7 @@ Some sysctls need to be changed in order to enable IPv4/IPv6 forwarding and
 MPLS (if supported by your platform). If your platform does not support MPLS,
 skip the MPLS related configuration in this section.
 
-Edit :file:`/etc/sysctl.conf`[*Create the file if it doesn't exist*] and 
+Edit :file:`/etc/sysctl.conf` [*Create the file if it doesn't exist*] and
 append the following values (ignore the other settings):
 
 ::

--- a/doc/developer/lists.rst
+++ b/doc/developer/lists.rst
@@ -107,6 +107,8 @@ Functions provided:
 +------------------------------------+------+------+------+---------+------------+
 | _first, _next, _next_safe          | yes  | yes  | yes  | yes     | yes        |
 +------------------------------------+------+------+------+---------+------------+
+| _first_const, _next_const          | yes  | yes  | yes  | --      | --         |
++------------------------------------+------+------+------+---------+------------+
 | _add_head, _add_tail, _add_after   | yes  | --   | --   | --      | --         |
 +------------------------------------+------+------+------+---------+------------+
 | _add                               | --   | yes  | yes  | yes     | yes        |
@@ -116,6 +118,8 @@ Functions provided:
 | _find                              | --   | --   | yes  | yes     | --         |
 +------------------------------------+------+------+------+---------+------------+
 | _find_lt, _find_gteq               | --   | --   | --   | yes     | yes        |
++------------------------------------+------+------+------+---------+------------+
+| _is_empty                          | yes  | --   | --   | --      | --         |
 +------------------------------------+------+------+------+---------+------------+
 | use with frr_each() macros         | yes  | yes  | yes  | yes     | yes        |
 +------------------------------------+------+------+------+---------+------------+
@@ -225,6 +229,19 @@ The following iteration macros work across all data structures:
       The ``from`` variable is written to.  This is intentional - you can
       resume iteration after breaking out of the loop by keeping the ``from``
       value persistent and reusing it for the next loop.
+
+The following iteration macro works only for the types that have const
+iterators:
+
+.. c:function:: frr_each_const(Z, &head, item)
+
+   This variant permits iteration where ``head`` is available ``const``.
+   Only some list types may have appropriate iterator macros.
+
+   .. warning::
+
+      This version is intended to support read-only access. If you find
+      yourself tempted to cast away const, please reconsider.
 
 Common API
 ----------

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3481,6 +3481,7 @@ enum zebra_dplane_result kernel_neigh_update_ctx(struct zebra_dplane_ctx *ctx)
 int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 {
 	mpls_lse_t lse;
+	const struct nhlfe_list_head *head;
 	const zebra_nhlfe_t *nhlfe;
 	struct nexthop *nexthop = NULL;
 	unsigned int nexthop_num;
@@ -3501,7 +3502,8 @@ int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 	 * or multipath case.
 	 */
 	nexthop_num = 0;
-	for (nhlfe = dplane_ctx_get_nhlfe(ctx); nhlfe; nhlfe = nhlfe->next) {
+	head = dplane_ctx_get_nhlfe_list(ctx);
+	frr_each_const(nhlfe_list, head, nhlfe) {
 		nexthop = nhlfe->nexthop;
 		if (!nexthop)
 			continue;
@@ -3556,8 +3558,7 @@ int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 				    routedesc);
 
 		nexthop_num = 0;
-		for (nhlfe = dplane_ctx_get_nhlfe(ctx);
-		     nhlfe; nhlfe = nhlfe->next) {
+		frr_each_const(nhlfe_list, head, nhlfe) {
 			nexthop = nhlfe->nexthop;
 			if (!nexthop)
 				continue;
@@ -3595,8 +3596,7 @@ int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 				    routedesc);
 
 		nexthop_num = 0;
-		for (nhlfe = dplane_ctx_get_nhlfe(ctx);
-		     nhlfe; nhlfe = nhlfe->next) {
+		frr_each_const(nhlfe_list, head, nhlfe) {
 			nexthop = nhlfe->nexthop;
 			if (!nexthop)
 				continue;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -33,6 +33,7 @@
 #include "zebra/zebra_router.h"
 #include "zebra/zebra_dplane.h"
 #include "zebra/zebra_vxlan_private.h"
+#include "zebra/zebra_mpls.h"
 #include "zebra/rt.h"
 #include "zebra/debug.h"
 
@@ -510,19 +511,16 @@ static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_LSP_DELETE:
 	case DPLANE_OP_LSP_NOTIFY:
 	{
-		zebra_nhlfe_t *nhlfe, *next;
+		zebra_nhlfe_t *nhlfe;
 
 		/* Free allocated NHLFEs */
-		for (nhlfe = ctx->u.lsp.nhlfe_list; nhlfe; nhlfe = next) {
-			next = nhlfe->next;
-
+		frr_each_safe(nhlfe_list, &ctx->u.lsp.nhlfe_list, nhlfe)
 			zebra_mpls_nhlfe_del(nhlfe);
-		}
 
 		/* Clear pointers in lsp struct, in case we're cacheing
 		 * free context structs.
 		 */
-		ctx->u.lsp.nhlfe_list = NULL;
+		nhlfe_list_init(&ctx->u.lsp.nhlfe_list);
 		ctx->u.lsp.best_nhlfe = NULL;
 
 		break;
@@ -1217,11 +1215,11 @@ void dplane_ctx_set_lsp_flags(struct zebra_dplane_ctx *ctx,
 	ctx->u.lsp.flags = flags;
 }
 
-const zebra_nhlfe_t *dplane_ctx_get_nhlfe(const struct zebra_dplane_ctx *ctx)
+const struct nhlfe_list_head *dplane_ctx_get_nhlfe_list(
+	const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
-
-	return ctx->u.lsp.nhlfe_list;
+	return &(ctx->u.lsp.nhlfe_list);
 }
 
 zebra_nhlfe_t *dplane_ctx_add_nhlfe(struct zebra_dplane_ctx *ctx,
@@ -1230,7 +1228,7 @@ zebra_nhlfe_t *dplane_ctx_add_nhlfe(struct zebra_dplane_ctx *ctx,
 				    union g_addr *gate,
 				    ifindex_t ifindex,
 				    uint8_t num_labels,
-				    mpls_label_t out_labels[])
+				    mpls_label_t *out_labels)
 {
 	zebra_nhlfe_t *nhlfe;
 
@@ -1730,13 +1728,14 @@ static int dplane_ctx_lsp_init(struct zebra_dplane_ctx *ctx,
 
 	memset(&ctx->u.lsp, 0, sizeof(ctx->u.lsp));
 
+	nhlfe_list_init(&(ctx->u.lsp.nhlfe_list));
 	ctx->u.lsp.ile = lsp->ile;
 	ctx->u.lsp.addr_family = lsp->addr_family;
 	ctx->u.lsp.num_ecmp = lsp->num_ecmp;
 	ctx->u.lsp.flags = lsp->flags;
 
 	/* Copy source LSP's nhlfes, and capture 'best' nhlfe */
-	for (nhlfe = lsp->nhlfe_list; nhlfe; nhlfe = nhlfe->next) {
+	frr_each(nhlfe_list, &lsp->nhlfe_list, nhlfe) {
 		/* Not sure if this is meaningful... */
 		if (nhlfe->nexthop == NULL)
 			continue;

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -310,14 +310,15 @@ void dplane_ctx_set_addr_family(struct zebra_dplane_ctx *ctx,
 uint32_t dplane_ctx_get_lsp_flags(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_lsp_flags(struct zebra_dplane_ctx *ctx,
 			      uint32_t flags);
-const zebra_nhlfe_t *dplane_ctx_get_nhlfe(const struct zebra_dplane_ctx *ctx);
+const struct nhlfe_list_head *dplane_ctx_get_nhlfe_list(
+	const struct zebra_dplane_ctx *ctx);
 zebra_nhlfe_t *dplane_ctx_add_nhlfe(struct zebra_dplane_ctx *ctx,
 				    enum lsp_types_t lsp_type,
 				    enum nexthop_types_t nh_type,
 				    union g_addr *gate,
 				    ifindex_t ifindex,
 				    uint8_t num_labels,
-				    mpls_label_t out_labels[]);
+				    mpls_label_t *out_labels);
 
 const zebra_nhlfe_t *dplane_ctx_get_best_nhlfe(
 	const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -55,6 +55,10 @@ typedef struct zebra_nhlfe_t_ zebra_nhlfe_t;
 typedef struct zebra_lsp_t_ zebra_lsp_t;
 typedef struct zebra_fec_t_ zebra_fec_t;
 
+/* Declare LSP nexthop list types */
+PREDECL_DLIST(snhlfe_list);
+PREDECL_DLIST(nhlfe_list);
+
 /*
  * (Outgoing) nexthop label forwarding entry configuration
  */
@@ -71,9 +75,8 @@ struct zebra_snhlfe_t_ {
 	/* Backpointer to base entry. */
 	zebra_slsp_t *slsp;
 
-	/* Pointers to more outgoing information for same in-label */
-	zebra_snhlfe_t *next;
-	zebra_snhlfe_t *prev;
+	/* Linkage for LSPs' lists */
+	struct snhlfe_list_item list;
 };
 
 /*
@@ -97,9 +100,10 @@ struct zebra_nhlfe_t_ {
 #define NHLFE_FLAG_DELETED     (1 << 3)
 #define NHLFE_FLAG_INSTALLED   (1 << 4)
 
-	zebra_nhlfe_t *next;
-	zebra_nhlfe_t *prev;
 	uint8_t distance;
+
+	/* Linkage for LSPs' lists */
+	struct nhlfe_list_item list;
 };
 
 /*
@@ -117,7 +121,7 @@ struct zebra_slsp_t_ {
 	zebra_ile_t ile;
 
 	/* List of outgoing nexthop static configuration */
-	zebra_snhlfe_t *snhlfe_list;
+	struct snhlfe_list_head snhlfe_list;
 };
 
 /*
@@ -127,8 +131,9 @@ struct zebra_lsp_t_ {
 	/* Incoming label */
 	zebra_ile_t ile;
 
-	/* List of NHLFE, pointer to best and num equal-cost. */
-	zebra_nhlfe_t *nhlfe_list;
+	/* List of NHLFEs, pointer to best, and num equal-cost. */
+	struct nhlfe_list_head nhlfe_list;
+
 	zebra_nhlfe_t *best_nhlfe;
 	uint32_t num_ecmp;
 
@@ -163,6 +168,9 @@ struct zebra_fec_t_ {
 	/* Clients interested in this FEC. */
 	struct list *client_list;
 };
+
+/* Declare typesafe list apis/macros */
+DECLARE_DLIST(nhlfe_list, struct zebra_nhlfe_t_, list);
 
 /* Function declarations. */
 

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -239,8 +239,9 @@ static int kernel_send_rtmsg_v6(int action, mpls_label_t in_label,
 
 static int kernel_lsp_cmd(struct zebra_dplane_ctx *ctx)
 {
+	const struct nhlfe_list_head *head;
 	const zebra_nhlfe_t *nhlfe;
-	struct nexthop *nexthop = NULL;
+	const struct nexthop *nexthop = NULL;
 	unsigned int nexthop_num = 0;
 	int action;
 
@@ -258,7 +259,8 @@ static int kernel_lsp_cmd(struct zebra_dplane_ctx *ctx)
 		return -1;
 	}
 
-	for (nhlfe = dplane_ctx_get_nhlfe(ctx); nhlfe; nhlfe = nhlfe->next) {
+	head = dplane_ctx_get_nhlfe_list(ctx);
+	frr_each_const(nhlfe_list, head, nhlfe) {
 		nexthop = nhlfe->nexthop;
 		if (!nexthop)
 			continue;


### PR DESCRIPTION
Convert the embedded lists of nhlfes and snhlfes in zebra LSPs and SLSPs to use typesafe dlists. I want a little more capability in those lists, so it seems better to just convert them, rather than enhancing the one-off apis using the current approach.

This also enhances the `lib/typesafe` lists (the slists and dlists) to offer some `const` apis.
