### PR TITLE
OSPF: Add ECMP support to Segment Routing

### DIFF
--- a/docker/centos-7/Dockerfile
+++ b/docker/centos-7/Dockerfile
@@ -1,10 +1,10 @@
 # This stage builds an rpm from the source
 FROM centos:centos7 as centos-7-builder
-
+RUN yum install -y epel-release
 RUN yum install -y rpm-build autoconf automake libtool make \
         readline-devel texinfo net-snmp-devel groff pkgconfig \
         json-c-devel pam-devel bison flex pytest c-ares-devel \
-        python-devel systemd-devel python-sphinx libcap-devel \
+        python3-devel python3-sphinx systemd-devel libcap-devel \
         https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-0.16.111-0.x86_64.rpm \
         https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-devel-0.16.111-0.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-0.7.0-1.el7.centos.x86_64.rpm \

--- a/ospfd/ospf_route.h
+++ b/ospfd/ospf_route.h
@@ -33,12 +33,24 @@
 #define OSPF_PATH_TYPE2_EXTERNAL	4
 #define OSPF_PATH_MAX			5
 
+/* Segment Routing information to complement ospf_path structure */
+struct sr_nexthop_info {
+	/* Output label associated to this route */
+	mpls_label_t label_out;
+	/*
+	 * Pointer to SR Node which is the next hop for this route
+	 * or NULL if next hop is the destination of the prefix
+	 */
+	struct sr_node *nexthop;
+};
+
 /* OSPF Path. */
 struct ospf_path {
 	struct in_addr nexthop;
 	struct in_addr adv_router;
 	ifindex_t ifindex;
 	unsigned char unnumbered;
+	struct sr_nexthop_info srni;
 };
 
 /* Below is the structure linked to every

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1369,7 +1369,7 @@ static int ospf_spf_calculate_timer(struct thread *thread)
 	abr_time = monotime_since(&start_time, NULL);
 
 	/* Schedule Segment Routing update */
-	ospf_sr_update_timer_add(ospf);
+	ospf_sr_update_task(ospf);
 
 	total_spf_time =
 		monotime_since(&spf_start_time, &ospf->ts_spf_duration);

--- a/ospfd/ospf_sr.h
+++ b/ospfd/ospf_sr.h
@@ -312,6 +312,10 @@ extern void ospf_sr_ext_link_lsa_update(struct ospf_lsa *lsa);
 extern void ospf_sr_ext_link_lsa_delete(struct ospf_lsa *lsa);
 extern void ospf_sr_ext_prefix_lsa_update(struct ospf_lsa *lsa);
 extern void ospf_sr_ext_prefix_lsa_delete(struct ospf_lsa *lsa);
+/* Segment Routing Extending Link management */
+struct ext_itf;
+extern void ospf_sr_ext_itf_add(struct ext_itf *exti);
+extern void ospf_sr_ext_itf_delete(struct ext_itf *exti);
 /* Segment Routing configuration functions */
 extern uint32_t get_ext_link_label_value(void);
 extern void ospf_sr_config_write_router(struct vty *vty);

--- a/ospfd/ospf_sr.h
+++ b/ospfd/ospf_sr.h
@@ -58,6 +58,10 @@
 			zlog_debug(__VA_ARGS__);                               \
 	} while (0)
 
+/* Macro to check if SR Prefix has no valid route */
+#define IS_NO_ROUTE(srp) ((srp->route == NULL) || (srp->route->paths == NULL)  \
+			   || list_isempty(srp->route->paths))
+
 /* SID/Label Sub TLV - section 2.1 */
 #define SUBTLV_SID_LABEL		1
 #define SUBTLV_SID_LABEL_SIZE		8

--- a/ospfd/ospf_sr.h
+++ b/ospfd/ospf_sr.h
@@ -291,7 +291,7 @@ struct sr_prefix {
 	mpls_label_t label_in;
 
 	/* Back pointer to OSPF Route for remote prefix */
-	struct ospf_route *or;
+	struct ospf_route *route;
 
 	/* NHLFE for local prefix */
 	struct sr_nhlfe nhlfe;
@@ -315,7 +315,8 @@ extern void ospf_sr_ext_prefix_lsa_delete(struct ospf_lsa *lsa);
 /* Segment Routing configuration functions */
 extern uint32_t get_ext_link_label_value(void);
 extern void ospf_sr_config_write_router(struct vty *vty);
-extern void ospf_sr_update_local_prefix(struct interface *ifp, struct prefix *p);
+extern void ospf_sr_update_local_prefix(struct interface *ifp,
+					struct prefix *p);
 /* Segment Routing re-routing function */
 extern void ospf_sr_update_task(struct ospf *ospf);
 #endif /* _FRR_OSPF_SR_H */

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1351,6 +1351,7 @@ void ospf_zebra_vrf_deregister(struct ospf *ospf)
 		zclient_send_dereg_requests(zclient, ospf->vrf_id);
 	}
 }
+
 static void ospf_zebra_connected(struct zclient *zclient)
 {
 	/* Send the client registration */

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -50,6 +50,7 @@
 #include "ospfd/ospf_nsm.h"
 #include "ospfd/ospf_zebra.h"
 #include "ospfd/ospf_te.h"
+#include "ospfd/ospf_sr.h"
 
 DEFINE_MTYPE_STATIC(OSPFD, OSPF_EXTERNAL, "OSPF External route table")
 DEFINE_MTYPE_STATIC(OSPFD, OSPF_REDISTRIBUTE, "OSPF Redistriute")
@@ -413,6 +414,119 @@ void ospf_external_del(struct ospf *ospf, uint8_t type, unsigned short instance)
 
 		XFREE(MTYPE_OSPF_EXTERNAL, ext);
 	}
+}
+
+/* Update NHLFE for Prefix SID */
+void ospf_zebra_update_prefix_sid(const struct sr_prefix *srp)
+{
+	struct zapi_labels zl;
+	struct zapi_nexthop *znh;
+	struct listnode *node;
+	struct ospf_path *path;
+
+	osr_debug("SR (%s): Update Labels %u for Prefix %pFX", __func__,
+		  srp->label_in, (struct prefix *)&srp->prefv4);
+
+	/* Prepare message. */
+	memset(&zl, 0, sizeof(zl));
+	zl.type = ZEBRA_LSP_OSPF_SR;
+	zl.local_label = srp->label_in;
+
+	switch (srp->type) {
+	case LOCAL_SID:
+		/* Set Label for local Prefix */
+		znh = &zl.nexthops[zl.nexthop_num++];
+		znh->type = NEXTHOP_TYPE_IFINDEX;
+		znh->ifindex = srp->nhlfe.ifindex;
+		znh->label_num = 1;
+		znh->labels[0] = srp->nhlfe.label_out;
+		break;
+
+	case PREF_SID:
+		/* Update route in the RIB too. */
+		SET_FLAG(zl.message, ZAPI_LABELS_FTN);
+		zl.route.prefix.u.prefix4 = srp->prefv4.prefix;
+		zl.route.prefix.prefixlen = srp->prefv4.prefixlen;
+		zl.route.prefix.family = srp->prefv4.family;
+		zl.route.type = ZEBRA_ROUTE_OSPF;
+		zl.route.instance = 0;
+
+		/* Check that SRP contains at least one valid path */
+		if (srp->route == NULL) {
+			return;
+		}
+		for (ALL_LIST_ELEMENTS_RO(srp->route->paths, node, path)) {
+			if (path->srni.label_out == MPLS_INVALID_LABEL)
+				continue;
+
+			if (zl.nexthop_num >= MULTIPATH_NUM)
+				break;
+
+			znh = &zl.nexthops[zl.nexthop_num++];
+			znh->type = NEXTHOP_TYPE_IPV4_IFINDEX;
+			znh->gate.ipv4 = path->nexthop;
+			znh->ifindex = path->ifindex;
+			znh->label_num = 1;
+			znh->labels[0] = path->srni.label_out;
+		}
+		break;
+	default:
+		return;
+	}
+
+	/* Finally, send message to zebra. */
+	(void)zebra_send_mpls_labels(zclient, ZEBRA_MPLS_LABELS_REPLACE, &zl);
+}
+
+/* Remove NHLFE for Prefix-SID */
+void ospf_zebra_delete_prefix_sid(const struct sr_prefix *srp)
+{
+	struct zapi_labels zl;
+
+	osr_debug("SR (%s): Delete Labels %u for Prefix %pFX", __func__,
+		  srp->label_in, (struct prefix *)&srp->prefv4);
+
+	/* Prepare message. */
+	memset(&zl, 0, sizeof(zl));
+	zl.type = ZEBRA_LSP_OSPF_SR;
+	zl.local_label = srp->label_in;
+
+	if (srp->type == PREF_SID) {
+		/* Update route in the RIB too */
+		SET_FLAG(zl.message, ZAPI_LABELS_FTN);
+		zl.route.prefix.u.prefix4 = srp->prefv4.prefix;
+		zl.route.prefix.prefixlen = srp->prefv4.prefixlen;
+		zl.route.prefix.family = srp->prefv4.family;
+		zl.route.type = ZEBRA_ROUTE_OSPF;
+		zl.route.instance = 0;
+	}
+
+	/* Send message to zebra. */
+	(void)zebra_send_mpls_labels(zclient, ZEBRA_MPLS_LABELS_DELETE, &zl);
+}
+
+/* Send MPLS Label entry to Zebra for installation or deletion */
+void ospf_zebra_send_adjacency_sid(int cmd, struct sr_nhlfe nhlfe)
+{
+	struct zapi_labels zl;
+	struct zapi_nexthop *znh;
+
+	osr_debug("SR (%s): %s Labels %u/%u for Adjacency via %u", __func__,
+		  cmd == ZEBRA_MPLS_LABELS_ADD ? "Add" : "Delete",
+		  nhlfe.label_in, nhlfe.label_out, nhlfe.ifindex);
+
+	memset(&zl, 0, sizeof(zl));
+	zl.type = ZEBRA_LSP_OSPF_SR;
+	zl.local_label = nhlfe.label_in;
+	zl.nexthop_num = 1;
+	znh = &zl.nexthops[0];
+	znh->type = NEXTHOP_TYPE_IPV4_IFINDEX;
+	znh->gate.ipv4 = nhlfe.nexthop;
+	znh->ifindex = nhlfe.ifindex;
+	znh->label_num = 1;
+	znh->labels[0] = nhlfe.label_out;
+
+	(void)zebra_send_mpls_labels(zclient, cmd, &zl);
 }
 
 struct ospf_redist *ospf_redist_lookup(struct ospf *ospf, uint8_t type,

--- a/ospfd/ospf_zebra.h
+++ b/ospfd/ospf_zebra.h
@@ -63,13 +63,19 @@ extern struct ospf_external *ospf_external_lookup(struct ospf *, uint8_t,
 						  unsigned short);
 extern struct ospf_external *ospf_external_add(struct ospf *, uint8_t,
 					       unsigned short);
+
+struct sr_prefix;
+struct sr_nhlfe;
+extern void ospf_zebra_update_prefix_sid(const struct sr_prefix *srp);
+extern void ospf_zebra_delete_prefix_sid(const struct sr_prefix *srp);
+extern void ospf_zebra_send_adjacency_sid(int cmd, struct sr_nhlfe nhlfe);
+
 extern void ospf_external_del(struct ospf *, uint8_t, unsigned short);
 extern struct ospf_redist *ospf_redist_lookup(struct ospf *, uint8_t,
 					      unsigned short);
 extern struct ospf_redist *ospf_redist_add(struct ospf *, uint8_t,
 					   unsigned short);
 extern void ospf_redist_del(struct ospf *, uint8_t, unsigned short);
-
 
 extern int ospf_redistribute_set(struct ospf *, int, unsigned short, int, int);
 extern int ospf_redistribute_unset(struct ospf *, int, unsigned short);

--- a/tests/topotests/ospf-sr-topo1/r1/ospf_srdb.json
+++ b/tests/topotests/ospf-sr-topo1/r1/ospf_srdb.json
@@ -15,9 +15,18 @@
           "prefix":"10.0.255.2\/32",
           "sid":200,
           "inputLabel":20200,
-          "outputLabel":"pop",
-          "interface":"r1-eth0",
-          "nexthop":"10.0.1.2"
+          "prefixRoute":[
+            {
+              "outputLabel":3,
+              "interface":"r1-eth0",
+              "nexthop":"10.0.0.2"
+            },
+            {
+              "outputLabel":3,
+              "interface":"r1-eth1",
+              "nexthop":"10.0.1.2"
+            }
+          ]
         }
       ]
     },
@@ -36,9 +45,18 @@
           "prefix":"10.0.255.4\/32",
           "sid":400,
           "inputLabel":20400,
-          "outputLabel":"8400",
-          "interface":"r1-eth0",
-          "nexthop":"10.0.1.2"
+          "prefixRoute":[
+            {
+              "outputLabel":8400,
+              "interface":"r1-eth0",
+              "nexthop":"10.0.0.2"
+            },
+            {
+              "outputLabel":8400,
+              "interface":"r1-eth1",
+              "nexthop":"10.0.1.2"
+            }
+          ]
         }
       ]
     },
@@ -47,19 +65,24 @@
       "srgbSize":10000,
       "srgbLabel":10000,
       "algorithms":[
-        {
-          "0":"SPF"
-        }
       ],
-      "nodeMsd":8,
       "extendedPrefix":[
         {
           "prefix":"10.0.255.3\/32",
           "sid":300,
           "inputLabel":20300,
-          "outputLabel":"8300",
-          "interface":"r1-eth0",
-          "nexthop":"10.0.1.2"
+          "prefixRoute":[
+            {
+              "outputLabel":8300,
+              "interface":"r1-eth0",
+              "nexthop":"10.0.0.2"
+            },
+            {
+              "outputLabel":8300,
+              "interface":"r1-eth1",
+              "nexthop":"10.0.1.2"
+            }
+          ]
         }
       ]
     },
@@ -78,26 +101,46 @@
           "prefix":"10.0.255.1\/32",
           "sid":100,
           "inputLabel":20100,
-          "outputLabel":"pop",
-          "interface":"lo",
-          "nexthop":"10.0.255.1"
+          "prefixRoute":[
+            {
+              "outputLabel":3,
+              "interface":"lo",
+              "nexthop":"10.0.255.1"
+            }
+          ]
         }
       ],
       "extendedLink":[
         {
-          "prefix":"10.0.1.1\/32",
-          "sid":50001,
-          "inputLabel":50001,
-          "outputLabel":"pop",
+          "prefix":"10.0.0.1\/32",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
           "interface":"r1-eth0",
+          "nexthop":"10.0.0.2"
+        },
+        {
+          "prefix":"10.0.0.1\/32",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r1-eth0",
+          "nexthop":"10.0.0.2"
+        },
+        {
+          "prefix":"10.0.1.1\/32",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r1-eth1",
           "nexthop":"10.0.1.2"
         },
         {
           "prefix":"10.0.1.1\/32",
-          "sid":50000,
-          "inputLabel":50000,
-          "outputLabel":"pop",
-          "interface":"r1-eth0",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r1-eth1",
           "nexthop":"10.0.1.2"
         }
       ]

--- a/tests/topotests/ospf-sr-topo1/r1/ospfd.conf
+++ b/tests/topotests/ospf-sr-topo1/r1/ospfd.conf
@@ -3,6 +3,11 @@ interface lo
   ip ospf area 0.0.0.0
 !
 interface r1-eth0
+  ip ospf network point-to-point
+  ip ospf area 0.0.0.0
+!
+interface r1-eth1
+  ip ospf network point-to-point
   ip ospf area 0.0.0.0
 !
 router ospf

--- a/tests/topotests/ospf-sr-topo1/r1/zebra.conf
+++ b/tests/topotests/ospf-sr-topo1/r1/zebra.conf
@@ -3,6 +3,9 @@ interface lo
  ip address 10.0.255.1/32
 !
 interface r1-eth0
+ ip address 10.0.0.1/24
+!
+interface r1-eth1
  ip address 10.0.1.1/24
 !
 ip forwarding

--- a/tests/topotests/ospf-sr-topo1/r1/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r1/zebra_mpls.json
@@ -7,8 +7,7 @@
         "type":"SR (OSPF)",
         "outLabel":3,
         "distance":150,
-        "installed":true,
-        "nexthop":"10.0.255.1"
+        "installed":true
       }
     ]
   },
@@ -22,6 +21,13 @@
         "distance":150,
         "installed":true,
         "nexthop":"10.0.1.2"
+      },
+      {
+        "type":"SR (OSPF)",
+        "outLabel":3,
+        "distance":150,
+        "installed":true,
+        "nexthop":"10.0.0.2"
       }
     ]
   },
@@ -35,6 +41,13 @@
         "distance":150,
         "installed":true,
         "nexthop":"10.0.1.2"
+      },
+      {
+        "type":"SR (OSPF)",
+        "outLabel":8300,
+        "distance":150,
+        "installed":true,
+        "nexthop":"10.0.0.2"
       }
     ]
   },
@@ -48,11 +61,44 @@
         "distance":150,
         "installed":true,
         "nexthop":"10.0.1.2"
+      },
+      {
+        "type":"SR (OSPF)",
+        "outLabel":8400,
+        "distance":150,
+        "installed":true,
+        "nexthop":"10.0.0.2"
       }
     ]
   },
-  "50000":{
-    "inLabel":50000,
+  "XX":{
+    "inLabel":"XX",
+    "installed":true,
+    "nexthops":[
+      {
+        "type":"SR (OSPF)",
+        "outLabel":3,
+        "distance":150,
+        "installed":true,
+        "nexthop":"10.0.0.2"
+      }
+    ]
+  },
+  "XX":{
+    "inLabel":"XX",
+    "installed":true,
+    "nexthops":[
+      {
+        "type":"SR (OSPF)",
+        "outLabel":3,
+        "distance":150,
+        "installed":true,
+        "nexthop":"10.0.0.2"
+      }
+    ]
+  },
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {
@@ -64,8 +110,8 @@
       }
     ]
   },
-  "50001":{
-    "inLabel":50001,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {

--- a/tests/topotests/ospf-sr-topo1/r2/ospf_srdb.json
+++ b/tests/topotests/ospf-sr-topo1/r2/ospf_srdb.json
@@ -15,59 +15,79 @@
           "prefix":"10.0.255.2\/32",
           "sid":200,
           "inputLabel":0,
-          "outputLabel":"0",
-          "interface":"lo",
-          "nexthop":"10.0.255.2"
+          "prefixRoute":[
+            {
+              "outputLabel":0,
+              "interface":"lo",
+              "nexthop":"10.0.255.2"
+            }
+          ]
         }
       ],
       "extendedLink":[
         {
           "prefix":"10.0.4.2\/32",
-          "sid":50001,
-          "inputLabel":50001,
-          "outputLabel":"pop",
-          "interface":"r2-eth2",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r2-eth3",
           "nexthop":"10.0.4.1"
         },
         {
           "prefix":"10.0.4.2\/32",
-          "sid":50000,
-          "inputLabel":50000,
-          "outputLabel":"pop",
-          "interface":"r2-eth2",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r2-eth3",
           "nexthop":"10.0.4.1"
         },
         {
-          "prefix":"10.0.3.2\/32",
-          "sid":50003,
-          "inputLabel":50003,
-          "outputLabel":"pop",
-          "interface":"r2-eth1",
-          "nexthop":"10.0.3.1"
+          "prefix":"10.0.0.2\/32",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r2-eth0",
+          "nexthop":"10.0.0.1"
         },
         {
-          "prefix":"10.0.3.2\/32",
-          "sid":50002,
-          "inputLabel":50002,
-          "outputLabel":"pop",
-          "interface":"r2-eth1",
-          "nexthop":"10.0.3.1"
+          "prefix":"10.0.0.2\/32",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r2-eth0",
+          "nexthop":"10.0.0.1"
         },
         {
           "prefix":"10.0.1.2\/32",
-          "sid":50005,
-          "inputLabel":50005,
-          "outputLabel":"pop",
-          "interface":"r2-eth0",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r2-eth1",
           "nexthop":"10.0.1.1"
         },
         {
           "prefix":"10.0.1.2\/32",
-          "sid":50004,
-          "inputLabel":50004,
-          "outputLabel":"pop",
-          "interface":"r2-eth0",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r2-eth1",
           "nexthop":"10.0.1.1"
+        },
+        {
+          "prefix":"10.0.3.2\/32",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r2-eth2",
+          "nexthop":"10.0.3.1"
+        },
+        {
+          "prefix":"10.0.3.2\/32",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
+          "interface":"r2-eth2",
+          "nexthop":"10.0.3.1"
         }
       ]
     },
@@ -76,19 +96,19 @@
       "srgbSize":10000,
       "srgbLabel":10000,
       "algorithms":[
-        {
-          "0":"SPF"
-        }
       ],
-      "nodeMsd":12,
       "extendedPrefix":[
         {
           "prefix":"10.0.255.4\/32",
           "sid":400,
           "inputLabel":8400,
-          "outputLabel":"10400",
-          "interface":"r2-eth2",
-          "nexthop":"10.0.4.1"
+          "prefixRoute":[
+            {
+              "outputLabel":10400,
+              "interface":"r2-eth3",
+              "nexthop":"10.0.4.1"
+            }
+          ]
         }
       ]
     },
@@ -97,19 +117,19 @@
       "srgbSize":10000,
       "srgbLabel":10000,
       "algorithms":[
-        {
-          "0":"SPF"
-        }
       ],
-      "nodeMsd":8,
       "extendedPrefix":[
         {
           "prefix":"10.0.255.3\/32",
           "sid":300,
           "inputLabel":8300,
-          "outputLabel":"pop",
-          "interface":"r2-eth1",
-          "nexthop":"10.0.3.1"
+          "prefixRoute":[
+            {
+              "outputLabel":3,
+              "interface":"r2-eth2",
+              "nexthop":"10.0.3.1"
+            }
+          ]
         }
       ]
     },
@@ -118,19 +138,24 @@
       "srgbSize":10000,
       "srgbLabel":20000,
       "algorithms":[
-        {
-          "0":"SPF"
-        }
       ],
-      "nodeMsd":16,
       "extendedPrefix":[
         {
           "prefix":"10.0.255.1\/32",
           "sid":100,
           "inputLabel":8100,
-          "outputLabel":"20100",
-          "interface":"r2-eth0",
-          "nexthop":"10.0.1.1"
+          "prefixRoute":[
+            {
+              "outputLabel":20100,
+              "interface":"r2-eth0",
+              "nexthop":"10.0.0.1"
+            },
+            {
+              "outputLabel":20100,
+              "interface":"r2-eth1",
+              "nexthop":"10.0.1.1"
+            }
+          ]
         }
       ]
     }

--- a/tests/topotests/ospf-sr-topo1/r2/ospfd.conf
+++ b/tests/topotests/ospf-sr-topo1/r2/ospfd.conf
@@ -5,6 +5,7 @@ interface lo
   ip ospf area 0.0.0.0
 !
 interface r2-eth0
+  ip ospf network point-to-point
   ip ospf area 0.0.0.0
 !
 interface r2-eth1
@@ -12,6 +13,9 @@ interface r2-eth1
   ip ospf area 0.0.0.0
 !
 interface r2-eth2
+  ip ospf area 0.0.0.0
+!
+interface r2-eth3
   ip ospf network point-to-point
   ip ospf area 0.0.0.0
 !

--- a/tests/topotests/ospf-sr-topo1/r2/zebra.conf
+++ b/tests/topotests/ospf-sr-topo1/r2/zebra.conf
@@ -3,12 +3,15 @@ interface lo
  ip address 10.0.255.2/32
 !
 interface r2-eth0
- ip address 10.0.1.2/24
+ ip address 10.0.0.2/24
 !
 interface r2-eth1
- ip address 10.0.3.2/24
+ ip address 10.0.1.2/24
 !
 interface r2-eth2
+ ip address 10.0.3.2/24
+!
+interface r2-eth3
  ip address 10.0.4.2/24
 !
 ip forwarding

--- a/tests/topotests/ospf-sr-topo1/r2/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r2/zebra_mpls.json
@@ -9,6 +9,13 @@
         "distance":150,
         "installed":true,
         "nexthop":"10.0.1.1"
+      },
+      {
+        "type":"SR (OSPF)",
+        "outLabel":20100,
+        "distance":150,
+        "installed":true,
+        "nexthop":"10.0.0.1"
       }
     ]
   },
@@ -38,8 +45,8 @@
       }
     ]
   },
-  "50000":{
-    "inLabel":50000,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {
@@ -51,8 +58,8 @@
       }
     ]
   },
-  "50001":{
-    "inLabel":50001,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {
@@ -64,8 +71,8 @@
       }
     ]
   },
-  "50002":{
-    "inLabel":50002,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {
@@ -73,12 +80,12 @@
         "outLabel":3,
         "distance":150,
         "installed":true,
-        "nexthop":"10.0.3.1"
+        "nexthop":"10.0.0.1"
       }
     ]
   },
-  "50003":{
-    "inLabel":50003,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {
@@ -86,12 +93,12 @@
         "outLabel":3,
         "distance":150,
         "installed":true,
-        "nexthop":"10.0.3.1"
+        "nexthop":"10.0.0.1"
       }
     ]
   },
-  "50004":{
-    "inLabel":50004,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {
@@ -103,8 +110,8 @@
       }
     ]
   },
-  "50005":{
-    "inLabel":50005,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {
@@ -113,6 +120,32 @@
         "distance":150,
         "installed":true,
         "nexthop":"10.0.1.1"
+      }
+    ]
+  },
+  "XX":{
+    "inLabel":"XX",
+    "installed":true,
+    "nexthops":[
+      {
+        "type":"SR (OSPF)",
+        "outLabel":3,
+        "distance":150,
+        "installed":true,
+        "nexthop":"10.0.3.1"
+      }
+    ]
+  },
+  "XX":{
+    "inLabel":"XX",
+    "installed":true,
+    "nexthops":[
+      {
+        "type":"SR (OSPF)",
+        "outLabel":3,
+        "distance":150,
+        "installed":true,
+        "nexthop":"10.0.3.1"
       }
     ]
   }

--- a/tests/topotests/ospf-sr-topo1/r3/ospf_srdb.json
+++ b/tests/topotests/ospf-sr-topo1/r3/ospf_srdb.json
@@ -15,9 +15,13 @@
           "prefix":"10.0.255.2\/32",
           "sid":200,
           "inputLabel":10200,
-          "outputLabel":"pop",
-          "interface":"r3-eth0",
-          "nexthop":"10.0.3.2"
+          "prefixRoute":[
+            {
+              "outputLabel":3,
+              "interface":"r3-eth0",
+              "nexthop":"10.0.3.2"
+            }
+          ]
         }
       ]
     },
@@ -36,9 +40,13 @@
           "prefix":"10.0.255.4\/32",
           "sid":400,
           "inputLabel":10400,
-          "outputLabel":"8400",
-          "interface":"r3-eth0",
-          "nexthop":"10.0.3.2"
+          "prefixRoute":[
+            {
+              "outputLabel":8400,
+              "interface":"r3-eth0",
+              "nexthop":"10.0.3.2"
+            }
+          ]
         }
       ]
     },
@@ -57,25 +65,29 @@
           "prefix":"10.0.255.3\/32",
           "sid":300,
           "inputLabel":0,
-          "outputLabel":"0",
-          "interface":"lo",
-          "nexthop":"10.0.255.3"
+          "prefixRoute":[
+            {
+              "outputLabel":0,
+              "interface":"lo",
+              "nexthop":"10.0.255.3"
+            }
+          ]
         }
       ],
       "extendedLink":[
         {
           "prefix":"10.0.3.1\/32",
-          "sid":50001,
-          "inputLabel":50001,
-          "outputLabel":"pop",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
           "interface":"r3-eth0",
           "nexthop":"10.0.3.2"
         },
         {
           "prefix":"10.0.3.1\/32",
-          "sid":50000,
-          "inputLabel":50000,
-          "outputLabel":"pop",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
           "interface":"r3-eth0",
           "nexthop":"10.0.3.2"
         }
@@ -96,9 +108,13 @@
           "prefix":"10.0.255.1\/32",
           "sid":100,
           "inputLabel":10100,
-          "outputLabel":"8100",
-          "interface":"r3-eth0",
-          "nexthop":"10.0.3.2"
+          "prefixRoute":[
+            {
+              "outputLabel":8100,
+              "interface":"r3-eth0",
+              "nexthop":"10.0.3.2"
+            }
+          ]
         }
       ]
     }

--- a/tests/topotests/ospf-sr-topo1/r3/ospfd.conf
+++ b/tests/topotests/ospf-sr-topo1/r3/ospfd.conf
@@ -3,7 +3,6 @@ interface lo
   ip ospf area 0.0.0.0
 !
 interface r3-eth0
-  ip ospf network point-to-point
   ip ospf area 0.0.0.0
 !
 !

--- a/tests/topotests/ospf-sr-topo1/r3/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r3/zebra_mpls.json
@@ -38,8 +38,8 @@
       }
     ]
   },
-  "50000":{
-    "inLabel":50000,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {
@@ -51,8 +51,8 @@
       }
     ]
   },
-  "50001":{
-    "inLabel":50001,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {

--- a/tests/topotests/ospf-sr-topo1/r4/ospf_srdb.json
+++ b/tests/topotests/ospf-sr-topo1/r4/ospf_srdb.json
@@ -6,18 +6,19 @@
       "srgbSize":20000,
       "srgbLabel":8000,
       "algorithms":[
-        {
-          "0":"SPF"
-        }
       ],
       "extendedPrefix":[
         {
           "prefix":"10.0.255.2\/32",
           "sid":200,
           "inputLabel":10200,
-          "outputLabel":"pop",
-          "interface":"r4-eth0",
-          "nexthop":"10.0.4.2"
+          "prefixRoute":[
+            {
+              "outputLabel":3,
+              "interface":"r4-eth0",
+              "nexthop":"10.0.4.2"
+            }
+          ]
         }
       ]
     },
@@ -36,25 +37,29 @@
           "prefix":"10.0.255.4\/32",
           "sid":400,
           "inputLabel":10400,
-          "outputLabel":"pop",
-          "interface":"lo",
-          "nexthop":"10.0.255.4"
+          "prefixRoute":[
+            {
+              "outputLabel":3,
+              "interface":"lo",
+              "nexthop":"10.0.255.4"
+            }
+          ]
         }
       ],
       "extendedLink":[
         {
           "prefix":"10.0.4.1\/32",
-          "sid":50001,
-          "inputLabel":50001,
-          "outputLabel":"pop",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
           "interface":"r4-eth0",
           "nexthop":"10.0.4.2"
         },
         {
           "prefix":"10.0.4.1\/32",
-          "sid":50000,
-          "inputLabel":50000,
-          "outputLabel":"pop",
+          "sid":"XX",
+          "inputLabel":"XX",
+          "outputLabel":3,
           "interface":"r4-eth0",
           "nexthop":"10.0.4.2"
         }
@@ -65,19 +70,19 @@
       "srgbSize":10000,
       "srgbLabel":10000,
       "algorithms":[
-        {
-          "0":"SPF"
-        }
       ],
-      "nodeMsd":8,
       "extendedPrefix":[
         {
           "prefix":"10.0.255.3\/32",
           "sid":300,
           "inputLabel":10300,
-          "outputLabel":"8300",
-          "interface":"r4-eth0",
-          "nexthop":"10.0.4.2"
+          "prefixRoute":[
+            {
+              "outputLabel":8300,
+              "interface":"r4-eth0",
+              "nexthop":"10.0.4.2"
+            }
+          ]
         }
       ]
     },
@@ -86,19 +91,19 @@
       "srgbSize":10000,
       "srgbLabel":20000,
       "algorithms":[
-        {
-          "0":"SPF"
-        }
       ],
-      "nodeMsd":16,
       "extendedPrefix":[
         {
           "prefix":"10.0.255.1\/32",
           "sid":100,
           "inputLabel":10100,
-          "outputLabel":"8100",
-          "interface":"r4-eth0",
-          "nexthop":"10.0.4.2"
+          "prefixRoute":[
+            {
+              "outputLabel":8100,
+              "interface":"r4-eth0",
+              "nexthop":"10.0.4.2"
+            }
+          ]
         }
       ]
     }

--- a/tests/topotests/ospf-sr-topo1/r4/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r4/zebra_mpls.json
@@ -46,13 +46,12 @@
         "type":"SR (OSPF)",
         "outLabel":3,
         "distance":150,
-        "installed":true,
-        "nexthop":"10.0.255.4"
+        "installed":true
       }
     ]
   },
-  "50000":{
-    "inLabel":50000,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {
@@ -64,8 +63,8 @@
       }
     ]
   },
-  "50001":{
-    "inLabel":50001,
+  "XX":{
+    "inLabel":"XX",
     "installed":true,
     "nexthops":[
       {

--- a/tests/topotests/ospf-sr-topo1/test_ospf_sr_topo1.py
+++ b/tests/topotests/ospf-sr-topo1/test_ospf_sr_topo1.py
@@ -27,6 +27,7 @@ test_ospf_sr_topo1.py: Test the FRR OSPF routing daemon with Segment Routing.
 """
 
 import os
+import re
 import sys
 from functools import partial
 
@@ -62,20 +63,23 @@ class OspfSrTopo(Topo):
         for routern in range(1, 5):
             tgen.add_router("r{}".format(routern))
 
-        # Interconect router 1 and 2
-        switch = tgen.add_switch("s1")
-        switch.add_link(tgen.gears["r1"])
-        switch.add_link(tgen.gears["r2"])
+        # Interconect router 1 and 2 with 2 links
+        switch = tgen.add_switch('s1')
+        switch.add_link(tgen.gears['r1'])
+        switch.add_link(tgen.gears['r2'])
+        switch = tgen.add_switch('s2')
+        switch.add_link(tgen.gears['r1'])
+        switch.add_link(tgen.gears['r2'])
 
         # Interconect router 3 and 2
-        switch = tgen.add_switch("s2")
-        switch.add_link(tgen.gears["r3"])
-        switch.add_link(tgen.gears["r2"])
+        switch = tgen.add_switch('s3')
+        switch.add_link(tgen.gears['r3'])
+        switch.add_link(tgen.gears['r2'])
 
         # Interconect router 4 and 2
-        switch = tgen.add_switch("s3")
-        switch.add_link(tgen.gears["r4"])
-        switch.add_link(tgen.gears["r2"])
+        switch = tgen.add_switch('s4')
+        switch.add_link(tgen.gears['r4'])
+        switch.add_link(tgen.gears['r2'])
 
 
 def setup_module(mod):
@@ -130,6 +134,9 @@ def compare_ospf_srdb(rname, expected):
     """
     tgen = get_topogen()
     current = tgen.gears[rname].vtysh_cmd("show ip ospf database segment-routing json")
+    # Filter Adjacency SID allocation
+    current = re.sub(r'"sid":5000[0-9],', '"sid":"XX",', current)
+    current = re.sub(r'"inputLabel":5000[0-9],', '"inputLabel":"XX",', current)
     return topotest.difflines(
         current, expected, title1="Current output", title2="Expected output"
     )
@@ -142,6 +149,9 @@ def compare_mpls_table(rname, expected):
     """
     tgen = get_topogen()
     current = tgen.gears[rname].vtysh_cmd("show mpls table json")
+    # Filter Adjacency SID allocation
+    current = re.sub(r'"5000[0-9]":', '"XX":', current)
+    current = re.sub(r'"inLabel":5000[0-9],', '"inLabel":"XX",', current)
     return topotest.difflines(
         current, expected, title1="Current output", title2="Expected output"
     )


### PR DESCRIPTION
This change add ECMP support to OSPF Segment Routing. Modifications are as follow:
- Change sr_prefix structure in ospf_sr.h to add support to ECMP
- Add new Segment Routing information to ospf_paths in ospf_route.h
- Backport MPLS label configuration from IS-IS Segment Routing implementation

In addition, following modifications were done:
- Change log debug message (add new osr_debug macro) and use '%pFX' and '%pI4'
- Correct how Router Information LSA is handle, in particular when a router stop Segment Routing (i.e. it Router Information LSA is not removed but advertise without Segment Routing capabilities)
- Update topotest accordingly

This change resolved issue #6038