### PR TITLE
tools: fix frr-reload.py daemon option

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -146,9 +146,10 @@ class Vtysh(object):
         return stdout.decode('UTF-8')
 
     def mark_show_run(self, daemon = None):
-        cmd = 'show running-config no-header'
+        cmd = 'show running-config'
         if daemon:
             cmd += ' %s' % daemon
+        cmd += ' no-header'
         show_run = self._call_cmd(cmd, stdout=subprocess.PIPE)
         mark = self._call(['-m', '-f', '-'], stdin=show_run.stdout, stdout=subprocess.PIPE)
 


### PR DESCRIPTION
the refactored frr-reload.py is adding 'no-header' to the 'show running' command of vtysh, but if a daemon is specified the no-header option should only be added after the daemon name, else vtysh will complain.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>