### PR TITLE
lib,zebra: support multiple backup nexthops

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -525,11 +525,12 @@ struct nexthop *nexthop_next_active_resolved(const struct nexthop *nexthop)
 	return next;
 }
 
-unsigned int nexthop_level(struct nexthop *nexthop)
+unsigned int nexthop_level(const struct nexthop *nexthop)
 {
 	unsigned int rv = 0;
 
-	for (struct nexthop *par = nexthop->rparent; par; par = par->rparent)
+	for (const struct nexthop *par = nexthop->rparent;
+	     par; par = par->rparent)
 		rv++;
 
 	return rv;

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -65,6 +65,12 @@ enum nh_encap_type {
 	NET_VXLAN = 100, /* value copied from FPM_NH_ENCAP_VXLAN. */
 };
 
+/* Fixed limit on the number of backup nexthops per primary nexthop */
+#define NEXTHOP_MAX_BACKUPS  8
+
+/* Backup index value is limited */
+#define NEXTHOP_BACKUP_IDX_MAX 255
+
 /* Nexthop structure. */
 struct nexthop {
 	struct nexthop *next;
@@ -124,10 +130,11 @@ struct nexthop {
 	/* Weight of the nexthop ( for unequal cost ECMP ) */
 	uint8_t weight;
 
-	/* Index of a corresponding backup nexthop in a backup list;
+	/* Count and index of corresponding backup nexthop(s) in a backup list;
 	 * only meaningful if the HAS_BACKUP flag is set.
 	 */
-	uint8_t backup_idx;
+	uint8_t backup_num;
+	uint8_t backup_idx[NEXTHOP_MAX_BACKUPS];
 
 	/* Encapsulation information. */
 	enum nh_encap_type nh_encap_type;
@@ -135,9 +142,6 @@ struct nexthop {
 		vni_t vni;
 	} nh_encap;
 };
-
-/* Backup index value is limited */
-#define NEXTHOP_BACKUP_IDX_MAX 255
 
 /* Utility to append one nexthop to another. */
 #define NEXTHOP_APPEND(to, new)           \

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -220,7 +220,7 @@ extern const char *nexthop2str(const struct nexthop *nexthop,
 extern struct nexthop *nexthop_next(const struct nexthop *nexthop);
 extern struct nexthop *
 nexthop_next_active_resolved(const struct nexthop *nexthop);
-extern unsigned int nexthop_level(struct nexthop *nexthop);
+extern unsigned int nexthop_level(const struct nexthop *nexthop);
 /* Copies to an already allocated nexthop struct */
 extern void nexthop_copy(struct nexthop *copy, const struct nexthop *nexthop,
 			 struct nexthop *rparent);

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -235,6 +235,15 @@ extern struct nexthop *nexthop_dup(const struct nexthop *nexthop,
 extern struct nexthop *nexthop_dup_no_recurse(const struct nexthop *nexthop,
 					      struct nexthop *rparent);
 
+/*
+ * Parse one or more backup index values, as comma-separated numbers,
+ * into caller's array of uint8_ts. The array must be NEXTHOP_MAX_BACKUPS
+ * in size. Mails back the number of values converted, and returns 0 on
+ * success, <0 if an error in parsing.
+ */
+int nexthop_str2backups(const char *str, int *num_backups,
+			uint8_t *backups);
+
 #ifdef _FRR_ATTRIBUTE_PRINTFRR
 #pragma FRR printfrr_ext "%pNH"  (struct nexthop *)
 #endif

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -806,7 +806,8 @@ static bool nexthop_group_parse_nexthop(struct nexthop *nhop,
 			return false;
 
 		SET_FLAG(nhop->flags, NEXTHOP_FLAG_HAS_BACKUP);
-		nhop->backup_idx = backup_idx;
+		nhop->backup_num = 1;
+		nhop->backup_idx[0] = backup_idx;
 	}
 
 	return true;
@@ -992,7 +993,7 @@ void nexthop_group_write_nexthop(struct vty *vty, struct nexthop *nh)
 		vty_out(vty, " weight %u", nh->weight);
 
 	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_HAS_BACKUP))
-		vty_out(vty, " backup-idx %d", nh->backup_idx);
+		vty_out(vty, " backup-idx %d", nh->backup_idx[0]);
 
 	vty_out(vty, "\n");
 }
@@ -1048,7 +1049,7 @@ void nexthop_group_json_nexthop(json_object *j, struct nexthop *nh)
 		json_object_int_add(j, "weight", nh->weight);
 
 	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_HAS_BACKUP))
-		json_object_int_add(j, "backupIdx", nh->backup_idx);
+		json_object_int_add(j, "backupIdx", nh->backup_idx[0]);
 }
 
 static void nexthop_group_write_nexthop_internal(struct vty *vty,

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -43,11 +43,8 @@ struct nexthop_hold {
 	char *intf;
 	char *labels;
 	uint32_t weight;
-	int backup_idx; /* Index of backup nexthop, if >= 0 */
+	char *backup_str;
 };
-
-/* Invalid/unset value for nexthop_hold's backup_idx */
-#define NHH_BACKUP_IDX_INVALID -1
 
 struct nexthop_group_hooks {
 	void (*new)(const char *name);
@@ -677,7 +674,8 @@ static void nexthop_group_save_nhop(struct nexthop_group_cmd *nhgc,
 				    const char *nhvrf_name,
 				    const union sockunion *addr,
 				    const char *intf, const char *labels,
-				    const uint32_t weight, int backup_idx)
+				    const uint32_t weight,
+				    const char *backup_str)
 {
 	struct nexthop_hold *nh;
 
@@ -694,7 +692,8 @@ static void nexthop_group_save_nhop(struct nexthop_group_cmd *nhgc,
 
 	nh->weight = weight;
 
-	nh->backup_idx = backup_idx;
+	if (backup_str)
+		nh->backup_str = XSTRDUP(MTYPE_TMP, backup_str);
 
 	listnode_add_sort(nhgc->nhg_list, nh);
 }
@@ -741,10 +740,11 @@ static bool nexthop_group_parse_nexthop(struct nexthop *nhop,
 					const union sockunion *addr,
 					const char *intf, const char *name,
 					const char *labels, int *lbl_ret,
-					uint32_t weight, int backup_idx)
+					uint32_t weight, const char *backup_str)
 {
 	int ret = 0;
 	struct vrf *vrf;
+	int num;
 
 	memset(nhop, 0, sizeof(*nhop));
 
@@ -800,14 +800,15 @@ static bool nexthop_group_parse_nexthop(struct nexthop *nhop,
 
 	nhop->weight = weight;
 
-	if (backup_idx != NHH_BACKUP_IDX_INVALID) {
-		/* Validate index value */
-		if (backup_idx > NEXTHOP_BACKUP_IDX_MAX)
+	if (backup_str) {
+		/* Parse backup indexes */
+		ret = nexthop_str2backups(backup_str,
+					  &num, nhop->backup_idx);
+		if (ret == 0) {
+			SET_FLAG(nhop->flags, NEXTHOP_FLAG_HAS_BACKUP);
+			nhop->backup_num = num;
+		} else
 			return false;
-
-		SET_FLAG(nhop->flags, NEXTHOP_FLAG_HAS_BACKUP);
-		nhop->backup_num = 1;
-		nhop->backup_idx[0] = backup_idx;
 	}
 
 	return true;
@@ -821,7 +822,7 @@ static bool nexthop_group_parse_nhh(struct nexthop *nhop,
 {
 	return (nexthop_group_parse_nexthop(nhop, nhh->addr, nhh->intf,
 					    nhh->nhvrf_name, nhh->labels, NULL,
-					    nhh->weight, nhh->backup_idx));
+					    nhh->weight, nhh->backup_str));
 }
 
 DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
@@ -834,7 +835,7 @@ DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
 	   nexthop-vrf NAME$vrf_name \
 	   |label WORD \
            |weight (1-255) \
-           |backup-idx$bi_str (0-254)$idx \
+           |backup-idx WORD \
 	}]",
       NO_STR
       "Specify one of the nexthops in this ECMP group\n"
@@ -848,19 +849,26 @@ DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
       "One or more labels in the range (16-1048575) separated by '/'\n"
       "Weight to be used by the nexthop for purposes of ECMP\n"
       "Weight value to be used\n"
-      "Backup nexthop index in another group\n"
-      "Nexthop index value\n")
+      "Specify backup nexthop indexes in another group\n"
+      "One or more indexes in the range (0-254) separated by ','\n")
 {
 	VTY_DECLVAR_CONTEXT(nexthop_group_cmd, nhgc);
 	struct nexthop nhop;
 	struct nexthop *nh;
 	int lbl_ret = 0;
 	bool legal;
-	int backup_idx = idx;
+	int num;
+	uint8_t backups[NEXTHOP_MAX_BACKUPS];
 	bool yes = !no;
 
-	if (bi_str == NULL)
-		backup_idx = NHH_BACKUP_IDX_INVALID;
+	/* Pre-parse backup string to validate */
+	if (backup_idx) {
+		lbl_ret = nexthop_str2backups(backup_idx, &num, backups);
+		if (lbl_ret < 0) {
+			vty_out(vty, "%% Invalid backups\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	}
 
 	legal = nexthop_group_parse_nexthop(&nhop, addr, intf, vrf_name, label,
 					    &lbl_ret, weight, backup_idx);
@@ -944,10 +952,11 @@ static struct cmd_node nexthop_group_node = {
 	.config_write = nexthop_group_write,
 };
 
-void nexthop_group_write_nexthop(struct vty *vty, struct nexthop *nh)
+void nexthop_group_write_nexthop(struct vty *vty, const struct nexthop *nh)
 {
 	char buf[100];
 	struct vrf *vrf;
+	int i;
 
 	vty_out(vty, "nexthop ");
 
@@ -992,16 +1001,22 @@ void nexthop_group_write_nexthop(struct vty *vty, struct nexthop *nh)
 	if (nh->weight)
 		vty_out(vty, " weight %u", nh->weight);
 
-	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_HAS_BACKUP))
+	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_HAS_BACKUP)) {
 		vty_out(vty, " backup-idx %d", nh->backup_idx[0]);
+
+		for (i = 1; i < nh->backup_num; i++)
+			vty_out(vty, ",%d", nh->backup_idx[i]);
+	}
 
 	vty_out(vty, "\n");
 }
 
-void nexthop_group_json_nexthop(json_object *j, struct nexthop *nh)
+void nexthop_group_json_nexthop(json_object *j, const struct nexthop *nh)
 {
 	char buf[100];
 	struct vrf *vrf;
+	json_object *json_backups = NULL;
+	int i;
 
 	switch (nh->type) {
 	case NEXTHOP_TYPE_IFINDEX:
@@ -1048,12 +1063,19 @@ void nexthop_group_json_nexthop(json_object *j, struct nexthop *nh)
 	if (nh->weight)
 		json_object_int_add(j, "weight", nh->weight);
 
-	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_HAS_BACKUP))
-		json_object_int_add(j, "backupIdx", nh->backup_idx[0]);
+	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_HAS_BACKUP)) {
+		json_backups = json_object_new_array();
+		for (i = 0; i < nh->backup_num; i++)
+			json_object_array_add(
+				json_backups,
+				json_object_new_int(nh->backup_idx[i]));
+
+		json_object_object_add(j, "backupIdx", json_backups);
+	}
 }
 
 static void nexthop_group_write_nexthop_internal(struct vty *vty,
-						 struct nexthop_hold *nh)
+						 const struct nexthop_hold *nh)
 {
 	char buf[100];
 
@@ -1074,8 +1096,8 @@ static void nexthop_group_write_nexthop_internal(struct vty *vty,
 	if (nh->weight)
 		vty_out(vty, " weight %u", nh->weight);
 
-	if (nh->backup_idx != NHH_BACKUP_IDX_INVALID)
-		vty_out(vty, " backup-idx %d", nh->backup_idx);
+	if (nh->backup_str)
+		vty_out(vty, " backup-idx %s", nh->backup_str);
 
 	vty_out(vty, "\n");
 }

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -135,9 +135,11 @@ extern bool nexthop_group_equal(const struct nexthop_group *nhg1,
 
 extern struct nexthop_group_cmd *nhgc_find(const char *name);
 
-extern void nexthop_group_write_nexthop(struct vty *vty, struct nexthop *nh);
+extern void nexthop_group_write_nexthop(struct vty *vty,
+					const struct nexthop *nh);
 
-extern void nexthop_group_json_nexthop(json_object *j, struct nexthop *nh);
+extern void nexthop_group_json_nexthop(json_object *j,
+				       const struct nexthop *nh);
 
 /* Return the number of nexthops in this nhg */
 extern uint8_t nexthop_group_nexthop_num(const struct nexthop_group *nhg);

--- a/lib/route_types.pl
+++ b/lib/route_types.pl
@@ -121,7 +121,7 @@ sub codelist {
 	}
 	$str =~ s/ $//;
 	push @lines, $str . "\\n\" \\\n";
-	push @lines, "  \"       > - selected route, * - FIB route, q - queued route, r - rejected route\\n\\n\"";
+	push @lines, "  \"       > - selected route, * - FIB route, q - queued, r - rejected, b - backup\\n\\n\"";
 	return join("", @lines);
 }
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -394,8 +394,9 @@ struct zapi_nexthop {
 
 	uint32_t weight;
 
-	/* Index of backup nexthop */
-	uint8_t backup_idx;
+	/* Backup nexthops, for IP-FRR, TI-LFA, etc */
+	uint8_t backup_num;
+	uint8_t backup_idx[NEXTHOP_MAX_BACKUPS];
 };
 
 /*

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -278,7 +278,8 @@ DEFPY (install_routes,
 	if (backup) {
 		/* Set flag and index in primary nexthop */
 		SET_FLAG(sg.r.nhop.flags, NEXTHOP_FLAG_HAS_BACKUP);
-		sg.r.nhop.backup_idx = 0;
+		sg.r.nhop.backup_num = 1;
+		sg.r.nhop.backup_idx[0] = 0;
 
 		if (backup_nexthop4.s_addr != INADDR_ANY) {
 			sg.r.backup_nhop.gate.ipv4 = backup_nexthop4;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -155,6 +155,8 @@ int sharp_install_lsps_helper(bool install_p, const struct prefix *p,
 				return -1;
 
 			i++;
+			if (i >= MULTIPATH_NUM)
+				break;
 		}
 	}
 
@@ -188,6 +190,8 @@ int sharp_install_lsps_helper(bool install_p, const struct prefix *p,
 				return -1;
 
 			i++;
+			if (i >= MULTIPATH_NUM)
+				break;
 		}
 
 		if (i > 0)

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2116,6 +2116,12 @@ static int dplane_ctx_pw_init(struct zebra_dplane_ctx *ctx,
 				if (nhg && nhg->nexthop)
 					copy_nexthops(&(ctx->u.pw.nhg.nexthop),
 						      nhg->nexthop, NULL);
+
+				/* Include any installed backup nexthops */
+				nhg = rib_get_fib_backup_nhg(re);
+				if (nhg && nhg->nexthop)
+					copy_nexthops(&(ctx->u.pw.nhg.nexthop),
+						      nhg->nexthop, NULL);
 			}
 			route_unlock_node(rn);
 		}

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -2112,6 +2112,7 @@ static int update_nhlfes_from_ctx(struct nhlfe_list_head *nhlfe_head,
 						   __func__, buf);
 
 				SET_FLAG(nhlfe->flags, NHLFE_FLAG_INSTALLED);
+				SET_FLAG(nhlfe->flags, NHLFE_FLAG_SELECTED);
 
 			} else {
 				if (is_debug)
@@ -2119,6 +2120,7 @@ static int update_nhlfes_from_ctx(struct nhlfe_list_head *nhlfe_head,
 						   __func__, buf);
 
 				UNSET_FLAG(nhlfe->flags, NHLFE_FLAG_INSTALLED);
+				UNSET_FLAG(nhlfe->flags, NHLFE_FLAG_SELECTED);
 			}
 
 			if (CHECK_FLAG(ctx_nhlfe->nexthop->flags,
@@ -2140,6 +2142,7 @@ static int update_nhlfes_from_ctx(struct nhlfe_list_head *nhlfe_head,
 				zlog_debug("%s: no match for lsp nhlfe %s",
 					   __func__, buf);
 			UNSET_FLAG(nhlfe->flags, NHLFE_FLAG_INSTALLED);
+			UNSET_FLAG(nhlfe->flags, NHLFE_FLAG_SELECTED);
 			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB);
 			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 		}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1951,8 +1951,11 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 				goto done_with_match;
 			}
 
-			/* Examine installed nexthops */
-			nhg = &match->nhe->nhg;
+			/* Examine installed nexthops; note that there
+			 * may not be any installed primary nexthops if
+			 * only backups are installed.
+			 */
+			nhg = rib_get_fib_nhg(match);
 			for (ALL_NEXTHOPS_PTR(nhg, newhop)) {
 				if (!nexthop_valid_resolve(nexthop, newhop))
 					continue;
@@ -1973,8 +1976,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 			 * dedicated fib list.
 			 */
 			nhg = rib_get_fib_backup_nhg(match);
-			if (nhg == NULL ||
-			    nhg == zebra_nhg_get_backup_nhg(match->nhe))
+			if (nhg == NULL || nhg->nexthop == NULL)
 				goto done_with_match;
 
 			for (ALL_NEXTHOPS_PTR(nhg, newhop)) {

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -518,6 +518,7 @@ static void vty_show_mpls_pseudowire_detail(struct vty *vty)
 	struct zebra_pw *pw;
 	struct route_entry *re;
 	struct nexthop *nexthop;
+	struct nexthop_group *nhg;
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 	if (!zvrf)
@@ -545,22 +546,41 @@ static void vty_show_mpls_pseudowire_detail(struct vty *vty)
 			vty_out(vty, "  VC-ID: %u\n", pw->data.ldp.pwid);
 		vty_out(vty, "  Status: %s \n",
 			(zebra_pw_enabled(pw) && pw->status == PW_FORWARDING)
-				? "Up"
-				: "Down");
+			? "Up"
+			: "Down");
 		re = rib_match(family2afi(pw->af), SAFI_UNICAST, pw->vrf_id,
 			       &pw->nexthop, NULL);
-		if (re) {
-			for (ALL_NEXTHOPS_PTR(rib_get_fib_nhg(re), nexthop)) {
-				snprintfrr(buf_nh, sizeof(buf_nh), "%pNHv",
-					   nexthop);
-				vty_out(vty, "  Next Hop: %s\n", buf_nh);
-				if (nexthop->nh_label)
-					vty_out(vty, "  Next Hop label: %u\n",
-						nexthop->nh_label->label[0]);
-				else
-					vty_out(vty, "  Next Hop label: %s\n",
-						"-");
-			}
+		if (re == NULL)
+			continue;
+
+		nhg = rib_get_fib_nhg(re);
+		for (ALL_NEXTHOPS_PTR(nhg, nexthop)) {
+			snprintfrr(buf_nh, sizeof(buf_nh), "%pNHv",
+				   nexthop);
+			vty_out(vty, "  Next Hop: %s\n", buf_nh);
+			if (nexthop->nh_label)
+				vty_out(vty, "  Next Hop label: %u\n",
+					nexthop->nh_label->label[0]);
+			else
+				vty_out(vty, "  Next Hop label: %s\n",
+					"-");
+		}
+
+		/* Include any installed backups */
+		nhg = rib_get_fib_backup_nhg(re);
+		if (nhg == NULL)
+			continue;
+
+		for (ALL_NEXTHOPS_PTR(nhg, nexthop)) {
+			snprintfrr(buf_nh, sizeof(buf_nh), "%pNHv",
+				   nexthop);
+			vty_out(vty, "  Next Hop: %s\n", buf_nh);
+			if (nexthop->nh_label)
+				vty_out(vty, "  Next Hop label: %u\n",
+					nexthop->nh_label->label[0]);
+			else
+				vty_out(vty, "  Next Hop label: %s\n",
+					"-");
 		}
 	}
 }
@@ -569,6 +589,7 @@ static void vty_show_mpls_pseudowire(struct zebra_pw *pw, json_object *json_pws)
 {
 	struct route_entry *re;
 	struct nexthop *nexthop;
+	struct nexthop_group *nhg;
 	char buf_nbr[INET6_ADDRSTRLEN];
 	char buf_nh[100];
 	json_object *json_pw = NULL;
@@ -603,23 +624,48 @@ static void vty_show_mpls_pseudowire(struct zebra_pw *pw, json_object *json_pws)
 								      : "Down");
 	re = rib_match(family2afi(pw->af), SAFI_UNICAST, pw->vrf_id,
 		       &pw->nexthop, NULL);
-	if (re) {
-		for (ALL_NEXTHOPS_PTR(rib_get_fib_nhg(re), nexthop)) {
-			json_nexthop = json_object_new_object();
-			snprintfrr(buf_nh, sizeof(buf_nh), "%pNHv", nexthop);
-			json_object_string_add(json_nexthop, "nexthop", buf_nh);
-			if (nexthop->nh_label)
-				json_object_int_add(
-					json_nexthop, "nhLabel",
-					nexthop->nh_label->label[0]);
-			else
-				json_object_string_add(json_nexthop, "nhLabel",
-						       "-");
+	if (re == NULL)
+		goto done;
 
-			json_object_array_add(json_nexthops, json_nexthop);
-		}
-		json_object_object_add(json_pw, "nexthops", json_nexthops);
+	nhg = rib_get_fib_nhg(re);
+	for (ALL_NEXTHOPS_PTR(nhg, nexthop)) {
+		json_nexthop = json_object_new_object();
+		snprintfrr(buf_nh, sizeof(buf_nh), "%pNHv", nexthop);
+		json_object_string_add(json_nexthop, "nexthop", buf_nh);
+		if (nexthop->nh_label)
+			json_object_int_add(
+				json_nexthop, "nhLabel",
+				nexthop->nh_label->label[0]);
+		else
+			json_object_string_add(json_nexthop, "nhLabel",
+					       "-");
+
+		json_object_array_add(json_nexthops, json_nexthop);
 	}
+
+	/* Include installed backup nexthops also */
+	nhg = rib_get_fib_backup_nhg(re);
+	if (nhg == NULL)
+		goto done;
+
+	for (ALL_NEXTHOPS_PTR(nhg, nexthop)) {
+		json_nexthop = json_object_new_object();
+		snprintfrr(buf_nh, sizeof(buf_nh), "%pNHv", nexthop);
+		json_object_string_add(json_nexthop, "nexthop", buf_nh);
+		if (nexthop->nh_label)
+			json_object_int_add(
+				json_nexthop, "nhLabel",
+				nexthop->nh_label->label[0]);
+		else
+			json_object_string_add(json_nexthop, "nhLabel",
+					       "-");
+
+		json_object_array_add(json_nexthops, json_nexthop);
+	}
+
+done:
+
+	json_object_object_add(json_pw, "nexthops", json_nexthops);
 	json_object_array_add(json_pws, json_pw);
 }
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2630,6 +2630,8 @@ static void _route_entry_dump_nh(const struct route_entry *re,
 	char nhname[PREFIX_STRLEN];
 	char backup_str[50];
 	char wgt_str[50];
+	char temp_str[10];
+	int i;
 	struct interface *ifp;
 	struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
 
@@ -2655,8 +2657,12 @@ static void _route_entry_dump_nh(const struct route_entry *re,
 
 	backup_str[0] = '\0';
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP)) {
-		snprintf(backup_str, sizeof(backup_str), "backup %d,",
-			 (int)nexthop->backup_idx);
+		snprintf(backup_str, sizeof(backup_str), "backup ");
+		for (i = 0; i < nexthop->backup_num; i++) {
+			snprintf(temp_str, sizeof(temp_str), "%d, ",
+				 nexthop->backup_idx[i]);
+			strlcat(backup_str, temp_str, sizeof(backup_str));
+		}
 	}
 
 	wgt_str[0] = '\0';

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1040,22 +1040,10 @@ static bool compare_valid_nexthops(struct route_entry *r1,
 	 * backups will be in the 'fib' list.
 	 */
 	nhg1 = rib_get_fib_backup_nhg(r1);
-	if (nhg1 == zebra_nhg_get_backup_nhg(r1->nhe))
-		nhg1 = NULL;
-
 	nhg2 = rib_get_fib_backup_nhg(r2);
-	if (nhg2 == zebra_nhg_get_backup_nhg(r2->nhe))
-		nhg2 = NULL;
 
-	if (nhg1)
-		nh1 = nhg1->nexthop;
-	else
-		nh1 = NULL;
-
-	if (nhg2)
-		nh2 = nhg2->nexthop;
-	else
-		nh2 = NULL;
+	nh1 = nhg1->nexthop;
+	nh2 = nhg2->nexthop;
 
 	while (1) {
 		/* Find each backup list's next valid nexthop */
@@ -1180,9 +1168,6 @@ static int send_client(struct rnh *rnh, struct zserv *client,
 			}
 
 		nhg = rib_get_fib_backup_nhg(re);
-		if (nhg == zebra_nhg_get_backup_nhg(re->nhe))
-			nhg = NULL;
-
 		if (nhg) {
 			for (ALL_NEXTHOPS_PTR(nhg, nh))
 				if (rnh_nexthop_valid(re, nh)) {


### PR DESCRIPTION
Enhance the backup nexthop/nhlfe feature to support multiple backups for a single primary - this is possible (or even common) in TI-LFA, apparently. This involved datastruct changes, zebra nht changes, and ui/vty changes. Also improved the use of installed backups (if any) with pseudowires.

There's a wiki page with some overall design summary info here:
https://github.com/mjstapp/frr/wiki/Backup-nexthop-design
