### PR TITLE
bgpd: Use true/false for reject_as_sets

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1935,7 +1935,7 @@ bool subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 	 * and RFC 5065 by eliminating AS_SET and AS_CONFED_SET types,
 	 * and obsoletes RFC 6472.
 	 */
-	if (peer->bgp->reject_as_sets == BGP_REJECT_AS_SETS_ENABLED)
+	if (peer->bgp->reject_as_sets)
 		if (aspath_check_as_sets(attr->aspath))
 			return false;
 
@@ -3425,7 +3425,7 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	 * and RFC 5065 by eliminating AS_SET and AS_CONFED_SET types,
 	 * and obsoletes RFC 6472.
 	 */
-	if (peer->bgp->reject_as_sets == BGP_REJECT_AS_SETS_ENABLED)
+	if (peer->bgp->reject_as_sets)
 		if (aspath_check_as_sets(attr->aspath)) {
 			reason =
 				"as-path contains AS_SET or AS_CONFED_SET type;";
@@ -6890,7 +6890,7 @@ static int bgp_aggregate_set(struct vty *vty, const char *prefix_str, afi_t afi,
 	 * subsumed by the previously aggregated route) without AS_SET
 	 * or AS_CONFED_SET in the updates.
 	 */
-	if (bgp->reject_as_sets == BGP_REJECT_AS_SETS_ENABLED) {
+	if (bgp->reject_as_sets) {
 		if (as_set == AGGREGATE_AS_SET) {
 			as_set_new = AGGREGATE_AS_UNSET;
 			zlog_warn(

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2067,7 +2067,7 @@ DEFUN(bgp_reject_as_sets, bgp_reject_as_sets_cmd,
 	struct listnode *node, *nnode;
 	struct peer *peer;
 
-	bgp->reject_as_sets = BGP_REJECT_AS_SETS_ENABLED;
+	bgp->reject_as_sets = true;
 
 	/* Reset existing BGP sessions to reject routes
 	 * with aspath containing AS_SET or AS_CONFED_SET.
@@ -2093,7 +2093,7 @@ DEFUN(no_bgp_reject_as_sets, no_bgp_reject_as_sets_cmd,
 	struct listnode *node, *nnode;
 	struct peer *peer;
 
-	bgp->reject_as_sets = BGP_REJECT_AS_SETS_DISABLED;
+	bgp->reject_as_sets = false;
 
 	/* Reset existing BGP sessions to reject routes
 	 * with aspath containing AS_SET or AS_CONFED_SET.
@@ -15082,7 +15082,7 @@ int bgp_config_write(struct vty *vty)
 					: "no ");
 
 		/* draft-ietf-idr-deprecate-as-set-confed-set */
-		if (bgp->reject_as_sets == BGP_REJECT_AS_SETS_ENABLED)
+		if (bgp->reject_as_sets)
 			vty_out(vty, " bgp reject-as-sets\n");
 
 		/* BGP default ipv4-unicast. */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2972,7 +2972,7 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	bgp->dynamic_neighbors_count = 0;
 	bgp->lb_ref_bw = BGP_LINK_BW_REF_BW;
 	bgp->lb_handling = BGP_LINK_BW_ECMP;
-	bgp->reject_as_sets = BGP_REJECT_AS_SETS_DISABLED;
+	bgp->reject_as_sets = false;
 	bgp_addpath_init_bgp_data(&bgp->tx_addpath);
 
 	bgp->as = *as;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -598,8 +598,6 @@ struct bgp {
 	 * Reject aspaths with AS_SET and/or AS_CONFED_SET.
 	 */
 	bool reject_as_sets;
-#define BGP_REJECT_AS_SETS_DISABLED 0
-#define BGP_REJECT_AS_SETS_ENABLED 1
 
 	struct bgp_evpn_info *evpn_info;
 


### PR DESCRIPTION
Just remove MACROS and use true/false.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>