### PR TITLE
Flexible ifname frr master

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -853,6 +853,7 @@ else
 fi
 AC_DEFINE_UNQUOTED([ALIAS_AS_IFNAME], $ALIAS_AS_IFNAME, [If there, use interface alias as interface name])
 AC_DEFINE_UNQUOTED([MAX_IFNAME_LEN], [$INTERFACE_NAMSIZ_MAX], [Maximum interface name length])
+AC_SUBST(INTERFACE_NAMSIZ_MAX, ${INTERFACE_NAMSIZ_MAX})
 
 AC_DEFINE_UNQUOTED([VTYSH_PAGER], ["$VTYSH_PAGER"], [What pager to use])
 
@@ -2454,6 +2455,7 @@ AC_CONFIG_FILES([tools/frr], [chmod +x tools/frr])
 AC_CONFIG_FILES([tools/watchfrr.sh], [chmod +x tools/watchfrr.sh])
 AC_CONFIG_FILES([tools/frrinit.sh], [chmod +x tools/frrinit.sh])
 AC_CONFIG_FILES([tools/frrcommon.sh])
+AC_CONFIG_FILES([yang/frr-interface.yang])
 
 AC_CONFIG_COMMANDS([lib/route_types.h], [
 	dst="${ac_abs_top_builddir}/lib/route_types.h"

--- a/configure.ac
+++ b/configure.ac
@@ -568,6 +568,8 @@ AC_ARG_ENABLE([ospfclient],
                           (this is the default if --disable-ospfapi is set)]))
 AC_ARG_ENABLE([multipath],
   AS_HELP_STRING([--enable-multipath=ARG], [enable multipath function, ARG must be digit]))
+AC_ARG_ENABLE([ifnamealias],
+  AS_HELP_STRING([--enable-ifnamealias=ARG], [If present, use interface alias as interface name. ARG is max ifname allowed]))
 AC_ARG_ENABLE([user],
   AS_HELP_STRING([--enable-user=USER], [user to run FRR suite as (default frr)]))
 AC_ARG_ENABLE([group],
@@ -838,6 +840,19 @@ case "${enable_multipath}" in
 esac
 
 AC_DEFINE_UNQUOTED([MULTIPATH_NUM], [$MPATH_NUM], [Maximum number of paths for a route])
+
+if test "${enable_ifnamealias}" ; then
+  if test "${enable_ifnamealias}" -gt 64 ; then
+     AC_MSG_FAILURE([Maximum interface size cannot exceed 64. Please specify a lower value.])
+  fi
+  INTERFACE_NAMSIZ_MAX=${enable_ifnamealias}
+  ALIAS_AS_IFNAME=1
+else
+  INTERFACE_NAMSIZ_MAX=16
+  ALIAS_AS_IFNAME=0
+fi
+AC_DEFINE_UNQUOTED([ALIAS_AS_IFNAME], $ALIAS_AS_IFNAME, [If there, use interface alias as interface name])
+AC_DEFINE_UNQUOTED([MAX_IFNAME_LEN], [$INTERFACE_NAMSIZ_MAX], [Maximum interface name length])
 
 AC_DEFINE_UNQUOTED([VTYSH_PAGER], ["$VTYSH_PAGER"], [What pager to use])
 

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -480,25 +480,28 @@ void isis_adj_print_vty(struct isis_adjacency *adj, struct vty *vty,
 
 	dyn = dynhn_find_by_id(adj->sysid);
 	if (dyn)
-		vty_out(vty, "  %-20s", dyn->hostname);
+		vty_out(vty, " %-20s", dyn->hostname);
 	else
-		vty_out(vty, "  %-20s", sysid_print(adj->sysid));
+		vty_out(vty, " %-20s", sysid_print(adj->sysid));
 
 	if (detail == ISIS_UI_LEVEL_BRIEF) {
 		if (adj->circuit)
-			vty_out(vty, "%-12s", adj->circuit->interface->name);
+			vty_out(vty, " %-*s", INTERFACE_NAMSIZ,
+				adj->circuit->interface->name);
 		else
-			vty_out(vty, "NULL circuit!");
-		vty_out(vty, "%-3u", adj->level); /* level */
-		vty_out(vty, "%-13s", adj_state2string(adj->adj_state));
+			vty_out(vty, " %-*s", INTERFACE_NAMSIZ,
+				"NULL circuit!");
+
+		vty_out(vty, " %-3u", adj->level); /* level */
+		vty_out(vty, " %-13s", adj_state2string(adj->adj_state));
 		now = time(NULL);
 		if (adj->last_upd)
-			vty_out(vty, "%-9llu",
+			vty_out(vty, " %-9llu",
 				(unsigned long long)adj->last_upd
 					+ adj->hold_time - now);
 		else
 			vty_out(vty, "-        ");
-		vty_out(vty, "%-10s", snpa_print(adj->snpa));
+		vty_out(vty, " %-10s", snpa_print(adj->snpa));
 		vty_out(vty, "\n");
 	}
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -873,11 +873,12 @@ void isis_circuit_print_vty(struct isis_circuit *circuit, struct vty *vty,
 			    char detail)
 {
 	if (detail == ISIS_UI_LEVEL_BRIEF) {
-		vty_out(vty, "  %-12s", circuit->interface->name);
-		vty_out(vty, "0x%-7x", circuit->circuit_id);
-		vty_out(vty, "%-9s", circuit_state2string(circuit->state));
-		vty_out(vty, "%-9s", circuit_type2string(circuit->circ_type));
-		vty_out(vty, "%-9s", circuit_t2string(circuit->is_type));
+		vty_out(vty, "  %-*s", INTERFACE_NAMSIZ,
+			circuit->interface->name);
+		vty_out(vty, " 0x%-7x", circuit->circuit_id);
+		vty_out(vty, " %-9s", circuit_state2string(circuit->state));
+		vty_out(vty, " %-9s", circuit_type2string(circuit->circ_type));
+		vty_out(vty, " %-9s", circuit_t2string(circuit->is_type));
 		vty_out(vty, "\n");
 	}
 

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1318,8 +1318,8 @@ static void isis_print_paths(struct vty *vty, struct isis_vertex_queue *queue,
 	struct isis_vertex *vertex;
 	char buff[VID2STR_BUFFER];
 
-	vty_out(vty,
-		"Vertex               Type         Metric Next-Hop             Interface Parent\n");
+	vty_out(vty, "%-20s %-12s %-6s %-20s %-*s %-s\n", "Vertex", "Type",
+		"Metric", "Next-Hop", INTERFACE_NAMSIZ, "Interface", "Parent");
 
 	for (ALL_QUEUE_ELEMENTS_RO(queue, node, vertex)) {
 		if (memcmp(vertex->N.id, root_sysid, ISIS_SYS_ID_LEN) == 0) {
@@ -1362,14 +1362,16 @@ static void isis_print_paths(struct vty *vty, struct isis_vertex_queue *queue,
 			}
 
 			if (adj) {
-				vty_out(vty, "%-20s %-9s ",
+				vty_out(vty, "%-20s %-*s ",
 					print_sys_hostname(adj->sysid),
+					INTERFACE_NAMSIZ,
 					adj->circuit->interface->name);
 			}
 
 			if (pvertex) {
 				if (!adj)
-					vty_out(vty, "%-20s %-9s ", "", "");
+					vty_out(vty, "%-20s %-*s ", "",
+						INTERFACE_NAMSIZ, "");
 
 				vty_out(vty, "%s(%d)",
 					vid2string(pvertex, buff, sizeof(buff)),

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -508,8 +508,9 @@ int show_isis_interface_common(struct vty *vty, const char *ifname, char detail)
 		vty_out(vty, "Area %s:\n", area->area_tag);
 
 		if (detail == ISIS_UI_LEVEL_BRIEF)
-			vty_out(vty,
-				"  Interface   CircId   State    Type     Level\n");
+			vty_out(vty, "  %-*s %-9s %-9s %-9s %-9s\n",
+				INTERFACE_NAMSIZ, "Interface", "CircId",
+				"State", "Type", "Level");
 
 		for (ALL_LIST_ELEMENTS_RO(area->circuit_list, cnode, circuit))
 			if (!ifname)
@@ -591,8 +592,9 @@ int show_isis_neighbor_common(struct vty *vty, const char *id, char detail)
 		vty_out(vty, "Area %s:\n", area->area_tag);
 
 		if (detail == ISIS_UI_LEVEL_BRIEF)
-			vty_out(vty,
-				"  System Id           Interface   L  State        Holdtime SNPA\n");
+			vty_out(vty, " %-20s %-*s %-3s %-13s %-9s %-10s\n",
+				"System Id", INTERFACE_NAMSIZ, "Interface", "L",
+				"state", "Holdtime", "SNPA");
 
 		for (ALL_LIST_ELEMENTS_RO(area->circuit_list, cnode, circuit)) {
 			if (circuit->circ_type == CIRCUIT_T_BROADCAST) {

--- a/ldpd/ldp_vty_exec.c
+++ b/ldpd/ldp_vty_exec.c
@@ -147,11 +147,12 @@ show_interface_msg(struct vty *vty, struct imsg *imsg,
 		snprintf(timers, sizeof(timers), "%u/%u",
 		    iface->hello_interval, iface->hello_holdtime);
 
-		vty_out (vty, "%-4s %-11s %-6s %-8s %-12s %3u\n",
-		    af_name(iface->af), iface->name,
-		    if_state_name(iface->state), iface->uptime == 0 ?
-		    "00:00:00" : log_time(iface->uptime), timers,
-		    iface->adj_cnt);
+		vty_out(vty, "%-4s %-*s %-6s %-8s %-12s %3u\n",
+			af_name(iface->af), IF_NAMESIZE, iface->name,
+			if_state_name(iface->state),
+			iface->uptime == 0 ? "00:00:00"
+					   : log_time(iface->uptime),
+			timers, iface->adj_cnt);
 		break;
 	case IMSG_CTL_END:
 		vty_out (vty, "\n");
@@ -224,12 +225,14 @@ show_discovery_msg(struct vty *vty, struct imsg *imsg,
 		    inet_ntoa(adj->id));
 		switch(adj->type) {
 		case HELLO_LINK:
-			vty_out(vty, "%-8s %-15s ", "Link", adj->ifname);
+			vty_out(vty, "%-8s %-*s ", "Link", IF_NAMESIZE,
+				adj->ifname);
 			break;
 		case HELLO_TARGETED:
 			addr = log_addr(adj->af, &adj->src_addr);
 
-			vty_out(vty, "%-8s %-15s ", "Targeted", addr);
+			vty_out(vty, "%-8s %-*s ", "Targeted", IF_NAMESIZE,
+				addr);
 			if (strlen(addr) > 15)
 				vty_out(vty, "\n%46s", " ");
 			break;
@@ -1352,9 +1355,10 @@ show_l2vpn_pw_msg(struct vty *vty, struct imsg *imsg, struct show_params *params
 	case IMSG_CTL_SHOW_L2VPN_PW:
 		pw = imsg->data;
 
-		vty_out (vty, "%-9s %-15s %-10u %-16s %-10s\n", pw->ifname,
-		    inet_ntoa(pw->lsr_id), pw->pwid, pw->l2vpn_name,
-		    (pw->status == PW_FORWARDING ? "UP" : "DOWN"));
+		vty_out(vty, "%-*s %-15s %-10u %-16s %-10s\n", IF_NAMESIZE,
+			pw->ifname, inet_ntoa(pw->lsr_id), pw->pwid,
+			pw->l2vpn_name,
+			(pw->status == PW_FORWARDING ? "UP" : "DOWN"));
 		break;
 	case IMSG_CTL_END:
 		vty_out (vty, "\n");
@@ -1822,8 +1826,8 @@ ldp_vty_show_discovery(struct vty *vty, const char *af_str, const char *detail,
 	params.json = (json) ? 1 : 0;
 
 	if (!params.detail && !params.json)
-		vty_out (vty, "%-4s %-15s %-8s %-15s %9s\n",
-		    "AF", "ID", "Type", "Source", "Holdtime");
+		vty_out(vty, "%-4s %-15s %-8s %-*s %9s\n", "AF", "ID", "Type",
+			IF_NAMESIZE, "Source", "Holdtime");
 
 	if (params.detail)
 		imsg_compose(&ibuf, IMSG_CTL_SHOW_DISCOVERY_DTL, 0, 0, -1,
@@ -1853,8 +1857,9 @@ ldp_vty_show_interface(struct vty *vty, const char *af_str, const char *json)
 
 	/* header */
 	if (!params.json) {
-		vty_out (vty, "%-4s %-11s %-6s %-8s %-12s %3s\n", "AF",
-		    "Interface", "State", "Uptime", "Hello Timers","ac");
+		vty_out(vty, "%-4s %-*s %-6s %-8s %-12s %3s\n", "AF",
+			IF_NAMESIZE, "Interface", "State", "Uptime",
+			"Hello Timers", "ac");
 	}
 
 	imsg_compose(&ibuf, IMSG_CTL_SHOW_INTERFACE, 0, 0, -1, &ifidx,
@@ -1996,11 +2001,11 @@ ldp_vty_show_atom_vc(struct vty *vty, const char *peer, const char *ifname,
 
 	if (!params.json) {
 		/* header */
-		vty_out (vty, "%-9s %-15s %-10s %-16s %-10s\n",
-		    "Interface", "Peer ID", "VC ID", "Name","Status");
-		vty_out (vty, "%-9s %-15s %-10s %-16s %-10s\n",
-		    "---------", "---------------", "----------",
-		    "----------------", "----------");
+		vty_out(vty, "%-*s %-15s %-10s %-16s %-10s\n", IF_NAMESIZE,
+			"Interface", "Peer ID", "VC ID", "Name", "Status");
+		vty_out(vty, "%-*s %-15s %-10s %-16s %-10s\n", IF_NAMESIZE,
+			"---------", "---------------", "----------",
+			"----------------", "----------");
 	}
 
 	imsg_compose(&ibuf, IMSG_CTL_SHOW_L2VPN_PW, 0, 0, -1, NULL, 0);

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -34,6 +34,12 @@
 #include "zclient.h"
 
 #include "ldp.h"
+#include "lib/if.h"
+
+#ifdef IF_NAMESIZE
+#undef IF_NAMESIZE
+#define IF_NAMESIZE INTERFACE_NAMSIZ
+#endif
 
 #define CONF_FILE		"/etc/ldpd.conf"
 #define LDPD_USER		"_ldpd"

--- a/lib/if.h
+++ b/lib/if.h
@@ -106,6 +106,13 @@ enum zebra_link_type {
 #define INTERFACE_NAMSIZ      20
 #define INTERFACE_HWADDR_MAX  20
 
+/* redefine INTERFACE_NAMSIZ to user-specified max value
+ * if use of alias as interface name is enabled */
+#if ALIAS_AS_IFNAME
+#undef INTERFACE_NAMSIZ
+#define INTERFACE_NAMSIZ (MAX_IFNAME_LEN + 1)
+#endif
+
 typedef signed int ifindex_t;
 
 #ifdef HAVE_PROC_NET_DEV

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -309,7 +309,8 @@ void ospf6_route_zebra_copy_nexthops(struct ospf6_route *route,
 				ifname = ifindex2ifname(nh->ifindex,
 							VRF_DEFAULT);
 				zlog_debug("  nexthop: %s%%%.*s(%d)", buf,
-					   IFNAMSIZ, ifname, nh->ifindex);
+					   INTERFACE_NAMSIZ, ifname,
+					   nh->ifindex);
 			}
 			if (i >= entries)
 				return;
@@ -1067,12 +1068,13 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route)
 				(ospf6_route_is_best(route) ? '*' : ' '),
 				OSPF6_DEST_TYPE_SUBSTR(route->type),
 				OSPF6_PATH_TYPE_SUBSTR(route->path.type),
-				destination, nexthop, IFNAMSIZ, ifname,
+				destination, nexthop, INTERFACE_NAMSIZ, ifname,
 				duration);
 			i++;
 		} else
 			vty_out(vty, "%c%1s %2s %-30s %-25s %6.*s %s\n", ' ',
-				"", "", "", nexthop, IFNAMSIZ, ifname, "");
+				"", "", "", nexthop, INTERFACE_NAMSIZ, ifname,
+				"");
 	}
 }
 
@@ -1161,7 +1163,7 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route)
 		/* nexthop */
 		inet_ntop(AF_INET6, &nh->address, nexthop, sizeof(nexthop));
 		ifname = ifindex2ifname(nh->ifindex, VRF_DEFAULT);
-		vty_out(vty, "  %s %.*s\n", nexthop, IFNAMSIZ, ifname);
+		vty_out(vty, "  %s %.*s\n", nexthop, INTERFACE_NAMSIZ, ifname);
 	}
 	vty_out(vty, "\n");
 }

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -115,7 +115,7 @@ const char *ospf_area_desc_string(struct ospf_area *area)
 	return buf;
 }
 
-#define OSPF_IF_STRING_MAXLEN  40
+
 const char *ospf_if_name_string(struct ospf_interface *oi)
 {
 	static char buf[OSPF_IF_STRING_MAXLEN] = "";

--- a/ospfd/ospf_dump.h
+++ b/ospfd/ospf_dump.h
@@ -143,4 +143,8 @@ extern void ospf_debug_init(void);
 /* Appropriate buffer size to use with ospf_timer_dump and ospf_timeval_dump: */
 #define OSPF_TIME_DUMP_SIZE	16
 
+/* Appropriate buffer size to use with ospf_if_name_string. The + 22 is to
+ * accommodate the local interface address and colon, ":aaaa.bbbb.cccc.dddd" */
+#define OSPF_IF_STRING_MAXLEN (INTERFACE_NAMSIZ + 22)
+
 #endif /* _ZEBRA_OSPF_DUMP_H */

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4157,9 +4157,9 @@ DEFUN (show_ip_ospf_interface_traffic,
 
 static void show_ip_ospf_neighbour_header(struct vty *vty)
 {
-	vty_out(vty, "\n%-15s %3s %-15s %9s %-15s %-32s %5s %5s %5s\n",
+	vty_out(vty, "\n%-15s %3s %-15s %9s %-15s %-*s %5s %5s %5s\n",
 		"Neighbor ID", "Pri", "State", "Dead Time", "Address",
-		"Interface", "RXmtL", "RqstL", "DBsmL");
+		OSPF_IF_STRING_MAXLEN, "Interface", "RXmtL", "RqstL", "DBsmL");
 }
 
 static void show_ip_ospf_neighbor_sub(struct vty *vty,
@@ -4263,8 +4263,8 @@ static void show_ip_ospf_neighbor_sub(struct vty *vty,
 							timebuf,
 							sizeof(timebuf)));
 				vty_out(vty, "%-15s ", inet_ntoa(nbr->src));
-				vty_out(vty, "%-32s %5ld %5ld %5d\n",
-					IF_NAME(oi),
+				vty_out(vty, "%-*s %5ld %5ld %5d\n",
+					OSPF_IF_STRING_MAXLEN, IF_NAME(oi),
 					ospf_ls_retransmit_count(nbr),
 					ospf_ls_request_count(nbr),
 					ospf_db_summary_count(nbr));
@@ -4526,9 +4526,9 @@ static int show_ip_ospf_neighbor_all_common(struct vty *vty, struct ospf *ospf,
 					vty_out(vty, "%-15s %3d %-15s %9s ",
 						"-", nbr_nbma->priority, "Down",
 						"-");
-					vty_out(vty,
-						"%-32s %-20s %5d %5d %5d\n",
+					vty_out(vty, "%-32s %-*s %5d %5d %5d\n",
 						inet_ntoa(nbr_nbma->addr),
+						OSPF_IF_STRING_MAXLEN,
 						IF_NAME(oi), 0, 0, 0);
 				}
 			}

--- a/yang/frr-interface.yang.in
+++ b/yang/frr-interface.yang.in
@@ -293,7 +293,7 @@ module frr-interface {
         "Interface.";
       leaf name {
         type string {
-          length "1..16";
+          length "1..@INTERFACE_NAMSIZ_MAX@";
         }
         description
           "Interface name.";

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -675,8 +675,13 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return -1;
 	name = (char *)RTA_DATA(tb[IFLA_IFNAME]);
 
-	if (tb[IFLA_IFALIAS])
+	if (tb[IFLA_IFALIAS]) {
 		desc = (char *)RTA_DATA(tb[IFLA_IFALIAS]);
+		if (ALIAS_AS_IFNAME) {
+			name = desc;
+			desc = NULL;
+		}
+	}
 
 	if (tb[IFLA_LINKINFO]) {
 		parse_rtattr_nested(linkinfo, IFLA_INFO_MAX, tb[IFLA_LINKINFO]);
@@ -1269,6 +1274,8 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	}
 	if (tb[IFLA_IFALIAS]) {
 		desc = (char *)RTA_DATA(tb[IFLA_IFALIAS]);
+		if (ALIAS_AS_IFNAME)
+			name = desc;
 	}
 
 	/* If VRF, create or update the VRF structure itself. */
@@ -1465,7 +1472,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		zif = ifp->info;
 		if (zif) {
 			XFREE(MTYPE_TMP, zif->desc);
-			if (desc)
+			if (desc && !ALIAS_AS_IFNAME)
 				zif->desc = XSTRDUP(MTYPE_TMP, desc);
 		}
 	} else {

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1212,7 +1212,7 @@ static void connected_dump_vty(struct vty *vty, struct connected *connected)
 	if (CHECK_FLAG(connected->flags, ZEBRA_IFA_UNNUMBERED))
 		vty_out(vty, " unnumbered");
 
-	if (connected->label)
+	if (connected->label && !ALIAS_AS_IFNAME)
 		vty_out(vty, " %s", connected->label);
 
 	vty_out(vty, "\n");
@@ -3569,7 +3569,7 @@ static int if_config_write(struct vty *vty)
 					}
 					vty_out(vty, "/%d", p->prefixlen);
 
-					if (ifc->label)
+					if (ifc->label && !ALIAS_AS_IFNAME)
 						vty_out(vty, " label %s",
 							ifc->label);
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1820,45 +1820,42 @@ static void if_show_description(struct vty *vty, struct vrf *vrf)
 {
 	struct interface *ifp;
 
-	vty_out(vty, "Interface       Status  Protocol  Description\n");
+	vty_out(vty, "%-*s Status  Protocol   Description\n", INTERFACE_NAMSIZ,
+		"Interface");
+
 	FOR_ALL_INTERFACES (vrf, ifp) {
-		int len;
+
 		struct zebra_if *zif;
-		bool intf_desc;
 
-		intf_desc = false;
-
-		len = vty_out(vty, "%s", ifp->name);
-		vty_out(vty, "%*s", (16 - len), " ");
+		vty_out(vty, "%-*s", INTERFACE_NAMSIZ, ifp->name);
 
 		if (if_is_up(ifp)) {
-			vty_out(vty, "up      ");
+			vty_out(vty, " up      ");
 			if (CHECK_FLAG(ifp->status,
 				       ZEBRA_INTERFACE_LINKDETECTION)) {
 				if (if_is_running(ifp))
-					vty_out(vty, "up        ");
+					vty_out(vty, " up        ");
 				else
-					vty_out(vty, "down      ");
+					vty_out(vty, " down      ");
 			} else {
-				vty_out(vty, "unknown   ");
+				vty_out(vty, " unknown   ");
 			}
 		} else {
-			vty_out(vty, "down    down      ");
+			vty_out(vty, " down    down      ");
 		}
 
-		if (ifp->desc) {
-			intf_desc = true;
+		if (ifp->desc)
 			vty_out(vty, "%s", ifp->desc);
-		}
+
 		zif = ifp->info;
 		if (zif && zif->desc) {
-			vty_out(vty, "%s%s",
-				intf_desc
-					? "\n                                  "
-					: "",
-				zif->desc);
-		}
 
+			if (ifp->desc)
+				vty_out(vty, "\n%*s%s", INTERFACE_NAMSIZ + 20,
+					"", zif->desc);
+			else
+				vty_out(vty, "%s", zif->desc);
+		}
 		vty_out(vty, "\n");
 	}
 }

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1302,15 +1302,15 @@ static void ifs_dump_brief_vty(struct vty *vty, struct vrf *vrf)
 		bool first_pfx_printed = false;
 
 		if (print_header) {
-			vty_out(vty, "%-16s%-8s%-16s%s\n", "Interface",
-				"Status", "VRF", "Addresses");
-			vty_out(vty, "%-16s%-8s%-16s%s\n", "---------",
-				"------", "---", "---------");
+			vty_out(vty, "%-*s%-8s%-16s%s\n", INTERFACE_NAMSIZ,
+				"Interface", "Status", "VRF", "Addresses");
+			vty_out(vty, "%-*s%-8s%-16s%s\n", INTERFACE_NAMSIZ,
+				"---------", "------", "---", "---------");
 			print_header = false; /* We have at least 1 iface */
 		}
 		zebra_if = ifp->info;
 
-		vty_out(vty, "%-16s", ifp->name);
+		vty_out(vty, "%-*s", INTERFACE_NAMSIZ, ifp->name);
 
 		if (if_is_up(ifp))
 			vty_out(vty, "%-8s", "up");


### PR DESCRIPTION
In linux, FRR derives interface names from the name of the underlying kernel interfaces when it learns (or hears  from) them via netlink.
This makes interface names in FRR inherit the limits of kernel interface names, namely:
  * a limit of up to **16** characters
  * the impossibility to use special characters like "**/**" (e.g. as in  **GigabitEthernet0/0/1** )

This PR adds a simple mechanism with which FRR interface names can be extended in character set and length while still being
in sync with the presence of the kernel interfaces. The approach is very simple: let zebra use (and distribute e.g. via ZAPI) as interface name, a **kernel alias** of the interface (if present), rather than the name itself, exploiting the fact that  kernel interface aliases are not limited in the character set and can be up to 255 characters.

The submitted patches:
  * augment the configure script so that the feature can be enabled, allowing to specify a maximum interface length (up to 64 chars). 
E.g. **--enable-ifnamealias=32** would enable the feature and set the interface name limit to **32 chars**. If the feature is not enabled, the maximum length remains as 16. 
  * modify the **frr-interface.yang** file so that the constraint in the length of the name of an interface is not 16 but the value specified at configure time. Therefore, all validations (NB/vtysh) use the value specified at configure time. This is achieved by replacing frr-interface.yang by **frr-interface.yang.in** where the limit wanted by users is set via AC substitution macros.
  * The actual feature is implemented in a single tiny commit that modifies **zebra/if_link.c**. The logic is: if there's an alias, the name of the interface will be that one. If not, the regular behavior applies.
  * The subsequent patches in several daemons fix cosmetic issues: most of the FRR show commands to display interface-related information with **vty_out()** assume lengths of up to 16 chars. These patches augment the format specifiers to use a macro that is defined to contain the desired maximum length. E.g.
```
 vty_out(vty, "%-16s", ifp->name);       --->     vty_out(vty, "%-*s", INTERFACE_NAMSIZ, ifp->name);
```
where INTERFACE_NAMSIZ is defined in **config.h** according to the maximum length specified at configure time (or 16 by default).
* The main reason to impose a hard limit of 64 characters is precisely because longer names cause vtysh tabular outputs unpleasant to read and are probably of little practical interest. For instance, the following sample snippet is obtained setting the limit of 32.

 ```
# show interface brief
Interface                        Status  VRF             Addresses
---------                        ------  ---             ---------
GigabitEthernet/A/B/C/2.0      up      default         12.0.0.1/24
GigabitEthernet/A/B/C/3.0      up      default         13.0.0.1/24
GigabitEthernet/A/B/C/4.0      up      default         14.0.0.1/24
```


Incidentally, this PR is related to a recent PR #6786 , which aims at achieving the same goal but using new linux kernel 'altname' facility, whereas the patches in this PR work for legacy kernels. I believe that most of the work on making the length of interfaces configurable (configure, yang model, vty_out(), etc....)  applies to both and that the underlying mechanism behind both could be unified depending on the target kernel FRR is built for: E.g. aliases for legacy kernels, and altname for newer. 
The following snippet shows one of the kernel interfaces corresponding to the snippet above, very similar to the output shown in PR #6786

```
linux# ip link show
2: foo2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 02:00:00:00:01:01 brd ff:ff:ff:ff:ff:ff 
    alias GigabitEthernet/A/B/C/2.0
```
