### PR TITLE
pbrd, lib: remember to free alloc'd qobj elements on delete

### DIFF
--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -614,6 +614,7 @@ static void nhgc_delete(struct nexthop_group_cmd *nhgc)
 
 	list_delete(&nhgc->nhg_list);
 
+	QOBJ_UNREG(nhgc);
 	XFREE(MTYPE_TMP, nhgc);
 }
 

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -75,6 +75,7 @@ static void pbr_map_sequence_delete(struct pbr_map_sequence *pbrms)
 {
 	XFREE(MTYPE_TMP, pbrms->internal_nhg_name);
 
+	QOBJ_UNREG(pbrms);
 	XFREE(MTYPE_PBR_MAP_SEQNO, pbrms);
 }
 


### PR DESCRIPTION
When qobj items are registered in the `_create` functions (using `QOBJ_REG`), they must also be deleted in the `_delete` functions when their memory is freed using `QOBJ_UNREG`)

The absence of these `QOBJ_UNREG` commands caused wonky behavior in qobj land when deleting a lot of nexthop_groups or pbr map sequences; this behavior was not exposed until the hash size was grown, causing a core dump in pbrd.