### PR TITLE
[7.4] Add BFD peer awareness to frr-reload.py and vtysh markfile

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -496,6 +496,7 @@ end
                   line.startswith("vnc defaults") or
                   line.startswith("vnc l2-group") or
                   line.startswith("vnc nve-group") or
+                  line.startswith("peer") or
                   line.startswith("member pseudowire")):
                 main_ctx_key = []
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -809,6 +809,9 @@ int vtysh_mark_file(const char *filename)
 			} else if ((prev_node == KEYCHAIN_KEY_NODE)
 				   && (tried == 1)) {
 				vty_out(vty, "exit\n");
+			} else if ((prev_node == BFD_PEER_NODE)
+				   && (tried == 1)) {
+				vty_out(vty, "exit\n");
 			} else if (tried) {
 				vty_out(vty, "end\n");
 			}


### PR DESCRIPTION
Summary
------------

This is a backport of PR: #6708 to `stable/7.4`.