### PR TITLE
yang: Convert to `FRRouting` for organization

### DIFF
--- a/yang/frr-igmp.yang
+++ b/yang/frr-igmp.yang
@@ -21,7 +21,7 @@ module frr-igmp {
   }
 
   organization
-    "Free Range Routing";
+    "FRRouting";
 
   contact
     "FRR Users List:       <mailto:frog@lists.frrouting.org>

--- a/yang/frr-pim-rp.yang
+++ b/yang/frr-pim-rp.yang
@@ -21,7 +21,7 @@ module frr-pim-rp {
   }
 
   organization
-    "Free Range Routing";
+    "FRRouting";
 
   contact
     "FRR Users List:       <mailto:frog@lists.frrouting.org>

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -21,7 +21,7 @@ module frr-pim {
   }
 
   organization
-    "Free Range Routing";
+    "FRRouting";
 
   contact
     "FRR Users List:       <mailto:frog@lists.frrouting.org>

--- a/yang/frr-routing.yang
+++ b/yang/frr-routing.yang
@@ -12,7 +12,7 @@ module frr-routing {
   }
 
   organization
-    "Free Range Routing";
+    "FRRouting";
 
   contact
     "FRR Users List:       <mailto:frog@lists.frrouting.org>

--- a/yang/frr-staticd.yang
+++ b/yang/frr-staticd.yang
@@ -17,7 +17,7 @@ module frr-staticd {
   }
 
   organization
-    "Free Range Routing";
+    "FRRouting";
 
   contact
     "FRR Users List: <mailto:frog@lists.frrouting.org>


### PR DESCRIPTION
We should be using `FRRouting` as our organization.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>