### PR TITLE
pimd: test command to stop/allow ageing of sg entries

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -586,6 +586,18 @@ the config was written out.
 
    This gathers data about events from zebra that come up through the ZAPI.
 
+PIM Test Commands
+=================
+Test commands are used to simulte some of the testing conditions
+
+.. index:: test pim [vrf NAME$name] sg-ageing [<stop|allow>]
+.. clicmd:: test pim [vrf NAME$name] sg-ageing [<stop|allow>]
+
+   This command stops or allows ageing of sg-entries. When this command is
+   executed with stop option. The ageing for the particular vrf is stopped.
+   On configuring with allow, this will allow to age out of sg entries.
+   This is a hidden command.
+
 PIM Clear Commands
 ==================
 Clear commands reset various variables.

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -87,6 +87,7 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 	pim->keep_alive_time = PIM_KEEPALIVE_PERIOD;
 	pim->rp_keep_alive_time = PIM_RP_KEEPALIVE_PERIOD;
 
+	pim->sg_ageing = true;
 	pim->ecmp_enable = false;
 	pim->ecmp_rebalance_enable = false;
 

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -181,6 +181,7 @@ struct pim_instance {
 	unsigned int keep_alive_time;
 	unsigned int rp_keep_alive_time;
 
+	bool sg_ageing;
 	bool ecmp_enable;
 	bool ecmp_rebalance_enable;
 	/* No. of Dual active I/fs in pim_instance */

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -831,16 +831,24 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 				   __func__);
 	}
 
+	up->flags = flags;
 	up->parent = pim_upstream_find_parent(pim, up);
 	if (up->sg.src.s_addr == INADDR_ANY) {
 		up->sources = list_new();
 		up->sources->cmp =
 			(int (*)(void *, void *))pim_upstream_compare;
-	} else
+	} else {
+		/* sg ageing shall be stopped if configured */
+		if (!pim->sg_ageing) {
+			PIM_UPSTREAM_FLAG_SET_DISABLE_KAT_EXPIRY(up->flags);
+			if (PIM_DEBUG_TRACE)
+				zlog_debug("%s: kat expiry disabled for (%s)\n",
+					   __func__, up->sg_str);
+		}
 		up->sources = NULL;
+	}
 
 	pim_upstream_find_new_children(pim, up);
-	up->flags = flags;
 	up->ref_count = 1;
 	up->t_join_timer = NULL;
 	up->t_ka_timer = NULL;


### PR DESCRIPTION
Decription: There are requirements where sg ageing is disabled.
A hidden CLI is introduced to test enable/disable sg-ageing. This is
used for testing purpose. This will be used to test all sg entries of the vrf
at once. We will have topotest using this CLI.

Signed-off-by: Saravanan K <saravanank@vmware.com>