### PR TITLE
test: fix some typos in bgp_multi_vrf_topo1

### DIFF
--- a/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
+++ b/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
@@ -657,10 +657,10 @@ def test_static_routes_associated_to_specific_vrfs_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that static routes 1.x.x.x/32 and 1::x/128 appear" "in VRF RED_A table"
+        "Verify that static routes 1.x.x.x/32 and 1::x/128 appear " "in VRF RED_A table"
     )
     step(
-        "Verify that static routes 2.x.x.x/32 and 2::x/128 appear" "in VRF RED_B table"
+        "Verify that static routes 2.x.x.x/32 and 2::x/128 appear " "in VRF RED_B table"
     )
 
     for addr_type in ADDR_TYPES:
@@ -688,10 +688,10 @@ def test_static_routes_associated_to_specific_vrfs_p0(request):
         )
 
     step(
-        "Verify that static routes 1.x.x.x/32 and 1::x/128 appear" "in VRF BLUE_A table"
+        "Verify that static routes 1.x.x.x/32 and 1::x/128 appear " "in VRF BLUE_A table"
     )
     step(
-        "Verify that static routes 2.x.x.x/32 and 2::x/128 appear" "in VRF BLUE_B table"
+        "Verify that static routes 2.x.x.x/32 and 2::x/128 appear " "in VRF BLUE_B table"
     )
 
     for addr_type in ADDR_TYPES:
@@ -1079,7 +1079,7 @@ def test_prefixes_leaking_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify on R1 that RED_A doesn't receive and static "
+        "Verify on R1 that RED_A doesn't receive any static "
         "route with metric value 123"
     )
 


### PR DESCRIPTION
Noticed a few text things in this topotest while tracking down some issues - thought we might as well clean them up?