### PR TITLE
bgpd: Update GR flags when peer is bound to group

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2511,6 +2511,9 @@ static void peer_group2peer_config_copy(struct peer_group *group,
 		}
 	}
 
+	/* Update GR flags for the peer. */
+	bgp_peer_gr_flags_update(peer);
+
 	bgp_bfd_peer_group2peer_copy(conf, peer);
 }
 


### PR DESCRIPTION
When a peer is bound to a peer-group, the GR flags set on the peer is over-written.
Update the GR flags for the peer after it has been bound to a peer-group.

Signed-off-by: NaveenThanikachalam <nthanikachal@vmware.com>