### PR TITLE
zebra: force off kernel NHG install with netns VRFs

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -93,7 +93,8 @@ static struct in_addr ipv4_ll;
 /* Helper to control use of kernel-level nexthop ids */
 static bool kernel_nexthops_supported(void)
 {
-	return (supports_nh && zebra_nhg_kernel_nexthops_enabled());
+	return (supports_nh && !vrf_is_backend_netns()
+		&& zebra_nhg_kernel_nexthops_enabled());
 }
 
 /*


### PR DESCRIPTION
Force off kernel NHG install with netns-based VRFs for
now. There is not really a good solution for allowing
kernel nexthop groups in namespaced based vrfs.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>