### PR TITLE
bgpd: Make sure network/aggregate-address commands lay down under lab…

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13431,6 +13431,12 @@ void bgp_route_init(void)
 	install_element(BGP_IPV4M_NODE, &no_aggregate_address_mask_cmd);
 
 	/* IPv4 labeled-unicast configuration.  */
+	install_element(BGP_IPV4L_NODE, &bgp_network_cmd);
+	install_element(BGP_IPV4L_NODE, &aggregate_address_cmd);
+	install_element(BGP_IPV4L_NODE, &aggregate_address_mask_cmd);
+	install_element(BGP_IPV4L_NODE, &no_aggregate_address_cmd);
+	install_element(BGP_IPV4L_NODE, &no_aggregate_address_mask_cmd);
+
 	install_element(VIEW_NODE, &show_ip_bgp_instance_all_cmd);
 	install_element(VIEW_NODE, &show_ip_bgp_cmd);
 	install_element(VIEW_NODE, &show_ip_bgp_afi_safi_statistics_cmd);
@@ -13476,6 +13482,11 @@ void bgp_route_init(void)
 	install_element(BGP_IPV6_NODE, &no_ipv6_aggregate_address_cmd);
 
 	install_element(BGP_IPV6M_NODE, &ipv6_bgp_network_cmd);
+
+	/* IPv6 labeled unicast address family. */
+	install_element(BGP_IPV6L_NODE, &ipv6_bgp_network_cmd);
+	install_element(BGP_IPV6L_NODE, &ipv6_aggregate_address_cmd);
+	install_element(BGP_IPV6L_NODE, &no_ipv6_aggregate_address_cmd);
 
 	install_element(BGP_NODE, &bgp_distance_cmd);
 	install_element(BGP_NODE, &no_bgp_distance_cmd);


### PR DESCRIPTION
…eled safi

unicast and labeled-unicast share the same table, but configuration should
be visible for both independently. Without this fix it confuses a bit
because when you enter `network 10.0.0.0/24` under labeled-unicast it's
written in unicast family block.

Closes https://github.com/FRRouting/frr/issues/4566

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>