### PR TITLE
zebra: avoid using c++ keywords in headers

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -323,7 +323,8 @@ enum rib_update_event {
 
 extern void route_entry_copy_nexthops(struct route_entry *re,
 				      struct nexthop *nh);
-int route_entry_update_nhe(struct route_entry *re, struct nhg_hash_entry *new);
+int route_entry_update_nhe(struct route_entry *re,
+			   struct nhg_hash_entry *new_nhghe);
 
 #define route_entry_dump(prefix, src, re) _route_entry_dump(__func__, prefix, src, re)
 extern void _route_entry_dump(const char *func, union prefixconstptr pp,

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -133,7 +133,7 @@ static void zebra_gr_client_info_delte(struct zserv *client,
 	       zebra_route_string(client->proto));
 
 	/* Delete all the stale routes. */
-	info->delete = true;
+	info->do_delete = true;
 	zebra_gr_delete_stale_routes(info);
 
 	XFREE(MTYPE_TMP, info);
@@ -456,7 +456,7 @@ static int32_t zebra_gr_route_stale_delete_timer_expiry(struct thread *thread)
 
 	/* Set the flag to indicate all stale route deletion */
 	if (thread->u.val == 1)
-		info->delete = true;
+		info->do_delete = true;
 
 	cnt = zebra_gr_delete_stale_routes(info);
 
@@ -581,7 +581,7 @@ static int32_t zebra_gr_delete_stale_route(struct client_gr_info *info,
 					 * Store the current prefix and afi
 					 */
 					if ((n >= ZEBRA_MAX_STALE_ROUTE_COUNT)
-					    && (info->delete == false)) {
+					    && (info->do_delete == false)) {
 						info->current_afi = afi;
 						info->current_prefix = XCALLOC(
 							MTYPE_TMP,

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -211,28 +211,29 @@ static void route_entry_attach_ref(struct route_entry *re,
 	zebra_nhg_increment_ref(new);
 }
 
-int route_entry_update_nhe(struct route_entry *re, struct nhg_hash_entry *new)
+int route_entry_update_nhe(struct route_entry *re,
+			   struct nhg_hash_entry *new_nhghe)
 {
 	struct nhg_hash_entry *old;
 	int ret = 0;
 
-	if (new == NULL) {
+	if (new_nhghe == NULL) {
 		if (re->nhe)
 			zebra_nhg_decrement_ref(re->nhe);
 		re->nhe = NULL;
 		goto done;
 	}
 
-	if ((re->nhe_id != 0) && (re->nhe_id != new->id)) {
+	if ((re->nhe_id != 0) && (re->nhe_id != new_nhghe->id)) {
 		old = re->nhe;
 
-		route_entry_attach_ref(re, new);
+		route_entry_attach_ref(re, new_nhghe);
 
 		if (old)
 			zebra_nhg_decrement_ref(old);
 	} else if (!re->nhe)
 		/* This is the first time it's being attached */
-		route_entry_attach_ref(re, new);
+		route_entry_attach_ref(re, new_nhghe);
 
 done:
 	return ret;

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -72,7 +72,7 @@ struct client_gr_info {
 	enum zserv_client_capabilities capabilities;
 
 	/* GR commands */
-	bool delete;
+	bool do_delete;
 	bool gr_enable;
 	bool stale_client;
 


### PR DESCRIPTION
to make sure that c++ code can include the zebra headers, avoid using reserved keywords like 'delete' or 'new'.