### PR TITLE
Fix BGP NHT to skip inappropriate paths & only act upon change

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -776,6 +776,11 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 					path->flags);
 		}
 
+		/* Skip paths marked for removal or as history. */
+		if (CHECK_FLAG(path->flags, BGP_PATH_REMOVED)
+		    || CHECK_FLAG(path->flags, BGP_PATH_HISTORY))
+			continue;
+
 		/* Copy the metric to the path. Will be used for bestpath
 		 * computation */
 		if (bgp_isvalid_nexthop(bnc) && bnc->metric)


### PR DESCRIPTION
These commits ensure that upon receipt of a NHT change event, any paths marked for removal or as history are skipped and also that EVPN route import or unimport is invoked only if there is a change to the path's validity. Some debug logs are also enhanced.