### PR TITLE
lib: add a backtrace when stream bounds check fails

### DIFF
--- a/lib/stream.c
+++ b/lib/stream.c
@@ -55,15 +55,19 @@ DEFINE_MTYPE_STATIC(LIB, STREAM_FIFO, "Stream FIFO")
  * using stream_put..._at() functions.
  */
 #define STREAM_WARN_OFFSETS(S)                                                 \
-	flog_warn(EC_LIB_STREAM,                                               \
-		  "&(struct stream): %p, size: %lu, getp: %lu, endp: %lu\n",   \
-		  (void *)(S), (unsigned long)(S)->size,                       \
-		  (unsigned long)(S)->getp, (unsigned long)(S)->endp)
+	do {                                                                   \
+		flog_warn(EC_LIB_STREAM,				       \
+			  "&(struct stream): %p, size: %lu, getp: %lu, endp: %lu\n", \
+			  (void *)(S), (unsigned long)(S)->size,	       \
+			  (unsigned long)(S)->getp, (unsigned long)(S)->endp); \
+		zlog_backtrace(LOG_WARNING);				       \
+	} while (0)
 
 #define STREAM_VERIFY_SANE(S)                                                  \
 	do {                                                                   \
-		if (!(GETP_VALID(S, (S)->getp) && ENDP_VALID(S, (S)->endp)))   \
+		if (!(GETP_VALID(S, (S)->getp) && ENDP_VALID(S, (S)->endp))) { \
 			STREAM_WARN_OFFSETS(S);                                \
+		}                                                              \
 		assert(GETP_VALID(S, (S)->getp));                              \
 		assert(ENDP_VALID(S, (S)->endp));                              \
 	} while (0)


### PR DESCRIPTION
Add a backtrace call when the stream code detects a bounds error, to help with debugging. I'm not certain this is the best or only place to backtrace, but it seems to be part of many failure paths.
