### PR TITLE
YANG operational-data fragmentation

### DIFF
--- a/bfdd/bfdd_nb_state.c
+++ b/bfdd/bfdd_nb_state.c
@@ -62,6 +62,8 @@ bfdd_bfd_sessions_single_hop_lookup_entry(struct nb_cb_lookup_entry_args *args)
 	struct sockaddr_any psa, lsa;
 	struct bfd_key bk;
 
+	/* TODO: take args->exact_match into account. */
+
 	strtosa(dest_addr, &psa);
 	memset(&lsa, 0, sizeof(lsa));
 	gen_bfd_key(&bk, &psa, &lsa, false, ifname, vrf);
@@ -367,6 +369,8 @@ bfdd_bfd_sessions_multi_hop_lookup_entry(struct nb_cb_lookup_entry_args *args)
 	const char *vrf = args->keys->key[3];
 	struct sockaddr_any psa, lsa;
 	struct bfd_key bk;
+
+	/* TODO: take args->exact_match into account. */
 
 	strtosa(dest_addr, &psa);
 	strtosa(source_addr, &lsa);

--- a/grpc/frr-northbound.proto
+++ b/grpc/frr-northbound.proto
@@ -129,8 +129,8 @@ message GetRequest {
   // Include implicit default nodes.
   bool with_defaults = 3;
 
-  // Paths requested by the client.
-  repeated string path = 4;
+  // YANG data path.
+  string path = 4;
 }
 
 message GetResponse {

--- a/grpc/frr-northbound.proto
+++ b/grpc/frr-northbound.proto
@@ -131,6 +131,16 @@ message GetRequest {
 
   // YANG data path.
   string path = 4;
+
+  // Base iteration offset (optional).
+  //
+  // This parameter is valid only for the STATE request type.
+  string offset = 5;
+
+  // Maximum number of elements to fetch (optional).
+  //
+  // This parameter is valid only for the STATE request type.
+  uint32 chunk_size = 6;
 }
 
 message GetResponse {
@@ -143,6 +153,11 @@ message GetResponse {
 
   // The requested data.
   DataTree data = 2;
+
+  // When the requested data can't be delivered in a single response,
+  // an offset is returned indicating where the next Get() call should
+  // start to retrieve the remaining data.
+  string offset = 3;
 }
 
 //

--- a/lib/if.c
+++ b/lib/if.c
@@ -1644,8 +1644,16 @@ lib_interface_lookup_entry(struct nb_cb_lookup_entry_args *args)
 	const char *ifname = args->keys->key[0];
 	const char *vrfname = args->keys->key[1];
 	struct vrf *vrf = vrf_lookup_by_name(vrfname);
+	struct interface interface;
 
-	return vrf ? if_lookup_by_name(ifname, vrf->vrf_id) : NULL;
+	if (!vrf)
+		return NULL;
+
+	strlcpy(interface.name, ifname, sizeof(interface.name));
+	return args->exact_match
+		       ? RB_FIND(if_name_head, &vrf->ifaces_by_name, &interface)
+		       : RB_NFIND(if_name_head, &vrf->ifaces_by_name,
+				  &interface);
 }
 
 /*

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -100,8 +100,8 @@ static int _nexthop_source_cmp(const struct nexthop *nh1,
 	return nexthop_g_addr_cmp(nh1->type, &nh1->src, &nh2->src);
 }
 
-static int _nexthop_cmp_no_labels(const struct nexthop *next1,
-				  const struct nexthop *next2)
+int nexthop_cmp_no_labels(const struct nexthop *next1,
+			  const struct nexthop *next2)
 {
 	int ret = 0;
 
@@ -193,7 +193,7 @@ int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
 {
 	int ret = 0;
 
-	ret = _nexthop_cmp_no_labels(next1, next2);
+	ret = nexthop_cmp_no_labels(next1, next2);
 	if (ret != 0)
 		return ret;
 
@@ -335,7 +335,7 @@ bool nexthop_same_no_labels(const struct nexthop *nh1,
 	if (nh1 == nh2)
 		return true;
 
-	if (_nexthop_cmp_no_labels(nh1, nh2) != 0)
+	if (nexthop_cmp_no_labels(nh1, nh2) != 0)
 		return false;
 
 	return true;

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -209,6 +209,8 @@ extern bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2);
 extern bool nexthop_same_no_labels(const struct nexthop *nh1,
 				   const struct nexthop *nh2);
 extern int nexthop_cmp(const struct nexthop *nh1, const struct nexthop *nh2);
+extern int nexthop_cmp_no_labels(const struct nexthop *next1,
+				 const struct nexthop *next2);
 extern int nexthop_g_addr_cmp(enum nexthop_types_t type,
 			      const union g_addr *addr1,
 			      const union g_addr *addr2);

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -1485,7 +1485,7 @@ nb_oper_data_check_stop_condition(struct nb_oper_data_iter_input *input,
 		/* Save where we stopped in the output parameters. */
 		strlcpy(output->offset_path, xpath,
 			sizeof(output->offset_path));
-		return NB_ITER_STOP;
+		return NB_ITER_SUSPEND;
 	}
 
 	return NB_ITER_CONTINUE;
@@ -2044,9 +2044,9 @@ exit:
 				"finished operational-data iteration (fetched %u elements)",
 				output->num_elements);
 			break;
-		case NB_ITER_STOP:
+		case NB_ITER_SUSPEND:
 			zlog_debug(
-				"stopping operational-data iteration at %s (fetched %u elements)",
+				"suspending operational-data iteration at %s (fetched %u elements)",
 				output->offset_path, output->num_elements);
 			break;
 		case NB_ITER_ABORT:

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -668,7 +668,8 @@ struct nb_transaction {
 /* Callback function used by nb_oper_data_iterate(). */
 typedef int (*nb_oper_data_cb)(const struct lys_node *snode,
 			       struct yang_translator *translator,
-			       struct yang_data *data, void *arg);
+			       struct yang_data *data, void *arg, char *errmsg,
+			       size_t errmsg_len);
 
 /* Northbound operational-data iteration input parameters. */
 struct nb_oper_data_iter_input {
@@ -714,6 +715,9 @@ struct nb_oper_data_iter_output {
 	/* Offset where the iteration stopped. */
 	char offset_path[XPATH_MAXLEN];
 	char offset_node[64];
+
+	/* Buffer to store human-readable error message in case of error. */
+	char errmsg[4096];
 };
 
 /* Hooks. */

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -656,8 +656,30 @@ typedef int (*nb_oper_data_cb)(const struct lys_node *snode,
 			       struct yang_translator *translator,
 			       struct yang_data *data, void *arg);
 
+/* Northbound operational-data iteration input parameters. */
+struct nb_oper_data_iter_input {
+	/* Data path of the YANG data we want to iterate over. */
+	const char *xpath;
+
+	/* Function to call for each retrieved state node. */
+	nb_oper_data_cb cb;
+
+	/*
+	 * Arbitrary argument passed as the fourth parameter in each call to
+	 * 'cb'.
+	 */
+	void *cb_arg;
+
+	/* YANG module translator (might be NULL). */
+	struct yang_translator *translator;
+
+	/*
+	 * F_NB_OPER_DATA_ITER_ flags to control how the iteration is performed.
+	 */
+	uint32_t flags;
+};
 /* Iterate over direct child nodes only. */
-#define NB_OPER_DATA_ITER_NORECURSE 0x0001
+#define F_NB_OPER_DATA_ITER_NORECURSE 0x0001
 
 /* Hooks. */
 DECLARE_HOOK(nb_notification_send, (const char *xpath, struct list *arguments),
@@ -1039,27 +1061,13 @@ extern int nb_running_lock_check(enum nb_client client, const void *user);
 /*
  * Iterate over operational data.
  *
- * xpath
- *    Data path of the YANG data we want to iterate over.
- *
- * translator
- *    YANG module translator (might be NULL).
- *
- * flags
- *    NB_OPER_DATA_ITER_ flags to control how the iteration is performed.
- *
- * cb
- *    Function to call with each data node.
- *
- * arg
- *    Arbitrary argument passed as the fourth parameter in each call to 'cb'.
+ * input
+ *    Iteration input parameters.
  *
  * Returns:
  *    NB_OK on success, NB_ERR otherwise.
  */
-extern int nb_oper_data_iterate(const char *xpath,
-				struct yang_translator *translator,
-				uint32_t flags, nb_oper_data_cb cb, void *arg);
+extern int nb_oper_data_iterate(struct nb_oper_data_iter_input *input);
 
 /*
  * Validate if the northbound operation is valid for the given node.

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -662,7 +662,7 @@ struct nb_transaction {
 
 /* Return values of the 'nb_oper_data_cb' callback. */
 #define NB_ITER_CONTINUE 0
-#define NB_ITER_STOP 1
+#define NB_ITER_SUSPEND 1
 #define NB_ITER_FINISH 2
 #define NB_ITER_ABORT -1
 
@@ -1108,9 +1108,10 @@ extern int nb_running_lock_check(enum nb_client client, const void *user);
  *
  * Returns:
  *    - NB_ITER_FINISH on success (all requested elements were iterated over).
- *    - NB_ITER_STOP on success (iteration stopped due to the provided maximum
- *      number of elements).
- *    - NB_ITER_ABORT when an error occurred.
+ *    - NB_ITER_SUSPEND on success (iteration had to be suspended due to the
+ *      provided maximum number of elements).
+ *    - NB_ITER_ABORT when an error occurred. In this case, a human-readable
+ *      error message is available on the errmsg buffer of the output parameter.
  */
 extern int nb_oper_data_iterate(struct nb_oper_data_iter_input *input,
 				struct nb_oper_data_iter_output *output);

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -663,6 +663,7 @@ struct nb_transaction {
 /* Return values of the 'nb_oper_data_cb' callback. */
 #define NB_ITER_CONTINUE 0
 #define NB_ITER_STOP 1
+#define NB_ITER_FINISH 2
 #define NB_ITER_ABORT -1
 
 /* Callback function used by nb_oper_data_iterate(). */
@@ -1106,7 +1107,10 @@ extern int nb_running_lock_check(enum nb_client client, const void *user);
  *    Iteration output parameters.
  *
  * Returns:
- *    NB_OK on success, NB_ERR otherwise.
+ *    - NB_ITER_FINISH on success (all requested elements were iterated over).
+ *    - NB_ITER_STOP on success (iteration stopped due to the provided maximum
+ *      number of elements).
+ *    - NB_ITER_ABORT when an error occurred.
  */
 extern int nb_oper_data_iterate(struct nb_oper_data_iter_input *input,
 				struct nb_oper_data_iter_output *output);

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -695,7 +695,6 @@ struct nb_oper_data_iter_input {
 	 * Base iteration offset (used when F_NB_OPER_DATA_ITER_OFFSET is set).
 	 */
 	char offset_path[XPATH_MAXLEN];
-	char offset_node[64];
 
 	/*
 	 * F_NB_OPER_DATA_ITER_ flags to control how the iteration is performed.
@@ -714,7 +713,6 @@ struct nb_oper_data_iter_output {
 
 	/* Offset where the iteration stopped. */
 	char offset_path[XPATH_MAXLEN];
-	char offset_node[64];
 
 	/* Buffer to store human-readable error message in case of error. */
 	char errmsg[4096];

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -1491,7 +1491,7 @@ DEFPY (show_yang_operational_data,
 
 	/* Display the data. */
 	if (lyd_print_mem(&strp, dnode, format,
-			  LYP_FORMAT | LYP_WITHSIBLINGS | LYP_WD_ALL)
+			  LYP_FORMAT | LYP_WITHSIBLINGS | LYP_WD_EXPLICIT)
 		    != 0
 	    || !strp) {
 		vty_out(vty, "%% Failed to display operational data.\n");

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -1471,7 +1471,7 @@ DEFPY (show_yang_operational_data,
 
 	for (;;) {
 		ret = nb_oper_data_iterate(&iter_input, &iter_output);
-		if (!repeat || ret != NB_ITER_STOP)
+		if (!repeat || ret != NB_ITER_SUSPEND)
 			break;
 
 		SET_FLAG(iter_input.flags, F_NB_OPER_DATA_ITER_OFFSET);

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -1477,8 +1477,6 @@ DEFPY (show_yang_operational_data,
 		SET_FLAG(iter_input.flags, F_NB_OPER_DATA_ITER_OFFSET);
 		strlcpy(iter_input.offset_path, iter_output.offset_path,
 			sizeof(iter_input.offset_path));
-		strlcpy(iter_input.offset_node, iter_output.offset_node,
-			sizeof(iter_input.offset_node));
 	}
 	if (ret == NB_ITER_ABORT) {
 		vty_out(vty, "%% Failed to fetch operational data: %s\n\n",

--- a/lib/northbound_confd.c
+++ b/lib/northbound_confd.c
@@ -143,7 +143,7 @@ static int frr_confd_hkeypath_get_list_entry(const confd_hkeypath_t *kp,
 		/* Obtain list entry. */
 		if (!CHECK_FLAG(nb_node_list->flags, F_NB_NODE_KEYLESS_LIST)) {
 			*list_entry = nb_callback_lookup_entry(
-				nb_node, *list_entry, &keys);
+				nb_node, *list_entry, &keys, true);
 			if (*list_entry == NULL)
 				return -1;
 		} else {

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -1189,13 +1189,14 @@ class NorthboundImpl
 	static struct lyd_node *get_dnode_state(const std::string &path)
 	{
 		struct nb_oper_data_iter_input iter_input = {};
+		struct nb_oper_data_iter_output iter_output = {};
 		struct lyd_node *dnode;
 
 		dnode = yang_dnode_new(ly_native_ctx, false);
 		iter_input.xpath = path.c_str();
 		iter_input.cb = get_oper_data_cb;
 		iter_input.cb_arg = dnode;
-		if (nb_oper_data_iterate(&iter_input) != NB_OK) {
+		if (nb_oper_data_iterate(&iter_input, &iter_output) != NB_OK) {
 			yang_dnode_free(dnode);
 			return NULL;
 		}

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -1215,7 +1215,7 @@ class NorthboundImpl
 			yang_dnode_free(dnode);
 			return NULL;
 		}
-		if (ret == NB_ITER_STOP)
+		if (ret == NB_ITER_SUSPEND)
 			*output_offset = iter_output.offset_path;
 
 		return dnode;

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -1188,12 +1188,14 @@ class NorthboundImpl
 
 	static struct lyd_node *get_dnode_state(const std::string &path)
 	{
+		struct nb_oper_data_iter_input iter_input = {};
 		struct lyd_node *dnode;
 
 		dnode = yang_dnode_new(ly_native_ctx, false);
-		if (nb_oper_data_iterate(path.c_str(), NULL, 0,
-					 get_oper_data_cb, dnode)
-		    != NB_OK) {
+		iter_input.xpath = path.c_str();
+		iter_input.cb = get_oper_data_cb;
+		iter_input.cb_arg = dnode;
+		if (nb_oper_data_iterate(&iter_input) != NB_OK) {
 			yang_dnode_free(dnode);
 			return NULL;
 		}

--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -402,12 +402,15 @@ static int frr_sr_state_cb(sr_session_ctx_t *session, const char *module_name,
 			   uint32_t request_id, struct lyd_node **parent,
 			   void *private_ctx)
 {
+	struct nb_oper_data_iter_input iter_input = {};
 	struct lyd_node *dnode;
 
 	dnode = *parent;
-	if (nb_oper_data_iterate(request_xpath, NULL, 0,
-				 frr_sr_state_data_iter_cb, dnode)
-	    != NB_OK) {
+	iter_input.xpath = xpath;
+	iter_input.cb = frr_sr_state_data_iter_cb;
+	iter_input.cb_arg = dnode;
+	iter_input.flags = F_NB_OPER_DATA_ITER_NORECURSE;
+	if (nb_oper_data_iterate(&iter_input) != NB_OK) {
 		flog_warn(EC_LIB_NB_OPERATIONAL_DATA,
 			  "%s: failed to obtain operational data [xpath %s]",
 			  __func__, xpath);

--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -378,7 +378,8 @@ static int frr_sr_config_change_cb(sr_session_ctx_t *session,
 
 static int frr_sr_state_data_iter_cb(const struct lys_node *snode,
 				     struct yang_translator *translator,
-				     struct yang_data *data, void *arg)
+				     struct yang_data *data, void *arg,
+				     char *errmsg, size_t errmsg_len)
 {
 	struct lyd_node *dnode = arg;
 
@@ -413,8 +414,8 @@ static int frr_sr_state_cb(sr_session_ctx_t *session, const char *module_name,
 	iter_input.flags = F_NB_OPER_DATA_ITER_NORECURSE;
 	if (nb_oper_data_iterate(&iter_input, &iter_output) == NB_ITER_ABORT) {
 		flog_warn(EC_LIB_NB_OPERATIONAL_DATA,
-			  "%s: failed to obtain operational data [xpath %s]",
-			  __func__, xpath);
+			  "%s: failed to fetch operational data: %s", __func__,
+			  iter_output.errmsg);
 		return SR_ERR_INTERNAL;
 	}
 

--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -393,7 +393,7 @@ static int frr_sr_state_data_iter_cb(const struct lys_node *snode,
 	}
 
 	yang_data_free(data);
-	return NB_OK;
+	return NB_ITER_CONTINUE;
 }
 
 /* Callback for state retrieval. */
@@ -403,6 +403,7 @@ static int frr_sr_state_cb(sr_session_ctx_t *session, const char *module_name,
 			   void *private_ctx)
 {
 	struct nb_oper_data_iter_input iter_input = {};
+	struct nb_oper_data_iter_output iter_output = {};
 	struct lyd_node *dnode;
 
 	dnode = *parent;
@@ -410,7 +411,7 @@ static int frr_sr_state_cb(sr_session_ctx_t *session, const char *module_name,
 	iter_input.cb = frr_sr_state_data_iter_cb;
 	iter_input.cb_arg = dnode;
 	iter_input.flags = F_NB_OPER_DATA_ITER_NORECURSE;
-	if (nb_oper_data_iterate(&iter_input) != NB_OK) {
+	if (nb_oper_data_iterate(&iter_input, &iter_output) == NB_ITER_ABORT) {
 		flog_warn(EC_LIB_NB_OPERATIONAL_DATA,
 			  "%s: failed to obtain operational data [xpath %s]",
 			  __func__, xpath);

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -1122,10 +1122,11 @@ static int lib_vrf_get_keys(struct nb_cb_get_keys_args *args)
 static const void *lib_vrf_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
 	const char *vrfname = args->keys->key[0];
+	struct vrf vrf;
 
-	struct vrf *vrf = vrf_lookup_by_name(vrfname);
-
-	return vrf;
+	strlcpy(vrf.name, vrfname, sizeof(vrf.name));
+	return args->exact_match ? RB_FIND(vrf_name_head, &vrfs_by_name, &vrf)
+				 : RB_NFIND(vrf_name_head, &vrfs_by_name, &vrf);
 }
 
 /*

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -241,6 +241,10 @@ typedef unsigned char uint8_t;
 #define static_cast(l, r) (r)
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef HAVE_STRLCAT
 size_t strlcat(char *__restrict dest,
 	       const char *__restrict src, size_t destsize);
@@ -248,6 +252,10 @@ size_t strlcat(char *__restrict dest,
 #ifndef HAVE_STRLCPY
 size_t strlcpy(char *__restrict dest,
 	       const char *__restrict src, size_t destsize);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /*

--- a/ripngd/ripng_nb_config.c
+++ b/ripngd/ripng_nb_config.c
@@ -99,36 +99,6 @@ int ripngd_instance_destroy(struct nb_cb_destroy_args *args)
 	return NB_OK;
 }
 
-const void *ripngd_instance_get_next(struct nb_cb_get_next_args *args)
-{
-	struct ripng *ripng = (struct ripng *)args->list_entry;
-
-	if (args->list_entry == NULL)
-		ripng = RB_MIN(ripng_instance_head, &ripng_instances);
-	else
-		ripng = RB_NEXT(ripng_instance_head, ripng);
-
-	return ripng;
-}
-
-int ripngd_instance_get_keys(struct nb_cb_get_keys_args *args)
-{
-	const struct ripng *ripng = args->list_entry;
-
-	args->keys->num = 1;
-	strlcpy(args->keys->key[0], ripng->vrf_name,
-		sizeof(args->keys->key[0]));
-
-	return NB_OK;
-}
-
-const void *ripngd_instance_lookup_entry(struct nb_cb_lookup_entry_args *args)
-{
-	const char *vrf_name = args->keys->key[0];
-
-	return ripng_lookup_by_vrf_name(vrf_name);
-}
-
 /*
  * XPath: /frr-ripngd:ripngd/instance/allow-ecmp
  */

--- a/ripngd/ripng_nb_state.c
+++ b/ripngd/ripng_nb_state.c
@@ -64,8 +64,13 @@ int ripngd_instance_get_keys(struct nb_cb_get_keys_args *args)
 const void *ripngd_instance_lookup_entry(struct nb_cb_lookup_entry_args *args)
 {
 	const char *vrf_name = args->keys->key[0];
+	struct ripng ripng;
 
-	return ripng_lookup_by_vrf_name(vrf_name);
+	ripng.vrf_name = (char *)vrf_name;
+	return args->exact_match
+		       ? RB_FIND(ripng_instance_head, &ripng_instances, &ripng)
+		       : RB_NFIND(ripng_instance_head, &ripng_instances,
+				  &ripng);
 }
 
 /*
@@ -109,8 +114,13 @@ const void *ripngd_instance_state_neighbors_neighbor_lookup_entry(
 	yang_str2ipv6(args->keys->key[0], &address);
 
 	for (ALL_LIST_ELEMENTS_RO(ripng->peer_list, node, peer)) {
-		if (IPV6_ADDR_SAME(&peer->addr, &address))
-			return node;
+		if (args->exact_match) {
+			if (IPV6_ADDR_SAME(&peer->addr, &address))
+				return node;
+		} else {
+			if (IPV6_ADDR_CMP(&peer->addr, &address) >= 0)
+				return node;
+		}
 	}
 
 	return NULL;
@@ -206,6 +216,9 @@ const void *ripngd_instance_state_routes_route_lookup_entry(
 	yang_str2ipv6p(args->keys->key[0], &prefix);
 
 	rn = agg_node_lookup(ripng->table, &prefix);
+	if ((!rn || !rn->info) && !args->exact_match)
+		rn = agg_node_from_rnode(route_table_get_next(
+			ripng->table->route_table, &prefix));
 	if (!rn || !rn->info)
 		return NULL;
 

--- a/ripngd/ripng_nb_state.c
+++ b/ripngd/ripng_nb_state.c
@@ -36,6 +36,39 @@
 #include "ripngd/ripng_route.h"
 
 /*
+ * XPath: /frr-ripngd:ripngd/instance
+ */
+const void *ripngd_instance_get_next(struct nb_cb_get_next_args *args)
+{
+	struct ripng *ripng = (struct ripng *)args->list_entry;
+
+	if (args->list_entry == NULL)
+		ripng = RB_MIN(ripng_instance_head, &ripng_instances);
+	else
+		ripng = RB_NEXT(ripng_instance_head, ripng);
+
+	return ripng;
+}
+
+int ripngd_instance_get_keys(struct nb_cb_get_keys_args *args)
+{
+	const struct ripng *ripng = args->list_entry;
+
+	args->keys->num = 1;
+	strlcpy(args->keys->key[0], ripng->vrf_name,
+		sizeof(args->keys->key[0]));
+
+	return NB_OK;
+}
+
+const void *ripngd_instance_lookup_entry(struct nb_cb_lookup_entry_args *args)
+{
+	const char *vrf_name = args->keys->key[0];
+
+	return ripng_lookup_by_vrf_name(vrf_name);
+}
+
+/*
  * XPath: /frr-ripngd:ripngd/instance/state/neighbors/neighbor
  */
 const void *ripngd_instance_state_neighbors_neighbor_get_next(

--- a/tests/lib/northbound/test_oper_data.c
+++ b/tests/lib/northbound/test_oper_data.c
@@ -83,8 +83,13 @@ frr_test_module_vrfs_vrf_lookup_entry(struct nb_cb_lookup_entry_args *args)
 	vrfname = args->keys->key[0];
 
 	for (ALL_LIST_ELEMENTS_RO(vrfs, node, vrf)) {
-		if (strmatch(vrf->name, vrfname))
-			return node;
+		if (args->exact_match) {
+			if (strmatch(vrf->name, vrfname))
+				return node;
+		} else {
+			if (strcmp(vrf->name, vrfname) >= 0)
+				return node;
+		}
 	}
 
 	return NULL;

--- a/tests/lib/northbound/test_oper_data.in
+++ b/tests/lib/northbound/test_oper_data.in
@@ -1,1 +1,2 @@
 show yang operational-data /frr-test-module:frr-test-module
+show yang operational-data /frr-test-module:frr-test-module max-elements 3 repeat

--- a/tests/lib/northbound/test_oper_data.refout
+++ b/tests/lib/northbound/test_oper_data.refout
@@ -115,5 +115,122 @@ test# show yang operational-data /frr-test-module:frr-test-module
     }
   }
 }
+test# show yang operational-data /frr-test-module:frr-test-module max-elements 3 repeat
+{
+  "frr-test-module:frr-test-module": {
+    "vrfs": {
+      "vrf": [
+        {
+          "name": "vrf0",
+          "interfaces": {
+            "interface": [
+              "eth0",
+              "eth1",
+              "eth2",
+              "eth3"
+            ]
+          },
+          "routes": {
+            "route": [
+              {
+                "prefix": "10.0.0.0/32",
+                "next-hop": "172.16.0.0",
+                "interface": "eth0",
+                "metric": 0,
+                "active": [null]
+              },
+              {
+                "prefix": "10.0.0.1/32",
+                "next-hop": "172.16.0.1",
+                "interface": "eth1",
+                "metric": 1
+              },
+              {
+                "prefix": "10.0.0.2/32",
+                "next-hop": "172.16.0.2",
+                "interface": "eth2",
+                "metric": 2,
+                "active": [null]
+              },
+              {
+                "prefix": "10.0.0.3/32",
+                "next-hop": "172.16.0.3",
+                "interface": "eth3",
+                "metric": 3
+              },
+              {
+                "prefix": "10.0.0.4/32",
+                "next-hop": "172.16.0.4",
+                "interface": "eth4",
+                "metric": 4,
+                "active": [null]
+              },
+              {
+                "prefix": "10.0.0.5/32",
+                "next-hop": "172.16.0.5",
+                "interface": "eth5",
+                "metric": 5
+              }
+            ]
+          }
+        },
+        {
+          "name": "vrf1",
+          "interfaces": {
+            "interface": [
+              "eth0",
+              "eth1",
+              "eth2",
+              "eth3"
+            ]
+          },
+          "routes": {
+            "route": [
+              {
+                "prefix": "10.0.0.0/32",
+                "next-hop": "172.16.0.0",
+                "interface": "eth0",
+                "metric": 0,
+                "active": [null]
+              },
+              {
+                "prefix": "10.0.0.1/32",
+                "next-hop": "172.16.0.1",
+                "interface": "eth1",
+                "metric": 1
+              },
+              {
+                "prefix": "10.0.0.2/32",
+                "next-hop": "172.16.0.2",
+                "interface": "eth2",
+                "metric": 2,
+                "active": [null]
+              },
+              {
+                "prefix": "10.0.0.3/32",
+                "next-hop": "172.16.0.3",
+                "interface": "eth3",
+                "metric": 3
+              },
+              {
+                "prefix": "10.0.0.4/32",
+                "next-hop": "172.16.0.4",
+                "interface": "eth4",
+                "metric": 4,
+                "active": [null]
+              },
+              {
+                "prefix": "10.0.0.5/32",
+                "next-hop": "172.16.0.5",
+                "interface": "eth5",
+                "metric": 5
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
 test# 
 end.

--- a/vrrpd/vrrp_northbound.c
+++ b/vrrpd/vrrp_northbound.c
@@ -134,6 +134,8 @@ lib_interface_vrrp_vrrp_group_lookup_entry(struct nb_cb_lookup_entry_args *args)
 	uint32_t vrid = strtoul(args->keys->key[0], NULL, 10);
 	const struct interface *ifp = args->parent_list_entry;
 
+	/* TODO: take args->exact_match into account. */
+
 	return vrrp_lookup(ifp, vrid);
 }
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2569,6 +2569,7 @@ DEFUN (show_yang_operational_data,
          [{\
 	   format <json|xml>\
 	   |translate WORD\
+	   |max-elements (1-1000000) [repeat]\
 	 }]" DAEMONS_LIST,
        SHOW_STR
        "YANG information\n"
@@ -2579,6 +2580,9 @@ DEFUN (show_yang_operational_data,
        "Extensible Markup Language\n"
        "Translate operational data\n"
        "YANG module translator\n"
+       "Maximum number of elements to fetch at once\n"
+       "Maximum number of elements to fetch at once\n"
+       "Fetch all data using batches of the provided size\n"
        DAEMONS_STR)
 {
 	int idx_protocol = argc - 1;

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1153,7 +1153,7 @@ int lib_vrf_zebra_ribs_rib_create(struct nb_cb_create_args *args)
 	afi_safi_name = yang_dnode_get_string(args->dnode, "./afi-safi-name");
 	yang_afi_safi_identity2value(afi_safi_name, &afi, &safi);
 
-	zrt = zebra_router_find_zrt(zvrf, table_id, afi, safi);
+	zrt = zebra_router_find_zrt(zvrf, table_id, afi, safi, true);
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -596,12 +596,12 @@ const void *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_lookup_entry(
 	struct nb_cb_lookup_entry_args *args)
 {
-	struct nhg_hash_entry *nhe;
+	const struct route_entry *re = args->parent_list_entry;
+	const struct nhg_hash_entry *nhe = re->nhe;
 	struct nexthop nexthop_lookup = {};
 	struct nexthop *nexthop;
 	const char *nh_type_str;
 
-	nhe = (struct nhg_hash_entry *)args->parent_list_entry;
 	nexthop_lookup.vrf_id = nhe->vrf_id;
 
 	/*

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -68,7 +68,7 @@ zebra_router_table_entry_compare(const struct zebra_router_table *e1,
 
 struct zebra_router_table *zebra_router_find_zrt(struct zebra_vrf *zvrf,
 						 uint32_t tableid, afi_t afi,
-						 safi_t safi)
+						 safi_t safi, bool exact_match)
 {
 	struct zebra_router_table finder;
 	struct zebra_router_table *zrt;
@@ -78,7 +78,13 @@ struct zebra_router_table *zebra_router_find_zrt(struct zebra_vrf *zvrf,
 	finder.safi = safi;
 	finder.tableid = tableid;
 	finder.ns_id = zvrf->zns->ns_id;
-	zrt = RB_FIND(zebra_router_table_head, &zrouter.tables, &finder);
+
+	if (exact_match)
+		zrt = RB_FIND(zebra_router_table_head, &zrouter.tables,
+			      &finder);
+	else
+		zrt = RB_NFIND(zebra_router_table_head, &zrouter.tables,
+			       &finder);
 
 	return zrt;
 }

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -194,7 +194,8 @@ extern void zebra_router_terminate(void);
 
 extern struct zebra_router_table *zebra_router_find_zrt(struct zebra_vrf *zvrf,
 							uint32_t tableid,
-							afi_t afi, safi_t safi);
+							afi_t afi, safi_t safi,
+							bool exact_match);
 extern struct route_table *zebra_router_find_table(struct zebra_vrf *zvrf,
 						   uint32_t tableid, afi_t afi,
 						   safi_t safi);


### PR DESCRIPTION
This PR extends the northbound layer with infrastructure for asynchronous YANG-modeled operational data retrieval. This should solve the problem of blocking the main pthread of the daemons for too long while fetching bulk state data (e.g. millions of routes).

The `nb_oper_data_iterate()` API function was modified to accept a starting offset, a maximum number of elements to iterate over and outputs where the iteration stopped. The outputted offset can be feeded back to the input to resume the iteration from where it stopped. It's up to the NB client whether to fetch and buffer all data before delivering it to the external client, or demand the external client to be in charge of resuming the iteration as necessary. In any case, canceling the iteration before it finishes should be possible (small chunk sizes are better for more responsiveness).

The challenge with asynchronous iteration is that data can be modified while it's being iterated over. In particular, the iteration might stop at a given YANG list entry, then once the iteration resumes that list entry might not exist anymore. This means the pointer returned by the latest `get_next()` callback is unsafe to use once the iteration is resumed. To deal with this problem, the NB should use the `lookup_entry()` callback as a form of synchronization to ensure the list entry referent to the base offset of the data iteration still exists. Further, a new `exact_match` parameter was added to that callback so that it can find the next available entry in the list in case the one we're looking for doesn't exist anymore. All instances of the `lookup_entry()` callback were updated to take that new parameter into account. Commit f88fb89e4bbc3c054482761d77d2abe1add93fa7 explains how that can be done (e.g. use `RB_FIND` for exact matches and `RB_NFIND` for non-exact matches when iterating over an rb-tree).

Here's an example of all callbacks called to fetch this [data](https://pastebin.com/raw/dLAQ3fn4):
* Using a single iteration: https://pastebin.com/raw/v1zVZ3tQ
* Fetching at most 10 elements at time: https://pastebin.com/raw/AtgH7Kq1

One limitation of the current implementation is that the data iteration can't stop in the middle of a leaf-list or keyless list. This is because the NB doesn't provide the `get_keys()` and `lookup_entry()` callbacks for such nodes, so there's no way to perform the required synchronization step once the iteration is resumed. In the future it should be possible to work around this limitation by implementing pseudo-keys that are internal to the FRR implementation and not visible to the external world. The ConfD API uses a similar strategy to deal with this problem.

As of now, none of the existing NB clients (CLI, gRPC, ConfD and Sysrepo) can leverage this new infrastructure since none of them have async capabilities (#6368 should resolve this problem for gRPC). In spite of that, the CLI "show yang operational-data" command was extended with the `max-elements (1-1000000) [repeat]` parameters for testing purposes (the data iteration can be stopped and resumed several times, but the command still runs synchronously). These new parameters should be removed once the CLI gets async capabilities (in that case a global knob to enable fragmentation at a system level should be better).