### PR TITLE
lib: always run a 1-second timer in the main pthread

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -1442,6 +1442,12 @@ struct thread *thread_fetch(struct thread_master *m, struct thread *fetch)
 			if (errno == EINTR) {
 				pthread_mutex_unlock(&m->mtx);
 				/* loop around to signal handler */
+				/* If this thread will not handle signals
+				 * let's crash and make that visible.
+				 */
+				if (!m->handle_signals)
+					abort();
+
 				continue;
 			}
 

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -87,6 +87,7 @@ struct thread_master {
 	bool handle_signals;
 	pthread_mutex_t mtx;
 	pthread_t owner;
+	struct thread *simple_timer;
 };
 
 /* Thread itself. */


### PR DESCRIPTION
Add a simple background timer event to main pthreads, to ensure that thread wakes from poll() periodically even when a process is idle. Also abort if a child/secondary pthread receives a signal - we don't expect that to happen. I'm trying to see if the zebra shutdown failures can be healed if the zebra main thread gets a chance to check for signals regularly.
