### PR TITLE
topotests: stabilize ospf-sr

### DIFF
--- a/tests/topotests/ospf-sr-topo1/r1/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r1/zebra_mpls.json
@@ -1,5 +1,5 @@
-{
-  "20100":{
+[
+  {
     "inLabel":20100,
     "installed":true,
     "nexthops":[
@@ -11,7 +11,7 @@
       }
     ]
   },
-  "20200":{
+  {
     "inLabel":20200,
     "installed":true,
     "nexthops":[
@@ -31,7 +31,7 @@
       }
     ]
   },
-  "20300":{
+  {
     "inLabel":20300,
     "installed":true,
     "nexthops":[
@@ -51,7 +51,7 @@
       }
     ]
   },
-  "20400":{
+  {
     "inLabel":20400,
     "installed":true,
     "nexthops":[
@@ -71,7 +71,7 @@
       }
     ]
   },
-  "label-1":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -84,7 +84,7 @@
       }
     ]
   },
-  "label-2":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -97,7 +97,7 @@
       }
     ]
   },
-  "label-3":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -110,7 +110,7 @@
       }
     ]
   },
-  "label-4":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -123,4 +123,4 @@
       }
     ]
   }
-}
+]

--- a/tests/topotests/ospf-sr-topo1/r2/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r2/zebra_mpls.json
@@ -1,5 +1,5 @@
-{
-  "8100":{
+[
+  {
     "inLabel":8100,
     "installed":true,
     "nexthops":[
@@ -19,7 +19,7 @@
       }
     ]
   },
-  "8300":{
+  {
     "inLabel":8300,
     "installed":true,
     "nexthops":[
@@ -32,7 +32,7 @@
       }
     ]
   },
-  "8400":{
+  {
     "inLabel":8400,
     "installed":true,
     "nexthops":[
@@ -45,7 +45,7 @@
       }
     ]
   },
-  "label-1":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -58,7 +58,7 @@
       }
     ]
   },
-  "label-2":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -71,7 +71,7 @@
       }
     ]
   },
-  "label-3":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -84,7 +84,7 @@
       }
     ]
   },
-  "label-4":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -97,7 +97,7 @@
       }
     ]
   },
-  "label-5":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -110,7 +110,7 @@
       }
     ]
   },
-  "label-6":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -123,7 +123,7 @@
       }
     ]
   },
-  "label-7":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -136,7 +136,7 @@
       }
     ]
   },
-  "label-8":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -149,4 +149,4 @@
       }
     ]
   }
-}
+]

--- a/tests/topotests/ospf-sr-topo1/r3/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r3/zebra_mpls.json
@@ -1,5 +1,5 @@
-{
-  "10100":{
+[
+  {
     "inLabel":10100,
     "installed":true,
     "nexthops":[
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "10200":{
+  {
     "inLabel":10200,
     "installed":true,
     "nexthops":[
@@ -25,7 +25,7 @@
       }
     ]
   },
-  "10400":{
+  {
     "inLabel":10400,
     "installed":true,
     "nexthops":[
@@ -38,7 +38,7 @@
       }
     ]
   },
-  "label-1":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -51,7 +51,7 @@
       }
     ]
   },
-  "label-2":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -64,4 +64,4 @@
       }
     ]
   }
-}
+]

--- a/tests/topotests/ospf-sr-topo1/r4/zebra_mpls.json
+++ b/tests/topotests/ospf-sr-topo1/r4/zebra_mpls.json
@@ -1,5 +1,5 @@
-{
-  "10100":{
+[
+  {
     "inLabel":10100,
     "installed":true,
     "nexthops":[
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "10200":{
+  {
     "inLabel":10200,
     "installed":true,
     "nexthops":[
@@ -25,7 +25,7 @@
       }
     ]
   },
-  "10300":{
+  {
     "inLabel":10300,
     "installed":true,
     "nexthops":[
@@ -38,7 +38,7 @@
       }
     ]
   },
-  "10400":{
+  {
     "inLabel":10400,
     "installed":true,
     "nexthops":[
@@ -50,7 +50,7 @@
       }
     ]
   },
-  "label-1":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -63,7 +63,7 @@
       }
     ]
   },
-  "label-2":{
+  {
     "inLabel":"*",
     "installed":true,
     "nexthops":[
@@ -76,4 +76,4 @@
       }
     ]
   }
-}
+]

--- a/tests/topotests/ospf-sr-topo1/test_ospf_sr_topo1.py
+++ b/tests/topotests/ospf-sr-topo1/test_ospf_sr_topo1.py
@@ -151,18 +151,31 @@ def test_ospf_kernel_route():
     logger.info("--- test OSPF Segment Routing MPLS tables ---")
 
     def show_mpls_table_json_cmp(rt, expected):
-        "Removes random label and use `label-X` instead."
-        text = rt.vtysh_cmd('show mpls table json')
+        """
+        Reformat MPLS table output to use a list of labels instead of dict.
 
-        # Substitue random labels with fixed label value.
-        for label in range(1, 10):
-            text = re.sub(r'"5000[0-9]"', '"label-{}"'.format(label), text,
-                          count=1)
+        Original:
+        {
+         "X": {
+            inLabel: "X",
+            # ...
+          }
+        }
 
-        print '\n{}\n'.format(text)
+        List format:
+        [
+          {
+            inLabel: "X",
+          }
+        ]
+        """
+        out = rt.vtysh_cmd('show mpls table json', isjson=True)
 
-        output = json.loads(text)
-        return topotest.json_cmp(output, expected)
+        outlist = []
+        for key in out.keys():
+            outlist.append(out[key])
+
+        return topotest.json_cmp(outlist, expected)
 
     for rnum in range(1, 5):
         router = "r{}".format(rnum)


### PR DESCRIPTION
**NOTE:** I'm fixing the test, however I think the command output has duplicated information: `inLabel` is the same information as the dictionary key.

It seems `show mpls table json` is not ordered or it can change, fix the test so it doesn't expect ordered outputs anymore.

```
        Original command output:
        {
         "X": {
            inLabel: "X",
            # ...
          }
        }

        Newly formatted command output:
        [
          {
            inLabel: "X",
          }
        ]
```

Should fix the following test failures:
- https://github.com/FRRouting/frr/pull/6544#issuecomment-641570339
- https://github.com/FRRouting/frr/pull/6528#issuecomment-641564956
- https://github.com/FRRouting/frr/pull/6542#issuecomment-641541817

Which looks like:

```
2020-06-09 19:04:01,537 ERROR: assert failed at "test_ospf_sr_topo1/test_ospf_kernel_route": OSPF did not properly instal MPLS table on r1:
  Generated JSON diff error report:
  
  
  > $->label-4->nexthops: d2 has the following element at index 0 which is not present in d1: 
  
  	{
  	    "distance": 150,
  	    "nexthop": "10.0.1.2",
  	    "type": "SR (OSPF)",
  	    "outLabel": 3,
  	    "installed": true
  	}
  
  	Closest match in d1 is at index 0 with the following errors: 
  
  	> $->label-4->nexthops[0]->nexthop: d1 has element with value '10.0.0.2' but in d2 it has value '10.0.1.2'
  
  > $->label-2->nexthops: d2 has the following element at index 0 which is not present in d1: 
  
  	{
  	    "distance": 150,
  	    "nexthop": "10.0.0.2",
  	    "type": "SR (OSPF)",
  	    "outLabel": 3,
  	    "installed": true
  	}
  
  	Closest match in d1 is at index 0 with the following errors: 
  
  	> $->label-2->nexthops[0]->nexthop: d1 has element with value '10.0.1.2' but in d2 it has value '10.0.0.2'
  
  > $->label-3->nexthops: d2 has the following element at index 0 which is not present in d1: 
  
  	{
  	    "distance": 150,
  	    "nexthop": "10.0.1.2",
  	    "type": "SR (OSPF)",
  	    "outLabel": 3,
  	    "installed": true
  	}
  
  	Closest match in d1 is at index 0 with the following errors: 
  
  	> $->label-3->nexthops[0]->nexthop: d1 has element with value '10.0.0.2' but in d2 it has value '10.0.1.2'
  
  > $->label-1->nexthops: d2 has the following element at index 0 which is not present in d1: 
  
  	{
  	    "distance": 150,
  	    "nexthop": "10.0.0.2",
  	    "type": "SR (OSPF)",
  	    "outLabel": 3,
  	    "installed": true
  	}
  
  	Closest match in d1 is at index 0 with the following errors: 
  
  	> $->label-1->nexthops[0]->nexthop: d1 has element with value '10.0.1.2' but in d2 it has value '10.0.0.2'
```