### PR TITLE
ISIS VRF: Route info with vrf_id from ISIS to Zebra

### DIFF
--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -355,7 +355,7 @@ static void isis_route_update(struct isis_area *area, struct prefix *prefix,
 		if (CHECK_FLAG(route_info->flag, ISIS_ROUTE_FLAG_ZEBRA_SYNCED))
 			return;
 
-		isis_zebra_route_add_route(prefix, src_p, route_info);
+		isis_zebra_route_add_route(area->isis, prefix, src_p, route_info);
 		hook_call(isis_route_update_hook, area, prefix, route_info);
 
 		SET_FLAG(route_info->flag, ISIS_ROUTE_FLAG_ZEBRA_SYNCED);
@@ -364,7 +364,7 @@ static void isis_route_update(struct isis_area *area, struct prefix *prefix,
 		if (!CHECK_FLAG(route_info->flag, ISIS_ROUTE_FLAG_ZEBRA_SYNCED))
 			return;
 
-		isis_zebra_route_del_route(prefix, src_p, route_info);
+		isis_zebra_route_del_route(area->isis, prefix, src_p, route_info);
 		hook_call(isis_route_update_hook, area, prefix, route_info);
 
 		UNSET_FLAG(route_info->flag, ISIS_ROUTE_FLAG_ZEBRA_SYNCED);

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -157,7 +157,8 @@ static int isis_zebra_link_params(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-void isis_zebra_route_add_route(struct prefix *prefix,
+void isis_zebra_route_add_route(struct isis *isis,
+				struct prefix *prefix,
 				struct prefix_ipv6 *src_p,
 				struct isis_route_info *route_info)
 {
@@ -171,7 +172,7 @@ void isis_zebra_route_add_route(struct prefix *prefix,
 		return;
 
 	memset(&api, 0, sizeof(api));
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id = isis->vrf_id;
 	api.type = PROTO_TYPE;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *prefix;
@@ -194,7 +195,7 @@ void isis_zebra_route_add_route(struct prefix *prefix,
 		api_nh = &api.nexthops[count];
 		if (fabricd)
 			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
-		api_nh->vrf_id = VRF_DEFAULT;
+		api_nh->vrf_id = isis->vrf_id;
 
 		switch (nexthop->family) {
 		case AF_INET:
@@ -232,7 +233,8 @@ void isis_zebra_route_add_route(struct prefix *prefix,
 	zclient_route_send(ZEBRA_ROUTE_ADD, zclient, &api);
 }
 
-void isis_zebra_route_del_route(struct prefix *prefix,
+void isis_zebra_route_del_route(struct isis *isis,
+				struct prefix *prefix,
 				struct prefix_ipv6 *src_p,
 				struct isis_route_info *route_info)
 {
@@ -242,7 +244,7 @@ void isis_zebra_route_del_route(struct prefix *prefix,
 		return;
 
 	memset(&api, 0, sizeof(api));
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id = isis->vrf_id;
 	api.type = PROTO_TYPE;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *prefix;

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -22,6 +22,8 @@
 #ifndef _ZEBRA_ISIS_ZEBRA_H
 #define _ZEBRA_ISIS_ZEBRA_H
 
+#include "isisd.h"
+
 extern struct zclient *zclient;
 
 struct label_chunk {
@@ -38,10 +40,12 @@ struct isis_route_info;
 struct sr_prefix;
 struct sr_adjacency;
 
-void isis_zebra_route_add_route(struct prefix *prefix,
+void isis_zebra_route_add_route(struct isis *isis,
+				struct prefix *prefix,
 				struct prefix_ipv6 *src_p,
 				struct isis_route_info *route_info);
-void isis_zebra_route_del_route(struct prefix *prefix,
+void isis_zebra_route_del_route(struct isis *isis,
+				struct prefix *prefix,
 				struct prefix_ipv6 *src_p,
 				struct isis_route_info *route_info);
 void isis_zebra_send_prefix_sid(int cmd, const struct sr_prefix *srp);


### PR DESCRIPTION
1. The "VRF_DEFAULT" param is changed to "isis->vrf_id"  while
   sending the routes to zebra.

Signed-off-by: Kaushik <kaushik@niralnetworks.com>