### PR TITLE
[7.2] build: use configfile mode in init script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -736,6 +736,7 @@ AC_SUBST([enable_vty_group])
 
 enable_configfile_mask=${enable_configfile_mask:-0600}
 AC_DEFINE_UNQUOTED([CONFIGFILE_MASK], [${enable_configfile_mask}], [Mask for config files])
+AC_SUBST([enable_configfile_mask])
 
 enable_logfile_mask=${enable_logfile_mask:-0600}
 AC_DEFINE_UNQUOTED([LOGFILE_MASK], [${enable_logfile_mask}], [Mask for log files])

--- a/tools/frr.in
+++ b/tools/frr.in
@@ -21,6 +21,7 @@ VTYSH="@vtysh_bin@" # /usr/bin/vtysh
 FRR_USER="@enable_user@" # frr
 FRR_GROUP="@enable_group@" # frr
 FRR_VTY_GROUP="@enable_vty_group@" # frrvty
+FRR_CONFIG_MODE="@enable_configfile_mask@" # 0600
 
 # Local Daemon selection may be done by using /etc/frr/daemons.
 # See /usr/share/doc/frr/README.Debian.gz for further information.
@@ -55,6 +56,7 @@ chownfrr()
 {
 	test -n "$FRR_USER" && chown "$FRR_USER" "$1"
 	test -n "$FRR_GROUP" && chgrp "$FRR_GROUP" "$1"
+	test -n "$FRR_CONFIG_MODE" && chmod "$FRR_CONFIG_MODE" "$1"
 }
 
 # Check if daemon is started by using the pidfile.

--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -24,6 +24,7 @@ VTYSH="@vtysh_bin@" # /usr/bin/vtysh
 FRR_USER="@enable_user@" # frr
 FRR_GROUP="@enable_group@" # frr
 FRR_VTY_GROUP="@enable_vty_group@" # frrvty
+FRR_CONFIG_MODE="@enable_configfile_mask@" # 0600
 
 # ORDER MATTERS FOR $DAEMONS!
 # - keep zebra first
@@ -52,6 +53,7 @@ debug() {
 chownfrr() {
 	[ -n "$FRR_USER" ] && chown "$FRR_USER" "$1"
 	[ -n "$FRR_GROUP" ] && chgrp "$FRR_GROUP" "$1"
+	[ -n "$FRR_CONFIG_MODE" ] && chmod "$FRR_CONFIG_MODE" "$1"
 }
 
 vtysh_b () {


### PR DESCRIPTION
This only applies for split-config;  the init script would create an
empty config file with default permissions.

Reported-by: Robert Scheck <robert@fedoraproject.org>
Signed-off-by: David Lamparter <equinox@opensourcerouting.org>
(cherry picked from commit 5c9063771195bb51a8cc1c64f9924e53a0602817)