### PR TITLE
ospfd: allow interfaces to come up in rare situation

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -132,6 +132,18 @@ void ospf_router_id_update(struct ospf *ospf)
 			 * !(virtual | ptop) links
 			 */
 			ospf_nbr_self_reset(oi, router_id);
+
+			/*
+			 * If the old router id was not set, but now it
+			 * is and the interface is operative and the
+			 * state is ISM_Down we should kick the state
+			 * machine as that we processed the interfaces
+			 * based upon the network statement( or intf config )
+			 * but could not start it at that time.
+			 */
+			if (if_is_operative(oi->ifp) && oi->state == ISM_Down
+			    && router_id_old.s_addr == INADDR_ANY)
+				ospf_if_up(oi);
 		}
 
 		/* Flush (inline) all external LSAs based on the OSPF_LSA_SELF


### PR DESCRIPTION
On startup of both zebra and ospfd.  If ospfd has not
received a valid router-id *but* has received interface
data, interfaces will not be turned on in the state
machine.  When ospf finally receives a valid router-id
it would never actually kick the state machine into
action for those interfaces it has been configured for.

Modify ospf on router id changes, *if* the old
router id was INADDR_ANY *and* the interface is
operative *and* the oi->state is ISM_Down, give
it the old kick in the patooeys

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>