### PR TITLE
*: Protocol Key Encryption

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@ AM_CFLAGS = \
 	$(SQLITE3_CFLAGS) \
 	$(UNWIND_CFLAGS) \
 	$(SAN_FLAGS) \
+	$(LIBRESSL_CFLAGS) \
 	$(WERROR) \
 	# end
 AM_CPPFLAGS = \

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -841,6 +841,9 @@ int bgp_vty_return(struct vty *vty, int ret)
 	case BGP_GR_NO_OPERATION:
 		str = GR_NO_OPER;
 		break;
+	case BGP_ERR_CRYPTO_FAILED:
+		str = "Cryptographic operation failed";
+		break;
 	}
 	if (str) {
 		vty_out(vty, "%% %s\n", str);
@@ -4850,26 +4853,51 @@ DEFUN (no_neighbor_solo,
 	return bgp_vty_return(vty, ret);
 }
 
-DEFUN_YANG(neighbor_password,
-	   neighbor_password_cmd,
-	   "neighbor <A.B.C.D|X:X::X:X|WORD> password LINE",
-	   NEIGHBOR_STR NEIGHBOR_ADDR_STR2
-	   "Set a password\n"
-	   "The password\n")
+DEFUN (neighbor_password,
+       neighbor_password_cmd,
+       "neighbor <A.B.C.D|X:X::X:X|WORD> password [101] LINE",
+       NEIGHBOR_STR
+       NEIGHBOR_ADDR_STR2
+       "Set a password\n"
+       "Encrypted password follows\n"
+       "The password\n")
 {
 	int idx_peer = 1;
 	int idx_line = 3;
+	int idx_101 = 0;
+	int ret;
+	bool is_encrypted = false;
 	char base_xpath[XPATH_MAXLEN];
+
+	if (argv_find(argv, argc, "101", &idx_101)) {
+		is_encrypted = true;
+		idx_line = idx_101 + 1;
+	}
 
 	if (peer_and_group_lookup_nb(vty, argv[idx_peer]->arg, base_xpath,
 				     sizeof(base_xpath), NULL)
 	    < 0)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	nb_cli_enqueue_change(vty, "./password", NB_OP_MODIFY,
-			      argv[idx_line]->arg);
+	if (is_encrypted) {
+		char *password = argv[idx_line]->arg;
+		char *pw;
+		size_t len;
 
-	return nb_cli_apply_changes(vty, base_xpath);
+		len = 4 + strlen(password) + 1;
+		pw = XMALLOC(MTYPE_TMP, len);
+		strlcpy(pw, "101 ", len);
+		strlcat(pw, password, len);
+		nb_cli_enqueue_change(vty, "./password", NB_OP_MODIFY, pw);
+		ret = nb_cli_apply_changes(vty, base_xpath);
+		XFREE(MTYPE_TMP, pw);
+	} else {
+		nb_cli_enqueue_change(vty, "./password", NB_OP_MODIFY,
+				      argv[idx_line]->arg);
+
+		ret =  nb_cli_apply_changes(vty, base_xpath);
+	}
+	return ret;
 }
 
 DEFUN_YANG(no_neighbor_password,
@@ -16467,9 +16495,20 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 	}
 
 	/* password */
-	if (peergroup_flag_check(peer, PEER_FLAG_PASSWORD))
-		vty_out(vty, " neighbor %s password %s\n", addr,
-			peer->password);
+	if (peer->password_encrypted) {
+		if (!peergroup_flag_check(peer, PEER_FLAG_PASSWORD)) {
+			vty_out(vty,
+				"!!! Error: Unable to decrypt the following string\n");
+		}
+		/* save encrypted password even if unable to decrypt earlier */
+		vty_out(vty, " neighbor %s password 101 %s\n", addr,
+			peer->password_encrypted);
+	} else {
+		if (peergroup_flag_check(peer, PEER_FLAG_PASSWORD)) {
+			vty_out(vty, " neighbor %s password %s\n", addr,
+				peer->password);
+		}
+	}
 
 	/* neighbor solo */
 	if (CHECK_FLAG(peer->flags, PEER_FLAG_LONESOUL)) {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1239,6 +1239,7 @@ struct peer {
 
 	/* MD5 password */
 	char *password;
+	char *password_encrypted; /* for cfg files and console */
 
 	/* default-originate route-map.  */
 	struct {
@@ -1776,6 +1777,8 @@ enum bgp_clear_type {
 #define BGP_ERR_GR_OPERATION_FAILED             -37
 #define BGP_GR_NO_OPERATION                     -38
 
+#define BGP_ERR_CRYPTO_FAILED -39
+
 /*
  * Enumeration of different policy kinds a peer can be configured with.
  */
@@ -2009,8 +2012,10 @@ extern int peer_advertise_map_set(struct peer *peer, afi_t afi, safi_t safi,
 				  struct route_map *condition_map,
 				  bool condition);
 
-extern int peer_password_set(struct peer *, const char *);
-extern int peer_password_unset(struct peer *);
+extern int peer_password_set(struct peer *peer, const char *password_in,
+			     bool is_encrypted,
+			     const char **ppCryptoErrorString);
+extern int peer_password_unset(struct peer *peer);
 
 extern int peer_unsuppress_map_unset(struct peer *, afi_t, safi_t);
 

--- a/configure.ac
+++ b/configure.ac
@@ -664,24 +664,98 @@ AC_ARG_ENABLE([memory-sanitizer],
 AC_ARG_ENABLE([undefined-sanitizer],
   AS_HELP_STRING([--undefined-sanitizer], [enable UndefinedBehaviorSanitizer support for detecting undefined behavior]))
 AC_ARG_WITH([crypto],
-  AS_HELP_STRING([--with-crypto=<internal|openssl>], [choose between different implementations of cryptographic functions(default value is --with-crypto=internal)]))
+  AS_HELP_STRING([--with-crypto=<internal|openssl|libressl>], [choose between different implementations of cryptographic functions (default value is --with-crypto=openssl) May also need PKG_CONFIG_PATH]))
 AC_ARG_WITH([frr-format],
   AS_HELP_STRING([--with-frr-format[=<.../frr-format.so>]], [use frr-format GCC plugin]))
 
 AC_ARG_ENABLE([version-build-config],
   AS_HELP_STRING([--disable-version-build-config], [do not include build configs in show version command]))
 
+#
+# May, 2020:
+# There has been some semantic drift of the term "crypto" as applied to FRR.
+# The original meaning seems to have applied to MD5 hashing functions only.
+# Now, we are also selecting a crypto library to use for RSA encryption.
+#
+# Further complicating matters, we now optionally support using the
+# libressl library. Libressl is a clone of openssl with almost the
+# same API and the same library/module names. They can not both be
+# installed in the default system location at the same time. The
+# significant difference detectable by the configure script is that
+# the version number of # openssl is 1.x whereas the version number
+# of libressl is 3.x
+#
+# To get this configure script to find a library (e.g., libressl) that
+# is installed in a non-standard location, specify the directory
+# containing the library's pkgconfig (.pc) file with PKG_CONFIG_PATH.
+# Example:
+#
+#	./configure PKG_CONFIG_PATH=/opt/libressl-3.1.1/lib/pkgconfig
+#
+# We will retain the original flags/semantics to avoid disrupting
+# the MD5-related code:
+#
+#	CRYPTO_INTERNAL		use internal MD5 (same as before)
+#	CRYPTO_OPENSSL		use openssl/libressl MD5 (same as before)
+#
+# We will add new flags. Zero, one, or more of these flags may be set:
+#
+#	HAVE_OPENSSL		libressl library found
+#	HAVE_LIBRESSL		libressl library found
+#	HAVE_GCRYPT		gcrypt library found
+#	HAVE_GNUTLS		gnutls library found
+#
+#
+
 #if openssl, else use the internal
-AS_IF([test "$with_crypto" = "openssl"], [
-AC_CHECK_LIB([crypto], [EVP_DigestInit], [LIBS="$LIBS -lcrypto"], [], [])
-if test "$ac_cv_lib_crypto_EVP_DigestInit" = "no"; then
-  AC_MSG_ERROR([build with openssl has been specified but openssl library was not found on your system])
-else
-  AC_DEFINE([CRYPTO_OPENSSL], [1], [Compile with openssl support])
+found_openssl_like="no"
+if test "$with_crypto" = "libressl" ; then
+   # NB the following PKG_CHECK_MODULES will cause LIBRESSL_LIBS and
+   # LIBRESSL_CFLAGS to be defined for Makefiles
+   PKG_CHECK_MODULES([LIBRESSL], [libcrypto >= 3], [
+      found_openssl_like="yes"
+      AC_DEFINE([HAVE_LIBRESSL], [1], [Compile with libressl cryptographic support])
+   ],[])
+   if test "$found_openssl_like" = "no" ; then
+      AC_MSG_ERROR([configuration specifies --with-crypto=libressl but libressl flavor of libcrypto not found])
+   fi
 fi
-], [test "$with_crypto" = "internal" || test "$with_crypto" = "" ], [AC_DEFINE([CRYPTO_INTERNAL], [1], [Compile with internal cryptographic implementation])
-], [AC_MSG_ERROR([Unknown value for --with-crypto])]
-)
+if test "$with_crypto" = "openssl" ; then
+   PKG_CHECK_MODULES([OPENSSL], [libcrypto < 2], [
+      found_openssl_like="yes"
+      AC_DEFINE([HAVE_OPENSSL], [1], [Compile with openssl cryptographic support])
+   ],[])
+   if test "$found_openssl_like" = "no" ; then
+      AC_MSG_ERROR([configuration specifies --with-crypto=openssl but openssl flavor of libcrypto not found])
+   fi
+fi
+
+if test "$found_openssl_like" = "yes" ; then
+   AC_CHECK_LIB([crypto], [PEM_read_bio_PrivateKey], [], [found_openssl_like=no], [])
+   AC_CHECK_LIB([crypto], [EVP_MD_CTX_new], [] , [found_openssl_like=no], [])
+   AC_CHECK_LIB([crypto], [EVP_DigestInit], [] , [found_openssl_like=no], [])
+   if test "$found_openssl_like" = "yes" ; then
+      LIBS="$LIBS -lcrypto"
+      AC_DEFINE([CRYPTO_OPENSSL], [1], [Compile with openssl/libressl cryptographic support])
+   else
+      AC_MSG_ERROR([configuration specifies --with-crypto=openssl|libressl but required symbols not found])
+   fi
+fi
+if test "$found_openssl_like" = "no" ; then
+   AC_DEFINE([CRYPTO_INTERNAL], [1], [Compile with internal cryptographic implementation])
+fi
+
+AC_CHECK_LIB([gcrypt], [gcry_sexp_build], [have_gcrypt=yes], [have_gcrypt=no], [])
+if test "$have_gcrypt" = "yes" ; then
+   LIBS="$LIBS -lgcrypt"
+   AC_DEFINE([HAVE_GCRYPT], [1], [Compile with gcrypt cryptographic support])
+fi
+
+AC_CHECK_LIB([gnutls], [gnutls_x509_privkey_import2], [have_gnutls=yes], [have_gnutls=no], [])
+if test "$have_gnutls" = "yes" ; then
+   LIBS="$LIBS -lgnutls"
+   AC_DEFINE([HAVE_GNUTLS], [1], [Compile with gnutls cryptographic support])
+fi
 
 AS_IF([test "$enable_clippy_only" != "yes"], [
 AC_CHECK_HEADERS([json-c/json.h])

--- a/doc/developer/building-frr-for-centos6.rst
+++ b/doc/developer/building-frr-for-centos6.rst
@@ -130,6 +130,18 @@ Install libyang and its dependencies:
    sudo yum install ./rpms/RPMS/x86_64/libyang-0.16.111-0.x86_64.rpm ./rpms/RPMS/x86_64/libyang-devel-0.16.111-0.x86_64.rpm
    cd ../..
 
+Install newer version openssl (Package versions are too old):
+
+.. code-block:: shell
+
+   wget https://www.openssl.org/source/old/1.1.1/openssl-1.1.1e.tar.gz
+   tar zxvf openssl-1.1.1e.tar.gz
+   cd openssl-1.1.1e
+   ./config --prefix=/usr
+   make
+   sudo make install
+   cd ..
+
 Get FRR, compile it and install it (from Git)
 ---------------------------------------------
 
@@ -174,6 +186,7 @@ an example.)
         --disable-exampledir \
         --disable-ldpd \
         --enable-fpm \
+        --with-crypto=openssl \
         --with-pkg-git-version \
         --with-pkg-extra-version=-MyOwnFRRVersion
     make

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1482,14 +1482,18 @@ Configuring Peers
 .. index:: neighbor PEER port PORT
 .. clicmd:: neighbor PEER port PORT
 
-.. index:: neighbor PEER password PASSWORD
-.. clicmd:: [no] neighbor PEER password PASSWORD
+.. index:: neighbor PEER [101] password PASSWORD
+.. clicmd:: [no] neighbor PEER [101] password PASSWORD
 
    Set a MD5 password to be used with the tcp socket that is being used
    to connect to the remote peer.  Please note if you are using this
    command with a large number of peers on linux you should consider
    modifying the `net.core.optmem_max` sysctl to a larger value to
    avoid out of memory errors from the linux kernel.
+
+   The optional "101" keyword indicates that the password is in encrypted
+   form. Encrypted passwords are encoded in base64. Please see
+   :ref:`protocol-key-encryption` for further details.
 
 .. index:: neighbor PEER send-community
 .. clicmd:: neighbor PEER send-community

--- a/doc/user/ldpd.rst
+++ b/doc/user/ldpd.rst
@@ -134,13 +134,17 @@ LDP Configuration
    the IPv4 or IPv6 transport-address used by the LDP protocol to talk on this
    interface.
 
-.. index:: neighbor A.B.C.D password PASSWORD
-.. clicmd:: [no] neighbor A.B.C.D password PASSWORD
+.. index:: neighbor A.B.C.D password [101] PASSWORD
+.. clicmd:: [no] neighbor A.B.C.D password [101] PASSWORD
 
    The following command located under MPLS router node configures the router
    of a LDP device. This device, if found, will have to comply with the
    configured password. PASSWORD is a clear text password wit its digest sent
    through the network.
+
+   The optional "101" keyword indicates that the password is in encrypted
+   form. Encrypted passwords are encoded in base64. Please see
+   :ref:`protocol-key-encryption` for further details.
 
 .. index:: neighbor A.B.C.D holdtime HOLDTIME
 .. clicmd:: [no] neighbor A.B.C.D holdtime HOLDTIME

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -580,14 +580,18 @@ Interfaces
    If you have a lot of interfaces, and/or a lot of subnets, then enabling OSPF
    via this command may result in a slight performance improvement.
 
-.. index:: ip ospf authentication-key AUTH_KEY
-.. clicmd:: ip ospf authentication-key AUTH_KEY
+.. index:: ip ospf authentication-key [101] AUTH_KEY
+.. clicmd:: ip ospf authentication-key [101] AUTH_KEY
 
 .. index:: ip ospf authentication-key
 .. clicmd:: no ip ospf authentication-key
 
    Set OSPF authentication key to a simple password. After setting `AUTH_KEY`,
    all OSPF packets are authenticated. `AUTH_KEY` has length up to 8 chars.
+
+   The optional "101" keyword indicates that the password is in encrypted
+   form. Encrypted passwords are encoded in base64. Please see
+   :ref:`protocol-key-encryption` for further details.
 
    Simple text password authentication is insecure and deprecated in favour of
    MD5 HMAC authentication.
@@ -609,8 +613,8 @@ Interfaces
    non-volatile storage and restored at boot if MD5 authentication is to be
    expected to work reliably.
 
-.. index:: ip ospf message-digest-key KEYID md5 KEY
-.. clicmd:: ip ospf message-digest-key KEYID md5 KEY
+.. index:: ip ospf message-digest-key KEYID md5 [101] KEY
+.. clicmd:: ip ospf message-digest-key KEYID md5 [101] KEY
 
 .. index:: ip ospf message-digest-key
 .. clicmd:: no ip ospf message-digest-key
@@ -623,6 +627,10 @@ Interfaces
 
    KEY is the actual message digest key, of up to 16 chars (larger strings will
    be truncated), and is associated with the given KEYID.
+
+   The optional "101" keyword indicates that the message digest key
+   is in encrypted form. Encrypted passwords are encoded in base64.
+   Please see :ref:`protocol-key-encryption` for further details.
 
 .. index:: ip ospf cost (1-65535)
 .. clicmd:: ip ospf cost (1-65535)

--- a/doc/user/ripd.rst
+++ b/doc/user/ripd.rst
@@ -552,14 +552,18 @@ To prevent such unauthenticated querying of routes disable RIPv1,
 
    Set the interface with RIPv2 simple password authentication.
 
-.. index:: ip rip authentication string STRING
-.. clicmd:: ip rip authentication string STRING
+.. index:: ip rip authentication string [101] STRING
+.. clicmd:: ip rip authentication string [101] STRING
 
-.. index:: ip rip authentication string STRING
-.. clicmd:: no ip rip authentication string STRING
+.. index:: ip rip authentication string [101] STRING
+.. clicmd:: no ip rip authentication string [101] STRING
 
    RIP version 2 has simple text authentication. This command sets
    authentication string. The string must be shorter than 16 characters.
+
+   The optional "101" keyword indicates that the authentication string
+   is in encrypted form. Encrypted strings are encoded in base64. Please
+   see :ref:`protocol-key-encryption` for further details.
 
 .. index:: ip rip authentication key-chain KEY-CHAIN
 .. clicmd:: ip rip authentication key-chain KEY-CHAIN

--- a/ldpd/ldp_vty.h
+++ b/ldpd/ldp_vty.h
@@ -33,6 +33,8 @@ extern struct cmd_node ldp_debug_node;
 
 union ldpd_addr;
 int	 ldp_get_address(const char *, int *, union ldpd_addr *);
+void ldpd_keycrypt_encryption_show_status(struct vty *, const char *);
+void ldpd_keycrypt_state_change(bool);
 int	 ldp_vty_mpls_ldp (struct vty *, const char *);
 int	 ldp_vty_address_family (struct vty *, const char *, const char *);
 int	 ldp_vty_disc_holdtime(struct vty *, const char *, enum hello_type, long);
@@ -53,7 +55,8 @@ int	 ldp_vty_ordered_control(struct vty *, const char *);
 int	 ldp_vty_wait_for_sync_interval(struct vty *, const char *, long);
 int	 ldp_vty_ds_cisco_interop(struct vty *, const char *);
 int	 ldp_vty_trans_pref_ipv4(struct vty *, const char *);
-int	 ldp_vty_neighbor_password(struct vty *, const char *, struct in_addr, const char *);
+int ldp_vty_neighbor_password(struct vty *, const char *, struct in_addr,
+			      const char *, bool);
 int	 ldp_vty_neighbor_ttl_security(struct vty *, const char *, struct in_addr, const char *);
 int	 ldp_vty_l2vpn(struct vty *, const char *, const char *);
 int	 ldp_vty_l2vpn_bridge(struct vty *, const char *, const char *);

--- a/ldpd/ldp_vty_cmds.c
+++ b/ldpd/ldp_vty_cmds.c
@@ -174,14 +174,22 @@ DEFPY  (ldp_dual_stack_cisco_interop,
 
 DEFPY  (ldp_neighbor_password,
 	ldp_neighbor_password_cmd,
-	"[no] neighbor A.B.C.D$neighbor password WORD$password",
+	"[no] neighbor A.B.C.D$neighbor password [101] WORD$password",
 	NO_STR
 	"Configure neighbor parameters\n"
 	"LDP Id of neighbor\n"
 	"Configure password for MD5 authentication\n"
+	"Encrypted password follows\n"
 	"The password\n")
 {
-	return (ldp_vty_neighbor_password(vty, no, neighbor, password));
+	int idx_101 = 0;
+	bool is_encrypted = false;
+
+	if (argv_find(argv, argc, "101", &idx_101))
+		is_encrypted = true;
+
+	return (ldp_vty_neighbor_password(vty, no, neighbor, password,
+					  is_encrypted));
 }
 
 DEFPY  (ldp_neighbor_session_holdtime,

--- a/ldpd/ldp_vty_conf.c
+++ b/ldpd/ldp_vty_conf.c
@@ -29,6 +29,9 @@
 #include "if.h"
 #include "vty.h"
 #include "ldp_vty.h"
+#include "libfrr.h"
+#include "memory.h"
+#include "keycrypt.h"
 
 static int	 ldp_config_write(struct vty *);
 static void	 ldp_af_iface_config_write(struct vty *, int);
@@ -303,9 +306,22 @@ ldp_config_write(struct vty *vty)
 				vty_out (vty, " neighbor %pI4 ttl-security disable\n",&nbrp->lsr_id);
 		}
 
-		if (nbrp->auth.method == AUTH_MD5SIG)
-			vty_out (vty, " neighbor %pI4 password %s\n",
-			    &nbrp->lsr_id,nbrp->auth.md5key);
+		if (nbrp->auth.method == AUTH_MD5SIG) {
+			const char *pfx;
+			char *str;
+			if (nbrp->auth.md5key_encrypted[0]) {
+				if (!nbrp->auth.md5key[0])
+					vty_out(vty,
+						"!!! Error: Unable to decrypt the following string\n");
+				pfx = "101 ";
+				str = nbrp->auth.md5key_encrypted;
+			} else {
+				pfx = "";
+				str = nbrp->auth.md5key;
+			}
+			vty_out(vty, " neighbor %pI4 password %s%s\n",
+				&nbrp->lsr_id, pfx, str);
+		}
 	}
 
 	ldp_af_config_write(vty, AF_INET, ldpd_conf, &ldpd_conf->ipv4);
@@ -314,6 +330,74 @@ ldp_config_write(struct vty *vty)
 	vty_out (vty, "!\n");
 
 	return (1);
+}
+
+void ldpd_keycrypt_encryption_show_status(struct vty *vty,
+					  const char *indentstr)
+{
+	struct nbr_params *nbrp;
+	uint md5_keys = 0;
+	uint md5_keys_encrypted = 0;
+
+	RB_FOREACH (nbrp, nbrp_head, &ldpd_conf->nbrp_tree) {
+		if (nbrp->auth.method == AUTH_MD5SIG) {
+			if (nbrp->auth.md5key_encrypted[0])
+				++md5_keys_encrypted;
+			if (nbrp->auth.md5key[0])
+				++md5_keys;
+		}
+	}
+
+	vty_out(vty, "%s%s: neighbor passwords: %u, encrypted: %u\n", indentstr,
+		frr_protoname, md5_keys, md5_keys_encrypted);
+}
+
+void ldpd_keycrypt_state_change(bool now_encrypting)
+{
+	/*
+	 * change from encrypting to non-encrypting has no effect on
+	 * previously-encrypted protocol keys: they remain encrypted.
+	 */
+	if (!now_encrypting)
+		return;
+
+	struct nbr_params *nbrp;
+
+	RB_FOREACH (nbrp, nbrp_head, &ldpd_conf->nbrp_tree) {
+
+		char *pCryptText;
+		size_t CryptTextLen;
+
+		/* skip if we already have an encrypted string */
+		if (nbrp->auth.md5key_encrypted[0])
+			continue;
+
+		/* skip if there is no cleartext string to encrypt */
+		if (!nbrp->auth.md5key[0])
+			continue;
+
+		if (keycrypt_encrypt(nbrp->auth.md5key,
+				     strlen(nbrp->auth.md5key), &pCryptText,
+				     &CryptTextLen)) {
+
+			zlog_err("%s: can't encrypt neighbor password for %pI4",
+				 __func__, &nbrp->lsr_id);
+		} else {
+			/* encrypt success */
+			if (CryptTextLen
+			    <= sizeof(nbrp->auth.md5key_encrypted)) {
+				strlcpy(nbrp->auth.md5key_encrypted, pCryptText,
+					sizeof(nbrp->auth.md5key_encrypted));
+			} else {
+				zlog_err(
+					"%s: can't store encrypted neighbor password"
+					": too big (%zu > %zu)",
+					__func__, CryptTextLen,
+					sizeof(nbrp->auth.md5key_encrypted));
+			}
+			XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pCryptText);
+		}
+	}
 }
 
 static void
@@ -1062,9 +1146,9 @@ ldp_vty_trans_pref_ipv4(struct vty *vty, const char *negate)
 	return (CMD_SUCCESS);
 }
 
-int
-ldp_vty_neighbor_password(struct vty *vty, const char *negate, struct in_addr lsr_id,
-    const char *password_str)
+int ldp_vty_neighbor_password(struct vty *vty, const char *negate,
+			      struct in_addr lsr_id, const char *password_str,
+			      bool is_encrypted)
 {
 	size_t			 password_len;
 	struct nbr_params	*nbrp;
@@ -1088,20 +1172,72 @@ ldp_vty_neighbor_password(struct vty *vty, const char *negate, struct in_addr ls
 		memset(&nbrp->auth, 0, sizeof(nbrp->auth));
 		nbrp->auth.method = AUTH_NONE;
 	} else {
+		char *passwdPlain;
+		char *passwdCrypt;
+		enum keycrypt_err krc;
+
 		if (nbrp == NULL) {
 			nbrp = nbr_params_new(lsr_id);
 			RB_INSERT(nbrp_head, &vty_conf->nbrp_tree, nbrp);
 			QOBJ_REG(nbrp, nbr_params);
-		} else if (nbrp->auth.method == AUTH_MD5SIG &&
-		    strcmp(nbrp->auth.md5key, password_str) == 0)
-			return (CMD_SUCCESS);
+		}
 
-		password_len = strlcpy(nbrp->auth.md5key, password_str,
-		    sizeof(nbrp->auth.md5key));
-		if (password_len >= sizeof(nbrp->auth.md5key))
-			vty_out(vty, "%% password has been truncated to %zu characters.", sizeof(nbrp->auth.md5key) - 1);
-		nbrp->auth.md5key_len = strlen(nbrp->auth.md5key);
-		nbrp->auth.method = AUTH_MD5SIG;
+		krc = keycrypt_build_passwords(password_str, is_encrypted,
+					       MTYPE_TMP, &passwdPlain,
+					       &passwdCrypt);
+		if (krc) {
+			zlog_err("%s: %s", __func__, keycrypt_strerror(krc));
+		}
+
+		if (passwdCrypt) {
+			if (strlen(passwdCrypt)
+			    < sizeof(nbrp->auth.md5key_encrypted)) {
+
+				strlcpy(nbrp->auth.md5key_encrypted,
+					passwdCrypt,
+					sizeof(nbrp->auth.md5key_encrypted));
+			} else {
+				zlog_err(
+					"%s: can't save encrypted neighbor password"
+					": too big (%zu > %zu) (key too large?)",
+					__func__, strlen(passwdCrypt) + 1,
+					sizeof(nbrp->auth.md5key_encrypted));
+			}
+			XFREE(MTYPE_KEYCRYPT_CIPHER_B64, passwdCrypt);
+		}
+
+		if (passwdPlain) {
+			if (nbrp->auth.method == AUTH_MD5SIG
+			    && strcmp(nbrp->auth.md5key, password_str) == 0) {
+
+				XFREE(MTYPE_TMP, passwdPlain);
+				return (CMD_SUCCESS);
+			}
+
+			password_len = strlcpy(nbrp->auth.md5key, passwdPlain,
+					       sizeof(nbrp->auth.md5key));
+			XFREE(MTYPE_TMP, passwdPlain);
+			if (password_len >= sizeof(nbrp->auth.md5key))
+				vty_out(vty,
+					"%% password has been truncated to %zu "
+					"characters.",
+					sizeof(nbrp->auth.md5key) - 1);
+			nbrp->auth.md5key_len = strlen(nbrp->auth.md5key);
+			nbrp->auth.method = AUTH_MD5SIG;
+		} else {
+			/*
+			 * We reach here if provided password was encrypted and
+			 * we are unable to decrypt (or if decrypted password
+			 * was 0-length).
+			 *
+			 * We want to retain the encrypted password for saving
+			 * in future config-writes. But the on-the-wire
+			 * password will be incorrect.
+			 */
+			nbrp->auth.md5key[0] = 0;
+			nbrp->auth.md5key_len = 0;
+			nbrp->auth.method = AUTH_MD5SIG;
+		}
 	}
 
 	ldp_config_apply(vty, vty_conf);

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -43,6 +43,7 @@
 #include "qobj.h"
 #include "libfrr.h"
 #include "lib_errors.h"
+#include "keycrypt.h"
 
 static void		 ldpd_shutdown(void);
 static pid_t		 start_child(enum ldpd_process, char *, int, int);
@@ -358,6 +359,11 @@ main(int argc, char *argv[])
 	access_list_init();
 	ldp_vty_init();
 	ldp_zebra_init(master);
+
+	keycrypt_init();
+	keycrypt_register_protocol_callback(ldpd_keycrypt_state_change);
+	keycrypt_register_protocol_show_callback(
+		ldpd_keycrypt_encryption_show_status);
 
 	/*
 	 * Create base configuration with sane defaults. All configuration
@@ -1679,6 +1685,8 @@ merge_nbrps(struct ldpd_conf *conf, struct ldpd_conf *xconf)
 		nbrp->auth.method = xn->auth.method;
 		strlcpy(nbrp->auth.md5key, xn->auth.md5key,
 		    sizeof(nbrp->auth.md5key));
+		strlcpy(nbrp->auth.md5key_encrypted, xn->auth.md5key_encrypted,
+			sizeof(nbrp->auth.md5key_encrypted));
 		nbrp->auth.md5key_len = xn->auth.md5key_len;
 		nbrp->flags = xn->flags;
 

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -47,6 +47,7 @@
 #define LDPD_OPT_NOACTION	0x00000004
 
 #define TCP_MD5_KEY_LEN		80
+#define TCP_MD5_KEY_LEN_ENCR	700 /* base64 encrypted max */
 
 #define	RT_BUF_SIZE		16384
 #define	MAX_RTSOCK_BUF		128 * 1024
@@ -398,6 +399,8 @@ struct nbr_params {
 		enum auth_method	 method;
 		char			 md5key[TCP_MD5_KEY_LEN];
 		uint8_t			 md5key_len;
+		/* size of md5key_encrypted limits RSA key length */
+		char md5key_encrypted[TCP_MD5_KEY_LEN_ENCR];
 	} auth;
 	uint8_t			 flags;
 	QOBJ_FIELDS

--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -25,6 +25,7 @@
 #include "ldpe.h"
 #include "lde.h"
 #include "log.h"
+#include "keycrypt.h"
 
 static __inline int	 nbr_id_compare(const struct nbr *, const struct nbr *);
 static __inline int	 nbr_addr_compare(const struct nbr *,

--- a/lib/command.c
+++ b/lib/command.c
@@ -48,6 +48,7 @@
 #include "lib_errors.h"
 #include "northbound_cli.h"
 #include "network.h"
+#include "keycrypt.h"
 
 DEFINE_MTYPE_STATIC(LIB, HOST, "Host config")
 DEFINE_MTYPE(LIB, COMPLETION, "Completion item")
@@ -2004,6 +2005,8 @@ DEFUN (service_password_encrypt,
 			XSTRDUP(MTYPE_HOST, zencrypt(host.enable));
 	}
 
+	keycrypt_state_change(true);
+
 	return CMD_SUCCESS;
 }
 
@@ -2026,6 +2029,8 @@ DEFUN (no_service_password_encrypt,
 	if (host.enable_encrypt)
 		XFREE(MTYPE_HOST, host.enable_encrypt);
 	host.enable_encrypt = NULL;
+
+	keycrypt_state_change(false);
 
 	return CMD_SUCCESS;
 }

--- a/lib/keychain.h
+++ b/lib/keychain.h
@@ -47,6 +47,7 @@ struct key {
 	uint32_t index;
 
 	char *string;
+	char *string_encrypted;
 
 	struct key_range send;
 	struct key_range accept;
@@ -60,6 +61,10 @@ extern struct keychain *keychain_lookup(const char *);
 extern struct key *key_lookup_for_accept(const struct keychain *, uint32_t);
 extern struct key *key_match_for_accept(const struct keychain *, const char *);
 extern struct key *key_lookup_for_send(const struct keychain *);
+extern void keychain_encryption_state_change(bool now_encrypting);
+struct vty; /* pet compiler */
+extern void keychain_encryption_show_status(struct vty *vty,
+	const char *indentstr);
 
 #ifdef __cplusplus
 }

--- a/lib/keycrypt.c
+++ b/lib/keycrypt.c
@@ -1,0 +1,3429 @@
+/*
+ * Copyright 2020, LabN Consulting, L.L.C.
+ * Copyright (C) 2008 Free Software Foundation, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+#include <sbuf.h>
+
+#include "memory.h"
+#include "log.h"
+#include "keycrypt.h"
+#include "command.h"
+#include "keychain.h"
+#include "libfrr.h"
+#include "lib_errors.h"
+
+DEFINE_MTYPE(LIB, KEYCRYPT_CIPHER_B64, "keycrypt base64 encoded")
+DEFINE_MTYPE(LIB, KEYCRYPT_PLAIN_TEXT, "keycrypt plain text")
+
+/* not compatible with oaep padding */
+#define KEYCRYPT_ENABLE_PKCS1_PADDING 0
+
+#ifdef KEYCRYPT_ENABLED
+
+/*
+ * normalize backend flag names
+ */
+#if 0 && defined(HAVE_GNUTLS) /* currently has no oaep mode, so disable */
+#define KEYCRYPT_HAVE_GNUTLS 1
+#endif
+#if defined(HAVE_OPENSSL) || defined(HAVE_LIBRESSL)
+#define KEYCRYPT_HAVE_OPENSSL 1
+#endif
+#if defined(HAVE_GCRYPT)
+#define KEYCRYPT_HAVE_GCRYPT 1
+#endif
+
+#if !defined(KEYCRYPT_HAVE_GNUTLS) && !defined(KEYCRYPT_HAVE_OPENSSL)          \
+	&& !defined(KEYCRYPT_HAVE_GCRYPT)
+#error "KEYCRYPT_ENABLED defined but no backend defined"
+#endif
+
+#endif /* KEYCRYPT_ENABLED */
+
+#ifdef KEYCRYPT_HAVE_GNUTLS
+#include <gnutls/gnutls.h>
+#include <gnutls/x509.h>
+#include <gnutls/abstract.h>
+#endif
+
+#ifdef KEYCRYPT_HAVE_OPENSSL
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/engine.h>
+#endif
+
+#ifdef KEYCRYPT_HAVE_GCRYPT
+#include <gcrypt.h>
+#endif
+
+/***********************************************************************
+ *		KEYCRYPT internal definitions
+ ***********************************************************************/
+
+/* #define KEYFILE_NAME_PRIVATE ".ssh/frr" */
+#define KEYFILE_NAME_PRIVATE "frr_pk_rsa"
+#define PWENT_BUFSIZE 512
+
+DEFINE_MTYPE_STATIC(LIB, KEYCRYPT_KEYFILE_PATH, "keycrypt keyfile path")
+DEFINE_MTYPE_STATIC(LIB, KEYCRYPT_CIPHER_TEXT, "keycrypt cipher text")
+DEFINE_MTYPE_STATIC(LIB, KEYCRYPT_B64DEC, "keycrypt base64 decoded")
+
+/* don't hit disk more often than this interval: */
+#define KEYCRYPT_CHECK_PKEY_SECONDS 10
+
+#ifdef KEYCRYPT_ENABLED
+/*
+ * Compute path to keyfile
+ *
+ * Caller must free returned buffer XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, path)
+ *
+ * Return value is NULL on failure.
+ */
+static char *keycrypt_keyfile_path(void)
+{
+	const char *hc;
+	const char *config_dir = NULL;
+	const char *kf_base = KEYFILE_NAME_PRIVATE;
+	char cwd[MAXPATHLEN];
+	char *slash;
+	char *path;
+	int config_dir_len = 0;
+	size_t total_length;
+
+	/*
+	 * compute config directory
+	 */
+	hc = host_config_get();
+	if (hc) {
+		slash = strrchr(hc, '/');
+		if (slash) {
+			config_dir = hc;
+			config_dir_len = slash - hc;
+		} else {
+			if (getcwd(cwd, MAXPATHLEN) == NULL) {
+				flog_err_sys(EC_LIB_SYSTEM_CALL,
+					     "%s: getcwd: %s", __func__,
+					     strerror(errno));
+				return NULL;
+			}
+			config_dir = cwd;
+			config_dir_len = strlen(config_dir);
+		}
+	} else {
+		config_dir = frr_sysconfdir;
+		slash = strrchr(config_dir, '/');
+		assert(slash);
+		config_dir_len = strlen(config_dir);
+	}
+
+	total_length = config_dir_len + 1 + strlen(kf_base) + 1;
+	path = XMALLOC(MTYPE_KEYCRYPT_KEYFILE_PATH, total_length);
+	snprintf(path, total_length, "%.*s/%s", config_dir_len, config_dir,
+		 kf_base);
+
+	return path;
+}
+#endif /* KEYCRYPT_ENABLED */
+
+/* clang-format off */
+typedef int be_encrypt_t(
+	const char	*pPlainText,
+	size_t		PlainTextLen,
+	char		**ppCipherTextB64,
+	size_t		*pCipherTextB64Len);
+
+typedef int be_decrypt_t(
+	struct memtype	*mt,
+	const char	*pCipherTextB64,
+	size_t		CipherTextB64Len,
+	char		**ppPlainText,
+	size_t		*pPlainTextLen);
+
+typedef int be_test_cmd_t(
+	struct vty	*vty,
+	const char	*cleartext);
+
+typedef enum keycrypt_err be_keyfile_read_status_t(
+	const char	*keyfile_path,
+	const char	**detail);
+
+struct keycrypt_backend {
+	const char			*name;
+	be_encrypt_t			*f_encrypt;
+	be_decrypt_t			*f_decrypt;
+	be_test_cmd_t			*f_test_cmd;
+	be_keyfile_read_status_t	*f_keyfile_read_status;
+	const char			*(*f_be_version_string)(void);
+};
+/* clang-format on */
+
+/***********************************************************************
+ *		openssl-specific functions
+ ***********************************************************************/
+
+#ifdef KEYCRYPT_HAVE_OPENSSL
+
+enum keycrypt_openssl_key_format {
+	KEYCRYPT_FORMAT_ASN1,
+	KEYCRYPT_FORMAT_PEM,
+	KEYCRYPT_FORMAT_PVK,
+};
+
+/*
+ * To generate a suitable private key, use:
+ *
+ *      chmod 0700 .ssh
+ *      openssl genpkey -algorithm RSA -out .ssh/frr
+ *      chmod 0400 .ssh/frr
+ *
+ * returns pointer to EVP_PKEY, or NULL. Caller must free EVP_PKEY
+ * when done, via EVP_PKEY_free(pkey).
+ *
+ * We read only the private keyfile because:
+ *  1. It contains both the private and public keys
+ *  2. We need to be able to decrypt and encrypt
+ */
+/* clang-format off */
+static enum keycrypt_err keycrypt_read_keyfile_openssl(
+	const char *path,
+	EVP_PKEY **ppKey)
+/* clang-format on */
+{
+	FILE *fp;
+	BIO *fb;
+	EVP_PKEY *pkey = NULL;
+	const char *formatstr = "";
+	enum keycrypt_openssl_key_format format = KEYCRYPT_FORMAT_PEM;
+
+	*ppKey = NULL;
+
+	/*
+	 * Use fopen() instead of BIO_new_file() so we can get meaningful
+	 * error messages to the log for not-found or permission issues.
+	 */
+	fp = fopen(path, "r");
+	if (!fp) {
+		zlog_err("%s: fopen(\"%s\") failed: %s", __func__, path,
+			 safe_strerror(errno));
+		return KC_ERR_KEYFILE_READ;
+	}
+
+	fb = BIO_new_fp(fp, BIO_CLOSE);
+	if (!fb) {
+		fclose(fp);
+		zlog_err("%s: BIO_new_fp() failed", __func__);
+		return KC_ERR_KEYFILE_READ;
+	}
+
+	switch (format) {
+	case KEYCRYPT_FORMAT_ASN1:
+		pkey = d2i_PrivateKey_bio(fb, NULL);
+		formatstr = "ASN1";
+		break;
+	case KEYCRYPT_FORMAT_PEM:
+		pkey = PEM_read_bio_PrivateKey(fb, NULL, NULL, NULL);
+		formatstr = "PEM";
+		break;
+	case KEYCRYPT_FORMAT_PVK:
+		pkey = b2i_PVK_bio(fb, NULL, NULL);
+		formatstr = "PVK";
+		break;
+	default:
+		zlog_err("%s: unknown format %u: not supported", __func__,
+			 format);
+	}
+
+	BIO_free(fb);
+
+	if (!pkey)
+		zlog_err(
+			"%s: unable to load format \"%s\" key from file \"%s\"",
+			__func__, formatstr, path);
+
+	*ppKey = pkey;
+	return 0;
+}
+
+/*
+ * Caller must free result XFREE(MTYPE_KEYCRYPT_CIPHER_B64, *pOut)
+ */
+static void keycrypt_base64_encode_openssl(const char *pIn, size_t InLen,
+					   char **ppOut, size_t *pOutLen)
+{
+	BIO *bio_b64;
+	BIO *bio_mem;
+	BUF_MEM *obufmem;
+
+	bio_mem = BIO_new(BIO_s_mem());
+	bio_b64 = BIO_new(BIO_f_base64());
+	BIO_set_flags(bio_b64, BIO_FLAGS_BASE64_NO_NL);
+	BIO_push(bio_b64, bio_mem);
+	BIO_write(bio_b64, pIn, InLen);
+
+	/* NetBSD 8 openssl BIO_flush() returns int */
+	(void)BIO_flush(bio_b64);
+
+	BIO_get_mem_ptr(bio_mem, &obufmem);
+	*ppOut = XMALLOC(MTYPE_KEYCRYPT_CIPHER_B64, obufmem->length + 1);
+	memcpy(*ppOut, obufmem->data, obufmem->length);
+	*((*ppOut) + obufmem->length) = 0; /* NUL-terminate */
+	*pOutLen = obufmem->length;
+
+	BIO_free_all(bio_b64);
+}
+
+/*
+ * Caller must free result XFREE(MTYPE_KEYCRYPT_B64DEC, *pOut)
+ */
+static void keycrypt_base64_decode_openssl(const char *pIn, size_t InLen,
+					   char **ppOut, size_t *pOutLen)
+{
+	BIO *bio_b64;
+	BIO *bio_mem;
+	BIO *bio_omem;
+	BUF_MEM *obufmem;
+	char inbuf[512];
+	int inlen;
+
+	/*
+	 * Debian 8, Ubuntu 14.04 openssl
+	 * BIO_new_mem_buf() discards const from 1st arg
+	 */
+	bio_mem = BIO_new_mem_buf((void *)pIn, InLen);
+	bio_b64 = BIO_new(BIO_f_base64());
+	BIO_set_flags(bio_b64, BIO_FLAGS_BASE64_NO_NL);
+	BIO_push(bio_b64, bio_mem);
+
+	bio_omem = BIO_new(BIO_s_mem());
+
+	while ((inlen = BIO_read(bio_b64, inbuf, sizeof(inbuf))) > 0)
+		BIO_write(bio_omem, inbuf, inlen);
+
+	/* NetBSD 8 openssl BIO_flush() returns int */
+	(void)BIO_flush(bio_omem);
+	BIO_free_all(bio_b64);
+
+	BIO_get_mem_ptr(bio_omem, &obufmem);
+	*ppOut = XMALLOC(MTYPE_KEYCRYPT_B64DEC, obufmem->length + 1);
+	memcpy(*ppOut, obufmem->data, obufmem->length);
+	*((*ppOut) + obufmem->length) = 0; /* NUL-terminate */
+	*pOutLen = obufmem->length;
+
+	BIO_free_all(bio_omem);
+}
+
+/*
+ * Encrypt provided plain text.
+ *
+ * Returns dynamically-allocated cipher text, which caller must
+ * free via XFREE(KEYCRYPT_CIPHER_TEXT, pCipherText)
+ *
+ * Return value is 0 if successful, non-0 for error
+ *
+ * NOTE: RSA encryption has a cleartext size limit slightly less
+ * (11 bits => 2 bytes?) than the key size.
+ */
+/* clang-format off */
+static int keycrypt_encrypt_internal_openssl_padding(
+	int		paddingtype,			/* IN */
+	EVP_PKEY	*pKey,				/* IN */
+	struct memtype	*mt,	/* of CipherText */	/* IN */
+	const char	*pPlainText,			/* IN */
+	size_t		PlainTextLen,			/* IN */
+	char		**ppCipherText,			/* OUT */
+	size_t		*pCipherTextLen)		/* OUT */
+
+/* clang-format on */
+{
+	EVP_PKEY_CTX *ctx;
+	ENGINE *eng = NULL; /* default RSA impl */
+	int rc;
+
+	ctx = EVP_PKEY_CTX_new(pKey, eng);
+	if (!ctx) {
+		zlog_warn("%s: unable to alloc context", __func__);
+		return -1;
+	}
+
+	rc = EVP_PKEY_encrypt_init(ctx);
+	if (rc <= 0) {
+		EVP_PKEY_CTX_free(ctx);
+		zlog_warn("%s: Error: EVP_PKEY_encrypt_init%s", __func__,
+			  ((rc == -2) ? ": not supported by public key alg"
+				      : ""));
+		return -1;
+	}
+
+	rc = EVP_PKEY_CTX_set_rsa_padding(ctx, paddingtype);
+	if (rc <= 0) {
+		EVP_PKEY_CTX_free(ctx);
+		zlog_warn("%s: Error: EVP_PKEY_CTX_set_rsa_padding%s", __func__,
+			  ((rc == -2) ? ": not supported by public key alg"
+				      : ""));
+		return -1;
+	}
+
+	/* Determine buffer length */
+	rc = EVP_PKEY_encrypt(ctx, NULL, pCipherTextLen,
+			      (const u8 *)pPlainText, PlainTextLen);
+	if (rc <= 0) {
+		EVP_PKEY_CTX_free(ctx);
+		zlog_warn("%s: Error: EVP_PKEY_encrypt (1)%s", __func__,
+			  ((rc == -2) ? ": not supported by public key alg"
+				      : ""));
+		return -1;
+	}
+
+	*ppCipherText = XMALLOC(mt, *pCipherTextLen);
+
+	rc = EVP_PKEY_encrypt(ctx, (u8 *)*ppCipherText, pCipherTextLen,
+			      (const u8 *)pPlainText, PlainTextLen);
+	if (rc <= 0) {
+		EVP_PKEY_CTX_free(ctx);
+		XFREE(mt, *ppCipherText);
+		zlog_warn("%s: Error: EVP_PKEY_encrypt (2)%s", __func__,
+			  ((rc == -2) ? ": not supported by public key alg"
+				      : ""));
+		return -1;
+	}
+
+	EVP_PKEY_CTX_free(ctx);
+
+	return 0;
+}
+
+/*
+ * Decrypt provided cipher text.
+ *
+ * Returns dynamically-allocated plain text, which caller must
+ * free via XFREE(KEYCRYPT_PLAIN_TEXT, pPlainText)
+ *
+ * Return value is 0 if successful, non-0 for error
+ */
+/* clang-format off */
+static int keycrypt_decrypt_internal_openssl_padding(
+	int		paddingtype,			/* IN */
+	EVP_PKEY	*pKey,				/* IN */
+	struct memtype	*mt,	/* of PlainText */	/* IN */
+	const char	*pCipherText,			/* IN */
+	size_t		CipherTextLen,			/* IN */
+	char		**ppPlainText,			/* OUT */
+	size_t		*pPlainTextLen)			/* OUT */
+
+/* clang-format on */
+{
+	EVP_PKEY_CTX *ctx;
+	ENGINE *eng = NULL; /* default RSA impl */
+	int rc;
+
+	ctx = EVP_PKEY_CTX_new(pKey, eng);
+	if (!ctx) {
+		zlog_warn("%s: unable to alloc context", __func__);
+		return -1;
+	}
+
+	rc = EVP_PKEY_decrypt_init(ctx);
+	if (rc <= 0) {
+		EVP_PKEY_CTX_free(ctx);
+		zlog_warn("%s: Error: EVP_PKEY_decrypt_init%s", __func__,
+			  ((rc == -2) ? ": not supported by public key alg"
+				      : ""));
+		return -1;
+	}
+
+	rc = EVP_PKEY_CTX_set_rsa_padding(ctx, paddingtype);
+	if (rc <= 0) {
+		EVP_PKEY_CTX_free(ctx);
+		zlog_warn("%s: Error: EVP_PKEY_CTX_set_rsa_padding%s", __func__,
+			  ((rc == -2) ? ": not supported by public key alg"
+				      : ""));
+		return -1;
+	}
+
+	/* Determine buffer length */
+	rc = EVP_PKEY_decrypt(ctx, NULL, pPlainTextLen,
+			      (const u8 *)pCipherText, CipherTextLen);
+	if (rc <= 0) {
+		EVP_PKEY_CTX_free(ctx);
+		zlog_warn("%s: Error: EVP_PKEY_decrypt (1)%s", __func__,
+			  ((rc == -2) ? ": not supported by public key alg"
+				      : ""));
+		return -1;
+	}
+
+	*ppPlainText = XMALLOC(mt, *pPlainTextLen + 1);
+
+	rc = EVP_PKEY_decrypt(ctx, (u8 *)*ppPlainText, pPlainTextLen,
+			      (const u8 *)pCipherText, CipherTextLen);
+	if (rc <= 0) {
+		EVP_PKEY_CTX_free(ctx);
+		if (*ppPlainText)
+			XFREE(mt, *ppPlainText);
+		zlog_warn(
+			"%s: EVP_PKEY_decrypt (2) CipherTextLen %zu, PlainTextLen %zu",
+			__func__, CipherTextLen, *pPlainTextLen);
+		zlog_warn("%s: Error: EVP_PKEY_decrypt (2)%s", __func__,
+			  ((rc == -2) ? ": not supported by public key alg"
+				      : ""));
+		return -1;
+	}
+	(*ppPlainText)[*pPlainTextLen] = '\0';
+
+	EVP_PKEY_CTX_free(ctx);
+
+	return 0;
+}
+
+/*
+ * Allocates an EVP_PKEY which should later be freed via EVP_PKEY_free()
+ */
+static enum keycrypt_err keycrypt_read_default_keyfile_openssl(EVP_PKEY **ppKey)
+{
+	char *keyfile_path;
+	enum keycrypt_err krc;
+
+	*ppKey = NULL;
+
+	keyfile_path = keycrypt_keyfile_path();
+	if (!keyfile_path) {
+		zlog_err("%s: Error: can't compute keyfile path\n", __func__);
+		return KC_ERR_KEYFILE_PATH;
+	}
+
+	krc = keycrypt_read_keyfile_openssl(keyfile_path, ppKey);
+	if (krc) {
+		zlog_err("%s: Error: %s can't read \"%s\"\n",
+			 __func__, "keycrypt_read_keyfile_openssl",
+			 keyfile_path);
+		XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+		return KC_ERR_KEYFILE_READ;
+	}
+	XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+	return KC_OK;
+}
+
+/*
+ * Caller should not free returned key
+ */
+static EVP_PKEY *keycrypt_get_pkey_openssl()
+{
+	static time_t keycrypt_pkey_check_time;
+	static EVP_PKEY *keycrypt_cached_pkey;
+
+	time_t now;
+
+	now = monotime(NULL);
+	if (now - keycrypt_pkey_check_time > KEYCRYPT_CHECK_PKEY_SECONDS) {
+		EVP_PKEY *pKey;
+		enum keycrypt_err rc;
+
+		keycrypt_pkey_check_time = now;
+
+		rc = keycrypt_read_default_keyfile_openssl(&pKey);
+		if (rc != KC_OK)
+			goto end;
+
+		if (keycrypt_cached_pkey)
+			EVP_PKEY_free(keycrypt_cached_pkey);
+
+		keycrypt_cached_pkey = pKey;
+	}
+end:
+	return keycrypt_cached_pkey;
+}
+
+/*
+ * After successful return (0), caller MUST free base-64 encoded
+ * cipher text via XFREE(MTYPE_KEYCRYPT_CIPHER_B64, ptr)
+ */
+/* clang-format off */
+static int keycrypt_encrypt_openssl_padding(
+	int		paddingtype,		/* IN */
+	const char	*pPlainText,		/* IN */
+	size_t		PlainTextLen,		/* IN */
+	char		**ppCipherTextB64,	/* OUT */
+	size_t		*pCipherTextB64Len)	/* OUT */
+
+/* clang-format on */
+{
+	EVP_PKEY *pKey;
+	int rc;
+	char *pCipherTextRaw;
+	size_t CipherTextRawLen;
+	size_t B64len;
+
+	pKey = keycrypt_get_pkey_openssl();
+	if (!pKey)
+		return -1;
+
+	rc = keycrypt_encrypt_internal_openssl_padding(
+		paddingtype, pKey, MTYPE_KEYCRYPT_CIPHER_TEXT, pPlainText,
+		PlainTextLen, &pCipherTextRaw, &CipherTextRawLen);
+	if (rc)
+		return -1;
+
+	keycrypt_base64_encode_openssl(pCipherTextRaw, CipherTextRawLen,
+				       ppCipherTextB64, &B64len);
+
+	if (pCipherTextB64Len)
+		*pCipherTextB64Len = B64len;
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_TEXT, pCipherTextRaw);
+
+	return 0;
+}
+
+/* clang-format off */
+static int keycrypt_encrypt_openssl_pkcs1(
+	const char	*pPlainText,		/* IN */
+	size_t		PlainTextLen,		/* IN */
+	char		**ppCipherTextB64,	/* OUT */
+	size_t		*pCipherTextB64Len)	/* OUT */
+
+{
+	return keycrypt_encrypt_openssl_padding(
+			RSA_PKCS1_PADDING,
+			pPlainText,
+			PlainTextLen,
+			ppCipherTextB64,
+			pCipherTextB64Len);
+}
+
+static int keycrypt_encrypt_openssl_oaep(
+	const char	*pPlainText,		/* IN */
+	size_t		PlainTextLen,		/* IN */
+	char		**ppCipherTextB64,	/* OUT */
+	size_t		*pCipherTextB64Len)	/* OUT */
+
+{
+	return keycrypt_encrypt_openssl_padding(
+			RSA_PKCS1_OAEP_PADDING,
+			pPlainText,
+			PlainTextLen,
+			ppCipherTextB64,
+			pCipherTextB64Len);
+}
+/* clang-format on */
+
+/* clang-format off */
+static int keycrypt_decrypt_openssl_padding(
+	int		paddingtype,			/* IN */
+	struct memtype	*mt,	/* of PlainText */	/* IN */
+	const char	*pCipherTextB64,		/* IN */
+	size_t		CipherTextB64Len,		/* IN */
+	char		**ppPlainText,			/* OUT */
+	size_t		*pPlainTextLen)			/* OUT */
+
+/* clang-format on */
+{
+	EVP_PKEY *pKey;
+	int rc;
+	char *pCipherTextRaw;
+	size_t CipherTextRawLen;
+	size_t PlainTextLen;
+
+	pKey = keycrypt_get_pkey_openssl();
+	if (!pKey)
+		return -1;
+
+	keycrypt_base64_decode_openssl(pCipherTextB64, CipherTextB64Len,
+				       &pCipherTextRaw, &CipherTextRawLen);
+
+	rc = keycrypt_decrypt_internal_openssl_padding(
+		paddingtype, pKey, mt, pCipherTextRaw, CipherTextRawLen,
+		ppPlainText, &PlainTextLen);
+
+	XFREE(MTYPE_KEYCRYPT_B64DEC, pCipherTextRaw);
+
+	if (rc)
+		return -1;
+
+	if (pPlainTextLen)
+		*pPlainTextLen = PlainTextLen;
+
+	return 0;
+}
+
+/* clang-format off */
+static int keycrypt_decrypt_openssl_pkcs1(
+	struct memtype	*mt,	/* of PlainText */	/* IN */
+	const char	*pCipherTextB64,		/* IN */
+	size_t		CipherTextB64Len,		/* IN */
+	char		**ppPlainText,			/* OUT */
+	size_t		*pPlainTextLen)			/* OUT */
+
+{
+	return keycrypt_decrypt_openssl_padding(
+			RSA_PKCS1_PADDING,
+			mt,
+			pCipherTextB64,
+			CipherTextB64Len,
+			ppPlainText,
+			pPlainTextLen);
+}
+
+static int keycrypt_decrypt_openssl_oaep(
+	struct memtype	*mt,	/* of PlainText */	/* IN */
+	const char	*pCipherTextB64,		/* IN */
+	size_t		CipherTextB64Len,		/* IN */
+	char		**ppPlainText,			/* OUT */
+	size_t		*pPlainTextLen)			/* OUT */
+
+{
+	return keycrypt_decrypt_openssl_padding(
+			RSA_PKCS1_OAEP_PADDING,
+			mt,
+			pCipherTextB64,
+			CipherTextB64Len,
+			ppPlainText,
+			pPlainTextLen);
+}
+/* clang-format on */
+
+/* clang-format off */
+static int debug_keycrypt_test_cmd_openssl_padding(
+	int		paddingtype,
+	struct vty	*vty,
+	const char	*cleartext)
+/* clang-format on */
+{
+	char *keyfile_path = NULL;
+	EVP_PKEY *pKey;
+	int rc;
+	char *pCipherText = NULL;
+	size_t CipherTextLen;
+	char *pClearText = NULL;
+	size_t ClearTextLen;
+	char *pB64Text;
+	size_t B64TextLen;
+	enum keycrypt_err krc;
+
+	keyfile_path = keycrypt_keyfile_path();
+	if (!keyfile_path) {
+		vty_out(vty, "%s: Error: can't compute keyfile path\n",
+			__func__);
+		return CMD_SUCCESS;
+	}
+
+	krc = keycrypt_read_keyfile_openssl(keyfile_path, &pKey);
+	if (krc) {
+		vty_out(vty, "%s: Error: %s\n", __func__,
+			"keycrypt_read_keyfile_openssl");
+		XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+		return CMD_SUCCESS;
+	}
+	XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+
+	rc = keycrypt_encrypt_internal_openssl_padding(
+		RSA_PKCS1_PADDING, pKey, MTYPE_KEYCRYPT_CIPHER_TEXT, cleartext,
+		strlen(cleartext), &pCipherText, &CipherTextLen);
+	if (rc) {
+		EVP_PKEY_free(pKey);
+		vty_out(vty, "%s: Error: keycrypt_encrypt_internal_openssl\n",
+			__func__);
+		return CMD_SUCCESS;
+	}
+
+	if (!pCipherText) {
+		vty_out(vty, "%s: missing cipher text\n", __func__);
+		return CMD_SUCCESS;
+	}
+
+	/*
+	 * Encode for printing
+	 */
+
+	keycrypt_base64_encode_openssl(pCipherText, CipherTextLen, &pB64Text,
+				       &B64TextLen);
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_TEXT, pCipherText);
+
+	vty_out(vty,
+		"INFO: clear text len: %zu, CipherTextLen: %zu, B64TextLen %zu\n",
+		strlen(cleartext), CipherTextLen, B64TextLen);
+
+	vty_out(vty, "INFO: base64 cipher text:\n%s\n", pB64Text);
+
+
+	/*
+	 * Decode back to binary
+	 */
+	keycrypt_base64_decode_openssl(pB64Text, B64TextLen, &pCipherText,
+				       &CipherTextLen);
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pB64Text);
+
+	vty_out(vty, "INFO: After B64 decode, CipherTextLen: %zu\n",
+		CipherTextLen);
+
+
+	rc = keycrypt_decrypt_internal_openssl_padding(
+		RSA_PKCS1_PADDING, pKey, MTYPE_KEYCRYPT_PLAIN_TEXT, pCipherText,
+		CipherTextLen, &pClearText, &ClearTextLen);
+
+	EVP_PKEY_free(pKey);
+
+	if (pCipherText) {
+		if (!strncmp(cleartext, pCipherText, strlen(cleartext))) {
+			vty_out(vty,
+				"%s: cipher text and cleartext same for %zu chars\n",
+				__func__, strlen(cleartext));
+			XFREE(MTYPE_KEYCRYPT_B64DEC, pCipherText);
+			if (pClearText)
+				XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+			return CMD_SUCCESS;
+		}
+		XFREE(MTYPE_KEYCRYPT_B64DEC, pCipherText);
+	}
+
+	if (rc) {
+		vty_out(vty, "%s: Error: keycrypt_decrypt_internal_openssl\n",
+			__func__);
+		if (pClearText)
+			XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+		return CMD_SUCCESS;
+	}
+
+	if (!pClearText) {
+		vty_out(vty,
+			"%s: keycrypt_decrypt_internal_openssl didn't return clear text pointer\n",
+			__func__);
+		return CMD_SUCCESS;
+	}
+	if (strlen(cleartext) != ClearTextLen) {
+		vty_out(vty,
+			"%s: decrypted ciphertext length (%zu) != original length (%zu)\n",
+			__func__, ClearTextLen, strlen(cleartext));
+		XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+		return CMD_SUCCESS;
+	}
+
+	if (strncmp(cleartext, pClearText, ClearTextLen)) {
+		vty_out(vty,
+			"%s: decrypted ciphertext differs from original text\n",
+			__func__);
+		XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+		return CMD_SUCCESS;
+	}
+
+	vty_out(vty, "OK: decrypted ciphertext matches original text\n");
+	return CMD_SUCCESS;
+}
+
+/* clang-format off */
+static int debug_keycrypt_test_cmd_openssl_pkcs1(
+	struct vty	*vty,
+	const char	*cleartext)
+/* clang-format on */
+{
+	return debug_keycrypt_test_cmd_openssl_padding(RSA_PKCS1_PADDING, vty,
+						       cleartext);
+}
+
+/* clang-format off */
+static int debug_keycrypt_test_cmd_openssl_oaep(
+	struct vty	*vty,
+	const char	*cleartext)
+/* clang-format on */
+{
+	return debug_keycrypt_test_cmd_openssl_padding(RSA_PKCS1_OAEP_PADDING,
+						       vty, cleartext);
+}
+
+static enum keycrypt_err keyfile_read_status_openssl(const char *keyfile_path,
+						  const char **detail)
+{
+	enum keycrypt_err krc;
+	EVP_PKEY *pKey;
+
+	*detail = NULL;
+
+	krc = keycrypt_read_keyfile_openssl(keyfile_path, &pKey);
+	if (krc)
+		*detail = keycrypt_strerror(krc);
+	else
+		EVP_PKEY_free(pKey);
+
+	return krc;
+}
+
+static const char *keycrypt_backend_version_string_openssl(void)
+{
+	return OpenSSL_version(OPENSSL_VERSION);
+}
+
+/* clang-format off */
+struct keycrypt_backend kbe_openssl_pkcs1 = {
+	.name			= "openssl-pkcs1-padding",
+	.f_encrypt		= keycrypt_encrypt_openssl_pkcs1,
+	.f_decrypt		= keycrypt_decrypt_openssl_pkcs1,
+	.f_test_cmd		= debug_keycrypt_test_cmd_openssl_pkcs1,
+	.f_keyfile_read_status	= keyfile_read_status_openssl,
+	.f_be_version_string	= keycrypt_backend_version_string_openssl,
+};
+struct keycrypt_backend kbe_openssl_oaep = {
+	.name			= "openssl",
+	.f_encrypt		= keycrypt_encrypt_openssl_oaep,
+	.f_decrypt		= keycrypt_decrypt_openssl_oaep,
+	.f_test_cmd		= debug_keycrypt_test_cmd_openssl_oaep,
+	.f_keyfile_read_status	= keyfile_read_status_openssl,
+	.f_be_version_string	= keycrypt_backend_version_string_openssl,
+};
+/* clang-format on */
+
+#endif /* KEYCRYPT_HAVE_OPENSSL */
+
+
+/***********************************************************************
+ *		gnutls-specific functions
+ ***********************************************************************/
+
+#if defined KEYCRYPT_HAVE_GNUTLS
+
+/*
+ * If successful (return value is 0), allocates and fills in
+ * private key structure. Caller is responsible for calling
+ * gnutls_x509_privkey_deinit() to free private key structure
+ */
+/* clang-format off */
+static enum keycrypt_err keycrypt_read_keyfile_gnutls(
+	const char		*filename,
+	/* gnutls_x509_privkey_t is a pointer to key struct */
+	gnutls_x509_privkey_t	*ppPrivKey)	/* ptr to caller's ptr */
+/* clang-format on */
+{
+	int rc;
+	gnutls_datum_t data;
+
+	rc = gnutls_load_file(filename, &data);
+	if (rc) {
+		zlog_err("%s: error: gnutls_load_file(\"%s\") returned %d: %s ",
+			 __func__, filename, rc, gnutls_strerror(rc));
+		return KC_ERR_KEYFILE_READ;
+	}
+
+	/*
+	 * Allocates structure and saves ptr in *ppPrivKey
+	 */
+	rc = gnutls_x509_privkey_init(ppPrivKey);
+	if (rc < 0) {
+		zlog_err("%s: %s returned error %d: %s\n", __func__,
+			 "gnutls_x509_privkey_init", rc, gnutls_strerror(rc));
+		return KC_ERR_MEMORY;
+	}
+	rc = gnutls_x509_privkey_import2(*ppPrivKey, &data, GNUTLS_X509_FMT_PEM,
+					 NULL /* password */,
+					 GNUTLS_PKCS_PLAIN);
+	free(data.data);
+	if (rc < 0) {
+		zlog_err("%s: %s returned error %d: %s\n", __func__,
+			 "gnutls_x509_privkey_import2", rc,
+			 gnutls_strerror(rc));
+		gnutls_x509_privkey_deinit(*ppPrivKey); /* frees structure */
+		return KC_ERR_KEYFILE_PARSE;
+	}
+	return KC_OK;
+}
+
+/*
+ * Allocates a *gnutls_x509_privkey_t  which should later be
+ * freed via gnutls_x509_privkey_deinit()
+ */
+static enum keycrypt_err
+keycrypt_read_default_keyfile_gnutls(gnutls_x509_privkey_t *ppPrivKey)
+{
+	enum keycrypt_err rc;
+	char *keyfile_path;
+
+	*ppPrivKey = NULL;
+
+	keyfile_path = keycrypt_keyfile_path();
+	if (!keyfile_path) {
+		zlog_err("%s: Error: can't compute keyfile path\n", __func__);
+		return KC_ERR_KEYFILE_PATH;
+	}
+
+	rc = keycrypt_read_keyfile_gnutls(keyfile_path, ppPrivKey);
+	if (rc) {
+		zlog_err("%s: Error: %s can't read \"%s\"\n", __func__,
+			 "keycrypt_read_keyfile_gnutls", keyfile_path);
+		XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+		return rc;
+	}
+
+	XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+	return KC_OK;
+}
+
+/*
+ * Caller should not free returned key
+ */
+static gnutls_x509_privkey_t keycrypt_get_pkey_gnutls(void)
+{
+	static time_t keycrypt_pkey_check_time;
+	static gnutls_x509_privkey_t keycrypt_cached_pkey_gnutls; /* ptr type */
+	time_t now;
+
+	now = monotime(NULL);
+	if (now - keycrypt_pkey_check_time > KEYCRYPT_CHECK_PKEY_SECONDS) {
+		gnutls_x509_privkey_t pKey;
+		enum keycrypt_err rc;
+
+		keycrypt_pkey_check_time = now;
+
+		rc = keycrypt_read_default_keyfile_gnutls(&pKey);
+		if (rc != KC_OK)
+			goto end;
+
+		if (keycrypt_cached_pkey_gnutls)
+			gnutls_x509_privkey_deinit(keycrypt_cached_pkey_gnutls);
+
+		keycrypt_cached_pkey_gnutls = pKey;
+	}
+end:
+	return keycrypt_cached_pkey_gnutls;
+}
+
+/* clang-format off */
+enum kc_gt_privdata_params {
+	GT_DATUM_M = 0,
+	GT_DATUM_E,
+	GT_DATUM_D,
+	GT_DATUM_P,
+	GT_DATUM_Q,
+	GT_DATUM_U,
+	GT_DATUM_E1,
+	GT_DATUM_E2,
+	N_GT_DATA
+};
+
+static int keycrypt_encrypt_internal_gnutls(
+	gnutls_x509_privkey_t	pPrivKey,			/* IN */
+	struct memtype		*mt,	/* of CipherText */	/* IN */
+	const char		*pPlainText,			/* IN */
+	size_t			PlainTextLen,			/* IN */
+	char			**ppCipherText,			/* OUT */
+	size_t			*pCipherTextLen)		/* OUT */
+
+{
+	int				rc;
+	gnutls_datum_t			d[N_GT_DATA];
+	gnutls_pubkey_t			pPubKey;
+	enum kc_gt_privdata_params	i;
+	/* clang-format on */
+
+	for (i = GT_DATUM_M; i < N_GT_DATA; ++i)
+		d[i].data = NULL;
+
+	/*
+	 * Derive public key from private key
+	 */
+	/* clang-format off */
+	rc = gnutls_x509_privkey_export_rsa_raw(pPrivKey,
+		d+GT_DATUM_M,
+		d+GT_DATUM_E,
+		d+GT_DATUM_D,
+		d+GT_DATUM_P,
+		d+GT_DATUM_Q,
+		d+GT_DATUM_U);
+	/* clang-format on */
+	if (rc) {
+		zlog_err("%s: error: %s returned %d: %s", __func__,
+			 "gnutls_privkey_export_rsa_raw", rc,
+			 gnutls_strerror(rc));
+		return KC_ERR_ENCRYPT;
+	}
+
+	gnutls_pubkey_init(&pPubKey);
+
+	rc = gnutls_pubkey_import_rsa_raw(pPubKey, d + GT_DATUM_M,
+					  d + GT_DATUM_E);
+
+	/*
+	 * gnutls documentation is not clear on need to keep data components
+	 * allocated during lifetime of public key
+	 */
+	for (i = GT_DATUM_M; i < N_GT_DATA; ++i) {
+		if (d[i].data)
+			gnutls_free(d[i].data);
+	}
+
+	if (rc) {
+		zlog_err("%s: error: %s returned %d: %s", __func__,
+			 "gnutls_pubkey_import_rsa_raw", rc,
+			 gnutls_strerror(rc));
+		gnutls_pubkey_deinit(pPubKey);
+		return KC_ERR_ENCRYPT;
+	}
+
+	gnutls_datum_t datum_plaintext;
+	gnutls_datum_t datum_ciphertext;
+
+	datum_plaintext.data = (unsigned char *)pPlainText;
+	datum_plaintext.size = PlainTextLen;
+
+	rc = gnutls_pubkey_encrypt_data(pPubKey, 0, &datum_plaintext,
+					&datum_ciphertext);
+	gnutls_pubkey_deinit(pPubKey);
+	if (rc) {
+		zlog_err("%s: error: %s returned %d: %s", __func__,
+			 "gnutls_pubkey_encrypt_data", rc, gnutls_strerror(rc));
+		return KC_ERR_ENCRYPT;
+	}
+	*pCipherTextLen = datum_ciphertext.size;
+	*ppCipherText = XMALLOC(mt, datum_ciphertext.size);
+	memcpy(*ppCipherText, datum_ciphertext.data, datum_ciphertext.size);
+
+	gnutls_free(datum_ciphertext.data);
+
+	return 0;
+}
+
+/*
+ * Decrypt provided cipher text.
+ *
+ * Returns dynamically-allocated plain text, which caller must
+ * free via XFREE(KEYCRYPT_PLAIN_TEXT, pPlainText)
+ *
+ * Return value is 0 if successful, non-0 for error
+ */
+/* clang-format off */
+static int keycrypt_decrypt_internal_gnutls(
+	gnutls_x509_privkey_t	pX509PrivKey,			/* IN */
+	struct memtype		*mt,	/* of PlainText */	/* IN */
+	const char		*pCipherText,			/* IN */
+	size_t			CipherTextLen,			/* IN */
+	char			**ppPlainText,			/* OUT */
+	size_t			*pPlainTextLen)			/* OUT */
+
+{
+	gnutls_datum_t		datum_ciphertext;
+	gnutls_datum_t		datum_plaintext;
+	gnutls_privkey_t	pPrivKey;
+	int		rc;
+	/* clang-format on */
+
+	/*
+	 * make a generic private key
+	 */
+	rc = gnutls_privkey_init(&pPrivKey);
+	if (rc) {
+		zlog_err("%s: error: %s returned %d: %s", __func__,
+			 "gnutls_privkey_init", rc, gnutls_strerror(rc));
+		return KC_ERR_DECRYPT;
+	}
+	rc = gnutls_privkey_import_x509(pPrivKey, pX509PrivKey, 0);
+	if (rc) {
+		zlog_err("%s: error: %s returned %d: %s", __func__,
+			 "gnutls_privkey_import_x509", rc, gnutls_strerror(rc));
+		return KC_ERR_DECRYPT;
+	}
+
+	datum_ciphertext.data = (unsigned char *)pCipherText;
+	datum_ciphertext.size = CipherTextLen;
+
+	rc = gnutls_privkey_decrypt_data(pPrivKey, 0, &datum_ciphertext,
+					 &datum_plaintext);
+	gnutls_privkey_deinit(pPrivKey);
+	if (rc) {
+		zlog_err("%s: error: %s returned %d: %s", __func__,
+			 "gnutls_privkey_decrypt_data", rc,
+			 gnutls_strerror(rc));
+		zlog_debug(
+			"%s: datum_ciphertext.data %p, datum_ciphertext.size %u",
+			__func__, datum_ciphertext.data, datum_ciphertext.size);
+		return KC_ERR_DECRYPT;
+	}
+	*pPlainTextLen = datum_plaintext.size;
+	*ppPlainText = XMALLOC(mt, datum_plaintext.size + 1);
+	memcpy(*ppPlainText, datum_plaintext.data, datum_plaintext.size);
+	(*ppPlainText)[*pPlainTextLen] = '\0';
+
+	gnutls_free(datum_plaintext.data);
+
+	return 0;
+}
+
+
+/*
+ * Caller must free result XFREE(MTYPE_KEYCRYPT_CIPHER_B64, *pOut)
+ */
+/* clang-format off */
+static enum keycrypt_err keycrypt_base64_encode_gnutls(
+	const char	*pIn,
+	size_t		InLen,
+	char		**ppOut,
+	size_t		*pOutLen)
+{
+	gnutls_datum_t	d_raw;
+	gnutls_datum_t	d_b64;
+	int		rc;
+	/* clang-format on */
+
+	d_raw.data = (unsigned char *)pIn;
+	d_raw.size = InLen;
+
+	rc = gnutls_base64_encode2(&d_raw, &d_b64);
+	if (rc) {
+		zlog_err("%s: error: %s returned %d: %s", __func__,
+			 "gnutls_base64_encode2", rc, gnutls_strerror(rc));
+		return KC_ERR_BASE64;
+	}
+
+	*ppOut = XMALLOC(MTYPE_KEYCRYPT_CIPHER_B64, d_b64.size + 1);
+	memcpy(*ppOut, d_b64.data, d_b64.size);
+	*(*ppOut + d_b64.size) = '\0';
+	*pOutLen = d_b64.size;
+	gnutls_free(d_b64.data);
+	return 0;
+}
+
+/*
+ * Caller must free result XFREE(MTYPE_KEYCRYPT_B64DEC, *pOut)
+ */
+/* clang-format off */
+static enum keycrypt_err keycrypt_base64_decode_gnutls(
+	const char	*pIn,
+	size_t		InLen,
+	char		**ppOut,
+	size_t		*pOutLen)
+{
+	gnutls_datum_t	d_raw;
+	gnutls_datum_t	d_b64;
+	int		rc;
+	/* clang-format on */
+
+	d_b64.data = (unsigned char *)pIn;
+	d_b64.size = InLen;
+
+	rc = gnutls_base64_decode2(&d_b64, &d_raw);
+	if (rc) {
+		zlog_err("%s: error: %s returned %d: %s", __func__,
+			 "gnutls_base64_decode2", rc, gnutls_strerror(rc));
+		zlog_err("%s: d_b64.data %p, d_b64.size %u", __func__,
+			 d_b64.data, d_b64.size);
+		return KC_ERR_BASE64;
+	}
+
+	*ppOut = XMALLOC(MTYPE_KEYCRYPT_B64DEC, d_raw.size + 1);
+	memcpy(*ppOut, d_raw.data, d_raw.size);
+	*(*ppOut + d_raw.size) = '\0';
+	*pOutLen = d_raw.size;
+	gnutls_free(d_raw.data);
+	return 0;
+}
+
+/*
+ * After successful return (0), caller MUST free base-64 encoded
+ * cipher text via XFREE(MTYPE_KEYCRYPT_CIPHER_B64, ptr)
+ */
+/* clang-format off */
+static int keycrypt_encrypt_gnutls(
+	const char	*pPlainText,		/* IN */
+	size_t		PlainTextLen,		/* IN */
+	char		**ppCipherTextB64,	/* OUT */
+	size_t		*pCipherTextB64Len)	/* OUT */
+
+{
+	gnutls_x509_privkey_t	pKey;
+	int			rc;
+	enum keycrypt_err	krc;
+	char			*pCipherTextRaw;
+	size_t			CipherTextRawLen = 0;
+	size_t			B64len = 0;
+	/* clang-format on */
+
+	pKey = keycrypt_get_pkey_gnutls();
+	if (!pKey)
+		return -1;
+
+	rc = keycrypt_encrypt_internal_gnutls(
+		pKey, MTYPE_KEYCRYPT_CIPHER_TEXT, pPlainText, PlainTextLen,
+		&pCipherTextRaw, &CipherTextRawLen);
+	if (rc)
+		return -1;
+
+	krc = keycrypt_base64_encode_gnutls(pCipherTextRaw, CipherTextRawLen,
+					    ppCipherTextB64, &B64len);
+
+	if (krc) {
+		zlog_err("%s: %s returned %d: %s", __func__,
+			 "keycrypt_base64_encode_gnutls", krc,
+			 keycrypt_strerror(krc));
+		XFREE(MTYPE_KEYCRYPT_CIPHER_TEXT, pCipherTextRaw);
+		return krc;
+	}
+
+	if (pCipherTextB64Len)
+		*pCipherTextB64Len = B64len;
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_TEXT, pCipherTextRaw);
+
+	return 0;
+}
+
+/* clang-format off */
+static int keycrypt_decrypt_gnutls(
+	struct memtype	*mt,	/* of PlainText */	/* IN */
+	const char	*pCipherTextB64,		/* IN */
+	size_t		CipherTextB64Len,		/* IN */
+	char		**ppPlainText,			/* OUT */
+	size_t		*pPlainTextLen)			/* OUT */
+
+{
+	gnutls_x509_privkey_t	pKey;
+	int			rc;
+	char			*pCipherTextRaw;
+	size_t			CipherTextRawLen = 0;
+	size_t			PlainTextLen = 0;
+	/* clang-format on */
+
+	pKey = keycrypt_get_pkey_gnutls();
+	if (!pKey)
+		return -1;
+
+	keycrypt_base64_decode_gnutls(pCipherTextB64, CipherTextB64Len,
+				      &pCipherTextRaw, &CipherTextRawLen);
+
+	rc = keycrypt_decrypt_internal_gnutls(pKey, mt, pCipherTextRaw,
+					      CipherTextRawLen, ppPlainText,
+					      &PlainTextLen);
+
+	XFREE(MTYPE_KEYCRYPT_B64DEC, pCipherTextRaw);
+
+	if (rc)
+		return -1;
+
+	if (pPlainTextLen)
+		*pPlainTextLen = PlainTextLen;
+
+	return 0;
+}
+
+/* clang-format off */
+static int debug_keycrypt_test_cmd_gnutls(
+	struct vty	*vty,
+	const char	*cleartext)
+{
+	char			*keyfile_path = NULL;
+	gnutls_x509_privkey_t	pPrivKey;
+
+	int			rc;
+	enum keycrypt_err	krc;
+	char			*pCipherText = NULL;
+	size_t			CipherTextLen;
+	char			*pClearText = NULL;
+	size_t			ClearTextLen;
+	char			*pB64Text;
+	size_t			B64TextLen = 0;
+	/* clang-format on */
+
+	keyfile_path = keycrypt_keyfile_path();
+	if (!keyfile_path) {
+		vty_out(vty, "%s: Error: can't compute keyfile path\n",
+			__func__);
+		return CMD_SUCCESS;
+	}
+
+	zlog_debug("%s: Computed keyfile_path: %s", __func__, keyfile_path);
+
+	krc = keycrypt_read_keyfile_gnutls(keyfile_path, &pPrivKey);
+	if (krc) {
+		vty_out(vty, "%s: Error: %s returned %d: %s\n", __func__,
+			"keycrypt_read_keyfile_gnutls", krc,
+			keycrypt_strerror(krc));
+		XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+		return CMD_SUCCESS;
+	}
+
+	zlog_debug("%s: Read keyfile", __func__);
+
+	krc = keycrypt_encrypt_internal_gnutls(
+		pPrivKey, MTYPE_KEYCRYPT_CIPHER_TEXT, cleartext,
+		strlen(cleartext), &pCipherText, &CipherTextLen);
+	if (krc) {
+		vty_out(vty, "%s: Error: %s returned %d: %s\n", __func__,
+			"keycrypt_encrypt_internal_gnutls", krc,
+			keycrypt_strerror(krc));
+		return CMD_SUCCESS;
+	}
+
+	zlog_debug("%s: encrypted successfully", __func__);
+
+	if (!pCipherText) {
+		vty_out(vty, "%s: missing cipher text\n", __func__);
+		return CMD_SUCCESS;
+	}
+
+	/*
+	 * Encode for printing
+	 */
+
+	krc = keycrypt_base64_encode_gnutls(pCipherText, CipherTextLen,
+					    &pB64Text, &B64TextLen);
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_TEXT, pCipherText);
+
+	if (krc) {
+		vty_out(vty, "%s: Error: %s returned %d: %s\n", __func__,
+			"keycrypt_base64_encode_gnutls", krc,
+			keycrypt_strerror(krc));
+		/* TBD does anything else need to be freed here? */
+		return CMD_SUCCESS;
+	}
+
+	zlog_debug("%s: base64-encoded successfully", __func__);
+
+	vty_out(vty,
+		"INFO: clear text len: %zu, CipherTextLen: %zu, B64TextLen %zu\n",
+		strlen(cleartext), CipherTextLen, B64TextLen);
+
+	vty_out(vty, "INFO: base64 cipher text:\n%s\n", pB64Text);
+
+
+	/*
+	 * Decode back to binary
+	 */
+	keycrypt_base64_decode_gnutls(pB64Text, B64TextLen, &pCipherText,
+				      &CipherTextLen);
+
+	vty_out(vty, "INFO: After B64 decode, CipherTextLen: %zu\n",
+		CipherTextLen);
+
+
+	rc = keycrypt_decrypt_internal_gnutls(
+		pPrivKey, MTYPE_KEYCRYPT_PLAIN_TEXT, pCipherText, CipherTextLen,
+		&pClearText, &ClearTextLen);
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pB64Text);
+
+	if (pCipherText) {
+		if (!strncmp(cleartext, pCipherText, strlen(cleartext))) {
+			vty_out(vty,
+				"%s: cipher text and cleartext same for %zu chars\n",
+				__func__, strlen(cleartext));
+			XFREE(MTYPE_KEYCRYPT_B64DEC, pCipherText);
+			if (pClearText)
+				XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+			return CMD_SUCCESS;
+		}
+		XFREE(MTYPE_KEYCRYPT_B64DEC, pCipherText);
+	}
+
+	if (rc) {
+		vty_out(vty, "%s: Error: keycrypt_decrypt_internal_gnutls\n",
+			__func__);
+		if (pClearText)
+			XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+		return CMD_SUCCESS;
+	}
+
+	if (!pClearText) {
+		vty_out(vty,
+			"%s: keycrypt_decrypt_internal_gnutls didn't return clear text pointer\n",
+			__func__);
+		return CMD_SUCCESS;
+	}
+	if (strlen(cleartext) != ClearTextLen) {
+		vty_out(vty,
+			"%s: decrypted ciphertext length (%zu) != original length (%lu)\n",
+			__func__, ClearTextLen, strlen(cleartext));
+		XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+		return CMD_SUCCESS;
+	}
+
+	if (strncmp(cleartext, pClearText, ClearTextLen)) {
+		vty_out(vty,
+			"%s: decrypted ciphertext differs from original text\n",
+			__func__);
+		XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+		return CMD_SUCCESS;
+	}
+
+	vty_out(vty, "OK: decrypted ciphertext matches original text\n");
+	return CMD_SUCCESS;
+}
+
+static enum keycrypt_err keyfile_read_status_gnutls(const char *keyfile_path,
+						 const char **detail)
+{
+	enum keycrypt_err krc;
+	gnutls_x509_privkey_t pPrivKey;
+
+	*detail = NULL;
+
+	krc = keycrypt_read_keyfile_gnutls(keyfile_path, &pPrivKey);
+	if (krc)
+		*detail = keycrypt_strerror(krc);
+	else
+		gnutls_x509_privkey_deinit(pPrivKey);
+
+	return krc;
+}
+
+static const char *keycrypt_backend_version_string_gnutls(void)
+{
+	return gnutls_check_version(NULL);
+}
+
+/* clang-format off */
+struct keycrypt_backend kbe_gnutls_pkcs1 = {
+	.name			= "gnutls-pkcs1-padding",
+	.f_encrypt		= keycrypt_encrypt_gnutls,
+	.f_decrypt		= keycrypt_decrypt_gnutls,
+	.f_test_cmd		= debug_keycrypt_test_cmd_gnutls,
+	.f_keyfile_read_status	= keyfile_read_status_gnutls,
+	.f_be_version_string	= keycrypt_backend_version_string_gnutls,
+};
+/* clang-format on */
+
+#endif /* KEYCRYPT_HAVE_GNUTLS */
+
+/***********************************************************************
+ *		libgcrypt-specific functions
+ ***********************************************************************/
+
+#if defined KEYCRYPT_HAVE_GCRYPT
+
+/*
+ * Based on libgcrypt-1.5.8 tests/fipsdrv.c read_private_key_file()
+ */
+
+/* clang-format off */
+static unsigned char const asctobin[128] = {
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3e, 0xff, 0xff, 0xff, 0x3f,
+	0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+	0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12,
+	0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24,
+	0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+	0x31, 0x32, 0x33, 0xff, 0xff, 0xff, 0xff, 0xff
+};
+
+static const unsigned char bintoasc[64+1] =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/* clang-format on */
+
+/* clang-format off */
+static enum keycrypt_err keycrypt_base64_decode_gcrypt(
+	const char	*pB64,
+	size_t		B64Length,
+	char		**ppData,
+	size_t		*pDataLength)
+	/* clang-format on */
+{
+	struct sbuf data;
+	size_t length;
+	const char *s;
+	uint8_t val = 0;
+	uint idx = 0;
+	int c = 0;
+
+	sbuf_init(&data, NULL, 0); /* MTYPE_TMP */
+
+	for (s = pB64, length = B64Length; length; length--, s++) {
+		if (isspace(*s))
+			continue;
+		if (*s == '=') {
+			/* Pad character: stop */
+			if (idx == 1)
+				sbuf_push(&data, 0, "%c", val);
+			break;
+		}
+		/* start: change to resolve checkpatch style error */
+		if (*s & 0x80) {
+			sbuf_free(&data);
+			return KC_ERR_BASE64;
+		}
+		c = asctobin[*(unsigned char *)s];
+		if (c == 0xff) {
+			sbuf_free(&data);
+			return KC_ERR_BASE64;
+		}
+		/* end: change to resolve checkpatch style error */
+
+		switch (idx) {
+		case 0:
+			val = c << 2;
+			break;
+		case 1:
+			val |= (c >> 4) & 3;
+			sbuf_push(&data, 0, "%c", val);
+			val = (c << 4) & 0xf0;
+			break;
+		case 2:
+			val |= (c >> 2) & 15;
+			sbuf_push(&data, 0, "%c", val);
+			val = (c << 6) & 0xc0;
+			break;
+		case 3:
+			val |= c & 0x3f;
+			sbuf_push(&data, 0, "%c", val);
+			break;
+		}
+		idx = (idx + 1) % 4;
+	}
+
+	*ppData = XMALLOC(MTYPE_KEYCRYPT_B64DEC, data.pos + 1);
+	memcpy(*ppData, sbuf_buf(&data), data.pos);
+	*(*ppData + data.pos) = '\0';
+	*pDataLength = data.pos;
+	sbuf_free(&data);
+	return KC_OK;
+}
+
+/* clang-format off */
+static enum keycrypt_err keycrypt_base64_encode_gcrypt(
+	const char	*pIn,
+	size_t		InLen,
+	char		**ppOut,
+	size_t		*pOutLen)
+{
+	struct sbuf	data;
+	const uint8_t	*p;
+	uint8_t		inbuf[4];
+	char		outbuf[4];
+	int		idx;
+	int		quads;
+	size_t		length;
+	/* clang-format on */
+
+	sbuf_init(&data, NULL, 0); /* MTYPE_TMP */
+
+	idx = quads = 0;
+	length = InLen;
+	for (p = (const uint8_t *)pIn; length; p++, length--) {
+		inbuf[idx++] = *p;
+		if (idx > 2) {
+			/* clang-format off */
+			outbuf[0] = bintoasc[(*inbuf>>2)&077];
+			outbuf[1] = bintoasc[(((*inbuf<<4)&060)
+						|((inbuf[1] >> 4)&017))&077];
+			outbuf[2] = bintoasc[(((inbuf[1]<<2)&074)
+						|((inbuf[2]>>6)&03))&077];
+			outbuf[3] = bintoasc[inbuf[2]&077];
+			/* clang-format on */
+			sbuf_push(&data, 0, "%c%c%c%c", outbuf[0], outbuf[1],
+				  outbuf[2], outbuf[3]);
+			idx = 0;
+			if (++quads >= (64 / 4)) {
+#ifdef KC_GCRYPT_B64_USE_NEWLINES /* openssl b64 decode doesn't like */
+				sbuf_push(&data, 0, "\n");
+#endif
+				quads = 0;
+			}
+		}
+	}
+	if (idx) {
+		/* clang-format off */
+		outbuf[0] = bintoasc[(*inbuf>>2)&077];
+		if (idx == 1) {
+			outbuf[1] = bintoasc[((*inbuf<<4)&060)&077];
+			outbuf[2] = outbuf[3] = '=';
+		} else {
+			outbuf[1] = bintoasc[(((*inbuf<<4)&060)
+						|((inbuf[1]>>4)&017))&077];
+			outbuf[2] = bintoasc[((inbuf[1]<<2)&074)&077];
+			outbuf[3] = '=';
+		}
+		/* clang-format on */
+		sbuf_push(&data, 0, "%c%c%c%c", outbuf[0], outbuf[1], outbuf[2],
+			  outbuf[3]);
+		quads++;
+	}
+#ifdef KC_GCRYPT_B64_USE_NEWLINES
+	if (quads)
+		sbuf_push(&data, 0, "\n");
+#endif
+
+	*ppOut = XMALLOC(MTYPE_KEYCRYPT_CIPHER_B64, data.pos + 1);
+	memcpy(*ppOut, sbuf_buf(&data), data.pos);
+	*(*ppOut + data.pos) = '\0';
+	*pOutLen = data.pos;
+	sbuf_free(&data);
+	return KC_OK;
+}
+
+/* clang-format off */
+enum keyfile_type {
+	KEYFILE_TYPE_UNKNOWN = 0,
+	KEYFILE_TYPE_PKCS1,
+	KEYFILE_TYPE_PKCS8,
+};
+
+/* ASN.1 classes.  */
+enum {
+	UNIVERSAL = 0,
+	APPLICATION = 1,
+	ASNCONTEXT = 2,
+	PRIVATE = 3
+};
+
+/* ASN.1 tags.  */
+enum {
+	TAG_NONE = 0,
+	TAG_BOOLEAN = 1,
+	TAG_INTEGER = 2,
+	TAG_BIT_STRING = 3,
+	TAG_OCTET_STRING = 4,
+	TAG_NULL = 5,
+	TAG_OBJECT_ID = 6,
+	TAG_OBJECT_DESCRIPTOR = 7,
+	TAG_EXTERNAL = 8,
+	TAG_REAL = 9,
+	TAG_ENUMERATED = 10,
+	TAG_EMBEDDED_PDV = 11,
+	TAG_UTF8_STRING = 12,
+	TAG_REALTIVE_OID = 13,
+	TAG_SEQUENCE = 16,
+	TAG_SET = 17,
+	TAG_NUMERIC_STRING = 18,
+	TAG_PRINTABLE_STRING = 19,
+	TAG_TELETEX_STRING = 20,
+	TAG_VIDEOTEX_STRING = 21,
+	TAG_IA5_STRING = 22,
+	TAG_UTC_TIME = 23,
+	TAG_GENERALIZED_TIME = 24,
+	TAG_GRAPHIC_STRING = 25,
+	TAG_VISIBLE_STRING = 26,
+	TAG_GENERAL_STRING = 27,
+	TAG_UNIVERSAL_STRING = 28,
+	TAG_CHARACTER_STRING = 29,
+	TAG_BMP_STRING = 30
+};
+
+/* ASN.1 Parser object.  */
+struct tag_info {
+	int class;             /* Object class.  */
+	unsigned long tag;     /* The tag of the object.  */
+	unsigned long length;  /* Length of the values.  */
+	int nhdr;              /* Length of the header (TL).  */
+	unsigned int ndef:1;   /* The object has an indefinite length.  */
+	unsigned int cons:1;   /* This is a constructed object.  */
+};
+/* clang-format on */
+
+/* clang-format off */
+static int keycrypt_parse_tag_gcrypt(
+	const char		**buffer,
+	size_t			*buflen,
+	struct tag_info		*ti)
+/* clang-format on */
+{
+	int c;
+	unsigned long tag;
+	const unsigned char *buf = *(const unsigned char **)buffer;
+	size_t length = *buflen;
+
+	ti->length = 0;
+	ti->ndef = 0;
+	ti->nhdr = 0;
+
+	/* Get the tag */
+	if (!length)
+		return -1; /* Premature EOF.  */
+	c = *buf++;
+	length--;
+	ti->nhdr++;
+
+	ti->class = (c & 0xc0) >> 6;
+	ti->cons = !!(c & 0x20);
+	tag = (c & 0x1f);
+
+	if (tag == 0x1f) {
+		tag = 0;
+		do {
+			tag <<= 7;
+			if (!length)
+				return -1; /* Premature EOF.  */
+			c = *buf++;
+			length--;
+			ti->nhdr++;
+			tag |= (c & 0x7f);
+		} while ((c & 0x80));
+	}
+	ti->tag = tag;
+
+	/* Get the length */
+	if (!length)
+		return -1; /* Premature EOF. */
+	c = *buf++;
+	length--;
+	ti->nhdr++;
+
+	if (!(c & 0x80))
+		ti->length = c;
+	else if (c == 0x80)
+		ti->ndef = 1;
+	else if (c == 0xff)
+		return -1; /* Forbidden length value.  */
+	else {
+		unsigned long len = 0;
+		int count = c & 0x7f;
+
+		for (; count; count--) {
+			len <<= 8;
+			if (!length)
+				return -1; /* Premature EOF.  */
+			c = *buf++;
+			length--;
+			ti->nhdr++;
+			len |= (c & 0xff);
+		}
+		ti->length = len;
+	}
+
+	if (ti->class == UNIVERSAL && !ti->tag)
+		ti->length = 0;
+
+	if (ti->length > length)
+		return -1; /* Data larger than buffer.  */
+
+	*buffer = (const char *)buf;
+	*buflen = length;
+	return 0;
+}
+
+/*
+ * Caller must free returned MTYPE_TMP buffer
+ */
+/* clang-format off */
+static enum keycrypt_err keycrypt_unwrap_privkey_file(
+	const char		*filename,
+	char			**ppBuf,
+	size_t			*pLength,
+	enum keyfile_type	*pKeyfileType)
+/* clang-format on */
+{
+	FILE *fp;
+	char buf[BUFSIZ];
+	bool seenbegin = false;
+	struct sbuf data;
+
+	*pKeyfileType = KEYFILE_TYPE_UNKNOWN;
+
+	fp = fopen(filename, "rb");
+	if (!fp) {
+		zlog_err("%s: fopen(\"%s\"): %m", __func__, filename);
+		return KC_ERR_KEYFILE_READ;
+	}
+	sbuf_init(&data, NULL, 0); /* MTYPE_TMP */
+	while (fgets(buf, BUFSIZ, fp)) {
+		if (!strncmp(buf, "-----END ", 9))
+			break;
+		if (seenbegin)
+			sbuf_push(&data, 0, "%s", buf);
+		if (!strncmp(buf, "-----BEGIN ", 11)) {
+			char *p;
+
+			seenbegin = true;
+
+			/*
+			 * BEGIN RSA PRIVATE KEY: PKCS1: (rsa) key only
+			 * BEGIN PRIVATE KEY: PKCS8: ver, algo, key
+			 */
+			p = buf + 11;
+			if (!strncmp(p, "RSA PRIVATE KEY-----", 20))
+				*pKeyfileType = KEYFILE_TYPE_PKCS1;
+			else if (!strncmp(p, "PRIVATE KEY-----", 16))
+				*pKeyfileType = KEYFILE_TYPE_PKCS8;
+			continue;
+		}
+	}
+	fclose(fp);
+
+	*ppBuf = XCALLOC(MTYPE_KEYCRYPT_CIPHER_B64, data.pos + 1);
+	memcpy(*ppBuf, sbuf_buf(&data), data.pos);
+	*(*ppBuf + data.pos) = '\0';
+	*pLength = data.pos;
+	sbuf_free(&data);
+
+	return KC_OK;
+}
+
+/* clang-format off */
+static enum keycrypt_err kc_parse_pkcs1(
+	const char		*pAsn1,
+	size_t			Asn1Length,
+	gcry_sexp_t		*ppPrivKey,	/* caller must free */
+	gcry_sexp_t		*ppPubKey)	/* caller must free */
+
+{
+	const char		*der;
+	size_t			derlen;
+	struct tag_info		ti;
+	gcry_mpi_t		keyparms[8];
+	int			n_keyparms = 8;
+	gcry_sexp_t		s_key_private;
+	gcry_sexp_t		s_key_public;
+	uint8_t			idx;
+	gcry_error_t		err;
+	int			rc;
+	/* clang-format on */
+
+	/* Parse the ASN.1 structure. */
+	der = (const char *)pAsn1;
+	derlen = Asn1Length;
+
+	if (keycrypt_parse_tag_gcrypt(&der, &derlen, &ti)
+	    || ti.tag != TAG_SEQUENCE || ti.class || !ti.cons || ti.ndef) {
+		zlog_debug("%s: %s 1 error", __func__,
+			   "keycrypt_parse_tag_gcrypt");
+		goto bad_asn1;
+	}
+	zlog_debug("%s: tag %lu, length %lu", __func__, ti.tag, ti.length);
+	if (keycrypt_parse_tag_gcrypt(&der, &derlen, &ti)
+	    || ti.tag != TAG_INTEGER || ti.class || ti.cons || ti.ndef) {
+		zlog_debug("%s: %s 2 error", __func__,
+			   "keycrypt_parse_tag_gcrypt");
+		goto bad_asn1;
+	}
+	zlog_debug("%s: tag %lu, length %lu", __func__, ti.tag, ti.length);
+	if (ti.length != 1 || *der) {
+		zlog_debug("%s: value of the first integer is not 0", __func__);
+		goto bad_asn1; /* The value of the first integer is not 0. */
+	}
+	der += ti.length;
+	derlen -= ti.length;
+
+	for (idx = 0; idx < n_keyparms; idx++) {
+		rc = keycrypt_parse_tag_gcrypt(&der, &derlen, &ti);
+		if (rc || ti.tag != TAG_INTEGER || ti.class || ti.cons
+		    || ti.ndef) {
+			zlog_debug("%s: idx %u error, rc %d", __func__, idx,
+				   rc);
+			if (!rc) {
+				zlog_debug(
+					"  tag %lu, class %d, cons %d, ndef %d",
+					ti.tag, ti.class, ti.cons, ti.ndef);
+			}
+			goto bad_asn1;
+		}
+		err = gcry_mpi_scan(keyparms + idx, GCRYMPI_FMT_USG, der,
+				    ti.length, NULL);
+		if (err) {
+			zlog_err("%s: error scanning RSA parameter %d: %s\n",
+				 __func__, idx, gpg_strerror(err));
+			goto error;
+		}
+		der += ti.length;
+		derlen -= ti.length;
+	}
+	if (idx != n_keyparms) {
+		zlog_err("%s: not enough RSA key parameters", __func__);
+		goto error;
+	}
+
+	/*
+	 * Convert from OpenSSL parameter ordering to the OpenPGP order.
+	 * First check that p < q; if not swap p and q and recompute u.
+	 */
+	if (gcry_mpi_cmp(keyparms[3], keyparms[4]) > 0) {
+		zlog_debug("%s: p<q swapping", __func__);
+		gcry_mpi_swap(keyparms[3], keyparms[4]);
+		gcry_mpi_invm(keyparms[7], keyparms[3], keyparms[4]);
+	} else {
+		/*
+		 * Sigh. It seems we must recompute u when we don't swap
+		 */
+		gcry_mpi_invm(keyparms[7], keyparms[3], keyparms[4]);
+	}
+#ifdef KEYCRYPT_LOG_PRIVATE_KEYS /* don't enable in production code */
+	gcry_mpi_t u_copy = NULL;
+
+	for (idx = 0; idx < n_keyparms; idx++) {
+		char pfx;
+		unsigned char *pbuf;
+
+		pfx = idx < 8 ? "nedpq12u"[idx] : '?';
+		err = gcry_mpi_aprint(GCRYMPI_FMT_HEX, &pbuf, NULL,
+				      keyparms[idx]);
+		if (err) {
+			zlog_err("%s: idx %u, gcry_mpi_aprint: %s", __func__,
+				 idx, gpg_strerror(err));
+			continue;
+		}
+		zlog_debug("%s: %c: %s", __func__, pfx, pbuf);
+		gcry_free(pbuf);
+	}
+#endif
+
+	/* Build private key S-expression. */
+	/* clang-format off */
+	err = gcry_sexp_build(&s_key_private, NULL,
+	    "(private-key(rsa(n%m)(e%m)"
+	    /**/            "(d%m)(p%m)(q%m)(u%m)))",
+	    keyparms[0], keyparms[1], keyparms[2],
+	    keyparms[3], keyparms[4], keyparms[7]);
+	/* clang-format on */
+
+	if (err) {
+		for (idx = 0; idx < n_keyparms; idx++)
+			gcry_mpi_release(keyparms[idx]);
+		zlog_err("%s: error building private-key S-expression: %s",
+			 __func__, gpg_strerror(err));
+		return KC_ERR_KEYFILE_PARSE;
+	}
+
+	/* Build public key S-expression */
+	/* clang-format off */
+	err = gcry_sexp_build(&s_key_public, NULL,
+	    "(public-key(rsa(n%m)(e%m)))",
+	    keyparms[0], keyparms[1]);
+	/* clang-format on */
+
+	/* get this out of the way before possible error return */
+	for (idx = 0; idx < n_keyparms; idx++)
+		gcry_mpi_release(keyparms[idx]);
+
+	if (err) {
+		/* TBD free s_key_private */
+		zlog_err("%s: error building private-key S-expression: %s",
+			 __func__, gpg_strerror(err));
+		return KC_ERR_KEYFILE_PARSE;
+	}
+
+	*ppPrivKey = s_key_private;
+	*ppPubKey = s_key_public;
+
+	return KC_OK;
+
+bad_asn1:
+	zlog_err("%s: invalid ASN.1 structure", __func__);
+error:
+	return KC_ERR_KEYFILE_PARSE;
+}
+
+/* currently only handles RSA keys */
+/* clang-format off */
+static enum keycrypt_err kc_parse_pkcs8(
+	char			*pAsn1,
+	size_t			Asn1Length,
+	gcry_sexp_t		*ppPrivKey,	/* caller must free */
+	gcry_sexp_t		*ppPubKey)	/* caller must free */
+
+{
+	const char		*der;
+	size_t			derlen;
+	struct tag_info		ti;
+	/* clang-format on */
+
+	/*
+	 * % openssl asn1parse -in ~/.ssh/frr
+	 *  0:d=0  hl=4 l=1214 cons: SEQUENCE
+	 *  4:d=1  hl=2 l=   1 prim: INTEGER           :00
+	 *  7:d=1  hl=2 l=  13 cons: SEQUENCE
+	 *  9:d=2  hl=2 l=   9 prim: OBJECT            :rsaEncryption
+	 * 20:d=2  hl=2 l=   0 prim: NULL
+	 * 22:d=1  hl=4 l=1192 prim: OCTET STRING      [HEX DUMP]:[bytes...]
+	 *
+	 * The octet string is the private key, which should be asn1-parsed
+	 */
+
+	/*
+	 * Get to the octet string
+	 */
+
+	/* first we should see an integer */
+
+	der = (const char *)pAsn1;
+	derlen = Asn1Length;
+
+	/* This sequence should enclose everything */
+	if (keycrypt_parse_tag_gcrypt(&der, &derlen, &ti)
+	    || ti.tag != TAG_SEQUENCE || ti.class || !ti.cons || ti.ndef) {
+		zlog_debug("%s: %s 1 error", __func__,
+			   "keycrypt_parse_tag_gcrypt");
+		return KC_ERR_KEYFILE_PARSE;
+	}
+	zlog_debug("%s: tag %lu, length %lu", __func__, ti.tag, ti.length);
+
+	/* integer: version 0 */
+	if (keycrypt_parse_tag_gcrypt(&der, &derlen, &ti)
+	    || ti.tag != TAG_INTEGER || ti.class || ti.cons || ti.ndef) {
+		zlog_debug("%s: %s 2 error", __func__,
+			   "keycrypt_parse_tag_gcrypt");
+		return KC_ERR_KEYFILE_PARSE;
+	}
+	zlog_debug("%s: tag %lu, length %lu", __func__, ti.tag, ti.length);
+	if (ti.length != 1 || *der) {
+		zlog_debug("%s: value of the first integer is not 0", __func__);
+		return KC_ERR_KEYFILE_PARSE;
+	}
+	der += ti.length;
+	derlen -= ti.length; /* go past value */
+
+	/* This sequence should enclose the algorithm id and any params */
+	if (keycrypt_parse_tag_gcrypt(&der, &derlen, &ti)
+	    || ti.tag != TAG_SEQUENCE || ti.class || !ti.cons || ti.ndef) {
+		zlog_debug("%s: %s 3 error", __func__,
+			   "keycrypt_parse_tag_gcrypt");
+		return KC_ERR_KEYFILE_PARSE;
+	}
+	zlog_debug("%s: tag %lu, length %lu", __func__, ti.tag, ti.length);
+
+	/* clang-format off */
+	{
+		/* look at enclosed object ID to ensure it is "rsaEncryption" */
+		const char	*der_inner = der;
+		size_t		derlen_inner = ti.length;
+		struct tag_info	ti_inner;
+		bool		is_rsaEncryption = false;
+
+		while (!keycrypt_parse_tag_gcrypt(&der_inner, &derlen_inner,
+			&ti_inner)) {
+
+			if (ti_inner.tag == TAG_OBJECT_ID &&
+			    ti_inner.length == 9) {
+
+				const char *p = der_inner;
+
+				zlog_debug("%s: examining oid", __func__);
+				zlog_debug("  %02x%02x%02x%02x %02x%02x%02x%02x %02x",
+				    p[0], p[1], p[2], p[3],
+				    p[4], p[5], p[6], p[7],
+				    p[8]);
+				/*
+				 * 1.2.840.113549.1.1.1 is "rsaEncryption"
+				 * which is encoded as
+				 * 06 09 2A 86 48 86 F7 0D 01 01 01
+				 * Type 0x06 = TAG_OBJECT_ID
+				 * Len 0x09
+				 *
+				 */
+				if (!memcmp(p,
+				    "\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01",
+				    ti_inner.length))
+					is_rsaEncryption = true;
+			}
+			der_inner += ti_inner.length;
+			derlen_inner -= ti_inner.length;
+		}
+
+		if (!is_rsaEncryption) {
+			zlog_err("%s: rsaEncryption objectID not found",
+			    __func__);
+			return KC_ERR_KEYFILE_PARSE;
+		}
+	}
+	/* clang-format on */
+	der += ti.length;
+	derlen -= ti.length; /* skip oid sequence value */
+
+	/* This sequence should enclose the algorithm id and any params */
+	if (keycrypt_parse_tag_gcrypt(&der, &derlen, &ti)
+	    || ti.tag != TAG_OCTET_STRING || ti.class || ti.cons || ti.ndef) {
+		zlog_debug("%s: %s 4 error", __func__,
+			   "keycrypt_parse_tag_gcrypt");
+		return KC_ERR_KEYFILE_PARSE;
+	}
+	zlog_debug("%s: tag %lu, length %lu", __func__, ti.tag, ti.length);
+
+	/*
+	 * Now we're lined up at the octet stream
+	 */
+	return kc_parse_pkcs1(der, derlen, ppPrivKey, ppPubKey);
+}
+
+/* clang-format off */
+static enum keycrypt_err keycrypt_read_keyfile_gcrypt(
+	const char		*filename,
+	gcry_sexp_t		*ppPrivKey,	/* caller must free */
+	gcry_sexp_t		*ppPubKey)	/* caller must free */
+
+{
+	enum keycrypt_err	krc;
+	char			*pB64 = NULL;
+	size_t			B64Length;
+	char			*pAsn1;
+	size_t			Asn1Length;
+	enum keyfile_type	KeyfileType;
+	/* clang-format on */
+
+	/* get buffer that is base64-encoded contents of PEM file */
+	krc = keycrypt_unwrap_privkey_file(filename, &pB64, &B64Length,
+					   &KeyfileType);
+	if (krc)
+		return krc;
+
+	/* base64 decode key */
+	krc = keycrypt_base64_decode_gcrypt(pB64, B64Length, &pAsn1,
+					    &Asn1Length);
+	XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pB64);
+	if (krc)
+		return krc;
+
+	zlog_debug("%s: B64Length %zu, Asn1Length %zu", __func__, B64Length,
+		   Asn1Length);
+
+	/*
+	 * parse DER structure
+	 */
+	switch (KeyfileType) {
+	case KEYFILE_TYPE_PKCS1:
+		krc = kc_parse_pkcs1(pAsn1, Asn1Length, ppPrivKey, ppPubKey);
+		break;
+	case KEYFILE_TYPE_PKCS8:
+		krc = kc_parse_pkcs8(pAsn1, Asn1Length, ppPrivKey, ppPubKey);
+		break;
+	case KEYFILE_TYPE_UNKNOWN:
+		zlog_debug("%s: \"%s\": unknown private key format", __func__,
+			   filename);
+		break;
+	}
+
+	XFREE(MTYPE_KEYCRYPT_B64DEC, pAsn1);
+	return krc;
+}
+
+/* clang-format off */
+static enum keycrypt_err
+keycrypt_read_default_keyfile_gcrypt(
+	gcry_sexp_t	*ppPrivKey,
+	gcry_sexp_t	*ppPubKey)
+/* clang-format on */
+{
+	enum keycrypt_err rc;
+	char *keyfile_path;
+
+	*ppPrivKey = NULL;
+	*ppPubKey = NULL;
+
+	keyfile_path = keycrypt_keyfile_path();
+	if (!keyfile_path) {
+		zlog_err("%s: Error: can't compute keyfile path\n", __func__);
+		return KC_ERR_KEYFILE_PATH;
+	}
+
+	rc = keycrypt_read_keyfile_gcrypt(keyfile_path, ppPrivKey, ppPubKey);
+	if (rc) {
+		zlog_err("%s: Error: %s can't read \"%s\"\n", __func__,
+			 "keycrypt_read_keyfile_gcrypt", keyfile_path);
+		XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+		return rc;
+	}
+
+	XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+	return KC_OK;
+}
+
+/*
+ * Caller should not free returned keys
+ */
+/* clang-format off */
+static void keycrypt_get_pkey_gcrypt(
+	gcry_sexp_t	*ppPrivKey,
+	gcry_sexp_t	*ppPubKey)
+{
+	static time_t		keycrypt_pkey_check_time;
+	static gcry_sexp_t	pCachedPrivKey;
+	static gcry_sexp_t	pCachedPubKey;
+	time_t			now;
+	bool			old = false;
+	/* clang-format on */
+
+	now = monotime(NULL);
+	if (now - keycrypt_pkey_check_time > KEYCRYPT_CHECK_PKEY_SECONDS)
+		old = true;
+
+	if (!pCachedPrivKey || !pCachedPubKey || old) {
+		enum keycrypt_err rc;
+		gcry_sexp_t pPrivKey;
+		gcry_sexp_t pPubKey;
+
+		keycrypt_pkey_check_time = now;
+
+		rc = keycrypt_read_default_keyfile_gcrypt(&pPrivKey, &pPubKey);
+		if (rc != KC_OK)
+			goto end;
+
+		if (pCachedPrivKey)
+			gcry_sexp_release(pCachedPrivKey);
+		if (pCachedPubKey)
+			gcry_sexp_release(pCachedPubKey);
+
+		pCachedPrivKey = pPrivKey;
+		pCachedPubKey = pPubKey;
+	}
+end:
+	*ppPrivKey = pCachedPrivKey;
+	*ppPubKey = pCachedPubKey;
+}
+
+/* clang-format off */
+static int keycrypt_encrypt_internal_gcrypt_padding(
+	bool			use_pkcs1_padding,		/* 0: oaep */
+	gcry_sexp_t		pPubKey,			/* IN */
+	struct memtype		*mt,	/* of CipherText */	/* IN */
+	const char		*pPlainText,			/* IN */
+	size_t			PlainTextLen,			/* IN */
+	char			**ppCipherText,			/* OUT */
+	size_t			*pCipherTextLen)		/* OUT */
+
+{
+	gcry_error_t		grc;
+	gcry_sexp_t		s_ciphertext;
+	gcry_sexp_t		s_plaintext;
+	gcry_buffer_t		b_ciphertext;
+	/* clang-format on */
+
+	grc = gcry_sexp_build(&s_plaintext, NULL, "(data(flags %s)(value %b))",
+			      (use_pkcs1_padding ? "pkcs1" : "oaep"),
+			      PlainTextLen, pPlainText);
+	if (grc) {
+		zlog_err("%s: Error: gcry_sexp_build(s_plaintext): %s",
+			 __func__, gpg_strerror(grc));
+		return KC_ERR_DECRYPT;
+	}
+	grc = gcry_pk_encrypt(&s_ciphertext, s_plaintext, pPubKey);
+	gcry_sexp_release(s_plaintext);
+	if (grc) {
+		zlog_err("%s: Error: gcry_pk_encrypt(s_ciphertext): %s",
+			 __func__, gpg_strerror(grc));
+		return KC_ERR_DECRYPT;
+	}
+
+	/*
+	 * extract plaintext from s-expression
+	 */
+	memset(&b_ciphertext, 0, sizeof(b_ciphertext));
+	grc = gcry_sexp_extract_param(s_ciphertext, NULL, "&'a'", &b_ciphertext,
+				      NULL);
+	gcry_sexp_release(s_ciphertext);
+	if (grc) {
+		zlog_err("%s: Error: %s: %s", __func__,
+			 "gcry_sexp_extract_param", gpg_strerror(grc));
+		return -1;
+	}
+
+	/*
+	 * Copy ciphertext to FRR buffer
+	 */
+	*ppCipherText = XCALLOC(mt, b_ciphertext.len + 1);
+	*pCipherTextLen = b_ciphertext.len;
+	memcpy(*ppCipherText, ((char *)b_ciphertext.data) + b_ciphertext.off,
+	       b_ciphertext.len);
+	*(*ppCipherText + b_ciphertext.len) = 0;
+	if (b_ciphertext.data)
+		gcry_free(b_ciphertext.data);
+
+	return KC_OK;
+}
+
+/* clang-format off */
+static int keycrypt_decrypt_internal_gcrypt_padding(
+	bool			use_pkcs1_padding,		/* 0: oaep */
+	gcry_sexp_t		pPrivKey,			/* IN */
+	struct memtype		*mt,	/* of PlainText */	/* IN */
+	const char		*pCipherText,			/* IN */
+	size_t			CipherTextLen,			/* IN */
+	char			**ppPlainText,			/* OUT */
+	size_t			*pPlainTextLen)			/* OUT */
+
+{
+	gcry_error_t		grc;
+	gcry_sexp_t		s_ciphertext;
+	gcry_sexp_t		s_plaintext;
+	gcry_buffer_t		b_plaintext;
+	/* clang-format on */
+
+	grc = gcry_sexp_build(&s_ciphertext, NULL,
+			      "(enc-val(flags %s)(rsa(a%b)))",
+			      (use_pkcs1_padding ? "pkcs1" : "oaep"),
+			      CipherTextLen, pCipherText);
+	if (grc) {
+		zlog_err("%s: Error: gcry_sexp_build(s_ciphertext): %s",
+			 __func__, gpg_strerror(grc));
+		return KC_ERR_DECRYPT;
+	}
+
+	grc = gcry_pk_decrypt(&s_plaintext, s_ciphertext, pPrivKey);
+	gcry_sexp_release(s_ciphertext);
+	if (grc) {
+		zlog_err("%s: Error: gcry_pk_decrypt(s_ciphertext): %s",
+			 __func__, gpg_strerror(grc));
+		return KC_ERR_DECRYPT;
+	}
+
+	/*
+	 * extract plaintext from s-expression
+	 */
+	memset(&b_plaintext, 0, sizeof(b_plaintext));
+	grc = gcry_sexp_extract_param(s_plaintext, NULL, "&'value'",
+				      &b_plaintext, NULL);
+	gcry_sexp_release(s_plaintext);
+	if (grc) {
+		zlog_err("%s: Error: %s: %s", __func__,
+			 "gcry_sexp_extract_param", gpg_strerror(grc));
+		return -1;
+	}
+
+	/*
+	 * Copy plaintext to FRR buffer
+	 */
+	*ppPlainText = XCALLOC(mt, b_plaintext.len + 1);
+	*pPlainTextLen = b_plaintext.len;
+	memcpy(*ppPlainText, ((char *)b_plaintext.data) + b_plaintext.off,
+	       b_plaintext.len);
+	*(*ppPlainText + b_plaintext.len) = 0;
+	if (b_plaintext.data)
+		gcry_free(b_plaintext.data);
+
+	return KC_OK;
+}
+
+/*
+ * After successful return (0), caller MUST free base-64 encoded
+ * cipher text via XFREE(MTYPE_KEYCRYPT_CIPHER_B64, ptr)
+ */
+/* clang-format off */
+static int keycrypt_encrypt_gcrypt_padding(
+	bool		use_pkcs1_padding,	/* 0: oaep */
+	const char	*pPlainText,		/* IN */
+	size_t		PlainTextLen,		/* IN */
+	char		**ppCipherTextB64,	/* OUT */
+	size_t		*pCipherTextB64Len)	/* OUT */
+
+{
+	gcry_sexp_t		pPrivKey;
+	gcry_sexp_t		pPubKey;
+	int			rc;
+	enum keycrypt_err	krc;
+	char			*pCipherTextRaw;
+	size_t			CipherTextRawLen = 0;
+	size_t			B64len = 0;
+	/* clang-format on */
+
+	keycrypt_get_pkey_gcrypt(&pPrivKey, &pPubKey);
+	if (!pPubKey)
+		return -1;
+
+	rc = keycrypt_encrypt_internal_gcrypt_padding(
+		use_pkcs1_padding, pPubKey, MTYPE_KEYCRYPT_CIPHER_TEXT,
+		pPlainText, PlainTextLen, &pCipherTextRaw, &CipherTextRawLen);
+	if (rc)
+		return -1;
+
+	krc = keycrypt_base64_encode_gcrypt(pCipherTextRaw, CipherTextRawLen,
+					    ppCipherTextB64, &B64len);
+
+	if (krc) {
+		zlog_err("%s: %s returned %d: %s", __func__,
+			 "keycrypt_base64_encode_gnutls", krc,
+			 keycrypt_strerror(krc));
+		XFREE(MTYPE_KEYCRYPT_CIPHER_TEXT, pCipherTextRaw);
+		return krc;
+	}
+
+	if (pCipherTextB64Len)
+		*pCipherTextB64Len = B64len;
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_TEXT, pCipherTextRaw);
+
+	return 0;
+}
+
+/* clang-format off */
+static int keycrypt_encrypt_gcrypt_pkcs1(
+	const char	*pPlainText,		/* IN */
+	size_t		PlainTextLen,		/* IN */
+	char		**ppCipherTextB64,	/* OUT */
+	size_t		*pCipherTextB64Len)	/* OUT */
+
+/* clang-format on */
+{
+	return keycrypt_encrypt_gcrypt_padding(1, pPlainText, PlainTextLen,
+					       ppCipherTextB64,
+					       pCipherTextB64Len);
+}
+
+/* clang-format off */
+static int keycrypt_encrypt_gcrypt_oaep(
+	const char	*pPlainText,		/* IN */
+	size_t		PlainTextLen,		/* IN */
+	char		**ppCipherTextB64,	/* OUT */
+	size_t		*pCipherTextB64Len)	/* OUT */
+
+/* clang-format on */
+{
+	return keycrypt_encrypt_gcrypt_padding(0, pPlainText, PlainTextLen,
+					       ppCipherTextB64,
+					       pCipherTextB64Len);
+}
+
+/* clang-format off */
+static int keycrypt_decrypt_gcrypt_padding(
+	bool		use_pkcs1_padding,		/* 0: oaep */
+	struct memtype	*mt,	/* of PlainText */	/* IN */
+	const char	*pCipherTextB64,		/* IN */
+	size_t		CipherTextB64Len,		/* IN */
+	char		**ppPlainText,			/* OUT */
+	size_t		*pPlainTextLen)			/* OUT */
+
+{
+	gcry_sexp_t		pPrivKey;
+	gcry_sexp_t		pPubKey;
+	int			rc;
+	char			*pCipherTextRaw;
+	size_t			CipherTextRawLen = 0;
+	size_t			PlainTextLen = 0;
+	enum keycrypt_err	krc;
+	/* clang-format on */
+
+	keycrypt_get_pkey_gcrypt(&pPrivKey, &pPubKey);
+	if (!pPrivKey)
+		return -1;
+
+	krc = keycrypt_base64_decode_gcrypt(pCipherTextB64, CipherTextB64Len,
+					    &pCipherTextRaw, &CipherTextRawLen);
+	if (krc) {
+		zlog_err("%s: Error: %s returned %d: %s", __func__,
+			 "keycrypt_base64_decode_gcrypt", krc,
+			 keycrypt_strerror(krc));
+		return -1;
+	}
+
+	rc = keycrypt_decrypt_internal_gcrypt_padding(
+		0, pPrivKey, mt, pCipherTextRaw, CipherTextRawLen, ppPlainText,
+		&PlainTextLen);
+
+	XFREE(MTYPE_KEYCRYPT_B64DEC, pCipherTextRaw);
+
+	if (rc)
+		return -1;
+
+	if (pPlainTextLen)
+		*pPlainTextLen = PlainTextLen;
+
+	return 0;
+}
+
+/* clang-format off */
+static int keycrypt_decrypt_gcrypt_pkcs1(
+	struct memtype	*mt,	/* of PlainText */	/* IN */
+	const char	*pCipherTextB64,		/* IN */
+	size_t		CipherTextB64Len,		/* IN */
+	char		**ppPlainText,			/* OUT */
+	size_t		*pPlainTextLen)			/* OUT */
+
+/* clang-format on */
+{
+	return keycrypt_decrypt_gcrypt_padding(1, mt, pCipherTextB64,
+					       CipherTextB64Len, ppPlainText,
+					       pPlainTextLen);
+}
+
+/* clang-format off */
+static int keycrypt_decrypt_gcrypt_oaep(
+	struct memtype	*mt,	/* of PlainText */	/* IN */
+	const char	*pCipherTextB64,		/* IN */
+	size_t		CipherTextB64Len,		/* IN */
+	char		**ppPlainText,			/* OUT */
+	size_t		*pPlainTextLen)			/* OUT */
+
+/* clang-format on */
+{
+	return keycrypt_decrypt_gcrypt_padding(0, mt, pCipherTextB64,
+					       CipherTextB64Len, ppPlainText,
+					       pPlainTextLen);
+}
+
+/* clang-format off */
+static int debug_keycrypt_test_cmd_gcrypt_padding(
+	bool		use_pkcs1_padding,		/* 0: oaep */
+	struct vty	*vty,
+	const char	*cleartext)
+{
+	char			*keyfile_path = NULL;
+	gcry_sexp_t		pPrivKey;
+	gcry_sexp_t		pPubKey;
+
+	int			rc;
+	enum keycrypt_err	krc;
+	char			*pCipherText = NULL;
+	size_t			CipherTextLen;
+	char			*pClearText = NULL;
+	size_t			ClearTextLen;
+	char			*pB64Text;
+	size_t			B64TextLen = 0;
+	/* clang-format on */
+
+	keyfile_path = keycrypt_keyfile_path();
+	if (!keyfile_path) {
+		vty_out(vty, "%s: Error: can't compute keyfile path\n",
+			__func__);
+		return CMD_SUCCESS;
+	}
+
+	zlog_debug("%s: Computed keyfile_path: %s", __func__, keyfile_path);
+
+	krc = keycrypt_read_keyfile_gcrypt(keyfile_path, &pPrivKey, &pPubKey);
+	if (krc) {
+		vty_out(vty, "%s: Error: %s returned %d: %s\n", __func__,
+			"keycrypt_read_keyfile_gcrypt", krc,
+			keycrypt_strerror(krc));
+		XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+		return CMD_SUCCESS;
+	}
+
+	zlog_debug("%s: Read keyfile", __func__);
+
+	krc = keycrypt_encrypt_internal_gcrypt_padding(
+		use_pkcs1_padding, pPrivKey, MTYPE_KEYCRYPT_CIPHER_TEXT,
+		cleartext, strlen(cleartext), &pCipherText, &CipherTextLen);
+	if (krc) {
+		vty_out(vty, "%s: Error: %s returned %d: %s\n", __func__,
+			"keycrypt_encrypt_internal_gcrypt_padding", krc,
+			keycrypt_strerror(krc));
+		return CMD_SUCCESS;
+	}
+
+	zlog_debug("%s: encrypted successfully", __func__);
+
+	if (!pCipherText) {
+		vty_out(vty, "%s: missing cipher text\n", __func__);
+		return CMD_SUCCESS;
+	}
+
+	/*
+	 * Encode for printing
+	 */
+
+	krc = keycrypt_base64_encode_gcrypt(pCipherText, CipherTextLen,
+					    &pB64Text, &B64TextLen);
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_TEXT, pCipherText);
+
+	if (krc) {
+		vty_out(vty, "%s: Error: %s returned %d: %s\n", __func__,
+			"keycrypt_base64_encode_gcrypt", krc,
+			keycrypt_strerror(krc));
+		/* TBD does anything else need to be freed here? */
+		return CMD_SUCCESS;
+	}
+
+	zlog_debug("%s: base64-encoded successfully", __func__);
+
+	vty_out(vty,
+		"INFO: clear text len: %zu, CipherTextLen: %zu, B64TextLen %zu\n",
+		strlen(cleartext), CipherTextLen, B64TextLen);
+
+	vty_out(vty, "INFO: base64 cipher text:\n%s\n", pB64Text);
+
+
+	/*
+	 * Decode back to binary
+	 */
+	keycrypt_base64_decode_gcrypt(pB64Text, B64TextLen, &pCipherText,
+				      &CipherTextLen);
+
+	vty_out(vty, "INFO: After B64 decode, CipherTextLen: %zu\n",
+		CipherTextLen);
+
+
+	rc = keycrypt_decrypt_internal_gcrypt_padding(
+		use_pkcs1_padding, pPrivKey, MTYPE_KEYCRYPT_PLAIN_TEXT,
+		pCipherText, CipherTextLen, &pClearText, &ClearTextLen);
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pB64Text);
+
+	if (pCipherText) {
+		if (!strncmp(cleartext, pCipherText, strlen(cleartext))) {
+			vty_out(vty,
+				"%s: cipher text and cleartext same for %zu chars\n",
+				__func__, strlen(cleartext));
+			XFREE(MTYPE_KEYCRYPT_B64DEC, pCipherText);
+			if (pClearText)
+				XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+			return CMD_SUCCESS;
+		}
+		XFREE(MTYPE_KEYCRYPT_B64DEC, pCipherText);
+	}
+
+	if (rc) {
+		vty_out(vty,
+			"%s: Error: keycrypt_decrypt_internal_gcrypt_padding\n",
+			__func__);
+		if (pClearText)
+			XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+		return CMD_SUCCESS;
+	}
+
+	if (!pClearText) {
+		vty_out(vty,
+			"%s: keycrypt_decrypt_internal_gcrypt_padding didn't return clear text pointer\n",
+			__func__);
+		return CMD_SUCCESS;
+	}
+	if (strlen(cleartext) != ClearTextLen) {
+		vty_out(vty,
+			"%s: decrypted ciphertext length (%zu) != original length (%lu)\n",
+			__func__, ClearTextLen, strlen(cleartext));
+		XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+		return CMD_SUCCESS;
+	}
+
+	if (strncmp(cleartext, pClearText, ClearTextLen)) {
+		vty_out(vty,
+			"%s: decrypted ciphertext differs from original text\n",
+			__func__);
+		XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pClearText);
+		return CMD_SUCCESS;
+	}
+
+	vty_out(vty, "OK: decrypted ciphertext matches original text\n");
+	return CMD_SUCCESS;
+}
+
+/* clang-format off */
+static int debug_keycrypt_test_cmd_gcrypt_pkcs1(
+	struct vty	*vty,
+	const char	*cleartext)
+{
+	return debug_keycrypt_test_cmd_gcrypt_padding(1, vty, cleartext);
+}
+
+static int debug_keycrypt_test_cmd_gcrypt_oaep(
+	struct vty	*vty,
+	const char	*cleartext)
+{
+	return debug_keycrypt_test_cmd_gcrypt_padding(0, vty, cleartext);
+}
+/* clang-format on */
+
+/* clang-format off */
+static enum keycrypt_err keyfile_read_status_gcrypt(
+	const char	*keyfile_path,
+	const char	**detail)
+{
+	enum keycrypt_err	krc;
+	gcry_sexp_t		pPrivKey;
+	gcry_sexp_t		pPubKey;
+	/* clang-format on */
+
+	*detail = NULL;
+
+	krc = keycrypt_read_keyfile_gcrypt(keyfile_path, &pPrivKey, &pPubKey);
+	if (krc)
+		*detail = keycrypt_strerror(krc);
+
+	return krc;
+}
+
+static const char *keycrypt_backend_version_string_gcrypt(void)
+{
+	static char versionstring[80]; /* arbitrary limit */
+
+	versionstring[0] = 0;
+
+	char *str = gcry_get_config(0, "version");
+
+	if (str) {
+		strlcpy(versionstring, str, sizeof(versionstring));
+		gcry_free(str);
+		return versionstring;
+	}
+	return "gcrypt (unknown version)";
+}
+
+/* clang-format off */
+struct keycrypt_backend kbe_gcrypt_pkcs1 = {
+	.name			= "gcrypt-pkcs1-padding",
+	.f_encrypt		= keycrypt_encrypt_gcrypt_pkcs1,
+	.f_decrypt		= keycrypt_decrypt_gcrypt_pkcs1,
+	.f_test_cmd		= debug_keycrypt_test_cmd_gcrypt_pkcs1,
+	.f_keyfile_read_status	= keyfile_read_status_gcrypt,
+	.f_be_version_string	= keycrypt_backend_version_string_gcrypt,
+};
+
+struct keycrypt_backend kbe_gcrypt_oaep = {
+	.name			= "gcrypt",
+	.f_encrypt		= keycrypt_encrypt_gcrypt_oaep,
+	.f_decrypt		= keycrypt_decrypt_gcrypt_oaep,
+	.f_test_cmd		= debug_keycrypt_test_cmd_gcrypt_oaep,
+	.f_keyfile_read_status	= keyfile_read_status_gcrypt,
+	.f_be_version_string	= keycrypt_backend_version_string_gcrypt,
+};
+/* clang-format on */
+
+#endif /* KEYCRYPT_HAVE_GCRYPT */
+
+/***********************************************************************
+ *		null backend simplifies error handling below
+ ***********************************************************************/
+
+/* clang-format off */
+static int keycrypt_encrypt_null(
+	const char	*pPlainText,		/* IN */
+	size_t		PlainTextLen,		/* IN */
+	char		**ppCipherTextB64,	/* OUT */
+	size_t		*pCipherTextB64Len)	/* OUT */
+
+{
+	zlog_err("%s: KEYCRYPT_ENABLED not defined: keycrypt not available",
+		 __func__);
+	return -1;
+}
+static int keycrypt_decrypt_null(
+	struct memtype	*mt,	/* of PlainText */	/* IN */
+	const char	*pCipherTextB64,		/* IN */
+	size_t		CipherTextB64Len,		/* IN */
+	char		**ppPlainText,			/* OUT */
+	size_t		*pPlainTextLen)			/* OUT */
+
+{
+	zlog_err("%s: KEYCRYPT_ENABLED not defined: keycrypt not available",
+		 __func__);
+	return -1;
+}
+
+static int debug_keycrypt_test_cmd_null(
+	struct vty	*vty,
+	const char	*cleartext)
+{
+	vty_out(vty, "Error: keycrypt not enabled in this build\n");
+	return CMD_SUCCESS;
+}
+
+static const char *keycrypt_backend_version_string_null(void)
+{
+	return "null backend version 0";
+}
+
+struct keycrypt_backend kbe_null = {
+	.name			= NULL,
+	.f_encrypt		= keycrypt_encrypt_null,
+	.f_decrypt		= keycrypt_decrypt_null,
+	.f_test_cmd		= debug_keycrypt_test_cmd_null,
+	.f_keyfile_read_status	= NULL,
+	.f_be_version_string	= keycrypt_backend_version_string_null,
+};
+/* clang-format on */
+
+/***********************************************************************
+ *		externally-visible functions
+ ***********************************************************************/
+
+
+/*
+ * first backend present is the one we use
+ */
+/* clang-format off */
+static struct keycrypt_backend *keycrypt_backends[] = {
+#ifdef KEYCRYPT_HAVE_GCRYPT
+	&kbe_gcrypt_oaep,
+#if KEYCRYPT_ENABLE_PKCS1_PADDING
+	&kbe_gcrypt_pkcs1,
+#endif
+#endif
+#ifdef KEYCRYPT_HAVE_OPENSSL
+	&kbe_openssl_oaep,
+#if KEYCRYPT_ENABLE_PKCS1_PADDING
+	&kbe_openssl_pkcs1,
+#endif
+#endif
+#ifdef KEYCRYPT_HAVE_GNUTLS
+#if KEYCRYPT_ENABLE_PKCS1_PADDING
+	&kbe_gnutls_pkcs1,
+#endif
+#endif
+	&kbe_null,
+	NULL};
+/* clang-format on */
+
+struct keycrypt_backend *kc_current_backend;
+
+#define KC_BACKEND (kc_current_backend)
+
+const char *keycrypt_strerror(enum keycrypt_err kc_err)
+{
+	switch (kc_err) {
+	case KC_OK:
+		return "No error";
+	case KC_ERR_MEMORY:
+		return "Can't allocate memory";
+	case KC_ERR_BASE64:
+		return "base64 encode/decode error";
+	case KC_ERR_DECRYPT:
+		return "Can't decrypt";
+	case KC_ERR_ENCRYPT:
+		return "Can't encrypt";
+	case KC_ERR_BUILD_NOT_ENABLED:
+		return "keycrypt not enabled in this build";
+	case KC_ERR_KEYFILE_PATH:
+		return "Can't compute private key file path";
+	case KC_ERR_KEYFILE_READ:
+		return "Can't read private key file";
+	case KC_ERR_KEYFILE_PARSE:
+		return "Can't parse private key file";
+	case KC_ERR_KEYFILE_EXISTS:
+		return "Keyfile already exists";
+	case KC_ERR_INTERNAL:
+		return "Unexpected/internal error";
+	}
+	return "Unknown error";
+}
+
+/*
+ * After successful return (0), caller MUST free base-64 encoded
+ * cipher text via XFREE(MTYPE_KEYCRYPT_CIPHER_B64, ptr)
+ */
+int keycrypt_encrypt(const char *pPlainText,    /* IN */
+		     size_t PlainTextLen,       /* IN */
+		     char **ppCipherTextB64,    /* OUT */
+		     size_t *pCipherTextB64Len) /* OUT */
+
+{
+	return (*KC_BACKEND->f_encrypt)(pPlainText, PlainTextLen,
+					ppCipherTextB64, pCipherTextB64Len);
+}
+
+int keycrypt_decrypt(struct memtype *mt, /* of PlainText */ /* IN */
+		     const char *pCipherTextB64,	    /* IN */
+		     size_t CipherTextB64Len,		    /* IN */
+		     char **ppPlainText,		    /* OUT */
+		     size_t *pPlainTextLen)		    /* OUT */
+
+{
+	return (*KC_BACKEND->f_decrypt)(mt, pCipherTextB64, CipherTextB64Len,
+					ppPlainText, pPlainTextLen);
+}
+
+/*
+ * keycrypt_build_passwords
+ *
+ * Takes a single encrypted or plaintext password as input.
+ *
+ * Attempts to encrypt or decrypt as needed, and returns either
+ * one or two dynamically-allocated strings containing the
+ * plaintext and encrypted passwords.
+ *
+ * Caller MUST take ownership of any returned allocated strings.
+ * These strings are indicated by non-NULL pointer values returned
+ * via the ppPlainText and ppCryptText parameters.
+ *
+ * NOTE! By design, this function allocates strings even if it
+ * returns an error value.
+ *
+ * Return codes:
+ *
+ *	0: KC_OK	Successful encrypt or decrypt operation
+ *	!0		encrypt or decrypt failed
+ */
+/* clang-format off */
+enum keycrypt_err
+keycrypt_build_passwords(
+	const char	*password_in,	/* IN */
+	bool		is_encrypted,	/* IN */
+	struct memtype	*mt_plaintext,	/* IN */
+	char		**ppPlainText,	/* OUT type mt_plaintext */
+	char		**ppCryptText)	/* OUT MTYPE_KEYCRYPT_CIPHER_B64 */
+
+{
+	*ppPlainText = NULL;
+	*ppCryptText = NULL;
+
+	if (is_encrypted) {
+		/* don't lose encrypted password */
+		*ppCryptText = XSTRDUP(MTYPE_KEYCRYPT_CIPHER_B64, password_in);
+
+#ifdef KEYCRYPT_ENABLED
+		int rc;
+
+		rc = keycrypt_decrypt(mt_plaintext, password_in,
+				     strlen(password_in), ppPlainText, NULL);
+
+		if (rc) {
+			zlog_err("%s: keycrypt_decrypt failed", __func__);
+			return KC_ERR_DECRYPT;
+		}
+#else
+		zlog_err("%s: can't decrypt: keycrypt not supported in this build",
+		    __func__);
+		return KC_ERR_BUILD_NOT_ENABLED;
+#endif
+
+	} else {
+
+		*ppPlainText = XSTRDUP(mt_plaintext, password_in);
+
+		if (keycrypt_is_now_encrypting()) {
+
+#ifdef KEYCRYPT_ENABLED
+			if (keycrypt_encrypt(password_in, strlen(password_in),
+					     ppCryptText, NULL)) {
+				zlog_err("%s: keycrypt_encrypt failed",
+				    __func__);
+				return KC_ERR_ENCRYPT;
+			}
+#else
+			zlog_err("%s: can't encrypt: keycrypt not supported in this build",
+			    __func__);
+			return KC_ERR_BUILD_NOT_ENABLED;
+#endif
+
+		}
+	}
+
+	return KC_OK;
+}
+/* clang-format on */
+
+/* clang-format off */
+DEFUN_HIDDEN (debug_keycrypt_test,
+	      debug_keycrypt_test_cmd,
+	      "debug keycrypt-test STRING",
+	      "Debug command\n"
+	      "Test keycrypt encryption and decryption\n"
+	      "plain text to encrypt and decrypt\n")
+/* clang-format on */
+{
+	int idx_string = 2;
+	const char *cleartext = argv[idx_string]->arg;
+
+	return (*KC_BACKEND->f_test_cmd)(vty, cleartext);
+}
+
+/* clang-format off */
+static void inter_backend_test(
+	struct vty		*vty,
+	const char		*cleartext,
+	struct keycrypt_backend	*b1,
+	struct keycrypt_backend	*b2)
+{
+	size_t	cleartext_len;
+	char	*pPlainText;
+	char	*pCipherTextB64;
+	size_t	PlainTextLen;
+	size_t	CipherTextB64Len;
+	int	rc;
+	/* clang-format on */
+
+	cleartext_len = strlen(cleartext);
+
+	vty_out(vty, "cross-backend test %s->%s\n", b1->name, b2->name);
+	vty_out(vty, "  cleartext \"%s\", cleartext_len %zu\n", cleartext,
+		cleartext_len);
+
+	/*
+	 * encrypt with b1
+	 * allocates pCipherTextB64 MTYPE_KEYCRYPT_CIPHER_B64
+	 */
+	rc = (*b1->f_encrypt)(cleartext, cleartext_len, &pCipherTextB64,
+			      &CipherTextB64Len);
+	if (rc) {
+		vty_out(vty, "Error: %s encryption failed, rc=%d\n", b1->name,
+			rc);
+		return;
+	}
+
+	vty_out(vty, "OK: %s encryption result len %zu: \"%s\"\n", b1->name,
+		CipherTextB64Len, pCipherTextB64);
+
+	/*
+	 * Decrypt with b1 (same as encrypt) first
+	 */
+	rc = (*b1->f_decrypt)(MTYPE_TMP, pCipherTextB64, CipherTextB64Len,
+			      &pPlainText, &PlainTextLen);
+	if (rc) {
+		vty_out(vty, "Error: %s decryption failed, rc=%d\n", b1->name,
+			rc);
+		XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pCipherTextB64);
+		return;
+	}
+
+	/*
+	 * compare plaintext
+	 */
+	if (PlainTextLen != cleartext_len) {
+		vty_out(vty,
+			"Error: orig cleartext len %zu, decrypted len %zu\n",
+			cleartext_len, PlainTextLen);
+		XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pCipherTextB64);
+		XFREE(MTYPE_TMP, pPlainText);
+		return;
+	}
+	if (strncmp(pPlainText, cleartext, cleartext_len)) {
+		vty_out(vty, "Error: orig cleartext differs from decrypted\n");
+		XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pCipherTextB64);
+		XFREE(MTYPE_TMP, pPlainText);
+		return;
+	}
+
+	vty_out(vty, "OK %s->%s \"%s\" == \"%s\"\n", b1->name, b1->name,
+		cleartext, pPlainText);
+
+	XFREE(MTYPE_TMP, pPlainText);
+
+
+	/*
+	 * decrypt with b2
+	 * allocates pPlainText MTYPE_TMP
+	 */
+	rc = (*b2->f_decrypt)(MTYPE_TMP, pCipherTextB64, CipherTextB64Len,
+			      &pPlainText, &PlainTextLen);
+	if (rc) {
+		vty_out(vty, "Error: %s decryption failed, rc=%d\n", b2->name,
+			rc);
+		XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pCipherTextB64);
+		return;
+	}
+
+	/*
+	 * compare plaintext
+	 */
+	if (PlainTextLen != cleartext_len) {
+		vty_out(vty,
+			"Error: orig cleartext len %zu, decrypted len %zu\n",
+			cleartext_len, PlainTextLen);
+		XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pCipherTextB64);
+		XFREE(MTYPE_TMP, pPlainText);
+		return;
+	}
+	if (strncmp(pPlainText, cleartext, cleartext_len)) {
+		vty_out(vty, "Error: orig cleartext differs from decrypted\n");
+		XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pCipherTextB64);
+		XFREE(MTYPE_TMP, pPlainText);
+		return;
+	}
+
+	vty_out(vty, "OK %s->%s \"%s\" == \"%s\"\n", b1->name, b2->name,
+		cleartext, pPlainText);
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_B64, pCipherTextB64);
+	XFREE(MTYPE_TMP, pPlainText);
+}
+
+/* clang-format off */
+DEFUN_HIDDEN (debug_keycrypt_test_inter_backend,
+	      debug_keycrypt_test_inter_backend_cmd,
+	      "debug keycrypt-test-inter-backend BE1 BE2 STRING",
+	      "Debug command\n"
+	      "Test keycrypt encryption and decryption\n"
+	      "Name of first backend\n"
+	      "Name of second backend\n"
+	      "plain text to encrypt and decrypt\n")
+/* clang-format on */
+{
+	int idx = 0;
+	const char *cleartext = NULL;
+
+	const char *name1 = NULL;
+	const char *name2 = NULL;
+
+	struct keycrypt_backend *b1 = NULL;
+	struct keycrypt_backend *b2 = NULL;
+	struct keycrypt_backend **p;
+
+	if (argv_find(argv, argc, "BE1", &idx))
+		name1 = argv[idx]->arg;
+	if (argv_find(argv, argc, "BE2", &idx))
+		name2 = argv[idx]->arg;
+	if (argv_find(argv, argc, "STRING", &idx))
+		cleartext = argv[idx]->arg;
+
+	if (!name1 || !name2) {
+		vty_out(vty, "missing two required backend names\n");
+		return CMD_SUCCESS;
+	}
+
+	for (p = keycrypt_backends; *p; ++p) {
+		if (!(*p)->name)
+			continue;
+		if (!strcmp((*p)->name, name1))
+			b1 = *p;
+		if (!strcmp((*p)->name, name2))
+			b2 = *p;
+	}
+
+	/*
+	 * Do we have cleartext?
+	 */
+	if (!cleartext) {
+		vty_out(vty, "no %s\n", "cleartext");
+		return CMD_SUCCESS;
+	}
+
+	/*
+	 * Do we have both backends?
+	 */
+	if (!b1) {
+		vty_out(vty, "no %s\n", name1);
+		return CMD_SUCCESS;
+	}
+	if (!b2) {
+		vty_out(vty, "no %s\n", name2);
+		return CMD_SUCCESS;
+	}
+
+	inter_backend_test(vty, cleartext, b1, b2);
+	inter_backend_test(vty, cleartext, b2, b1);
+
+	return CMD_SUCCESS;
+}
+
+/* clang-format off */
+DEFUN_HIDDEN (debug_keycrypt_test_inter_padding,
+	      debug_keycrypt_test_inter_padding_cmd,
+	      "debug keycrypt-test-inter-padding STRING",
+	      "Debug command\n"
+	      "Test keycrypt encryption and decryption\n"
+	      "plain text to encrypt and decrypt\n")
+/* clang-format on */
+{
+	int idx_string = 2;
+	const char *cleartext = argv[idx_string]->arg;
+
+	struct keycrypt_backend *b1 = NULL;
+	struct keycrypt_backend *b2 = NULL;
+	struct keycrypt_backend **p;
+
+	for (p = keycrypt_backends; *p; ++p) {
+		if (!(*p)->name)
+			continue;
+		if (!strcmp((*p)->name, "openssl"))
+			b1 = *p;
+		if (!strcmp((*p)->name, "openssl-oaep"))
+			b2 = *p;
+	}
+
+	/*
+	 * Do we have both backends?
+	 */
+	if (!b1) {
+		vty_out(vty, "no b1\n");
+		return CMD_SUCCESS;
+	}
+	if (!b2) {
+		vty_out(vty, "no b2\n");
+		return CMD_SUCCESS;
+	}
+
+	inter_backend_test(vty, cleartext, b2, b1);
+	inter_backend_test(vty, cleartext, b1, b2);
+
+	return CMD_SUCCESS;
+}
+
+/* clang-format off */
+DEFUN_HIDDEN (debug_keycrypt_show_backends,
+	      debug_keycrypt_show_backends_cmd,
+	      "debug keycrypt show backends",
+	      "Debug command\n"
+	      "Keycrypt encryption and decryption\n"
+	      "show\n"
+	      "list available crypto backends\n")
+/* clang-format on */
+{
+	struct keycrypt_backend **p;
+
+	for (p = keycrypt_backends; *p; ++p) {
+		const char *version;
+		bool selected;
+
+		if (!(*p)->name)
+			continue;
+		if ((*p)->f_be_version_string)
+			version = ((*p)->f_be_version_string)();
+		else
+			version = "?";
+
+		if (*p == kc_current_backend)
+			selected = true;
+		else
+			selected = false;
+
+		/* clang-format off */
+		vty_out(vty, "%c%s: %s\n",
+			(selected ? '*' : ' '), (*p)->name, version);
+		/* clang-format on */
+	}
+
+	return CMD_SUCCESS;
+}
+
+/* clang-format off */
+DEFUN_HIDDEN (debug_keycrypt_set_backend,
+	      debug_keycrypt_set_backend_cmd,
+	      "debug keycrypt set backend STRING",
+	      "Debug command\n"
+	      "keycrypt encryption and decryption\n"
+	      "set\n"
+	      "backend\n"
+	      "select an available crypto backend")
+/* clang-format on */
+{
+	int idx_string = 4;
+	const char *be_name = argv[idx_string]->arg;
+
+	struct keycrypt_backend *b = NULL;
+	struct keycrypt_backend **p;
+
+	for (p = keycrypt_backends; *p; ++p) {
+		if (!(*p)->name)
+			continue;
+		if (!strcmp((*p)->name, be_name)) {
+			b = *p;
+			break;
+		}
+	}
+
+	if (!b) {
+		vty_out(vty, "keycrypt: unknown backend \"%s\"\n", be_name);
+		return CMD_SUCCESS;
+	}
+
+	kc_current_backend = b;
+
+	return CMD_SUCCESS;
+}
+
+static bool keycrypt_now_encrypting;
+static keycrypt_callback_t *keycrypt_protocol_callback;
+static keycrypt_show_callback_t *keycrypt_protocol_show_callback;
+
+void keycrypt_register_protocol_callback(keycrypt_callback_t *kcb)
+{
+	keycrypt_protocol_callback = kcb;
+}
+
+bool keycrypt_is_now_encrypting(void)
+{
+	return keycrypt_now_encrypting;
+}
+
+void keycrypt_state_change(bool now_encrypting)
+{
+	if (now_encrypting == keycrypt_now_encrypting)
+		return;
+
+	keycrypt_now_encrypting = now_encrypting;
+
+	if (keycrypt_protocol_callback)
+		(*keycrypt_protocol_callback)(now_encrypting);
+
+	keychain_encryption_state_change(now_encrypting);
+}
+
+static void keycrypt_show_status_internal(struct vty *vty)
+{
+	const char *status;
+
+#ifdef KEYCRYPT_ENABLED
+	status = keycrypt_now_encrypting ? "ON" : "off";
+#else
+	status = "not included in software build";
+#endif
+	vty_out(vty, "%s Keycrypt status: %s\n", frr_protoname, status);
+
+#ifdef KEYCRYPT_ENABLED
+	const char *indentstr = "  ";
+	char *keyfile_path;
+	enum keycrypt_err krc;
+
+	vty_out(vty, "%s%s: Keycrypt backend: %s\n", indentstr, frr_protoname,
+		KC_BACKEND->name);
+
+	vty_out(vty, "%s%s: Keycrypt backend version: %s\n", indentstr,
+		frr_protoname, KC_BACKEND->f_be_version_string());
+
+	keyfile_path = keycrypt_keyfile_path();
+
+	/* clang-format off */
+	if (keyfile_path) {
+
+		const char *details = NULL;
+
+		vty_out(vty, "%s%s: Private key file name: \"%s\"\n",
+			indentstr, frr_protoname, keyfile_path);
+
+		if (KC_BACKEND->f_keyfile_read_status) {
+			krc = (*KC_BACKEND->f_keyfile_read_status)(
+				keyfile_path, &details);
+			XFREE(MTYPE_KEYCRYPT_KEYFILE_PATH, keyfile_path);
+			if (krc) {
+				vty_out(vty,
+				    "%s%s: Private key file status: NOT READABLE\n",
+				    indentstr, frr_protoname);
+				if (details) {
+					vty_out(vty,
+					    "%s%s: Private key file details: %s\n",
+					    indentstr, frr_protoname, details);
+				}
+			} else {
+				vty_out(vty,
+				    "%s%s: Private key file status: readable\n",
+				    indentstr, frr_protoname);
+			}
+		}
+
+	} else {
+		uid_t uid = geteuid();
+
+		vty_out(vty,
+		    "%s%s: Private key file name: UNABLE TO COMPUTE (euid %u)\n",
+		    indentstr, frr_protoname, (unsigned int)uid);
+	}
+	/* clang-format on */
+
+	keychain_encryption_show_status(vty, indentstr);
+
+	if (keycrypt_protocol_show_callback)
+		(*keycrypt_protocol_show_callback)(vty, indentstr);
+#endif
+}
+
+void keycrypt_register_protocol_show_callback(keycrypt_show_callback_t *kcb)
+{
+	keycrypt_protocol_show_callback = kcb;
+}
+
+DEFUN (keycrypt_show_status,
+       keycrypt_show_status_cmd,
+       "show keycrypt status",
+       "Show command\n"
+       "keycrypt protocol key encryption\n"
+       "status\n")
+{
+	keycrypt_show_status_internal(vty);
+	return CMD_SUCCESS;
+}
+
+void keycrypt_init(void)
+{
+	kc_current_backend = keycrypt_backends[0];
+
+	install_element(VIEW_NODE, &debug_keycrypt_show_backends_cmd);
+
+	install_element(ENABLE_NODE, &debug_keycrypt_set_backend_cmd);
+	/* install in config node for benefit of topotests/authentication */
+	install_element(CONFIG_NODE, &debug_keycrypt_set_backend_cmd);
+
+	install_element(VIEW_NODE, &debug_keycrypt_test_cmd);
+	install_element(VIEW_NODE, &debug_keycrypt_test_inter_backend_cmd);
+	install_element(VIEW_NODE, &debug_keycrypt_test_inter_padding_cmd);
+	install_element(VIEW_NODE, &keycrypt_show_status_cmd);
+}

--- a/lib/keycrypt.h
+++ b/lib/keycrypt.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020, LabN Consulting, L.L.C.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _FRR_KEYCRYPT_H
+#define _FRR_KEYCRYPT_H
+
+#include <zebra.h>
+#include <memory.h>
+
+#undef KEYCRYPT_ENABLED
+/* NB HAVE_GNUTLS is ignored because it does not support oaep yet */
+/* NB coordinate changes here with CPP logic at start of keycrypt.c */
+#if defined HAVE_OPENSSL || defined HAVE_LIBRESSL || defined HAVE_GCRYPT
+#define KEYCRYPT_ENABLED 1
+#endif
+
+DECLARE_MTYPE(KEYCRYPT_CIPHER_B64)
+DECLARE_MTYPE(KEYCRYPT_PLAIN_TEXT)
+
+/*
+ * return codes used by some functions
+ */
+/* clang-format off */
+enum keycrypt_err {
+	KC_OK = 0,
+	KC_ERR_MEMORY,		/* allocation failure */
+	KC_ERR_BASE64,		/* base64 encode/decode error */
+	KC_ERR_DECRYPT,
+	KC_ERR_ENCRYPT,
+	KC_ERR_BUILD_NOT_ENABLED,
+	KC_ERR_KEYFILE_PATH,	/* can't generate keyfile path */
+	KC_ERR_KEYFILE_READ,	/* can't read keyfile */
+	KC_ERR_KEYFILE_PARSE,	/* can't parse keyfile */
+	KC_ERR_KEYFILE_EXISTS,	/* would overwrite existing keyfile */
+	KC_ERR_INTERNAL,	/* unexpected error */
+};
+/* clang-format on */
+
+const char *keycrypt_strerror(enum keycrypt_err kc_err);
+
+#ifdef KEYCRYPT_ENABLED
+
+extern void keycrypt_base64_encode(const char *pIn, size_t InLen, char **ppOut,
+				   size_t *pOutLen);
+
+extern void keycrypt_base64_decode(const char *pIn, size_t InLen, char **ppOut,
+				   size_t *pOutLen);
+
+#endif /* KEYCRYPT_ENABLED */
+
+extern void keycrypt_init(void);
+
+typedef void(keycrypt_callback_t)(bool);
+struct vty; /* pet compiler for next line */
+typedef void(keycrypt_show_callback_t)(struct vty *, const char *);
+
+void keycrypt_register_protocol_callback(keycrypt_callback_t *kcb);
+
+void keycrypt_register_protocol_show_callback(keycrypt_show_callback_t *kcb);
+
+bool keycrypt_is_now_encrypting(void);
+
+void keycrypt_state_change(bool now_encrypting);
+
+extern int keycrypt_encrypt(const char *pPlainText,  /* IN */
+			    size_t PlainTextLen,     /* IN */
+			    char **ppCipherText,     /* OUT */
+			    size_t *pCipherTextLen); /* OUT */
+
+extern int keycrypt_decrypt(struct memtype *mt, /* of PlainText */ /* IN */
+			    const char *pCipherText,		   /* IN */
+			    size_t CipherTextLen,		   /* IN */
+			    char **pPlainText,			   /* OUT */
+			    size_t *pPlainTextLen);		   /* OUT */
+
+extern enum keycrypt_err keycrypt_build_passwords(
+	const char *password_in,      /* IN */
+	bool is_encrypted,	    /* IN */
+	struct memtype *mt_plaintext, /* IN */
+	char **ppPlainText,	   /* OUT MTYPE_KEY */
+	char **ppCryptText);	  /* OUT MTYPE_KEYCRYPT_CIPHER_B64 */
+
+#endif /* _FRR_KEYCRYPT_H */

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -3,7 +3,7 @@
 #
 lib_LTLIBRARIES += lib/libfrr.la
 lib_libfrr_la_LDFLAGS = -version-info 0:0:0 -Xlinker -e_libfrr_version
-lib_libfrr_la_LIBADD = $(LIBCAP) $(UNWIND_LIBS) $(LIBYANG_LIBS) $(LUA_LIB) $(UST_LIBS) $(LIBM)
+lib_libfrr_la_LIBADD = $(LIBCAP) $(UNWIND_LIBS) $(LIBYANG_LIBS) $(LUA_LIB) $(UST_LIBS) $(LIBM) $(LIBRESSL_LIBS)
 
 lib_libfrr_la_SOURCES = \
 	lib/agg_table.c \
@@ -42,6 +42,7 @@ lib_libfrr_la_SOURCES = \
 	lib/jhash.c \
 	lib/json.c \
 	lib/keychain.c \
+	lib/keycrypt.c \
 	lib/ldp_sync.c \
 	lib/lib_errors.c \
 	lib/lib_vty.c \
@@ -137,6 +138,7 @@ vtysh_scan += \
 	lib/if.c \
 	lib/if_rmap.c \
 	lib/keychain.c \
+	lib/keycrypt.c \
 	lib/lib_vty.c \
 	lib/nexthop_group.c \
 	lib/plist.c \
@@ -202,6 +204,7 @@ pkginclude_HEADERS += \
 	lib/jhash.h \
 	lib/json.h \
 	lib/keychain.h \
+	lib/keycrypt.h \
 	lib/ldp_sync.h \
 	lib/lib_errors.h \
 	lib/lib_vty.h \

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2517,12 +2517,16 @@ bool vty_read_config(struct nb_config *config, const char *config_file,
 			fullpath = config_default_dir;
 	}
 
+	/*
+	 * set config file path before reading config file so that
+	 * keycrypt can find its private key file during config processing
+	 */
+	host_config_set(fullpath);
+
 	vty_read_file(config, confp);
 	read_success = true;
 
 	fclose(confp);
-
-	host_config_set(fullpath);
 
 tmp_free_and_out:
 	XFREE(MTYPE_TMP, tmp);

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -33,6 +33,7 @@
 #include "zclient.h"
 #include "bfd.h"
 #include "ldp_sync.h"
+#include "keycrypt.h"
 
 #include "ospfd/ospfd.h"
 #include "ospfd/ospf_spf.h"
@@ -533,6 +534,7 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	UNSET_IF_PARAM(oip, priority);
 	UNSET_IF_PARAM(oip, type);
 	UNSET_IF_PARAM(oip, auth_simple);
+	UNSET_IF_PARAM(oip, auth_simple_encrypted);
 	UNSET_IF_PARAM(oip, auth_crypt);
 	UNSET_IF_PARAM(oip, auth_type);
 	UNSET_IF_PARAM(oip, if_area);
@@ -579,6 +581,7 @@ void ospf_free_if_params(struct interface *ifp, struct in_addr addr)
 	    && !OSPF_IF_PARAM_CONFIGURED(oip, priority)
 	    && !OSPF_IF_PARAM_CONFIGURED(oip, type)
 	    && !OSPF_IF_PARAM_CONFIGURED(oip, auth_simple)
+	    && !OSPF_IF_PARAM_CONFIGURED(oip, auth_simple_encrypted)
 	    && !OSPF_IF_PARAM_CONFIGURED(oip, auth_type)
 	    && !OSPF_IF_PARAM_CONFIGURED(oip, if_area)
 	    && listcount(oip->auth_crypt) == 0) {
@@ -1246,6 +1249,8 @@ int ospf_crypt_key_delete(struct list *auth_crypt, uint8_t key_id)
 
 	for (ALL_LIST_ELEMENTS(auth_crypt, node, nnode, ck)) {
 		if (ck->key_id == key_id) {
+			XFREE(MTYPE_KEYCRYPT_CIPHER_B64,
+			      ck->auth_key_encrypted);
 			listnode_delete(auth_crypt, ck);
 			XFREE(MTYPE_OSPF_CRYPT_KEY, ck);
 			return 1;

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -96,6 +96,9 @@ struct ospf_if_params {
 	uint8_t auth_simple[OSPF_AUTH_SIMPLE_SIZE + 1]; /* Simple password. */
 	uint8_t auth_simple__config : 1;
 
+	char *auth_simple_encrypted; /* dynamically allocated */
+	uint8_t auth_simple_encrypted__config : 1;
+
 	DECLARE_IF_PARAM(struct list *,
 			 auth_crypt);     /* List of Auth cryptographic data. */
 	DECLARE_IF_PARAM(int, auth_type); /* OSPF authentication type */
@@ -146,6 +149,7 @@ struct ospf_vl_data {
 struct crypt_key {
 	uint8_t key_id;
 	uint8_t auth_key[OSPF_AUTH_MD5_SIZE + 1];
+	char *auth_key_encrypted; /* dynamically allocated */
 };
 
 /* OSPF interface structure. */

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -36,6 +36,8 @@
 #include <lib/json.h>
 #include "defaults.h"
 #include "lib/printfrr.h"
+#include "keycrypt.h"
+#include "libfrr.h"
 
 #include "ospfd/ospfd.h"
 #include "ospfd/ospf_asbr.h"
@@ -850,8 +852,10 @@ struct ospf_vl_config_data {
 	struct in_addr vl_peer; /* command line vl_peer */
 	int auth_type;		/* Authehntication type, if given */
 	char *auth_key;		/* simple password if present */
+	bool auth_key_is_encrypted;
 	int crypto_key_id;      /* Cryptographic key ID */
 	char *md5_key;		/* MD5 authentication key */
+	bool md5_key_is_encrypted;
 	int hello_interval;     /* Obvious what these are... */
 	int retransmit_interval;
 	int transmit_delay;
@@ -913,7 +917,6 @@ ospf_find_vl_data(struct ospf *ospf, struct ospf_vl_config_data *vl_config)
 	return vl_data;
 }
 
-
 static int ospf_vl_set_security(struct ospf_vl_data *vl_data,
 				struct ospf_vl_config_data *vl_config)
 {
@@ -929,12 +932,49 @@ static int ospf_vl_set_security(struct ospf_vl_data *vl_data,
 	}
 
 	if (vl_config->auth_key) {
-		memset(IF_DEF_PARAMS(ifp)->auth_simple, 0,
-		       OSPF_AUTH_SIMPLE_SIZE + 1);
-		strlcpy((char *)IF_DEF_PARAMS(ifp)->auth_simple,
-			vl_config->auth_key,
-			sizeof(IF_DEF_PARAMS(ifp)->auth_simple));
+		char *pPlainText;
+		char *pCryptText;
+
+		if (!vl_config->auth_key_is_encrypted
+		    && (vl_config->auth_key)[0] == 0) {
+
+			/* unset */
+			XFREE(MTYPE_KEYCRYPT_CIPHER_B64,
+			      IF_DEF_PARAMS(ifp)->auth_simple_encrypted);
+			*(char *)IF_DEF_PARAMS(ifp)->auth_simple = 0;
+		} else {
+
+			enum keycrypt_err krc;
+
+			krc = keycrypt_build_passwords(
+				vl_config->auth_key,
+				vl_config->auth_key_is_encrypted,
+				MTYPE_KEYCRYPT_PLAIN_TEXT, &pPlainText,
+				&pCryptText);
+			if (krc) {
+				zlog_err("%s: %s", __func__,
+					 keycrypt_strerror(krc));
+				vty_out(vty, "Error: %s\n",
+					keycrypt_strerror(krc));
+			}
+
+			memset(IF_DEF_PARAMS(ifp)->auth_simple, 0,
+			       OSPF_AUTH_SIMPLE_SIZE + 1);
+			if (pPlainText)
+				strlcpy((char *)IF_DEF_PARAMS(ifp)->auth_simple,
+					pPlainText,
+					sizeof(IF_DEF_PARAMS(ifp)
+						       ->auth_simple));
+			XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pPlainText);
+			XFREE(MTYPE_KEYCRYPT_CIPHER_B64,
+			      IF_DEF_PARAMS(ifp)->auth_simple_encrypted);
+			IF_DEF_PARAMS(ifp)->auth_simple_encrypted = pCryptText;
+		}
+
 	} else if (vl_config->md5_key) {
+		char *pPlainText;
+		char *pCryptText;
+
 		if (ospf_crypt_key_lookup(IF_DEF_PARAMS(ifp)->auth_crypt,
 					  vl_config->crypto_key_id)
 		    != NULL) {
@@ -942,11 +982,27 @@ static int ospf_vl_set_security(struct ospf_vl_data *vl_data,
 				vl_config->crypto_key_id);
 			return CMD_WARNING;
 		}
+
+		enum keycrypt_err krc;
+
+		krc = keycrypt_build_passwords(
+			vl_config->md5_key, vl_config->md5_key_is_encrypted,
+			MTYPE_KEYCRYPT_PLAIN_TEXT, &pPlainText, &pCryptText);
+		if (krc) {
+			zlog_err("%s: %s", __func__, keycrypt_strerror(krc));
+			vty_out(vty, "Error: %s\n", keycrypt_strerror(krc));
+		}
+
 		ck = ospf_crypt_key_new();
 		ck->key_id = vl_config->crypto_key_id;
 		memset(ck->auth_key, 0, OSPF_AUTH_MD5_SIZE + 1);
-		strlcpy((char *)ck->auth_key, vl_config->md5_key,
-			sizeof(ck->auth_key));
+		if (pPlainText)
+			strlcpy((char *)ck->auth_key, pPlainText,
+				sizeof(ck->auth_key));
+
+		XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pPlainText);
+		XFREE(MTYPE_KEYCRYPT_CIPHER_B64, ck->auth_key_encrypted);
+		ck->auth_key_encrypted = pCryptText;
 
 		ospf_crypt_key_add(IF_DEF_PARAMS(ifp)->auth_crypt, ck);
 	} else if (vl_config->crypto_key_id != 0) {
@@ -999,14 +1055,17 @@ static int ospf_vl_set_timers(struct ospf_vl_data *vl_data,
 
 
 /* The business end of all of the above */
-static int ospf_vl_set(struct ospf *ospf, struct ospf_vl_config_data *vl_config)
+static int ospf_vl_set(struct vty *vty, struct ospf *ospf,
+		       struct ospf_vl_config_data *vl_config)
 {
 	struct ospf_vl_data *vl_data;
 	int ret;
 
 	vl_data = ospf_find_vl_data(ospf, vl_config);
-	if (!vl_data)
+	if (!vl_data) {
+		vty_out(vty, "Error: can't find virtual link data\n");
 		return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	/* Process this one first as it can have a fatal result, which can
 	   only logically occur if the virtual link exists already
@@ -1014,14 +1073,19 @@ static int ospf_vl_set(struct ospf *ospf, struct ospf_vl_config_data *vl_config)
 	   running configuration such as unexpectedly altered timer
 	   values etc.*/
 	ret = ospf_vl_set_security(vl_data, vl_config);
-	if (ret != CMD_SUCCESS)
+	if (ret != CMD_SUCCESS) {
+		vty_out(vty,
+			"Error: can't set virtual link security parameters\n");
 		return ret;
+	}
 
 	/* Set any time based parameters, these area already range checked */
 
 	ret = ospf_vl_set_timers(vl_data, vl_config);
-	if (ret != CMD_SUCCESS)
+	if (ret != CMD_SUCCESS) {
+		vty_out(vty, "Error: can't set virtual link timers\n");
 		return ret;
+	}
 
 	return CMD_SUCCESS;
 }
@@ -1056,17 +1120,19 @@ static int ospf_vl_set(struct ospf *ospf, struct ospf_vl_config_data *vl_config)
 
 #define VLINK_HELPSTR_AUTH_SIMPLE                                              \
 	"Authentication password (key)\n"                                      \
+	"Encrypted key follows\n"                                              \
 	"The OSPF password (key)\n"
 
 #define VLINK_HELPSTR_AUTH_MD5                                                 \
 	"Message digest authentication password (key)\n"                       \
 	"Key ID\n"                                                             \
 	"Use MD5 algorithm\n"                                                  \
+	"Encrypted key follows\n"                                              \
 	"The OSPF password (key)\n"
 
 DEFUN (ospf_area_vlink,
        ospf_area_vlink_cmd,
-       "area <A.B.C.D|(0-4294967295)> virtual-link A.B.C.D [authentication [<message-digest|null>]] [<message-digest-key (1-255) md5 KEY|authentication-key AUTH_KEY>]",
+       "area <A.B.C.D|(0-4294967295)> virtual-link A.B.C.D [authentication [<message-digest|null>]] [<message-digest-key (1-255) md5 [101] KEY|authentication-key [101] AUTH_KEY>]",
        VLINK_HELPSTR_IPADDR
        "Enable authentication on this virtual link\n"
        "Use message-digest authentication\n"
@@ -1102,7 +1168,7 @@ DEFUN (ospf_area_vlink,
 	if (argc <= 4) {
 		/* Thats all folks! - BUGS B. strikes again!!!*/
 
-		return ospf_vl_set(ospf, &vl_config);
+		return ospf_vl_set(vty, ospf, &vl_config);
 	}
 
 	if (argv_find(argv, argc, "authentication", &idx)) {
@@ -1125,23 +1191,33 @@ DEFUN (ospf_area_vlink,
 		if (vl_config.crypto_key_id < 0)
 			return CMD_WARNING_CONFIG_FAILED;
 
-		strlcpy(md5_key, argv[idx + 3]->arg, sizeof(md5_key));
-		vl_config.md5_key = md5_key;
+		if (!strcmp(argv[idx + 3]->arg, "101")) {
+			vl_config.md5_key = argv[idx + 4]->arg;
+			vl_config.md5_key_is_encrypted = true;
+		} else {
+			strlcpy(md5_key, argv[idx + 3]->arg, sizeof(md5_key));
+			vl_config.md5_key = md5_key;
+		}
 	}
 
 	if (argv_find(argv, argc, "authentication-key", &idx)) {
-		strlcpy(auth_key, argv[idx + 1]->arg, sizeof(auth_key));
-		vl_config.auth_key = auth_key;
+		if (!strcmp(argv[idx + 1]->arg, "101")) {
+			vl_config.auth_key = argv[idx + 2]->arg;
+			vl_config.auth_key_is_encrypted = true;
+		} else {
+			strlcpy(auth_key, argv[idx + 1]->arg, sizeof(auth_key));
+			vl_config.auth_key = auth_key;
+		}
 	}
 
 	/* Action configuration */
 
-	return ospf_vl_set(ospf, &vl_config);
+	return ospf_vl_set(vty, ospf, &vl_config);
 }
 
 DEFUN (no_ospf_area_vlink,
        no_ospf_area_vlink_cmd,
-       "no area <A.B.C.D|(0-4294967295)> virtual-link A.B.C.D [authentication [<message-digest|null>]] [<message-digest-key (1-255) md5 KEY|authentication-key AUTH_KEY>]",
+       "no area <A.B.C.D|(0-4294967295)> virtual-link A.B.C.D [authentication [<message-digest|null>]] [<message-digest-key (1-255) [md5 [101] KEY]|authentication-key [101] [AUTH_KEY]>]",
        NO_STR
        VLINK_HELPSTR_IPADDR
        "Enable authentication on this virtual link\n"
@@ -1219,7 +1295,7 @@ DEFUN (no_ospf_area_vlink,
 
 	/* Action configuration */
 
-	return ospf_vl_set(ospf, &vl_config);
+	return ospf_vl_set(vty, ospf, &vl_config);
 }
 
 DEFUN (ospf_area_vlink_intervals,
@@ -1265,7 +1341,7 @@ DEFUN (ospf_area_vlink_intervals,
 	}
 
 	/* Action configuration */
-	return ospf_vl_set(ospf, &vl_config);
+	return ospf_vl_set(vty, ospf, &vl_config);
 }
 
 DEFUN (no_ospf_area_vlink_intervals,
@@ -1310,7 +1386,7 @@ DEFUN (no_ospf_area_vlink_intervals,
 	}
 
 	/* Action configuration */
-	return ospf_vl_set(ospf, &vl_config);
+	return ospf_vl_set(vty, ospf, &vl_config);
 }
 
 DEFUN (ospf_area_shortcut,
@@ -7597,17 +7673,20 @@ DEFUN (no_ip_ospf_authentication,
 
 DEFUN (ip_ospf_authentication_key,
        ip_ospf_authentication_key_addr_cmd,
-       "ip ospf authentication-key AUTH_KEY [A.B.C.D]",
+       "ip ospf authentication-key [101] AUTH_KEY [A.B.C.D]",
        "IP Information\n"
        "OSPF interface commands\n"
-       "Authentication password (key)\n"
-       "The OSPF password (key)\n"
+       VLINK_HELPSTR_AUTH_SIMPLE
        "Address of interface\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	int idx = 0;
 	struct in_addr addr;
 	struct ospf_if_params *params;
+	int idx_key = 3;
+	bool is_encrypted = false;
+	char *pPlainText;
+	char *pCryptText;
 
 	params = IF_DEF_PARAMS(ifp);
 
@@ -7622,26 +7701,62 @@ DEFUN (ip_ospf_authentication_key,
 		ospf_if_update_params(ifp, addr);
 	}
 
-	strlcpy((char *)params->auth_simple, argv[3]->arg,
-		sizeof(params->auth_simple));
-	SET_IF_PARAM(params, auth_simple);
+	if (!strcmp(argv[3]->arg, "101")) {
+		idx_key = 4;
+		is_encrypted = true;
+	}
+
+	enum keycrypt_err krc;
+	krc = keycrypt_build_passwords(argv[idx_key]->arg, is_encrypted,
+				       MTYPE_KEYCRYPT_PLAIN_TEXT, &pPlainText,
+				       &pCryptText);
+	if (krc) {
+		zlog_err("%s: Error: %s", __func__, keycrypt_strerror(krc));
+		vty_out(vty, "Error: %s\n", keycrypt_strerror(krc));
+	}
+
+	if (is_encrypted && pPlainText && !strlen(pPlainText)) {
+		const char *msg =
+		    "Error: encrypted password decrypted to 0-length string";
+		vty_out(vty, "%s\n", msg);
+		zlog_err("%s: %s", __func__, msg);
+		XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pPlainText);
+	}
+
+	if (pPlainText) {
+		strlcpy((char *)params->auth_simple, pPlainText,
+			sizeof(params->auth_simple));
+		SET_IF_PARAM(params, auth_simple);
+	} else {
+		/* can't  decrypt is equivalent to unsetting auth str */
+		memset(params->auth_simple, 0, OSPF_AUTH_SIMPLE_SIZE);
+		UNSET_IF_PARAM(params, auth_simple);
+		if (params != IF_DEF_PARAMS(ifp)) {
+			ospf_free_if_params(ifp, addr);
+			ospf_if_update_params(ifp, addr);
+		}
+	}
+	XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pPlainText);
+
+	XFREE(MTYPE_KEYCRYPT_CIPHER_B64, params->auth_simple_encrypted);
+	params->auth_simple_encrypted = pCryptText;
 
 	return CMD_SUCCESS;
 }
 
 DEFUN_HIDDEN (ospf_authentication_key,
-              ospf_authentication_key_cmd,
-              "ospf authentication-key AUTH_KEY [A.B.C.D]",
-              "OSPF interface commands\n"
-              VLINK_HELPSTR_AUTH_SIMPLE
-              "Address of interface\n")
+	      ospf_authentication_key_cmd,
+	      "ospf authentication-key [101] AUTH_KEY [A.B.C.D]",
+	      "OSPF interface commands\n"
+	      VLINK_HELPSTR_AUTH_SIMPLE
+	      "Address of interface\n")
 {
 	return ip_ospf_authentication_key(self, vty, argc, argv);
 }
 
 DEFUN (no_ip_ospf_authentication_key,
        no_ip_ospf_authentication_key_authkey_addr_cmd,
-       "no ip ospf authentication-key [AUTH_KEY [A.B.C.D]]",
+       "no ip ospf authentication-key [[101] AUTH_KEY [A.B.C.D]]",
        NO_STR
        "IP Information\n"
        "OSPF interface commands\n"
@@ -7652,6 +7767,7 @@ DEFUN (no_ip_ospf_authentication_key,
 	int idx = 0;
 	struct in_addr addr;
 	struct ospf_if_params *params;
+
 	params = IF_DEF_PARAMS(ifp);
 
 	if (argv_find(argv, argc, "A.B.C.D", &idx)) {
@@ -7668,6 +7784,7 @@ DEFUN (no_ip_ospf_authentication_key,
 
 	memset(params->auth_simple, 0, OSPF_AUTH_SIMPLE_SIZE);
 	UNSET_IF_PARAM(params, auth_simple);
+	XFREE(MTYPE_KEYCRYPT_CIPHER_B64, params->auth_simple_encrypted);
 
 	if (params != IF_DEF_PARAMS(ifp)) {
 		ospf_free_if_params(ifp, addr);
@@ -7678,11 +7795,10 @@ DEFUN (no_ip_ospf_authentication_key,
 }
 
 DEFUN_HIDDEN (no_ospf_authentication_key,
-              no_ospf_authentication_key_authkey_addr_cmd,
-              "no ospf authentication-key [AUTH_KEY [A.B.C.D]]",
-              NO_STR
-              "OSPF interface commands\n"
-              VLINK_HELPSTR_AUTH_SIMPLE
+	      no_ospf_authentication_key_authkey_addr_cmd,
+	      "no ospf authentication-key [[101] AUTH_KEY [A.B.C.D]]",
+	      NO_STR "OSPF interface commands\n"
+	      VLINK_HELPSTR_AUTH_SIMPLE
 	      "Address of interface\n")
 {
 	return no_ip_ospf_authentication_key(self, vty, argc, argv);
@@ -7690,12 +7806,13 @@ DEFUN_HIDDEN (no_ospf_authentication_key,
 
 DEFUN (ip_ospf_message_digest_key,
        ip_ospf_message_digest_key_cmd,
-       "ip ospf message-digest-key (1-255) md5 KEY [A.B.C.D]",
+       "ip ospf message-digest-key (1-255) md5 [101] KEY [A.B.C.D]",
        "IP Information\n"
        "OSPF interface commands\n"
        "Message digest authentication password (key)\n"
        "Key ID\n"
        "Use MD5 algorithm\n"
+       "Encrypted key follows\n"
        "The OSPF password (key)\n"
        "Address of interface\n")
 {
@@ -7704,12 +7821,19 @@ DEFUN (ip_ospf_message_digest_key,
 	uint8_t key_id;
 	struct in_addr addr;
 	struct ospf_if_params *params;
+	bool is_encrypted = false;
+	char *pPlainText;
+	char *pCryptText;
 
 	params = IF_DEF_PARAMS(ifp);
 	int idx = 0;
 
 	argv_find(argv, argc, "(1-255)", &idx);
+
 	char *keyid = argv[idx]->arg;
+
+	if (argv_find(argv, argc, "101", &idx))
+		is_encrypted = true;
 	argv_find(argv, argc, "KEY", &idx);
 	char *cryptkey = argv[idx]->arg;
 
@@ -7730,9 +7854,31 @@ DEFUN (ip_ospf_message_digest_key,
 		return CMD_WARNING;
 	}
 
+	enum keycrypt_err krc;
+
+	krc = keycrypt_build_passwords(cryptkey, is_encrypted,
+				       MTYPE_KEYCRYPT_PLAIN_TEXT, &pPlainText,
+				       &pCryptText);
+	if (krc) {
+		zlog_err("%s: Error: %s", __func__, keycrypt_strerror(krc));
+		vty_out(vty, "Error: %s\n", keycrypt_strerror(krc));
+	}
+
+	if (is_encrypted && pPlainText && !strlen(pPlainText)) {
+		const char *msg =
+		    "Error: encrypted password decrypted to 0-length string";
+		vty_out(vty, "%s\n", msg);
+		zlog_err("%s: %s", __func__, msg);
+		XFREE(MTYPE_KEYCRYPT_PLAIN_TEXT, pPlainText);
+	}
+
+
 	ck = ospf_crypt_key_new();
 	ck->key_id = (uint8_t)key_id;
-	strlcpy((char *)ck->auth_key, cryptkey, sizeof(ck->auth_key));
+	if (pPlainText)
+		strlcpy((char *)ck->auth_key, pPlainText, sizeof(ck->auth_key));
+	XFREE(MTYPE_KEYCRYPT_CIPHER_B64, ck->auth_key_encrypted);
+	ck->auth_key_encrypted = pCryptText;
 
 	ospf_crypt_key_add(params->auth_crypt, ck);
 	SET_IF_PARAM(params, auth_crypt);
@@ -7741,27 +7887,29 @@ DEFUN (ip_ospf_message_digest_key,
 }
 
 DEFUN_HIDDEN (ospf_message_digest_key,
-              ospf_message_digest_key_cmd,
-              "ospf message-digest-key (1-255) md5 KEY [A.B.C.D]",
-              "OSPF interface commands\n"
-              "Message digest authentication password (key)\n"
-              "Key ID\n"
-              "Use MD5 algorithm\n"
-              "The OSPF password (key)\n"
-              "Address of interface\n")
+	      ospf_message_digest_key_cmd,
+	      "ospf message-digest-key (1-255) md5 [101] KEY [A.B.C.D]",
+	      "OSPF interface commands\n"
+	      "Message digest authentication password (key)\n"
+	      "Key ID\n"
+	      "Use MD5 algorithm\n"
+	      "Encrypted key follows\n"
+	      "The OSPF password (key)\n"
+	      "Address of interface\n")
 {
 	return ip_ospf_message_digest_key(self, vty, argc, argv);
 }
 
 DEFUN (no_ip_ospf_message_digest_key,
        no_ip_ospf_message_digest_key_cmd,
-       "no ip ospf message-digest-key (1-255) [md5 KEY] [A.B.C.D]",
-        NO_STR
+       "no ip ospf message-digest-key (1-255) [md5 [101] KEY] [A.B.C.D]",
+       NO_STR
        "IP Information\n"
        "OSPF interface commands\n"
        "Message digest authentication password (key)\n"
        "Key ID\n"
        "Use MD5 algorithm\n"
+       "Encrypted key follows\n"
        "The OSPF password (key)\n"
        "Address of interface\n")
 {
@@ -7806,15 +7954,16 @@ DEFUN (no_ip_ospf_message_digest_key,
 }
 
 DEFUN_HIDDEN (no_ospf_message_digest_key,
-              no_ospf_message_digest_key_cmd,
-              "no ospf message-digest-key (1-255) [md5 KEY] [A.B.C.D]",
-              NO_STR
-              "OSPF interface commands\n"
-              "Message digest authentication password (key)\n"
-              "Key ID\n"
-              "Use MD5 algorithm\n"
-              "The OSPF password (key)\n"
-              "Address of interface\n")
+	      no_ospf_message_digest_key_cmd,
+	      "no ospf message-digest-key (1-255) [md5 [101] KEY] [A.B.C.D]",
+	      NO_STR
+	      "OSPF interface commands\n"
+	      "Message digest authentication password (key)\n"
+	      "Key ID\n"
+	      "Use MD5 algorithm\n"
+	      "Encrypted key follows\n"
+	      "The OSPF password (key)\n"
+	      "Address of interface\n")
 {
 	return no_ip_ospf_message_digest_key(self, vty, argc, argv);
 }
@@ -11177,6 +11326,378 @@ DEFUN (show_ip_ospf_vrfs,
 	return CMD_SUCCESS;
 }
 
+/* see ospf_config_write_one */
+static void ospf_keycrypt_state_change_ospf_one(struct ospf *ospf)
+{
+	struct listnode *node;
+	struct ospf_vl_data *vl_data;
+
+	/* this part modeled on config_write_virtual_link() */
+	for (ALL_LIST_ELEMENTS_RO(ospf->vlinks, node, vl_data)) {
+		struct listnode *n2;
+		struct crypt_key *ck;
+		struct ospf_if_params *params;
+		char buf[INET_ADDRSTRLEN];
+
+		if (!vl_data)
+			continue;
+
+		area_id2str(buf, sizeof(buf), &vl_data->vl_area_id,
+			    vl_data->vl_area_id_fmt);
+
+		params = IF_DEF_PARAMS(vl_data->vl_oi->ifp);
+
+		/* Auth key */
+		if (params->auth_simple[0]) {
+			if (!params->auth_simple_encrypted) {
+				if (keycrypt_encrypt(
+					    (char *)params->auth_simple,
+					    strlen((char *)params
+							   ->auth_simple),
+					    &params->auth_simple_encrypted,
+					    NULL)) {
+					zlog_err(
+					    "%s: can't encrypt simple passwd for ospf instance %u vrf %s area %s virtual-link %pI4",
+					    __func__,
+					    ospf->instance,
+					    ospf->name, buf,
+					    &vl_data->vl_peer);
+				}
+			}
+		}
+		/* md5 keys */
+		for (ALL_LIST_ELEMENTS_RO(params->auth_crypt, n2, ck)) {
+
+			if (!ck->auth_key_encrypted) {
+				if (keycrypt_encrypt(
+					    (char *)ck->auth_key,
+					    strlen((char *)ck
+							   ->auth_key),
+					    &ck->auth_key_encrypted,
+					    NULL)) {
+
+					zlog_err(
+						"%s: can't encrypt md5 id %d for ospf instance %u vrf %s area %s virtual-link %pI4",
+						__func__, ck->key_id,
+						ospf->instance,
+						ospf->name, buf,
+						&vl_data->vl_peer);
+				}
+			}
+		}
+	}
+}
+
+static void ospf_keycrypt_state_change_vrf_one_ifp(struct vrf *vrf,
+	struct interface *ifp)
+{
+	struct ospf_if_params *params;
+	struct route_node *rn = NULL;
+
+	if (memcmp(ifp->name, "VLINK", 5) == 0)
+		return;
+
+	params = IF_DEF_PARAMS(ifp);
+
+	do {
+		/* Simple Authentication Password print. */
+		if (OSPF_IF_PARAM_CONFIGURED(params, auth_simple)
+		    && params->auth_simple[0] != '\0') {
+
+			if (!params->auth_simple_encrypted) {
+				if (keycrypt_encrypt(
+					    (char *)params->auth_simple,
+					    strlen((char *)params->auth_simple),
+					    &params->auth_simple_encrypted,
+					    NULL)) {
+
+					char pstr[INET_ADDRSTRLEN];
+
+					if (rn
+					    && (params != IF_DEF_PARAMS(ifp)))
+
+						snprintfrr(pstr, sizeof(pstr),
+							"%pI4",
+							&rn->p.u.prefix4);
+					else
+						pstr[0] = '\0';
+					zlog_err(
+						"%s: interface %s vrf %s authentication-key %s: can't encrypt",
+						__func__, ifp->name,
+						((ifp->vrf_id == VRF_DEFAULT)
+							 ? "default"
+							 : vrf->name),
+						pstr);
+				}
+			}
+		}
+
+
+		/* Cryptographic Authentication Key print. */
+		if (params && params->auth_crypt) {
+
+			struct listnode *node;
+			struct crypt_key *ck;
+
+			for (ALL_LIST_ELEMENTS_RO(params->auth_crypt,
+						  node, ck)) {
+
+				if (ck->auth_key_encrypted)
+					continue;
+
+				if (keycrypt_encrypt(
+					    (char *)ck->auth_key,
+					    strlen((char *)ck->auth_key),
+					    &ck->auth_key_encrypted,
+					    NULL)) {
+
+					char pstr[INET_ADDRSTRLEN];
+
+					if (rn
+					    && (params
+						!= IF_DEF_PARAMS(ifp)))
+
+						snprintfrr(pstr, sizeof(pstr),
+							"%pI4",
+							&rn->p.u.prefix4);
+					else
+						pstr[0] = '\0';
+					zlog_err(
+					    "%s: interface %s vrf %s message-digest-key %d %s: can't encrypt",
+					    __func__,
+					    ifp->name,
+					    ((ifp->vrf_id == VRF_DEFAULT)
+						     ? "default"
+						     : vrf->name),
+					    ck->key_id,
+					    pstr);
+				}
+			}
+		}
+		while (1) {
+			if (rn == NULL)
+				rn = route_top(IF_OIFS_PARAMS(ifp));
+			else
+				rn = route_next(rn);
+
+			if (rn == NULL)
+				break;
+			params = rn->info;
+			if (params != NULL)
+				break;
+		}
+	} while (rn);
+}
+
+static void ospf_keycrypt_state_change_vrf_one(struct vrf *vrf)
+{
+	/* this part based on config_write_interface_one(vty, vrf) */
+
+	struct interface *ifp;
+
+	FOR_ALL_INTERFACES (vrf, ifp)
+		ospf_keycrypt_state_change_vrf_one_ifp(vrf, ifp);
+}
+
+static void ospf_keycrypt_state_change(bool now_encrypting)
+{
+	/*
+	 * change from encrypting to non-encrypting has no effect on
+	 * previously-encrypted protocol keys: they remain encrypted.
+	 */
+	if (!now_encrypting)
+		return;
+
+	if (listcount(om->ospf)) {
+
+		struct ospf *ospf;
+		struct listnode *ospf_node = NULL;
+
+		for (ALL_LIST_ELEMENTS_RO(om->ospf, ospf_node, ospf)) {
+			/* VRF Default check if it is running.
+			 * Upon daemon start, there could be default instance
+			 * in absence of 'router ospf'/oi_running is disabled.
+			 */
+			if (ospf->vrf_id == VRF_DEFAULT && ospf->oi_running)
+				ospf_keycrypt_state_change_ospf_one(ospf);
+			/*
+			 * For Non-Default VRF simply display the configuration,
+			 * even if it is not oi_running.
+			 */
+			else if (ospf->vrf_id != VRF_DEFAULT)
+				ospf_keycrypt_state_change_ospf_one(ospf);
+		}
+	}
+
+	struct vrf *vrf = NULL;
+
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		ospf_keycrypt_state_change_vrf_one(vrf);
+	}
+}
+
+/* see ospf_config_write_one */
+static void ospf_keycrypt_status_ospf_one(struct vty *vty,
+					  const char *indentstr,
+					  struct ospf *ospf)
+{
+	uint simple_keys = 0;
+	uint simple_keys_encrypted = 0;
+
+	uint md5_keys = 0;
+	uint md5_keys_encrypted = 0;
+
+	struct listnode *node;
+	struct ospf_vl_data *vl_data;
+
+	/* this part modeled on config_write_virtual_link() */
+	for (ALL_LIST_ELEMENTS_RO(ospf->vlinks, node, vl_data)) {
+		struct listnode *n2;
+		struct crypt_key *ck;
+		struct ospf_if_params *params;
+
+		if (!vl_data)
+			continue;
+
+		params = IF_DEF_PARAMS(vl_data->vl_oi->ifp);
+
+		/* Auth key */
+		if (params->auth_simple[0])
+			++simple_keys;
+		if (params->auth_simple_encrypted)
+			++simple_keys_encrypted;
+		/* md5 keys */
+		for (ALL_LIST_ELEMENTS_RO(params->auth_crypt, n2, ck)) {
+			if (ck->auth_key[0])
+				++md5_keys;
+			if (ck->auth_key_encrypted)
+				++md5_keys_encrypted;
+		}
+	}
+
+	if (simple_keys || simple_keys_encrypted || md5_keys
+	    || md5_keys_encrypted) {
+		vty_out(vty,
+			"%s%s: instance %u vrf %s: simple keys: %u, encrypted: %u\n",
+			indentstr, frr_protoname, ospf->instance,
+			(ospf->name ? ospf->name : "(none)"), simple_keys,
+			simple_keys_encrypted);
+		vty_out(vty,
+			"%s%s: instance %u vrf %s: md5 keys: %u, encrypted: %u\n",
+			indentstr, frr_protoname, ospf->instance,
+			(ospf->name ? ospf->name : "(none)"), md5_keys,
+			md5_keys_encrypted);
+	}
+}
+
+static void ospf_keycrypt_status_vrf_one(struct vty *vty, const char *indentstr,
+					 struct vrf *vrf)
+{
+	/* this part based on config_write_interface_one(vty, vrf) */
+
+	struct listnode *node;
+	struct interface *ifp;
+	struct crypt_key *ck;
+
+	uint simple_keys = 0;
+	uint simple_keys_encrypted = 0;
+
+	uint ca_keys = 0;
+	uint ca_keys_encrypted = 0;
+
+	FOR_ALL_INTERFACES (vrf, ifp) {
+
+		struct ospf_if_params *params;
+		struct route_node *rn = NULL;
+
+		if (memcmp(ifp->name, "VLINK", 5) == 0)
+			continue;
+
+		params = IF_DEF_PARAMS(ifp);
+
+		do {
+			/* Simple Authentication Password print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params, auth_simple)
+			    && params->auth_simple[0] != '\0') {
+
+				++simple_keys;
+			}
+			if (params->auth_simple_encrypted)
+				++simple_keys_encrypted;
+
+
+			/* Cryptographic Authentication Key print. */
+			if (params && params->auth_crypt) {
+
+				for (ALL_LIST_ELEMENTS_RO(params->auth_crypt,
+							  node, ck)) {
+
+					if (ck->auth_key[0])
+						++ca_keys;
+					if (ck->auth_key_encrypted)
+						++ca_keys_encrypted;
+				}
+			}
+			while (1) {
+				if (rn == NULL)
+					rn = route_top(IF_OIFS_PARAMS(ifp));
+				else
+					rn = route_next(rn);
+
+				if (rn == NULL)
+					break;
+				params = rn->info;
+				if (params != NULL)
+					break;
+			}
+		} while (rn);
+	}
+	if (simple_keys || simple_keys_encrypted || ca_keys
+	    || ca_keys_encrypted) {
+		vty_out(vty, "%s%s: vrf %s: simple keys: %u, encrypted: %u\n",
+			indentstr, frr_protoname, vrf->name, simple_keys,
+			simple_keys_encrypted);
+
+		vty_out(vty,
+			"%s%s: vrf %s: message-digest-keys keys: %u, encrypted: %u\n",
+			indentstr, frr_protoname, vrf->name, ca_keys,
+			ca_keys_encrypted);
+	}
+}
+
+static void ospf_keycrypt_encryption_show_status(struct vty *vty,
+						 const char *indentstr)
+{
+	if (listcount(om->ospf)) {
+
+		struct ospf *ospf;
+		struct listnode *ospf_node = NULL;
+
+		for (ALL_LIST_ELEMENTS_RO(om->ospf, ospf_node, ospf)) {
+			/* VRF Default check if it is running.
+			 * Upon daemon start, there could be default instance
+			 * in absence of 'router ospf'/oi_running is disabled.
+			 */
+			if (ospf->vrf_id == VRF_DEFAULT && ospf->oi_running)
+				ospf_keycrypt_status_ospf_one(vty, indentstr,
+							      ospf);
+			/*
+			 * For Non-Default VRF simply display the configuration,
+			 * even if it is not oi_running.
+			 */
+			else if (ospf->vrf_id != VRF_DEFAULT)
+				ospf_keycrypt_status_ospf_one(vty, indentstr,
+							      ospf);
+		}
+	}
+
+	struct vrf *vrf = NULL;
+
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		ospf_keycrypt_status_vrf_one(vty, indentstr, vrf);
+	}
+}
+
 static const char *const ospf_abr_type_str[] = {
 	"unknown", "standard", "ibm", "cisco", "shortcut"
 };
@@ -11533,23 +12054,91 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 			}
 
 			/* Simple Authentication Password print. */
-			if (OSPF_IF_PARAM_CONFIGURED(params, auth_simple)
-			    && params->auth_simple[0] != '\0') {
-				vty_out(vty, " ip ospf authentication-key %s",
-					params->auth_simple);
-				if (params != IF_DEF_PARAMS(ifp) && rn)
-					vty_out(vty, " %pI4",
-						&rn->p.u.prefix4);
-				vty_out(vty, "\n");
+			{
+				const char *str = NULL;
+				const char *pfx;
+				bool simple_is_set;
+				bool warn_decrypt_fail = false;
+
+				/*
+				 * There are two ways to express this password
+				 * in the configuration: plaintext or encrypted.
+				 * If we have an encrypted version, emit that
+				 * version ONLY, otherwise emit the plaintext.
+				 *
+				 * If we have the encrypted version but not the
+				 * plaintext, it means there was some problem
+				 * decrypting, so print a warning comment to the
+				 * emitted configuration so that the user might
+				 * have a clue why the password doesn't work
+				 * in the routing protocol.
+				 *
+				 * Internally, presence of the plaintext
+				 * password is indicated when both a flag is set
+				 * AND the first byte of the password string is
+				 * nonzero.
+				 *
+				 * Presence of the encrypted password is
+				 * indicated when the auth_simple_encrypted
+				 * field is nonzero.
+				 */
+				simple_is_set =
+					OSPF_IF_PARAM_CONFIGURED(params,
+								 auth_simple)
+					&& (params->auth_simple[0] != '\0');
+
+				if (params->auth_simple_encrypted) {
+					pfx = "101 ";
+					str = params->auth_simple_encrypted;
+					if (!simple_is_set)
+						warn_decrypt_fail = true;
+				} else if (simple_is_set) {
+					pfx = "";
+					str = (char *)params->auth_simple;
+				}
+
+				if (str) {
+					if (warn_decrypt_fail) {
+						vty_out(vty,
+							"!!! Error: Unable to decrypt the following string\n");
+					}
+					vty_out(vty,
+						" ip ospf authentication-key %s%s",
+						pfx, str);
+					if (params != IF_DEF_PARAMS(ifp) && rn)
+						vty_out(vty, " %pI4",
+							&rn->p.u.prefix4);
+					vty_out(vty, "\n");
+				}
 			}
 
 			/* Cryptographic Authentication Key print. */
 			if (params && params->auth_crypt) {
+				const char *pfx;
+				char *str;
+
 				for (ALL_LIST_ELEMENTS_RO(params->auth_crypt,
 							  node, ck)) {
+
+					bool warn_decrypt_fail = false;
+
+					if (ck->auth_key_encrypted) {
+						pfx = "101 ";
+						str = ck->auth_key_encrypted;
+						if (!ck->auth_key[0])
+							warn_decrypt_fail =
+								true;
+					} else {
+						pfx = "";
+						str = (char *)ck->auth_key;
+					}
+					if (warn_decrypt_fail) {
+						vty_out(vty,
+							"!!! Error: Unable to decrypt the following string\n");
+					}
 					vty_out(vty,
-						" ip ospf message-digest-key %d md5 %s",
-						ck->key_id, ck->auth_key);
+						" ip ospf message-digest-key %d md5 %s%s",
+						ck->key_id, pfx, str);
 					if (params != IF_DEF_PARAMS(ifp) && rn)
 						vty_out(vty, " %pI4",
 							&rn->p.u.prefix4);
@@ -11914,23 +12503,65 @@ static int config_write_virtual_link(struct vty *vty, struct ospf *ospf)
 				vty_out(vty,
 					" area %s virtual-link %pI4 authentication%s\n",
 					buf, &vl_data->vl_peer, auth_str);
+
+			struct ospf_if_params *params;
+
+			params = IF_DEF_PARAMS(vl_data->vl_oi->ifp);
+
 			/* Auth key */
-			if (IF_DEF_PARAMS(vl_data->vl_oi->ifp)->auth_simple[0]
-			    != '\0')
-				vty_out(vty,
-					" area %s virtual-link %pI4 authentication-key %s\n",
-					buf, &vl_data->vl_peer,
-					IF_DEF_PARAMS(vl_data->vl_oi->ifp)
-						->auth_simple);
+			{
+				const char *pfx;
+				const char *str = NULL;
+				bool warn_decrypt_fail = false;
+
+				if (params->auth_simple_encrypted) {
+					pfx = "101 ";
+					str = params->auth_simple_encrypted;
+					if (!params->auth_simple[0])
+						warn_decrypt_fail = true;
+				} else if (params->auth_simple[0]) {
+					pfx = "";
+					str = (char *)params->auth_simple;
+				}
+				if (str) {
+					if (warn_decrypt_fail) {
+						vty_out(vty,
+							"!!! Error: Unable to decrypt the following string\n");
+					}
+					vty_out(vty,
+						" area %s virtual-link %pI4 authentication-key %s%s\n",
+						buf,
+						&vl_data->vl_peer,
+						pfx, str);
+				}
+			}
+
 			/* md5 keys */
-			for (ALL_LIST_ELEMENTS_RO(
-				     IF_DEF_PARAMS(vl_data->vl_oi->ifp)
-					     ->auth_crypt,
-				     n2, ck))
+			for (ALL_LIST_ELEMENTS_RO(params->auth_crypt, n2, ck)) {
+
+				const char *pfx;
+				const char *str = NULL;
+				bool warn_decrypt_fail = false;
+
+				if (ck->auth_key_encrypted) {
+					pfx = "101 ";
+					str = ck->auth_key_encrypted;
+					if (!ck->auth_key[0])
+						warn_decrypt_fail = true;
+				} else {
+					pfx = "";
+					str = (char *)ck->auth_key;
+				}
+
+				if (warn_decrypt_fail) {
+					vty_out(vty,
+						"!!! Error: Unable to decrypt the following string\n");
+				}
 				vty_out(vty,
-					" area %s virtual-link %pI4 message-digest-key %d md5 %s\n",
+					" area %s virtual-link %pI4  message-digest-key %d md5 %s%s\n",
 					buf, &vl_data->vl_peer,
-					ck->key_id, ck->auth_key);
+					ck->key_id, pfx, str);
+			}
 		}
 	}
 
@@ -12713,4 +13344,9 @@ void ospf_vty_init(void)
 
 	/* Init zebra related vty commands. */
 	ospf_vty_zebra_init();
+
+	keycrypt_init();
+	keycrypt_register_protocol_callback(ospf_keycrypt_state_change);
+	keycrypt_register_protocol_show_callback(
+		ospf_keycrypt_encryption_show_status);
 }

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -299,6 +299,7 @@ struct rip_interface {
 
 	/* RIPv2 authentication string. */
 	char *auth_str;
+	char *auth_str_encrypted;
 
 	/* RIPv2 authentication key chain. */
 	char *key_chain;

--- a/tests/topotests/authentication/KFvars.py
+++ b/tests/topotests/authentication/KFvars.py
@@ -1,0 +1,27 @@
+
+#
+# Define keyfile paths and commands in this file and import to scripts
+#
+
+# Directory containing keyfile
+#KFdir = '~frr/.ssh'
+KFdir = '/etc/frr'
+
+# basename of keyfile
+#KFbase = 'frr'
+KFbase = 'frr_pk_rsa'
+
+# Full path of keyfile
+KFfile = '{}/{}'.format(KFdir, KFbase)
+
+# openssl variant to create keyfile
+KFmk_o = 'openssl genpkey -algorithm RSA -out {}'.format(KFfile)
+
+# can specify "--bits=1024" to certtool for keys smaller than default 3072
+# certtool variant to create keyfile
+KFmk_c = 'certtool --generate-privkey --key-type=rsa --null-password --outfile {}'.format(KFfile)
+
+# create keyfile based on which command is available
+KFmk = 'mkdir {} ; if which certtool ; then {}; else if which openssl ; then {} ; fi ; fi; chown -R frr.frr {} ; chmod -R go-rwx {} '.format(KFdir, KFmk_c, KFmk_o, KFdir, KFdir)
+
+

--- a/tests/topotests/authentication/customize.py
+++ b/tests/topotests/authentication/customize.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+
+#
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2017 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+customize.py: Topology for authentication tests
+
+                  |
+             +----+----+
+             |    r0   |
+             | 99.0.0.1|                             
+             +----+----+
+       192.168.1. | .2  r0-eth0
+                  | .1  r1-eth1
+             +---------+
+             |    r1   |
+             | 1.1.1.1 |                             
+             +----+----+
+                  | .1  r1-eth0
+                  |
+            ~~~~~~~~~~~~~
+          ~~     sw0     ~~
+          ~~ 10.0.1.0/24 ~~
+            ~~~~~~~~~~~~~
+                  |10.0.1.0/24
+                  |
+                  | .2  r2-eth0
+             +----+----+
+             |    r2   |
+             | 2.2.2.2 |                             
+             +--+---+--+
+    r2-eth2  .2 |   | .2  r2-eth1
+         ______/     \______
+        /                   \
+  ~~~~~~~~~~~~~        ~~~~~~~~~~~~~
+~~     sw2     ~~    ~~     sw1     ~~
+~~ 10.0.3.0/24 ~~    ~~ 10.0.2.0/24 ~~
+  ~~~~~~~~~~~~~        ~~~~~~~~~~~~~
+        |                 /    |
+         \      _________/     |
+          \    /                \
+r3-eth1 .3 |  | .3  r3-eth0      | .4 r4-eth0
+      +----+--+---+         +----+----+
+      |     r3    |         |    r4   | r4-eth2
+      |  3.3.3.3  |         | 4.4.4.4 |-------+      
+      +-----------+         +---------+       |
+192.168.2.1 |r3-eth2 192.168.3.1 | r4-eth1    |192.168.4.1
+         .2 |        rX-eth0  .2 |            |         .2
+      +-----+-----+         +----+-----+ +----+-----+
+      |     r5    |         |    r6    | |    r7    |
+      | 99.0.0.2  |         | 99.0.0.3 | | 99.0.0.4 |
+      +-----+-----+         +----+-----+ +----+-----+
+            |                    |            |
+
+"""
+
+import os
+import re
+import pytest
+import platform
+import KFvars
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.ltemplate import ltemplateRtrCmd
+
+# Required to instantiate the topology builder class.
+from mininet.topo import Topo
+
+import shutil
+CWD = os.path.dirname(os.path.realpath(__file__))
+# test name based on directory
+TEST = os.path.basename(CWD)
+
+class ThisTestTopo(Topo):
+    "Test topology builder"
+    def build(self, *_args, **_opts):
+        "Build function"
+        tgen = get_topogen(self)
+
+        # This function only purpose is to define allocation and relationship
+        # between routers, switches and hosts.
+        #
+        # Create routers
+        for routern in range(0, 8):
+            tgen.add_router('r{}'.format(routern))
+        mach = platform.machine()
+        krel = platform.release()
+        if mach[:1] == 'a' and topotest.version_cmp(krel, '4.11') < 0:
+            logger.info('Need Kernel version 4.11 to run on arm processor')
+            return
+
+        #CE/PE links
+        tgen.add_link(tgen.gears['r0'], tgen.gears['r1'], 'r0-eth0', 'r1-eth1')
+        tgen.add_link(tgen.gears['r5'], tgen.gears['r3'], 'r5-eth0', 'r3-eth2')
+        tgen.add_link(tgen.gears['r6'], tgen.gears['r4'], 'r6-eth0', 'r4-eth1')
+        tgen.add_link(tgen.gears['r7'], tgen.gears['r4'], 'r7-eth0', 'r4-eth2')
+
+        # Create a switch with just one router connected to it to simulate a
+        # empty network.
+        switch = {}
+        switch[0] = tgen.add_switch('sw0')
+        switch[0].add_link(tgen.gears['r1'], nodeif='r1-eth0')
+        switch[0].add_link(tgen.gears['r2'], nodeif='r2-eth0')
+
+        switch[1] = tgen.add_switch('sw1')
+        switch[1].add_link(tgen.gears['r2'], nodeif='r2-eth1')
+        switch[1].add_link(tgen.gears['r3'], nodeif='r3-eth0')
+        switch[1].add_link(tgen.gears['r4'], nodeif='r4-eth0')
+
+        switch[1] = tgen.add_switch('sw2')
+        switch[1].add_link(tgen.gears['r2'], nodeif='r2-eth2')
+        switch[1].add_link(tgen.gears['r3'], nodeif='r3-eth1')
+
+l3mdev_accept = 0
+
+def ltemplatePreRouterStartHook():
+    global l3mdev_accept
+    cc = ltemplateRtrCmd()
+    krel = platform.release()
+    tgen = get_topogen()
+    logger.info('pre router-start hook, kernel=' + krel)
+    #check for normal init
+    if len(tgen.net) == 1:
+        logger.info('Topology not configured, skipping setup')
+        return False
+    #trace errors/unexpected output
+    cc.resetCounts()
+
+    cmd = KFvars.KFmk
+
+    #comment out next line if *do *not* want to test key missing startup case
+    #cmd='echo "Key file generated *after* daemon start"'
+    for r in range(0, 8):
+        cc.doCmd(tgen, 'r{}'.format(r), cmd)
+    return True
+
+def ltemplatePostRouterStartHook():
+    logger.info('post router-start hook')
+    return True

--- a/tests/topotests/authentication/r0/bgpd.conf
+++ b/tests/topotests/authentication/r0/bgpd.conf
@@ -1,0 +1,38 @@
+service password-encryption
+frr defaults traditional
+debug keycrypt set backend gcrypt
+!
+hostname r0
+password zebra
+log stdout notifications
+
+log commands
+log file bgpd.log
+
+router bgp 5226
+   bgp router-id 99.0.0.1
+   neighbor 192.168.1.1 remote-as 5226
+   neighbor 192.168.1.1 password 192.168.1.0
+   neighbor 192.168.1.1 update-source 192.168.1.2
+
+   address-family ipv4 unicast
+     network 99.0.0.1/32
+     neighbor 192.168.1.1 activate
+   exit-address-family
+
+   #neighbor 2001:db8:beee:1::1 remote-as 5226
+   #neighbor 2001:db8:beee:1::1 update-source 2001:db8:beee:1::2
+   #neighbor 2001:db8:beee:1::1 password 192.168.1.6
+
+   #address-family ipv6 unicast
+     # TBD enter ipv6 equivalent
+     # network 99.0.0.1/32
+
+   #  neighbor 2001:db8:beee:1::1 activate
+   #exit-address-family
+!
+
+end
+   
+   
+

--- a/tests/topotests/authentication/r0/ospfd.conf
+++ b/tests/topotests/authentication/r0/ospfd.conf
@@ -1,0 +1,12 @@
+service password-encryption
+hostname r0
+log file ospfd.log
+!
+interface r0-eth0
+  ip ospf network point-to-point
+!
+router ospf
+ router-id 99.0.0.1
+ network 0.0.0.0/4 area 0
+ redistribute static
+ area 0.0.0.0 authentication message-digest

--- a/tests/topotests/authentication/r0/ripd.conf
+++ b/tests/topotests/authentication/r0/ripd.conf
@@ -1,0 +1,19 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r0-eth0
+ ip rip authentication mode md5
+ ip rip authentication string 192x168x1x0
+ ip rip send version 2
+
+router rip
+ version 2
+ timers basic 5 180 5
+ redistribute connected
+ redistribute static
+ network r0-eth0
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r0/ripngd.conf
+++ b/tests/topotests/authentication/r0/ripngd.conf
@@ -1,0 +1,17 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r0-eth0
+# ip rip authentication mode md5
+# ip rip authentication string 192x168x1x0
+# ip rip send version 2
+
+router ripng
+ redistribute connected
+ redistribute static
+ network r0-eth0
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r0/zebra.conf
+++ b/tests/topotests/authentication/r0/zebra.conf
@@ -1,0 +1,19 @@
+service password-encryption
+log file zebra.log
+!
+hostname r0
+!
+interface lo
+ ip address 99.0.0.1/32
+!
+interface r0-eth0
+ description to r1
+ ip address 192.168.1.2/24
+ ipv6 address 2001:db8:beee:1::2/64
+ no link-detect
+!
+ip forwarding
+!
+!
+line vty
+!

--- a/tests/topotests/authentication/r1/bgpd.conf
+++ b/tests/topotests/authentication/r1/bgpd.conf
@@ -1,0 +1,43 @@
+service password-encryption
+frr defaults traditional
+
+hostname r1
+password zebra
+log stdout notifications
+
+log commands
+
+log file bgpd.log debugging
+
+router bgp 5226
+   bgp router-id 1.1.1.1
+   bgp cluster-id 1.1.1.1
+   neighbor 2.2.2.2 remote-as 5226
+   neighbor 2.2.2.2 update-source 1.1.1.1
+   neighbor 2.2.2.2 password 1.2.0.0
+   neighbor 192.168.1.2 remote-as 5226
+   neighbor 192.168.1.2 update-source 192.168.1.1
+   neighbor 192.168.1.2 password 192.168.1.0
+
+   address-family ipv4 unicast
+     neighbor 2.2.2.2 activate
+     neighbor 192.168.1.2 activate
+     neighbor 192.168.1.2 next-hop-self
+   exit-address-family
+
+   neighbor 2001:db8:beed:2::2 remote-as 5226
+   neighbor 2001:db8:beed:2::2 update-source 2001:db8:beed:1::1
+   neighbor 2001:db8:beed:2::2 password 1.2.0.6
+
+   #neighbor 2001:db8:beee:1::2 remote-as 5226
+   #neighbor 2001:db8:beee:1::2 update-source neighbor 2001:db8:beee:1::1
+   #neighbor 2001:db8:beee:1::2 password 192.168.1.6
+
+   address-family ipv6 unicast
+     neighbor 2001:db8:beed:2::2 activate
+
+     #neighbor 2001:db8:beee:1::2 activate
+     neighbor 2001:db8:beee:1::2 next-hop-self
+   exit-address-family
+!
+end

--- a/tests/topotests/authentication/r1/ospfd.conf
+++ b/tests/topotests/authentication/r1/ospfd.conf
@@ -1,0 +1,15 @@
+service password-encryption
+hostname r1
+log file ospfd.log
+
+interface r1-eth0
+  ip ospf message-digest-key 1 md5 10x0x1x0
+
+interface r1-eth1
+  ip ospf network point-to-point
+!
+router ospf
+ router-id 1.1.1.1
+ network 0.0.0.0/4 area 0
+ redistribute static
+ area 0.0.0.0 authentication message-digest

--- a/tests/topotests/authentication/r1/ripd.conf
+++ b/tests/topotests/authentication/r1/ripd.conf
@@ -1,0 +1,29 @@
+service password-encryption
+log file ripd.log
+debug keycrypt set backend openssl
+!
+!
+interface r1-eth0
+ ip rip authentication mode md5
+ ip rip authentication string 10x0x1x0
+ ip rip send version 2
+interface r1-eth1 
+ ip rip authentication mode md5
+ ip rip authentication string 192x168x1x0
+ ip rip send version 2
+
+key chain sunshine-band
+ key 1
+  key-string shake
+
+router rip
+ version 2
+ timers basic 5 180 5
+ redistribute connected
+ redistribute static
+ network r1-eth0
+ network r1-eth1
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r1/ripngd.conf
+++ b/tests/topotests/authentication/r1/ripngd.conf
@@ -1,0 +1,22 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r1-eth0
+# ip rip authentication mode md5
+# ip rip authentication string 10x0x1x0
+# ip rip send version 2
+interface r1-eth1 
+# ip rip authentication mode md5
+# ip rip authentication string 192x168x1x0
+# ip rip send version 2
+
+router ripng
+ redistribute connected
+ redistribute static
+ network r1-eth0
+ network r1-eth1
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r1/zebra.conf
+++ b/tests/topotests/authentication/r1/zebra.conf
@@ -1,0 +1,25 @@
+service password-encryption
+log file zebra.log
+!
+hostname r1
+password zebra
+!
+interface lo
+ ip address 1.1.1.1/32
+ ipv6 address 2001:db8:beed:1::1/128
+!
+interface r1-eth0
+ description to sw0
+ ip address 10.0.1.1/24
+ ipv6 address 2001:db8:beef:1::1/64
+!
+interface r1-eth1
+ description to r0
+ ip address 192.168.1.1/24
+ ipv6 address 2001:db8:beee:1::1/64
+!
+ip forwarding
+!
+!
+line vty
+!

--- a/tests/topotests/authentication/r2/bgpd.conf
+++ b/tests/topotests/authentication/r2/bgpd.conf
@@ -1,0 +1,57 @@
+service password-encryption
+frr defaults traditional
+debug keycrypt set backend gcrypt
+
+hostname r2
+password zebra
+log stdout notifications
+
+log commands
+log file bgpd.log debugging
+
+router bgp 5226
+   bgp router-id 2.2.2.2
+   bgp cluster-id 2.2.2.2
+
+   neighbor 1.1.1.1 remote-as 5226
+   neighbor 1.1.1.1 update-source 2.2.2.2
+   neighbor 1.1.1.1 password 1.2.0.0
+   neighbor 3.3.3.3 remote-as 5226
+   neighbor 3.3.3.3 update-source 2.2.2.2
+   neighbor 3.3.3.3 password 2.3.0.0
+   neighbor 4.4.4.4 remote-as 5226
+   neighbor 4.4.4.4 update-source 2.2.2.2
+   neighbor 4.4.4.4 password 2.4.0.0
+   address-family ipv4 unicast
+     neighbor 1.1.1.1 activate
+     neighbor 1.1.1.1 route-reflector-client
+     neighbor 3.3.3.3 activate
+     neighbor 3.3.3.3 route-reflector-client
+     neighbor 4.4.4.4 activate
+     neighbor 4.4.4.4 route-reflector-client
+   exit-address-family
+
+   neighbor 2001:db8:beed:1::1 remote-as 5226
+   neighbor 2001:db8:beed:3::3 remote-as 5226
+   neighbor 2001:db8:beed:4::4 remote-as 5226
+
+   neighbor 2001:db8:beed:1::1 update-source 2001:db8:beed:2::2
+   neighbor 2001:db8:beed:3::3 update-source 2001:db8:beed:2::2
+   neighbor 2001:db8:beed:4::4 update-source 2001:db8:beed:2::2
+
+   neighbor 2001:db8:beed:1::1 password 1.2.0.6
+   neighbor 2001:db8:beed:3::3 password 2.3.0.6
+   neighbor 2001:db8:beed:4::4 password 2.4.0.6
+
+   address-family ipv6 unicast
+     neighbor 2001:db8:beed:1::1 activate
+     neighbor 2001:db8:beed:1::1 route-reflector-client
+     neighbor 2001:db8:beed:3::3 activate
+     neighbor 2001:db8:beed:3::3 route-reflector-client
+     neighbor 2001:db8:beed:4::4 activate
+     neighbor 2001:db8:beed:4::4 route-reflector-client
+   exit-address-family
+end
+   
+   
+

--- a/tests/topotests/authentication/r2/ospfd.conf
+++ b/tests/topotests/authentication/r2/ospfd.conf
@@ -1,0 +1,20 @@
+service password-encryption
+hostname r2
+log file ospfd.log
+debug keycrypt set backend gcrypt
+!
+
+interface r2-eth0
+  ip ospf message-digest-key 1 md5 10x0x1x0
+
+interface r2-eth1
+  ip ospf message-digest-key 1 md5 10x0x2x0
+
+interface r2-eth2
+  ip ospf message-digest-key 1 md5 10x0x3x0
+
+
+router ospf
+ router-id 2.2.2.2
+ network 0.0.0.0/0 area 0
+ area 0.0.0.0 authentication message-digest

--- a/tests/topotests/authentication/r2/ripd.conf
+++ b/tests/topotests/authentication/r2/ripd.conf
@@ -1,0 +1,29 @@
+service password-encryption
+log file ripd.log
+debug keycrypt set backend gcrypt
+!
+!
+interface r2-eth0
+ ip rip authentication mode md5
+ ip rip authentication string 10x0x1x0
+ ip rip send version 2
+interface r2-eth1
+ ip rip authentication mode md5
+ ip rip authentication string 10x0x2x0
+ ip rip send version 2
+interface r2-eth2
+ ip rip authentication mode md5
+ ip rip authentication string 10x0x3x0
+ ip rip send version 2
+router rip
+ version 2
+ timers basic 5 180 5
+ redistribute connected
+ redistribute static
+ network r2-eth0
+ network r2-eth1
+ network r2-eth2
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r2/ripngd.conf
+++ b/tests/topotests/authentication/r2/ripngd.conf
@@ -1,0 +1,26 @@
+service password-encryption
+log file ripngd.log
+!
+!
+interface r2-eth0
+# ip rip authentication mode md5
+# ip rip authentication string 10x0x1x0
+# ip rip send version 2
+interface r2-eth1
+# ip rip authentication mode md5
+# ip rip authentication string 10x0x2x0
+# ip rip send version 2
+interface r2-eth2
+# ip rip authentication mode md5
+# ip rip authentication string 10x0x3x0
+# ip rip send version 2
+router ripng
+ redistribute connected
+ redistribute static
+ network r2-eth0
+ network r2-eth1
+ network r2-eth2
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r2/zebra.conf
+++ b/tests/topotests/authentication/r2/zebra.conf
@@ -1,0 +1,33 @@
+service password-encryption
+log file zebra.log
+
+hostname r2
+password zebra
+!
+interface lo
+ ip address 2.2.2.2/32
+ ipv6 address 2001:db8:beed:2::2/128
+!
+interface r2-eth0
+ description to sw0
+ ip address 10.0.1.2/24
+ ipv6 address 2001:db8:beef:1::2/64
+ no link-detect
+!
+interface r2-eth1
+ description to sw1
+ ip address 10.0.2.2/24
+ ipv6 address 2001:db8:beef:2::2/64
+ no link-detect
+!
+interface r2-eth2
+ description to sw2
+ ip address 10.0.3.2/24
+ ipv6 address 2001:db8:beef:3::2/64
+ no link-detect
+!
+ip forwarding
+!
+!
+line vty
+!

--- a/tests/topotests/authentication/r3/bgpd.conf
+++ b/tests/topotests/authentication/r3/bgpd.conf
@@ -1,0 +1,42 @@
+service password-encryption
+frr defaults traditional
+
+hostname r3
+password zebra
+log stdout notifications
+
+log commands
+log file bgpd.log
+
+#debug bgp vpn label
+router bgp 5226
+   bgp router-id 3.3.3.3
+   bgp cluster-id 3.3.3.3
+   neighbor 2.2.2.2 remote-as 5226
+   neighbor 2.2.2.2 update-source 3.3.3.3
+   neighbor 2.2.2.2 password 2.3.0.0
+   neighbor 192.168.2.2 remote-as 5226
+   neighbor 192.168.2.2 update-source 192.168.2.1 
+   neighbor 192.168.2.2 password 192.168.2.0
+
+   address-family ipv4 unicast
+     neighbor 2.2.2.2 activate
+     neighbor 192.168.2.2 activate
+     neighbor 192.168.2.2 next-hop-self
+   exit-address-family
+
+   neighbor 2001:db8:beed:2::2 remote-as 5226
+   neighbor 2001:db8:beed:2::2 update-source 2001:db8:beed:3::3
+   neighbor 2001:db8:beed:2::2 password 2.3.0.6
+
+   neighbor 2001:db8:beee:2::2 remote-as 5226
+   neighbor 2001:db8:beee:2::2 update-source 2001:db8:beee:2::1
+   neighbor 2001:db8:beee:2::2 password 192.168.2.6
+
+   address-family ipv6 unicast
+     neighbor 2001:db8:beed:2::2 activate
+
+     neighbor 2001:db8:beee:2::2 activate
+     neighbor 2001:db8:beee:2::2 next-hop-self
+   exit-address-family
+end

--- a/tests/topotests/authentication/r3/ldpd.conf
+++ b/tests/topotests/authentication/r3/ldpd.conf
@@ -1,0 +1,12 @@
+service password-encryption
+hostname r3
+password 1
+log file ldpd.log
+
+mpls ldp
+  router-id 192.168.2.1
+  neighbor 192.168.2.2 password pw-ldpd-35
+
+address-family ipv4
+  discovery transport-address 192.168.2.1
+  interface r3-eth2

--- a/tests/topotests/authentication/r3/ospfd.conf
+++ b/tests/topotests/authentication/r3/ospfd.conf
@@ -1,0 +1,20 @@
+service password-encryption
+hostname r3
+password 1
+log file ospfd.log
+
+interface r3-eth0
+  ip ospf message-digest-key 1 md5 10x0x2x0
+
+interface r3-eth1
+  ip ospf message-digest-key 1 md5 10x0x3x0
+
+interface r3-eth2
+  ip ospf network point-to-point
+!
+router ospf
+ router-id 3.3.3.3
+ network 0.0.0.0/4 area 0
+ redistribute static
+!
+ area 0.0.0.0 authentication message-digest

--- a/tests/topotests/authentication/r3/ripd.conf
+++ b/tests/topotests/authentication/r3/ripd.conf
@@ -1,0 +1,28 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r3-eth0
+ ip rip authentication mode md5
+ ip rip authentication string 10x0x2x0
+ ip rip send version 2
+interface r3-eth1
+ ip rip authentication mode md5
+ ip rip authentication string 10x0x3x0
+ ip rip send version 2
+interface r3-eth2
+ ip rip authentication mode md5
+ ip rip authentication string 192x168x2x0
+ ip rip send version 2
+router rip
+ version 2
+ timers basic 5 180 5
+ redistribute connected
+ redistribute static
+ network r3-eth0
+ network r3-eth1
+ network r3-eth2
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r3/ripngd.conf
+++ b/tests/topotests/authentication/r3/ripngd.conf
@@ -1,0 +1,26 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r3-eth0
+# ip rip authentication mode md5
+# ip rip authentication string 10x0x2x0
+# ip rip send version 2
+interface r3-eth1
+# ip rip authentication mode md5
+# ip rip authentication string 10x0x3x0
+# ip rip send version 2
+interface r3-eth2
+# ip rip authentication mode md5
+# ip rip authentication string 192x168x2x0
+# ip rip send version 2
+router ripng
+ redistribute connected
+ redistribute static
+ network r3-eth0
+ network r3-eth1
+ network r3-eth2
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r3/zebra.conf
+++ b/tests/topotests/authentication/r3/zebra.conf
@@ -1,0 +1,34 @@
+service password-encryption
+log file zebra.log
+
+hostname r3
+password zebra
+!
+interface lo
+ ip address 3.3.3.3/32
+ ipv6 address 2001:db8:beed:3::3/128
+!
+interface r3-eth0
+ description to sw1
+ ip address 10.0.2.3/24
+ ipv6 address 2001:db8:beef:2::3/64
+ no link-detect
+!
+interface r3-eth1
+ description to sw2
+ ip address 10.0.3.3/24
+ ipv6 address 2001:db8:beef:3::3/64
+ no link-detect
+!
+interface r3-eth2
+ description to r5
+ ip address 192.168.2.1/24
+ ipv6 address 2001:db8:beee:2::1/64
+ no link-detect
+!
+!
+ip forwarding
+!
+!
+line vty
+!

--- a/tests/topotests/authentication/r4/bgpd.conf
+++ b/tests/topotests/authentication/r4/bgpd.conf
@@ -1,0 +1,61 @@
+service password-encryption
+frr defaults traditional
+debug keycrypt set backend gcrypt
+
+hostname r4
+password zebra
+log stdout notifications
+
+log commands
+log file bgpd.log debug
+
+#debug bgp vpn label
+#debug bgp nht
+#debug bgp zebra
+
+router bgp 5226
+   bgp router-id 4.4.4.4
+   bgp cluster-id 4.4.4.4
+   neighbor 2.2.2.2 remote-as 5226
+   neighbor 2.2.2.2 update-source 4.4.4.4
+   neighbor 2.2.2.2 password 2.4.0.0
+   neighbor 192.168.3.2 remote-as 5226
+   neighbor 192.168.3.2 update-source 192.168.3.1 
+   neighbor 192.168.3.2 password 192.168.3.0
+   neighbor 192.168.4.2 remote-as 5226
+   neighbor 192.168.4.2 update-source 192.168.4.1
+   neighbor 192.168.4.2 password 192.168.4.0
+
+   address-family ipv4 unicast
+     neighbor 2.2.2.2 activate
+     no neighbor 192.168.3.2 activate
+     neighbor 192.168.3.2 next-hop-self
+     no neighbor 192.168.4.2 activate
+     neighbor 192.168.4.2 next-hop-self
+   exit-address-family
+
+   neighbor 2001:db8:beed:2::2 remote-as 5226
+   neighbor 2001:db8:beed:2::2 update-source 2001:db8:beed:4::4
+   neighbor 2001:db8:beed:2::2 password 2.4.0.6
+
+   neighbor 2001:db8:beee:3::2 remote-as 5226
+   neighbor 2001:db8:beee:3::2 update-source 2001:db8:beee:3::1
+   neighbor 2001:db8:beee:3::2 password 192.168.3.6
+
+   neighbor 2001:db8:beee:4::2 remote-as 5226
+   neighbor 2001:db8:beee:4::2 update-source 2001:db8:beee:4::1
+   neighbor 2001:db8:beee:4::2 password 192.168.4.6
+
+   address-family ipv6 unicast
+
+     neighbor 2001:db8:beed:2::2 activate
+
+     neighbor 2001:db8:beee:3::2 activate
+     neighbor 2001:db8:beee:3::2 next-hop-self
+
+     neighbor 2001:db8:beee:4::2 activate
+     neighbor 2001:db8:beee:4::2 next-hop-self
+
+   exit-address-family
+
+end

--- a/tests/topotests/authentication/r4/ospfd.conf
+++ b/tests/topotests/authentication/r4/ospfd.conf
@@ -1,0 +1,19 @@
+service password-encryption
+hostname r4
+log file ospfd.log
+!
+interface r4-eth0
+  ip ospf message-digest-key 1 md5 10x0x2x0
+
+interface r4-eth1
+  ip ospf network point-to-point
+
+interface r4-eth2
+  ip ospf network point-to-point
+
+router ospf
+ router-id 4.4.4.4
+ network 0.0.0.0/4 area 0
+ redistribute static
+!
+ area 0.0.0.0 authentication message-digest

--- a/tests/topotests/authentication/r4/ripd.conf
+++ b/tests/topotests/authentication/r4/ripd.conf
@@ -1,0 +1,29 @@
+service password-encryption
+log file ripd.log
+debug keycrypt set backend gcrypt
+!
+interface r4-eth0
+ ip rip authentication mode md5
+ ip rip authentication string 10x0x2x0
+ ip rip send version 2
+interface r4-eth1
+ ip rip authentication mode md5
+ ip rip authentication string 192x168x3x0
+ ip rip send version 2
+interface r4-eth2
+ ip rip authentication mode md5
+ ip rip authentication string 192x168x4x0
+ ip rip send version 2
+!
+router rip
+ version 2
+ timers basic 5 180 5
+ redistribute connected
+ redistribute static
+ network r4-eth0
+ network r4-eth1
+ network r4-eth2
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r4/ripngd.conf
+++ b/tests/topotests/authentication/r4/ripngd.conf
@@ -1,0 +1,26 @@
+service password-encryption
+log file ripd.log
+!
+interface r4-eth0
+# ip rip authentication mode md5
+# ip rip authentication string 10x0x2x0
+# ip rip send version 2
+interface r4-eth1
+# ip rip authentication mode md5
+# ip rip authentication string 192x168x3x0
+# ip rip send version 2
+interface r4-eth2
+# ip rip authentication mode md5
+# ip rip authentication string 192x168x4x0
+# ip rip send version 2
+!
+router rip
+ redistribute connected
+ redistribute static
+ network r4-eth0
+ network r4-eth1
+ network r4-eth2
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r4/zebra.conf
+++ b/tests/topotests/authentication/r4/zebra.conf
@@ -1,0 +1,30 @@
+service password-encryption
+log file zebra.log
+
+hostname r4
+password zebra
+!
+interface lo
+ ip address 4.4.4.4/32
+ ipv6 address 2001:db8:beed:4::4/128
+!
+interface r4-eth0
+ description to sw1
+ ip address 10.0.2.4/24
+ ipv6 address 2001:db8:beef:2::4/64
+!
+interface r4-eth1
+ description to r6
+ ip address 192.168.3.1/24
+ ipv6 address 2001:db8:beee:3::1/64
+!
+interface r4-eth2
+ description to r7
+ ip address 192.168.4.1/24
+ ipv6 address 2001:db8:beee:4::1/64
+!
+!
+ip forwarding
+!
+line vty
+!

--- a/tests/topotests/authentication/r5/bgpd.conf
+++ b/tests/topotests/authentication/r5/bgpd.conf
@@ -1,0 +1,38 @@
+service password-encryption
+frr defaults traditional
+debug keycrypt set backend openssl
+!
+hostname r5
+password zebra
+log stdout notifications
+
+log commands
+log file bgpd.log
+
+router bgp 5226
+   bgp router-id 99.0.0.2
+   neighbor 192.168.2.1 remote-as 5226
+   neighbor 192.168.2.1 password 192.168.2.0
+   neighbor 192.168.2.1 update-source 192.168.2.2
+
+   address-family ipv4 unicast
+     network 99.0.0.2/32
+     neighbor 192.168.2.1 activate
+   exit-address-family
+
+   neighbor 2001:db8:beee:2::1 remote-as 5226
+   neighbor 2001:db8:beee:2::1 update-source 2001:db8:beee:2::2
+   neighbor 2001:db8:beee:2::1 password 192.168.2.6
+
+   address-family ipv6 unicast
+     # TBD enter ipv6 equivalent
+     #network 99.0.0.2/32
+
+     neighbor 2001:db8:beee:2::1 activate
+   exit-address-family
+!
+
+end
+   
+   
+

--- a/tests/topotests/authentication/r5/ldpd.conf
+++ b/tests/topotests/authentication/r5/ldpd.conf
@@ -1,0 +1,13 @@
+service password-encryption
+debug keycrypt set backend openssl
+hostname r5
+password 1
+log file ldpd.log
+
+mpls ldp
+  router-id 192.168.2.2
+  neighbor 192.168.2.1 password pw-ldpd-35
+
+address-family ipv4
+  discovery transport-address 192.168.2.2
+  interface r5-eth0

--- a/tests/topotests/authentication/r5/ospfd.conf
+++ b/tests/topotests/authentication/r5/ospfd.conf
@@ -1,0 +1,13 @@
+service password-encryption
+hostname r5
+log file ospfd.log
+!
+interface r5-eth0
+  ip ospf network point-to-point
+!
+router ospf
+ router-id 99.0.0.2
+ network 0.0.0.0/4 area 0
+ redistribute static
+!
+ area 0.0.0.0 authentication message-digest

--- a/tests/topotests/authentication/r5/ripd.conf
+++ b/tests/topotests/authentication/r5/ripd.conf
@@ -1,0 +1,19 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r5-eth0
+ ip rip authentication mode md5
+ ip rip authentication string 192x168x5x0
+ ip rip send version 2
+
+router rip
+ version 2
+ timers basic 5 180 5
+ redistribute connected
+ redistribute static
+ network r5-eth0
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r5/ripngd.conf
+++ b/tests/topotests/authentication/r5/ripngd.conf
@@ -1,0 +1,14 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r5-eth0
+
+router rip
+ redistribute connected
+ redistribute static
+ network r5-eth0
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r5/zebra.conf
+++ b/tests/topotests/authentication/r5/zebra.conf
@@ -1,0 +1,19 @@
+service password-encryption
+log file zebra.log
+!
+hostname r5
+!
+interface lo
+ ip address 99.0.0.2/32
+!
+interface r5-eth0
+ description to r3
+ ip address 192.168.2.2/24
+ ipv6 address 2001:db8:beee:2::2/64
+ no link-detect
+!
+ip forwarding
+!
+!
+line vty
+!

--- a/tests/topotests/authentication/r6/bgpd.conf
+++ b/tests/topotests/authentication/r6/bgpd.conf
@@ -1,0 +1,52 @@
+service password-encryption
+frr defaults traditional
+!
+hostname r6
+password zebra
+log stdout notifications
+
+log commands
+log file bgpd.log
+
+router bgp 5226
+   bgp router-id 99.0.0.3
+   #neighbor 192.168.3.1 remote-as 5226
+   #neighbor 192.168.3.1 password 192.168.3.0
+   #neighbor 192.168.3.1 update-source 192.168.3.2
+
+   #address-family ipv4 unicast
+   #  network 99.0.0.3/32
+   #  network 5.1.2.0/24 route-map rm-nh
+   #  network 5.1.3.0/24 route-map rm-nh
+   #  neighbor 192.168.3.1 activate
+   #exit-address-family
+
+   neighbor 2001:db8:beee:3::1 remote-as 5226
+   neighbor 2001:db8:beee:3::1 update-source 2001:db8:beee:3::2
+   neighbor 2001:db8:beee:3::1 password 192.168.3.6
+
+   address-family ipv6 unicast
+     # TBD do ipv6 equivalent
+     #network 99.0.0.3/32
+     #network 5.1.2.0/24 route-map rm-nh
+     #network 5.1.3.0/24 route-map rm-nh
+
+     neighbor 2001:db8:beee:3::1 activate
+   exit-address-family
+!
+access-list al-any permit any
+!
+route-map rm-nh permit 10
+ match ip address al-any
+ set ip next-hop 99.0.0.3
+ set local-preference 50
+ set metric 200
+ set large-community 12:34:56
+ set extcommunity rt 89:123
+ set community 0:67
+!
+
+end
+   
+   
+

--- a/tests/topotests/authentication/r6/ospfd.conf
+++ b/tests/topotests/authentication/r6/ospfd.conf
@@ -1,0 +1,13 @@
+service password-encryption
+hostname r6
+log file ospfd.log
+!
+interface r6-eth0
+  ip ospf network point-to-point
+!
+router ospf
+ router-id 99.0.0.3
+ network 0.0.0.0/4 area 0
+ redistribute static
+!
+ area 0.0.0.0 authentication message-digest

--- a/tests/topotests/authentication/r6/ripd.conf
+++ b/tests/topotests/authentication/r6/ripd.conf
@@ -1,0 +1,19 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r6-eth0
+ ip rip authentication mode md5
+ ip rip authentication string 192x168x3x0
+ ip rip send version 2
+
+router rip
+ version 2
+ timers basic 5 180 5
+ redistribute connected
+ redistribute static
+ network r6-eth0
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r6/ripngd.conf
+++ b/tests/topotests/authentication/r6/ripngd.conf
@@ -1,0 +1,14 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r6-eth0
+
+router rip
+ redistribute connected
+ redistribute static
+ network r6-eth0
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r6/zebra.conf
+++ b/tests/topotests/authentication/r6/zebra.conf
@@ -1,0 +1,19 @@
+service password-encryption
+log file zebra.log
+!
+hostname r6
+!
+interface lo
+ ip address 99.0.0.3/32
+!
+interface r6-eth0
+ description to r4
+ ip address 192.168.3.2/24
+ ipv6 address 2001:db8:beee:3::2/64
+ no link-detect
+!
+ip forwarding
+!
+!
+line vty
+!

--- a/tests/topotests/authentication/r7/bgpd.conf
+++ b/tests/topotests/authentication/r7/bgpd.conf
@@ -1,0 +1,50 @@
+service password-encryption
+frr defaults traditional
+debug keycrypt set backend openssl
+!
+hostname r7
+password zebra
+log stdout notifications
+
+log commands
+log file bgpd.log
+
+router bgp 5226
+   bgp router-id 99.0.0.4
+   #neighbor 192.168.4.1 remote-as 5226
+   #neighbor 192.168.4.1 password 192.168.4.0
+   #neighbor 192.168.4.1 update-source 192.168.4.2
+
+   #address-family ipv4 unicast
+   #  network 99.0.0.4/32
+   #  network 5.4.2.0/24 route-map rm-nh
+   #  network 5.4.3.0/24 route-map rm-nh
+   #  neighbor 192.168.4.1 activate
+   #exit-address-family
+
+   neighbor 2001:db8:beee:4::1 remote-as 5226
+   neighbor 2001:db8:beee:4::1 update-source 2001:db8:beee:4::2
+   neighbor 2001:db8:beee:4::1 password 192.168.4.6
+
+   address-family ipv6 unicast
+     # TBD do ipv6 equivalent
+     #network 99.0.0.4/32
+     #network 5.4.2.0/24 route-map rm-nh
+     #network 5.4.3.0/24 route-map rm-nh
+
+     neighbor 2001:db8:beee:4::1 activate
+   exit-address-family
+!
+access-list al-any permit any
+!
+route-map rm-nh permit 10
+ match ip address al-any
+ set ip next-hop 99.0.0.4
+ set local-preference 50
+ set metric 200
+ set large-community 12:34:56
+ set extcommunity rt 89:123
+ set community 0:67
+!
+
+end

--- a/tests/topotests/authentication/r7/ospfd.conf
+++ b/tests/topotests/authentication/r7/ospfd.conf
@@ -1,0 +1,12 @@
+service password-encryption
+hostname r7
+log file ospfd.log
+!
+interface r7-eth0
+  ip ospf network point-to-point
+!
+router ospf
+ router-id 99.0.0.4
+ network 0.0.0.0/4 area 0
+ redistribute static
+ area 0.0.0.0 authentication message-digest

--- a/tests/topotests/authentication/r7/ripd.conf
+++ b/tests/topotests/authentication/r7/ripd.conf
@@ -1,0 +1,19 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r7-eth0
+ ip rip authentication mode md5
+ ip rip authentication string 192x168x4x0
+ ip rip send version 2
+
+router rip
+ version 2
+ timers basic 5 180 5
+ redistribute connected
+ redistribute static
+ network r7-eth0
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r7/ripngd.conf
+++ b/tests/topotests/authentication/r7/ripngd.conf
@@ -1,0 +1,14 @@
+service password-encryption
+log file ripd.log
+!
+!
+interface r7-eth0
+
+router rip
+ redistribute connected
+ redistribute static
+ network r7-eth0
+!
+line vty
+!
+

--- a/tests/topotests/authentication/r7/zebra.conf
+++ b/tests/topotests/authentication/r7/zebra.conf
@@ -1,0 +1,19 @@
+service password-encryption
+log file zebra.log
+!
+hostname r7
+!
+interface lo
+ ip address 99.0.0.4/32
+!
+interface r7-eth0
+ description to r4
+ ip address 192.168.4.2/24
+ ipv6 address 2001:db8:beee:4::2/64
+ no link-detect
+!
+ip forwarding
+!
+!
+line vty
+!

--- a/tests/topotests/authentication/scripts/bgp-adjacencies.py
+++ b/tests/topotests/authentication/scripts/bgp-adjacencies.py
@@ -1,0 +1,37 @@
+from lutil import luCommand
+
+########################################################################
+# ipv4
+########################################################################
+
+luCommand('r0','vtysh -c "show bgp ipv4 summary"',' 00:0','wait','BGP v4 Adjacencies up',60)
+luCommand('r5','vtysh -c "show bgp ipv4 summary"',' 00:0','wait','BGP v4 Adjacencies up',10)
+#luCommand('r6','vtysh -c "show bgp summary"',' 00:0','wait','BGP v4 Adjacencies up',10)
+#luCommand('r7','vtysh -c "show bgp summary"',' 00:0','wait','BGP v4 Adjacencies up',10)
+
+luCommand('r1','ping 2.2.2.2 -c 1',' 0. packet loss','wait','PE->P2 (loopback) ping',10)
+luCommand('r3','ping 2.2.2.2 -c 1',' 0. packet loss','wait','PE->P2 (loopback) ping',10)
+luCommand('r4','ping 2.2.2.2 -c 1',' 0. packet loss','wait','PE->P2 (loopback) ping',10)
+
+luCommand('r2','vtysh -c "show bgp summary"',' 00:0.* 00:0.* 00:0','wait','Core adjacencies up',10)
+luCommand('r1','vtysh -c "show bgp summary"',' 00:0.* 00:0','wait','Core adjacencies up',10)
+luCommand('r3','vtysh -c "show bgp summary"',' 00:0.* 00:0','wait','Core adjacencies up',10)
+luCommand('r4','vtysh -c "show bgp summary"',' 00:0.* 00:0.* 00:0','wait','Core adjacencies up',10)
+
+########################################################################
+# ipv6
+########################################################################
+
+#luCommand('r0','vtysh -c "show bgp ipv6 summary"',' 00:0','wait','BGP v6 Adjacencies up',60)
+luCommand('r5','vtysh -c "show bgp ipv6 summary"',' 00:0','wait','BGP v6 Adjacencies up',60)
+luCommand('r6','vtysh -c "show bgp ipv6 summary"',' 00:0','wait','BGP v6 Adjacencies up',60)
+luCommand('r7','vtysh -c "show bgp ipv6 summary"',' 00:0','wait','BGP v6 Adjacencies up',60)
+
+luCommand('r1','ping6 2001:db8:beed:2::2 -c 1',' 0. packet loss','wait','PE->P2 (loopback) ping v6',10)
+luCommand('r3','ping6 2001:db8:beed:2::2 -c 1',' 0. packet loss','wait','PE->P2 (loopback) ping v6',10)
+luCommand('r4','ping6 2001:db8:beed:2::2 -c 1',' 0. packet loss','wait','PE->P2 (loopback) ping v6',10)
+
+luCommand('r2','vtysh -c "show bgp ipv6 summary"',' 00:0.* 00:0.* 00:0','wait','Core ipv6 adjacencies up',10)
+luCommand('r1','vtysh -c "show bgp ipv6 summary"',' 00:0','wait','Core ipv6 adjacencies up',10)
+luCommand('r3','vtysh -c "show bgp ipv6 summary"',' 00:0.* 00:0','wait','Core ipv6 adjacencies up',10)
+luCommand('r4','vtysh -c "show bgp ipv6 summary"',' 00:0.* 00:0.* 00:0','wait','Core ipv6 adjacencies up',10)

--- a/tests/topotests/authentication/scripts/check-crypto-backend-diversity.py
+++ b/tests/topotests/authentication/scripts/check-crypto-backend-diversity.py
@@ -1,0 +1,74 @@
+from lutil import luCommand, luLast
+
+#
+# Set and verify crypto backends. This test requires that the specified
+# backends are actually built into FRR (specified/detected at "configure"
+# time)
+#
+
+#
+# Only routers 1,2,4 had rip restarted by restart script
+# Only routers 2 had ospf restarted by restart script
+# Only routers 0,2,4,5,7 had bgp restarted by restart script
+#
+
+want = {
+    'r0': {
+        'set-backend': 'gcrypt',
+        'BGP': 'gcrypt',
+    },
+    'r1': {
+	'set-backend':'openssl',
+	'RIP':'openssl',
+    },
+    'r2': {
+	'set-backend':'gcrypt',
+	'BGP':'gcrypt',
+	'RIP':'gcrypt',
+	'OSPF':'gcrypt',
+    },
+    'r4': {
+	'set-backend':'gcrypt',
+	'BGP':'gcrypt',
+	'RIP':'gcrypt',
+    },
+    'r5': {
+	'set-backend':'openssl',
+        'LDP': 'openssl',
+        'BGP': 'openssl',
+    },
+    'r7': {
+	'set-backend':'openssl',
+        'BGP': 'openssl',
+    },
+}
+
+for router,protoinfo in want.items():
+
+    #
+    # Backends should be set in config files before any passwords appear.
+    # Availability of backends depends on build-time configuration.
+    #
+
+    # set backend (should set all protocols at once)
+    # logic here should be improved
+    available = 0
+    for proto,backend in protoinfo.items():
+	if proto == 'set-backend':
+            # Is desired backend available?
+            match = '[\s\*]({}):'.format(backend)
+            ret = luCommand(router, 'vtysh -c "debug keycrypt show backends"',
+                match, 'none', "match desired backend")
+            found = luLast()
+            if ret != False and found != None:
+                available = 1
+
+    # check backend on each active protocol
+    if available:
+        for proto,backend in protoinfo.items():
+            if proto != 'set-backend':
+                # Is desired backend set?
+                match = '{}: Keycrypt backend: {}'.format(proto,backend)
+                luCommand(router, 'vtysh -c "show keycrypt status"',
+                    match, 'pass',
+                    '{} Has desired keycrypt backend ({})'.format(proto,backend))

--- a/tests/topotests/authentication/scripts/check-decrypt-fail-cfg-warning.py
+++ b/tests/topotests/authentication/scripts/check-decrypt-fail-cfg-warning.py
@@ -1,0 +1,20 @@
+from lutil import luCommand
+
+#
+# Number of decrypt failure warnings we expect in the various
+# protocol configuration outputs
+#
+want = {
+    'r0': {'bgp': 1},
+    'r1': {'rip': 3},				# 2 rip, 1 keychain
+    'r2': {'bgp': 6, 'ospf': 3, 'rip': 3,},
+    'r4': {'bgp': 6, 'rip': 3,},
+    'r5': {'bgp': 2, 'ldp': 1},
+    'r7': {'bgp': 1},
+}
+
+for router,protoinfo in want.items():
+    for proto,count in protoinfo.items():
+        cmd = "grep '!!! Error: Unable to decrypt' /etc/frr/{}d.conf|wc -l".format(proto)
+        luCommand(router, cmd, '{}'.format(count), 'pass',
+            "{} number of decrypt fail warnings".format(proto))

--- a/tests/topotests/authentication/scripts/check-keys-encrypted-only.py
+++ b/tests/topotests/authentication/scripts/check-keys-encrypted-only.py
@@ -1,0 +1,90 @@
+from lutil import luCommand
+
+#
+# Only routers 1,2,4 had rip restarted by restart script
+# Only routers 2 had ospf restarted by restart script
+# Only routers 0,2,4,5,7 had bgp restarted by restart script
+#
+
+want = {
+    'r0': {
+        'bgp': {
+            'plain': 0,
+            'crypt': 1,
+        },
+    },
+    'r1': {
+        'rip': {
+            'plain': 0,
+            'crypt': 2,
+        },
+        'rip-keychain': {
+            'plain': 0,
+            'crypt': 1,
+        },
+    },
+    'r2': {
+        'bgp': {
+            'plain': 0,
+            'crypt': 6,
+        },
+        'rip': {
+            'plain': 0,
+            'crypt': 3,
+        },
+        'ospf': {		# message-digest keys
+            'plain': 0,
+            'crypt': 3,
+        },
+    },
+    'r4': {
+        'bgp': {
+            'plain': 0,
+            'crypt': 6,
+        },
+        'rip': {
+            'plain': 0,
+            'crypt': 3,
+        },
+    },
+    'r5': {
+        'ldp': {
+            'plain': 0,
+            'crypt': 1,
+        },
+        'bgp': {
+            'plain': 0,
+            'crypt': 2,
+        },
+    },
+    'r7': {
+        'bgp': {
+            'plain': 0,
+            'crypt': 1,
+        },
+    },
+}
+
+for router,protoinfo in want.items():
+    for proto,keyinfo in protoinfo.items():
+        match = None
+        if proto == 'bgp':
+            match = 'passwords: {}, encrypted: {}'.format(
+                keyinfo['plain'], keyinfo['crypt'])
+        if proto == 'ospf':
+            match = 'OSPF: vrf default: message-digest-keys keys: {}, encrypted: {}'.format(keyinfo['plain'], keyinfo['crypt'])
+        if proto == 'rip':
+            match = 'RIP: authentication strings: {}, encrypted: {}'.format(
+                keyinfo['plain'], keyinfo['crypt'])
+        if proto == 'rip-keychain':
+            match = 'RIP: Keychain: keys: {}, encrypted: {}'.format(
+                keyinfo['plain'], keyinfo['crypt'])
+	if proto == 'ldp':
+	    match = 'LDP: neighbor passwords: {}, encrypted: {}'.format(
+                keyinfo['plain'], keyinfo['crypt'])
+        if match == None:
+            luResult(router, False, "Invalid Protocol: test coding error")
+        else:
+            luCommand(router, 'vtysh -c "show k s"', match, 'pass',
+                '{} Keycrypt Status'.format(proto))
+

--- a/tests/topotests/authentication/scripts/check-keys.py
+++ b/tests/topotests/authentication/scripts/check-keys.py
@@ -1,0 +1,31 @@
+from lutil import luCommand
+
+for r in range(0, 8):
+    luCommand('r{}'.format(r),'vtysh -c "show k s"','Keycrypt status: ON.*Keycrypt status: ON.*Keycrypt status: ON','pass','Keycrypt ON')
+
+rtrs = ['r0', 'r6', 'r7']
+for rtr in rtrs:
+    luCommand(rtr,'vtysh -c "show k s"', 'RIP: authentication strings: 1, encrypted: 1','pass','RIP Keycrypt status')
+    luCommand(rtr,'vtysh -c "show k s"', 'passwords: 1, encrypted: 1','pass','BGP Keycrypt status')
+
+luCommand('r5','vtysh -c "show k s"', 'RIP: authentication strings: 1, encrypted: 1','pass','RIP Keycrypt status')
+luCommand('r5','vtysh -c "show k s"', 'passwords: 2, encrypted: 2','pass','BGP Keycrypt status')
+luCommand('r5','vtysh -c "show k s"', 'LDP: neighbor passwords: 1, encrypted: 1','pass','LDP Keycrypt status')
+
+luCommand('r1','vtysh -c "show k s"', 'RIP: authentication strings: 2, encrypted: 2','pass','RIP Keycrypt status')
+luCommand('r1','vtysh -c "show k s"', 'RIP: Keychain: keys: 1, encrypted: 1','pass','RIP Keychain Keycrypt status')
+luCommand('r1','vtysh -c "show k s"', 'OSPF: vrf default: message-digest-keys keys: 1, encrypted: 1','pass','OSPF Keycrypt status')
+luCommand('r1','vtysh -c "show k s"', 'passwords: 3, encrypted: 3','pass','BGP Keycrypt status')
+
+luCommand('r2','vtysh -c "show k s"', 'RIP: authentication strings: 3, encrypted: 3','pass','RIP Keycrypt status')
+luCommand('r2','vtysh -c "show k s"', 'OSPF: vrf default: message-digest-keys keys: 3, encrypted: 3','pass','OSPF Keycrypt status')
+luCommand('r2','vtysh -c "show k s"', 'passwords: 6, encrypted: 6','pass','BGP Keycrypt status')
+
+luCommand('r3','vtysh -c "show k s"', 'RIP: authentication strings: 3, encrypted: 3','pass','RIP Keycrypt status')
+luCommand('r3','vtysh -c "show k s"', 'OSPF: vrf default: message-digest-keys keys: 2, encrypted: 2','pass','OSPF Keycrypt status')
+luCommand('r3','vtysh -c "show k s"', 'passwords: 4, encrypted: 4','pass','BGP Keycrypt status')
+luCommand('r3','vtysh -c "show k s"', 'LDP: neighbor passwords: 1, encrypted: 1','pass','LDP Keycrypt status')
+
+luCommand('r4','vtysh -c "show k s"', 'RIP: authentication strings: 3, encrypted: 3','pass','RIP Keycrypt status')
+luCommand('r4','vtysh -c "show k s"', 'OSPF: vrf default: message-digest-keys keys: 1, encrypted: 1','pass','OSPF Keycrypt status')
+luCommand('r4','vtysh -c "show k s"', 'passwords: 6, encrypted: 6','pass','BGP Keycrypt status')

--- a/tests/topotests/authentication/scripts/init-keys.py
+++ b/tests/topotests/authentication/scripts/init-keys.py
@@ -1,0 +1,10 @@
+import pytest
+from lutil import luCommand
+import KFvars
+
+# only create keyfile if it does not already exist
+cmd = 'if [ ! -e {} ] ; then ({}) ; fi; ls -al {}'.format(KFvars.KFfile, KFvars.KFmk, KFvars.KFdir)
+pattern = ' {}'.format(KFvars.KFbase)
+
+for r in range(0, 8):
+    luCommand('r{}'.format(r),cmd, pattern, 'pass','key file found')

--- a/tests/topotests/authentication/scripts/ldp-neighbors.py
+++ b/tests/topotests/authentication/scripts/ldp-neighbors.py
@@ -1,0 +1,6 @@
+from lutil import luCommand
+
+luCommand('r3','vtysh -c "show mpls ldp interface"','r3-eth2','pass','LDP interface', 60)
+luCommand('r5','vtysh -c "show mpls ldp interface"','r5-eth0','pass','LDP interface', 60)
+luCommand('r3','vtysh -c "show mpls ldp neigh"','192.168.2.2.*OPERAT','wait','LDPD operational', 60)
+luCommand('r5','vtysh -c "show mpls ldp neigh"','192.168.2.1.*OPERAT','wait','LDPD operational', 60)

--- a/tests/topotests/authentication/scripts/move-key-away.py
+++ b/tests/topotests/authentication/scripts/move-key-away.py
@@ -1,0 +1,8 @@
+from lutil import luCommand
+import KFvars
+
+cmd = 'mv {} {}- ; ls -al {}'.format(KFvars.KFfile, KFvars.KFfile, KFvars.KFdir)
+pattern = ' {}-'.format(KFvars.KFbase)
+
+for r in range(0, 8):
+    luCommand('r{}'.format(r),cmd, pattern,'pass','key file found')

--- a/tests/topotests/authentication/scripts/move-key-back.py
+++ b/tests/topotests/authentication/scripts/move-key-back.py
@@ -1,0 +1,8 @@
+from lutil import luCommand
+import KFvars
+
+cmd = 'mv {}- {} ; ls -al {}'.format(KFvars.KFfile, KFvars.KFfile, KFvars.KFdir)
+pattern = ' {}'.format(KFvars.KFbase)
+
+for r in range(0, 8):
+    luCommand('r{}'.format(r),cmd, pattern,'pass','key file found')

--- a/tests/topotests/authentication/scripts/notification_check.py
+++ b/tests/topotests/authentication/scripts/notification_check.py
@@ -1,0 +1,9 @@
+from lutil import luCommand
+for routern in range(0, 8):
+    rtr='r{}'.format(routern)
+    ret = luCommand(rtr, 'vtysh -c "show bgp neigh" | grep -v Cease/', 'Notification received .([A-Za-z0-9/ ]*)', 'none', 'collect neighbor stats')
+    found = luLast()
+    if ret != False and found != None:
+        val = found.group(1)
+        ret = luCommand(rtr, 'vtysh -c "show bgp neigh"', 'Notification received', 'fail', 'Notify RXed! {}'.format(val))
+#done

--- a/tests/topotests/authentication/scripts/ospf-neighbors.py
+++ b/tests/topotests/authentication/scripts/ospf-neighbors.py
@@ -1,0 +1,16 @@
+from lutil import luCommand
+
+oneIntf   = 'eth0.*message.digest.key 1 md5 101 '
+twoIntf   = oneIntf + '.*eth1.*message.digest.key 1 md5 101 '
+threeIntf = twoIntf + '.*eth2.*message.digest.key 1 md5 101 '
+
+#check configs for encrypted keys
+luCommand('r1','vtysh -c "show run ospfd"',oneIntf,'pass','Auth key encrypted')
+luCommand('r2','vtysh -c "show run ospfd"',threeIntf,'pass','Auth key encrypted')
+luCommand('r3','vtysh -c "show run ospfd"',twoIntf,'pass','Auth key encrypted')
+luCommand('r4','vtysh -c "show run ospfd"',oneIntf,'pass','Auth key encrypted')
+
+luCommand('r1','vtysh -c "show ip ospf neigh"','Full.*eth0','wait','OSPF Full', 60)
+luCommand('r4','vtysh -c "show ip ospf neigh"','Full.*eth0.*Full.*eth0','wait','OSPF Full', 20)
+luCommand('r3','vtysh -c "show ip ospf neigh"','Full.*eth0.*Full.*eth0.*Full.*eth1','wait','OSPF Full', 10)
+luCommand('r2','vtysh -c "show ip ospf neigh"','Full.*eth0.*Full.*eth1.*Full.*eth1.*Full.*eth2','wait','OSPF Full', 60)

--- a/tests/topotests/authentication/scripts/restart-bgp.py
+++ b/tests/topotests/authentication/scripts/restart-bgp.py
@@ -1,0 +1,22 @@
+from lutil import luCommand
+import time
+
+stamp = time.strftime("%y%m%d-%H%M%S")
+
+oneIntf   = 'neighbor.*password 101 '
+#note restart of r0 results in a hung connection
+rtrs = ['r0', 'r2', 'r4', 'r5', 'r7']
+for rtr in rtrs:
+    luCommand(rtr,'vtysh -c "write memory"','.','none','wrote file')
+    luCommand(rtr,'ls -alt /etc/frr /var/run/frr','.','none')
+    luCommand(rtr,'cat /etc/frr/bgpd.conf',oneIntf,'pass','Auth key encrypted in config')
+    luCommand(rtr,'cat /var/run/frr/bgpd.pid','.','none')
+    luCommand(rtr,'kill `cat /var/run/frr/bgpd.pid`','.','none','kill bgpd')
+    luCommand(rtr,'ps `cat /var/run/frr/bgpd.pid` | wc -l ','1','wait','bgpd killed', 10)
+    luCommand(rtr,
+        '/usr/lib/frr/bgpd -d --log ' +
+        'file:/tmp/topotests/authentication.test_authentication/%s/bgpd-%s.log'
+            % (rtr, stamp),
+        '.','none','restart bgpd')
+    luCommand(rtr,'ps `cat /var/run/frr/bgpd.pid` | wc -l ','2','wait','bgpd restarted', 10)
+    luCommand(rtr,'cat /var/run/frr/bgpd.pid','.','none')

--- a/tests/topotests/authentication/scripts/restart-ldp.py
+++ b/tests/topotests/authentication/scripts/restart-ldp.py
@@ -1,0 +1,19 @@
+from lutil import luCommand
+import time
+
+stamp = time.strftime("%y%m%d-%H%M%S")
+oneIntf   = 'neighbor.*password 101 '
+
+rtrs = ['r3', 'r5']
+for rtr in rtrs:
+    luCommand(rtr,'vtysh -c "write memory"','.','none','wrote file')
+    luCommand(rtr,'ls -alt /etc/frr /var/run/frr','.','none')
+    luCommand(rtr,'cat /etc/frr/ldpd.conf',oneIntf,'pass','Auth key encrypted in config')
+    luCommand(rtr,'kill `cat /var/run/frr/ldpd.pid`','.','none','kill ldpd')
+    luCommand(rtr,'ps `cat /var/run/frr/ldpd.pid` | wc -l ','1','wait','ldpd killed', 10)
+    luCommand(rtr,'/usr/lib/frr/ldpd -d --log ' +
+        'file:/tmp/topotests/authentication.test_authentication/%s/ldpd-%s.log'
+            % (rtr, stamp),
+        '.','none','restart ldpd')
+    luCommand(rtr,'ps `cat /var/run/frr/ldpd.pid` | wc -l ','2','wait','ldpd restarted', 10)
+    

--- a/tests/topotests/authentication/scripts/restart-ospf.py
+++ b/tests/topotests/authentication/scripts/restart-ospf.py
@@ -1,0 +1,19 @@
+from lutil import luCommand
+import time
+
+stamp = time.strftime("%y%m%d-%H%M%S")
+
+oneIntf   = 'eth0.*message.digest.key 1 md5 101 '
+rtrs = ['r2']
+for rtr in rtrs:
+    luCommand(rtr,'vtysh -c "write memory"','.','none','wrote file')
+    luCommand(rtr,'ls -alt /etc/frr /var/run/frr','.','none')
+    luCommand(rtr,'cat /etc/frr/ospfd.conf',oneIntf,'pass','Auth key encrypted in config')
+    luCommand(rtr,'kill `cat /var/run/frr/ospfd.pid`','.','none','kill ospfd')
+    luCommand(rtr,'ps `cat /var/run/frr/ospfd.pid` | wc -l ','1','wait','ospfd killed', 10)
+    luCommand(rtr,'/usr/lib/frr/ospfd -d ' +
+        'file:/tmp/topotests/authentication.test_authentication/%s/ospfd-%s.log'
+            % (rtr, stamp),
+        '.','none','restart ospfd')
+    luCommand(rtr,'ps `cat /var/run/frr/ospfd.pid` | wc -l ','2','wait','ospfd restarted', 10)
+    

--- a/tests/topotests/authentication/scripts/restart-rip.py
+++ b/tests/topotests/authentication/scripts/restart-rip.py
@@ -1,0 +1,20 @@
+from lutil import luCommand
+import time
+
+stamp = time.strftime("%y%m%d-%H%M%S")
+
+oneIntf   = 'eth0.*authentication string 101 .*ip rip send'
+
+rtrs = ['r1', 'r2', 'r4']
+for rtr in rtrs:
+    luCommand(rtr,'vtysh -c "write memory"','.','none','wrote file')
+    luCommand(rtr,'ls -alt /etc/frr /var/run/frr','.','none')
+    luCommand(rtr,'cat /etc/frr/ripd.conf',oneIntf,'pass','Auth key encrypted in config')
+    luCommand(rtr,'kill `cat /var/run/frr/ripd.pid`','.','none','kill ripd')
+    luCommand(rtr,'ps `cat /var/run/frr/ripd.pid` | wc -l ','1','wait','ripd killed', 10)
+    luCommand(rtr,'/usr/lib/frr/ripd -d ' +
+        'file:/tmp/topotests/authentication.test_authentication/%s/ripd-%s.log'
+            % (rtr, stamp),
+        '.','none','restart ripd')
+    luCommand(rtr,'ps `cat /var/run/frr/ripd.pid` | wc -l ','2','wait','ripd restarted', 10)
+    

--- a/tests/topotests/authentication/scripts/rip-show.py
+++ b/tests/topotests/authentication/scripts/rip-show.py
@@ -1,0 +1,25 @@
+from lutil import luCommand
+
+oneIntf   = 'eth0.*authentication string 101 .*ip rip send'
+twoIntf   = oneIntf + '.*eth1.*authentication string 101 .*ip rip send'
+threeIntf = twoIntf + '.*eth2.*authentication string 101 .*ip rip send'
+
+#check configs for encrypted keys
+luCommand('r0','vtysh -c "show run ripd"',oneIntf,'pass','Auth key encrypted')
+luCommand('r1','vtysh -c "show run ripd"',twoIntf,'pass','Auth key encrypted')
+luCommand('r2','vtysh -c "show run ripd"',threeIntf,'pass','Auth key encrypted')
+luCommand('r3','vtysh -c "show run ripd"',threeIntf,'pass','Auth key encrypted')
+luCommand('r4','vtysh -c "show run ripd"',threeIntf,'pass','Auth key encrypted')
+luCommand('r5','vtysh -c "show run ripd"',oneIntf,'pass','Auth key encrypted')
+luCommand('r6','vtysh -c "show run ripd"',oneIntf,'pass','Auth key encrypted')
+luCommand('r7','vtysh -c "show run ripd"',oneIntf,'pass','Auth key encrypted')
+
+#check that keys are working
+luCommand('r0','vtysh -c "show ip rip status"',' 00:0','wait','RIP Peers', 60)
+luCommand('r1','vtysh -c "show ip rip status"',' 00:0.* 00:0','wait','RIP Peers', 30)
+luCommand('r2','vtysh -c "show ip rip status"',' 00:0.* 00:0.* 00:0.* 00:0','wait','RIP Peers', 30)
+luCommand('r3','vtysh -c "show ip rip status"',' 00:0.* 00:0.* 00:0.* 00:0','wait','RIP Peers', 30)
+luCommand('r4','vtysh -c "show ip rip status"',' 00:0.* 00:0.* 00:0.* 00:0','wait','RIP Peers', 30)
+luCommand('r5','vtysh -c "show ip rip status"',' 00:0','wait','RIP Peers', 10)
+luCommand('r6','vtysh -c "show ip rip status"',' 00:0','wait','RIP Peers', 10)
+luCommand('r7','vtysh -c "show ip rip status"',' 00:0','wait','RIP Peers', 10)

--- a/tests/topotests/authentication/scripts/ripng-show.py
+++ b/tests/topotests/authentication/scripts/ripng-show.py
@@ -1,0 +1,41 @@
+from lutil import luCommand
+
+# show routes: "show ip ripng"
+# show status: "show ip ripng status"
+
+# foreign routers can use link-local addresses in their advertisements so
+# it's not straightforward to parse the "gateway" field of the status output.
+
+# the patterns below are pretty loose
+
+luCommand('r0','vtysh -c "show ip ripng"',
+    ' 2001:db8:beed:1::1/128 .* r0-eth0 .* 2001:db8:beed:2::2/128 .* r0-eth0 .* 2001:db8:beed:3::3/128 .* r0-eth0 .* 2001:db8:beed:4::4/128 .* r0-eth0 ',
+    'wait','RIPng Routes', 60)
+
+luCommand('r1','vtysh -c "show ip ripng"',
+    ' 2001:db8:beed:1::1/128 .* self .* 2001:db8:beed:2::2/128 .* r1-eth0 .* 2001:db8:beed:3::3/128 .* r1-eth0 .* 2001:db8:beed:4::4/128 .* r1-eth0 ',
+    'wait','RIPng Routes', 30)
+
+luCommand('r2','vtysh -c "show ip ripng"',
+    ' 2001:db8:beed:1::1/128 .* r2-eth0 .* 2001:db8:beed:2::2/128 .* self .* 2001:db8:beed:3::3/128 .* r2-eth[12] .* 2001:db8:beed:4::4/128 .* r2-eth1 ',
+    'wait','RIPng Routes', 30)
+
+luCommand('r3','vtysh -c "show ip ripng"',
+    ' 2001:db8:beed:1::1/128 .* r3-eth[01] .* 2001:db8:beed:2::2/128 .* r3-eth[01] .* 2001:db8:beed:3::3/128 .* self .* 2001:db8:beed:4::4/128 .* r3-eth0 ',
+    'wait','RIPng Routes', 30)
+
+luCommand('r4','vtysh -c "show ip ripng"',
+    ' 2001:db8:beed:1::1/128 .* r4-eth0 .* 2001:db8:beed:2::2/128 .* r4-eth0 .* 2001:db8:beed:3::3/128 .* r4-eth0 .* 2001:db8:beed:4::4/128 .* self ',
+    'wait','RIPng Routes', 30)
+
+luCommand('r5','vtysh -c "show ip ripng"',
+    ' 2001:db8:beed:1::1/128 .* r5-eth0 .* 2001:db8:beed:2::2/128 .* r5-eth0 .* 2001:db8:beed:3::3/128 .* r5-eth0 .* 2001:db8:beed:4::4/128 .* r5-eth0 ',
+    'wait','RIPng Routes', 10)
+
+luCommand('r6','vtysh -c "show ip ripng"',
+    ' 2001:db8:beed:1::1/128 .* r6-eth0 .* 2001:db8:beed:2::2/128 .* r6-eth0 .* 2001:db8:beed:3::3/128 .* r6-eth0 .* 2001:db8:beed:4::4/128 .* r6-eth0 ',
+    'wait','RIPng Routes', 10)
+
+luCommand('r7','vtysh -c "show ip ripng"',
+    ' 2001:db8:beed:1::1/128 .* r7-eth0 .* 2001:db8:beed:2::2/128 .* r7-eth0 .* 2001:db8:beed:3::3/128 .* r7-eth0 .* 2001:db8:beed:4::4/128 .* r7-eth0 ',
+    'wait','RIPng Routes', 10)

--- a/tests/topotests/authentication/test_authentication.py
+++ b/tests/topotests/authentication/test_authentication.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+
+#
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2020, LabN Consulting, L.L.C.
+# Authored by Lou Berger <lberger@labn.net>
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../'))
+# Following is for KFvars
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), './'))
+
+from lib.ltemplate import *
+from lib.lutil import luCommand
+
+CliOnFail = None
+# For debugging, uncomment the next line
+#CliOnFail = 'tgen.mininet_cli'
+
+RunTests = None
+
+#code currently doesn't handle case where key created after startup
+def test_have_keycrypt():
+    global RunTests
+    RunTests = True
+    ErrStr = 'not included in software build'
+    ret = luCommand('r0','vtysh -c "show k s"', ErrStr, 'none')
+    found = luLast()
+    if ret != False and found != None:
+        if len(found.group()):
+            luCommand('r0','vtysh -c "show k s"', ErrStr, 'pass', 'Skipping test - keycrypt %s' % ErrStr)
+            RunTests = False
+
+def test_init_keys():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/init-keys.py', False, CliOnFail, CheckFunc)
+
+def test_check_keys1():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/check-keys.py', False, CliOnFail, CheckFunc)
+
+# test for backend diversity (only runs if FRR built with desired backends)
+def test_check_backend_diversity():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/check-crypto-backend-diversity.py', False, CliOnFail, CheckFunc)
+
+
+#test conversion first (then do re-boots, and test again)
+
+def test_rip_show1():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/rip-show.py', False, CliOnFail, CheckFunc)
+
+def test_ripng_show1():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/ripng-show.py', False, CliOnFail, CheckFunc)
+
+#test conversion
+def test_ospf_neighbors1():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/ospf-neighbors.py', False, CliOnFail, CheckFunc)
+
+def test_bgp_adjacencies1():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/bgp-adjacencies.py', False, CliOnFail, CheckFunc)
+
+def test_notification_check1():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/notification_check.py', False, CliOnFail, CheckFunc)
+
+def test_ldp1():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/ldp-neighbors.py', False, CliOnFail, CheckFunc)
+
+#do restarts
+def test_restart_rip():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/restart-rip.py', False, CliOnFail, CheckFunc)
+
+def test_restart_ospf():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/restart-ospf.py', False, CliOnFail, CheckFunc)
+
+def test_restart_bgp():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/restart-bgp.py', False, CliOnFail, CheckFunc)
+
+def test_restart_ldp():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/restart-ldp.py', False, CliOnFail, CheckFunc)
+
+def test_check_keys2():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/check-keys.py', False, CliOnFail, CheckFunc)
+
+#test load from file
+def test_rip_show2():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/rip-show.py', False, CliOnFail, CheckFunc)
+
+def test_ospf_neighbors2():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/ospf-neighbors.py', False, CliOnFail, CheckFunc)
+
+def test_bgp_adjacencies2():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/bgp-adjacencies.py', False, CliOnFail, CheckFunc)
+
+def test_notification_check():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/notification_check.py', False, CliOnFail, CheckFunc)
+
+#
+# encrypted protocol key conservation test:
+# - move openssl private key file away
+# - save cfg/restart protocol (have plaintext keys, but save encrypted keys;
+#				load encrypted keys but can't decrypt)
+# - save cfg/restart protocol (save encrypted keys, load encrypted keys but
+#				can't decrypt)
+# - verify encrypted protocol keys in running configuration but no plain
+# - move openssl private key file back (same private key as before!)
+# - save cfg/restart protocol (save encrypted keys, load encrypted keys
+#				and able to decrypt)
+# - verify peerings
+# - verify correct plain/encrypted key counts (scripts/check-keys.py)
+#
+def test_protocol_key_conservation():
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', kernel=None)'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, kernel=None)'
+    if RunTests != True:
+         pytest.skip('keycrypt not included in software build')
+    else:
+        ltemplateTest('scripts/move-key-away.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-rip.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-rip.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-ospf.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-ospf.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-bgp.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-bgp.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-ldp.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-ldp.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/check-keys-encrypted-only.py', False, CliOnFail,
+                      CheckFunc, LogTag='ck 1')
+        ltemplateTest('scripts/check-decrypt-fail-cfg-warning.py',
+                      False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/move-key-back.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-rip.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/rip-show.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-ospf.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/ospf-neighbors.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-bgp.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/bgp-adjacencies.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/restart-ldp.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/ldp-neighbors.py', False, CliOnFail, CheckFunc)
+        ltemplateTest('scripts/check-keys.py', False, CliOnFail,
+                      CheckFunc, LogTag='ck 2')
+
+if __name__ == '__main__':
+    retval = pytest.main(["-s"])
+    sys.exit(retval)

--- a/tests/topotests/lib/ltemplate.py
+++ b/tests/topotests/lib/ltemplate.py
@@ -151,9 +151,8 @@ def teardown_module(mod):
     tgen.stop_topology()
     _lt = None
 
-
 def ltemplateTest(
-    script, SkipIfFailed=True, CallOnFail=None, CheckFuncStr=None, KeepGoing=False
+    script, SkipIfFailed=True, CallOnFail=None, CheckFuncStr=None, KeepGoing=False, LogTag=None
 ):
     global _lt
     if _lt == None or _lt.prestarthooksuccess != True:
@@ -165,6 +164,8 @@ def ltemplateTest(
             logger.error("Could not find script file: " + script)
             assert "Could not find script file: " + script
     logger.info("Starting template test: " + script)
+    if LogTag != None:
+        logger.info("LogTag: " + LogTag)
     numEntry = luNumFail()
 
     if SkipIfFailed and tgen.routers_have_failure():

--- a/vtysh/extract.pl.in
+++ b/vtysh/extract.pl.in
@@ -91,6 +91,9 @@ sub scan_file {
         if ($file =~ /lib\/keychain\.c$/) {
             $protocol = "VTYSH_RIPD|VTYSH_EIGRPD";
         }
+        elsif ($file =~ /lib\/keycrypt\.c$/) {
+            $protocol = "VTYSH_BGPD|VTYSH_OSPFD|VTYSH_RIPD|VTYSH_LDPD";
+        }
         elsif ($file =~ /lib\/routemap\.c$/ || $file =~ /lib\/routemap_cli\.c$/) {
             $protocol = "VTYSH_RMAP";
         }

--- a/yang/frr-bgp-neighbor.yang
+++ b/yang/frr-bgp-neighbor.yang
@@ -48,9 +48,9 @@ submodule frr-bgp-neighbor {
 
   grouping neighbor-parameters {
     leaf password {
-      type string {
-        length "1..254";
-      }
+      // Note: length checking done in C handler because limit is dependent
+      // on plaintext vs. encrypted
+      type string;
       description
         "Actual password.";
     }

--- a/yang/frr-ripd.yang
+++ b/yang/frr-ripd.yang
@@ -566,9 +566,7 @@ module frr-ripd {
         description
           "Choose whether to use a simple password or a key-chain.";
         leaf authentication-password {
-          type string {
-            length "1..16";
-          }
+          type string;
           description
             "Authentication string.";
         }


### PR DESCRIPTION
[note: supersedes #6311. I believe these commits address licensing and code comments from that PR. New PR in order to preserve #6311 history]
```
*: Protocol Key Encryption

SUMMARY
    CLI support for: bgpd, ldpd, ospfd, ripd, keychain.
    Not yet implemented: isisd.

    Show/store/parse authentication strings/passwords/keys in
    encrypted form instead of plaintext. Use separate RSA key
    file to encrypt/decrypt.

USAGE
    Controlled by "[no] service password-encrypt"

    "service password-encryption" turns on CLI encryption of
    protocol keys, i.e., the strings used for authentication
    between routers.

    When "service password-encryption" is in effect, plain text passwords
    will be encrypted when entered and will be output only in encrypted
    form, even if "no service password-encryption" is specified.

    "show keycrypt status" displays:
        - enable/disable
        - crypto backend type and version
        - keyfile path and readability
        - counts of plain/encrypted keys per daemon

OPERATION
    lib/keyencrypt.[ch] library to encrypt/decrypt protocol keys.
    Specific protocol key systems (bgpd, rip, etc.) call this library.

    Uses RSA encryption.

    Encrypted strings are base64 encoded for CLI read/write.

    Key length implies upper limit on length of encrypted protocol
    passwords: roughly 2 bytes shorter than key length. Thus
    1024-bit key can encrypt up to about 126 byte string, which
    should be much more than needed.

    Encrypted protocol keys are conserved even if they can't be
    decrypted (e.g., bad/missing RSA key file)

KEY FILE
    - Private key file contains both private and public encryption keys.
    - Uses effective userid of running protocol process to
      look up (getpwuid) home directory, reads private key
      file ~/.ssh/frr
    - generate private key file via gnutls or openssl tools:
        chown <user> ~<user>/.ssh
        chmod 0700 ~<user>/.ssh
            Option 1:
                certtool --generate-privkey --key-type=rsa --null-password \
                    --outfile ~<user>/.ssh/frr
            Option 2:
                openssl genpkey -algorithm RSA -out ~<user>/.ssh/frr
        chown <user> ~<user>/.ssh/frr
        chmod 0400 ~<user>/.ssh/frr

BUILDING
    - Requires libgcrypt or openssl/libressl to encrypt/decrypt.

    - libgcrypt will be used if available.

    - openssl/libressl must be specified explicitly to "configure" via
      --with-crypto=openssl|libressl and possibly
      PKG_CONFIG_PATH=/path/to/pkgconfig/directory

TOPOTESTS
    "authentication" module tests protocol key encrypt, decrypt, and
    protocol operation with keys: bgp v4/v6, ldpd, ospf, rip, keychain.

DESIGN NOTES

    Crypto backends are modular so it is straightforward to
    add a new rsa mechanism.

    Current backends are: gcrypt, openssl/libressl, gnutls. gcrypt is
    preferred; openssl/libressl 2nd choice. gnutls is currently disabled
    (see below).

    OAEP (defined in pkcs#1 v2.1+) padding affords more security for
    rsa encryption than the pkcs#1 v1.5 padding, so we use OAEP.
    pkcs#1 v1.5 padding is often referred to as "pkcs1 padding" in
    crypto constants/flags/keywords.

    configure.ac/configure now picks up gnutls and gcrypt libraries
    automatically. openssl/libressl must be explicitly requested via
    --with-crypto per legacy behavior.

    Having multiple crypto libraries linked simultaneously makes
    it possible to do valuable interoperability checking a) between
    keycrypt backends in the same executable, and b) between multiple
    instances of protocol daemons running in, e.g., topotest
    that are using different backends.

    libressl is very nearly a drop-in API-compatible replacement
    for openssl and can not be linked simultaneously with openssl.
    Therefore, we treat libressl internally as a kind of openssl.
    The developer can specify --with-crypto=openssl or
    --with-crypto=libressl and the configure script will detect
    one or the other based on the version number (currently
    openssl is version 1.x and libressl is version 3.x).

    gnutls relies on nettle for low-level crypto functions.
    Nettle does not have oaep padding for rsa. Therefore, we
    will disable the gnutls backend for now until oaep support
    is added to nettle.

    gcrypt library supports OAEP but has limited keyfile parsing
    capabilities. We do our own PKCS1/PKCS8 (PEM) parsing for this
    backend.

    clang-format applied
```