### PR TITLE
tests: After clear give it more than 90 seconds to come up

### DIFF
--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -1394,7 +1394,7 @@ def clear_bgp_and_verify(tgen, topo, router):
 
     peer_uptime_before_clear_bgp = {}
     # Verifying BGP convergence before bgp clear command
-    for retry in range(31):
+    for retry in range(44):
         sleeptime = 3
         # Waiting for BGP to converge
         logger.info(
@@ -1477,7 +1477,7 @@ def clear_bgp_and_verify(tgen, topo, router):
 
     peer_uptime_after_clear_bgp = {}
     # Verifying BGP convergence after bgp clear command
-    for retry in range(31):
+    for retry in range(44):
         sleeptime = 3
         # Waiting for BGP to converge
         logger.info(


### PR DESCRIPTION
Error Message seen:
2020-06-11 14:00:35,288 ERROR: assert failed at "test_ebgp_ecmp_topo2/test_ecmp_after_clear_bgp[redist_static]": Testcase test_ecmp_after_clear_bgp[redist_static] : Failed
   Error: TIMEOUT!! BGP is not converged in 30 seconds for router r3
assert 'TIMEOUT!! BGP is not converged in 30 seconds for router r3' is True

if a retry for a failed connection is 120 seconds we should wait slightly
longer than a retry session, which this clear test was not doing.
Especially since we know our topotests are lossy on data under load.

Apparently I changed this earlier to 90 seconds, but a retry window
is 120.  Not sure wtf I was thinking

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>