### PR TITLE
build, yang: bump libyang minimum required version to 1.0.184

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1740,8 +1740,8 @@ AC_SUBST([SNMP_CFLAGS])
 dnl ---------------
 dnl libyang
 dnl ---------------
-PKG_CHECK_MODULES([LIBYANG], [libyang >= 0.16.105], , [
-  AC_MSG_ERROR([libyang (>= 0.16.105) was not found on your system.])
+PKG_CHECK_MODULES([LIBYANG], [libyang >= 1.0.184], , [
+  AC_MSG_ERROR([libyang (>= 1.0.184) was not found on your system.])
 ])
 ac_cflags_save="$CFLAGS"
 CFLAGS="$CFLAGS $LIBYANG_CFLAGS"

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Build-Depends:
  libsnmp-dev,
  libssh-dev <!pkg.frr.nortrlib>,
  libsystemd-dev <!pkg.frr.nosystemd>,
- libyang-dev (>= 0.16.74),
+ libyang-dev (>= 1.0.184),
  pkg-config,
  python3,
  python3-dev,

--- a/doc/developer/building-libyang.rst
+++ b/doc/developer/building-libyang.rst
@@ -10,7 +10,7 @@ The FRR project builds binary ``libyang`` packages, which we offer for download
 
 .. warning::
 
-   ``libyang`` version 0.16.105 or newer is required to build FRR.
+   ``libyang`` version 1.0.184 or newer is required to build FRR.
 
 .. note::
 
@@ -50,8 +50,4 @@ The FRR project builds binary ``libyang`` packages, which we offer for download
          -D CMAKE_BUILD_TYPE:String="Release" ..
    make
    sudo make install
-
-When building ``libyang`` version ``0.16.x`` it's also necessary to pass the
-``-DENABLE_CACHE=OFF`` parameter to ``cmake`` to work around a
-`known bug <https://github.com/CESNET/libyang/issues/752>`_ in libyang.
 

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -170,7 +170,7 @@ BuildRequires:  make
 BuildRequires:  ncurses-devel
 BuildRequires:  readline-devel
 BuildRequires:  texinfo
-BuildRequires:  libyang-devel >= 0.16.74
+BuildRequires:  libyang-devel >= 1.0.184
 %if 0%{?rhel} && 0%{?rhel} < 7
 #python27-devel is available from ius community repo for RedHat/CentOS 6
 BuildRequires:  python27-devel

--- a/yang/frr-interface.yang
+++ b/yang/frr-interface.yang
@@ -300,11 +300,7 @@ module frr-interface {
       }
 
       leaf vrf {
-        type string {
-          length "1..16";
-        }
-        /* yang version 0.16 having issue accessing leafref. */ 
-        /* type frr-vrf:vrf-ref;*/
+        type frr-vrf:vrf-ref;
         description
           "VRF this interface is associated with.";
       }

--- a/yang/frr-ripd.yang
+++ b/yang/frr-ripd.yang
@@ -143,7 +143,7 @@ module frr-ripd {
           "Enable RIP on the specified IP network.";
       }
       leaf-list interface {
-        type string;
+        type frr-interface:interface-ref;
         description
           "Enable RIP on the specified interface.";
       }
@@ -204,14 +204,14 @@ module frr-ripd {
       }
       leaf-list passive-interface {
         when "../passive-default = 'false'";
-        type string;
+        type frr-interface:interface-ref;
         description
           "A list of interfaces where the sending of RIP packets
            is disabled.";
       }
       leaf-list non-passive-interface {
         when "../passive-default = 'true'";
-        type string;
+        type frr-interface:interface-ref;
         description
           "A list of interfaces where the sending of RIP packets
            is enabled.";

--- a/yang/frr-ripngd.yang
+++ b/yang/frr-ripngd.yang
@@ -101,7 +101,7 @@ module frr-ripngd {
           "Enable RIPng on the specified IPv6 network.";
       }
       leaf-list interface {
-        type string;
+        type frr-interface:interface-ref;
         description
           "Enable RIPng on the specified interface.";
       }

--- a/yang/frr-route-map.yang
+++ b/yang/frr-route-map.yang
@@ -249,7 +249,7 @@ module frr-route-map {
             case interface {
               when "./condition = 'interface'";
               leaf interface {
-                type string;
+                type frr-interface:interface-ref;
               }
             }
 

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -393,9 +393,7 @@ module frr-zebra {
     }
 
     leaf vrf {
-      type string {
-        length "1..36";
-      }
+      type frr-vrf:vrf-ref;
       description
         "The tenant VRF.";
     }
@@ -715,9 +713,7 @@ module frr-zebra {
       choice vrf-choice {
         case single {
           leaf vrf {
-            type string {
-              length "1..36";
-            }
+            type frr-vrf:vrf-ref;
             description
               "Retrieve routes in a non-default vrf.";
           }
@@ -815,9 +811,7 @@ module frr-zebra {
       choice vrf-choice {
         case single {
           leaf vrf {
-            type string {
-              length "1..36";
-            }
+            type frr-vrf:vrf-ref;
             description
               "Retrieve routes in a non-default vrf.";
           }
@@ -853,9 +847,7 @@ module frr-zebra {
     output {
       list vrf-list {
         leaf name {
-          type string {
-            length "1..36";
-          }
+          type frr-vrf:vrf-ref;
           description
             "The VRF name";
         }
@@ -910,9 +902,7 @@ module frr-zebra {
     output {
       list vrf-vni-list {
         leaf vrf-name {
-          type string {
-            length "1..36";
-          }
+          type frr-vrf:vrf-ref;
           description
             "The VRF name.";
         }


### PR DESCRIPTION
It's time to say good bye to libyang 0.16.105. The recently
released libyang 1.0.167 includes numerous bug fixes and performance
improvements that we need.

Despite the major version bump from 0.x to 1.x, the libyang API is
the same except for a single backward-incompatible change in the
user types interface (which we're currently not using). Hence no
code changes were necessary to adapt FRR to libyang 1.x.

This commit also reintroduces some leafrefs that needed to be
removed from our YANG modules due to a bug that was present on
libyang 0.16.105.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>