### PR TITLE
Add BFD peer awareness to frr-reload.py and vtysh markfile

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -617,7 +617,7 @@ end
                 sub_main_ctx_key = copy.deepcopy(ctx_keys)
                 log.debug('LINE %-50s: entering sub-sub-context, append to ctx_keys', line)
                 ctx_keys.append(line)
-            
+
             elif ((line.startswith("interface ") and
                    len(ctx_keys) == 2 and
                    ctx_keys[0].startswith('mpls ldp') and

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -588,6 +588,7 @@ end
                   line.startswith("vnc defaults") or
                   line.startswith("vnc l2-group") or
                   line.startswith("vnc nve-group") or
+                  line.startswith("peer") or
                   line.startswith("member pseudowire")):
                 main_ctx_key = []
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -809,6 +809,9 @@ int vtysh_mark_file(const char *filename)
 			} else if ((prev_node == KEYCHAIN_KEY_NODE)
 				   && (tried == 1)) {
 				vty_out(vty, "exit\n");
+			} else if ((prev_node == BFD_PEER_NODE)
+				   && (tried == 1)) {
+				vty_out(vty, "exit\n");
 			} else if (tried) {
 				vty_out(vty, "end\n");
 			}


### PR DESCRIPTION
This PR is a bugfix for https://github.com/FRRouting/frr/issues/6511.

frr-reload.py is amended to recognize the peer sub-context in the BFD configuration node. Without this change, it erroneously treats everything under BFD as a single context as shown in this snippet from frr-reload.log
```
['\nbfd',
 '\nbfd\n peer 169.254.1.1',
 '\nbfd\n detect-multiplier 4']
```
With the included change, the peer is properly handled as a sub-context, and the peer config is handled properly.
```
['\nbfd',
 '\nbfd\n peer 169.254.1.1',
 '\nbfd\n peer 169.254.1.1\n detect-multiplier 4']
```

vtysh.c is amended to also recognize the peer sub-context in the BFD configuration node. Without this change, vtysh -m will not mark the exit of a peer and actually writes an end before the subsequent peers are processed. Without the exit in place for the peer, frr-reload.py will not recognize the need to pop up 1 context level. Here is vtysh -m without the change...
```
bfd
 peer 169.254.1.1
  detect-multiplier 4
 !
end
 peer 169.254.1.3
  detect-multiplier 4
 !
!
```
here is the output with the included patch.
```
bfd
 peer 169.254.1.1
  detect-multiplier 4
 !
exit
 peer 169.254.1.3
  detect-multiplier 4
 !
!
```