### PR TITLE
*: coccinelle printfrr `%s` → `%pFX`, `%pI4`, etc.

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -1118,7 +1118,7 @@ DEFUN (show_babel_route_addr,
     }
 
     /* Quagga has no convenient prefix constructors. */
-    snprintf(buf, sizeof(buf), "%s/%d", inet_ntoa(addr), 32);
+    snprintfrr(buf, sizeof(buf), "%pI4/%d", &addr, 32);
 
     ret = str2prefix(buf, &prefix);
     if (ret == 0) {

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -773,17 +773,16 @@ static void bfdd_sessions_enable_address(struct connected *ifc)
 static int bfdd_interface_address_update(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
-	char buf[64];
 
 	ifc = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 	if (ifc == NULL)
 		return 0;
 
 	if (bglobal.debug_zebra)
-		zlog_debug("zclient: %s local address %s",
+		zlog_debug("zclient: %s local address %pFX",
 			   cmd == ZEBRA_INTERFACE_ADDRESS_ADD ? "add"
 							      : "delete",
-			   prefix2str(ifc->address, buf, sizeof(buf)));
+			   ifc->address);
 
 	bfdd_sessions_enable_address(ifc);
 

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -2603,7 +2603,7 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 	if (prd)
 		snprintfrr(str, size, "RD %s %pFX%s%s %s %s",
 			   prefix_rd2str(prd, rd_buf, sizeof(rd_buf)),
-			   pu, tag_buf,
+			   pu.p, tag_buf,
 			   pathid_buf, afi2str(afi), safi2str(safi));
 	else if (safi == SAFI_FLOWSPEC) {
 		char return_string[BGP_FLOWSPEC_NLRI_STRING_MAX];
@@ -2617,7 +2617,7 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 			 return_string);
 	} else
 		snprintfrr(str, size, "%pFX%s%s %s %s",
-			   pu, tag_buf,
+			   pu.p, tag_buf,
 			   pathid_buf, afi2str(afi), safi2str(safi));
 
 	return str;

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3102,7 +3102,6 @@ static int install_uninstall_routes_for_es(struct bgp *bgp,
 	int ret;
 	afi_t afi;
 	safi_t safi;
-	char buf[PREFIX_STRLEN];
 	char buf1[ESI_STR_LEN];
 	struct bgp_dest *rd_dest, *dest;
 	struct bgp_table *table;
@@ -3211,7 +3210,6 @@ static int install_uninstall_routes_for_vrf(struct bgp *bgp_vrf, int install)
 	struct bgp_table *table;
 	struct bgp_path_info *pi;
 	int ret;
-	char buf[PREFIX_STRLEN];
 	struct bgp *bgp_evpn = NULL;
 
 	afi = AFI_L2VPN;

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -1332,7 +1332,6 @@ static int update_evpn_type4_route_entry(struct bgp *bgp, struct evpnes *es,
 					 int *route_changed)
 {
 	char buf[ESI_STR_LEN];
-	char buf1[INET6_ADDRSTRLEN];
 	struct bgp_path_info *tmp_pi = NULL;
 	struct bgp_path_info *local_pi = NULL;  /* local route entry if any */
 	struct bgp_path_info *remote_pi = NULL; /* remote route entry if any */
@@ -3441,6 +3440,7 @@ static int install_uninstall_route_in_es(struct bgp *bgp, struct evpnes *es,
 					 struct prefix_evpn *evp,
 					 struct bgp_path_info *pi, int install)
 {
+	char buf[ESI_STR_LEN];
 	int ret = 0;
 
 	if (install)
@@ -6107,6 +6107,7 @@ int bgp_evpn_local_es_del(struct bgp *bgp,
 			  esi_t *esi,
 			  struct ipaddr *originator_ip)
 {
+	char buf[ESI_STR_LEN];
 	struct evpnes *es = NULL;
 
 	if (!bgp->esihash) {
@@ -6142,6 +6143,7 @@ int bgp_evpn_local_es_add(struct bgp *bgp,
 			  esi_t *esi,
 			  struct ipaddr *originator_ip)
 {
+	char buf[ESI_STR_LEN];
 	struct evpnes *es = NULL;
 	struct prefix_evpn p;
 

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -5661,7 +5661,6 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 				safi_t safi)
 {
 	char buf1[RD_ADDRSTRLEN];
-	char buf2[INET6_ADDRSTRLEN];
 
 	if (bgp->advertise_all_vni)
 		vty_out(vty, "  advertise-all-vni\n");
@@ -5746,7 +5745,6 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 					&bgp->evpn_info->pip_ip_static);
 				if (!is_zero_mac(&(
 					    bgp->evpn_info->pip_rmac_static))) {
-					char buf[ETHER_ADDR_STRLEN];
 
 					vty_out(vty, " mac %pEA",
 						&bgp->evpn_info->pip_rmac);

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -102,8 +102,8 @@ static void display_vrf_import_rt(struct vty *vty, struct vrf_irt_node *irt,
 		eip.val = (*pnt++ << 8);
 		eip.val |= (*pnt++);
 
-		snprintf(rt_buf, sizeof(rt_buf), "%s:%u", inet_ntoa(eip.ip),
-			 eip.val);
+		snprintfrr(rt_buf, sizeof(rt_buf), "%pI4:%u", &eip.ip,
+			   eip.val);
 
 		if (json)
 			json_object_string_add(json_rt, "rt", rt_buf);
@@ -212,8 +212,8 @@ static void display_import_rt(struct vty *vty, struct irt_node *irt,
 		eip.val = (*pnt++ << 8);
 		eip.val |= (*pnt++);
 
-		snprintf(rt_buf, sizeof(rt_buf), "%s:%u", inet_ntoa(eip.ip),
-			 eip.val);
+		snprintfrr(rt_buf, sizeof(rt_buf), "%pI4:%u", &eip.ip,
+			   eip.val);
 
 		if (json)
 			json_object_string_add(json_rt, "rt", rt_buf);
@@ -313,8 +313,8 @@ static void bgp_evpn_show_route_rd_header(struct vty *vty,
 
 	case RD_TYPE_IP:
 		decode_rd_ip(pnt + 2, &rd_ip);
-		snprintf(rd_str, len, "%s:%d", inet_ntoa(rd_ip.ip),
-			 rd_ip.val);
+		snprintfrr(rd_str, len, "%pI4:%d", &rd_ip.ip,
+			   rd_ip.val);
 		if (json)
 			json_object_string_add(json, "rd", rd_str);
 		else
@@ -342,8 +342,9 @@ static void bgp_evpn_show_route_header(struct vty *vty, struct bgp *bgp,
 	if (json)
 		return;
 
-	vty_out(vty, "BGP table version is %" PRIu64 ", local router ID is %s\n",
-		tbl_ver, inet_ntoa(bgp->router_id));
+	vty_out(vty,
+		"BGP table version is %" PRIu64 ", local router ID is %pI4\n",
+		tbl_ver, &bgp->router_id);
 	vty_out(vty,
 		"Status codes: s suppressed, d damped, h history, * valid, > best, i - internal\n");
 	vty_out(vty, "Origin codes: i - IGP, e - EGP, ? - incomplete\n");
@@ -406,21 +407,18 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 			vrf_id_to_name(bgp_vrf->vrf_id));
 		vty_out(vty, "  RD: %s\n",
 			prefix_rd2str(&bgp_vrf->vrf_prd, buf1, RD_ADDRSTRLEN));
-		vty_out(vty, "  Originator IP: %s\n",
-			inet_ntoa(bgp_vrf->originator_ip));
+		vty_out(vty, "  Originator IP: %pI4\n",
+			&bgp_vrf->originator_ip);
 		vty_out(vty, "  Advertise-gw-macip : %s\n", "n/a");
 		vty_out(vty, "  Advertise-svi-macip : %s\n", "n/a");
 		vty_out(vty, "  Advertise-pip: %s\n",
 			bgp_vrf->evpn_info->advertise_pip ? "Yes" : "No");
-		vty_out(vty, "  System-IP: %s\n",
-			inet_ntop(AF_INET, &bgp_vrf->evpn_info->pip_ip,
-				  buf1, INET_ADDRSTRLEN));
-		vty_out(vty, "  System-MAC: %s\n",
-				prefix_mac2str(&bgp_vrf->evpn_info->pip_rmac,
-					       buf2, sizeof(buf2)));
-		vty_out(vty, "  Router-MAC: %s\n",
-				prefix_mac2str(&bgp_vrf->rmac,
-					       buf2, sizeof(buf2)));
+		vty_out(vty, "  System-IP: %pI4\n",
+			&bgp_vrf->evpn_info->pip_ip);
+		vty_out(vty, "  System-MAC: %pEA\n",
+				&bgp_vrf->evpn_info->pip_rmac);
+		vty_out(vty, "  Router-MAC: %pEA\n",
+				&bgp_vrf->rmac);
 	}
 
 	if (!json)
@@ -492,12 +490,12 @@ static void display_es(struct vty *vty, struct evpnes *es, json_object *json)
 			esi_to_str(&es->esi, buf, sizeof(buf)));
 		vty_out(vty, "  RD: %s\n", prefix_rd2str(&es->prd, buf1,
 						       sizeof(buf1)));
-		vty_out(vty, "  Originator-IP: %s\n",
-			ipaddr2str(&es->originator_ip, buf2, sizeof(buf2)));
+		vty_out(vty, "  Originator-IP: %pIA\n",
+			&es->originator_ip);
 		if (es->vtep_list) {
 			vty_out(vty, "  VTEP List:\n");
 			for (ALL_LIST_ELEMENTS_RO(es->vtep_list, node, vtep))
-				vty_out(vty, "    %s\n", inet_ntoa(*vtep));
+				vty_out(vty, "    %pI4\n", vtep);
 		}
 	}
 }
@@ -563,10 +561,10 @@ static void display_vni(struct vty *vty, struct bgpevpn *vpn, json_object *json)
 			vrf_id_to_name(vpn->tenant_vrf_id));
 		vty_out(vty, "  RD: %s\n",
 			prefix_rd2str(&vpn->prd, buf1, sizeof(buf1)));
-		vty_out(vty, "  Originator IP: %s\n",
-			inet_ntoa(vpn->originator_ip));
-		vty_out(vty, "  Mcast group: %s\n",
-				inet_ntoa(vpn->mcast_grp));
+		vty_out(vty, "  Originator IP: %pI4\n",
+			&vpn->originator_ip);
+		vty_out(vty, "  Mcast group: %pI4\n",
+				&vpn->mcast_grp);
 		if (!vpn->advertise_gw_macip &&
 		    bgp_evpn && bgp_evpn->advertise_gw_macip)
 			vty_out(vty, "  Advertise-gw-macip : %s\n",
@@ -1011,12 +1009,11 @@ static void show_es_entry(struct hash_bucket *bucket, void *args[])
 		}
 		json_object_object_add(json, "vteps", json_vteps);
 	} else {
-		vty_out(vty, "%-30s %-6s %-21s %-15s %-6d\n",
+		vty_out(vty, "%-30s %-6s %-21s %-15pIA %-6d\n",
 			esi_to_str(&es->esi, buf, sizeof(buf)),
 			is_es_local(es) ? "Local" : "Remote",
 			prefix_rd2str(&es->prd, buf1, sizeof(buf1)),
-			ipaddr2str(&es->originator_ip, buf2,
-				   sizeof(buf2)),
+			&es->originator_ip,
 			es->vtep_list ? listcount(es->vtep_list) : 0);
 	}
 }
@@ -5197,10 +5194,10 @@ DEFUN (show_bgp_vrf_l3vni_info,
 
 	if (!json) {
 		vty_out(vty, "BGP VRF: %s\n", name);
-		vty_out(vty, "  Local-Ip: %s\n", inet_ntoa(bgp->originator_ip));
+		vty_out(vty, "  Local-Ip: %pI4\n", &bgp->originator_ip);
 		vty_out(vty, "  L3-VNI: %u\n", bgp->l3vni);
-		vty_out(vty, "  Rmac: %s\n",
-			prefix_mac2str(&bgp->rmac, buf, sizeof(buf)));
+		vty_out(vty, "  Rmac: %pEA\n",
+			&bgp->rmac);
 		vty_out(vty, "  VNI Filter: %s\n",
 			CHECK_FLAG(bgp->vrf_flags,
 				   BGP_VRF_L3VNI_PREFIX_ROUTES_ONLY)
@@ -5745,19 +5742,14 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 		if (bgp->evpn_info->advertise_pip) {
 			if (bgp->evpn_info->pip_ip_static.s_addr
 			    != INADDR_ANY) {
-				vty_out(vty, "  advertise-pip ip %s",
-					inet_ntop(AF_INET,
-					&bgp->evpn_info->pip_ip_static,
-					buf2, INET_ADDRSTRLEN));
+				vty_out(vty, "  advertise-pip ip %pI4",
+					&bgp->evpn_info->pip_ip_static);
 				if (!is_zero_mac(&(
 					    bgp->evpn_info->pip_rmac_static))) {
 					char buf[ETHER_ADDR_STRLEN];
 
-					vty_out(vty, " mac %s",
-						prefix_mac2str(
-							&bgp->evpn_info
-								 ->pip_rmac,
-							buf, sizeof(buf)));
+					vty_out(vty, " mac %pEA",
+						&bgp->evpn_info->pip_rmac);
 				}
 				vty_out(vty, "\n");
 			}

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -315,8 +315,8 @@ void route_vty_out_flowspec(struct vty *vty, const struct prefix *p,
 		}
 		if (attr->nexthop.s_addr != 0 &&
 		    display == NLRI_STRING_FORMAT_LARGE)
-			vty_out(vty, "\tNLRI NH %-16s\n",
-				inet_ntoa(attr->nexthop));
+			vty_out(vty, "\tNLRI NH %-16pI4\n",
+				&attr->nexthop);
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
 	peer_uptime(path->uptime, timebuf, BGP_UPTIME_LEN, 0, NULL);

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -215,7 +215,6 @@ void bgp_reg_dereg_for_label(struct bgp_dest *dest, struct bgp_path_info *pi,
 	int command;
 	uint16_t flags = 0;
 	size_t flags_pos = 0;
-	char addr[PREFIX_STRLEN];
 
 	p = bgp_dest_get_prefix(dest);
 	local_label = &(dest->local_label);

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -243,9 +243,8 @@ void bgp_reg_dereg_for_label(struct bgp_dest *dest, struct bgp_path_info *pi,
 			 */
 			if (!have_label_to_reg) {
 				if (BGP_DEBUG(labelpool, LABELPOOL)) {
-					prefix2str(p, addr, PREFIX_STRLEN);
-					zlog_debug("%s: Requesting label from LP for %s",
-						 __func__, addr);
+					zlog_debug("%s: Requesting label from LP for %pFX",
+						   __func__, p);
 				}
 				/* bgp_reg_for_label_callback() will call back
 				 * __func__ when it gets a label from the pool.

--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -405,10 +405,9 @@ static void bgp_mac_show_mac_entry(struct hash_bucket *bucket, void *arg)
 	struct bgp_self_mac *bsm = bucket->data;
 	struct listnode *node;
 	char *name;
-	char buf_mac[ETHER_ADDR_STRLEN];
 
-	vty_out(vty, "Mac Address: %s ",
-		prefix_mac2str(&bsm->macaddr, buf_mac, sizeof(buf_mac)));
+	vty_out(vty, "Mac Address: %pEA ",
+		&bsm->macaddr);
 
 	for (ALL_LIST_ELEMENTS_RO(bsm->ifp_list, node, name))
 		vty_out(vty, "%s ", name);

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -217,7 +217,6 @@ int bgp_md5_unset(struct peer *peer)
 
 int bgp_set_socket_ttl(struct peer *peer, int bgp_sock)
 {
-	char buf[INET_ADDRSTRLEN];
 	int ret = 0;
 
 	/* In case of peer is EBGP, we should set TTL for this connection.  */
@@ -226,10 +225,9 @@ int bgp_set_socket_ttl(struct peer *peer, int bgp_sock)
 		if (ret) {
 			flog_err(
 				EC_LIB_SOCKET,
-				"%s: Can't set TxTTL on peer (rtrid %s) socket, err = %d",
+				"%s: Can't set TxTTL on peer (rtrid %pI4) socket, err = %d",
 				__func__,
-				inet_ntop(AF_INET, &peer->remote_id, buf,
-					  sizeof(buf)),
+				&peer->remote_id,
 				errno);
 			return ret;
 		}
@@ -242,10 +240,9 @@ int bgp_set_socket_ttl(struct peer *peer, int bgp_sock)
 		if (ret) {
 			flog_err(
 				EC_LIB_SOCKET,
-				"%s: Can't set TxTTL on peer (rtrid %s) socket, err = %d",
+				"%s: Can't set TxTTL on peer (rtrid %pI4) socket, err = %d",
 				__func__,
-				inet_ntop(AF_INET, &peer->remote_id, buf,
-					  sizeof(buf)),
+				&peer->remote_id,
 				errno);
 			return ret;
 		}
@@ -254,10 +251,9 @@ int bgp_set_socket_ttl(struct peer *peer, int bgp_sock)
 		if (ret) {
 			flog_err(
 				EC_LIB_SOCKET,
-				"%s: Can't set MinTTL on peer (rtrid %s) socket, err = %d",
+				"%s: Can't set MinTTL on peer (rtrid %pI4) socket, err = %d",
 				__func__,
-				inet_ntop(AF_INET, &peer->remote_id, buf,
-					  sizeof(buf)),
+				&peer->remote_id,
 				errno);
 			return ret;
 		}

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -731,35 +731,30 @@ static void bgp_show_nexthop_paths(struct vty *vty, struct bgp *bgp,
 static void bgp_show_nexthops_detail(struct vty *vty, struct bgp *bgp,
 				     struct bgp_nexthop_cache *bnc)
 {
-	char buf[PREFIX2STR_BUFFER];
 	struct nexthop *nexthop;
 
 	for (nexthop = bnc->nexthop; nexthop; nexthop = nexthop->next) {
 		switch (nexthop->type) {
 		case NEXTHOP_TYPE_IPV6:
-			vty_out(vty, "  gate %s\n",
-				inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf,
-					  sizeof(buf)));
+			vty_out(vty, "  gate %pI6\n",
+				&nexthop->gate.ipv6);
 			break;
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
-			vty_out(vty, "  gate %s, if %s\n",
-				inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf,
-					  sizeof(buf)),
+			vty_out(vty, "  gate %pI6, if %s\n",
+				&nexthop->gate.ipv6,
 				ifindex2ifname(nexthop->ifindex, bgp->vrf_id));
 			break;
 		case NEXTHOP_TYPE_IPV4:
-			vty_out(vty, "  gate %s\n",
-				inet_ntop(AF_INET, &nexthop->gate.ipv4, buf,
-					  sizeof(buf)));
+			vty_out(vty, "  gate %pI4\n",
+				&nexthop->gate.ipv4);
 			break;
 		case NEXTHOP_TYPE_IFINDEX:
 			vty_out(vty, "  if %s\n",
 				ifindex2ifname(nexthop->ifindex, bgp->vrf_id));
 			break;
 		case NEXTHOP_TYPE_IPV4_IFINDEX:
-			vty_out(vty, "  gate %s, if %s\n",
-				inet_ntop(AF_INET, &nexthop->gate.ipv4, buf,
-					  sizeof(buf)),
+			vty_out(vty, "  gate %pI4, if %s\n",
+				&nexthop->gate.ipv4,
 				ifindex2ifname(nexthop->ifindex, bgp->vrf_id));
 			break;
 		case NEXTHOP_TYPE_BLACKHOLE:

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -626,12 +626,9 @@ static void sendmsg_zebra_rnh(struct bgp_nexthop_cache *bnc, int command)
 		exact_match = true;
 
 	if (BGP_DEBUG(zebra, ZEBRA)) {
-		char buf[PREFIX2STR_BUFFER];
-
-		prefix2str(p, buf, PREFIX2STR_BUFFER);
-		zlog_debug("%s: sending cmd %s for %s (vrf %s)",
-			__func__, zserv_command_string(command), buf,
-			bnc->bgp->name_pretty);
+		zlog_debug("%s: sending cmd %s for %pFX (vrf %s)",
+			   __func__, zserv_command_string(command), p,
+			   bnc->bgp->name_pretty);
 	}
 
 	ret = zclient_send_rnh(zclient, command, p, exact_match,

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2026,7 +2026,6 @@ static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 					p_pnt += psize;
 
 					if (bgp_debug_neighbor_events(peer)) {
-						char buf[INET6_BUFSIZ];
 
 						zlog_debug("%s rcvd %s %s seq %u %pFX ge %d le %d%s",
 							   peer->host,

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -563,10 +563,9 @@ void bgp_open_send(struct peer *peer)
 	(void)bgp_packet_set_size(s);
 
 	if (bgp_debug_neighbor_events(peer))
-		zlog_debug(
-			"%s sending OPEN, version %d, my as %u, holdtime %d, id %s",
-			peer->host, BGP_VERSION_4, local_as, send_holdtime,
-			inet_ntoa(peer->local_id));
+		zlog_debug("%s sending OPEN, version %d, my as %u, holdtime %d, id %pI4",
+			   peer->host, BGP_VERSION_4, local_as, send_holdtime,
+			   &peer->local_id);
 
 	/* Dump packet if debug option is set. */
 	/* bgp_packet_dump (s); */
@@ -1020,8 +1019,8 @@ static int bgp_collision_detect(struct peer *new, struct in_addr remote_id)
 				    && peer->local_as == peer->as)
 					flog_err(
 						EC_BGP_ROUTER_ID_SAME,
-						"Peer's router-id %s is the same as ours",
-						inet_ntoa(remote_id));
+						"Peer's router-id %pI4 is the same as ours",
+						&remote_id);
 
 				/* 3. Otherwise, the local system closes newly
 				   created
@@ -1112,10 +1111,9 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 
 	/* Receive OPEN message log  */
 	if (bgp_debug_neighbor_events(peer))
-		zlog_debug(
-			"%s rcv OPEN, version %d, remote-as (in open) %u, holdtime %d, id %s",
-			peer->host, version, remote_as, holdtime,
-			inet_ntoa(remote_id));
+		zlog_debug("%s rcv OPEN, version %d, remote-as (in open) %u, holdtime %d, id %pI4",
+			   peer->host, version, remote_as, holdtime,
+			   &remote_id);
 
 	/* BEGIN to read the capability here, but dont do it yet */
 	mp_capability = 0;
@@ -1218,8 +1216,8 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 	    || (peer->sort == BGP_PEER_IBGP
 		&& ntohl(peer->local_id.s_addr) == ntohl(remote_id.s_addr))) {
 		if (bgp_debug_neighbor_events(peer))
-			zlog_debug("%s bad OPEN, wrong router identifier %s",
-				   peer->host, inet_ntoa(remote_id));
+			zlog_debug("%s bad OPEN, wrong router identifier %pI4",
+				   peer->host, &remote_id);
 		bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 					  BGP_NOTIFY_OPEN_BAD_BGP_IDENT,
 					  notify_data_remote_id, 4);

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2028,22 +2028,16 @@ static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 					if (bgp_debug_neighbor_events(peer)) {
 						char buf[INET6_BUFSIZ];
 
-						zlog_debug(
-							"%s rcvd %s %s seq %u %s/%d ge %d le %d%s",
-							peer->host,
-							(common & ORF_COMMON_PART_REMOVE
+						zlog_debug("%s rcvd %s %s seq %u %pFX ge %d le %d%s",
+							   peer->host,
+							   (common & ORF_COMMON_PART_REMOVE
 								 ? "Remove"
 								 : "Add"),
 							(common & ORF_COMMON_PART_DENY
 								 ? "deny"
 								 : "permit"),
 							orfp.seq,
-							inet_ntop(
-								orfp.p.family,
-								&orfp.p.u.prefix,
-								buf,
-								INET6_BUFSIZ),
-							orfp.p.prefixlen,
+							&orfp.p,
 							orfp.ge, orfp.le,
 							ok ? "" : " MALFORMED");
 					}

--- a/bgpd/bgp_rd.c
+++ b/bgpd/bgp_rd.c
@@ -182,8 +182,8 @@ char *prefix_rd2str(const struct prefix_rd *prd, char *buf, size_t size)
 		return buf;
 	} else if (type == RD_TYPE_IP) {
 		decode_rd_ip(pnt + 2, &rd_ip);
-		snprintf(buf, size, "%s:%hu", inet_ntoa(rd_ip.ip),
-			 rd_ip.val);
+		snprintfrr(buf, size, "%pI4:%hu", &rd_ip.ip,
+			   rd_ip.val);
 		return buf;
 	}
 #ifdef ENABLE_BGP_VNC
@@ -210,6 +210,6 @@ void form_auto_rd(struct in_addr router_id,
 
 	prd->family = AF_UNSPEC;
 	prd->prefixlen = 64;
-	snprintf(buf, sizeof(buf), "%s:%hu", inet_ntoa(router_id), rd_id);
+	snprintfrr(buf, sizeof(buf), "%pI4:%hu", &router_id, rd_id);
 	(void)str2prefix_rd(buf, prd);
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10045,7 +10045,6 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 	struct peer *peer;
 	struct listnode *node, *nnode;
 	char buf1[RD_ADDRSTRLEN];
-	char buf2[INET6_ADDRSTRLEN];
 	char buf3[EVPN_ROUTE_STRLEN];
 	char prefix_str[BUFSIZ];
 	int count = 0;
@@ -13255,7 +13254,6 @@ static void bgp_config_write_network_vpn(struct vty *vty, struct bgp *bgp,
 	const struct prefix_rd *prd;
 	struct bgp_static *bgp_static;
 	mpls_label_t label;
-	char buf[SU_ADDRSTRLEN];
 	char rdbuf[RD_ADDRSTRLEN];
 
 	/* Network configuration. */
@@ -13378,7 +13376,6 @@ void bgp_config_write_network(struct vty *vty, struct bgp *bgp, afi_t afi,
 	const struct prefix *p;
 	struct bgp_static *bgp_static;
 	struct bgp_aggregate *bgp_aggregate;
-	char buf[SU_ADDRSTRLEN];
 
 	if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP)) {
 		bgp_config_write_network_vpn(vty, bgp, afi, safi);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1644,11 +1644,9 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 		mpls_label_t label = bgp_adv_label(dest, pi, peer, afi, safi);
 		if (!bgp_is_valid_label(&label)) {
 			if (bgp_debug_update(NULL, p, subgrp->update_group, 0))
-				zlog_debug("u%" PRIu64 ":s%" PRIu64" %s/%d is filtered - no label (%p)",
+				zlog_debug("u%" PRIu64 ":s%" PRIu64" %pFX is filtered - no label (%p)",
 					   subgrp->update_group->id, subgrp->id,
-					   inet_ntop(p->family, &p->u.prefix,
-						     buf, SU_ADDRSTRLEN),
-					   p->prefixlen, &label);
+					   p, &label);
 			return false;
 		}
 	}
@@ -7416,9 +7414,8 @@ static void route_vty_out_route(const struct prefix *p, struct vty *vty,
 	if (p->family == AF_INET) {
 		if (!json) {
 			len = vty_out(
-				vty, "%s/%d",
-				inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ),
-				p->prefixlen);
+				vty, "%pFX",
+				p);
 		} else {
 			json_object_string_add(json, "prefix",
 					       inet_ntop(p->family,
@@ -7447,9 +7444,8 @@ static void route_vty_out_route(const struct prefix *p, struct vty *vty,
 	} else {
 		if (!json)
 			len = vty_out(
-				vty, "%s/%d",
-				inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ),
-				p->prefixlen);
+				vty, "%pFX",
+				p);
 		else {
 			json_object_string_add(json, "prefix",
 						inet_ntop(p->family,
@@ -10095,15 +10091,13 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 		}
 	} else {
 		if (!json) {
-			vty_out(vty, "BGP routing table entry for %s%s%s/%d\n",
+			vty_out(vty, "BGP routing table entry for %s%s%pFX\n",
 				((safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP)
 				 ? prefix_rd2str(prd, buf1,
 					 sizeof(buf1))
 				 : ""),
 				safi == SAFI_MPLS_VPN ? ":" : "",
-				inet_ntop(p->family, &p->u.prefix, buf2,
-					INET6_ADDRSTRLEN),
-				p->prefixlen);
+				p);
 
 		} else
 			json_object_string_add(json, "prefix",
@@ -13285,10 +13279,8 @@ static void bgp_config_write_network_vpn(struct vty *vty, struct bgp *bgp,
 			prefix_rd2str(prd, rdbuf, sizeof(rdbuf));
 			label = decode_label(&bgp_static->label);
 
-			vty_out(vty, "  network %s/%d rd %s",
-				inet_ntop(p->family, &p->u.prefix, buf,
-					  SU_ADDRSTRLEN),
-				p->prefixlen, rdbuf);
+			vty_out(vty, "  network %pFX rd %s",
+				p, rdbuf);
 			if (safi == SAFI_MPLS_VPN)
 				vty_out(vty, " label %u", label);
 
@@ -13407,9 +13399,8 @@ void bgp_config_write_network(struct vty *vty, struct bgp *bgp, afi_t afi,
 
 		p = bgp_dest_get_prefix(dest);
 
-		vty_out(vty, "  network %s/%d",
-			inet_ntop(p->family, &p->u.prefix, buf, SU_ADDRSTRLEN),
-			p->prefixlen);
+		vty_out(vty, "  network %pFX",
+			p);
 
 		if (bgp_static->label_index != BGP_INVALID_LABEL_INDEX)
 			vty_out(vty, " label-index %u",
@@ -13433,9 +13424,8 @@ void bgp_config_write_network(struct vty *vty, struct bgp *bgp, afi_t afi,
 
 		p = bgp_dest_get_prefix(dest);
 
-		vty_out(vty, "  aggregate-address %s/%d",
-			inet_ntop(p->family, &p->u.prefix, buf, SU_ADDRSTRLEN),
-			p->prefixlen);
+		vty_out(vty, "  aggregate-address %pFX",
+			p);
 
 		if (bgp_aggregate->as_set)
 			vty_out(vty, " as-set");

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -246,9 +246,9 @@ static void subgrp_show_adjq_vty(struct update_subgroup *subgrp,
 			if (adj->subgroup == subgrp) {
 				if (header1) {
 					vty_out(vty,
-						"BGP table version is %" PRIu64", local router ID is %s\n",
+						"BGP table version is %" PRIu64", local router ID is %pI4\n",
 						table->version,
-						inet_ntoa(bgp->router_id));
+						&bgp->router_id);
 					vty_out(vty, BGP_SHOW_SCODE_HEADER);
 					vty_out(vty, BGP_SHOW_OCODE_HEADER);
 					header1 = 0;

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -387,8 +387,6 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 	struct stream *s = NULL;
 	bpacket_attr_vec *vec;
 	struct peer *peer;
-	char buf[BUFSIZ];
-	char buf2[BUFSIZ];
 	struct bgp_filter *filter;
 
 	s = stream_dup(pkt->buffer);

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -488,10 +488,10 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 			stream_put_in_addr_at(s, offset_nh, mod_v4nh);
 
 		if (bgp_debug_update(peer, NULL, NULL, 0))
-			zlog_debug("u%" PRIu64 ":s%" PRIu64" %s send UPDATE w/ nexthop %s%s",
+			zlog_debug("u%" PRIu64 ":s%" PRIu64" %s send UPDATE w/ nexthop %pI4%s",
 				   PAF_SUBGRP(paf)->update_group->id,
 				   PAF_SUBGRP(paf)->id, peer->host,
-				   inet_ntoa(*mod_v4nh),
+				   mod_v4nh,
 				   (nhlen == BGP_ATTR_NHLEN_VPNV4 ? " and RD"
 								  : ""));
 	} else if (nhafi == AFI_IP6) {
@@ -592,23 +592,19 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 		if (bgp_debug_update(peer, NULL, NULL, 0)) {
 			if (nhlen == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL
 			    || nhlen == BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL)
-				zlog_debug(
-					"u%" PRIu64 ":s%" PRIu64" %s send UPDATE w/ mp_nexthops %s, %s%s",
-					PAF_SUBGRP(paf)->update_group->id,
-					PAF_SUBGRP(paf)->id, peer->host,
-					inet_ntop(AF_INET6, mod_v6nhg, buf,
-						  BUFSIZ),
-					inet_ntop(AF_INET6, mod_v6nhl, buf2,
-						  BUFSIZ),
-					(nhlen == BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL
+				zlog_debug("u%" PRIu64 ":s%" PRIu64" %s send UPDATE w/ mp_nexthops %pI6, %pI6%s",
+					   PAF_SUBGRP(paf)->update_group->id,
+					   PAF_SUBGRP(paf)->id, peer->host,
+					   mod_v6nhg,
+					   mod_v6nhl,
+					   (nhlen == BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL
 						 ? " and RD"
 						 : ""));
 			else
-				zlog_debug("u%" PRIu64 ":s%" PRIu64" %s send UPDATE w/ mp_nexthop %s%s",
+				zlog_debug("u%" PRIu64 ":s%" PRIu64" %s send UPDATE w/ mp_nexthop %pI6%s",
 					   PAF_SUBGRP(paf)->update_group->id,
 					   PAF_SUBGRP(paf)->id, peer->host,
-					   inet_ntop(AF_INET6, mod_v6nhg, buf,
-						     BUFSIZ),
+					   mod_v6nhg,
 					   (nhlen == BGP_ATTR_NHLEN_VPNV6_GLOBAL
 						    ? " and RD"
 						    : ""));
@@ -630,10 +626,10 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 			stream_put_in_addr_at(s, vec->offset + 1, mod_v4nh);
 
 		if (bgp_debug_update(peer, NULL, NULL, 0))
-			zlog_debug("u%" PRIu64 ":s%" PRIu64" %s send UPDATE w/ nexthop %s",
+			zlog_debug("u%" PRIu64 ":s%" PRIu64" %s send UPDATE w/ nexthop %pI4",
 				   PAF_SUBGRP(paf)->update_group->id,
 				   PAF_SUBGRP(paf)->id, peer->host,
-				   inet_ntoa(*mod_v4nh));
+				   mod_v4nh);
 	}
 
 	return s;
@@ -1125,7 +1121,6 @@ void subgroup_default_update_packet(struct update_subgroup *subgrp,
 	/* Logging the attribute. */
 	if (bgp_debug_update(NULL, &p, subgrp->update_group, 0)) {
 		char attrstr[BUFSIZ];
-		char buf[PREFIX_STRLEN];
 		/* ' with addpath ID '          17
 		 * max strlen of uint32       + 10
 		 * +/- (just in case)         +  1
@@ -1144,9 +1139,9 @@ void subgroup_default_update_packet(struct update_subgroup *subgrp,
 		else
 			tx_id_buf[0] = '\0';
 
-		zlog_debug("u%" PRIu64 ":s%" PRIu64 " send UPDATE %s%s %s",
+		zlog_debug("u%" PRIu64 ":s%" PRIu64 " send UPDATE %pFX%s %s",
 			   (SUBGRP_UPDGRP(subgrp))->id, subgrp->id,
-			   prefix2str(&p, buf, sizeof(buf)), tx_id_buf,
+			   &p, tx_id_buf,
 			   attrstr);
 	}
 
@@ -1210,7 +1205,6 @@ void subgroup_default_withdraw_packet(struct update_subgroup *subgrp)
 	p.prefixlen = 0;
 
 	if (bgp_debug_update(NULL, &p, subgrp->update_group, 0)) {
-		char buf[PREFIX_STRLEN];
 		/* ' with addpath ID '          17
 		 * max strlen of uint32       + 10
 		 * +/- (just in case)         +  1
@@ -1223,9 +1217,9 @@ void subgroup_default_withdraw_packet(struct update_subgroup *subgrp)
 				 " with addpath ID %u",
 				 BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE);
 
-		zlog_debug("u%" PRIu64 ":s%" PRIu64" send UPDATE %s%s -- unreachable",
+		zlog_debug("u%" PRIu64 ":s%" PRIu64" send UPDATE %pFX%s -- unreachable",
 			   (SUBGRP_UPDGRP(subgrp))->id, subgrp->id,
-			   prefix2str(&p, buf, sizeof(buf)), tx_id_buf);
+			   &p, tx_id_buf);
 	}
 
 	s = stream_new(BGP_MAX_PACKET_SIZE);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3473,7 +3473,6 @@ void bgp_config_write_listen(struct vty *vty, struct bgp *bgp)
 	struct listnode *node, *nnode, *rnode, *nrnode;
 	struct prefix *range;
 	afi_t afi;
-	char buf[PREFIX2STR_BUFFER];
 
 	if (bgp->dynamic_neighbors_limit != BGP_DYNAMIC_NEIGHBORS_LIMIT_DEFAULT)
 		vty_out(vty, " bgp listen limit %d\n",
@@ -3483,10 +3482,9 @@ void bgp_config_write_listen(struct vty *vty, struct bgp *bgp)
 		for (afi = AFI_IP; afi < AFI_MAX; afi++) {
 			for (ALL_LIST_ELEMENTS(group->listen_range[afi], rnode,
 					       nrnode, range)) {
-				prefix2str(range, buf, sizeof(buf));
 				vty_out(vty,
-					" bgp listen range %s peer-group %s\n",
-					buf, group->name);
+					" bgp listen range %pFX peer-group %s\n",
+					range, group->name);
 			}
 		}
 	}
@@ -8551,7 +8549,7 @@ static void show_tip_entry(struct hash_bucket *bucket, void *args)
 	struct vty *vty = (struct vty *)args;
 	struct tip_addr *tip = (struct tip_addr *)bucket->data;
 
-	vty_out(vty, "addr: %s, count: %d\n", inet_ntoa(tip->addr),
+	vty_out(vty, "addr: %pI4, count: %d\n", &tip->addr,
 		tip->refcnt);
 }
 
@@ -11002,11 +11000,10 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 
 		/* BGP Version. */
 		vty_out(vty, "  BGP version 4");
-		vty_out(vty, ", remote router ID %s",
-			inet_ntop(AF_INET, &p->remote_id, buf1, sizeof(buf1)));
-		vty_out(vty, ", local router ID %s\n",
-			inet_ntop(AF_INET, &bgp->router_id, buf1,
-					sizeof(buf1)));
+		vty_out(vty, ", remote router ID %pI4",
+			&p->remote_id);
+		vty_out(vty, ", local router ID %pI4\n",
+			&bgp->router_id);
 
 		/* Confederation */
 		if (CHECK_FLAG(bgp->config, BGP_CONFIG_CONFEDERATION)
@@ -12304,15 +12301,12 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 						       "bgpConnection",
 						       "nonSharedNetwork");
 		} else {
-			vty_out(vty, "Nexthop: %s\n",
-				inet_ntop(AF_INET, &p->nexthop.v4, buf1,
-					  sizeof(buf1)));
-			vty_out(vty, "Nexthop global: %s\n",
-				inet_ntop(AF_INET6, &p->nexthop.v6_global, buf1,
-					  sizeof(buf1)));
-			vty_out(vty, "Nexthop local: %s\n",
-				inet_ntop(AF_INET6, &p->nexthop.v6_local, buf1,
-					  sizeof(buf1)));
+			vty_out(vty, "Nexthop: %pI4\n",
+				&p->nexthop.v4);
+			vty_out(vty, "Nexthop global: %pI6\n",
+				&p->nexthop.v6_global);
+			vty_out(vty, "Nexthop local: %pI6\n",
+				&p->nexthop.v6_local);
 			vty_out(vty, "BGP connection: %s\n",
 				p->shared_network ? "shared network"
 						  : "non shared network");
@@ -13506,7 +13500,6 @@ static int bgp_show_one_peer_group(struct vty *vty, struct peer_group *group)
 	struct prefix *range;
 	struct peer *conf;
 	struct peer *peer;
-	char buf[PREFIX2STR_BUFFER];
 	afi_t afi;
 	safi_t safi;
 	const char *peer_status;
@@ -13561,8 +13554,7 @@ static int bgp_show_one_peer_group(struct vty *vty, struct peer_group *group)
 
 			for (ALL_LIST_ELEMENTS(group->listen_range[afi], node,
 					       nnode, range)) {
-				prefix2str(range, buf, sizeof(buf));
-				vty_out(vty, "    %s\n", buf);
+				vty_out(vty, "    %pFX\n", range);
 			}
 		}
 	}

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -284,11 +284,10 @@ void bgp_router_id_zebra_bump(vrf_id_t vrf_id, const struct prefix *router_id)
 				 */
 				if (bgp->established_peers == 0) {
 					if (BGP_DEBUG(zebra, ZEBRA))
-						zlog_debug(
-							"RID change : vrf %s(%u), RTR ID %s",
-							bgp->name_pretty,
-							bgp->vrf_id,
-							inet_ntoa(*addr));
+						zlog_debug("RID change : vrf %s(%u), RTR ID %pI4",
+							   bgp->name_pretty,
+							   bgp->vrf_id,
+							   addr);
 					bgp_router_id_set(bgp, addr, false);
 				}
 			}
@@ -307,11 +306,10 @@ void bgp_router_id_zebra_bump(vrf_id_t vrf_id, const struct prefix *router_id)
 				 */
 				if (bgp->established_peers == 0) {
 					if (BGP_DEBUG(zebra, ZEBRA))
-						zlog_debug(
-							"RID change : vrf %s(%u), RTR ID %s",
-							bgp->name_pretty,
-							bgp->vrf_id,
-							inet_ntoa(*addr));
+						zlog_debug("RID change : vrf %s(%u), RTR ID %pI4",
+							   bgp->name_pretty,
+							   bgp->vrf_id,
+							   addr);
 					bgp_router_id_set(bgp, addr, false);
 				}
 			}

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -432,11 +432,8 @@ void rfapi_vty_out_vncinfo(struct vty *vty, const struct prefix *p,
 				decode_label(&bpi->extra->label[0]));
 
 		if (bpi->extra->num_sids) {
-			char buf[BUFSIZ];
-
-			vty_out(vty, " sid=%s",
-				inet_ntop(AF_INET6, &bpi->extra->sid[0], buf,
-					  sizeof(buf)));
+			vty_out(vty, " sid=%pI6",
+				&bpi->extra->sid[0]);
 		}
 	}
 

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -697,11 +697,11 @@ char *rfapiMonitorVpn2Str(struct rfapi_monitor_vpn *m, char *buf, int size)
 	rfapiRfapiIpAddr2Str(&m->rfd->un_addr, buf_vn, BUFSIZ);
 	rfapiRfapiIpAddr2Str(&m->rfd->vn_addr, buf_un, BUFSIZ);
 
-	rc = snprintf(buf, size,
-		      "m=%p, next=%p, rfd=%p(vn=%s un=%s), p=%s/%d, node=%p", m,
+	rc = snprintfrr(buf, size,
+		      "m=%p, next=%p, rfd=%p(vn=%s un=%s), p=%pFX, node=%p",
+		      m,
 		      m->next, m->rfd, buf_vn, buf_un,
-		      inet_ntop(m->p.family, &m->p.u.prefix, buf_pfx, BUFSIZ),
-		      m->p.prefixlen, m->node);
+		      &m->p, m->node);
 	buf[size - 1] = 0;
 	if (rc >= size)
 		return NULL;

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -689,7 +689,6 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bpi)
 
 char *rfapiMonitorVpn2Str(struct rfapi_monitor_vpn *m, char *buf, int size)
 {
-	char buf_pfx[BUFSIZ];
 	char buf_vn[BUFSIZ];
 	char buf_un[BUFSIZ];
 	int rc;

--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -122,8 +122,8 @@ void eigrp_ip_header_dump(struct ip *iph)
 	zlog_debug("ip_ttl %u", iph->ip_ttl);
 	zlog_debug("ip_p %u", iph->ip_p);
 	zlog_debug("ip_sum 0x%x", (uint32_t)iph->ip_sum);
-	zlog_debug("ip_src %s", inet_ntoa(iph->ip_src));
-	zlog_debug("ip_dst %s", inet_ntoa(iph->ip_dst));
+	zlog_debug("ip_src %pI4", &iph->ip_src);
+	zlog_debug("ip_dst %pI4", &iph->ip_dst);
 }
 
 /*
@@ -231,8 +231,9 @@ void show_ip_eigrp_neighbor_sub(struct vty *vty, struct eigrp_neighbor *nbr,
  */
 void show_ip_eigrp_topology_header(struct vty *vty, struct eigrp *eigrp)
 {
-	vty_out(vty, "\nEIGRP Topology Table for AS(%d)/ID(%s)\n\n", eigrp->AS,
-		inet_ntoa(eigrp->router_id));
+	vty_out(vty, "\nEIGRP Topology Table for AS(%d)/ID(%pI4)\n\n",
+		eigrp->AS,
+		&eigrp->router_id);
 	vty_out(vty,
 		"Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply\n       r - reply Status, s - sia Status\n\n");
 }
@@ -240,12 +241,11 @@ void show_ip_eigrp_topology_header(struct vty *vty, struct eigrp *eigrp)
 void show_ip_eigrp_prefix_entry(struct vty *vty, struct eigrp_prefix_entry *tn)
 {
 	struct list *successors = eigrp_topology_get_successor(tn);
-	char buffer[PREFIX_STRLEN];
 
 	vty_out(vty, "%-3c", (tn->state > 0) ? 'A' : 'P');
 
-	vty_out(vty, "%s, ",
-		prefix2str(tn->destination, buffer, PREFIX_STRLEN));
+	vty_out(vty, "%pFX, ",
+		tn->destination);
 	vty_out(vty, "%u successors, ", (successors) ? successors->count : 0);
 	vty_out(vty, "FD is %u, serno: %" PRIu64 " \n", tn->fdistance,
 		tn->serno);
@@ -269,8 +269,8 @@ void show_ip_eigrp_nexthop_entry(struct vty *vty, struct eigrp *eigrp,
 		vty_out(vty, "%-7s%s, %s\n", " ", "via Connected",
 			IF_NAME(te->ei));
 	else {
-		vty_out(vty, "%-7s%s%s (%u/%u), %s\n", " ", "via ",
-			inet_ntoa(te->adv_router->src), te->distance,
+		vty_out(vty, "%-7s%s%pI4 (%u/%u), %s\n", " ", "via ",
+			&te->adv_router->src, te->distance,
 			te->reported_distance, IF_NAME(te->ei));
 	}
 }

--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -144,8 +144,8 @@ eigrp_hello_parameter_decode(struct eigrp_neighbor *nbr,
 	    && (eigrp->k_values[4] == nbr->K5)) {
 
 		if (eigrp_nbr_state_get(nbr) == EIGRP_NEIGHBOR_DOWN) {
-			zlog_info("Neighbor %s (%s) is pending: new adjacency",
-				  inet_ntoa(nbr->src),
+			zlog_info("Neighbor %pI4 (%s) is pending: new adjacency",
+				  &nbr->src,
 				  ifindex2ifname(nbr->ei->ifp->ifindex,
 						 eigrp->vrf_id));
 
@@ -163,19 +163,17 @@ eigrp_hello_parameter_decode(struct eigrp_neighbor *nbr,
 			if ((param->K1 & param->K2 & param->K3 & param->K4
 			     & param->K5)
 			    == 255) {
-				zlog_info(
-					"Neighbor %s (%s) is down: Interface PEER-TERMINATION received",
-					inet_ntoa(nbr->src),
-					ifindex2ifname(nbr->ei->ifp->ifindex,
-						       eigrp->vrf_id));
+				zlog_info("Neighbor %pI4 (%s) is down: Interface PEER-TERMINATION received",
+					  &nbr->src,
+					  ifindex2ifname(nbr->ei->ifp->ifindex,
+							 eigrp->vrf_id));
 				eigrp_nbr_delete(nbr);
 				return NULL;
 			} else {
-				zlog_info(
-					"Neighbor %s (%s) going down: Kvalue mismatch",
-					inet_ntoa(nbr->src),
-					ifindex2ifname(nbr->ei->ifp->ifindex,
-						       eigrp->vrf_id));
+				zlog_info("Neighbor %pI4 (%s) going down: Kvalue mismatch",
+					  &nbr->src,
+					  ifindex2ifname(nbr->ei->ifp->ifindex,
+							 eigrp->vrf_id));
 				eigrp_nbr_state_set(nbr, EIGRP_NEIGHBOR_DOWN);
 			}
 		}
@@ -253,8 +251,8 @@ static void eigrp_peer_termination_decode(struct eigrp_neighbor *nbr,
 	uint32_t received_ip = param->neighbor_ip;
 
 	if (my_ip == received_ip) {
-		zlog_info("Neighbor %s (%s) is down: Peer Termination received",
-			  inet_ntoa(nbr->src),
+		zlog_info("Neighbor %pI4 (%s) is down: Peer Termination received",
+			  &nbr->src,
 			  ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id));
 		/* set neighbor to DOWN */
 		nbr->state = EIGRP_NEIGHBOR_DOWN;
@@ -403,8 +401,8 @@ void eigrp_hello_receive(struct eigrp *eigrp, struct ip *iph,
 	}
 
 	if (IS_DEBUG_EIGRP_PACKET(0, RECV))
-		zlog_debug("Hello Packet received from %s",
-			   inet_ntoa(nbr->src));
+		zlog_debug("Hello Packet received from %pI4",
+			   &nbr->src);
 }
 
 uint32_t FRR_MAJOR;
@@ -708,9 +706,9 @@ void eigrp_hello_send_ack(struct eigrp_neighbor *nbr)
 
 	if (ep) {
 		if (IS_DEBUG_EIGRP_PACKET(0, SEND))
-			zlog_debug("Queueing [Hello] Ack Seq [%u] nbr [%s]",
+			zlog_debug("Queueing [Hello] Ack Seq [%u] nbr [%pI4]",
 				   nbr->recv_sequence_number,
-				   inet_ntoa(nbr->src));
+				   &nbr->src);
 
 		/* Add packet to the top of the interface output queue*/
 		eigrp_fifo_push(nbr->ei->obuf, ep);

--- a/eigrpd/eigrp_neighbor.c
+++ b/eigrpd/eigrp_neighbor.c
@@ -197,8 +197,8 @@ int holddown_timer_expired(struct thread *thread)
 	struct eigrp_neighbor *nbr = THREAD_ARG(thread);
 	struct eigrp *eigrp = nbr->ei->eigrp;
 
-	zlog_info("Neighbor %s (%s) is down: holding time expired",
-		  inet_ntoa(nbr->src),
+	zlog_info("Neighbor %pI4 (%s) is down: holding time expired",
+		  &nbr->src,
 		  ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id));
 	nbr->state = EIGRP_NEIGHBOR_DOWN;
 	eigrp_nbr_delete(nbr);
@@ -330,13 +330,13 @@ void eigrp_nbr_hard_restart(struct eigrp_neighbor *nbr, struct vty *vty)
 {
 	struct eigrp *eigrp = nbr->ei->eigrp;
 
-	zlog_debug("Neighbor %s (%s) is down: manually cleared",
-		   inet_ntoa(nbr->src),
+	zlog_debug("Neighbor %pI4 (%s) is down: manually cleared",
+		   &nbr->src,
 		   ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id));
 	if (vty != NULL) {
 		vty_time_print(vty, 0);
-		vty_out(vty, "Neighbor %s (%s) is down: manually cleared\n",
-			inet_ntoa(nbr->src),
+		vty_out(vty, "Neighbor %pI4 (%s) is down: manually cleared\n",
+			&nbr->src,
 			ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id));
 	}
 

--- a/eigrpd/eigrp_network.c
+++ b/eigrpd/eigrp_network.c
@@ -159,10 +159,9 @@ int eigrp_if_ipmulticast(struct eigrp *top, struct prefix *p,
 
 	ret = setsockopt_ipv4_multicast_if(top->fd, p->u.prefix4, ifindex);
 	if (ret < 0)
-		zlog_warn(
-			"can't setsockopt IP_MULTICAST_IF (fd %d, addr %s, ifindex %u): %s",
-			top->fd, inet_ntoa(p->u.prefix4), ifindex,
-			safe_strerror(errno));
+		zlog_warn("can't setsockopt IP_MULTICAST_IF (fd %d, addr %pI4, ifindex %u): %s",
+			  top->fd, &p->u.prefix4, ifindex,
+			  safe_strerror(errno));
 
 	return ret;
 }
@@ -177,13 +176,12 @@ int eigrp_if_add_allspfrouters(struct eigrp *top, struct prefix *p,
 		top->fd, IP_ADD_MEMBERSHIP, p->u.prefix4,
 		htonl(EIGRP_MULTICAST_ADDRESS), ifindex);
 	if (ret < 0)
-		zlog_warn(
-			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllSPFRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
-			top->fd, inet_ntoa(p->u.prefix4), ifindex,
-			safe_strerror(errno));
+		zlog_warn("can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllSPFRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
+			  top->fd, &p->u.prefix4, ifindex,
+			  safe_strerror(errno));
 	else
-		zlog_debug("interface %s [%u] join EIGRP Multicast group.",
-			   inet_ntoa(p->u.prefix4), ifindex);
+		zlog_debug("interface %pI4 [%u] join EIGRP Multicast group.",
+			   &p->u.prefix4, ifindex);
 
 	return ret;
 }
@@ -197,13 +195,12 @@ int eigrp_if_drop_allspfrouters(struct eigrp *top, struct prefix *p,
 		top->fd, IP_DROP_MEMBERSHIP, p->u.prefix4,
 		htonl(EIGRP_MULTICAST_ADDRESS), ifindex);
 	if (ret < 0)
-		zlog_warn(
-			"can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllSPFRouters): %s",
-			top->fd, inet_ntoa(p->u.prefix4), ifindex,
-			safe_strerror(errno));
+		zlog_warn("can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllSPFRouters): %s",
+			  top->fd, &p->u.prefix4, ifindex,
+			  safe_strerror(errno));
 	else
-		zlog_debug("interface %s [%u] leave EIGRP Multicast group.",
-			   inet_ntoa(p->u.prefix4), ifindex);
+		zlog_debug("interface %pI4 [%u] leave EIGRP Multicast group.",
+			   &p->u.prefix4, ifindex);
 
 	return ret;
 }

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -441,18 +441,16 @@ int eigrp_write(struct thread *thread)
 
 	if (IS_DEBUG_EIGRP_TRANSMIT(0, SEND)) {
 		eigrph = (struct eigrp_header *)STREAM_DATA(ep->s);
-		zlog_debug(
-			"Sending [%s][%d/%d] to [%s] via [%s] ret [%d].",
-			lookup_msg(eigrp_packet_type_str, eigrph->opcode, NULL),
-			seqno, ack, inet_ntoa(ep->dst), IF_NAME(ei), ret);
+		zlog_debug("Sending [%s][%d/%d] to [%pI4] via [%s] ret [%d].",
+			   lookup_msg(eigrp_packet_type_str, eigrph->opcode, NULL),
+			   seqno, ack, &ep->dst, IF_NAME(ei), ret);
 	}
 
 	if (ret < 0)
-		zlog_warn(
-			"*** sendmsg in eigrp_write failed to %s, id %d, off %d, len %d, interface %s, mtu %u: %s",
-			inet_ntoa(iph.ip_dst), iph.ip_id, iph.ip_off,
-			iph.ip_len, ei->ifp->name, ei->ifp->mtu,
-			safe_strerror(errno));
+		zlog_warn("*** sendmsg in eigrp_write failed to %pI4, id %d, off %d, len %d, interface %s, mtu %u: %s",
+			  &iph.ip_dst, iph.ip_id, iph.ip_off,
+			  iph.ip_len, ei->ifp->name, ei->ifp->mtu,
+			  safe_strerror(errno));
 
 	/* Now delete packet from queue. */
 	eigrp_packet_delete(ei);
@@ -551,9 +549,8 @@ int eigrp_read(struct thread *thread)
 	if (eigrp_if_lookup_by_local_addr(eigrp, NULL, iph->ip_src)
 	    || (IPV4_ADDR_SAME(&srcaddr, &ei->address.u.prefix4))) {
 		if (IS_DEBUG_EIGRP_TRANSMIT(0, RECV))
-			zlog_debug(
-				"eigrp_read[%s]: Dropping self-originated packet",
-				inet_ntoa(srcaddr));
+			zlog_debug("eigrp_read[%pI4]: Dropping self-originated packet",
+				   &srcaddr);
 		return 0;
 	}
 
@@ -596,8 +593,8 @@ int eigrp_read(struct thread *thread)
 	 */
 	else if (ei->ifp != ifp) {
 		if (IS_DEBUG_EIGRP_TRANSMIT(0, RECV))
-			zlog_warn("Packet from [%s] received on wrong link %s",
-				  inet_ntoa(iph->ip_src), ifp->name);
+			zlog_warn("Packet from [%pI4] received on wrong link %s",
+				  &iph->ip_src, ifp->name);
 		return 0;
 	}
 
@@ -605,9 +602,8 @@ int eigrp_read(struct thread *thread)
 	ret = eigrp_verify_header(ibuf, ei, iph, eigrph);
 	if (ret < 0) {
 		if (IS_DEBUG_EIGRP_TRANSMIT(0, RECV))
-			zlog_debug(
-				"eigrp_read[%s]: Header check failed, dropping.",
-				inet_ntoa(iph->ip_src));
+			zlog_debug("eigrp_read[%pI4]: Header check failed, dropping.",
+				   &iph->ip_src);
 		return ret;
 	}
 
@@ -648,8 +644,8 @@ int eigrp_read(struct thread *thread)
 			    && (ntohl(eigrph->ack)
 				== nbr->init_sequence_number)) {
 				eigrp_nbr_state_set(nbr, EIGRP_NEIGHBOR_UP);
-				zlog_info("Neighbor(%s) adjacency became full",
-					  inet_ntoa(nbr->src));
+				zlog_info("Neighbor(%pI4) adjacency became full",
+					  &nbr->src);
 				nbr->init_sequence_number = 0;
 				nbr->recv_sequence_number =
 					ntohl(eigrph->sequence);
@@ -956,9 +952,8 @@ static int eigrp_verify_header(struct stream *ibuf, struct eigrp_interface *ei,
 {
 	/* Check network mask, Silently discarded. */
 	if (!eigrp_check_network_mask(ei, iph->ip_src)) {
-		zlog_warn(
-			"interface %s: eigrp_read network address is not same [%s]",
-			IF_NAME(ei), inet_ntoa(iph->ip_src));
+		zlog_warn("interface %s: eigrp_read network address is not same [%pI4]",
+			  IF_NAME(ei), &iph->ip_src);
 		return -1;
 	}
 	//

--- a/eigrpd/eigrp_topology.c
+++ b/eigrpd/eigrp_topology.c
@@ -134,12 +134,9 @@ void eigrp_prefix_entry_add(struct route_table *topology,
 	rn = route_node_get(topology, pe->destination);
 	if (rn->info) {
 		if (IS_DEBUG_EIGRP_EVENT) {
-			char buf[PREFIX_STRLEN];
-
-			zlog_debug(
-				"%s: %s Should we have found this entry in the topo table?",
-				__func__,
-				prefix2str(pe->destination, buf, sizeof(buf)));
+			zlog_debug("%s: %pFX Should we have found this entry in the topo table?",
+				   __func__,
+				   pe->destination);
 		}
 		route_unlock_node(rn);
 	}

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -291,15 +291,14 @@ DEFPY (clear_ip_eigrp_neighbors,
 		/* iterate over all neighbors on eigrp interface */
 		for (ALL_LIST_ELEMENTS(ei->nbrs, node2, nnode2, nbr)) {
 			if (nbr->state != EIGRP_NEIGHBOR_DOWN) {
-				zlog_debug(
-					"Neighbor %s (%s) is down: manually cleared",
-					inet_ntoa(nbr->src),
-					ifindex2ifname(nbr->ei->ifp->ifindex,
-						       eigrp->vrf_id));
+				zlog_debug("Neighbor %pI4 (%s) is down: manually cleared",
+					   &nbr->src,
+					   ifindex2ifname(nbr->ei->ifp->ifindex,
+							  eigrp->vrf_id));
 				vty_time_print(vty, 0);
 				vty_out(vty,
-					"Neighbor %s (%s) is down: manually cleared\n",
-					inet_ntoa(nbr->src),
+					"Neighbor %pI4 (%s) is down: manually cleared\n",
+					&nbr->src,
 					ifindex2ifname(nbr->ei->ifp->ifindex,
 						       eigrp->vrf_id));
 
@@ -352,14 +351,14 @@ DEFPY (clear_ip_eigrp_neighbors_int,
 	/* iterate over all neighbors on eigrp interface */
 	for (ALL_LIST_ELEMENTS(ei->nbrs, node2, nnode2, nbr)) {
 		if (nbr->state != EIGRP_NEIGHBOR_DOWN) {
-			zlog_debug("Neighbor %s (%s) is down: manually cleared",
-				   inet_ntoa(nbr->src),
+			zlog_debug("Neighbor %pI4 (%s) is down: manually cleared",
+				   &nbr->src,
 				   ifindex2ifname(nbr->ei->ifp->ifindex,
 						  eigrp->vrf_id));
 			vty_time_print(vty, 0);
 			vty_out(vty,
-				"Neighbor %s (%s) is down: manually cleared\n",
-				inet_ntoa(nbr->src),
+				"Neighbor %pI4 (%s) is down: manually cleared\n",
+				&nbr->src,
 				ifindex2ifname(nbr->ei->ifp->ifindex,
 					       eigrp->vrf_id));
 

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -151,10 +151,9 @@ static int eigrp_interface_address_add(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 	if (IS_DEBUG_EIGRP(zebra, ZEBRA_INTERFACE)) {
-		char buf[128];
-		prefix2str(c->address, buf, sizeof(buf));
-		zlog_debug("Zebra: interface %s address add %s", c->ifp->name,
-			   buf);
+		zlog_debug("Zebra: interface %s address add %pFX",
+			   c->ifp->name,
+			   c->address);
 	}
 
 	eigrp_if_update(c->ifp);
@@ -174,10 +173,8 @@ static int eigrp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 	if (IS_DEBUG_EIGRP(zebra, ZEBRA_INTERFACE)) {
-		char buf[128];
-		prefix2str(c->address, buf, sizeof(buf));
-		zlog_debug("Zebra: interface %s address delete %s",
-			   c->ifp->name, buf);
+		zlog_debug("Zebra: interface %s address delete %pFX",
+			   c->ifp->name, c->address);
 	}
 
 	ifp = c->ifp;
@@ -258,9 +255,8 @@ void eigrp_zebra_route_delete(struct eigrp *eigrp, struct prefix *p)
 	zclient_route_send(ZEBRA_ROUTE_DELETE, zclient, &api);
 
 	if (IS_DEBUG_EIGRP(zebra, ZEBRA_REDISTRIBUTE)) {
-		char buf[PREFIX_STRLEN];
-		zlog_debug("Zebra: Route del %s",
-			   prefix2str(p, buf, PREFIX_STRLEN));
+		zlog_debug("Zebra: Route del %pFX",
+			   p);
 	}
 
 	return;

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -970,8 +970,7 @@ void isis_circuit_print_vty(struct isis_circuit *circuit, struct vty *vty,
 			vty_out(vty, "    IP Prefix(es):\n");
 			for (ALL_LIST_ELEMENTS_RO(circuit->ip_addrs, node,
 						  ip_addr)) {
-				prefix2str(ip_addr, buf, sizeof(buf));
-				vty_out(vty, "      %s\n", buf);
+				vty_out(vty, "      %pFX\n", ip_addr);
 			}
 		}
 		if (circuit->ipv6_link && listcount(circuit->ipv6_link) > 0) {

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -326,8 +326,8 @@ DEFUN (show_isis_mpls_te_router,
 
 		vty_out(vty, "Area %s:\n", area->area_tag);
 		if (ntohs(area->mta->router_id.s_addr) != 0)
-			vty_out(vty, "  MPLS-TE Router-Address: %s\n",
-				inet_ntoa(area->mta->router_id));
+			vty_out(vty, "  MPLS-TE Router-Address: %pI4\n",
+				&area->mta->router_id);
 		else
 			vty_out(vty, "  N/A\n");
 	}

--- a/ldpd/adjacency.c
+++ b/ldpd/adjacency.c
@@ -84,8 +84,8 @@ adj_new(struct in_addr lsr_id, struct hello_source *source,
 {
 	struct adj	*adj;
 
-	log_debug("%s: lsr-id %s, %s", __func__, inet_ntoa(lsr_id),
-	    log_hello_src(source));
+	log_debug("%s: lsr-id %pI4, %s", __func__, &lsr_id,
+		  log_hello_src(source));
 
 	if ((adj = calloc(1, sizeof(*adj))) == NULL)
 		fatal(__func__);
@@ -114,8 +114,8 @@ adj_del(struct adj *adj, uint32_t notif_status)
 {
 	struct nbr	*nbr = adj->nbr;
 
-	log_debug("%s: lsr-id %s, %s (%s)", __func__, inet_ntoa(adj->lsr_id),
-	    log_hello_src(&adj->source), af_name(adj_get_af(adj)));
+	log_debug("%s: lsr-id %pI4, %s (%s)", __func__, &adj->lsr_id,
+		  log_hello_src(&adj->source), af_name(adj_get_af(adj)));
 
 	adj_stop_itimer(adj);
 
@@ -176,7 +176,7 @@ adj_itimer(struct thread *thread)
 
 	adj->inactivity_timer = NULL;
 
-	log_debug("%s: lsr-id %s", __func__, inet_ntoa(adj->lsr_id));
+	log_debug("%s: lsr-id %pI4", __func__, &adj->lsr_id);
 
 	if (adj->source.type == HELLO_TARGETED) {
 		if (!(adj->source.target->flags & F_TNBR_CONFIGURED) &&

--- a/ldpd/hello.c
+++ b/ldpd/hello.c
@@ -179,24 +179,26 @@ recv_hello(struct in_addr lsr_id, struct ldp_msg *msg, int af,
 
 	r = tlv_decode_hello_prms(buf, len, &holdtime, &flags);
 	if (r == -1) {
-		log_debug("%s: lsr-id %s: failed to decode params", __func__,
-		    inet_ntoa(lsr_id));
+		log_debug("%s: lsr-id %pI4: failed to decode params",
+		          __func__,
+		          &lsr_id);
 		return;
 	}
 	/* safety checks */
 	if (holdtime != 0 && holdtime < MIN_HOLDTIME) {
-		log_debug("%s: lsr-id %s: invalid hello holdtime (%u)",
-		    __func__, inet_ntoa(lsr_id), holdtime);
+		log_debug("%s: lsr-id %pI4: invalid hello holdtime (%u)",
+		          __func__, &lsr_id, holdtime);
 		return;
 	}
 	if (multicast && (flags & F_HELLO_TARGETED)) {
-		log_debug("%s: lsr-id %s: multicast targeted hello", __func__,
-		    inet_ntoa(lsr_id));
+		log_debug("%s: lsr-id %pI4: multicast targeted hello",
+		          __func__,
+		          &lsr_id);
 		return;
 	}
 	if (!multicast && !((flags & F_HELLO_TARGETED))) {
-		log_debug("%s: lsr-id %s: unicast link hello", __func__,
-		    inet_ntoa(lsr_id));
+		log_debug("%s: lsr-id %pI4: unicast link hello", __func__,
+		          &lsr_id);
 		return;
 	}
 	buf += r;
@@ -205,13 +207,13 @@ recv_hello(struct in_addr lsr_id, struct ldp_msg *msg, int af,
 	r = tlv_decode_opt_hello_prms(buf, len, &tlvs_rcvd, af, &trans_addr,
 	    &conf_seqnum, &trans_pref);
 	if (r == -1) {
-		log_debug("%s: lsr-id %s: failed to decode optional params",
-		    __func__, inet_ntoa(lsr_id));
+		log_debug("%s: lsr-id %pI4: failed to decode optional params",
+		          __func__, &lsr_id);
 		return;
 	}
 	if (r != len) {
-		log_debug("%s: lsr-id %s: unexpected data in message",
-		    __func__, inet_ntoa(lsr_id));
+		log_debug("%s: lsr-id %pI4: unexpected data in message",
+		          __func__, &lsr_id);
 		return;
 	}
 	ds_tlv = (tlvs_rcvd & F_HELLO_TLV_RCVD_DS) ? 1 : 0;
@@ -220,8 +222,8 @@ recv_hello(struct in_addr lsr_id, struct ldp_msg *msg, int af,
 	if (!(tlvs_rcvd & F_HELLO_TLV_RCVD_ADDR))
 		trans_addr = *src;
 	if (bad_addr(af, &trans_addr)) {
-		log_debug("%s: lsr-id %s: invalid transport address %s",
-		    __func__, inet_ntoa(lsr_id), log_addr(af, &trans_addr));
+		log_debug("%s: lsr-id %pI4: invalid transport address %s",
+		          __func__, &lsr_id, log_addr(af, &trans_addr));
 		return;
 	}
 	if (af == AF_INET6 && IN6_IS_SCOPE_EMBED(&trans_addr.v6)) {
@@ -234,8 +236,9 @@ recv_hello(struct in_addr lsr_id, struct ldp_msg *msg, int af,
 		 * check)".
 		 */
 		if (flags & F_HELLO_TARGETED) {
-			log_debug("%s: lsr-id %s: invalid targeted hello transport address %s", __func__, inet_ntoa(lsr_id),
-			     log_addr(af, &trans_addr));
+			log_debug("%s: lsr-id %pI4: invalid targeted hello transport address %s",
+				  __func__, &lsr_id,
+				  log_addr(af, &trans_addr));
 			return;
 		}
 		scope_id = iface->ifindex;
@@ -249,8 +252,9 @@ recv_hello(struct in_addr lsr_id, struct ldp_msg *msg, int af,
 		* targeted LDP Hello packet's source or destination addresses".
 		*/
 		if (af == AF_INET6 && IN6_IS_SCOPE_EMBED(&src->v6)) {
-			log_debug("%s: lsr-id %s: targeted hello with link-local source address", __func__,
-			    inet_ntoa(lsr_id));
+			log_debug("%s: lsr-id %pI4: targeted hello with link-local source address",
+				  __func__,
+				  &lsr_id);
 			return;
 		}
 
@@ -316,7 +320,8 @@ recv_hello(struct in_addr lsr_id, struct ldp_msg *msg, int af,
 		 * send a fatal Notification message with status code of
 		 * 'Transport Connection Mismatch' and reset the session".
 		 */
-		log_debug("%s: lsr-id %s: remote transport preference does not match the local preference", __func__, inet_ntoa(lsr_id));
+		log_debug("%s: lsr-id %pI4: remote transport preference does not match the local preference",
+		          __func__, &lsr_id);
 		if (nbr)
 			session_shutdown(nbr, S_TRANS_MISMTCH, msg->id,
 			    msg->type);
@@ -364,8 +369,9 @@ recv_hello(struct in_addr lsr_id, struct ldp_msg *msg, int af,
 	if (nbr == NULL) {
 		nbrt = nbr_find_addr(af, &trans_addr);
 		if (nbrt) {
-			log_debug("%s: transport address %s is already being used by lsr-id %s", __func__, log_addr(af,
-			    &trans_addr), inet_ntoa(nbrt->id));
+			log_debug("%s: transport address %s is already being used by lsr-id %pI4",
+				  __func__, log_addr(af,
+						     &trans_addr), &nbrt->id);
 			if (adj)
 				adj_del(adj, S_SHUTDOWN);
 			return;

--- a/ldpd/init.c
+++ b/ldpd/init.c
@@ -222,7 +222,7 @@ send_capability(struct nbr *nbr, uint16_t capability, int enable)
 	uint16_t		 size;
 	int			 err = 0;
 
-	log_debug("%s: lsr-id %s", __func__, inet_ntoa(nbr->id));
+	log_debug("%s: lsr-id %pI4", __func__, &nbr->id);
 
 	size = LDP_HDR_SIZE + LDP_MSG_SIZE + CAP_TLV_DYNAMIC_SIZE;
 	if ((buf = ibuf_open(size)) == NULL)

--- a/ldpd/interface.c
+++ b/ldpd/interface.c
@@ -502,15 +502,15 @@ if_join_ipv4_group(struct iface *iface, struct in_addr *addr)
 {
 	struct in_addr		 if_addr;
 
-	log_debug("%s: interface %s addr %s", __func__, iface->name,
-	    inet_ntoa(*addr));
+	log_debug("%s: interface %s addr %pI4", __func__, iface->name,
+		  addr);
 
 	if_addr.s_addr = if_get_ipv4_addr(iface);
 
 	if (setsockopt_ipv4_multicast(global.ipv4.ldp_disc_socket,
 	    IP_ADD_MEMBERSHIP, if_addr, addr->s_addr, iface->ifindex) < 0) {
-		log_warn("%s: error IP_ADD_MEMBERSHIP, interface %s address %s",
-		     __func__, iface->name, inet_ntoa(*addr));
+		log_warn("%s: error IP_ADD_MEMBERSHIP, interface %s address %pI4",
+			 __func__, iface->name, addr);
 		return (-1);
 	}
 	return (0);
@@ -521,14 +521,15 @@ if_leave_ipv4_group(struct iface *iface, struct in_addr *addr)
 {
 	struct in_addr		 if_addr;
 
-	log_debug("%s: interface %s addr %s", __func__, iface->name,
-	    inet_ntoa(*addr));
+	log_debug("%s: interface %s addr %pI4", __func__, iface->name,
+		  addr);
 
 	if_addr.s_addr = if_get_ipv4_addr(iface);
 
 	if (setsockopt_ipv4_multicast(global.ipv4.ldp_disc_socket,
 	    IP_DROP_MEMBERSHIP, if_addr, addr->s_addr, iface->ifindex) < 0) {
-		log_warn("%s: error IP_DROP_MEMBERSHIP, interface %s address %s", __func__, iface->name, inet_ntoa(*addr));
+		log_warn("%s: error IP_DROP_MEMBERSHIP, interface %s address %pI4",
+			 __func__, iface->name, addr);
 		return (-1);
 	}
 

--- a/ldpd/ldp_vty_conf.c
+++ b/ldpd/ldp_vty_conf.c
@@ -255,7 +255,7 @@ ldp_config_write(struct vty *vty)
 	vty_out (vty, "mpls ldp\n");
 
 	if (ldpd_conf->rtr_id.s_addr != INADDR_ANY)
-		vty_out(vty, " router-id %s\n", inet_ntoa(ldpd_conf->rtr_id));
+		vty_out(vty, " router-id %pI4\n", &ldpd_conf->rtr_id);
 
 	if (ldpd_conf->lhello_holdtime != LINK_DFLT_HOLDTIME &&
 	    ldpd_conf->lhello_holdtime != 0)
@@ -287,20 +287,24 @@ ldp_config_write(struct vty *vty)
 
 	RB_FOREACH(nbrp, nbrp_head, &ldpd_conf->nbrp_tree) {
 		if (nbrp->flags & F_NBRP_KEEPALIVE)
-			vty_out (vty, " neighbor %s session holdtime %u\n",
-			    inet_ntoa(nbrp->lsr_id),nbrp->keepalive);
+			vty_out (vty, " neighbor %pI4 session holdtime %u\n",
+				 &nbrp->lsr_id,nbrp->keepalive);
 
 		if (nbrp->flags & F_NBRP_GTSM) {
 			if (nbrp->gtsm_enabled)
-				vty_out (vty, " neighbor %s ttl-security hops %u\n",  inet_ntoa(nbrp->lsr_id),
-				    nbrp->gtsm_hops);
+				vty_out (vty,
+					 " neighbor %pI4 ttl-security hops %u\n",
+					   &nbrp->lsr_id,
+					 nbrp->gtsm_hops);
 			else
-				vty_out (vty, " neighbor %s ttl-security disable\n",inet_ntoa(nbrp->lsr_id));
+				vty_out (vty,
+					 " neighbor %pI4 ttl-security disable\n",
+					 &nbrp->lsr_id);
 		}
 
 		if (nbrp->auth.method == AUTH_MD5SIG)
-			vty_out (vty, " neighbor %s password %s\n",
-			    inet_ntoa(nbrp->lsr_id),nbrp->auth.md5key);
+			vty_out (vty, " neighbor %pI4 password %s\n",
+				 &nbrp->lsr_id,nbrp->auth.md5key);
 	}
 
 	ldp_af_config_write(vty, AF_INET, ldpd_conf, &ldpd_conf->ipv4);
@@ -321,7 +325,7 @@ ldp_l2vpn_pw_config_write(struct vty *vty, struct l2vpn_pw *pw)
 	vty_out (vty, " member pseudowire %s\n", pw->ifname);
 
 	if (pw->lsr_id.s_addr != INADDR_ANY)
-		vty_out (vty, "  neighbor lsr-id %s\n",inet_ntoa(pw->lsr_id));
+		vty_out (vty, "  neighbor lsr-id %pI4\n",&pw->lsr_id);
 		else
 			missing_lsrid = 1;
 

--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -152,11 +152,11 @@ nbr_fsm(struct nbr *nbr, enum nbr_event event)
 		nbr->state = new_state;
 
 	if (old_state != nbr->state) {
-		log_debug("%s: event %s resulted in action %s and changing state for lsr-id %s from %s to %s",
-		    __func__, nbr_event_names[event],
-		    nbr_action_names[nbr_fsm_tbl[i].action],
-		    inet_ntoa(nbr->id), nbr_state_name(old_state),
-		    nbr_state_name(nbr->state));
+		log_debug("%s: event %s resulted in action %s and changing state for lsr-id %pI4 from %s to %s",
+			  __func__, nbr_event_names[event],
+			  nbr_action_names[nbr_fsm_tbl[i].action],
+			  &nbr->id, nbr_state_name(old_state),
+			  nbr_state_name(nbr->state));
 
 		if (nbr->state == NBR_STA_OPER) {
 			gettimeofday(&now, NULL);
@@ -223,8 +223,8 @@ nbr_new(struct in_addr id, int af, int ds_tlv, union ldpd_addr *addr,
 	struct adj		*adj;
 	struct pending_conn	*pconn;
 
-	log_debug("%s: lsr-id %s transport-address %s", __func__,
-	    inet_ntoa(id), log_addr(af, addr));
+	log_debug("%s: lsr-id %pI4 transport-address %s", __func__,
+		  &id, log_addr(af, addr));
 
 	if ((nbr = calloc(1, sizeof(*nbr))) == NULL)
 		fatal(__func__);
@@ -289,7 +289,7 @@ nbr_del(struct nbr *nbr)
 {
 	struct adj		*adj;
 
-	log_debug("%s: lsr-id %s", __func__, inet_ntoa(nbr->id));
+	log_debug("%s: lsr-id %pI4", __func__, &nbr->id);
 
 	nbr_fsm(nbr, NBR_EVT_CLOSE_SESSION);
 #ifdef __OpenBSD__
@@ -436,7 +436,7 @@ nbr_ktimeout(struct thread *thread)
 
 	nbr->keepalive_timeout = NULL;
 
-	log_debug("%s: lsr-id %s", __func__, inet_ntoa(nbr->id));
+	log_debug("%s: lsr-id %pI4", __func__, &nbr->id);
 
 	session_shutdown(nbr, S_KEEPALIVE_TMR, 0, 0);
 
@@ -465,7 +465,7 @@ nbr_itimeout(struct thread *thread)
 {
 	struct nbr	*nbr = THREAD_ARG(thread);
 
-	log_debug("%s: lsr-id %s", __func__, inet_ntoa(nbr->id));
+	log_debug("%s: lsr-id %pI4", __func__, &nbr->id);
 
 	nbr_fsm(nbr, NBR_EVT_CLOSE_SESSION);
 
@@ -498,7 +498,7 @@ nbr_idtimer(struct thread *thread)
 
 	nbr->initdelay_timer = NULL;
 
-	log_debug("%s: lsr-id %s", __func__, inet_ntoa(nbr->id));
+	log_debug("%s: lsr-id %pI4", __func__, &nbr->id);
 
 	nbr_establish_connection(nbr);
 

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -366,7 +366,8 @@ session_accept(struct thread *thread)
 		return (0);
 	}
 	if (nbr->state != NBR_STA_PRESENT) {
-		log_debug("%s: lsr-id %s: rejecting additional transport connection", __func__, inet_ntoa(nbr->id));
+		log_debug("%s: lsr-id %pI4: rejecting additional transport connection",
+			  __func__, &nbr->id);
 		close(newfd);
 		return (0);
 	}
@@ -680,8 +681,8 @@ session_shutdown(struct nbr *nbr, uint32_t status, uint32_t msg_id,
 void
 session_close(struct nbr *nbr)
 {
-	log_debug("%s: closing session with lsr-id %s", __func__,
-	    inet_ntoa(nbr->id));
+	log_debug("%s: closing session with lsr-id %pI4", __func__,
+		  &nbr->id);
 
 	tcp_close(nbr->tcp);
 	nbr_stop_ktimer(nbr);

--- a/lib/filter.c
+++ b/lib/filter.c
@@ -762,9 +762,8 @@ static void config_write_access_zebra(struct vty *vty, struct filter *mfilter)
 	if (p->prefixlen == 0 && !filter->exact)
 		vty_out(vty, " any");
 	else if (p->family == AF_INET6 || p->family == AF_INET)
-		vty_out(vty, " %s/%d%s",
-			inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ),
-			p->prefixlen, filter->exact ? " exact-match" : "");
+		vty_out(vty, " %pFX%s",
+			p, filter->exact ? " exact-match" : "");
 	else if (p->family == AF_ETHERNET) {
 		if (p->prefixlen == 0)
 			vty_out(vty, " any");

--- a/lib/filter.c
+++ b/lib/filter.c
@@ -576,14 +576,13 @@ static int filter_show(struct vty *vty, const char *name, afi_t afi)
 				if (filter->addr_mask.s_addr == 0xffffffff)
 					vty_out(vty, " any\n");
 				else {
-					vty_out(vty, " %s",
-						inet_ntoa(filter->addr));
+					vty_out(vty, " %pI4",
+						&filter->addr);
 					if (filter->addr_mask.s_addr
 					    != INADDR_ANY)
 						vty_out(vty,
-							", wildcard bits %s",
-							inet_ntoa(
-								filter->addr_mask));
+							", wildcard bits %pI4",
+							&filter->addr_mask);
 					vty_out(vty, "\n");
 				}
 			}
@@ -625,14 +624,13 @@ static int filter_show(struct vty *vty, const char *name, afi_t afi)
 				if (filter->addr_mask.s_addr == 0xffffffff)
 					vty_out(vty, " any\n");
 				else {
-					vty_out(vty, " %s",
-						inet_ntoa(filter->addr));
+					vty_out(vty, " %pI4",
+						&filter->addr);
 					if (filter->addr_mask.s_addr
 					    != INADDR_ANY)
 						vty_out(vty,
-							", wildcard bits %s",
-							inet_ntoa(
-								filter->addr_mask));
+							", wildcard bits %pI4",
+							&filter->addr_mask);
 					vty_out(vty, "\n");
 				}
 			}
@@ -722,29 +720,29 @@ static void config_write_access_cisco(struct vty *vty, struct filter *mfilter)
 		if (filter->addr_mask.s_addr == 0xffffffff)
 			vty_out(vty, " any");
 		else if (filter->addr_mask.s_addr == INADDR_ANY)
-			vty_out(vty, " host %s", inet_ntoa(filter->addr));
+			vty_out(vty, " host %pI4", &filter->addr);
 		else {
-			vty_out(vty, " %s", inet_ntoa(filter->addr));
-			vty_out(vty, " %s", inet_ntoa(filter->addr_mask));
+			vty_out(vty, " %pI4", &filter->addr);
+			vty_out(vty, " %pI4", &filter->addr_mask);
 		}
 
 		if (filter->mask_mask.s_addr == 0xffffffff)
 			vty_out(vty, " any");
 		else if (filter->mask_mask.s_addr == INADDR_ANY)
-			vty_out(vty, " host %s", inet_ntoa(filter->mask));
+			vty_out(vty, " host %pI4", &filter->mask);
 		else {
-			vty_out(vty, " %s", inet_ntoa(filter->mask));
-			vty_out(vty, " %s", inet_ntoa(filter->mask_mask));
+			vty_out(vty, " %pI4", &filter->mask);
+			vty_out(vty, " %pI4", &filter->mask_mask);
 		}
 		vty_out(vty, "\n");
 	} else {
 		if (filter->addr_mask.s_addr == 0xffffffff)
 			vty_out(vty, " any\n");
 		else {
-			vty_out(vty, " %s", inet_ntoa(filter->addr));
+			vty_out(vty, " %pI4", &filter->addr);
 			if (filter->addr_mask.s_addr != INADDR_ANY)
-				vty_out(vty, " %s",
-					inet_ntoa(filter->addr_mask));
+				vty_out(vty, " %pI4",
+					&filter->addr_mask);
 			vty_out(vty, "\n");
 		}
 	}
@@ -754,7 +752,6 @@ static void config_write_access_zebra(struct vty *vty, struct filter *mfilter)
 {
 	struct filter_zebra *filter;
 	struct prefix *p;
-	char buf[BUFSIZ];
 
 	filter = &mfilter->u.zfilter;
 	p = &filter->prefix;
@@ -768,8 +765,7 @@ static void config_write_access_zebra(struct vty *vty, struct filter *mfilter)
 		if (p->prefixlen == 0)
 			vty_out(vty, " any");
 		else
-			vty_out(vty, " %s", prefix_mac2str(&(p->u.prefix_eth),
-							   buf, sizeof(buf)));
+			vty_out(vty, " %pEA", &(p->u.prefix_eth));
 	}
 
 	vty_out(vty, "\n");

--- a/lib/if.c
+++ b/lib/if.c
@@ -968,10 +968,11 @@ connected_log(struct connected *connected, char *str)
 	p = connected->address;
 
 	vrf = vrf_lookup_by_id(ifp->vrf_id);
-	snprintf(logbuf, sizeof(logbuf), "%s interface %s vrf %s(%u) %s %s/%d ",
-		 str, ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id,
-		 prefix_family_str(p),
-		 inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ), p->prefixlen);
+	snprintfrr(logbuf, sizeof(logbuf),
+		   "%s interface %s vrf %s(%u) %s %pFX ",
+		   str, ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id,
+		   prefix_family_str(p),
+		   p);
 
 	p = connected->destination;
 	if (p) {
@@ -993,9 +994,9 @@ nbr_connected_log(struct nbr_connected *connected, char *str)
 	ifp = connected->ifp;
 	p = connected->address;
 
-	snprintf(logbuf, sizeof(logbuf), "%s interface %s %s %s/%d ", str,
-		 ifp->name, prefix_family_str(p),
-		 inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ), p->prefixlen);
+	snprintfrr(logbuf, sizeof(logbuf), "%s interface %s %s %pFX ", str,
+		   ifp->name, prefix_family_str(p),
+		   p);
 
 	zlog_info("%s", logbuf);
 }

--- a/lib/if.c
+++ b/lib/if.c
@@ -989,7 +989,6 @@ nbr_connected_log(struct nbr_connected *connected, char *str)
 	struct prefix *p;
 	struct interface *ifp;
 	char logbuf[BUFSIZ];
-	char buf[BUFSIZ];
 
 	ifp = connected->ifp;
 	p = connected->address;

--- a/lib/log.h
+++ b/lib/log.h
@@ -33,6 +33,7 @@
 #include "lib/hook.h"
 #include "lib/zlog.h"
 #include "lib/zlog_targets.h"
+#include "lib/printfrr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -463,8 +463,8 @@ const char *nexthop2str(const struct nexthop *nexthop, char *str, int size)
 		break;
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		snprintf(str, size, "%s if %u", inet_ntoa(nexthop->gate.ipv4),
-			 nexthop->ifindex);
+		snprintfrr(str, size, "%pI4 if %u", &nexthop->gate.ipv4,
+			   nexthop->ifindex);
 		break;
 	case NEXTHOP_TYPE_IPV6:
 	case NEXTHOP_TYPE_IPV6_IFINDEX:

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -954,7 +954,6 @@ static struct cmd_node nexthop_group_node = {
 
 void nexthop_group_write_nexthop(struct vty *vty, const struct nexthop *nh)
 {
-	char buf[100];
 	struct vrf *vrf;
 	int i;
 

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -965,19 +965,19 @@ void nexthop_group_write_nexthop(struct vty *vty, const struct nexthop *nh)
 		vty_out(vty, "%s", ifindex2ifname(nh->ifindex, nh->vrf_id));
 		break;
 	case NEXTHOP_TYPE_IPV4:
-		vty_out(vty, "%s", inet_ntoa(nh->gate.ipv4));
+		vty_out(vty, "%pI4", &nh->gate.ipv4);
 		break;
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		vty_out(vty, "%s %s", inet_ntoa(nh->gate.ipv4),
+		vty_out(vty, "%pI4 %s", &nh->gate.ipv4,
 			ifindex2ifname(nh->ifindex, nh->vrf_id));
 		break;
 	case NEXTHOP_TYPE_IPV6:
-		vty_out(vty, "%s",
-			inet_ntop(AF_INET6, &nh->gate.ipv6, buf, sizeof(buf)));
+		vty_out(vty, "%pI6",
+			&nh->gate.ipv6);
 		break;
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
-		vty_out(vty, "%s %s",
-			inet_ntop(AF_INET6, &nh->gate.ipv6, buf, sizeof(buf)),
+		vty_out(vty, "%pI6 %s",
+			&nh->gate.ipv6,
 			ifindex2ifname(nh->ifindex, nh->vrf_id));
 		break;
 	case NEXTHOP_TYPE_BLACKHOLE:

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1014,7 +1014,6 @@ static void vty_show_prefix_entry(struct vty *vty, afi_t afi,
 				vty_out(vty, "any");
 			else {
 				struct prefix *p = &pentry->prefix;
-				char buf[BUFSIZ];
 
 				vty_out(vty, "%pFX",
 					p);
@@ -1119,7 +1118,6 @@ static int vty_show_prefix_list_prefix(struct vty *vty, afi_t afi,
 				vty_out(vty, "any");
 			else {
 				struct prefix *pf = &pentry->prefix;
-				char buf[BUFSIZ];
 
 				vty_out(vty, "%pFX",
 					pf);
@@ -1487,7 +1485,6 @@ int prefix_bgp_show_prefix_list(struct vty *vty, afi_t afi, char *name,
 		for (pentry = plist->head; pentry; pentry = pentry->next) {
 			struct prefix *p = &pentry->prefix;
 			char buf_a[BUFSIZ];
-			char buf_b[BUFSIZ];
 
 			snprintfrr(buf_a, sizeof(buf_a), "%pFX",
 				   p);
@@ -1521,7 +1518,6 @@ int prefix_bgp_show_prefix_list(struct vty *vty, afi_t afi, char *name,
 
 		for (pentry = plist->head; pentry; pentry = pentry->next) {
 			struct prefix *p = &pentry->prefix;
-			char buf[BUFSIZ];
 
 			vty_out(vty, "   seq %" PRId64 " %s %pFX",
 				pentry->seq,

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1016,10 +1016,8 @@ static void vty_show_prefix_entry(struct vty *vty, afi_t afi,
 				struct prefix *p = &pentry->prefix;
 				char buf[BUFSIZ];
 
-				vty_out(vty, "%s/%d",
-					inet_ntop(p->family, p->u.val, buf,
-						  BUFSIZ),
-					p->prefixlen);
+				vty_out(vty, "%pFX",
+					p);
 
 				if (pentry->ge)
 					vty_out(vty, " ge %d", pentry->ge);
@@ -1123,10 +1121,8 @@ static int vty_show_prefix_list_prefix(struct vty *vty, afi_t afi,
 				struct prefix *pf = &pentry->prefix;
 				char buf[BUFSIZ];
 
-				vty_out(vty, "%s/%d",
-					inet_ntop(pf->family, pf->u.val, buf,
-						  BUFSIZ),
-					pf->prefixlen);
+				vty_out(vty, "%pFX",
+					pf);
 
 				if (pentry->ge)
 					vty_out(vty, " ge %d", pentry->ge);
@@ -1493,9 +1489,8 @@ int prefix_bgp_show_prefix_list(struct vty *vty, afi_t afi, char *name,
 			char buf_a[BUFSIZ];
 			char buf_b[BUFSIZ];
 
-			snprintf(buf_a, sizeof(buf_a), "%s/%d",
-				 inet_ntop(p->family, p->u.val, buf_b, BUFSIZ),
-				 p->prefixlen);
+			snprintfrr(buf_a, sizeof(buf_a), "%pFX",
+				   p);
 
 			json_object_int_add(json_list, "seq", pentry->seq);
 			json_object_string_add(json_list, "seqPrefixListType",
@@ -1528,11 +1523,10 @@ int prefix_bgp_show_prefix_list(struct vty *vty, afi_t afi, char *name,
 			struct prefix *p = &pentry->prefix;
 			char buf[BUFSIZ];
 
-			vty_out(vty, "   seq %" PRId64 " %s %s/%d",
+			vty_out(vty, "   seq %" PRId64 " %s %pFX",
 				pentry->seq,
 				prefix_list_type_str(pentry),
-				inet_ntop(p->family, p->u.val, buf, BUFSIZ),
-				p->prefixlen);
+				p);
 
 			if (pentry->ge)
 				vty_out(vty, " ge %d", pentry->ge);

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -905,26 +905,23 @@ static const char *prefixevpn_macip2str(const struct prefix_evpn *p, char *str,
 {
 	uint8_t family;
 	char buf[PREFIX2STR_BUFFER];
-	char buf2[ETHER_ADDR_STRLEN];
 
 	if (is_evpn_prefix_ipaddr_none(p))
-		snprintf(str, size, "[%d]:[%s]/%d",
-			 p->prefix.route_type,
-			 prefix_mac2str(&p->prefix.macip_addr.mac,
-					buf2, sizeof(buf2)),
-			 p->prefixlen);
+		snprintfrr(str, size, "[%d]:[%pEA]/%d",
+			   p->prefix.route_type,
+			   &p->prefix.macip_addr.mac,
+			   p->prefixlen);
 	else {
 		family = is_evpn_prefix_ipaddr_v4(p)
 				 ? AF_INET
 				 : AF_INET6;
-		snprintf(str, size, "[%d]:[%s]:[%s]/%d",
-			 p->prefix.route_type,
-			 prefix_mac2str(&p->prefix.macip_addr.mac,
-					buf2, sizeof(buf2)),
-			 inet_ntop(family,
-				   &p->prefix.macip_addr.ip.ip.addr,
-				   buf, PREFIX2STR_BUFFER),
-			 p->prefixlen);
+		snprintfrr(str, size, "[%d]:[%pEA]:[%s]/%d",
+			   p->prefix.route_type,
+			   &p->prefix.macip_addr.mac,
+			   inet_ntop(family,
+				     &p->prefix.macip_addr.ip.ip.addr,
+				     buf, PREFIX2STR_BUFFER),
+			   p->prefixlen);
 	}
 	return str;
 }
@@ -951,10 +948,10 @@ static const char *prefixevpn_es2str(const struct prefix_evpn *p, char *str,
 {
 	char buf[ESI_STR_LEN];
 
-	snprintf(str, size, "[%d]:[%s]:[%s]/%d", p->prefix.route_type,
-		 esi_to_str(&p->prefix.es_addr.esi, buf, sizeof(buf)),
-		 inet_ntoa(p->prefix.es_addr.ip.ipaddr_v4),
-		 p->prefixlen);
+	snprintfrr(str, size, "[%d]:[%s]:[%pI4]/%d", p->prefix.route_type,
+		   esi_to_str(&p->prefix.es_addr.esi, buf, sizeof(buf)),
+		   &p->prefix.es_addr.ip.ipaddr_v4,
+		   p->prefixlen);
 	return str;
 }
 
@@ -1029,9 +1026,9 @@ const char *prefix2str(union prefixconstptr pu, char *str, int size)
 		break;
 
 	case AF_ETHERNET:
-		snprintf(str, size, "%s/%d",
-			 prefix_mac2str(&p->u.prefix_eth, buf, sizeof(buf)),
-			 p->prefixlen);
+		snprintfrr(str, size, "%pEA/%d",
+			   &p->u.prefix_eth,
+			   p->prefixlen);
 		break;
 
 	case AF_EVPN:

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -3096,7 +3096,6 @@ DEFUN_HIDDEN(show_route_map_pfx_tbl, show_route_map_pfx_tbl_cmd,
 	struct listnode *ln = NULL, *nln = NULL;
 	struct route_map_index *index = NULL;
 	struct prefix *p = NULL, *pp = NULL;
-	char buf[SU_ADDRSTRLEN], pbuf[SU_ADDRSTRLEN];
 	uint8_t len = 54;
 
 	vty_out(vty, "%s:\n", frr_protonameinst);

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -3112,20 +3112,15 @@ DEFUN_HIDDEN(show_route_map_pfx_tbl, show_route_map_pfx_tbl_cmd,
 			     rn = route_next(rn)) {
 				p = &rn->p;
 
-				vty_out(vty, "    %s/%d (%d)\n",
-					inet_ntop(p->family, &p->u.prefix, buf,
-						  SU_ADDRSTRLEN),
-					p->prefixlen, rn->lock);
+				vty_out(vty, "    %pFX (%d)\n",
+					p, rn->lock);
 
 				vty_out(vty, "(P) ");
 				prn = rn->parent;
 				if (prn) {
 					pp = &prn->p;
-					vty_out(vty, "%s/%d\n",
-						inet_ntop(pp->family,
-							  &pp->u.prefix, pbuf,
-							  SU_ADDRSTRLEN),
-						pp->prefixlen);
+					vty_out(vty, "%pFX\n",
+						pp);
 				}
 
 				vty_out(vty, "\n");
@@ -3156,20 +3151,15 @@ DEFUN_HIDDEN(show_route_map_pfx_tbl, show_route_map_pfx_tbl_cmd,
 			     rn = route_next(rn)) {
 				p = &rn->p;
 
-				vty_out(vty, "    %s/%d (%d)\n",
-					inet_ntop(p->family, &p->u.prefix, buf,
-						  SU_ADDRSTRLEN),
-					p->prefixlen, rn->lock);
+				vty_out(vty, "    %pFX (%d)\n",
+					p, rn->lock);
 
 				vty_out(vty, "(P) ");
 				prn = rn->parent;
 				if (prn) {
 					pp = &prn->p;
-					vty_out(vty, "%s/%d\n",
-						inet_ntop(pp->family,
-							  &pp->u.prefix, pbuf,
-							  SU_ADDRSTRLEN),
-						pp->prefixlen);
+					vty_out(vty, "%pFX\n",
+						pp);
 				}
 
 				vty_out(vty, "\n");

--- a/lib/srcdest_table.c
+++ b/lib/srcdest_table.c
@@ -287,14 +287,14 @@ const char *srcdest2str(const struct prefix *dst_p,
 			const struct prefix_ipv6 *src_p,
 			char *str, int size)
 {
-	char dst_buf[PREFIX_STRLEN], src_buf[PREFIX_STRLEN];
+	char src_buf[PREFIX_STRLEN];
 
-	snprintf(str, size, "%s%s%s",
-		 prefix2str(dst_p, dst_buf, sizeof(dst_buf)),
-		 (src_p && src_p->prefixlen) ? " from " : "",
-		 (src_p && src_p->prefixlen)
-			 ? prefix2str(src_p, src_buf, sizeof(src_buf))
-			 : "");
+	snprintfrr(str, size, "%pFX%s%s",
+		   dst_p,
+		   (src_p && src_p->prefixlen) ? " from " : "",
+		   (src_p && src_p->prefixlen)
+		   ? prefix2str(src_p, src_buf, sizeof(src_buf))
+		   : "");
 	return str;
 }
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2178,15 +2178,11 @@ struct connected *zebra_interface_address_read(int type, struct stream *s,
 				ifc->destination->prefixlen =
 					ifc->address->prefixlen;
 			else if (CHECK_FLAG(ifc->flags, ZEBRA_IFA_PEER)) {
-				/* carp interfaces on OpenBSD with 0.0.0.0/0 as
-				 * "peer" */
-				char buf[PREFIX_STRLEN];
 				flog_err(
 					EC_LIB_ZAPI_ENCODE,
-					"warning: interface %s address %s with peer flag set, but no peer address!",
+					"warning: interface %s address %pFX with peer flag set, but no peer address!",
 					ifp->name,
-					prefix2str(ifc->address, buf,
-						   sizeof(buf)));
+					ifc->address);
 				UNSET_FLAG(ifc->flags, ZEBRA_IFA_PEER);
 			}
 		}

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -220,8 +220,8 @@ static void nhrp_interface_update_address(struct interface *ifp, afi_t afi,
 	/* On NHRP interfaces a host prefix is required */
 	if (best && if_ad->configured
 	    && best->address->prefixlen != 8 * prefix_blen(best->address)) {
-		zlog_notice("%s: %s is not a host prefix", ifp->name,
-			    prefix2str(best->address, buf, sizeof(buf)));
+		zlog_notice("%s: %pFX is not a host prefix", ifp->name,
+			    best->address);
 		best = NULL;
 	}
 

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -710,7 +710,7 @@ static void show_ip_nhrp_shortcut(struct nhrp_shortcut *s, void *pctx)
 	struct info_ctx *ctx = pctx;
 	struct nhrp_cache *c;
 	struct vty *vty = ctx->vty;
-	char buf2[SU_ADDRSTRLEN];
+	char buf1[PREFIX_STRLEN], buf2[SU_ADDRSTRLEN];
 	struct json_object *json = NULL;
 
 	if (!ctx->count) {
@@ -727,7 +727,8 @@ static void show_ip_nhrp_shortcut(struct nhrp_shortcut *s, void *pctx)
 		json = json_object_new_object();
 		json_object_string_add(json, "type",
 				       nhrp_cache_type_str[s->type]);
-		json_object_string_add(json, "prefix", buf1);
+		json_object_string_add(json, "prefix",
+				       prefix2str(s->p, buf1, sizeof(buf1)));
 
 		if (c)
 			json_object_string_add(json, "via", buf2);

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -710,7 +710,7 @@ static void show_ip_nhrp_shortcut(struct nhrp_shortcut *s, void *pctx)
 	struct info_ctx *ctx = pctx;
 	struct nhrp_cache *c;
 	struct vty *vty = ctx->vty;
-	char buf1[PREFIX_STRLEN], buf2[SU_ADDRSTRLEN];
+	char buf2[SU_ADDRSTRLEN];
 	struct json_object *json = NULL;
 
 	if (!ctx->count) {
@@ -722,7 +722,6 @@ static void show_ip_nhrp_shortcut(struct nhrp_shortcut *s, void *pctx)
 	c = s->cache;
 	if (c)
 		sockunion2str(&c->remote_addr, buf2, sizeof(buf2));
-	prefix2str(s->p, buf1, sizeof(buf1));
 
 	if (ctx->json) {
 		json = json_object_new_object();
@@ -743,9 +742,9 @@ static void show_ip_nhrp_shortcut(struct nhrp_shortcut *s, void *pctx)
 		return;
 	}
 
-	vty_out(ctx->vty, "%-8s %-24s %-24s %s\n",
+	vty_out(ctx->vty, "%-8s %-24pFX %-24s %s\n",
 		nhrp_cache_type_str[s->type],
-		buf1, buf2,
+		s->p, buf2,
 		(c && c->cur.peer) ? c->cur.peer->vc->remote.id : "");
 }
 

--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -196,12 +196,9 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 	if (route->type == OSPF6_DEST_TYPE_ROUTER) {
 		if (ADV_ROUTER_IN_PREFIX(&route->prefix)
 		    == area->ospf6->router_id) {
-			inet_ntop(AF_INET,
-				  &(ADV_ROUTER_IN_PREFIX(&route->prefix)), buf,
-				  sizeof(buf));
-			zlog_debug(
-				"%s: Skipping ASBR announcement for ABR (%s)",
-				__func__, buf);
+			zlog_debug("%s: Skipping ASBR announcement for ABR (%pI4)",
+				   __func__,
+				   &(ADV_ROUTER_IN_PREFIX(&route->prefix)));
 			return 0;
 		}
 	}
@@ -227,14 +224,10 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		    htons(OSPF6_LSTYPE_INTER_PREFIX)) {
 			if (!CHECK_FLAG(route->flag, OSPF6_ROUTE_BEST)) {
 				if (is_debug) {
-					inet_ntop(AF_INET,
-						  &(ADV_ROUTER_IN_PREFIX(
-							&route->prefix)), buf,
-						  sizeof(buf));
-					zlog_debug(
-						"%s: route %s with cost %u is not best, ignore.",
-						__func__, buf,
-						route->path.cost);
+					zlog_debug("%s: route %pI4 with cost %u is not best, ignore.",
+						   __func__,
+						   &(ADV_ROUTER_IN_PREFIX(&route->prefix)),
+						   route->path.cost);
 				}
 				return 0;
 			}
@@ -244,12 +237,9 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		    htons(OSPF6_LSTYPE_INTRA_PREFIX)) {
 			if (!CHECK_FLAG(route->flag, OSPF6_ROUTE_BEST)) {
 				if (is_debug) {
-					prefix2str(&route->prefix, buf,
-						   sizeof(buf));
-					zlog_debug(
-						"%s: intra-prefix route %s with cost %u is not best, ignore.",
-						__func__, buf,
-						route->path.cost);
+					zlog_debug("%s: intra-prefix route %pFX with cost %u is not best, ignore.",
+						   __func__, &route->prefix,
+						   route->path.cost);
 				}
 				return 0;
 			}
@@ -370,9 +360,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		    && (route->path.area_id != OSPF_AREA_BACKBONE
 			|| !IS_AREA_TRANSIT(area))) {
 			if (is_debug) {
-				prefix2str(&range->prefix, buf, sizeof(buf));
-				zlog_debug("Suppressed by range %s of area %s",
-					   buf, route_area->name);
+				zlog_debug("Suppressed by range %pFX of area %s",
+					   &range->prefix, route_area->name);
 			}
 			ospf6_abr_delete_route(route, summary, summary_table,
 					       old);
@@ -412,13 +401,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 			if (access_list_apply(EXPORT_LIST(area), &route->prefix)
 			    == FILTER_DENY) {
 				if (is_debug) {
-					inet_ntop(AF_INET,
-						  &(ADV_ROUTER_IN_PREFIX(
-							  &route->prefix)),
-						  buf, sizeof(buf));
-					zlog_debug(
-						"prefix %s was denied by export list",
-						buf);
+					zlog_debug("prefix %pI4 was denied by export list",
+						   &(ADV_ROUTER_IN_PREFIX(&route->prefix)));
 				}
 				return 0;
 			}
@@ -429,13 +413,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		if (prefix_list_apply(PREFIX_LIST_OUT(area), &route->prefix)
 		    != PREFIX_PERMIT) {
 			if (is_debug) {
-				inet_ntop(
-					AF_INET,
-					&(ADV_ROUTER_IN_PREFIX(&route->prefix)),
-					buf, sizeof(buf));
-				zlog_debug(
-					"prefix %s was denied by filter-list out",
-					buf);
+				zlog_debug("prefix %pI4 was denied by filter-list out",
+					   &(ADV_ROUTER_IN_PREFIX(&route->prefix)));
 			}
 			return 0;
 		}
@@ -1385,8 +1364,8 @@ static int ospf6_inter_area_router_lsa_show(struct vty *vty,
 	vty_out(vty, "     Metric: %lu\n",
 		(unsigned long)OSPF6_ABR_SUMMARY_METRIC(router_lsa));
 
-	inet_ntop(AF_INET, &router_lsa->router_id, buf, sizeof(buf));
-	vty_out(vty, "     Destination Router ID: %s\n", buf);
+	vty_out(vty, "     Destination Router ID: %pI4\n",
+		&router_lsa->router_id);
 
 	return 0;
 }

--- a/ospf6d/ospf6_abr.h
+++ b/ospf6d/ospf6_abr.h
@@ -45,7 +45,7 @@ struct ospf6_inter_router_lsa {
 	uint8_t mbz;
 	uint8_t options[3];
 	uint32_t metric;
-	uint32_t router_id;
+	in_addr_t router_id;
 };
 
 #define OSPF6_ABR_SUMMARY_METRIC(E) (ntohl ((E)->metric & htonl (0x00ffffff)))

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -505,13 +505,12 @@ void ospf6_area_config_write(struct vty *vty)
 	struct listnode *node;
 	struct ospf6_area *oa;
 	struct ospf6_route *range;
-	char buf[PREFIX2STR_BUFFER];
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
 		for (range = ospf6_route_head(oa->range_table); range;
 		     range = ospf6_route_next(range)) {
-			prefix2str(&range->prefix, buf, sizeof(buf));
-			vty_out(vty, " area %s range %s", oa->name, buf);
+			vty_out(vty, " area %s range %pFX", oa->name,
+				&range->prefix);
 
 			if (CHECK_FLAG(range->flag,
 				       OSPF6_ROUTE_DO_NOT_ADVERTISE)) {

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -63,7 +63,6 @@ static void ospf6_as_external_lsa_originate(struct ospf6_route *route)
 	struct ospf6_external_info *info = route->route_option;
 
 	struct ospf6_as_external_lsa *as_external_lsa;
-	char buf[PREFIX2STR_BUFFER];
 	caddr_t p;
 
 	if (IS_OSPF6_DEBUG_ASBR || IS_OSPF6_DEBUG_ORIGINATE(AS_EXTERNAL)) {
@@ -453,7 +452,6 @@ void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa)
 	struct prefix asbr_id;
 	struct ospf6_route *asbr_entry, *route, *old;
 	struct ospf6_path *path;
-	char buf[PREFIX2STR_BUFFER];
 
 	external = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
 		lsa->header);
@@ -1024,7 +1022,7 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 	struct ospf6_external_info *info;
 	struct prefix prefix_id;
 	struct route_node *node;
-	char pbuf[PREFIX2STR_BUFFER], ibuf[16];
+	char pbuf[PREFIX2STR_BUFFER];
 	struct listnode *lnode, *lnnode;
 	struct ospf6_area *oa;
 

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1805,7 +1805,7 @@ static void ospf6_asbr_external_route_show(struct vty *vty,
 {
 	struct ospf6_external_info *info = route->route_option;
 	char forwarding[64];
-	uint32_t tmp_id;
+	in_addr_t tmp_id;
 
 	tmp_id = ntohl(info->id);
 	if (!IN6_IS_ADDR_UNSPECIFIED(&info->forwarding))

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -73,7 +73,6 @@ void ospf6_bfd_reg_dereg_nbr(struct ospf6_neighbor *on, int command)
 	struct ospf6_interface *oi = on->ospf6_if;
 	struct interface *ifp = oi->interface;
 	struct bfd_info *bfd_info;
-	char src[64];
 	int cbit;
 
 	if (!oi->bfd_info || !on->bfd_info)
@@ -81,9 +80,9 @@ void ospf6_bfd_reg_dereg_nbr(struct ospf6_neighbor *on, int command)
 	bfd_info = (struct bfd_info *)oi->bfd_info;
 
 	if (IS_OSPF6_DEBUG_ZEBRA(SEND)) {
-		inet_ntop(AF_INET6, &on->linklocal_addr, src, sizeof(src));
-		zlog_debug("%s nbr (%s) with BFD",
-			   bfd_get_command_dbg_str(command), src);
+		zlog_debug("%s nbr (%pI6) with BFD",
+			   bfd_get_command_dbg_str(command),
+			   &on->linklocal_addr);
 	}
 
 	cbit = CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CBIT_ON);

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1985,7 +1985,7 @@ void ospf6_intra_route_calculation(struct ospf6_area *oa)
 
 static void ospf6_brouter_debug_print(struct ospf6_route *brouter)
 {
-	uint32_t brouter_id;
+	in_addr_t brouter_id;
 	char destination[64];
 	char installed[64], changed[64];
 	struct timeval now, res;

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -84,8 +84,8 @@ struct ospf6_router_lsdesc {
 	uint8_t type;
 	uint8_t reserved;
 	uint16_t metric; /* output cost */
-	uint32_t interface_id;
-	uint32_t neighbor_interface_id;
+	in_addr_t interface_id;
+	in_addr_t neighbor_interface_id;
 	in_addr_t neighbor_router_id;
 };
 

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -338,22 +338,18 @@ int ospf6_lsa_compare(struct ospf6_lsa *a, struct ospf6_lsa *b)
 
 char *ospf6_lsa_printbuf(struct ospf6_lsa *lsa, char *buf, int size)
 {
-	char id[16], adv_router[16];
-	inet_ntop(AF_INET, &lsa->header->id, id, sizeof(id));
-	inet_ntop(AF_INET, &lsa->header->adv_router, adv_router,
-		  sizeof(adv_router));
-	snprintf(buf, size, "[%s Id:%s Adv:%s]",
-		 ospf6_lstype_name(lsa->header->type), id, adv_router);
+	snprintfrr(buf, size, "[%s Id:%pI4 Adv:%pI4]",
+		   ospf6_lstype_name(lsa->header->type), &lsa->header->id,
+		   &lsa->header->adv_router);
 	return buf;
 }
 
 void ospf6_lsa_header_print_raw(struct ospf6_lsa_header *header)
 {
-	char id[16], adv_router[16];
-	inet_ntop(AF_INET, &header->id, id, sizeof(id));
-	inet_ntop(AF_INET, &header->adv_router, adv_router, sizeof(adv_router));
-	zlog_debug("    [%s Id:%s Adv:%s]", ospf6_lstype_name(header->type), id,
-		   adv_router);
+	zlog_debug("    [%s Id:%pI4 Adv:%pI4]",
+		   ospf6_lstype_name(header->type),
+		   &header->id,
+		   &header->adv_router);
 	zlog_debug("    Age: %4hu SeqNum: %#08lx Cksum: %04hx Len: %d",
 		   ntohs(header->age), (unsigned long)ntohl(header->seqnum),
 		   ntohs(header->checksum), ntohs(header->length));
@@ -442,19 +438,13 @@ void ospf6_lsa_show_dump(struct vty *vty, struct ospf6_lsa *lsa)
 
 void ospf6_lsa_show_internal(struct vty *vty, struct ospf6_lsa *lsa)
 {
-	char adv_router[64], id[64];
-
 	assert(lsa && lsa->header);
-
-	inet_ntop(AF_INET, &lsa->header->id, id, sizeof(id));
-	inet_ntop(AF_INET, &lsa->header->adv_router, adv_router,
-		  sizeof(adv_router));
 
 	vty_out(vty, "\n");
 	vty_out(vty, "Age: %4hu Type: %s\n", ospf6_lsa_age_current(lsa),
 		ospf6_lstype_name(lsa->header->type));
-	vty_out(vty, "Link State ID: %s\n", id);
-	vty_out(vty, "Advertising Router: %s\n", adv_router);
+	vty_out(vty, "Link State ID: %pI4\n", &lsa->header->id);
+	vty_out(vty, "Advertising Router: %pI4\n", &lsa->header->adv_router);
 	vty_out(vty, "LS Sequence Number: %#010lx\n",
 		(unsigned long)ntohl(lsa->header->seqnum));
 	vty_out(vty, "CheckSum: %#06hx Length: %hu\n",
@@ -470,16 +460,11 @@ void ospf6_lsa_show_internal(struct vty *vty, struct ospf6_lsa *lsa)
 
 void ospf6_lsa_show(struct vty *vty, struct ospf6_lsa *lsa)
 {
-	char adv_router[64], id[64];
 	const struct ospf6_lsa_handler *handler;
 	struct timeval now, res;
 	char duration[64];
 
 	assert(lsa && lsa->header);
-
-	inet_ntop(AF_INET, &lsa->header->id, id, sizeof(id));
-	inet_ntop(AF_INET, &lsa->header->adv_router, adv_router,
-		  sizeof(adv_router));
 
 	monotime(&now);
 	timersub(&now, &lsa->installed, &res);
@@ -487,8 +472,8 @@ void ospf6_lsa_show(struct vty *vty, struct ospf6_lsa *lsa)
 
 	vty_out(vty, "Age: %4hu Type: %s\n", ospf6_lsa_age_current(lsa),
 		ospf6_lstype_name(lsa->header->type));
-	vty_out(vty, "Link State ID: %s\n", id);
-	vty_out(vty, "Advertising Router: %s\n", adv_router);
+	vty_out(vty, "Link State ID: %pI4\n", &lsa->header->id);
+	vty_out(vty, "Advertising Router: %pI4\n", &lsa->header->adv_router);
 	vty_out(vty, "LS Sequence Number: %#010lx\n",
 		(unsigned long)ntohl(lsa->header->seqnum));
 	vty_out(vty, "CheckSum: %#06hx Length: %hu\n",

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -116,7 +116,7 @@ void ospf6_hello_print(struct ospf6_header *oh)
 	for (p = (char *)((caddr_t)hello + sizeof(struct ospf6_hello));
 	     p + sizeof(uint32_t) <= OSPF6_MESSAGE_END(oh);
 	     p += sizeof(uint32_t)) {
-		zlog_debug("    Neighbor: %pI4", (void *)p);
+		zlog_debug("    Neighbor: %pI4", (in_addr_t *)p);
 	}
 
 	assert(p == OSPF6_MESSAGE_END(oh));

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1515,7 +1515,6 @@ int ospf6_receive(struct thread *thread)
 {
 	int sockfd;
 	unsigned int len;
-	char srcname[64], dstname[64];
 	struct in6_addr src, dst;
 	ifindex_t ifindex;
 	struct iovec iovector[2];

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -86,7 +86,7 @@ struct ospf6_neighbor *ospf6_neighbor_lookup(uint32_t router_id,
 }
 
 /* create ospf6_neighbor */
-struct ospf6_neighbor *ospf6_neighbor_create(uint32_t router_id,
+struct ospf6_neighbor *ospf6_neighbor_create(in_addr_t router_id,
 					     struct ospf6_interface *oi)
 {
 	struct ospf6_neighbor *on;

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1079,8 +1079,8 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route)
 void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route)
 {
 	const char *ifname;
-	char destination[PREFIX2STR_BUFFER], nexthop[64];
-	char area_id[16], id[16], adv_router[16], capa[16], options[16];
+	char destination[PREFIX2STR_BUFFER];
+	char capa[16], options[16];
 	struct timeval now, res;
 	char duration[64];
 	struct listnode *node;

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1519,7 +1519,7 @@ void ospf6_brouter_show_header(struct vty *vty)
 
 void ospf6_brouter_show(struct vty *vty, struct ospf6_route *route)
 {
-	uint32_t adv_router;
+	in_addr_t adv_router;
 	char rbits[16], options[16];
 
 	adv_router = ospf6_linkstate_prefix_adv_router(&route->prefix);

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -336,10 +336,8 @@ static int ospf6_spf_install(struct ospf6_vertex *v,
 		return -1;
 	} else if (route && route->path.cost == v->cost) {
 		if (IS_OSPF6_DEBUG_SPF(PROCESS)) {
-			prefix2str(&route->prefix, pbuf, sizeof(pbuf));
-			zlog_debug(
-				"  another path found to route %s lsa %s, merge",
-				pbuf, v->lsa->name);
+			zlog_debug("  another path found to route %pFX lsa %s, merge",
+				   &route->prefix, v->lsa->name);
 		}
 		ospf6_spf_merge_nexthops_to_route(route, v);
 

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -320,7 +320,6 @@ static int ospf6_spf_install(struct ospf6_vertex *v,
 {
 	struct ospf6_route *route, *parent_route;
 	struct ospf6_vertex *prev;
-	char pbuf[PREFIX2STR_BUFFER];
 
 	if (IS_OSPF6_DEBUG_SPF(PROCESS))
 		zlog_debug("SPF install %s (lsa %s) hops %d cost %d", v->name,

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -104,7 +104,7 @@ static void ospf6_top_brouter_hook_add(struct ospf6_route *route)
 {
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL) ||
 	    IS_OSPF6_DEBUG_BROUTER) {
-		uint32_t brouter_id;
+		in_addr_t brouter_id;
 
 		brouter_id = ADV_ROUTER_IN_PREFIX(&route->prefix);
 		zlog_debug("%s: brouter %pI4 add with adv router %x nh count %u",
@@ -121,7 +121,7 @@ static void ospf6_top_brouter_hook_remove(struct ospf6_route *route)
 {
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL) ||
 	    IS_OSPF6_DEBUG_BROUTER) {
-		uint32_t brouter_id;
+		in_addr_t brouter_id;
 
 		brouter_id = ADV_ROUTER_IN_PREFIX(&route->prefix);
 		zlog_debug("%s: brouter %p %pI4 del with adv router %x nh %u",

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -105,13 +105,10 @@ static void ospf6_top_brouter_hook_add(struct ospf6_route *route)
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL) ||
 	    IS_OSPF6_DEBUG_BROUTER) {
 		uint32_t brouter_id;
-		char brouter_name[16];
 
 		brouter_id = ADV_ROUTER_IN_PREFIX(&route->prefix);
-		inet_ntop(AF_INET, &brouter_id, brouter_name,
-			  sizeof(brouter_name));
-		zlog_debug("%s: brouter %s add with adv router %x nh count %u",
-			   __func__, brouter_name,
+		zlog_debug("%s: brouter %pI4 add with adv router %x nh count %u",
+			   __func__, &brouter_id,
 			   route->path.origin.adv_router,
 			   listcount(route->nh_list));
 	}
@@ -125,13 +122,10 @@ static void ospf6_top_brouter_hook_remove(struct ospf6_route *route)
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL) ||
 	    IS_OSPF6_DEBUG_BROUTER) {
 		uint32_t brouter_id;
-		char brouter_name[16];
 
 		brouter_id = ADV_ROUTER_IN_PREFIX(&route->prefix);
-		inet_ntop(AF_INET, &brouter_id, brouter_name,
-			  sizeof(brouter_name));
-		zlog_debug("%s: brouter %p %s del with adv router %x nh %u",
-			   __func__, (void *)route, brouter_name,
+		zlog_debug("%s: brouter %p %pI4 del with adv router %x nh %u",
+			   __func__, (void *)route, &brouter_id,
 			   route->path.origin.adv_router,
 			   listcount(route->nh_list));
 	}
@@ -847,14 +841,13 @@ static void ospf6_show(struct vty *vty, struct ospf6 *o)
 {
 	struct listnode *n;
 	struct ospf6_area *oa;
-	char router_id[16], duration[32];
+	char duration[32];
 	struct timeval now, running, result;
 	char buf[32], rbuf[32];
 
 	/* process id, router id */
-	inet_ntop(AF_INET, &o->router_id, router_id, sizeof(router_id));
-	vty_out(vty, " OSPFv3 Routing Process (0) with Router-ID %s\n",
-		router_id);
+	vty_out(vty, " OSPFv3 Routing Process (0) with Router-ID %pI4\n",
+		&o->router_id);
 
 	/* running time */
 	monotime(&now);
@@ -1038,11 +1031,9 @@ static int ospf6_distance_config_write(struct vty *vty)
 
 	for (rn = route_top(ospf6->distance_table); rn; rn = route_next(rn))
 		if ((odistance = rn->info) != NULL) {
-			char buf[PREFIX_STRLEN];
-
-			vty_out(vty, " distance %u %s %s\n",
+			vty_out(vty, " distance %u %pFX %s\n",
 				odistance->distance,
-				prefix2str(&rn->p, buf, sizeof(buf)),
+				&rn->p,
 				odistance->access_list ? odistance->access_list
 						       : "");
 		}

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -62,11 +62,8 @@ static int ospf6_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 
 	o->router_id_zebra = router_id.u.prefix4;
 	if (IS_OSPF6_DEBUG_ZEBRA(RECV)) {
-		char buf[INET_ADDRSTRLEN];
-
-		zlog_debug("%s: zebra router-id %s update", __func__,
-			   inet_ntop(AF_INET, &router_id.u.prefix4, buf,
-				     INET_ADDRSTRLEN));
+		zlog_debug("%s: zebra router-id %pI4 update", __func__,
+			   &router_id.u.prefix4);
 	}
 
 	ospf6_router_id_update();
@@ -319,7 +316,6 @@ void ospf6_zebra_route_update_remove(struct ospf6_route *request)
 void ospf6_zebra_add_discard(struct ospf6_route *request)
 {
 	struct zapi_route api;
-	char buf[INET6_ADDRSTRLEN];
 	struct prefix *dest = &request->prefix;
 
 	if (!CHECK_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
@@ -333,26 +329,22 @@ void ospf6_zebra_add_discard(struct ospf6_route *request)
 		zclient_route_send(ZEBRA_ROUTE_ADD, zclient, &api);
 
 		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
-			zlog_debug("Zebra: Route add discard %s/%d",
-				   inet_ntop(AF_INET6, &dest->u.prefix6, buf,
-					     INET6_ADDRSTRLEN),
+			zlog_debug("Zebra: Route add discard %pI6/%d",
+				   &dest->u.prefix6,
 				   dest->prefixlen);
 
 		SET_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED);
 	} else {
 		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
-			zlog_debug(
-				"Zebra: Blackhole route present already %s/%d",
-				inet_ntop(AF_INET6, &dest->u.prefix6, buf,
-					  INET6_ADDRSTRLEN),
-				dest->prefixlen);
+			zlog_debug("Zebra: Blackhole route present already %pI6/%d",
+				   &dest->u.prefix6,
+				   dest->prefixlen);
 	}
 }
 
 void ospf6_zebra_delete_discard(struct ospf6_route *request)
 {
 	struct zapi_route api;
-	char buf[INET6_ADDRSTRLEN];
 	struct prefix *dest = &request->prefix;
 
 	if (CHECK_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
@@ -366,19 +358,16 @@ void ospf6_zebra_delete_discard(struct ospf6_route *request)
 		zclient_route_send(ZEBRA_ROUTE_DELETE, zclient, &api);
 
 		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
-			zlog_debug("Zebra: Route delete discard %s/%d",
-				   inet_ntop(AF_INET6, &dest->u.prefix6, buf,
-					     INET6_ADDRSTRLEN),
+			zlog_debug("Zebra: Route delete discard %pI6/%d",
+				   &dest->u.prefix6,
 				   dest->prefixlen);
 
 		UNSET_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED);
 	} else {
 		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
-			zlog_debug(
-				"Zebra: Blackhole route already deleted %s/%d",
-				inet_ntop(AF_INET6, &dest->u.prefix6, buf,
-					  INET6_ADDRSTRLEN),
-				dest->prefixlen);
+			zlog_debug("Zebra: Blackhole route already deleted %pI6/%d",
+				   &dest->u.prefix6,
+				   dest->prefixlen);
 	}
 }
 

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -107,11 +107,9 @@ static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
-		zlog_debug("Zebra Interface address add: %s %5s %s/%d",
+		zlog_debug("Zebra Interface address add: %s %5s %pFX",
 			   c->ifp->name, prefix_family_str(c->address),
-			   inet_ntop(c->address->family, &c->address->u.prefix,
-				     buf, sizeof(buf)),
-			   c->address->prefixlen);
+			   c->address);
 
 	if (c->address->family == AF_INET6) {
 		ospf6_interface_state_update(c->ifp);
@@ -131,11 +129,9 @@ static int ospf6_zebra_if_address_update_delete(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
-		zlog_debug("Zebra Interface address delete: %s %5s %s/%d",
+		zlog_debug("Zebra Interface address delete: %s %5s %pFX",
 			   c->ifp->name, prefix_family_str(c->address),
-			   inet_ntop(c->address->family, &c->address->u.prefix,
-				     buf, sizeof(buf)),
-			   c->address->prefixlen);
+			   c->address);
 
 	if (c->address->family == AF_INET6) {
 		ospf6_interface_connected_route_update(c->ifp);

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -99,7 +99,6 @@ void ospf6_zebra_no_redistribute(int type)
 static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
-	char buf[128];
 
 	c = zebra_interface_address_read(ZEBRA_INTERFACE_ADDRESS_ADD,
 					 zclient->ibuf, vrf_id);
@@ -121,7 +120,6 @@ static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 static int ospf6_zebra_if_address_update_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
-	char buf[128];
 
 	c = zebra_interface_address_read(ZEBRA_INTERFACE_ADDRESS_DELETE,
 					 zclient->ibuf, vrf_id);

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -347,9 +347,8 @@ static int ospf_abr_nssa_am_elected(struct ospf_area *area)
 		/* Router has Nt flag - always translate */
 		if (IS_ROUTER_LSA_NT(rlsa)) {
 			if (IS_DEBUG_OSPF_NSSA)
-				zlog_debug(
-					"ospf_abr_nssa_am_elected: router %s asserts Nt",
-					inet_ntoa(lsa->data->id));
+				zlog_debug("ospf_abr_nssa_am_elected: router %pI4 asserts Nt",
+				           &lsa->data->id);
 			return 0;
 		}
 
@@ -389,9 +388,8 @@ static void ospf_abr_nssa_check_status(struct ospf *ospf)
 			continue;
 
 		if (IS_DEBUG_OSPF(nssa, NSSA))
-			zlog_debug(
-				"ospf_abr_nssa_check_status: checking area %s",
-				inet_ntoa(area->area_id));
+			zlog_debug("ospf_abr_nssa_check_status: checking area %pI4",
+				   &area->area_id);
 
 		if (!IS_OSPF_ABR(area->ospf)) {
 			if (IS_DEBUG_OSPF(nssa, NSSA))
@@ -614,16 +612,14 @@ static int ospf_abr_translate_nssa(struct ospf_area *area, struct ospf_lsa *lsa)
 
 	if (!CHECK_FLAG(lsa->data->options, OSPF_OPTION_NP)) {
 		if (IS_DEBUG_OSPF_NSSA)
-			zlog_debug(
-				"ospf_abr_translate_nssa(): LSA Id %s, P-bit off, NO Translation",
-				inet_ntoa(lsa->data->id));
+			zlog_debug("ospf_abr_translate_nssa(): LSA Id %pI4, P-bit off, NO Translation",
+				   &lsa->data->id);
 		return 1;
 	}
 
 	if (IS_DEBUG_OSPF_NSSA)
-		zlog_debug(
-			"ospf_abr_translate_nssa(): LSA Id %s, TRANSLATING 7 to 5",
-			inet_ntoa(lsa->data->id));
+		zlog_debug("ospf_abr_translate_nssa(): LSA Id %pI4, TRANSLATING 7 to 5",
+			   &lsa->data->id);
 
 	ext7 = (struct as_external_lsa *)(lsa->data);
 	p.prefix = lsa->data->id;
@@ -631,9 +627,8 @@ static int ospf_abr_translate_nssa(struct ospf_area *area, struct ospf_lsa *lsa)
 
 	if (ext7->e[0].fwd_addr.s_addr == OSPF_DEFAULT_DESTINATION) {
 		if (IS_DEBUG_OSPF_NSSA)
-			zlog_debug(
-				"ospf_abr_translate_nssa(): LSA Id %s, Forward address is 0, NO Translation",
-				inet_ntoa(lsa->data->id));
+			zlog_debug("ospf_abr_translate_nssa(): LSA Id %pI4, Forward address is 0, NO Translation",
+				   &lsa->data->id);
 		return 1;
 	}
 
@@ -643,17 +638,15 @@ static int ospf_abr_translate_nssa(struct ospf_area *area, struct ospf_lsa *lsa)
 
 	if (old) {
 		if (IS_DEBUG_OSPF_NSSA)
-			zlog_debug(
-				"ospf_abr_translate_nssa(): found old translated LSA Id %s, refreshing",
-				inet_ntoa(old->data->id));
+			zlog_debug("ospf_abr_translate_nssa(): found old translated LSA Id %pI4, refreshing",
+				   &old->data->id);
 
 		/* refresh */
 		new = ospf_translated_nssa_refresh(area->ospf, lsa, old);
 		if (!new) {
 			if (IS_DEBUG_OSPF_NSSA)
-				zlog_debug(
-					"ospf_abr_translate_nssa(): could not refresh translated LSA Id %s",
-					inet_ntoa(old->data->id));
+				zlog_debug("ospf_abr_translate_nssa(): could not refresh translated LSA Id %pI4",
+					   &old->data->id);
 		}
 	} else {
 		/* no existing external route for this LSA Id
@@ -662,9 +655,8 @@ static int ospf_abr_translate_nssa(struct ospf_area *area, struct ospf_lsa *lsa)
 
 		if (ospf_translated_nssa_originate(area->ospf, lsa) == NULL) {
 			if (IS_DEBUG_OSPF_NSSA)
-				zlog_debug(
-					"ospf_abr_translate_nssa(): Could not translate Type-7 for %s to Type-5",
-					inet_ntoa(lsa->data->id));
+				zlog_debug("ospf_abr_translate_nssa(): Could not translate Type-7 for %pI4 to Type-5",
+					   &lsa->data->id);
 			return 1;
 		}
 	}
@@ -727,14 +719,10 @@ void ospf_abr_announce_network_to_area(struct prefix_ipv4 *p, uint32_t cost,
 			lsa = ospf_lsa_refresh(area->ospf, old);
 
 			if (!lsa) {
-				char buf[PREFIX2STR_BUFFER];
-
-				prefix2str((struct prefix *)p, buf,
-					   sizeof(buf));
 				flog_warn(EC_OSPF_LSA_MISSING,
-					  "%s: Could not refresh %s to %s",
-					  __func__, buf,
-					  inet_ntoa(area->area_id));
+					  "%s: Could not refresh %pFX to %pI4",
+					  __func__, (struct prefix *)p,
+					  &area->area_id);
 				return;
 			}
 
@@ -749,12 +737,10 @@ void ospf_abr_announce_network_to_area(struct prefix_ipv4 *p, uint32_t cost,
 		/* This will flood through area. */
 
 		if (!lsa) {
-			char buf[PREFIX2STR_BUFFER];
-
-			prefix2str((struct prefix *)p, buf, sizeof(buf));
 			flog_warn(EC_OSPF_LSA_MISSING,
-				  "%s: Could not originate %s to %s", __func__,
-				  buf, inet_ntoa(area->area_id));
+				  "%s: Could not originate %pFX to %pI4",
+				  __func__,
+				  (struct prefix *)p, &area->area_id);
 			return;
 		}
 
@@ -846,9 +832,8 @@ static void ospf_abr_announce_network(struct ospf *ospf, struct prefix_ipv4 *p,
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area)) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"ospf_abr_announce_network(): looking at area %s",
-				inet_ntoa(area->area_id));
+			zlog_debug("ospf_abr_announce_network(): looking at area %pI4",
+				   &area->area_id);
 
 		if (IPV4_ADDR_SAME(& or->u.std.area_id, &area->area_id))
 			continue;
@@ -873,9 +858,8 @@ static void ospf_abr_announce_network(struct ospf *ospf, struct prefix_ipv4 *p,
 		if (area->external_routing != OSPF_AREA_DEFAULT
 		    && area->no_summary) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_announce_network(): area %s is stub and no_summary",
-					inet_ntoa(area->area_id));
+				zlog_debug("ospf_abr_announce_network(): area %pI4 is stub and no_summary",
+					   &area->area_id);
 			continue;
 		}
 
@@ -950,9 +934,8 @@ static void ospf_abr_process_nssa_translates(struct ospf *ospf)
 			continue; /* skip if not Nssa Area */
 
 		if (IS_DEBUG_OSPF_NSSA)
-			zlog_debug(
-				"ospf_abr_process_nssa_translates(): looking at area %s",
-				inet_ntoa(area->area_id));
+			zlog_debug("ospf_abr_process_nssa_translates(): looking at area %pI4",
+				   &area->area_id);
 
 		LSDB_LOOP (NSSA_LSDB(area), rn, lsa)
 			ospf_abr_translate_nssa(area, lsa);
@@ -979,9 +962,8 @@ static void ospf_abr_process_network_rt(struct ospf *ospf,
 		if (!(area = ospf_area_lookup_by_area_id(ospf,
 							 or->u.std.area_id))) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_process_network_rt(): area %s no longer exists",
-					inet_ntoa(or->u.std.area_id));
+				zlog_debug("ospf_abr_process_network_rt(): area %pI4 no longer exists",
+				           &or->u.std.area_id);
 			continue;
 		}
 
@@ -1100,12 +1082,10 @@ static void ospf_abr_announce_rtr_to_area(struct prefix_ipv4 *p, uint32_t cost,
 		} else
 			lsa = ospf_summary_asbr_lsa_originate(p, cost, area);
 		if (!lsa) {
-			char buf[PREFIX2STR_BUFFER];
-
-			prefix2str((struct prefix *)p, buf, sizeof(buf));
 			flog_warn(EC_OSPF_LSA_MISSING,
-				  "%s: Could not refresh/originate %s to %s",
-				  __func__, buf, inet_ntoa(area->area_id));
+				  "%s: Could not refresh/originate %pFX to %pI4",
+				  __func__, (struct prefix *)p,
+				  &area->area_id);
 			return;
 		}
 
@@ -1138,9 +1118,8 @@ static void ospf_abr_announce_rtr(struct ospf *ospf, struct prefix_ipv4 *p,
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area)) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"ospf_abr_announce_rtr(): looking at area %s",
-				inet_ntoa(area->area_id));
+			zlog_debug("ospf_abr_announce_rtr(): looking at area %pI4",
+				   &area->area_id);
 
 		if (IPV4_ADDR_SAME(& or->u.std.area_id, &area->area_id))
 			continue;
@@ -1150,17 +1129,15 @@ static void ospf_abr_announce_rtr(struct ospf *ospf, struct prefix_ipv4 *p,
 
 		if (area->external_routing != OSPF_AREA_DEFAULT) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_announce_rtr(): area %s doesn't support external routing",
-					inet_ntoa(area->area_id));
+				zlog_debug("ospf_abr_announce_rtr(): area %pI4 doesn't support external routing",
+				           &area->area_id);
 			continue;
 		}
 
 		if (or->path_type == OSPF_PATH_INTER_AREA) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_announce_rtr(): this is inter-area route to %s",
-					inet_ntoa(p->prefix));
+				zlog_debug("ospf_abr_announce_rtr(): this is inter-area route to %pI4",
+				           &p->prefix);
 			if (!OSPF_IS_AREA_BACKBONE(area))
 				ospf_abr_announce_rtr_to_area(p, or->cost,
 							      area);
@@ -1168,9 +1145,8 @@ static void ospf_abr_announce_rtr(struct ospf *ospf, struct prefix_ipv4 *p,
 
 		if (or->path_type == OSPF_PATH_INTRA_AREA) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_announce_rtr(): this is intra-area route to %s",
-					inet_ntoa(p->prefix));
+				zlog_debug("ospf_abr_announce_rtr(): this is intra-area route to %pI4",
+				           &p->prefix);
 			ospf_abr_announce_rtr_to_area(p, or->cost, area);
 		}
 	}
@@ -1200,17 +1176,15 @@ static void ospf_abr_process_router_rt(struct ospf *ospf,
 		l = rn->info;
 
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"ospf_abr_process_router_rt(): this is a route to %s",
-				inet_ntoa(rn->p.u.prefix4));
+			zlog_debug("ospf_abr_process_router_rt(): this is a route to %pI4",
+				   &rn->p.u.prefix4);
 
 		for (ALL_LIST_ELEMENTS(l, node, nnode, or)) {
 			if (!ospf_area_lookup_by_area_id(ospf,
 							 or->u.std.area_id)) {
 				if (IS_DEBUG_OSPF_EVENT)
-					zlog_debug(
-						"ospf_abr_process_router_rt(): area %s no longer exists",
-						inet_ntoa(or->u.std.area_id));
+					zlog_debug("ospf_abr_process_router_rt(): area %pI4 no longer exists",
+						   &or->u.std.area_id);
 				continue;
 			}
 
@@ -1290,9 +1264,8 @@ ospf_abr_unapprove_translates(struct ospf *ospf) /* For NSSA Translations */
 		if (CHECK_FLAG(lsa->flags, OSPF_LSA_LOCAL_XLT)) {
 			UNSET_FLAG(lsa->flags, OSPF_LSA_APPROVED);
 			if (IS_DEBUG_OSPF_NSSA)
-				zlog_debug(
-					"ospf_abr_unapprove_translates(): approved unset on link id %s",
-					inet_ntoa(lsa->data->id));
+				zlog_debug("ospf_abr_unapprove_translates(): approved unset on link id %pI4",
+				           &lsa->data->id);
 		}
 
 	if (IS_DEBUG_OSPF_NSSA)
@@ -1311,24 +1284,21 @@ static void ospf_abr_unapprove_summaries(struct ospf *ospf)
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area)) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"ospf_abr_unapprove_summaries(): considering area %s",
-				inet_ntoa(area->area_id));
+			zlog_debug("ospf_abr_unapprove_summaries(): considering area %pI4",
+				   &area->area_id);
 		LSDB_LOOP (SUMMARY_LSDB(area), rn, lsa)
 			if (ospf_lsa_is_self_originated(ospf, lsa)) {
 				if (IS_DEBUG_OSPF_EVENT)
-					zlog_debug(
-						"ospf_abr_unapprove_summaries(): approved unset on summary link id %s",
-						inet_ntoa(lsa->data->id));
+					zlog_debug("ospf_abr_unapprove_summaries(): approved unset on summary link id %pI4",
+						   &lsa->data->id);
 				UNSET_FLAG(lsa->flags, OSPF_LSA_APPROVED);
 			}
 
 		LSDB_LOOP (ASBR_SUMMARY_LSDB(area), rn, lsa)
 			if (ospf_lsa_is_self_originated(ospf, lsa)) {
 				if (IS_DEBUG_OSPF_EVENT)
-					zlog_debug(
-						"ospf_abr_unapprove_summaries(): approved unset on asbr-summary link id %s",
-						inet_ntoa(lsa->data->id));
+					zlog_debug("ospf_abr_unapprove_summaries(): approved unset on asbr-summary link id %pI4",
+						   &lsa->data->id);
 				UNSET_FLAG(lsa->flags, OSPF_LSA_APPROVED);
 			}
 	}
@@ -1372,9 +1342,8 @@ static void ospf_abr_announce_aggregates(struct ospf *ospf)
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area)) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"ospf_abr_announce_aggregates(): looking at area %s",
-				inet_ntoa(area->area_id));
+			zlog_debug("ospf_abr_announce_aggregates(): looking at area %pI4",
+				   &area->area_id);
 
 		for (rn = route_top(area->ranges); rn; rn = route_next(rn))
 			if ((range = rn->info)) {
@@ -1460,9 +1429,8 @@ ospf_abr_send_nssa_aggregates(struct ospf *ospf) /* temporarily turned off */
 			continue;
 
 		if (IS_DEBUG_OSPF_NSSA)
-			zlog_debug(
-				"ospf_abr_send_nssa_aggregates(): looking at area %s",
-				inet_ntoa(area->area_id));
+			zlog_debug("ospf_abr_send_nssa_aggregates(): looking at area %pI4",
+				   &area->area_id);
 
 		for (rn = route_top(area->ranges); rn; rn = route_next(rn)) {
 			if (rn->info == NULL)
@@ -1530,9 +1498,8 @@ static void ospf_abr_announce_stub_defaults(struct ospf *ospf)
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area)) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"ospf_abr_announce_stub_defaults(): looking at area %s",
-				inet_ntoa(area->area_id));
+			zlog_debug("ospf_abr_announce_stub_defaults(): looking at area %pI4",
+				   &area->area_id);
 
 		if ((area->external_routing != OSPF_AREA_STUB)
 		    && (area->external_routing != OSPF_AREA_NSSA))
@@ -1542,9 +1509,8 @@ static void ospf_abr_announce_stub_defaults(struct ospf *ospf)
 			continue; /* Sanity Check */
 
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"ospf_abr_announce_stub_defaults(): announcing 0.0.0.0/0 to area %s",
-				inet_ntoa(area->area_id));
+			zlog_debug("ospf_abr_announce_stub_defaults(): announcing 0.0.0.0/0 to area %pI4",
+				   &area->area_id);
 		ospf_abr_announce_network_to_area(&p, area->default_cost, area);
 	}
 
@@ -1557,9 +1523,8 @@ static int ospf_abr_remove_unapproved_translates_apply(struct ospf *ospf,
 {
 	if (CHECK_FLAG(lsa->flags, OSPF_LSA_LOCAL_XLT)
 	    && !CHECK_FLAG(lsa->flags, OSPF_LSA_APPROVED)) {
-		zlog_info(
-			"ospf_abr_remove_unapproved_translates(): removing unapproved translates, ID: %s",
-			inet_ntoa(lsa->data->id));
+		zlog_info("ospf_abr_remove_unapproved_translates(): removing unapproved translates, ID: %pI4",
+			  &lsa->data->id);
 
 		/* FLUSH THROUGHOUT AS */
 		ospf_lsa_flush_as(ospf, lsa);
@@ -1598,9 +1563,8 @@ static void ospf_abr_remove_unapproved_summaries(struct ospf *ospf)
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area)) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"ospf_abr_remove_unapproved_summaries(): looking at area %s",
-				inet_ntoa(area->area_id));
+			zlog_debug("ospf_abr_remove_unapproved_summaries(): looking at area %pI4",
+				   &area->area_id);
 
 		LSDB_LOOP (SUMMARY_LSDB(area), rn, lsa)
 			if (ospf_lsa_is_self_originated(ospf, lsa))

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -858,17 +858,15 @@ static void ospf_abr_announce_network(struct ospf *ospf, struct prefix_ipv4 *p,
 
 		if (!ospf_abr_should_accept(p, area)) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_announce_network(): prefix %s/%d was denied by import-list",
-					inet_ntoa(p->prefix), p->prefixlen);
+				zlog_debug("ospf_abr_announce_network(): prefix %pFX was denied by import-list",
+					   p);
 			continue;
 		}
 
 		if (!ospf_abr_plist_in_check(area, or, p)) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_announce_network(): prefix %s/%d was denied by prefix-list",
-					inet_ntoa(p->prefix), p->prefixlen);
+				zlog_debug("ospf_abr_announce_network(): prefix %pFX was denied by prefix-list",
+					   p);
 			continue;
 		}
 
@@ -883,9 +881,8 @@ static void ospf_abr_announce_network(struct ospf *ospf, struct prefix_ipv4 *p,
 
 		if (or->path_type == OSPF_PATH_INTER_AREA) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_announce_network(): this is inter-area route to %s/%d",
-					inet_ntoa(p->prefix), p->prefixlen);
+				zlog_debug("ospf_abr_announce_network(): this is inter-area route to %pFX",
+					   p);
 
 			if (!OSPF_IS_AREA_BACKBONE(area))
 				ospf_abr_announce_network_to_area(p, or->cost,
@@ -894,9 +891,8 @@ static void ospf_abr_announce_network(struct ospf *ospf, struct prefix_ipv4 *p,
 
 		if (or->path_type == OSPF_PATH_INTRA_AREA) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_announce_network(): this is intra-area route to %s/%d",
-					inet_ntoa(p->prefix), p->prefixlen);
+				zlog_debug("ospf_abr_announce_network(): this is intra-area route to %pFX",
+					   p);
 			if ((range = ospf_area_range_match(or_area, p))
 			    && !ospf_area_is_transit(area))
 				ospf_abr_update_aggregate(range, or, area);
@@ -990,9 +986,8 @@ static void ospf_abr_process_network_rt(struct ospf *ospf,
 		}
 
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"ospf_abr_process_network_rt(): this is a route to %s/%d",
-				inet_ntoa(rn->p.u.prefix4), rn->p.prefixlen);
+			zlog_debug("ospf_abr_process_network_rt(): this is a route to %pFX",
+				   &rn->p);
 		if (or->path_type >= OSPF_PATH_TYPE1_EXTERNAL) {
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(
@@ -1396,10 +1391,8 @@ static void ospf_abr_announce_aggregates(struct ospf *ospf)
 				p.prefixlen = range->masklen;
 
 				if (IS_DEBUG_OSPF_EVENT)
-					zlog_debug(
-						"ospf_abr_announce_aggregates(): this is range: %s/%d",
-						inet_ntoa(p.u.prefix4),
-						p.prefixlen);
+					zlog_debug("ospf_abr_announce_aggregates(): this is range: %pFX",
+						   &p);
 
 				if (CHECK_FLAG(range->flags,
 					       OSPF_AREA_RANGE_SUBSTITUTE)) {
@@ -1490,9 +1483,8 @@ ospf_abr_send_nssa_aggregates(struct ospf *ospf) /* temporarily turned off */
 			p.prefixlen = range->masklen;
 
 			if (IS_DEBUG_OSPF_NSSA)
-				zlog_debug(
-					"ospf_abr_send_nssa_aggregates(): this is range: %s/%d",
-					inet_ntoa(p.prefix), p.prefixlen);
+				zlog_debug("ospf_abr_send_nssa_aggregates(): this is range: %pFX",
+				           &p);
 
 			if (CHECK_FLAG(range->flags,
 				       OSPF_AREA_RANGE_SUBSTITUTE)) {

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -387,8 +387,8 @@ int ospf_apiserver_read(struct thread *thread)
 		apiserv->t_sync_read = NULL;
 
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("API: ospf_apiserver_read: Peer: %s/%u",
-				   inet_ntoa(apiserv->peer_sync.sin_addr),
+			zlog_debug("API: ospf_apiserver_read: Peer: %pI4/%u",
+				   &apiserv->peer_sync.sin_addr,
 				   ntohs(apiserv->peer_sync.sin_port));
 	}
 #ifdef USE_ASYNC_READ
@@ -397,8 +397,8 @@ int ospf_apiserver_read(struct thread *thread)
 		apiserv->t_async_read = NULL;
 
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("API: ospf_apiserver_read: Peer: %s/%u",
-				   inet_ntoa(apiserv->peer_async.sin_addr),
+			zlog_debug("API: ospf_apiserver_read: Peer: %pI4/%u",
+				   &apiserv->peer_async.sin_addr,
 				   ntohs(apiserv->peer_async.sin_port));
 	}
 #endif /* USE_ASYNC_READ */
@@ -455,8 +455,8 @@ int ospf_apiserver_sync_write(struct thread *thread)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("API: ospf_apiserver_sync_write: Peer: %s/%u",
-			   inet_ntoa(apiserv->peer_sync.sin_addr),
+		zlog_debug("API: ospf_apiserver_sync_write: Peer: %pI4/%u",
+			   &apiserv->peer_sync.sin_addr,
 			   ntohs(apiserv->peer_sync.sin_port));
 
 	/* Check whether there is really a message in the fifo. */
@@ -519,8 +519,8 @@ int ospf_apiserver_async_write(struct thread *thread)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("API: ospf_apiserver_async_write: Peer: %s/%u",
-			   inet_ntoa(apiserv->peer_async.sin_addr),
+		zlog_debug("API: ospf_apiserver_async_write: Peer: %pI4/%u",
+			   &apiserv->peer_async.sin_addr,
 			   ntohs(apiserv->peer_async.sin_port));
 
 	/* Check whether there is really a message in the fifo. */
@@ -645,8 +645,8 @@ int ospf_apiserver_accept(struct thread *thread)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("API: ospf_apiserver_accept: New peer: %s/%u",
-			   inet_ntoa(peer_sync.sin_addr),
+		zlog_debug("API: ospf_apiserver_accept: New peer: %pI4/%u",
+			   &peer_sync.sin_addr,
 			   ntohs(peer_sync.sin_port));
 
 	/* Create new socket for asynchronous messages. */
@@ -656,10 +656,9 @@ int ospf_apiserver_accept(struct thread *thread)
 	/* Check if remote port number to make reverse connection is valid one.
 	 */
 	if (ntohs(peer_async.sin_port) == ospf_apiserver_getport()) {
-		zlog_warn(
-			"API: ospf_apiserver_accept: Peer(%s/%u): Invalid async port number?",
-			inet_ntoa(peer_async.sin_addr),
-			ntohs(peer_async.sin_port));
+		zlog_warn("API: ospf_apiserver_accept: Peer(%pI4/%u): Invalid async port number?",
+			  &peer_async.sin_addr,
+			  ntohs(peer_async.sin_port));
 		close(new_sync_sock);
 		return -1;
 	}
@@ -1409,8 +1408,8 @@ struct ospf_lsa *ospf_apiserver_opaque_lsa_new(struct ospf_area *area,
 	options |= OSPF_OPTION_O; /* Don't forget to set option bit */
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Creating an Opaque-LSA instance",
-			   protolsa->type, inet_ntoa(protolsa->id));
+		zlog_debug("LSA[Type%d:%pI4]: Creating an Opaque-LSA instance",
+			   protolsa->type, &protolsa->id);
 	}
 
 	/* Set opaque-LSA header fields. */
@@ -1510,8 +1509,8 @@ int ospf_apiserver_handle_originate_request(struct ospf_apiserver *apiserv,
 	case OSPF_OPAQUE_LINK_LSA:
 		oi = ospf_apiserver_if_lookup_by_addr(omsg->ifaddr);
 		if (!oi) {
-			zlog_warn("apiserver_originate: unknown interface %s",
-				  inet_ntoa(omsg->ifaddr));
+			zlog_warn("apiserver_originate: unknown interface %pI4",
+				  &omsg->ifaddr);
 			rc = OSPF_API_NOSUCHINTERFACE;
 			goto out;
 		}
@@ -1521,8 +1520,8 @@ int ospf_apiserver_handle_originate_request(struct ospf_apiserver *apiserv,
 	case OSPF_OPAQUE_AREA_LSA:
 		area = ospf_area_lookup_by_area_id(ospf, omsg->area_id);
 		if (!area) {
-			zlog_warn("apiserver_originate: unknown area %s",
-				  inet_ntoa(omsg->area_id));
+			zlog_warn("apiserver_originate: unknown area %pI4",
+				  &omsg->area_id);
 			rc = OSPF_API_NOSUCHAREA;
 			goto out;
 		}
@@ -1791,8 +1790,8 @@ struct ospf_lsa *ospf_apiserver_lsa_refresher(struct ospf_lsa *lsa)
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Refresh Opaque LSA",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: Refresh Opaque LSA",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1829,8 +1828,8 @@ int ospf_apiserver_handle_delete_request(struct ospf_apiserver *apiserv,
 	case OSPF_OPAQUE_AREA_LSA:
 		area = ospf_area_lookup_by_area_id(ospf, dmsg->area_id);
 		if (!area) {
-			zlog_warn("ospf_apiserver_lsa_delete: unknown area %s",
-				  inet_ntoa(dmsg->area_id));
+			zlog_warn("ospf_apiserver_lsa_delete: unknown area %pI4",
+				  &dmsg->area_id);
 			rc = OSPF_API_NOSUCHAREA;
 			goto out;
 		}
@@ -1871,9 +1870,8 @@ int ospf_apiserver_handle_delete_request(struct ospf_apiserver *apiserv,
 	 */
 	old = ospf_lsa_lookup(ospf, area, dmsg->lsa_type, id, ospf->router_id);
 	if (!old) {
-		zlog_warn(
-			"ospf_apiserver_lsa_delete: LSA[Type%d:%s] not in LSDB",
-			dmsg->lsa_type, inet_ntoa(id));
+		zlog_warn("ospf_apiserver_lsa_delete: LSA[Type%d:%pI4] not in LSDB",
+			  dmsg->lsa_type, &id);
 		rc = OSPF_API_NOSUCHLSA;
 		goto out;
 	}

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -155,7 +155,7 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 		zlog_debug("Redistribute[%s][%u]: %pFX external info created, with NH %pI4",
 			   ospf_redist_string(type), ospf->vrf_id,
-			   &p, (void *)&nexthop.s_addr);
+			   &p, &nexthop.s_addr);
 	}
 	return new;
 }

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -53,8 +53,8 @@ void ospf_external_route_remove(struct ospf *ospf, struct prefix_ipv4 *p)
 	rn = route_node_lookup(ospf->old_external_route, (struct prefix *)p);
 	if (rn)
 		if ((or = rn->info)) {
-			zlog_info("Route[%s/%d]: external path deleted",
-				  inet_ntoa(p->prefix), p->prefixlen);
+			zlog_info("Route[%pFX]: external path deleted",
+				  p);
 
 			/* Remove route from zebra. */
 			if (or->type == OSPF_DESTINATION_NETWORK)
@@ -69,8 +69,7 @@ void ospf_external_route_remove(struct ospf *ospf, struct prefix_ipv4 *p)
 			return;
 		}
 
-	zlog_info("Route[%s/%d]: no such external path", inet_ntoa(p->prefix),
-		  p->prefixlen);
+	zlog_info("Route[%pFX]: no such external path", p);
 }
 
 /* Add an External info for AS-external-LSA. */
@@ -135,11 +134,9 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 			inet_ntop(AF_INET, (void *)&nexthop.s_addr, inetbuf,
 				  INET6_BUFSIZ);
 			if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-				zlog_debug(
-					"Redistribute[%s][%d][%u]: %s/%d discarding old info with NH %s.",
-					ospf_redist_string(type), instance,
-					ospf->vrf_id, inet_ntoa(p.prefix),
-					p.prefixlen, inetbuf);
+				zlog_debug("Redistribute[%s][%d][%u]: %pFX discarding old info with NH %s.",
+					   ospf_redist_string(type), instance,
+					   ospf->vrf_id, &p, inetbuf);
 			XFREE(MTYPE_OSPF_EXTERNAL_INFO, rn->info);
 		}
 
@@ -158,10 +155,9 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 		inet_ntop(AF_INET, (void *)&nexthop.s_addr, inetbuf,
 			  INET6_BUFSIZ);
-		zlog_debug(
-			"Redistribute[%s][%u]: %s/%d external info created, with NH %s",
-			ospf_redist_string(type), ospf->vrf_id,
-			inet_ntoa(p.prefix), p.prefixlen, inetbuf);
+		zlog_debug("Redistribute[%s][%u]: %pFX external info created, with NH %s",
+			   ospf_redist_string(type), ospf->vrf_id,
+			   &p, inetbuf);
 	}
 	return new;
 }

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -153,11 +153,9 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 		rn->info = new;
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		inet_ntop(AF_INET, (void *)&nexthop.s_addr, inetbuf,
-			  INET6_BUFSIZ);
-		zlog_debug("Redistribute[%s][%u]: %pFX external info created, with NH %s",
+		zlog_debug("Redistribute[%s][%u]: %pFX external info created, with NH %pI4",
 			   ospf_redist_string(type), ospf->vrf_id,
-			   &p, inetbuf);
+			   &p, (void *)&nexthop.s_addr);
 	}
 	return new;
 }

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -301,11 +301,10 @@ int ospf_ase_calculate_route(struct ospf *ospf, struct ospf_lsa *lsa)
 	}
 
 	if (IS_DEBUG_OSPF(lsa, LSA)) {
-		snprintf(buf1, sizeof(buf1), "%s",
-			 inet_ntoa(al->header.adv_router));
-		zlog_debug(
-			"Route[External]: Calculate AS-external-LSA to %s/%d adv_router %s",
-			inet_ntoa(al->header.id), ip_masklen(al->mask), buf1);
+		snprintfrr(buf1, sizeof(buf1), "%pI4",
+			   &al->header.adv_router);
+		zlog_debug("Route[External]: Calculate AS-external-LSA to %pI4/%d adv_router %s",
+			   &al->header.id, ip_masklen(al->mask), buf1);
 	}
 
 	/* (1) If the cost specified by the LSA is LSInfinity, or if the
@@ -657,9 +656,8 @@ static int ospf_ase_calculate_timer(struct thread *t)
 		if (ospf->anyNSSA)
 			for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area)) {
 				if (IS_DEBUG_OSPF_NSSA)
-					zlog_debug(
-						"ospf_ase_calculate_timer(): looking at area %s",
-						inet_ntoa(area->area_id));
+					zlog_debug("ospf_ase_calculate_timer(): looking at area %pI4",
+						   &area->area_id);
 
 				if (area->external_routing == OSPF_AREA_NSSA)
 					LSDB_LOOP (NSSA_LSDB(area), rn, lsa)

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -457,8 +457,8 @@ int ospf_ase_calculate_route(struct ospf *ospf, struct ospf_lsa *lsa)
 
 	if (!rn || (or = rn->info) == NULL) {
 		if (IS_DEBUG_OSPF(lsa, LSA))
-			zlog_debug("Route[External]: Adding a new route %s/%d with paths %u",
-				   inet_ntoa(p.prefix), p.prefixlen,
+			zlog_debug("Route[External]: Adding a new route %pFX with paths %u",
+				   &p,
 				   listcount(asbr_route->paths));
 
 		ospf_route_add(ospf->new_external_route, &p, new, asbr_route);

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -76,9 +76,9 @@ static void ospf_bfd_reg_dereg_nbr(struct ospf_neighbor *nbr, int command)
 	bfd_info = (struct bfd_info *)params->bfd_info;
 
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
-		zlog_debug("%s nbr (%s) with BFD. OSPF vrf %s",
+		zlog_debug("%s nbr (%pI4) with BFD. OSPF vrf %s",
 			   bfd_get_command_dbg_str(command),
-			   inet_ntoa(nbr->src),
+			   &nbr->src,
 			   ospf_vrf_id_to_name(oi->ospf->vrf_id));
 
 	cbit = CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CBIT_ON);
@@ -180,8 +180,8 @@ static int ospf_bfd_nbr_replay(ZAPI_CALLBACK_ARGS)
 					continue;
 
 				if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
-					zlog_debug("Replaying nbr (%s) to BFD",
-						   inet_ntoa(nbr->src));
+					zlog_debug("Replaying nbr (%pI4) to BFD",
+						   &nbr->src);
 
 				ospf_bfd_reg_dereg_nbr(nbr,
 						       ZEBRA_BFD_DEST_UPDATE);

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -235,20 +235,20 @@ static void ospf_packet_hello_dump(struct stream *s, uint16_t length)
 	hello = (struct ospf_hello *)stream_pnt(s);
 
 	zlog_debug("Hello");
-	zlog_debug("  NetworkMask %s", inet_ntoa(hello->network_mask));
+	zlog_debug("  NetworkMask %pI4", &hello->network_mask);
 	zlog_debug("  HelloInterval %d", ntohs(hello->hello_interval));
 	zlog_debug("  Options %d (%s)", hello->options,
 		   ospf_options_dump(hello->options));
 	zlog_debug("  RtrPriority %d", hello->priority);
 	zlog_debug("  RtrDeadInterval %ld",
 		   (unsigned long)ntohl(hello->dead_interval));
-	zlog_debug("  DRouter %s", inet_ntoa(hello->d_router));
-	zlog_debug("  BDRouter %s", inet_ntoa(hello->bd_router));
+	zlog_debug("  DRouter %pI4", &hello->d_router);
+	zlog_debug("  BDRouter %pI4", &hello->bd_router);
 
 	length -= OSPF_HEADER_SIZE + OSPF_HELLO_MIN_SIZE;
 	zlog_debug("  # Neighbors %d", length / 4);
 	for (i = 0; length > 0; i++, length -= sizeof(struct in_addr))
-		zlog_debug("    Neighbor %s", inet_ntoa(hello->neighbors[i]));
+		zlog_debug("    Neighbor %pI4", &hello->neighbors[i]);
 }
 
 static char *ospf_dd_flags_dump(uint8_t flags, char *buf, size_t size)
@@ -285,9 +285,9 @@ static void ospf_router_lsa_dump(struct stream *s, uint16_t length)
 
 	len = ntohs(rl->header.length) - OSPF_LSA_HEADER_SIZE - 4;
 	for (i = 0; len > 0; i++) {
-		zlog_debug("    Link ID %s", inet_ntoa(rl->link[i].link_id));
-		zlog_debug("    Link Data %s",
-			   inet_ntoa(rl->link[i].link_data));
+		zlog_debug("    Link ID %pI4", &rl->link[i].link_id);
+		zlog_debug("    Link Data %pI4",
+			   &rl->link[i].link_data);
 		zlog_debug("    Type %d", (uint8_t)rl->link[i].type);
 		zlog_debug("    TOS %d", (uint8_t)rl->link[i].tos);
 		zlog_debug("    metric %d", ntohs(rl->link[i].metric));
@@ -310,11 +310,11 @@ static void ospf_network_lsa_dump(struct stream *s, uint16_t length)
 	zlog_debug ("Network-LSA size %d",
 	ntohs (nl->header.length) - OSPF_LSA_HEADER_SIZE);
 	*/
-	zlog_debug("    Network Mask %s", inet_ntoa(nl->mask));
+	zlog_debug("    Network Mask %pI4", &nl->mask);
 	zlog_debug("    # Attached Routers %d", cnt);
 	for (i = 0; i < cnt; i++)
-		zlog_debug("      Attached Router %s",
-			   inet_ntoa(nl->routers[i]));
+		zlog_debug("      Attached Router %pI4",
+			   &nl->routers[i]);
 }
 
 static void ospf_summary_lsa_dump(struct stream *s, uint16_t length)
@@ -326,7 +326,7 @@ static void ospf_summary_lsa_dump(struct stream *s, uint16_t length)
 	sl = (struct summary_lsa *)stream_pnt(s);
 
 	zlog_debug("  Summary-LSA");
-	zlog_debug("    Network Mask %s", inet_ntoa(sl->mask));
+	zlog_debug("    Network Mask %pI4", &sl->mask);
 
 	size = ntohs(sl->header.length) - OSPF_LSA_HEADER_SIZE - 4;
 	for (i = 0; size > 0; size -= 4, i++)
@@ -342,15 +342,15 @@ static void ospf_as_external_lsa_dump(struct stream *s, uint16_t length)
 
 	al = (struct as_external_lsa *)stream_pnt(s);
 	zlog_debug("  %s", ospf_lsa_type_msg[al->header.type].str);
-	zlog_debug("    Network Mask %s", inet_ntoa(al->mask));
+	zlog_debug("    Network Mask %pI4", &al->mask);
 
 	size = ntohs(al->header.length) - OSPF_LSA_HEADER_SIZE - 4;
 	for (i = 0; size > 0; size -= 12, i++) {
 		zlog_debug("    bit %s TOS=%d metric %d",
 			   IS_EXTERNAL_METRIC(al->e[i].tos) ? "E" : "-",
 			   al->e[i].tos & 0x7f, GET_METRIC(al->e[i].metric));
-		zlog_debug("    Forwarding address %s",
-			   inet_ntoa(al->e[i].fwd_addr));
+		zlog_debug("    Forwarding address %pI4",
+			   &al->e[i].fwd_addr);
 		zlog_debug("    External Route Tag %" ROUTE_TAG_PRI,
 			   al->e[i].route_tag);
 	}
@@ -420,8 +420,8 @@ static void ospf_packet_ls_req_dump(struct stream *s, uint16_t length)
 		adv_router.s_addr = stream_get_ipv4(s);
 
 		zlog_debug("  LS type %d", ls_type);
-		zlog_debug("  Link State ID %s", inet_ntoa(ls_id));
-		zlog_debug("  Advertising Router %s", inet_ntoa(adv_router));
+		zlog_debug("  Link State ID %pI4", &ls_id);
+		zlog_debug("  Advertising Router %pI4", &adv_router);
 	}
 
 	stream_set_getp(s, sp);
@@ -512,8 +512,8 @@ static void ospf_header_dump(struct ospf_header *ospfh)
 	zlog_debug("  Type %d (%s)", ospfh->type,
 		   lookup_msg(ospf_packet_type_str, ospfh->type, NULL));
 	zlog_debug("  Packet Len %d", ntohs(ospfh->length));
-	zlog_debug("  Router ID %s", inet_ntoa(ospfh->router_id));
-	zlog_debug("  Area ID %s", inet_ntoa(ospfh->area_id));
+	zlog_debug("  Router ID %pI4", &ospfh->router_id);
+	zlog_debug("  Area ID %pI4", &ospfh->area_id);
 	zlog_debug("  Checksum 0x%x", ntohs(ospfh->checksum));
 	zlog_debug("  AuType %s",
 		   lookup_msg(ospf_auth_type_str, auth_type, NULL));

--- a/ospfd/ospf_dump_api.c
+++ b/ospfd/ospf_dump_api.c
@@ -127,8 +127,8 @@ void ospf_lsa_header_dump(struct lsa_header *lsah)
 		   ospf_options_dump(lsah->options));
 	zlog_debug("    LS type %d (%s)", lsah->type,
 		   (lsah->type ? lsah_type : "unknown type"));
-	zlog_debug("    Link State ID %s", inet_ntoa(lsah->id));
-	zlog_debug("    Advertising Router %s", inet_ntoa(lsah->adv_router));
+	zlog_debug("    Link State ID %pI4", &lsah->id);
+	zlog_debug("    Advertising Router %pI4", &lsah->adv_router);
 	zlog_debug("    LS sequence number 0x%lx",
 		   (unsigned long)ntohl(lsah->ls_seqnum));
 	zlog_debug("    LS checksum 0x%x", ntohs(lsah->checksum));

--- a/ospfd/ospf_ext.c
+++ b/ospfd/ospf_ext.c
@@ -1618,8 +1618,8 @@ static uint16_t show_vty_ext_link_rmt_itf_addr(struct vty *vty,
 	top = (struct ext_subtlv_rmt_itf_addr *)tlvh;
 
 	vty_out(vty,
-		"  Remote Interface Address Sub-TLV: Length %u\n	Address: %s\n",
-		ntohs(top->header.length), inet_ntoa(top->value));
+		"  Remote Interface Address Sub-TLV: Length %u\n	Address: %pI4\n",
+		ntohs(top->header.length), &top->value);
 
 	return TLV_SIZE(tlvh);
 }
@@ -1650,9 +1650,9 @@ static uint16_t show_vty_ext_link_lan_adj_sid(struct vty *vty,
 		(struct ext_subtlv_lan_adj_sid *)tlvh;
 
 	vty_out(vty,
-		"  LAN-Adj-SID Sub-TLV: Length %u\n\tFlags: 0x%x\n\tMT-ID:0x%x\n\tWeight: 0x%x\n\tNeighbor ID: %s\n\t%s: %u\n",
+		"  LAN-Adj-SID Sub-TLV: Length %u\n\tFlags: 0x%x\n\tMT-ID:0x%x\n\tWeight: 0x%x\n\tNeighbor ID: %pI4\n\t%s: %u\n",
 		ntohs(top->header.length), top->flags, top->mtid, top->weight,
-		inet_ntoa(top->neighbor_id),
+		&top->neighbor_id,
 		CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG) ? "Label"
 								     : "Index",
 		CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG)
@@ -1683,7 +1683,7 @@ static uint16_t show_vty_link_info(struct vty *vty, struct tlv_header *ext)
 		"	Link ID: %s\n",
 		ntohs(top->header.length), top->link_type,
 		inet_ntoa(top->link_id));
-	vty_out(vty, "	Link data: %s\n", inet_ntoa(top->link_data));
+	vty_out(vty, "	Link data: %pI4\n", &top->link_data);
 
 	tlvh = (struct tlv_header *)((char *)(ext) + TLV_HDR_SIZE
 				     + EXT_TLV_LINK_SIZE);

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -156,10 +156,9 @@ static void ospf_process_self_originated_lsa(struct ospf *ospf,
 	struct listnode *node;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"%s:LSA[Type%d:%s]: Process self-originated LSA seq 0x%x",
-			ospf_get_name(ospf), new->data->type,
-			inet_ntoa(new->data->id), ntohl(new->data->ls_seqnum));
+		zlog_debug("%s:LSA[Type%d:%pI4]: Process self-originated LSA seq 0x%x",
+			   ospf_get_name(ospf), new->data->type,
+			   &new->data->id, ntohl(new->data->ls_seqnum));
 
 	/* If we're here, we installed a self-originated LSA that we received
 	   from a neighbor, i.e. it's more recent.  We must see whether we want
@@ -275,11 +274,10 @@ int ospf_flood(struct ospf *ospf, struct ospf_neighbor *nbr,
 	   but will also be flooded as Type-5's into ABR capable links.  */
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"%s:LSA[Flooding]: start, NBR %s (%s), cur(%p), New-LSA[%s]",
-			ospf_get_name(ospf), inet_ntoa(nbr->router_id),
-			lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
-			(void *)current, dump_lsa_key(new));
+		zlog_debug("%s:LSA[Flooding]: start, NBR %pI4 (%s), cur(%p), New-LSA[%s]",
+			   ospf_get_name(ospf), &nbr->router_id,
+			   lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
+			   (void *)current, dump_lsa_key(new));
 
 	oi = nbr->oi;
 
@@ -734,9 +732,9 @@ void ospf_ls_request_add(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 	 * the common function "ospf_lsdb_add()" -- endo.
 	 */
 	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-		zlog_debug("RqstL(%lu)++, NBR(%s(%s)), LSA[%s]",
+		zlog_debug("RqstL(%lu)++, NBR(%pI4(%s)), LSA[%s]",
 			   ospf_ls_request_count(nbr),
-			   inet_ntoa(nbr->router_id),
+			   &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf), dump_lsa_key(lsa));
 
 	ospf_lsdb_add(&nbr->ls_req, lsa);
@@ -761,9 +759,9 @@ void ospf_ls_request_delete(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 	}
 
 	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING)) /* -- endo. */
-		zlog_debug("RqstL(%lu)--, NBR(%s(%s)), LSA[%s]",
+		zlog_debug("RqstL(%lu)--, NBR(%pI4(%s)), LSA[%s]",
 			   ospf_ls_request_count(nbr),
-			   inet_ntoa(nbr->router_id),
+			   &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf), dump_lsa_key(lsa));
 
 	ospf_lsdb_delete(&nbr->ls_req, lsa);
@@ -823,9 +821,9 @@ void ospf_ls_retransmit_add(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 		if (old) {
 			old->retransmit_counter--;
 			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-				zlog_debug("RXmtL(%lu)--, NBR(%s(%s)), LSA[%s]",
+				zlog_debug("RXmtL(%lu)--, NBR(%pI4(%s)), LSA[%s]",
 					   ospf_ls_retransmit_count(nbr),
-					   inet_ntoa(nbr->router_id),
+					   &nbr->router_id,
 					   ospf_get_name(nbr->oi->ospf),
 					   dump_lsa_key(old));
 			ospf_lsdb_delete(&nbr->ls_rxmt, old);
@@ -840,9 +838,9 @@ void ospf_ls_retransmit_add(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 		 * the common function "ospf_lsdb_add()" -- endo.
 		 */
 		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-			zlog_debug("RXmtL(%lu)++, NBR(%s(%s)), LSA[%s]",
+			zlog_debug("RXmtL(%lu)++, NBR(%pI4(%s)), LSA[%s]",
 				   ospf_ls_retransmit_count(nbr),
-				   inet_ntoa(nbr->router_id),
+				   &nbr->router_id,
 				   ospf_get_name(nbr->oi->ospf),
 				   dump_lsa_key(lsa));
 		ospf_lsdb_add(&nbr->ls_rxmt, lsa);
@@ -855,9 +853,9 @@ void ospf_ls_retransmit_delete(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 	if (ospf_ls_retransmit_lookup(nbr, lsa)) {
 		lsa->retransmit_counter--;
 		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING)) /* -- endo. */
-			zlog_debug("RXmtL(%lu)--, NBR(%s(%s)), LSA[%s]",
+			zlog_debug("RXmtL(%lu)--, NBR(%pI4(%s)), LSA[%s]",
 				   ospf_ls_retransmit_count(nbr),
-				   inet_ntoa(nbr->router_id),
+				   &nbr->router_id,
 				   ospf_get_name(nbr->oi->ospf),
 				   dump_lsa_key(lsa));
 		ospf_lsdb_delete(&nbr->ls_rxmt, lsa);
@@ -945,8 +943,8 @@ void ospf_lsa_flush_area(struct ospf_lsa *lsa, struct ospf_area *area)
 	   retransmissions */
 	lsa->data->ls_age = htons(OSPF_LSA_MAXAGE);
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("%s: MAXAGE set to LSA %s", __func__,
-			   inet_ntoa(lsa->data->id));
+		zlog_debug("%s: MAXAGE set to LSA %pI4", __func__,
+			   &lsa->data->id);
 	monotime(&lsa->tv_recv);
 	lsa->tv_orig = lsa->tv_recv;
 	ospf_flood_through_area(area, NULL, lsa);

--- a/ospfd/ospf_ia.c
+++ b/ospfd/ospf_ia.c
@@ -75,9 +75,8 @@ static void ospf_ia_network_route(struct ospf *ospf, struct route_table *rt,
 	struct ospf_route * or ;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"ospf_ia_network_route(): processing summary route to %s/%d",
-			inet_ntoa(p->prefix), p->prefixlen);
+		zlog_debug("ospf_ia_network_route(): processing summary route to %pFX",
+			   p);
 
 	/* Find a route to the same dest */
 	if ((rn1 = route_node_lookup(rt, (struct prefix *)p))) {
@@ -112,9 +111,8 @@ static void ospf_ia_network_route(struct ospf *ospf, struct route_table *rt,
 	}	 /*if (rn1)*/
 	else {    /* no route */
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"ospf_ia_network_route(): add new route to %s/%d",
-				inet_ntoa(p->prefix), p->prefixlen);
+			zlog_debug("ospf_ia_network_route(): add new route to %pFX",
+				   p);
 		ospf_route_add(rt, p, new_or, abr_or);
 	}
 }
@@ -129,8 +127,8 @@ static void ospf_ia_router_route(struct ospf *ospf, struct route_table *rtrs,
 	int ret;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("ospf_ia_router_route(): considering %s/%d",
-			   inet_ntoa(p->prefix), p->prefixlen);
+		zlog_debug("ospf_ia_router_route(): considering %pFX",
+			   p);
 	/* Find a route to the same dest */
 	rn = route_node_get(rtrs, (struct prefix *)p);
 

--- a/ospfd/ospf_ia.c
+++ b/ospfd/ospf_ia.c
@@ -200,8 +200,8 @@ static int process_summary_lsa(struct ospf_area *area, struct route_table *rt,
 	sl = (struct summary_lsa *)lsa->data;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("process_summary_lsa(): LS ID: %s",
-			   inet_ntoa(sl->header.id));
+		zlog_debug("process_summary_lsa(): LS ID: %pI4",
+			   &sl->header.id);
 
 	metric = GET_METRIC(sl->metric);
 
@@ -522,8 +522,8 @@ static int process_transit_summary_lsa(struct ospf_area *area,
 	sl = (struct summary_lsa *)lsa->data;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("process_transit_summaries(): LS ID: %s",
-			   inet_ntoa(lsa->data->id));
+		zlog_debug("process_transit_summaries(): LS ID: %pI4",
+			   &lsa->data->id);
 	metric = GET_METRIC(sl->metric);
 
 	if (metric == OSPF_LS_INFINITY) {

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -940,17 +940,17 @@ struct ospf_vl_data *ospf_vl_lookup(struct ospf *ospf, struct ospf_area *area,
 	struct listnode *node;
 
 	if (IS_DEBUG_OSPF_EVENT) {
-		zlog_debug("%s: Looking for %s", __func__, inet_ntoa(vl_peer));
+		zlog_debug("%s: Looking for %pI4", __func__, &vl_peer);
 		if (area)
-			zlog_debug("%s: in area %s", __func__,
-				   inet_ntoa(area->area_id));
+			zlog_debug("%s: in area %pI4", __func__,
+				   &area->area_id);
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->vlinks, node, vl_data)) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("%s: VL %s, peer %s", __func__,
+			zlog_debug("%s: VL %s, peer %pI4", __func__,
 				   vl_data->vl_oi->ifp->name,
-				   inet_ntoa(vl_data->vl_peer));
+				   &vl_data->vl_peer);
 
 		if (area
 		    && !IPV4_ADDR_SAME(&vl_data->vl_area_id, &area->area_id))
@@ -1063,9 +1063,9 @@ static int ospf_vl_set_params(struct ospf_vl_data *vl_data, struct vertex *v)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("%s: %s peer address: %s, cost: %d,%schanged",
+		zlog_debug("%s: %s peer address: %pI4, cost: %d,%schanged",
 			   __func__, vl_data->vl_oi->ifp->name,
-			   inet_ntoa(vl_data->peer_addr), voi->output_cost,
+			   &vl_data->peer_addr, voi->output_cost,
 			   (changed ? " " : " un"));
 
 	return changed;
@@ -1082,19 +1082,19 @@ void ospf_vl_up_check(struct ospf_area *area, struct in_addr rid,
 
 	if (IS_DEBUG_OSPF_EVENT) {
 		zlog_debug("ospf_vl_up_check(): Start");
-		zlog_debug("ospf_vl_up_check(): Router ID is %s",
-			   inet_ntoa(rid));
-		zlog_debug("ospf_vl_up_check(): Area is %s",
-			   inet_ntoa(area->area_id));
+		zlog_debug("ospf_vl_up_check(): Router ID is %pI4",
+			   &rid);
+		zlog_debug("ospf_vl_up_check(): Area is %pI4",
+			   &area->area_id);
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->vlinks, node, vl_data)) {
 		if (IS_DEBUG_OSPF_EVENT) {
-			zlog_debug("%s: considering VL, %s in area %s",
+			zlog_debug("%s: considering VL, %s in area %pI4",
 				   __func__, vl_data->vl_oi->ifp->name,
-				   inet_ntoa(vl_data->vl_area_id));
-			zlog_debug("%s: peer ID: %s", __func__,
-				   inet_ntoa(vl_data->vl_peer));
+				   &vl_data->vl_area_id);
+			zlog_debug("%s: peer ID: %pI4", __func__,
+				   &vl_data->vl_peer);
 		}
 
 		if (IPV4_ADDR_SAME(&vl_data->vl_peer, &rid)
@@ -1151,9 +1151,8 @@ void ospf_vl_shut_unapproved(struct ospf *ospf)
 int ospf_full_virtual_nbrs(struct ospf_area *area)
 {
 	if (IS_DEBUG_OSPF_EVENT) {
-		zlog_debug(
-			"counting fully adjacent virtual neighbors in area %s",
-			inet_ntoa(area->area_id));
+		zlog_debug("counting fully adjacent virtual neighbors in area %pI4",
+			   &area->area_id);
 		zlog_debug("there are %d of them", area->full_vls);
 	}
 

--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -223,8 +223,8 @@ static int ospf_dr_election(struct ospf_interface *oi)
 
 	new_state = ospf_ism_state(oi);
 
-	zlog_debug("DR-Election[1st]: Backup %s", inet_ntoa(BDR(oi)));
-	zlog_debug("DR-Election[1st]: DR     %s", inet_ntoa(DR(oi)));
+	zlog_debug("DR-Election[1st]: Backup %pI4", &BDR(oi));
+	zlog_debug("DR-Election[1st]: DR     %pI4", &DR(oi));
 
 	if (new_state != old_state
 	    && !(new_state == ISM_DROther && old_state < ISM_DROther)) {
@@ -233,8 +233,8 @@ static int ospf_dr_election(struct ospf_interface *oi)
 
 		new_state = ospf_ism_state(oi);
 
-		zlog_debug("DR-Election[2nd]: Backup %s", inet_ntoa(BDR(oi)));
-		zlog_debug("DR-Election[2nd]: DR     %s", inet_ntoa(DR(oi)));
+		zlog_debug("DR-Election[2nd]: Backup %pI4", &BDR(oi));
+		zlog_debug("DR-Election[2nd]: DR     %pI4", &DR(oi));
 	}
 
 	list_delete(&el_list);

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -97,10 +97,9 @@ int ospf_lsa_refresh_delay(struct ospf_lsa *lsa)
 		delay = minv.tv_sec + !!minv.tv_usec;
 
 		if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-			zlog_debug(
-				"LSA[Type%d:%s]: Refresh timer delay %d seconds",
-				lsa->data->type, inet_ntoa(lsa->data->id),
-				delay);
+			zlog_debug("LSA[Type%d:%pI4]: Refresh timer delay %d seconds",
+				   lsa->data->type, &lsa->data->id,
+				   delay);
 
 		assert(delay > 0);
 	}
@@ -280,8 +279,8 @@ struct lsa_header *ospf_lsa_data_dup(struct lsa_header *lsah)
 void ospf_lsa_data_free(struct lsa_header *lsah)
 {
 	if (IS_DEBUG_OSPF(lsa, LSA))
-		zlog_debug("LSA[Type%d:%s]: data freed %p", lsah->type,
-			   inet_ntoa(lsah->id), (void *)lsah);
+		zlog_debug("LSA[Type%d:%pI4]: data freed %p", lsah->type,
+			   &lsah->id, (void *)lsah);
 
 	XFREE(MTYPE_OSPF_LSA_DATA, lsah);
 }
@@ -626,11 +625,8 @@ static int lsa_link_ptomp_set(struct stream **s, struct ospf_interface *oi)
 						LSA_LINK_TYPE_POINTOPOINT, 0,
 						cost);
 					if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-						zlog_debug(
-							"PointToMultipoint: set link to %s",
-							inet_ntoa(
-								oi->address->u
-									.prefix4));
+						zlog_debug("PointToMultipoint: set link to %pI4",
+							   &oi->address->u.prefix4);
 				}
 
 	return links;
@@ -836,8 +832,8 @@ static struct ospf_lsa *ospf_router_lsa_originate(struct ospf_area *area)
 	ospf_flood_through_area(area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Originate router-LSA %p",
-			   new->data->type, inet_ntoa(new->data->id),
+		zlog_debug("LSA[Type%d:%pI4]: Originate router-LSA %p",
+			   new->data->type, &new->data->id,
 			   (void *)new);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -875,8 +871,8 @@ static struct ospf_lsa *ospf_router_lsa_refresh(struct ospf_lsa *lsa)
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: router-LSA refresh",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: router-LSA refresh",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -927,10 +923,9 @@ int ospf_router_lsa_update(struct ospf *ospf)
 		   First flush old LSA, then originate new. */
 		else if (!IPV4_ADDR_SAME(&lsa->data->id, &ospf->router_id)) {
 			if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-				zlog_debug(
-					"LSA[Type%d:%s]: Refresh router-LSA for Area %s",
-					lsa->data->type,
-					inet_ntoa(lsa->data->id), area_str);
+				zlog_debug("LSA[Type%d:%pI4]: Refresh router-LSA for Area %s",
+					   lsa->data->type,
+					   &lsa->data->id, area_str);
 			ospf_refresher_unregister_lsa(ospf, lsa);
 			ospf_lsa_flush_area(lsa, area);
 			ospf_lsa_unlock(&area->router_lsa_self);
@@ -1058,8 +1053,8 @@ void ospf_network_lsa_update(struct ospf_interface *oi)
 	ospf_flood_through_area(oi->area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Originate network-LSA %p",
-			   new->data->type, inet_ntoa(new->data->id),
+		zlog_debug("LSA[Type%d:%pI4]: Originate network-LSA %p",
+			   new->data->type, &new->data->id,
 			   (void *)new);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -1080,9 +1075,8 @@ static struct ospf_lsa *ospf_network_lsa_refresh(struct ospf_lsa *lsa)
 	oi = ospf_if_lookup_by_local_addr(area->ospf, NULL, lsa->data->id);
 	if (oi == NULL) {
 		if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-			zlog_debug(
-				"LSA[Type%d:%s]: network-LSA refresh: no oi found, ick, ignoring.",
-				lsa->data->type, inet_ntoa(lsa->data->id));
+			zlog_debug("LSA[Type%d:%pI4]: network-LSA refresh: no oi found, ick, ignoring.",
+				   lsa->data->type, &lsa->data->id);
 			ospf_lsa_header_dump(lsa->data);
 		}
 		return NULL;
@@ -1111,8 +1105,8 @@ static struct ospf_lsa *ospf_network_lsa_refresh(struct ospf_lsa *lsa)
 	ospf_flood_through_area(area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: network-LSA refresh",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: network-LSA refresh",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1230,8 +1224,8 @@ struct ospf_lsa *ospf_summary_lsa_originate(struct prefix_ipv4 *p,
 	ospf_flood_through_area(area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Originate summary-LSA %p",
-			   new->data->type, inet_ntoa(new->data->id),
+		zlog_debug("LSA[Type%d:%pI4]: Originate summary-LSA %p",
+			   new->data->type, &new->data->id,
 			   (void *)new);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -1266,8 +1260,8 @@ static struct ospf_lsa *ospf_summary_lsa_refresh(struct ospf *ospf,
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: summary-LSA refresh",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: summary-LSA refresh",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1373,8 +1367,8 @@ struct ospf_lsa *ospf_summary_asbr_lsa_originate(struct prefix_ipv4 *p,
 	ospf_flood_through_area(area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Originate summary-ASBR-LSA %p",
-			   new->data->type, inet_ntoa(new->data->id),
+		zlog_debug("LSA[Type%d:%pI4]: Originate summary-ASBR-LSA %p",
+			   new->data->type, &new->data->id,
 			   (void *)new);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -1407,8 +1401,8 @@ static struct ospf_lsa *ospf_summary_asbr_lsa_refresh(struct ospf *ospf,
 	ospf_flood_through_area(new->area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: summary-ASBR-LSA refresh",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: summary-ASBR-LSA refresh",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1756,9 +1750,8 @@ static struct ospf_lsa *ospf_lsa_translated_nssa_new(struct ospf *ospf,
 	if ((new = ospf_external_lsa_new(ospf, &ei, &type7->data->id))
 	    == NULL) {
 		if (IS_DEBUG_OSPF_NSSA)
-			zlog_debug(
-				"ospf_nssa_translate_originate(): Could not originate Translated Type-5 for %s",
-				inet_ntoa(ei.p.prefix));
+			zlog_debug("ospf_nssa_translate_originate(): Could not originate Translated Type-5 for %pI4",
+				   &ei.p.prefix);
 		return NULL;
 	}
 
@@ -1790,9 +1783,8 @@ struct ospf_lsa *ospf_translated_nssa_originate(struct ospf *ospf,
 
 	if ((new = ospf_lsa_translated_nssa_new(ospf, type7)) == NULL) {
 		if (IS_DEBUG_OSPF_NSSA)
-			zlog_debug(
-				"ospf_translated_nssa_originate(): Could not translate Type-7, Id %s, to Type-5",
-				inet_ntoa(type7->data->id));
+			zlog_debug("ospf_translated_nssa_originate(): Could not translate Type-7, Id %pI4, to Type-5",
+				   &type7->data->id);
 		return NULL;
 	}
 
@@ -1803,14 +1795,14 @@ struct ospf_lsa *ospf_translated_nssa_originate(struct ospf *ospf,
 			"ospf_translated_nssa_originate(): translated Type 7, installed:");
 		ospf_lsa_header_dump(new->data);
 		zlog_debug("   Network mask: %d", ip_masklen(extnew->mask));
-		zlog_debug("   Forward addr: %s",
-			   inet_ntoa(extnew->e[0].fwd_addr));
+		zlog_debug("   Forward addr: %pI4",
+			   &extnew->e[0].fwd_addr);
 	}
 
 	if ((new = ospf_lsa_install(ospf, NULL, new)) == NULL) {
 		flog_warn(EC_OSPF_LSA_INSTALL_FAILURE,
-			  "ospf_lsa_translated_nssa_originate(): Could not install LSA id %s",
-			  inet_ntoa(type7->data->id));
+			  "ospf_lsa_translated_nssa_originate(): Could not install LSA id %pI4",
+			  &type7->data->id);
 		return NULL;
 	}
 
@@ -1984,9 +1976,8 @@ struct ospf_lsa *ospf_external_lsa_originate(struct ospf *ospf,
 	/* Create new AS-external-LSA instance. */
 	if ((new = ospf_external_lsa_new(ospf, ei, NULL)) == NULL) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"LSA[Type5:%s]: Could not originate AS-external-LSA",
-				inet_ntoa(ei->p.prefix));
+			zlog_debug("LSA[Type5:%pI4]: Could not originate AS-external-LSA",
+				   &ei->p.prefix);
 		return NULL;
 	}
 
@@ -2008,8 +1999,8 @@ struct ospf_lsa *ospf_external_lsa_originate(struct ospf *ospf,
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Originate AS-external-LSA %p",
-			   new->data->type, inet_ntoa(new->data->id),
+		zlog_debug("LSA[Type%d:%pI4]: Originate AS-external-LSA %p",
+			   new->data->type, &new->data->id,
 			   (void *)new);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -2250,9 +2241,8 @@ struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *ospf,
 	/* Check the AS-external-LSA should be originated. */
 	if (!ospf_redistribute_check(ospf, ei, &changed)) {
 		if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-			zlog_debug(
-				"LSA[Type%d:%s]: Could not be refreshed, redist check fail",
-				lsa->data->type, inet_ntoa(lsa->data->id));
+			zlog_debug("LSA[Type%d:%pI4]: Could not be refreshed, redist check fail",
+				   lsa->data->type, &lsa->data->id);
 		ospf_external_lsa_flush(ospf, ei->type, &ei->p,
 					ei->ifindex /*, ei->nexthop */);
 		return NULL;
@@ -2260,9 +2250,8 @@ struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *ospf,
 
 	if (!changed && !force) {
 		if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-			zlog_debug(
-				"LSA[Type%d:%s]: Not refreshed, not changed/forced",
-				lsa->data->type, inet_ntoa(lsa->data->id));
+			zlog_debug("LSA[Type%d:%pI4]: Not refreshed, not changed/forced",
+				   lsa->data->type, &lsa->data->id);
 		return NULL;
 	}
 
@@ -2276,8 +2265,8 @@ struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *ospf,
 
 	if (new == NULL) {
 		if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-			zlog_debug("LSA[Type%d:%s]: Could not be refreshed",
-				   lsa->data->type, inet_ntoa(lsa->data->id));
+			zlog_debug("LSA[Type%d:%pI4]: Could not be refreshed",
+				   lsa->data->type, &lsa->data->id);
 		return NULL;
 	}
 
@@ -2302,8 +2291,8 @@ struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *ospf,
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: AS-external-LSA refresh",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: AS-external-LSA refresh",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -2695,8 +2684,8 @@ struct ospf_lsa *ospf_lsa_install(struct ospf *ospf, struct ospf_interface *oi,
 	 */
 	if (IS_LSA_MAXAGE(new)) {
 		if (IS_DEBUG_OSPF(lsa, LSA_INSTALL))
-			zlog_debug("LSA[Type%d:%s]: Install LSA 0x%p, MaxAge",
-				   new->data->type, inet_ntoa(new->data->id),
+			zlog_debug("LSA[Type%d:%pI4]: Install LSA 0x%p, MaxAge",
+				   new->data->type, &new->data->id,
 				   (void *)lsa);
 		ospf_lsa_maxage(ospf, lsa);
 	}
@@ -2856,10 +2845,9 @@ void ospf_lsa_maxage(struct ospf *ospf, struct ospf_lsa *lsa)
 	   and schedule the MaxAge LSA remover. */
 	if (CHECK_FLAG(lsa->flags, OSPF_LSA_IN_MAXAGE)) {
 		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-			zlog_debug(
-				"LSA[Type%d:%s]: %p already exists on MaxAge LSA list",
-				lsa->data->type, inet_ntoa(lsa->data->id),
-				(void *)lsa);
+			zlog_debug("LSA[Type%d:%pI4]: %p already exists on MaxAge LSA list",
+				   lsa->data->type, &lsa->data->id,
+				   (void *)lsa);
 		return;
 	}
 
@@ -3093,8 +3081,8 @@ struct ospf_lsa *ospf_lsa_lookup_by_header(struct ospf_area *area,
 
 	if (match == NULL)
 		if (IS_DEBUG_OSPF(lsa, LSA) == OSPF_DEBUG_LSA)
-			zlog_debug("LSA[Type%d:%s]: Lookup by header, NO MATCH",
-				   lsah->type, inet_ntoa(lsah->id));
+			zlog_debug("LSA[Type%d:%pI4]: Lookup by header, NO MATCH",
+				   lsah->type, &lsah->id);
 
 	return match;
 }
@@ -3189,9 +3177,8 @@ int ospf_lsa_flush_schedule(struct ospf *ospf, struct ospf_lsa *lsa)
 		return 0;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"LSA[Type%d:%s]: Schedule self-originated LSA to FLUSH",
-			lsa->data->type, inet_ntoa(lsa->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: Schedule self-originated LSA to FLUSH",
+			   lsa->data->type, &lsa->data->id);
 
 	/* Force given lsa's age to MaxAge. */
 	lsa->data->ls_age = htons(OSPF_LSA_MAXAGE);
@@ -3227,10 +3214,9 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 	for (ALL_LIST_ELEMENTS(ospf->areas, node, nnode, area)) {
 		if ((lsa = area->router_lsa_self) != NULL) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"LSA[Type%d:%s]: Schedule self-originated LSA to FLUSH",
-					lsa->data->type,
-					inet_ntoa(lsa->data->id));
+				zlog_debug("LSA[Type%d:%pI4]: Schedule self-originated LSA to FLUSH",
+					   lsa->data->type,
+					   &lsa->data->id);
 
 			ospf_refresher_unregister_lsa(ospf, lsa);
 			ospf_lsa_flush_area(lsa, area);
@@ -3242,10 +3228,9 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 			if ((lsa = oi->network_lsa_self) != NULL
 			    && oi->state == ISM_DR && oi->full_nbrs > 0) {
 				if (IS_DEBUG_OSPF_EVENT)
-					zlog_debug(
-						"LSA[Type%d:%s]: Schedule self-originated LSA to FLUSH",
-						lsa->data->type,
-						inet_ntoa(lsa->data->id));
+					zlog_debug("LSA[Type%d:%pI4]: Schedule self-originated LSA to FLUSH",
+						   lsa->data->type,
+						   &lsa->data->id);
 
 				ospf_refresher_unregister_lsa(
 					ospf, oi->network_lsa_self);
@@ -3510,10 +3495,9 @@ void ospf_refresher_register_lsa(struct ospf *ospf, struct ospf_lsa *lsa)
 			% (OSPF_LSA_REFRESHER_SLOTS);
 
 		if (IS_DEBUG_OSPF(lsa, LSA_REFRESH))
-			zlog_debug(
-				"LSA[Refresh:Type%d:%s]: age %d, added to index %d",
-				lsa->data->type, inet_ntoa(lsa->data->id),
-				LS_AGE(lsa), index);
+			zlog_debug("LSA[Refresh:Type%d:%pI4]: age %d, added to index %d",
+				   lsa->data->type, &lsa->data->id,
+				   LS_AGE(lsa), index);
 
 		if (!ospf->lsa_refresh_queue.qs[index])
 			ospf->lsa_refresh_queue.qs[index] = list_new();
@@ -3523,10 +3507,9 @@ void ospf_refresher_register_lsa(struct ospf *ospf, struct ospf_lsa *lsa)
 		lsa->refresh_list = index;
 
 		if (IS_DEBUG_OSPF(lsa, LSA_REFRESH))
-			zlog_debug(
-				"LSA[Refresh:Type%d:%s]: ospf_refresher_register_lsa(): setting refresh_list on lsa %p (slod %d)",
-				lsa->data->type, inet_ntoa(lsa->data->id),
-				(void *)lsa, index);
+			zlog_debug("LSA[Refresh:Type%d:%pI4]: ospf_refresher_register_lsa(): setting refresh_list on lsa %p (slod %d)",
+				   lsa->data->type, &lsa->data->id,
+				   (void *)lsa, index);
 	}
 }
 
@@ -3595,11 +3578,10 @@ int ospf_lsa_refresh_walker(struct thread *t)
 			for (ALL_LIST_ELEMENTS(refresh_list, node, nnode,
 					       lsa)) {
 				if (IS_DEBUG_OSPF(lsa, LSA_REFRESH))
-					zlog_debug(
-						"LSA[Refresh:Type%d:%s]: ospf_lsa_refresh_walker(): refresh lsa %p (slot %d)",
-						lsa->data->type,
-						inet_ntoa(lsa->data->id),
-						(void *)lsa, i);
+					zlog_debug("LSA[Refresh:Type%d:%pI4]: ospf_lsa_refresh_walker(): refresh lsa %p (slot %d)",
+						   lsa->data->type,
+						   &lsa->data->id,
+						   (void *)lsa, i);
 
 				assert(lsa->lock > 0);
 				list_delete_node(refresh_list, node);

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2114,10 +2114,8 @@ void ospf_nssa_lsa_flush(struct ospf *ospf, struct prefix_ipv4 *p)
 					      p->prefix, ospf->router_id);
 			if (!lsa) {
 				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-					zlog_debug(
-						"LSA: There is no such AS-NSSA-LSA %s/%d in LSDB",
-						inet_ntoa(p->prefix),
-						p->prefixlen);
+					zlog_debug("LSA: There is no such AS-NSSA-LSA %pFX in LSDB",
+						   p);
 				continue;
 			}
 			ospf_ls_retransmit_delete_nbr_area(area, lsa);
@@ -2137,15 +2135,14 @@ void ospf_external_lsa_flush(struct ospf *ospf, uint8_t type,
 	struct ospf_lsa *lsa;
 
 	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-		zlog_debug("LSA: Flushing AS-external-LSA %s/%d",
-			   inet_ntoa(p->prefix), p->prefixlen);
+		zlog_debug("LSA: Flushing AS-external-LSA %pFX",
+			   p);
 
 	/* First lookup LSA from LSDB. */
 	if (!(lsa = ospf_external_info_find_lsa(ospf, p))) {
 		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-			zlog_debug(
-				"LSA: There is no such AS-external-LSA %s/%d in LSDB",
-				inet_ntoa(p->prefix), p->prefixlen);
+			zlog_debug("LSA: There is no such AS-external-LSA %pFX in LSDB",
+				   p);
 		return;
 	}
 
@@ -3349,9 +3346,8 @@ struct in_addr ospf_lsa_unique_id(struct ospf *ospf, struct ospf_lsdb *lsdb,
 			(struct as_external_lsa *)lsa->data;
 		if (ip_masklen(al->mask) == p->prefixlen) {
 			if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-				zlog_debug(
-					"ospf_lsa_unique_id(): Can't get Link State ID for %s/%d",
-					inet_ntoa(p->prefix), p->prefixlen);
+				zlog_debug("ospf_lsa_unique_id(): Can't get Link State ID for %pFX",
+					   p);
 			/*	  id.s_addr = 0; */
 			id.s_addr = 0xffffffff;
 			return id;
@@ -3366,10 +3362,8 @@ struct in_addr ospf_lsa_unique_id(struct ospf *ospf, struct ospf_lsdb *lsdb,
 						     ospf->router_id);
 			if (lsa) {
 				if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-					zlog_debug(
-						"ospf_lsa_unique_id(): Can't get Link State ID for %s/%d",
-						inet_ntoa(p->prefix),
-						p->prefixlen);
+					zlog_debug("ospf_lsa_unique_id(): Can't get Link State ID for %pFX",
+						   p);
 				/* 	      id.s_addr = 0; */
 				id.s_addr = 0xffffffff;
 				return id;

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -173,8 +173,8 @@ void ospf_nbr_delete(struct ospf_neighbor *nbr)
 			rn->info = NULL;
 			route_unlock_node(rn);
 		} else
-			zlog_info("Can't find neighbor %s in the interface %s",
-				  inet_ntoa(nbr->src), IF_NAME(oi));
+			zlog_info("Can't find neighbor %pI4 in the interface %s",
+				  &nbr->src, IF_NAME(oi));
 
 		route_unlock_node(rn);
 	} else {
@@ -272,9 +272,8 @@ void ospf_nbr_add_self(struct ospf_interface *oi, struct in_addr router_id)
 	if (rn->info) {
 		/* There is already pseudo neighbor. */
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"router_id %s already present in neighbor table. node refcount %u",
-				inet_ntoa(router_id), rn->lock);
+			zlog_debug("router_id %pI4 already present in neighbor table. node refcount %u",
+				   &router_id, rn->lock);
 		route_unlock_node(rn);
 	} else
 		rn->info = oi->nbr_self;
@@ -389,9 +388,8 @@ void ospf_renegotiate_optional_capabilities(struct ospf *top)
 				continue;
 
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"Renegotiate optional capabilities with neighbor(%s)",
-					inet_ntoa(nbr->router_id));
+				zlog_debug("Renegotiate optional capabilities with neighbor(%pI4)",
+					   &nbr->router_id);
 
 			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_SeqNumberMismatch);
 		}
@@ -448,8 +446,8 @@ static struct ospf_neighbor *ospf_nbr_add(struct ospf_interface *oi,
 		nbr->crypt_seqnum = ospfh->u.crypt.crypt_seqnum;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("NSM[%s:%s]: start", IF_NAME(oi),
-			   inet_ntoa(nbr->router_id));
+		zlog_debug("NSM[%s:%pI4]: start", IF_NAME(oi),
+			   &nbr->router_id);
 
 	return nbr;
 }

--- a/ospfd/ospf_network.c
+++ b/ospfd/ospf_network.c
@@ -53,14 +53,13 @@ int ospf_if_add_allspfrouters(struct ospf *top, struct prefix *p,
 	if (ret < 0)
 		flog_err(
 			EC_LIB_SOCKET,
-			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllSPFRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
-			top->fd, inet_ntoa(p->u.prefix4), ifindex,
+			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllSPFRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
+			top->fd, &p->u.prefix4, ifindex,
 			safe_strerror(errno));
 	else {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"interface %s [%u] join AllSPFRouters Multicast group.",
-				inet_ntoa(p->u.prefix4), ifindex);
+			zlog_debug("interface %pI4 [%u] join AllSPFRouters Multicast group.",
+				   &p->u.prefix4, ifindex);
 	}
 
 	return ret;
@@ -76,14 +75,13 @@ int ospf_if_drop_allspfrouters(struct ospf *top, struct prefix *p,
 					ifindex);
 	if (ret < 0)
 		flog_err(EC_LIB_SOCKET,
-			 "can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllSPFRouters): %s",
-			 top->fd, inet_ntoa(p->u.prefix4), ifindex,
+			 "can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllSPFRouters): %s",
+			 top->fd, &p->u.prefix4, ifindex,
 			 safe_strerror(errno));
 	else {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"interface %s [%u] leave AllSPFRouters Multicast group.",
-				inet_ntoa(p->u.prefix4), ifindex);
+			zlog_debug("interface %pI4 [%u] leave AllSPFRouters Multicast group.",
+				   &p->u.prefix4, ifindex);
 	}
 
 	return ret;
@@ -101,13 +99,12 @@ int ospf_if_add_alldrouters(struct ospf *top, struct prefix *p,
 	if (ret < 0)
 		flog_err(
 			EC_LIB_SOCKET,
-			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllDRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
-			top->fd, inet_ntoa(p->u.prefix4), ifindex,
+			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllDRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
+			top->fd, &p->u.prefix4, ifindex,
 			safe_strerror(errno));
 	else
-		zlog_debug(
-			"interface %s [%u] join AllDRouters Multicast group.",
-			inet_ntoa(p->u.prefix4), ifindex);
+		zlog_debug("interface %pI4 [%u] join AllDRouters Multicast group.",
+			   &p->u.prefix4, ifindex);
 
 	return ret;
 }
@@ -122,13 +119,12 @@ int ospf_if_drop_alldrouters(struct ospf *top, struct prefix *p,
 					ifindex);
 	if (ret < 0)
 		flog_err(EC_LIB_SOCKET,
-			 "can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllDRouters): %s",
-			 top->fd, inet_ntoa(p->u.prefix4), ifindex,
+			 "can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllDRouters): %s",
+			 top->fd, &p->u.prefix4, ifindex,
 			 safe_strerror(errno));
 	else
-		zlog_debug(
-			"interface %s [%u] leave AllDRouters Multicast group.",
-			inet_ntoa(p->u.prefix4), ifindex);
+		zlog_debug("interface %pI4 [%u] leave AllDRouters Multicast group.",
+			   &p->u.prefix4, ifindex);
 
 	return ret;
 }
@@ -161,8 +157,8 @@ int ospf_if_ipmulticast(struct ospf *top, struct prefix *p, ifindex_t ifindex)
 	ret = setsockopt_ipv4_multicast_if(top->fd, p->u.prefix4, ifindex);
 	if (ret < 0)
 		flog_err(EC_LIB_SOCKET,
-			 "can't setsockopt IP_MULTICAST_IF(fd %d, addr %s, ifindex %u): %s",
-			 top->fd, inet_ntoa(p->u.prefix4), ifindex,
+			 "can't setsockopt IP_MULTICAST_IF(fd %d, addr %pI4, ifindex %u): %s",
+			 top->fd, &p->u.prefix4, ifindex,
 			 safe_strerror(errno));
 #endif
 

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -66,8 +66,8 @@ static int ospf_inactivity_timer(struct thread *thread)
 	nbr->t_inactivity = NULL;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_TIMERS))
-		zlog_debug("NSM[%s:%s:%s]: Timer (Inactivity timer expire)",
-			   IF_NAME(nbr->oi), inet_ntoa(nbr->router_id),
+		zlog_debug("NSM[%s:%pI4:%s]: Timer (Inactivity timer expire)",
+			   IF_NAME(nbr->oi), &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf));
 
 	OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_InactivityTimer);
@@ -83,8 +83,8 @@ static int ospf_db_desc_timer(struct thread *thread)
 	nbr->t_db_desc = NULL;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_TIMERS))
-		zlog_debug("NSM[%s:%s:%s]: Timer (DD Retransmit timer expire)",
-			   IF_NAME(nbr->oi), inet_ntoa(nbr->src),
+		zlog_debug("NSM[%s:%pI4:%s]: Timer (DD Retransmit timer expire)",
+			   IF_NAME(nbr->oi), &nbr->src,
 			   ospf_get_name(nbr->oi->ospf));
 
 	/* resent last send DD packet. */
@@ -389,11 +389,10 @@ static int nsm_kill_nbr(struct ospf_neighbor *nbr)
 				   nbr_nbma->v_poll);
 
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug(
-				"NSM[%s:%s:%s]: Down (PollIntervalTimer scheduled)",
-				IF_NAME(nbr->oi),
-				inet_ntoa(nbr->address.u.prefix4),
-				ospf_get_name(nbr->oi->ospf));
+			zlog_debug("NSM[%s:%pI4:%s]: Down (PollIntervalTimer scheduled)",
+				   IF_NAME(nbr->oi),
+				   &nbr->address.u.prefix4,
+				   ospf_get_name(nbr->oi->ospf));
 	}
 
 	return 0;
@@ -589,8 +588,8 @@ static void nsm_notice_state_change(struct ospf_neighbor *nbr, int next_state,
 {
 	/* Logging change of status. */
 	if (IS_DEBUG_OSPF(nsm, NSM_STATUS))
-		zlog_debug("NSM[%s:%s:%s]: State change %s -> %s (%s)",
-			   IF_NAME(nbr->oi), inet_ntoa(nbr->router_id),
+		zlog_debug("NSM[%s:%pI4:%s]: State change %s -> %s (%s)",
+			   IF_NAME(nbr->oi), &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf),
 			   lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
 			   lookup_msg(ospf_nsm_state_msg, next_state, NULL),
@@ -600,8 +599,8 @@ static void nsm_notice_state_change(struct ospf_neighbor *nbr, int next_state,
 	if (CHECK_FLAG(nbr->oi->ospf->config, OSPF_LOG_ADJACENCY_CHANGES)
 	    && (CHECK_FLAG(nbr->oi->ospf->config, OSPF_LOG_ADJACENCY_DETAIL)
 		|| (next_state == NSM_Full) || (next_state < nbr->state)))
-		zlog_notice("AdjChg: Nbr %s(%s) on %s: %s -> %s (%s)",
-			    inet_ntoa(nbr->router_id),
+		zlog_notice("AdjChg: Nbr %pI4(%s) on %s: %s -> %s (%s)",
+			    &nbr->router_id,
 			    ospf_get_name(nbr->oi->ospf), IF_NAME(nbr->oi),
 			    lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
 			    lookup_msg(ospf_nsm_state_msg, next_state, NULL),
@@ -682,12 +681,11 @@ static void nsm_change_state(struct ospf_neighbor *nbr, int state)
 		}
 
 		if (CHECK_FLAG(oi->ospf->config, OSPF_LOG_ADJACENCY_DETAIL))
-			zlog_info(
-				"%s:[%s:%s], %s -> %s): scheduling new router-LSA origination",
-				__func__, inet_ntoa(nbr->router_id),
-				ospf_get_name(oi->ospf),
-				lookup_msg(ospf_nsm_state_msg, old_state, NULL),
-				lookup_msg(ospf_nsm_state_msg, state, NULL));
+			zlog_info("%s:[%pI4:%s], %s -> %s): scheduling new router-LSA origination",
+				  __func__, &nbr->router_id,
+				  ospf_get_name(oi->ospf),
+				  lookup_msg(ospf_nsm_state_msg, old_state, NULL),
+				  lookup_msg(ospf_nsm_state_msg, state, NULL));
 
 		ospf_router_lsa_update_area(oi->area);
 
@@ -730,12 +728,11 @@ static void nsm_change_state(struct ospf_neighbor *nbr, int state)
 		nbr->dd_flags =
 			OSPF_DD_FLAG_I | OSPF_DD_FLAG_M | OSPF_DD_FLAG_MS;
 		if (CHECK_FLAG(oi->ospf->config, OSPF_LOG_ADJACENCY_DETAIL))
-			zlog_info(
-				"%s: Initializing [DD]: %s with seqnum:%x , flags:%x",
-				(oi->ospf->name) ? oi->ospf->name
-						 : VRF_DEFAULT_NAME,
-				inet_ntoa(nbr->router_id), nbr->dd_seqnum,
-				nbr->dd_flags);
+			zlog_info("%s: Initializing [DD]: %pI4 with seqnum:%x , flags:%x",
+				  (oi->ospf->name) ? oi->ospf->name
+				  : VRF_DEFAULT_NAME,
+				  &nbr->router_id, nbr->dd_seqnum,
+				  nbr->dd_flags);
 		ospf_db_desc_send(nbr);
 	}
 
@@ -759,8 +756,8 @@ int ospf_nsm_event(struct thread *thread)
 	event = THREAD_VAL(thread);
 
 	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-		zlog_debug("NSM[%s:%s:%s]: %s (%s)", IF_NAME(nbr->oi),
-			   inet_ntoa(nbr->router_id),
+		zlog_debug("NSM[%s:%pI4:%s]: %s (%s)", IF_NAME(nbr->oi),
+			   &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf),
 			   lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
 			   ospf_nsm_event_str[event]);
@@ -784,8 +781,8 @@ int ospf_nsm_event(struct thread *thread)
 			 */
 			flog_err(
 				EC_OSPF_FSM_INVALID_STATE,
-				"NSM[%s:%s:%s]: %s (%s): Warning: action tried to change next_state to %s",
-				IF_NAME(nbr->oi), inet_ntoa(nbr->router_id),
+				"NSM[%s:%pI4:%s]: %s (%s): Warning: action tried to change next_state to %s",
+				IF_NAME(nbr->oi), &nbr->router_id,
 				ospf_get_name(nbr->oi->ospf),
 				lookup_msg(ospf_nsm_state_msg, nbr->state,
 					   NULL),

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1468,9 +1468,8 @@ static int ospf_opaque_type10_lsa_originate(struct thread *t)
 	area->t_opaque_lsa_self = NULL;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"Timer[Type10-LSA]: Originate Opaque-LSAs for Area %s",
-			inet_ntoa(area->area_id));
+		zlog_debug("Timer[Type10-LSA]: Originate Opaque-LSAs for Area %pI4",
+			   &area->area_id);
 
 	rc = opaque_lsa_originate_callback(ospf_opaque_type10_funclist, area);
 
@@ -1626,8 +1625,8 @@ struct ospf_lsa *ospf_opaque_lsa_refresh(struct ospf_lsa *lsa)
 		 * LSA from the routing domain.
 		 */
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("LSA[Type%d:%s]: Flush stray Opaque-LSA",
-				   lsa->data->type, inet_ntoa(lsa->data->id));
+			zlog_debug("LSA[Type%d:%pI4]: Flush stray Opaque-LSA",
+				   lsa->data->type, &lsa->data->id);
 
 		lsa->data->ls_age = htons(OSPF_LSA_MAXAGE);
 		ospf_lsa_flush(ospf, lsa);
@@ -1701,8 +1700,8 @@ void ospf_opaque_lsa_reoriginate_schedule(void *lsa_type_dependent,
 		if ((top = area->ospf) == NULL) {
 			flog_warn(
 				EC_OSPF_LSA,
-				"ospf_opaque_lsa_reoriginate_schedule: AREA(%s) -> TOP?",
-				inet_ntoa(area->area_id));
+				"ospf_opaque_lsa_reoriginate_schedule: AREA(%pI4) -> TOP?",
+				&area->area_id);
 			goto out;
 		}
 		if (!list_isempty(ospf_opaque_type10_funclist)
@@ -1710,8 +1709,8 @@ void ospf_opaque_lsa_reoriginate_schedule(void *lsa_type_dependent,
 		    && area->t_opaque_lsa_self != NULL) {
 			flog_warn(
 				EC_OSPF_LSA,
-				"Type-10 Opaque-LSA (opaque_type=%u): Common origination for AREA(%s) has already started",
-				opaque_type, inet_ntoa(area->area_id));
+				"Type-10 Opaque-LSA (opaque_type=%u): Common origination for AREA(%pI4) has already started",
+				opaque_type, &area->area_id);
 			goto out;
 		}
 		func = ospf_opaque_type10_lsa_reoriginate_timer;
@@ -1926,9 +1925,8 @@ static int ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"Timer[Type10-LSA]: Re-originate Opaque-LSAs (opaque-type=%u) for Area %s",
-			oipt->opaque_type, inet_ntoa(area->area_id));
+		zlog_debug("Timer[Type10-LSA]: Re-originate Opaque-LSAs (opaque-type=%u) for Area %pI4",
+			   oipt->opaque_type, &area->area_id);
 
 	rc = (*functab->lsa_originator)(area);
 out:

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -521,8 +521,8 @@ static void initialize_params(struct ospf_router_info *ori)
 		if (!list_isempty(OspfRI.area_info))
 			list_delete_all_node(OspfRI.area_info);
 		for (ALL_LIST_ELEMENTS(top->areas, node, nnode, area)) {
-			zlog_debug("RI (%s): Add area %s to Router Information",
-				__func__, inet_ntoa(area->area_id));
+			zlog_debug("RI (%s): Add area %pI4 to Router Information",
+				   __func__, &area->area_id);
 			new = XCALLOC(MTYPE_OSPF_ROUTER_INFO,
 				sizeof(struct ospf_ri_area_info));
 			new->area = area;
@@ -762,9 +762,8 @@ static struct ospf_lsa *ospf_router_info_lsa_new(struct ospf_area *area)
 	lsa_id.s_addr = htonl(tmp);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-		zlog_debug(
-			"LSA[Type%d:%s]: Create an Opaque-LSA/ROUTER INFORMATION instance",
-			lsa_type, inet_ntoa(lsa_id));
+		zlog_debug("LSA[Type%d:%pI4]: Create an Opaque-LSA/ROUTER INFORMATION instance",
+			   lsa_type, &lsa_id);
 
 	top = ospf_lookup_by_vrf_id(VRF_DEFAULT);
 
@@ -841,9 +840,8 @@ static int ospf_router_info_lsa_originate_as(void *arg)
 	ospf_flood_through_as(top, NULL /*nbr */, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug(
-			"LSA[Type%d:%s]: Originate Opaque-LSA/ROUTER INFORMATION",
-			new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: Originate Opaque-LSA/ROUTER INFORMATION",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -910,9 +908,8 @@ static int ospf_router_info_lsa_originate_area(void *arg)
 	ospf_flood_through_area(ai->area, NULL /*nbr */, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug(
-			"LSA[Type%d:%s]: Originate Opaque-LSA/ROUTER INFORMATION",
-			new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: Originate Opaque-LSA/ROUTER INFORMATION",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1061,9 +1058,8 @@ static struct ospf_lsa *ospf_router_info_lsa_refresh(struct ospf_lsa *lsa)
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug(
-			"LSA[Type%d:%s]: Refresh Opaque-LSA/ROUTER INFORMATION",
-			new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: Refresh Opaque-LSA/ROUTER INFORMATION",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1215,11 +1211,11 @@ static uint16_t show_vty_pce_subtlv_address(struct vty *vty,
 
 	if (ntohs(top->address.type) == PCE_ADDRESS_TYPE_IPV4) {
 		if (vty != NULL)
-			vty_out(vty, "  PCE Address: %s\n",
-				inet_ntoa(top->address.value));
+			vty_out(vty, "  PCE Address: %pI4\n",
+				&top->address.value);
 		else
-			zlog_debug("    PCE Address: %s",
-				   inet_ntoa(top->address.value));
+			zlog_debug("    PCE Address: %pI4",
+				   &top->address.value);
 	} else {
 		/* TODO: Add support to IPv6 with inet_ntop() */
 		if (vty != NULL)
@@ -1256,9 +1252,9 @@ static uint16_t show_vty_pce_subtlv_domain(struct vty *vty,
 	if (ntohs(top->type) == PCE_DOMAIN_TYPE_AREA) {
 		tmp.s_addr = top->value;
 		if (vty != NULL)
-			vty_out(vty, "  PCE domain Area: %s\n", inet_ntoa(tmp));
+			vty_out(vty, "  PCE domain Area: %pI4\n", &tmp);
 		else
-			zlog_debug("    PCE domain Area: %s", inet_ntoa(tmp));
+			zlog_debug("    PCE domain Area: %pI4", &tmp);
 	} else {
 		if (vty != NULL)
 			vty_out(vty, "  PCE domain AS: %d\n",
@@ -1280,10 +1276,10 @@ static uint16_t show_vty_pce_subtlv_neighbor(struct vty *vty,
 	if (ntohs(top->type) == PCE_DOMAIN_TYPE_AREA) {
 		tmp.s_addr = top->value;
 		if (vty != NULL)
-			vty_out(vty, "  PCE neighbor Area: %s\n",
-				inet_ntoa(tmp));
+			vty_out(vty, "  PCE neighbor Area: %pI4\n",
+				&tmp);
 		else
-			zlog_debug("    PCE neighbor Area: %s", inet_ntoa(tmp));
+			zlog_debug("    PCE neighbor Area: %pI4", &tmp);
 	} else {
 		if (vty != NULL)
 			vty_out(vty, "  PCE neighbor AS: %d\n",
@@ -1504,8 +1500,8 @@ static void ospf_router_info_config_write_router(struct vty *vty)
 	if (OspfRI.pce_info.enabled) {
 
 		if (pce->pce_address.header.type != 0)
-			vty_out(vty, "  pce address %s\n",
-				inet_ntoa(pce->pce_address.address.value));
+			vty_out(vty, "  pce address %pI4\n",
+				&pce->pce_address.address.value);
 
 		if (pce->pce_cap_flag.header.type != 0)
 			vty_out(vty, "  pce flag 0x%x\n",
@@ -1515,8 +1511,9 @@ static void ospf_router_info_config_write_router(struct vty *vty)
 			if (domain->header.type != 0) {
 				if (domain->type == PCE_DOMAIN_TYPE_AREA) {
 					tmp.s_addr = domain->value;
-					vty_out(vty, "  pce domain area %s\n",
-						inet_ntoa(tmp));
+					vty_out(vty,
+						"  pce domain area %pI4\n",
+						&tmp);
 				} else {
 					vty_out(vty, "  pce domain as %d\n",
 						ntohl(domain->value));
@@ -1528,8 +1525,9 @@ static void ospf_router_info_config_write_router(struct vty *vty)
 			if (neighbor->header.type != 0) {
 				if (neighbor->type == PCE_DOMAIN_TYPE_AREA) {
 					tmp.s_addr = neighbor->value;
-					vty_out(vty, "  pce neighbor area %s\n",
-						inet_ntoa(tmp));
+					vty_out(vty,
+						"  pce neighbor area %pI4\n",
+						&tmp);
 				} else {
 					vty_out(vty, "  pce neighbor as %d\n",
 						ntohl(neighbor->value));

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -364,8 +364,8 @@ void ospf_intra_add_router(struct route_table *rt, struct vertex *v,
 	apply_mask_ipv4(&p);
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("ospf_intra_add_router: talking about %s/%d",
-			   inet_ntoa(p.prefix), p.prefixlen);
+		zlog_debug("ospf_intra_add_router: talking about %pFX",
+			   &p);
 
 	rn = route_node_get(rt, (struct prefix *)&p);
 
@@ -467,8 +467,8 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 	apply_mask_ipv4(&p);
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("ospf_intra_add_stub(): processing route to %s/%d",
-			   inet_ntoa(p.prefix), p.prefixlen);
+		zlog_debug("ospf_intra_add_stub(): processing route to %pFX",
+			   &p);
 
 	/* (1) Calculate the distance D of stub network from the root.  D is
 	   equal to the distance from the root to the router vertex
@@ -843,9 +843,8 @@ void ospf_prune_unreachable_networks(struct route_table *rt)
 			or = rn->info;
 			if (listcount(or->paths) == 0) {
 				if (IS_DEBUG_OSPF_EVENT)
-					zlog_debug("Pruning route to %s/%d",
-						   inet_ntoa(rn->p.u.prefix4),
-						   rn->p.prefixlen);
+					zlog_debug("Pruning route to %pFX",
+						   &rn->p);
 
 				ospf_route_free(or);
 				rn->info = NULL;
@@ -936,9 +935,8 @@ int ospf_add_discard_route(struct ospf *ospf, struct route_table *rt,
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"ospf_add_discard_route(): adding %s/%d",
-			inet_ntoa(p->prefix), p->prefixlen);
+		zlog_debug("ospf_add_discard_route(): adding %pFX",
+			   p);
 
 	new_or = ospf_route_new();
 	new_or->type = OSPF_DESTINATION_DISCARD;
@@ -961,9 +959,8 @@ void ospf_delete_discard_route(struct ospf *ospf, struct route_table *rt,
 	struct ospf_route * or ;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"ospf_delete_discard_route(): deleting %s/%d",
-			inet_ntoa(p->prefix), p->prefixlen);
+		zlog_debug("ospf_delete_discard_route(): deleting %pFX",
+			   p);
 
 	rn = route_node_lookup(rt, (struct prefix *)p);
 

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -307,8 +307,8 @@ void ospf_intra_add_router(struct route_table *rt, struct vertex *v,
 	lsa = (struct router_lsa *)v->lsa;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("ospf_intra_add_router: LS ID: %s",
-			   inet_ntoa(lsa->header.id));
+		zlog_debug("ospf_intra_add_router: LS ID: %pI4",
+			   &lsa->header.id);
 
 	if (!OSPF_IS_AREA_BACKBONE(area))
 		ospf_vl_up_check(area, lsa->header.id, v);
@@ -488,8 +488,8 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 	if (parent_is_root && link->link_data.s_addr == 0xffffffff
 	    && ospf_if_lookup_by_local_addr(area->ospf, NULL, link->link_id)) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("%s: ignoring host route %s/32 to self.",
-				   __func__, inet_ntoa(link->link_id));
+			zlog_debug("%s: ignoring host route %pI4/32 to self.",
+				   __func__, &link->link_id);
 		return;
 	}
 
@@ -642,8 +642,8 @@ void ospf_route_table_dump(struct route_table *rt)
 					   or->cost);
 				for (ALL_LIST_ELEMENTS_RO(or->paths, pnode,
 							  path))
-					zlog_debug("  -> %s",
-						   inet_ntoa(path->nexthop));
+					zlog_debug("  -> %pI4",
+						   &path->nexthop);
 			} else
 				zlog_debug("R %-18pI4 %-15pI4 %s %d",
 					   &rn->p.u.prefix4,
@@ -872,11 +872,10 @@ void ospf_prune_unreachable_routers(struct route_table *rtrs)
 		for (ALL_LIST_ELEMENTS(paths, node, nnode, or)) {
 			if (listcount(or->paths) == 0) {
 				if (IS_DEBUG_OSPF_EVENT) {
-					zlog_debug("Pruning route to rtr %s",
-						   inet_ntoa(rn->p.u.prefix4));
-					zlog_debug(
-						"               via area %s",
-						inet_ntoa(or->u.std.area_id));
+					zlog_debug("Pruning route to rtr %pI4",
+						   &rn->p.u.prefix4);
+					zlog_debug("               via area %pI4",
+						   &or->u.std.area_id);
 				}
 
 				listnode_delete(paths, or);
@@ -886,8 +885,8 @@ void ospf_prune_unreachable_routers(struct route_table *rtrs)
 
 		if (listcount(paths) == 0) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug("Pruning router node %s",
-					   inet_ntoa(rn->p.u.prefix4));
+				zlog_debug("Pruning router node %pI4",
+					   &rn->p.u.prefix4);
 
 			list_delete(&paths);
 			rn->info = NULL;

--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -2455,8 +2455,8 @@ static void ospfTrapNbrStateChange(struct ospf_neighbor *on)
 
 	ospf_nbr_state_message(on, msgbuf, sizeof(msgbuf));
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_info("%s: trap sent: %s now %s", __func__,
-			  inet_ntoa(on->address.u.prefix4), msgbuf);
+		zlog_info("%s: trap sent: %pI4 now %s", __func__,
+			  &on->address.u.prefix4, msgbuf);
 
 	oid_copy_addr(index, &(on->address.u.prefix4), IN_ADDR_SIZE);
 	index[IN_ADDR_SIZE] = 0;
@@ -2508,8 +2508,8 @@ static void ospfTrapIfStateChange(struct ospf_interface *oi)
 	oid index[sizeof(oid) * (IN_ADDR_SIZE + 1)];
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_info("%s: trap sent: %s now %s", __func__,
-			  inet_ntoa(oi->address->u.prefix4),
+		zlog_info("%s: trap sent: %pI4 now %s", __func__,
+			  &oi->address->u.prefix4,
 			  lookup_msg(ospf_ism_state_msg, oi->state, NULL));
 
 	oid_copy_addr(index, &(oi->address->u.prefix4), IN_ADDR_SIZE);

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -1637,8 +1637,8 @@ void ospf_sr_config_write_router(struct vty *vty)
 			for (ALL_LIST_ELEMENTS_RO(OspfSR.self->ext_prefix, node,
 						  srp)) {
 				vty_out(vty,
-					" segment-routing prefix %s/%u index %u%s\n",
-					inet_ntoa(srp->prefv4.prefix),
+					" segment-routing prefix %pI4/%u index %u%s\n",
+					&srp->prefv4.prefix,
 					srp->prefv4.prefixlen, srp->sid,
 					CHECK_FLAG(srp->flags,
 						   EXT_SUBTLV_PREFIX_SID_NPFLG)
@@ -2372,8 +2372,8 @@ DEFUN (show_ip_opsf_srdb,
 		json_object_object_add(json, "srNodes", json_node_array);
 	} else {
 		vty_out(vty,
-			"\n\t\tOSPF Segment Routing database for ID %s\n\n",
-			inet_ntoa(OspfSR.self->adv_router));
+			"\n\t\tOSPF Segment Routing database for ID %pI4\n\n",
+			&OspfSR.self->adv_router);
 	}
 
 	if (argv_find(argv, argc, "self-originate", &idx)) {

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1042,9 +1042,8 @@ static void ospf_mpls_te_nsm_change(struct ospf_neighbor *nbr, int old_state)
 	}
 
 	if (IS_DEBUG_OSPF_TE)
-		zlog_debug(
-			"MPLS-TE (%s): Add Link-ID %s for interface %s ",
-			__func__, inet_ntoa(lp->link_id.value), oi->ifp->name);
+		zlog_debug("MPLS-TE (%s): Add Link-ID %pI4 for interface %s ",
+			   __func__, &lp->link_id.value, oi->ifp->name);
 
 	/* Try to Schedule LSA */
 	if (OspfMplsTE.enabled) {
@@ -1186,9 +1185,8 @@ static struct ospf_lsa *ospf_mpls_te_lsa_new(struct ospf *ospf,
 	}
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-		zlog_debug(
-			"LSA[Type%d:%s]: Create an Opaque-LSA/MPLS-TE instance",
-			lsa_type, inet_ntoa(lsa_id));
+		zlog_debug("LSA[Type%d:%pI4]: Create an Opaque-LSA/MPLS-TE instance",
+			   lsa_type, &lsa_id);
 
 	/* Set opaque-LSA body fields. */
 	ospf_mpls_te_lsa_body_set(s, lp);
@@ -1245,10 +1243,9 @@ static int ospf_mpls_te_lsa_originate1(struct ospf_area *area,
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 		char area_id[INET_ADDRSTRLEN];
 		strlcpy(area_id, inet_ntoa(area->area_id), sizeof(area_id));
-		zlog_debug(
-			"LSA[Type%d:%s]: Originate Opaque-LSA/MPLS-TE: Area(%s), Link(%s)",
-			new->data->type, inet_ntoa(new->data->id), area_id,
-			lp->ifp->name);
+		zlog_debug("LSA[Type%d:%pI4]: Originate Opaque-LSA/MPLS-TE: Area(%s), Link(%s)",
+			   new->data->type, &new->data->id, area_id,
+			   lp->ifp->name);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1346,9 +1343,8 @@ static int ospf_mpls_te_lsa_originate2(struct ospf *top,
 	ospf_flood_through_as(top, NULL /*nbr */, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug(
-			"LSA[Type%d:%s]: Originate Opaque-LSA/MPLS-TE Inter-AS",
-			new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: Originate Opaque-LSA/MPLS-TE Inter-AS",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1490,8 +1486,8 @@ static struct ospf_lsa *ospf_mpls_te_lsa_refresh(struct ospf_lsa *lsa)
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Refresh Opaque-LSA/MPLS-TE",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: Refresh Opaque-LSA/MPLS-TE",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1593,9 +1589,9 @@ static uint16_t show_vty_router_addr(struct vty *vty, struct tlv_header *tlvh)
 	struct te_tlv_router_addr *top = (struct te_tlv_router_addr *)tlvh;
 
 	if (vty != NULL)
-		vty_out(vty, "  Router-Address: %s\n", inet_ntoa(top->value));
+		vty_out(vty, "  Router-Address: %pI4\n", &top->value);
 	else
-		zlog_debug("    Router-Address: %s", inet_ntoa(top->value));
+		zlog_debug("    Router-Address: %pI4", &top->value);
 
 	return TLV_SIZE(tlvh);
 }
@@ -1648,9 +1644,9 @@ static uint16_t show_vty_link_subtlv_link_id(struct vty *vty,
 
 	top = (struct te_link_subtlv_link_id *)tlvh;
 	if (vty != NULL)
-		vty_out(vty, "  Link-ID: %s\n", inet_ntoa(top->value));
+		vty_out(vty, "  Link-ID: %pI4\n", &top->value);
 	else
-		zlog_debug("    Link-ID: %s", inet_ntoa(top->value));
+		zlog_debug("    Link-ID: %pI4", &top->value);
 
 	return TLV_SIZE(tlvh);
 }
@@ -1671,11 +1667,11 @@ static uint16_t show_vty_link_subtlv_lclif_ipaddr(struct vty *vty,
 
 	for (i = 0; i < n; i++) {
 		if (vty != NULL)
-			vty_out(vty, "    #%d: %s\n", i,
-				inet_ntoa(top->value[i]));
+			vty_out(vty, "    #%d: %pI4\n", i,
+				&top->value[i]);
 		else
-			zlog_debug("      #%d: %s", i,
-				   inet_ntoa(top->value[i]));
+			zlog_debug("      #%d: %pI4", i,
+				   &top->value[i]);
 	}
 	return TLV_SIZE(tlvh);
 }
@@ -1695,11 +1691,11 @@ static uint16_t show_vty_link_subtlv_rmtif_ipaddr(struct vty *vty,
 
 	for (i = 0; i < n; i++) {
 		if (vty != NULL)
-			vty_out(vty, "    #%d: %s\n", i,
-				inet_ntoa(top->value[i]));
+			vty_out(vty, "    #%d: %pI4\n", i,
+				&top->value[i]);
 		else
-			zlog_debug("      #%d: %s", i,
-				   inet_ntoa(top->value[i]));
+			zlog_debug("      #%d: %pI4", i,
+				   &top->value[i]);
 	}
 	return TLV_SIZE(tlvh);
 }
@@ -1811,15 +1807,15 @@ static uint16_t show_vty_link_subtlv_lrrid(struct vty *vty,
 	top = (struct te_link_subtlv_lrrid *)tlvh;
 
 	if (vty != NULL) {
-		vty_out(vty, "  Local  TE Router ID: %s\n",
-			inet_ntoa(top->local));
-		vty_out(vty, "  Remote TE Router ID: %s\n",
-			inet_ntoa(top->remote));
+		vty_out(vty, "  Local  TE Router ID: %pI4\n",
+			&top->local);
+		vty_out(vty, "  Remote TE Router ID: %pI4\n",
+			&top->remote);
 	} else {
-		zlog_debug("    Local  TE Router ID: %s",
-			   inet_ntoa(top->local));
-		zlog_debug("    Remote TE Router ID: %s",
-			   inet_ntoa(top->remote));
+		zlog_debug("    Local  TE Router ID: %pI4",
+			   &top->local);
+		zlog_debug("    Remote TE Router ID: %pI4",
+			   &top->remote);
 	}
 
 	return TLV_SIZE(tlvh);
@@ -1855,11 +1851,11 @@ static uint16_t show_vty_link_subtlv_rip(struct vty *vty,
 	top = (struct te_link_subtlv_rip *)tlvh;
 
 	if (vty != NULL)
-		vty_out(vty, "  Inter-AS TE Remote ASBR IP address: %s\n",
-			inet_ntoa(top->value));
+		vty_out(vty, "  Inter-AS TE Remote ASBR IP address: %pI4\n",
+			&top->value);
 	else
-		zlog_debug("    Inter-AS TE Remote ASBR IP address: %s",
-			   inet_ntoa(top->value));
+		zlog_debug("    Inter-AS TE Remote ASBR IP address: %pI4",
+			   &top->value);
 
 	return TLV_SIZE(tlvh);
 }
@@ -2160,15 +2156,15 @@ static void ospf_mpls_te_config_write_router(struct vty *vty)
 
 	if (OspfMplsTE.enabled) {
 		vty_out(vty, " mpls-te on\n");
-		vty_out(vty, " mpls-te router-address %s\n",
-			inet_ntoa(OspfMplsTE.router_addr.value));
+		vty_out(vty, " mpls-te router-address %pI4\n",
+			&OspfMplsTE.router_addr.value);
 	}
 
 	if (OspfMplsTE.inter_as == AS)
 		vty_out(vty, "  mpls-te inter-as as\n");
 	if (OspfMplsTE.inter_as == Area)
-		vty_out(vty, "  mpls-te inter-as area %s \n",
-			inet_ntoa(OspfMplsTE.interas_areaid));
+		vty_out(vty, "  mpls-te inter-as area %pI4 \n",
+			&OspfMplsTE.interas_areaid);
 
 	return;
 }

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -920,7 +920,7 @@ ospf_find_vl_data(struct ospf *ospf, struct ospf_vl_config_data *vl_config)
 
 	if (area->external_routing != OSPF_AREA_DEFAULT) {
 		if (vl_config->area_id_fmt == OSPF_AREA_ID_FMT_DOTTEDQUAD)
-			vty_out(vty, "Area %s is %s\n", inet_ntoa(area_id),
+			vty_out(vty, "Area %pI4 is %s\n", &area_id,
 				area->external_routing == OSPF_AREA_NSSA
 					? "nssa"
 					: "stub");
@@ -1715,9 +1715,8 @@ DEFUN (ospf_area_default_cost,
 	p.prefix.s_addr = OSPF_DEFAULT_DESTINATION;
 	p.prefixlen = 0;
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"ospf_abr_announce_stub_defaults(): announcing 0.0.0.0/0 to area %s",
-			inet_ntoa(area->area_id));
+		zlog_debug("ospf_abr_announce_stub_defaults(): announcing 0.0.0.0/0 to area %pI4",
+			   &area->area_id);
 	ospf_abr_announce_network_to_area(&p, area->default_cost, area);
 
 	return CMD_SUCCESS;
@@ -1758,9 +1757,8 @@ DEFUN (no_ospf_area_default_cost,
 	p.prefix.s_addr = OSPF_DEFAULT_DESTINATION;
 	p.prefixlen = 0;
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"ospf_abr_announce_stub_defaults(): announcing 0.0.0.0/0 to area %s",
-			inet_ntoa(area->area_id));
+		zlog_debug("ospf_abr_announce_stub_defaults(): announcing 0.0.0.0/0 to area %pI4",
+			   &area->area_id);
 	ospf_abr_announce_network_to_area(&p, area->default_cost, area);
 
 
@@ -2648,7 +2646,7 @@ static void show_ip_ospf_area(struct vty *vty, struct ospf_area *area,
 
 	/* Show Area ID. */
 	if (!use_json)
-		vty_out(vty, " Area ID: %s", inet_ntoa(area->area_id));
+		vty_out(vty, " Area ID: %pI4", &area->area_id);
 
 	/* Show Area type/mode. */
 	if (OSPF_IS_AREA_BACKBONE(area)) {
@@ -2975,8 +2973,8 @@ static int show_ip_ospf_common(struct vty *vty, struct ospf *ospf,
 		json_object_string_add(json_vrf, "routerId",
 				       inet_ntoa(ospf->router_id));
 	} else {
-		vty_out(vty, " OSPF Routing Process, Router ID: %s\n",
-			inet_ntoa(ospf->router_id));
+		vty_out(vty, " OSPF Routing Process, Router ID: %pI4\n",
+			&ospf->router_id);
 	}
 
 	/* Graceful shutdown */
@@ -4526,8 +4524,8 @@ static int show_ip_ospf_neighbor_all_common(struct vty *vty, struct ospf *ospf,
 						"-", nbr_nbma->priority, "Down",
 						"-");
 					vty_out(vty,
-						"%-32s %-20s %5d %5d %5d\n",
-						inet_ntoa(nbr_nbma->addr),
+						"%-32pI4 %-20s %5d %5d %5d\n",
+						&nbr_nbma->addr,
 						IF_NAME(oi), 0, 0, 0);
 				}
 			}
@@ -4821,8 +4819,8 @@ static void show_ip_ospf_nbr_nbma_detail_sub(struct vty *vty,
 		json_object_string_add(json_sub, "ifaceAddress",
 				       inet_ntoa(nbr_nbma->addr));
 	else
-		vty_out(vty, " interface address %s\n",
-			inet_ntoa(nbr_nbma->addr));
+		vty_out(vty, " interface address %pI4\n",
+			&nbr_nbma->addr);
 
 	/* Show Area ID. */
 	if (use_json) {
@@ -4922,8 +4920,8 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 		    && nbr->router_id.s_addr == INADDR_ANY)
 			vty_out(vty, " Neighbor %s,", "-");
 		else
-			vty_out(vty, " Neighbor %s,",
-				inet_ntoa(nbr->router_id));
+			vty_out(vty, " Neighbor %pI4,",
+				&nbr->router_id);
 	}
 
 	/* Show interface address. */
@@ -4931,8 +4929,8 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 		json_object_string_add(json_neigh, "ifaceAddress",
 				       inet_ntoa(nbr->address.u.prefix4));
 	else
-		vty_out(vty, " interface address %s\n",
-			inet_ntoa(nbr->address.u.prefix4));
+		vty_out(vty, " interface address %pI4\n",
+			&nbr->address.u.prefix4);
 
 	/* Show Area ID. */
 	if (use_json) {
@@ -5009,14 +5007,14 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 		json_object_string_add(json_neigh, "routerDesignatedId",
 				       inet_ntoa(nbr->d_router));
 	else
-		vty_out(vty, "    DR is %s,", inet_ntoa(nbr->d_router));
+		vty_out(vty, "    DR is %pI4,", &nbr->d_router);
 
 	/* Show Backup Designated Rotuer ID. */
 	if (use_json)
 		json_object_string_add(json_neigh, "routerDesignatedBackupId",
 				       inet_ntoa(nbr->bd_router));
 	else
-		vty_out(vty, " BDR is %s\n", inet_ntoa(nbr->bd_router));
+		vty_out(vty, " BDR is %pI4\n", &nbr->bd_router);
 
 	/* Show options. */
 	if (use_json) {
@@ -5721,9 +5719,9 @@ static int show_lsa_summary(struct vty *vty, struct ospf_lsa *lsa, int self)
 		/* If self option is set, check LSA self flag. */
 		if (self == 0 || IS_LSA_SELF(lsa)) {
 			/* LSA common part show. */
-			vty_out(vty, "%-15s ", inet_ntoa(lsa->data->id));
-			vty_out(vty, "%-15s %4d 0x%08lx 0x%04x",
-				inet_ntoa(lsa->data->adv_router), LS_AGE(lsa),
+			vty_out(vty, "%-15pI4 ", &lsa->data->id);
+			vty_out(vty, "%-15pI4 %4d 0x%08lx 0x%04x",
+				&lsa->data->adv_router, LS_AGE(lsa),
 				(unsigned long)ntohl(lsa->data->ls_seqnum),
 				ntohs(lsa->data->checksum));
 			/* LSA specific part show. */
@@ -5830,10 +5828,10 @@ static void show_ip_ospf_database_header(struct vty *vty, struct ospf_lsa *lsa)
 	}
 	vty_out(vty, "  LS Type: %s\n",
 		lookup_msg(ospf_lsa_type_msg, lsa->data->type, NULL));
-	vty_out(vty, "  Link State ID: %s %s\n", inet_ntoa(lsa->data->id),
+	vty_out(vty, "  Link State ID: %pI4 %s\n", &lsa->data->id,
 		lookup_msg(ospf_link_state_id_type_msg, lsa->data->type, NULL));
-	vty_out(vty, "  Advertising Router: %s\n",
-		inet_ntoa(lsa->data->adv_router));
+	vty_out(vty, "  Advertising Router: %pI4\n",
+		&lsa->data->adv_router);
 	vty_out(vty, "  LS Seq Number: %08lx\n",
 		(unsigned long)ntohl(lsa->data->ls_seqnum));
 	vty_out(vty, "  Checksum: 0x%04x\n", ntohs(lsa->data->checksum));
@@ -5871,10 +5869,11 @@ static void show_ip_ospf_database_router_links(struct vty *vty,
 
 		vty_out(vty, "    Link connected to: %s\n",
 			link_type_desc[type]);
-		vty_out(vty, "     (Link ID) %s: %s\n", link_id_desc[type],
-			inet_ntoa(rl->link[i].link_id));
-		vty_out(vty, "     (Link Data) %s: %s\n", link_data_desc[type],
-			inet_ntoa(rl->link[i].link_data));
+		vty_out(vty, "     (Link ID) %s: %pI4\n", link_id_desc[type],
+			&rl->link[i].link_id);
+		vty_out(vty, "     (Link Data) %s: %pI4\n",
+			link_data_desc[type],
+			&rl->link[i].link_data);
 		vty_out(vty, "      Number of TOS metrics: 0\n");
 		vty_out(vty, "       TOS 0 Metric: %d\n",
 			ntohs(rl->link[i].metric));
@@ -5914,8 +5913,8 @@ static int show_network_lsa_detail(struct vty *vty, struct ospf_lsa *lsa)
 		length = ntohs(lsa->data->length) - OSPF_LSA_HEADER_SIZE - 4;
 
 		for (i = 0; length > 0; i++, length -= 4)
-			vty_out(vty, "        Attached Router: %s\n",
-				inet_ntoa(nl->routers[i]));
+			vty_out(vty, "        Attached Router: %pI4\n",
+				&nl->routers[i]);
 
 		vty_out(vty, "\n");
 	}
@@ -5974,8 +5973,8 @@ static int show_as_external_lsa_detail(struct vty *vty, struct ospf_lsa *lsa)
 		vty_out(vty, "        TOS: 0\n");
 		vty_out(vty, "        Metric: %d\n",
 			GET_METRIC(al->e[0].metric));
-		vty_out(vty, "        Forward Address: %s\n",
-			inet_ntoa(al->e[0].fwd_addr));
+		vty_out(vty, "        Forward Address: %pI4\n",
+			&al->e[0].fwd_addr);
 
 		vty_out(vty,
 			"        External Route Tag: %" ROUTE_TAG_PRI "\n\n",
@@ -6026,8 +6025,8 @@ static int show_as_nssa_lsa_detail(struct vty *vty, struct ospf_lsa *lsa)
 		vty_out(vty, "        TOS: 0\n");
 		vty_out(vty, "        Metric: %d\n",
 			GET_METRIC(al->e[0].metric));
-		vty_out(vty, "        NSSA: Forward Address: %s\n",
-			inet_ntoa(al->e[0].fwd_addr));
+		vty_out(vty, "        NSSA: Forward Address: %pI4\n",
+			&al->e[0].fwd_addr);
 
 		vty_out(vty,
 			"        External Route Tag: %" ROUTE_TAG_PRI "\n\n",
@@ -6249,10 +6248,10 @@ static void show_ip_ospf_database_maxage(struct vty *vty, struct ospf *ospf)
 
 		if ((lsa = rn->info) != NULL) {
 			vty_out(vty, "Link type: %d\n", lsa->data->type);
-			vty_out(vty, "Link State ID: %s\n",
-				inet_ntoa(lsa->data->id));
-			vty_out(vty, "Advertising Router: %s\n",
-				inet_ntoa(lsa->data->adv_router));
+			vty_out(vty, "Link State ID: %pI4\n",
+				&lsa->data->id);
+			vty_out(vty, "Advertising Router: %pI4\n",
+				&lsa->data->adv_router);
 			vty_out(vty, "LSA lock count: %d\n", lsa->lock);
 			vty_out(vty, "\n");
 		}
@@ -6290,8 +6289,8 @@ static int show_ip_ospf_database_common(struct vty *vty, struct ospf *ospf,
 
 	ospf_show_vrf_name(ospf, vty, NULL, use_vrf);
 
-	vty_out(vty, "\n       OSPF Router with ID (%s)\n\n",
-		inet_ntoa(ospf->router_id));
+	vty_out(vty, "\n       OSPF Router with ID (%pI4)\n\n",
+		&ospf->router_id);
 
 	/* Show all LSA. */
 	if (argc == arg_base + 4) {
@@ -6540,8 +6539,8 @@ static int show_ip_ospf_database_type_adv_router_common(struct vty *vty,
 
 	ospf_show_vrf_name(ospf, vty, NULL, use_vrf);
 
-	vty_out(vty, "\n       OSPF Router with ID (%s)\n\n",
-		inet_ntoa(ospf->router_id));
+	vty_out(vty, "\n       OSPF Router with ID (%pI4)\n\n",
+		&ospf->router_id);
 
 	/* Set database type to show. */
 	if (strncmp(argv[arg_base + idx_type]->text, "r", 1) == 0)
@@ -8988,9 +8987,9 @@ static void show_ip_ospf_route_network(struct vty *vty, struct ospf *ospf,
 						inet_ntoa(or->u.std.area_id));
 				} else {
 					vty_out(vty,
-						"N IA %-18s    [%d] area: %s\n",
+						"N IA %-18s    [%d] area: %pI4\n",
 						buf1, or->cost,
-						inet_ntoa(or->u.std.area_id));
+						&or->u.std.area_id);
 				}
 			} else if (or->type == OSPF_DESTINATION_DISCARD) {
 				if (json) {
@@ -9014,9 +9013,10 @@ static void show_ip_ospf_route_network(struct vty *vty, struct ospf *ospf,
 					json_route, "area",
 					inet_ntoa(or->u.std.area_id));
 			} else {
-				vty_out(vty, "N    %-18s    [%d] area: %s\n",
+				vty_out(vty,
+					"N    %-18s    [%d] area: %pI4\n",
 					buf1, or->cost,
-					inet_ntoa(or->u.std.area_id));
+					&or->u.std.area_id);
 			}
 			break;
 		default:
@@ -9075,10 +9075,9 @@ static void show_ip_ospf_route_network(struct vty *vty, struct ospf *ospf,
 									ospf->vrf_id));
 						} else {
 							vty_out(vty,
-								"%24s   via %s, %s\n",
+								"%24s   via %pI4, %s\n",
 								"",
-								inet_ntoa(
-									path->nexthop),
+								&path->nexthop,
 								ifindex2ifname(
 									path->ifindex,
 									ospf->vrf_id));
@@ -9121,8 +9120,8 @@ static void show_ip_ospf_route_router(struct vty *vty, struct ospf *ospf,
 					       json_route);
 			json_object_string_add(json_route, "routeType", "R ");
 		} else {
-			vty_out(vty, "R    %-15s    ",
-				inet_ntoa(rn->p.u.prefix4));
+			vty_out(vty, "R    %-15pI4    ",
+				&rn->p.u.prefix4);
 		}
 
 		for (ALL_LIST_ELEMENTS_RO((struct list *)rn->info, node, or)) {
@@ -9150,11 +9149,11 @@ static void show_ip_ospf_route_router(struct vty *vty, struct ospf *ospf,
 							       "routerType",
 							       "asbr");
 			} else {
-				vty_out(vty, "%s [%d] area: %s",
+				vty_out(vty, "%s [%d] area: %pI4",
 					(or->path_type == OSPF_PATH_INTER_AREA
 						 ? "IA"
 						 : "  "),
-					or->cost, inet_ntoa(or->u.std.area_id));
+					or->cost, &or->u.std.area_id);
 				/* Show flags. */
 				vty_out(vty, "%s%s\n",
 					(or->u.std.flags & ROUTER_LSA_BORDER
@@ -9214,10 +9213,9 @@ static void show_ip_ospf_route_router(struct vty *vty, struct ospf *ospf,
 									ospf->vrf_id));
 						} else {
 							vty_out(vty,
-								"%24s   via %s, %s\n",
+								"%24s   via %pI4, %s\n",
 								"",
-								inet_ntoa(
-									path->nexthop),
+								&path->nexthop,
 								ifindex2ifname(
 									path->ifindex,
 									ospf->vrf_id));
@@ -9339,10 +9337,9 @@ static void show_ip_ospf_route_external(struct vty *vty, struct ospf *ospf,
 								ospf->vrf_id));
 					} else {
 						vty_out(vty,
-							"%24s   via %s, %s\n",
+							"%24s   via %pI4, %s\n",
 							"",
-							inet_ntoa(
-								path->nexthop),
+							&path->nexthop,
 							ifindex2ifname(
 								path->ifindex,
 								ospf->vrf_id));
@@ -9688,8 +9685,8 @@ DEFUN (show_ip_ospf_vrfs,
 			json_object_object_add(json_vrfs, name, json_vrf);
 
 		} else {
-			vty_out(vty, "%-25s  %-5d  %-16s  \n", name,
-				ospf->vrf_id, inet_ntoa(ospf->router_id));
+			vty_out(vty, "%-25s  %-5d  %-16pI4  \n", name,
+				ospf->vrf_id, &ospf->router_id);
 		}
 	}
 
@@ -10092,8 +10089,8 @@ static int config_write_ospf_area(struct vty *vty, struct ospf *ospf)
 
 				if (CHECK_FLAG(range->flags,
 					       OSPF_AREA_RANGE_SUBSTITUTE))
-					vty_out(vty, " substitute %s/%d",
-						inet_ntoa(range->subst_addr),
+					vty_out(vty, " substitute %pI4/%d",
+						&range->subst_addr,
 						range->subst_masklen);
 
 				vty_out(vty, "\n");
@@ -10127,7 +10124,7 @@ static int config_write_ospf_nbr_nbma(struct vty *vty, struct ospf *ospf)
 	/* Static Neighbor configuration print. */
 	for (rn = route_top(ospf->nbr_nbma); rn; rn = route_next(rn))
 		if ((nbr_nbma = rn->info)) {
-			vty_out(vty, " neighbor %s", inet_ntoa(nbr_nbma->addr));
+			vty_out(vty, " neighbor %pI4", &nbr_nbma->addr);
 
 			if (nbr_nbma->priority
 			    != OSPF_NEIGHBOR_PRIORITY_DEFAULT)
@@ -10171,21 +10168,22 @@ static int config_write_virtual_link(struct vty *vty, struct ospf *ospf)
 			    || OSPF_IF_PARAM(oi, transmit_delay)
 				       != OSPF_TRANSMIT_DELAY_DEFAULT)
 				vty_out(vty,
-					" area %s virtual-link %s hello-interval %d retransmit-interval %d transmit-delay %d dead-interval %d\n",
-					buf, inet_ntoa(vl_data->vl_peer),
+					" area %s virtual-link %pI4 hello-interval %d retransmit-interval %d transmit-delay %d dead-interval %d\n",
+					buf, &vl_data->vl_peer,
 					OSPF_IF_PARAM(oi, v_hello),
 					OSPF_IF_PARAM(oi, retransmit_interval),
 					OSPF_IF_PARAM(oi, transmit_delay),
 					OSPF_IF_PARAM(oi, v_wait));
 			else
-				vty_out(vty, " area %s virtual-link %s\n", buf,
-					inet_ntoa(vl_data->vl_peer));
+				vty_out(vty, " area %s virtual-link %pI4\n",
+					buf,
+					&vl_data->vl_peer);
 			/* Auth key */
 			if (IF_DEF_PARAMS(vl_data->vl_oi->ifp)->auth_simple[0]
 			    != '\0')
 				vty_out(vty,
-					" area %s virtual-link %s authentication-key %s\n",
-					buf, inet_ntoa(vl_data->vl_peer),
+					" area %s virtual-link %pI4 authentication-key %s\n",
+					buf, &vl_data->vl_peer,
 					IF_DEF_PARAMS(vl_data->vl_oi->ifp)
 						->auth_simple);
 			/* md5 keys */
@@ -10194,8 +10192,8 @@ static int config_write_virtual_link(struct vty *vty, struct ospf *ospf)
 					     ->auth_crypt,
 				     n2, ck))
 				vty_out(vty,
-					" area %s virtual-link %s message-digest-key %d md5 %s\n",
-					buf, inet_ntoa(vl_data->vl_peer),
+					" area %s virtual-link %pI4 message-digest-key %d md5 %s\n",
+					buf, &vl_data->vl_peer,
 					ck->key_id, ck->auth_key);
 		}
 	}

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3460,9 +3460,8 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 						    "ipAddressPrefixlen",
 						    oi->address->prefixlen);
 			} else
-				vty_out(vty, "  Internet Address %s/%d,",
-					inet_ntoa(oi->address->u.prefix4),
-					oi->address->prefixlen);
+				vty_out(vty, "  Internet Address %pFX,",
+					oi->address);
 
 			/* For Vlinks, showing the peer address is
 			 * probably more informative than the local
@@ -5741,8 +5740,7 @@ static int show_lsa_summary(struct vty *vty, struct ospf_lsa *lsa, int self)
 				p.prefixlen = ip_masklen(sl->mask);
 				apply_mask_ipv4(&p);
 
-				vty_out(vty, " %s/%d", inet_ntoa(p.prefix),
-					p.prefixlen);
+				vty_out(vty, " %pFX", &p);
 				break;
 			case OSPF_AS_EXTERNAL_LSA:
 			case OSPF_AS_NSSA_LSA:
@@ -5753,11 +5751,11 @@ static int show_lsa_summary(struct vty *vty, struct ospf_lsa *lsa, int self)
 				p.prefixlen = ip_masklen(asel->mask);
 				apply_mask_ipv4(&p);
 
-				vty_out(vty, " %s %s/%d [0x%lx]",
+				vty_out(vty, " %s %pFX [0x%lx]",
 					IS_EXTERNAL_METRIC(asel->e[0].tos)
 						? "E2"
 						: "E1",
-					inet_ntoa(p.prefix), p.prefixlen,
+					&p,
 					(unsigned long)ntohl(
 						asel->e[0].route_tag));
 				break;
@@ -9256,8 +9254,8 @@ static void show_ip_ospf_route_external(struct vty *vty, struct ospf *ospf,
 
 		char buf1[19];
 
-		snprintf(buf1, sizeof(buf1), "%s/%d",
-			 inet_ntoa(rn->p.u.prefix4), rn->p.prefixlen);
+		snprintfrr(buf1, sizeof(buf1), "%pFX",
+		           &rn->p);
 		json_route = json_object_new_object();
 		if (json) {
 			json_object_object_add(json, buf1, json_route);
@@ -10007,8 +10005,8 @@ static int config_write_network_area(struct vty *vty, struct ospf *ospf)
 						 n->area_id.s_addr));
 
 			/* Network print. */
-			vty_out(vty, " network %s/%d area %s\n",
-				inet_ntoa(rn->p.u.prefix4), rn->p.prefixlen,
+			vty_out(vty, " network %pFX area %s\n",
+				&rn->p,
 				buf);
 		}
 
@@ -10080,9 +10078,8 @@ static int config_write_ospf_area(struct vty *vty, struct ospf *ospf)
 			if (rn1->info) {
 				struct ospf_area_range *range = rn1->info;
 
-				vty_out(vty, " area %s range %s/%d", buf,
-					inet_ntoa(rn1->p.u.prefix4),
-					rn1->p.prefixlen);
+				vty_out(vty, " area %s range %pFX", buf,
+					&rn1->p);
 
 				if (range->cost_config
 				    != OSPF_AREA_RANGE_COST_UNSPEC)
@@ -10315,9 +10312,8 @@ static int config_write_ospf_distance(struct vty *vty, struct ospf *ospf)
 
 	for (rn = route_top(ospf->distance_table); rn; rn = route_next(rn))
 		if ((odistance = rn->info) != NULL) {
-			vty_out(vty, " distance %d %s/%d %s\n",
-				odistance->distance, inet_ntoa(rn->p.u.prefix4),
-				rn->p.prefixlen,
+			vty_out(vty, " distance %d %pFX %s\n",
+				odistance->distance, &rn->p,
 				odistance->access_list ? odistance->access_list
 						       : "");
 		}

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -100,8 +100,8 @@ void ospf_router_id_update(struct ospf *ospf)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("Router-ID[OLD:%s]: Update",
-			   inet_ntoa(ospf->router_id));
+		zlog_debug("Router-ID[OLD:%pI4]: Update",
+			   &ospf->router_id);
 
 	router_id_old = ospf->router_id;
 
@@ -120,8 +120,8 @@ void ospf_router_id_update(struct ospf *ospf)
 		router_id = ospf->router_id_zebra;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("Router-ID[OLD:%s]: Update to %s",
-			   inet_ntoa(ospf->router_id), inet_ntoa(router_id));
+		zlog_debug("Router-ID[OLD:%pI4]: Update to %pI4",
+			   &ospf->router_id, &router_id);
 
 	if (!IPV4_ADDR_SAME(&router_id_old, &router_id)) {
 
@@ -159,8 +159,8 @@ void ospf_router_id_update(struct ospf *ospf)
 
 		ospf->router_id = router_id;
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("Router-ID[NEW:%s]: Update",
-				   inet_ntoa(ospf->router_id));
+			zlog_debug("Router-ID[NEW:%pI4]: Update",
+				   &ospf->router_id);
 
 		/* Flush (inline) all external LSAs which now match the new
 		   router-id,
@@ -1320,11 +1320,10 @@ void ospf_if_update(struct ospf *ospf, struct interface *ifp)
 		return;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"%s: interface %s ifp->vrf_id %u ospf vrf %s vrf_id %u router_id %s",
-			__func__, ifp->name, ifp->vrf_id,
-			ospf_vrf_id_to_name(ospf->vrf_id), ospf->vrf_id,
-			inet_ntoa(ospf->router_id));
+		zlog_debug("%s: interface %s ifp->vrf_id %u ospf vrf %s vrf_id %u router_id %pI4",
+			   __func__, ifp->name, ifp->vrf_id,
+			   ospf_vrf_id_to_name(ospf->vrf_id), ospf->vrf_id,
+			   &ospf->router_id);
 
 	/* OSPF must be ready. */
 	if (!ospf_is_ready(ospf))
@@ -1361,16 +1360,16 @@ static void ospf_area_type_set(struct ospf_area *area, int type)
 
 	if (area->external_routing == type) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("Area[%s]: Types are the same, ignored.",
-				   inet_ntoa(area->area_id));
+			zlog_debug("Area[%pI4]: Types are the same, ignored.",
+				   &area->area_id);
 		return;
 	}
 
 	area->external_routing = type;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("Area[%s]: Configured as %s",
-			   inet_ntoa(area->area_id),
+		zlog_debug("Area[%pI4]: Configured as %s",
+			   &area->area_id,
 			   lookup_msg(ospf_area_type_msg, type, NULL));
 
 	switch (area->external_routing) {

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -621,7 +621,6 @@ DEFPY (show_pbr,
 static void vty_show_pbrms(struct vty *vty,
 			   const struct pbr_map_sequence *pbrms, bool detail)
 {
-	char buf[PREFIX_STRLEN];
 	char rbuf[64];
 
 	if (pbrms->reason)
@@ -639,11 +638,11 @@ static void vty_show_pbrms(struct vty *vty,
 			pbrms->reason ? rbuf : "Valid");
 
 	if (pbrms->src)
-		vty_out(vty, "        SRC Match: %s\n",
-			prefix2str(pbrms->src, buf, sizeof(buf)));
+		vty_out(vty, "        SRC Match: %pFX\n",
+			pbrms->src);
 	if (pbrms->dst)
-		vty_out(vty, "        DST Match: %s\n",
-			prefix2str(pbrms->dst, buf, sizeof(buf)));
+		vty_out(vty, "        DST Match: %pFX\n",
+			pbrms->dst);
 	if (pbrms->dsfield & PBR_DSFIELD_DSCP)
 		vty_out(vty, "        DSCP Match: %u\n",
 			(pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2);
@@ -1031,17 +1030,15 @@ static int pbr_vty_map_config_write_sequence(struct vty *vty,
 					     struct pbr_map *pbrm,
 					     struct pbr_map_sequence *pbrms)
 {
-	char buff[PREFIX_STRLEN];
-
 	vty_out(vty, "pbr-map %s seq %u\n", pbrm->name, pbrms->seqno);
 
 	if (pbrms->src)
-		vty_out(vty, " match src-ip %s\n",
-			prefix2str(pbrms->src, buff, sizeof(buff)));
+		vty_out(vty, " match src-ip %pFX\n",
+			pbrms->src);
 
 	if (pbrms->dst)
-		vty_out(vty, " match dst-ip %s\n",
-			prefix2str(pbrms->dst, buff, sizeof(buff)));
+		vty_out(vty, " match dst-ip %pFX\n",
+			pbrms->dst);
 
 	if (pbrms->dsfield & PBR_DSFIELD_DSCP)
 		vty_out(vty, " match dscp %u\n",

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -379,13 +379,10 @@ static void pim_g2rp_timer_start(struct bsm_rpinfo *bsrp, int hold_time)
 	}
 	THREAD_OFF(bsrp->g2rp_timer);
 	if (PIM_DEBUG_BSM) {
-		char buf[48];
-
-		zlog_debug(
-			"%s : starting g2rp timer for grp: %s - rp: %s with timeout  %d secs(Actual Hold time : %d secs)",
-			__func__, prefix2str(&bsrp->bsgrp_node->group, buf, 48),
-			inet_ntoa(bsrp->rp_address), hold_time,
-			bsrp->rp_holdtime);
+		zlog_debug("%s : starting g2rp timer for grp: %pFX - rp: %pI4 with timeout  %d secs(Actual Hold time : %d secs)",
+			   __func__, &bsrp->bsgrp_node->group,
+			   &bsrp->rp_address, hold_time,
+			   bsrp->rp_holdtime);
 	}
 
 	thread_add_timer(router->master, pim_on_g2rp_timer, bsrp, hold_time,
@@ -404,12 +401,10 @@ static void pim_g2rp_timer_stop(struct bsm_rpinfo *bsrp)
 		return;
 
 	if (PIM_DEBUG_BSM) {
-		char buf[48];
-
-		zlog_debug("%s : stopping g2rp timer for grp: %s - rp: %s",
+		zlog_debug("%s : stopping g2rp timer for grp: %pFX - rp: %pI4",
 			   __func__,
-			   prefix2str(&bsrp->bsgrp_node->group, buf, 48),
-			   inet_ntoa(bsrp->rp_address));
+			   &bsrp->bsgrp_node->group,
+			   &bsrp->rp_address);
 	}
 
 	THREAD_OFF(bsrp->g2rp_timer);
@@ -617,7 +612,6 @@ static void pim_bsm_update(struct pim_instance *pim, struct in_addr bsr,
 
 	if (bsr.s_addr != pim->global_scope.current_bsr.s_addr) {
 		struct prefix nht_p;
-		char buf[PREFIX2STR_BUFFER];
 		bool is_bsr_tracking = true;
 
 		/* De-register old BSR and register new BSR with Zebra NHT */
@@ -627,10 +621,8 @@ static void pim_bsm_update(struct pim_instance *pim, struct in_addr bsr,
 		if (pim->global_scope.current_bsr.s_addr != INADDR_ANY) {
 			nht_p.u.prefix4 = pim->global_scope.current_bsr;
 			if (PIM_DEBUG_BSM) {
-				prefix2str(&nht_p, buf, sizeof(buf));
-				zlog_debug(
-					"%s: Deregister BSR addr %s with Zebra NHT",
-					__func__, buf);
+				zlog_debug("%s: Deregister BSR addr %pFX with Zebra NHT",
+					   __func__, &nht_p);
 			}
 			pim_delete_tracked_nexthop(pim, &nht_p, NULL, NULL,
 						   is_bsr_tracking);
@@ -638,10 +630,8 @@ static void pim_bsm_update(struct pim_instance *pim, struct in_addr bsr,
 
 		nht_p.u.prefix4 = bsr;
 		if (PIM_DEBUG_BSM) {
-			prefix2str(&nht_p, buf, sizeof(buf));
-			zlog_debug(
-				"%s: NHT Register BSR addr %s with Zebra NHT",
-				__func__, buf);
+			zlog_debug("%s: NHT Register BSR addr %pFX with Zebra NHT",
+				   __func__, &nht_p);
 		}
 
 		memset(&pnc, 0, sizeof(struct pim_nexthop_cache));

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -210,8 +210,8 @@ static void pim_show_assert_helper(struct vty *vty,
 	pim_time_uptime(uptime, sizeof(uptime), now - ch->ifassert_creation);
 	pim_time_timer_to_mmss(timer, sizeof(timer), ch->t_ifassert_timer);
 
-	vty_out(vty, "%-16s %-15s %-15s %-15s %-6s %-15s %-8s %-5s\n",
-		ch->interface->name, inet_ntoa(ifaddr), ch_src_str, ch_grp_str,
+	vty_out(vty, "%-16s %-15pI4 %-15s %-15s %-6s %-15s %-8s %-5s\n",
+		ch->interface->name, &ifaddr, ch_src_str, ch_grp_str,
 		pim_ifchannel_ifassert_name(ch->ifassert_state), winner_str,
 		uptime, timer);
 }
@@ -251,8 +251,8 @@ static void pim_show_assert_internal_helper(struct vty *vty,
 
 	pim_inet4_dump("<ch_src?>", ch->sg.src, ch_src_str, sizeof(ch_src_str));
 	pim_inet4_dump("<ch_grp?>", ch->sg.grp, ch_grp_str, sizeof(ch_grp_str));
-	vty_out(vty, "%-16s %-15s %-15s %-15s %-3s %-3s %-3s %-4s\n",
-		ch->interface->name, inet_ntoa(ifaddr), ch_src_str, ch_grp_str,
+	vty_out(vty, "%-16s %-15pI4 %-15s %-15s %-3s %-3s %-3s %-4s\n",
+		ch->interface->name, &ifaddr, ch_src_str, ch_grp_str,
 		PIM_IF_FLAG_TEST_COULD_ASSERT(ch->flags) ? "yes" : "no",
 		pim_macro_ch_could_assert_eval(ch) ? "yes" : "no",
 		PIM_IF_FLAG_TEST_ASSERT_TRACKING_DESIRED(ch->flags) ? "yes"
@@ -304,8 +304,8 @@ static void pim_show_assert_metric_helper(struct vty *vty,
 	pim_inet4_dump("<ch_grp?>", ch->sg.grp, ch_grp_str, sizeof(ch_grp_str));
 	pim_inet4_dump("<addr?>", am.ip_address, addr_str, sizeof(addr_str));
 
-	vty_out(vty, "%-16s %-15s %-15s %-15s %-3s %4u %6u %-15s\n",
-		ch->interface->name, inet_ntoa(ifaddr), ch_src_str, ch_grp_str,
+	vty_out(vty, "%-16s %-15pI4 %-15s %-15s %-3s %4u %6u %-15s\n",
+		ch->interface->name, &ifaddr, ch_src_str, ch_grp_str,
 		am.rpt_bit_flag ? "yes" : "no", am.metric_preference,
 		am.route_metric, addr_str);
 }
@@ -361,8 +361,8 @@ static void pim_show_assert_winner_metric_helper(struct vty *vty,
 	else
 		snprintf(metr_str, sizeof(metr_str), "%6u", am->route_metric);
 
-	vty_out(vty, "%-16s %-15s %-15s %-15s %-3s %-4s %-6s %-15s\n",
-		ch->interface->name, inet_ntoa(ifaddr), ch_src_str, ch_grp_str,
+	vty_out(vty, "%-16s %-15pI4 %-15s %-15s %-3s %-4s %-6s %-15s\n",
+		ch->interface->name, &ifaddr, ch_src_str, ch_grp_str,
 		am->rpt_bit_flag ? "yes" : "no", pref_str, metr_str, addr_str);
 }
 
@@ -626,13 +626,13 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 				}
 			} else {
 				vty_out(vty,
-					"%-16s  %5s  %15s  %d  %7s  %11s  %8s\n",
+					"%-16s  %5s  %15pI4  %d  %7s  %11s  %8s\n",
 					ifp->name,
 					if_is_up(ifp)
 						? (igmp->mtrace_only ? "mtrc"
 								     : "up")
 						: "down",
-					inet_ntoa(igmp->ifaddr),
+					&igmp->ifaddr,
 					pim_ifp->igmp_version,
 					igmp->t_igmp_query_timer ? "local"
 								 : "other",
@@ -1732,8 +1732,8 @@ static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 		} else
 			json_object_object_add(json_grp, ch_src_str, json_row);
 	} else {
-		vty_out(vty, "%-16s %-15s %-15s %-15s %-10s %8s %-6s %5s\n",
-			ch->interface->name, inet_ntoa(ifaddr), ch_src_str,
+		vty_out(vty, "%-16s %-15pI4 %-15s %-15s %-10s %8s %-6s %5s\n",
+			ch->interface->name, &ifaddr, ch_src_str,
 			ch_grp_str,
 			pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->flags),
 			uptime, expire, prune);
@@ -2337,8 +2337,8 @@ static void pim_show_neighbors_secondary(struct pim_instance *pim,
 				prefix2str(p, neigh_sec_str,
 					   sizeof(neigh_sec_str));
 
-				vty_out(vty, "%-16s %-15s %-15s %-15s\n",
-					ifp->name, inet_ntoa(ifaddr),
+				vty_out(vty, "%-16s %-15pI4 %-15s %-15s\n",
+					ifp->name, &ifaddr,
 					neigh_src_str, neigh_sec_str);
 			}
 		}
@@ -2989,9 +2989,9 @@ static int pim_print_pnc_cache_walkcb(struct hash_bucket *bucket, void *arg)
 		first_ifindex = nh_node->ifindex;
 		ifp = if_lookup_by_index(first_ifindex, pim->vrf_id);
 
-		vty_out(vty, "%-15s ", inet_ntoa(pnc->rpf.rpf_addr.u.prefix4));
+		vty_out(vty, "%-15pI4 ", &pnc->rpf.rpf_addr.u.prefix4);
 		vty_out(vty, "%-16s ", ifp ? ifp->name : "NULL");
-		vty_out(vty, "%s ", inet_ntoa(nh_node->gate.ipv4));
+		vty_out(vty, "%pI4 ", &nh_node->gate.ipv4);
 		vty_out(vty, "\n");
 	}
 	return CMD_SUCCESS;
@@ -5720,8 +5720,8 @@ static void show_multicast_interfaces(struct pim_instance *pim, struct vty *vty,
 			json_object_object_add(json, ifp->name, json_row);
 		} else {
 			vty_out(vty,
-				"%-16s %-15s %3d %3d %7lu %7lu %10lu %10lu\n",
-				ifp->name, inet_ntoa(ifaddr), ifp->ifindex,
+				"%-16s %-15pI4 %3d %3d %7lu %7lu %10lu %10lu\n",
+				ifp->name, &ifaddr, ifp->ifindex,
 				pim_ifp->mroute_vif_index,
 				(unsigned long)vreq.icount,
 				(unsigned long)vreq.ocount,

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -519,10 +519,8 @@ void pim_if_addr_add(struct connected *ifc)
 		return;
 
 	if (PIM_DEBUG_ZEBRA) {
-		char buf[BUFSIZ];
-		prefix2str(ifc->address, buf, BUFSIZ);
-		zlog_debug("%s: %s ifindex=%d connected IP address %s %s",
-			   __func__, ifp->name, ifp->ifindex, buf,
+		zlog_debug("%s: %s ifindex=%d connected IP address %pFX %s",
+			   __func__, ifp->name, ifp->ifindex, ifc->address,
 			   CHECK_FLAG(ifc->flags, ZEBRA_IFA_SECONDARY)
 				   ? "secondary"
 				   : "primary");
@@ -716,10 +714,8 @@ void pim_if_addr_del(struct connected *ifc, int force_prim_as_any)
 	zassert(ifp);
 
 	if (PIM_DEBUG_ZEBRA) {
-		char buf[BUFSIZ];
-		prefix2str(ifc->address, buf, BUFSIZ);
-		zlog_debug("%s: %s ifindex=%d disconnected IP address %s %s",
-			   __func__, ifp->name, ifp->ifindex, buf,
+		zlog_debug("%s: %s ifindex=%d disconnected IP address %pFX %s",
+			   __func__, ifp->name, ifp->ifindex, ifc->address,
 			   CHECK_FLAG(ifc->flags, ZEBRA_IFA_SECONDARY)
 				   ? "secondary"
 				   : "primary");

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -62,10 +62,10 @@ static int igmp_sock_open(struct in_addr ifaddr, struct interface *ifp,
 			if (!pim_socket_join(fd, group, ifaddr, ifp->ifindex))
 				++join;
 		} else {
-			zlog_warn(
-				"%s %s: IGMP socket fd=%d interface %s: could not solve %s to group address: errno=%d: %s",
-				__FILE__, __func__, fd, inet_ntoa(ifaddr),
-				PIM_ALL_ROUTERS, errno, safe_strerror(errno));
+			zlog_warn("%s %s: IGMP socket fd=%d interface %pI4: could not solve %s to group address: errno=%d: %s",
+				  __FILE__, __func__, fd, &ifaddr,
+				  PIM_ALL_ROUTERS, errno,
+				  safe_strerror(errno));
 		}
 	}
 
@@ -78,10 +78,9 @@ static int igmp_sock_open(struct in_addr ifaddr, struct interface *ifp,
 		if (!pim_socket_join(fd, group, ifaddr, ifp->ifindex))
 			++join;
 	} else {
-		zlog_warn(
-			"%s %s: IGMP socket fd=%d interface %s: could not solve %s to group address: errno=%d: %s",
-			__FILE__, __func__, fd, inet_ntoa(ifaddr),
-			PIM_ALL_SYSTEMS, errno, safe_strerror(errno));
+		zlog_warn("%s %s: IGMP socket fd=%d interface %pI4: could not solve %s to group address: errno=%d: %s",
+			  __FILE__, __func__, fd, &ifaddr,
+			  PIM_ALL_SYSTEMS, errno, safe_strerror(errno));
 	}
 
 	if (inet_aton(PIM_ALL_IGMP_ROUTERS, &group)) {
@@ -89,10 +88,9 @@ static int igmp_sock_open(struct in_addr ifaddr, struct interface *ifp,
 			++join;
 		}
 	} else {
-		zlog_warn(
-			"%s %s: IGMP socket fd=%d interface %s: could not solve %s to group address: errno=%d: %s",
-			__FILE__, __func__, fd, inet_ntoa(ifaddr),
-			PIM_ALL_IGMP_ROUTERS, errno, safe_strerror(errno));
+		zlog_warn("%s %s: IGMP socket fd=%d interface %pI4: could not solve %s to group address: errno=%d: %s",
+			  __FILE__, __func__, fd, &ifaddr,
+			  PIM_ALL_IGMP_ROUTERS, errno, safe_strerror(errno));
 	}
 
 	if (!join) {
@@ -117,8 +115,8 @@ static void igmp_sock_dump(array_t *igmp_sock_array)
 
 		struct igmp_sock *igmp = array_get(igmp_sock_array, i);
 
-		zlog_debug("%s %s: [%d/%d] igmp_addr=%s fd=%d", __FILE__,
-			   __func__, i, size, inet_ntoa(igmp->ifaddr),
+		zlog_debug("%s %s: [%d/%d] igmp_addr=%pI4 fd=%d", __FILE__,
+			   __func__, i, size, &igmp->ifaddr,
 			   igmp->fd);
 	}
 }
@@ -700,10 +698,9 @@ static void sock_close(struct igmp_sock *igmp)
 
 	if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
 		if (igmp->t_igmp_read) {
-			zlog_debug(
-				"Cancelling READ event on IGMP socket %s fd=%d on interface %s",
-				inet_ntoa(igmp->ifaddr), igmp->fd,
-				igmp->interface->name);
+			zlog_debug("Cancelling READ event on IGMP socket %pI4 fd=%d on interface %s",
+				   &igmp->ifaddr, igmp->fd,
+				   igmp->interface->name);
 		}
 	}
 	THREAD_OFF(igmp->t_igmp_read);
@@ -711,14 +708,14 @@ static void sock_close(struct igmp_sock *igmp)
 	if (close(igmp->fd)) {
 		flog_err(
 			EC_LIB_SOCKET,
-			"Failure closing IGMP socket %s fd=%d on interface %s: errno=%d: %s",
-			inet_ntoa(igmp->ifaddr), igmp->fd,
+			"Failure closing IGMP socket %pI4 fd=%d on interface %s: errno=%d: %s",
+			&igmp->ifaddr, igmp->fd,
 			igmp->interface->name, errno, safe_strerror(errno));
 	}
 
 	if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
-		zlog_debug("Deleted IGMP socket %s fd=%d on interface %s",
-			   inet_ntoa(igmp->ifaddr), igmp->fd,
+		zlog_debug("Deleted IGMP socket %pI4 fd=%d on interface %s",
+			   &igmp->ifaddr, igmp->fd,
 			   igmp->interface->name);
 	}
 }
@@ -901,9 +898,8 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	pim_ifp = ifp->info;
 
 	if (PIM_DEBUG_IGMP_TRACE) {
-		zlog_debug(
-			"Creating IGMP socket fd=%d for address %s on interface %s",
-			fd, inet_ntoa(ifaddr), ifp->name);
+		zlog_debug("Creating IGMP socket fd=%d for address %pI4 on interface %s",
+			   fd, &ifaddr, ifp->name);
 	}
 
 	igmp = XCALLOC(MTYPE_PIM_IGMP_SOCKET, sizeof(*igmp));
@@ -1001,8 +997,8 @@ struct igmp_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
 
 	fd = igmp_sock_open(ifaddr, ifp, pim_ifp->options);
 	if (fd < 0) {
-		zlog_warn("Could not open IGMP socket for %s on %s",
-			  inet_ntoa(ifaddr), ifp->name);
+		zlog_warn("Could not open IGMP socket for %pI4 on %s",
+			  &ifaddr, ifp->name);
 		return 0;
 	}
 
@@ -1142,9 +1138,8 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 
 	if (pim_is_group_224_0_0_0_24(group_addr)) {
 		if (PIM_DEBUG_IGMP_TRACE)
-			zlog_debug(
-				"%s: Group specified %s is part of 224.0.0.0/24",
-				__func__, inet_ntoa(group_addr));
+			zlog_debug("%s: Group specified %pI4 is part of 224.0.0.0/24",
+				   __func__, &group_addr);
 		return NULL;
 	}
 	/*

--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -114,7 +114,6 @@ static bool mtrace_fwd_info(struct pim_instance *pim,
 	struct interface *ifp_in;
 	struct in_addr nh_addr;
 	uint32_t total;
-	char up_str[INET_ADDRSTRLEN];
 
 	memset(&sg, 0, sizeof(struct prefix_sg));
 	sg.src = mtracep->src_addr;
@@ -269,8 +268,6 @@ static int mtrace_send_packet(struct interface *ifp,
 	ssize_t sent;
 	int ret;
 	int fd;
-	char if_str[INET_ADDRSTRLEN];
-	char rsp_str[INET_ADDRSTRLEN];
 	uint8_t ttl;
 
 	memset(&to, 0, sizeof(to));

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -704,8 +704,6 @@ static void pim_mlag_process_peer_frr_state_change(struct mlag_frr_status msg)
 
 static void pim_mlag_process_vxlan_update(struct mlag_vxlan *msg)
 {
-	char addr_buf1[INET_ADDRSTRLEN];
-	char addr_buf2[INET_ADDRSTRLEN];
 	uint32_t local_ip;
 
 	if (!(router->mlag_flags & PIM_MLAGF_LOCAL_CONN_UP)) {
@@ -724,13 +722,9 @@ static void pim_mlag_process_vxlan_update(struct mlag_vxlan *msg)
 	}
 
 	if (PIM_DEBUG_MLAG) {
-		inet_ntop(AF_INET, &router->local_vtep_ip,
-				addr_buf1, INET_ADDRSTRLEN);
-		inet_ntop(AF_INET, &router->anycast_vtep_ip,
-				addr_buf2, INET_ADDRSTRLEN);
-
-		zlog_debug("%s: msg dump: local-ip:%s, anycast-ip:%s",
-				__func__, addr_buf1, addr_buf2);
+		zlog_debug("%s: msg dump: local-ip:%pI4, anycast-ip:%pI4",
+				__func__, &router->local_vtep_ip,
+				&router->anycast_vtep_ip);
 	}
 }
 

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -57,13 +57,11 @@ void pim_sendmsg_zebra_rnh(struct pim_instance *pim, struct zclient *zclient,
 		zlog_warn("sendmsg_nexthop: zclient_send_message() failed");
 
 	if (PIM_DEBUG_PIM_NHT) {
-		char buf[PREFIX2STR_BUFFER];
-		prefix2str(p, buf, sizeof(buf));
-		zlog_debug(
-			"%s: NHT %sregistered addr %s(%s) with Zebra ret:%d ",
-			__func__,
-			(command == ZEBRA_NEXTHOP_REGISTER) ? " " : "de", buf,
-			pim->vrf->name, ret);
+		zlog_debug("%s: NHT %sregistered addr %pFX(%s) with Zebra ret:%d ",
+			   __func__,
+			   (command == ZEBRA_NEXTHOP_REGISTER) ? " " : "de",
+			   p,
+			   pim->vrf->name, ret);
 	}
 
 	return;
@@ -89,7 +87,6 @@ static struct pim_nexthop_cache *pim_nexthop_cache_add(struct pim_instance *pim,
 {
 	struct pim_nexthop_cache *pnc;
 	char hash_name[64];
-	char buf1[64];
 
 	pnc = XCALLOC(MTYPE_PIM_NEXTHOP_CACHE,
 		      sizeof(struct pim_nexthop_cache));
@@ -103,8 +100,8 @@ static struct pim_nexthop_cache *pim_nexthop_cache_add(struct pim_instance *pim,
 	pnc->rp_list = list_new();
 	pnc->rp_list->cmp = pim_rp_list_cmp;
 
-	snprintf(hash_name, sizeof(hash_name), "PNC %s(%s) Upstream Hash",
-		 prefix2str(&pnc->rpf.rpf_addr, buf1, 64), pim->vrf->name);
+	snprintfrr(hash_name, sizeof(hash_name), "PNC %pFX(%s) Upstream Hash",
+		   &pnc->rpf.rpf_addr, pim->vrf->name);
 	pnc->upstream_hash = hash_create_size(8192, pim_upstream_hash_key,
 					      pim_upstream_equal, hash_name);
 
@@ -141,11 +138,8 @@ int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
 		pim_sendmsg_zebra_rnh(pim, zclient, pnc,
 				      ZEBRA_NEXTHOP_REGISTER);
 		if (PIM_DEBUG_PIM_NHT) {
-			char buf[PREFIX2STR_BUFFER];
-			prefix2str(addr, buf, sizeof(buf));
-			zlog_debug(
-				"%s: NHT cache and zebra notification added for %s(%s)",
-				__func__, buf, pim->vrf->name);
+			zlog_debug("%s: NHT cache and zebra notification added for %pFX(%s)",
+				   __func__, addr, pim->vrf->name);
 		}
 	}
 

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -75,8 +75,8 @@ void pim_register_stop_send(struct interface *ifp, struct prefix_sg *sg,
 	struct prefix p;
 
 	if (PIM_DEBUG_PIM_REG) {
-		zlog_debug("Sending Register stop for %s to %s on %s",
-			   pim_str_sg_dump(sg), inet_ntoa(originator),
+		zlog_debug("Sending Register stop for %s to %pI4 on %s",
+			   pim_str_sg_dump(sg), &originator,
 			   ifp->name);
 	}
 
@@ -170,9 +170,9 @@ void pim_register_send(const uint8_t *buf, int buf_size, struct in_addr src,
 	struct interface *ifp;
 
 	if (PIM_DEBUG_PIM_REG) {
-		zlog_debug("Sending %s %sRegister Packet to %s", up->sg_str,
+		zlog_debug("Sending %s %sRegister Packet to %pI4", up->sg_str,
 			   null_register ? "NULL " : "",
-			   inet_ntoa(rpg->rpf_addr.u.prefix4));
+			   &rpg->rpf_addr.u.prefix4);
 	}
 
 	ifp = rpg->source_nexthop.interface;

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -249,7 +249,6 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
 
 	rp_info = rn->info;
 	if (PIM_DEBUG_PIM_TRACE) {
-		char buf[PREFIX_STRLEN];
 
 		zlog_debug("Lookedup: %p for rp_info: %p(%pFX) Lock: %d", rn,
 			   rp_info,
@@ -834,7 +833,6 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 					"Expected rn->info to be equal to rp_info");
 
 			if (PIM_DEBUG_PIM_TRACE) {
-				char buf[PREFIX_STRLEN];
 
 				zlog_debug("%s:Found for Freeing: %p for rp_info: %p(%pFX) Lock: %d",
 					   __func__, rn, rp_info,

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -953,10 +953,9 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 		pim_mlag_up_local_add(pim, up);
 
 	if (PIM_DEBUG_PIM_TRACE) {
-		zlog_debug(
-			"%s: Created Upstream %s upstream_addr %s ref count %d increment",
-			__func__, up->sg_str, inet_ntoa(up->upstream_addr),
-			up->ref_count);
+		zlog_debug("%s: Created Upstream %s upstream_addr %pI4 ref count %d increment",
+			   __func__, up->sg_str, &up->upstream_addr,
+			   up->ref_count);
 	}
 
 	return up;
@@ -1063,13 +1062,12 @@ struct pim_upstream *pim_upstream_add(struct pim_instance *pim,
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		if (up) {
-			char buf[PREFIX2STR_BUFFER];
-			prefix2str(&up->rpf.rpf_addr, buf, sizeof(buf));
-			zlog_debug("%s(%s): %s, iif %s (%s) found: %d: ref_count: %d",
-		   __func__, name,
-		   up->sg_str, buf, up->rpf.source_nexthop.interface ?
-                   up->rpf.source_nexthop.interface->name : "Unknown" ,
-		   found, up->ref_count);
+			zlog_debug("%s(%s): %s, iif %pFX (%s) found: %d: ref_count: %d",
+				   __func__, name,
+				   up->sg_str, &up->rpf.rpf_addr,
+				   up->rpf.source_nexthop.interface ?
+				   up->rpf.source_nexthop.interface->name : "Unknown" ,
+				   found, up->ref_count);
 		} else
 			zlog_debug("%s(%s): (%s) failure to create", __func__,
 				   name, pim_str_sg_dump(sg));

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -852,18 +852,15 @@ void pim_vxlan_mlag_update(bool enable, bool peer_state, uint32_t role,
 				struct in_addr *reg_addr)
 {
 	struct pim_instance *pim;
-	char addr_buf[INET_ADDRSTRLEN];
 	struct pim_interface *pim_ifp = NULL;
 
 	if (PIM_DEBUG_VXLAN) {
-		inet_ntop(AF_INET, reg_addr,
-				addr_buf, INET_ADDRSTRLEN);
-		zlog_debug("vxlan MLAG update %s state %s role %d rif %s addr %s",
+		zlog_debug("vxlan MLAG update %s state %s role %d rif %s addr %pI4",
 				enable ? "enable" : "disable",
 				peer_state ? "up" : "down",
 				role,
 				peerlink_rif ? peerlink_rif->name : "-",
-				addr_buf);
+				reg_addr);
 	}
 
 	/* XXX: for now vxlan termination is only possible in the default VRF

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -602,8 +602,8 @@ int rip_interface_address_add(ZAPI_CALLBACK_ARGS)
 
 	if (p->family == AF_INET) {
 		if (IS_RIP_DEBUG_ZEBRA)
-			zlog_debug("connected address %s/%d is added",
-				   inet_ntoa(p->u.prefix4), p->prefixlen);
+			zlog_debug("connected address %pFX is added",
+				   p);
 
 		rip_enable_apply(ifc->ifp);
 		/* Check if this prefix needs to be redistributed */
@@ -652,9 +652,8 @@ int rip_interface_address_delete(ZAPI_CALLBACK_ARGS)
 		p = ifc->address;
 		if (p->family == AF_INET) {
 			if (IS_RIP_DEBUG_ZEBRA)
-				zlog_debug("connected address %s/%d is deleted",
-					   inet_ntoa(p->u.prefix4),
-					   p->prefixlen);
+				zlog_debug("connected address %pFX is deleted",
+					   p);
 
 			hook_call(rip_ifaddr_del, ifc);
 

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -172,8 +172,8 @@ static void rip_request_interface_send(struct interface *ifp, uint8_t version)
 				continue;
 
 			if (IS_RIP_DEBUG_EVENT)
-				zlog_debug("SEND request to %s",
-					   inet_ntoa(to.sin_addr));
+				zlog_debug("SEND request to %pI4",
+					   &to.sin_addr);
 
 			rip_request_send(&to, ifp, version, connected);
 		}
@@ -1174,8 +1174,8 @@ int rip_show_network_config(struct vty *vty, struct rip *rip)
 	for (node = route_top(rip->enable_network); node;
 	     node = route_next(node))
 		if (node->info)
-			vty_out(vty, "    %s/%u\n",
-				inet_ntoa(node->p.u.prefix4),
+			vty_out(vty, "    %pI4/%u\n",
+				&node->p.u.prefix4,
 				node->p.prefixlen);
 
 	/* Interface name RIP enable statement. */
@@ -1186,7 +1186,7 @@ int rip_show_network_config(struct vty *vty, struct rip *rip)
 	/* RIP neighbors listing. */
 	for (node = route_top(rip->neighbor); node; node = route_next(node))
 		if (node->info)
-			vty_out(vty, "    %s\n", inet_ntoa(node->p.u.prefix4));
+			vty_out(vty, "    %pI4\n", &node->p.u.prefix4);
 
 	return 0;
 }

--- a/ripd/rip_peer.c
+++ b/ripd/rip_peer.c
@@ -155,8 +155,8 @@ void rip_peer_display(struct vty *vty, struct rip *rip)
 	char timebuf[RIP_UPTIME_LEN];
 
 	for (ALL_LIST_ELEMENTS(rip->peer_list, node, nnode, peer)) {
-		vty_out(vty, "    %-16s %9d %9d %9d   %s\n",
-			inet_ntoa(peer->addr), peer->recv_badpackets,
+		vty_out(vty, "    %-16pI4 %9d %9d %9d   %s\n",
+			&peer->addr, peer->recv_badpackets,
 			peer->recv_badroutes, ZEBRA_RIP_DISTANCE_DEFAULT,
 			rip_peer_uptime(peer, timebuf, RIP_UPTIME_LEN));
 	}

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -88,18 +88,18 @@ static void rip_zebra_ipv4_send(struct rip *rip, struct route_node *rp,
 
 	if (IS_RIP_DEBUG_ZEBRA) {
 		if (rip->ecmp)
-			zlog_debug("%s: %s/%d nexthops %d",
+			zlog_debug("%s: %pFX nexthops %d",
 				   (cmd == ZEBRA_ROUTE_ADD)
 					   ? "Install into zebra"
 					   : "Delete from zebra",
-				   inet_ntoa(rp->p.u.prefix4), rp->p.prefixlen,
+				   &rp->p,
 				   count);
 		else
-			zlog_debug("%s: %s/%d",
+			zlog_debug("%s: %pFX",
 				   (cmd == ZEBRA_ROUTE_ADD)
 					   ? "Install into zebra"
 					   : "Delete from zebra",
-				   inet_ntoa(rp->p.u.prefix4), rp->p.prefixlen);
+				   &rp->p);
 	}
 
 	rip->counters.route_changes++;

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -427,7 +427,6 @@ int ripng_interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
 	struct prefix *p;
-	char buf[INET6_ADDRSTRLEN];
 
 	ifc = zebra_interface_address_read(ZEBRA_INTERFACE_ADDRESS_DELETE,
 					   zclient->ibuf, vrf_id);
@@ -437,11 +436,9 @@ int ripng_interface_address_delete(ZAPI_CALLBACK_ARGS)
 
 		if (p->family == AF_INET6) {
 			if (IS_RIPNG_DEBUG_ZEBRA)
-				zlog_debug(
-					"RIPng connected address %s/%d delete",
-					inet_ntop(AF_INET6, &p->u.prefix6, buf,
-						  INET6_ADDRSTRLEN),
-					p->prefixlen);
+				zlog_debug("RIPng connected address %pI6/%d delete",
+					   &p->u.prefix6,
+					   p->prefixlen);
 
 			/* Check wether this prefix needs to be removed. */
 			ripng_apply_address_del(ifc);

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -374,8 +374,8 @@ int ripng_interface_address_add(ZAPI_CALLBACK_ARGS)
 		struct ripng_interface *ri = c->ifp->info;
 
 		if (IS_RIPNG_DEBUG_ZEBRA)
-			zlog_debug("RIPng connected address %s/%d add",
-				   inet6_ntoa(p->u.prefix6), p->prefixlen);
+			zlog_debug("RIPng connected address %pFX add",
+				   p);
 
 		/* Check is this prefix needs to be redistributed. */
 		ripng_apply_address_add(c);

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -643,8 +643,8 @@ static int ripng_filter(int ripng_distribute, struct prefix_ipv6 *p,
 				      (struct prefix *)p)
 		    == FILTER_DENY) {
 			if (IS_RIPNG_DEBUG_PACKET)
-				zlog_debug("%s/%d filtered by distribute %s",
-					   inet6_ntoa(p->prefix), p->prefixlen,
+				zlog_debug("%pFX filtered by distribute %s",
+					   p,
 					   inout);
 			return -1;
 		}
@@ -654,8 +654,8 @@ static int ripng_filter(int ripng_distribute, struct prefix_ipv6 *p,
 				      (struct prefix *)p)
 		    == PREFIX_DENY) {
 			if (IS_RIPNG_DEBUG_PACKET)
-				zlog_debug("%s/%d filtered by prefix-list %s",
-					   inet6_ntoa(p->prefix), p->prefixlen,
+				zlog_debug("%pFX filtered by prefix-list %s",
+					   p,
 					   inout);
 			return -1;
 		}
@@ -672,10 +672,8 @@ static int ripng_filter(int ripng_distribute, struct prefix_ipv6 *p,
 				if (access_list_apply(alist, (struct prefix *)p)
 				    == FILTER_DENY) {
 					if (IS_RIPNG_DEBUG_PACKET)
-						zlog_debug(
-							"%s/%d filtered by distribute %s",
-							inet6_ntoa(p->prefix),
-							p->prefixlen, inout);
+						zlog_debug("%pFX filtered by distribute %s",
+							   p, inout);
 					return -1;
 				}
 			}
@@ -688,10 +686,8 @@ static int ripng_filter(int ripng_distribute, struct prefix_ipv6 *p,
 				if (prefix_list_apply(plist, (struct prefix *)p)
 				    == PREFIX_DENY) {
 					if (IS_RIPNG_DEBUG_PACKET)
-						zlog_debug(
-							"%s/%d filtered by prefix-list %s",
-							inet6_ntoa(p->prefix),
-							p->prefixlen, inout);
+						zlog_debug("%pFX filtered by prefix-list %s",
+							   p, inout);
 					return -1;
 				}
 			}
@@ -757,9 +753,8 @@ static void ripng_route_process(struct rte *rte, struct sockaddr_in6 *from,
 
 		if (ret == RMAP_DENYMATCH) {
 			if (IS_RIPNG_DEBUG_PACKET)
-				zlog_debug(
-					"RIPng %s/%d is filtered by route-map in",
-					inet6_ntoa(p.prefix), p.prefixlen);
+				zlog_debug("RIPng %pFX is filtered by route-map in",
+					   &p);
 			return;
 		}
 
@@ -996,16 +991,14 @@ void ripng_redistribute_add(struct ripng *ripng, int type, int sub_type,
 
 	if (IS_RIPNG_DEBUG_EVENT) {
 		if (!nexthop)
-			zlog_debug(
-				"Redistribute new prefix %s/%d on the interface %s",
-				inet6_ntoa(p->prefix), p->prefixlen,
-				ifindex2ifname(ifindex, ripng->vrf->vrf_id));
+			zlog_debug("Redistribute new prefix %pFX on the interface %s",
+				   p,
+				   ifindex2ifname(ifindex, ripng->vrf->vrf_id));
 		else
-			zlog_debug(
-				"Redistribute new prefix %s/%d with nexthop %s on the interface %s",
-				inet6_ntoa(p->prefix), p->prefixlen,
-				inet6_ntoa(*nexthop),
-				ifindex2ifname(ifindex, ripng->vrf->vrf_id));
+			zlog_debug("Redistribute new prefix %pFX with nexthop %s on the interface %s",
+				   p,
+				   inet6_ntoa(*nexthop),
+				   ifindex2ifname(ifindex, ripng->vrf->vrf_id));
 	}
 
 	ripng_event(ripng, RIPNG_TRIGGERED_UPDATE, 0);
@@ -1046,13 +1039,11 @@ void ripng_redistribute_delete(struct ripng *ripng, int type, int sub_type,
 				rinfo->flags |= RIPNG_RTF_CHANGED;
 
 				if (IS_RIPNG_DEBUG_EVENT)
-					zlog_debug(
-						"Poisone %s/%d on the interface %s with an infinity metric [delete]",
-						inet6_ntoa(p->prefix),
-						p->prefixlen,
-						ifindex2ifname(
-							ifindex,
-							ripng->vrf->vrf_id));
+					zlog_debug("Poisone %pFX on the interface %s with an infinity metric [delete]",
+						   p,
+						   ifindex2ifname(
+								  ifindex,
+								  ripng->vrf->vrf_id));
 
 				ripng_event(ripng, RIPNG_TRIGGERED_UPDATE, 0);
 			}
@@ -1090,13 +1081,11 @@ void ripng_redistribute_withdraw(struct ripng *ripng, int type)
 						(struct prefix_ipv6 *)
 							agg_node_get_prefix(rp);
 
-					zlog_debug(
-						"Poisone %s/%d on the interface %s [withdraw]",
-						inet6_ntoa(p->prefix),
-						p->prefixlen,
-						ifindex2ifname(
-							rinfo->ifindex,
-							ripng->vrf->vrf_id));
+					zlog_debug("Poisone %pFX on the interface %s [withdraw]",
+						   p,
+						   ifindex2ifname(
+								  rinfo->ifindex,
+								  ripng->vrf->vrf_id));
 				}
 
 				ripng_event(ripng, RIPNG_TRIGGERED_UPDATE, 0);
@@ -1679,10 +1668,8 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIPNG_DEBUG_PACKET)
-						zlog_debug(
-							"RIPng %s/%d is filtered by route-map out",
-							inet6_ntoa(p->prefix),
-							p->prefixlen);
+						zlog_debug("RIPng %pFX is filtered by route-map out",
+							   p);
 					continue;
 				}
 			}
@@ -1696,10 +1683,8 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIPNG_DEBUG_PACKET)
-						zlog_debug(
-							"RIPng %s/%d is filtered by route-map",
-							inet6_ntoa(p->prefix),
-							p->prefixlen);
+						zlog_debug("RIPng %pFX is filtered by route-map",
+							   p);
 					continue;
 				}
 			}
@@ -1794,10 +1779,8 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIPNG_DEBUG_PACKET)
-						zlog_debug(
-							"RIPng %s/%d is filtered by route-map out",
-							inet6_ntoa(p->prefix),
-							p->prefixlen);
+						zlog_debug("RIPng %pFX is filtered by route-map out",
+							   p);
 					continue;
 				}
 

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -351,8 +351,6 @@ void ripng_packet_dump(struct ripng_packet *packet, int size,
 static void ripng_nexthop_rte(struct rte *rte, struct sockaddr_in6 *from,
 			      struct ripng_nexthop *nexthop)
 {
-	char buf[INET6_BUFSIZ];
-
 	/* Logging before checking RTE. */
 	if (IS_RIPNG_DEBUG_RECV)
 		zlog_debug("RIPng nexthop RTE address %s tag %" ROUTE_TAG_PRI
@@ -398,9 +396,9 @@ static void ripng_nexthop_rte(struct rte *rte, struct sockaddr_in6 *from,
 	 information is ignored, a possibly sub-optimal, but absolutely
 	 valid, route may be taken.  If the received next hop address is not
 	 a link-local address, it should be treated as 0:0:0:0:0:0:0:0.  */
-	zlog_warn("RIPng nexthop RTE with non link-local address %s from %s",
+	zlog_warn("RIPng nexthop RTE with non link-local address %s from %pI6",
 		  inet6_ntoa(rte->addr),
-		  inet_ntop(AF_INET6, &from->sin6_addr, buf, INET6_BUFSIZ));
+		  &from->sin6_addr);
 
 	nexthop->flag = RIPNG_NEXTHOP_UNSPEC;
 	memset(&nexthop->address, 0, sizeof(struct in6_addr));

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -57,10 +57,8 @@ void sharp_nh_tracker_dump(struct vty *vty)
 	struct sharp_nh_tracker *nht;
 
 	for (ALL_LIST_ELEMENTS_RO(sg.nhs, node, nht)) {
-		char buf[PREFIX_STRLEN];
-
-		vty_out(vty, "%s: Nexthops: %u Updates: %u\n",
-			prefix2str(&nht->p, buf, sizeof(buf)),
+		vty_out(vty, "%pFX: Nexthops: %u Updates: %u\n",
+			&nht->p,
 			nht->nhop_num,
 			nht->updates);
 	}

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -146,12 +146,11 @@ DEFPY (install_routes_data_dump,
        "Data about what is going on\n"
        "Route Install/Removal Information\n")
 {
-	char buf[PREFIX_STRLEN];
 	struct timeval r;
 
 	timersub(&sg.r.t_end, &sg.r.t_start, &r);
-	vty_out(vty, "Prefix: %s Total: %u %u %u Time: %jd.%ld\n",
-		prefix2str(&sg.r.orig_prefix, buf, sizeof(buf)),
+	vty_out(vty, "Prefix: %pFX Total: %u %u %u Time: %jd.%ld\n",
+		&sg.r.orig_prefix,
 		sg.r.total_routes,
 		sg.r.installed_routes,
 		sg.r.removed_routes,

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -437,7 +437,6 @@ void sharp_zebra_nexthop_watch(struct prefix *p, vrf_id_t vrf_id, bool import,
 static int sharp_debug_nexthops(struct zapi_route *api)
 {
 	int i;
-	char buf[PREFIX_STRLEN];
 
 	if (api->nexthop_num == 0) {
 		zlog_debug(
@@ -451,21 +450,17 @@ static int sharp_debug_nexthops(struct zapi_route *api)
 		switch (znh->type) {
 		case NEXTHOP_TYPE_IPV4_IFINDEX:
 		case NEXTHOP_TYPE_IPV4:
-			zlog_debug(
-				"        Nexthop %s, type: %d, ifindex: %d, vrf: %d, label_num: %d",
-				inet_ntop(AF_INET, &znh->gate.ipv4.s_addr, buf,
-					  sizeof(buf)),
-				znh->type, znh->ifindex, znh->vrf_id,
-				znh->label_num);
+			zlog_debug("        Nexthop %pI4, type: %d, ifindex: %d, vrf: %d, label_num: %d",
+				   &znh->gate.ipv4.s_addr,
+				   znh->type, znh->ifindex, znh->vrf_id,
+				   znh->label_num);
 			break;
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
 		case NEXTHOP_TYPE_IPV6:
-			zlog_debug(
-				"        Nexthop %s, type: %d, ifindex: %d, vrf: %d, label_num: %d",
-				inet_ntop(AF_INET6, &znh->gate.ipv6, buf,
-					  sizeof(buf)),
-				znh->type, znh->ifindex, znh->vrf_id,
-				znh->label_num);
+			zlog_debug("        Nexthop %pI6, type: %d, ifindex: %d, vrf: %d, label_num: %d",
+				   &znh->gate.ipv6,
+				   znh->type, znh->ifindex, znh->vrf_id,
+				   znh->label_num);
 			break;
 		case NEXTHOP_TYPE_IFINDEX:
 			zlog_debug("        Nexthop IFINDEX: %d, ifindex: %d",

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -367,8 +367,8 @@ int static_config(struct vty *vty, struct static_vrf *svrf, afi_t afi,
 
 				switch (nh->type) {
 				case STATIC_IPV4_GATEWAY:
-					vty_out(vty, " %s",
-						inet_ntoa(nh->addr.ipv4));
+					vty_out(vty, " %pI4",
+						&nh->addr.ipv4);
 					break;
 				case STATIC_IPV6_GATEWAY:
 					vty_out(vty, " %s",

--- a/tests/lib/cli/test_cli.c
+++ b/tests/lib/cli/test_cli.c
@@ -47,12 +47,11 @@ DEFPY(magic_test, magic_test_cmd,
 	"magic (0-100) {ipv4net A.B.C.D/M|X:X::X:X$ipv6}",
 	"1\n2\n3\n4\n5\n")
 {
-	char buf[256];
 	vty_out(vty, "def: %s\n", self->string);
 	vty_out(vty, "num: %ld\n", magic);
-	vty_out(vty, "ipv4: %s\n", prefix2str(ipv4net, buf, sizeof(buf)));
-	vty_out(vty, "ipv6: %s\n",
-		inet_ntop(AF_INET6, &ipv6, buf, sizeof(buf)));
+	vty_out(vty, "ipv4: %pFX\n", ipv4net);
+	vty_out(vty, "ipv6: %pI6\n",
+		&ipv6);
 	return CMD_SUCCESS;
 }
 

--- a/tests/lib/test_prefix2str.c
+++ b/tests/lib/test_prefix2str.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
 {
 	size_t i, j, k, l;
 	struct in6_addr i6;
-	char buf1[64], buf2[64], ntopbuf[64];
+	char buf1[64], buf2[64];
 	struct prng *prng;
 	struct prefix p = {};
 
@@ -39,10 +39,9 @@ int main(int argc, char **argv)
 	for (i = 0; i < 1000; i++) {
 		p.u.prefix = prng_rand(prng);
 		p.prefixlen = prng_rand(prng) >> 26;
-		snprintf(buf1, sizeof(buf1), "%s/%d",
-			 inet_ntop(AF_INET, &p.u.prefix4, ntopbuf,
-				   sizeof(ntopbuf)),
-			 p.prefixlen);
+		snprintfrr(buf1, sizeof(buf1), "%pI4/%d",
+			   &p.u.prefix4,
+			   p.prefixlen);
 		prefix2str(&p, buf2, sizeof(buf2));
 		assert(!strcmp(buf1, buf2));
 		fprintf(stdout, "%s\n", buf1);
@@ -67,10 +66,9 @@ int main(int argc, char **argv)
 
 		p.prefixlen = prng_rand(prng) >> 24;
 		memcpy(&p.u.prefix, &i6, sizeof(i6));
-		snprintf(buf1, sizeof(buf1), "%s/%d",
-			 inet_ntop(AF_INET6, &p.u.prefix6, ntopbuf,
-				   sizeof(ntopbuf)),
-			 p.prefixlen);
+		snprintfrr(buf1, sizeof(buf1), "%pI6/%d",
+			   &p.u.prefix6,
+			   p.prefixlen);
 		prefix2str(&p, buf2, sizeof(buf2));
 		assert(!strcmp(buf1, buf2));
 		fprintf(stdout, "%s\n", buf1);

--- a/tests/ospf6d/test_lsdb.c
+++ b/tests/ospf6d/test_lsdb.c
@@ -116,17 +116,12 @@ DEFPY(lsdb_remove, lsdb_remove_cmd,
 
 static void lsa_show_oneline(struct vty *vty, struct ospf6_lsa *lsa)
 {
-	char adv_router[64], id[64];
-
 	if (!lsa) {
 		vty_out(vty, "lsa = NULL\n");
 		return;
 	}
-	inet_ntop(AF_INET, &lsa->header->id, id, sizeof(id));
-	inet_ntop(AF_INET, &lsa->header->adv_router, adv_router,
-		  sizeof(adv_router));
-	vty_out(vty, "type %u adv %s id %s\n", ntohs(lsa->header->type),
-		adv_router, id);
+	vty_out(vty, "type %u adv %pI4 id %pI4\n", ntohs(lsa->header->type),
+		&lsa->header->adv_router, &lsa->header->id);
 }
 
 DEFPY(lsdb_walk, lsdb_walk_cmd,

--- a/tools/cocci.h
+++ b/tools/cocci.h
@@ -1,6 +1,8 @@
 /* some of this stuff doesn't seem to parse properly in coccinelle
  */
 
+#define OPTIMIZE __attribute__((optimize))
+
 #define DEFUN(funcname, cmdname, str, help)                                    \
 	static int funcname(const struct cmd_element *self, struct vty *vty,   \
 			    int argc, struct cmd_token *argv[])
@@ -121,4 +123,34 @@
 	lsa;                                                                   \
 	lsa = ospf6_lsdb_next(iterend, lsa)
 
+#define ALL_NEXTHOPS(head, nhop)					\
+	(nhop) = (head.nexthop);					\
+	(nhop);								\
+	(nhop) = nexthop_next(nhop)
+
+#define ALL_NEXTHOPS_PTR(head, nhop)					\
+	(nhop) = ((head)->nexthop);					\
+	(nhop);								\
+	(nhop) = nexthop_next(nhop)
+
 #define QOBJ_FIELDS struct qobj_node qobj_node;
+
+#define STAILQ_HEAD(name, type)                                                \
+	struct name {                                                          \
+		struct type *stqh_first; /* first element */                   \
+		struct type **stqh_last; /* addr of last next element */       \
+	}
+#define STAILQ_ENTRY(type)                                                     \
+	struct {                                                               \
+		struct type *stqe_next; /* next element */                     \
+	}
+#define TAILQ_HEAD(name, type)                                                 \
+	struct name {                                                          \
+		struct type *tqh_first; /* first element */                    \
+		struct type **tqh_last; /* addr of last next element */        \
+	}
+#define TAILQ_ENTRY(type)                                                      \
+	struct {                                                               \
+		struct type *tqe_next;  /* next element */                     \
+		struct type **tqe_prev; /* address of previous next element */ \
+	}

--- a/tools/coccinelle/cocci_re.py
+++ b/tools/coccinelle/cocci_re.py
@@ -1,0 +1,67 @@
+import sys
+import re
+
+fmt_re = re.compile(r'''
+    %
+    (?P<argnum>[0-9]+\$)?
+    (?P<flags>[-+#'0 I]*)
+    (?P<width>[1-9][0-9]*|(?:[0-9]+\$)?\*)?
+    (?P<prec>\.[0-9]+|\.(?:[0-9]+\$)?\*)?
+    (?P<modif>hh|h|l|ll|L|q|j|z|Z|t)?
+    (?P<conv>[diouxXeEfFgGaAcCsSpnm%])
+    ''', re.X)
+
+def fmt_replace(fmt, idx, newconv, kill_plen = False):
+    items = list(fmt_re.finditer(fmt))
+    newfmt = None
+
+    while len(items) > 0:
+        item = items.pop(0)
+
+        if item.group('conv') in ['%', 'm']:
+            # no args on these
+            continue
+
+        if '$' in (item.group('width') or '') or '$' in (item.group('prec') or ''):
+            sys.stderr.write('\033[31;1m"%s" - argument reordering not supported\033[m\n' % (fmt))
+            break
+
+        if '*' in (item.group('width') or ''):
+            idx -= 1
+        if '*' in (item.group('prec') or ''):
+            idx -= 1
+        if idx < 0:
+            sys.stderr.write('\033[31;1m"%s" - WTF width arg?\033[m\n' % (fmt))
+            break
+        if idx > 0:
+            idx -= 1
+            continue
+
+        if item.group('conv') != 's':
+            sys.stderr.write('\033[31;1m"%s" - expected %%s conversion\033[m\n' % (fmt))
+            break
+
+        newfmt = []
+        newfmt.append(fmt[:item.start()])
+        newfmt.append('%')
+        newfmt.append(item.group('argnum') or '')
+        newfmt.append(item.group('flags'))
+        newfmt.append(item.group('width') or '')
+        newfmt.append(item.group('prec') or '')
+        newfmt.append(newconv)
+        if kill_plen:
+            after = fmt[item.end():]
+            if not after.startswith('/%d'):
+                return None
+            newfmt.append(fmt[item.end() + 3:])
+        else:
+            newfmt.append(fmt[item.end():])
+
+        newfmt = ''.join(newfmt)
+
+        sys.stderr.write('\033[32;1m%s => %s\033[m\n' % (fmt, newfmt))
+        break
+    else:
+        sys.stderr.write('\033[31;1m"%s" - out of args?\033[m\n' % (fmt))
+
+    return newfmt

--- a/tools/coccinelle/printfrr-prefixmerge-ptr.cocci
+++ b/tools/coccinelle/printfrr-prefixmerge-ptr.cocci
@@ -1,0 +1,166 @@
+@initialize:python@
+@@
+
+import sys
+
+sys.path.append('tools/coccinelle')
+
+from cocci_re import fmt_replace
+
+prev_replacements = set()
+
+@formatter@
+expression E;
+expression dummy;
+expression b;
+position pos;
+identifier af =~ "^AF_INET6?$";
+@@
+
+(
+ inet_ntoa@pos((E->u.prefix4))
+|
+ inet6_ntoa@pos((E->u.prefix))
+|
+ inet6_ntoa@pos((E->u.prefix6))
+|
+ inet_ntop@pos(af, &(E->u.prefix), b, dummy)
+|
+ inet_ntop@pos(E->family, &(E->u.prefix), b, dummy)
+|
+ inet_ntop@pos(af, (E->u.val), b, dummy)
+|
+ inet_ntop@pos(E->family, (E->u.val), b, dummy)
+|
+ inet_ntoa@pos((E->prefix))
+|
+ inet6_ntoa@pos((E->prefix))
+|
+ inet_ntop@pos(af, &(E->prefix), b, dummy)
+|
+ inet_ntop@pos(E->family, &(E->prefix), b, dummy)
+)
+
+@logcall@
+position formatter.pos;
+position callpos;
+identifier logfunc =~ "^(z|)log_(err|warn|info|notice|debug)$";
+identifier argfunc =~ "^(flog_(err|warn|info|notice|debug)|vty_out)$";
+identifier snpfunc =~ "^snprintf(rr)?$";
+format list fmt;
+expression list P;
+expression formatter.E;
+expression formatter.b;
+expression F, G;
+expression arg, arg2;
+@@
+
+(
+ logfunc@callpos("%@fmt@", P, F@pos(...), E->prefixlen, ...);
+|
+ argfunc@callpos(arg, "%@fmt@", P, F@pos(...), E->prefixlen, ...);
+|
+ G = argfunc@callpos(arg, "%@fmt@", P, F@pos(...), E->prefixlen, ...);
+|
+ snpfunc@callpos(arg, arg2, "%@fmt@", P, F@pos(...), E->prefixlen, ...);
+|
+ G = snpfunc@callpos(arg, arg2, "%@fmt@", P, F@pos(...), E->prefixlen, ...);
+)
+
+@script:python logcallfmt@
+oldexpr << formatter.E;
+oldaf << formatter.af = "...";
+otherargs << logcall.P;
+callpos << logcall.callpos;
+fmtfn << logcall.F;
+fmt << logcall.fmt;
+newfmt;
+newexpr;
+@@
+
+once_key = (fmt, callpos[0].file, callpos[0].line)
+
+if once_key in prev_replacements:
+    sys.stderr.write('\033[33;1mmore replacements, run again\033[m\n')
+    cocci.include_match(False)
+else:
+    prev_replacements.add(once_key)
+
+    newfmt = fmt_replace(fmt, len(otherargs.elements), 'pFX', True)
+    if newfmt is not None:
+        coccinelle.newfmt = cocci.make_expr('"%s"' % newfmt)
+
+@@
+expression logcall.F;
+expression logcall.G;
+expression formatter.E;
+expression formatter.b;
+position formatter.pos;
+expression list logcall.P;
+identifier logcall.logfunc;
+identifier logcall.argfunc;
+identifier logcall.snpfunc;
+format list logcall.fmt;
+expression logcallfmt.newfmt;
+expression logcallfmt.newexpr;
+expression arg, arg2;
+@@
+
+(
+  logfunc(
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...), E->prefixlen
++	E
+	,
+	...
+	);
+|
+  argfunc(arg,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...), E->prefixlen
++	E
+	,
+	...
+	);
+|
+  G = argfunc(arg,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...), E->prefixlen
++	E
+	,
+	...
+	);
+|
+- snpfunc
++ snprintfrr
+  (arg, arg2,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...), E->prefixlen
++	E
+	,
+	...
+	);
+|
+  G =
+- snpfunc
++ snprintfrr
+  (arg, arg2,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...), E->prefixlen
++	E
+	,
+	...
+	);
+)
+
+

--- a/tools/coccinelle/printfrr-prefixmerge.cocci
+++ b/tools/coccinelle/printfrr-prefixmerge.cocci
@@ -1,0 +1,166 @@
+@initialize:python@
+@@
+
+import sys
+
+sys.path.append('tools/coccinelle')
+
+from cocci_re import fmt_replace
+
+prev_replacements = set()
+
+@formatter@
+expression E;
+expression dummy;
+expression b;
+position pos;
+identifier af =~ "^AF_INET6?$";
+@@
+
+(
+ inet_ntoa@pos((E.u.prefix4))
+|
+ inet6_ntoa@pos((E.u.prefix))
+|
+ inet6_ntoa@pos((E.u.prefix6))
+|
+ inet_ntop@pos(af, &(E.u.prefix), b, dummy)
+|
+ inet_ntop@pos(E.family, &(E.u.prefix), b, dummy)
+|
+ inet_ntop@pos(af, (E.u.val), b, dummy)
+|
+ inet_ntop@pos(E.family, (E.u.val), b, dummy)
+|
+ inet_ntoa@pos((E.prefix))
+|
+ inet6_ntoa@pos((E.prefix))
+|
+ inet_ntop@pos(af, &(E.prefix), b, dummy)
+|
+ inet_ntop@pos(E.family, &(E.prefix), b, dummy)
+)
+
+@logcall@
+position formatter.pos;
+position callpos;
+identifier logfunc =~ "^(z|)log_(err|warn|info|notice|debug)$";
+identifier argfunc =~ "^(flog_(err|warn|info|notice|debug)|vty_out)$";
+identifier snpfunc =~ "^snprintf(rr)?$";
+format list fmt;
+expression list P;
+expression formatter.E;
+expression formatter.b;
+expression F, G;
+expression arg, arg2;
+@@
+
+(
+ logfunc@callpos("%@fmt@", P, F@pos(...), E.prefixlen, ...)
+|
+ argfunc@callpos(arg, "%@fmt@", P, F@pos(...), E.prefixlen, ...)
+|
+ G = argfunc@callpos(arg, "%@fmt@", P, F@pos(...), E.prefixlen, ...)
+|
+ snpfunc@callpos(arg, arg2, "%@fmt@", P, F@pos(...), E.prefixlen, ...)
+|
+ G = snpfunc@callpos(arg, arg2, "%@fmt@", P, F@pos(...), E.prefixlen, ...)
+)
+
+@script:python logcallfmt@
+oldexpr << formatter.E;
+oldaf << formatter.af = "...";
+otherargs << logcall.P;
+callpos << logcall.callpos;
+fmtfn << logcall.F;
+fmt << logcall.fmt;
+newfmt;
+newexpr;
+@@
+
+once_key = (fmt, callpos[0].file, callpos[0].line)
+
+if once_key in prev_replacements:
+    sys.stderr.write('\033[33;1mmore replacements, run again\033[m\n')
+    cocci.include_match(False)
+else:
+    prev_replacements.add(once_key)
+
+    newfmt = fmt_replace(fmt, len(otherargs.elements), 'pFX', True)
+    if newfmt is not None:
+        coccinelle.newfmt = cocci.make_expr('"%s"' % newfmt)
+
+@@
+expression logcall.F;
+expression logcall.G;
+expression formatter.E;
+expression formatter.b;
+position formatter.pos;
+expression list logcall.P;
+identifier logcall.logfunc;
+identifier logcall.argfunc;
+identifier logcall.snpfunc;
+format list logcall.fmt;
+expression logcallfmt.newfmt;
+expression logcallfmt.newexpr;
+expression arg, arg2;
+@@
+
+(
+  logfunc(
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...), E.prefixlen
++	&E
+	,
+	...
+	);
+|
+  argfunc(arg,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...), E.prefixlen
++	&E
+	,
+	...
+	);
+|
+  G = argfunc(arg,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...), E.prefixlen
++	&E
+	,
+	...
+	);
+|
+- snpfunc
++ snprintfrr
+  (arg, arg2,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...), E.prefixlen
++	&E
+	,
+	...
+	);
+|
+  G =
+- snpfunc
++ snprintfrr
+  (arg, arg2,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...), E.prefixlen
++	&E
+	,
+	...
+	);
+)
+
+

--- a/tools/coccinelle/printfrr.cocci
+++ b/tools/coccinelle/printfrr.cocci
@@ -1,0 +1,202 @@
+@initialize:python@
+@@
+
+import sys
+
+sys.path.append('tools/coccinelle')
+
+from cocci_re import fmt_replace
+
+prev_replacements = set()
+
+@formatter@
+expression E;
+expression dummy;
+identifier b;
+position pos;
+identifier af =~ "^AF_INET6?$";
+@@
+
+(
+ prefix2str@pos(E, b, dummy)
+|
+ prefix_mac2str@pos(E, b, dummy)
+|
+ inet_ntoa@pos(E)
+|
+ inet_ntop@pos(af, E, b, dummy)
+|
+ ipaddr2str@pos(E, b, dummy)
+)
+
+@logcall@
+position formatter.pos;
+identifier formatter.b;
+position callpos;
+identifier logfunc =~ "^(z|)log_(err|warn|info|notice|debug)$";
+identifier argfunc =~ "^(flog_(err|warn|info|notice|debug)|vty_out)$";
+identifier snpfunc =~ "^snprintf(rr)?$";
+format list fmt;
+expression list P;
+expression F;
+expression arg, arg2;
+@@
+
+(
+ logfunc@callpos("%@fmt@", P, F@pos(...), ...);
+|
+ argfunc@callpos(arg, "%@fmt@", P, F@pos(...), ...);
+|
+ snpfunc@callpos(arg, arg2, "%@fmt@", P, F@pos(...), ...);
+|
+ { ...
+ F@pos(...)
+ ... when != b
+(
+ logfunc@callpos("%@fmt@", P, b, ...);
+|
+ argfunc@callpos(arg, "%@fmt@", P, b, ...);
+|
+ snpfunc@callpos(arg, arg2, "%@fmt@", P, b, ...);
+)
+ ... when != b
+ }
+)
+
+@script:python logcallfmt@
+oldexpr << formatter.E;
+oldaf << formatter.af = "...";
+otherargs << logcall.P;
+callpos << logcall.callpos;
+fmtfn << logcall.F;
+fmt << logcall.fmt;
+newfmt;
+newexpr;
+@@
+
+replacements = {
+    'prefix2str': 'pFX',
+    'prefix_mac2str': 'pEA',
+    'ipaddr2str': 'pIA',
+    'inet_ntoa': 'pI4',
+    'inet_ntop': 'pI6' if oldaf == 'AF_INET6' else 'pI4',
+}
+
+once_key = (fmt, callpos[0].file, callpos[0].line)
+
+if fmtfn not in replacements:
+    sys.stderr.write('\033[33;1mno replacement for %s()\033[m\n' % fmtfn)
+    cocci.include_match(False)
+elif once_key in prev_replacements:
+    sys.stderr.write('\033[33;1mmore replacements, run again\033[m\n')
+    cocci.include_match(False)
+else:
+    prev_replacements.add(once_key)
+
+    newfmt = fmt_replace(fmt, len(otherargs.elements), replacements[fmtfn])
+    if newfmt is not None:
+        coccinelle.newfmt = cocci.make_expr('"%s"' % newfmt)
+
+    if fmtfn in ['inet_ntoa']:
+        if oldexpr.startswith('*'):
+            coccinelle.newexpr = cocci.make_expr(oldexpr[1:].strip())
+        else:
+            coccinelle.newexpr = cocci.make_expr('&%s' % oldexpr)
+    else:
+        coccinelle.newexpr = cocci.make_expr(oldexpr)
+
+@@
+expression logcall.F;
+identifier formatter.b;
+position formatter.pos;
+expression list logcall.P;
+identifier logcall.logfunc;
+identifier logcall.argfunc;
+identifier logcall.snpfunc;
+format list logcall.fmt;
+expression logcallfmt.newfmt;
+expression logcallfmt.newexpr;
+expression arg, arg2;
+@@
+
+(
+  logfunc(
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...)
++	newexpr
+	,
+	...
+	);
+|
+  argfunc(arg,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...)
++	newexpr
+	,
+	...
+	);
+|
+- snpfunc
++ snprintfrr
+  (arg, arg2,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	F@pos(...)
++	newexpr
+	,
+	...
+	);
+|
+- F@pos(...);
+  ...
+(
+  logfunc(
+-	"%@fmt@"
++	newfmt
+	, P,
+-	b
++	newexpr
+	,
+	...
+	);
+|
+  argfunc(arg,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	b
++	newexpr
+	,
+	...
+	);
+|
+- snpfunc
++ snprintfrr
+  (arg, arg2,
+-	"%@fmt@"
++	newfmt
+	, P,
+-	b
++	newexpr
+	,
+	...
+	);
+)
+)
+
+@@
+identifier formatter.b;
+type T;
+expression Z;
+@@
+
+  {
+  ...
+- T b[Z];
+  ... when != b
+  }

--- a/tools/printfrr.sh
+++ b/tools/printfrr.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+pfiles=`git grep -lP 'PRI[udx]64'`
+
+case "$1" in
+prepare)
+	sed -E -i \
+		-e 's%"(\s*PRI[udx]64\s*)"%lldXxX\1YyY%g' \
+		-e 's%"(\s*PRI[udx]64)%lldXxX\1ZzZ"%g' \
+		$pfiles
+	;;
+runargs)
+	shift
+	spatch -I . -I lib --macro-file tools/cocci.h "$@" --use-gitgrep
+	#-j16 --sp-file tools/coccinelle/printfrr.cocci --in-place --steps 64 --dir .
+	;;
+revert)
+	sed -E -i \
+		-e 's%lldXxX(\s*PRI[udx]64\s*)YyY%"\1"%g' \
+		-e 's%lldXxX(\s*PRI[udx]64\s*)ZzZ"%"\1%g' \
+		$pfiles
+	;;
+esac

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -260,12 +260,9 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 	/* Schedule LSP forwarding entries for processing, if appropriate. */
 	if (zvrf->vrf->vrf_id == VRF_DEFAULT) {
 		if (IS_ZEBRA_DEBUG_MPLS) {
-			char buf[PREFIX_STRLEN];
-
-			zlog_debug(
-				"%u: IF %s IP %s address add/up, scheduling MPLS processing",
-				zvrf->vrf->vrf_id, ifp->name,
-				prefix2str(&p, buf, sizeof(buf)));
+			zlog_debug("%u: IF %s IP %pFX address add/up, scheduling MPLS processing",
+				   zvrf->vrf->vrf_id, ifp->name,
+				   &p);
 		}
 		mpls_mark_lsps_for_processing(zvrf, &p);
 	}
@@ -312,8 +309,8 @@ void connected_add_ipv4(struct interface *ifp, int flags, struct in_addr *addr,
 			if (IPV4_ADDR_SAME(addr, dest))
 				flog_warn(
 					EC_ZEBRA_IFACE_SAME_LOCAL_AS_PEER,
-					"warning: interface %s has same local and peer address %s, routing protocols may malfunction",
-					ifp->name, inet_ntoa(*addr));
+					"warning: interface %s has same local and peer address %pI4, routing protocols may malfunction",
+					ifp->name, addr);
 		} else {
 			zlog_debug(
 				"warning: %s called for interface %s with peer flag set, but no peer address supplied",
@@ -325,9 +322,8 @@ void connected_add_ipv4(struct interface *ifp, int flags, struct in_addr *addr,
 	/* no destination address was supplied */
 	if (!dest && (prefixlen == IPV4_MAX_PREFIXLEN)
 		&& if_is_pointopoint(ifp))
-		zlog_debug(
-			"warning: PtP interface %s with addr %s/%d needs a peer address",
-			ifp->name, inet_ntoa(*addr), prefixlen);
+		zlog_debug("warning: PtP interface %s with addr %pI4/%d needs a peer address",
+			   ifp->name, addr, prefixlen);
 
 	/* Label of this address. */
 	if (label)
@@ -401,12 +397,9 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 	/* Schedule LSP forwarding entries for processing, if appropriate. */
 	if (zvrf->vrf->vrf_id == VRF_DEFAULT) {
 		if (IS_ZEBRA_DEBUG_MPLS) {
-			char buf[PREFIX_STRLEN];
-
-			zlog_debug(
-				"%u: IF %s IP %s address down, scheduling MPLS processing",
-				zvrf->vrf->vrf_id, ifp->name,
-				prefix2str(&p, buf, sizeof(buf)));
+			zlog_debug("%u: IF %s IP %pFX address down, scheduling MPLS processing",
+				   zvrf->vrf->vrf_id, ifp->name,
+				   &p);
 		}
 		mpls_mark_lsps_for_processing(zvrf, &p);
 	}
@@ -425,12 +418,9 @@ static void connected_delete_helper(struct connected *ifc, struct prefix *p)
 	/* Schedule LSP forwarding entries for processing, if appropriate. */
 	if (ifp->vrf_id == VRF_DEFAULT) {
 		if (IS_ZEBRA_DEBUG_MPLS) {
-			char buf[PREFIX_STRLEN];
-
-			zlog_debug(
-				"%u: IF %s IP %s address delete, scheduling MPLS processing",
-				ifp->vrf_id, ifp->name,
-				prefix2str(p, buf, sizeof(buf)));
+			zlog_debug("%u: IF %s IP %pFX address delete, scheduling MPLS processing",
+				   ifp->vrf_id, ifp->name,
+				   p);
 		}
 		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id), p);
 	}

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -3497,7 +3497,7 @@ static int link_params_config_write(struct vty *vty, struct interface *ifp)
 	if (IS_PARAM_SET(iflp, LP_USE_BW))
 		vty_out(vty, "  use-bw %g\n", iflp->use_bw);
 	if (IS_PARAM_SET(iflp, LP_RMT_AS))
-		vty_out(vty, "  neighbor %s as %u\n", inet_ntoa(iflp->rmt_ip),
+		vty_out(vty, "  neighbor %pI4 as %u\n", &iflp->rmt_ip,
 			iflp->rmt_as);
 	vty_out(vty, "  exit-link-params\n");
 	return 0;

--- a/zebra/ioctl_solaris.c
+++ b/zebra/ioctl_solaris.c
@@ -416,24 +416,16 @@ int if_unset_flags(struct interface *ifp, uint64_t flags)
 /* Interface's address add/delete functions. */
 static int if_set_prefix6_ctx(const struct zebra_dplane_ctx *ctx)
 {
-	char addrbuf[PREFIX_STRLEN];
-
-	prefix2str(dplane_ctx_get_intf_addr(ctx), addrbuf, sizeof(addrbuf));
-
-	flog_warn(EC_LIB_DEVELOPMENT, "Can't set %s on interface %s",
-		  addrbuf, dplane_ctx_get_ifname(ctx));
+	flog_warn(EC_LIB_DEVELOPMENT, "Can't set %pFX on interface %s",
+		  dplane_ctx_get_intf_addr(ctx), dplane_ctx_get_ifname(ctx));
 
 	return 0;
 }
 
 static int if_unset_prefix6_ctx(const struct zebra_dplane_ctx *ctx)
 {
-	char addrbuf[PREFIX_STRLEN];
-
-	prefix2str(dplane_ctx_get_intf_addr(ctx), addrbuf, sizeof(addrbuf));
-
-	flog_warn(EC_LIB_DEVELOPMENT, "Can't delete %s on interface %s",
-		  addrbuf, dplane_ctx_get_ifname(ctx));
+	flog_warn(EC_LIB_DEVELOPMENT, "Can't delete %pFX on interface %s",
+		  dplane_ctx_get_intf_addr(ctx), dplane_ctx_get_ifname(ctx));
 
 	return 0;
 }

--- a/zebra/irdp_main.c
+++ b/zebra/irdp_main.c
@@ -175,7 +175,6 @@ static void irdp_send(struct interface *ifp, struct prefix *p, struct stream *s)
 {
 	struct zebra_if *zi = ifp->info;
 	struct irdp_interface *irdp = zi->irdp;
-	char buf[PREFIX_STRLEN];
 	uint32_t dst;
 	uint32_t ttl = 1;
 
@@ -190,8 +189,8 @@ static void irdp_send(struct interface *ifp, struct prefix *p, struct stream *s)
 		dst = htonl(INADDR_ALLHOSTS_GROUP);
 
 	if (irdp->flags & IF_DEBUG_MESSAGES)
-		zlog_debug("IRDP: TX Advert on %s %s Holdtime=%d Preference=%d",
-			   ifp->name, prefix2str(p, buf, sizeof(buf)),
+		zlog_debug("IRDP: TX Advert on %s %pFX Holdtime=%d Preference=%d",
+			   ifp->name, p,
 			   irdp->flags & IF_SHUTDOWN ? 0 : irdp->Lifetime,
 			   get_pref(irdp, p));
 

--- a/zebra/irdp_packet.c
+++ b/zebra/irdp_packet.c
@@ -104,8 +104,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 
 	if (iplen < ICMP_MINLEN) {
 		flog_err(EC_ZEBRA_IRDP_LEN_MISMATCH,
-			 "IRDP: RX ICMP packet too short from %s\n",
-			 inet_ntoa(src));
+			 "IRDP: RX ICMP packet too short from %pI4\n",
+			 &src);
 		return;
 	}
 
@@ -115,8 +115,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	 len of IP-header) 14+20 */
 	if (iplen > IRDP_RX_BUF - 34) {
 		flog_err(EC_ZEBRA_IRDP_LEN_MISMATCH,
-			 "IRDP: RX ICMP packet too long from %s\n",
-			 inet_ntoa(src));
+			 "IRDP: RX ICMP packet too long from %pI4\n",
+			 &src);
 		return;
 	}
 
@@ -128,8 +128,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	if (in_cksum(icmp, datalen) != saved_chksum) {
 		flog_warn(
 			EC_ZEBRA_IRDP_BAD_CHECKSUM,
-			"IRDP: RX ICMP packet from %s. Bad checksum, silently ignored",
-			inet_ntoa(src));
+			"IRDP: RX ICMP packet from %pI4. Bad checksum, silently ignored",
+			&src);
 		return;
 	}
 
@@ -141,8 +141,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	if (icmp->code != 0) {
 		flog_warn(
 			EC_ZEBRA_IRDP_BAD_TYPE_CODE,
-			"IRDP: RX packet type %d from %s. Bad ICMP type code, silently ignored",
-			icmp->type, inet_ntoa(src));
+			"IRDP: RX packet type %d from %pI4. Bad ICMP type code, silently ignored",
+			icmp->type, &src);
 		return;
 	}
 
@@ -152,8 +152,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 		&& !(irdp->flags & IF_BROADCAST))) {
 		flog_warn(
 			EC_ZEBRA_IRDP_BAD_RX_FLAGS,
-			"IRDP: RX illegal from %s to %s while %s operates in %s; Please correct settings\n",
-			inet_ntoa(src),
+			"IRDP: RX illegal from %pI4 to %s while %s operates in %s; Please correct settings\n",
+			&src,
 			ntohl(ip->ip_dst.s_addr) == INADDR_ALLRTRS_GROUP
 				? "multicast"
 				: inet_ntoa(ip->ip_dst),
@@ -169,8 +169,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	case ICMP_ROUTERSOLICIT:
 
 		if (irdp->flags & IF_DEBUG_MESSAGES)
-			zlog_debug("IRDP: RX Solicit on %s from %s",
-				   ifp->name, inet_ntoa(src));
+			zlog_debug("IRDP: RX Solicit on %s from %pI4",
+				   ifp->name, &src);
 
 		process_solicit(ifp);
 		break;
@@ -178,8 +178,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	default:
 		flog_warn(
 			EC_ZEBRA_IRDP_BAD_TYPE_CODE,
-			"IRDP: RX packet type %d from %s. Bad ICMP type code, silently ignored",
-			icmp->type, inet_ntoa(src));
+			"IRDP: RX packet type %d from %pI4. Bad ICMP type code, silently ignored",
+			icmp->type, &src);
 	}
 }
 

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -196,14 +196,12 @@ void redistribute_update(const struct prefix *p, const struct prefix *src_p,
 	struct listnode *node, *nnode;
 	struct zserv *client;
 	int afi;
-	char buf[PREFIX_STRLEN];
 
 	if (IS_ZEBRA_DEBUG_RIB) {
-		zlog_debug(
-			"%u:%s: Redist update re %p (%s), old %p (%s)",
-			re->vrf_id, prefix2str(p, buf, sizeof(buf)),
-			re, zebra_route_string(re->type), prev_re,
-			prev_re ? zebra_route_string(prev_re->type) : "None");
+		zlog_debug("%u:%pFX: Redist update re %p (%s), old %p (%s)",
+			   re->vrf_id, p,
+			   re, zebra_route_string(re->type), prev_re,
+			   prev_re ? zebra_route_string(prev_re->type) : "None");
 	}
 
 	afi = family2afi(p->family);
@@ -214,8 +212,8 @@ void redistribute_update(const struct prefix *p, const struct prefix *src_p,
 	}
 	if (!zebra_check_addr(p)) {
 		if (IS_ZEBRA_DEBUG_RIB)
-			zlog_debug("Redist update filter prefix %s",
-				   prefix2str(p, buf, sizeof(buf)));
+			zlog_debug("Redist update filter prefix %pFX",
+				   p);
 		return;
 	}
 
@@ -223,11 +221,10 @@ void redistribute_update(const struct prefix *p, const struct prefix *src_p,
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		if (zebra_redistribute_check(re, client, p, afi)) {
 			if (IS_ZEBRA_DEBUG_RIB) {
-				zlog_debug(
-					   "%s: client %s %s(%u), type=%d, distance=%d, metric=%d",
+				zlog_debug("%s: client %s %pFX(%u), type=%d, distance=%d, metric=%d",
 					   __func__,
 					   zebra_route_string(client->proto),
-					   prefix2str(p, buf, sizeof(buf)),
+					   p,
 					   re->vrf_id, re->type,
 					   re->distance, re->metric);
 			}
@@ -292,9 +289,8 @@ void redistribute_delete(const struct prefix *p, const struct prefix *src_p,
 	/* Skip invalid (e.g. linklocal) prefix */
 	if (!zebra_check_addr(p)) {
 		if (IS_ZEBRA_DEBUG_RIB) {
-			zlog_debug(
-				"%u:%s: Redist del old: skipping invalid prefix",
-				vrfid, prefix2str(p, buf, sizeof(buf)));
+			zlog_debug("%u:%pFX: Redist del old: skipping invalid prefix",
+				   vrfid, p);
 		}
 		return;
 	}
@@ -541,11 +537,9 @@ void zebra_interface_address_add_update(struct interface *ifp,
 	struct prefix *p;
 
 	if (IS_ZEBRA_DEBUG_EVENT) {
-		char buf[PREFIX_STRLEN];
-
 		p = ifc->address;
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADDRESS_ADD %s on %s(%u)",
-			   prefix2str(p, buf, sizeof(buf)), ifp->name,
+		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADDRESS_ADD %pFX on %s(%u)",
+			   p, ifp->name,
 			   ifp->vrf_id);
 	}
 
@@ -580,11 +574,9 @@ void zebra_interface_address_delete_update(struct interface *ifp,
 	struct prefix *p;
 
 	if (IS_ZEBRA_DEBUG_EVENT) {
-		char buf[PREFIX_STRLEN];
-
 		p = ifc->address;
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADDRESS_DELETE %s on %s(%u)",
-			   prefix2str(p, buf, sizeof(buf)),
+		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADDRESS_DELETE %pFX on %s(%u)",
+			   p,
 			   ifp->name, ifp->vrf_id);
 	}
 

--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -178,8 +178,8 @@ void router_id_write(struct vty *vty, struct zebra_vrf *zvrf)
 		snprintf(space, sizeof(space), "%s", " ");
 
 	if (zvrf->rid_user_assigned.u.prefix4.s_addr != INADDR_ANY) {
-		vty_out(vty, "%srouter-id %s\n", space,
-			inet_ntoa(zvrf->rid_user_assigned.u.prefix4));
+		vty_out(vty, "%srouter-id %pI4\n", space,
+			&zvrf->rid_user_assigned.u.prefix4);
 	}
 }
 
@@ -299,11 +299,11 @@ DEFUN (show_router_id,
         if ((zvrf != NULL) && (zvrf->rid_user_assigned.u.prefix4.s_addr)) {
                 vty_out(vty, "zebra:\n");
                 if (vrf_id == VRF_DEFAULT)
-                        vty_out(vty, "     router-id %s vrf default\n",
-                                inet_ntoa(zvrf->rid_user_assigned.u.prefix4));
+                        vty_out(vty, "     router-id %pI4 vrf default\n",
+                                &zvrf->rid_user_assigned.u.prefix4);
                 else
-                        vty_out(vty, "     router-id %s vrf %s\n",
-                                inet_ntoa(zvrf->rid_user_assigned.u.prefix4),
+                        vty_out(vty, "     router-id %pI4 vrf %s\n",
+                                &zvrf->rid_user_assigned.u.prefix4,
                                 argv[idx_name]->arg);
         }
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -674,7 +674,6 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 		p.prefixlen = rtm->rtm_dst_len;
 
 		if (rtm->rtm_src_len != 0) {
-			char buf[PREFIX_STRLEN];
 			flog_warn(
 				EC_ZEBRA_UNSUPPORTED_V4_SRCDEST,
 				"unsupported IPv4 sourcedest route (dest %pFX vrf %u)",
@@ -729,7 +728,6 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 	}
 
 	if (IS_ZEBRA_DEBUG_KERNEL) {
-		char buf[PREFIX_STRLEN];
 		char buf2[PREFIX_STRLEN];
 		zlog_debug("%s %pFX%s%s vrf %s(%u) table_id: %u metric: %d Admin Distance: %d",
 			   nl_msg_type_to_str(h->nlmsg_type),
@@ -2769,7 +2767,6 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	vlanid_t vid = 0;
 	struct in_addr vtep_ip;
 	int vid_present = 0, dst_present = 0;
-	char buf[ETHER_ADDR_STRLEN];
 	char vid_buf[20];
 	char dst_buf[30];
 	bool sticky;
@@ -3168,7 +3165,6 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	struct ipaddr ip;
 	struct vrf *vrf;
 	char buf[ETHER_ADDR_STRLEN];
-	char buf2[INET6_ADDRSTRLEN];
 	int mac_present = 0;
 	bool is_ext;
 	bool is_router;

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -2408,8 +2408,8 @@ static int rtadv_config_write(struct vty *vty, struct interface *ifp)
 	for (ALL_LIST_ELEMENTS_RO(zif->rtadv.AdvPrefixList, node, rprefix)) {
 		if ((rprefix->AdvPrefixCreate == PREFIX_SRC_MANUAL)
 		    || (rprefix->AdvPrefixCreate == PREFIX_SRC_BOTH)) {
-			vty_out(vty, " ipv6 nd prefix %s",
-				prefix2str(&rprefix->prefix, buf, sizeof(buf)));
+			vty_out(vty, " ipv6 nd prefix %pFX",
+				&rprefix->prefix);
 			if ((rprefix->AdvValidLifetime != RTADV_VALID_LIFETIME)
 			    || (rprefix->AdvPreferredLifetime
 				!= RTADV_PREFERRED_LIFETIME)) {
@@ -2437,8 +2437,8 @@ static int rtadv_config_write(struct vty *vty, struct interface *ifp)
 	for (ALL_LIST_ELEMENTS_RO(zif->rtadv.AdvRDNSSList, node, rdnss)) {
 		char buf[INET6_ADDRSTRLEN];
 
-		vty_out(vty, " ipv6 nd rdnss %s",
-			inet_ntop(AF_INET6, &rdnss->addr, buf, sizeof(buf)));
+		vty_out(vty, " ipv6 nd rdnss %pI6",
+			&rdnss->addr);
 		if (rdnss->lifetime_set) {
 			if (rdnss->lifetime == UINT32_MAX)
 				vty_out(vty, " infinite");

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -2337,7 +2337,6 @@ static int rtadv_config_write(struct vty *vty, struct interface *ifp)
 	struct rtadv_prefix *rprefix;
 	struct rtadv_rdnss *rdnss;
 	struct rtadv_dnssl *dnssl;
-	char buf[PREFIX_STRLEN];
 	int interval;
 
 	zif = ifp->info;
@@ -2435,7 +2434,6 @@ static int rtadv_config_write(struct vty *vty, struct interface *ifp)
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(zif->rtadv.AdvRDNSSList, node, rdnss)) {
-		char buf[INET6_ADDRSTRLEN];
 
 		vty_out(vty, " ipv6 nd rdnss %pI6",
 			&rdnss->addr);

--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -138,12 +138,12 @@ netlink_rule_msg_encode(int cmd, const struct zebra_dplane_ctx *ctx,
 	}
 
 	if (IS_ZEBRA_DEBUG_KERNEL)
-		zlog_debug(
-			"Tx %s family %s IF %s(%u) Pref %u Fwmark %u Src %s Dst %s Table %u",
-			nl_msg_type_to_str(cmd), nl_family_to_str(family),
-			ifname, dplane_ctx_get_ifindex(ctx), priority, fwmark,
-			prefix2str(src_ip, buf1, sizeof(buf1)),
-			prefix2str(dst_ip, buf2, sizeof(buf2)), table);
+		zlog_debug("Tx %s family %s IF %s(%u) Pref %u Fwmark %u Src %pFX Dst %pFX Table %u",
+			   nl_msg_type_to_str(cmd), nl_family_to_str(family),
+			   ifname, dplane_ctx_get_ifindex(ctx), priority,
+			   fwmark,
+			   src_ip,
+			   dst_ip, table);
 
 	return NLMSG_ALIGN(req->n.nlmsg_len);
 }
@@ -328,18 +328,15 @@ int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 			ret = dplane_pbr_rule_delete(&rule);
 
-			zlog_debug(
-				"%s: %s leftover rule: family %s IF %s(%u) Pref %u Src %s Dst %s Table %u",
-				__func__,
-				((ret == ZEBRA_DPLANE_REQUEST_FAILURE)
+			zlog_debug("%s: %s leftover rule: family %s IF %s(%u) Pref %u Src %pFX Dst %pFX Table %u",
+				   __func__,
+				   ((ret == ZEBRA_DPLANE_REQUEST_FAILURE)
 					 ? "Failed to remove"
 					 : "Removed"),
 				nl_family_to_str(frh->family), rule.ifname,
 				rule.rule.ifindex, rule.rule.priority,
-				prefix2str(&rule.rule.filter.src_ip, buf1,
-					   sizeof(buf1)),
-				prefix2str(&rule.rule.filter.dst_ip, buf2,
-					   sizeof(buf2)),
+				&rule.rule.filter.src_ip,
+				&rule.rule.filter.dst_ip,
 				rule.rule.action.table);
 		}
 
@@ -354,16 +351,13 @@ int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_KERNEL)
-		zlog_debug(
-			"Rx %s family %s IF %s(%u) Pref %u Src %s Dst %s Table %u",
-			nl_msg_type_to_str(h->nlmsg_type),
-			nl_family_to_str(frh->family), rule.ifname,
-			rule.rule.ifindex, rule.rule.priority,
-			prefix2str(&rule.rule.filter.src_ip, buf1,
-				   sizeof(buf1)),
-			prefix2str(&rule.rule.filter.dst_ip, buf2,
-				   sizeof(buf2)),
-			rule.rule.action.table);
+		zlog_debug("Rx %s family %s IF %s(%u) Pref %u Src %pFX Dst %pFX Table %u",
+			   nl_msg_type_to_str(h->nlmsg_type),
+			   nl_family_to_str(frh->family), rule.ifname,
+			   rule.rule.ifindex, rule.rule.priority,
+			   &rule.rule.filter.src_ip,
+			   &rule.rule.filter.dst_ip,
+			   rule.rule.action.table);
 
 	return kernel_pbr_rule_del(&rule);
 }

--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -75,8 +75,6 @@ netlink_rule_msg_encode(int cmd, const struct zebra_dplane_ctx *ctx,
 	} *req = buf;
 
 	const char *ifname = dplane_ctx_get_ifname(ctx);
-	char buf1[PREFIX_STRLEN];
-	char buf2[PREFIX_STRLEN];
 
 	memset(req, 0, sizeof(*req));
 	family = PREFIX_FAMILY(src_ip);
@@ -236,8 +234,6 @@ int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	int len;
 	char *ifname;
 	struct zebra_pbr_rule rule = {};
-	char buf1[PREFIX_STRLEN];
-	char buf2[PREFIX_STRLEN];
 	uint8_t proto = 0;
 
 	/* Basic validation followed by extracting attributes. */

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -366,7 +366,6 @@ static void zebra_interface_nbr_address_add_update(struct interface *ifp,
 	struct prefix *p;
 
 	if (IS_ZEBRA_DEBUG_EVENT) {
-		char buf[INET6_ADDRSTRLEN];
 
 		p = ifc->address;
 		zlog_debug("MESSAGE: ZEBRA_INTERFACE_NBR_ADDRESS_ADD %pFX on %s",
@@ -392,7 +391,6 @@ static void zebra_interface_nbr_address_delete_update(struct interface *ifp,
 	struct prefix *p;
 
 	if (IS_ZEBRA_DEBUG_EVENT) {
-		char buf[INET6_ADDRSTRLEN];
 
 		p = ifc->address;
 		zlog_debug("MESSAGE: ZEBRA_INTERFACE_NBR_ADDRESS_DELETE %pFX on %s",

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -369,11 +369,8 @@ static void zebra_interface_nbr_address_add_update(struct interface *ifp,
 		char buf[INET6_ADDRSTRLEN];
 
 		p = ifc->address;
-		zlog_debug(
-			"MESSAGE: ZEBRA_INTERFACE_NBR_ADDRESS_ADD %s/%d on %s",
-			inet_ntop(p->family, &p->u.prefix, buf,
-				  INET6_ADDRSTRLEN),
-			p->prefixlen, ifc->ifp->name);
+		zlog_debug("MESSAGE: ZEBRA_INTERFACE_NBR_ADDRESS_ADD %pFX on %s",
+			   p, ifc->ifp->name);
 	}
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
@@ -398,11 +395,8 @@ static void zebra_interface_nbr_address_delete_update(struct interface *ifp,
 		char buf[INET6_ADDRSTRLEN];
 
 		p = ifc->address;
-		zlog_debug(
-			"MESSAGE: ZEBRA_INTERFACE_NBR_ADDRESS_DELETE %s/%d on %s",
-			inet_ntop(p->family, &p->u.prefix, buf,
-				  INET6_ADDRSTRLEN),
-			p->prefixlen, ifc->ifp->name);
+		zlog_debug("MESSAGE: ZEBRA_INTERFACE_NBR_ADDRESS_DELETE %pFX on %s",
+			   p, ifc->ifp->name);
 	}
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -718,21 +718,16 @@ static int route_notify_internal(const struct prefix *p, int type,
 	client = zserv_find_client(type, instance);
 	if (!client || !client->notify_owner) {
 		if (IS_ZEBRA_DEBUG_PACKET) {
-			char buff[PREFIX_STRLEN];
-
-			zlog_debug(
-				"Not Notifying Owner: %u about prefix %s(%u) %d vrf: %u",
-				type, prefix2str(p, buff, sizeof(buff)),
-				table_id, note, vrf_id);
+			zlog_debug("Not Notifying Owner: %u about prefix %pFX(%u) %d vrf: %u",
+				   type, p,
+				   table_id, note, vrf_id);
 		}
 		return 0;
 	}
 
 	if (IS_ZEBRA_DEBUG_PACKET) {
-		char buff[PREFIX_STRLEN];
-
-		zlog_debug("Notifying Owner: %u about prefix %s(%u) %d vrf: %u",
-			   type, prefix2str(p, buff, sizeof(buff)),
+		zlog_debug("Notifying Owner: %u about prefix %pFX(%u) %d vrf: %u",
+			   type, p,
 			   table_id, note, vrf_id);
 	}
 
@@ -1388,13 +1383,10 @@ void zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 			    const unsigned int nexthop_num)
 {
 	if (nexthop_num > zrouter.multipath_num) {
-		char buff[PREFIX2STR_BUFFER];
-
-		prefix2str(p, buff, sizeof(buff));
 		flog_warn(
 			EC_ZEBRA_MORE_NH_THAN_MULTIPATH,
-			"%s: Prefix %s has %d nexthops, but we can only use the first %d",
-			caller, buff, nexthop_num, zrouter.multipath_num);
+			"%s: Prefix %pFX has %d nexthops, but we can only use the first %d",
+			caller, p, nexthop_num, zrouter.multipath_num);
 	}
 }
 

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1934,7 +1934,7 @@ static int fpm_remote_srv_write(struct vty *vty)
 	if ((zfpm_g->fpm_server != FPM_DEFAULT_IP
 	     && zfpm_g->fpm_server != INADDR_ANY)
 	    || (zfpm_g->fpm_port != FPM_DEFAULT_PORT && zfpm_g->fpm_port != 0))
-		vty_out(vty, "fpm connection ip %s port %d\n", inet_ntoa(in),
+		vty_out(vty, "fpm connection ip %pI4 port %d\n", &in,
 			zfpm_g->fpm_port);
 
 	return 0;

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -490,18 +490,15 @@ static void zebra_gr_process_route_entry(struct zserv *client,
 					 struct route_node *rn,
 					 struct route_entry *re)
 {
-	char buf[PREFIX2STR_BUFFER];
-
 	if ((client == NULL) || (rn == NULL) || (re == NULL))
 		return;
 
 	/* If the route is not refreshed after restart, delete the entry */
 	if (re->uptime < client->restart_time) {
 		if (IS_ZEBRA_DEBUG_RIB) {
-			prefix2str(&rn->p, buf, sizeof(buf));
-			zlog_debug("%s: Client %s stale route %s is deleted",
+			zlog_debug("%s: Client %s stale route %pFX is deleted",
 				   __func__, zebra_route_string(client->proto),
-				   buf);
+				   &rn->p);
 		}
 		rib_delnode(rn, re);
 	}

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -1579,7 +1579,7 @@ static void nhlfe_print(zebra_nhlfe_t *nhlfe, struct vty *vty,
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		vty_out(vty, "  via %s", inet_ntoa(nexthop->gate.ipv4));
+		vty_out(vty, "  via %pI4", &nexthop->gate.ipv4);
 		if (nexthop->ifindex)
 			vty_out(vty, " dev %s",
 				ifindex2ifname(nexthop->ifindex,
@@ -1587,9 +1587,8 @@ static void nhlfe_print(zebra_nhlfe_t *nhlfe, struct vty *vty,
 		break;
 	case NEXTHOP_TYPE_IPV6:
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
-		vty_out(vty, "  via %s",
-			inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf,
-				  sizeof(buf)));
+		vty_out(vty, "  via %pI6",
+			&nexthop->gate.ipv6);
 		if (nexthop->ifindex)
 			vty_out(vty, " dev %s",
 				ifindex2ifname(nexthop->ifindex,
@@ -2553,10 +2552,9 @@ int zebra_mpls_fec_unregister(struct zebra_vrf *zvrf, struct prefix *p,
 
 	fec = fec_find(table, p);
 	if (!fec) {
-		prefix2str(p, buf, BUFSIZ);
 		flog_err(EC_ZEBRA_FEC_RM_FAILED,
-			 "Failed to find FEC %s upon unregister, client %s",
-			 buf, zebra_route_string(client->proto));
+			 "Failed to find FEC %pFX upon unregister, client %s",
+			 p, zebra_route_string(client->proto));
 		return -1;
 	}
 
@@ -2721,9 +2719,8 @@ int zebra_mpls_static_fec_add(struct zebra_vrf *zvrf, struct prefix *p,
 		fec = fec_add(table, p, in_label, FEC_FLAG_CONFIGURED,
 			      MPLS_INVALID_LABEL_INDEX);
 		if (!fec) {
-			prefix2str(p, buf, BUFSIZ);
 			flog_err(EC_ZEBRA_FEC_ADD_FAILED,
-				 "Failed to add FEC %s upon config", buf);
+				 "Failed to add FEC %pFX upon config", p);
 			return -1;
 		}
 
@@ -2761,7 +2758,6 @@ int zebra_mpls_static_fec_del(struct zebra_vrf *zvrf, struct prefix *p)
 	struct route_table *table;
 	zebra_fec_t *fec;
 	mpls_label_t old_label;
-	char buf[BUFSIZ];
 
 	table = zvrf->fec_table[family2afi(PREFIX_FAMILY(p))];
 	if (!table)
@@ -2769,15 +2765,13 @@ int zebra_mpls_static_fec_del(struct zebra_vrf *zvrf, struct prefix *p)
 
 	fec = fec_find(table, p);
 	if (!fec) {
-		prefix2str(p, buf, BUFSIZ);
 		flog_err(EC_ZEBRA_FEC_RM_FAILED,
-			 "Failed to find FEC %s upon delete", buf);
+			 "Failed to find FEC %pFX upon delete", p);
 		return -1;
 	}
 
 	if (IS_ZEBRA_DEBUG_MPLS) {
-		prefix2str(p, buf, BUFSIZ);
-		zlog_debug("Delete fec %s label %u label index %u", buf,
+		zlog_debug("Delete fec %pFX label %u label index %u", p,
 			   fec->label, fec->label_index);
 	}
 

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -850,15 +850,15 @@ int lib_interface_zebra_ip_addrs_create(struct nb_cb_create_args *args)
 	case NB_EV_VALIDATE:
 		if (prefix.family == AF_INET
 		    && ipv4_martian(&prefix.u.prefix4)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "invalid address %s",
-				 prefix2str(&prefix, buf, sizeof(buf)));
+			snprintfrr(args->errmsg, args->errmsg_len,
+				 "invalid address %pFX",
+				 &prefix);
 			return NB_ERR_VALIDATION;
 		} else if (prefix.family == AF_INET6
 			   && ipv6_martian(&prefix.u.prefix6)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "invalid address %s",
-				 prefix2str(&prefix, buf, sizeof(buf)));
+			snprintfrr(args->errmsg, args->errmsg_len,
+				 "invalid address %pFX",
+				 &prefix);
 			return NB_ERR_VALIDATION;
 		}
 		break;

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -839,7 +839,6 @@ int lib_interface_zebra_ip_addrs_create(struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
 	struct prefix prefix;
-	char buf[PREFIX_STRLEN] = {0};
 
 	ifp = nb_running_get_entry(args->dnode, NULL, true);
 	// addr_family = yang_dnode_get_enum(dnode, "./address-family");

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -430,8 +430,6 @@ static void if_bfd_session_update(struct interface *ifp, struct prefix *dp,
 				  vrf_id_t vrf_id)
 {
 	if (IS_ZEBRA_DEBUG_EVENT) {
-		char buf[2][INET6_ADDRSTRLEN];
-
 		if (ifp) {
 			zlog_debug("MESSAGE: ZEBRA_INTERFACE_BFD_DEST_UPDATE %pFX on %s %s event",
 				   dp, ifp->name,

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -433,24 +433,16 @@ static void if_bfd_session_update(struct interface *ifp, struct prefix *dp,
 		char buf[2][INET6_ADDRSTRLEN];
 
 		if (ifp) {
-			zlog_debug(
-				"MESSAGE: ZEBRA_INTERFACE_BFD_DEST_UPDATE %s/%d on %s %s event",
-				inet_ntop(dp->family, &dp->u.prefix, buf[0],
-					  INET6_ADDRSTRLEN),
-				dp->prefixlen, ifp->name,
-				bfd_get_status_str(status));
+			zlog_debug("MESSAGE: ZEBRA_INTERFACE_BFD_DEST_UPDATE %pFX on %s %s event",
+				   dp, ifp->name,
+				   bfd_get_status_str(status));
 		} else {
 			struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
-			zlog_debug(
-				"MESSAGE: ZEBRA_INTERFACE_BFD_DEST_UPDATE %s/%d with src %s/%d and vrf %s(%u) %s event",
-				inet_ntop(dp->family, &dp->u.prefix, buf[0],
-					  INET6_ADDRSTRLEN),
-				dp->prefixlen,
-				inet_ntop(sp->family, &sp->u.prefix, buf[1],
-					  INET6_ADDRSTRLEN),
-				sp->prefixlen, VRF_LOGNAME(vrf), vrf_id,
-				bfd_get_status_str(status));
+			zlog_debug("MESSAGE: ZEBRA_INTERFACE_BFD_DEST_UPDATE %pFX with src %pFX and vrf %s(%u) %s event",
+				   dp,
+				   sp, VRF_LOGNAME(vrf), vrf_id,
+				   bfd_get_status_str(status));
 		}
 	}
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2708,7 +2708,7 @@ void _route_entry_dump(const char *func, union prefixconstptr pp,
 	struct nexthop_group *nhg;
 
 	zlog_debug("%s: dumping RE entry %p for %pFX%s%s vrf %s(%u)", func,
-		   (const void *)re, pp,
+		   (const void *)re, pp.p,
 		   is_srcdst ? " from " : "",
 		   is_srcdst ? prefix2str(src_pp, srcaddr, sizeof(srcaddr))
 			     : "",

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -346,11 +346,9 @@ struct route_entry *rib_match_ipv4_multicast(vrf_id_t vrf_id,
 		*rn_out = (re == mre) ? m_rn : u_rn;
 
 	if (IS_ZEBRA_DEBUG_RIB) {
-		char buf[BUFSIZ];
-		inet_ntop(AF_INET, &addr, buf, BUFSIZ);
-
-		zlog_debug("%s: %s: vrf: %s(%u) found %s, using %s", __func__,
-			   buf, vrf_id_to_name(vrf_id), vrf_id,
+		zlog_debug("%s: %pI4: vrf: %s(%u) found %s, using %s",
+			   __func__,
+			   &addr, vrf_id_to_name(vrf_id), vrf_id,
 			   mre ? (ure ? "MRIB+URIB" : "MRIB")
 			       : ure ? "URIB" : "nothing",
 			   re == ure ? "URIB" : re == mre ? "MRIB" : "none");
@@ -2709,8 +2707,8 @@ void _route_entry_dump(const char *func, union prefixconstptr pp,
 	struct vrf *vrf = vrf_lookup_by_id(re->vrf_id);
 	struct nexthop_group *nhg;
 
-	zlog_debug("%s: dumping RE entry %p for %s%s%s vrf %s(%u)", func,
-		   (const void *)re, prefix2str(pp, straddr, sizeof(straddr)),
+	zlog_debug("%s: dumping RE entry %p for %pFX%s%s vrf %s(%u)", func,
+		   (const void *)re, pp,
 		   is_srcdst ? " from " : "",
 		   is_srcdst ? prefix2str(src_pp, srcaddr, sizeof(srcaddr))
 			     : "",
@@ -2750,7 +2748,6 @@ void rib_lookup_and_dump(struct prefix_ipv4 *p, vrf_id_t vrf_id)
 	struct route_node *rn;
 	struct route_entry *re;
 	struct vrf *vrf;
-	char prefix_buf[INET_ADDRSTRLEN];
 
 	vrf = vrf_lookup_by_id(vrf_id);
 
@@ -2768,10 +2765,9 @@ void rib_lookup_and_dump(struct prefix_ipv4 *p, vrf_id_t vrf_id)
 
 	/* No route for this prefix. */
 	if (!rn) {
-		zlog_debug("%s:%s(%u) lookup failed for %s", __func__,
+		zlog_debug("%s:%s(%u) lookup failed for %pFX", __func__,
 			   VRF_LOGNAME(vrf), vrf_id,
-			   prefix2str((struct prefix *)p, prefix_buf,
-				      sizeof(prefix_buf)));
+			   (struct prefix *)p);
 		return;
 	}
 
@@ -2830,14 +2826,13 @@ void rib_lookup_and_pushup(struct prefix_ipv4 *p, vrf_id_t vrf_id)
 	 */
 	if (dest->selected_fib) {
 		if (IS_ZEBRA_DEBUG_RIB) {
-			char buf[PREFIX_STRLEN];
 			struct vrf *vrf =
 				vrf_lookup_by_id(dest->selected_fib->vrf_id);
 
-			zlog_debug(
-				"%s(%u):%s: freeing way for connected prefix",
-				VRF_LOGNAME(vrf), dest->selected_fib->vrf_id,
-				prefix2str(&rn->p, buf, sizeof(buf)));
+			zlog_debug("%s(%u):%pFX: freeing way for connected prefix",
+				   VRF_LOGNAME(vrf),
+				   dest->selected_fib->vrf_id,
+				   &rn->p);
 			route_entry_dump(&rn->p, NULL, dest->selected_fib);
 		}
 		rib_uninstall(rn, dest->selected_fib);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -282,8 +282,8 @@ static void show_nexthop_detail_helper(struct vty *vty,
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		vty_out(vty, " %s",
-			inet_ntoa(nexthop->gate.ipv4));
+		vty_out(vty, " %pI4",
+			&nexthop->gate.ipv4);
 		if (nexthop->ifindex)
 			vty_out(vty, ", via %s",
 				ifindex2ifname(
@@ -292,9 +292,8 @@ static void show_nexthop_detail_helper(struct vty *vty,
 		break;
 	case NEXTHOP_TYPE_IPV6:
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
-		vty_out(vty, " %s",
-			inet_ntop(AF_INET6, &nexthop->gate.ipv6,
-				  buf, sizeof(buf)));
+		vty_out(vty, " %pI6",
+			&nexthop->gate.ipv6);
 		if (nexthop->ifindex)
 			vty_out(vty, ", via %s",
 				ifindex2ifname(
@@ -493,7 +492,7 @@ static void show_route_nexthop_helper(struct vty *vty,
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		vty_out(vty, " via %s", inet_ntoa(nexthop->gate.ipv4));
+		vty_out(vty, " via %pI4", &nexthop->gate.ipv4);
 		if (nexthop->ifindex)
 			vty_out(vty, ", %s",
 				ifindex2ifname(nexthop->ifindex,
@@ -501,9 +500,8 @@ static void show_route_nexthop_helper(struct vty *vty,
 		break;
 	case NEXTHOP_TYPE_IPV6:
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
-		vty_out(vty, " via %s",
-			inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf,
-				  sizeof(buf)));
+		vty_out(vty, " via %pI6",
+			&nexthop->gate.ipv6);
 		if (nexthop->ifindex)
 			vty_out(vty, ", %s",
 				ifindex2ifname(nexthop->ifindex,

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -570,8 +570,6 @@ static void zebra_vxlan_dup_addr_detect_for_neigh(struct zebra_vrf *zvrf,
 {
 
 	struct timeval elapsed = {0, 0};
-	char buf[ETHER_ADDR_STRLEN];
-	char buf1[INET6_ADDRSTRLEN];
 	bool reset_params = false;
 
 	if (!zvrf->dup_addr_detect)
@@ -2708,8 +2706,6 @@ static int zvni_advertise_subnet(zebra_vni_t *zvni, struct interface *ifp,
 static int zvni_gw_macip_add(struct interface *ifp, zebra_vni_t *zvni,
 			     struct ethaddr *macaddr, struct ipaddr *ip)
 {
-	char buf[ETHER_ADDR_STRLEN];
-	char buf2[INET6_ADDRSTRLEN];
 	zebra_neigh_t *n = NULL;
 	zebra_mac_t *mac = NULL;
 	struct zebra_if *zif = NULL;
@@ -2992,8 +2988,6 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 				   struct ethaddr *macaddr,
 				   bool is_router)
 {
-	char buf[ETHER_ADDR_STRLEN];
-	char buf2[INET6_ADDRSTRLEN];
 	struct zebra_vrf *zvrf;
 	zebra_neigh_t *n = NULL;
 	zebra_mac_t *zmac = NULL, *old_zmac = NULL;
@@ -5601,7 +5595,6 @@ static void process_remote_macip_add(vni_t vni,
 	zebra_mac_t *mac = NULL, *old_mac = NULL;
 	zebra_neigh_t *n = NULL;
 	int update_mac = 0, update_neigh = 0;
-	char buf[ETHER_ADDR_STRLEN];
 	char buf1[INET6_ADDRSTRLEN];
 	struct interface *ifp = NULL;
 	struct zebra_if *zif = NULL;
@@ -5935,7 +5928,6 @@ static void process_remote_macip_del(vni_t vni,
 	struct zebra_ns *zns;
 	struct zebra_l2info_vxlan *vxl;
 	struct zebra_vrf *zvrf;
-	char buf[ETHER_ADDR_STRLEN];
 	char buf1[INET6_ADDRSTRLEN];
 
 	/* Locate VNI hash entry - expected to exist. */
@@ -7599,8 +7591,6 @@ int zebra_vxlan_handle_kernel_neigh_del(struct interface *ifp,
 					struct interface *link_if,
 					struct ipaddr *ip)
 {
-	char buf[INET6_ADDRSTRLEN];
-	char buf2[ETHER_ADDR_STRLEN];
 	zebra_neigh_t *n = NULL;
 	zebra_vni_t *zvni = NULL;
 	zebra_mac_t *zmac = NULL;
@@ -7849,7 +7839,6 @@ void zebra_vxlan_remote_macip_add(ZAPI_HANDLER_ARGS)
 	uint16_t l = 0, ipa_len;
 	uint8_t flags = 0;
 	uint32_t seq;
-	char buf[ETHER_ADDR_STRLEN];
 	char buf1[INET6_ADDRSTRLEN];
 
 	memset(&macaddr, 0, sizeof(struct ethaddr));
@@ -8118,7 +8107,6 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 	zebra_vni_t *zvni;
 	zebra_mac_t *mac;
 	struct zebra_vrf *zvrf;
-	char buf[ETHER_ADDR_STRLEN];
 	bool mac_sticky = false;
 	bool inform_client = false;
 	bool upd_neigh = false;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -441,12 +441,11 @@ static void zebra_vxlan_dup_addr_detect_for_mac(struct zebra_vrf *zvrf,
 	 */
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_DUPLICATE)) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"%s: duplicate addr MAC %s flags 0x%x skip update to client, learn count %u recover time %u",
-				__func__,
-				prefix_mac2str(&mac->macaddr, buf, sizeof(buf)),
-				mac->flags, mac->dad_count,
-				zvrf->dad_freeze_time);
+			zlog_debug("%s: duplicate addr MAC %pEA flags 0x%x skip update to client, learn count %u recover time %u",
+				   __func__,
+				   &mac->macaddr,
+				   mac->flags, mac->dad_count,
+				   zvrf->dad_freeze_time);
 
 		/* For duplicate MAC do not update
 		 * client but update neigh due to
@@ -506,11 +505,11 @@ static void zebra_vxlan_dup_addr_detect_for_mac(struct zebra_vrf *zvrf,
 
 	if (mac->dad_count >= zvrf->dad_max_moves) {
 		flog_warn(EC_ZEBRA_DUP_MAC_DETECTED,
-			  "VNI %u: MAC %s detected as duplicate during %s VTEP %s",
+			  "VNI %u: MAC %s detected as duplicate during %s VTEP %pI4",
 			  mac->zvni->vni,
 			  prefix_mac2str(&mac->macaddr, buf, sizeof(buf)),
 			  is_local ? "local update, last" :
-			  "remote update, from", inet_ntoa(vtep_ip));
+			  "remote update, from", &vtep_ip);
 
 		SET_FLAG(mac->flags, ZEBRA_MAC_DUPLICATE);
 
@@ -543,12 +542,10 @@ static void zebra_vxlan_dup_addr_detect_for_mac(struct zebra_vrf *zvrf,
 		THREAD_OFF(mac->dad_mac_auto_recovery_timer);
 		if (zvrf->dad_freeze && zvrf->dad_freeze_time) {
 			if (IS_ZEBRA_DEBUG_VXLAN)
-				zlog_debug(
-					"%s: duplicate addr MAC %s flags 0x%x auto recovery time %u start",
-					__func__,
-					prefix_mac2str(&mac->macaddr, buf,
-						       sizeof(buf)),
-					mac->flags, zvrf->dad_freeze_time);
+				zlog_debug("%s: duplicate addr MAC %pEA flags 0x%x auto recovery time %u start",
+					   __func__,
+					   &mac->macaddr,
+					   mac->flags, zvrf->dad_freeze_time);
 
 			thread_add_timer(zrouter.master,
 					 zebra_vxlan_dad_mac_auto_recovery_exp,
@@ -586,13 +583,12 @@ static void zebra_vxlan_dup_addr_detect_for_neigh(struct zebra_vrf *zvrf,
 	 */
 	if (CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_DUPLICATE)) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"%s: duplicate addr MAC %s IP %s flags 0x%x skip installing, learn count %u recover time %u",
-				__func__,
-				prefix_mac2str(&nbr->emac, buf, sizeof(buf)),
-				ipaddr2str(&nbr->ip, buf1, sizeof(buf1)),
-				nbr->flags, nbr->dad_count,
-				zvrf->dad_freeze_time);
+			zlog_debug("%s: duplicate addr MAC %pEA IP %pIA flags 0x%x skip installing, learn count %u recover time %u",
+				   __func__,
+				   &nbr->emac,
+				   &nbr->ip,
+				   nbr->flags, nbr->dad_count,
+				   zvrf->dad_freeze_time);
 
 		if (zvrf->dad_freeze)
 			*is_dup_detect = true;
@@ -626,12 +622,11 @@ static void zebra_vxlan_dup_addr_detect_for_neigh(struct zebra_vrf *zvrf,
 
 	if (reset_params) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"%s: duplicate addr MAC %s IP %s flags 0x%x detection time passed, reset learn count %u",
-				__func__,
-				prefix_mac2str(&nbr->emac, buf, sizeof(buf)),
-				ipaddr2str(&nbr->ip, buf1, sizeof(buf1)),
-				nbr->flags, nbr->dad_count);
+			zlog_debug("%s: duplicate addr MAC %pEA IP %pIA flags 0x%x detection time passed, reset learn count %u",
+				   __func__,
+				   &nbr->emac,
+				   &nbr->ip,
+				   nbr->flags, nbr->dad_count);
 		/* Reset learn count but do not start detection
 		 * during REMOTE learn event.
 		 */
@@ -659,13 +654,13 @@ static void zebra_vxlan_dup_addr_detect_for_neigh(struct zebra_vrf *zvrf,
 
 	if (nbr->dad_count >= zvrf->dad_max_moves) {
 		flog_warn(EC_ZEBRA_DUP_IP_DETECTED,
-			  "VNI %u: MAC %s IP %s detected as duplicate during %s VTEP %s",
+			  "VNI %u: MAC %pEA IP %pIA detected as duplicate during %s VTEP %pI4",
 			  nbr->zvni->vni,
-			  prefix_mac2str(&nbr->emac, buf, sizeof(buf)),
-			  ipaddr2str(&nbr->ip, buf1, sizeof(buf1)),
+			  &nbr->emac,
+			  &nbr->ip,
 			  is_local ? "local update, last" :
 			  "remote update, from",
-			  inet_ntoa(vtep_ip));
+			  &vtep_ip);
 
 		SET_FLAG(nbr->flags, ZEBRA_NEIGH_DUPLICATE);
 
@@ -676,14 +671,11 @@ static void zebra_vxlan_dup_addr_detect_for_neigh(struct zebra_vrf *zvrf,
 		THREAD_OFF(nbr->dad_ip_auto_recovery_timer);
 		if (zvrf->dad_freeze && zvrf->dad_freeze_time) {
 			if (IS_ZEBRA_DEBUG_VXLAN)
-				zlog_debug(
-					"%s: duplicate addr MAC %s IP %s flags 0x%x auto recovery time %u start",
-					__func__,
-					prefix_mac2str(&nbr->emac, buf,
-						       sizeof(buf)),
-					ipaddr2str(&nbr->ip, buf1,
-						   sizeof(buf1)),
-					nbr->flags, zvrf->dad_freeze_time);
+				zlog_debug("%s: duplicate addr MAC %pEA IP %pIA flags 0x%x auto recovery time %u start",
+					   __func__,
+					   &nbr->emac,
+					   &nbr->ip,
+					   nbr->flags, zvrf->dad_freeze_time);
 
 			thread_add_timer(zrouter.master,
 				zebra_vxlan_dad_ip_auto_recovery_exp,
@@ -742,12 +734,12 @@ static void zvni_print_neigh(zebra_neigh_t *n, void *ctxt, json_object *json)
 	state_str = IS_ZEBRA_NEIGH_ACTIVE(n) ? "active" : "inactive";
 	vty = (struct vty *)ctxt;
 	if (json == NULL) {
-		vty_out(vty, "IP: %s\n",
-			ipaddr2str(&n->ip, buf2, sizeof(buf2)));
+		vty_out(vty, "IP: %pIA\n",
+			&n->ip);
 		vty_out(vty, " Type: %s\n", type_str);
 		vty_out(vty, " State: %s\n", state_str);
-		vty_out(vty, " MAC: %s\n",
-			prefix_mac2str(&n->emac, buf1, sizeof(buf1)));
+		vty_out(vty, " MAC: %pEA\n",
+			&n->emac);
 	} else {
 		json_object_string_add(json, "ip", buf2);
 		json_object_string_add(json, "type", type_str);
@@ -756,8 +748,8 @@ static void zvni_print_neigh(zebra_neigh_t *n, void *ctxt, json_object *json)
 	}
 	if (CHECK_FLAG(n->flags, ZEBRA_NEIGH_REMOTE)) {
 		if (json == NULL) {
-			vty_out(vty, " Remote VTEP: %s\n",
-				inet_ntoa(n->r_vtep_ip));
+			vty_out(vty, " Remote VTEP: %pI4\n",
+				&n->r_vtep_ip);
 		} else
 			json_object_string_add(json, "remoteVtep",
 					       inet_ntoa(n->r_vtep_ip));
@@ -875,9 +867,9 @@ static void zvni_print_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 					-wctx->addr_width, "Neighbor", "Type",
 					"State", "MAC", "Remote VTEP",
 					"Seq #'s");
-			vty_out(vty, "%*s %-6s %-8s %-17s %-21s %u/%u\n",
+			vty_out(vty, "%*s %-6s %-8s %-17s %-21pI4 %u/%u\n",
 				-wctx->addr_width, buf2, "remote", state_str,
-				buf1, inet_ntoa(n->r_vtep_ip), n->loc_seq, n->rem_seq);
+				buf1, &n->r_vtep_ip, n->loc_seq, n->rem_seq);
 		} else {
 			json_object_string_add(json_row, "type", "remote");
 			json_object_string_add(json_row, "state", state_str);
@@ -1091,22 +1083,21 @@ static void zvni_print_neigh_hash_all_vni_detail(struct hash_bucket *bucket,
 static void zl3vni_print_nh(zebra_neigh_t *n, struct vty *vty,
 			    json_object *json)
 {
-	char buf1[ETHER_ADDR_STRLEN];
 	char buf2[INET6_ADDRSTRLEN];
 	json_object *json_hosts = NULL;
 	struct host_rb_entry *hle;
 
 	if (!json) {
-		vty_out(vty, "Ip: %s\n",
-			ipaddr2str(&n->ip, buf2, sizeof(buf2)));
-		vty_out(vty, "  RMAC: %s\n",
-			prefix_mac2str(&n->emac, buf1, sizeof(buf1)));
+		vty_out(vty, "Ip: %pIA\n",
+			&n->ip);
+		vty_out(vty, "  RMAC: %pEA\n",
+			&n->emac);
 		vty_out(vty, "  Refcount: %d\n",
 			rb_host_count(&n->host_rb));
 		vty_out(vty, "  Prefixes:\n");
 		RB_FOREACH (hle, host_rb_tree_entry, &n->host_rb)
-			vty_out(vty, "    %s\n",
-				prefix2str(&hle->p, buf2, sizeof(buf2)));
+			vty_out(vty, "    %pFX\n",
+				&hle->p);
 	} else {
 		json_hosts = json_object_new_array();
 		json_object_string_add(
@@ -1134,15 +1125,15 @@ static void zl3vni_print_rmac(zebra_mac_t *zrmac, struct vty *vty,
 	struct host_rb_entry *hle;
 
 	if (!json) {
-		vty_out(vty, "MAC: %s\n",
-			prefix_mac2str(&zrmac->macaddr, buf1, sizeof(buf1)));
-		vty_out(vty, " Remote VTEP: %s\n",
-			inet_ntoa(zrmac->fwd_info.r_vtep_ip));
+		vty_out(vty, "MAC: %pEA\n",
+			&zrmac->macaddr);
+		vty_out(vty, " Remote VTEP: %pI4\n",
+			&zrmac->fwd_info.r_vtep_ip);
 		vty_out(vty, " Refcount: %d\n", rb_host_count(&zrmac->host_rb));
 		vty_out(vty, "  Prefixes:\n");
 		RB_FOREACH (hle, host_rb_tree_entry, &zrmac->host_rb)
-			vty_out(vty, "    %s\n",
-				prefix2str(&hle->p, buf2, sizeof(buf2)));
+			vty_out(vty, "    %pFX\n",
+				&hle->p);
 	} else {
 		json_hosts = json_object_new_array();
 		json_object_string_add(
@@ -1284,8 +1275,8 @@ static void zvni_print_mac(zebra_mac_t *mac, void *ctxt, json_object *json)
 				vty_out(vty, " VLAN: %u",
 					mac->fwd_info.local.vid);
 		} else if (CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE)) {
-			vty_out(vty, " Remote VTEP: %s",
-				inet_ntoa(mac->fwd_info.r_vtep_ip));
+			vty_out(vty, " Remote VTEP: %pI4",
+				&mac->fwd_info.r_vtep_ip);
 		} else if (CHECK_FLAG(mac->flags, ZEBRA_MAC_AUTO)) {
 			vty_out(vty, " Auto Mac ");
 		}
@@ -1326,8 +1317,8 @@ static void zvni_print_mac(zebra_mac_t *mac, void *ctxt, json_object *json)
 			vty_out(vty, "    No Neighbors\n");
 		else {
 			for (ALL_LIST_ELEMENTS_RO(mac->neigh_list, node, n)) {
-				vty_out(vty, "    %s %s\n",
-					ipaddr2str(&n->ip, buf2, sizeof(buf2)),
+				vty_out(vty, "    %pIA %s\n",
+					&n->ip,
 					(IS_ZEBRA_NEIGH_ACTIVE(n)
 						 ? "Active"
 						 : "Inactive"));
@@ -1424,8 +1415,8 @@ static void zvni_print_mac_hash(struct hash_bucket *bucket, void *ctxt)
 					"MAC", "Type", "Intf/Remote VTEP",
 					"VLAN", "Seq #'s");
 			}
-			vty_out(vty, "%-17s %-6s %-21s %-5s %u/%u\n", buf1,
-				"remote", inet_ntoa(mac->fwd_info.r_vtep_ip),
+			vty_out(vty, "%-17s %-6s %-21pI4 %-5s %u/%u\n", buf1,
+				"remote", &mac->fwd_info.r_vtep_ip,
 				"", mac->loc_seq, mac->rem_seq);
 		} else {
 			json_object_string_add(json_mac, "type", "remote");
@@ -1655,9 +1646,9 @@ static void zl3vni_print_nh_hash(struct hash_bucket *bucket, void *ctx)
 	n = (zebra_neigh_t *)bucket->data;
 
 	if (!json_vni) {
-		vty_out(vty, "%-15s %-17s\n",
-			ipaddr2str(&(n->ip), buf2, sizeof(buf2)),
-			prefix_mac2str(&n->emac, buf1, sizeof(buf1)));
+		vty_out(vty, "%-15pIA %-17pEA\n",
+			&(n->ip),
+			&n->emac);
 	} else {
 		json_object_string_add(json_nh, "nexthopIp",
 				       ipaddr2str(&n->ip, buf2, sizeof(buf2)));
@@ -1769,9 +1760,9 @@ static void zl3vni_print_rmac_hash(struct hash_bucket *bucket, void *ctx)
 	zrmac = (zebra_mac_t *)bucket->data;
 
 	if (!json) {
-		vty_out(vty, "%-17s %-21s\n",
-			prefix_mac2str(&zrmac->macaddr, buf, sizeof(buf)),
-			inet_ntoa(zrmac->fwd_info.r_vtep_ip));
+		vty_out(vty, "%-17pEA %-21pI4\n",
+			&zrmac->macaddr,
+			&zrmac->fwd_info.r_vtep_ip);
 	} else {
 		json_object_string_add(
 			json_rmac, "routerMac",
@@ -1801,8 +1792,8 @@ static void zl3vni_print(zebra_l3vni_t *zl3vni, void **ctx)
 		vty_out(vty, "VNI: %u\n", zl3vni->vni);
 		vty_out(vty, "  Type: %s\n", "L3");
 		vty_out(vty, "  Tenant VRF: %s\n", zl3vni_vrf_name(zl3vni));
-		vty_out(vty, "  Local Vtep Ip: %s\n",
-			inet_ntoa(zl3vni->local_vtep_ip));
+		vty_out(vty, "  Local Vtep Ip: %pI4\n",
+			&zl3vni->local_vtep_ip);
 		vty_out(vty, "  Vxlan-Intf: %s\n",
 			zl3vni_vxlan_if_name(zl3vni));
 		vty_out(vty, "  SVI-If: %s\n", zl3vni_svi_if_name(zl3vni));
@@ -1887,10 +1878,10 @@ static void zvni_print(zebra_vni_t *zvni, void **ctxt)
 	if (json == NULL) {
 		vty_out(vty, " VxLAN interface: %s\n", zvni->vxlan_if->name);
 		vty_out(vty, " VxLAN ifIndex: %u\n", zvni->vxlan_if->ifindex);
-		vty_out(vty, " Local VTEP IP: %s\n",
-			inet_ntoa(zvni->local_vtep_ip));
-		vty_out(vty, " Mcast group: %s\n",
-				inet_ntoa(zvni->mcast_grp));
+		vty_out(vty, " Local VTEP IP: %pI4\n",
+			&zvni->local_vtep_ip);
+		vty_out(vty, " Mcast group: %pI4\n",
+				&zvni->mcast_grp);
 	} else {
 		json_object_string_add(json, "vxlanInterface",
 				       zvni->vxlan_if->name);
@@ -1918,8 +1909,8 @@ static void zvni_print(zebra_vni_t *zvni, void **ctxt)
 					VXLAN_FLOOD_STR_DEFAULT);
 
 			if (json == NULL) {
-				vty_out(vty, "  %s flood: %s\n",
-						inet_ntoa(zvtep->vtep_ip),
+				vty_out(vty, "  %pI4 flood: %s\n",
+						&zvtep->vtep_ip,
 						flood_str);
 			} else {
 				json_ip_str = json_object_new_string(
@@ -2108,8 +2099,6 @@ static int zvni_macip_send_msg_to_client(vni_t vni, struct ethaddr *macaddr,
 					 struct ipaddr *ip, uint8_t flags,
 					 uint32_t seq, int state, uint16_t cmd)
 {
-	char buf[ETHER_ADDR_STRLEN];
-	char buf2[INET6_ADDRSTRLEN];
 	int ipa_len;
 	struct zserv *client = NULL;
 	struct stream *s = NULL;
@@ -2149,12 +2138,11 @@ static int zvni_macip_send_msg_to_client(vni_t vni, struct ethaddr *macaddr,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug(
-			"Send MACIP %s flags 0x%x MAC %s IP %s seq %u L2-VNI %u to %s",
-			(cmd == ZEBRA_MACIP_ADD) ? "Add" : "Del", flags,
-			prefix_mac2str(macaddr, buf, sizeof(buf)),
-			ipaddr2str(ip, buf2, sizeof(buf2)), seq, vni,
-			zebra_route_string(client->proto));
+		zlog_debug("Send MACIP %s flags 0x%x MAC %pEA IP %pIA seq %u L2-VNI %u to %s",
+			   (cmd == ZEBRA_MACIP_ADD) ? "Add" : "Del", flags,
+			   macaddr,
+			   ip, seq, vni,
+			   zebra_route_string(client->proto));
 
 	if (cmd == ZEBRA_MACIP_ADD)
 		client->macipadd_cnt++;
@@ -2341,13 +2329,12 @@ static void zvni_process_neigh_on_local_mac_change(zebra_vni_t *zvni,
 	zebra_neigh_t *n = NULL;
 	struct listnode *node = NULL;
 	struct zebra_vrf *zvrf = NULL;
-	char buf[ETHER_ADDR_STRLEN];
 
 	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Processing neighbors on local MAC %s %s, VNI %u",
-			   prefix_mac2str(&zmac->macaddr, buf, sizeof(buf)),
+		zlog_debug("Processing neighbors on local MAC %pEA %s, VNI %u",
+			   &zmac->macaddr,
 			   seq_change ? "CHANGE" : "ADD", zvni->vni);
 
 	/* Walk all neighbors and mark any inactive local neighbors as
@@ -2381,11 +2368,10 @@ static void zvni_process_neigh_on_local_mac_del(zebra_vni_t *zvni,
 {
 	zebra_neigh_t *n = NULL;
 	struct listnode *node = NULL;
-	char buf[ETHER_ADDR_STRLEN];
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Processing neighbors on local MAC %s DEL, VNI %u",
-			   prefix_mac2str(&zmac->macaddr, buf, sizeof(buf)),
+		zlog_debug("Processing neighbors on local MAC %pEA DEL, VNI %u",
+			   &zmac->macaddr,
 			   zvni->vni);
 
 	/* Walk all local neighbors and mark as inactive and inform
@@ -2415,11 +2401,10 @@ static void zvni_process_neigh_on_remote_mac_add(zebra_vni_t *zvni,
 {
 	zebra_neigh_t *n = NULL;
 	struct listnode *node = NULL;
-	char buf[ETHER_ADDR_STRLEN];
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Processing neighbors on remote MAC %s ADD, VNI %u",
-			   prefix_mac2str(&zmac->macaddr, buf, sizeof(buf)),
+		zlog_debug("Processing neighbors on remote MAC %pEA ADD, VNI %u",
+			   &zmac->macaddr,
 			   zvni->vni);
 
 	/* Walk all local neighbors and mark as inactive and inform
@@ -2746,8 +2731,8 @@ static int zvni_gw_macip_add(struct interface *ifp, zebra_vni_t *zvni,
 		mac = zvni_mac_add(zvni, macaddr);
 		if (!mac) {
 			flog_err(EC_ZEBRA_MAC_ADD_FAILED,
-				 "Failed to add MAC %s intf %s(%u) VID %u",
-				 prefix_mac2str(macaddr, buf, sizeof(buf)),
+				 "Failed to add MAC %pEA intf %s(%u) VID %u",
+				 macaddr,
 				 ifp->name, ifp->ifindex, vxl->access_vlan);
 			return -1;
 		}
@@ -2768,9 +2753,9 @@ static int zvni_gw_macip_add(struct interface *ifp, zebra_vni_t *zvni,
 		if (!n) {
 			flog_err(
 				EC_ZEBRA_MAC_ADD_FAILED,
-				"Failed to add neighbor %s MAC %s intf %s(%u) -> VNI %u",
-				ipaddr2str(ip, buf2, sizeof(buf2)),
-				prefix_mac2str(macaddr, buf, sizeof(buf)),
+				"Failed to add neighbor %pIA MAC %pEA intf %s(%u) -> VNI %u",
+				ip,
+				macaddr,
 				ifp->name, ifp->ifindex, zvni->vni);
 			return -1;
 		}
@@ -2792,11 +2777,10 @@ static int zvni_gw_macip_add(struct interface *ifp, zebra_vni_t *zvni,
 			SET_FLAG(n->flags, ZEBRA_NEIGH_ROUTER_FLAG);
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-			"SVI %s(%u) L2-VNI %u, sending GW MAC %s IP %s add to BGP with flags 0x%x",
-			ifp->name, ifp->ifindex, zvni->vni,
-			prefix_mac2str(macaddr, buf, sizeof(buf)),
-			ipaddr2str(ip, buf2, sizeof(buf2)), n->flags);
+			zlog_debug("SVI %s(%u) L2-VNI %u, sending GW MAC %pEA IP %pIA add to BGP with flags 0x%x",
+				   ifp->name, ifp->ifindex, zvni->vni,
+				   macaddr,
+				   ip, n->flags);
 
 		zvni_neigh_send_add_to_client(zvni->vni, ip, macaddr,
 					      n->flags, n->loc_seq);
@@ -2804,11 +2788,10 @@ static int zvni_gw_macip_add(struct interface *ifp, zebra_vni_t *zvni,
 
 		SET_FLAG(n->flags, ZEBRA_NEIGH_SVI_IP);
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-			"SVI %s(%u) L2-VNI %u, sending SVI MAC %s IP %s add to BGP with flags 0x%x",
-			ifp->name, ifp->ifindex, zvni->vni,
-			prefix_mac2str(macaddr, buf, sizeof(buf)),
-			ipaddr2str(ip, buf2, sizeof(buf2)), n->flags);
+			zlog_debug("SVI %s(%u) L2-VNI %u, sending SVI MAC %pEA IP %pIA add to BGP with flags 0x%x",
+				   ifp->name, ifp->ifindex, zvni->vni,
+				   macaddr,
+				   ip, n->flags);
 
 		zvni_neigh_send_add_to_client(zvni->vni, ip, macaddr,
 					      n->flags, n->loc_seq);
@@ -2823,8 +2806,6 @@ static int zvni_gw_macip_add(struct interface *ifp, zebra_vni_t *zvni,
 static int zvni_gw_macip_del(struct interface *ifp, zebra_vni_t *zvni,
 			     struct ipaddr *ip)
 {
-	char buf1[ETHER_ADDR_STRLEN];
-	char buf2[INET6_ADDRSTRLEN];
 	zebra_neigh_t *n = NULL;
 	zebra_mac_t *mac = NULL;
 
@@ -2837,10 +2818,9 @@ static int zvni_gw_macip_del(struct interface *ifp, zebra_vni_t *zvni,
 	mac = zvni_mac_lookup(zvni, &n->emac);
 	if (!mac) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("MAC %s doesn't exist for neigh %s on VNI %u",
-				   prefix_mac2str(&n->emac,
-						  buf1, sizeof(buf1)),
-				   ipaddr2str(ip, buf2, sizeof(buf2)),
+			zlog_debug("MAC %pEA doesn't exist for neigh %pIA on VNI %u",
+				   &n->emac,
+				   ip,
 				   zvni->vni);
 		return -1;
 	}
@@ -2851,11 +2831,10 @@ static int zvni_gw_macip_del(struct interface *ifp, zebra_vni_t *zvni,
 
 	/* only need to delete the entry from bgp if we sent it before */
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug(
-			"%u:SVI %s(%u) VNI %u, sending GW MAC %s IP %s del to BGP",
-			ifp->vrf_id, ifp->name, ifp->ifindex, zvni->vni,
-			prefix_mac2str(&(n->emac), buf1, sizeof(buf1)),
-			ipaddr2str(ip, buf2, sizeof(buf2)));
+		zlog_debug("%u:SVI %s(%u) VNI %u, sending GW MAC %pEA IP %pIA del to BGP",
+			   ifp->vrf_id, ifp->name, ifp->ifindex, zvni->vni,
+			   &(n->emac),
+			   ip);
 
 	/* Remove neighbor from BGP. */
 	zvni_neigh_send_del_to_client(zvni->vni, &n->ip, &n->emac,
@@ -3031,15 +3010,14 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 	if (!zmac) {
 		/* create a dummy MAC if the MAC is not already present */
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"AUTO MAC %s created for neigh %s on VNI %u",
-				prefix_mac2str(macaddr, buf, sizeof(buf)),
-				ipaddr2str(ip, buf2, sizeof(buf2)), zvni->vni);
+			zlog_debug("AUTO MAC %pEA created for neigh %pIA on VNI %u",
+				   macaddr,
+				   ip, zvni->vni);
 
 		zmac = zvni_mac_add(zvni, macaddr);
 		if (!zmac) {
-			zlog_debug("Failed to add MAC %s VNI %u",
-				   prefix_mac2str(macaddr, buf, sizeof(buf)),
+			zlog_debug("Failed to add MAC %pEA VNI %u",
+				   macaddr,
 				   zvni->vni);
 			return -1;
 		}
@@ -3076,9 +3054,9 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 		if (!n) {
 			flog_err(
 				EC_ZEBRA_MAC_ADD_FAILED,
-				"Failed to add neighbor %s MAC %s intf %s(%u) -> VNI %u",
-				ipaddr2str(ip, buf2, sizeof(buf2)),
-				prefix_mac2str(macaddr, buf, sizeof(buf)),
+				"Failed to add neighbor %pIA MAC %pEA intf %s(%u) -> VNI %u",
+				ip,
+				macaddr,
 				ifp->name, ifp->ifindex, zvni->vni);
 			return -1;
 		}
@@ -3222,10 +3200,10 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 	 */
 	if (zebra_vxlan_ip_inherit_dad_from_mac(zvrf, old_zmac, zmac, n)) {
 		flog_warn(EC_ZEBRA_DUP_IP_INHERIT_DETECTED,
-			"VNI %u: MAC %s IP %s detected as duplicate during local update, inherit duplicate from MAC",
+			"VNI %u: MAC %pEA IP %pIA detected as duplicate during local update, inherit duplicate from MAC",
 			zvni->vni,
-			prefix_mac2str(macaddr, buf, sizeof(buf)),
-			ipaddr2str(&n->ip, buf2, sizeof(buf2)));
+			macaddr,
+			&n->ip);
 	}
 
 	/* For IP Duplicate Address Detection (DAD) is trigger,
@@ -3255,8 +3233,8 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 	 */
 	if (upd_mac_seq && zmac->loc_seq != mac_new_seq) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("Seq changed for MAC %s VNI %u - old %u new %u",
-				   prefix_mac2str(macaddr, buf, sizeof(buf)),
+			zlog_debug("Seq changed for MAC %pEA VNI %u - old %u new %u",
+				   macaddr,
 				   zvni->vni, zmac->loc_seq, mac_new_seq);
 		zmac->loc_seq = mac_new_seq;
 		if (zvni_mac_send_add_to_client(zvni->vni, macaddr,
@@ -3286,8 +3264,6 @@ static int zvni_remote_neigh_update(zebra_vni_t *zvni,
 				    struct ethaddr *macaddr,
 				    uint16_t state)
 {
-	char buf[ETHER_ADDR_STRLEN];
-	char buf2[INET6_ADDRSTRLEN];
 	zebra_neigh_t *n = NULL;
 	zebra_mac_t *zmac = NULL;
 
@@ -3310,11 +3286,10 @@ static int zvni_remote_neigh_update(zebra_vni_t *zvni,
 		 */
 		zmac = zvni_mac_lookup(zvni, macaddr);
 		if (!zmac || !CHECK_FLAG(zmac->flags, ZEBRA_MAC_REMOTE)) {
-			zlog_debug(
-				"Ignore remote neigh %s (MAC %s) on L2-VNI %u - MAC unknown or local",
-				ipaddr2str(&n->ip, buf2, sizeof(buf2)),
-				prefix_mac2str(macaddr, buf, sizeof(buf)),
-				zvni->vni);
+			zlog_debug("Ignore remote neigh %pIA (MAC %pEA) on L2-VNI %u - MAC unknown or local",
+				   &n->ip,
+				   macaddr,
+				   zvni->vni);
 			return -1;
 		}
 
@@ -3428,12 +3403,9 @@ static bool zvni_check_mac_del_from_db(struct mac_walk_ctx *wctx,
 		 (mac->flags & ZEBRA_MAC_AUTO) &&
 		 !listcount(mac->neigh_list)) {
 		if (IS_ZEBRA_DEBUG_VXLAN) {
-			char buf[ETHER_ADDR_STRLEN];
-
-			zlog_debug(
-				"%s: Del MAC %s flags 0x%x", __func__,
-				prefix_mac2str(&mac->macaddr, buf, sizeof(buf)),
-				mac->flags);
+			zlog_debug("%s: Del MAC %pEA flags 0x%x", __func__,
+				   &mac->macaddr,
+				   mac->flags);
 		}
 		wctx->uninstall = 0;
 
@@ -4198,8 +4170,9 @@ static int zvni_send_add_to_client(zebra_vni_t *zvni)
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Send VNI_ADD %u %s tenant vrf %s to %s", zvni->vni,
-			   inet_ntoa(zvni->local_vtep_ip),
+		zlog_debug("Send VNI_ADD %u %pI4 tenant vrf %s to %s",
+			   zvni->vni,
+			   &zvni->local_vtep_ip,
 			   vrf_id_to_name(zvni->vrf_id),
 			   zebra_route_string(client->proto));
 
@@ -4732,7 +4705,6 @@ static int zl3vni_rmac_install(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
  */
 static int zl3vni_rmac_uninstall(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 {
-	char buf[ETHER_ADDR_STRLEN];
 	const struct zebra_if *zif = NULL, *br_zif;
 	const struct zebra_l2info_vxlan *vxl = NULL;
 	const struct interface *br_ifp;
@@ -4745,11 +4717,9 @@ static int zl3vni_rmac_uninstall(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 
 	if (!zl3vni->vxlan_if) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"RMAC %s on L3-VNI %u hash %p couldn't be uninstalled - no vxlan_if",
-				prefix_mac2str(&zrmac->macaddr,
-					       buf, sizeof(buf)),
-				zl3vni->vni, zl3vni);
+			zlog_debug("RMAC %pEA on L3-VNI %u hash %p couldn't be uninstalled - no vxlan_if",
+				   &zrmac->macaddr,
+				   zl3vni->vni, zl3vni);
 		return -1;
 	}
 
@@ -4783,9 +4753,6 @@ static int zl3vni_remote_rmac_add(zebra_l3vni_t *zl3vni,
 				  const struct ipaddr *vtep_ip,
 				  const struct prefix *host_prefix)
 {
-	char buf[ETHER_ADDR_STRLEN];
-	char buf1[INET6_ADDRSTRLEN];
-	char buf2[PREFIX_STRLEN];
 	zebra_mac_t *zrmac = NULL;
 
 	zrmac = zl3vni_rmac_lookup(zl3vni, rmac);
@@ -4794,12 +4761,11 @@ static int zl3vni_remote_rmac_add(zebra_l3vni_t *zl3vni,
 		 /* Create the RMAC entry, or update its vtep, if necessary. */
 		zrmac = zl3vni_rmac_add(zl3vni, rmac);
 		if (!zrmac) {
-			zlog_debug(
-				"Failed to add RMAC %s L3VNI %u Remote VTEP %s, prefix %s",
-				prefix_mac2str(rmac, buf, sizeof(buf)),
-				zl3vni->vni,
-				ipaddr2str(vtep_ip, buf1, sizeof(buf1)),
-				prefix2str(host_prefix, buf2, sizeof(buf2)));
+			zlog_debug("Failed to add RMAC %pEA L3VNI %u Remote VTEP %pIA, prefix %pFX",
+				   rmac,
+				   zl3vni->vni,
+				   vtep_ip,
+				   host_prefix);
 			return -1;
 		}
 		memset(&zrmac->fwd_info, 0, sizeof(zrmac->fwd_info));
@@ -4814,13 +4780,12 @@ static int zl3vni_remote_rmac_add(zebra_l3vni_t *zl3vni,
 	} else if (!IPV4_ADDR_SAME(&zrmac->fwd_info.r_vtep_ip,
 				   &vtep_ip->ipaddr_v4)) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"L3VNI %u Remote VTEP change(%s -> %s) for RMAC %s, prefix %s",
-				zl3vni->vni,
-				inet_ntoa(zrmac->fwd_info.r_vtep_ip),
-				ipaddr2str(vtep_ip, buf1, sizeof(buf1)),
-				prefix_mac2str(rmac, buf, sizeof(buf)),
-				prefix2str(host_prefix, buf2, sizeof(buf2)));
+			zlog_debug("L3VNI %u Remote VTEP change(%pI4 -> %pIA) for RMAC %pEA, prefix %pFX",
+				   zl3vni->vni,
+				   &zrmac->fwd_info.r_vtep_ip,
+				   vtep_ip,
+				   rmac,
+				   host_prefix);
 
 		zrmac->fwd_info.r_vtep_ip = vtep_ip->ipaddr_v4;
 
@@ -4976,10 +4941,6 @@ static int zl3vni_remote_nh_add(zebra_l3vni_t *zl3vni,
 				const struct ethaddr *rmac,
 				const struct prefix *host_prefix)
 {
-	char buf[ETHER_ADDR_STRLEN];
-	char buf1[ETHER_ADDR_STRLEN];
-	char buf2[INET6_ADDRSTRLEN];
-	char buf3[PREFIX_STRLEN];
 	zebra_neigh_t *nh = NULL;
 
 	/* Create the next hop entry, or update its mac, if necessary. */
@@ -4987,12 +4948,11 @@ static int zl3vni_remote_nh_add(zebra_l3vni_t *zl3vni,
 	if (!nh) {
 		nh = zl3vni_nh_add(zl3vni, vtep_ip, rmac);
 		if (!nh) {
-			zlog_debug(
-				"Failed to add NH %s as Neigh (RMAC %s L3-VNI %u prefix %s)",
-				ipaddr2str(vtep_ip, buf1, sizeof(buf2)),
-				prefix_mac2str(rmac, buf, sizeof(buf)),
-				zl3vni->vni,
-				prefix2str(host_prefix, buf2, sizeof(buf2)));
+			zlog_debug("Failed to add NH %pIA as Neigh (RMAC %pEA L3-VNI %u prefix %pFX)",
+				   vtep_ip,
+				   rmac,
+				   zl3vni->vni,
+				   host_prefix);
 			return -1;
 		}
 
@@ -5000,12 +4960,12 @@ static int zl3vni_remote_nh_add(zebra_l3vni_t *zl3vni,
 		zl3vni_nh_install(zl3vni, nh);
 	} else if (memcmp(&nh->emac, rmac, ETH_ALEN) != 0) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("L3VNI %u RMAC change(%s --> %s) for nexthop %s, prefix %s",
+			zlog_debug("L3VNI %u RMAC change(%pEA --> %pEA) for nexthop %pIA, prefix %pFX",
 				   zl3vni->vni,
-				   prefix_mac2str(&nh->emac, buf, sizeof(buf)),
-				   prefix_mac2str(rmac, buf1, sizeof(buf1)),
-				   ipaddr2str(vtep_ip, buf2, sizeof(buf2)),
-				   prefix2str(host_prefix, buf3, sizeof(buf3)));
+				   &nh->emac,
+				   rmac,
+				   vtep_ip,
+				   host_prefix);
 
 		memcpy(&nh->emac, rmac, ETH_ALEN);
 		/* install (update) the nh neigh in kernel */
@@ -5385,8 +5345,6 @@ static int zl3vni_send_add_to_client(zebra_l3vni_t *zl3vni)
 	struct zserv *client = NULL;
 	struct ethaddr svi_rmac, vrr_rmac = {.octet = {0} };
 	struct zebra_vrf *zvrf;
-	char buf[ETHER_ADDR_STRLEN];
-	char buf1[ETHER_ADDR_STRLEN];
 	bool is_anycast_mac = true;
 
 	client = zserv_find_client(ZEBRA_ROUTE_BGP, 0);
@@ -5426,16 +5384,15 @@ static int zl3vni_send_add_to_client(zebra_l3vni_t *zl3vni)
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug(
-			"Send L3_VNI_ADD %u VRF %s RMAC %s VRR %s local-ip %s filter %s to %s",
-			zl3vni->vni, vrf_id_to_name(zl3vni_vrf_id(zl3vni)),
-			prefix_mac2str(&svi_rmac, buf, sizeof(buf)),
-			prefix_mac2str(&vrr_rmac, buf1, sizeof(buf1)),
-			inet_ntoa(zl3vni->local_vtep_ip),
-			CHECK_FLAG(zl3vni->filter, PREFIX_ROUTES_ONLY)
-				? "prefix-routes-only"
-				: "none",
-			zebra_route_string(client->proto));
+		zlog_debug("Send L3_VNI_ADD %u VRF %s RMAC %pEA VRR %pEA local-ip %pI4 filter %s to %s",
+			   zl3vni->vni, vrf_id_to_name(zl3vni_vrf_id(zl3vni)),
+			   &svi_rmac,
+			   &vrr_rmac,
+			   &zl3vni->local_vtep_ip,
+			   CHECK_FLAG(zl3vni->filter, PREFIX_ROUTES_ONLY)
+			   ? "prefix-routes-only"
+			   : "none",
+			   zebra_route_string(client->proto));
 
 	client->l3vniadd_cnt++;
 	return zserv_send_message(client, s);
@@ -5584,7 +5541,6 @@ static int ip_prefix_send_to_client(vrf_id_t vrf_id, struct prefix *p,
 {
 	struct zserv *client = NULL;
 	struct stream *s = NULL;
-	char buf[PREFIX_STRLEN];
 
 	client = zserv_find_client(ZEBRA_ROUTE_BGP, 0);
 	/* BGP may not be running. */
@@ -5600,8 +5556,8 @@ static int ip_prefix_send_to_client(vrf_id_t vrf_id, struct prefix *p,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Send ip prefix %s %s on vrf %s",
-			   prefix2str(p, buf, sizeof(buf)),
+		zlog_debug("Send ip prefix %pFX %s on vrf %s",
+			   p,
 			   (cmd == ZEBRA_IP_PREFIX_ROUTE_ADD) ? "ADD" : "DEL",
 			   vrf_id_to_name(vrf_id));
 
@@ -5617,7 +5573,6 @@ static int ip_prefix_send_to_client(vrf_id_t vrf_id, struct prefix *p,
 static int zebra_vxlan_readd_remote_rmac(zebra_l3vni_t *zl3vni,
 					 struct ethaddr *rmac)
 {
-	char buf[ETHER_ADDR_STRLEN];
 	zebra_mac_t *zrmac = NULL;
 
 	zrmac = zl3vni_rmac_lookup(zl3vni, rmac);
@@ -5625,8 +5580,8 @@ static int zebra_vxlan_readd_remote_rmac(zebra_l3vni_t *zl3vni,
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Del remote RMAC %s L3VNI %u - readd",
-			   prefix_mac2str(rmac, buf, sizeof(buf)), zl3vni->vni);
+		zlog_debug("Del remote RMAC %pEA L3VNI %u - readd",
+			   rmac, zl3vni->vni);
 
 	zl3vni_rmac_install(zl3vni, zrmac);
 	return 0;
@@ -5706,9 +5661,9 @@ static void process_remote_macip_add(vni_t vni,
 	    CHECK_FLAG(mac->flags, ZEBRA_MAC_DEF_GW) &&
 	    CHECK_FLAG(flags, ZEBRA_MACIP_TYPE_GW)) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("Ignore remote MACIP ADD VNI %u MAC %s%s%s as MAC is already configured as gateway MAC",
+			zlog_debug("Ignore remote MACIP ADD VNI %u MAC %pEA%s%s as MAC is already configured as gateway MAC",
 				   vni,
-				   prefix_mac2str(macaddr, buf, sizeof(buf)),
+				   macaddr,
 				   ipa_len ? " IP " : "",
 				   ipa_len ?
 				   ipaddr2str(ipaddr, buf1, sizeof(buf1)) : "");
@@ -5735,11 +5690,9 @@ static void process_remote_macip_add(vni_t vni,
 		if (!mac) {
 			mac = zvni_mac_add(zvni, macaddr);
 			if (!mac) {
-				zlog_warn(
-					"Failed to add MAC %s VNI %u Remote VTEP %s",
-					prefix_mac2str(macaddr, buf,
-						       sizeof(buf)),
-					vni, inet_ntoa(vtep_ip));
+				zlog_warn("Failed to add MAC %pEA VNI %u Remote VTEP %pI4",
+					  macaddr,
+					  vni, &vtep_ip);
 				return;
 			}
 
@@ -5762,15 +5715,14 @@ static void process_remote_macip_add(vni_t vni,
 
 			if (seq < tmp_seq) {
 				if (IS_ZEBRA_DEBUG_VXLAN)
-					zlog_debug("Ignore remote MACIP ADD VNI %u MAC %s%s%s as existing MAC has higher seq %u flags 0x%x",
-					vni,
-					prefix_mac2str(macaddr,
-						       buf, sizeof(buf)),
-					ipa_len ? " IP " : "",
-					ipa_len ?
-					ipaddr2str(ipaddr,
-						   buf1, sizeof(buf1)) : "",
-					tmp_seq, mac->flags);
+					zlog_debug("Ignore remote MACIP ADD VNI %u MAC %pEA%s%s as existing MAC has higher seq %u flags 0x%x",
+						   vni,
+						   macaddr,
+						   ipa_len ? " IP " : "",
+						   ipa_len ?
+						   ipaddr2str(ipaddr,
+							      buf1, sizeof(buf1)) : "",
+						   tmp_seq, mac->flags);
 				return;
 			}
 		}
@@ -5852,13 +5804,10 @@ static void process_remote_macip_add(vni_t vni,
 		if (!n) {
 			n = zvni_neigh_add(zvni, ipaddr, macaddr);
 			if (!n) {
-				zlog_warn(
-					"Failed to add Neigh %s MAC %s VNI %u Remote VTEP %s",
-					ipaddr2str(ipaddr, buf1,
-						   sizeof(buf1)),
-					prefix_mac2str(macaddr, buf,
-						       sizeof(buf)),
-					vni, inet_ntoa(vtep_ip));
+				zlog_warn("Failed to add Neigh %pIA MAC %pEA VNI %u Remote VTEP %pI4",
+					  ipaddr,
+					  macaddr,
+					  vni, &vtep_ip);
 				return;
 			}
 
@@ -5882,14 +5831,13 @@ static void process_remote_macip_add(vni_t vni,
 			}
 			if (seq < tmp_seq) {
 				if (IS_ZEBRA_DEBUG_VXLAN)
-					zlog_debug("Ignore remote MACIP ADD VNI %u MAC %s%s%s as existing %s Neigh has higher seq %u",
-					vni,
-					prefix_mac2str(macaddr,
-						       buf, sizeof(buf)),
-					" IP ",
-					ipaddr2str(ipaddr, buf1, sizeof(buf1)),
-					n_type,
-					tmp_seq);
+					zlog_debug("Ignore remote MACIP ADD VNI %u MAC %pEA%s%pIA as existing %s Neigh has higher seq %u",
+						   vni,
+						   macaddr,
+						   " IP ",
+						   ipaddr,
+						   n_type,
+						   tmp_seq);
 				return;
 			}
 			if (memcmp(&n->emac, macaddr, sizeof(*macaddr)) != 0) {
@@ -5949,10 +5897,10 @@ static void process_remote_macip_add(vni_t vni,
 		if (zebra_vxlan_ip_inherit_dad_from_mac(zvrf, old_mac,
 							mac, n)) {
 			flog_warn(EC_ZEBRA_DUP_IP_INHERIT_DETECTED,
-				"VNI %u: MAC %s IP %s detected as duplicate during remote update, inherit duplicate from MAC",
+				"VNI %u: MAC %pEA IP %pIA detected as duplicate during remote update, inherit duplicate from MAC",
 				zvni->vni,
-				prefix_mac2str(&mac->macaddr, buf, sizeof(buf)),
-				ipaddr2str(&n->ip, buf1, sizeof(buf1)));
+				&mac->macaddr,
+				&n->ip);
 		}
 
 		/* Check duplicate address detection for IP */
@@ -6023,9 +5971,9 @@ static void process_remote_macip_del(vni_t vni,
 		n = zvni_neigh_lookup(zvni, ipaddr);
 
 	if (n && !mac) {
-		zlog_warn("Failed to locate MAC %s for neigh %s VNI %u upon remote MACIP DEL",
-			  prefix_mac2str(macaddr, buf, sizeof(buf)),
-			  ipaddr2str(ipaddr, buf1, sizeof(buf1)), vni);
+		zlog_warn("Failed to locate MAC %pEA for neigh %pIA VNI %u upon remote MACIP DEL",
+			  macaddr,
+			  ipaddr, vni);
 		return;
 	}
 
@@ -6040,13 +5988,12 @@ static void process_remote_macip_del(vni_t vni,
 	/* Ignore the delete if this mac is a gateway mac-ip */
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL)
 	    && CHECK_FLAG(mac->flags, ZEBRA_MAC_DEF_GW)) {
-		zlog_warn(
-			"Ignore remote MACIP DEL VNI %u MAC %s%s%s as MAC is already configured as gateway MAC",
-			vni,
-			prefix_mac2str(macaddr, buf, sizeof(buf)),
-			ipa_len ? " IP " : "",
-			ipa_len ?
-			ipaddr2str(ipaddr, buf1, sizeof(buf1)) : "");
+		zlog_warn("Ignore remote MACIP DEL VNI %u MAC %pEA%s%s as MAC is already configured as gateway MAC",
+			  vni,
+			  macaddr,
+			  ipa_len ? " IP " : "",
+			  ipa_len ?
+			  ipaddr2str(ipaddr, buf1, sizeof(buf1)) : "");
 		return;
 	}
 
@@ -6061,12 +6008,11 @@ static void process_remote_macip_del(vni_t vni,
 			vlan_if = zvni_map_to_svi(vxl->access_vlan,
 					zif->brslave_info.br_if);
 			if (IS_ZEBRA_DEBUG_VXLAN)
-				zlog_debug(
-					"%s: IP %s (flags 0x%x intf %s) is remote and duplicate, read kernel for local entry",
-					__func__,
-					ipaddr2str(ipaddr, buf1, sizeof(buf1)),
-					n->flags,
-					vlan_if ? vlan_if->name : "Unknown");
+				zlog_debug("%s: IP %pIA (flags 0x%x intf %s) is remote and duplicate, read kernel for local entry",
+					   __func__,
+					   ipaddr,
+					   n->flags,
+					   vlan_if ? vlan_if->name : "Unknown");
 			if (vlan_if)
 				neigh_read_specific_ip(ipaddr, vlan_if);
 		}
@@ -6093,12 +6039,10 @@ static void process_remote_macip_del(vni_t vni,
 		    CHECK_FLAG(mac->flags, ZEBRA_MAC_DUPLICATE) &&
 		    CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE)) {
 			if (IS_ZEBRA_DEBUG_VXLAN)
-				zlog_debug(
-					"%s: MAC %s (flags 0x%x) is remote and duplicate, read kernel for local entry",
-					__func__,
-					prefix_mac2str(macaddr, buf,
-						       sizeof(buf)),
-					mac->flags);
+				zlog_debug("%s: MAC %pEA (flags 0x%x) is remote and duplicate, read kernel for local entry",
+					   __func__,
+					   macaddr,
+					   mac->flags);
 			macfdb_read_specific_mac(zns, zif->brslave_info.br_if,
 						 macaddr, vxl->access_vlan);
 		}
@@ -7125,7 +7069,6 @@ int zebra_vxlan_clear_dup_detect_vni_ip(struct zebra_vrf *zvrf, vni_t vni,
 	zebra_neigh_t *nbr;
 	zebra_mac_t *mac;
 	char buf[INET6_ADDRSTRLEN];
-	char buf2[ETHER_ADDR_STRLEN];
 
 	if (!is_evpn_enabled())
 		return 0;
@@ -7153,9 +7096,8 @@ int zebra_vxlan_clear_dup_detect_vni_ip(struct zebra_vrf *zvrf, vni_t vni,
 	mac = zvni_mac_lookup(zvni, &nbr->emac);
 
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_DUPLICATE)) {
-		zlog_warn(
-			"Requested IP's associated MAC %s is still in duplicate state\n",
-			prefix_mac2str(&nbr->emac, buf2, sizeof(buf2)));
+		zlog_warn("Requested IP's associated MAC %pEA is still in duplicate state\n",
+			  &nbr->emac);
 		return -1;
 	}
 
@@ -7241,7 +7183,6 @@ static void zvni_clear_dup_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 	struct neigh_walk_ctx *wctx = ctxt;
 	zebra_neigh_t *nbr;
 	zebra_vni_t *zvni;
-	char buf[INET6_ADDRSTRLEN];
 
 	nbr = (zebra_neigh_t *)bucket->data;
 	if (!nbr)
@@ -7253,9 +7194,8 @@ static void zvni_clear_dup_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 		return;
 
 	if (IS_ZEBRA_DEBUG_VXLAN) {
-		ipaddr2str(&nbr->ip, buf, sizeof(buf));
-		zlog_debug("%s: clear neigh %s dup state, flags 0x%x seq %u",
-			   __func__, buf, nbr->flags, nbr->loc_seq);
+		zlog_debug("%s: clear neigh %pIA dup state, flags 0x%x seq %u",
+			   __func__, &nbr->ip, nbr->flags, nbr->loc_seq);
 	}
 
 	UNSET_FLAG(nbr->flags, ZEBRA_NEIGH_DUPLICATE);
@@ -7680,10 +7620,9 @@ int zebra_vxlan_handle_kernel_neigh_del(struct interface *ifp,
 	zvni = zvni_from_svi(ifp, link_if);
 	if (!zvni) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"%s: Del neighbor %s VNI is not present for interface %s",
-				__func__, ipaddr2str(ip, buf, sizeof(buf)),
-				ifp->name);
+			zlog_debug("%s: Del neighbor %pIA VNI is not present for interface %s",
+				   __func__, ip,
+				   ifp->name);
 		return 0;
 	}
 
@@ -7695,8 +7634,8 @@ int zebra_vxlan_handle_kernel_neigh_del(struct interface *ifp,
 	}
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Del neighbor %s intf %s(%u) -> L2-VNI %u",
-			   ipaddr2str(ip, buf, sizeof(buf)), ifp->name,
+		zlog_debug("Del neighbor %pIA intf %s(%u) -> L2-VNI %u",
+			   ip, ifp->name,
 			   ifp->ifindex, zvni->vni);
 
 	/* If entry doesn't exist, nothing to do. */
@@ -7707,11 +7646,10 @@ int zebra_vxlan_handle_kernel_neigh_del(struct interface *ifp,
 	zmac = zvni_mac_lookup(zvni, &n->emac);
 	if (!zmac) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"Trying to del a neigh %s without a mac %s on VNI %u",
-				ipaddr2str(ip, buf, sizeof(buf)),
-				prefix_mac2str(&n->emac, buf2, sizeof(buf2)),
-				zvni->vni);
+			zlog_debug("Trying to del a neigh %pIA without a mac %pEA on VNI %u",
+				   ip,
+				   &n->emac,
+				   zvni->vni);
 
 		return 0;
 	}
@@ -7767,8 +7705,6 @@ int zebra_vxlan_handle_kernel_neigh_update(struct interface *ifp,
 					   bool is_ext,
 					   bool is_router)
 {
-	char buf[ETHER_ADDR_STRLEN];
-	char buf2[INET6_ADDRSTRLEN];
 	zebra_vni_t *zvni = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 
@@ -7787,13 +7723,13 @@ int zebra_vxlan_handle_kernel_neigh_update(struct interface *ifp,
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug(
-			"Add/Update neighbor %s MAC %s intf %s(%u) state 0x%x %s %s-> L2-VNI %u",
-			ipaddr2str(ip, buf2, sizeof(buf2)),
-			prefix_mac2str(macaddr, buf, sizeof(buf)), ifp->name,
-			ifp->ifindex, state, is_ext ? "ext-learned " : "",
-			is_router ? "router " : "",
-			zvni->vni);
+		zlog_debug("Add/Update neighbor %pIA MAC %pEA intf %s(%u) state 0x%x %s %s-> L2-VNI %u",
+			   ip,
+			   macaddr,
+			   ifp->name,
+			   ifp->ifindex, state, is_ext ? "ext-learned " : "",
+			   is_router ? "router " : "",
+			   zvni->vni);
 
 	/* Is this about a local neighbor or a remote one? */
 	if (!is_ext)
@@ -7864,7 +7800,6 @@ void zebra_vxlan_remote_macip_del(ZAPI_HANDLER_ARGS)
 	struct ipaddr ip;
 	struct in_addr vtep_ip;
 	uint16_t l = 0, ipa_len;
-	char buf[ETHER_ADDR_STRLEN];
 	char buf1[INET6_ADDRSTRLEN];
 
 	memset(&macaddr, 0, sizeof(struct ethaddr));
@@ -7883,15 +7818,14 @@ void zebra_vxlan_remote_macip_del(ZAPI_HANDLER_ARGS)
 
 		l += res_length;
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"Recv MACIP DEL VNI %u MAC %s%s%s Remote VTEP %s from %s",
-				vni,
-				prefix_mac2str(&macaddr, buf, sizeof(buf)),
-				ipa_len ? " IP " : "",
-				ipa_len ?
-				ipaddr2str(&ip, buf1, sizeof(buf1)) : "",
-				inet_ntoa(vtep_ip),
-				zebra_route_string(client->proto));
+			zlog_debug("Recv MACIP DEL VNI %u MAC %pEA%s%s Remote VTEP %pI4 from %s",
+				   vni,
+				   &macaddr,
+				   ipa_len ? " IP " : "",
+				   ipa_len ?
+				   ipaddr2str(&ip, buf1, sizeof(buf1)) : "",
+				   &vtep_ip,
+				   zebra_route_string(client->proto));
 
 		process_remote_macip_del(vni, &macaddr, ipa_len, &ip, vtep_ip);
 	}
@@ -7939,15 +7873,14 @@ void zebra_vxlan_remote_macip_add(ZAPI_HANDLER_ARGS)
 
 		l += res_length;
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"Recv MACIP ADD VNI %u MAC %s%s%s flags 0x%x seq %u VTEP %s from %s",
-				vni,
-				prefix_mac2str(&macaddr, buf, sizeof(buf)),
-				ipa_len ? " IP " : "",
-				ipa_len ?
-				ipaddr2str(&ip, buf1, sizeof(buf1)) : "",
-				flags, seq, inet_ntoa(vtep_ip),
-				zebra_route_string(client->proto));
+			zlog_debug("Recv MACIP ADD VNI %u MAC %pEA%s%s flags 0x%x seq %u VTEP %s from %s",
+				   vni,
+				   &macaddr,
+				   ipa_len ? " IP " : "",
+				   ipa_len ?
+				   ipaddr2str(&ip, buf1, sizeof(buf1)) : "",
+				   flags, seq, inet_ntoa(vtep_ip),
+				   zebra_route_string(client->proto));
 
 		process_remote_macip_add(vni, &macaddr, ipa_len, &ip,
 					 flags, seq, vtep_ip);
@@ -7995,9 +7928,8 @@ int zebra_vxlan_check_readd_vtep(struct interface *ifp,
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug(
-			"Del MAC for remote VTEP %s intf %s(%u) VNI %u - readd",
-			inet_ntoa(vtep_ip), ifp->name, ifp->ifindex, vni);
+		zlog_debug("Del MAC for remote VTEP %pI4 intf %s(%u) VNI %u - readd",
+			   &vtep_ip, ifp->name, ifp->ifindex, vni);
 
 	zvni_vtep_install(zvni, zvtep);
 	return 0;
@@ -8017,7 +7949,6 @@ int zebra_vxlan_check_del_local_mac(struct interface *ifp,
 	vni_t vni;
 	zebra_vni_t *zvni;
 	zebra_mac_t *mac;
-	char buf[ETHER_ADDR_STRLEN];
 
 	zif = ifp->info;
 	assert(zif);
@@ -8043,10 +7974,9 @@ int zebra_vxlan_check_del_local_mac(struct interface *ifp,
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug(
-			"Add/update remote MAC %s intf %s(%u) VNI %u flags 0x%x - del local",
-			prefix_mac2str(macaddr, buf, sizeof(buf)), ifp->name,
-			ifp->ifindex, vni, mac->flags);
+		zlog_debug("Add/update remote MAC %pEA intf %s(%u) VNI %u flags 0x%x - del local",
+			   macaddr, ifp->name,
+			   ifp->ifindex, vni, mac->flags);
 
 	/* Remove MAC from BGP. */
 	zvni_mac_send_del_to_client(zvni->vni, macaddr);
@@ -8081,7 +8011,6 @@ int zebra_vxlan_check_readd_remote_mac(struct interface *ifp,
 	zebra_vni_t *zvni = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 	zebra_mac_t *mac = NULL;
-	char buf[ETHER_ADDR_STRLEN];
 
 	zif = ifp->info;
 	assert(zif);
@@ -8112,8 +8041,8 @@ int zebra_vxlan_check_readd_remote_mac(struct interface *ifp,
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Del remote MAC %s intf %s(%u) VNI %u - readd",
-			   prefix_mac2str(macaddr, buf, sizeof(buf)), ifp->name,
+		zlog_debug("Del remote MAC %pEA intf %s(%u) VNI %u - readd",
+			   macaddr, ifp->name,
 			   ifp->ifindex, vni);
 
 	zvni_mac_install(zvni, mac);
@@ -8128,7 +8057,6 @@ int zebra_vxlan_local_mac_del(struct interface *ifp, struct interface *br_if,
 {
 	zebra_vni_t *zvni;
 	zebra_mac_t *mac;
-	char buf[ETHER_ADDR_STRLEN];
 
 	/* We are interested in MACs only on ports or (port, VLAN) that
 	 * map to a VNI.
@@ -8153,8 +8081,8 @@ int zebra_vxlan_local_mac_del(struct interface *ifp, struct interface *br_if,
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("DEL MAC %s intf %s(%u) VID %u -> VNI %u seq %u flags 0x%x nbr count %u",
-			   prefix_mac2str(macaddr, buf, sizeof(buf)), ifp->name,
+		zlog_debug("DEL MAC %pEA intf %s(%u) VID %u -> VNI %u seq %u flags 0x%x nbr count %u",
+			   macaddr, ifp->name,
 			   ifp->ifindex, vid, zvni->vni, mac->loc_seq,
 			   mac->flags, listcount(mac->neigh_list));
 
@@ -8208,11 +8136,10 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 	zvni = zvni_map_vlan(ifp, br_if, vid);
 	if (!zvni) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"        Add/Update %sMAC %s intf %s(%u) VID %u, could not find VNI",
-				sticky ? "sticky " : "",
-				prefix_mac2str(macaddr, buf, sizeof(buf)),
-				ifp->name, ifp->ifindex, vid);
+			zlog_debug("        Add/Update %sMAC %pEA intf %s(%u) VID %u, could not find VNI",
+				   sticky ? "sticky " : "",
+				   macaddr,
+				   ifp->name, ifp->ifindex, vid);
 		return 0;
 	}
 
@@ -8235,18 +8162,17 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 	mac = zvni_mac_lookup(zvni, macaddr);
 	if (!mac) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"ADD %sMAC %s intf %s(%u) VID %u -> VNI %u",
-				sticky ? "sticky " : "",
-				prefix_mac2str(macaddr, buf, sizeof(buf)),
-				ifp->name, ifp->ifindex, vid, zvni->vni);
+			zlog_debug("ADD %sMAC %pEA intf %s(%u) VID %u -> VNI %u",
+				   sticky ? "sticky " : "",
+				   macaddr,
+				   ifp->name, ifp->ifindex, vid, zvni->vni);
 
 		mac = zvni_mac_add(zvni, macaddr);
 		if (!mac) {
 			flog_err(
 				EC_ZEBRA_MAC_ADD_FAILED,
-				"Failed to add MAC %s intf %s(%u) VID %u VNI %u",
-				prefix_mac2str(macaddr, buf, sizeof(buf)),
+				"Failed to add MAC %pEA intf %s(%u) VID %u VNI %u",
+				macaddr,
 				ifp->name, ifp->ifindex, vid, zvni->vni);
 			return -1;
 		}
@@ -8260,12 +8186,11 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 
 	} else {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"UPD %sMAC %s intf %s(%u) VID %u -> VNI %u curFlags 0x%x",
-				sticky ? "sticky " : "",
-				prefix_mac2str(macaddr, buf, sizeof(buf)),
-				ifp->name, ifp->ifindex, vid, zvni->vni,
-				mac->flags);
+			zlog_debug("UPD %sMAC %pEA intf %s(%u) VID %u -> VNI %u curFlags 0x%x",
+				   sticky ? "sticky " : "",
+				   macaddr,
+				   ifp->name, ifp->ifindex, vid, zvni->vni,
+				   mac->flags);
 
 		if (CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL)) {
 			if (CHECK_FLAG(mac->flags, ZEBRA_MAC_STICKY))
@@ -8280,13 +8205,12 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 			    && mac->fwd_info.local.ns_id == local_ns_id
 			    && mac->fwd_info.local.vid == vid) {
 				if (IS_ZEBRA_DEBUG_VXLAN)
-					zlog_debug(
-						"        Add/Update %sMAC %s intf %s(%u) VID %u -> VNI %u, entry exists and has not changed ",
-						sticky ? "sticky " : "",
-						prefix_mac2str(macaddr, buf,
-							       sizeof(buf)),
-						ifp->name, ifp->ifindex, vid,
-						zvni->vni);
+					zlog_debug("        Add/Update %sMAC %pEA intf %s(%u) VID %u -> VNI %u, entry exists and has not changed ",
+						   sticky ? "sticky " : "",
+						   macaddr,
+						   ifp->name, ifp->ifindex,
+						   vid,
+						   zvni->vni);
 				return 0;
 			}
 			if (mac_sticky != sticky) {
@@ -8317,10 +8241,9 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 			if (CHECK_FLAG(mac->flags, ZEBRA_MAC_STICKY)) {
 				flog_warn(
 					EC_ZEBRA_STICKY_MAC_ALREADY_LEARNT,
-					"MAC %s already learnt as remote sticky MAC behind VTEP %s VNI %u",
-					prefix_mac2str(macaddr, buf,
-						       sizeof(buf)),
-					inet_ntoa(mac->fwd_info.r_vtep_ip),
+					"MAC %pEA already learnt as remote sticky MAC behind VTEP %pI4 VNI %u",
+					macaddr,
+					&mac->fwd_info.r_vtep_ip,
 					zvni->vni);
 				return 0;
 			}
@@ -8420,8 +8343,8 @@ void zebra_vxlan_remote_vtep_del(ZAPI_HANDLER_ARGS)
 		l += 4;
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("Recv VTEP_DEL %s VNI %u from %s",
-				   inet_ntoa(vtep_ip), vni,
+			zlog_debug("Recv VTEP_DEL %pI4 VNI %u from %s",
+				   &vtep_ip, vni,
 				   zebra_route_string(client->proto));
 
 		/* Locate VNI hash entry - expected to exist. */
@@ -8504,8 +8427,8 @@ void zebra_vxlan_remote_vtep_add(ZAPI_HANDLER_ARGS)
 		l += IPV4_MAX_BYTELEN + 4;
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("Recv VTEP_ADD %s VNI %u flood %d from %s",
-					inet_ntoa(vtep_ip), vni, flood_control,
+			zlog_debug("Recv VTEP_ADD %pI4 VNI %u flood %d from %s",
+					&vtep_ip, vni, flood_control,
 					zebra_route_string(client->proto));
 
 		/* Locate VNI hash entry - expected to exist. */
@@ -9079,11 +9002,11 @@ int zebra_vxlan_if_update(struct interface *ifp, uint16_t chgflags)
 	if (zl3vni) {
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"Update L3-VNI %u intf %s(%u) VLAN %u local IP %s master %u chg 0x%x",
-				vni, ifp->name, ifp->ifindex, vxl->access_vlan,
-				inet_ntoa(vxl->vtep_ip),
-				zif->brslave_info.bridge_ifindex, chgflags);
+			zlog_debug("Update L3-VNI %u intf %s(%u) VLAN %u local IP %pI4 master %u chg 0x%x",
+				   vni, ifp->name, ifp->ifindex,
+				   vxl->access_vlan,
+				   &vxl->vtep_ip,
+				   zif->brslave_info.bridge_ifindex, chgflags);
 
 		/* Removed from bridge? Cleanup and return */
 		if ((chgflags & ZEBRA_VXLIF_MASTER_CHANGE)
@@ -9143,11 +9066,11 @@ int zebra_vxlan_if_update(struct interface *ifp, uint16_t chgflags)
 		}
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"Update L2-VNI %u intf %s(%u) VLAN %u local IP %s master %u chg 0x%x",
-				vni, ifp->name, ifp->ifindex, vxl->access_vlan,
-				inet_ntoa(vxl->vtep_ip),
-				zif->brslave_info.bridge_ifindex, chgflags);
+			zlog_debug("Update L2-VNI %u intf %s(%u) VLAN %u local IP %pI4 master %u chg 0x%x",
+				   vni, ifp->name, ifp->ifindex,
+				   vxl->access_vlan,
+				   &vxl->vtep_ip,
+				   zif->brslave_info.bridge_ifindex, chgflags);
 
 		/* Removed from bridge? Cleanup and return */
 		if ((chgflags & ZEBRA_VXLIF_MASTER_CHANGE)
@@ -9247,11 +9170,11 @@ int zebra_vxlan_if_add(struct interface *ifp)
 
 		/* process if-add for l3-vni*/
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"Add L3-VNI %u intf %s(%u) VLAN %u local IP %s master %u",
-				vni, ifp->name, ifp->ifindex, vxl->access_vlan,
-				inet_ntoa(vxl->vtep_ip),
-				zif->brslave_info.bridge_ifindex);
+			zlog_debug("Add L3-VNI %u intf %s(%u) VLAN %u local IP %pI4 master %u",
+				   vni, ifp->name, ifp->ifindex,
+				   vxl->access_vlan,
+				   &vxl->vtep_ip,
+				   zif->brslave_info.bridge_ifindex);
 
 		/* associate with vxlan_if */
 		zl3vni->local_vtep_ip = vxl->vtep_ip;
@@ -9302,22 +9225,13 @@ int zebra_vxlan_if_add(struct interface *ifp)
 		}
 
 		if (IS_ZEBRA_DEBUG_VXLAN) {
-			char addr_buf1[INET_ADDRSTRLEN];
-			char addr_buf2[INET_ADDRSTRLEN];
-
-			inet_ntop(AF_INET, &vxl->vtep_ip,
-					addr_buf1, INET_ADDRSTRLEN);
-			inet_ntop(AF_INET, &vxl->mcast_grp,
-					addr_buf2, INET_ADDRSTRLEN);
-
-			zlog_debug(
-				"Add L2-VNI %u VRF %s intf %s(%u) VLAN %u local IP %s mcast_grp %s master %u",
-				vni,
-				vlan_if ? vrf_id_to_name(vlan_if->vrf_id)
-					: VRF_DEFAULT_NAME,
-				ifp->name, ifp->ifindex, vxl->access_vlan,
-				addr_buf1, addr_buf2,
-				zif->brslave_info.bridge_ifindex);
+			zlog_debug("Add L2-VNI %u VRF %s intf %s(%u) VLAN %u local IP %pI4 mcast_grp %pI4 master %u",
+				   vni,
+				   vlan_if ? vrf_id_to_name(vlan_if->vrf_id)
+				   : VRF_DEFAULT_NAME,
+				   ifp->name, ifp->ifindex, vxl->access_vlan,
+				   &vxl->vtep_ip, &vxl->mcast_grp,
+				   zif->brslave_info.bridge_ifindex);
 		}
 
 		/* If down or not mapped to a bridge, we're done. */
@@ -9963,8 +9877,6 @@ static int zebra_vxlan_dad_ip_auto_recovery_exp(struct thread *t)
 	struct zebra_vrf *zvrf = NULL;
 	zebra_neigh_t *nbr = NULL;
 	zebra_vni_t *zvni = NULL;
-	char buf1[INET6_ADDRSTRLEN];
-	char buf2[ETHER_ADDR_STRLEN];
 
 	nbr = THREAD_ARG(t);
 
@@ -9982,12 +9894,12 @@ static int zebra_vxlan_dad_ip_auto_recovery_exp(struct thread *t)
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug(
-			"%s: duplicate addr MAC %s IP %s flags 0x%x learn count %u vni %u auto recovery expired",
-			__func__,
-			prefix_mac2str(&nbr->emac, buf2, sizeof(buf2)),
-			ipaddr2str(&nbr->ip, buf1, sizeof(buf1)), nbr->flags,
-			nbr->dad_count, zvni->vni);
+		zlog_debug("%s: duplicate addr MAC %pEA IP %pIA flags 0x%x learn count %u vni %u auto recovery expired",
+			   __func__,
+			   &nbr->emac,
+			   &nbr->ip,
+			   nbr->flags,
+			   nbr->dad_count, zvni->vni);
 
 	UNSET_FLAG(nbr->flags, ZEBRA_NEIGH_DUPLICATE);
 	nbr->dad_count = 0;

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1159,9 +1159,8 @@ static void zebra_show_stale_client_detail(struct vty *vty,
 			}
 			vty_out(vty, "Current AFI : %d\n", info->current_afi);
 			if (info->current_prefix) {
-				prefix2str(info->current_prefix, buf,
-					   sizeof(buf));
-				vty_out(vty, "Current prefix : %s\n", buf);
+				vty_out(vty, "Current prefix : %pFX\n",
+					info->current_prefix);
 			}
 		}
 	}


### PR DESCRIPTION
cocinelle'd replacement/simplification of printfrr formats

formatting/whitespace cleanup pending