### PR TITLE
bfdd: support pre configured peer profiles

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -33,6 +33,7 @@
 #include "bfd.h"
 
 DEFINE_MTYPE_STATIC(BFDD, BFDD_CONFIG, "long-lived configuration memory")
+DEFINE_MTYPE_STATIC(BFDD, BFDD_PROFILE, "long-lived profile memory")
 DEFINE_MTYPE_STATIC(BFDD, BFDD_SESSION_OBSERVER, "Session observer")
 DEFINE_MTYPE_STATIC(BFDD, BFDD_VRF, "BFD VRF")
 
@@ -56,9 +57,173 @@ static void bs_neighbour_admin_down_handler(struct bfd_session *bfd,
 /* Zeroed array with the size of an IPv6 address. */
 struct in6_addr zero_addr;
 
+/** BFD profiles list. */
+struct bfdproflist bplist;
+
 /*
  * Functions
  */
+struct bfd_profile *bfd_profile_lookup(const char *name)
+{
+	struct bfd_profile *bp;
+
+	TAILQ_FOREACH (bp, &bplist, entry) {
+		if (strcmp(name, bp->name))
+			continue;
+
+		return bp;
+	}
+
+	return NULL;
+}
+
+static void bfd_profile_set_default(struct bfd_profile *bp)
+{
+	bp->admin_shutdown = true;
+	bp->detection_multiplier = BFD_DEFDETECTMULT;
+	bp->echo_mode = false;
+	bp->min_echo_rx = BFD_DEF_REQ_MIN_ECHO;
+	bp->min_rx = BFD_DEFREQUIREDMINRX;
+	bp->min_tx = BFD_DEFDESIREDMINTX;
+}
+
+struct bfd_profile *bfd_profile_new(const char *name)
+{
+	struct bfd_profile *bp;
+
+	/* Search for duplicates. */
+	if (bfd_profile_lookup(name) != NULL)
+		return NULL;
+
+	/* Allocate, name it and put into list. */
+	bp = XCALLOC(MTYPE_BFDD_PROFILE, sizeof(*bp));
+	strlcpy(bp->name, name, sizeof(bp->name));
+	TAILQ_INSERT_TAIL(&bplist, bp, entry);
+
+	/* Set default values. */
+	bfd_profile_set_default(bp);
+
+	return bp;
+}
+
+void bfd_profile_free(struct bfd_profile *bp)
+{
+	TAILQ_REMOVE(&bplist, bp, entry);
+	free(bp);
+}
+
+/**
+ * Removes a profile and tests whether it needs to apply the changes or not.
+ *
+ * \param bs the BFD session.
+ * \param apply whether or not to apply configurations immediately.
+ */
+static void _bfd_profile_remove(struct bfd_session *bs, bool apply)
+{
+	struct bfd_profile *bp;
+
+	/* No profile applied, nothing to do. */
+	bp = bs->profile;
+	if (bp == NULL)
+		return;
+
+	/* Remove the profile association. */
+	bs->profile = NULL;
+
+	/* Set multiplier to the default. */
+	bs->detect_mult = bs->peer_profile.detection_multiplier;
+
+	/* Set timers back to user configuration. */
+	bs->timers.desired_min_tx = bs->peer_profile.min_tx;
+	bs->timers.required_min_rx = bs->peer_profile.min_rx;
+
+	/* We can only apply echo options on single hop sessions. */
+	if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)) {
+		/* Set default echo timer. */
+		bs->timers.required_min_echo = bs->peer_profile.min_echo_rx;
+
+		/* Default is no echo mode. */
+		if (apply)
+			bfd_set_echo(bs, bs->peer_profile.echo_mode);
+	}
+
+	if (apply)
+		bfd_set_shutdown(bs, bs->peer_profile.admin_shutdown);
+}
+
+void bfd_profile_apply(const char *profname, struct bfd_session *bs)
+{
+	struct bfd_profile *bp;
+
+	/* Remove previous profile if any. */
+	if (bs->profile_name) {
+		_bfd_profile_remove(bs, false);
+
+		/* We are changing profiles. */
+		if (strcmp(bs->profile_name, profname)) {
+			XFREE(MTYPE_BFDD_PROFILE, bs->profile_name);
+			bs->profile_name =
+				XSTRDUP(MTYPE_BFDD_PROFILE, profname);
+		}
+	} else /* Save the current profile name (in case it doesn't exist). */
+		bs->profile_name = XSTRDUP(MTYPE_BFDD_PROFILE, profname);
+
+	/* Look up new profile to apply. */
+	bp = bfd_profile_lookup(profname);
+	if (bp == NULL)
+		return;
+
+	/* Point to profile if it exists. */
+	bs->profile = bp;
+
+	/* Set multiplier if not the default. */
+	if (bs->peer_profile.detection_multiplier == BFD_DEFDETECTMULT)
+		bs->detect_mult = bp->detection_multiplier;
+	else
+		bs->detect_mult = bs->peer_profile.detection_multiplier;
+
+	/* Set timers if not the default. */
+	if (bs->peer_profile.min_tx == BFD_DEFDESIREDMINTX)
+		bs->timers.desired_min_tx = bp->min_tx;
+	else
+		bs->timers.desired_min_tx = bs->peer_profile.min_tx;
+
+	if (bs->peer_profile.min_rx == BFD_DEFREQUIREDMINRX)
+		bs->timers.required_min_rx = bp->min_rx;
+	else
+		bs->timers.required_min_rx = bs->peer_profile.min_rx;
+
+	/* We can only apply echo options on single hop sessions. */
+	if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)) {
+		/* Configure remote echo if it was default. */
+		if (bs->peer_profile.min_echo_rx == BFD_DEF_REQ_MIN_ECHO)
+			bs->timers.required_min_echo = bp->min_echo_rx;
+		else
+			bs->timers.required_min_echo =
+				bs->peer_profile.min_echo_rx;
+
+		/* Toggle echo if default value. */
+		if (bs->peer_profile.echo_mode == false)
+			bfd_set_echo(bs, bp->echo_mode);
+		else
+			bfd_set_echo(bs, bs->peer_profile.echo_mode);
+	}
+
+	/* Toggle 'no shutdown' if default value. */
+	if (bs->peer_profile.admin_shutdown)
+		bfd_set_shutdown(bs, bp->admin_shutdown);
+	else
+		bfd_set_shutdown(bs, bs->peer_profile.admin_shutdown);
+}
+
+void bfd_profile_remove(struct bfd_session *bs)
+{
+	/* Remove any previous set profile name. */
+	XFREE(MTYPE_BFDD_PROFILE, bs->profile_name);
+
+	_bfd_profile_remove(bs, true);
+}
+
 void gen_bfd_key(struct bfd_key *key, struct sockaddr_any *peer,
 		 struct sockaddr_any *local, bool mhop, const char *ifname,
 		 const char *vrfname)
@@ -494,6 +659,9 @@ struct bfd_session *bfd_session_new(void)
 
 	bs = XCALLOC(MTYPE_BFDD_CONFIG, sizeof(*bs));
 
+	/* Set peer session defaults. */
+	bfd_profile_set_default(&bs->peer_profile);
+
 	bs->timers.desired_min_tx = BFD_DEFDESIREDMINTX;
 	bs->timers.required_min_rx = BFD_DEFREQUIREDMINRX;
 	bs->timers.required_min_echo = BFD_DEF_REQ_MIN_ECHO;
@@ -550,17 +718,25 @@ int bfd_session_update_label(struct bfd_session *bs, const char *nlabel)
 static void _bfd_session_update(struct bfd_session *bs,
 				struct bfd_peer_cfg *bpc)
 {
-	if (bpc->bpc_has_txinterval)
+	if (bpc->bpc_has_txinterval) {
 		bs->timers.desired_min_tx = bpc->bpc_txinterval * 1000;
+		bs->peer_profile.min_tx = bs->timers.desired_min_tx;
+	}
 
-	if (bpc->bpc_has_recvinterval)
+	if (bpc->bpc_has_recvinterval) {
 		bs->timers.required_min_rx = bpc->bpc_recvinterval * 1000;
+		bs->peer_profile.min_rx = bs->timers.required_min_rx;
+	}
 
-	if (bpc->bpc_has_detectmultiplier)
+	if (bpc->bpc_has_detectmultiplier) {
 		bs->detect_mult = bpc->bpc_detectmultiplier;
+		bs->peer_profile.detection_multiplier = bs->detect_mult;
+	}
 
-	if (bpc->bpc_has_echointerval)
+	if (bpc->bpc_has_echointerval) {
 		bs->timers.required_min_echo = bpc->bpc_echointerval * 1000;
+		bs->peer_profile.min_echo_rx = bs->timers.required_min_echo;
+	}
 
 	if (bpc->bpc_has_label)
 		bfd_session_update_label(bs, bpc->bpc_label);
@@ -570,12 +746,14 @@ static void _bfd_session_update(struct bfd_session *bs,
 	else
 		UNSET_FLAG(bs->flags, BFD_SESS_FLAG_CBIT);
 
+	bs->peer_profile.echo_mode = bpc->bpc_echo;
 	bfd_set_echo(bs, bpc->bpc_echo);
 
 	/*
 	 * Shutdown needs to be the last in order to avoid timers enable when
 	 * the session is disabled.
 	 */
+	bs->peer_profile.admin_shutdown = bpc->bpc_shutdown;
 	bfd_set_shutdown(bs, bpc->bpc_shutdown);
 }
 
@@ -613,6 +791,7 @@ void bfd_session_free(struct bfd_session *bs)
 
 	pl_free(bs->pl);
 
+	XFREE(MTYPE_BFDD_PROFILE, bs->profile_name);
 	XFREE(MTYPE_BFDD_CONFIG, bs);
 }
 
@@ -1070,9 +1249,21 @@ void bfd_set_echo(struct bfd_session *bs, bool echo)
 
 void bfd_set_shutdown(struct bfd_session *bs, bool shutdown)
 {
+	bool is_shutdown;
+
+	/*
+	 * Special case: we are batching changes and the previous state was
+	 * not shutdown. Instead of potentially disconnect a running peer,
+	 * we'll get the current status to validate we were really down.
+	 */
+	if (bs->ses_state == PTM_BFD_UP)
+		is_shutdown = false;
+	else
+		is_shutdown = CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
+
 	if (shutdown) {
 		/* Already shutdown. */
-		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+		if (is_shutdown)
 			return;
 
 		SET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
@@ -1092,7 +1283,7 @@ void bfd_set_shutdown(struct bfd_session *bs, bool shutdown)
 			ptm_bfd_snd(bs, 0);
 	} else {
 		/* Already working. */
-		if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+		if (!is_shutdown)
 			return;
 
 		UNSET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
@@ -1577,6 +1768,7 @@ void bfd_initialize(void)
 				  "BFD session discriminator hash");
 	bfd_key_hash = hash_create(bfd_key_hash_do, bfd_key_hash_cmp,
 				   "BFD session hash");
+	TAILQ_INIT(&bplist);
 }
 
 static void _bfd_free(struct hash_bucket *hb,
@@ -1687,6 +1879,26 @@ static void _bfd_session_remove_manual(struct hash_bucket *hb,
 void bfd_sessions_remove_manual(void)
 {
 	hash_iterate(bfd_key_hash, _bfd_session_remove_manual, NULL);
+}
+
+/*
+ * Profile related hash functions.
+ */
+static void _bfd_profile_update(struct hash_bucket *hb, void *arg)
+{
+	struct bfd_profile *bp = arg;
+	struct bfd_session *bs = hb->data;
+
+	/* This session is not using the profile. */
+	if (bs->profile_name == NULL || strcmp(bs->profile_name, bp->name) != 0)
+		return;
+
+	bfd_profile_apply(bp->name, bs);
+}
+
+void bfd_profile_update(struct bfd_profile *bp)
+{
+	hash_iterate(bfd_key_hash, _bfd_profile_update, bp);
 }
 
 /*

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -192,6 +192,34 @@ struct bfd_session_stats {
 	uint64_t znotification;
 };
 
+/**
+ * BFD session profile to override default configurations.
+ */
+struct bfd_profile {
+	/** Profile name. */
+	char name[64];
+
+	/** Session detection multiplier. */
+	uint8_t detection_multiplier;
+	/** Desired transmission interval (in microseconds). */
+	uint32_t min_tx;
+	/** Minimum required receive interval (in microseconds). */
+	uint32_t min_rx;
+	/** Administrative state. */
+	bool admin_shutdown;
+
+	/** Echo mode (only applies to single hop). */
+	bool echo_mode;
+	/** Minimum required echo receive interval (in microseconds). */
+	uint32_t min_echo_rx;
+
+	/** Profile list entry. */
+	TAILQ_ENTRY(bfd_profile) entry;
+};
+
+/** Profile list type. */
+TAILQ_HEAD(bfdproflist, bfd_profile);
+
 /* bfd_session shortcut label forwarding. */
 struct peer_label;
 
@@ -209,6 +237,13 @@ struct bfd_session {
 	uint8_t remote_detect_mult;
 	uint8_t mh_ttl;
 	uint8_t remote_cbit;
+
+	/** BFD profile name. */
+	char *profile_name;
+	/** BFD pre configured profile. */
+	struct bfd_profile *profile;
+	/** BFD peer configuration (without profile). */
+	struct bfd_profile peer_profile;
 
 	/* Timers */
 	struct bfd_timers timers;
@@ -597,6 +632,57 @@ int bfd_echo_xmt_cb(struct thread *t);
 
 extern struct in6_addr zero_addr;
 
+/**
+ * Creates a new profile entry and insert into the global list.
+ *
+ * \param name the BFD profile name.
+ *
+ * \returns `NULL` if it already exists otherwise the new entry.
+ */
+struct bfd_profile *bfd_profile_new(const char *name);
+
+/**
+ * Search for configured BFD profiles (profile name is case insensitive).
+ *
+ * \param name the BFD profile name.
+ *
+ * \returns `NULL` if it doesn't exist otherwise the entry.
+ */
+struct bfd_profile *bfd_profile_lookup(const char *name);
+
+/**
+ * Removes profile from list and free memory.
+ *
+ * \param bp the BFD profile.
+ */
+void bfd_profile_free(struct bfd_profile *bp);
+
+/**
+ * Apply a profile configuration to an existing BFD session. The non default
+ * values will not be overriden.
+ *
+ * NOTE: if the profile doesn't exist yet, then the profile will be applied
+ * once it begins to exist.
+ *
+ * \param profile_name the BFD profile name.
+ * \param bs the BFD session.
+ */
+void bfd_profile_apply(const char *profname, struct bfd_session *bs);
+
+/**
+ * Remove any applied profile from session and revert the session
+ * configuration.
+ *
+ * \param bs the BFD session.
+ */
+void bfd_profile_remove(struct bfd_session *bs);
+
+/**
+ * Apply new profile values to sessions using it.
+ *
+ * \param[in] bp the BFD profile that got updated.
+ */
+void bfd_profile_update(struct bfd_profile *bp);
 
 /*
  * bfdd_vty.c

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -395,6 +395,33 @@ void bfd_cli_show_echo_interval(struct vty *vty, struct lyd_node *dnode,
 	}
 }
 
+/*
+ * Profile commands.
+ */
+DEFPY_NOSH(bfd_profile, bfd_profile_cmd,
+	   "profile WORD$name",
+	   BFD_PROFILE_STR
+	   BFD_PROFILE_NAME_STR)
+{
+	return CMD_SUCCESS;
+}
+
+DEFPY(no_bfd_profile, no_bfd_profile_cmd,
+      "no profile BFDPROF$name",
+      NO_STR
+      BFD_PROFILE_STR
+      BFD_PROFILE_NAME_STR)
+{
+	return CMD_SUCCESS;
+}
+
+struct cmd_node bfd_profile_node = {
+	.name = "bfd profile",
+	.node = BFD_PROFILE_NODE,
+	.parent_node = BFD_NODE,
+	.prompt = "%s(config-bfd-profile)# ",
+};
+
 void
 bfdd_cli_init(void)
 {
@@ -410,4 +437,11 @@ bfdd_cli_init(void)
 	install_element(BFD_PEER_NODE, &bfd_peer_tx_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_interval_cmd);
+
+	/* Profile commands. */
+	install_node(&bfd_profile_node);
+	install_default(BFD_PROFILE_NODE);
+
+	install_element(BFD_NODE, &bfd_profile_cmd);
+	install_element(BFD_NODE, &no_bfd_profile_cmd);
 }

--- a/bfdd/bfdd_nb.c
+++ b/bfdd/bfdd_nb.c
@@ -41,6 +41,57 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			}
 		},
 		{
+                        .xpath = "/frr-bfdd:bfdd/bfd/profile",
+                        .cbs = {
+                                .create = bfdd_bfd_profile_create,
+                                .destroy = bfdd_bfd_profile_destroy,
+				.cli_show = bfd_cli_show_profile,
+				.cli_show_end = bfd_cli_show_peer_end,
+                        }
+                },
+                {
+                        .xpath = "/frr-bfdd:bfdd/bfd/profile/detection-multiplier",
+                        .cbs = {
+                                .modify = bfdd_bfd_profile_detection_multiplier_modify,
+				.cli_show = bfd_cli_show_mult,
+                        }
+                },
+                {
+                        .xpath = "/frr-bfdd:bfdd/bfd/profile/desired-transmission-interval",
+                        .cbs = {
+                                .modify = bfdd_bfd_profile_desired_transmission_interval_modify,
+				.cli_show = bfd_cli_show_tx,
+                        }
+                },
+                {
+                        .xpath = "/frr-bfdd:bfdd/bfd/profile/required-receive-interval",
+                        .cbs = {
+                                .modify = bfdd_bfd_profile_required_receive_interval_modify,
+				.cli_show = bfd_cli_show_rx,
+                        }
+                },
+                {
+                        .xpath = "/frr-bfdd:bfdd/bfd/profile/administrative-down",
+                        .cbs = {
+                                .modify = bfdd_bfd_profile_administrative_down_modify,
+				.cli_show = bfd_cli_show_shutdown,
+                        }
+                },
+                {
+                        .xpath = "/frr-bfdd:bfdd/bfd/profile/echo-mode",
+                        .cbs = {
+                                .modify = bfdd_bfd_profile_echo_mode_modify,
+				.cli_show = bfd_cli_show_echo,
+                        }
+                },
+                {
+                        .xpath = "/frr-bfdd:bfdd/bfd/profile/desired-echo-transmission-interval",
+                        .cbs = {
+                                .modify = bfdd_bfd_profile_desired_echo_transmission_interval_modify,
+				.cli_show = bfd_cli_show_echo_interval,
+                       }
+                },
+		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop",
 			.cbs = {
 				.create = bfdd_bfd_sessions_single_hop_create,
@@ -59,6 +110,14 @@ const struct frr_yang_module_info frr_bfdd_info = {
 				.destroy = bfdd_bfd_sessions_single_hop_source_addr_destroy,
 			}
 		},
+                {
+                        .xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/profile",
+                        .cbs = {
+                                .modify = bfdd_bfd_sessions_single_hop_profile_modify,
+                                .destroy = bfdd_bfd_sessions_single_hop_profile_destroy,
+				.cli_show = bfd_cli_peer_profile_show,
+                        }
+                },
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/detection-multiplier",
 			.cbs = {
@@ -233,6 +292,14 @@ const struct frr_yang_module_info frr_bfdd_info = {
 				.cli_show_end = bfd_cli_show_peer_end,
 			}
 		},
+                {
+                        .xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/profile",
+                        .cbs = {
+                                .modify = bfdd_bfd_sessions_single_hop_profile_modify,
+                                .destroy = bfdd_bfd_sessions_single_hop_profile_destroy,
+				.cli_show = bfd_cli_peer_profile_show,
+                        }
+                },
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/detection-multiplier",
 			.cbs = {

--- a/bfdd/bfdd_nb.h
+++ b/bfdd/bfdd_nb.h
@@ -28,6 +28,18 @@ extern const struct frr_yang_module_info frr_bfdd_info;
 /* Mandatory callbacks. */
 int bfdd_bfd_create(struct nb_cb_create_args *args);
 int bfdd_bfd_destroy(struct nb_cb_destroy_args *args);
+int bfdd_bfd_profile_create(struct nb_cb_create_args *args);
+int bfdd_bfd_profile_destroy(struct nb_cb_destroy_args *args);
+int bfdd_bfd_profile_detection_multiplier_modify(
+	struct nb_cb_modify_args *args);
+int bfdd_bfd_profile_desired_transmission_interval_modify(
+	struct nb_cb_modify_args *args);
+int bfdd_bfd_profile_required_receive_interval_modify(
+	struct nb_cb_modify_args *args);
+int bfdd_bfd_profile_administrative_down_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_profile_echo_mode_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_profile_desired_echo_transmission_interval_modify(
+	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_create(struct nb_cb_create_args *args);
 int bfdd_bfd_sessions_single_hop_destroy(struct nb_cb_destroy_args *args);
 const void *
@@ -38,6 +50,9 @@ bfdd_bfd_sessions_single_hop_lookup_entry(struct nb_cb_lookup_entry_args *args);
 int bfdd_bfd_sessions_single_hop_source_addr_modify(
 	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_source_addr_destroy(
+	struct nb_cb_destroy_args *args);
+int bfdd_bfd_sessions_single_hop_profile_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_single_hop_profile_destroy(
 	struct nb_cb_destroy_args *args);
 int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(
 	struct nb_cb_modify_args *args);
@@ -187,5 +202,9 @@ void bfd_cli_show_echo(struct vty *vty, struct lyd_node *dnode,
 		       bool show_defaults);
 void bfd_cli_show_echo_interval(struct vty *vty, struct lyd_node *dnode,
 				bool show_defaults);
+void bfd_cli_show_profile(struct vty *vty, struct lyd_node *dnode,
+			  bool show_defaults);
+void bfd_cli_peer_profile_show(struct vty *vty, struct lyd_node *dnode,
+			       bool show_defaults);
 
 #endif /* _FRR_BFDD_NB_H_ */

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -215,6 +215,211 @@ int bfdd_bfd_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
+ * XPath: /frr-bfdd:bfdd/bfd/profile
+ */
+int bfdd_bfd_profile_create(struct nb_cb_create_args *args)
+{
+	struct bfd_profile *bp;
+	const char *name;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	name = yang_dnode_get_string(args->dnode, "./name");
+	bp = bfd_profile_new(name);
+	nb_running_set_entry(args->dnode, bp);
+
+	return NB_OK;
+}
+
+int bfdd_bfd_profile_destroy(struct nb_cb_destroy_args *args)
+{
+	struct bfd_profile *bp;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	bp = nb_running_unset_entry(args->dnode);
+	bfd_profile_free(bp);
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/profile/detection-multiplier
+ */
+int bfdd_bfd_profile_detection_multiplier_modify(struct nb_cb_modify_args *args)
+{
+	struct bfd_profile *bp;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	bp = nb_running_get_entry(args->dnode, NULL, true);
+	bp->detection_multiplier = yang_dnode_get_uint8(args->dnode, NULL);
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/profile/desired-transmission-interval
+ */
+int bfdd_bfd_profile_desired_transmission_interval_modify(
+	struct nb_cb_modify_args *args)
+{
+	struct bfd_profile *bp;
+	uint32_t min_tx;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		min_tx = yang_dnode_get_uint32(args->dnode, NULL);
+		if (min_tx < 10000 || min_tx > 60000000)
+			return NB_ERR_VALIDATION;
+		break;
+
+	case NB_EV_PREPARE:
+		/* NOTHING */
+		break;
+
+	case NB_EV_APPLY:
+		min_tx = yang_dnode_get_uint32(args->dnode, NULL);
+		bp = nb_running_get_entry(args->dnode, NULL, true);
+		if (bp->min_tx == min_tx)
+			return NB_OK;
+
+		bp->min_tx = min_tx;
+		bfd_profile_update(bp);
+		break;
+
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/profile/required-receive-interval
+ */
+int bfdd_bfd_profile_required_receive_interval_modify(
+	struct nb_cb_modify_args *args)
+{
+	struct bfd_profile *bp;
+	uint32_t min_rx;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		min_rx = yang_dnode_get_uint32(args->dnode, NULL);
+		if (min_rx < 10000 || min_rx > 60000000)
+			return NB_ERR_VALIDATION;
+		break;
+
+	case NB_EV_PREPARE:
+		/* NOTHING */
+		break;
+
+	case NB_EV_APPLY:
+		min_rx = yang_dnode_get_uint32(args->dnode, NULL);
+		bp = nb_running_get_entry(args->dnode, NULL, true);
+		if (bp->min_rx == min_rx)
+			return NB_OK;
+
+		bp->min_rx = min_rx;
+		bfd_profile_update(bp);
+		break;
+
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/profile/administrative-down
+ */
+int bfdd_bfd_profile_administrative_down_modify(struct nb_cb_modify_args *args)
+{
+	struct bfd_profile *bp;
+	bool shutdown;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	shutdown = yang_dnode_get_bool(args->dnode, NULL);
+	bp = nb_running_get_entry(args->dnode, NULL, true);
+	if (bp->admin_shutdown == shutdown)
+		return NB_OK;
+
+	bp->admin_shutdown = shutdown;
+	bfd_profile_update(bp);
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/profile/echo-mode
+ */
+int bfdd_bfd_profile_echo_mode_modify(struct nb_cb_modify_args *args)
+{
+	struct bfd_profile *bp;
+	bool echo;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	echo = yang_dnode_get_bool(args->dnode, NULL);
+	bp = nb_running_get_entry(args->dnode, NULL, true);
+	if (bp->echo_mode == echo)
+		return NB_OK;
+
+	bp->echo_mode = echo;
+	bfd_profile_update(bp);
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/profile/desired-echo-echo-transmission-interval
+ */
+int bfdd_bfd_profile_desired_echo_transmission_interval_modify(
+	struct nb_cb_modify_args *args)
+{
+	struct bfd_profile *bp;
+	uint32_t min_rx;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		min_rx = yang_dnode_get_uint32(args->dnode, NULL);
+		if (min_rx < 10000 || min_rx > 60000000)
+			return NB_ERR_VALIDATION;
+		break;
+
+	case NB_EV_PREPARE:
+		/* NOTHING */
+		break;
+
+	case NB_EV_APPLY:
+		min_rx = yang_dnode_get_uint32(args->dnode, NULL);
+		bp = nb_running_get_entry(args->dnode, NULL, true);
+		if (bp->min_echo_rx == min_rx)
+			return NB_OK;
+
+		bp->min_echo_rx = min_rx;
+		bfd_profile_update(bp);
+		break;
+
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop
  */
 int bfdd_bfd_sessions_single_hop_create(struct nb_cb_create_args *args)
@@ -244,6 +449,36 @@ int bfdd_bfd_sessions_single_hop_source_addr_destroy(
 }
 
 /*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/profile
+ */
+int bfdd_bfd_sessions_single_hop_profile_modify(struct nb_cb_modify_args *args)
+{
+	struct bfd_session *bs;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	bs = nb_running_get_entry(args->dnode, NULL, true);
+	bfd_profile_apply(yang_dnode_get_string(args->dnode, NULL), bs);
+
+	return NB_OK;
+}
+
+int bfdd_bfd_sessions_single_hop_profile_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	struct bfd_session *bs;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	bs = nb_running_get_entry(args->dnode, NULL, true);
+	bfd_profile_remove(bs);
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/detection-multiplier
  */
 int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(
@@ -263,6 +498,7 @@ int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(
 	case NB_EV_APPLY:
 		bs = nb_running_get_entry(args->dnode, NULL, true);
 		bs->detect_mult = detection_multiplier;
+		bs->peer_profile.detection_multiplier = detection_multiplier;
 		break;
 
 	case NB_EV_ABORT:
@@ -298,6 +534,7 @@ int bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify(
 			return NB_OK;
 
 		bs->timers.desired_min_tx = tx_interval;
+		bs->peer_profile.min_tx = tx_interval;
 		bfd_set_polling(bs);
 		break;
 
@@ -334,6 +571,7 @@ int bfdd_bfd_sessions_single_hop_required_receive_interval_modify(
 			return NB_OK;
 
 		bs->timers.required_min_rx = rx_interval;
+		bs->peer_profile.min_rx = rx_interval;
 		bfd_set_polling(bs);
 		break;
 
@@ -367,6 +605,7 @@ int bfdd_bfd_sessions_single_hop_administrative_down_modify(
 	}
 
 	bs = nb_running_get_entry(args->dnode, NULL, true);
+	bs->peer_profile.admin_shutdown = shutdown;
 	bfd_set_shutdown(bs, shutdown);
 
 	return NB_OK;
@@ -394,6 +633,7 @@ int bfdd_bfd_sessions_single_hop_echo_mode_modify(
 	}
 
 	bs = nb_running_get_entry(args->dnode, NULL, true);
+	bs->peer_profile.echo_mode = echo;
 	bfd_set_echo(bs, echo);
 
 	return NB_OK;
@@ -425,6 +665,7 @@ int bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify(
 			return NB_OK;
 
 		bs->timers.required_min_echo = echo_interval;
+		bs->peer_profile.min_echo_rx = echo_interval;
 		break;
 
 	case NB_EV_ABORT:

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -417,6 +417,9 @@ static void bfdd_dest_register(struct stream *msg, vrf_id_t vrf_id)
 					"ptm-add-dest: failed to create BFD session");
 			return;
 		}
+
+		/* Protocol created peers are 'no shutdown' by default. */
+		bs->peer_profile.admin_shutdown = false;
 	} else {
 		/* Don't try to change echo/shutdown state. */
 		bpc.bpc_echo = CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -84,6 +84,20 @@ BFDd Commands
 
     Stops and removes the selected peer.
 
+
+.. index:: profile WORD
+.. clicmd:: profile WORD
+
+   Creates a peer profile that can be configured in multiple peers.
+
+
+.. index:: no profile WORD
+.. clicmd:: no profile WORD
+
+   Deletes a peer profile. Any peer using the profile will have their
+   configurations reset to the default values.
+
+
 .. index:: show bfd [vrf NAME] peers [json]
 .. clicmd:: show bfd [vrf NAME] peers [json]
 
@@ -101,8 +115,10 @@ BFDd Commands
 
 .. _bfd-peer-config:
 
-Peer Configurations
--------------------
+Peer / Profile Configuration
+----------------------------
+
+BFD peers and profiles share the same BFD session configuration commands.
 
 .. index:: detect-multiplier (2-255)
 .. clicmd:: detect-multiplier (2-255)
@@ -154,11 +170,30 @@ Peer Configurations
    Enables or disables the peer. When the peer is disabled an
    'administrative down' message is sent to the remote peer.
 
+
+BFD Peer Specific Commands
+--------------------------
+
 .. index:: label WORD
 .. clicmd:: label WORD
 
    Labels a peer with the provided word. This word can be referenced
    later on other daemons to refer to a specific peer.
+
+
+.. index:: profile BFDPROF
+.. clicmd:: profile BFDPROF
+
+   Configure peer to use the profile configurations.
+
+   Notes:
+
+   - Profile configurations can be overriden on a peer basis by specifying
+     new parameters in peer configuration node.
+   - Non existing profiles can be configured and they will only be applied
+     once they start to exist.
+   - If the profile gets updated the new configuration will be applied to all
+     peers with the profile without interruptions.
 
 
 .. _bfd-bgp-peer-config:
@@ -292,6 +327,24 @@ Here are the available peer configurations:
 ::
 
    bfd
+    ! Configure a fast profile
+    profile fast
+     receive-interval 150
+     transmit-interval 150
+    !
+
+    ! Configure peer with fast profile
+    peer 192.168.0.6
+     profile fast
+     no shutdown
+    !
+
+   ! Configure peer with fast profile and override receive speed.
+    peer 192.168.0.7
+     profile fast
+     receive-interval 500
+     no shutdown
+    !
 
     ! configure a peer on an specific interface
     peer 192.168.0.1 interface eth0

--- a/lib/command.c
+++ b/lib/command.c
@@ -836,6 +836,9 @@ enum node_type node_parent(enum node_type node)
 	case BFD_PEER_NODE:
 		ret = BFD_NODE;
 		break;
+	case BFD_PROFILE_NODE:
+		ret = BFD_NODE;
+		break;
 	default:
 		ret = CONFIG_NODE;
 		break;

--- a/lib/command.h
+++ b/lib/command.h
@@ -155,6 +155,7 @@ enum node_type {
 	BGP_FLOWSPECV6_NODE,	/* BGP IPv6 FLOWSPEC Address-Family */
 	BFD_NODE,		 /* BFD protocol mode. */
 	BFD_PEER_NODE,		 /* BFD peer configuration mode. */
+	BFD_PROFILE_NODE,	 /* BFD profile configuration mode. */
 	OPENFABRIC_NODE,	/* OpenFabric router configuration node */
 	VRRP_NODE,		 /* VRRP node */
 	BMP_NODE,		/* BMP config under router bgp */
@@ -403,6 +404,8 @@ struct cmd_node {
 #define WATCHFRR_STR "watchfrr information\n"
 #define ZEBRA_STR "Zebra information\n"
 #define FILTER_LOG_STR "Filter Logs\n"
+#define BFD_PROFILE_STR "BFD profile.\n"
+#define BFD_PROFILE_NAME_STR "BFD profile name.\n"
 
 #define CMD_VNI_RANGE "(1-16777215)"
 #define CONF_BACKUP_EXT ".sav"

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1492,6 +1492,13 @@ static struct cmd_node bfd_peer_node = {
 	.parent_node = BFD_NODE,
 	.prompt = "%s(config-bfd-peer)# ",
 };
+
+static struct cmd_node bfd_profile_node = {
+	.name = "bfd profile",
+	.node = BFD_PROFILE_NODE,
+	.parent_node = BFD_NODE,
+	.prompt = "%s(config-bfd-profile)# ",
+};
 #endif /* HAVE_BFDD */
 
 /* Defined in lib/vty.c */
@@ -1945,6 +1952,15 @@ DEFUNSH(VTYSH_BFDD, bfd_peer_enter, bfd_peer_enter_cmd,
 	"Configure VRF name\n")
 {
 	vty->node = BFD_PEER_NODE;
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_BFDD, bfd_profile_enter, bfd_profile_enter_cmd,
+	"profile WORD",
+	BFD_PROFILE_STR
+	BFD_PROFILE_NAME_STR)
+{
+	vty->node = BFD_PROFILE_NODE;
 	return CMD_SUCCESS;
 }
 #endif /* HAVE_BFDD */
@@ -3796,6 +3812,7 @@ void vtysh_init_vty(void)
 #if HAVE_BFDD > 0
 	install_node(&bfd_node);
 	install_node(&bfd_peer_node);
+	install_node(&bfd_profile_node);
 #endif /* HAVE_BFDD */
 
 	struct cmd_node *node;
@@ -3897,16 +3914,20 @@ void vtysh_init_vty(void)
 	/* Enter node. */
 	install_element(CONFIG_NODE, &bfd_enter_cmd);
 	install_element(BFD_NODE, &bfd_peer_enter_cmd);
+	install_element(BFD_NODE, &bfd_profile_enter_cmd);
 
 	/* Exit/quit node. */
 	install_element(BFD_NODE, &vtysh_exit_bfdd_cmd);
 	install_element(BFD_NODE, &vtysh_quit_bfdd_cmd);
 	install_element(BFD_PEER_NODE, &vtysh_exit_bfdd_cmd);
 	install_element(BFD_PEER_NODE, &vtysh_quit_bfdd_cmd);
+	install_element(BFD_PROFILE_NODE, &vtysh_exit_bfdd_cmd);
+	install_element(BFD_PROFILE_NODE, &vtysh_quit_bfdd_cmd);
 
 	/* End/exit all. */
 	install_element(BFD_NODE, &vtysh_end_all_cmd);
 	install_element(BFD_PEER_NODE, &vtysh_end_all_cmd);
+	install_element(BFD_PROFILE_NODE, &vtysh_end_all_cmd);
 #endif /* HAVE_BFDD */
 	install_element(VTY_NODE, &vtysh_exit_line_vty_cmd);
 	install_element(VTY_NODE, &vtysh_quit_line_vty_cmd);

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -139,6 +139,21 @@ module frr-bfdd {
     }
   }
 
+  typedef profile-name {
+    type string {
+      length "1..64";
+    }
+    description "Profile name format";
+  }
+
+  typedef profile-ref {
+    type leafref {
+      path "/frr-bfdd:bfdd/frr-bfdd:bfd/frr-bfdd:profile/frr-bfdd:name";
+      require-instance false;
+    }
+    description "Reference to a BFD profile";
+  }
+
   /*
    * Shared BFD items.
    */
@@ -337,6 +352,19 @@ module frr-bfdd {
     container bfd {
       presence "Present if the BFD protocol is enabled";
 
+      list profile {
+        key "name";
+        description "BFD pre configuration profiles";
+
+        leaf name {
+          type profile-name;
+          description "Profile name";
+        }
+
+        uses session-common;
+        uses session-echo;
+      }
+
       container sessions {
         list single-hop {
           key "dest-addr interface vrf";
@@ -362,6 +390,11 @@ module frr-bfdd {
           leaf source-addr {
             type inet:ip-address;
             description "Local IP address";
+          }
+
+          leaf profile {
+            type profile-ref;
+            description "Override defaults with profile.";
           }
 
           uses session-common;
@@ -397,6 +430,11 @@ module frr-bfdd {
           leaf vrf {
             type string;
             description "Virtual Routing Domain name";
+          }
+
+          leaf profile {
+            type profile-ref;
+            description "Override defaults with profile.";
           }
 
           uses session-common;


### PR DESCRIPTION
## Summary

Since FRR imported the BFD daemon (`bfdd`) we migrated the peer configuration to the BFD node:

```
bfd
 peer 192.168.0.2
  no shutdown
 !
!
```

The protocol integration, however, does not require a peer configuration to exist in the BFD node, so we have protocol configurations like this:

```
router bgp 100
 neighbor 192.168.0.2 remote-as 100
 neighbor 192.168.0.2 bfd
!
```

I observed that some users will skip the BFD node entirely first and then come back to configure the peers individually and some might not even be able to configure the peers first because they might have dynamic setup (peers get detected on run time like OSPF or unnumbered BGP).

In order to address the issue of not knowning the peers before hand or having to repeat the same configuration for multiple peers I've implemented a BFD configuration profile. The profiles let you configure the BFD session parameters even before having the peers (or vice versa: configure the peers with the profile without having the profile created).

Here is how it will look like:

```
interface eth0
 ip ospf bfd profile slowpeer
!
router bgp 100
 neighbor 192.168.0.2 remote-as 100
 neighbor 192.168.0.2 bfd profile fastpeer
 neighbor 192.168.0.3 remote-as 100
 neighbor 192.168.0.3 bfd profile fastpeer
!
bfd
 profile fastpeer
  receive-interval 150
  transmit-interval 150
 !
 profile slowpeer
  receive-interval 800
  transmit-interval 800
 !
 peer 192.168.0.2
  ! this peer uses the profile configuration and uses echo-mode.
  echo-mode
 !
!
```

This PR only implements the first part: the BFD daemon support and the BFD YANG model support.

After this PR there will be a PR for `bgpd`, `ospfd`, `ospf6d`, `isisd` and `pimd`.