### PR TITLE
bgpd: Incorrect auto-RT formed when L3VNI is not configured

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4715,7 +4715,8 @@ void bgp_evpn_unconfigure_import_rt_for_vrf(struct bgp *bgp_vrf,
 	/* fallback to auto import rt, if this was the last RT */
 	if (bgp_vrf->vrf_import_rtl && list_isempty(bgp_vrf->vrf_import_rtl)) {
 		UNSET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_IMPORT_RT_CFGD);
-		evpn_auto_rt_import_add_for_vrf(bgp_vrf);
+		if (is_l3vni_live(bgp_vrf))
+			evpn_auto_rt_import_add_for_vrf(bgp_vrf);
 	}
 
 	/* map VRFs to its RTs and install routes matching this new RT */
@@ -4735,7 +4736,8 @@ void bgp_evpn_configure_export_rt_for_vrf(struct bgp *bgp_vrf,
 	listnode_add_sort(bgp_vrf->vrf_export_rtl, ecomadd);
 	SET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_EXPORT_RT_CFGD);
 
-	bgp_evpn_handle_export_rt_change_for_vrf(bgp_vrf);
+	if (is_l3vni_live(bgp_vrf))
+		bgp_evpn_handle_export_rt_change_for_vrf(bgp_vrf);
 }
 
 void bgp_evpn_unconfigure_export_rt_for_vrf(struct bgp *bgp_vrf,
@@ -4769,10 +4771,12 @@ void bgp_evpn_unconfigure_export_rt_for_vrf(struct bgp *bgp_vrf,
 	/* fall back to auto-generated RT if this was the last RT */
 	if (list_isempty(bgp_vrf->vrf_export_rtl)) {
 		UNSET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_EXPORT_RT_CFGD);
-		evpn_auto_rt_export_add_for_vrf(bgp_vrf);
+		if (is_l3vni_live(bgp_vrf))
+			evpn_auto_rt_export_add_for_vrf(bgp_vrf);
 	}
 
-	bgp_evpn_handle_export_rt_change_for_vrf(bgp_vrf);
+	if (is_l3vni_live(bgp_vrf))
+		bgp_evpn_handle_export_rt_change_for_vrf(bgp_vrf);
 }
 
 /*


### PR DESCRIPTION
We use ASN:VNI format to calculate auto RT for L3VNI.
When L3VNI is not configured, if we delete the configured RT, incorrect auto-RT
value is generated as VRF VNI is 0.

Fix:
Do not configure auto-RT if L3VNI is not configured.

Trigger:
1. Delete L3VNI
2. Delete configured RT.

Before fix:

dev# sh bgp vrf vrf-blue vni
BGP VRF: vrf-blue
  Local-Ip: 10.100.0.1
  L3-VNI: 0
  Rmac: 00:00:00:00:00:00
  VNI Filter: none
  L2-VNI List:

  Export-RTs:
  RT:101:0
  Import-RTs:
  RT:101:0
  RD: 10.100.0.1:2

After fix:

dev# sh bgp vrf vrf-blue vni
BGP VRF: vrf-blue
  Local-Ip: 10.100.0.1
  L3-VNI: 0
  Rmac: 00:00:00:00:00:00
  VNI Filter: none
  L2-VNI List:

  Export-RTs:

  Import-RTs:

  RD: 10.100.0.1:2

Signed-off-by: Ameya Dharkar <adharkar@vmware.com>