### PR TITLE
bgpd: fix multiple bugs with cluster_list attrs

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -335,7 +335,6 @@ extern unsigned long int attr_unknown_count(void);
 
 /* Cluster list prototypes. */
 extern bool cluster_loop_check(struct cluster_list *, struct in_addr);
-extern void cluster_unintern(struct cluster_list *);
 
 /* Below exported for unit-test purposes only */
 struct bgp_attr_parser_args {


### PR DESCRIPTION
Multiple different issues causing mostly UAFs but maybe other more
subtle things.

I believe the undefined behavior fixed in #6156 was masking these.

- Cluster lists were the only attributes whose pointers were not being
  NULL'd when freed, resulting in heap UAF
- When performing an insert into the cluster hash, our temporary struct
  used for hash_get() was inconsistent with our hash keying and
  comparison functions. In the case of a zero length cluster list, the
  ->length field is 0 and the ->list field is NULL. When performing an
  insert, we set the ->list field regardless of whether the length is 0.
  This resulted in the two cluster lists hashing equal but not comparing
  equal. Later, when removing one of them from the hash before freeing
  it, because the key matched and the comparison succeeded (because it
  was set to NULL *after* the search but *before* inserting into the
  hash) we would sometimes release the duplicated copy of the struct,
  and then free the one that remained in the hash table. Later accesses
  constitute UAF. This is fixed by making sure the fields used for the
  existence check match what is actually inserted into the hash when
  that check fails.

This patch also makes cluster_unintern static, because it should be.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>