### PR TITLE
lib: Allow deletion of some access-lists

### DIFF
--- a/lib/filter.c
+++ b/lib/filter.c
@@ -868,7 +868,7 @@ DEFUN (no_access_list_standard,
        "Address to match\n"
        "Wildcard bits\n")
 {
-	int idx_acl = 1;
+	int idx_acl = 2;
 	int idx = 0;
 	char *seq = NULL;
 	char *permit_deny = NULL;
@@ -1949,7 +1949,7 @@ DEFUN (no_mac_access_list,
 		mac = argv[idx]->arg;
 	assert(mac);
 
-	return filter_set_zebra(vty, argv[2]->arg, seq, permit_deny, AFI_L2VPN,
+	return filter_set_zebra(vty, argv[3]->arg, seq, permit_deny, AFI_L2VPN,
 				mac, 0, 0);
 }
 


### PR DESCRIPTION
Recent rework of access lists to allow sequence numbers
accidently introduced the inability to delete some
access lists.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>