### PR TITLE
tests: Fix rare case in ospf tests due to small hello timer

### DIFF
--- a/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
+++ b/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
@@ -599,6 +599,7 @@ def test_ospfv2_interfaces():
 
             # Drop time in next due 
             actual = re.sub(r"Hello due in [0-9\.]+s", "Hello due in XX.XXXs", actual)
+            actual = re.sub(r"Hello due in [0-9\.]+ usecs", "Hello due in XX.XXXs", actual)
             # Fix 'MTU mismatch detection: enabled' vs 'MTU mismatch detection:enabled' - accept both
             actual = re.sub(r"MTU mismatch detection:([a-z]+.*)", r"MTU mismatch detection: \1", actual)
             # Fix newlines (make them all the same)


### PR DESCRIPTION
There exists the possiblity that the hello timer printed would
show a time to expiration in this format:

Hello due in 350 usecs

The tests are looking for:

Hello due in 5.430s

Just notice that we may have gotten usecs and act accordingly

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>