### PR TITLE
*: preparations for printfrr coccinelle run

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3797,13 +3797,9 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 						       BGP_PATH_VALID);
 			else {
 				if (BGP_DEBUG(nht, NHT)) {
-					char buf1[INET6_ADDRSTRLEN];
-					inet_ntop(AF_INET,
-						  (const void *)&attr_new
-							  ->nexthop,
-						  buf1, INET6_ADDRSTRLEN);
-					zlog_debug("%s(%s): NH unresolved",
-						   __func__, buf1);
+					zlog_debug("%s(%pI4): NH unresolved",
+						   __func__,
+						   (in_addr_t *)&attr_new->nexthop);
 				}
 				bgp_path_info_unset_flag(dest, pi,
 							 BGP_PATH_VALID);
@@ -9598,7 +9594,6 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 	unsigned long output_count = 0;
 	unsigned long total_count = 0;
 	struct prefix *p;
-	char buf2[BUFSIZ];
 	json_object *json_paths = NULL;
 	int first = 1;
 
@@ -9863,11 +9858,10 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 						dest_p->u.prefix_flowspec
 							.prefixlen);
 			} else {
-				prefix2str(dest_p, buf2, sizeof(buf2));
 				if (first)
-					vty_out(vty, "\"%s\": ", buf2);
+					vty_out(vty, "\"%pFX\": ", dest_p);
 				else
-					vty_out(vty, ",\"%s\": ", buf2);
+					vty_out(vty, ",\"%pFX\": ", dest_p);
 			}
 			vty_out(vty, "%s",
 				json_object_to_json_string_ext(

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10884,10 +10884,9 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 					p->group, &prefix);
 
 				if (range) {
-					prefix2str(range, buf1, sizeof(buf1));
 					vty_out(vty,
-						" Belongs to the subnet range group: %s\n",
-						buf1);
+						" Belongs to the subnet range group: %pFX\n",
+						range);
 				}
 			}
 		}

--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -33,9 +33,9 @@ extern "C" {
  * Generic IP address - union of IPv4 and IPv6 address.
  */
 enum ipaddr_type_t {
-	IPADDR_NONE = 0,
-	IPADDR_V4 = 1, /* IPv4 */
-	IPADDR_V6 = 2, /* IPv6 */
+	IPADDR_NONE = AF_UNSPEC,
+	IPADDR_V4 = AF_INET,
+	IPADDR_V6 = AF_INET6,
 };
 
 struct ipaddr {
@@ -84,12 +84,8 @@ static inline int str2ipaddr(const char *str, struct ipaddr *ip)
 static inline char *ipaddr2str(const struct ipaddr *ip, char *buf, int size)
 {
 	buf[0] = '\0';
-	if (ip) {
-		if (IS_IPADDR_V4(ip))
-			inet_ntop(AF_INET, &ip->ip.addr, buf, size);
-		else if (IS_IPADDR_V6(ip))
-			inet_ntop(AF_INET6, &ip->ip.addr, buf, size);
-	}
+	if (ip)
+		inet_ntop(ip->ipa_type, &ip->ip.addr, buf, size);
 	return buf;
 }
 

--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -124,6 +124,10 @@ static inline bool ipaddr_isset(struct ipaddr *ip)
 	return (0 != memcmp(&a, ip, sizeof(struct ipaddr)));
 }
 
+#ifdef _FRR_ATTRIBUTE_PRINTFRR
+#pragma FRR printfrr_ext "%pIA"  (struct ipaddr *)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1317,6 +1317,16 @@ char *esi_to_str(const esi_t *esi, char *buf, int size)
 	return ptr;
 }
 
+printfrr_ext_autoreg_p("EA", printfrr_ea)
+static ssize_t printfrr_ea(char *buf, size_t bsz, const char *fmt,
+			   int prec, const void *ptr)
+{
+	const struct ethaddr *mac = ptr;
+
+	prefix_mac2str(mac, buf, bsz);
+	return 2;
+}
+
 printfrr_ext_autoreg_p("IA", printfrr_ia)
 static ssize_t printfrr_ia(char *buf, size_t bsz, const char *fmt,
 			   int prec, const void *ptr)

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -22,6 +22,7 @@
 #include <zebra.h>
 
 #include "prefix.h"
+#include "ipaddr.h"
 #include "vty.h"
 #include "sockunion.h"
 #include "memory.h"
@@ -1314,6 +1315,16 @@ char *esi_to_str(const esi_t *esi, char *buf, int size)
 		 esi->val[6], esi->val[7], esi->val[8],
 		 esi->val[9]);
 	return ptr;
+}
+
+printfrr_ext_autoreg_p("IA", printfrr_ia)
+static ssize_t printfrr_ia(char *buf, size_t bsz, const char *fmt,
+			   int prec, const void *ptr)
+{
+	const struct ipaddr *ipa = ptr;
+
+	ipaddr2str(ipa, buf, bsz);
+	return 2;
 }
 
 printfrr_ext_autoreg_p("I4", printfrr_i4)

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -555,6 +555,8 @@ static inline int is_default_host_route(const struct prefix *p)
 }
 
 #ifdef _FRR_ATTRIBUTE_PRINTFRR
+#pragma FRR printfrr_ext "%pEA"  (struct ethaddr *)
+
 #pragma FRR printfrr_ext "%pI4"  (struct in_addr *)
 #pragma FRR printfrr_ext "%pI4"  (in_addr_t *)
 

--- a/lib/sockunion.h
+++ b/lib/sockunion.h
@@ -103,6 +103,10 @@ extern union sockunion *sockunion_dup(const union sockunion *);
 extern void sockunion_free(union sockunion *);
 extern void sockunion_init(union sockunion *);
 
+#ifdef _FRR_ATTRIBUTE_PRINTFRR
+#pragma FRR printfrr_ext "%pSU"  (union sockunion *)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -875,7 +875,6 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 	bool old_entry_updated = false;
 	struct ospf6_path *path, *o_path, *ecmp_path;
 	struct listnode *anode;
-	char adv_router[16];
 
 	memset(&prefix, 0, sizeof(prefix));
 
@@ -940,10 +939,6 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 			if (listcount(route->paths) > 1) {
 				for (ALL_LIST_ELEMENTS_RO(route->paths, anode,
 							  o_path)) {
-					inet_ntop(AF_INET,
-						  &o_path->origin.adv_router,
-						  adv_router,
-						  sizeof(adv_router));
 					if (o_path->origin.id == lsa->header->id
 					    && o_path->origin.adv_router ==
 					    lsa->header->adv_router) {
@@ -951,9 +946,9 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 
 						if (is_debug)
 							zlog_debug(
-								"%s: old entry found in paths, adv_router %s",
+								"%s: old entry found in paths, adv_router %pI4",
 								__func__,
-								adv_router);
+								&o_path->origin.adv_router);
 
 						break;
 					}
@@ -1185,14 +1180,11 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 			listnode_add_sort(old_route->paths, ecmp_path);
 
 			if (is_debug) {
-				prefix2str(&route->prefix, buf, sizeof(buf));
-				inet_ntop(AF_INET,
-					  &ecmp_path->origin.adv_router,
-					  adv_router, sizeof(adv_router));
 				zlog_debug(
-					"%s: route %s cost %u another path %s added with nh %u, effective paths %u nh %u",
-					__func__, buf, old_route->path.cost,
-					adv_router,
+					"%s: route %pFX cost %u another path %pI4 added with nh %u, effective paths %u nh %u",
+					__func__, &route->prefix,
+					old_route->path.cost,
+					&ecmp_path->origin.adv_router,
 					listcount(ecmp_path->nh_list),
 					old_route->paths
 						? listcount(old_route->paths)
@@ -1239,12 +1231,11 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 
 	if (old_entry_updated == false) {
 		if (is_debug) {
-			inet_ntop(AF_INET, &route->path.origin.adv_router,
-				  adv_router, sizeof(adv_router));
 			zlog_debug(
-				"%s: Install route: %s cost %u nh %u adv_router %s ",
+				"%s: Install route: %s cost %u nh %u adv_router %pI4",
 				__func__, buf, route->path.cost,
-				listcount(route->nh_list), adv_router);
+				listcount(route->nh_list),
+				&route->path.origin.adv_router);
 		}
 
 		path = ospf6_path_dup(&route->path);

--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -28,7 +28,7 @@ struct ospf6_area {
 	struct ospf6 *ospf6;
 
 	/* Area-ID */
-	uint32_t area_id;
+	in_addr_t area_id;
 
 #define OSPF6_AREA_FMT_DOTTEDQUAD 1
 #define OSPF6_AREA_FMT_DECIMAL    2

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -244,11 +244,9 @@ void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 				continue;
 
 			if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL)) {
-				prefix2str(&old_route->prefix, buf,
-					   sizeof(buf));
 				zlog_debug(
-					"%s: route %s cost old %u new %u is not same, replace route",
-					__func__, buf, o_path->cost,
+					"%s: route %pFX cost old %u new %u is not same, replace route",
+					__func__, &old_route->prefix, o_path->cost,
 					route->path.cost);
 			}
 
@@ -308,11 +306,9 @@ void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 				}
 			} else {
 				if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL)) {
-					prefix2str(&old_route->prefix, buf,
-						   sizeof(buf));
 					zlog_debug(
-						"%s: route %s old cost %u new cost %u, delete old entry.",
-						__func__, buf,
+						"%s: route %pFX old cost %u new cost %u, delete old entry.",
+						__func__, &old_route->prefix,
 						old_route->path.cost,
 						route->path.cost);
 				}
@@ -339,11 +335,10 @@ void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 		    && (old_route->path.u.cost_e2 == route->path.u.cost_e2)) {
 
 			if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL)) {
-				prefix2str(&old_route->prefix, buf,
-					   sizeof(buf));
 				zlog_debug(
-					"%s: old route %s path  cost %u e2 %u",
-					__func__, buf, old_route->path.cost,
+					"%s: old route %pFX path  cost %u e2 %u",
+					__func__, &old_route->prefix,
+					old_route->path.cost,
 					old_route->path.u.cost_e2);
 			}
 			route_found = true;
@@ -562,7 +557,6 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 	struct ospf6_as_external_lsa *external;
 	struct prefix prefix;
 	struct ospf6_route *route, *nroute, *route_to_del;
-	char buf[PREFIX2STR_BUFFER];
 
 	external = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
 		lsa->header);
@@ -612,8 +606,7 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 	route = ospf6_route_lookup(&prefix, ospf6->route_table);
 	if (route == NULL) {
 		if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL)) {
-			prefix2str(&prefix, buf, sizeof(buf));
-			zlog_debug("AS-External route %s not found", buf);
+			zlog_debug("AS-External route %pFX not found", &prefix);
 		}
 
 		ospf6_route_delete(route_to_del);
@@ -621,10 +614,9 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 	}
 
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL)) {
-		prefix2str(&prefix, buf, sizeof(buf));
 		zlog_debug(
-			"%s: Current route %s cost %u e2 %u, route to del cost %u e2 %u",
-			__func__, buf, route->path.cost, route->path.u.cost_e2,
+			"%s: Current route %pFX cost %u e2 %u, route to del cost %u e2 %u",
+			__func__, &prefix, route->path.cost, route->path.u.cost_e2,
 			route_to_del->path.cost, route_to_del->path.u.cost_e2);
 	}
 
@@ -668,11 +660,9 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 							      .cost_e2)) {
 					if (IS_OSPF6_DEBUG_EXAMIN(
 						    AS_EXTERNAL)) {
-						prefix2str(&prefix, buf,
-							   sizeof(buf));
 						zlog_debug(
-							"%s: route %s to delete is not same, cost %u del cost %u. skip",
-							__func__, buf,
+							"%s: route %pFX to delete is not same, cost %u del cost %u. skip",
+							__func__, &prefix,
 							route->path.cost,
 							route_to_del->path
 								.cost);
@@ -681,10 +671,9 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 				}
 
 				if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL)) {
-					prefix2str(&prefix, buf, sizeof(buf));
 					zlog_debug(
-						"%s: route %s path found with cost %u nh %u to remove.",
-						__func__, buf, route->path.cost,
+						"%s: route %pFX path found with cost %u nh %u to remove.",
+						__func__, &prefix, route->path.cost,
 						listcount(o_path->nh_list));
 				}
 
@@ -723,16 +712,14 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 				}
 
 				if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL)) {
-					prefix2str(&route->prefix, buf,
-						   sizeof(buf));
 					zlog_debug(
-						"%s: AS-External %u route %s update paths %u nh %u",
+						"%s: AS-External %u route %pFX update paths %u nh %u",
 						__func__,
 						(route->path.type
 						 == OSPF6_PATH_TYPE_EXTERNAL1)
 							? 1
 							: 2,
-						buf, listcount(route->paths),
+						&route->prefix, listcount(route->paths),
 						route->nh_list ? listcount(
 							route->nh_list)
 							       : 0);
@@ -784,10 +771,9 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 				|| (route->path.u.cost_e2
 				    != route_to_del->path.u.cost_e2))) {
 				if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL)) {
-					prefix2str(&prefix, buf, sizeof(buf));
 					zlog_debug(
-						"%s: route %s to delete is not same, cost %u del cost %u. skip",
-						__func__, buf, route->path.cost,
+						"%s: route %pFX to delete is not same, cost %u del cost %u. skip",
+						__func__, &prefix, route->path.cost,
 						route_to_del->path.cost);
 				}
 				continue;
@@ -800,14 +786,13 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 				continue;
 		}
 		if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL)) {
-			prefix2str(&route->prefix, buf, sizeof(buf));
 			zlog_debug(
-				"%s: AS-External %u route remove %s cost %u(%u) nh %u",
+				"%s: AS-External %u route remove %pFX cost %u(%u) nh %u",
 				__func__,
 				route->path.type == OSPF6_PATH_TYPE_EXTERNAL1
 					? 1
 					: 2,
-				buf, route->path.cost, route->path.u.cost_e2,
+				&route->prefix, route->path.cost, route->path.u.cost_e2,
 				listcount(route->nh_list));
 		}
 		ospf6_route_remove(route, ospf6->route_table);

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -90,10 +90,10 @@ struct ospf6_interface {
 	uint8_t mtu_ignore;
 
 	/* Decision of DR Election */
-	uint32_t drouter;
-	uint32_t bdrouter;
-	uint32_t prev_drouter;
-	uint32_t prev_bdrouter;
+	in_addr_t drouter;
+	in_addr_t bdrouter;
+	in_addr_t prev_drouter;
+	in_addr_t prev_bdrouter;
 
 	/* Linklocal LSA Database: includes Link-LSA */
 	struct ospf6_lsdb *lsdb;

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1400,11 +1400,9 @@ void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 				continue;
 
 			if (IS_OSPF6_DEBUG_EXAMIN(INTRA_PREFIX)) {
-				prefix2str(&old_route->prefix, buf,
-					   sizeof(buf));
 				zlog_debug(
-					"%s: route %s cost old %u new %u is not same, replace route",
-					__func__, buf, o_path->cost,
+					"%s: route %pFX cost old %u new %u is not same, replace route",
+					__func__, &old_route->prefix, o_path->cost,
 					route->path.cost);
 			}
 
@@ -1458,11 +1456,9 @@ void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 				}
 			} else {
 				if (IS_OSPF6_DEBUG_EXAMIN(INTRA_PREFIX)) {
-					prefix2str(&old_route->prefix, buf,
-						   sizeof(buf));
 					zlog_debug(
-						"%s: route %s old cost %u new cost %u, delete old entry.",
-						__func__, buf,
+						"%s: route %pFX old cost %u new cost %u, delete old entry.",
+						__func__, &old_route->prefix,
 						old_route->path.cost,
 						route->path.cost);
 				}
@@ -1515,11 +1511,9 @@ void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 				listnode_add_sort(old_route->paths, ecmp_path);
 
 				if (IS_OSPF6_DEBUG_EXAMIN(INTRA_PREFIX)) {
-					prefix2str(&route->prefix, buf,
-						   sizeof(buf));
 					zlog_debug(
-						"%s: route %s %p another path added with nh %u, effective paths %u nh %u",
-						__func__, buf,
+						"%s: route %pFX %p another path added with nh %u, effective paths %u nh %u",
+						__func__, &route->prefix,
 						(void *)old_route,
 						listcount(ecmp_path->nh_list),
 						old_route->paths ? listcount(

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -23,8 +23,8 @@
 
 /* Debug option */
 extern unsigned char conf_debug_ospf6_brouter;
-extern uint32_t conf_debug_ospf6_brouter_specific_router_id;
-extern uint32_t conf_debug_ospf6_brouter_specific_area_id;
+extern in_addr_t conf_debug_ospf6_brouter_specific_router_id;
+extern in_addr_t conf_debug_ospf6_brouter_specific_area_id;
 #define OSPF6_DEBUG_BROUTER_SUMMARY         0x01
 #define OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER 0x02
 #define OSPF6_DEBUG_BROUTER_SPECIFIC_AREA   0x04
@@ -86,7 +86,7 @@ struct ospf6_router_lsdesc {
 	uint16_t metric; /* output cost */
 	uint32_t interface_id;
 	uint32_t neighbor_interface_id;
-	uint32_t neighbor_router_id;
+	in_addr_t neighbor_router_id;
 };
 
 #define OSPF6_ROUTER_LSDESC_POINTTOPOINT       1
@@ -125,7 +125,7 @@ struct ospf6_network_lsa {
 /* Link State Description in Router-LSA */
 #define OSPF6_NETWORK_LSDESC_FIX_SIZE          4U
 struct ospf6_network_lsdesc {
-	uint32_t router_id;
+	in_addr_t router_id;
 };
 #define NETWORK_LSDESC_GET_NBR_ROUTERID(x)                                     \
 	(((struct ospf6_network_lsdesc *)(x))->router_id)
@@ -146,7 +146,7 @@ struct ospf6_intra_prefix_lsa {
 	uint16_t prefix_num;
 	uint16_t ref_type;
 	uint32_t ref_id;
-	uint32_t ref_adv_router;
+	in_addr_t ref_adv_router;
 	/* followed by ospf6 prefix(es) */
 };
 

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -80,8 +80,8 @@
 struct ospf6_lsa_header {
 	uint16_t age;	/* LS age */
 	uint16_t type;       /* LS type */
-	uint32_t id;	 /* Link State ID */
-	uint32_t adv_router; /* Advertising Router */
+	in_addr_t id;	 /* Link State ID */
+	in_addr_t adv_router; /* Advertising Router */
 	uint32_t seqnum;     /* LS sequence number */
 	uint16_t checksum;   /* LS checksum */
 	uint16_t length;     /* LSA length */

--- a/ospf6d/ospf6_message.h
+++ b/ospf6d/ospf6_message.h
@@ -49,8 +49,8 @@ struct ospf6_header {
 	uint8_t version;
 	uint8_t type;
 	uint16_t length;
-	uint32_t router_id;
-	uint32_t area_id;
+	in_addr_t router_id;
+	in_addr_t area_id;
 	uint16_t checksum;
 	uint8_t instance_id;
 	uint8_t reserved;
@@ -66,8 +66,8 @@ struct ospf6_hello {
 	uint8_t options[3];
 	uint16_t hello_interval;
 	uint16_t dead_interval;
-	uint32_t drouter;
-	uint32_t bdrouter;
+	in_addr_t drouter;
+	in_addr_t bdrouter;
 	/* Followed by Router-IDs */
 };
 
@@ -94,8 +94,8 @@ struct ospf6_dbdesc {
 struct ospf6_lsreq_entry {
 	uint16_t reserved;   /* Must Be Zero */
 	uint16_t type;       /* LS type */
-	uint32_t id;	 /* Link State ID */
-	uint32_t adv_router; /* Advertising Router */
+	in_addr_t id;	 /* Link State ID */
+	in_addr_t adv_router; /* Advertising Router */
 };
 
 /* Link State Update */

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -48,7 +48,7 @@ struct ospf6_neighbor {
 	struct timeval last_changed;
 
 	/* Neighbor Router ID */
-	uint32_t router_id;
+	in_addr_t router_id;
 
 	/* Neighbor Interface ID */
 	ifindex_t ifindex;
@@ -56,10 +56,10 @@ struct ospf6_neighbor {
 	/* Router Priority of this neighbor */
 	uint8_t priority;
 
-	uint32_t drouter;
-	uint32_t bdrouter;
-	uint32_t prev_drouter;
-	uint32_t prev_bdrouter;
+	in_addr_t drouter;
+	in_addr_t bdrouter;
+	in_addr_t prev_drouter;
+	in_addr_t prev_bdrouter;
 
 	/* Options field (Capability) */
 	char options[3];

--- a/ospf6d/ospf6_route.h
+++ b/ospf6d/ospf6_route.h
@@ -64,8 +64,8 @@ struct ospf6_nexthop {
 /* Path */
 struct ospf6_ls_origin {
 	uint16_t type;
-	uint32_t id;
-	uint32_t adv_router;
+	in_addr_t id;
+	in_addr_t adv_router;
 };
 
 struct ospf6_path {
@@ -82,7 +82,7 @@ struct ospf6_path {
 	uint8_t prefix_options;
 
 	/* Associated Area */
-	uint32_t area_id;
+	in_addr_t area_id;
 
 	/* Path-type */
 	uint8_t type;

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -26,7 +26,7 @@
 
 struct ospf6_master {
 
-	uint32_t zebra_router_id;
+	in_addr_t zebra_router_id;
 };
 
 /* ospf6->config_flags */
@@ -41,10 +41,10 @@ struct ospf6 {
 	vrf_id_t vrf_id;
 
 	/* my router id */
-	uint32_t router_id;
+	in_addr_t router_id;
 
 	/* static router id */
-	uint32_t router_id_static;
+	in_addr_t router_id_static;
 
 	struct in_addr router_id_zebra;
 

--- a/tools/cocci.h
+++ b/tools/cocci.h
@@ -7,6 +7,18 @@
 #define DEFUN_HIDDEN(funcname, cmdname, str, help)                             \
 	static int funcname(const struct cmd_element *self, struct vty *vty,   \
 			    int argc, struct cmd_token *argv[])
+#define DEFUN_NOSH(funcname, cmdname, str, help)                               \
+	static int funcname(const struct cmd_element *self, struct vty *vty,   \
+			    int argc, struct cmd_token *argv[])
+#define DEFPY(funcname, cmdname, str, help)                                    \
+	static int funcname(const struct cmd_element *self, struct vty *vty,   \
+			    int argc, struct cmd_token *argv[])
+#define DEFPY_HIDDEN(funcname, cmdname, str, help)                             \
+	static int funcname(const struct cmd_element *self, struct vty *vty,   \
+			    int argc, struct cmd_token *argv[])
+#define DEFPY_NOSH(funcname, cmdname, str, help)                               \
+	static int funcname(const struct cmd_element *self, struct vty *vty,   \
+			    int argc, struct cmd_token *argv[])
 
 #define ENABLE_BGP_VNC 1
 #define ALL_LIST_ELEMENTS_RO(list, node, data)                                 \
@@ -85,3 +97,28 @@
 		for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++)
 
 #define FOREACH_SAFI(safi) for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++)
+
+#define frr_with_privs(p) \
+	for (int x = 1; x; x--)
+#define frr_with_mutex(m) \
+	for (int x = 1; x; x--)
+
+#define ALL_LSDB_TYPED_ADVRTR(lsdb, type, adv_router, lsa)                     \
+	const struct route_node *iterend =                                     \
+		ospf6_lsdb_head(lsdb, 2, type, adv_router, &lsa);              \
+	lsa;                                                                   \
+	lsa = ospf6_lsdb_next(iterend, lsa)
+
+#define ALL_LSDB_TYPED(lsdb, type, lsa)                                        \
+	const struct route_node *iterend =                                     \
+		ospf6_lsdb_head(lsdb, 1, type, 0, &lsa);                       \
+	lsa;                                                                   \
+	lsa = ospf6_lsdb_next(iterend, lsa)
+
+#define ALL_LSDB(lsdb, lsa)                                                    \
+	const struct route_node *iterend =                                     \
+		ospf6_lsdb_head(lsdb, 0, 0, 0, &lsa);                          \
+	lsa;                                                                   \
+	lsa = ospf6_lsdb_next(iterend, lsa)
+
+#define QOBJ_FIELDS struct qobj_node qobj_node;


### PR DESCRIPTION
This is all prep for the big fat coccinelle script that will do the

```
printf("%s", inet_ntoa(ip, ...));
```

→

```
printfrr("%pI4", &ip);
```

replacement.  Mostly just a few additional printfrr specifiers, but also this "pre-fixes" some locations where coccinelle otherwise gets into a weird almost-infinite loop trying to understand the C code.