### PR TITLE
build: find all future minor versions of python3

### DIFF
--- a/m4/ax_python.m4
+++ b/m4/ax_python.m4
@@ -186,7 +186,8 @@ AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
       AC_MSG_RESULT([yes])
 
       PYTHON_CFLAGS="`\"$pycfg\" --includes`"
-      if test x"${py_ver}" = x"3.8" || test x"{py_ver}" = x"3.9"; then
+      minor_ver=${py_ver#*\.}
+      if test $((minor_ver)) -gt 7; then
         PYTHON_LIBS="`\"$pycfg\" --ldflags --embed`"
       else
         PYTHON_LIBS="`\"$pycfg\" --ldflags`"


### PR DESCRIPTION
This way we can find every python from 3.8 further

Signed-off-by: Michal Ruprich <michalruprich@gmail.com>