### PR TITLE
lib: yang wrapper for date-and-time

### DIFF
--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -24,6 +24,7 @@
 #include "northbound.h"
 #include "printfrr.h"
 #include "nexthop.h"
+#include "printfrr.h"
 
 static const char *yang_get_default_value(const char *xpath)
 {
@@ -1136,6 +1137,32 @@ struct yang_data *yang_data_new_mac(const char *xpath,
 void yang_str2mac(const char *value, struct ethaddr *mac)
 {
 	(void)prefix_str2mac(value, mac);
+}
+
+struct yang_data *yang_data_new_date_and_time(const char *xpath, time_t time)
+{
+	struct tm tm;
+	char timebuf[MONOTIME_STRLEN];
+	struct timeval _time, time_real;
+	char *ts_dot;
+	uint16_t buflen;
+
+	_time.tv_sec = time;
+	_time.tv_usec = 0;
+	monotime_to_realtime(&_time, &time_real);
+
+	gmtime_r(&time_real.tv_sec, &tm);
+
+	/* rfc-3339 format */
+	strftime(timebuf, sizeof(timebuf), "%Y-%m-%dT%H:%M:%S", &tm);
+	buflen = strlen(timebuf);
+	ts_dot = timebuf + buflen;
+
+	/* microseconds and appends Z */
+	snprintfrr(ts_dot, sizeof(timebuf) - buflen, ".%06luZ",
+		   (unsigned long)time_real.tv_usec);
+
+	return yang_data_new(xpath, timebuf);
 }
 
 const char *yang_nexthop_type2str(uint32_t ntype)

--- a/lib/yang_wrappers.h
+++ b/lib/yang_wrappers.h
@@ -180,6 +180,11 @@ extern struct yang_data *yang_data_new_mac(const char *xpath,
 					   const struct ethaddr *mac);
 extern void yang_str2mac(const char *value, struct ethaddr *mac);
 
+/*data-and-time */
+extern struct yang_data *yang_data_new_date_and_time(const char *xpath,
+						     time_t time);
+
+/* nexthop enum2str */
 extern const char *yang_nexthop_type2str(uint32_t ntype);
 
 #endif /* _FRR_NORTHBOUND_WRAPPERS_H_ */


### PR DESCRIPTION
This commit has change a wrapper api to create a data node for yang date-and-time field.

```"route-entry": [
  {
    "protocol": "connected",
    "distance": 0,
    "metric": 0,
    "selected": [null],
    "installed": [null],
    "internal-flags": 8,
    "internal-status": 16, 
    "uptime": "2020-04-13T20:49:43.564458Z",```


Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>