### PR TITLE
tools: 'evpn mh' is a new one-line context

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -504,7 +504,8 @@ end
                                 "table ",
                                 "username ",
                                 "zebra ",
-                                "vrrp autoconfigure")
+                                "vrrp autoconfigure",
+                                "evpn mh")
 
         for line in self.lines:
 


### PR DESCRIPTION
frr-reload.py needs to know about config-level commands, otherwise it
assumes they are contexts

note, this can go in separately from the actual multihoming prs. If requested we can get it into that branch 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>