### PR TITLE
lib: [YANG] Route-map inteface forward ref

### DIFF
--- a/yang/frr-route-map.yang
+++ b/yang/frr-route-map.yang
@@ -210,7 +210,7 @@ module frr-route-map {
             case interface {
               when "./condition = 'interface'";
               leaf interface {
-                type frr-interface:interface-ref;
+                type string;
               }
             }
             case access-list-num {


### PR DESCRIPTION
To satisfy forward reference for interface in route-map.
Libyang 0.16 does not support leafref yet.

Signed-off-by: Santosh P K <sapk@vmware.com>