### PR TITLE
doc: document lsp-mtu knob for IS-IS

### DIFF
--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -111,6 +111,12 @@ writing, *isisd* does not support multiple ISIS processes.
 
    Enable or disable :rfc:`6232` purge originator identification.
 
+.. index:: [no] lsp-mtu (128-4352)
+.. clicmd:: [no] lsp-mtu (128-4352)
+
+   Configure the maximum size of generated LSPs, in bytes.
+
+
 .. _isis-timer:
 
 ISIS Timer


### PR DESCRIPTION
We're missing docs on the knob used to specify the maximum LSP MTU.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>