### PR TITLE
Bgp auth vrf frr

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -160,12 +160,26 @@ static int bgp_md5_set_password(struct peer *peer, const char *password)
 	 */
 	frr_with_privs(&bgpd_privs) {
 		for (ALL_LIST_ELEMENTS_RO(bm->listen_sockets, node, listener))
-			if (listener->su.sa.sa_family
-			    == peer->su.sa.sa_family) {
+			if (listener->su.sa.sa_family ==
+			    peer->su.sa.sa_family) {
 				uint16_t prefixlen =
 					peer->su.sa.sa_family == AF_INET
-						? IPV4_MAX_PREFIXLEN
-						: IPV6_MAX_PREFIXLEN;
+					? IPV4_MAX_PREFIXLEN
+					: IPV6_MAX_PREFIXLEN;
+
+				/*
+				 * if we have stored a BGP vrf instance in the
+				 * listener it must match the bgp instance in
+				 * the peer otherwise the peer bgp instance
+				 * must be the default vrf or a view instance
+				 */
+				if (!listener->bgp) {
+					if (peer->bgp->vrf_id != VRF_DEFAULT
+					    && peer->bgp->inst_type
+						       != BGP_INSTANCE_TYPE_VIEW)
+						continue;
+				} else if (listener->bgp != peer->bgp)
+					continue;
 
 				ret = bgp_md5_set_socket(listener->fd,
 							 &peer->su, prefixlen,
@@ -176,7 +190,7 @@ static int bgp_md5_set_password(struct peer *peer, const char *password)
 	return ret;
 }
 
-int bgp_md5_set_prefix(struct prefix *p, const char *password)
+int bgp_md5_set_prefix(struct bgp *bgp, struct prefix *p, const char *password)
 {
 	int ret = 0;
 	union sockunion su;
@@ -186,7 +200,9 @@ int bgp_md5_set_prefix(struct prefix *p, const char *password)
 	/* Set or unset the password on the listen socket(s). */
 	frr_with_privs(&bgpd_privs) {
 		for (ALL_LIST_ELEMENTS_RO(bm->listen_sockets, node, listener))
-			if (listener->su.sa.sa_family == p->family) {
+			if (listener->su.sa.sa_family == p->family
+			    && ((bgp->vrf_id == VRF_DEFAULT)
+				|| (listener->bgp == bgp))) {
 				prefix2sockunion(p, &su);
 				ret = bgp_md5_set_socket(listener->fd, &su,
 							 p->prefixlen,
@@ -198,9 +214,9 @@ int bgp_md5_set_prefix(struct prefix *p, const char *password)
 	return ret;
 }
 
-int bgp_md5_unset_prefix(struct prefix *p)
+int bgp_md5_unset_prefix(struct bgp *bgp, struct prefix *p)
 {
-	return bgp_md5_set_prefix(p, NULL);
+	return bgp_md5_set_prefix(bgp, p, NULL);
 }
 
 int bgp_md5_set(struct peer *peer)
@@ -812,8 +828,9 @@ static int bgp_listener(int sock, struct sockaddr *sa, socklen_t salen,
 	listener->fd = sock;
 	listener->name = XSTRDUP(MTYPE_BGP_LISTENER, bgp->name);
 
-	/* this socket needs a change of ns. record bgp back pointer */
-	if (bgp->vrf_id != VRF_DEFAULT && vrf_is_backend_netns())
+	/* this socket is in a vrf record bgp back pointer */
+	if (bgp->vrf_id != VRF_DEFAULT
+	    && bgp->inst_type != BGP_INSTANCE_TYPE_VIEW)
 		listener->bgp = bgp;
 
 	memcpy(&listener->su, sa, salen);

--- a/bgpd/bgp_network.h
+++ b/bgpd/bgp_network.h
@@ -31,8 +31,9 @@ extern void bgp_close(void);
 extern int bgp_connect(struct peer *);
 extern int bgp_getsockname(struct peer *);
 
-extern int bgp_md5_set_prefix(struct prefix *p, const char *password);
-extern int bgp_md5_unset_prefix(struct prefix *p);
+extern int bgp_md5_set_prefix(struct bgp *bgp, struct prefix *p,
+			      const char *password);
+extern int bgp_md5_unset_prefix(struct bgp *bgp, struct prefix *p);
 extern int bgp_md5_set(struct peer *);
 extern int bgp_md5_unset(struct peer *);
 extern int bgp_set_socket_ttl(struct peer *, int fd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2284,9 +2284,9 @@ int peer_delete(struct peer *peer)
 	/* Password configuration */
 	if (CHECK_FLAG(peer->flags, PEER_FLAG_PASSWORD)) {
 		XFREE(MTYPE_PEER_PASSWORD, peer->password);
-
 		if (!accept_peer && !BGP_PEER_SU_UNSPEC(peer)
-		    && !CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+		    && !CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)
+		    && !CHECK_FLAG(peer->flags, PEER_FLAG_DYNAMIC_NEIGHBOR))
 			bgp_md5_unset(peer);
 	}
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2668,7 +2668,7 @@ int peer_group_listen_range_add(struct peer_group *group, struct prefix *range)
 
 	/* Update passwords for new ranges */
 	if (group->conf->password)
-		bgp_md5_set_prefix(prefix, group->conf->password);
+		bgp_md5_set_prefix(group->bgp, prefix, group->conf->password);
 
 	return 0;
 }
@@ -2715,7 +2715,7 @@ int peer_group_listen_range_del(struct peer_group *group, struct prefix *range)
 
 	/* Remove passwords for deleted ranges */
 	if (group->conf->password)
-		bgp_md5_unset_prefix(prefix);
+		bgp_md5_unset_prefix(group->bgp, prefix);
 
 	return 0;
 }
@@ -5621,9 +5621,9 @@ int peer_password_set(struct peer *peer, const char *password)
 	struct prefix *lr;
 
 	for (ALL_LIST_ELEMENTS_RO(peer->group->listen_range[AFI_IP], ln, lr))
-		bgp_md5_set_prefix(lr, password);
+		bgp_md5_set_prefix(peer->bgp, lr, password);
 	for (ALL_LIST_ELEMENTS_RO(peer->group->listen_range[AFI_IP6], ln, lr))
-		bgp_md5_set_prefix(lr, password);
+		bgp_md5_set_prefix(peer->bgp, lr, password);
 
 	return ret;
 }
@@ -5659,7 +5659,6 @@ int peer_password_unset(struct peer *peer)
 		/* Attempt to uninstall password on socket. */
 		if (!BGP_PEER_SU_UNSPEC(peer))
 			bgp_md5_unset(peer);
-
 		/* Skip peer-group mechanics for regular peers. */
 		return 0;
 	}
@@ -5694,9 +5693,9 @@ int peer_password_unset(struct peer *peer)
 	struct prefix *lr;
 
 	for (ALL_LIST_ELEMENTS_RO(peer->group->listen_range[AFI_IP], ln, lr))
-		bgp_md5_unset_prefix(lr);
+		bgp_md5_unset_prefix(peer->bgp, lr);
 	for (ALL_LIST_ELEMENTS_RO(peer->group->listen_range[AFI_IP6], ln, lr))
-		bgp_md5_unset_prefix(lr);
+		bgp_md5_unset_prefix(peer->bgp, lr);
 
 	return 0;
 }

--- a/tests/topotests/bgp-auth/R1/bgpd.conf
+++ b/tests/topotests/bgp-auth/R1/bgpd.conf
@@ -1,0 +1,18 @@
+router bgp 65001
+ timers bgp 3 9
+ bgp router-id 1.1.1.1
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 password hello1
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 password hello2
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ address-family ipv4 unicast
+  neighbor 2.2.2.2 activate
+  neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp-auth/R1/bgpd_multi_vrf.conf
+++ b/tests/topotests/bgp-auth/R1/bgpd_multi_vrf.conf
@@ -1,0 +1,40 @@
+log file /tmp/topotests/test_bgp_auth/R1/bgpd.log debugging
+debug bgp neighbor-events
+
+router bgp 65001 vrf blue
+ timers bgp 3 9
+ bgp router-id 1.1.1.1
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo1
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 password blue1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo1
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password blue2
+ address-family ipv4 unicast
+  neighbor 2.2.2.2 activate
+  neighbor 3.3.3.3 activate
+
+router bgp 65001 vrf red
+ timers bgp 3 9
+ bgp router-id 1.1.1.1
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo2
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 password red1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo2
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password red2
+ address-family ipv4 unicast
+  neighbor 2.2.2.2 activate
+  neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp-auth/R1/bgpd_multi_vrf_prefix.conf
+++ b/tests/topotests/bgp-auth/R1/bgpd_multi_vrf_prefix.conf
@@ -1,0 +1,37 @@
+router bgp 65001 vrf blue
+ timers bgp 3 9
+ bgp router-id 1.1.1.1
+ neighbor TWO_GROUP_blue peer-group
+ neighbor TWO_GROUP_blue remote-as 65002
+ neighbor TWO_GROUP_blue update-source 1.1.1.1
+ neighbor TWO_GROUP_blue ebgp-multihop 3
+ neighbor TWO_GROUP_blue password blue1
+ neighbor THREE_GROUP_blue peer-group
+ neighbor THREE_GROUP_blue remote-as 65003
+ neighbor THREE_GROUP_blue update-source 1.1.1.1
+ neighbor THREE_GROUP_blue ebgp-multihop 3
+ neighbor THREE_GROUP_blue password blue2
+ bgp listen range 2.2.2.0/24 peer-group TWO_GROUP_blue 
+ bgp listen range 3.3.3.0/24 peer-group THREE_GROUP_blue
+ address-family ipv4 unicast
+ neighbor TWO_GROUP_blue maximum-prefix 4294967295
+ neighbor THREE_GROUP_blue maximum-prefix 4294967295
+
+router bgp 65001 vrf red
+ timers bgp 3 9
+ bgp router-id 1.1.1.1
+ neighbor TWO_GROUP_red peer-group
+ neighbor TWO_GROUP_red remote-as 65002
+ neighbor TWO_GROUP_red update-source 1.1.1.1
+ neighbor TWO_GROUP_red ebgp-multihop 3
+ neighbor TWO_GROUP_red password red1
+ neighbor THREE_GROUP_red peer-group
+ neighbor THREE_GROUP_red remote-as 65003
+ neighbor THREE_GROUP_red update-source 1.1.1.1
+ neighbor THREE_GROUP_red ebgp-multihop 3
+ neighbor THREE_GROUP_red password red2
+ bgp listen range 2.2.2.0/24 peer-group TWO_GROUP_red
+ bgp listen range 3.3.3.0/24 peer-group THREE_GROUP_red
+ address-family ipv4 unicast
+ neighbor TWO_GROUP_red maximum-prefix 4294967295
+ neighbor THREE_GROUP_red maximum-prefix 4294967295

--- a/tests/topotests/bgp-auth/R1/bgpd_prefix.conf
+++ b/tests/topotests/bgp-auth/R1/bgpd_prefix.conf
@@ -1,0 +1,18 @@
+router bgp 65001
+ timers bgp 3 9
+ bgp router-id 1.1.1.1
+ neighbor TWO_GROUP peer-group
+ neighbor TWO_GROUP remote-as 65002
+ neighbor TWO_GROUP update-source 1.1.1.1
+ neighbor TWO_GROUP ebgp-multihop 3
+ neighbor TWO_GROUP password hello1
+ neighbor THREE_GROUP peer-group
+ neighbor THREE_GROUP remote-as 65003
+ neighbor THREE_GROUP update-source 1.1.1.1
+ neighbor THREE_GROUP ebgp-multihop 3
+ neighbor THREE_GROUP password hello2
+ bgp listen range 2.2.2.0/24 peer-group TWO_GROUP 
+ bgp listen range 3.3.3.0/24 peer-group THREE_GROUP 
+ address-family ipv4 unicast
+ neighbor TWO_GROUP maximum-prefix 4294967295
+ neighbor THREE_GROUP maximum-prefix 4294967295

--- a/tests/topotests/bgp-auth/R1/bgpd_vrf.conf
+++ b/tests/topotests/bgp-auth/R1/bgpd_vrf.conf
@@ -1,0 +1,21 @@
+log file /tmp/topotests/test_bgp_auth/R1/bgpd.log debugging
+debug bgp neighbor-events
+
+router bgp 65001 vrf blue
+ timers bgp 3 9
+ bgp router-id 1.1.1.1
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo1
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 password hello1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo1
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password hello2
+ address-family ipv4 unicast
+  neighbor 2.2.2.2 activate
+  neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp-auth/R1/bgpd_vrf_prefix.conf
+++ b/tests/topotests/bgp-auth/R1/bgpd_vrf_prefix.conf
@@ -1,0 +1,18 @@
+router bgp 65001 vrf blue
+ timers bgp 3 9
+ bgp router-id 1.1.1.1
+ neighbor TWO_GROUP_blue peer-group
+ neighbor TWO_GROUP_blue remote-as 65002
+ neighbor TWO_GROUP_blue update-source 1.1.1.1
+ neighbor TWO_GROUP_blue ebgp-multihop 3
+ neighbor TWO_GROUP_blue password hello1
+ neighbor THREE_GROUP_blue peer-group
+ neighbor THREE_GROUP_blue remote-as 65003
+ neighbor THREE_GROUP_blue update-source 1.1.1.1
+ neighbor THREE_GROUP_blue ebgp-multihop 3
+ neighbor THREE_GROUP_blue password hello2
+ bgp listen range 2.2.2.0/24 peer-group TWO_GROUP_blue
+ bgp listen range 3.3.3.0/24 peer-group THREE_GROUP_blue 
+ address-family ipv4 unicast
+ neighbor TWO_GROUP_blue maximum-prefix 4294967295
+ neighbor THREE_GROUP_blue maximum-prefix 4294967295

--- a/tests/topotests/bgp-auth/R1/ospfd.conf
+++ b/tests/topotests/bgp-auth/R1/ospfd.conf
@@ -1,0 +1,4 @@
+router ospf
+ network 10.10.0.0/16 area 0
+ network 10.20.0.0/16 area 0
+ network 1.1.1.1/32 area 0

--- a/tests/topotests/bgp-auth/R1/ospfd_multi_vrf.conf
+++ b/tests/topotests/bgp-auth/R1/ospfd_multi_vrf.conf
@@ -1,0 +1,9 @@
+router ospf vrf blue
+ network 10.10.0.0/16 area 0
+ network 10.20.0.0/16 area 0
+ network 1.1.1.1/32 area 0
+
+router ospf vrf red
+ network 10.10.0.0/16 area 0
+ network 10.20.0.0/16 area 0
+ network 1.1.1.1/32 area 0

--- a/tests/topotests/bgp-auth/R1/ospfd_vrf.conf
+++ b/tests/topotests/bgp-auth/R1/ospfd_vrf.conf
@@ -1,0 +1,4 @@
+router ospf vrf blue
+ network 10.10.0.0/16 area 0
+ network 10.20.0.0/16 area 0
+ network 1.1.1.1/32 area 0

--- a/tests/topotests/bgp-auth/R1/zebra.conf
+++ b/tests/topotests/bgp-auth/R1/zebra.conf
@@ -1,0 +1,21 @@
+log file zebra.log
+!
+interface lo
+ ip address 1.1.1.1/32
+interface lo1 vrf blue
+ ip address 1.1.1.1/32
+interface lo2 vrf red
+ ip address 1.1.1.1/32
+interface R1-eth0
+ ip address 10.10.0.1/24
+interface R1-eth1
+ ip address 10.20.0.1/24
+interface R1-eth2 vrf blue
+ ip address 10.10.0.1/24
+interface R1-eth3 vrf blue
+ ip address 10.20.0.1/24
+interface R1-eth4 vrf red
+ ip address 10.10.0.1/24
+interface R1-eth5 vrf red
+ ip address 10.20.0.1/24
+!

--- a/tests/topotests/bgp-auth/R2/bgpd.conf
+++ b/tests/topotests/bgp-auth/R2/bgpd.conf
@@ -1,0 +1,18 @@
+router bgp 65002
+ timers bgp 3 9
+ bgp router-id 2.2.2.2
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password hello1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password hello3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp-auth/R2/bgpd_multi_vrf.conf
+++ b/tests/topotests/bgp-auth/R2/bgpd_multi_vrf.conf
@@ -1,0 +1,37 @@
+router bgp 65002 vrf blue
+ timers bgp 3 9
+ bgp router-id 2.2.2.2
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo1
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password blue1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo1
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password blue3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 3.3.3.3 activate
+
+router bgp 65002 vrf red
+ timers bgp 3 9
+ bgp router-id 2.2.2.2
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo2
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password red1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo2
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password red3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp-auth/R2/bgpd_multi_vrf_prefix.conf
+++ b/tests/topotests/bgp-auth/R2/bgpd_multi_vrf_prefix.conf
@@ -1,0 +1,37 @@
+router bgp 65002 vrf blue
+ timers bgp 3 9
+ bgp router-id 2.2.2.2
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo1
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password blue1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo1
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password blue3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 3.3.3.3 activate
+
+router bgp 65002 vrf red
+ timers bgp 3 9
+ bgp router-id 2.2.2.2
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo2
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password red1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo2
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password red3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp-auth/R2/bgpd_prefix.conf
+++ b/tests/topotests/bgp-auth/R2/bgpd_prefix.conf
@@ -1,0 +1,18 @@
+router bgp 65002
+ timers bgp 3 9
+ bgp router-id 2.2.2.2
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password hello1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password hello3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp-auth/R2/bgpd_vrf.conf
+++ b/tests/topotests/bgp-auth/R2/bgpd_vrf.conf
@@ -1,0 +1,18 @@
+router bgp 65002 vrf blue
+ timers bgp 3 9
+ bgp router-id 2.2.2.2
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo1
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password hello1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo1
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password hello3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp-auth/R2/bgpd_vrf_prefix.conf
+++ b/tests/topotests/bgp-auth/R2/bgpd_vrf_prefix.conf
@@ -1,0 +1,18 @@
+router bgp 65002 vrf blue
+ timers bgp 3 9
+ bgp router-id 2.2.2.2
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo1
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password hello1
+ neighbor 3.3.3.3 remote-as 65003
+ neighbor 3.3.3.3 update-source lo1
+ neighbor 3.3.3.3 ebgp-multihop 3
+ neighbor 3.3.3.3 timers 3 10
+ neighbor 3.3.3.3 timers connect 10
+ neighbor 3.3.3.3 password hello3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp-auth/R2/ospfd.conf
+++ b/tests/topotests/bgp-auth/R2/ospfd.conf
@@ -1,0 +1,4 @@
+router ospf
+ network 10.10.0.0/16 area 0
+ network 10.30.0.0/16 area 0
+ network 2.2.2.2/32 area 0

--- a/tests/topotests/bgp-auth/R2/ospfd_multi_vrf.conf
+++ b/tests/topotests/bgp-auth/R2/ospfd_multi_vrf.conf
@@ -1,0 +1,9 @@
+router ospf vrf blue
+ network 10.10.0.0/16 area 0
+ network 10.30.0.0/16 area 0
+ network 2.2.2.2/32 area 0
+
+router ospf vrf red
+ network 10.10.0.0/16 area 0
+ network 10.30.0.0/16 area 0
+ network 2.2.2.2/32 area 0

--- a/tests/topotests/bgp-auth/R2/ospfd_vrf.conf
+++ b/tests/topotests/bgp-auth/R2/ospfd_vrf.conf
@@ -1,0 +1,4 @@
+router ospf vrf blue
+ network 10.10.0.0/16 area 0
+ network 10.30.0.0/16 area 0
+ network 2.2.2.2/32 area 0

--- a/tests/topotests/bgp-auth/R2/zebra.conf
+++ b/tests/topotests/bgp-auth/R2/zebra.conf
@@ -1,0 +1,21 @@
+log file zebra.log
+!
+interface lo
+ ip address 2.2.2.2/32
+interface lo1 vrf blue
+ ip address 2.2.2.2/32
+interface lo2 vrf red
+ ip address 2.2.2.2/32
+interface R2-eth0
+ ip address 10.10.0.2/24
+interface R2-eth1
+ ip address 10.30.0.2/24
+interface R2-eth2 vrf blue
+ ip address 10.10.0.2/24
+interface R2-eth3 vrf blue
+ ip address 10.30.0.2/24
+interface R2-eth4 vrf red
+ ip address 10.10.0.2/24
+interface R2-eth5 vrf red
+ ip address 10.30.0.2/24
+!

--- a/tests/topotests/bgp-auth/R3/bgpd.conf
+++ b/tests/topotests/bgp-auth/R3/bgpd.conf
@@ -1,0 +1,18 @@
+router bgp 65003
+ timers bgp 3 9
+ bgp router-id 3.3.3.3
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password hello2
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 password hello3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 2.2.2.2 activate

--- a/tests/topotests/bgp-auth/R3/bgpd_multi_vrf.conf
+++ b/tests/topotests/bgp-auth/R3/bgpd_multi_vrf.conf
@@ -1,0 +1,37 @@
+router bgp 65003 vrf blue
+ timers bgp 3 9
+ bgp router-id 3.3.3.3
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo1
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password blue2
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo1
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 password blue3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 2.2.2.2 activate
+
+router bgp 65003 vrf red
+ timers bgp 3 9
+ bgp router-id 3.3.3.3
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo2
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password red2
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo2
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 password red3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 2.2.2.2 activate

--- a/tests/topotests/bgp-auth/R3/bgpd_multi_vrf_prefix.conf
+++ b/tests/topotests/bgp-auth/R3/bgpd_multi_vrf_prefix.conf
@@ -1,0 +1,37 @@
+router bgp 65003 vrf blue
+ timers bgp 3 9
+ bgp router-id 3.3.3.3
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo1
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password blue2
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo1
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 password blue3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 2.2.2.2 activate
+
+router bgp 65003 vrf red
+ timers bgp 3 9
+ bgp router-id 3.3.3.3
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo2
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password red2
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo2
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 password red3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 2.2.2.2 activate

--- a/tests/topotests/bgp-auth/R3/bgpd_prefix.conf
+++ b/tests/topotests/bgp-auth/R3/bgpd_prefix.conf
@@ -1,0 +1,18 @@
+router bgp 65003
+ timers bgp 3 9
+ bgp router-id 3.3.3.3
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password hello2
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 password hello3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 2.2.2.2 activate

--- a/tests/topotests/bgp-auth/R3/bgpd_vrf.conf
+++ b/tests/topotests/bgp-auth/R3/bgpd_vrf.conf
@@ -1,0 +1,18 @@
+router bgp 65003 vrf blue
+ timers bgp 3 9
+ bgp router-id 3.3.3.3
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo1
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password hello2
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo1
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 password hello3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 2.2.2.2 activate

--- a/tests/topotests/bgp-auth/R3/bgpd_vrf_prefix.conf
+++ b/tests/topotests/bgp-auth/R3/bgpd_vrf_prefix.conf
@@ -1,0 +1,18 @@
+router bgp 65003 vrf blue
+ timers bgp 3 9
+ bgp router-id 3.3.3.3
+ neighbor 1.1.1.1 remote-as 65001
+ neighbor 1.1.1.1 update-source lo1
+ neighbor 1.1.1.1 ebgp-multihop 3
+ neighbor 1.1.1.1 timers 3 10
+ neighbor 1.1.1.1 timers connect 10
+ neighbor 1.1.1.1 password hello2
+ neighbor 2.2.2.2 remote-as 65002
+ neighbor 2.2.2.2 update-source lo1
+ neighbor 2.2.2.2 ebgp-multihop 3
+ neighbor 2.2.2.2 timers connect 10
+ neighbor 2.2.2.2 timers 3 10
+ neighbor 2.2.2.2 password hello3
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 activate
+  neighbor 2.2.2.2 activate

--- a/tests/topotests/bgp-auth/R3/ospfd.conf
+++ b/tests/topotests/bgp-auth/R3/ospfd.conf
@@ -1,0 +1,4 @@
+router ospf
+ network 10.20.0.0/16 area 0
+ network 10.30.0.0/16 area 0
+ network 3.3.3.3/32 area 0

--- a/tests/topotests/bgp-auth/R3/ospfd_multi_vrf.conf
+++ b/tests/topotests/bgp-auth/R3/ospfd_multi_vrf.conf
@@ -1,0 +1,9 @@
+router ospf vrf blue
+ network 10.20.0.0/16 area 0
+ network 10.30.0.0/16 area 0
+ network 3.3.3.3/32 area 0
+!
+router ospf vrf red
+ network 10.20.0.0/16 area 0
+ network 10.30.0.0/16 area 0
+ network 3.3.3.3/32 area 0

--- a/tests/topotests/bgp-auth/R3/ospfd_vrf.conf
+++ b/tests/topotests/bgp-auth/R3/ospfd_vrf.conf
@@ -1,0 +1,4 @@
+router ospf vrf blue
+ network 10.20.0.0/16 area 0
+ network 10.30.0.0/16 area 0
+ network 3.3.3.3/32 area 0

--- a/tests/topotests/bgp-auth/R3/zebra.conf
+++ b/tests/topotests/bgp-auth/R3/zebra.conf
@@ -1,0 +1,21 @@
+log file zebra.log
+!
+interface lo
+ ip address 3.3.3.3/32
+interface lo1 vrf blue
+ ip address 3.3.3.3/32
+interface lo2 vrf red
+ ip address 3.3.3.3/32
+interface R3-eth0
+ ip address 10.20.0.3/24
+interface R3-eth1
+ ip address 10.30.0.3/24
+interface R3-eth2 vrf blue
+ ip address 10.20.0.3/24
+interface R3-eth3 vrf blue
+ ip address 10.30.0.3/24
+interface R3-eth4 vrf red
+ ip address 10.20.0.3/24
+interface R3-eth5 vrf red
+ ip address 10.30.0.3/24
+!

--- a/tests/topotests/bgp-auth/test_bgp_auth.py
+++ b/tests/topotests/bgp-auth/test_bgp_auth.py
@@ -1,0 +1,747 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_auth.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2020 by Volta Networks
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+test_bgp_auth.py: Test BGP Md5 Authentication
+
+                             +------+
+                    +--------|      |--------+
+                    | +------|  R1  |------+ |
+                    | | -----|      |----+ | |
+                    | | |    +------+    | | |
+                    | | |                | | |
+                   +------+            +------+
+                   |      |------------|      |
+                   |  R2  |------------|  R3  |
+                   |      |------------|      |
+                   +------+            +------+
+
+
+setup is 3 routers with 3 links between each each link in a different vrf
+Default, blue and red respectively
+Tests check various fiddling with passwords and checking that the peer
+establishment is as expected and passwords are not leaked across sockets 
+for bgp instances
+"""
+
+import os
+import sys
+import json
+import platform
+from functools import partial
+import pytest
+from time import sleep
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+# Required to instantiate the topology builder class.
+from mininet.topo import Topo
+
+from lib.common_config import apply_raw_config
+
+ERROR_LIST = ["Malformed", "Failure", "Unknown", "Incomplete"]
+
+
+class InvalidCLIError(Exception):
+    """Raise when the CLI command is wrong"""
+
+    pass
+
+
+class TemplateTopo(Topo):
+    "Test topology builder"
+
+    def build(self, *_args, **_opts):
+        "Build function"
+        tgen = get_topogen(self)
+
+        # This function only purpose is to define allocation and relationship
+        # between routers, switches and hosts.
+        #
+        #
+        # Create routers
+        tgen.add_router("R1")
+        tgen.add_router("R2")
+        tgen.add_router("R3")
+
+        # R1-R2 1
+        switch = tgen.add_switch("s1")
+        switch.add_link(tgen.gears["R1"])
+        switch.add_link(tgen.gears["R2"])
+
+        # R1-R3 1
+        switch = tgen.add_switch("s2")
+        switch.add_link(tgen.gears["R1"])
+        switch.add_link(tgen.gears["R3"])
+
+        # R2-R3 1
+        switch = tgen.add_switch("s3")
+        switch.add_link(tgen.gears["R2"])
+        switch.add_link(tgen.gears["R3"])
+
+        # R1-R2 2
+        switch = tgen.add_switch("s4")
+        switch.add_link(tgen.gears["R1"])
+        switch.add_link(tgen.gears["R2"])
+
+        # R1-R3 2
+        switch = tgen.add_switch("s5")
+        switch.add_link(tgen.gears["R1"])
+        switch.add_link(tgen.gears["R3"])
+
+        # R2-R3 2
+        switch = tgen.add_switch("s6")
+        switch.add_link(tgen.gears["R2"])
+        switch.add_link(tgen.gears["R3"])
+
+        # R1-R2 3
+        switch = tgen.add_switch("s7")
+        switch.add_link(tgen.gears["R1"])
+        switch.add_link(tgen.gears["R2"])
+
+        # R1-R3 2
+        switch = tgen.add_switch("s8")
+        switch.add_link(tgen.gears["R1"])
+        switch.add_link(tgen.gears["R3"])
+
+        # R2-R3 2
+        switch = tgen.add_switch("s9")
+        switch.add_link(tgen.gears["R2"])
+        switch.add_link(tgen.gears["R3"])
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    # This function initiates the topology build with Topogen...
+    tgen = Topogen(TemplateTopo, mod.__name__)
+    # ... and here it calls Mininet initialization functions.
+    tgen.start_topology()
+
+    r1 = tgen.gears["R1"]
+    r2 = tgen.gears["R2"]
+    r3 = tgen.gears["R3"]
+
+    # blue vrf
+    r1.run("ip link add blue type vrf table 1001")
+    r1.run("ip link set up dev blue")
+    r2.run("ip link add blue type vrf table 1001")
+    r2.run("ip link set up dev blue")
+    r3.run("ip link add blue type vrf table 1001")
+    r3.run("ip link set up dev blue")
+
+    r1.run("ip link add lo1 type dummy")
+    r1.run("ip link set lo1 master blue")
+    r1.run("ip link set up dev lo1")
+    r2.run("ip link add lo1 type dummy")
+    r2.run("ip link set up dev lo1")
+    r2.run("ip link set lo1 master blue")
+    r3.run("ip link add lo1 type dummy")
+    r3.run("ip link set up dev lo1")
+    r3.run("ip link set lo1 master blue")
+
+    r1.run("ip link set R1-eth2 master blue")
+    r1.run("ip link set R1-eth3 master blue")
+    r2.run("ip link set R2-eth2 master blue")
+    r2.run("ip link set R2-eth3 master blue")
+    r3.run("ip link set R3-eth2 master blue")
+    r3.run("ip link set R3-eth3 master blue")
+
+    r1.run("ip link set up dev  R1-eth2")
+    r1.run("ip link set up dev  R1-eth3")
+    r2.run("ip link set up dev  R2-eth2")
+    r2.run("ip link set up dev  R2-eth3")
+    r3.run("ip link set up dev  R3-eth2")
+    r3.run("ip link set up dev  R3-eth3")
+
+    # red vrf
+    r1.run("ip link add red type vrf table 1002")
+    r1.run("ip link set up dev red")
+    r2.run("ip link add red type vrf table 1002")
+    r2.run("ip link set up dev red")
+    r3.run("ip link add red type vrf table 1002")
+    r3.run("ip link set up dev red")
+
+    r1.run("ip link add lo2 type dummy")
+    r1.run("ip link set lo2 master red")
+    r1.run("ip link set up dev lo2")
+    r2.run("ip link add lo2 type dummy")
+    r2.run("ip link set up dev lo2")
+    r2.run("ip link set lo2 master red")
+    r3.run("ip link add lo2 type dummy")
+    r3.run("ip link set up dev lo2")
+    r3.run("ip link set lo2 master red")
+
+    r1.run("ip link set R1-eth4 master red")
+    r1.run("ip link set R1-eth5 master red")
+    r2.run("ip link set R2-eth4 master red")
+    r2.run("ip link set R2-eth5 master red")
+    r3.run("ip link set R3-eth4 master red")
+    r3.run("ip link set R3-eth5 master red")
+
+    r1.run("ip link set up dev  R1-eth4")
+    r1.run("ip link set up dev  R1-eth5")
+    r2.run("ip link set up dev  R2-eth4")
+    r2.run("ip link set up dev  R2-eth5")
+    r3.run("ip link set up dev  R3-eth4")
+    r3.run("ip link set up dev  R3-eth5")
+
+    # This is a sample of configuration loading.
+    router_list = tgen.routers()
+
+    # For all registred routers, load the zebra configuration file
+    for rname, router in router_list.iteritems():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_OSPF, os.path.join(CWD, "{}/ospfd.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
+
+    # After loading the configurations, this function loads configured daemons.
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+
+    # This function tears down the whole topology.
+    tgen.stop_topology()
+
+
+def vrf_str(vrf):
+    if vrf == "":
+        vrf_str = ""
+    else:
+        vrf_str = "vrf {}".format(vrf)
+
+    return vrf_str
+
+
+def peer_name(rtr, prefix, vrf):
+    "generate VRF string for CLI"
+    if vrf == "":
+        vrf_str = ""
+    else:
+        vrf_str = "_" + vrf
+
+    if prefix == "yes":
+        if rtr == "R2":
+            return "TWO_GROUP" + vrf_str
+        else:
+            return "THREE_GROUP" + vrf_str
+    else:
+        if rtr == "R2":
+            return "2.2.2.2"
+        else:
+            return "3.3.3.3"
+
+
+def print_diag(vrf):
+    "print failure disagnostics"
+    
+    tgen = get_topogen()
+    router_list = tgen.routers()
+    for rname, router in router_list.iteritems():
+        print(rname + ":")
+        print(router.vtysh_cmd("show run"))
+        print(router.vtysh_cmd("show ip route {}".format(vrf_str(vrf))))
+        print(router.vtysh_cmd("show bgp {} neighbor".format(vrf_str(vrf))))
+
+
+def configure(conf_file):
+    "configure from a file"
+
+    tgen = get_topogen()
+    router_list = tgen.routers()
+    for rname, router in router_list.iteritems():
+        with open(
+            os.path.join(CWD, "{}/{}").format(router.name, conf_file), "r+"
+        ) as cfg:
+            new_config = cfg.read()
+
+            output = router.vtysh_multicmd(new_config, pretty_output=False)
+            for out_err in ERROR_LIST:
+                if out_err.lower() in output.lower():
+                    raise InvalidCLIError("%s" % output)
+
+
+def clear_bgp(vrf=""):
+    " clear bgp configuration for a vrf"
+
+    tgen = get_topogen()
+    r1 = tgen.gears["R1"]
+    r2 = tgen.gears["R2"]
+    r3 = tgen.gears["R3"]
+
+    router_list = tgen.routers()
+    if vrf == "":
+        r1.vtysh_cmd("conf t\nno router bgp 65001")
+        r2.vtysh_cmd("conf t\nno router bgp 65002")
+        r2.vtysh_cmd("conf t\nno router bgp 65003")
+    else:
+        r1.vtysh_cmd("conf t\nno router bgp 65001 vrf {}".format(vrf))
+        r2.vtysh_cmd("conf t\nno router bgp 65002 vrf {}".format(vrf))
+        r3.vtysh_cmd("conf t\nno router bgp 65003 vrf {}".format(vrf))
+
+
+def clear_ospf(vrf=""):
+    "clear ospf configuration for a vrf"
+
+    tgen = get_topogen()
+    router_list = tgen.routers()
+    for rname, router in router_list.iteritems():
+        if vrf == "":
+            router.vtysh_cmd("conf t\nno router ospf")
+        else:
+            router.vtysh_cmd("conf t\nno router ospf vrf {}".format(vrf))
+
+
+def check_neigh_state(router, peer, state, vrf=""):
+    "check BGP neighbor state on a router"
+    
+    count = 0
+    matched = False
+    neigh_output = ""
+    while count < 125:
+        if vrf == "":
+            neigh_output = router.vtysh_cmd("show bgp neighbors {} json".format(peer))
+        else:
+            neigh_output = router.vtysh_cmd(
+                "show bgp vrf {} neighbors {} json".format(vrf, peer)
+            )
+        neigh_output_json = json.loads(neigh_output)
+        if neigh_output_json[peer]["bgpState"] == state:
+            matched = True
+            break
+        count += 1
+        sleep(1)
+
+    assertmsg = "{} could not peer {} state expected {} got {} ".format(
+        router.name, peer, state, neigh_output_json[peer]["bgpState"]
+    )
+    if matched != True:
+        print_diag(vrf)
+    assert matched == True, assertmsg
+
+
+def check_all_peers_established(vrf=""):
+    "standard check for extablished peers per vrf"
+
+    tgen = get_topogen()
+    r1 = tgen.gears["R1"]
+    r2 = tgen.gears["R2"]
+    r3 = tgen.gears["R3"]
+    # do r1 last as he might be the dynamic one
+    check_neigh_state(r2, "1.1.1.1", "Established", vrf)
+    check_neigh_state(r2, "3.3.3.3", "Established", vrf)
+    check_neigh_state(r3, "1.1.1.1", "Established", vrf)
+    check_neigh_state(r3, "2.2.2.2", "Established", vrf)
+    check_neigh_state(r1, "2.2.2.2", "Established", vrf)
+    check_neigh_state(r1, "3.3.3.3", "Established", vrf)
+
+
+def check_vrf_peer_remove_passwords(vrf="", prefix="no"):
+    "selectively remove passwords checking state"
+
+    tgen = get_topogen()
+    r1 = tgen.gears["R1"]
+    r2 = tgen.gears["R2"]
+    r3 = tgen.gears["R3"]
+
+    r1.vtysh_cmd(
+        "conf t\nrouter bgp 65001 {}\nno neighbor {} password".format(
+            vrf_str(vrf), peer_name("R2", prefix, vrf)
+        )
+    )
+
+    check_neigh_state(r2, "1.1.1.1", "Connect", vrf)
+    check_neigh_state(r2, "3.3.3.3", "Established", vrf)
+    check_neigh_state(r3, "1.1.1.1", "Established", vrf)
+    check_neigh_state(r3, "2.2.2.2", "Established", vrf)
+    # don't check dynamic downed peers - they are removed
+    if prefix == "no":
+        check_neigh_state(r1, "2.2.2.2", "Connect", vrf)
+    check_neigh_state(r1, "3.3.3.3", "Established", vrf)
+
+    r2.vtysh_cmd(
+        "conf t\nrouter bgp 65002 {}\nno neighbor 1.1.1.1 password".format(vrf_str(vrf))
+    )
+    check_all_peers_established(vrf)
+
+    r1.vtysh_cmd(
+        "conf t\nrouter bgp 65001 {}\nno neighbor {} password".format(
+            vrf_str(vrf), peer_name("R3", prefix, vrf)
+        )
+    )
+    check_neigh_state(r2, "1.1.1.1", "Established", vrf)
+    check_neigh_state(r2, "3.3.3.3", "Established", vrf)
+    check_neigh_state(r3, "1.1.1.1", "Connect", vrf)
+    check_neigh_state(r3, "2.2.2.2", "Established", vrf)
+    check_neigh_state(r1, "2.2.2.2", "Established", vrf)
+    # don't check dynamic downed peers - they are removed
+    if prefix == "no":
+        check_neigh_state(r1, "3.3.3.3", "Connect", vrf)
+
+    r3.vtysh_cmd(
+        "conf t\nrouter bgp 65003 {}\nno neighbor 1.1.1.1 password".format(vrf_str(vrf))
+    )
+    check_all_peers_established(vrf)
+
+    r2.vtysh_cmd(
+        "conf t\nrouter bgp 65002 {}\nno neighbor 3.3.3.3 password".format(vrf_str(vrf))
+    )
+    check_neigh_state(r2, "1.1.1.1", "Established", vrf)
+    check_neigh_state(r2, "3.3.3.3", "Connect", vrf)
+    check_neigh_state(r3, "1.1.1.1", "Established", vrf)
+    check_neigh_state(r3, "2.2.2.2", "Connect", vrf)
+    check_neigh_state(r1, "2.2.2.2", "Established", vrf)
+    check_neigh_state(r1, "3.3.3.3", "Established", vrf)
+
+    r3.vtysh_cmd(
+        "conf t\nrouter bgp 65003 {}\nno neighbor 2.2.2.2 password".format(vrf_str(vrf))
+    )
+    check_all_peers_established(vrf)
+
+
+def check_vrf_peer_change_passwords(vrf="", prefix="no"):
+    "selectively change passwords checking state"
+
+    tgen = get_topogen()
+    r1 = tgen.gears["R1"]
+    r2 = tgen.gears["R2"]
+    r3 = tgen.gears["R3"]
+    check_all_peers_established(vrf)
+
+    r1.vtysh_cmd(
+        "conf t\nrouter bgp 65001 {}\nneighbor {} password change1".format(
+            vrf_str(vrf), peer_name("R2", prefix, vrf)
+        )
+    )
+    check_neigh_state(r2, "1.1.1.1", "Connect", vrf)
+    check_neigh_state(r2, "3.3.3.3", "Established", vrf)
+    check_neigh_state(r3, "1.1.1.1", "Established", vrf)
+    check_neigh_state(r3, "2.2.2.2", "Established", vrf)
+    # don't check dynamic downed peers - they are removed
+    if prefix == "no":
+        check_neigh_state(r1, "2.2.2.2", "Connect", vrf)
+    check_neigh_state(r1, "3.3.3.3", "Established", vrf)
+
+    r2.vtysh_cmd(
+        "conf t\nrouter bgp 65002 {}\nneighbor 1.1.1.1 password change1".format(
+            vrf_str(vrf)
+        )
+    )
+    check_all_peers_established(vrf)
+
+    r1.vtysh_cmd(
+        "conf t\nrouter bgp 65001 {}\nneighbor {} password change2".format(
+            vrf_str(vrf), peer_name("R3", prefix, vrf)
+        )
+    )
+    check_neigh_state(r2, "1.1.1.1", "Established", vrf)
+    check_neigh_state(r2, "3.3.3.3", "Established", vrf)
+    check_neigh_state(r3, "1.1.1.1", "Connect", vrf)
+    check_neigh_state(r3, "2.2.2.2", "Established", vrf)
+    check_neigh_state(r1, "2.2.2.2", "Established", vrf)
+    # don't check dynamic downed peers - they are removed
+    if prefix == "no":
+        check_neigh_state(r1, "3.3.3.3", "Connect", vrf)
+
+    r3.vtysh_cmd(
+        "conf t\nrouter bgp 65003 {}\nneighbor 1.1.1.1 password change2".format(
+            vrf_str(vrf)
+        )
+    )
+    check_all_peers_established(vrf)
+
+    r2.vtysh_cmd(
+        "conf t\nrouter bgp 65002 {}\nneighbor 3.3.3.3 password change3".format(
+            vrf_str(vrf)
+        )
+    )
+    check_neigh_state(r2, "1.1.1.1", "Established", vrf)
+    check_neigh_state(r2, "3.3.3.3", "Connect", vrf)
+    check_neigh_state(r3, "1.1.1.1", "Established", vrf)
+    check_neigh_state(r3, "2.2.2.2", "Connect", vrf)
+    check_neigh_state(r1, "2.2.2.2", "Established", vrf)
+    check_neigh_state(r1, "3.3.3.3", "Established", vrf)
+
+    r3.vtysh_cmd(
+        "conf t\nrouter bgp 65003 {}\nneighbor 2.2.2.2 password change3".format(
+            vrf_str(vrf)
+        )
+    )
+    check_all_peers_established(vrf)
+
+
+def test_default_peer_established():
+    "default vrf 3 peers same password"
+
+    check_all_peers_established()
+    clear_bgp()
+    # tgen.mininet_cli()
+
+
+def test_default_peer_remove_passwords():
+    "selectively remove passwords checking state"
+
+    configure("bgpd.conf")
+    check_vrf_peer_remove_passwords()
+    clear_bgp()
+
+
+def test_default_peer_change_passwords():
+    "selectively change passwords checking state"
+
+    configure("bgpd.conf")
+    check_vrf_peer_change_passwords()
+    clear_bgp()
+
+
+def test_default_prefix_peer_established():
+    "default vrf 3 peers same password with prefix config"
+
+    # only supported in kernel > 5.3
+    if topotest.version_cmp(platform.release(), "5.3") < 0:
+        return
+
+    configure("bgpd_prefix.conf")
+    check_all_peers_established()
+    clear_bgp()
+    # tgen.mininet_cli()
+
+
+def test_prefix_peer_remove_passwords():
+    "selectively remove passwords checking state with prefix config"
+
+    # only supported in kernel > 5.3
+    if topotest.version_cmp(platform.release(), "5.3") < 0:
+        return
+    configure("bgpd_prefix.conf")
+    check_vrf_peer_remove_passwords(prefix="yes")
+    clear_bgp()
+
+
+def test_prefix_peer_change_passwords():
+    "selecively change passwords checkig state with prefix config"
+
+    # only supported in kernel > 5.3
+    if topotest.version_cmp(platform.release(), "5.3") < 0:
+        return
+    configure("bgpd_prefix.conf")
+    check_vrf_peer_change_passwords(prefix="yes")
+    clear_bgp()
+    clear_ospf()
+
+
+def test_vrf_peer_established():
+    "default vrf 3 peers same password with VRF config"
+
+    # clean routers and load vrf config
+    configure("bgpd_vrf.conf")
+    configure("ospfd_vrf.conf")
+
+    check_all_peers_established("blue")
+    clear_bgp("blue")
+    # tgen.mininet_cli()
+
+
+def test_vrf_peer_remove_passwords():
+    "selectively remove passwords checking state with VRF config"
+
+    configure("bgpd_vrf.conf")
+    check_vrf_peer_remove_passwords(vrf="blue")
+    clear_bgp("blue")
+
+
+def test_vrf_peer_change_passwords():
+    "selectively change passwords checking state with VRF config"
+
+    configure("bgpd_vrf.conf")
+    check_vrf_peer_change_passwords(vrf="blue")
+    clear_bgp("blue")
+
+
+def test_vrf_prefix_peer_established():
+    "default vrf 3 peers same password with VRF prefix config"
+
+    # only supported in kernel > 5.3
+    if topotest.version_cmp(platform.release(), "5.3") < 0:
+        clear_bgp("blue")
+        return
+
+    configure("bgpd_vrf_prefix.conf")
+    check_all_peers_established("blue")
+    clear_bgp("blue")
+
+
+def test_vrf_prefix_peer_remove_passwords():
+    "selectively remove passwords checking state with VRF prefix config"
+
+    # only supported in kernel > 5.3
+    if topotest.version_cmp(platform.release(), "5.3") < 0:
+        return
+
+    configure("bgpd_vrf_prefix.conf")
+    check_vrf_peer_remove_passwords(vrf="blue", prefix="yes")
+    clear_bgp("blue")
+
+
+def test_vrf_prefix_peer_change_passwords():
+    "selectively change passwords checking state with VRF prefix config"
+
+    tgen = get_topogen()
+    r1 = tgen.gears["R1"]
+    r2 = tgen.gears["R2"]
+    r3 = tgen.gears["R3"]
+
+    # only supported in kernel > 5.3
+    if topotest.version_cmp(platform.release(), "5.3") < 0:
+        clear_ospf("blue")
+        return
+
+    configure("bgpd_vrf_prefix.conf")
+    check_vrf_peer_change_passwords(vrf="blue", prefix="yes")
+    clear_bgp("blue")
+    clear_ospf("blue")
+
+
+def test_multiple_vrf_peer_established():
+    "default vrf 3 peers same password with multiple VRFs"
+
+    configure("bgpd_multi_vrf.conf")
+    configure("ospfd_multi_vrf.conf")
+    check_all_peers_established("blue")
+    check_all_peers_established("red")
+    clear_bgp("blue")
+    clear_bgp("red")
+    # tgen.mininet_cli()
+
+
+def test_multiple_vrf_peer_remove_passwords():
+    "selectively remove passwords checking state with multiple VRFs"
+
+    configure("bgpd_multi_vrf.conf")
+    check_vrf_peer_remove_passwords("blue")
+    check_all_peers_established("red")
+    check_vrf_peer_remove_passwords("red")
+    check_all_peers_established("blue")
+    clear_bgp("blue")
+    clear_bgp("red")
+    # tgen.mininet_cli()
+
+
+def test_multiple_vrf_peer_change_passwords():
+    "selectively change passwords checking state with multiple VRFs"
+
+    configure("bgpd_multi_vrf.conf")
+    check_vrf_peer_change_passwords("blue")
+    check_all_peers_established("red")
+    check_vrf_peer_change_passwords("red")
+    check_all_peers_established("blue")
+    clear_bgp("blue")
+    clear_bgp("red")
+    # tgen.mininet_cli()
+
+
+def test_multiple_vrf_prefix_peer_established():
+    "default vrf 3 peers same password with multilpe VRFs and prefix config"
+
+    # only supported in kernel > 5.3
+    if topotest.version_cmp(platform.release(), "5.3") < 0:
+        return
+
+    configure("bgpd_multi_vrf.conf")
+    configure("ospfd_multi_vrf.conf")
+    check_all_peers_established("blue")
+    check_all_peers_established("red")
+    clear_bgp("blue")
+    clear_bgp("red")
+    # tgen.mininet_cli()
+
+
+def test_multiple_vrf_prefix_peer_remove_passwords():
+    "selectively remove passwords checking state with multiple vrfs and prefix config"
+
+    # only supported in kernel > 5.3
+    if topotest.version_cmp(platform.release(), "5.3") < 0:
+        return
+
+    configure("bgpd_multi_vrf_prefix.conf")
+    tgen = get_topogen()
+    check_vrf_peer_remove_passwords(vrf="blue", prefix="yes")
+    check_all_peers_established("red")
+    check_vrf_peer_remove_passwords(vrf="red", prefix="yes")
+    check_all_peers_established("blue")
+    clear_bgp("blue")
+    clear_bgp("red")
+    # tgen.mininet_cli()
+
+
+def test_multiple_vrf_prefix_peer_change_passwords():
+    "selectively change passwords checking state with multiple vrfs and prefix config"
+
+    # only supported in kernel > 5.3
+    if topotest.version_cmp(platform.release(), "5.3") < 0:
+        clear_bgp("blue")
+        clear_bgp("red")
+        clear_ospf("blue")
+        clear_ospf("red")
+        return
+
+    configure("bgpd_multi_vrf_prefix.conf")
+    check_vrf_peer_change_passwords(vrf="blue", prefix="yes")
+    check_all_peers_established("red")
+    check_vrf_peer_change_passwords(vrf="red", prefix="yes")
+    check_all_peers_established("blue")
+    clear_bgp("blue")
+    clear_bgp("red")
+    clear_ospf("blue")
+    clear_ospf("red")
+    # tgen.mininet_cli()
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
When using BGP authentication in a multi-vrf scenario in the setting of the MD5 password on a listener socket there is no way of idenitfying the listener socket associated with the vrf in question. Thus the password is set on the first listener it finds on the list that matches the AF. This ususally doesn't cause a huge issue as the outgoing connect will pass since it is probably connecting to a default vrf on the other end.
In addition if a dynamic peer goes down then the password on the listener socket is reset. This stops future dynamic peers from connecting.

I have added a set of topotests which adds 18 tests which cover

- authenticated password session extablishment
- password removal
- wrong password

over the following configurations:
- default
- default prefix-based,
- vrf
- vrf prefix-based
- multi-vrf
- multi-vrf prefix-based