### PR TITLE
tools: fix frr-reload AF issue with ldpd

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1077,6 +1077,13 @@ def compare_context_objects(newconf, running):
                 add_cmd = ('no ' + running_ctx_keys[0],)
                 lines_to_add.append((add_cmd, None))
 
+            # if this an interface sub-subcontext in an address-family block in ldpd and
+            # we are already deleting the whole context, then ignore this
+            elif (len(running_ctx_keys) > 2 and running_ctx_keys[0].startswith('mpls ldp') and
+                  running_ctx_keys[1].startswith('address-family') and
+                  (running_ctx_keys[:2], None) in lines_to_del):
+                continue
+
             # Non-global context
             elif running_ctx_keys and not any("address-family" in key for key in running_ctx_keys):
                 lines_to_del.append((running_ctx_keys, None))


### PR DESCRIPTION
when removing a whole address-family block from ldpd config we were erroneously trying to also remove each of the interface sub-sub-contexts that belonged to it; this would effectively re-enable the AF we just removed. Work around this by ignoring these sub-sub-contexts if we detect that we are already removing the parent block.

Example before the patch: start with a simple running config like the following:
```
mpls ldp
 router-id 7.0.0.1
 !
 address-family ipv4
  discovery transport-address 7.0.0.1
  !
  interface 1-xge2.0
  !
 exit-address-family
 !
!
```
remove the ipv4 AF block and call frr-reload.py, you will get the following "lines to delete":
```
2020-04-27 12:05:09,973  INFO: Executed "/rootfs/bin/vtysh --config_dir /tmp/demo1_1_1 --vty_socket /var/run/demo1.vty -c conf t -c mpls ldp -c no address-family ipv4"
2020-04-27 12:05:10,126  INFO: Executed "/rootfs/bin/vtysh --config_dir /tmp/demo1_1_1 --vty_socket /var/run/demo1.vty -c conf t -c mpls ldp -c address-family ipv4 -c no interface 1-xge2.0"
```
-> vtysh `show running` now shows the following
```
mpls ldp
 router-id 7.0.0.1
 !
 address-family ipv4
  ! Incomplete config, specify a discovery transport-address
  !
 exit-address-family
 !
!
```
