### PR TITLE
zebra: When installing a nexthop-group success is vital

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2077,7 +2077,7 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 		 * other ids.
 		 */
 		if (dplane_ctx_get_nhe_nh_grp_count(ctx)) {
-			if (_netlink_nexthop_build_group(
+			if (!_netlink_nexthop_build_group(
 				    &req->n, buflen, id,
 				    dplane_ctx_get_nhe_nh_grp(ctx),
 				    dplane_ctx_get_nhe_nh_grp_count(ctx)))


### PR DESCRIPTION
When installing a nexthop-group the recent commit:
commit 0be6e7d75dbbbfae33c3b51ae7c160d35b228915

reversed the logic for testing if adding data to
the netlink message succeeded and we thought we did
not thus not creating the nexthop group.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>