### PR TITLE
Change network statement default

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -73,8 +73,12 @@
 #endif
 
 FRR_CFG_DEFAULT_BOOL(BGP_IMPORT_CHECK,
-	{ .val_bool = true, .match_profile = "datacenter", },
-	{ .val_bool = false },
+	{
+		.val_bool = false,
+			.match_profile = "traditional",
+			.match_version = "< 7.4",
+	},
+	{ .val_bool = true },
 )
 FRR_CFG_DEFAULT_BOOL(BGP_SHOW_HOSTNAME,
 	{ .val_bool = true, .match_profile = "datacenter", },

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -908,6 +908,17 @@ Networks
 .. index:: no network A.B.C.D/M
 .. clicmd:: no network A.B.C.D/M
 
+.. index:: [no] bgp network import-check
+.. clicmd:: [no] bgp network import-check
+
+   This configuration modifies the behavior of the network statement.
+   If you have this configured the underlying network must exist in
+   the rib.  If you have the [no] form configured then BGP will not
+   check for the networks existence in the rib.  For versions 7.3 and
+   before frr defaults for datacenter were the network must exist,
+   traditional did not check for existence.  For versions 7.4 and beyond
+   both traditional and datacenter the network must exist.
+
 .. _bgp-route-aggregation:
 
 Route Aggregation

--- a/tests/topotests/all-protocol-startup/r1/bgpd.conf
+++ b/tests/topotests/all-protocol-startup/r1/bgpd.conf
@@ -5,6 +5,7 @@ router bgp 100
  bgp router-id 192.168.0.1
  bgp log-neighbor-changes
  no bgp ebgp-requires-policy
+ no bgp network import-check
  neighbor 192.168.7.10 remote-as 100
  neighbor 192.168.7.20 remote-as 200
  neighbor fc00:0:0:8::1000 remote-as 100

--- a/tests/topotests/bfd-bgp-cbit-topo3/r1/bgpd.conf
+++ b/tests/topotests/bfd-bgp-cbit-topo3/r1/bgpd.conf
@@ -2,6 +2,7 @@ debug bgp neighbor-events
 router bgp 101
  bgp router-id 10.254.254.1
  no bgp ebgp-requires-policy
+ no bgp network import-check
  timers bgp 8 24
  bgp graceful-restart
  neighbor 2001:db8:4::1 remote-as 102

--- a/tests/topotests/bfd-bgp-cbit-topo3/r3/bgpd.conf
+++ b/tests/topotests/bfd-bgp-cbit-topo3/r3/bgpd.conf
@@ -2,6 +2,7 @@ debug bgp neighbor-events
 router bgp 102
  bgp router-id 10.254.254.3
  no bgp ebgp-requires-policy
+ no bgp network import-check
  timers bgp 20 60
  bgp graceful-restart
  ! simulate NSF machine

--- a/tests/topotests/bfd-topo1/r1/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r1/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 101
  no bgp ebgp-requires-policy
+ no bgp network import-check
  neighbor 192.168.0.2 remote-as 102
  neighbor 192.168.0.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bfd-topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r2/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 102
  no bgp ebgp-requires-policy
+ no bgp network import-check
  neighbor 192.168.0.1 remote-as 101
  neighbor 192.168.0.1 bfd
  neighbor 192.168.1.1 remote-as 103

--- a/tests/topotests/bfd-topo1/r3/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r3/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 103
  no bgp ebgp-requires-policy
+ no bgp network import-check
  neighbor 192.168.1.2 remote-as 102
  neighbor 192.168.1.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bfd-topo1/r4/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r4/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 104
  no bgp ebgp-requires-policy
+ no bgp network import-check
  neighbor 192.168.2.2 remote-as 102
  neighbor 192.168.2.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bfd-vrf-topo1/r1/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r1/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 101 vrf r1-cust1
  no bgp ebgp-requires-policy
+ no bgp network import-check
  neighbor 192.168.0.2 remote-as 102
 ! neighbor 192.168.0.2 ebgp-multihop 10
  neighbor 192.168.0.2 bfd

--- a/tests/topotests/bfd-vrf-topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r2/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 102 vrf r2-cust1
  no bgp ebgp-requires-policy
+ no bgp network import-check
  neighbor 192.168.0.1 remote-as 101
  neighbor 192.168.0.1 bfd
  neighbor 192.168.1.1 remote-as 103

--- a/tests/topotests/bfd-vrf-topo1/r3/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r3/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 103 vrf r3-cust1
  no bgp ebgp-requires-policy
+ no bgp network import-check
  neighbor 192.168.1.2 remote-as 102
  neighbor 192.168.1.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bfd-vrf-topo1/r4/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r4/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 104 vrf r4-cust1
  no bgp ebgp-requires-policy
+ no bgp network import-check
  neighbor 192.168.2.2 remote-as 102
  neighbor 192.168.2.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce1/bgpd.conf
@@ -6,6 +6,7 @@ log stdout notifications
 log monitor notifications
 log commands
 router bgp 5226
+   no bgp network import-check
    bgp router-id 99.0.0.1
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5226

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce2/bgpd.conf
@@ -6,6 +6,7 @@ log stdout notifications
 log monitor notifications
 log commands
 router bgp 5226
+   no bgp network import-check
    bgp router-id 99.0.0.2
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5226

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce3/bgpd.conf
@@ -6,6 +6,7 @@ log stdout notifications
 log monitor notifications
 log commands
 router bgp 5226
+   no bgp network import-check
    bgp router-id 99.0.0.3
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5226

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce1/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 log file bgpd.log
 
 router bgp 5227
+   no bgp network import-check
    bgp router-id 99.0.0.1
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5227

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce2/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 log file bgpd.log
 
 router bgp 5227
+   no bgp network import-check
    bgp router-id 99.0.0.2
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5227

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce3/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 log file bgpd.log
 
 router bgp 5227
+   no bgp network import-check
    bgp router-id 99.0.0.3
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5227

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce4/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce4/bgpd.conf
@@ -8,6 +8,7 @@ log commands
 log file bgpd.log
 
 router bgp 5228 vrf ce4-cust2
+   no bgp network import-check
    bgp router-id 99.0.0.4
    no bgp ebgp-requires-policy
    neighbor 192.168.2.1 remote-as 5228

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -219,6 +219,7 @@ def __create_bgp_global(tgen, input_dict, router, build=False):
     if router_id:
         config_data.append("bgp router-id {}".format(router_id))
 
+    config_data.append("no bgp network import-check")
     return config_data
 
 


### PR DESCRIPTION
As discussed in the bgp slack channel, change the defaults of `bgp import network-check` to require the underlying network to exist in the rib