### PR TITLE
zebra: add IPv6 router-id

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1050,23 +1050,34 @@ Many routing protocols require a router-id to be configured. To have a
 consistent router-id across all daemons, the following commands are available
 to configure and display the router-id:
 
-.. index:: [no] router-id A.B.C.D
-.. clicmd:: [no] router-id A.B.C.D
+.. index:: [no] [ip] router-id A.B.C.D
+.. clicmd:: [no] [ip] router-id A.B.C.D
 
    Allow entering of the router-id.  This command also works under the
-   vrf subnode, to allow router-id's per vrf. 
+   vrf subnode, to allow router-id's per vrf.
 
-.. index:: [no] router-id A.B.C.D vrf NAME
-.. clicmd:: [no] router-id A.B.C.D vrf NAME
+.. index:: [no] [ip] router-id A.B.C.D vrf NAME
+.. clicmd:: [no] [ip] router-id A.B.C.D vrf NAME
 
    Configure the router-id of this router from the configure NODE.
    A show run of this command will display the router-id command
    under the vrf sub node.  This command is deprecated and will
    be removed at some point in time in the future.
- 
-.. index:: show router-id [vrf NAME]
-.. clicmd:: show router-id [vrf NAME]
+
+.. index:: show [ip] router-id [vrf NAME]
+.. clicmd:: show [ip] router-id [vrf NAME]
 
    Display the user configured router-id.
 
+For protocols requiring an IPv6 router-id, the following commands are available:
 
+.. index:: [no] ipv6 router-id X:X::X:X
+.. clicmd:: [no] ipv6 router-id X:X::X:X
+
+   Configure the IPv6 router-id of this router. Like its IPv4 counterpart,
+   this command works under the vrf subnode, to allow router-id's per vrf.
+
+.. index:: show ipv6 router-id [vrf NAME]
+.. clicmd:: show ipv6 router-id [vrf NAME]
+
+   Display the user configured IPv6 router-id.

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -436,7 +436,8 @@ void zclient_send_reg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 			   vrf_id);
 
 	/* We need router-id information. */
-	zebra_message_send(zclient, ZEBRA_ROUTER_ID_ADD, vrf_id);
+	zclient_send_router_id_update(zclient, ZEBRA_ROUTER_ID_ADD, AFI_IP,
+				      vrf_id);
 
 	/* We need interface information. */
 	zebra_message_send(zclient, ZEBRA_INTERFACE_ADD, vrf_id);
@@ -503,7 +504,8 @@ void zclient_send_dereg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 			   vrf_id);
 
 	/* We need router-id information. */
-	zebra_message_send(zclient, ZEBRA_ROUTER_ID_DELETE, vrf_id);
+	zclient_send_router_id_update(zclient, ZEBRA_ROUTER_ID_DELETE, AFI_IP,
+				      vrf_id);
 
 	zebra_message_send(zclient, ZEBRA_INTERFACE_DELETE, vrf_id);
 
@@ -552,6 +554,18 @@ void zclient_send_dereg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 				ZEBRA_REDISTRIBUTE_DEFAULT_DELETE, zclient, afi,
 				vrf_id);
 	}
+}
+
+int zclient_send_router_id_update(struct zclient *zclient,
+				  zebra_message_types_t type, afi_t afi,
+				  vrf_id_t vrf_id)
+{
+	struct stream *s = zclient->obuf;
+	stream_reset(s);
+	zclient_create_header(s, type, vrf_id);
+	stream_putw(s, afi);
+	stream_putw_at(s, 0, stream_get_endp(s));
+	return zclient_send_message(zclient);
 }
 
 /* Send request to zebra daemon to start or stop RA. */

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -647,6 +647,9 @@ extern void zclient_send_vrf_label(struct zclient *zclient, vrf_id_t vrf_id,
 
 extern void zclient_send_reg_requests(struct zclient *, vrf_id_t);
 extern void zclient_send_dereg_requests(struct zclient *, vrf_id_t);
+extern int zclient_send_router_id_update(struct zclient *zclient,
+					 zebra_message_types_t type, afi_t afi,
+					 vrf_id_t vrf_id);
 
 extern void zclient_send_interface_radv_req(struct zclient *zclient,
 					    vrf_id_t vrf_id,

--- a/zebra/router-id.h
+++ b/zebra/router-id.h
@@ -39,7 +39,7 @@ extern void router_id_del_address(struct connected *c);
 extern void router_id_init(struct zebra_vrf *zvrf);
 extern void router_id_cmd_init(void);
 extern void router_id_write(struct vty *vty, struct zebra_vrf *zvrf);
-extern void router_id_get(struct prefix *p, struct zebra_vrf *zvrf);
+extern int router_id_get(afi_t afi, struct prefix *p, struct zebra_vrf *zvrf);
 
 #ifdef __cplusplus
 }

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -904,17 +904,18 @@ void zsend_iptable_notify_owner(struct zebra_pbr_iptable *iptable,
 	zserv_send_message(client, s);
 }
 
-/* Router-id is updated. Send ZEBRA_ROUTER_ID_ADD to client. */
-int zsend_router_id_update(struct zserv *client, struct prefix *p,
+/* Router-id is updated. Send ZEBRA_ROUTER_ID_UPDATE to client. */
+int zsend_router_id_update(struct zserv *client, afi_t afi, struct prefix *p,
 			   vrf_id_t vrf_id)
 {
 	int blen;
+	struct stream *s;
 
 	/* Check this client need interface information. */
-	if (!vrf_bitmap_check(client->ridinfo, vrf_id))
+	if (!vrf_bitmap_check(client->ridinfo[afi], vrf_id))
 		return 0;
 
-	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	/* Message type. */
 	zclient_create_header(s, ZEBRA_ROUTER_ID_UPDATE, vrf_id);
@@ -1874,20 +1875,48 @@ stream_failure:
 /* Register zebra server router-id information.  Send current router-id */
 static void zread_router_id_add(ZAPI_HANDLER_ARGS)
 {
+	afi_t afi;
+
 	struct prefix p;
 
+	STREAM_GETW(msg, afi);
+
+	if (afi <= AFI_UNSPEC || afi >= AFI_MAX) {
+		zlog_warn(
+			"Invalid AFI %u while registering for router ID notifications",
+			afi);
+		goto stream_failure;
+	}
+
 	/* Router-id information is needed. */
-	vrf_bitmap_set(client->ridinfo, zvrf_id(zvrf));
+	vrf_bitmap_set(client->ridinfo[afi], zvrf_id(zvrf));
 
-	router_id_get(&p, zvrf);
+	router_id_get(afi, &p, zvrf);
 
-	zsend_router_id_update(client, &p, zvrf_id(zvrf));
+	zsend_router_id_update(client, afi, &p, zvrf_id(zvrf));
+
+stream_failure:
+	return;
 }
 
 /* Unregister zebra server router-id information. */
 static void zread_router_id_delete(ZAPI_HANDLER_ARGS)
 {
-	vrf_bitmap_unset(client->ridinfo, zvrf_id(zvrf));
+	afi_t afi;
+
+	STREAM_GETW(msg, afi);
+
+	if (afi <= AFI_UNSPEC || afi >= AFI_MAX) {
+		zlog_warn(
+			"Invalid AFI %u while unregistering from router ID notifications",
+			afi);
+		goto stream_failure;
+	}
+
+	vrf_bitmap_unset(client->ridinfo[afi], zvrf_id(zvrf));
+
+stream_failure:
+	return;
 }
 
 static void zsend_capabilities(struct zserv *client, struct zebra_vrf *zvrf)
@@ -1976,8 +2005,8 @@ static void zread_vrf_unregister(ZAPI_HANDLER_ARGS)
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
 			vrf_bitmap_unset(client->redist[afi][i], zvrf_id(zvrf));
 		vrf_bitmap_unset(client->redist_default[afi], zvrf_id(zvrf));
+		vrf_bitmap_unset(client->ridinfo[afi], zvrf_id(zvrf));
 	}
-	vrf_bitmap_unset(client->ridinfo, zvrf_id(zvrf));
 }
 
 /*

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -68,8 +68,8 @@ extern int zsend_redistribute_route(int cmd, struct zserv *zclient,
 				    const struct prefix *src_p,
 				    const struct route_entry *re);
 
-extern int zsend_router_id_update(struct zserv *zclient, struct prefix *p,
-				  vrf_id_t vrf_id);
+extern int zsend_router_id_update(struct zserv *zclient, afi_t afi,
+				  struct prefix *p, vrf_id_t vrf_id);
 extern int zsend_interface_vrf_update(struct zserv *zclient,
 				      struct interface *ifp, vrf_id_t vrf_id);
 extern int zsend_interface_link_params(struct zserv *zclient,

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -92,6 +92,11 @@ struct zebra_vrf {
 	struct list *rid_all_sorted_list;
 	struct list *rid_lo_sorted_list;
 	struct prefix rid_user_assigned;
+	struct list _rid6_all_sorted_list;
+	struct list _rid6_lo_sorted_list;
+	struct list *rid6_all_sorted_list;
+	struct list *rid6_lo_sorted_list;
+	struct prefix rid6_user_assigned;
 
 	/*
 	 * Back pointer to the owning namespace.

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -628,8 +628,8 @@ static void zserv_client_free(struct zserv *client)
 		}
 
 		vrf_bitmap_free(client->redist_default[afi]);
+		vrf_bitmap_free(client->ridinfo[afi]);
 	}
-	vrf_bitmap_free(client->ridinfo);
 
 	/*
 	 * If any instance are graceful restart enabled,
@@ -750,8 +750,8 @@ static struct zserv *zserv_client_create(int sock)
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
 			client->redist[afi][i] = vrf_bitmap_init();
 		client->redist_default[afi] = vrf_bitmap_init();
+		client->ridinfo[afi] = vrf_bitmap_init();
 	}
-	client->ridinfo = vrf_bitmap_init();
 
 	/* Add this client to linked list. */
 	frr_with_mutex(&client_mutex) {

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -135,7 +135,7 @@ struct zserv {
 	vrf_bitmap_t redist_default[AFI_MAX];
 
 	/* Router-id information. */
-	vrf_bitmap_t ridinfo;
+	vrf_bitmap_t ridinfo[AFI_MAX];
 
 	bool notify_owner;
 


### PR DESCRIPTION
 * add command `[no] ipv6 router-id X:X::X:X [vrf NAME]`.
 * add command `show ipv6 router-id [vrf NAME]`.
 * add command `[no] ip router-id A.B.C.D [vrf NAME]` and
   make the old one without `ip` an alias for it.
 * add command `show ip router-id [vrf NAME]` and make
   the old one without `ip` an alias for it.
 * add ZAPI commands `ZEBRA_ROUTER_ID_V6_ADD`,
   `ZEBRA_ROUTER_ID_V6_DELETE` and `ZEBRA_ROUTER_ID_V6_UPDATE`
   for deamons to get notified of the IPv6 router-id.
 * update zebra documentation.