### PR TITLE
bgpd: Fix the bug that BGP MRAI does not work.

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -408,6 +408,9 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 	if (peer->bgp->main_peers_update_hold)
 		return 0;
 
+	if (peer->t_routeadv)
+		return 0;
+
 	do {
 		s = NULL;
 		FOREACH_AFI_SAFI (afi, safi) {


### PR DESCRIPTION
Issue: bgp_process_writes will be called when the fd is writable.
       And it will bgp_generate_updgrp_packets to generate the
       update packets no matter MRAI is set or not.
Fix:   bgp_process_writes only start bgp_generate_updgrp_packets thread
       when MRAI is not set.
       When MRAI is set, the MRAI thread will start
       bgp_generate_updgrp_packets thread in the MRAI timer.

Signed-off-by: Richard Wu <wutong23@baidu.com>