### PR TITLE
tests: introduce a proper JSON diff for topotests

### DIFF
--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -48,7 +48,7 @@ def pytest_assertrepr_compare(op, left, right):
         if not isinstance(json_result, json_cmp_result):
             return None
 
-    return json_result.errors
+    return json_result.gen_report()
 
 
 def pytest_configure(config):

--- a/tests/topotests/lib/test/test_json.py
+++ b/tests/topotests/lib/test/test_json.py
@@ -286,5 +286,182 @@ def test_json_list_start_failure():
     assert json_cmp(dcomplete, dsub4) is not None
 
 
+def test_json_list_ordered():
+    "Test JSON encoded data that should be ordered using the '__ordered__' tag."
+
+    dcomplete = [
+        {"id": 1, "value": "abc"},
+        "some string",
+        123,
+    ]
+
+    dsub1 = [
+        '__ordered__',
+        "some string",
+        {"id": 1, "value": "abc"},
+        123,
+    ]
+
+    assert json_cmp(dcomplete, dsub1) is not None
+
+
+def test_json_list_exact_matching():
+    "Test JSON array on exact matching using the 'exact' parameter."
+
+    dcomplete = [
+        {"id": 1, "value": "abc"},
+        "some string",
+        123,
+        [1,2,3],
+    ]
+
+    dsub1 = [
+        "some string",
+        {"id": 1, "value": "abc"},
+        123,
+        [1,2,3],
+    ]
+
+    dsub2 = [
+        {"id": 1},
+        "some string",
+        123,
+        [1,2,3],
+    ]
+
+    dsub3 = [
+        {"id": 1, "value": "abc"},
+        "some string",
+        123,
+        [1,3,2],
+    ]
+
+    assert json_cmp(dcomplete, dsub1, exact=True) is not None
+    assert json_cmp(dcomplete, dsub2, exact=True) is not None
+
+
+def test_json_object_exact_matching():
+    "Test JSON object on exact matching using the 'exact' parameter."
+
+    dcomplete = {
+        'a': {"id": 1, "value": "abc"},
+        'b': "some string",
+        'c': 123,
+        'd': [1,2,3],
+    }
+
+    dsub1 = {
+        'a': {"id": 1, "value": "abc"},
+        'c': 123,
+        'd': [1,2,3],
+    }
+
+    dsub2 = {
+        'a': {"id": 1},
+        'b': "some string",
+        'c': 123,
+        'd': [1,2,3],
+    }
+
+    dsub3 = {
+        'a': {"id": 1, "value": "abc"},
+        'b': "some string",
+        'c': 123,
+        'd': [1,3],
+    }
+
+    assert json_cmp(dcomplete, dsub1, exact=True) is not None
+    assert json_cmp(dcomplete, dsub2, exact=True) is not None
+    assert json_cmp(dcomplete, dsub3, exact=True) is not None
+
+
+def test_json_list_asterisk_matching():
+    "Test JSON array elements on matching '*' as a placeholder for arbitrary data."
+
+    dcomplete = [
+        {"id": 1, "value": "abc"},
+        "some string",
+        123,
+        [1,2,3],
+    ]
+
+    dsub1 = [
+        '*',
+        "some string",
+        123,
+        [1,2,3],
+    ]
+
+    dsub2 = [
+        {"id": '*', "value": "abc"},
+        "some string",
+        123,
+        [1,2,3],
+    ]
+
+    dsub3 = [
+        {"id": 1, "value": "abc"},
+        "some string",
+        123,
+        [1,'*',3],
+    ]
+
+    dsub4 = [
+        '*',
+        "some string",
+        '*',
+        [1,2,3],
+    ]
+
+    assert json_cmp(dcomplete, dsub1) is None
+    assert json_cmp(dcomplete, dsub2) is None
+    assert json_cmp(dcomplete, dsub3) is None
+    assert json_cmp(dcomplete, dsub4) is None
+
+
+def test_json_object_asterisk_matching():
+    "Test JSON object value elements on matching '*' as a placeholder for arbitrary data."
+
+    dcomplete = {
+        'a': {"id": 1, "value": "abc"},
+        'b': "some string",
+        'c': 123,
+        'd': [1,2,3],
+    }
+
+    dsub1 = {
+        'a': '*',
+        'b': "some string",
+        'c': 123,
+        'd': [1,2,3],
+    }
+
+    dsub2 = {
+        'a': {"id": 1, "value": "abc"},
+        'b': "some string",
+        'c': 123,
+        'd': [1,'*',3],
+    }
+
+    dsub3 = {
+        'a': {"id": '*', "value": "abc"},
+        'b': "some string",
+        'c': 123,
+        'd': [1,2,3],
+    }
+
+    dsub4 = {
+        'a': '*',
+        'b': "some string",
+        'c': '*',
+        'd': [1,2,3],
+    }
+
+    assert json_cmp(dcomplete, dsub1) is None
+    assert json_cmp(dcomplete, dsub2) is None
+    assert json_cmp(dcomplete, dsub3) is None
+    assert json_cmp(dcomplete, dsub4) is None
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main())


### PR DESCRIPTION
Background: I'm currently working on OSPF SR topotests and
handling large'ish JSON files which has become quite a pain.

Diff'ing JSON objects is a crucial operation in the topotests for
comparing e.g. vtysh output (formatted as JSON) with a file which
covers the expectation of the tests. The current diff functionality
is 'self-written' and intended to test a JSON object d2 on being a
subset of another JSON object d1. For mismatches a diff is generated
based on a normalized textual representation of the JSON objects.

This approach has several disadvantages:

  * the human provided JSON text might not be normalized, hence
    a diff with line numbers might be worthless since it provides
    close to zero orientation what the problem is
  * the diff contains changes like commatas which are meaningless
  * the diff might contain a lot of changes about meaningless
    content which is present in d1 but not in d2
  * there is no proper functionality to test for 'equality' of
    d1 and d2
  * it is not possible to test for order, e.g. JSON arrays are
    just tested with respect to being a subset of another array
  * it is not possible to check if a key exists without also
    checking the value of that particular key

This commit attempts to solve these issues. An error report is
generated which includes the "JSON Path" to the problematic JSON
elements and also hints on what the actual problem is (e.g. missing
key, mismatch in dict values etc.).

A special parameter 'exact' was introduced such that equality can be
tested. Also there was a convention that absence of keys can be
tested using the key in question with value 'None'. This convention
is still honored such that full backwards compatiiblity is in
place.

Further order can be tested using the new tag '__ordered__' in
lists (as first element). Example:

    d1 = [1, 2, 3]
    d2 = ['__ordered__', 1, 3, 2]

Tesing d1 and d2 this way will now result in an error.

Key existence can now be tested using an asterisk '*'. Example:

    d1 = [1, 2, 3]
    d2 = [1, '*', 3]

    d1 = {'a': 1, 'b': 2}
    d2 = {'a': '*'}

Both cases will result now in a clean diff for d1 and d2.

Signed-off-by: GalaxyGorilla <sascha@netdef.org>