### PR TITLE
tests: Add a route-map test to ensure it accepts an unknown intf name

### DIFF
--- a/tests/topotests/all-protocol-startup/r1/bgpd.conf
+++ b/tests/topotests/all-protocol-startup/r1/bgpd.conf
@@ -45,3 +45,6 @@ route-map bgp-map permit 20
 line vty
 !
 
+route-map LIES deny 10
+  match interface notpresent
+!

--- a/tests/topotests/all-protocol-startup/r1/ospf6d.conf
+++ b/tests/topotests/all-protocol-startup/r1/ospf6d.conf
@@ -14,3 +14,6 @@ router ospf6
 !
 line vty
 !
+route-map LIES deny 10
+ match interface notpresent
+!

--- a/tests/topotests/all-protocol-startup/r1/ospfd.conf
+++ b/tests/topotests/all-protocol-startup/r1/ospfd.conf
@@ -11,3 +11,6 @@ router ospf
 !
 line vty
 !
+route-map LIES deny 10
+ match interface notpresent
+!

--- a/tests/topotests/all-protocol-startup/r1/ripd.conf
+++ b/tests/topotests/all-protocol-startup/r1/ripd.conf
@@ -10,3 +10,6 @@ router rip
 line vty
 !
 
+route-map LIES deny 10
+ match interface notpresent
+!

--- a/tests/topotests/all-protocol-startup/r1/ripngd.conf
+++ b/tests/topotests/all-protocol-startup/r1/ripngd.conf
@@ -9,3 +9,6 @@ router ripng
 line vty
 !
 
+route-map LIES deny 10
+ match interface notpresent
+!

--- a/tests/topotests/all-protocol-startup/r1/show_route_map.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_route_map.ref
@@ -1,0 +1,73 @@
+ZEBRA:
+route-map: LIES Invoked: 0 Optimization: enabled
+ deny, sequence 10 Invoked 0
+  Match clauses:
+    interface notpresent
+  Set clauses:
+  Call clause:
+  Action:
+    Exit routemap
+RIP:
+route-map: LIES Invoked: 0 Optimization: enabled
+ deny, sequence 10 Invoked 0
+  Match clauses:
+    interface notpresent
+  Set clauses:
+  Call clause:
+  Action:
+    Exit routemap
+RIPNG:
+route-map: LIES Invoked: 0 Optimization: enabled
+ deny, sequence 10 Invoked 0
+  Match clauses:
+    interface notpresent
+  Set clauses:
+  Call clause:
+  Action:
+    Exit routemap
+OSPF:
+route-map: LIES Invoked: 0 Optimization: enabled
+ deny, sequence 10 Invoked 0
+  Match clauses:
+    interface notpresent
+  Set clauses:
+  Call clause:
+  Action:
+    Exit routemap
+OSPF6:
+route-map: LIES Invoked: 0 Optimization: enabled
+ deny, sequence 10 Invoked 0
+  Match clauses:
+    interface notpresent
+  Set clauses:
+  Call clause:
+  Action:
+    Exit routemap
+BGP:
+route-map: LIES Invoked: 0 Optimization: enabled
+ deny, sequence 10 Invoked 0
+  Match clauses:
+    interface notpresent
+  Set clauses:
+  Call clause:
+  Action:
+    Exit routemap
+route-map: bgp-map Invoked: 0 Optimization: enabled
+ permit, sequence 10 Invoked 0
+  Match clauses:
+  Set clauses:
+    community 100:100 additive
+    local-preference 100
+  Call clause:
+  Action:
+    Exit routemap
+ permit, sequence 20 Invoked 0
+  Match clauses:
+  Set clauses:
+    metric 10
+    local-preference 200
+  Call clause:
+  Action:
+    Exit routemap
+ISIS:
+SHARP:

--- a/tests/topotests/all-protocol-startup/r1/zebra.conf
+++ b/tests/topotests/all-protocol-startup/r1/zebra.conf
@@ -100,3 +100,6 @@ ipv6 forwarding
 line vty
 !
 
+route-map LIES deny 10
+  match interface notpresent
+!

--- a/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
+++ b/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
@@ -891,7 +891,38 @@ def test_bgp_ipv6():
     # For debugging after starting FRR/Quagga daemons, uncomment the next line
     # CLI(net)
 
+def test_route_map():
+    global fatal_error
+    global net
 
+    if (fatal_error != ""):
+        pytest.skip(fatal_error)
+
+    thisDir = os.path.dirname(os.path.realpath(__file__))
+
+    print("\n\n** Verifying some basic routemap forward references\n")
+    print("*******************************************************\n")
+    failures = 0
+    for i in range(1, 2):
+        refroutemap = '%s/r%s/show_route_map.ref' % (thisDir, i)
+        if os.path.isfile(refroutemap):
+            expected = open(refroutemap).read().rstrip()
+            expected = ('\n'.join(expected.splitlines()) + '\n').splitlines(1)
+
+            actual = net['r%s' %i].cmd('vtysh -c "show route-map" 2> /dev/null').rstrip()
+            actual = ('\n'.join(actual.splitlines()) + '\n').splitlines(1)
+
+            diff = topotest.get_textdiff(actual, expected,
+                                         title1="actual show route-map",
+                                         title2="expected show route-map")
+
+            if diff:
+                sys.stderr.write('r%s failed show route-map command Check:\n%s\n' % (i, diff))
+                failures += 1
+            else:
+                print("r%s ok" %i)
+
+            assert failures == 0, "Show route-map command failed for router r%s:\n%s" % (i, diff)
 
 def test_mpls_interfaces():
     global fatal_error


### PR DESCRIPTION
Add a test to route-amps to ensure that it accepts an unknown interface
name.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>