### PR TITLE
bgpd: Have bgp ignore SIGHUP at the moment

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -126,8 +126,18 @@ static struct frr_daemon_info bgpd_di;
 /* SIGHUP handler. */
 void sighup(void)
 {
-	zlog_info("SIGHUP received");
+	zlog_info("SIGHUP received, ignoring");
 
+	return;
+
+	/*
+	 * This is turned off for the moment.  There is all
+	 * sorts of config turned off by bgp_terminate
+	 * that is not setup properly again in bgp_rest.
+	 * I see no easy way to do this nor do I see that
+	 * this is a desirable way to reload config
+	 * given the yang work.
+	 */
 	/* Terminate all thread. */
 	bgp_terminate();
 	bgp_reset();


### PR DESCRIPTION
SIGHUP is ostensibly supposed to reload configuration
from a fresh slate.  This is currently horribly broken
so much so that bgp just crashes.  I see no point
in trying to make this work considering the yang
work coming down the pike.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>