### PR TITLE
bgpd: Show "(Policy)" under PfxRcd/PfxSnt when eBGP policy is in use

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8766,6 +8766,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 	json_object *json_peer = NULL;
 	json_object *json_peers = NULL;
 	struct peer_af *paf;
+	struct bgp_filter *filter;
 
 	/* labeled-unicast routes are installed in the unicast table so in order
 	 * to
@@ -9066,6 +9067,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 		}
 
 		paf = peer_af_find(peer, afi, pfx_rcd_safi);
+		filter = &peer->filter[afi][safi];
 
 		count++;
 		/* Works for both failed & successful cases */
@@ -9208,18 +9210,39 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 						    BGP_UPTIME_LEN, 0, NULL));
 
 				if (peer->status == Established) {
-					if (peer->afc_recv[afi][safi])
-						vty_out(vty, " %12" PRIu32,
-							peer->pcount
-								[afi]
-								[pfx_rcd_safi]);
-					else
+					if (peer->afc_recv[afi][safi]) {
+						if (CHECK_FLAG(
+							    bgp->flags,
+							    BGP_FLAG_EBGP_REQUIRES_POLICY)
+						    && !bgp_inbound_policy_exists(
+							    peer, filter))
+							vty_out(vty, " %12s",
+								"(Policy)");
+						else
+							vty_out(vty,
+								" %12" PRIu32,
+								peer->pcount
+									[afi]
+									[pfx_rcd_safi]);
+					} else {
 						vty_out(vty, " NoNeg");
+					}
 
-					if (paf && PAF_SUBGRP(paf))
-						vty_out(vty, " %8" PRIu32,
-							(PAF_SUBGRP(paf))
-								->scount);
+					if (paf && PAF_SUBGRP(paf)) {
+						if (CHECK_FLAG(
+							    bgp->flags,
+							    BGP_FLAG_EBGP_REQUIRES_POLICY)
+						    && !bgp_outbound_policy_exists(
+							    peer, filter))
+							vty_out(vty, " %8s",
+								"(Policy)");
+						else
+							vty_out(vty,
+								" %8" PRIu32,
+								(PAF_SUBGRP(
+									 paf))
+									->scount);
+					}
 				} else {
 					if (CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN))
 						vty_out(vty, " Idle (Admin)");

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -420,6 +420,23 @@ Require policy on EBGP
 
    This is enabled by default.
 
+   When the incoming or outgoing filter is missing you will see
+   "(Policy)" sign under ``show bgp summary``:
+
+   .. code-block:: frr
+
+      exit1# show bgp summary
+
+      IPv4 Unicast Summary:
+      BGP router identifier 10.10.10.1, local AS number 65001 vrf-id 0
+      BGP table version 4
+      RIB entries 7, using 1344 bytes of memory
+      Peers 2, using 43 KiB of memory
+
+      Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
+      192.168.0.2     4      65002         8        10        0    0    0 00:03:09            5 (Policy)
+      fe80:1::2222    4      65002         9        11        0    0    0 00:03:09     (Policy) (Policy)
+
 Reject routes with AS_SET or AS_CONFED_SET types
 ------------------------------------------------
 


### PR DESCRIPTION
It could be hard to notice when eBGP policy is missing in `show bgp summary`.

This adds more sugar to the output:

Normal:
```
 MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
      10        0    0    0 00:02:07            6        8
```
When rfc8212 is enabled (default since 7.4) - OUTBOUND:
```
 MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
      13        0    0    0 00:04:56            6 (Policy)
```
INBOUND:
```
 MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
      19        0    0    0 00:06:27     (Policy)        2
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>