### PR TITLE
bgpd: remove extcommunity attribute on leaked route if empty

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1095,6 +1095,14 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 		new_ecom = ecommunity_dup(old_ecom);
 		ecommunity_strip_rts(new_ecom);
 		static_attr.ecommunity = new_ecom;
+
+		if (new_ecom->size == 0) {
+			UNSET_FLAG(static_attr.flag,
+				   ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES));
+			ecommunity_free(&new_ecom);
+			static_attr.ecommunity = NULL;
+		}
+
 		if (!old_ecom->refcnt)
 			ecommunity_free(&old_ecom);
 	}


### PR DESCRIPTION
Problem reported where bgp sessions were being torn down for ibgp
peers with the reason being optional attribute error.  Found that
when a route was leaked, the RTs were stripped but the actual
EXTCOMMUNUNITY attribute was not cleared so an empty ecommunity
attribute stayed in the bgp table and was sent in updates.

Ticket: CM-30000
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>