### PR TITLE
zebra: evpn Revert "zebra: probe local inactive neigh"

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3138,25 +3138,6 @@ enum zebra_dplane_result dplane_local_neigh_add(const struct interface *ifp,
 }
 
 /*
- * Enqueue evpn neighbor update for the dataplane.
- */
-enum zebra_dplane_result dplane_rem_neigh_update(const struct interface *ifp,
-					     const struct ipaddr *ip,
-					     const struct ethaddr *mac)
-{
-	enum zebra_dplane_result result;
-	uint32_t update_flags = 0;
-
-	update_flags |= DPLANE_NEIGH_REMOTE;
-
-	result = neigh_update_internal(DPLANE_OP_NEIGH_UPDATE,
-				       ifp, mac, ip, 0, DPLANE_NUD_PROBE,
-				       update_flags);
-
-	return result;
-}
-
-/*
  * Enqueue evpn neighbor delete for the dataplane.
  */
 enum zebra_dplane_result dplane_rem_neigh_delete(const struct interface *ifp,

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -557,9 +557,6 @@ enum zebra_dplane_result dplane_local_neigh_add(const struct interface *ifp,
 					  const struct ethaddr *mac,
 					  bool set_router, bool set_static,
 					  bool set_inactive);
-enum zebra_dplane_result dplane_rem_neigh_update(const struct interface *ifp,
-					     const struct ipaddr *ip,
-					     const struct ethaddr *mac);
 enum zebra_dplane_result dplane_rem_neigh_delete(const struct interface *ifp,
 					     const struct ipaddr *ip);
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -116,7 +116,6 @@ static int zvni_neigh_send_del_to_client(vni_t vni, struct ipaddr *ip,
 static int zvni_rem_neigh_install(zebra_vni_t *zvni,
 		zebra_neigh_t *n, bool was_static);
 static int zvni_neigh_uninstall(zebra_vni_t *zvni, zebra_neigh_t *n);
-static int zvni_neigh_probe(zebra_vni_t *zvni, zebra_neigh_t *n);
 static zebra_vni_t *zvni_from_svi(struct interface *ifp,
 				  struct interface *br_if);
 static struct interface *zvni_map_to_svi(vlanid_t vid, struct interface *br_if);
@@ -2657,18 +2656,6 @@ static void zvni_process_neigh_on_remote_mac_del(zebra_vni_t *zvni,
 	/* NOTE: Currently a NO-OP. */
 }
 
-static void zvni_probe_neigh_on_mac_add(zebra_vni_t *zvni, zebra_mac_t *zmac)
-{
-	zebra_neigh_t *nbr = NULL;
-	struct listnode *node = NULL;
-
-	for (ALL_LIST_ELEMENTS_RO(zmac->neigh_list, node, nbr)) {
-		if (CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_LOCAL) &&
-		    IS_ZEBRA_NEIGH_INACTIVE(nbr))
-			zvni_neigh_probe(zvni, nbr);
-	}
-}
-
 /*
  * Inform BGP about local neighbor addition.
  */
@@ -2793,29 +2780,6 @@ static int zvni_neigh_uninstall(zebra_vni_t *zvni, zebra_neigh_t *n)
 	n->loc_seq = 0;
 
 	dplane_rem_neigh_delete(vlan_if, &n->ip);
-
-	return 0;
-}
-
-/*
- * Probe neighbor from the kernel.
- */
-static int zvni_neigh_probe(zebra_vni_t *zvni, zebra_neigh_t *n)
-{
-	struct zebra_if *zif;
-	struct zebra_l2info_vxlan *vxl;
-	struct interface *vlan_if;
-
-	zif = zvni->vxlan_if->info;
-	if (!zif)
-		return -1;
-	vxl = &zif->l2info.vxl;
-
-	vlan_if = zvni_map_to_svi(vxl->access_vlan, zif->brslave_info.br_if);
-	if (!vlan_if)
-		return -1;
-
-	dplane_rem_neigh_update(vlan_if, &n->ip, &n->emac);
 
 	return 0;
 }
@@ -7452,8 +7416,6 @@ static void process_remote_macip_add(vni_t vni,
 		if (!is_dup_detect)
 			zvni_rem_neigh_install(zvni, n, old_static);
 	}
-
-	zvni_probe_neigh_on_mac_add(zvni, mac);
 
 	/* Update seq number. */
 	n->rem_seq = seq;


### PR DESCRIPTION
Reverting probing of neigh entry. There is a timing where
probe and remote macip add request comes at the same time resulting
in neigh to remain in local state event though it should be remote.

In mobility case, the host moves to remote VTEP, first MAC only type-2
route is received which triggers a PROBE of neighs (associated to MAC).
PROBE request can go via network port to remote VTEP.

PROBE request picks up local neigh with MAC entry's outgoing port is
remote VTEP tunnel port.
The PROBE reply and MAC-IP (containing IP) almost comes same time at
DUT.

DUT first processes remote macip and installs neigh as remote.
Followed by receives neigh as REACHABLE which marks neigh as LOCAL.

FRR does have BPF filter which does not allow its own netlink request
to receive. Otherwise frr's request to program neigh as remote can move
neigh from local to remote.

Though ordering can not be guranteed that REACHABLE (PROBE's repsonse)
can come at anytime and move it to LOCAL.

This fix would not suffice the needs of converging LOCAL inactive neighs
to remove from DB. As mobility draft sugges to PROBE local neigh when
MAC moves to remote but it is not working with current framework.

This reverts commit 44bc8ae5508975f216ad1cbb42884579896e7258

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>