### PR TITLE
* : Sanitize the language in source code

### DIFF
--- a/doc/developer/building-frr-for-centos6.rst
+++ b/doc/developer/building-frr-for-centos6.rst
@@ -26,7 +26,7 @@ CentOS 6 restrictions:
 -  MPLS is not supported on ``CentOS 6``. MPLS requires Linux Kernel 4.5
    or higher (LDP can be built, but may have limited use without MPLS)
 -  Zebra is unable to detect what bridge/vrf an interface is associated
-   with (IFLA\_INFO\_SLAVE\_KIND does not exist in the kernel headers,
+   with (IFLA\_INFO\_SECONDARY\_KIND does not exist in the kernel headers,
    you can use a newer kernel + headers to get this functionality)
 -  frr\_reload.py will not work, as this requires Python 2.7, and CentOS
    6 only has 2.6. You can install Python 2.7 via IUS, but it won't work

--- a/doc/user/vrrp.rst
+++ b/doc/user/vrrp.rst
@@ -166,7 +166,7 @@ In either case, the created interfaces will look like this:
 
 Using ``vrrp4-2-1`` as an example, a few things to note about this interface:
 
-- It is slaved to ``eth0``; any packets transmitted on this interface will
+- It is secondary to ``eth0``; any packets transmitted on this interface will
   egress via ``eth0``
 - Its MAC address is set to the VRRP IPv4 virtual MAC specified by the RFC for
   :abbr:`VRID (Virtual Router ID)` ``5``

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3712,7 +3712,7 @@ static void zclient_event(enum event event, struct zclient *zclient)
 
 void zclient_interface_set_master(struct zclient *client,
 				  struct interface *master,
-				  struct interface *slave)
+				  struct interface *member_intf)
 {
 	struct stream *s;
 
@@ -3723,8 +3723,8 @@ void zclient_interface_set_master(struct zclient *client,
 
 	stream_putl(s, master->vrf_id);
 	stream_putl(s, master->ifindex);
-	stream_putl(s, slave->vrf_id);
-	stream_putl(s, slave->ifindex);
+	stream_putl(s, member_intf->vrf_id);
+	stream_putl(s, member_intf->ifindex);
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 	zclient_send_message(client);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -733,7 +733,7 @@ extern bool zapi_parse_header(struct stream *zmsg, struct zmsghdr *hdr);
 
 extern void zclient_interface_set_master(struct zclient *client,
 					 struct interface *master,
-					 struct interface *slave);
+					 struct interface *member_intf);
 extern struct interface *zebra_interface_state_read(struct stream *s, vrf_id_t);
 extern struct connected *zebra_interface_address_read(int, struct stream *,
 						      vrf_id_t);

--- a/ospf6d/ospf6_message.h
+++ b/ospf6d/ospf6_message.h
@@ -83,7 +83,7 @@ struct ospf6_dbdesc {
 	/* Followed by LSA Headers */
 };
 
-#define OSPF6_DBDESC_MSBIT (0x01) /* master/slave bit */
+#define OSPF6_DBDESC_MSBIT (0x01) /* master/secondary bit */
 #define OSPF6_DBDESC_MBIT  (0x02) /* more bit */
 #define OSPF6_DBDESC_IBIT  (0x04) /* initial bit */
 

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -711,7 +711,7 @@ static void ospf6_neighbor_show_detail(struct vty *vty,
 								: ""),
 		(CHECK_FLAG(on->dbdesc_bits, OSPF6_DBDESC_MBIT) ? "More " : ""),
 		(CHECK_FLAG(on->dbdesc_bits, OSPF6_DBDESC_MSBIT) ? "Master"
-								 : "Slave"),
+								 : "Secondary"),
 		(unsigned long)ntohl(on->dbdesc_seqnum));
 
 	vty_out(vty, "    Summary-List: %d LSAs\n", on->summary_list->count);

--- a/tests/topotests/pbr-topo1/test_pbr_topo1.py
+++ b/tests/topotests/pbr-topo1/test_pbr_topo1.py
@@ -87,7 +87,7 @@ def setup_module(module):
 
     router_list = tgen.routers()
     for rname, router in router_list.iteritems():
-        # Install vrf into the kernel and slave eth3
+        # Install vrf into the kernel and member interface eth3
         router.run("ip link add vrf-chiyoda type vrf table 1000")
         router.run("ip link set dev {}-eth3 master vrf-chiyoda".format(rname))
         router.run("ip link set vrf-chiyoda up")

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -160,10 +160,10 @@ module frr-zebra {
       "Zebra interface type bond.";
   }
 
-  identity zif-bond-slave {
+  identity zif-bond-secondary {
     base zebra-interface-type;
     description
-      "Zebra interface type bond slave.";
+      "Zebra interface type bond secondary.";
   }
 
   identity zif-macvlan {

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -993,13 +993,13 @@ static void fpm_enqueue_rmac_table(struct hash_bucket *backet, void *arg)
 
 	sticky = !!CHECK_FLAG(zrmac->flags,
 			      (ZEBRA_MAC_STICKY | ZEBRA_MAC_REMOTE_DEF_GW));
-	br_zif = (struct zebra_if *)(zif->brslave_info.br_if->info);
+	br_zif = (struct zebra_if *)(zif->brsecondary_info.br_if->info);
 	vid = IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(br_zif) ? vxl->access_vlan : 0;
 
 	dplane_ctx_reset(fra->ctx);
 	dplane_ctx_set_op(fra->ctx, DPLANE_OP_MAC_INSTALL);
 	dplane_mac_init(fra->ctx, fra->zl3vni->vxlan_if,
-			zif->brslave_info.br_if, vid,
+			zif->brsecondary_info.br_if, vid,
 			&zrmac->macaddr, zrmac->fwd_info.r_vtep_ip, sticky);
 	if (fpm_nl_enqueue(fra->fnc, fra->ctx) == -1) {
 		thread_add_timer(zrouter.master, fpm_rmac_send,

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -830,10 +830,10 @@ void if_delete_update(struct interface *ifp)
 	zif = ifp->info;
 	if (zif) {
 		zif->zif_type = ZEBRA_IF_OTHER;
-		zif->zif_slave_type = ZEBRA_IF_SLAVE_NONE;
+		zif->zif_member_type = ZEBRA_IF_MEMBER_NONE;
 		memset(&zif->l2info, 0, sizeof(union zebra_l2if_info));
-		memset(&zif->brslave_info, 0,
-		       sizeof(struct zebra_l2info_brslave));
+		memset(&zif->brsecondary_info, 0,
+		       sizeof(struct zebra_l2info_brmember));
 	}
 
 	if (!ifp->configured) {
@@ -1236,18 +1236,18 @@ static void nbr_connected_dump_vty(struct vty *vty,
 	vty_out(vty, "\n");
 }
 
-static const char *zebra_zifslavetype_2str(zebra_slave_iftype_t zif_slave_type)
+static const char *zebra_zifmembertype_2str(zebra_member_iftype_t zif_member_type)
 {
-	switch (zif_slave_type) {
-	case ZEBRA_IF_SLAVE_BRIDGE:
+	switch (zif_member_type) {
+	case ZEBRA_IF_MEMBER_BRIDGE:
 		return "Bridge";
-	case ZEBRA_IF_SLAVE_VRF:
+	case ZEBRA_IF_MEMBER_VRF:
 		return "Vrf";
-	case ZEBRA_IF_SLAVE_BOND:
+	case ZEBRA_IF_MEMBER_BOND:
 		return "Bond";
-	case ZEBRA_IF_SLAVE_OTHER:
+	case ZEBRA_IF_MEMBER_OTHER:
 		return "Other";
-	case ZEBRA_IF_SLAVE_NONE:
+	case ZEBRA_IF_MEMBER_NONE:
 		return "None";
 	}
 	return "None";
@@ -1277,8 +1277,8 @@ static const char *zebra_ziftype_2str(zebra_iftype_t zif_type)
 	case ZEBRA_IF_BOND:
 		return "bond";
 
-	case ZEBRA_IF_BOND_SLAVE:
-		return "bond_slave";
+	case ZEBRA_IF_BOND_SECONDARY:
+		return "bond_member";
 
 	case ZEBRA_IF_MACVLAN:
 		return "macvlan";
@@ -1480,8 +1480,8 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 
 	vty_out(vty, "  Interface Type %s\n",
 		zebra_ziftype_2str(zebra_if->zif_type));
-	vty_out(vty, "  Interface Slave Type %s\n",
-		zebra_zifslavetype_2str(zebra_if->zif_slave_type));
+	vty_out(vty, "  Interface Member Type %s\n",
+		zebra_zifmembertype_2str(zebra_if->zif_member_type));
 
 	if (IS_ZEBRA_IF_BRIDGE(ifp)) {
 		struct zebra_l2info_bridge *bridge_info;
@@ -1522,31 +1522,31 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 		vty_out(vty, "\n");
 	}
 
-	if (IS_ZEBRA_IF_BRIDGE_SLAVE(ifp)) {
-		struct zebra_l2info_brslave *br_slave;
+	if (IS_ZEBRA_IF_BRIDGE_MEMBER(ifp)) {
+		struct zebra_l2info_brmember *br_member;
 
-		br_slave = &zebra_if->brslave_info;
-		if (br_slave->bridge_ifindex != IFINDEX_INTERNAL) {
-			if (br_slave->br_if)
+		br_member = &zebra_if->brsecondary_info;
+		if (br_member->bridge_ifindex != IFINDEX_INTERNAL) {
+			if (br_member->br_if)
 				vty_out(vty, "  Master interface: %s\n",
-					br_slave->br_if->name);
+					br_member->br_if->name);
 			else
 				vty_out(vty, "  Master ifindex: %u\n",
-					br_slave->bridge_ifindex);
+					br_member->bridge_ifindex);
 		}
 	}
 
-	if (IS_ZEBRA_IF_BOND_SLAVE(ifp)) {
-		struct zebra_l2info_bondslave *bond_slave;
+	if (IS_ZEBRA_IF_BOND_MEMBER(ifp)) {
+		struct zebra_l2info_bondsecondary *bond_member;
 
-		bond_slave = &zebra_if->bondslave_info;
-		if (bond_slave->bond_ifindex != IFINDEX_INTERNAL) {
-			if (bond_slave->bond_if)
+		bond_member = &zebra_if->bondsecondary_info;
+		if (bond_member->bond_ifindex != IFINDEX_INTERNAL) {
+			if (bond_member->bond_if)
 				vty_out(vty, "  Master interface: %s\n",
-					bond_slave->bond_if->name);
+					bond_member->bond_if->name);
 			else
 				vty_out(vty, "  Master ifindex: %u\n",
-					bond_slave->bond_ifindex);
+					bond_member->bond_ifindex);
 		}
 	}
 

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -66,7 +66,7 @@ enum zebra_dplane_result kernel_neigh_update_ctx(struct zebra_dplane_ctx *ctx);
 extern int kernel_neigh_update(int cmd, int ifindex, uint32_t addr, char *lla,
 			       int llalen, ns_id_t ns_id);
 extern int kernel_interface_set_master(struct interface *master,
-				       struct interface *slave);
+				       struct interface *secondary);
 
 extern int mpls_kernel_init(void);
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2836,17 +2836,17 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 		return 0;
 
 	/* The interface should be something we're interested in. */
-	if (!IS_ZEBRA_IF_BRIDGE_SLAVE(ifp))
+	if (!IS_ZEBRA_IF_BRIDGE_MEMBER(ifp))
 		return 0;
 
 	zif = (struct zebra_if *)ifp->info;
-	if ((br_if = zif->brslave_info.br_if) == NULL) {
+	if ((br_if = zif->brsecondary_info.br_if) == NULL) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
 				"%s AF_BRIDGE IF %s(%u) brIF %u - no bridge master",
 				nl_msg_type_to_str(h->nlmsg_type), ifp->name,
 				ndm->ndm_ifindex,
-				zif->brslave_info.bridge_ifindex);
+				zif->brsecondary_info.bridge_ifindex);
 		return 0;
 	}
 

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -408,7 +408,7 @@ enum zebra_dplane_result kernel_mac_update_ctx(struct zebra_dplane_ctx *ctx)
 }
 
 extern int kernel_interface_set_master(struct interface *master,
-				       struct interface *slave)
+				       struct interface *secondary)
 {
 	return 0;
 }

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2401,7 +2401,7 @@ stream_failure:
 static void zread_interface_set_master(ZAPI_HANDLER_ARGS)
 {
 	struct interface *master;
-	struct interface *slave;
+	struct interface *secondary;
 	struct stream *s = msg;
 	int ifindex;
 	vrf_id_t vrf_id;
@@ -2412,12 +2412,12 @@ static void zread_interface_set_master(ZAPI_HANDLER_ARGS)
 
 	STREAM_GETL(s, vrf_id);
 	STREAM_GETL(s, ifindex);
-	slave = if_lookup_by_index(ifindex, vrf_id);
+	secondary = if_lookup_by_index(ifindex, vrf_id);
 
-	if (!master || !slave)
+	if (!master || !secondary)
 		return;
 
-	kernel_interface_set_master(master, slave);
+	kernel_interface_set_master(master, secondary);
 
 stream_failure:
 	return;

--- a/zebra/zebra_l2.h
+++ b/zebra/zebra_l2.h
@@ -33,8 +33,8 @@
 extern "C" {
 #endif
 
-/* zebra L2 interface information - bridge slave (linkage to bridge) */
-struct zebra_l2info_brslave {
+/* zebra L2 interface information - bridge secondary (linkage to bridge) */
+struct zebra_l2info_brmember {
 	ifindex_t bridge_ifindex; /* Bridge Master */
 	struct interface *br_if;  /* Pointer to master */
 	ns_id_t ns_id; /* network namespace where bridge is */
@@ -62,7 +62,7 @@ struct zebra_l2info_vxlan {
 	ns_id_t link_nsid;
 };
 
-struct zebra_l2info_bondslave {
+struct zebra_l2info_bondsecondary {
 	ifindex_t bond_ifindex;    /* Bridge Master */
 	struct interface *bond_if; /* Pointer to master */
 };
@@ -82,14 +82,14 @@ union zebra_l2if_info {
 
 #define IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(zif) ((zif)->l2info.br.vlan_aware == 1)
 
-extern void zebra_l2_map_slave_to_bridge(struct zebra_l2info_brslave *br_slave,
+extern void zebra_l2_map_secondary_to_bridge(struct zebra_l2info_brmember *br_member,
 					 struct zebra_ns *zns);
 extern void
-zebra_l2_unmap_slave_from_bridge(struct zebra_l2info_brslave *br_slave);
+zebra_l2_unmap_secondary_from_bridge(struct zebra_l2info_brmember *br_member);
 extern void
-zebra_l2_map_slave_to_bond(struct zebra_l2info_bondslave *bond_slave, vrf_id_t);
+zebra_l2_map_secondary_to_bond(struct zebra_l2info_bondsecondary *bond_member, vrf_id_t);
 extern void
-zebra_l2_unmap_slave_from_bond(struct zebra_l2info_bondslave *bond_slave);
+zebra_l2_unmap_secondary_from_bond(struct zebra_l2info_bondsecondary *bond_member);
 extern void zebra_l2_bridge_add_update(struct interface *ifp,
 				       struct zebra_l2info_bridge *bridge_info,
 				       int add);
@@ -102,11 +102,11 @@ extern void zebra_l2_vxlanif_add_update(struct interface *ifp,
 extern void zebra_l2_vxlanif_update_access_vlan(struct interface *ifp,
 						vlanid_t access_vlan);
 extern void zebra_l2_vxlanif_del(struct interface *ifp);
-extern void zebra_l2if_update_bridge_slave(struct interface *ifp,
+extern void zebra_l2if_update_bridge_member(struct interface *ifp,
 					   ifindex_t bridge_ifindex,
 					   ns_id_t ns_id);
 
-extern void zebra_l2if_update_bond_slave(struct interface *ifp,
+extern void zebra_l2if_update_bond_member(struct interface *ifp,
 					 ifindex_t bond_ifindex);
 
 #ifdef __cplusplus

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2513,7 +2513,7 @@ static int zvni_neigh_install(zebra_vni_t *zvni, zebra_neigh_t *n)
 		return -1;
 	vxl = &zif->l2info.vxl;
 
-	vlan_if = zvni_map_to_svi(vxl->access_vlan, zif->brslave_info.br_if);
+	vlan_if = zvni_map_to_svi(vxl->access_vlan, zif->brsecondary_info.br_if);
 	if (!vlan_if)
 		return -1;
 
@@ -2550,7 +2550,7 @@ static int zvni_neigh_uninstall(zebra_vni_t *zvni, zebra_neigh_t *n)
 	if (!zif)
 		return -1;
 	vxl = &zif->l2info.vxl;
-	vlan_if = zvni_map_to_svi(vxl->access_vlan, zif->brslave_info.br_if);
+	vlan_if = zvni_map_to_svi(vxl->access_vlan, zif->brsecondary_info.br_if);
 	if (!vlan_if)
 		return -1;
 
@@ -2576,7 +2576,7 @@ static int zvni_neigh_probe(zebra_vni_t *zvni, zebra_neigh_t *n)
 		return -1;
 	vxl = &zif->l2info.vxl;
 
-	vlan_if = zvni_map_to_svi(vxl->access_vlan, zif->brslave_info.br_if);
+	vlan_if = zvni_map_to_svi(vxl->access_vlan, zif->brsecondary_info.br_if);
 	if (!vlan_if)
 		return -1;
 
@@ -2902,13 +2902,13 @@ static void zvni_gw_macip_del_for_vni_hash(struct hash_bucket *bucket,
 	zif = ifp->info;
 
 	/* If down or not mapped to a bridge, we're done. */
-	if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+	if (!if_is_operative(ifp) || !zif->brsecondary_info.br_if)
 		return;
 
 	zl2_info = zif->l2info.vxl;
 
 	vlan_if =
-		zvni_map_to_svi(zl2_info.access_vlan, zif->brslave_info.br_if);
+		zvni_map_to_svi(zl2_info.access_vlan, zif->brsecondary_info.br_if);
 	if (!vlan_if)
 		return;
 
@@ -2941,12 +2941,12 @@ static void zvni_gw_macip_add_for_vni_hash(struct hash_bucket *bucket,
 	zif = ifp->info;
 
 	/* If down or not mapped to a bridge, we're done. */
-	if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+	if (!if_is_operative(ifp) || !zif->brsecondary_info.br_if)
 		return;
 	zl2_info = zif->l2info.vxl;
 
 	vlan_if =
-		zvni_map_to_svi(zl2_info.access_vlan, zif->brslave_info.br_if);
+		zvni_map_to_svi(zl2_info.access_vlan, zif->brsecondary_info.br_if);
 	if (!vlan_if)
 		return;
 
@@ -2993,13 +2993,13 @@ static void zvni_svi_macip_del_for_vni_hash(struct hash_bucket *bucket,
 	zif = ifp->info;
 
 	/* If down or not mapped to a bridge, we're done. */
-	if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+	if (!if_is_operative(ifp) || !zif->brsecondary_info.br_if)
 		return;
 
 	zl2_info = zif->l2info.vxl;
 
 	vlan_if = zvni_map_to_svi(zl2_info.access_vlan,
-				  zif->brslave_info.br_if);
+				  zif->brsecondary_info.br_if);
 	if (!vlan_if)
 		return;
 
@@ -3572,7 +3572,7 @@ static int zvni_map_vlan_ns(struct ns *ns,
 			continue;
 		vxl = &zif->l2info.vxl;
 
-		if (zif->brslave_info.br_if != br_if)
+		if (zif->brsecondary_info.br_if != br_if)
 			continue;
 
 		if (!in_param->bridge_vlan_aware
@@ -3653,7 +3653,7 @@ static int zvni_from_svi_ns(struct ns *ns,
 			continue;
 		vxl = &zif->l2info.vxl;
 
-		if (zif->brslave_info.br_if != br_if)
+		if (zif->brsecondary_info.br_if != br_if)
 			continue;
 
 		if (!in_param->bridge_vlan_aware
@@ -3887,7 +3887,7 @@ static int zvni_mac_install(zebra_vni_t *zvni, zebra_mac_t *mac)
 	if (!zif)
 		return -1;
 
-	br_ifp = zif->brslave_info.br_if;
+	br_ifp = zif->brsecondary_info.br_if;
 	if (br_ifp == NULL)
 		return -1;
 
@@ -3937,7 +3937,7 @@ static int zvni_mac_uninstall(zebra_vni_t *zvni, zebra_mac_t *mac)
 	if (!zif)
 		return -1;
 
-	br_ifp = zif->brslave_info.br_if;
+	br_ifp = zif->brsecondary_info.br_if;
 	if (br_ifp == NULL)
 		return -1;
 
@@ -4037,10 +4037,10 @@ static void zvni_read_mac_neigh(zebra_vni_t *zvni, struct interface *ifp)
 		zlog_debug(
 			"Reading MAC FDB and Neighbors for intf %s(%u) VNI %u master %u",
 			ifp->name, ifp->ifindex, zvni->vni,
-			zif->brslave_info.bridge_ifindex);
+			zif->brsecondary_info.bridge_ifindex);
 
-	macfdb_read_for_bridge(zns, ifp, zif->brslave_info.br_if);
-	vlan_if = zvni_map_to_svi(vxl->access_vlan, zif->brslave_info.br_if);
+	macfdb_read_for_bridge(zns, ifp, zif->brsecondary_info.br_if);
+	vlan_if = zvni_map_to_svi(vxl->access_vlan, zif->brsecondary_info.br_if);
 	if (vlan_if) {
 
 		/* Add SVI MAC-IP */
@@ -4333,7 +4333,7 @@ static int zvni_build_hash_table_ns(struct ns *ns,
 				 * bridge.
 				 */
 				if (if_is_operative(ifp) &&
-					zif->brslave_info.br_if)
+					zif->brsecondary_info.br_if)
 					zvni_send_add_to_client(zvni);
 
 				/* Send Local MAC-entries to client */
@@ -4364,7 +4364,7 @@ static int zvni_build_hash_table_ns(struct ns *ns,
 				}
 				zvni->vxlan_if = ifp;
 				vlan_if = zvni_map_to_svi(vxl->access_vlan,
-						zif->brslave_info.br_if);
+						zif->brsecondary_info.br_if);
 				if (vlan_if) {
 					zvni->vrf_id = vlan_if->vrf_id;
 					zl3vni = zl3vni_from_vrf(
@@ -4379,7 +4379,7 @@ static int zvni_build_hash_table_ns(struct ns *ns,
 				 * bridge.
 				 */
 				if (if_is_operative(ifp) &&
-					zif->brslave_info.br_if)
+					zif->brsecondary_info.br_if)
 					zvni_send_add_to_client(zvni);
 			}
 		}
@@ -4709,7 +4709,7 @@ static int zl3vni_rmac_install(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 	if (!zif)
 		return -1;
 
-	br_ifp = zif->brslave_info.br_if;
+	br_ifp = zif->brsecondary_info.br_if;
 	if (br_ifp == NULL)
 		return -1;
 
@@ -4760,7 +4760,7 @@ static int zl3vni_rmac_uninstall(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 	if (!zif)
 		return -1;
 
-	br_ifp = zif->brslave_info.br_if;
+	br_ifp = zif->brsecondary_info.br_if;
 	if (br_ifp == NULL)
 		return -1;
 
@@ -5263,7 +5263,7 @@ struct interface *zl3vni_map_to_svi_if(zebra_l3vni_t *zl3vni)
 
 	vxl = &zif->l2info.vxl;
 
-	return zvni_map_to_svi(vxl->access_vlan, zif->brslave_info.br_if);
+	return zvni_map_to_svi(vxl->access_vlan, zif->brsecondary_info.br_if);
 }
 
 struct interface *zl3vni_map_to_mac_vlan_if(zebra_l3vni_t *zl3vni)
@@ -5280,7 +5280,7 @@ struct interface *zl3vni_map_to_mac_vlan_if(zebra_l3vni_t *zl3vni)
 	if (!zif)
 		return NULL;
 
-	return zvni_map_to_macvlan(zif->brslave_info.br_if, zl3vni->svi_if);
+	return zvni_map_to_macvlan(zif->brsecondary_info.br_if, zl3vni->svi_if);
 }
 
 
@@ -5351,7 +5351,7 @@ static zebra_l3vni_t *zl3vni_from_svi(struct interface *ifp,
 			continue;
 		vxl = &zif->l2info.vxl;
 
-		if (zif->brslave_info.br_if != br_if)
+		if (zif->brsecondary_info.br_if != br_if)
 			continue;
 
 		if (!bridge_vlan_aware || vxl->access_vlan == vid) {
@@ -5675,7 +5675,7 @@ static void process_remote_macip_add(vni_t vni,
 	if (!ifp ||
 	    !if_is_operative(ifp) ||
 	    !zif ||
-	    !zif->brslave_info.br_if) {
+	    !zif->brsecondary_info.br_if) {
 		zlog_warn("Ignoring remote MACIP ADD VNI %u, invalid interface state or info",
 			  vni);
 		return;
@@ -6008,7 +6008,7 @@ static void process_remote_macip_del(vni_t vni,
 	if (!ifp ||
 	    !if_is_operative(ifp) ||
 	    !zif ||
-	    !zif->brslave_info.br_if) {
+	    !zif->brsecondary_info.br_if) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug("Ignoring remote MACIP DEL VNI %u, invalid interface state or info",
 				   vni);
@@ -6063,7 +6063,7 @@ static void process_remote_macip_del(vni_t vni,
 			struct interface *vlan_if;
 
 			vlan_if = zvni_map_to_svi(vxl->access_vlan,
-					zif->brslave_info.br_if);
+					zif->brsecondary_info.br_if);
 			if (IS_ZEBRA_DEBUG_VXLAN)
 				zlog_debug(
 					"%s: IP %s (flags 0x%x intf %s) is remote and duplicate, read kernel for local entry",
@@ -6103,7 +6103,7 @@ static void process_remote_macip_del(vni_t vni,
 					prefix_mac2str(macaddr, buf,
 						       sizeof(buf)),
 					mac->flags);
-			macfdb_read_specific_mac(zns, zif->brslave_info.br_if,
+			macfdb_read_specific_mac(zns, zif->brsecondary_info.br_if,
 						 macaddr, vxl->access_vlan);
 		}
 
@@ -8450,7 +8450,7 @@ void zebra_vxlan_remote_vtep_del(ZAPI_HANDLER_ARGS)
 		zif = ifp->info;
 
 		/* If down or not mapped to a bridge, we're done. */
-		if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+		if (!if_is_operative(ifp) || !zif->brsecondary_info.br_if)
 			continue;
 
 		/* If the remote VTEP does not exist, there's nothing more to
@@ -8536,7 +8536,7 @@ void zebra_vxlan_remote_vtep_add(ZAPI_HANDLER_ARGS)
 		zif = ifp->info;
 
 		/* If down or not mapped to a bridge, we're done. */
-		if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+		if (!if_is_operative(ifp) || !zif->brsecondary_info.br_if)
 			continue;
 
 		zvtep = zvni_vtep_find(zvni, &vtep_ip);
@@ -8966,7 +8966,7 @@ int zebra_vxlan_if_up(struct interface *ifp)
 
 		assert(zvni->vxlan_if == ifp);
 		vlan_if = zvni_map_to_svi(vxl->access_vlan,
-					  zif->brslave_info.br_if);
+					  zif->brsecondary_info.br_if);
 		if (vlan_if) {
 			zvni->vrf_id = vlan_if->vrf_id;
 			zl3vni = zl3vni_from_vrf(vlan_if->vrf_id);
@@ -8976,7 +8976,7 @@ int zebra_vxlan_if_up(struct interface *ifp)
 
 		/* If part of a bridge, inform BGP about this VNI. */
 		/* Also, read and populate local MACs and neighbors. */
-		if (zif->brslave_info.br_if) {
+		if (zif->brsecondary_info.br_if) {
 			zvni_send_add_to_client(zvni);
 			zvni_read_mac_neigh(zvni, ifp);
 		}
@@ -9089,11 +9089,11 @@ int zebra_vxlan_if_update(struct interface *ifp, uint16_t chgflags)
 				"Update L3-VNI %u intf %s(%u) VLAN %u local IP %s master %u chg 0x%x",
 				vni, ifp->name, ifp->ifindex, vxl->access_vlan,
 				inet_ntoa(vxl->vtep_ip),
-				zif->brslave_info.bridge_ifindex, chgflags);
+				zif->brsecondary_info.bridge_ifindex, chgflags);
 
 		/* Removed from bridge? Cleanup and return */
 		if ((chgflags & ZEBRA_VXLIF_MASTER_CHANGE)
-		    && (zif->brslave_info.bridge_ifindex == IFINDEX_INTERNAL)) {
+		    && (zif->brsecondary_info.bridge_ifindex == IFINDEX_INTERNAL)) {
 			zebra_vxlan_process_l3vni_oper_down(zl3vni);
 			return 0;
 		}
@@ -9153,11 +9153,11 @@ int zebra_vxlan_if_update(struct interface *ifp, uint16_t chgflags)
 				"Update L2-VNI %u intf %s(%u) VLAN %u local IP %s master %u chg 0x%x",
 				vni, ifp->name, ifp->ifindex, vxl->access_vlan,
 				inet_ntoa(vxl->vtep_ip),
-				zif->brslave_info.bridge_ifindex, chgflags);
+				zif->brsecondary_info.bridge_ifindex, chgflags);
 
 		/* Removed from bridge? Cleanup and return */
 		if ((chgflags & ZEBRA_VXLIF_MASTER_CHANGE)
-		    && (zif->brslave_info.bridge_ifindex == IFINDEX_INTERNAL)) {
+		    && (zif->brsecondary_info.bridge_ifindex == IFINDEX_INTERNAL)) {
 			/* Delete from client, remove all remote VTEPs */
 			/* Also, free up all MACs and neighbors. */
 			zvni_send_del_to_client(zvni->vni);
@@ -9190,7 +9190,7 @@ int zebra_vxlan_if_update(struct interface *ifp, uint16_t chgflags)
 		 * Note that if we are here, there is a change of interest.
 		 */
 		/* If down or not mapped to a bridge, we're done. */
-		if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+		if (!if_is_operative(ifp) || !zif->brsecondary_info.br_if)
 			return 0;
 
 		/* Inform BGP, if there is a change of interest. */
@@ -9257,7 +9257,7 @@ int zebra_vxlan_if_add(struct interface *ifp)
 				"Add L3-VNI %u intf %s(%u) VLAN %u local IP %s master %u",
 				vni, ifp->name, ifp->ifindex, vxl->access_vlan,
 				inet_ntoa(vxl->vtep_ip),
-				zif->brslave_info.bridge_ifindex);
+				zif->brsecondary_info.bridge_ifindex);
 
 		/* associate with vxlan_if */
 		zl3vni->local_vtep_ip = vxl->vtep_ip;
@@ -9299,7 +9299,7 @@ int zebra_vxlan_if_add(struct interface *ifp)
 		}
 		zvni->vxlan_if = ifp;
 		vlan_if = zvni_map_to_svi(vxl->access_vlan,
-					  zif->brslave_info.br_if);
+					  zif->brsecondary_info.br_if);
 		if (vlan_if) {
 			zvni->vrf_id = vlan_if->vrf_id;
 			zl3vni = zl3vni_from_vrf(vlan_if->vrf_id);
@@ -9323,11 +9323,11 @@ int zebra_vxlan_if_add(struct interface *ifp)
 					: VRF_DEFAULT_NAME,
 				ifp->name, ifp->ifindex, vxl->access_vlan,
 				addr_buf1, addr_buf2,
-				zif->brslave_info.bridge_ifindex);
+				zif->brsecondary_info.bridge_ifindex);
 		}
 
 		/* If down or not mapped to a bridge, we're done. */
-		if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+		if (!if_is_operative(ifp) || !zif->brsecondary_info.br_if)
 			return 0;
 
 		/* Inform BGP */
@@ -9618,12 +9618,12 @@ void zebra_vxlan_advertise_svi_macip(ZAPI_HANDLER_ARGS)
 		zif = ifp->info;
 
 		/* If down or not mapped to a bridge, we're done. */
-		if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+		if (!if_is_operative(ifp) || !zif->brsecondary_info.br_if)
 			return;
 
 		zl2_info = zif->l2info.vxl;
 		vlan_if = zvni_map_to_svi(zl2_info.access_vlan,
-					  zif->brslave_info.br_if);
+					  zif->brsecondary_info.br_if);
 		if (!vlan_if)
 			return;
 
@@ -9687,13 +9687,13 @@ void zebra_vxlan_advertise_subnet(ZAPI_HANDLER_ARGS)
 	zif = ifp->info;
 
 	/* If down or not mapped to a bridge, we're done. */
-	if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+	if (!if_is_operative(ifp) || !zif->brsecondary_info.br_if)
 		return;
 
 	zl2_info = zif->l2info.vxl;
 
 	vlan_if =
-		zvni_map_to_svi(zl2_info.access_vlan, zif->brslave_info.br_if);
+		zvni_map_to_svi(zl2_info.access_vlan, zif->brsecondary_info.br_if);
 	if (!vlan_if)
 		return;
 
@@ -9777,13 +9777,13 @@ void zebra_vxlan_advertise_gw_macip(ZAPI_HANDLER_ARGS)
 		zif = ifp->info;
 
 		/* If down or not mapped to a bridge, we're done. */
-		if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+		if (!if_is_operative(ifp) || !zif->brsecondary_info.br_if)
 			return;
 
 		zl2_info = zif->l2info.vxl;
 
 		vlan_if = zvni_map_to_svi(zl2_info.access_vlan,
-					  zif->brslave_info.br_if);
+					  zif->brsecondary_info.br_if);
 		if (!vlan_if)
 			return;
 


### PR DESCRIPTION
Many organization and projetcs are moving toward dropping the
use of racially loaded terms in software. The use of the word
"slave" was more or less consistent in FRR  sources. This change
drops it in favor of the word "secondary". We have a more
diverse use of the word "master" such as a thread name,
git branch name, in addition to the more traditional technical
use of the term. We will have to decide on how we want to
approach that.

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>