### PR TITLE
lib, zebra: add missing extern "C" {} blocks to new header files

### DIFF
--- a/lib/atomlist.h
+++ b/lib/atomlist.h
@@ -20,6 +20,10 @@
 #include "typesafe.h"
 #include "frratomic.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* pointer with lock/deleted/invalid bit in lowest bit
  *
  * for atomlist/atomsort, "locked" means "this pointer can't be updated, the
@@ -360,5 +364,9 @@ void atomsort_del_hint(struct atomsort_head *h,
 		struct atomsort_item *item, atomic_atomptr_t *hint);
 
 struct atomsort_item *atomsort_pop(struct atomsort_head *h);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_ATOMLIST_H */

--- a/lib/defaults.h
+++ b/lib/defaults.h
@@ -22,6 +22,10 @@
 
 #include "compiler.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* frr_default wraps information about a default that has different
  * values depending on FRR version or default-set
  *
@@ -134,5 +138,9 @@ extern bool frr_defaults_profile_valid(const char *profile);
 
 /* like strcmp(), but with version ordering */
 extern int frr_version_cmp(const char *aa, const char *bb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_DEFAULTS_H */

--- a/lib/frrcu.h
+++ b/lib/frrcu.h
@@ -20,6 +20,10 @@
 #include "memory.h"
 #include "atomlist.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* quick RCU primer:
  *   There's a global sequence counter.  Whenever a thread does a
  *   rcu_read_lock(), it is marked as holding the current sequence counter.
@@ -169,5 +173,9 @@ extern void rcu_enqueue(struct rcu_head *head, const struct rcu_action *action);
 	} while (0)
 
 extern void rcu_close(struct rcu_head_close *head, int fd);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRRCU_H */

--- a/lib/iana_afi.h
+++ b/lib/iana_afi.h
@@ -21,6 +21,10 @@
 
 #include <prefix.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * The above AFI and SAFI definitions are for internal use. The protocol
  * definitions (IANA values) as for example used in BGP protocol packets
@@ -129,5 +133,9 @@ static inline const char *iana_safi2str(iana_safi_t safi)
 {
 	return safi2str(safi_iana2int(safi));
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/log_vty.h
+++ b/lib/log_vty.h
@@ -23,6 +23,10 @@
 
 #include "lib/hook.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct vty;
 
 extern void log_cmd_init(void);
@@ -32,5 +36,9 @@ extern void log_show_syslog(struct vty *vty);
 
 DECLARE_HOOK(zlog_rotate, (), ())
 extern void zlog_rotate(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __LOG_VTY_H__ */

--- a/lib/printfrr.h
+++ b/lib/printfrr.h
@@ -24,6 +24,10 @@
 #include "compiler.h"
 #include "memory.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct fbuf {
 	char *buf;
 	char *pos;
@@ -155,5 +159,9 @@ void printfrr_ext_reg(const struct printfrr_ext *);
 		printfrr_ext_reg(&_printext_##print_fn);                       \
 	}                                                                      \
 	/* end */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/pullwr.h
+++ b/lib/pullwr.h
@@ -26,6 +26,10 @@
 #include "thread.h"
 #include "stream.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct pullwr;
 
 /* This is a "pull-driven" write event handler.  Instead of having some buffer
@@ -106,5 +110,9 @@ static inline void pullwr_write_stream(struct pullwr *pullwr,
 
 extern void pullwr_stats(struct pullwr *pullwr, uint64_t *total_written,
 			 size_t *pending, size_t *kernel_pending);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _WRITEPOLL_H */

--- a/lib/resolver.h
+++ b/lib/resolver.h
@@ -13,6 +13,10 @@
 #include "thread.h"
 #include "sockunion.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct resolver_query {
 	void (*callback)(struct resolver_query *, const char *errstr, int n,
 			 union sockunion *);
@@ -27,5 +31,9 @@ void resolver_resolve(struct resolver_query *query, int af,
 		      const char *hostname, void (*cb)(struct resolver_query *,
 						       const char *, int,
 						       union sockunion *));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_RESOLVER_H */

--- a/lib/seqlock.h
+++ b/lib/seqlock.h
@@ -27,6 +27,10 @@
 #include <pthread.h>
 #include "frratomic.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * this locking primitive is intended to use in a 1:N setup.
  *
@@ -134,5 +138,9 @@ extern void seqlock_release(struct seqlock *sqlo);
 /* release should normally be followed by a bump on the "counter", if
  * anything other than reading RCU items was done
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SEQLOCK_H */

--- a/lib/version.h.in
+++ b/lib/version.h.in
@@ -28,6 +28,10 @@
 #include "gitversion.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef GIT_SUFFIX
 #define GIT_SUFFIX ""
 #endif
@@ -53,5 +57,9 @@
 	GIT_INFO "\n"
 
 pid_t pid_output (const char *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_VERSION_H */

--- a/lib/yang_wrappers.h
+++ b/lib/yang_wrappers.h
@@ -22,6 +22,10 @@
 
 #include "prefix.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* bool */
 extern bool yang_str2bool(const char *value);
 extern struct yang_data *yang_data_new_bool(const char *xpath, bool value);
@@ -181,5 +185,9 @@ extern struct yang_data *yang_data_new_mac(const char *xpath,
 extern void yang_str2mac(const char *value, struct ethaddr *mac);
 
 extern const char *yang_nexthop_type2str(uint32_t ntype);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_NORTHBOUND_WRAPPERS_H_ */

--- a/lib/zassert.h
+++ b/lib/zassert.h
@@ -19,6 +19,10 @@
 #ifndef _QUAGGA_ASSERT_H
 #define _QUAGGA_ASSERT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _zlog_assert_failed(const char *assertion, const char *file,
 				unsigned int line, const char *function)
 	__attribute__((noreturn));
@@ -38,5 +42,9 @@ extern void _zlog_assert_failed(const char *assertion, const char *file,
 
 #undef assert
 #define assert(EX) zassert(EX)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _QUAGGA_ASSERT_H */

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -38,6 +38,10 @@
 
 #include "mlag.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Zebra types. Used in Zserv message header. */
 typedef uint16_t zebra_size_t;
 
@@ -825,5 +829,9 @@ extern void zclient_send_mlag_data(struct zclient *client,
  * Returns 0 for success or -1 on an I/O error.
  */
 extern int zclient_send_hello(struct zclient *client);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_ZCLIENT_H */

--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -30,6 +30,10 @@
 #include "memory.h"
 #include "hook.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern char zlog_prefix[];
 extern size_t zlog_prefixsz;
 extern int zlog_tmpdirfd;
@@ -182,5 +186,9 @@ extern void zlog_startup_end(void);
 extern void zlog_tls_buffer_init(void);
 extern void zlog_tls_buffer_flush(void);
 extern void zlog_tls_buffer_fini(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_ZLOG_H */

--- a/lib/zlog_targets.h
+++ b/lib/zlog_targets.h
@@ -21,6 +21,10 @@
 
 #include "zlog.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* multiple file log targets can be active */
 
 struct zlt_fd;
@@ -62,5 +66,9 @@ extern int zlog_syslog_get_facility(void);
 /* use ZLOG_DISABLED to disable */
 extern void zlog_syslog_set_prio_min(int prio_min);
 extern int zlog_syslog_get_prio_min(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_ZLOG_TARGETS_H */

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -30,6 +30,10 @@
 #include "mlag/mlag.pb-c.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define ZEBRA_MLAG_BUF_LIMIT 2048
 #define ZEBRA_MLAG_LEN_SIZE 4
 
@@ -73,4 +77,8 @@ int zebra_mlag_protobuf_encode_client_data(struct stream *s,
 					   uint32_t *msg_type);
 int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 				       uint32_t len);
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/zebra/zebra_mlag_vty.h
+++ b/zebra/zebra_mlag_vty.h
@@ -22,10 +22,18 @@
 #ifndef __ZEBRA_MLAG_VTY_CODE__
 #define __ZEBRA_MLAG_VTY_CODE__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int32_t zebra_mlag_test_mlag_internal(const char *none,
 					     const char *primary,
 					     const char *secondary);
 
 extern void zebra_mlag_vty_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -20,6 +20,10 @@
 #ifndef ZEBRA_ZEBRA_NB_H_
 #define ZEBRA_ZEBRA_NB_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern const struct frr_yang_module_info frr_zebra_info;
 
 /* prototypes */
@@ -484,5 +488,9 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_el
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
 	const char *xpath, const void *list_entry);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -26,6 +26,10 @@
 #include "lib/nexthop.h"
 #include "lib/nexthop_group.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* This struct is used exclusively for dataplane
  * interaction via a dataplane context.
  *
@@ -268,5 +272,9 @@ extern void zebra_nhg_sweep_table(struct hash *hash);
 /* Nexthop resolution processing */
 struct route_entry; /* Forward ref to avoid circular includes */
 extern int nexthop_active_update(struct route_node *rn, struct route_entry *re);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif	/* __ZEBRA_NHG_H__ */

--- a/zebra/zebra_nhg_private.h
+++ b/zebra/zebra_nhg_private.h
@@ -30,6 +30,10 @@
 
 #include "zebra/zebra_nhg.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Abstraction for connected trees */
 struct nhg_connected {
 	struct nhg_connected_tree_item tree_item;
@@ -69,5 +73,9 @@ nhg_connected_tree_del_nhe(struct nhg_connected_tree_head *head,
 extern struct nhg_hash_entry *
 nhg_connected_tree_add_nhe(struct nhg_connected_tree_head *head,
 			   struct nhg_hash_entry *nhe);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ZEBRA_NHG_PRIVATE_H__ */


### PR DESCRIPTION
This is necessary to fix a recent breakage that prevents the gRPC plugin from being loaded correctly.