### PR TITLE
lib: northbound wrapper api for yang date-and-time

### DIFF
--- a/lib/yang_wrappers.h
+++ b/lib/yang_wrappers.h
@@ -180,6 +180,11 @@ extern struct yang_data *yang_data_new_mac(const char *xpath,
 					   const struct ethaddr *mac);
 extern void yang_str2mac(const char *value, struct ethaddr *mac);
 
+/*data-and-time */
+extern struct yang_data *yang_data_new_date_and_time(const char *xpath,
+						     time_t time);
+
+/* nexthop enum2str */
 extern const char *yang_nexthop_type2str(uint32_t ntype);
 
 #endif /* _FRR_NORTHBOUND_WRAPPERS_H_ */


### PR DESCRIPTION
This commit has change a wrapper api to create a data node for yang date-and-time field. 


Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>