### PR TITLE
tests: Skipping evpn_type5_test_topo1 tests from CI runs

### DIFF
--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
@@ -22,7 +22,6 @@
 
 """
 Following tests are covered to test EVPN-Type5 functionality:
-
 1. In absence of an overlay index all IP-Prefixes(RT-5)
     are advertised with default values for below parameters:
         --> Ethernet Tag ID = GW IP address = ESI=0

--- a/tests/topotests/pytest.ini
+++ b/tests/topotests/pytest.ini
@@ -1,6 +1,6 @@
 # Skip pytests example directory
 [pytest]
-norecursedirs = .git example-test example-topojson-test lib docker
+norecursedirs = .git example-test example-topojson-test lib docker evpn_type5_test_topo1
 
 [topogen]
 # Default configuration values


### PR DESCRIPTION
1. evpn_type5_test_topo1 tests started failing in CI for all Ubuntu 18.04 machine,
which are having kernel version: 5.4.0-42-generic
2. We will enable these tests once issue is found and fixed.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>