### PR TITLE
lib,zebra: add a session id for zapi sessions

### DIFF
--- a/doc/developer/zebra.rst
+++ b/doc/developer/zebra.rst
@@ -9,13 +9,20 @@ Zebra
 Overview of the Zebra Protocol
 ==============================
 
-The Zebra protocol is used by protocol daemons to communicate with the
-**zebra** daemon.
+The Zebra protocol (or ``ZAPI``) is used by protocol daemons to
+communicate with the **zebra** daemon.
 
-Each protocol daemon may request and send information to and from the **zebra**
-daemon such as interface states, routing state, nexthop-validation, and so on.
-Protocol daemons may also install routes with **zebra**. The **zebra** daemon
-manages which routes are installed into the forwarding table with the kernel.
+Each protocol daemon may request and send information to and from the
+**zebra** daemon such as interface states, routing state,
+nexthop-validation, and so on.  Protocol daemons may also install
+routes with **zebra**. The **zebra** daemon manages which routes are
+installed into the forwarding table with the kernel. Some daemons use
+more than one ZAPI connection. This is supported: each ZAPI session is
+identified by a tuple of: ``{protocol, instance, session_id}``. LDPD
+is an example: it uses a second, synchronous ZAPI session to manage
+label blocks. The default value for ``session_id`` is zero; daemons
+who use multiple ZAPI sessions must assign unique values to the
+sessions' ids.
 
 The Zebra protocol is a streaming protocol, with a common header. Version 0
 lacks a version field and is implicitly versioned. Version 1 and all subsequent

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -1756,6 +1756,7 @@ static void zclient_sync_init(unsigned short instance)
 	zclient_sync->sock = -1;
 	zclient_sync->redist_default = ZEBRA_ROUTE_LDP;
 	zclient_sync->instance = instance;
+	zclient_sync->session_id = 1; /* Distinguish from main session */
 	zclient_sync->privs = &lde_privs;
 
 	while (zclient_socket_connect(zclient_sync) < 0) {

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -388,6 +388,7 @@ int zclient_send_hello(struct zclient *zclient)
 		zclient_create_header(s, ZEBRA_HELLO, VRF_DEFAULT);
 		stream_putc(s, zclient->redist_default);
 		stream_putw(s, zclient->instance);
+		stream_putl(s, zclient->session_id);
 		if (zclient->receive_notify)
 			stream_putc(s, 1);
 		else

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -258,6 +258,9 @@ struct zclient {
 	/* Is this a synchronous client? */
 	bool synchronous;
 
+	/* Session id (optional) to support clients with multiple sessions */
+	uint32_t session_id;
+
 	/* Socket to zebra daemon. */
 	int sock;
 

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -52,48 +52,45 @@ DEFINE_MTYPE_STATIC(LBL_MGR, LM_CHUNK, "Label Manager Chunk");
  * externally
  */
 
-DEFINE_HOOK(lm_client_connect,
-	    (uint8_t proto, uint16_t instance, vrf_id_t vrf_id),
-	    (proto, instance, vrf_id));
-DEFINE_HOOK(lm_client_disconnect, (uint8_t proto, uint16_t instance),
-	    (proto, instance));
+DEFINE_HOOK(lm_client_connect, (struct zserv *client, vrf_id_t vrf_id),
+	    (client, vrf_id));
+DEFINE_HOOK(lm_client_disconnect, (struct zserv *client), (client));
 DEFINE_HOOK(lm_get_chunk,
-	    (struct label_manager_chunk * *lmc, uint8_t proto,
-	     uint16_t instance, uint8_t keep, uint32_t size, uint32_t base,
-	     vrf_id_t vrf_id),
-	    (lmc, proto, instance, keep, size, base, vrf_id));
+	     (struct label_manager_chunk * *lmc, struct zserv *client,
+	      uint8_t keep, uint32_t size, uint32_t base, vrf_id_t vrf_id),
+	     (lmc, client, keep, size, base, vrf_id));
 DEFINE_HOOK(lm_release_chunk,
-	    (uint8_t proto, uint16_t instance, uint32_t start, uint32_t end),
-	    (proto, instance, start, end));
+	     (struct zserv *client, uint32_t start, uint32_t end),
+	     (client, start, end));
 DEFINE_HOOK(lm_cbs_inited, (), ());
 
 /* define wrappers to be called in zapi_msg.c (as hooks must be called in
  * source file where they were defined)
  */
-void lm_client_connect_call(uint8_t proto, uint16_t instance, vrf_id_t vrf_id)
+void lm_client_connect_call(struct zserv *client, vrf_id_t vrf_id)
 {
-	hook_call(lm_client_connect, proto, instance, vrf_id);
+	hook_call(lm_client_connect, client, vrf_id);
 }
-void lm_get_chunk_call(struct label_manager_chunk **lmc, uint8_t proto,
-		       uint16_t instance, uint8_t keep, uint32_t size,
-		       uint32_t base, vrf_id_t vrf_id)
+void lm_get_chunk_call(struct label_manager_chunk **lmc, struct zserv *client,
+		       uint8_t keep, uint32_t size, uint32_t base,
+		       vrf_id_t vrf_id)
 {
-	hook_call(lm_get_chunk, lmc, proto, instance, keep, size, base, vrf_id);
+	hook_call(lm_get_chunk, lmc, client, keep, size, base, vrf_id);
 }
-void lm_release_chunk_call(uint8_t proto, uint16_t instance, uint32_t start,
-			   uint32_t end)
+void lm_release_chunk_call(struct zserv *client, uint32_t start, uint32_t end)
 {
-	hook_call(lm_release_chunk, proto, instance, start, end);
+	hook_call(lm_release_chunk, client, start, end);
 }
 
 /* forward declarations of the static functions to be used for some hooks */
-static int label_manager_connect(uint8_t proto, uint16_t instance,
-				 vrf_id_t vrf_id);
-static int label_manager_disconnect(uint8_t proto, uint16_t instance);
+static int label_manager_connect(struct zserv *client, vrf_id_t vrf_id);
+static int label_manager_disconnect(struct zserv *client);
 static int label_manager_get_chunk(struct label_manager_chunk **lmc,
-				   uint8_t proto, uint16_t instance,
-				   uint8_t keep, uint32_t size, uint32_t base,
+				   struct zserv *client, uint8_t keep,
+				   uint32_t size, uint32_t base,
 				   vrf_id_t vrf_id);
+static int label_manager_release_label_chunk(struct zserv *client,
+					     uint32_t start, uint32_t end);
 
 void delete_label_chunk(void *val)
 {
@@ -110,7 +107,7 @@ void delete_label_chunk(void *val)
  * @param instance Instance, to identify the owner
  * @return Number of chunks released
  */
-int release_daemon_label_chunks(uint8_t proto, unsigned short instance)
+int release_daemon_label_chunks(struct zserv *client)
 {
 	struct listnode *node;
 	struct label_manager_chunk *lmc;
@@ -118,13 +115,16 @@ int release_daemon_label_chunks(uint8_t proto, unsigned short instance)
 	int ret;
 
 	if (IS_ZEBRA_DEBUG_PACKET)
-		zlog_debug("%s: Releasing chunks for client proto %s, instance %d",
-			   __func__, zebra_route_string(proto), instance);
+		zlog_debug("%s: Releasing chunks for client proto %s, instance %d, session %u",
+			   __func__, zebra_route_string(client->proto),
+			   client->instance, client->session_id);
 
 	for (ALL_LIST_ELEMENTS_RO(lbl_mgr.lc_list, node, lmc)) {
-		if (lmc->proto == proto && lmc->instance == instance
-		    && lmc->keep == 0) {
+		if (lmc->proto == client->proto &&
+		    lmc->instance == client->instance &&
+		    lmc->session_id == client->session_id && lmc->keep == 0) {
 			ret = release_label_chunk(lmc->proto, lmc->instance,
+						  lmc->session_id,
 						  lmc->start, lmc->end);
 			if (ret == 0)
 				count++;
@@ -139,10 +139,7 @@ int release_daemon_label_chunks(uint8_t proto, unsigned short instance)
 
 int lm_client_disconnect_cb(struct zserv *client)
 {
-	uint8_t proto = client->proto;
-	uint16_t instance = client->instance;
-
-	hook_call(lm_client_disconnect, proto, instance);
+	hook_call(lm_client_disconnect, client);
 	return 0;
 }
 
@@ -151,14 +148,14 @@ void lm_hooks_register(void)
 	hook_register(lm_client_connect, label_manager_connect);
 	hook_register(lm_client_disconnect, label_manager_disconnect);
 	hook_register(lm_get_chunk, label_manager_get_chunk);
-	hook_register(lm_release_chunk, release_label_chunk);
+	hook_register(lm_release_chunk, label_manager_release_label_chunk);
 }
 void lm_hooks_unregister(void)
 {
 	hook_unregister(lm_client_connect, label_manager_connect);
 	hook_unregister(lm_client_disconnect, label_manager_disconnect);
 	hook_unregister(lm_get_chunk, label_manager_get_chunk);
-	hook_unregister(lm_release_chunk, release_label_chunk);
+	hook_unregister(lm_release_chunk, label_manager_release_label_chunk);
 }
 
 /**
@@ -180,6 +177,7 @@ void label_manager_init(void)
 /* alloc and fill a label chunk */
 struct label_manager_chunk *create_label_chunk(uint8_t proto,
 					       unsigned short instance,
+					       uint32_t session_id,
 					       uint8_t keep, uint32_t start,
 					       uint32_t end)
 {
@@ -191,6 +189,7 @@ struct label_manager_chunk *create_label_chunk(uint8_t proto,
 	lmc->end = end;
 	lmc->proto = proto;
 	lmc->instance = instance;
+	lmc->session_id = session_id;
 	lmc->keep = keep;
 
 	return lmc;
@@ -199,7 +198,8 @@ struct label_manager_chunk *create_label_chunk(uint8_t proto,
 /* attempt to get a specific label chunk */
 static struct label_manager_chunk *
 assign_specific_label_chunk(uint8_t proto, unsigned short instance,
-			    uint8_t keep, uint32_t size, uint32_t base)
+			    uint32_t session_id, uint8_t keep, uint32_t size,
+			    uint32_t base)
 {
 	struct label_manager_chunk *lmc;
 	struct listnode *node, *next = NULL;
@@ -248,7 +248,8 @@ assign_specific_label_chunk(uint8_t proto, unsigned short instance,
 
 	/* insert chunk between existing chunks */
 	if (insert_node) {
-		lmc = create_label_chunk(proto, instance, keep, base, end);
+		lmc = create_label_chunk(proto, instance, session_id, keep,
+					 base, end);
 		listnode_add_before(lbl_mgr.lc_list, insert_node, lmc);
 		return lmc;
 	}
@@ -270,7 +271,8 @@ assign_specific_label_chunk(uint8_t proto, unsigned short instance,
 			delete_label_chunk(death);
 		}
 
-		lmc = create_label_chunk(proto, instance, keep, base, end);
+		lmc = create_label_chunk(proto, instance, session_id, keep,
+					 base, end);
 		if (last_node)
 			listnode_add_before(lbl_mgr.lc_list, last_node, lmc);
 		else
@@ -280,7 +282,8 @@ assign_specific_label_chunk(uint8_t proto, unsigned short instance,
 	} else {
 		/* create a new chunk past all the existing ones and link at
 		 * tail */
-		lmc = create_label_chunk(proto, instance, keep, base, end);
+		lmc = create_label_chunk(proto, instance, session_id, keep,
+					 base, end);
 		listnode_add(lbl_mgr.lc_list, lmc);
 		return lmc;
 	}
@@ -301,6 +304,7 @@ assign_specific_label_chunk(uint8_t proto, unsigned short instance,
  */
 struct label_manager_chunk *assign_label_chunk(uint8_t proto,
 					       unsigned short instance,
+					       uint32_t session_id,
 					       uint8_t keep, uint32_t size,
 					       uint32_t base)
 {
@@ -310,8 +314,8 @@ struct label_manager_chunk *assign_label_chunk(uint8_t proto,
 
 	/* handle chunks request with a specific base label */
 	if (base != MPLS_LABEL_BASE_ANY)
-		return assign_specific_label_chunk(proto, instance, keep, size,
-						   base);
+		return assign_specific_label_chunk(proto, instance, session_id,
+						   keep, size, base);
 
 	/* appease scan-build, who gets confused by the use of macros */
 	assert(lbl_mgr.lc_list);
@@ -322,6 +326,7 @@ struct label_manager_chunk *assign_label_chunk(uint8_t proto,
 		    && lmc->end - lmc->start + 1 == size) {
 			lmc->proto = proto;
 			lmc->instance = instance;
+			lmc->session_id = session_id;
 			lmc->keep = keep;
 			return lmc;
 		}
@@ -329,8 +334,9 @@ struct label_manager_chunk *assign_label_chunk(uint8_t proto,
 		 */
 		if ((lmc->start > prev_end)
 		    && (lmc->start - prev_end >= size)) {
-			lmc = create_label_chunk(proto, instance, keep,
-						 prev_end + 1, prev_end + size);
+			lmc = create_label_chunk(proto, instance, session_id,
+						 keep, prev_end + 1,
+						 prev_end + size);
 			listnode_add_before(lbl_mgr.lc_list, node, lmc);
 			return lmc;
 		}
@@ -355,10 +361,28 @@ struct label_manager_chunk *assign_label_chunk(uint8_t proto,
 	}
 
 	/* create chunk and link at tail */
-	lmc = create_label_chunk(proto, instance, keep, start_free,
+	lmc = create_label_chunk(proto, instance, session_id, keep, start_free,
 				 start_free + size - 1);
 	listnode_add(lbl_mgr.lc_list, lmc);
 	return lmc;
+}
+
+/**
+ * Release label chunks from a client.
+ *
+ * Called on client disconnection or reconnection. It only releases chunks
+ * with empty keep value.
+ *
+ * @param client Client zapi session
+ * @param start First label of the chunk
+ * @param end Last label of the chunk
+ * @return 0 on success
+ */
+static int label_manager_release_label_chunk(struct zserv *client,
+					     uint32_t start, uint32_t end)
+{
+	return release_label_chunk(client->proto, client->instance,
+				   client->session_id, start, end);
 }
 
 /**
@@ -370,8 +394,8 @@ struct label_manager_chunk *assign_label_chunk(uint8_t proto,
  * @param end Last label of the chunk
  * @return 0 on success, -1 otherwise
  */
-int release_label_chunk(uint8_t proto, unsigned short instance, uint32_t start,
-			uint32_t end)
+int release_label_chunk(uint8_t proto, unsigned short instance,
+			uint32_t session_id, uint32_t start, uint32_t end)
 {
 	struct listnode *node;
 	struct label_manager_chunk *lmc;
@@ -386,13 +410,15 @@ int release_label_chunk(uint8_t proto, unsigned short instance, uint32_t start,
 			continue;
 		if (lmc->end != end)
 			continue;
-		if (lmc->proto != proto || lmc->instance != instance) {
+		if (lmc->proto != proto || lmc->instance != instance ||
+		    lmc->session_id != session_id) {
 			flog_err(EC_ZEBRA_LM_DAEMON_MISMATCH,
 				 "%s: Daemon mismatch!!", __func__);
 			continue;
 		}
 		lmc->proto = NO_PROTO;
 		lmc->instance = 0;
+		lmc->session_id = 0;
 		lmc->keep = 0;
 		ret = 0;
 		break;
@@ -405,64 +431,60 @@ int release_label_chunk(uint8_t proto, unsigned short instance, uint32_t start,
 }
 
 /* default functions to be called on hooks  */
-static int label_manager_connect(uint8_t proto, uint16_t instance,
-				 vrf_id_t vrf_id)
+static int label_manager_connect(struct zserv *client, vrf_id_t vrf_id)
 {
 	/*
 	 * Release previous labels of same protocol and instance.
 	 * This is done in case it restarted from an unexpected shutdown.
 	 */
-	release_daemon_label_chunks(proto, instance);
-	return lm_client_connect_response(proto, instance, vrf_id, 0);
+	release_daemon_label_chunks(client);
+	return zsend_label_manager_connect_response(client, vrf_id, 0);
 }
-static int label_manager_disconnect(uint8_t proto, uint16_t instance)
+static int label_manager_disconnect(struct zserv *client)
 {
-	release_daemon_label_chunks(proto, instance);
+	release_daemon_label_chunks(client);
 	return 0;
 }
 static int label_manager_get_chunk(struct label_manager_chunk **lmc,
-				   uint8_t proto, uint16_t instance,
-				   uint8_t keep, uint32_t size, uint32_t base,
+				   struct zserv *client, uint8_t keep,
+				   uint32_t size, uint32_t base,
 				   vrf_id_t vrf_id)
 {
-	*lmc = assign_label_chunk(proto, instance, keep, size, base);
-	return lm_get_chunk_response(*lmc, proto, instance, vrf_id);
+	*lmc = assign_label_chunk(client->proto, client->instance,
+				  client->session_id, keep, size, base);
+	return lm_get_chunk_response(*lmc, client, vrf_id);
 }
 
 /* Respond to a connect request */
 int lm_client_connect_response(uint8_t proto, uint16_t instance,
-			       vrf_id_t vrf_id, uint8_t result)
+			       uint32_t session_id, vrf_id_t vrf_id,
+			       uint8_t result)
 {
-	struct zserv *client = zserv_find_client(proto, instance);
+	struct zserv *client = zserv_find_client_session(proto, instance,
+							 session_id);
 	if (!client) {
-		zlog_err("%s: could not find client for daemon %s instance %u",
-			 __func__, zebra_route_string(proto), instance);
+		zlog_err("%s: could not find client for daemon %s instance %u session %u",
+			 __func__, zebra_route_string(proto), instance,
+			 session_id);
 		return 1;
 	}
 	return zsend_label_manager_connect_response(client, vrf_id, result);
 }
 
 /* Respond to a get_chunk request */
-int lm_get_chunk_response(struct label_manager_chunk *lmc, uint8_t proto,
-			  uint16_t instance, vrf_id_t vrf_id)
+int lm_get_chunk_response(struct label_manager_chunk *lmc, struct zserv *client,
+			  vrf_id_t vrf_id)
 {
 	if (!lmc)
 		flog_err(EC_ZEBRA_LM_CANNOT_ASSIGN_CHUNK,
 			 "Unable to assign Label Chunk to %s instance %u",
-			 zebra_route_string(proto), instance);
+			 zebra_route_string(client->proto), client->instance);
 	else if (IS_ZEBRA_DEBUG_PACKET)
 		zlog_debug("Assigned Label Chunk %u - %u to %s instance %u",
-			   lmc->start, lmc->end, zebra_route_string(proto),
-			   instance);
+			   lmc->start, lmc->end,
+			   zebra_route_string(client->proto), client->instance);
 
-	struct zserv *client = zserv_find_client(proto, instance);
-	if (!client) {
-		zlog_err("%s: could not find client for daemon %s instance %u",
-			 __func__, zebra_route_string(proto), instance);
-		return 1;
-	}
-	return zsend_assign_label_chunk_response(client, vrf_id, proto,
-						 instance, lmc);
+	return zsend_assign_label_chunk_response(client, vrf_id, lmc);
 }
 
 void label_manager_close(void)

--- a/zebra/label_manager.h
+++ b/zebra/label_manager.h
@@ -40,19 +40,20 @@ extern "C" {
 
 /*
  * Label chunk struct
- * Client daemon which the chunk belongs to can be identified by either
- * proto (daemon protocol) + instance.
+ * Client daemon which the chunk belongs to can be identified by a tuple of:
+ * proto (daemon protocol) + instance + zapi session_id
  * If the client then passes a non-empty value to keep field when it requests
  * for chunks, the chunks won't be garbage collected and the client will be
- * responsible of its release.
+ * responsible for releasing them.
  * Otherwise, if the keep field is not set (value 0) for the chunk, it will be
  * automatically released when the client disconnects or when it reconnects
  * (in case it died unexpectedly, we can know it's the same because it will have
- * the same proto and instance values)
+ * the same proto+instance+session values)
  */
 struct label_manager_chunk {
 	uint8_t proto;
 	unsigned short instance;
+	uint32_t session_id;
 	uint8_t keep;
 	uint32_t start; /* First label of the chunk */
 	uint32_t end;   /* Last label of the chunk */
@@ -63,41 +64,40 @@ struct label_manager_chunk {
  * so that any external module wanting to replace those can react
  */
 
-DECLARE_HOOK(lm_client_connect,
-	     (uint8_t proto, uint16_t instance, vrf_id_t vrf_id),
-	     (proto, instance, vrf_id));
-DECLARE_HOOK(lm_client_disconnect, (uint8_t proto, uint16_t instance),
-	     (proto, instance));
+DECLARE_HOOK(lm_client_connect, (struct zserv *client, vrf_id_t vrf_id),
+	     (client, vrf_id));
+DECLARE_HOOK(lm_client_disconnect, (struct zserv *client), (client));
 DECLARE_HOOK(lm_get_chunk,
-	     (struct label_manager_chunk * *lmc, uint8_t proto,
-	      uint16_t instance, uint8_t keep, uint32_t size, uint32_t base,
-	      vrf_id_t vrf_id),
-	     (lmc, proto, instance, keep, size, base, vrf_id));
+	     (struct label_manager_chunk * *lmc, struct zserv *client,
+	      uint8_t keep, uint32_t size, uint32_t base, vrf_id_t vrf_id),
+	     (lmc, client, keep, size, base, vrf_id));
 DECLARE_HOOK(lm_release_chunk,
-	     (uint8_t proto, uint16_t instance, uint32_t start, uint32_t end),
-	     (proto, instance, start, end));
+	     (struct zserv *client, uint32_t start, uint32_t end),
+	     (client, start, end));
 DECLARE_HOOK(lm_cbs_inited, (), ());
 
 
 /* declare wrappers to be called in zapi_msg.c (as hooks must be called in
  * source file where they were defined)
  */
-void lm_client_connect_call(uint8_t proto, uint16_t instance, vrf_id_t vrf_id);
-void lm_get_chunk_call(struct label_manager_chunk **lmc, uint8_t proto,
-		       uint16_t instance, uint8_t keep, uint32_t size,
-		       uint32_t base, vrf_id_t vrf_id);
-void lm_release_chunk_call(uint8_t proto, uint16_t instance, uint32_t start,
+void lm_client_connect_call(struct zserv *client, vrf_id_t vrf_id);
+void lm_get_chunk_call(struct label_manager_chunk **lmc, struct zserv *client,
+		       uint8_t keep, uint32_t size, uint32_t base,
+		       vrf_id_t vrf_id);
+void lm_release_chunk_call(struct zserv *client, uint32_t start,
 			   uint32_t end);
 
 /* API for an external LM to return responses for requests */
 int lm_client_connect_response(uint8_t proto, uint16_t instance,
-			       vrf_id_t vrf_id, uint8_t result);
-int lm_get_chunk_response(struct label_manager_chunk *lmc, uint8_t proto,
-			  uint16_t instance, vrf_id_t vrf_id);
+			       uint32_t session_id, vrf_id_t vrf_id,
+			       uint8_t result);
+int lm_get_chunk_response(struct label_manager_chunk *lmc, struct zserv *client,
+			  vrf_id_t vrf_id);
 
 /* convenience function to allocate an lmc to be consumed by the above API */
 struct label_manager_chunk *create_label_chunk(uint8_t proto,
 					       unsigned short instance,
+					       uint32_t session_id,
 					       uint8_t keep, uint32_t start,
 					       uint32_t end);
 void delete_label_chunk(void *val);
@@ -117,12 +117,13 @@ struct label_manager {
 void label_manager_init(void);
 struct label_manager_chunk *assign_label_chunk(uint8_t proto,
 					       unsigned short instance,
+					       uint32_t session_id,
 					       uint8_t keep, uint32_t size,
 					       uint32_t base);
-int release_label_chunk(uint8_t proto, unsigned short instance, uint32_t start,
-			uint32_t end);
+int release_label_chunk(uint8_t proto, unsigned short instance,
+			uint32_t session_id, uint32_t start, uint32_t end);
 int lm_client_disconnect_cb(struct zserv *client);
-int release_daemon_label_chunks(uint8_t proto, unsigned short instance);
+int release_daemon_label_chunks(struct zserv *client);
 void label_manager_close(void);
 
 #ifdef __cplusplus

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1931,9 +1931,11 @@ static void zread_hello(ZAPI_HANDLER_ARGS)
 	unsigned short instance;
 	uint8_t notify;
 	uint8_t synchronous;
+	uint32_t session_id;
 
 	STREAM_GETC(msg, proto);
 	STREAM_GETW(msg, instance);
+	STREAM_GETL(msg, session_id);
 	STREAM_GETC(msg, notify);
 	STREAM_GETC(msg, synchronous);
 	if (notify)
@@ -1953,6 +1955,7 @@ static void zread_hello(ZAPI_HANDLER_ARGS)
 
 		client->proto = proto;
 		client->instance = instance;
+		client->session_id = session_id;
 
 		/* Graceful restart processing for client connect */
 		zebra_gr_client_reconnect(client);

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -94,8 +94,7 @@ extern void zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 
 extern void zsend_capabilities_all_clients(void);
 extern int zsend_assign_label_chunk_response(struct zserv *client,
-					     vrf_id_t vrf_id, uint8_t proto,
-					     uint16_t instance,
+					     vrf_id_t vrf_id,
 					     struct label_manager_chunk *lmc);
 extern int zsend_label_manager_connect_response(struct zserv *client,
 						vrf_id_t vrf_id,

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -134,9 +134,10 @@ struct zserv {
 	/* Indicates if client is synchronous. */
 	bool synchronous;
 
-	/* client's protocol */
+	/* client's protocol and session info */
 	uint8_t proto;
 	uint16_t instance;
+	uint32_t session_id;
 
 	/*
 	 * Interested for MLAG Updates, and also stores the client
@@ -285,6 +286,24 @@ extern int zserv_send_message(struct zserv *client, struct stream *msg);
  *    The Zebra API client.
  */
 extern struct zserv *zserv_find_client(uint8_t proto, unsigned short instance);
+
+/*
+ * Retrieve a client by its protocol, instance number, and session id.
+ *
+ * proto
+ *    protocol number
+ *
+ * instance
+ *    instance number
+ *
+ * session_id
+ *    session id
+ *
+ * Returns:
+ *    The Zebra API client.
+ */
+struct zserv *zserv_find_client_session(uint8_t proto, unsigned short instance,
+					uint32_t session_id);
 
 /*
  * Close a client.


### PR DESCRIPTION
Distinguish zapi sessions, for daemons who use more than one, by adding a session id. Use ldp as an example. Include the id in the client show output. Use the tuple of {proto, instance, session_id} in the label-manager apis, so that LM clients are uniquely identified and associated with their label allocations.
