### PR TITLE
lib: fix bandwidth multiplier for link param

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1274,7 +1274,7 @@ struct if_link_params *if_link_params_get(struct interface *ifp)
 	/* Compute default bandwidth based on interface */
 	iflp->default_bw =
 		((ifp->bandwidth ? ifp->bandwidth : DEFAULT_BANDWIDTH)
-		 * TE_KILO_BIT / TE_BYTE);
+		 * TE_MEGA_BIT / TE_BYTE);
 
 	/* Set Max, Reservable and Unreserved Bandwidth */
 	iflp->max_bw = iflp->default_bw;

--- a/lib/if.h
+++ b/lib/if.h
@@ -143,7 +143,7 @@ struct if_stats {
 #define TE_EXT_MASK             0x0FFFFFFF
 #define TE_EXT_ANORMAL          0x80000000
 #define LOSS_PRECISION          0.000003
-#define TE_KILO_BIT             1000
+#define TE_MEGA_BIT             1000000
 #define TE_BYTE                 8
 #define DEFAULT_BANDWIDTH       10000
 #define MAX_CLASS_TYPE          8


### PR DESCRIPTION
in the CLI we state that the bandwidth of a link is in Megabits per second, but when converting it to
Bytes per second for TE purposes we were treating it as Kilobits. Fix the conversion error.

This can be checked with wireshark. With the following config:
```
interface XXX
 bandwidth 1000
 link-params
  enable
  exit-link-params
 !
[...]
router isis YYY
 mpls-te on
 [...]
```
before the patch with wireshark we would see 1.00 Mbps of Maximum link bandwidth advertised in the IS-IS TLV; with the patch we get the correct value of 1000.00 Mbps

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>