### PR TITLE
clang-format: add FOREACH_SAFI to the ForEachMacros list

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -66,5 +66,6 @@ ForEachMacros:
   - SUBGRP_FOREACH_ADJ_SAFE
   - AF_FOREACH
   - FOREACH_AFI_SAFI
+  - FOREACH_SAFI
   # ospfd
   - LSDB_LOOP


### PR DESCRIPTION
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>