### PR TITLE
zebra: always set kernel table ID in FPM netlink

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -294,6 +294,7 @@ struct rib_table_info {
 	struct zebra_vrf *zvrf;
 	afi_t afi;
 	safi_t safi;
+	uint32_t table_id;
 };
 
 enum rib_tables_iter_state {

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -279,7 +279,6 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 				   rib_dest_t *dest, struct route_entry *re)
 {
 	struct nexthop *nexthop;
-	struct zebra_vrf *zvrf;
 
 	memset(ri, 0, sizeof(*ri));
 
@@ -287,9 +286,7 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 	ri->af = rib_dest_af(dest);
 
 	ri->nlmsg_type = cmd;
-	zvrf = rib_dest_vrf(dest);
-	if (zvrf)
-		ri->rtm_table = zvrf->table_id;
+	ri->rtm_table = rib_table_info(rib_dest_table(dest))->table_id;
 	ri->rtm_protocol = RTPROT_UNSPEC;
 
 	/*

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -133,6 +133,7 @@ struct route_table *zebra_router_get_table(struct zebra_vrf *zvrf,
 	info->zvrf = zvrf;
 	info->afi = afi;
 	info->safi = safi;
+	info->table_id = tableid;
 	route_table_set_info(zrt->table, info);
 	zrt->table->cleanup = zebra_rtable_node_cleanup;
 


### PR DESCRIPTION
rtm_table is not correctly set when the route is installed in a non-main table. This prevents the FPM server from knowing the correct table in which to install such routes.