### PR TITLE
*: change the signature of the northbound callbacks to be  more flexible

### DIFF
--- a/bfdd/bfdd_nb.h
+++ b/bfdd/bfdd_nb.h
@@ -26,171 +26,145 @@
 extern const struct frr_yang_module_info frr_bfdd_info;
 
 /* Mandatory callbacks. */
-int bfdd_bfd_create(enum nb_event event, const struct lyd_node *dnode,
-		    union nb_resource *resource);
-int bfdd_bfd_destroy(enum nb_event event, const struct lyd_node *dnode);
-int bfdd_bfd_sessions_single_hop_create(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource);
-int bfdd_bfd_sessions_single_hop_destroy(enum nb_event event,
-					 const struct lyd_node *dnode);
-const void *bfdd_bfd_sessions_single_hop_get_next(const void *parent_list_entry,
-						  const void *list_entry);
-int bfdd_bfd_sessions_single_hop_get_keys(const void *list_entry,
-					  struct yang_list_keys *keys);
+int bfdd_bfd_create(struct nb_cb_create_args *args);
+int bfdd_bfd_destroy(struct nb_cb_destroy_args *args);
+int bfdd_bfd_sessions_single_hop_create(struct nb_cb_create_args *args);
+int bfdd_bfd_sessions_single_hop_destroy(struct nb_cb_destroy_args *args);
 const void *
-bfdd_bfd_sessions_single_hop_lookup_entry(const void *parent_list_entry,
-					  const struct yang_list_keys *keys);
+bfdd_bfd_sessions_single_hop_get_next(struct nb_cb_get_next_args *args);
+int bfdd_bfd_sessions_single_hop_get_keys(struct nb_cb_get_keys_args *args);
+const void *
+bfdd_bfd_sessions_single_hop_lookup_entry(struct nb_cb_lookup_entry_args *args);
 int bfdd_bfd_sessions_single_hop_source_addr_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_source_addr_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_required_receive_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_administrative_down_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int bfdd_bfd_sessions_single_hop_echo_mode_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource);
+	struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_single_hop_echo_mode_modify(
+	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem(
-	const char *xpath, const void *list_entry);
-struct yang_data *
-bfdd_bfd_sessions_single_hop_stats_local_state_get_elem(const char *xpath,
-							const void *list_entry);
+	struct nb_cb_get_elem_args *args);
+struct yang_data *bfdd_bfd_sessions_single_hop_stats_local_state_get_elem(
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem(
-	const char *xpath, const void *list_entry);
-int bfdd_bfd_sessions_multi_hop_create(enum nb_event event,
-				       const struct lyd_node *dnode,
-				       union nb_resource *resource);
-int bfdd_bfd_sessions_multi_hop_destroy(enum nb_event event,
-					const struct lyd_node *dnode);
-const void *bfdd_bfd_sessions_multi_hop_get_next(const void *parent_list_entry,
-						 const void *list_entry);
-int bfdd_bfd_sessions_multi_hop_get_keys(const void *list_entry,
-					 struct yang_list_keys *keys);
+	struct nb_cb_get_elem_args *args);
+int bfdd_bfd_sessions_multi_hop_create(struct nb_cb_create_args *args);
+int bfdd_bfd_sessions_multi_hop_destroy(struct nb_cb_destroy_args *args);
 const void *
-bfdd_bfd_sessions_multi_hop_lookup_entry(const void *parent_list_entry,
-					 const struct yang_list_keys *keys);
+bfdd_bfd_sessions_multi_hop_get_next(struct nb_cb_get_next_args *args);
+int bfdd_bfd_sessions_multi_hop_get_keys(struct nb_cb_get_keys_args *args);
+const void *
+bfdd_bfd_sessions_multi_hop_lookup_entry(struct nb_cb_lookup_entry_args *args);
 int bfdd_bfd_sessions_multi_hop_detection_multiplier_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_multi_hop_desired_transmission_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_multi_hop_required_receive_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_multi_hop_administrative_down_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 struct yang_data *
 bfdd_bfd_sessions_multi_hop_stats_local_discriminator_get_elem(
-	const char *xpath, const void *list_entry);
-struct yang_data *
-bfdd_bfd_sessions_multi_hop_stats_local_state_get_elem(const char *xpath,
-						       const void *list_entry);
+	struct nb_cb_get_elem_args *args);
+struct yang_data *bfdd_bfd_sessions_multi_hop_stats_local_state_get_elem(
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_multi_hop_stats_local_diagnostic_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_multi_hop_stats_local_multiplier_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_multi_hop_stats_remote_discriminator_get_elem(
-	const char *xpath, const void *list_entry);
-struct yang_data *
-bfdd_bfd_sessions_multi_hop_stats_remote_state_get_elem(const char *xpath,
-							const void *list_entry);
+	struct nb_cb_get_elem_args *args);
+struct yang_data *bfdd_bfd_sessions_multi_hop_stats_remote_state_get_elem(
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_multi_hop_stats_remote_diagnostic_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_multi_hop_stats_remote_multiplier_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_multi_hop_stats_negotiated_transmission_interval_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_multi_hop_stats_negotiated_receive_interval_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_multi_hop_stats_detection_mode_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_multi_hop_stats_last_down_time_get_elem(
-	const char *xpath, const void *list_entry);
-struct yang_data *
-bfdd_bfd_sessions_multi_hop_stats_last_up_time_get_elem(const char *xpath,
-							const void *list_entry);
+	struct nb_cb_get_elem_args *args);
+struct yang_data *bfdd_bfd_sessions_multi_hop_stats_last_up_time_get_elem(
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_multi_hop_stats_session_down_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *bfdd_bfd_sessions_multi_hop_stats_session_up_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_multi_hop_stats_control_packet_input_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_multi_hop_stats_control_packet_output_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_multi_hop_stats_negotiated_echo_transmission_interval_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_multi_hop_stats_echo_packet_input_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_multi_hop_stats_echo_packet_output_count_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 
 /* Optional 'cli_show' callbacks. */
 void bfd_cli_show_header(struct vty *vty, struct lyd_node *dnode,

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -185,17 +185,15 @@ static int bfd_session_destroy(enum nb_event event,
 /*
  * XPath: /frr-bfdd:bfdd/bfd
  */
-int bfdd_bfd_create(enum nb_event event,
-		    const struct lyd_node *dnode __attribute__((__unused__)),
-		    union nb_resource *resource __attribute__((__unused__)))
+int bfdd_bfd_create(struct nb_cb_create_args *args)
 {
 	/* NOTHING */
 	return NB_OK;
 }
 
-int bfdd_bfd_destroy(enum nb_event event, const struct lyd_node *dnode)
+int bfdd_bfd_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* NOTHING */
 		return NB_OK;
@@ -219,35 +217,28 @@ int bfdd_bfd_destroy(enum nb_event event, const struct lyd_node *dnode)
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop
  */
-int bfdd_bfd_sessions_single_hop_create(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource)
+int bfdd_bfd_sessions_single_hop_create(struct nb_cb_create_args *args)
 {
-	return bfd_session_create(event, dnode, resource, false);
+	return bfd_session_create(args->event, args->dnode, args->resource,
+				  false);
 }
 
-int bfdd_bfd_sessions_single_hop_destroy(enum nb_event event,
-					 const struct lyd_node *dnode)
+int bfdd_bfd_sessions_single_hop_destroy(struct nb_cb_destroy_args *args)
 {
-	return bfd_session_destroy(event, dnode, false);
+	return bfd_session_destroy(args->event, args->dnode, false);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/source-addr
  */
-int bfdd_bfd_sessions_single_hop_source_addr_modify(enum nb_event event
-						    __attribute__((__unused__)),
-						    const struct lyd_node *dnode
-						    __attribute__((__unused__)),
-						    union nb_resource *resource
-						    __attribute__((__unused__)))
+int bfdd_bfd_sessions_single_hop_source_addr_modify(
+	struct nb_cb_modify_args *args)
 {
 	return NB_OK;
 }
 
 int bfdd_bfd_sessions_single_hop_source_addr_destroy(
-	enum nb_event event __attribute__((__unused__)),
-	const struct lyd_node *dnode __attribute__((__unused__)))
+	struct nb_cb_destroy_args *args)
 {
 	return NB_OK;
 }
@@ -256,13 +247,12 @@ int bfdd_bfd_sessions_single_hop_source_addr_destroy(
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/detection-multiplier
  */
 int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource __attribute__((__unused__)))
+	struct nb_cb_modify_args *args)
 {
-	uint8_t detection_multiplier = yang_dnode_get_uint8(dnode, NULL);
+	uint8_t detection_multiplier = yang_dnode_get_uint8(args->dnode, NULL);
 	struct bfd_session *bs;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		break;
 
@@ -271,7 +261,7 @@ int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(
 		break;
 
 	case NB_EV_APPLY:
-		bs = nb_running_get_entry(dnode, NULL, true);
+		bs = nb_running_get_entry(args->dnode, NULL, true);
 		bs->detect_mult = detection_multiplier;
 		break;
 
@@ -287,13 +277,12 @@ int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/desired-transmission-interval
  */
 int bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource __attribute__((__unused__)))
+	struct nb_cb_modify_args *args)
 {
-	uint32_t tx_interval = yang_dnode_get_uint32(dnode, NULL);
+	uint32_t tx_interval = yang_dnode_get_uint32(args->dnode, NULL);
 	struct bfd_session *bs;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if (tx_interval < 10000 || tx_interval > 60000000)
 			return NB_ERR_VALIDATION;
@@ -304,7 +293,7 @@ int bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify(
 		break;
 
 	case NB_EV_APPLY:
-		bs = nb_running_get_entry(dnode, NULL, true);
+		bs = nb_running_get_entry(args->dnode, NULL, true);
 		if (tx_interval == bs->timers.desired_min_tx)
 			return NB_OK;
 
@@ -324,13 +313,12 @@ int bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify(
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/required-receive-interval
  */
 int bfdd_bfd_sessions_single_hop_required_receive_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource __attribute__((__unused__)))
+	struct nb_cb_modify_args *args)
 {
-	uint32_t rx_interval = yang_dnode_get_uint32(dnode, NULL);
+	uint32_t rx_interval = yang_dnode_get_uint32(args->dnode, NULL);
 	struct bfd_session *bs;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if (rx_interval < 10000 || rx_interval > 60000000)
 			return NB_ERR_VALIDATION;
@@ -341,7 +329,7 @@ int bfdd_bfd_sessions_single_hop_required_receive_interval_modify(
 		break;
 
 	case NB_EV_APPLY:
-		bs = nb_running_get_entry(dnode, NULL, true);
+		bs = nb_running_get_entry(args->dnode, NULL, true);
 		if (rx_interval == bs->timers.required_min_rx)
 			return NB_OK;
 
@@ -361,13 +349,12 @@ int bfdd_bfd_sessions_single_hop_required_receive_interval_modify(
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/administrative-down
  */
 int bfdd_bfd_sessions_single_hop_administrative_down_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource __attribute__((__unused__)))
+	struct nb_cb_modify_args *args)
 {
-	bool shutdown = yang_dnode_get_bool(dnode, NULL);
+	bool shutdown = yang_dnode_get_bool(args->dnode, NULL);
 	struct bfd_session *bs;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 		return NB_OK;
@@ -379,7 +366,7 @@ int bfdd_bfd_sessions_single_hop_administrative_down_modify(
 		return NB_OK;
 	}
 
-	bs = nb_running_get_entry(dnode, NULL, true);
+	bs = nb_running_get_entry(args->dnode, NULL, true);
 
 	if (!shutdown) {
 		if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
@@ -423,15 +410,13 @@ int bfdd_bfd_sessions_single_hop_administrative_down_modify(
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/echo-mode
  */
-int bfdd_bfd_sessions_single_hop_echo_mode_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource
-						  __attribute__((__unused__)))
+int bfdd_bfd_sessions_single_hop_echo_mode_modify(
+	struct nb_cb_modify_args *args)
 {
-	bool echo = yang_dnode_get_bool(dnode, NULL);
+	bool echo = yang_dnode_get_bool(args->dnode, NULL);
 	struct bfd_session *bs;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 		return NB_OK;
@@ -443,7 +428,7 @@ int bfdd_bfd_sessions_single_hop_echo_mode_modify(enum nb_event event,
 		return NB_OK;
 	}
 
-	bs = nb_running_get_entry(dnode, NULL, true);
+	bs = nb_running_get_entry(args->dnode, NULL, true);
 
 	if (!echo) {
 		if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
@@ -469,13 +454,12 @@ int bfdd_bfd_sessions_single_hop_echo_mode_modify(enum nb_event event,
  * /frr-bfdd:bfdd/bfd/sessions/single-hop/desired-echo-transmission-interval
  */
 int bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource __attribute__((__unused__)))
+	struct nb_cb_modify_args *args)
 {
-	uint32_t echo_interval = yang_dnode_get_uint32(dnode, NULL);
+	uint32_t echo_interval = yang_dnode_get_uint32(args->dnode, NULL);
 	struct bfd_session *bs;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if (echo_interval < 10000 || echo_interval > 60000000)
 			return NB_ERR_VALIDATION;
@@ -486,7 +470,7 @@ int bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify(
 		break;
 
 	case NB_EV_APPLY:
-		bs = nb_running_get_entry(dnode, NULL, true);
+		bs = nb_running_get_entry(args->dnode, NULL, true);
 		if (echo_interval == bs->timers.required_min_echo)
 			return NB_OK;
 
@@ -504,15 +488,13 @@ int bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify(
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/multi-hop
  */
-int bfdd_bfd_sessions_multi_hop_create(enum nb_event event,
-				       const struct lyd_node *dnode,
-				       union nb_resource *resource)
+int bfdd_bfd_sessions_multi_hop_create(struct nb_cb_create_args *args)
 {
-	return bfd_session_create(event, dnode, resource, true);
+	return bfd_session_create(args->event, args->dnode, args->resource,
+				  true);
 }
 
-int bfdd_bfd_sessions_multi_hop_destroy(enum nb_event event,
-					const struct lyd_node *dnode)
+int bfdd_bfd_sessions_multi_hop_destroy(struct nb_cb_destroy_args *args)
 {
-	return bfd_session_destroy(event, dnode, true);
+	return bfd_session_destroy(args->event, args->dnode, true);
 }

--- a/bfdd/bfdd_nb_state.c
+++ b/bfdd/bfdd_nb_state.c
@@ -31,37 +31,34 @@
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop
  */
-const void *bfdd_bfd_sessions_single_hop_get_next(const void *parent_list_entry
-						  __attribute__((__unused__)),
-						  const void *list_entry)
+const void *
+bfdd_bfd_sessions_single_hop_get_next(struct nb_cb_get_next_args *args)
 {
-	return bfd_session_next(list_entry, false);
+	return bfd_session_next(args->list_entry, false);
 }
 
-int bfdd_bfd_sessions_single_hop_get_keys(const void *list_entry,
-					  struct yang_list_keys *keys)
+int bfdd_bfd_sessions_single_hop_get_keys(struct nb_cb_get_keys_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 	char dstbuf[INET6_ADDRSTRLEN];
 
 	inet_ntop(bs->key.family, &bs->key.peer, dstbuf, sizeof(dstbuf));
 
-	keys->num = 3;
-	strlcpy(keys->key[0], dstbuf, sizeof(keys->key[0]));
-	strlcpy(keys->key[1], bs->key.ifname, sizeof(keys->key[1]));
-	strlcpy(keys->key[2], bs->key.vrfname, sizeof(keys->key[2]));
+	args->keys->num = 3;
+	strlcpy(args->keys->key[0], dstbuf, sizeof(args->keys->key[0]));
+	strlcpy(args->keys->key[1], bs->key.ifname, sizeof(args->keys->key[1]));
+	strlcpy(args->keys->key[2], bs->key.vrfname,
+		sizeof(args->keys->key[2]));
 
 	return NB_OK;
 }
 
 const void *
-bfdd_bfd_sessions_single_hop_lookup_entry(const void *parent_list_entry
-					  __attribute__((__unused__)),
-					  const struct yang_list_keys *keys)
+bfdd_bfd_sessions_single_hop_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
-	const char *dest_addr = keys->key[0];
-	const char *ifname = keys->key[1];
-	const char *vrf = keys->key[2];
+	const char *dest_addr = args->keys->key[0];
+	const char *ifname = args->keys->key[1];
+	const char *vrf = args->keys->key[2];
 	struct sockaddr_any psa, lsa;
 	struct bfd_key bk;
 
@@ -77,45 +74,44 @@ bfdd_bfd_sessions_single_hop_lookup_entry(const void *parent_list_entry
  */
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_uint32(xpath, bs->discrs.my_discr);
+	return yang_data_new_uint32(args->xpath, bs->discrs.my_discr);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-state
  */
-struct yang_data *
-bfdd_bfd_sessions_single_hop_stats_local_state_get_elem(const char *xpath,
-							const void *list_entry)
+struct yang_data *bfdd_bfd_sessions_single_hop_stats_local_state_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_enum(xpath, bs->ses_state);
+	return yang_data_new_enum(args->xpath, bs->ses_state);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-diagnostic
  */
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_enum(xpath, bs->local_diag);
+	return yang_data_new_enum(args->xpath, bs->local_diag);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-multiplier
  */
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_int8(xpath, bs->detect_mult);
+	return yang_data_new_int8(args->xpath, bs->detect_mult);
 }
 
 /*
@@ -123,48 +119,47 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem(
  */
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
 	if (bs->discrs.remote_discr == 0)
 		return NULL;
 
-	return yang_data_new_uint32(xpath, bs->discrs.remote_discr);
+	return yang_data_new_uint32(args->xpath, bs->discrs.remote_discr);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-state
  */
-struct yang_data *
-bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem(const char *xpath,
-							 const void *list_entry)
+struct yang_data *bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_enum(xpath, bs->ses_state);
+	return yang_data_new_enum(args->xpath, bs->ses_state);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-diagnostic
  */
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_enum(xpath, bs->remote_diag);
+	return yang_data_new_enum(args->xpath, bs->remote_diag);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-multiplier
  */
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_int8(xpath, bs->remote_detect_mult);
+	return yang_data_new_int8(args->xpath, bs->remote_detect_mult);
 }
 
 /*
@@ -173,11 +168,12 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem(
  */
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_uint32(xpath, bs->remote_timers.desired_min_tx);
+	return yang_data_new_uint32(args->xpath,
+				    bs->remote_timers.desired_min_tx);
 }
 
 /*
@@ -186,20 +182,21 @@ bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem(
  */
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_uint32(xpath, bs->remote_timers.required_min_rx);
+	return yang_data_new_uint32(args->xpath,
+				    bs->remote_timers.required_min_rx);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/detection-mode
  */
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 	int detection_mode;
 
 	/*
@@ -216,15 +213,14 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem(
 	else
 		detection_mode = 2;
 
-	return yang_data_new_enum(xpath, detection_mode);
+	return yang_data_new_enum(args->xpath, detection_mode);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/last-down-time
  */
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem(
-	const char *xpath __attribute__((__unused__)),
-	const void *list_entry __attribute__((__unused__)))
+	struct nb_cb_get_elem_args *args)
 {
 	/*
 	 * TODO: implement me.
@@ -238,8 +234,7 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem(
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/last-up-time
  */
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem(
-	const char *xpath __attribute__((__unused__)),
-	const void *list_entry __attribute__((__unused__)))
+	struct nb_cb_get_elem_args *args)
 {
 	/*
 	 * TODO: implement me.
@@ -254,22 +249,22 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem(
  */
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_uint64(xpath, bs->stats.session_down);
+	return yang_data_new_uint64(args->xpath, bs->stats.session_down);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/session-up-count
  */
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_uint64(xpath, bs->stats.session_up);
+	return yang_data_new_uint64(args->xpath, bs->stats.session_up);
 }
 
 /*
@@ -278,11 +273,11 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem(
  */
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_uint64(xpath, bs->stats.rx_ctrl_pkt);
+	return yang_data_new_uint64(args->xpath, bs->stats.rx_ctrl_pkt);
 }
 
 /*
@@ -291,11 +286,11 @@ bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem(
  */
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_uint64(xpath, bs->stats.tx_ctrl_pkt);
+	return yang_data_new_uint64(args->xpath, bs->stats.tx_ctrl_pkt);
 }
 
 /*
@@ -304,11 +299,12 @@ bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem(
  */
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_uint32(xpath, bs->remote_timers.required_min_echo);
+	return yang_data_new_uint32(args->xpath,
+				    bs->remote_timers.required_min_echo);
 }
 
 /*
@@ -316,11 +312,11 @@ bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_ele
  */
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_uint64(xpath, bs->stats.rx_echo_pkt);
+	return yang_data_new_uint64(args->xpath, bs->stats.rx_echo_pkt);
 }
 
 /*
@@ -328,50 +324,47 @@ bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem(
  */
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 
-	return yang_data_new_uint64(xpath, bs->stats.tx_echo_pkt);
+	return yang_data_new_uint64(args->xpath, bs->stats.tx_echo_pkt);
 }
 
 /*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/multi-hop
  */
-const void *bfdd_bfd_sessions_multi_hop_get_next(const void *parent_list_entry
-						 __attribute__((__unused__)),
-						 const void *list_entry)
+const void *
+bfdd_bfd_sessions_multi_hop_get_next(struct nb_cb_get_next_args *args)
 {
-	return bfd_session_next(list_entry, true);
+	return bfd_session_next(args->list_entry, true);
 }
 
-int bfdd_bfd_sessions_multi_hop_get_keys(const void *list_entry,
-					 struct yang_list_keys *keys)
+int bfdd_bfd_sessions_multi_hop_get_keys(struct nb_cb_get_keys_args *args)
 {
-	const struct bfd_session *bs = list_entry;
+	const struct bfd_session *bs = args->list_entry;
 	char dstbuf[INET6_ADDRSTRLEN], srcbuf[INET6_ADDRSTRLEN];
 
 	inet_ntop(bs->key.family, &bs->key.peer, dstbuf, sizeof(dstbuf));
 	inet_ntop(bs->key.family, &bs->key.local, srcbuf, sizeof(srcbuf));
 
-	keys->num = 4;
-	strlcpy(keys->key[0], srcbuf, sizeof(keys->key[0]));
-	strlcpy(keys->key[1], dstbuf, sizeof(keys->key[1]));
-	strlcpy(keys->key[2], bs->key.ifname, sizeof(keys->key[2]));
-	strlcpy(keys->key[3], bs->key.vrfname, sizeof(keys->key[3]));
+	args->keys->num = 4;
+	strlcpy(args->keys->key[0], srcbuf, sizeof(args->keys->key[0]));
+	strlcpy(args->keys->key[1], dstbuf, sizeof(args->keys->key[1]));
+	strlcpy(args->keys->key[2], bs->key.ifname, sizeof(args->keys->key[2]));
+	strlcpy(args->keys->key[3], bs->key.vrfname,
+		sizeof(args->keys->key[3]));
 
 	return NB_OK;
 }
 
 const void *
-bfdd_bfd_sessions_multi_hop_lookup_entry(const void *parent_list_entry
-					 __attribute__((__unused__)),
-					 const struct yang_list_keys *keys)
+bfdd_bfd_sessions_multi_hop_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
-	const char *source_addr = keys->key[0];
-	const char *dest_addr = keys->key[1];
-	const char *ifname = keys->key[2];
-	const char *vrf = keys->key[3];
+	const char *source_addr = args->keys->key[0];
+	const char *dest_addr = args->keys->key[1];
+	const char *ifname = args->keys->key[2];
+	const char *vrf = args->keys->key[3];
 	struct sockaddr_any psa, lsa;
 	struct bfd_key bk;
 

--- a/eigrpd/eigrp_northbound.c
+++ b/eigrpd/eigrp_northbound.c
@@ -74,49 +74,47 @@ static struct eigrp_interface *eigrp_interface_lookup(const struct eigrp *eigrp,
 /*
  * XPath: /frr-eigrpd:eigrpd/instance
  */
-static int eigrpd_instance_create(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource)
+static int eigrpd_instance_create(struct nb_cb_create_args *args)
 {
 	struct eigrp *eigrp;
 	const char *vrf;
 	vrf_id_t vrfid;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* NOTHING */
 		break;
 	case NB_EV_PREPARE:
-		vrf = yang_dnode_get_string(dnode, "./vrf");
+		vrf = yang_dnode_get_string(args->dnode, "./vrf");
 		vrfid = vrf_name_to_id(vrf);
 
-		eigrp = eigrp_get(yang_dnode_get_uint16(dnode, "./asn"), vrfid);
-		resource->ptr = eigrp;
+		eigrp = eigrp_get(yang_dnode_get_uint16(args->dnode, "./asn"),
+				  vrfid);
+		args->resource->ptr = eigrp;
 		break;
 	case NB_EV_ABORT:
-		eigrp_finish_final(resource->ptr);
+		eigrp_finish_final(args->resource->ptr);
 		break;
 	case NB_EV_APPLY:
-		nb_running_set_entry(dnode, resource->ptr);
+		nb_running_set_entry(args->dnode, args->resource->ptr);
 		break;
 	}
 
 	return NB_OK;
 }
 
-static int eigrpd_instance_destroy(enum nb_event event,
-				   const struct lyd_node *dnode)
+static int eigrpd_instance_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_unset_entry(dnode);
+		eigrp = nb_running_unset_entry(args->dnode);
 		eigrp_finish_final(eigrp);
 		break;
 	}
@@ -127,40 +125,38 @@ static int eigrpd_instance_destroy(enum nb_event event,
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/router-id
  */
-static int eigrpd_instance_router_id_modify(enum nb_event event,
-					    const struct lyd_node *dnode,
-					    union nb_resource *resource)
+static int eigrpd_instance_router_id_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		yang_dnode_get_ipv4(&eigrp->router_id_static, dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		yang_dnode_get_ipv4(&eigrp->router_id_static, args->dnode,
+				    NULL);
 		break;
 	}
 
 	return NB_OK;
 }
 
-static int eigrpd_instance_router_id_destroy(enum nb_event event,
-					     const struct lyd_node *dnode)
+static int eigrpd_instance_router_id_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp->router_id_static.s_addr = INADDR_ANY;
 		break;
 	}
@@ -172,17 +168,15 @@ static int eigrpd_instance_router_id_destroy(enum nb_event event,
  * XPath: /frr-eigrpd:eigrpd/instance/passive-interface
  */
 static int
-eigrpd_instance_passive_interface_create(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+eigrpd_instance_passive_interface_create(struct nb_cb_create_args *args)
 {
 	struct eigrp_interface *eif;
 	struct eigrp *eigrp;
 	const char *ifname;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		eigrp = nb_running_get_entry(dnode, NULL, false);
+		eigrp = nb_running_get_entry(args->dnode, NULL, false);
 		if (eigrp == NULL) {
 			/*
 			 * XXX: we can't verify if the interface exists
@@ -191,7 +185,7 @@ eigrpd_instance_passive_interface_create(enum nb_event event,
 			break;
 		}
 
-		ifname = yang_dnode_get_string(dnode, NULL);
+		ifname = yang_dnode_get_string(args->dnode, NULL);
 		eif = eigrp_interface_lookup(eigrp, ifname);
 		if (eif == NULL)
 			return NB_ERR_INCONSISTENCY;
@@ -201,8 +195,8 @@ eigrpd_instance_passive_interface_create(enum nb_event event,
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		ifname = yang_dnode_get_string(dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		ifname = yang_dnode_get_string(args->dnode, NULL);
 		eif = eigrp_interface_lookup(eigrp, ifname);
 		if (eif == NULL)
 			return NB_ERR_INCONSISTENCY;
@@ -215,22 +209,21 @@ eigrpd_instance_passive_interface_create(enum nb_event event,
 }
 
 static int
-eigrpd_instance_passive_interface_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+eigrpd_instance_passive_interface_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp_interface *eif;
 	struct eigrp *eigrp;
 	const char *ifname;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		ifname = yang_dnode_get_string(dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		ifname = yang_dnode_get_string(args->dnode, NULL);
 		eif = eigrp_interface_lookup(eigrp, ifname);
 		if (eif == NULL)
 			break;
@@ -245,11 +238,9 @@ eigrpd_instance_passive_interface_destroy(enum nb_event event,
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/active-time
  */
-static int eigrpd_instance_active_time_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource)
+static int eigrpd_instance_active_time_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* TODO: Not implemented. */
 		return NB_ERR_INCONSISTENCY;
@@ -266,40 +257,37 @@ static int eigrpd_instance_active_time_modify(enum nb_event event,
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/variance
  */
-static int eigrpd_instance_variance_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource)
+static int eigrpd_instance_variance_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		eigrp->variance = yang_dnode_get_uint8(dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		eigrp->variance = yang_dnode_get_uint8(args->dnode, NULL);
 		break;
 	}
 
 	return NB_OK;
 }
 
-static int eigrpd_instance_variance_destroy(enum nb_event event,
-					    const struct lyd_node *dnode)
+static int eigrpd_instance_variance_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp->variance = EIGRP_VARIANCE_DEFAULT;
 		break;
 	}
@@ -310,40 +298,38 @@ static int eigrpd_instance_variance_destroy(enum nb_event event,
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/maximum-paths
  */
-static int eigrpd_instance_maximum_paths_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource)
+static int eigrpd_instance_maximum_paths_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		eigrp->max_paths = yang_dnode_get_uint8(dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		eigrp->max_paths = yang_dnode_get_uint8(args->dnode, NULL);
 		break;
 	}
 
 	return NB_OK;
 }
 
-static int eigrpd_instance_maximum_paths_destroy(enum nb_event event,
-						 const struct lyd_node *dnode)
+static int
+eigrpd_instance_maximum_paths_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp->max_paths = EIGRP_MAX_PATHS_DEFAULT;
 		break;
 	}
@@ -355,21 +341,19 @@ static int eigrpd_instance_maximum_paths_destroy(enum nb_event event,
  * XPath: /frr-eigrpd:eigrpd/instance/metric-weights/K1
  */
 static int
-eigrpd_instance_metric_weights_K1_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+eigrpd_instance_metric_weights_K1_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		eigrp->k_values[0] = yang_dnode_get_uint8(dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		eigrp->k_values[0] = yang_dnode_get_uint8(args->dnode, NULL);
 		break;
 	}
 
@@ -377,19 +361,18 @@ eigrpd_instance_metric_weights_K1_modify(enum nb_event event,
 }
 
 static int
-eigrpd_instance_metric_weights_K1_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+eigrpd_instance_metric_weights_K1_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp->k_values[0] = EIGRP_K1_DEFAULT;
 		break;
 	}
@@ -401,21 +384,19 @@ eigrpd_instance_metric_weights_K1_destroy(enum nb_event event,
  * XPath: /frr-eigrpd:eigrpd/instance/metric-weights/K2
  */
 static int
-eigrpd_instance_metric_weights_K2_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+eigrpd_instance_metric_weights_K2_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		eigrp->k_values[1] = yang_dnode_get_uint8(dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		eigrp->k_values[1] = yang_dnode_get_uint8(args->dnode, NULL);
 		break;
 	}
 
@@ -423,19 +404,18 @@ eigrpd_instance_metric_weights_K2_modify(enum nb_event event,
 }
 
 static int
-eigrpd_instance_metric_weights_K2_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+eigrpd_instance_metric_weights_K2_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp->k_values[1] = EIGRP_K2_DEFAULT;
 		break;
 	}
@@ -447,21 +427,19 @@ eigrpd_instance_metric_weights_K2_destroy(enum nb_event event,
  * XPath: /frr-eigrpd:eigrpd/instance/metric-weights/K3
  */
 static int
-eigrpd_instance_metric_weights_K3_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+eigrpd_instance_metric_weights_K3_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		eigrp->k_values[2] = yang_dnode_get_uint8(dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		eigrp->k_values[2] = yang_dnode_get_uint8(args->dnode, NULL);
 		break;
 	}
 
@@ -469,19 +447,18 @@ eigrpd_instance_metric_weights_K3_modify(enum nb_event event,
 }
 
 static int
-eigrpd_instance_metric_weights_K3_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+eigrpd_instance_metric_weights_K3_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp->k_values[2] = EIGRP_K3_DEFAULT;
 		break;
 	}
@@ -493,21 +470,19 @@ eigrpd_instance_metric_weights_K3_destroy(enum nb_event event,
  * XPath: /frr-eigrpd:eigrpd/instance/metric-weights/K4
  */
 static int
-eigrpd_instance_metric_weights_K4_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+eigrpd_instance_metric_weights_K4_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		eigrp->k_values[3] = yang_dnode_get_uint8(dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		eigrp->k_values[3] = yang_dnode_get_uint8(args->dnode, NULL);
 		break;
 	}
 
@@ -515,19 +490,18 @@ eigrpd_instance_metric_weights_K4_modify(enum nb_event event,
 }
 
 static int
-eigrpd_instance_metric_weights_K4_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+eigrpd_instance_metric_weights_K4_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp->k_values[3] = EIGRP_K4_DEFAULT;
 		break;
 	}
@@ -539,21 +513,19 @@ eigrpd_instance_metric_weights_K4_destroy(enum nb_event event,
  * XPath: /frr-eigrpd:eigrpd/instance/metric-weights/K5
  */
 static int
-eigrpd_instance_metric_weights_K5_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+eigrpd_instance_metric_weights_K5_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		eigrp->k_values[4] = yang_dnode_get_uint8(dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		eigrp->k_values[4] = yang_dnode_get_uint8(args->dnode, NULL);
 		break;
 	}
 
@@ -561,19 +533,18 @@ eigrpd_instance_metric_weights_K5_modify(enum nb_event event,
 }
 
 static int
-eigrpd_instance_metric_weights_K5_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+eigrpd_instance_metric_weights_K5_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp->k_values[4] = EIGRP_K5_DEFAULT;
 		break;
 	}
@@ -585,21 +556,19 @@ eigrpd_instance_metric_weights_K5_destroy(enum nb_event event,
  * XPath: /frr-eigrpd:eigrpd/instance/metric-weights/K6
  */
 static int
-eigrpd_instance_metric_weights_K6_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+eigrpd_instance_metric_weights_K6_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		eigrp->k_values[5] = yang_dnode_get_uint8(dnode, NULL);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		eigrp->k_values[5] = yang_dnode_get_uint8(args->dnode, NULL);
 		break;
 	}
 
@@ -607,19 +576,18 @@ eigrpd_instance_metric_weights_K6_modify(enum nb_event event,
 }
 
 static int
-eigrpd_instance_metric_weights_K6_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+eigrpd_instance_metric_weights_K6_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp->k_values[5] = EIGRP_K6_DEFAULT;
 		break;
 	}
@@ -630,20 +598,18 @@ eigrpd_instance_metric_weights_K6_destroy(enum nb_event event,
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/network
  */
-static int eigrpd_instance_network_create(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource)
+static int eigrpd_instance_network_create(struct nb_cb_create_args *args)
 {
 	struct route_node *rnode;
 	struct prefix prefix;
 	struct eigrp *eigrp;
 	int exists;
 
-	yang_dnode_get_ipv4p(&prefix, dnode, NULL);
+	yang_dnode_get_ipv4p(&prefix, args->dnode, NULL);
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		eigrp = nb_running_get_entry(dnode, NULL, false);
+		eigrp = nb_running_get_entry(args->dnode, NULL, false);
 		/* If entry doesn't exist it means the list is empty. */
 		if (eigrp == NULL)
 			break;
@@ -659,7 +625,7 @@ static int eigrpd_instance_network_create(enum nb_event event,
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		if (eigrp_network_set(eigrp, &prefix) == 0)
 			return NB_ERR_INCONSISTENCY;
 		break;
@@ -668,19 +634,18 @@ static int eigrpd_instance_network_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int eigrpd_instance_network_destroy(enum nb_event event,
-					   const struct lyd_node *dnode)
+static int eigrpd_instance_network_destroy(struct nb_cb_destroy_args *args)
 {
 	struct route_node *rnode;
 	struct prefix prefix;
 	struct eigrp *eigrp;
 	int exists = 0;
 
-	yang_dnode_get_ipv4p(&prefix, dnode, NULL);
+	yang_dnode_get_ipv4p(&prefix, args->dnode, NULL);
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		eigrp = nb_running_get_entry(dnode, NULL, false);
+		eigrp = nb_running_get_entry(args->dnode, NULL, false);
 		/* If entry doesn't exist it means the list is empty. */
 		if (eigrp == NULL)
 			break;
@@ -696,7 +661,7 @@ static int eigrpd_instance_network_destroy(enum nb_event event,
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp_network_unset(eigrp, &prefix);
 		break;
 	}
@@ -707,11 +672,9 @@ static int eigrpd_instance_network_destroy(enum nb_event event,
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/neighbor
  */
-static int eigrpd_instance_neighbor_create(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource)
+static int eigrpd_instance_neighbor_create(struct nb_cb_create_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* TODO: Not implemented. */
 		return NB_ERR_INCONSISTENCY;
@@ -725,10 +688,9 @@ static int eigrpd_instance_neighbor_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int eigrpd_instance_neighbor_destroy(enum nb_event event,
-					    const struct lyd_node *dnode)
+static int eigrpd_instance_neighbor_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* TODO: Not implemented. */
 		return NB_ERR_INCONSISTENCY;
@@ -745,9 +707,7 @@ static int eigrpd_instance_neighbor_destroy(enum nb_event event,
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/redistribute
  */
-static int eigrpd_instance_redistribute_create(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource)
+static int eigrpd_instance_redistribute_create(struct nb_cb_create_args *args)
 {
 	struct eigrp_metrics metrics;
 	const char *vrfname;
@@ -755,10 +715,10 @@ static int eigrpd_instance_redistribute_create(enum nb_event event,
 	uint32_t proto;
 	vrf_id_t vrfid;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		proto = yang_dnode_get_enum(dnode, "./protocol");
-		vrfname = yang_dnode_get_string(dnode, "../vrf");
+		proto = yang_dnode_get_enum(args->dnode, "./protocol");
+		vrfname = yang_dnode_get_string(args->dnode, "../vrf");
 		vrfid = vrf_name_to_id(vrfname);
 		if (vrf_bitmap_check(zclient->redist[AFI_IP][proto], vrfid))
 			return NB_ERR_INCONSISTENCY;
@@ -768,9 +728,9 @@ static int eigrpd_instance_redistribute_create(enum nb_event event,
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		proto = yang_dnode_get_enum(dnode, "./protocol");
-		redistribute_get_metrics(dnode, &metrics);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		proto = yang_dnode_get_enum(args->dnode, "./protocol");
+		redistribute_get_metrics(args->dnode, &metrics);
 		eigrp_redistribute_set(eigrp, proto, metrics);
 		break;
 	}
@@ -778,21 +738,20 @@ static int eigrpd_instance_redistribute_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int eigrpd_instance_redistribute_destroy(enum nb_event event,
-						const struct lyd_node *dnode)
+static int eigrpd_instance_redistribute_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp *eigrp;
 	uint32_t proto;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		proto = yang_dnode_get_enum(dnode, "./protocol");
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		proto = yang_dnode_get_enum(args->dnode, "./protocol");
 		eigrp_redistribute_unset(eigrp, proto);
 		break;
 	}
@@ -804,11 +763,9 @@ static int eigrpd_instance_redistribute_destroy(enum nb_event event,
  * XPath: /frr-eigrpd:eigrpd/instance/redistribute/route-map
  */
 static int
-eigrpd_instance_redistribute_route_map_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource)
+eigrpd_instance_redistribute_route_map_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* TODO: Not implemented. */
 		return NB_ERR_INCONSISTENCY;
@@ -823,10 +780,9 @@ eigrpd_instance_redistribute_route_map_modify(enum nb_event event,
 }
 
 static int
-eigrpd_instance_redistribute_route_map_destroy(enum nb_event event,
-					       const struct lyd_node *dnode)
+eigrpd_instance_redistribute_route_map_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* TODO: Not implemented. */
 		return NB_ERR_INCONSISTENCY;
@@ -844,23 +800,22 @@ eigrpd_instance_redistribute_route_map_destroy(enum nb_event event,
  * XPath: /frr-eigrpd:eigrpd/instance/redistribute/metrics/bandwidth
  */
 static int eigrpd_instance_redistribute_metrics_bandwidth_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct eigrp_metrics metrics;
 	struct eigrp *eigrp;
 	uint32_t proto;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		proto = yang_dnode_get_enum(dnode, "../../protocol");
-		redistribute_get_metrics(dnode, &metrics);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		proto = yang_dnode_get_enum(args->dnode, "../../protocol");
+		redistribute_get_metrics(args->dnode, &metrics);
 		eigrp_redistribute_set(eigrp, proto, metrics);
 		break;
 	}
@@ -869,22 +824,22 @@ static int eigrpd_instance_redistribute_metrics_bandwidth_modify(
 }
 
 static int eigrpd_instance_redistribute_metrics_bandwidth_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
 	struct eigrp_metrics metrics;
 	struct eigrp *eigrp;
 	uint32_t proto;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eigrp = nb_running_get_entry(dnode, NULL, true);
-		proto = yang_dnode_get_enum(dnode, "../../protocol");
-		redistribute_get_metrics(dnode, &metrics);
+		eigrp = nb_running_get_entry(args->dnode, NULL, true);
+		proto = yang_dnode_get_enum(args->dnode, "../../protocol");
+		redistribute_get_metrics(args->dnode, &metrics);
 		eigrp_redistribute_set(eigrp, proto, metrics);
 		break;
 	}
@@ -895,98 +850,74 @@ static int eigrpd_instance_redistribute_metrics_bandwidth_destroy(
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/redistribute/metrics/delay
  */
-static int
-eigrpd_instance_redistribute_metrics_delay_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource)
+static int eigrpd_instance_redistribute_metrics_delay_modify(
+	struct nb_cb_modify_args *args)
 {
-	return eigrpd_instance_redistribute_metrics_bandwidth_modify(event,
-								     dnode,
-								     resource);
+	return eigrpd_instance_redistribute_metrics_bandwidth_modify(args);
 }
 
-static int
-eigrpd_instance_redistribute_metrics_delay_destroy(enum nb_event event,
-						   const struct lyd_node *dnode)
+static int eigrpd_instance_redistribute_metrics_delay_destroy(
+	struct nb_cb_destroy_args *args)
 {
-	return eigrpd_instance_redistribute_metrics_bandwidth_destroy(event,
-								      dnode);
+	return eigrpd_instance_redistribute_metrics_bandwidth_destroy(args);
 }
 
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/redistribute/metrics/reliability
  */
 static int eigrpd_instance_redistribute_metrics_reliability_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return eigrpd_instance_redistribute_metrics_bandwidth_modify(event,
-								     dnode,
-								     resource);
+	return eigrpd_instance_redistribute_metrics_bandwidth_modify(args);
 }
 
 static int eigrpd_instance_redistribute_metrics_reliability_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return eigrpd_instance_redistribute_metrics_bandwidth_destroy(event,
-								      dnode);
+	return eigrpd_instance_redistribute_metrics_bandwidth_destroy(args);
 }
 
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/redistribute/metrics/load
  */
 static int
-eigrpd_instance_redistribute_metrics_load_modify(enum nb_event event,
-						 const struct lyd_node *dnode,
-						 union nb_resource *resource)
+eigrpd_instance_redistribute_metrics_load_modify(struct nb_cb_modify_args *args)
 {
-	return eigrpd_instance_redistribute_metrics_bandwidth_modify(event,
-								     dnode,
-								     resource);
+	return eigrpd_instance_redistribute_metrics_bandwidth_modify(args);
 }
 
-static int
-eigrpd_instance_redistribute_metrics_load_destroy(enum nb_event event,
-						  const struct lyd_node *dnode)
+static int eigrpd_instance_redistribute_metrics_load_destroy(
+	struct nb_cb_destroy_args *args)
 {
-	return eigrpd_instance_redistribute_metrics_bandwidth_destroy(event,
-								      dnode);
+	return eigrpd_instance_redistribute_metrics_bandwidth_destroy(args);
 }
 
 /*
  * XPath: /frr-eigrpd:eigrpd/instance/redistribute/metrics/mtu
  */
 static int
-eigrpd_instance_redistribute_metrics_mtu_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource)
+eigrpd_instance_redistribute_metrics_mtu_modify(struct nb_cb_modify_args *args)
 {
-	return eigrpd_instance_redistribute_metrics_bandwidth_modify(event,
-								     dnode,
-								     resource);
+	return eigrpd_instance_redistribute_metrics_bandwidth_modify(args);
 }
 
-static int
-eigrpd_instance_redistribute_metrics_mtu_destroy(enum nb_event event,
-						 const struct lyd_node *dnode)
+static int eigrpd_instance_redistribute_metrics_mtu_destroy(
+	struct nb_cb_destroy_args *args)
 {
-	return eigrpd_instance_redistribute_metrics_bandwidth_destroy(event,
-								      dnode);
+	return eigrpd_instance_redistribute_metrics_bandwidth_destroy(args);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/frr-eigrpd:eigrp/delay
  */
-static int lib_interface_eigrp_delay_modify(enum nb_event event,
-					    const struct lyd_node *dnode,
-					    union nb_resource *resource)
+static int lib_interface_eigrp_delay_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp_interface *ei;
 	struct interface *ifp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		ifp = nb_running_get_entry(dnode, NULL, false);
+		ifp = nb_running_get_entry(args->dnode, NULL, false);
 		if (ifp == NULL) {
 			/*
 			 * XXX: we can't verify if the interface exists
@@ -1004,12 +935,12 @@ static int lib_interface_eigrp_delay_modify(enum nb_event event,
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		ifp = nb_running_get_entry(dnode, NULL, true);
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		ei = ifp->info;
 		if (ei == NULL)
 			return NB_ERR_INCONSISTENCY;
 
-		ei->params.delay = yang_dnode_get_uint32(dnode, NULL);
+		ei->params.delay = yang_dnode_get_uint32(args->dnode, NULL);
 		eigrp_if_reset(ifp);
 		break;
 	}
@@ -1020,16 +951,14 @@ static int lib_interface_eigrp_delay_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-eigrpd:eigrp/bandwidth
  */
-static int lib_interface_eigrp_bandwidth_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource)
+static int lib_interface_eigrp_bandwidth_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct eigrp_interface *ei;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		ifp = nb_running_get_entry(dnode, NULL, false);
+		ifp = nb_running_get_entry(args->dnode, NULL, false);
 		if (ifp == NULL) {
 			/*
 			 * XXX: we can't verify if the interface exists
@@ -1047,12 +976,12 @@ static int lib_interface_eigrp_bandwidth_modify(enum nb_event event,
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		ifp = nb_running_get_entry(dnode, NULL, true);
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		ei = ifp->info;
 		if (ei == NULL)
 			return NB_ERR_INCONSISTENCY;
 
-		ei->params.bandwidth = yang_dnode_get_uint32(dnode, NULL);
+		ei->params.bandwidth = yang_dnode_get_uint32(args->dnode, NULL);
 		eigrp_if_reset(ifp);
 		break;
 	}
@@ -1064,16 +993,14 @@ static int lib_interface_eigrp_bandwidth_modify(enum nb_event event,
  * XPath: /frr-interface:lib/interface/frr-eigrpd:eigrp/hello-interval
  */
 static int
-lib_interface_eigrp_hello_interval_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource)
+lib_interface_eigrp_hello_interval_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct eigrp_interface *ei;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		ifp = nb_running_get_entry(dnode, NULL, false);
+		ifp = nb_running_get_entry(args->dnode, NULL, false);
 		if (ifp == NULL) {
 			/*
 			 * XXX: we can't verify if the interface exists
@@ -1091,12 +1018,12 @@ lib_interface_eigrp_hello_interval_modify(enum nb_event event,
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		ifp = nb_running_get_entry(dnode, NULL, true);
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		ei = ifp->info;
 		if (ei == NULL)
 			return NB_ERR_INCONSISTENCY;
 
-		ei->params.v_hello = yang_dnode_get_uint16(dnode, NULL);
+		ei->params.v_hello = yang_dnode_get_uint16(args->dnode, NULL);
 		break;
 	}
 
@@ -1106,16 +1033,14 @@ lib_interface_eigrp_hello_interval_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-eigrpd:eigrp/hold-time
  */
-static int lib_interface_eigrp_hold_time_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource)
+static int lib_interface_eigrp_hold_time_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct eigrp_interface *ei;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		ifp = nb_running_get_entry(dnode, NULL, false);
+		ifp = nb_running_get_entry(args->dnode, NULL, false);
 		if (ifp == NULL) {
 			/*
 			 * XXX: we can't verify if the interface exists
@@ -1133,12 +1058,12 @@ static int lib_interface_eigrp_hold_time_modify(enum nb_event event,
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		ifp = nb_running_get_entry(dnode, NULL, true);
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		ei = ifp->info;
 		if (ei == NULL)
 			return NB_ERR_INCONSISTENCY;
 
-		ei->params.v_wait = yang_dnode_get_uint16(dnode, NULL);
+		ei->params.v_wait = yang_dnode_get_uint16(args->dnode, NULL);
 		break;
 	}
 
@@ -1149,11 +1074,9 @@ static int lib_interface_eigrp_hold_time_modify(enum nb_event event,
  * XPath: /frr-interface:lib/interface/frr-eigrpd:eigrp/split-horizon
  */
 static int
-lib_interface_eigrp_split_horizon_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+lib_interface_eigrp_split_horizon_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* TODO: Not implemented. */
 		return NB_ERR_INCONSISTENCY;
@@ -1170,17 +1093,15 @@ lib_interface_eigrp_split_horizon_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-eigrpd:eigrp/instance
  */
-static int lib_interface_eigrp_instance_create(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource)
+static int lib_interface_eigrp_instance_create(struct nb_cb_create_args *args)
 {
 	struct eigrp_interface *eif;
 	struct interface *ifp;
 	struct eigrp *eigrp;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		ifp = nb_running_get_entry(dnode, NULL, false);
+		ifp = nb_running_get_entry(args->dnode, NULL, false);
 		if (ifp == NULL) {
 			/*
 			 * XXX: we can't verify if the interface exists
@@ -1189,7 +1110,7 @@ static int lib_interface_eigrp_instance_create(enum nb_event event,
 			break;
 		}
 
-		eigrp = eigrp_get(yang_dnode_get_uint16(dnode, "./asn"),
+		eigrp = eigrp_get(yang_dnode_get_uint16(args->dnode, "./asn"),
 				  ifp->vrf_id);
 		eif = eigrp_interface_lookup(eigrp, ifp->name);
 		if (eif == NULL)
@@ -1200,31 +1121,30 @@ static int lib_interface_eigrp_instance_create(enum nb_event event,
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		ifp = nb_running_get_entry(dnode, NULL, true);
-		eigrp = eigrp_get(yang_dnode_get_uint16(dnode, "./asn"),
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		eigrp = eigrp_get(yang_dnode_get_uint16(args->dnode, "./asn"),
 				  ifp->vrf_id);
 		eif = eigrp_interface_lookup(eigrp, ifp->name);
 		if (eif == NULL)
 			return NB_ERR_INCONSISTENCY;
 
-		nb_running_set_entry(dnode, eif);
+		nb_running_set_entry(args->dnode, eif);
 		break;
 	}
 
 	return NB_OK;
 }
 
-static int lib_interface_eigrp_instance_destroy(enum nb_event event,
-						const struct lyd_node *dnode)
+static int lib_interface_eigrp_instance_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		nb_running_unset_entry(dnode);
+		nb_running_unset_entry(args->dnode);
 		break;
 	}
 
@@ -1236,10 +1156,9 @@ static int lib_interface_eigrp_instance_destroy(enum nb_event event,
  * /frr-interface:lib/interface/frr-eigrpd:eigrp/instance/summarize-addresses
  */
 static int lib_interface_eigrp_instance_summarize_addresses_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* TODO: Not implemented. */
 		return NB_ERR_INCONSISTENCY;
@@ -1254,9 +1173,9 @@ static int lib_interface_eigrp_instance_summarize_addresses_create(
 }
 
 static int lib_interface_eigrp_instance_summarize_addresses_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* TODO: Not implemented. */
 		return NB_ERR_INCONSISTENCY;
@@ -1273,22 +1192,20 @@ static int lib_interface_eigrp_instance_summarize_addresses_destroy(
 /*
  * XPath: /frr-interface:lib/interface/frr-eigrpd:eigrp/instance/authentication
  */
-static int
-lib_interface_eigrp_instance_authentication_modify(enum nb_event event,
-						   const struct lyd_node *dnode,
-						   union nb_resource *resource)
+static int lib_interface_eigrp_instance_authentication_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct eigrp_interface *eif;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eif = nb_running_get_entry(dnode, NULL, true);
-		eif->params.auth_type = yang_dnode_get_enum(dnode, NULL);
+		eif = nb_running_get_entry(args->dnode, NULL, true);
+		eif->params.auth_type = yang_dnode_get_enum(args->dnode, NULL);
 		break;
 	}
 
@@ -1299,34 +1216,34 @@ lib_interface_eigrp_instance_authentication_modify(enum nb_event event,
  * XPath: /frr-interface:lib/interface/frr-eigrpd:eigrp/instance/keychain
  */
 static int
-lib_interface_eigrp_instance_keychain_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+lib_interface_eigrp_instance_keychain_modify(struct nb_cb_modify_args *args)
 {
 	struct eigrp_interface *eif;
 	struct keychain *keychain;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		keychain = keychain_lookup(yang_dnode_get_string(dnode, NULL));
+		keychain = keychain_lookup(
+			yang_dnode_get_string(args->dnode, NULL));
 		if (keychain == NULL)
 			return NB_ERR_INCONSISTENCY;
 		break;
 	case NB_EV_PREPARE:
-		resource->ptr = strdup(yang_dnode_get_string(dnode, NULL));
-		if (resource->ptr == NULL)
+		args->resource->ptr =
+			strdup(yang_dnode_get_string(args->dnode, NULL));
+		if (args->resource->ptr == NULL)
 			return NB_ERR_RESOURCE;
 		break;
 	case NB_EV_ABORT:
-		free(resource->ptr);
-		resource->ptr = NULL;
+		free(args->resource->ptr);
+		args->resource->ptr = NULL;
 		break;
 	case NB_EV_APPLY:
-		eif = nb_running_get_entry(dnode, NULL, true);
+		eif = nb_running_get_entry(args->dnode, NULL, true);
 		if (eif->params.auth_keychain)
 			free(eif->params.auth_keychain);
 
-		eif->params.auth_keychain = resource->ptr;
+		eif->params.auth_keychain = args->resource->ptr;
 		break;
 	}
 
@@ -1334,19 +1251,18 @@ lib_interface_eigrp_instance_keychain_modify(enum nb_event event,
 }
 
 static int
-lib_interface_eigrp_instance_keychain_destroy(enum nb_event event,
-					      const struct lyd_node *dnode)
+lib_interface_eigrp_instance_keychain_destroy(struct nb_cb_destroy_args *args)
 {
 	struct eigrp_interface *eif;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		/* NOTHING */
 		break;
 	case NB_EV_APPLY:
-		eif = nb_running_get_entry(dnode, NULL, true);
+		eif = nb_running_get_entry(args->dnode, NULL, true);
 		if (eif->params.auth_keychain)
 			free(eif->params.auth_keychain);
 

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -28,379 +28,247 @@ struct isis_circuit;
 struct isis_adjacency;
 
 /* Mandatory callbacks. */
-int isis_instance_create(enum nb_event event, const struct lyd_node *dnode,
-			 union nb_resource *resource);
-int isis_instance_destroy(enum nb_event event, const struct lyd_node *dnode);
-int isis_instance_is_type_modify(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource);
-int isis_instance_area_address_create(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource);
-int isis_instance_area_address_destroy(enum nb_event event,
-				       const struct lyd_node *dnode);
-int isis_instance_dynamic_hostname_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource);
-int isis_instance_attached_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource);
-int isis_instance_overload_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource);
-int isis_instance_metric_style_modify(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource);
-int isis_instance_purge_originator_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource);
-int isis_instance_lsp_mtu_modify(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource);
+int isis_instance_create(struct nb_cb_create_args *args);
+int isis_instance_destroy(struct nb_cb_destroy_args *args);
+int isis_instance_is_type_modify(struct nb_cb_modify_args *args);
+int isis_instance_area_address_create(struct nb_cb_create_args *args);
+int isis_instance_area_address_destroy(struct nb_cb_destroy_args *args);
+int isis_instance_dynamic_hostname_modify(struct nb_cb_modify_args *args);
+int isis_instance_attached_modify(struct nb_cb_modify_args *args);
+int isis_instance_overload_modify(struct nb_cb_modify_args *args);
+int isis_instance_metric_style_modify(struct nb_cb_modify_args *args);
+int isis_instance_purge_originator_modify(struct nb_cb_modify_args *args);
+int isis_instance_lsp_mtu_modify(struct nb_cb_modify_args *args);
 int isis_instance_lsp_refresh_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_lsp_refresh_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_lsp_maximum_lifetime_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_lsp_maximum_lifetime_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_lsp_generation_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_lsp_generation_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int isis_instance_spf_ietf_backoff_delay_create(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource);
-int isis_instance_spf_ietf_backoff_delay_destroy(enum nb_event event,
-						 const struct lyd_node *dnode);
+	struct nb_cb_modify_args *args);
+int isis_instance_spf_ietf_backoff_delay_create(struct nb_cb_create_args *args);
+int isis_instance_spf_ietf_backoff_delay_destroy(
+	struct nb_cb_destroy_args *args);
 int isis_instance_spf_ietf_backoff_delay_init_delay_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_spf_ietf_backoff_delay_short_delay_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_spf_ietf_backoff_delay_long_delay_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_spf_ietf_backoff_delay_hold_down_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_spf_ietf_backoff_delay_time_to_learn_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_spf_minimum_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_spf_minimum_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int isis_instance_area_password_create(enum nb_event event,
-				       const struct lyd_node *dnode,
-				       union nb_resource *resource);
-int isis_instance_area_password_destroy(enum nb_event event,
-					const struct lyd_node *dnode);
-int isis_instance_area_password_password_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource);
+	struct nb_cb_modify_args *args);
+int isis_instance_area_password_create(struct nb_cb_create_args *args);
+int isis_instance_area_password_destroy(struct nb_cb_destroy_args *args);
+int isis_instance_area_password_password_modify(struct nb_cb_modify_args *args);
 int isis_instance_area_password_password_type_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_area_password_authenticate_snp_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int isis_instance_domain_password_create(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource);
-int isis_instance_domain_password_destroy(enum nb_event event,
-					  const struct lyd_node *dnode);
-int isis_instance_domain_password_password_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource);
+	struct nb_cb_modify_args *args);
+int isis_instance_domain_password_create(struct nb_cb_create_args *args);
+int isis_instance_domain_password_destroy(struct nb_cb_destroy_args *args);
+int isis_instance_domain_password_password_modify(
+	struct nb_cb_modify_args *args);
 int isis_instance_domain_password_password_type_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_domain_password_authenticate_snp_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_default_information_originate_ipv4_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_create_args *args);
 int isis_instance_default_information_originate_ipv4_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int isis_instance_default_information_originate_ipv4_always_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_default_information_originate_ipv4_route_map_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_default_information_originate_ipv4_route_map_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int isis_instance_default_information_originate_ipv4_metric_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_default_information_originate_ipv6_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_create_args *args);
 int isis_instance_default_information_originate_ipv6_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int isis_instance_default_information_originate_ipv6_always_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_default_information_originate_ipv6_route_map_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_default_information_originate_ipv6_route_map_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int isis_instance_default_information_originate_ipv6_metric_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int isis_instance_redistribute_ipv4_create(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource);
-int isis_instance_redistribute_ipv4_destroy(enum nb_event event,
-					    const struct lyd_node *dnode);
+	struct nb_cb_modify_args *args);
+int isis_instance_redistribute_ipv4_create(struct nb_cb_create_args *args);
+int isis_instance_redistribute_ipv4_destroy(struct nb_cb_destroy_args *args);
 int isis_instance_redistribute_ipv4_route_map_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_redistribute_ipv4_route_map_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
-int isis_instance_redistribute_ipv4_metric_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource);
-int isis_instance_redistribute_ipv6_create(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource);
-int isis_instance_redistribute_ipv6_destroy(enum nb_event event,
-					    const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
+int isis_instance_redistribute_ipv4_metric_modify(
+	struct nb_cb_modify_args *args);
+int isis_instance_redistribute_ipv6_create(struct nb_cb_create_args *args);
+int isis_instance_redistribute_ipv6_destroy(struct nb_cb_destroy_args *args);
 int isis_instance_redistribute_ipv6_route_map_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_redistribute_ipv6_route_map_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
-int isis_instance_redistribute_ipv6_metric_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource);
+	struct nb_cb_destroy_args *args);
+int isis_instance_redistribute_ipv6_metric_modify(
+	struct nb_cb_modify_args *args);
 int isis_instance_multi_topology_ipv4_multicast_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_create_args *args);
 int isis_instance_multi_topology_ipv4_multicast_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int isis_instance_multi_topology_ipv4_multicast_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_multi_topology_ipv4_management_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_create_args *args);
 int isis_instance_multi_topology_ipv4_management_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int isis_instance_multi_topology_ipv4_management_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_multi_topology_ipv6_unicast_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_create_args *args);
 int isis_instance_multi_topology_ipv6_unicast_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int isis_instance_multi_topology_ipv6_unicast_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_multi_topology_ipv6_multicast_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_create_args *args);
 int isis_instance_multi_topology_ipv6_multicast_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int isis_instance_multi_topology_ipv6_multicast_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_multi_topology_ipv6_management_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_create_args *args);
 int isis_instance_multi_topology_ipv6_management_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int isis_instance_multi_topology_ipv6_management_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int isis_instance_multi_topology_ipv6_dstsrc_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_create_args *args);
 int isis_instance_multi_topology_ipv6_dstsrc_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int isis_instance_multi_topology_ipv6_dstsrc_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int isis_instance_log_adjacency_changes_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource);
-int isis_instance_mpls_te_create(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource);
-int isis_instance_mpls_te_destroy(enum nb_event event,
-				  const struct lyd_node *dnode);
-int isis_instance_mpls_te_router_address_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource);
-int isis_instance_mpls_te_router_address_destroy(enum nb_event event,
-						 const struct lyd_node *dnode);
-int lib_interface_isis_create(enum nb_event event, const struct lyd_node *dnode,
-			      union nb_resource *resource);
-int lib_interface_isis_destroy(enum nb_event event,
-			       const struct lyd_node *dnode);
-int lib_interface_isis_area_tag_modify(enum nb_event event,
-				       const struct lyd_node *dnode,
-				       union nb_resource *resource);
-int lib_interface_isis_ipv4_routing_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource);
-int lib_interface_isis_ipv6_routing_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource);
-int lib_interface_isis_circuit_type_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource);
-int lib_interface_isis_bfd_monitoring_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
+	struct nb_cb_modify_args *args);
+int isis_instance_log_adjacency_changes_modify(struct nb_cb_modify_args *args);
+int isis_instance_mpls_te_create(struct nb_cb_create_args *args);
+int isis_instance_mpls_te_destroy(struct nb_cb_destroy_args *args);
+int isis_instance_mpls_te_router_address_modify(struct nb_cb_modify_args *args);
+int isis_instance_mpls_te_router_address_destroy(
+	struct nb_cb_destroy_args *args);
+int lib_interface_isis_create(struct nb_cb_create_args *args);
+int lib_interface_isis_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_isis_area_tag_modify(struct nb_cb_modify_args *args);
+int lib_interface_isis_ipv4_routing_modify(struct nb_cb_modify_args *args);
+int lib_interface_isis_ipv6_routing_modify(struct nb_cb_modify_args *args);
+int lib_interface_isis_circuit_type_modify(struct nb_cb_modify_args *args);
+int lib_interface_isis_bfd_monitoring_modify(struct nb_cb_modify_args *args);
 int lib_interface_isis_csnp_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_csnp_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_psnp_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_psnp_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int lib_interface_isis_hello_padding_modify(enum nb_event event,
-					    const struct lyd_node *dnode,
-					    union nb_resource *resource);
+	struct nb_cb_modify_args *args);
+int lib_interface_isis_hello_padding_modify(struct nb_cb_modify_args *args);
 int lib_interface_isis_hello_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_hello_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_hello_multiplier_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_hello_multiplier_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int lib_interface_isis_metric_level_1_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
-int lib_interface_isis_metric_level_2_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
-int lib_interface_isis_priority_level_1_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource);
-int lib_interface_isis_priority_level_2_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource);
-int lib_interface_isis_network_type_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource);
-int lib_interface_isis_passive_modify(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource);
-int lib_interface_isis_password_create(enum nb_event event,
-				       const struct lyd_node *dnode,
-				       union nb_resource *resource);
-int lib_interface_isis_password_destroy(enum nb_event event,
-					const struct lyd_node *dnode);
-int lib_interface_isis_password_password_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource);
+	struct nb_cb_modify_args *args);
+int lib_interface_isis_metric_level_1_modify(struct nb_cb_modify_args *args);
+int lib_interface_isis_metric_level_2_modify(struct nb_cb_modify_args *args);
+int lib_interface_isis_priority_level_1_modify(struct nb_cb_modify_args *args);
+int lib_interface_isis_priority_level_2_modify(struct nb_cb_modify_args *args);
+int lib_interface_isis_network_type_modify(struct nb_cb_modify_args *args);
+int lib_interface_isis_passive_modify(struct nb_cb_modify_args *args);
+int lib_interface_isis_password_create(struct nb_cb_create_args *args);
+int lib_interface_isis_password_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_isis_password_password_modify(struct nb_cb_modify_args *args);
 int lib_interface_isis_password_password_type_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_disable_three_way_handshake_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_multi_topology_ipv4_unicast_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_multi_topology_ipv4_multicast_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_multi_topology_ipv4_management_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_multi_topology_ipv6_unicast_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_multi_topology_ipv6_multicast_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_multi_topology_ipv6_management_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_multi_topology_ipv6_dstsrc_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-const void *
-lib_interface_isis_adjacencies_adjacency_get_next(const void *parent_list_entry,
-						  const void *list_entry);
+	struct nb_cb_modify_args *args);
+const void *lib_interface_isis_adjacencies_adjacency_get_next(
+	struct nb_cb_get_next_args *args);
 struct yang_data *
 lib_interface_isis_adjacencies_adjacency_neighbor_sys_type_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_interface_isis_adjacencies_adjacency_neighbor_sysid_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_interface_isis_adjacencies_adjacency_neighbor_extended_circuit_id_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_interface_isis_adjacencies_adjacency_neighbor_snpa_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *lib_interface_isis_adjacencies_adjacency_hold_timer_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_interface_isis_adjacencies_adjacency_neighbor_priority_get_elem(
-	const char *xpath, const void *list_entry);
-struct yang_data *
-lib_interface_isis_adjacencies_adjacency_state_get_elem(const char *xpath,
-							const void *list_entry);
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_interface_isis_adjacencies_adjacency_state_get_elem(
+	struct nb_cb_get_elem_args *args);
 struct yang_data *lib_interface_isis_event_counters_adjacency_changes_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *lib_interface_isis_event_counters_adjacency_number_get_elem(
-	const char *xpath, const void *list_entry);
-struct yang_data *
-lib_interface_isis_event_counters_init_fails_get_elem(const char *xpath,
-						      const void *list_entry);
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_interface_isis_event_counters_init_fails_get_elem(
+	struct nb_cb_get_elem_args *args);
 struct yang_data *lib_interface_isis_event_counters_adjacency_rejects_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *lib_interface_isis_event_counters_id_len_mismatch_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_interface_isis_event_counters_max_area_addresses_mismatch_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_interface_isis_event_counters_authentication_type_fails_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_interface_isis_event_counters_authentication_fails_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 
 /* Optional 'apply_finish' callbacks. */
-void ietf_backoff_delay_apply_finish(const struct lyd_node *dnode);
-void area_password_apply_finish(const struct lyd_node *dnode);
-void domain_password_apply_finish(const struct lyd_node *dnode);
+void ietf_backoff_delay_apply_finish(struct nb_cb_apply_finish_args *args);
+void area_password_apply_finish(struct nb_cb_apply_finish_args *args);
+void domain_password_apply_finish(struct nb_cb_apply_finish_args *args);
 void default_info_origin_apply_finish(const struct lyd_node *dnode, int family);
-void default_info_origin_ipv4_apply_finish(const struct lyd_node *dnode);
-void default_info_origin_ipv6_apply_finish(const struct lyd_node *dnode);
+void default_info_origin_ipv4_apply_finish(
+	struct nb_cb_apply_finish_args *args);
+void default_info_origin_ipv6_apply_finish(
+	struct nb_cb_apply_finish_args *args);
 void redistribute_apply_finish(const struct lyd_node *dnode, int family);
-void redistribute_ipv4_apply_finish(const struct lyd_node *dnode);
-void redistribute_ipv6_apply_finish(const struct lyd_node *dnode);
+void redistribute_ipv4_apply_finish(struct nb_cb_apply_finish_args *args);
+void redistribute_ipv6_apply_finish(struct nb_cb_apply_finish_args *args);
 
 /* Optional 'cli_show' callbacks. */
 void cli_show_router_isis(struct vty *vty, struct lyd_node *dnode,

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -49,35 +49,34 @@
 /*
  * XPath: /frr-isisd:isis/instance
  */
-int isis_instance_create(enum nb_event event, const struct lyd_node *dnode,
-			 union nb_resource *resource)
+int isis_instance_create(struct nb_cb_create_args *args)
 {
 	struct isis_area *area;
 	const char *area_tag;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area_tag = yang_dnode_get_string(dnode, "./area-tag");
+	area_tag = yang_dnode_get_string(args->dnode, "./area-tag");
 	area = isis_area_lookup(area_tag);
 	if (area)
 		return NB_ERR_INCONSISTENCY;
 
 	area = isis_area_create(area_tag);
 	/* save area in dnode to avoid looking it up all the time */
-	nb_running_set_entry(dnode, area);
+	nb_running_set_entry(args->dnode, area);
 
 	return NB_OK;
 }
 
-int isis_instance_destroy(enum nb_event event, const struct lyd_node *dnode)
+int isis_instance_destroy(struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_unset_entry(dnode);
+	area = nb_running_unset_entry(args->dnode);
 	isis_area_destroy(area->area_tag);
 
 	return NB_OK;
@@ -86,18 +85,16 @@ int isis_instance_destroy(enum nb_event event, const struct lyd_node *dnode)
 /*
  * XPath: /frr-isisd:isis/instance/is-type
  */
-int isis_instance_is_type_modify(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource)
+int isis_instance_is_type_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	int type;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	type = yang_dnode_get_enum(dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	type = yang_dnode_get_enum(args->dnode, NULL);
 	isis_area_is_type_set(area, type);
 
 	return NB_OK;
@@ -106,17 +103,15 @@ int isis_instance_is_type_modify(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/area-address
  */
-int isis_instance_area_address_create(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource)
+int isis_instance_area_address_create(struct nb_cb_create_args *args)
 {
 	struct isis_area *area;
 	struct area_addr addr, *addrr = NULL, *addrp = NULL;
 	struct listnode *node;
 	uint8_t buff[255];
-	const char *net_title = yang_dnode_get_string(dnode, NULL);
+	const char *net_title = yang_dnode_get_string(args->dnode, NULL);
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		addr.addr_len = dotformat2buff(buff, net_title);
 		memcpy(addr.area_addr, buff, addr.addr_len);
@@ -141,14 +136,14 @@ int isis_instance_area_address_create(enum nb_event event,
 		addrr = XMALLOC(MTYPE_ISIS_AREA_ADDR, sizeof(struct area_addr));
 		addrr->addr_len = dotformat2buff(buff, net_title);
 		memcpy(addrr->area_addr, buff, addrr->addr_len);
-		resource->ptr = addrr;
+		args->resource->ptr = addrr;
 		break;
 	case NB_EV_ABORT:
-		XFREE(MTYPE_ISIS_AREA_ADDR, resource->ptr);
+		XFREE(MTYPE_ISIS_AREA_ADDR, args->resource->ptr);
 		break;
 	case NB_EV_APPLY:
-		area = nb_running_get_entry(dnode, NULL, true);
-		addrr = resource->ptr;
+		area = nb_running_get_entry(args->dnode, NULL, true);
+		addrr = args->resource->ptr;
 
 		if (isis->sysid_set == 0) {
 			/*
@@ -190,8 +185,7 @@ int isis_instance_area_address_create(enum nb_event event,
 	return NB_OK;
 }
 
-int isis_instance_area_address_destroy(enum nb_event event,
-				       const struct lyd_node *dnode)
+int isis_instance_area_address_destroy(struct nb_cb_destroy_args *args)
 {
 	struct area_addr addr, *addrp = NULL;
 	struct listnode *node;
@@ -199,13 +193,13 @@ int isis_instance_area_address_destroy(enum nb_event event,
 	struct isis_area *area;
 	const char *net_title;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	net_title = yang_dnode_get_string(dnode, NULL);
+	net_title = yang_dnode_get_string(args->dnode, NULL);
 	addr.addr_len = dotformat2buff(buff, net_title);
 	memcpy(addr.area_addr, buff, (int)addr.addr_len);
-	area = nb_running_get_entry(dnode, NULL, true);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	for (ALL_LIST_ELEMENTS_RO(area->area_addrs, node, addrp)) {
 		if ((addrp->addr_len + ISIS_SYS_ID_LEN + 1) == addr.addr_len
 		    && !memcmp(addrp->area_addr, addr.area_addr, addr.addr_len))
@@ -232,17 +226,15 @@ int isis_instance_area_address_destroy(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/dynamic-hostname
  */
-int isis_instance_dynamic_hostname_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource)
+int isis_instance_dynamic_hostname_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	isis_area_dynhostname_set(area, yang_dnode_get_bool(dnode, NULL));
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	isis_area_dynhostname_set(area, yang_dnode_get_bool(args->dnode, NULL));
 
 	return NB_OK;
 }
@@ -250,18 +242,16 @@ int isis_instance_dynamic_hostname_modify(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/attached
  */
-int isis_instance_attached_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource)
+int isis_instance_attached_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	bool attached;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	attached = yang_dnode_get_bool(dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	attached = yang_dnode_get_bool(args->dnode, NULL);
 	isis_area_attached_bit_set(area, attached);
 
 	return NB_OK;
@@ -270,18 +260,16 @@ int isis_instance_attached_modify(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/overload
  */
-int isis_instance_overload_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource)
+int isis_instance_overload_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	bool overload;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	overload = yang_dnode_get_bool(dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	overload = yang_dnode_get_bool(args->dnode, NULL);
 	isis_area_overload_bit_set(area, overload);
 
 	return NB_OK;
@@ -290,18 +278,17 @@ int isis_instance_overload_modify(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/metric-style
  */
-int isis_instance_metric_style_modify(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource)
+int isis_instance_metric_style_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	bool old_metric, new_metric;
-	enum isis_metric_style metric_style = yang_dnode_get_enum(dnode, NULL);
+	enum isis_metric_style metric_style =
+		yang_dnode_get_enum(args->dnode, NULL);
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	old_metric = (metric_style == ISIS_WIDE_METRIC) ? false : true;
 	new_metric = (metric_style == ISIS_NARROW_METRIC) ? false : true;
 	isis_area_metricstyle_set(area, old_metric, new_metric);
@@ -312,17 +299,15 @@ int isis_instance_metric_style_modify(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/purge-originator
  */
-int isis_instance_purge_originator_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource)
+int isis_instance_purge_originator_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	area->purge_originator = yang_dnode_get_bool(dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	area->purge_originator = yang_dnode_get_bool(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -330,18 +315,16 @@ int isis_instance_purge_originator_modify(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/lsp/mtu
  */
-int isis_instance_lsp_mtu_modify(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource)
+int isis_instance_lsp_mtu_modify(struct nb_cb_modify_args *args)
 {
 	struct listnode *node;
 	struct isis_circuit *circuit;
-	uint16_t lsp_mtu = yang_dnode_get_uint16(dnode, NULL);
+	uint16_t lsp_mtu = yang_dnode_get_uint16(args->dnode, NULL);
 	struct isis_area *area;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		area = nb_running_get_entry(dnode, NULL, false);
+		area = nb_running_get_entry(args->dnode, NULL, false);
 		if (!area)
 			break;
 		for (ALL_LIST_ELEMENTS_RO(area->circuit_list, node, circuit)) {
@@ -362,7 +345,7 @@ int isis_instance_lsp_mtu_modify(enum nb_event event,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		area = nb_running_get_entry(dnode, NULL, true);
+		area = nb_running_get_entry(args->dnode, NULL, true);
 		isis_area_lsp_mtu_set(area, lsp_mtu);
 		break;
 	}
@@ -374,17 +357,16 @@ int isis_instance_lsp_mtu_modify(enum nb_event event,
  * XPath: /frr-isisd:isis/instance/lsp/timers/level-1/refresh-interval
  */
 int isis_instance_lsp_refresh_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	uint16_t refr_int;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	refr_int = yang_dnode_get_uint16(dnode, NULL);
-	area = nb_running_get_entry(dnode, NULL, true);
+	refr_int = yang_dnode_get_uint16(args->dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	isis_area_lsp_refresh_set(area, IS_LEVEL_1, refr_int);
 
 	return NB_OK;
@@ -394,17 +376,16 @@ int isis_instance_lsp_refresh_interval_level_1_modify(
  * XPath: /frr-isisd:isis/instance/lsp/timers/level-2/refresh-interval
  */
 int isis_instance_lsp_refresh_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	uint16_t refr_int;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	refr_int = yang_dnode_get_uint16(dnode, NULL);
-	area = nb_running_get_entry(dnode, NULL, true);
+	refr_int = yang_dnode_get_uint16(args->dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	isis_area_lsp_refresh_set(area, IS_LEVEL_2, refr_int);
 
 	return NB_OK;
@@ -414,17 +395,16 @@ int isis_instance_lsp_refresh_interval_level_2_modify(
  * XPath: /frr-isisd:isis/instance/lsp/timers/level-1/maximum-lifetime
  */
 int isis_instance_lsp_maximum_lifetime_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	uint16_t max_lt;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	max_lt = yang_dnode_get_uint16(dnode, NULL);
-	area = nb_running_get_entry(dnode, NULL, true);
+	max_lt = yang_dnode_get_uint16(args->dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	isis_area_max_lsp_lifetime_set(area, IS_LEVEL_1, max_lt);
 
 	return NB_OK;
@@ -434,17 +414,16 @@ int isis_instance_lsp_maximum_lifetime_level_1_modify(
  * XPath: /frr-isisd:isis/instance/lsp/timers/level-2/maximum-lifetime
  */
 int isis_instance_lsp_maximum_lifetime_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	uint16_t max_lt;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	max_lt = yang_dnode_get_uint16(dnode, NULL);
-	area = nb_running_get_entry(dnode, NULL, true);
+	max_lt = yang_dnode_get_uint16(args->dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	isis_area_max_lsp_lifetime_set(area, IS_LEVEL_2, max_lt);
 
 	return NB_OK;
@@ -454,17 +433,16 @@ int isis_instance_lsp_maximum_lifetime_level_2_modify(
  * XPath: /frr-isisd:isis/instance/lsp/timers/level-1/generation-interval
  */
 int isis_instance_lsp_generation_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	uint16_t gen_int;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	gen_int = yang_dnode_get_uint16(dnode, NULL);
-	area = nb_running_get_entry(dnode, NULL, true);
+	gen_int = yang_dnode_get_uint16(args->dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	area->lsp_gen_interval[0] = gen_int;
 
 	return NB_OK;
@@ -474,17 +452,16 @@ int isis_instance_lsp_generation_interval_level_1_modify(
  * XPath: /frr-isisd:isis/instance/lsp/timers/level-2/generation-interval
  */
 int isis_instance_lsp_generation_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	uint16_t gen_int;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	gen_int = yang_dnode_get_uint16(dnode, NULL);
-	area = nb_running_get_entry(dnode, NULL, true);
+	gen_int = yang_dnode_get_uint16(args->dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	area->lsp_gen_interval[1] = gen_int;
 
 	return NB_OK;
@@ -493,14 +470,15 @@ int isis_instance_lsp_generation_interval_level_2_modify(
 /*
  * XPath: /frr-isisd:isis/instance/spf/ietf-backoff-delay
  */
-void ietf_backoff_delay_apply_finish(const struct lyd_node *dnode)
+void ietf_backoff_delay_apply_finish(struct nb_cb_apply_finish_args *args)
 {
-	long init_delay = yang_dnode_get_uint16(dnode, "./init-delay");
-	long short_delay = yang_dnode_get_uint16(dnode, "./short-delay");
-	long long_delay = yang_dnode_get_uint16(dnode, "./long-delay");
-	long holddown = yang_dnode_get_uint16(dnode, "./hold-down");
-	long timetolearn = yang_dnode_get_uint16(dnode, "./time-to-learn");
-	struct isis_area *area = nb_running_get_entry(dnode, NULL, true);
+	long init_delay = yang_dnode_get_uint16(args->dnode, "./init-delay");
+	long short_delay = yang_dnode_get_uint16(args->dnode, "./short-delay");
+	long long_delay = yang_dnode_get_uint16(args->dnode, "./long-delay");
+	long holddown = yang_dnode_get_uint16(args->dnode, "./hold-down");
+	long timetolearn =
+		yang_dnode_get_uint16(args->dnode, "./time-to-learn");
+	struct isis_area *area = nb_running_get_entry(args->dnode, NULL, true);
 	size_t bufsiz = strlen(area->area_tag) + sizeof("IS-IS  Lx");
 	char *buf = XCALLOC(MTYPE_TMP, bufsiz);
 
@@ -519,23 +497,21 @@ void ietf_backoff_delay_apply_finish(const struct lyd_node *dnode)
 	XFREE(MTYPE_TMP, buf);
 }
 
-int isis_instance_spf_ietf_backoff_delay_create(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource)
+int isis_instance_spf_ietf_backoff_delay_create(struct nb_cb_create_args *args)
 {
 	/* All the work is done in the apply_finish */
 	return NB_OK;
 }
 
-int isis_instance_spf_ietf_backoff_delay_destroy(enum nb_event event,
-						 const struct lyd_node *dnode)
+int isis_instance_spf_ietf_backoff_delay_destroy(
+	struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	spf_backoff_free(area->spf_delay_ietf[0]);
 	spf_backoff_free(area->spf_delay_ietf[1]);
 	area->spf_delay_ietf[0] = NULL;
@@ -548,8 +524,7 @@ int isis_instance_spf_ietf_backoff_delay_destroy(enum nb_event event,
  * XPath: /frr-isisd:isis/instance/spf/ietf-backoff-delay/init-delay
  */
 int isis_instance_spf_ietf_backoff_delay_init_delay_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* All the work is done in the apply_finish */
 	return NB_OK;
@@ -559,8 +534,7 @@ int isis_instance_spf_ietf_backoff_delay_init_delay_modify(
  * XPath: /frr-isisd:isis/instance/spf/ietf-backoff-delay/short-delay
  */
 int isis_instance_spf_ietf_backoff_delay_short_delay_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* All the work is done in the apply_finish */
 	return NB_OK;
@@ -570,8 +544,7 @@ int isis_instance_spf_ietf_backoff_delay_short_delay_modify(
  * XPath: /frr-isisd:isis/instance/spf/ietf-backoff-delay/long-delay
  */
 int isis_instance_spf_ietf_backoff_delay_long_delay_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* All the work is done in the apply_finish */
 	return NB_OK;
@@ -581,8 +554,7 @@ int isis_instance_spf_ietf_backoff_delay_long_delay_modify(
  * XPath: /frr-isisd:isis/instance/spf/ietf-backoff-delay/hold-down
  */
 int isis_instance_spf_ietf_backoff_delay_hold_down_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* All the work is done in the apply_finish */
 	return NB_OK;
@@ -592,8 +564,7 @@ int isis_instance_spf_ietf_backoff_delay_hold_down_modify(
  * XPath: /frr-isisd:isis/instance/spf/ietf-backoff-delay/time-to-learn
  */
 int isis_instance_spf_ietf_backoff_delay_time_to_learn_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* All the work is done in the apply_finish */
 	return NB_OK;
@@ -603,16 +574,15 @@ int isis_instance_spf_ietf_backoff_delay_time_to_learn_modify(
  * XPath: /frr-isisd:isis/instance/spf/minimum-interval/level-1
  */
 int isis_instance_spf_minimum_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	area->min_spf_interval[0] = yang_dnode_get_uint16(dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	area->min_spf_interval[0] = yang_dnode_get_uint16(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -621,16 +591,15 @@ int isis_instance_spf_minimum_interval_level_1_modify(
  * XPath: /frr-isisd:isis/instance/spf/minimum-interval/level-2
  */
 int isis_instance_spf_minimum_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	area->min_spf_interval[1] = yang_dnode_get_uint16(dnode, NULL);
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	area->min_spf_interval[1] = yang_dnode_get_uint16(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -638,12 +607,13 @@ int isis_instance_spf_minimum_interval_level_2_modify(
 /*
  * XPath: /frr-isisd:isis/instance/area-password
  */
-void area_password_apply_finish(const struct lyd_node *dnode)
+void area_password_apply_finish(struct nb_cb_apply_finish_args *args)
 {
-	const char *password = yang_dnode_get_string(dnode, "./password");
-	struct isis_area *area = nb_running_get_entry(dnode, NULL, true);
-	int pass_type = yang_dnode_get_enum(dnode, "./password-type");
-	uint8_t snp_auth = yang_dnode_get_enum(dnode, "./authenticate-snp");
+	const char *password = yang_dnode_get_string(args->dnode, "./password");
+	struct isis_area *area = nb_running_get_entry(args->dnode, NULL, true);
+	int pass_type = yang_dnode_get_enum(args->dnode, "./password-type");
+	uint8_t snp_auth =
+		yang_dnode_get_enum(args->dnode, "./authenticate-snp");
 
 	switch (pass_type) {
 	case ISIS_PASSWD_TYPE_CLEARTXT:
@@ -657,23 +627,20 @@ void area_password_apply_finish(const struct lyd_node *dnode)
 	}
 }
 
-int isis_instance_area_password_create(enum nb_event event,
-				       const struct lyd_node *dnode,
-				       union nb_resource *resource)
+int isis_instance_area_password_create(struct nb_cb_create_args *args)
 {
 	/* actual setting is done in apply_finish */
 	return NB_OK;
 }
 
-int isis_instance_area_password_destroy(enum nb_event event,
-					const struct lyd_node *dnode)
+int isis_instance_area_password_destroy(struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	isis_area_passwd_unset(area, IS_LEVEL_1);
 
 	return NB_OK;
@@ -682,9 +649,7 @@ int isis_instance_area_password_destroy(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/area-password/password
  */
-int isis_instance_area_password_password_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource)
+int isis_instance_area_password_password_modify(struct nb_cb_modify_args *args)
 {
 	/* actual setting is done in apply_finish */
 	return NB_OK;
@@ -694,8 +659,7 @@ int isis_instance_area_password_password_modify(enum nb_event event,
  * XPath: /frr-isisd:isis/instance/area-password/password-type
  */
 int isis_instance_area_password_password_type_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* actual setting is done in apply_finish */
 	return NB_OK;
@@ -705,8 +669,7 @@ int isis_instance_area_password_password_type_modify(
  * XPath: /frr-isisd:isis/instance/area-password/authenticate-snp
  */
 int isis_instance_area_password_authenticate_snp_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* actual setting is done in apply_finish */
 	return NB_OK;
@@ -715,12 +678,13 @@ int isis_instance_area_password_authenticate_snp_modify(
 /*
  * XPath: /frr-isisd:isis/instance/domain-password
  */
-void domain_password_apply_finish(const struct lyd_node *dnode)
+void domain_password_apply_finish(struct nb_cb_apply_finish_args *args)
 {
-	const char *password = yang_dnode_get_string(dnode, "./password");
-	struct isis_area *area = nb_running_get_entry(dnode, NULL, true);
-	int pass_type = yang_dnode_get_enum(dnode, "./password-type");
-	uint8_t snp_auth = yang_dnode_get_enum(dnode, "./authenticate-snp");
+	const char *password = yang_dnode_get_string(args->dnode, "./password");
+	struct isis_area *area = nb_running_get_entry(args->dnode, NULL, true);
+	int pass_type = yang_dnode_get_enum(args->dnode, "./password-type");
+	uint8_t snp_auth =
+		yang_dnode_get_enum(args->dnode, "./authenticate-snp");
 
 	switch (pass_type) {
 	case ISIS_PASSWD_TYPE_CLEARTXT:
@@ -734,23 +698,20 @@ void domain_password_apply_finish(const struct lyd_node *dnode)
 	}
 }
 
-int isis_instance_domain_password_create(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+int isis_instance_domain_password_create(struct nb_cb_create_args *args)
 {
 	/* actual setting is done in apply_finish */
 	return NB_OK;
 }
 
-int isis_instance_domain_password_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+int isis_instance_domain_password_destroy(struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	isis_area_passwd_unset(area, IS_LEVEL_2);
 
 	return NB_OK;
@@ -759,9 +720,8 @@ int isis_instance_domain_password_destroy(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/domain-password/password
  */
-int isis_instance_domain_password_password_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource)
+int isis_instance_domain_password_password_modify(
+	struct nb_cb_modify_args *args)
 {
 	/* actual setting is done in apply_finish */
 	return NB_OK;
@@ -771,8 +731,7 @@ int isis_instance_domain_password_password_modify(enum nb_event event,
  * XPath: /frr-isisd:isis/instance/domain-password/password-type
  */
 int isis_instance_domain_password_password_type_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* actual setting is done in apply_finish */
 	return NB_OK;
@@ -782,8 +741,7 @@ int isis_instance_domain_password_password_type_modify(
  * XPath: /frr-isisd:isis/instance/domain-password/authenticate-snp
  */
 int isis_instance_domain_password_authenticate_snp_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* actual setting is done in apply_finish */
 	return NB_OK;
@@ -817,35 +775,34 @@ void default_info_origin_apply_finish(const struct lyd_node *dnode, int family)
 			originate_type);
 }
 
-void default_info_origin_ipv4_apply_finish(const struct lyd_node *dnode)
+void default_info_origin_ipv4_apply_finish(struct nb_cb_apply_finish_args *args)
 {
-	default_info_origin_apply_finish(dnode, AF_INET);
+	default_info_origin_apply_finish(args->dnode, AF_INET);
 }
 
-void default_info_origin_ipv6_apply_finish(const struct lyd_node *dnode)
+void default_info_origin_ipv6_apply_finish(struct nb_cb_apply_finish_args *args)
 {
-	default_info_origin_apply_finish(dnode, AF_INET6);
+	default_info_origin_apply_finish(args->dnode, AF_INET6);
 }
 
 int isis_instance_default_information_originate_ipv4_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
 	/* It's all done by default_info_origin_apply_finish */
 	return NB_OK;
 }
 
 int isis_instance_default_information_originate_ipv4_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
 	int level;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	level = yang_dnode_get_enum(dnode, "./level");
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	level = yang_dnode_get_enum(args->dnode, "./level");
 	isis_redist_unset(area, level, AF_INET, DEFAULT_ROUTE);
 
 	return NB_OK;
@@ -855,8 +812,7 @@ int isis_instance_default_information_originate_ipv4_destroy(
  * XPath: /frr-isisd:isis/instance/default-information-originate/ipv4/always
  */
 int isis_instance_default_information_originate_ipv4_always_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* It's all done by default_info_origin_apply_finish */
 	return NB_OK;
@@ -866,15 +822,14 @@ int isis_instance_default_information_originate_ipv4_always_modify(
  * XPath: /frr-isisd:isis/instance/default-information-originate/ipv4/route-map
  */
 int isis_instance_default_information_originate_ipv4_route_map_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* It's all done by default_info_origin_apply_finish */
 	return NB_OK;
 }
 
 int isis_instance_default_information_originate_ipv4_route_map_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
 	/* It's all done by default_info_origin_apply_finish */
 	return NB_OK;
@@ -884,8 +839,7 @@ int isis_instance_default_information_originate_ipv4_route_map_destroy(
  * XPath: /frr-isisd:isis/instance/default-information-originate/ipv4/metric
  */
 int isis_instance_default_information_originate_ipv4_metric_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* It's all done by default_info_origin_apply_finish */
 	return NB_OK;
@@ -895,24 +849,23 @@ int isis_instance_default_information_originate_ipv4_metric_modify(
  * XPath: /frr-isisd:isis/instance/default-information-originate/ipv6
  */
 int isis_instance_default_information_originate_ipv6_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
 	/* It's all done by default_info_origin_apply_finish */
 	return NB_OK;
 }
 
 int isis_instance_default_information_originate_ipv6_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
 	int level;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	level = yang_dnode_get_enum(dnode, "./level");
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	level = yang_dnode_get_enum(args->dnode, "./level");
 	isis_redist_unset(area, level, AF_INET6, DEFAULT_ROUTE);
 
 	return NB_OK;
@@ -922,8 +875,7 @@ int isis_instance_default_information_originate_ipv6_destroy(
  * XPath: /frr-isisd:isis/instance/default-information-originate/ipv6/always
  */
 int isis_instance_default_information_originate_ipv6_always_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* It's all done by default_info_origin_apply_finish */
 	return NB_OK;
@@ -933,15 +885,14 @@ int isis_instance_default_information_originate_ipv6_always_modify(
  * XPath: /frr-isisd:isis/instance/default-information-originate/ipv6/route-map
  */
 int isis_instance_default_information_originate_ipv6_route_map_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* It's all done by default_info_origin_apply_finish */
 	return NB_OK;
 }
 
 int isis_instance_default_information_originate_ipv6_route_map_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
 	/* It's all done by default_info_origin_apply_finish */
 	return NB_OK;
@@ -951,8 +902,7 @@ int isis_instance_default_information_originate_ipv6_route_map_destroy(
  * XPath: /frr-isisd:isis/instance/default-information-originate/ipv6/metric
  */
 int isis_instance_default_information_originate_ipv6_metric_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* It's all done by default_info_origin_apply_finish */
 	return NB_OK;
@@ -981,36 +931,33 @@ void redistribute_apply_finish(const struct lyd_node *dnode, int family)
 	isis_redist_set(area, level, family, type, metric, routemap, 0);
 }
 
-void redistribute_ipv4_apply_finish(const struct lyd_node *dnode)
+void redistribute_ipv4_apply_finish(struct nb_cb_apply_finish_args *args)
 {
-	redistribute_apply_finish(dnode, AF_INET);
+	redistribute_apply_finish(args->dnode, AF_INET);
 }
 
-void redistribute_ipv6_apply_finish(const struct lyd_node *dnode)
+void redistribute_ipv6_apply_finish(struct nb_cb_apply_finish_args *args)
 {
-	redistribute_apply_finish(dnode, AF_INET6);
+	redistribute_apply_finish(args->dnode, AF_INET6);
 }
 
-int isis_instance_redistribute_ipv4_create(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource)
+int isis_instance_redistribute_ipv4_create(struct nb_cb_create_args *args)
 {
 	/* It's all done by redistribute_apply_finish */
 	return NB_OK;
 }
 
-int isis_instance_redistribute_ipv4_destroy(enum nb_event event,
-					    const struct lyd_node *dnode)
+int isis_instance_redistribute_ipv4_destroy(struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
 	int level, type;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	level = yang_dnode_get_enum(dnode, "./level");
-	type = yang_dnode_get_enum(dnode, "./protocol");
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	level = yang_dnode_get_enum(args->dnode, "./level");
+	type = yang_dnode_get_enum(args->dnode, "./protocol");
 	isis_redist_unset(area, level, AF_INET, type);
 
 	return NB_OK;
@@ -1020,15 +967,14 @@ int isis_instance_redistribute_ipv4_destroy(enum nb_event event,
  * XPath: /frr-isisd:isis/instance/redistribute/ipv4/route-map
  */
 int isis_instance_redistribute_ipv4_route_map_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* It's all done by redistribute_apply_finish */
 	return NB_OK;
 }
 
 int isis_instance_redistribute_ipv4_route_map_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
 	/* It's all done by redistribute_apply_finish */
 	return NB_OK;
@@ -1037,9 +983,8 @@ int isis_instance_redistribute_ipv4_route_map_destroy(
 /*
  * XPath: /frr-isisd:isis/instance/redistribute/ipv4/metric
  */
-int isis_instance_redistribute_ipv4_metric_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource)
+int isis_instance_redistribute_ipv4_metric_modify(
+	struct nb_cb_modify_args *args)
 {
 	/* It's all done by redistribute_apply_finish */
 	return NB_OK;
@@ -1048,26 +993,23 @@ int isis_instance_redistribute_ipv4_metric_modify(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/redistribute/ipv6
  */
-int isis_instance_redistribute_ipv6_create(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource)
+int isis_instance_redistribute_ipv6_create(struct nb_cb_create_args *args)
 {
 	/* It's all done by redistribute_apply_finish */
 	return NB_OK;
 }
 
-int isis_instance_redistribute_ipv6_destroy(enum nb_event event,
-					    const struct lyd_node *dnode)
+int isis_instance_redistribute_ipv6_destroy(struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
 	int level, type;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
-	level = yang_dnode_get_enum(dnode, "./level");
-	type = yang_dnode_get_enum(dnode, "./protocol");
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	level = yang_dnode_get_enum(args->dnode, "./level");
+	type = yang_dnode_get_enum(args->dnode, "./protocol");
 	isis_redist_unset(area, level, AF_INET6, type);
 
 	return NB_OK;
@@ -1077,15 +1019,14 @@ int isis_instance_redistribute_ipv6_destroy(enum nb_event event,
  * XPath: /frr-isisd:isis/instance/redistribute/ipv6/route-map
  */
 int isis_instance_redistribute_ipv6_route_map_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	/* It's all done by redistribute_apply_finish */
 	return NB_OK;
 }
 
 int isis_instance_redistribute_ipv6_route_map_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
 	/* It's all done by redistribute_apply_finish */
 	return NB_OK;
@@ -1094,9 +1035,8 @@ int isis_instance_redistribute_ipv6_route_map_destroy(
 /*
  * XPath: /frr-isisd:isis/instance/redistribute/ipv6/metric
  */
-int isis_instance_redistribute_ipv6_metric_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource)
+int isis_instance_redistribute_ipv6_metric_modify(
+	struct nb_cb_modify_args *args)
 {
 	/* It's all done by redistribute_apply_finish */
 	return NB_OK;
@@ -1157,27 +1097,26 @@ static int isis_multi_topology_overload_common(enum nb_event event,
 }
 
 int isis_instance_multi_topology_ipv4_multicast_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv4-multicast", true);
+	return isis_multi_topology_common(args->event, args->dnode,
+					  "ipv4-multicast", true);
 }
 
 int isis_instance_multi_topology_ipv4_multicast_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv4-multicast",
-					  false);
+	return isis_multi_topology_common(args->event, args->dnode,
+					  "ipv4-multicast", false);
 }
 
 /*
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv4-multicast/overload
  */
 int isis_instance_multi_topology_ipv4_multicast_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return isis_multi_topology_overload_common(event, dnode,
+	return isis_multi_topology_overload_common(args->event, args->dnode,
 						   "ipv4-multicast");
 }
 
@@ -1185,52 +1124,53 @@ int isis_instance_multi_topology_ipv4_multicast_overload_modify(
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv4-management
  */
 int isis_instance_multi_topology_ipv4_management_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv4-mgmt", true);
+	return isis_multi_topology_common(args->event, args->dnode, "ipv4-mgmt",
+					  true);
 }
 
 int isis_instance_multi_topology_ipv4_management_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv4-mgmt", false);
+	return isis_multi_topology_common(args->event, args->dnode, "ipv4-mgmt",
+					  false);
 }
 
 /*
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv4-management/overload
  */
 int isis_instance_multi_topology_ipv4_management_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return isis_multi_topology_overload_common(event, dnode, "ipv4-mgmt");
+	return isis_multi_topology_overload_common(args->event, args->dnode,
+						   "ipv4-mgmt");
 }
 
 /*
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv6-unicast
  */
 int isis_instance_multi_topology_ipv6_unicast_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv6-unicast", true);
+	return isis_multi_topology_common(args->event, args->dnode,
+					  "ipv6-unicast", true);
 }
 
 int isis_instance_multi_topology_ipv6_unicast_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv6-unicast", false);
+	return isis_multi_topology_common(args->event, args->dnode,
+					  "ipv6-unicast", false);
 }
 
 /*
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv6-unicast/overload
  */
 int isis_instance_multi_topology_ipv6_unicast_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return isis_multi_topology_overload_common(event, dnode,
+	return isis_multi_topology_overload_common(args->event, args->dnode,
 						   "ipv6-unicast");
 }
 
@@ -1238,27 +1178,26 @@ int isis_instance_multi_topology_ipv6_unicast_overload_modify(
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv6-multicast
  */
 int isis_instance_multi_topology_ipv6_multicast_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv6-multicast", true);
+	return isis_multi_topology_common(args->event, args->dnode,
+					  "ipv6-multicast", true);
 }
 
 int isis_instance_multi_topology_ipv6_multicast_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv6-multicast",
-					  false);
+	return isis_multi_topology_common(args->event, args->dnode,
+					  "ipv6-multicast", false);
 }
 
 /*
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv6-multicast/overload
  */
 int isis_instance_multi_topology_ipv6_multicast_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return isis_multi_topology_overload_common(event, dnode,
+	return isis_multi_topology_overload_common(args->event, args->dnode,
 						   "ipv6-multicast");
 }
 
@@ -1266,68 +1205,68 @@ int isis_instance_multi_topology_ipv6_multicast_overload_modify(
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv6-management
  */
 int isis_instance_multi_topology_ipv6_management_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv6-mgmt", true);
+	return isis_multi_topology_common(args->event, args->dnode, "ipv6-mgmt",
+					  true);
 }
 
 int isis_instance_multi_topology_ipv6_management_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv6-mgmt", false);
+	return isis_multi_topology_common(args->event, args->dnode, "ipv6-mgmt",
+					  false);
 }
 
 /*
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv6-management/overload
  */
 int isis_instance_multi_topology_ipv6_management_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return isis_multi_topology_overload_common(event, dnode, "ipv6-mgmt");
+	return isis_multi_topology_overload_common(args->event, args->dnode,
+						   "ipv6-mgmt");
 }
 
 /*
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv6-dstsrc
  */
 int isis_instance_multi_topology_ipv6_dstsrc_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv6-dstsrc", true);
+	return isis_multi_topology_common(args->event, args->dnode,
+					  "ipv6-dstsrc", true);
 }
 
 int isis_instance_multi_topology_ipv6_dstsrc_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return isis_multi_topology_common(event, dnode, "ipv6-dstsrc", false);
+	return isis_multi_topology_common(args->event, args->dnode,
+					  "ipv6-dstsrc", false);
 }
 
 /*
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv6-dstsrc/overload
  */
 int isis_instance_multi_topology_ipv6_dstsrc_overload_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return isis_multi_topology_overload_common(event, dnode, "ipv6-dstsrc");
+	return isis_multi_topology_overload_common(args->event, args->dnode,
+						   "ipv6-dstsrc");
 }
 
 /*
  * XPath: /frr-isisd:isis/instance/log-adjacency-changes
  */
-int isis_instance_log_adjacency_changes_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource)
+int isis_instance_log_adjacency_changes_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
-	bool log = yang_dnode_get_bool(dnode, NULL);
+	bool log = yang_dnode_get_bool(args->dnode, NULL);
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	area->log_adj_changes = log ? 1 : 0;
 
 	return NB_OK;
@@ -1336,18 +1275,16 @@ int isis_instance_log_adjacency_changes_modify(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/mpls-te
  */
-int isis_instance_mpls_te_create(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource)
+int isis_instance_mpls_te_create(struct nb_cb_create_args *args)
 {
 	struct listnode *node;
 	struct isis_area *area;
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	if (area->mta == NULL) {
 
 		struct mpls_te_area *new;
@@ -1379,17 +1316,16 @@ int isis_instance_mpls_te_create(enum nb_event event,
 	return NB_OK;
 }
 
-int isis_instance_mpls_te_destroy(enum nb_event event,
-				  const struct lyd_node *dnode)
+int isis_instance_mpls_te_destroy(struct nb_cb_destroy_args *args)
 {
 	struct listnode *node;
 	struct isis_area *area;
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	if (IS_MPLS_TE(area->mta))
 		area->mta->status = disable;
 	else
@@ -1421,23 +1357,21 @@ int isis_instance_mpls_te_destroy(enum nb_event event,
 /*
  * XPath: /frr-isisd:isis/instance/mpls-te/router-address
  */
-int isis_instance_mpls_te_router_address_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource)
+int isis_instance_mpls_te_router_address_modify(struct nb_cb_modify_args *args)
 {
 	struct in_addr value;
 	struct isis_area *area;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	/* only proceed if MPLS-TE is enabled */
 	if (!IS_MPLS_TE(area->mta))
 		return NB_OK;
 
 	/* Update Area Router ID */
-	yang_dnode_get_ipv4(&value, dnode, NULL);
+	yang_dnode_get_ipv4(&value, args->dnode, NULL);
 	area->mta->router_id.s_addr = value.s_addr;
 
 	/* And re-schedule LSP update */
@@ -1446,15 +1380,15 @@ int isis_instance_mpls_te_router_address_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int isis_instance_mpls_te_router_address_destroy(enum nb_event event,
-						 const struct lyd_node *dnode)
+int isis_instance_mpls_te_router_address_destroy(
+	struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = nb_running_get_entry(dnode, NULL, true);
+	area = nb_running_get_entry(args->dnode, NULL, true);
 	/* only proceed if MPLS-TE is enabled */
 	if (!IS_MPLS_TE(area->mta))
 		return NB_OK;
@@ -1471,16 +1405,15 @@ int isis_instance_mpls_te_router_address_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis
  */
-int lib_interface_isis_create(enum nb_event event, const struct lyd_node *dnode,
-			      union nb_resource *resource)
+int lib_interface_isis_create(struct nb_cb_create_args *args)
 {
 	struct isis_area *area;
 	struct interface *ifp;
 	struct isis_circuit *circuit;
-	const char *area_tag = yang_dnode_get_string(dnode, "./area-tag");
+	const char *area_tag = yang_dnode_get_string(args->dnode, "./area-tag");
 	uint32_t min_mtu, actual_mtu;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
@@ -1488,7 +1421,7 @@ int lib_interface_isis_create(enum nb_event event, const struct lyd_node *dnode,
 		/* check if interface mtu is sufficient. If the area has not
 		 * been created yet, assume default MTU for the area
 		 */
-		ifp = nb_running_get_entry(dnode, NULL, false);
+		ifp = nb_running_get_entry(args->dnode, NULL, false);
 		/* zebra might not know yet about the MTU - nothing we can do */
 		if (!ifp || ifp->mtu == 0)
 			break;
@@ -1527,27 +1460,26 @@ int lib_interface_isis_create(enum nb_event event, const struct lyd_node *dnode,
 			abort();
 		}
 
-		ifp = nb_running_get_entry(dnode, NULL, true);
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		circuit = isis_circuit_create(area, ifp);
 		assert(circuit
 		       && (circuit->state == C_STATE_CONF
 			   || circuit->state == C_STATE_UP));
-		nb_running_set_entry(dnode, circuit);
+		nb_running_set_entry(args->dnode, circuit);
 		break;
 	}
 
 	return NB_OK;
 }
 
-int lib_interface_isis_destroy(enum nb_event event,
-			       const struct lyd_node *dnode)
+int lib_interface_isis_destroy(struct nb_cb_destroy_args *args)
 {
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_unset_entry(dnode);
+	circuit = nb_running_unset_entry(args->dnode);
 	if (!circuit)
 		return NB_ERR_INCONSISTENCY;
 
@@ -1563,27 +1495,27 @@ int lib_interface_isis_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/area-tag
  */
-int lib_interface_isis_area_tag_modify(enum nb_event event,
-				       const struct lyd_node *dnode,
-				       union nb_resource *resource)
+int lib_interface_isis_area_tag_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	struct interface *ifp;
 	struct vrf *vrf;
 	const char *area_tag, *ifname, *vrfname;
 
-	if (event == NB_EV_VALIDATE) {
+	if (args->event == NB_EV_VALIDATE) {
 		/* libyang doesn't like relative paths across module boundaries
 		 */
-		ifname = yang_dnode_get_string(dnode->parent->parent, "./name");
-		vrfname = yang_dnode_get_string(dnode->parent->parent, "./vrf");
+		ifname = yang_dnode_get_string(args->dnode->parent->parent,
+					       "./name");
+		vrfname = yang_dnode_get_string(args->dnode->parent->parent,
+						"./vrf");
 		vrf = vrf_lookup_by_name(vrfname);
 		assert(vrf);
 		ifp = if_lookup_by_name(ifname, vrf->vrf_id);
 		if (!ifp)
 			return NB_OK;
 		circuit = circuit_lookup_by_ifp(ifp, isis->init_circ_list);
-		area_tag = yang_dnode_get_string(dnode, NULL);
+		area_tag = yang_dnode_get_string(args->dnode, NULL);
 		if (circuit && circuit->area && circuit->area->area_tag
 		    && strcmp(circuit->area->area_tag, area_tag)) {
 			flog_warn(EC_LIB_NB_CB_CONFIG_VALIDATE,
@@ -1599,22 +1531,22 @@ int lib_interface_isis_area_tag_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/circuit-type
  */
-int lib_interface_isis_circuit_type_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource)
+int lib_interface_isis_circuit_type_modify(struct nb_cb_modify_args *args)
 {
-	int circ_type = yang_dnode_get_enum(dnode, NULL);
+	int circ_type = yang_dnode_get_enum(args->dnode, NULL);
 	struct isis_circuit *circuit;
 	struct interface *ifp;
 	struct vrf *vrf;
 	const char *ifname, *vrfname;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		/* libyang doesn't like relative paths across module boundaries
 		 */
-		ifname = yang_dnode_get_string(dnode->parent->parent, "./name");
-		vrfname = yang_dnode_get_string(dnode->parent->parent, "./vrf");
+		ifname = yang_dnode_get_string(args->dnode->parent->parent,
+					       "./name");
+		vrfname = yang_dnode_get_string(args->dnode->parent->parent,
+						"./vrf");
 		vrf = vrf_lookup_by_name(vrfname);
 		assert(vrf);
 		ifp = if_lookup_by_name(ifname, vrf->vrf_id);
@@ -1634,7 +1566,7 @@ int lib_interface_isis_circuit_type_modify(enum nb_event event,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		circuit = nb_running_get_entry(dnode, NULL, true);
+		circuit = nb_running_get_entry(args->dnode, NULL, true);
 		isis_circuit_is_type_set(circuit, circ_type);
 		break;
 	}
@@ -1645,19 +1577,17 @@ int lib_interface_isis_circuit_type_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/ipv4-routing
  */
-int lib_interface_isis_ipv4_routing_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource)
+int lib_interface_isis_ipv4_routing_modify(struct nb_cb_modify_args *args)
 {
 	bool ipv4, ipv6;
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	ipv4 = yang_dnode_get_bool(dnode, NULL);
-	ipv6 = yang_dnode_get_bool(dnode, "../ipv6-routing");
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	ipv4 = yang_dnode_get_bool(args->dnode, NULL);
+	ipv6 = yang_dnode_get_bool(args->dnode, "../ipv6-routing");
 	isis_circuit_af_set(circuit, ipv4, ipv6);
 
 	return NB_OK;
@@ -1666,19 +1596,17 @@ int lib_interface_isis_ipv4_routing_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/ipv6-routing
  */
-int lib_interface_isis_ipv6_routing_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource)
+int lib_interface_isis_ipv6_routing_modify(struct nb_cb_modify_args *args)
 {
 	bool ipv4, ipv6;
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	ipv4 = yang_dnode_exists(dnode, "../ipv4-routing");
-	ipv6 = yang_dnode_get_bool(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	ipv4 = yang_dnode_exists(args->dnode, "../ipv4-routing");
+	ipv6 = yang_dnode_get_bool(args->dnode, NULL);
 	isis_circuit_af_set(circuit, ipv4, ipv6);
 
 	return NB_OK;
@@ -1687,18 +1615,16 @@ int lib_interface_isis_ipv6_routing_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/bfd-monitoring
  */
-int lib_interface_isis_bfd_monitoring_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+int lib_interface_isis_bfd_monitoring_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	bool bfd_monitoring;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	bfd_monitoring = yang_dnode_get_bool(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	bfd_monitoring = yang_dnode_get_bool(args->dnode, NULL);
 
 	if (bfd_monitoring) {
 		isis_bfd_circuit_param_set(circuit, BFD_DEF_MIN_RX,
@@ -1716,16 +1642,15 @@ int lib_interface_isis_bfd_monitoring_modify(enum nb_event event,
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/csnp-interval/level-1
  */
 int lib_interface_isis_csnp_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	circuit->csnp_interval[0] = yang_dnode_get_uint16(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	circuit->csnp_interval[0] = yang_dnode_get_uint16(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -1734,16 +1659,15 @@ int lib_interface_isis_csnp_interval_level_1_modify(
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/csnp-interval/level-2
  */
 int lib_interface_isis_csnp_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	circuit->csnp_interval[1] = yang_dnode_get_uint16(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	circuit->csnp_interval[1] = yang_dnode_get_uint16(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -1752,16 +1676,15 @@ int lib_interface_isis_csnp_interval_level_2_modify(
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/psnp-interval/level-1
  */
 int lib_interface_isis_psnp_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	circuit->psnp_interval[0] = yang_dnode_get_uint16(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	circuit->psnp_interval[0] = yang_dnode_get_uint16(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -1770,16 +1693,15 @@ int lib_interface_isis_psnp_interval_level_1_modify(
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/psnp-interval/level-2
  */
 int lib_interface_isis_psnp_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	circuit->psnp_interval[1] = yang_dnode_get_uint16(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	circuit->psnp_interval[1] = yang_dnode_get_uint16(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -1787,17 +1709,15 @@ int lib_interface_isis_psnp_interval_level_2_modify(
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/hello/padding
  */
-int lib_interface_isis_hello_padding_modify(enum nb_event event,
-					    const struct lyd_node *dnode,
-					    union nb_resource *resource)
+int lib_interface_isis_hello_padding_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	circuit->pad_hellos = yang_dnode_get_bool(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	circuit->pad_hellos = yang_dnode_get_bool(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -1806,17 +1726,16 @@ int lib_interface_isis_hello_padding_modify(enum nb_event event,
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/hello/interval/level-1
  */
 int lib_interface_isis_hello_interval_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	uint32_t interval;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	interval = yang_dnode_get_uint32(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	interval = yang_dnode_get_uint32(args->dnode, NULL);
 	circuit->hello_interval[0] = interval;
 
 	return NB_OK;
@@ -1826,17 +1745,16 @@ int lib_interface_isis_hello_interval_level_1_modify(
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/hello/interval/level-2
  */
 int lib_interface_isis_hello_interval_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	uint32_t interval;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	interval = yang_dnode_get_uint32(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	interval = yang_dnode_get_uint32(args->dnode, NULL);
 	circuit->hello_interval[1] = interval;
 
 	return NB_OK;
@@ -1846,17 +1764,16 @@ int lib_interface_isis_hello_interval_level_2_modify(
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/hello/multiplier/level-1
  */
 int lib_interface_isis_hello_multiplier_level_1_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	uint16_t multi;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	multi = yang_dnode_get_uint16(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	multi = yang_dnode_get_uint16(args->dnode, NULL);
 	circuit->hello_multiplier[0] = multi;
 
 	return NB_OK;
@@ -1866,17 +1783,16 @@ int lib_interface_isis_hello_multiplier_level_1_modify(
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/hello/multiplier/level-2
  */
 int lib_interface_isis_hello_multiplier_level_2_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	uint16_t multi;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	multi = yang_dnode_get_uint16(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	multi = yang_dnode_get_uint16(args->dnode, NULL);
 	circuit->hello_multiplier[1] = multi;
 
 	return NB_OK;
@@ -1885,18 +1801,16 @@ int lib_interface_isis_hello_multiplier_level_2_modify(
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/metric/level-1
  */
-int lib_interface_isis_metric_level_1_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+int lib_interface_isis_metric_level_1_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	unsigned int met;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	met = yang_dnode_get_uint32(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	met = yang_dnode_get_uint32(args->dnode, NULL);
 	isis_circuit_metric_set(circuit, IS_LEVEL_1, met);
 
 	return NB_OK;
@@ -1905,18 +1819,16 @@ int lib_interface_isis_metric_level_1_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/metric/level-2
  */
-int lib_interface_isis_metric_level_2_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+int lib_interface_isis_metric_level_2_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	unsigned int met;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	met = yang_dnode_get_uint32(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	met = yang_dnode_get_uint32(args->dnode, NULL);
 	isis_circuit_metric_set(circuit, IS_LEVEL_2, met);
 
 	return NB_OK;
@@ -1925,17 +1837,15 @@ int lib_interface_isis_metric_level_2_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/priority/level-1
  */
-int lib_interface_isis_priority_level_1_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource)
+int lib_interface_isis_priority_level_1_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	circuit->priority[0] = yang_dnode_get_uint8(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	circuit->priority[0] = yang_dnode_get_uint8(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -1943,17 +1853,15 @@ int lib_interface_isis_priority_level_1_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/priority/level-2
  */
-int lib_interface_isis_priority_level_2_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource)
+int lib_interface_isis_priority_level_2_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	circuit->priority[1] = yang_dnode_get_uint8(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	circuit->priority[1] = yang_dnode_get_uint8(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -1961,16 +1869,14 @@ int lib_interface_isis_priority_level_2_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/network-type
  */
-int lib_interface_isis_network_type_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource)
+int lib_interface_isis_network_type_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
-	int net_type = yang_dnode_get_enum(dnode, NULL);
+	int net_type = yang_dnode_get_enum(args->dnode, NULL);
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		circuit = nb_running_get_entry(dnode, NULL, false);
+		circuit = nb_running_get_entry(args->dnode, NULL, false);
 		if (!circuit)
 			break;
 		if (circuit->circ_type == CIRCUIT_T_LOOPBACK) {
@@ -1992,7 +1898,7 @@ int lib_interface_isis_network_type_modify(enum nb_event event,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		circuit = nb_running_get_entry(dnode, NULL, true);
+		circuit = nb_running_get_entry(args->dnode, NULL, true);
 		isis_circuit_circ_type_set(circuit, net_type);
 		break;
 	}
@@ -2003,18 +1909,16 @@ int lib_interface_isis_network_type_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/passive
  */
-int lib_interface_isis_passive_modify(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource)
+int lib_interface_isis_passive_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	struct isis_area *area;
 	struct interface *ifp;
-	bool passive = yang_dnode_get_bool(dnode, NULL);
+	bool passive = yang_dnode_get_bool(args->dnode, NULL);
 
 	/* validation only applies if we are setting passive to false */
-	if (!passive && event == NB_EV_VALIDATE) {
-		circuit = nb_running_get_entry(dnode, NULL, false);
+	if (!passive && args->event == NB_EV_VALIDATE) {
+		circuit = nb_running_get_entry(args->dnode, NULL, false);
 		if (!circuit)
 			return NB_OK;
 		ifp = circuit->interface;
@@ -2027,10 +1931,10 @@ int lib_interface_isis_passive_modify(enum nb_event event,
 		}
 	}
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
 	if (circuit->state != C_STATE_UP) {
 		circuit->is_passive = passive;
 	} else {
@@ -2046,22 +1950,19 @@ int lib_interface_isis_passive_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/password
  */
-int lib_interface_isis_password_create(enum nb_event event,
-				       const struct lyd_node *dnode,
-				       union nb_resource *resource)
+int lib_interface_isis_password_create(struct nb_cb_create_args *args)
 {
 	return NB_OK;
 }
 
-int lib_interface_isis_password_destroy(enum nb_event event,
-					const struct lyd_node *dnode)
+int lib_interface_isis_password_destroy(struct nb_cb_destroy_args *args)
 {
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
 	isis_circuit_passwd_unset(circuit);
 
 	return NB_OK;
@@ -2070,18 +1971,16 @@ int lib_interface_isis_password_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/password/password
  */
-int lib_interface_isis_password_password_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource)
+int lib_interface_isis_password_password_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	const char *password;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	password = yang_dnode_get_string(dnode, NULL);
-	circuit = nb_running_get_entry(dnode, NULL, true);
+	password = yang_dnode_get_string(args->dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
 
 	isis_circuit_passwd_set(circuit, circuit->passwd.type, password);
 
@@ -2092,17 +1991,16 @@ int lib_interface_isis_password_password_modify(enum nb_event event,
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/password/password-type
  */
 int lib_interface_isis_password_password_type_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 	uint8_t pass_type;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	pass_type = yang_dnode_get_enum(dnode, NULL);
-	circuit = nb_running_get_entry(dnode, NULL, true);
+	pass_type = yang_dnode_get_enum(args->dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
 	circuit->passwd.type = pass_type;
 
 	return NB_OK;
@@ -2113,16 +2011,15 @@ int lib_interface_isis_password_password_type_modify(
  * /frr-interface:lib/interface/frr-isisd:isis/disable-three-way-handshake
  */
 int lib_interface_isis_disable_three_way_handshake_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = nb_running_get_entry(dnode, NULL, true);
-	circuit->disable_threeway_adj = yang_dnode_get_bool(dnode, NULL);
+	circuit = nb_running_get_entry(args->dnode, NULL, true);
+	circuit->disable_threeway_adj = yang_dnode_get_bool(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -2161,11 +2058,10 @@ static int lib_interface_isis_multi_topology_common(
 }
 
 int lib_interface_isis_multi_topology_ipv4_unicast_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return lib_interface_isis_multi_topology_common(event, dnode,
-							ISIS_MT_IPV4_UNICAST);
+	return lib_interface_isis_multi_topology_common(
+		args->event, args->dnode, ISIS_MT_IPV4_UNICAST);
 }
 
 /*
@@ -2173,11 +2069,10 @@ int lib_interface_isis_multi_topology_ipv4_unicast_modify(
  * /frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv4-multicast
  */
 int lib_interface_isis_multi_topology_ipv4_multicast_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return lib_interface_isis_multi_topology_common(event, dnode,
-							ISIS_MT_IPV4_MULTICAST);
+	return lib_interface_isis_multi_topology_common(
+		args->event, args->dnode, ISIS_MT_IPV4_MULTICAST);
 }
 
 /*
@@ -2185,11 +2080,10 @@ int lib_interface_isis_multi_topology_ipv4_multicast_modify(
  * /frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv4-management
  */
 int lib_interface_isis_multi_topology_ipv4_management_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return lib_interface_isis_multi_topology_common(event, dnode,
-							ISIS_MT_IPV4_MGMT);
+	return lib_interface_isis_multi_topology_common(
+		args->event, args->dnode, ISIS_MT_IPV4_MGMT);
 }
 
 /*
@@ -2197,11 +2091,10 @@ int lib_interface_isis_multi_topology_ipv4_management_modify(
  * /frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv6-unicast
  */
 int lib_interface_isis_multi_topology_ipv6_unicast_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return lib_interface_isis_multi_topology_common(event, dnode,
-							ISIS_MT_IPV6_UNICAST);
+	return lib_interface_isis_multi_topology_common(
+		args->event, args->dnode, ISIS_MT_IPV6_UNICAST);
 }
 
 /*
@@ -2209,11 +2102,10 @@ int lib_interface_isis_multi_topology_ipv6_unicast_modify(
  * /frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv6-multicast
  */
 int lib_interface_isis_multi_topology_ipv6_multicast_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return lib_interface_isis_multi_topology_common(event, dnode,
-							ISIS_MT_IPV6_MULTICAST);
+	return lib_interface_isis_multi_topology_common(
+		args->event, args->dnode, ISIS_MT_IPV6_MULTICAST);
 }
 
 /*
@@ -2221,20 +2113,18 @@ int lib_interface_isis_multi_topology_ipv6_multicast_modify(
  * /frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv6-management
  */
 int lib_interface_isis_multi_topology_ipv6_management_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return lib_interface_isis_multi_topology_common(event, dnode,
-							ISIS_MT_IPV6_MGMT);
+	return lib_interface_isis_multi_topology_common(
+		args->event, args->dnode, ISIS_MT_IPV6_MGMT);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv6-dstsrc
  */
 int lib_interface_isis_multi_topology_ipv6_dstsrc_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	return lib_interface_isis_multi_topology_common(event, dnode,
-							ISIS_MT_IPV6_DSTSRC);
+	return lib_interface_isis_multi_topology_common(
+		args->event, args->dnode, ISIS_MT_IPV6_DSTSRC);
 }

--- a/isisd/isis_nb_state.c
+++ b/isisd/isis_nb_state.c
@@ -31,9 +31,8 @@
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/adjacencies/adjacency
  */
-const void *
-lib_interface_isis_adjacencies_adjacency_get_next(const void *parent_list_entry,
-						  const void *list_entry)
+const void *lib_interface_isis_adjacencies_adjacency_get_next(
+	struct nb_cb_get_next_args *args)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
@@ -42,8 +41,8 @@ lib_interface_isis_adjacencies_adjacency_get_next(const void *parent_list_entry,
 	struct listnode *node, *node_next;
 
 	/* Get first adjacency. */
-	if (list_entry == NULL) {
-		ifp = (struct interface *)parent_list_entry;
+	if (args->list_entry == NULL) {
+		ifp = (struct interface *)args->parent_list_entry;
 		if (!ifp)
 			return NULL;
 
@@ -73,7 +72,7 @@ lib_interface_isis_adjacencies_adjacency_get_next(const void *parent_list_entry,
 	}
 
 	/* Get next adjacency. */
-	adj = (struct isis_adjacency *)list_entry;
+	adj = (struct isis_adjacency *)args->list_entry;
 	circuit = adj->circuit;
 	switch (circuit->circ_type) {
 	case CIRCUIT_T_BROADCAST:
@@ -106,11 +105,11 @@ lib_interface_isis_adjacencies_adjacency_get_next(const void *parent_list_entry,
  */
 struct yang_data *
 lib_interface_isis_adjacencies_adjacency_neighbor_sys_type_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct isis_adjacency *adj = list_entry;
+	const struct isis_adjacency *adj = args->list_entry;
 
-	return yang_data_new_enum(xpath, adj->level);
+	return yang_data_new_enum(args->xpath, adj->level);
 }
 
 /*
@@ -119,11 +118,11 @@ lib_interface_isis_adjacencies_adjacency_neighbor_sys_type_get_elem(
  */
 struct yang_data *
 lib_interface_isis_adjacencies_adjacency_neighbor_sysid_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct isis_adjacency *adj = list_entry;
+	const struct isis_adjacency *adj = args->list_entry;
 
-	return yang_data_new_string(xpath, sysid_print(adj->sysid));
+	return yang_data_new_string(args->xpath, sysid_print(adj->sysid));
 }
 
 /*
@@ -132,11 +131,11 @@ lib_interface_isis_adjacencies_adjacency_neighbor_sysid_get_elem(
  */
 struct yang_data *
 lib_interface_isis_adjacencies_adjacency_neighbor_extended_circuit_id_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct isis_adjacency *adj = list_entry;
+	const struct isis_adjacency *adj = args->list_entry;
 
-	return yang_data_new_uint32(xpath, adj->circuit->circuit_id);
+	return yang_data_new_uint32(args->xpath, adj->circuit->circuit_id);
 }
 
 /*
@@ -145,11 +144,11 @@ lib_interface_isis_adjacencies_adjacency_neighbor_extended_circuit_id_get_elem(
  */
 struct yang_data *
 lib_interface_isis_adjacencies_adjacency_neighbor_snpa_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct isis_adjacency *adj = list_entry;
+	const struct isis_adjacency *adj = args->list_entry;
 
-	return yang_data_new_string(xpath, snpa_print(adj->snpa));
+	return yang_data_new_string(args->xpath, snpa_print(adj->snpa));
 }
 
 /*
@@ -157,11 +156,11 @@ lib_interface_isis_adjacencies_adjacency_neighbor_snpa_get_elem(
  * /frr-interface:lib/interface/frr-isisd:isis/adjacencies/adjacency/hold-timer
  */
 struct yang_data *lib_interface_isis_adjacencies_adjacency_hold_timer_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct isis_adjacency *adj = list_entry;
+	const struct isis_adjacency *adj = args->list_entry;
 
-	return yang_data_new_uint16(xpath, adj->hold_time);
+	return yang_data_new_uint16(args->xpath, adj->hold_time);
 }
 
 /*
@@ -170,24 +169,24 @@ struct yang_data *lib_interface_isis_adjacencies_adjacency_hold_timer_get_elem(
  */
 struct yang_data *
 lib_interface_isis_adjacencies_adjacency_neighbor_priority_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct isis_adjacency *adj = list_entry;
+	const struct isis_adjacency *adj = args->list_entry;
 
-	return yang_data_new_uint8(xpath, adj->prio[adj->level - 1]);
+	return yang_data_new_uint8(args->xpath, adj->prio[adj->level - 1]);
 }
 
 /*
  * XPath:
  * /frr-interface:lib/interface/frr-isisd:isis/adjacencies/adjacency/state
  */
-struct yang_data *
-lib_interface_isis_adjacencies_adjacency_state_get_elem(const char *xpath,
-							const void *list_entry)
+struct yang_data *lib_interface_isis_adjacencies_adjacency_state_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct isis_adjacency *adj = list_entry;
+	const struct isis_adjacency *adj = args->list_entry;
 
-	return yang_data_new_string(xpath, isis_adj_yang_state(adj->adj_state));
+	return yang_data_new_string(args->xpath,
+				    isis_adj_yang_state(adj->adj_state));
 }
 
 /*
@@ -195,12 +194,12 @@ lib_interface_isis_adjacencies_adjacency_state_get_elem(const char *xpath,
  * /frr-interface:lib/interface/frr-isisd:isis/event-counters/adjacency-changes
  */
 struct yang_data *lib_interface_isis_event_counters_adjacency_changes_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
 
-	ifp = (struct interface *)list_entry;
+	ifp = (struct interface *)args->list_entry;
 	if (!ifp)
 		return NULL;
 
@@ -208,7 +207,7 @@ struct yang_data *lib_interface_isis_event_counters_adjacency_changes_get_elem(
 	if (!circuit)
 		return NULL;
 
-	return yang_data_new_uint32(xpath, circuit->adj_state_changes);
+	return yang_data_new_uint32(args->xpath, circuit->adj_state_changes);
 }
 
 /*
@@ -216,7 +215,7 @@ struct yang_data *lib_interface_isis_event_counters_adjacency_changes_get_elem(
  * /frr-interface:lib/interface/frr-isisd:isis/event-counters/adjacency-number
  */
 struct yang_data *lib_interface_isis_event_counters_adjacency_number_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
@@ -224,7 +223,7 @@ struct yang_data *lib_interface_isis_event_counters_adjacency_number_get_elem(
 	struct listnode *node;
 	uint32_t total = 0;
 
-	ifp = (struct interface *)list_entry;
+	ifp = (struct interface *)args->list_entry;
 	if (!ifp)
 		return NULL;
 
@@ -253,20 +252,19 @@ struct yang_data *lib_interface_isis_event_counters_adjacency_number_get_elem(
 		break;
 	}
 
-	return yang_data_new_uint32(xpath, total);
+	return yang_data_new_uint32(args->xpath, total);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/event-counters/init-fails
  */
-struct yang_data *
-lib_interface_isis_event_counters_init_fails_get_elem(const char *xpath,
-						      const void *list_entry)
+struct yang_data *lib_interface_isis_event_counters_init_fails_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
 
-	ifp = (struct interface *)list_entry;
+	ifp = (struct interface *)args->list_entry;
 	if (!ifp)
 		return NULL;
 
@@ -274,7 +272,7 @@ lib_interface_isis_event_counters_init_fails_get_elem(const char *xpath,
 	if (!circuit)
 		return NULL;
 
-	return yang_data_new_uint32(xpath, circuit->init_failures);
+	return yang_data_new_uint32(args->xpath, circuit->init_failures);
 }
 
 /*
@@ -282,12 +280,12 @@ lib_interface_isis_event_counters_init_fails_get_elem(const char *xpath,
  * /frr-interface:lib/interface/frr-isisd:isis/event-counters/adjacency-rejects
  */
 struct yang_data *lib_interface_isis_event_counters_adjacency_rejects_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
 
-	ifp = (struct interface *)list_entry;
+	ifp = (struct interface *)args->list_entry;
 	if (!ifp)
 		return NULL;
 
@@ -295,7 +293,7 @@ struct yang_data *lib_interface_isis_event_counters_adjacency_rejects_get_elem(
 	if (!circuit)
 		return NULL;
 
-	return yang_data_new_uint32(xpath, circuit->rej_adjacencies);
+	return yang_data_new_uint32(args->xpath, circuit->rej_adjacencies);
 }
 
 /*
@@ -303,12 +301,12 @@ struct yang_data *lib_interface_isis_event_counters_adjacency_rejects_get_elem(
  * /frr-interface:lib/interface/frr-isisd:isis/event-counters/id-len-mismatch
  */
 struct yang_data *lib_interface_isis_event_counters_id_len_mismatch_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
 
-	ifp = (struct interface *)list_entry;
+	ifp = (struct interface *)args->list_entry;
 	if (!ifp)
 		return NULL;
 
@@ -316,7 +314,7 @@ struct yang_data *lib_interface_isis_event_counters_id_len_mismatch_get_elem(
 	if (!circuit)
 		return NULL;
 
-	return yang_data_new_uint32(xpath, circuit->id_len_mismatches);
+	return yang_data_new_uint32(args->xpath, circuit->id_len_mismatches);
 }
 
 /*
@@ -325,12 +323,12 @@ struct yang_data *lib_interface_isis_event_counters_id_len_mismatch_get_elem(
  */
 struct yang_data *
 lib_interface_isis_event_counters_max_area_addresses_mismatch_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
 
-	ifp = (struct interface *)list_entry;
+	ifp = (struct interface *)args->list_entry;
 	if (!ifp)
 		return NULL;
 
@@ -338,7 +336,8 @@ lib_interface_isis_event_counters_max_area_addresses_mismatch_get_elem(
 	if (!circuit)
 		return NULL;
 
-	return yang_data_new_uint32(xpath, circuit->max_area_addr_mismatches);
+	return yang_data_new_uint32(args->xpath,
+				    circuit->max_area_addr_mismatches);
 }
 
 /*
@@ -347,12 +346,12 @@ lib_interface_isis_event_counters_max_area_addresses_mismatch_get_elem(
  */
 struct yang_data *
 lib_interface_isis_event_counters_authentication_type_fails_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
 
-	ifp = (struct interface *)list_entry;
+	ifp = (struct interface *)args->list_entry;
 	if (!ifp)
 		return NULL;
 
@@ -360,7 +359,7 @@ lib_interface_isis_event_counters_authentication_type_fails_get_elem(
 	if (!circuit)
 		return NULL;
 
-	return yang_data_new_uint32(xpath, circuit->auth_type_failures);
+	return yang_data_new_uint32(args->xpath, circuit->auth_type_failures);
 }
 
 /*
@@ -369,12 +368,12 @@ lib_interface_isis_event_counters_authentication_type_fails_get_elem(
  */
 struct yang_data *
 lib_interface_isis_event_counters_authentication_fails_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
 
-	ifp = (struct interface *)list_entry;
+	ifp = (struct interface *)args->list_entry;
 	if (!ifp)
 		return NULL;
 
@@ -382,5 +381,5 @@ lib_interface_isis_event_counters_authentication_fails_get_elem(
 	if (!circuit)
 		return NULL;
 
-	return yang_data_new_uint32(xpath, circuit->auth_failures);
+	return yang_data_new_uint32(args->xpath, circuit->auth_failures);
 }

--- a/lib/if.c
+++ b/lib/if.c
@@ -1489,19 +1489,17 @@ void if_zapi_callbacks(int (*create)(struct interface *ifp),
 /*
  * XPath: /frr-interface:lib/interface
  */
-static int lib_interface_create(enum nb_event event,
-				const struct lyd_node *dnode,
-				union nb_resource *resource)
+static int lib_interface_create(struct nb_cb_create_args *args)
 {
 	const char *ifname;
 	const char *vrfname;
 	struct vrf *vrf;
 	struct interface *ifp;
 
-	ifname = yang_dnode_get_string(dnode, "./name");
-	vrfname = yang_dnode_get_string(dnode, "./vrf");
+	ifname = yang_dnode_get_string(args->dnode, "./name");
+	vrfname = yang_dnode_get_string(args->dnode, "./vrf");
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		vrf = vrf_lookup_by_name(vrfname);
 		if (!vrf) {
@@ -1542,22 +1540,21 @@ static int lib_interface_create(enum nb_event event,
 #endif /* SUNOS_5 */
 
 		ifp->configured = true;
-		nb_running_set_entry(dnode, ifp);
+		nb_running_set_entry(args->dnode, ifp);
 		break;
 	}
 
 	return NB_OK;
 }
 
-static int lib_interface_destroy(enum nb_event event,
-				 const struct lyd_node *dnode)
+static int lib_interface_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		ifp = nb_running_get_entry(dnode, NULL, true);
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		if (CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
 			zlog_warn("%s: only inactive interfaces can be deleted",
 				  __func__);
@@ -1568,7 +1565,7 @@ static int lib_interface_destroy(enum nb_event event,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		ifp = nb_running_unset_entry(dnode);
+		ifp = nb_running_unset_entry(args->dnode);
 
 		ifp->configured = false;
 		if_delete(&ifp);
@@ -1581,13 +1578,12 @@ static int lib_interface_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface
  */
-static const void *lib_interface_get_next(const void *parent_list_entry,
-					  const void *list_entry)
+static const void *lib_interface_get_next(struct nb_cb_get_next_args *args)
 {
 	struct vrf *vrf;
-	struct interface *pif = (struct interface *)list_entry;
+	struct interface *pif = (struct interface *)args->list_entry;
 
-	if (list_entry == NULL) {
+	if (args->list_entry == NULL) {
 		vrf = RB_MIN(vrf_name_head, &vrfs_by_name);
 		assert(vrf);
 		pif = RB_MIN(if_name_head, &vrf->ifaces_by_name);
@@ -1606,27 +1602,26 @@ static const void *lib_interface_get_next(const void *parent_list_entry,
 	return pif;
 }
 
-static int lib_interface_get_keys(const void *list_entry,
-				  struct yang_list_keys *keys)
+static int lib_interface_get_keys(struct nb_cb_get_keys_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 
 	struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
 
 	assert(vrf);
 
-	keys->num = 2;
-	strlcpy(keys->key[0], ifp->name, sizeof(keys->key[0]));
-	strlcpy(keys->key[1], vrf->name, sizeof(keys->key[1]));
+	args->keys->num = 2;
+	strlcpy(args->keys->key[0], ifp->name, sizeof(args->keys->key[0]));
+	strlcpy(args->keys->key[1], vrf->name, sizeof(args->keys->key[1]));
 
 	return NB_OK;
 }
 
-static const void *lib_interface_lookup_entry(const void *parent_list_entry,
-					      const struct yang_list_keys *keys)
+static const void *
+lib_interface_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
-	const char *ifname = keys->key[0];
-	const char *vrfname = keys->key[1];
+	const char *ifname = args->keys->key[0];
+	const char *vrfname = args->keys->key[1];
 	struct vrf *vrf = vrf_lookup_by_name(vrfname);
 
 	return vrf ? if_lookup_by_name(ifname, vrf->vrf_id) : NULL;
@@ -1635,33 +1630,30 @@ static const void *lib_interface_lookup_entry(const void *parent_list_entry,
 /*
  * XPath: /frr-interface:lib/interface/description
  */
-static int lib_interface_description_modify(enum nb_event event,
-					    const struct lyd_node *dnode,
-					    union nb_resource *resource)
+static int lib_interface_description_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	const char *description;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
 	XFREE(MTYPE_TMP, ifp->desc);
-	description = yang_dnode_get_string(dnode, NULL);
+	description = yang_dnode_get_string(args->dnode, NULL);
 	ifp->desc = XSTRDUP(MTYPE_TMP, description);
 
 	return NB_OK;
 }
 
-static int lib_interface_description_destroy(enum nb_event event,
-					     const struct lyd_node *dnode)
+static int lib_interface_description_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
 	XFREE(MTYPE_TMP, ifp->desc);
 
 	return NB_OK;
@@ -1670,63 +1662,63 @@ static int lib_interface_description_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/state/if-index
  */
-struct yang_data *lib_interface_state_if_index_get_elem(const char *xpath,
-							const void *list_entry)
+static struct yang_data *
+lib_interface_state_if_index_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 
-	return yang_data_new_int32(xpath, ifp->ifindex);
+	return yang_data_new_int32(args->xpath, ifp->ifindex);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/state/mtu
  */
-struct yang_data *lib_interface_state_mtu_get_elem(const char *xpath,
-						   const void *list_entry)
+static struct yang_data *
+lib_interface_state_mtu_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 
-	return yang_data_new_uint16(xpath, ifp->mtu);
+	return yang_data_new_uint16(args->xpath, ifp->mtu);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/state/mtu6
  */
-struct yang_data *lib_interface_state_mtu6_get_elem(const char *xpath,
-						    const void *list_entry)
+static struct yang_data *
+lib_interface_state_mtu6_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 
-	return yang_data_new_uint32(xpath, ifp->mtu6);
+	return yang_data_new_uint32(args->xpath, ifp->mtu6);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/state/speed
  */
-struct yang_data *lib_interface_state_speed_get_elem(const char *xpath,
-						     const void *list_entry)
+static struct yang_data *
+lib_interface_state_speed_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 
-	return yang_data_new_uint32(xpath, ifp->speed);
+	return yang_data_new_uint32(args->xpath, ifp->speed);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/state/metric
  */
-struct yang_data *lib_interface_state_metric_get_elem(const char *xpath,
-						      const void *list_entry)
+static struct yang_data *
+lib_interface_state_metric_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 
-	return yang_data_new_uint32(xpath, ifp->metric);
+	return yang_data_new_uint32(args->xpath, ifp->metric);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/state/flags
  */
-struct yang_data *lib_interface_state_flags_get_elem(const char *xpath,
-						     const void *list_entry)
+static struct yang_data *
+lib_interface_state_flags_get_elem(struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -1735,8 +1727,8 @@ struct yang_data *lib_interface_state_flags_get_elem(const char *xpath,
 /*
  * XPath: /frr-interface:lib/interface/state/type
  */
-struct yang_data *lib_interface_state_type_get_elem(const char *xpath,
-						    const void *list_entry)
+static struct yang_data *
+lib_interface_state_type_get_elem(struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -1745,16 +1737,15 @@ struct yang_data *lib_interface_state_type_get_elem(const char *xpath,
 /*
  * XPath: /frr-interface:lib/interface/state/phy-address
  */
-struct yang_data *
-lib_interface_state_phy_address_get_elem(const char *xpath,
-					 const void *list_entry)
+static struct yang_data *
+lib_interface_state_phy_address_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 	struct ethaddr macaddr;
 
 	memcpy(&macaddr.octet, ifp->hw_addr, ETH_ALEN);
 
-	return yang_data_new_mac(xpath, &macaddr);
+	return yang_data_new_mac(args->xpath, &macaddr);
 }
 
 /* clang-format off */

--- a/lib/if.h
+++ b/lib/if.h
@@ -602,24 +602,6 @@ extern void if_destroy_via_zapi(struct interface *ifp);
 
 extern const struct frr_yang_module_info frr_interface_info;
 
-struct yang_data *lib_interface_state_if_index_get_elem(const char *xpath,
-							const void *list_entry);
-struct yang_data *lib_interface_state_mtu_get_elem(const char *xpath,
-						   const void *list_entry);
-struct yang_data *lib_interface_state_mtu6_get_elem(const char *xpath,
-						    const void *list_entry);
-struct yang_data *lib_interface_state_speed_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *lib_interface_state_metric_get_elem(const char *xpath,
-						      const void *list_entry);
-struct yang_data *lib_interface_state_flags_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *lib_interface_state_type_get_elem(const char *xpath,
-						    const void *list_entry);
-struct yang_data *
-lib_interface_state_phy_address_get_elem(const char *xpath,
-					 const void *list_entry);
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -805,102 +805,147 @@ static int nb_callback_create(const struct nb_node *nb_node,
 			      enum nb_event event, const struct lyd_node *dnode,
 			      union nb_resource *resource)
 {
+	struct nb_cb_create_args args = {};
+
 	nb_log_config_callback(event, NB_OP_CREATE, dnode);
 
-	return nb_node->cbs.create(event, dnode, resource);
+	args.event = event;
+	args.dnode = dnode;
+	args.resource = resource;
+	return nb_node->cbs.create(&args);
 }
 
 static int nb_callback_modify(const struct nb_node *nb_node,
 			      enum nb_event event, const struct lyd_node *dnode,
 			      union nb_resource *resource)
 {
+	struct nb_cb_modify_args args = {};
+
 	nb_log_config_callback(event, NB_OP_MODIFY, dnode);
 
-	return nb_node->cbs.modify(event, dnode, resource);
+	args.event = event;
+	args.dnode = dnode;
+	args.resource = resource;
+	return nb_node->cbs.modify(&args);
 }
 
 static int nb_callback_destroy(const struct nb_node *nb_node,
 			       enum nb_event event,
 			       const struct lyd_node *dnode)
 {
+	struct nb_cb_destroy_args args = {};
+
 	nb_log_config_callback(event, NB_OP_DESTROY, dnode);
 
-	return nb_node->cbs.destroy(event, dnode);
+	args.event = event;
+	args.dnode = dnode;
+	return nb_node->cbs.destroy(&args);
 }
 
 static int nb_callback_move(const struct nb_node *nb_node, enum nb_event event,
 			    const struct lyd_node *dnode)
 {
+	struct nb_cb_move_args args = {};
+
 	nb_log_config_callback(event, NB_OP_MOVE, dnode);
 
-	return nb_node->cbs.move(event, dnode);
+	args.event = event;
+	args.dnode = dnode;
+	return nb_node->cbs.move(&args);
 }
 
 static int nb_callback_pre_validate(const struct nb_node *nb_node,
 				    const struct lyd_node *dnode)
 {
+	struct nb_cb_pre_validate_args args = {};
+
 	nb_log_config_callback(NB_EV_VALIDATE, NB_OP_PRE_VALIDATE, dnode);
 
-	return nb_node->cbs.pre_validate(dnode);
+	args.dnode = dnode;
+	return nb_node->cbs.pre_validate(&args);
 }
 
 static void nb_callback_apply_finish(const struct nb_node *nb_node,
 				     const struct lyd_node *dnode)
 {
+	struct nb_cb_apply_finish_args args = {};
+
 	nb_log_config_callback(NB_EV_APPLY, NB_OP_APPLY_FINISH, dnode);
 
-	nb_node->cbs.apply_finish(dnode);
+	args.dnode = dnode;
+	nb_node->cbs.apply_finish(&args);
 }
 
 struct yang_data *nb_callback_get_elem(const struct nb_node *nb_node,
 				       const char *xpath,
 				       const void *list_entry)
 {
+	struct nb_cb_get_elem_args args = {};
+
 	DEBUGD(&nb_dbg_cbs_state,
 	       "northbound callback (get_elem): xpath [%s] list_entry [%p]",
 	       xpath, list_entry);
 
-	return nb_node->cbs.get_elem(xpath, list_entry);
+	args.xpath = xpath;
+	args.list_entry = list_entry;
+	return nb_node->cbs.get_elem(&args);
 }
 
 const void *nb_callback_get_next(const struct nb_node *nb_node,
 				 const void *parent_list_entry,
 				 const void *list_entry)
 {
+	struct nb_cb_get_next_args args = {};
+
 	DEBUGD(&nb_dbg_cbs_state,
 	       "northbound callback (get_next): node [%s] parent_list_entry [%p] list_entry [%p]",
 	       nb_node->xpath, parent_list_entry, list_entry);
 
-	return nb_node->cbs.get_next(parent_list_entry, list_entry);
+	args.parent_list_entry = parent_list_entry;
+	args.list_entry = list_entry;
+	return nb_node->cbs.get_next(&args);
 }
 
 int nb_callback_get_keys(const struct nb_node *nb_node, const void *list_entry,
 			 struct yang_list_keys *keys)
 {
+	struct nb_cb_get_keys_args args = {};
+
 	DEBUGD(&nb_dbg_cbs_state,
 	       "northbound callback (get_keys): node [%s] list_entry [%p]",
 	       nb_node->xpath, list_entry);
 
-	return nb_node->cbs.get_keys(list_entry, keys);
+	args.list_entry = list_entry;
+	args.keys = keys;
+	return nb_node->cbs.get_keys(&args);
 }
 
 const void *nb_callback_lookup_entry(const struct nb_node *nb_node,
 				     const void *parent_list_entry,
 				     const struct yang_list_keys *keys)
 {
+	struct nb_cb_lookup_entry_args args = {};
+
 	DEBUGD(&nb_dbg_cbs_state,
 	       "northbound callback (lookup_entry): node [%s] parent_list_entry [%p]",
 	       nb_node->xpath, parent_list_entry);
 
-	return nb_node->cbs.lookup_entry(parent_list_entry, keys);
+	args.parent_list_entry = parent_list_entry;
+	args.keys = keys;
+	return nb_node->cbs.lookup_entry(&args);
 }
 
 int nb_callback_rpc(const struct nb_node *nb_node, const char *xpath,
 		    const struct list *input, struct list *output)
 {
+	struct nb_cb_rpc_args args = {};
+
 	DEBUGD(&nb_dbg_cbs_rpc, "northbound RPC: %s", xpath);
 
-	return nb_node->cbs.rpc(xpath, input, output);
+	args.xpath = xpath;
+	args.input = input;
+	args.output = output;
+	return nb_node->cbs.rpc(&args);
 }
 
 /*

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -86,6 +86,129 @@ union nb_resource {
 	void *ptr;
 };
 
+/*
+ * Northbound callbacks parameters.
+ */
+
+struct nb_cb_create_args {
+	/*
+	 * The transaction phase. Refer to the documentation comments of
+	 * nb_event for more details.
+	 */
+	enum nb_event event;
+
+	/* libyang data node that is being created. */
+	const struct lyd_node *dnode;
+
+	/*
+	 * Pointer to store resource(s) allocated during the NB_EV_PREPARE
+	 * phase. The same pointer can be used during the NB_EV_ABORT and
+	 * NB_EV_APPLY phases to either release or make use of the allocated
+	 * resource(s). It's set to NULL when the event is NB_EV_VALIDATE.
+	 */
+	union nb_resource *resource;
+};
+
+struct nb_cb_modify_args {
+	/*
+	 * The transaction phase. Refer to the documentation comments of
+	 * nb_event for more details.
+	 */
+	enum nb_event event;
+
+	/* libyang data node that is being modified. */
+	const struct lyd_node *dnode;
+
+	/*
+	 * Pointer to store resource(s) allocated during the NB_EV_PREPARE
+	 * phase. The same pointer can be used during the NB_EV_ABORT and
+	 * NB_EV_APPLY phases to either release or make use of the allocated
+	 * resource(s). It's set to NULL when the event is NB_EV_VALIDATE.
+	 */
+	union nb_resource *resource;
+};
+
+struct nb_cb_destroy_args {
+	/*
+	 * The transaction phase. Refer to the documentation comments of
+	 * nb_event for more details.
+	 */
+	enum nb_event event;
+
+	/* libyang data node that is being deleted. */
+	const struct lyd_node *dnode;
+};
+
+struct nb_cb_move_args {
+	/*
+	 * The transaction phase. Refer to the documentation comments of
+	 * nb_event for more details.
+	 */
+	enum nb_event event;
+
+	/* libyang data node that is being moved. */
+	const struct lyd_node *dnode;
+};
+
+struct nb_cb_pre_validate_args {
+	/* libyang data node associated with the 'pre_validate' callback. */
+	const struct lyd_node *dnode;
+};
+
+struct nb_cb_apply_finish_args {
+	/* libyang data node associated with the 'apply_finish' callback. */
+	const struct lyd_node *dnode;
+};
+
+struct nb_cb_get_elem_args {
+	/* YANG data path of the data we want to get. */
+	const char *xpath;
+
+	/* Pointer to list entry (might be NULL). */
+	const void *list_entry;
+};
+
+struct nb_cb_get_next_args {
+	/* Pointer to parent list entry. */
+	const void *parent_list_entry;
+
+	/* Pointer to (leaf-)list entry. */
+	const void *list_entry;
+};
+
+struct nb_cb_get_keys_args {
+	/* Pointer to list entry. */
+	const void *list_entry;
+
+	/*
+	 * Structure to be filled based on the attributes of the provided list
+	 * entry.
+	 */
+	struct yang_list_keys *keys;
+};
+
+struct nb_cb_lookup_entry_args {
+	/* Pointer to parent list entry. */
+	const void *parent_list_entry;
+
+	/* Structure containing the keys of the list entry. */
+	const struct yang_list_keys *keys;
+};
+
+struct nb_cb_rpc_args {
+	/* XPath of the YANG RPC or action. */
+	const char *xpath;
+
+	/* Read-only list of input parameters. */
+	const struct list *input;
+
+	/* List of output parameters to be populated by the callback. */
+	struct list *output;
+};
+
+/*
+ * Set of configuration callbacks that can be associated to a northbound node.
+ */
 struct nb_callbacks {
 	/*
 	 * Configuration callback.
@@ -97,18 +220,9 @@ struct nb_callbacks {
 	 * initialize the default values of its children (if any) from the YANG
 	 * models.
 	 *
-	 * event
-	 *    The transaction phase. Refer to the documentation comments of
-	 *    nb_event for more details.
-	 *
-	 * dnode
-	 *    libyang data node that is being created.
-	 *
-	 * resource
-	 *    Pointer to store resource(s) allocated during the NB_EV_PREPARE
-	 *    phase. The same pointer can be used during the NB_EV_ABORT and
-	 *    NB_EV_APPLY phases to either release or make use of the allocated
-	 *    resource(s). It's set to NULL when the event is NB_EV_VALIDATE.
+	 * args
+	 *    Refer to the documentation comments of nb_cb_create_args for
+	 *    details.
 	 *
 	 * Returns:
 	 *    - NB_OK on success.
@@ -117,8 +231,7 @@ struct nb_callbacks {
 	 *    - NB_ERR_INCONSISTENCY when an inconsistency was detected.
 	 *    - NB_ERR for other errors.
 	 */
-	int (*create)(enum nb_event event, const struct lyd_node *dnode,
-		      union nb_resource *resource);
+	int (*create)(struct nb_cb_create_args *args);
 
 	/*
 	 * Configuration callback.
@@ -129,18 +242,9 @@ struct nb_callbacks {
 	 * modified, the northbound treats this as if the list was deleted and a
 	 * new one created with the updated key value.
 	 *
-	 * event
-	 *    The transaction phase. Refer to the documentation comments of
-	 *    nb_event for more details.
-	 *
-	 * dnode
-	 *    libyang data node that is being modified
-	 *
-	 * resource
-	 *    Pointer to store resource(s) allocated during the NB_EV_PREPARE
-	 *    phase. The same pointer can be used during the NB_EV_ABORT and
-	 *    NB_EV_APPLY phases to either release or make use of the allocated
-	 *    resource(s). It's set to NULL when the event is NB_EV_VALIDATE.
+	 * args
+	 *    Refer to the documentation comments of nb_cb_modify_args for
+	 *    details.
 	 *
 	 * Returns:
 	 *    - NB_OK on success.
@@ -149,8 +253,7 @@ struct nb_callbacks {
 	 *    - NB_ERR_INCONSISTENCY when an inconsistency was detected.
 	 *    - NB_ERR for other errors.
 	 */
-	int (*modify)(enum nb_event event, const struct lyd_node *dnode,
-		      union nb_resource *resource);
+	int (*modify)(struct nb_cb_modify_args *args);
 
 	/*
 	 * Configuration callback.
@@ -161,12 +264,9 @@ struct nb_callbacks {
 	 * The callback is supposed to delete the entire configuration object,
 	 * including its children when they exist.
 	 *
-	 * event
-	 *    The transaction phase. Refer to the documentation comments of
-	 *    nb_event for more details.
-	 *
-	 * dnode
-	 *    libyang data node that is being deleted.
+	 * args
+	 *    Refer to the documentation comments of nb_cb_destroy_args for
+	 *    details.
 	 *
 	 * Returns:
 	 *    - NB_OK on success.
@@ -174,7 +274,7 @@ struct nb_callbacks {
 	 *    - NB_ERR_INCONSISTENCY when an inconsistency was detected.
 	 *    - NB_ERR for other errors.
 	 */
-	int (*destroy)(enum nb_event event, const struct lyd_node *dnode);
+	int (*destroy)(struct nb_cb_destroy_args *args);
 
 	/*
 	 * Configuration callback.
@@ -182,12 +282,9 @@ struct nb_callbacks {
 	 * A list entry or leaf-list entry has been moved. Only applicable when
 	 * the "ordered-by user" statement is present.
 	 *
-	 * event
-	 *    The transaction phase. Refer to the documentation comments of
-	 *    nb_event for more details.
-	 *
-	 * dnode
-	 *    libyang data node that is being moved.
+	 * args
+	 *    Refer to the documentation comments of nb_cb_move_args for
+	 *    details.
 	 *
 	 * Returns:
 	 *    - NB_OK on success.
@@ -195,7 +292,7 @@ struct nb_callbacks {
 	 *    - NB_ERR_INCONSISTENCY when an inconsistency was detected.
 	 *    - NB_ERR for other errors.
 	 */
-	int (*move)(enum nb_event event, const struct lyd_node *dnode);
+	int (*move)(struct nb_cb_move_args *args);
 
 	/*
 	 * Optional configuration callback.
@@ -205,10 +302,11 @@ struct nb_callbacks {
 	 * changes themselves. It's useful to perform more complex validations
 	 * that depend on the relationship between multiple nodes.
 	 *
-	 * dnode
-	 *    libyang data node associated with the 'pre_validate' callback.
+	 * args
+	 *    Refer to the documentation comments of nb_cb_pre_validate_args for
+	 *    details.
 	 */
-	int (*pre_validate)(const struct lyd_node *dnode);
+	int (*pre_validate)(struct nb_cb_pre_validate_args *args);
 
 	/*
 	 * Optional configuration callback.
@@ -224,10 +322,11 @@ struct nb_callbacks {
 	 * once even if multiple changes occurred within the descendants of the
 	 * data node.
 	 *
-	 * dnode
-	 *    libyang data node associated with the 'apply_finish' callback.
+	 * args
+	 *    Refer to the documentation comments of nb_cb_apply_finish_args for
+	 *    details.
 	 */
-	void (*apply_finish)(const struct lyd_node *dnode);
+	void (*apply_finish)(struct nb_cb_apply_finish_args *args);
 
 	/*
 	 * Operational data callback.
@@ -236,18 +335,15 @@ struct nb_callbacks {
 	 * leaf-list entry or inform if a typeless value (presence containers or
 	 * leafs of type empty) exists or not.
 	 *
-	 * xpath
-	 *    YANG data path of the data we want to get.
-	 *
-	 * list_entry
-	 *    Pointer to list entry (might be NULL).
+	 * args
+	 *    Refer to the documentation comments of nb_cb_get_elem_args for
+	 *    details.
 	 *
 	 * Returns:
 	 *    Pointer to newly created yang_data structure, or NULL to indicate
 	 *    the absence of data.
 	 */
-	struct yang_data *(*get_elem)(const char *xpath,
-				      const void *list_entry);
+	struct yang_data *(*get_elem)(struct nb_cb_get_elem_args *args);
 
 	/*
 	 * Operational data callback for YANG lists and leaf-lists.
@@ -256,18 +352,15 @@ struct nb_callbacks {
 	 * leaf-list. The 'list_entry' parameter will be NULL on the first
 	 * invocation.
 	 *
-	 * parent_list_entry
-	 *    Pointer to parent list entry.
-	 *
-	 * list_entry
-	 *    Pointer to (leaf-)list entry.
+	 * args
+	 *    Refer to the documentation comments of nb_cb_get_next_args for
+	 *    details.
 	 *
 	 * Returns:
 	 *    Pointer to the next entry in the (leaf-)list, or NULL to signal
 	 *    that the end of the (leaf-)list was reached.
 	 */
-	const void *(*get_next)(const void *parent_list_entry,
-				const void *list_entry);
+	const void *(*get_next)(struct nb_cb_get_next_args *args);
 
 	/*
 	 * Operational data callback for YANG lists.
@@ -276,17 +369,14 @@ struct nb_callbacks {
 	 * given list_entry. Keyless lists don't need to implement this
 	 * callback.
 	 *
-	 * list_entry
-	 *    Pointer to list entry.
-	 *
-	 * keys
-	 *    Structure to be filled based on the attributes of the provided
-	 *    list entry.
+	 * args
+	 *    Refer to the documentation comments of nb_cb_get_keys_args for
+	 *    details.
 	 *
 	 * Returns:
 	 *    NB_OK on success, NB_ERR otherwise.
 	 */
-	int (*get_keys)(const void *list_entry, struct yang_list_keys *keys);
+	int (*get_keys)(struct nb_cb_get_keys_args *args);
 
 	/*
 	 * Operational data callback for YANG lists.
@@ -295,17 +385,14 @@ struct nb_callbacks {
 	 * keys given as a parameter. Keyless lists don't need to implement this
 	 * callback.
 	 *
-	 * parent_list_entry
-	 *    Pointer to parent list entry.
-	 *
-	 * keys
-	 *    Structure containing the keys of the list entry.
+	 * args
+	 *    Refer to the documentation comments of nb_cb_lookup_entry_args for
+	 *    details.
 	 *
 	 * Returns:
 	 *    Pointer to the list entry if found, or NULL if not found.
 	 */
-	const void *(*lookup_entry)(const void *parent_list_entry,
-				    const struct yang_list_keys *keys);
+	const void *(*lookup_entry)(struct nb_cb_lookup_entry_args *args);
 
 	/*
 	 * RPC and action callback.
@@ -314,20 +401,13 @@ struct nb_callbacks {
 	 * callback should fetch all the input parameters from the 'input' list,
 	 * and add output parameters to the 'output' list if necessary.
 	 *
-	 * xpath
-	 *    XPath of the YANG RPC or action.
-	 *
-	 * input
-	 *    Read-only list of input parameters.
-	 *
-	 * output
-	 *    List of output parameters to be populated by the callback.
+	 * args
+	 *    Refer to the documentation comments of nb_cb_rpc_args for details.
 	 *
 	 * Returns:
 	 *    NB_OK on success, NB_ERR otherwise.
 	 */
-	int (*rpc)(const char *xpath, const struct list *input,
-		   struct list *output);
+	int (*rpc)(struct nb_cb_rpc_args *args);
 
 	/*
 	 * Optional callback to show the CLI command associated to the given

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -545,7 +545,8 @@ class NorthboundImpl final : public frr::Northbound::Service
 		}
 
 		// Execute callback registered for this XPath.
-		if (nb_node->cbs.rpc(xpath, input_list, output_list) != NB_OK) {
+		if (nb_callback_rpc(nb_node, xpath, input_list, output_list)
+		    != NB_OK) {
 			flog_warn(EC_LIB_NB_CB_RPC,
 				  "%s: rpc callback failed: %s", __func__,
 				  xpath);

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -681,10 +681,8 @@ struct routemap_hook_context {
 	TAILQ_ENTRY(routemap_hook_context) rhc_entry;
 };
 
-int lib_route_map_entry_match_destroy(enum nb_event event,
-				      const struct lyd_node *dnode);
-int lib_route_map_entry_set_destroy(enum nb_event event,
-				    const struct lyd_node *dnode);
+int lib_route_map_entry_match_destroy(struct nb_cb_destroy_args *args);
+int lib_route_map_entry_set_destroy(struct nb_cb_destroy_args *args);
 
 struct routemap_hook_context *
 routemap_hook_context_insert(struct route_map_index *rmi);

--- a/ripd/rip_nb.h
+++ b/ripd/rip_nb.h
@@ -23,186 +23,109 @@
 extern const struct frr_yang_module_info frr_ripd_info;
 
 /* Mandatory callbacks. */
-int ripd_instance_create(enum nb_event event, const struct lyd_node *dnode,
-			 union nb_resource *resource);
-int ripd_instance_destroy(enum nb_event event, const struct lyd_node *dnode);
-const void *ripd_instance_get_next(const void *parent_list_entry,
-				   const void *list_entry);
-int ripd_instance_get_keys(const void *list_entry, struct yang_list_keys *keys);
-const void *ripd_instance_lookup_entry(const void *parent_list_entry,
-				       const struct yang_list_keys *keys);
-int ripd_instance_allow_ecmp_modify(enum nb_event event,
-				    const struct lyd_node *dnode,
-				    union nb_resource *resource);
+int ripd_instance_create(struct nb_cb_create_args *args);
+int ripd_instance_destroy(struct nb_cb_destroy_args *args);
+const void *ripd_instance_get_next(struct nb_cb_get_next_args *args);
+int ripd_instance_get_keys(struct nb_cb_get_keys_args *args);
+const void *ripd_instance_lookup_entry(struct nb_cb_lookup_entry_args *args);
+int ripd_instance_allow_ecmp_modify(struct nb_cb_modify_args *args);
 int ripd_instance_default_information_originate_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int ripd_instance_default_metric_modify(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource);
-int ripd_instance_distance_default_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource);
-int ripd_instance_distance_source_create(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource);
-int ripd_instance_distance_source_destroy(enum nb_event event,
-					  const struct lyd_node *dnode);
-int ripd_instance_distance_source_distance_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource);
+	struct nb_cb_modify_args *args);
+int ripd_instance_default_metric_modify(struct nb_cb_modify_args *args);
+int ripd_instance_distance_default_modify(struct nb_cb_modify_args *args);
+int ripd_instance_distance_source_create(struct nb_cb_create_args *args);
+int ripd_instance_distance_source_destroy(struct nb_cb_destroy_args *args);
+int ripd_instance_distance_source_distance_modify(
+	struct nb_cb_modify_args *args);
 int ripd_instance_distance_source_access_list_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int ripd_instance_distance_source_access_list_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
-int ripd_instance_explicit_neighbor_create(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource);
-int ripd_instance_explicit_neighbor_destroy(enum nb_event event,
-					    const struct lyd_node *dnode);
-int ripd_instance_network_create(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource);
-int ripd_instance_network_destroy(enum nb_event event,
-				  const struct lyd_node *dnode);
-int ripd_instance_interface_create(enum nb_event event,
-				   const struct lyd_node *dnode,
-				   union nb_resource *resource);
-int ripd_instance_interface_destroy(enum nb_event event,
-				    const struct lyd_node *dnode);
-int ripd_instance_offset_list_create(enum nb_event event,
-				     const struct lyd_node *dnode,
-				     union nb_resource *resource);
-int ripd_instance_offset_list_destroy(enum nb_event event,
-				      const struct lyd_node *dnode);
-int ripd_instance_offset_list_access_list_modify(enum nb_event event,
-						 const struct lyd_node *dnode,
-						 union nb_resource *resource);
-int ripd_instance_offset_list_metric_modify(enum nb_event event,
-					    const struct lyd_node *dnode,
-					    union nb_resource *resource);
-int ripd_instance_passive_default_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource);
-int ripd_instance_passive_interface_create(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource);
-int ripd_instance_passive_interface_destroy(enum nb_event event,
-					    const struct lyd_node *dnode);
-int ripd_instance_non_passive_interface_create(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource);
-int ripd_instance_non_passive_interface_destroy(enum nb_event event,
-						const struct lyd_node *dnode);
-int ripd_instance_redistribute_create(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource);
-int ripd_instance_redistribute_destroy(enum nb_event event,
-				       const struct lyd_node *dnode);
-int ripd_instance_redistribute_route_map_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource);
-int ripd_instance_redistribute_route_map_destroy(enum nb_event event,
-						 const struct lyd_node *dnode);
-int ripd_instance_redistribute_metric_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
-int ripd_instance_redistribute_metric_destroy(enum nb_event event,
-					      const struct lyd_node *dnode);
-int ripd_instance_static_route_create(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource);
-int ripd_instance_static_route_destroy(enum nb_event event,
-				       const struct lyd_node *dnode);
-int ripd_instance_timers_flush_interval_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource);
-int ripd_instance_timers_holddown_interval_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource);
-int ripd_instance_timers_update_interval_modify(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource);
-int ripd_instance_version_receive_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource);
-int ripd_instance_version_send_modify(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource);
-const void *
-ripd_instance_state_neighbors_neighbor_get_next(const void *parent_list_entry,
-						const void *list_entry);
+	struct nb_cb_destroy_args *args);
+int ripd_instance_explicit_neighbor_create(struct nb_cb_create_args *args);
+int ripd_instance_explicit_neighbor_destroy(struct nb_cb_destroy_args *args);
+int ripd_instance_network_create(struct nb_cb_create_args *args);
+int ripd_instance_network_destroy(struct nb_cb_destroy_args *args);
+int ripd_instance_interface_create(struct nb_cb_create_args *args);
+int ripd_instance_interface_destroy(struct nb_cb_destroy_args *args);
+int ripd_instance_offset_list_create(struct nb_cb_create_args *args);
+int ripd_instance_offset_list_destroy(struct nb_cb_destroy_args *args);
+int ripd_instance_offset_list_access_list_modify(
+	struct nb_cb_modify_args *args);
+int ripd_instance_offset_list_metric_modify(struct nb_cb_modify_args *args);
+int ripd_instance_passive_default_modify(struct nb_cb_modify_args *args);
+int ripd_instance_passive_interface_create(struct nb_cb_create_args *args);
+int ripd_instance_passive_interface_destroy(struct nb_cb_destroy_args *args);
+int ripd_instance_non_passive_interface_create(struct nb_cb_create_args *args);
+int ripd_instance_non_passive_interface_destroy(
+	struct nb_cb_destroy_args *args);
+int ripd_instance_redistribute_create(struct nb_cb_create_args *args);
+int ripd_instance_redistribute_destroy(struct nb_cb_destroy_args *args);
+int ripd_instance_redistribute_route_map_modify(struct nb_cb_modify_args *args);
+int ripd_instance_redistribute_route_map_destroy(
+	struct nb_cb_destroy_args *args);
+int ripd_instance_redistribute_metric_modify(struct nb_cb_modify_args *args);
+int ripd_instance_redistribute_metric_destroy(struct nb_cb_destroy_args *args);
+int ripd_instance_static_route_create(struct nb_cb_create_args *args);
+int ripd_instance_static_route_destroy(struct nb_cb_destroy_args *args);
+int ripd_instance_timers_flush_interval_modify(struct nb_cb_modify_args *args);
+int ripd_instance_timers_holddown_interval_modify(
+	struct nb_cb_modify_args *args);
+int ripd_instance_timers_update_interval_modify(struct nb_cb_modify_args *args);
+int ripd_instance_version_receive_modify(struct nb_cb_modify_args *args);
+int ripd_instance_version_send_modify(struct nb_cb_modify_args *args);
+const void *ripd_instance_state_neighbors_neighbor_get_next(
+	struct nb_cb_get_next_args *args);
 int ripd_instance_state_neighbors_neighbor_get_keys(
-	const void *list_entry, struct yang_list_keys *keys);
+	struct nb_cb_get_keys_args *args);
 const void *ripd_instance_state_neighbors_neighbor_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys);
-struct yang_data *
-ripd_instance_state_neighbors_neighbor_address_get_elem(const char *xpath,
-							const void *list_entry);
+	struct nb_cb_lookup_entry_args *args);
+struct yang_data *ripd_instance_state_neighbors_neighbor_address_get_elem(
+	struct nb_cb_get_elem_args *args);
 struct yang_data *ripd_instance_state_neighbors_neighbor_last_update_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 ripd_instance_state_neighbors_neighbor_bad_packets_rcvd_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 ripd_instance_state_neighbors_neighbor_bad_routes_rcvd_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 const void *
-ripd_instance_state_routes_route_get_next(const void *parent_list_entry,
-					  const void *list_entry);
-int ripd_instance_state_routes_route_get_keys(const void *list_entry,
-					      struct yang_list_keys *keys);
+ripd_instance_state_routes_route_get_next(struct nb_cb_get_next_args *args);
+int ripd_instance_state_routes_route_get_keys(struct nb_cb_get_keys_args *args);
 const void *ripd_instance_state_routes_route_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys);
-struct yang_data *
-ripd_instance_state_routes_route_prefix_get_elem(const char *xpath,
-						 const void *list_entry);
-struct yang_data *
-ripd_instance_state_routes_route_next_hop_get_elem(const char *xpath,
-						   const void *list_entry);
-struct yang_data *
-ripd_instance_state_routes_route_interface_get_elem(const char *xpath,
-						    const void *list_entry);
-struct yang_data *
-ripd_instance_state_routes_route_metric_get_elem(const char *xpath,
-						 const void *list_entry);
-int clear_rip_route_rpc(const char *xpath, const struct list *input,
-			struct list *output);
-int lib_interface_rip_split_horizon_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource);
-int lib_interface_rip_v2_broadcast_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource);
-int lib_interface_rip_version_receive_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
-int lib_interface_rip_version_send_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource);
+	struct nb_cb_lookup_entry_args *args);
+struct yang_data *ripd_instance_state_routes_route_prefix_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *ripd_instance_state_routes_route_next_hop_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *ripd_instance_state_routes_route_interface_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *ripd_instance_state_routes_route_metric_get_elem(
+	struct nb_cb_get_elem_args *args);
+int clear_rip_route_rpc(struct nb_cb_rpc_args *args);
+int lib_interface_rip_split_horizon_modify(struct nb_cb_modify_args *args);
+int lib_interface_rip_v2_broadcast_modify(struct nb_cb_modify_args *args);
+int lib_interface_rip_version_receive_modify(struct nb_cb_modify_args *args);
+int lib_interface_rip_version_send_modify(struct nb_cb_modify_args *args);
 int lib_interface_rip_authentication_scheme_mode_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_rip_authentication_scheme_md5_auth_length_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_rip_authentication_scheme_md5_auth_length_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int lib_interface_rip_authentication_password_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_rip_authentication_password_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int lib_interface_rip_authentication_key_chain_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_interface_rip_authentication_key_chain_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 
 /* Optional 'apply_finish' callbacks. */
-void ripd_instance_redistribute_apply_finish(const struct lyd_node *dnode);
-void ripd_instance_timers_apply_finish(const struct lyd_node *dnode);
+void ripd_instance_redistribute_apply_finish(
+	struct nb_cb_apply_finish_args *args);
+void ripd_instance_timers_apply_finish(struct nb_cb_apply_finish_args *args);
 
 /* Optional 'cli_show' callbacks. */
 void cli_show_router_rip(struct vty *vty, struct lyd_node *dnode,

--- a/ripd/rip_nb_rpcs.c
+++ b/ripd/rip_nb_rpcs.c
@@ -78,13 +78,13 @@ static void clear_rip_route(struct rip *rip)
 	}
 }
 
-int clear_rip_route_rpc(const char *xpath, const struct list *input,
-			struct list *output)
+int clear_rip_route_rpc(struct nb_cb_rpc_args *args)
 {
 	struct rip *rip;
 	struct yang_data *yang_vrf;
 
-	yang_vrf = yang_data_list_find(input, "%s/%s", xpath, "input/vrf");
+	yang_vrf = yang_data_list_find(args->input, "%s/%s", args->xpath,
+				       "input/vrf");
 	if (yang_vrf) {
 		rip = rip_lookup_by_vrf_name(yang_vrf->value);
 		if (rip)

--- a/ripd/rip_nb_state.c
+++ b/ripd/rip_nb_state.c
@@ -37,12 +37,11 @@
 /*
  * XPath: /frr-ripd:ripd/instance
  */
-const void *ripd_instance_get_next(const void *parent_list_entry,
-				   const void *list_entry)
+const void *ripd_instance_get_next(struct nb_cb_get_next_args *args)
 {
-	struct rip *rip = (struct rip *)list_entry;
+	struct rip *rip = (struct rip *)args->list_entry;
 
-	if (list_entry == NULL)
+	if (args->list_entry == NULL)
 		rip = RB_MIN(rip_instance_head, &rip_instances);
 	else
 		rip = RB_NEXT(rip_instance_head, rip);
@@ -50,20 +49,19 @@ const void *ripd_instance_get_next(const void *parent_list_entry,
 	return rip;
 }
 
-int ripd_instance_get_keys(const void *list_entry, struct yang_list_keys *keys)
+int ripd_instance_get_keys(struct nb_cb_get_keys_args *args)
 {
-	const struct rip *rip = list_entry;
+	const struct rip *rip = args->list_entry;
 
-	keys->num = 1;
-	strlcpy(keys->key[0], rip->vrf_name, sizeof(keys->key[0]));
+	args->keys->num = 1;
+	strlcpy(args->keys->key[0], rip->vrf_name, sizeof(args->keys->key[0]));
 
 	return NB_OK;
 }
 
-const void *ripd_instance_lookup_entry(const void *parent_list_entry,
-				       const struct yang_list_keys *keys)
+const void *ripd_instance_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
-	const char *vrf_name = keys->key[0];
+	const char *vrf_name = args->keys->key[0];
 
 	return rip_lookup_by_vrf_name(vrf_name);
 }
@@ -71,43 +69,42 @@ const void *ripd_instance_lookup_entry(const void *parent_list_entry,
 /*
  * XPath: /frr-ripd:ripd/instance/state/neighbors/neighbor
  */
-const void *
-ripd_instance_state_neighbors_neighbor_get_next(const void *parent_list_entry,
-						const void *list_entry)
+const void *ripd_instance_state_neighbors_neighbor_get_next(
+	struct nb_cb_get_next_args *args)
 {
-	const struct rip *rip = parent_list_entry;
+	const struct rip *rip = args->parent_list_entry;
 	struct listnode *node;
 
-	if (list_entry == NULL)
+	if (args->list_entry == NULL)
 		node = listhead(rip->peer_list);
 	else
-		node = listnextnode((struct listnode *)list_entry);
+		node = listnextnode((struct listnode *)args->list_entry);
 
 	return node;
 }
 
-int ripd_instance_state_neighbors_neighbor_get_keys(const void *list_entry,
-						    struct yang_list_keys *keys)
+int ripd_instance_state_neighbors_neighbor_get_keys(
+	struct nb_cb_get_keys_args *args)
 {
-	const struct listnode *node = list_entry;
+	const struct listnode *node = args->list_entry;
 	const struct rip_peer *peer = listgetdata(node);
 
-	keys->num = 1;
-	(void)inet_ntop(AF_INET, &peer->addr, keys->key[0],
-			sizeof(keys->key[0]));
+	args->keys->num = 1;
+	(void)inet_ntop(AF_INET, &peer->addr, args->keys->key[0],
+			sizeof(args->keys->key[0]));
 
 	return NB_OK;
 }
 
 const void *ripd_instance_state_neighbors_neighbor_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys)
+	struct nb_cb_lookup_entry_args *args)
 {
-	const struct rip *rip = parent_list_entry;
+	const struct rip *rip = args->parent_list_entry;
 	struct in_addr address;
 	struct rip_peer *peer;
 	struct listnode *node;
 
-	yang_str2ipv4(keys->key[0], &address);
+	yang_str2ipv4(args->keys->key[0], &address);
 
 	for (ALL_LIST_ELEMENTS_RO(rip->peer_list, node, peer)) {
 		if (IPV4_ADDR_SAME(&peer->addr, &address))
@@ -120,21 +117,20 @@ const void *ripd_instance_state_neighbors_neighbor_lookup_entry(
 /*
  * XPath: /frr-ripd:ripd/instance/state/neighbors/neighbor/address
  */
-struct yang_data *
-ripd_instance_state_neighbors_neighbor_address_get_elem(const char *xpath,
-							const void *list_entry)
+struct yang_data *ripd_instance_state_neighbors_neighbor_address_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct listnode *node = list_entry;
+	const struct listnode *node = args->list_entry;
 	const struct rip_peer *peer = listgetdata(node);
 
-	return yang_data_new_ipv4(xpath, &peer->addr);
+	return yang_data_new_ipv4(args->xpath, &peer->addr);
 }
 
 /*
  * XPath: /frr-ripd:ripd/instance/state/neighbors/neighbor/last-update
  */
 struct yang_data *ripd_instance_state_neighbors_neighbor_last_update_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: yang:date-and-time is tricky */
 	return NULL;
@@ -145,12 +141,12 @@ struct yang_data *ripd_instance_state_neighbors_neighbor_last_update_get_elem(
  */
 struct yang_data *
 ripd_instance_state_neighbors_neighbor_bad_packets_rcvd_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct listnode *node = list_entry;
+	const struct listnode *node = args->list_entry;
 	const struct rip_peer *peer = listgetdata(node);
 
-	return yang_data_new_uint32(xpath, peer->recv_badpackets);
+	return yang_data_new_uint32(args->xpath, peer->recv_badpackets);
 }
 
 /*
@@ -158,54 +154,52 @@ ripd_instance_state_neighbors_neighbor_bad_packets_rcvd_get_elem(
  */
 struct yang_data *
 ripd_instance_state_neighbors_neighbor_bad_routes_rcvd_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct listnode *node = list_entry;
+	const struct listnode *node = args->list_entry;
 	const struct rip_peer *peer = listgetdata(node);
 
-	return yang_data_new_uint32(xpath, peer->recv_badroutes);
+	return yang_data_new_uint32(args->xpath, peer->recv_badroutes);
 }
 
 /*
  * XPath: /frr-ripd:ripd/instance/state/routes/route
  */
 const void *
-ripd_instance_state_routes_route_get_next(const void *parent_list_entry,
-					  const void *list_entry)
+ripd_instance_state_routes_route_get_next(struct nb_cb_get_next_args *args)
 {
-	const struct rip *rip = parent_list_entry;
+	const struct rip *rip = args->parent_list_entry;
 	struct route_node *rn;
 
-	if (list_entry == NULL)
+	if (args->list_entry == NULL)
 		rn = route_top(rip->table);
 	else
-		rn = route_next((struct route_node *)list_entry);
+		rn = route_next((struct route_node *)args->list_entry);
 	while (rn && rn->info == NULL)
 		rn = route_next(rn);
 
 	return rn;
 }
 
-int ripd_instance_state_routes_route_get_keys(const void *list_entry,
-					      struct yang_list_keys *keys)
+int ripd_instance_state_routes_route_get_keys(struct nb_cb_get_keys_args *args)
 {
-	const struct route_node *rn = list_entry;
+	const struct route_node *rn = args->list_entry;
 
-	keys->num = 1;
-	(void)prefix2str(&rn->p, keys->key[0], sizeof(keys->key[0]));
+	args->keys->num = 1;
+	(void)prefix2str(&rn->p, args->keys->key[0],
+			 sizeof(args->keys->key[0]));
 
 	return NB_OK;
 }
 
-const void *
-ripd_instance_state_routes_route_lookup_entry(const void *parent_list_entry,
-					      const struct yang_list_keys *keys)
+const void *ripd_instance_state_routes_route_lookup_entry(
+	struct nb_cb_lookup_entry_args *args)
 {
-	const struct rip *rip = parent_list_entry;
+	const struct rip *rip = args->parent_list_entry;
 	struct prefix prefix;
 	struct route_node *rn;
 
-	yang_str2ipv4p(keys->key[0], &prefix);
+	yang_str2ipv4p(args->keys->key[0], &prefix);
 
 	rn = route_node_lookup(rip->table, &prefix);
 	if (!rn || !rn->info)
@@ -219,30 +213,28 @@ ripd_instance_state_routes_route_lookup_entry(const void *parent_list_entry,
 /*
  * XPath: /frr-ripd:ripd/instance/state/routes/route/prefix
  */
-struct yang_data *
-ripd_instance_state_routes_route_prefix_get_elem(const char *xpath,
-						 const void *list_entry)
+struct yang_data *ripd_instance_state_routes_route_prefix_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct route_node *rn = list_entry;
+	const struct route_node *rn = args->list_entry;
 	const struct rip_info *rinfo = listnode_head(rn->info);
 
-	return yang_data_new_ipv4p(xpath, &rinfo->rp->p);
+	return yang_data_new_ipv4p(args->xpath, &rinfo->rp->p);
 }
 
 /*
  * XPath: /frr-ripd:ripd/instance/state/routes/route/next-hop
  */
-struct yang_data *
-ripd_instance_state_routes_route_next_hop_get_elem(const char *xpath,
-						   const void *list_entry)
+struct yang_data *ripd_instance_state_routes_route_next_hop_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct route_node *rn = list_entry;
+	const struct route_node *rn = args->list_entry;
 	const struct rip_info *rinfo = listnode_head(rn->info);
 
 	switch (rinfo->nh.type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		return yang_data_new_ipv4(xpath, &rinfo->nh.gate.ipv4);
+		return yang_data_new_ipv4(args->xpath, &rinfo->nh.gate.ipv4);
 	default:
 		return NULL;
 	}
@@ -251,11 +243,10 @@ ripd_instance_state_routes_route_next_hop_get_elem(const char *xpath,
 /*
  * XPath: /frr-ripd:ripd/instance/state/routes/route/interface
  */
-struct yang_data *
-ripd_instance_state_routes_route_interface_get_elem(const char *xpath,
-						    const void *list_entry)
+struct yang_data *ripd_instance_state_routes_route_interface_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct route_node *rn = list_entry;
+	const struct route_node *rn = args->list_entry;
 	const struct rip_info *rinfo = listnode_head(rn->info);
 	const struct rip *rip = rip_info_get_instance(rinfo);
 
@@ -263,7 +254,7 @@ ripd_instance_state_routes_route_interface_get_elem(const char *xpath,
 	case NEXTHOP_TYPE_IFINDEX:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 		return yang_data_new_string(
-			xpath,
+			args->xpath,
 			ifindex2ifname(rinfo->nh.ifindex, rip->vrf->vrf_id));
 	default:
 		return NULL;
@@ -273,12 +264,11 @@ ripd_instance_state_routes_route_interface_get_elem(const char *xpath,
 /*
  * XPath: /frr-ripd:ripd/instance/state/routes/route/metric
  */
-struct yang_data *
-ripd_instance_state_routes_route_metric_get_elem(const char *xpath,
-						 const void *list_entry)
+struct yang_data *ripd_instance_state_routes_route_metric_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct route_node *rn = list_entry;
+	const struct route_node *rn = args->list_entry;
 	const struct rip_info *rinfo = listnode_head(rn->info);
 
-	return yang_data_new_uint8(xpath, rinfo->metric);
+	return yang_data_new_uint8(args->xpath, rinfo->metric);
 }

--- a/ripngd/ripng_nb.h
+++ b/ripngd/ripng_nb.h
@@ -23,129 +23,82 @@
 extern const struct frr_yang_module_info frr_ripngd_info;
 
 /* Mandatory callbacks. */
-int ripngd_instance_create(enum nb_event event, const struct lyd_node *dnode,
-			   union nb_resource *resource);
-int ripngd_instance_destroy(enum nb_event event, const struct lyd_node *dnode);
-const void *ripngd_instance_get_next(const void *parent_list_entry,
-				     const void *list_entry);
-int ripngd_instance_get_keys(const void *list_entry,
-			     struct yang_list_keys *keys);
-const void *ripngd_instance_lookup_entry(const void *parent_list_entry,
-					 const struct yang_list_keys *keys);
-int ripngd_instance_allow_ecmp_modify(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource);
+int ripngd_instance_create(struct nb_cb_create_args *args);
+int ripngd_instance_destroy(struct nb_cb_destroy_args *args);
+const void *ripngd_instance_get_next(struct nb_cb_get_next_args *args);
+int ripngd_instance_get_keys(struct nb_cb_get_keys_args *args);
+const void *ripngd_instance_lookup_entry(struct nb_cb_lookup_entry_args *args);
+int ripngd_instance_allow_ecmp_modify(struct nb_cb_modify_args *args);
 int ripngd_instance_default_information_originate_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int ripngd_instance_default_metric_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource);
-int ripngd_instance_network_create(enum nb_event event,
-				   const struct lyd_node *dnode,
-				   union nb_resource *resource);
-int ripngd_instance_network_destroy(enum nb_event event,
-				    const struct lyd_node *dnode);
-int ripngd_instance_interface_create(enum nb_event event,
-				     const struct lyd_node *dnode,
-				     union nb_resource *resource);
-int ripngd_instance_interface_destroy(enum nb_event event,
-				      const struct lyd_node *dnode);
-int ripngd_instance_offset_list_create(enum nb_event event,
-				       const struct lyd_node *dnode,
-				       union nb_resource *resource);
-int ripngd_instance_offset_list_destroy(enum nb_event event,
-					const struct lyd_node *dnode);
-int ripngd_instance_offset_list_access_list_modify(enum nb_event event,
-						   const struct lyd_node *dnode,
-						   union nb_resource *resource);
-int ripngd_instance_offset_list_metric_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource);
-int ripngd_instance_passive_interface_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
-int ripngd_instance_passive_interface_destroy(enum nb_event event,
-					      const struct lyd_node *dnode);
-int ripngd_instance_redistribute_create(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource);
-int ripngd_instance_redistribute_destroy(enum nb_event event,
-					 const struct lyd_node *dnode);
-int ripngd_instance_redistribute_route_map_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource);
+	struct nb_cb_modify_args *args);
+int ripngd_instance_default_metric_modify(struct nb_cb_modify_args *args);
+int ripngd_instance_network_create(struct nb_cb_create_args *args);
+int ripngd_instance_network_destroy(struct nb_cb_destroy_args *args);
+int ripngd_instance_interface_create(struct nb_cb_create_args *args);
+int ripngd_instance_interface_destroy(struct nb_cb_destroy_args *args);
+int ripngd_instance_offset_list_create(struct nb_cb_create_args *args);
+int ripngd_instance_offset_list_destroy(struct nb_cb_destroy_args *args);
+int ripngd_instance_offset_list_access_list_modify(
+	struct nb_cb_modify_args *args);
+int ripngd_instance_offset_list_metric_modify(struct nb_cb_modify_args *args);
+int ripngd_instance_passive_interface_create(struct nb_cb_create_args *args);
+int ripngd_instance_passive_interface_destroy(struct nb_cb_destroy_args *args);
+int ripngd_instance_redistribute_create(struct nb_cb_create_args *args);
+int ripngd_instance_redistribute_destroy(struct nb_cb_destroy_args *args);
+int ripngd_instance_redistribute_route_map_modify(
+	struct nb_cb_modify_args *args);
 int ripngd_instance_redistribute_route_map_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
-int ripngd_instance_redistribute_metric_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource);
-int ripngd_instance_redistribute_metric_destroy(enum nb_event event,
-						const struct lyd_node *dnode);
-int ripngd_instance_static_route_create(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource);
-int ripngd_instance_static_route_destroy(enum nb_event event,
-					 const struct lyd_node *dnode);
-int ripngd_instance_aggregate_address_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
-int ripngd_instance_aggregate_address_destroy(enum nb_event event,
-					      const struct lyd_node *dnode);
-int ripngd_instance_timers_flush_interval_modify(enum nb_event event,
-						 const struct lyd_node *dnode,
-						 union nb_resource *resource);
+	struct nb_cb_destroy_args *args);
+int ripngd_instance_redistribute_metric_modify(struct nb_cb_modify_args *args);
+int ripngd_instance_redistribute_metric_destroy(
+	struct nb_cb_destroy_args *args);
+int ripngd_instance_static_route_create(struct nb_cb_create_args *args);
+int ripngd_instance_static_route_destroy(struct nb_cb_destroy_args *args);
+int ripngd_instance_aggregate_address_create(struct nb_cb_create_args *args);
+int ripngd_instance_aggregate_address_destroy(struct nb_cb_destroy_args *args);
+int ripngd_instance_timers_flush_interval_modify(
+	struct nb_cb_modify_args *args);
 int ripngd_instance_timers_holddown_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int ripngd_instance_timers_update_interval_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource);
-const void *
-ripngd_instance_state_neighbors_neighbor_get_next(const void *parent_list_entry,
-						  const void *list_entry);
+	struct nb_cb_modify_args *args);
+int ripngd_instance_timers_update_interval_modify(
+	struct nb_cb_modify_args *args);
+const void *ripngd_instance_state_neighbors_neighbor_get_next(
+	struct nb_cb_get_next_args *args);
 int ripngd_instance_state_neighbors_neighbor_get_keys(
-	const void *list_entry, struct yang_list_keys *keys);
+	struct nb_cb_get_keys_args *args);
 const void *ripngd_instance_state_neighbors_neighbor_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys);
+	struct nb_cb_lookup_entry_args *args);
 struct yang_data *ripngd_instance_state_neighbors_neighbor_address_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *ripngd_instance_state_neighbors_neighbor_last_update_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 ripngd_instance_state_neighbors_neighbor_bad_packets_rcvd_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 ripngd_instance_state_neighbors_neighbor_bad_routes_rcvd_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 const void *
-ripngd_instance_state_routes_route_get_next(const void *parent_list_entry,
-					    const void *list_entry);
-int ripngd_instance_state_routes_route_get_keys(const void *list_entry,
-						struct yang_list_keys *keys);
+ripngd_instance_state_routes_route_get_next(struct nb_cb_get_next_args *args);
+int ripngd_instance_state_routes_route_get_keys(
+	struct nb_cb_get_keys_args *args);
 const void *ripngd_instance_state_routes_route_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys);
-struct yang_data *
-ripngd_instance_state_routes_route_prefix_get_elem(const char *xpath,
-						   const void *list_entry);
-struct yang_data *
-ripngd_instance_state_routes_route_next_hop_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *
-ripngd_instance_state_routes_route_interface_get_elem(const char *xpath,
-						      const void *list_entry);
-struct yang_data *
-ripngd_instance_state_routes_route_metric_get_elem(const char *xpath,
-						   const void *list_entry);
-int clear_ripng_route_rpc(const char *xpath, const struct list *input,
-			  struct list *output);
-int lib_interface_ripng_split_horizon_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
+	struct nb_cb_lookup_entry_args *args);
+struct yang_data *ripngd_instance_state_routes_route_prefix_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *ripngd_instance_state_routes_route_next_hop_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *ripngd_instance_state_routes_route_interface_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *ripngd_instance_state_routes_route_metric_get_elem(
+	struct nb_cb_get_elem_args *args);
+int clear_ripng_route_rpc(struct nb_cb_rpc_args *args);
+int lib_interface_ripng_split_horizon_modify(struct nb_cb_modify_args *args);
 
 /* Optional 'apply_finish' callbacks. */
-void ripngd_instance_redistribute_apply_finish(const struct lyd_node *dnode);
-void ripngd_instance_timers_apply_finish(const struct lyd_node *dnode);
+void ripngd_instance_redistribute_apply_finish(
+	struct nb_cb_apply_finish_args *args);
+void ripngd_instance_timers_apply_finish(struct nb_cb_apply_finish_args *args);
 
 /* Optional 'cli_show' callbacks. */
 void cli_show_router_ripng(struct vty *vty, struct lyd_node *dnode,

--- a/ripngd/ripng_nb_config.c
+++ b/ripngd/ripng_nb_config.c
@@ -39,22 +39,21 @@
 /*
  * XPath: /frr-ripngd:ripngd/instance
  */
-int ripngd_instance_create(enum nb_event event, const struct lyd_node *dnode,
-			   union nb_resource *resource)
+int ripngd_instance_create(struct nb_cb_create_args *args)
 {
 	struct ripng *ripng;
 	struct vrf *vrf;
 	const char *vrf_name;
 	int socket;
 
-	vrf_name = yang_dnode_get_string(dnode, "./vrf");
+	vrf_name = yang_dnode_get_string(args->dnode, "./vrf");
 	vrf = vrf_lookup_by_name(vrf_name);
 
 	/*
 	 * Try to create a RIPng socket only if the VRF is enabled, otherwise
 	 * create a disabled RIPng instance and wait for the VRF to be enabled.
 	 */
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		break;
 	case NB_EV_PREPARE:
@@ -64,48 +63,47 @@ int ripngd_instance_create(enum nb_event event, const struct lyd_node *dnode,
 		socket = ripng_make_socket(vrf);
 		if (socket < 0)
 			return NB_ERR_RESOURCE;
-		resource->fd = socket;
+		args->resource->fd = socket;
 		break;
 	case NB_EV_ABORT:
 		if (!vrf || !vrf_is_enabled(vrf))
 			break;
 
-		socket = resource->fd;
+		socket = args->resource->fd;
 		close(socket);
 		break;
 	case NB_EV_APPLY:
 		if (vrf && vrf_is_enabled(vrf))
-			socket = resource->fd;
+			socket = args->resource->fd;
 		else
 			socket = -1;
 
 		ripng = ripng_create(vrf_name, vrf, socket);
-		nb_running_set_entry(dnode, ripng);
+		nb_running_set_entry(args->dnode, ripng);
 		break;
 	}
 
 	return NB_OK;
 }
 
-int ripngd_instance_destroy(enum nb_event event, const struct lyd_node *dnode)
+int ripngd_instance_destroy(struct nb_cb_destroy_args *args)
 {
 	struct ripng *ripng;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_unset_entry(dnode);
+	ripng = nb_running_unset_entry(args->dnode);
 	ripng_clean(ripng);
 
 	return NB_OK;
 }
 
-const void *ripngd_instance_get_next(const void *parent_list_entry,
-				     const void *list_entry)
+const void *ripngd_instance_get_next(struct nb_cb_get_next_args *args)
 {
-	struct ripng *ripng = (struct ripng *)list_entry;
+	struct ripng *ripng = (struct ripng *)args->list_entry;
 
-	if (list_entry == NULL)
+	if (args->list_entry == NULL)
 		ripng = RB_MIN(ripng_instance_head, &ripng_instances);
 	else
 		ripng = RB_NEXT(ripng_instance_head, ripng);
@@ -113,21 +111,20 @@ const void *ripngd_instance_get_next(const void *parent_list_entry,
 	return ripng;
 }
 
-int ripngd_instance_get_keys(const void *list_entry,
-			     struct yang_list_keys *keys)
+int ripngd_instance_get_keys(struct nb_cb_get_keys_args *args)
 {
-	const struct ripng *ripng = list_entry;
+	const struct ripng *ripng = args->list_entry;
 
-	keys->num = 1;
-	strlcpy(keys->key[0], ripng->vrf_name, sizeof(keys->key[0]));
+	args->keys->num = 1;
+	strlcpy(args->keys->key[0], ripng->vrf_name,
+		sizeof(args->keys->key[0]));
 
 	return NB_OK;
 }
 
-const void *ripngd_instance_lookup_entry(const void *parent_list_entry,
-					 const struct yang_list_keys *keys)
+const void *ripngd_instance_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
-	const char *vrf_name = keys->key[0];
+	const char *vrf_name = args->keys->key[0];
 
 	return ripng_lookup_by_vrf_name(vrf_name);
 }
@@ -135,17 +132,15 @@ const void *ripngd_instance_lookup_entry(const void *parent_list_entry,
 /*
  * XPath: /frr-ripngd:ripngd/instance/allow-ecmp
  */
-int ripngd_instance_allow_ecmp_modify(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource)
+int ripngd_instance_allow_ecmp_modify(struct nb_cb_modify_args *args)
 {
 	struct ripng *ripng;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	ripng->ecmp = yang_dnode_get_bool(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	ripng->ecmp = yang_dnode_get_bool(args->dnode, NULL);
 	if (!ripng->ecmp)
 		ripng_ecmp_disable(ripng);
 
@@ -156,18 +151,17 @@ int ripngd_instance_allow_ecmp_modify(enum nb_event event,
  * XPath: /frr-ripngd:ripngd/instance/default-information-originate
  */
 int ripngd_instance_default_information_originate_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct ripng *ripng;
 	bool default_information;
 	struct prefix_ipv6 p;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	default_information = yang_dnode_get_bool(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	default_information = yang_dnode_get_bool(args->dnode, NULL);
 
 	str2prefix_ipv6("::/0", &p);
 	if (default_information) {
@@ -184,17 +178,15 @@ int ripngd_instance_default_information_originate_modify(
 /*
  * XPath: /frr-ripngd:ripngd/instance/default-metric
  */
-int ripngd_instance_default_metric_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource)
+int ripngd_instance_default_metric_modify(struct nb_cb_modify_args *args)
 {
 	struct ripng *ripng;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	ripng->default_metric = yang_dnode_get_uint8(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	ripng->default_metric = yang_dnode_get_uint8(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -202,34 +194,31 @@ int ripngd_instance_default_metric_modify(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/network
  */
-int ripngd_instance_network_create(enum nb_event event,
-				   const struct lyd_node *dnode,
-				   union nb_resource *resource)
+int ripngd_instance_network_create(struct nb_cb_create_args *args)
 {
 	struct ripng *ripng;
 	struct prefix p;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	yang_dnode_get_ipv6p(&p, dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	yang_dnode_get_ipv6p(&p, args->dnode, NULL);
 	apply_mask_ipv6((struct prefix_ipv6 *)&p);
 
 	return ripng_enable_network_add(ripng, &p);
 }
 
-int ripngd_instance_network_destroy(enum nb_event event,
-				    const struct lyd_node *dnode)
+int ripngd_instance_network_destroy(struct nb_cb_destroy_args *args)
 {
 	struct ripng *ripng;
 	struct prefix p;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	yang_dnode_get_ipv6p(&p, dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	yang_dnode_get_ipv6p(&p, args->dnode, NULL);
 	apply_mask_ipv6((struct prefix_ipv6 *)&p);
 
 	return ripng_enable_network_delete(ripng, &p);
@@ -238,33 +227,30 @@ int ripngd_instance_network_destroy(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/interface
  */
-int ripngd_instance_interface_create(enum nb_event event,
-				     const struct lyd_node *dnode,
-				     union nb_resource *resource)
+int ripngd_instance_interface_create(struct nb_cb_create_args *args)
 {
 	struct ripng *ripng;
 	const char *ifname;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	ifname = yang_dnode_get_string(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	ifname = yang_dnode_get_string(args->dnode, NULL);
 
 	return ripng_enable_if_add(ripng, ifname);
 }
 
-int ripngd_instance_interface_destroy(enum nb_event event,
-				      const struct lyd_node *dnode)
+int ripngd_instance_interface_destroy(struct nb_cb_destroy_args *args)
 {
 	struct ripng *ripng;
 	const char *ifname;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	ifname = yang_dnode_get_string(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	ifname = yang_dnode_get_string(args->dnode, NULL);
 
 	return ripng_enable_if_delete(ripng, ifname);
 }
@@ -272,38 +258,35 @@ int ripngd_instance_interface_destroy(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/offset-list
  */
-int ripngd_instance_offset_list_create(enum nb_event event,
-				       const struct lyd_node *dnode,
-				       union nb_resource *resource)
+int ripngd_instance_offset_list_create(struct nb_cb_create_args *args)
 {
 	struct ripng *ripng;
 	const char *ifname;
 	struct ripng_offset_list *offset;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	ifname = yang_dnode_get_string(dnode, "./interface");
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	ifname = yang_dnode_get_string(args->dnode, "./interface");
 
 	offset = ripng_offset_list_new(ripng, ifname);
-	nb_running_set_entry(dnode, offset);
+	nb_running_set_entry(args->dnode, offset);
 
 	return NB_OK;
 }
 
-int ripngd_instance_offset_list_destroy(enum nb_event event,
-					const struct lyd_node *dnode)
+int ripngd_instance_offset_list_destroy(struct nb_cb_destroy_args *args)
 {
 	int direct;
 	struct ripng_offset_list *offset;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	direct = yang_dnode_get_enum(dnode, "./direction");
+	direct = yang_dnode_get_enum(args->dnode, "./direction");
 
-	offset = nb_running_unset_entry(dnode);
+	offset = nb_running_unset_entry(args->dnode);
 	if (offset->direct[direct].alist_name) {
 		free(offset->direct[direct].alist_name);
 		offset->direct[direct].alist_name = NULL;
@@ -318,21 +301,20 @@ int ripngd_instance_offset_list_destroy(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/offset-list/access-list
  */
-int ripngd_instance_offset_list_access_list_modify(enum nb_event event,
-						   const struct lyd_node *dnode,
-						   union nb_resource *resource)
+int ripngd_instance_offset_list_access_list_modify(
+	struct nb_cb_modify_args *args)
 {
 	int direct;
 	struct ripng_offset_list *offset;
 	const char *alist_name;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	direct = yang_dnode_get_enum(dnode, "../direction");
-	alist_name = yang_dnode_get_string(dnode, NULL);
+	direct = yang_dnode_get_enum(args->dnode, "../direction");
+	alist_name = yang_dnode_get_string(args->dnode, NULL);
 
-	offset = nb_running_get_entry(dnode, NULL, true);
+	offset = nb_running_get_entry(args->dnode, NULL, true);
 	if (offset->direct[direct].alist_name)
 		free(offset->direct[direct].alist_name);
 	offset->direct[direct].alist_name = strdup(alist_name);
@@ -343,21 +325,19 @@ int ripngd_instance_offset_list_access_list_modify(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/offset-list/metric
  */
-int ripngd_instance_offset_list_metric_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource)
+int ripngd_instance_offset_list_metric_modify(struct nb_cb_modify_args *args)
 {
 	int direct;
 	uint8_t metric;
 	struct ripng_offset_list *offset;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	direct = yang_dnode_get_enum(dnode, "../direction");
-	metric = yang_dnode_get_uint8(dnode, NULL);
+	direct = yang_dnode_get_enum(args->dnode, "../direction");
+	metric = yang_dnode_get_uint8(args->dnode, NULL);
 
-	offset = nb_running_get_entry(dnode, NULL, true);
+	offset = nb_running_get_entry(args->dnode, NULL, true);
 	offset->direct[direct].metric = metric;
 
 	return NB_OK;
@@ -366,33 +346,30 @@ int ripngd_instance_offset_list_metric_modify(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/passive-interface
  */
-int ripngd_instance_passive_interface_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+int ripngd_instance_passive_interface_create(struct nb_cb_create_args *args)
 {
 	struct ripng *ripng;
 	const char *ifname;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	ifname = yang_dnode_get_string(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	ifname = yang_dnode_get_string(args->dnode, NULL);
 
 	return ripng_passive_interface_set(ripng, ifname);
 }
 
-int ripngd_instance_passive_interface_destroy(enum nb_event event,
-					      const struct lyd_node *dnode)
+int ripngd_instance_passive_interface_destroy(struct nb_cb_destroy_args *args)
 {
 	struct ripng *ripng;
 	const char *ifname;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	ifname = yang_dnode_get_string(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	ifname = yang_dnode_get_string(args->dnode, NULL);
 
 	return ripng_passive_interface_unset(ripng, ifname);
 }
@@ -400,35 +377,32 @@ int ripngd_instance_passive_interface_destroy(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/redistribute
  */
-int ripngd_instance_redistribute_create(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource)
+int ripngd_instance_redistribute_create(struct nb_cb_create_args *args)
 {
 	struct ripng *ripng;
 	int type;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	type = yang_dnode_get_enum(dnode, "./protocol");
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	type = yang_dnode_get_enum(args->dnode, "./protocol");
 
 	ripng->redist[type].enabled = true;
 
 	return NB_OK;
 }
 
-int ripngd_instance_redistribute_destroy(enum nb_event event,
-					 const struct lyd_node *dnode)
+int ripngd_instance_redistribute_destroy(struct nb_cb_destroy_args *args)
 {
 	struct ripng *ripng;
 	int type;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	type = yang_dnode_get_enum(dnode, "./protocol");
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	type = yang_dnode_get_enum(args->dnode, "./protocol");
 
 	ripng->redist[type].enabled = false;
 	if (ripng->redist[type].route_map.name) {
@@ -445,13 +419,14 @@ int ripngd_instance_redistribute_destroy(enum nb_event event,
 	return NB_OK;
 }
 
-void ripngd_instance_redistribute_apply_finish(const struct lyd_node *dnode)
+void ripngd_instance_redistribute_apply_finish(
+	struct nb_cb_apply_finish_args *args)
 {
 	struct ripng *ripng;
 	int type;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	type = yang_dnode_get_enum(dnode, "./protocol");
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	type = yang_dnode_get_enum(args->dnode, "./protocol");
 
 	if (ripng->enabled)
 		ripng_redistribute_conf_update(ripng, type);
@@ -460,20 +435,19 @@ void ripngd_instance_redistribute_apply_finish(const struct lyd_node *dnode)
 /*
  * XPath: /frr-ripngd:ripngd/instance/redistribute/route-map
  */
-int ripngd_instance_redistribute_route_map_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource)
+int ripngd_instance_redistribute_route_map_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct ripng *ripng;
 	int type;
 	const char *rmap_name;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	type = yang_dnode_get_enum(dnode, "../protocol");
-	rmap_name = yang_dnode_get_string(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	type = yang_dnode_get_enum(args->dnode, "../protocol");
+	rmap_name = yang_dnode_get_string(args->dnode, NULL);
 
 	if (ripng->redist[type].route_map.name)
 		free(ripng->redist[type].route_map.name);
@@ -483,17 +457,17 @@ int ripngd_instance_redistribute_route_map_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int ripngd_instance_redistribute_route_map_destroy(enum nb_event event,
-						   const struct lyd_node *dnode)
+int ripngd_instance_redistribute_route_map_destroy(
+	struct nb_cb_destroy_args *args)
 {
 	struct ripng *ripng;
 	int type;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	type = yang_dnode_get_enum(dnode, "../protocol");
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	type = yang_dnode_get_enum(args->dnode, "../protocol");
 
 	free(ripng->redist[type].route_map.name);
 	ripng->redist[type].route_map.name = NULL;
@@ -505,20 +479,18 @@ int ripngd_instance_redistribute_route_map_destroy(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/redistribute/metric
  */
-int ripngd_instance_redistribute_metric_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource)
+int ripngd_instance_redistribute_metric_modify(struct nb_cb_modify_args *args)
 {
 	struct ripng *ripng;
 	int type;
 	uint8_t metric;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	type = yang_dnode_get_enum(dnode, "../protocol");
-	metric = yang_dnode_get_uint8(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	type = yang_dnode_get_enum(args->dnode, "../protocol");
+	metric = yang_dnode_get_uint8(args->dnode, NULL);
 
 	ripng->redist[type].metric_config = true;
 	ripng->redist[type].metric = metric;
@@ -526,17 +498,16 @@ int ripngd_instance_redistribute_metric_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int ripngd_instance_redistribute_metric_destroy(enum nb_event event,
-						const struct lyd_node *dnode)
+int ripngd_instance_redistribute_metric_destroy(struct nb_cb_destroy_args *args)
 {
 	struct ripng *ripng;
 	int type;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	type = yang_dnode_get_enum(dnode, "../protocol");
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	type = yang_dnode_get_enum(args->dnode, "../protocol");
 
 	ripng->redist[type].metric_config = false;
 	ripng->redist[type].metric = 0;
@@ -547,18 +518,16 @@ int ripngd_instance_redistribute_metric_destroy(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/static-route
  */
-int ripngd_instance_static_route_create(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource)
+int ripngd_instance_static_route_create(struct nb_cb_create_args *args)
 {
 	struct ripng *ripng;
 	struct prefix_ipv6 p;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	yang_dnode_get_ipv6p(&p, dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	yang_dnode_get_ipv6p(&p, args->dnode, NULL);
 	apply_mask_ipv6(&p);
 
 	ripng_redistribute_add(ripng, ZEBRA_ROUTE_RIPNG, RIPNG_ROUTE_STATIC, &p,
@@ -567,17 +536,16 @@ int ripngd_instance_static_route_create(enum nb_event event,
 	return NB_OK;
 }
 
-int ripngd_instance_static_route_destroy(enum nb_event event,
-					 const struct lyd_node *dnode)
+int ripngd_instance_static_route_destroy(struct nb_cb_destroy_args *args)
 {
 	struct ripng *ripng;
 	struct prefix_ipv6 p;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	yang_dnode_get_ipv6p(&p, dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	yang_dnode_get_ipv6p(&p, args->dnode, NULL);
 	apply_mask_ipv6(&p);
 
 	ripng_redistribute_delete(ripng, ZEBRA_ROUTE_RIPNG, RIPNG_ROUTE_STATIC,
@@ -589,18 +557,16 @@ int ripngd_instance_static_route_destroy(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/aggregate-address
  */
-int ripngd_instance_aggregate_address_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+int ripngd_instance_aggregate_address_create(struct nb_cb_create_args *args)
 {
 	struct ripng *ripng;
 	struct prefix_ipv6 p;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	yang_dnode_get_ipv6p(&p, dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	yang_dnode_get_ipv6p(&p, args->dnode, NULL);
 	apply_mask_ipv6(&p);
 
 	ripng_aggregate_add(ripng, (struct prefix *)&p);
@@ -608,17 +574,16 @@ int ripngd_instance_aggregate_address_create(enum nb_event event,
 	return NB_OK;
 }
 
-int ripngd_instance_aggregate_address_destroy(enum nb_event event,
-					      const struct lyd_node *dnode)
+int ripngd_instance_aggregate_address_destroy(struct nb_cb_destroy_args *args)
 {
 	struct ripng *ripng;
 	struct prefix_ipv6 p;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	yang_dnode_get_ipv6p(&p, dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	yang_dnode_get_ipv6p(&p, args->dnode, NULL);
 	apply_mask_ipv6(&p);
 
 	ripng_aggregate_delete(ripng, (struct prefix *)&p);
@@ -629,11 +594,11 @@ int ripngd_instance_aggregate_address_destroy(enum nb_event event,
 /*
  * XPath: /frr-ripngd:ripngd/instance/timers
  */
-void ripngd_instance_timers_apply_finish(const struct lyd_node *dnode)
+void ripngd_instance_timers_apply_finish(struct nb_cb_apply_finish_args *args)
 {
 	struct ripng *ripng;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
 
 	/* Reset update timer thread. */
 	ripng_event(ripng, RIPNG_UPDATE_EVENT, 0);
@@ -642,17 +607,15 @@ void ripngd_instance_timers_apply_finish(const struct lyd_node *dnode)
 /*
  * XPath: /frr-ripngd:ripngd/instance/timers/flush-interval
  */
-int ripngd_instance_timers_flush_interval_modify(enum nb_event event,
-						 const struct lyd_node *dnode,
-						 union nb_resource *resource)
+int ripngd_instance_timers_flush_interval_modify(struct nb_cb_modify_args *args)
 {
 	struct ripng *ripng;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	ripng->garbage_time = yang_dnode_get_uint16(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	ripng->garbage_time = yang_dnode_get_uint16(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -661,16 +624,15 @@ int ripngd_instance_timers_flush_interval_modify(enum nb_event event,
  * XPath: /frr-ripngd:ripngd/instance/timers/holddown-interval
  */
 int ripngd_instance_timers_holddown_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct ripng *ripng;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	ripng->timeout_time = yang_dnode_get_uint16(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	ripng->timeout_time = yang_dnode_get_uint16(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -678,17 +640,16 @@ int ripngd_instance_timers_holddown_interval_modify(
 /*
  * XPath: /frr-ripngd:ripngd/instance/timers/update-interval
  */
-int ripngd_instance_timers_update_interval_modify(enum nb_event event,
-						  const struct lyd_node *dnode,
-						  union nb_resource *resource)
+int ripngd_instance_timers_update_interval_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct ripng *ripng;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = nb_running_get_entry(dnode, NULL, true);
-	ripng->update_time = yang_dnode_get_uint16(dnode, NULL);
+	ripng = nb_running_get_entry(args->dnode, NULL, true);
+	ripng->update_time = yang_dnode_get_uint16(args->dnode, NULL);
 
 	return NB_OK;
 }
@@ -696,19 +657,17 @@ int ripngd_instance_timers_update_interval_modify(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-ripngd:ripng/split-horizon
  */
-int lib_interface_ripng_split_horizon_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+int lib_interface_ripng_split_horizon_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct ripng_interface *ri;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
 	ri = ifp->info;
-	ri->split_horizon = yang_dnode_get_enum(dnode, NULL);
+	ri->split_horizon = yang_dnode_get_enum(args->dnode, NULL);
 
 	return NB_OK;
 }

--- a/ripngd/ripng_nb_rpcs.c
+++ b/ripngd/ripng_nb_rpcs.c
@@ -80,13 +80,13 @@ static void clear_ripng_route(struct ripng *ripng)
 	}
 }
 
-int clear_ripng_route_rpc(const char *xpath, const struct list *input,
-			  struct list *output)
+int clear_ripng_route_rpc(struct nb_cb_rpc_args *args)
 {
 	struct ripng *ripng;
 	struct yang_data *yang_vrf;
 
-	yang_vrf = yang_data_list_find(input, "%s/%s", xpath, "input/vrf");
+	yang_vrf = yang_data_list_find(args->input, "%s/%s", args->xpath,
+				       "input/vrf");
 	if (yang_vrf) {
 		ripng = ripng_lookup_by_vrf_name(yang_vrf->value);
 		if (ripng)

--- a/ripngd/ripng_nb_state.c
+++ b/ripngd/ripng_nb_state.c
@@ -38,43 +38,42 @@
 /*
  * XPath: /frr-ripngd:ripngd/instance/state/neighbors/neighbor
  */
-const void *
-ripngd_instance_state_neighbors_neighbor_get_next(const void *parent_list_entry,
-						  const void *list_entry)
+const void *ripngd_instance_state_neighbors_neighbor_get_next(
+	struct nb_cb_get_next_args *args)
 {
-	const struct ripng *ripng = parent_list_entry;
+	const struct ripng *ripng = args->parent_list_entry;
 	struct listnode *node;
 
-	if (list_entry == NULL)
+	if (args->list_entry == NULL)
 		node = listhead(ripng->peer_list);
 	else
-		node = listnextnode((struct listnode *)list_entry);
+		node = listnextnode((struct listnode *)args->list_entry);
 
 	return node;
 }
 
 int ripngd_instance_state_neighbors_neighbor_get_keys(
-	const void *list_entry, struct yang_list_keys *keys)
+	struct nb_cb_get_keys_args *args)
 {
-	const struct listnode *node = list_entry;
+	const struct listnode *node = args->list_entry;
 	const struct ripng_peer *peer = listgetdata(node);
 
-	keys->num = 1;
-	(void)inet_ntop(AF_INET6, &peer->addr, keys->key[0],
-			sizeof(keys->key[0]));
+	args->keys->num = 1;
+	(void)inet_ntop(AF_INET6, &peer->addr, args->keys->key[0],
+			sizeof(args->keys->key[0]));
 
 	return NB_OK;
 }
 
 const void *ripngd_instance_state_neighbors_neighbor_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys)
+	struct nb_cb_lookup_entry_args *args)
 {
-	const struct ripng *ripng = parent_list_entry;
+	const struct ripng *ripng = args->parent_list_entry;
 	struct in6_addr address;
 	struct ripng_peer *peer;
 	struct listnode *node;
 
-	yang_str2ipv6(keys->key[0], &address);
+	yang_str2ipv6(args->keys->key[0], &address);
 
 	for (ALL_LIST_ELEMENTS_RO(ripng->peer_list, node, peer)) {
 		if (IPV6_ADDR_SAME(&peer->addr, &address))
@@ -88,19 +87,19 @@ const void *ripngd_instance_state_neighbors_neighbor_lookup_entry(
  * XPath: /frr-ripngd:ripngd/instance/state/neighbors/neighbor/address
  */
 struct yang_data *ripngd_instance_state_neighbors_neighbor_address_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct listnode *node = list_entry;
+	const struct listnode *node = args->list_entry;
 	const struct ripng_peer *peer = listgetdata(node);
 
-	return yang_data_new_ipv6(xpath, &peer->addr);
+	return yang_data_new_ipv6(args->xpath, &peer->addr);
 }
 
 /*
  * XPath: /frr-ripngd:ripngd/instance/state/neighbors/neighbor/last-update
  */
 struct yang_data *ripngd_instance_state_neighbors_neighbor_last_update_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: yang:date-and-time is tricky */
 	return NULL;
@@ -111,12 +110,12 @@ struct yang_data *ripngd_instance_state_neighbors_neighbor_last_update_get_elem(
  */
 struct yang_data *
 ripngd_instance_state_neighbors_neighbor_bad_packets_rcvd_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct listnode *node = list_entry;
+	const struct listnode *node = args->list_entry;
 	const struct ripng_peer *peer = listgetdata(node);
 
-	return yang_data_new_uint32(xpath, peer->recv_badpackets);
+	return yang_data_new_uint32(args->xpath, peer->recv_badpackets);
 }
 
 /*
@@ -124,54 +123,53 @@ ripngd_instance_state_neighbors_neighbor_bad_packets_rcvd_get_elem(
  */
 struct yang_data *
 ripngd_instance_state_neighbors_neighbor_bad_routes_rcvd_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct listnode *node = list_entry;
+	const struct listnode *node = args->list_entry;
 	const struct ripng_peer *peer = listgetdata(node);
 
-	return yang_data_new_uint32(xpath, peer->recv_badroutes);
+	return yang_data_new_uint32(args->xpath, peer->recv_badroutes);
 }
 
 /*
  * XPath: /frr-ripngd:ripngd/instance/state/routes/route
  */
 const void *
-ripngd_instance_state_routes_route_get_next(const void *parent_list_entry,
-					    const void *list_entry)
+ripngd_instance_state_routes_route_get_next(struct nb_cb_get_next_args *args)
 {
-	const struct ripng *ripng = parent_list_entry;
+	const struct ripng *ripng = args->parent_list_entry;
 	struct agg_node *rn;
 
-	if (list_entry == NULL)
+	if (args->list_entry == NULL)
 		rn = agg_route_top(ripng->table);
 	else
-		rn = agg_route_next((struct agg_node *)list_entry);
+		rn = agg_route_next((struct agg_node *)args->list_entry);
 	while (rn && rn->info == NULL)
 		rn = agg_route_next(rn);
 
 	return rn;
 }
 
-int ripngd_instance_state_routes_route_get_keys(const void *list_entry,
-						struct yang_list_keys *keys)
+int ripngd_instance_state_routes_route_get_keys(
+	struct nb_cb_get_keys_args *args)
 {
-	const struct agg_node *rn = list_entry;
+	const struct agg_node *rn = args->list_entry;
 
-	keys->num = 1;
-	(void)prefix2str(agg_node_get_prefix(rn), keys->key[0],
-			 sizeof(keys->key[0]));
+	args->keys->num = 1;
+	(void)prefix2str(agg_node_get_prefix(rn), args->keys->key[0],
+			 sizeof(args->keys->key[0]));
 
 	return NB_OK;
 }
 
 const void *ripngd_instance_state_routes_route_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys)
+	struct nb_cb_lookup_entry_args *args)
 {
-	const struct ripng *ripng = parent_list_entry;
+	const struct ripng *ripng = args->parent_list_entry;
 	struct prefix prefix;
 	struct agg_node *rn;
 
-	yang_str2ipv6p(keys->key[0], &prefix);
+	yang_str2ipv6p(args->keys->key[0], &prefix);
 
 	rn = agg_node_lookup(ripng->table, &prefix);
 	if (!rn || !rn->info)
@@ -185,53 +183,50 @@ const void *ripngd_instance_state_routes_route_lookup_entry(
 /*
  * XPath: /frr-ripngd:ripngd/instance/state/routes/route/prefix
  */
-struct yang_data *
-ripngd_instance_state_routes_route_prefix_get_elem(const char *xpath,
-						   const void *list_entry)
+struct yang_data *ripngd_instance_state_routes_route_prefix_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct agg_node *rn = list_entry;
+	const struct agg_node *rn = args->list_entry;
 	const struct ripng_info *rinfo = listnode_head(rn->info);
 
-	return yang_data_new_ipv6p(xpath, agg_node_get_prefix(rinfo->rp));
+	return yang_data_new_ipv6p(args->xpath, agg_node_get_prefix(rinfo->rp));
 }
 
 /*
  * XPath: /frr-ripngd:ripngd/instance/state/routes/route/next-hop
  */
-struct yang_data *
-ripngd_instance_state_routes_route_next_hop_get_elem(const char *xpath,
-						     const void *list_entry)
+struct yang_data *ripngd_instance_state_routes_route_next_hop_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct agg_node *rn = list_entry;
+	const struct agg_node *rn = args->list_entry;
 	const struct ripng_info *rinfo = listnode_head(rn->info);
 
-	return yang_data_new_ipv6(xpath, &rinfo->nexthop);
+	return yang_data_new_ipv6(args->xpath, &rinfo->nexthop);
 }
 
 /*
  * XPath: /frr-ripngd:ripngd/instance/state/routes/route/interface
  */
-struct yang_data *
-ripngd_instance_state_routes_route_interface_get_elem(const char *xpath,
-						      const void *list_entry)
+struct yang_data *ripngd_instance_state_routes_route_interface_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct agg_node *rn = list_entry;
+	const struct agg_node *rn = args->list_entry;
 	const struct ripng_info *rinfo = listnode_head(rn->info);
 	const struct ripng *ripng = ripng_info_get_instance(rinfo);
 
 	return yang_data_new_string(
-		xpath, ifindex2ifname(rinfo->ifindex, ripng->vrf->vrf_id));
+		args->xpath,
+		ifindex2ifname(rinfo->ifindex, ripng->vrf->vrf_id));
 }
 
 /*
  * XPath: /frr-ripngd:ripngd/instance/state/routes/route/metric
  */
-struct yang_data *
-ripngd_instance_state_routes_route_metric_get_elem(const char *xpath,
-						   const void *list_entry)
+struct yang_data *ripngd_instance_state_routes_route_metric_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct agg_node *rn = list_entry;
+	const struct agg_node *rn = args->list_entry;
 	const struct ripng_info *rinfo = listnode_head(rn->info);
 
-	return yang_data_new_uint8(xpath, rinfo->metric);
+	return yang_data_new_uint8(args->xpath, rinfo->metric);
 }

--- a/tests/lib/northbound/test_oper_data.c
+++ b/tests/lib/northbound/test_oper_data.c
@@ -49,41 +49,38 @@ static struct list *vrfs;
  * XPath: /frr-test-module:frr-test-module/vrfs/vrf
  */
 static const void *
-frr_test_module_vrfs_vrf_get_next(const void *parent_list_entry,
-				  const void *list_entry)
+frr_test_module_vrfs_vrf_get_next(struct nb_cb_get_next_args *args)
 {
 	struct listnode *node;
 
-	if (list_entry == NULL)
+	if (args->list_entry == NULL)
 		node = listhead(vrfs);
 	else
-		node = listnextnode((struct listnode *)list_entry);
+		node = listnextnode((struct listnode *)args->list_entry);
 
 	return node;
 }
 
-static int frr_test_module_vrfs_vrf_get_keys(const void *list_entry,
-					     struct yang_list_keys *keys)
+static int frr_test_module_vrfs_vrf_get_keys(struct nb_cb_get_keys_args *args)
 {
 	const struct tvrf *vrf;
 
-	vrf = listgetdata((struct listnode *)list_entry);
+	vrf = listgetdata((struct listnode *)args->list_entry);
 
-	keys->num = 1;
-	strlcpy(keys->key[0], vrf->name, sizeof(keys->key[0]));
+	args->keys->num = 1;
+	strlcpy(args->keys->key[0], vrf->name, sizeof(args->keys->key[0]));
 
 	return NB_OK;
 }
 
 static const void *
-frr_test_module_vrfs_vrf_lookup_entry(const void *parent_list_entry,
-				      const struct yang_list_keys *keys)
+frr_test_module_vrfs_vrf_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
 	struct listnode *node;
 	struct tvrf *vrf;
 	const char *vrfname;
 
-	vrfname = keys->key[0];
+	vrfname = args->keys->key[0];
 
 	for (ALL_LIST_ELEMENTS_RO(vrfs, node, vrf)) {
 		if (strmatch(vrf->name, vrfname))
@@ -97,39 +94,37 @@ frr_test_module_vrfs_vrf_lookup_entry(const void *parent_list_entry,
  * XPath: /frr-test-module:frr-test-module/vrfs/vrf/name
  */
 static struct yang_data *
-frr_test_module_vrfs_vrf_name_get_elem(const char *xpath,
-				       const void *list_entry)
+frr_test_module_vrfs_vrf_name_get_elem(struct nb_cb_get_elem_args *args)
 {
 	const struct tvrf *vrf;
 
-	vrf = listgetdata((struct listnode *)list_entry);
-	return yang_data_new_string(xpath, vrf->name);
+	vrf = listgetdata((struct listnode *)args->list_entry);
+	return yang_data_new_string(args->xpath, vrf->name);
 }
 
 /*
  * XPath: /frr-test-module:frr-test-module/vrfs/vrf/interfaces/interface
  */
-static struct yang_data *
-frr_test_module_vrfs_vrf_interfaces_interface_get_elem(const char *xpath,
-						       const void *list_entry)
+static struct yang_data *frr_test_module_vrfs_vrf_interfaces_interface_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	const char *interface;
 
-	interface = listgetdata((struct listnode *)list_entry);
-	return yang_data_new_string(xpath, interface);
+	interface = listgetdata((struct listnode *)args->list_entry);
+	return yang_data_new_string(args->xpath, interface);
 }
 
 static const void *frr_test_module_vrfs_vrf_interfaces_interface_get_next(
-	const void *parent_list_entry, const void *list_entry)
+	struct nb_cb_get_next_args *args)
 {
 	const struct tvrf *vrf;
 	struct listnode *node;
 
-	vrf = listgetdata((struct listnode *)parent_list_entry);
-	if (list_entry == NULL)
+	vrf = listgetdata((struct listnode *)args->parent_list_entry);
+	if (args->list_entry == NULL)
 		node = listhead(vrf->interfaces);
 	else
-		node = listnextnode((struct listnode *)list_entry);
+		node = listnextnode((struct listnode *)args->list_entry);
 
 	return node;
 }
@@ -138,17 +133,16 @@ static const void *frr_test_module_vrfs_vrf_interfaces_interface_get_next(
  * XPath: /frr-test-module:frr-test-module/vrfs/vrf/routes/route
  */
 static const void *
-frr_test_module_vrfs_vrf_routes_route_get_next(const void *parent_list_entry,
-					       const void *list_entry)
+frr_test_module_vrfs_vrf_routes_route_get_next(struct nb_cb_get_next_args *args)
 {
 	const struct tvrf *vrf;
 	struct listnode *node;
 
-	vrf = listgetdata((struct listnode *)parent_list_entry);
-	if (list_entry == NULL)
+	vrf = listgetdata((struct listnode *)args->parent_list_entry);
+	if (args->list_entry == NULL)
 		node = listhead(vrf->routes);
 	else
-		node = listnextnode((struct listnode *)list_entry);
+		node = listnextnode((struct listnode *)args->list_entry);
 
 	return node;
 }
@@ -156,67 +150,64 @@ frr_test_module_vrfs_vrf_routes_route_get_next(const void *parent_list_entry,
 /*
  * XPath: /frr-test-module:frr-test-module/vrfs/vrf/routes/route/prefix
  */
-static struct yang_data *
-frr_test_module_vrfs_vrf_routes_route_prefix_get_elem(const char *xpath,
-						      const void *list_entry)
+static struct yang_data *frr_test_module_vrfs_vrf_routes_route_prefix_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	const struct troute *route;
 
-	route = listgetdata((struct listnode *)list_entry);
-	return yang_data_new_ipv4p(xpath, &route->prefix);
+	route = listgetdata((struct listnode *)args->list_entry);
+	return yang_data_new_ipv4p(args->xpath, &route->prefix);
 }
 
 /*
  * XPath: /frr-test-module:frr-test-module/vrfs/vrf/routes/route/next-hop
  */
 static struct yang_data *
-frr_test_module_vrfs_vrf_routes_route_next_hop_get_elem(const char *xpath,
-							const void *list_entry)
+frr_test_module_vrfs_vrf_routes_route_next_hop_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	const struct troute *route;
 
-	route = listgetdata((struct listnode *)list_entry);
-	return yang_data_new_ipv4(xpath, &route->nexthop);
+	route = listgetdata((struct listnode *)args->list_entry);
+	return yang_data_new_ipv4(args->xpath, &route->nexthop);
 }
 
 /*
  * XPath: /frr-test-module:frr-test-module/vrfs/vrf/routes/route/interface
  */
 static struct yang_data *
-frr_test_module_vrfs_vrf_routes_route_interface_get_elem(const char *xpath,
-							 const void *list_entry)
+frr_test_module_vrfs_vrf_routes_route_interface_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	const struct troute *route;
 
-	route = listgetdata((struct listnode *)list_entry);
-	return yang_data_new_string(xpath, route->ifname);
+	route = listgetdata((struct listnode *)args->list_entry);
+	return yang_data_new_string(args->xpath, route->ifname);
 }
 
 /*
  * XPath: /frr-test-module:frr-test-module/vrfs/vrf/routes/route/metric
  */
-static struct yang_data *
-frr_test_module_vrfs_vrf_routes_route_metric_get_elem(const char *xpath,
-						      const void *list_entry)
+static struct yang_data *frr_test_module_vrfs_vrf_routes_route_metric_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	const struct troute *route;
 
-	route = listgetdata((struct listnode *)list_entry);
-	return yang_data_new_uint8(xpath, route->metric);
+	route = listgetdata((struct listnode *)args->list_entry);
+	return yang_data_new_uint8(args->xpath, route->metric);
 }
 
 /*
  * XPath: /frr-test-module:frr-test-module/vrfs/vrf/routes/route/active
  */
-static struct yang_data *
-frr_test_module_vrfs_vrf_routes_route_active_get_elem(const char *xpath,
-						      const void *list_entry)
+static struct yang_data *frr_test_module_vrfs_vrf_routes_route_active_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	const struct troute *route;
 
-	route = listgetdata((struct listnode *)list_entry);
+	route = listgetdata((struct listnode *)args->list_entry);
 	if (route->active)
-		return yang_data_new(xpath, NULL);
+		return yang_data_new(args->xpath, NULL);
 
 	return NULL;
 }

--- a/tools/coccinelle/nb-cbs.cocci
+++ b/tools/coccinelle/nb-cbs.cocci
@@ -1,0 +1,298 @@
+@@
+identifier func =~ ".*_create$";
+identifier event, dnode, resource;
+@@
+
+int
+- func(enum nb_event event, const struct lyd_node *dnode, union nb_resource *resource)
++ func(struct nb_cb_create_args *args)
+  {
+<...
+(
+- event
++ args->event
+|
+- dnode
++ args->dnode
+|
+- resource
++ args->resource
+)
+...>
+  }
+
+@@
+identifier func =~ ".*_modify$";
+identifier event, dnode, resource;
+@@
+
+int
+- func(enum nb_event event, const struct lyd_node *dnode, union nb_resource *resource)
++ func(struct nb_cb_modify_args *args)
+  {
+<...
+(
+- event
++ args->event
+|
+- dnode
++ args->dnode
+|
+- resource
++ args->resource
+)
+...>
+  }
+
+@@
+identifier func =~ ".*_destroy$";
+identifier event, dnode;
+@@
+
+int
+- func(enum nb_event event, const struct lyd_node *dnode)
++ func(struct nb_cb_destroy_args *args)
+  {
+<...
+(
+- dnode
++ args->dnode
+|
+- event
++ args->event
+)
+...>
+  }
+
+@@
+identifier func =~ ".*_pre_validate$";
+identifier dnode;
+@@
+
+int
+- func(const struct lyd_node dnode)
++ func(struct nb_cb_pre_validate_args *args)
+  {
+<...
+- dnode
++ args->dnode
+...>
+  }
+
+@@
+identifier func =~ ".*_apply_finish$";
+identifier dnode;
+@@
+
+void
+- func(const struct lyd_node *dnode)
++ func(struct nb_cb_apply_finish_args *args)
+  {
+<...
+- dnode
++ args->dnode
+...>
+  }
+
+@@
+identifier func =~ ".*_get_elem$";
+identifier xpath, list_entry;
+@@
+
+struct yang_data *
+- func(const char *xpath, const void *list_entry)
++ func(struct nb_cb_get_elem_args *args)
+  {
+<...
+(
+- xpath
++ args->xpath
+|
+- list_entry
++ args->list_entry
+)
+...>
+  }
+
+@@
+identifier func =~ ".*_get_next$";
+identifier parent_list_entry, list_entry;
+@@
+
+const void *
+- func(const void *parent_list_entry, const void *list_entry)
++ func(struct nb_cb_get_next_args *args)
+  {
+<...
+(
+- parent_list_entry
++ args->parent_list_entry
+|
+- list_entry
++ args->list_entry
+)
+...>
+  }
+
+@@
+identifier func =~ ".*_get_keys$";
+identifier list_entry, keys;
+@@
+
+int
+- func(const void *list_entry, struct yang_list_keys *keys)
++ func(struct nb_cb_get_keys_args *args)
+  {
+<...
+(
+- list_entry
++ args->list_entry
+|
+- keys
++ args->keys
+)
+...>
+  }
+
+@@
+identifier func =~ ".*_lookup_entry$";
+identifier parent_list_entry, keys;
+@@
+
+const void *
+- func(const void *parent_list_entry, const struct yang_list_keys *keys)
++ func(struct nb_cb_lookup_entry_args *args)
+  {
+<...
+(
+- parent_list_entry
++ args->parent_list_entry
+|
+- keys
++ args->keys
+)
+...>
+  }
+
+@@
+identifier func =~ ".*_rpc$";
+identifier xpath, input, output;
+@@
+
+int
+- func(const char *xpath, const struct list *input, struct list *output)
++ func(struct nb_cb_rpc_args *args)
+  {
+<...
+(
+- xpath
++ args->xpath
+|
+- input
++ args->input
+|
+- output
++ args->output
+)
+...>
+  }
+
+@@
+identifier func =~ ".*_create$";
+identifier event, dnode, resource;
+@@
+
+int
+- func(enum nb_event event, const struct lyd_node *dnode, union nb_resource *resource)
++ func(struct nb_cb_create_args *args)
+;
+
+@@
+identifier func =~ ".*_modify$";
+identifier event, dnode, resource;
+@@
+
+int
+- func(enum nb_event event, const struct lyd_node *dnode, union nb_resource *resource)
++ func(struct nb_cb_modify_args *args)
+;
+
+@@
+identifier func =~ ".*_destroy$";
+identifier event, dnode;
+@@
+
+int
+- func(enum nb_event event, const struct lyd_node *dnode)
++ func(struct nb_cb_destroy_args *args)
+;
+
+@@
+identifier func =~ ".*_pre_validate$";
+identifier dnode;
+@@
+
+int
+- func(const struct lyd_node dnode)
++ func(struct nb_cb_pre_validate_args *args)
+;
+
+@@
+identifier func =~ ".*_apply_finish$";
+identifier dnode;
+@@
+
+void
+- func(const struct lyd_node *dnode)
++ func(struct nb_cb_apply_finish_args *args)
+;
+
+@@
+identifier func =~ ".*_get_elem$";
+identifier xpath, list_entry;
+@@
+
+struct yang_data *
+- func(const char *xpath, const void *list_entry)
++ func(struct nb_cb_get_elem_args *args)
+;
+
+@@
+identifier func =~ ".*_get_next$";
+identifier parent_list_entry, list_entry;
+@@
+
+const void *
+- func(const void *parent_list_entry, const void *list_entry)
++ func(struct nb_cb_get_next_args *args)
+;
+
+@@
+identifier func =~ ".*_get_keys$";
+identifier list_entry, keys;
+@@
+
+int
+- func(const void *list_entry, struct yang_list_keys *keys)
++ func(struct nb_cb_get_keys_args *args)
+;
+
+@@
+identifier func =~ ".*_lookup_entry$";
+identifier parent_list_entry, keys;
+@@
+
+const void *
+- func(const void *parent_list_entry, const struct yang_list_keys *keys)
++ func(struct nb_cb_lookup_entry_args *args)
+;
+
+@@
+identifier func =~ ".*_rpc$";
+identifier xpath, input, output;
+@@
+
+int
+- func(const char *xpath, const struct list *input, struct list *output)
++ func(struct nb_cb_rpc_args *args)
+;

--- a/tools/gen_northbound_callbacks.c
+++ b/tools/gen_northbound_callbacks.c
@@ -46,70 +46,62 @@ static struct nb_callback_info {
 		.operation = NB_OP_CREATE,
 		.return_type = "int ",
 		.return_value = "NB_OK",
-		.arguments =
-			"enum nb_event event, const struct lyd_node *dnode, union nb_resource *resource",
+		.arguments = "struct nb_cb_create_args *args",
 	},
 	{
 		.operation = NB_OP_MODIFY,
 		.return_type = "int ",
 		.return_value = "NB_OK",
-		.arguments =
-			"enum nb_event event, const struct lyd_node *dnode, union nb_resource *resource",
+		.arguments = "struct nb_cb_modify_args *args",
 	},
 	{
 		.operation = NB_OP_DESTROY,
 		.return_type = "int ",
 		.return_value = "NB_OK",
-		.arguments =
-			"enum nb_event event, const struct lyd_node *dnode",
+		.arguments = "struct nb_cb_destroy_args *args",
 	},
 	{
 		.operation = NB_OP_MOVE,
 		.return_type = "int ",
 		.return_value = "NB_OK",
-		.arguments =
-			"enum nb_event event, const struct lyd_node *dnode",
+		.arguments = "struct nb_cb_move_args *args",
 	},
 	{
 		.operation = NB_OP_APPLY_FINISH,
 		.optional = true,
 		.return_type = "void ",
 		.return_value = "",
-		.arguments = "const struct lyd_node *dnode",
+		.arguments = "struct nb_cb_apply_finish_args *args",
 	},
 	{
 		.operation = NB_OP_GET_ELEM,
 		.return_type = "struct yang_data *",
 		.return_value = "NULL",
-		.arguments = "const char *xpath, const void *list_entry",
+		.arguments = "struct nb_cb_get_elem_args *args",
 	},
 	{
 		.operation = NB_OP_GET_NEXT,
 		.return_type = "const void *",
 		.return_value = "NULL",
-		.arguments =
-			"const void *parent_list_entry, const void *list_entry",
+		.arguments = "struct nb_cb_get_next_args *args",
 	},
 	{
 		.operation = NB_OP_GET_KEYS,
 		.return_type = "int ",
 		.return_value = "NB_OK",
-		.arguments =
-			"const void *list_entry, struct yang_list_keys *keys",
+		.arguments = "struct nb_cb_get_keys_args *args",
 	},
 	{
 		.operation = NB_OP_LOOKUP_ENTRY,
 		.return_type = "const void *",
 		.return_value = "NULL",
-		.arguments =
-			"const void *parent_list_entry, const struct yang_list_keys *keys",
+		.arguments = "struct nb_cb_lookup_entry_args *args",
 	},
 	{
 		.operation = NB_OP_RPC,
 		.return_type = "int ",
 		.return_value = "NB_OK",
-		.arguments =
-			"const char *xpath, const struct list *input, struct list *output",
+		.arguments = "struct nb_cb_rpc_args *args",
 	},
 	{
 		/* sentinel */

--- a/vrrpd/vrrp_northbound.c
+++ b/vrrpd/vrrp_northbound.c
@@ -33,58 +33,55 @@
 /*
  * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group
  */
-static int lib_interface_vrrp_vrrp_group_create(enum nb_event event,
-						const struct lyd_node *dnode,
-						union nb_resource *resource)
+static int lib_interface_vrrp_vrrp_group_create(struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
 	uint8_t vrid;
 	uint8_t version = 3;
 	struct vrrp_vrouter *vr;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
-	vrid = yang_dnode_get_uint8(dnode, "./virtual-router-id");
-	version = yang_dnode_get_enum(dnode, "./version");
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
+	vrid = yang_dnode_get_uint8(args->dnode, "./virtual-router-id");
+	version = yang_dnode_get_enum(args->dnode, "./version");
 	vr = vrrp_vrouter_create(ifp, vrid, version);
-	nb_running_set_entry(dnode, vr);
+	nb_running_set_entry(args->dnode, vr);
 
 	return NB_OK;
 }
 
-static int lib_interface_vrrp_vrrp_group_destroy(enum nb_event event,
-						 const struct lyd_node *dnode)
+static int
+lib_interface_vrrp_vrrp_group_destroy(struct nb_cb_destroy_args *args)
 {
 	struct vrrp_vrouter *vr;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	vr = nb_running_unset_entry(dnode);
+	vr = nb_running_unset_entry(args->dnode);
 	vrrp_vrouter_destroy(vr);
 
 	return NB_OK;
 }
 
 static const void *
-lib_interface_vrrp_vrrp_group_get_next(const void *parent_list_entry,
-				       const void *list_entry)
+lib_interface_vrrp_vrrp_group_get_next(struct nb_cb_get_next_args *args)
 {
 	struct list *l = hash_to_list(vrrp_vrouters_hash);
 	struct listnode *ln;
 	const struct vrrp_vrouter *curr;
-	const struct interface *ifp = parent_list_entry;
+	const struct interface *ifp = args->parent_list_entry;
 
 	/*
 	 * If list_entry is null, we return the first vrrp instance with a
 	 * matching interface
 	 */
-	bool nextone = list_entry ? false : true;
+	bool nextone = args->list_entry ? false : true;
 
 	for (ALL_LIST_ELEMENTS_RO(l, ln, curr)) {
-		if (curr == list_entry) {
+		if (curr == args->list_entry) {
 			nextone = true;
 			continue;
 		}
@@ -100,23 +97,23 @@ done:
 	return curr;
 }
 
-static int lib_interface_vrrp_vrrp_group_get_keys(const void *list_entry,
-						  struct yang_list_keys *keys)
+static int
+lib_interface_vrrp_vrrp_group_get_keys(struct nb_cb_get_keys_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	keys->num = 1;
-	snprintf(keys->key[0], sizeof(keys->key[0]), "%" PRIu32, vr->vrid);
+	args->keys->num = 1;
+	snprintf(args->keys->key[0], sizeof(args->keys->key[0]), "%" PRIu32,
+		 vr->vrid);
 
 	return NB_OK;
 }
 
 static const void *
-lib_interface_vrrp_vrrp_group_lookup_entry(const void *parent_list_entry,
-					   const struct yang_list_keys *keys)
+lib_interface_vrrp_vrrp_group_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
-	uint32_t vrid = strtoul(keys->key[0], NULL, 10);
-	const struct interface *ifp = parent_list_entry;
+	uint32_t vrid = strtoul(args->keys->key[0], NULL, 10);
+	const struct interface *ifp = args->parent_list_entry;
 
 	return vrrp_lookup(ifp, vrid);
 }
@@ -125,20 +122,18 @@ lib_interface_vrrp_vrrp_group_lookup_entry(const void *parent_list_entry,
  * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/version
  */
 static int
-lib_interface_vrrp_vrrp_group_version_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+lib_interface_vrrp_vrrp_group_version_modify(struct nb_cb_modify_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct vrrp_vrouter *vr;
 	uint8_t version;
 
-	vr = nb_running_get_entry(dnode, NULL, true);
+	vr = nb_running_get_entry(args->dnode, NULL, true);
 	vrrp_event(vr->v4, VRRP_EVENT_SHUTDOWN);
 	vrrp_event(vr->v6, VRRP_EVENT_SHUTDOWN);
-	version = yang_dnode_get_enum(dnode, NULL);
+	version = yang_dnode_get_enum(args->dnode, NULL);
 	vr->version = version;
 
 	vrrp_check_start(vr);
@@ -170,24 +165,23 @@ static void vrrp_yang_add_del_virtual_address(const struct lyd_node *dnode,
  * /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/v4/virtual-address
  */
 static int lib_interface_vrrp_vrrp_group_v4_virtual_address_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	vrrp_yang_add_del_virtual_address(dnode, true);
+	vrrp_yang_add_del_virtual_address(args->dnode, true);
 
 	return NB_OK;
 }
 
 static int lib_interface_vrrp_vrrp_group_v4_virtual_address_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	vrrp_yang_add_del_virtual_address(dnode, false);
+	vrrp_yang_add_del_virtual_address(args->dnode, false);
 
 	return NB_OK;
 }
@@ -198,11 +192,11 @@ static int lib_interface_vrrp_vrrp_group_v4_virtual_address_destroy(
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v4_current_priority_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint8(xpath, vr->v4->priority);
+	return yang_data_new_uint8(args->xpath, vr->v4->priority);
 }
 
 /*
@@ -210,15 +204,15 @@ lib_interface_vrrp_vrrp_group_v4_current_priority_get_elem(
  * /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/v4/vrrp-interface
  */
 static struct yang_data *
-lib_interface_vrrp_vrrp_group_v4_vrrp_interface_get_elem(const char *xpath,
-							 const void *list_entry)
+lib_interface_vrrp_vrrp_group_v4_vrrp_interface_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
 	struct yang_data *val = NULL;
 
 	if (vr->v4->mvl_ifp)
-		val = yang_data_new_string(xpath, vr->v4->mvl_ifp->name);
+		val = yang_data_new_string(args->xpath, vr->v4->mvl_ifp->name);
 
 	return val;
 }
@@ -228,17 +222,17 @@ lib_interface_vrrp_vrrp_group_v4_vrrp_interface_get_elem(const char *xpath,
  * /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/v4/source-address
  */
 static struct yang_data *
-lib_interface_vrrp_vrrp_group_v4_source_address_get_elem(const char *xpath,
-							 const void *list_entry)
+lib_interface_vrrp_vrrp_group_v4_source_address_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 	struct yang_data *val = NULL;
 	struct ipaddr ip;
 
 	memset(&ip, 0x00, sizeof(ip));
 
 	if (memcmp(&vr->v4->src.ipaddr_v4, &ip.ipaddr_v4, sizeof(ip.ipaddr_v4)))
-		val = yang_data_new_ip(xpath, &vr->v4->src);
+		val = yang_data_new_ip(args->xpath, &vr->v4->src);
 
 	return val;
 }
@@ -246,13 +240,12 @@ lib_interface_vrrp_vrrp_group_v4_source_address_get_elem(const char *xpath,
 /*
  * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/v4/state
  */
-static struct yang_data *
-lib_interface_vrrp_vrrp_group_v4_state_get_elem(const char *xpath,
-						const void *list_entry)
+static struct yang_data *lib_interface_vrrp_vrrp_group_v4_state_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_enum(xpath, vr->v4->fsm.state);
+	return yang_data_new_enum(args->xpath, vr->v4->fsm.state);
 }
 
 /*
@@ -261,23 +254,22 @@ lib_interface_vrrp_vrrp_group_v4_state_get_elem(const char *xpath,
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v4_master_advertisement_interval_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint16(xpath, vr->v4->master_adver_interval);
+	return yang_data_new_uint16(args->xpath, vr->v4->master_adver_interval);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/v4/skew-time
  */
-static struct yang_data *
-lib_interface_vrrp_vrrp_group_v4_skew_time_get_elem(const char *xpath,
-						    const void *list_entry)
+static struct yang_data *lib_interface_vrrp_vrrp_group_v4_skew_time_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint16(xpath, vr->v4->skew_time);
+	return yang_data_new_uint16(args->xpath, vr->v4->skew_time);
 }
 
 /*
@@ -286,11 +278,11 @@ lib_interface_vrrp_vrrp_group_v4_skew_time_get_elem(const char *xpath,
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v4_counter_state_transition_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint32(xpath, vr->v4->stats.trans_cnt);
+	return yang_data_new_uint32(args->xpath, vr->v4->stats.trans_cnt);
 }
 
 /*
@@ -299,11 +291,11 @@ lib_interface_vrrp_vrrp_group_v4_counter_state_transition_get_elem(
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v4_counter_tx_advertisement_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint32(xpath, vr->v4->stats.adver_tx_cnt);
+	return yang_data_new_uint32(args->xpath, vr->v4->stats.adver_tx_cnt);
 }
 
 /*
@@ -312,11 +304,11 @@ lib_interface_vrrp_vrrp_group_v4_counter_tx_advertisement_get_elem(
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v4_counter_tx_gratuitous_arp_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint32(xpath, vr->v4->stats.garp_tx_cnt);
+	return yang_data_new_uint32(args->xpath, vr->v4->stats.garp_tx_cnt);
 }
 
 /*
@@ -325,11 +317,11 @@ lib_interface_vrrp_vrrp_group_v4_counter_tx_gratuitous_arp_get_elem(
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v4_counter_rx_advertisement_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint32(xpath, vr->v4->stats.adver_rx_cnt);
+	return yang_data_new_uint32(args->xpath, vr->v4->stats.adver_rx_cnt);
 }
 
 /*
@@ -337,24 +329,23 @@ lib_interface_vrrp_vrrp_group_v4_counter_rx_advertisement_get_elem(
  * /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/v6/virtual-address
  */
 static int lib_interface_vrrp_vrrp_group_v6_virtual_address_create(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_create_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	vrrp_yang_add_del_virtual_address(dnode, true);
+	vrrp_yang_add_del_virtual_address(args->dnode, true);
 
 	return NB_OK;
 }
 
 static int lib_interface_vrrp_vrrp_group_v6_virtual_address_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	vrrp_yang_add_del_virtual_address(dnode, false);
+	vrrp_yang_add_del_virtual_address(args->dnode, false);
 
 	return NB_OK;
 }
@@ -365,11 +356,11 @@ static int lib_interface_vrrp_vrrp_group_v6_virtual_address_destroy(
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v6_current_priority_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint8(xpath, vr->v6->priority);
+	return yang_data_new_uint8(args->xpath, vr->v6->priority);
 }
 
 /*
@@ -377,14 +368,14 @@ lib_interface_vrrp_vrrp_group_v6_current_priority_get_elem(
  * /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/v6/vrrp-interface
  */
 static struct yang_data *
-lib_interface_vrrp_vrrp_group_v6_vrrp_interface_get_elem(const char *xpath,
-							 const void *list_entry)
+lib_interface_vrrp_vrrp_group_v6_vrrp_interface_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 	struct yang_data *val = NULL;
 
 	if (vr->v6->mvl_ifp)
-		val = yang_data_new_string(xpath, vr->v6->mvl_ifp->name);
+		val = yang_data_new_string(args->xpath, vr->v6->mvl_ifp->name);
 
 	return val;
 }
@@ -394,14 +385,14 @@ lib_interface_vrrp_vrrp_group_v6_vrrp_interface_get_elem(const char *xpath,
  * /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/v6/source-address
  */
 static struct yang_data *
-lib_interface_vrrp_vrrp_group_v6_source_address_get_elem(const char *xpath,
-							 const void *list_entry)
+lib_interface_vrrp_vrrp_group_v6_source_address_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 	struct yang_data *val = NULL;
 
 	if (ipaddr_isset(&vr->v6->src))
-		val = yang_data_new_ip(xpath, &vr->v6->src);
+		val = yang_data_new_ip(args->xpath, &vr->v6->src);
 
 	return val;
 }
@@ -409,13 +400,12 @@ lib_interface_vrrp_vrrp_group_v6_source_address_get_elem(const char *xpath,
 /*
  * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/v6/state
  */
-static struct yang_data *
-lib_interface_vrrp_vrrp_group_v6_state_get_elem(const char *xpath,
-						const void *list_entry)
+static struct yang_data *lib_interface_vrrp_vrrp_group_v6_state_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_enum(xpath, vr->v6->fsm.state);
+	return yang_data_new_enum(args->xpath, vr->v6->fsm.state);
 }
 
 /*
@@ -424,23 +414,22 @@ lib_interface_vrrp_vrrp_group_v6_state_get_elem(const char *xpath,
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v6_master_advertisement_interval_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint16(xpath, vr->v6->master_adver_interval);
+	return yang_data_new_uint16(args->xpath, vr->v6->master_adver_interval);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/v6/skew-time
  */
-static struct yang_data *
-lib_interface_vrrp_vrrp_group_v6_skew_time_get_elem(const char *xpath,
-						    const void *list_entry)
+static struct yang_data *lib_interface_vrrp_vrrp_group_v6_skew_time_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint16(xpath, vr->v6->skew_time);
+	return yang_data_new_uint16(args->xpath, vr->v6->skew_time);
 }
 
 /*
@@ -449,11 +438,11 @@ lib_interface_vrrp_vrrp_group_v6_skew_time_get_elem(const char *xpath,
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v6_counter_state_transition_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint32(xpath, vr->v6->stats.trans_cnt);
+	return yang_data_new_uint32(args->xpath, vr->v6->stats.trans_cnt);
 }
 
 /*
@@ -462,11 +451,11 @@ lib_interface_vrrp_vrrp_group_v6_counter_state_transition_get_elem(
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v6_counter_tx_advertisement_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
-	const struct vrrp_vrouter *vr = list_entry;
+	const struct vrrp_vrouter *vr = args->list_entry;
 
-	return yang_data_new_uint32(xpath, vr->v6->stats.adver_tx_cnt);
+	return yang_data_new_uint32(args->xpath, vr->v6->stats.adver_tx_cnt);
 }
 
 /*
@@ -475,7 +464,7 @@ lib_interface_vrrp_vrrp_group_v6_counter_tx_advertisement_get_elem(
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v6_counter_tx_neighbor_advertisement_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -487,7 +476,7 @@ lib_interface_vrrp_vrrp_group_v6_counter_tx_neighbor_advertisement_get_elem(
  */
 static struct yang_data *
 lib_interface_vrrp_vrrp_group_v6_counter_rx_advertisement_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -497,18 +486,16 @@ lib_interface_vrrp_vrrp_group_v6_counter_rx_advertisement_get_elem(
  * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/priority
  */
 static int
-lib_interface_vrrp_vrrp_group_priority_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource)
+lib_interface_vrrp_vrrp_group_priority_modify(struct nb_cb_modify_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct vrrp_vrouter *vr;
 	uint8_t priority;
 
-	vr = nb_running_get_entry(dnode, NULL, true);
-	priority = yang_dnode_get_uint8(dnode, NULL);
+	vr = nb_running_get_entry(args->dnode, NULL, true);
+	priority = yang_dnode_get_uint8(args->dnode, NULL);
 	vrrp_set_priority(vr, priority);
 
 	return NB_OK;
@@ -518,18 +505,16 @@ lib_interface_vrrp_vrrp_group_priority_modify(enum nb_event event,
  * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/preempt
  */
 static int
-lib_interface_vrrp_vrrp_group_preempt_modify(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+lib_interface_vrrp_vrrp_group_preempt_modify(struct nb_cb_modify_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct vrrp_vrouter *vr;
 	bool preempt;
 
-	vr = nb_running_get_entry(dnode, NULL, true);
-	preempt = yang_dnode_get_bool(dnode, NULL);
+	vr = nb_running_get_entry(args->dnode, NULL, true);
+	preempt = yang_dnode_get_bool(args->dnode, NULL);
 	vr->preempt_mode = preempt;
 
 	return NB_OK;
@@ -539,18 +524,16 @@ lib_interface_vrrp_vrrp_group_preempt_modify(enum nb_event event,
  * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/accept-mode
  */
 static int
-lib_interface_vrrp_vrrp_group_accept_mode_modify(enum nb_event event,
-						 const struct lyd_node *dnode,
-						 union nb_resource *resource)
+lib_interface_vrrp_vrrp_group_accept_mode_modify(struct nb_cb_modify_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct vrrp_vrouter *vr;
 	bool accept;
 
-	vr = nb_running_get_entry(dnode, NULL, true);
-	accept = yang_dnode_get_bool(dnode, NULL);
+	vr = nb_running_get_entry(args->dnode, NULL, true);
+	accept = yang_dnode_get_bool(args->dnode, NULL);
 	vr->accept_mode = accept;
 
 	return NB_OK;
@@ -561,17 +544,16 @@ lib_interface_vrrp_vrrp_group_accept_mode_modify(enum nb_event event,
  * /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/advertisement-interval
  */
 static int lib_interface_vrrp_vrrp_group_advertisement_interval_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct vrrp_vrouter *vr;
 	uint16_t advert_int;
 
-	vr = nb_running_get_entry(dnode, NULL, true);
-	advert_int = yang_dnode_get_uint16(dnode, NULL);
+	vr = nb_running_get_entry(args->dnode, NULL, true);
+	advert_int = yang_dnode_get_uint16(args->dnode, NULL);
 	vrrp_set_advertisement_interval(vr, advert_int);
 
 	return NB_OK;
@@ -581,18 +563,16 @@ static int lib_interface_vrrp_vrrp_group_advertisement_interval_modify(
  * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/shutdown
  */
 static int
-lib_interface_vrrp_vrrp_group_shutdown_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource)
+lib_interface_vrrp_vrrp_group_shutdown_modify(struct nb_cb_modify_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct vrrp_vrouter *vr;
 	bool shutdown;
 
-	vr = nb_running_get_entry(dnode, NULL, true);
-	shutdown = yang_dnode_get_bool(dnode, NULL);
+	vr = nb_running_get_entry(args->dnode, NULL, true);
+	shutdown = yang_dnode_get_bool(args->dnode, NULL);
 
 	vr->shutdown = shutdown;
 

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -23,466 +23,293 @@
 extern const struct frr_yang_module_info frr_zebra_info;
 
 /* prototypes */
-int get_route_information_rpc(const char *xpath, const struct list *input,
-			      struct list *output);
-int get_v6_mroute_info_rpc(const char *xpath, const struct list *input,
-			   struct list *output);
-int get_vrf_info_rpc(const char *xpath, const struct list *input,
-		     struct list *output);
-int get_vrf_vni_info_rpc(const char *xpath, const struct list *input,
-			 struct list *output);
-int get_evpn_info_rpc(const char *xpath, const struct list *input,
-		      struct list *output);
-int get_vni_info_rpc(const char *xpath, const struct list *input,
-		     struct list *output);
-int get_evpn_vni_rmac_rpc(const char *xpath, const struct list *input,
-			  struct list *output);
-int get_evpn_vni_nexthops_rpc(const char *xpath, const struct list *input,
-			      struct list *output);
-int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
-			    struct list *output);
-int get_evpn_macs_rpc(const char *xpath, const struct list *input,
-		      struct list *output);
-int get_evpn_arp_cache_rpc(const char *xpath, const struct list *input,
-			   struct list *output);
-int get_pbr_ipset_rpc(const char *xpath, const struct list *input,
-		      struct list *output);
-int get_pbr_iptable_rpc(const char *xpath, const struct list *input,
-			struct list *output);
-int get_debugs_rpc(const char *xpath, const struct list *input,
-		   struct list *output);
-int zebra_mcast_rpf_lookup_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource);
-int zebra_ip_forwarding_modify(enum nb_event event,
-			       const struct lyd_node *dnode,
-			       union nb_resource *resource);
-int zebra_ip_forwarding_destroy(enum nb_event event,
-				const struct lyd_node *dnode);
-int zebra_ipv6_forwarding_modify(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource);
-int zebra_ipv6_forwarding_destroy(enum nb_event event,
-				  const struct lyd_node *dnode);
-int zebra_workqueue_hold_timer_modify(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource);
-int zebra_zapi_packets_modify(enum nb_event event, const struct lyd_node *dnode,
-			      union nb_resource *resource);
-int zebra_import_kernel_table_table_id_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource);
-int zebra_import_kernel_table_table_id_destroy(enum nb_event event,
-					       const struct lyd_node *dnode);
-int zebra_import_kernel_table_distance_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource);
-int zebra_import_kernel_table_route_map_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource);
-int zebra_import_kernel_table_route_map_destroy(enum nb_event event,
-						const struct lyd_node *dnode);
-int zebra_allow_external_route_update_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
-int zebra_allow_external_route_update_destroy(enum nb_event event,
-					      const struct lyd_node *dnode);
-int zebra_dplane_queue_limit_modify(enum nb_event event,
-				    const struct lyd_node *dnode,
-				    union nb_resource *resource);
-int zebra_vrf_vni_mapping_create(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource);
-int zebra_vrf_vni_mapping_destroy(enum nb_event event,
-				  const struct lyd_node *dnode);
-int zebra_vrf_vni_mapping_vni_id_modify(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource);
-int zebra_vrf_vni_mapping_vni_id_destroy(enum nb_event event,
-					 const struct lyd_node *dnode);
-int zebra_vrf_vni_mapping_prefix_only_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
-int zebra_vrf_vni_mapping_prefix_only_destroy(enum nb_event event,
-					      const struct lyd_node *dnode);
-int zebra_debugs_debug_events_modify(enum nb_event event,
-				     const struct lyd_node *dnode,
-				     union nb_resource *resource);
-int zebra_debugs_debug_events_destroy(enum nb_event event,
-				      const struct lyd_node *dnode);
-int zebra_debugs_debug_zapi_send_modify(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource);
-int zebra_debugs_debug_zapi_send_destroy(enum nb_event event,
-					 const struct lyd_node *dnode);
-int zebra_debugs_debug_zapi_recv_modify(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource);
-int zebra_debugs_debug_zapi_recv_destroy(enum nb_event event,
-					 const struct lyd_node *dnode);
-int zebra_debugs_debug_zapi_detail_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource);
-int zebra_debugs_debug_zapi_detail_destroy(enum nb_event event,
-					   const struct lyd_node *dnode);
-int zebra_debugs_debug_kernel_modify(enum nb_event event,
-				     const struct lyd_node *dnode,
-				     union nb_resource *resource);
-int zebra_debugs_debug_kernel_destroy(enum nb_event event,
-				      const struct lyd_node *dnode);
-int zebra_debugs_debug_kernel_msg_send_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource);
-int zebra_debugs_debug_kernel_msg_send_destroy(enum nb_event event,
-					       const struct lyd_node *dnode);
-int zebra_debugs_debug_kernel_msg_recv_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource);
-int zebra_debugs_debug_kernel_msg_recv_destroy(enum nb_event event,
-					       const struct lyd_node *dnode);
-int zebra_debugs_debug_rib_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource);
-int zebra_debugs_debug_rib_destroy(enum nb_event event,
-				   const struct lyd_node *dnode);
-int zebra_debugs_debug_rib_detail_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource);
-int zebra_debugs_debug_rib_detail_destroy(enum nb_event event,
-					  const struct lyd_node *dnode);
-int zebra_debugs_debug_fpm_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource);
-int zebra_debugs_debug_fpm_destroy(enum nb_event event,
-				   const struct lyd_node *dnode);
-int zebra_debugs_debug_nht_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource);
-int zebra_debugs_debug_nht_destroy(enum nb_event event,
-				   const struct lyd_node *dnode);
-int zebra_debugs_debug_nht_detail_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource);
-int zebra_debugs_debug_nht_detail_destroy(enum nb_event event,
-					  const struct lyd_node *dnode);
-int zebra_debugs_debug_mpls_modify(enum nb_event event,
-				   const struct lyd_node *dnode,
-				   union nb_resource *resource);
-int zebra_debugs_debug_mpls_destroy(enum nb_event event,
-				    const struct lyd_node *dnode);
-int zebra_debugs_debug_vxlan_modify(enum nb_event event,
-				    const struct lyd_node *dnode,
-				    union nb_resource *resource);
-int zebra_debugs_debug_vxlan_destroy(enum nb_event event,
-				     const struct lyd_node *dnode);
-int zebra_debugs_debug_pw_modify(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource);
-int zebra_debugs_debug_pw_destroy(enum nb_event event,
-				  const struct lyd_node *dnode);
-int zebra_debugs_debug_dplane_modify(enum nb_event event,
-				     const struct lyd_node *dnode,
-				     union nb_resource *resource);
-int zebra_debugs_debug_dplane_destroy(enum nb_event event,
-				      const struct lyd_node *dnode);
-int zebra_debugs_debug_dplane_detail_modify(enum nb_event event,
-					    const struct lyd_node *dnode,
-					    union nb_resource *resource);
-int zebra_debugs_debug_dplane_detail_destroy(enum nb_event event,
-					     const struct lyd_node *dnode);
-int zebra_debugs_debug_mlag_modify(enum nb_event event,
-				   const struct lyd_node *dnode,
-				   union nb_resource *resource);
-int zebra_debugs_debug_mlag_destroy(enum nb_event event,
-				    const struct lyd_node *dnode);
-int lib_interface_zebra_ip_addrs_create(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource);
-int lib_interface_zebra_ip_addrs_destroy(enum nb_event event,
-					 const struct lyd_node *dnode);
-int lib_interface_zebra_ip_addrs_label_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource);
-int lib_interface_zebra_ip_addrs_label_destroy(enum nb_event event,
-					       const struct lyd_node *dnode);
-int lib_interface_zebra_ip_addrs_ip4_peer_modify(enum nb_event event,
-						 const struct lyd_node *dnode,
-						 union nb_resource *resource);
-int lib_interface_zebra_ip_addrs_ip4_peer_destroy(enum nb_event event,
-						  const struct lyd_node *dnode);
-int lib_interface_zebra_multicast_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource);
-int lib_interface_zebra_multicast_destroy(enum nb_event event,
-					  const struct lyd_node *dnode);
-int lib_interface_zebra_link_detect_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource);
-int lib_interface_zebra_link_detect_destroy(enum nb_event event,
-					    const struct lyd_node *dnode);
-int lib_interface_zebra_shutdown_modify(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource);
-int lib_interface_zebra_shutdown_destroy(enum nb_event event,
-					 const struct lyd_node *dnode);
-int lib_interface_zebra_bandwidth_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource);
-int lib_interface_zebra_bandwidth_destroy(enum nb_event event,
-					  const struct lyd_node *dnode);
+int get_route_information_rpc(struct nb_cb_rpc_args *args);
+int get_v6_mroute_info_rpc(struct nb_cb_rpc_args *args);
+int get_vrf_info_rpc(struct nb_cb_rpc_args *args);
+int get_vrf_vni_info_rpc(struct nb_cb_rpc_args *args);
+int get_evpn_info_rpc(struct nb_cb_rpc_args *args);
+int get_vni_info_rpc(struct nb_cb_rpc_args *args);
+int get_evpn_vni_rmac_rpc(struct nb_cb_rpc_args *args);
+int get_evpn_vni_nexthops_rpc(struct nb_cb_rpc_args *args);
+int clear_evpn_dup_addr_rpc(struct nb_cb_rpc_args *args);
+int get_evpn_macs_rpc(struct nb_cb_rpc_args *args);
+int get_evpn_arp_cache_rpc(struct nb_cb_rpc_args *args);
+int get_pbr_ipset_rpc(struct nb_cb_rpc_args *args);
+int get_pbr_iptable_rpc(struct nb_cb_rpc_args *args);
+int get_debugs_rpc(struct nb_cb_rpc_args *args);
+int zebra_mcast_rpf_lookup_modify(struct nb_cb_modify_args *args);
+int zebra_ip_forwarding_modify(struct nb_cb_modify_args *args);
+int zebra_ip_forwarding_destroy(struct nb_cb_destroy_args *args);
+int zebra_ipv6_forwarding_modify(struct nb_cb_modify_args *args);
+int zebra_ipv6_forwarding_destroy(struct nb_cb_destroy_args *args);
+int zebra_workqueue_hold_timer_modify(struct nb_cb_modify_args *args);
+int zebra_zapi_packets_modify(struct nb_cb_modify_args *args);
+int zebra_import_kernel_table_table_id_modify(struct nb_cb_modify_args *args);
+int zebra_import_kernel_table_table_id_destroy(struct nb_cb_destroy_args *args);
+int zebra_import_kernel_table_distance_modify(struct nb_cb_modify_args *args);
+int zebra_import_kernel_table_route_map_modify(struct nb_cb_modify_args *args);
+int zebra_import_kernel_table_route_map_destroy(
+	struct nb_cb_destroy_args *args);
+int zebra_allow_external_route_update_create(struct nb_cb_create_args *args);
+int zebra_allow_external_route_update_destroy(struct nb_cb_destroy_args *args);
+int zebra_dplane_queue_limit_modify(struct nb_cb_modify_args *args);
+int zebra_vrf_vni_mapping_create(struct nb_cb_create_args *args);
+int zebra_vrf_vni_mapping_destroy(struct nb_cb_destroy_args *args);
+int zebra_vrf_vni_mapping_vni_id_modify(struct nb_cb_modify_args *args);
+int zebra_vrf_vni_mapping_vni_id_destroy(struct nb_cb_destroy_args *args);
+int zebra_vrf_vni_mapping_prefix_only_create(struct nb_cb_create_args *args);
+int zebra_vrf_vni_mapping_prefix_only_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_events_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_events_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_zapi_send_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_zapi_send_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_zapi_recv_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_zapi_recv_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_zapi_detail_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_zapi_detail_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_kernel_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_kernel_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_kernel_msg_send_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_kernel_msg_send_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_kernel_msg_recv_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_kernel_msg_recv_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_rib_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_rib_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_rib_detail_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_rib_detail_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_fpm_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_fpm_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_nht_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_nht_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_nht_detail_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_nht_detail_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_mpls_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_mpls_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_vxlan_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_vxlan_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_pw_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_pw_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_dplane_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_dplane_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_dplane_detail_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_dplane_detail_destroy(struct nb_cb_destroy_args *args);
+int zebra_debugs_debug_mlag_modify(struct nb_cb_modify_args *args);
+int zebra_debugs_debug_mlag_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_zebra_ip_addrs_create(struct nb_cb_create_args *args);
+int lib_interface_zebra_ip_addrs_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_zebra_ip_addrs_label_modify(struct nb_cb_modify_args *args);
+int lib_interface_zebra_ip_addrs_label_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_zebra_ip_addrs_ip4_peer_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_zebra_ip_addrs_ip4_peer_destroy(
+	struct nb_cb_destroy_args *args);
+int lib_interface_zebra_multicast_modify(struct nb_cb_modify_args *args);
+int lib_interface_zebra_multicast_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_zebra_link_detect_modify(struct nb_cb_modify_args *args);
+int lib_interface_zebra_link_detect_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_zebra_shutdown_modify(struct nb_cb_modify_args *args);
+int lib_interface_zebra_shutdown_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_zebra_bandwidth_modify(struct nb_cb_modify_args *args);
+int lib_interface_zebra_bandwidth_destroy(struct nb_cb_destroy_args *args);
 int lib_route_map_entry_match_condition_ipv4_prefix_length_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_route_map_entry_match_condition_ipv4_prefix_length_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int lib_route_map_entry_match_condition_ipv6_prefix_length_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_route_map_entry_match_condition_ipv6_prefix_length_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int lib_route_map_entry_match_condition_source_protocol_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_route_map_entry_match_condition_source_protocol_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int lib_route_map_entry_match_condition_source_instance_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_route_map_entry_match_condition_source_instance_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int lib_route_map_entry_set_action_source_v4_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_route_map_entry_set_action_source_v4_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 int lib_route_map_entry_set_action_source_v6_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
+	struct nb_cb_modify_args *args);
 int lib_route_map_entry_set_action_source_v6_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+	struct nb_cb_destroy_args *args);
 struct yang_data *
-lib_interface_zebra_state_up_count_get_elem(const char *xpath,
-					    const void *list_entry);
+lib_interface_zebra_state_up_count_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_interface_zebra_state_down_count_get_elem(const char *xpath,
-					      const void *list_entry);
+lib_interface_zebra_state_down_count_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_interface_zebra_state_zif_type_get_elem(const char *xpath,
-					    const void *list_entry);
+lib_interface_zebra_state_zif_type_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_interface_zebra_state_ptm_status_get_elem(const char *xpath,
-					      const void *list_entry);
+lib_interface_zebra_state_ptm_status_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_interface_zebra_state_vlan_id_get_elem(const char *xpath,
-					   const void *list_entry);
+lib_interface_zebra_state_vlan_id_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_interface_zebra_state_vni_id_get_elem(const char *xpath,
-					  const void *list_entry);
-struct yang_data *
-lib_interface_zebra_state_remote_vtep_get_elem(const char *xpath,
-					       const void *list_entry);
-struct yang_data *
-lib_interface_zebra_state_mcast_group_get_elem(const char *xpath,
-					       const void *list_entry);
-int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
-			    union nb_resource *resource);
-int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode);
-const void *lib_vrf_ribs_rib_get_next(const void *parent_list_entry,
-				      const void *list_entry);
-int lib_vrf_ribs_rib_get_keys(const void *list_entry,
-			      struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_lookup_entry(const void *parent_list_entry,
-					  const struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_route_get_next(const void *parent_list_entry,
-					    const void *list_entry);
-int lib_vrf_ribs_rib_route_get_keys(const void *list_entry,
-				    struct yang_list_keys *keys);
+lib_interface_zebra_state_vni_id_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *lib_interface_zebra_state_remote_vtep_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_interface_zebra_state_mcast_group_get_elem(
+	struct nb_cb_get_elem_args *args);
+int lib_vrf_ribs_rib_create(struct nb_cb_create_args *args);
+int lib_vrf_ribs_rib_destroy(struct nb_cb_destroy_args *args);
+const void *lib_vrf_ribs_rib_get_next(struct nb_cb_get_next_args *args);
+int lib_vrf_ribs_rib_get_keys(struct nb_cb_get_keys_args *args);
+const void *lib_vrf_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args);
+const void *lib_vrf_ribs_rib_route_get_next(struct nb_cb_get_next_args *args);
+int lib_vrf_ribs_rib_route_get_keys(struct nb_cb_get_keys_args *args);
 const void *
-lib_vrf_ribs_rib_route_lookup_entry(const void *parent_list_entry,
-				    const struct yang_list_keys *keys);
+lib_vrf_ribs_rib_route_lookup_entry(struct nb_cb_lookup_entry_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_prefix_get_elem(const char *xpath,
-				       const void *list_entry);
+lib_vrf_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_protocol_get_elem(const char *xpath,
-					 const void *list_entry);
+lib_vrf_ribs_rib_route_protocol_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_protocol_v6_get_elem(const char *xpath,
-					    const void *list_entry);
-struct yang_data *lib_vrf_ribs_rib_route_vrf_get_elem(const char *xpath,
-						      const void *list_entry);
+lib_vrf_ribs_rib_route_protocol_v6_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_distance_get_elem(const char *xpath,
-					 const void *list_entry);
+lib_vrf_ribs_rib_route_vrf_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_metric_get_elem(const char *xpath,
-				       const void *list_entry);
-struct yang_data *lib_vrf_ribs_rib_route_tag_get_elem(const char *xpath,
-						      const void *list_entry);
+lib_vrf_ribs_rib_route_distance_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_selected_get_elem(const char *xpath,
-					 const void *list_entry);
+lib_vrf_ribs_rib_route_metric_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_installed_get_elem(const char *xpath,
-					  const void *list_entry);
+lib_vrf_ribs_rib_route_tag_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_failed_get_elem(const char *xpath,
-				       const void *list_entry);
+lib_vrf_ribs_rib_route_selected_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_queued_get_elem(const char *xpath,
-				       const void *list_entry);
+lib_vrf_ribs_rib_route_installed_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_internal_flags_get_elem(const char *xpath,
-					       const void *list_entry);
+lib_vrf_ribs_rib_route_failed_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_internal_status_get_elem(const char *xpath,
-						const void *list_entry);
+lib_vrf_ribs_rib_route_queued_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_internal_flags_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_internal_status_get_elem(
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_uptime_get_elem(const char *xpath,
-				       const void *list_entry);
+lib_vrf_ribs_rib_route_uptime_get_elem(struct nb_cb_get_elem_args *args);
 const void *
-lib_vrf_ribs_rib_route_nexthop_group_get_next(const void *parent_list_entry,
-					      const void *list_entry);
-int lib_vrf_ribs_rib_route_nexthop_group_get_keys(const void *list_entry,
-						  struct yang_list_keys *keys);
+lib_vrf_ribs_rib_route_nexthop_group_get_next(struct nb_cb_get_next_args *args);
+int lib_vrf_ribs_rib_route_nexthop_group_get_keys(
+	struct nb_cb_get_keys_args *args);
 const void *lib_vrf_ribs_rib_route_nexthop_group_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys);
-struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_name_get_elem(const char *xpath,
-						   const void *list_entry);
+	struct nb_cb_lookup_entry_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_nexthop_group_name_get_elem(
+	struct nb_cb_get_elem_args *args);
 const void *lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next(
-	const void *parent_list_entry, const void *list_entry);
+	struct nb_cb_get_next_args *args);
 int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys(
-	const void *list_entry, struct yang_list_keys *keys);
-int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
-			    union nb_resource *resource);
-int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode);
-const void *lib_vrf_ribs_rib_get_next(const void *parent_list_entry,
-				      const void *list_entry);
-int lib_vrf_ribs_rib_get_keys(const void *list_entry,
-			      struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_lookup_entry(const void *parent_list_entry,
-					  const struct yang_list_keys *keys);
-const void *lib_vrf_ribs_rib_route_get_next(const void *parent_list_entry,
-					    const void *list_entry);
-int lib_vrf_ribs_rib_route_get_keys(const void *list_entry,
-				    struct yang_list_keys *keys);
+	struct nb_cb_get_keys_args *args);
+int lib_vrf_ribs_rib_create(struct nb_cb_create_args *args);
+int lib_vrf_ribs_rib_destroy(struct nb_cb_destroy_args *args);
+const void *lib_vrf_ribs_rib_get_next(struct nb_cb_get_next_args *args);
+int lib_vrf_ribs_rib_get_keys(struct nb_cb_get_keys_args *args);
+const void *lib_vrf_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args);
+const void *lib_vrf_ribs_rib_route_get_next(struct nb_cb_get_next_args *args);
+int lib_vrf_ribs_rib_route_get_keys(struct nb_cb_get_keys_args *args);
 const void *
-lib_vrf_ribs_rib_route_lookup_entry(const void *parent_list_entry,
-				    const struct yang_list_keys *keys);
+lib_vrf_ribs_rib_route_lookup_entry(struct nb_cb_lookup_entry_args *args);
 struct yang_data *
-lib_vrf_ribs_rib_route_prefix_get_elem(const char *xpath,
-				       const void *list_entry);
+lib_vrf_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args);
 const void *
-lib_vrf_ribs_rib_route_route_entry_get_next(const void *parent_list_entry,
-					    const void *list_entry);
-int lib_vrf_ribs_rib_route_route_entry_get_keys(const void *list_entry,
-						struct yang_list_keys *keys);
+lib_vrf_ribs_rib_route_route_entry_get_next(struct nb_cb_get_next_args *args);
+int lib_vrf_ribs_rib_route_route_entry_get_keys(
+	struct nb_cb_get_keys_args *args);
 const void *lib_vrf_ribs_rib_route_route_entry_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_protocol_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_instance_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_distance_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_metric_get_elem(const char *xpath,
-						   const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_tag_get_elem(const char *xpath,
-						const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_selected_get_elem(const char *xpath,
-						     const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_installed_get_elem(const char *xpath,
-						      const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_failed_get_elem(const char *xpath,
-						   const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_queued_get_elem(const char *xpath,
-						   const void *list_entry);
+	struct nb_cb_lookup_entry_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_protocol_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_instance_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_distance_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_metric_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_tag_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_selected_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_installed_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_failed_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_queued_get_elem(
+	struct nb_cb_get_elem_args *args);
 struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_flags_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_status_get_elem(
-	const char *xpath, const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_uptime_get_elem(const char *xpath,
-						   const void *list_entry);
+	struct nb_cb_get_elem_args *args);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_uptime_get_elem(
+	struct nb_cb_get_elem_args *args);
 const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_next(
-	const void *parent_list_entry, const void *list_entry);
+	struct nb_cb_get_next_args *args);
 int lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_keys(
-	const void *list_entry, struct yang_list_keys *keys);
+	struct nb_cb_get_keys_args *args);
 const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys);
+	struct nb_cb_lookup_entry_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_name_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 const void *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next(
-	const void *parent_list_entry, const void *list_entry);
+	struct nb_cb_get_next_args *args);
 int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys(
-	const void *list_entry, struct yang_list_keys *keys);
+	struct nb_cb_get_keys_args *args);
 const void *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys);
+	struct nb_cb_lookup_entry_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 const void *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
-	const void *parent_list_entry, const void *list_entry);
+	struct nb_cb_get_next_args *args);
 int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
-	const void *list_entry, struct yang_list_keys *keys);
+	struct nb_cb_get_keys_args *args);
 const void *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys);
+	struct nb_cb_lookup_entry_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
-	const char *xpath, const void *list_entry);
+	struct nb_cb_get_elem_args *args);
 
 #endif

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -33,11 +33,9 @@
 /*
  * XPath: /frr-zebra:zebra/mcast-rpf-lookup
  */
-int zebra_mcast_rpf_lookup_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource)
+int zebra_mcast_rpf_lookup_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -52,11 +50,9 @@ int zebra_mcast_rpf_lookup_modify(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/ip-forwarding
  */
-int zebra_ip_forwarding_modify(enum nb_event event,
-			       const struct lyd_node *dnode,
-			       union nb_resource *resource)
+int zebra_ip_forwarding_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -68,10 +64,9 @@ int zebra_ip_forwarding_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_ip_forwarding_destroy(enum nb_event event,
-				const struct lyd_node *dnode)
+int zebra_ip_forwarding_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -86,11 +81,9 @@ int zebra_ip_forwarding_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/ipv6-forwarding
  */
-int zebra_ipv6_forwarding_modify(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource)
+int zebra_ipv6_forwarding_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -102,10 +95,9 @@ int zebra_ipv6_forwarding_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_ipv6_forwarding_destroy(enum nb_event event,
-				  const struct lyd_node *dnode)
+int zebra_ipv6_forwarding_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -120,11 +112,9 @@ int zebra_ipv6_forwarding_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/workqueue-hold-timer
  */
-int zebra_workqueue_hold_timer_modify(enum nb_event event,
-				      const struct lyd_node *dnode,
-				      union nb_resource *resource)
+int zebra_workqueue_hold_timer_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -139,10 +129,9 @@ int zebra_workqueue_hold_timer_modify(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/zapi-packets
  */
-int zebra_zapi_packets_modify(enum nb_event event, const struct lyd_node *dnode,
-			      union nb_resource *resource)
+int zebra_zapi_packets_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -157,11 +146,9 @@ int zebra_zapi_packets_modify(enum nb_event event, const struct lyd_node *dnode,
 /*
  * XPath: /frr-zebra:zebra/import-kernel-table/table-id
  */
-int zebra_import_kernel_table_table_id_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource)
+int zebra_import_kernel_table_table_id_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -173,10 +160,9 @@ int zebra_import_kernel_table_table_id_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_import_kernel_table_table_id_destroy(enum nb_event event,
-					       const struct lyd_node *dnode)
+int zebra_import_kernel_table_table_id_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -191,11 +177,9 @@ int zebra_import_kernel_table_table_id_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/import-kernel-table/distance
  */
-int zebra_import_kernel_table_distance_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource)
+int zebra_import_kernel_table_distance_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -210,11 +194,9 @@ int zebra_import_kernel_table_distance_modify(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/import-kernel-table/route-map
  */
-int zebra_import_kernel_table_route_map_modify(enum nb_event event,
-					       const struct lyd_node *dnode,
-					       union nb_resource *resource)
+int zebra_import_kernel_table_route_map_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -226,10 +208,9 @@ int zebra_import_kernel_table_route_map_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_import_kernel_table_route_map_destroy(enum nb_event event,
-						const struct lyd_node *dnode)
+int zebra_import_kernel_table_route_map_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -244,11 +225,9 @@ int zebra_import_kernel_table_route_map_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/allow-external-route-update
  */
-int zebra_allow_external_route_update_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+int zebra_allow_external_route_update_create(struct nb_cb_create_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -260,10 +239,9 @@ int zebra_allow_external_route_update_create(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_allow_external_route_update_destroy(enum nb_event event,
-					      const struct lyd_node *dnode)
+int zebra_allow_external_route_update_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -278,11 +256,9 @@ int zebra_allow_external_route_update_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/dplane-queue-limit
  */
-int zebra_dplane_queue_limit_modify(enum nb_event event,
-				    const struct lyd_node *dnode,
-				    union nb_resource *resource)
+int zebra_dplane_queue_limit_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -297,11 +273,9 @@ int zebra_dplane_queue_limit_modify(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/vrf-vni-mapping
  */
-int zebra_vrf_vni_mapping_create(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource)
+int zebra_vrf_vni_mapping_create(struct nb_cb_create_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -313,10 +287,9 @@ int zebra_vrf_vni_mapping_create(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_vrf_vni_mapping_destroy(enum nb_event event,
-				  const struct lyd_node *dnode)
+int zebra_vrf_vni_mapping_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -331,11 +304,9 @@ int zebra_vrf_vni_mapping_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/vrf-vni-mapping/vni-id
  */
-int zebra_vrf_vni_mapping_vni_id_modify(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource)
+int zebra_vrf_vni_mapping_vni_id_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -347,10 +318,9 @@ int zebra_vrf_vni_mapping_vni_id_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_vrf_vni_mapping_vni_id_destroy(enum nb_event event,
-					 const struct lyd_node *dnode)
+int zebra_vrf_vni_mapping_vni_id_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -365,11 +335,9 @@ int zebra_vrf_vni_mapping_vni_id_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/vrf-vni-mapping/prefix-only
  */
-int zebra_vrf_vni_mapping_prefix_only_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+int zebra_vrf_vni_mapping_prefix_only_create(struct nb_cb_create_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -381,10 +349,9 @@ int zebra_vrf_vni_mapping_prefix_only_create(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_vrf_vni_mapping_prefix_only_destroy(enum nb_event event,
-					      const struct lyd_node *dnode)
+int zebra_vrf_vni_mapping_prefix_only_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -399,11 +366,9 @@ int zebra_vrf_vni_mapping_prefix_only_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-events
  */
-int zebra_debugs_debug_events_modify(enum nb_event event,
-				     const struct lyd_node *dnode,
-				     union nb_resource *resource)
+int zebra_debugs_debug_events_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -415,10 +380,9 @@ int zebra_debugs_debug_events_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_events_destroy(enum nb_event event,
-				      const struct lyd_node *dnode)
+int zebra_debugs_debug_events_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -433,11 +397,9 @@ int zebra_debugs_debug_events_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-zapi-send
  */
-int zebra_debugs_debug_zapi_send_modify(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource)
+int zebra_debugs_debug_zapi_send_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -449,10 +411,9 @@ int zebra_debugs_debug_zapi_send_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_zapi_send_destroy(enum nb_event event,
-					 const struct lyd_node *dnode)
+int zebra_debugs_debug_zapi_send_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -467,11 +428,9 @@ int zebra_debugs_debug_zapi_send_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-zapi-recv
  */
-int zebra_debugs_debug_zapi_recv_modify(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource)
+int zebra_debugs_debug_zapi_recv_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -483,10 +442,9 @@ int zebra_debugs_debug_zapi_recv_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_zapi_recv_destroy(enum nb_event event,
-					 const struct lyd_node *dnode)
+int zebra_debugs_debug_zapi_recv_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -501,11 +459,9 @@ int zebra_debugs_debug_zapi_recv_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-zapi-detail
  */
-int zebra_debugs_debug_zapi_detail_modify(enum nb_event event,
-					  const struct lyd_node *dnode,
-					  union nb_resource *resource)
+int zebra_debugs_debug_zapi_detail_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -517,10 +473,9 @@ int zebra_debugs_debug_zapi_detail_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_zapi_detail_destroy(enum nb_event event,
-					   const struct lyd_node *dnode)
+int zebra_debugs_debug_zapi_detail_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -535,11 +490,9 @@ int zebra_debugs_debug_zapi_detail_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-kernel
  */
-int zebra_debugs_debug_kernel_modify(enum nb_event event,
-				     const struct lyd_node *dnode,
-				     union nb_resource *resource)
+int zebra_debugs_debug_kernel_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -551,10 +504,9 @@ int zebra_debugs_debug_kernel_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_kernel_destroy(enum nb_event event,
-				      const struct lyd_node *dnode)
+int zebra_debugs_debug_kernel_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -569,11 +521,9 @@ int zebra_debugs_debug_kernel_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-kernel-msg-send
  */
-int zebra_debugs_debug_kernel_msg_send_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource)
+int zebra_debugs_debug_kernel_msg_send_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -585,10 +535,9 @@ int zebra_debugs_debug_kernel_msg_send_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_kernel_msg_send_destroy(enum nb_event event,
-					       const struct lyd_node *dnode)
+int zebra_debugs_debug_kernel_msg_send_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -603,11 +552,9 @@ int zebra_debugs_debug_kernel_msg_send_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-kernel-msg-recv
  */
-int zebra_debugs_debug_kernel_msg_recv_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource)
+int zebra_debugs_debug_kernel_msg_recv_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -619,10 +566,9 @@ int zebra_debugs_debug_kernel_msg_recv_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_kernel_msg_recv_destroy(enum nb_event event,
-					       const struct lyd_node *dnode)
+int zebra_debugs_debug_kernel_msg_recv_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -637,11 +583,9 @@ int zebra_debugs_debug_kernel_msg_recv_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-rib
  */
-int zebra_debugs_debug_rib_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource)
+int zebra_debugs_debug_rib_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -653,10 +597,9 @@ int zebra_debugs_debug_rib_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_rib_destroy(enum nb_event event,
-				   const struct lyd_node *dnode)
+int zebra_debugs_debug_rib_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -671,11 +614,9 @@ int zebra_debugs_debug_rib_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-rib-detail
  */
-int zebra_debugs_debug_rib_detail_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+int zebra_debugs_debug_rib_detail_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -687,10 +628,9 @@ int zebra_debugs_debug_rib_detail_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_rib_detail_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+int zebra_debugs_debug_rib_detail_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -705,11 +645,9 @@ int zebra_debugs_debug_rib_detail_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-fpm
  */
-int zebra_debugs_debug_fpm_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource)
+int zebra_debugs_debug_fpm_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -721,10 +659,9 @@ int zebra_debugs_debug_fpm_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_fpm_destroy(enum nb_event event,
-				   const struct lyd_node *dnode)
+int zebra_debugs_debug_fpm_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -739,11 +676,9 @@ int zebra_debugs_debug_fpm_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-nht
  */
-int zebra_debugs_debug_nht_modify(enum nb_event event,
-				  const struct lyd_node *dnode,
-				  union nb_resource *resource)
+int zebra_debugs_debug_nht_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -755,10 +690,9 @@ int zebra_debugs_debug_nht_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_nht_destroy(enum nb_event event,
-				   const struct lyd_node *dnode)
+int zebra_debugs_debug_nht_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -773,11 +707,9 @@ int zebra_debugs_debug_nht_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-nht-detail
  */
-int zebra_debugs_debug_nht_detail_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+int zebra_debugs_debug_nht_detail_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -789,10 +721,9 @@ int zebra_debugs_debug_nht_detail_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_nht_detail_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+int zebra_debugs_debug_nht_detail_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -807,11 +738,9 @@ int zebra_debugs_debug_nht_detail_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-mpls
  */
-int zebra_debugs_debug_mpls_modify(enum nb_event event,
-				   const struct lyd_node *dnode,
-				   union nb_resource *resource)
+int zebra_debugs_debug_mpls_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -823,10 +752,9 @@ int zebra_debugs_debug_mpls_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_mpls_destroy(enum nb_event event,
-				    const struct lyd_node *dnode)
+int zebra_debugs_debug_mpls_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -841,11 +769,9 @@ int zebra_debugs_debug_mpls_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-vxlan
  */
-int zebra_debugs_debug_vxlan_modify(enum nb_event event,
-				    const struct lyd_node *dnode,
-				    union nb_resource *resource)
+int zebra_debugs_debug_vxlan_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -857,10 +783,9 @@ int zebra_debugs_debug_vxlan_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_vxlan_destroy(enum nb_event event,
-				     const struct lyd_node *dnode)
+int zebra_debugs_debug_vxlan_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -875,11 +800,9 @@ int zebra_debugs_debug_vxlan_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-pw
  */
-int zebra_debugs_debug_pw_modify(enum nb_event event,
-				 const struct lyd_node *dnode,
-				 union nb_resource *resource)
+int zebra_debugs_debug_pw_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -891,10 +814,9 @@ int zebra_debugs_debug_pw_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_pw_destroy(enum nb_event event,
-				  const struct lyd_node *dnode)
+int zebra_debugs_debug_pw_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -909,11 +831,9 @@ int zebra_debugs_debug_pw_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-dplane
  */
-int zebra_debugs_debug_dplane_modify(enum nb_event event,
-				     const struct lyd_node *dnode,
-				     union nb_resource *resource)
+int zebra_debugs_debug_dplane_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -925,10 +845,9 @@ int zebra_debugs_debug_dplane_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_dplane_destroy(enum nb_event event,
-				      const struct lyd_node *dnode)
+int zebra_debugs_debug_dplane_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -943,11 +862,9 @@ int zebra_debugs_debug_dplane_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-dplane-detail
  */
-int zebra_debugs_debug_dplane_detail_modify(enum nb_event event,
-					    const struct lyd_node *dnode,
-					    union nb_resource *resource)
+int zebra_debugs_debug_dplane_detail_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -959,10 +876,9 @@ int zebra_debugs_debug_dplane_detail_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_dplane_detail_destroy(enum nb_event event,
-					     const struct lyd_node *dnode)
+int zebra_debugs_debug_dplane_detail_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -977,11 +893,9 @@ int zebra_debugs_debug_dplane_detail_destroy(enum nb_event event,
 /*
  * XPath: /frr-zebra:zebra/debugs/debug-mlag
  */
-int zebra_debugs_debug_mlag_modify(enum nb_event event,
-				   const struct lyd_node *dnode,
-				   union nb_resource *resource)
+int zebra_debugs_debug_mlag_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -993,10 +907,9 @@ int zebra_debugs_debug_mlag_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int zebra_debugs_debug_mlag_destroy(enum nb_event event,
-				    const struct lyd_node *dnode)
+int zebra_debugs_debug_mlag_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -1011,20 +924,18 @@ int zebra_debugs_debug_mlag_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip-addrs
  */
-int lib_interface_zebra_ip_addrs_create(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource)
+int lib_interface_zebra_ip_addrs_create(struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
 	struct prefix prefix;
 	char buf[PREFIX_STRLEN] = {0};
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
 	// addr_family = yang_dnode_get_enum(dnode, "./address-family");
-	yang_dnode_get_prefix(&prefix, dnode, "./ip-prefix");
+	yang_dnode_get_prefix(&prefix, args->dnode, "./ip-prefix");
 	apply_mask(&prefix);
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if (prefix.family == AF_INET
 		    && ipv4_martian(&prefix.u.prefix4)) {
@@ -1053,18 +964,17 @@ int lib_interface_zebra_ip_addrs_create(enum nb_event event,
 	return NB_OK;
 }
 
-int lib_interface_zebra_ip_addrs_destroy(enum nb_event event,
-					 const struct lyd_node *dnode)
+int lib_interface_zebra_ip_addrs_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct prefix prefix;
 	struct connected *ifc;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
-	yang_dnode_get_prefix(&prefix, dnode, "./ip-prefix");
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
+	yang_dnode_get_prefix(&prefix, args->dnode, "./ip-prefix");
 	apply_mask(&prefix);
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if (prefix.family == AF_INET) {
 			/* Check current interface address. */
@@ -1113,11 +1023,9 @@ int lib_interface_zebra_ip_addrs_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip-addrs/label
  */
-int lib_interface_zebra_ip_addrs_label_modify(enum nb_event event,
-					      const struct lyd_node *dnode,
-					      union nb_resource *resource)
+int lib_interface_zebra_ip_addrs_label_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -1129,10 +1037,9 @@ int lib_interface_zebra_ip_addrs_label_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int lib_interface_zebra_ip_addrs_label_destroy(enum nb_event event,
-					       const struct lyd_node *dnode)
+int lib_interface_zebra_ip_addrs_label_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -1147,11 +1054,9 @@ int lib_interface_zebra_ip_addrs_label_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip-addrs/ip4-peer
  */
-int lib_interface_zebra_ip_addrs_ip4_peer_modify(enum nb_event event,
-						 const struct lyd_node *dnode,
-						 union nb_resource *resource)
+int lib_interface_zebra_ip_addrs_ip4_peer_modify(struct nb_cb_modify_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -1163,10 +1068,10 @@ int lib_interface_zebra_ip_addrs_ip4_peer_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int lib_interface_zebra_ip_addrs_ip4_peer_destroy(enum nb_event event,
-						  const struct lyd_node *dnode)
+int lib_interface_zebra_ip_addrs_ip4_peer_destroy(
+	struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -1181,31 +1086,28 @@ int lib_interface_zebra_ip_addrs_ip4_peer_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/multicast
  */
-int lib_interface_zebra_multicast_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+int lib_interface_zebra_multicast_modify(struct nb_cb_modify_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct interface *ifp;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
 
 	if_multicast_set(ifp);
 
 	return NB_OK;
 }
 
-int lib_interface_zebra_multicast_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+int lib_interface_zebra_multicast_destroy(struct nb_cb_destroy_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct interface *ifp;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
 
 	if_multicast_unset(ifp);
 
@@ -1215,35 +1117,32 @@ int lib_interface_zebra_multicast_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/link-detect
  */
-int lib_interface_zebra_link_detect_modify(enum nb_event event,
-					   const struct lyd_node *dnode,
-					   union nb_resource *resource)
+int lib_interface_zebra_link_detect_modify(struct nb_cb_modify_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct interface *ifp;
 	bool link_detect;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
-	link_detect = yang_dnode_get_bool(dnode, "./link-detect");
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
+	link_detect = yang_dnode_get_bool(args->dnode, "./link-detect");
 
 	if_linkdetect(ifp, link_detect);
 
 	return NB_OK;
 }
 
-int lib_interface_zebra_link_detect_destroy(enum nb_event event,
-					    const struct lyd_node *dnode)
+int lib_interface_zebra_link_detect_destroy(struct nb_cb_destroy_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct interface *ifp;
 	bool link_detect;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
-	link_detect = yang_dnode_get_bool(dnode, "./link-detect");
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
+	link_detect = yang_dnode_get_bool(args->dnode, "./link-detect");
 
 	if_linkdetect(ifp, link_detect);
 
@@ -1253,25 +1152,22 @@ int lib_interface_zebra_link_detect_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/shutdown
  */
-int lib_interface_zebra_shutdown_modify(enum nb_event event,
-					const struct lyd_node *dnode,
-					union nb_resource *resource)
+int lib_interface_zebra_shutdown_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
 
 	if_shutdown(ifp);
 
 	return NB_OK;
 }
 
-int lib_interface_zebra_shutdown_destroy(enum nb_event event,
-					 const struct lyd_node *dnode)
+int lib_interface_zebra_shutdown_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
 
 	if_no_shutdown(ifp);
 
@@ -1281,18 +1177,16 @@ int lib_interface_zebra_shutdown_destroy(enum nb_event event,
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/bandwidth
  */
-int lib_interface_zebra_bandwidth_modify(enum nb_event event,
-					 const struct lyd_node *dnode,
-					 union nb_resource *resource)
+int lib_interface_zebra_bandwidth_modify(struct nb_cb_modify_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct interface *ifp;
 	uint32_t bandwidth;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
-	bandwidth = yang_dnode_get_uint32(dnode, "./bandwidth");
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
+	bandwidth = yang_dnode_get_uint32(args->dnode, "./bandwidth");
 
 	ifp->bandwidth = bandwidth;
 
@@ -1303,15 +1197,14 @@ int lib_interface_zebra_bandwidth_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int lib_interface_zebra_bandwidth_destroy(enum nb_event event,
-					  const struct lyd_node *dnode)
+int lib_interface_zebra_bandwidth_destroy(struct nb_cb_destroy_args *args)
 {
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	struct interface *ifp;
 
-	ifp = nb_running_get_entry(dnode, NULL, true);
+	ifp = nb_running_get_entry(args->dnode, NULL, true);
 
 	ifp->bandwidth = 0;
 
@@ -1325,10 +1218,9 @@ int lib_interface_zebra_bandwidth_destroy(enum nb_event event,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib
  */
-int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
-			    union nb_resource *resource)
+int lib_vrf_ribs_rib_create(struct nb_cb_create_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -1340,9 +1232,9 @@ int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
 	return NB_OK;
 }
 
-int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode)
+int lib_vrf_ribs_rib_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -1360,20 +1252,20 @@ int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode)
  * /frr-route-map:lib/route-map/entry/match-condition/frr-zebra:ipv4-prefix-length
  */
 int lib_route_map_entry_match_condition_ipv4_prefix_length_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct routemap_hook_context *rhc;
 	const char *length;
 	int condition, rv;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	/* Add configuration. */
-	rhc = nb_running_get_entry(dnode, NULL, true);
-	length = yang_dnode_get_string(dnode, NULL);
-	condition = yang_dnode_get_enum(dnode, "../frr-route-map:condition");
+	rhc = nb_running_get_entry(args->dnode, NULL, true);
+	length = yang_dnode_get_string(args->dnode, NULL);
+	condition =
+		yang_dnode_get_enum(args->dnode, "../frr-route-map:condition");
 
 	/* Set destroy information. */
 	switch (condition) {
@@ -1399,9 +1291,9 @@ int lib_route_map_entry_match_condition_ipv4_prefix_length_modify(
 }
 
 int lib_route_map_entry_match_condition_ipv4_prefix_length_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return lib_route_map_entry_match_destroy(event, dnode);
+	return lib_route_map_entry_match_destroy(args);
 }
 
 /*
@@ -1409,19 +1301,18 @@ int lib_route_map_entry_match_condition_ipv4_prefix_length_destroy(
  * /frr-route-map:lib/route-map/entry/match-condition/frr-zebra:ipv6-prefix-length
  */
 int lib_route_map_entry_match_condition_ipv6_prefix_length_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct routemap_hook_context *rhc;
 	const char *length;
 	int rv;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	/* Add configuration. */
-	rhc = nb_running_get_entry(dnode, NULL, true);
-	length = yang_dnode_get_string(dnode, NULL);
+	rhc = nb_running_get_entry(args->dnode, NULL, true);
+	length = yang_dnode_get_string(args->dnode, NULL);
 
 	/* Set destroy information. */
 	rhc->rhc_mhook = generic_match_delete;
@@ -1439,9 +1330,9 @@ int lib_route_map_entry_match_condition_ipv6_prefix_length_modify(
 }
 
 int lib_route_map_entry_match_condition_ipv6_prefix_length_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return lib_route_map_entry_match_destroy(event, dnode);
+	return lib_route_map_entry_match_destroy(args);
 }
 
 /*
@@ -1449,16 +1340,15 @@ int lib_route_map_entry_match_condition_ipv6_prefix_length_destroy(
  * /frr-route-map:lib/route-map/entry/match-condition/frr-zebra:source-protocol
  */
 int lib_route_map_entry_match_condition_source_protocol_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct routemap_hook_context *rhc;
 	const char *type;
 	int rv;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
-		type = yang_dnode_get_string(dnode, NULL);
+		type = yang_dnode_get_string(args->dnode, NULL);
 		if (proto_name2num(type) == -1) {
 			zlog_warn("%s: invalid protocol: %s", __func__, type);
 			return NB_ERR_VALIDATION;
@@ -1473,8 +1363,8 @@ int lib_route_map_entry_match_condition_source_protocol_modify(
 	}
 
 	/* Add configuration. */
-	rhc = nb_running_get_entry(dnode, NULL, true);
-	type = yang_dnode_get_string(dnode, NULL);
+	rhc = nb_running_get_entry(args->dnode, NULL, true);
+	type = yang_dnode_get_string(args->dnode, NULL);
 
 	/* Set destroy information. */
 	rhc->rhc_mhook = generic_match_delete;
@@ -1492,9 +1382,9 @@ int lib_route_map_entry_match_condition_source_protocol_modify(
 }
 
 int lib_route_map_entry_match_condition_source_protocol_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return lib_route_map_entry_match_destroy(event, dnode);
+	return lib_route_map_entry_match_destroy(args);
 }
 
 /*
@@ -1502,19 +1392,18 @@ int lib_route_map_entry_match_condition_source_protocol_destroy(
  * /frr-route-map:lib/route-map/entry/match-condition/frr-zebra:source-instance
  */
 int lib_route_map_entry_match_condition_source_instance_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct routemap_hook_context *rhc;
 	const char *type;
 	int rv;
 
-	if (event != NB_EV_APPLY)
+	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	/* Add configuration. */
-	rhc = nb_running_get_entry(dnode, NULL, true);
-	type = yang_dnode_get_string(dnode, NULL);
+	rhc = nb_running_get_entry(args->dnode, NULL, true);
+	type = yang_dnode_get_string(args->dnode, NULL);
 
 	/* Set destroy information. */
 	rhc->rhc_mhook = generic_match_delete;
@@ -1532,17 +1421,16 @@ int lib_route_map_entry_match_condition_source_instance_modify(
 }
 
 int lib_route_map_entry_match_condition_source_instance_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return lib_route_map_entry_match_destroy(event, dnode);
+	return lib_route_map_entry_match_destroy(args);
 }
 
 /*
  * XPath: /frr-route-map:lib/route-map/entry/set-action/frr-zebra:source-v4
  */
 int lib_route_map_entry_set_action_source_v4_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct routemap_hook_context *rhc;
 	struct interface *pif = NULL;
@@ -1551,13 +1439,13 @@ int lib_route_map_entry_set_action_source_v4_modify(
 	struct prefix p;
 	int rv;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		memset(&p, 0, sizeof(p));
-		yang_dnode_get_ipv4p(&p, dnode, NULL);
+		yang_dnode_get_ipv4p(&p, args->dnode, NULL);
 		if (zebra_check_addr(&p) == 0) {
 			zlog_warn("%s: invalid IPv4 address: %s", __func__,
-				  yang_dnode_get_string(dnode, NULL));
+				  yang_dnode_get_string(args->dnode, NULL));
 			return NB_ERR_VALIDATION;
 		}
 
@@ -1569,7 +1457,7 @@ int lib_route_map_entry_set_action_source_v4_modify(
 		}
 		if (pif == NULL) {
 			zlog_warn("%s: is not a local adddress: %s", __func__,
-				  yang_dnode_get_string(dnode, NULL));
+				  yang_dnode_get_string(args->dnode, NULL));
 			return NB_ERR_VALIDATION;
 		}
 		return NB_OK;
@@ -1582,8 +1470,8 @@ int lib_route_map_entry_set_action_source_v4_modify(
 	}
 
 	/* Add configuration. */
-	rhc = nb_running_get_entry(dnode, NULL, true);
-	source = yang_dnode_get_string(dnode, NULL);
+	rhc = nb_running_get_entry(args->dnode, NULL, true);
+	source = yang_dnode_get_string(args->dnode, NULL);
 
 	/* Set destroy information. */
 	rhc->rhc_shook = generic_set_delete;
@@ -1599,17 +1487,16 @@ int lib_route_map_entry_set_action_source_v4_modify(
 }
 
 int lib_route_map_entry_set_action_source_v4_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return lib_route_map_entry_set_destroy(event, dnode);
+	return lib_route_map_entry_set_destroy(args);
 }
 
 /*
  * XPath: /frr-route-map:lib/route-map/entry/set-action/frr-zebra:source-v6
  */
 int lib_route_map_entry_set_action_source_v6_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+	struct nb_cb_modify_args *args)
 {
 	struct routemap_hook_context *rhc;
 	struct interface *pif = NULL;
@@ -1618,13 +1505,13 @@ int lib_route_map_entry_set_action_source_v6_modify(
 	struct prefix p;
 	int rv;
 
-	switch (event) {
+	switch (args->event) {
 	case NB_EV_VALIDATE:
 		memset(&p, 0, sizeof(p));
-		yang_dnode_get_ipv6p(&p, dnode, NULL);
+		yang_dnode_get_ipv6p(&p, args->dnode, NULL);
 		if (zebra_check_addr(&p) == 0) {
 			zlog_warn("%s: invalid IPv6 address: %s", __func__,
-				  yang_dnode_get_string(dnode, NULL));
+				  yang_dnode_get_string(args->dnode, NULL));
 			return NB_ERR_VALIDATION;
 		}
 
@@ -1636,7 +1523,7 @@ int lib_route_map_entry_set_action_source_v6_modify(
 		}
 		if (pif == NULL) {
 			zlog_warn("%s: is not a local adddress: %s", __func__,
-				  yang_dnode_get_string(dnode, NULL));
+				  yang_dnode_get_string(args->dnode, NULL));
 			return NB_ERR_VALIDATION;
 		}
 		return NB_OK;
@@ -1649,8 +1536,8 @@ int lib_route_map_entry_set_action_source_v6_modify(
 	}
 
 	/* Add configuration. */
-	rhc = nb_running_get_entry(dnode, NULL, true);
-	source = yang_dnode_get_string(dnode, NULL);
+	rhc = nb_running_get_entry(args->dnode, NULL, true);
+	source = yang_dnode_get_string(args->dnode, NULL);
 
 	/* Set destroy information. */
 	rhc->rhc_shook = generic_set_delete;
@@ -1666,7 +1553,7 @@ int lib_route_map_entry_set_action_source_v6_modify(
 }
 
 int lib_route_map_entry_set_action_source_v6_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+	struct nb_cb_destroy_args *args)
 {
-	return lib_route_map_entry_set_destroy(event, dnode);
+	return lib_route_map_entry_set_destroy(args);
 }

--- a/zebra/zebra_nb_rpcs.c
+++ b/zebra/zebra_nb_rpcs.c
@@ -29,15 +29,14 @@
 /*
  * XPath: /frr-zebra:clear-evpn-dup-addr
  */
-int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
-			    struct list *output)
+int clear_evpn_dup_addr_rpc(struct nb_cb_rpc_args *args)
 {
 	struct zebra_vrf *zvrf;
 	int ret = NB_OK;
 	struct yang_data *yang_dup_choice = NULL, *yang_dup_vni = NULL,
 			 *yang_dup_ip = NULL, *yang_dup_mac = NULL;
 
-	yang_dup_choice = yang_data_list_find(input, "%s/%s", xpath,
+	yang_dup_choice = yang_data_list_find(args->input, "%s/%s", args->xpath,
 					      "input/clear-dup-choice");
 
 	zvrf = zebra_vrf_get_evpn();
@@ -51,16 +50,16 @@ int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
 		struct ethaddr mac;
 
 		yang_dup_vni = yang_data_list_find(
-			input, "%s/%s", xpath,
+			args->input, "%s/%s", args->xpath,
 			"input/clear-dup-choice/single-case/vni-id");
 		if (yang_dup_vni) {
 			vni = yang_str2uint32(yang_dup_vni->value);
 
 			yang_dup_mac = yang_data_list_find(
-				input, "%s/%s", xpath,
+				args->input, "%s/%s", args->xpath,
 				"input/clear-dup-choice/single-case/vni-id/mac-addr");
 			yang_dup_ip = yang_data_list_find(
-				input, "%s/%s", xpath,
+				args->input, "%s/%s", args->xpath,
 				"input/clear-dup-choice/single-case/vni-id/vni-ipaddr");
 
 			if (yang_dup_mac) {
@@ -84,8 +83,7 @@ int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-route-information
  */
-int get_route_information_rpc(const char *xpath, const struct list *input,
-			      struct list *output)
+int get_route_information_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -94,8 +92,7 @@ int get_route_information_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-v6-mroute-info
  */
-int get_v6_mroute_info_rpc(const char *xpath, const struct list *input,
-			   struct list *output)
+int get_v6_mroute_info_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -104,8 +101,7 @@ int get_v6_mroute_info_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-vrf-info
  */
-int get_vrf_info_rpc(const char *xpath, const struct list *input,
-		     struct list *output)
+int get_vrf_info_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -114,8 +110,7 @@ int get_vrf_info_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-vrf-vni-info
  */
-int get_vrf_vni_info_rpc(const char *xpath, const struct list *input,
-			 struct list *output)
+int get_vrf_vni_info_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -124,8 +119,7 @@ int get_vrf_vni_info_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-evpn-info
  */
-int get_evpn_info_rpc(const char *xpath, const struct list *input,
-		      struct list *output)
+int get_evpn_info_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -134,8 +128,7 @@ int get_evpn_info_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-vni-info
  */
-int get_vni_info_rpc(const char *xpath, const struct list *input,
-		     struct list *output)
+int get_vni_info_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -144,8 +137,7 @@ int get_vni_info_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-evpn-vni-rmac
  */
-int get_evpn_vni_rmac_rpc(const char *xpath, const struct list *input,
-			  struct list *output)
+int get_evpn_vni_rmac_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -154,8 +146,7 @@ int get_evpn_vni_rmac_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-evpn-vni-nexthops
  */
-int get_evpn_vni_nexthops_rpc(const char *xpath, const struct list *input,
-			      struct list *output)
+int get_evpn_vni_nexthops_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -164,8 +155,7 @@ int get_evpn_vni_nexthops_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-evpn-macs
  */
-int get_evpn_macs_rpc(const char *xpath, const struct list *input,
-		      struct list *output)
+int get_evpn_macs_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -174,8 +164,7 @@ int get_evpn_macs_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-evpn-arp-cache
  */
-int get_evpn_arp_cache_rpc(const char *xpath, const struct list *input,
-			   struct list *output)
+int get_evpn_arp_cache_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -184,8 +173,7 @@ int get_evpn_arp_cache_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-pbr-ipset
  */
-int get_pbr_ipset_rpc(const char *xpath, const struct list *input,
-		      struct list *output)
+int get_pbr_ipset_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -194,8 +182,7 @@ int get_pbr_ipset_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-pbr-iptable
  */
-int get_pbr_iptable_rpc(const char *xpath, const struct list *input,
-			struct list *output)
+int get_pbr_iptable_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;
@@ -204,8 +191,7 @@ int get_pbr_iptable_rpc(const char *xpath, const struct list *input,
 /*
  * XPath: /frr-zebra:get-debugs
  */
-int get_debugs_rpc(const char *xpath, const struct list *input,
-		   struct list *output)
+int get_debugs_rpc(struct nb_cb_rpc_args *args)
 {
 	/* TODO: implement me. */
 	return NB_ERR_NOT_FOUND;

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -27,38 +27,35 @@
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/up-count
  */
 struct yang_data *
-lib_interface_zebra_state_up_count_get_elem(const char *xpath,
-					    const void *list_entry)
+lib_interface_zebra_state_up_count_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 	struct zebra_if *zebra_if;
 
 	zebra_if = ifp->info;
 
-	return yang_data_new_uint16(xpath, zebra_if->up_count);
+	return yang_data_new_uint16(args->xpath, zebra_if->up_count);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/down-count
  */
 struct yang_data *
-lib_interface_zebra_state_down_count_get_elem(const char *xpath,
-					      const void *list_entry)
+lib_interface_zebra_state_down_count_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 	struct zebra_if *zebra_if;
 
 	zebra_if = ifp->info;
 
-	return yang_data_new_uint16(xpath, zebra_if->down_count);
+	return yang_data_new_uint16(args->xpath, zebra_if->down_count);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/zif-type
  */
 struct yang_data *
-lib_interface_zebra_state_zif_type_get_elem(const char *xpath,
-					    const void *list_entry)
+lib_interface_zebra_state_zif_type_get_elem(struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -68,8 +65,7 @@ lib_interface_zebra_state_zif_type_get_elem(const char *xpath,
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/ptm-status
  */
 struct yang_data *
-lib_interface_zebra_state_ptm_status_get_elem(const char *xpath,
-					      const void *list_entry)
+lib_interface_zebra_state_ptm_status_get_elem(struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -79,10 +75,9 @@ lib_interface_zebra_state_ptm_status_get_elem(const char *xpath,
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/vlan-id
  */
 struct yang_data *
-lib_interface_zebra_state_vlan_id_get_elem(const char *xpath,
-					   const void *list_entry)
+lib_interface_zebra_state_vlan_id_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 	struct zebra_if *zebra_if;
 	struct zebra_l2info_vlan *vlan_info;
 
@@ -92,17 +87,16 @@ lib_interface_zebra_state_vlan_id_get_elem(const char *xpath,
 	zebra_if = ifp->info;
 	vlan_info = &zebra_if->l2info.vl;
 
-	return yang_data_new_uint16(xpath, vlan_info->vid);
+	return yang_data_new_uint16(args->xpath, vlan_info->vid);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/vni-id
  */
 struct yang_data *
-lib_interface_zebra_state_vni_id_get_elem(const char *xpath,
-					  const void *list_entry)
+lib_interface_zebra_state_vni_id_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 	struct zebra_if *zebra_if;
 	struct zebra_l2info_vxlan *vxlan_info;
 
@@ -112,17 +106,16 @@ lib_interface_zebra_state_vni_id_get_elem(const char *xpath,
 	zebra_if = ifp->info;
 	vxlan_info = &zebra_if->l2info.vxl;
 
-	return yang_data_new_uint32(xpath, vxlan_info->vni);
+	return yang_data_new_uint32(args->xpath, vxlan_info->vni);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/remote-vtep
  */
 struct yang_data *
-lib_interface_zebra_state_remote_vtep_get_elem(const char *xpath,
-					       const void *list_entry)
+lib_interface_zebra_state_remote_vtep_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 	struct zebra_if *zebra_if;
 	struct zebra_l2info_vxlan *vxlan_info;
 
@@ -132,17 +125,16 @@ lib_interface_zebra_state_remote_vtep_get_elem(const char *xpath,
 	zebra_if = ifp->info;
 	vxlan_info = &zebra_if->l2info.vxl;
 
-	return yang_data_new_ipv4(xpath, &vxlan_info->vtep_ip);
+	return yang_data_new_ipv4(args->xpath, &vxlan_info->vtep_ip);
 }
 
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/mcast-group
  */
 struct yang_data *
-lib_interface_zebra_state_mcast_group_get_elem(const char *xpath,
-					       const void *list_entry)
+lib_interface_zebra_state_mcast_group_get_elem(struct nb_cb_get_elem_args *args)
 {
-	const struct interface *ifp = list_entry;
+	const struct interface *ifp = args->list_entry;
 	struct zebra_if *zebra_if;
 	struct zebra_l2info_vxlan *vxlan_info;
 
@@ -152,25 +144,22 @@ lib_interface_zebra_state_mcast_group_get_elem(const char *xpath,
 	zebra_if = ifp->info;
 	vxlan_info = &zebra_if->l2info.vxl;
 
-	return yang_data_new_ipv4(xpath, &vxlan_info->mcast_grp);
+	return yang_data_new_ipv4(args->xpath, &vxlan_info->mcast_grp);
 }
 
-const void *lib_vrf_ribs_rib_get_next(const void *parent_list_entry,
-				      const void *list_entry)
+const void *lib_vrf_ribs_rib_get_next(struct nb_cb_get_next_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
 }
 
-int lib_vrf_ribs_rib_get_keys(const void *list_entry,
-			      struct yang_list_keys *keys)
+int lib_vrf_ribs_rib_get_keys(struct nb_cb_get_keys_args *args)
 {
 	/* TODO: implement me. */
 	return NB_OK;
 }
 
-const void *lib_vrf_ribs_rib_lookup_entry(const void *parent_list_entry,
-					  const struct yang_list_keys *keys)
+const void *lib_vrf_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -179,23 +168,20 @@ const void *lib_vrf_ribs_rib_lookup_entry(const void *parent_list_entry,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route
  */
-const void *lib_vrf_ribs_rib_route_get_next(const void *parent_list_entry,
-					    const void *list_entry)
+const void *lib_vrf_ribs_rib_route_get_next(struct nb_cb_get_next_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
 }
 
-int lib_vrf_ribs_rib_route_get_keys(const void *list_entry,
-				    struct yang_list_keys *keys)
+int lib_vrf_ribs_rib_route_get_keys(struct nb_cb_get_keys_args *args)
 {
 	/* TODO: implement me. */
 	return NB_OK;
 }
 
 const void *
-lib_vrf_ribs_rib_route_lookup_entry(const void *parent_list_entry,
-				    const struct yang_list_keys *keys)
+lib_vrf_ribs_rib_route_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -204,8 +190,8 @@ lib_vrf_ribs_rib_route_lookup_entry(const void *parent_list_entry,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/prefix
  */
-struct yang_data *lib_vrf_ribs_rib_route_prefix_get_elem(const char *xpath,
-							 const void *list_entry)
+struct yang_data *
+lib_vrf_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -215,22 +201,21 @@ struct yang_data *lib_vrf_ribs_rib_route_prefix_get_elem(const char *xpath,
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry
  */
 const void *
-lib_vrf_ribs_rib_route_route_entry_get_next(const void *parent_list_entry,
-					    const void *list_entry)
+lib_vrf_ribs_rib_route_route_entry_get_next(struct nb_cb_get_next_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
 }
 
-int lib_vrf_ribs_rib_route_route_entry_get_keys(const void *list_entry,
-						struct yang_list_keys *keys)
+int lib_vrf_ribs_rib_route_route_entry_get_keys(
+	struct nb_cb_get_keys_args *args)
 {
 	/* TODO: implement me. */
 	return NB_OK;
 }
 
 const void *lib_vrf_ribs_rib_route_route_entry_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys)
+	struct nb_cb_lookup_entry_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -239,9 +224,8 @@ const void *lib_vrf_ribs_rib_route_route_entry_lookup_entry(
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/protocol
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_protocol_get_elem(const char *xpath,
-						     const void *list_entry)
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_protocol_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -250,9 +234,8 @@ lib_vrf_ribs_rib_route_route_entry_protocol_get_elem(const char *xpath,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/instance
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_instance_get_elem(const char *xpath,
-						     const void *list_entry)
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_instance_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -261,9 +244,8 @@ lib_vrf_ribs_rib_route_route_entry_instance_get_elem(const char *xpath,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/distance
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_distance_get_elem(const char *xpath,
-						     const void *list_entry)
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_distance_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -272,9 +254,8 @@ lib_vrf_ribs_rib_route_route_entry_distance_get_elem(const char *xpath,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/metric
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_metric_get_elem(const char *xpath,
-						   const void *list_entry)
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_metric_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -283,9 +264,8 @@ lib_vrf_ribs_rib_route_route_entry_metric_get_elem(const char *xpath,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/tag
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_tag_get_elem(const char *xpath,
-						const void *list_entry)
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_tag_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -294,9 +274,8 @@ lib_vrf_ribs_rib_route_route_entry_tag_get_elem(const char *xpath,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/selected
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_selected_get_elem(const char *xpath,
-						     const void *list_entry)
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_selected_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -305,9 +284,8 @@ lib_vrf_ribs_rib_route_route_entry_selected_get_elem(const char *xpath,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/installed
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_installed_get_elem(const char *xpath,
-						      const void *list_entry)
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_installed_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -316,9 +294,8 @@ lib_vrf_ribs_rib_route_route_entry_installed_get_elem(const char *xpath,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/failed
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_failed_get_elem(const char *xpath,
-						   const void *list_entry)
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_failed_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -327,9 +304,8 @@ lib_vrf_ribs_rib_route_route_entry_failed_get_elem(const char *xpath,
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/queued
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_queued_get_elem(const char *xpath,
-						   const void *list_entry)
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_queued_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -339,7 +315,7 @@ lib_vrf_ribs_rib_route_route_entry_queued_get_elem(const char *xpath,
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/internal-flags
  */
 struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_flags_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -349,7 +325,7 @@ struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_flags_get_elem(
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/internal-status
  */
 struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_status_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -358,9 +334,8 @@ struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_status_get_elem(
 /*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/uptime
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_route_entry_uptime_get_elem(const char *xpath,
-						   const void *list_entry)
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_uptime_get_elem(
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -370,21 +345,21 @@ lib_vrf_ribs_rib_route_route_entry_uptime_get_elem(const char *xpath,
  * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group
  */
 const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_next(
-	const void *parent_list_entry, const void *list_entry)
+	struct nb_cb_get_next_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
 }
 
 int lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_keys(
-	const void *list_entry, struct yang_list_keys *keys)
+	struct nb_cb_get_keys_args *args)
 {
 	/* TODO: implement me. */
 	return NB_OK;
 }
 
 const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys)
+	struct nb_cb_lookup_entry_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -396,7 +371,7 @@ const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_lookup_entry(
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_name_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -408,14 +383,14 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_name_get_elem(
  */
 const void *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next(
-	const void *parent_list_entry, const void *list_entry)
+	struct nb_cb_get_next_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
 }
 
 int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys(
-	const void *list_entry, struct yang_list_keys *keys)
+	struct nb_cb_get_keys_args *args)
 {
 	/* TODO: implement me. */
 	return NB_OK;
@@ -423,7 +398,7 @@ int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_ke
 
 const void *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys)
+	struct nb_cb_lookup_entry_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -435,7 +410,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_ent
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -447,7 +422,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_ge
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -459,7 +434,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_el
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -471,7 +446,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_ge
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -483,7 +458,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -495,7 +470,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_ge
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -507,14 +482,14 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get
  */
 const void *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
-	const void *parent_list_entry, const void *list_entry)
+	struct nb_cb_get_next_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
 }
 
 int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
-	const void *list_entry, struct yang_list_keys *keys)
+	struct nb_cb_get_keys_args *args)
 {
 	/* TODO: implement me. */
 	return NB_OK;
@@ -522,7 +497,7 @@ int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_l
 
 const void *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
-	const void *parent_list_entry, const struct yang_list_keys *keys)
+	struct nb_cb_lookup_entry_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -534,7 +509,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -546,7 +521,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -558,7 +533,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -570,7 +545,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -582,7 +557,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -594,7 +569,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -606,7 +581,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -618,7 +593,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;
@@ -630,7 +605,7 @@ lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_el
  */
 struct yang_data *
 lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_weight_get_elem(
-	const char *xpath, const void *list_entry)
+	struct nb_cb_get_elem_args *args)
 {
 	/* TODO: implement me. */
 	return NULL;


### PR DESCRIPTION
Having a fixed set of parameters for each northbound callback isn't a
good idea since it makes it difficult to add new parameters whenever
that becomes necessary, as several hundreds or thousands of existing
callbacks need to be updated accordingly.

To remediate this issue, this commit changes the signature of all
northbound callbacks to have a single parameter: a pointer to a
'nb_cb_x_args' structure (where x is different for each type
of callback). These structures encapsulate all real parameters
(both input and output) the callbacks need to have access to. And
adding a new parameter to a given callback is as simple as adding
a new field to the corresponding 'nb_cb_x_args' structure, without
needing to update any instance of that callback in any daemon.

This commit includes a .cocci semantic patch that can be used to
update old code to the new format automatically.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>