### PR TITLE
yang, lib: increase xpath len and add weight in nexthop operational model

### DIFF
--- a/lib/yang.h
+++ b/lib/yang.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 /* Maximum XPath length. */
-#define XPATH_MAXLEN 256
+#define XPATH_MAXLEN 512
 
 /* Maximum list key length. */
 #define LIST_MAXKEYS 8

--- a/yang/frr-nexthop.yang
+++ b/yang/frr-nexthop.yang
@@ -16,7 +16,7 @@ module frr-nexthop {
   }
 
   import frr-vrf {
-    prefix "frr-vrf";
+    prefix frr-vrf;
   }
 
   organization
@@ -33,13 +33,12 @@ module frr-nexthop {
   }
 
   typedef optional-ip-address {
-     type union {
-       type inet:ip-address;
-       type string {
-         pattern
-           '';
-       }
-     }
+    type union {
+      type inet:ip-address;
+      type string {
+        pattern '';
+      }
+    }
   }
 
   /*
@@ -148,10 +147,11 @@ module frr-nexthop {
       when "../nh-type = 'ip4-ifindex' or
             ../nh-type = 'ip6-ifindex'";
       type boolean;
-      default false;
+      default "false";
       description
         "Nexthop is directly connected.";
     }
+
     uses rt-types:mpls-label-stack {
       description
         "Nexthop's MPLS label stack.";
@@ -163,28 +163,38 @@ module frr-nexthop {
    */
   grouping frr-nexthop-operational {
     leaf duplicate {
-      config false;
       type empty;
+      config false;
       description
         "Duplicate nexthop";
     }
+
     leaf recursive {
-      config false;
       type empty;
+      config false;
       description
         "Nexthop resolved through another gateway.";
     }
+
     leaf active {
-      config false;
       type empty;
+      config false;
       description
         "Nexthop is active.";
     }
+
     leaf fib {
-      config false;
       type empty;
+      config false;
       description
         "Nexthop is installed in fib.";
+    }
+
+    leaf weight {
+      type uint8;
+      config false;
+      description
+        "Weight to be used by the nexthop for purposes of ECMP";
     }
   }
 
@@ -199,7 +209,6 @@ module frr-nexthop {
         key "nh-type gateway interface";
         description
           "A list of nexthop objects.";
-
         uses frr-nexthop-attributes;
       }
     }
@@ -228,12 +237,18 @@ module frr-nexthop {
   container frr-nexthop-group {
     description
       "A nexthop-group, represented as a list of nexthop objects.";
-
     uses frr-nexthop-grouping;
   }
 
+  typedef nexthop-group-ref {
+    type leafref {
+      require-instance false;
+      path "/frr-nexthop:frr-nexthop-group/frr-nexthop:nexthop-group/frr-nexthop:name";
+    }
+  }
+
   /*
-   * Agument weight attributes to nexthop group.
+   * Augment weight attributes to nexthop group.
    */
   augment "/frr-nexthop-group/nexthop-group/frr-nexthops/nexthop" {
     leaf weight {

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -638,6 +638,12 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/weight",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem,
+			}
+		},
+		{
 			.xpath = NULL,
 		},
 	}

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -451,5 +451,8 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
 	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
+	const char *xpath, const void *list_entry);
 
 #endif

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -623,3 +623,15 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_el
 	/* TODO: implement me. */
 	return NULL;
 }
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/weight
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}


### PR DESCRIPTION


    lib: increase xpath maxlen
    Certain xpath are well 256 characters, increasing
    to 512.

    yang: add weight in nexthop operational model
        add weight field to operational model.
        add leafref to nexthop group.
        format according to yanglint.

    Signed-off-by: Chirag Shah chirag@cumulusnetworks.com
