### PR TITLE
lib: fix route map description memory leak

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -971,6 +971,9 @@ void route_map_index_delete(struct route_map_index *index, int notify)
 		zlog_debug("Deleting route-map %s sequence %d",
 			   index->map->name, index->pref);
 
+	/* Free route map entry description. */
+	XFREE(MTYPE_TMP, index->description);
+
 	/* Free route map northbound hook contexts. */
 	while ((rhc = TAILQ_FIRST(&index->rhclist)) != NULL)
 		routemap_hook_context_free(rhc);


### PR DESCRIPTION
Summary
------------

Fixes #6659 .

Route map entries are not getting a chance to call `description` string
deallocation on shutdown or when the parent entry is destroyed, so lets
add a code to handle this in the `route_map_index_delete` function.

This PR might need to be backported to 7.4.