### PR TITLE
pimd: Add a needed space for formatting

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5825,7 +5825,7 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 		json = json_object_new_object();
 	} else {
 		vty_out(vty, "IP Multicast Routing Table\n");
-		vty_out(vty, "Flags: S- Sparse, C - Connected, P - Pruned\n");
+		vty_out(vty, "Flags: S - Sparse, C - Connected, P - Pruned\n");
 		vty_out(vty,
 			"       R - RP-bit set, F - Register flag, T - SPT-bit set\n");
 		vty_out(vty,


### PR DESCRIPTION
Display a space in the output.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>