### PR TITLE
tools: Only load instances or daemon

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -90,7 +90,7 @@ daemon_list() {
 				continue
 			fi
 			debug "$daemon enabled"
-			enabled="$enabled $daemon"
+
 			if [ -n "$inst" ]; then
 				debug "$daemon multi-instance $inst"
 				oldifs="${IFS}"
@@ -99,6 +99,8 @@ daemon_list() {
 					enabled="$enabled $daemon-$i"
 				done
 				IFS="${oldifs}"
+			else
+			    enabled="$enabled $daemon"
 			fi
 		else
 			debug "$daemon disabled"


### PR DESCRIPTION
Original start/stop of FRR prior to David's rewrite in
PR 3507, when configuring multi-instance would
only start multi-instance (-1 -2 -3 -4...) or
just the daemon, not both.  If you happened
to start a ospfd instance of 1 then both
the default and instance 1 would react to cli.

Do not allow this, put it back to original behavior

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>