### PR TITLE
bgpd: wide option

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -679,7 +679,8 @@ static void show_esi_routes(struct bgp *bgp,
 			if (json)
 				json_path = json_object_new_array();
 
-			route_vty_out(vty, p, pi, 0, SAFI_EVPN, json_path);
+			route_vty_out(vty, p, pi, 0, SAFI_EVPN, json_path,
+				      false);
 
 			if (json)
 				json_object_array_add(json_paths, json_path);
@@ -788,7 +789,7 @@ static void show_vni_routes(struct bgp *bgp, struct bgpevpn *vpn, int type,
 						     json_path);
 			else
 				route_vty_out(vty, p, pi, 0, SAFI_EVPN,
-					      json_path);
+					      json_path, false);
 
 			if (json)
 				json_object_array_add(json_paths, json_path);
@@ -1314,7 +1315,7 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 					route_vty_out(vty,
 						      bgp_dest_get_prefix(rm),
 						      pi, no_display, SAFI_EVPN,
-						      json_array);
+						      json_array, false);
 				no_display = 1;
 			}
 
@@ -2813,7 +2814,7 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 						SAFI_EVPN, json_path);
 				} else
 					route_vty_out(vty, p, pi, 0, SAFI_EVPN,
-						      json_path);
+						      json_path, false);
 
 				if (json)
 					json_object_array_add(json_paths,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -72,6 +72,7 @@ enum bgp_show_adj_route_type {
 #define BGP_SHOW_OCODE_HEADER "Origin codes:  i - IGP, e - EGP, ? - incomplete\n\n"
 #define BGP_SHOW_NCODE_HEADER "Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self\n"
 #define BGP_SHOW_HEADER "   Network          Next Hop            Metric LocPrf Weight Path\n"
+#define BGP_SHOW_HEADER_WIDE "   Network                                      Next Hop                                  Metric LocPrf Weight Path\n"
 
 /* Maximum number of labels we can process or send with a prefix. We
  * really do only 1 for MPLS (BGP-LU) but we can do 2 for EVPN-VxLAN.
@@ -618,13 +619,13 @@ extern struct bgp_path_info *info_make(int type, int sub_type,
 
 extern void route_vty_out(struct vty *vty, const struct prefix *p,
 			  struct bgp_path_info *path, int display, safi_t safi,
-			  json_object *json_paths);
+			  json_object *json_paths, bool wide);
 extern void route_vty_out_tag(struct vty *vty, const struct prefix *p,
 			      struct bgp_path_info *path, int display,
 			      safi_t safi, json_object *json);
 extern void route_vty_out_tmp(struct vty *vty, const struct prefix *p,
 			      struct attr *attr, safi_t safi, bool use_json,
-			      json_object *json_ar);
+			      json_object *json_ar, bool wide);
 extern void route_vty_out_overlay(struct vty *vty, const struct prefix *p,
 				  struct bgp_path_info *path, int display,
 				  json_object *json);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -262,14 +262,15 @@ static void subgrp_show_adjq_vty(struct update_subgroup *subgrp,
 					route_vty_out_tmp(vty, dest_p,
 							  adj->adv->baa->attr,
 							  SUBGRP_SAFI(subgrp),
-							  0, NULL);
+							  0, NULL, false);
 					output_count++;
 				}
 				if ((flags & UPDWALK_FLAGS_ADVERTISED)
 				    && adj->attr) {
-					route_vty_out_tmp(
-						vty, dest_p, adj->attr,
-						SUBGRP_SAFI(subgrp), 0, NULL);
+					route_vty_out_tmp(vty, dest_p,
+							  adj->attr,
+							  SUBGRP_SAFI(subgrp),
+							  0, NULL, false);
 					output_count++;
 				}
 			}

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -226,7 +226,7 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 				rd_header = 0;
 			}
 			route_vty_out_tmp(vty, bgp_dest_get_prefix(rm), attr,
-					  safi, use_json, json_routes);
+					  safi, use_json, json_routes, false);
 			output_count++;
 		}
 


### PR DESCRIPTION
Adding wide option to increase the prefix table for the below commands
show <ip> bgp <wide>
show <ip> bgp ipv4/ipv6 unicast <wide>
show ip bgp neighbor <router-id> advertised-router|received-routes|filtered-routes <wide> 

Signed-off-by: Madhuri Kuruganti <k.madhuri@samsung.com>