### PR TITLE
[7.4] Daemons should call frr_fini() on shutdown

### DIFF
--- a/lib/privs.c
+++ b/lib/privs.c
@@ -406,9 +406,11 @@ static void zprivs_caps_init(struct zebra_privs_t *zprivs)
 
 static void zprivs_caps_terminate(void)
 {
-	/* clear all capabilities */
+	/* Clear all capabilities, if we have any. */
 	if (zprivs_state.caps)
 		cap_clear(zprivs_state.caps);
+	else
+		return;
 
 	/* and boom, capabilities are gone forever */
 	if (cap_set_proc(zprivs_state.caps)) {

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -1094,7 +1094,8 @@ static void do_thread_cancel(struct thread_master *master)
 	}
 
 	/* Delete and free all cancellation requests */
-	list_delete_all_node(master->cancel_req);
+	if (master->cancel_req)
+		list_delete_all_node(master->cancel_req);
 
 	/* Wake up any threads which may be blocked in thread_cancel_async() */
 	master->canceled = true;

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -98,6 +98,7 @@ static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 	ospf_terminate();
+	exit(0);
 }
 
 /* SIGUSR1 handler. */

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -517,9 +517,9 @@ void ospf_terminate(void)
 
 	SET_FLAG(om->options, OSPF_MASTER_SHUTDOWN);
 
-	/* exit immediately if OSPF not actually running */
+	/* Skip some steps if OSPF not actually running */
 	if (listcount(om->ospf) == 0)
-		exit(0);
+		goto done;
 
 	bfd_gbl_exit();
 	for (ALL_LIST_ELEMENTS(om->ospf, node, nnode, ospf))
@@ -543,6 +543,7 @@ void ospf_terminate(void)
 	zclient_stop(zclient);
 	zclient_free(zclient);
 
+done:
 	frr_fini();
 }
 

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -82,6 +82,8 @@ static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 
+	frr_fini();
+
 	exit(0);
 }
 

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -81,6 +81,8 @@ static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 
+	frr_fini();
+
 	exit(0);
 }
 

--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -42,6 +42,7 @@ char backup_config_file[256];
 
 bool mpls_enabled;
 
+
 zebra_capabilities_t _caps_p[] = {
 };
 
@@ -74,6 +75,8 @@ static void sigint(void)
 	zlog_notice("Terminating on signal");
 
 	static_vrf_terminate();
+
+	frr_fini();
 
 	exit(0);
 }

--- a/vrrpd/vrrp_main.c
+++ b/vrrpd/vrrp_main.c
@@ -82,6 +82,8 @@ static void __attribute__((noreturn)) sigint(void)
 
 	vrrp_fini();
 
+	frr_fini();
+
 	exit(0);
 }
 


### PR DESCRIPTION
This is the 7.4 version of the fix for left-behind temporary files from daemons who didn't call frr_fini() during shutdown.

This is the 7.4 fix for issue #6541 