### PR TITLE
lib: yang wrapper for getting empty type

### DIFF
--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -792,6 +792,29 @@ struct yang_data *yang_data_new_empty(const char *xpath)
 	return yang_data_new(xpath, NULL);
 }
 
+bool yang_dnode_get_empty(const struct lyd_node *dnode, const char *xpath_fmt,
+			  ...)
+{
+	va_list ap;
+	char xpath[XPATH_MAXLEN];
+	const struct lyd_node_leaf_list *dleaf;
+
+	assert(dnode);
+
+	va_start(ap, xpath_fmt);
+	vsnprintf(xpath, sizeof(xpath), xpath_fmt, ap);
+	va_end(ap);
+
+	dnode = yang_dnode_get(dnode, xpath);
+	if (dnode) {
+		dleaf = (const struct lyd_node_leaf_list *)dnode;
+		if (dleaf->value_type == LY_TYPE_EMPTY)
+			return true;
+	}
+
+	return false;
+}
+
 /*
  * Derived type: IP prefix.
  */

--- a/lib/yang_wrappers.h
+++ b/lib/yang_wrappers.h
@@ -120,6 +120,8 @@ extern void yang_get_default_string_buf(char *buf, size_t size,
 
 /* empty */
 extern struct yang_data *yang_data_new_empty(const char *xpath);
+extern bool yang_dnode_get_empty(const struct lyd_node *dnode,
+				 const char *xpath_fmt, ...);
 
 /* ip prefix */
 extern void yang_str2prefix(const char *value, union prefixptr prefix);

--- a/tools/gen_northbound_callbacks.c
+++ b/tools/gen_northbound_callbacks.c
@@ -194,7 +194,7 @@ static void generate_callback(const struct nb_callback_info *ncinfo,
 	case NB_OP_MODIFY:
 	case NB_OP_DESTROY:
 	case NB_OP_MOVE:
-		printf("\tswitch (event) {\n"
+		printf("\tswitch (args->event) {\n"
 		       "\tcase NB_EV_VALIDATE:\n"
 		       "\tcase NB_EV_PREPARE:\n"
 		       "\tcase NB_EV_ABORT:\n"


### PR DESCRIPTION
yang wrapper to provide a wrapper to check empty type dnode is set. 


northbound auto generate callbacks script to use `attr->event`. 


Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>