### PR TITLE
lib: [7.4] Make sure route_map_dep_data is not NULL before decrementing ref…

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -2747,7 +2747,12 @@ static int route_map_dep_update(struct hash *dephash, const char *dep_name,
 		memset(&tmp_dep_data, 0, sizeof(struct route_map_dep_data));
 		tmp_dep_data.rname = rname;
 		dep_data = hash_lookup(dep->dep_rmap_hash, &tmp_dep_data);
-		dep_data->refcnt--;
+
+		if (!dep_data)
+			goto out;
+
+		if (dep_data->refcnt)
+			dep_data->refcnt--;
 
 		if (!dep_data->refcnt) {
 			ret_dep_data = hash_release(dep->dep_rmap_hash,


### PR DESCRIPTION
…count

```
2  0x00007fb9adb07a10 in core_handler (signo=11, siginfo=0x7ffe1414a630, context=<optimized out>) at lib/sigevent.c:228
        sa_default = {__sigaction_handler = {sa_handler = 0x0, sa_sigaction = 0x0}, sa_mask = {__val = {0 <repeats 16 times>}}, sa_flags = 0, sa_restorer = 0x0}
        sigset = {__val = {8192, 0 <repeats 15 times>}}
3  <signal handler called>
No locals.
4  route_map_dep_update (type=RMAP_EVENT_CLIST_DELETED, rmap_name=0x55d807ddd410 "export4-as49917", dep_name=<optimized out>, dephash=0x55d807adf170) at lib/routemap.c:2750
        dep = 0x55d807d35b00
        dname = 0x55d8081ba560 "123:124"
        rname = 0x55d8081ba540 "export4-as49917"
        ret = 0
        dep_data = 0x0
        ret_dep_data = 0x0
        tmp_dep_data = {rname = 0x55d8081ba540 "export4-as49917", refcnt = 0}
5  route_map_upd8_dependency (type=RMAP_EVENT_CLIST_DELETED, arg=<optimized out>, rmap_name=0x55d807ddd410 "export4-as49917") at lib/routemap.c:2865
        upd8_hash = 0x55d807adf170
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>