### PR TITLE
bgpd: move advertise-vni-all above vni config

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -5657,6 +5657,9 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 	char buf1[RD_ADDRSTRLEN];
 	char buf2[INET6_ADDRSTRLEN];
 
+	if (bgp->advertise_all_vni)
+		vty_out(vty, "  advertise-all-vni\n");
+
 	if (bgp->vnihash) {
 		struct list *vnilist = hash_to_list(bgp->vnihash);
 		struct listnode *ln;
@@ -5668,9 +5671,6 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 
 		list_delete(&vnilist);
 	}
-
-	if (bgp->advertise_all_vni)
-		vty_out(vty, "  advertise-all-vni\n");
 
 	if (bgp->advertise_autort_rfc8365)
 		vty_out(vty, "  autort rfc8365-compatible\n");


### PR DESCRIPTION
Move config 'advertise-vni-all' above all evpn configuration as vni specific configurations commands
have check for advertise-vni-all enabled first.

When a configuration is replayed upon frr restart all vni specific config fails as `advertise-vni-all` is not enabled under bgp instance. 

```
 bgp_evpn_vni_rt_cmd()
        if (!EVPN_ENABLED(bgp)) {
                vty_out(vty,
                        "This command is only supported under EVPN VRF\n");
                return CMD_WARNING;
        }

```

Testing Done:

router bgp 5650
...
advertise-all-vni
vni 1002
 route-target import 55500:10002
 route-target export 55500:10002
exit-vni
...

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>