### PR TITLE
zebra: Modify netlink_request to statisfy coverity

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -764,7 +764,7 @@ static int netlink_request_intf_addr(struct nlsock *netlink_cmd, int family,
 	if (filter_mask)
 		addattr32(&req.n, sizeof(req), IFLA_EXT_MASK, filter_mask);
 
-	return netlink_request(netlink_cmd, &req.n);
+	return netlink_request(netlink_cmd, &req);
 }
 
 /* Interface lookup by netlink socket. */

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1061,10 +1061,11 @@ int netlink_talk(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 /* Issue request message to kernel via netlink socket. GET messages
  * are issued through this interface.
  */
-int netlink_request(struct nlsock *nl, struct nlmsghdr *n)
+int netlink_request(struct nlsock *nl, void *req)
 {
 	int ret;
 	struct sockaddr_nl snl;
+	struct nlmsghdr *n = (struct nlmsghdr *)req;
 
 	/* Check netlink socket. */
 	if (nl->sock < 0) {
@@ -1082,7 +1083,7 @@ int netlink_request(struct nlsock *nl, struct nlmsghdr *n)
 
 	/* Raise capabilities and send message, then lower capabilities. */
 	frr_with_privs(&zserv_privs) {
-		ret = sendto(nl->sock, (void *)n, n->nlmsg_len, 0,
+		ret = sendto(nl->sock, req, n->nlmsg_len, 0,
 			     (struct sockaddr *)&snl, sizeof(snl));
 	}
 

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -68,7 +68,7 @@ int netlink_talk_info(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 		      struct nlmsghdr *n,
 		      const struct zebra_dplane_info *dp_info, int startup);
 
-extern int netlink_request(struct nlsock *nl, struct nlmsghdr *n);
+extern int netlink_request(struct nlsock *nl, void *req);
 
 #endif /* HAVE_NETLINK */
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -983,7 +983,7 @@ static int netlink_request_route(struct zebra_ns *zns, int family, int type)
 	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
 	req.rtm.rtm_family = family;
 
-	return netlink_request(&zns->netlink_cmd, &req.n);
+	return netlink_request(&zns->netlink_cmd, &req);
 }
 
 /* Routing table read function using netlink interface.  Only called
@@ -2492,7 +2492,7 @@ static int netlink_request_nexthop(struct zebra_ns *zns, int family, int type)
 	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct nhmsg));
 	req.nhm.nh_family = family;
 
-	return netlink_request(&zns->netlink_cmd, &req.n);
+	return netlink_request(&zns->netlink_cmd, &req);
 }
 
 
@@ -2822,7 +2822,7 @@ static int netlink_request_macs(struct nlsock *netlink_cmd, int family,
 	if (master_ifindex)
 		addattr32(&req.n, sizeof(req), IFLA_MASTER, master_ifindex);
 
-	return netlink_request(netlink_cmd, &req.n);
+	return netlink_request(netlink_cmd, &req);
 }
 
 /*
@@ -2925,7 +2925,7 @@ static int netlink_request_specific_mac_in_bridge(struct zebra_ns *zns,
 			vrf_id_to_name(br_if->vrf_id), br_if->vrf_id,
 			prefix_mac2str(mac, buf, sizeof(buf)), vid);
 
-	return netlink_request(&zns->netlink_cmd, &req.n);
+	return netlink_request(&zns->netlink_cmd, &req);
 }
 
 int netlink_macfdb_read_specific_mac(struct zebra_ns *zns,
@@ -3225,7 +3225,7 @@ static int netlink_request_neigh(struct nlsock *netlink_cmd, int family,
 	if (ifindex)
 		addattr32(&req.n, sizeof(req), NDA_IFINDEX, ifindex);
 
-	return netlink_request(netlink_cmd, &req.n);
+	return netlink_request(netlink_cmd, &req);
 }
 
 /*
@@ -3313,7 +3313,7 @@ static int netlink_request_specific_neigh_in_vlan(struct zebra_ns *zns,
 			   ipaddr2str(ip, buf, sizeof(buf)), req.n.nlmsg_flags);
 	}
 
-	return netlink_request(&zns->netlink_cmd, &req.n);
+	return netlink_request(&zns->netlink_cmd, &req);
 }
 
 int netlink_neigh_read_specific_ip(struct ipaddr *ip,

--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -355,7 +355,7 @@ static int netlink_request_rules(struct zebra_ns *zns, int family, int type)
 	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct fib_rule_hdr));
 	req.frh.family = family;
 
-	return netlink_request(&zns->netlink_cmd, &req.n);
+	return netlink_request(&zns->netlink_cmd, &req);
 }
 
 /*


### PR DESCRIPTION
The netlink_request function takes a `struct nlmsghdr *`
pointer from a common pattern that we use:

	struct {
		struct nlmsghdr n;
		struct fib_rule_hdr frh;
		char buf[NL_PKT_BUF_SIZE];
	} req;

We were calling it `netlink_request(Socket, &req.n)`

The problem here is that coverity, rightly so, sees that
we access the data after the nlmsghdr in netlink_request and
tells us we have an read beyond end of the structure.  While
we know we haven't mangled anything up here because of manual
inspection coverity doesn't have this knowledge implicitly.

So let's modify the code call to netlink_request to pass in the
void pointer of the req structure itself, cast to the appropriate
data structure in the function and do the right thing.  Hopefully
the coverity SA will be happy and we can move on with our life.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>