### PR TITLE
*: RIB operational northbound callbacks implementation

### DIFF
--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -658,9 +658,7 @@ module frr-zebra {
           list route-entry {
             key "protocol";
             leaf protocol {
-               type frr-route-types:frr-route-types-v4;
-               //TODO: Use unified route types done in PR 5183 when it is merged.
-               //type frr-route-types:frr-route-types;
+               type frr-route-types:frr-route-types;
                description
                   "The protocol owning the route.";
             }

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -654,6 +654,7 @@ module frr-zebra {
              description
                 "The route's prefix.";
           }
+
           list route-entry {
             key "protocol";
             leaf protocol {
@@ -2069,10 +2070,12 @@ module frr-zebra {
   augment "/frr-vrf:lib/frr-vrf:vrf" {
     description
       "Extends VRF model with Zebra-related parameters.";
-    uses ribs;
+    container zebra {
+      uses ribs;
+    }
   }
 
-  augment "/frr-vrf:lib/frr-vrf:vrf/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop" {
+  augment "/frr-vrf:lib/frr-vrf:vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop" {
     uses frr-nh:frr-nexthop-operational;
   }
 

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -642,7 +642,6 @@ module frr-zebra {
           type identityref {
             base afi-safi-type;
           }
-          mandatory true;
           description
             "AFI, SAFI name.";
         }

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -632,12 +632,6 @@ module frr-zebra {
         "RIBs supported by FRR.";
       list rib {
         key "afi-safi-name table-id";
-        leaf table-id {
-          type uint32;
-          description
-            "Routing Table id (default id - 254).";
-        }
-
         leaf afi-safi-name {
           type identityref {
             base afi-safi-type;
@@ -646,29 +640,36 @@ module frr-zebra {
             "AFI, SAFI name.";
         }
 
+        leaf table-id {
+          type uint32;
+          description
+            "Routing Table id (default id - 254).";
+        }
+
         list route {
           key "prefix";
           config false;
           leaf prefix {
-             type inet:ip-prefix;
-             description
-                "The route's prefix.";
+            type inet:ip-prefix;
+            description
+              "The route's prefix.";
           }
 
           list route-entry {
             key "protocol";
             leaf protocol {
-               type frr-route-types:frr-route-types;
-               description
-                  "The protocol owning the route.";
+              type frr-route-types:frr-route-types;
+              description
+                "The protocol owning the route.";
             }
 
             leaf instance {
               type uint16;
               must "../protocol = \"ospf\"";
               description
-              "Retrieve routes from a specific OSPF instance.";
+                "Retrieve routes from a specific OSPF instance.";
             }
+
             uses route-common;
           }
         }

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -251,11 +251,21 @@ DECLARE_LIST(re_list, struct route_entry, next);
 	     (re) && ((next) = re_list_next(&((dest)->routes), (re)), 1);      \
 	     (re) = (next))
 
+#define RE_DEST_FIRST_ROUTE(dest, re)                                          \
+	((re) = (dest) ? re_list_first(&((dest)->routes)) : NULL)
+
+#define RE_DEST_NEXT_ROUTE(dest, re)                                           \
+	((re) = (dest) ? re_list_next(&((dest)->routes), (re)) : NULL)
+
 #define RNODE_FOREACH_RE(rn, re)                                               \
 	RE_DEST_FOREACH_ROUTE (rib_dest_from_rnode(rn), re)
 
 #define RNODE_FOREACH_RE_SAFE(rn, re, next)                                    \
 	RE_DEST_FOREACH_ROUTE_SAFE (rib_dest_from_rnode(rn), re, next)
+
+#define RNODE_FIRST_RE(rn, re) RE_DEST_FIRST_ROUTE(rib_dest_from_rnode(rn), re)
+
+#define RNODE_NEXT_RE(rn, re) RE_DEST_NEXT_ROUTE(rib_dest_from_rnode(rn), re)
 
 #if defined(HAVE_RTADV)
 /* Structure which hold status of router advertisement. */

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -420,221 +420,221 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib",
 			.cbs = {
-				.create = lib_vrf_ribs_rib_create,
-				.destroy = lib_vrf_ribs_rib_destroy,
-				.get_next = lib_vrf_ribs_rib_get_next,
-				.get_keys = lib_vrf_ribs_rib_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_lookup_entry,
+				.create = lib_vrf_zebra_ribs_rib_create,
+				.destroy = lib_vrf_zebra_ribs_rib_destroy,
+				.get_next = lib_vrf_zebra_ribs_rib_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_lookup_entry,
+				.get_next = lib_vrf_zebra_ribs_rib_route_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_route_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_route_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/prefix",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/prefix",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_prefix_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_prefix_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_route_entry_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_route_entry_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_lookup_entry,
+				.get_next = lib_vrf_zebra_ribs_rib_route_route_entry_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_route_route_entry_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_route_route_entry_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/protocol",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/protocol",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_protocol_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_protocol_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/instance",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/instance",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_instance_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_instance_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/distance",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/distance",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_distance_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_distance_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/metric",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/metric",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_metric_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_metric_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/tag",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/tag",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_tag_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_tag_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/selected",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/selected",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_selected_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_selected_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/installed",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/installed",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_installed_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_installed_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/failed",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/failed",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_failed_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_failed_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/queued",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/queued",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_queued_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_queued_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/internal-flags",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/internal-flags",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_internal_flags_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_internal_flags_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/internal-status",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/internal-status",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_internal_status_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_internal_status_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/uptime",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/uptime",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_uptime_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_uptime_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_nexthop_group_lookup_entry,
+				.get_next = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/name",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/name",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_name_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_name_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry,
+				.get_next = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/nh-type",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/nh-type",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/vrf",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/vrf",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/gateway",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/gateway",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/interface",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/interface",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/bh-type",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/bh-type",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/onlink",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/onlink",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry,
+				.get_next = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next,
+				.get_keys = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys,
+				.lookup_entry = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/id",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/id",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/label",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/label",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/ttl",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/ttl",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/duplicate",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/duplicate",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/recursive",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/recursive",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/active",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/active",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/fib",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/fib",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem,
 			}
 		},
 		{
@@ -680,9 +680,9 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/weight",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/weight",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem,
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem,
 			}
 		},
 		{

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -22,6 +22,40 @@
 #include "libfrr.h"
 #include "zebra_nb.h"
 
+const char *zebra_afi_safi_value2identity(afi_t afi, safi_t safi)
+{
+	if (afi == AFI_IP && safi == SAFI_UNICAST)
+		return "ipv4-unicast";
+	if (afi == AFI_IP6 && safi == SAFI_UNICAST)
+		return "ipv6-unicast";
+	if (afi == AFI_IP && safi == SAFI_MULTICAST)
+		return "ipv4-multicast";
+	if (afi == AFI_IP6 && safi == SAFI_MULTICAST)
+		return "ipv6-multicast";
+
+	return " ";
+}
+
+void zebra_afi_safi_identity2value(const char *key, afi_t *afi, safi_t *safi)
+{
+	if (strmatch(key, "frr-zebra:ipv4-unicast")) {
+		*afi = AFI_IP;
+		*safi = SAFI_UNICAST;
+	} else if (strmatch(key, "frr-zebra:ipv6-unicast")) {
+		*afi = AFI_IP6;
+		*safi = SAFI_UNICAST;
+	} else if (strmatch(key, "frr-zebra:ipv4-multicast")) {
+		*afi = AFI_IP;
+		*safi = SAFI_MULTICAST;
+	} else if (strmatch(key, "frr-zebra:ipv6-multicast")) {
+		*afi = AFI_IP6;
+		*safi = SAFI_MULTICAST;
+	} else {
+		*afi = AFI_UNSPEC;
+		*safi = SAFI_UNSPEC;
+	}
+}
+
 /* clang-format off */
 const struct frr_yang_module_info frr_zebra_info = {
 	.name = "frr-zebra",

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -155,165 +155,172 @@ struct yang_data *lib_interface_zebra_state_remote_vtep_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *lib_interface_zebra_state_mcast_group_get_elem(
 	struct nb_cb_get_elem_args *args);
-int lib_vrf_ribs_rib_create(struct nb_cb_create_args *args);
-int lib_vrf_ribs_rib_destroy(struct nb_cb_destroy_args *args);
-const void *lib_vrf_ribs_rib_get_next(struct nb_cb_get_next_args *args);
-int lib_vrf_ribs_rib_get_keys(struct nb_cb_get_keys_args *args);
-const void *lib_vrf_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args);
-const void *lib_vrf_ribs_rib_route_get_next(struct nb_cb_get_next_args *args);
-int lib_vrf_ribs_rib_route_get_keys(struct nb_cb_get_keys_args *args);
+int lib_vrf_zebra_ribs_rib_create(struct nb_cb_create_args *args);
+int lib_vrf_zebra_ribs_rib_destroy(struct nb_cb_destroy_args *args);
+const void *lib_vrf_zebra_ribs_rib_get_next(struct nb_cb_get_next_args *args);
+int lib_vrf_zebra_ribs_rib_get_keys(struct nb_cb_get_keys_args *args);
 const void *
-lib_vrf_ribs_rib_route_lookup_entry(struct nb_cb_lookup_entry_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_protocol_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_protocol_v6_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_vrf_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_distance_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_metric_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_tag_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_selected_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_installed_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_failed_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_queued_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_internal_flags_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_internal_status_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_uptime_get_elem(struct nb_cb_get_elem_args *args);
+lib_vrf_zebra_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args);
 const void *
-lib_vrf_ribs_rib_route_nexthop_group_get_next(struct nb_cb_get_next_args *args);
-int lib_vrf_ribs_rib_route_nexthop_group_get_keys(
-	struct nb_cb_get_keys_args *args);
-const void *lib_vrf_ribs_rib_route_nexthop_group_lookup_entry(
-	struct nb_cb_lookup_entry_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_nexthop_group_name_get_elem(
+lib_vrf_zebra_ribs_rib_route_get_next(struct nb_cb_get_next_args *args);
+int lib_vrf_zebra_ribs_rib_route_get_keys(struct nb_cb_get_keys_args *args);
+const void *
+lib_vrf_zebra_ribs_rib_route_lookup_entry(struct nb_cb_lookup_entry_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_protocol_get_elem(
 	struct nb_cb_get_elem_args *args);
-const void *lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next(
+struct yang_data *lib_vrf_zebra_ribs_rib_route_protocol_v6_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_vrf_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_distance_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_metric_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_tag_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_selected_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_installed_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_failed_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_queued_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_internal_flags_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_internal_status_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_uptime_get_elem(struct nb_cb_get_elem_args *args);
+const void *lib_vrf_zebra_ribs_rib_route_nexthop_group_get_next(
 	struct nb_cb_get_next_args *args);
-int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys(
+int lib_vrf_zebra_ribs_rib_route_nexthop_group_get_keys(
 	struct nb_cb_get_keys_args *args);
-int lib_vrf_ribs_rib_create(struct nb_cb_create_args *args);
-int lib_vrf_ribs_rib_destroy(struct nb_cb_destroy_args *args);
-const void *lib_vrf_ribs_rib_get_next(struct nb_cb_get_next_args *args);
-int lib_vrf_ribs_rib_get_keys(struct nb_cb_get_keys_args *args);
-const void *lib_vrf_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args);
-const void *lib_vrf_ribs_rib_route_get_next(struct nb_cb_get_next_args *args);
-int lib_vrf_ribs_rib_route_get_keys(struct nb_cb_get_keys_args *args);
-const void *
-lib_vrf_ribs_rib_route_lookup_entry(struct nb_cb_lookup_entry_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args);
-const void *
-lib_vrf_ribs_rib_route_route_entry_get_next(struct nb_cb_get_next_args *args);
-int lib_vrf_ribs_rib_route_route_entry_get_keys(
-	struct nb_cb_get_keys_args *args);
-const void *lib_vrf_ribs_rib_route_route_entry_lookup_entry(
+const void *lib_vrf_zebra_ribs_rib_route_nexthop_group_lookup_entry(
 	struct nb_cb_lookup_entry_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_protocol_get_elem(
+struct yang_data *lib_vrf_zebra_ribs_rib_route_nexthop_group_name_get_elem(
 	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_instance_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_distance_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_metric_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_tag_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_selected_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_installed_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_failed_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_queued_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_flags_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_status_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_ribs_rib_route_route_entry_uptime_get_elem(
-	struct nb_cb_get_elem_args *args);
-const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_next(
+const void *
+lib_vrf_zebra_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next(
 	struct nb_cb_get_next_args *args);
-int lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_keys(
+int lib_vrf_zebra_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys(
 	struct nb_cb_get_keys_args *args);
-const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_lookup_entry(
-	struct nb_cb_lookup_entry_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_name_get_elem(
-	struct nb_cb_get_elem_args *args);
+int lib_vrf_zebra_ribs_rib_create(struct nb_cb_create_args *args);
+int lib_vrf_zebra_ribs_rib_destroy(struct nb_cb_destroy_args *args);
+const void *lib_vrf_zebra_ribs_rib_get_next(struct nb_cb_get_next_args *args);
+int lib_vrf_zebra_ribs_rib_get_keys(struct nb_cb_get_keys_args *args);
 const void *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next(
+lib_vrf_zebra_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args);
+const void *
+lib_vrf_zebra_ribs_rib_route_get_next(struct nb_cb_get_next_args *args);
+int lib_vrf_zebra_ribs_rib_route_get_keys(struct nb_cb_get_keys_args *args);
+const void *
+lib_vrf_zebra_ribs_rib_route_lookup_entry(struct nb_cb_lookup_entry_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args);
+const void *lib_vrf_zebra_ribs_rib_route_route_entry_get_next(
 	struct nb_cb_get_next_args *args);
-int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys(
+int lib_vrf_zebra_ribs_rib_route_route_entry_get_keys(
 	struct nb_cb_get_keys_args *args);
-const void *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry(
+const void *lib_vrf_zebra_ribs_rib_route_route_entry_lookup_entry(
 	struct nb_cb_lookup_entry_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_protocol_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_instance_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_distance_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_metric_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_tag_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_selected_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_installed_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_failed_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_queued_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_internal_flags_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_internal_status_get_elem(
 	struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
+struct yang_data *lib_vrf_zebra_ribs_rib_route_route_entry_uptime_get_elem(
 	struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
-	struct nb_cb_get_elem_args *args);
-const void *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
+const void *lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_get_next(
 	struct nb_cb_get_next_args *args);
-int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
+int lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_get_keys(
 	struct nb_cb_get_keys_args *args);
-const void *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
+const void *lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_lookup_entry(
 	struct nb_cb_lookup_entry_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_name_get_elem(
+	struct nb_cb_get_elem_args *args);
+const void *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next(
+	struct nb_cb_get_next_args *args);
+int lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys(
+	struct nb_cb_get_keys_args *args);
+const void *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry(
+	struct nb_cb_lookup_entry_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
+	struct nb_cb_get_elem_args *args);
+const void *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
+	struct nb_cb_get_next_args *args);
+int lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
+	struct nb_cb_get_keys_args *args);
+const void *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
+	struct nb_cb_lookup_entry_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
 	struct nb_cb_get_elem_args *args);
 
 #ifdef __cplusplus

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -26,6 +26,10 @@ extern "C" {
 
 extern const struct frr_yang_module_info frr_zebra_info;
 
+/* helper functions */
+const char *zebra_afi_safi_value2identity(afi_t afi, safi_t safi);
+void zebra_afi_safi_identity2value(const char *key, afi_t *afi, safi_t *safi);
+
 /* prototypes */
 int get_route_information_rpc(struct nb_cb_rpc_args *args);
 int get_v6_mroute_info_rpc(struct nb_cb_rpc_args *args);

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1217,9 +1217,9 @@ int lib_interface_zebra_bandwidth_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib
  */
-int lib_vrf_ribs_rib_create(struct nb_cb_create_args *args)
+int lib_vrf_zebra_ribs_rib_create(struct nb_cb_create_args *args)
 {
 	struct vrf *vrf;
 	afi_t afi = AFI_IP;
@@ -1261,7 +1261,7 @@ int lib_vrf_ribs_rib_create(struct nb_cb_create_args *args)
 	return NB_OK;
 }
 
-int lib_vrf_ribs_rib_destroy(struct nb_cb_destroy_args *args)
+int lib_vrf_zebra_ribs_rib_destroy(struct nb_cb_destroy_args *args)
 {
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -30,6 +30,7 @@
 #include "zebra/interface.h"
 #include "zebra/connected.h"
 #include "zebra/zebra_router.h"
+#include "zebra/debug.h"
 
 /*
  * XPath: /frr-zebra:zebra/mcast-rpf-lookup
@@ -1222,11 +1223,12 @@ int lib_interface_zebra_bandwidth_destroy(struct nb_cb_destroy_args *args)
 int lib_vrf_zebra_ribs_rib_create(struct nb_cb_create_args *args)
 {
 	struct vrf *vrf;
-	afi_t afi = AFI_IP;
-	safi_t safi = SAFI_UNICAST;
+	afi_t afi;
+	safi_t safi;
 	struct zebra_vrf *zvrf;
 	struct zebra_router_table *zrt;
 	uint32_t table_id;
+	const char *afi_safi_name;
 
 	vrf = nb_running_get_entry(args->dnode, NULL, false);
 	zvrf = vrf_info_lookup(vrf->vrf_id);
@@ -1234,9 +1236,8 @@ int lib_vrf_zebra_ribs_rib_create(struct nb_cb_create_args *args)
 	if (!table_id)
 		table_id = zvrf->table_id;
 
-	/* TODO: once identityref nb wrapper available, parse
-	 * afi-safi-name and feed into the creation of the table
-	 */
+	afi_safi_name = yang_dnode_get_string(args->dnode, "./afi-safi-name");
+	zebra_afi_safi_identity2value(afi_safi_name, &afi, &safi);
 
 	zrt = zebra_router_find_zrt(zvrf, table_id, afi, safi);
 

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -22,6 +22,7 @@
 #include "libfrr.h"
 #include "zebra_nb.h"
 #include "zebra/interface.h"
+#include "zebra/zebra_router.h"
 
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/up-count
@@ -149,20 +150,57 @@ lib_interface_zebra_state_mcast_group_get_elem(struct nb_cb_get_elem_args *args)
 
 const void *lib_vrf_ribs_rib_get_next(struct nb_cb_get_next_args *args)
 {
-	/* TODO: implement me. */
-	return NULL;
+	struct vrf *vrf = (struct vrf *)parent_list_entry;
+	struct zebra_router_table *zrt =
+		(struct zebra_router_table *)list_entry;
+
+	struct zebra_vrf *zvrf;
+	afi_t afi;
+	safi_t safi;
+
+	zvrf = zebra_vrf_lookup_by_id(vrf->vrf_id);
+
+	if (list_entry == NULL) {
+		afi = AFI_IP;
+		safi = SAFI_UNICAST;
+
+		zrt = zebra_router_find_zrt(zvrf, zvrf->table_id, afi, safi);
+		if (zrt == NULL)
+			return NULL;
+	} else {
+		zrt = RB_NEXT(zebra_router_table_head, zrt);
+		/* vrf_id/ns_id do not match, only walk for the given VRF */
+		while (zrt && zrt->ns_id != zvrf->zns->ns_id)
+			zrt = RB_NEXT(zebra_router_table_head, zrt);
+	}
+
+	return zrt;
 }
 
 int lib_vrf_ribs_rib_get_keys(struct nb_cb_get_keys_args *args)
 {
-	/* TODO: implement me. */
+	const struct zebra_router_table *zrt = list_entry;
+
+	keys->num = 2;
+
+	snprintf(keys->key[0], sizeof(keys->key[0]), "%s",
+		 "frr-zebra:ipv4-unicast");
+	/* TODO: implement key[0], afi-safi identityref */
+	snprintf(keys->key[1], sizeof(keys->key[1]), "%" PRIu32, zrt->tableid);
+
 	return NB_OK;
 }
 
 const void *lib_vrf_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
-	/* TODO: implement me. */
-	return NULL;
+	struct vrf *vrf = (struct vrf *)parent_list_entry;
+	struct zebra_vrf *zvrf;
+	afi_t afi = AFI_IP;
+	safi_t safi = SAFI_UNICAST;
+
+	zvrf = zebra_vrf_lookup_by_id(vrf->vrf_id);
+
+	return zebra_router_find_zrt(zvrf, zvrf->table_id, afi, safi);
 }
 
 /*
@@ -170,21 +208,48 @@ const void *lib_vrf_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args)
  */
 const void *lib_vrf_ribs_rib_route_get_next(struct nb_cb_get_next_args *args)
 {
-	/* TODO: implement me. */
-	return NULL;
+	const struct zebra_router_table *zrt = parent_list_entry;
+	const struct route_node *rn = list_entry;
+
+	if (list_entry == NULL)
+		rn = route_top(zrt->table);
+	else
+		rn = srcdest_route_next((struct route_node *)rn);
+
+	return rn;
 }
 
 int lib_vrf_ribs_rib_route_get_keys(struct nb_cb_get_keys_args *args)
 {
-	/* TODO: implement me. */
+	const struct route_node *rn = list_entry;
+	char dst_buf[PREFIX_STRLEN];
+	const struct prefix *dst_p;
+
+	srcdest_rnode_prefixes(rn, &dst_p, NULL);
+	keys->num = 1;
+	strlcpy(keys->key[0], prefix2str(dst_p, dst_buf, sizeof(dst_p)),
+		sizeof(keys->key[0]));
+
 	return NB_OK;
 }
 
 const void *
 lib_vrf_ribs_rib_route_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
-	/* TODO: implement me. */
-	return NULL;
+	const struct zebra_router_table *zrt = parent_list_entry;
+	struct prefix p;
+	struct route_node *rn;
+
+	yang_str2prefix(keys->key[0], &p);
+
+	rn = route_node_lookup(zrt->table, &p);
+
+	if (!rn)
+		return NULL;
+
+	route_unlock_node(rn);
+
+	return rn;
 }
 
 /*
@@ -193,8 +258,9 @@ lib_vrf_ribs_rib_route_lookup_entry(struct nb_cb_lookup_entry_args *args)
 struct yang_data *
 lib_vrf_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args)
 {
-	/* TODO: implement me. */
-	return NULL;
+	const struct route_node *rn = list_entry;
+
+	return yang_data_new_prefix(xpath, &rn->p);
 }
 
 /*
@@ -203,8 +269,9 @@ lib_vrf_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args)
 const void *
 lib_vrf_ribs_rib_route_route_entry_get_next(struct nb_cb_get_next_args *args)
 {
-	/* TODO: implement me. */
-	return NULL;
+	struct route_entry *re = NULL;
+
+	return re;
 }
 
 int lib_vrf_ribs_rib_route_route_entry_get_keys(

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -66,6 +66,22 @@ zebra_router_table_entry_compare(const struct zebra_router_table *e1,
 	return (e1->safi - e2->safi);
 }
 
+struct zebra_router_table *zebra_router_find_zrt(struct zebra_vrf *zvrf,
+						 uint32_t tableid, afi_t afi,
+						 safi_t safi)
+{
+	struct zebra_router_table finder;
+	struct zebra_router_table *zrt;
+
+	memset(&finder, 0, sizeof(finder));
+	finder.afi = afi;
+	finder.safi = safi;
+	finder.tableid = tableid;
+	finder.ns_id = zvrf->zns->ns_id;
+	zrt = RB_FIND(zebra_router_table_head, &zrouter.tables, &finder);
+
+	return zrt;
+}
 
 struct route_table *zebra_router_find_table(struct zebra_vrf *zvrf,
 					    uint32_t tableid, afi_t afi,

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -186,6 +186,9 @@ extern void zebra_router_init(void);
 extern void zebra_router_cleanup(void);
 extern void zebra_router_terminate(void);
 
+extern struct zebra_router_table *zebra_router_find_zrt(struct zebra_vrf *zvrf,
+							uint32_t tableid,
+							afi_t afi, safi_t safi);
 extern struct route_table *zebra_router_find_table(struct zebra_vrf *zvrf,
 						   uint32_t tableid, afi_t afi,
 						   safi_t safi);


### PR DESCRIPTION
e set of changes contain the RIB operational model northbound callbacks implementation.

    Added zebra container to rib model and respective changes in northbound conversion callbacks.
    Add macros to extract `first` and `next` route_entry from a given route node.
    zebra northbound callbacks implementation


Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>