### PR TITLE
tests: Don't enforce setting IPv6 link-locals

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1179,11 +1179,6 @@ class Router(Node):
                     logger.debug('{}: {} zebra started'.format(self, self.routertype))
                     sleep(1, '{}: waiting for zebra to start'.format(self.name))
 
-                    # Fix Link-Local Addresses
-                    # Somehow (on Mininet only), Zebra removes the IPv6 Link-Local
-                    #  addresses on start. Fix this
-                    self.cmd('for i in `ls /sys/class/net/` ; do mac=`cat /sys/class/net/$i/address`; IFS=\':\'; set $mac; unset IFS; ip address add dev $i scope link fe80::$(printf %02x $((0x$1 ^ 2)))$2:${3}ff:fe$4:$5$6/64; done')
-
             if daemon == 'staticd':
                 # Start staticd next if required
                 if self.daemons['staticd'] == 1:


### PR DESCRIPTION
This should work by default and also this code "overwrites"
settings in zebra which leads to problems in e.g. BFD.

Signed-off-by: GalaxyGorilla <sascha@netdef.org>