### PR TITLE
ospfd: fix uaf upon rx of self-originated lsa

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2038,10 +2038,10 @@ static void ospf_ls_upd(struct ospf *ospf, struct ip *iph,
 
 				SET_FLAG(lsa->flags, OSPF_LSA_SELF);
 
-				ospf_opaque_self_originated_lsa_received(nbr,
-									 lsa);
 				ospf_ls_ack_send(nbr, lsa);
 
+				ospf_opaque_self_originated_lsa_received(nbr,
+									 lsa);
 				continue;
 			}
 		}


### PR DESCRIPTION
ospf_opaque_self_originated_lsa_received decrements refcount which can
result in a free, this is followed by a call to ospf_ls_ack_send which
accesses the freed LSA

reversing the calls results in ospf_ls_ack_send locking first which prevents the free

@odd22 or @chiragshah6 please check this one, this fix seems like bs

```
=================================================================    
==31801==ERROR: AddressSanitizer: heap-use-after-free on address 0x60c000268630 at pc 0x0000005848d9 bp 0x7fffd92aa240 sp 0x7fffd92aa238    
READ of size 4 at 0x60c000268630 thread T0    
    #0 0x5848d8 in ospf_lsa_lock /home/qlyoung/projects/frr/ospfd/ospf_lsa.c:230:11    
    #1 0x6a7010 in ospf_ls_ack_send /home/qlyoung/projects/frr/ospfd/ospf_packet.c:4319:41    
    #2 0x687803 in ospf_ls_upd /home/qlyoung/projects/frr/ospfd/ospf_packet.c:2049:5    
    #3 0x66c083 in ospf_read_helper /home/qlyoung/projects/frr/ospfd/ospf_packet.c:3215:3    
    #4 0x50bfb1 in LLVMFuzzerTestOneInput /home/qlyoung/projects/frr/ospfd/ospf_main.c:245:2    
    #5 0x449a71 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/qlyoung/fuzzing/jobs/ospfd-fuzz-14-04-2020-libFuzzer-1586839816/target+0x449a71)    
    #6 0x4491a5 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool*) (/home/qlyoung/fuzzing/jobs/ospfd-fuzz-14-04-2020-libFuzzer-1586839816/target+0x4491a5)    
    #7 0x44b79b in fuzzer::Fuzzer::MutateAndTestOne() (/home/qlyoung/fuzzing/jobs/ospfd-fuzz-14-04-2020-libFuzzer-1586839816/target+0x44b79b)    
    #8 0x44c515 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) (/home/qlyoung/fuzzing/jobs/ospfd-fuzz-14-04-2020-libFuzzer-1586839816/target+0x44c515)    
    #9 0x43819b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/qlyoung/fuzzing/jobs/ospfd-fuzz-14-04-2020-libFuzzer-1586839816/target+0x43819b)    
    #10 0x463fa2 in main (/home/qlyoung/fuzzing/jobs/ospfd-fuzz-14-04-2020-libFuzzer-1586839816/target+0x463fa2)    
    #11 0x7fc034eebb96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310    
    #12 0x42c359 in _start (/home/qlyoung/fuzzing/jobs/ospfd-fuzz-14-04-2020-libFuzzer-1586839816/target+0x42c359)    
    
0x60c000268630 is located 48 bytes inside of 120-byte region [0x60c000268600,0x60c000268678)    
freed by thread T0 here:    
    #0 0x4dbb6d in free (/home/qlyoung/fuzzing/jobs/ospfd-fuzz-14-04-2020-libFuzzer-1586839816/target+0x4dbb6d)    
    #1 0x7fc036dd6279 in qfree /home/qlyoung/projects/frr/lib/memory.c:129:2    
    #2 0x584497 in ospf_lsa_free /home/qlyoung/projects/frr/ospfd/ospf_lsa.c:224:2    
    #3 0x585465 in ospf_lsa_unlock /home/qlyoung/projects/frr/ospfd/ospf_lsa.c:247:3    
    #4 0x585929 in ospf_lsa_discard /home/qlyoung/projects/frr/ospfd/ospf_lsa.c:257:3    
    #5 0x657cb8 in ospf_opaque_self_originated_lsa_received /home/qlyoung/projects/frr/ospfd/ospf_opaque.c:2171:2    
    #6 0x6877f0 in ospf_ls_upd /home/qlyoung/projects/frr/ospfd/ospf_packet.c:2047:5    
    #7 0x66c083 in ospf_read_helper /home/qlyoung/projects/frr/ospfd/ospf_packet.c:3215:3    
    #8 0x50bfb1 in LLVMFuzzerTestOneInput /home/qlyoung/projects/frr/ospfd/ospf_main.c:245:2    
    #9 0x449a71 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/qlyoung/fuzzing/jobs/ospfd-fuzz-14-04-2020-libFuzzer-1586839816/target+0x449a71)    

```

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>