### PR TITLE
bgpd: Show PfxSnt for `show bgp <afi> <safi>` command

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9047,9 +9047,11 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					vty_out(vty, "EstdCnt DropCnt ResetTime Reason\n");
 				else
 					vty_out(vty,
-					"V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd\n");
+						"V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt\n");
 			}
 		}
+
+		paf = peer_af_find(peer, afi, pfx_rcd_safi);
 
 		count++;
 		/* Works for both failed & successful cases */
@@ -9106,7 +9108,6 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 				json_object_int_add(json_peer, "pfxRcd",
 						    peer->pcount[afi][pfx_rcd_safi]);
 
-				paf = peer_af_find(peer, afi, pfx_rcd_safi);
 				if (paf && PAF_SUBGRP(paf))
 					json_object_int_add(json_peer,
 							    "pfxSnt",
@@ -9192,7 +9193,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					peer_uptime(peer->uptime, timebuf,
 						    BGP_UPTIME_LEN, 0, NULL));
 
-				if (peer->status == Established)
+				if (peer->status == Established) {
 					if (peer->afc_recv[afi][safi])
 						vty_out(vty, " %12" PRIu32,
 							peer->pcount
@@ -9200,7 +9201,12 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 								[pfx_rcd_safi]);
 					else
 						vty_out(vty, " NoNeg");
-				else {
+
+					if (paf && PAF_SUBGRP(paf))
+						vty_out(vty, " %8" PRIu32,
+							(PAF_SUBGRP(paf))
+								->scount);
+				} else {
 					if (CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN))
 						vty_out(vty, " Idle (Admin)");
 					else if (CHECK_FLAG(
@@ -9211,6 +9217,8 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 						vty_out(vty, " %12s",
 							lookup_msg(bgp_status_msg,
 								   peer->status, NULL));
+
+					vty_out(vty, " %8" PRIu32, 0);
 				}
 				vty_out(vty, "\n");
 			}

--- a/tests/topotests/all-protocol-startup/r1/show_bgp_ipv6_summary.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_bgp_ipv6_summary.ref
@@ -3,6 +3,6 @@ BGP table version 1
 RIB entries 1, using XXXX bytes of memory
 Peers 2, using XXXX KiB of memory
 
-Neighbor         V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
-fc00:0:0:8::1000 4        100         0         0        0    0    0    never       Active
-fc00:0:0:8::2000 4        200         0         0        0    0    0    never       Active
+Neighbor         V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
+fc00:0:0:8::1000 4        100         0         0        0    0    0    never       Active        0
+fc00:0:0:8::2000 4        200         0         0        0    0    0    never       Active        0

--- a/tests/topotests/all-protocol-startup/r1/show_ip_bgp_summary.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_ip_bgp_summary.ref
@@ -3,8 +3,8 @@ BGP table version 1
 RIB entries 1, using XXXX bytes of memory
 Peers 4, using XXXX KiB of memory
 
-Neighbor         V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
-192.168.7.10     4        100         0         0        0    0    0    never       Active
-192.168.7.20     4        200         0         0        0    0    0    never       Active
-fc00:0:0:8::1000 4        100         0         0        0    0    0    never       Active
-fc00:0:0:8::2000 4        200         0         0        0    0    0    never       Active
+Neighbor         V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
+192.168.7.10     4        100         0         0        0    0    0    never       Active        0
+192.168.7.20     4        200         0         0        0    0    0    never       Active        0
+fc00:0:0:8::1000 4        100         0         0        0    0    0    never       Active        0
+fc00:0:0:8::2000 4        200         0         0        0    0    0    never       Active        0

--- a/tests/topotests/bgp_multiview_topo1/test_bgp_multiview_topo1.py
+++ b/tests/topotests/bgp_multiview_topo1/test_bgp_multiview_topo1.py
@@ -29,19 +29,19 @@ test_bgp_multiview_topo1.py: Simple Quagga/FRR Route-Server Test
 |  peer1   | |  peer2   | |  peer3   | |  peer4   | |  peer5   |
 | AS 65001 | | AS 65002 | | AS 65003 | | AS 65004 | | AS 65005 |
 +-----+----+ +-----+----+ +-----+----+ +-----+----+ +-----+----+
-      | .1         | .2         | .3         | .4         | .5 
+      | .1         | .2         | .3         | .4         | .5
       |     ______/            /            /   _________/
-       \   /  ________________/            /   /     
-        | |  /   _________________________/   /     +----------+  
+       \   /  ________________/            /   /
+        | |  /   _________________________/   /     +----------+
         | | |  /   __________________________/   ___|  peer6   |
         | | | |  /  ____________________________/.6 | AS 65006 |
         | | | | |  /  _________________________     +----------+
-        | | | | | |  /  __________________     \    +----------+ 
+        | | | | | |  /  __________________     \    +----------+
         | | | | | | |  /                  \     \___|  peer7   |
         | | | | | | | |                    \     .7 | AS 65007 |
      ~~~~~~~~~~~~~~~~~~~~~                  \       +----------+
    ~~         SW1         ~~                 \      +----------+
-   ~~       Switch           ~~               \_____|  peer8   |  
+   ~~       Switch           ~~               \_____|  peer8   |
    ~~    172.16.1.0/24     ~~                    .8 | AS 65008 |
      ~~~~~~~~~~~~~~~~~~~~~                          +----------+
               |
@@ -49,7 +49,7 @@ test_bgp_multiview_topo1.py: Simple Quagga/FRR Route-Server Test
     +---------+---------+
     |      FRR R1       |
     |   BGP Multi-View  |
-    | Peer 1-3 > View 1 |       
+    | Peer 1-3 > View 1 |
     | Peer 4-5 > View 2 |
     | Peer 6-8 > View 3 |
     +---------+---------+
@@ -226,7 +226,7 @@ def test_bgp_converge():
         for i in range(1, 2):
             for view in range(1, 4):
                 notConverged = net["r%s" % i].cmd(
-                    'vtysh -c "show ip bgp view %s summary" 2> /dev/null | grep ^[0-9] | grep -v " 11$"'
+                    'vtysh -c "show ip bgp view %s summary" 2> /dev/null | grep ^[0-9] | grep -vP " 11\s+(\d+)$"'
                     % view
                 )
                 if notConverged:


### PR DESCRIPTION
JSON output was already in, just printing in CLI as well.

```
root@exit1-debian-9:~# vtysh -c 'show bgp ipv4 summary'

IPv4 Unicast Summary:
BGP router identifier 10.10.10.1, local AS number 65001 vrf-id 0
BGP table version 100003
RIB entries 200005, using 37 MiB of memory
Peers 1, using 21 KiB of memory

... MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
...      64       157        0    0    0 00:01:18            0   100003

Total number of neighbors 1
```

JSON:

```
root@exit1-debian-9:~# vtysh -c 'show bgp ipv4 summary json' \ |
> jq '.ipv4Unicast.peers."192.168.0.2".pfxSnt'
100003
```

Closes https://github.com/FRRouting/frr/issues/6273

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>