### PR TITLE
doc: remove duplicated command documentation

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -831,7 +831,8 @@ FPM Commands
 .. index:: clear zebra fpm stats
 .. clicmd:: clear zebra fpm stats
 
-   Resets all FPM counters.
+   Reset statistics related to the zebra code that interacts with the
+   optional Forwarding Plane Manager (FPM) component.
 
 
 ``dplane_fpm_nl`` implementation
@@ -879,7 +880,8 @@ FPM Commands
 .. index:: clear fpm counters
 .. clicmd:: clear fpm counters
 
-   Resets all FPM counters.
+   Reset statistics related to the zebra code that interacts with the
+   optional Forwarding Plane Manager (FPM) component.
 
 
 .. _zebra-dplane:

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -999,18 +999,6 @@ zebra Terminal Mode Commands
    total number of route nodes in the table.  Which will be higher than
    the actual number of routes that are held.
 
-.. index:: show zebra fpm stats
-.. clicmd:: show zebra fpm stats
-
-   Display statistics related to the zebra code that interacts with the
-   optional Forwarding Plane Manager (FPM) component.
-
-.. index:: clear zebra fpm stats
-.. clicmd:: clear zebra fpm stats
-
-   Reset statistics related to the zebra code that interacts with the
-   optional Forwarding Plane Manager (FPM) component.
-
 .. index:: show nexthop-group rib [ID] [vrf NAME] [singleton [ip|ip6]]
 .. clicmd:: show nexthop-group rib [ID] [vrf NAME]
 


### PR DESCRIPTION
Fixes a documentation warning during compilation.

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>