### PR TITLE
bgpd: Bypass SA tests regarding division by zero for reuse_limit in dampening

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -50,6 +50,12 @@ static int bgp_reuse_index(int penalty, struct bgp_damp_config *bdc)
 	unsigned int i;
 	int index;
 
+	/*
+	 * reuse_limit can't be zero, this is for Coverity
+	 * to bypass division by zero test.
+	 */
+	assert(bdc->reuse_limit);
+
 	i = (int)(((double)penalty / bdc->reuse_limit - 1.0)
 		  * bdc->scale_factor);
 


### PR DESCRIPTION
reuse_limit can't be zero basically, Coverity just does not know how the
value comes in.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>