### PR TITLE
build: assorted fixes (protobuf, frr-format)

### DIFF
--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -20,15 +20,16 @@
  * 02110-1301 USA.
  */
 
+#include "zebra.h"
 #include "northbound.h"
 #include "prefix.h"
-#include "zebra.h"
 
 #include "lib/command.h"
 #include "lib/filter.h"
 #include "lib/northbound_cli.h"
 #include "lib/plist.h"
 #include "lib/plist_int.h"
+#include "lib/printfrr.h"
 
 #ifndef VTYSH_EXTRACT_PL
 #include "lib/filter_cli_clippy.c"
@@ -197,11 +198,11 @@ DEFPY(
 	if (seq_str == NULL) {
 		/* Use XPath to find the next sequence number. */
 		sseq = acl_get_seq(vty, xpath);
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	} else
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%s']", xpath, seq_str);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%s']", xpath, seq_str);
 
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_CREATE, NULL);
 
@@ -270,8 +271,8 @@ DEFPY(
 	if (sseq == -1)
 		return CMD_WARNING;
 
-	snprintf(xpath_entry, sizeof(xpath_entry),
-		 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+	snprintfrr(xpath_entry, sizeof(xpath_entry),
+		   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -312,11 +313,11 @@ DEFPY(
 	if (seq_str == NULL) {
 		/* Use XPath to find the next sequence number. */
 		sseq = acl_get_seq(vty, xpath);
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	} else
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%s']", xpath, seq_str);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%s']", xpath, seq_str);
 
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_CREATE, NULL);
 
@@ -376,7 +377,7 @@ DEFPY(
 
 	/* If the user provided sequence number, then just go for it. */
 	if (seq_str != NULL) {
-		snprintf(
+		snprintfrr(
 			xpath, sizeof(xpath),
 			"/frr-filter:lib/access-list-legacy[number='%s']/entry[sequence='%s']",
 			number_str, seq_str);
@@ -421,8 +422,8 @@ DEFPY(
 	if (sseq == -1)
 		return CMD_WARNING;
 
-	snprintf(xpath_entry, sizeof(xpath_entry),
-		 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+	snprintfrr(xpath_entry, sizeof(xpath_entry),
+		   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -577,11 +578,11 @@ DEFPY(
 	if (seq_str == NULL) {
 		/* Use XPath to find the next sequence number. */
 		sseq = acl_get_seq(vty, xpath);
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	} else
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%s']", xpath, seq_str);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%s']", xpath, seq_str);
 
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_CREATE, NULL);
 
@@ -648,8 +649,8 @@ DEFPY(
 	if (sseq == -1)
 		return CMD_WARNING;
 
-	snprintf(xpath_entry, sizeof(xpath_entry),
-		 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+	snprintfrr(xpath_entry, sizeof(xpath_entry),
+		   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -748,11 +749,11 @@ DEFPY(
 	if (seq_str == NULL) {
 		/* Use XPath to find the next sequence number. */
 		sseq = acl_get_seq(vty, xpath);
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	} else
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%s']", xpath, seq_str);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%s']", xpath, seq_str);
 
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_CREATE, NULL);
 
@@ -820,8 +821,8 @@ DEFPY(
 	if (sseq == -1)
 		return CMD_WARNING;
 
-	snprintf(xpath_entry, sizeof(xpath_entry),
-		 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+	snprintfrr(xpath_entry, sizeof(xpath_entry),
+		   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -923,11 +924,11 @@ DEFPY(
 	if (seq_str == NULL) {
 		/* Use XPath to find the next sequence number. */
 		sseq = acl_get_seq(vty, xpath);
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	} else
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%s']", xpath, seq_str);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%s']", xpath, seq_str);
 
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_CREATE, NULL);
 
@@ -991,8 +992,8 @@ DEFPY(
 	if (sseq == -1)
 		return CMD_WARNING;
 
-	snprintf(xpath_entry, sizeof(xpath_entry),
-		 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+	snprintfrr(xpath_entry, sizeof(xpath_entry),
+		   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -1231,8 +1232,8 @@ static int plist_remove(struct vty *vty, const char *iptype, const char *name,
 	if (pentry == NULL)
 		return CMD_WARNING;
 
-	snprintf(xpath_entry, sizeof(xpath_entry),
-		 "%s/entry[sequence='%" PRId64 "']", xpath, pentry->seq);
+	snprintfrr(xpath_entry, sizeof(xpath_entry),
+		   "%s/entry[sequence='%" PRId64 "']", xpath, pentry->seq);
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_DESTROY, NULL);
 
 	rv = nb_cli_apply_changes(vty, NULL);
@@ -1271,11 +1272,11 @@ DEFPY(
 	if (seq_str == NULL) {
 		/* Use XPath to find the next sequence number. */
 		sseq = acl_get_seq(vty, xpath);
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	} else
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%s']", xpath, seq_str);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%s']", xpath, seq_str);
 
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_CREATE, NULL);
 
@@ -1431,11 +1432,11 @@ DEFPY(
 	if (seq_str == NULL) {
 		/* Use XPath to find the next sequence number. */
 		sseq = acl_get_seq(vty, xpath);
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
 	} else
-		snprintf(xpath_entry, sizeof(xpath_entry),
-			 "%s/entry[sequence='%s']", xpath, seq_str);
+		snprintfrr(xpath_entry, sizeof(xpath_entry),
+			   "%s/entry[sequence='%s']", xpath, seq_str);
 
 	nb_cli_enqueue_change(vty, xpath_entry, NB_OP_CREATE, NULL);
 

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -44,6 +44,7 @@ endif
 zebra_zebra_LDADD = lib/libfrr.la $(LIBCAP)
 if HAVE_PROTOBUF3
 zebra_zebra_LDADD += mlag/libmlag_pb.la $(PROTOBUF_C_LIBS)
+zebra/zebra_mlag.$(OBJEXT): mlag/mlag.pb-c.h
 endif
 zebra_zebra_SOURCES = \
 	zebra/connected.c \
@@ -188,8 +189,10 @@ zebra_zebra_fpm_la_SOURCES += zebra/zebra_fpm_netlink.c
 if HAVE_PROTOBUF
 zebra_zebra_fpm_la_LIBADD += fpm/libfrrfpm_pb.la qpb/libfrr_pb.la $(PROTOBUF_C_LIBS)
 zebra_zebra_fpm_la_SOURCES += zebra/zebra_fpm_protobuf.c
+zebra/zebra_fpm_protobuf.lo: fpm/fpm.pb-c.h qpb/qpb.pb-c.h
 if DEV_BUILD
 zebra_zebra_fpm_la_SOURCES += zebra/zebra_fpm_dt.c
+zebra/zebra_fpm_dt.lo: fpm/fpm.pb-c.h qpb/qpb.pb-c.h
 endif
 endif
 

--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -33,6 +33,10 @@
 #include "zebra/zapi_msg.h"
 #include "zebra/debug.h"
 
+#ifdef HAVE_PROTOBUF_VERSION_3
+#include "mlag/mlag.pb-c.h"
+#endif
+
 DEFINE_HOOK(zebra_mlag_private_write_data,
 	    (uint8_t *data, uint32_t len), (data, len))
 DEFINE_HOOK(zebra_mlag_private_monitor_state, (), ())

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -26,10 +26,6 @@
 #include "zclient.h"
 #include "zebra/zserv.h"
 
-#ifdef HAVE_PROTOBUF_VERSION_3
-#include "mlag/mlag.pb-c.h"
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Just a bunch of minor adjustments.

protobuf stuff was just missing dependencies in Makefile.

The `filter_cli.c` warnings only show up when using `--with-frr-format`, which I guess is only me :disappointed:

Fixes: #6576