### PR TITLE
bgpd: Remove memset from bgp_zebra_announce

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1178,7 +1178,7 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 			struct bgp_path_info *info, struct bgp *bgp, afi_t afi,
 			safi_t safi)
 {
-	struct zapi_route api;
+	struct zapi_route api = { 0 };
 	struct zapi_nexthop *api_nh;
 	int nh_family;
 	unsigned int valid_nh_count = 0;
@@ -1224,7 +1224,6 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 		nh_othervrf = 1;
 
 	/* Make Zebra API structure. */
-	memset(&api, 0, sizeof(api));
 	api.vrf_id = bgp->vrf_id;
 	api.type = ZEBRA_ROUTE_BGP;
 	api.safi = safi;


### PR DESCRIPTION
During perf testing of receiving and installing 7.5 million
routes into zebra it was noticed that memset in bgp_zebra_announce
was taking ~11% of the runtime.  With this change bgp_zebra_announce
now no longer has any appreciable time spent in memset as reported
by perf.  In addition bgp_zebra_announce run time in perf was
reduced by a composite amount.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>