### PR TITLE
bgpd: Set nh_ifindex to peer's interface ifindex

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2016,10 +2016,12 @@ int bgp_mp_reach_parse(struct bgp_attr_parser_args *args,
 			stream_getl(s); /* RD low */
 		}
 		stream_get(&attr->mp_nexthop_global, s, IPV6_MAX_BYTELEN);
-		if (IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_global)) {
+		if (IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_global)
+		    || IN6_IS_ADDR_UNSPECIFIED(&attr->mp_nexthop_global)) {
 			if (!peer->nexthop.ifp) {
-				zlog_warn("%s sent a v6 global and LL attribute but global address is a V6 LL and there's no peer interface information. Hence, withdrawing",
-					  peer->host);
+				zlog_warn(
+					"%s sent a v6 global and LL attribute but global address is a V6 LL or :: and there's no peer interface information. Hence, withdrawing",
+					peer->host);
 				return BGP_ATTR_PARSE_WITHDRAW;
 			}
 			attr->nh_ifindex = peer->nexthop.ifp->ifindex;


### PR DESCRIPTION
According to https://tools.ietf.org/html/draft-white-linklocalnh-00

In order to support backwards compatibility
with existing implementations, an implementation MAY ignore a second
link local IPv6 address or 0::0/0 included with an IPv6 link local
address when the length of the Next Hop Field is set to 32.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>