### PR TITLE
tests: use ipaddress module; tolerate missing support bundle file

### DIFF
--- a/tests/topotests/bgp-path-attributes-topo1/test_bgp_path_attributes.py
+++ b/tests/topotests/bgp-path-attributes-topo1/test_bgp_path_attributes.py
@@ -56,7 +56,6 @@ import pdb
 import json
 import time
 import inspect
-import ipaddress
 from time import sleep
 import pytest
 

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -21,7 +21,7 @@
 from copy import deepcopy
 from time import sleep
 import traceback
-import ipaddr
+import ipaddress
 import os
 import sys
 from lib import topotest
@@ -381,10 +381,10 @@ def __create_bgp_unicast_neighbor(
             del_action = advertise_network_dict.setdefault("delete", False)
 
             # Generating IPs for verification
-            prefix = str(ipaddr.IPNetwork(unicode(network[0])).prefixlen)
+            prefix = str(ipaddress.ip_network(unicode(network[0])).prefixlen)
             network_list = generate_ips(network, no_of_network)
             for ip in network_list:
-                ip = str(ipaddr.IPNetwork(unicode(ip)).network)
+                ip = str(ipaddress.ip_network(unicode(ip)).network_address)
 
                 cmd = "network {}/{}".format(ip, prefix)
                 if del_action:
@@ -859,7 +859,7 @@ def verify_router_id(tgen, topo, input_dict):
         logger.info("Checking router %s router-id", router)
         show_bgp_json = run_frr_cmd(rnode, "show bgp summary json", isjson=True)
         router_id_out = show_bgp_json["ipv4Unicast"]["routerId"]
-        router_id_out = ipaddr.IPv4Address(unicode(router_id_out))
+        router_id_out = ipaddress.IPv4Address(unicode(router_id_out))
 
         # Once router-id is deleted, highest interface ip should become
         # router-id
@@ -867,7 +867,7 @@ def verify_router_id(tgen, topo, input_dict):
             router_id = find_interface_with_greater_ip(topo, router)
         else:
             router_id = input_dict[router]["bgp"]["router_id"]
-        router_id = ipaddr.IPv4Address(unicode(router_id))
+        router_id = ipaddress.IPv4Address(unicode(router_id))
 
         if router_id == router_id_out:
             logger.info("Found expected router-id %s for router %s", router_id, router)
@@ -2102,7 +2102,7 @@ def verify_best_path_as_per_bgp_attribute(
 
             routes = generate_ips(_network, no_of_ip)
             for route in routes:
-                route = str(ipaddr.IPNetwork(unicode(route)))
+                route = str(ipaddress.ip_network(unicode(route)))
 
                 if route in sh_ip_bgp_json["routes"]:
                     route_attributes = sh_ip_bgp_json["routes"][route]
@@ -2411,7 +2411,7 @@ def verify_bgp_rib(tgen, addr_type, dut, input_dict, next_hop=None, aspath=None)
                     ip_list = generate_ips(network, no_of_ip)
 
                     for st_rt in ip_list:
-                        st_rt = str(ipaddr.IPNetwork(unicode(st_rt)))
+                        st_rt = str(ipaddress.ip_network(unicode(st_rt)))
 
                         _addr_type = validate_ip_address(st_rt)
                         if _addr_type != addr_type:
@@ -2547,7 +2547,7 @@ def verify_bgp_rib(tgen, addr_type, dut, input_dict, next_hop=None, aspath=None)
                     ip_list = generate_ips(network, no_of_network)
 
                     for st_rt in ip_list:
-                        st_rt = str(ipaddr.IPNetwork(unicode(st_rt)))
+                        st_rt = str(ipaddress.ip_network(unicode(st_rt)))
 
                         _addr_type = validate_ip_address(st_rt)
                         if _addr_type != addr_type:

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -36,7 +36,7 @@ import sys
 import ConfigParser
 import traceback
 import socket
-import ipaddr
+import ipaddress
 
 from lib.topolog import logger, logger_config
 from lib.topogen import TopoRouter, get_topogen
@@ -1066,10 +1066,10 @@ def generate_ips(network, no_of_ips):
 
         addr_type = validate_ip_address(start_ip)
         if addr_type == "ipv4":
-            start_ip = ipaddr.IPv4Address(unicode(start_ip))
+            start_ip = ipaddress.IPv4Address(unicode(start_ip))
             step = 2 ** (32 - mask)
         if addr_type == "ipv6":
-            start_ip = ipaddr.IPv6Address(unicode(start_ip))
+            start_ip = ipaddress.IPv6Address(unicode(start_ip))
             step = 2 ** (128 - mask)
 
         next_ip = start_ip
@@ -1077,7 +1077,7 @@ def generate_ips(network, no_of_ips):
         while count < no_of_ips:
             ipaddress_list.append("{}/{}".format(next_ip, mask))
             if addr_type == "ipv6":
-                next_ip = ipaddr.IPv6Address(int(next_ip) + step)
+                next_ip = ipaddress.IPv6Address(int(next_ip) + step)
             else:
                 next_ip += step
             count += 1
@@ -2273,7 +2273,7 @@ def verify_rib(
                     nh_found = False
 
                     for st_rt in ip_list:
-                        st_rt = str(ipaddr.IPNetwork(unicode(st_rt)))
+                        st_rt = str(ipaddress.ip_network(unicode(st_rt)))
 
                         _addr_type = validate_ip_address(st_rt)
                         if _addr_type != addr_type:
@@ -2469,7 +2469,7 @@ def verify_rib(
                 nh_found = False
 
                 for st_rt in ip_list:
-                    st_rt = str(ipaddr.IPNetwork(unicode(st_rt)))
+                    st_rt = str(ipaddress.ip_network(unicode(st_rt)))
 
                     _addr_type = validate_ip_address(st_rt)
                     if _addr_type != addr_type:

--- a/tests/topotests/lib/topojson.py
+++ b/tests/topotests/lib/topojson.py
@@ -21,7 +21,7 @@
 from collections import OrderedDict
 from json import dumps as json_dumps
 from re import search as re_search
-import ipaddr
+import ipaddress
 import pytest
 
 # Import topogen and topotest helpers
@@ -65,12 +65,12 @@ def build_topo_from_json(tgen, topo):
         listRouters.append(routerN)
 
     if "ipv4base" in topo:
-        ipv4Next = ipaddr.IPv4Address(topo["link_ip_start"]["ipv4"])
+        ipv4Next = ipaddress.IPv4Address(topo["link_ip_start"]["ipv4"])
         ipv4Step = 2 ** (32 - topo["link_ip_start"]["v4mask"])
         if topo["link_ip_start"]["v4mask"] < 32:
             ipv4Next += 1
     if "ipv6base" in topo:
-        ipv6Next = ipaddr.IPv6Address(topo["link_ip_start"]["ipv6"])
+        ipv6Next = ipaddress.IPv6Address(topo["link_ip_start"]["ipv6"])
         ipv6Step = 2 ** (128 - topo["link_ip_start"]["v6mask"])
         if topo["link_ip_start"]["v6mask"] < 127:
             ipv6Next += 1
@@ -181,7 +181,7 @@ def build_topo_from_json(tgen, topo):
                             destRouter_link_json["ipv6"] = "{}/{}".format(
                                 ipv6Next + 1, topo["link_ip_start"]["v6mask"]
                             )
-                            ipv6Next = ipaddr.IPv6Address(int(ipv6Next) + ipv6Step)
+                            ipv6Next = ipaddress.IPv6Address(int(ipv6Next) + ipv6Step)
 
             logger.debug(
                 "Generated link data for router: %s\n%s",

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1180,9 +1180,11 @@ class Router(Node):
     def startRouterDaemons(self, daemons=None):
         "Starts all FRR daemons for this router."
 
-        bundle_data = subprocess.check_output(
-            ["cat /etc/frr/support_bundle_commands.conf"], shell=True
-        )
+        bundle_data = ''
+
+        if os.path.exists('/etc/frr/support_bundle_commands.conf'):
+            bundle_data = subprocess.check_output(
+                ["cat /etc/frr/support_bundle_commands.conf"], shell=True)
         self.cmd(
             "echo '{}' > /etc/frr/support_bundle_commands.conf".format(bundle_data)
         )


### PR DESCRIPTION
Use the standard ipaddress python lib module instead of installing the deprecated ipaddr module. Also tolerate a missing 'support bundle' file - check /etc/frr/ for it before trying to read from it. At least in my development sandbox, 'make install' didn't create a file, and tests failed because the read failed.