### PR TITLE
zebra: fix crash in vrf-vni mapping

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2434,7 +2434,7 @@ DEFUN (no_vrf_vni_mapping,
 	int filter = 0;
 
 	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
-	vni_t vni = strtoul(argv[1]->arg, NULL, 10);
+	vni_t vni = strtoul(argv[2]->arg, NULL, 10);
 
 	assert(vrf);
 	assert(zvrf);


### PR DESCRIPTION
As part of PR 6758 vrf vni converted to transactional cli.
Handle a scenario where vrf is not created yet (inactive) and vni is mapped to the inactive vrf.

<Testing Done:>

```
bharat(config-vrf)# do show vrf
vrf vrf1 id 11 table 1001
vrf vrf5 inactive (configured)

bharat(config)# vrf vrf5
bharat(config-vrf)# vni 5005

bharat(config-vrf)# do show vrf vni
VRF                                   VNI        VxLAN IF             L3-SVI               State Rmac
vrf5                                  5005       None                 None                 Down  None

bharat(config-vrf)# no vni 5005
bharat(config-vrf)# do show vrf vni
VRF                                   VNI        VxLAN IF             L3-SVI               State Rmac

```

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>