### PR TITLE
git: ignore emacs desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ compile_commands.json
 refix
 .vscode
 .kitchen
+.emacs.desktop*


### PR DESCRIPTION
Ignore the emacs desktop files - should never ever be committed.
