### PR TITLE
zebra: mark connected nh inactive if not matching ifindex

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1921,6 +1921,13 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 				if (nexthop->type == NEXTHOP_TYPE_IPV4
 				    || nexthop->type == NEXTHOP_TYPE_IPV6)
 					nexthop->ifindex = newhop->ifindex;
+				else if (nexthop->ifindex != newhop->ifindex) {
+					/*
+					 * NEXTHOP_TYPE_*_IFINDEX but ifindex
+					 * doesn't match what we found.
+					 */
+					return 0;
+				}
 			}
 
 			if (IS_ZEBRA_DEBUG_NHG_DETAIL)


### PR DESCRIPTION
If we are asked to check if a nexthop is active and it matches a
connected route but the ifindex on it does not match the interface
with the connected route, mark as inactive. This is a bad nexthop.

Before, we would skip this check and just assume any nexthop that matches
on a connected route is valid and return here then fail during
installation. This adds a check for the IPV*_ifindex nexthop case where the
ifindex we have been sent doesn't match.

```
Old:
F>r 0.0.0.0/0 [200/0] via 20.0.0.2, test, weight 1, 00:00:27
  r                   via 40.4.4.4, lo, weight 1, 00:00:27

New:
F>* 0.0.0.0/0 [200/0] via 20.0.0.2, test, weight 1, 00:00:06
  *                   via 40.4.4.4, lo inactive, weight 1, 00:00:06
```

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>