### PR TITLE
zebra: fix SA warnings in backup nexthop code

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -3408,7 +3408,7 @@ int mpls_lsp_uninstall(struct zebra_vrf *zvrf, enum lsp_types_t type,
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_MPLS) {
-		nhlfe2str(nhlfe, buf, BUFSIZ);
+		nhlfe2str(nhlfe, buf, sizeof(buf));
 		zlog_debug("Del LSP in-label %u type %d nexthop %s flags 0x%x",
 			   in_label, type, buf, nhlfe->flags);
 	}
@@ -3639,7 +3639,7 @@ int zebra_mpls_static_lsp_add(struct zebra_vrf *zvrf, mpls_label_t in_label,
 			return 0;
 
 		if (IS_ZEBRA_DEBUG_MPLS) {
-			snhlfe2str(snhlfe, buf, BUFSIZ);
+			snhlfe2str(snhlfe, buf, sizeof(buf));
 			zlog_debug(
 				"Upd static LSP in-label %u nexthop %s "
 				"out-label %u (old %u)",
@@ -3653,7 +3653,7 @@ int zebra_mpls_static_lsp_add(struct zebra_vrf *zvrf, mpls_label_t in_label,
 			return -1;
 
 		if (IS_ZEBRA_DEBUG_MPLS) {
-			snhlfe2str(snhlfe, buf, BUFSIZ);
+			snhlfe2str(snhlfe, buf, sizeof(buf));
 			zlog_debug(
 				"Add static LSP in-label %u nexthop %s out-label %u",
 				in_label, buf, out_label);
@@ -3798,7 +3798,8 @@ void zebra_mpls_print_lsp_table(struct vty *vty, struct zebra_vrf *zvrf,
 
 		for (ALL_LIST_ELEMENTS_RO(lsp_list, node, lsp))
 			json_object_object_add(
-				json, label2str(lsp->ile.in_label, buf, BUFSIZ),
+				json, label2str(lsp->ile.in_label, buf,
+						sizeof(buf)),
 				lsp_json(lsp));
 
 		vty_out(vty, "%s\n", json_object_to_json_string_ext(
@@ -3853,7 +3854,7 @@ void zebra_mpls_print_lsp_table(struct vty *vty, struct zebra_vrf *zvrf,
 					out_label_str = mpls_label2str(
 						nexthop->nh_label->num_labels,
 						&nexthop->nh_label->label[0],
-						buf, BUFSIZ, 1);
+						buf, sizeof(buf), 1);
 				else
 					out_label_str = "-";
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1937,7 +1937,7 @@ static int rib_count_installed_nh(struct route_entry *re)
 		/* The meaningful flag depends on where the installed
 		 * nexthops reside.
 		 */
-		if (nhg == &(re->fib_backup_ng)) {
+		if (nhg == &(re->fib_ng)) {
 			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB))
 				count++;
 		} else {
@@ -1946,9 +1946,12 @@ static int rib_count_installed_nh(struct route_entry *re)
 		}
 	}
 
-	for (ALL_NEXTHOPS_PTR(rib_get_fib_backup_nhg(re), nexthop)) {
-		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB))
-			count++;
+	nhg = rib_get_fib_backup_nhg(re);
+	if (nhg) {
+		for (ALL_NEXTHOPS_PTR(nhg, nexthop)) {
+			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB))
+				count++;
+		}
 	}
 
 	return count;

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1187,8 +1187,11 @@ static int send_client(struct rnh *rnh, struct zserv *client,
 			for (ALL_NEXTHOPS_PTR(nhg, nh))
 				if (rnh_nexthop_valid(re, nh)) {
 					zapi_nexthop_from_nexthop(&znh, nh);
-					zapi_nexthop_encode(s, &znh,
-							    0 /* flags */);
+					ret = zapi_nexthop_encode(
+						s, &znh, 0 /* flags */);
+					if (ret < 0)
+						goto failure;
+
 					num++;
 				}
 		}


### PR DESCRIPTION
Fix a couple of recent coverity SA warnings that came from backup nexthop/nhlfe changes. These didn't show up with clang scan-build, fwiw, but they do seem to be valid.
