### PR TITLE
tests: Fix JSON diff for nested lists

### DIFF
--- a/tests/topotests/lib/test/test_json.py
+++ b/tests/topotests/lib/test/test_json.py
@@ -463,5 +463,39 @@ def test_json_object_asterisk_matching():
     assert json_cmp(dcomplete, dsub4) is None
 
 
+def test_json_list_nested_with_objects():
+
+    dcomplete = [
+        {
+            "key": 1,
+            "list": [
+                123
+            ]
+        },
+        {
+            "key": 2,
+            "list": [
+                123
+            ]
+        }
+    ]
+
+    dsub1 = [
+        {
+            "key": 2,
+            "list": [
+                123
+            ]
+        },
+        {
+            "key": 1,
+            "list": [
+                123
+            ]
+        }
+    ]
+
+    assert json_cmp(dcomplete, dsub1) is None
+
 if __name__ == "__main__":
     sys.exit(pytest.main())

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -173,7 +173,9 @@ def gen_json_diff_report(d1, d2, exact=False, path="> $", acc=(0, "")):
                 closest_diff = None
                 closest_idx = None
                 for idx1, v1 in zip(range(0, len(d1)), d1):
-                    tmp_diff = gen_json_diff_report(v1, v2, path=add_idx(idx1))
+                    tmp_v1 = deepcopy(v1)
+                    tmp_v2 = deepcopy(v2)
+                    tmp_diff = gen_json_diff_report(tmp_v1, tmp_v2, path=add_idx(idx1))
                     if not has_errors(tmp_diff):
                         found_match = True
                         del d1[idx1]


### PR DESCRIPTION
The involved piece of code is supposed to find a 'closest' match for two
JSON structures using another JSON diff. However, it can happen that
during that new diff the JSON structures are altered (elements from a
list are deleted when 'found'). This is in general ok when the deleted
element is part of the JSON structure which 'matches', but when it later
turns out that some other element of the structure doesn't fit, then the
whole structure should be recovered. This is now realized by using a
deepcopy for the besaid new JSON diff such that the original is only
altered (e.g. deleted) when the diff is clean.

Signed-off-by: GalaxyGorilla <sascha@netdef.org>