### PR TITLE
lib, zebra: add support for sending ARP requests

### DIFF
--- a/doc/developer/zebra.rst
+++ b/doc/developer/zebra.rst
@@ -382,9 +382,11 @@ Zebra Protocol Commands
 +------------------------------------+-------+
 | ZEBRA_OPAQUE_UNREGISTER            | 109   |
 +------------------------------------+-------+
+| ZEBRA_NEIGH_DISCOVER               | 110   |
++------------------------------------+-------+
 
 Dataplane batching
-=========================
+==================
 
 Dataplane batching is an optimization feature that reduces the processing 
 time involved in the user space to kernel space transition for every message we

--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -138,3 +138,9 @@ keyword. At present, no sharp commands will be preserved in the config.
 
    Remove a test zapi client session that was created with the
    specified session id.
+
+.. index:: sharp neigh discover
+.. clicmd:: sharp neigh discover [vrf NAME] <A.B.C.D|X:X::X:X> IFNAME
+
+   Send an ARP/NDP request to trigger the addition of a neighbor in the ARP
+   table.

--- a/lib/log.c
+++ b/lib/log.c
@@ -451,7 +451,8 @@ static const struct zebra_desc_table command_types[] = {
 	DESC_ENTRY(ZEBRA_CLIENT_CAPABILITIES),
 	DESC_ENTRY(ZEBRA_OPAQUE_MESSAGE),
 	DESC_ENTRY(ZEBRA_OPAQUE_REGISTER),
-	DESC_ENTRY(ZEBRA_OPAQUE_UNREGISTER)};
+	DESC_ENTRY(ZEBRA_OPAQUE_UNREGISTER),
+	DESC_ENTRY(ZEBRA_NEIGH_DISCOVER)};
 #undef DESC_ENTRY
 
 static const struct zebra_desc_table unknown = {0, "unknown", '?'};

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3953,3 +3953,23 @@ int32_t zapi_capabilities_decode(struct stream *s, struct zapi_cap *api)
 stream_failure:
 	return 0;
 }
+
+int zclient_send_neigh_discovery_req(struct zclient *zclient,
+				     const struct interface *ifp,
+				     const struct prefix *p)
+{
+	struct stream *s;
+
+	s = zclient->obuf;
+	stream_reset(s);
+
+	zclient_create_header(s, ZEBRA_NEIGH_DISCOVER, ifp->vrf_id);
+	stream_putl(s, ifp->ifindex);
+
+	stream_putc(s, p->family);
+	stream_putc(s, p->prefixlen);
+	stream_put(s, &p->u.prefix, prefix_blen(p));
+
+	stream_putw_at(s, 0, stream_get_endp(s));
+	return zclient_send_message(zclient);
+}

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -214,6 +214,7 @@ typedef enum {
 	ZEBRA_OPAQUE_MESSAGE,
 	ZEBRA_OPAQUE_REGISTER,
 	ZEBRA_OPAQUE_UNREGISTER,
+	ZEBRA_NEIGH_DISCOVER,
 } zebra_message_types_t;
 
 enum zebra_error_types {
@@ -955,6 +956,10 @@ enum zapi_opaque_registry {
  * Returns 0 for success or -1 on an I/O error.
  */
 extern int zclient_send_hello(struct zclient *client);
+
+extern int zclient_send_neigh_discovery_req(struct zclient *zclient,
+					    const struct interface *ifp,
+					    const struct prefix *p);
 
 #ifdef __cplusplus
 }

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -53,6 +53,7 @@
 #include "ospfd/ospf_flood.h"
 #include "ospfd/ospf_dump.h"
 #include "ospfd/ospf_errors.h"
+#include "ospfd/ospf_zebra.h"
 
 /*
  * OSPF Fragmentation / fragmented writes
@@ -4319,21 +4320,10 @@ void ospf_ls_ack_send_delayed(struct ospf_interface *oi)
  * punt-to-CPU set on them. This may overload the CPU control path that
  * can be avoided if the MAC was known apriori.
  */
-#define OSPF_PING_NBR_STR_MAX  (BUFSIZ)
 void ospf_proactively_arp(struct ospf_neighbor *nbr)
 {
-	char ping_nbr[OSPF_PING_NBR_STR_MAX];
-	int ret;
-
 	if (!nbr)
 		return;
 
-	snprintf(ping_nbr, sizeof(ping_nbr),
-		 "ping -c 1 -I %s %s > /dev/null 2>&1 &", nbr->oi->ifp->name,
-		 inet_ntoa(nbr->address.u.prefix4));
-
-	ret = system(ping_nbr);
-	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("Executed %s %s", ping_nbr,
-			   ((ret == 0) ? "successfully" : "but failed"));
+	ospf_zebra_send_arp(nbr->oi->ifp, &nbr->address);
 }

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1741,3 +1741,8 @@ void ospf_zebra_init(struct thread_master *master, unsigned short instance)
 	prefix_list_add_hook(ospf_prefix_list_update);
 	prefix_list_delete_hook(ospf_prefix_list_update);
 }
+
+void ospf_zebra_send_arp(const struct interface *ifp, const struct prefix *p)
+{
+	zclient_send_neigh_discovery_req(zclient, ifp, p);
+}

--- a/ospfd/ospf_zebra.h
+++ b/ospfd/ospf_zebra.h
@@ -41,6 +41,7 @@ struct ospf_distance {
 };
 
 /* Prototypes */
+struct ospf_route;
 extern void ospf_zebra_add(struct ospf *ospf, struct prefix_ipv4 *,
 			   struct ospf_route *);
 extern void ospf_zebra_delete(struct ospf *ospf, struct prefix_ipv4 *,
@@ -98,4 +99,7 @@ bool ospf_external_default_routemap_apply_walk(
 int ospf_external_info_apply_default_routemap(struct ospf *ospf,
 					      struct external_info *ei,
 					      struct external_info *default_ei);
+
+extern void ospf_zebra_send_arp(const struct interface *ifp,
+				const struct prefix *p);
 #endif /* _ZEBRA_OSPF_ZEBRA_H */

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -663,6 +663,11 @@ void sharp_opaque_reg_send(bool is_reg, uint32_t proto, uint32_t instance,
 
 }
 
+void sharp_zebra_send_arp(const struct interface *ifp, const struct prefix *p)
+{
+	zclient_send_neigh_discovery_req(zclient, ifp, p);
+}
+
 void sharp_zebra_init(void)
 {
 	struct zclient_options opt = {.receive_notify = true};

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -58,4 +58,7 @@ void sharp_opaque_send(uint32_t type, uint32_t proto, uint32_t instance,
 void sharp_opaque_reg_send(bool is_reg, uint32_t proto, uint32_t instance,
 			   uint32_t session_id, uint32_t type);
 
+extern void sharp_zebra_send_arp(const struct interface *ifp,
+				 const struct prefix *p);
+
 #endif

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1417,6 +1417,7 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
 	case DPLANE_OP_NEIGH_DELETE:
 	case DPLANE_OP_VTEP_ADD:
 	case DPLANE_OP_VTEP_DELETE:
+	case DPLANE_OP_NEIGH_DISCOVER:
 		return netlink_put_neigh_update_msg(bth, ctx);
 
 	case DPLANE_OP_RULE_ADD:

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1526,6 +1526,7 @@ void kernel_update_multi(struct dplane_ctx_q *ctx_list)
 		case DPLANE_OP_NEIGH_DELETE:
 		case DPLANE_OP_VTEP_ADD:
 		case DPLANE_OP_VTEP_DELETE:
+		case DPLANE_OP_NEIGH_DISCOVER:
 			res = kernel_neigh_update_ctx(ctx);
 			break;
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -147,6 +147,8 @@ static uint8_t neigh_flags_to_netlink(uint8_t dplane_flags)
 		flags |= NTF_EXT_LEARNED;
 	if (dplane_flags & DPLANE_NTF_ROUTER)
 		flags |= NTF_ROUTER;
+	if (dplane_flags & DPLANE_NTF_USE)
+		flags |= NTF_USE;
 
 	return flags;
 }
@@ -166,6 +168,8 @@ static uint16_t neigh_state_to_netlink(uint16_t dplane_state)
 		state |= NUD_NOARP;
 	if (dplane_state & DPLANE_NUD_PROBE)
 		state |= NUD_PROBE;
+	if (dplane_state & DPLANE_NUD_INCOMPLETE)
+		state |= NUD_INCOMPLETE;
 
 	return state;
 }
@@ -3631,6 +3635,7 @@ static ssize_t netlink_neigh_msg_encoder(struct zebra_dplane_ctx *ctx,
 	switch (dplane_ctx_get_op(ctx)) {
 	case DPLANE_OP_NEIGH_INSTALL:
 	case DPLANE_OP_NEIGH_UPDATE:
+	case DPLANE_OP_NEIGH_DISCOVER:
 		ret = netlink_neigh_update_ctx(ctx, RTM_NEWNEIGH, buf, buflen);
 		break;
 	case DPLANE_OP_NEIGH_DELETE:

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -149,6 +149,9 @@ enum dplane_op_e {
 	DPLANE_OP_RULE_ADD,
 	DPLANE_OP_RULE_DELETE,
 	DPLANE_OP_RULE_UPDATE,
+
+	/* Link layer address discovery */
+	DPLANE_OP_NEIGH_DISCOVER,
 };
 
 /*
@@ -160,12 +163,14 @@ enum dplane_op_e {
 /* Neighbor cache flags */
 #define DPLANE_NTF_EXT_LEARNED    0x01
 #define DPLANE_NTF_ROUTER         0x02
+#define DPLANE_NTF_USE            0x04
 
 /* Neighbor cache states */
 #define DPLANE_NUD_REACHABLE      0x01
 #define DPLANE_NUD_STALE          0x02
 #define DPLANE_NUD_NOARP          0x04
 #define DPLANE_NUD_PROBE          0x08
+#define DPLANE_NUD_INCOMPLETE     0x10
 
 /* MAC update flags - dplane_mac_info.update_flags */
 #define DPLANE_MAC_REMOTE       (1 << 0)
@@ -571,6 +576,12 @@ enum zebra_dplane_result dplane_vtep_add(const struct interface *ifp,
 enum zebra_dplane_result dplane_vtep_delete(const struct interface *ifp,
 					    const struct in_addr *ip,
 					    vni_t vni);
+
+/*
+ * Enqueue a neighbour discovery request for the dataplane.
+ */
+enum zebra_dplane_result dplane_neigh_discover(const struct interface *ifp,
+					       const struct ipaddr *ip);
 
 /* Forward ref of zebra_pbr_rule */
 struct zebra_pbr_rule;

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2663,6 +2663,7 @@ void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_RULE_ADD:
 	case DPLANE_OP_RULE_DELETE:
 	case DPLANE_OP_RULE_UPDATE:
+	case DPLANE_OP_NEIGH_DISCOVER:
 	case DPLANE_OP_NONE:
 		break;
 	}

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3764,6 +3764,7 @@ static int rib_process_dplane_results(struct thread *thread)
 			case DPLANE_OP_NEIGH_DELETE:
 			case DPLANE_OP_VTEP_ADD:
 			case DPLANE_OP_VTEP_DELETE:
+			case DPLANE_OP_NEIGH_DISCOVER:
 			case DPLANE_OP_NONE:
 				/* Don't expect this: just return the struct? */
 				dplane_ctx_fini(&ctx);


### PR DESCRIPTION
We can make the Linux kernel send an ARP/NDP request by adding a neighbour with the 'NUD_INCOMPLETE' state and the 'NTF_USE' flag. I haven't found any docs related to this flag, but there is a [kernel patch](https://lists.openwall.net/netdev/2009/02/20/85) adding this.

This PR adds new dataplane operation as well as new zapi message to allow other daemons send ARP/NDP requests. We can use this to arp neighbours in ospfd instead of executing `ping` command.

I also added sharpd CLI command `sharp neigh discover` that allows to send these requests manually.
