### PR TITLE
tests: [topojson] Increase BGP convergence wait time

### DIFF
--- a/tests/topotests/bgp-ecmp-topo2/test_ebgp_ecmp_topo2.py
+++ b/tests/topotests/bgp-ecmp-topo2/test_ebgp_ecmp_topo2.py
@@ -63,7 +63,7 @@ from lib.common_config import (
     reset_config_on_routers,
 )
 from lib.topolog import logger
-from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp_and_verify
+from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp
 from lib.topojson import build_topo_from_json, build_config_from_json
 
 # Reading the data from JSON File for topology and configuration creation
@@ -295,7 +295,7 @@ def test_modify_ecmp_max_paths(request, ecmp_num, test_type):
             addr_type,
             dut,
             input_dict_1,
-            next_hop=NEXT_HOPS[addr_type][:int(ecmp_num)],
+            next_hop=NEXT_HOPS[addr_type][: int(ecmp_num)],
             protocol=protocol,
         )
         assert result is True, "Testcase {} : Failed \n Error: {}".format(
@@ -336,8 +336,12 @@ def test_ecmp_after_clear_bgp(request, test_type):
             tc_name, result
         )
 
-    # Clear bgp
-    result = clear_bgp_and_verify(tgen, topo, dut)
+    # Clear BGP
+    for addr_type in ADDR_TYPES:
+        clear_bgp(tgen, addr_type, dut)
+
+    # Verify BGP convergence
+    result = verify_bgp_convergence(tgen, topo)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     for addr_type in ADDR_TYPES:

--- a/tests/topotests/bgp-ecmp-topo2/test_ibgp_ecmp_topo2.py
+++ b/tests/topotests/bgp-ecmp-topo2/test_ibgp_ecmp_topo2.py
@@ -63,7 +63,7 @@ from lib.common_config import (
     reset_config_on_routers,
 )
 from lib.topolog import logger
-from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp_and_verify
+from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp
 from lib.topojson import build_topo_from_json, build_config_from_json
 
 # Reading the data from JSON File for topology and configuration creation
@@ -296,7 +296,7 @@ def test_modify_ecmp_max_paths(request, ecmp_num, test_type):
             addr_type,
             dut,
             input_dict_1,
-            next_hop=NEXT_HOPS[addr_type][:int(ecmp_num)],
+            next_hop=NEXT_HOPS[addr_type][: int(ecmp_num)],
             protocol=protocol,
         )
         assert result is True, "Testcase {} : Failed \n Error: {}".format(
@@ -337,8 +337,12 @@ def test_ecmp_after_clear_bgp(request, test_type):
             tc_name, result
         )
 
-    # Clear bgp
-    result = clear_bgp_and_verify(tgen, topo, dut)
+    # Clear BGP
+    for addr_type in ADDR_TYPES:
+        clear_bgp(tgen, addr_type, dut)
+
+    # Verify BGP convergence
+    result = verify_bgp_convergence(tgen, topo)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     for addr_type in ADDR_TYPES:

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -44,7 +44,6 @@ from lib.common_config import (
 LOGDIR = "/tmp/topotests/"
 TMPDIR = None
 
-
 def create_router_bgp(tgen, topo, input_dict=None, build=False, load_config=True):
     """
     API to configure bgp on router
@@ -882,7 +881,7 @@ def verify_router_id(tgen, topo, input_dict):
     return True
 
 
-@retry(attempts=44, wait=3, return_is_str=True)
+@retry(attempts=50, wait=3, return_is_str=True)
 def verify_bgp_convergence(tgen, topo, dut=None):
     """
     API will verify if BGP is converged with in the given time frame.
@@ -1052,11 +1051,13 @@ def verify_bgp_convergence(tgen, topo, dut=None):
                                 if nh_state == "Established":
                                     no_of_peer += 1
 
-                if no_of_peer == total_peer:
-                    logger.info("[DUT: %s] VRF: %s, BGP is Converged", router, vrf)
-                else:
-                    errormsg = "[DUT: %s] VRF: %s, BGP is not converged" % (router, vrf)
-                    return errormsg
+                    if no_of_peer == total_peer:
+                        logger.info("[DUT: %s] VRF: %s, BGP is Converged for %s address-family",
+                                    router, vrf, addr_type)
+                    else:
+                        errormsg = ("[DUT: %s] VRF: %s, BGP is not converged for %s address-family" %
+                            (router, vrf, addr_type))
+                        return errormsg
 
     logger.debug("Exiting API: verify_bgp_convergence()")
     return True
@@ -1326,7 +1327,7 @@ def verify_as_numbers(tgen, topo, input_dict):
     return True
 
 
-@retry(attempts=44, wait=3, return_is_str=True)
+@retry(attempts=50, wait=3, return_is_str=True)
 def verify_bgp_convergence_from_running_config(tgen, dut=None):
     """
     API to verify BGP convergence b/w loopback and physical interface.
@@ -1470,7 +1471,7 @@ def clear_bgp_and_verify(tgen, topo, router):
     sleeptime = 3
 
     # Verifying BGP convergence before bgp clear command
-    for retry in range(44):
+    for retry in range(50):
         # Waiting for BGP to converge
         logger.info(
             "Waiting for %s sec for BGP to converge on router" " %s...",
@@ -1552,7 +1553,7 @@ def clear_bgp_and_verify(tgen, topo, router):
 
     peer_uptime_after_clear_bgp = {}
     # Verifying BGP convergence after bgp clear command
-    for retry in range(44):
+    for retry in range(50):
 
         # Waiting for BGP to converge
         logger.info(

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -690,6 +690,12 @@ def start_topology(tgen):
     router_list = tgen.routers()
     for rname in ROUTER_LIST:
         router = router_list[rname]
+
+        # It will help in debugging the failures, will give more details on which
+        # specific kernel version tests are failing
+        linux_ver = router.run("uname -a")
+        logger.info("Logging platform related details: \n %s \n", linux_ver)
+
         try:
             os.chdir(TMPDIR)
 


### PR DESCRIPTION
1. Increasing BGP convergence wait time to fix Ubuntu 16.04 arm8 box issue, as
bgp neighorship is taking more time to come up in this particular testbed.

Description:
Found through support bundles generated for test: test_bgp_recursive_route_ebgp_multi_hop/test_BGP_peering_bw_loopback_and_physical_p1 that BGP convergence is taking more time in Ununtu 16.04 arm8 box, so raising this pull request to fix issue specific to Ununtu 16.04 arm8.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>