### PR TITLE
Clean up the zebra's Netlink API

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -709,12 +709,13 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	switch (op) {
 	case DPLANE_OP_ROUTE_UPDATE:
 	case DPLANE_OP_ROUTE_DELETE:
-		rv = netlink_route_multipath(RTM_DELROUTE, ctx, nl_buf,
-					     sizeof(nl_buf), true,
-					     fnc->use_nhg);
+		rv = netlink_route_multipath_msg_encode(RTM_DELROUTE, ctx,
+							nl_buf, sizeof(nl_buf),
+							true, fnc->use_nhg);
 		if (rv <= 0) {
-			zlog_err("%s: netlink_route_multipath failed",
-				 __func__);
+			zlog_err(
+				"%s: netlink_route_multipath_msg_encode failed",
+				__func__);
 			return 0;
 		}
 
@@ -726,12 +727,13 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 
 		/* FALL THROUGH */
 	case DPLANE_OP_ROUTE_INSTALL:
-		rv = netlink_route_multipath(
+		rv = netlink_route_multipath_msg_encode(
 			RTM_NEWROUTE, ctx, &nl_buf[nl_buf_len],
 			sizeof(nl_buf) - nl_buf_len, true, fnc->use_nhg);
 		if (rv <= 0) {
-			zlog_err("%s: netlink_route_multipath failed",
-				 __func__);
+			zlog_err(
+				"%s: netlink_route_multipath_msg_encode failed",
+				__func__);
 			return 0;
 		}
 
@@ -751,10 +753,11 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 		break;
 
 	case DPLANE_OP_NH_DELETE:
-		rv = netlink_nexthop_encode(RTM_DELNEXTHOP, ctx, nl_buf,
-					    sizeof(nl_buf));
+		rv = netlink_nexthop_msg_encode(RTM_DELNEXTHOP, ctx, nl_buf,
+						sizeof(nl_buf));
 		if (rv <= 0) {
-			zlog_err("%s: netlink_nexthop_encode failed", __func__);
+			zlog_err("%s: netlink_nexthop_msg_encode failed",
+				 __func__);
 			return 0;
 		}
 
@@ -762,10 +765,11 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 		break;
 	case DPLANE_OP_NH_INSTALL:
 	case DPLANE_OP_NH_UPDATE:
-		rv = netlink_nexthop_encode(RTM_NEWNEXTHOP, ctx, nl_buf,
-					    sizeof(nl_buf));
+		rv = netlink_nexthop_msg_encode(RTM_NEWNEXTHOP, ctx, nl_buf,
+						sizeof(nl_buf));
 		if (rv <= 0) {
-			zlog_err("%s: netlink_nexthop_encode failed", __func__);
+			zlog_err("%s: netlink_nexthop_msg_encode failed",
+				 __func__);
 			return 0;
 		}
 

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -798,7 +798,7 @@ static int netlink_request_intf_addr(struct nlsock *netlink_cmd, int family,
 
 	/* Include filter, if specified. */
 	if (filter_mask)
-		addattr32(&req.n, sizeof(req), IFLA_EXT_MASK, filter_mask);
+		nl_attr_put32(&req.n, sizeof(req), IFLA_EXT_MASK, filter_mask);
 
 	return netlink_request(netlink_cmd, &req);
 }
@@ -903,8 +903,8 @@ int kernel_interface_set_master(struct interface *master,
 
 	req.ifa.ifi_index = slave->ifindex;
 
-	addattr_l(&req.n, sizeof(req), IFLA_MASTER, &master->ifindex, 4);
-	addattr_l(&req.n, sizeof(req), IFLA_LINK, &slave->ifindex, 4);
+	nl_attr_put(&req.n, sizeof(req), IFLA_MASTER, &master->ifindex, 4);
+	nl_attr_put(&req.n, sizeof(req), IFLA_LINK, &slave->ifindex, 4);
 
 	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns,
 			    0);
@@ -942,20 +942,20 @@ static int netlink_address_ctx(const struct zebra_dplane_ctx *ctx)
 
 	req.ifa.ifa_index = dplane_ctx_get_ifindex(ctx);
 
-	addattr_l(&req.n, sizeof(req), IFA_LOCAL, &p->u.prefix, bytelen);
+	nl_attr_put(&req.n, sizeof(req), IFA_LOCAL, &p->u.prefix, bytelen);
 
 	if (p->family == AF_INET) {
 		if (dplane_ctx_intf_is_connected(ctx)) {
 			p = dplane_ctx_get_intf_dest(ctx);
-			addattr_l(&req.n, sizeof(req), IFA_ADDRESS,
-				  &p->u.prefix, bytelen);
+			nl_attr_put(&req.n, sizeof(req), IFA_ADDRESS,
+				    &p->u.prefix, bytelen);
 		} else if (cmd == RTM_NEWADDR) {
 			struct in_addr broad = {
 				.s_addr = ipv4_broadcast_addr(p->u.prefix4.s_addr,
 							p->prefixlen)
 			};
-			addattr_l(&req.n, sizeof(req), IFA_BROADCAST,
-				  &broad, bytelen);
+			nl_attr_put(&req.n, sizeof(req), IFA_BROADCAST, &broad,
+				    bytelen);
 		}
 	}
 
@@ -967,8 +967,8 @@ static int netlink_address_ctx(const struct zebra_dplane_ctx *ctx)
 
 	if (dplane_ctx_intf_has_label(ctx)) {
 		label = dplane_ctx_get_intf_label(ctx);
-		addattr_l(&req.n, sizeof(req), IFA_LABEL, label,
-			  strlen(label) + 1);
+		nl_attr_put(&req.n, sizeof(req), IFA_LABEL, label,
+			    strlen(label) + 1);
 	}
 
 	return netlink_talk_info(netlink_talk_filter, &req.n,
@@ -1520,8 +1520,8 @@ int netlink_protodown(struct interface *ifp, bool down)
 
 	req.ifa.ifi_index = ifp->ifindex;
 
-	addattr_l(&req.n, sizeof(req), IFLA_PROTO_DOWN, &down, sizeof(down));
-	addattr_l(&req.n, sizeof(req), IFLA_LINK, &ifp->ifindex, 4);
+	nl_attr_put(&req.n, sizeof(req), IFLA_PROTO_DOWN, &down, sizeof(down));
+	nl_attr_put(&req.n, sizeof(req), IFLA_LINK, &ifp->ifindex, 4);
 
 	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns,
 			    0);

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -903,8 +903,8 @@ int kernel_interface_set_master(struct interface *master,
 
 	req.ifa.ifi_index = slave->ifindex;
 
-	nl_attr_put(&req.n, sizeof(req), IFLA_MASTER, &master->ifindex, 4);
-	nl_attr_put(&req.n, sizeof(req), IFLA_LINK, &slave->ifindex, 4);
+	nl_attr_put32(&req.n, sizeof(req), IFLA_MASTER, master->ifindex);
+	nl_attr_put32(&req.n, sizeof(req), IFLA_LINK, slave->ifindex);
 
 	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns,
 			    0);
@@ -1521,7 +1521,7 @@ int netlink_protodown(struct interface *ifp, bool down)
 	req.ifa.ifi_index = ifp->ifindex;
 
 	nl_attr_put(&req.n, sizeof(req), IFLA_PROTO_DOWN, &down, sizeof(down));
-	nl_attr_put(&req.n, sizeof(req), IFLA_LINK, &ifp->ifindex, 4);
+	nl_attr_put32(&req.n, sizeof(req), IFLA_LINK, ifp->ifindex);
 
 	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns,
 			    0);

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -527,8 +527,8 @@ void netlink_parse_rtattr_nested(struct rtattr **tb, int max,
 	netlink_parse_rtattr(tb, max, RTA_DATA(rta), RTA_PAYLOAD(rta));
 }
 
-int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type,
-	      const void *data, unsigned int alen)
+bool nl_attr_put(struct nlmsghdr *n, unsigned int maxlen, int type,
+		 const void *data, unsigned int alen)
 {
 	int len;
 	struct rtattr *rta;
@@ -536,7 +536,7 @@ int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type,
 	len = RTA_LENGTH(alen);
 
 	if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxlen)
-		return -1;
+		return false;
 
 	rta = (struct rtattr *)(((char *)n) + NLMSG_ALIGN(n->nlmsg_len));
 	rta->rta_type = type;
@@ -549,72 +549,56 @@ int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type,
 
 	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len);
 
-	return 0;
+	return true;
 }
 
-int rta_addattr_l(struct rtattr *rta, unsigned int maxlen, int type,
-		  const void *data, unsigned int alen)
+bool nl_attr_put16(struct nlmsghdr *n, unsigned int maxlen, int type,
+		   uint16_t data)
 {
-	unsigned int len;
-	struct rtattr *subrta;
-
-	len = RTA_LENGTH(alen);
-
-	if (RTA_ALIGN(rta->rta_len) + RTA_ALIGN(len) > maxlen)
-		return -1;
-
-	subrta = (struct rtattr *)(((char *)rta) + RTA_ALIGN(rta->rta_len));
-	subrta->rta_type = type;
-	subrta->rta_len = len;
-
-	if (data)
-		memcpy(RTA_DATA(subrta), data, alen);
-	else
-		assert(alen == 0);
-
-	rta->rta_len = NLMSG_ALIGN(rta->rta_len) + RTA_ALIGN(len);
-
-	return 0;
+	return nl_attr_put(n, maxlen, type, &data, sizeof(uint16_t));
 }
 
-int addattr16(struct nlmsghdr *n, unsigned int maxlen, int type, uint16_t data)
+bool nl_attr_put32(struct nlmsghdr *n, unsigned int maxlen, int type,
+		   uint32_t data)
 {
-	return addattr_l(n, maxlen, type, &data, sizeof(uint16_t));
+	return nl_attr_put(n, maxlen, type, &data, sizeof(uint32_t));
 }
 
-int addattr32(struct nlmsghdr *n, unsigned int maxlen, int type, int data)
-{
-	return addattr_l(n, maxlen, type, &data, sizeof(uint32_t));
-}
-
-struct rtattr *addattr_nest(struct nlmsghdr *n, int maxlen, int type)
+struct rtattr *nl_attr_nest(struct nlmsghdr *n, unsigned int maxlen, int type)
 {
 	struct rtattr *nest = NLMSG_TAIL(n);
 
-	addattr_l(n, maxlen, type, NULL, 0);
+	if (!nl_attr_put(n, maxlen, type, NULL, 0))
+		return NULL;
+
 	nest->rta_type |= NLA_F_NESTED;
 	return nest;
 }
 
-int addattr_nest_end(struct nlmsghdr *n, struct rtattr *nest)
+int nl_attr_nest_end(struct nlmsghdr *n, struct rtattr *nest)
 {
 	nest->rta_len = (uint8_t *)NLMSG_TAIL(n) - (uint8_t *)nest;
 	return n->nlmsg_len;
 }
 
-struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type)
+struct rtnexthop *nl_attr_rtnh(struct nlmsghdr *n, unsigned int maxlen)
 {
-	struct rtattr *nest = RTA_TAIL(rta);
+	struct rtnexthop *rtnh = (struct rtnexthop *)NLMSG_TAIL(n);
 
-	rta_addattr_l(rta, maxlen, type, NULL, 0);
-	nest->rta_type |= NLA_F_NESTED;
-	return nest;
+	if (NLMSG_ALIGN(n->nlmsg_len) + RTNH_ALIGN(sizeof(struct rtnexthop))
+	    > maxlen)
+		return NULL;
+
+	memset(rtnh, 0, sizeof(struct rtnexthop));
+	n->nlmsg_len =
+		NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(sizeof(struct rtnexthop));
+
+	return rtnh;
 }
 
-int rta_nest_end(struct rtattr *rta, struct rtattr *nest)
+void nl_attr_rtnh_end(struct nlmsghdr *n, struct rtnexthop *rtnh)
 {
-	nest->rta_len = (uint8_t *)RTA_TAIL(rta) - (uint8_t *)nest;
-	return rta->rta_len;
+	rtnh->rtnh_len = (uint8_t *)NLMSG_TAIL(n) - (uint8_t *)rtnh;
 }
 
 const char *nl_msg_type_to_str(uint16_t msg_type)

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -30,22 +30,57 @@ extern "C" {
 #define NL_RCV_PKT_BUF_SIZE     32768
 #define NL_PKT_BUF_SIZE         8192
 
+/*
+ * nl_attr_put - add an attribute to the Netlink message.
+ *
+ * Returns true if the attribute could be added to the message (fits into the
+ * buffer), otherwise false is returned.
+ */
+extern bool nl_attr_put(struct nlmsghdr *n, unsigned int maxlen, int type,
+			const void *data, unsigned int alen);
+extern bool nl_attr_put16(struct nlmsghdr *n, unsigned int maxlen, int type,
+			  uint16_t data);
+extern bool nl_attr_put32(struct nlmsghdr *n, unsigned int maxlen, int type,
+			  uint32_t data);
+
+/*
+ * nl_attr_nest - start an attribute nest.
+ *
+ * Returns a valid pointer to the beginning of the nest if the attribute
+ * describing the nest could be added to the message (fits into the buffer),
+ * otherwise NULL is returned.
+ */
+extern struct rtattr *nl_attr_nest(struct nlmsghdr *n, unsigned int maxlen,
+				   int type);
+
+/*
+ * nl_attr_nest_end - finalize nesting of attributes.
+ *
+ * Updates the length field of the attribute header to include the appeneded
+ * attributes. Returns a total length of the Netlink message.
+ */
+extern int nl_attr_nest_end(struct nlmsghdr *n, struct rtattr *nest);
+
+/*
+ * nl_attr_rtnh - append a rtnexthop record to the Netlink message.
+ *
+ * Returns a valid pointer to the rtnexthop struct if it could be added to
+ * the message (fits into the buffer), otherwise NULL is returned.
+ */
+extern struct rtnexthop *nl_attr_rtnh(struct nlmsghdr *n, unsigned int maxlen);
+
+/*
+ * nl_attr_rtnh_end - finalize adding a rtnexthop record.
+ *
+ * Updates the length field of the rtnexthop to include the appeneded
+ * attributes.
+ */
+extern void nl_attr_rtnh_end(struct nlmsghdr *n, struct rtnexthop *rtnh);
+
 extern void netlink_parse_rtattr(struct rtattr **tb, int max,
 				 struct rtattr *rta, int len);
 extern void netlink_parse_rtattr_nested(struct rtattr **tb, int max,
 					struct rtattr *rta);
-extern int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type,
-		     const void *data, unsigned int alen);
-extern int rta_addattr_l(struct rtattr *rta, unsigned int maxlen, int type,
-			 const void *data, unsigned int alen);
-extern int addattr16(struct nlmsghdr *n, unsigned int maxlen, int type,
-		     uint16_t data);
-extern int addattr32(struct nlmsghdr *n, unsigned int maxlen, int type,
-		     int data);
-extern struct rtattr *addattr_nest(struct nlmsghdr *n, int maxlen, int type);
-extern int addattr_nest_end(struct nlmsghdr *n, struct rtattr *nest);
-extern struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type);
-extern int rta_nest_end(struct rtattr *rta, struct rtattr *nest);
 extern const char *nl_msg_type_to_str(uint16_t msg_type);
 extern const char *nl_rtproto_to_str(uint8_t rtproto);
 extern const char *nl_family_to_str(uint8_t family);

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -64,11 +64,14 @@ extern "C" {
 void rt_netlink_init(void);
 
 /* MPLS label forwarding table change, using dataplane context information. */
-extern int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx);
+extern ssize_t netlink_mpls_multipath_msg_encode(int cmd,
+						 struct zebra_dplane_ctx *ctx,
+						 void *buf, size_t buflen);
 
-extern ssize_t netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx,
-				       uint8_t *data, size_t datalen, bool fpm,
-				       bool force_nhg);
+extern ssize_t netlink_route_multipath_msg_encode(int cmd,
+						  struct zebra_dplane_ctx *ctx,
+						  uint8_t *data, size_t datalen,
+						  bool fpm, bool force_nhg);
 extern ssize_t netlink_macfdb_update_ctx(struct zebra_dplane_ctx *ctx,
 					 uint8_t *data, size_t datalen);
 
@@ -78,9 +81,9 @@ extern int netlink_route_read(struct zebra_ns *zns);
 extern int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id,
 				  int startup);
 extern int netlink_nexthop_read(struct zebra_ns *zns);
-extern ssize_t netlink_nexthop_encode(uint16_t cmd,
-				      const struct zebra_dplane_ctx *ctx,
-				      void *buf, size_t buflen);
+extern ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
+					  const struct zebra_dplane_ctx *ctx,
+					  void *buf, size_t buflen);
 
 extern int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id);
 extern int netlink_macfdb_read(struct zebra_ns *zns);

--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -87,38 +87,48 @@ static ssize_t netlink_rule_msg_encode(
 	req->frh.family = family;
 	req->frh.action = FR_ACT_TO_TBL;
 
-	nl_attr_put(&req->n, buflen, FRA_PROTOCOL, &protocol, sizeof(protocol));
+	if (!nl_attr_put(&req->n, buflen, FRA_PROTOCOL, &protocol,
+			 sizeof(protocol)))
+		return 0;
 
 	/* rule's pref # */
-	nl_attr_put32(&req->n, buflen, FRA_PRIORITY, priority);
+	if (!nl_attr_put32(&req->n, buflen, FRA_PRIORITY, priority))
+		return 0;
 
 	/* interface on which applied */
-	nl_attr_put(&req->n, buflen, FRA_IFNAME, ifname, strlen(ifname) + 1);
+	if (!nl_attr_put(&req->n, buflen, FRA_IFNAME, ifname,
+			 strlen(ifname) + 1))
+		return 0;
 
 	/* source IP, if specified */
 	if (filter_bm & PBR_FILTER_SRC_IP) {
 		req->frh.src_len = src_ip->prefixlen;
-		nl_attr_put(&req->n, buflen, FRA_SRC, &src_ip->u.prefix,
-			    bytelen);
+		if (!nl_attr_put(&req->n, buflen, FRA_SRC, &src_ip->u.prefix,
+				 bytelen))
+			return 0;
 	}
 
 	/* destination IP, if specified */
 	if (filter_bm & PBR_FILTER_DST_IP) {
 		req->frh.dst_len = dst_ip->prefixlen;
-		nl_attr_put(&req->n, buflen, FRA_DST, &dst_ip->u.prefix,
-			    bytelen);
+		if (!nl_attr_put(&req->n, buflen, FRA_DST, &dst_ip->u.prefix,
+				 bytelen))
+			return 0;
 	}
 
 	/* fwmark, if specified */
-	if (filter_bm & PBR_FILTER_FWMARK)
-		nl_attr_put32(&req->n, buflen, FRA_FWMARK, fwmark);
+	if (filter_bm & PBR_FILTER_FWMARK) {
+		if (!nl_attr_put32(&req->n, buflen, FRA_FWMARK, fwmark))
+			return 0;
+	}
 
 	/* Route table to use to forward, if filter criteria matches. */
 	if (table < 256)
 		req->frh.table = table;
 	else {
 		req->frh.table = RT_TABLE_UNSPEC;
-		nl_attr_put32(&req->n, buflen, FRA_TABLE, table);
+		if (!nl_attr_put32(&req->n, buflen, FRA_TABLE, table))
+			return 0;
 	}
 
 	if (IS_ZEBRA_DEBUG_KERNEL)

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -361,9 +361,9 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 	size_t buf_offset;
 	struct netlink_nh_info *nhi;
 	enum fpm_nh_encap_type_t encap;
-	struct rtattr *nest;
+	struct rtattr *nest, *inner_nest;
+	struct rtnexthop *rtnh;
 	struct vxlan_encap_info_t *vxlan;
-	int nest_len;
 
 	struct {
 		struct nlmsghdr n;
@@ -400,20 +400,21 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 		req->r.rtm_table = ri->rtm_table;
 	else {
 		req->r.rtm_table = RT_TABLE_UNSPEC;
-		addattr32(&req->n, in_buf_len, RTA_TABLE, ri->rtm_table);
+		nl_attr_put32(&req->n, in_buf_len, RTA_TABLE, ri->rtm_table);
 	}
 
 	req->r.rtm_dst_len = ri->prefix->prefixlen;
 	req->r.rtm_protocol = ri->rtm_protocol;
 	req->r.rtm_scope = RT_SCOPE_UNIVERSE;
 
-	addattr_l(&req->n, in_buf_len, RTA_DST, &ri->prefix->u.prefix, bytelen);
+	nl_attr_put(&req->n, in_buf_len, RTA_DST, &ri->prefix->u.prefix,
+		    bytelen);
 
 	req->r.rtm_type = ri->rtm_type;
 
 	/* Metric. */
 	if (ri->metric)
-		addattr32(&req->n, in_buf_len, RTA_PRIORITY, *ri->metric);
+		nl_attr_put32(&req->n, in_buf_len, RTA_PRIORITY, *ri->metric);
 
 	if (ri->num_nhs == 0)
 		goto done;
@@ -422,12 +423,13 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 		nhi = &ri->nhs[0];
 
 		if (nhi->gateway) {
-			addattr_l(&req->n, in_buf_len, RTA_GATEWAY,
-				  nhi->gateway, bytelen);
+			nl_attr_put(&req->n, in_buf_len, RTA_GATEWAY,
+				    nhi->gateway, bytelen);
 		}
 
 		if (nhi->if_index) {
-			addattr32(&req->n, in_buf_len, RTA_OIF, nhi->if_index);
+			nl_attr_put32(&req->n, in_buf_len, RTA_OIF,
+				      nhi->if_index);
 		}
 
 		encap = nhi->encap_info.encap_type;
@@ -436,12 +438,13 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 		case FPM_NH_ENCAP_MAX:
 			break;
 		case FPM_NH_ENCAP_VXLAN:
-			addattr_l(&req->n, in_buf_len, RTA_ENCAP_TYPE, &encap,
-				  sizeof(uint16_t));
+			nl_attr_put16(&req->n, in_buf_len, RTA_ENCAP_TYPE,
+				      encap);
 			vxlan = &nhi->encap_info.vxlan_encap;
-			nest = addattr_nest(&req->n, in_buf_len, RTA_ENCAP);
-			addattr32(&req->n, in_buf_len, VXLAN_VNI, vxlan->vni);
-			addattr_nest_end(&req->n, nest);
+			nest = nl_attr_nest(&req->n, in_buf_len, RTA_ENCAP);
+			nl_attr_put32(&req->n, in_buf_len, VXLAN_VNI,
+				      vxlan->vni);
+			nl_attr_nest_end(&req->n, nest);
 			break;
 		}
 
@@ -451,28 +454,15 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 	/*
 	 * Multipath case.
 	 */
-	char buf[NL_PKT_BUF_SIZE];
-	struct rtattr *rta = (void *)buf;
-	struct rtnexthop *rtnh;
-
-	rta->rta_type = RTA_MULTIPATH;
-	rta->rta_len = RTA_LENGTH(0);
-	rtnh = RTA_DATA(rta);
+	nest = nl_attr_nest(&req->n, in_buf_len, RTA_MULTIPATH);
 
 	for (nexthop_num = 0; nexthop_num < ri->num_nhs; nexthop_num++) {
+		rtnh = nl_attr_rtnh(&req->n, in_buf_len);
 		nhi = &ri->nhs[nexthop_num];
 
-		rtnh->rtnh_len = sizeof(*rtnh);
-		rtnh->rtnh_flags = 0;
-		rtnh->rtnh_hops = 0;
-		rtnh->rtnh_ifindex = 0;
-		rta->rta_len += rtnh->rtnh_len;
-
-		if (nhi->gateway) {
-			rta_addattr_l(rta, sizeof(buf), RTA_GATEWAY,
-				      nhi->gateway, bytelen);
-			rtnh->rtnh_len += sizeof(struct rtattr) + bytelen;
-		}
+		if (nhi->gateway)
+			nl_attr_put(&req->n, in_buf_len, RTA_GATEWAY,
+				    nhi->gateway, bytelen);
 
 		if (nhi->if_index) {
 			rtnh->rtnh_ifindex = nhi->if_index;
@@ -484,31 +474,28 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 		case FPM_NH_ENCAP_MAX:
 			break;
 		case FPM_NH_ENCAP_VXLAN:
-			rta_addattr_l(rta, sizeof(buf), RTA_ENCAP_TYPE,
-				      &encap, sizeof(uint16_t));
-			rtnh->rtnh_len += sizeof(struct rtattr) +
-					  sizeof(uint16_t);
+			nl_attr_put16(&req->n, in_buf_len, RTA_ENCAP_TYPE,
+				      encap);
 			vxlan = &nhi->encap_info.vxlan_encap;
-			nest = rta_nest(rta, sizeof(buf), RTA_ENCAP);
-			rta_addattr_l(rta, sizeof(buf), VXLAN_VNI, &vxlan->vni,
-				      sizeof(uint32_t));
-			nest_len = rta_nest_end(rta, nest);
-			rtnh->rtnh_len += nest_len;
+			inner_nest =
+				nl_attr_nest(&req->n, in_buf_len, RTA_ENCAP);
+			nl_attr_put32(&req->n, in_buf_len, VXLAN_VNI,
+				      vxlan->vni);
+			nl_attr_nest_end(&req->n, inner_nest);
 			break;
 		}
 
-		rtnh = RTNH_NEXT(rtnh);
+		nl_attr_rtnh_end(&req->n, rtnh);
 	}
 
-	assert(rta->rta_len > RTA_LENGTH(0));
-	addattr_l(&req->n, in_buf_len, RTA_MULTIPATH, RTA_DATA(rta),
-		  RTA_PAYLOAD(rta));
+	nl_attr_nest_end(&req->n, nest);
+	assert(nest->rta_len > RTA_LENGTH(0));
 
 done:
 
 	if (ri->pref_src) {
-		addattr_l(&req->n, in_buf_len, RTA_PREFSRC, &ri->pref_src,
-			  bytelen);
+		nl_attr_put(&req->n, in_buf_len, RTA_PREFSRC, &ri->pref_src,
+			    bytelen);
 	}
 
 	assert(req->n.nlmsg_len < in_buf_len);
@@ -614,10 +601,10 @@ int zfpm_netlink_encode_mac(struct fpm_mac_info_t *mac, char *in_buf,
 		req->ndm.ndm_flags |= NTF_EXT_LEARNED;
 
 	/* Add attributes */
-	addattr_l(&req->hdr, in_buf_len, NDA_LLADDR, &mac->macaddr, 6);
-	addattr_l(&req->hdr, in_buf_len, NDA_DST, &mac->r_vtep_ip, 4);
-	addattr32(&req->hdr, in_buf_len, NDA_MASTER, mac->svi_if);
-	addattr32(&req->hdr, in_buf_len, NDA_VNI, mac->vni);
+	nl_attr_put(&req->hdr, in_buf_len, NDA_LLADDR, &mac->macaddr, 6);
+	nl_attr_put(&req->hdr, in_buf_len, NDA_DST, &mac->r_vtep_ip, 4);
+	nl_attr_put32(&req->hdr, in_buf_len, NDA_MASTER, mac->svi_if);
+	nl_attr_put32(&req->hdr, in_buf_len, NDA_VNI, mac->vni);
 
 	assert(req->hdr.nlmsg_len < in_buf_len);
 

--- a/zebra/zebra_netns_id.c
+++ b/zebra/zebra_netns_id.c
@@ -216,8 +216,8 @@ ns_id_t zebra_ns_id_get(const char *netnspath, int fd_param)
 	nlh->nlmsg_len += NETLINK_ALIGN(sizeof(struct rtgenmsg));
 	rt->rtgen_family = AF_UNSPEC;
 
-	addattr32(nlh, NETLINK_SOCKET_BUFFER_SIZE, NETNSA_FD, fd);
-	addattr32(nlh, NETLINK_SOCKET_BUFFER_SIZE, NETNSA_NSID, ns_id);
+	nl_attr_put32(nlh, NETLINK_SOCKET_BUFFER_SIZE, NETNSA_FD, fd);
+	nl_attr_put32(nlh, NETLINK_SOCKET_BUFFER_SIZE, NETNSA_NSID, ns_id);
 
 	ret = send_receive(sock, nlh, seq, buf);
 	if (ret < 0) {
@@ -282,8 +282,9 @@ ns_id_t zebra_ns_id_get(const char *netnspath, int fd_param)
 		nlh->nlmsg_len += NETLINK_ALIGN(sizeof(struct rtgenmsg));
 		rt->rtgen_family = AF_UNSPEC;
 
-		addattr32(nlh, NETLINK_SOCKET_BUFFER_SIZE, NETNSA_FD, fd);
-		addattr32(nlh, NETLINK_SOCKET_BUFFER_SIZE, NETNSA_NSID, ns_id);
+		nl_attr_put32(nlh, NETLINK_SOCKET_BUFFER_SIZE, NETNSA_FD, fd);
+		nl_attr_put32(nlh, NETLINK_SOCKET_BUFFER_SIZE, NETNSA_NSID,
+			      ns_id);
 
 		ret = send_receive(sock, nlh, seq, buf);
 		if (ret < 0) {


### PR DESCRIPTION
This is the part of the dataplane batch sending project. I added bounds checking in functions encoding Netlink messages. It shouldn't have any effect on the way the code works now, but this will be more important in the future.

* Rename netlink utility functions like addattr to be less ambiguous
* Replace rta_attr_* functions with nl_attr_* since they introduced
   inconsistencies in the code
* Add helper functions for adding rtnexthop struct to the Netlink
   message
* Move code encoding Netlink messages to separate functions
* Add buffer bounds checking while creating Nelink messages