### PR TITLE
bgpd: Free non-best paths also during table cleanup

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4706,8 +4706,9 @@ static void bgp_cleanup_table(struct bgp *bgp, struct bgp_table *table,
 
 				if (bgp_fibupd_safi(safi))
 					bgp_zebra_withdraw(p, pi, bgp, safi);
-				bgp_path_info_reap(rn, pi);
 			}
+
+			bgp_path_info_reap(rn, pi);
 		}
 }
 


### PR DESCRIPTION
Non-best paths (path info structures) also need to be freed during
table cleanup not only to release their memory but to also ensure
any linkages are updated correctly. One such example is for EVPN
where there is a link between the imported path info (in a L2 or
L3 vrf instance) and its parent path info.

Signed-off-by: Vivek Venkatraman <vivek@cumulusnetworks.com>