### PR TITLE
[7.2] fix random debian & SA warnings

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -61,7 +61,7 @@ OpenSSL now is not compatible with the GNU GENERAL PUBLIC LICENSE (GPL)
 licence that FRR is distributed under. For more explanation read:
   http://www.gnome.org/~markmc/openssl-and-the-gpl.html
   http://www.gnu.org/licenses/gpl-faq.html#GPLIncompatibleLibs
-Updating the licence to explecitly allow linking against OpenSSL
+Updating the licence to explicitly allow linking against OpenSSL
 would requite the affirmation of all people that ever contributed
 a significant part to Zebra / Quagga or FRR and thus are the collective
 "copyright holder". That's too much work. Using a shrinked down 

--- a/nhrpd/list.h
+++ b/nhrpd/list.h
@@ -199,7 +199,8 @@ static inline int list_empty(const struct list_head *n)
 
 #define list_for_each_entry_safe(pos, n, head, member)                         \
 	for (pos = list_entry((head)->next, typeof(*pos), member),             \
-	    n = list_entry(pos->member.next, typeof(*pos), member);            \
+	     n = (&pos->member != (head) ?                                     \
+		  list_entry(pos->member.next, typeof(*pos), member) : NULL);  \
 	     &pos->member != (head);                                           \
 	     pos = n, n = list_entry(n->member.next, typeof(*n), member))
 

--- a/nhrpd/list.h
+++ b/nhrpd/list.h
@@ -198,10 +198,12 @@ static inline int list_empty(const struct list_head *n)
 	     pos = list_entry(pos->member.next, typeof(*pos), member))
 
 #define list_for_each_entry_safe(pos, n, head, member)                         \
-	for (pos = list_entry((head)->next, typeof(*pos), member),             \
-	     n = (&pos->member != (head) ?                                     \
+	for (pos = ((head)->next != head ?                                     \
+		    list_entry((head)->next, typeof(*pos), member) :	       \
+		    NULL),			                               \
+	     n = (pos ?                                                        \
 		  list_entry(pos->member.next, typeof(*pos), member) : NULL);  \
-	     &pos->member != (head);                                           \
+	     pos && (&pos->member != (head));                                  \
 	     pos = n, n = list_entry(n->member.next, typeof(*n), member))
 
 #endif

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -76,8 +76,10 @@ static inline void notifier_del(struct notifier_block *n)
 static inline void notifier_call(struct notifier_list *l, int cmd)
 {
 	struct notifier_block *n, *nn;
-	list_for_each_entry_safe(n, nn, &l->notifier_head, notifier_entry)
-		n->action(n, cmd);
+	list_for_each_entry_safe(n, nn, &l->notifier_head, notifier_entry) {
+		if (n)
+			n->action(n, cmd);
+	}
 }
 
 static inline int notifier_active(struct notifier_list *l)

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -77,8 +77,7 @@ static inline void notifier_call(struct notifier_list *l, int cmd)
 {
 	struct notifier_block *n, *nn;
 	list_for_each_entry_safe(n, nn, &l->notifier_head, notifier_entry) {
-		if (n)
-			n->action(n, cmd);
+		n->action(n, cmd);
 	}
 }
 


### PR DESCRIPTION
Just 3 patches backported from 7.3 to fix a debian spelling warning & a SA warning.