### PR TITLE
lib: update the CLI xpath index when exiting from the VRF node

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -726,7 +726,7 @@ DEFUN_NOSH(vrf_exit,
 {
 	/* We have to set vrf context to default vrf */
 	VTY_PUSH_CONTEXT(VRF_NODE, vrf_get(VRF_DEFAULT, VRF_DEFAULT_NAME));
-	vty->node = CONFIG_NODE;
+	cmd_exit(vty);
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
All custom "exit-*" commands that exit from a YANG-modeled
CLI node need to use cmd_exit() to ensure the CLI xpath index
(vty->xpath_index) will be updated accordingly.

Fixes #6316.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>