### PR TITLE
zebra: permit usage of show nexthop-group with namespace based vrfs

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1348,8 +1348,9 @@ DEFPY (show_nexthop_group,
 	else if (v6)
 		afi = AFI_IP6;
 
-	if (vrf_is_backend_netns() && (vrf_name || vrf_all)) {
-		vty_out(vty, "VRF subcommand does not make any sense in l3mdev based vrf's");
+	if (!vrf_is_backend_netns() && (vrf_name || vrf_all)) {
+		vty_out(vty,
+			"VRF subcommand does not make any sense in l3mdev based vrf's\n");
 		return CMD_WARNING;
 	}
 


### PR DESCRIPTION
namespace based vrfs can be used along with show nexthop-group command.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>