### PR TITLE
zebra: When debugging route notifications use string instead of number

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -729,9 +729,10 @@ static int route_notify_internal(const struct prefix *p, int type,
 			char buff[PREFIX_STRLEN];
 
 			zlog_debug(
-				"Not Notifying Owner: %u about prefix %s(%u) %d vrf: %u",
-				type, prefix2str(p, buff, sizeof(buff)),
-				table_id, note, vrf_id);
+				"Not Notifying Owner: %s about prefix %s(%u) %d vrf: %u",
+				zebra_route_string(type),
+				prefix2str(p, buff, sizeof(buff)), table_id,
+				note, vrf_id);
 		}
 		return 0;
 	}
@@ -739,9 +740,10 @@ static int route_notify_internal(const struct prefix *p, int type,
 	if (IS_ZEBRA_DEBUG_PACKET) {
 		char buff[PREFIX_STRLEN];
 
-		zlog_debug("Notifying Owner: %u about prefix %s(%u) %d vrf: %u",
-			   type, prefix2str(p, buff, sizeof(buff)),
-			   table_id, note, vrf_id);
+		zlog_debug("Notifying Owner: %s about prefix %s(%u) %d vrf: %u",
+			   zebra_route_string(type),
+			   prefix2str(p, buff, sizeof(buff)), table_id, note,
+			   vrf_id);
 	}
 
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);


### PR DESCRIPTION
Current behavior:
eva# show mem
2020/08/04 18:07:38 ZEBRA: Not Notifying Owner: 2 about prefix 3.3.3.3/32(254) 2 vrf: 0

Fix it to show:

2020/08/04 18:07:38 ZEBRA: Not Notifying Owner: connected about prefix 3.3.3.3/32(254) 2 vrf: 0

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>