### PR TITLE
nhrpd: ignore zebra updates about our routes being deleted/added

### DIFF
--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -198,6 +198,10 @@ int nhrp_route_read(ZAPI_CALLBACK_ARGS)
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_SRCPFX))
 		return 0;
 
+	/* ignore our routes */
+	if (api.type == ZEBRA_ROUTE_NHRP)
+		return 0;
+
 	sockunion_family(&nexthop_addr) = AF_UNSPEC;
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP)) {
 		api_nh = &api.nexthops[0];


### PR DESCRIPTION
nhrp listens for route entries to be deleted, in case some new routes
impact the current routes installed by nhrp. To prevent from
unconfiguring nhrp shortcut route, just prevent nhrp routes to be
processed.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>