### PR TITLE
zebra: fix the installation of the evpn neighbor update

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2686,7 +2686,7 @@ static ssize_t netlink_neigh_update_msg_encode(
 
 	if (datalen < sizeof(*req))
 		return 0;
-	memset(req, 0, datalen);
+	memset(req, 0, sizeof(*req));
 
 	op = dplane_ctx_get_op(ctx);
 
@@ -2703,7 +2703,7 @@ static ssize_t netlink_neigh_update_msg_encode(
 	req->ndm.ndm_flags = flags;
 	req->ndm.ndm_ifindex = dplane_ctx_get_ifindex(ctx);
 
-	if (!nl_attr_put(&req->n, sizeof(req), NDA_PROTOCOL, &protocol,
+	if (!nl_attr_put(&req->n, datalen, NDA_PROTOCOL, &protocol,
 			 sizeof(protocol)))
 		return 0;
 


### PR DESCRIPTION
Fix the function encoding evpn neighbor. The size of the buffer
for the netlink message wasn't correct and because of that we thought that
the message didn't fit entirely in the buffer and thus we were not sending
the update to the kernel.

Signed-off-by: Jakub Urbańczyk <xthaid@gmail.com>