### PR TITLE
topotests: stop the zombie apocalypse

### DIFF
--- a/tests/topotests/Dockerfile
+++ b/tests/topotests/Dockerfile
@@ -19,6 +19,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         libjson-c-dev \
         libpcre3-dev \
         libpython-dev \
+        libpython3-dev \
         libreadline-dev \
         libc-ares-dev \
         libcap-dev \
@@ -26,7 +27,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         mininet \
         pkg-config \
         python-pip \
-        python-sphinx \
+        python3 \
+        python3-dev \
+        python3-sphinx \
+        python3-pytest \
         rsync \
         strace \
         tcpdump \


### PR DESCRIPTION
individual commit messages say most of this.  Docker was just straight up f*cked, I guess not a lot of people are using it?  Backtraces were unnecessarily non-verbose.  And we were waiting on our own process zombies during shutdown.

The "stop wasting time at exit" commit [f033a78] is kinda duplicate to #6720 (sorry, I was poking around in the code because I didn't understand why the f*ck we were waiting so long at exit and ended up with a different changeset - apologies to @mjstapp )



(1) table was destroyed due to excessive headdesking during creation of this PR.  No ~animals~ heads were harmed in the production of this PR.