### PR TITLE
ospfd: small doc and cli changes

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -177,8 +177,8 @@ To start OSPF process you have to specify the OSPF router.
    OSPF (:ref:`redistribute-routes-to-ospf`). This is the only way to
    advertise non-OSPF links into stub areas.
 
-.. index:: timers throttle spf DELAY INITIAL-HOLDTIME MAX-HOLDTIME
-.. clicmd:: timers throttle spf DELAY INITIAL-HOLDTIME MAX-HOLDTIME
+.. index:: timers throttle spf (0-600000) (0-600000) (0-600000)
+.. clicmd:: timers throttle spf (0-600000) (0-600000) (0-600000)
 
 .. index:: no timers throttle spf
 .. clicmd:: no timers throttle spf

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -693,11 +693,11 @@ Interfaces
    retransmitting Database Description and Link State Request packets. The
    default value is 5 seconds.
 
-.. index:: ip ospf transmit-delay
-.. clicmd:: ip ospf transmit-delay
+.. index:: ip ospf transmit-delay (1-65535) [A.B.C.D]
+.. clicmd:: ip ospf transmit-delay (1-65535) [A.B.C.D]
 
-.. index:: no ip ospf transmit-delay
-.. clicmd:: no ip ospf transmit-delay
+.. index:: no ip ospf transmit-delay [(1-65535)] [A.B.C.D]
+.. clicmd:: no ip ospf transmit-delay [(1-65535)] [A.B.C.D]
 
    Set number of seconds for InfTransDelay value. LSAs' age should be
    incremented by this value when transmitting. The default value is 1 second.

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -7809,7 +7809,7 @@ DEFUN_HIDDEN (no_ospf_priority,
 
 DEFUN (ip_ospf_retransmit_interval,
        ip_ospf_retransmit_interval_addr_cmd,
-       "ip ospf retransmit-interval (3-65535) [A.B.C.D]",
+       "ip ospf retransmit-interval (1-65535) [A.B.C.D]",
        "IP Information\n"
        "OSPF interface commands\n"
        "Time between retransmitting lost link state advertisements\n"
@@ -7823,7 +7823,7 @@ DEFUN (ip_ospf_retransmit_interval,
 	struct ospf_if_params *params;
 	params = IF_DEF_PARAMS(ifp);
 
-	argv_find(argv, argc, "(3-65535)", &idx);
+	argv_find(argv, argc, "(1-65535)", &idx);
 	seconds = strtol(argv[idx]->arg, NULL, 10);
 
 	if (argv_find(argv, argc, "A.B.C.D", &idx)) {
@@ -7845,7 +7845,7 @@ DEFUN (ip_ospf_retransmit_interval,
 
 DEFUN_HIDDEN (ospf_retransmit_interval,
               ospf_retransmit_interval_cmd,
-              "ospf retransmit-interval (3-65535) [A.B.C.D]",
+              "ospf retransmit-interval (1-65535) [A.B.C.D]",
               "OSPF interface commands\n"
               "Time between retransmitting lost link state advertisements\n"
               "Seconds\n"
@@ -7856,7 +7856,7 @@ DEFUN_HIDDEN (ospf_retransmit_interval,
 
 DEFUN (no_ip_ospf_retransmit_interval,
        no_ip_ospf_retransmit_interval_addr_cmd,
-       "no ip ospf retransmit-interval [(3-65535)] [A.B.C.D]",
+       "no ip ospf retransmit-interval [(1-65535)] [A.B.C.D]",
        NO_STR
        "IP Information\n"
        "OSPF interface commands\n"
@@ -7896,7 +7896,7 @@ DEFUN (no_ip_ospf_retransmit_interval,
 
 DEFUN_HIDDEN (no_ospf_retransmit_interval,
        no_ospf_retransmit_interval_cmd,
-       "no ospf retransmit-interval [(3-65535)] [A.B.C.D]",
+       "no ospf retransmit-interval [(1-65535)] [A.B.C.D]",
        NO_STR
        "OSPF interface commands\n"
        "Time between retransmitting lost link state advertisements\n"


### PR DESCRIPTION
## Summary

Changes:
- Show the command `timers throttle spf` timers range in docs.
- Document command ` ip ospf transmit-delay` parameters.
- Allow `ip ospf retransmit-interval` timer interval range to start from `1` instead of `3` like what we have in the virtual link command (`area <foo> virtual-link <bar> retransmit-interval`). I didn't find any reason for the command to start in `3` and it was imported that way ( https://github.com/FRRouting/frr/commit/718e3744195351130f4ce7dbe0613f4b3e23df93#diff-4f2f2d542f9f1d0523483b6fe2e3230aR5003 ).