### PR TITLE
*: RIB operational northbound callbacks implementation

### DIFF
--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -630,6 +630,7 @@ module frr-zebra {
              description
                 "The route's prefix.";
           }
+
           list route-entry {
             key "protocol";
             leaf protocol {
@@ -2045,10 +2046,12 @@ module frr-zebra {
   augment "/frr-vrf:lib/frr-vrf:vrf" {
     description
       "Extends VRF model with Zebra-related parameters.";
-    uses ribs;
+    container zebra {
+      uses ribs;
+    }
   }
 
-  augment "/frr-vrf:lib/frr-vrf:vrf/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop" {
+  augment "/frr-vrf:lib/frr-vrf:vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop" {
     uses frr-nh:frr-nexthop-operational;
   }
 

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -251,11 +251,21 @@ DECLARE_LIST(re_list, struct route_entry, next);
 	     (re) && ((next) = re_list_next(&((dest)->routes), (re)), 1);      \
 	     (re) = (next))
 
+#define RE_DEST_FIRST_ROUTE(dest, re)                                          \
+	((re) = (dest) ? re_list_first(&((dest)->routes)) : NULL)
+
+#define RE_DEST_NEXT_ROUTE(dest, re)                                           \
+	((re) = (dest) ? re_list_next(&((dest)->routes), (re)) : NULL)
+
 #define RNODE_FOREACH_RE(rn, re)                                               \
 	RE_DEST_FOREACH_ROUTE (rib_dest_from_rnode(rn), re)
 
 #define RNODE_FOREACH_RE_SAFE(rn, re, next)                                    \
 	RE_DEST_FOREACH_ROUTE_SAFE (rib_dest_from_rnode(rn), re, next)
+
+#define RNODE_FIRST_RE(rn, re) RE_DEST_FIRST_ROUTE(rib_dest_from_rnode(rn), re)
+
+#define RNODE_NEXT_RE(rn, re) RE_DEST_NEXT_ROUTE(rib_dest_from_rnode(rn), re)
 
 #if defined(HAVE_RTADV)
 /* Structure which hold status of router advertisement. */

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -420,221 +420,221 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib",
 			.cbs = {
-				.create = lib_vrf_ribs_rib_create,
-				.destroy = lib_vrf_ribs_rib_destroy,
-				.get_next = lib_vrf_ribs_rib_get_next,
-				.get_keys = lib_vrf_ribs_rib_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_lookup_entry,
+				.create = lib_vrf_zebra_ribs_rib_create,
+				.destroy = lib_vrf_zebra_ribs_rib_destroy,
+				.get_next = lib_vrf_zebra_ribs_rib_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_lookup_entry,
+				.get_next = lib_vrf_zebra_ribs_rib_route_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_route_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_route_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/prefix",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/prefix",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_prefix_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_prefix_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_route_entry_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_route_entry_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_lookup_entry,
+				.get_next = lib_vrf_zebra_ribs_rib_route_route_entry_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_route_route_entry_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_route_route_entry_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/protocol",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/protocol",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_protocol_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_protocol_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/instance",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/instance",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_instance_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_instance_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/distance",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/distance",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_distance_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_distance_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/metric",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/metric",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_metric_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_metric_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/tag",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/tag",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_tag_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_tag_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/selected",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/selected",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_selected_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_selected_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/installed",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/installed",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_installed_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_installed_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/failed",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/failed",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_failed_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_failed_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/queued",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/queued",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_queued_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_queued_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/internal-flags",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/internal-flags",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_internal_flags_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_internal_flags_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/internal-status",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/internal-status",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_internal_status_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_internal_status_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/uptime",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/uptime",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_uptime_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_uptime_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_nexthop_group_lookup_entry,
+				.get_next = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/name",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/name",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_name_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_name_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry,
+				.get_next = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/nh-type",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/nh-type",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/vrf",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/vrf",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/gateway",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/gateway",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/interface",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/interface",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/bh-type",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/bh-type",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/onlink",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/onlink",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry,
+				.get_next = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/id",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/id",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/label",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/label",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/ttl",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/ttl",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/duplicate",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/duplicate",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/recursive",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/recursive",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/active",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/active",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/fib",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/fib",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem,
 			}
 		},
 		{

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -680,9 +680,9 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/weight",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/weight",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem,
 			}
 		},
 		{

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -408,7 +408,7 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
 	const char *xpath, const void *list_entry);
 
 #endif

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -284,202 +284,128 @@ lib_interface_zebra_state_remote_vtep_get_elem(const char *xpath,
 struct yang_data *
 lib_interface_zebra_state_mcast_group_get_elem(const char *xpath,
 					       const void *list_entry);
-int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
-			    union nb_resource *resource);
-int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode);
-const void *lib_vrf_ribs_rib_get_next(const void *parent_list_entry,
-				      const void *list_entry);
-int lib_vrf_ribs_rib_get_keys(const void *list_entry,
-			      struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_lookup_entry(const void *parent_list_entry,
-					  const struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_route_get_next(const void *parent_list_entry,
+int lib_vrf_zebra_ribs_rib_create(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource);
+int lib_vrf_zebra_ribs_rib_destroy(enum nb_event event,
+				   const struct lyd_node *dnode);
+const void *lib_vrf_zebra_ribs_rib_get_next(const void *parent_list_entry,
 					    const void *list_entry);
-int lib_vrf_ribs_rib_route_get_keys(const void *list_entry,
+int lib_vrf_zebra_ribs_rib_get_keys(const void *list_entry,
 				    struct yang_list_keys *keys);
 const void *
-lib_vrf_ribs_rib_route_lookup_entry(const void *parent_list_entry,
+lib_vrf_zebra_ribs_rib_lookup_entry(const void *parent_list_entry,
 				    const struct yang_list_keys *keys);
-struct yang_data *
-lib_vrf_ribs_rib_route_prefix_get_elem(const char *xpath,
-				       const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_protocol_get_elem(const char *xpath,
-					 const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_protocol_v6_get_elem(const char *xpath,
-					    const void *list_entry);
-struct yang_data *lib_vrf_ribs_rib_route_vrf_get_elem(const char *xpath,
-						      const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_distance_get_elem(const char *xpath,
-					 const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_metric_get_elem(const char *xpath,
-				       const void *list_entry);
-struct yang_data *lib_vrf_ribs_rib_route_tag_get_elem(const char *xpath,
-						      const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_selected_get_elem(const char *xpath,
-					 const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_installed_get_elem(const char *xpath,
-					  const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_failed_get_elem(const char *xpath,
-				       const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_queued_get_elem(const char *xpath,
-				       const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_internal_flags_get_elem(const char *xpath,
-					       const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_internal_status_get_elem(const char *xpath,
-						const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_uptime_get_elem(const char *xpath,
-				       const void *list_entry);
+const void *lib_vrf_zebra_ribs_rib_route_get_next(const void *parent_list_entry,
+						  const void *list_entry);
+int lib_vrf_zebra_ribs_rib_route_get_keys(const void *list_entry,
+					  struct yang_list_keys *keys);
 const void *
-lib_vrf_ribs_rib_route_nexthop_group_get_next(const void *parent_list_entry,
-					      const void *list_entry);
-int lib_vrf_ribs_rib_route_nexthop_group_get_keys(const void *list_entry,
-						  struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_route_nexthop_group_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys);
-struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_name_get_elem(const char *xpath,
-						   const void *list_entry);
-const void *lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next(
-	const void *parent_list_entry, const void *list_entry);
-int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys(
-	const void *list_entry, struct yang_list_keys *keys);
-int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
-			    union nb_resource *resource);
-int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode);
-const void *lib_vrf_ribs_rib_get_next(const void *parent_list_entry,
-				      const void *list_entry);
-int lib_vrf_ribs_rib_get_keys(const void *list_entry,
-			      struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_lookup_entry(const void *parent_list_entry,
+lib_vrf_zebra_ribs_rib_route_lookup_entry(const void *parent_list_entry,
 					  const struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_route_get_next(const void *parent_list_entry,
-					    const void *list_entry);
-int lib_vrf_ribs_rib_route_get_keys(const void *list_entry,
-				    struct yang_list_keys *keys);
-const void *
-lib_vrf_ribs_rib_route_lookup_entry(const void *parent_list_entry,
-				    const struct yang_list_keys *keys);
 struct yang_data *
-lib_vrf_ribs_rib_route_prefix_get_elem(const char *xpath,
-				       const void *list_entry);
+lib_vrf_zebra_ribs_rib_route_prefix_get_elem(const char *xpath,
+					     const void *list_entry);
 const void *
-lib_vrf_ribs_rib_route_route_entry_get_next(const void *parent_list_entry,
-					    const void *list_entry);
-int lib_vrf_ribs_rib_route_route_entry_get_keys(const void *list_entry,
-						struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_route_route_entry_lookup_entry(
+lib_vrf_zebra_ribs_rib_route_route_entry_get_next(const void *parent_list_entry,
+						  const void *list_entry);
+int lib_vrf_zebra_ribs_rib_route_route_entry_get_keys(
+	const void *list_entry, struct yang_list_keys *keys);
+const void *lib_vrf_zebra_ribs_rib_route_route_entry_lookup_entry(
 	const void *parent_list_entry, const struct yang_list_keys *keys);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_protocol_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_instance_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_distance_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_metric_get_elem(
+	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_protocol_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_instance_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_distance_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_metric_get_elem(const char *xpath,
-						   const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_tag_get_elem(const char *xpath,
-						const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_selected_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_installed_get_elem(const char *xpath,
+lib_vrf_zebra_ribs_rib_route_route_entry_tag_get_elem(const char *xpath,
 						      const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_failed_get_elem(const char *xpath,
-						   const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_queued_get_elem(const char *xpath,
-						   const void *list_entry);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_flags_get_elem(
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_selected_get_elem(
 	const char *xpath, const void *list_entry);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_status_get_elem(
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_installed_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_failed_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_queued_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_uptime_get_elem(const char *xpath,
-						   const void *list_entry);
-const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_next(
+lib_vrf_zebra_ribs_rib_route_route_entry_internal_flags_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_route_entry_internal_status_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_uptime_get_elem(
+	const char *xpath, const void *list_entry);
+const void *lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_get_next(
 	const void *parent_list_entry, const void *list_entry);
-int lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_keys(
+int lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_get_keys(
 	const void *list_entry, struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_lookup_entry(
+const void *lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_lookup_entry(
 	const void *parent_list_entry, const struct yang_list_keys *keys);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_name_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_name_get_elem(
 	const char *xpath, const void *list_entry);
 const void *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next(
 	const void *parent_list_entry, const void *list_entry);
-int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys(
+int lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys(
 	const void *list_entry, struct yang_list_keys *keys);
 const void *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry(
 	const void *parent_list_entry, const struct yang_list_keys *keys);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
 	const char *xpath, const void *list_entry);
 const void *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
 	const void *parent_list_entry, const void *list_entry);
-int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
+int lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
 	const void *list_entry, struct yang_list_keys *keys);
 const void *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
 	const void *parent_list_entry, const struct yang_list_keys *keys);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1324,10 +1324,11 @@ int lib_interface_zebra_bandwidth_destroy(enum nb_event event,
 }
 
 /*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib
  */
-int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
-			    union nb_resource *resource)
+int lib_vrf_zebra_ribs_rib_create(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource)
 {
 	// uint32_t table_id;
 	const char *vrf_name;
@@ -1369,7 +1370,8 @@ int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
 	return NB_OK;
 }
 
-int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode)
+int lib_vrf_zebra_ribs_rib_destroy(enum nb_event event,
+				   const struct lyd_node *dnode)
 {
 	if (event != NB_EV_APPLY)
 		return NB_OK;

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -30,6 +30,7 @@
 #include "zebra/interface.h"
 #include "zebra/connected.h"
 #include "zebra/zebra_router.h"
+#include "zebra/debug.h"
 
 /*
  * XPath: /frr-zebra:zebra/mcast-rpf-lookup
@@ -1021,7 +1022,8 @@ int lib_interface_zebra_ip_addrs_create(enum nb_event event,
 	char buf[PREFIX_STRLEN] = {0};
 
 	ifp = nb_running_get_entry(dnode, NULL, true);
-	// addr_family = yang_dnode_get_enum(dnode, "./address-family");
+	/* TODO: wrapper for identityref */
+	/* addr_family = yang_dnode_get_enum(dnode, "./address-family"); */
 	yang_dnode_get_prefix(&prefix, dnode, "./ip-prefix");
 	apply_mask(&prefix);
 
@@ -1330,7 +1332,6 @@ int lib_vrf_zebra_ribs_rib_create(enum nb_event event,
 				  const struct lyd_node *dnode,
 				  union nb_resource *resource)
 {
-	// uint32_t table_id;
 	struct vrf *vrf;
 	afi_t afi = AFI_IP;
 	safi_t safi = SAFI_UNICAST;
@@ -1340,19 +1341,19 @@ int lib_vrf_zebra_ribs_rib_create(enum nb_event event,
 	vrf = nb_running_get_entry(dnode, NULL, false);
 	zvrf = vrf_info_lookup(vrf->vrf_id);
 
-	// TODO: parse afi-safi-name and table_id
-	// table_id = yang_dnode_get_uint32(dnode, "./table-id");
-	zlog_debug("%s: vrf %s", __PRETTY_FUNCTION__, vrf->name);
+	/* TODO: parse afi-safi-name and table_id
+	   uint32_t table_id;
+	   table_id = yang_dnode_get_uint32(dnode, "./table-id");
+    */
 
 	zrt = zebra_router_find_zrt(zvrf, zvrf->table_id, afi, safi);
-	// table = zebra_vrf_lookup_table_with_table_id(afi, safi, vrf->vrf_id,
-	// zvrf->table_id);
 
 	switch (event) {
 	case NB_EV_VALIDATE:
 		if (!zrt) {
-			zlog_debug("%s: vrf %s table is not found.",
-				   __PRETTY_FUNCTION__, vrf->name);
+			if (IS_ZEBRA_DEBUG_EVENT)
+				zlog_debug("%s: vrf %s table is not found.",
+					   __PRETTY_FUNCTION__, vrf->name);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -1379,7 +1380,9 @@ int lib_vrf_zebra_ribs_rib_destroy(enum nb_event event,
 
 	zrt = nb_running_unset_entry(dnode);
 	if (!zrt) {
-		zlog_debug("%s: zrt is not found", __func__);
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s: zrt is not found", __func__);
+
 		return NB_ERR_INCONSISTENCY;
 	}
 

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1331,17 +1331,16 @@ int lib_vrf_zebra_ribs_rib_create(enum nb_event event,
 				  union nb_resource *resource)
 {
 	// uint32_t table_id;
-	const char *vrf_name;
 	struct vrf *vrf;
 	afi_t afi = AFI_IP;
 	safi_t safi = SAFI_UNICAST;
 	struct zebra_vrf *zvrf;
 	struct zebra_router_table *zrt;
 
-	vrf_name = nb_running_get_entry(dnode, NULL, false);
-	vrf = vrf_lookup_by_name(vrf_name);
+	vrf = nb_running_get_entry(dnode, NULL, false);
 	zvrf = vrf_info_lookup(vrf->vrf_id);
 
+	// TODO: parse afi-safi-name and table_id
 	// table_id = yang_dnode_get_uint32(dnode, "./table-id");
 	zlog_debug("%s: vrf %s", __PRETTY_FUNCTION__, vrf->name);
 
@@ -1379,8 +1378,10 @@ int lib_vrf_zebra_ribs_rib_destroy(enum nb_event event,
 	struct zebra_router_table *zrt;
 
 	zrt = nb_running_unset_entry(dnode);
-	if (!zrt)
+	if (!zrt) {
+		zlog_debug("%s: zrt is not found", __func__);
 		return NB_ERR_INCONSISTENCY;
+	}
 
 	return NB_OK;
 }

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -23,6 +23,20 @@
 #include "zebra_nb.h"
 #include "zebra/interface.h"
 #include "zebra/zebra_router.h"
+#include "zebra/debug.h"
+
+static void zebra_extract_afi_safi_key(char *key, int len, afi_t afi,
+				       safi_t safi, const char *mname)
+{
+	if (afi == AFI_IP && safi == SAFI_UNICAST)
+		snprintf(key, len, "%s:%s", mname, "ipv4-unicast");
+	if (afi == AFI_IP6 && safi == SAFI_UNICAST)
+		snprintf(key, len, "%s:%s", mname, "ipv6-unicast");
+	if (afi == AFI_IP && safi == SAFI_MULTICAST)
+		snprintf(key, len, "%s:%s", "frr-zebra", "ipv4-multicast");
+	if (afi == AFI_IP6 && safi == SAFI_MULTICAST)
+		snprintf(key, len, "%s:%s", "frr-zebra", "ipv6-multicast");
+}
 
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/up-count
@@ -173,18 +187,20 @@ const void *lib_vrf_zebra_ribs_rib_get_next(const void *parent_list_entry,
 		afi = AFI_IP;
 		safi = SAFI_UNICAST;
 
-		zlog_debug("%s: vrf %s entry is null", __func__, vrf->name);
+		/* Start from AFI_IP and SAFI_UNICAST */
 		zrt = zebra_router_find_zrt(zvrf, zvrf->table_id, afi, safi);
 		if (zrt == NULL)
 			return NULL;
 	} else {
-		zlog_debug("%s: vrf %s table %u ", __func__, vrf->name,
-			   zrt->tableid);
 		zrt = RB_NEXT(zebra_router_table_head, zrt);
 		/* vrf_id/ns_id do not match, only walk for the given VRF */
 		while (zrt && zrt->ns_id != zvrf->zns->ns_id)
 			zrt = RB_NEXT(zebra_router_table_head, zrt);
 	}
+
+	if (IS_ZEBRA_DEBUG_EVENT && zrt)
+		zlog_debug("%s: vrf %s afi %s safi %s", __func__, vrf->name,
+			   afi2str(zrt->afi), safi2str(zrt->safi));
 
 	return zrt;
 }
@@ -193,31 +209,19 @@ int lib_vrf_zebra_ribs_rib_get_keys(const void *list_entry,
 				    struct yang_list_keys *keys)
 {
 	const struct zebra_router_table *zrt = list_entry;
-	// struct vrf *vrf;
 
 	assert(zrt);
 
 	keys->num = 2;
+	zebra_extract_afi_safi_key(keys->key[0], sizeof(keys->key[0]), zrt->afi,
+				   zrt->safi, "frr-zebra");
 
-	snprintf(keys->key[0], sizeof(keys->key[0]), "%s",
-		 "frr-zebra:ipv4-unicast");
-	/* TODO: implement key[0], afi-safi identityref */
 	snprintf(keys->key[1], sizeof(keys->key[1]), "%" PRIu32, zrt->tableid);
-#if 0
-	if (!vrf_is_backend_netns()) {
-		zlog_debug("vrf backed netns ns_id %u", zrt->ns_id);
-		return NB_ERR_INCONSISTENCY;
-	}
-	vrf = vrf_lookup_by_id((vrf_id_t)zrt->ns_id);
 
-	if (!vrf) {
-		zlog_debug("vrf is not found for ns_id %u", zrt->ns_id);
-		return NB_ERR_INCONSISTENCY;
-	}
-#endif
-	zlog_debug("%s: key %s ", __func__, keys->key[1]);
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("%s: key[0] %s key[1] %s", __func__, keys->key[0],
+			   keys->key[1]);
 
-	/* TODO: implement me. */
 	return NB_OK;
 }
 
@@ -226,14 +230,11 @@ lib_vrf_zebra_ribs_rib_lookup_entry(const void *parent_list_entry,
 				    const struct yang_list_keys *keys)
 {
 	struct vrf *vrf = (struct vrf *)parent_list_entry;
-	// uint32_t tableid = strtoul(keys->key[1], NULL, 10);
 	struct zebra_vrf *zvrf;
 	afi_t afi = AFI_IP;
 	safi_t safi = SAFI_UNICAST;
 
 	zvrf = zebra_vrf_lookup_by_id(vrf->vrf_id);
-
-	zlog_debug("%s: ", __func__);
 
 	return zebra_router_find_zrt(zvrf, zvrf->table_id, afi, safi);
 }
@@ -247,19 +248,10 @@ const void *lib_vrf_zebra_ribs_rib_route_get_next(const void *parent_list_entry,
 	const struct zebra_router_table *zrt = parent_list_entry;
 	const struct route_node *rn = list_entry;
 
-	char buf[PREFIX_STRLEN];
-	if (list_entry == NULL) {
+	if (list_entry == NULL)
 		rn = route_top(zrt->table);
-		zlog_debug("%s: prefix %s list_entry is null", __func__,
-			   prefix2str(&rn->p, buf, sizeof(buf)));
-	} else {
+	else
 		rn = srcdest_route_next((struct route_node *)rn);
-		if (rn) {
-			zlog_debug("%s: prefix %s rn %p ", __func__,
-				   prefix2str(&rn->p, buf, sizeof(buf)),
-				   (void *)rn);
-		}
-	}
 
 	return rn;
 }
@@ -275,8 +267,6 @@ int lib_vrf_zebra_ribs_rib_route_get_keys(const void *list_entry,
 
 	strlcpy(keys->key[0], dst_buf, sizeof(keys->key[0]));
 
-	zlog_debug("%s: key %s rn %p", __func__, keys->key[0], (void *)rn);
-
 	return NB_OK;
 }
 
@@ -287,20 +277,20 @@ lib_vrf_zebra_ribs_rib_route_lookup_entry(const void *parent_list_entry,
 	const struct zebra_router_table *zrt = parent_list_entry;
 	struct prefix p;
 	struct route_node *rn;
-	char dst_buf[PREFIX_STRLEN] = {'\0'};
 
 	yang_str2prefix(keys->key[0], &p);
-	zlog_debug("%s: key %s", __func__, keys->key[0]);
-	rn = route_node_lookup(zrt->table, &p);
 
+	rn = route_node_match(zrt->table, &p);
 	if (!rn) {
-		char buf[PREFIX_STRLEN];
-		zlog_debug("prefix %s is not present in route table",
-			   prefix2str(&p, buf, sizeof(buf)));
-	}
+		if (IS_ZEBRA_DEBUG_EVENT) {
+			char buf[PREFIX_STRLEN];
 
-	zlog_debug("%s: rn->p %s ", __func__,
-		   prefix2str(&rn->p, dst_buf, sizeof(dst_buf)));
+			zlog_debug("prefix %s is not present in route table",
+				   prefix2str(&p, buf, sizeof(buf)));
+		}
+		return NULL;
+	}
+	route_unlock_node(rn);
 
 	return rn;
 }
@@ -314,7 +304,6 @@ lib_vrf_zebra_ribs_rib_route_prefix_get_elem(const char *xpath,
 {
 	const struct route_node *rn = list_entry;
 
-	zlog_debug("%s: ", __func__);
 	return yang_data_new_prefix(xpath, &rn->p);
 }
 
@@ -325,7 +314,23 @@ const void *
 lib_vrf_zebra_ribs_rib_route_route_entry_get_next(const void *parent_list_entry,
 						  const void *list_entry)
 {
-	struct route_entry *re = NULL;
+	struct route_entry *re = (struct route_entry *)list_entry;
+	struct route_node *rn = (struct route_node *)parent_list_entry;
+
+	if (list_entry == NULL) {
+		RNODE_FIRST_RE(rn, re);
+		if (re)
+			zlog_debug(
+				"%s: list_entry is null. route_entry is found.",
+				__func__);
+	} else {
+		RNODE_NEXT_RE(rn, re);
+		if (re) {
+			if (IS_ZEBRA_DEBUG_EVENT)
+				zlog_debug("%s: next route_entry is found.",
+					   __func__);
+		}
+	}
 
 	return re;
 }
@@ -333,14 +338,55 @@ lib_vrf_zebra_ribs_rib_route_route_entry_get_next(const void *parent_list_entry,
 int lib_vrf_zebra_ribs_rib_route_route_entry_get_keys(
 	const void *list_entry, struct yang_list_keys *keys)
 {
-	/* TODO: implement me. */
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	keys->num = 1;
+
+	strlcpy(keys->key[0], zebra_route_string(re->type),
+		sizeof(keys->key[0]));
+
 	return NB_OK;
 }
 
 const void *lib_vrf_zebra_ribs_rib_route_route_entry_lookup_entry(
 	const void *parent_list_entry, const struct yang_list_keys *keys)
 {
-	/* TODO: implement me. */
+	struct route_node *rn = (struct route_node *)parent_list_entry;
+	struct route_entry *re = NULL;
+	int type = 0;
+	char *ptype = (char *)keys->key[0];
+
+	if (strncmp(ptype, "kernel", 10) == 0)
+		type = 1;
+	else if (strncmp(ptype, "connected", 10) == 0)
+		type = 2;
+	else if (strncmp(ptype, "static", 10) == 0)
+		type = 3;
+	else if (strncmp(ptype, "rip", 10) == 0)
+		type = 4;
+	else if (strncmp(ptype, "ripng", 10) == 0)
+		type = 5;
+	else if (strncmp(ptype, "ospf", 10) == 0)
+		type = 6;
+	else if (strncmp(ptype, "ospf6", 10) == 0)
+		type = 7;
+	else if (strncmp(ptype, "isis", 10) == 0)
+		type = 8;
+	else if (strncmp(ptype, "bgp", 10) == 0)
+		type = 9;
+	else if (strncmp(ptype, "table", 10) == 0)
+		type = 15;
+	else if (strncmp(ptype, "sharp", 10) == 0)
+		type = 23;
+
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("%s: type %u", __func__, type);
+
+	RNODE_FOREACH_RE (rn, re) {
+		if (type == re->type)
+			return re;
+	}
+
 	return NULL;
 }
 
@@ -350,8 +396,9 @@ const void *lib_vrf_zebra_ribs_rib_route_route_entry_lookup_entry(
 struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_protocol_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	return yang_data_new_enum(xpath, re->type);
 }
 
 /*
@@ -360,7 +407,11 @@ struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_protocol_get_elem(
 struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_instance_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	if (re->instance)
+		return yang_data_new_uint16(xpath, re->instance);
+
 	return NULL;
 }
 
@@ -370,8 +421,9 @@ struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_instance_get_elem(
 struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_distance_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	return yang_data_new_uint8(xpath, re->distance);
 }
 
 /*
@@ -381,8 +433,9 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_metric_get_elem(const char *xpath,
 							 const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	return yang_data_new_uint32(xpath, re->metric);
 }
 
 /*
@@ -392,7 +445,11 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_tag_get_elem(const char *xpath,
 						      const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	if (re->tag)
+		return yang_data_new_uint32(xpath, re->tag);
+
 	return NULL;
 }
 
@@ -402,7 +459,11 @@ lib_vrf_zebra_ribs_rib_route_route_entry_tag_get_elem(const char *xpath,
 struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_selected_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	if (CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED))
+		return yang_data_new_empty(xpath);
+
 	return NULL;
 }
 
@@ -412,7 +473,11 @@ struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_selected_get_elem(
 struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_installed_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	if (CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED))
+		return yang_data_new_empty(xpath);
+
 	return NULL;
 }
 
@@ -423,7 +488,11 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_failed_get_elem(const char *xpath,
 							 const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	if (CHECK_FLAG(re->status, ROUTE_ENTRY_FAILED))
+		return yang_data_new_empty(xpath);
+
 	return NULL;
 }
 
@@ -434,7 +503,11 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_queued_get_elem(const char *xpath,
 							 const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	if (CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED))
+		return yang_data_new_empty(xpath);
+
 	return NULL;
 }
 
@@ -446,7 +519,11 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_internal_flags_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	if (re->flags)
+		return yang_data_new_int32(xpath, re->flags);
+
 	return NULL;
 }
 
@@ -458,7 +535,11 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_internal_status_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct route_entry *re = (struct route_entry *)list_entry;
+
+	if (re->status)
+		return yang_data_new_int32(xpath, re->status);
+
 	return NULL;
 }
 
@@ -480,14 +561,24 @@ lib_vrf_zebra_ribs_rib_route_route_entry_uptime_get_elem(const char *xpath,
 const void *lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_get_next(
 	const void *parent_list_entry, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct route_entry *re = (struct route_entry *)parent_list_entry;
+	struct nhg_hash_entry *nhe = (struct nhg_hash_entry *)list_entry;
+
+	if (list_entry == NULL) {
+		nhe = re->nhe;
+		return nhe;
+	}
 	return NULL;
 }
 
 int lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_get_keys(
 	const void *list_entry, struct yang_list_keys *keys)
 {
-	/* TODO: implement me. */
+	struct nhg_hash_entry *nhe = (struct nhg_hash_entry *)list_entry;
+
+	keys->num = 1;
+	snprintf(keys->key[0], sizeof(keys->key[0]), "%" PRIu32, nhe->id);
+
 	return NB_OK;
 }
 
@@ -506,7 +597,14 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_name_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct nhg_hash_entry *nhe = (struct nhg_hash_entry *)list_entry;
+
+	if (nhe) {
+		char name[20] = {'\0'};
+
+		snprintf(name, sizeof(name), "%" PRIu32, nhe->id);
+		return yang_data_new_string(xpath, name);
+	}
 	return NULL;
 }
 
@@ -518,14 +616,79 @@ const void *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next(
 	const void *parent_list_entry, const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+	struct nhg_hash_entry *nhe = (struct nhg_hash_entry *)parent_list_entry;
+
+	if (list_entry == NULL)
+		nexthop = (nhe->nhg.nexthop);
+	else
+		nexthop = nexthop_next(nexthop);
+
+	return nexthop;
 }
 
 int lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys(
 	const void *list_entry, struct yang_list_keys *keys)
 {
-	/* TODO: implement me. */
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+	char buf[PREFIX2STR_BUFFER];
+
+	keys->num = 3;
+
+	strlcpy(keys->key[0], yang_nexthop_type2str(nexthop->type),
+		sizeof(keys->key[0]));
+
+	switch (nexthop->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		inet_ntop(AF_INET, &nexthop->gate.ipv4, buf, sizeof(buf));
+		strlcpy(keys->key[1], buf, sizeof(keys->key[1]));
+
+		if (nexthop->ifindex)
+			strlcpy(keys->key[2],
+				ifindex2ifname(nexthop->ifindex,
+					       nexthop->vrf_id),
+				sizeof(keys->key[2]));
+		else
+			/* no ifindex */
+			strlcpy(keys->key[2], " ", sizeof(keys->key[2]));
+
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf, sizeof(buf));
+		strlcpy(keys->key[1], buf, sizeof(keys->key[1]));
+
+		if (nexthop->ifindex)
+			strlcpy(keys->key[2],
+				ifindex2ifname(nexthop->ifindex,
+					       nexthop->vrf_id),
+				sizeof(keys->key[2]));
+		else
+			/* no ifindex */
+			strlcpy(keys->key[2], " ", sizeof(keys->key[2]));
+
+		break;
+	case NEXTHOP_TYPE_IFINDEX:
+		strlcpy(keys->key[1], "", sizeof(keys->key[1]));
+		strlcpy(keys->key[2],
+			ifindex2ifname(nexthop->ifindex, nexthop->vrf_id),
+			sizeof(keys->key[2]));
+
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+		/* Gateway IP */
+		strlcpy(keys->key[1], "", sizeof(keys->key[1]));
+		strlcpy(keys->key[2], "", sizeof(keys->key[2]));
+		break;
+	default:
+		break;
+	}
+
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("%s: key1 %s key2 %s  key3 %s", __func__,
+			   keys->key[0], keys->key[1], keys->key[2]);
+
 	return NB_OK;
 }
 
@@ -545,7 +708,28 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+
+	switch (nexthop->type) {
+	case NEXTHOP_TYPE_IFINDEX:
+		return yang_data_new_string(xpath, "ifindex");
+		break;
+	case NEXTHOP_TYPE_IPV4:
+		return yang_data_new_string(xpath, "ip4");
+		break;
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		return yang_data_new_string(xpath, "ip4-ifindex");
+		break;
+	case NEXTHOP_TYPE_IPV6:
+		return yang_data_new_string(xpath, "ip6");
+		break;
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		return yang_data_new_string(xpath, "ip6-ifindex");
+		break;
+	default:
+		break;
+	}
+
 	return NULL;
 }
 
@@ -557,8 +741,9 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+
+	return yang_data_new_string(xpath, vrf_id_to_name(nexthop->vrf_id));
 }
 
 /*
@@ -569,8 +754,38 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+	struct ipaddr addr;
+
+	switch (nexthop->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		addr.ipa_type = IPADDR_V4;
+		memcpy(&addr.ipaddr_v4, &(nexthop->gate.ipv4),
+		       sizeof(struct in_addr));
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		addr.ipa_type = IPADDR_V6;
+		memcpy(&addr.ipaddr_v6, &(nexthop->gate.ipv6),
+		       sizeof(struct in6_addr));
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+	case NEXTHOP_TYPE_IFINDEX:
+		/* No addr here */
+		return yang_data_new_string(xpath, "");
+		break;
+	default:
+		break;
+	}
+
+	if (IS_ZEBRA_DEBUG_EVENT) {
+		char buf2[INET6_ADDRSTRLEN];
+
+		zlog_debug("%s: ipaddr %s ", __func__,
+			   ipaddr2str(&addr, buf2, sizeof(buf2)));
+	}
+	return yang_data_new_ip(xpath, &addr);
 }
 
 /*
@@ -581,7 +796,17 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+
+	if (nexthop->ifindex) {
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s: ifindex %s", __func__,
+				   ifindex2ifname(nexthop->ifindex,
+						  nexthop->vrf_id));
+		yang_data_new_string(xpath, ifindex2ifname(nexthop->ifindex,
+							   nexthop->vrf_id));
+	}
+
 	return NULL;
 }
 
@@ -593,8 +818,30 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+
+	if (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)
+		return NULL;
+
+	char type_str[PREFIX2STR_BUFFER] = {'\0'};
+	switch (nexthop->bh_type) {
+	case BLACKHOLE_NULL:
+		strlcpy(type_str, "null", 12);
+		break;
+	case BLACKHOLE_REJECT:
+		strlcpy(type_str, "reject", 12);
+		break;
+	case BLACKHOLE_ADMINPROHIB:
+		strlcpy(type_str, "prohibited", 12);
+		break;
+	case BLACKHOLE_UNSPEC:
+		strlcpy(type_str, "unspec", 12);
+		break;
+	}
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("%s: type %s ", __func__, type_str);
+
+	return yang_data_new_string(xpath, type_str);
 }
 
 /*
@@ -605,7 +852,11 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK))
+		return yang_data_new_bool(xpath, true);
+
 	return NULL;
 }
 
@@ -692,7 +943,11 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
+		return yang_data_new_empty(xpath);
+
 	return NULL;
 }
 
@@ -704,7 +959,11 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
+		return yang_data_new_empty(xpath);
+
 	return NULL;
 }
 
@@ -716,7 +975,11 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
+		return yang_data_new_empty(xpath);
+
 	return NULL;
 }
 
@@ -728,18 +991,26 @@ struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB))
+		return yang_data_new_empty(xpath);
+
 	return NULL;
 }
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/weight
+ * /frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/weight
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
 	const char *xpath, const void *list_entry)
 {
-	/* TODO: implement me. */
+	struct nexthop *nexthop = (struct nexthop *)list_entry;
+
+	if (nexthop->weight)
+		return yang_data_new_uint8(xpath, nexthop->weight);
+
 	return NULL;
 }

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -317,19 +317,14 @@ lib_vrf_zebra_ribs_rib_route_route_entry_get_next(const void *parent_list_entry,
 	struct route_entry *re = (struct route_entry *)list_entry;
 	struct route_node *rn = (struct route_node *)parent_list_entry;
 
-	if (list_entry == NULL) {
+	if (list_entry == NULL)
 		RNODE_FIRST_RE(rn, re);
-		if (re)
-			zlog_debug(
-				"%s: list_entry is null. route_entry is found.",
-				__func__);
-	} else {
+	else
 		RNODE_NEXT_RE(rn, re);
-		if (re) {
-			if (IS_ZEBRA_DEBUG_EVENT)
-				zlog_debug("%s: next route_entry is found.",
-					   __func__);
-		}
+
+	if (re) {
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s: next route_entry is found.", __func__);
 	}
 
 	return re;
@@ -713,19 +708,14 @@ lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_t
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IFINDEX:
 		return yang_data_new_string(xpath, "ifindex");
-		break;
 	case NEXTHOP_TYPE_IPV4:
 		return yang_data_new_string(xpath, "ip4");
-		break;
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 		return yang_data_new_string(xpath, "ip4-ifindex");
-		break;
 	case NEXTHOP_TYPE_IPV6:
 		return yang_data_new_string(xpath, "ip6");
-		break;
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
 		return yang_data_new_string(xpath, "ip6-ifindex");
-		break;
 	default:
 		break;
 	}
@@ -774,7 +764,6 @@ lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gate
 	case NEXTHOP_TYPE_IFINDEX:
 		/* No addr here */
 		return yang_data_new_string(xpath, "");
-		break;
 	default:
 		break;
 	}
@@ -819,11 +808,11 @@ lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_t
 	const char *xpath, const void *list_entry)
 {
 	struct nexthop *nexthop = (struct nexthop *)list_entry;
+	char type_str[PREFIX2STR_BUFFER] = {'\0'};
 
 	if (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)
 		return NULL;
 
-	char type_str[PREFIX2STR_BUFFER] = {'\0'};
 	switch (nexthop->bh_type) {
 	case BLACKHOLE_NULL:
 		strlcpy(type_str, "null", 12);
@@ -838,6 +827,7 @@ lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_t
 		strlcpy(type_str, "unspec", 12);
 		break;
 	}
+
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("%s: type %s ", __func__, type_str);
 

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -66,6 +66,22 @@ zebra_router_table_entry_compare(const struct zebra_router_table *e1,
 	return (e1->safi - e2->safi);
 }
 
+struct zebra_router_table *zebra_router_find_zrt(struct zebra_vrf *zvrf,
+						 uint32_t tableid, afi_t afi,
+						 safi_t safi)
+{
+	struct zebra_router_table finder;
+	struct zebra_router_table *zrt;
+
+	memset(&finder, 0, sizeof(finder));
+	finder.afi = afi;
+	finder.safi = safi;
+	finder.tableid = tableid;
+	finder.ns_id = zvrf->zns->ns_id;
+	zrt = RB_FIND(zebra_router_table_head, &zrouter.tables, &finder);
+
+	return zrt;
+}
 
 struct route_table *zebra_router_find_table(struct zebra_vrf *zvrf,
 					    uint32_t tableid, afi_t afi,

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -186,6 +186,9 @@ extern void zebra_router_init(void);
 extern void zebra_router_cleanup(void);
 extern void zebra_router_terminate(void);
 
+extern struct zebra_router_table *zebra_router_find_zrt(struct zebra_vrf *zvrf,
+							uint32_t tableid,
+							afi_t afi, safi_t safi);
 extern struct route_table *zebra_router_find_table(struct zebra_vrf *zvrf,
 						   uint32_t tableid, afi_t afi,
 						   safi_t safi);


### PR DESCRIPTION
The set of changes contain the RIB operational model northbound callbacks implementation. 

- Added zebra container to rib model and respective changes in northbound conversion callbacks. 
- Add macros to extract `first` and ``next` route_entry from a given route node. 
- zebra northbound callbacks implementation

Commits:
zebra: zebra rib nexthop northbound
zebra: route node first next node
zebra: add zebra container to rib model
zebra: northbound changes for the rib model

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>