### PR TITLE
zebra: Silently ignore afi 128/129 for rules

### DIFF
--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -247,7 +247,16 @@ int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	}
 
 	frh = NLMSG_DATA(h);
+
 	if (frh->family != AF_INET && frh->family != AF_INET6) {
+		if (frh->family == RTNL_FAMILY_IPMR
+		    || frh->family == RTNL_FAMILY_IP6MR) {
+			if (IS_ZEBRA_DEBUG_KERNEL)
+				zlog_debug(
+					"Received rule netlink that we are ignoring for family %u, rule change: %u",
+					frh->family, h->nlmsg_type);
+			return 0;
+		}
 		flog_warn(
 			EC_ZEBRA_NETLINK_INVALID_AF,
 			"Invalid address family: %u received from kernel rule change: %u",


### PR DESCRIPTION
We do not need to know anything about rules in afi 128/129
at this point in time.  Just note it with a zebra kernel
debug and move on.  This is not something that a operator
can do anything with and at this point in time FRR
does not care.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>