### PR TITLE
ospfd: Route-tag is not set to external routes when applied using route maps

### DIFF
--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -149,6 +149,7 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 	new->ifindex = ifindex;
 	new->nexthop = nexthop;
 	new->tag = tag;
+	new->orig_tag = tag;
 
 	/* we don't unlock rn from the get() because we're attaching the info */
 	if (rn)

--- a/ospfd/ospf_asbr.h
+++ b/ospfd/ospf_asbr.h
@@ -46,6 +46,9 @@ struct external_info {
 	/* Additional Route tag. */
 	route_tag_t tag;
 
+	/* Actual tag received from zebra*/
+	route_tag_t orig_tag;
+
 	struct route_map_set_values route_map_set;
 #define ROUTEMAP_METRIC(E)      (E)->route_map_set.metric
 #define ROUTEMAP_METRIC_TYPE(E) (E)->route_map_set.metric_type

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -726,7 +726,10 @@ int ospf_redistribute_check(struct ospf *ospf, struct external_info *ei,
 
 	save_values = ei->route_map_set;
 	ospf_reset_route_map_set_values(&ei->route_map_set);
+
 	saved_tag = ei->tag;
+	/* Resetting with original route tag */
+	ei->tag = ei->orig_tag;
 
 	/* apply route-map if needed */
 	red = ospf_redist_lookup(ospf, type, instance);


### PR DESCRIPTION
Issue 1 :
Steps:
1. redistribute static routes
2. redistribute static route with routemap ramp1 (set a tag) 
Route-tag is not set to external lsas originated by ospf when a routemap ramp1 applied on redistribution.

Description:
When applying a route-map on redistribution, external lsas will be refreshed if there is any change in the route parametrs after applying routemap. But tag change is not handled here so routes are not refreshing with new tag information.
Added a fix to address this.

 Issue 2:
1. redistribute static routes with a routemap rmap1 (set a tag tag1)
2. redistribute static route with a routemap ramp2 (permitting some prefixes)
Here after applying rmap2,  Permitted routes are expected to be refreshed/originated with original tag received from zebra but those are still  originated with tag1. 

Description:
Here, tag parameter in external_info structure is modified when a routemap applied to set a tag. 
the original tag received from zebra is completely lost until received from zebra again.
To address this, added a new parameter to restore the original tag received from zebra and other tag is used for routemap tag manipulations. 

Signed-off-by: Rajesh Girada <rgirada@vmware.com>
