### PR TITLE
lib: fix TLS log buffer on NetBSD

### DIFF
--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -246,10 +246,10 @@ void zlog_tls_buffer_init(void)
 	fchown(mmfd, zlog_uid, zlog_gid);
 
 #ifdef HAVE_POSIX_FALLOCATE
-	if (posix_fallocate(mmfd, 0, TLS_LOG_BUF_SIZE) < 0) {
-#else
-	if (ftruncate(mmfd, TLS_LOG_BUF_SIZE) < 0) {
+	if (posix_fallocate(mmfd, 0, TLS_LOG_BUF_SIZE) != 0)
+	/* note next statement is under above if() */
 #endif
+	if (ftruncate(mmfd, TLS_LOG_BUF_SIZE) < 0) {
 		zlog_err("failed to allocate thread log buffer \"%s\": %s",
 			 mmpath, strerror(errno));
 		goto out_anon_unlink;


### PR DESCRIPTION
... this didn't work on NetBSD.  Like, at all.  It returns a positive
error code from posix_fallocate() and then we bang our head against a
brick wall trying to write to the mmap'd buffer.

Signed-off-by: David Lamparter <equinox@diac24.net>