### PR TITLE
bfdd: Use XFREE when freeing bfd profiles

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -120,7 +120,8 @@ void bfd_profile_free(struct bfd_profile *bp)
 
 	/* Remove from global list. */
 	TAILQ_REMOVE(&bplist, bp, entry);
-	free(bp);
+
+	XFREE(MTYPE_BFDD_PROFILE, bp);
 }
 
 /**


### PR DESCRIPTION
Use XFREE instead of raw free, clean up SA warning in bfd profile delete.