### PR TITLE
tests: Allow a useful amount of time for bgp to converge

### DIFF
--- a/tests/topotests/bgp_as_wide_bgp_identifier/test_bgp_as_wide_bgp_identifier.py
+++ b/tests/topotests/bgp_as_wide_bgp_identifier/test_bgp_as_wide_bgp_identifier.py
@@ -102,12 +102,12 @@ def test_bgp_as_wide_bgp_identifier():
         return topotest.json_cmp(output, expected)
 
     test_func = functools.partial(_bgp_converge, tgen.gears["r1"])
-    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    success, result = topotest.run_and_expect(test_func, None, count=260, wait=0.5)
 
     assert result is None, 'Failed to converge: "{}"'.format(tgen.gears["r1"])
 
     test_func = functools.partial(_bgp_failed, tgen.gears["r3"])
-    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    success, result = topotest.run_and_expect(test_func, None, count=260, wait=0.5)
 
     assert result is None, 'Bad BGP Identifier notification not sent: "{}"'.format(
         tgen.gears["r3"]


### PR DESCRIPTION
The bgp_as_wide_bgp_identifier test can time out after
30 seconds waiting for convergence.  This is of course
a problem in our test setup where we know that convergence
can fail on first startup due to load issues in the
topology.  Additionally we also know that our default time
for bgp sessions is 120 seconds to retry.  Give things
a bit longer than 120 seconds to actually fail
instead of 30 seconds

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>