### PR TITLE
zebra: add ability to set hoplimit for IPv6 RAs

### DIFF
--- a/doc/user/ipv6.rst
+++ b/doc/user/ipv6.rst
@@ -91,6 +91,17 @@ Router Advertisement
    Default: enabled
 
 .. index::
+   single: ipv6 nd ra-hop-limit (0-255)
+   single: no ipv6 nd ra-hop-limit [(0-255)]
+.. clicmd:: [no] ipv6 nd ra-hop-limit [(0-255)]
+
+   The value to be placed in the hop count field of router advertisements sent
+   from the interface, in hops. Indicates the maximum diameter of the network.
+   Setting the value to zero indicates that the value is unspecified by this
+   router.  Must be between zero or 255 hops.
+   Default: ``64``
+
+.. index::
    single: ipv6 nd ra-lifetime (0-9000)
    single: no ipv6 nd ra-lifetime [(0-9000)]
 .. clicmd:: [no] ipv6 nd ra-lifetime [(0-9000)]

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -153,7 +153,7 @@ static int if_zebra_new_hook(struct interface *ifp)
 		rtadv->AdvLinkMTU = 0;
 		rtadv->AdvReachableTime = 0;
 		rtadv->AdvRetransTimer = 0;
-		rtadv->AdvCurHopLimit = 0;
+		rtadv->AdvCurHopLimit = RTADV_DEFAULT_HOPLIMIT;
 		rtadv->AdvDefaultLifetime =
 			-1; /* derive from MaxRtrAdvInterval */
 		rtadv->HomeAgentPreference = 0;

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -117,6 +117,7 @@ struct rtadvconf {
 	   Default: The value specified in the "Assigned Numbers" RFC
 	   [ASSIGNED] that was in effect at the time of implementation. */
 	int AdvCurHopLimit;
+#define RTADV_DEFAULT_HOPLIMIT 64 /* 64 hops */
 
 	/* The value to be placed in the Router Lifetime field of Router
 	   Advertisements sent from the interface, in seconds.  MUST be

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -120,6 +120,9 @@ zebra/zebra_vty.$(OBJEXT): zebra/zebra_vty_clippy.c
 zebra/zebra_routemap_clippy.c: $(CLIPPY_DEPS)
 zebra/zebra_routemap.$(OBJEXT): zebra/zebra_routemap_clippy.c
 
+zebra/rtadv_clippy.c: $(CLIPPY_DEPS)
+zebra/rtadv.$(OBJEXT): zebra/rtadv_clippy.c
+
 noinst_HEADERS += \
 	zebra/connected.h \
 	zebra/debug.h \


### PR DESCRIPTION
Reported by testing agency that rfc 4861 section 6.2.1 states
that all implementations must have a configuration knob to change
the setting of the advertised hop limit.  This fix adds that
capability.

Ticket: CM-29200
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>