### PR TITLE
bgpd: Actually find the sequence number for `bgp extcommunity-list...`

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17617,8 +17617,7 @@ DEFUN (extcommunity_list_standard,
 	argv_find(argv, argc, "WORD", &idx);
 	cl_number_or_name = argv[idx]->arg;
 
-	argv_find(argv, argc, "(1-4294967295)", &idx);
-	if (idx)
+	if (argv_find(argv, argc, "(1-4294967295)", &idx))
 		seq = argv[idx]->arg;
 
 	direct = argv_find(argv, argc, "permit", &idx) ? COMMUNITY_PERMIT
@@ -17663,8 +17662,7 @@ DEFUN (extcommunity_list_name_expanded,
 	argv_find(argv, argc, "WORD", &idx);
 	cl_number_or_name = argv[idx]->arg;
 
-	argv_find(argv, argc, "(1-4294967295)", &idx);
-	if (idx)
+	if (argv_find(argv, argc, "(1-4294967295)", &idx))
 		seq = argv[idx]->arg;
 
 	direct = argv_find(argv, argc, "permit", &idx) ? COMMUNITY_PERMIT
@@ -17707,8 +17705,7 @@ DEFUN (no_extcommunity_list_standard_all,
 	char *seq = NULL;
 	int idx = 0;
 
-	argv_find(argv, argc, "(1-4294967295)", &idx);
-	if (idx)
+	if (argv_find(argv, argc, "(1-4294967295)", &idx))
 		seq = argv[idx]->arg;
 
 	idx = 0;
@@ -17772,8 +17769,7 @@ DEFUN (no_extcommunity_list_expanded_all,
 	char *seq = NULL;
 	int idx = 0;
 
-	argv_find(argv, argc, "(1-4294967295)", &idx);
-	if (idx)
+	if (argv_find(argv, argc, "(1-4294967295)", &idx))
 		seq = argv[idx]->arg;
 
 	idx = 0;


### PR DESCRIPTION
The code in the bgp extcommunity-list function was using
argv_find to get the correct idx.  The problem was that
we had already done argv_finds before and idx was non-zero
thus having us always set the seq pointer to what was last
looked up.  This causes us to pass in a value to the
underlying function and it would just wisely ignore it
causing a seq number of 0.

We would then write this seq number of 0 and then immediately
reject it on read in again.  BOO!

Actually handle argv_find the way it was meant to be.

Ticket:CM-29926
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>