### PR TITLE
lib: fix STREAM_GETF macro

### DIFF
--- a/lib/stream.h
+++ b/lib/stream.h
@@ -426,7 +426,7 @@ static inline const uint8_t *ptr_get_be32(const uint8_t *ptr, uint32_t *out)
 			float r;                                               \
 			uint32_t d;                                            \
 		} _pval;                                                       \
-		if (stream_getl2((S), &_pval.d))                               \
+		if (!stream_getl2((S), &_pval.d))                              \
 			goto stream_failure;                                   \
 		(P) = _pval.r;                                                 \
 	} while (0)


### PR DESCRIPTION
a missing '!' operator was making any STREAM_GETF fail when in fact it should have succeeded. As a consequence of this, for example, many link-params of an interface were not being read and populated.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>