### PR TITLE
ISIS VRF: ISIS Debug structure modifications Type 2

### DIFF
--- a/isisd/fabricd.c
+++ b/isisd/fabricd.c
@@ -543,7 +543,7 @@ static void move_to_queue(struct isis_lsp *lsp, struct neighbor_entry *n,
 	if (n->adj && n->adj->circuit == circuit)
 		return;
 
-	if (isis->debugs & DEBUG_FLOODING) {
+	if (IS_DEBUG_FLOODING) {
 		zlog_debug("OpenFabric: Adding %s to %s",
 			   print_sys_hostname(n->id),
 			   (type == TX_LSP_NORMAL) ? "RF" : "DNR");
@@ -576,7 +576,7 @@ static void handle_firsthops(struct hash_bucket *bucket, void *arg)
 
 	n = neighbor_entry_lookup_list(f->neighbors, vertex->N.id);
 	if (n) {
-		if (isis->debugs & DEBUG_FLOODING) {
+		if (IS_DEBUG_FLOODING) {
 			zlog_debug("Removing %s from NL as its in the reverse path",
 				   print_sys_hostname(n->id));
 		}
@@ -585,7 +585,7 @@ static void handle_firsthops(struct hash_bucket *bucket, void *arg)
 
 	n = neighbor_entry_lookup_hash(f->neighbors_neighbors, vertex->N.id);
 	if (n) {
-		if (isis->debugs & DEBUG_FLOODING) {
+		if (IS_DEBUG_FLOODING) {
 			zlog_debug("Removing %s from NN as its in the reverse path",
 				   print_sys_hostname(n->id));
 		}
@@ -673,7 +673,7 @@ void fabricd_lsp_flood(struct isis_lsp *lsp, struct isis_circuit *circuit)
 
 		struct isis_lsp *nlsp = lsp_for_neighbor(f, n);
 		if (!nlsp || !nlsp->tlvs) {
-			if (isis->debugs & DEBUG_FLOODING) {
+			if (IS_DEBUG_FLOODING) {
 				zlog_debug("Moving %s to DNR as it has no LSP",
 					   print_sys_hostname(n->id));
 			}
@@ -682,7 +682,7 @@ void fabricd_lsp_flood(struct isis_lsp *lsp, struct isis_circuit *circuit)
 			continue;
 		}
 
-		if (isis->debugs & DEBUG_FLOODING) {
+		if (IS_DEBUG_FLOODING) {
 			zlog_debug("Considering %s from NL...",
 				   print_sys_hostname(n->id));
 		}
@@ -699,7 +699,7 @@ void fabricd_lsp_flood(struct isis_lsp *lsp, struct isis_circuit *circuit)
 							er->id);
 
 			if (nn) {
-				if (isis->debugs & DEBUG_FLOODING) {
+				if (IS_DEBUG_FLOODING) {
 					zlog_debug("Found neighbor %s in NN, removing it from NN and setting reflood.",
 						   print_sys_hostname(nn->id));
 				}
@@ -714,7 +714,7 @@ void fabricd_lsp_flood(struct isis_lsp *lsp, struct isis_circuit *circuit)
 			      circuit);
 	}
 
-	if (isis->debugs & DEBUG_FLOODING) {
+	if (IS_DEBUG_FLOODING) {
 		zlog_debug("OpenFabric: Flooding algorithm complete.");
 	}
 }

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -229,7 +229,7 @@ void isis_adj_process_threeway(struct isis_adjacency *adj,
 	}
 
 	if (next_tw_state != adj->threeway_state) {
-		if (isis->debugs & DEBUG_ADJ_PACKETS) {
+		if (IS_DEBUG_ADJ_PACKETS) {
 			zlog_info("ISIS-Adj (%s): Threeway state change %s to %s",
 				  adj->circuit->area->area_tag,
 				  isis_threeway_state_name(adj->threeway_state),
@@ -274,7 +274,7 @@ void isis_adj_state_change(struct isis_adjacency **padj,
 	adj->adj_state = new_state;
 	send_hello_sched(circuit, adj->level, TRIGGERED_IIH_DELAY);
 
-	if (isis->debugs & DEBUG_ADJ_PACKETS) {
+	if (IS_DEBUG_ADJ_PACKETS) {
 		zlog_debug("ISIS-Adj (%s): Adjacency state change %d->%d: %s",
 			   circuit->area->area_tag, old_state, new_state,
 			   reason ? reason : "unspecified");

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -122,7 +122,7 @@ static void bfd_adj_event(struct isis_adjacency *adj, struct prefix *dst,
 	if (old_status == new_status)
 		return;
 
-	if (isis->debugs & DEBUG_BFD) {
+	if (IS_DEBUG_BFD) {
 		char dst_str[INET6_ADDRSTRLEN];
 
 		inet_ntop(adj->bfd_session->family, &adj->bfd_session->dst_ip,
@@ -152,7 +152,7 @@ static int isis_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
 	if (!ifp || (dst_ip.family != AF_INET && dst_ip.family != AF_INET6))
 		return 0;
 
-	if (isis->debugs & DEBUG_BFD) {
+	if (IS_DEBUG_BFD) {
 		char dst_buf[INET6_ADDRSTRLEN];
 
 		inet_ntop(dst_ip.family, &dst_ip.u.prefix, dst_buf,
@@ -194,7 +194,7 @@ static int isis_bfd_nbr_replay(ZAPI_CALLBACK_ARGS)
 	struct listnode *anode;
 	struct isis_area *area;
 
-	if (isis->debugs & DEBUG_BFD)
+	if (IS_DEBUG_BFD)
 		zlog_debug("ISIS-BFD: Got neighbor replay request, resending neighbors.");
 
 	for (ALL_LIST_ELEMENTS_RO(isis->area_list, anode, area)) {
@@ -205,7 +205,7 @@ static int isis_bfd_nbr_replay(ZAPI_CALLBACK_ARGS)
 			isis_bfd_circuit_cmd(circuit, ZEBRA_BFD_DEST_UPDATE);
 	}
 
-	if (isis->debugs & DEBUG_BFD)
+	if (IS_DEBUG_BFD)
 		zlog_debug("ISIS-BFD: Done with replay.");
 
 	return 0;
@@ -223,7 +223,7 @@ static void isis_bfd_zebra_connected(struct zclient *zclient)
 static void bfd_debug(int family, union g_addr *dst, union g_addr *src,
 		      const char *interface, int command)
 {
-	if (!(isis->debugs & DEBUG_BFD))
+	if (!(IS_DEBUG_BFD))
 		return;
 
 	char dst_str[INET6_ADDRSTRLEN];

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -469,7 +469,7 @@ void isis_circuit_if_add(struct isis_circuit *circuit, struct interface *ifp)
 		circuit->is_passive = 1;
 	} else {
 		/* It's normal in case of loopback etc. */
-		if (isis->debugs & DEBUG_EVENTS)
+		if (IS_DEBUG_EVENTS)
 			zlog_debug("isis_circuit_if_add: unsupported media");
 		circuit->circ_type = CIRCUIT_T_UNKNOWN;
 	}

--- a/isisd/isis_csm.c
+++ b/isisd/isis_csm.c
@@ -68,7 +68,7 @@ isis_csm_state_change(int event, struct isis_circuit *circuit, void *arg)
 	int old_state;
 
 	old_state = circuit ? circuit->state : C_STATE_NA;
-	if (isis->debugs & DEBUG_EVENTS)
+	if (IS_DEBUG_EVENTS)
 		zlog_debug("CSM_EVENT: %s", EVENT2STR(event));
 
 	switch (old_state) {
@@ -190,7 +190,7 @@ isis_csm_state_change(int event, struct isis_circuit *circuit, void *arg)
 		zlog_warn("Invalid circuit state %d", old_state);
 	}
 
-	if (isis->debugs & DEBUG_EVENTS)
+	if (IS_DEBUG_EVENTS)
 		zlog_debug("CSM_STATE_CHANGE: %s -> %s ", STATE2STR(old_state),
 			   circuit ? STATE2STR(circuit->state)
 				   : STATE2STR(C_STATE_NA));

--- a/isisd/isis_dr.c
+++ b/isisd/isis_dr.c
@@ -264,7 +264,7 @@ int isis_dr_commence(struct isis_circuit *circuit, int level)
 {
 	uint8_t old_dr[ISIS_SYS_ID_LEN + 2];
 
-	if (isis->debugs & DEBUG_EVENTS)
+	if (IS_DEBUG_EVENTS)
 		zlog_debug("isis_dr_commence l%d", level);
 
 	/* Lets keep a pause in DR election */

--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -62,7 +62,7 @@ void isis_event_circuit_state_change(struct isis_circuit *circuit,
 {
 	area->circuit_state_changes++;
 
-	if (isis->debugs & DEBUG_EVENTS)
+	if (IS_DEBUG_EVENTS)
 		zlog_debug("ISIS-Evt (%s) circuit %s", area->area_tag,
 			   up ? "up" : "down");
 
@@ -128,7 +128,7 @@ void isis_circuit_is_type_set(struct isis_circuit *circuit, int newtype)
 		return;
 	}
 
-	if (isis->debugs & DEBUG_EVENTS)
+	if (IS_DEBUG_EVENTS)
 		zlog_debug("ISIS-Evt (%s) circuit type change %s -> %s",
 			   circuit->area->area_tag,
 			   circuit_t2string(circuit->is_type),
@@ -208,7 +208,7 @@ int isis_event_dis_status_change(struct thread *thread)
 	/* invalid arguments */
 	if (!circuit || !circuit->area)
 		return 0;
-	if (isis->debugs & DEBUG_EVENTS)
+	if (IS_DEBUG_EVENTS)
 		zlog_debug("ISIS-Evt (%s) DIS status change",
 			   circuit->area->area_tag);
 
@@ -221,7 +221,7 @@ int isis_event_dis_status_change(struct thread *thread)
 void isis_event_auth_failure(char *area_tag, const char *error_string,
 			     uint8_t *sysid)
 {
-	if (isis->debugs & DEBUG_EVENTS)
+	if (IS_DEBUG_EVENTS)
 		zlog_debug("ISIS-Evt (%s) Authentication failure %s from %s",
 			   area_tag, error_string, sysid_print(sysid));
 

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -198,7 +198,7 @@ int lsp_compare(char *areatag, struct isis_lsp *lsp, uint32_t seqno,
 	if (lsp->hdr.seqno == seqno && lsp->hdr.checksum == checksum
 	    && ((lsp->hdr.rem_lifetime == 0 && rem_lifetime == 0)
 		|| (lsp->hdr.rem_lifetime != 0 && rem_lifetime != 0))) {
-		if (isis->debugs & DEBUG_SNP_PACKETS) {
+		if (IS_DEBUG_SNP_PACKETS) {
 			zlog_debug(
 				"ISIS-Snp (%s): Compare LSP %s seq 0x%08" PRIx32
 				", cksum 0x%04" PRIx16 ", lifetime %" PRIu16
@@ -232,7 +232,7 @@ int lsp_compare(char *areatag, struct isis_lsp *lsp, uint32_t seqno,
 		&& ((lsp->hdr.rem_lifetime != 0 && rem_lifetime == 0)
 		    || (lsp->hdr.checksum != checksum
 			&& lsp->hdr.rem_lifetime)))) {
-		if (isis->debugs & DEBUG_SNP_PACKETS) {
+		if (IS_DEBUG_SNP_PACKETS) {
 			zlog_debug(
 				"ISIS-Snp (%s): Compare LSP %s seq 0x%08" PRIx32
 				", cksum 0x%04" PRIx16 ", lifetime %" PRIu16
@@ -248,7 +248,7 @@ int lsp_compare(char *areatag, struct isis_lsp *lsp, uint32_t seqno,
 		}
 		return LSP_NEWER;
 	}
-	if (isis->debugs & DEBUG_SNP_PACKETS) {
+	if (IS_DEBUG_SNP_PACKETS) {
 		zlog_debug("ISIS-Snp (%s): Compare LSP %s seq 0x%08" PRIx32
 			   ", cksum 0x%04" PRIx16 ", lifetime %" PRIu16 "s",
 			   areatag, rawlspid_print(lsp->hdr.lsp_id), seqno,
@@ -548,7 +548,7 @@ struct isis_lsp *lsp_new(struct isis_area *area, uint8_t *lsp_id,
 	lsp_link_fragment(lsp, lsp0);
 	put_lsp_hdr(lsp, NULL, false);
 
-	if (isis->debugs & DEBUG_EVENTS)
+	if (IS_DEBUG_EVENTS)
 		zlog_debug("New LSP with ID %s-%02x-%02x len %d seqnum %08x",
 			   sysid_print(lsp_id), LSP_PSEUDO_ID(lsp->hdr.lsp_id),
 			   LSP_FRAGMENT(lsp->hdr.lsp_id), lsp->hdr.pdu_len,
@@ -1246,7 +1246,7 @@ int lsp_generate(struct isis_area *area, int level)
 			 &area->lsp_refresh_arg[level - 1], refresh_time,
 			 &area->t_lsp_refresh[level - 1]);
 
-	if (isis->debugs & DEBUG_UPDATE_PACKETS) {
+	if (IS_DEBUG_UPDATE_PACKETS) {
 		zlog_debug("ISIS-Upd (%s): Building L%d LSP %s, len %" PRIu16
 			   ", seq 0x%08" PRIx32 ", cksum 0x%04" PRIx16
 			   ", lifetime %" PRIu16 "s refresh %" PRIu16 "s",
@@ -1330,7 +1330,7 @@ static int lsp_regenerate(struct isis_area *area, int level)
 			 &area->t_lsp_refresh[level - 1]);
 	area->lsp_regenerate_pending[level - 1] = 0;
 
-	if (isis->debugs & DEBUG_UPDATE_PACKETS) {
+	if (IS_DEBUG_UPDATE_PACKETS) {
 		zlog_debug(
 			"ISIS-Upd (%s): Refreshed our L%d LSP %s, len %" PRIu16
 			", seq 0x%08" PRIx32 ", cksum 0x%04" PRIx16
@@ -1629,7 +1629,7 @@ int lsp_generate_pseudo(struct isis_circuit *circuit, int level)
 			master, lsp_l2_refresh_pseudo, circuit, refresh_time,
 			&circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
 
-	if (isis->debugs & DEBUG_UPDATE_PACKETS) {
+	if (IS_DEBUG_UPDATE_PACKETS) {
 		zlog_debug(
 			"ISIS-Upd (%s): Built L%d Pseudo LSP %s, len %" PRIu16
 			", seq 0x%08" PRIx32 ", cksum 0x%04" PRIx16
@@ -1686,7 +1686,7 @@ static int lsp_regenerate_pseudo(struct isis_circuit *circuit, int level)
 			master, lsp_l2_refresh_pseudo, circuit, refresh_time,
 			&circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
 
-	if (isis->debugs & DEBUG_UPDATE_PACKETS) {
+	if (IS_DEBUG_UPDATE_PACKETS) {
 		zlog_debug(
 			"ISIS-Upd (%s): Refreshed L%d Pseudo LSP %s, len %" PRIu16
 			", seq 0x%08" PRIx32 ", cksum 0x%04" PRIx16
@@ -2013,7 +2013,7 @@ void lsp_set_all_srmflags(struct isis_lsp *lsp, bool set)
 void _lsp_flood(struct isis_lsp *lsp, struct isis_circuit *circuit,
 		const char *func, const char *file, int line)
 {
-	if (isis->debugs & DEBUG_FLOODING) {
+	if (IS_DEBUG_FLOODING) {
 		zlog_debug("Flooding LSP %s%s%s (From %s %s:%d)",
 			   rawlspid_print(lsp->hdr.lsp_id),
 			   circuit ? " except on " : "",

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -216,7 +216,7 @@ int isis_instance_area_address_destroy(struct nb_cb_destroy_args *args)
 	if (listcount(area->area_addrs) == 0) {
 		memset(isis->sysid, 0, ISIS_SYS_ID_LEN);
 		isis->sysid_set = 0;
-		if (isis->debugs & DEBUG_EVENTS)
+		if (IS_DEBUG_EVENTS)
 			zlog_debug("Router has no SystemID");
 	}
 
@@ -1430,13 +1430,13 @@ int isis_instance_segment_routing_enabled_modify(
 	area->srdb.config.enabled = yang_dnode_get_bool(args->dnode, NULL);
 
 	if (area->srdb.config.enabled) {
-		if (IS_DEBUG_ISIS(DEBUG_EVENTS))
+		if (IS_DEBUG_EVENTS)
 			zlog_debug("SR: Segment Routing: OFF -> ON");
 
 		if (isis_sr_start(area) == 0)
 			area->srdb.enabled = true;
 	} else {
-		if (IS_DEBUG_ISIS(DEBUG_EVENTS))
+		if (IS_DEBUG_EVENTS)
 			zlog_debug("SR: Segment Routing: ON -> OFF");
 
 		isis_sr_stop(area);

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -130,7 +130,7 @@ static int process_p2p_hello(struct iih_info *iih)
 	struct isis_threeway_adj *tw_adj = iih->tlvs->threeway_adj;
 	if (tw_adj) {
 		if (tw_adj->state > ISIS_THREEWAY_DOWN) {
-			if (isis->debugs & DEBUG_ADJ_PACKETS) {
+			if (IS_DEBUG_ADJ_PACKETS) {
 				zlog_debug("ISIS-Adj (%s): Rcvd P2P IIH from (%s) with invalid three-way state: %d",
 					   iih->circuit->area->area_tag,
 					   iih->circuit->interface->name,
@@ -143,7 +143,7 @@ static int process_p2p_hello(struct iih_info *iih)
 		    && (memcmp(tw_adj->neighbor_id, isis->sysid, ISIS_SYS_ID_LEN)
 			|| tw_adj->neighbor_circuit_id != (uint32_t) iih->circuit->idx)) {
 
-			if (isis->debugs & DEBUG_ADJ_PACKETS) {
+			if (IS_DEBUG_ADJ_PACKETS) {
 				zlog_debug("ISIS-Adj (%s): Rcvd P2P IIH from (%s) which lists IS/Circuit different from us as neighbor.",
 					   iih->circuit->area->area_tag,
 					   iih->circuit->interface->name);
@@ -425,7 +425,7 @@ static int process_p2p_hello(struct iih_info *iih)
 		}
 	}
 
-	if (isis->debugs & DEBUG_ADJ_PACKETS) {
+	if (IS_DEBUG_ADJ_PACKETS) {
 		zlog_debug(
 			"ISIS-Adj (%s): Rcvd P2P IIH from (%s), cir type %s,"
 			" cir id %hhu, length %" PRIu16,
@@ -522,7 +522,7 @@ static int process_lan_hello(struct iih_info *iih)
 	if (adj->adj_state == ISIS_ADJ_UP && changed)
 		lsp_regenerate_schedule(adj->circuit->area, iih->level, 0);
 
-	if (isis->debugs & DEBUG_ADJ_PACKETS) {
+	if (IS_DEBUG_ADJ_PACKETS) {
 		zlog_debug(
 			"ISIS-Adj (%s): Rcvd L%d LAN IIH from %s on %s, cirType %s, cirID %u, length %zd",
 			iih->circuit->area->area_tag, iih->level,
@@ -565,13 +565,13 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 
 	stream_get_from(raw_pdu, circuit->rcv_stream, pdu_start,
 			pdu_end - pdu_start);
-	if (isis->debugs & DEBUG_ADJ_PACKETS) {
+	if (IS_DEBUG_ADJ_PACKETS) {
 		zlog_debug("ISIS-Adj (%s): Rcvd %s on %s, cirType %s, cirID %u",
 			   circuit->area->area_tag, pdu_name,
 			   circuit->interface->name,
 			   circuit_t2string(circuit->is_type),
 			   circuit->circuit_id);
-		if (isis->debugs & DEBUG_PACKET_DUMP)
+		if (IS_DEBUG_PACKET_DUMP)
 			zlog_dump_data(STREAM_DATA(circuit->rcv_stream),
 				       stream_get_endp(circuit->rcv_stream));
 	}
@@ -614,7 +614,7 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 		}
 
 		if (!(circuit->is_type & level)) {
-			if (isis->debugs & DEBUG_ADJ_PACKETS) {
+			if (IS_DEBUG_ADJ_PACKETS) {
 				zlog_debug(
 					"ISIS-Adj (%s): Interface level mismatch, %s",
 					circuit->area->area_tag,
@@ -742,7 +742,7 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 		|| (level == ISIS_LEVEL1
 		    && !isis_tlvs_area_addresses_match(
 			       iih.tlvs, circuit->area->area_addrs)))) {
-		if (isis->debugs & DEBUG_ADJ_PACKETS) {
+		if (IS_DEBUG_ADJ_PACKETS) {
 			zlog_debug(
 				"ISIS-Adj (%s): Area mismatch, level %d IIH on %s",
 				circuit->area->area_tag, level,
@@ -762,7 +762,7 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 			 && iih.tlvs->ipv6_address.count);
 
 	if (!iih.v4_usable && !iih.v6_usable) {
-		if (isis->debugs & DEBUG_ADJ_PACKETS) {
+		if (IS_DEBUG_ADJ_PACKETS) {
 			zlog_warn(
 				"ISIS-Adj (%s): Neither IPv4 nor IPv6 considered usable. Ignoring IIH",
 				circuit->area->area_tag);
@@ -831,7 +831,7 @@ static int process_lsp(uint8_t pdu_type, struct isis_circuit *circuit,
 		circuit_scoped = false;
 	}
 
-	if (isis->debugs & DEBUG_UPDATE_PACKETS) {
+	if (IS_DEBUG_UPDATE_PACKETS) {
 		zlog_debug(
 			"ISIS-Upd (%s): Rcvd %sL%d LSP on %s, cirType %s, cirID %u",
 			circuit->area->area_tag,
@@ -839,7 +839,7 @@ static int process_lsp(uint8_t pdu_type, struct isis_circuit *circuit,
 			circuit->interface->name,
 			circuit_t2string(circuit->is_type),
 			circuit->circuit_id);
-		if (isis->debugs & DEBUG_PACKET_DUMP)
+		if (IS_DEBUG_PACKET_DUMP)
 			zlog_dump_data(STREAM_DATA(circuit->rcv_stream),
 				       stream_get_endp(circuit->rcv_stream));
 	}
@@ -866,7 +866,7 @@ static int process_lsp(uint8_t pdu_type, struct isis_circuit *circuit,
 		return ISIS_WARNING;
 	}
 
-	if (isis->debugs & DEBUG_UPDATE_PACKETS) {
+	if (IS_DEBUG_UPDATE_PACKETS) {
 		zlog_debug("ISIS-Upd (%s): Rcvd L%d LSP %s, seq 0x%08" PRIx32
 			   ", cksum 0x%04" PRIx16 ", lifetime %" PRIu16
 			   "s, len %" PRIu16 ", on %s",
@@ -1123,7 +1123,7 @@ dontcheckadj:
 							  lsp, TX_LSP_NORMAL);
 					ISIS_CLEAR_FLAG(lsp->SSNflags, circuit);
 				}
-				if (isis->debugs & DEBUG_UPDATE_PACKETS)
+				if (IS_DEBUG_UPDATE_PACKETS)
 					zlog_debug(
 						"ISIS-Upd (%s): (1) "
 						"re-originating LSP %s new seq "
@@ -1167,7 +1167,7 @@ dontcheckadj:
 			isis_notif_seqno_skipped(circuit,
 						 rawlspid_print(hdr.lsp_id));
 #endif /* ifndef FABRICD */
-			if (isis->debugs & DEBUG_UPDATE_PACKETS) {
+			if (IS_DEBUG_UPDATE_PACKETS) {
 				zlog_debug(
 					"ISIS-Upd (%s): (2) re-originating LSP %s new seq 0x%08" PRIx32,
 					circuit->area->area_tag,
@@ -1298,14 +1298,14 @@ static int process_snp(uint8_t pdu_type, struct isis_circuit *circuit,
 		return ISIS_WARNING;
 	}
 
-	if (isis->debugs & DEBUG_SNP_PACKETS) {
+	if (IS_DEBUG_SNP_PACKETS) {
 		zlog_debug(
 			"ISIS-Snp (%s): Rcvd L%d %cSNP on %s, cirType %s, cirID %u",
 			circuit->area->area_tag, level, typechar,
 			circuit->interface->name,
 			circuit_t2string(circuit->is_type),
 			circuit->circuit_id);
-		if (isis->debugs & DEBUG_PACKET_DUMP)
+		if (IS_DEBUG_PACKET_DUMP)
 			zlog_dump_data(STREAM_DATA(circuit->rcv_stream),
 				       stream_get_endp(circuit->rcv_stream));
 	}
@@ -1412,7 +1412,7 @@ static int process_snp(uint8_t pdu_type, struct isis_circuit *circuit,
 		(struct isis_lsp_entry *)tlvs->lsp_entries.head;
 
 	/* debug isis snp-packets */
-	if (isis->debugs & DEBUG_SNP_PACKETS) {
+	if (IS_DEBUG_SNP_PACKETS) {
 		zlog_debug("ISIS-Snp (%s): Rcvd L%d %cSNP from %s on %s",
 			   circuit->area->area_tag, level, typechar,
 			   snpa_print(ssnpa), circuit->interface->name);
@@ -1915,7 +1915,7 @@ int send_hello(struct isis_circuit *circuit, int level)
 		return ISIS_WARNING; /* XXX: Maybe Log TLV structure? */
 	}
 
-	if (isis->debugs & DEBUG_ADJ_PACKETS) {
+	if (IS_DEBUG_ADJ_PACKETS) {
 		if (circuit->circ_type == CIRCUIT_T_BROADCAST) {
 			zlog_debug(
 				"ISIS-Adj (%s): Sending L%d LAN IIH on %s, length %zd",
@@ -1929,7 +1929,7 @@ int send_hello(struct isis_circuit *circuit, int level)
 				circuit->interface->name,
 				stream_get_endp(circuit->snd_stream));
 		}
-		if (isis->debugs & DEBUG_PACKET_DUMP)
+		if (IS_DEBUG_PACKET_DUMP)
 			zlog_dump_data(STREAM_DATA(circuit->snd_stream),
 				       stream_get_endp(circuit->snd_stream));
 	}
@@ -2134,7 +2134,7 @@ int send_csnp(struct isis_circuit *circuit, int level)
 			return ISIS_WARNING;
 		}
 
-		if (isis->debugs & DEBUG_SNP_PACKETS) {
+		if (IS_DEBUG_SNP_PACKETS) {
 			zlog_debug(
 				"ISIS-Snp (%s): Sending L%d CSNP on %s, length %zd",
 				circuit->area->area_tag, level,
@@ -2142,7 +2142,7 @@ int send_csnp(struct isis_circuit *circuit, int level)
 				stream_get_endp(circuit->snd_stream));
 			log_multiline(LOG_DEBUG, "              ", "%s",
 				      isis_format_tlvs(tlvs));
-			if (isis->debugs & DEBUG_PACKET_DUMP)
+			if (IS_DEBUG_PACKET_DUMP)
 				zlog_dump_data(
 					STREAM_DATA(circuit->snd_stream),
 					stream_get_endp(circuit->snd_stream));
@@ -2297,7 +2297,7 @@ static int send_psnp(int level, struct isis_circuit *circuit)
 			return ISIS_WARNING;
 		}
 
-		if (isis->debugs & DEBUG_SNP_PACKETS) {
+		if (IS_DEBUG_SNP_PACKETS) {
 			zlog_debug(
 				"ISIS-Snp (%s): Sending L%d PSNP on %s, length %zd",
 				circuit->area->area_tag, level,
@@ -2305,7 +2305,7 @@ static int send_psnp(int level, struct isis_circuit *circuit)
 				stream_get_endp(circuit->snd_stream));
 			log_multiline(LOG_DEBUG, "              ", "%s",
 				      isis_format_tlvs(tlvs));
-			if (isis->debugs & DEBUG_PACKET_DUMP)
+			if (IS_DEBUG_PACKET_DUMP)
 				zlog_dump_data(
 					STREAM_DATA(circuit->snd_stream),
 					stream_get_endp(circuit->snd_stream));
@@ -2422,7 +2422,7 @@ void send_lsp(struct isis_circuit *circuit, struct isis_lsp *lsp,
 		isis_notif_lsp_too_large(circuit, stream_get_endp(lsp->pdu),
 					 rawlspid_print(lsp->hdr.lsp_id));
 #endif /* ifndef FABRICD */
-		if (isis->debugs & DEBUG_PACKET_DUMP)
+		if (IS_DEBUG_PACKET_DUMP)
 			zlog_dump_data(STREAM_DATA(lsp->pdu),
 				       stream_get_endp(lsp->pdu));
 		retval = ISIS_ERROR;
@@ -2438,7 +2438,7 @@ void send_lsp(struct isis_circuit *circuit, struct isis_lsp *lsp,
 			       L2_CIRCUIT_FLOODING_SCOPE);
 	}
 
-	if (isis->debugs & DEBUG_UPDATE_PACKETS) {
+	if (IS_DEBUG_UPDATE_PACKETS) {
 		zlog_debug("ISIS-Upd (%s): Sending %sL%d LSP %s, seq 0x%08" PRIx32
 			   ", cksum 0x%04" PRIx16 ", lifetime %" PRIu16
 			   "s on %s",
@@ -2449,7 +2449,7 @@ void send_lsp(struct isis_circuit *circuit, struct isis_lsp *lsp,
 			   rawlspid_print(lsp->hdr.lsp_id), lsp->hdr.seqno,
 			   lsp->hdr.checksum, lsp->hdr.rem_lifetime,
 			   circuit->interface->name);
-		if (isis->debugs & DEBUG_PACKET_DUMP)
+		if (IS_DEBUG_PACKET_DUMP)
 			zlog_dump_data(STREAM_DATA(circuit->snd_stream),
 				       stream_get_endp(circuit->snd_stream));
 	}

--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -280,24 +280,24 @@ struct isis_route_info *isis_route_create(struct prefix *prefix,
 
 	rinfo_old = route_node->info;
 	if (!rinfo_old) {
-		if (isis->debugs & DEBUG_RTE_EVENTS)
+		if (IS_DEBUG_RTE_EVENTS)
 			zlog_debug("ISIS-Rte (%s) route created: %s",
 				   area->area_tag, buff);
 		route_info = rinfo_new;
 		UNSET_FLAG(route_info->flag, ISIS_ROUTE_FLAG_ZEBRA_SYNCED);
 	} else {
 		route_unlock_node(route_node);
-		if (isis->debugs & DEBUG_RTE_EVENTS)
+		if (IS_DEBUG_RTE_EVENTS)
 			zlog_debug("ISIS-Rte (%s) route already exists: %s",
 				   area->area_tag, buff);
 		if (isis_route_info_same(rinfo_new, rinfo_old, family)) {
-			if (isis->debugs & DEBUG_RTE_EVENTS)
+			if (IS_DEBUG_RTE_EVENTS)
 				zlog_debug("ISIS-Rte (%s) route unchanged: %s",
 					   area->area_tag, buff);
 			isis_route_info_delete(rinfo_new);
 			route_info = rinfo_old;
 		} else {
-			if (isis->debugs & DEBUG_RTE_EVENTS)
+			if (IS_DEBUG_RTE_EVENTS)
 				zlog_debug("ISIS-Rte (%s) route changed: %s",
 					   area->area_tag, buff);
 			isis_route_info_delete(rinfo_old);
@@ -329,7 +329,7 @@ static void isis_route_delete(struct isis_area *area, struct route_node *rode,
 
 	rinfo = rode->info;
 	if (rinfo == NULL) {
-		if (isis->debugs & DEBUG_RTE_EVENTS)
+		if (IS_DEBUG_RTE_EVENTS)
 			zlog_debug(
 				"ISIS-Rte: tried to delete non-existant route %s",
 				buff);
@@ -338,7 +338,7 @@ static void isis_route_delete(struct isis_area *area, struct route_node *rode,
 
 	if (CHECK_FLAG(rinfo->flag, ISIS_ROUTE_FLAG_ZEBRA_SYNCED)) {
 		UNSET_FLAG(rinfo->flag, ISIS_ROUTE_FLAG_ACTIVE);
-		if (isis->debugs & DEBUG_RTE_EVENTS)
+		if (IS_DEBUG_RTE_EVENTS)
 			zlog_debug("ISIS-Rte: route delete  %s", buff);
 		isis_route_update(area, prefix, src_p, rinfo);
 	}
@@ -392,7 +392,7 @@ static void _isis_route_verify_table(struct isis_area *area,
 				       (const struct prefix **)&dst_p,
 				       (const struct prefix **)&src_p);
 
-		if (isis->debugs & DEBUG_RTE_EVENTS) {
+		if (IS_DEBUG_RTE_EVENTS) {
 			srcdest2str(dst_p, src_p, buff, sizeof(buff));
 			zlog_debug(
 				"ISIS-Rte (%s): route validate: %s %s %s %s",

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -814,7 +814,7 @@ static int isis_spf_preload_tent(struct isis_spftree *spftree,
 			isis_adj_build_up_list(adjdb, adj_list);
 			if (listcount(adj_list) == 0) {
 				list_delete(&adj_list);
-				if (isis->debugs & DEBUG_SPF_EVENTS)
+				if (IS_DEBUG_SPF_EVENTS)
 					zlog_debug(
 						"ISIS-Spf: no L%d adjacencies on circuit %s",
 						spftree->level,
@@ -890,7 +890,7 @@ static int isis_spf_preload_tent(struct isis_spftree *spftree,
 			/* can happen during DR reboot */
 			if (memcmp(lsp_id, null_lsp_id, ISIS_SYS_ID_LEN + 1)
 			    == 0) {
-				if (isis->debugs & DEBUG_SPF_EVENTS)
+				if (IS_DEBUG_SPF_EVENTS)
 					zlog_debug(
 						"ISIS-Spf: No L%d DR on %s (ID %d)",
 						spftree->level,
@@ -1007,7 +1007,7 @@ static void add_to_paths(struct isis_spftree *spftree,
 					  vertex->d_N, vertex->depth,
 					  vertex->Adj_N, spftree->area,
 					  spftree->route_table);
-		else if (isis->debugs & DEBUG_SPF_EVENTS)
+		else if (IS_DEBUG_SPF_EVENTS)
 			zlog_debug(
 				"ISIS-Spf: no adjacencies do not install route for "
 				"%s depth %d dist %d",
@@ -1144,7 +1144,7 @@ static int isis_run_spf(struct isis_area *area, int level,
 	 * C.2.7 Step 2
 	 */
 	if (!isis_vertex_queue_count(&spftree->tents)
-	    && (isis->debugs & DEBUG_SPF_EVENTS)) {
+	    && (IS_DEBUG_SPF_EVENTS)) {
 		zlog_warn("ISIS-Spf: TENT is empty SPF-root:%s",
 			  print_sys_hostname(sysid));
 	}
@@ -1189,7 +1189,7 @@ static int isis_run_spf_cb(struct thread *thread)
 	area->spf_timer[level - 1] = NULL;
 
 	if (!(area->is_type & level)) {
-		if (isis->debugs & DEBUG_SPF_EVENTS)
+		if (IS_DEBUG_SPF_EVENTS)
 			zlog_warn("ISIS-SPF (%s) area does not share level",
 				  area->area_tag);
 		return ISIS_WARNING;
@@ -1197,7 +1197,7 @@ static int isis_run_spf_cb(struct thread *thread)
 
 	isis_area_invalidate_routes(area, level);
 
-	if (isis->debugs & DEBUG_SPF_EVENTS)
+	if (IS_DEBUG_SPF_EVENTS)
 		zlog_debug("ISIS-Spf (%s) L%d SPF needed, periodic SPF",
 			   area->area_tag, level);
 
@@ -1247,7 +1247,7 @@ int _isis_spf_schedule(struct isis_area *area, int level,
 	assert(diff >= 0);
 	assert(area->is_type & level);
 
-	if (isis->debugs & DEBUG_SPF_EVENTS) {
+	if (IS_DEBUG_SPF_EVENTS) {
 		zlog_debug(
 			"ISIS-Spf (%s) L%d SPF schedule called, lastrun %d sec ago"
 			" Caller: %s %s:%d",
@@ -1285,7 +1285,7 @@ int _isis_spf_schedule(struct isis_area *area, int level,
 	thread_add_timer(master, isis_run_spf_cb, isis_run_spf_arg(area, level),
 			 timer, &area->spf_timer[level - 1]);
 
-	if (isis->debugs & DEBUG_SPF_EVENTS)
+	if (IS_DEBUG_SPF_EVENTS)
 		zlog_debug("ISIS-Spf (%s) L%d SPF scheduled %ld sec from now",
 			   area->area_tag, level, timer);
 

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -749,7 +749,7 @@ static int sr_prefix_install_remote(struct sr_prefix *srp)
 		if (output_label == MPLS_INVALID_LABEL)
 			goto next;
 
-		if (IS_DEBUG_ISIS(DEBUG_SR)) {
+		if (IS_DEBUG_SR) {
 			static char buf[INET6_ADDRSTRLEN];
 
 			inet_ntop(nexthop->family, &nexthop->ip, buf,

--- a/isisd/isis_tx_queue.c
+++ b/isisd/isis_tx_queue.c
@@ -144,7 +144,7 @@ void _isis_tx_queue_add(struct isis_tx_queue *queue,
 	if (!queue)
 		return;
 
-	if (isis->debugs & DEBUG_TX_QUEUE) {
+	if (IS_DEBUG_TX_QUEUE) {
 		zlog_debug("Add LSP %s to %s queue as %s LSP. (From %s %s:%d)",
 			   rawlspid_print(lsp->hdr.lsp_id),
 			   queue->circuit->interface->name,
@@ -183,7 +183,7 @@ void _isis_tx_queue_del(struct isis_tx_queue *queue, struct isis_lsp *lsp,
 	if (!e)
 		return;
 
-	if (isis->debugs & DEBUG_TX_QUEUE) {
+	if (IS_DEBUG_TX_QUEUE) {
 		zlog_debug("Remove LSP %s from %s queue. (From %s %s:%d)",
 			   rawlspid_print(lsp->hdr.lsp_id),
 			   queue->circuit->interface->name,

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -60,6 +60,21 @@
 #include "isisd/fabricd.h"
 #include "isisd/isis_nb.h"
 
+/* For debug statement. */
+unsigned long debug_adj_pkt;
+unsigned long debug_snp_pkt;
+unsigned long debug_update_pkt;
+unsigned long debug_spf_events;
+unsigned long debug_rte_events;
+unsigned long debug_events;
+unsigned long debug_pkt_dump;
+unsigned long debug_lsp_gen;
+unsigned long debug_lsp_sched;
+unsigned long debug_flooding;
+unsigned long debug_bfd;
+unsigned long debug_tx_queue;
+unsigned long debug_sr;
+
 struct isis *isis = NULL;
 
 DEFINE_QOBJ_TYPE(isis)
@@ -90,10 +105,6 @@ void isis_new(unsigned long process_id, vrf_id_t vrf_id)
 	isis->init_circ_list = list_new();
 	isis->uptime = time(NULL);
 	dyn_cache_init();
-	/*
-	 * uncomment the next line for full debugs
-	 */
-	/* isis->debugs = 0xFFFF; */
 
 	QOBJ_REG(isis, isis);
 }
@@ -225,7 +236,7 @@ int isis_area_get(struct vty *vty, const char *area_tag)
 
 	area = isis_area_create(area_tag);
 
-	if (isis->debugs & DEBUG_EVENTS)
+	if (IS_DEBUG_EVENTS)
 		zlog_debug("New IS-IS area instance %s", area->area_tag);
 
 	VTY_PUSH_CONTEXT(ROUTER_NODE, area);
@@ -387,7 +398,7 @@ int area_net_title(struct vty *vty, const char *net_title)
 		 */
 		memcpy(isis->sysid, GETSYSID(addr), ISIS_SYS_ID_LEN);
 		isis->sysid_set = 1;
-		if (isis->debugs & DEBUG_EVENTS)
+		if (IS_DEBUG_EVENTS)
 			zlog_debug("Router has SystemID %s",
 				   sysid_print(isis->sysid));
 	} else {
@@ -468,7 +479,7 @@ int area_clear_net_title(struct vty *vty, const char *net_title)
 	if (listcount(area->area_addrs) == 0) {
 		memset(isis->sysid, 0, ISIS_SYS_ID_LEN);
 		isis->sysid_set = 0;
-		if (isis->debugs & DEBUG_EVENTS)
+		if (IS_DEBUG_EVENTS)
 			zlog_debug("Router has no SystemID");
 	}
 
@@ -784,9 +795,32 @@ DEFUN_NOSH (show_debugging,
 {
 	vty_out(vty, PROTO_NAME " debugging status:\n");
 
-	if (isis->debugs)
-		print_debug(vty, isis->debugs, 1);
-
+	if (IS_DEBUG_ADJ_PACKETS)
+		print_debug(vty, DEBUG_ADJ_PACKETS, 1);
+	if (IS_DEBUG_TX_QUEUE)
+		print_debug(vty, DEBUG_TX_QUEUE, 1);
+	if (IS_DEBUG_SNP_PACKETS)
+		print_debug(vty, DEBUG_SNP_PACKETS, 1);
+	if (IS_DEBUG_SPF_EVENTS)
+		print_debug(vty, DEBUG_SPF_EVENTS, 1);
+	if (IS_DEBUG_SR)
+		print_debug(vty, DEBUG_SR, 1);
+	if (IS_DEBUG_UPDATE_PACKETS)
+		print_debug(vty, DEBUG_UPDATE_PACKETS, 1);
+	if (IS_DEBUG_RTE_EVENTS)
+		print_debug(vty, DEBUG_RTE_EVENTS, 1);
+	if (IS_DEBUG_EVENTS)
+		print_debug(vty, DEBUG_EVENTS, 1);
+	if (IS_DEBUG_PACKET_DUMP)
+		print_debug(vty, DEBUG_PACKET_DUMP, 1);
+	if (IS_DEBUG_LSP_GEN)
+		print_debug(vty, DEBUG_LSP_GEN, 1);
+	if (IS_DEBUG_LSP_SCHED)
+		print_debug(vty, DEBUG_LSP_SCHED, 1);
+	if (IS_DEBUG_FLOODING)
+		print_debug(vty, DEBUG_FLOODING, 1);
+	if (IS_DEBUG_BFD)
+		print_debug(vty, DEBUG_BFD, 1);
 	return CMD_SUCCESS;
 }
 
@@ -802,57 +836,56 @@ static struct cmd_node debug_node = {
 static int config_write_debug(struct vty *vty)
 {
 	int write = 0;
-	int flags = isis->debugs;
 
-	if (flags & DEBUG_ADJ_PACKETS) {
+	if (IS_DEBUG_ADJ_PACKETS) {
 		vty_out(vty, "debug " PROTO_NAME " adj-packets\n");
 		write++;
 	}
-	if (flags & DEBUG_TX_QUEUE) {
+	if (IS_DEBUG_TX_QUEUE) {
 		vty_out(vty, "debug " PROTO_NAME " tx-queue\n");
 		write++;
 	}
-	if (flags & DEBUG_SNP_PACKETS) {
+	if (IS_DEBUG_SNP_PACKETS) {
 		vty_out(vty, "debug " PROTO_NAME " snp-packets\n");
 		write++;
 	}
-	if (flags & DEBUG_SPF_EVENTS) {
+	if (IS_DEBUG_SPF_EVENTS) {
 		vty_out(vty, "debug " PROTO_NAME " spf-events\n");
 		write++;
 	}
-	if (flags & DEBUG_SR) {
+	if (IS_DEBUG_SR) {
 		vty_out(vty, "debug " PROTO_NAME " sr-events\n");
 		write++;
 	}
-	if (flags & DEBUG_UPDATE_PACKETS) {
+	if (IS_DEBUG_UPDATE_PACKETS) {
 		vty_out(vty, "debug " PROTO_NAME " update-packets\n");
 		write++;
 	}
-	if (flags & DEBUG_RTE_EVENTS) {
+	if (IS_DEBUG_RTE_EVENTS) {
 		vty_out(vty, "debug " PROTO_NAME " route-events\n");
 		write++;
 	}
-	if (flags & DEBUG_EVENTS) {
+	if (IS_DEBUG_EVENTS) {
 		vty_out(vty, "debug " PROTO_NAME " events\n");
 		write++;
 	}
-	if (flags & DEBUG_PACKET_DUMP) {
+	if (IS_DEBUG_PACKET_DUMP) {
 		vty_out(vty, "debug " PROTO_NAME " packet-dump\n");
 		write++;
 	}
-	if (flags & DEBUG_LSP_GEN) {
+	if (IS_DEBUG_LSP_GEN) {
 		vty_out(vty, "debug " PROTO_NAME " lsp-gen\n");
 		write++;
 	}
-	if (flags & DEBUG_LSP_SCHED) {
+	if (IS_DEBUG_LSP_SCHED) {
 		vty_out(vty, "debug " PROTO_NAME " lsp-sched\n");
 		write++;
 	}
-	if (flags & DEBUG_FLOODING) {
+	if (IS_DEBUG_FLOODING) {
 		vty_out(vty, "debug " PROTO_NAME " flooding\n");
 		write++;
 	}
-	if (flags & DEBUG_BFD) {
+	if (IS_DEBUG_BFD) {
 		vty_out(vty, "debug " PROTO_NAME " bfd\n");
 		write++;
 	}
@@ -868,7 +901,7 @@ DEFUN (debug_isis_adj,
        PROTO_HELP
        "IS-IS Adjacency related packets\n")
 {
-	isis->debugs |= DEBUG_ADJ_PACKETS;
+	debug_adj_pkt |= DEBUG_ADJ_PACKETS;
 	print_debug(vty, DEBUG_ADJ_PACKETS, 1);
 
 	return CMD_SUCCESS;
@@ -882,7 +915,7 @@ DEFUN (no_debug_isis_adj,
        PROTO_HELP
        "IS-IS Adjacency related packets\n")
 {
-	isis->debugs &= ~DEBUG_ADJ_PACKETS;
+	debug_adj_pkt &= ~DEBUG_ADJ_PACKETS;
 	print_debug(vty, DEBUG_ADJ_PACKETS, 0);
 
 	return CMD_SUCCESS;
@@ -895,7 +928,7 @@ DEFUN (debug_isis_tx_queue,
        PROTO_HELP
        "IS-IS TX queues\n")
 {
-	isis->debugs |= DEBUG_TX_QUEUE;
+	debug_tx_queue |= DEBUG_TX_QUEUE;
 	print_debug(vty, DEBUG_TX_QUEUE, 1);
 
 	return CMD_SUCCESS;
@@ -909,7 +942,7 @@ DEFUN (no_debug_isis_tx_queue,
        PROTO_HELP
        "IS-IS TX queues\n")
 {
-	isis->debugs &= ~DEBUG_TX_QUEUE;
+	debug_tx_queue &= ~DEBUG_TX_QUEUE;
 	print_debug(vty, DEBUG_TX_QUEUE, 0);
 
 	return CMD_SUCCESS;
@@ -922,7 +955,7 @@ DEFUN (debug_isis_flooding,
        PROTO_HELP
        "Flooding algorithm\n")
 {
-	isis->debugs |= DEBUG_FLOODING;
+	debug_flooding |= DEBUG_FLOODING;
 	print_debug(vty, DEBUG_FLOODING, 1);
 
 	return CMD_SUCCESS;
@@ -936,7 +969,7 @@ DEFUN (no_debug_isis_flooding,
        PROTO_HELP
        "Flooding algorithm\n")
 {
-	isis->debugs &= ~DEBUG_FLOODING;
+	debug_flooding &= ~DEBUG_FLOODING;
 	print_debug(vty, DEBUG_FLOODING, 0);
 
 	return CMD_SUCCESS;
@@ -949,7 +982,7 @@ DEFUN (debug_isis_snp,
        PROTO_HELP
        "IS-IS CSNP/PSNP packets\n")
 {
-	isis->debugs |= DEBUG_SNP_PACKETS;
+	debug_snp_pkt |= DEBUG_SNP_PACKETS;
 	print_debug(vty, DEBUG_SNP_PACKETS, 1);
 
 	return CMD_SUCCESS;
@@ -963,7 +996,7 @@ DEFUN (no_debug_isis_snp,
        PROTO_HELP
        "IS-IS CSNP/PSNP packets\n")
 {
-	isis->debugs &= ~DEBUG_SNP_PACKETS;
+	debug_snp_pkt &= ~DEBUG_SNP_PACKETS;
 	print_debug(vty, DEBUG_SNP_PACKETS, 0);
 
 	return CMD_SUCCESS;
@@ -976,7 +1009,7 @@ DEFUN (debug_isis_upd,
        PROTO_HELP
        "IS-IS Update related packets\n")
 {
-	isis->debugs |= DEBUG_UPDATE_PACKETS;
+	debug_update_pkt |= DEBUG_UPDATE_PACKETS;
 	print_debug(vty, DEBUG_UPDATE_PACKETS, 1);
 
 	return CMD_SUCCESS;
@@ -990,7 +1023,7 @@ DEFUN (no_debug_isis_upd,
        PROTO_HELP
        "IS-IS Update related packets\n")
 {
-	isis->debugs &= ~DEBUG_UPDATE_PACKETS;
+	debug_update_pkt &= ~DEBUG_UPDATE_PACKETS;
 	print_debug(vty, DEBUG_UPDATE_PACKETS, 0);
 
 	return CMD_SUCCESS;
@@ -1003,7 +1036,7 @@ DEFUN (debug_isis_spfevents,
        PROTO_HELP
        "IS-IS Shortest Path First Events\n")
 {
-	isis->debugs |= DEBUG_SPF_EVENTS;
+	debug_spf_events |= DEBUG_SPF_EVENTS;
 	print_debug(vty, DEBUG_SPF_EVENTS, 1);
 
 	return CMD_SUCCESS;
@@ -1017,7 +1050,7 @@ DEFUN (no_debug_isis_spfevents,
        PROTO_HELP
        "IS-IS Shortest Path First Events\n")
 {
-	isis->debugs &= ~DEBUG_SPF_EVENTS;
+	debug_spf_events &= ~DEBUG_SPF_EVENTS;
 	print_debug(vty, DEBUG_SPF_EVENTS, 0);
 
 	return CMD_SUCCESS;
@@ -1030,7 +1063,7 @@ DEFUN (debug_isis_srevents,
        PROTO_HELP
        "IS-IS Segment Routing Events\n")
 {
-	isis->debugs |= DEBUG_SR;
+	debug_sr |= DEBUG_SR;
 	print_debug(vty, DEBUG_SR, 1);
 
 	return CMD_SUCCESS;
@@ -1044,7 +1077,7 @@ DEFUN (no_debug_isis_srevents,
        PROTO_HELP
        "IS-IS Segment Routing Events\n")
 {
-	isis->debugs &= ~DEBUG_SR;
+	debug_sr &= ~DEBUG_SR;
 	print_debug(vty, DEBUG_SR, 0);
 
 	return CMD_SUCCESS;
@@ -1057,7 +1090,7 @@ DEFUN (debug_isis_rtevents,
        PROTO_HELP
        "IS-IS Route related events\n")
 {
-	isis->debugs |= DEBUG_RTE_EVENTS;
+	debug_rte_events |= DEBUG_RTE_EVENTS;
 	print_debug(vty, DEBUG_RTE_EVENTS, 1);
 
 	return CMD_SUCCESS;
@@ -1071,7 +1104,7 @@ DEFUN (no_debug_isis_rtevents,
        PROTO_HELP
        "IS-IS Route related events\n")
 {
-	isis->debugs &= ~DEBUG_RTE_EVENTS;
+	debug_rte_events &= ~DEBUG_RTE_EVENTS;
 	print_debug(vty, DEBUG_RTE_EVENTS, 0);
 
 	return CMD_SUCCESS;
@@ -1084,7 +1117,7 @@ DEFUN (debug_isis_events,
        PROTO_HELP
        "IS-IS Events\n")
 {
-	isis->debugs |= DEBUG_EVENTS;
+	debug_events |= DEBUG_EVENTS;
 	print_debug(vty, DEBUG_EVENTS, 1);
 
 	return CMD_SUCCESS;
@@ -1098,7 +1131,7 @@ DEFUN (no_debug_isis_events,
        PROTO_HELP
        "IS-IS Events\n")
 {
-	isis->debugs &= ~DEBUG_EVENTS;
+	debug_events &= ~DEBUG_EVENTS;
 	print_debug(vty, DEBUG_EVENTS, 0);
 
 	return CMD_SUCCESS;
@@ -1111,7 +1144,7 @@ DEFUN (debug_isis_packet_dump,
        PROTO_HELP
        "IS-IS packet dump\n")
 {
-	isis->debugs |= DEBUG_PACKET_DUMP;
+	debug_pkt_dump |= DEBUG_PACKET_DUMP;
 	print_debug(vty, DEBUG_PACKET_DUMP, 1);
 
 	return CMD_SUCCESS;
@@ -1125,7 +1158,7 @@ DEFUN (no_debug_isis_packet_dump,
        PROTO_HELP
        "IS-IS packet dump\n")
 {
-	isis->debugs &= ~DEBUG_PACKET_DUMP;
+	debug_pkt_dump &= ~DEBUG_PACKET_DUMP;
 	print_debug(vty, DEBUG_PACKET_DUMP, 0);
 
 	return CMD_SUCCESS;
@@ -1138,7 +1171,7 @@ DEFUN (debug_isis_lsp_gen,
        PROTO_HELP
        "IS-IS generation of own LSPs\n")
 {
-	isis->debugs |= DEBUG_LSP_GEN;
+	debug_lsp_gen |= DEBUG_LSP_GEN;
 	print_debug(vty, DEBUG_LSP_GEN, 1);
 
 	return CMD_SUCCESS;
@@ -1152,7 +1185,7 @@ DEFUN (no_debug_isis_lsp_gen,
        PROTO_HELP
        "IS-IS generation of own LSPs\n")
 {
-	isis->debugs &= ~DEBUG_LSP_GEN;
+	debug_lsp_gen &= ~DEBUG_LSP_GEN;
 	print_debug(vty, DEBUG_LSP_GEN, 0);
 
 	return CMD_SUCCESS;
@@ -1165,7 +1198,7 @@ DEFUN (debug_isis_lsp_sched,
        PROTO_HELP
        "IS-IS scheduling of LSP generation\n")
 {
-	isis->debugs |= DEBUG_LSP_SCHED;
+	debug_lsp_sched |= DEBUG_LSP_SCHED;
 	print_debug(vty, DEBUG_LSP_SCHED, 1);
 
 	return CMD_SUCCESS;
@@ -1179,7 +1212,7 @@ DEFUN (no_debug_isis_lsp_sched,
        PROTO_HELP
        "IS-IS scheduling of LSP generation\n")
 {
-	isis->debugs &= ~DEBUG_LSP_SCHED;
+	debug_lsp_sched &= ~DEBUG_LSP_SCHED;
 	print_debug(vty, DEBUG_LSP_SCHED, 0);
 
 	return CMD_SUCCESS;
@@ -1192,7 +1225,7 @@ DEFUN (debug_isis_bfd,
        PROTO_HELP
        PROTO_NAME " interaction with BFD\n")
 {
-	isis->debugs |= DEBUG_BFD;
+	debug_bfd |= DEBUG_BFD;
 	print_debug(vty, DEBUG_BFD, 1);
 
 	return CMD_SUCCESS;
@@ -1206,7 +1239,7 @@ DEFUN (no_debug_isis_bfd,
        PROTO_HELP
        PROTO_NAME " interaction with BFD\n")
 {
-	isis->debugs &= ~DEBUG_BFD;
+	debug_bfd &= ~DEBUG_BFD;
 	print_debug(vty, DEBUG_BFD, 0);
 
 	return CMD_SUCCESS;
@@ -1749,7 +1782,7 @@ void isis_area_is_type_set(struct isis_area *area, int is_type)
 	struct listnode *node;
 	struct isis_circuit *circuit;
 
-	if (isis->debugs & DEBUG_EVENTS)
+	if (IS_DEBUG_EVENTS)
 		zlog_debug("ISIS-Evt (%s) system type change %s -> %s",
 			   area->area_tag, circuit_t2string(area->is_type),
 			   circuit_t2string(is_type));

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -72,7 +72,6 @@ struct isis {
 	struct list *init_circ_list;
 	uint8_t max_area_addrs;		  /* maximumAreaAdresses */
 	struct area_addr *man_area_addrs; /* manualAreaAddresses */
-	uint32_t debugs;		  /* bitmap for debug */
 	time_t uptime;			  /* when did we start */
 	struct thread *t_dync_clean;      /* dynamic hostname cache cleanup thread */
 	uint32_t circuit_ids_used[8];     /* 256 bits to track circuit ids 1 through 255 */
@@ -228,6 +227,20 @@ int isis_area_passwd_hmac_md5_set(struct isis_area *area, int level,
 /* Master of threads. */
 extern struct thread_master *master;
 
+extern unsigned long debug_adj_pkt;
+extern unsigned long debug_snp_pkt;
+extern unsigned long debug_update_pkt;
+extern unsigned long debug_spf_events;
+extern unsigned long debug_rte_events;
+extern unsigned long debug_events;
+extern unsigned long debug_pkt_dump;
+extern unsigned long debug_lsp_gen;
+extern unsigned long debug_lsp_sched;
+extern unsigned long debug_flooding;
+extern unsigned long debug_bfd;
+extern unsigned long debug_tx_queue;
+extern unsigned long debug_sr;
+
 #define DEBUG_ADJ_PACKETS                (1<<0)
 #define DEBUG_SNP_PACKETS                (1<<1)
 #define DEBUG_UPDATE_PACKETS             (1<<2)
@@ -242,26 +255,39 @@ extern struct thread_master *master;
 #define DEBUG_TX_QUEUE                   (1<<11)
 #define DEBUG_SR                         (1<<12)
 
+/* Debug related macro. */
+#define IS_DEBUG_ADJ_PACKETS (debug_adj_pkt & DEBUG_ADJ_PACKETS)
+#define IS_DEBUG_SNP_PACKETS (debug_snp_pkt & DEBUG_SNP_PACKETS)
+#define IS_DEBUG_UPDATE_PACKETS (debug_update_pkt & DEBUG_UPDATE_PACKETS)
+#define IS_DEBUG_SPF_EVENTS (debug_spf_events & DEBUG_SPF_EVENTS)
+#define IS_DEBUG_RTE_EVENTS (debug_rte_events & DEBUG_RTE_EVENTS)
+#define IS_DEBUG_EVENTS (debug_events & DEBUG_EVENTS)
+#define IS_DEBUG_PACKET_DUMP (debug_pkt_dump & DEBUG_PACKET_DUMP)
+#define IS_DEBUG_LSP_GEN (debug_lsp_gen & DEBUG_LSP_GEN)
+#define IS_DEBUG_LSP_SCHED (debug_lsp_sched & DEBUG_LSP_SCHED)
+#define IS_DEBUG_FLOODING (debug_flooding & DEBUG_FLOODING)
+#define IS_DEBUG_BFD (debug_bfd & DEBUG_BFD)
+#define IS_DEBUG_TX_QUEUE (debug_tx_queue & DEBUG_TX_QUEUE)
+#define IS_DEBUG_SR (debug_sr & DEBUG_SR)
+
 #define lsp_debug(...)                                                         \
 	do {                                                                   \
-		if (isis->debugs & DEBUG_LSP_GEN)                              \
+		if (IS_DEBUG_LSP_GEN)                                          \
 			zlog_debug(__VA_ARGS__);                               \
 	} while (0)
 
 #define sched_debug(...)                                                       \
 	do {                                                                   \
-		if (isis->debugs & DEBUG_LSP_SCHED)                            \
+		if (IS_DEBUG_LSP_SCHED)                                        \
 			zlog_debug(__VA_ARGS__);                               \
 	} while (0)
 
 #define sr_debug(...)                                                          \
 	do {                                                                   \
-		if (IS_DEBUG_ISIS(DEBUG_SR))                                   \
+		if (IS_DEBUG_SR)                                               \
 			zlog_debug(__VA_ARGS__);                               \
 	} while (0)
 
 #define DEBUG_TE                         DEBUG_LSP_GEN
-
-#define IS_DEBUG_ISIS(x)                 (isis->debugs & x)
 
 #endif /* ISISD_H */


### PR DESCRIPTION
1. The "isis->debug" variable dependency on debug logs print is removed.
2. This debug model is followed from zebra.

Signed-off-by: harios <hari@niralnetworks.com>