### PR TITLE
feed debian/ changes back into master

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -52,31 +52,6 @@ used.  This option should only be used for systems that do not have systemd,
 e.g. Ubuntu 14.04.
 
 
-* Why has SNMP support been disabled?
-=====================================
-FRR used to link against the NetSNMP libraries to provide SNMP
-support. Those libraries sadly link against the OpenSSL libraries
-to provide crypto support for SNMPv3 among others.
-OpenSSL now is not compatible with the GNU GENERAL PUBLIC LICENSE (GPL)
-licence that FRR is distributed under. For more explanation read:
-  http://www.gnome.org/~markmc/openssl-and-the-gpl.html
-  http://www.gnu.org/licenses/gpl-faq.html#GPLIncompatibleLibs
-Updating the licence to explicitly allow linking against OpenSSL
-would requite the affirmation of all people that ever contributed
-a significant part to Zebra / Quagga or FRR and thus are the collective
-"copyright holder". That's too much work. Using a shrinked down 
-version of NetSNMP without OpenSSL or convincing the NetSNMP people
-to change to GnuTLS are maybe good solutions but not reachable
-during the last days before the Sarge release :-(
-
-        *BUT*
-
-It is allowed by the used licence mix that you fetch the sources and
-build FRR yourself with SNMP with
-        # apt-get -b source -Ppkg.frr.snmp frr
-Just distributing it in binary form, linked against OpenSSL, is forbidden.
-
-
 * Debian Policy compliance notes
 ================================
 

--- a/debian/control
+++ b/debian/control
@@ -31,10 +31,10 @@ Build-Depends:
  python3-sphinx,
  python3-pytest <!nocheck>,
  texinfo (>= 4.7)
-Standards-Version: 4.2.1
+Standards-Version: 4.4.1
 Homepage: https://www.frrouting.org/
-Vcs-Browser: https://github.com/FRRouting/frr/
-Vcs-Git: https://github.com/FRRouting/frr.git
+Vcs-Browser: https://github.com/FRRouting/frr/tree/debian/master
+Vcs-Git: https://github.com/FRRouting/frr.git -b debian/master
 
 Package: frr
 Architecture: linux-any
@@ -104,6 +104,7 @@ Build-Profiles: <!pkg.frr.nortrlib>
 Package: frr-doc
 Section: doc
 Architecture: all
+Multi-Arch: foreign
 Depends:
  ${misc:Depends},
  libjs-jquery,

--- a/debian/frr.lintian-overrides
+++ b/debian/frr.lintian-overrides
@@ -6,5 +6,8 @@ frr binary: spelling-error-in-binary usr/lib/frr/zebra writen written
 frr binary: spelling-error-in-binary usr/lib/frr/pimd writen written
 frr binary: spelling-error-in-binary usr/lib/frr/pimd iif if
 
+# prefixed man pages for off-PATH daemons
+manpage-without-executable
+
 # personal name
 spelling-error-in-copyright Ang And


### PR DESCRIPTION
This is just a bunch of small changes that have accumulated on the `debian/master` branch for Debian packaging that should be backpropagated into `master`

(Don't get confused by the "7.2.1 prep" commit subject, it's just a bunch of small cleanups that were good to go at the time of 7.2.1)