### PR TITLE
tools: frr-reload.py must use python2

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Frr Reloader
 # Copyright (C) 2014 Cumulus Networks, Inc.
 #


### PR DESCRIPTION
Use python2 explicitly in frr-reload.py - on ubuntu 20 for example, "python" is now python3.
