### PR TITLE
bgpd: Some backports to 7.4

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -107,14 +107,14 @@ bool ecommunity_add_val(struct ecommunity *ecom, struct ecommunity_val *eval,
 			    p[1] == eval->val[1]) {
 				if (overwrite) {
 					memcpy(p, eval->val, ECOMMUNITY_SIZE);
-					return 1;
+					return true;
 				}
-				return 0;
+				return false;
 			}
 		}
 		int ret = memcmp(p, eval->val, ECOMMUNITY_SIZE);
 		if (ret == 0)
-			return 0;
+			return false;
 		if (ret > 0) {
 			if (!unique)
 				break;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1941,7 +1941,7 @@ bool subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 
 	/* Codification of AS 0 Processing */
 	if (aspath_check_as_zero(attr->aspath))
-		return 0;
+		return false;
 
 	if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
 		if (peer->sort == BGP_PEER_IBGP

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17235,8 +17235,7 @@ static int lcommunity_list_set_vty(struct vty *vty, int argc,
 	char *cl_name;
 	char *seq = NULL;
 
-	argv_find(argv, argc, "(1-4294967295)", &idx);
-	if (idx)
+	if (argv_find(argv, argc, "(1-4294967295)", &idx))
 		seq = argv[idx]->arg;
 
 	idx = 0;
@@ -17285,8 +17284,7 @@ static int lcommunity_list_unset_vty(struct vty *vty, int argc,
 	int idx = 0;
 	char *seq = NULL;
 
-	argv_find(argv, argc, "(1-4294967295)", &idx);
-	if (idx)
+	if (argv_find(argv, argc, "(1-4294967295)", &idx))
 		seq = argv[idx]->arg;
 
 	idx = 0;


### PR DESCRIPTION
bgpd: Actually find the sequence number for large-community-list
bgpd: Return bool type for ecommunity_add_val and subgroup_announce_check