### PR TITLE
bgpd, ospfd, ospf6d: long is not bool :(

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -73,20 +73,20 @@
 #endif
 
 FRR_CFG_DEFAULT_BOOL(BGP_IMPORT_CHECK,
-	{ .val_long = true, .match_profile = "datacenter", },
-	{ .val_long = false },
+	{ .val_bool = true, .match_profile = "datacenter", },
+	{ .val_bool = false },
 )
 FRR_CFG_DEFAULT_BOOL(BGP_SHOW_HOSTNAME,
-	{ .val_long = true, .match_profile = "datacenter", },
-	{ .val_long = false },
+	{ .val_bool = true, .match_profile = "datacenter", },
+	{ .val_bool = false },
 )
 FRR_CFG_DEFAULT_BOOL(BGP_LOG_NEIGHBOR_CHANGES,
-	{ .val_long = true, .match_profile = "datacenter", },
-	{ .val_long = false },
+	{ .val_bool = true, .match_profile = "datacenter", },
+	{ .val_bool = false },
 )
 FRR_CFG_DEFAULT_BOOL(BGP_DETERMINISTIC_MED,
-	{ .val_long = true, .match_profile = "datacenter", },
-	{ .val_long = false },
+	{ .val_bool = true, .match_profile = "datacenter", },
+	{ .val_bool = false },
 )
 FRR_CFG_DEFAULT_ULONG(BGP_CONNECT_RETRY,
 	{ .val_ulong = 10, .match_profile = "datacenter", },

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -52,8 +52,8 @@
 DEFINE_QOBJ_TYPE(ospf6)
 
 FRR_CFG_DEFAULT_BOOL(OSPF6_LOG_ADJACENCY_CHANGES,
-	{ .val_long = true, .match_profile = "datacenter", },
-	{ .val_long = false },
+	{ .val_bool = true, .match_profile = "datacenter", },
+	{ .val_bool = false },
 )
 
 /* global ospf6d variable */

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -54,8 +54,8 @@
 #include "ospfd/ospf_bfd.h"
 
 FRR_CFG_DEFAULT_BOOL(OSPF_LOG_ADJACENCY_CHANGES,
-	{ .val_long = true, .match_profile = "datacenter", },
-	{ .val_long = false },
+	{ .val_bool = true, .match_profile = "datacenter", },
+	{ .val_bool = false },
 )
 
 static const char *const ospf_network_type_str[] = {


### PR DESCRIPTION
Whoopsie daisy :(

(for context, the defaults code originally didn't have a dedicated
"bool" variant and just used long for bools...  I derp'd this when
adding bool as a separate case :( )

(Backport for 7.3 coming.  Older versions don't have the defaults logic.)