### PR TITLE
OSPF Graceful Restart RFC 3623 (pre-restart)

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -1216,6 +1216,31 @@ Summary Route will be originated on-behalf of all matched external LSAs.
    Show configuration for display all configured summary routes with
    matching external LSA information.
 
+.. _nsf:
+
+Nonstop Forwarding (NSF, also known as Graceful Restart)
+========================================================
+
+.. index:: graceful-restart [grace-period (1-1800)]
+.. clicmd:: graceful-restart [grace-period (1-1800)]
+
+.. index:: no graceful-restart [grace-period (1-1800)]
+.. clicmd:: no graceful-restart [grace-period (1-1800)]
+
+   Enable nonstop forwarding also known as 'Graceful Restart' (:rfc:`3623`).
+   Default 'grace period' is 120 seconds.
+
+.. index:: graceful-restart prepare [period (1-1800)]
+.. clicmd:: graceful-restart prepare [period (1-1800)]
+
+.. index:: no graceful-restart prepare [period (1-1800)]
+.. clicmd:: no graceful-restart prepare [period (1-1800)]
+
+   Prepare a restart of OSPFd by sending out 'grace' LSAs and stalling the RIB.
+   Default 'prepare period' is 120 seconds. During the 'prepare period' OSPFd
+   should be restarted, otherwise the 'grace' LSAs are flushed again and the
+   'Graceful Restart' is aborted.
+
 Debugging OSPF
 ==============
 

--- a/lib/command.h
+++ b/lib/command.h
@@ -418,6 +418,8 @@ struct cmd_node {
 #define BFD_PROFILE_STR "BFD profile.\n"
 #define BFD_PROFILE_NAME_STR "BFD profile name.\n"
 #define SHARP_STR "Sharp Routing Protocol\n"
+#define OSPF_GR_STR                                                            \
+	"OSPF non-stop forwarding (NSF) also known as OSPF Graceful Restart\n"
 
 #define CMD_VNI_RANGE "(1-16777215)"
 #define CONF_BACKUP_EXT ".sav"

--- a/ospfd/ospf_apiserver.h
+++ b/ospfd/ospf_apiserver.h
@@ -179,7 +179,8 @@ extern void ospf_apiserver_ism_change(struct ospf_interface *oi,
 				      int old_status);
 extern void ospf_apiserver_nsm_change(struct ospf_neighbor *nbr,
 				      int old_status);
-extern void ospf_apiserver_config_write_router(struct vty *vty);
+extern void ospf_apiserver_config_write_router(struct vty *vty,
+					       struct ospf *ospf);
 extern void ospf_apiserver_config_write_if(struct vty *vty,
 					   struct interface *ifp);
 extern void ospf_apiserver_show_info(struct vty *vty, struct ospf_lsa *lsa);

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -1524,21 +1524,16 @@ DEFUN(no_debug_ospf_ldp_sync,
 	return CMD_SUCCESS;
 }
 
-DEFPY (debug_ospf_gr,
-       debug_ospf_gr_cmd,
-       "[no$no] debug ospf graceful-restart helper",
-       NO_STR
-       DEBUG_STR OSPF_STR
-       "Gracefull restart\n"
-       "Helper Information\n")
+DEFPY(debug_ospf_gr, debug_ospf_gr_cmd, "[no$no] debug ospf graceful-restart",
+      NO_STR DEBUG_STR OSPF_STR "OSPF Graceful Restart\n")
 {
 	if (vty->node == CONFIG_NODE)
-		CONF_DEBUG_ON(gr, GR_HELPER);
+		CONF_DEBUG_ON(gr, GR);
 
 	if (!no)
-		TERM_DEBUG_ON(gr, GR_HELPER);
+		TERM_DEBUG_ON(gr, GR);
 	else
-		TERM_DEBUG_OFF(gr, GR_HELPER);
+		TERM_DEBUG_OFF(gr, GR);
 
 	return CMD_SUCCESS;
 }
@@ -1706,9 +1701,9 @@ static int show_debugging_ospf_common(struct vty *vty, struct ospf *ospf)
 	if (IS_DEBUG_OSPF(ldp_sync, LDP_SYNC) == OSPF_DEBUG_LDP_SYNC)
 		vty_out(vty, "  OSPF ldp-sync debugging is on\n");
 
-	/* Show debug status for GR helper. */
-	if (IS_DEBUG_OSPF(gr, GR_HELPER) == OSPF_DEBUG_GR_HELPER)
-		vty_out(vty, "  OSPF Graceful Restart Helper debugging is on\n");
+	/* Show debug status for GR. */
+	if (IS_DEBUG_OSPF(gr, GR) == OSPF_DEBUG_GR)
+		vty_out(vty, "  OSPF Graceful Restart debugging is on\n");
 
 	vty_out(vty, "\n");
 
@@ -1897,9 +1892,9 @@ static int config_write_debug(struct vty *vty)
 		write = 1;
 	}
 
-	/* debug ospf gr helper */
-	if (IS_CONF_DEBUG_OSPF(gr, GR_HELPER) == OSPF_DEBUG_GR_HELPER) {
-		vty_out(vty, "debug ospf%s graceful-restart helper\n", str);
+	/* debug ospf gr */
+	if (IS_CONF_DEBUG_OSPF(gr, GR) == OSPF_DEBUG_GR) {
+		vty_out(vty, "debug ospf%s graceful-restart\n", str);
 		write = 1;
 	}
 

--- a/ospfd/ospf_dump.h
+++ b/ospfd/ospf_dump.h
@@ -63,8 +63,7 @@
 #define OSPF_DEBUG_DEFAULTINFO 0x20
 #define OSPF_DEBUG_LDP_SYNC 0x40
 
-#define OSPF_DEBUG_GR_HELPER 0x01
-#define OSPF_DEBUG_GR 0x03
+#define OSPF_DEBUG_GR 0x01
 
 /* Macro for setting debug option. */
 #define CONF_DEBUG_PACKET_ON(a, b)	    conf_debug_ospf_packet[a] |= (b)
@@ -113,7 +112,7 @@
 #define IS_DEBUG_OSPF_DEFAULT_INFO IS_DEBUG_OSPF(defaultinfo, DEFAULTINFO)
 
 #define IS_DEBUG_OSPF_LDP_SYNC IS_DEBUG_OSPF(ldp_sync, LDP_SYNC)
-#define IS_DEBUG_OSPF_GR_HELPER IS_DEBUG_OSPF(gr, GR_HELPER)
+#define IS_DEBUG_OSPF_GR IS_DEBUG_OSPF(gr, GR)
 
 #define IS_CONF_DEBUG_OSPF_PACKET(a, b)                                        \
 	(conf_debug_ospf_packet[a] & OSPF_DEBUG_##b)

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -385,7 +385,7 @@ int ospf_flood(struct ospf *ospf, struct ospf_neighbor *nbr,
 		if (IS_LSA_MAXAGE(new)) {
 
 			/*  Handling Max age grace LSA.*/
-			if (IS_DEBUG_OSPF_GR_HELPER)
+			if (IS_DEBUG_OSPF_GR)
 				zlog_debug(
 					"%s, Received a maxage GRACE-LSA from router %pI4",
 					__PRETTY_FUNCTION__,
@@ -394,14 +394,14 @@ int ospf_flood(struct ospf *ospf, struct ospf_neighbor *nbr,
 			if (current) {
 				ospf_process_maxage_grace_lsa(ospf, new, nbr);
 			} else {
-				if (IS_DEBUG_OSPF_GR_HELPER)
+				if (IS_DEBUG_OSPF_GR)
 					zlog_debug(
 						"%s, Grace LSA doesn't exist in lsdb, so discarding grace lsa",
 						__PRETTY_FUNCTION__);
 				return -1;
 			}
 		} else {
-			if (IS_DEBUG_OSPF_GR_HELPER)
+			if (IS_DEBUG_OSPF_GR)
 				zlog_debug(
 					"%s, Received a GRACE-LSA from router %pI4",
 					__PRETTY_FUNCTION__,
@@ -409,7 +409,7 @@ int ospf_flood(struct ospf *ospf, struct ospf_neighbor *nbr,
 
 			if (ospf_process_grace_lsa(ospf, new, nbr)
 			    == OSPF_GR_NOT_HELPER) {
-				if (IS_DEBUG_OSPF_GR_HELPER)
+				if (IS_DEBUG_OSPF_GR)
 					zlog_debug(
 						"%s, Not moving to HELPER role, So discarding grace LSA",
 						__PRETTY_FUNCTION__);

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -447,9 +447,9 @@ int ospf_flood(struct ospf *ospf, struct ospf_neighbor *nbr,
 }
 
 /* OSPF LSA flooding -- RFC2328 Section 13.3. */
-static int ospf_flood_through_interface(struct ospf_interface *oi,
-					struct ospf_neighbor *inbr,
-					struct ospf_lsa *lsa)
+int ospf_flood_through_interface(struct ospf_interface *oi,
+				 struct ospf_neighbor *inbr,
+				 struct ospf_lsa *lsa)
 {
 	struct ospf_neighbor *onbr;
 	struct route_node *rn;

--- a/ospfd/ospf_flood.h
+++ b/ospfd/ospf_flood.h
@@ -30,6 +30,9 @@ extern int ospf_flood_through_area(struct ospf_area *, struct ospf_neighbor *,
 				   struct ospf_lsa *);
 extern int ospf_flood_through_as(struct ospf *, struct ospf_neighbor *,
 				 struct ospf_lsa *);
+extern int ospf_flood_through_interface(struct ospf_interface *oi,
+					struct ospf_neighbor *inbr,
+					struct ospf_lsa *lsa);
 
 extern unsigned long ospf_ls_request_count(struct ospf_neighbor *);
 extern int ospf_ls_request_isempty(struct ospf_neighbor *);

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -1,0 +1,201 @@
+/*
+ * This is an implementation of RFC 3623 Graceful OSPF Restart.
+ *
+ * Author: Sascha Kattelmann <sascha@netdef.org>
+ * Copyright 2020 6WIND (c), All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+
+#include "memory.h"
+#include "command.h"
+#include "vty.h"
+#include "log.h"
+
+#include "ospfd/ospfd.h"
+#include "ospfd/ospf_asbr.h"
+#include "ospfd/ospf_lsa.h"
+#include "ospfd/ospf_gr.h"
+#include "ospfd/ospf_errors.h"
+
+
+static void ospf_gr_register_vty(void);
+static void ospf_gr_config_write_router(struct vty *vty, struct ospf *ospf);
+
+int ospf_gr_init(void)
+{
+	int rc;
+
+	zlog_debug(
+		"GR (%s): Initializing nonstop forwarding (NSF) / Graceful Restart",
+		__func__);
+
+	rc = ospf_register_opaque_functab(OSPF_OPAQUE_LINK_LSA,
+					  OPAQUE_TYPE_GRACE_LSA,
+					  NULL, /* new interface */
+					  NULL, /* del interface */
+					  NULL, /* ISM Change */
+					  NULL, /* NSM change */
+					  ospf_gr_config_write_router,
+					  NULL,  /* Config. write interface */
+					  NULL,  /* Config. write debug */
+					  NULL,  /* show info */
+					  NULL,  /* LSA originate */
+					  NULL,  /* LSA refresh */
+					  NULL,  /* LSA update */
+					  NULL); /* del_lsa_hook */
+
+	if (rc != 0) {
+		flog_warn(EC_OSPF_OPAQUE_REGISTRATION,
+			  "GR (%s): Failed to register functions", __func__);
+		return rc;
+	}
+
+	ospf_gr_register_vty();
+
+	return 0;
+}
+
+void ospf_gr_term(void)
+{
+	ospf_delete_opaque_functab(OSPF_OPAQUE_LINK_LSA, OPAQUE_TYPE_GRACE_LSA);
+
+	return;
+}
+
+DEFUN(graceful_restart,
+      graceful_restart_cmd,
+      "graceful-restart [grace-period (1-1800)]",
+      OSPF_GR_STR
+      "Maximum length of the 'grace period'\n"
+      "Maximum length of the 'grace period' in seconds\n")
+{
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
+	int idx = 2;
+
+	/* Check and get restart period if present */
+	if (argc > 1)
+		ospf->gr_info.grace_period =
+			strtoul(argv[idx]->arg, NULL, 10);
+	else
+		ospf->gr_info.grace_period =
+			OSPF_GR_DEFAULT_GRACE_PERIOD;
+
+	if (!ospf->gr_info.restart_support)
+		zlog_debug("GR: OFF -> ON");
+
+	ospf->gr_info.restart_support = true;
+
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_graceful_restart,
+      no_graceful_restart_cmd,
+      "no graceful-restart [period (1-1800)]",
+      NO_STR
+      OSPF_GR_STR
+      "Maximum length of the 'grace period'\n"
+      "Maximum length of the 'grace period' in seconds\n")
+{
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
+
+	ospf->gr_info.restart_support = false;
+
+	zlog_debug("GR: ON -> OFF");
+
+	return CMD_SUCCESS;
+}
+
+DEFUN(graceful_restart_prepare,
+      graceful_restart_prepare_cmd,
+      "graceful-restart prepare [period (1-1800)]",
+      OSPF_GR_STR
+      "Prepare upcoming OSPF restart by sending out 'grace' LSAs and stalling the RIB\n"
+      "Length of the 'prepare period' after which 'grace' LSAs are flushed and the RIB being unstalled again\n"
+      "Length of the 'prepare period' in seconds\n")
+{
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
+	int idx = 3;
+
+	if (!ospf->gr_info.restart_support) {
+		zlog_warn(
+			"GR: Graceful Restart not enabled, can't start preparation");
+		return CMD_WARNING;
+	}
+
+	/* Check and get restart period if present */
+	if (argc > 2)
+		ospf->gr_info.prepare_period =
+			strtoul(argv[idx]->arg, NULL, 10);
+	else
+		ospf->gr_info.prepare_period =
+			OSPF_GR_DEFAULT_PREPARE_PERIOD;
+
+	if (!ospf->gr_info.prepare_running)
+		zlog_debug("GR PREPARE: OFF -> ON with period %d",
+			   ospf->gr_info.prepare_period);
+
+	ospf->gr_info.prepare_running = true;
+
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_graceful_restart_prepare,
+      no_graceful_restart_prepare_cmd,
+      "no graceful-restart prepare [period (1-1800)]",
+      NO_STR
+      OSPF_GR_STR
+      "Prepare upcoming OSPF restart by sending out 'grace' LSAs and stalling the RIB\n"
+      "Length of the 'prepare period' after which 'grace' LSAs are flushed and the RIB being unstalled again\n"
+      "Length of the 'prepare period' in seconds\n")
+{
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
+
+	if (ospf->gr_info.prepare_running)
+		zlog_debug("GR PREPARE: ON -> OFF");
+
+	ospf->gr_info.prepare_running = false;
+
+	return CMD_SUCCESS;
+}
+
+static void ospf_gr_config_write_router(struct vty *vty, struct ospf *ospf)
+{
+	if (!ospf->gr_info.restart_support)
+		return;
+
+	if (ospf->gr_info.grace_period
+	    == OSPF_GR_DEFAULT_GRACE_PERIOD)
+		vty_out(vty, " graceful-restart\n");
+	else
+		vty_out(vty, " graceful-restart grace-period %d\n",
+			ospf->gr_info.grace_period);
+
+	return;
+}
+
+/* Install new CLI commands */
+static void ospf_gr_register_vty(void)
+{
+	install_element(OSPF_NODE, &graceful_restart_cmd);
+	install_element(OSPF_NODE, &no_graceful_restart_cmd);
+
+	install_element(OSPF_NODE, &graceful_restart_prepare_cmd);
+	install_element(OSPF_NODE, &no_graceful_restart_prepare_cmd);
+
+	return;
+}

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -27,16 +27,21 @@
 #include "log.h"
 
 #include "ospfd/ospfd.h"
+#include "ospfd/ospf_flood.h"
+#include "ospfd/ospf_ism.h"
+#include "ospfd/ospf_interface.h"
 #include "ospfd/ospf_asbr.h"
 #include "ospfd/ospf_lsa.h"
 #include "ospfd/ospf_route.h"
 #include "ospfd/ospf_zebra.h"
 #include "ospfd/ospf_gr.h"
 #include "ospfd/ospf_errors.h"
+#include "ospfd/ospf_dump.h"
 
 
 static void ospf_gr_register_vty(void);
 static void ospf_gr_config_write_router(struct vty *vty, struct ospf *ospf);
+static struct ospf_lsa *ospf_gr_lsa_refresh(struct ospf_lsa *lsa);
 
 int ospf_gr_init(void)
 {
@@ -46,20 +51,20 @@ int ospf_gr_init(void)
 		"GR (%s): Initializing nonstop forwarding (NSF) / Graceful Restart",
 		__func__);
 
-	rc = ospf_register_opaque_functab(OSPF_OPAQUE_LINK_LSA,
-					  OPAQUE_TYPE_GRACE_LSA,
-					  NULL, /* new interface */
-					  NULL, /* del interface */
-					  NULL, /* ISM Change */
-					  NULL, /* NSM change */
-					  ospf_gr_config_write_router,
-					  NULL,  /* Config. write interface */
-					  NULL,  /* Config. write debug */
-					  NULL,  /* show info */
-					  NULL,  /* LSA originate */
-					  NULL,  /* LSA refresh */
-					  NULL,  /* LSA update */
-					  NULL); /* del_lsa_hook */
+	rc = ospf_register_opaque_functab(
+		OSPF_OPAQUE_LINK_LSA, OPAQUE_TYPE_GRACE_LSA,
+		NULL,			     /* new interface */
+		NULL,			     /* del interface */
+		NULL,			     /* ISM Change */
+		NULL,			     /* NSM change */
+		ospf_gr_config_write_router, /* Config. write router */
+		NULL,			     /* Config. write interface */
+		NULL,			     /* Config. write debug */
+		NULL,			     /* show info */
+		NULL,			     /* LSA originate */
+		ospf_gr_lsa_refresh,	 /* LSA refresh */
+		NULL,			     /* LSA update */
+		NULL);			     /* del_lsa_hook */
 
 	if (rc != 0) {
 		flog_warn(EC_OSPF_OPAQUE_REGISTRATION,
@@ -77,6 +82,262 @@ void ospf_gr_term(void)
 	ospf_delete_opaque_functab(OSPF_OPAQUE_LINK_LSA, OPAQUE_TYPE_GRACE_LSA);
 
 	return;
+}
+
+static struct ospf_lsa *ospf_gr_lsa_lookup(struct ospf *ospf)
+{
+	struct ospf_lsa *lsa = NULL;
+	struct in_addr lsa_id;
+	uint32_t lsa_id_host_byte_order;
+	struct ospf_area *area;
+
+	area = ospf_area_get(ospf, ospf->router_id);
+
+	lsa_id_host_byte_order = SET_OPAQUE_LSID(OPAQUE_TYPE_GRACE_LSA, 0);
+	lsa_id.s_addr = htonl(lsa_id_host_byte_order);
+	lsa = ospf_lsa_lookup(ospf, area, OSPF_OPAQUE_LINK_LSA, lsa_id,
+			      ospf->router_id);
+
+	return lsa;
+}
+
+static int ospf_gr_prepare_timer(struct thread *thread)
+{
+	struct ospf *ospf = (struct ospf *)THREAD_ARG(thread);
+	struct ospf_lsa *lsa;
+
+	zlog_debug(
+		"[GR] Prepared restart timer expired, flushing all self-originated Grace-LSAs.");
+
+	ospf->gr_info.t_prepare = NULL;
+	ospf->gr_info.prepare_running = false;
+
+	lsa = ospf_gr_lsa_lookup(ospf);
+	if (lsa)
+		ospf_opaque_lsa_flush_schedule(lsa);
+	else
+		zlog_debug("[GR] no self-originated Grace-LSAs to flush!");
+
+	if (ospf->present_zebra_gr_state == ZEBRA_GR_ENABLED) {
+		zlog_debug("[GR] Un-stalling the RIB");
+		if (ospf_zebra_gr_disable(ospf))
+			return CMD_WARNING;
+	}
+
+	return 0;
+}
+
+/*
+ * Before each generation of Grace-LSAs, call this function to
+ * initialize the restart period loaded in the period-TLV.
+ */
+static void ospf_gr_init_period(struct ospf_gr_info *gr_info)
+{
+	struct timeval prepare_left;
+	uint32_t prepare_diff;
+
+	if (gr_info->t_prepare) {
+		prepare_left = thread_timer_remain(gr_info->t_prepare);
+		prepare_diff = gr_info->prepare_period - prepare_left.tv_sec;
+		gr_info->tlv_period.value =
+			htonl(gr_info->grace_period - prepare_diff);
+	} else {
+		gr_info->tlv_period.value = htonl(gr_info->grace_period);
+	}
+}
+
+static void ospf_gr_build_period_tlv(struct ospf_gr_info *gr_info,
+				     struct stream *s)
+{
+	stream_put(s, &gr_info->tlv_period, sizeof(struct gr_tlv_period));
+}
+
+static void ospf_gr_build_reason_tlv(struct ospf_gr_info *gr_info,
+				     struct stream *s)
+{
+	if (gr_info->prepare_running)
+		gr_info->tlv_reason.reason = GR_REASON_RESTART;
+	else
+		gr_info->tlv_reason.reason = GR_REASON_UNKNOWN;
+
+	stream_put(s, &gr_info->tlv_reason, sizeof(struct gr_tlv_reason));
+}
+
+static void ospf_gr_build_address_tlv(struct ospf_gr_info *gr_info,
+				      struct stream *s,
+				      struct ospf_interface *oi)
+{
+	gr_info->tlv_address.addr = oi->address->u.prefix4;
+	stream_put(s, &gr_info->tlv_address, sizeof(struct gr_tlv_address));
+}
+
+static void ospf_gr_lsa_body_set(struct ospf_gr_info *gr_info, struct stream *s,
+				 struct ospf_interface *oi)
+{
+	ospf_gr_build_period_tlv(gr_info, s);
+	ospf_gr_build_reason_tlv(gr_info, s);
+	if (oi->type == OSPF_IFTYPE_BROADCAST || oi->type == OSPF_IFTYPE_NBMA
+	    || oi->type == OSPF_IFTYPE_POINTOMULTIPOINT)
+		ospf_gr_build_address_tlv(gr_info, s, oi);
+}
+
+static struct ospf_lsa *ospf_gr_lsa_new(struct ospf_interface *oi)
+{
+	struct stream *s;
+	struct lsa_header *lsah;
+	struct ospf_lsa *new;
+	uint8_t options, lsa_type;
+	struct in_addr lsa_id;
+	uint32_t lsa_id_host_byte_order;
+	uint16_t length;
+
+	/* Create a stream for LSA. */
+	s = stream_new(OSPF_MAX_LSA_SIZE);
+	assert(s);
+
+	lsah = (struct lsa_header *)STREAM_DATA(s);
+
+	options = LSA_OPTIONS_GET(oi->area);
+	options |= LSA_OPTIONS_NSSA_GET(oi->area);
+	options |= OSPF_OPTION_O;
+
+	lsa_type = OSPF_OPAQUE_LINK_LSA;
+	lsa_id_host_byte_order = SET_OPAQUE_LSID(OPAQUE_TYPE_GRACE_LSA, 0);
+	lsa_id.s_addr = htonl(lsa_id_host_byte_order);
+
+	/* Set opaque-LSA header fields. */
+	lsa_header_set(s, options, lsa_type, lsa_id, oi->ospf->router_id);
+
+	/* Set opaque-LSA body fields. */
+	ospf_gr_lsa_body_set(&oi->ospf->gr_info, s, oi);
+
+	/* Set length. */
+	length = stream_get_endp(s);
+	lsah->length = htons(length);
+
+	/* Now, create an OSPF LSA instance. */
+	new = ospf_lsa_new_and_data(length);
+	assert(new);
+
+	zlog_debug("LSA[Type%d:%s]: Create an Opaque-LSA/GR instance", lsa_type,
+		   inet_ntoa(lsa_id));
+
+	new->area = oi->area;
+	new->oi = oi;
+	SET_FLAG(new->flags, OSPF_LSA_SELF);
+	memcpy(new->data, lsah, length);
+	stream_free(s);
+
+	return new;
+}
+
+static struct ospf_lsa *ospf_gr_lsa_originate(struct ospf_interface *oi,
+					      struct ospf_lsa *old)
+{
+	struct ospf_lsa *new = NULL;
+	struct ospf_area *area;
+
+	if (oi->state == ISM_Down) {
+		zlog_debug(
+			"%s:Originating Grace LSA on Down interface %s (abort)",
+			__func__, IF_NAME(oi));
+		goto out;
+	}
+
+	/* Create new Grace-LSA instance. */
+	new = ospf_gr_lsa_new(oi);
+	if (!new) {
+		zlog_warn("ospf_gr_lsa_generate: ospf_gr_lsa_new() failed");
+		goto out;
+	}
+
+	/* Adjust the sequence number */
+	if (!old) {
+		/* Find the old LSA and increase the seq. */
+		area = ospf_area_get(oi->ospf, oi->ospf->router_id);
+		old = ospf_lsa_lookup_by_header(area, new->data);
+		if (old)
+			new->data->ls_seqnum = lsa_seqnum_increment(old);
+	}
+
+	/* Install this LSA into LSDB. */
+	if (ospf_lsa_install(oi->ospf, oi, new) == NULL) {
+		zlog_warn("ospf_gr_lsa_generate: ospf_lsa_install() failed");
+		ospf_lsa_unlock(&new);
+		goto out;
+	}
+
+	/* Update new LSA origination count. */
+	if (!old)
+		oi->ospf->lsa_originate_count++;
+
+	/* Flood the LSA through out the interface */
+	ospf_flood_through_interface(oi, NULL, new);
+
+out:
+	return new;
+}
+
+static struct ospf_lsa *ospf_gr_lsa_refresh(struct ospf_lsa *lsa)
+{
+	struct ospf *ospf = lsa->oi->ospf;
+	bool force_org = false;
+
+	if (!IS_GR_LSA(lsa->data) || !CHECK_FLAG(lsa->flags, OSPF_LSA_SELF))
+		return NULL;
+
+	if (!ospf->gr_info.restart_support) {
+		/* Seems to be a leftover, flush it away. */
+		lsa->data->ls_age = htons(OSPF_LSA_MAXAGE);
+	} else if (ospf->gr_info.prepare_running) {
+		/* Prepare running, refresh this LSA */
+		force_org = true;
+	} else {
+		lsa->data->ls_age = htons(OSPF_LSA_MAXAGE);
+	}
+
+	/* If the lsa's age reached to MaxAge, start flushing procedure. */
+	if (IS_LSA_MAXAGE(lsa) && !force_org) {
+		ospf_opaque_lsa_flush_schedule(lsa);
+	} else {
+		ospf_gr_init_period(&lsa->oi->ospf->gr_info);
+		ospf_gr_lsa_originate(lsa->oi, lsa);
+	}
+
+	return NULL;
+}
+
+static void ospf_gr_prepare(struct ospf *ospf, uint32_t period)
+{
+	struct listnode *node = NULL;
+	struct ospf_interface *oi = NULL;
+
+	zlog_debug("[GR] NSF PREPARE with the period %u second(s)", period);
+
+	if (!ospf->gr_info.restart_support
+	    || ospf->present_zebra_gr_state != ZEBRA_GR_ENABLED) {
+		zlog_debug(
+			"[GR] The graceful restart capability is not active!");
+		return;
+	}
+
+	if (ospf->gr_info.prepare_running) {
+		zlog_debug(
+			"[GR] The prepared restart has already been committed!");
+		return;
+	}
+
+	ospf->gr_info.prepare_running = true;
+
+	thread_add_timer(master, ospf_gr_prepare_timer, ospf,
+			 ospf->gr_info.prepare_period,
+			 &ospf->gr_info.t_prepare);
+
+	ospf_gr_init_period(&ospf->gr_info);
+
+	/* Send a Grace-LSA to all neighbors */
+	for (ALL_LIST_ELEMENTS_RO(ospf->oiflist, node, oi))
+		ospf_gr_lsa_originate(oi, NULL);
 }
 
 DEFUN(graceful_restart,
@@ -151,8 +412,6 @@ DEFUN(graceful_restart_prepare,
 		zlog_debug("GR PREPARE: OFF -> ON with period %d",
 			   ospf->gr_info.prepare_period);
 
-	ospf->gr_info.prepare_running = true;
-
 	if (ospf->present_zebra_gr_state == ZEBRA_GR_ENABLED
 	    && ospf->rib_stale_time != ospf->gr_info.grace_period) {
 		if (ospf_zebra_gr_stale_time_update(
@@ -163,6 +422,8 @@ DEFUN(graceful_restart_prepare,
 		if (ospf_zebra_gr_enable(ospf, ospf->gr_info.grace_period))
 			return CMD_WARNING;
 	}
+
+	ospf_gr_prepare(ospf, ospf->gr_info.prepare_period);
 
 	return CMD_SUCCESS;
 }
@@ -202,8 +463,6 @@ static void ospf_gr_config_write_router(struct vty *vty, struct ospf *ospf)
 	else
 		vty_out(vty, " graceful-restart grace-period %d\n",
 			ospf->gr_info.grace_period);
-
-	return;
 }
 
 /* Install new CLI commands */
@@ -214,6 +473,4 @@ static void ospf_gr_register_vty(void)
 
 	install_element(OSPF_NODE, &graceful_restart_prepare_cmd);
 	install_element(OSPF_NODE, &no_graceful_restart_prepare_cmd);
-
-	return;
 }

--- a/ospfd/ospf_gr.h
+++ b/ospfd/ospf_gr.h
@@ -1,0 +1,32 @@
+/*
+ * This is an implementation of RFC 3623 Graceful OSPF Restart.
+ *
+ * Author: Sascha Kattelmann <sascha@netdef.org>
+ * Copyright 2020 6WIND (c), All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _ZEBRA_OSPF_GR_H
+#define _ZEBRA_OSPF_GR_H
+
+#define OSPF_GR_DEFAULT_GRACE_PERIOD 120
+#define OSPF_GR_DEFAULT_PREPARE_PERIOD 120
+
+/* Prototypes. */
+extern int ospf_gr_init(void);
+extern void ospf_gr_term(void);
+
+#endif /* _ZEBRA_OSPF_GR_H */

--- a/ospfd/ospf_gr.h
+++ b/ospfd/ospf_gr.h
@@ -22,8 +22,42 @@
 #ifndef _ZEBRA_OSPF_GR_H
 #define _ZEBRA_OSPF_GR_H
 
+/*
+ *        24       16        8        0
+ * +--------+--------+--------+--------+ ---
+ * |      LS age     |Options |    9   |  A
+ * +--------+--------+--------+--------+  |
+ * |    3   |            0             |  |
+ * +--------+--------+--------+--------+  |
+ * |        Advertising router         |  |  Standard (Opaque) LSA header;
+ * +--------+--------+--------+--------+  |  Only type-9 is used.
+ * |        LS sequence number         |  |
+ * +--------+--------+--------+--------+  |
+ * |   LS checksum   |     Length      |  V
+ * +--------+--------+--------+--------+ ---
+ * |      Type       |     Length      |  A
+ * +--------+--------+--------+--------+  |  TLV part for GR.
+ * |              Values ...           |  V
+ * +--------+--------+--------+--------+ ---
+ *
+ * Opaque LSA's link state ID for Graceful Restart is 0x03000000.
+ * Opaque Type: 3
+ * opaque ID  : 0
+ *
+ */
+
+#define IS_GR_LSA(header)                                                      \
+	((header)->type == OSPF_OPAQUE_LINK_LSA                                \
+	 && ntohl((header)->id.s_addr)                                         \
+		    == SET_OPAQUE_LSID(OPAQUE_TYPE_GRACE_LSA, 0))
+
 #define OSPF_GR_DEFAULT_GRACE_PERIOD 120
 #define OSPF_GR_DEFAULT_PREPARE_PERIOD 120
+
+#define GR_REASON_UNKNOWN 0 /* unknown */
+#define GR_REASON_RESTART 1 /* software restart */
+#define GR_REASON_UPGRADE 2 /* software reload/upgrade */
+#define GR_REASON_SWITCH 3  /* switch to redundant control processer */
 
 /* Prototypes. */
 extern int ospf_gr_init(void);

--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -163,7 +163,7 @@ void ospf_gr_helper_init(struct ospf *ospf)
 {
 	int rc;
 
-	if (IS_DEBUG_OSPF_GR_HELPER)
+	if (IS_DEBUG_OSPF_GR)
 		zlog_debug("%s, GR Helper init.", __PRETTY_FUNCTION__);
 
 	ospf->is_helper_supported = OSPF_GR_FALSE;
@@ -200,7 +200,7 @@ void ospf_gr_helper_init(struct ospf *ospf)
 void ospf_gr_helper_stop(struct ospf *ospf)
 {
 
-	if (IS_DEBUG_OSPF_GR_HELPER)
+	if (IS_DEBUG_OSPF_GR)
 		zlog_debug("%s, GR helper deinit.", __PRETTY_FUNCTION__);
 
 	ospf_enable_rtr_hash_destroy(ospf);
@@ -237,7 +237,7 @@ static int ospf_extract_grace_lsa_fields(struct ospf_lsa *lsa,
 
 	/* Check LSA len */
 	if (length <= OSPF_LSA_HEADER_SIZE) {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug("%s: Malformed packet: Invalid LSA len:%d",
 				   __func__, length);
 		return OSPF_GR_FAILURE;
@@ -250,7 +250,7 @@ static int ospf_extract_grace_lsa_fields(struct ospf_lsa *lsa,
 
 		/* Check TLV len against overall LSA */
 		if (sum + TLV_SIZE(tlvh) > length) {
-			if (IS_DEBUG_OSPF_GR_HELPER)
+			if (IS_DEBUG_OSPF_GR)
 				zlog_debug("%s: Malformed packet: Invalid TLV len:%u",
 					   __func__, TLV_SIZE(tlvh));
 			return OSPF_GR_FAILURE;
@@ -302,7 +302,7 @@ static int ospf_extract_grace_lsa_fields(struct ospf_lsa *lsa,
 			sum += TLV_SIZE(tlvh);
 			break;
 		default:
-			if (IS_DEBUG_OSPF_GR_HELPER)
+			if (IS_DEBUG_OSPF_GR)
 				zlog_debug(
 					"%s, Malformed packet.Invalid TLV type:%d",
 					__PRETTY_FUNCTION__, ntohs(tlvh->type));
@@ -369,13 +369,13 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	ret = ospf_extract_grace_lsa_fields(lsa, &grace_interval, &restart_addr,
 					    &restart_reason);
 	if (ret != OSPF_GR_SUCCESS) {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug("%s, Wrong Grace LSA packet.",
 				   __PRETTY_FUNCTION__);
 		return OSPF_GR_NOT_HELPER;
 	}
 
-	if (IS_DEBUG_OSPF_GR_HELPER)
+	if (IS_DEBUG_OSPF_GR)
 		zlog_debug(
 			"%s, Grace LSA received from %pI4, grace interval:%u, restartreason :%s",
 			__PRETTY_FUNCTION__, &restart_addr,
@@ -390,7 +390,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		restarter = ospf_nbr_lookup_by_addr(oi->nbrs, &restart_addr);
 
 		if (!restarter) {
-			if (IS_DEBUG_OSPF_GR_HELPER)
+			if (IS_DEBUG_OSPF_GR)
 				zlog_debug(
 					"%s, Restarter is not a nbr(%pI4) for this router.",
 					__PRETTY_FUNCTION__,
@@ -408,7 +408,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		lookup.advRtrAddr.s_addr = restarter->router_id.s_addr;
 
 		if (!hash_lookup(ospf->enable_rtr_list, &lookup)) {
-			if (IS_DEBUG_OSPF_GR_HELPER)
+			if (IS_DEBUG_OSPF_GR)
 				zlog_debug(
 					"%s, HELPER support is disabled, So not a HELPER",
 					__PRETTY_FUNCTION__);
@@ -423,7 +423,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	 * became a adjacency.
 	 */
 	if (!IS_NBR_STATE_FULL(restarter)) {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug(
 				"%s, This Neighbour %pI4 is not in FULL state.",
 				__PRETTY_FUNCTION__, &restarter->src);
@@ -437,7 +437,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	 */
 	if (ospf->only_planned_restart
 	    && !OSPF_GR_IS_PLANNED_RESTART(restart_reason)) {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug(
 				"%s, Router supports only planned restarts but received the GRACE LSA for an unplanned restart.",
 				__PRETTY_FUNCTION__);
@@ -451,7 +451,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	 */
 	if (ospf->strict_lsa_check && !ospf_ls_retransmit_isempty(restarter)
 	    && ospf_check_change_in_rxmt_list(restarter)) {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug(
 				"%s, Changed LSA in Rxmt list. So not Helper.",
 				__PRETTY_FUNCTION__);
@@ -462,7 +462,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 
 	/*LSA age must be less than the grace period */
 	if (ntohs(lsa->data->ls_age) >= grace_interval) {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug(
 				"%s, Grace LSA age(%d) is more than the graceinterval(%d)",
 				__PRETTY_FUNCTION__, lsa->data->ls_age,
@@ -479,7 +479,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	 */
 	actual_grace_interval = grace_interval;
 	if (grace_interval > ospf->supported_grace_time) {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug(
 				"%s, Received grace period %d is larger than supported grace %d",
 				__PRETTY_FUNCTION__, grace_interval,
@@ -494,12 +494,12 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		if (ospf->active_restarter_cnt > 0)
 			ospf->active_restarter_cnt--;
 
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug(
 				"%s, Router is already acting as a HELPER for this nbr,so restart the grace timer",
 				__PRETTY_FUNCTION__);
 	} else {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug(
 				"%s, This Router becomes a HELPER for the neighbour %pI4",
 				__PRETTY_FUNCTION__, &restarter->src);
@@ -517,7 +517,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	/* Incremnet the active restarer count */
 	ospf->active_restarter_cnt++;
 
-	if (IS_DEBUG_OSPF_GR_HELPER)
+	if (IS_DEBUG_OSPF_GR)
 		zlog_debug("%s, Grace timer started.interval:%d",
 			   __PRETTY_FUNCTION__, actual_grace_interval);
 
@@ -604,7 +604,7 @@ void ospf_helper_handle_topo_chg(struct ospf *ospf, struct ospf_lsa *lsa)
 	if (!ospf->strict_lsa_check)
 		return;
 
-	if (IS_DEBUG_OSPF_GR_HELPER)
+	if (IS_DEBUG_OSPF_GR)
 		zlog_debug(
 			"%s, Topo change detected due to lsa LSID:%pI4 type:%d",
 			__PRETTY_FUNCTION__, &lsa->data->id,
@@ -669,7 +669,7 @@ void ospf_gr_helper_exit(struct ospf_neighbor *nbr,
 	if (!OSPF_GR_IS_ACTIVE_HELPER(nbr))
 		return;
 
-	if (IS_DEBUG_OSPF_GR_HELPER)
+	if (IS_DEBUG_OSPF_GR)
 		zlog_debug("%s, Exiting from HELPER support to %pI4, due to %s",
 			   __PRETTY_FUNCTION__, &nbr->src,
 			   ospf_exit_reason2str(reason));
@@ -701,7 +701,7 @@ void ospf_gr_helper_exit(struct ospf_neighbor *nbr,
 	 * If no, bringdown the neighbour.
 	 */
 	if (reason != OSPF_GR_HELPER_COMPLETED) {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug(
 				"%s, Failed GR exit, so bringing down the neighbour",
 				__PRETTY_FUNCTION__);
@@ -751,13 +751,13 @@ void ospf_process_maxage_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	ret = ospf_extract_grace_lsa_fields(lsa, &graceInterval, &restartAddr,
 					    &restartReason);
 	if (ret != OSPF_GR_SUCCESS) {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug("%s, Wrong Grace LSA packet.",
 				   __PRETTY_FUNCTION__);
 		return;
 	}
 
-	if (IS_DEBUG_OSPF_GR_HELPER)
+	if (IS_DEBUG_OSPF_GR)
 		zlog_debug("%s, GraceLSA received for neighbour %pI4",
 			   __PRETTY_FUNCTION__, &restartAddr);
 
@@ -769,7 +769,7 @@ void ospf_process_maxage_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		restarter = ospf_nbr_lookup_by_addr(oi->nbrs, &restartAddr);
 
 		if (!restarter) {
-			if (IS_DEBUG_OSPF_GR_HELPER)
+			if (IS_DEBUG_OSPF_GR)
 				zlog_debug(
 					"%s, Restarter is not a neighbour for this router.",
 					__PRETTY_FUNCTION__);

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -75,7 +75,7 @@ static int ospf_inactivity_timer(struct thread *thread)
 	 */
 	if (!OSPF_GR_IS_ACTIVE_HELPER(nbr))
 		OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_InactivityTimer);
-	else if (IS_DEBUG_OSPF_GR_HELPER)
+	else if (IS_DEBUG_OSPF_GR)
 		zlog_debug(
 			"%s, Acting as HELPER for this neighbour, So inactivitytimer event will not be fired.",
 			__PRETTY_FUNCTION__);

--- a/ospfd/ospf_opaque.h
+++ b/ospfd/ospf_opaque.h
@@ -132,7 +132,7 @@ extern int ospf_register_opaque_functab(
 	int (*del_if_hook)(struct interface *ifp),
 	void (*ism_change_hook)(struct ospf_interface *oi, int old_status),
 	void (*nsm_change_hook)(struct ospf_neighbor *nbr, int old_status),
-	void (*config_write_router)(struct vty *vty),
+	void (*config_write_router)(struct vty *vty, struct ospf *ospf),
 	void (*config_write_if)(struct vty *vty, struct interface *ifp),
 	void (*config_write_debug)(struct vty *vty),
 	void (*show_opaque_info)(struct vty *vty, struct ospf_lsa *lsa),

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -4269,7 +4269,7 @@ void ospf_ls_ack_send(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 	struct ospf_interface *oi = nbr->oi;
 
 	if (IS_GRACE_LSA(lsa)) {
-		if (IS_DEBUG_OSPF_GR_HELPER)
+		if (IS_DEBUG_OSPF_GR)
 			zlog_debug("%s, Sending GRACE ACK to Restarter.",
 				   __PRETTY_FUNCTION__);
 	}

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -72,7 +72,8 @@ static struct ospf_router_info OspfRI;
 
 static void ospf_router_info_ism_change(struct ospf_interface *oi,
 					int old_status);
-static void ospf_router_info_config_write_router(struct vty *vty);
+static void ospf_router_info_config_write_router(struct vty *vty,
+						 struct ospf *ospf);
 static void ospf_router_info_show_info(struct vty *vty, struct ospf_lsa *lsa);
 static int ospf_router_info_lsa_originate(void *arg);
 static struct ospf_lsa *ospf_router_info_lsa_refresh(struct ospf_lsa *lsa);
@@ -1524,7 +1525,8 @@ static void ospf_router_info_show_info(struct vty *vty, struct ospf_lsa *lsa)
 	return;
 }
 
-static void ospf_router_info_config_write_router(struct vty *vty)
+static void ospf_router_info_config_write_router(struct vty *vty,
+						 struct ospf *ospf)
 {
 	struct ospf_pce_info *pce = &OspfRI.pce_info;
 	struct listnode *node;

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -1922,7 +1922,7 @@ void ospf_sr_update_task(struct ospf *ospf)
  *
  * @return none
  */
-void ospf_sr_config_write_router(struct vty *vty)
+void ospf_sr_config_write_router(struct vty *vty, struct ospf *ospf)
 {
 	struct listnode *node;
 	struct sr_prefix *srp;

--- a/ospfd/ospf_sr.h
+++ b/ospfd/ospf_sr.h
@@ -356,7 +356,7 @@ struct ext_itf;
 extern void ospf_sr_ext_itf_add(struct ext_itf *exti);
 extern void ospf_sr_ext_itf_delete(struct ext_itf *exti);
 /* Segment Routing configuration functions */
-extern void ospf_sr_config_write_router(struct vty *vty);
+extern void ospf_sr_config_write_router(struct vty *vty, struct ospf *ospf);
 extern void ospf_sr_update_local_prefix(struct interface *ifp,
 					struct prefix *p);
 /* Segment Routing re-routing function */

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -79,7 +79,8 @@ static int ospf_mpls_te_new_if(struct interface *ifp);
 static int ospf_mpls_te_del_if(struct interface *ifp);
 static void ospf_mpls_te_ism_change(struct ospf_interface *oi, int old_status);
 static void ospf_mpls_te_nsm_change(struct ospf_neighbor *nbr, int old_status);
-static void ospf_mpls_te_config_write_router(struct vty *vty);
+static void ospf_mpls_te_config_write_router(struct vty *vty,
+					     struct ospf *ospf);
 static void ospf_mpls_te_show_info(struct vty *vty, struct ospf_lsa *lsa);
 static int ospf_mpls_te_lsa_originate_area(void *arg);
 static int ospf_mpls_te_lsa_originate_as(void *arg);
@@ -2150,7 +2151,7 @@ static void ospf_mpls_te_show_info(struct vty *vty, struct ospf_lsa *lsa)
 	return;
 }
 
-static void ospf_mpls_te_config_write_router(struct vty *vty)
+static void ospf_mpls_te_config_write_router(struct vty *vty, struct ospf *ospf)
 {
 
 	if (OspfMplsTE.enabled) {

--- a/ospfd/ospf_zebra.h
+++ b/ospfd/ospf_zebra.h
@@ -86,6 +86,10 @@ extern int ospf_distribute_list_out_set(struct ospf *, int, const char *);
 extern int ospf_distribute_list_out_unset(struct ospf *, int, const char *);
 extern void ospf_routemap_set(struct ospf_redist *, const char *);
 extern void ospf_routemap_unset(struct ospf_redist *);
+extern int ospf_zebra_gr_enable(struct ospf *ospf, uint32_t stale_time);
+extern int ospf_zebra_gr_disable(struct ospf *ospf);
+extern int ospf_zebra_gr_stale_time_update(struct ospf *ospf,
+					   uint32_t stale_time);
 extern int ospf_distance_set(struct vty *, struct ospf *, const char *,
 			     const char *, const char *);
 extern int ospf_distance_unset(struct vty *, struct ospf *, const char *,

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1770,7 +1770,6 @@ int ospf_timers_refresh_unset(struct ospf *ospf)
 	return 1;
 }
 
-
 static struct ospf_nbr_nbma *ospf_nbr_nbma_new(void)
 {
 	struct ospf_nbr_nbma *nbr_nbma;

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -129,6 +129,36 @@ enum {
 /* Zebra Gracaful Restart states */
 enum zebra_gr_mode { ZEBRA_GR_DISABLED = 0, ZEBRA_GR_ENABLED };
 
+/*
+ * Following section defines TLV (tag, length, value) structures,
+ * used for Graceful Restart.
+ */
+struct gr_tlv_header {
+	uint16_t type;   /* GR_TLV_XXX (see below) */
+	uint16_t length; /* Value portion only, in octets */
+};
+
+/* Graceful Restart Period TLV -- Mandatory */
+struct gr_tlv_period {
+	struct gr_tlv_header header; /* Value length is 4 octets */
+	uint32_t value;		     /* Number of seconds */
+};
+
+/* Graceful Restart Reason TLV -- Mandatory */
+struct gr_tlv_reason {
+	struct gr_tlv_header header; /* Value length is 1 octet */
+	uint8_t reason;		     /* Reason of GR */
+	uint8_t reserve0;	    /* Must be 0 */
+	uint8_t reserve1;	    /* Must be 0 */
+	uint8_t reserve2;	    /* Must be 0 */
+};
+
+/* Graceful Restart Address TLV */
+struct gr_tlv_address {
+	struct gr_tlv_header header; /* Value length is 4 octets */
+	struct in_addr addr;
+};
+
 /* OSPF nonstop forwarding aka Graceful Restart */
 struct ospf_gr_info {
 	bool restart_support;
@@ -136,6 +166,12 @@ struct ospf_gr_info {
 
 	bool prepare_running;
 	uint32_t prepare_period;
+	struct thread *t_prepare;
+
+	/* TLVs used in the Grace-LSA */
+	struct gr_tlv_period tlv_period;
+	struct gr_tlv_reason tlv_reason;
+	struct gr_tlv_address tlv_address;
 };
 
 /* OSPF instance structure. */

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -126,6 +126,9 @@ enum {
 	OSPF_LOG_ADJACENCY_DETAIL =	(1 << 4),
 };
 
+/* Zebra Gracaful Restart states */
+enum zebra_gr_mode { ZEBRA_GR_DISABLED = 0, ZEBRA_GR_ENABLED };
+
 /* OSPF nonstop forwarding aka Graceful Restart */
 struct ospf_gr_info {
 	bool restart_support;
@@ -385,6 +388,12 @@ struct ospf {
 
 	/* OSPF Graceful Restart info */
 	struct ospf_gr_info gr_info;
+
+	/* State of Zebra Graceful Restart */
+	enum zebra_gr_mode present_zebra_gr_state;
+
+	/* Time in secs for staling OSPF routes after zclient connection loss */
+	uint32_t rib_stale_time;
 
 	QOBJ_FIELDS
 };

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -126,6 +126,15 @@ enum {
 	OSPF_LOG_ADJACENCY_DETAIL =	(1 << 4),
 };
 
+/* OSPF nonstop forwarding aka Graceful Restart */
+struct ospf_gr_info {
+	bool restart_support;
+	uint32_t grace_period;
+
+	bool prepare_running;
+	uint32_t prepare_period;
+};
+
 /* OSPF instance structure. */
 struct ospf {
 	/* OSPF's running state based on the '[no] router ospf [<instance>]'
@@ -373,6 +382,9 @@ struct ospf {
 
 	/* MPLS LDP-IGP Sync */
 	struct ldp_sync_info_cmd ldp_sync_cmd;
+
+	/* OSPF Graceful Restart info */
+	struct ospf_gr_info gr_info;
 
 	QOBJ_FIELDS
 };

--- a/ospfd/subdir.am
+++ b/ospfd/subdir.am
@@ -12,6 +12,7 @@ vtysh_scan += \
 	ospfd/ospf_ldp_sync.c \
 	ospfd/ospf_opaque.c \
 	ospfd/ospf_ri.c \
+	ospfd/ospf_gr.c \
 	ospfd/ospf_routemap.c \
 	ospfd/ospf_te.c \
 	ospfd/ospf_sr.c \
@@ -49,6 +50,7 @@ ospfd_libfrrospf_a_SOURCES = \
 	ospfd/ospf_opaque.c \
 	ospfd/ospf_packet.c \
 	ospfd/ospf_ri.c \
+	ospfd/ospf_gr.c \
 	ospfd/ospf_route.c \
 	ospfd/ospf_routemap.c \
 	ospfd/ospf_spf.c \
@@ -98,6 +100,7 @@ noinst_HEADERS += \
 	ospfd/ospf_network.h \
 	ospfd/ospf_packet.h \
 	ospfd/ospf_ri.h \
+	ospfd/ospf_gr.h \
 	ospfd/ospf_route.h \
 	ospfd/ospf_spf.h \
 	ospfd/ospf_sr.h \


### PR DESCRIPTION
See https://github.com/GalaxyGorilla/frr/wiki/OSPF-Graceful-Restart-(RFC-3623) for a project summary.

RFC 3623 introduces the OSPF Graceful Restart (GR) which is similar to what people might know from BGP. In a nutshell GR tells the neighbors of a restarting router to act on behalf of it. The forwarding plane on the restarting router stays active and the traffic flow is _not_ supposed to change during a GR (unless there is a topology change).

Note that OSPF GR is somewhat different to BGP GR when it comes to announcing a restart. While BGP neighbors detect a restart due to a termination of a TCP session the OSPF process needs to announce a restart with so called 'grace' LSAs. The flooding of those LSAs is for now supposed to be triggered using a CLI command ('graceful-restart prepare') which might not turn out as the go-to solution for real-world applications. There is (to my knowledge) no 'administrative entity' in FRR which is supposed to handle such operative tasks. The same can be said about the GR timer info. But you gotta start somehow :).

- [x] Provide means for configuring OSPF GR on router level (enable GR, trigger GR)
- [x] Couple the CLI infrastructure to the opaque LSA 'framework'
- [x] Stale the RIB using zclient/zapi infrastructure
- [x] Provide means for creating and installing interface dependent 'grace' LSAs
- [x] Flood 'grace' LSAs to OSPF neighbors
- [x] ~Provide means for parsing 'grace' LSAs (for the neighbors)~ (will be done in helper mode PR)
- [x] Store 'grace interval' timer information in `zebra` using `zebra`'s GR capabilities

See also #5506.