### PR TITLE
lib: clarify usage of prefix_bit function

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -75,10 +75,10 @@ bool is_mcast_mac(const struct ethaddr *mac)
 	return false;
 }
 
-unsigned int prefix_bit(const uint8_t *prefix, const uint16_t prefixlen)
+unsigned int prefix_bit(const uint8_t *prefix, const uint16_t bit_index)
 {
-	unsigned int offset = prefixlen / 8;
-	unsigned int shift = 7 - (prefixlen % 8);
+	unsigned int offset = bit_index / 8;
+	unsigned int shift = 7 - (bit_index % 8);
 
 	return (prefix[offset] >> shift) & 1;
 }

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -392,8 +392,16 @@ extern const char *family2str(int family);
 extern const char *safi2str(safi_t safi);
 extern const char *afi2str(afi_t afi);
 
-/* Check bit of the prefix. */
-extern unsigned int prefix_bit(const uint8_t *prefix, const uint16_t prefixlen);
+/*
+ * Check bit of the prefix.
+ *
+ * prefix
+ *    byte buffer
+ *
+ * bit_index
+ *    which bit to fetch from byte buffer, 0 indexed.
+ */
+extern unsigned int prefix_bit(const uint8_t *prefix, const uint16_t bit_index);
 
 extern struct prefix *prefix_new(void);
 extern void prefix_free(struct prefix **p);


### PR DESCRIPTION
"prefixlen" is really a bit index

Closes #6620 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>