### PR TITLE
Fix evpn type2 heap read overflow(s)

### DIFF
--- a/lib/stream.c
+++ b/lib/stream.c
@@ -252,6 +252,18 @@ void stream_forward_getp(struct stream *s, size_t size)
 	s->getp += size;
 }
 
+bool stream_forward_getp2(struct stream *s, size_t size)
+{
+	STREAM_VERIFY_SANE(s);
+
+	if (!GETP_VALID(s, s->getp + size))
+		return false;
+
+	s->getp += size;
+
+	return true;
+}
+
 void stream_forward_endp(struct stream *s, size_t size)
 {
 	STREAM_VERIFY_SANE(s);
@@ -262,6 +274,18 @@ void stream_forward_endp(struct stream *s, size_t size)
 	}
 
 	s->endp += size;
+}
+
+bool stream_forward_endp2(struct stream *s, size_t size)
+{
+	STREAM_VERIFY_SANE(s);
+
+	if (!ENDP_VALID(s, s->endp + size))
+		return false;
+
+	s->endp += size;
+
+	return true;
 }
 
 /* Copy from stream to destination. */

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -173,7 +173,9 @@ extern struct stream *stream_dupcat(const struct stream *s1,
 extern void stream_set_getp(struct stream *, size_t);
 extern void stream_set_endp(struct stream *, size_t);
 extern void stream_forward_getp(struct stream *, size_t);
+extern bool stream_forward_getp2(struct stream *, size_t);
 extern void stream_forward_endp(struct stream *, size_t);
+extern bool stream_forward_endp2(struct stream *, size_t);
 
 /* steam_put: NULL source zeroes out size_t bytes of stream */
 extern void stream_put(struct stream *, const void *, size_t);
@@ -452,6 +454,18 @@ static inline uint8_t *ptr_get_be16(uint8_t *ptr, uint16_t *out)
 #define STREAM_GET(P, STR, SIZE)                                               \
 	do {                                                                   \
 		if (!stream_get2((P), (STR), (SIZE)))                          \
+			goto stream_failure;                                   \
+	} while (0)
+
+#define STREAM_FORWARD_GETP(STR, SIZE)                                         \
+	do {                                                                   \
+		if (!stream_forward_getp2((STR), (SIZE)))                      \
+			goto stream_failure;                                   \
+	} while (0)
+
+#define STREAM_FORWARD_ENDP(STR, SIZE)                                         \
+	do {                                                                   \
+		if (!stream_forward_endp2((STR), (SIZE)))                      \
 			goto stream_failure;                                   \
 	} while (0)
 


### PR DESCRIPTION
Various forms of corrupt packets could trigger reads of garbage heap.

Note that this PR is targeted against the `evpn-mh` branch, so this bug will continue to exist in `master` until that is merged. I'm putting it there to avoid merge conflicts later on.

```
READ of size 16 at 0x60e0000008b8 thread T0
    #0 0x4e5bb9 in __asan_memcpy (/usr/lib/frr/bgpd+0x4e5bb9)
    #1 0x5d6e11 in process_type2_route /home/qlyoung/projects/frr/bgpd/bgp_evpn.c:3682:3
    #2 0x5d6e11 in bgp_nlri_parse_evpn /home/qlyoung/projects/frr/bgpd/bgp_evpn.c:4795:8
    #3 0x7064e4 in bgp_update_receive /home/qlyoung/projects/frr/bgpd/bgp_packet.c
    #4 0x7064e4 in bgp_process_packet /home/qlyoung/projects/frr/bgpd/bgp_packet.c:2376:11
    #5 0x51886d in LLVMFuzzerTestOneInput /home/qlyoung/projects/frr/bgpd/bgp_main.c:522:12
    #6 0x454401 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/usr/lib/frr/bgpd+0x454401)
    #7 0x43c8f7 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/usr/lib/frr/bgpd+0x43c8f7)
    #8 0x4428d1 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/usr/lib/frr/bgpd+0x4428d1)
    #9 0x46e932 in main (/usr/lib/frr/bgpd+0x46e932)
    #10 0x7f46ac9c7b96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
    #11 0x436ce9 in _start (/usr/lib/frr/bgpd+0x436ce9)

0x60e0000008b8 is located 0 bytes to the right of 152-byte region [0x60e000000820,0x60e0000008b8)
allocated by thread T0 here:
    #0 0x4e677d in malloc (/usr/lib/frr/bgpd+0x4e677d)
    #1 0x7f46ae5786b4 in qmalloc /home/qlyoung/projects/frr/lib/memory.c:105:27
    #2 0x7f46ae7012db in stream_new /home/qlyoung/projects/frr/lib/stream.c:106:6
    #3 0x518719 in LLVMFuzzerTestOneInput /home/qlyoung/projects/frr/bgpd/bgp_main.c:515:24
    #4 0x454401 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/usr/lib/frr/bgpd+0x454401)
    #5 0x43c8f7 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/usr/lib/frr/bgpd+0x43c8f7)
    #6 0x4428d1 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/usr/lib/frr/bgpd+0x4428d1)
    #7 0x46e932 in main (/usr/lib/frr/bgpd+0x46e932)
    #8 0x7f46ac9c7b96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
```