### PR TITLE
libfrr: Retain return value if the best index is found

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1741,14 +1741,19 @@ route_map_get_index(struct route_map *map, const struct prefix *prefix,
 				 * more noops, we retain this return value and
 				 * return this eventually if there are no
 				 * matches.
+				 * If a best match route-map index already
+				 * exists, do not reset the match_ret.
 				 */
-				if (*match_ret != RMAP_NOMATCH)
+				if (!best_index && (*match_ret != RMAP_NOMATCH))
 					*match_ret = ret;
 			} else {
 				/*
 				 * ret is RMAP_NOMATCH.
+				 * If a best match route-map index already
+				 * exists, do not reset the match_ret.
 				 */
-				*match_ret = ret;
+				if (!best_index)
+					*match_ret = ret;
 			}
 		}
 


### PR DESCRIPTION
While iteratively looking for a best match route-map index amongst
a list of potential best match route-map indices, if a candidate
best match index is already found, disregard the value returned by
the function route_map_apply_match() if it returns either RMAP_NOOP
or RMAP_NOMATCH in the following iterations.
This is because if a best match route-map index is found then, the
return value must always be set to RMAP_MATCH.

Signed-off-by: NaveenThanikachalam <nthanikachal@vmware.com>