### PR TITLE
bgpd: Add to neighbor prefix-counts the count of best path selected

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11651,6 +11651,7 @@ enum bgp_pcounts {
 	PCOUNT_VALID,
 	PCOUNT_ALL,
 	PCOUNT_COUNTED,
+	PCOUNT_BPATH_SELECTED,
 	PCOUNT_PFCNT, /* the figure we display to users */
 	PCOUNT_MAX,
 };
@@ -11664,6 +11665,7 @@ static const char *const pcount_strs[] = {
 		[PCOUNT_VALID] = "Valid",
 		[PCOUNT_ALL] = "All RIB",
 		[PCOUNT_COUNTED] = "PfxCt counted",
+		[PCOUNT_BPATH_SELECTED] = "PfxCt Best Selected",
 		[PCOUNT_PFCNT] = "Useable",
 		[PCOUNT_MAX] = NULL,
 };
@@ -11704,6 +11706,8 @@ static void bgp_peer_count_proc(struct bgp_dest *rn, struct peer_pcounts *pc)
 			pc->count[PCOUNT_VALID]++;
 		if (!CHECK_FLAG(pi->flags, BGP_PATH_UNUSEABLE))
 			pc->count[PCOUNT_PFCNT]++;
+		if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
+			pc->count[PCOUNT_BPATH_SELECTED]++;
 
 		if (CHECK_FLAG(pi->flags, BGP_PATH_COUNTED)) {
 			pc->count[PCOUNT_COUNTED]++;


### PR DESCRIPTION
When we have a prefix that has been selected, note that that
particular flag has been set and give that information to the
end user.

eva# show bgp ipv4 uni neighbors 192.168.161.131 prefix-counts
Prefix counts for 192.168.161.131, IPv4 Unicast
PfxCt: 814246

Counts from RIB table walk:

              Adj-in: 0
              Damped: 0
             Removed: 0
             History: 0
               Stale: 0
               Valid: 814246
             All RIB: 814246
       PfxCt counted: 814246
 PfxCt Best Selected: 0
             Useable: 814246
eva# show bgp ipv4 uni neighbors 192.168.161.2 prefix-counts
Prefix counts for 192.168.161.2, IPv4 Unicast
PfxCt: 814070

Counts from RIB table walk:

              Adj-in: 0
              Damped: 0
             Removed: 0
             History: 0
               Stale: 0
               Valid: 814070
             All RIB: 814070
       PfxCt counted: 814070
 PfxCt Best Selected: 814070
             Useable: 814070

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>