### PR TITLE
lib: clear data pointer in bf_free

### DIFF
--- a/lib/bitfield.h
+++ b/lib/bitfield.h
@@ -154,6 +154,7 @@ typedef unsigned int word_t;
 	do {                                                                   \
 		if ((v).data) {                                                \
 			free((v).data);                                        \
+			(v).data = NULL;                                       \
 		}                                                              \
 	} while (0)
 


### PR DESCRIPTION
Help avoid double-free by clearing data pointer - we're using vanilla 'free' here.