### PR TITLE
tests: Remove 'log monitor' from tests

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce1/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname ce1
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    no bgp network import-check

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce2/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname ce2
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    no bgp network import-check

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce3/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname ce3
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    no bgp network import-check

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r1/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r1
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 1.1.1.1

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r2/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r2
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 2.2.2.2

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r3/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r3
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 3.3.3.3

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r4/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r4/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r4
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 4.4.4.4

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce1/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname ce1
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 log file bgpd.log
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce2/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname ce2
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 log file bgpd.log
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce3/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname ce3
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 log file bgpd.log
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce4/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce4/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname ce4
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 log file bgpd.log
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r1/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r1
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 
 log file bgpd.log debugging

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r2/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r2
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 log file bgpd.log debugging
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r3/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r3
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 log file bgpd.log
 

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r4/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r4/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r4
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 log file bgpd.log debug
 

--- a/tests/topotests/bgp_prefix_sid/r1/bgpd.conf
+++ b/tests/topotests/bgp_prefix_sid/r1/bgpd.conf
@@ -1,5 +1,4 @@
 log stdout notifications
-log monitor notifications
 log commands
 !
 router bgp 1

--- a/tests/topotests/bgp_rfapi_basic_sanity/r1/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r1/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r1
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 1.1.1.1

--- a/tests/topotests/bgp_rfapi_basic_sanity/r2/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r2/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r2
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 2.2.2.2

--- a/tests/topotests/bgp_rfapi_basic_sanity/r3/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r3/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r3
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 3.3.3.3

--- a/tests/topotests/bgp_rfapi_basic_sanity/r4/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r4/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r4
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 4.4.4.4

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r1/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r1/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r1
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 1.1.1.1

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r2/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r2/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r2
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 2.2.2.2

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r3/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r3/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r3
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 3.3.3.3

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r4/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r4/bgpd.conf
@@ -3,7 +3,6 @@ frr defaults traditional
 hostname r4
 password zebra
 log stdout notifications
-log monitor notifications
 log commands
 router bgp 5226
    bgp router-id 4.4.4.4


### PR DESCRIPTION
The `log monitor' command is a no-op and actually
outputs a `this doesn't do anything` warning.  Let's remove
this cli line from our tests as that don't do anything and
people will look at these configs for guidance.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>