### PR TITLE
lib, zebra: Notice DAD Failed but don't use

### DIFF
--- a/lib/if.h
+++ b/lib/if.h
@@ -411,6 +411,7 @@ struct connected {
 #define ZEBRA_IFA_SECONDARY    (1 << 0)
 #define ZEBRA_IFA_PEER         (1 << 1)
 #define ZEBRA_IFA_UNNUMBERED   (1 << 2)
+#define ZEBRA_IFA_DADFAILED    (1 << 3)
 	/* N.B. the ZEBRA_IFA_PEER flag should be set if and only if
 	   a peer address has been configured.  If this flag is set,
 	   the destination field must contain the peer address.

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -456,6 +456,13 @@ struct zapi_route {
  * route entry.  This mainly is used for backup static routes.
  */
 #define ZEBRA_FLAG_RR_USE_DISTANCE    0x40
+/*
+ * With IPv6 routes, there is a mechanism for DAD
+ * when FRR detects this, we need to note to the rib
+ * that it *exists* but there is a problem.
+ * this is how this is done.
+ */
+#define ZEBRA_FLAG_NEVER_SELECT       0x80
 
 	/* The older XXX_MESSAGE flags live here */
 	uint8_t message;

--- a/zebra/connected.h
+++ b/zebra/connected.h
@@ -55,7 +55,7 @@ extern void connected_down(struct interface *ifp, struct connected *ifc);
 extern void connected_add_ipv6(struct interface *ifp, int flags,
 			       struct in6_addr *address, struct in6_addr *dest,
 			       uint16_t prefixlen, const char *label,
-			       uint32_t metric);
+			       uint32_t metric, bool dad_failed);
 extern void connected_delete_ipv6(struct interface *ifp,
 				  struct in6_addr *address,
 				  struct in6_addr *dest, uint16_t prefixlen);

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -259,7 +259,7 @@ static int if_getaddrs(void)
 #endif
 
 			connected_add_ipv6(ifp, flags, &addr->sin6_addr, NULL,
-					   prefixlen, NULL, METRIC_MAX);
+					   prefixlen, NULL, METRIC_MAX, false);
 		}
 	}
 

--- a/zebra/if_ioctl_solaris.c
+++ b/zebra/if_ioctl_solaris.c
@@ -307,7 +307,7 @@ static int if_get_addr(struct interface *ifp, struct sockaddr *addr,
 				   METRIC_MAX);
 	else if (af == AF_INET6)
 		connected_add_ipv6(ifp, flags, &SIN6(addr)->sin6_addr, NULL,
-				   prefixlen, label, METRIC_MAX);
+				   prefixlen, label, METRIC_MAX, false);
 
 	return 0;
 }

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1146,19 +1146,15 @@ int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			return -1;
 		}
 		if (h->nlmsg_type == RTM_NEWADDR) {
-			/* Only consider valid addresses; we'll not get a
-			 * notification from
-			 * the kernel till IPv6 DAD has completed, but at init
-			 * time, Quagga
-			 * does query for and will receive all addresses.
-			 */
-			if (!(kernel_flags
-			      & (IFA_F_DADFAILED | IFA_F_TENTATIVE)))
-				connected_add_ipv6(ifp, flags,
-						   (struct in6_addr *)addr,
-						   (struct in6_addr *)broad,
-						   ifa->ifa_prefixlen, label,
-						   metric);
+			bool dad_failed = false;
+
+			if (kernel_flags & (IFA_F_DADFAILED | IFA_F_TENTATIVE))
+				dad_failed = true;
+
+			connected_add_ipv6(ifp, flags, (struct in6_addr *)addr,
+					   (struct in6_addr *)broad,
+					   ifa->ifa_prefixlen, label, metric,
+					   dad_failed);
 		} else
 			connected_delete_ipv6(ifp, (struct in6_addr *)addr,
 					      NULL, ifa->ifa_prefixlen);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1215,6 +1215,9 @@ static void connected_dump_vty(struct vty *vty, struct connected *connected)
 	if (connected->label)
 		vty_out(vty, " %s", connected->label);
 
+	if (CHECK_FLAG(connected->flags, ZEBRA_IFA_DADFAILED))
+		vty_out(vty, " DAD Failed");
+
 	vty_out(vty, "\n");
 }
 

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -927,7 +927,7 @@ int ifam_read(struct ifa_msghdr *ifam)
 					   NULL,
 					   ip6_masklen(mask.sin6.sin6_addr),
 					   (isalias ? ifname : NULL),
-					   METRIC_MAX);
+					   METRIC_MAX, false);
 		else
 			connected_delete_ipv6(ifp, &addr.sin6.sin6_addr, NULL,
 					      ip6_masklen(mask.sin6.sin6_addr));

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1108,7 +1108,8 @@ static void rib_process(struct route_node *rn)
 					   ROUTE_ENTRY_CHANGED);
 			new_fib = best;
 		} else {
-			best = rib_choose_best(new_selected, re);
+			if (!CHECK_FLAG(re->flags, ZEBRA_FLAG_NEVER_SELECT))
+				best = rib_choose_best(new_selected, re);
 			if (new_selected && best != new_selected)
 				UNSET_FLAG(new_selected->status,
 					   ROUTE_ENTRY_CHANGED);
@@ -1296,7 +1297,10 @@ static void zebra_rib_fixup_system(struct route_node *rn)
 		if (CHECK_FLAG(re->status, ROUTE_ENTRY_REMOVED))
 			continue;
 
-		SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_NEVER_SELECT))
+			SET_FLAG(re->status, ROUTE_ENTRY_FAILED);
+		else
+			SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
 		UNSET_FLAG(re->status, ROUTE_ENTRY_QUEUED);
 
 		for (ALL_NEXTHOPS(re->nhe->nhg, nhop)) {

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -387,6 +387,8 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 		}
 		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED))
 			vty_out(vty, ", best");
+		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_NEVER_SELECT))
+			vty_out(vty, ", Not Usable");
 		vty_out(vty, "\n");
 
 		time_t uptime;


### PR DESCRIPTION
ipv6 addresses on interfaces can be notified to zebra
that the kernel has noticed that a interface has
a duplicate address on an interface.

When this happens the kernel tells zebra about this
situation.  Prior to this change we were just silently
dropping this and never creating a connected interface.

With this change we now notice that a interface is in
a DAD state, keep the connected interface as well as
marking the created route as rejected.  Hopefully we
add enough bread crumbs to allow the end user to figure
out what has gone wrong.

From talking with kernel people you can modify kernel
behavior for DAD routes via the accept_dad sysctl.
Please see the kernel documenation for how it works.

Additionally the `official` recovery methodology
is to fix the address and then down/up the link.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>