### PR TITLE
vtysh: rework DEFPY processing in extract.pl

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -328,18 +328,6 @@ struct cmd_node {
 	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr,                  \
 			  CMD_ATTR_DEPRECATED, daemon)
 
-#else /* VTYSH_EXTRACT_PL */
-#define DEFPY(funcname, cmdname, cmdstr, helpstr)                              \
-	DEFUN(funcname, cmdname, cmdstr, helpstr)
-
-#define DEFPY_NOSH(funcname, cmdname, cmdstr, helpstr)                         \
-	DEFUN_NOSH(funcname, cmdname, cmdstr, helpstr)
-
-#define DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, attr)                   \
-	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, attr)
-
-#define DEFPY_HIDDEN(funcname, cmdname, cmdstr, helpstr)                       \
-	DEFUN_HIDDEN(funcname, cmdname, cmdstr, helpstr)
 #endif /* VTYSH_EXTRACT_PL */
 
 /* Some macroes */

--- a/vtysh/extract.pl.in
+++ b/vtysh/extract.pl.in
@@ -48,7 +48,7 @@ sub scan_file {
     }
 
     # ?: makes a group non-capturing
-    @defun = ($line =~ /((?:DEFUN|DEFUN_HIDDEN|ALIAS|ALIAS_HIDDEN)\s*\(.+?\));?\s?\s?\n/sg);
+    @defun = ($line =~ /((?:DEFUN|DEFUN_HIDDEN|ALIAS|ALIAS_HIDDEN|DEFPY|DEFPY_HIDDEN)\s*\(.+?\));?\s?\s?\n/sg);
     @install = ($line =~ /install_element\s*\(\s*[0-9A-Z_]+,\s*&[^;]*;\s*\n/sg);
 
     # DEFUN process


### PR DESCRIPTION
Currently, all DEFPY commands are translated into one-liners in
vtysh_cmd.c. After the patch, DEFPY commands are correctly indented just
like DEFUN/ALIAS commands.

Before:
```
DEFSH (VTYSH_BGPD, af_import_vrf_route_map_cmd_vtysh,  "import vrf route-map RMAP$rmap_str",  "Import routes from another VRF\n" "Vrf routes being filtered\n" "Specify route map\n" "name of route-map\n")
```

After:
```
DEFSH (VTYSH_BGPD, af_import_vrf_route_map_cmd_vtysh, 
      "import vrf route-map RMAP$rmap_str", 
      "Import routes from another VRF\n"
      "Vrf routes being filtered\n"
      "Specify route map\n"
      "name of route-map\n")
```

Old and new vtysh_cmd.c are [attached](https://github.com/FRRouting/frr/files/4948655/vtysh_cmd.zip) if anyone wants the full comparison.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>