### PR TITLE
[fix] Docker centos 7

### DIFF
--- a/docker/centos-7/Dockerfile
+++ b/docker/centos-7/Dockerfile
@@ -4,13 +4,13 @@ RUN yum install -y epel-release
 RUN yum install -y rpm-build autoconf automake libtool make \
         readline-devel texinfo net-snmp-devel groff pkgconfig \
         json-c-devel pam-devel bison flex pytest c-ares-devel \
-        python3-devel python3-sphinx systemd-devel libcap-devel \
+        python3-devel python3-sphinx systemd-devel libcap-devel git\
         https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-0.16.111-0.x86_64.rpm \
         https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-devel-0.16.111-0.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-0.7.0-1.el7.centos.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-devel-0.7.0-1.el7.centos.x86_64.rpm
 
-COPY . /src
+RUN git clone https://github.com/FRRouting/frr.git /src
 ARG PKGVER
 
 RUN echo '%_smp_mflags %( echo "-j$(/usr/bin/getconf _NPROCESSORS_ONLN)"; )' >> /root/.rpmmacros \
@@ -39,5 +39,5 @@ COPY --from=centos-7-builder /rpmbuild/RPMS/ /pkgs/rpm/
 
 RUN yum install -y /pkgs/rpm/*/*.rpm \
     && rm -rf /pkgs
-COPY docker/centos-7/docker-start /usr/lib/frr/docker-start
+COPY docker-start /usr/lib/frr/docker-start
 ENTRYPOINT [ "/usr/lib/frr/docker-start" ]


### PR DESCRIPTION
docker: COPY was not working, changing by using git clone and second COPY by fixing the folder

resolve: #6592

Signed-off-by: Cyril Lopez <cylopez@redhat.com>

Tested on Red Hat Enterprise Linux Server release 7.6 with podman-1.6.4-18.el7_8.x86_64

```
podman build -t frr -f docker/centos-7/Dockerfile
[...]
STEP 13: COMMIT frr
5eff3acffcef31e4f414c4e4e96fc7635d9bedfc23429cd674694d961c3dab79
[root@frrouting frr]# podman run -d 5eff3acffcef31e4f414c4e4e96fc7635d9bedfc23429cd674694d961c3dab79
f2ab25fe765b89acd92c366dae1bbc7a88449ac362c8311e8e9f2644c8a40dc8
[root@frrouting frr]# podman ps
CONTAINER ID  IMAGE                 COMMAND  CREATED        STATUS            PORTS  NAMES
f2ab25fe765b  localhost/frr:latest           4 seconds ago  Up 4 seconds ago         reverent_lovelace
```