### PR TITLE
lib/defaults: fix version number comparison

### DIFF
--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -102,7 +102,7 @@ static bool frr_match_version(const char *name, const char *vspec,
 	int cmp;
 	static struct spec {
 		const char *str;
-		bool dir, eq;
+		int dir, eq;
 	} *s, specs[] = {
 		{"<=", -1, 1},
 		{">=", 1, 1},

--- a/lib/defaults.c
+++ b/lib/defaults.c
@@ -100,10 +100,10 @@ static bool frr_match_version(const char *name, const char *vspec,
 			      const char *version, bool check)
 {
 	int cmp;
-	static struct spec {
+	static const struct spec {
 		const char *str;
 		int dir, eq;
-	} *s, specs[] = {
+	} specs[] = {
 		{"<=", -1, 1},
 		{">=", 1, 1},
 		{"==", 0, 1},
@@ -112,6 +112,7 @@ static bool frr_match_version(const char *name, const char *vspec,
 		{"=", 0, 1},
 		{NULL, 0, 0},
 	};
+	const struct spec *s;
 
 	if (!vspec)
 		/* NULL = all versions */


### PR DESCRIPTION
Clearly, I'm `bool` impaired...

`<` was silently getting interpreted as `>`, which, er, is not helpful...

Also fix a weird use of a `static` variable while we're at it.