### PR TITLE
isisd, yang: unified lsp-timers command

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -640,7 +640,8 @@ void cli_show_isis_domain_pwd(struct vty *vty, struct lyd_node *dnode,
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/lsp/generation-interval
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-1/generation-interval
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-2/generation-interval
  */
 DEFPY(lsp_gen_interval, lsp_gen_interval_cmd,
       "lsp-gen-interval [level-1|level-2]$level (1-120)$val",
@@ -650,11 +651,13 @@ DEFPY(lsp_gen_interval, lsp_gen_interval_cmd,
       "Minimum interval in seconds\n")
 {
 	if (!level || strmatch(level, "level-1"))
-		nb_cli_enqueue_change(vty, "./lsp/generation-interval/level-1",
-				      NB_OP_MODIFY, val_str);
+		nb_cli_enqueue_change(
+			vty, "./lsp/timers/level-1/generation-interval",
+			NB_OP_MODIFY, val_str);
 	if (!level || strmatch(level, "level-2"))
-		nb_cli_enqueue_change(vty, "./lsp/generation-interval/level-2",
-				      NB_OP_MODIFY, val_str);
+		nb_cli_enqueue_change(
+			vty, "./lsp/timers/level-2/generation-interval",
+			NB_OP_MODIFY, val_str);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -668,31 +671,20 @@ DEFPY(no_lsp_gen_interval, no_lsp_gen_interval_cmd,
       "Minimum interval in seconds\n")
 {
 	if (!level || strmatch(level, "level-1"))
-		nb_cli_enqueue_change(vty, "./lsp/generation-interval/level-1",
-				      NB_OP_MODIFY, NULL);
+		nb_cli_enqueue_change(
+			vty, "./lsp/timers/level-1/generation-interval",
+			NB_OP_MODIFY, NULL);
 	if (!level || strmatch(level, "level-2"))
-		nb_cli_enqueue_change(vty, "./lsp/generation-interval/level-2",
-				      NB_OP_MODIFY, NULL);
+		nb_cli_enqueue_change(
+			vty, "./lsp/timers/level-2/generation-interval",
+			NB_OP_MODIFY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_lsp_gen_interval(struct vty *vty, struct lyd_node *dnode,
-				    bool show_defaults)
-{
-	const char *l1 = yang_dnode_get_string(dnode, "./level-1");
-	const char *l2 = yang_dnode_get_string(dnode, "./level-2");
-
-	if (strmatch(l1, l2))
-		vty_out(vty, " lsp-gen-interval %s\n", l1);
-	else {
-		vty_out(vty, " lsp-gen-interval level-1 %s\n", l1);
-		vty_out(vty, " lsp-gen-interval level-2 %s\n", l2);
-	}
-}
-
 /*
- * XPath: /frr-isisd:isis/instance/lsp/refresh-interval
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-1/refresh-interval
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-2/refresh-interval
  */
 DEFPY(lsp_refresh_interval, lsp_refresh_interval_cmd,
       "lsp-refresh-interval [level-1|level-2]$level (1-65235)$val",
@@ -702,10 +694,12 @@ DEFPY(lsp_refresh_interval, lsp_refresh_interval_cmd,
       "LSP refresh interval in seconds\n")
 {
 	if (!level || strmatch(level, "level-1"))
-		nb_cli_enqueue_change(vty, "./lsp/refresh-interval/level-1",
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-1/refresh-interval",
 				      NB_OP_MODIFY, val_str);
 	if (!level || strmatch(level, "level-2"))
-		nb_cli_enqueue_change(vty, "./lsp/refresh-interval/level-2",
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-2/refresh-interval",
 				      NB_OP_MODIFY, val_str);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -720,32 +714,22 @@ DEFPY(no_lsp_refresh_interval, no_lsp_refresh_interval_cmd,
       "LSP refresh interval in seconds\n")
 {
 	if (!level || strmatch(level, "level-1"))
-		nb_cli_enqueue_change(vty, "./lsp/refresh-interval/level-1",
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-1/refresh-interval",
 				      NB_OP_MODIFY, NULL);
 	if (!level || strmatch(level, "level-2"))
-		nb_cli_enqueue_change(vty, "./lsp/refresh-interval/level-2",
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-2/refresh-interval",
 				      NB_OP_MODIFY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_lsp_ref_interval(struct vty *vty, struct lyd_node *dnode,
-				    bool show_defaults)
-{
-	const char *l1 = yang_dnode_get_string(dnode, "./level-1");
-	const char *l2 = yang_dnode_get_string(dnode, "./level-2");
-
-	if (strmatch(l1, l2))
-		vty_out(vty, " lsp-refresh-interval %s\n", l1);
-	else {
-		vty_out(vty, " lsp-refresh-interval level-1 %s\n", l1);
-		vty_out(vty, " lsp-refresh-interval level-2 %s\n", l2);
-	}
-}
-
 /*
- * XPath: /frr-isisd:isis/instance/lsp/maximum-lifetime
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-1/maximum-lifetime
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-1/maximum-lifetime
  */
+
 DEFPY(max_lsp_lifetime, max_lsp_lifetime_cmd,
       "max-lsp-lifetime [level-1|level-2]$level (350-65535)$val",
       "Maximum LSP lifetime\n"
@@ -754,10 +738,12 @@ DEFPY(max_lsp_lifetime, max_lsp_lifetime_cmd,
       "LSP lifetime in seconds\n")
 {
 	if (!level || strmatch(level, "level-1"))
-		nb_cli_enqueue_change(vty, "./lsp/maximum-lifetime/level-1",
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-1/maximum-lifetime",
 				      NB_OP_MODIFY, val_str);
 	if (!level || strmatch(level, "level-2"))
-		nb_cli_enqueue_change(vty, "./lsp/maximum-lifetime/level-2",
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-2/maximum-lifetime",
 				      NB_OP_MODIFY, val_str);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -772,26 +758,125 @@ DEFPY(no_max_lsp_lifetime, no_max_lsp_lifetime_cmd,
       "LSP lifetime in seconds\n")
 {
 	if (!level || strmatch(level, "level-1"))
-		nb_cli_enqueue_change(vty, "./lsp/maximum-lifetime/level-1",
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-1/maximum-lifetime",
 				      NB_OP_MODIFY, NULL);
 	if (!level || strmatch(level, "level-2"))
-		nb_cli_enqueue_change(vty, "./lsp/maximum-lifetime/level-2",
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-2/maximum-lifetime",
 				      NB_OP_MODIFY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_lsp_max_lifetime(struct vty *vty, struct lyd_node *dnode,
-				    bool show_defaults)
-{
-	const char *l1 = yang_dnode_get_string(dnode, "./level-1");
-	const char *l2 = yang_dnode_get_string(dnode, "./level-2");
+/* unified LSP timers command
+ * XPath: /frr-isisd:isis/instance/lsp/timers
+ */
 
-	if (strmatch(l1, l2))
-		vty_out(vty, " max-lsp-lifetime %s\n", l1);
+DEFPY(lsp_timers, lsp_timers_cmd,
+      "lsp-timers [level-1|level-2]$level gen-interval (1-120)$gen refresh-interval (1-65235)$refresh max-lifetime (350-65535)$lifetime",
+      "LSP-related timers\n"
+      "LSP-related timers for Level 1 only\n"
+      "LSP-related timers for Level 2 only\n"
+      "Minimum interval between regenerating same LSP\n"
+      "Generation interval in seconds\n"
+      "LSP refresh interval\n"
+      "LSP refresh interval in seconds\n"
+      "Maximum LSP lifetime\n"
+      "Maximum LSP lifetime in seconds\n")
+{
+	if (!level || strmatch(level, "level-1")) {
+		nb_cli_enqueue_change(
+			vty, "./lsp/timers/level-1/generation-interval",
+			NB_OP_MODIFY, gen_str);
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-1/refresh-interval",
+				      NB_OP_MODIFY, refresh_str);
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-1/maximum-lifetime",
+				      NB_OP_MODIFY, lifetime_str);
+	}
+	if (!level || strmatch(level, "level-2")) {
+		nb_cli_enqueue_change(
+			vty, "./lsp/timers/level-2/generation-interval",
+			NB_OP_MODIFY, gen_str);
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-2/refresh-interval",
+				      NB_OP_MODIFY, refresh_str);
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-2/maximum-lifetime",
+				      NB_OP_MODIFY, lifetime_str);
+	}
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY(no_lsp_timers, no_lsp_timers_cmd,
+      "no lsp-timers [level-1|level-2]$level [gen-interval (1-120) refresh-interval (1-65235) max-lifetime (350-65535)]",
+      NO_STR
+      "LSP-related timers\n"
+      "LSP-related timers for Level 1 only\n"
+      "LSP-related timers for Level 2 only\n"
+      "Minimum interval between regenerating same LSP\n"
+      "Generation interval in seconds\n"
+      "LSP refresh interval\n"
+      "LSP refresh interval in seconds\n"
+      "Maximum LSP lifetime\n"
+      "Maximum LSP lifetime in seconds\n")
+{
+	if (!level || strmatch(level, "level-1")) {
+		nb_cli_enqueue_change(
+			vty, "./lsp/timers/level-1/generation-interval",
+			NB_OP_MODIFY, NULL);
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-1/refresh-interval",
+				      NB_OP_MODIFY, NULL);
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-1/maximum-lifetime",
+				      NB_OP_MODIFY, NULL);
+	}
+	if (!level || strmatch(level, "level-2")) {
+		nb_cli_enqueue_change(
+			vty, "./lsp/timers/level-2/generation-interval",
+			NB_OP_MODIFY, NULL);
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-2/refresh-interval",
+				      NB_OP_MODIFY, NULL);
+		nb_cli_enqueue_change(vty,
+				      "./lsp/timers/level-2/maximum-lifetime",
+				      NB_OP_MODIFY, NULL);
+	}
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+void cli_show_isis_lsp_timers(struct vty *vty, struct lyd_node *dnode,
+			      bool show_defaults)
+{
+	const char *l1_refresh =
+		yang_dnode_get_string(dnode, "./level-1/refresh-interval");
+	const char *l2_refresh =
+		yang_dnode_get_string(dnode, "./level-2/refresh-interval");
+	const char *l1_lifetime =
+		yang_dnode_get_string(dnode, "./level-1/maximum-lifetime");
+	const char *l2_lifetime =
+		yang_dnode_get_string(dnode, "./level-2/maximum-lifetime");
+	const char *l1_gen =
+		yang_dnode_get_string(dnode, "./level-1/generation-interval");
+	const char *l2_gen =
+		yang_dnode_get_string(dnode, "./level-2/generation-interval");
+	if (strmatch(l1_refresh, l2_refresh)
+	    && strmatch(l1_lifetime, l2_lifetime) && strmatch(l1_gen, l2_gen))
+		vty_out(vty,
+			" lsp-timers gen-interval %s refresh-interval %s max-lifetime %s\n",
+			l1_gen, l1_refresh, l1_lifetime);
 	else {
-		vty_out(vty, " max-lsp-lifetime level-1 %s\n", l1);
-		vty_out(vty, " max-lsp-lifetime level-2 %s\n", l2);
+		vty_out(vty,
+			" lsp-timers level-1 gen-interval %s refresh-interval %s max-lifetime %s\n",
+			l1_gen, l1_refresh, l1_lifetime);
+		vty_out(vty,
+			" lsp-timers level-2 gen-interval %s refresh-interval %s max-lifetime %s\n",
+			l2_gen, l2_refresh, l2_lifetime);
 	}
 }
 
@@ -2001,6 +2086,8 @@ void isis_cli_init(void)
 	install_element(ISIS_NODE, &no_lsp_refresh_interval_cmd);
 	install_element(ISIS_NODE, &max_lsp_lifetime_cmd);
 	install_element(ISIS_NODE, &no_max_lsp_lifetime_cmd);
+	install_element(ISIS_NODE, &lsp_timers_cmd);
+	install_element(ISIS_NODE, &no_lsp_timers_cmd);
 	install_element(ISIS_NODE, &area_lsp_mtu_cmd);
 	install_element(ISIS_NODE, &no_area_lsp_mtu_cmd);
 

--- a/isisd/isis_nb.c
+++ b/isisd/isis_nb.c
@@ -95,55 +95,43 @@ const struct frr_yang_module_info frr_isisd_info = {
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/lsp/refresh-interval",
+			.xpath = "/frr-isisd:isis/instance/lsp/timers",
 			.cbs = {
-				.cli_show = cli_show_isis_lsp_ref_interval,
+				.cli_show = cli_show_isis_lsp_timers,
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/lsp/refresh-interval/level-1",
+			.xpath = "/frr-isisd:isis/instance/lsp/timers/level-1/refresh-interval",
 			.cbs = {
 				.modify = isis_instance_lsp_refresh_interval_level_1_modify,
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/lsp/refresh-interval/level-2",
-			.cbs = {
-				.modify = isis_instance_lsp_refresh_interval_level_2_modify,
-			},
-		},
-		{
-			.xpath = "/frr-isisd:isis/instance/lsp/maximum-lifetime",
-			.cbs = {
-				.cli_show = cli_show_isis_lsp_max_lifetime,
-			},
-		},
-		{
-			.xpath = "/frr-isisd:isis/instance/lsp/maximum-lifetime/level-1",
+			.xpath = "/frr-isisd:isis/instance/lsp/timers/level-1/maximum-lifetime",
 			.cbs = {
 				.modify = isis_instance_lsp_maximum_lifetime_level_1_modify,
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/lsp/maximum-lifetime/level-2",
-			.cbs = {
-				.modify = isis_instance_lsp_maximum_lifetime_level_2_modify,
-			},
-		},
-		{
-			.xpath = "/frr-isisd:isis/instance/lsp/generation-interval",
-			.cbs = {
-				.cli_show = cli_show_isis_lsp_gen_interval,
-			},
-		},
-		{
-			.xpath = "/frr-isisd:isis/instance/lsp/generation-interval/level-1",
+			.xpath = "/frr-isisd:isis/instance/lsp/timers/level-1/generation-interval",
 			.cbs = {
 				.modify = isis_instance_lsp_generation_interval_level_1_modify,
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/lsp/generation-interval/level-2",
+			.xpath = "/frr-isisd:isis/instance/lsp/timers/level-2/refresh-interval",
+			.cbs = {
+				.modify = isis_instance_lsp_refresh_interval_level_2_modify,
+			},
+		},
+		{
+			.xpath = "/frr-isisd:isis/instance/lsp/timers/level-2/maximum-lifetime",
+			.cbs = {
+				.modify = isis_instance_lsp_maximum_lifetime_level_2_modify,
+			},
+		},
+		{
+			.xpath = "/frr-isisd:isis/instance/lsp/timers/level-2/generation-interval",
 			.cbs = {
 				.modify = isis_instance_lsp_generation_interval_level_2_modify,
 			},

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -427,12 +427,8 @@ void cli_show_isis_area_pwd(struct vty *vty, struct lyd_node *dnode,
 			    bool show_defaults);
 void cli_show_isis_domain_pwd(struct vty *vty, struct lyd_node *dnode,
 			      bool show_defaults);
-void cli_show_isis_lsp_gen_interval(struct vty *vty, struct lyd_node *dnode,
-				    bool show_defaults);
-void cli_show_isis_lsp_ref_interval(struct vty *vty, struct lyd_node *dnode,
-				    bool show_defaults);
-void cli_show_isis_lsp_max_lifetime(struct vty *vty, struct lyd_node *dnode,
-				    bool show_defaults);
+void cli_show_isis_lsp_timers(struct vty *vty, struct lyd_node *dnode,
+			      bool show_defaults);
 void cli_show_isis_lsp_mtu(struct vty *vty, struct lyd_node *dnode,
 			   bool show_defaults);
 void cli_show_isis_spf_min_interval(struct vty *vty, struct lyd_node *dnode,

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -371,7 +371,7 @@ int isis_instance_lsp_mtu_modify(enum nb_event event,
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/lsp/refresh-interval/level-1
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-1/refresh-interval
  */
 int isis_instance_lsp_refresh_interval_level_1_modify(
 	enum nb_event event, const struct lyd_node *dnode,
@@ -391,7 +391,7 @@ int isis_instance_lsp_refresh_interval_level_1_modify(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/lsp/refresh-interval/level-2
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-2/refresh-interval
  */
 int isis_instance_lsp_refresh_interval_level_2_modify(
 	enum nb_event event, const struct lyd_node *dnode,
@@ -411,7 +411,7 @@ int isis_instance_lsp_refresh_interval_level_2_modify(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/lsp/maximum-lifetime/level-1
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-1/maximum-lifetime
  */
 int isis_instance_lsp_maximum_lifetime_level_1_modify(
 	enum nb_event event, const struct lyd_node *dnode,
@@ -431,7 +431,7 @@ int isis_instance_lsp_maximum_lifetime_level_1_modify(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/lsp/maximum-lifetime/level-2
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-2/maximum-lifetime
  */
 int isis_instance_lsp_maximum_lifetime_level_2_modify(
 	enum nb_event event, const struct lyd_node *dnode,
@@ -451,7 +451,7 @@ int isis_instance_lsp_maximum_lifetime_level_2_modify(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/lsp/generation-interval/level-1
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-1/generation-interval
  */
 int isis_instance_lsp_generation_interval_level_1_modify(
 	enum nb_event event, const struct lyd_node *dnode,
@@ -471,7 +471,7 @@ int isis_instance_lsp_generation_interval_level_1_modify(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/lsp/generation-interval/level-2
+ * XPath: /frr-isisd:isis/instance/lsp/timers/level-2/generation-interval
  */
 int isis_instance_lsp_generation_interval_level_2_modify(
 	enum nb_event event, const struct lyd_node *dnode,

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -137,17 +137,17 @@ struct isis_area *isis_area_create(const char *area_tag)
 	enum isis_metric_style default_style;
 
 	area->max_lsp_lifetime[0] = yang_get_default_uint16(
-		"/frr-isisd:isis/instance/lsp/maximum-lifetime/level-1");
+		"/frr-isisd:isis/instance/lsp/timers/level-1/maximum-lifetime");
 	area->max_lsp_lifetime[1] = yang_get_default_uint16(
-		"/frr-isisd:isis/instance/lsp/maximum-lifetime/level-2");
+		"/frr-isisd:isis/instance/lsp/timers/level-2/maximum-lifetime");
 	area->lsp_refresh[0] = yang_get_default_uint16(
-		"/frr-isisd:isis/instance/lsp/refresh-interval/level-1");
+		"/frr-isisd:isis/instance/lsp/timers/level-1/refresh-interval");
 	area->lsp_refresh[1] = yang_get_default_uint16(
-		"/frr-isisd:isis/instance/lsp/refresh-interval/level-2");
+		"/frr-isisd:isis/instance/lsp/timers/level-2/refresh-interval");
 	area->lsp_gen_interval[0] = yang_get_default_uint16(
-		"/frr-isisd:isis/instance/lsp/generation-interval/level-1");
+		"/frr-isisd:isis/instance/lsp/timers/level-1/generation-interval");
 	area->lsp_gen_interval[1] = yang_get_default_uint16(
-		"/frr-isisd:isis/instance/lsp/generation-interval/level-2");
+		"/frr-isisd:isis/instance/lsp/timers/level-2/generation-interval");
 	area->min_spf_interval[0] = yang_get_default_uint16(
 		"/frr-isisd:isis/instance/spf/minimum-interval/level-1");
 	area->min_spf_interval[1] = yang_get_default_uint16(

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -27,6 +27,11 @@ module frr-isisd {
   description
     "This module defines a model for managing FRR isisd daemon.";
 
+  revision 2020-04-06 {
+    description
+      "Group LSP timers in a container so that they can be displayed and
+       configured together";
+  }
   revision 2019-12-17 {
     description
       "Changed default area is-type to level-1-2";
@@ -34,7 +39,7 @@ module frr-isisd {
   revision 2019-09-09 {
     description
       "Changed interface references to use
-      frr-interface:interface-ref typedef";
+       frr-interface:interface-ref typedef";
   }
   revision 2018-07-26 {
     description
@@ -301,8 +306,8 @@ module frr-isisd {
   }
 
   grouping interface-config {
-    description "Interface configuration grouping";
-
+    description
+      "Interface configuration grouping";
     leaf area-tag {
       type string;
       mandatory true;
@@ -333,8 +338,9 @@ module frr-isisd {
 
     leaf bfd-monitoring {
       type boolean;
-      default false;
-      description "Monitor IS-IS peers on this circuit.";
+      default "false";
+      description
+        "Monitor IS-IS peers on this circuit.";
     }
 
     container csnp-interval {
@@ -490,8 +496,8 @@ module frr-isisd {
 
     leaf network-type {
       type network-type;
-      default "broadcast";
       must "(. = \"point-to-point\") or (. = \"broadcast\")";
+      default "broadcast";
       description
         "Explicitly configured type of IS-IS circuit (broadcast or point-to-point).";
     }
@@ -570,38 +576,50 @@ module frr-isisd {
   }
 
   grouping adjacency-state {
+    description
+      "Adjacency state";
     container adjacencies {
       config false;
+      description
+        "This container lists the adjacencies of
+         the local node.";
       list adjacency {
+        description
+          "List of operational adjacencies.";
         leaf neighbor-sys-type {
           type level;
           description
             "Level capability of neighboring system";
         }
+
         leaf neighbor-sysid {
           type system-id;
           description
             "The system-id of the neighbor";
         }
+
         leaf neighbor-extended-circuit-id {
           type extended-circuit-id;
           description
             "Circuit ID of the neighbor";
         }
+
         leaf neighbor-snpa {
           type snpa;
           description
             "SNPA of the neighbor";
         }
+
         leaf hold-timer {
           type uint16;
-          units seconds;
+          units "seconds";
           description
             "The holding time in seconds for this
              adjacency. This value is based on
              received hello PDUs and the elapsed
              time since receipt.";
         }
+
         leaf neighbor-priority {
           type uint8 {
             range "0 .. 127";
@@ -610,37 +628,36 @@ module frr-isisd {
             "Priority of the neighboring IS for becoming
              the DIS.";
         }
+
         leaf state {
           type adj-state-type;
           description
             "This leaf describes the state of the interface.";
         }
-
-        description
-          "List of operational adjacencies.";
       }
-      description
-        "This container lists the adjacencies of
-         the local node.";
     }
-    description
-      "Adjacency state";
   }
 
   grouping event-counters {
+    description
+      "Grouping for IS-IS interface event counters";
     container event-counters {
       config false;
+      description
+        "IS-IS interface event counters.";
       leaf adjacency-changes {
         type uint32;
         description
           "The number of times an adjacency state change has
            occurred on this interface.";
       }
+
       leaf adjacency-number {
         type uint32;
         description
           "The number of adjacencies on this interface.";
       }
+
       leaf init-fails {
         type uint32;
         description
@@ -649,12 +666,14 @@ module frr-isisd {
            as PPP NCP failures. Failures to form an
            adjacency are counted by adjacency-rejects.";
       }
+
       leaf adjacency-rejects {
         type uint32;
         description
           "The number of times an adjacency has been
            rejected on this interface.";
       }
+
       leaf id-len-mismatch {
         type uint32;
         description
@@ -662,6 +681,7 @@ module frr-isisd {
            field length different from that for this
            system has been received on this interface.";
       }
+
       leaf max-area-addresses-mismatch {
         type uint32;
         description
@@ -670,26 +690,26 @@ module frr-isisd {
            max area address field differing from that of
            this system.";
       }
+
       leaf authentication-type-fails {
         type uint32;
         description
           "Number of authentication type mismatches.";
       }
+
       leaf authentication-fails {
         type uint32;
         description
           "Number of authentication key failures.";
       }
-      description "IS-IS interface event counters.";
     }
-    description
-      "Grouping for IS-IS interface event counters";
   }
 
   grouping interface-state {
     description
       "IS-IS interface operational state.";
     uses adjacency-state;
+
     uses event-counters;
   }
 
@@ -814,75 +834,75 @@ module frr-isisd {
             "MTU of an LSP.";
         }
 
-        container refresh-interval {
+        container timers {
           description
-            "";
-          leaf level-1 {
-            type uint16;
-            units "seconds";
-            default "900";
+            "LSP-related timers";
+          container level-1 {
             description
-              "LSP refresh interval for level-1.";
-          }
-
-          leaf level-2 {
-            type uint16;
-            units "seconds";
-            default "900";
-            description
-              "LSP refresh interval for level-2.";
-          }
-        }
-
-        container maximum-lifetime {
-          description
-            "Maximum LSP lifetime.";
-          leaf level-1 {
-            type uint16 {
-              range "350..65535";
+              "Level-1 LSP-related timers";
+            leaf refresh-interval {
+              type uint16;
+              units "seconds";
+              default "900";
+              description
+                "LSP refresh interval for level-1.";
             }
-            units "seconds";
-            must ". >= ../../refresh-interval/level-1 + 300";
-            default "1200";
-            description
-              "Maximum LSP lifetime for level-1.";
+
+            leaf maximum-lifetime {
+              type uint16 {
+                range "350..65535";
+              }
+              units "seconds";
+              must ". >= ../refresh-interval + 300";
+              default "1200";
+              description
+                "Maximum LSP lifetime for level-1.";
+            }
+
+            leaf generation-interval {
+              type uint16 {
+                range "1..120";
+              }
+              units "seconds";
+              must ". < ../refresh-interval";
+              default "30";
+              description
+                "Minimum time allowed before level-1 LSP retransmissions.";
+            }
           }
 
-          leaf level-2 {
-            type uint16 {
-              range "350..65535";
-            }
-            units "seconds";
-            must ". >= ../../refresh-interval/level-2 + 300";
-            default "1200";
+          container level-2 {
             description
-              "Maximum LSP lifetime for level-2.";
-          }
-        }
+              "Level-2 LSP-related timers";
+            leaf refresh-interval {
+              type uint16;
+              units "seconds";
+              default "900";
+              description
+                "LSP refresh interval for level-2.";
+            }
 
-        container generation-interval {
-          description
-            "Minimum LSP regeneration interval.";
-          leaf level-1 {
-            type uint16 {
-              range "1..120";
+            leaf maximum-lifetime {
+              type uint16 {
+                range "350..65535";
+              }
+              units "seconds";
+              must ". >= ../refresh-interval + 300";
+              default "1200";
+              description
+                "Maximum LSP lifetime for level-2.";
             }
-            units "seconds";
-            must ". < ../../refresh-interval/level-1";
-            default "30";
-            description
-              "Minimum time allowed before level-1 LSP retransmissions.";
-          }
 
-          leaf level-2 {
-            type uint16 {
-              range "1..120";
+            leaf generation-interval {
+              type uint16 {
+                range "1..120";
+              }
+              units "seconds";
+              must ". < ../refresh-interval";
+              default "30";
+              description
+                "Minimum time allowed before level-2 LSP retransmissions.";
             }
-            units "seconds";
-            must ". < ../../refresh-interval/level-2";
-            default "30";
-            description
-              "Minimum time allowed before level-2 LSP retransmissions.";
           }
         }
       }
@@ -1152,6 +1172,7 @@ module frr-isisd {
       description
         "IS-IS interface parameters.";
       uses interface-config;
+
       uses interface-state;
     }
   }


### PR DESCRIPTION
Yang constraints enforced by the northbound callbacks require that the LSP maximum lifetime be >= than (refresh interval + 300). When we are moving from one config to another through frr-reload.py, we issue a number of vtysh -c commands (`no lsp-refresh-interval level-1 500`, `no max-lsp-lifetime level-1 1000`), which reset these parameters to their default values, respectively 900 and 1200. Depending on the actual values in the current config, the order in which these commands are sent might be the wrong one, in that we hit an invalid intermediate state and make vtysh (and by extension frr-reload.py) return an error.

As a workaround, let's add a one-liner command that sets all these inter-related parameters in one go, and make isisd display them as a single line too, so that the diff will be computed as a single command. The old individual commands are kept to ensure backwards compatibility.

I also just noticed that yanglint added a couple of formatting "fixes" to the isisd yang model that do not strictly belong to the patch. If this is a problem let me know and I can remove those or place them in a separate commit.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>