### PR TITLE
topotests: stabilize ospf-sr-topo1

### DIFF
--- a/tests/topotests/ospf-sr-topo1/r1/ospf_srdb.json
+++ b/tests/topotests/ospf-sr-topo1/r1/ospf_srdb.json
@@ -113,32 +113,32 @@
       "extendedLink":[
         {
           "prefix":"10.0.0.1\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r1-eth0",
           "nexthop":"10.0.0.2"
         },
         {
           "prefix":"10.0.0.1\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r1-eth0",
           "nexthop":"10.0.0.2"
         },
         {
           "prefix":"10.0.1.1\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r1-eth1",
           "nexthop":"10.0.1.2"
         },
         {
           "prefix":"10.0.1.1\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r1-eth1",
           "nexthop":"10.0.1.2"

--- a/tests/topotests/ospf-sr-topo1/r1/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r1/zebra_mpls.json
@@ -71,8 +71,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-1":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -84,8 +84,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-2":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -97,8 +97,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-3":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -110,8 +110,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-4":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {

--- a/tests/topotests/ospf-sr-topo1/r2/ospf_srdb.json
+++ b/tests/topotests/ospf-sr-topo1/r2/ospf_srdb.json
@@ -27,64 +27,64 @@
       "extendedLink":[
         {
           "prefix":"10.0.4.2\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r2-eth3",
           "nexthop":"10.0.4.1"
         },
         {
           "prefix":"10.0.4.2\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r2-eth3",
           "nexthop":"10.0.4.1"
         },
         {
           "prefix":"10.0.0.2\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r2-eth0",
           "nexthop":"10.0.0.1"
         },
         {
           "prefix":"10.0.0.2\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r2-eth0",
           "nexthop":"10.0.0.1"
         },
         {
           "prefix":"10.0.1.2\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r2-eth1",
           "nexthop":"10.0.1.1"
         },
         {
           "prefix":"10.0.1.2\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r2-eth1",
           "nexthop":"10.0.1.1"
         },
         {
           "prefix":"10.0.3.2\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r2-eth2",
           "nexthop":"10.0.3.1"
         },
         {
           "prefix":"10.0.3.2\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r2-eth2",
           "nexthop":"10.0.3.1"

--- a/tests/topotests/ospf-sr-topo1/r2/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r2/zebra_mpls.json
@@ -45,8 +45,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-1":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -58,8 +58,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-2":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -71,8 +71,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-3":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -84,8 +84,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-4":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -97,8 +97,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-5":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -110,8 +110,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-6":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -123,8 +123,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-7":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -136,8 +136,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-8":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {

--- a/tests/topotests/ospf-sr-topo1/r3/ospf_srdb.json
+++ b/tests/topotests/ospf-sr-topo1/r3/ospf_srdb.json
@@ -77,16 +77,16 @@
       "extendedLink":[
         {
           "prefix":"10.0.3.1\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r3-eth0",
           "nexthop":"10.0.3.2"
         },
         {
           "prefix":"10.0.3.1\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r3-eth0",
           "nexthop":"10.0.3.2"

--- a/tests/topotests/ospf-sr-topo1/r3/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r3/zebra_mpls.json
@@ -38,8 +38,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-1":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -51,8 +51,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-2":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {

--- a/tests/topotests/ospf-sr-topo1/r4/ospf_srdb.json
+++ b/tests/topotests/ospf-sr-topo1/r4/ospf_srdb.json
@@ -49,16 +49,16 @@
       "extendedLink":[
         {
           "prefix":"10.0.4.1\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r4-eth0",
           "nexthop":"10.0.4.2"
         },
         {
           "prefix":"10.0.4.1\/32",
-          "sid":"XX",
-          "inputLabel":"XX",
+          "sid":"*",
+          "inputLabel":"*",
           "outputLabel":3,
           "interface":"r4-eth0",
           "nexthop":"10.0.4.2"

--- a/tests/topotests/ospf-sr-topo1/r4/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r4/zebra_mpls.json
@@ -50,8 +50,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-1":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {
@@ -63,8 +63,8 @@
       }
     ]
   },
-  "XX":{
-    "inLabel":"XX",
+  "label-2":{
+    "inLabel":"*",
     "installed":true,
     "nexthops":[
       {

--- a/tests/topotests/ospf-sr-topo1/test_ospf_sr_topo1.py
+++ b/tests/topotests/ospf-sr-topo1/test_ospf_sr_topo1.py
@@ -103,19 +103,6 @@ def setup_module(mod):
     # Initialize all routers.
     tgen.start_router()
 
-    # Verify that version, MPLS and Segment Routing are OK
-    for router in router_list.values():
-        # Check for Version
-        if router.has_version("<", "4"):
-            tgen.set_error("Unsupported FRR version")
-            break
-        # Check that Segment Routing is available
-        output = tgen.gears[router.name].vtysh_cmd(
-            "show ip ospf database segment-routing json"
-        )
-        if output.find("Unknown") != -1:
-            tgen.set_error("Segment Routing is not available")
-
 
 def teardown_module(mod):
     "Teardown the pytest environment"

--- a/tests/topotests/ospf-sr-topo1/test_ospf_sr_topo1.py
+++ b/tests/topotests/ospf-sr-topo1/test_ospf_sr_topo1.py
@@ -29,6 +29,7 @@ test_ospf_sr_topo1.py: Test the FRR OSPF routing daemon with Segment Routing.
 import os
 import re
 import sys
+import json
 from functools import partial
 
 # Save the Current Working Directory to find configuration files.
@@ -113,37 +114,6 @@ def teardown_module(mod):
     logger.info("\n\n---- OSPF Segment Routing tests End ----\n")
 
 
-# Shared test function to validate expected output.
-def compare_ospf_srdb(rname, expected):
-    """
-    Calls 'show ip ospf database segment-routing json' for router `rname`
-    and compare the obtained result with the expected output.
-    """
-    tgen = get_topogen()
-    current = tgen.gears[rname].vtysh_cmd("show ip ospf database segment-routing json")
-    # Filter Adjacency SID allocation
-    current = re.sub(r'"sid":5000[0-9],', '"sid":"XX",', current)
-    current = re.sub(r'"inputLabel":5000[0-9],', '"inputLabel":"XX",', current)
-    return topotest.difflines(
-        current, expected, title1="Current output", title2="Expected output"
-    )
-
-
-def compare_mpls_table(rname, expected):
-    """
-    Calls 'show mpls table json' for router `rname` and compare the obtained
-    result with the expected output.
-    """
-    tgen = get_topogen()
-    current = tgen.gears[rname].vtysh_cmd("show mpls table json")
-    # Filter Adjacency SID allocation
-    current = re.sub(r'"5000[0-9]":', '"XX":', current)
-    current = re.sub(r'"inLabel":5000[0-9],', '"inLabel":"XX",', current)
-    return topotest.difflines(
-        current, expected, title1="Current output", title2="Expected output"
-    )
-
-
 def test_ospf_sr():
     "Test OSPF daemon Segment Routing"
     tgen = get_topogen()
@@ -159,12 +129,15 @@ def test_ospf_sr():
 
         # Load expected results from the command
         reffile = os.path.join(CWD, "{}/ospf_srdb.json".format(router))
-        expected = open(reffile).read()
+        expected = json.loads(open(reffile).read())
 
         # Run test function until we get an result. Wait at most 60 seconds.
-        test_func = partial(compare_ospf_srdb, router, expected)
-        result, diff = topotest.run_and_expect(test_func, "", count=25, wait=3)
-        assert result, ("OSPF did not start Segment Routing on {}:\n{}").format(
+        rt = tgen.gears[router]
+        test_func = partial(
+            topotest.router_json_cmp, rt, 'show ip ospf database segment-routing json', expected
+        )
+        rv, diff = topotest.run_and_expect(test_func, None, count=25, wait=3)
+        assert rv, "OSPF did not start Segment Routing on {}:\n{}".format(
             router, diff
         )
 
@@ -177,6 +150,20 @@ def test_ospf_kernel_route():
 
     logger.info("--- test OSPF Segment Routing MPLS tables ---")
 
+    def show_mpls_table_json_cmp(rt, expected):
+        "Removes random label and use `label-X` instead."
+        text = rt.vtysh_cmd('show mpls table json')
+
+        # Substitue random labels with fixed label value.
+        for label in range(1, 10):
+            text = re.sub(r'"5000[0-9]"', '"label-{}"'.format(label), text,
+                          count=1)
+
+        print '\n{}\n'.format(text)
+
+        output = json.loads(text)
+        return topotest.json_cmp(output, expected)
+
     for rnum in range(1, 5):
         router = "r{}".format(rnum)
 
@@ -184,12 +171,13 @@ def test_ospf_kernel_route():
 
         # Load expected results from the command
         reffile = os.path.join(CWD, "{}/zebra_mpls.json".format(router))
-        expected = open(reffile).read()
+        expected = json.loads(open(reffile).read())
 
         # Run test function until we get an result. Wait at most 60 seconds.
-        test_func = partial(compare_mpls_table, router, expected)
-        result, diff = topotest.run_and_expect(test_func, "", count=25, wait=3)
-        assert result, ("OSPF did not properly instal MPLS table on {}:\n{}").format(
+        rt = tgen.gears[router]
+        test_func = partial(show_mpls_table_json_cmp, rt, expected)
+        rv, diff = topotest.run_and_expect(test_func, None, count=25, wait=3)
+        assert rv, "OSPF did not properly instal MPLS table on {}:\n{}".format(
             router, diff
         )
 


### PR DESCRIPTION
## Summary

@mjstapp found a problem in a test that may be solved using the new topotest wildcard feature. Here is a PR that attempts to improve the situation a little bit by turning text comparison into JSON comparison.