### PR TITLE
bgpd: rpki fixes (master)

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -811,7 +811,7 @@ static int add_tcp_cache(const char *host, const char *port,
 {
 	struct rtr_socket *rtr_socket;
 	struct tr_tcp_config *tcp_config =
-		XMALLOC(MTYPE_BGP_RPKI_CACHE, sizeof(struct tr_tcp_config));
+		XCALLOC(MTYPE_BGP_RPKI_CACHE, sizeof(struct tr_tcp_config));
 	struct tr_socket *tr_socket =
 		XMALLOC(MTYPE_BGP_RPKI_CACHE, sizeof(struct tr_socket));
 	struct cache *cache =
@@ -845,7 +845,7 @@ static int add_ssh_cache(const char *host, const unsigned int port,
 			 const uint8_t preference)
 {
 	struct tr_ssh_config *ssh_config =
-		XMALLOC(MTYPE_BGP_RPKI_CACHE, sizeof(struct tr_ssh_config));
+		XCALLOC(MTYPE_BGP_RPKI_CACHE, sizeof(struct tr_ssh_config));
 	struct cache *cache =
 		XMALLOC(MTYPE_BGP_RPKI_CACHE, sizeof(struct cache));
 	struct tr_socket *tr_socket =

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -347,9 +347,15 @@ static inline uint64_t bgp_table_version(struct bgp_table *table)
 	return table->version;
 }
 
-void bgp_table_range_lookup(const struct bgp_table *table,
-			    const struct prefix *p,
-			    uint8_t maxlen, struct list *matches);
+/* Find the subtree of the prefix p
+ *
+ * This will return the first node that belongs the the subtree of p. Including
+ * p itself, if it is in the tree.
+ *
+ * If the subtree is not present in the table, NULL is returned.
+ */
+struct bgp_node *bgp_table_subtree_lookup(const struct bgp_table *table,
+					  const struct prefix *p);
 
 
 static inline struct bgp_aggregate *

--- a/tests/bgpd/test_bgp_table.py
+++ b/tests/bgpd/test_bgp_table.py
@@ -3,5 +3,5 @@ import frrtest
 class TestTable(frrtest.TestMultiOut):
     program = './test_bgp_table'
 
-for i in range(9):
+for i in range(7):
     TestTable.onesimple('Checks successfull')


### PR DESCRIPTION
This fixes a bug in the rpki revalidation logic that prevented routes with an invalid length from being revalidated.
I also pre initialize the rtrlibs tr_ structures with zeros now. This is a forward compatibility fix.