### PR TITLE
bgpd: Actually find the sequence number for large-community-list

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17332,8 +17332,7 @@ static int lcommunity_list_set_vty(struct vty *vty, int argc,
 	char *cl_name;
 	char *seq = NULL;
 
-	argv_find(argv, argc, "(1-4294967295)", &idx);
-	if (idx)
+	if (argv_find(argv, argc, "(1-4294967295)", &idx))
 		seq = argv[idx]->arg;
 
 	idx = 0;
@@ -17382,8 +17381,7 @@ static int lcommunity_list_unset_vty(struct vty *vty, int argc,
 	int idx = 0;
 	char *seq = NULL;
 
-	argv_find(argv, argc, "(1-4294967295)", &idx);
-	if (idx)
+	if (argv_find(argv, argc, "(1-4294967295)", &idx))
 		seq = argv[idx]->arg;
 
 	idx = 0;

--- a/tools/coccinelle/argv_find.cocci
+++ b/tools/coccinelle/argv_find.cocci
@@ -1,0 +1,16 @@
+@@
+identifier idx;
+identifier argv;
+identifier argc;
+expression e1;
+expression e2;
+@@
+
+- argv_find(argv, argc, e1, &idx);
+  if (
+-   idx
++   argv_find(argv, argc, e1, &idx)
+  )
+  {
+    e2;
+  }


### PR DESCRIPTION
Add argv_find.cocci script to catch all those cases. Seems nothing more to add. 