### PR TITLE
pimd: Allow mlag to create ifchannel

### DIFF
--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -728,7 +728,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
 		}
 	}
 
-	if (PIM_I_am_DR(pim_oif)) {
+	if (PIM_I_am_DR(pim_oif) || PIM_I_am_DualActive(pim_oif)) {
 		result = pim_channel_add_oif(source->source_channel_oil,
 					     group->group_igmp_sock->interface,
 					     PIM_OIF_FLAG_PROTO_IGMP, __func__);


### PR DESCRIPTION
When the mlag code was ported upstream the structure
of the calls in igmp_source_forward_start had been
reset and as a result we missed the call to check
that creating an ifchannel when we are DualActive
is allowed.

Ticket: CM-29941
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>