### PR TITLE
ldpd: LDP does not always send traffic with correct DSCP value.

### DIFF
--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -619,6 +619,16 @@ nbr_establish_connection(struct nbr *nbr)
 #endif
 	}
 
+	if (nbr->af == AF_INET) {
+		if (sock_set_ipv4_tos(nbr->fd, IPTOS_PREC_INTERNETCONTROL) == -1)
+			log_warn("%s: lsr-id %s, sock_set_ipv4_tos error",
+				__func__, inet_ntoa(nbr->id));
+	} else if (nbr->af == AF_INET6) {
+		if (sock_set_ipv6_dscp(nbr->fd, IPTOS_PREC_INTERNETCONTROL) == -1)
+			log_warn("%s: lsr-id %s, sock_set_ipv6_dscp error",
+				__func__, inet_ntoa(nbr->id));
+	}
+
 	addr2sa(nbr->af, &nbr->laddr, 0, &local_su);
 	addr2sa(nbr->af, &nbr->raddr, LDP_PORT, &remote_su);
 	if (nbr->af == AF_INET6 && nbr->raddr_scope)


### PR DESCRIPTION
Adding code so that the LDP neighbor that does not initiate the
TCP connection also sets the DSCP (via setsocketopt).

Signed-off-by: Karen Schoener <karen@voltanet.io>