### PR TITLE
bgpd: [7.3] bools use `true/false` not `TRUE/FALSE`

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9936,7 +9936,7 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 		}
 	} else if (safi == SAFI_EVPN) {
 		struct bgp_node *longest_pfx;
-		bool is_exact_pfxlen_match = FALSE;
+		bool is_exact_pfxlen_match = false;
 
 		for (rn = bgp_table_top(rib); rn; rn = bgp_route_next(rn)) {
 			if (prd && memcmp(rn->p.u.val, prd->val, 8) != 0)
@@ -9946,7 +9946,7 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 				continue;
 
 			longest_pfx = NULL;
-			is_exact_pfxlen_match = FALSE;
+			is_exact_pfxlen_match = false;
 			/*
 			 * Search through all the prefixes for a match.  The
 			 * pfx's are enumerated in ascending order of pfxlens.
@@ -9965,7 +9965,7 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 					int type5_pfxlen =
 					   bgp_evpn_get_type5_prefixlen(&rm->p);
 					if (type5_pfxlen == match.prefixlen) {
-						is_exact_pfxlen_match = TRUE;
+						is_exact_pfxlen_match = true;
 						bgp_unlock_node(rm);
 						break;
 					}


### PR DESCRIPTION
Who knows where these values were coming from.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

Closes https://github.com/FRRouting/frr/issues/6337