### PR TITLE
bgpd: GR fixes

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1863,6 +1863,30 @@ static int bgp_establish(struct peer *peer)
 			}
 		}
 
+	if (!CHECK_FLAG(peer->cap, PEER_CAP_RESTART_RCV)) {
+		if ((bgp_peer_gr_mode_get(peer) == PEER_GR)
+		    || ((bgp_peer_gr_mode_get(peer) == PEER_GLOBAL_INHERIT)
+			&& (bgp_global_gr_mode_get(peer->bgp) == GLOBAL_GR))) {
+			FOREACH_AFI_SAFI (afi, safi)
+				/* Send route processing complete
+				   message to RIB */
+				bgp_zebra_update(
+					afi, safi, peer->bgp->vrf_id,
+					ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE);
+		}
+	} else {
+		/* Peer sends R-bit. In this case, we need to send
+		 * ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE to Zebra. */
+		if (CHECK_FLAG(peer->cap, PEER_CAP_RESTART_BIT_RCV)) {
+			FOREACH_AFI_SAFI (afi, safi)
+				/* Send route processing complete
+				   message to RIB */
+				bgp_zebra_update(
+					afi, safi, peer->bgp->vrf_id,
+					ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE);
+		}
+	}
+
 	peer->nsf_af_count = nsf_af_count;
 
 	if (nsf_af_count)

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1114,6 +1114,9 @@ int bgp_open_option_parse(struct peer *peer, uint8_t length, int *mp_capability)
 		zlog_debug("%s rcv OPEN w/ OPTION parameter len: %u",
 			   peer->host, length);
 
+	/* Unset any previously received GR capability. */
+	UNSET_FLAG(peer->cap, PEER_CAP_RESTART_RCV);
+
 	while (stream_get_getp(s) < end) {
 		uint8_t opt_type;
 		uint8_t opt_length;


### PR DESCRIPTION
1) When a session comes up for a peer and if the peer has not adverised
   the GR capabilities, BGP sends a request to Zebra to clear any
   stale routes that might exist from that peer.
2) When OPEN message is received from the peer, clear the previously
   advertised GR capability by the peer, if the lastest received
   OPEN message does not contain the GR capability.

Signed-off-by: NaveenThanikachalam <nthanikachal@vmware.com>