### PR TITLE
Ip as path removal really

### DIFF
--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -548,15 +548,6 @@ DEFUN (no_as_path_all,
 	return CMD_SUCCESS;
 }
 
-ALIAS (no_as_path_all,
-       no_ip_as_path_all_cmd,
-       "no ip as-path access-list WORD",
-       NO_STR
-       IP_STR
-       "BGP autonomous system path filter\n"
-       "Specify an access list name\n"
-       "Regular expression access list name\n")
-
 static void as_list_show(struct vty *vty, struct as_list *aslist)
 {
 	struct as_filter *asfilter;
@@ -683,7 +674,6 @@ void bgp_filter_init(void)
 	install_element(CONFIG_NODE, &bgp_as_path_cmd);
 	install_element(CONFIG_NODE, &no_bgp_as_path_cmd);
 	install_element(CONFIG_NODE, &no_bgp_as_path_all_cmd);
-	install_element(CONFIG_NODE, &no_ip_as_path_all_cmd);
 
 	install_element(VIEW_NODE, &show_bgp_as_path_access_list_cmd);
 	install_element(VIEW_NODE, &show_ip_as_path_access_list_cmd);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3041,8 +3041,8 @@ certainly contains silly mistakes, if not serious flaws.
    ip prefix-list pl-peer2-network permit 192.168.2.0/24
    ip prefix-list pl-peer2-network permit 172.16.1/24
    !
-   ip as-path access-list asp-own-as permit ^$
-   ip as-path access-list asp-own-as permit _64512_
+   bgp as-path access-list asp-own-as permit ^$
+   bgp as-path access-list asp-own-as permit _64512_
    !
    ! #################################################################
    ! Match communities we provide actions for, on routes receives from


### PR DESCRIPTION
see individual commits. 

remove the `no ip as-path` ALIAS it's dead jim.
update docs to not sure no-longer usable command