### PR TITLE
ldpd: ldp-oc withdraw fix

### DIFF
--- a/ldpd/lde_lib.c
+++ b/ldpd/lde_lib.c
@@ -856,6 +856,9 @@ lde_check_withdraw(struct map *map, struct lde_nbr *ln)
 	if (me && (map->label == NO_LABEL || map->label == me->map.label))
 		/* LWd.4: remove record of previously received lbl mapping */
 		lde_map_del(ln, me, 0);
+	else
+		/* LWd.13 done */
+		return;
 
 	/* Ordered Control: additional withdraw steps */
 	if (ldeconf->flags & F_LDPD_ORDERED_CONTROL) {
@@ -867,15 +870,17 @@ lde_check_withdraw(struct map *map, struct lde_nbr *ln)
 			/* LWd.9: check if previously sent a label mapping */
 			me = (struct lde_map *)fec_find(&lnbr->sent_map,
 			    &fn->fec);
+
 			/*
 			 * LWd.10: does label sent to peer "map" to withdraw
 			 * label
 			 */
-			if (me)
+			if (me && lde_nbr_is_nexthop(fn, lnbr))
 				/* LWd.11: send label withdraw */
 				lde_send_labelwithdraw(lnbr, fn, NULL, NULL);
 		}
 	}
+
 }
 
 void
@@ -933,24 +938,33 @@ lde_check_withdraw_wcard(struct map *map, struct lde_nbr *ln)
 			 * label mapping
 			 */
 			lde_map_del(ln, me, 0);
+		else
+			/* LWd.13 done */
+			continue;
 
 		/* Ordered Control: additional withdraw steps */
 		if (ldeconf->flags & F_LDPD_ORDERED_CONTROL) {
-			/* LWd.8: for each neighbor other that src of withdraw msg */
+			/*
+			 * LWd.8: for each neighbor other that src of
+			 *  withdraw msg
+			 */
 			RB_FOREACH(lnbr, nbr_tree, &lde_nbrs) {
 				if (ln->peerid == lnbr->peerid)
 					continue;
 
-				/* LWd.9: check if previously sent a label mapping */
-				me = (struct lde_map *)fec_find(&lnbr->sent_map,
-					&fn->fec);
-				/*
-				 * LWd.10: does label sent to peer "map" to withdraw
-				 * label
+				/* LWd.9: check if previously sent a label
+				 * mapping
 				 */
-				if (me)
+				me = (struct lde_map *)fec_find(
+				    &lnbr->sent_map, &fn->fec);
+				/*
+				 * LWd.10: does label sent to peer "map" to
+				 *  withdraw label
+				 */
+				if (me && lde_nbr_is_nexthop(fn, lnbr))
 					/* LWd.11: send label withdraw */
-					lde_send_labelwithdraw(lnbr, fn, NULL, NULL);
+					lde_send_labelwithdraw(lnbr, fn, NULL,
+					    NULL);
 			}
 		}
 	}


### PR DESCRIPTION
When LDP is configured in Order Control mode and we receive a
label withdraw message, we should only resend label withdraws to
peers that are the NH for that fec being withdrawn.

Signed-off-by: Lynne Morrison <lynne@voltanet.io>