### PR TITLE
tools: Fix reload with 'ipv6 address...' in interface

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -234,7 +234,7 @@ class Config(object):
             # Compress duplicate whitespaces
             line = ' '.join(line.split())
 
-            if ":" in line:
+            if ":" in line and not "ipv6 add":
                 qv6_line = get_normalized_ipv6_line(line)
                 self.lines.append(qv6_line)
             else:


### PR DESCRIPTION
When you have this configuration:

int foo
  ipv6 address fd01:0:0:1::1/64

And issue a reload statement, FRR-reload
is reducing the code to a
`no ipv6 address fd01:0:0:1::/64`
and then issuing a:
`ipv6 address fd01:0:0:1::/64`

The end result is of course that the foo
interface now has two v6 addresses on it.

The brilliance of this is of course if you
happen to have two systems that are connected
over an interface, and you issue a reload command.
They both get fd01:0:0:1::/64 as an ipv6 address
and DAD detection kicks in and stomps on your stuff.

Put a special hey don't munch the v6 address line
in a reload situation.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>