### PR TITLE
zebra: minor fix to label manager log

### DIFF
--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -446,6 +446,15 @@ int lm_client_connect_response(uint8_t proto, uint16_t instance,
 int lm_get_chunk_response(struct label_manager_chunk *lmc, uint8_t proto,
 			  uint16_t instance, vrf_id_t vrf_id)
 {
+	if (!lmc)
+		flog_err(EC_ZEBRA_LM_CANNOT_ASSIGN_CHUNK,
+			 "Unable to assign Label Chunk to %s instance %u",
+			 zebra_route_string(proto), instance);
+	else if (IS_ZEBRA_DEBUG_PACKET)
+		zlog_debug("Assigned Label Chunk %u - %u to %s instance %u",
+			   lmc->start, lmc->end, zebra_route_string(proto),
+			   instance);
+
 	struct zserv *client = zserv_find_client(proto, instance);
 	if (!client) {
 		zlog_err("%s: could not find client for daemon %s instance %u",

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2225,17 +2225,6 @@ static void zread_get_label_chunk(struct zserv *client, struct stream *msg,
 	/* call hook to get a chunk using wrapper */
 	lm_get_chunk_call(&lmc, proto, instance, keep, size, base, vrf_id);
 
-	if (!lmc)
-		flog_err(
-			EC_ZEBRA_LM_CANNOT_ASSIGN_CHUNK,
-			"Unable to assign Label Chunk of size %u to %s instance %u",
-			size, zebra_route_string(proto), instance);
-	else
-		if (IS_ZEBRA_DEBUG_PACKET)
-			zlog_debug("Assigned Label Chunk %u - %u to %s instance %u",
-				   lmc->start, lmc->end,
-				   zebra_route_string(proto), instance);
-
 stream_failure:
 	return;
 }


### PR DESCRIPTION
zebra should only check whether a get_chunk operation succeeded
when processing the response, rather than insde the get_chunk
call itself. Spllitting the request and response hooks was done
precisely to allow for asynchronous calls to an external label
manager; in this case, the requested chunk is not necessarily
going to be available at request time.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>