### PR TITLE
bgpd: Use IPv6 LL address as nexthop if global was set to ::/LL

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -558,7 +558,18 @@ static int make_prefix(int afi, struct bgp_path_info *pi, struct prefix *p)
 			p->u.prefix6 = p_orig->u.prefix6;
 			p->prefixlen = p_orig->prefixlen;
 		} else {
-			p->u.prefix6 = pi->attr->mp_nexthop_global;
+			/* If we receive MP_REACH nexthop with ::(LL)
+			 * or LL(LL), use LL address as nexthop cache.
+			 */
+			if (pi->attr->mp_nexthop_len
+				    == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL
+			    && (IN6_IS_ADDR_UNSPECIFIED(
+					&pi->attr->mp_nexthop_global)
+				|| IN6_IS_ADDR_LINKLOCAL(
+					&pi->attr->mp_nexthop_global)))
+				p->u.prefix6 = pi->attr->mp_nexthop_local;
+			else
+				p->u.prefix6 = pi->attr->mp_nexthop_global;
 			p->prefixlen = IPV6_MAX_BITLEN;
 		}
 		break;


### PR DESCRIPTION
This happens between Bird and FRR. Maybe others as well, dunno.

Bird sends ::(fe80::1588) and we have a nexthop as :: which is inaccessible:

```
BGP routing table entry for fdff:b87d:f5b0::/48
Paths: (1 available, no best path)
  Not advertised to any peer
  4242421588 4242422547 4242422601 4242423605
    :: (inaccessible) from fe80::1588 (172.20.16.140)
    (fe80::1588) (used)
      Origin IGP, invalid, external
      Last update: Mon May 25 14:27:02 2020
```

bgpd[9554]: fe80::1588 went from OpenConfirm to Established
bgpd[9554]: fe80::1588 [FSM] Timer (routeadv timer expire)
bgpd[9554]: fe80::1588 rcvd UPDATE w/ attr: , origin i, mp_nexthop ::(fe80::1588)
bgpd[9554]: fe80::1588 rcvd UPDATE wlen 0 attrlen 120 alen 0
bgpd[9554]: fe80::1588 rcvd fda9:26a9:1c47:2d42::/64 IPv6 unicast
bgpd[9554]: Allocated bnc ::/128(VRF default) peer 0x0
bgpd[9554]: bgp_update(0.0.0.0): NH unresolved
bgpd[9554]: fe80::1588 rcvd fda9:26a9:1c47:d42::/64 IPv6 unicast

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>