### PR TITLE
zebra: fix SA warning in zebra_rnh.c

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1069,8 +1069,8 @@ static int send_client(struct rnh *rnh, struct zserv *client,
 	return zserv_send_message(client, s);
 
 failure:
-	if (s)
-		stream_free(s);
+
+	stream_free(s);
 	return -1;
 }
 


### PR DESCRIPTION
Fix an SA warning... that I introduced while resolving a different SA warning. Not my day today...