### PR TITLE
tests,zebra: fix more startup topotest issues

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1242,7 +1242,7 @@ class Router(Node):
         )
 
         # Now start all the other daemons
-        for daemon in self.daemons:
+        for daemon in daemons_list:
             # Skip disabled daemons and zebra
             if self.daemons[daemon] == 0:
                 continue

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -976,10 +976,10 @@ static void zebra_nhg_set_unhashable(struct nhg_hash_entry *nhe)
 	SET_FLAG(nhe->flags, NEXTHOP_GROUP_UNHASHABLE);
 	SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
 
-	flog_warn(
-		EC_ZEBRA_DUPLICATE_NHG_MESSAGE,
-		"Nexthop Group with ID (%d) is a duplicate, therefore unhashable, ignoring",
-		nhe->id);
+	flog(LOG_INFO,
+	     EC_ZEBRA_DUPLICATE_NHG_MESSAGE,
+	     "Nexthop Group with ID (%d) is a duplicate, therefore unhashable, ignoring",
+	     nhe->id);
 }
 
 static void zebra_nhg_set_valid(struct nhg_hash_entry *nhe)


### PR DESCRIPTION
Use the right list of daemons to avoid trying to start zebra twice - topotest.py was pruning one list of daemons, but then using another list. Also change a zebra log message to INFO level to avoid stderr check failure.
