### PR TITLE
ospf6d: stop looping thru same Inter-Area Router LSAs

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -1200,9 +1200,23 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 					listcount(old_route->nh_list));
 			}
 		} else {
-			/* adv. router exists in the list, update the nhs */
-			list_delete_all_node(o_path->nh_list);
-			ospf6_copy_nexthops(o_path->nh_list, route->nh_list);
+			struct ospf6_route *tmp_route = ospf6_route_create();
+
+			ospf6_copy_nexthops(tmp_route->nh_list,
+					    o_path->nh_list);
+
+			if (ospf6_route_cmp_nexthops(tmp_route, route) != 0) {
+				/* adv. router exists in the list, update nhs */
+				list_delete_all_node(o_path->nh_list);
+				ospf6_copy_nexthops(o_path->nh_list,
+						    route->nh_list);
+				ospf6_route_delete(tmp_route);
+			} else {
+				/* adv. router has no change in nhs */
+				old_entry_updated = false;
+				ospf6_route_delete(tmp_route);
+				continue;
+			}
 		}
 
 		if (is_debug)


### PR DESCRIPTION
Processing loop uncovered when there are multiple ABRs also
acting as ASBRs into the same area in ospf6.  The problem
was that when looking thru the list of Inter-area router
entries, if the current entry being processed matched, it
still merged next-hops and re-initiated the process.  In
this fix, if the route/path matches and the next-hops also
match, there is no need to re-initiate the examine process.

Note that this fix addresses issue #852

Ticket: CM-28900
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>