### PR TITLE
Unequal cost multipath fixes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2444,6 +2444,54 @@ struct bgp_process_queue {
 	unsigned int queued;
 };
 
+static void bgp_process_evpn_route_injection(struct bgp *bgp, afi_t afi,
+					     safi_t safi, struct bgp_node *rn,
+					     struct bgp_path_info *new_select,
+					     struct bgp_path_info *old_select)
+{
+	const struct prefix *p = bgp_node_get_prefix(rn);
+
+	if ((afi != AFI_IP && afi != AFI_IP6) || (safi != SAFI_UNICAST))
+		return;
+
+	if (advertise_type5_routes(bgp, afi) && new_select
+	    && is_route_injectable_into_evpn(new_select)) {
+
+		/* apply the route-map */
+		if (bgp->adv_cmd_rmap[afi][safi].map) {
+			route_map_result_t ret;
+			struct bgp_path_info rmap_path;
+			struct bgp_path_info_extra rmap_path_extra;
+			struct attr dummy_attr;
+
+			dummy_attr = *new_select->attr;
+
+			/* Fill temp path_info */
+			prep_for_rmap_apply(&rmap_path, &rmap_path_extra, rn,
+					    new_select, new_select->peer,
+					    &dummy_attr);
+
+			RESET_FLAG(dummy_attr.rmap_change_flags);
+
+			ret = route_map_apply(bgp->adv_cmd_rmap[afi][safi].map,
+					      p, RMAP_BGP, &rmap_path);
+
+			if (ret == RMAP_DENYMATCH) {
+				bgp_attr_flush(&dummy_attr);
+				bgp_evpn_withdraw_type5_route(bgp, p, afi,
+							      safi);
+			} else
+				bgp_evpn_advertise_type5_route(
+					bgp, p, &dummy_attr, afi, safi);
+		} else {
+			bgp_evpn_advertise_type5_route(bgp, p, new_select->attr,
+						       afi, safi);
+		}
+	} else if (advertise_type5_routes(bgp, afi) && old_select
+		   && is_route_injectable_into_evpn(old_select))
+		bgp_evpn_withdraw_type5_route(bgp, p, afi, safi);
+}
+
 /*
  * old_select = The old best path
  * new_select = the new best path
@@ -2607,6 +2655,12 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 			UNSET_FLAG(rn->flags, BGP_NODE_LABEL_CHANGED);
 		}
 
+		/* advertise/withdraw type-5 routes */
+		if (CHECK_FLAG(old_select->flags, BGP_PATH_LINK_BW_CHG)
+		    || CHECK_FLAG(old_select->flags, BGP_PATH_MULTIPATH_CHG))
+			bgp_process_evpn_route_injection(
+				bgp, afi, safi, rn, old_select, old_select);
+
 		UNSET_FLAG(old_select->flags, BGP_PATH_MULTIPATH_CHG);
 		UNSET_FLAG(old_select->flags, BGP_PATH_LINK_BW_CHG);
 		bgp_zebra_clear_route_change_flags(rn);
@@ -2696,53 +2750,8 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 		}
 	}
 
-	/* advertise/withdraw type-5 routes */
-	if ((afi == AFI_IP || afi == AFI_IP6) && (safi == SAFI_UNICAST)) {
-		const struct prefix *p = bgp_node_get_prefix(rn);
-
-		if (advertise_type5_routes(bgp, afi) &&
-		    new_select &&
-		    is_route_injectable_into_evpn(new_select)) {
-
-			/* apply the route-map */
-			if (bgp->adv_cmd_rmap[afi][safi].map) {
-				route_map_result_t ret;
-				struct bgp_path_info rmap_path;
-				struct bgp_path_info_extra rmap_path_extra;
-				struct attr dummy_attr;
-
-				dummy_attr = *new_select->attr;
-
-				/* Fill temp path_info */
-				prep_for_rmap_apply(
-					&rmap_path, &rmap_path_extra,
-					rn, new_select, new_select->peer,
-					&dummy_attr);
-
-				RESET_FLAG(dummy_attr.rmap_change_flags);
-
-				ret = route_map_apply(
-					bgp->adv_cmd_rmap[afi][safi].map,
-					p, RMAP_BGP, &rmap_path);
-				if (ret == RMAP_DENYMATCH) {
-					bgp_attr_flush(&dummy_attr);
-					bgp_evpn_withdraw_type5_route(
-						bgp, p, afi, safi);
-				} else
-					bgp_evpn_advertise_type5_route(
-						bgp, p, &dummy_attr,
-						afi, safi);
-			} else {
-				bgp_evpn_advertise_type5_route(bgp, p,
-							       new_select->attr,
-							       afi, safi);
-
-			}
-		} else if (advertise_type5_routes(bgp, afi) &&
-			   old_select &&
-			   is_route_injectable_into_evpn(old_select))
-			bgp_evpn_withdraw_type5_route(bgp, p, afi, safi);
-	}
+	bgp_process_evpn_route_injection(bgp, afi, safi, rn, new_select,
+					 old_select);
 
 	/* Clear any route change flags. */
 	bgp_zebra_clear_route_change_flags(rn);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2569,7 +2569,7 @@ route_set_ecommunity_lb(void *rule, const struct prefix *prefix,
 	/* Build link bandwidth extended community */
 	as = (peer->bgp->as > BGP_AS_MAX) ? BGP_AS_TRANS : peer->bgp->as;
 	if (rels->lb_type == RMAP_ECOMM_LB_SET_VALUE) {
-		bw_bytes = ((uint64_t)(rels->bw * 1000 * 1000))/8;
+		bw_bytes = ((uint64_t)rels->bw * 1000 * 1000) / 8;
 	} else if (rels->lb_type == RMAP_ECOMM_LB_SET_CUMUL) {
 		/* process this only for the best path. */
 		if (!CHECK_FLAG(path->flags, BGP_PATH_SELECTED))
@@ -2585,7 +2585,7 @@ route_set_ecommunity_lb(void *rule, const struct prefix *prefix,
 		if (!CHECK_FLAG(path->flags, BGP_PATH_SELECTED))
 			return RMAP_OKAY;
 
-		bw_bytes = ((uint64_t)(peer->bgp->lb_ref_bw * 1000 * 1000))/8;
+		bw_bytes = ((uint64_t)peer->bgp->lb_ref_bw * 1000 * 1000) / 8;
 		mpath_count = bgp_path_info_mpath_count(path) + 1;
 		bw_bytes *= mpath_count;
 	}


### PR DESCRIPTION
These two commits fix warnings/issues in BGP link-bandwidth related processing.
- The first commit addresses Coverity warnings related to integer arithmetic overflow
- The second commit address an issue in a EVPN topology with BGP link-bandwidth where the bandwidth is not updated correctly upon multipath change for the "contributing" route