### PR TITLE
zebra: fix NULL deref reported by coverity in evpn-pim cleanup

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -10259,7 +10259,7 @@ static int zebra_evpn_pim_cfg_clean_up(struct zserv *client)
 {
 	struct zebra_vrf *zvrf = zebra_vrf_get_evpn();
 
-	if (CHECK_FLAG(zvrf->flags, ZEBRA_PIM_SEND_VXLAN_SG)) {
+	if (zvrf && CHECK_FLAG(zvrf->flags, ZEBRA_PIM_SEND_VXLAN_SG)) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug("VxLAN SG updates to PIM, stop");
 		UNSET_FLAG(zvrf->flags, ZEBRA_PIM_SEND_VXLAN_SG);


### PR DESCRIPTION
*** CID 1492481:  Null pointer dereferences  (NULL_RETURNS)
/zebra/zebra_vxlan.c: 10262 in zebra_evpn_pim_cfg_clean_up()
10256     }
10257
10258     static int zebra_evpn_pim_cfg_clean_up(struct zserv *client)
10259     {
10260     	struct zebra_vrf *zvrf = zebra_vrf_get_evpn();
10261
>>>     CID 1492481:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing "zvrf", which is known to be "NULL".
10262     	if (CHECK_FLAG(zvrf->flags, ZEBRA_PIM_SEND_VXLAN_SG)) {
10263     		if (IS_ZEBRA_DEBUG_VXLAN)
10264     			zlog_debug("VxLAN SG updates to PIM, stop");
10265     		UNSET_FLAG(zvrf->flags, ZEBRA_PIM_SEND_VXLAN_SG);
10266     	}

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>