### PR TITLE
zebra: Add code to install v6 blackhole routes on *bsd

### DIFF
--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -180,6 +180,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 			switch (p->family) {
 			case AF_INET: {
 				struct in_addr loopback;
+
 				loopback.s_addr = htonl(INADDR_LOOPBACK);
 				sin_gate.sin.sin_addr = loopback;
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
@@ -187,11 +188,21 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 					sizeof(struct sockaddr_in);
 #endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 				gate = true;
-			}
-				break;
-			case AF_INET6:
-				zlog_warn("v6 blackhole routes have not been programmed yet");
-				break;
+			} break;
+			case AF_INET6: {
+				struct in6_addr loopback;
+
+				inet_pton(AF_INET6, "::1", &loopback);
+
+				sin_gate.sin6.sin6_addr = loopback;
+				sin_gate.sin6.sin6_family = AF_INET6;
+
+#ifdef HAVE_STRUCTSOCKADDR_SA_LEN
+				sin_gate.sin6.sin6_len =
+					sizeof(struct sockaddr_in6);
+#endif /* HAVE_STRUCTSOCKADDR_SA_LEN */
+				gate = true;
+			} break;
 			}
 		}
 


### PR DESCRIPTION
This code was just missing.  Take the few minutes and
get it done.

!
ip route 4.5.6.7/32 Null0
ipv6 route 4::5/128 Null0
!
$ netstat -rn
Routing tables

Internet:
Destination        Gateway            Flags     Netif Expire
default            192.168.122.1      UGS      vtnet0
4.5.6.7/32         127.0.0.1          UG1B        lo0
127.0.0.1          link#2             UH          lo0
192.168.122.0/24   link#1             U        vtnet0
192.168.122.40     link#1             UHS         lo0

Internet6:
Destination                       Gateway                       Flags     Netif Expire
::/96                             ::1                           UGRS        lo0
::1                               link#2                        UH          lo0
::ffff:0.0.0.0/96                 ::1                           UGRS        lo0
4::5/128                          ::1                           UG1B        lo0
fe80::/10                         ::1                           UGRS        lo0
fe80::%vtnet0/64                  link#1                        U        vtnet0
fe80::5054:ff:fe5a:e705%vtnet0    link#1                        UHS         lo0
fe80::%lo0/64                     link#2                        U           lo0
fe80::1%lo0                       link#2                        UHS         lo0
ff02::/16                         ::1                           UGRS        lo0
$

$ uname -a
FreeBSD donna 12.1-RELEASE FreeBSD 12.1-RELEASE r354233 GENERIC  amd64
$

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>