### PR TITLE
topotests: stabilize bfd-vrf-topo1

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -207,15 +207,9 @@ static void bgp_bfd_update_peer(struct peer *peer)
  */
 void bgp_bfd_reset_peer(struct peer *peer)
 {
-	struct bfd_info *bfd_info;
-
 	if (!peer->bfd_info)
 		return;
-	bfd_info = (struct bfd_info *)peer->bfd_info;
 
-	/* if status is not down, reset bfd */
-	if (bfd_info->status != BFD_STATUS_DOWN)
-		bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_DEREGISTER);
 	bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_REGISTER);
 }
 

--- a/tests/topotests/bfd-vrf-topo1/test_bfd_vrf_topo1.py
+++ b/tests/topotests/bfd-vrf-topo1/test_bfd_vrf_topo1.py
@@ -129,14 +129,6 @@ def setup_module(mod):
     # Initialize all routers.
     tgen.start_router()
 
-    # Verify that we are using the proper version and that the BFD
-    # daemon exists.
-    for router in router_list.values():
-        # Check for Version
-        if router.has_version("<", "5.1"):
-            tgen.set_error("Unsupported FRR version")
-            break
-
 
 def teardown_module(_mod):
     "Teardown the pytest environment"

--- a/tests/topotests/bfd-vrf-topo1/test_bfd_vrf_topo1.py
+++ b/tests/topotests/bfd-vrf-topo1/test_bfd_vrf_topo1.py
@@ -168,7 +168,7 @@ def test_bfd_connection():
         test_func = partial(
             topotest.router_json_cmp, router, "show bfd peers json", expected
         )
-        _, result = topotest.run_and_expect(test_func, None, count=8, wait=0.5)
+        _, result = topotest.run_and_expect(test_func, None, count=16, wait=1)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 
@@ -212,7 +212,7 @@ def test_bgp_fast_convergence():
             "show ip bgp vrf {}-cust1 json".format(router.name),
             expected,
         )
-        _, res = topotest.run_and_expect(test_func, None, count=40, wait=0.5)
+        _, res = topotest.run_and_expect(test_func, None, count=40, wait=1)
         assertmsg = "{}: bgp did not converge".format(router.name)
         assert res is None, assertmsg
 
@@ -254,7 +254,7 @@ def test_bfd_fast_convergence():
         test_func = partial(
             topotest.router_json_cmp, router, "show bfd peers json", expected
         )
-        _, res = topotest.run_and_expect(test_func, None, count=20, wait=0.5)
+        _, res = topotest.run_and_expect(test_func, None, count=40, wait=1)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert res is None, assertmsg
 
@@ -287,7 +287,7 @@ def test_bgp_fast_reconvergence():
             "show ip bgp vrf {}-cust1 json".format(router.name),
             expected,
         )
-        _, res = topotest.run_and_expect(test_func, None, count=3, wait=1)
+        _, res = topotest.run_and_expect(test_func, None, count=16, wait=1)
         assertmsg = "{}: bgp did not converge".format(router.name)
         assert res is None, assertmsg
 


### PR DESCRIPTION
## Summary

This PR is an attempt to fix the recent BFD VRF topology failures.

Fixes #6605 .

Looking at the log files I can see this:

**bgpd**

```
2020/06/18 07:59:36 BGP: [EC 33554465] 192.168.0.1 [FSM] Ignoring event BGP_Start in state Connect, prior events BGP_Start, BGP_Start, fd 23
2020/06/18 07:59:36 BGP: [EC 33554451] bgp_process_packet: BGP OPEN receipt failed for peer: 192.168.0.1
2020/06/18 07:59:36 BGP: [EC 33554465] 192.168.0.1 [FSM] Ignoring event BGP_Start in state Connect, prior events BGP_Start, BGP_Start, fd 22
2020/06/18 07:59:36 BGP: [EC 33554451] bgp_process_packet: BGP OPEN receipt failed for peer: 192.168.0.1
2020/06/18 07:59:36 BGP: [EC 33554454] 192.168.0.1 [Error] bgp_read_packet error: Connection reset by peer
2020/06/18 07:59:37 BGP: [EC 33554465] 192.168.0.1 [FSM] Ignoring event BGP_Start in state Connect, prior events BGP_Start, BGP_Start, fd 22
2020/06/18 07:59:37 BGP: [EC 33554451] bgp_process_packet: BGP OPEN receipt failed for peer: 192.168.0.1
2020/06/18 07:59:37 BGP: [EC 33554465] 192.168.0.1 [FSM] Ignoring event BGP_Start in state Connect, prior events BGP_Start, BGP_Start, fd 23
2020/06/18 07:59:37 BGP: [EC 33554465] 192.168.0.1 [FSM] Ignoring event BGP_Start in state Connect, prior events BGP_Start, BGP_Start, fd 23
```

**bfdd**

```
2020/06/18 07:59:36 BFD:  peer 192.168.0.1 found, but ifp r2-eth0 ignored
2020/06/18 07:59:36 BFD:  peer 192.168.0.1 found, but ifp r2-eth0 and loc-addr 0.0.0.0 ignored
2020/06/18 07:59:36 BFD:  peer 192.168.0.1 found, but ifp r2-eth0 and loc-addr 0.0.0.0 ignored
2020/06/18 07:59:37 BFD: state-change: [mhop:no peer:192.168.0.1 local:0.0.0.0 vrf:r2-cust1] init -> up
2020/06/18 07:59:37 BFD: ptm-del-dest: deregister peer [mhop:no peer:192.168.0.1 vrf:r2-cust1 cbit:0x01]
2020/06/18 07:59:37 BFD:  peer 192.168.0.1 found, but ifp r2-eth0 ignored
2020/06/18 07:59:37 BFD: ptm-del-session: [mhop:no peer:192.168.0.1 local:0.0.0.0 vrf:r2-cust1] refcount=1
2020/06/18 07:59:37 BFD: session-delete: mhop:no peer:192.168.0.1 local:0.0.0.0 vrf:r2-cust1
2020/06/18 07:59:37 BFD: ptm-add-dest: register peer [mhop:no peer:192.168.0.1 vrf:r2-cust1 cbit:0x01]
2020/06/18 07:59:37 BFD:  peer 192.168.0.1 found, but ifp r2-eth0 ignored
2020/06/18 07:59:37 BFD:  peer 192.168.0.1 found, but ifp r2-eth0 and loc-addr 0.0.0.0 ignored
2020/06/18 07:59:37 BFD:  peer 192.168.0.1 found, but ifp r2-eth0 and loc-addr 0.0.0.0 ignored
2020/06/18 07:59:37 BFD:  peer 192.168.1.1 found, but ifp r2-eth1 and loc-addr 0.0.0.0 ignored
2020/06/18 07:59:37 BFD: ptm-del-dest: deregister peer [mhop:no peer:192.168.1.1 vrf:r2-cust1 cbit:0x01]
2020/06/18 07:59:37 BFD:  peer 192.168.1.1 found, but ifp r2-eth1 ignored
2020/06/18 07:59:37 BFD: ptm-del-dest: failed to find BFD session
2020/06/18 07:59:37 BFD: session-delete: mhop:no peer:192.168.1.1 local:0.0.0.0 vrf:r2-cust1
2020/06/18 07:59:37 BFD: ptm-add-dest: register peer [mhop:no peer:192.168.1.1 vrf:r2-cust1 cbit:0x01]
2020/06/18 07:59:37 BFD:  peer 192.168.1.1 found, but ifp r2-eth1 ignored
2020/06/18 07:59:37 BFD: state-change: [mhop:no peer:192.168.0.1 local:0.0.0.0 vrf:r2-cust1] init -> up
2020/06/18 07:59:37 BFD: ptm-del-dest: deregister peer [mhop:no peer:192.168.0.1 vrf:r2-cust1 cbit:0x01]
```

`bfdd` keeps receiving registration and unregistration messages.

Investigating the code a little bit I've found this:

```c
/**
 * Transition to Established state.
 *
 * Convert peer from stub to full fledged peer, set some timers, and generate
 * initial updates.
 */
static int bgp_establish(struct peer *peer)
{
  // ... tons of code here
	bgp_bfd_reset_peer(peer);
	return ret;
}
```

( https://github.com/FRRouting/frr/blob/master/bgpd/bgp_fsm.c#L1978 )


And that function does the following:

```c
/**
 * bgp_bfd_reset_peer - reinitialise bfd
 * ensures that bfd state machine is restarted
 * to be synced with remote bfd
 */
void bgp_bfd_reset_peer(struct peer *peer)
{
	struct bfd_info *bfd_info;

	if (!peer->bfd_info)
		return;
	bfd_info = (struct bfd_info *)peer->bfd_info;

	/* if status is not down, reset bfd */
	if (bfd_info->status != BFD_STATUS_DOWN)
		bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_DEREGISTER);
	bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_REGISTER);
}
```

( https://github.com/FRRouting/frr/blob/master/bgpd/bgp_bfd.c#L208 )

I just commented the `DEREGISTER` part in this PR, but I feel this might not be the correct solution.

Please, feel free to edit the PR to include the proper solution or open another one.