### PR TITLE
lib: move all userdata when changing node xpath

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -263,15 +263,21 @@ void if_update_to_new_vrf(struct interface *ifp, vrf_id_t vrf_id)
 	 */
 	if (yang_module_find("frr-interface")) {
 		struct lyd_node *if_dnode;
+		char oldpath[XPATH_MAXLEN];
+		char newpath[XPATH_MAXLEN];
 
 		if_dnode = yang_dnode_get(
 			running_config->dnode,
 			"/frr-interface:lib/interface[name='%s'][vrf='%s']/vrf",
 			ifp->name, old_vrf->name);
+
 		if (if_dnode) {
-			nb_running_unset_entry(if_dnode->parent);
+			yang_dnode_get_path(if_dnode->parent, oldpath,
+					    sizeof(oldpath));
 			yang_dnode_change_leaf(if_dnode, vrf->name);
-			nb_running_set_entry(if_dnode->parent, ifp);
+			yang_dnode_get_path(if_dnode->parent, newpath,
+					    sizeof(newpath));
+			nb_running_move_tree(oldpath, newpath);
 			running_config->version++;
 		}
 	}

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -993,6 +993,23 @@ extern int nb_notification_send(const char *xpath, struct list *arguments);
 extern void nb_running_set_entry(const struct lyd_node *dnode, void *entry);
 
 /*
+ * Move an entire tree of user pointer nodes.
+ *
+ * Suppose we have xpath A/B/C/D, with user pointers associated to C and D. We
+ * need to move B to be under Z, so the new xpath is Z/B/C/D. Because user
+ * pointers are indexed with their absolute path, We need to move all user
+ * pointers at and below B to their new absolute paths; this function does
+ * that.
+ *
+ * xpath_from
+ *    base xpath of tree to move (A/B)
+ *
+ * xpath_to
+ *    base xpath of new location of tree (Z/B)
+ */
+extern void nb_running_move_tree(const char *xpath_from, const char *xpath_to);
+
+/*
  * Unset the user pointer associated to a configuration node.
  *
  * This should be called by northbound 'destroy' callbacks in the NB_EV_APPLY


### PR DESCRIPTION
All userdata pointers need to be rekeyed to their new xpaths, not just
the one associated with the dnode being moved.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>