### PR TITLE
doc: specify output for json commands w/ no output

### DIFF
--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -1034,7 +1034,9 @@ the development mailing list / public Slack instance.
 JSON Output
 ^^^^^^^^^^^
 
-All JSON keys are to be camelCased, with no spaces.
+* All JSON keys are to be camelCased, with no spaces
+* Commands which output JSON should produce ``{}`` if they have nothing to
+  display
 
 Use of const
 ^^^^^^^^^^^^


### PR DESCRIPTION
JSON commands should always return valid JSON

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>