### PR TITLE
doc: add note about generous BGP topotest timeouts

### DIFF
--- a/doc/developer/topotests-jsontopo.rst
+++ b/doc/developer/topotests-jsontopo.rst
@@ -55,8 +55,14 @@ This is the recommended test writing routine:
 * Create topology from json
 * Create configuration from json
 * Write the tests
+* Format the new code using `black <https://github.com/psf/black>`_
 * Create a Pull Request
 
+.. Note::
+
+   BGP tests MUST use generous convergence timeouts - you must ensure
+   that any test involving BGP uses a convergence timeout of at least
+   130 seconds.
 
 File Hierarchy
 ^^^^^^^^^^^^^^

--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -363,6 +363,12 @@ This is the recommended test writing routine:
 - Format the new code using `black <https://github.com/psf/black>`_
 - Create a Pull Request
 
+.. Note::
+
+   BGP tests MUST use generous convergence timeouts - you must ensure
+   that any test involving BGP uses a convergence timeout of at least
+   130 seconds.
+
 Topotest File Hierarchy
 """""""""""""""""""""""
 


### PR DESCRIPTION
We keep having trouble with bgp timers in the CI tests: add note blocks to the topotest and topotest-json dev docs to emphasize the need for generous BGP retry/convergence timers. 