### PR TITLE
BGP : Fix for nexthop as IPv4 mapped IPv6 address

### DIFF
--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -574,6 +574,18 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 			gnh_modified = 1;
 		}
 
+		if (IN6_IS_ADDR_UNSPECIFIED(mod_v6nhg)) {
+			if (peer->nexthop.v4.s_addr) {
+				ipv4_to_ipv4_mapped_ipv6(mod_v6nhg,
+							 peer->nexthop.v4);
+			}
+		}
+
+		if (IS_MAPPED_IPV6(&peer->nexthop.v6_global)) {
+			mod_v6nhg = &peer->nexthop.v6_global;
+			gnh_modified = 1;
+		}
+
 		if (nhlen == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL
 		    || nhlen == BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL) {
 			stream_get_from(&v6nhlocal, s, offset_nhlocal,

--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -89,6 +89,13 @@ static inline char *ipaddr2str(const struct ipaddr *ip, char *buf, int size)
 	return buf;
 }
 
+#define IS_MAPPED_IPV6(A)                                                      \
+	((A)->s6_addr32[0] == 0x00000000                                       \
+		 ? ((A)->s6_addr32[1] == 0x00000000                            \
+			    ? (ntohl((A)->s6_addr32[2]) == 0xFFFF ? 1 : 0)     \
+			    : 0)                                               \
+		 : 0)
+
 /*
  * Convert IPv4 address to IPv4-mapped IPv6 address which is of the
  * form ::FFFF:<IPv4 address> (RFC 4291). This IPv6 address can then

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1051,14 +1051,17 @@ static bool _netlink_route_add_gateway_info(uint8_t route_family,
 				 bytelen + 2))
 			return false;
 	} else {
-		if (gw_family == AF_INET) {
-			if (!nl_attr_put(nlmsg, req_size, RTA_GATEWAY,
-					 &nexthop->gate.ipv4, bytelen))
-				return false;
-		} else {
-			if (!nl_attr_put(nlmsg, req_size, RTA_GATEWAY,
-					 &nexthop->gate.ipv6, bytelen))
-				return false;
+		if (!(nexthop->rparent
+		      && IS_MAPPED_IPV6(&nexthop->rparent->gate.ipv6))) {
+			if (gw_family == AF_INET) {
+				if (!nl_attr_put(nlmsg, req_size, RTA_GATEWAY,
+						 &nexthop->gate.ipv4, bytelen))
+					return false;
+			} else {
+				if (!nl_attr_put(nlmsg, req_size, RTA_GATEWAY,
+						 &nexthop->gate.ipv6, bytelen))
+					return false;
+			}
 		}
 	}
 


### PR DESCRIPTION
1. Added a macro to validate the IPv4 Mapped IPv6 address.
2. Modifications done for bgp receive and while sending updates
   for IPv4 Mapped IPv6 address as nexthop.
3. Modifications done for installing IPv4 Mapped IPv6 address as nexthop
   in RIB.
4. Minor correction done in fpm while sending the routes for
   nexthop as IPv4 Mapped IPv6 address.

Signed-off-by: Kaushik <kaushik@niralnetworks.com>