### PR TITLE
zebra: Every time zebra receives a ZEBRA_PW_SET, zebra should evaluate nh

### DIFF
--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -125,9 +125,12 @@ void zebra_pw_change(struct zebra_pw *pw, ifindex_t ifindex, int type, int af,
 	pw->flags = flags;
 	pw->data = *data;
 
-	if (zebra_pw_enabled(pw))
-		zebra_register_rnh_pseudowire(pw->vrf_id, pw);
-	else {
+	if (zebra_pw_enabled(pw)) {
+		bool nht_exists;
+		zebra_register_rnh_pseudowire(pw->vrf_id, pw, &nht_exists);
+		if (nht_exists)
+			zebra_pw_update(pw);
+	} else {
 		if (pw->protocol == ZEBRA_ROUTE_STATIC)
 			zebra_deregister_rnh_pseudowire(pw->vrf_id, pw);
 		zebra_pw_uninstall(pw);

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -50,7 +50,7 @@ extern struct rnh *zebra_lookup_rnh(struct prefix *p, vrf_id_t vrfid,
 extern void zebra_free_rnh(struct rnh *rnh);
 extern void zebra_add_rnh_client(struct rnh *rnh, struct zserv *client,
 				 enum rnh_type type, vrf_id_t vrfid);
-extern void zebra_register_rnh_pseudowire(vrf_id_t, struct zebra_pw *);
+extern void zebra_register_rnh_pseudowire(vrf_id_t, struct zebra_pw *, bool *);
 extern void zebra_deregister_rnh_pseudowire(vrf_id_t, struct zebra_pw *);
 extern void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client,
 				    enum rnh_type type);


### PR DESCRIPTION
zebra: Every time zebra receives a ZEBRA_PW_SET, zebra should call zebra_evaluate_rnh().

This fixes a race condition where zebra sometimes fails to install
a pseudowire that is 'up' and has a reachable next hop.

Signed-off-by: Karen Schoener <karen@voltanet.io>