### PR TITLE
sharpd: add zclient session create and delete

### DIFF
--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -125,3 +125,15 @@ keyword. At present, no sharp commands will be preserved in the config.
    single subtype. The messages must specify a protocol daemon by
    name, and can include optional zapi ``instance`` and ``session``
    values.
+
+.. index:: sharp create session
+.. clicmd:: sharp create session (1-1024)
+
+   Create an additional zapi client session for testing, using the
+   specified session id.
+
+.. index:: sharp remove session
+.. clicmd:: sharp remove session (1-1024)
+
+   Remove a test zapi client session that was created with the
+   specified session id.

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -164,7 +164,7 @@ void zclient_stop(struct zclient *zclient)
 	int i;
 
 	if (zclient_debug)
-		zlog_debug("zclient stopped");
+		zlog_debug("zclient %p stopped", zclient);
 
 	/* Stop threads. */
 	THREAD_OFF(zclient->t_read);

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -547,6 +547,34 @@ DEFPY (logpump,
 	return CMD_SUCCESS;
 }
 
+DEFPY (create_session,
+       create_session_cmd,
+       "sharp create session (1-1024)",
+       "Sharp Routing Protocol\n"
+       "Create data\n"
+       "Create a test session\n"
+       "Session ID\n")
+{
+	if (sharp_zclient_create(session) != 0) {
+		vty_out(vty, "%% Client session error\n");
+		return CMD_WARNING;
+	}
+
+	return CMD_SUCCESS;
+}
+
+DEFPY (remove_session,
+       remove_session_cmd,
+       "sharp remove session (1-1024)",
+       "Sharp Routing Protocol\n"
+       "Remove data\n"
+       "Remove a test session\n"
+       "Session ID\n")
+{
+	sharp_zclient_delete(session);
+	return CMD_SUCCESS;
+}
+
 DEFPY (send_opaque,
        send_opaque_cmd,
        "sharp send opaque type (1-255) (1-1000)$count",
@@ -626,6 +654,8 @@ void sharp_vty_init(void)
 	install_element(ENABLE_NODE, &sharp_lsp_prefix_v4_cmd);
 	install_element(ENABLE_NODE, &sharp_remove_lsp_prefix_v4_cmd);
 	install_element(ENABLE_NODE, &logpump_cmd);
+	install_element(ENABLE_NODE, &create_session_cmd);
+	install_element(ENABLE_NODE, &remove_session_cmd);
 	install_element(ENABLE_NODE, &send_opaque_cmd);
 	install_element(ENABLE_NODE, &send_opaque_unicast_cmd);
 	install_element(ENABLE_NODE, &send_opaque_reg_cmd);

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -24,6 +24,10 @@
 
 extern void sharp_zebra_init(void);
 
+/* Add and delete extra zapi client sessions, for testing */
+int sharp_zclient_create(uint32_t session_id);
+int sharp_zclient_delete(uint32_t session_id);
+
 extern void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label);
 extern void route_add(const struct prefix *p, vrf_id_t, uint8_t instance,
 		      const struct nexthop_group *nhg,


### PR DESCRIPTION
Add a couple of clis and some simple support that allows sharpd to create extra zapi client sessions. Extra sessions helps support use of sharpd with, for example, the opaque messaging feature.
