### PR TITLE
bgpd: Set a proper SAFI for labaled-unicast when looking for scount

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9066,7 +9066,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 			}
 		}
 
-		paf = peer_af_find(peer, afi, pfx_rcd_safi);
+		paf = peer_af_find(peer, afi, safi);
 		filter = &peer->filter[afi][safi];
 
 		count++;


### PR DESCRIPTION
The problem is that peer_af_array returns NULL when SAFI is changed to
unicast. We use unicast table, but peer is created and activated under
labeled-unicast, hence we should lookup with a proper SAFI id.

Without this patch peer_af_find() returns NULL and we can't show
PfxSnt in `show bgp summary`.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>