### PR TITLE
zebra: Address invalid memory access on VRF delete.

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -294,6 +294,7 @@ struct rib_table_info {
 	struct zebra_vrf *zvrf;
 	afi_t afi;
 	safi_t safi;
+	uint32_t table_id;
 };
 
 enum rib_tables_iter_state {
@@ -484,6 +485,14 @@ static inline struct route_table *rib_dest_table(rib_dest_t *dest)
 static inline struct zebra_vrf *rib_dest_vrf(rib_dest_t *dest)
 {
 	return rib_table_info(rib_dest_table(dest))->zvrf;
+}
+
+/*
+ * rib_dest_table_id
+ */
+static inline uint32_t rib_dest_table_id(rib_dest_t *dest)
+{
+	return rib_table_info(rib_dest_table(dest))->table_id;
 }
 
 /*

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -279,7 +279,6 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 				   rib_dest_t *dest, struct route_entry *re)
 {
 	struct nexthop *nexthop;
-	struct zebra_vrf *zvrf;
 
 	memset(ri, 0, sizeof(*ri));
 
@@ -287,9 +286,7 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 	ri->af = rib_dest_af(dest);
 
 	ri->nlmsg_type = cmd;
-	zvrf = rib_dest_vrf(dest);
-	if (zvrf)
-		ri->rtm_table = zvrf->table_id;
+	ri->rtm_table = rib_dest_table_id(dest);
 	ri->rtm_protocol = RTPROT_UNSPEC;
 
 	/*

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -133,6 +133,7 @@ struct route_table *zebra_router_get_table(struct zebra_vrf *zvrf,
 	info->zvrf = zvrf;
 	info->afi = afi;
 	info->safi = safi;
+	info->table_id = zvrf->table_id;
 	route_table_set_info(zrt->table, info);
 	zrt->table->cleanup = zebra_rtable_node_cleanup;
 


### PR DESCRIPTION
A new 'zvrf' is created when the VRF is created.
This happens in zebra_vrf_new().
The rib_table_info_t points to this 'zvrf'.

During VRF deletion, the 'zvrf' is deleted.
However, the rib_table_info_t continues to hold a dangling
pointer to the deleted 'zvrf'.
Further, as part of route delete messages to the FPM, this dangling
pointer is accessed. 
The table-id fetched from this dangling pointer will be corrupt.

Prevent 'zvrf' access completely in the FPM while sending route add
and delete messages. The 'zvrf' is only required to fetch the table-id.
Instead of accessing the table-id  via 'zvrf', store the table-id in
rib_table_info_t directly and access it.

Signed-off-by: NaveenThanikachalam <nthanikachal@vmware.com>