### PR TITLE
*: start converting 'thread' to 'event'

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -317,13 +317,9 @@ babel_clean_routing_process(void)
     flush_all_routes();
     babel_interface_close_all();
 
-    /* cancel threads */
-    if (babel_routing_process->t_read != NULL) {
-        thread_cancel(babel_routing_process->t_read);
-    }
-    if (babel_routing_process->t_update != NULL) {
-        thread_cancel(babel_routing_process->t_update);
-    }
+    /* cancel events */
+    thread_cancel(&babel_routing_process->t_read);
+    thread_cancel(&babel_routing_process->t_update);
 
     distribute_list_delete(&babel_routing_process->distribute_ctx);
     XFREE(MTYPE_BABEL, babel_routing_process);
@@ -503,9 +499,7 @@ static void
 babel_set_timer(struct timeval *timeout)
 {
     long msecs = timeout->tv_sec * 1000 + timeout->tv_usec / 1000;
-    if (babel_routing_process->t_update != NULL) {
-        thread_cancel(babel_routing_process->t_update);
-    }
+    thread_cancel(&(babel_routing_process->t_update));
     thread_add_timer_msec(master, babel_main_loop, NULL, msecs, &babel_routing_process->t_update);
 }
 

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -2048,12 +2048,12 @@ static int bfd_vrf_disable(struct vrf *vrf)
 		zlog_debug("VRF disable %s id %d", vrf->name, vrf->vrf_id);
 
 	/* Disable read/write poll triggering. */
-	THREAD_OFF(bvrf->bg_ev[0]);
-	THREAD_OFF(bvrf->bg_ev[1]);
-	THREAD_OFF(bvrf->bg_ev[2]);
-	THREAD_OFF(bvrf->bg_ev[3]);
-	THREAD_OFF(bvrf->bg_ev[4]);
-	THREAD_OFF(bvrf->bg_ev[5]);
+	EVENT_CANCEL(bvrf->bg_ev[0]);
+	EVENT_CANCEL(bvrf->bg_ev[1]);
+	EVENT_CANCEL(bvrf->bg_ev[2]);
+	EVENT_CANCEL(bvrf->bg_ev[3]);
+	EVENT_CANCEL(bvrf->bg_ev[4]);
+	EVENT_CANCEL(bvrf->bg_ev[5]);
 
 	/* Close all descriptors. */
 	socket_close(&bvrf->bg_echo);

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -463,27 +463,27 @@ ssize_t bfd_recv_ipv6(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
 static void bfd_sd_reschedule(struct bfd_vrf_global *bvrf, int sd)
 {
 	if (sd == bvrf->bg_shop) {
-		THREAD_OFF(bvrf->bg_ev[0]);
+		EVENT_CANCEL(bvrf->bg_ev[0]);
 		thread_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_shop,
 				&bvrf->bg_ev[0]);
 	} else if (sd == bvrf->bg_mhop) {
-		THREAD_OFF(bvrf->bg_ev[1]);
+		EVENT_CANCEL(bvrf->bg_ev[1]);
 		thread_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_mhop,
 				&bvrf->bg_ev[1]);
 	} else if (sd == bvrf->bg_shop6) {
-		THREAD_OFF(bvrf->bg_ev[2]);
+		EVENT_CANCEL(bvrf->bg_ev[2]);
 		thread_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_shop6,
 				&bvrf->bg_ev[2]);
 	} else if (sd == bvrf->bg_mhop6) {
-		THREAD_OFF(bvrf->bg_ev[3]);
+		EVENT_CANCEL(bvrf->bg_ev[3]);
 		thread_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_mhop6,
 				&bvrf->bg_ev[3]);
 	} else if (sd == bvrf->bg_echo) {
-		THREAD_OFF(bvrf->bg_ev[4]);
+		EVENT_CANCEL(bvrf->bg_ev[4]);
 		thread_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_echo,
 				&bvrf->bg_ev[4]);
 	} else if (sd == bvrf->bg_echov6) {
-		THREAD_OFF(bvrf->bg_ev[5]);
+		EVENT_CANCEL(bvrf->bg_ev[5]);
 		thread_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_echov6,
 				&bvrf->bg_ev[5]);
 	}

--- a/bfdd/control.c
+++ b/bfdd/control.c
@@ -145,10 +145,7 @@ void control_shutdown(void)
 {
 	struct bfd_control_socket *bcs;
 
-	if (bglobal.bg_csockev) {
-		thread_cancel(bglobal.bg_csockev);
-		bglobal.bg_csockev = NULL;
-	}
+	thread_cancel(&bglobal.bg_csockev);
 
 	socket_close(&bglobal.bg_csock);
 
@@ -204,15 +201,8 @@ static void control_free(struct bfd_control_socket *bcs)
 	struct bfd_control_queue *bcq;
 	struct bfd_notify_peer *bnp;
 
-	if (bcs->bcs_ev) {
-		thread_cancel(bcs->bcs_ev);
-		bcs->bcs_ev = NULL;
-	}
-
-	if (bcs->bcs_outev) {
-		thread_cancel(bcs->bcs_outev);
-		bcs->bcs_outev = NULL;
-	}
+	thread_cancel(&(bcs->bcs_ev));
+	thread_cancel(&(bcs->bcs_outev));
 
 	close(bcs->bcs_sd);
 
@@ -318,10 +308,7 @@ static int control_queue_dequeue(struct bfd_control_socket *bcs)
 	return 1;
 
 empty_list:
-	if (bcs->bcs_outev) {
-		thread_cancel(bcs->bcs_outev);
-		bcs->bcs_outev = NULL;
-	}
+	thread_cancel(&(bcs->bcs_outev));
 	bcs->bcs_bout = NULL;
 	return 0;
 }

--- a/bfdd/event.c
+++ b/bfdd/event.c
@@ -108,20 +108,20 @@ void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 
 void bfd_recvtimer_delete(struct bfd_session *bs)
 {
-	THREAD_OFF(bs->recvtimer_ev);
+	EVENT_CANCEL(bs->recvtimer_ev);
 }
 
 void bfd_echo_recvtimer_delete(struct bfd_session *bs)
 {
-	THREAD_OFF(bs->echo_recvtimer_ev);
+	EVENT_CANCEL(bs->echo_recvtimer_ev);
 }
 
 void bfd_xmttimer_delete(struct bfd_session *bs)
 {
-	THREAD_OFF(bs->xmttimer_ev);
+	EVENT_CANCEL(bs->xmttimer_ev);
 }
 
 void bfd_echo_xmttimer_delete(struct bfd_session *bs)
 {
-	THREAD_OFF(bs->echo_xmttimer_ev);
+	EVENT_CANCEL(bs->echo_xmttimer_ev);
 }

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1439,7 +1439,7 @@ static void bmp_close(struct bmp *bmp)
 		if (!bqe->refcount)
 			XFREE(MTYPE_BMP_QUEUE, bqe);
 
-	THREAD_OFF(bmp->t_read);
+	EVENT_CANCEL(bmp->t_read);
 	pullwr_del(bmp->pullwr);
 	close(bmp->socket);
 }
@@ -1638,7 +1638,7 @@ out_sock:
 
 static void bmp_listener_stop(struct bmp_listener *bl)
 {
-	THREAD_OFF(bl->t_accept);
+	EVENT_CANCEL(bl->t_accept);
 
 	if (bl->sock != -1)
 		close(bl->sock);
@@ -1677,9 +1677,9 @@ static struct bmp_active *bmp_active_get(struct bmp_targets *bt,
 
 static void bmp_active_put(struct bmp_active *ba)
 {
-	THREAD_OFF(ba->t_timer);
-	THREAD_OFF(ba->t_read);
-	THREAD_OFF(ba->t_write);
+	EVENT_CANCEL(ba->t_timer);
+	EVENT_CANCEL(ba->t_read);
+	EVENT_CANCEL(ba->t_write);
 
 	bmp_actives_del(&ba->targets->actives, ba);
 
@@ -1772,9 +1772,9 @@ static int bmp_active_thread(struct thread *t)
 
 	/* all 3 end up here, though only timer or read+write are active
 	 * at a time */
-	THREAD_OFF(ba->t_timer);
-	THREAD_OFF(ba->t_read);
-	THREAD_OFF(ba->t_write);
+	EVENT_CANCEL(ba->t_timer);
+	EVENT_CANCEL(ba->t_read);
+	EVENT_CANCEL(ba->t_write);
 
 	ba->last_err = NULL;
 
@@ -1824,9 +1824,9 @@ static void bmp_active_disconnected(struct bmp_active *ba)
 
 static void bmp_active_setup(struct bmp_active *ba)
 {
-	THREAD_OFF(ba->t_timer);
-	THREAD_OFF(ba->t_read);
-	THREAD_OFF(ba->t_write);
+	EVENT_CANCEL(ba->t_timer);
+	EVENT_CANCEL(ba->t_read);
+	EVENT_CANCEL(ba->t_write);
 
 	if (ba->bmp)
 		return;
@@ -2015,7 +2015,7 @@ DEFPY(bmp_stats_cfg,
 {
 	VTY_DECLVAR_CONTEXT_SUB(bmp_targets, bt);
 
-	THREAD_OFF(bt->t_stats);
+	EVENT_CANCEL(bt->t_stats);
 	if (no)
 		bt->stat_msec = 0;
 	else if (interval_str)

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -459,10 +459,8 @@ int bgp_damp_disable(struct bgp *bgp, afi_t afi, safi_t safi)
 	if (!CHECK_FLAG(bgp->af_flags[afi][safi], BGP_CONFIG_DAMPENING))
 		return 0;
 
-	/* Cancel reuse thread. */
-	if (bdc->t_reuse)
-		thread_cancel(bdc->t_reuse);
-	bdc->t_reuse = NULL;
+	/* Cancel reuse event. */
+	thread_cancel(&(bdc->t_reuse));
 
 	/* Clean BGP dampening information.  */
 	bgp_damp_info_clean(afi, safi);

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -677,11 +677,8 @@ static int bgp_dump_unset(struct bgp_dump *bgp_dump)
 		bgp_dump->fp = NULL;
 	}
 
-	/* Removing interval thread. */
-	if (bgp_dump->t_interval) {
-		thread_cancel(bgp_dump->t_interval);
-		bgp_dump->t_interval = NULL;
-	}
+	/* Removing interval event. */
+	thread_cancel(&bgp_dump->t_interval);
 
 	bgp_dump->interval = 0;
 

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -713,8 +713,8 @@ bool bgp_update_delay_configured(struct bgp *bgp)
    on ending the update delay. */
 void bgp_update_delay_end(struct bgp *bgp)
 {
-	THREAD_TIMER_OFF(bgp->t_update_delay);
-	THREAD_TIMER_OFF(bgp->t_establish_wait);
+	EVENT_CANCEL(bgp->t_update_delay);
+	EVENT_CANCEL(bgp->t_establish_wait);
 
 	/* Reset update-delay related state */
 	bgp->update_delay_over = 1;
@@ -932,7 +932,7 @@ static int bgp_maxmed_onstartup_timer(struct thread *thread)
 	zlog_info("Max med on startup ended - timer expired.");
 
 	bgp = THREAD_ARG(thread);
-	THREAD_TIMER_OFF(bgp->t_maxmed_onstartup);
+	EVENT_CANCEL(bgp->t_maxmed_onstartup);
 	bgp->maxmed_onstartup_over = 1;
 
 	bgp_maxmed_update(bgp);
@@ -976,7 +976,7 @@ static int bgp_update_delay_timer(struct thread *thread)
 	zlog_info("Update delay ended - timer expired.");
 
 	bgp = THREAD_ARG(thread);
-	THREAD_TIMER_OFF(bgp->t_update_delay);
+	EVENT_CANCEL(bgp->t_update_delay);
 	bgp_update_delay_end(bgp);
 
 	return 0;
@@ -990,7 +990,7 @@ static int bgp_establish_wait_timer(struct thread *thread)
 	zlog_info("Establish wait - timer expired.");
 
 	bgp = THREAD_ARG(thread);
-	THREAD_TIMER_OFF(bgp->t_establish_wait);
+	EVENT_CANCEL(bgp->t_establish_wait);
 	bgp_check_update_delay(bgp);
 
 	return 0;
@@ -1290,8 +1290,8 @@ int bgp_stop(struct peer *peer)
 	bgp_writes_off(peer);
 	bgp_reads_off(peer);
 
-	THREAD_OFF(peer->t_connect_check_r);
-	THREAD_OFF(peer->t_connect_check_w);
+	EVENT_CANCEL(peer->t_connect_check_r);
+	EVENT_CANCEL(peer->t_connect_check_w);
 
 	/* Stop all timers. */
 	BGP_TIMER_OFF(peer->t_start);
@@ -1450,8 +1450,8 @@ static int bgp_connect_check(struct thread *thread)
 	assert(!peer->t_read);
 	assert(!peer->t_write);
 
-	THREAD_OFF(peer->t_connect_check_r);
-	THREAD_OFF(peer->t_connect_check_w);
+	EVENT_CANCEL(peer->t_connect_check_r);
+	EVENT_CANCEL(peer->t_connect_check_w);
 
 	/* Check file descriptor. */
 	slen = sizeof(status);

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -32,7 +32,7 @@
 #define BGP_TIMER_OFF(T)                                                       \
 	do {                                                                   \
 		if (T)                                                         \
-			THREAD_TIMER_OFF(T);                                   \
+			EVENT_CANCEL((T));                                     \
 	} while (0)
 
 #define BGP_EVENT_ADD(P, E)                                                    \

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -31,7 +31,7 @@
 #include "network.h"		// for ERRNO_IO_RETRY
 #include "stream.h"		// for stream_get_endp, stream_getw_from, str...
 #include "ringbuf.h"		// for ringbuf_remain, ringbuf_peek, ringbuf_...
-#include "thread.h"		// for THREAD_OFF, THREAD_ARG, thread, thread...
+#include "thread.h"		// for EVENT_CANCEL, THREAD_ARG, thread...
 #include "zassert.h"		// for assert
 
 #include "bgpd/bgp_io.h"
@@ -79,7 +79,7 @@ void bgp_writes_off(struct peer *peer)
 	assert(fpt->running);
 
 	thread_cancel_async(fpt->master, &peer->t_write, NULL);
-	THREAD_OFF(peer->t_generate_updgrp_packets);
+	EVENT_CANCEL(peer->t_generate_updgrp_packets);
 
 	UNSET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
 }
@@ -110,7 +110,7 @@ void bgp_reads_off(struct peer *peer)
 	assert(fpt->running);
 
 	thread_cancel_async(fpt->master, &peer->t_read, NULL);
-	THREAD_OFF(peer->t_process_packet);
+	EVENT_CANCEL(peer->t_process_packet);
 
 	UNSET_FLAG(peer->thread_flags, PEER_THREAD_READS_ON);
 }

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -401,7 +401,7 @@ static int bgp_accept(struct thread *thread)
 				"[Error] accept() failed with error \"%s\" on BGP listener socket %d for BGP instance in VRF \"%s\"; refreshing socket",
 				safe_strerror(save_errno), accept_sock,
 				VRF_LOGNAME(vrf));
-			THREAD_OFF(listener->thread);
+			EVENT_CANCEL(listener->thread);
 		} else {
 			flog_err_sys(
 				EC_LIB_SOCKET,
@@ -916,7 +916,7 @@ void bgp_close_vrf_socket(struct bgp *bgp)
 
 	for (ALL_LIST_ELEMENTS(bm->listen_sockets, node, next, listener)) {
 		if (listener->bgp == bgp) {
-			THREAD_OFF(listener->thread);
+			EVENT_CANCEL(listener->thread);
 			close(listener->fd);
 			listnode_delete(bm->listen_sockets, listener);
 			XFREE(MTYPE_BGP_LISTENER, listener->name);
@@ -938,7 +938,7 @@ void bgp_close(void)
 	for (ALL_LIST_ELEMENTS(bm->listen_sockets, node, next, listener)) {
 		if (listener->bgp)
 			continue;
-		THREAD_OFF(listener->thread);
+		EVENT_CANCEL(listener->thread);
 		close(listener->fd);
 		listnode_delete(bm->listen_sockets, listener);
 		XFREE(MTYPE_BGP_LISTENER, listener->name);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4187,7 +4187,7 @@ void bgp_stop_announce_route_timer(struct peer_af *paf)
 	if (!paf->t_announce_route)
 		return;
 
-	THREAD_TIMER_OFF(paf->t_announce_route);
+	EVENT_CANCEL(paf->t_announce_route);
 }
 
 /*

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3917,7 +3917,7 @@ static void bgp_route_map_mark_update(const char *rmap_name)
 	 * turn it off and start a new timer.
 	 */
 	if (bm->t_rmap_update != NULL)
-		THREAD_OFF(bm->t_rmap_update);
+		EVENT_CANCEL(bm->t_rmap_update);
 
 	/* rmap_update_timer of 0 means don't do route updates */
 	if (bm->rmap_update_timer) {

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -794,16 +794,16 @@ static void update_subgroup_delete(struct update_subgroup *subgrp)
 		UPDGRP_INCR_STAT(subgrp->update_group, subgrps_deleted);
 
 	if (subgrp->t_merge_check)
-		THREAD_OFF(subgrp->t_merge_check);
+		EVENT_CANCEL(subgrp->t_merge_check);
 
 	if (subgrp->t_coalesce)
-		THREAD_TIMER_OFF(subgrp->t_coalesce);
+		EVENT_CANCEL(subgrp->t_coalesce);
 
 	bpacket_queue_cleanup(SUBGRP_PKTQ(subgrp));
 	subgroup_clear_table(subgrp);
 
 	if (subgrp->t_coalesce)
-		THREAD_TIMER_OFF(subgrp->t_coalesce);
+		EVENT_CANCEL(subgrp->t_coalesce);
 	sync_delete(subgrp);
 
 	if (BGP_DEBUG(update_groups, UPDATE_GROUPS) && subgrp->update_group)
@@ -1769,7 +1769,7 @@ int update_group_refresh_default_originate_route_map(struct thread *thread)
 	bgp = THREAD_ARG(thread);
 	update_group_walk(bgp, update_group_default_originate_route_map_walkcb,
 			  reason);
-	THREAD_TIMER_OFF(bgp->t_rmap_def_originate_eval);
+	EVENT_CANCEL(bgp->t_rmap_def_originate_eval);
 	bgp_unlock(bgp);
 
 	return 0;

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1628,7 +1628,7 @@ DEFUN (no_bgp_maxmed_onstartup,
 
 	/* Cancel max-med onstartup if its on */
 	if (bgp->t_maxmed_onstartup) {
-		THREAD_TIMER_OFF(bgp->t_maxmed_onstartup);
+		EVENT_CANCEL(bgp->t_maxmed_onstartup);
 		bgp->maxmed_onstartup_over = 1;
 	}
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3309,10 +3309,10 @@ int bgp_delete(struct bgp *bgp)
 
 	hook_call(bgp_inst_delete, bgp);
 
-	THREAD_OFF(bgp->t_startup);
-	THREAD_OFF(bgp->t_maxmed_onstartup);
-	THREAD_OFF(bgp->t_update_delay);
-	THREAD_OFF(bgp->t_establish_wait);
+	EVENT_CANCEL(bgp->t_startup);
+	EVENT_CANCEL(bgp->t_maxmed_onstartup);
+	EVENT_CANCEL(bgp->t_update_delay);
+	EVENT_CANCEL(bgp->t_establish_wait);
 
 	/* Set flag indicating bgp instance delete in progress */
 	SET_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS);

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -863,9 +863,9 @@ static void rfapiBgpInfoChainFree(struct bgp_path_info *bpi)
 		if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)
 		    && bpi->extra->vnc.import.timer) {
 
-			struct thread *t =
-				(struct thread *)bpi->extra->vnc.import.timer;
-			struct rfapi_withdraw *wcb = t->arg;
+			struct thread **t =
+				&(bpi->extra->vnc.import.timer);
+			struct rfapi_withdraw *wcb = (*t)->arg;
 
 			XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 			thread_cancel(t);
@@ -3101,10 +3101,9 @@ static void rfapiBgpInfoFilteredImportEncap(
 				if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)
 				    && bpi->extra->vnc.import.timer) {
 
-					struct thread *t =
-						(struct thread *)bpi->extra->vnc
-							.import.timer;
-					struct rfapi_withdraw *wcb = t->arg;
+					struct thread **t =
+						&(bpi->extra->vnc.import.timer);
+					struct rfapi_withdraw *wcb = (*t)->arg;
 
 					XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 					thread_cancel(t);
@@ -3194,9 +3193,9 @@ static void rfapiBgpInfoFilteredImportEncap(
 			"%s: removing holddown bpi matching NVE of new route",
 			__func__);
 		if (bpi->extra->vnc.import.timer) {
-			struct thread *t =
-				(struct thread *)bpi->extra->vnc.import.timer;
-			struct rfapi_withdraw *wcb = t->arg;
+			struct thread **t =
+				&(bpi->extra->vnc.import.timer);
+			struct rfapi_withdraw *wcb = (*t)->arg;
 
 			XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 			thread_cancel(t);
@@ -3557,10 +3556,9 @@ void rfapiBgpInfoFilteredImportVPN(
 				if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)
 				    && bpi->extra->vnc.import.timer) {
 
-					struct thread *t =
-						(struct thread *)bpi->extra->vnc
-							.import.timer;
-					struct rfapi_withdraw *wcb = t->arg;
+					struct thread **t =
+						&(bpi->extra->vnc.import.timer);
+					struct rfapi_withdraw *wcb = (*t)->arg;
 
 					XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 					thread_cancel(t);
@@ -3778,9 +3776,9 @@ void rfapiBgpInfoFilteredImportVPN(
 			"%s: removing holddown bpi matching NVE of new route",
 			__func__);
 		if (bpi->extra->vnc.import.timer) {
-			struct thread *t =
-				(struct thread *)bpi->extra->vnc.import.timer;
-			struct rfapi_withdraw *wcb = t->arg;
+			struct thread **t =
+				&(bpi->extra->vnc.import.timer);
+			struct rfapi_withdraw *wcb = (*t)->arg;
 
 			XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 			thread_cancel(t);
@@ -4512,12 +4510,11 @@ static void rfapiDeleteRemotePrefixesIt(
 						continue;
 					if (bpi->extra->vnc.import.timer) {
 
-						struct thread *t =
-							(struct thread *)bpi
-								->extra->vnc
-								.import.timer;
+						struct thread **t =
+							&(bpi->extra->vnc
+								.import.timer);
 						struct rfapi_withdraw *wcb =
-							t->arg;
+							(*t)->arg;
 
 						wcb->import_table
 							->holddown_count[afi] -=

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -620,10 +620,7 @@ void rfapiMonitorDel(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		rfapiMonitorDetachImport(m);
 	}
 
-	if (m->timer) {
-		thread_cancel(m->timer);
-		m->timer = NULL;
-	}
+	thread_cancel(&m->timer);
 
 	/*
 	 * remove from rfd list
@@ -660,10 +657,7 @@ int rfapiMonitorDelHd(struct rfapi_descriptor *rfd)
 					rfapiMonitorDetachImport(m);
 				}
 
-				if (m->timer) {
-					thread_cancel(m->timer);
-					m->timer = NULL;
-				}
+				thread_cancel(&m->timer);
 
 				XFREE(MTYPE_RFAPI_MONITOR, m);
 				rn->info = NULL;
@@ -697,10 +691,7 @@ int rfapiMonitorDelHd(struct rfapi_descriptor *rfd)
 #endif
 			}
 
-			if (mon_eth->timer) {
-				thread_cancel(mon_eth->timer);
-				mon_eth->timer = NULL;
-			}
+			thread_cancel(&mon_eth->timer);
 
 			/*
 			 * remove from rfd list
@@ -766,8 +757,7 @@ static void rfapiMonitorTimerRestart(struct rfapi_monitor_vpn *m)
 		if (m->rfd->response_lifetime - remain < 2)
 			return;
 
-		thread_cancel(m->timer);
-		m->timer = NULL;
+		thread_cancel(&m->timer);
 	}
 
 	{
@@ -1086,8 +1076,7 @@ static void rfapiMonitorEthTimerRestart(struct rfapi_monitor_eth *m)
 		if (m->rfd->response_lifetime - remain < 2)
 			return;
 
-		thread_cancel(m->timer);
-		m->timer = NULL;
+		thread_cancel(&m->timer);
 	}
 
 	{
@@ -1432,10 +1421,7 @@ void rfapiMonitorEthDel(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		rfapiMonitorEthDetachImport(bgp, val);
 	}
 
-	if (val->timer) {
-		thread_cancel(val->timer);
-		val->timer = NULL;
-	}
+	thread_cancel(&val->timer);
 
 	/*
 	 * remove from rfd list

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -269,9 +269,8 @@ static void rfapi_info_free(struct rfapi_info *goner)
 			struct rfapi_rib_tcb *tcb;
 
 			tcb = goner->timer->arg;
-			thread_cancel(goner->timer);
+			thread_cancel(&goner->timer);
 			XFREE(MTYPE_RFAPI_RECENT_DELETE, tcb);
-			goner->timer = NULL;
 		}
 		XFREE(MTYPE_RFAPI_INFO, goner);
 	}
@@ -338,13 +337,11 @@ static void rfapiRibStartTimer(struct rfapi_descriptor *rfd,
 			       struct agg_node *rn, /* route node attached to */
 			       int deleted)
 {
-	struct thread *t = ri->timer;
 	struct rfapi_rib_tcb *tcb = NULL;
 
-	if (t) {
-		tcb = t->arg;
-		thread_cancel(t);
-		ri->timer = NULL;
+	if (ri->timer) {
+		tcb = ri->timer->arg;
+		thread_cancel(&ri->timer);
 	} else {
 		tcb = XCALLOC(MTYPE_RFAPI_RECENT_DELETE,
 			      sizeof(struct rfapi_rib_tcb));
@@ -921,10 +918,9 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 				if (ri->timer) {
 					struct rfapi_rib_tcb *tcb;
 
-					tcb = ((struct thread *)ri->timer)->arg;
-					thread_cancel(ri->timer);
+					tcb = ri->timer->arg;
+					thread_cancel(&ri->timer);
 					XFREE(MTYPE_RFAPI_RECENT_DELETE, tcb);
-					ri->timer = NULL;
 				}
 
 				prefix2str(&ri->rk.vn, buf, sizeof(buf));
@@ -1009,11 +1005,9 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 				if (ori->timer) {
 					struct rfapi_rib_tcb *tcb;
 
-					tcb = ((struct thread *)ori->timer)
-						      ->arg;
-					thread_cancel(ori->timer);
+					tcb = ori->timer->arg;
+					thread_cancel(&ori->timer);
 					XFREE(MTYPE_RFAPI_RECENT_DELETE, tcb);
-					ori->timer = NULL;
 				}
 
 #if DEBUG_PROCESS_PENDING_NODE
@@ -1357,11 +1351,9 @@ callback:
 				if (ri->timer) {
 					struct rfapi_rib_tcb *tcb;
 
-					tcb = ((struct thread *)ri->timer)->arg;
-					thread_cancel(
-						(struct thread *)ri->timer);
+					tcb = ri->timer->arg;
+					thread_cancel(&ri->timer);
 					XFREE(MTYPE_RFAPI_RECENT_DELETE, tcb);
-					ri->timer = NULL;
 				}
 				RFAPI_RIB_CHECK_COUNTS(0, delete_list->count);
 

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -1711,14 +1711,11 @@ void vnc_direct_bgp_rh_add_route(struct bgp *bgp, afi_t afi,
 	rfapiGetVncLifetime(attr, &eti->lifetime);
 	eti->lifetime = rfapiGetHolddownFromLifetime(eti->lifetime);
 
-	if (eti->timer) {
-		/*
-		 * export expiration timer is already running on
-		 * this route: cancel it
-		 */
-		thread_cancel(eti->timer);
-		eti->timer = NULL;
-	}
+	/*
+	 * export expiration timer is already running on
+	 * this route: cancel it
+	 */
+	thread_cancel(&eti->timer);
 
 	bgp_update(peer, prefix, /* prefix */
 		   0,		 /* addpath_id */
@@ -1947,15 +1944,12 @@ void vnc_direct_bgp_rh_vpn_enable(struct bgp *bgp, afi_t afi)
 					rfapiGetVncLifetime(ri->attr,
 							    &eti->lifetime);
 
-					if (eti->timer) {
-						/*
-						 * export expiration timer is
-						 * already running on
-						 * this route: cancel it
-						 */
-						thread_cancel(eti->timer);
-						eti->timer = NULL;
-					}
+					/*
+					 * export expiration timer is
+					 * already running on
+					 * this route: cancel it
+					 */
+					thread_cancel(&eti->timer);
 
 					vnc_zlog_debug_verbose(
 						"%s: calling bgp_update",
@@ -2024,8 +2018,7 @@ void vnc_direct_bgp_rh_vpn_disable(struct bgp *bgp, afi_t afi)
 					ZEBRA_ROUTE_VNC_DIRECT_RH,
 					BGP_ROUTE_REDISTRIBUTE);
 				if (eti) {
-					if (eti->timer)
-						thread_cancel(eti->timer);
+					thread_cancel(&eti->timer);
 					vnc_eti_delete(eti);
 				}
 

--- a/eigrpd/eigrp_filter.c
+++ b/eigrpd/eigrp_filter.c
@@ -159,8 +159,8 @@ void eigrp_distribute_update(struct distribute_ctx *ctx,
 #endif
 		// TODO: check Graceful restart after 10sec
 
-      		/* cancel GR scheduled */
-      		thread_cancel(&(e->t_distribute));
+		/* cancel GR scheduled */
+		thread_cancel(&(e->t_distribute));
 
 		/* schedule Graceful restart for whole process in 10sec */
 		thread_add_timer(master, eigrp_distribute_timer_process, e,
@@ -264,7 +264,7 @@ void eigrp_distribute_update(struct distribute_ctx *ctx,
 #endif
 	// TODO: check Graceful restart after 10sec
 
-  	/* Cancel GR scheduled */
+	/* Cancel GR scheduled */
 	thread_cancel(&(ei->t_distribute));
 	/* schedule Graceful restart for interface in 10sec */
 	e->t_distribute = NULL;

--- a/eigrpd/eigrp_filter.c
+++ b/eigrpd/eigrp_filter.c
@@ -159,13 +159,10 @@ void eigrp_distribute_update(struct distribute_ctx *ctx,
 #endif
 		// TODO: check Graceful restart after 10sec
 
-		/* check if there is already GR scheduled */
-		if (e->t_distribute != NULL) {
-			/* if is, cancel schedule */
-			thread_cancel(e->t_distribute);
-		}
+      		/* cancel GR scheduled */
+      		thread_cancel(&(e->t_distribute));
+
 		/* schedule Graceful restart for whole process in 10sec */
-		e->t_distribute = NULL;
 		thread_add_timer(master, eigrp_distribute_timer_process, e,
 				 (10), &e->t_distribute);
 
@@ -267,11 +264,8 @@ void eigrp_distribute_update(struct distribute_ctx *ctx,
 #endif
 	// TODO: check Graceful restart after 10sec
 
-	/* check if there is already GR scheduled */
-	if (ei->t_distribute != NULL) {
-		/* if is, cancel schedule */
-		thread_cancel(ei->t_distribute);
-	}
+  	/* Cancel GR scheduled */
+	thread_cancel(&(ei->t_distribute));
 	/* schedule Graceful restart for interface in 10sec */
 	e->t_distribute = NULL;
 	thread_add_timer(master, eigrp_distribute_timer_interface, ei, 10,

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -332,7 +332,7 @@ int eigrp_if_down(struct eigrp_interface *ei)
 
 	/* Shutdown packet reception and sending */
 	if (ei->t_hello)
-		THREAD_OFF(ei->t_hello);
+		EVENT_CANCEL(ei->t_hello);
 
 	eigrp_if_stream_unset(ei);
 
@@ -421,7 +421,7 @@ void eigrp_if_free(struct eigrp_interface *ei, int source)
 	struct eigrp *eigrp = ei->eigrp;
 
 	if (source == INTERFACE_DOWN_BY_VTY) {
-		THREAD_OFF(ei->t_hello);
+		EVENT_CANCEL(ei->t_hello);
 		eigrp_hello_send(ei, EIGRP_HELLO_GRACEFUL_SHUTDOWN, NULL);
 	}
 

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -359,7 +359,7 @@ void eigrp_if_stream_unset(struct eigrp_interface *ei)
 	if (ei->on_write_q) {
 		listnode_delete(eigrp->oi_write_q, ei);
 		if (list_isempty(eigrp->oi_write_q))
-			thread_cancel(eigrp->t_write);
+			thread_cancel(&(eigrp->t_write));
 		ei->on_write_q = 0;
 	}
 }

--- a/eigrpd/eigrp_neighbor.c
+++ b/eigrpd/eigrp_neighbor.c
@@ -185,7 +185,7 @@ void eigrp_nbr_delete(struct eigrp_neighbor *nbr)
 	thread_cancel_event(master, nbr);
 	eigrp_fifo_free(nbr->multicast_queue);
 	eigrp_fifo_free(nbr->retrans_queue);
-	THREAD_OFF(nbr->t_holddown);
+	EVENT_CANCEL(nbr->t_holddown);
 
 	if (nbr->ei)
 		listnode_delete(nbr->ei->nbrs, nbr);
@@ -231,7 +231,7 @@ void eigrp_nbr_state_set(struct eigrp_neighbor *nbr, uint8_t state)
 
 		// hold time..
 		nbr->v_holddown = EIGRP_HOLD_INTERVAL_DEFAULT;
-		THREAD_OFF(nbr->t_holddown);
+		EVENT_CANCEL(nbr->t_holddown);
 
 		/* out with the old */
 		if (nbr->multicast_queue)
@@ -273,7 +273,7 @@ void eigrp_nbr_state_update(struct eigrp_neighbor *nbr)
 	switch (nbr->state) {
 	case EIGRP_NEIGHBOR_DOWN: {
 		/*Start Hold Down Timer for neighbor*/
-		//     THREAD_OFF(nbr->t_holddown);
+		//     EVENT_CANCEL(nbr->t_holddown);
 		//     THREAD_TIMER_ON(master, nbr->t_holddown,
 		//     holddown_timer_expired,
 		//     nbr, nbr->v_holddown);
@@ -281,14 +281,14 @@ void eigrp_nbr_state_update(struct eigrp_neighbor *nbr)
 	}
 	case EIGRP_NEIGHBOR_PENDING: {
 		/*Reset Hold Down Timer for neighbor*/
-		THREAD_OFF(nbr->t_holddown);
+		EVENT_CANCEL(nbr->t_holddown);
 		thread_add_timer(master, holddown_timer_expired, nbr,
 				 nbr->v_holddown, &nbr->t_holddown);
 		break;
 	}
 	case EIGRP_NEIGHBOR_UP: {
 		/*Reset Hold Down Timer for neighbor*/
-		THREAD_OFF(nbr->t_holddown);
+		EVENT_CANCEL(nbr->t_holddown);
 		thread_add_timer(master, holddown_timer_expired, nbr,
 				 nbr->v_holddown, &nbr->t_holddown);
 		break;

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -945,7 +945,7 @@ void eigrp_packet_free(struct eigrp_packet *ep)
 	if (ep->s)
 		stream_free(ep->s);
 
-	THREAD_OFF(ep->t_retrans_timer);
+	EVENT_CANCEL(ep->t_retrans_timer);
 
 	XFREE(MTYPE_EIGRP_PACKET, ep);
 }

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -276,8 +276,8 @@ void eigrp_finish_final(struct eigrp *eigrp)
 		eigrp_if_free(ei, INTERFACE_DOWN_BY_FINAL);
 	}
 
-	THREAD_OFF(eigrp->t_write);
-	THREAD_OFF(eigrp->t_read);
+	EVENT_CANCEL(eigrp->t_write);
+	EVENT_CANCEL(eigrp->t_read);
 	close(eigrp->fd);
 
 	list_delete(&eigrp->eiflist);

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -170,7 +170,7 @@ void isis_delete_adj(void *arg)
 	if (!adj)
 		return;
 
-	THREAD_TIMER_OFF(adj->t_expire);
+	EVENT_CANCEL(adj->t_expire);
 	if (adj->adj_state != ISIS_ADJ_DOWN)
 		adj->adj_state = ISIS_ADJ_DOWN;
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -793,12 +793,12 @@ void isis_circuit_down(struct isis_circuit *circuit)
 		memset(circuit->u.bc.l2_desig_is, 0, ISIS_SYS_ID_LEN + 1);
 		memset(circuit->u.bc.snpa, 0, ETH_ALEN);
 
-		THREAD_TIMER_OFF(circuit->u.bc.t_send_lan_hello[0]);
-		THREAD_TIMER_OFF(circuit->u.bc.t_send_lan_hello[1]);
-		THREAD_TIMER_OFF(circuit->u.bc.t_run_dr[0]);
-		THREAD_TIMER_OFF(circuit->u.bc.t_run_dr[1]);
-		THREAD_TIMER_OFF(circuit->u.bc.t_refresh_pseudo_lsp[0]);
-		THREAD_TIMER_OFF(circuit->u.bc.t_refresh_pseudo_lsp[1]);
+		EVENT_CANCEL(circuit->u.bc.t_send_lan_hello[0]);
+		EVENT_CANCEL(circuit->u.bc.t_send_lan_hello[1]);
+		EVENT_CANCEL(circuit->u.bc.t_run_dr[0]);
+		EVENT_CANCEL(circuit->u.bc.t_run_dr[1]);
+		EVENT_CANCEL(circuit->u.bc.t_refresh_pseudo_lsp[0]);
+		EVENT_CANCEL(circuit->u.bc.t_refresh_pseudo_lsp[1]);
 		circuit->lsp_regenerate_pending[0] = 0;
 		circuit->lsp_regenerate_pending[1] = 0;
 
@@ -807,15 +807,15 @@ void isis_circuit_down(struct isis_circuit *circuit)
 	} else if (circuit->circ_type == CIRCUIT_T_P2P) {
 		isis_delete_adj(circuit->u.p2p.neighbor);
 		circuit->u.p2p.neighbor = NULL;
-		THREAD_TIMER_OFF(circuit->u.p2p.t_send_p2p_hello);
+		EVENT_CANCEL(circuit->u.p2p.t_send_p2p_hello);
 	}
 
 	/* Cancel all active threads */
-	THREAD_TIMER_OFF(circuit->t_send_csnp[0]);
-	THREAD_TIMER_OFF(circuit->t_send_csnp[1]);
-	THREAD_TIMER_OFF(circuit->t_send_psnp[0]);
-	THREAD_TIMER_OFF(circuit->t_send_psnp[1]);
-	THREAD_OFF(circuit->t_read);
+	EVENT_CANCEL(circuit->t_send_csnp[0]);
+	EVENT_CANCEL(circuit->t_send_csnp[1]);
+	EVENT_CANCEL(circuit->t_send_psnp[0]);
+	EVENT_CANCEL(circuit->t_send_psnp[1]);
+	EVENT_CANCEL(circuit->t_read);
 
 	if (circuit->tx_queue) {
 		isis_tx_queue_free(circuit->tx_queue);

--- a/isisd/isis_dr.c
+++ b/isisd/isis_dr.c
@@ -221,8 +221,8 @@ int isis_dr_resign(struct isis_circuit *circuit, int level)
 
 	circuit->u.bc.is_dr[level - 1] = 0;
 	circuit->u.bc.run_dr_elect[level - 1] = 0;
-	THREAD_TIMER_OFF(circuit->u.bc.t_run_dr[level - 1]);
-	THREAD_TIMER_OFF(circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
+	EVENT_CANCEL(circuit->u.bc.t_run_dr[level - 1]);
+	EVENT_CANCEL(circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
 	circuit->lsp_regenerate_pending[level - 1] = 0;
 
 	memcpy(id, isis->sysid, ISIS_SYS_ID_LEN);
@@ -246,7 +246,7 @@ int isis_dr_resign(struct isis_circuit *circuit, int level)
 				 &circuit->t_send_psnp[1]);
 	}
 
-	THREAD_TIMER_OFF(circuit->t_send_csnp[level - 1]);
+	EVENT_CANCEL(circuit->t_send_csnp[level - 1]);
 
 	thread_add_timer(master, isis_run_dr,
 			 &circuit->level_arg[level - 1],

--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -105,13 +105,13 @@ static void circuit_resign_level(struct isis_circuit *circuit, int level)
 {
 	int idx = level - 1;
 
-	THREAD_TIMER_OFF(circuit->t_send_csnp[idx]);
-	THREAD_TIMER_OFF(circuit->t_send_psnp[idx]);
+	EVENT_CANCEL(circuit->t_send_csnp[idx]);
+	EVENT_CANCEL(circuit->t_send_psnp[idx]);
 
 	if (circuit->circ_type == CIRCUIT_T_BROADCAST) {
-		THREAD_TIMER_OFF(circuit->u.bc.t_send_lan_hello[idx]);
-		THREAD_TIMER_OFF(circuit->u.bc.t_run_dr[idx]);
-		THREAD_TIMER_OFF(circuit->u.bc.t_refresh_pseudo_lsp[idx]);
+		EVENT_CANCEL(circuit->u.bc.t_send_lan_hello[idx]);
+		EVENT_CANCEL(circuit->u.bc.t_run_dr[idx]);
+		EVENT_CANCEL(circuit->u.bc.t_refresh_pseudo_lsp[idx]);
 		circuit->lsp_regenerate_pending[idx] = 0;
 		circuit->u.bc.run_dr_elect[idx] = 0;
 		if (circuit->u.bc.lan_neighs[idx] != NULL)

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1239,7 +1239,7 @@ int lsp_generate(struct isis_area *area, int level)
 
 	refresh_time = lsp_refresh_time(newlsp, rem_lifetime);
 
-	THREAD_TIMER_OFF(area->t_lsp_refresh[level - 1]);
+	EVENT_CANCEL(area->t_lsp_refresh[level - 1]);
 	area->lsp_regenerate_pending[level - 1] = 0;
 	thread_add_timer(master, lsp_refresh,
 			 &area->lsp_refresh_arg[level - 1], refresh_time,
@@ -1450,7 +1450,7 @@ int _lsp_regenerate_schedule(struct isis_area *area, int level,
 			"ISIS (%s): Will schedule regen timer. Last run was: %lld, Now is: %lld",
 			area->area_tag, (long long)lsp->last_generated,
 			(long long)now);
-		THREAD_TIMER_OFF(area->t_lsp_refresh[lvl - 1]);
+		EVENT_CANCEL(area->t_lsp_refresh[lvl - 1]);
 		diff = now - lsp->last_generated;
 		if (diff < area->lsp_gen_interval[lvl - 1]
 		    && !(area->bfd_signalled_down)) {
@@ -1627,7 +1627,7 @@ int lsp_generate_pseudo(struct isis_circuit *circuit, int level)
 	lsp_flood(lsp, NULL);
 
 	refresh_time = lsp_refresh_time(lsp, rem_lifetime);
-	THREAD_TIMER_OFF(circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
+	EVENT_CANCEL(circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
 	circuit->lsp_regenerate_pending[level - 1] = 0;
 	if (level == IS_LEVEL_1)
 		thread_add_timer(
@@ -1818,7 +1818,7 @@ int lsp_regenerate_schedule_pseudo(struct isis_circuit *circuit, int level)
 			"ISIS (%s): Will schedule PSN regen timer. Last run was: %lld, Now is: %lld",
 			area->area_tag, (long long)lsp->last_generated,
 			(long long)now);
-		THREAD_TIMER_OFF(circuit->u.bc.t_refresh_pseudo_lsp[lvl - 1]);
+		EVENT_CANCEL(circuit->u.bc.t_refresh_pseudo_lsp[lvl - 1]);
 		diff = now - lsp->last_generated;
 		if (diff < circuit->area->lsp_gen_interval[lvl - 1]) {
 			timeout =

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -201,7 +201,7 @@ static int process_p2p_hello(struct iih_info *iih)
 				      adj);
 
 	/* lets take care of the expiry */
-	THREAD_TIMER_OFF(adj->t_expire);
+	EVENT_CANCEL(adj->t_expire);
 	thread_add_timer(master, isis_adj_expire, adj, (long)adj->hold_time,
 			 &adj->t_expire);
 
@@ -493,7 +493,7 @@ static int process_lan_hello(struct iih_info *iih)
 				      adj);
 
 	/* lets take care of the expiry */
-	THREAD_TIMER_OFF(adj->t_expire);
+	EVENT_CANCEL(adj->t_expire);
 	thread_add_timer(master, isis_adj_expire, adj, (long)adj->hold_time,
 			 &adj->t_expire);
 

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -1980,7 +1980,7 @@ static void _send_hello_sched(struct isis_circuit *circuit,
 		if (thread_timer_remain_msec(*threadp) < (unsigned long)delay)
 			return;
 
-		thread_cancel(*threadp);
+		thread_cancel(threadp);
 	}
 
 	thread_add_timer_msec(master, send_hello_cb,

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -2193,7 +2193,7 @@ void isis_sr_stop(struct isis_area *area)
 		 area->area_tag);
 
 	/* Disable any re-attempt to connect to Label Manager */
-	THREAD_TIMER_OFF(srdb->t_start_lm);
+	EVENT_CANCEL(srdb->t_start_lm);
 
 	/* Uninstall all local Adjacency-SIDs. */
 	for (ALL_LIST_ELEMENTS(area->srdb.adj_sids, node, nnode, sra))

--- a/isisd/isis_tx_queue.c
+++ b/isisd/isis_tx_queue.c
@@ -93,8 +93,7 @@ static void tx_queue_element_free(void *element)
 {
 	struct isis_tx_queue_entry *e = element;
 
-	if (e->retry)
-		thread_cancel(e->retry);
+	thread_cancel(&(e->retry));
 
 	XFREE(MTYPE_TX_QUEUE_ENTRY, e);
 }
@@ -166,8 +165,7 @@ void _isis_tx_queue_add(struct isis_tx_queue *queue,
 
 	e->type = type;
 
-	if (e->retry)
-		thread_cancel(e->retry);
+	thread_cancel(&(e->retry));
 	thread_add_event(master, tx_queue_send_event, e, 0, &e->retry);
 
 	e->is_retry = false;
@@ -190,8 +188,7 @@ void _isis_tx_queue_del(struct isis_tx_queue *queue, struct isis_lsp *lsp,
 			   func, file, line);
 	}
 
-	if (e->retry)
-		thread_cancel(e->retry);
+	thread_cancel(&(e->retry));
 
 	hash_release(queue->hash, e);
 	XFREE(MTYPE_TX_QUEUE_ENTRY, e);

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -292,8 +292,8 @@ int isis_area_destroy(const char *area_tag)
 
 	spftree_area_del(area);
 
-	THREAD_TIMER_OFF(area->spf_timer[0]);
-	THREAD_TIMER_OFF(area->spf_timer[1]);
+	EVENT_CANCEL(area->spf_timer[0]);
+	EVENT_CANCEL(area->spf_timer[1]);
 
 	spf_backoff_free(area->spf_delay_ietf[0]);
 	spf_backoff_free(area->spf_delay_ietf[1]);
@@ -306,9 +306,9 @@ int isis_area_destroy(const char *area_tag)
 	}
 	area->area_addrs = NULL;
 
-	THREAD_TIMER_OFF(area->t_tick);
-	THREAD_TIMER_OFF(area->t_lsp_refresh[0]);
-	THREAD_TIMER_OFF(area->t_lsp_refresh[1]);
+	EVENT_CANCEL(area->t_tick);
+	EVENT_CANCEL(area->t_lsp_refresh[0]);
+	EVENT_CANCEL(area->t_lsp_refresh[1]);
 
 	thread_cancel_event(master, area);
 
@@ -1771,12 +1771,12 @@ static void area_resign_level(struct isis_area *area, int level)
 		}
 	}
 
-	THREAD_TIMER_OFF(area->spf_timer[level - 1]);
+	EVENT_CANCEL(area->spf_timer[level - 1]);
 
 	sched_debug(
 		"ISIS (%s): Resigned from L%d - canceling LSP regeneration timer.",
 		area->area_tag, level);
-	THREAD_TIMER_OFF(area->t_lsp_refresh[level - 1]);
+	EVENT_CANCEL(area->t_lsp_refresh[level - 1]);
 	area->lsp_regenerate_pending[level - 1] = 0;
 }
 

--- a/ldpd/accept.c
+++ b/ldpd/accept.c
@@ -74,7 +74,7 @@ accept_del(int fd)
 	LIST_FOREACH(av, &accept_queue.queue, entry)
 		if (av->fd == fd) {
 			log_debug("%s: %d removed from queue", __func__, fd);
-			THREAD_READ_OFF(av->ev);
+			EVENT_CANCEL(av->ev);
 			LIST_REMOVE(av, entry);
 			free(av);
 			return;
@@ -95,7 +95,7 @@ accept_unpause(void)
 {
 	if (accept_queue.evt != NULL) {
 		log_debug(__func__);
-		THREAD_TIMER_OFF(accept_queue.evt);
+		EVENT_CANCEL(accept_queue.evt);
 		accept_arm();
 	}
 }
@@ -115,7 +115,7 @@ accept_unarm(void)
 {
 	struct accept_ev	*av;
 	LIST_FOREACH(av, &accept_queue.queue, entry)
-		THREAD_READ_OFF(av->ev);
+		EVENT_CANCEL(av->ev);
 }
 
 static int

--- a/ldpd/adjacency.c
+++ b/ldpd/adjacency.c
@@ -195,7 +195,7 @@ adj_itimer(struct thread *thread)
 void
 adj_start_itimer(struct adj *adj)
 {
-	THREAD_TIMER_OFF(adj->inactivity_timer);
+	EVENT_CANCEL(adj->inactivity_timer);
 	adj->inactivity_timer = NULL;
 	thread_add_timer(master, adj_itimer, adj, adj->holdtime,
 			 &adj->inactivity_timer);
@@ -204,7 +204,7 @@ adj_start_itimer(struct adj *adj)
 void
 adj_stop_itimer(struct adj *adj)
 {
-	THREAD_TIMER_OFF(adj->inactivity_timer);
+	EVENT_CANCEL(adj->inactivity_timer);
 }
 
 /* targeted neighbors */
@@ -356,7 +356,7 @@ tnbr_hello_timer(struct thread *thread)
 static void
 tnbr_start_hello_timer(struct tnbr *tnbr)
 {
-	THREAD_TIMER_OFF(tnbr->hello_timer);
+	EVENT_CANCEL(tnbr->hello_timer);
 	tnbr->hello_timer = NULL;
 	thread_add_timer(master, tnbr_hello_timer, tnbr, tnbr_get_hello_interval(tnbr),
 			 &tnbr->hello_timer);
@@ -365,7 +365,7 @@ tnbr_start_hello_timer(struct tnbr *tnbr)
 static void
 tnbr_stop_hello_timer(struct tnbr *tnbr)
 {
-	THREAD_TIMER_OFF(tnbr->hello_timer);
+	EVENT_CANCEL(tnbr->hello_timer);
 }
 
 struct ctl_adj *

--- a/ldpd/control.c
+++ b/ldpd/control.c
@@ -183,8 +183,8 @@ control_close(int fd)
 	msgbuf_clear(&c->iev.ibuf.w);
 	TAILQ_REMOVE(&ctl_conns, c, entry);
 
-	THREAD_READ_OFF(c->iev.ev_read);
-	THREAD_WRITE_OFF(c->iev.ev_write);
+	EVENT_CANCEL(c->iev.ev_read);
+	EVENT_CANCEL(c->iev.ev_write);
 	close(c->iev.ibuf.fd);
 	accept_unpause();
 	free(c);

--- a/ldpd/interface.c
+++ b/ldpd/interface.c
@@ -443,7 +443,7 @@ if_hello_timer(struct thread *thread)
 static void
 if_start_hello_timer(struct iface_af *ia)
 {
-	THREAD_TIMER_OFF(ia->hello_timer);
+	EVENT_CANCEL(ia->hello_timer);
 	ia->hello_timer = NULL;
 	thread_add_timer(master, if_hello_timer, ia, if_get_hello_interval(ia),
 			 &ia->hello_timer);
@@ -452,7 +452,7 @@ if_start_hello_timer(struct iface_af *ia)
 static void
 if_stop_hello_timer(struct iface_af *ia)
 {
-	THREAD_TIMER_OFF(ia->hello_timer);
+	EVENT_CANCEL(ia->hello_timer);
 }
 
 struct ctl_iface *

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -415,8 +415,8 @@ lde_dispatch_imsg(struct thread *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		THREAD_READ_OFF(iev->ev_read);
-		THREAD_WRITE_OFF(iev->ev_write);
+		EVENT_CANCEL(iev->ev_read);
+		EVENT_CANCEL(iev->ev_write);
 		lde_shutdown();
 	}
 
@@ -657,8 +657,8 @@ lde_dispatch_parent(struct thread *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		THREAD_READ_OFF(iev->ev_read);
-		THREAD_WRITE_OFF(iev->ev_write);
+		EVENT_CANCEL(iev->ev_read);
+		EVENT_CANCEL(iev->ev_write);
 		lde_shutdown();
 	}
 

--- a/ldpd/lde_lib.c
+++ b/ldpd/lde_lib.c
@@ -1036,7 +1036,7 @@ lde_gc_timer(struct thread *thread)
 void
 lde_gc_start_timer(void)
 {
-	THREAD_TIMER_OFF(gc_timer);
+	EVENT_CANCEL(gc_timer);
 	gc_timer = NULL;
 	thread_add_timer(master, lde_gc_timer, NULL, LDE_GC_INTERVAL,
 			 &gc_timer);
@@ -1045,5 +1045,5 @@ lde_gc_start_timer(void)
 void
 lde_gc_stop_timer(void)
 {
-	THREAD_TIMER_OFF(gc_timer);
+	EVENT_CANCEL(gc_timer);
 }

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -597,8 +597,8 @@ main_dispatch_ldpe(struct thread *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		THREAD_READ_OFF(iev->ev_read);
-		THREAD_WRITE_OFF(iev->ev_write);
+		EVENT_CANCEL(iev->ev_read);
+		EVENT_CANCEL(iev->ev_write);
 		ldpe_pid = 0;
 		if (lde_pid == 0)
 			ldpd_shutdown();
@@ -695,8 +695,8 @@ main_dispatch_lde(struct thread *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		THREAD_READ_OFF(iev->ev_read);
-		THREAD_WRITE_OFF(iev->ev_write);
+		EVENT_CANCEL(iev->ev_read);
+		EVENT_CANCEL(iev->ev_write);
 		lde_pid = 0;
 		if (ldpe_pid == 0)
 			ldpd_shutdown();
@@ -721,8 +721,8 @@ ldp_write_handler(struct thread *thread)
 		fatal("msgbuf_write");
 	if (n == 0) {
 		/* this pipe is dead, so remove the event handlers */
-		THREAD_READ_OFF(iev->ev_read);
-		THREAD_WRITE_OFF(iev->ev_write);
+		EVENT_CANCEL(iev->ev_read);
+		EVENT_CANCEL(iev->ev_write);
 		return (0);
 	}
 
@@ -809,7 +809,7 @@ evbuf_init(struct evbuf *eb, int fd, int (*handler)(struct thread *),
 void
 evbuf_clear(struct evbuf *eb)
 {
-	THREAD_WRITE_OFF(eb->ev);
+	EVENT_CANCEL(eb->ev);
 	msgbuf_clear(&eb->wbuf);
 	eb->wbuf.fd = -1;
 }

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -208,7 +208,7 @@ ldpe_shutdown(void)
 
 #ifdef __OpenBSD__
 	if (sysdep.no_pfkey == 0) {
-		THREAD_READ_OFF(pfkey_ev);
+		EVENT_CANCEL(pfkey_ev);
 		close(global.pfkeysock);
 	}
 #endif
@@ -570,8 +570,8 @@ ldpe_dispatch_main(struct thread *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		THREAD_READ_OFF(iev->ev_read);
-		THREAD_WRITE_OFF(iev->ev_write);
+		EVENT_CANCEL(iev->ev_read);
+		EVENT_CANCEL(iev->ev_write);
 		ldpe_shutdown();
 	}
 
@@ -713,8 +713,8 @@ ldpe_dispatch_lde(struct thread *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		THREAD_READ_OFF(iev->ev_read);
-		THREAD_WRITE_OFF(iev->ev_write);
+		EVENT_CANCEL(iev->ev_read);
+		EVENT_CANCEL(iev->ev_write);
 		ldpe_shutdown();
 	}
 
@@ -772,14 +772,14 @@ ldpe_close_sockets(int af)
 	af_global = ldp_af_global_get(&global, af);
 
 	/* discovery socket */
-	THREAD_READ_OFF(af_global->disc_ev);
+	EVENT_CANCEL(af_global->disc_ev);
 	if (af_global->ldp_disc_socket != -1) {
 		close(af_global->ldp_disc_socket);
 		af_global->ldp_disc_socket = -1;
 	}
 
 	/* extended discovery socket */
-	THREAD_READ_OFF(af_global->edisc_ev);
+	EVENT_CANCEL(af_global->edisc_ev);
 	if (af_global->ldp_edisc_socket != -1) {
 		close(af_global->ldp_edisc_socket);
 		af_global->ldp_edisc_socket = -1;

--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -302,7 +302,7 @@ nbr_del(struct nbr *nbr)
 	nbr->auth.method = AUTH_NONE;
 
 	if (nbr_pending_connect(nbr))
-		THREAD_WRITE_OFF(nbr->ev_connect);
+		EVENT_CANCEL(nbr->ev_connect);
 	nbr_stop_ktimer(nbr);
 	nbr_stop_ktimeout(nbr);
 	nbr_stop_itimeout(nbr);
@@ -416,7 +416,7 @@ nbr_start_ktimer(struct nbr *nbr)
 
 	/* send three keepalives per period */
 	secs = nbr->keepalive / KEEPALIVE_PER_PERIOD;
-	THREAD_TIMER_OFF(nbr->keepalive_timer);
+	EVENT_CANCEL(nbr->keepalive_timer);
 	nbr->keepalive_timer = NULL;
 	thread_add_timer(master, nbr_ktimer, nbr, secs, &nbr->keepalive_timer);
 }
@@ -424,7 +424,7 @@ nbr_start_ktimer(struct nbr *nbr)
 void
 nbr_stop_ktimer(struct nbr *nbr)
 {
-	THREAD_TIMER_OFF(nbr->keepalive_timer);
+	EVENT_CANCEL(nbr->keepalive_timer);
 }
 
 /* Keepalive timeout: if the nbr hasn't sent keepalive */
@@ -446,7 +446,7 @@ nbr_ktimeout(struct thread *thread)
 static void
 nbr_start_ktimeout(struct nbr *nbr)
 {
-	THREAD_TIMER_OFF(nbr->keepalive_timeout);
+	EVENT_CANCEL(nbr->keepalive_timeout);
 	nbr->keepalive_timeout = NULL;
 	thread_add_timer(master, nbr_ktimeout, nbr, nbr->keepalive,
 			 &nbr->keepalive_timeout);
@@ -455,7 +455,7 @@ nbr_start_ktimeout(struct nbr *nbr)
 void
 nbr_stop_ktimeout(struct nbr *nbr)
 {
-	THREAD_TIMER_OFF(nbr->keepalive_timeout);
+	EVENT_CANCEL(nbr->keepalive_timeout);
 }
 
 /* Session initialization timeout: if nbr got stuck in the initialization FSM */
@@ -478,7 +478,7 @@ nbr_start_itimeout(struct nbr *nbr)
 	int		 secs;
 
 	secs = INIT_FSM_TIMEOUT;
-	THREAD_TIMER_OFF(nbr->init_timeout);
+	EVENT_CANCEL(nbr->init_timeout);
 	nbr->init_timeout = NULL;
 	thread_add_timer(master, nbr_itimeout, nbr, secs, &nbr->init_timeout);
 }
@@ -486,7 +486,7 @@ nbr_start_itimeout(struct nbr *nbr)
 void
 nbr_stop_itimeout(struct nbr *nbr)
 {
-	THREAD_TIMER_OFF(nbr->init_timeout);
+	EVENT_CANCEL(nbr->init_timeout);
 }
 
 /* Init delay timer: timer to retry to iniziatize session */
@@ -527,7 +527,7 @@ nbr_start_idtimer(struct nbr *nbr)
 		break;
 	}
 
-	THREAD_TIMER_OFF(nbr->initdelay_timer);
+	EVENT_CANCEL(nbr->initdelay_timer);
 	nbr->initdelay_timer = NULL;
 	thread_add_timer(master, nbr_idtimer, nbr, secs,
 			 &nbr->initdelay_timer);
@@ -536,7 +536,7 @@ nbr_start_idtimer(struct nbr *nbr)
 void
 nbr_stop_idtimer(struct nbr *nbr)
 {
-	THREAD_TIMER_OFF(nbr->initdelay_timer);
+	EVENT_CANCEL(nbr->initdelay_timer);
 }
 
 int

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -662,7 +662,7 @@ session_shutdown(struct nbr *nbr, uint32_t status, uint32_t msg_id,
 	switch (nbr->state) {
 	case NBR_STA_PRESENT:
 		if (nbr_pending_connect(nbr))
-			THREAD_WRITE_OFF(nbr->ev_connect);
+			EVENT_CANCEL(nbr->ev_connect);
 		break;
 	case NBR_STA_INITIAL:
 	case NBR_STA_OPENREC:
@@ -760,7 +760,7 @@ tcp_close(struct tcp_conn *tcp)
 	evbuf_clear(&tcp->wbuf);
 
 	if (tcp->nbr) {
-		THREAD_READ_OFF(tcp->rev);
+		EVENT_CANCEL(tcp->rev);
 		free(tcp->rbuf);
 		tcp->nbr->tcp = NULL;
 	}
@@ -792,7 +792,7 @@ pending_conn_new(int fd, int af, union ldpd_addr *addr)
 void
 pending_conn_del(struct pending_conn *pconn)
 {
-	THREAD_TIMER_OFF(pconn->ev_timeout);
+	EVENT_CANCEL(pconn->ev_timeout);
 	TAILQ_REMOVE(&global.pending_conns, pconn, entry);
 	free(pconn);
 }

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -107,7 +107,7 @@ static void agentx_events_update(void)
 	struct thread *thr;
 	int fd, thr_fd;
 
-	THREAD_OFF(timeout_thr);
+	EVENT_CANCEL(timeout_thr);
 
 	FD_ZERO(&fds);
 	snmp_select_info(&maxfd, &fds, &timeout, &block);

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -130,7 +130,7 @@ static void agentx_events_update(void)
 		if (thr_fd == fd) {
 			struct listnode *nextln = listnextnode(ln);
 			if (!FD_ISSET(fd, &fds)) {
-				thread_cancel(thr);
+				thread_cancel(&thr);
 				list_delete_node(events, ln);
 			}
 			ln = nextln;
@@ -151,7 +151,8 @@ static void agentx_events_update(void)
 	 */
 	while (ln) {
 		struct listnode *nextln = listnextnode(ln);
-		thread_cancel(listgetdata(ln));
+		thr = listgetdata(ln);
+		thread_cancel(&thr);
 		list_delete_node(events, ln);
 		ln = nextln;
 	}

--- a/lib/frr_zmq.c
+++ b/lib/frr_zmq.c
@@ -190,10 +190,8 @@ int funcname_frrzmq_thread_add_read(struct thread_master *master,
 	cb->read.cancelled = false;
 
 	if (events & ZMQ_POLLIN) {
-		if (cb->read.thread) {
-			thread_cancel(cb->read.thread);
-			cb->read.thread = NULL;
-		}
+		thread_cancel(&cb->read.thread);
+
 		funcname_thread_add_event(master, frrzmq_read_msg, cbp, fd,
 					  &cb->read.thread, funcname, schedfrom,
 					  fromln);
@@ -298,10 +296,8 @@ int funcname_frrzmq_thread_add_write(struct thread_master *master,
 	cb->write.cancelled = false;
 
 	if (events & ZMQ_POLLOUT) {
-		if (cb->write.thread) {
-			thread_cancel(cb->write.thread);
-			cb->write.thread = NULL;
-		}
+		thread_cancel(&cb->write.thread);
+
 		funcname_thread_add_event(master, frrzmq_write_msg, cbp, fd,
 					  &cb->write.thread, funcname,
 					  schedfrom, fromln);
@@ -317,10 +313,8 @@ void frrzmq_thread_cancel(struct frrzmq_cb **cb, struct cb_core *core)
 	if (!cb || !*cb)
 		return;
 	core->cancelled = true;
-	if (core->thread) {
-		thread_cancel(core->thread);
-		core->thread = NULL;
-	}
+	thread_cancel(&core->thread);
+
 	if ((*cb)->read.cancelled && !(*cb)->read.thread
 	    && (*cb)->write.cancelled && (*cb)->write.thread)
 		XFREE(MTYPE_ZEROMQ_CB, *cb);
@@ -344,8 +338,8 @@ void frrzmq_check_events(struct frrzmq_cb **cbp, struct cb_core *core,
 		return;
 	if (events & event && core->thread && !core->cancelled) {
 		struct thread_master *tm = core->thread->master;
-		thread_cancel(core->thread);
-		core->thread = NULL;
+		thread_cancel(&core->thread);
+
 		thread_add_event(tm, (event == ZMQ_POLLIN ? frrzmq_read_msg
 							  : frrzmq_write_msg),
 				 cbp, cb->fd, &core->thread);

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -205,7 +205,7 @@ int nb_cli_rpc(const char *xpath, struct list *input, struct list *output)
 
 void nb_cli_confirmed_commit_clean(struct vty *vty)
 {
-	THREAD_TIMER_OFF(vty->t_confirmed_commit_timeout);
+	EVENT_CANCEL(vty->t_confirmed_commit_timeout);
 	nb_config_free(vty->confirmed_commit_rollback);
 	vty->confirmed_commit_rollback = NULL;
 }
@@ -267,7 +267,7 @@ static int nb_cli_commit(struct vty *vty, bool force,
 				"%% Resetting confirmed-commit timeout to %u minute(s)\n\n",
 				confirmed_timeout);
 
-			THREAD_TIMER_OFF(vty->t_confirmed_commit_timeout);
+			EVENT_CANCEL(vty->t_confirmed_commit_timeout);
 			thread_add_timer(master,
 					 nb_cli_confirmed_commit_timeout, vty,
 					 confirmed_timeout * 60,

--- a/lib/northbound_confd.c
+++ b/lib/northbound_confd.c
@@ -591,7 +591,7 @@ error:
 static void frr_confd_finish_cdb(void)
 {
 	if (cdb_sub_sock > 0) {
-		THREAD_OFF(t_cdb_sub);
+		EVENT_CANCEL(t_cdb_sub);
 		cdb_close(cdb_sub_sock);
 	}
 }
@@ -1321,11 +1321,11 @@ error:
 static void frr_confd_finish_dp(void)
 {
 	if (dp_worker_sock > 0) {
-		THREAD_OFF(t_dp_worker);
+		EVENT_CANCEL(t_dp_worker);
 		close(dp_worker_sock);
 	}
 	if (dp_ctl_sock > 0) {
-		THREAD_OFF(t_dp_ctl);
+		EVENT_CANCEL(t_dp_ctl);
 		close(dp_ctl_sock);
 	}
 	if (dctx != NULL)

--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -608,7 +608,7 @@ static void frr_sr_fd_add(int event, int fd)
 
 static void frr_sr_fd_free(struct sysrepo_thread *sr_thread)
 {
-	THREAD_OFF(sr_thread->thread);
+	EVENT_CANCEL(sr_thread->thread);
 	XFREE(MTYPE_SYSREPO, sr_thread);
 }
 

--- a/lib/pullwr.c
+++ b/lib/pullwr.c
@@ -75,7 +75,7 @@ struct pullwr *_pullwr_new(struct thread_master *tm, int fd,
 
 void pullwr_del(struct pullwr *pullwr)
 {
-	THREAD_OFF(pullwr->writer);
+	EVENT_CANCEL(pullwr->writer);
 
 	XFREE(MTYPE_PULLWR_BUF, pullwr->buffer);
 	XFREE(MTYPE_PULLWR_HEAD, pullwr);

--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -89,7 +89,7 @@ static void resolver_update_timeouts(struct resolver_state *r)
 	if (r->timeout == THREAD_RUNNING)
 		return;
 
-	THREAD_OFF(r->timeout);
+	EVENT_CANCEL(r->timeout);
 	tv = ares_timeout(r->channel, NULL, &tvbuf);
 	if (tv) {
 		unsigned int timeoutms = tv->tv_sec * 1000 + tv->tv_usec / 1000;
@@ -115,7 +115,7 @@ static void ares_socket_cb(void *data, ares_socket_t fd, int readable,
 		t = vector_lookup(r->read_threads, fd);
 		if (t) {
 			if (t != THREAD_RUNNING) {
-				THREAD_OFF(t);
+				EVENT_CANCEL(t);
 			}
 			vector_unset(r->read_threads, fd);
 		}
@@ -132,7 +132,7 @@ static void ares_socket_cb(void *data, ares_socket_t fd, int readable,
 		t = vector_lookup(r->write_threads, fd);
 		if (t) {
 			if (t != THREAD_RUNNING) {
-				THREAD_OFF(t);
+				EVENT_CANCEL(t);
 			}
 			vector_unset(r->write_threads, fd);
 		}

--- a/lib/spf_backoff.c
+++ b/lib/spf_backoff.c
@@ -110,8 +110,8 @@ void spf_backoff_free(struct spf_backoff *backoff)
 	if (!backoff)
 		return;
 
-	THREAD_TIMER_OFF(backoff->t_holddown);
-	THREAD_TIMER_OFF(backoff->t_timetolearn);
+	EVENT_CANCEL(backoff->t_holddown);
+	EVENT_CANCEL(backoff->t_timetolearn);
 	XFREE(MTYPE_SPF_BACKOFF_NAME, backoff->name);
 
 	XFREE(MTYPE_SPF_BACKOFF, backoff);
@@ -133,7 +133,7 @@ static int spf_backoff_holddown_elapsed(struct thread *thread)
 	struct spf_backoff *backoff = THREAD_ARG(thread);
 
 	backoff->t_holddown = NULL;
-	THREAD_TIMER_OFF(backoff->t_timetolearn);
+	EVENT_CANCEL(backoff->t_timetolearn);
 	timerclear(&backoff->first_event_time);
 	backoff->state = SPF_BACKOFF_QUIET;
 	backoff_debug("SPF Back-off(%s) HOLDDOWN elapsed, move to state %s",
@@ -167,7 +167,7 @@ long spf_backoff_schedule(struct spf_backoff *backoff)
 		break;
 	case SPF_BACKOFF_SHORT_WAIT:
 	case SPF_BACKOFF_LONG_WAIT:
-		THREAD_TIMER_OFF(backoff->t_holddown);
+		EVENT_CANCEL(backoff->t_holddown);
 		thread_add_timer_msec(backoff->m, spf_backoff_holddown_elapsed,
 				      backoff, backoff->holddown,
 				      &backoff->t_holddown);

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -1128,19 +1128,26 @@ void thread_cancel_event(struct thread_master *master, void *arg)
  *
  * @param thread task to cancel
  */
-void thread_cancel(struct thread *thread)
+void thread_cancel(struct thread **thread)
 {
-	struct thread_master *master = thread->master;
+	struct thread_master *master;
+
+	if (thread == NULL || *thread == NULL)
+		return;
+
+	master = (*thread)->master;
 
 	assert(master->owner == pthread_self());
 
 	frr_with_mutex(&master->mtx) {
 		struct cancel_req *cr =
 			XCALLOC(MTYPE_TMP, sizeof(struct cancel_req));
-		cr->thread = thread;
+		cr->thread = *thread;
 		listnode_add(master->cancel_req, cr);
 		do_thread_cancel(master);
 	}
+
+	*thread = NULL;
 }
 
 /**

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -89,8 +89,6 @@ struct thread_master {
 	pthread_t owner;
 };
 
-typedef struct thread_master event_master;
-
 /* Thread itself. */
 struct thread {
 	uint8_t type;		  /* thread type */
@@ -147,10 +145,7 @@ struct cpu_thread_history {
 #define THREAD_FD(X)  ((X)->u.fd)
 #define THREAD_VAL(X) ((X)->u.val)
 
-#define THREAD_OFF(thread) thread_cancel(&(thread))
-#define THREAD_READ_OFF(thread)  thread_cancel(&(thread))
-#define THREAD_WRITE_OFF(thread)  thread_cancel(&(thread))
-#define THREAD_TIMER_OFF(thread)  thread_cancel(&(thread))
+#define EVENT_CANCEL(thread) thread_cancel(&(thread))
 
 #define debugargdef  const char *funcname, const char *schedfrom, int fromln
 

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -89,6 +89,8 @@ struct thread_master {
 	pthread_t owner;
 };
 
+typedef struct thread_master event_master;
+
 /* Thread itself. */
 struct thread {
 	uint8_t type;		  /* thread type */
@@ -145,17 +147,10 @@ struct cpu_thread_history {
 #define THREAD_FD(X)  ((X)->u.fd)
 #define THREAD_VAL(X) ((X)->u.val)
 
-#define THREAD_OFF(thread)                                                     \
-	do {                                                                   \
-		if (thread) {                                                  \
-			thread_cancel(thread);                                 \
-			thread = NULL;                                         \
-		}                                                              \
-	} while (0)
-
-#define THREAD_READ_OFF(thread)  THREAD_OFF(thread)
-#define THREAD_WRITE_OFF(thread)  THREAD_OFF(thread)
-#define THREAD_TIMER_OFF(thread)  THREAD_OFF(thread)
+#define THREAD_OFF(thread) thread_cancel(&(thread))
+#define THREAD_READ_OFF(thread)  thread_cancel(&(thread))
+#define THREAD_WRITE_OFF(thread)  thread_cancel(&(thread))
+#define THREAD_TIMER_OFF(thread)  thread_cancel(&(thread))
 
 #define debugargdef  const char *funcname, const char *schedfrom, int fromln
 
@@ -205,7 +200,7 @@ extern void funcname_thread_execute(struct thread_master *,
 				    debugargdef);
 #undef debugargdef
 
-extern void thread_cancel(struct thread *);
+extern void thread_cancel(struct thread **event);
 extern void thread_cancel_async(struct thread_master *, struct thread **,
 				void *);
 extern void thread_cancel_event(struct thread_master *, void *);

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -1546,7 +1546,7 @@ static int vty_flush(struct thread *thread)
 
 	/* Tempolary disable read thread. */
 	if (vty->lines == 0)
-		THREAD_OFF(vty->t_read);
+		EVENT_CANCEL(vty->t_read);
 
 	/* Function execution continue. */
 	erase = ((vty->status == VTY_MORE || vty->status == VTY_MORELINE));
@@ -1724,9 +1724,9 @@ void vty_stdio_suspend(void)
 	if (!stdio_vty)
 		return;
 
-	THREAD_OFF(stdio_vty->t_write);
-	THREAD_OFF(stdio_vty->t_read);
-	THREAD_OFF(stdio_vty->t_timeout);
+	EVENT_CANCEL(stdio_vty->t_write);
+	EVENT_CANCEL(stdio_vty->t_read);
+	EVENT_CANCEL(stdio_vty->t_timeout);
 
 	if (stdio_termios)
 		tcsetattr(0, TCSANOW, &stdio_orig_termios);
@@ -2201,9 +2201,9 @@ void vty_close(struct vty *vty)
 	vty_config_exit(vty);
 
 	/* Cancel threads.*/
-	THREAD_OFF(vty->t_read);
-	THREAD_OFF(vty->t_write);
-	THREAD_OFF(vty->t_timeout);
+	EVENT_CANCEL(vty->t_read);
+	EVENT_CANCEL(vty->t_write);
+	EVENT_CANCEL(vty->t_timeout);
 
 	/* Flush buffer. */
 	buffer_flush_all(vty->obuf, vty->wfd);
@@ -2688,7 +2688,7 @@ static void vty_event(enum event event, int sock, struct vty *vty)
 
 		/* Time out treatment. */
 		if (vty->v_timeout) {
-			THREAD_OFF(vty->t_timeout);
+			EVENT_CANCEL(vty->t_timeout);
 			thread_add_timer(vty_master, vty_timeout, vty,
 					 vty->v_timeout, &vty->t_timeout);
 		}
@@ -2698,7 +2698,7 @@ static void vty_event(enum event event, int sock, struct vty *vty)
 				 &vty->t_write);
 		break;
 	case VTY_TIMEOUT_RESET:
-		THREAD_OFF(vty->t_timeout);
+		EVENT_CANCEL(vty->t_timeout);
 		if (vty->v_timeout)
 			thread_add_timer(vty_master, vty_timeout, vty,
 					 vty->v_timeout, &vty->t_timeout);
@@ -3043,7 +3043,7 @@ void vty_reset(void)
 	for (i = 0; i < vector_active(Vvty_serv_thread); i++)
 		if ((vty_serv_thread = vector_slot(Vvty_serv_thread, i))
 		    != NULL) {
-			THREAD_OFF(vty_serv_thread);
+			EVENT_CANCEL(vty_serv_thread);
 			vector_slot(Vvty_serv_thread, i) = NULL;
 			close(i);
 		}

--- a/lib/wheel.c
+++ b/lib/wheel.c
@@ -40,7 +40,7 @@ static int wheel_timer_thread_helper(struct thread *t)
 	void *data;
 
 	wheel = THREAD_ARG(t);
-	THREAD_OFF(wheel->timer);
+	EVENT_CANCEL(wheel->timer);
 
 	wheel->curr_slot += wheel->slots_to_skip;
 
@@ -118,7 +118,7 @@ void wheel_delete(struct timer_wheel *wheel)
 		list_delete(&wheel->wheel_slot_lists[i]);
 	}
 
-	THREAD_OFF(wheel->timer);
+	EVENT_CANCEL(wheel->timer);
 	XFREE(MTYPE_TIMER_WHEEL_LIST, wheel->wheel_slot_lists);
 	XFREE(MTYPE_TIMER_WHEEL, wheel->name);
 	XFREE(MTYPE_TIMER_WHEEL, wheel);
@@ -126,7 +126,7 @@ void wheel_delete(struct timer_wheel *wheel)
 
 int wheel_stop(struct timer_wheel *wheel)
 {
-	THREAD_OFF(wheel->timer);
+	EVENT_CANCEL(wheel->timer);
 	return 0;
 }
 

--- a/lib/workqueue.c
+++ b/lib/workqueue.c
@@ -104,7 +104,7 @@ void work_queue_free_and_null(struct work_queue **wqp)
 	struct work_queue *wq = *wqp;
 
 	if (wq->thread != NULL)
-		thread_cancel(wq->thread);
+		thread_cancel(&(wq->thread));
 
 	while (!work_queue_empty(wq)) {
 		struct work_queue_item *item = work_queue_last_item(wq);
@@ -215,7 +215,7 @@ void workqueue_cmd_init(void)
 void work_queue_plug(struct work_queue *wq)
 {
 	if (wq->thread)
-		thread_cancel(wq->thread);
+		thread_cancel(&(wq->thread));
 
 	wq->thread = NULL;
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -167,9 +167,9 @@ void zclient_stop(struct zclient *zclient)
 		zlog_debug("zclient %p stopped", zclient);
 
 	/* Stop threads. */
-	THREAD_OFF(zclient->t_read);
-	THREAD_OFF(zclient->t_connect);
-	THREAD_OFF(zclient->t_write);
+	EVENT_CANCEL(zclient->t_read);
+	EVENT_CANCEL(zclient->t_connect);
+	EVENT_CANCEL(zclient->t_write);
 
 	/* Reset streams. */
 	stream_reset(zclient->ibuf);
@@ -294,7 +294,7 @@ int zclient_send_message(struct zclient *zclient)
 			 __func__, zclient->sock);
 		return zclient_failed(zclient);
 	case BUFFER_EMPTY:
-		THREAD_OFF(zclient->t_write);
+		EVENT_CANCEL(zclient->t_write);
 		break;
 	case BUFFER_PENDING:
 		thread_add_write(zclient->master, zclient_flush_data, zclient,

--- a/nhrpd/netlink_arp.c
+++ b/nhrpd/netlink_arp.c
@@ -257,7 +257,7 @@ static int netlink_log_recv(struct thread *t)
 void netlink_set_nflog_group(int nlgroup)
 {
 	if (netlink_log_fd >= 0) {
-		THREAD_OFF(netlink_log_thread);
+		EVENT_CANCEL(netlink_log_thread);
 		close(netlink_log_fd);
 		netlink_log_fd = -1;
 	}

--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -219,7 +219,7 @@ static void nhrp_cache_peer_notifier(struct notifier_block *n,
 
 static void nhrp_cache_reset_new(struct nhrp_cache *c)
 {
-	THREAD_OFF(c->t_auth);
+	EVENT_CANCEL(c->t_auth);
 	if (list_hashed(&c->newpeer_notifier.notifier_entry))
 		nhrp_peer_notify_del(c->new.peer, &c->newpeer_notifier);
 	nhrp_peer_unref(c->new.peer);
@@ -229,7 +229,7 @@ static void nhrp_cache_reset_new(struct nhrp_cache *c)
 
 static void nhrp_cache_update_timers(struct nhrp_cache *c)
 {
-	THREAD_OFF(c->t_timeout);
+	EVENT_CANCEL(c->t_timeout);
 
 	switch (c->cur.type) {
 	case NHRP_CACHE_INVALID:

--- a/nhrpd/nhrp_event.c
+++ b/nhrpd/nhrp_event.c
@@ -35,8 +35,8 @@ static int evmgr_reconnect(struct thread *t);
 
 static void evmgr_connection_error(struct event_manager *evmgr)
 {
-	THREAD_OFF(evmgr->t_read);
-	THREAD_OFF(evmgr->t_write);
+	EVENT_CANCEL(evmgr->t_read);
+	EVENT_CANCEL(evmgr->t_write);
 	zbuf_reset(&evmgr->ibuf);
 	zbufq_reset(&evmgr->obuf);
 

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -43,7 +43,7 @@ static void nhrp_peer_check_delete(struct nhrp_peer *p)
 	if (p->ref || notifier_active(&p->notifier_list))
 		return;
 
-	THREAD_OFF(p->t_fallback);
+	EVENT_CANCEL(p->t_fallback);
 	hash_release(nifp->peer_hash, p);
 	nhrp_interface_notify_del(p->ifp, &p->ifp_notifier);
 	nhrp_vc_notify_del(p->vc, &p->vc_notifier);
@@ -77,7 +77,7 @@ static void __nhrp_peer_check(struct nhrp_peer *p)
 
 	online = nifp->enabled && (!nifp->ipsec_profile || vc->ipsec);
 	if (p->online != online) {
-		THREAD_OFF(p->t_fallback);
+		EVENT_CANCEL(p->t_fallback);
 		if (online && notifier_active(&p->notifier_list)) {
 			/* If we requested the IPsec connection, delay
 			 * the up notification a bit to allow things

--- a/nhrpd/nhrp_shortcut.c
+++ b/nhrpd/nhrp_shortcut.c
@@ -139,7 +139,7 @@ static void nhrp_shortcut_update_binding(struct nhrp_shortcut *s,
 		s->route_installed = 0;
 	}
 
-	THREAD_OFF(s->t_timer);
+	EVENT_CANCEL(s->t_timer);
 	if (holding_time) {
 		s->expiring = 0;
 		s->holding_time = holding_time;
@@ -154,7 +154,7 @@ static void nhrp_shortcut_delete(struct nhrp_shortcut *s)
 	afi_t afi = family2afi(PREFIX_FAMILY(s->p));
 	char buf[PREFIX_STRLEN];
 
-	THREAD_OFF(s->t_timer);
+	EVENT_CANCEL(s->t_timer);
 	nhrp_reqid_free(&nhrp_packet_reqid, &s->reqid);
 
 	debugf(NHRP_DEBUG_ROUTE, "Shortcut %s purged",
@@ -223,7 +223,7 @@ static void nhrp_shortcut_recv_resolution_rep(struct nhrp_reqid *reqid,
 	int holding_time = pp->if_ad->holdtime;
 
 	nhrp_reqid_free(&nhrp_packet_reqid, &s->reqid);
-	THREAD_OFF(s->t_timer);
+	EVENT_CANCEL(s->t_timer);
 	thread_add_timer(master, nhrp_shortcut_do_purge, s, 1, &s->t_timer);
 
 	if (pp->hdr->type != NHRP_PACKET_RESOLUTION_REPLY) {
@@ -411,7 +411,7 @@ void nhrp_shortcut_initiate(union sockunion *addr)
 	s = nhrp_shortcut_get(&p);
 	if (s && s->type != NHRP_CACHE_INCOMPLETE) {
 		s->addr = *addr;
-		THREAD_OFF(s->t_timer);
+		EVENT_CANCEL(s->t_timer);
 		thread_add_timer(master, nhrp_shortcut_do_purge, s, 30,
 				 &s->t_timer);
 		nhrp_shortcut_send_resolution_req(s);
@@ -456,7 +456,7 @@ struct purge_ctx {
 
 void nhrp_shortcut_purge(struct nhrp_shortcut *s, int force)
 {
-	THREAD_OFF(s->t_timer);
+	EVENT_CANCEL(s->t_timer);
 	nhrp_reqid_free(&nhrp_packet_reqid, &s->reqid);
 
 	if (force) {

--- a/nhrpd/vici.c
+++ b/nhrpd/vici.c
@@ -74,8 +74,8 @@ static void vici_connection_error(struct vici_conn *vici)
 {
 	nhrp_vc_reset();
 
-	THREAD_OFF(vici->t_read);
-	THREAD_OFF(vici->t_write);
+	EVENT_CANCEL(vici->t_read);
+	EVENT_CANCEL(vici->t_write);
 	zbuf_reset(&vici->ibuf);
 	zbufq_reset(&vici->obuf);
 

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -338,8 +338,8 @@ void ospf6_area_disable(struct ospf6_area *oa)
 	ospf6_spf_table_finish(oa->spf_table);
 	ospf6_route_remove_all(oa->route_table);
 
-	THREAD_OFF(oa->thread_router_lsa);
-	THREAD_OFF(oa->thread_intra_prefix_lsa);
+	EVENT_CANCEL(oa->thread_router_lsa);
+	EVENT_CANCEL(oa->thread_intra_prefix_lsa);
 }
 
 

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -242,7 +242,7 @@ static int ospf6_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
 
 		if ((status == BFD_STATUS_DOWN)
 		    && (old_status == BFD_STATUS_UP)) {
-			THREAD_OFF(on->inactivity_timer);
+			EVENT_CANCEL(on->inactivity_timer);
 			thread_add_event(master, inactivity_timer, on, 0, NULL);
 		}
 	}

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -148,8 +148,8 @@ void ospf6_lsa_purge(struct ospf6_lsa *lsa)
 	self = ospf6_lsdb_lookup(lsa->header->type, lsa->header->id,
 				 lsa->header->adv_router, lsdb_self);
 	if (self) {
-		THREAD_OFF(self->expire);
-		THREAD_OFF(self->refresh);
+		EVENT_CANCEL(self->expire);
+		EVENT_CANCEL(self->refresh);
 		ospf6_lsdb_remove(self, lsdb_self);
 	}
 
@@ -219,8 +219,8 @@ void ospf6_install_lsa(struct ospf6_lsa *lsa)
 	old = ospf6_lsdb_lookup(lsa->header->type, lsa->header->id,
 				lsa->header->adv_router, lsa->lsdb);
 	if (old) {
-		THREAD_OFF(old->expire);
-		THREAD_OFF(old->refresh);
+		EVENT_CANCEL(old->expire);
+		EVENT_CANCEL(old->refresh);
 		ospf6_flood_clear(old);
 	}
 
@@ -433,7 +433,7 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 	} else {
 		/* reschedule retransmissions to all neighbors */
 		for (ALL_LIST_ELEMENTS(oi->neighbor_list, node, nnode, on)) {
-			THREAD_OFF(on->thread_send_lsupdate);
+			EVENT_CANCEL(on->thread_send_lsupdate);
 			on->thread_send_lsupdate = NULL;
 			thread_add_event(master, ospf6_lsupdate_send_neighbor,
 					 on, 0, &on->thread_send_lsupdate);

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -243,10 +243,10 @@ void ospf6_interface_delete(struct ospf6_interface *oi)
 
 	list_delete(&oi->neighbor_list);
 
-	THREAD_OFF(oi->thread_send_hello);
-	THREAD_OFF(oi->thread_send_lsupdate);
-	THREAD_OFF(oi->thread_send_lsack);
-	THREAD_OFF(oi->thread_sso);
+	EVENT_CANCEL(oi->thread_send_hello);
+	EVENT_CANCEL(oi->thread_send_lsupdate);
+	EVENT_CANCEL(oi->thread_send_lsack);
+	EVENT_CANCEL(oi->thread_sso);
 
 	ospf6_lsdb_remove_all(oi->lsdb);
 	ospf6_lsdb_remove_all(oi->lsupdate_list);
@@ -292,15 +292,15 @@ void ospf6_interface_disable(struct ospf6_interface *oi)
 	ospf6_lsdb_remove_all(oi->lsupdate_list);
 	ospf6_lsdb_remove_all(oi->lsack_list);
 
-	THREAD_OFF(oi->thread_send_hello);
-	THREAD_OFF(oi->thread_send_lsupdate);
-	THREAD_OFF(oi->thread_send_lsack);
-	THREAD_OFF(oi->thread_sso);
+	EVENT_CANCEL(oi->thread_send_hello);
+	EVENT_CANCEL(oi->thread_send_lsupdate);
+	EVENT_CANCEL(oi->thread_send_lsack);
+	EVENT_CANCEL(oi->thread_sso);
 
-	THREAD_OFF(oi->thread_network_lsa);
-	THREAD_OFF(oi->thread_link_lsa);
-	THREAD_OFF(oi->thread_intra_prefix_lsa);
-	THREAD_OFF(oi->thread_as_extern_lsa);
+	EVENT_CANCEL(oi->thread_network_lsa);
+	EVENT_CANCEL(oi->thread_link_lsa);
+	EVENT_CANCEL(oi->thread_intra_prefix_lsa);
+	EVENT_CANCEL(oi->thread_as_extern_lsa);
 }
 
 static struct in6_addr *
@@ -856,10 +856,10 @@ int interface_down(struct thread *thread)
 			   oi->interface->name);
 
 	/* Stop Hellos */
-	THREAD_OFF(oi->thread_send_hello);
+	EVENT_CANCEL(oi->thread_send_hello);
 
 	/* Stop trying to set socket options. */
-	THREAD_OFF(oi->thread_sso);
+	EVENT_CANCEL(oi->thread_sso);
 
 	/* Leave AllSPFRouters */
 	if (oi->state > OSPF6_INTERFACE_DOWN)
@@ -1240,7 +1240,7 @@ DEFUN (ipv6_ospf6_ifmtu,
 
 	/* re-establish adjacencies */
 	for (ALL_LIST_ELEMENTS(oi->neighbor_list, node, nnode, on)) {
-		THREAD_OFF(on->inactivity_timer);
+		EVENT_CANCEL(on->inactivity_timer);
 		thread_add_event(master, inactivity_timer, on, 0, NULL);
 	}
 
@@ -1286,7 +1286,7 @@ DEFUN (no_ipv6_ospf6_ifmtu,
 
 	/* re-establish adjacencies */
 	for (ALL_LIST_ELEMENTS(oi->neighbor_list, node, nnode, on)) {
-		THREAD_OFF(on->inactivity_timer);
+		EVENT_CANCEL(on->inactivity_timer);
 		thread_add_event(master, inactivity_timer, on, 0, NULL);
 	}
 
@@ -1642,11 +1642,11 @@ DEFUN (ipv6_ospf6_passive,
 	assert(oi);
 
 	SET_FLAG(oi->flag, OSPF6_INTERFACE_PASSIVE);
-	THREAD_OFF(oi->thread_send_hello);
-	THREAD_OFF(oi->thread_sso);
+	EVENT_CANCEL(oi->thread_send_hello);
+	EVENT_CANCEL(oi->thread_sso);
 
 	for (ALL_LIST_ELEMENTS(oi->neighbor_list, node, nnode, on)) {
-		THREAD_OFF(on->inactivity_timer);
+		EVENT_CANCEL(on->inactivity_timer);
 		thread_add_event(master, inactivity_timer, on, 0, NULL);
 	}
 
@@ -1672,8 +1672,8 @@ DEFUN (no_ipv6_ospf6_passive,
 	assert(oi);
 
 	UNSET_FLAG(oi->flag, OSPF6_INTERFACE_PASSIVE);
-	THREAD_OFF(oi->thread_send_hello);
-	THREAD_OFF(oi->thread_sso);
+	EVENT_CANCEL(oi->thread_send_hello);
+	EVENT_CANCEL(oi->thread_sso);
 	thread_add_event(master, ospf6_hello_send, oi, 0,
 			 &oi->thread_send_hello);
 

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -194,13 +194,13 @@ struct ospf6_intra_prefix_lsa {
 
 #define OSPF6_NETWORK_LSA_EXECUTE(oi)                                          \
 	do {                                                                   \
-		THREAD_OFF((oi)->thread_network_lsa);                          \
+		EVENT_CANCEL((oi)->thread_network_lsa);                        \
 		thread_execute(master, ospf6_network_lsa_originate, oi, 0);    \
 	} while (0)
 
 #define OSPF6_INTRA_PREFIX_LSA_EXECUTE_TRANSIT(oi)                             \
 	do {                                                                   \
-		THREAD_OFF((oi)->thread_intra_prefix_lsa);                     \
+		EVENT_CANCEL((oi)->thread_intra_prefix_lsa);                   \
 		thread_execute(master,                                         \
 			       ospf6_intra_prefix_lsa_originate_transit, oi,   \
 			       0);                                             \
@@ -208,7 +208,7 @@ struct ospf6_intra_prefix_lsa {
 
 #define OSPF6_AS_EXTERN_LSA_EXECUTE(oi)                                        \
 	do {                                                                   \
-		THREAD_OFF((oi)->thread_as_extern_lsa);                        \
+		EVENT_CANCEL((oi)->thread_as_extern_lsa);                      \
 		thread_execute(master, ospf6_orig_as_external_lsa, oi, 0);     \
 	} while (0)
 

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -253,8 +253,8 @@ void ospf6_lsa_premature_aging(struct ospf6_lsa *lsa)
 	if (IS_OSPF6_DEBUG_LSA_TYPE(lsa->header->type))
 		zlog_debug("LSA: Premature aging: %s", lsa->name);
 
-	THREAD_OFF(lsa->expire);
-	THREAD_OFF(lsa->refresh);
+	EVENT_CANCEL(lsa->expire);
+	EVENT_CANCEL(lsa->refresh);
 
 	/*
 	 * We clear the LSA from the neighbor retx lists now because it
@@ -571,8 +571,8 @@ void ospf6_lsa_delete(struct ospf6_lsa *lsa)
 	assert(lsa->lock == 0);
 
 	/* cancel threads */
-	THREAD_OFF(lsa->expire);
-	THREAD_OFF(lsa->refresh);
+	EVENT_CANCEL(lsa->expire);
+	EVENT_CANCEL(lsa->refresh);
 
 	/* do free */
 	XFREE(MTYPE_OSPF6_LSA_HEADER, lsa->header);

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -340,7 +340,7 @@ int ospf6_lsdb_maxage_remover(struct ospf6_lsdb *lsdb)
 				htonl(OSPF_MAX_SEQUENCE_NUMBER + 1);
 			ospf6_lsa_checksum(lsa->header);
 
-			THREAD_OFF(lsa->refresh);
+			EVENT_CANCEL(lsa->refresh);
 			thread_execute(master, ospf6_lsa_refresh, lsa, 0);
 		} else {
 			ospf6_lsdb_remove(lsa, lsdb);

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -528,7 +528,7 @@ static void ospf6_dbdesc_recv_master(struct ospf6_header *oh,
 		thread_add_event(master, ospf6_lsreq_send, on, 0,
 				 &on->thread_send_lsreq);
 
-	THREAD_OFF(on->thread_send_dbdesc);
+	EVENT_CANCEL(on->thread_send_dbdesc);
 
 	/* More bit check */
 	if (!CHECK_FLAG(dbdesc->bits, OSPF6_DBDESC_MBIT)
@@ -613,7 +613,7 @@ static void ospf6_dbdesc_recv_slave(struct ospf6_header *oh,
 			if (IS_OSPF6_DEBUG_MESSAGE(oh->type, RECV))
 				zlog_debug(
 					"Duplicated dbdesc causes retransmit");
-			THREAD_OFF(on->thread_send_dbdesc);
+			EVENT_CANCEL(on->thread_send_dbdesc);
 			on->thread_send_dbdesc = NULL;
 			thread_add_event(master, ospf6_dbdesc_send, on, 0,
 					 &on->thread_send_dbdesc);
@@ -664,7 +664,7 @@ static void ospf6_dbdesc_recv_slave(struct ospf6_header *oh,
 			if (IS_OSPF6_DEBUG_MESSAGE(oh->type, RECV))
 				zlog_debug(
 					"Duplicated dbdesc causes retransmit");
-			THREAD_OFF(on->thread_send_dbdesc);
+			EVENT_CANCEL(on->thread_send_dbdesc);
 			thread_add_event(master, ospf6_dbdesc_send, on, 0,
 					 &on->thread_send_dbdesc);
 			return;
@@ -738,7 +738,7 @@ static void ospf6_dbdesc_recv_slave(struct ospf6_header *oh,
 		thread_add_event(master, ospf6_lsreq_send, on, 0,
 				 &on->thread_send_lsreq);
 
-	THREAD_OFF(on->thread_send_dbdesc);
+	EVENT_CANCEL(on->thread_send_dbdesc);
 	thread_add_event(master, ospf6_dbdesc_send_newone, on, 0,
 			 &on->thread_send_dbdesc);
 
@@ -864,7 +864,7 @@ static void ospf6_lsreq_recv(struct in6_addr *src, struct in6_addr *dst,
 	assert(p == OSPF6_MESSAGE_END(oh));
 
 	/* schedule send lsupdate */
-	THREAD_OFF(on->thread_send_lsupdate);
+	EVENT_CANCEL(on->thread_send_lsupdate);
 	thread_add_event(master, ospf6_lsupdate_send_neighbor, on, 0,
 			 &on->thread_send_lsupdate);
 }
@@ -2388,7 +2388,7 @@ int ospf6_lsack_send_interface(struct thread *thread)
 		    > ospf6_packet_max(oi)) {
 			/* if we run out of packet size/space here,
 			   better to try again soon. */
-			THREAD_OFF(oi->thread_send_lsack);
+			EVENT_CANCEL(oi->thread_send_lsack);
 			thread_add_event(master, ospf6_lsack_send_interface, oi,
 					 0, &oi->thread_send_lsack);
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -238,10 +238,10 @@ static void ospf6_disable(struct ospf6 *o)
 		ospf6_route_remove_all(o->route_table);
 		ospf6_route_remove_all(o->brouter_table);
 
-		THREAD_OFF(o->maxage_remover);
-		THREAD_OFF(o->t_spf_calc);
-		THREAD_OFF(o->t_ase_calc);
-		THREAD_OFF(o->t_distribute_update);
+		EVENT_CANCEL(o->maxage_remover);
+		EVENT_CANCEL(o->t_spf_calc);
+		EVENT_CANCEL(o->t_ase_calc);
+		EVENT_CANCEL(o->t_distribute_update);
 	}
 }
 

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -317,21 +317,12 @@ void ospf_apiserver_free(struct ospf_apiserver *apiserv)
 	struct listnode *node;
 
 	/* Cancel read and write threads. */
-	if (apiserv->t_sync_read) {
-		thread_cancel(apiserv->t_sync_read);
-	}
+	thread_cancel(&apiserv->t_sync_read);
 #ifdef USE_ASYNC_READ
-	if (apiserv->t_async_read) {
-		thread_cancel(apiserv->t_async_read);
-	}
+	thread_cancel(&apiserv->t_async_read);
 #endif /* USE_ASYNC_READ */
-	if (apiserv->t_sync_write) {
-		thread_cancel(apiserv->t_sync_write);
-	}
-
-	if (apiserv->t_async_write) {
-		thread_cancel(apiserv->t_async_write);
-	}
+	thread_cancel(&apiserv->t_sync_write);
+	thread_cancel(&apiserv->t_async_write);
 
 	/* Unregister all opaque types that application registered
 	   and flush opaque LSAs if still in LSDB. */

--- a/ospfd/ospf_ism.h
+++ b/ospfd/ospf_ism.h
@@ -79,7 +79,7 @@
 	} while (0)
 
 /* Macro for OSPF ISM timer turn off. */
-#define OSPF_ISM_TIMER_OFF(X) thread_cancel(&(X));
+#define OSPF_ISM_TIMER_OFF(X) thread_cancel(&(X))
 
 /* Macro for OSPF schedule event. */
 #define OSPF_ISM_EVENT_SCHEDULE(I, E)                                          \

--- a/ospfd/ospf_ism.h
+++ b/ospfd/ospf_ism.h
@@ -79,13 +79,7 @@
 	} while (0)
 
 /* Macro for OSPF ISM timer turn off. */
-#define OSPF_ISM_TIMER_OFF(X)                                                  \
-	do {                                                                   \
-		if (X) {                                                       \
-			thread_cancel(X);                                      \
-			(X) = NULL;                                            \
-		}                                                              \
-	} while (0)
+#define OSPF_ISM_TIMER_OFF(X) thread_cancel(&(X));
 
 /* Macro for OSPF schedule event. */
 #define OSPF_ISM_EVENT_SCHEDULE(I, E)                                          \

--- a/ospfd/ospf_nsm.h
+++ b/ospfd/ospf_nsm.h
@@ -59,13 +59,7 @@
 #define OSPF_NSM_TIMER_ON(T,F,V) thread_add_timer (master, (F), nbr, (V), &(T))
 
 /* Macro for OSPF NSM timer turn off. */
-#define OSPF_NSM_TIMER_OFF(X)                                                  \
-	do {                                                                   \
-		if (X) {                                                       \
-			thread_cancel(X);                                      \
-			(X) = NULL;                                            \
-		}                                                              \
-	} while (0)
+#define OSPF_NSM_TIMER_OFF(X) thread_cancel(&(X))
 
 /* Macro for OSPF NSM schedule event. */
 #define OSPF_NSM_EVENT_SCHEDULE(N, E)                                          \

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -466,11 +466,7 @@ static int ospf_ls_req_timer(struct thread *thread)
 
 void ospf_ls_req_event(struct ospf_neighbor *nbr)
 {
-	if (nbr->t_ls_req) {
-		thread_cancel(nbr->t_ls_req);
-		nbr->t_ls_req = NULL;
-	}
-	nbr->t_ls_req = NULL;
+	thread_cancel(&nbr->t_ls_req);
 	thread_add_event(master, ospf_ls_req_timer, nbr, 0, &nbr->t_ls_req);
 }
 

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1307,10 +1307,7 @@ void ospf_ls_upd_queue_empty(struct ospf_interface *oi)
 		}
 
 	/* remove update event */
-	if (oi->t_ls_upd_event) {
-		thread_cancel(oi->t_ls_upd_event);
-		oi->t_ls_upd_event = NULL;
-	}
+	thread_cancel(&oi->t_ls_upd_event);
 }
 
 void ospf_if_update(struct ospf *ospf, struct interface *ifp)
@@ -2141,7 +2138,7 @@ static int ospf_vrf_disable(struct vrf *vrf)
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug("%s: ospf old_vrf_id %d unlinked", __func__,
 				   old_vrf_id);
-		thread_cancel(ospf->t_read);
+		thread_cancel(&ospf->t_read);
 		close(ospf->fd);
 		ospf->fd = -1;
 	}

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -487,13 +487,7 @@ struct ospf_nbr_nbma {
 #define OSPF_AREA_TIMER_ON(T,F,V) thread_add_timer (master, (F), area, (V), &(T))
 #define OSPF_POLL_TIMER_ON(T,F,V) thread_add_timer (master, (F), nbr_nbma, (V), &(T))
 #define OSPF_POLL_TIMER_OFF(X) OSPF_TIMER_OFF((X))
-#define OSPF_TIMER_OFF(X)                                                      \
-	do {                                                                   \
-		if (X) {                                                       \
-			thread_cancel(X);                                      \
-			(X) = NULL;                                            \
-		}                                                              \
-	} while (0)
+#define OSPF_TIMER_OFF(X) thread_cancel(&(X))
 
 /* Extern variables. */
 extern struct ospf_master *om;

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -547,7 +547,7 @@ static void assert_timer_off(struct pim_ifchannel *ch)
 				__func__, ch->sg_str, ch->interface->name);
 		}
 	}
-	THREAD_OFF(ch->t_ifassert_timer);
+	EVENT_CANCEL(ch->t_ifassert_timer);
 }
 
 static void pim_assert_timer_set(struct pim_ifchannel *ch, int interval)

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -118,7 +118,7 @@ static int pim_g2rp_list_compare(struct bsm_rpinfo *node1,
 static void pim_free_bsrp_node(struct bsm_rpinfo *bsrp_info)
 {
 	if (bsrp_info->g2rp_timer)
-		THREAD_OFF(bsrp_info->g2rp_timer);
+		EVENT_CANCEL(bsrp_info->g2rp_timer);
 	XFREE(MTYPE_PIM_BSRP_NODE, bsrp_info);
 }
 
@@ -175,7 +175,7 @@ static int pim_on_bs_timer(struct thread *t)
 	bool is_bsr_tracking = true;
 
 	scope = THREAD_ARG(t);
-	THREAD_OFF(scope->bs_timer);
+	EVENT_CANCEL(scope->bs_timer);
 
 	if (PIM_DEBUG_BSM)
 		zlog_debug("%s: Bootstrap Timer expired for scope: %d",
@@ -231,7 +231,7 @@ static void pim_bs_timer_stop(struct bsm_scope *scope)
 	if (PIM_DEBUG_BSM)
 		zlog_debug("%s : BS timer being stopped of sz: %d", __func__,
 			   scope->sz_id);
-	THREAD_OFF(scope->bs_timer);
+	EVENT_CANCEL(scope->bs_timer);
 }
 
 static void pim_bs_timer_start(struct bsm_scope *scope, int bs_timeout)
@@ -241,7 +241,7 @@ static void pim_bs_timer_start(struct bsm_scope *scope, int bs_timeout)
 			zlog_debug("%s : Invalid scope(NULL).", __func__);
 		return;
 	}
-	THREAD_OFF(scope->bs_timer);
+	EVENT_CANCEL(scope->bs_timer);
 	if (PIM_DEBUG_BSM)
 		zlog_debug(
 			"%s : starting bs timer for scope %d with timeout %d secs",
@@ -315,7 +315,7 @@ static int pim_on_g2rp_timer(struct thread *t)
 	struct in_addr bsrp_addr;
 
 	bsrp = THREAD_ARG(t);
-	THREAD_OFF(bsrp->g2rp_timer);
+	EVENT_CANCEL(bsrp->g2rp_timer);
 	bsgrp_node = bsrp->bsgrp_node;
 
 	/* elapse time is the hold time of expired node */
@@ -377,7 +377,7 @@ static void pim_g2rp_timer_start(struct bsm_rpinfo *bsrp, int hold_time)
 			zlog_debug("%s : Invalid brsp(NULL).", __func__);
 		return;
 	}
-	THREAD_OFF(bsrp->g2rp_timer);
+	EVENT_CANCEL(bsrp->g2rp_timer);
 	if (PIM_DEBUG_BSM) {
 		char buf[48];
 
@@ -412,7 +412,7 @@ static void pim_g2rp_timer_stop(struct bsm_rpinfo *bsrp)
 			   inet_ntoa(bsrp->rp_address));
 	}
 
-	THREAD_OFF(bsrp->g2rp_timer);
+	EVENT_CANCEL(bsrp->g2rp_timer);
 }
 
 static bool is_hold_time_zero(void *data)

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -205,7 +205,7 @@ void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp)
 				"Querier %s resetting TIMER event for Other-Querier-Present",
 				ifaddr_str);
 		}
-		THREAD_OFF(igmp->t_other_querier_timer);
+		EVENT_CANCEL(igmp->t_other_querier_timer);
 	} else {
 		/*
 		  We are the current querier, then stop sending general queries:
@@ -267,7 +267,7 @@ void pim_igmp_other_querier_timer_off(struct igmp_sock *igmp)
 				ifaddr_str, igmp->fd, igmp->interface->name);
 		}
 	}
-	THREAD_OFF(igmp->t_other_querier_timer);
+	EVENT_CANCEL(igmp->t_other_querier_timer);
 }
 
 static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
@@ -631,7 +631,7 @@ void pim_igmp_general_query_off(struct igmp_sock *igmp)
 				ifaddr_str, igmp->fd, igmp->interface->name);
 		}
 	}
-	THREAD_OFF(igmp->t_igmp_query_timer);
+	EVENT_CANCEL(igmp->t_igmp_query_timer);
 }
 
 /* Issue IGMP general query */
@@ -706,7 +706,7 @@ static void sock_close(struct igmp_sock *igmp)
 				igmp->interface->name);
 		}
 	}
-	THREAD_OFF(igmp->t_igmp_read);
+	EVENT_CANCEL(igmp->t_igmp_read);
 
 	if (close(igmp->fd)) {
 		flog_err(
@@ -805,7 +805,7 @@ void igmp_group_delete(struct igmp_group *group)
 	}
 
 	if (group->t_group_query_retransmit_timer) {
-		THREAD_OFF(group->t_group_query_retransmit_timer);
+		EVENT_CANCEL(group->t_group_query_retransmit_timer);
 	}
 
 	group_timer_off(group);
@@ -1083,7 +1083,7 @@ static void group_timer_off(struct igmp_group *group)
 		zlog_debug("Cancelling TIMER event for group %s on %s",
 			   group_str, group->group_igmp_sock->interface->name);
 	}
-	THREAD_OFF(group->t_group_timer);
+	EVENT_CANCEL(group->t_group_timer);
 }
 
 void igmp_group_timer_on(struct igmp_group *group, long interval_msec,

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -192,7 +192,7 @@ static void source_timer_off(struct igmp_group *group,
 			group->group_igmp_sock->interface->name);
 	}
 
-	THREAD_OFF(source->t_source_timer);
+	EVENT_CANCEL(source->t_source_timer);
 }
 
 static void igmp_source_timer_on(struct igmp_group *group,

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -742,7 +742,7 @@ static void mroute_read_on(struct pim_instance *pim)
 
 static void mroute_read_off(struct pim_instance *pim)
 {
-	THREAD_OFF(pim->thread);
+	EVENT_CANCEL(pim->thread);
 }
 
 int pim_mroute_socket_enable(struct pim_instance *pim)

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -83,7 +83,7 @@ static int pim_msdp_sa_adv_timer_cb(struct thread *t)
 }
 static void pim_msdp_sa_adv_timer_setup(struct pim_instance *pim, bool start)
 {
-	THREAD_OFF(pim->msdp.sa_adv_timer);
+	EVENT_CANCEL(pim->msdp.sa_adv_timer);
 	if (start) {
 		thread_add_timer(pim->msdp.master, pim_msdp_sa_adv_timer_cb,
 				 pim, PIM_MSDP_SA_ADVERTISMENT_TIME,
@@ -107,7 +107,7 @@ static int pim_msdp_sa_state_timer_cb(struct thread *t)
 }
 static void pim_msdp_sa_state_timer_setup(struct pim_msdp_sa *sa, bool start)
 {
-	THREAD_OFF(sa->sa_state_timer);
+	EVENT_CANCEL(sa->sa_state_timer);
 	if (start) {
 		thread_add_timer(sa->pim->msdp.master,
 				 pim_msdp_sa_state_timer_cb, sa,
@@ -927,7 +927,7 @@ static int pim_msdp_peer_hold_timer_cb(struct thread *t)
 static void pim_msdp_peer_hold_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
 	struct pim_instance *pim = mp->pim;
-	THREAD_OFF(mp->hold_timer);
+	EVENT_CANCEL(mp->hold_timer);
 	if (start) {
 		thread_add_timer(pim->msdp.master, pim_msdp_peer_hold_timer_cb,
 				 mp, PIM_MSDP_PEER_HOLD_TIME, &mp->hold_timer);
@@ -952,7 +952,7 @@ static int pim_msdp_peer_ka_timer_cb(struct thread *t)
 }
 static void pim_msdp_peer_ka_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
-	THREAD_OFF(mp->ka_timer);
+	EVENT_CANCEL(mp->ka_timer);
 	if (start) {
 		thread_add_timer(mp->pim->msdp.master,
 				 pim_msdp_peer_ka_timer_cb, mp,
@@ -1016,7 +1016,7 @@ static int pim_msdp_peer_cr_timer_cb(struct thread *t)
 }
 static void pim_msdp_peer_cr_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
-	THREAD_OFF(mp->cr_timer);
+	EVENT_CANCEL(mp->cr_timer);
 	if (start) {
 		thread_add_timer(
 			mp->pim->msdp.master, pim_msdp_peer_cr_timer_cb, mp,

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -208,8 +208,8 @@ struct pim_msdp {
 	thread_add_write(mp->pim->msdp.master, pim_msdp_write, mp, mp->fd,     \
 			 &mp->t_write)
 
-#define PIM_MSDP_PEER_READ_OFF(mp) THREAD_READ_OFF(mp->t_read)
-#define PIM_MSDP_PEER_WRITE_OFF(mp) THREAD_WRITE_OFF(mp->t_write)
+#define PIM_MSDP_PEER_READ_OFF(mp) EVENT_CANCEL(mp->t_read)
+#define PIM_MSDP_PEER_WRITE_OFF(mp) EVENT_CANCEL(mp->t_write)
 
 // struct pim_msdp *msdp;
 struct pim_instance;

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -246,7 +246,7 @@ void pim_neighbor_timer_reset(struct pim_neighbor *neigh, uint16_t holdtime)
 {
 	neigh->holdtime = holdtime;
 
-	THREAD_OFF(neigh->t_expire_timer);
+	EVENT_CANCEL(neigh->t_expire_timer);
 
 	/*
 	  0xFFFF is request for no holdtime
@@ -294,7 +294,7 @@ static int on_neighbor_jp_timer(struct thread *t)
 
 static void pim_neighbor_start_jp_timer(struct pim_neighbor *neigh)
 {
-	THREAD_TIMER_OFF(neigh->jp_timer);
+	EVENT_CANCEL(neigh->jp_timer);
 	thread_add_timer(router->master, on_neighbor_jp_timer, neigh,
 			 router->t_periodic, &neigh->jp_timer);
 }
@@ -417,7 +417,7 @@ void pim_neighbor_free(struct pim_neighbor *neigh)
 	delete_prefix_list(neigh);
 
 	list_delete(&neigh->upstream_jp_agg);
-	THREAD_OFF(neigh->jp_timer);
+	EVENT_CANCEL(neigh->jp_timer);
 
 	if (neigh->bfd_info)
 		pim_bfd_info_free(&neigh->bfd_info);
@@ -620,7 +620,7 @@ void pim_neighbor_delete(struct interface *ifp, struct pim_neighbor *neigh,
 	zlog_info("PIM NEIGHBOR DOWN: neighbor %s on interface %s: %s", src_str,
 		  ifp->name, delete_message);
 
-	THREAD_OFF(neigh->t_expire_timer);
+	EVENT_CANCEL(neigh->t_expire_timer);
 
 	pim_if_assert_on_neighbor_down(ifp, neigh->source_addr);
 

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -81,7 +81,7 @@ static void sock_close(struct interface *ifp)
 				pim_ifp->pim_sock_fd, ifp->name);
 		}
 	}
-	THREAD_OFF(pim_ifp->t_pim_sock_read);
+	EVENT_CANCEL(pim_ifp->t_pim_sock_read);
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		if (pim_ifp->t_pim_hello_timer) {
@@ -90,7 +90,7 @@ static void sock_close(struct interface *ifp)
 				ifp->name);
 		}
 	}
-	THREAD_OFF(pim_ifp->t_pim_hello_timer);
+	EVENT_CANCEL(pim_ifp->t_pim_hello_timer);
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		zlog_debug("Deleting PIM socket fd=%d on interface %s",
@@ -722,7 +722,7 @@ static void hello_resched(struct interface *ifp)
 		zlog_debug("Rescheduling %d sec hello on interface %s",
 			   pim_ifp->pim_hello_period, ifp->name);
 	}
-	THREAD_OFF(pim_ifp->t_pim_hello_timer);
+	EVENT_CANCEL(pim_ifp->t_pim_hello_timer);
 	thread_add_timer(router->master, on_pim_hello_send, ifp,
 			 pim_ifp->pim_hello_period,
 			 &pim_ifp->t_pim_hello_timer);
@@ -825,7 +825,7 @@ void pim_hello_restart_triggered(struct interface *ifp)
 			return;
 		}
 
-		THREAD_OFF(pim_ifp->t_pim_hello_timer);
+		EVENT_CANCEL(pim_ifp->t_pim_hello_timer);
 	}
 
 	random_msec = triggered_hello_delay_msec;

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -544,7 +544,7 @@ void pim_reg_del_on_couldreg_fail(struct interface *ifp)
 		    && (up->reg_state != PIM_REG_NOINFO)) {
 			pim_channel_del_oif(up->channel_oil, pim->regiface,
 					    PIM_OIF_FLAG_PROTO_PIM, __func__);
-			THREAD_OFF(up->t_rs_timer);
+			EVENT_CANCEL(up->t_rs_timer);
 			up->reg_state = PIM_REG_NOINFO;
 		}
 	}

--- a/pimd/pim_ssmpingd.c
+++ b/pimd/pim_ssmpingd.c
@@ -199,7 +199,7 @@ static void ssmpingd_delete(struct ssmpingd_sock *ss)
 {
 	zassert(ss);
 
-	THREAD_OFF(ss->t_sock_read);
+	EVENT_CANCEL(ss->t_sock_read);
 
 	if (close(ss->sock_fd)) {
 		char source_str[INET_ADDRSTRLEN];

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -194,7 +194,7 @@ static int pim_vxlan_work_timer_cb(struct thread *t)
 /* global 1second timer used for periodic processing */
 static void pim_vxlan_work_timer_setup(bool start)
 {
-	THREAD_OFF(vxlan_info.work_timer);
+	EVENT_CANCEL(vxlan_info.work_timer);
 	if (start)
 		thread_add_timer(router->master, pim_vxlan_work_timer_cb, NULL,
 			PIM_VXLAN_WORK_TIME, &vxlan_info.work_timer);
@@ -241,7 +241,7 @@ static void pim_vxlan_orig_mr_up_del(struct pim_vxlan_sg *vxlan_sg)
 		 * if there are no other references.
 		 */
 		if (PIM_UPSTREAM_FLAG_TEST_SRC_STREAM(up->flags)) {
-			THREAD_OFF(up->t_ka_timer);
+			EVENT_CANCEL(up->t_ka_timer);
 			up = pim_upstream_keep_alive_timer_proc(up);
 		} else {
 			/* this is really unexpected as we force vxlan

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -125,7 +125,7 @@ static void zclient_lookup_failed(struct zclient *zlookup)
 
 void zclient_lookup_free(void)
 {
-	THREAD_OFF(zlookup_read);
+	EVENT_CANCEL(zlookup_read);
 	zclient_stop(zlookup);
 	zclient_free(zlookup);
 	zlookup = NULL;

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -467,10 +467,7 @@ static void rip_interface_clean(struct rip_interface *ri)
 	ri->enable_interface = 0;
 	ri->running = 0;
 
-	if (ri->t_wakeup) {
-		thread_cancel(ri->t_wakeup);
-		ri->t_wakeup = NULL;
-	}
+	thread_cancel(&ri->t_wakeup);
 }
 
 void rip_interfaces_clean(struct rip *rip)

--- a/ripd/rip_peer.c
+++ b/ripd/rip_peer.c
@@ -86,8 +86,7 @@ static struct rip_peer *rip_peer_get(struct rip *rip, struct in_addr *addr)
 	peer = rip_peer_lookup(rip, addr);
 
 	if (peer) {
-		if (peer->t_timeout)
-			thread_cancel(peer->t_timeout);
+		thread_cancel(&peer->t_timeout);
 	} else {
 		peer = rip_peer_new();
 		peer->rip = rip;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3610,7 +3610,7 @@ static void rip_instance_disable(struct rip *rip)
 	RIP_TIMER_OFF(rip->t_triggered_interval);
 
 	/* Cancel read thread. */
-	THREAD_READ_OFF(rip->t_read);
+	EVENT_CANCEL(rip->t_read);
 
 	/* Close RIP socket. */
 	close(rip->sock);

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -405,7 +405,7 @@ enum rip_event {
 #define RIP_TIMER_ON(T,F,V) thread_add_timer (master, (F), rinfo, (V), &(T))
 
 /* Macro for timer turn off. */
-#define RIP_TIMER_OFF(X) THREAD_TIMER_OFF(X)
+#define RIP_TIMER_OFF(X) EVENT_CANCEL((X))
 
 #define RIP_OFFSET_LIST_IN  0
 #define RIP_OFFSET_LIST_OUT 1

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -320,10 +320,7 @@ void ripng_interface_clean(struct ripng *ripng)
 		ri->enable_interface = 0;
 		ri->running = 0;
 
-		if (ri->t_wakeup) {
-			thread_cancel(ri->t_wakeup);
-			ri->t_wakeup = NULL;
-		}
+		thread_cancel(&ri->t_wakeup);
 	}
 }
 

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -95,8 +95,7 @@ static struct ripng_peer *ripng_peer_get(struct ripng *ripng,
 	peer = ripng_peer_lookup(ripng, addr);
 
 	if (peer) {
-		if (peer->t_timeout)
-			thread_cancel(peer->t_timeout);
+		thread_cancel(&peer->t_timeout);
 	} else {
 		peer = ripng_peer_new();
 		peer->ripng = ripng;
@@ -105,7 +104,6 @@ static struct ripng_peer *ripng_peer_get(struct ripng *ripng,
 	}
 
 	/* Update timeout thread. */
-	peer->t_timeout = NULL;
 	thread_add_timer(master, ripng_peer_timeout, peer,
 			 RIPNG_PEER_TIMER_DEFAULT, &peer->t_timeout);
 

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -1471,10 +1471,7 @@ static int ripng_update(struct thread *t)
 
 	/* Triggered updates may be suppressed if a regular update is due by
 	   the time the triggered update would be sent. */
-	if (ripng->t_triggered_interval) {
-		thread_cancel(ripng->t_triggered_interval);
-		ripng->t_triggered_interval = NULL;
-	}
+	thread_cancel(&ripng->t_triggered_interval);
 	ripng->trigger = 0;
 
 	/* Reset flush event. */
@@ -1508,10 +1505,7 @@ int ripng_triggered_update(struct thread *t)
 	ripng->t_triggered_update = NULL;
 
 	/* Cancel interval timer. */
-	if (ripng->t_triggered_interval) {
-		thread_cancel(ripng->t_triggered_interval);
-		ripng->t_triggered_interval = NULL;
-	}
+	thread_cancel(&ripng->t_triggered_interval);
 	ripng->trigger = 0;
 
 	/* Logging triggered update. */
@@ -1963,10 +1957,8 @@ void ripng_event(struct ripng *ripng, enum ripng_event event, int sock)
 				&ripng->t_read);
 		break;
 	case RIPNG_UPDATE_EVENT:
-		if (ripng->t_update) {
-			thread_cancel(ripng->t_update);
-			ripng->t_update = NULL;
-		}
+		thread_cancel(&ripng->t_update);
+
 		/* Update timer jitter. */
 		jitter = ripng_update_jitter(ripng->update_time);
 
@@ -2729,10 +2721,7 @@ static void ripng_instance_disable(struct ripng *ripng)
 	RIPNG_TIMER_OFF(ripng->t_triggered_interval);
 
 	/* Cancel the read thread */
-	if (ripng->t_read) {
-		thread_cancel(ripng->t_read);
-		ripng->t_read = NULL;
-	}
+	thread_cancel(&ripng->t_read);
 
 	/* Close the RIPng socket */
 	if (ripng->sock >= 0) {

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -351,7 +351,7 @@ enum ripng_event {
 /* RIPng timer on/off macro. */
 #define RIPNG_TIMER_ON(T,F,V) thread_add_timer (master, (F), rinfo, (V), &(T))
 
-#define RIPNG_TIMER_OFF(T)  thread_cancel(&(T));
+#define RIPNG_TIMER_OFF(T)  thread_cancel(&(T))
 
 #define RIPNG_OFFSET_LIST_IN  0
 #define RIPNG_OFFSET_LIST_OUT 1

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -351,13 +351,7 @@ enum ripng_event {
 /* RIPng timer on/off macro. */
 #define RIPNG_TIMER_ON(T,F,V) thread_add_timer (master, (F), rinfo, (V), &(T))
 
-#define RIPNG_TIMER_OFF(T)                                                     \
-	do {                                                                   \
-		if (T) {                                                       \
-			thread_cancel(T);                                      \
-			(T) = NULL;                                            \
-		}                                                              \
-	} while (0)
+#define RIPNG_TIMER_OFF(T)  thread_cancel(&(T));
 
 #define RIPNG_OFFSET_LIST_IN  0
 #define RIPNG_OFFSET_LIST_OUT 1

--- a/tests/lib/test_timer_correctness.c
+++ b/tests/lib/test_timer_correctness.c
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
 			continue;
 
 		XFREE(MTYPE_TMP, timers[index]->arg);
-		thread_cancel(timers[index]);
+		thread_cancel(&timers[index]);
 		timers[index] = NULL;
 		timers_pending--;
 	}

--- a/tests/lib/test_timer_performance.c
+++ b/tests/lib/test_timer_performance.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
 		thread_add_timer_msec(master, dummy_func, NULL, 0, &timers[i]);
 	}
 	for (i = 0; i < SCHEDULE_TIMERS; i++)
-		thread_cancel(timers[i]);
+		thread_cancel(&timers[i]);
 
 	monotime(&tv_start);
 
@@ -78,8 +78,7 @@ int main(int argc, char **argv)
 		int index;
 
 		index = prng_rand(prng) % SCHEDULE_TIMERS;
-		if (timers[index])
-			thread_cancel(timers[index]);
+		thread_cancel(&timers[index]);
 		timers[index] = NULL;
 	}
 

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -913,7 +913,7 @@ static int vrrp_recv_advertisement(struct vrrp_router *r, struct ipaddr *src,
 
 		if (pkt->hdr.priority == 0) {
 			vrrp_send_advertisement(r);
-			THREAD_OFF(r->t_adver_timer);
+			EVENT_CANCEL(r->t_adver_timer);
 			thread_add_timer_msec(
 				master, vrrp_adver_timer_expire, r,
 				r->vr->advertisement_interval * CS2MS,
@@ -926,13 +926,13 @@ static int vrrp_recv_advertisement(struct vrrp_router *r, struct ipaddr *src,
 				"Received advertisement from %s w/ priority %hhu; switching to Backup",
 				r->vr->vrid, family2str(r->family), sipstr,
 				pkt->hdr.priority);
-			THREAD_OFF(r->t_adver_timer);
+			EVENT_CANCEL(r->t_adver_timer);
 			if (r->vr->version == 3) {
 				r->master_adver_interval =
 					htons(pkt->hdr.v3.adver_int);
 			}
 			vrrp_recalculate_timers(r);
-			THREAD_OFF(r->t_master_down_timer);
+			EVENT_CANCEL(r->t_master_down_timer);
 			thread_add_timer_msec(master,
 					      vrrp_master_down_timer_expire, r,
 					      r->master_down_interval * CS2MS,
@@ -949,7 +949,7 @@ static int vrrp_recv_advertisement(struct vrrp_router *r, struct ipaddr *src,
 		break;
 	case VRRP_STATE_BACKUP:
 		if (pkt->hdr.priority == 0) {
-			THREAD_OFF(r->t_master_down_timer);
+			EVENT_CANCEL(r->t_master_down_timer);
 			thread_add_timer_msec(
 				master, vrrp_master_down_timer_expire, r,
 				r->skew_time * CS2MS, &r->t_master_down_timer);
@@ -960,7 +960,7 @@ static int vrrp_recv_advertisement(struct vrrp_router *r, struct ipaddr *src,
 					ntohs(pkt->hdr.v3.adver_int);
 			}
 			vrrp_recalculate_timers(r);
-			THREAD_OFF(r->t_master_down_timer);
+			EVENT_CANCEL(r->t_master_down_timer);
 			thread_add_timer_msec(master,
 					      vrrp_master_down_timer_expire, r,
 					      r->master_down_interval * CS2MS,
@@ -1418,7 +1418,7 @@ static void vrrp_change_state_backup(struct vrrp_router *r)
 		vrrp_zebra_radv_set(r, false);
 
 	/* Disable Adver_Timer */
-	THREAD_OFF(r->t_adver_timer);
+	EVENT_CANCEL(r->t_adver_timer);
 
 	r->advert_pending = false;
 	r->garp_pending = false;
@@ -1649,10 +1649,10 @@ static int vrrp_shutdown(struct vrrp_router *r)
 	}
 
 	/* Cancel all timers */
-	THREAD_OFF(r->t_adver_timer);
-	THREAD_OFF(r->t_master_down_timer);
-	THREAD_OFF(r->t_read);
-	THREAD_OFF(r->t_write);
+	EVENT_CANCEL(r->t_adver_timer);
+	EVENT_CANCEL(r->t_master_down_timer);
+	EVENT_CANCEL(r->t_read);
+	EVENT_CANCEL(r->t_write);
 
 	/* Protodown macvlan */
 	if (r->mvl_ifp)

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -399,8 +399,8 @@ static void sigchild(void)
 		what = restart->what;
 		restart->pid = 0;
 		gs.numpids--;
-		thread_cancel(restart->t_kill);
-		restart->t_kill = NULL;
+		thread_cancel(&restart->t_kill);
+
 		/* Update restart time to reflect the time the command
 		 * completed. */
 		gettimeofday(&restart->time, NULL);
@@ -669,8 +669,7 @@ static int handle_read(struct thread *t_read)
 			   dmn->name, (long)delay.tv_sec, (long)delay.tv_usec);
 
 	SET_READ_HANDLER(dmn);
-	if (dmn->t_wakeup)
-		thread_cancel(dmn->t_wakeup);
+	thread_cancel(&dmn->t_wakeup);
 	SET_WAKEUP_ECHO(dmn);
 
 	return 0;
@@ -857,9 +856,8 @@ static int phase_hanging(struct thread *t_hanging)
 static void set_phase(restart_phase_t new_phase)
 {
 	gs.phase = new_phase;
-	if (gs.t_phase_hanging)
-		thread_cancel(gs.t_phase_hanging);
-	gs.t_phase_hanging = NULL;
+	thread_cancel(&gs.t_phase_hanging);
+
 	thread_add_timer(master, phase_hanging, NULL, PHASE_TIMEOUT,
 			 &gs.t_phase_hanging);
 }

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -576,7 +576,7 @@ static void restart_done(struct daemon *dmn)
 		return;
 	}
 	if (dmn->t_wakeup)
-		THREAD_OFF(dmn->t_wakeup);
+		EVENT_CANCEL(dmn->t_wakeup);
 	if (try_connect(dmn) < 0)
 		SET_WAKEUP_DOWN(dmn);
 }
@@ -595,9 +595,9 @@ static void daemon_down(struct daemon *dmn, const char *why)
 		close(dmn->fd);
 		dmn->fd = -1;
 	}
-	THREAD_OFF(dmn->t_read);
-	THREAD_OFF(dmn->t_write);
-	THREAD_OFF(dmn->t_wakeup);
+	EVENT_CANCEL(dmn->t_read);
+	EVENT_CANCEL(dmn->t_write);
+	EVENT_CANCEL(dmn->t_wakeup);
 	if (try_connect(dmn) < 0)
 		SET_WAKEUP_DOWN(dmn);
 	phase_check();
@@ -921,7 +921,7 @@ static void phase_check(void)
 			}
 		}
 		gs.phase = PHASE_NONE;
-		THREAD_OFF(gs.t_phase_hanging);
+		EVENT_CANCEL(gs.t_phase_hanging);
 		zlog_notice("Phased global restart has completed.");
 		break;
 	}

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -439,8 +439,8 @@ static void fpm_reconnect(struct fpm_nl_ctx *fnc)
 
 	stream_reset(fnc->ibuf);
 	stream_reset(fnc->obuf);
-	THREAD_OFF(fnc->t_read);
-	THREAD_OFF(fnc->t_write);
+	EVENT_CANCEL(fnc->t_read);
+	EVENT_CANCEL(fnc->t_write);
 
 	thread_cancel_async(zrouter.master, &fnc->t_nhgreset, NULL);
 	thread_cancel_async(zrouter.master, &fnc->t_nhgwalk, NULL);
@@ -1211,12 +1211,12 @@ static int fpm_nl_start(struct zebra_dplane_provider *prov)
 static int fpm_nl_finish_early(struct fpm_nl_ctx *fnc)
 {
 	/* Disable all events and close socket. */
-	THREAD_OFF(fnc->t_nhgreset);
-	THREAD_OFF(fnc->t_nhgwalk);
-	THREAD_OFF(fnc->t_ribreset);
-	THREAD_OFF(fnc->t_ribwalk);
-	THREAD_OFF(fnc->t_rmacreset);
-	THREAD_OFF(fnc->t_rmacwalk);
+	EVENT_CANCEL(fnc->t_nhgreset);
+	EVENT_CANCEL(fnc->t_nhgwalk);
+	EVENT_CANCEL(fnc->t_ribreset);
+	EVENT_CANCEL(fnc->t_ribwalk);
+	EVENT_CANCEL(fnc->t_rmacreset);
+	EVENT_CANCEL(fnc->t_rmacwalk);
 	thread_cancel_async(fnc->fthread->master, &fnc->t_read, NULL);
 	thread_cancel_async(fnc->fthread->master, &fnc->t_write, NULL);
 	thread_cancel_async(fnc->fthread->master, &fnc->t_connect, NULL);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -243,7 +243,7 @@ static int if_zebra_delete_hook(struct interface *ifp)
 
 		XFREE(MTYPE_TMP, zebra_if->desc);
 
-		THREAD_OFF(zebra_if->speed_update);
+		EVENT_CANCEL(zebra_if->speed_update);
 
 		XFREE(MTYPE_ZINFO, zebra_if);
 	}

--- a/zebra/irdp_main.c
+++ b/zebra/irdp_main.c
@@ -263,9 +263,7 @@ void irdp_advert_off(struct interface *ifp)
 	if (!irdp)
 		return;
 
-	if (irdp->t_advertise)
-		thread_cancel(irdp->t_advertise);
-	irdp->t_advertise = NULL;
+	thread_cancel(&irdp->t_advertise);
 
 	if (ifp->connected)
 		for (ALL_LIST_ELEMENTS(ifp->connected, node, nnode, ifc)) {
@@ -300,9 +298,7 @@ void process_solicit(struct interface *ifp)
 		return;
 
 	irdp->flags |= IF_SOLICIT;
-	if (irdp->t_advertise)
-		thread_cancel(irdp->t_advertise);
-	irdp->t_advertise = NULL;
+	thread_cancel(&irdp->t_advertise);
 
 	timer = (frr_weak_random() % MAX_RESPONSE_DELAY) + 1;
 

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1194,7 +1194,7 @@ void kernel_init(struct zebra_ns *zns)
 
 void kernel_terminate(struct zebra_ns *zns, bool complete)
 {
-	THREAD_READ_OFF(zns->t_netlink);
+	EVENT_CANCEL(zns->t_netlink);
 
 	if (zns->netlink.sock >= 0) {
 		close(zns->netlink.sock);

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -2480,8 +2480,8 @@ static void rtadv_event(struct zebra_vrf *zvrf, enum rtadv_event event, int val)
 				 &rtadv->ra_timer);
 		break;
 	case RTADV_STOP:
-		THREAD_OFF(rtadv->ra_timer);
-		THREAD_OFF(rtadv->ra_read);
+		EVENT_CANCEL(rtadv->ra_timer);
+		EVENT_CANCEL(rtadv->ra_read);
 		break;
 	case RTADV_TIMER:
 		thread_add_timer(zrouter.master, rtadv_timer, zvrf, val,

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -489,7 +489,7 @@ static inline void zfpm_write_on(void)
  */
 static inline void zfpm_read_off(void)
 {
-	THREAD_READ_OFF(zfpm_g->t_read);
+	EVENT_CANCEL(zfpm_g->t_read);
 }
 
 /*
@@ -497,12 +497,12 @@ static inline void zfpm_read_off(void)
  */
 static inline void zfpm_write_off(void)
 {
-	THREAD_WRITE_OFF(zfpm_g->t_write);
+	EVENT_CANCEL(zfpm_g->t_write);
 }
 
 static inline void zfpm_connect_off(void)
 {
-	THREAD_TIMER_OFF(zfpm_g->t_connect);
+	EVENT_CANCEL(zfpm_g->t_connect);
 }
 
 /*
@@ -1688,7 +1688,7 @@ static void zfpm_stop_stats_timer(void)
 		return;
 
 	zfpm_debug("Stopping existing stats timer");
-	THREAD_TIMER_OFF(zfpm_g->t_stats);
+	EVENT_CANCEL(zfpm_g->t_stats);
 }
 
 /*

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -92,7 +92,7 @@ void zebra_gr_stale_client_cleanup(struct list *client_list)
 
 			/* Cancel the stale timer */
 			if (info->t_stale_removal != NULL) {
-				THREAD_OFF(info->t_stale_removal);
+				EVENT_CANCEL(info->t_stale_removal);
 				info->t_stale_removal = NULL;
 				/* Process the stale routes */
 				thread_execute(
@@ -125,7 +125,7 @@ static void zebra_gr_client_info_delte(struct zserv *client,
 {
 	TAILQ_REMOVE(&(client->gr_info_queue), info, gr_info);
 
-	THREAD_OFF(info->t_stale_removal);
+	EVENT_CANCEL(info->t_stale_removal);
 
 	XFREE(MTYPE_TMP, info->current_prefix);
 
@@ -675,7 +675,7 @@ static void zebra_gr_process_client_stale_routes(struct zserv *client,
 		LOG_GR("%s: Client %s cancled stale delete timer vrf %d",
 		       __func__, zebra_route_string(client->proto),
 		       info->vrf_id);
-		THREAD_OFF(info->t_stale_removal);
+		EVENT_CANCEL(info->t_stale_removal);
 		thread_execute(zrouter.master,
 			       zebra_gr_route_stale_delete_timer_expiry, info,
 			       0);

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -378,7 +378,7 @@ void zebra_ns_notify_close(void)
 		fd = zebra_netns_notify_current->u.fd;
 
 	if (zebra_netns_notify_current->master != NULL)
-		thread_cancel(zebra_netns_notify_current);
+		thread_cancel(&zebra_netns_notify_current);
 
 	/* auto-removal of notify items */
 	if (fd > 0)

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -215,7 +215,7 @@ static int zebra_ptm_send_message(char *data, int size)
 				 ptm_cb.reconnect_time, &ptm_cb.t_timer);
 		return -1;
 	case BUFFER_EMPTY:
-		THREAD_OFF(ptm_cb.t_write);
+		EVENT_CANCEL(ptm_cb.t_write);
 		break;
 	case BUFFER_PENDING:
 		thread_add_write(zrouter.master, zebra_ptm_flush_messages, NULL,

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -156,13 +156,10 @@ void zebra_ptm_finish(void)
 	if (ptm_cb.in_data)
 		free(ptm_cb.in_data);
 
-	/* Release threads. */
-	if (ptm_cb.t_read)
-		thread_cancel(ptm_cb.t_read);
-	if (ptm_cb.t_write)
-		thread_cancel(ptm_cb.t_write);
-	if (ptm_cb.t_timer)
-		thread_cancel(ptm_cb.t_timer);
+	/* Cancel events. */
+	thread_cancel(&ptm_cb.t_read);
+	thread_cancel(&ptm_cb.t_write);
+	thread_cancel(&ptm_cb.t_timer);
 
 	if (ptm_cb.wb)
 		buffer_free(ptm_cb.wb);

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -102,7 +102,7 @@ void zebra_pw_del(struct zebra_vrf *zvrf, struct zebra_pw *pw)
 		hook_call(pw_uninstall, pw);
 		dplane_pw_uninstall(pw);
 	} else if (pw->install_retry_timer)
-		THREAD_TIMER_OFF(pw->install_retry_timer);
+		EVENT_CANCEL(pw->install_retry_timer);
 
 	/* unlink and release memory */
 	RB_REMOVE(zebra_pw_head, &zvrf->pseudowires, pw);
@@ -219,7 +219,7 @@ void zebra_pw_install_failure(struct zebra_pw *pw, int pwstatus)
 			pw->vrf_id, pw->ifname, PW_INSTALL_RETRY_INTERVAL);
 
 	/* schedule to retry later */
-	THREAD_TIMER_OFF(pw->install_retry_timer);
+	EVENT_CANCEL(pw->install_retry_timer);
 	thread_add_timer(zrouter.master, zebra_pw_install_retry, pw,
 			 PW_INSTALL_RETRY_INTERVAL, &pw->install_retry_timer);
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1695,7 +1695,7 @@ static void zebra_route_map_set_delay_timer(uint32_t value)
 	if (!value && zebra_t_rmap_update) {
 		/* Event driven route map updates is being disabled */
 		/* But there's a pending timer. Fire it off now */
-		thread_cancel(zebra_t_rmap_update);
+		thread_cancel(&zebra_t_rmap_update);
 		zebra_route_map_update_timer(zebra_t_rmap_update);
 	}
 }

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1705,7 +1705,7 @@ void zebra_routemap_finish(void)
 	/* Set zebra_rmap_update_timer to 0 so that it wont schedule again */
 	zebra_rmap_update_timer = 0;
 	/* Thread off if any scheduled already */
-	THREAD_TIMER_OFF(zebra_t_rmap_update);
+	EVENT_CANCEL(zebra_t_rmap_update);
 	route_map_finish();
 }
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -541,7 +541,7 @@ static void zebra_vxlan_dup_addr_detect_for_mac(struct zebra_vrf *zvrf,
 		}
 
 		/* Start auto recovery timer for this MAC */
-		THREAD_OFF(mac->dad_mac_auto_recovery_timer);
+		EVENT_CANCEL(mac->dad_mac_auto_recovery_timer);
 		if (zvrf->dad_freeze && zvrf->dad_freeze_time) {
 			if (IS_ZEBRA_DEBUG_VXLAN)
 				zlog_debug(
@@ -674,7 +674,7 @@ static void zebra_vxlan_dup_addr_detect_for_neigh(struct zebra_vrf *zvrf,
 		nbr->dad_dup_detect_time = monotime(NULL);
 
 		/* Start auto recovery timer for this IP */
-		THREAD_OFF(nbr->dad_ip_auto_recovery_timer);
+		EVENT_CANCEL(nbr->dad_ip_auto_recovery_timer);
 		if (zvrf->dad_freeze && zvrf->dad_freeze_time) {
 			if (IS_ZEBRA_DEBUG_VXLAN)
 				zlog_debug(
@@ -2260,7 +2260,7 @@ static int zvni_neigh_del(zebra_vni_t *zvni, zebra_neigh_t *n)
 		listnode_delete(zmac->neigh_list, n);
 
 	/* Cancel auto recovery */
-	THREAD_OFF(n->dad_ip_auto_recovery_timer);
+	EVENT_CANCEL(n->dad_ip_auto_recovery_timer);
 
 	/* Free the VNI hash entry and allocated memory. */
 	tmp_n = hash_release(zvni->neigh_table, n);
@@ -3401,7 +3401,7 @@ static int zvni_mac_del(zebra_vni_t *zvni, zebra_mac_t *mac)
 	zebra_mac_t *tmp_mac;
 
 	/* Cancel auto recovery */
-	THREAD_OFF(mac->dad_mac_auto_recovery_timer);
+	EVENT_CANCEL(mac->dad_mac_auto_recovery_timer);
 
 	list_delete(&mac->neigh_list);
 
@@ -7091,7 +7091,7 @@ int zebra_vxlan_clear_dup_detect_vni_mac(struct zebra_vrf *zvrf, vni_t vni,
 	mac->detect_start_time.tv_sec = 0;
 	mac->detect_start_time.tv_usec = 0;
 	mac->dad_dup_detect_time = 0;
-	THREAD_OFF(mac->dad_mac_auto_recovery_timer);
+	EVENT_CANCEL(mac->dad_mac_auto_recovery_timer);
 
 	/* warn-only action return */
 	if (!zvrf->dad_freeze)
@@ -7169,7 +7169,7 @@ int zebra_vxlan_clear_dup_detect_vni_ip(struct zebra_vrf *zvrf, vni_t vni,
 	nbr->detect_start_time.tv_sec = 0;
 	nbr->detect_start_time.tv_usec = 0;
 	nbr->dad_dup_detect_time = 0;
-	THREAD_OFF(nbr->dad_ip_auto_recovery_timer);
+	EVENT_CANCEL(nbr->dad_ip_auto_recovery_timer);
 
 	if (!!CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_LOCAL)) {
 		zvni_neigh_send_add_to_client(zvni->vni, ip,
@@ -7204,7 +7204,7 @@ static void zvni_clear_dup_mac_hash(struct hash_bucket *bucket, void *ctxt)
 	mac->detect_start_time.tv_sec = 0;
 	mac->detect_start_time.tv_usec = 0;
 	mac->dad_dup_detect_time = 0;
-	THREAD_OFF(mac->dad_mac_auto_recovery_timer);
+	EVENT_CANCEL(mac->dad_mac_auto_recovery_timer);
 
 	/* Remove all IPs as duplicate associcated with this MAC */
 	for (ALL_LIST_ELEMENTS_RO(mac->neigh_list, node, nbr)) {
@@ -7264,7 +7264,7 @@ static void zvni_clear_dup_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 	nbr->detect_start_time.tv_sec = 0;
 	nbr->detect_start_time.tv_usec = 0;
 	nbr->dad_dup_detect_time = 0;
-	THREAD_OFF(nbr->dad_ip_auto_recovery_timer);
+	EVENT_CANCEL(nbr->dad_ip_auto_recovery_timer);
 
 	if (CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_LOCAL)) {
 		zvni_neigh_send_add_to_client(zvni->vni, &nbr->ip,

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -191,8 +191,8 @@ static void zserv_client_fail(struct zserv *client)
 	atomic_store_explicit(&client->pthread->running, false,
 			      memory_order_relaxed);
 
-	THREAD_OFF(client->t_read);
-	THREAD_OFF(client->t_write);
+	EVENT_CANCEL(client->t_read);
+	EVENT_CANCEL(client->t_write);
 	zserv_event(client, ZSERV_HANDLE_CLIENT_FAIL);
 }
 
@@ -665,8 +665,8 @@ void zserv_close_client(struct zserv *client)
 				   zebra_route_string(client->proto));
 
 		thread_cancel_event(zrouter.master, client);
-		THREAD_OFF(client->t_cleanup);
-		THREAD_OFF(client->t_process);
+		EVENT_CANCEL(client->t_cleanup);
+		EVENT_CANCEL(client->t_process);
 
 		/* destroy pthread */
 		frr_pthread_destroy(client->pthread);


### PR DESCRIPTION
Starting steps to migrate the "thread" library functions to use "event" naming. I'm interested in socializing the idea, and getting some CI mileage on some initial changes.

I'd like to get to the point where the libs use the the word "event" or "task" instead of "thread", and replace the term "master" with "dispatcher" or "handler" (or something even better).