### PR TITLE
bgpd: Enable rfc8212 by default

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1925,8 +1925,7 @@ bool subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 	 * benefit from consistent behavior across different BGP
 	 * implementations.
 	 */
-	if (peer->bgp->ebgp_requires_policy
-	    == DEFAULT_EBGP_POLICY_ENABLED)
+	if (peer->bgp->ebgp_requires_policy)
 		if (!bgp_outbound_policy_exists(peer, filter))
 			return false;
 
@@ -3404,7 +3403,7 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	 * benefit from consistent behavior across different BGP
 	 * implementations.
 	 */
-	if (peer->bgp->ebgp_requires_policy == DEFAULT_EBGP_POLICY_ENABLED)
+	if (peer->bgp->ebgp_requires_policy)
 		if (!bgp_inbound_policy_exists(peer,
 					       &peer->filter[afi][safi])) {
 			reason = "inbound policy missing";

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2036,7 +2036,7 @@ DEFUN(bgp_ebgp_requires_policy, bgp_ebgp_requires_policy_cmd,
       "Require in and out policy for eBGP peers (RFC8212)\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp->ebgp_requires_policy = DEFAULT_EBGP_POLICY_ENABLED;
+	bgp->ebgp_requires_policy = true;
 	return CMD_SUCCESS;
 }
 
@@ -2047,7 +2047,7 @@ DEFUN(no_bgp_ebgp_requires_policy, no_bgp_ebgp_requires_policy_cmd,
       "Require in and out policy for eBGP peers (RFC8212)\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp->ebgp_requires_policy = DEFAULT_EBGP_POLICY_DISABLED;
+	bgp->ebgp_requires_policy = false;
 	return CMD_SUCCESS;
 }
 
@@ -10149,14 +10149,14 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 				filter->map[RMAP_OUT].name);
 
 		/* ebgp-requires-policy (inbound) */
-		if (p->bgp->ebgp_requires_policy == DEFAULT_EBGP_POLICY_ENABLED
+		if (p->bgp->ebgp_requires_policy
 		    && !bgp_inbound_policy_exists(p, filter))
 			json_object_string_add(
 				json_addr, "inboundEbgpRequiresPolicy",
 				"Inbound updates discarded due to missing policy");
 
 		/* ebgp-requires-policy (outbound) */
-		if (p->bgp->ebgp_requires_policy == DEFAULT_EBGP_POLICY_ENABLED
+		if (p->bgp->ebgp_requires_policy
 		    && (!bgp_outbound_policy_exists(p, filter)))
 			json_object_string_add(
 				json_addr, "outboundEbgpRequiresPolicy",
@@ -10445,13 +10445,13 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 				filter->map[RMAP_OUT].name);
 
 		/* ebgp-requires-policy (inbound) */
-		if (p->bgp->ebgp_requires_policy == DEFAULT_EBGP_POLICY_ENABLED
+		if (p->bgp->ebgp_requires_policy
 		    && !bgp_inbound_policy_exists(p, filter))
 			vty_out(vty,
 				"  Inbound updates discarded due to missing policy\n");
 
 		/* ebgp-requires-policy (outbound) */
-		if (p->bgp->ebgp_requires_policy == DEFAULT_EBGP_POLICY_ENABLED
+		if (p->bgp->ebgp_requires_policy
 		    && !bgp_outbound_policy_exists(p, filter))
 			vty_out(vty,
 				"  Outbound updates discarded due to missing policy\n");
@@ -15059,9 +15059,8 @@ int bgp_config_write(struct vty *vty)
 			vty_out(vty, " bgp always-compare-med\n");
 
 		/* RFC8212 default eBGP policy. */
-		if (bgp->ebgp_requires_policy
-		    == DEFAULT_EBGP_POLICY_ENABLED)
-			vty_out(vty, " bgp ebgp-requires-policy\n");
+		if (!bgp->ebgp_requires_policy)
+			vty_out(vty, " no bgp ebgp-requires-policy\n");
 
 		/* draft-ietf-idr-deprecate-as-set-confed-set */
 		if (bgp->reject_as_sets == BGP_REJECT_AS_SETS_ENABLED)

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2972,7 +2972,7 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	bgp->dynamic_neighbors_count = 0;
 	bgp->lb_ref_bw = BGP_LINK_BW_REF_BW;
 	bgp->lb_handling = BGP_LINK_BW_ECMP;
-	bgp->ebgp_requires_policy = DEFAULT_EBGP_POLICY_DISABLED;
+	bgp->ebgp_requires_policy = true;
 	bgp->reject_as_sets = BGP_REJECT_AS_SETS_DISABLED;
 	bgp_addpath_init_bgp_data(&bgp->tx_addpath);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -594,9 +594,7 @@ struct bgp {
 	int advertise_all_vni;
 
 	/* RFC 8212 - prevent route leaks. */
-	int ebgp_requires_policy;
-#define DEFAULT_EBGP_POLICY_DISABLED 0
-#define DEFAULT_EBGP_POLICY_ENABLED 1
+	bool ebgp_requires_policy;
 
 	/* draft-ietf-idr-deprecate-as-set-confed-set
 	 * Reject aspaths with AS_SET and/or AS_CONFED_SET.

--- a/tests/topotests/all-protocol-startup/r1/bgpd.conf
+++ b/tests/topotests/all-protocol-startup/r1/bgpd.conf
@@ -4,6 +4,7 @@ log file bgpd.log
 router bgp 100
  bgp router-id 192.168.0.1
  bgp log-neighbor-changes
+ no bgp ebgp-requires-policy
  neighbor 192.168.7.10 remote-as 100
  neighbor 192.168.7.20 remote-as 200
  neighbor fc00:0:0:8::1000 remote-as 100

--- a/tests/topotests/bfd-bgp-cbit-topo3/r1/bgpd.conf
+++ b/tests/topotests/bfd-bgp-cbit-topo3/r1/bgpd.conf
@@ -1,6 +1,7 @@
 debug bgp neighbor-events
 router bgp 101
  bgp router-id 10.254.254.1
+ no bgp ebgp-requires-policy
  timers bgp 8 24
  bgp graceful-restart
  neighbor 2001:db8:4::1 remote-as 102
@@ -14,7 +15,7 @@ router bgp 101
  exit-address-family
  address-family ipv6 unicast
   network 2001:db8:8::/64
-  network 2001:db8:9::/64 
+  network 2001:db8:9::/64
   neighbor 2001:db8:4::1 activate
  exit-address-family
 !

--- a/tests/topotests/bfd-bgp-cbit-topo3/r3/bgpd.conf
+++ b/tests/topotests/bfd-bgp-cbit-topo3/r3/bgpd.conf
@@ -1,6 +1,7 @@
 debug bgp neighbor-events
 router bgp 102
  bgp router-id 10.254.254.3
+ no bgp ebgp-requires-policy
  timers bgp 20 60
  bgp graceful-restart
  ! simulate NSF machine

--- a/tests/topotests/bfd-topo1/r1/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 101
+ no bgp ebgp-requires-policy
  neighbor 192.168.0.2 remote-as 102
  neighbor 192.168.0.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bfd-topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 102
+ no bgp ebgp-requires-policy
  neighbor 192.168.0.1 remote-as 101
  neighbor 192.168.0.1 bfd
  neighbor 192.168.1.1 remote-as 103

--- a/tests/topotests/bfd-topo1/r3/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r3/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 103
+ no bgp ebgp-requires-policy
  neighbor 192.168.1.2 remote-as 102
  neighbor 192.168.1.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bfd-topo1/r4/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r4/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 104
+ no bgp ebgp-requires-policy
  neighbor 192.168.2.2 remote-as 102
  neighbor 192.168.2.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bfd-topo2/r1/bgpd.conf
+++ b/tests/topotests/bfd-topo2/r1/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 101
  bgp router-id 10.254.254.1
+ no bgp ebgp-requires-policy
  neighbor r2g peer-group
  neighbor r2g remote-as external
  neighbor r2g bfd

--- a/tests/topotests/bfd-topo2/r2/bgpd.conf
+++ b/tests/topotests/bfd-topo2/r2/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 102
  bgp router-id 10.254.254.2
+ no bgp ebgp-requires-policy
  neighbor r2g peer-group
  neighbor r2g remote-as external
  neighbor r2g bfd

--- a/tests/topotests/bfd-vrf-topo1/r1/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 101 vrf r1-cust1
+ no bgp ebgp-requires-policy
  neighbor 192.168.0.2 remote-as 102
 ! neighbor 192.168.0.2 ebgp-multihop 10
  neighbor 192.168.0.2 bfd

--- a/tests/topotests/bfd-vrf-topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 102 vrf r2-cust1
+ no bgp ebgp-requires-policy
  neighbor 192.168.0.1 remote-as 101
  neighbor 192.168.0.1 bfd
  neighbor 192.168.1.1 remote-as 103

--- a/tests/topotests/bfd-vrf-topo1/r3/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r3/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 103 vrf r3-cust1
+ no bgp ebgp-requires-policy
  neighbor 192.168.1.2 remote-as 102
  neighbor 192.168.1.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bfd-vrf-topo1/r4/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r4/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 104 vrf r4-cust1
+ no bgp ebgp-requires-policy
  neighbor 192.168.2.2 remote-as 102
  neighbor 192.168.2.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bgp-ecmp-topo1/r1/bgpd.conf
+++ b/tests/topotests/bgp-ecmp-topo1/r1/bgpd.conf
@@ -5,6 +5,7 @@ log file bgpd.log
 router bgp 100
  bgp router-id 10.0.255.1
  bgp bestpath as-path multipath-relax
+ no bgp ebgp-requires-policy
  neighbor 10.0.1.101 remote-as 99
  neighbor 10.0.1.102 remote-as 99
  neighbor 10.0.1.103 remote-as 99

--- a/tests/topotests/bgp-vrf-route-leak-basic/r1/bgpd.conf
+++ b/tests/topotests/bgp-vrf-route-leak-basic/r1/bgpd.conf
@@ -1,12 +1,14 @@
 hostname r1
 
 router bgp 99 vrf DONNA
+  no bgp ebgp-requires-policy
   address-family ipv4 unicast
     redistribute connected
     import vrf EVA
   !
 !
 router bgp 99 vrf EVA
+  no bgp ebgp-requires-policy
   address-family ipv4 unicast
     redistribute connected
     import vrf DONNA

--- a/tests/topotests/bgp_aggregate-address_origin/r1/bgpd.conf
+++ b/tests/topotests/bgp_aggregate-address_origin/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_aggregate-address_origin/r2/bgpd.conf
+++ b/tests/topotests/bgp_aggregate-address_origin/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
   exit-address-family
 !

--- a/tests/topotests/bgp_aggregate-address_route-map/r1/bgpd.conf
+++ b/tests/topotests/bgp_aggregate-address_route-map/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_aggregate-address_route-map/r2/bgpd.conf
+++ b/tests/topotests/bgp_aggregate-address_route-map/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
   exit-address-family
 !

--- a/tests/topotests/bgp_as_wide_bgp_identifier/r1/bgpd.conf
+++ b/tests/topotests/bgp_as_wide_bgp_identifier/r1/bgpd.conf
@@ -1,5 +1,6 @@
 ! exit1
 router bgp 65001
   bgp router-id 10.10.10.10
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65002
 !

--- a/tests/topotests/bgp_as_wide_bgp_identifier/r2/bgpd.conf
+++ b/tests/topotests/bgp_as_wide_bgp_identifier/r2/bgpd.conf
@@ -1,6 +1,7 @@
 ! spine
 router bgp 65002
   bgp router-id 10.10.10.10
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   neighbor 192.168.255.3 remote-as 65002
 !

--- a/tests/topotests/bgp_as_wide_bgp_identifier/r3/bgpd.conf
+++ b/tests/topotests/bgp_as_wide_bgp_identifier/r3/bgpd.conf
@@ -1,5 +1,6 @@
 ! exit2
 router bgp 65002
   bgp router-id 10.10.10.10
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65002
 !

--- a/tests/topotests/bgp_comm-list_delete/r1/bgpd.conf
+++ b/tests/topotests/bgp_comm-list_delete/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   address-family ipv4 unicast
     redistribute connected route-map r2-out

--- a/tests/topotests/bgp_comm-list_delete/r2/bgpd.conf
+++ b/tests/topotests/bgp_comm-list_delete/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
   address-family ipv4
     neighbor 192.168.255.1 route-map r1-in in

--- a/tests/topotests/bgp_default-route_route-map/r1/bgpd.conf
+++ b/tests/topotests/bgp_default-route_route-map/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   address-family ipv4 unicast
     neighbor 192.168.255.2 default-originate route-map default

--- a/tests/topotests/bgp_default-route_route-map/r2/bgpd.conf
+++ b/tests/topotests/bgp_default-route_route-map/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_distance_change/r1/bgpd.conf
+++ b/tests/topotests/bgp_distance_change/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   exit-address-family
 !

--- a/tests/topotests/bgp_distance_change/r2/bgpd.conf
+++ b/tests/topotests/bgp_distance_change/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
   address-family ipv4
     redistribute connected

--- a/tests/topotests/bgp_ebgp_requires_policy/r1/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r1/bgpd.conf
@@ -1,5 +1,4 @@
 router bgp 65000
-  bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 1000
   neighbor 192.168.255.2 local-as 500
   address-family ipv4 unicast

--- a/tests/topotests/bgp_ebgp_requires_policy/r2/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r2/bgpd.conf
@@ -1,2 +1,3 @@
 router bgp 1000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 500

--- a/tests/topotests/bgp_ebgp_requires_policy/r3/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r3/bgpd.conf
@@ -1,5 +1,4 @@
 router bgp 65000
-  bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 1000
   neighbor 192.168.255.2 local-as 500
   address-family ipv4 unicast

--- a/tests/topotests/bgp_ebgp_requires_policy/r4/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r4/bgpd.conf
@@ -1,2 +1,3 @@
 router bgp 1000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 500

--- a/tests/topotests/bgp_ebgp_requires_policy/r5/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r5/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65000
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_ebgp_requires_policy/r6/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r6/bgpd.conf
@@ -1,3 +1,2 @@
 router bgp 65000
-  bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000

--- a/tests/topotests/bgp_ipv6_rtadv/r1/bgpd.conf
+++ b/tests/topotests/bgp_ipv6_rtadv/r1/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 101
  bgp router-id 10.254.254.1
+ no bgp ebgp-requires-policy
  neighbor r2g peer-group
  neighbor r2g remote-as external
  neighbor r2g bfd

--- a/tests/topotests/bgp_ipv6_rtadv/r2/bgpd.conf
+++ b/tests/topotests/bgp_ipv6_rtadv/r2/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 102
  bgp router-id 10.254.254.2
+ no bgp ebgp-requires-policy
  neighbor r2g peer-group
  neighbor r2g remote-as external
  neighbor r2g bfd

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce1/bgpd.conf
@@ -7,6 +7,7 @@ log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 99.0.0.1
+   no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5226
    neighbor 192.168.1.1 update-source 192.168.1.2
    address-family ipv4 unicast
@@ -28,6 +29,6 @@ route-map rm-nh permit 10
 !
 
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce2/bgpd.conf
@@ -7,6 +7,7 @@ log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 99.0.0.2
+   no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5226
    neighbor 192.168.1.1 update-source 192.168.1.2
    address-family ipv4 unicast
@@ -28,6 +29,6 @@ route-map rm-nh permit 10
 !
 
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce3/bgpd.conf
@@ -7,6 +7,7 @@ log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 99.0.0.3
+   no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5226
    neighbor 192.168.1.1 update-source 192.168.1.2
    address-family ipv4 unicast
@@ -28,6 +29,6 @@ route-map rm-nh permit 10
 !
 
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r1/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 1.1.1.1
    bgp cluster-id 1.1.1.1
+   no bgp ebgp-requires-policy
    neighbor 192.168.1.2 remote-as 5226
    neighbor 192.168.1.2 update-source 192.168.1.1
    neighbor 192.168.1.2 route-reflector-client

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r2/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 2.2.2.2
    bgp cluster-id 2.2.2.2
+   no bgp ebgp-requires-policy
    neighbor 1.1.1.1 remote-as 5226
    neighbor 1.1.1.1 update-source 2.2.2.2
    neighbor 3.3.3.3 remote-as 5226
@@ -28,6 +29,6 @@ router bgp 5226
      neighbor 4.4.4.4 route-reflector-client
    exit-address-family
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r3/bgpd.conf
@@ -8,8 +8,9 @@ log commands
 router bgp 5226
    bgp router-id 3.3.3.3
    bgp cluster-id 3.3.3.3
+   no bgp ebgp-requires-policy
    neighbor 192.168.1.2 remote-as 5226
-   neighbor 192.168.1.2 update-source 192.168.1.2 
+   neighbor 192.168.1.2 update-source 192.168.1.2
    neighbor 192.168.1.2 route-reflector-client
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 3.3.3.3
@@ -37,6 +38,6 @@ router bgp 5226
  vnc redistribute ipv4 bgp-direct
 !
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r4/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r4/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 4.4.4.4
    bgp cluster-id 4.4.4.4
+   no bgp ebgp-requires-policy
    neighbor 192.168.1.2 remote-as 5226
    neighbor 192.168.1.2 update-source 192.168.1.1
    neighbor 192.168.1.2 route-reflector-client
@@ -37,6 +38,6 @@ router bgp 5226
  vnc redistribute ipv4 bgp-direct
 !
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce1/bgpd.conf
@@ -9,6 +9,7 @@ log file bgpd.log
 
 router bgp 5227
    bgp router-id 99.0.0.1
+   no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5227
    neighbor 192.168.1.1 update-source 192.168.1.2
    address-family ipv4 unicast
@@ -41,6 +42,6 @@ route-map sharp-nh permit 10
 !
 
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce2/bgpd.conf
@@ -9,6 +9,7 @@ log file bgpd.log
 
 router bgp 5227
    bgp router-id 99.0.0.2
+   no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5227
    neighbor 192.168.1.1 update-source 192.168.1.2
    address-family ipv4 unicast
@@ -41,6 +42,6 @@ route-map sharp-nh permit 10
 !
 
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce3/bgpd.conf
@@ -9,6 +9,7 @@ log file bgpd.log
 
 router bgp 5227
    bgp router-id 99.0.0.3
+   no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5227
    neighbor 192.168.1.1 update-source 192.168.1.2
    address-family ipv4 unicast
@@ -31,6 +32,6 @@ route-map rm-nh permit 10
 !
 
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce4/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce4/bgpd.conf
@@ -9,6 +9,7 @@ log file bgpd.log
 
 router bgp 5228 vrf ce4-cust2
    bgp router-id 99.0.0.4
+   no bgp ebgp-requires-policy
    neighbor 192.168.2.1 remote-as 5228
    neighbor 192.168.2.1 update-source 192.168.2.2
    address-family ipv4 unicast
@@ -31,6 +32,6 @@ route-map rm-nh permit 10
 !
 
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r1/bgpd.conf
@@ -16,6 +16,7 @@ log file bgpd.log debugging
 router bgp 5226
    bgp router-id 1.1.1.1
    bgp cluster-id 1.1.1.1
+   no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 1.1.1.1
 
@@ -31,6 +32,7 @@ router bgp 5226
 router bgp 5227 vrf r1-cust1
 
    bgp router-id 192.168.1.1
+   no bgp ebgp-requires-policy
 
    neighbor 192.168.1.2 remote-as 5227
    neighbor 192.168.1.2 update-source 192.168.1.1

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r2/bgpd.conf
@@ -10,6 +10,7 @@ log file bgpd.log debugging
 router bgp 5226
    bgp router-id 2.2.2.2
    bgp cluster-id 2.2.2.2
+   no bgp ebgp-requires-policy
    neighbor 1.1.1.1 remote-as 5226
    neighbor 1.1.1.1 update-source 2.2.2.2
    neighbor 3.3.3.3 remote-as 5226
@@ -30,6 +31,6 @@ router bgp 5226
      neighbor 4.4.4.4 route-reflector-client
    exit-address-family
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r3/bgpd.conf
@@ -11,6 +11,7 @@ log file bgpd.log
 router bgp 5226
    bgp router-id 3.3.3.3
    bgp cluster-id 3.3.3.3
+   no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 3.3.3.3
 
@@ -25,9 +26,10 @@ router bgp 5226
 router bgp 5227 vrf r3-cust1
 
    bgp router-id 192.168.1.1
+   no bgp ebgp-requires-policy
 
    neighbor 192.168.1.2 remote-as 5227
-   neighbor 192.168.1.2 update-source 192.168.1.1 
+   neighbor 192.168.1.2 update-source 192.168.1.1
 
    address-family ipv4 unicast
      neighbor 192.168.1.2 activate

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r4/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r4/bgpd.conf
@@ -14,6 +14,7 @@ log file bgpd.log debug
 router bgp 5226
    bgp router-id 4.4.4.4
    bgp cluster-id 4.4.4.4
+   no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 4.4.4.4
 
@@ -28,9 +29,10 @@ router bgp 5226
 router bgp 5227 vrf r4-cust1
 
    bgp router-id 192.168.1.1
+   no bgp ebgp-requires-policy
 
    neighbor 192.168.1.2 remote-as 5227
-   neighbor 192.168.1.2 update-source 192.168.1.1 
+   neighbor 192.168.1.2 update-source 192.168.1.1
 
    address-family ipv4 unicast
      neighbor 192.168.1.2 activate
@@ -47,6 +49,7 @@ router bgp 5227 vrf r4-cust1
 router bgp 5228 vrf r4-cust2
 
    bgp router-id 192.168.2.1
+   no bgp ebgp-requires-policy
 
    neighbor 192.168.2.2 remote-as 5228
    neighbor 192.168.2.2 update-source 192.168.2.1

--- a/tests/topotests/bgp_link_bw_ip/r1/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r1/bgpd.conf
@@ -2,6 +2,7 @@ hostname r1
 !
 router bgp 65101
  bgp router-id 11.1.1.1
+ no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
  neighbor 11.1.1.2 remote-as external
  neighbor 11.1.1.6 remote-as external

--- a/tests/topotests/bgp_link_bw_ip/r10/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r10/bgpd.conf
@@ -7,6 +7,7 @@ route-map redist permit 10
 !
 router bgp 65354
  bgp router-id 11.1.6.2
+ no bgp ebgp-requires-policy
  neighbor 11.1.6.1 remote-as external
  !
  address-family ipv4 unicast

--- a/tests/topotests/bgp_link_bw_ip/r2/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r2/bgpd.conf
@@ -3,6 +3,7 @@ hostname r2
 router bgp 65201
  bgp router-id 11.1.2.1
  bgp bestpath as-path multipath-relax
+ no bgp ebgp-requires-policy
  neighbor 11.1.1.1 remote-as external
  neighbor 11.1.2.2 remote-as external
  neighbor 11.1.2.6 remote-as external

--- a/tests/topotests/bgp_link_bw_ip/r3/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r3/bgpd.conf
@@ -3,6 +3,7 @@ hostname r3
 router bgp 65202
  bgp router-id 11.1.3.1
  bgp bestpath as-path multipath-relax
+ no bgp ebgp-requires-policy
  neighbor 11.1.1.5 remote-as external
  neighbor 11.1.3.2 remote-as external
 !

--- a/tests/topotests/bgp_link_bw_ip/r4/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r4/bgpd.conf
@@ -18,6 +18,7 @@ route-map anycast_ip permit 20
 router bgp 65301
  bgp router-id 11.1.4.1
  bgp bestpath as-path multipath-relax
+ no bgp ebgp-requires-policy
  neighbor 11.1.2.1 remote-as external
  neighbor 11.1.4.2 remote-as external
  neighbor 11.1.4.6 remote-as external

--- a/tests/topotests/bgp_link_bw_ip/r5/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r5/bgpd.conf
@@ -11,6 +11,7 @@ route-map anycast_ip permit 20
 router bgp 65302
  bgp router-id 11.1.5.1
  bgp bestpath as-path multipath-relax
+ no bgp ebgp-requires-policy
  neighbor 11.1.2.5 remote-as external
  neighbor 11.1.5.2 remote-as external
  !

--- a/tests/topotests/bgp_link_bw_ip/r6/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r6/bgpd.conf
@@ -11,6 +11,7 @@ route-map anycast_ip permit 20
 router bgp 65303
  bgp router-id 11.1.6.1
  bgp bestpath as-path multipath-relax
+ no bgp ebgp-requires-policy
  neighbor 11.1.3.1 remote-as external
  neighbor 11.1.6.2 remote-as external
  !

--- a/tests/topotests/bgp_link_bw_ip/r7/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r7/bgpd.conf
@@ -7,6 +7,7 @@ route-map redist permit 10
 !
 router bgp 65351
  bgp router-id 11.1.4.2
+ no bgp ebgp-requires-policy
  neighbor 11.1.4.1 remote-as external
  !
  address-family ipv4 unicast

--- a/tests/topotests/bgp_link_bw_ip/r8/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r8/bgpd.conf
@@ -7,6 +7,7 @@ route-map redist permit 10
 !
 router bgp 65352
  bgp router-id 11.1.4.6
+ no bgp ebgp-requires-policy
  neighbor 11.1.4.5 remote-as external
  !
  address-family ipv4 unicast

--- a/tests/topotests/bgp_link_bw_ip/r9/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r9/bgpd.conf
@@ -7,6 +7,7 @@ route-map redist permit 10
 !
 router bgp 65353
  bgp router-id 11.1.5.2
+ no bgp ebgp-requires-policy
  neighbor 11.1.5.1 remote-as external
  !
  address-family ipv4 unicast

--- a/tests/topotests/bgp_local_as_private_remove/r1/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 1000
   neighbor 192.168.255.2 local-as 500
   address-family ipv4 unicast

--- a/tests/topotests/bgp_local_as_private_remove/r2/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r2/bgpd.conf
@@ -1,2 +1,3 @@
 router bgp 1000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 500

--- a/tests/topotests/bgp_local_as_private_remove/r3/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r3/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 3000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 1000
   neighbor 192.168.255.2 local-as 500
   address-family ipv4 unicast

--- a/tests/topotests/bgp_local_as_private_remove/r4/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r4/bgpd.conf
@@ -1,2 +1,3 @@
 router bgp 1000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 500

--- a/tests/topotests/bgp_maximum_prefix_invalid_update/r1/bgpd.conf
+++ b/tests/topotests/bgp_maximum_prefix_invalid_update/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_maximum_prefix_invalid_update/r2/bgpd.conf
+++ b/tests/topotests/bgp_maximum_prefix_invalid_update/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
   address-family ipv4
     neighbor 192.168.255.1 maximum-prefix 1

--- a/tests/topotests/bgp_maximum_prefix_out/r1/bgpd.conf
+++ b/tests/topotests/bgp_maximum_prefix_out/r1/bgpd.conf
@@ -1,5 +1,6 @@
 !
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65002
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_maximum_prefix_out/r2/bgpd.conf
+++ b/tests/topotests/bgp_maximum_prefix_out/r2/bgpd.conf
@@ -1,5 +1,6 @@
 !
 router bgp 65002
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   exit-address-family
   !

--- a/tests/topotests/bgp_multiview_topo1/r1/bgpd.conf
+++ b/tests/topotests/bgp_multiview_topo1/r1/bgpd.conf
@@ -13,6 +13,7 @@ log file bgpd.log
 !
 router bgp 100 view 1
  bgp router-id 172.30.1.1
+ no bgp ebgp-requires-policy
  network 172.20.0.0/28 route-map local1
  timers bgp 60 180
  neighbor 172.16.1.1 remote-as 65001
@@ -21,6 +22,7 @@ router bgp 100 view 1
 !
 router bgp 100 view 2
  bgp router-id 172.30.1.1
+ no bgp ebgp-requires-policy
  network 172.20.0.0/28 route-map local2
  timers bgp 60 180
  neighbor 172.16.1.3 remote-as 65003
@@ -28,6 +30,7 @@ router bgp 100 view 2
 !
 router bgp 100 view 3
  bgp router-id 172.30.1.1
+ no bgp ebgp-requires-policy
  network 172.20.0.0/28
  timers bgp 60 180
  neighbor 172.16.1.6 remote-as 65006

--- a/tests/topotests/bgp_prefix_sid/r1/bgpd.conf
+++ b/tests/topotests/bgp_prefix_sid/r1/bgpd.conf
@@ -5,6 +5,7 @@ log commands
 router bgp 1
  bgp router-id 10.0.0.1
  no bgp default ipv4-unicast
+ no bgp ebgp-requires-policy
  neighbor 10.0.0.101 remote-as 2
  neighbor 10.0.0.102 remote-as 3
  !

--- a/tests/topotests/bgp_reject_as_sets/r1/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r1/bgpd.conf
@@ -1,5 +1,6 @@
 ! exit1
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65002
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_reject_as_sets/r2/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r2/bgpd.conf
@@ -1,6 +1,7 @@
 ! spine
 router bgp 65002
   bgp reject-as-sets
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   neighbor 192.168.254.2 remote-as 65003
   address-family ipv4 unicast

--- a/tests/topotests/bgp_reject_as_sets/r3/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r3/bgpd.conf
@@ -1,5 +1,6 @@
 ! exit2
 router bgp 65003
+  no bgp ebgp-requires-policy
   neighbor 192.168.254.1 remote-as 65002
   address-family ipv4 unicast
     neighbor 192.168.254.1 allowas-in

--- a/tests/topotests/bgp_rfapi_basic_sanity/r1/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r1/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 1.1.1.1
    bgp cluster-id 1.1.1.1
+   no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 1.1.1.1
 !

--- a/tests/topotests/bgp_rfapi_basic_sanity/r2/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r2/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 2.2.2.2
    bgp cluster-id 2.2.2.2
+   no bgp ebgp-requires-policy
    neighbor 1.1.1.1 remote-as 5226
    neighbor 1.1.1.1 update-source 2.2.2.2
    neighbor 3.3.3.3 remote-as 5226
@@ -28,6 +29,6 @@ router bgp 5226
      neighbor 4.4.4.4 route-reflector-client
    exit-address-family
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_rfapi_basic_sanity/r3/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r3/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 3.3.3.3
    bgp cluster-id 3.3.3.3
+   no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 3.3.3.3
 !
@@ -45,6 +46,6 @@ router bgp 5226
   exit-vnc
 !
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_rfapi_basic_sanity/r4/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r4/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 4.4.4.4
    bgp cluster-id 4.4.4.4
+   no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 4.4.4.4
 !
@@ -46,6 +47,6 @@ router bgp 5226
   exit-vnc
 !
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r1/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r1/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 1.1.1.1
    bgp cluster-id 1.1.1.1
+   no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 1.1.1.1
 !

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r2/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r2/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 2.2.2.2
    bgp cluster-id 2.2.2.2
+   no bgp ebgp-requires-policy
    neighbor 1.1.1.1 remote-as 5226
    neighbor 1.1.1.1 update-source 2.2.2.2
    neighbor 3.3.3.3 remote-as 5226
@@ -28,6 +29,6 @@ router bgp 5226
      neighbor 4.4.4.4 route-reflector-client
    exit-address-family
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r3/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r3/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 3.3.3.3
    bgp cluster-id 3.3.3.3
+   no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 3.3.3.3
 !
@@ -46,6 +47,6 @@ router bgp 5226
   exit-vnc
 !
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r4/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r4/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 router bgp 5226
    bgp router-id 4.4.4.4
    bgp cluster-id 4.4.4.4
+   no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 4.4.4.4
 !
@@ -47,6 +48,6 @@ router bgp 5226
   exit-vnc
 !
 end
-   
-   
+
+
 

--- a/tests/topotests/bgp_rr_ibgp/spine1/bgpd.conf
+++ b/tests/topotests/bgp_rr_ibgp/spine1/bgpd.conf
@@ -1,5 +1,6 @@
 hostname spine1
 router bgp 99
+  no bgp ebgp-requires-policy
   neighbor 192.168.2.1 remote-as internal
   neighbor 192.168.4.2 remote-as internal
   address-family ipv4 uni

--- a/tests/topotests/bgp_rr_ibgp/tor1/bgpd.conf
+++ b/tests/topotests/bgp_rr_ibgp/tor1/bgpd.conf
@@ -1,4 +1,5 @@
 hostname tor1
 router bgp 99
+  no bgp ebgp-requires-policy
   neighbor 192.168.2.3 remote-as internal
   redistribute connected

--- a/tests/topotests/bgp_rr_ibgp/tor2/bgpd.conf
+++ b/tests/topotests/bgp_rr_ibgp/tor2/bgpd.conf
@@ -1,4 +1,5 @@
 hostname tor2
 router bgp 99
+  no bgp ebgp-requires-policy
   neighbor 192.168.4.3 remote-as internal
   redistribute connected

--- a/tests/topotests/bgp_sender-as-path-loop-detection/r1/bgpd.conf
+++ b/tests/topotests/bgp_sender-as-path-loop-detection/r1/bgpd.conf
@@ -1,5 +1,6 @@
 ! exit1
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65002
   address-family ipv4 unicast
     neighbor 192.168.255.1 route-map prepend out

--- a/tests/topotests/bgp_sender-as-path-loop-detection/r2/bgpd.conf
+++ b/tests/topotests/bgp_sender-as-path-loop-detection/r2/bgpd.conf
@@ -1,5 +1,6 @@
 ! spine
 router bgp 65002
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   neighbor 192.168.255.2 solo
   neighbor 192.168.254.2 remote-as 65003

--- a/tests/topotests/bgp_sender-as-path-loop-detection/r3/bgpd.conf
+++ b/tests/topotests/bgp_sender-as-path-loop-detection/r3/bgpd.conf
@@ -1,4 +1,5 @@
 ! exit2
 router bgp 65003
+  no bgp ebgp-requires-policy
   neighbor 192.168.254.1 remote-as 65002
 !

--- a/tests/topotests/bgp_set_local-preference_add_subtract/r1/bgpd.conf
+++ b/tests/topotests/bgp_set_local-preference_add_subtract/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65000
   neighbor 192.168.255.3 remote-as 65000
   exit-address-family

--- a/tests/topotests/bgp_set_local-preference_add_subtract/r2/bgpd.conf
+++ b/tests/topotests/bgp_set_local-preference_add_subtract/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
   address-family ipv4
     redistribute connected

--- a/tests/topotests/bgp_set_local-preference_add_subtract/r3/bgpd.conf
+++ b/tests/topotests/bgp_set_local-preference_add_subtract/r3/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
   address-family ipv4
     redistribute connected

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/r1/bgpd.conf
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65000
+  no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/r2/bgpd.conf
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65001
+  no bgp ebgp-requires-policy
   bgp default show-hostname
   neighbor 192.168.255.1 remote-as 65000
   address-family ipv4 unicast

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r1/bgpd.conf
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r1/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 101 vrf r1-cust1
  bgp router-id 10.254.254.1
+ no bgp ebgp-requires-policy
  neighbor r2g peer-group
  neighbor r2g remote-as external
  neighbor r2g bfd

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r2/bgpd.conf
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r2/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 102 vrf r2-cust1
  bgp router-id 10.254.254.2
+ no bgp ebgp-requires-policy
  neighbor r2g peer-group
  neighbor r2g remote-as external
  neighbor r2g bfd

--- a/tests/topotests/bgp_vrf_netns/r1/bgpd.conf
+++ b/tests/topotests/bgp_vrf_netns/r1/bgpd.conf
@@ -2,6 +2,7 @@
 router bgp 100 vrf r1-cust1
  bgp router-id 10.0.1.1
  bgp bestpath as-path multipath-relax
+ no bgp ebgp-requires-policy
  neighbor 10.0.1.101 remote-as 99
  !
 !

--- a/tests/topotests/evpn-pim-1/leaf1/bgpd.conf
+++ b/tests/topotests/evpn-pim-1/leaf1/bgpd.conf
@@ -1,5 +1,6 @@
 
 router bgp 65002
+   no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as external
    redistribute connected
    address-family l2vpn evpn

--- a/tests/topotests/evpn-pim-1/leaf2/bgpd.conf
+++ b/tests/topotests/evpn-pim-1/leaf2/bgpd.conf
@@ -1,5 +1,6 @@
 
 router bgp 65003
+  no bgp ebgp-requires-policy
   neighbor 192.168.2.1 remote-as external
   redistribute connected
   address-family l2vpn evpn

--- a/tests/topotests/evpn-pim-1/spine/bgpd.conf
+++ b/tests/topotests/evpn-pim-1/spine/bgpd.conf
@@ -1,5 +1,6 @@
 
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 192.168.1.2 remote-as external
   neighbor 192.168.2.3 remote-as external
   redistribute connected

--- a/tests/topotests/pim-basic/r1/bgpd.conf
+++ b/tests/topotests/pim-basic/r1/bgpd.conf
@@ -1,3 +1,4 @@
 router bgp 65001
+  no bgp ebgp-requires-policy
   neighbor 10.0.30.3 remote-as external
   redistribute connected

--- a/tests/topotests/pim-basic/rp/bgpd.conf
+++ b/tests/topotests/pim-basic/rp/bgpd.conf
@@ -1,3 +1,4 @@
 router bgp 65003
+   no bgp ebgp-requires-policy
    neighbor 10.0.30.1 remote-as external
    redistribute connected


### PR DESCRIPTION
Eventually this switch should be dropped to conform RFC. Right now,
this is possible to switch it off.

Some competitive vendors like Cisco, Bird, OpenBGPD, Nokia already have this by default enabled.

The list is here: https://github.com/bgp/RFC8212