### PR TITLE
zebra: fix deletion of evpn mh neigh-holdtime

### DIFF
--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3444,7 +3444,7 @@ int zebra_evpn_mh_neigh_holdtime_update(struct vty *vty,
 		uint32_t duration, bool set_default)
 {
 	if (set_default)
-		zmh_info->neigh_hold_time = ZEBRA_EVPN_MH_NEIGH_HOLD_TIME_DEF;
+		duration = ZEBRA_EVPN_MH_NEIGH_HOLD_TIME_DEF;
 
 	zmh_info->neigh_hold_time = duration;
 


### PR DESCRIPTION
Found that the command "evpn mh neigh-holdtime" can be set but
not deleted.  This fix solves the delete process

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>