### PR TITLE
vtysh: return success from "no vrf" when VRF doesn't exist

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -758,10 +758,8 @@ DEFUN (no_vrf,
 
 	vrfp = vrf_lookup_by_name(vrfname);
 
-	if (vrfp == NULL) {
-		vty_out(vty, "%% VRF %s does not exist\n", vrfname);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
+	if (vrfp == NULL)
+		return CMD_SUCCESS;
 
 	if (CHECK_FLAG(vrfp->status, VRF_ACTIVE)) {
 		vty_out(vty, "%% Only inactive VRFs can be deleted\n");


### PR DESCRIPTION
It is possible that the same VRF exists in one daemon and doesn't exist
in another. In this case, "no vrf NAME" command execution will stop on
the first daemon without the VRF and it won't be possible to delete the
VRF from other daemons.

Such behavior can be reproduced with the following steps:
```
# ip link add test type vrf table 1
# vtysh -c "conf t" -c "vrf test" -c "ip route 1.1.1.1/32 blackhole"
# vtysh -c "show run"
...
vrf test
 ip route 1.1.1.1/32 blackhole
 exit-vrf
!
...
# ip link del test
# vtysh -c "conf t" -c "no vrf test"
% VRF test does not exist
# vtysh -c "show run"
...
vrf test
 ip route 1.1.1.1/32 blackhole
 exit-vrf
!
...
```

This commit fixes the issue by sending "no vrf" command to all daemons
despite the "VRF does not exist" error from other daemons.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>