### PR TITLE
EVPN Multihoming part-2 - NHG ZAPI Infrastructure and Sharpd Implementation

### DIFF
--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -39,7 +39,7 @@ listing of ECMP nexthops used to forward packets for when a pbr-map is matched.
    sub-mode where you can specify individual nexthops.  To exit this mode type
    exit or end as per normal conventions for leaving a sub-mode.
 
-.. clicmd:: nexthop [A.B.C.D|X:X::X:XX] [interface] [nexthop-vrf NAME] [label LABELS]
+.. clicmd:: nexthop [A.B.C.D|X:X::X:XX] [interface [onlink]] [nexthop-vrf NAME] [label LABELS]
 
    Create a v4 or v6 nexthop.  All normal rules for creating nexthops that you
    are used to are allowed here.  The syntax was intentionally kept the same as

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -45,6 +45,17 @@ listing of ECMP nexthops used to forward packets for when a pbr-map is matched.
    are used to are allowed here.  The syntax was intentionally kept the same as
    creating nexthops as you would for static routes.
 
+.. clicmd:: set installable
+
+   Sets the nexthop group to be installable i.e. treated as a separate object in
+   the protocol client and zebra's RIB. The proto will send down the object
+   separately from the route to install into into the RIB and dataplane.
+
+.. note::
+   ``set installable`` is only supported for groups with onlink, interface, and
+   gateway/interface nexthop types at the moment. Recursive nexthops
+   (gateway only) are considered undefined behavior.
+
 .. clicmd:: [no] pbr table range (10000-4294966272) (10000-4294966272)
 
    Set or unset the range used to assign numeric table ID's to new

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -45,17 +45,6 @@ listing of ECMP nexthops used to forward packets for when a pbr-map is matched.
    are used to are allowed here.  The syntax was intentionally kept the same as
    creating nexthops as you would for static routes.
 
-.. clicmd:: set installable
-
-   Sets the nexthop group to be installable i.e. treated as a separate object in
-   the protocol client and zebra's RIB. The proto will send down the object
-   separately from the route to install into into the RIB and dataplane.
-
-.. note::
-   ``set installable`` is only supported for groups with onlink, interface, and
-   gateway/interface nexthop types at the moment. Recursive nexthops
-   (gateway only) are considered undefined behavior.
-
 .. clicmd:: [no] pbr table range (10000-4294966272) (10000-4294966272)
 
    Set or unset the range used to assign numeric table ID's to new

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -236,7 +236,8 @@ extern void *hash_release(struct hash *hash, void *data);
  * Iterate over the elements in a hash table.
  *
  * It is safe to delete items passed to the iteration function from the hash
- * table during iteration.  Please note that adding entries to the hash
+ * table during iteration. More than one item cannot be deleted during each
+ * iteration. Please note that adding entries to the hash
  * during the walk will cause undefined behavior in that some new entries
  * will be walked and some will not.  So do not do this.
  *

--- a/lib/log.c
+++ b/lib/log.c
@@ -454,7 +454,8 @@ static const struct zebra_desc_table command_types[] = {
 	DESC_ENTRY(ZEBRA_OPAQUE_UNREGISTER),
 	DESC_ENTRY(ZEBRA_NEIGH_DISCOVER),
 	DESC_ENTRY(ZEBRA_NHG_ADD),
-	DESC_ENTRY(ZEBRA_NHG_DEL)};
+	DESC_ENTRY(ZEBRA_NHG_DEL),
+	DESC_ENTRY(ZEBRA_NHG_NOTIFY_OWNER)};
 #undef DESC_ENTRY
 
 static const struct zebra_desc_table unknown = {0, "unknown", '?'};

--- a/lib/log.c
+++ b/lib/log.c
@@ -452,7 +452,9 @@ static const struct zebra_desc_table command_types[] = {
 	DESC_ENTRY(ZEBRA_OPAQUE_MESSAGE),
 	DESC_ENTRY(ZEBRA_OPAQUE_REGISTER),
 	DESC_ENTRY(ZEBRA_OPAQUE_UNREGISTER),
-	DESC_ENTRY(ZEBRA_NEIGH_DISCOVER)};
+	DESC_ENTRY(ZEBRA_NEIGH_DISCOVER),
+	DESC_ENTRY(ZEBRA_NHG_ADD),
+	DESC_ENTRY(ZEBRA_NHG_DEL)};
 #undef DESC_ENTRY
 
 static const struct zebra_desc_table unknown = {0, "unknown", '?'};

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -54,6 +54,7 @@ struct nexthop_group_hooks {
 	void (*del_nexthop)(const struct nexthop_group_cmd *nhg,
 			    const struct nexthop *nhop);
 	void (*delete)(const char *name);
+	void (*installable)(const struct nexthop_group_cmd *nhg);
 };
 
 static struct nexthop_group_hooks nhg_hooks;
@@ -675,6 +676,37 @@ DEFPY(no_nexthop_group_backup, no_nexthop_group_backup_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(set_installable, set_installable_cmd,
+      "set installable",
+      "Set for nexthop-group\n"
+      "Install nexthop-group into RIB as separate object\n")
+{
+	VTY_DECLVAR_CONTEXT(nexthop_group_cmd, nhgc);
+
+	nhgc->installable = true;
+
+	if (nhg_hooks.installable)
+		nhg_hooks.installable(nhgc);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(no_set_installable, no_set_installable_cmd,
+      "no set installable",
+      NO_STR
+      "Set for nexthop-group\n"
+      "Install nexthop-group into RIB as separate object\n")
+{
+	VTY_DECLVAR_CONTEXT(nexthop_group_cmd, nhgc);
+
+	nhgc->installable = false;
+
+	if (nhg_hooks.installable)
+		nhg_hooks.installable(nhgc);
+
+	return CMD_SUCCESS;
+}
+
 static void nexthop_group_save_nhop(struct nexthop_group_cmd *nhgc,
 				    const char *nhvrf_name,
 				    const union sockunion *addr,
@@ -1147,6 +1179,9 @@ static int nexthop_group_write(struct vty *vty)
 
 		vty_out(vty, "nexthop-group %s\n", nhgc->name);
 
+		if (nhgc->installable)
+			vty_out(vty, " set installable\n");
+
 		if (nhgc->backup_list_name[0])
 			vty_out(vty, " backup-group %s\n",
 				nhgc->backup_list_name);
@@ -1316,12 +1351,14 @@ static const struct cmd_variable_handler nhg_name_handlers[] = {
 	{.tokenname = "NHGNAME", .completions = nhg_name_autocomplete},
 	{.completions = NULL}};
 
-void nexthop_group_init(void (*new)(const char *name),
-			void (*add_nexthop)(const struct nexthop_group_cmd *nhg,
-					    const struct nexthop *nhop),
-			void (*del_nexthop)(const struct nexthop_group_cmd *nhg,
-					    const struct nexthop *nhop),
-			void (*delete)(const char *name))
+void nexthop_group_init(
+	void (*new)(const char *name),
+	void (*add_nexthop)(const struct nexthop_group_cmd *nhg,
+			    const struct nexthop *nhop),
+	void (*del_nexthop)(const struct nexthop_group_cmd *nhg,
+			    const struct nexthop *nhop),
+	void (*delete)(const char *name),
+	void (*installable)(const struct nexthop_group_cmd *nhg))
 {
 	RB_INIT(nhgc_entry_head, &nhgc_entries);
 
@@ -1334,6 +1371,8 @@ void nexthop_group_init(void (*new)(const char *name),
 	install_default(NH_GROUP_NODE);
 	install_element(NH_GROUP_NODE, &nexthop_group_backup_cmd);
 	install_element(NH_GROUP_NODE, &no_nexthop_group_backup_cmd);
+	install_element(NH_GROUP_NODE, &set_installable_cmd);
+	install_element(NH_GROUP_NODE, &no_set_installable_cmd);
 	install_element(NH_GROUP_NODE, &ecmp_nexthops_cmd);
 
 	memset(&nhg_hooks, 0, sizeof(nhg_hooks));
@@ -1346,4 +1385,6 @@ void nexthop_group_init(void (*new)(const char *name),
 		nhg_hooks.del_nexthop = del_nexthop;
 	if (delete)
 		nhg_hooks.delete = delete;
+	if (installable)
+		nhg_hooks.installable = installable;
 }

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -54,7 +54,6 @@ struct nexthop_group_hooks {
 	void (*del_nexthop)(const struct nexthop_group_cmd *nhg,
 			    const struct nexthop *nhop);
 	void (*delete)(const char *name);
-	void (*installable)(const struct nexthop_group_cmd *nhg);
 };
 
 static struct nexthop_group_hooks nhg_hooks;
@@ -676,37 +675,6 @@ DEFPY(no_nexthop_group_backup, no_nexthop_group_backup_cmd,
 	return CMD_SUCCESS;
 }
 
-DEFPY(set_installable, set_installable_cmd,
-      "set installable",
-      "Set for nexthop-group\n"
-      "Install nexthop-group into RIB as separate object\n")
-{
-	VTY_DECLVAR_CONTEXT(nexthop_group_cmd, nhgc);
-
-	nhgc->installable = true;
-
-	if (nhg_hooks.installable)
-		nhg_hooks.installable(nhgc);
-
-	return CMD_SUCCESS;
-}
-
-DEFPY(no_set_installable, no_set_installable_cmd,
-      "no set installable",
-      NO_STR
-      "Set for nexthop-group\n"
-      "Install nexthop-group into RIB as separate object\n")
-{
-	VTY_DECLVAR_CONTEXT(nexthop_group_cmd, nhgc);
-
-	nhgc->installable = false;
-
-	if (nhg_hooks.installable)
-		nhg_hooks.installable(nhgc);
-
-	return CMD_SUCCESS;
-}
-
 static void nexthop_group_save_nhop(struct nexthop_group_cmd *nhgc,
 				    const char *nhvrf_name,
 				    const union sockunion *addr,
@@ -1179,9 +1147,6 @@ static int nexthop_group_write(struct vty *vty)
 
 		vty_out(vty, "nexthop-group %s\n", nhgc->name);
 
-		if (nhgc->installable)
-			vty_out(vty, " set installable\n");
-
 		if (nhgc->backup_list_name[0])
 			vty_out(vty, " backup-group %s\n",
 				nhgc->backup_list_name);
@@ -1351,14 +1316,12 @@ static const struct cmd_variable_handler nhg_name_handlers[] = {
 	{.tokenname = "NHGNAME", .completions = nhg_name_autocomplete},
 	{.completions = NULL}};
 
-void nexthop_group_init(
-	void (*new)(const char *name),
-	void (*add_nexthop)(const struct nexthop_group_cmd *nhg,
-			    const struct nexthop *nhop),
-	void (*del_nexthop)(const struct nexthop_group_cmd *nhg,
-			    const struct nexthop *nhop),
-	void (*delete)(const char *name),
-	void (*installable)(const struct nexthop_group_cmd *nhg))
+void nexthop_group_init(void (*new)(const char *name),
+			void (*add_nexthop)(const struct nexthop_group_cmd *nhg,
+					    const struct nexthop *nhop),
+			void (*del_nexthop)(const struct nexthop_group_cmd *nhg,
+					    const struct nexthop *nhop),
+			void (*delete)(const char *name))
 {
 	RB_INIT(nhgc_entry_head, &nhgc_entries);
 
@@ -1371,8 +1334,6 @@ void nexthop_group_init(
 	install_default(NH_GROUP_NODE);
 	install_element(NH_GROUP_NODE, &nexthop_group_backup_cmd);
 	install_element(NH_GROUP_NODE, &no_nexthop_group_backup_cmd);
-	install_element(NH_GROUP_NODE, &set_installable_cmd);
-	install_element(NH_GROUP_NODE, &no_set_installable_cmd);
 	install_element(NH_GROUP_NODE, &ecmp_nexthops_cmd);
 
 	memset(&nhg_hooks, 0, sizeof(nhg_hooks));
@@ -1385,6 +1346,4 @@ void nexthop_group_init(
 		nhg_hooks.del_nexthop = del_nexthop;
 	if (delete)
 		nhg_hooks.delete = delete;
-	if (installable)
-		nhg_hooks.installable = installable;
 }

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -97,6 +97,9 @@ struct nexthop_group_cmd {
 
 	struct list *nhg_list;
 
+	/* Install nhg as separate object in RIB */
+	bool installable;
+
 	QOBJ_FIELDS
 };
 RB_HEAD(nhgc_entry_head, nexthp_group_cmd);
@@ -116,7 +119,8 @@ void nexthop_group_init(
 			    const struct nexthop *nhop),
 	void (*del_nexthop)(const struct nexthop_group_cmd *nhgc,
 			    const struct nexthop *nhop),
-	void (*destroy)(const char *name));
+	void (*destroy)(const char *name),
+	void (*installable)(const struct nexthop_group_cmd *nhg));
 
 void nexthop_group_enable_vrf(struct vrf *vrf);
 void nexthop_group_disable_vrf(struct vrf *vrf);

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -97,9 +97,6 @@ struct nexthop_group_cmd {
 
 	struct list *nhg_list;
 
-	/* Install nhg as separate object in RIB */
-	bool installable;
-
 	QOBJ_FIELDS
 };
 RB_HEAD(nhgc_entry_head, nexthp_group_cmd);
@@ -119,8 +116,7 @@ void nexthop_group_init(
 			    const struct nexthop *nhop),
 	void (*del_nexthop)(const struct nexthop_group_cmd *nhgc,
 			    const struct nexthop *nhop),
-	void (*destroy)(const char *name),
-	void (*installable)(const struct nexthop_group_cmd *nhg));
+	void (*destroy)(const char *name));
 
 void nexthop_group_enable_vrf(struct vrf *vrf);
 void nexthop_group_disable_vrf(struct vrf *vrf);

--- a/lib/route_types.txt
+++ b/lib/route_types.txt
@@ -84,7 +84,7 @@ ZEBRA_ROUTE_PBR,        pbr,       pbrd,   'F', 1, 1, 0,     "PBR"
 ZEBRA_ROUTE_BFD,        bfd,       bfdd,   '-', 0, 0, 0,     "BFD"
 ZEBRA_ROUTE_OPENFABRIC, openfabric, fabricd,  'f', 1, 1, 1, "OpenFabric"
 ZEBRA_ROUTE_VRRP,       vrrp,      vrrpd,  '-', 0, 0, 0,     "VRRP"
-ZEBRA_ROUTE_NHG,        nhg,       none,  '-', 0, 0, 0,     "Nexthop Group"
+ZEBRA_ROUTE_NHG,        zebra,     none,  '-', 0, 0, 0,      "Nexthop Group"
 ZEBRA_ROUTE_SRTE,       srte,      none,   '-', 0, 0, 0,     "SR-TE"
 ZEBRA_ROUTE_ALL,        wildcard,  none,   '-', 0, 0, 0,     "-"
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1649,6 +1649,9 @@ int zapi_nexthop_from_nexthop(struct zapi_nexthop *znh,
 	znh->ifindex = nh->ifindex;
 	znh->gate = nh->gate;
 
+	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_ONLINK))
+		SET_FLAG(znh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
+
 	if (nh->nh_label && (nh->nh_label->num_labels > 0)) {
 
 		/* Validate */

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -4083,3 +4083,11 @@ uint32_t zclient_get_nhg_start(uint32_t proto)
 
 	return ZEBRA_NHG_SPACING * proto;
 }
+
+/*
+ * Where do routing protocols IDs start overall (first ID after zebra)
+ */
+uint32_t zclient_get_nhg_lower_bound()
+{
+	return ZEBRA_NHG_SPACING * (ZEBRA_ROUTE_CONNECT + 1);
+}

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -4081,13 +4081,5 @@ uint32_t zclient_get_nhg_start(uint32_t proto)
 {
 	assert(proto < ZEBRA_ROUTE_MAX);
 
-	return ZEBRA_NHG_SPACING * proto;
-}
-
-/*
- * Where do routing protocols IDs start overall (first ID after zebra)
- */
-uint32_t zclient_get_nhg_lower_bound()
-{
-	return ZEBRA_NHG_SPACING * (ZEBRA_ROUTE_CONNECT + 1);
+	return ZEBRA_NHG_PROTO_SPACING * proto;
 }

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1486,10 +1486,10 @@ int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s, struct pbr_rule *zrule)
 bool zapi_nhg_notify_decode(struct stream *s, uint32_t *id,
 			    enum zapi_nhg_notify_owner *note)
 {
-	uint16_t read_id;
+	uint32_t read_id;
 
-	STREAM_GETL(s, read_id);
 	STREAM_GET(note, s, sizeof(*note));
+	STREAM_GETL(s, read_id);
 
 	*id = read_id;
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1017,6 +1017,51 @@ done:
 	return ret;
 }
 
+extern void zclient_nhg_del(struct zclient *zclient, uint32_t id)
+{
+	struct stream *s = zclient->obuf;
+
+	stream_reset(s);
+	zclient_create_header(s, ZEBRA_NHG_DEL, VRF_DEFAULT);
+
+	stream_putw(s, zclient->redist_default);
+	stream_putl(s, id);
+
+	stream_putw_at(s, 0, stream_get_endp(s));
+}
+
+static void zclient_nhg_writer(struct stream *s, uint16_t proto, int cmd,
+			       uint32_t id, size_t nhops,
+			       struct zapi_nexthop *znh)
+{
+	size_t i;
+
+	stream_reset(s);
+
+	zapi_nexthop_group_sort(znh, nhops);
+
+	zclient_create_header(s, cmd, VRF_DEFAULT);
+
+	stream_putw(s, proto);
+	stream_putl(s, id);
+	stream_putw(s, nhops);
+	for (i = 0; i < nhops; i++) {
+		zapi_nexthop_encode(s, znh, 0, 0);
+		znh++;
+	}
+
+	stream_putw_at(s, 0, stream_get_endp(s));
+}
+
+extern void zclient_nhg_add(struct zclient *zclient, uint32_t id,
+			    size_t nhops, struct zapi_nexthop *znh)
+{
+	struct stream *s = zclient->obuf;
+
+	zclient_nhg_writer(s, zclient->redist_default, ZEBRA_NHG_ADD, id, nhops,
+			   znh);
+}
+
 int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 {
 	struct zapi_nexthop *api_nh;
@@ -1171,8 +1216,8 @@ int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 /*
  * Decode a single zapi nexthop object
  */
-static int zapi_nexthop_decode(struct stream *s, struct zapi_nexthop *api_nh,
-			       uint32_t api_flags, uint32_t api_message)
+int zapi_nexthop_decode(struct stream *s, struct zapi_nexthop *api_nh,
+			uint32_t api_flags, uint32_t api_message)
 {
 	int i, ret = -1;
 
@@ -1430,6 +1475,22 @@ int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s, struct pbr_rule *zrule)
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	return 0;
+}
+
+bool zapi_nhg_notify_decode(struct stream *s, uint32_t *id,
+			    enum zapi_nhg_notify_owner *note)
+{
+	uint16_t read_id;
+
+	STREAM_GETL(s, read_id);
+	STREAM_GET(note, s, sizeof(*note));
+
+	*id = read_id;
+
+	return true;
+
+stream_failure:
+	return false;
 }
 
 bool zapi_route_notify_decode(struct stream *s, struct prefix *p,
@@ -3732,6 +3793,11 @@ static int zclient_read(struct thread *thread)
 		if (zclient->rule_notify_owner)
 			(*zclient->rule_notify_owner)(command, zclient, length,
 						      vrf_id);
+		break;
+	case ZEBRA_NHG_NOTIFY_OWNER:
+		if (zclient->nhg_notify_owner)
+			(*zclient->nhg_notify_owner)(command, zclient, length,
+						     vrf_id);
 		break;
 	case ZEBRA_GET_LABEL_CHUNK:
 		if (zclient->label_chunk)

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1053,8 +1053,8 @@ static void zclient_nhg_writer(struct stream *s, uint16_t proto, int cmd,
 	stream_putw_at(s, 0, stream_get_endp(s));
 }
 
-extern void zclient_nhg_add(struct zclient *zclient, uint32_t id,
-			    size_t nhops, struct zapi_nexthop *znh)
+extern void zclient_nhg_add(struct zclient *zclient, uint32_t id, size_t nhops,
+			    struct zapi_nexthop *znh)
 {
 	struct stream *s = zclient->obuf;
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -4001,3 +4001,13 @@ int zclient_send_neigh_discovery_req(struct zclient *zclient,
 	stream_putw_at(s, 0, stream_get_endp(s));
 	return zclient_send_message(zclient);
 }
+
+/*
+ * Get a starting nhg point for a routing protocol
+ */
+uint32_t zclient_get_nhg_start(uint32_t proto)
+{
+	assert(proto < ZEBRA_ROUTE_MAX);
+
+	return ZEBRA_NHG_SPACING * proto;
+}

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1103,6 +1103,9 @@ int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 		stream_write(s, (uint8_t *)&api->src_prefix.prefix, psize);
 	}
 
+	if (CHECK_FLAG(api->message, ZAPI_MESSAGE_NHG))
+		stream_putl(s, api->nhgid);
+
 	/* Nexthops.  */
 	if (CHECK_FLAG(api->message, ZAPI_MESSAGE_NEXTHOP)) {
 		/* limit the number of nexthops if necessary */
@@ -1372,6 +1375,9 @@ int zapi_route_decode(struct stream *s, struct zapi_route *api)
 			return -1;
 		}
 	}
+
+	if (CHECK_FLAG(api->message, ZAPI_MESSAGE_NHG))
+		STREAM_GETL(s, api->nhgid);
 
 	/* Nexthops. */
 	if (CHECK_FLAG(api->message, ZAPI_MESSAGE_NEXTHOP)) {

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -374,6 +374,7 @@ struct zclient {
 #define ZAPI_MESSAGE_SRCPFX   0x20
 /* Backup nexthops are present */
 #define ZAPI_MESSAGE_BACKUP_NEXTHOPS 0x40
+#define ZAPI_MESSAGE_NHG      0x80
 
 /*
  * This should only be used by a DAEMON that needs to communicate
@@ -517,6 +518,8 @@ struct zapi_route {
 	/* Support backup routes for IP FRR, TI-LFA, traffic engineering */
 	uint16_t backup_nexthop_num;
 	struct zapi_nexthop backup_nexthops[MULTIPATH_NUM];
+
+	uint32_t nhgid;
 
 	uint8_t distance;
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -439,6 +439,15 @@ struct zapi_nexthop {
 #define ZAPI_NEXTHOP_FLAG_HAS_BACKUP	0x08 /* Nexthop has a backup */
 
 /*
+ * ZAPI Nexthop Group. For use with protocol creation of nexthop groups.
+ */
+struct zapi_nhg {
+	uint32_t id;
+	uint16_t nexthop_num;
+	struct zapi_nexthop nexthops[MULTIPATH_NUM];
+};
+
+/*
  * Some of these data structures do not map easily to
  * a actual data structure size giving different compilers
  * and systems.  For those data structures we need
@@ -898,9 +907,8 @@ bool zapi_ipset_notify_decode(struct stream *s,
 			      uint32_t *unique,
 			     enum zapi_ipset_notify_owner *note);
 
-extern void zclient_nhg_add(struct zclient *zclient, uint32_t id, size_t nhops,
-			    struct zapi_nexthop *znh);
-extern void zclient_nhg_del(struct zclient *zclient, uint32_t id);
+extern int zclient_nhg_send(struct zclient *zclient, int cmd,
+			    struct zapi_nhg *api_nhg);
 
 #define ZEBRA_IPSET_NAME_SIZE   32
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -692,6 +692,7 @@ extern struct zclient_options zclient_options_default;
  */
 #define ZEBRA_NHG_SPACING 50000000
 extern uint32_t zclient_get_nhg_start(uint32_t proto);
+extern uint32_t zclient_get_nhg_lower_bound(void);
 
 extern struct zclient *zclient_new(struct thread_master *m,
 				   struct zclient_options *opt);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -374,7 +374,7 @@ struct zclient {
 #define ZAPI_MESSAGE_SRCPFX   0x20
 /* Backup nexthops are present */
 #define ZAPI_MESSAGE_BACKUP_NEXTHOPS 0x40
-#define ZAPI_MESSAGE_NHG      0x80
+#define ZAPI_MESSAGE_NHG 0x80
 
 /*
  * This should only be used by a DAEMON that needs to communicate
@@ -898,8 +898,7 @@ bool zapi_ipset_notify_decode(struct stream *s,
 			      uint32_t *unique,
 			     enum zapi_ipset_notify_owner *note);
 
-extern void zclient_nhg_add(struct zclient *zclient,
-			    uint32_t id, size_t nhops,
+extern void zclient_nhg_add(struct zclient *zclient, uint32_t id, size_t nhops,
 			    struct zapi_nexthop *znh);
 extern void zclient_nhg_del(struct zclient *zclient, uint32_t id);
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -209,6 +209,9 @@ typedef enum {
 	ZEBRA_MLAG_CLIENT_REGISTER,
 	ZEBRA_MLAG_CLIENT_UNREGISTER,
 	ZEBRA_MLAG_FORWARD_MSG,
+	ZEBRA_NHG_ADD,
+	ZEBRA_NHG_DEL,
+	ZEBRA_NHG_NOTIFY_OWNER,
 	ZEBRA_ERROR,
 	ZEBRA_CLIENT_CAPABILITIES,
 	ZEBRA_OPAQUE_MESSAGE,
@@ -354,6 +357,7 @@ struct zclient {
 	int (*mlag_process_up)(void);
 	int (*mlag_process_down)(void);
 	int (*mlag_handle_msg)(struct stream *msg, int len);
+	int (*nhg_notify_owner)(ZAPI_CALLBACK_ARGS);
 	int (*handle_error)(enum zebra_error_types error);
 	int (*opaque_msg_handler)(ZAPI_CALLBACK_ARGS);
 	int (*opaque_register_handler)(ZAPI_CALLBACK_ARGS);
@@ -590,6 +594,13 @@ enum zapi_route_notify_owner {
 	ZAPI_ROUTE_INSTALLED,
 	ZAPI_ROUTE_REMOVED,
 	ZAPI_ROUTE_REMOVE_FAIL,
+};
+
+enum zapi_nhg_notify_owner {
+	ZAPI_NHG_FAIL_INSTALL,
+	ZAPI_NHG_INSTALLED,
+	ZAPI_NHG_REMOVED,
+	ZAPI_NHG_REMOVE_FAIL,
 };
 
 enum zapi_rule_notify_owner {
@@ -861,7 +872,11 @@ extern int zclient_send_rnh(struct zclient *zclient, int command,
 int zapi_nexthop_encode(struct stream *s, const struct zapi_nexthop *api_nh,
 			uint32_t api_flags, uint32_t api_message);
 extern int zapi_route_encode(uint8_t, struct stream *, struct zapi_route *);
-extern int zapi_route_decode(struct stream *, struct zapi_route *);
+extern int zapi_route_decode(struct stream *s, struct zapi_route *api);
+extern int zapi_nexthop_decode(struct stream *s, struct zapi_nexthop *api_nh,
+			       uint32_t api_flags, uint32_t api_message);
+bool zapi_nhg_notify_decode(struct stream *s, uint32_t *id,
+			    enum zapi_nhg_notify_owner *note);
 bool zapi_route_notify_decode(struct stream *s, struct prefix *p,
 			      uint32_t *tableid,
 			      enum zapi_route_notify_owner *note);
@@ -871,6 +886,11 @@ bool zapi_rule_notify_decode(struct stream *s, uint32_t *seqno,
 bool zapi_ipset_notify_decode(struct stream *s,
 			      uint32_t *unique,
 			     enum zapi_ipset_notify_owner *note);
+
+extern void zclient_nhg_add(struct zclient *zclient,
+			    uint32_t id, size_t nhops,
+			    struct zapi_nexthop *znh);
+extern void zclient_nhg_del(struct zclient *zclient, uint32_t id);
 
 #define ZEBRA_IPSET_NAME_SIZE   32
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -671,6 +671,14 @@ struct zclient_options {
 
 extern struct zclient_options zclient_options_default;
 
+/*
+ * Each client is going to get it's own nexthop group space
+ * and we'll separate them by 50 million, we'll figure out where
+ * to start based upon the route_types.h
+ */
+#define ZEBRA_NHG_SPACING 50000000
+extern uint32_t zclient_get_nhg_start(uint32_t proto);
+
 extern struct zclient *zclient_new(struct thread_master *m,
 				   struct zclient_options *opt);
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -686,13 +686,20 @@ struct zclient_options {
 extern struct zclient_options zclient_options_default;
 
 /*
+ * We reserve the top 4 bits for l2-NHG, everything else
+ * is for zebra/proto l3-NHG.
+ *
  * Each client is going to get it's own nexthop group space
- * and we'll separate them by 50 million, we'll figure out where
- * to start based upon the route_types.h
+ * and we'll separate them, we'll figure out where to start based upon
+ * the route_types.h
  */
-#define ZEBRA_NHG_SPACING 50000000
+#define ZEBRA_NHG_PROTO_UPPER                                                  \
+	((uint32_t)250000000) /* Bottom 28 bits then rounded down */
+#define ZEBRA_NHG_PROTO_SPACING (ZEBRA_NHG_PROTO_UPPER / ZEBRA_ROUTE_MAX)
+#define ZEBRA_NHG_PROTO_LOWER                                                  \
+	(ZEBRA_NHG_PROTO_SPACING * (ZEBRA_ROUTE_CONNECT + 1))
+
 extern uint32_t zclient_get_nhg_start(uint32_t proto);
-extern uint32_t zclient_get_nhg_lower_bound(void);
 
 extern struct zclient *zclient_new(struct thread_master *m,
 				   struct zclient_options *opt);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -442,9 +442,14 @@ struct zapi_nexthop {
  * ZAPI Nexthop Group. For use with protocol creation of nexthop groups.
  */
 struct zapi_nhg {
+	uint16_t proto;
 	uint32_t id;
+
 	uint16_t nexthop_num;
 	struct zapi_nexthop nexthops[MULTIPATH_NUM];
+
+	uint16_t backup_nexthop_num;
+	struct zapi_nexthop backup_nexthops[MULTIPATH_NUM];
 };
 
 /*
@@ -907,6 +912,9 @@ bool zapi_ipset_notify_decode(struct stream *s,
 			      uint32_t *unique,
 			     enum zapi_ipset_notify_owner *note);
 
+
+extern int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg);
+extern int zapi_nhg_decode(struct stream *s, int cmd, struct zapi_nhg *api_nhg);
 extern int zclient_nhg_send(struct zclient *zclient, int cmd,
 			    struct zapi_nhg *api_nhg);
 

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -157,9 +157,10 @@ int main(int argc, char **argv, char **envp)
 
 	pbr_debug_init();
 
-	nexthop_group_init(pbr_nhgroup_add_cb, pbr_nhgroup_add_nexthop_cb,
-			   pbr_nhgroup_del_nexthop_cb, pbr_nhgroup_delete_cb,
-			   NULL);
+	nexthop_group_init(pbr_nhgroup_add_cb,
+			   pbr_nhgroup_add_nexthop_cb,
+			   pbr_nhgroup_del_nexthop_cb,
+			   pbr_nhgroup_delete_cb);
 
 	/*
 	 * So we safely ignore these commands since

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -157,10 +157,9 @@ int main(int argc, char **argv, char **envp)
 
 	pbr_debug_init();
 
-	nexthop_group_init(pbr_nhgroup_add_cb,
-			   pbr_nhgroup_add_nexthop_cb,
-			   pbr_nhgroup_del_nexthop_cb,
-			   pbr_nhgroup_delete_cb);
+	nexthop_group_init(pbr_nhgroup_add_cb, pbr_nhgroup_add_nexthop_cb,
+			   pbr_nhgroup_del_nexthop_cb, pbr_nhgroup_delete_cb,
+			   NULL);
 
 	/*
 	 * So we safely ignore these commands since

--- a/sharpd/sharp_globals.h
+++ b/sharpd/sharp_globals.h
@@ -31,6 +31,7 @@ struct sharp_routes {
 	/* The nexthop info we are using for installation */
 	struct nexthop nhop;
 	struct nexthop backup_nhop;
+	uint32_t nhgid;
 	struct nexthop_group nhop_group;
 	struct nexthop_group backup_nhop_group;
 

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -47,6 +47,7 @@
 #include "sharp_zebra.h"
 #include "sharp_vty.h"
 #include "sharp_globals.h"
+#include "sharp_nht.h"
 
 DEFINE_MGROUP(SHARPD, "sharpd")
 
@@ -164,7 +165,7 @@ int main(int argc, char **argv, char **envp)
 
 	sharp_global_init();
 
-	nexthop_group_init(NULL, NULL, NULL, NULL);
+	sharp_nhgroup_init();
 	vrf_init(NULL, NULL, NULL, NULL, NULL);
 
 	sharp_zebra_init();

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -78,6 +78,8 @@ struct sharp_nhg {
 	uint32_t id;
 
 	char name[256];
+
+	bool installed;
 };
 
 static uint32_t nhg_id;
@@ -98,6 +100,22 @@ static int sharp_nhg_compare_func(const struct sharp_nhg *a,
 
 DECLARE_RBTREE_UNIQ(sharp_nhg_rb, struct sharp_nhg, mylistitem,
 		    sharp_nhg_compare_func);
+
+static struct sharp_nhg *sharp_nhgroup_find_id(uint32_t id)
+{
+	struct sharp_nhg *lookup;
+
+	/* Yea its just a for loop, I don't want add complexity
+	 * to sharpd with another RB tree for just IDs
+	 */
+
+	frr_each(sharp_nhg_rb, &nhg_head, lookup) {
+		if (lookup->id == id)
+			return lookup;
+	}
+
+	return NULL;
+}
 
 static void sharp_nhgroup_add_cb(const char *name)
 {
@@ -164,6 +182,32 @@ uint32_t sharp_nhgroup_get_id(const char *name)
 		return 0;
 
 	return snhg->id;
+}
+
+void sharp_nhgroup_id_set_installed(uint32_t id, bool installed)
+{
+	struct sharp_nhg *snhg;
+
+	snhg = sharp_nhgroup_find_id(id);
+	if (!snhg) {
+		zlog_debug("%s: nhg %u not found", __func__, id);
+		return;
+	}
+
+	snhg->installed = installed;
+}
+
+bool sharp_nhgroup_id_is_installed(uint32_t id)
+{
+	struct sharp_nhg *snhg;
+
+	snhg = sharp_nhgroup_find_id(id);
+	if (!snhg) {
+		zlog_debug("%s: nhg %u not found", __func__, id);
+		return false;
+	}
+
+	return snhg->installed;
 }
 
 void sharp_nhgroup_init(void)

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -86,7 +86,7 @@ static uint32_t nhg_id;
 
 static uint32_t sharp_get_next_nhid(void)
 {
-	zlog_debug("Id assigned: %u", nhg_id);
+	zlog_debug("NHG ID assigned: %u", nhg_id);
 	return nhg_id++;
 }
 

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -25,11 +25,15 @@
 #include "nexthop.h"
 #include "nexthop_group.h"
 #include "vty.h"
+#include "typesafe.h"
+#include "zclient.h"
 
 #include "sharp_nht.h"
 #include "sharp_globals.h"
+#include "sharp_zebra.h"
 
 DEFINE_MTYPE_STATIC(SHARPD, NH_TRACKER, "Nexthop Tracker")
+DEFINE_MTYPE_STATIC(SHARPD, NHG, "Nexthop Group")
 
 struct sharp_nh_tracker *sharp_nh_tracker_get(struct prefix *p)
 {
@@ -64,4 +68,110 @@ void sharp_nh_tracker_dump(struct vty *vty)
 			nht->nhop_num,
 			nht->updates);
 	}
+}
+
+PREDECL_RBTREE_UNIQ(sharp_nhg_rb);
+
+struct sharp_nhg {
+	struct sharp_nhg_rb_item mylistitem;
+
+	uint32_t id;
+
+	char name[256];
+};
+
+static uint32_t nhg_id;
+
+static uint32_t sharp_get_next_nhid(void)
+{
+	zlog_debug("Id assigned: %u", nhg_id + 1);
+	return nhg_id++;
+}
+
+struct sharp_nhg_rb_head nhg_head;
+
+static int sharp_nhg_compare_func(const struct sharp_nhg *a,
+				  const struct sharp_nhg *b)
+{
+	return strncmp(a->name, b->name, strlen(a->name));
+}
+
+DECLARE_RBTREE_UNIQ(sharp_nhg_rb, struct sharp_nhg, mylistitem,
+		    sharp_nhg_compare_func);
+
+static void sharp_nhgroup_add_cb(const char *name)
+{
+	struct sharp_nhg *snhg;
+
+	snhg = XCALLOC(MTYPE_NHG, sizeof(*snhg));
+	snhg->id = sharp_get_next_nhid();
+	strncpy(snhg->name, name, sizeof(snhg->name));
+
+	sharp_nhg_rb_add(&nhg_head, snhg);
+	return;
+}
+
+static void sharp_nhgroup_add_nexthop_cb(const struct nexthop_group_cmd *nhgc,
+					 const struct nexthop *nhop)
+{
+	struct sharp_nhg lookup;
+	struct sharp_nhg *snhg;
+
+	strncpy(lookup.name, nhgc->name, sizeof(lookup.name));
+	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
+
+	nhg_add(snhg->id, &nhgc->nhg);
+	return;
+}
+
+static void sharp_nhgroup_del_nexthop_cb(const struct nexthop_group_cmd *nhgc,
+					 const struct nexthop *nhop)
+{
+	struct sharp_nhg lookup;
+	struct sharp_nhg *snhg;
+
+	strncpy(lookup.name, nhgc->name, sizeof(lookup.name));
+	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
+
+	nhg_add(snhg->id, &nhgc->nhg);
+	return;
+}
+
+static void sharp_nhgroup_delete_cb(const char *name)
+{
+	struct sharp_nhg lookup;
+	struct sharp_nhg *snhg;
+
+	strncpy(lookup.name, name, sizeof(lookup.name));
+	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
+	if (!snhg)
+		return;
+
+	nhg_del(snhg->id);
+	sharp_nhg_rb_del(&nhg_head, snhg);
+	XFREE(MTYPE_NHG, snhg);
+	return;
+}
+
+uint32_t sharp_nhgroup_get_id(const char *name)
+{
+	struct sharp_nhg lookup;
+	struct sharp_nhg *snhg;
+
+	strncpy(lookup.name, name, sizeof(lookup.name));
+	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
+	if (!snhg)
+		return 0;
+
+	return snhg->id;
+}
+
+void sharp_nhgroup_init(void)
+{
+	sharp_nhg_rb_init(&nhg_head);
+	nhg_id = zclient_get_nhg_start(ZEBRA_ROUTE_SHARP);
+
+	nexthop_group_init(sharp_nhgroup_add_cb, sharp_nhgroup_add_nexthop_cb,
+			   sharp_nhgroup_del_nexthop_cb,
+			   sharp_nhgroup_delete_cb);
 }

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -133,11 +133,15 @@ static void sharp_nhgroup_add_nexthop_cb(const struct nexthop_group_cmd *nhgc,
 {
 	struct sharp_nhg lookup;
 	struct sharp_nhg *snhg;
+	struct nexthop_group_cmd *bnhgc = NULL;
 
 	strlcpy(lookup.name, nhgc->name, sizeof(lookup.name));
 	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
 
-	nhg_add(snhg->id, &nhgc->nhg);
+	if (nhgc->backup_list_name[0])
+		bnhgc = nhgc_find(nhgc->backup_list_name);
+
+	nhg_add(snhg->id, &nhgc->nhg, (bnhgc ? &bnhgc->nhg : NULL));
 }
 
 static void sharp_nhgroup_del_nexthop_cb(const struct nexthop_group_cmd *nhgc,
@@ -145,11 +149,15 @@ static void sharp_nhgroup_del_nexthop_cb(const struct nexthop_group_cmd *nhgc,
 {
 	struct sharp_nhg lookup;
 	struct sharp_nhg *snhg;
+	struct nexthop_group_cmd *bnhgc = NULL;
 
 	strlcpy(lookup.name, nhgc->name, sizeof(lookup.name));
 	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
 
-	nhg_add(snhg->id, &nhgc->nhg);
+	if (nhgc->backup_list_name[0])
+		bnhgc = nhgc_find(nhgc->backup_list_name);
+
+	nhg_add(snhg->id, &nhgc->nhg, (bnhgc ? &bnhgc->nhg : NULL));
 }
 
 static void sharp_nhgroup_delete_cb(const char *name)

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -78,8 +78,6 @@ struct sharp_nhg {
 	uint32_t id;
 
 	char name[256];
-
-	bool installable;
 };
 
 static uint32_t nhg_id;
@@ -122,9 +120,7 @@ static void sharp_nhgroup_add_nexthop_cb(const struct nexthop_group_cmd *nhgc,
 	strncpy(lookup.name, nhgc->name, sizeof(lookup.name));
 	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
 
-	if (snhg->installable)
-		nhg_add(snhg->id, &nhgc->nhg);
-
+	nhg_add(snhg->id, &nhgc->nhg);
 	return;
 }
 
@@ -137,9 +133,7 @@ static void sharp_nhgroup_del_nexthop_cb(const struct nexthop_group_cmd *nhgc,
 	strncpy(lookup.name, nhgc->name, sizeof(lookup.name));
 	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
 
-	if (snhg->installable)
-		nhg_add(snhg->id, &nhgc->nhg);
-
+	nhg_add(snhg->id, &nhgc->nhg);
 	return;
 }
 
@@ -153,31 +147,9 @@ static void sharp_nhgroup_delete_cb(const char *name)
 	if (!snhg)
 		return;
 
-	if (snhg->installable)
-		nhg_del(snhg->id);
-
+	nhg_del(snhg->id);
 	sharp_nhg_rb_del(&nhg_head, snhg);
 	XFREE(MTYPE_NHG, snhg);
-	return;
-}
-
-static void sharp_nhgroup_installable_cb(const struct nexthop_group_cmd *nhgc)
-{
-	struct sharp_nhg lookup;
-	struct sharp_nhg *snhg;
-
-	strncpy(lookup.name, nhgc->name, sizeof(lookup.name));
-	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
-	if (!snhg)
-		return;
-
-	snhg->installable = nhgc->installable;
-
-	if (snhg->installable)
-		nhg_add(snhg->id, &nhgc->nhg);
-	else
-		nhg_del(snhg->id);
-
 	return;
 }
 
@@ -191,9 +163,6 @@ uint32_t sharp_nhgroup_get_id(const char *name)
 	if (!snhg)
 		return 0;
 
-	if (!snhg->installable)
-		return 0;
-
 	return snhg->id;
 }
 
@@ -204,6 +173,5 @@ void sharp_nhgroup_init(void)
 
 	nexthop_group_init(sharp_nhgroup_add_cb, sharp_nhgroup_add_nexthop_cb,
 			   sharp_nhgroup_del_nexthop_cb,
-			   sharp_nhgroup_delete_cb,
-			   sharp_nhgroup_installable_cb);
+			   sharp_nhgroup_delete_cb);
 }

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -84,7 +84,7 @@ static uint32_t nhg_id;
 
 static uint32_t sharp_get_next_nhid(void)
 {
-	zlog_debug("Id assigned: %u", nhg_id + 1);
+	zlog_debug("Id assigned: %u", nhg_id);
 	return nhg_id++;
 }
 

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -109,7 +109,7 @@ static struct sharp_nhg *sharp_nhgroup_find_id(uint32_t id)
 	 * to sharpd with another RB tree for just IDs
 	 */
 
-	frr_each(sharp_nhg_rb, &nhg_head, lookup) {
+	frr_each (sharp_nhg_rb, &nhg_head, lookup) {
 		if (lookup->id == id)
 			return lookup;
 	}

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -123,10 +123,9 @@ static void sharp_nhgroup_add_cb(const char *name)
 
 	snhg = XCALLOC(MTYPE_NHG, sizeof(*snhg));
 	snhg->id = sharp_get_next_nhid();
-	strncpy(snhg->name, name, sizeof(snhg->name));
+	strlcpy(snhg->name, name, sizeof(snhg->name));
 
 	sharp_nhg_rb_add(&nhg_head, snhg);
-	return;
 }
 
 static void sharp_nhgroup_add_nexthop_cb(const struct nexthop_group_cmd *nhgc,
@@ -135,11 +134,10 @@ static void sharp_nhgroup_add_nexthop_cb(const struct nexthop_group_cmd *nhgc,
 	struct sharp_nhg lookup;
 	struct sharp_nhg *snhg;
 
-	strncpy(lookup.name, nhgc->name, sizeof(lookup.name));
+	strlcpy(lookup.name, nhgc->name, sizeof(lookup.name));
 	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
 
 	nhg_add(snhg->id, &nhgc->nhg);
-	return;
 }
 
 static void sharp_nhgroup_del_nexthop_cb(const struct nexthop_group_cmd *nhgc,
@@ -148,11 +146,10 @@ static void sharp_nhgroup_del_nexthop_cb(const struct nexthop_group_cmd *nhgc,
 	struct sharp_nhg lookup;
 	struct sharp_nhg *snhg;
 
-	strncpy(lookup.name, nhgc->name, sizeof(lookup.name));
+	strlcpy(lookup.name, nhgc->name, sizeof(lookup.name));
 	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
 
 	nhg_add(snhg->id, &nhgc->nhg);
-	return;
 }
 
 static void sharp_nhgroup_delete_cb(const char *name)
@@ -160,7 +157,7 @@ static void sharp_nhgroup_delete_cb(const char *name)
 	struct sharp_nhg lookup;
 	struct sharp_nhg *snhg;
 
-	strncpy(lookup.name, name, sizeof(lookup.name));
+	strlcpy(lookup.name, name, sizeof(lookup.name));
 	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
 	if (!snhg)
 		return;
@@ -168,7 +165,6 @@ static void sharp_nhgroup_delete_cb(const char *name)
 	nhg_del(snhg->id);
 	sharp_nhg_rb_del(&nhg_head, snhg);
 	XFREE(MTYPE_NHG, snhg);
-	return;
 }
 
 uint32_t sharp_nhgroup_get_id(const char *name)
@@ -176,7 +172,7 @@ uint32_t sharp_nhgroup_get_id(const char *name)
 	struct sharp_nhg lookup;
 	struct sharp_nhg *snhg;
 
-	strncpy(lookup.name, name, sizeof(lookup.name));
+	strlcpy(lookup.name, name, sizeof(lookup.name));
 	snhg = sharp_nhg_rb_find(&nhg_head, &lookup);
 	if (!snhg)
 		return 0;

--- a/sharpd/sharp_nht.h
+++ b/sharpd/sharp_nht.h
@@ -37,5 +37,8 @@ extern struct sharp_nh_tracker *sharp_nh_tracker_get(struct prefix *p);
 extern void sharp_nh_tracker_dump(struct vty *vty);
 
 extern uint32_t sharp_nhgroup_get_id(const char *name);
+extern void sharp_nhgroup_id_set_installed(uint32_t id, bool installed);
+extern bool sharp_nhgroup_id_is_installed(uint32_t id);
+
 extern void sharp_nhgroup_init(void);
 #endif

--- a/sharpd/sharp_nht.h
+++ b/sharpd/sharp_nht.h
@@ -35,4 +35,7 @@ struct sharp_nh_tracker {
 extern struct sharp_nh_tracker *sharp_nh_tracker_get(struct prefix *p);
 
 extern void sharp_nh_tracker_dump(struct vty *vty);
+
+extern uint32_t sharp_nhgroup_get_id(const char *name);
+extern void sharp_nhgroup_init(void);
 #endif

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -299,9 +299,9 @@ DEFPY (install_routes,
 	sg.r.inst = instance;
 	sg.r.vrf_id = vrf->vrf_id;
 	rts = routes;
-	sharp_install_routes_helper(&prefix, sg.r.vrf_id, sg.r.inst,
-				    nhgid, &sg.r.nhop_group,
-				    &sg.r.backup_nhop_group, rts);
+	sharp_install_routes_helper(&prefix, sg.r.vrf_id, sg.r.inst, nhgid,
+				    &sg.r.nhop_group, &sg.r.backup_nhop_group,
+				    rts);
 
 	return CMD_SUCCESS;
 }

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -192,6 +192,7 @@ DEFPY (install_routes,
 	struct vrf *vrf;
 	struct prefix prefix;
 	uint32_t rts;
+	uint32_t nhgid = 0;
 
 	sg.r.total_routes = routes;
 	sg.r.installed_routes = 0;
@@ -244,6 +245,8 @@ DEFPY (install_routes,
 			return CMD_WARNING;
 		}
 
+		nhgid = sharp_nhgroup_get_id(nexthop_group);
+		sg.r.nhgid = nhgid;
 		sg.r.nhop_group.nexthop = nhgc->nhg.nexthop;
 
 		/* Use group's backup nexthop info if present */
@@ -297,8 +300,8 @@ DEFPY (install_routes,
 	sg.r.vrf_id = vrf->vrf_id;
 	rts = routes;
 	sharp_install_routes_helper(&prefix, sg.r.vrf_id, sg.r.inst,
-				    &sg.r.nhop_group, &sg.r.backup_nhop_group,
-				    rts);
+				    nhgid, &sg.r.nhop_group,
+				    &sg.r.backup_nhop_group, rts);
 
 	return CMD_SUCCESS;
 }

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -288,8 +288,7 @@ static void handle_repeated(bool installed)
 	if (!installed) {
 		sg.r.installed_routes = 0;
 		sharp_install_routes_helper(&p, sg.r.vrf_id, sg.r.inst,
-					    sg.r.nhgid,
-					    &sg.r.nhop_group,
+					    sg.r.nhgid, &sg.r.nhop_group,
 					    &sg.r.backup_nhop_group,
 					    sg.r.total_routes);
 	}
@@ -383,9 +382,8 @@ void nhg_del(uint32_t id)
 	zclient_send_message(zclient);
 }
 
-void route_add(const struct prefix *p, vrf_id_t vrf_id,
-	       uint8_t instance, uint32_t nhgid,
-	       const struct nexthop_group *nhg,
+void route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
+	       uint32_t nhgid, const struct nexthop_group *nhg,
 	       const struct nexthop_group *backup_nhg)
 {
 	struct zapi_route api;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -217,7 +217,7 @@ int sharp_install_lsps_helper(bool install_p, bool update_p,
 }
 
 void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
-				 uint8_t instance,
+				 uint8_t instance, uint32_t nhgid,
 				 const struct nexthop_group *nhg,
 				 const struct nexthop_group *backup_nhg,
 				 uint32_t routes)
@@ -239,7 +239,7 @@ void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 
 	monotime(&sg.r.t_start);
 	for (i = 0; i < routes; i++) {
-		route_add(p, vrf_id, (uint8_t)instance, nhg, backup_nhg);
+		route_add(p, vrf_id, (uint8_t)instance, nhgid, nhg, backup_nhg);
 		if (v4)
 			p->u.prefix4.s_addr = htonl(++temp);
 		else
@@ -288,6 +288,7 @@ static void handle_repeated(bool installed)
 	if (!installed) {
 		sg.r.installed_routes = 0;
 		sharp_install_routes_helper(&p, sg.r.vrf_id, sg.r.inst,
+					    sg.r.nhgid,
 					    &sg.r.nhop_group,
 					    &sg.r.backup_nhop_group,
 					    sg.r.total_routes);
@@ -357,8 +358,34 @@ void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label)
 	zclient_send_vrf_label(zclient, vrf_id, afi, label, ZEBRA_LSP_SHARP);
 }
 
+void nhg_add(uint32_t id, const struct nexthop_group *nhg)
+{
+	struct zapi_nexthop nh_array[MULTIPATH_NUM];
+	struct zapi_nexthop *api_nh;
+	uint16_t nexthop_num = 0;
+	struct nexthop *nh;
+
+	for (ALL_NEXTHOPS_PTR(nhg, nh)) {
+		api_nh = &nh_array[nexthop_num];
+
+		zapi_nexthop_from_nexthop(api_nh, nh);
+		nexthop_num++;
+	}
+
+	zclient_nhg_add(zclient, id, nexthop_num, nh_array);
+
+	zclient_send_message(zclient);
+}
+
+void nhg_del(uint32_t id)
+{
+	zclient_nhg_del(zclient, id);
+	zclient_send_message(zclient);
+}
+
 void route_add(const struct prefix *p, vrf_id_t vrf_id,
-	       uint8_t instance, const struct nexthop_group *nhg,
+	       uint8_t instance, uint32_t nhgid,
+	       const struct nexthop_group *nhg,
 	       const struct nexthop_group *backup_nhg)
 {
 	struct zapi_route api;
@@ -376,14 +403,19 @@ void route_add(const struct prefix *p, vrf_id_t vrf_id,
 	SET_FLAG(api.flags, ZEBRA_FLAG_ALLOW_RECURSION);
 	SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
 
-	for (ALL_NEXTHOPS_PTR(nhg, nh)) {
-		api_nh = &api.nexthops[i];
+	if (nhgid) {
+		SET_FLAG(api.message, ZAPI_MESSAGE_NHG);
+		api.nhgid = nhgid;
+	} else {
+		for (ALL_NEXTHOPS_PTR(nhg, nh)) {
+			api_nh = &api.nexthops[i];
 
-		zapi_nexthop_from_nexthop(api_nh, nh);
+			zapi_nexthop_from_nexthop(api_nh, nh);
 
-		i++;
+			i++;
+		}
+		api.nexthop_num = i;
 	}
-	api.nexthop_num = i;
 
 	/* Include backup nexthops, if present */
 	if (backup_nhg && backup_nhg->nexthop) {

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -365,6 +365,13 @@ void nhg_add(uint32_t id, const struct nexthop_group *nhg)
 	struct nexthop *nh;
 
 	for (ALL_NEXTHOPS_PTR(nhg, nh)) {
+		if (nexthop_num >= MULTIPATH_NUM) {
+			zlog_warn(
+				"%s: number of nexthops greater than max multipath size, truncating",
+				__func__);
+			break;
+		}
+
 		api_nh = &nh_array[nexthop_num];
 
 		zapi_nexthop_from_nexthop(api_nh, nh);

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -29,7 +29,8 @@ int sharp_zclient_create(uint32_t session_id);
 int sharp_zclient_delete(uint32_t session_id);
 
 extern void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label);
-extern void nhg_add(uint32_t id, const struct nexthop_group *nhg);
+extern void nhg_add(uint32_t id, const struct nexthop_group *nhg,
+		    const struct nexthop_group *backup_nhg);
 extern void nhg_del(uint32_t id);
 extern void route_add(const struct prefix *p, vrf_id_t, uint8_t instance,
 		      uint32_t nhgid, const struct nexthop_group *nhg,

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -29,15 +29,17 @@ int sharp_zclient_create(uint32_t session_id);
 int sharp_zclient_delete(uint32_t session_id);
 
 extern void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label);
+extern void nhg_add(uint32_t id, const struct nexthop_group *nhg);
+extern void nhg_del(uint32_t id);
 extern void route_add(const struct prefix *p, vrf_id_t, uint8_t instance,
-		      const struct nexthop_group *nhg,
+		      uint32_t nhgid, const struct nexthop_group *nhg,
 		      const struct nexthop_group *backup_nhg);
 extern void route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance);
 extern void sharp_zebra_nexthop_watch(struct prefix *p, vrf_id_t vrf_id,
 				      bool import, bool watch, bool connected);
 
 extern void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
-					uint8_t instance,
+					uint8_t instance, uint32_t nhgid,
 					const struct nexthop_group *nhg,
 					const struct nexthop_group *backup_nhg,
 					uint32_t routes);

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -333,6 +333,10 @@ extern void route_entry_copy_nexthops(struct route_entry *re,
 int route_entry_update_nhe(struct route_entry *re,
 			   struct nhg_hash_entry *new_nhghe);
 
+/* NHG replace has happend, we have to update route_entry pointers to new one */
+void rib_handle_nhg_replace(struct nhg_hash_entry *old,
+			    struct nhg_hash_entry *new);
+
 #define route_entry_dump(prefix, src, re) _route_entry_dump(__func__, prefix, src, re)
 extern void _route_entry_dump(const char *func, union prefixconstptr pp,
 			      union prefixconstptr src_pp,

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2100,16 +2100,35 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 	mpls_lse_t out_lse[MPLS_MAX_LABELS];
 	char label_buf[256];
 	int num_labels = 0;
+	uint32_t id = dplane_ctx_get_nhe_id(ctx);
+	int type = dplane_ctx_get_nhe_type(ctx);
+
+	if (!id) {
+		flog_err(
+			EC_ZEBRA_NHG_FIB_UPDATE,
+			"Failed trying to update a nexthop group in the kernel that does not have an ID");
+		return -1;
+	}
 
 	/*
 	 * Nothing to do if the kernel doesn't support nexthop objects or
 	 * we dont want to install this type of NHG
 	 */
-	if (!kernel_nexthops_supported()
-	    || (proto_nexthops_only()
-		&& !is_proto_nhg(dplane_ctx_get_nhe_id(ctx),
-				 dplane_ctx_get_nhe_type(ctx))))
+	if (!kernel_nexthops_supported()) {
+		if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_NHG)
+			zlog_debug(
+				"%s: nhg_id %u (%s): kernel nexthops not supported, ignoring",
+				__func__, id, zebra_route_string(type));
 		return 0;
+	}
+
+	if (proto_nexthops_only() && !is_proto_nhg(id, type)) {
+		if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_NHG)
+			zlog_debug(
+				"%s: nhg_id %u (%s): proto-based nexthops only, ignoring",
+				__func__, id, zebra_route_string(type));
+		return 0;
+	}
 
 	label_buf[0] = '\0';
 
@@ -2129,15 +2148,6 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 
 	req->nhm.nh_family = AF_UNSPEC;
 	/* TODO: Scope? */
-
-	uint32_t id = dplane_ctx_get_nhe_id(ctx);
-
-	if (!id) {
-		flog_err(
-			EC_ZEBRA_NHG_FIB_UPDATE,
-			"Failed trying to update a nexthop group in the kernel that does not have an ID");
-		return -1;
-	}
 
 	if (!nl_attr_put32(&req->n, buflen, NHA_ID, id))
 		return 0;
@@ -2259,8 +2269,7 @@ nexthop_done:
 					   nh->vrf_id, label_buf);
 }
 
-		req->nhm.nh_protocol =
-			zebra2proto(dplane_ctx_get_nhe_type(ctx));
+		req->nhm.nh_protocol = zebra2proto(type);
 
 	} else if (cmd != RTM_DELNEXTHOP) {
 		flog_err(

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2269,7 +2269,7 @@ nexthop_done:
 					   nh->vrf_id, label_buf);
 }
 
-		req->nhm.nh_protocol = zebra2proto(type);
+req->nhm.nh_protocol = zebra2proto(type);
 
 	} else if (cmd != RTM_DELNEXTHOP) {
 		flog_err(

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -144,7 +144,7 @@ static bool is_proto_nhg(uint32_t id, int type)
 		return false;
 	}
 
-	if (id >= zclient_get_nhg_lower_bound())
+	if (id >= ZEBRA_NHG_PROTO_LOWER)
 		return true;
 
 	return false;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1817,9 +1817,9 @@ static void zread_nhg_add(ZAPI_HANDLER_ARGS)
 	 *
 	 * Resolution is going to need some more work.
 	 */
-	if (nhe) {
+	if (nhe)
 		nhg_notify(proto, client->instance, id, ZAPI_NHG_INSTALLED);
-	} else
+	else
 		nhg_notify(proto, client->instance, id, ZAPI_NHG_FAIL_INSTALL);
 
 	return;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1746,7 +1746,8 @@ static void zread_nhg_del(ZAPI_HANDLER_ARGS)
 	nhe = zebra_nhg_proto_del(id);
 
 	if (nhe) {
-		zebra_nhg_uninstall_kernel(nhe);
+		/* TODO: just decrement for now */
+		zebra_nhg_decrement_ref(nhe);
 		nhg_notify(proto, client->instance, id, ZAPI_NHG_REMOVED);
 	} else
 		nhg_notify(proto, client->instance, id, ZAPI_NHG_REMOVE_FAIL);
@@ -1818,6 +1819,7 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 	 * Resolution is going to need some more work.
 	 */
 	if (nhe) {
+		zebra_nhg_increment_ref(nhe);
 		zebra_nhg_install_kernel(nhe);
 		nhg_notify(proto, client->instance, id, ZAPI_NHG_INSTALLED);
 	} else

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1578,23 +1578,145 @@ done:
 	return nexthop;
 }
 
+static bool zapi_read_nexthops(struct zserv *client, struct zapi_route *api,
+			       struct route_entry *re,
+			       struct nexthop_group **png,
+			       struct nhg_backup_info **pbnhg)
+{
+	struct nexthop_group *ng = NULL;
+	struct nhg_backup_info *bnhg = NULL;
+	uint16_t nexthop_num, i;;
+	struct zapi_nexthop *nhops;
+	struct nexthop *last_nh = NULL;
+
+	assert(!(png && pbnhg));
+
+	if (png) {
+		*png = ng = nexthop_group_new();
+		nexthop_num = api->nexthop_num;
+		nhops = api->nexthops;
+	}
+
+	if (pbnhg && api->backup_nexthop_num > 0) {
+		if (IS_ZEBRA_DEBUG_RECV)
+			zlog_debug("%s: adding %d backup nexthops",
+				   __func__, api->backup_nexthop_num);
+
+		nexthop_num = api->backup_nexthop_num;
+		*pbnhg = bnhg = zebra_nhg_backup_alloc();
+		nhops = api->backup_nexthops;
+	}
+
+	/*
+	 * TBD should _all_ of the nexthop add operations use
+	 * api_nh->vrf_id instead of re->vrf_id ? I only changed
+	 * for cases NEXTHOP_TYPE_IPV4 and NEXTHOP_TYPE_IPV6.
+	 */
+	for (i = 0; i < nexthop_num; i++) {
+		struct nexthop *nexthop;
+		enum lsp_types_t label_type;
+		char nhbuf[NEXTHOP_STRLEN];
+		char labelbuf[MPLS_LABEL_STRLEN];
+		struct zapi_nexthop *api_nh = &nhops[i];
+
+		/* Convert zapi nexthop */
+		nexthop = nexthop_from_zapi(re, api_nh, api);
+		if (!nexthop) {
+			flog_warn(
+				EC_ZEBRA_NEXTHOP_CREATION_FAILED,
+				"%s: Nexthops Specified: %u(%u) but we failed to properly create one",
+				__func__, nexthop_num, i);
+			if (ng)
+				nexthop_group_delete(&ng);
+			if (bnhg)
+				zebra_nhg_backup_free(&bnhg);
+			return false;
+		}
+
+		if (bnhg && CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP)) {
+			if (IS_ZEBRA_DEBUG_RECV) {
+				nexthop2str(nexthop, nhbuf, sizeof(nhbuf));
+				zlog_debug("%s: backup nh %s with BACKUP flag!",
+					   __func__, nhbuf);
+			}
+			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP);
+			nexthop->backup_num = 0;
+		}
+
+		if (CHECK_FLAG(api->message, ZAPI_MESSAGE_SRTE)) {
+			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_SRTE);
+			nexthop->srte_color = api_nh->srte_color;
+		}
+
+		/* MPLS labels for BGP-LU or Segment Routing */
+		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL)
+		    && api_nh->type != NEXTHOP_TYPE_IFINDEX
+		    && api_nh->type != NEXTHOP_TYPE_BLACKHOLE
+		    && api_nh->label_num > 0) {
+
+			label_type = lsp_type_from_re_type(client->proto);
+			nexthop_add_labels(nexthop, label_type,
+					   api_nh->label_num,
+					   &api_nh->labels[0]);
+		}
+
+		if (IS_ZEBRA_DEBUG_RECV) {
+			labelbuf[0] = '\0';
+			nhbuf[0] = '\0';
+
+			nexthop2str(nexthop, nhbuf, sizeof(nhbuf));
+
+			if (nexthop->nh_label &&
+			    nexthop->nh_label->num_labels > 0) {
+				mpls_label2str(nexthop->nh_label->num_labels,
+					       nexthop->nh_label->label,
+					       labelbuf, sizeof(labelbuf),
+					       false);
+			}
+
+			zlog_debug("%s: nh=%s, vrf_id=%d %s",
+				   __func__, nhbuf, api_nh->vrf_id, labelbuf);
+		}
+
+		if (png) {
+			/* Add new nexthop to temporary list. This list is
+			 * canonicalized - sorted - so that it can be hashed later
+			 * in route processing. We expect that the sender has sent
+			 * the list sorted, and the zapi client api attempts to enforce
+			 * that, so this should be inexpensive - but it is necessary
+			 * to support shared nexthop-groups.
+			 */
+			nexthop_group_add_sorted(ng, nexthop);
+		}
+		if (bnhg) {
+			/* Note that the order of the backup nexthops is significant,
+			 * so we don't sort this list as we do the primary nexthops,
+			 * we just append.
+			 */
+			if (last_nh)
+				NEXTHOP_APPEND(last_nh, nexthop);
+			else
+				bnhg->nhe->nhg.nexthop = nexthop;
+
+			last_nh = nexthop;
+		}
+	}
+
+	return true;
+}
+
 static void zread_route_add(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	struct zapi_route api;
-	struct zapi_nexthop *api_nh;
 	afi_t afi;
 	struct prefix_ipv6 *src_p = NULL;
 	struct route_entry *re;
-	struct nexthop *nexthop = NULL, *last_nh;
 	struct nexthop_group *ng = NULL;
 	struct nhg_backup_info *bnhg = NULL;
-	int i, ret;
+	int ret;
 	vrf_id_t vrf_id;
 	struct nhg_hash_entry nhe;
-	enum lsp_types_t label_type;
-	char nhbuf[NEXTHOP_STRLEN];
-	char labelbuf[MPLS_LABEL_STRLEN];
 
 	s = msg;
 	if (zapi_route_decode(s, &api) < 0) {
@@ -1611,7 +1733,8 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 
 		prefix2str(&api.prefix, buf_prefix, sizeof(buf_prefix));
 		zlog_debug("%s: p=(%u:%u)%s, msg flags=0x%x, flags=0x%x",
-			   __func__, vrf_id, api.tableid, buf_prefix, (int)api.message, api.flags);
+			   __func__, vrf_id, api.tableid, buf_prefix,
+			   (int)api.message, api.flags);
 	}
 
 	/* Allocate new route. */
@@ -1647,158 +1770,10 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 				zebra_route_string(client->proto), &api.prefix);
 	}
 
-	/* Use temporary list of nexthops */
-	ng = nexthop_group_new();
-
-	/*
-	 * TBD should _all_ of the nexthop add operations use
-	 * api_nh->vrf_id instead of re->vrf_id ? I only changed
-	 * for cases NEXTHOP_TYPE_IPV4 and NEXTHOP_TYPE_IPV6.
-	 */
-	for (i = 0; i < api.nexthop_num; i++) {
-		api_nh = &api.nexthops[i];
-
-		/* Convert zapi nexthop */
-		nexthop = nexthop_from_zapi(re, api_nh, &api);
-		if (!nexthop) {
-			flog_warn(
-				EC_ZEBRA_NEXTHOP_CREATION_FAILED,
-				"%s: Nexthops Specified: %d but we failed to properly create one",
-				__func__, api.nexthop_num);
-			nexthop_group_delete(&ng);
-			XFREE(MTYPE_RE, re);
-			return;
-		}
-
-		if (CHECK_FLAG(api.message, ZAPI_MESSAGE_SRTE)) {
-			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_SRTE);
-			nexthop->srte_color = api_nh->srte_color;
-		}
-
-		/* MPLS labels for BGP-LU or Segment Routing */
-		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL)
-		    && api_nh->type != NEXTHOP_TYPE_IFINDEX
-		    && api_nh->type != NEXTHOP_TYPE_BLACKHOLE
-		    && api_nh->label_num > 0) {
-
-			label_type = lsp_type_from_re_type(client->proto);
-			nexthop_add_labels(nexthop, label_type,
-					   api_nh->label_num,
-					   &api_nh->labels[0]);
-		}
-
-		if (IS_ZEBRA_DEBUG_RECV) {
-			labelbuf[0] = '\0';
-			nhbuf[0] = '\0';
-
-			nexthop2str(nexthop, nhbuf, sizeof(nhbuf));
-
-			if (nexthop->nh_label &&
-			    nexthop->nh_label->num_labels > 0) {
-				mpls_label2str(nexthop->nh_label->num_labels,
-					       nexthop->nh_label->label,
-					       labelbuf, sizeof(labelbuf),
-					       false);
-			}
-
-			zlog_debug("%s: nh=%s, vrf_id=%d %s",
-				   __func__, nhbuf, api_nh->vrf_id, labelbuf);
-		}
-
-		/* Add new nexthop to temporary list. This list is
-		 * canonicalized - sorted - so that it can be hashed later
-		 * in route processing. We expect that the sender has sent
-		 * the list sorted, and the zapi client api attempts to enforce
-		 * that, so this should be inexpensive - but it is necessary
-		 * to support shared nexthop-groups.
-		 */
-		nexthop_group_add_sorted(ng, nexthop);
-	}
-
-	/* Allocate temporary list of backup nexthops, if necessary */
-	if (api.backup_nexthop_num > 0) {
-		if (IS_ZEBRA_DEBUG_RECV)
-			zlog_debug("%s: adding %d backup nexthops",
-				   __func__, api.backup_nexthop_num);
-
-		bnhg = zebra_nhg_backup_alloc();
-		nexthop = NULL;
-		last_nh = NULL;
-	}
-
-	/* Copy backup nexthops also, if present */
-	for (i = 0; i < api.backup_nexthop_num; i++) {
-		api_nh = &api.backup_nexthops[i];
-
-		/* Convert zapi backup nexthop */
-		nexthop = nexthop_from_zapi(re, api_nh, &api);
-		if (!nexthop) {
-			flog_warn(
-				EC_ZEBRA_NEXTHOP_CREATION_FAILED,
-				"%s: Backup Nexthops Specified: %d but we failed to properly create one",
-				__func__, api.backup_nexthop_num);
-			nexthop_group_delete(&ng);
-			zebra_nhg_backup_free(&bnhg);
-			XFREE(MTYPE_RE, re);
-			return;
-		}
-
-		/* Backup nexthops can't have backups; that's not valid. */
-		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP)) {
-			if (IS_ZEBRA_DEBUG_RECV) {
-				nexthop2str(nexthop, nhbuf, sizeof(nhbuf));
-				zlog_debug("%s: backup nh %s with BACKUP flag!",
-					   __func__, nhbuf);
-			}
-			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP);
-			nexthop->backup_num = 0;
-		}
-
-		if (CHECK_FLAG(api.message, ZAPI_MESSAGE_SRTE)) {
-			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_SRTE);
-			nexthop->srte_color = api_nh->srte_color;
-		}
-
-		/* MPLS labels for BGP-LU or Segment Routing */
-		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL)
-		    && api_nh->type != NEXTHOP_TYPE_IFINDEX
-		    && api_nh->type != NEXTHOP_TYPE_BLACKHOLE
-		    && api_nh->label_num > 0) {
-
-			label_type = lsp_type_from_re_type(client->proto);
-			nexthop_add_labels(nexthop, label_type,
-					   api_nh->label_num,
-					   &api_nh->labels[0]);
-		}
-
-		if (IS_ZEBRA_DEBUG_RECV) {
-			labelbuf[0] = '\0';
-			nhbuf[0] = '\0';
-
-			nexthop2str(nexthop, nhbuf, sizeof(nhbuf));
-
-			if (nexthop->nh_label &&
-			    nexthop->nh_label->num_labels > 0) {
-				mpls_label2str(nexthop->nh_label->num_labels,
-					       nexthop->nh_label->label,
-					       labelbuf, sizeof(labelbuf),
-					       false);
-			}
-
-			zlog_debug("%s: backup nh=%s, vrf_id=%d %s",
-				   __func__, nhbuf, api_nh->vrf_id, labelbuf);
-		}
-
-		/* Note that the order of the backup nexthops is significant,
-		 * so we don't sort this list as we do the primary nexthops,
-		 * we just append.
-		 */
-		if (last_nh)
-			NEXTHOP_APPEND(last_nh, nexthop);
-		else
-			bnhg->nhe->nhg.nexthop = nexthop;
-
-		last_nh = nexthop;
+	if (!zapi_read_nexthops(client, &api, re, &ng, NULL) ||
+	    !zapi_read_nexthops(client, &api, re, NULL, &bnhg)) {
+		XFREE(MTYPE_RE, re);
+		return;
 	}
 
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_DISTANCE))

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1806,7 +1806,7 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 	 */
 
 	// TODO: Forcing AF_UNSPEC/AF_IP for now
-	nhe = zebra_nhg_proto_add(id, ZEBRA_ROUTE_BGP, nhg,
+	nhe = zebra_nhg_proto_add(id, proto, nhg,
 				  ((nhops > 1) ? AFI_UNSPEC : AFI_IP));
 
 	nexthop_group_delete(&nhg);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1825,8 +1825,6 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 	 * Resolution is going to need some more work.
 	 */
 	if (nhe) {
-		zebra_nhg_increment_ref(nhe);
-		zebra_nhg_install_kernel(nhe);
 		nhg_notify(proto, client->instance, id, ZAPI_NHG_INSTALLED);
 	} else
 		nhg_notify(proto, client->instance, id, ZAPI_NHG_FAIL_INSTALL);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1783,6 +1783,12 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 	// if (zserv_nexthop_num_warn(__func__, &p, nhops))
 	//	return;
 
+	if (nhops <= 0) {
+		flog_warn(EC_ZEBRA_NEXTHOP_CREATION_FAILED,
+			  "%s: No nexthops sent", __func__);
+		return;
+	}
+
 	for (i = 0; i < nhops; i++) {
 		struct zapi_nexthop *znh = &zapi_nexthops[i];
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1734,16 +1734,22 @@ static void zread_nhg_del(ZAPI_HANDLER_ARGS)
 	struct stream *s = msg;
 	uint32_t id;
 	uint16_t proto;
+	struct nhg_hash_entry *nhe;
 
 	STREAM_GETW(s, proto);
 	STREAM_GETL(s, id);
 
 	/*
 	 * Delete the received nhg id
-	 * id is incremented to make compiler happy right now
-	 * it should be removed in future code work.
 	 */
-	nhg_notify(proto, client->instance, id, ZAPI_NHG_REMOVED);
+
+	nhe = zebra_nhg_proto_del(id);
+
+	if (nhe) {
+		zebra_nhg_uninstall_kernel(nhe);
+		nhg_notify(proto, client->instance, id, ZAPI_NHG_REMOVED);
+	} else
+		nhg_notify(proto, client->instance, id, ZAPI_NHG_REMOVE_FAIL);
 
 	return;
 
@@ -1762,6 +1768,7 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 	struct nexthop_group *nhg = NULL;
 	struct prefix p;
 	uint16_t proto;
+	struct nhg_hash_entry *nhe;
 
 	memset(&p, 0, sizeof(p));
 
@@ -1771,8 +1778,9 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 	STREAM_GETL(s, id);
 	STREAM_GETW(s, nhops);
 
-	if (zserv_nexthop_num_warn(__func__, &p, nhops))
-		return;
+	// TODO: Can't use this without a prefix.
+	// if (zserv_nexthop_num_warn(__func__, &p, nhops))
+	//	return;
 
 	for (i = 0; i < nhops; i++) {
 		struct zapi_nexthop *znh = &zapi_nexthops[i];
@@ -1792,10 +1800,28 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 			  __func__);
 		return;
 	}
+
 	/*
 	 * Install the nhg
 	 */
-	nhg_notify(proto, client->instance, id, ZAPI_NHG_INSTALLED);
+
+	// TODO: Forcing AF_UNSPEC/AF_IP for now
+	nhe = zebra_nhg_proto_add(id, ZEBRA_ROUTE_BGP, nhg,
+				  ((nhops > 1) ? AFI_UNSPEC : AFI_IP));
+
+	nexthop_group_delete(&nhg);
+
+	/*
+	 * TODO:
+	 * Assume fully resolved for now and install.
+	 *
+	 * Resolution is going to need some more work.
+	 */
+	if (nhe) {
+		zebra_nhg_install_kernel(nhe);
+		nhg_notify(proto, client->instance, id, ZAPI_NHG_INSTALLED);
+	} else
+		nhg_notify(proto, client->instance, id, ZAPI_NHG_FAIL_INSTALL);
 
 	return;
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -712,6 +712,34 @@ static int zsend_ipv4_nexthop_lookup_mrib(struct zserv *client,
 	return zserv_send_message(client, s);
 }
 
+static int nhg_notify(uint16_t type, uint16_t instance, uint16_t id,
+		      enum zapi_nhg_notify_owner note)
+{
+	struct zserv *client;
+	struct stream *s;
+
+	client = zserv_find_client(type, instance);
+	if (!client) {
+		if (IS_ZEBRA_DEBUG_PACKET) {
+			zlog_debug("Not Notifying Owner: %u(%u) about %u(%d)",
+				   type, instance, id, note);
+		}
+		return 0;
+	}
+
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	stream_reset(s);
+
+	zclient_create_header(s, ZEBRA_NHG_NOTIFY_OWNER, VRF_DEFAULT);
+
+	stream_putw(s, id);
+	stream_put(s, &note, sizeof(note));
+
+	stream_putw_at(s, 0, stream_get_endp(s));
+
+	return zserv_send_message(client, s);
+}
+
 /*
  * Common utility send route notification, called from a path using a
  * route_entry and from a path using a dataplane context.
@@ -1431,9 +1459,9 @@ bool zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 /*
  * Create a new nexthop based on a zapi nexthop.
  */
-static struct nexthop *nexthop_from_zapi(struct route_entry *re,
-					 const struct zapi_nexthop *api_nh,
-					 const struct zapi_route *api)
+static struct nexthop *nexthop_from_zapi(const struct zapi_nexthop *api_nh,
+					 uint32_t flags, struct prefix *p,
+					 uint16_t backup_nexthop_num)
 {
 	struct nexthop *nexthop = NULL;
 	struct ipaddr vtep_ip;
@@ -1471,14 +1499,14 @@ static struct nexthop *nexthop_from_zapi(struct route_entry *re,
 		/* Special handling for IPv4 routes sourced from EVPN:
 		 * the nexthop and associated MAC need to be installed.
 		 */
-		if (CHECK_FLAG(api->flags, ZEBRA_FLAG_EVPN_ROUTE)) {
+		if (CHECK_FLAG(flags, ZEBRA_FLAG_EVPN_ROUTE)) {
 			memset(&vtep_ip, 0, sizeof(struct ipaddr));
 			vtep_ip.ipa_type = IPADDR_V4;
 			memcpy(&(vtep_ip.ipaddr_v4), &(api_nh->gate.ipv4),
 			       sizeof(struct in_addr));
 			zebra_vxlan_evpn_vrf_route_add(
 				api_nh->vrf_id, &api_nh->rmac,
-				&vtep_ip, &api->prefix);
+				&vtep_ip, p);
 		}
 		break;
 	case NEXTHOP_TYPE_IPV6:
@@ -1505,14 +1533,14 @@ static struct nexthop *nexthop_from_zapi(struct route_entry *re,
 		/* Special handling for IPv6 routes sourced from EVPN:
 		 * the nexthop and associated MAC need to be installed.
 		 */
-		if (CHECK_FLAG(api->flags, ZEBRA_FLAG_EVPN_ROUTE)) {
+		if (CHECK_FLAG(flags, ZEBRA_FLAG_EVPN_ROUTE)) {
 			memset(&vtep_ip, 0, sizeof(struct ipaddr));
 			vtep_ip.ipa_type = IPADDR_V6;
 			memcpy(&vtep_ip.ipaddr_v6, &(api_nh->gate.ipv6),
 			       sizeof(struct in6_addr));
 			zebra_vxlan_evpn_vrf_route_add(
 				api_nh->vrf_id, &api_nh->rmac,
-				&vtep_ip, &api->prefix);
+				&vtep_ip, p);
 		}
 		break;
 	case NEXTHOP_TYPE_BLACKHOLE:
@@ -1560,7 +1588,7 @@ static struct nexthop *nexthop_from_zapi(struct route_entry *re,
 
 		for (i = 0; i < api_nh->backup_num; i++) {
 			/* Validate backup index */
-			if (api_nh->backup_idx[i] < api->backup_nexthop_num) {
+			if (api_nh->backup_idx[i] < backup_nexthop_num) {
 				nexthop->backup_idx[i] = api_nh->backup_idx[i];
 			} else {
 				if (IS_ZEBRA_DEBUG_RECV || IS_ZEBRA_DEBUG_EVENT)
@@ -1578,33 +1606,29 @@ done:
 	return nexthop;
 }
 
-static bool zapi_read_nexthops(struct zserv *client, struct zapi_route *api,
-			       struct route_entry *re,
+static bool zapi_read_nexthops(struct zserv *client, struct prefix *p,
+			       struct zapi_nexthop *nhops, uint32_t flags,
+			       uint32_t message, uint16_t nexthop_num,
+			       uint16_t backup_nh_num,
 			       struct nexthop_group **png,
 			       struct nhg_backup_info **pbnhg)
 {
 	struct nexthop_group *ng = NULL;
 	struct nhg_backup_info *bnhg = NULL;
-	uint16_t nexthop_num, i;;
-	struct zapi_nexthop *nhops;
+	uint16_t i;
 	struct nexthop *last_nh = NULL;
 
 	assert(!(png && pbnhg));
 
-	if (png) {
+	if (png)
 		*png = ng = nexthop_group_new();
-		nexthop_num = api->nexthop_num;
-		nhops = api->nexthops;
-	}
 
-	if (pbnhg && api->backup_nexthop_num > 0) {
+	if (pbnhg && backup_nh_num > 0) {
 		if (IS_ZEBRA_DEBUG_RECV)
-			zlog_debug("%s: adding %d backup nexthops",
-				   __func__, api->backup_nexthop_num);
+			zlog_debug("%s: adding %d backup nexthops", __func__,
+				   backup_nh_num);
 
-		nexthop_num = api->backup_nexthop_num;
 		*pbnhg = bnhg = zebra_nhg_backup_alloc();
-		nhops = api->backup_nexthops;
 	}
 
 	/*
@@ -1620,7 +1644,7 @@ static bool zapi_read_nexthops(struct zserv *client, struct zapi_route *api,
 		struct zapi_nexthop *api_nh = &nhops[i];
 
 		/* Convert zapi nexthop */
-		nexthop = nexthop_from_zapi(re, api_nh, api);
+		nexthop = nexthop_from_zapi(api_nh, flags, p, backup_nh_num);
 		if (!nexthop) {
 			flog_warn(
 				EC_ZEBRA_NEXTHOP_CREATION_FAILED,
@@ -1643,7 +1667,7 @@ static bool zapi_read_nexthops(struct zserv *client, struct zapi_route *api,
 			nexthop->backup_num = 0;
 		}
 
-		if (CHECK_FLAG(api->message, ZAPI_MESSAGE_SRTE)) {
+		if (CHECK_FLAG(message, ZAPI_MESSAGE_SRTE)) {
 			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_SRTE);
 			nexthop->srte_color = api_nh->srte_color;
 		}
@@ -1703,6 +1727,83 @@ static bool zapi_read_nexthops(struct zserv *client, struct zapi_route *api,
 	}
 
 	return true;
+}
+
+static void zread_nhg_del(ZAPI_HANDLER_ARGS)
+{
+	struct stream *s = msg;
+	uint32_t id;
+	uint16_t proto;
+
+	STREAM_GETW(s, proto);
+	STREAM_GETL(s, id);
+
+	/*
+	 * Delete the received nhg id
+	 * id is incremented to make compiler happy right now
+	 * it should be removed in future code work.
+	 */
+	nhg_notify(proto, client->instance, id, ZAPI_NHG_REMOVED);
+
+	return;
+
+stream_failure:
+	flog_warn(EC_ZEBRA_NEXTHOP_CREATION_FAILED,
+		  "%s: Nexthop group deletion failed", __func__);
+	return;
+}
+
+static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
+{
+	struct stream *s;
+	uint32_t id;
+	size_t nhops, i;
+	struct zapi_nexthop zapi_nexthops[MULTIPATH_NUM];
+	struct nexthop_group *nhg = NULL;
+	struct prefix p;
+	uint16_t proto;
+
+	memset(&p, 0, sizeof(p));
+
+	s = msg;
+
+	STREAM_GETW(s, proto);
+	STREAM_GETL(s, id);
+	STREAM_GETW(s, nhops);
+
+	if (zserv_nexthop_num_warn(__func__, &p, nhops))
+		return;
+
+	for (i = 0; i < nhops; i++) {
+		struct zapi_nexthop *znh = &zapi_nexthops[i];
+
+		if (zapi_nexthop_decode(s, znh, 0, 0) != 0) {
+			flog_warn(EC_ZEBRA_NEXTHOP_CREATION_FAILED,
+				  "%s: Nexthop creation failed",
+				  __func__);
+			return;
+		}
+	}
+
+	if (!zapi_read_nexthops(client, &p, zapi_nexthops, 0, 0, nhops, 0, &nhg,
+				NULL)) {
+		flog_warn(EC_ZEBRA_NEXTHOP_CREATION_FAILED,
+			  "%s: Nexthop Group Creation failed",
+			  __func__);
+		return;
+	}
+	/*
+	 * Install the nhg
+	 */
+	nhg_notify(proto, client->instance, id, ZAPI_NHG_INSTALLED);
+
+	return;
+
+stream_failure:
+	flog_warn(EC_ZEBRA_NEXTHOP_CREATION_FAILED,
+		  "%s: Nexthop Group creation failed with some sort of stream read failure",
+		  __func__);
+	return;
 }
 
 static void zread_route_add(ZAPI_HANDLER_ARGS)
@@ -1770,8 +1871,13 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 				zebra_route_string(client->proto), &api.prefix);
 	}
 
-	if (!zapi_read_nexthops(client, &api, re, &ng, NULL) ||
-	    !zapi_read_nexthops(client, &api, re, NULL, &bnhg)) {
+	if (!zapi_read_nexthops(client, &api.prefix, api.nexthops, api.flags,
+				api.message, api.nexthop_num,
+				api.backup_nexthop_num, &ng, NULL)
+	    || !zapi_read_nexthops(client, &api.prefix, api.backup_nexthops,
+				   api.flags, api.message,
+				   api.backup_nexthop_num,
+				   api.backup_nexthop_num, NULL, &bnhg)) {
 		XFREE(MTYPE_RE, re);
 		return;
 	}
@@ -3095,7 +3201,10 @@ void (*const zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_MLAG_CLIENT_UNREGISTER] = zebra_mlag_client_unregister,
 	[ZEBRA_MLAG_FORWARD_MSG] = zebra_mlag_forward_client_msg,
 	[ZEBRA_CLIENT_CAPABILITIES] = zread_client_capabilities,
-	[ZEBRA_NEIGH_DISCOVER] = zread_neigh_discover};
+	[ZEBRA_NEIGH_DISCOVER] = zread_neigh_discover,
+	[ZEBRA_NHG_ADD] = zread_nhg_reader,
+	[ZEBRA_NHG_DEL] = zread_nhg_del,
+};
 
 /*
  * Process a batch of zapi messages.

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1749,7 +1749,6 @@ static void zread_nhg_del(ZAPI_HANDLER_ARGS)
 	nhe = zebra_nhg_proto_del(id);
 
 	if (nhe) {
-		/* TODO: just decrement for now */
 		zebra_nhg_decrement_ref(nhe);
 		nhg_notify(proto, client->instance, id, ZAPI_NHG_REMOVED);
 	} else
@@ -1763,7 +1762,7 @@ stream_failure:
 	return;
 }
 
-static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
+static void zread_nhg_add(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	uint32_t id;
@@ -1808,12 +1807,9 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 	}
 
 	/*
-	 * Install the nhg
+	 * Create the nhg
 	 */
-
-	// TODO: Forcing AF_UNSPEC/AF_IP for now
-	nhe = zebra_nhg_proto_add(id, proto, nhg,
-				  ((nhops > 1) ? AFI_UNSPEC : AFI_IP));
+	nhe = zebra_nhg_proto_add(id, proto, nhg, 0);
 
 	nexthop_group_delete(&nhg);
 
@@ -3246,7 +3242,7 @@ void (*const zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_MLAG_FORWARD_MSG] = zebra_mlag_forward_client_msg,
 	[ZEBRA_CLIENT_CAPABILITIES] = zread_client_capabilities,
 	[ZEBRA_NEIGH_DISCOVER] = zread_neigh_discover,
-	[ZEBRA_NHG_ADD] = zread_nhg_reader,
+	[ZEBRA_NHG_ADD] = zread_nhg_add,
 	[ZEBRA_NHG_DEL] = zread_nhg_del,
 };
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1902,13 +1902,13 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 		re->nhe_id = api.nhgid;
 
 	if (!re->nhe_id
-	    || !zapi_read_nexthops(client, &api.prefix, api.nexthops, api.flags,
-				   api.message, api.nexthop_num,
-				   api.backup_nexthop_num, &ng, NULL)
-	    || !zapi_read_nexthops(client, &api.prefix, api.backup_nexthops,
-				   api.flags, api.message,
-				   api.backup_nexthop_num,
-				   api.backup_nexthop_num, NULL, &bnhg)) {
+	    && (!zapi_read_nexthops(client, &api.prefix, api.nexthops,
+				    api.flags, api.message, api.nexthop_num,
+				    api.backup_nexthop_num, &ng, NULL)
+		|| !zapi_read_nexthops(client, &api.prefix, api.backup_nexthops,
+				       api.flags, api.message,
+				       api.backup_nexthop_num,
+				       api.backup_nexthop_num, NULL, &bnhg))) {
 		XFREE(MTYPE_RE, re);
 		return;
 	}

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1411,8 +1411,7 @@ stream_failure:
 	return;
 }
 
-
-void zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
+bool zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 			    const unsigned int nexthop_num)
 {
 	if (nexthop_num > zrouter.multipath_num) {
@@ -1423,7 +1422,10 @@ void zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 			EC_ZEBRA_MORE_NH_THAN_MULTIPATH,
 			"%s: Prefix %s has %d nexthops, but we can only use the first %d",
 			caller, buff, nexthop_num, zrouter.multipath_num);
+		return true;
 	}
+
+	return false;
 }
 
 /*

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -712,7 +712,7 @@ static int zsend_ipv4_nexthop_lookup_mrib(struct zserv *client,
 	return zserv_send_message(client, s);
 }
 
-static int nhg_notify(uint16_t type, uint16_t instance, uint16_t id,
+static int nhg_notify(uint16_t type, uint16_t instance, uint32_t id,
 		      enum zapi_nhg_notify_owner note)
 {
 	struct zserv *client;
@@ -732,8 +732,8 @@ static int nhg_notify(uint16_t type, uint16_t instance, uint16_t id,
 
 	zclient_create_header(s, ZEBRA_NHG_NOTIFY_OWNER, VRF_DEFAULT);
 
-	stream_putw(s, id);
 	stream_put(s, &note, sizeof(note));
+	stream_putl(s, id);
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1445,11 +1445,14 @@ bool zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 	if (nexthop_num > zrouter.multipath_num) {
 		char buff[PREFIX2STR_BUFFER];
 
-		prefix2str(p, buff, sizeof(buff));
+		if (p)
+			prefix2str(p, buff, sizeof(buff));
+
 		flog_warn(
 			EC_ZEBRA_MORE_NH_THAN_MULTIPATH,
 			"%s: Prefix %s has %d nexthops, but we can only use the first %d",
-			caller, buff, nexthop_num, zrouter.multipath_num);
+			caller, (p ? buff : "(NULL)"), nexthop_num,
+			zrouter.multipath_num);
 		return true;
 	}
 
@@ -1767,11 +1770,8 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 	size_t nhops, i;
 	struct zapi_nexthop zapi_nexthops[MULTIPATH_NUM];
 	struct nexthop_group *nhg = NULL;
-	struct prefix p;
 	uint16_t proto;
 	struct nhg_hash_entry *nhe;
-
-	memset(&p, 0, sizeof(p));
 
 	s = msg;
 
@@ -1779,9 +1779,8 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 	STREAM_GETL(s, id);
 	STREAM_GETW(s, nhops);
 
-	// TODO: Can't use this without a prefix.
-	// if (zserv_nexthop_num_warn(__func__, &p, nhops))
-	//	return;
+	if (zserv_nexthop_num_warn(__func__, NULL, nhops))
+		return;
 
 	if (nhops <= 0) {
 		flog_warn(EC_ZEBRA_NEXTHOP_CREATION_FAILED,
@@ -1800,8 +1799,8 @@ static void zread_nhg_reader(ZAPI_HANDLER_ARGS)
 		}
 	}
 
-	if (!zapi_read_nexthops(client, &p, zapi_nexthops, 0, 0, nhops, 0, &nhg,
-				NULL)) {
+	if (!zapi_read_nexthops(client, NULL, zapi_nexthops, 0, 0, nhops, 0,
+				&nhg, NULL)) {
 		flog_warn(EC_ZEBRA_NEXTHOP_CREATION_FAILED,
 			  "%s: Nexthop Group Creation failed",
 			  __func__);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1746,7 +1746,7 @@ static void zread_nhg_del(ZAPI_HANDLER_ARGS)
 	 * Delete the received nhg id
 	 */
 
-	nhe = zebra_nhg_proto_del(id);
+	nhe = zebra_nhg_proto_del(id, proto);
 
 	if (nhe) {
 		zebra_nhg_decrement_ref(nhe);

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -90,7 +90,7 @@ zsend_ipset_entry_notify_owner(struct zebra_pbr_ipset_entry *ipset,
 			       enum zapi_ipset_entry_notify_owner note);
 extern void zsend_iptable_notify_owner(struct zebra_pbr_iptable *iptable,
 				       enum zapi_iptable_notify_owner note);
-extern void zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
+extern bool zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 				   const unsigned int nexthop_num);
 
 extern void zsend_capabilities_all_clients(void);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -73,6 +73,7 @@ const uint32_t DPLANE_DEFAULT_NEW_WORK = 100;
  */
 struct dplane_nexthop_info {
 	uint32_t id;
+	uint32_t old_id;
 	afi_t afi;
 	vrf_id_t vrf_id;
 	int type;
@@ -1242,6 +1243,12 @@ uint32_t dplane_ctx_get_nhe_id(const struct zebra_dplane_ctx *ctx)
 	return ctx->u.rinfo.nhe.id;
 }
 
+uint32_t dplane_ctx_get_old_nhe_id(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.old_id;
+}
+
 afi_t dplane_ctx_get_nhe_afi(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
@@ -1912,6 +1919,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		struct nhg_hash_entry *nhe = zebra_nhg_resolve(re->nhe);
 
 		ctx->u.rinfo.nhe.id = nhe->id;
+		ctx->u.rinfo.nhe.old_id = 0;
 		/*
 		 * Check if the nhe is installed/queued before doing anything
 		 * with this route.
@@ -2328,6 +2336,7 @@ dplane_route_update_internal(struct route_node *rn,
 			ctx->u.rinfo.zd_old_instance = old_re->instance;
 			ctx->u.rinfo.zd_old_distance = old_re->distance;
 			ctx->u.rinfo.zd_old_metric = old_re->metric;
+			ctx->u.rinfo.nhe.old_id = old_re->nhe->id;
 
 #ifndef HAVE_NETLINK
 			/* For bsd, capture previous re's nexthops too, sigh.
@@ -2347,6 +2356,24 @@ dplane_route_update_internal(struct route_node *rn,
 					copy_nexthops(nh, nhg->nexthop, NULL);
 			}
 #endif	/* !HAVE_NETLINK */
+		}
+
+		/*
+		 * If the old and new context type, and nexthop group id
+		 * are the same there is no need to send down a route replace
+		 * as that we know we have sent a nexthop group replace
+		 * or an upper level protocol has sent us the exact
+		 * same route again.
+		 */
+		if ((dplane_ctx_get_type(ctx) == dplane_ctx_get_old_type(ctx))
+		    && (dplane_ctx_get_nhe_id(ctx)
+			== dplane_ctx_get_old_nhe_id(ctx))) {
+			if (IS_ZEBRA_DEBUG_DPLANE)
+				zlog_debug(
+					"%s: Ignoring Route exactly the same",
+					__func__);
+
+			return ZEBRA_DPLANE_REQUEST_SUCCESS;
 		}
 
 		/* Enqueue context for processing */

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2367,7 +2367,8 @@ dplane_route_update_internal(struct route_node *rn,
 		 */
 		if ((dplane_ctx_get_type(ctx) == dplane_ctx_get_old_type(ctx))
 		    && (dplane_ctx_get_nhe_id(ctx)
-			== dplane_ctx_get_old_nhe_id(ctx))) {
+			== dplane_ctx_get_old_nhe_id(ctx))
+		    && (dplane_ctx_get_nhe_id(ctx) >= ZEBRA_NHG_PROTO_LOWER)) {
 			struct nexthop *nexthop;
 
 			if (IS_ZEBRA_DEBUG_DPLANE)

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2388,6 +2388,7 @@ dplane_route_update_internal(struct route_node *rn,
 						 NEXTHOP_FLAG_FIB);
 			}
 
+			dplane_ctx_free(&ctx);
 			return ZEBRA_DPLANE_REQUEST_SUCCESS;
 		}
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2368,10 +2368,24 @@ dplane_route_update_internal(struct route_node *rn,
 		if ((dplane_ctx_get_type(ctx) == dplane_ctx_get_old_type(ctx))
 		    && (dplane_ctx_get_nhe_id(ctx)
 			== dplane_ctx_get_old_nhe_id(ctx))) {
+			struct nexthop *nexthop;
+
 			if (IS_ZEBRA_DEBUG_DPLANE)
 				zlog_debug(
 					"%s: Ignoring Route exactly the same",
 					__func__);
+
+			for (ALL_NEXTHOPS_PTR(dplane_ctx_get_ng(ctx),
+					      nexthop)) {
+				if (CHECK_FLAG(nexthop->flags,
+					       NEXTHOP_FLAG_RECURSIVE))
+					continue;
+
+				if (CHECK_FLAG(nexthop->flags,
+					       NEXTHOP_FLAG_ACTIVE))
+					SET_FLAG(nexthop->flags,
+						 NEXTHOP_FLAG_FIB);
+			}
 
 			return ZEBRA_DPLANE_REQUEST_SUCCESS;
 		}

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -316,6 +316,7 @@ dplane_ctx_get_old_backup_ng(const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for nexthop information */
 uint32_t dplane_ctx_get_nhe_id(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_old_nhe_id(const struct zebra_dplane_ctx *ctx);
 afi_t dplane_ctx_get_nhe_afi(const struct zebra_dplane_ctx *ctx);
 vrf_id_t dplane_ctx_get_nhe_vrf_id(const struct zebra_dplane_ctx *ctx);
 int dplane_ctx_get_nhe_type(const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -53,7 +53,7 @@ uint32_t id_counter;
 
 /*  */
 static bool g_nexthops_enabled = true;
-static bool proto_nexthops_only = false;
+static bool proto_nexthops_only;
 
 static struct nhg_hash_entry *depends_find(const struct nexthop *nh, afi_t afi,
 					   int type);
@@ -70,7 +70,7 @@ static struct nhg_backup_info *
 nhg_backup_copy(const struct nhg_backup_info *orig);
 
 /* Helper function for getting the next allocatable ID */
-static uint32_t nhg_get_next_id()
+static uint32_t nhg_get_next_id(void)
 {
 	while (1) {
 		id_counter++;

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -676,7 +676,7 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 	if (lookup->id == 0)
 		lookup->id = ++id_counter;
 
-	if (lookup->id < zclient_get_nhg_lower_bound()) {
+	if (lookup->id < ZEBRA_NHG_PROTO_LOWER) {
 		/*
 		 * This is a zebra hashed/owned NHG.
 		 *
@@ -730,7 +730,7 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_ACTIVE))
 		SET_FLAG(newnhe->flags, NEXTHOP_GROUP_VALID);
 
-	if (nh->next == NULL && newnhe->id < zclient_get_nhg_lower_bound()) {
+	if (nh->next == NULL && newnhe->id < ZEBRA_NHG_PROTO_LOWER) {
 		if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_RECURSIVE)) {
 			/* Single recursive nexthop */
 			handle_recursive_depend(&newnhe->nhg_depends,
@@ -1246,7 +1246,7 @@ int zebra_nhg_kernel_find(uint32_t id, struct nexthop *nh, struct nh_grp *grp,
 		zlog_debug("%s: nh %pNHv, id %u, count %d",
 			   __func__, nh, id, (int)count);
 
-	if (id > id_counter && id < zclient_get_nhg_lower_bound())
+	if (id > id_counter && id < ZEBRA_NHG_PROTO_LOWER)
 		/* Increase our counter so we don't try to create
 		 * an ID that already exists
 		 */
@@ -2319,7 +2319,7 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 	struct nhg_hash_entry *curr_nhe;
 	uint32_t curr_active = 0, backup_active = 0;
 
-	if (re->nhe->id >= zclient_get_nhg_lower_bound())
+	if (re->nhe->id >= ZEBRA_NHG_PROTO_LOWER)
 		return proto_nhg_nexthop_active_update(&re->nhe->nhg);
 
 	afi_t rt_afi = family2afi(rn->p.family);
@@ -2525,7 +2525,7 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe)
 
 	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_VALID)
 	    && (!CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED)
-		|| nhe->id >= zclient_get_nhg_lower_bound())
+		|| nhe->id >= ZEBRA_NHG_PROTO_LOWER)
 	    && !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) {
 		/* Change its type to us since we are installing it */
 		if (!ZEBRA_NHG_CREATED(nhe))

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2758,8 +2758,16 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 	 *
 	 * Once resolution is figured out, we won't need this!
 	 */
-	for (ALL_NEXTHOPS_PTR(nhg, newhop))
+	for (ALL_NEXTHOPS_PTR(nhg, newhop)) {
+		if (!newhop->ifindex) {
+			if (IS_ZEBRA_DEBUG_NHG)
+				zlog_debug(
+					"%s: id %u, nexthop without ifindex passed to add",
+					__func__, id);
+			return NULL;
+		}
 		SET_FLAG(newhop->flags, NEXTHOP_FLAG_ACTIVE);
+	}
 
 	zebra_nhe_init(&lookup, afi, nhg->nexthop);
 	lookup.nhg.nexthop = nhg->nexthop;

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -960,30 +960,6 @@ static struct nhg_ctx *nhg_ctx_init(uint32_t id, struct nexthop *nh,
 	return ctx;
 }
 
-static bool zebra_nhg_contains_unhashable(struct nhg_hash_entry *nhe)
-{
-	struct nhg_connected *rb_node_dep = NULL;
-
-	frr_each(nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
-		if (CHECK_FLAG(rb_node_dep->nhe->flags,
-			       NEXTHOP_GROUP_UNHASHABLE))
-			return true;
-	}
-
-	return false;
-}
-
-static void zebra_nhg_set_unhashable(struct nhg_hash_entry *nhe)
-{
-	SET_FLAG(nhe->flags, NEXTHOP_GROUP_UNHASHABLE);
-	SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
-
-	flog(LOG_INFO,
-	     EC_ZEBRA_DUPLICATE_NHG_MESSAGE,
-	     "Nexthop Group with ID (%d) is a duplicate, therefore unhashable, ignoring",
-	     nhe->id);
-}
-
 static void zebra_nhg_set_valid(struct nhg_hash_entry *nhe)
 {
 	struct nhg_connected *rb_node_dep;
@@ -1038,10 +1014,10 @@ static void zebra_nhg_release(struct nhg_hash_entry *nhe)
 		if_nhg_dependents_del(nhe->ifp, nhe);
 
 	/*
-	 * If its unhashable, we didn't store it here and have to be
+	 * If its not zebra created, we didn't store it here and have to be
 	 * sure we don't clear one thats actually being used.
 	 */
-	if (!CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_UNHASHABLE))
+	if (nhe->type == ZEBRA_ROUTE_NHG)
 		hash_release(zrouter.nhgs, nhe);
 
 	hash_release(zrouter.nhgs_id, nhe);
@@ -1127,60 +1103,19 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 		nhe = zebra_nhg_find_nexthop(id, nhg_ctx_get_nh(ctx), afi,
 					     type);
 
-	if (nhe) {
-		if (id != nhe->id) {
-			struct nhg_hash_entry *kernel_nhe = NULL;
-
-			/* Duplicate but with different ID from
-			 * the kernel
-			 */
-
-			/* The kernel allows duplicate nexthops
-			 * as long as they have different IDs.
-			 * We are ignoring those to prevent
-			 * syncing problems with the kernel
-			 * changes.
-			 *
-			 * We maintain them *ONLY* in the ID hash table to
-			 * track them and set the flag to indicated
-			 * their attributes are unhashable.
-			 */
-
-			kernel_nhe = zebra_nhe_copy(nhe, id);
-
-			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-				zlog_debug("%s: copying kernel nhe (%u), dup of %u",
-					   __func__, id, nhe->id);
-
-			zebra_nhg_insert_id(kernel_nhe);
-			zebra_nhg_set_unhashable(kernel_nhe);
-		} else if (zebra_nhg_contains_unhashable(nhe)) {
-			/* The group we got contains an unhashable/duplicated
-			 * depend, so lets mark this group as unhashable as well
-			 * and release it from the non-ID hash.
-			 */
-			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-				zlog_debug("%s: nhe %p (%u) unhashable",
-					   __func__, nhe, nhe->id);
-
-			hash_release(zrouter.nhgs, nhe);
-			zebra_nhg_set_unhashable(nhe);
-		} else {
-			/* It actually created a new nhe */
-			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-				zlog_debug("%s: nhe %p (%u) is new",
-					   __func__, nhe, nhe->id);
-
-			SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
-			SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
-		}
-	} else {
+	if (!nhe) {
 		flog_err(
 			EC_ZEBRA_TABLE_LOOKUP_FAILED,
 			"Zebra failed to find or create a nexthop hash entry for ID (%u)",
 			id);
 		return -1;
 	}
+
+	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+		zlog_debug("%s: nhe %p (%u) is new", __func__, nhe, nhe->id);
+
+	SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
+	SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
 
 	return 0;
 }

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2813,9 +2813,3 @@ struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id)
 	return nhe;
 }
 
-/* Replace NHE from upper level proto */
-struct nhg_hash_entry *
-zebra_nhg_proto_replace(uint32_t id, struct nexthop_group *nhg, afi_t afi)
-{
-	return NULL;
-}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2838,7 +2838,7 @@ struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id)
 			zlog_debug(
 				"%s: id %u, still being used by routes refcnt %u",
 				__func__, nhe->id, nhe->refcnt);
-		return NULL;
+		return nhe;
 	}
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2553,8 +2553,7 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe)
 	}
 
 	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_VALID)
-	    && (!CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED)
-		|| nhe->id >= ZEBRA_NHG_PROTO_LOWER)
+	    && !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED)
 	    && !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) {
 		/* Change its type to us since we are installing it */
 		if (!ZEBRA_NHG_CREATED(nhe))

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2759,10 +2759,26 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 	 * Once resolution is figured out, we won't need this!
 	 */
 	for (ALL_NEXTHOPS_PTR(nhg, newhop)) {
+		if (newhop->type == NEXTHOP_TYPE_BLACKHOLE) {
+			if (IS_ZEBRA_DEBUG_NHG)
+				zlog_debug(
+					"%s: id %u, blackhole nexthop not supported",
+					__func__, id);
+			return NULL;
+		}
+
+		if (newhop->type == NEXTHOP_TYPE_IFINDEX) {
+			if (IS_ZEBRA_DEBUG_NHG)
+				zlog_debug(
+					"%s: id %u, nexthop without gateway not supported",
+					__func__, id);
+			return NULL;
+		}
+
 		if (!newhop->ifindex) {
 			if (IS_ZEBRA_DEBUG_NHG)
 				zlog_debug(
-					"%s: id %u, nexthop without ifindex passed to add",
+					"%s: id %u, nexthop without ifindex is not supported",
 					__func__, id);
 			return NULL;
 		}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -53,6 +53,7 @@ uint32_t id_counter;
 
 /*  */
 static bool g_nexthops_enabled = true;
+static bool proto_nexthops_only = false;
 
 static struct nhg_hash_entry *depends_find(const struct nexthop *nh, afi_t afi,
 					   int type);
@@ -2659,6 +2660,24 @@ void zebra_nhg_enable_kernel_nexthops(bool set)
 bool zebra_nhg_kernel_nexthops_enabled(void)
 {
 	return g_nexthops_enabled;
+}
+
+/*
+ * Global control to only use kernel nexthops for protocol created NHGs.
+ * There are some use cases where you may not want zebra to implicitly
+ * create kernel nexthops for all routes and only create them for NHGs
+ * passed down by upper level protos.
+ *
+ * Default is off.
+ */
+void zebra_nhg_set_proto_nexthops_only(bool set)
+{
+	proto_nexthops_only = set;
+}
+
+bool zebra_nhg_proto_nexthops_only(void)
+{
+	return proto_nexthops_only;
 }
 
 /* Add NHE from upper level proto */

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2893,7 +2893,7 @@ struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id)
 
 struct nhg_score_proto_iter {
 	int type;
-	unsigned long found;
+	struct list *found;
 };
 
 static void zebra_nhg_score_proto_entry(struct hash_bucket *bucket, void *arg)
@@ -2906,27 +2906,42 @@ static void zebra_nhg_score_proto_entry(struct hash_bucket *bucket, void *arg)
 
 	/* Needs to match type and outside zebra ID space */
 	if (nhe->type == iter->type && nhe->id >= ZEBRA_NHG_PROTO_LOWER) {
-		iter->found++;
-
 		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 			zlog_debug(
 				"%s: found nhe %p (%u), vrf %d, type %s after client disconnect",
 				__func__, nhe, nhe->id, nhe->vrf_id,
 				zebra_route_string(nhe->type));
 
-		/* This should be the last ref if we remove client routes too */
-		zebra_nhg_decrement_ref(nhe);
+		/* Add to removal list */
+		listnode_add(iter->found, nhe);
 	}
 }
 
 /* Remove specific by proto NHGs */
 unsigned long zebra_nhg_score_proto(int type)
 {
+	struct nhg_hash_entry *nhe;
 	struct nhg_score_proto_iter iter = {};
+	struct listnode *ln;
+	unsigned long count;
 
 	iter.type = type;
+	iter.found = list_new();
 
+	/* Find matching entries to remove */
 	hash_iterate(zrouter.nhgs_id, zebra_nhg_score_proto_entry, &iter);
 
-	return iter.found;
+	/* Now remove them */
+	for (ALL_LIST_ELEMENTS_RO(iter.found, ln, nhe)) {
+		/*
+		 * This should be the last ref if we remove client routes too,
+		 * and thus should remove and free them.
+		 */
+		zebra_nhg_decrement_ref(nhe);
+	}
+
+	count = iter.found->count;
+	list_delete(&iter.found);
+
+	return count;
 }

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2759,6 +2759,14 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 	 * Once resolution is figured out, we won't need this!
 	 */
 	for (ALL_NEXTHOPS_PTR(nhg, newhop)) {
+		if (CHECK_FLAG(newhop->flags, NEXTHOP_FLAG_HAS_BACKUP)) {
+			if (IS_ZEBRA_DEBUG_NHG)
+				zlog_debug(
+					"%s: id %u, backup nexthops not supported",
+					__func__, id);
+			return NULL;
+		}
+
 		if (newhop->type == NEXTHOP_TYPE_BLACKHOLE) {
 			if (IS_ZEBRA_DEBUG_NHG)
 				zlog_debug(

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2864,6 +2864,8 @@ static void zebra_nhg_score_proto_entry(struct hash_bucket *bucket, void *arg)
 
 	/* Needs to match type and outside zebra ID space */
 	if (nhe->type == iter->type && nhe->id >= ZEBRA_NHG_PROTO_LOWER) {
+		iter->found++;
+
 		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 			zlog_debug(
 				"%s: found nhe %p (%u), vrf %d, type %s after client disconnect",

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -54,13 +54,13 @@ uint32_t id_counter;
 /*  */
 static bool g_nexthops_enabled = true;
 
-static struct nhg_hash_entry *depends_find(const struct nexthop *nh,
-					   afi_t afi);
+static struct nhg_hash_entry *depends_find(const struct nexthop *nh, afi_t afi,
+					   int type);
 static void depends_add(struct nhg_connected_tree_head *head,
 			struct nhg_hash_entry *depend);
 static struct nhg_hash_entry *
 depends_find_add(struct nhg_connected_tree_head *head, struct nexthop *nh,
-		 afi_t afi);
+		 afi_t afi, int type);
 static struct nhg_hash_entry *
 depends_find_id_add(struct nhg_connected_tree_head *head, uint32_t id);
 static void depends_decrement_free(struct nhg_connected_tree_head *head);
@@ -431,7 +431,6 @@ static void *zebra_nhg_hash_alloc(void *arg)
 				nhe->nhg.nexthop->vrf_id, nhe->id);
 	}
 
-	zebra_nhg_insert_id(nhe);
 
 	return nhe;
 }
@@ -439,17 +438,17 @@ static void *zebra_nhg_hash_alloc(void *arg)
 uint32_t zebra_nhg_hash_key(const void *arg)
 {
 	const struct nhg_hash_entry *nhe = arg;
-	uint32_t val, key = 0x5a351234;
+	uint32_t key = 0x5a351234;
+	uint32_t primary = 0;
+	uint32_t backup = 0;
 
-	val = nexthop_group_hash(&(nhe->nhg));
-	if (nhe->backup_info) {
-		val = jhash_2words(val,
-				   nexthop_group_hash(
-					   &(nhe->backup_info->nhe->nhg)),
-				   key);
-	}
+	primary = nexthop_group_hash(&(nhe->nhg));
+	if (nhe->backup_info)
+		backup = nexthop_group_hash(&(nhe->backup_info->nhe->nhg));
 
-	key = jhash_3words(nhe->vrf_id, nhe->afi, val, key);
+	key = jhash_3words(primary, backup, nhe->type, key);
+
+	key = jhash_2words(nhe->vrf_id, nhe->afi, key);
 
 	return key;
 }
@@ -511,6 +510,9 @@ bool zebra_nhg_hash_equal(const void *arg1, const void *arg2)
 	/* No matter what if they equal IDs, assume equal */
 	if (nhe1->id && nhe2->id && (nhe1->id == nhe2->id))
 		return true;
+
+	if (nhe1->type != nhe2->type)
+		return false;
 
 	if (nhe1->vrf_id != nhe2->vrf_id)
 		return false;
@@ -611,7 +613,7 @@ static int zebra_nhg_process_grp(struct nexthop_group *nhg,
 }
 
 static void handle_recursive_depend(struct nhg_connected_tree_head *nhg_depends,
-				    struct nexthop *nh, afi_t afi)
+				    struct nexthop *nh, afi_t afi, int type)
 {
 	struct nhg_hash_entry *depend = NULL;
 	struct nexthop_group resolved_ng = {};
@@ -622,7 +624,7 @@ static void handle_recursive_depend(struct nhg_connected_tree_head *nhg_depends,
 		zlog_debug("%s: head %p, nh %pNHv",
 			   __func__, nhg_depends, nh);
 
-	depend = zebra_nhg_rib_find(0, &resolved_ng, afi);
+	depend = zebra_nhg_rib_find(0, &resolved_ng, afi, type);
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 		zlog_debug("%s: nh %pNHv => %p (%u)",
@@ -672,7 +674,25 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 	 */
 	if (lookup->id == 0)
 		lookup->id = ++id_counter;
-	newnhe = hash_get(zrouter.nhgs, lookup, zebra_nhg_hash_alloc);
+
+	if (ZEBRA_OWNED(lookup)) {
+		/*
+		 * This is a zebra hashed/owned NHG.
+		 *
+		 * It goes in HASH and ID table.
+		 */
+		newnhe = hash_get(zrouter.nhgs, lookup, zebra_nhg_hash_alloc);
+		zebra_nhg_insert_id(newnhe);
+	} else {
+		/*
+		 * This is upperproto owned NHG and should not be hashed to.
+		 *
+		 * It goes in ID table.
+		 */
+		newnhe =
+			hash_get(zrouter.nhgs_id, lookup, zebra_nhg_hash_alloc);
+	}
+
 	created = true;
 
 	/* Mail back the new object */
@@ -713,7 +733,8 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 		if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_RECURSIVE)) {
 			/* Single recursive nexthop */
 			handle_recursive_depend(&newnhe->nhg_depends,
-						nh->resolved, afi);
+						nh->resolved, afi,
+						newnhe->type);
 			recursive = true;
 		}
 	} else {
@@ -726,7 +747,8 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 						      NEXTHOP_FLAG_RECURSIVE) ?
 					   "(R)" : "");
 
-			depends_find_add(&newnhe->nhg_depends, nh, afi);
+			depends_find_add(&newnhe->nhg_depends, nh, afi,
+					 newnhe->type);
 		}
 	}
 
@@ -753,8 +775,8 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 				   __func__, nh);
 
 		/* Single recursive nexthop */
-		handle_recursive_depend(&backup_nhe->nhg_depends,
-					nh->resolved, afi);
+		handle_recursive_depend(&backup_nhe->nhg_depends, nh->resolved,
+					afi, backup_nhe->type);
 		recursive = true;
 	} else {
 		/* One or more backup NHs */
@@ -766,8 +788,8 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 						      NEXTHOP_FLAG_RECURSIVE) ?
 					   "(R)" : "");
 
-			depends_find_add(&backup_nhe->nhg_depends,
-					 nh, afi);
+			depends_find_add(&backup_nhe->nhg_depends, nh, afi,
+					 backup_nhe->type);
 		}
 	}
 
@@ -1014,10 +1036,10 @@ static void zebra_nhg_release(struct nhg_hash_entry *nhe)
 		if_nhg_dependents_del(nhe->ifp, nhe);
 
 	/*
-	 * If its not zebra created, we didn't store it here and have to be
+	 * If its not zebra owned, we didn't store it here and have to be
 	 * sure we don't clear one thats actually being used.
 	 */
-	if (nhe->type == ZEBRA_ROUTE_NHG)
+	if (ZEBRA_OWNED(nhe))
 		hash_release(zrouter.nhgs, nhe);
 
 	hash_release(zrouter.nhgs_id, nhe);
@@ -1093,8 +1115,8 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 			return -ENOENT;
 		}
 
-		if (!zebra_nhg_find(&nhe, id, nhg, &nhg_depends, vrf_id, type,
-				    afi))
+		if (!zebra_nhg_find(&nhe, id, nhg, &nhg_depends, vrf_id, afi,
+				    type))
 			depends_decrement_free(&nhg_depends);
 
 		/* These got copied over in zebra_nhg_alloc() */
@@ -1261,14 +1283,14 @@ int zebra_nhg_kernel_del(uint32_t id, vrf_id_t vrf_id)
 
 /* Some dependency helper functions */
 static struct nhg_hash_entry *depends_find_recursive(const struct nexthop *nh,
-						     afi_t afi)
+						     afi_t afi, int type)
 {
 	struct nhg_hash_entry *nhe;
 	struct nexthop *lookup = NULL;
 
 	lookup = nexthop_dup(nh, NULL);
 
-	nhe = zebra_nhg_find_nexthop(0, lookup, afi, 0);
+	nhe = zebra_nhg_find_nexthop(0, lookup, afi, type);
 
 	nexthops_free(lookup);
 
@@ -1276,7 +1298,7 @@ static struct nhg_hash_entry *depends_find_recursive(const struct nexthop *nh,
 }
 
 static struct nhg_hash_entry *depends_find_singleton(const struct nexthop *nh,
-						     afi_t afi)
+						     afi_t afi, int type)
 {
 	struct nhg_hash_entry *nhe;
 	struct nexthop lookup = {};
@@ -1286,7 +1308,7 @@ static struct nhg_hash_entry *depends_find_singleton(const struct nexthop *nh,
 	 */
 	nexthop_copy_no_recurse(&lookup, nh, NULL);
 
-	nhe = zebra_nhg_find_nexthop(0, &lookup, afi, 0);
+	nhe = zebra_nhg_find_nexthop(0, &lookup, afi, type);
 
 	/* The copy may have allocated labels; free them if necessary. */
 	nexthop_del_labels(&lookup);
@@ -1298,7 +1320,8 @@ static struct nhg_hash_entry *depends_find_singleton(const struct nexthop *nh,
 	return nhe;
 }
 
-static struct nhg_hash_entry *depends_find(const struct nexthop *nh, afi_t afi)
+static struct nhg_hash_entry *depends_find(const struct nexthop *nh, afi_t afi,
+					   int type)
 {
 	struct nhg_hash_entry *nhe = NULL;
 
@@ -1309,9 +1332,9 @@ static struct nhg_hash_entry *depends_find(const struct nexthop *nh, afi_t afi)
 	 * in the non-recursive case (by not alloc/freeing)
 	 */
 	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_RECURSIVE))
-		nhe = depends_find_recursive(nh, afi);
+		nhe = depends_find_recursive(nh, afi, type);
 	else
-		nhe = depends_find_singleton(nh, afi);
+		nhe = depends_find_singleton(nh, afi, type);
 
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL) {
@@ -1344,11 +1367,11 @@ static void depends_add(struct nhg_connected_tree_head *head,
 
 static struct nhg_hash_entry *
 depends_find_add(struct nhg_connected_tree_head *head, struct nexthop *nh,
-		 afi_t afi)
+		 afi_t afi, int type)
 {
 	struct nhg_hash_entry *depend = NULL;
 
-	depend = depends_find(nh, afi);
+	depend = depends_find(nh, afi, type);
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 		zlog_debug("%s: nh %pNHv => %p",
@@ -1380,8 +1403,9 @@ static void depends_decrement_free(struct nhg_connected_tree_head *head)
 }
 
 /* Find an nhe based on a list of nexthops */
-struct nhg_hash_entry *
-zebra_nhg_rib_find(uint32_t id, struct nexthop_group *nhg, afi_t rt_afi)
+struct nhg_hash_entry *zebra_nhg_rib_find(uint32_t id,
+					  struct nexthop_group *nhg,
+					  afi_t rt_afi, int type)
 {
 	struct nhg_hash_entry *nhe = NULL;
 	vrf_id_t vrf_id;
@@ -1393,7 +1417,7 @@ zebra_nhg_rib_find(uint32_t id, struct nexthop_group *nhg, afi_t rt_afi)
 	assert(nhg->nexthop);
 	vrf_id = !vrf_is_backend_netns() ? VRF_DEFAULT : nhg->nexthop->vrf_id;
 
-	zebra_nhg_find(&nhe, id, nhg, NULL, vrf_id, rt_afi, 0);
+	zebra_nhg_find(&nhe, id, nhg, NULL, vrf_id, rt_afi, type);
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 		zlog_debug("%s: => nhe %p (%u)",
@@ -2478,7 +2502,8 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe)
 	    && !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED)
 	    && !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) {
 		/* Change its type to us since we are installing it */
-		nhe->type = ZEBRA_ROUTE_NHG;
+		if (!ZEBRA_NHG_CREATED(nhe))
+			nhe->type = ZEBRA_ROUTE_NHG;
 
 		int ret = dplane_nexthop_add(nhe);
 
@@ -2634,4 +2659,75 @@ void zebra_nhg_enable_kernel_nexthops(bool set)
 bool zebra_nhg_kernel_nexthops_enabled(void)
 {
 	return g_nexthops_enabled;
+}
+
+/* Add NHE from upper level proto */
+struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
+					   struct nexthop_group *nhg, afi_t afi)
+{
+	struct nhg_hash_entry lookup;
+	struct nhg_hash_entry *new;
+	struct nhg_connected *rb_node_dep = NULL;
+
+	zebra_nhe_init(&lookup, afi, nhg->nexthop);
+	lookup.nhg.nexthop = nhg->nexthop;
+	lookup.id = id;
+	lookup.type = type;
+
+	new = zebra_nhg_rib_find_nhe(&lookup, afi);
+
+	if (!new)
+		return NULL;
+
+	/* TODO: Assuming valid/onlink for now */
+	SET_FLAG(new->flags, NEXTHOP_GROUP_VALID);
+
+	if (!zebra_nhg_depends_is_empty(new)) {
+		frr_each (nhg_connected_tree, &new->nhg_depends, rb_node_dep)
+			SET_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_VALID);
+	}
+
+	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+		zlog_debug("%s: added nhe %p (%u), vrf %d, type %s", __func__,
+			   new, new->id, new->vrf_id,
+			   zebra_route_string(new->type));
+
+	return new;
+}
+
+/* Delete NHE from upper level proto */
+struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id)
+{
+	struct nhg_hash_entry *nhe;
+
+	nhe = zebra_nhg_lookup_id(id);
+
+	if (!nhe) {
+		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			zlog_debug("%s: id %u, lookup failed", __func__, id);
+
+		return NULL;
+	}
+
+	if (nhe->refcnt) {
+		/* TODO: should be warn? */
+		if (IS_ZEBRA_DEBUG_NHG)
+			zlog_debug("%s: id %u, still being used refcnt %u",
+				   __func__, nhe->id, nhe->refcnt);
+		return NULL;
+	}
+
+	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+		zlog_debug("%s: deleted nhe %p (%u), vrf %d, type %s", __func__,
+			   nhe, nhe->id, nhe->vrf_id,
+			   zebra_route_string(nhe->type));
+
+	return nhe;
+}
+
+/* Replace NHE from upper level proto */
+struct nhg_hash_entry *
+zebra_nhg_proto_replace(uint32_t id, struct nexthop_group *nhg, afi_t afi)
+{
+	return NULL;
 }

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2853,7 +2853,7 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 }
 
 /* Delete NHE from upper level proto, caller must decrement ref */
-struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id)
+struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id, int type)
 {
 	struct nhg_hash_entry *nhe;
 
@@ -2863,6 +2863,15 @@ struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id)
 		if (IS_ZEBRA_DEBUG_NHG)
 			zlog_debug("%s: id %u, lookup failed", __func__, id);
 
+		return NULL;
+	}
+
+	if (type != nhe->type) {
+		if (IS_ZEBRA_DEBUG_NHG)
+			zlog_debug(
+				"%s: id %u, type %s mismatch, sent by %s, ignoring",
+				__func__, id, zebra_route_string(nhe->type),
+				zebra_route_string(type));
 		return NULL;
 	}
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -69,6 +69,35 @@ static void depends_decrement_free(struct nhg_connected_tree_head *head);
 static struct nhg_backup_info *
 nhg_backup_copy(const struct nhg_backup_info *orig);
 
+/* Helper function for getting the next allocatable ID */
+static uint32_t nhg_get_next_id()
+{
+	while (1) {
+		id_counter++;
+
+		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			zlog_debug("%s: ID %u checking", __func__, id_counter);
+
+		if (id_counter == ZEBRA_NHG_PROTO_LOWER) {
+			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+				zlog_debug("%s: ID counter wrapped", __func__);
+
+			id_counter = 0;
+			continue;
+		}
+
+		if (zebra_nhg_lookup_id(id_counter)) {
+			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+				zlog_debug("%s: ID already exists", __func__);
+
+			continue;
+		}
+
+		break;
+	}
+
+	return id_counter;
+}
 
 static void nhg_connected_free(struct nhg_connected *dep)
 {
@@ -674,7 +703,7 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 	 * assign the next global id value if necessary.
 	 */
 	if (lookup->id == 0)
-		lookup->id = ++id_counter;
+		lookup->id = nhg_get_next_id();
 
 	if (lookup->id < ZEBRA_NHG_PROTO_LOWER) {
 		/*

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2813,3 +2813,40 @@ struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id)
 	return nhe;
 }
 
+struct nhg_score_proto_iter {
+	int type;
+	unsigned long found;
+};
+
+static void zebra_nhg_score_proto_entry(struct hash_bucket *bucket, void *arg)
+{
+	struct nhg_hash_entry *nhe;
+	struct nhg_score_proto_iter *iter;
+
+	nhe = (struct nhg_hash_entry *)bucket->data;
+	iter = arg;
+
+	/* Needs to match type and outside zebra ID space */
+	if (nhe->type == iter->type && nhe->id >= ZEBRA_NHG_PROTO_LOWER) {
+		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			zlog_debug(
+				"%s: found nhe %p (%u), vrf %d, type %s after client disconnect",
+				__func__, nhe, nhe->id, nhe->vrf_id,
+				zebra_route_string(nhe->type));
+
+		/* This should be the last ref if we remove client routes too */
+		zebra_nhg_decrement_ref(nhe);
+	}
+}
+
+/* Remove specific by proto NHGs */
+unsigned long zebra_nhg_score_proto(int type)
+{
+	struct nhg_score_proto_iter iter = {};
+
+	iter.type = type;
+
+	hash_iterate(zrouter.nhgs_id, zebra_nhg_score_proto_entry, &iter);
+
+	return iter.found;
+}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1074,7 +1074,7 @@ static void zebra_nhg_release(struct nhg_hash_entry *nhe)
 	 * If its not zebra owned, we didn't store it here and have to be
 	 * sure we don't clear one thats actually being used.
 	 */
-	if (ZEBRA_OWNED(nhe))
+	if (nhe->id < ZEBRA_NHG_PROTO_LOWER)
 		hash_release(zrouter.nhgs, nhe);
 
 	hash_release(zrouter.nhgs_id, nhe);

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -676,7 +676,7 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 	if (lookup->id == 0)
 		lookup->id = ++id_counter;
 
-	if (ZEBRA_OWNED(lookup)) {
+	if (lookup->id < zclient_get_nhg_lower_bound()) {
 		/*
 		 * This is a zebra hashed/owned NHG.
 		 *

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2291,6 +2291,22 @@ static uint32_t nexthop_list_active_update(struct route_node *rn,
 	return counter;
 }
 
+
+static uint32_t proto_nhg_nexthop_active_update(struct nexthop_group *nhg)
+{
+	struct nexthop *nh;
+	uint32_t curr_active = 0;
+
+	/* Assume all active for now */
+
+	for (nh = nhg->nexthop; nh; nh = nh->next) {
+		SET_FLAG(nh->flags, NEXTHOP_FLAG_ACTIVE);
+		curr_active++;
+	}
+
+	return curr_active;
+}
+
 /*
  * Iterate over all nexthops of the given RIB entry and refresh their
  * ACTIVE flag.  If any nexthop is found to toggle the ACTIVE flag,
@@ -2302,6 +2318,9 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 {
 	struct nhg_hash_entry *curr_nhe;
 	uint32_t curr_active = 0, backup_active = 0;
+
+	if (re->nhe->id >= zclient_get_nhg_lower_bound())
+		return proto_nhg_nexthop_active_update(&re->nhe->nhg);
 
 	afi_t rt_afi = family2afi(rn->p.family);
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1246,7 +1246,7 @@ int zebra_nhg_kernel_find(uint32_t id, struct nexthop *nh, struct nh_grp *grp,
 		zlog_debug("%s: nh %pNHv, id %u, count %d",
 			   __func__, nh, id, (int)count);
 
-	if (id > id_counter)
+	if (id > id_counter && id < zclient_get_nhg_lower_bound())
 		/* Increase our counter so we don't try to create
 		 * an ID that already exists
 		 */

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2741,6 +2741,26 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 	struct nhg_hash_entry lookup;
 	struct nhg_hash_entry *new, *old;
 	struct nhg_connected *rb_node_dep = NULL;
+	struct nexthop *newhop;
+	bool replace = false;
+
+	if (!nhg->nexthop) {
+		if (IS_ZEBRA_DEBUG_NHG)
+			zlog_debug("%s: id %u, no nexthops passed to add",
+				   __func__, id);
+		return NULL;
+	}
+
+
+	/* Set nexthop list as active, since they wont go through rib
+	 * processing.
+	 *
+	 * Assuming valid/onlink for now.
+	 *
+	 * Once resolution is figured out, we won't need this!
+	 */
+	for (ALL_NEXTHOPS_PTR(nhg, newhop))
+		SET_FLAG(newhop->flags, NEXTHOP_FLAG_ACTIVE);
 
 	zebra_nhe_init(&lookup, afi, nhg->nexthop);
 	lookup.nhg.nexthop = nhg->nexthop;
@@ -2754,36 +2774,51 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 		 * This is a replace, just release NHE from ID for now, The
 		 * depends/dependents may still be used in the replacement.
 		 */
+		replace = true;
 		hash_release(zrouter.nhgs_id, old);
 	}
 
 	new = zebra_nhg_rib_find_nhe(&lookup, afi);
 
+	zebra_nhg_increment_ref(new);
+
+	zebra_nhg_set_valid_if_active(new);
+
+	zebra_nhg_install_kernel(new);
+
 	if (old) {
-		/* Now release depends/dependents in old one */
+		rib_handle_nhg_replace(old, new);
+
+		/* if this != 1 at this point, we have a bug */
+		assert(old->refcnt == 1);
+
+		/* We have to decrement its singletons
+		 * because some might not exist in NEW.
+		 */
+		if (!zebra_nhg_depends_is_empty(old)) {
+			frr_each (nhg_connected_tree, &old->nhg_depends,
+				  rb_node_dep)
+				zebra_nhg_decrement_ref(rb_node_dep->nhe);
+		}
+
+		/* Free all the things */
 		zebra_nhg_release_all_deps(old);
-	}
 
-	if (!new)
-		return NULL;
-
-	/* TODO: Assuming valid/onlink for now */
-	SET_FLAG(new->flags, NEXTHOP_GROUP_VALID);
-
-	if (!zebra_nhg_depends_is_empty(new)) {
-		frr_each (nhg_connected_tree, &new->nhg_depends, rb_node_dep)
-			SET_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_VALID);
+		/* Dont call the dec API, we dont want to uninstall the ID */
+		old->refcnt = 0;
+		zebra_nhg_free(old);
+		old = NULL;
 	}
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 		zlog_debug("%s: %s nhe %p (%u), vrf %d, type %s", __func__,
-			   (old ? "replaced" : "added"), new, new->id,
+			   (replace ? "replaced" : "added"), new, new->id,
 			   new->vrf_id, zebra_route_string(new->type));
 
 	return new;
 }
 
-/* Delete NHE from upper level proto */
+/* Delete NHE from upper level proto, caller must decrement ref */
 struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id)
 {
 	struct nhg_hash_entry *nhe;
@@ -2797,11 +2832,12 @@ struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id)
 		return NULL;
 	}
 
-	if (nhe->refcnt) {
+	if (nhe->refcnt > 1) {
 		/* TODO: should be warn? */
 		if (IS_ZEBRA_DEBUG_NHG)
-			zlog_debug("%s: id %u, still being used refcnt %u",
-				   __func__, nhe->id, nhe->refcnt);
+			zlog_debug(
+				"%s: id %u, still being used by routes refcnt %u",
+				__func__, nhe->id, nhe->refcnt);
 		return NULL;
 	}
 

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -182,6 +182,10 @@ struct nhg_ctx {
 void zebra_nhg_enable_kernel_nexthops(bool set);
 bool zebra_nhg_kernel_nexthops_enabled(void);
 
+/* Global control for zebra to only use proto-owned nexthops */
+void zebra_nhg_set_proto_nexthops_only(bool set);
+bool zebra_nhg_proto_nexthops_only(void);
+
 /**
  * NHE abstracted tree functions.
  * Use these where possible instead of direct access.

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -110,9 +110,20 @@ struct nhg_hash_entry {
 #define NEXTHOP_GROUP_BACKUP (1 << 4)
 
 /*
+ * The NHG has been release by an upper level protocol via the
+ * `zebra_nhg_proto_del()` API.
+ *
+ * We use this flag to track this state in case the NHG is still being used
+ * by routes therefore holding their refcnts as well. Otherwise, the NHG will
+ * be removed and uninstalled.
+ *
+ */
+#define NEXTHOP_GROUP_PROTO_RELEASED (1 << 5)
+
+/*
  * Track FPM installation status..
  */
-#define NEXTHOP_GROUP_FPM (1 << 5)
+#define NEXTHOP_GROUP_FPM (1 << 6)
 };
 
 /* Was this one we created, either this session or previously? */

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -285,6 +285,14 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
  */
 struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id);
 
+/*
+ * Remove specific by proto NHGs.
+ *
+ * Called after client disconnect.
+ *
+ */
+unsigned long zebra_nhg_score_proto(int type);
+
 /* Reference counter functions */
 extern void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe);
 extern void zebra_nhg_increment_ref(struct nhg_hash_entry *nhe);

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -294,7 +294,7 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
  *
  * Caller must decrement ref with zebra_nhg_decrement_ref() when done.
  */
-struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id);
+struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id, int type);
 
 /*
  * Remove specific by proto NHGs.

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -281,7 +281,7 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
  *
  * Returns deleted NHE on success, otherwise NULL.
  *
- * Caller must free the NHE.
+ * Caller must decrement ref with zebra_nhg_decrement_ref() when done.
  */
 struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id);
 

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -268,14 +268,13 @@ zebra_nhg_rib_find_nhe(struct nhg_hash_entry *rt_nhe, afi_t rt_afi);
  */
 
 /*
- * Add NHE.
+ * Add NHE. If already exists, Replace.
  *
  * Returns allocated NHE on success, otherwise NULL.
  */
 struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 					   struct nexthop_group *nhg,
 					   afi_t afi);
-
 
 /*
  * Del NHE.
@@ -285,14 +284,6 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
  * Caller must free the NHE.
  */
 struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id);
-
-/*
- * Replace NHE.
- *
- * Returns new NHE on success, otherwise NULL.
- */
-struct nhg_hash_entry *
-zebra_nhg_proto_replace(uint32_t id, struct nexthop_group *nhg, afi_t afi);
 
 /* Reference counter functions */
 extern void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -235,7 +235,7 @@ int route_entry_update_nhe(struct route_entry *re,
 		goto done;
 	}
 
-	if ((re->nhe_id != 0) && (re->nhe_id != new_nhghe->id)) {
+	if ((re->nhe_id != 0) && re->nhe && (re->nhe != new_nhghe)) {
 		old = re->nhe;
 
 		route_entry_attach_ref(re, new_nhghe);
@@ -248,6 +248,29 @@ int route_entry_update_nhe(struct route_entry *re,
 
 done:
 	return ret;
+}
+
+void rib_handle_nhg_replace(struct nhg_hash_entry *old,
+			    struct nhg_hash_entry *new)
+{
+	struct zebra_router_table *zrt;
+	struct route_node *rn;
+	struct route_entry *re, *next;
+
+	if (IS_ZEBRA_DEBUG_RIB_DETAILED || IS_ZEBRA_DEBUG_NHG_DETAIL)
+		zlog_debug("%s: replacing routes nhe (%u) OLD %p NEW %p",
+			   __func__, new->id, new, old);
+
+	/* We have to do them ALL */
+	RB_FOREACH (zrt, zebra_router_table_head, &zrouter.tables) {
+		for (rn = route_top(zrt->table); rn;
+		     rn = srcdest_route_next(rn)) {
+			RNODE_FOREACH_RE_SAFE (rn, re, next) {
+				if (re->nhe && re->nhe == old)
+					route_entry_update_nhe(re, new);
+			}
+		}
+	}
 }
 
 struct route_entry *rib_match(afi_t afi, safi_t safi, vrf_id_t vrf_id,

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2906,14 +2906,14 @@ int rib_add_multipath_nhe(afi_t afi, safi_t safi, struct prefix *p,
 	if (!table)
 		return -1;
 
-	if (re_nhe->id > 0) {
-		nhe = zebra_nhg_lookup_id(re_nhe->id);
+	if (re->nhe_id > 0) {
+		nhe = zebra_nhg_lookup_id(re->nhe_id);
 
 		if (!nhe) {
 			flog_err(
 				EC_ZEBRA_TABLE_LOOKUP_FAILED,
 				"Zebra failed to find the nexthop hash entry for id=%u in a route entry",
-				re_nhe->id);
+				re->nhe_id);
 
 			return -1;
 		}

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1300,7 +1300,7 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe)
 	struct nhg_connected *rb_node_dep = NULL;
 	struct nexthop_group *backup_nhg;
 
-	vty_out(vty, "ID: %u\n", nhe->id);
+	vty_out(vty, "ID: %u (%s)\n", nhe->id, zebra_route_string(nhe->type));
 	vty_out(vty, "     RefCnt: %d\n", nhe->refcnt);
 	vty_out(vty, "     VRF: %s\n", vrf_id_to_name(nhe->vrf_id));
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1566,14 +1566,12 @@ DEFPY_HIDDEN(nexthop_group_use_enable,
 	return CMD_SUCCESS;
 }
 
-DEFPY_HIDDEN (proto_nexthop_group_only,
-              proto_nexthop_group_only_cmd,
-              "[no] zebra nexthop proto only",
-              NO_STR
-              ZEBRA_STR
-              "Nexthop configuration\n"
-              "Configure exclusive use of proto nexthops\n"
-              "Only use proto nexthops\n")
+DEFPY_HIDDEN(proto_nexthop_group_only, proto_nexthop_group_only_cmd,
+	     "[no] zebra nexthop proto only",
+	     NO_STR ZEBRA_STR
+	     "Nexthop configuration\n"
+	     "Configure exclusive use of proto nexthops\n"
+	     "Only use proto nexthops\n")
 {
 	zebra_nhg_set_proto_nexthops_only(!no);
 	return CMD_SUCCESS;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1304,9 +1304,6 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe)
 	vty_out(vty, "     RefCnt: %d\n", nhe->refcnt);
 	vty_out(vty, "     VRF: %s\n", vrf_id_to_name(nhe->vrf_id));
 
-	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_UNHASHABLE))
-		vty_out(vty, "     Duplicate - from kernel not hashable\n");
-
 	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_VALID)) {
 		vty_out(vty, "     Valid");
 		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED))

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1566,6 +1566,19 @@ DEFPY_HIDDEN(nexthop_group_use_enable,
 	return CMD_SUCCESS;
 }
 
+DEFPY_HIDDEN (proto_nexthop_group_only,
+              proto_nexthop_group_only_cmd,
+              "[no] zebra nexthop proto only",
+              NO_STR
+              ZEBRA_STR
+              "Nexthop configuration\n"
+              "Configure exclusive use of proto nexthops\n"
+              "Only use proto nexthops\n")
+{
+	zebra_nhg_set_proto_nexthops_only(!no);
+	return CMD_SUCCESS;
+}
+
 DEFUN (no_ip_nht_default_route,
        no_ip_nht_default_route_cmd,
        "no ip nht resolve-via-default",
@@ -3448,6 +3461,9 @@ static int config_write_protocol(struct vty *vty)
 	if (!zebra_nhg_kernel_nexthops_enabled())
 		vty_out(vty, "no zebra nexthop kernel enable\n");
 
+	if (zebra_nhg_proto_nexthops_only())
+		vty_out(vty, "zebra nexthop proto only\n");
+
 #ifdef HAVE_NETLINK
 	/* Include netlink info */
 	netlink_config_write_helper(vty);
@@ -3882,6 +3898,7 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &zebra_packet_process_cmd);
 	install_element(CONFIG_NODE, &no_zebra_packet_process_cmd);
 	install_element(CONFIG_NODE, &nexthop_group_use_enable_cmd);
+	install_element(CONFIG_NODE, &proto_nexthop_group_only_cmd);
 
 	install_element(VIEW_NODE, &show_nexthop_group_cmd);
 	install_element(VIEW_NODE, &show_interface_nexthop_group_cmd);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -590,6 +590,7 @@ static void zserv_client_free(struct zserv *client)
 	/* Close file descriptor. */
 	if (client->sock) {
 		unsigned long nroutes;
+		unsigned long nnhgs;
 
 		close(client->sock);
 
@@ -599,6 +600,13 @@ static void zserv_client_free(struct zserv *client)
 			zlog_notice(
 				"client %d disconnected %lu %s routes removed from the rib",
 				client->sock, nroutes,
+				zebra_route_string(client->proto));
+
+			/* Not worrying about instance for now */
+			nnhgs = zebra_nhg_score_proto(client->proto);
+			zlog_notice(
+				"client %d disconnected %lu %s nhgs removed from the rib",
+				client->sock, nnhgs,
 				zebra_route_string(client->proto));
 		}
 		client->sock = -1;


### PR DESCRIPTION
These patches add new ZAPI definitions for proto-owned NHGs that are sent to zebra via and ID and `struct nexthop_group`.
We have divided the ID space among route_types while maintaining and ID space for zebra-created NHGs and L2-NHGs as well. These patches allow us to make use of the Replace API in the linux kernel for NHGs and are a starting point for route scalability. EVPN-MH will make use of this new API in a later patch set.

Currently this only supports upperlevel protos sending zebra fully resolved `connected` or `onlink` nexthops in the nexthop group. Nexthop resolution is a much harder headache to solve later on given the complexity of route-maps and will have to come later.


To test this functionality you can do this:


```
alfred# c                                                                                                              
alfred(config)# nexthop-group red                                                                                      
alfred(config-nh-group)# nexthop 1.1.1.1 dummy1                                                                        
alfred(config-nh-group)# nexthop 1.1.1.2 dummy2                                                                        
alfred(config-nh-group)# end                                                                                           
alfred# sharp install routes 3.3.3.1 nexthop-group red 1                                                               
alfred# c                                                                                                              
alfred(config)# nexthop-group red                                                                                      
alfred(config-nh-group)# nexthop 1.1.1.3 dummy3                                                                        
alfred(config-nh-group)# no nexthop 1.1.1.1 dummy1                                                                     
alfred(config-nh-group)# end                                                                                           
alfred# 
```

In the above we are directly modifying the nexthop group by adding/removing a nexthop. You can do this with N routes and it will only need to send a single REPLACE operation per change in the linux kernel rather than a route removal and add of the N routes:

```
sworley@alfred ~/D/c/e/frr-2> ip ro show 3.3.3.1
3.3.3.1 nhid 191666659 proto 194 metric 20 
        nexthop via 1.1.1.2 dev dummy2 weight 1 
        nexthop via 1.1.1.3 dev dummy3 weight 1 
```


A hidden command was also added: `zebra nexthop proto only` that will allow users to ONLY create these types of nexthops in the dataplane and none of the ones implicitly created by zebra. This will allow people with various dataplanes to still test NHGs without committing to them fully just yet.

Since these are coming in a separate PR from the EVPN-MH tests, I will add some topotests with sharpd as well before its merged.

TODO:
- [x] Add topotests!