### PR TITLE
zebra: Add a new zserv_find_sync_client() function

### DIFF
--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -433,7 +433,7 @@ static int label_manager_get_chunk(struct label_manager_chunk **lmc,
 int lm_client_connect_response(uint8_t proto, uint16_t instance,
 			       vrf_id_t vrf_id, uint8_t result)
 {
-	struct zserv *client = zserv_find_client(proto, instance);
+	struct zserv *client = zserv_find_sync_client(proto, instance);
 	if (!client) {
 		zlog_err("%s: could not find client for daemon %s instance %u",
 			 __func__, zebra_route_string(proto), instance);
@@ -455,7 +455,7 @@ int lm_get_chunk_response(struct label_manager_chunk *lmc, uint8_t proto,
 			   lmc->start, lmc->end, zebra_route_string(proto),
 			   instance);
 
-	struct zserv *client = zserv_find_client(proto, instance);
+	struct zserv *client = zserv_find_sync_client(proto, instance);
 	if (!client) {
 		zlog_err("%s: could not find client for daemon %s instance %u",
 			 __func__, zebra_route_string(proto), instance);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1070,17 +1070,29 @@ static void zebra_show_client_brief(struct vty *vty, struct zserv *client)
 		client->v6_route_del_cnt);
 }
 
-struct zserv *zserv_find_client(uint8_t proto, unsigned short instance)
+static struct zserv *find_zclient(uint8_t proto, unsigned short instance,
+				  bool synchronous)
 {
 	struct listnode *node, *nnode;
 	struct zserv *client;
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
-		if (client->proto == proto && client->instance == instance)
+		if (client->proto == proto && client->instance == instance
+		    && client->synchronous == synchronous)
 			return client;
 	}
 
 	return NULL;
+}
+
+struct zserv *zserv_find_client(uint8_t proto, unsigned short instance)
+{
+	return find_zclient(proto, instance, false);
+}
+
+struct zserv *zserv_find_sync_client(uint8_t proto, unsigned short instance)
+{
+	return find_zclient(proto, instance, true);
 }
 
 /* This command is for debugging purpose. */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -287,6 +287,21 @@ extern int zserv_send_message(struct zserv *client, struct stream *msg);
 extern struct zserv *zserv_find_client(uint8_t proto, unsigned short instance);
 
 /*
+ * Retrieve a synchronous client by its protocol and instance number.
+ *
+ * proto
+ *    protocol number
+ *
+ * instance
+ *    instance number
+ *
+ * Returns:
+ *    The Zebra API client.
+ */
+extern struct zserv *zserv_find_sync_client(uint8_t proto,
+					    unsigned short instance);
+
+/*
  * Close a client.
  *
  * Kills a client's thread, removes the client from the client list and cleans


### PR DESCRIPTION
zserv_find_client() function returns the fist zclient for the given proto and
instance. It could be a synchronous or an asynchronous socket. When using
Label Manager in synchronous way, client must change the instance value prior
to initialize the socket otherwise, depending in which order the sockets are
open, it may works or not.

This change introduce a new zserv_find_sync_client() function to return only
zclient which is open with a synchronous socket always for the given proto and
instance. This new function is then used in lm_client_connect_response()
function when responding to the hello message to the client, and in function
lm_get_chunk_response() when answering to a label chunk request.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>