### PR TITLE
bfdd: code/logging/debug improvements

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -526,8 +526,7 @@ int bfd_session_update_label(struct bfd_session *bs, const char *nlabel)
 			return -1;
 		}
 
-		if (pl_new(nlabel, bs) == NULL)
-			return -1;
+		pl_new(nlabel, bs);
 
 		return 0;
 	}
@@ -685,10 +684,6 @@ struct bfd_session *ptm_bfd_sess_new(struct bfd_peer_cfg *bpc)
 
 	/* Get BFD session storage with its defaults. */
 	bfd = bfd_session_new();
-	if (bfd == NULL) {
-		zlog_err("session-new: allocation failed");
-		return NULL;
-	}
 
 	/*
 	 * Store interface/VRF name in case we need to delay session

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1111,13 +1111,13 @@ static const char *get_diag_str(int diag)
 	return "N/A";
 }
 
-const char *satostr(struct sockaddr_any *sa)
+const char *satostr(const struct sockaddr_any *sa)
 {
 #define INETSTR_BUFCOUNT 8
 	static char buf[INETSTR_BUFCOUNT][INET6_ADDRSTRLEN];
 	static int bufidx;
-	struct sockaddr_in *sin = &sa->sa_sin;
-	struct sockaddr_in6 *sin6 = &sa->sa_sin6;
+	const struct sockaddr_in *sin = &sa->sa_sin;
+	const struct sockaddr_in6 *sin6 = &sa->sa_sin6;
 
 	bufidx += (bufidx + 1) % INETSTR_BUFCOUNT;
 	buf[bufidx][0] = 0;

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -529,7 +529,7 @@ void bs_state_handler(struct bfd_session *bs, int nstate);
 void bs_echo_timer_handler(struct bfd_session *bs);
 void bs_final_handler(struct bfd_session *bs);
 void bs_set_slow_timers(struct bfd_session *bs);
-const char *satostr(struct sockaddr_any *sa);
+const char *satostr(const struct sockaddr_any *sa);
 const char *diag2str(uint8_t diag);
 int strtosa(const char *addr, struct sockaddr_any *sa);
 void integer2timestr(uint64_t time, char *buf, size_t buflen);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -393,7 +393,26 @@ struct bfd_global {
 	struct obslist bg_obslist;
 
 	struct zebra_privs_t bfdd_privs;
+
+	/* Debug options. */
+	/* Show all peer state changes events. */
+	bool debug_peer_event;
+	/*
+	 * Show zebra message exchanges:
+	 * - Interface add/delete.
+	 * - Local address add/delete.
+	 * - VRF add/delete.
+	 */
+	bool debug_zebra;
+	/*
+	 * Show network level debug information:
+	 * - Echo packets without session.
+	 * - Unavailable peer sessions.
+	 * - Network system call failures.
+	 */
+	bool debug_network;
 };
+
 extern struct bfd_global bglobal;
 extern const struct bfd_diag_str_list diag_list[];
 extern const struct bfd_state_str_list state_list[];

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -107,8 +107,6 @@ static int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
 		}
 
 		bs = bfd_session_new();
-		if (bs == NULL)
-			return NB_ERR_RESOURCE;
 
 		/* Fill the session key. */
 		bfd_session_get_key(mhop, dnode, &bs->key);

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -738,6 +738,42 @@ DEFPY(bfd_show_peers_brief, bfd_show_peers_brief_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(
+	bfd_debug_peer, bfd_debug_peer_cmd,
+	"[no] debug bfd peer",
+	NO_STR
+	DEBUG_STR
+	"Bidirection Forwarding Detection\n"
+	"Peer events debugging\n")
+{
+	bglobal.debug_peer_event = !no;
+	return CMD_SUCCESS;
+}
+
+DEFPY(
+	bfd_debug_zebra, bfd_debug_zebra_cmd,
+	"[no] debug bfd zebra",
+	NO_STR
+	DEBUG_STR
+	"Bidirection Forwarding Detection\n"
+	"Zebra events debugging\n")
+{
+	bglobal.debug_zebra = !no;
+	return CMD_SUCCESS;
+}
+
+DEFPY(
+	bfd_debug_network, bfd_debug_network_cmd,
+	"[no] debug bfd network",
+	NO_STR
+	DEBUG_STR
+	"Bidirection Forwarding Detection\n"
+	"Network layer debugging\n")
+{
+	bglobal.debug_network = !no;
+	return CMD_SUCCESS;
+}
+
 /*
  * Function definitions.
  */
@@ -842,6 +878,9 @@ DEFUN_NOSH(show_debugging_bfd,
 	   "BFD daemon\n")
 {
 	vty_out(vty, "BFD debugging status:\n");
+	vty_out(vty, "  Peer events debugging.\n");
+	vty_out(vty, "  Zebra events debugging.\n");
+	vty_out(vty, "  Network layer debugging.\n");
 
 	return CMD_SUCCESS;
 }
@@ -863,6 +902,21 @@ static int bfdd_write_config(struct vty *vty)
 	struct lyd_node *dnode;
 	int written = 0;
 
+	if (bglobal.debug_peer_event) {
+		vty_out(vty, "debug bfd peer\n");
+		written = 1;
+	}
+
+	if (bglobal.debug_zebra) {
+		vty_out(vty, "debug bfd zebra\n");
+		written = 1;
+	}
+
+	if (bglobal.debug_network) {
+		vty_out(vty, "debug bfd network\n");
+		written = 1;
+	}
+
 	dnode = yang_dnode_get(running_config->dnode, "/frr-bfdd:bfdd");
 	if (dnode) {
 		nb_cli_show_dnode_cmds(vty, dnode, false);
@@ -881,6 +935,14 @@ void bfdd_vty_init(void)
 	install_element(ENABLE_NODE, &bfd_show_peer_cmd);
 	install_element(ENABLE_NODE, &bfd_show_peers_brief_cmd);
 	install_element(ENABLE_NODE, &show_debugging_bfd_cmd);
+
+	install_element(ENABLE_NODE, &bfd_debug_peer_cmd);
+	install_element(ENABLE_NODE, &bfd_debug_zebra_cmd);
+	install_element(ENABLE_NODE, &bfd_debug_network_cmd);
+
+	install_element(CONFIG_NODE, &bfd_debug_peer_cmd);
+	install_element(CONFIG_NODE, &bfd_debug_zebra_cmd);
+	install_element(CONFIG_NODE, &bfd_debug_network_cmd);
 
 	/* Install BFD node and commands. */
 	install_node(&bfd_node, bfdd_write_config);

--- a/bfdd/control.c
+++ b/bfdd/control.c
@@ -168,8 +168,7 @@ int control_accept(struct thread *t)
 		return 0;
 	}
 
-	if (control_new(csock) == NULL)
-		close(csock);
+	control_new(csock);
 
 	bglobal.bg_csockev = NULL;
 	thread_add_read(master, control_accept, NULL, sd, &bglobal.bg_csockev);
@@ -334,8 +333,6 @@ static int control_queue_enqueue(struct bfd_control_socket *bcs,
 	struct bfd_control_buffer *bcb;
 
 	bcq = control_queue_new(bcs);
-	if (bcq == NULL)
-		return -1;
 
 	bcb = &bcq->bcq_bcb;
 	bcb->bcb_left = sizeof(struct bfd_control_msg) + ntohl(bcm->bcm_length);
@@ -656,8 +653,7 @@ static int notify_add_cb(struct bfd_peer_cfg *bpc, void *arg)
 	if (bs == NULL)
 		return -1;
 
-	if (control_notifypeer_new(bcs, bs) == NULL)
-		return -1;
+	control_notifypeer_new(bcs, bs);
 
 	/* Notify peer status. */
 	_control_notify(bcs, bs);

--- a/bfdd/event.c
+++ b/bfdd/event.c
@@ -48,10 +48,6 @@ void bfd_recvtimer_update(struct bfd_session *bs)
 		return;
 
 	tv_normalize(&tv);
-#ifdef BFD_EVENT_DEBUG
-	zlog_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec,
-		   tv.tv_usec);
-#endif /* BFD_EVENT_DEBUG */
 
 	thread_add_timer_tv(master, bfd_recvtimer_cb, bs, &tv,
 			    &bs->recvtimer_ev);
@@ -70,10 +66,6 @@ void bfd_echo_recvtimer_update(struct bfd_session *bs)
 		return;
 
 	tv_normalize(&tv);
-#ifdef BFD_EVENT_DEBUG
-	zlog_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec,
-		   tv.tv_usec);
-#endif /* BFD_EVENT_DEBUG */
 
 	thread_add_timer_tv(master, bfd_echo_recvtimer_cb, bs, &tv,
 			    &bs->echo_recvtimer_ev);
@@ -92,10 +84,6 @@ void bfd_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 		return;
 
 	tv_normalize(&tv);
-#ifdef BFD_EVENT_DEBUG
-	zlog_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec,
-		   tv.tv_usec);
-#endif /* BFD_EVENT_DEBUG */
 
 	thread_add_timer_tv(master, bfd_xmt_cb, bs, &tv, &bs->xmttimer_ev);
 }
@@ -113,10 +101,6 @@ void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 		return;
 
 	tv_normalize(&tv);
-#ifdef BFD_EVENT_DEBUG
-	zlog_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec,
-		   tv.tv_usec);
-#endif /* BFD_EVENT_DEBUG */
 
 	thread_add_timer_tv(master, bfd_echo_xmt_cb, bs, &tv,
 			    &bs->echo_xmttimer_ev);

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -315,10 +315,6 @@ static int _ptm_msg_read(struct stream *msg, int command, vrf_id_t vrf_id,
 	STREAM_GETL(msg, pid);
 
 	*pc = pc_new(pid);
-	if (*pc == NULL) {
-		zlog_debug("ptm-read: failed to allocate memory");
-		return -1;
-	}
 
 	/* Register/update peer information. */
 	_ptm_msg_read_address(msg, &bpc->bpc_peer);
@@ -404,7 +400,6 @@ stream_failure:
 static void bfdd_dest_register(struct stream *msg, vrf_id_t vrf_id)
 {
 	struct ptm_client *pc;
-	struct ptm_client_notification *pcn;
 	struct bfd_session *bs;
 	struct bfd_peer_cfg bpc;
 
@@ -432,11 +427,7 @@ static void bfdd_dest_register(struct stream *msg, vrf_id_t vrf_id)
 	}
 
 	/* Create client peer notification register. */
-	pcn = pcn_new(pc, bs);
-	if (pcn == NULL) {
-		zlog_err("ptm-add-dest: failed to registrate notifications");
-		return;
-	}
+	pcn_new(pc, bs);
 
 	ptm_bfd_notify(bs, bs->ses_state);
 }
@@ -481,17 +472,12 @@ static void bfdd_dest_deregister(struct stream *msg, vrf_id_t vrf_id)
  */
 static void bfdd_client_register(struct stream *msg)
 {
-	struct ptm_client *pc;
 	uint32_t pid;
 
 	/* Find or allocate process context data. */
 	STREAM_GETL(msg, pid);
 
-	pc = pc_new(pid);
-	if (pc == NULL) {
-		zlog_err("ptm-add-client: failed to register client: %u", pid);
-		return;
-	}
+	pc_new(pid);
 
 	return;
 

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -476,13 +476,36 @@ You can also clear packet counters per session with the following commands, only
                 Session down events: 0
                 Zebra notifications: 4
 
-Logging / debugging
-===================
+Debugging
+=========
 
-There are no fine grained debug controls for bfdd. Just enable debug logs.
+By default only informational, warning and errors messages are going to be
+displayed. If you want to get debug messages and other diagnostics then make
+sure you have `debugging` level enabled:
 
 ::
 
    config
    log file /var/log/frr/frr.log debugging
    log syslog debugging
+
+You may also fine tune the debug messages by selecting one or more of the
+debug levels:
+
+.. index:: [no] debug bfd network
+.. clicmd:: [no] debug bfd network
+
+   Toggle network events: show messages about socket failures and unexpected
+   BFD messages that may not belong to registered peers.
+
+.. index:: [no] debug bfd peer
+.. clicmd:: [no] debug bfd peer
+
+   Toggle peer event log messages: show messages about peer creation/removal
+   and state changes.
+
+.. index:: [no] debug bfd zebra
+.. clicmd:: [no] debug bfd zebra
+
+   Toggle zebra message events: show messages about interfaces, local
+   addresses, VRF and daemon peer registrations.

--- a/tests/topotests/bfd-bgp-cbit-topo3/r1/bfdd.conf
+++ b/tests/topotests/bfd-bgp-cbit-topo3/r1/bfdd.conf
@@ -3,9 +3,3 @@ debug bfd network
 debug bfd peer
 debug bfd zebra
 !
-bfd
- peer 192.168.0.2
-  echo-mode
-  no shutdown
- !
-!

--- a/tests/topotests/bfd-bgp-cbit-topo3/r3/bfdd.conf
+++ b/tests/topotests/bfd-bgp-cbit-topo3/r3/bfdd.conf
@@ -3,9 +3,3 @@ debug bfd network
 debug bfd peer
 debug bfd zebra
 !
-bfd
- peer 192.168.0.2
-  echo-mode
-  no shutdown
- !
-!

--- a/tests/topotests/bfd-topo1/r2/bfdd.conf
+++ b/tests/topotests/bfd-topo1/r2/bfdd.conf
@@ -1,3 +1,8 @@
+!
+debug bfd network
+debug bfd peer
+debug bfd zebra
+!
 bfd
  peer 192.168.0.1
   receive-interval 1000

--- a/tests/topotests/bfd-topo1/r3/bfdd.conf
+++ b/tests/topotests/bfd-topo1/r3/bfdd.conf
@@ -1,3 +1,8 @@
+!
+debug bfd network
+debug bfd peer
+debug bfd zebra
+!
 bfd
  peer 192.168.1.2
   echo-interval 100

--- a/tests/topotests/bfd-topo1/r4/bfdd.conf
+++ b/tests/topotests/bfd-topo1/r4/bfdd.conf
@@ -1,3 +1,8 @@
+!
+debug bfd network
+debug bfd peer
+debug bfd zebra
+!
 bfd
  peer 192.168.2.2
   transmit-interval 2000

--- a/tests/topotests/bfd-topo2/r1/bfdd.conf
+++ b/tests/topotests/bfd-topo2/r1/bfdd.conf
@@ -1,3 +1,8 @@
+!
+debug bfd network
+debug bfd peer
+debug bfd zebra
+!
 bfd
  peer 2001:db8:4::1 multihop local-address 2001:db8:1::1
   no shutdown

--- a/tests/topotests/bfd-topo2/r2/bfdd.conf
+++ b/tests/topotests/bfd-topo2/r2/bfdd.conf
@@ -3,9 +3,3 @@ debug bfd network
 debug bfd peer
 debug bfd zebra
 !
-bfd
- peer 192.168.0.2
-  echo-mode
-  no shutdown
- !
-!

--- a/tests/topotests/bfd-topo2/r3/bfdd.conf
+++ b/tests/topotests/bfd-topo2/r3/bfdd.conf
@@ -3,9 +3,3 @@ debug bfd network
 debug bfd peer
 debug bfd zebra
 !
-bfd
- peer 192.168.0.2
-  echo-mode
-  no shutdown
- !
-!

--- a/tests/topotests/bfd-topo2/r4/bfdd.conf
+++ b/tests/topotests/bfd-topo2/r4/bfdd.conf
@@ -1,3 +1,8 @@
+!
+debug bfd network
+debug bfd peer
+debug bfd zebra
+!
 bfd
  peer 2001:db8:1::1 multihop local-address 2001:db8:4::1
   no shutdown

--- a/tests/topotests/bfd-vrf-topo1/r1/bfdd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r1/bfdd.conf
@@ -1,3 +1,8 @@
+!
+debug bfd network
+debug bfd peer
+debug bfd zebra
+!
 bfd
  peer 192.168.0.2 vrf r1-cust1
   echo-mode

--- a/tests/topotests/bfd-vrf-topo1/r2/bfdd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r2/bfdd.conf
@@ -1,3 +1,8 @@
+!
+debug bfd network
+debug bfd peer
+debug bfd zebra
+!
 bfd
  peer 192.168.0.1 vrf r2-cust1
   receive-interval 1000

--- a/tests/topotests/bfd-vrf-topo1/r3/bfdd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r3/bfdd.conf
@@ -1,3 +1,8 @@
+!
+debug bfd network
+debug bfd peer
+debug bfd zebra
+!
 bfd
  peer 192.168.1.2 vrf r3-cust1
   echo-interval 100

--- a/tests/topotests/bfd-vrf-topo1/r4/bfdd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r4/bfdd.conf
@@ -1,3 +1,8 @@
+!
+debug bfd network
+debug bfd peer
+debug bfd zebra
+!
 bfd
  peer 192.168.2.2 vrf r4-cust1
   transmit-interval 2000


### PR DESCRIPTION
## Summary

This PR introduces a batch of improvements for `bfdd`:
- Debug messages tuning.
- Remove code that was expecting `XMALLOC`/`XCALLOC` to return `NULL`.
- Remove disabled timers debug.
- `const`ify `satostr` function.
- Enable `zebra` relayed messages debugging.
- Enable new debug options in all BFD tests.
- Update docs.