### PR TITLE
bgpd: Set nexthop length to 16 bytes for IPv4 family prefixes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1858,6 +1858,15 @@ bool subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 				BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
 		}
 
+		/* If prefix is IPv4 and we send ::(LL) or LL(LL) then
+		 * other vendors (e.g.: JunOS) complains about bad nhop
+		 * length. Setting this to 16 bytes for unnumbered sessions.
+		 */
+		if (p->family == AF_INET
+		    && (IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_global)
+			|| IN6_IS_ADDR_UNSPECIFIED(&peer->nexthop.v6_global)))
+			attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
+
 		/* Clear off link-local nexthop in source, whenever it is not
 		 * needed to
 		 * ensure more prefixes share the same attribute for


### PR DESCRIPTION
This is the issue between other vendors with unnumbered sessions.
I tested with vQFX-re and got this notification from JunOS:

`NOTIFICATION sent to fe80::a00:27ff:fec4:4b3e (External AS 65002): code 3 (Update Message Error) subcode 9 (error with optional attribute)`

With this _fix_ the session is UP and all prefixes received on JunOS side:

```
root@vqfx-re> show route 172.16.255.253/32 detail

inet.0: 13 destinations, 15 routes (13 active, 0 holddown, 0 hidden)
172.16.255.253/32 (1 entry, 1 announced)
        *BGP    Preference: 170/-101
                Next hop type: Router, Next hop index: 342
                Address: 0xc65eb68
                Next-hop reference count: 16
                Source: fe80::a00:27ff:fec4:4b3e
                Next hop: fe80::a00:27ff:fec4:4b3e via em1.0, selected
                Session Id: 0x0
                State: <Active Ext>
                Local AS: 65004 Peer AS: 65002
                Age: 4:59       Metric: 0
                Validation State: unverified
                Task: BGP_65002.fe80::a00:27ff:fec4:4b3e
                Announcement bits (2): 0-KRT 1-Resolve tree 1
                AS path: 65002 ?
                Accepted
                Localpref: 100
                Router ID: 2.2.2.2

{master:0}
```

Related: https://github.com/FRRouting/frr/issues/6433

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>