### PR TITLE
zebra: split northbound callbacks into multiple files

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -36,6 +36,7 @@
 #include "libfrr.h"
 #include "routemap.h"
 
+#include "zebra/zebra_nb.h"
 #include "zebra/zebra_router.h"
 #include "zebra/zebra_errors.h"
 #include "zebra/rib.h"

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -75,7 +75,6 @@ zebra_zebra_SOURCES = \
 	zebra/zebra_mlag.c \
 	zebra/zebra_mlag_vty.c \
 	zebra/zebra_l2.c \
-	zebra/zebra_northbound.c \
 	zebra/zebra_memory.c \
 	zebra/zebra_dplane.c \
 	zebra/zebra_mpls.c \
@@ -84,6 +83,11 @@ zebra_zebra_SOURCES = \
 	zebra/zebra_mpls_null.c \
 	zebra/zebra_mpls_vty.c \
 	zebra/zebra_mroute.c \
+	zebra/zebra_nb.c \
+	zebra/zebra_nb_config.c \
+	zebra/zebra_nb_notifications.c \
+	zebra/zebra_nb_rpcs.c \
+	zebra/zebra_nb_state.c \
 	zebra/zebra_nhg.c \
 	zebra/zebra_ns.c \
 	zebra/zebra_pbr.c \
@@ -147,6 +151,7 @@ noinst_HEADERS += \
 	zebra/zebra_memory.h \
 	zebra/zebra_mpls.h \
 	zebra/zebra_mroute.h \
+	zebra/zebra_nb.h \
 	zebra/zebra_nhg.h \
 	zebra/zebra_nhg_private.h \
 	zebra/zebra_ns.h \

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -1,0 +1,439 @@
+/*
+ * Zebra northbound implementation.
+ *
+ * Copyright (C) 2019 Network Device Education Foundation, Inc. ("NetDEF")
+ *                    Rafael Zalamena
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+#include <zebra.h>
+
+#include "northbound.h"
+#include "libfrr.h"
+
+#include "zebra/zebra_nb.h"
+
+/* clang-format off */
+const struct frr_yang_module_info frr_zebra_info = {
+	.name = "frr-zebra",
+	.nodes = {
+		{
+			.xpath = "/frr-zebra:zebra/mcast-rpf-lookup",
+			.cbs = {
+				.modify = zebra_mcast_rpf_lookup_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/ip-forwarding",
+			.cbs = {
+				.modify = zebra_ip_forwarding_modify,
+				.destroy = zebra_ip_forwarding_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/ipv6-forwarding",
+			.cbs = {
+				.modify = zebra_ipv6_forwarding_modify,
+				.destroy = zebra_ipv6_forwarding_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/workqueue-hold-timer",
+			.cbs = {
+				.modify = zebra_workqueue_hold_timer_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/zapi-packets",
+			.cbs = {
+				.modify = zebra_zapi_packets_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/import-kernel-table/table-id",
+			.cbs = {
+				.modify = zebra_import_kernel_table_table_id_modify,
+				.destroy = zebra_import_kernel_table_table_id_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/import-kernel-table/distance",
+			.cbs = {
+				.modify = zebra_import_kernel_table_distance_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/import-kernel-table/route-map",
+			.cbs = {
+				.modify = zebra_import_kernel_table_route_map_modify,
+				.destroy = zebra_import_kernel_table_route_map_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/allow-external-route-update",
+			.cbs = {
+				.create = zebra_allow_external_route_update_create,
+				.destroy = zebra_allow_external_route_update_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/dplane-queue-limit",
+			.cbs = {
+				.modify = zebra_dplane_queue_limit_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/vrf-vni-mapping",
+			.cbs = {
+				.create = zebra_vrf_vni_mapping_create,
+				.destroy = zebra_vrf_vni_mapping_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/vrf-vni-mapping/vni-id",
+			.cbs = {
+				.modify = zebra_vrf_vni_mapping_vni_id_modify,
+				.destroy = zebra_vrf_vni_mapping_vni_id_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/vrf-vni-mapping/prefix-only",
+			.cbs = {
+				.create = zebra_vrf_vni_mapping_prefix_only_create,
+				.destroy = zebra_vrf_vni_mapping_prefix_only_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-events",
+			.cbs = {
+				.modify = zebra_debugs_debug_events_modify,
+				.destroy = zebra_debugs_debug_events_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-zapi-send",
+			.cbs = {
+				.modify = zebra_debugs_debug_zapi_send_modify,
+				.destroy = zebra_debugs_debug_zapi_send_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-zapi-recv",
+			.cbs = {
+				.modify = zebra_debugs_debug_zapi_recv_modify,
+				.destroy = zebra_debugs_debug_zapi_recv_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-zapi-detail",
+			.cbs = {
+				.modify = zebra_debugs_debug_zapi_detail_modify,
+				.destroy = zebra_debugs_debug_zapi_detail_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-kernel",
+			.cbs = {
+				.modify = zebra_debugs_debug_kernel_modify,
+				.destroy = zebra_debugs_debug_kernel_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-kernel-msg-send",
+			.cbs = {
+				.modify = zebra_debugs_debug_kernel_msg_send_modify,
+				.destroy = zebra_debugs_debug_kernel_msg_send_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-kernel-msg-recv",
+			.cbs = {
+				.modify = zebra_debugs_debug_kernel_msg_recv_modify,
+				.destroy = zebra_debugs_debug_kernel_msg_recv_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-rib",
+			.cbs = {
+				.modify = zebra_debugs_debug_rib_modify,
+				.destroy = zebra_debugs_debug_rib_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-rib-detail",
+			.cbs = {
+				.modify = zebra_debugs_debug_rib_detail_modify,
+				.destroy = zebra_debugs_debug_rib_detail_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-fpm",
+			.cbs = {
+				.modify = zebra_debugs_debug_fpm_modify,
+				.destroy = zebra_debugs_debug_fpm_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-nht",
+			.cbs = {
+				.modify = zebra_debugs_debug_nht_modify,
+				.destroy = zebra_debugs_debug_nht_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-nht-detail",
+			.cbs = {
+				.modify = zebra_debugs_debug_nht_detail_modify,
+				.destroy = zebra_debugs_debug_nht_detail_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-mpls",
+			.cbs = {
+				.modify = zebra_debugs_debug_mpls_modify,
+				.destroy = zebra_debugs_debug_mpls_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-vxlan",
+			.cbs = {
+				.modify = zebra_debugs_debug_vxlan_modify,
+				.destroy = zebra_debugs_debug_vxlan_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-pw",
+			.cbs = {
+				.modify = zebra_debugs_debug_pw_modify,
+				.destroy = zebra_debugs_debug_pw_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-dplane",
+			.cbs = {
+				.modify = zebra_debugs_debug_dplane_modify,
+				.destroy = zebra_debugs_debug_dplane_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-dplane-detail",
+			.cbs = {
+				.modify = zebra_debugs_debug_dplane_detail_modify,
+				.destroy = zebra_debugs_debug_dplane_detail_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-mlag",
+			.cbs = {
+				.modify = zebra_debugs_debug_mlag_modify,
+				.destroy = zebra_debugs_debug_mlag_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-route-information",
+			.cbs = {
+				.rpc = get_route_information_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-v6-mroute-info",
+			.cbs = {
+				.rpc = get_v6_mroute_info_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-vrf-info",
+			.cbs = {
+				.rpc = get_vrf_info_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-vrf-vni-info",
+			.cbs = {
+				.rpc = get_vrf_vni_info_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-evpn-info",
+			.cbs = {
+				.rpc = get_evpn_info_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-vni-info",
+			.cbs = {
+				.rpc = get_vni_info_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-evpn-vni-rmac",
+			.cbs = {
+				.rpc = get_evpn_vni_rmac_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-evpn-vni-nexthops",
+			.cbs = {
+				.rpc = get_evpn_vni_nexthops_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:clear-evpn-dup-addr",
+			.cbs = {
+				.rpc = clear_evpn_dup_addr_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-evpn-macs",
+			.cbs = {
+				.rpc = get_evpn_macs_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-evpn-arp-cache",
+			.cbs = {
+				.rpc = get_evpn_arp_cache_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-pbr-ipset",
+			.cbs = {
+				.rpc = get_pbr_ipset_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-pbr-iptable",
+			.cbs = {
+				.rpc = get_pbr_iptable_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-debugs",
+			.cbs = {
+				.rpc = get_debugs_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list",
+			.cbs = {
+				.create = lib_interface_zebra_ip4_addr_list_create,
+				.destroy = lib_interface_zebra_ip4_addr_list_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/ip4-peer",
+			.cbs = {
+				.modify = lib_interface_zebra_ip4_addr_list_ip4_peer_modify,
+				.destroy = lib_interface_zebra_ip4_addr_list_ip4_peer_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/label",
+			.cbs = {
+				.modify = lib_interface_zebra_ip4_addr_list_label_modify,
+				.destroy = lib_interface_zebra_ip4_addr_list_label_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list",
+			.cbs = {
+				.create = lib_interface_zebra_ip6_addr_list_create,
+				.destroy = lib_interface_zebra_ip6_addr_list_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list/label",
+			.cbs = {
+				.modify = lib_interface_zebra_ip6_addr_list_label_modify,
+				.destroy = lib_interface_zebra_ip6_addr_list_label_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/multicast",
+			.cbs = {
+				.modify = lib_interface_zebra_multicast_modify,
+				.destroy = lib_interface_zebra_multicast_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/link-detect",
+			.cbs = {
+				.modify = lib_interface_zebra_link_detect_modify,
+				.destroy = lib_interface_zebra_link_detect_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/shutdown",
+			.cbs = {
+				.modify = lib_interface_zebra_shutdown_modify,
+				.destroy = lib_interface_zebra_shutdown_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/bandwidth",
+			.cbs = {
+				.modify = lib_interface_zebra_bandwidth_modify,
+				.destroy = lib_interface_zebra_bandwidth_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/frr-zebra:ipv4-prefix-length",
+			.cbs = {
+				.modify = lib_route_map_entry_match_condition_ipv4_prefix_length_modify,
+				.destroy = lib_route_map_entry_match_condition_ipv4_prefix_length_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/frr-zebra:ipv6-prefix-length",
+			.cbs = {
+				.modify = lib_route_map_entry_match_condition_ipv6_prefix_length_modify,
+				.destroy = lib_route_map_entry_match_condition_ipv6_prefix_length_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/frr-zebra:source-protocol",
+			.cbs = {
+				.modify = lib_route_map_entry_match_condition_source_protocol_modify,
+				.destroy = lib_route_map_entry_match_condition_source_protocol_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/frr-zebra:source-instance",
+			.cbs = {
+				.modify = lib_route_map_entry_match_condition_source_instance_modify,
+				.destroy = lib_route_map_entry_match_condition_source_instance_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/set-action/frr-zebra:source-v4",
+			.cbs = {
+				.modify = lib_route_map_entry_set_action_source_v4_modify,
+				.destroy = lib_route_map_entry_set_action_source_v4_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/set-action/frr-zebra:source-v6",
+			.cbs = {
+				.modify = lib_route_map_entry_set_action_source_v6_modify,
+				.destroy = lib_route_map_entry_set_action_source_v6_destroy,
+			}
+		},
+		{
+			.xpath = NULL,
+		},
+	}
+};

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -1,0 +1,289 @@
+/*
+ * Zebra northbound implementation.
+ *
+ * Copyright (C) 2019 Network Device Education Foundation, Inc. ("NetDEF")
+ *                    Rafael Zalamena
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+#ifndef _FRR_ZEBRA_NB_H_
+#define _FRR_ZEBRA_NB_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const struct frr_yang_module_info frr_zebra_info;
+
+/* Mandatory callbacks. */
+int get_route_information_rpc(const char *xpath, const struct list *input,
+			      struct list *output);
+int get_v6_mroute_info_rpc(const char *xpath, const struct list *input,
+			   struct list *output);
+int get_vrf_info_rpc(const char *xpath, const struct list *input,
+		     struct list *output);
+int get_vrf_vni_info_rpc(const char *xpath, const struct list *input,
+			 struct list *output);
+int get_evpn_info_rpc(const char *xpath, const struct list *input,
+		      struct list *output);
+int get_vni_info_rpc(const char *xpath, const struct list *input,
+		     struct list *output);
+int get_evpn_vni_rmac_rpc(const char *xpath, const struct list *input,
+			  struct list *output);
+int get_evpn_vni_nexthops_rpc(const char *xpath, const struct list *input,
+			      struct list *output);
+int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
+			    struct list *output);
+int get_evpn_macs_rpc(const char *xpath, const struct list *input,
+		      struct list *output);
+int get_evpn_arp_cache_rpc(const char *xpath, const struct list *input,
+			   struct list *output);
+int get_pbr_ipset_rpc(const char *xpath, const struct list *input,
+		      struct list *output);
+int get_pbr_iptable_rpc(const char *xpath, const struct list *input,
+			struct list *output);
+int get_debugs_rpc(const char *xpath, const struct list *input,
+		   struct list *output);
+int zebra_mcast_rpf_lookup_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource);
+int zebra_ip_forwarding_modify(enum nb_event event,
+			       const struct lyd_node *dnode,
+			       union nb_resource *resource);
+int zebra_ip_forwarding_destroy(enum nb_event event,
+				const struct lyd_node *dnode);
+int zebra_ipv6_forwarding_modify(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource);
+int zebra_ipv6_forwarding_destroy(enum nb_event event,
+				  const struct lyd_node *dnode);
+int zebra_workqueue_hold_timer_modify(enum nb_event event,
+				      const struct lyd_node *dnode,
+				      union nb_resource *resource);
+int zebra_zapi_packets_modify(enum nb_event event, const struct lyd_node *dnode,
+			      union nb_resource *resource);
+int zebra_import_kernel_table_table_id_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource);
+int zebra_import_kernel_table_table_id_destroy(enum nb_event event,
+					       const struct lyd_node *dnode);
+int zebra_import_kernel_table_distance_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource);
+int zebra_import_kernel_table_route_map_modify(enum nb_event event,
+					       const struct lyd_node *dnode,
+					       union nb_resource *resource);
+int zebra_import_kernel_table_route_map_destroy(enum nb_event event,
+						const struct lyd_node *dnode);
+int zebra_allow_external_route_update_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource);
+int zebra_allow_external_route_update_destroy(enum nb_event event,
+					      const struct lyd_node *dnode);
+int zebra_dplane_queue_limit_modify(enum nb_event event,
+				    const struct lyd_node *dnode,
+				    union nb_resource *resource);
+int zebra_vrf_vni_mapping_create(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource);
+int zebra_vrf_vni_mapping_destroy(enum nb_event event,
+				  const struct lyd_node *dnode);
+int zebra_vrf_vni_mapping_vni_id_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource);
+int zebra_vrf_vni_mapping_vni_id_destroy(enum nb_event event,
+					 const struct lyd_node *dnode);
+int zebra_vrf_vni_mapping_prefix_only_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource);
+int zebra_vrf_vni_mapping_prefix_only_destroy(enum nb_event event,
+					      const struct lyd_node *dnode);
+int zebra_debugs_debug_events_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource);
+int zebra_debugs_debug_events_destroy(enum nb_event event,
+				      const struct lyd_node *dnode);
+int zebra_debugs_debug_zapi_send_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource);
+int zebra_debugs_debug_zapi_send_destroy(enum nb_event event,
+					 const struct lyd_node *dnode);
+int zebra_debugs_debug_zapi_recv_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource);
+int zebra_debugs_debug_zapi_recv_destroy(enum nb_event event,
+					 const struct lyd_node *dnode);
+int zebra_debugs_debug_zapi_detail_modify(enum nb_event event,
+					  const struct lyd_node *dnode,
+					  union nb_resource *resource);
+int zebra_debugs_debug_zapi_detail_destroy(enum nb_event event,
+					   const struct lyd_node *dnode);
+int zebra_debugs_debug_kernel_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource);
+int zebra_debugs_debug_kernel_destroy(enum nb_event event,
+				      const struct lyd_node *dnode);
+int zebra_debugs_debug_kernel_msg_send_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource);
+int zebra_debugs_debug_kernel_msg_send_destroy(enum nb_event event,
+					       const struct lyd_node *dnode);
+int zebra_debugs_debug_kernel_msg_recv_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource);
+int zebra_debugs_debug_kernel_msg_recv_destroy(enum nb_event event,
+					       const struct lyd_node *dnode);
+int zebra_debugs_debug_rib_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource);
+int zebra_debugs_debug_rib_destroy(enum nb_event event,
+				   const struct lyd_node *dnode);
+int zebra_debugs_debug_rib_detail_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource);
+int zebra_debugs_debug_rib_detail_destroy(enum nb_event event,
+					  const struct lyd_node *dnode);
+int zebra_debugs_debug_fpm_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource);
+int zebra_debugs_debug_fpm_destroy(enum nb_event event,
+				   const struct lyd_node *dnode);
+int zebra_debugs_debug_nht_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource);
+int zebra_debugs_debug_nht_destroy(enum nb_event event,
+				   const struct lyd_node *dnode);
+int zebra_debugs_debug_nht_detail_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource);
+int zebra_debugs_debug_nht_detail_destroy(enum nb_event event,
+					  const struct lyd_node *dnode);
+int zebra_debugs_debug_mpls_modify(enum nb_event event,
+				   const struct lyd_node *dnode,
+				   union nb_resource *resource);
+int zebra_debugs_debug_mpls_destroy(enum nb_event event,
+				    const struct lyd_node *dnode);
+int zebra_debugs_debug_vxlan_modify(enum nb_event event,
+				    const struct lyd_node *dnode,
+				    union nb_resource *resource);
+int zebra_debugs_debug_vxlan_destroy(enum nb_event event,
+				     const struct lyd_node *dnode);
+int zebra_debugs_debug_pw_modify(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource);
+int zebra_debugs_debug_pw_destroy(enum nb_event event,
+				  const struct lyd_node *dnode);
+int zebra_debugs_debug_dplane_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource);
+int zebra_debugs_debug_dplane_destroy(enum nb_event event,
+				      const struct lyd_node *dnode);
+int zebra_debugs_debug_dplane_detail_modify(enum nb_event event,
+					    const struct lyd_node *dnode,
+					    union nb_resource *resource);
+int zebra_debugs_debug_dplane_detail_destroy(enum nb_event event,
+					     const struct lyd_node *dnode);
+int zebra_debugs_debug_mlag_modify(enum nb_event event,
+				   const struct lyd_node *dnode,
+				   union nb_resource *resource);
+int zebra_debugs_debug_mlag_destroy(enum nb_event event,
+				    const struct lyd_node *dnode);
+int lib_interface_zebra_ip4_addr_list_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource);
+int lib_interface_zebra_ip4_addr_list_destroy(enum nb_event event,
+					      const struct lyd_node *dnode);
+int lib_interface_zebra_ip4_addr_list_ip4_peer_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource);
+int lib_interface_zebra_ip4_addr_list_ip4_peer_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_interface_zebra_ip4_addr_list_label_modify(enum nb_event event,
+						   const struct lyd_node *dnode,
+						   union nb_resource *resource);
+int lib_interface_zebra_ip4_addr_list_label_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_interface_zebra_ip6_addr_list_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource);
+int lib_interface_zebra_ip6_addr_list_destroy(enum nb_event event,
+					      const struct lyd_node *dnode);
+int lib_interface_zebra_ip6_addr_list_label_modify(enum nb_event event,
+						   const struct lyd_node *dnode,
+						   union nb_resource *resource);
+int lib_interface_zebra_ip6_addr_list_label_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_interface_zebra_multicast_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource);
+int lib_interface_zebra_multicast_destroy(enum nb_event event,
+					  const struct lyd_node *dnode);
+int lib_interface_zebra_link_detect_modify(enum nb_event event,
+					   const struct lyd_node *dnode,
+					   union nb_resource *resource);
+int lib_interface_zebra_link_detect_destroy(enum nb_event event,
+					    const struct lyd_node *dnode);
+int lib_interface_zebra_shutdown_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource);
+int lib_interface_zebra_shutdown_destroy(enum nb_event event,
+					 const struct lyd_node *dnode);
+int lib_interface_zebra_bandwidth_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource);
+int lib_interface_zebra_bandwidth_destroy(enum nb_event event,
+					  const struct lyd_node *dnode);
+int lib_route_map_entry_match_condition_ipv4_prefix_length_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource);
+int lib_route_map_entry_match_condition_ipv4_prefix_length_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_route_map_entry_match_condition_ipv6_prefix_length_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource);
+int lib_route_map_entry_match_condition_ipv6_prefix_length_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_route_map_entry_match_condition_source_protocol_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource);
+int lib_route_map_entry_match_condition_source_protocol_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_route_map_entry_match_condition_source_instance_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource);
+int lib_route_map_entry_match_condition_source_instance_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_route_map_entry_set_action_source_v4_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource);
+int lib_route_map_entry_set_action_source_v4_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_route_map_entry_set_action_source_v6_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource);
+int lib_route_map_entry_set_action_source_v6_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+
+/* Optional 'apply_finish' callbacks. */
+
+/* Optional 'cli_show' callbacks. */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FRR_ZEBRA_NB_H_ */

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1,0 +1,1631 @@
+/*
+ * Zebra implementation of northbound configuration callbacks.
+ *
+ * Copyright (C) 2019 Network Device Education Foundation, Inc. ("NetDEF")
+ *                    Rafael Zalamena
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+#include <zebra.h>
+
+#include "lib/log.h"
+#include "lib/northbound.h"
+#include "lib/command.h"
+#include "lib/routemap.h"
+
+#include "zebra/zebra_nb.h"
+#include "zebra/rib.h"
+
+/*
+ * XPath: /frr-zebra:zebra/mcast-rpf-lookup
+ */
+int zebra_mcast_rpf_lookup_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/ip-forwarding
+ */
+int zebra_ip_forwarding_modify(enum nb_event event,
+			       const struct lyd_node *dnode,
+			       union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_ip_forwarding_destroy(enum nb_event event,
+				const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/ipv6-forwarding
+ */
+int zebra_ipv6_forwarding_modify(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_ipv6_forwarding_destroy(enum nb_event event,
+				  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/workqueue-hold-timer
+ */
+int zebra_workqueue_hold_timer_modify(enum nb_event event,
+				      const struct lyd_node *dnode,
+				      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/zapi-packets
+ */
+int zebra_zapi_packets_modify(enum nb_event event, const struct lyd_node *dnode,
+			      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/import-kernel-table/table-id
+ */
+int zebra_import_kernel_table_table_id_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_import_kernel_table_table_id_destroy(enum nb_event event,
+					       const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/import-kernel-table/distance
+ */
+int zebra_import_kernel_table_distance_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/import-kernel-table/route-map
+ */
+int zebra_import_kernel_table_route_map_modify(enum nb_event event,
+					       const struct lyd_node *dnode,
+					       union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_import_kernel_table_route_map_destroy(enum nb_event event,
+						const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/allow-external-route-update
+ */
+int zebra_allow_external_route_update_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_allow_external_route_update_destroy(enum nb_event event,
+					      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/dplane-queue-limit
+ */
+int zebra_dplane_queue_limit_modify(enum nb_event event,
+				    const struct lyd_node *dnode,
+				    union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/vrf-vni-mapping
+ */
+int zebra_vrf_vni_mapping_create(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_vrf_vni_mapping_destroy(enum nb_event event,
+				  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/vrf-vni-mapping/vni-id
+ */
+int zebra_vrf_vni_mapping_vni_id_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_vrf_vni_mapping_vni_id_destroy(enum nb_event event,
+					 const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/vrf-vni-mapping/prefix-only
+ */
+int zebra_vrf_vni_mapping_prefix_only_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_vrf_vni_mapping_prefix_only_destroy(enum nb_event event,
+					      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-events
+ */
+int zebra_debugs_debug_events_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_events_destroy(enum nb_event event,
+				      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-zapi-send
+ */
+int zebra_debugs_debug_zapi_send_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_zapi_send_destroy(enum nb_event event,
+					 const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-zapi-recv
+ */
+int zebra_debugs_debug_zapi_recv_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_zapi_recv_destroy(enum nb_event event,
+					 const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-zapi-detail
+ */
+int zebra_debugs_debug_zapi_detail_modify(enum nb_event event,
+					  const struct lyd_node *dnode,
+					  union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_zapi_detail_destroy(enum nb_event event,
+					   const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-kernel
+ */
+int zebra_debugs_debug_kernel_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_kernel_destroy(enum nb_event event,
+				      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-kernel-msg-send
+ */
+int zebra_debugs_debug_kernel_msg_send_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_kernel_msg_send_destroy(enum nb_event event,
+					       const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-kernel-msg-recv
+ */
+int zebra_debugs_debug_kernel_msg_recv_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_kernel_msg_recv_destroy(enum nb_event event,
+					       const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-rib
+ */
+int zebra_debugs_debug_rib_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_rib_destroy(enum nb_event event,
+				   const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-rib-detail
+ */
+int zebra_debugs_debug_rib_detail_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_rib_detail_destroy(enum nb_event event,
+					  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-fpm
+ */
+int zebra_debugs_debug_fpm_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_fpm_destroy(enum nb_event event,
+				   const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-nht
+ */
+int zebra_debugs_debug_nht_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_nht_destroy(enum nb_event event,
+				   const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-nht-detail
+ */
+int zebra_debugs_debug_nht_detail_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_nht_detail_destroy(enum nb_event event,
+					  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-mpls
+ */
+int zebra_debugs_debug_mpls_modify(enum nb_event event,
+				   const struct lyd_node *dnode,
+				   union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_mpls_destroy(enum nb_event event,
+				    const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-vxlan
+ */
+int zebra_debugs_debug_vxlan_modify(enum nb_event event,
+				    const struct lyd_node *dnode,
+				    union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_vxlan_destroy(enum nb_event event,
+				     const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-pw
+ */
+int zebra_debugs_debug_pw_modify(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_pw_destroy(enum nb_event event,
+				  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-dplane
+ */
+int zebra_debugs_debug_dplane_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_dplane_destroy(enum nb_event event,
+				      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-dplane-detail
+ */
+int zebra_debugs_debug_dplane_detail_modify(enum nb_event event,
+					    const struct lyd_node *dnode,
+					    union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_dplane_detail_destroy(enum nb_event event,
+					     const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-mlag
+ */
+int zebra_debugs_debug_mlag_modify(enum nb_event event,
+				   const struct lyd_node *dnode,
+				   union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_mlag_destroy(enum nb_event event,
+				    const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list
+ */
+int lib_interface_zebra_ip4_addr_list_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_ip4_addr_list_destroy(enum nb_event event,
+					      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/ip4-peer
+ */
+int lib_interface_zebra_ip4_addr_list_ip4_peer_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_ip4_addr_list_ip4_peer_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/label
+ */
+int lib_interface_zebra_ip4_addr_list_label_modify(enum nb_event event,
+						   const struct lyd_node *dnode,
+						   union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_ip4_addr_list_label_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list
+ */
+int lib_interface_zebra_ip6_addr_list_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_ip6_addr_list_destroy(enum nb_event event,
+					      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list/label
+ */
+int lib_interface_zebra_ip6_addr_list_label_modify(enum nb_event event,
+						   const struct lyd_node *dnode,
+						   union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_ip6_addr_list_label_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/multicast
+ */
+int lib_interface_zebra_multicast_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_multicast_destroy(enum nb_event event,
+					  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/link-detect
+ */
+int lib_interface_zebra_link_detect_modify(enum nb_event event,
+					   const struct lyd_node *dnode,
+					   union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_link_detect_destroy(enum nb_event event,
+					    const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/shutdown
+ */
+int lib_interface_zebra_shutdown_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_shutdown_destroy(enum nb_event event,
+					 const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/bandwidth
+ */
+int lib_interface_zebra_bandwidth_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_bandwidth_destroy(enum nb_event event,
+					  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-route-map:lib/route-map/entry/match-condition/frr-zebra:ipv4-prefix-length
+ */
+int lib_route_map_entry_match_condition_ipv4_prefix_length_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource)
+{
+	struct routemap_hook_context *rhc;
+	const char *length;
+	int condition, rv;
+
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	/* Add configuration. */
+	rhc = nb_running_get_entry(dnode, NULL, true);
+	length = yang_dnode_get_string(dnode, NULL);
+	condition = yang_dnode_get_enum(dnode, "../frr-route-map:condition");
+
+	/* Set destroy information. */
+	switch (condition) {
+	case 100: /* ipv4-prefix-length */
+		rhc->rhc_rule = "ip address prefix-len";
+		break;
+
+	case 102: /* ipv4-next-hop-prefix-length */
+		rhc->rhc_rule = "ip next-hop prefix-len";
+		break;
+	}
+	rhc->rhc_mhook = generic_match_delete;
+	rhc->rhc_event = RMAP_EVENT_MATCH_DELETED;
+
+	rv = generic_match_add(NULL, rhc->rhc_rmi, rhc->rhc_rule, length,
+			       RMAP_EVENT_MATCH_ADDED);
+	if (rv != CMD_SUCCESS) {
+		rhc->rhc_mhook = NULL;
+		return NB_ERR_INCONSISTENCY;
+	}
+
+	return NB_OK;
+}
+
+int lib_route_map_entry_match_condition_ipv4_prefix_length_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	return lib_route_map_entry_match_destroy(event, dnode);
+}
+
+/*
+ * XPath:
+ * /frr-route-map:lib/route-map/entry/match-condition/frr-zebra:ipv6-prefix-length
+ */
+int lib_route_map_entry_match_condition_ipv6_prefix_length_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource)
+{
+	struct routemap_hook_context *rhc;
+	const char *length;
+	int rv;
+
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	/* Add configuration. */
+	rhc = nb_running_get_entry(dnode, NULL, true);
+	length = yang_dnode_get_string(dnode, NULL);
+
+	/* Set destroy information. */
+	rhc->rhc_mhook = generic_match_delete;
+	rhc->rhc_rule = "ipv6 address prefix-len";
+	rhc->rhc_event = RMAP_EVENT_MATCH_DELETED;
+
+	rv = generic_match_add(NULL, rhc->rhc_rmi, "ipv6 address prefix-len",
+			       length, RMAP_EVENT_MATCH_ADDED);
+	if (rv != CMD_SUCCESS) {
+		rhc->rhc_mhook = NULL;
+		return NB_ERR_INCONSISTENCY;
+	}
+
+	return NB_OK;
+}
+
+int lib_route_map_entry_match_condition_ipv6_prefix_length_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	return lib_route_map_entry_match_destroy(event, dnode);
+}
+
+/*
+ * XPath:
+ * /frr-route-map:lib/route-map/entry/match-condition/frr-zebra:source-protocol
+ */
+int lib_route_map_entry_match_condition_source_protocol_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource)
+{
+	struct routemap_hook_context *rhc;
+	const char *type;
+	int rv;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+		type = yang_dnode_get_string(dnode, NULL);
+		if (proto_name2num(type) == -1) {
+			zlog_warn("%s: invalid protocol: %s", __func__, type);
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		return NB_OK;
+	case NB_EV_APPLY:
+		/* NOTHING */
+		break;
+	}
+
+	/* Add configuration. */
+	rhc = nb_running_get_entry(dnode, NULL, true);
+	type = yang_dnode_get_string(dnode, NULL);
+
+	/* Set destroy information. */
+	rhc->rhc_mhook = generic_match_delete;
+	rhc->rhc_rule = "source-protocol";
+	rhc->rhc_event = RMAP_EVENT_MATCH_DELETED;
+
+	rv = generic_match_add(NULL, rhc->rhc_rmi, "source-protocol", type,
+			       RMAP_EVENT_MATCH_ADDED);
+	if (rv != CMD_SUCCESS) {
+		rhc->rhc_mhook = NULL;
+		return NB_ERR_INCONSISTENCY;
+	}
+
+	return NB_OK;
+}
+
+int lib_route_map_entry_match_condition_source_protocol_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	return lib_route_map_entry_match_destroy(event, dnode);
+}
+
+/*
+ * XPath:
+ * /frr-route-map:lib/route-map/entry/match-condition/frr-zebra:source-instance
+ */
+int lib_route_map_entry_match_condition_source_instance_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource)
+{
+	struct routemap_hook_context *rhc;
+	const char *type;
+	int rv;
+
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	/* Add configuration. */
+	rhc = nb_running_get_entry(dnode, NULL, true);
+	type = yang_dnode_get_string(dnode, NULL);
+
+	/* Set destroy information. */
+	rhc->rhc_mhook = generic_match_delete;
+	rhc->rhc_rule = "source-instance";
+	rhc->rhc_event = RMAP_EVENT_MATCH_DELETED;
+
+	rv = generic_match_add(NULL, rhc->rhc_rmi, "source-instance", type,
+			       RMAP_EVENT_MATCH_ADDED);
+	if (rv != CMD_SUCCESS) {
+		rhc->rhc_mhook = NULL;
+		return NB_ERR_INCONSISTENCY;
+	}
+
+	return NB_OK;
+}
+
+int lib_route_map_entry_match_condition_source_instance_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	return lib_route_map_entry_match_destroy(event, dnode);
+}
+
+/*
+ * XPath: /frr-route-map:lib/route-map/entry/set-action/frr-zebra:source-v4
+ */
+int lib_route_map_entry_set_action_source_v4_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource)
+{
+	struct routemap_hook_context *rhc;
+	struct interface *pif = NULL;
+	const char *source;
+	struct vrf *vrf;
+	struct prefix p;
+	int rv;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+		memset(&p, 0, sizeof(p));
+		yang_dnode_get_ipv4p(&p, dnode, NULL);
+		if (zebra_check_addr(&p) == 0) {
+			zlog_warn("%s: invalid IPv4 address: %s", __func__,
+				  yang_dnode_get_string(dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+
+		RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
+			pif = if_lookup_exact_address(&p.u.prefix4, AF_INET,
+						      vrf->vrf_id);
+			if (pif != NULL)
+				break;
+		}
+		if (pif == NULL) {
+			zlog_warn("%s: is not a local adddress: %s", __func__,
+				  yang_dnode_get_string(dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		return NB_OK;
+	case NB_EV_APPLY:
+		/* NOTHING */
+		break;
+	}
+
+	/* Add configuration. */
+	rhc = nb_running_get_entry(dnode, NULL, true);
+	source = yang_dnode_get_string(dnode, NULL);
+
+	/* Set destroy information. */
+	rhc->rhc_shook = generic_set_delete;
+	rhc->rhc_rule = "src";
+
+	rv = generic_set_add(NULL, rhc->rhc_rmi, "src", source);
+	if (rv != CMD_SUCCESS) {
+		rhc->rhc_shook = NULL;
+		return NB_ERR_INCONSISTENCY;
+	}
+
+	return NB_OK;
+}
+
+int lib_route_map_entry_set_action_source_v4_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	return lib_route_map_entry_set_destroy(event, dnode);
+}
+
+/*
+ * XPath: /frr-route-map:lib/route-map/entry/set-action/frr-zebra:source-v6
+ */
+int lib_route_map_entry_set_action_source_v6_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource)
+{
+	struct routemap_hook_context *rhc;
+	struct interface *pif = NULL;
+	const char *source;
+	struct vrf *vrf;
+	struct prefix p;
+	int rv;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+		memset(&p, 0, sizeof(p));
+		yang_dnode_get_ipv6p(&p, dnode, NULL);
+		if (zebra_check_addr(&p) == 0) {
+			zlog_warn("%s: invalid IPv6 address: %s", __func__,
+				  yang_dnode_get_string(dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+
+		RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
+			pif = if_lookup_exact_address(&p.u.prefix6, AF_INET6,
+						      vrf->vrf_id);
+			if (pif != NULL)
+				break;
+		}
+		if (pif == NULL) {
+			zlog_warn("%s: is not a local adddress: %s", __func__,
+				  yang_dnode_get_string(dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		return NB_OK;
+	case NB_EV_APPLY:
+		/* NOTHING */
+		break;
+	}
+
+	/* Add configuration. */
+	rhc = nb_running_get_entry(dnode, NULL, true);
+	source = yang_dnode_get_string(dnode, NULL);
+
+	/* Set destroy information. */
+	rhc->rhc_shook = generic_set_delete;
+	rhc->rhc_rule = "src";
+
+	rv = generic_set_add(NULL, rhc->rhc_rmi, "src", source);
+	if (rv != CMD_SUCCESS) {
+		rhc->rhc_shook = NULL;
+		return NB_ERR_INCONSISTENCY;
+	}
+
+	return NB_OK;
+}
+
+int lib_route_map_entry_set_action_source_v6_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	return lib_route_map_entry_set_destroy(event, dnode);
+}

--- a/zebra/zebra_nb_notifications.c
+++ b/zebra/zebra_nb_notifications.c
@@ -1,5 +1,5 @@
 /*
- * Zebra northbound implementation.
+ * Zebra implementation of northbound notification functions.
  *
  * Copyright (C) 2019 Network Device Education Foundation, Inc. ("NetDEF")
  *                    Rafael Zalamena
@@ -22,11 +22,7 @@
 
 #include <zebra.h>
 
-#include "lib/command.h"
 #include "lib/log.h"
 #include "lib/northbound.h"
-#include "lib/routemap.h"
 
-#include "zebra/rib.h"
-
-
+#include "zebra/zebra_nb.h"

--- a/zebra/zebra_nb_rpcs.c
+++ b/zebra/zebra_nb_rpcs.c
@@ -1,0 +1,168 @@
+/*
+ * Zebra implementation of northbound RPC callbacks.
+ *
+ * Copyright (C) 2019 Network Device Education Foundation, Inc. ("NetDEF")
+ *                    Rafael Zalamena
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+#include <zebra.h>
+
+#include "lib/log.h"
+#include "lib/northbound.h"
+
+#include "zebra/zebra_nb.h"
+
+/*
+ * XPath: /frr-zebra:get-route-information
+ */
+int get_route_information_rpc(const char *xpath, const struct list *input,
+			      struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-v6-mroute-info
+ */
+int get_v6_mroute_info_rpc(const char *xpath, const struct list *input,
+			   struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-vrf-info
+ */
+int get_vrf_info_rpc(const char *xpath, const struct list *input,
+		     struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-vrf-vni-info
+ */
+int get_vrf_vni_info_rpc(const char *xpath, const struct list *input,
+			 struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-evpn-info
+ */
+int get_evpn_info_rpc(const char *xpath, const struct list *input,
+		      struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-vni-info
+ */
+int get_vni_info_rpc(const char *xpath, const struct list *input,
+		     struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-evpn-vni-rmac
+ */
+int get_evpn_vni_rmac_rpc(const char *xpath, const struct list *input,
+			  struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-evpn-vni-nexthops
+ */
+int get_evpn_vni_nexthops_rpc(const char *xpath, const struct list *input,
+			      struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:clear-evpn-dup-addr
+ */
+int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
+			    struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-evpn-macs
+ */
+int get_evpn_macs_rpc(const char *xpath, const struct list *input,
+		      struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-evpn-arp-cache
+ */
+int get_evpn_arp_cache_rpc(const char *xpath, const struct list *input,
+			   struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-pbr-ipset
+ */
+int get_pbr_ipset_rpc(const char *xpath, const struct list *input,
+		      struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-pbr-iptable
+ */
+int get_pbr_iptable_rpc(const char *xpath, const struct list *input,
+			struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}
+
+/*
+ * XPath: /frr-zebra:get-debugs
+ */
+int get_debugs_rpc(const char *xpath, const struct list *input,
+		   struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_ERR_NOT_FOUND;
+}

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -1,5 +1,5 @@
 /*
- * Zebra northbound implementation.
+ * Zebra implementation of northbound state callbacks.
  *
  * Copyright (C) 2019 Network Device Education Foundation, Inc. ("NetDEF")
  *                    Rafael Zalamena
@@ -22,11 +22,7 @@
 
 #include <zebra.h>
 
-#include "lib/command.h"
 #include "lib/log.h"
 #include "lib/northbound.h"
-#include "lib/routemap.h"
 
-#include "zebra/rib.h"
-
-
+#include "zebra/zebra_nb.h"

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -218,9 +218,6 @@ extern void multicast_mode_ipv4_set(enum multicast_mode mode);
 
 extern enum multicast_mode multicast_mode_ipv4_get(void);
 
-/* zebra_northbound.c */
-extern const struct frr_yang_module_info frr_zebra_info;
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Rearrange the zebra northbound callbacks as following:
* zebra_nb.h: prototypes of all northbound callbacks.
* zebra_nb.c: definition of all northbound callbacks and their
  associated YANG data paths.
* zebra_nb_config.c: implementation of YANG configuration nodes.
* zebra_nb_state.c: implementation of YANG state nodes.
* zebra_nb_rpcs.c: implementation of YANG RPCs.
* zebra_nb_notifications.c: implementation of YANG notifications.

This should help to keep to code more organized and easier to
maintain.

No behavior changes intended.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>