### PR TITLE
pbrd: Interface existence is not enough to install rule

### DIFF
--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -292,7 +292,10 @@ void pbr_map_policy_interface_update(const struct interface *ifp, bool state_up)
 	 */
 	for (ALL_LIST_ELEMENTS_RO(pbrm->seqnumbers, node, pbrms))
 		for (ALL_LIST_ELEMENTS_RO(pbrm->incoming, inode, pmi))
-			if (pmi->ifp == ifp && pbr_map_interface_is_valid(pmi))
+			if ((pbrms->vrf_unchanged || pbrms->vrf_lookup
+			     || pbrms->nhgrp_name || pbrms->nhg)
+			    && (pmi->ifp == ifp
+				&& pbr_map_interface_is_valid(pmi)))
 				pbr_send_pbr_map(pbrms, pmi, state_up, true);
 }
 


### PR DESCRIPTION
If we receive a callback for an interface coming up event
*and* we have a partially installed pbrms we were just
blindly installing the rules into the kernel.  This
was leading to situations where zebra was receiving
a message that was not fully encoded since we were
not sending down a table to have the rule act on.
This not fully encoded message was being droped
with a EC error about stream not being long enough.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>