### PR TITLE
zebra,fpm: fix force disable next hop groups

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1713,7 +1713,7 @@ ssize_t netlink_route_multipath_msg_encode(int cmd,
 		nl_attr_nest_end(&req->n, nest);
 	}
 
-	if (kernel_nexthops_supported() || force_nhg) {
+	if ((!fpm && kernel_nexthops_supported()) || (fpm && force_nhg)) {
 		/* Kernel supports nexthop objects */
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug("%s: %pFX nhg_id is %u", __func__, p,


### PR DESCRIPTION
`force_nhg` is only settable when calling from `fpm`, so if the kernel
was using next hop groups it would override our knob.