### PR TITLE
isisd: fix display of "isis bfd" in the running configuration

### DIFF
--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -391,6 +391,7 @@ void isis_bfd_circuit_param_set(struct isis_circuit *circuit,
 		isis_bfd_circuit_cmd(circuit, command);
 }
 
+#ifdef FABRICD
 static int bfd_circuit_write_settings(struct isis_circuit *circuit,
 				      struct vty *vty)
 {
@@ -402,6 +403,7 @@ static int bfd_circuit_write_settings(struct isis_circuit *circuit,
 	vty_out(vty, " %s bfd\n", PROTO_NAME);
 	return 1;
 }
+#endif
 
 void isis_bfd_init(void)
 {
@@ -413,6 +415,8 @@ void isis_bfd_init(void)
 	zclient->bfd_dest_replay = isis_bfd_nbr_replay;
 	hook_register(isis_adj_state_change_hook,
 		      bfd_handle_adj_state_change);
+#ifdef FABRICD
 	hook_register(isis_circuit_config_write,
 		      bfd_circuit_write_settings);
+#endif
 }

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -963,11 +963,11 @@ void isis_circuit_print_vty(struct isis_circuit *circuit, struct vty *vty,
 	return;
 }
 
+#ifdef FABRICD
 DEFINE_HOOK(isis_circuit_config_write,
 	    (struct isis_circuit *circuit, struct vty *vty),
 	    (circuit, vty))
 
-#ifdef FABRICD
 static int isis_interface_config_write(struct vty *vty)
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
@@ -1196,7 +1196,6 @@ static int isis_interface_config_write(struct vty *vty)
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	int write = 0;
 	struct interface *ifp;
-	struct isis_circuit *circuit;
 	struct lyd_node *dnode;
 
 	FOR_ALL_INTERFACES (vrf, ifp) {
@@ -1209,10 +1208,6 @@ static int isis_interface_config_write(struct vty *vty)
 
 		write++;
 		nb_cli_show_dnode_cmds(vty, dnode, false);
-		circuit = circuit_scan_by_ifp(ifp);
-		if (circuit)
-			write += hook_call(isis_circuit_config_write, circuit,
-					   vty);
 	}
 	return write;
 }

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -208,8 +208,10 @@ ferr_r isis_circuit_passwd_hmac_md5_set(struct isis_circuit *circuit,
 int isis_circuit_mt_enabled_set(struct isis_circuit *circuit, uint16_t mtid,
 				bool enabled);
 
+#ifdef FABRICD
 DECLARE_HOOK(isis_circuit_config_write,
 	    (struct isis_circuit *circuit, struct vty *vty),
 	    (circuit, vty))
+#endif
 
 #endif /* _ZEBRA_ISIS_CIRCUIT_H */

--- a/isisd/isis_mt.c
+++ b/isisd/isis_mt.c
@@ -302,6 +302,7 @@ circuit_get_mt_setting(struct isis_circuit *circuit, uint16_t mtid)
 	return setting;
 }
 
+#ifdef FABRICD
 static int circuit_write_mt_settings(struct isis_circuit *circuit,
 				     struct vty *vty)
 {
@@ -318,6 +319,7 @@ static int circuit_write_mt_settings(struct isis_circuit *circuit,
 	}
 	return written;
 }
+#endif
 
 struct isis_circuit_mt_setting **
 circuit_mt_settings(struct isis_circuit *circuit, unsigned int *mt_count)
@@ -552,6 +554,8 @@ void tlvs_add_mt_p2p(struct isis_tlvs *tlvs, struct isis_circuit *circuit,
 
 void mt_init(void)
 {
+#ifdef FABRICD
 	hook_register(isis_circuit_config_write,
 		      circuit_write_mt_settings);
+#endif
 }


### PR DESCRIPTION
Since this command is modeled using YANG, it's already displayed
as part of the call to nb_cli_show_dnode_cmds(). Calling the
'isis_circuit_config_write' hook was only making that command
to be displayed twice.

The aforementioned hook is still necessary for fabricd, which wasn't
converted to the new northbound model yet.

Fixes #6281.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>