### PR TITLE
ldpd: clean up temp zlog files

### DIFF
--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -206,6 +206,8 @@ lde_shutdown(void)
 	free(iev_main_sync);
 
 	log_info("label decision engine exiting");
+
+	zlog_fini();
 	exit(0);
 }
 

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -495,7 +495,8 @@ start_child(enum ldpd_process p, char *argv0, int fd_async, int fd_sync)
 	int	 argc = 0, nullfd;
 	pid_t	 pid;
 
-	switch (pid = fork()) {
+	pid = fork();
+	switch (pid) {
 	case -1:
 		fatal("cannot fork");
 	case 0:

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -235,6 +235,9 @@ ldpe_shutdown(void)
 	free(pkt_ptr);
 
 	log_info("ldp engine exiting");
+
+	zlog_fini();
+
 	exit(0);
 }
 


### PR DESCRIPTION
Clean up the temp zlog dirs in /var/tmp/frr/ that the ldpd child processes were leaving. The child processes do a non-standard lib init/deinit, so they need to explicitly deinit the zlog module.
