### PR TITLE
lib,yang: merge cisco/zebra access list styles

### DIFF
--- a/lib/filter.h
+++ b/lib/filter.h
@@ -170,11 +170,6 @@ enum yang_prefix_list_action {
 struct lyd_node;
 struct vty;
 
-extern void access_list_legacy_show(struct vty *vty, struct lyd_node *dnode,
-				    bool show_defaults);
-extern void access_list_legacy_remark_show(struct vty *vty,
-					   struct lyd_node *dnode,
-					   bool show_defaults);
 extern void access_list_show(struct vty *vty, struct lyd_node *dnode,
 			     bool show_defaults);
 extern void access_list_remark_show(struct vty *vty, struct lyd_node *dnode,

--- a/lib/routemap_northbound.c
+++ b/lib/routemap_northbound.c
@@ -516,77 +516,6 @@ static int lib_route_map_entry_match_condition_interface_destroy(
 }
 
 /*
- * XPath: /frr-route-map:lib/route-map/entry/match-condition/access-list-num
- */
-static int lib_route_map_entry_match_condition_access_list_num_modify(
-	struct nb_cb_modify_args *args)
-{
-	struct routemap_hook_context *rhc;
-	const char *acl;
-	int condition, rv;
-
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
-
-	/* Check for hook function. */
-	rv = CMD_SUCCESS;
-	acl = yang_dnode_get_string(args->dnode, NULL);
-	rhc = nb_running_get_entry(args->dnode, NULL, true);
-	condition = yang_dnode_get_enum(args->dnode, "../condition");
-	switch (condition) {
-	case 1: /* ipv4-address-list */
-		if (rmap_match_set_hook.match_ip_address == NULL)
-			break;
-		rhc->rhc_mhook = rmap_match_set_hook.no_match_ip_address;
-		rhc->rhc_rule = "ip address";
-		rhc->rhc_event = RMAP_EVENT_FILTER_DELETED;
-		rv = rmap_match_set_hook.match_ip_address(
-			NULL, rhc->rhc_rmi, "ip address", acl,
-			RMAP_EVENT_FILTER_ADDED);
-		break;
-	case 3: /* ipv4-next-hop-list */
-		if (rmap_match_set_hook.match_ip_next_hop == NULL)
-			break;
-		rhc->rhc_mhook = rmap_match_set_hook.no_match_ip_next_hop;
-		rhc->rhc_rule = "ip next-hop";
-		rhc->rhc_event = RMAP_EVENT_FILTER_DELETED;
-		rv = rmap_match_set_hook.match_ip_next_hop(
-			NULL, rhc->rhc_rmi, "ip next-hop", acl,
-			RMAP_EVENT_FILTER_ADDED);
-		break;
-	}
-	if (rv != CMD_SUCCESS) {
-		rhc->rhc_mhook = NULL;
-		return NB_ERR_INCONSISTENCY;
-	}
-
-	return NB_OK;
-}
-
-static int lib_route_map_entry_match_condition_access_list_num_destroy(
-	struct nb_cb_destroy_args *args)
-{
-	return lib_route_map_entry_match_destroy(args);
-}
-
-/*
- * XPath:
- * /frr-route-map:lib/route-map/entry/match-condition/access-list-num-extended
- */
-static int lib_route_map_entry_match_condition_access_list_num_extended_modify(
-	struct nb_cb_modify_args *args)
-{
-	return lib_route_map_entry_match_condition_access_list_num_modify(args);
-}
-
-static int lib_route_map_entry_match_condition_access_list_num_extended_destroy(
-	struct nb_cb_destroy_args *args)
-{
-	return lib_route_map_entry_match_condition_access_list_num_destroy(
-		args);
-}
-
-/*
  * XPath: /frr-route-map:lib/route-map/entry/match-condition/list-name
  */
 static int lib_route_map_entry_match_condition_list_name_modify(
@@ -1242,20 +1171,6 @@ const struct frr_yang_module_info frr_route_map_info = {
 			.cbs = {
 				.modify = lib_route_map_entry_match_condition_interface_modify,
 				.destroy = lib_route_map_entry_match_condition_interface_destroy,
-			}
-		},
-		{
-			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/access-list-num",
-			.cbs = {
-				.modify = lib_route_map_entry_match_condition_access_list_num_modify,
-				.destroy = lib_route_map_entry_match_condition_access_list_num_destroy,
-			}
-		},
-		{
-			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/access-list-num-extended",
-			.cbs = {
-				.modify = lib_route_map_entry_match_condition_access_list_num_extended_modify,
-				.destroy = lib_route_map_entry_match_condition_access_list_num_extended_destroy,
 			}
 		},
 		{

--- a/yang/frr-filter.yang
+++ b/yang/frr-filter.yang
@@ -49,28 +49,6 @@ module frr-filter {
   /*
    * Types.
    */
-  typedef access-list-standard {
-    description "Standard IPv4 access list (any, host or a prefix)";
-    type uint16 {
-      range "1..99 | 1300..1999";
-    }
-  }
-
-  typedef access-list-extended {
-    description
-      "Extended IPv4 access list (source / destination any, hosts or prefixes)";
-    type uint16 {
-      range "100..199 | 2000..2699";
-    }
-  }
-
-  typedef access-list-legacy {
-    description "Standard/Extended IPv4 access list";
-    type uint16 {
-      range "1..199 | 1300..2699";
-    }
-  }
-
   typedef access-list-name {
     description "Access list name formatting";
     type string {
@@ -103,79 +81,6 @@ module frr-filter {
    * Configuration data.
    */
   container lib {
-    list access-list-legacy {
-      description "Access list legacy instance";
-
-      key "number";
-
-      leaf number {
-        description "Access list sequence value";
-        type access-list-legacy;
-      }
-
-      leaf remark {
-        description "Access list remark";
-        type string;
-      }
-
-      list entry {
-        description "Access list legacy entry";
-
-        key "sequence";
-
-        leaf sequence {
-          description "Access list sequence value";
-          type access-list-sequence;
-        }
-
-        leaf action {
-          description "Access list action on match";
-          type access-list-action;
-          mandatory true;
-        }
-
-        choice value {
-          description
-            "Standard access list: value to match.
-             Extended access list: source value to match.";
-          mandatory true;
-
-          leaf host {
-            description "Host to match";
-            type inet:ipv4-address;
-          }
-          leaf network {
-            description "Network to match";
-            type inet:ipv4-prefix;
-          }
-          leaf any {
-            description "Match any";
-            type empty;
-          }
-        }
-
-        choice extended-value {
-          when "../number >= 100 and ../number <= 199 or
-                ../number >= 2000 and ../number <= 2699";
-          description "Destination value to match";
-          mandatory true;
-
-          leaf destination-host {
-            description "Host to match";
-            type inet:ipv4-address;
-          }
-          leaf destination-network {
-            description "Network to match";
-            type inet:ipv4-prefix;
-          }
-          leaf destination-any {
-            description "Match any";
-            type empty;
-          }
-        }
-      }
-    }
-
     list access-list {
       description "Access list instance";
 
@@ -232,15 +137,66 @@ module frr-filter {
           case ipv4-prefix {
             when "../type = 'ipv4'";
 
-            leaf ipv4-prefix {
-              description "Configure IPv4 prefix to match";
-              type inet:ipv4-prefix;
-            }
+            choice style {
+              description "Access list entry style selection: zebra or cisco.";
+              mandatory true;
 
-            leaf ipv4-exact-match {
-              description "Exact match of prefix";
-              type boolean;
-              default false;
+              case zebra {
+                leaf ipv4-prefix {
+                  description "Configure IPv4 prefix to match";
+                  type inet:ipv4-prefix;
+                }
+
+                leaf ipv4-exact-match {
+                  description "Exact match of prefix";
+                  type boolean;
+                  default false;
+                }
+              }
+              case cisco {
+                leaf host {
+                  description "Host to match";
+                  type inet:ipv4-address;
+                }
+                leaf network {
+                  description "Network to match";
+                  type inet:ipv4-prefix;
+                }
+                leaf source-any {
+                  /*
+                   * Was `any`, however it conflicts with `any` leaf
+                   * outside this choice.
+                   */
+                  description "Match any";
+                  type empty;
+                }
+              }
+
+              choice extended-value {
+                /*
+                 * Legacy note: before using the new access-list format the
+                 * cisco styled list only accepted identifiers using numbers
+                 * and they had the following restriction:
+                 *
+                 * when "../number >= 100 and ../number <= 199 or
+                 *     ../number >= 2000 and ../number <= 2699";
+                 */
+                description "Destination value to match";
+                mandatory true;
+
+                leaf destination-host {
+                  description "Host to match";
+                  type inet:ipv4-address;
+                }
+                leaf destination-network {
+                  description "Network to match";
+                  type inet:ipv4-prefix;
+                }
+                leaf destination-any {
+                  description "Match any";
+                  type empty;
+                }
+              }
             }
           }
           case ipv6-prefix {

--- a/yang/frr-route-map.yang
+++ b/yang/frr-route-map.yang
@@ -239,20 +239,6 @@ module frr-route-map {
                 type string;
               }
             }
-            case access-list-num {
-              when "./condition = 'ipv4-address-list' or
-                    ./condition = 'ipv4-next-hop-list'";
-              leaf access-list-num {
-                type filter:access-list-standard;
-              }
-            }
-            case access-list-num-extended {
-              when "./condition = 'ipv4-address-list' or
-                    ./condition = 'ipv4-next-hop-list'";
-              leaf access-list-num-extended {
-                type filter:access-list-extended;
-              }
-            }
             case list-name {
               when "./condition = 'ipv4-address-list' or
                     ./condition = 'ipv4-prefix-list' or


### PR DESCRIPTION
Summary
------------

Fixes #6747 .

This PR wants to fix some of the issues described in the issue I mentioned above. It solves the following problems:

- The crash
- Issue of having two list types

Both problems were created by me unintentionally by separating Cisco entries from zebra entries. The crash was happening because the main access-list data structure is indeed shared between both types, so when you created the both types with the same name it ended up sharing the main list type (`struct access-list`).

Because of the share when the first list was removed it also removed the entries in the second list (different type), so when you removed the second (or maybe added new entries) it would crash (e.g. northbound kept the pointers that were already `free()`ed in its private section).


Commit Message
----------------------

Merge the cisco style access list with zebra's logic so we can mix bothtypes of rules while keeping the commands.

With this the cisco style limitation of having 'destination-*' only for specific number ranges no longer exist for users of YANG/northbound (the CLI still has this limitation).