### PR TITLE
doc: add a doc for the frr-reload script

### DIFF
--- a/doc/user/frr-reload.rst
+++ b/doc/user/frr-reload.rst
@@ -1,0 +1,12 @@
+.. _frr-reload:
+
+
+The frr-reload.py script
+========================
+
+
+
+Options
+-------
+
+There are several options that control the behavior of ``frr-reload``.

--- a/doc/user/index.rst
+++ b/doc/user/index.rst
@@ -71,6 +71,7 @@ Appendix
    bugs
    packet-dumps
    glossary
+   frr-reload
 
 ################
 Copyright notice

--- a/doc/user/setup.rst
+++ b/doc/user/setup.rst
@@ -218,6 +218,9 @@ individual or unified daemon configuration files.
 
       systemctl reload frr
 
+See :ref:`FRR-RELOAD <frr-reload>` for more about the `frr-reload.py` script.
+
+      
 Starting a new daemon
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/user/subdir.am
+++ b/doc/user/subdir.am
@@ -13,6 +13,7 @@ user_RSTFILES = \
 	doc/user/eigrpd.rst \
 	doc/user/fabricd.rst \
 	doc/user/filter.rst \
+	doc/user/frr-reload.rst \
 	doc/user/glossary.rst \
 	doc/user/index.rst \
 	doc/user/installation.rst \


### PR DESCRIPTION
Add a skeleton frr-reload doc, so we have a place to capture info about the script's options.