### PR TITLE
zebra: Refactored Interface messages to zclients

### DIFF
--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -46,6 +46,7 @@
 #include "pbr_nht.h"
 #include "pbr_map.h"
 #include "pbr_zebra.h"
+#include "pbr_vrf.h"
 #include "pbr_vty.h"
 #include "pbr_debug.h"
 #include "pbr_vrf.h"

--- a/pbrd/pbr_vrf.c
+++ b/pbrd/pbr_vrf.c
@@ -21,6 +21,8 @@
 
 #include "vrf.h"
 
+#include "pbr_nht.h"
+#include "pbr_zebra.h"
 #include "pbr_vrf.h"
 #include "pbr_memory.h"
 #include "pbr_map.h"
@@ -61,6 +63,7 @@ static int pbr_vrf_enable(struct vrf *vrf)
 
 	pbr_map_vrf_update(vrf->info);
 
+	pbr_zebra_vrf_register(vrf);
 	return 0;
 }
 
@@ -70,6 +73,7 @@ static int pbr_vrf_disable(struct vrf *vrf)
 
 	pbr_map_vrf_update(vrf->info);
 
+	pbr_zebra_vrf_unregister(vrf);
 	return 0;
 }
 

--- a/pbrd/pbr_vrf.h
+++ b/pbrd/pbr_vrf.h
@@ -38,6 +38,5 @@ extern struct pbr_vrf *pbr_vrf_lookup_by_id(vrf_id_t vrf_id);
 extern struct pbr_vrf *pbr_vrf_lookup_by_name(const char *name);
 extern bool pbr_vrf_is_valid(const struct pbr_vrf *pbr_vrf);
 extern bool pbr_vrf_is_enabled(const struct pbr_vrf *pbr_vrf);
-
 extern void pbr_vrf_init(void);
 #endif

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -594,3 +594,17 @@ void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 
 	zclient_send_message(zclient);
 }
+
+void pbr_zebra_vrf_register(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void pbr_zebra_vrf_unregister(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_dereg_requests(zclient, vrf->vrf_id);
+}

--- a/pbrd/pbr_zebra.h
+++ b/pbrd/pbr_zebra.h
@@ -46,4 +46,7 @@ extern int pbr_ifp_up(struct interface *ifp);
 extern int pbr_ifp_down(struct interface *ifp);
 extern int pbr_ifp_destroy(struct interface *ifp);
 
+void pbr_zebra_vrf_register(struct vrf *vrf);
+void pbr_zebra_vrf_unregister(struct vrf *vrf);
+
 #endif

--- a/pbrd/subdir.am
+++ b/pbrd/subdir.am
@@ -15,6 +15,7 @@ endif
 
 pbrd_libpbr_a_SOURCES = \
 	pbrd/pbr_zebra.c \
+	pbrd/pbr_vrf.c \
 	pbrd/pbr_vty.c \
 	pbrd/pbr_map.c \
 	pbrd/pbr_memory.c \
@@ -29,6 +30,7 @@ noinst_HEADERS += \
 	pbrd/pbr_nht.h \
 	pbrd/pbr_vty.h \
 	pbrd/pbr_zebra.h \
+	pbrd/pbr_vrf.h \
 	pbrd/pbr_debug.h \
 	pbrd/pbr_vrf.h \
 	# end

--- a/zebra/zebra_ptm_redistribute.c
+++ b/zebra/zebra_ptm_redistribute.c
@@ -36,6 +36,10 @@ static int zsend_interface_bfd_update(int cmd, struct zserv *client,
 	int blen;
 	struct stream *s;
 
+	/* Check this client need interface information. */
+	if (!vrf_bitmap_check(client->ifinfo, vrf_id))
+		return 0;
+
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, vrf_id);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -629,6 +629,7 @@ static void zserv_client_free(struct zserv *client)
 
 		vrf_bitmap_free(client->redist_default[afi]);
 	}
+	vrf_bitmap_free(client->ifinfo);
 	vrf_bitmap_free(client->ridinfo);
 
 	/*
@@ -751,6 +752,7 @@ static struct zserv *zserv_client_create(int sock)
 			client->redist[afi][i] = vrf_bitmap_init();
 		client->redist_default[afi] = vrf_bitmap_init();
 	}
+	client->ifinfo = vrf_bitmap_init();
 	client->ridinfo = vrf_bitmap_init();
 
 	/* Add this client to linked list. */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -134,6 +134,9 @@ struct zserv {
 	/* Redistribute default route flag. */
 	vrf_bitmap_t redist_default[AFI_MAX];
 
+	/* VRF registration information. */
+	vrf_bitmap_t ifinfo;
+
 	/* Router-id information. */
 	vrf_bitmap_t ridinfo;
 


### PR DESCRIPTION
Protocol daemons register with Zebra for interface events. While some protocol
daemons have VRF-based registration, others register for Default VRF only.

For lack of VRF awareness, when a protocol daemon registers for a specific VRF.
Zebra sends out the Interface events for all interfaces in the system.

In a scaled environment with hundereds of VRFs and thousands of interfaces,
this causes an unnecessary flood of events to daemons such as BGP, OSPF etc.

So, I have reinstated the VRF awareness for zclients.

VRF-aware zclients register for VRF when the corresponding deamon has configuration
related to the VRF.

VRF-unaware zclients register for VRF when a VRF is enabled and unregisters
VRF when it is disabled.

Signed-off-by: Kishore Aramalla <kishore.aramalla@vmware.com>