### PR TITLE
sprintf -> snprintf round 1

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -971,7 +971,7 @@ show_babel_routes_sub(struct babel_route *route, struct vty *vty,
         channels[0] = '\0';
     else {
         int k, j = 0;
-        snprintf(channels, 100, " chan (");
+        snprintf(channels, sizeof(channels), " chan (");
         j = strlen(channels);
         for(k = 0; k < DIVERSITY_HOPS; k++) {
             if(route->channels[k] == 0)

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -546,24 +546,20 @@ static char *lcommunity_str_get(struct lcommunity *lcom, int i)
 	uint32_t localdata2;
 	char *str;
 	const uint8_t *ptr;
-	char *pnt;
 
 	ptr = lcom->val + (i * LCOMMUNITY_SIZE);
 
 	memcpy(&lcomval, ptr, LCOMMUNITY_SIZE);
 
 	/* Allocate memory.  48 bytes taken off bgp_lcommunity.c */
-	str = pnt = XMALLOC(MTYPE_LCOMMUNITY_STR, 48);
-
 	ptr = (uint8_t *)lcomval.val;
 	ptr = ptr_get_be32(ptr, &globaladmin);
 	ptr = ptr_get_be32(ptr, &localdata1);
 	ptr = ptr_get_be32(ptr, &localdata2);
 	(void)ptr; /* consume value */
 
-	sprintf(pnt, "%u:%u:%u", globaladmin, localdata1, localdata2);
-	pnt += strlen(pnt);
-	*pnt = '\0';
+	str = XMALLOC(MTYPE_LCOMMUNITY_STR, 48);
+	snprintf(str, 48, "%u:%u:%u", globaladmin, localdata1, localdata2);
 
 	return str;
 }

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -570,34 +570,39 @@ static void bgp_debug_print_evpn_prefix(struct vty *vty, const char *desc,
 
 	if (p->u.prefix_evpn.route_type == BGP_EVPN_MAC_IP_ROUTE) {
 		if (is_evpn_prefix_ipaddr_none((struct prefix_evpn *)p)) {
-			sprintf(evpn_desc, "l2vpn evpn type macip mac %s",
-				 prefix_mac2str(
-					&p->u.prefix_evpn.macip_addr.mac,
-					buf2, sizeof(buf2)));
+			snprintf(
+				evpn_desc, sizeof(evpn_desc),
+				"l2vpn evpn type macip mac %s",
+				prefix_mac2str(&p->u.prefix_evpn.macip_addr.mac,
+					       buf2, sizeof(buf2)));
 		} else {
 			uint8_t family = is_evpn_prefix_ipaddr_v4(
 						(struct prefix_evpn *)p) ?
 							AF_INET : AF_INET6;
-			sprintf(evpn_desc, "l2vpn evpn type macip mac %s ip %s",
-				 prefix_mac2str(
-					&p->u.prefix_evpn.macip_addr.mac,
-					buf2, sizeof(buf2)),
-				 inet_ntop(family,
+			snprintf(
+				evpn_desc, sizeof(evpn_desc),
+				"l2vpn evpn type macip mac %s ip %s",
+				prefix_mac2str(&p->u.prefix_evpn.macip_addr.mac,
+					       buf2, sizeof(buf2)),
+				inet_ntop(
+					family,
 					&p->u.prefix_evpn.macip_addr.ip.ip.addr,
 					buf, PREFIX2STR_BUFFER));
 		}
 	} else if (p->u.prefix_evpn.route_type == BGP_EVPN_IMET_ROUTE) {
-		sprintf(evpn_desc, "l2vpn evpn type multicast ip %s",
-			inet_ntoa(p->u.prefix_evpn.imet_addr.ip.ipaddr_v4));
+		snprintf(evpn_desc, sizeof(evpn_desc),
+			 "l2vpn evpn type multicast ip %s",
+			 inet_ntoa(p->u.prefix_evpn.imet_addr.ip.ipaddr_v4));
 	} else if (p->u.prefix_evpn.route_type == BGP_EVPN_IP_PREFIX_ROUTE) {
 		uint8_t family = is_evpn_prefix_ipaddr_v4(
 					(struct prefix_evpn *)p) ? AF_INET
 								: AF_INET6;
-		sprintf(evpn_desc, "l2vpn evpn type prefix ip %s/%d",
-			inet_ntop(family,
-				  &p->u.prefix_evpn.prefix_addr.ip.ip.addr, buf,
-				  PREFIX2STR_BUFFER),
-			p->u.prefix_evpn.prefix_addr.ip_prefix_length);
+		snprintf(evpn_desc, sizeof(evpn_desc),
+			 "l2vpn evpn type prefix ip %s/%d",
+			 inet_ntop(family,
+				   &p->u.prefix_evpn.prefix_addr.ip.ip.addr,
+				   buf, PREFIX2STR_BUFFER),
+			 p->u.prefix_evpn.prefix_addr.ip_prefix_length);
 	}
 
 	vty_out(vty, "%s %s\n", desc, evpn_desc);
@@ -2592,12 +2597,14 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 			char tag_buf2[20];
 
 			bgp_evpn_label2str(label, num_labels, tag_buf2, 20);
-			sprintf(tag_buf, " label %s", tag_buf2);
+			snprintf(tag_buf, sizeof(tag_buf), " label %s",
+				 tag_buf2);
 		} else {
 			uint32_t label_value;
 
 			label_value = decode_label(label);
-			sprintf(tag_buf, " label %u", label_value);
+			snprintf(tag_buf, sizeof(tag_buf), " label %u",
+				 label_value);
 		}
 	}
 

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -787,32 +787,6 @@ static struct cmd_node bgp_dump_node = {
 	.config_write = config_write_bgp_dump,
 };
 
-#if 0
-char *
-config_time2str (unsigned int interval)
-{
-  static char buf[BUFSIZ];
-
-  buf[0] = '\0';
-
-  if (interval / 3600)
-    {
-      sprintf (buf, "%dh", interval / 3600);
-      interval %= 3600;
-    }
-  if (interval / 60)
-    {
-      sprintf (buf + strlen (buf), "%dm", interval /60);
-      interval %= 60;
-    }
-  if (interval)
-    {
-      sprintf (buf + strlen (buf), "%d", interval);
-    }
-  return buf;
-}
-#endif
-
 static int config_write_bgp_dump(struct vty *vty)
 {
 	if (bgp_dump_all.filename) {

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -115,7 +115,8 @@ static FILE *bgp_dump_open_file(struct bgp_dump *bgp_dump)
 	localtime_r(&clock, &tm);
 
 	if (bgp_dump->filename[0] != DIRECTORY_SEP) {
-		sprintf(fullpath, "%s/%s", vty_get_cwd(), bgp_dump->filename);
+		snprintf(fullpath, sizeof(fullpath), "%s/%s", vty_get_cwd(),
+			 bgp_dump->filename);
 		ret = strftime(realpath, MAXPATHLEN, fullpath, &tm);
 	} else
 		ret = strftime(realpath, MAXPATHLEN, bgp_dump->filename, &tm);

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -652,13 +652,16 @@ static int ecommunity_lb_str(char *buf, size_t bufsz, const uint8_t *pnt)
 	as |= (*pnt++);
 	(void)ptr_get_be32(pnt, &bw);
 	if (bw >= ONE_GBPS_BYTES)
-		sprintf(bps_buf, "%.3f Gbps", (float)(bw/ONE_GBPS_BYTES));
+		snprintf(bps_buf, sizeof(bps_buf), "%.3f Gbps",
+			 (float)(bw / ONE_GBPS_BYTES));
 	else if (bw >= ONE_MBPS_BYTES)
-		sprintf(bps_buf, "%.3f Mbps", (float)(bw/ONE_MBPS_BYTES));
+		snprintf(bps_buf, sizeof(bps_buf), "%.3f Mbps",
+			 (float)(bw / ONE_MBPS_BYTES));
 	else if (bw >= ONE_KBPS_BYTES)
-		sprintf(bps_buf, "%.3f Kbps", (float)(bw/ONE_KBPS_BYTES));
+		snprintf(bps_buf, sizeof(bps_buf), "%.3f Kbps",
+			 (float)(bw / ONE_KBPS_BYTES));
 	else
-		sprintf(bps_buf, "%u bps", bw * 8);
+		snprintf(bps_buf, sizeof(bps_buf), "%u bps", bw * 8);
 
 	len = snprintf(buf, bufsz, "LB:%u:%u (%s)", as, bw, bps_buf);
 	return len;

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5386,7 +5386,8 @@ void bgp_evpn_derive_auto_rd(struct bgp *bgp, struct bgpevpn *vpn)
 
 	vpn->prd.family = AF_UNSPEC;
 	vpn->prd.prefixlen = 64;
-	sprintf(buf, "%s:%hu", inet_ntoa(bgp->router_id), vpn->rd_id);
+	snprintf(buf, sizeof(buf), "%s:%hu", inet_ntoa(bgp->router_id),
+		 vpn->rd_id);
 	(void)str2prefix_rd(buf, &vpn->prd);
 	UNSET_FLAG(vpn->flags, VNI_FLAG_RD_CFGD);
 }
@@ -5529,7 +5530,8 @@ struct evpnes *bgp_evpn_es_new(struct bgp *bgp,
 	bf_assign_index(bm->rd_idspace, es->rd_id);
 	es->prd.family = AF_UNSPEC;
 	es->prd.prefixlen = 64;
-	sprintf(buf, "%s:%hu", inet_ntoa(bgp->router_id), es->rd_id);
+	snprintf(buf, sizeof(buf), "%s:%hu", inet_ntoa(bgp->router_id),
+		 es->rd_id);
 	(void)str2prefix_rd(buf, &es->prd);
 
 	/* Initialize the ES route table */

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -87,7 +87,7 @@ static void display_vrf_import_rt(struct vty *vty, struct vrf_irt_node *irt,
 		eas.as |= (*pnt++);
 		ptr_get_be32(pnt, &eas.val);
 
-		snprintf(rt_buf, RT_ADDRSTRLEN, "%u:%u", eas.as, eas.val);
+		snprintf(rt_buf, sizeof(rt_buf), "%u:%u", eas.as, eas.val);
 
 		if (json)
 			json_object_string_add(json_rt, "rt", rt_buf);
@@ -102,7 +102,7 @@ static void display_vrf_import_rt(struct vty *vty, struct vrf_irt_node *irt,
 		eip.val = (*pnt++ << 8);
 		eip.val |= (*pnt++);
 
-		snprintf(rt_buf, RT_ADDRSTRLEN, "%s:%u", inet_ntoa(eip.ip),
+		snprintf(rt_buf, sizeof(rt_buf), "%s:%u", inet_ntoa(eip.ip),
 			 eip.val);
 
 		if (json)
@@ -117,7 +117,7 @@ static void display_vrf_import_rt(struct vty *vty, struct vrf_irt_node *irt,
 		eas.val = (*pnt++ << 8);
 		eas.val |= (*pnt++);
 
-		snprintf(rt_buf, RT_ADDRSTRLEN, "%u:%u", eas.as, eas.val);
+		snprintf(rt_buf, sizeof(rt_buf), "%u:%u", eas.as, eas.val);
 
 		if (json)
 			json_object_string_add(json_rt, "rt", rt_buf);
@@ -197,7 +197,7 @@ static void display_import_rt(struct vty *vty, struct irt_node *irt,
 		eas.as |= (*pnt++);
 		ptr_get_be32(pnt, &eas.val);
 
-		snprintf(rt_buf, RT_ADDRSTRLEN, "%u:%u", eas.as, eas.val);
+		snprintf(rt_buf, sizeof(rt_buf), "%u:%u", eas.as, eas.val);
 
 		if (json)
 			json_object_string_add(json_rt, "rt", rt_buf);
@@ -212,7 +212,7 @@ static void display_import_rt(struct vty *vty, struct irt_node *irt,
 		eip.val = (*pnt++ << 8);
 		eip.val |= (*pnt++);
 
-		snprintf(rt_buf, RT_ADDRSTRLEN, "%s:%u", inet_ntoa(eip.ip),
+		snprintf(rt_buf, sizeof(rt_buf), "%s:%u", inet_ntoa(eip.ip),
 			 eip.val);
 
 		if (json)
@@ -227,7 +227,7 @@ static void display_import_rt(struct vty *vty, struct irt_node *irt,
 		eas.val = (*pnt++ << 8);
 		eas.val |= (*pnt++);
 
-		snprintf(rt_buf, RT_ADDRSTRLEN, "%u:%u", eas.as, eas.val);
+		snprintf(rt_buf, sizeof(rt_buf), "%u:%u", eas.as, eas.val);
 
 		if (json)
 			json_object_string_add(json_rt, "rt", rt_buf);
@@ -841,7 +841,7 @@ static void show_vni_routes_hash(struct hash_bucket *bucket, void *arg)
 	json_object *json_vni = NULL;
 	char vni_str[VNI_STR_LEN];
 
-	snprintf(vni_str, VNI_STR_LEN, "%d", vpn->vni);
+	snprintf(vni_str, sizeof(vni_str), "%d", vpn->vni);
 	if (json) {
 		json_vni = json_object_new_object();
 		json_object_int_add(json_vni, "vni", vpn->vni);
@@ -880,7 +880,7 @@ static void show_l3vni_entry(struct vty *vty, struct bgp *bgp,
 
 	/* if an l3vni is present in bgp it is live */
 	buf1[0] = '\0';
-	sprintf(buf1, "*");
+	snprintf(buf1, sizeof(buf1), "*");
 
 	if (json) {
 		json_object_int_add(json_vni, "vni", bgp->l3vni);
@@ -921,9 +921,11 @@ static void show_l3vni_entry(struct vty *vty, struct bgp *bgp,
 					      json_object_new_string(ecom_str));
 		} else {
 			if (listcount(bgp->vrf_import_rtl) > 1)
-				sprintf(rt_buf, "%s, ...", ecom_str);
+				snprintf(rt_buf, sizeof(rt_buf), "%s, ...",
+					 ecom_str);
 			else
-				sprintf(rt_buf, "%s", ecom_str);
+				snprintf(rt_buf, sizeof(rt_buf), "%s",
+					 ecom_str);
 			vty_out(vty, " %-25s", rt_buf);
 		}
 
@@ -947,9 +949,11 @@ static void show_l3vni_entry(struct vty *vty, struct bgp *bgp,
 					      json_object_new_string(ecom_str));
 		} else {
 			if (listcount(bgp->vrf_export_rtl) > 1)
-				sprintf(rt_buf, "%s, ...", ecom_str);
+				snprintf(rt_buf, sizeof(rt_buf), "%s, ...",
+					 ecom_str);
 			else
-				sprintf(rt_buf, "%s", ecom_str);
+				snprintf(rt_buf, sizeof(rt_buf), "%s",
+					 ecom_str);
 			vty_out(vty, " %-25s", rt_buf);
 		}
 
@@ -968,7 +972,7 @@ static void show_l3vni_entry(struct vty *vty, struct bgp *bgp,
 		char vni_str[VNI_STR_LEN];
 
 		json_object_object_add(json_vni, "exportRTs", json_export_rtl);
-		snprintf(vni_str, VNI_STR_LEN, "%u", bgp->l3vni);
+		snprintf(vni_str, sizeof(vni_str), "%u", bgp->l3vni);
 		json_object_object_add(json, vni_str, json_vni);
 	} else {
 		vty_out(vty, "\n");
@@ -1046,7 +1050,7 @@ static void show_vni_entry(struct hash_bucket *bucket, void *args[])
 
 	buf1[0] = '\0';
 	if (is_vni_live(vpn))
-		sprintf(buf1, "*");
+		snprintf(buf1, sizeof(buf1), "*");
 
 	if (json) {
 		json_object_int_add(json_vni, "vni", vpn->vni);
@@ -1098,9 +1102,11 @@ static void show_vni_entry(struct hash_bucket *bucket, void *args[])
 					      json_object_new_string(ecom_str));
 		} else {
 			if (listcount(vpn->import_rtl) > 1)
-				sprintf(rt_buf, "%s, ...", ecom_str);
+				snprintf(rt_buf, sizeof(rt_buf), "%s, ...",
+					 ecom_str);
 			else
-				sprintf(rt_buf, "%s", ecom_str);
+				snprintf(rt_buf, sizeof(rt_buf), "%s",
+					 ecom_str);
 			vty_out(vty, " %-25s", rt_buf);
 		}
 
@@ -1124,9 +1130,11 @@ static void show_vni_entry(struct hash_bucket *bucket, void *args[])
 					      json_object_new_string(ecom_str));
 		} else {
 			if (listcount(vpn->export_rtl) > 1)
-				sprintf(rt_buf, "%s, ...", ecom_str);
+				snprintf(rt_buf, sizeof(rt_buf), "%s, ...",
+					 ecom_str);
 			else
-				sprintf(rt_buf, "%s", ecom_str);
+				snprintf(rt_buf, sizeof(rt_buf), "%s",
+					 ecom_str);
 			vty_out(vty, " %-25s", rt_buf);
 		}
 
@@ -1145,7 +1153,7 @@ static void show_vni_entry(struct hash_bucket *bucket, void *args[])
 		char vni_str[VNI_STR_LEN];
 
 		json_object_object_add(json_vni, "exportRTs", json_export_rtl);
-		snprintf(vni_str, VNI_STR_LEN, "%u", vpn->vni);
+		snprintf(vni_str, sizeof(vni_str), "%u", vpn->vni);
 		json_object_object_add(json, vni_str, json_vni);
 	} else {
 		vty_out(vty, "\n");

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1321,7 +1321,8 @@ int bgp_stop(struct peer *peer)
 		if ((peer->status == OpenConfirm)
 		    || (peer->status == Established)) {
 			/* ORF received prefix-filter pnt */
-			sprintf(orf_name, "%s.%d.%d", peer->host, afi, safi);
+			snprintf(orf_name, sizeof(orf_name), "%s.%d.%d",
+				 peer->host, afi, safi);
 			prefix_bgp_orf_remove_all(afi, orf_name);
 		}
 	}

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1960,8 +1960,8 @@ static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 					break;
 
 				/* ORF prefix-list name */
-				sprintf(name, "%s.%d.%d", peer->host, afi,
-					safi);
+				snprintf(name, sizeof(name), "%s.%d.%d",
+					 peer->host, afi, safi);
 
 				while (p_pnt < p_end) {
 					/* If the ORF entry is malformed, want

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -605,13 +605,15 @@ static int bgp_pbr_validate_policy_route(struct bgp_pbr_entry_main *api)
 				    api->fragment[i].value != 4 &&
 				    api->fragment[i].value != 8) {
 					success = false;
-					sprintf(fail_str,
+					snprintf(
+						fail_str, sizeof(fail_str),
 						"Value not valid (%d) for this implementation",
 						api->fragment[i].value);
 				}
 			}
 		} else
-			sprintf(fail_str, "too complex. ignoring");
+			snprintf(fail_str, sizeof(fail_str),
+				 "too complex. ignoring");
 		if (!success) {
 			if (BGP_DEBUG(pbr, PBR))
 				zlog_debug("BGP: match fragment operation (%d) %s",

--- a/bgpd/bgp_rd.c
+++ b/bgpd/bgp_rd.c
@@ -210,6 +210,6 @@ void form_auto_rd(struct in_addr router_id,
 
 	prd->family = AF_UNSPEC;
 	prd->prefixlen = 64;
-	sprintf(buf, "%s:%hu", inet_ntoa(router_id), rd_id);
+	snprintf(buf, sizeof(buf), "%s:%hu", inet_ntoa(router_id), rd_id);
 	(void)str2prefix_rd(buf, prd);
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12356,8 +12356,7 @@ DEFUN (show_ip_bgp_neighbor_received_prefix_filter,
 		}
 	}
 
-	snprintf(name, 
-		 sizeof(name), "%s.%d.%d", peer->host, afi, safi);
+	snprintf(name, sizeof(name), "%s.%d.%d", peer->host, afi, safi);
 	count = prefix_bgp_show_prefix_list(NULL, afi, name, uj);
 	if (count) {
 		if (!uj)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2264,7 +2264,7 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,
 			bgp_path_info_path_with_addpath_rx_str(new_select,
 							       path_buf);
 		else
-			sprintf(path_buf, "NONE");
+			snprintf(path_buf, sizeof(path_buf), "NONE");
 		zlog_debug(
 			"%s: After path selection, newbest is %s oldbest was %s",
 			pfx_buf, path_buf,
@@ -7635,17 +7635,17 @@ void route_vty_out(struct vty *vty, const struct prefix *p,
 
 		switch (af) {
 		case AF_INET:
-			sprintf(nexthop, "%s",
-				inet_ntop(af, &attr->mp_nexthop_global_in, buf,
-					  BUFSIZ));
+			snprintf(nexthop, sizeof(nexthop), "%s",
+				 inet_ntop(af, &attr->mp_nexthop_global_in, buf,
+					   BUFSIZ));
 			break;
 		case AF_INET6:
-			sprintf(nexthop, "%s",
-				inet_ntop(af, &attr->mp_nexthop_global, buf,
-					  BUFSIZ));
+			snprintf(nexthop, sizeof(nexthop), "%s",
+				 inet_ntop(af, &attr->mp_nexthop_global, buf,
+					   BUFSIZ));
 			break;
 		default:
-			sprintf(nexthop, "?");
+			snprintf(nexthop, sizeof(nexthop), "?");
 			break;
 		}
 
@@ -12356,7 +12356,8 @@ DEFUN (show_ip_bgp_neighbor_received_prefix_filter,
 		}
 	}
 
-	sprintf(name, "%s.%d.%d", peer->host, afi, safi);
+	snprintf(name, 
+		 sizeof(name), "%s.%d.%d", peer->host, afi, safi);
 	count = prefix_bgp_show_prefix_list(NULL, afi, name, uj);
 	if (count) {
 		if (!uj)
@@ -13249,8 +13250,9 @@ static void bgp_config_write_network_evpn(struct vty *vty, struct bgp *bgp,
 				inet_ntop(family,
 					  &p->u.prefix_evpn.prefix_addr.ip.ip.addr,
 					  local_buf, PREFIX_STRLEN);
-				sprintf(buf, "%s/%u", local_buf,
-					p->u.prefix_evpn.prefix_addr.ip_prefix_length);
+				snprintf(buf, sizeof(buf), "%s/%u", local_buf,
+					 p->u.prefix_evpn.prefix_addr
+						 .ip_prefix_length);
 			} else {
 				prefix2str(p, buf, sizeof(buf));
 			}

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -180,12 +180,14 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 
 					if (type == RD_TYPE_AS
 					    || type == RD_TYPE_AS4)
-						sprintf(rd_str, "%u:%d",
-							rd_as.as, rd_as.val);
+						snprintf(rd_str, sizeof(rd_str),
+							 "%u:%d", rd_as.as,
+							 rd_as.val);
 					else if (type == RD_TYPE_IP)
-						sprintf(rd_str, "%s:%d",
-							inet_ntoa(rd_ip.ip),
-							rd_ip.val);
+						snprintf(rd_str, sizeof(rd_str),
+							 "%s:%d",
+							 inet_ntoa(rd_ip.ip),
+							 rd_ip.val);
 					json_object_string_add(
 						json_routes,
 						"rd", rd_str);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8619,8 +8619,9 @@ static void bgp_show_peer_reset(struct vty * vty, struct peer *peer,
 					 peer->notify.code,
 					 peer->notify.subcode);
 
-			sprintf(errorcodesubcode_hexstr, "%02X%02X",
-				peer->notify.code, peer->notify.subcode);
+			snprintf(errorcodesubcode_hexstr,
+				 sizeof(errorcodesubcode_hexstr), "%02X%02X",
+				 peer->notify.code, peer->notify.subcode);
 			json_object_string_add(json_peer,
 					       "lastErrorCodeSubcode",
 					       errorcodesubcode_hexstr);
@@ -8799,12 +8800,14 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 				if (peer->hostname
 				    && CHECK_FLAG(bgp->flags,
 						  BGP_FLAG_SHOW_HOSTNAME))
-					sprintf(neighbor_buf, "%s%s(%s) ",
-						dn_flag, peer->hostname,
-						peer->host);
+					snprintf(neighbor_buf,
+						 sizeof(neighbor_buf),
+						 "%s%s(%s) ", dn_flag,
+						 peer->hostname, peer->host);
 				else
-					sprintf(neighbor_buf, "%s%s ", dn_flag,
-						peer->host);
+					snprintf(neighbor_buf,
+						 sizeof(neighbor_buf), "%s%s ",
+						 dn_flag, peer->host);
 
 				len = strlen(neighbor_buf);
 
@@ -9877,7 +9880,8 @@ static void bgp_show_peer_gr_status(struct vty *vty, struct peer *p,
 					: sockunion2str(&p->su, buf,
 							SU_ADDRSTRLEN));
 	} else {
-		sprintf(neighborAddr, "%s%s", dn_flag, p->host);
+		snprintf(neighborAddr, sizeof(neighborAddr), "%s%s", dn_flag,
+			 p->host);
 
 		if (use_json)
 			json_object_string_add(json, "neighborAddr",
@@ -9978,7 +9982,8 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 		else
 			json_object_free(json_af);
 
-		sprintf(orf_pfx_name, "%s.%d.%d", p->host, afi, safi);
+		snprintf(orf_pfx_name, sizeof(orf_pfx_name), "%s.%d.%d",
+			 p->host, afi, safi);
 		orf_pfx_count = prefix_bgp_show_prefix_list(
 			NULL, afi, orf_pfx_name, use_json);
 
@@ -10274,7 +10279,8 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 				PEER_CAP_ORF_PREFIX_RM_OLD_RCV, use_json, NULL);
 		}
 
-		sprintf(orf_pfx_name, "%s.%d.%d", p->host, afi, safi);
+		snprintf(orf_pfx_name, sizeof(orf_pfx_name), "%s.%d.%d",
+			 p->host, afi, safi);
 		orf_pfx_count = prefix_bgp_show_prefix_list(
 			NULL, afi, orf_pfx_name, use_json);
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9860,7 +9860,8 @@ static void bgp_show_peer_gr_status(struct vty *vty, struct peer *p,
 {
 	char buf[SU_ADDRSTRLEN] = {0};
 	char dn_flag[2] = {0};
-	char neighborAddr[INET6_ADDRSTRLEN] = {0};
+	/* '*' + v6 address of neighbor */
+	char neighborAddr[INET6_ADDRSTRLEN + 1] = {0};
 
 	if (!p->conf_if && peer_dynamic_neighbor(p))
 		dn_flag[0] = '*';

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -4627,7 +4627,8 @@ void bgp_rfapi_show_summary(struct bgp *bgp, struct vty *vty)
 		(hc->rfp_cfg.download_type == RFAPI_RFP_DOWNLOAD_PARTIAL
 			 ? "(default)"
 			 : ""));
-	sprintf(tmp, "%u seconds", hc->rfp_cfg.ftd_advertisement_interval);
+	snprintf(tmp, sizeof(tmp), "%u seconds",
+		 hc->rfp_cfg.ftd_advertisement_interval);
 	vty_out(vty, "%-39s %-19s %s\n", "    Advertisement Interval:", tmp,
 		(hc->rfp_cfg.ftd_advertisement_interval
 				 == RFAPI_RFP_CFG_DEFAULT_FTD_ADVERTISEMENT_INTERVAL

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -3506,8 +3506,7 @@ DEFUN (debug_rfapi_show_import,
 						"\nLNI-based Ethernet Tables:\n");
 					first_l2 = 0;
 				}
-				snprintf(buf, sizeof(buf), "L2VPN LNI=%u",
-					 lni);
+				snprintf(buf, sizeof(buf), "L2VPN LNI=%u", lni);
 				rfapiShowImportTable(
 					vty, buf, it->imported_vpn[AFI_L2VPN],
 					1);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -3506,7 +3506,8 @@ DEFUN (debug_rfapi_show_import,
 						"\nLNI-based Ethernet Tables:\n");
 					first_l2 = 0;
 				}
-				snprintf(buf, BUFSIZ, "L2VPN LNI=%u", lni);
+				snprintf(buf, sizeof(buf), "L2VPN LNI=%u",
+					 lni);
 				rfapiShowImportTable(
 					vty, buf, it->imported_vpn[AFI_L2VPN],
 					1);

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1038,7 +1038,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 	 * Prefix
 	 */
 	buf_pfx[0] = 0;
-	snprintf(buf_pfx, BUFSIZ, "%s/%d",
+	snprintf(buf_pfx, sizeof(buf_pfx), "%s/%d",
 		 rfapi_ntop(p->family, &p->u.prefix, buf_ntop, BUFSIZ),
 		 p->prefixlen);
 	buf_pfx[BUFSIZ - 1] = 0;
@@ -1049,7 +1049,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 	 */
 	buf_un[0] = 0;
 	if (!rfapiGetUnAddrOfVpnBi(bpi, &pfx_un)) {
-		snprintf(buf_un, BUFSIZ, "%s",
+		snprintf(buf_un, sizeof(buf_un), "%s",
 			 inet_ntop(pfx_un.family, &pfx_un.u.prefix, buf_ntop,
 				   BUFSIZ));
 	}
@@ -1063,18 +1063,18 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 	if (tun_type == BGP_ENCAP_TYPE_MPLS) {
 		/* MPLS carries un in nrli next hop (same as vn for IP tunnels)
 		 */
-		snprintf(buf_un, BUFSIZ, "%s",
+		snprintf(buf_un, sizeof(buf_un), "%s",
 			 inet_ntop(pfx_vn.family, &pfx_vn.u.prefix, buf_ntop,
 				   BUFSIZ));
 		if (bpi->extra) {
 			uint32_t l = decode_label(&bpi->extra->label[0]);
-			snprintf(buf_vn, BUFSIZ, "Label: %d", l);
+			snprintf(buf_vn, sizeof(buf_vn), "Label: %d", l);
 		} else /* should never happen */
 		{
-			snprintf(buf_vn, BUFSIZ, "Label: N/A");
+			snprintf(buf_vn, sizeof(buf_vn), "Label: N/A");
 		}
 	} else {
-		snprintf(buf_vn, BUFSIZ, "%s",
+		snprintf(buf_vn, sizeof(buf_vn), "%s",
 			 inet_ntop(pfx_vn.family, &pfx_vn.u.prefix, buf_ntop,
 				   BUFSIZ));
 	}

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -275,7 +275,12 @@ static void vnc_rhnck(char *tag)
 	vnc_zlog_debug_verbose("%s: vnc_rhnck OK", tag);
 }
 
-#define VNC_RHNCK(n)	do {char buf[BUFSIZ];sprintf(buf,"%s: %s", __func__, #n);vnc_rhnck(buf);} while (0)
+#define VNC_RHNCK(n)                                                           \
+	do {                                                                   \
+		char buf[BUFSIZ];                                              \
+		snprintf(buf, sizeof(buf), "%s: %s", __func__, #n);            \
+		vnc_rhnck(buf);                                                \
+	} while (0)
 
 #else
 

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -611,11 +611,9 @@ void lspid_print(uint8_t *lsp_id, char *dest, char dynhost, char frag)
 		dyn = NULL;
 
 	if (dyn)
-		snprintf(id, 
-		         sizeof(id), "%.14s", dyn->hostname);
+		snprintf(id, sizeof(id), "%.14s", dyn->hostname);
 	else if (!memcmp(isis->sysid, lsp_id, ISIS_SYS_ID_LEN) && dynhost)
-		snprintf(id, 
-		         sizeof(id), "%.14s", cmd_hostname_get());
+		snprintf(id, sizeof(id), "%.14s", cmd_hostname_get());
 	else
 		memcpy(id, sysid_print(lsp_id), 15);
 	if (frag)

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -603,7 +603,7 @@ static void lsp_set_time(struct isis_lsp *lsp)
 void lspid_print(uint8_t *lsp_id, char *dest, char dynhost, char frag)
 {
 	struct isis_dynhn *dyn = NULL;
-	uint8_t id[SYSID_STRLEN];
+	char id[SYSID_STRLEN];
 
 	if (dynhost)
 		dyn = dynhn_find_by_id(lsp_id);
@@ -611,9 +611,11 @@ void lspid_print(uint8_t *lsp_id, char *dest, char dynhost, char frag)
 		dyn = NULL;
 
 	if (dyn)
-		sprintf((char *)id, "%.14s", dyn->hostname);
+		snprintf(id, 
+		         sizeof(id), "%.14s", dyn->hostname);
 	else if (!memcmp(isis->sysid, lsp_id, ISIS_SYS_ID_LEN) && dynhost)
-		sprintf((char *)id, "%.14s", cmd_hostname_get());
+		snprintf(id, 
+		         sizeof(id), "%.14s", cmd_hostname_get());
 	else
 		memcpy(id, sysid_print(lsp_id), 15);
 	if (frag)
@@ -659,7 +661,7 @@ void lsp_print(struct isis_lsp *lsp, struct vty *vty, char dynhost)
 	vty_out(vty, "0x%08" PRIx32 "  ", lsp->hdr.seqno);
 	vty_out(vty, "0x%04" PRIx16 "  ", lsp->hdr.checksum);
 	if (lsp->hdr.rem_lifetime == 0) {
-		snprintf(age_out, 8, "(%d)", lsp->age_out);
+		snprintf(age_out, sizeof(age_out), "(%d)", lsp->age_out);
 		age_out[7] = '\0';
 		vty_out(vty, "%7s   ", age_out);
 	} else

--- a/ldpd/ldp_vty_exec.c
+++ b/ldpd/ldp_vty_exec.c
@@ -193,7 +193,8 @@ show_interface_msg_json(struct imsg *imsg, struct show_params *params,
 		json_object_int_add(json_iface, "adjacencyCount",
 		    iface->adj_cnt);
 
-		sprintf(key_name, "%s: %s", iface->name, af_name(iface->af));
+		snprintf(key_name, sizeof(key_name), "%s: %s", iface->name,
+			 af_name(iface->af));
 		json_object_object_add(json, key_name, json_iface);
 		break;
 	case IMSG_CTL_END:
@@ -1328,7 +1329,8 @@ show_l2vpn_binding_msg_json(struct imsg *imsg, struct show_params *params,
 			json_object_string_add(json_pw, "remoteLabel",
 			    "unassigned");
 
-		sprintf(key_name, "%s: %u", inet_ntoa(pw->lsr_id), pw->pwid);
+		snprintf(key_name, sizeof(key_name), "%s: %u",
+			 inet_ntoa(pw->lsr_id), pw->pwid);
 		json_object_object_add(json, key_name, json_pw);
 		break;
 	case IMSG_CTL_END:

--- a/lib/command.c
+++ b/lib/command.c
@@ -1535,7 +1535,8 @@ static int file_write_config(struct vty *vty)
 
 
 	config_file_tmp = XMALLOC(MTYPE_TMP, strlen(config_file) + 8);
-	sprintf(config_file_tmp, "%s.XXXXXX", config_file);
+	snprintf(config_file_tmp, strlen(config_file) + 8, "%s.XXXXXX",
+		 config_file);
 
 	/* Open file to configuration write. */
 	fd = mkstemp(config_file_tmp);

--- a/lib/csv.c
+++ b/lib/csv.c
@@ -640,7 +640,7 @@ static int get_memory_usage(pid_t pid)
 	char buf[4096], status_child[BUFSIZ];
 	char *vm;
 
-	sprintf(status_child, "/proc/%d/status", pid);
+	snprintf(status_child, sizeof(status_child), "/proc/%d/status", pid);
 	if ((fd = open(status_child, O_RDONLY)) < 0)
 		return -1;
 
@@ -672,8 +672,8 @@ int main()
 
 	log_verbose("Mem: %d\n", get_memory_usage(getpid()));
 	csv_init(&csv, buf, 256);
-	sprintf(hdr1, "%4d", 0);
-	sprintf(hdr2, "%4d", 1);
+	snprintf(hdr1, sizeof(hdr1), "%4d", 0);
+	snprintf(hdr2, sizeof(hdr2), "%4d", 1);
 	log_verbose("(%zu/%zu/%d/%d)\n", strlen(hdr1), strlen(hdr2), atoi(hdr1),
 		    atoi(hdr2));
 	rec = csv_encode(&csv, 2, hdr1, hdr2);
@@ -685,8 +685,8 @@ int main()
 	}
 	csv_encode(&csv, 2, "pdfadfadfadsadsaddfdfdsfdsd", "35444554545454545");
 	log_verbose("%s\n", buf);
-	sprintf(hdr1, "%4d", csv.csv_len);
-	sprintf(hdr2, "%4d", 1);
+	snprintf(hdr1, sizeof(hdr1), "%4d", csv.csv_len);
+	snprintf(hdr2, sizeof(hdr2), "%4d", 1);
 	log_verbose("(%zu/%zu/%d/%d)\n", strlen(hdr1), strlen(hdr2), atoi(hdr1),
 		    atoi(hdr2));
 	rec = csv_encode_record(&csv, rec, 2, hdr1, hdr2);

--- a/lib/csv.c
+++ b/lib/csv.c
@@ -637,7 +637,7 @@ void csv_dump(csv_t *csv)
 static int get_memory_usage(pid_t pid)
 {
 	int fd, data, stack;
-	char buf[4096], status_child[BUFSIZ];
+	char buf[4096], status_child[PATH_MAX];
 	char *vm;
 
 	snprintf(status_child, sizeof(status_child), "/proc/%d/status", pid);

--- a/lib/if.c
+++ b/lib/if.c
@@ -949,8 +949,9 @@ connected_log(struct connected *connected, char *str)
 	p = connected->address;
 
 	vrf = vrf_lookup_by_id(ifp->vrf_id);
-	snprintf(logbuf, BUFSIZ, "%s interface %s vrf %s(%u) %s %s/%d ", str,
-		 ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, prefix_family_str(p),
+	snprintf(logbuf, sizeof(logbuf), "%s interface %s vrf %s(%u) %s %s/%d ",
+		 str, ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id,
+		 prefix_family_str(p),
 		 inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ), p->prefixlen);
 
 	p = connected->destination;
@@ -973,8 +974,8 @@ nbr_connected_log(struct nbr_connected *connected, char *str)
 	ifp = connected->ifp;
 	p = connected->address;
 
-	snprintf(logbuf, BUFSIZ, "%s interface %s %s %s/%d ", str, ifp->name,
-		 prefix_family_str(p),
+	snprintf(logbuf, sizeof(logbuf), "%s interface %s %s %s/%d ", str,
+		 ifp->name, prefix_family_str(p),
 		 inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ), p->prefixlen);
 
 	zlog_info("%s", logbuf);

--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -260,9 +260,10 @@ DEFUN_HIDDEN (no_config_log_monitor,
 static int set_log_file(struct zlog_cfg_file *target, struct vty *vty,
 			const char *fname, int loglevel)
 {
-	char *p = NULL;
+	char path[MAXPATHLEN + 1];
 	const char *fullpath;
 	bool ok;
+
 
 	/* Path detection. */
 	if (!IS_DIRECTORY_SEP(*fname)) {
@@ -276,16 +277,13 @@ static int set_log_file(struct zlog_cfg_file *target, struct vty *vty,
 			return CMD_WARNING_CONFIG_FAILED;
 		}
 
-		p = XMALLOC(MTYPE_TMP, strlen(cwd) + strlen(fname) + 2);
-		sprintf(p, "%s/%s", cwd, fname);
-		fullpath = p;
+		snprintf(path, sizeof(path), "%s/%s", cwd, fname);
+		fullpath = path;
 	} else
 		fullpath = fname;
 
 	target->prio_min = loglevel;
 	ok = zlog_file_set_filename(target, fullpath);
-
-	XFREE(MTYPE_TMP, p);
 
 	if (!ok) {
 		if (vty)

--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -277,7 +277,15 @@ static int set_log_file(struct zlog_cfg_file *target, struct vty *vty,
 			return CMD_WARNING_CONFIG_FAILED;
 		}
 
-		snprintf(path, sizeof(path), "%s/%s", cwd, fname);
+		int pr = snprintf(path, sizeof(path), "%s/%s", cwd, fname);
+		if (pr < 0 || (unsigned int)pr >= sizeof(path)) {
+			flog_err_sys(
+				EC_LIB_SYSTEM_CALL,
+				"%s: Path too long ('%s/%s'); system maximum is %u",
+				__func__, cwd, fname, MAXPATHLEN);
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+
 		fullpath = path;
 	} else
 		fullpath = fname;

--- a/lib/netns_linux.c
+++ b/lib/netns_linux.c
@@ -431,7 +431,7 @@ char *ns_netns_pathname(struct vty *vty, const char *name)
 		/* relevant pathname */
 		char tmp_name[PATH_MAX];
 
-		snprintf(tmp_name, PATH_MAX, "%s/%s", NS_RUN_DIR, name);
+		snprintf(tmp_name, sizeof(tmp_name), "%s/%s", NS_RUN_DIR, name);
 		result = realpath(tmp_name, pathname);
 	}
 

--- a/lib/pid_output.c
+++ b/lib/pid_output.c
@@ -65,7 +65,7 @@ pid_t pid_output(const char *path)
 			exit(1);
 		}
 
-		sprintf(buf, "%d\n", (int)pid);
+		snprintf(buf, sizeof(buf), "%d\n", (int)pid);
 		pidsize = strlen(buf);
 		if ((tmp = write(fd, buf, pidsize)) != (int)pidsize)
 			flog_err_sys(

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1961,10 +1961,9 @@ int prefix_bgp_show_prefix_list(struct vty *vty, afi_t afi, char *name,
 			char buf_a[BUFSIZ];
 			char buf_b[BUFSIZ];
 
-			sprintf(buf_a, "%s/%d",
-				inet_ntop(p->family, p->u.val, buf_b,
-					  BUFSIZ),
-				p->prefixlen);
+			snprintf(buf_a, sizeof(buf_a), "%s/%d",
+				 inet_ntop(p->family, p->u.val, buf_b, BUFSIZ),
+				 p->prefixlen);
 
 			json_object_int_add(json_list, "seq", pentry->seq);
 			json_object_string_add(json_list, "seqPrefixListType",

--- a/lib/ptm_lib.c
+++ b/lib/ptm_lib.c
@@ -65,10 +65,10 @@ static csv_record_t *_ptm_lib_encode_header(csv_t *csv, csv_record_t *rec,
 	char client_buf[32];
 	csv_record_t *rec1;
 
-	sprintf(msglen_buf, "%4d", msglen);
-	sprintf(vers_buf, "%4d", version);
-	sprintf(type_buf, "%4d", type);
-	sprintf(cmdid_buf, "%4d", cmd_id);
+	snprintf(msglen_buf, sizeof(msglen_buf), "%4d", msglen);
+	snprintf(vers_buf, sizeof(vers_buf), "%4d", version);
+	snprintf(type_buf, sizeof(type_buf), "%4d", type);
+	snprintf(cmdid_buf, sizeof(cmdid_buf), "%4d", cmd_id);
 	snprintf(client_buf, 17, "%16.16s", client_name);
 	if (rec) {
 		rec1 = csv_encode_record(csv, rec, 5, msglen_buf, vers_buf,

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2380,7 +2380,7 @@ static FILE *vty_use_backup_config(const char *fullpath)
 	}
 
 	fullpath_tmp = malloc(strlen(fullpath) + 8);
-	sprintf(fullpath_tmp, "%s.XXXXXX", fullpath);
+	snprintf(fullpath_tmp, strlen(fullpath) + 8, "%s.XXXXXX", fullpath);
 
 	/* Open file to configuration write. */
 	tmp = mkstemp(fullpath_tmp);

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -1882,7 +1882,7 @@ static void vty_serv_sock_addrinfo(const char *hostname, unsigned short port)
 	req.ai_flags = AI_PASSIVE;
 	req.ai_family = AF_UNSPEC;
 	req.ai_socktype = SOCK_STREAM;
-	sprintf(port_str, "%d", port);
+	snprintf(port_str, sizeof(port_str), "%d", port);
 	port_str[sizeof(port_str) - 1] = '\0';
 
 	ret = getaddrinfo(hostname, port_str, &req, &ainfo);

--- a/nhrpd/linux.c
+++ b/nhrpd/linux.c
@@ -25,6 +25,7 @@
 #include <linux/ip.h>
 #include <linux/if_arp.h>
 #include <linux/if_tunnel.h>
+#include <linux/limits.h>
 
 #include "nhrp_protocol.h"
 #include "os.h"
@@ -127,7 +128,7 @@ static int linux_configure_arp(const char *iface, int on)
 
 static int linux_icmp_redirect_off(const char *iface)
 {
-	char fname[256];
+	char fname[PATH_MAX];
 	int fd, ret = -1;
 
 	snprintf(fname, sizeof(fname),

--- a/nhrpd/linux.c
+++ b/nhrpd/linux.c
@@ -130,7 +130,8 @@ static int linux_icmp_redirect_off(const char *iface)
 	char fname[256];
 	int fd, ret = -1;
 
-	sprintf(fname, "/proc/sys/net/ipv4/conf/%s/send_redirects", iface);
+	snprintf(fname, sizeof(fname),
+		 "/proc/sys/net/ipv4/conf/%s/send_redirects", iface);
 	fd = open(fname, O_WRONLY);
 	if (fd < 0)
 		return -1;

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -397,10 +397,10 @@ void ospf6_lsa_show_summary(struct vty *vty, struct ospf6_lsa *lsa)
 			(unsigned long)ntohl(lsa->header->seqnum),
 			handler->lh_get_prefix_str(lsa, buf, sizeof(buf), 0));
 	} else if (type != OSPF6_LSTYPE_UNKNOWN) {
-		sprintf(tmpbuf, "%-4s %-15s%-15s%4hu %8lx",
-			ospf6_lstype_short_name(lsa->header->type), id,
-			adv_router, ospf6_lsa_age_current(lsa),
-			(unsigned long)ntohl(lsa->header->seqnum));
+		snprintf(tmpbuf, sizeof(tmpbuf), "%-4s %-15s%-15s%4hu %8lx",
+			 ospf6_lstype_short_name(lsa->header->type), id,
+			 adv_router, ospf6_lsa_age_current(lsa),
+			 (unsigned long)ntohl(lsa->header->seqnum));
 
 		while (handler->lh_get_prefix_str(lsa, buf, sizeof(buf), cnt)
 		       != NULL) {

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -306,7 +306,7 @@ int ospf_ase_calculate_route(struct ospf *ospf, struct ospf_lsa *lsa)
 	}
 
 	if (IS_DEBUG_OSPF(lsa, LSA)) {
-		snprintf(buf1, INET_ADDRSTRLEN, "%s",
+		snprintf(buf1, sizeof(buf1), "%s",
 			 inet_ntoa(al->header.adv_router));
 		zlog_debug(
 			"Route[External]: Calculate AS-external-LSA to %s/%d adv_router %s",

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -82,9 +82,8 @@ const char *ospf_area_name_string(struct ospf_area *area)
 		return "-";
 
 	area_id = ntohl(area->area_id.s_addr);
-	snprintf(buf, OSPF_AREA_STRING_MAXLEN, "%d.%d.%d.%d",
-		 (area_id >> 24) & 0xff, (area_id >> 16) & 0xff,
-		 (area_id >> 8) & 0xff, area_id & 0xff);
+	snprintf(buf, sizeof(buf), "%d.%d.%d.%d", (area_id >> 24) & 0xff,
+		 (area_id >> 16) & 0xff, (area_id >> 8) & 0xff, area_id & 0xff);
 	return buf;
 }
 
@@ -100,11 +99,11 @@ const char *ospf_area_desc_string(struct ospf_area *area)
 	type = area->external_routing;
 	switch (type) {
 	case OSPF_AREA_NSSA:
-		snprintf(buf, OSPF_AREA_DESC_STRING_MAXLEN, "%s [NSSA]",
+		snprintf(buf, sizeof(buf), "%s [NSSA]",
 			 ospf_area_name_string(area));
 		break;
 	case OSPF_AREA_STUB:
-		snprintf(buf, OSPF_AREA_DESC_STRING_MAXLEN, "%s [Stub]",
+		snprintf(buf, sizeof(buf), "%s [Stub]",
 			 ospf_area_name_string(area));
 		break;
 	default:
@@ -127,7 +126,7 @@ const char *ospf_if_name_string(struct ospf_interface *oi)
 		return oi->ifp->name;
 
 	ifaddr = ntohl(oi->address->u.prefix4.s_addr);
-	snprintf(buf, OSPF_IF_STRING_MAXLEN, "%s:%d.%d.%d.%d", oi->ifp->name,
+	snprintf(buf, sizeof(buf), "%s:%d.%d.%d.%d", oi->ifp->name,
 		 (ifaddr >> 24) & 0xff, (ifaddr >> 16) & 0xff,
 		 (ifaddr >> 8) & 0xff, ifaddr & 0xff);
 	return buf;
@@ -1669,7 +1668,7 @@ static int config_write_debug(struct vty *vty)
 		return CMD_SUCCESS;
 
 	if (ospf->instance)
-		sprintf(str, " %u", ospf->instance);
+		snprintf(str, sizeof(str), " %u", ospf->instance);
 
 	/* debug ospf ism (status|events|timers). */
 	if (IS_CONF_DEBUG_OSPF(ism, ISM) == OSPF_DEBUG_ISM)

--- a/ospfd/ospf_dump_api.c
+++ b/ospfd/ospf_dump_api.c
@@ -105,7 +105,7 @@ char *ospf_options_dump(uint8_t options)
 {
 	static char buf[OSPF_OPTION_STR_MAXLEN];
 
-	snprintf(buf, OSPF_OPTION_STR_MAXLEN, "*|%s|%s|%s|%s|%s|%s|%s",
+	snprintf(buf, sizeof(buf), "*|%s|%s|%s|%s|%s|%s|%s",
 		 (options & OSPF_OPTION_O) ? "O" : "-",
 		 (options & OSPF_OPTION_DC) ? "DC" : "-",
 		 (options & OSPF_OPTION_EA) ? "EA" : "-",

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -298,7 +298,8 @@ const char *dump_lsa_key(struct ospf_lsa *lsa)
 		strlcpy(id, inet_ntoa(lsah->id), sizeof(id));
 		strlcpy(ar, inet_ntoa(lsah->adv_router), sizeof(ar));
 
-		sprintf(buf, "Type%d,id(%s),ar(%s)", lsah->type, id, ar);
+		snprintf(buf, sizeof(buf), "Type%d,id(%s),ar(%s)", lsah->type,
+			 id, ar);
 	} else
 		strlcpy(buf, "NULL", sizeof(buf));
 

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -2094,7 +2094,7 @@ static void show_sr_node(struct vty *vty, struct json_object *json,
 			json_obj = json_object_new_object();
 			char tmp[2];
 
-			snprintf(tmp, 2, "%u", i);
+			snprintf(tmp, sizeof(tmp), "%u", i);
 			json_object_string_add(json_obj, tmp,
 					       srn->algo[i] == SR_ALGORITHM_SPF
 						       ? "SPF"
@@ -2129,13 +2129,15 @@ static void show_sr_node(struct vty *vty, struct json_object *json,
 			"---------------------  ---------  ---------------\n");
 	}
 	for (ALL_LIST_ELEMENTS_RO(srn->ext_prefix, node, srp)) {
-		snprintf(pref, 19, "%s/%u", inet_ntoa(srp->nhlfe.prefv4.prefix),
+		snprintf(pref, sizeof(pref), "%s/%u",
+			 inet_ntoa(srp->nhlfe.prefv4.prefix),
 			 srp->nhlfe.prefv4.prefixlen);
-		snprintf(sid, 22, "SR Pfx (idx %u)", srp->sid);
+		snprintf(sid, sizeof(sid), "SR Pfx (idx %u)", srp->sid);
 		if (srp->nhlfe.label_out == MPLS_LABEL_IMPLICIT_NULL)
-			sprintf(label, "pop");
+			snprintf(label, sizeof(label), "pop");
 		else
-			sprintf(label, "%u", srp->nhlfe.label_out);
+			snprintf(label, sizeof(label), "%u",
+				 srp->nhlfe.label_out);
 		itf = if_lookup_by_index(srp->nhlfe.ifindex, VRF_DEFAULT);
 		if (json) {
 			if (!json_prefix) {
@@ -2164,14 +2166,15 @@ static void show_sr_node(struct vty *vty, struct json_object *json,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(srn->ext_link, node, srl)) {
-		snprintf(pref, 19, "%s/%u",
+		snprintf(pref, sizeof(pref), "%s/%u",
 			 inet_ntoa(srl->nhlfe[0].prefv4.prefix),
 			 srl->nhlfe[0].prefv4.prefixlen);
-		snprintf(sid, 22, "SR Adj. (lbl %u)", srl->sid[0]);
+		snprintf(sid, sizeof(sid), "SR Adj. (lbl %u)", srl->sid[0]);
 		if (srl->nhlfe[0].label_out == MPLS_LABEL_IMPLICIT_NULL)
-			sprintf(label, "pop");
+			snprintf(label, sizeof(label), "pop");
 		else
-			sprintf(label, "%u", srl->nhlfe[0].label_out);
+			snprintf(label, sizeof(label), "%u",
+				 srl->nhlfe[0].label_out);
 		itf = if_lookup_by_index(srl->nhlfe[0].ifindex, VRF_DEFAULT);
 		if (json) {
 			if (!json_link) {
@@ -2194,11 +2197,13 @@ static void show_sr_node(struct vty *vty, struct json_object *json,
 			json_object_array_add(json_link, json_obj);
 			/* Backup Link */
 			json_obj = json_object_new_object();
-			snprintf(sid, 22, "SR Adj. (lbl %u)", srl->sid[1]);
+			snprintf(sid, sizeof(sid), "SR Adj. (lbl %u)",
+				 srl->sid[1]);
 			if (srl->nhlfe[1].label_out == MPLS_LABEL_IMPLICIT_NULL)
-				sprintf(label, "pop");
+				snprintf(label, sizeof(label), "pop");
 			else
-				sprintf(label, "%u", srl->nhlfe[0].label_out);
+				snprintf(label, sizeof(label), "%u",
+					 srl->nhlfe[0].label_out);
 			json_object_string_add(json_obj, "prefix", pref);
 			json_object_int_add(json_obj, "sid", srl->sid[1]);
 			json_object_int_add(json_obj, "inputLabel",
@@ -2215,11 +2220,13 @@ static void show_sr_node(struct vty *vty, struct json_object *json,
 				srl->nhlfe[0].label_in, label, sid,
 				itf ? itf->name : "-",
 				inet_ntoa(srl->nhlfe[0].nexthop));
-			snprintf(sid, 22, "SR Adj. (lbl %u)", srl->sid[1]);
+			snprintf(sid, sizeof(sid), "SR Adj. (lbl %u)",
+				 srl->sid[1]);
 			if (srl->nhlfe[1].label_out == MPLS_LABEL_IMPLICIT_NULL)
-				sprintf(label, "pop");
+				snprintf(label, sizeof(label), "pop");
 			else
-				sprintf(label, "%u", srl->nhlfe[1].label_out);
+				snprintf(label, sizeof(label), "%u",
+					 srl->nhlfe[1].label_out);
 			vty_out(vty, "%18s  %8u  %9s  %21s  %9s  %15s\n", pref,
 				srl->nhlfe[1].label_in, label, sid,
 				itf ? itf->name : "-",

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9263,8 +9263,8 @@ static void show_ip_ospf_route_external(struct vty *vty, struct ospf *ospf,
 
 		char buf1[19];
 
-		snprintf(buf1, 19, "%s/%d", inet_ntoa(rn->p.u.prefix4),
-			 rn->p.prefixlen);
+		snprintf(buf1, sizeof(buf1), "%s/%d",
+			 inet_ntoa(rn->p.u.prefix4), rn->p.prefixlen);
 		json_route = json_object_new_object();
 		if (json) {
 			json_object_object_add(json, buf1, json_route);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -83,7 +83,8 @@ static void area_id2str(char *buf, int length, struct in_addr *area_id,
 	if (area_id_fmt == OSPF_AREA_ID_FMT_DOTTEDQUAD)
 		inet_ntop(AF_INET, area_id, buf, length);
 	else
-		sprintf(buf, "%lu", (unsigned long)ntohl(area_id->s_addr));
+		snprintf(buf, length, "%lu",
+			 (unsigned long)ntohl(area_id->s_addr));
 }
 
 static int str2metric(const char *str, int *metric)
@@ -9997,7 +9998,7 @@ static int config_write_interface(struct vty *vty)
 static int config_write_network_area(struct vty *vty, struct ospf *ospf)
 {
 	struct route_node *rn;
-	uint8_t buf[INET_ADDRSTRLEN];
+	char buf[INET_ADDRSTRLEN];
 
 	/* `network area' print. */
 	for (rn = route_top(ospf->networks); rn; rn = route_next(rn))
@@ -10006,12 +10007,12 @@ static int config_write_network_area(struct vty *vty, struct ospf *ospf)
 
 			/* Create Area ID string by specified Area ID format. */
 			if (n->area_id_fmt == OSPF_AREA_ID_FMT_DOTTEDQUAD)
-				inet_ntop(AF_INET, &n->area_id, (char *)buf,
+				inet_ntop(AF_INET, &n->area_id, buf,
 					  sizeof(buf));
 			else
-				sprintf((char *)buf, "%lu",
-					(unsigned long int)ntohl(
-						n->area_id.s_addr));
+				snprintf(buf, sizeof(buf), "%lu",
+					 (unsigned long int)ntohl(
+						 n->area_id.s_addr));
 
 			/* Network print. */
 			vty_out(vty, " network %s/%d area %s\n",
@@ -10026,13 +10027,13 @@ static int config_write_ospf_area(struct vty *vty, struct ospf *ospf)
 {
 	struct listnode *node;
 	struct ospf_area *area;
-	uint8_t buf[INET_ADDRSTRLEN];
+	char buf[INET_ADDRSTRLEN];
 
 	/* Area configuration print. */
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area)) {
 		struct route_node *rn1;
 
-		area_id2str((char *)buf, sizeof(buf), &area->area_id,
+		area_id2str(buf, sizeof(buf), &area->area_id,
 			    area->area_id_fmt);
 
 		if (area->auth_type != OSPF_AUTH_NULL) {

--- a/pimd/mtracebis.c
+++ b/pimd/mtracebis.c
@@ -108,7 +108,7 @@ static const char *rtg_proto_str(enum mtrace_rtg_proto proto)
 	case MTRACE_RTG_PROTO_PIM_ASSERT:
 		return "PIM assert";
 	default:
-		sprintf(buf, "unknown protocol (%d)", proto);
+		snprintf(buf, sizeof(buf), "unknown protocol (%d)", proto);
 		return buf;
 	}
 }
@@ -161,7 +161,7 @@ static const char *fwd_code_str(enum mtrace_fwd_code code)
 	case MTRACE_FWD_CODE_ADMIN_PROHIB:
 		return "admin. prohib.";
 	default:
-		sprintf(buf, "unknown fwd. code (%d)", code);
+		snprintf(buf, sizeof(buf), "unknown fwd. code (%d)", code);
 		return buf;
 	}
 }

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2510,8 +2510,8 @@ static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 		pim_upstream_state2brief_str(up->join_state, state_str, sizeof(state_str));
 		if (up->reg_state != PIM_REG_NOINFO) {
 			char tmp_str[PIM_REG_STATE_STR_LEN];
+			char tmp[sizeof(state_str) + 1];
 
-			char tmp[sizeof(state_str)];
 			snprintf(tmp, sizeof(tmp), ",%s",
 				 pim_reg_state2brief_str(up->reg_state, tmp_str,
 							 sizeof(tmp_str)));

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2511,9 +2511,11 @@ static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 		if (up->reg_state != PIM_REG_NOINFO) {
 			char tmp_str[PIM_REG_STATE_STR_LEN];
 
-			sprintf(state_str + strlen(state_str), ",%s",
-				pim_reg_state2brief_str(up->reg_state, tmp_str,
-							sizeof(tmp_str)));
+			char tmp[sizeof(state_str)];
+			snprintf(tmp, sizeof(tmp), ",%s",
+				 pim_reg_state2brief_str(up->reg_state, tmp_str,
+							 sizeof(tmp_str)));
+			strlcat(state_str, tmp, sizeof(state_str));
 		}
 
 		if (uj) {

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -879,7 +879,7 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	igmp->igmp_group_list = list_new();
 	igmp->igmp_group_list->del = (void (*)(void *))igmp_group_free;
 
-	snprintf(hash_name, 64, "IGMP %s hash", ifp->name);
+	snprintf(hash_name, sizeof(hash_name), "IGMP %s hash", ifp->name);
 	igmp->igmp_group_hash = hash_create(igmp_group_hash_key,
 					    igmp_group_hash_equal, hash_name);
 

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1945,7 +1945,8 @@ int igmp_v3_recv_report(struct igmp_sock *igmp, struct in_addr from,
 
 				if (!inet_ntop(AF_INET, src, src_str,
 					       sizeof(src_str)))
-					sprintf(src_str, "<source?>");
+					snprintf(src_str, sizeof(src_str),
+						 "<source?>");
 
 				zlog_debug(
 					"        Recv IGMP report v3 from %s on %s: record=%d group=%s source=%s",

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -99,7 +99,7 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 	pim_msdp_init(pim, router->master);
 	pim_vxlan_init(pim);
 
-	snprintf(hash_name, 64, "PIM %s RPF Hash", vrf->name);
+	snprintf(hash_name, sizeof(hash_name), "PIM %s RPF Hash", vrf->name);
 	pim->rpf_hash = hash_create_size(256, pim_rpf_hash_key, pim_rpf_equal,
 					 hash_name);
 

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1574,14 +1574,16 @@ void pim_msdp_init(struct pim_instance *pim, struct thread_master *master)
 	pim->msdp.master = master;
 	char hash_name[64];
 
-	snprintf(hash_name, 64, "PIM %s MSDP Peer Hash", pim->vrf->name);
+	snprintf(hash_name, sizeof(hash_name), "PIM %s MSDP Peer Hash",
+		 pim->vrf->name);
 	pim->msdp.peer_hash = hash_create(pim_msdp_peer_hash_key_make,
 					  pim_msdp_peer_hash_eq, hash_name);
 	pim->msdp.peer_list = list_new();
 	pim->msdp.peer_list->del = (void (*)(void *))pim_msdp_peer_free;
 	pim->msdp.peer_list->cmp = (int (*)(void *, void *))pim_msdp_peer_comp;
 
-	snprintf(hash_name, 64, "PIM %s MSDP SA Hash", pim->vrf->name);
+	snprintf(hash_name, sizeof(hash_name), "PIM %s MSDP SA Hash",
+		 pim->vrf->name);
 	pim->msdp.sa_hash = hash_create(pim_msdp_sa_hash_key_make,
 					pim_msdp_sa_hash_eq, hash_name);
 	pim->msdp.sa_list = list_new();

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -103,7 +103,7 @@ static struct pim_nexthop_cache *pim_nexthop_cache_add(struct pim_instance *pim,
 	pnc->rp_list = list_new();
 	pnc->rp_list->cmp = pim_rp_list_cmp;
 
-	snprintf(hash_name, 64, "PNC %s(%s) Upstream Hash",
+	snprintf(hash_name, sizeof(hash_name), "PNC %s(%s) Upstream Hash",
 		 prefix2str(&pnc->rpf.rpf_addr, buf1, 64), pim->vrf->name);
 	pnc->upstream_hash = hash_create_size(8192, pim_upstream_hash_key,
 					      pim_upstream_equal, hash_name);

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -728,7 +728,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 	char rp_str[INET_ADDRSTRLEN];
 
 	if (!inet_ntop(AF_INET, &rp_addr, rp_str, sizeof(rp_str)))
-		sprintf(rp_str, "<rp?>");
+		snprintf(rp_str, sizeof(rp_str), "<rp?>");
 	prefix2str(&group, grp_str, sizeof(grp_str));
 
 	if (plist)
@@ -763,7 +763,9 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 
 					if (!inet_ntop(AF_INET, bsrp, bsrp_str,
 						       sizeof(bsrp_str)))
-						sprintf(bsrp_str, "<bsrp?>");
+						snprintf(bsrp_str,
+							 sizeof(bsrp_str),
+							 "<bsrp?>");
 
 					zlog_debug(
 						"%s: BSM RP %s found for the group %s",

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -288,10 +288,10 @@ int pim_socket_join(int fd, struct in_addr group, struct in_addr ifaddr,
 		char group_str[INET_ADDRSTRLEN];
 		char ifaddr_str[INET_ADDRSTRLEN];
 		if (!inet_ntop(AF_INET, &group, group_str, sizeof(group_str)))
-			sprintf(group_str, "<group?>");
+			snprintf(group_str, sizeof(group_str), "<group?>");
 		if (!inet_ntop(AF_INET, &ifaddr, ifaddr_str,
 			       sizeof(ifaddr_str)))
-			sprintf(ifaddr_str, "<ifaddr?>");
+			snprintf(ifaddr_str, sizeof(ifaddr_str), "<ifaddr?>");
 
 		flog_err(
 			EC_LIB_SOCKET,
@@ -304,10 +304,10 @@ int pim_socket_join(int fd, struct in_addr group, struct in_addr ifaddr,
 		char group_str[INET_ADDRSTRLEN];
 		char ifaddr_str[INET_ADDRSTRLEN];
 		if (!inet_ntop(AF_INET, &group, group_str, sizeof(group_str)))
-			sprintf(group_str, "<group?>");
+			snprintf(group_str, sizeof(group_str), "<group?>");
 		if (!inet_ntop(AF_INET, &ifaddr, ifaddr_str,
 			       sizeof(ifaddr_str)))
-			sprintf(ifaddr_str, "<ifaddr?>");
+			snprintf(ifaddr_str, sizeof(ifaddr_str), "<ifaddr?>");
 
 		zlog_debug(
 			"Socket fd=%d joined group %s on interface address %s",

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -2164,8 +2164,7 @@ void pim_upstream_init(struct pim_instance *pim)
 {
 	char name[64];
 
-	snprintf(name, 64, "PIM %s Timer Wheel",
-		 pim->vrf->name);
+	snprintf(name, sizeof(name), "PIM %s Timer Wheel", pim->vrf->name);
 	pim->upstream_sg_wheel =
 		wheel_init(router->master, 31000, 100, pim_upstream_hash_key,
 			   pim_upstream_sg_running, name);

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -172,9 +172,9 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 	char spaces[10];
 
 	if (pim->vrf_id == VRF_DEFAULT)
-		sprintf(spaces, "%s", "");
+		snprintf(spaces, sizeof(spaces), "%s", "");
 	else
-		sprintf(spaces, "%s", " ");
+		snprintf(spaces, sizeof(spaces), "%s", " ");
 
 	writes += pim_msdp_config_write(pim, vty, spaces);
 

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2972,8 +2972,8 @@ static void rip_distance_show(struct vty *vty, struct rip *rip)
 					"    Address           Distance  List\n");
 				header = 0;
 			}
-			sprintf(buf, "%s/%d", inet_ntoa(rn->p.u.prefix4),
-				rn->p.prefixlen);
+			snprintf(buf, sizeof(buf), "%s/%d",
+				 inet_ntoa(rn->p.u.prefix4), rn->p.prefixlen);
 			vty_out(vty, "    %-20s  %4d  %s\n", buf,
 				rdistance->distance,
 				rdistance->access_list ? rdistance->access_list

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -614,8 +614,8 @@ int static_config(struct vty *vty, struct static_vrf *svrf, afi_t afi,
 	if (stable == NULL)
 		return write;
 
-	sprintf(spacing, "%s%s", (svrf->vrf->vrf_id == VRF_DEFAULT) ? "" : " ",
-		cmd);
+	snprintf(spacing, sizeof(spacing), "%s%s",
+		 (svrf->vrf->vrf_id == VRF_DEFAULT) ? "" : " ", cmd);
 
 	/*
 	 * Static routes for vrfs not fully inited

--- a/tests/lib/test_zmq.c
+++ b/tests/lib/test_zmq.c
@@ -120,7 +120,7 @@ static void run_client(int syncfd)
 
 	/* write callback */
 	printf("---\n");
-	snprintf(buf, 32, "Done receiving");
+	snprintf(buf, sizeof(buf), "Done receiving");
 	printf("client send: %s\n", buf);
 	fflush(stdout);
 	send_delim(zmqsock);

--- a/tools/cocci.h
+++ b/tools/cocci.h
@@ -27,3 +27,62 @@
 		struct type *le_next;  /* next element */                      \
 		struct type **le_prev; /* address of previous next element */  \
 	}
+
+#define STREAM_GETC(S, P)                                                      \
+	do {                                                                   \
+		uint8_t _pval;                                                 \
+		if (!stream_getc2((S), &_pval))                                \
+			goto stream_failure;                                   \
+		(P) = _pval;                                                   \
+	} while (0)
+
+#define STREAM_GETW(S, P)                                                      \
+	do {                                                                   \
+		uint16_t _pval;                                                \
+		if (!stream_getw2((S), &_pval))                                \
+			goto stream_failure;                                   \
+		(P) = _pval;                                                   \
+	} while (0)
+
+#define STREAM_GETL(S, P)                                                      \
+	do {                                                                   \
+		uint32_t _pval;                                                \
+		if (!stream_getl2((S), &_pval))                                \
+			goto stream_failure;                                   \
+		(P) = _pval;                                                   \
+	} while (0)
+
+#define STREAM_GETF(S, P)                                                      \
+	do {                                                                   \
+		union {                                                        \
+			float r;                                               \
+			uint32_t d;                                            \
+		} _pval;                                                       \
+		if (stream_getl2((S), &_pval.d))                               \
+			goto stream_failure;                                   \
+		(P) = _pval.r;                                                 \
+	} while (0)
+
+#define STREAM_GETQ(S, P)                                                      \
+	do {                                                                   \
+		uint64_t _pval;                                                \
+		if (!stream_getq2((S), &_pval))                                \
+			goto stream_failure;                                   \
+		(P) = _pval;                                                   \
+	} while (0)
+
+#define STREAM_GET(P, STR, SIZE)                                               \
+	do {                                                                   \
+		if (!stream_get2((P), (STR), (SIZE)))                          \
+			goto stream_failure;                                   \
+	} while (0)
+
+#define AF_FOREACH(af) for ((af) = BGP_AF_START; (af) < BGP_AF_MAX; (af)++)
+
+#define FOREACH_AFI_SAFI(afi, safi)                                            \
+                                                                               \
+	for (afi = AFI_IP; afi < AFI_MAX; afi++)                               \
+		for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++)
+
+#define FOREACH_SAFI(safi) for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++)
+

--- a/tools/cocci.h
+++ b/tools/cocci.h
@@ -85,4 +85,3 @@
 		for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++)
 
 #define FOREACH_SAFI(safi) for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++)
-

--- a/tools/start-stop-daemon.c
+++ b/tools/start-stop-daemon.c
@@ -605,7 +605,7 @@ static void parse_options(int argc, char *const *argv)
 static int pid_is_exec(pid_t pid, const struct stat *esb)
 {
 	struct stat sb;
-	char buf[32];
+	char buf[PATH_MAX];
 
 	snprintf(buf, sizeof(buf), "/proc/%ld/exe", (long)pid);
 	if (stat(buf, &sb) != 0)
@@ -617,7 +617,7 @@ static int pid_is_exec(pid_t pid, const struct stat *esb)
 static int pid_is_user(pid_t pid, uid_t uid)
 {
 	struct stat sb;
-	char buf[32];
+	char buf[PATH_MAX];
 
 	snprintf(buf, sizeof(buf), "/proc/%ld", (long)pid);
 	if (stat(buf, &sb) != 0)
@@ -628,7 +628,7 @@ static int pid_is_user(pid_t pid, uid_t uid)
 
 static int pid_is_cmd(pid_t pid, const char *name)
 {
-	char buf[32];
+	char buf[PATH_MAX];
 	FILE *f;
 	int c;
 

--- a/tools/start-stop-daemon.c
+++ b/tools/start-stop-daemon.c
@@ -607,7 +607,7 @@ static int pid_is_exec(pid_t pid, const struct stat *esb)
 	struct stat sb;
 	char buf[32];
 
-	sprintf(buf, "/proc/%ld/exe", (long)pid);
+	snprintf(buf, sizeof(buf), "/proc/%ld/exe", (long)pid);
 	if (stat(buf, &sb) != 0)
 		return 0;
 	return (sb.st_dev == esb->st_dev && sb.st_ino == esb->st_ino);
@@ -619,7 +619,7 @@ static int pid_is_user(pid_t pid, uid_t uid)
 	struct stat sb;
 	char buf[32];
 
-	sprintf(buf, "/proc/%ld", (long)pid);
+	snprintf(buf, sizeof(buf), "/proc/%ld", (long)pid);
 	if (stat(buf, &sb) != 0)
 		return 0;
 	return (sb.st_uid == uid);
@@ -632,7 +632,7 @@ static int pid_is_cmd(pid_t pid, const char *name)
 	FILE *f;
 	int c;
 
-	sprintf(buf, "/proc/%ld/stat", (long)pid);
+	snprintf(buf, sizeof(buf), "/proc/%ld/stat", (long)pid);
 	f = fopen(buf, "r");
 	if (!f)
 		return 0;

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -543,7 +543,8 @@ void vtysh_config_write(void)
 	}
 
 	if (cmd_domainname_get()) {
-		sprintf(line, "domainname %s", cmd_domainname_get());
+		snprintf(line, sizeof(line), "domainname %s",
+			 cmd_domainname_get());
 		vtysh_config_parse_line(NULL, line);
 	}
 	if (vtysh_write_integrated == WRITE_INTEGRATED_NO)

--- a/vtysh/vtysh_user.c
+++ b/vtysh/vtysh_user.c
@@ -115,7 +115,8 @@ void user_config_write(void)
 
 	for (ALL_LIST_ELEMENTS(userlist, node, nnode, user)) {
 		if (user->nopassword) {
-			sprintf(line, "username %s nopassword", user->name);
+			snprintf(line, sizeof(line), "username %s nopassword",
+				 user->name);
 			config_add_line(config_top, line);
 		}
 	}

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -904,8 +904,8 @@ static int netlink_route_change_read_multicast(struct nlmsghdr *h,
 			ifp = if_lookup_by_index(oif[count], vrf);
 			char temp[256];
 
-			sprintf(temp, "%s(%d) ", ifp ? ifp->name : "Unknown",
-				oif[count]);
+			snprintf(temp, sizeof(temp), "%s(%d) ",
+				 ifp ? ifp->name : "Unknown", oif[count]);
 			strlcat(oif_list, temp, sizeof(oif_list));
 		}
 		zvrf = zebra_vrf_lookup_by_id(vrf);
@@ -1087,7 +1087,8 @@ static int build_label_stack(struct mpls_label_stack *nh_label,
 				sprintf(label_buf, "label %u",
 					nh_label->label[i]);
 			else {
-				sprintf(label_buf1, "/%u", nh_label->label[i]);
+				snprintf(label_buf1, sizeof(label_buf1), "/%u",
+					 nh_label->label[i]);
 				strlcat(label_buf, label_buf1, label_buf_size);
 			}
 		}
@@ -2686,7 +2687,7 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	if ((NDA_VLAN <= NDA_MAX) && tb[NDA_VLAN]) {
 		vid_present = 1;
 		vid = *(uint16_t *)RTA_DATA(tb[NDA_VLAN]);
-		sprintf(vid_buf, " VLAN %u", vid);
+		snprintf(vid_buf, sizeof(vid_buf), " VLAN %u", vid);
 	}
 
 	if (tb[NDA_DST]) {
@@ -2694,7 +2695,8 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 		dst_present = 1;
 		memcpy(&vtep_ip.s_addr, RTA_DATA(tb[NDA_DST]),
 		       IPV4_MAX_BYTELEN);
-		sprintf(dst_buf, " dst %s", inet_ntoa(vtep_ip));
+		snprintf(dst_buf, sizeof(dst_buf), " dst %s",
+			 inet_ntoa(vtep_ip));
 	}
 
 	if (IS_ZEBRA_DEBUG_KERNEL)

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -760,8 +760,9 @@ static int zfpm_read_cb(struct thread *thread)
 			if (nbyte == -1) {
 				char buffer[1024];
 
-				sprintf(buffer, "closed socket in read(%d): %s",
-					errno, safe_strerror(errno));
+				snprintf(buffer, sizeof(buffer),
+					 "closed socket in read(%d): %s", errno,
+					 safe_strerror(errno));
 				zfpm_connection_down(buffer);
 			} else
 				zfpm_connection_down("closed socket in read");
@@ -797,8 +798,9 @@ static int zfpm_read_cb(struct thread *thread)
 			if (nbyte == -1) {
 				char buffer[1024];
 
-				sprintf(buffer, "failed to read message(%d) %s",
-					errno, safe_strerror(errno));
+				snprintf(buffer, sizeof(buffer),
+					 "failed to read message(%d) %s", errno,
+					 safe_strerror(errno));
 				zfpm_connection_down(buffer);
 			} else
 				zfpm_connection_down("failed to read message");

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -3335,7 +3335,8 @@ int zebra_mpls_write_lsp_config(struct vty *vty, struct zebra_vrf *zvrf)
 				strlcpy(lstr, "implicit-null", sizeof(lstr));
 				break;
 			default:
-				sprintf(lstr, "%u", snhlfe->out_label);
+				snprintf(lstr, sizeof(lstr), "%u",
+					 snhlfe->out_label);
 				break;
 			}
 

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -153,7 +153,7 @@ static int zebra_ns_delete(char *name)
 
 static int zebra_ns_notify_self_identify(struct stat *netst)
 {
-	char net_path[64];
+	char net_path[PATH_MAX];
 	int netns;
 
 	snprintf(net_path, sizeof(net_path), "/proc/self/ns/net");

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -156,7 +156,7 @@ static int zebra_ns_notify_self_identify(struct stat *netst)
 	char net_path[64];
 	int netns;
 
-	sprintf(net_path, "/proc/self/ns/net");
+	snprintf(net_path, sizeof(net_path), "/proc/self/ns/net");
 	netns = open(net_path, O_RDONLY);
 	if (netns < 0)
 		return -1;
@@ -178,7 +178,7 @@ static bool zebra_ns_notify_is_default_netns(const char *name)
 		return false;
 
 	memset(&st, 0, sizeof(struct stat));
-	snprintf(netnspath, 64, "%s/%s", NS_RUN_DIR, name);
+	snprintf(netnspath, sizeof(netnspath), "%s/%s", NS_RUN_DIR, name);
 	/* compare with local stat */
 	if (stat(netnspath, &st) == 0 &&
 	    (st.st_dev == default_netns_stat.st_dev) &&

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -884,9 +884,8 @@ static void zebra_pbr_display_icmp(struct vty *vty,
 		port = ((zpie->src_port_min << 8) & 0xff00) +
 			(zpie->dst_port_min & 0xff);
 		memset(decoded_str, 0, sizeof(decoded_str));
-		sprintf(decoded_str, "%d/%d",
-			zpie->src_port_min,
-			zpie->dst_port_min);
+		snprintf(decoded_str, sizeof(decoded_str), "%d/%d",
+			 zpie->src_port_min, zpie->dst_port_min);
 		vty_out(vty, ":icmp:%s",
 			lookup_msg(icmp_typecode_str,
 				   port, decoded_str));
@@ -1129,7 +1128,7 @@ static void zebra_pbr_show_iptable_unit(struct zebra_pbr_iptable *iptable,
 	if (iptable->fragment) {
 		char val_str[10];
 
-		sprintf(val_str, "%d", iptable->fragment);
+		snprintf(val_str, sizeof(val_str), "%d", iptable->fragment);
 		vty_out(vty, "\t fragment%s %s\n",
 			iptable->filter_bm & MATCH_FRAGMENT_INVERSE_SET ?
 			" not" : "", lookup_msg(fragment_value_str,

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -877,14 +877,14 @@ static void zebra_pbr_display_icmp(struct vty *vty,
 
 	/* range icmp type */
 	if (zpie->src_port_max || zpie->dst_port_max) {
-		vty_out(vty, ":icmp:[type <%d:%d>;code <%d:%d>",
+		vty_out(vty, ":icmp:[type <%u:%u>;code <%u:%u>",
 			zpie->src_port_min, zpie->src_port_max,
 			zpie->dst_port_min, zpie->dst_port_max);
 	} else {
 		port = ((zpie->src_port_min << 8) & 0xff00) +
 			(zpie->dst_port_min & 0xff);
 		memset(decoded_str, 0, sizeof(decoded_str));
-		snprintf(decoded_str, sizeof(decoded_str), "%d/%d",
+		snprintf(decoded_str, sizeof(decoded_str), "%u/%u",
 			 zpie->src_port_min, zpie->dst_port_min);
 		vty_out(vty, ":icmp:%s",
 			lookup_msg(icmp_typecode_str,

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -132,7 +132,7 @@ void zebra_ptm_init(void)
 	ptm_cb.pid = getpid();
 	zebra_ptm_install_commands();
 
-	sprintf(buf, "%s", FRR_PTM_NAME);
+	snprintf(buf, sizeof(buf), "%s", FRR_PTM_NAME);
 	ptm_hdl = ptm_lib_register(buf, NULL, zebra_ptm_handle_msg_cb,
 				   zebra_ptm_handle_msg_cb);
 	ptm_cb.wb = buffer_new(0);
@@ -710,16 +710,17 @@ void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS)
 	}
 
 	ptm_lib_init_msg(ptm_hdl, 0, PTMLIB_MSG_TYPE_CMD, NULL, &out_ctxt);
-	sprintf(tmp_buf, "%s", ZEBRA_PTM_BFD_START_CMD);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%s", ZEBRA_PTM_BFD_START_CMD);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_CMD_STR, tmp_buf);
-	sprintf(tmp_buf, "%s", zebra_route_string(client->proto));
+	snprintf(tmp_buf, sizeof(tmp_buf), "%s",
+		 zebra_route_string(client->proto));
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_CLIENT_FIELD,
 			   tmp_buf);
 
 	s = msg;
 
 	STREAM_GETL(s, pid);
-	sprintf(tmp_buf, "%d", pid);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%d", pid);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_SEQID_FIELD,
 			   tmp_buf);
 
@@ -742,21 +743,21 @@ void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS)
 	}
 
 	STREAM_GETL(s, min_rx_timer);
-	sprintf(tmp_buf, "%d", min_rx_timer);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%d", min_rx_timer);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_MIN_RX_FIELD,
 			   tmp_buf);
 	STREAM_GETL(s, min_tx_timer);
-	sprintf(tmp_buf, "%d", min_tx_timer);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%d", min_tx_timer);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_MIN_TX_FIELD,
 			   tmp_buf);
 	STREAM_GETC(s, detect_mul);
-	sprintf(tmp_buf, "%d", detect_mul);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%d", detect_mul);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_DETECT_MULT_FIELD,
 			   tmp_buf);
 
 	STREAM_GETC(s, multi_hop);
 	if (multi_hop) {
-		sprintf(tmp_buf, "%d", 1);
+		snprintf(tmp_buf, sizeof(tmp_buf), "%d", 1);
 		ptm_lib_append_msg(ptm_hdl, out_ctxt,
 				   ZEBRA_PTM_BFD_MULTI_HOP_FIELD, tmp_buf);
 		STREAM_GETW(s, src_p.family);
@@ -778,7 +779,7 @@ void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS)
 		}
 
 		STREAM_GETC(s, multi_hop_cnt);
-		sprintf(tmp_buf, "%d", multi_hop_cnt);
+		snprintf(tmp_buf, sizeof(tmp_buf), "%d", multi_hop_cnt);
 		ptm_lib_append_msg(ptm_hdl, out_ctxt,
 				   ZEBRA_PTM_BFD_MAX_HOP_CNT_FIELD, tmp_buf);
 
@@ -818,11 +819,11 @@ void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS)
 				   ZEBRA_PTM_BFD_IFNAME_FIELD, if_name);
 	}
 	STREAM_GETC(s, cbit_set);
-	sprintf(tmp_buf, "%d", cbit_set);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%d", cbit_set);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt,
 			   ZEBRA_PTM_BFD_CBIT_FIELD, tmp_buf);
 
-	sprintf(tmp_buf, "%d", 1);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%d", 1);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_SEND_EVENT,
 			   tmp_buf);
 
@@ -869,17 +870,18 @@ void zebra_ptm_bfd_dst_deregister(ZAPI_HANDLER_ARGS)
 
 	ptm_lib_init_msg(ptm_hdl, 0, PTMLIB_MSG_TYPE_CMD, NULL, &out_ctxt);
 
-	sprintf(tmp_buf, "%s", ZEBRA_PTM_BFD_STOP_CMD);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%s", ZEBRA_PTM_BFD_STOP_CMD);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_CMD_STR, tmp_buf);
 
-	sprintf(tmp_buf, "%s", zebra_route_string(client->proto));
+	snprintf(tmp_buf, sizeof(tmp_buf), "%s",
+		 zebra_route_string(client->proto));
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_CLIENT_FIELD,
 			   tmp_buf);
 
 	s = msg;
 
 	STREAM_GETL(s, pid);
-	sprintf(tmp_buf, "%d", pid);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%d", pid);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_SEQID_FIELD,
 			   tmp_buf);
 
@@ -900,7 +902,7 @@ void zebra_ptm_bfd_dst_deregister(ZAPI_HANDLER_ARGS)
 
 	STREAM_GETC(s, multi_hop);
 	if (multi_hop) {
-		sprintf(tmp_buf, "%d", 1);
+		snprintf(tmp_buf, sizeof(tmp_buf), "%d", 1);
 		ptm_lib_append_msg(ptm_hdl, out_ctxt,
 				   ZEBRA_PTM_BFD_MULTI_HOP_FIELD, tmp_buf);
 
@@ -996,14 +998,15 @@ void zebra_ptm_bfd_client_register(ZAPI_HANDLER_ARGS)
 
 	ptm_lib_init_msg(ptm_hdl, 0, PTMLIB_MSG_TYPE_CMD, NULL, &out_ctxt);
 
-	sprintf(tmp_buf, "%s", ZEBRA_PTM_BFD_CLIENT_REG_CMD);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%s", ZEBRA_PTM_BFD_CLIENT_REG_CMD);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_CMD_STR, tmp_buf);
 
-	sprintf(tmp_buf, "%s", zebra_route_string(client->proto));
+	snprintf(tmp_buf, sizeof(tmp_buf), "%s",
+		 zebra_route_string(client->proto));
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_CLIENT_FIELD,
 			   tmp_buf);
 
-	sprintf(tmp_buf, "%d", pid);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%d", pid);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_SEQID_FIELD,
 			   tmp_buf);
 
@@ -1054,10 +1057,11 @@ int zebra_ptm_bfd_client_deregister(struct zserv *client)
 
 	ptm_lib_init_msg(ptm_hdl, 0, PTMLIB_MSG_TYPE_CMD, NULL, &out_ctxt);
 
-	sprintf(tmp_buf, "%s", ZEBRA_PTM_BFD_CLIENT_DEREG_CMD);
+	snprintf(tmp_buf, sizeof(tmp_buf), "%s",
+		 ZEBRA_PTM_BFD_CLIENT_DEREG_CMD);
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_CMD_STR, tmp_buf);
 
-	sprintf(tmp_buf, "%s", zebra_route_string(proto));
+	snprintf(tmp_buf, sizeof(tmp_buf), "%s", zebra_route_string(proto));
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_CLIENT_FIELD,
 			   tmp_buf);
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2456,11 +2456,12 @@ static void _route_entry_dump_nh(const struct route_entry *re,
 
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_BLACKHOLE:
-		sprintf(nhname, "Blackhole");
+		snprintf(nhname, sizeof(nhname), "Blackhole");
 		break;
 	case NEXTHOP_TYPE_IFINDEX:
 		ifp = if_lookup_by_index(nexthop->ifindex, nexthop->vrf_id);
-		sprintf(nhname, "%s", ifp ? ifp->name : "Unknown");
+		snprintf(nhname, sizeof(nhname), "%s",
+			 ifp ? ifp->name : "Unknown");
 		break;
 	case NEXTHOP_TYPE_IPV4:
 		/* fallthrough */

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1860,7 +1860,7 @@ void zebra_routemap_config_write_protocol(struct vty *vty,
 	memset(space, 0, sizeof(space));
 
 	if (zvrf_id(zvrf) != VRF_DEFAULT)
-		sprintf(space, "%s", " ");
+		snprintf(space, sizeof(space), "%s", " ");
 
 	for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
 		if (PROTO_RM_NAME(zvrf, AFI_IP, i))

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -967,7 +967,7 @@ static void zvni_print_neigh_hash_all_vni(struct hash_bucket *bucket,
 	} else {
 		json_vni = json_object_new_object();
 		json_object_int_add(json_vni, "numArpNd", num_neigh);
-		snprintf(vni_str, VNI_STR_LEN, "%u", zvni->vni);
+		snprintf(vni_str, sizeof(vni_str), "%u", zvni->vni);
 	}
 
 	if (!num_neigh) {
@@ -1063,7 +1063,7 @@ static void zvni_print_neigh_hash_all_vni_detail(struct hash_bucket *bucket,
 	} else {
 		json_vni = json_object_new_object();
 		json_object_int_add(json_vni, "numArpNd", num_neigh);
-		snprintf(vni_str, VNI_STR_LEN, "%u", zvni->vni);
+		snprintf(vni_str, sizeof(vni_str), "%u", zvni->vni);
 	}
 	if (!num_neigh) {
 		if (json)
@@ -1534,7 +1534,7 @@ static void zvni_print_mac_hash_all_vni(struct hash_bucket *bucket, void *ctxt)
 	if (json) {
 		json_vni = json_object_new_object();
 		json_mac = json_object_new_object();
-		snprintf(vni_str, VNI_STR_LEN, "%u", zvni->vni);
+		snprintf(vni_str, sizeof(vni_str), "%u", zvni->vni);
 	}
 
 	if (!CHECK_FLAG(wctx->flags, SHOW_REMOTE_MAC_FROM_VTEP)) {
@@ -1610,7 +1610,7 @@ static void zvni_print_mac_hash_all_vni_detail(struct hash_bucket *bucket,
 	if (json) {
 		json_vni = json_object_new_object();
 		json_mac = json_object_new_object();
-		snprintf(vni_str, VNI_STR_LEN, "%u", zvni->vni);
+		snprintf(vni_str, sizeof(vni_str), "%u", zvni->vni);
 	}
 
 	if (!CHECK_FLAG(wctx->flags, SHOW_REMOTE_MAC_FROM_VTEP)) {
@@ -1693,7 +1693,7 @@ static void zl3vni_print_nh_hash_all_vni(struct hash_bucket *bucket,
 
 	if (json) {
 		json_vni = json_object_new_object();
-		snprintf(vni_str, VNI_STR_LEN, "%u", zl3vni->vni);
+		snprintf(vni_str, sizeof(vni_str), "%u", zl3vni->vni);
 	}
 
 	if (json == NULL) {
@@ -1732,7 +1732,7 @@ static void zl3vni_print_rmac_hash_all_vni(struct hash_bucket *bucket,
 
 	if (json) {
 		json_vni = json_object_new_object();
-		snprintf(vni_str, VNI_STR_LEN, "%u", zl3vni->vni);
+		snprintf(vni_str, sizeof(vni_str), "%u", zl3vni->vni);
 	}
 
 	if (json == NULL) {
@@ -1968,7 +1968,7 @@ static void zl3vni_print_hash(struct hash_bucket *bucket, void *ctx[])
 	} else {
 		char vni_str[VNI_STR_LEN];
 
-		snprintf(vni_str, VNI_STR_LEN, "%u", zl3vni->vni);
+		snprintf(vni_str, sizeof(vni_str), "%u", zl3vni->vni);
 		json_vni = json_object_new_object();
 		json_object_int_add(json_vni, "vni", zl3vni->vni);
 		json_object_string_add(json_vni, "vxlanIf",
@@ -2053,7 +2053,7 @@ static void zvni_print_hash(struct hash_bucket *bucket, void *ctxt[])
 			vrf_id_to_name(zvni->vrf_id));
 	else {
 		char vni_str[VNI_STR_LEN];
-		snprintf(vni_str, VNI_STR_LEN, "%u", zvni->vni);
+		snprintf(vni_str, sizeof(vni_str), "%u", zvni->vni);
 		json_vni = json_object_new_object();
 		json_object_int_add(json_vni, "vni", zvni->vni);
 		json_object_string_add(json_vni, "type", "L2");


### PR DESCRIPTION
* Replace sprintf with snprintf when the buffer is scope local (and therefore of known size)
* Replace snprintf with a non-`sizeof` length to use `sizeof` where possible
* Manually convert some additional ones
* Update cocci macro file

Also fixes a couple minor bugs related to string handling, one in bgpd and one in Zebra.