### PR TITLE
ospf6d: Revert "ospf6d: Prevent use after free"

### DIFF
--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -298,17 +298,13 @@ struct ospf6_lsa *ospf6_lsdb_next(const struct route_node *iterend,
 
 void ospf6_lsdb_remove_all(struct ospf6_lsdb *lsdb)
 {
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	if (lsdb == NULL)
 		return;
 
-	for (iterend = ospf6_lsdb_head(lsdb, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(lsdb, lsa))
 		ospf6_lsdb_remove(lsa, lsdb);
-	}
 }
 
 void ospf6_lsdb_lsa_unlock(struct ospf6_lsa *lsa)
@@ -323,12 +319,9 @@ void ospf6_lsdb_lsa_unlock(struct ospf6_lsa *lsa)
 int ospf6_lsdb_maxage_remover(struct ospf6_lsdb *lsdb)
 {
 	int reschedule = 0;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
-	for (iterend = ospf6_lsdb_head(lsdb, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(lsdb, lsa)) {
 		if (!OSPF6_LSA_IS_MAXAGE(lsa))
 			continue;
 		if (lsa->retrans_count != 0) {

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -118,15 +118,11 @@ struct ospf6_neighbor *ospf6_neighbor_create(uint32_t router_id,
 
 void ospf6_neighbor_delete(struct ospf6_neighbor *on)
 {
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	ospf6_lsdb_remove_all(on->summary_list);
 	ospf6_lsdb_remove_all(on->request_list);
-
-	for (iterend = ospf6_lsdb_head(on->retrans_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->retrans_list, lsa)) {
 		ospf6_decrement_retrans_count(lsa);
 		ospf6_lsdb_remove(lsa, on->retrans_list);
 	}
@@ -297,8 +293,7 @@ int twoway_received(struct thread *thread)
 int negotiation_done(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	assert(on);
@@ -312,10 +307,7 @@ int negotiation_done(struct thread *thread)
 	/* clear ls-list */
 	ospf6_lsdb_remove_all(on->summary_list);
 	ospf6_lsdb_remove_all(on->request_list);
-
-	for (iterend = ospf6_lsdb_head(on->retrans_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->retrans_list, lsa)) {
 		ospf6_decrement_retrans_count(lsa);
 		ospf6_lsdb_remove(lsa, on->retrans_list);
 	}
@@ -509,8 +501,7 @@ int seqnumber_mismatch(struct thread *thread)
 int bad_lsreq(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	assert(on);
@@ -529,10 +520,7 @@ int bad_lsreq(struct thread *thread)
 
 	ospf6_lsdb_remove_all(on->summary_list);
 	ospf6_lsdb_remove_all(on->request_list);
-
-	for (iterend = ospf6_lsdb_head(on->retrans_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->retrans_list, lsa)) {
 		ospf6_decrement_retrans_count(lsa);
 		ospf6_lsdb_remove(lsa, on->retrans_list);
 	}
@@ -550,8 +538,7 @@ int bad_lsreq(struct thread *thread)
 int oneway_received(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	assert(on);
@@ -568,9 +555,7 @@ int oneway_received(struct thread *thread)
 
 	ospf6_lsdb_remove_all(on->summary_list);
 	ospf6_lsdb_remove_all(on->request_list);
-	for (iterend = ospf6_lsdb_head(on->retrans_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->retrans_list, lsa)) {
 		ospf6_decrement_retrans_count(lsa);
 		ospf6_lsdb_remove(lsa, on->retrans_list);
 	}


### PR DESCRIPTION
This reverts commit 0f9f74baeb97f437d7acf7feda0f400d50943c4c.

This commit was causing crashes and the goal of this commit
was to make coverity sanity happy.  I'd rather have coverity
sad and not have ospfv3 crash

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>