### PR TITLE
redux lists/datastructure const

### DIFF
--- a/lib/typerb.c
+++ b/lib/typerb.c
@@ -377,12 +377,13 @@ struct typed_rb_entry *typed_rb_insert(struct rbt_tree *rbt,
 }
 
 /* Finds the node with the same key as elm */
-struct rb_entry *typed_rb_find(struct rbt_tree *rbt, const struct rb_entry *key,
+const struct rb_entry *typed_rb_find(const struct rbt_tree *rbt,
+		const struct rb_entry *key,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b))
 {
-	struct rb_entry *tmp = RBH_ROOT(rbt);
+	const struct rb_entry *tmp = RBH_ROOT(rbt);
 	int comp;
 
 	while (tmp != NULL) {
@@ -398,13 +399,13 @@ struct rb_entry *typed_rb_find(struct rbt_tree *rbt, const struct rb_entry *key,
 	return NULL;
 }
 
-struct rb_entry *typed_rb_find_gteq(struct rbt_tree *rbt,
+const struct rb_entry *typed_rb_find_gteq(const struct rbt_tree *rbt,
 		const struct rb_entry *key,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b))
 {
-	struct rb_entry *tmp = RBH_ROOT(rbt), *best = NULL;
+	const struct rb_entry *tmp = RBH_ROOT(rbt), *best = NULL;
 	int comp;
 
 	while (tmp != NULL) {
@@ -421,13 +422,13 @@ struct rb_entry *typed_rb_find_gteq(struct rbt_tree *rbt,
 	return best;
 }
 
-struct rb_entry *typed_rb_find_lt(struct rbt_tree *rbt,
+const struct rb_entry *typed_rb_find_lt(const struct rbt_tree *rbt,
 		const struct rb_entry *key,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b))
 {
-	struct rb_entry *tmp = RBH_ROOT(rbt), *best = NULL;
+	const struct rb_entry *tmp = RBH_ROOT(rbt), *best = NULL;
 	int comp;
 
 	while (tmp != NULL) {
@@ -443,8 +444,10 @@ struct rb_entry *typed_rb_find_lt(struct rbt_tree *rbt,
 	return best;
 }
 
-struct rb_entry *typed_rb_next(struct rb_entry *rbe)
+struct rb_entry *typed_rb_next(const struct rb_entry *rbe_const)
 {
+	struct rb_entry *rbe = (struct rb_entry *)rbe_const;
+
 	if (RBE_RIGHT(rbe) != NULL) {
 		rbe = RBE_RIGHT(rbe);
 		while (RBE_LEFT(rbe) != NULL)
@@ -463,7 +466,7 @@ struct rb_entry *typed_rb_next(struct rb_entry *rbe)
 	return rbe;
 }
 
-struct rb_entry *typed_rb_min(struct rbt_tree *rbt)
+struct rb_entry *typed_rb_min(const struct rbt_tree *rbt)
 {
 	struct rb_entry *rbe = RBH_ROOT(rbt);
 	struct rb_entry *parent = NULL;

--- a/lib/typerb.h
+++ b/lib/typerb.h
@@ -45,23 +45,23 @@ struct typed_rb_entry *typed_rb_insert(struct typed_rb_root *rbt,
 			const struct typed_rb_entry *b));
 struct typed_rb_entry *typed_rb_remove(struct typed_rb_root *rbt,
 				       struct typed_rb_entry *rbe);
-struct typed_rb_entry *typed_rb_find(struct typed_rb_root *rbt,
+const struct typed_rb_entry *typed_rb_find(const struct typed_rb_root *rbt,
 		const struct typed_rb_entry *rbe,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b));
-struct typed_rb_entry *typed_rb_find_gteq(struct typed_rb_root *rbt,
+const struct typed_rb_entry *typed_rb_find_gteq(const struct typed_rb_root *rbt,
 		const struct typed_rb_entry *rbe,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b));
-struct typed_rb_entry *typed_rb_find_lt(struct typed_rb_root *rbt,
+const struct typed_rb_entry *typed_rb_find_lt(const struct typed_rb_root *rbt,
 		const struct typed_rb_entry *rbe,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b));
-struct typed_rb_entry *typed_rb_min(struct typed_rb_root *rbt);
-struct typed_rb_entry *typed_rb_next(struct typed_rb_entry *rbe);
+struct typed_rb_entry *typed_rb_min(const struct typed_rb_root *rbt);
+struct typed_rb_entry *typed_rb_next(const struct typed_rb_entry *rbe);
 
 #define _PREDECL_RBTREE(prefix)                                                \
 struct prefix ## _head { struct typed_rb_root rr; };                           \
@@ -86,20 +86,21 @@ macro_inline type *prefix ## _add(struct prefix##_head *h, type *item)         \
 	re = typed_rb_insert(&h->rr, &item->field.re, cmpfn_uq);               \
 	return container_of_null(re, type, field.re);                          \
 }                                                                              \
-macro_inline type *prefix ## _find_gteq(struct prefix##_head *h,               \
-		const type *item)                                              \
+macro_inline const type *prefix ## _const_find_gteq(                           \
+		const struct prefix##_head *h, const type *item)               \
 {                                                                              \
-	struct typed_rb_entry *re;                                             \
+	const struct typed_rb_entry *re;                                       \
 	re = typed_rb_find_gteq(&h->rr, &item->field.re, cmpfn_nuq);           \
 	return container_of_null(re, type, field.re);                          \
 }                                                                              \
-macro_inline type *prefix ## _find_lt(struct prefix##_head *h,                 \
-		const type *item)                                              \
+macro_inline const type *prefix ## _const_find_lt(                             \
+		const struct prefix##_head *h, const type *item)               \
 {                                                                              \
-	struct typed_rb_entry *re;                                             \
+	const struct typed_rb_entry *re;                                       \
 	re = typed_rb_find_lt(&h->rr, &item->field.re, cmpfn_nuq);             \
 	return container_of_null(re, type, field.re);                          \
 }                                                                              \
+TYPESAFE_FIND_CMP(prefix, type)                                                \
 macro_inline type *prefix ## _del(struct prefix##_head *h, type *item)         \
 {                                                                              \
 	struct typed_rb_entry *re;                                             \
@@ -115,18 +116,20 @@ macro_inline type *prefix ## _pop(struct prefix##_head *h)                     \
 	typed_rb_remove(&h->rr, re);                                           \
 	return container_of(re, type, field.re);                               \
 }                                                                              \
-macro_pure type *prefix ## _first(struct prefix##_head *h)                     \
+macro_pure const type *prefix ## _const_first(const struct prefix##_head *h)   \
 {                                                                              \
-	struct typed_rb_entry *re;                                             \
+	const struct typed_rb_entry *re;                                       \
 	re = typed_rb_min(&h->rr);                                             \
 	return container_of_null(re, type, field.re);                          \
 }                                                                              \
-macro_pure type *prefix ## _next(struct prefix##_head *h, type *item)          \
+macro_pure const type *prefix ## _const_next(const struct prefix##_head *h,    \
+					     const type *item)                 \
 {                                                                              \
-	struct typed_rb_entry *re;                                             \
+	const struct typed_rb_entry *re;                                       \
 	re = typed_rb_next(&item->field.re);                                   \
 	return container_of_null(re, type, field.re);                          \
 }                                                                              \
+TYPESAFE_FIRST_NEXT(prefix, type)                                              \
 macro_pure type *prefix ## _next_safe(struct prefix##_head *h, type *item)     \
 {                                                                              \
 	struct typed_rb_entry *re;                                             \
@@ -149,12 +152,14 @@ macro_inline int prefix ## __cmp(const struct typed_rb_entry *a,               \
 	return cmpfn(container_of(a, type, field.re),                          \
 			container_of(b, type, field.re));                      \
 }                                                                              \
-macro_inline type *prefix ## _find(struct prefix##_head *h, const type *item)  \
+macro_inline const type *prefix ## _const_find(const struct prefix##_head *h,  \
+					       const type *item)               \
 {                                                                              \
-	struct typed_rb_entry *re;                                             \
+	const struct typed_rb_entry *re;                                       \
 	re = typed_rb_find(&h->rr, &item->field.re, &prefix ## __cmp);         \
 	return container_of_null(re, type, field.re);                          \
 }                                                                              \
+TYPESAFE_FIND(prefix, type)                                                    \
                                                                                \
 _DECLARE_RBTREE(prefix, type, field, prefix ## __cmp, prefix ## __cmp)         \
 /* ... */

--- a/lib/typesafe.c
+++ b/lib/typesafe.c
@@ -158,7 +158,7 @@ void typesafe_hash_shrink(struct thash_head *head)
 
 /* skiplist */
 
-static inline struct sskip_item *sl_level_get(struct sskip_item *item,
+static inline struct sskip_item *sl_level_get(const struct sskip_item *item,
 			size_t level)
 {
 	if (level < SKIPLIST_OVERFLOW)
@@ -263,13 +263,14 @@ struct sskip_item *typesafe_skiplist_add(struct sskip_head *head,
 
 /* NOTE: level counting below is 1-based since that makes the code simpler! */
 
-struct sskip_item *typesafe_skiplist_find(struct sskip_head *head,
+const struct sskip_item *typesafe_skiplist_find(
+		const struct sskip_head *head,
 		const struct sskip_item *item, int (*cmpfn)(
 				const struct sskip_item *a,
 				const struct sskip_item *b))
 {
 	size_t level = SKIPLIST_MAXDEPTH;
-	struct sskip_item *prev = &head->hitem, *next;
+	const struct sskip_item *prev = &head->hitem, *next;
 	int cmpval;
 
 	while (level) {
@@ -290,13 +291,14 @@ struct sskip_item *typesafe_skiplist_find(struct sskip_head *head,
 	return NULL;
 }
 
-struct sskip_item *typesafe_skiplist_find_gteq(struct sskip_head *head,
+const struct sskip_item *typesafe_skiplist_find_gteq(
+		const struct sskip_head *head,
 		const struct sskip_item *item, int (*cmpfn)(
 				const struct sskip_item *a,
 				const struct sskip_item *b))
 {
 	size_t level = SKIPLIST_MAXDEPTH;
-	struct sskip_item *prev = &head->hitem, *next;
+	const struct sskip_item *prev = &head->hitem, *next;
 	int cmpval;
 
 	while (level) {
@@ -317,13 +319,14 @@ struct sskip_item *typesafe_skiplist_find_gteq(struct sskip_head *head,
 	return next;
 }
 
-struct sskip_item *typesafe_skiplist_find_lt(struct sskip_head *head,
+const struct sskip_item *typesafe_skiplist_find_lt(
+		const struct sskip_head *head,
 		const struct sskip_item *item, int (*cmpfn)(
 				const struct sskip_item *a,
 				const struct sskip_item *b))
 {
 	size_t level = SKIPLIST_MAXDEPTH;
-	struct sskip_item *prev = &head->hitem, *next, *best = NULL;
+	const struct sskip_item *prev = &head->hitem, *next, *best = NULL;
 	int cmpval;
 
 	while (level) {


### PR DESCRIPTION
This was originally #6137 

> Convert the embedded lists of nhlfes and snhlfes in zebra LSPs and SLSPs to use typesafe dlists. I want a little more capability in those lists, so it seems better to just convert them, rather than enhancing the one-off apis using the current approach.
> 
> This also enhances the `lib/typesafe` lists (the slists and dlists) to offer some `const` apis.

Differences:
- no `_is_empty()` in this one
- `_const_{first,next,...}` instead of `_{first,next,...}_const`.  This allows using `frr_each(something_const, ...)` instead of `frr_each_const(something, ...)`, so no new `frr_each_const` macro (:shower: idea :grin:)
- added RB-tree `const` versions too
- added `_const_find()`, `_const_findlt()`, `_const_findgteq()`
- non-`const` functions are just wrappers around the `const` to avoid duplication; each function is only ~declared~ defined once regardless of `const` or not.  
  - Means there is essentially no net loss/gain in number of DS function implementations.  Also means no extra testing footprint really.
- adapted the unit tests slightly

edit: removed zebra NHLFE on request by @mjstapp 