### PR TITLE
ldpd and Zebra:  Expand existing debug commands.

### DIFF
--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -751,7 +751,6 @@ lde_update_label(struct fec_node *fn)
 				return (MPLS_LABEL_IMPLICIT_NULL);
 			return MPLS_LABEL_IPV6_EXPLICIT_NULL;
 		default:
-			fatalx("lde_update_label: unexpected fec type");
 			break;
 		}
 	}
@@ -1421,8 +1420,10 @@ lde_nbr_del(struct lde_nbr *ln)
 				if (f->u.pwid.lsr_id.s_addr != ln->id.s_addr)
 					continue;
 				pw = (struct l2vpn_pw *) fn->data;
-				if (pw)
+				if (pw) {
+					pw->reason = F_PW_NO_REMOTE_LABEL;
 					l2vpn_pw_reset(pw);
+				}
 				break;
 			default:
 				break;

--- a/ldpd/ldp_vty_exec.c
+++ b/ldpd/ldp_vty_exec.c
@@ -1256,6 +1256,8 @@ show_l2vpn_binding_msg(struct vty *vty, struct imsg *imsg,
 			    "GroupID: %u\n", "", pw->local_cword,
 			    pw_type_name(pw->type),pw->local_gid);
 			vty_out (vty, "%-8sMTU: %u\n", "",pw->local_ifmtu);
+			vty_out (vty, "%-8sLast failure: %s\n", "",
+			    pw_error_code(pw->reason));
 		} else
 			vty_out (vty,"    Local Label: unassigned\n");
 
@@ -1309,6 +1311,8 @@ show_l2vpn_binding_msg_json(struct imsg *imsg, struct show_params *params,
 			    pw->local_gid);
 			json_object_int_add(json_pw, "localIfMtu",
 			    pw->local_ifmtu);
+			json_object_string_add(json_pw, "lastFailureReason",
+			    pw_error_code(pw->reason));
 		} else
 			json_object_string_add(json_pw, "localLabel",
 			    "unassigned");

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -422,6 +422,7 @@ struct l2vpn_pw {
 	uint32_t		 local_status;
 	uint32_t		 remote_status;
 	uint8_t			 flags;
+	uint8_t			 reason;
 	QOBJ_FIELDS
 };
 RB_HEAD(l2vpn_pw_head, l2vpn_pw);
@@ -432,6 +433,12 @@ DECLARE_QOBJ_TYPE(l2vpn_pw)
 #define F_PW_CWORD_CONF		0x04	/* control word configured */
 #define F_PW_CWORD		0x08	/* control word negotiated */
 #define F_PW_STATIC_NBR_ADDR	0x10	/* static neighbor address configured */
+
+#define F_PW_NO_ERR             0x00	/* no error reported */
+#define F_PW_LOCAL_NOT_FWD      0x01	/* locally can't forward over PW */
+#define F_PW_REMOTE_NOT_FWD     0x02	/* remote end of PW reported fwd error*/
+#define F_PW_NO_REMOTE_LABEL    0x03	/* have not recvd label from peer */
+#define F_PW_MTU_MISMATCH       0x04	/* mtu mismatch between peers */
 
 struct l2vpn {
 	RB_ENTRY(l2vpn)		 entry;
@@ -662,6 +669,7 @@ struct ctl_pw {
 	uint16_t		 remote_ifmtu;
 	uint8_t			 remote_cword;
 	uint32_t		 status;
+	uint8_t			 reason;
 };
 
 extern struct ldpd_conf		*ldpd_conf, *vty_conf;
@@ -808,6 +816,7 @@ const char	*if_type_name(enum iface_type);
 const char	*msg_name(uint16_t);
 const char	*status_code_name(uint32_t);
 const char	*pw_type_name(uint16_t);
+const char	*pw_error_code(uint8_t);
 
 /* quagga */
 extern struct thread_master	*master;

--- a/ldpd/logmsg.c
+++ b/ldpd/logmsg.c
@@ -485,3 +485,25 @@ pw_type_name(uint16_t pw_type)
 		return (buf);
 	}
 }
+
+const char *
+pw_error_code(uint8_t status)
+{
+	static char buf[16];
+
+	switch (status) {
+	case F_PW_NO_ERR:
+		return ("No Error");
+	case F_PW_LOCAL_NOT_FWD:
+		return ("local not forwarding");
+	case F_PW_REMOTE_NOT_FWD:
+		return ("remote not forwarding");
+	case F_PW_NO_REMOTE_LABEL:
+		return ("no remote label");
+	case F_PW_MTU_MISMATCH:
+		return ("mtu mismatch between peers");
+	default:
+		snprintf(buf, sizeof(buf), "[%0x]", status);
+		return (buf);
+	}
+}


### PR DESCRIPTION
L2VPN PW are very hard to determine why they do not come up.  The following
fixes expand the existing show commands in ldp and zebra to display a
reason why the PW is in the DOWN state and also display the labeled nexthop
route selected to reach the PW peer.  By adding this information it will
provide the user some guidance on how to debug the PW issue.  Also fixed an
assert if labels were changed for a PW that is between directly connected
peers.

Signed-off-by: Lynne Morrison <lynne@voltanet.io>