### PR TITLE
ospf6: decimal area format in interface command

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -20,8 +20,11 @@ OSPF6 router
 
    Set router's Router-ID.
 
-.. index:: interface IFNAME area AREA
-.. clicmd:: interface IFNAME area AREA
+.. index:: interface IFNAME area (0-4294967295)
+.. clicmd:: interface IFNAME area (0-4294967295)
+
+.. index:: interface IFNAME area A.B.C.D
+.. clicmd:: interface IFNAME area A.B.C.D
 
    Bind interface to specified area, and start sending OSPF packets. `area` can
    be specified as 0.

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -379,22 +379,6 @@ void ospf6_area_show(struct vty *vty, struct ospf6_area *oa)
 		vty_out(vty, "SPF has not been run\n");
 }
 
-
-#define OSPF6_CMD_AREA_GET(str, oa)                                            \
-	{                                                                      \
-		char *ep;                                                      \
-		uint32_t area_id = htonl(strtoul(str, &ep, 10));               \
-		if (*ep && inet_pton(AF_INET, str, &area_id) != 1) {           \
-			vty_out(vty, "Malformed Area-ID: %s\n", str);          \
-			return CMD_SUCCESS;                                    \
-		}                                                              \
-		int format = !*ep ? OSPF6_AREA_FMT_DECIMAL                     \
-				  : OSPF6_AREA_FMT_DOTTEDQUAD;                 \
-		oa = ospf6_area_lookup(area_id, ospf6);                        \
-		if (oa == NULL)                                                \
-			oa = ospf6_area_create(area_id, ospf6, format);        \
-	}
-
 DEFUN (area_range,
        area_range_cmd,
        "area <A.B.C.D|(0-4294967295)> range X:X::X:X/M [<advertise|not-advertise|cost (0-16777215)>]",

--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -117,6 +117,21 @@ struct ospf6_area {
 #define IS_AREA_TRANSIT(oa) (CHECK_FLAG ((oa)->flag, OSPF6_AREA_TRANSIT))
 #define IS_AREA_STUB(oa) (CHECK_FLAG ((oa)->flag, OSPF6_AREA_STUB))
 
+#define OSPF6_CMD_AREA_GET(str, oa)                                            \
+	{                                                                      \
+		char *ep;                                                      \
+		uint32_t area_id = htonl(strtoul(str, &ep, 10));               \
+		if (*ep && inet_pton(AF_INET, str, &area_id) != 1) {           \
+			vty_out(vty, "Malformed Area-ID: %s\n", str);          \
+			return CMD_SUCCESS;                                    \
+		}                                                              \
+		int format = !*ep ? OSPF6_AREA_FMT_DECIMAL                     \
+				  : OSPF6_AREA_FMT_DOTTEDQUAD;                 \
+		oa = ospf6_area_lookup(area_id, ospf6);                        \
+		if (oa == NULL)                                                \
+			oa = ospf6_area_create(area_id, ospf6, format);        \
+	}
+
 /* prototypes */
 extern int ospf6_area_cmp(void *va, void *vb);
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -644,11 +644,12 @@ DEFUN (no_ospf6_distance_source,
 
 DEFUN (ospf6_interface_area,
        ospf6_interface_area_cmd,
-       "interface IFNAME area A.B.C.D",
+       "interface IFNAME area <A.B.C.D|(0-4294967295)>",
        "Enable routing on an IPv6 interface\n"
        IFNAME_STR
        "Specify the OSPF6 area ID\n"
        "OSPF6 area ID in IPv4 address notation\n"
+       "OSPF6 area ID in decimal notation\n"
       )
 {
 	VTY_DECLVAR_CONTEXT(ospf6, o);
@@ -657,7 +658,6 @@ DEFUN (ospf6_interface_area,
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	struct interface *ifp;
-	uint32_t area_id;
 
 	/* find/create ospf6 interface */
 	ifp = if_get_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
@@ -671,15 +671,7 @@ DEFUN (ospf6_interface_area,
 	}
 
 	/* parse Area-ID */
-	if (inet_pton(AF_INET, argv[idx_ipv4]->arg, &area_id) != 1) {
-		vty_out(vty, "Invalid Area-ID: %s\n", argv[idx_ipv4]->arg);
-		return CMD_SUCCESS;
-	}
-
-	/* find/create ospf6 area */
-	oa = ospf6_area_lookup(area_id, o);
-	if (oa == NULL)
-		oa = ospf6_area_create(area_id, o, OSPF6_AREA_FMT_DOTTEDQUAD);
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, oa);
 
 	/* attach interface to area */
 	listnode_add(oa->if_list, oi); /* sort ?? */
@@ -703,12 +695,13 @@ DEFUN (ospf6_interface_area,
 
 DEFUN (no_ospf6_interface_area,
        no_ospf6_interface_area_cmd,
-       "no interface IFNAME area A.B.C.D",
+       "no interface IFNAME area <A.B.C.D|(0-4294967295)>",
        NO_STR
        "Disable routing on an IPv6 interface\n"
        IFNAME_STR
        "Specify the OSPF6 area ID\n"
        "OSPF6 area ID in IPv4 address notation\n"
+       "OSPF6 area ID in decimal notation\n"
        )
 {
 	int idx_ifname = 2;
@@ -731,10 +724,8 @@ DEFUN (no_ospf6_interface_area,
 	}
 
 	/* parse Area-ID */
-	if (inet_pton(AF_INET, argv[idx_ipv4]->arg, &area_id) != 1) {
-		vty_out(vty, "Invalid Area-ID: %s\n", argv[idx_ipv4]->arg);
-		return CMD_SUCCESS;
-	}
+	if (inet_pton(AF_INET, argv[idx_ipv4]->arg, &area_id) != 1)
+		area_id = htonl(strtoul(argv[idx_ipv4]->arg, NULL, 10));
 
 	/* Verify Area */
 	if (oi->area == NULL) {


### PR DESCRIPTION
The ospf6 "interface <blah> area <x>" command only allows the area to
be specified in the ipv4 address format, whereas the show run command
always shows it in the format in which the area was created. This causes
the frr-reload script to be unable to remove ospfv3 interfaces when the
area was created in decimal format. The solution is to allow both formats
to be configured as they can be for other area commands.

Signed-off-by: Duncan Eastoe <duncan.eastoe@att.com>

cc @pjdruddy 