### PR TITLE
ospfd: Solve crash after removing and adding conf.

### DIFF
--- a/ospfd/ospf_ext.h
+++ b/ospfd/ospf_ext.h
@@ -151,10 +151,6 @@ struct ospf_ext_lp {
 	 */
 	uint8_t scope;
 
-	/* area pointer if flooding is Type 10 Null if flooding is AS scope */
-	struct ospf_area *area;
-	struct in_addr area_id;
-
 	/* List of interface with Segment Routing enable */
 	struct list *iflist;
 };

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -178,6 +178,14 @@ void ospf_router_info_term(void)
 
 void ospf_router_info_finish(void)
 {
+	struct listnode *node, *nnode;
+	struct ospf_ri_area_info *ai;
+
+	/* Flush Router Info LSA */
+	for (ALL_LIST_ELEMENTS(OspfRI.area_info, node, nnode, ai))
+		if (CHECK_FLAG(ai->flags, RIFLG_LSA_ENGAGED))
+			ospf_router_info_lsa_schedule(ai, FLUSH_THIS_LSA);
+
 	list_delete_all_node(OspfRI.pce_info.pce_domain);
 	list_delete_all_node(OspfRI.pce_info.pce_neighbor);
 
@@ -510,6 +518,8 @@ static void initialize_params(struct ospf_router_info *ori)
 	/* Try to get available Area's context from ospf at this step.
 	 * Do it latter if not available */
 	if (OspfRI.scope == OSPF_OPAQUE_AREA_LSA) {
+		if (!list_isempty(OspfRI.area_info))
+			list_delete_all_node(OspfRI.area_info);
 		for (ALL_LIST_ELEMENTS(top->areas, node, nnode, area)) {
 			zlog_debug("RI (%s): Add area %s to Router Information",
 				__func__, inet_ntoa(area->area_id));

--- a/tests/topotests/ospf-sr-topo1/r2/ospfd.conf
+++ b/tests/topotests/ospf-sr-topo1/r2/ospfd.conf
@@ -1,4 +1,6 @@
 !
+debug ospf sr
+!
 interface lo
   ip ospf area 0.0.0.0
 !


### PR DESCRIPTION
Issue number #6291 describes how OSPFd crashes after being deleted and then
added again with configuration when segment routing is used.

The problem occurs in ospf_ri.c because the OspfRI structures retains
the reference to the old area pointer which is mofified when ospfd is
reactivated by configuration. When segment routing is activated, the LSA Router
Information is sent with reference to the old area pointer, instead the new one,
which causes the crash. The same problem is also present in ospf_ext_c with
OspfExt structure for Extended Prefix and Extended Link LSA.

This commit introduces Extended Link and Router Information LSAs flusing when
OSPFd is stopped when configuration is removed and adds the correct
initialization to the area pointer in OspfRI and OspfExt structure when OSPFd
is re-enabled with the configuration.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>