### PR TITLE
build: Allow removal of build configs from version string

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -645,6 +645,9 @@ AC_ARG_WITH([crypto],
 AC_ARG_WITH([frr-format],
   AS_HELP_STRING([--with-frr-format[=<.../frr-format.so>]], [use frr-format GCC plugin]))
 
+AC_ARG_ENABLE([version-build-config],
+  AS_HELP_STRING([--disable-version-build-config], [do not include build configs in show version command]))
+
 #if openssl, else use the internal
 AS_IF([test "$with_crypto" = "openssl"], [
 AC_CHECK_LIB([crypto], [EVP_DigestInit], [LIBS="$LIBS -lcrypto"], [], [])
@@ -1681,6 +1684,10 @@ case "${enable_bmp}" in
     fi
     ;;
 esac
+
+if test "$enable_version_build_config" != "no";then
+  AC_DEFINE([ENABLE_VERSION_BUILD_CONFIG], [1], [Report build configs in show version])
+fi
 
 dnl ##########################################################################
 dnl LARGE if block

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -279,6 +279,18 @@ options from the list below.
    With this option, we provide a way to strip out these characters for APK dev
    package builds.
 
+..option:: --disable-version-build-config
+
+   Remove the "configuerd with" field that has all of the build configuration
+   arguments when reporting the version string in `show version` command.
+
+..option:: --with-pkg-extra-version=VER
+   Add extra version field, for packagers/distributions
+
+..option::  --with-pkg-git-version
+
+   Add git information to MOTD and build version string
+
 .. option:: --enable-multipath=X
 
    Compile FRR with up to X way ECMP supported.  This number can be from 0-999.

--- a/lib/command.c
+++ b/lib/command.c
@@ -144,7 +144,9 @@ void print_version(const char *progname)
 {
 	printf("%s version %s\n", progname, FRR_VERSION);
 	printf("%s\n", FRR_COPYRIGHT);
+#ifdef ENABLE_VERSION_BUILD_CONFIG
 	printf("configured with:\n\t%s\n", FRR_CONFIG_ARGS);
+#endif
 }
 
 char *argv_concat(struct cmd_token **argv, int argc, int shift)
@@ -1334,8 +1336,9 @@ DEFUN (show_version,
 	vty_out(vty, "%s %s (%s).\n", FRR_FULL_NAME, FRR_VERSION,
 		cmd_hostname_get() ? cmd_hostname_get() : "");
 	vty_out(vty, "%s%s\n", FRR_COPYRIGHT, GIT_INFO);
+#ifdef ENABLE_VERSION_BUILD_CONFIG
 	vty_out(vty, "configured with:\n    %s\n", FRR_CONFIG_ARGS);
-
+#endif
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
A new config option `--disable-version-build-config`
allows you to show short version string by dropping
"configured with:" and all of its build configs

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>