### PR TITLE
bgpd: [7.2] Use IPv6 LL address as nexthop if global was set to ::/LL

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -563,7 +563,18 @@ static int make_prefix(int afi, struct bgp_path_info *pi, struct prefix *p)
 			p->u.prefix6 = pi->net->p.u.prefix6;
 			p->prefixlen = pi->net->p.prefixlen;
 		} else {
-			p->u.prefix6 = pi->attr->mp_nexthop_global;
+			/* If we receive MP_REACH nexthop with ::(LL)
+			 * or LL(LL), use LL address as nexthop cache.
+			 */
+			if (pi->attr->mp_nexthop_len
+				    == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL
+			    && (IN6_IS_ADDR_UNSPECIFIED(
+					&pi->attr->mp_nexthop_global)
+				|| IN6_IS_ADDR_LINKLOCAL(
+					&pi->attr->mp_nexthop_global)))
+				p->u.prefix6 = pi->attr->mp_nexthop_local;
+			else
+				p->u.prefix6 = pi->attr->mp_nexthop_global;
 			p->prefixlen = IPV6_MAX_BITLEN;
 		}
 		break;


### PR DESCRIPTION
Backport of 606fdbb1fab98bac305dca3d19eb38b140b7c3e6