### PR TITLE
DSCP / ECN-based PBR Matching

### DIFF
--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -123,11 +123,15 @@ end destination.
    on another platform it will be denied.  This mark translates to the
    underlying `ip rule .... fwmark XXXX` command.
 
-.. clicmd:: match dscp (0-63)
+.. clicmd:: match dscp (DSCP|0-63)
 
    Match packets according to the specified differentiated services code point
    (DSCP) in the IP header; if this value matches then forward the packet
-   according to the nexthop(s) specified.
+   according to the nexthop(s) specified. The passed DSCP value may also be a
+   standard name for a differentiated service code point like cs0 or af11.
+
+   You may only specify one dscp per route map sequence; to match on multiple
+   dscp values you will need to create several sequences, one for each value.
 
 .. clicmd:: match ecn (0-3)
 

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -123,6 +123,18 @@ end destination.
    on another platform it will be denied.  This mark translates to the
    underlying `ip rule .... fwmark XXXX` command.
 
+.. clicmd:: match dscp (0-63)
+
+   Match packets according to the specified differentiated services code point
+   (DSCP) in the IP header; if this value matches then forward the packet
+   according to the nexthop(s) specified.
+
+.. clicmd:: match ecn (0-3)
+
+   Match packets according to the specified explicit congestion notification
+   (ECN) field in the IP header; if this value matches then forward the packet
+   according to the nexthop(s) specified.
+
 .. clicmd:: set nexthop-group NAME
 
    Use the nexthop-group NAME as the place to forward packets when the match

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -49,6 +49,10 @@ struct pbr_filter {
 #define PBR_FILTER_PROTO		(1 << 5)
 #define PBR_FILTER_SRC_PORT_RANGE	(1 << 6)
 #define PBR_FILTER_DST_PORT_RANGE	(1 << 7)
+#define PBR_FILTER_DSFIELD			(1 << 8)
+
+#define PBR_DSFIELD_DSCP (0xfc) /* Upper 6 bits of DS field: DSCP */
+#define PBR_DSFIELD_ECN (0x03)	/* Lower 2 bits of DS field: BCN */
 
 	/* Source and Destination IP address with masks. */
 	struct prefix src_ip;
@@ -57,6 +61,9 @@ struct pbr_filter {
 	/* Source and Destination higher-layer (TCP/UDP) port numbers. */
 	uint16_t src_port;
 	uint16_t dst_port;
+
+	/* Filter by Differentiated Services field  */
+	uint8_t dsfield; /* DSCP (6 bits) & ECN (2 bits) */
 
 	/* Filter with fwmark */
 	uint32_t fwmark;

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -444,6 +444,59 @@ static void pbr_map_add_interfaces(struct pbr_map *pbrm)
 	}
 }
 
+/* Decodes a standardized DSCP into its representative value */
+uint8_t pbr_map_decode_dscp_enum(const char *name)
+{
+	/* Standard Differentiated Services Field Codepoints */
+	if (!strcmp(name, "cs0"))
+		return 0;
+	if (!strcmp(name, "cs1"))
+		return 8;
+	if (!strcmp(name, "cs2"))
+		return 16;
+	if (!strcmp(name, "cs3"))
+		return 24;
+	if (!strcmp(name, "cs4"))
+		return 32;
+	if (!strcmp(name, "cs5"))
+		return 40;
+	if (!strcmp(name, "cs6"))
+		return 48;
+	if (!strcmp(name, "cs7"))
+		return 56;
+	if (!strcmp(name, "af11"))
+		return 10;
+	if (!strcmp(name, "af12"))
+		return 12;
+	if (!strcmp(name, "af13"))
+		return 14;
+	if (!strcmp(name, "af21"))
+		return 18;
+	if (!strcmp(name, "af22"))
+		return 20;
+	if (!strcmp(name, "af23"))
+		return 22;
+	if (!strcmp(name, "af31"))
+		return 26;
+	if (!strcmp(name, "af32"))
+		return 28;
+	if (!strcmp(name, "af33"))
+		return 30;
+	if (!strcmp(name, "af41"))
+		return 34;
+	if (!strcmp(name, "af42"))
+		return 36;
+	if (!strcmp(name, "af43"))
+		return 38;
+	if (!strcmp(name, "ef"))
+		return 46;
+	if (!strcmp(name, "voice-admit"))
+		return 44;
+
+	/* No match? Error out */
+	return -1;
+}
+
 struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
 {
 	struct pbr_map *pbrm;

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -547,7 +547,7 @@ pbr_map_sequence_check_nexthops_valid(struct pbr_map_sequence *pbrms)
 
 static void pbr_map_sequence_check_not_empty(struct pbr_map_sequence *pbrms)
 {
-	if (!pbrms->src && !pbrms->dst && !pbrms->mark)
+	if (!pbrms->src && !pbrms->dst && !pbrms->mark && !pbrms->dsfield)
 		pbrms->reason |= PBR_MAP_INVALID_EMPTY;
 }
 

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -89,6 +89,7 @@ struct pbr_map_sequence {
 	 */
 	struct prefix *src;
 	struct prefix *dst;
+	uint8_t dsfield;
 	uint32_t mark;
 
 	/*

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -169,6 +169,8 @@ extern void pbr_map_add_interface(struct pbr_map *pbrm, struct interface *ifp);
 extern void pbr_map_interface_delete(struct pbr_map *pbrm,
 				     struct interface *ifp);
 
+extern uint8_t pbr_map_decode_dscp_enum(const char *name);
+
 /* Update maps installed on interface */
 extern void pbr_map_policy_interface_update(const struct interface *ifp,
 					    bool state_up);

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -744,6 +744,12 @@ static void vty_json_pbrms(json_object *j, struct vty *vty,
 			prefix2str(pbrms->dst, buf, sizeof(buf)));
 	if (pbrms->mark)
 		json_object_int_add(jpbrm, "matchMark", pbrms->mark);
+	if (pbrms->dsfield & PBR_DSFIELD_DSCP)
+		json_object_int_add(jpbrm, "matchDscp",
+				    (pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2);
+	if (pbrms->dsfield & PBR_DSFIELD_ECN)
+		json_object_int_add(jpbrm, "matchEcn",
+				    pbrms->dsfield & PBR_DSFIELD_ECN);
 
 	json_object_array_add(j, jpbrm);
 }

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -536,6 +536,7 @@ static void pbr_encode_pbr_map_sequence(struct stream *s,
 	stream_putw(s, 0);  /* src port */
 	pbr_encode_pbr_map_sequence_prefix(s, pbrms->dst, family);
 	stream_putw(s, 0);  /* dst port */
+	stream_putc(s, pbrms->dsfield);
 	stream_putl(s, pbrms->mark);
 
 	if (pbrms->vrf_unchanged || pbrms->vrf_lookup)

--- a/tests/topotests/pbr-topo1/r1/pbr-map.json
+++ b/tests/topotests/pbr-topo1/r1/pbr-map.json
@@ -62,6 +62,32 @@
         },
         "matchDst":"dead:beef::\/64",
         "matchMark":314159
+      },
+      {
+        "sequenceNumber":15,
+        "vrfUnchanged":false,
+        "installed":true,
+        "installedReason":"Valid",
+        "nexthopGroup":{
+          "name":"ASAKUSA15",
+          "installed":true,
+          "installedInternally":1
+        },
+        "matchDst":"dead:beef::/64",
+        "matchDscp":10
+      },
+      {
+        "sequenceNumber":20,
+        "vrfUnchanged":false,
+        "installed":true,
+        "installedReason":"Valid",
+        "nexthopGroup":{
+          "name":"ASAKUSA20",
+          "installed":true,
+          "installedInternally":1
+        },
+        "matchDst":"dead:beef::/64",
+        "matchEcn":1
       }
     ]
   },

--- a/tests/topotests/pbr-topo1/r1/pbrd.conf
+++ b/tests/topotests/pbr-topo1/r1/pbrd.conf
@@ -73,6 +73,16 @@ pbr-map ASAKUSA seq 10
   match mark 314159
   set nexthop c0ff:ee::1
 !
+pbr-map ASAKUSA seq 15
+  match dst-ip dead:beef::/64
+  match dscp af11
+  set nexthop c0ff:ee::1
+!
+pbr-map ASAKUSA seq 20
+  match dst-ip dead:beef::/64
+  match ecn 1
+  set nexthop c0ff:ee::1
+!
 # Interface policies
 int r1-eth1
   pbr-policy EVA

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2526,6 +2526,7 @@ static inline void zread_rule(ZAPI_HANDLER_ARGS)
 		STREAM_GET(&zpr.rule.filter.dst_ip.u.prefix, s,
 			   prefix_blen(&zpr.rule.filter.dst_ip));
 		STREAM_GETW(s, zpr.rule.filter.dst_port);
+		STREAM_GETC(s, zpr.rule.filter.dsfield);
 		STREAM_GETL(s, zpr.rule.filter.fwmark);
 		STREAM_GETL(s, zpr.rule.action.table);
 		STREAM_GETL(s, zpr.rule.ifindex);
@@ -2555,6 +2556,9 @@ static inline void zread_rule(ZAPI_HANDLER_ARGS)
 
 		if (zpr.rule.filter.dst_port)
 			zpr.rule.filter.filter_bm |= PBR_FILTER_DST_PORT;
+
+		if (zpr.rule.filter.dsfield)
+			zpr.rule.filter.filter_bm |= PBR_FILTER_DSFIELD;
 
 		if (zpr.rule.filter.fwmark)
 			zpr.rule.filter.filter_bm |= PBR_FILTER_FWMARK;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -204,6 +204,7 @@ struct dplane_ctx_rule {
 	/* Filter criteria */
 	uint32_t filter_bm;
 	uint32_t fwmark;
+	uint8_t dsfield;
 	struct prefix src_ip;
 	struct prefix dst_ip;
 };
@@ -1676,6 +1677,20 @@ uint32_t dplane_ctx_rule_get_old_fwmark(const struct zebra_dplane_ctx *ctx)
 	return ctx->u.rule.old.fwmark;
 }
 
+uint8_t dplane_ctx_rule_get_dsfield(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.rule.new.dsfield;
+}
+
+uint8_t dplane_ctx_rule_get_old_dsfield(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.rule.old.dsfield;
+}
+
 const struct prefix *
 dplane_ctx_rule_get_src_ip(const struct zebra_dplane_ctx *ctx)
 {
@@ -2129,6 +2144,7 @@ static void dplane_ctx_rule_init_single(struct dplane_ctx_rule *dplane_rule,
 
 	dplane_rule->filter_bm = rule->rule.filter.filter_bm;
 	dplane_rule->fwmark = rule->rule.filter.fwmark;
+	dplane_rule->dsfield = rule->rule.filter.dsfield;
 	prefix_copy(&(dplane_rule->dst_ip), &rule->rule.filter.dst_ip);
 	prefix_copy(&(dplane_rule->src_ip), &rule->rule.filter.src_ip);
 }

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -412,6 +412,8 @@ uint32_t dplane_ctx_rule_get_filter_bm(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_rule_get_old_filter_bm(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_rule_get_fwmark(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_rule_get_old_fwmark(const struct zebra_dplane_ctx *ctx);
+uint8_t dplane_ctx_rule_get_dsfield(const struct zebra_dplane_ctx *ctx);
+uint8_t dplane_ctx_rule_get_old_dsfield(const struct zebra_dplane_ctx *ctx);
 const struct prefix *
 dplane_ctx_rule_get_src_ip(const struct zebra_dplane_ctx *ctx);
 const struct prefix *

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -54,6 +54,8 @@ struct zebra_pbr_rule {
 	(r->rule.filter.filter_bm & PBR_FILTER_SRC_PORT)
 #define IS_RULE_FILTERING_ON_DST_PORT(r) \
 	(r->rule.filter.filter_bm & PBR_FILTER_DST_PORT)
+#define IS_RULE_FILTERING_ON_DSFIELD(r) \
+	(r->rule.filter.filter_bm & PBR_FILTER_DSFIELD)
 #define IS_RULE_FILTERING_ON_FWMARK(r) \
 	(r->rule.filter.filter_bm & PBR_FILTER_FWMARK)
 


### PR DESCRIPTION
Match traffic based on its Differentiated Service Code Point (DSCP) or Explicit Congestion Notification (ECN) values. These 6-bit and 2-bit values respectively make up the DSField (Differentiated Services field) part of the IP header and may be used to shape and route different types of traffic using these operator defined values.
```
      0     1     2     3     4     5     6     7
    +-----+-----+-----+-----+-----+-----+-----+-----+
    |          DS FIELD, DSCP           | ECN FIELD |
    +-----+-----+-----+-----+-----+-----+-----+-----+
      DSCP: differentiated services codepoint
      ECN:  Explicit Congestion Notification
```
An example configuration might look like:
```
pbr-map mapA seq 10
  match src-ip 1.1.1.1/32
  set nexthop 1.1.1.3
  match dscp af11
pbr-map mapA seq 15
  match src-ip 1.1.1.2/32
  set nexthop 1.1.1.3
  match ecn 1
```
... the resultant kernel rule will then look like:
```
root@fresh-static-snow ~ # ip rule show
309:	from 1.1.1.1 tos AF11 iif dummy1 lookup 10000  proto zebra 
314:	from 1.1.1.2 tos 0x01 iif dummy1 lookup 10001  proto zebra
```
The existing PBR topotest has been amended to cover ECN and DSCP as well.
