### PR TITLE
bgpd: turn off RAs when numbered peers are deleted

### DIFF
--- a/bgpd/bgp_nht.h
+++ b/bgpd/bgp_nht.h
@@ -87,6 +87,7 @@ extern void bgp_nht_register_nexthops(struct bgp *bgp);
  * this code can walk the registered nexthops and
  * register the important ones with zebra for RA.
  */
-extern void bgp_nht_register_enhe_capability_interfaces(struct peer *peer);
+extern void bgp_nht_reg_enhe_cap_intfs(struct peer *peer);
+extern void bgp_nht_dereg_enhe_cap_intfs(struct peer *peer);
 
 #endif /* _BGP_NHT_H */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3818,6 +3818,10 @@ DEFUN (no_neighbor,
 			}
 
 			other = peer->doppelganger;
+
+			if (CHECK_FLAG(peer->flags, PEER_FLAG_CAPABILITY_ENHE))
+				bgp_zebra_terminate_radv(peer->bgp, peer);
+
 			peer_notify_unconfig(peer);
 			peer_delete(peer);
 			if (other && other->status != Deleted) {
@@ -4237,6 +4241,9 @@ DEFUN (no_neighbor_set_peer_group,
 		vty_out(vty, "%% Configure the peer-group first\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	if (CHECK_FLAG(peer->flags, PEER_FLAG_CAPABILITY_ENHE))
+		bgp_zebra_terminate_radv(peer->bgp, peer);
 
 	peer_notify_unconfig(peer);
 	ret = peer_delete(peer);


### PR DESCRIPTION
Problem reported that in many circumstances, RAs created in the
process of bringing up numbered IPv6 peers with extended-nexthop
capability enabled (for ipv4 over ipv6) were not stopped on the
interface when those peers were deleted.  Found several circumstances
where this occurred and fix them in this patch.

Ticket: CM-26875
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>