### PR TITLE
ospfd: router LSA link info missing length check

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2604,7 +2604,7 @@ static unsigned ospf_router_lsa_links_examin(struct router_lsa_link *link,
 {
 	unsigned counted_links = 0, thislinklen;
 
-	while (linkbytes) {
+	while (linkbytes > OSPF_ROUTER_LSA_LINK_SIZE) {
 		thislinklen =
 			OSPF_ROUTER_LSA_LINK_SIZE + 4 * link->m[0].tos_count;
 		if (thislinklen > linkbytes) {
@@ -2642,26 +2642,33 @@ static unsigned ospf_lsa_examin(struct lsa_header *lsah, const uint16_t lsalen,
 		return MSG_NG;
 	}
 	switch (lsah->type) {
-	case OSPF_ROUTER_LSA:
-		/* RFC2328 A.4.2, LSA header + 4 bytes followed by N>=1
-		 * (12+)-byte link blocks */
-		if (headeronly) {
-			ret = (lsalen - OSPF_LSA_HEADER_SIZE
-			       - OSPF_ROUTER_LSA_MIN_SIZE)
-					      % 4
-				      ? MSG_NG
-				      : MSG_OK;
-			break;
-		}
+	case OSPF_ROUTER_LSA: {
+		/*
+		 * RFC2328 A.4.2, LSA header + 4 bytes followed by N>=0
+		 * (12+)-byte link blocks
+		 */
+		size_t linkbytes_len = lsalen - OSPF_LSA_HEADER_SIZE
+				       - OSPF_ROUTER_LSA_MIN_SIZE;
+
+		/*
+		 * LSA link blocks are variable length but always multiples of
+		 * 4; basic sanity check
+		 */
+		if (linkbytes_len % 4 != 0)
+			return MSG_NG;
+
+		if (headeronly)
+			return MSG_OK;
+
 		rlsa = (struct router_lsa *)lsah;
+
 		ret = ospf_router_lsa_links_examin(
 			(struct router_lsa_link *)rlsa->link,
-			lsalen - OSPF_LSA_HEADER_SIZE - 4, /* skip: basic
-							      header, "flags",
-							      0, "# links" */
-			ntohs(rlsa->links)		   /* 16 bits */
-			);
+			lsalen - OSPF_LSA_HEADER_SIZE
+				- OSPF_ROUTER_LSA_MIN_SIZE,
+			ntohs(rlsa->links));
 		break;
+	}
 	case OSPF_AS_EXTERNAL_LSA:
 	/* RFC2328 A.4.5, LSA header + 4 bytes followed by N>=1 12-bytes long
 	 * blocks */


### PR DESCRIPTION
Fix
- Modulo check on data length not inclusive enough
- Garbage heap read when bounds checking

```
=================================================================
==19733==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6100000089fd at pc 0x0000006ab584 bp 0x7ffe833ea8a0 sp 0x7ffe833ea898
READ of size 1 at 0x6100000089fd thread T0
    #0 0x6ab583 in ospf_router_lsa_links_examin /home/qlyoung/projects/frr/ospfd/ospf_packet.c:2622:47
    #1 0x6aae8a in ospf_lsa_examin /home/qlyoung/projects/frr/ospfd/ospf_packet.c:2670:9
    #2 0x6a9c0e in ospf_lsaseq_examin /home/qlyoung/projects/frr/ospfd/ospf_packet.c:2777:18
    #3 0x66dd41 in ospf_packet_examin /home/qlyoung/projects/frr/ospfd/ospf_packet.c:2894:9
    #4 0x665dcf in ospf_read_helper /home/qlyoung/projects/frr/ospfd/ospf_packet.c:3036:9
    #5 0x50bfb1 in LLVMFuzzerTestOneInput /home/qlyoung/projects/frr/ospfd/ospf_main.c:245:2
```

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>