### PR TITLE
Make lsb-base a hard dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Build-Depends:
  libssh-dev <!pkg.frr.nortrlib>,
  libsystemd-dev <!pkg.frr.nosystemd>,
  libyang-dev (>= 0.16.74),
+ lsb-base,
  pkg-config,
  python3,
  python3-dev,

--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -16,19 +16,7 @@
 # provides the actual functions to start/stop/restart things.
 #
 
-if [ -r "/lib/lsb/init-functions" ]; then
-	. /lib/lsb/init-functions
-else
-	log_success_msg() {
-		echo "$@"
-	}
-	log_warning_msg() {
-		echo "$@" >&2
-	}
-	log_failure_msg() {
-		echo "$@" >&2
-	}
-fi
+. /lib/lsb/init-functions
 
 self="`dirname $0`"
 if [ -r "$self/frrcommon.sh" ]; then


### PR DESCRIPTION
Instead of working around missing /lib/lsb/init-functions shell snippet,
directly depend on lsb-base, so we know it's always there.

Signed-off-by: Ondřej Surý <ondrej@sury.org>