### PR TITLE
ldpd: remove unused 'pwstatus' field from message zapi_pw_status

### DIFF
--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -519,7 +519,6 @@ struct zapi_pw_status {
 	char ifname[IF_NAMESIZE];
 	ifindex_t ifindex;
 	uint32_t status;
-	uint32_t pwstatus;
 };
 
 enum zapi_route_notify_owner {


### PR DESCRIPTION
ldpd: remove unused 'pwstatus' field from message zapi_pw_status.

Signed-off-by: Karen Schoener <karen@voltanet.io>