### PR TITLE
isisd: log adj change when circuit goes down

### DIFF
--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -126,6 +126,9 @@ DECLARE_HOOK(isis_adj_ip_enabled_hook,
 	     (struct isis_adjacency *adj, int family), (adj, family))
 DECLARE_HOOK(isis_adj_ip_disabled_hook,
 	     (struct isis_adjacency *adj, int family), (adj, family))
+void isis_log_adj_change(struct isis_adjacency *adj,
+			 enum isis_adj_state old_state,
+			 enum isis_adj_state new_state, const char *reason);
 void isis_adj_state_change(struct isis_adjacency **adj,
 			   enum isis_adj_state state, const char *reason);
 void isis_adj_print(struct isis_adjacency *adj);


### PR DESCRIPTION
if we shutdown an interface isisd will delete the adjacencies on the corresponding circuit, but it will not log the change, regardless of the area configuration. Fix it to make sure that each change is logged. Also specify the level of the adjacency in the log message, while we are at it.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>