### PR TITLE
bgpd: Add a sanitify check for bgp_nexthop_cache against NULL

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7544,7 +7544,7 @@ static char *bgp_nexthop_hostname(struct peer *peer,
 				  struct bgp_nexthop_cache *bnc)
 {
 	if (peer->hostname
-	    && CHECK_FLAG(peer->bgp->flags, BGP_FLAG_SHOW_HOSTNAME)
+	    && CHECK_FLAG(peer->bgp->flags, BGP_FLAG_SHOW_HOSTNAME) && bnc
 	    && CHECK_FLAG(bnc->flags, BGP_NEXTHOP_CONNECTED))
 		return peer->hostname;
 	return NULL;


### PR DESCRIPTION
In real world sometimes happens that bgp_nexthop_cache is NULL. Avoid
segfaulting when using `show [ip] bgp ...` CLI commands.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>