### PR TITLE
isisd: Preparation to merge Segment-Routing into master

### DIFF
--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -473,15 +473,16 @@ Traffic Engineering
 Segment Routing
 ===============
 
-This is an EXPERIMENTAL support of Segment Routing as per draft
-`draft-ietf-isis-segment-routing-extensions-25.txt` for MPLS dataplane.
-It supports IPv4, IPv6 and ECMP and has been tested against Cisco & Juniper
-routers.
+This is an EXPERIMENTAL support of Segment Routing as per RFC8667
+for MPLS dataplane. It supports IPv4, IPv6 and ECMP and has been
+tested against Cisco & Juniper routers.
 
 Known limitations:
  - No support for level redistribution (L1 to L2 or L2 to L1)
  - No support for binding SID
  - No support for SRMS
+ - No support for SRLB
+ - Only one SRGB and default SPF Algorithm is supported
 
 .. index:: [no] segment-routing on
 .. clicmd:: [no] segment-routing on
@@ -491,14 +492,15 @@ Known limitations:
 .. index:: [no] segment-routing global-block (0-1048575) (0-1048575)
 .. clicmd:: [no] segment-routing global-block (0-1048575) (0-1048575)
 
-   Seet the Segment Routing Global Block i.e. the label range used by MPLS
+   Set the Segment Routing Global Block i.e. the label range used by MPLS
    to store label in the MPLS FIB.
 
 .. index:: [no] segment-routing node-msd (1-16)
 .. clicmd:: [no] segment-routing node-msd (1-16)
 
    Set the Maximum Stack Depth supported by the router. The value depend of the
-   MPLS dataplane. E.g. for Linux kernel, since version 4.13 it is 32.
+   MPLS dataplane. E.g. for Linux kernel, since version 4.13 the maximum value
+   is 32.
 
 .. index:: [no] segment-routing prefix <A.B.C.D/M|X:X::X:X/M> <absolute (16-1048575)|index (0-65535)> [no-php-flag|explicit-null]
 .. clicmd:: [no] segment-routing prefix <A.B.C.D/M|X:X::X:X/M> <absolute (16-1048575)|index (0-65535) [no-php-flag|explicit-null]
@@ -513,6 +515,11 @@ Known limitations:
 .. clicmd:: show isis segment-routing prefix-sids
 
    Show detailed information about all learned Segment Routing Prefix-SIDs.
+
+.. index:: show isis segment-routing nodes
+.. clicmd:: show isis segment-routing nodes
+
+   Show detailed information about all learned Segment Routing Nodes.
 
 Debugging ISIS
 ==============
@@ -707,3 +714,32 @@ Then the :file:`isisd.conf` itself:
      mpls-te router-address 10.1.1.1
    !
    line vty
+
+A Segment Routing configuration, with IPv4, IPv6, SRGB and MSD configuration.
+
+.. code-block:: frr
+
+   hostname HOSTNAME
+   password PASSWORD
+   log file /var/log/isisd.log
+   !
+   !
+   interface eth0
+    ip router isis SR
+    isis network point-to-point
+   !
+   interface eth1
+    ip router isis SR
+   !
+   !
+   router isis SR
+    net 49.0000.0000.0000.0001.00
+    is-type level-1
+    topology ipv6-unicast
+    lsp-gen-interval 2
+    segment-routing on
+    segment-routing node-msd 8
+    segment-routing prefix 10.1.1.1/32 index 100 explicit-null
+    segment-routing prefix 2001:db8:1000::1/128 index 101 explicit-null
+   !
+

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -1521,7 +1521,9 @@ int isis_instance_segment_routing_msd_node_msd_modify(
 
 	area = nb_running_get_entry(args->dnode, NULL, true);
 	area->srdb.config.msd = yang_dnode_get_uint8(args->dnode, NULL);
-	isis_sr_cfg_msd_update(area);
+
+	/* Update and regenerate LSP */
+	lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -1536,7 +1538,9 @@ int isis_instance_segment_routing_msd_node_msd_destroy(
 
 	area = nb_running_get_entry(args->dnode, NULL, true);
 	area->srdb.config.msd = 0;
-	isis_sr_cfg_msd_update(area);
+
+	/* Update and regenerate LSP */
+	lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }

--- a/isisd/isis_sr.h
+++ b/isisd/isis_sr.h
@@ -120,8 +120,8 @@ struct sr_prefix {
 	/* SID value, algorithm and flags. */
 	struct isis_prefix_sid sid;
 
-	/* Local label value. */
-	mpls_label_t local_label;
+	/* Input label value. */
+	mpls_label_t input_label;
 
 	/* Prefix-SID type. */
 	enum sr_prefix_type type;

--- a/isisd/isis_sr.h
+++ b/isisd/isis_sr.h
@@ -1,8 +1,7 @@
 /*
- * This is an implementation of Segment Routing for IS-IS
- * as per draft draft-ietf-isis-segment-routing-extensions-25
+ * This is an implementation of Segment Routing for IS-IS as per RFC 8667
  *
- * Copyright (C) 2019 Orange Labs http://www.orange.com
+ * Copyright (C) 2019 Orange http://www.orange.com
  *
  * Author: Olivier Dugeon <olivier.dugeon@orange.com>
  * Contributor: Renato Westphal <renato@opensourcerouting.org> for NetDEF
@@ -55,30 +54,31 @@
 #define SRGB_LOWER_BOUND               16000
 #define SRGB_UPPER_BOUND               23999
 
+/* Segment Routing Data Base (SRDB) RB-Tree structure */
 PREDECL_RBTREE_UNIQ(srdb_node)
 PREDECL_RBTREE_UNIQ(srdb_node_prefix)
 PREDECL_RBTREE_UNIQ(srdb_area_prefix)
 PREDECL_RBTREE_UNIQ(srdb_prefix_cfg)
 
-/* SR Adj-SID type. */
+/* Segment Routing Adjacency-SID type. */
 enum sr_adj_type {
 	ISIS_SR_ADJ_NORMAL = 0,
 	ISIS_SR_LAN_BACKUP,
 };
 
-/* SR Adjacency. */
+/* Segment Routing Adjacency. */
 struct sr_adjacency {
 	/* Adjacency type. */
 	enum sr_adj_type type;
 
-	/* Adj-SID nexthop information. */
+	/* Adjacency-SID nexthop information. */
 	struct {
 		int family;
 		union g_addr address;
 		mpls_label_t label;
 	} nexthop;
 
-	/* (LAN-)Adj-SID Sub-TLV. */
+	/* (LAN-)Adjacency-SID Sub-TLV. */
 	union {
 		struct isis_adj_sid *adj_sid;
 		struct isis_lan_adj_sid *ladj_sid;
@@ -88,13 +88,13 @@ struct sr_adjacency {
 	struct isis_adjacency *adj;
 };
 
-/* SR Prefix-SID type. */
+/* Segment Routing Prefix-SID type. */
 enum sr_prefix_type {
 	ISIS_SR_PREFIX_LOCAL = 0,
 	ISIS_SR_PREFIX_REMOTE,
 };
 
-/* SR Nexthop Information. */
+/* Segment Routing Nexthop Information. */
 struct sr_nexthop_info {
 	mpls_label_t label;
 	time_t uptime;
@@ -108,16 +108,16 @@ enum srdb_state {
 	SRDB_STATE_UNCHANGED
 };
 
-/* SR Prefix-SID. */
+/* Segment Routing Prefix-SID. */
 struct sr_prefix {
-	/* RB-tree entries. */
+	/* SRDB RB-tree entries. */
 	struct srdb_node_prefix_item node_entry;
 	struct srdb_area_prefix_item area_entry;
 
 	/* IP prefix. */
 	struct prefix prefix;
 
-	/* SID value, algorithm and flags. */
+	/* SID value, algorithm and flags subTLVs. */
 	struct isis_prefix_sid sid;
 
 	/* Input label value. */
@@ -136,16 +136,16 @@ struct sr_prefix {
 		} remote;
 	} u;
 
-	/* Backpointer to SR node. */
+	/* Backpointer to Segment Routing node. */
 	struct sr_node *srn;
 
 	/* SR-Prefix State used while the LSPDB is being parsed. */
 	enum srdb_state state;
 };
 
-/* SR node. */
+/* Segment Routing node. */
 struct sr_node {
-	/* RB-tree entry. */
+	/* SRDB RB-tree entry. */
 	struct srdb_node_item entry;
 
 	/* IS-IS level: ISIS_LEVEL1 or ISIS_LEVEL2. */
@@ -154,7 +154,7 @@ struct sr_node {
 	/* IS-IS node identifier. */
 	uint8_t sysid[ISIS_SYS_ID_LEN];
 
-	/* IS-IS node capabilities (SRGB, SR Algorithms, etc). */
+	/* Segment Routing node capabilities (SRGB, SR Algorithms) subTLVs. */
 	struct isis_router_cap cap;
 
 	/* List of Prefix-SIDs advertised by this node. */
@@ -167,7 +167,7 @@ struct sr_node {
 	enum srdb_state state;
 };
 
-/* NOTE: these values must be in sync with the YANG module. */
+/* SID type. NOTE: these values must be in sync with the YANG module. */
 enum sr_sid_value_type {
 	SR_SID_VALUE_TYPE_INDEX = 0,
 	SR_SID_VALUE_TYPE_ABSOLUTE = 1,
@@ -175,16 +175,16 @@ enum sr_sid_value_type {
 
 #define IS_SID_VALUE(flag) CHECK_FLAG(flag, ISIS_PREFIX_SID_VALUE)
 
-/* NOTE: these values must be in sync with the YANG module. */
+/* Last Hop Behavior. NOTE: these values must be in sync with the YANG module */
 enum sr_last_hop_behavior {
 	SR_LAST_HOP_BEHAVIOR_EXP_NULL = 0,
 	SR_LAST_HOP_BEHAVIOR_NO_PHP = 1,
 	SR_LAST_HOP_BEHAVIOR_PHP = 2,
 };
 
-/* SR Prefix-SID configuration. */
+/* Segment Routing Prefix-SID configuration. */
 struct sr_prefix_cfg {
-	/* RB-tree entry. */
+	/* SRDB RB-tree entry. */
 	struct srdb_prefix_cfg_item entry;
 
 	/* IP prefix. */
@@ -206,21 +206,21 @@ struct sr_prefix_cfg {
 	struct isis_area *area;
 };
 
-/* Per-area IS-IS Segment Routing information. */
+/* Per-area IS-IS Segment Routing Data Base (SRDB). */
 struct isis_sr_db {
-	/* Operational status of Segment Routing. */
+	/* Global Operational status of Segment Routing. */
 	bool enabled;
 
-	/* Adj-SIDs. */
+	/* List of local Adjacency-SIDs. */
 	struct list *adj_sids;
 
-	/* SR information from all nodes. */
+	/* Segment Routing Node information per IS-IS level. */
 	struct srdb_node_head sr_nodes[ISIS_LEVELS];
 
-	/* Prefix-SIDs. */
+	/* Segment Routing Prefix-SIDs per IS-IS level. */
 	struct srdb_area_prefix_head prefix_sids[ISIS_LEVELS];
 
-	/* Area SR configuration. */
+	/* Area Segment Routing configuration. */
 	struct {
 		/* Administrative status of Segment Routing. */
 		bool enabled;

--- a/isisd/isis_sr.h
+++ b/isisd/isis_sr.h
@@ -240,7 +240,6 @@ struct isis_sr_db {
 /* Prototypes. */
 extern int isis_sr_cfg_srgb_update(struct isis_area *area, uint32_t lower_bound,
 				   uint32_t upper_bound);
-extern void isis_sr_cfg_msd_update(struct isis_area *area);
 extern struct sr_prefix_cfg *
 isis_sr_cfg_prefix_add(struct isis_area *area, const struct prefix *prefix);
 extern void isis_sr_cfg_prefix_del(struct sr_prefix_cfg *pcfg);

--- a/isisd/isis_sr.h
+++ b/isisd/isis_sr.h
@@ -173,6 +173,8 @@ enum sr_sid_value_type {
 	SR_SID_VALUE_TYPE_ABSOLUTE = 1,
 };
 
+#define IS_SID_VALUE(flag) CHECK_FLAG(flag, ISIS_PREFIX_SID_VALUE)
+
 /* NOTE: these values must be in sync with the YANG module. */
 enum sr_last_hop_behavior {
 	SR_LAST_HOP_BEHAVIOR_EXP_NULL = 0,

--- a/isisd/isis_tlvs.h
+++ b/isisd/isis_tlvs.h
@@ -135,10 +135,7 @@ struct isis_threeway_adj {
 	uint32_t neighbor_circuit_id;
 };
 
-/*
- * Segment Routing subTLV's as per
- * draft-ietf-isis-segment-routing-extension-25
- */
+/* Segment Routing subTLV's as per RFC8667 */
 #define ISIS_SUBTLV_SRGB_FLAG_I		0x80
 #define ISIS_SUBTLV_SRGB_FLAG_V		0x40
 #define IS_SR_IPV4(srgb)               (srgb.flags & ISIS_SUBTLV_SRGB_FLAG_I)
@@ -216,7 +213,7 @@ struct isis_router_cap {
 	struct in_addr router_id;
 	uint8_t flags;
 
-	/* draft-ietf-segment-routing-extensions-25 */
+	/* RFC 8667 section #3 */
 	struct isis_srgb srgb;
 	uint8_t algo[SR_ALGORITHM_COUNT];
 	/* RFC 8491 */
@@ -344,7 +341,7 @@ struct isis_subtlvs {
 
 	/* draft-baker-ipv6-isis-dst-src-routing-06 */
 	struct prefix_ipv6 *source_prefix;
-	/* draft-ietf-isis-segment-routing-extensions-25 */
+	/* RFC 8667 section #2.4 */
 	struct isis_item_list prefix_sids;
 };
 
@@ -394,15 +391,17 @@ enum isis_tlv_type {
 	/* RFC 5307 */
 	ISIS_SUBTLV_LLRI = 4,
 
+	/* RFC 8491 */
+	ISIS_SUBTLV_NODE_MSD = 23,
+
 	/* RFC 5316 */
 	ISIS_SUBTLV_RAS = 24,
 	ISIS_SUBTLV_RIP = 25,
 
-	/* draft-isis-segment-routing-extension-25 */
+	/* RFC 8667 section #2 */
 	ISIS_SUBTLV_SID_LABEL = 1,
 	ISIS_SUBTLV_SID_LABEL_RANGE = 2,
 	ISIS_SUBTLV_ALGORITHM = 19,
-	ISIS_SUBTLV_NODE_MSD = 23,
 	ISIS_SUBTLV_PREFIX_SID = 3,
 	ISIS_SUBTLV_ADJ_SID = 31,
 	ISIS_SUBTLV_LAN_ADJ_SID = 32,
@@ -421,21 +420,26 @@ enum isis_tlv_type {
 
 /* subTLVs size for TE and SR */
 enum ext_subtlv_size {
+	/* RFC 5307 */
 	ISIS_SUBTLV_LLRI_SIZE = 8,
 
+	/* RFC 5305 & RFC 6119 */
 	ISIS_SUBTLV_UNRSV_BW_SIZE = 32,
 	ISIS_SUBTLV_TE_METRIC_SIZE = 3,
 	ISIS_SUBTLV_IPV6_ADDR_SIZE = 16,
 
-	/* draft-isis-segment-routing-extension-25 */
+	/* RFC 8491 */
+	ISIS_SUBTLV_NODE_MSD_SIZE = 2,
+
+	/* RFC 8667 section #2 */
 	ISIS_SUBTLV_SID_LABEL_SIZE = 3,
 	ISIS_SUBTLV_SID_LABEL_RANGE_SIZE = 9,
 	ISIS_SUBTLV_ALGORITHM_SIZE = 4,
-	ISIS_SUBTLV_NODE_MSD_SIZE = 2,
 	ISIS_SUBTLV_ADJ_SID_SIZE = 5,
 	ISIS_SUBTLV_LAN_ADJ_SID_SIZE = 11,
 	ISIS_SUBTLV_PREFIX_SID_SIZE = 5,
 
+	/* RFC 7810 */
 	ISIS_SUBTLV_MM_DELAY_SIZE = 8,
 
 	ISIS_SUBTLV_HDR_SIZE = 2,

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -254,7 +254,11 @@ void isis_zebra_route_del_route(struct prefix *prefix,
 	zclient_route_send(ZEBRA_ROUTE_DELETE, zclient, &api);
 }
 
-/* Install Prefix-SID in the forwarding plane. */
+/**
+ * Install Prefix-SID in the forwarding plane through Zebra.
+ *
+ * @param srp	Segment Routing Prefix-SID
+ */
 static void isis_zebra_prefix_install_prefix_sid(const struct sr_prefix *srp)
 {
 	struct zapi_labels zl;
@@ -315,7 +319,11 @@ static void isis_zebra_prefix_install_prefix_sid(const struct sr_prefix *srp)
 	(void)zebra_send_mpls_labels(zclient, ZEBRA_MPLS_LABELS_REPLACE, &zl);
 }
 
-/* Uninstall Prefix-SID from the forwarding plane. */
+/**
+ * Uninstall Prefix-SID from the forwarding plane through Zebra.
+ *
+ * @param srp	Segment Routing Prefix-SID
+ */
 static void isis_zebra_uninstall_prefix_sid(const struct sr_prefix *srp)
 {
 	struct zapi_labels zl;
@@ -337,6 +345,12 @@ static void isis_zebra_uninstall_prefix_sid(const struct sr_prefix *srp)
 	(void)zebra_send_mpls_labels(zclient, ZEBRA_MPLS_LABELS_DELETE, &zl);
 }
 
+/**
+ * Send Prefix-SID to ZEBRA for installation or deletion.
+ *
+ * @param cmd	ZEBRA_MPLS_LABELS_REPLACE or ZEBRA_ROUTE_DELETE
+ * @param srp	Segment Routing Prefix-SID
+ */
 void isis_zebra_send_prefix_sid(int cmd, const struct sr_prefix *srp)
 {
 
@@ -357,7 +371,12 @@ void isis_zebra_send_prefix_sid(int cmd, const struct sr_prefix *srp)
 		isis_zebra_uninstall_prefix_sid(srp);
 }
 
-/* Install or uninstall (LAN)-Adj-SID. */
+/**
+ * Send (LAN)-Adjacency-SID to ZEBRA for installation or deletion.
+ *
+ * @param cmd	ZEBRA_MPLS_LABELS_ADD or ZEBRA_ROUTE_DELETE
+ * @param sra	Segment Routing Adjacency-SID
+ */
 void isis_zebra_send_adjacency_sid(int cmd, const struct sr_adjacency *sra)
 {
 	struct zapi_labels zl;

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -265,7 +265,7 @@ void isis_zebra_install_prefix_sid(const struct sr_prefix *srp)
 	/* Prepare message. */
 	memset(&zl, 0, sizeof(zl));
 	zl.type = ZEBRA_LSP_ISIS_SR;
-	zl.local_label = srp->local_label;
+	zl.local_label = srp->input_label;
 
 	switch (srp->type) {
 	case ISIS_SR_PREFIX_LOCAL:
@@ -322,7 +322,7 @@ void isis_zebra_uninstall_prefix_sid(const struct sr_prefix *srp)
 	/* Prepare message. */
 	memset(&zl, 0, sizeof(zl));
 	zl.type = ZEBRA_LSP_ISIS_SR;
-	zl.local_label = srp->local_label;
+	zl.local_label = srp->input_label;
 
 	if (srp->type == ISIS_SR_PREFIX_REMOTE) {
 		/* Update route in the RIB too. */

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -49,6 +49,7 @@
 #include "isisd/isis_lsp.h"
 #include "isisd/isis_route.h"
 #include "isisd/isis_zebra.h"
+#include "isisd/isis_adjacency.h"
 #include "isisd/isis_te.h"
 #include "isisd/isis_sr.h"
 
@@ -254,7 +255,7 @@ void isis_zebra_route_del_route(struct prefix *prefix,
 }
 
 /* Install Prefix-SID in the forwarding plane. */
-void isis_zebra_install_prefix_sid(const struct sr_prefix *srp)
+static void isis_zebra_prefix_install_prefix_sid(const struct sr_prefix *srp)
 {
 	struct zapi_labels zl;
 	struct zapi_nexthop *znh;
@@ -315,7 +316,7 @@ void isis_zebra_install_prefix_sid(const struct sr_prefix *srp)
 }
 
 /* Uninstall Prefix-SID from the forwarding plane. */
-void isis_zebra_uninstall_prefix_sid(const struct sr_prefix *srp)
+static void isis_zebra_uninstall_prefix_sid(const struct sr_prefix *srp)
 {
 	struct zapi_labels zl;
 
@@ -334,6 +335,58 @@ void isis_zebra_uninstall_prefix_sid(const struct sr_prefix *srp)
 
 	/* Send message to zebra. */
 	(void)zebra_send_mpls_labels(zclient, ZEBRA_MPLS_LABELS_DELETE, &zl);
+}
+
+void isis_zebra_send_prefix_sid(int cmd, const struct sr_prefix *srp)
+{
+
+	if (cmd != ZEBRA_MPLS_LABELS_REPLACE
+	    && cmd != ZEBRA_MPLS_LABELS_DELETE) {
+		flog_warn(EC_LIB_DEVELOPMENT, "%s: wrong ZEBRA command",
+			  __func__);
+		return;
+	}
+
+	sr_debug("  |- %s label %u for prefix %pFX",
+		 cmd == ZEBRA_MPLS_LABELS_REPLACE ? "Update" : "Delete",
+		 srp->input_label, &srp->prefix);
+
+	if (cmd == ZEBRA_MPLS_LABELS_REPLACE)
+		isis_zebra_prefix_install_prefix_sid(srp);
+	else
+		isis_zebra_uninstall_prefix_sid(srp);
+}
+
+/* Install or uninstall (LAN)-Adj-SID. */
+void isis_zebra_send_adjacency_sid(int cmd, const struct sr_adjacency *sra)
+{
+	struct zapi_labels zl;
+	struct zapi_nexthop *znh;
+
+	if (cmd != ZEBRA_MPLS_LABELS_ADD && cmd != ZEBRA_MPLS_LABELS_DELETE) {
+		flog_warn(EC_LIB_DEVELOPMENT, "%s: wrong ZEBRA command",
+			  __func__);
+		return;
+	}
+
+	sr_debug("  |- %s label %u for interface %s",
+		 cmd == ZEBRA_MPLS_LABELS_ADD ? "Add" : "Delete",
+		 sra->nexthop.label, sra->adj->circuit->interface->name);
+
+	memset(&zl, 0, sizeof(zl));
+	zl.type = ZEBRA_LSP_ISIS_SR;
+	zl.local_label = sra->nexthop.label;
+	zl.nexthop_num = 1;
+	znh = &zl.nexthops[0];
+	znh->gate = sra->nexthop.address;
+	znh->type = (sra->nexthop.family == AF_INET)
+			    ? NEXTHOP_TYPE_IPV4_IFINDEX
+			    : NEXTHOP_TYPE_IPV6_IFINDEX;
+	znh->ifindex = sra->adj->circuit->interface->ifindex;
+	znh->label_num = 1;
+	znh->labels[0] = MPLS_LABEL_IMPLICIT_NULL;
+
+	(void)zebra_send_mpls_labels(zclient, cmd, &zl);
 }
 
 static int isis_zebra_read(ZAPI_CALLBACK_ARGS)

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -36,6 +36,7 @@ void isis_zebra_stop(void);
 
 struct isis_route_info;
 struct sr_prefix;
+struct sr_adjacency;
 
 void isis_zebra_route_add_route(struct prefix *prefix,
 				struct prefix_ipv6 *src_p,
@@ -43,8 +44,8 @@ void isis_zebra_route_add_route(struct prefix *prefix,
 void isis_zebra_route_del_route(struct prefix *prefix,
 				struct prefix_ipv6 *src_p,
 				struct isis_route_info *route_info);
-void isis_zebra_install_prefix_sid(const struct sr_prefix *srp);
-void isis_zebra_uninstall_prefix_sid(const struct sr_prefix *srp);
+void isis_zebra_send_prefix_sid(int cmd, const struct sr_prefix *srp);
+void isis_zebra_send_adjacency_sid(int cmd, const struct sr_adjacency *sra);
 int isis_distribute_list_update(int routetype);
 void isis_zebra_redistribute_set(afi_t afi, int type);
 void isis_zebra_redistribute_unset(afi_t afi, int type);

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -254,6 +254,12 @@ extern struct thread_master *master;
 			zlog_debug(__VA_ARGS__);                               \
 	} while (0)
 
+#define sr_debug(...)                                                          \
+	do {                                                                   \
+		if (IS_DEBUG_ISIS(DEBUG_SR))                                   \
+			zlog_debug(__VA_ARGS__);                               \
+	} while (0)
+
 #define DEBUG_TE                         DEBUG_LSP_GEN
 
 #define IS_DEBUG_ISIS(x)                 (isis->debugs & x)


### PR DESCRIPTION
This is a series of 7 commits to prepare IS-IS Segment Routing code to be merge into master. All these modifications are proposed in order to improve readability of the code, and thus ease maintainability. Commits are as follow:

1. Rename SR DataBase
    - RB-TREE variable from `tree_sr_XXX` to `srdb_XXX`
    - Replace parse_flags by an enum and rename it srdb_state which reflects
       more the role of this flag: determined the state of SR-Node and SR-Prefix
       stored in the SRDB: VALIDATED, NEW, MODIFIED, UNCHANGED
2. Rename functions and variables
    - Functions with name in `isis_sr_XXX` are kept for external functions and `isis_sr` prefix is removed 
       for static ones.
    -  Rename `local_label` & `remote_label` variables by `input_label` & `output_label`
    -  Change parameter order (to follow other functions) in sr_node_srgb_update()
3. Add debug macro and debug messages
4. Update interaction with Zebra for LFIB
    - Centralize functions to install label for Prefix and Adjacency SID in isisd/isis_sr.c
    - Update call to Label re-Installation function
    - Call directly lsp_regenerate_schedule() from isis_nb_config.c when MSD is updated
5. Update comments (doxygen style) for all functions.
6. Update & add show command
7. Update user documentation

