### PR TITLE
ISIS VRF: Added vrf_socket and new param in isisd privileges.

### DIFF
--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -66,7 +66,7 @@
 #define FABRICD_VTY_PORT     2618
 
 /* isisd privileges */
-zebra_capabilities_t _caps_p[] = {ZCAP_NET_RAW, ZCAP_BIND};
+zebra_capabilities_t _caps_p[] = {ZCAP_NET_RAW, ZCAP_BIND, ZCAP_SYS_ADMIN};
 
 struct zebra_privs_t isisd_privs = {
 #if defined(FRR_USER)


### PR DESCRIPTION
1. The socket() call replaced with vrf_socket() in open_packet_socket().
2. One new isisd privileges is added in zebra_capabilities_t [].

Signed-off-by: Kaushik <kaushik@niralnetworks.com>