### PR TITLE
bgpd: Show hostname in `show [ip] bgp ...` only if nexthop is connected

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7540,11 +7540,12 @@ static void route_vty_short_status_out(struct vty *vty,
 		vty_out(vty, " ");
 }
 
-static char *bgp_nexthop_hostname(struct peer *peer, struct attr *attr)
+static char *bgp_nexthop_hostname(struct peer *peer,
+				  struct bgp_nexthop_cache *bnc)
 {
 	if (peer->hostname
 	    && CHECK_FLAG(peer->bgp->flags, BGP_FLAG_SHOW_HOSTNAME)
-	    && !(attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID)))
+	    && CHECK_FLAG(bnc->flags, BGP_NEXTHOP_CONNECTED))
 		return peer->hostname;
 	return NULL;
 }
@@ -7566,7 +7567,8 @@ void route_vty_out(struct vty *vty, const struct prefix *p,
 	bool nexthop_othervrf = false;
 	vrf_id_t nexthop_vrfid = VRF_DEFAULT;
 	const char *nexthop_vrfname = VRF_DEFAULT_NAME;
-	char *nexthop_hostname = bgp_nexthop_hostname(path->peer, attr);
+	char *nexthop_hostname =
+		bgp_nexthop_hostname(path->peer, path->nexthop);
 
 	if (json_paths)
 		json_path = json_object_new_object();
@@ -8637,7 +8639,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 	bool nexthop_self =
 		CHECK_FLAG(path->flags, BGP_PATH_ANNC_NH_SELF) ? true : false;
 	int i;
-	char *nexthop_hostname = bgp_nexthop_hostname(path->peer, attr);
+	char *nexthop_hostname =
+		bgp_nexthop_hostname(path->peer, path->nexthop);
 
 	if (json_paths) {
 		json_path = json_object_new_object();

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/r2/bgpd.conf
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/r2/bgpd.conf
@@ -1,5 +1,4 @@
 router bgp 65001
   bgp default show-hostname
   neighbor 192.168.255.1 remote-as 65000
-  address-family ipv4 unicast
-    redistribute connected
+  neighbor 192.168.254.1 remote-as 65001

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/r2/zebra.conf
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/r2/zebra.conf
@@ -5,5 +5,8 @@ interface lo
 interface r2-eth0
  ip address 192.168.255.2/24
 !
+interface r2-eth1
+ ip address 192.168.254.2/24
+!
 ip forwarding
 !

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/r3/bgpd.conf
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/r3/bgpd.conf
@@ -1,0 +1,3 @@
+router bgp 65001
+  bgp default show-hostname
+  neighbor 192.168.254.2 remote-as 65001

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/r3/zebra.conf
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/r3/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r3-eth0
+ ip address 192.168.254.1/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/test_bgp_show_ip_bgp_fqdn.py
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/test_bgp_show_ip_bgp_fqdn.py
@@ -26,6 +26,13 @@
 test_bgp_show_ip_bgp_fqdn.py:
 Test if FQND is visible in `show [ip] bgp` output if
 `bgp default show-hostname` is toggled.
+
+Topology:
+r1 <-- eBGP --> r2 <-- iBGP --> r3
+
+1. Check if both hostname and ip are added to JSON output
+for 172.16.255.254/32 on r2.
+2. Check if only ip is added to JSON output for 172.16.255.254/32 on r3.
 """
 
 import os
@@ -49,12 +56,16 @@ class TemplateTopo(Topo):
     def build(self, *_args, **_opts):
         tgen = get_topogen(self)
 
-        for routern in range(1, 3):
+        for routern in range(1, 4):
             tgen.add_router("r{}".format(routern))
 
         switch = tgen.add_switch("s1")
         switch.add_link(tgen.gears["r1"])
         switch.add_link(tgen.gears["r2"])
+
+        switch = tgen.add_switch("s2")
+        switch.add_link(tgen.gears["r2"])
+        switch.add_link(tgen.gears["r3"])
 
 
 def setup_module(mod):
@@ -85,30 +96,36 @@ def test_bgp_show_ip_bgp_hostname():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
-    router = tgen.gears["r2"]
-
     def _bgp_converge(router):
-        output = json.loads(router.vtysh_cmd("show ip bgp neighbor 192.168.255.1 json"))
-        expected = {
-            "192.168.255.1": {
-                "bgpState": "Established",
-                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
-            }
-        }
+        output = json.loads(router.vtysh_cmd("show ip bgp 172.16.255.254/32 json"))
+        expected = {"prefix": "172.16.255.254/32"}
         return topotest.json_cmp(output, expected)
 
     def _bgp_show_nexthop_hostname_and_ip(router):
         output = json.loads(router.vtysh_cmd("show ip bgp json"))
-        for nh in output["routes"]["172.16.255.253/32"][0]["nexthops"]:
+        for nh in output["routes"]["172.16.255.254/32"][0]["nexthops"]:
             if "hostname" in nh and "ip" in nh:
                 return True
         return False
 
-    test_func = functools.partial(_bgp_converge, router)
+    def _bgp_show_nexthop_ip_only(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp json"))
+        for nh in output["routes"]["172.16.255.254/32"][0]["nexthops"]:
+            if "ip" in nh and not "hostname" in nh:
+                return True
+        return False
+
+    test_func = functools.partial(_bgp_converge, tgen.gears["r2"])
     success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
 
-    assert result is None, 'Failed bgp convergence in "{}"'.format(router)
-    assert _bgp_show_nexthop_hostname_and_ip(router) == True
+    test_func = functools.partial(_bgp_converge, tgen.gears["r3"])
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+
+    assert result is None, 'Failed bgp convergence in "{}"'.format(tgen.gears["r2"])
+    assert _bgp_show_nexthop_hostname_and_ip(tgen.gears["r2"]) == True
+
+    assert result is None, 'Failed bgp convergence in "{}"'.format(tgen.gears["r3"])
+    assert _bgp_show_nexthop_ip_only(tgen.gears["r3"]) == True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The problem is when using kinda such topologies:
(192.168.1.1/32) r1 <-- eBGP --> r2 <-- iBGP --> r3

Looking at r3's nexthop for 192.168.1.1/32 we have it as r2, but really
it MUST be r1.

Checking if the nexthop is connected solves the problem even for cases
when route-reflectors are used.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>