### PR TITLE
ldpd: use a timer instead of sleeping in LM init

### DIFF
--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -239,9 +239,6 @@ main(int argc, char *argv[])
 		"      --ctl_socket   Override ctl socket path\n"
 		"  -n, --instance     Instance id\n");
 
-	/* set default instance (to differentiate ldpd socket from lde one */
-	init.instance = 1;
-
 	while (1) {
 		int opt;
 


### PR DESCRIPTION
Man, this synchronous thing is so fragile. Stop sleeping if synchronous label-manager zapi session has trouble during init; retry using a timer instead. Move initial label-block request to a point where the LM zapi session is known to be running.
