### PR TITLE
bgpd: Fixes for memory leaks.

### DIFF
--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -46,6 +46,8 @@ void lcommunity_free(struct lcommunity **lcom)
 {
 	XFREE(MTYPE_LCOMMUNITY_VAL, (*lcom)->val);
 	XFREE(MTYPE_LCOMMUNITY_STR, (*lcom)->str);
+	if ((*lcom)->json)
+		json_object_free((*lcom)->json);
 	XFREE(MTYPE_LCOMMUNITY, *lcom);
 }
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11594,8 +11594,8 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 	struct bgp_table *table;
 	struct bgp_adj_in *ain;
 	struct bgp_adj_out *adj;
-	unsigned long output_count;
-	unsigned long filtered_count;
+	unsigned long output_count = 0;
+	unsigned long filtered_count = 0;
 	struct bgp_node *rn;
 	int header1 = 1;
 	struct bgp *bgp;
@@ -11885,6 +11885,12 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 
 		vty_out(vty, "%s\n", json_object_to_json_string_ext(
 					     json, JSON_C_TO_STRING_PRETTY));
+
+		if (!output_count && !filtered_count) {
+			json_object_free(json_scode);
+			json_object_free(json_ocode);
+		}
+
 		json_object_free(json);
 	} else if (output_count > 0) {
 		if (filtered_count > 0)


### PR DESCRIPTION
This commit addresses the following memory leaks when certain BGP JSON
show commands are executed:

==4473== 6,720 (720 direct, 6,000 indirect) bytes in 10 blocks are definitely lost in loss record 27 of 27
==4473==    at 0x4C2FFAC: calloc (vg_replace_malloc.c:762)
==4473==    by 0x54161F1: ??? (in /lib/x86_64-linux-gnu/libjson-c.so.2.0.0)
==4473==    by 0x541666A: json_object_new_object (in /lib/x86_64-linux-gnu/libjson-c.so.2.0.0)
==4473==    by 0x1B1CDE: bgp_show_neighbor_graceful_restart (bgp_vty.c:11812)
==4473==    by 0x1B1F1E: bgp_show_neighbor_graceful_restart_vty (bgp_vty.c:12003)
==4473==    by 0x1B21D1: bgp_show_neighbor_graceful_restart_afi_all (bgp_vty.c:12370)
==4473==    by 0x1B21D1: show_ip_bgp_neighbors_gracrful_restart (bgp_vty.c:12187)
==4473==    by 0x4E63322: cmd_execute_command_real.isra.2 (command.c:1060)
==4473==    by 0x4E65599: cmd_execute_command (command.c:1119)
==4473==    by 0x4E65716: cmd_execute (command.c:1273)
==4473==    by 0x4EAEFA2: vty_command (vty.c:533)
==4473==    by 0x4EAF235: vty_execute (vty.c:1304)
==4473==    by 0x4EB1B23: vtysh_read (vty.c:2147)

==5902== 7,640 (360 direct, 7,280 indirect) bytes in 5 blocks are definitely lost in loss record 81 of 81
==5902==    at 0x4C2FFAC: calloc (vg_replace_malloc.c:762)
==5902==    by 0x54161F1: ??? (in /lib/x86_64-linux-gnu/libjson-c.so.2.0.0)
==5902==    by 0x541666A: json_object_new_object (in /lib/x86_64-linux-gnu/libjson-c.so.2.0.0)
==5902==    by 0x161524: set_lcommunity_string (bgp_lcommunity.c:197)
==5902==    by 0x161CC7: lcommunity_str (bgp_lcommunity.c:301)
==5902==    by 0x18A4B0: route_vty_out_detail (bgp_route.c:8935)
==5902==    by 0x18CE49: bgp_show_path_info.isra.53 (bgp_route.c:9892)
==5902==    by 0x18D286: bgp_show_route_in_table (bgp_route.c:10024)
==5902==    by 0x18D286: bgp_show_route (bgp_route.c:10069)
==5902==    by 0x18D889: show_ip_bgp_route (bgp_route.c:10511)
==5902==    by 0x4E63292: cmd_execute_command_real.isra.2 (command.c:1060)
==5902==    by 0x4E65509: cmd_execute_command (command.c:1119)
==5902==    by 0x4E65686: cmd_execute (command.c:1273)



Signed-off-by: NaveenThanikachalam <nthanikachal@vmware.com>