### PR TITLE
tests: Cleanup bgp config for evpn vxlan topotest

### DIFF
--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE1/bgpd.conf
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE1/bgpd.conf
@@ -1,10 +1,9 @@
 router bgp 65000
+ timers 3 9
  bgp router-id 10.10.10.10
  no bgp default ipv4-unicast
  neighbor 10.30.30.30 remote-as 65000
- neighbor 10.30.30.30 ebgp-multihop 2
  neighbor 10.30.30.30 update-source lo
- neighbor 10.30.30.30 capability extended-nexthop
  address-family l2vpn evpn
   neighbor 10.30.30.30 activate
   advertise-all-vni

--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE2/bgpd.conf
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE2/bgpd.conf
@@ -1,10 +1,9 @@
 router bgp 65000
+ timers bgp 3 9
  bgp router-id 10.30.30.30
  no bgp default ipv4-unicast
  neighbor 10.10.10.10 remote-as 65000
- neighbor 10.10.10.10 ebgp-multihop 2
  neighbor 10.10.10.10 update-source lo
- neighbor 10.10.10.10 capability extended-nexthop
  !
  address-family l2vpn evpn
   neighbor 10.10.10.10 activate


### PR DESCRIPTION
The bgp configuration for the vxlan topotest mixed
and matched some configuration that does not belong
for an IBGP setup.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>