### PR TITLE
zebra, lib: bugfix for zebra packet debugging messages

### DIFF
--- a/lib/stream.c
+++ b/lib/stream.c
@@ -1122,6 +1122,11 @@ int stream_flush(struct stream *s, int fd)
 	return nbytes;
 }
 
+void stream_hexdump(struct stream *s)
+{
+	zlog_hexdump(s->data, s->endp);
+}
+
 /* Stream first in first out queue. */
 
 struct stream_fifo *stream_fifo_new(void)

--- a/lib/stream.c
+++ b/lib/stream.c
@@ -1122,7 +1122,7 @@ int stream_flush(struct stream *s, int fd)
 	return nbytes;
 }
 
-void stream_hexdump(struct stream *s)
+void stream_hexdump(const struct stream *s)
 {
 	zlog_hexdump(s->data, s->endp);
 }

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -252,6 +252,9 @@ extern void stream_reset(struct stream *);
 extern int stream_flush(struct stream *, int);
 extern int stream_empty(struct stream *); /* is the stream empty? */
 
+/* debugging */
+extern void stream_hexdump(struct stream *);
+
 /* deprecated */
 extern uint8_t *stream_pnt(struct stream *);
 

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -253,7 +253,7 @@ extern int stream_flush(struct stream *, int);
 extern int stream_empty(struct stream *); /* is the stream empty? */
 
 /* debugging */
-extern void stream_hexdump(struct stream *);
+extern void stream_hexdump(const struct stream *s);
 
 /* deprecated */
 extern uint8_t *stream_pnt(struct stream *);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -160,7 +160,7 @@ void zserv_log_message(const char *errmsg, struct stream *msg,
 		zlog_debug("Command: %s", zserv_command_string(hdr->command));
 		zlog_debug("    VRF: %u", hdr->vrf_id);
 	}
-	zlog_hexdump(msg->data, STREAM_READABLE(msg));
+	stream_hexdump(msg);
 }
 
 /*


### PR DESCRIPTION
`debug zebra packet detail` now dumps the full received message whereas it had been dropping exactly 10 bytes in the debugging output before.

Example output before this fix:
```
2020/05/28 10:53:47 ZEBRA: Rx'd ZAPI message
2020/05/28 10:53:47 ZEBRA:  Length: 54
2020/05/28 10:53:47 ZEBRA: Command: ZEBRA_RULE_ADD
2020/05/28 10:53:47 ZEBRA:     VRF: 0
2020/05/28 10:53:47 ZEBRA: 00007ff35c003380: 00 36 fe 06 00 00 00 00 .6......
2020/05/28 10:53:47 ZEBRA: 00007ff35c003388: 00 51 00 00 00 01 00 00 .Q......
2020/05/28 10:53:47 ZEBRA: 00007ff35c003390: 00 7a 00 00 01 a5 00 00 .z......
2020/05/28 10:53:47 ZEBRA: 00007ff35c003398: 00 01 02 20 01 01 02 02 ... ....
2020/05/28 10:53:47 ZEBRA: 00007ff35c0033a0: 00 00 02 00 00 00 00 00 ........
2020/05/28 10:53:47 ZEBRA: 00007ff35c0033a8: 00 00 00 00             ....
```

After this fix:
```
2020/05/28 10:39:20 2020/05/28 10:39:20 ZEBRA: Rx'd ZAPI message
2020/05/28 10:39:20 ZEBRA:  Length: 54
2020/05/28 10:39:20 ZEBRA: Command: ZEBRA_RULE_ADD
2020/05/28 10:39:20 ZEBRA:     VRF: 0
2020/05/28 10:39:20 ZEBRA: 00007f5950003380: 00 36 fe 06 00 00 00 00 .6......
2020/05/28 10:39:20 ZEBRA: 00007f5950003388: 00 51 00 00 00 01 00 00 .Q......
2020/05/28 10:39:20 ZEBRA: 00007f5950003390: 00 7a 00 00 01 a5 00 00 .z......
2020/05/28 10:39:20 ZEBRA: 00007f5950003398: 00 01 02 20 01 01 02 02 ... ....
2020/05/28 10:39:20 ZEBRA: 00007f59500033a0: 00 00 02 00 00 00 00 00 ........
2020/05/28 10:39:20 ZEBRA: 00007f59500033a8: 00 00 00 00 00 00 00 00 ........
2020/05/28 10:39:20 ZEBRA: 00007f59500033b0: 27 11 00 00 00 03       '.....
```

Signed-off-by: Wesley Coakley <wcoakley@cumulusnetworks.com>