### PR TITLE
tests: pbr is not working properly on arm 4.9 kernels

### DIFF
--- a/tests/topotests/pbr-topo1/test_pbr_topo1.py
+++ b/tests/topotests/pbr-topo1/test_pbr_topo1.py
@@ -32,6 +32,7 @@ import re
 import sys
 import pytest
 import json
+import platform
 from functools import partial
 
 # Save the Current Working Directory to find configuration files.
@@ -84,6 +85,11 @@ def setup_module(module):
     "Setup topology"
     tgen = Topogen(NetworkTopo, module.__name__)
     tgen.start_topology()
+
+    krel = platform.release()
+    if topotest.version_cmp(krel, "4.10") < 0:
+	tgen.errors = "Newer kernel than 4.9 needed for pbr tests"
+	pytest.skip(tgen.errors)
 
     router_list = tgen.routers()
     for rname, router in router_list.iteritems():


### PR DESCRIPTION
Just disable pbr tests on anything less than 4.10.

This has to do with the fact that the arm platform
is not allowing us to install a route into a
non default table using a interface associated
with a vrf.

ip route add default 4.5.6.7 via swp39 table 10000

When swp39 is in a vrf other than default

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>