### PR TITLE
lib: make hook.h cpp-compatible

### DIFF
--- a/lib/hook.h
+++ b/lib/hook.h
@@ -145,7 +145,7 @@ extern void _hook_register(struct hook *hook, struct hookent *stackent,
  */
 #define _hook_reg_svar(hook, funcptr, arg, has_arg, module, funcname, prio)    \
 	do {                                                                   \
-		static struct hookent stack_hookent = { .ent_on_heap = 0, };   \
+		static struct hookent stack_hookent = {};                      \
 		_hook_register(hook, &stack_hookent, funcptr, arg, has_arg,    \
 			       module, funcname, prio);                        \
 	} while (0)


### PR DESCRIPTION
Some CPP compilers don't support these designated initializers, since
we're just zero initializing don't need em

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>