### PR TITLE
*: pim igmp yang registery to appropriate makefile

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -124,9 +124,6 @@ nodist_lib_libfrr_la_SOURCES = \
 	yang/ietf/ietf-interfaces.yang.c \
 	yang/frr-module-translator.yang.c \
 	yang/frr-nexthop.yang.c \
-	yang/frr-igmp.yang.c \
-	yang/frr-pim.yang.c \
-	yang/frr-pim-rp.yang.c \
 	# end
 
 vtysh_scan += \

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -127,6 +127,12 @@ clippy_scan += \
 	pimd/pim_cmd.c \
 	# end
 
+nodist_pimd_pimd_SOURCES = \
+	yang/frr-igmp.yang.c \
+	yang/frr-pim.yang.c \
+	yang/frr-pim-rp.yang.c \
+	# end
+
 pimd_pimd_LDADD = pimd/libpim.a lib/libfrr.la $(LIBCAP)
 pimd_pimd_SOURCES = pimd/pim_main.c
 

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -29,10 +29,7 @@ dist_yangmodels_DATA += yang/frr-vrf.yang
 dist_yangmodels_DATA += yang/frr-route-types.yang
 dist_yangmodels_DATA += yang/frr-routing.yang
 dist_yangmodels_DATA += yang/ietf/ietf-routing-types.yang
-dist_yangmodels_DATA += yang/frr-igmp.yang
 dist_yangmodels_DATA += yang/ietf/ietf-interfaces.yang
-dist_yangmodels_DATA += yang/frr-pim.yang
-dist_yangmodels_DATA += yang/frr-pim-rp.yang
 
 if BFDD
 dist_yangmodels_DATA += yang/frr-bfdd.yang
@@ -64,4 +61,10 @@ endif
 
 if ZEBRA
 dist_yangmodels_DATA += yang/frr-zebra.yang
+endif
+
+if PIMD
+dist_yangmodels_DATA += yang/frr-igmp.yang
+dist_yangmodels_DATA += yang/frr-pim.yang
+dist_yangmodels_DATA += yang/frr-pim-rp.yang
 endif


### PR DESCRIPTION
Move pim and igmp yang files registery to appropriate makefiles.

In yang directory makefile move under `PIMD`
Remove pimd yang files from library makefile instead move them
to pimd makefile.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>