### PR TITLE
bgpd: [7.3] Create peer_sort_lookup()

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -203,7 +203,7 @@ int bgp_set_socket_ttl(struct peer *peer, int bgp_sock)
 	int ret = 0;
 
 	/* In case of peer is EBGP, we should set TTL for this connection.  */
-	if (!peer->gtsm_hops && (peer_sort(peer) == BGP_PEER_EBGP)) {
+	if (!peer->gtsm_hops && (peer_sort_lookup(peer) == BGP_PEER_EBGP)) {
 		ret = sockopt_ttl(peer->su.sa.sa_family, bgp_sock, peer->ttl);
 		if (ret) {
 			flog_err(

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -833,8 +833,8 @@ static int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 	   pair (newm, existm) with the cluster list length. Prefer the
 	   path with smaller cluster list length.                       */
 	if (newm == existm) {
-		if (peer_sort(new->peer) == BGP_PEER_IBGP
-		    && peer_sort(exist->peer) == BGP_PEER_IBGP
+		if (peer_sort_lookup(new->peer) == BGP_PEER_IBGP
+		    && peer_sort_lookup(exist->peer) == BGP_PEER_IBGP
 		    && (mpath_cfg == NULL
 			|| CHECK_FLAG(
 				   mpath_cfg->ibgp_flags,

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -978,6 +978,11 @@ bgp_peer_sort_t peer_sort(struct peer *peer)
 	return peer->sort;
 }
 
+bgp_peer_sort_t peer_sort_lookup(struct peer *peer)
+{
+	return peer->sort;
+}
+
 static void peer_free(struct peer *peer)
 {
 	afi_t afi;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1588,6 +1588,8 @@ extern struct peer *peer_unlock_with_caller(const char *, struct peer *);
 #define peer_lock(B) peer_lock_with_caller(__FUNCTION__, (B))
 
 extern bgp_peer_sort_t peer_sort(struct peer *peer);
+extern bgp_peer_sort_t peer_sort_lookup(struct peer *peer);
+
 extern int peer_active(struct peer *);
 extern int peer_active_nego(struct peer *);
 extern void bgp_recalculate_all_bestpaths(struct bgp *bgp);


### PR DESCRIPTION
The act of peer_sort() being called always set this value
even when we are just looking it up.  We need to seperate
out the idea of lookup from set.

For those places that this is immediately obvious that
this is a lookup switch over to using this function.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

Fixes for 7.3:
```
bgpd/bgpd.c: In function ‘peer_as_change’:
bgpd/bgpd.c:1588:13: warning: implicit declaration of function ‘peer_sort_lookup’ [-Wimplicit-function-declaration]
  origtype = peer_sort_lookup(peer);
             ^~~~~~~~~~~~~~~~
```