### PR TITLE
tools: ignore prefix-lists, routemaps etc. in frr-reload.py for daemons other than zebra

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -260,6 +260,15 @@ class Config(object):
                     not line):
                 continue
 
+            # some config lines appear for all daemons, which is an issue when computing the diff per-daemon
+            # so skip those if daemon is set and it's not zebra
+            if daemon and daemon is not "zebra":
+                if (line.startswith("ip prefix-list") or
+                        line.startswith("ipv6 prefix-list") or
+                        line.startswith("route-map") or
+                        line.startswith("access-list")):
+                    continue
+
             self.lines.append(line)
 
         self.load_contexts()


### PR DESCRIPTION
some configuration options like prefix-lists, route-maps etc. appear in multiple daemons' config, because IGPs need to be aware
of them; this is a problem when we are trying to compute a diff for a single daemon in frr-reload.py.

The solution is to skip those config lines when parsing them from vtysh if a daemon other than zebra was specified.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>