### PR TITLE
zebra, lib: new zebra TED module

### DIFF
--- a/lib/stream.c
+++ b/lib/stream.c
@@ -120,34 +120,34 @@ void stream_free(struct stream *s)
 	XFREE(MTYPE_STREAM, s);
 }
 
-struct stream *stream_copy(struct stream *new, struct stream *src)
+struct stream *stream_copy(struct stream *dest, const struct stream *src)
 {
 	STREAM_VERIFY_SANE(src);
 
-	assert(new != NULL);
-	assert(STREAM_SIZE(new) >= src->endp);
+	assert(dest != NULL);
+	assert(STREAM_SIZE(dest) >= src->endp);
 
-	new->endp = src->endp;
-	new->getp = src->getp;
+	dest->endp = src->endp;
+	dest->getp = src->getp;
 
-	memcpy(new->data, src->data, src->endp);
+	memcpy(dest->data, src->data, src->endp);
 
-	return new;
+	return dest;
 }
 
-struct stream *stream_dup(struct stream *s)
+struct stream *stream_dup(const struct stream *s)
 {
-	struct stream *new;
+	struct stream *snew;
 
 	STREAM_VERIFY_SANE(s);
 
-	if ((new = stream_new(s->endp)) == NULL)
+	if ((snew = stream_new(s->endp)) == NULL)
 		return NULL;
 
-	return (stream_copy(new, s));
+	return (stream_copy(snew, s));
 }
 
-struct stream *stream_dupcat(struct stream *s1, struct stream *s2,
+struct stream *stream_dupcat(const struct stream *s1, const struct stream *s2,
 			     size_t offset)
 {
 	struct stream *new;
@@ -187,19 +187,19 @@ size_t stream_resize_inplace(struct stream **sptr, size_t newsize)
 	return orig->size;
 }
 
-size_t stream_get_getp(struct stream *s)
+size_t stream_get_getp(const struct stream *s)
 {
 	STREAM_VERIFY_SANE(s);
 	return s->getp;
 }
 
-size_t stream_get_endp(struct stream *s)
+size_t stream_get_endp(const struct stream *s)
 {
 	STREAM_VERIFY_SANE(s);
 	return s->endp;
 }
 
-size_t stream_get_size(struct stream *s)
+size_t stream_get_size(const struct stream *s)
 {
 	STREAM_VERIFY_SANE(s);
 	return s->size;
@@ -1107,9 +1107,15 @@ struct stream_fifo *stream_fifo_new(void)
 {
 	struct stream_fifo *new;
 
-	new = XCALLOC(MTYPE_STREAM_FIFO, sizeof(struct stream_fifo));
-	pthread_mutex_init(&new->mtx, NULL);
+	new = XMALLOC(MTYPE_STREAM_FIFO, sizeof(struct stream_fifo));
+	stream_fifo_init(new);
 	return new;
+}
+
+void stream_fifo_init(struct stream_fifo *fifo)
+{
+	memset(fifo, 0, sizeof(struct stream_fifo));
+	pthread_mutex_init(&fifo->mtx, NULL);
 }
 
 /* Add new stream to fifo. */
@@ -1219,9 +1225,14 @@ size_t stream_fifo_count_safe(struct stream_fifo *fifo)
 	return atomic_load_explicit(&fifo->count, memory_order_acquire);
 }
 
-void stream_fifo_free(struct stream_fifo *fifo)
+void stream_fifo_deinit(struct stream_fifo *fifo)
 {
 	stream_fifo_clean(fifo);
 	pthread_mutex_destroy(&fifo->mtx);
+}
+
+void stream_fifo_free(struct stream_fifo *fifo)
+{
+	stream_fifo_deinit(fifo);
 	XFREE(MTYPE_STREAM_FIFO, fifo);
 }

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -150,23 +150,25 @@ struct stream_fifo {
  */
 extern struct stream *stream_new(size_t);
 extern void stream_free(struct stream *);
-extern struct stream *stream_copy(struct stream *, struct stream *src);
-extern struct stream *stream_dup(struct stream *);
+/* Copy 'src' into 'dest', returns 'dest' */
+extern struct stream *stream_copy(struct stream *dest,
+				  const struct stream *src);
+extern struct stream *stream_dup(const struct stream *s);
 
 extern size_t stream_resize_inplace(struct stream **sptr, size_t newsize);
 
-extern size_t stream_get_getp(struct stream *);
-extern size_t stream_get_endp(struct stream *);
-extern size_t stream_get_size(struct stream *);
-extern uint8_t *stream_get_data(struct stream *);
+extern size_t stream_get_getp(const struct stream *s);
+extern size_t stream_get_endp(const struct stream *s);
+extern size_t stream_get_size(const struct stream *s);
+extern uint8_t *stream_get_data(struct stream *s);
 
 /**
  * Create a new stream structure; copy offset bytes from s1 to the new
  * stream; copy s2 data to the new stream; copy rest of s1 data to the
  * new stream.
  */
-extern struct stream *stream_dupcat(struct stream *s1, struct stream *s2,
-				    size_t offset);
+extern struct stream *stream_dupcat(const struct stream *s1,
+				    const struct stream *s2, size_t offset);
 
 extern void stream_set_getp(struct stream *, size_t);
 extern void stream_set_endp(struct stream *, size_t);
@@ -277,6 +279,18 @@ extern uint8_t *stream_pnt(struct stream *);
  *    newly created stream_fifo
  */
 extern struct stream_fifo *stream_fifo_new(void);
+
+/*
+ * Init or re-init an on-stack fifo. This allows use of a fifo struct without
+ * requiring a malloc/free cycle.
+ * Note well that the fifo must be de-inited with the 'fifo_deinit' api.
+ */
+void stream_fifo_init(struct stream_fifo *fifo);
+
+/*
+ * Deinit an on-stack fifo.
+ */
+void stream_fifo_deinit(struct stream_fifo *fifo);
 
 /*
  * Push a stream onto a stream_fifo.

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -196,7 +196,8 @@ typedef enum {
 	ZEBRA_MLAG_CLIENT_UNREGISTER,
 	ZEBRA_MLAG_FORWARD_MSG,
 	ZEBRA_ERROR,
-	ZEBRA_CLIENT_CAPABILITIES
+	ZEBRA_CLIENT_CAPABILITIES,
+	ZEBRA_OPAQUE_MESSAGE,
 } zebra_message_types_t;
 
 enum zebra_error_types {
@@ -332,6 +333,7 @@ struct zclient {
 	int (*mlag_process_down)(void);
 	int (*mlag_handle_msg)(struct stream *msg, int len);
 	int (*handle_error)(enum zebra_error_types error);
+	int (*opaque_msg_handler)(ZAPI_CALLBACK_ARGS);
 };
 
 /* Zebra API message flag. */
@@ -816,6 +818,10 @@ extern void zclient_send_mlag_deregister(struct zclient *client);
 
 extern void zclient_send_mlag_data(struct zclient *client,
 				   struct stream *client_s);
+
+/* Send an OPAQUE message, contents ... opaque. */
+int zclient_send_opaque(struct zclient *zclient, const uint8_t *data,
+			size_t datasize);
 
 /* Send the hello message.
  * Returns 0 for success or -1 on an I/O error.

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -10,14 +10,15 @@ vtysh_scan += \
 	$(top_srcdir)/zebra/interface.c \
 	$(top_srcdir)/zebra/router-id.c \
 	$(top_srcdir)/zebra/rtadv.c \
+	$(top_srcdir)/zebra/zebra_gr.c \
 	$(top_srcdir)/zebra/zebra_mlag_vty.c \
 	$(top_srcdir)/zebra/zebra_mpls_vty.c \
 	$(top_srcdir)/zebra/zebra_ptm.c \
 	$(top_srcdir)/zebra/zebra_pw.c \
 	$(top_srcdir)/zebra/zebra_routemap.c \
+	$(top_srcdir)/zebra/zebra_ted.c \
 	$(top_srcdir)/zebra/zebra_vty.c \
 	$(top_srcdir)/zebra/zserv.c \
-	$(top_srcdir)/zebra/zebra_gr.c \
 	# end
 
 # can be loaded as DSO - always include for vtysh
@@ -72,18 +73,24 @@ zebra_zebra_SOURCES = \
 	zebra/rtread_sysctl.c \
 	zebra/rule_netlink.c \
 	zebra/rule_socket.c \
+	zebra/table_manager.c \
+	zebra/zapi_msg.c \
+	zebra/zebra_dplane.c \
+	zebra/zebra_errors.c \
+	zebra/zebra_gr.c \
+	zebra/zebra_l2.c \
 	zebra/zebra_mlag.c \
 	zebra/zebra_mlag_vty.c \
-	zebra/zebra_l2.c \
 	zebra/zebra_northbound.c \
 	zebra/zebra_memory.c \
-	zebra/zebra_dplane.c \
 	zebra/zebra_mpls.c \
 	zebra/zebra_mpls_netlink.c \
 	zebra/zebra_mpls_openbsd.c \
 	zebra/zebra_mpls_null.c \
 	zebra/zebra_mpls_vty.c \
 	zebra/zebra_mroute.c \
+	zebra/zebra_netns_id.c \
+	zebra/zebra_netns_notify.c \
 	zebra/zebra_nhg.c \
 	zebra/zebra_ns.c \
 	zebra/zebra_pbr.c \
@@ -94,16 +101,11 @@ zebra_zebra_SOURCES = \
 	zebra/zebra_router.c \
 	zebra/zebra_rnh.c \
 	zebra/zebra_routemap.c \
+	zebra/zebra_ted.c \
 	zebra/zebra_vrf.c \
 	zebra/zebra_vty.c \
 	zebra/zebra_vxlan.c \
 	zebra/zserv.c \
-	zebra/zebra_netns_id.c \
-	zebra/zebra_netns_notify.c \
-	zebra/table_manager.c \
-	zebra/zapi_msg.c \
-	zebra/zebra_errors.c \
-	zebra/zebra_gr.c \
 	# end
 
 zebra/debug_clippy.c: $(CLIPPY_DEPS)
@@ -139,14 +141,19 @@ noinst_HEADERS += \
 	zebra/rt_netlink.h \
 	zebra/rtadv.h \
 	zebra/rule_netlink.h \
-	zebra/zebra_mlag.h \
-	zebra/zebra_mlag_vty.h \
+	zebra/table_manager.h \
+	zebra/zapi_msg.h \
+	zebra/zebra_dplane.h \
+	zebra/zebra_errors.h \
 	zebra/zebra_fpm_private.h \
 	zebra/zebra_l2.h \
-	zebra/zebra_dplane.h \
 	zebra/zebra_memory.h \
+	zebra/zebra_mlag.h \
+	zebra/zebra_mlag_vty.h \
 	zebra/zebra_mpls.h \
 	zebra/zebra_mroute.h \
+	zebra/zebra_netns_id.h \
+	zebra/zebra_netns_notify.h \
 	zebra/zebra_nhg.h \
 	zebra/zebra_nhg_private.h \
 	zebra/zebra_ns.h \
@@ -157,15 +164,11 @@ noinst_HEADERS += \
 	zebra/zebra_rnh.h \
 	zebra/zebra_routemap.h \
 	zebra/zebra_router.h \
+	zebra/zebra_ted.h \
 	zebra/zebra_vrf.h \
 	zebra/zebra_vxlan.h \
 	zebra/zebra_vxlan_private.h \
 	zebra/zserv.h \
-	zebra/zebra_netns_id.h \
-	zebra/zebra_netns_notify.h \
-	zebra/table_manager.h \
-	zebra/zapi_msg.h \
-	zebra/zebra_errors.h \
 	# end
 
 zebra_zebra_irdp_la_SOURCES = \

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -24,23 +24,16 @@
 #include <libgen.h>
 
 #include "lib/prefix.h"
-#include "lib/command.h"
-#include "lib/if.h"
-#include "lib/thread.h"
 #include "lib/stream.h"
 #include "lib/memory.h"
 #include "lib/table.h"
 #include "lib/network.h"
-#include "lib/sockunion.h"
 #include "lib/log.h"
 #include "lib/zclient.h"
 #include "lib/privs.h"
-#include "lib/network.h"
-#include "lib/buffer.h"
 #include "lib/nexthop.h"
 #include "lib/vrf.h"
 #include "lib/libfrr.h"
-#include "lib/sockopt.h"
 #include "lib/lib_errors.h"
 
 #include "zebra/zebra_router.h"
@@ -52,7 +45,6 @@
 #include "zebra/redistribute.h"
 #include "zebra/debug.h"
 #include "zebra/zebra_rnh.h"
-#include "zebra/rt_netlink.h"
 #include "zebra/interface.h"
 #include "zebra/zebra_ptm.h"
 #include "zebra/rtadv.h"
@@ -66,6 +58,7 @@
 #include "zebra/zebra_errors.h"
 #include "zebra/zebra_mlag.h"
 #include "zebra/connected.h"
+#include "zebra/zebra_ted.h"
 
 /* Encoding helpers -------------------------------------------------------- */
 
@@ -2892,38 +2885,78 @@ static void zserv_write_incoming(struct stream *orig, uint16_t command)
 }
 #endif
 
-void zserv_handle_commands(struct zserv *client, struct stream *msg)
+/*
+ * Process a batch of zapi messages.
+ */
+void zserv_handle_commands(struct zserv *client, struct stream_fifo *fifo)
 {
 	struct zmsghdr hdr;
 	struct zebra_vrf *zvrf;
+	struct stream *msg;
+	struct stream_fifo temp_fifo;
 
-	if (STREAM_READABLE(msg) > ZEBRA_MAX_PACKET_SIZ) {
+	stream_fifo_init(&temp_fifo);
+
+	while (stream_fifo_head(fifo)) {
+		msg = stream_fifo_pop(fifo);
+
+		if (STREAM_READABLE(msg) > ZEBRA_MAX_PACKET_SIZ) {
+			if (IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV)
+				zlog_debug(
+					"ZAPI message is %zu bytes long but the maximum packet size is %u; dropping",
+					STREAM_READABLE(msg),
+					ZEBRA_MAX_PACKET_SIZ);
+			goto continue_loop;
+		}
+
+		zapi_parse_header(msg, &hdr);
+
 		if (IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV)
-			zlog_debug(
-				"ZAPI message is %zu bytes long but the maximum packet size is %u; dropping",
-				STREAM_READABLE(msg), ZEBRA_MAX_PACKET_SIZ);
-		return;
-	}
-
-	zapi_parse_header(msg, &hdr);
-
-	if (IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV)
-		zserv_log_message(NULL, msg, &hdr);
+			zserv_log_message(NULL, msg, &hdr);
 
 #if defined(HANDLE_ZAPI_FUZZING)
-	zserv_write_incoming(msg, hdr.command);
+		zserv_write_incoming(msg, hdr.command);
 #endif
 
-	hdr.length -= ZEBRA_HEADER_SIZE;
+		hdr.length -= ZEBRA_HEADER_SIZE;
 
-	/* lookup vrf */
-	zvrf = zebra_vrf_lookup_by_id(hdr.vrf_id);
-	if (!zvrf)
-		return zserv_error_no_vrf(client, &hdr, msg, zvrf);
+		/* Before checking for a handler function, check for
+		 * special messages that are handled in another module;
+		 * we'll treat these as opaque.
+		 */
+		if (zebra_ted_handle_msgid(hdr.command)) {
+			/* Reset message buffer */
+			stream_set_getp(msg, 0);
 
-	if (hdr.command >= array_size(zserv_handlers)
-	    || zserv_handlers[hdr.command] == NULL)
-		return zserv_error_invalid_msg_type(client, &hdr, msg, zvrf);
+			stream_fifo_push(&temp_fifo, msg);
 
-	zserv_handlers[hdr.command](client, &hdr, msg, zvrf);
+			/* Continue without freeing the message */
+			msg = NULL;
+			goto continue_loop;
+		}
+
+		/* lookup vrf */
+		zvrf = zebra_vrf_lookup_by_id(hdr.vrf_id);
+		if (!zvrf) {
+			zserv_error_no_vrf(client, &hdr, msg, zvrf);
+			goto continue_loop;
+		}
+
+		if (hdr.command >= array_size(zserv_handlers)
+		    || zserv_handlers[hdr.command] == NULL) {
+			zserv_error_invalid_msg_type(client, &hdr, msg, zvrf);
+			goto continue_loop;
+		}
+
+		zserv_handlers[hdr.command](client, &hdr, msg, zvrf);
+
+continue_loop:
+		stream_free(msg);
+	}
+
+	/* Dispatch any special messages from the temp fifo */
+	if (stream_fifo_head(&temp_fifo) != NULL)
+		zebra_ted_enqueue_batch(&temp_fifo);
+
+	stream_fifo_deinit(&temp_fifo);
 }

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -42,10 +42,11 @@ extern "C" {
  * client
  *    the client datastructure
  *
- * msg
- *    the message
+ * fifo
+ *    a batch of messages
  */
-extern void zserv_handle_commands(struct zserv *client, struct stream *msg);
+extern void zserv_handle_commands(struct zserv *client,
+				  struct stream_fifo *fifo);
 
 extern int zsend_vrf_add(struct zserv *zclient, struct zebra_vrf *zvrf);
 extern int zsend_vrf_delete(struct zserv *zclient, struct zebra_vrf *zvrf);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -28,7 +28,6 @@
 #include "lib/memory.h"
 #include "lib/queue.h"
 #include "lib/zebra.h"
-#include "zebra/zebra_router.h"
 #include "zebra/zebra_memory.h"
 #include "zebra/zebra_router.h"
 #include "zebra/zebra_dplane.h"

--- a/zebra/zebra_ted.c
+++ b/zebra/zebra_ted.c
@@ -1,0 +1,270 @@
+/*
+ * Zebra TE data module
+ * Copyright (c) 2020 Volta Networks, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+
+#include <zebra.h>
+#include "lib/debug.h"
+#include "lib/frr_pthread.h"
+#include "lib/stream.h"
+#include "zebra/debug.h"
+#include "zebra/zserv.h"
+#include "zebra/zebra_ted.h"
+
+/*
+ * Globals
+ */
+static struct zebra_ted_globals {
+
+	/* Sentinel for run or start of shutdown */
+	_Atomic uint32_t run;
+
+	/* Limit number of pending, unprocessed updates */
+	_Atomic uint32_t max_queued_updates;
+
+	/* Limit number of new messages dequeued at once, to pace an
+	 * incoming burst.
+	 */
+	uint32_t msgs_per_cycle;
+
+	/* Stats: counters of incoming messages, errors, and yields (when
+	 * the limit has been reached.)
+	 */
+	_Atomic uint32_t msgs_in;
+	_Atomic uint32_t msg_errors;
+	_Atomic uint32_t yields;
+
+	/* pthread */
+	struct frr_pthread *pthread;
+
+	/* Event-delivery context 'master' for the module */
+	struct thread_master *master;
+
+	/* Event/'thread' pointer for queued zapi messages */
+	struct thread *t_msgs;
+
+	/* Input fifo queue to the module, and lock to protect it. */
+	pthread_mutex_t mutex;
+	struct stream_fifo in_fifo;
+
+} zt_info;
+
+/* Name string for debugs/logs */
+static const char *LOG_NAME = "Zebra TED";
+
+/* Prototypes */
+
+/* Main event loop, processing incoming message queue */
+static int process_messages(struct thread *event);
+
+/*
+ * Initialize the module at startup
+ */
+void zebra_ted_init(void)
+{
+	memset(&zt_info, 0, sizeof(zt_info));
+
+	pthread_mutex_init(&zt_info.mutex, NULL);
+	stream_fifo_init(&zt_info.in_fifo);
+
+	zt_info.msgs_per_cycle = ZEBRA_TED_MSG_LIMIT;
+}
+
+/*
+ * Start the module pthread. This step is run later than the
+ * 'init' step, in case zebra has fork-ed.
+ */
+void zebra_ted_start(void)
+{
+	struct frr_pthread_attr pattr = {
+		.start = frr_pthread_attr_default.start,
+		.stop = frr_pthread_attr_default.stop
+	};
+
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("%s module starting", LOG_NAME);
+
+	/* Start pthread */
+	zt_info.pthread = frr_pthread_new(&pattr, "Zebra TED thread",
+					  "zebra_TED");
+
+	/* Associate event 'master' */
+	zt_info.master = zt_info.pthread->master;
+
+	atomic_store_explicit(&zt_info.run, 1, memory_order_relaxed);
+
+	/* Enqueue an initial event for the pthread */
+	thread_add_event(zt_info.master, process_messages, NULL, 0,
+			 &zt_info.t_msgs);
+
+	/* And start the pthread */
+	frr_pthread_run(zt_info.pthread, NULL);
+}
+
+/*
+ * Module stop, halting the dedicated pthread; called from the main pthread.
+ */
+void zebra_ted_stop(void)
+{
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("%s module stop", LOG_NAME);
+
+	atomic_store_explicit(&zt_info.run, 0, memory_order_relaxed);
+
+	frr_pthread_stop(zt_info.pthread, NULL);
+
+	frr_pthread_destroy(zt_info.pthread);
+
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("%s module stop complete", LOG_NAME);
+}
+
+/*
+ * Module final cleanup, called from the zebra main pthread.
+ */
+void zebra_ted_finish(void)
+{
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("%s module shutdown", LOG_NAME);
+
+	pthread_mutex_destroy(&zt_info.mutex);
+	stream_fifo_deinit(&zt_info.in_fifo);
+}
+
+/*
+ * Does this module handle (intercept) the specified zapi message type?
+ */
+bool zebra_ted_handle_msgid(uint16_t id)
+{
+	bool ret = false;
+
+	switch (id) {
+	case ZEBRA_OPAQUE_MESSAGE:
+		ret = true;
+		break;
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+/*
+ * Enqueue a batch of messages for processing - this is the public api
+ * used from the zapi processing threads.
+ */
+uint32_t zebra_ted_enqueue_batch(struct stream_fifo *batch)
+{
+	uint32_t counter = 0;
+	struct stream *msg;
+
+	/* Dequeue messages from the incoming batch, and save them
+	 * on the module fifo.
+	 */
+	frr_with_mutex(&zt_info.mutex) {
+		msg = stream_fifo_pop(batch);
+		while (msg) {
+			stream_fifo_push(&zt_info.in_fifo, msg);
+			counter++;
+			msg = stream_fifo_pop(batch);
+		}
+	}
+
+	/* Schedule module pthread to process the batch */
+	if (counter > 0) {
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s: received %u messages",
+				   __func__, counter);
+		thread_add_event(zt_info.master, process_messages, NULL, 0,
+				 &zt_info.t_msgs);
+	}
+
+	return counter;
+}
+
+
+/*
+ * Pthread event loop, process the incoming message queue.
+ */
+static int process_messages(struct thread *event)
+{
+	struct stream_fifo fifo;
+	struct stream *msg;
+	uint32_t i;
+	bool need_resched = false;
+
+	stream_fifo_init(&fifo);
+
+	/* Check for zebra shutdown */
+	if (atomic_load_explicit(&zt_info.run, memory_order_relaxed) == 0)
+		goto done;
+
+	/* Dequeue some messages from the incoming queue, temporarily
+	 * save them on the local fifo
+	 */
+	frr_with_mutex(&zt_info.mutex) {
+
+		for (i = 0; i < zt_info.msgs_per_cycle; i++) {
+			msg = stream_fifo_pop(&zt_info.in_fifo);
+			if (msg == NULL)
+				break;
+
+			stream_fifo_push(&fifo, msg);
+		}
+
+		/* We may need to reschedule, if there are still
+		 * queued messages
+		 */
+		if (stream_fifo_head(&zt_info.in_fifo) != NULL)
+			need_resched = true;
+	}
+
+	/* Update stats */
+	atomic_fetch_add_explicit(&zt_info.msgs_in, i, memory_order_relaxed);
+
+	/* Check for zebra shutdown */
+	if (atomic_load_explicit(&zt_info.run, memory_order_relaxed) == 0) {
+		need_resched = false;
+		goto done;
+	}
+
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("%s: processing %u messages", __func__, i);
+
+	/* Process the messages on the local fifo */
+	/* TODO -- just discarding the messages for now */
+	msg = stream_fifo_pop(&fifo);
+	while (msg) {
+		stream_free(msg);
+		msg = stream_fifo_pop(&fifo);
+	}
+
+done:
+
+	if (need_resched) {
+		atomic_fetch_add_explicit(&zt_info.yields, 1,
+					  memory_order_relaxed);
+		thread_add_event(zt_info.master, process_messages, NULL, 0,
+				 &zt_info.t_msgs);
+	}
+
+	/* This will also free any leftover messages, in the shutdown case */
+	stream_fifo_deinit(&fifo);
+
+	return 0;
+}

--- a/zebra/zebra_ted.h
+++ b/zebra/zebra_ted.h
@@ -1,0 +1,61 @@
+/*
+ * Zebra TE data zapi message handler
+ * Copyright (c) 2020 Volta Networks, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _ZEBRA_TED_H
+#define _ZEBRA_TED_H 1
+
+/* Default for number of messages to dequeue per lock cycle */
+#define ZEBRA_TED_MSG_LIMIT 1000
+
+/*
+ * Initialize the module at startup
+ */
+void zebra_ted_init(void);
+
+/*
+ * Start the module pthread. This step is run later than the
+ * 'init' step, in case zebra has fork-ed.
+ */
+void zebra_ted_start(void);
+
+/*
+ * Does this module handle (intercept) the specified zapi message type?
+ */
+bool zebra_ted_handle_msgid(uint16_t id);
+
+/*
+ * Module stop, called from the main pthread. This is synchronous:
+ * once it returns, the pthread has stopped and exited.
+ */
+void zebra_ted_stop(void);
+
+/*
+ * Module cleanup, called from the zebra main pthread. When it returns,
+ * all module cleanup is complete.
+ */
+void zebra_ted_finish(void);
+
+/*
+ * Enqueue a batch of messages for processing. Returns the number dequeued
+ * from the batch fifo.
+ */
+uint32_t zebra_ted_enqueue_batch(struct stream_fifo *batch);
+
+
+#endif	/* _ZEBRA_TED_H */

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -71,6 +71,13 @@ extern struct zebra_privs_t zserv_privs;
 /* The listener socket for clients connecting to us */
 static int zsock;
 
+/* The lock that protects access to zapi client objects */
+static pthread_mutex_t client_mutex;
+
+static struct zserv *find_client_internal(uint8_t proto,
+					  unsigned short instance);
+
+
 /*
  * Client thread events.
  *
@@ -629,26 +636,47 @@ static void zserv_client_free(struct zserv *client)
 
 void zserv_close_client(struct zserv *client)
 {
-	/* synchronously stop and join pthread */
-	frr_pthread_stop(client->pthread, NULL);
+	bool free_p = true;
 
-	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("Closing client '%s'",
-			   zebra_route_string(client->proto));
+	if (client->pthread) {
+		/* synchronously stop and join pthread */
+		frr_pthread_stop(client->pthread, NULL);
 
-	thread_cancel_event(zrouter.master, client);
-	THREAD_OFF(client->t_cleanup);
-	THREAD_OFF(client->t_process);
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("Closing client '%s'",
+				   zebra_route_string(client->proto));
 
-	/* destroy pthread */
-	frr_pthread_destroy(client->pthread);
-	client->pthread = NULL;
+		thread_cancel_event(zrouter.master, client);
+		THREAD_OFF(client->t_cleanup);
+		THREAD_OFF(client->t_process);
 
-	/* remove from client list */
-	listnode_delete(zrouter.client_list, client);
+		/* destroy pthread */
+		frr_pthread_destroy(client->pthread);
+		client->pthread = NULL;
+	}
+
+	/*
+	 * Final check in case the client struct is in use in another
+	 * pthread: if not in-use, continue and free the client
+	 */
+	frr_with_mutex(&client_mutex) {
+		if (client->busy_count <= 0) {
+			/* remove from client list */
+			listnode_delete(zrouter.client_list, client);
+		} else {
+			/*
+			 * The client session object may be in use, although
+			 * the associated pthread is gone. Defer final
+			 * cleanup.
+			 */
+			client->is_closed = true;
+			free_p = false;
+		}
+	}
 
 	/* delete client */
-	zserv_client_free(client);
+	if (free_p)
+		zserv_client_free(client);
 }
 
 /*
@@ -708,7 +736,9 @@ static struct zserv *zserv_client_create(int sock)
 	client->ridinfo = vrf_bitmap_init();
 
 	/* Add this client to linked list. */
-	listnode_add(zrouter.client_list, client);
+	frr_with_mutex(&client_mutex) {
+		listnode_add(zrouter.client_list, client);
+	}
 
 	struct frr_pthread_attr zclient_pthr_attrs = {
 		.start = frr_pthread_attr_default.start,
@@ -728,6 +758,61 @@ static struct zserv *zserv_client_create(int sock)
 	frr_pthread_run(client->pthread, NULL);
 
 	return client;
+}
+
+/*
+ * Retrieve a client object by its protocol and instance number. This version
+ * supports use from a different pthread: the object will be returned marked
+ * in-use. The caller *must* release the client object with the
+ * release_client() api, to ensure that the in-use marker is cleared properly.
+ */
+struct zserv *zserv_acquire_client(uint8_t proto, unsigned short instance)
+{
+	struct zserv *client = NULL;
+
+	frr_with_mutex(&client_mutex) {
+		client = find_client_internal(proto, instance);
+		if (client) {
+			/* Don't return a dead/closed client object */
+			if (client->is_closed)
+				client = NULL;
+			else
+				client->busy_count++;
+		}
+	}
+
+	return client;
+}
+
+/*
+ * Release a client object that was acquired with the acquire_client() api.
+ * After this has been called, the caller must not use the client pointer -
+ * it may be freed if the client has closed.
+ */
+void zserv_release_client(struct zserv *client)
+{
+	bool cleanup_p = false;
+
+	frr_with_mutex(&client_mutex) {
+		client->busy_count--;
+
+		if (client->busy_count <= 0) {
+			/* No more users of the client object. If the client
+			 * session is closed, schedule cleanup
+			 * on the zebra main pthread.
+			 */
+			if (client->is_closed)
+				cleanup_p = true;
+		}
+	}
+
+	/* Cleanup must take place on the zebra main pthread, so we
+	 * schedule an event.
+	 */
+	if (cleanup_p)
+		thread_add_event(zrouter.master,
+				 zserv_handle_client_fail,
+				 client, 0, &client->t_cleanup);
 }
 
 /*
@@ -1070,17 +1155,37 @@ static void zebra_show_client_brief(struct vty *vty, struct zserv *client)
 		client->v6_route_del_cnt);
 }
 
-struct zserv *zserv_find_client(uint8_t proto, unsigned short instance)
+/*
+ * Common logic that searches the client list for a zapi client; this
+ * MUST be called holding the client list mutex.
+ */
+static struct zserv *find_client_internal(uint8_t proto,
+					  unsigned short instance)
 {
 	struct listnode *node, *nnode;
-	struct zserv *client;
+	struct zserv *client = NULL;
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		if (client->proto == proto && client->instance == instance)
-			return client;
+			break;
 	}
 
-	return NULL;
+	return client;
+}
+
+/*
+ * Public api that searches for a client session; this version is
+ * used from the zebra main pthread.
+ */
+struct zserv *zserv_find_client(uint8_t proto, unsigned short instance)
+{
+	struct zserv *client;
+
+	frr_with_mutex(&client_mutex) {
+		client = find_client_internal(proto, instance);
+	}
+
+	return client;
 }
 
 /* This command is for debugging purpose. */
@@ -1147,6 +1252,7 @@ void zserv_init(void)
 
 	/* Misc init. */
 	zsock = -1;
+	pthread_mutex_init(&client_mutex, NULL);
 
 	install_element(ENABLE_NODE, &show_zebra_client_cmd);
 	install_element(ENABLE_NODE, &show_zebra_client_summary_cmd);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -519,11 +519,9 @@ static int zserv_process_messages(struct thread *thread)
 			need_resched = true;
 	}
 
-	while (stream_fifo_head(cache)) {
-		msg = stream_fifo_pop(cache);
-		zserv_handle_commands(client, msg);
-		stream_free(msg);
-	}
+	/* Process the batch of messages */
+	if (stream_fifo_head(cache))
+		zserv_handle_commands(client, cache);
 
 	stream_fifo_free(cache);
 

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -96,6 +96,14 @@ struct zserv {
 	/* Client file descriptor. */
 	int sock;
 
+	/* Attributes used to permit access to zapi clients from
+	 * other pthreads: the client has a busy counter, and a
+	 * 'closed' flag. These attributes are managed using a
+	 * lock, via the acquire_client() and release_client() apis.
+	 */
+	int busy_count;
+	bool is_closed;
+
 	/* Input/output buffer to the client. */
 	pthread_mutex_t ibuf_mtx;
 	struct stream_fifo *ibuf_fifo;
@@ -116,7 +124,7 @@ struct zserv {
 	/* Event for message processing, for the main pthread */
 	struct thread *t_process;
 
-	/* Threads for the main pthread */
+	/* Event for the main pthread */
 	struct thread *t_cleanup;
 
 	/* This client's redistribute flag. */
@@ -285,6 +293,31 @@ extern int zserv_send_message(struct zserv *client, struct stream *msg);
  *    The Zebra API client.
  */
 extern struct zserv *zserv_find_client(uint8_t proto, unsigned short instance);
+
+/*
+ * Retrieve a client object by its protocol and instance number. This version
+ * supports use from a different pthread: the object will be returned marked
+ * in-use. The caller *must* release the client object with the
+ * release_client() api, to ensure that the in-use marker is cleared properly.
+ *
+ * proto
+ *    protocol number
+ *
+ * instance
+ *    instance number
+ *
+ * Returns:
+ *    The Zebra API client.
+ */
+extern struct zserv *zserv_acquire_client(uint8_t proto,
+					  unsigned short instance);
+
+/*
+ * Release a client object that was acquired with the acquire_client() api.
+ * After this has been called, the pointer must not be used - it may be freed
+ * in another pthread if the client has closed.
+ */
+extern void zserv_release_client(struct zserv *client);
 
 /*
  * Close a client.


### PR DESCRIPTION
Draft for a new zebra module, currently called 'ted', to support some new TE/SR/LSDB functionality. The new module runs its own pthread, and is intended to be able to do a couple of things - eventually:
1) handle one or more zapi messages that are passed among daemons, but are opaque to zebra. The specific case is for topology and link information that will flow from IGPs to BGP (for BGP-LS), and possibly to other consumers of topology and path information.
2) possibly, depending on the ongoing design discussions, maintain a copy of the current state of the topology information itself.

The initial commits introduce the new zebra module, and start and stop its pthread in coordination with the zebra main pthread. The new module offers an api towards zserv that allows a batch of messages to enqueued towards it, much like the batch message management that's done for zclients' io pthreads currently. In order to allow zclient sessions to be accessed from the new ted pthread, there's some new busy- or ref-counting machinery that's intended to prevent the zebra main pthread from destroying a client session that's in-use.