### PR TITLE
bgpd: [7.1] Check to ensure community attributes exist before freeing them

### DIFF
--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -40,6 +40,9 @@ static struct community *community_new(void)
 /* Free communities value.  */
 void community_free(struct community **com)
 {
+	if (!(*com))
+		return;
+
 	XFREE(MTYPE_COMMUNITY_VAL, (*com)->val);
 	XFREE(MTYPE_COMMUNITY_STR, (*com)->str);
 

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -59,6 +59,9 @@ void ecommunity_strfree(char **s)
 /* Allocate ecommunities.  */
 void ecommunity_free(struct ecommunity **ecom)
 {
+	if (!(*ecom))
+		return;
+
 	XFREE(MTYPE_ECOMMUNITY_VAL, (*ecom)->val);
 	XFREE(MTYPE_ECOMMUNITY_STR, (*ecom)->str);
 	XFREE(MTYPE_ECOMMUNITY, *ecom);

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -44,6 +44,9 @@ static struct lcommunity *lcommunity_new(void)
 /* Allocate lcommunities.  */
 void lcommunity_free(struct lcommunity **lcom)
 {
+	if (!(*lcom))
+		return;
+
 	XFREE(MTYPE_LCOMMUNITY_VAL, (*lcom)->val);
 	XFREE(MTYPE_LCOMMUNITY_STR, (*lcom)->str);
 	XFREE(MTYPE_LCOMMUNITY, *lcom);


### PR DESCRIPTION
Community attributes might have been removed by an inbound route map, so we
should check to ensure they still exist before trying to free them.
This fixes a segfault described in issue #6345.

Signed-off-by: Josh Cox <josh.cox@pureport.com>