### PR TITLE
docker: don't fail on chown /etc/frr

### DIFF
--- a/docker/alpine/docker-start
+++ b/docker/alpine/docker-start
@@ -5,7 +5,7 @@ set -e
 ##
 # For volume mounts...
 ##
-chown -R frr:frr /etc/frr
+chown -R frr:frr /etc/frr || true
 /usr/lib/frr/frrinit.sh start
 
 # Sleep forever


### PR DESCRIPTION
If we can chown /etc/frr then fine, but there's circumstances where we
won't be able to - for instance, if running FRR in Kubernetes where
/etc/frr/* is actually a virtual filesystem.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>