### PR TITLE
tools: do not silently ignore errors when loading config during startup

### DIFF
--- a/tools/frr.in
+++ b/tools/frr.in
@@ -77,7 +77,7 @@ vtysh_b ()
 {
 	# Rember, that all variables have been incremented by 1 in convert_daemon_prios()
 	if [ "$vtysh_enable" = 2 -a -f $C_PATH/frr.conf ]; then
-		$VTYSH -b -n
+		$VTYSH -b
 	fi
 }
 

--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -65,9 +65,9 @@ vtysh_b () {
 	[ "$1" = "watchfrr" ] && return 0
 	[ -r "$C_PATH/frr.conf" ] || return 0
 	if [ -n "$1" ]; then
-		"$VTYSH" `echo $nsopt` -b -n -d "$1"
+		"$VTYSH" `echo $nsopt` -b -d "$1"
 	else
-		"$VTYSH" `echo $nsopt` -b -n
+		"$VTYSH" `echo $nsopt` -b
 	fi
 }
 


### PR DESCRIPTION
Drop the `-n` (`--noerror`) flag from the `vtysh -b` invocation called by the
init script responsible for starting FRR. This ensures that errors in the
configuration file is propagated to the administrator, and prevents a node from
entering a production network while running an essentially undefined
configuration (a behaviour that I can personally attest to has the potential to
cause disastrous network outages - documented in more detail in Cumulus support
request 12791).

Silently ignoring errors also leads to the rather odd behaviour that starting
FRR will ostensibly succeed, while reloading it immediately after - without
changing the configuration - will fail. This is due to the fact that the `-n`
flag is not used while reloading.

The use of the `-n` flag appears to have been introduced without any
explanation in commit 858aa29c6862ed2390baee53b6fc9f54e65246e2 by @donaldsharp.
Looking at the commit message, I suspect that it was not an intentional change.
It seems more likely to me that it was just meant to be used during testing and
development, but ended up being committed to master by accident.

Signed-off-by: Tore Anderson <tore@fud.no>