### PR TITLE
zebra: nhlfe_alloc should not fail

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -1258,8 +1258,7 @@ static zebra_nhlfe_t *nhlfe_alloc(zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
 	zebra_nhlfe_t *nhlfe;
 	struct nexthop *nexthop;
 
-	if (!lsp)
-		return NULL;
+	assert(lsp);
 
 	nhlfe = XCALLOC(MTYPE_NHLFE, sizeof(zebra_nhlfe_t));
 
@@ -1268,10 +1267,6 @@ static zebra_nhlfe_t *nhlfe_alloc(zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
 	nhlfe->distance = lsp_distance(lsp_type);
 
 	nexthop = nexthop_new();
-	if (!nexthop) {
-		XFREE(MTYPE_NHLFE, nhlfe);
-		return NULL;
-	}
 
 	nexthop_add_labels(nexthop, lsp_type, num_labels, labels);
 
@@ -1322,8 +1317,7 @@ static zebra_nhlfe_t *nhlfe_add(zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
 			    labels);
 
 	/* Enqueue to LSP, at head of list. */
-	if (nhlfe)
-		nhlfe_list_add_head(&lsp->nhlfe_list, nhlfe);
+	nhlfe_list_add_head(&lsp->nhlfe_list, nhlfe);
 
 	return nhlfe;
 }
@@ -1351,8 +1345,7 @@ static zebra_nhlfe_t *nhlfe_backup_add(zebra_lsp_t *lsp,
 	SET_FLAG(nhlfe->flags, NHLFE_FLAG_IS_BACKUP);
 
 	/* Enqueue to LSP, at tail of list. */
-	if (nhlfe)
-		nhlfe_list_add_tail(&lsp->backup_nhlfe_list, nhlfe);
+	nhlfe_list_add_tail(&lsp->backup_nhlfe_list, nhlfe);
 
 	return nhlfe;
 }


### PR DESCRIPTION
Let's prevent nhlfe_alloc from actually returning anything that can fail:

1) nexthop_new -> never returns NULL so checking for NULL here
makes no sense, remove it.

2) lsp not being NULL is a assert condition here as that it's
a precondition for the function to work properly.

3) since nhlfe_alloc cannot return NULL now remove tests
for it in callng functions

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>