### PR TITLE
bgpd: Use THREAD_CANCEL instead of thread_cancel

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -909,7 +909,7 @@ void bgp_close(void)
 	for (ALL_LIST_ELEMENTS(bm->listen_sockets, node, next, listener)) {
 		if (listener->bgp)
 			continue;
-		thread_cancel(listener->thread);
+		THREAD_OFF(listener->thread);
 		close(listener->fd);
 		listnode_delete(bm->listen_sockets, listener);
 		XFREE(MTYPE_BGP_LISTENER, listener->name);


### PR DESCRIPTION
We are crashing in thread_cancel on shutdown because
the thread pointer is NULL.  Use the more appropriate
THREAD_CANCEL macro

Ticket: CM-29873
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>