### PR TITLE
ospfd: Fix Zebra route add message truncation issue

### DIFF
--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -276,7 +276,7 @@ void ospf_zebra_add(struct ospf *ospf, struct prefix_ipv4 *p,
 		count++;
 
 		if (IS_DEBUG_OSPF(zebra, ZEBRA_REDISTRIBUTE)) {
-			char buf[2][INET_ADDRSTRLEN];
+			char buf[2][PREFIX2STR_BUFFER];
 			struct interface *ifp;
 
 			ifp = if_lookup_by_index(path->ifindex, ospf->vrf_id);


### PR DESCRIPTION
The `INET_ADDRSTRLEN` is 16 and is only enough to format an IPv4 address.  So when there is a prefix (`/xx`), the debug output may get truncated. Use `PREFIX2STR_BUFFER` macro instead to fix the issue.