### PR TITLE
zebra: vrf disable clean up evpn rmac and nxthp cache

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -9475,8 +9475,15 @@ int zebra_vxlan_vrf_disable(struct zebra_vrf *zvrf)
 	if (!zl3vni)
 		return 0;
 
-	zl3vni->vrf_id = VRF_UNKNOWN;
 	zebra_vxlan_process_l3vni_oper_down(zl3vni);
+
+	/* delete and uninstall all rmacs */
+	hash_iterate(zl3vni->rmac_table, zl3vni_del_rmac_hash_entry, zl3vni);
+	/* delete and uninstall all next-hops */
+	hash_iterate(zl3vni->nh_table, zl3vni_del_nh_hash_entry, zl3vni);
+
+	zl3vni->vrf_id = VRF_UNKNOWN;
+
 	return 0;
 }
 


### PR DESCRIPTION
In networking restart event, l3vni (vxlan) interface followed by associated vrf interfaces go down/deleted.
L3vni (oper) down event (from zebra to bgp) triggers to clean up/un-import evpn routes (one-by-one) from the vrf table, zebra internally removes the route entry from nexthop and RMAC hash.
When all the routes references in nexthop and RMAC db removed both are suppose to be uninstalled from the bridge fdb and neigh table.
While evpn routes removal in progress, a vrf disable event removes l3vni to its vrf association. 
Subsequent bgp to evpn routes removal does not clean up thus evpn routes
reference to nexthop and RMAC remains in zebra hash.
bridge fdb and neigh tables are flushed out since networking restart brings down 
all interfaces which results in flush of fdb and neigh tables.
By product is the zebra does not install nexthop and rmac when routes are re-imported
into vrf in VNI/VRF up event.

The fix is in vrf disable event to flush all l3vni's nexthop and rmac db.

Testing Done:

Performed multiple networking restart and checked neigh and
bridge fdb tables for respective nexthop and router mac entry
programmed.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>