### PR TITLE
tools: fix frr traceback on bgp neighbor bfd deletion

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -779,13 +779,14 @@ def ignore_delete_re_add_lines(lines_to_add, lines_to_del):
                     bfd_search_string =  bfd_nbr + r' bfd (\S+) (\S+) (\S+)'
 
                     for (ctx_keys, add_line) in lines_to_add:
-                        re_add_nbr_bfd_timers = re.search(bfd_search_string, add_line)
+                        if ctx_keys[0].startswith('router bgp'):
+                            re_add_nbr_bfd_timers = re.search(bfd_search_string, add_line)
 
-                        if re_add_nbr_bfd_timers:
-                            found_add_bfd_nbr = line_exist(lines_to_add, ctx_keys, bfd_nbr, False)
+                            if re_add_nbr_bfd_timers:
+                                found_add_bfd_nbr = line_exist(lines_to_add, ctx_keys, bfd_nbr, False)
 
-                            if found_add_bfd_nbr:
-                                lines_to_del_to_del.append((ctx_keys, line))
+                                if found_add_bfd_nbr:
+                                    lines_to_del_to_del.append((ctx_keys, line))
 
                 '''
                 We changed how we display the neighbor interface command. Older


### PR DESCRIPTION
Problem reported that with certain configs, when the user
deleted a "neighbor x.x.x.x bfd 4 100 100" statement from
frr.conf and then reloaded, a traceback was seen and the
deletion did not succeed.  Found that in some scenarios
it was possible to have something in lines_to_add that
was in a different context and when the re.search was
attempted, it found an empy line and was unhappy.  This
fix avoids trying to search in the wrong context.

Ticket: CM-29145
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>