### PR TITLE
zebra: Fix zebra crashed in building FPM netlink message when bgp sen…

### DIFF
--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -339,7 +339,7 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 	}
 
 	/* If there is no useful nexthop then return. */
-	if (ri->num_nhs == 0) {
+	if (ri->rtm_type != RTN_BLACKHOLE && ri->num_nhs == 0) {
 		zfpm_debug("netlink_encode_route(): No useful nexthop.");
 		return 0;
 	}


### PR DESCRIPTION
…ds aggregation routes to zebra.

Signed-off-by: Richard Wu <wutong23@baidu.com>


Issue:
When BGP sends aggregation routes to zebra, the next hop is black hole. Then Zebra will try to build the netlink FPM message, but there is no next hop as it is a black hole route. Then the  netlink_route_info_fill function returns 0. In the result, zebra will crashed in "assert(data_len)" of zfpm_build_route_updates.

This issue also happen when I create a static black hole route via staticd.


Fix: 
As the netlink message of the blackhole route is legal,  it should return success.


