### PR TITLE
ldpd: ldp_vty_neighbor_password(): fix auth.md5key_len calculation

### DIFF
--- a/ldpd/ldp_vty_conf.c
+++ b/ldpd/ldp_vty_conf.c
@@ -1077,7 +1077,7 @@ ldp_vty_neighbor_password(struct vty *vty, const char *negate, struct in_addr ls
 		if (password_len >= sizeof(nbrp->auth.md5key))
 			vty_out(vty, "%% password has been truncated to %zu "
 			    "characters.", sizeof(nbrp->auth.md5key) - 1);
-		nbrp->auth.md5key_len = password_len;
+		nbrp->auth.md5key_len = strlen(nbrp->auth.md5key);
 		nbrp->auth.method = AUTH_MD5SIG;
 	}
 


### PR DESCRIPTION
Per issue #6202

Very long passwords (>79 chars) get truncated: save truncated length in ```nbrp->auth.md5key_len``` instead of original length.