### PR TITLE
Standardize JSON `index` keys by deprecating old `ifIndex` keys

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3384,6 +3384,10 @@ DEFUN (show_ip_ospf_instance,
 	return ret;
 }
 
+#if CONFDATE > 20210601
+CPP_NOTICE("Please remove ifIndex key from `show ip ospf interface` json")
+#endif
+
 static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 				       struct interface *ifp,
 				       json_object *json_interface_sub,
@@ -3404,6 +3408,7 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 			json_object_boolean_false_add(json_interface_sub,
 						      "ifDown");
 
+		json_object_int_add(json_interface_sub, "index", ifp->ifindex);
 		json_object_int_add(json_interface_sub, "ifIndex",
 				    ifp->ifindex);
 		json_object_int_add(json_interface_sub, "mtuBytes", ifp->mtu);
@@ -3797,6 +3802,8 @@ static void show_ip_ospf_interface_traffic_sub(struct vty *vty,
 					       bool use_json)
 {
 	if (use_json) {
+		json_object_int_add(json_interface_sub, "index",
+				    oi->ifp->ifindex);
 		json_object_int_add(json_interface_sub, "ifIndex",
 				    oi->ifp->ifindex);
 		json_object_int_add(json_interface_sub, "helloIn",

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5662,6 +5662,10 @@ DEFUN (show_ip_pim_statistics,
 	return CMD_SUCCESS;
 }
 
+#if CONFDATE > 20210601
+CPP_NOTICE("Please remove ifIndex key from `show ip multicast count` json")
+#endif
+
 static void show_multicast_interfaces(struct pim_instance *pim, struct vty *vty,
 				      bool uj)
 {
@@ -5708,6 +5712,7 @@ static void show_multicast_interfaces(struct pim_instance *pim, struct vty *vty,
 				json_row, "address",
 				inet_ntoa(pim_ifp->primary_address));
 			json_object_int_add(json_row, "ifIndex", ifp->ifindex);
+			json_object_int_add(json_row, "index", ifp->ifindex);
 			json_object_int_add(json_row, "vif",
 					    pim_ifp->mroute_vif_index);
 			json_object_int_add(json_row, "pktsIn",

--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE1/evpn.vni.json
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE1/evpn.vni.json
@@ -3,7 +3,7 @@
   "type":"L2",
   "vrf":"default",
   "vxlanInterface":"vxlan101",
-  "ifindex":5,
+  "index":5,
   "vtepIp":"10.10.10.10",
   "mcastGroup":"0.0.0.0",
   "advertiseGatewayMacip":"No",

--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE2/evpn.vni.json
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE2/evpn.vni.json
@@ -3,7 +3,7 @@
   "type":"L2",
   "vrf":"default",
   "vxlanInterface":"vxlan101",
-  "ifindex":5,
+  "index":5,
   "vtepIp":"10.30.30.30",
   "mcastGroup":"0.0.0.0",
   "advertiseGatewayMacip":"No",

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1164,6 +1164,10 @@ static void zl3vni_print_rmac(zebra_mac_t *zrmac, struct vty *vty,
 	}
 }
 
+#if CONFDATE > 20210601
+CPP_NOTICE("Please remove ifindex key from show evpn mac vni all detail json")
+#endif
+
 /*
  * Print a specific MAC entry.
  */
@@ -1200,6 +1204,7 @@ static void zvni_print_mac(zebra_mac_t *mac, void *ctxt, json_object *json)
 				return;
 			json_object_string_add(json_mac, "type", "local");
 			json_object_string_add(json_mac, "intf", ifp->name);
+			json_object_int_add(json_mac, "index", ifindex);
 			json_object_int_add(json_mac, "ifindex", ifindex);
 			if (mac->fwd_info.local.vid)
 				json_object_int_add(json_mac, "vlan",
@@ -1851,6 +1856,10 @@ static void zl3vni_print(zebra_l3vni_t *zl3vni, void **ctx)
 	}
 }
 
+#if CONFDATE > 20210601
+CPP_NOTICE("Please remove ifindex key from show evpn vni json")
+#endif
+
 /*
  * Print a specific VNI entry.
  */
@@ -1895,6 +1904,7 @@ static void zvni_print(zebra_vni_t *zvni, void **ctxt)
 	} else {
 		json_object_string_add(json, "vxlanInterface",
 				       zvni->vxlan_if->name);
+		json_object_int_add(json, "index", zvni->vxlan_if->ifindex);
 		json_object_int_add(json, "ifindex", zvni->vxlan_if->ifindex);
 		json_object_string_add(json, "vtepIp",
 				       inet_ntoa(zvni->local_vtep_ip));


### PR DESCRIPTION
Standardize the JSON key naming the interface index to be `index` where it had been a random choice of either `ifIndex` or `ifindex` before. This change will only affect the JSON outputs of the below vtysh directives:

- `show ip ospf [vrf <NAME|all>] interface [INTERFACE] json`
- `show ip multicast count [VRF|all] json`
- `show evpn mac vni all [detail] json`
- `show evpn vni [detail] json`

Please note that the `ifIndex` key is now marked for deprecation; please use the new `index` key to avoid any problems when the deprecated key is removed.

Signed-off-by: Wesley Coakley <wcoakley@cumulusnetworks.com>