### PR TITLE
tests: stop daemons consistently in mem leak path

### DIFF
--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -819,7 +819,9 @@ class TopoRouter(TopoGear):
         if memleak_file is None:
             return
 
-        self.stop()
+        self.stop(False, False)
+        self.stop(wait=True)
+
         self.logger.info("running memory leak report")
         self.tgen.net[self.name].report_memory_leaks(memleak_file, testname)
 


### PR DESCRIPTION
When the topotest mem-leak reporting is enabled, use the same two-step daemon stop procedure that's used in the topogen.stop_topology path. The two-step path sends SIGTERM twice, once without waiting and once with waiting. Without this, we've been seeing that SIGTERM appears to be missed (by zebra, at least) and that triggers false failures in test runs.
