### PR TITLE
Some ad-hoc work that is independent of actual bug fixes/feature work I am doing

### DIFF
--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -78,7 +78,8 @@ keyword. At present, no sharp commands will be preserved in the config.
    The nexthop or import choice chooses the type of nexthop we are asking
    zebra to watch for us.  This choice affects zebra's decision on what
    matches.  Connected tells zebra whether or not that we want the route
-   matched against to be a static or connected route.  The no form of
+   matched against to be a static or connected route for the nexthop keyword,
+   for the import keyword connected means exact match.  The no form of
    the command obviously turns this watching off.
 
 .. index:: sharp data nexthop

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -131,8 +131,8 @@ DEFPY(sharp_nht_data_dump,
       sharp_nht_data_dump_cmd,
       "sharp data nexthop",
       "Sharp routing Protocol\n"
-      "Nexthop information\n"
-      "Data Dump\n")
+      "Data about what is going on\n"
+      "Nexthop information\n")
 {
 	sharp_nh_tracker_dump(vty);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1078,7 +1078,8 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 
 	s = msg;
 
-	client->nh_reg_time = monotime(NULL);
+	if (!client->nh_reg_time)
+		client->nh_reg_time = monotime(NULL);
 
 	while (l < hdr->length) {
 		STREAM_GETC(s, flags);


### PR DESCRIPTION
See individual commits

1) Only store first nht registration time
2) sharpd help text was wrong
3) sharpd doc was wrong
4) Make a function static since it's never used.