### PR TITLE
isisd: set TE link params on circuit creation

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1223,6 +1223,8 @@ struct isis_circuit *isis_circuit_create(struct isis_area *area,
 	if (circuit->state != C_STATE_CONF && circuit->state != C_STATE_UP)
 		return circuit;
 	isis_circuit_if_bind(circuit, ifp);
+	if (circuit->area->mta && circuit->area->mta->status)
+		isis_link_params_update(circuit, ifp);
 	return circuit;
 }
 


### PR DESCRIPTION
if mpls-te is enabled in the area, on creating a circuit we must refresh the link params - else interfaces that are enabled for IS-IS after configuring 'mpls-te on' will not correctly advertise link parameters.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>