### PR TITLE
yang: use the correct type for EIGRP neighbors

### DIFF
--- a/yang/frr-eigrpd.yang
+++ b/yang/frr-eigrpd.yang
@@ -191,7 +191,7 @@ module frr-eigrpd {
 
       leaf-list neighbor {
         description "Specific EIGRP neighbor";
-        type inet:ipv4-prefix;
+        type inet:ipv4-address;
       }
 
       list redistribute {


### PR DESCRIPTION
Fixes #6193.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>