### PR TITLE
Fix for nexthop as IPv4 mapped IPv6 address

### DIFF
--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -574,6 +574,17 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 			gnh_modified = 1;
 		}
 
+		if (IN6_IS_ADDR_UNSPECIFIED(mod_v6nhg)) {
+			if(peer->nexthop.v4.s_addr) {
+				ipv4_to_ipv4_mapped_ipv6(mod_v6nhg, peer->nexthop.v4);
+			}
+		} else {
+			if(peer->nexthop.v4.s_addr && (!IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_local))) {
+				ipv4_to_ipv4_mapped_ipv6(mod_v6nhg, peer->nexthop.v4);
+				gnh_modified = 1;
+			}
+		}
+
 		if (nhlen == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL
 		    || nhlen == BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL) {
 			stream_get_from(&v6nhlocal, s, offset_nhlocal,
@@ -818,7 +829,6 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 						subgrp, adj);
 				return NULL;
 			}
-
 			if (BGP_DEBUG(update, UPDATE_OUT)
 			    || BGP_DEBUG(update, UPDATE_PREFIX)) {
 				memset(send_attr_str, 0, BUFSIZ);

--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -93,6 +93,11 @@ static inline char *ipaddr2str(const struct ipaddr *ip, char *buf, int size)
 	return buf;
 }
 
+#define VALIDATE_MAPPED_IPV6(A)                                           \
+  ((A)->s6_addr32[0] == 0x00000000 ?                                      \
+  ((A)->s6_addr32[1] == 0x00000000 ?                                      \
+  (ntohl((A)->s6_addr32[2]) == 0xFFFF ? 1 : 0): 0): 0)
+
 /*
  * Convert IPv4 address to IPv4-mapped IPv6 address which is of the
  * form ::FFFF:<IPv4 address> (RFC 4291). This IPv6 address can then

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1046,12 +1046,16 @@ static void _netlink_route_nl_add_gateway_info(uint8_t route_family,
 		addattr_l(nlmsg, req_size, RTA_VIA, &gw_fam.family,
 			  bytelen + 2);
 	} else {
-		if (gw_family == AF_INET)
-			addattr_l(nlmsg, req_size, RTA_GATEWAY,
-				  &nexthop->gate.ipv4, bytelen);
-		else
-			addattr_l(nlmsg, req_size, RTA_GATEWAY,
-				  &nexthop->gate.ipv6, bytelen);
+
+		if(nexthop->rparent && VALIDATE_MAPPED_IPV6(&nexthop->rparent->gate.ipv6)) {
+		} else {
+			if (gw_family == AF_INET)
+				addattr_l(nlmsg, req_size, RTA_GATEWAY,
+						&nexthop->gate.ipv4, bytelen);
+			else
+				addattr_l(nlmsg, req_size, RTA_GATEWAY,
+						&nexthop->gate.ipv6, bytelen);
+		}
 	}
 }
 

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -364,6 +364,7 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 	struct rtattr *nest;
 	struct vxlan_encap_info_t *vxlan;
 	int nest_len;
+	struct in6_addr ipv6;
 
 	struct {
 		struct nlmsghdr n;
@@ -420,8 +421,12 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 
 	if (ri->num_nhs == 1) {
 		nhi = &ri->nhs[0];
-
 		if (nhi->gateway) {
+			if(nhi->type == NEXTHOP_TYPE_IPV4_IFINDEX && ri->af == AF_INET6) {
+				ipv4_to_ipv4_mapped_ipv6(&ipv6, nhi->gateway->ipv4);
+				addattr_l(&req->n, in_buf_len, RTA_GATEWAY,
+						&ipv6, bytelen);
+			} else
 			addattr_l(&req->n, in_buf_len, RTA_GATEWAY,
 				  nhi->gateway, bytelen);
 		}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1767,6 +1767,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 	struct interface *ifp;
 	rib_dest_t *dest;
 	struct zebra_vrf *zvrf;
+	struct in_addr ipv4;
 
 	if ((nexthop->type == NEXTHOP_TYPE_IPV4)
 	    || nexthop->type == NEXTHOP_TYPE_IPV6)
@@ -1827,13 +1828,22 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 		return 0;
 	}
 
+	/* Validation for ipv4 mapped ipv6 nexthop. */
+	if (VALIDATE_MAPPED_IPV6 (&nexthop->gate.ipv6)) {
+		afi = AFI_IP;
+	}
 	/* Make lookup prefix. */
 	memset(&p, 0, sizeof(struct prefix));
 	switch (afi) {
 	case AFI_IP:
 		p.family = AF_INET;
 		p.prefixlen = IPV4_MAX_PREFIXLEN;
-		p.u.prefix4 = nexthop->gate.ipv4;
+		if (VALIDATE_MAPPED_IPV6 (&nexthop->gate.ipv6)) {
+			ipv4_mapped_ipv6_to_ipv4(&nexthop->gate.ipv6, &ipv4);
+			p.u.prefix4 = ipv4;
+		} else {
+			p.u.prefix4 = nexthop->gate.ipv4;
+		}
 		break;
 	case AFI_IP6:
 		p.family = AF_INET6;


### PR DESCRIPTION
BUG No. #6341 and #6382
lib   : Added a macro to validate the IPv4 Mapped IPv6 address.
bgp   : Modifications done for bgp receive and while sending updates
	for IPv4 Mapped IPv6 address.
zebra : Modifications done for installing IPv4 Mapped IPv6 address as nexthop
	in RIB. Minor correction done in fpm while sending the routes for
	nexthop as IPv4 Mapped IPv6 address.