### PR TITLE
bfdd: misc code improvements and fixes

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -131,7 +131,7 @@ int bfd_session_enable(struct bfd_session *bs)
 	if (bs->key.vrfname[0]) {
 		vrf = vrf_lookup_by_name(bs->key.vrfname);
 		if (vrf == NULL) {
-			log_error(
+			zlog_err(
 				"session-enable: specified VRF doesn't exists.");
 			return 0;
 		}
@@ -143,15 +143,15 @@ int bfd_session_enable(struct bfd_session *bs)
 		else
 			ifp = if_lookup_by_name_all_vrf(bs->key.ifname);
 		if (ifp == NULL) {
-			log_error(
-				  "session-enable: specified interface doesn't exists.");
+			zlog_err(
+				"session-enable: specified interface doesn't exists.");
 			return 0;
 		}
 		if (bs->key.ifname[0] && !vrf) {
 			vrf = vrf_lookup_by_id(ifp->vrf_id);
 			if (vrf == NULL) {
-				log_error(
-					  "session-enable: specified VRF doesn't exists.");
+				zlog_err(
+					"session-enable: specified VRF doesn't exists.");
 				return 0;
 			}
 		}
@@ -169,7 +169,7 @@ int bfd_session_enable(struct bfd_session *bs)
 
 	/* Sanity check: don't leak open sockets. */
 	if (bs->sock != -1) {
-		log_debug("session-enable: previous socket open");
+		zlog_debug("session-enable: previous socket open");
 		close(bs->sock);
 		bs->sock = -1;
 	}
@@ -318,9 +318,9 @@ void ptm_bfd_sess_up(struct bfd_session *bfd)
 
 	if (old_state != bfd->ses_state) {
 		bfd->stats.session_up++;
-		log_info("state-change: [%s] %s -> %s", bs_to_string(bfd),
-			 state_list[old_state].str,
-			 state_list[bfd->ses_state].str);
+		zlog_debug("state-change: [%s] %s -> %s", bs_to_string(bfd),
+			   state_list[old_state].str,
+			   state_list[bfd->ses_state].str);
 	}
 }
 
@@ -357,10 +357,10 @@ void ptm_bfd_sess_dn(struct bfd_session *bfd, uint8_t diag)
 
 	if (old_state != bfd->ses_state) {
 		bfd->stats.session_down++;
-		log_info("state-change: [%s] %s -> %s reason:%s",
-			 bs_to_string(bfd), state_list[old_state].str,
-			 state_list[bfd->ses_state].str,
-			 get_diag_str(bfd->local_diag));
+		zlog_debug("state-change: [%s] %s -> %s reason:%s",
+			   bs_to_string(bfd), state_list[old_state].str,
+			   state_list[bfd->ses_state].str,
+			   get_diag_str(bfd->local_diag));
 	}
 }
 
@@ -682,7 +682,7 @@ struct bfd_session *ptm_bfd_sess_new(struct bfd_peer_cfg *bpc)
 	/* Get BFD session storage with its defaults. */
 	bfd = bfd_session_new();
 	if (bfd == NULL) {
-		log_error("session-new: allocation failed");
+		zlog_err("session-new: allocation failed");
 		return NULL;
 	}
 
@@ -758,7 +758,7 @@ struct bfd_session *bs_registrate(struct bfd_session *bfd)
 	if (bfd->key.ifname[0] || bfd->key.vrfname[0] || bfd->sock == -1)
 		bs_observer_add(bfd);
 
-	log_info("session-new: %s", bs_to_string(bfd));
+	zlog_debug("session-new: %s", bs_to_string(bfd));
 
 	control_notify_config(BCM_NOTIFY_CONFIG_ADD, bfd);
 
@@ -776,13 +776,13 @@ int ptm_bfd_sess_del(struct bfd_peer_cfg *bpc)
 
 	/* This pointer is being referenced, don't let it be deleted. */
 	if (bs->refcount > 0) {
-		log_error("session-delete: refcount failure: %" PRIu64
-			  " references",
-			  bs->refcount);
+		zlog_err("session-delete: refcount failure: %" PRIu64
+			 " references",
+			 bs->refcount);
 		return -1;
 	}
 
-	log_info("session-delete: %s", bs_to_string(bs));
+	zlog_debug("session-delete: %s", bs_to_string(bs));
 
 	control_notify_config(BCM_NOTIFY_CONFIG_DELETE, bs);
 
@@ -849,7 +849,8 @@ static void bs_down_handler(struct bfd_session *bs, int nstate)
 		break;
 
 	default:
-		log_debug("state-change: unhandled neighbor state: %d", nstate);
+		zlog_debug("state-change: unhandled neighbor state: %d",
+			   nstate);
 		break;
 	}
 }
@@ -876,7 +877,8 @@ static void bs_init_handler(struct bfd_session *bs, int nstate)
 		break;
 
 	default:
-		log_debug("state-change: unhandled neighbor state: %d", nstate);
+		zlog_debug("state-change: unhandled neighbor state: %d",
+			   nstate);
 		break;
 	}
 }
@@ -907,10 +909,10 @@ static void bs_neighbour_admin_down_handler(struct bfd_session *bfd,
 	if (old_state != bfd->ses_state) {
 		bfd->stats.session_down++;
 
-		log_info("state-change: [%s] %s -> %s reason:%s",
-			bs_to_string(bfd), state_list[old_state].str,
-			state_list[bfd->ses_state].str,
-			get_diag_str(bfd->local_diag));
+		zlog_debug("state-change: [%s] %s -> %s reason:%s",
+			   bs_to_string(bfd), state_list[old_state].str,
+			   state_list[bfd->ses_state].str,
+			   get_diag_str(bfd->local_diag));
 	}
 }
 
@@ -932,7 +934,8 @@ static void bs_up_handler(struct bfd_session *bs, int nstate)
 		break;
 
 	default:
-		log_debug("state-change: unhandled neighbor state: %d", nstate);
+		zlog_debug("state-change: unhandled neighbor state: %d",
+			   nstate);
 		break;
 	}
 }
@@ -954,8 +957,8 @@ void bs_state_handler(struct bfd_session *bs, int nstate)
 		break;
 
 	default:
-		log_debug("state-change: [%s] is in invalid state: %d",
-			  bs_to_string(bs), nstate);
+		zlog_debug("state-change: [%s] is in invalid state: %d",
+			   bs_to_string(bs), nstate);
 		break;
 	}
 }
@@ -1434,8 +1437,8 @@ struct bfd_session *bfd_key_lookup(struct bfd_key key)
 
 			inet_ntop(bs.key.family, &key.local, addr_buf,
 				  sizeof(addr_buf));
-			log_debug(" peer %s found, but loc-addr %s ignored",
-				  peer_buf, addr_buf);
+			zlog_debug(" peer %s found, but loc-addr %s ignored",
+				   peer_buf, addr_buf);
 			return bsp;
 		}
 	}
@@ -1446,8 +1449,8 @@ struct bfd_session *bfd_key_lookup(struct bfd_key key)
 		memset(bs.key.ifname, 0, sizeof(bs.key.ifname));
 		bsp = hash_lookup(bfd_key_hash, &bs);
 		if (bsp) {
-			log_debug(" peer %s found, but ifp %s ignored",
-				  peer_buf, key.ifname);
+			zlog_debug(" peer %s found, but ifp %s ignored",
+				   peer_buf, key.ifname);
 			return bsp;
 		}
 	}
@@ -1461,10 +1464,10 @@ struct bfd_session *bfd_key_lookup(struct bfd_key key)
 
 			inet_ntop(bs.key.family, &bs.key.local, addr_buf,
 				  sizeof(addr_buf));
-			log_debug(" peer %s found, but ifp %s"
-				  " and loc-addr %s ignored",
-				  peer_buf, key.ifname,
-				  addr_buf);
+			zlog_debug(
+				" peer %s found, but ifp %s"
+				" and loc-addr %s ignored",
+				peer_buf, key.ifname, addr_buf);
 			return bsp;
 		}
 	}
@@ -1482,8 +1485,10 @@ struct bfd_session *bfd_key_lookup(struct bfd_key key)
 	/* change key */
 	if (ctx.result) {
 		bsp = ctx.result;
-		log_debug(" peer %s found, but ifp"
-			  " and/or loc-addr params ignored", peer_buf);
+		zlog_debug(
+			" peer %s found, but ifp"
+			" and/or loc-addr params ignored",
+			peer_buf);
 	}
 	return bsp;
 }
@@ -1671,13 +1676,13 @@ void bfd_sessions_remove_manual(void)
  */
 static int bfd_vrf_new(struct vrf *vrf)
 {
-	log_debug("VRF Created: %s(%u)", vrf->name, vrf->vrf_id);
+	zlog_debug("VRF Created: %s(%u)", vrf->name, vrf->vrf_id);
 	return 0;
 }
 
 static int bfd_vrf_delete(struct vrf *vrf)
 {
-	log_debug("VRF Deletion: %s(%u)", vrf->name, vrf->vrf_id);
+	zlog_debug("VRF Deletion: %s(%u)", vrf->name, vrf->vrf_id);
 	return 0;
 }
 
@@ -1685,7 +1690,7 @@ static int bfd_vrf_update(struct vrf *vrf)
 {
 	if (!vrf_is_enabled(vrf))
 		return 0;
-	log_debug("VRF update: %s(%u)", vrf->name, vrf->vrf_id);
+	zlog_debug("VRF update: %s(%u)", vrf->name, vrf->vrf_id);
 	/* a different name is given; update bfd list */
 	bfdd_sessions_enable_vrf(vrf);
 	return 0;
@@ -1702,7 +1707,7 @@ static int bfd_vrf_enable(struct vrf *vrf)
 		vrf->info = (void *)bvrf;
 	} else
 		bvrf = vrf->info;
-	log_debug("VRF enable add %s id %u", vrf->name, vrf->vrf_id);
+	zlog_debug("VRF enable add %s id %u", vrf->name, vrf->vrf_id);
 	if (vrf->vrf_id == VRF_DEFAULT ||
 	    vrf_get_backend() == VRF_BACKEND_NETNS) {
 		if (!bvrf->bg_shop)
@@ -1758,7 +1763,7 @@ static int bfd_vrf_disable(struct vrf *vrf)
 		bfdd_zclient_unregister(vrf->vrf_id);
 	}
 
-	log_debug("VRF disable %s id %d", vrf->name, vrf->vrf_id);
+	zlog_debug("VRF disable %s id %d", vrf->name, vrf->vrf_id);
 
 	/* Disable read/write poll triggering. */
 	THREAD_OFF(bvrf->bg_ev[0]);

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -164,7 +164,7 @@ int bfd_session_enable(struct bfd_session *bs)
 	assert(bs->vrf);
 
 	if (bs->key.ifname[0]
-	    && BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH) == 0)
+	    && CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH) == 0)
 		bs->ifp = ifp;
 
 	/* Sanity check: don't leak open sockets. */
@@ -179,7 +179,7 @@ int bfd_session_enable(struct bfd_session *bs)
 	 * could use the destination port (3784) for the source
 	 * port we wouldn't need a socket per session.
 	 */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_IPV6) == 0) {
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_IPV6) == 0) {
 		psock = bp_peer_socket(bs);
 		if (psock == -1)
 			return 0;
@@ -287,7 +287,7 @@ void ptm_bfd_echo_stop(struct bfd_session *bfd)
 {
 	bfd->echo_xmt_TO = 0;
 	bfd->echo_detect_TO = 0;
-	BFD_UNSET_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE);
+	UNSET_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE);
 
 	bfd_echo_xmttimer_delete(bfd);
 	bfd_echo_recvtimer_delete(bfd);
@@ -352,7 +352,7 @@ void ptm_bfd_sess_dn(struct bfd_session *bfd, uint8_t diag)
 		control_notify(bfd, PTM_BFD_DOWN);
 
 	/* Stop echo packet transmission if they are active */
-	if (BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE))
+	if (CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE))
 		ptm_bfd_echo_stop(bfd);
 
 	if (old_state != bfd->ses_state) {
@@ -548,19 +548,19 @@ static void _bfd_session_update(struct bfd_session *bs,
 {
 	if (bpc->bpc_echo) {
 		/* Check if echo mode is already active. */
-		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
 			goto skip_echo;
 
-		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
+		SET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
 
 		/* Activate/update echo receive timeout timer. */
 		bs_echo_timer_handler(bs);
 	} else {
 		/* Check if echo mode is already disabled. */
-		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+		if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
 			goto skip_echo;
 
-		BFD_UNSET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
+		UNSET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
 		ptm_bfd_echo_stop(bs);
 	}
 
@@ -582,10 +582,10 @@ skip_echo:
 
 	if (bpc->bpc_shutdown) {
 		/* Check if already shutdown. */
-		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 			return;
 
-		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
+		SET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
 
 		/* Disable all events. */
 		bfd_recvtimer_delete(bs);
@@ -602,10 +602,10 @@ skip_echo:
 			ptm_bfd_snd(bs, 0);
 	} else {
 		/* Check if already working. */
-		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+		if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 			return;
 
-		BFD_UNSET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
+		UNSET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
 
 		/* Change and notify state change. */
 		bs->ses_state = PTM_BFD_DOWN;
@@ -616,15 +616,15 @@ skip_echo:
 		bfd_xmttimer_update(bs, bs->xmt_TO);
 	}
 	if (bpc->bpc_cbit) {
-		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CBIT))
+		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CBIT))
 			return;
 
-		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_CBIT);
+		SET_FLAG(bs->flags, BFD_SESS_FLAG_CBIT);
 	} else {
-		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CBIT))
+		if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CBIT))
 			return;
 
-		BFD_UNSET_FLAG(bs->flags, BFD_SESS_FLAG_CBIT);
+		UNSET_FLAG(bs->flags, BFD_SESS_FLAG_CBIT);
 	}
 }
 
@@ -703,7 +703,7 @@ struct bfd_session *ptm_bfd_sess_new(struct bfd_peer_cfg *bpc)
 
 	/* Copy remaining data. */
 	if (bpc->bpc_ipv4 == false)
-		BFD_SET_FLAG(bfd->flags, BFD_SESS_FLAG_IPV6);
+		SET_FLAG(bfd->flags, BFD_SESS_FLAG_IPV6);
 
 	bfd->key.family = (bpc->bpc_ipv4) ? AF_INET : AF_INET6;
 	switch (bfd->key.family) {
@@ -727,7 +727,7 @@ struct bfd_session *ptm_bfd_sess_new(struct bfd_peer_cfg *bpc)
 	}
 
 	if (bpc->bpc_mhop)
-		BFD_SET_FLAG(bfd->flags, BFD_SESS_FLAG_MH);
+		SET_FLAG(bfd->flags, BFD_SESS_FLAG_MH);
 
 	bfd->key.mhop = bpc->bpc_mhop;
 
@@ -901,7 +901,7 @@ static void bs_neighbour_admin_down_handler(struct bfd_session *bfd,
 		control_notify(bfd, PTM_BFD_ADM_DOWN);
 
 	/* Stop echo packet transmission if they are active */
-	if (BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE))
+	if (CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE))
 		ptm_bfd_echo_stop(bfd);
 
 	if (old_state != bfd->ses_state) {
@@ -976,14 +976,14 @@ void bs_echo_timer_handler(struct bfd_session *bs)
 	 *     Section 3).
 	 *   - Check that we are already at the up state.
 	 */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO) == 0
-	    || BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO) == 0
+	    || CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)
 	    || bs->ses_state != PTM_BFD_UP)
 		return;
 
 	/* Remote peer asked to stop echo. */
 	if (bs->remote_timers.required_min_echo == 0) {
-		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO_ACTIVE))
+		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO_ACTIVE))
 			ptm_bfd_echo_stop(bs);
 
 		return;
@@ -1002,7 +1002,7 @@ void bs_echo_timer_handler(struct bfd_session *bs)
 	else
 		bs->echo_xmt_TO = bs->timers.required_min_echo;
 
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO_ACTIVE) == 0
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO_ACTIVE) == 0
 	    || old_timer != bs->echo_xmt_TO)
 		ptm_bfd_echo_start(bs);
 }
@@ -1241,7 +1241,7 @@ const char *bs_to_string(const struct bfd_session *bs)
 	static char buf[256];
 	char addr_buf[INET6_ADDRSTRLEN];
 	int pos;
-	bool is_mhop = BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH);
+	bool is_mhop = CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH);
 
 	pos = snprintf(buf, sizeof(buf), "mhop:%s", is_mhop ? "yes" : "no");
 	pos += snprintf(buf + pos, sizeof(buf) - pos, " peer:%s",
@@ -1644,11 +1644,11 @@ static void _bfd_session_remove_manual(struct hash_bucket *hb,
 	struct bfd_session *bs = hb->data;
 
 	/* Delete only manually configured sessions. */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG) == 0)
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG) == 0)
 		return;
 
 	bs->refcount--;
-	BFD_UNSET_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG);
+	UNSET_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG);
 
 	/* Don't delete sessions still in use. */
 	if (bs->refcount != 0)

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1032,20 +1032,19 @@ void bs_final_handler(struct bfd_session *bs)
 	}
 
 	/*
-	 * Calculate detection time based on new timers.
+	 * Calculate transmission time based on new timers.
 	 *
 	 * Transmission calculation:
-	 * We must respect the RequiredMinRxInterval from the remote
-	 * system: if our desired transmission timer is more than the
-	 * minimum receive rate, then we must lower it to at least the
-	 * minimum receive interval.
+	 * Unless specified by exceptions at the end of Section 6.8.7, the
+	 * transmission time will be determined by the system with the
+	 * slowest rate.
 	 *
-	 * RFC 5880, Section 6.8.3.
+	 * RFC 5880, Section 6.8.7.
 	 */
 	if (bs->timers.desired_min_tx > bs->remote_timers.required_min_rx)
-		bs->xmt_TO = bs->remote_timers.required_min_rx;
-	else
 		bs->xmt_TO = bs->timers.desired_min_tx;
+	else
+		bs->xmt_TO = bs->remote_timers.required_min_rx;
 
 	/* Apply new transmission timer immediately. */
 	ptm_bfd_start_xmt_timer(bs, false);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -172,10 +172,6 @@ enum bfd_session_flags {
 	BFD_SESS_FLAG_CBIT = 1 << 9,	/* CBIT is set */
 };
 
-#define BFD_SET_FLAG(field, flag) (field |= flag)
-#define BFD_UNSET_FLAG(field, flag) (field &= ~flag)
-#define BFD_CHECK_FLAG(field, flag) (field & flag)
-
 /* BFD session hash keys */
 struct bfd_key {
 	uint16_t family;

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -425,15 +425,9 @@ void pl_free(struct peer_label *pl);
 /*
  * logging - alias to zebra log
  */
-
-#define log_debug	zlog_debug
-#define log_info	zlog_info
-#define log_warning	zlog_warn
-#define log_error	zlog_err
-
-#define log_fatal(msg, ...)                                                    \
+#define zlog_fatal(msg, ...)                                                   \
 	do {                                                                   \
-		zlog_err(msg, ## __VA_ARGS__);                                 \
+		zlog_err(msg, ##__VA_ARGS__);                                  \
 		assert(!msg);                                                  \
 		abort();                                                       \
 	} while (0)

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -214,7 +214,7 @@ static int ptm_bfd_process_echo_pkt(struct bfd_vrf_global *bvrf, int s)
 
 void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 {
-	struct bfd_pkt cp;
+	struct bfd_pkt cp = {};
 
 	/* Set fields according to section 6.5.7 */
 	cp.diag = bfd->local_diag;

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -112,11 +112,11 @@ int _ptm_bfd_send(struct bfd_session *bs, uint16_t *port, const void *data,
 #endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 	rv = sendto(sd, data, datalen, 0, sa, slen);
 	if (rv <= 0) {
-		log_debug("packet-send: send failure: %s", strerror(errno));
+		zlog_debug("packet-send: send failure: %s", strerror(errno));
 		return -1;
 	}
 	if (rv < (ssize_t)datalen)
-		log_debug("packet-send: send partial: %s", strerror(errno));
+		zlog_debug("packet-send: send partial: %s", strerror(errno));
 
 	return 0;
 }
@@ -190,13 +190,14 @@ static int ptm_bfd_process_echo_pkt(struct bfd_vrf_global *bvrf, int s)
 	/* Your discriminator not zero - use it to find session */
 	bfd = bfd_id_lookup(my_discr);
 	if (bfd == NULL) {
-		log_debug("echo-packet: no matching session (id:%u)", my_discr);
+		zlog_debug("echo-packet: no matching session (id:%u)",
+			   my_discr);
 		return -1;
 	}
 
 	if (!CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE)) {
-		log_debug("echo-packet: echo disabled [%s] (id:%u)",
-			  bs_to_string(bfd), my_discr);
+		zlog_debug("echo-packet: echo disabled [%s] (id:%u)",
+			   bs_to_string(bfd), my_discr);
 		return -1;
 	}
 
@@ -291,8 +292,7 @@ ssize_t bfd_recv_ipv4(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
 	mlen = recvmsg(sd, &msghdr, MSG_DONTWAIT);
 	if (mlen == -1) {
 		if (errno != EAGAIN)
-			log_error("ipv4-recv: recv failed: %s",
-				  strerror(errno));
+			zlog_err("ipv4-recv: recv failed: %s", strerror(errno));
 
 		return -1;
 	}
@@ -313,7 +313,8 @@ ssize_t bfd_recv_ipv4(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
 
 			memcpy(&ttlval, CMSG_DATA(cm), sizeof(ttlval));
 			if (ttlval > 255) {
-				log_debug("ipv4-recv: invalid TTL: %u", ttlval);
+				zlog_debug("ipv4-recv: invalid TTL: %u",
+					   ttlval);
 				return -1;
 			}
 			*ttl = ttlval;
@@ -402,8 +403,7 @@ ssize_t bfd_recv_ipv6(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
 	mlen = recvmsg(sd, &msghdr6, MSG_DONTWAIT);
 	if (mlen == -1) {
 		if (errno != EAGAIN)
-			log_error("ipv6-recv: recv failed: %s",
-				  strerror(errno));
+			zlog_err("ipv6-recv: recv failed: %s", strerror(errno));
 
 		return -1;
 	}
@@ -420,7 +420,8 @@ ssize_t bfd_recv_ipv6(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
 		if (cm->cmsg_type == IPV6_HOPLIMIT) {
 			memcpy(&ttlval, CMSG_DATA(cm), sizeof(ttlval));
 			if (ttlval > 255) {
-				log_debug("ipv6-recv: invalid TTL: %u", ttlval);
+				zlog_debug("ipv6-recv: invalid TTL: %u",
+					   ttlval);
 				return -1;
 			}
 
@@ -511,8 +512,8 @@ static void cp_debug(bool mhop, struct sockaddr_any *peer,
 	vsnprintf(buf, sizeof(buf), fmt, vl);
 	va_end(vl);
 
-	log_debug("control-packet: %s [mhop:%s%s%s%s%s]", buf,
-		  mhop ? "yes" : "no", peerstr, localstr, portstr, vrfstr);
+	zlog_debug("control-packet: %s [mhop:%s%s%s%s%s]", buf,
+		   mhop ? "yes" : "no", peerstr, localstr, portstr, vrfstr);
 }
 
 int bfd_recv_cb(struct thread *t)
@@ -796,11 +797,12 @@ int bp_udp_send(int sd, uint8_t ttl, uint8_t *data, size_t datalen,
 	/* Send echo back. */
 	wlen = sendmsg(sd, &msg, 0);
 	if (wlen <= 0) {
-		log_debug("udp-send: loopback failure: (%d) %s", errno, strerror(errno));
+		zlog_debug("udp-send: loopback failure: (%d) %s", errno,
+			   strerror(errno));
 		return -1;
 	} else if (wlen < (ssize_t)datalen) {
-		log_debug("udp-send: partial send: %zd expected %zu", wlen,
-			  datalen);
+		zlog_debug("udp-send: partial send: %zd expected %zu", wlen,
+			   datalen);
 		return -1;
 	}
 
@@ -821,8 +823,8 @@ int bp_set_ttl(int sd, uint8_t value)
 	int ttl = value;
 
 	if (setsockopt(sd, IPPROTO_IP, IP_TTL, &ttl, sizeof(ttl)) == -1) {
-		log_warning("set-ttl: setsockopt(IP_TTL, %d): %s", value,
-			    strerror(errno));
+		zlog_warn("set-ttl: setsockopt(IP_TTL, %d): %s", value,
+			  strerror(errno));
 		return -1;
 	}
 
@@ -834,8 +836,8 @@ int bp_set_tos(int sd, uint8_t value)
 	int tos = value;
 
 	if (setsockopt(sd, IPPROTO_IP, IP_TOS, &tos, sizeof(tos)) == -1) {
-		log_warning("set-tos: setsockopt(IP_TOS, %d): %s", value,
-			    strerror(errno));
+		zlog_warn("set-tos: setsockopt(IP_TOS, %d): %s", value,
+			  strerror(errno));
 		return -1;
 	}
 
@@ -847,12 +849,12 @@ static void bp_set_ipopts(int sd)
 	int rcvttl = BFD_RCV_TTL_VAL;
 
 	if (bp_set_ttl(sd, BFD_TTL_VAL) != 0)
-		log_fatal("set-ipopts: TTL configuration failed");
+		zlog_fatal("set-ipopts: TTL configuration failed");
 
 	if (setsockopt(sd, IPPROTO_IP, IP_RECVTTL, &rcvttl, sizeof(rcvttl))
 	    == -1)
-		log_fatal("set-ipopts: setsockopt(IP_RECVTTL, %d): %s", rcvttl,
-			  strerror(errno));
+		zlog_fatal("set-ipopts: setsockopt(IP_RECVTTL, %d): %s", rcvttl,
+			   strerror(errno));
 
 #ifdef BFD_LINUX
 	int pktinfo = BFD_PKT_INFO_VAL;
@@ -860,21 +862,21 @@ static void bp_set_ipopts(int sd)
 	/* Figure out address and interface to do the peer matching. */
 	if (setsockopt(sd, IPPROTO_IP, IP_PKTINFO, &pktinfo, sizeof(pktinfo))
 	    == -1)
-		log_fatal("set-ipopts: setsockopt(IP_PKTINFO, %d): %s", pktinfo,
-			  strerror(errno));
+		zlog_fatal("set-ipopts: setsockopt(IP_PKTINFO, %d): %s",
+			   pktinfo, strerror(errno));
 #endif /* BFD_LINUX */
 #ifdef BFD_BSD
 	int yes = 1;
 
 	/* Find out our address for peer matching. */
 	if (setsockopt(sd, IPPROTO_IP, IP_RECVDSTADDR, &yes, sizeof(yes)) == -1)
-		log_fatal("set-ipopts: setsockopt(IP_RECVDSTADDR, %d): %s", yes,
-			  strerror(errno));
+		zlog_fatal("set-ipopts: setsockopt(IP_RECVDSTADDR, %d): %s",
+			   yes, strerror(errno));
 
 	/* Find out interface where the packet came in. */
 	if (setsockopt_ifindex(AF_INET, sd, yes) == -1)
-		log_fatal("set-ipopts: setsockopt_ipv4_ifindex(%d): %s", yes,
-			  strerror(errno));
+		zlog_fatal("set-ipopts: setsockopt_ipv4_ifindex(%d): %s", yes,
+			   strerror(errno));
 #endif /* BFD_BSD */
 }
 
@@ -887,7 +889,7 @@ static void bp_bind_ip(int sd, uint16_t port)
 	sin.sin_addr.s_addr = htonl(INADDR_ANY);
 	sin.sin_port = htons(port);
 	if (bind(sd, (struct sockaddr *)&sin, sizeof(sin)) == -1)
-		log_fatal("bind-ip: bind: %s", strerror(errno));
+		zlog_fatal("bind-ip: bind: %s", strerror(errno));
 }
 
 int bp_udp_shop(const struct vrf *vrf)
@@ -899,7 +901,7 @@ int bp_udp_shop(const struct vrf *vrf)
 				vrf->name);
 	}
 	if (sd == -1)
-		log_fatal("udp-shop: socket: %s", strerror(errno));
+		zlog_fatal("udp-shop: socket: %s", strerror(errno));
 
 	bp_set_ipopts(sd);
 	bp_bind_ip(sd, BFD_DEFDESTPORT);
@@ -915,7 +917,7 @@ int bp_udp_mhop(const struct vrf *vrf)
 				vrf->name);
 	}
 	if (sd == -1)
-		log_fatal("udp-mhop: socket: %s", strerror(errno));
+		zlog_fatal("udp-mhop: socket: %s", strerror(errno));
 
 	bp_set_ipopts(sd);
 	bp_bind_ip(sd, BFD_DEF_MHOP_DEST_PORT);
@@ -941,8 +943,8 @@ int bp_peer_socket(const struct bfd_session *bs)
 				bs->vrf->vrf_id, device_to_bind);
 	}
 	if (sd == -1) {
-		log_error("ipv4-new: failed to create socket: %s",
-			  strerror(errno));
+		zlog_err("ipv4-new: failed to create socket: %s",
+			 strerror(errno));
 		return -1;
 	}
 
@@ -972,8 +974,8 @@ int bp_peer_socket(const struct bfd_session *bs)
 	do {
 		if ((++pcount) > (BFD_SRCPORTMAX - BFD_SRCPORTINIT)) {
 			/* Searched all ports, none available */
-			log_error("ipv4-new: failed to bind port: %s",
-				  strerror(errno));
+			zlog_err("ipv4-new: failed to bind port: %s",
+				 strerror(errno));
 			close(sd);
 			return -1;
 		}
@@ -1008,8 +1010,8 @@ int bp_peer_socketv6(const struct bfd_session *bs)
 				bs->vrf->vrf_id, device_to_bind);
 	}
 	if (sd == -1) {
-		log_error("ipv6-new: failed to create socket: %s",
-			  strerror(errno));
+		zlog_err("ipv6-new: failed to create socket: %s",
+			 strerror(errno));
 		return -1;
 	}
 
@@ -1039,8 +1041,8 @@ int bp_peer_socketv6(const struct bfd_session *bs)
 	do {
 		if ((++pcount) > (BFD_SRCPORTMAX - BFD_SRCPORTINIT)) {
 			/* Searched all ports, none available */
-			log_error("ipv6-new: failed to bind port: %s",
-				  strerror(errno));
+			zlog_err("ipv6-new: failed to bind port: %s",
+				 strerror(errno));
 			close(sd);
 			return -1;
 		}
@@ -1058,8 +1060,8 @@ int bp_set_ttlv6(int sd, uint8_t value)
 
 	if (setsockopt(sd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &ttl, sizeof(ttl))
 	    == -1) {
-		log_warning("set-ttlv6: setsockopt(IPV6_UNICAST_HOPS, %d): %s",
-			    value, strerror(errno));
+		zlog_warn("set-ttlv6: setsockopt(IPV6_UNICAST_HOPS, %d): %s",
+			  value, strerror(errno));
 		return -1;
 	}
 
@@ -1072,8 +1074,8 @@ int bp_set_tosv6(int sd, uint8_t value)
 
 	if (setsockopt(sd, IPPROTO_IPV6, IPV6_TCLASS, &tos, sizeof(tos))
 	    == -1) {
-		log_warning("set-tosv6: setsockopt(IPV6_TCLASS, %d): %s", value,
-			    strerror(errno));
+		zlog_warn("set-tosv6: setsockopt(IPV6_TCLASS, %d): %s", value,
+			  strerror(errno));
 		return -1;
 	}
 
@@ -1086,22 +1088,23 @@ static void bp_set_ipv6opts(int sd)
 	int ipv6_only = BFD_IPV6_ONLY_VAL;
 
 	if (bp_set_ttlv6(sd, BFD_TTL_VAL) == -1)
-		log_fatal("set-ipv6opts: setsockopt(IPV6_UNICAST_HOPS, %d): %s",
-			  BFD_TTL_VAL, strerror(errno));
+		zlog_fatal(
+			"set-ipv6opts: setsockopt(IPV6_UNICAST_HOPS, %d): %s",
+			BFD_TTL_VAL, strerror(errno));
 
 	if (setsockopt_ipv6_hoplimit(sd, BFD_RCV_TTL_VAL) == -1)
-		log_fatal("set-ipv6opts: setsockopt(IPV6_HOPLIMIT, %d): %s",
-			  BFD_RCV_TTL_VAL, strerror(errno));
+		zlog_fatal("set-ipv6opts: setsockopt(IPV6_HOPLIMIT, %d): %s",
+			   BFD_RCV_TTL_VAL, strerror(errno));
 
 	if (setsockopt_ipv6_pktinfo(sd, ipv6_pktinfo) == -1)
-		log_fatal("set-ipv6opts: setsockopt(IPV6_PKTINFO, %d): %s",
-			  ipv6_pktinfo, strerror(errno));
+		zlog_fatal("set-ipv6opts: setsockopt(IPV6_PKTINFO, %d): %s",
+			   ipv6_pktinfo, strerror(errno));
 
 	if (setsockopt(sd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_only,
 		       sizeof(ipv6_only))
 	    == -1)
-		log_fatal("set-ipv6opts: setsockopt(IPV6_V6ONLY, %d): %s",
-			  ipv6_only, strerror(errno));
+		zlog_fatal("set-ipv6opts: setsockopt(IPV6_V6ONLY, %d): %s",
+			   ipv6_only, strerror(errno));
 }
 
 static void bp_bind_ipv6(int sd, uint16_t port)
@@ -1116,7 +1119,7 @@ static void bp_bind_ipv6(int sd, uint16_t port)
 	sin6.sin6_len = sizeof(sin6);
 #endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 	if (bind(sd, (struct sockaddr *)&sin6, sizeof(sin6)) == -1)
-		log_fatal("bind-ipv6: bind: %s", strerror(errno));
+		zlog_fatal("bind-ipv6: bind: %s", strerror(errno));
 }
 
 int bp_udp6_shop(const struct vrf *vrf)
@@ -1128,7 +1131,7 @@ int bp_udp6_shop(const struct vrf *vrf)
 				vrf->name);
 	}
 	if (sd == -1)
-		log_fatal("udp6-shop: socket: %s", strerror(errno));
+		zlog_fatal("udp6-shop: socket: %s", strerror(errno));
 
 	bp_set_ipv6opts(sd);
 	bp_bind_ipv6(sd, BFD_DEFDESTPORT);
@@ -1145,7 +1148,7 @@ int bp_udp6_mhop(const struct vrf *vrf)
 				vrf->name);
 	}
 	if (sd == -1)
-		log_fatal("udp6-mhop: socket: %s", strerror(errno));
+		zlog_fatal("udp6-mhop: socket: %s", strerror(errno));
 
 	bp_set_ipv6opts(sd);
 	bp_bind_ipv6(sd, BFD_DEF_MHOP_DEST_PORT);
@@ -1161,7 +1164,7 @@ int bp_echo_socket(const struct vrf *vrf)
 		s = vrf_socket(AF_INET, SOCK_DGRAM, 0, vrf->vrf_id, vrf->name);
 	}
 	if (s == -1)
-		log_fatal("echo-socket: socket: %s", strerror(errno));
+		zlog_fatal("echo-socket: socket: %s", strerror(errno));
 
 	bp_set_ipopts(s);
 	bp_bind_ip(s, BFD_DEF_ECHO_PORT);
@@ -1177,7 +1180,7 @@ int bp_echov6_socket(const struct vrf *vrf)
 		s = vrf_socket(AF_INET6, SOCK_DGRAM, 0, vrf->vrf_id, vrf->name);
 	}
 	if (s == -1)
-		log_fatal("echov6-socket: socket: %s", strerror(errno));
+		zlog_fatal("echov6-socket: socket: %s", strerror(errno));
 
 	bp_set_ipv6opts(s);
 	bp_bind_ipv6(s, BFD_DEF_ECHO_PORT);

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -76,7 +76,7 @@ int _ptm_bfd_send(struct bfd_session *bs, uint16_t *port, const void *data,
 	ssize_t rv;
 	int sd = -1;
 
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_IPV6)) {
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_IPV6)) {
 		memset(&sin6, 0, sizeof(sin6));
 		sin6.sin6_family = AF_INET6;
 		memcpy(&sin6.sin6_addr, &bs->key.peer, sizeof(sin6.sin6_addr));
@@ -85,7 +85,7 @@ int _ptm_bfd_send(struct bfd_session *bs, uint16_t *port, const void *data,
 
 		sin6.sin6_port =
 			(port) ? *port
-			       : (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH))
+			       : (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH))
 					 ? htons(BFD_DEF_MHOP_DEST_PORT)
 					 : htons(BFD_DEFDESTPORT);
 
@@ -98,7 +98,7 @@ int _ptm_bfd_send(struct bfd_session *bs, uint16_t *port, const void *data,
 		memcpy(&sin.sin_addr, &bs->key.peer, sizeof(sin.sin_addr));
 		sin.sin_port =
 			(port) ? *port
-			       : (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH))
+			       : (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH))
 					 ? htons(BFD_DEF_MHOP_DEST_PORT)
 					 : htons(BFD_DEFDESTPORT);
 
@@ -133,15 +133,15 @@ void ptm_bfd_echo_snd(struct bfd_session *bfd)
 
 	if (!bvrf)
 		return;
-	if (!BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE))
-		BFD_SET_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE);
+	if (!CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE))
+		SET_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE);
 
 	memset(&bep, 0, sizeof(bep));
 	bep.ver = BFD_ECHO_VERSION;
 	bep.len = BFD_ECHO_PKT_LEN;
 	bep.my_discr = htonl(bfd->discrs.my_discr);
 
-	if (BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_IPV6)) {
+	if (CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_IPV6)) {
 		sd = bvrf->bg_echov6;
 		memset(&sin6, 0, sizeof(sin6));
 		sin6.sin6_family = AF_INET6;
@@ -194,7 +194,7 @@ static int ptm_bfd_process_echo_pkt(struct bfd_vrf_global *bvrf, int s)
 		return -1;
 	}
 
-	if (!BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE)) {
+	if (!CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_ECHO_ACTIVE)) {
 		log_debug("echo-packet: echo disabled [%s] (id:%u)",
 			  bs_to_string(bfd), my_discr);
 		return -1;
@@ -222,7 +222,7 @@ void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 	cp.flags = 0;
 	BFD_SETSTATE(cp.flags, bfd->ses_state);
 
-	if (BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_CBIT))
+	if (CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_CBIT))
 		BFD_SETCBIT(cp.flags, BFD_CBIT);
 
 	BFD_SETDEMANDBIT(cp.flags, BFD_DEF_DEMAND);
@@ -932,7 +932,7 @@ int bp_peer_socket(const struct bfd_session *bs)
 
 	if (bs->key.ifname[0])
 		device_to_bind = (const char *)bs->key.ifname;
-	else if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)
+	else if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)
 	    && bs->key.vrfname[0])
 		device_to_bind = (const char *)bs->key.vrfname;
 
@@ -965,7 +965,7 @@ int bp_peer_socket(const struct bfd_session *bs)
 	sin.sin_len = sizeof(sin);
 #endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 	memcpy(&sin.sin_addr, &bs->key.local, sizeof(sin.sin_addr));
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH) == 0)
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH) == 0)
 		sin.sin_addr.s_addr = INADDR_ANY;
 
 	pcount = 0;
@@ -999,7 +999,7 @@ int bp_peer_socketv6(const struct bfd_session *bs)
 
 	if (bs->key.ifname[0])
 		device_to_bind = (const char *)bs->key.ifname;
-	else if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)
+	else if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)
 	    && bs->key.vrfname[0])
 		device_to_bind = (const char *)bs->key.vrfname;
 

--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -49,8 +49,8 @@ void socket_close(int *s)
 		return;
 
 	if (close(*s) != 0)
-		log_error("%s: close(%d): (%d) %s", __func__, *s, errno,
-			  strerror(errno));
+		zlog_err("%s: close(%d): (%d) %s", __func__, *s, errno,
+			 strerror(errno));
 
 	*s = -1;
 }

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -99,7 +99,7 @@ static int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
 		/* This session was already configured by another daemon. */
 		if (bs != NULL) {
 			/* Now it is configured also by CLI. */
-			BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG);
+			SET_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG);
 			bs->refcount++;
 
 			resource->ptr = bs;
@@ -115,11 +115,11 @@ static int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
 
 		/* Set configuration flags. */
 		bs->refcount = 1;
-		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG);
+		SET_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG);
 		if (mhop)
-			BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_MH);
+			SET_FLAG(bs->flags, BFD_SESS_FLAG_MH);
 		if (bs->key.family == AF_INET6)
-			BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_IPV6);
+			SET_FLAG(bs->flags, BFD_SESS_FLAG_IPV6);
 
 		resource->ptr = bs;
 		break;
@@ -164,10 +164,10 @@ static int bfd_session_destroy(enum nb_event event,
 	case NB_EV_APPLY:
 		bs = nb_running_unset_entry(dnode);
 		/* CLI is not using this session anymore. */
-		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG) == 0)
+		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG) == 0)
 			break;
 
-		BFD_UNSET_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG);
+		UNSET_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG);
 		bs->refcount--;
 		/* There are still daemons using it. */
 		if (bs->refcount > 0)
@@ -384,10 +384,10 @@ int bfdd_bfd_sessions_single_hop_administrative_down_modify(
 	bs = nb_running_get_entry(dnode, NULL, true);
 
 	if (!shutdown) {
-		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+		if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 			return NB_OK;
 
-		BFD_UNSET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
+		UNSET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
 
 		/* Change and notify state change. */
 		bs->ses_state = PTM_BFD_DOWN;
@@ -396,15 +396,15 @@ int bfdd_bfd_sessions_single_hop_administrative_down_modify(
 		/* Enable all timers. */
 		bfd_recvtimer_update(bs);
 		bfd_xmttimer_update(bs, bs->xmt_TO);
-		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO)) {
+		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO)) {
 			bfd_echo_recvtimer_update(bs);
 			bfd_echo_xmttimer_update(bs, bs->echo_xmt_TO);
 		}
 	} else {
-		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 			return NB_OK;
 
-		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
+		SET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
 
 		/* Disable all events. */
 		bfd_recvtimer_delete(bs);
@@ -448,18 +448,18 @@ int bfdd_bfd_sessions_single_hop_echo_mode_modify(enum nb_event event,
 	bs = nb_running_get_entry(dnode, NULL, true);
 
 	if (!echo) {
-		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+		if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
 			return NB_OK;
 
-		BFD_UNSET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
+		UNSET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
 		ptm_bfd_echo_stop(bs);
 	} else {
-		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
 			return NB_OK;
 
-		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
+		SET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
 		/* Apply setting immediately. */
-		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+		if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 			bs_echo_timer_handler(bs);
 	}
 

--- a/bfdd/bfdd_nb_state.c
+++ b/bfdd/bfdd_nb_state.c
@@ -211,7 +211,7 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem(
 	 *
 	 * TODO: support demand mode.
 	 */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
 		detection_mode = 1;
 	else
 		detection_mode = 2;

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -84,7 +84,7 @@ static void _display_peer_header(struct vty *vty, struct bfd_session *bs)
 		inet_ntop(bs->key.family, &bs->key.peer, addr_buf,
 			  sizeof(addr_buf)));
 
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH))
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH))
 		vty_out(vty, " multihop");
 
 	if (memcmp(&bs->key.local, &zero_addr, sizeof(bs->key.local)))
@@ -143,7 +143,7 @@ static void _display_peer(struct vty *vty, struct bfd_session *bs)
 	vty_out(vty, "\t\tDiagnostics: %s\n", diag2str(bs->local_diag));
 	vty_out(vty, "\t\tRemote diagnostics: %s\n", diag2str(bs->remote_diag));
 	vty_out(vty, "\t\tPeer Type: %s\n",
-		BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG) ? "configured" : "dynamic");
+		CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG) ? "configured" : "dynamic");
 
 	vty_out(vty, "\t\tLocal timers:\n");
 	vty_out(vty, "\t\t\tDetect-multiplier: %" PRIu32 "\n",
@@ -235,7 +235,7 @@ static struct json_object *__display_peer_json(struct bfd_session *bs)
 			    bs->timers.required_min_rx / 1000);
 	json_object_int_add(jo, "transmit-interval",
 			    bs->timers.desired_min_tx / 1000);
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
 		json_object_int_add(jo, "echo-interval",
 				    bs->timers.required_min_echo / 1000);
 	else
@@ -457,7 +457,7 @@ static void _display_peer_brief(struct vty *vty, struct bfd_session *bs)
 {
 	char addr_buf[INET6_ADDRSTRLEN];
 
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)) {
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)) {
 		vty_out(vty, "%-10u", bs->discrs.my_discr);
 		inet_ntop(bs->key.family, &bs->key.local, addr_buf, sizeof(addr_buf));
 		vty_out(vty, " %-40s", addr_buf);

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -305,7 +305,7 @@ static void _display_peer_json_iter(struct hash_bucket *hb, void *arg)
 
 	jon = __display_peer_json(bs);
 	if (jon == NULL) {
-		log_warning("%s: not enough memory", __func__);
+		zlog_warn("%s: not enough memory", __func__);
 		return;
 	}
 
@@ -415,7 +415,7 @@ static void _display_peer_counter_json_iter(struct hash_bucket *hb, void *arg)
 
 	jon = __display_peer_counters_json(bs);
 	if (jon == NULL) {
-		log_warning("%s: not enough memory", __func__);
+		zlog_warn("%s: not enough memory", __func__);
 		return;
 	}
 

--- a/bfdd/config.c
+++ b/bfdd/config.c
@@ -92,8 +92,8 @@ static int parse_config_json(struct json_object *jo, bpc_handle h, void *arg)
 			error += parse_list(jo_val, PLT_LABEL, h, arg);
 		} else {
 			sval = json_object_get_string(jo_val);
-			log_warning("%s:%d invalid configuration: %s", __func__,
-				    __LINE__, sval);
+			zlog_warn("%s:%d invalid configuration: %s", __func__,
+				  __LINE__, sval);
 			error++;
 		}
 	}
@@ -139,15 +139,15 @@ static int parse_list(struct json_object *jo, enum peer_list_type plt,
 
 		switch (plt) {
 		case PLT_IPV4:
-			log_debug("ipv4 peers %d:", allen);
+			zlog_debug("ipv4 peers %d:", allen);
 			bpc.bpc_ipv4 = true;
 			break;
 		case PLT_IPV6:
-			log_debug("ipv6 peers %d:", allen);
+			zlog_debug("ipv6 peers %d:", allen);
 			bpc.bpc_ipv4 = false;
 			break;
 		case PLT_LABEL:
-			log_debug("label peers %d:", allen);
+			zlog_debug("label peers %d:", allen);
 			if (parse_peer_label_config(jo_val, &bpc) != 0) {
 				error++;
 				continue;
@@ -156,8 +156,8 @@ static int parse_list(struct json_object *jo, enum peer_list_type plt,
 
 		default:
 			error++;
-			log_error("%s:%d: unsupported peer type", __func__,
-				  __LINE__);
+			zlog_err("%s:%d: unsupported peer type", __func__,
+				 __LINE__);
 			break;
 		}
 
@@ -178,7 +178,7 @@ static int parse_peer_config(struct json_object *jo, struct bfd_peer_cfg *bpc)
 	int family_type = (bpc->bpc_ipv4) ? AF_INET : AF_INET6;
 	int error = 0;
 
-	log_debug("        peer: %s", bpc->bpc_ipv4 ? "ipv4" : "ipv6");
+	zlog_debug("        peer: %s", bpc->bpc_ipv4 ? "ipv4" : "ipv6");
 
 	JSON_FOREACH (jo, joi, join) {
 		key = json_object_iter_peek_name(&joi);
@@ -186,41 +186,41 @@ static int parse_peer_config(struct json_object *jo, struct bfd_peer_cfg *bpc)
 
 		if (strcmp(key, "multihop") == 0) {
 			bpc->bpc_mhop = json_object_get_boolean(jo_val);
-			log_debug("        multihop: %s",
-				  bpc->bpc_mhop ? "true" : "false");
+			zlog_debug("        multihop: %s",
+				   bpc->bpc_mhop ? "true" : "false");
 		} else if (strcmp(key, "peer-address") == 0) {
 			sval = json_object_get_string(jo_val);
 			if (strtosa(sval, &bpc->bpc_peer) != 0
 			    || bpc->bpc_peer.sa_sin.sin_family != family_type) {
-				log_info(
+				zlog_debug(
 					"%s:%d failed to parse peer-address '%s'",
 					__func__, __LINE__, sval);
 				error++;
 			}
-			log_debug("        peer-address: %s", sval);
+			zlog_debug("        peer-address: %s", sval);
 		} else if (strcmp(key, "local-address") == 0) {
 			sval = json_object_get_string(jo_val);
 			if (strtosa(sval, &bpc->bpc_local) != 0
 			    || bpc->bpc_local.sa_sin.sin_family
 				       != family_type) {
-				log_info(
+				zlog_debug(
 					"%s:%d failed to parse local-address '%s'",
 					__func__, __LINE__, sval);
 				error++;
 			}
-			log_debug("        local-address: %s", sval);
+			zlog_debug("        local-address: %s", sval);
 		} else if (strcmp(key, "local-interface") == 0) {
 			bpc->bpc_has_localif = true;
 			sval = json_object_get_string(jo_val);
 			if (strlcpy(bpc->bpc_localif, sval,
 				    sizeof(bpc->bpc_localif))
 			    > sizeof(bpc->bpc_localif)) {
-				log_debug(
+				zlog_debug(
 					"        local-interface: %s (truncated)",
 					sval);
 				error++;
 			} else {
-				log_debug("        local-interface: %s", sval);
+				zlog_debug("        local-interface: %s", sval);
 			}
 		} else if (strcmp(key, "vrf-name") == 0) {
 			bpc->bpc_has_vrfname = true;
@@ -228,67 +228,68 @@ static int parse_peer_config(struct json_object *jo, struct bfd_peer_cfg *bpc)
 			if (strlcpy(bpc->bpc_vrfname, sval,
 				    sizeof(bpc->bpc_vrfname))
 			    > sizeof(bpc->bpc_vrfname)) {
-				log_debug("        vrf-name: %s (truncated)",
-					  sval);
+				zlog_debug("        vrf-name: %s (truncated)",
+					   sval);
 				error++;
 			} else {
-				log_debug("        vrf-name: %s", sval);
+				zlog_debug("        vrf-name: %s", sval);
 			}
 		} else if (strcmp(key, "detect-multiplier") == 0) {
 			bpc->bpc_detectmultiplier =
 				json_object_get_int64(jo_val);
 			bpc->bpc_has_detectmultiplier = true;
-			log_debug("        detect-multiplier: %u",
-				  bpc->bpc_detectmultiplier);
+			zlog_debug("        detect-multiplier: %u",
+				   bpc->bpc_detectmultiplier);
 		} else if (strcmp(key, "receive-interval") == 0) {
 			bpc->bpc_recvinterval = json_object_get_int64(jo_val);
 			bpc->bpc_has_recvinterval = true;
-			log_debug("        receive-interval: %" PRIu64,
-				  bpc->bpc_recvinterval);
+			zlog_debug("        receive-interval: %" PRIu64,
+				   bpc->bpc_recvinterval);
 		} else if (strcmp(key, "transmit-interval") == 0) {
 			bpc->bpc_txinterval = json_object_get_int64(jo_val);
 			bpc->bpc_has_txinterval = true;
-			log_debug("        transmit-interval: %" PRIu64,
-				  bpc->bpc_txinterval);
+			zlog_debug("        transmit-interval: %" PRIu64,
+				   bpc->bpc_txinterval);
 		} else if (strcmp(key, "echo-interval") == 0) {
 			bpc->bpc_echointerval = json_object_get_int64(jo_val);
 			bpc->bpc_has_echointerval = true;
-			log_debug("        echo-interval: %" PRIu64,
-				  bpc->bpc_echointerval);
+			zlog_debug("        echo-interval: %" PRIu64,
+				   bpc->bpc_echointerval);
 		} else if (strcmp(key, "create-only") == 0) {
 			bpc->bpc_createonly = json_object_get_boolean(jo_val);
-			log_debug("        create-only: %s",
-				  bpc->bpc_createonly ? "true" : "false");
+			zlog_debug("        create-only: %s",
+				   bpc->bpc_createonly ? "true" : "false");
 		} else if (strcmp(key, "shutdown") == 0) {
 			bpc->bpc_shutdown = json_object_get_boolean(jo_val);
-			log_debug("        shutdown: %s",
-				  bpc->bpc_shutdown ? "true" : "false");
+			zlog_debug("        shutdown: %s",
+				   bpc->bpc_shutdown ? "true" : "false");
 		} else if (strcmp(key, "echo-mode") == 0) {
 			bpc->bpc_echo = json_object_get_boolean(jo_val);
-			log_debug("        echo-mode: %s",
-				  bpc->bpc_echo ? "true" : "false");
+			zlog_debug("        echo-mode: %s",
+				   bpc->bpc_echo ? "true" : "false");
 		} else if (strcmp(key, "label") == 0) {
 			bpc->bpc_has_label = true;
 			sval = json_object_get_string(jo_val);
 			if (strlcpy(bpc->bpc_label, sval,
 				    sizeof(bpc->bpc_label))
 			    > sizeof(bpc->bpc_label)) {
-				log_debug("        label: %s (truncated)",
-					  sval);
+				zlog_debug("        label: %s (truncated)",
+					   sval);
 				error++;
 			} else {
-				log_debug("        label: %s", sval);
+				zlog_debug("        label: %s", sval);
 			}
 		} else {
 			sval = json_object_get_string(jo_val);
-			log_warning("%s:%d invalid configuration: '%s: %s'",
-				    __func__, __LINE__, key, sval);
+			zlog_warn("%s:%d invalid configuration: '%s: %s'",
+				  __func__, __LINE__, key, sval);
 			error++;
 		}
 	}
 
 	if (bpc->bpc_peer.sa_sin.sin_family == 0) {
-		log_debug("%s:%d no peer address provided", __func__, __LINE__);
+		zlog_debug("%s:%d no peer address provided", __func__,
+			   __LINE__);
 		error++;
 	}
 
@@ -312,7 +313,7 @@ static int parse_peer_label_config(struct json_object *jo,
 	if (pl == NULL)
 		return 1;
 
-	log_debug("        peer-label: %s", sval);
+	zlog_debug("        peer-label: %s", sval);
 
 	/* Translate the label into BFD address keys. */
 	bs_to_bpc(pl->pl_bs, bpc);
@@ -573,7 +574,7 @@ struct peer_label *pl_new(const char *label, struct bfd_session *bs)
 
 	if (strlcpy(pl->pl_label, label, sizeof(pl->pl_label))
 	    > sizeof(pl->pl_label))
-		log_warning("%s:%d: label was truncated", __func__, __LINE__);
+		zlog_warn("%s:%d: label was truncated", __func__, __LINE__);
 
 	pl->pl_bs = bs;
 	bs->pl = pl;

--- a/bfdd/config.c
+++ b/bfdd/config.c
@@ -474,12 +474,12 @@ char *config_notify_config(const char *op, struct bfd_session *bs)
 	json_object_int_add(resp, "remote-echo-interval",
 			    bs->remote_timers.required_min_echo / 1000);
 
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
 		json_object_boolean_true_add(resp, "echo-mode");
 	else
 		json_object_boolean_false_add(resp, "echo-mode");
 
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 		json_object_boolean_true_add(resp, "shutdown");
 	else
 		json_object_boolean_false_add(resp, "shutdown");
@@ -511,12 +511,12 @@ static int json_object_add_peer(struct json_object *jo, struct bfd_session *bs)
 	char addr_buf[INET6_ADDRSTRLEN];
 
 	/* Add peer 'key' information. */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_IPV6))
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_IPV6))
 		json_object_boolean_true_add(jo, "ipv6");
 	else
 		json_object_boolean_false_add(jo, "ipv6");
 
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)) {
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)) {
 		json_object_boolean_true_add(jo, "multihop");
 		json_object_string_add(jo, "peer-address",
 				       inet_ntop(bs->key.family, &bs->key.peer,

--- a/bfdd/event.c
+++ b/bfdd/event.c
@@ -43,7 +43,7 @@ void bfd_recvtimer_update(struct bfd_session *bs)
 	bfd_recvtimer_delete(bs);
 
 	/* Don't add event if peer is deactivated. */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
 	    bs->sock == -1)
 		return;
 
@@ -64,7 +64,7 @@ void bfd_echo_recvtimer_update(struct bfd_session *bs)
 	bfd_echo_recvtimer_delete(bs);
 
 	/* Don't add event if peer is deactivated. */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
 	    bs->sock == -1)
 		return;
 
@@ -85,7 +85,7 @@ void bfd_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 	bfd_xmttimer_delete(bs);
 
 	/* Don't add event if peer is deactivated. */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
 	    bs->sock == -1)
 		return;
 
@@ -105,7 +105,7 @@ void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 	bfd_echo_xmttimer_delete(bs);
 
 	/* Don't add event if peer is deactivated. */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
 	    bs->sock == -1)
 		return;
 

--- a/bfdd/event.c
+++ b/bfdd/event.c
@@ -49,7 +49,8 @@ void bfd_recvtimer_update(struct bfd_session *bs)
 
 	tv_normalize(&tv);
 #ifdef BFD_EVENT_DEBUG
-	log_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec, tv.tv_usec);
+	zlog_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec,
+		   tv.tv_usec);
 #endif /* BFD_EVENT_DEBUG */
 
 	thread_add_timer_tv(master, bfd_recvtimer_cb, bs, &tv,
@@ -70,7 +71,8 @@ void bfd_echo_recvtimer_update(struct bfd_session *bs)
 
 	tv_normalize(&tv);
 #ifdef BFD_EVENT_DEBUG
-	log_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec, tv.tv_usec);
+	zlog_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec,
+		   tv.tv_usec);
 #endif /* BFD_EVENT_DEBUG */
 
 	thread_add_timer_tv(master, bfd_echo_recvtimer_cb, bs, &tv,
@@ -91,7 +93,8 @@ void bfd_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 
 	tv_normalize(&tv);
 #ifdef BFD_EVENT_DEBUG
-	log_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec, tv.tv_usec);
+	zlog_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec,
+		   tv.tv_usec);
 #endif /* BFD_EVENT_DEBUG */
 
 	thread_add_timer_tv(master, bfd_xmt_cb, bs, &tv, &bs->xmttimer_ev);
@@ -111,7 +114,8 @@ void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 
 	tv_normalize(&tv);
 #ifdef BFD_EVENT_DEBUG
-	log_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec, tv.tv_usec);
+	zlog_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec,
+		   tv.tv_usec);
 #endif /* BFD_EVENT_DEBUG */
 
 	thread_add_timer_tv(master, bfd_echo_xmt_cb, bs, &tv,

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -120,9 +120,9 @@ static void debug_printbpc(const char *func, unsigned int line,
 
 	sprintf(cbit_str, "CB %x", bpc->bpc_cbit);
 
-	log_debug("%s:%d: %s %s%s%s%s%s%s %s", func, line,
-		  bpc->bpc_mhop ? "multi-hop" : "single-hop", addr[0], addr[1],
-		  addr[2], timers[0], timers[1], timers[2], cbit_str);
+	zlog_debug("%s:%d: %s %s%s%s%s%s%s %s", func, line,
+		   bpc->bpc_mhop ? "multi-hop" : "single-hop", addr[0], addr[1],
+		   addr[2], timers[0], timers[1], timers[2], cbit_str);
 }
 
 #define DEBUG_PRINTBPC(bpc) debug_printbpc(__FILE__, __LINE__, (bpc))
@@ -260,7 +260,7 @@ static void _ptm_msg_read_address(struct stream *msg, struct sockaddr_any *sa)
 		return;
 
 	default:
-		log_warning("ptm-read-address: invalid family: %d", family);
+		zlog_warn("ptm-read-address: invalid family: %d", family);
 		break;
 	}
 
@@ -316,7 +316,7 @@ static int _ptm_msg_read(struct stream *msg, int command, vrf_id_t vrf_id,
 
 	*pc = pc_new(pid);
 	if (*pc == NULL) {
-		log_debug("ptm-read: failed to allocate memory");
+		zlog_debug("ptm-read: failed to allocate memory");
 		return -1;
 	}
 
@@ -358,7 +358,7 @@ static int _ptm_msg_read(struct stream *msg, int command, vrf_id_t vrf_id,
 		 */
 		STREAM_GETC(msg, ifnamelen);
 		if (ifnamelen >= sizeof(bpc->bpc_localif)) {
-			log_error("ptm-read: interface name is too big");
+			zlog_err("ptm-read: interface name is too big");
 			return -1;
 		}
 
@@ -376,7 +376,8 @@ static int _ptm_msg_read(struct stream *msg, int command, vrf_id_t vrf_id,
 			bpc->bpc_has_vrfname = true;
 			strlcpy(bpc->bpc_vrfname, vrf->name, sizeof(bpc->bpc_vrfname));
 		} else {
-			log_error("ptm-read: vrf id %u could not be identified", vrf_id);
+			zlog_err("ptm-read: vrf id %u could not be identified",
+				 vrf_id);
 			return -1;
 		}
 	} else {
@@ -390,7 +391,7 @@ static int _ptm_msg_read(struct stream *msg, int command, vrf_id_t vrf_id,
 	if (bpc->bpc_local.sa_sin.sin_family != 0
 	    && (bpc->bpc_local.sa_sin.sin_family
 		!= bpc->bpc_peer.sa_sin.sin_family)) {
-		log_warning("ptm-read: peer family doesn't match local type");
+		zlog_warn("ptm-read: peer family doesn't match local type");
 		return -1;
 	}
 
@@ -418,7 +419,8 @@ static void bfdd_dest_register(struct stream *msg, vrf_id_t vrf_id)
 	if (bs == NULL) {
 		bs = ptm_bfd_sess_new(&bpc);
 		if (bs == NULL) {
-			log_debug("ptm-add-dest: failed to create BFD session");
+			zlog_debug(
+				"ptm-add-dest: failed to create BFD session");
 			return;
 		}
 	} else {
@@ -431,7 +433,7 @@ static void bfdd_dest_register(struct stream *msg, vrf_id_t vrf_id)
 	/* Create client peer notification register. */
 	pcn = pcn_new(pc, bs);
 	if (pcn == NULL) {
-		log_error("ptm-add-dest: failed to registrate notifications");
+		zlog_err("ptm-add-dest: failed to registrate notifications");
 		return;
 	}
 
@@ -454,7 +456,7 @@ static void bfdd_dest_deregister(struct stream *msg, vrf_id_t vrf_id)
 	/* Find or start new BFD session. */
 	bs = bs_peer_find(&bpc);
 	if (bs == NULL) {
-		log_debug("ptm-del-dest: failed to find BFD session");
+		zlog_debug("ptm-del-dest: failed to find BFD session");
 		return;
 	}
 
@@ -485,14 +487,14 @@ static void bfdd_client_register(struct stream *msg)
 
 	pc = pc_new(pid);
 	if (pc == NULL) {
-		log_error("ptm-add-client: failed to register client: %u", pid);
+		zlog_err("ptm-add-client: failed to register client: %u", pid);
 		return;
 	}
 
 	return;
 
 stream_failure:
-	log_error("ptm-add-client: failed to register client");
+	zlog_err("ptm-add-client: failed to register client");
 }
 
 /*
@@ -509,7 +511,7 @@ static void bfdd_client_deregister(struct stream *msg)
 
 	pc = pc_lookup(pid);
 	if (pc == NULL) {
-		log_debug("ptm-del-client: failed to find client: %u", pid);
+		zlog_debug("ptm-del-client: failed to find client: %u", pid);
 		return;
 	}
 
@@ -518,7 +520,7 @@ static void bfdd_client_deregister(struct stream *msg)
 	return;
 
 stream_failure:
-	log_error("ptm-del-client: failed to deregister client");
+	zlog_err("ptm-del-client: failed to deregister client");
 }
 
 static int bfdd_replay(ZAPI_CALLBACK_ARGS)
@@ -544,14 +546,14 @@ static int bfdd_replay(ZAPI_CALLBACK_ARGS)
 		break;
 
 	default:
-		log_debug("ptm-replay: invalid message type %u", rcmd);
+		zlog_debug("ptm-replay: invalid message type %u", rcmd);
 		return -1;
 	}
 
 	return 0;
 
 stream_failure:
-	log_error("ptm-replay: failed to find command");
+	zlog_err("ptm-replay: failed to find command");
 	return -1;
 }
 

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -423,9 +423,9 @@ static void bfdd_dest_register(struct stream *msg, vrf_id_t vrf_id)
 		}
 	} else {
 		/* Don't try to change echo/shutdown state. */
-		bpc.bpc_echo = BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
+		bpc.bpc_echo = CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
 		bpc.bpc_shutdown =
-			BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
+			CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
 	}
 
 	/* Create client peer notification register. */
@@ -462,7 +462,7 @@ static void bfdd_dest_deregister(struct stream *msg, vrf_id_t vrf_id)
 	pcn = pcn_lookup(pc, bs);
 	pcn_free(pcn);
 	if (bs->refcount ||
-	    BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG))
+	    CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG))
 		return;
 
 	bs->ses_state = PTM_BFD_ADM_DOWN;


### PR DESCRIPTION
## Summary

This PR brings `bfdd` code closer to the rest of the FRR daemons by removing some old abstractions and fixes two potential issues.

* Replace `BFD_*_FLAG` with FRR's `*_FLAG`.
* Remove `log_*` with FRR's `zlog_*`.
* Always initialize packet buffer with zeroes.
* Fix transmission time calculation ( fixes #5712 ).