### PR TITLE
lib: avoid poll if signals are ready

### DIFF
--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -63,6 +63,12 @@ static void quagga_signal_handler(int signo)
 	sigmaster.caught = 1;
 }
 
+/* Check whether a signal is ready to be processed - but do not process. */
+bool frr_sigevent_check(void)
+{
+	return (sigmaster.caught > 0);
+}
+
 /* check if signals have been caught and run appropriate handlers */
 int quagga_sigevent_process(void)
 {

--- a/lib/sigevent.h
+++ b/lib/sigevent.h
@@ -51,6 +51,9 @@ extern void signal_init(struct thread_master *m, int sigc,
 /* check whether there are signals to handle, process any found */
 extern int quagga_sigevent_process(void);
 
+/* Check whether a signal is ready to be processed - but do not process. */
+bool frr_sigevent_check(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -1428,6 +1428,12 @@ struct thread *thread_fetch(struct thread_master *m, struct thread *fetch)
 		memcpy(m->handler.copy, m->handler.pfds,
 		       m->handler.copycount * sizeof(struct pollfd));
 
+		/* If there are signals that need to be processed in this
+		 * pthread, don't poll.
+		 */
+		if (m->handle_signals && frr_sigevent_check())
+			continue;
+
 		pthread_mutex_unlock(&m->mtx);
 		{
 			num = fd_poll(m, m->handler.copy, m->handler.pfdsize,


### PR DESCRIPTION
If a thread-master has pending signals, avoid calling poll in the main event loop. This is another attempt to help with the lost TERM/shutdown signals we see in topotests fairly regularly.