### PR TITLE
ISIS VRF: Added vrf_socket and new param in isisd privileges.

### DIFF
--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -66,7 +66,7 @@
 #define FABRICD_VTY_PORT     2618
 
 /* isisd privileges */
-zebra_capabilities_t _caps_p[] = {ZCAP_NET_RAW, ZCAP_BIND};
+zebra_capabilities_t _caps_p[] = {ZCAP_NET_RAW, ZCAP_BIND, ZCAP_SYS_ADMIN};
 
 struct zebra_privs_t isisd_privs = {
 #if defined(FRR_USER)

--- a/isisd/isis_pfpacket.c
+++ b/isisd/isis_pfpacket.c
@@ -32,6 +32,7 @@
 #include "stream.h"
 #include "if.h"
 #include "lib_errors.h"
+#include "vrf.h"
 
 #include "isisd/isis_constants.h"
 #include "isisd/isis_common.h"

--- a/isisd/isis_pfpacket.c
+++ b/isisd/isis_pfpacket.c
@@ -122,7 +122,9 @@ static int open_packet_socket(struct isis_circuit *circuit)
 	struct sockaddr_ll s_addr;
 	int fd, retval = ISIS_OK;
 
-	fd = socket(PF_PACKET, SOCK_DGRAM, htons(ETH_P_ALL));
+	fd = vrf_socket(PF_PACKET, SOCK_DGRAM, htons(ETH_P_ALL),
+			circuit->interface->vrf_id, circuit->interface->name);
+
 	if (fd < 0) {
 		zlog_warn("open_packet_socket(): socket() failed %s",
 			  safe_strerror(errno));


### PR DESCRIPTION
1. The socket() call replaced with vrf_socket() in open_packet_socket().
2. One new isisd privileges is added in zebra_capabilities_t [].

Signed-off-by: Kaushik <kaushik@niralnetworks.com>