### PR TITLE
bgpd: Ensure that we have a ifp pointer

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -962,6 +962,9 @@ void bgp_nht_dereg_enhe_cap_intfs(struct peer *peer)
 	for (nhop = bnc->nexthop; nhop; nhop = nhop->next) {
 		ifp = if_lookup_by_index(nhop->ifindex, nhop->vrf_id);
 
+		if (!ifp)
+			continue;
+
 		zclient_send_interface_radv_req(zclient, nhop->vrf_id, ifp, 0,
 						0);
 	}


### PR DESCRIPTION
It is possible that the if_lookup_by_index() call will return
a NULL value and calling zclient_send_interface_radv_req.  Just
test that we have a valid interface pointer.

Found by Coverity

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>