### PR TITLE
pimd: fix negative bitshift in BSM code

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -1282,6 +1282,13 @@ int pim_bsm_process(struct interface *ifp, struct ip *ip_hdr, uint8_t *buf,
 	bshdr = (struct bsm_hdr *)(buf + PIM_MSG_HEADER_LEN);
 	pim_inet4_dump("<bsr?>", bshdr->bsr_addr.addr, bsr_str,
 		       sizeof(bsr_str));
+	if (bshdr->hm_len > 32) {
+		zlog_warn("Bad hashmask length for IPv4; got %" PRIu8
+			  ", expected value in range 0-32",
+			  bshdr->hm_len);
+		pim->bsm_dropped++;
+		return -1;
+	}
 	pim->global_scope.hashMasklen = bshdr->hm_len;
 	frag_tag = ntohs(bshdr->frag_tag);
 


### PR DESCRIPTION
Subtracting a byte obtained from the network from 32 can result in a negative number. Negative bitshifts are undefined.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>