### PR TITLE
ldpd: Update LDP to process received pw-status in received order.

### DIFF
--- a/ldpd/l2vpn.c
+++ b/ldpd/l2vpn.c
@@ -294,6 +294,16 @@ l2vpn_pw_reset(struct l2vpn_pw *pw)
 		pw->flags |= F_PW_STATUSTLV;
 	else
 		pw->flags &= ~F_PW_STATUSTLV;
+
+	if (pw->flags & F_PW_STATUSTLV_CONF) {
+		struct fec_node         *fn;
+		struct fec fec;
+		l2vpn_pw_fec(pw, &fec);
+		fn = (struct fec_node *)fec_find(&ft, &fec);
+		if (fn)
+			pw->remote_status = fn->pw_remote_status;
+	}
+
 }
 
 int
@@ -432,6 +442,8 @@ l2vpn_recv_pw_status(struct lde_nbr *ln, struct notify_msg *nm)
 	if (fn == NULL)
 		/* unknown fec */
 		return;
+
+	fn->pw_remote_status = nm->pw_status;
 
 	pw = (struct l2vpn_pw *) fn->data;
 	if (pw == NULL)

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -296,7 +296,7 @@ lde_dispatch_imsg(struct thread *thread)
 
 			switch (imsg.hdr.type) {
 			case IMSG_LABEL_MAPPING:
-				lde_check_mapping(map, ln);
+				lde_check_mapping(map, ln, 1);
 				break;
 			case IMSG_LABEL_REQUEST:
 				lde_check_request(map, ln);

--- a/ldpd/lde.h
+++ b/ldpd/lde.h
@@ -125,6 +125,9 @@ struct fec_node {
 	struct lde_map_head	 upstream;	/* sent mappings */
 
 	uint32_t		 local_label;
+
+	uint32_t		 pw_remote_status;
+
 	void			*data;		/* fec specific data */
 };
 
@@ -209,7 +212,7 @@ void		 lde_kernel_insert(struct fec *, int, union ldpd_addr *,
 void		 lde_kernel_remove(struct fec *, int, union ldpd_addr *,
 		    ifindex_t, uint8_t, unsigned short);
 void		 lde_kernel_update(struct fec *);
-void		 lde_check_mapping(struct map *, struct lde_nbr *);
+void		 lde_check_mapping(struct map *, struct lde_nbr *, int);
 void		 lde_check_request(struct map *, struct lde_nbr *);
 void		 lde_check_request_wcard(struct map *, struct lde_nbr *);
 void		 lde_check_release(struct map *, struct lde_nbr *);


### PR DESCRIPTION
ldpd: Update LDP to process received pw-status in received order.

Update LDP to process received pw-status in received order.
Update LDP to save pw-status regardless of whether the PW is configured.
When the PW is configured, LDP checks for any saved pw-status.

Signed-off-by: Karen Schoener <karen@voltanet.io> 