### PR TITLE
Update ifname before hook

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -217,14 +217,16 @@ struct interface *if_create_name(const char *name, vrf_id_t vrf_id)
 	return ifp;
 }
 
-struct interface *if_create_ifindex(ifindex_t ifindex, vrf_id_t vrf_id)
+struct interface *if_create_ifindex(ifindex_t ifindex, vrf_id_t vrf_id,
+				    char *optional_name)
 {
 	struct interface *ifp;
 
 	ifp = if_new(vrf_id);
 
 	if_set_index(ifp, ifindex);
-
+	if (optional_name)
+		if_set_name(ifp, optional_name);
 	hook_call(if_add, ifp);
 	return ifp;
 }
@@ -554,7 +556,8 @@ struct interface *if_get_by_name(const char *name, vrf_id_t vrf_id)
 	return NULL;
 }
 
-struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id)
+struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id,
+				    char *optional_name)
 {
 	struct interface *ifp;
 
@@ -564,7 +567,7 @@ struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id)
 		ifp = if_lookup_by_ifindex(ifindex, vrf_id);
 		if (ifp)
 			return ifp;
-		return if_create_ifindex(ifindex, vrf_id);
+		return if_create_ifindex(ifindex, vrf_id, optional_name);
 	case VRF_BACKEND_VRF_LITE:
 		ifp = if_lookup_by_index_all_vrf(ifindex);
 		if (ifp) {
@@ -576,7 +579,7 @@ struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id)
 			if_update_to_new_vrf(ifp, vrf_id);
 			return ifp;
 		}
-		return if_create_ifindex(ifindex, vrf_id);
+		return if_create_ifindex(ifindex, vrf_id, optional_name);
 	}
 
 	return NULL;

--- a/lib/if.h
+++ b/lib/if.h
@@ -509,7 +509,8 @@ extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
 extern struct interface *if_create_name(const char *name, vrf_id_t vrf_id);
 
 /* Create new interface, adds to index list only */
-extern struct interface *if_create_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);
+extern struct interface *if_create_ifindex(ifindex_t ifindex, vrf_id_t vrf_id,
+					   char *name);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
 extern struct interface *if_lookup_by_index_all_vrf(ifindex_t);
 extern struct interface *if_lookup_exact_address(const void *matchaddr,
@@ -524,8 +525,8 @@ size_t if_lookup_by_hwaddr(const uint8_t *hw_addr, size_t addrsz,
 extern struct interface *if_lookup_by_name_all_vrf(const char *ifname);
 extern struct interface *if_lookup_by_name(const char *ifname, vrf_id_t vrf_id);
 extern struct interface *if_get_by_name(const char *ifname, vrf_id_t vrf_id);
-extern struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);
-
+extern struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id,
+					   char *optional_name);
 /* Sets the index and adds to index list */
 extern int if_set_index(struct interface *ifp, ifindex_t ifindex);
 /* Sets the name and adds to name list */

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -711,10 +711,8 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	 * back references on the slave interfaces is painful if not done
 	 * this way, i.e. by creating by ifindex.
 	 */
-	ifp = if_get_by_ifindex(ifi->ifi_index, vrf_id);
+	ifp = if_get_by_ifindex(ifi->ifi_index, vrf_id, name);
 	set_ifindex(ifp, ifi->ifi_index, zns); /* add it to ns struct */
-
-	if_set_name(ifp, name);
 
 	ifp->flags = ifi->ifi_flags & 0x0000fffff;
 	ifp->mtu6 = ifp->mtu = *(uint32_t *)RTA_DATA(tb[IFLA_MTU]);

--- a/zebra/zebra_l2.c
+++ b/zebra/zebra_l2.c
@@ -110,7 +110,7 @@ void zebra_l2_map_slave_to_bond(struct zebra_l2info_bondslave *bond_slave,
 		bond_slave->bond_if = bond_if;
 	else
 		bond_slave->bond_if = if_create_ifindex(bond_slave->bond_ifindex,
-							vrf_id);
+							vrf_id, NULL);
 }
 
 void zebra_l2_unmap_slave_from_bond(struct zebra_l2info_bondslave *bond_slave)


### PR DESCRIPTION
    the interface name was not present in the hook in charge of updating the
    interface context to the registered hook service. For that, update the
    name before informing it.
