### PR TITLE
pimd: Fix crash on restart from thread_cancel

### DIFF
--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -125,7 +125,7 @@ static void zclient_lookup_failed(struct zclient *zlookup)
 
 void zclient_lookup_free(void)
 {
-	thread_cancel(zlookup_read);
+	THREAD_OFF(zlookup_read);
 	zclient_stop(zlookup);
 	zclient_free(zlookup);
 	zlookup = NULL;


### PR DESCRIPTION
We were using thread_cancel() directly instead of
THREAD_OFF which correctly ensures the pointer is not NULL.

Ticket:CM-29866
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>