### PR TITLE
yang: evpn data model

### DIFF
--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -663,6 +663,41 @@ module frr-zebra {
     }
   }
 
+  grouping dup-detect-params {
+    container dup-addr-detect {
+      presence "Enable/disable Duplicate Address Detection (DAD).";
+      choice freeze {
+        case permanent {
+          description
+            "DAD permanent freeze.";
+          leaf enable {
+            type boolean;
+          }
+        }
+
+        case duration {
+          leaf timeout {
+            type uint32 {
+              range "30..3600";
+            }
+            units "seconds";
+            description
+              "DAD freeze interval; freeze the address until the duration.";
+          }
+        }
+      }
+
+      leaf move-threshold {
+        type uint32 {
+          range "2..1000";
+        }
+        default "5";
+        description
+          "Maximum moves allowed before the address is considered as duplicate.";
+      }
+    }
+  }
+
   // End of zebra container
   /*
    * RPCs
@@ -2155,6 +2190,119 @@ module frr-zebra {
       description
         "Limit on the number of updates queued to the dataplane subsystem.";
     }
+
+    container evpn {
+      description
+        "EVPN control plane configuraitons and informations.";
+      container global {
+        container enable-evpn {
+          leaf enable {
+            type boolean;
+            default "false";
+            description
+              "Advertise all local VNIs.";
+          }
+
+          leaf vrf {
+            type string {
+              length "1..36";
+            }
+            description
+              "The tenant VRF under which vxlan is enabled.";
+          }
+        }
+
+        container encapsulations {
+          list encap {
+            key "encap-type";
+            leaf encap-type {
+              type enumeration {
+                enum "vxlan" {
+                  value 1;
+                }
+                enum "mpls" {
+                  value 2;
+                }
+              }
+            }
+
+            leaf advertise-default-gw {
+              type boolean;
+              default "false";
+              description
+                "In centralize routing, advertise all SVI addresses across EVIs as type-2 routes.";
+            }
+
+            leaf advertise-svi-ip {
+              type boolean;
+              default "false";
+              description
+                "Advertise addresses of SVIs across all EVIs as MAC-IP routes in EVPN.";
+            }
+
+            leaf advertise-pip {
+              type boolean;
+              default "true";
+              description
+                "Advertise type-5 routes across VRFs and
+                 self type-2 evpn routes across all EVIs with system's primary IP as nexthop in EVPN.";
+            }
+
+            uses dup-detect-params;
+
+            container evpn-instances {
+              list evi {
+                key "name";
+                description
+                  "evpn ethernet virtual instance; Per-EVI informations.";
+                leaf name {
+                  type string;
+                  description
+                    "EVI instance name.";
+                }
+
+                leaf vni-id {
+                  type vni-id-type;
+                  description
+                    "An L2 VNI identifier for VxLAN.";
+                }
+
+                container br-vlan {
+                  leaf bridge-id {
+                    type uint32;
+                    description
+                      "Bridge Id.";
+                  }
+
+                  leaf-list vlan-id {
+                    type uint16 {
+                      range "1..4094";
+                    }
+                    description
+                      "A VLAN identifier.";
+                  }
+                }
+
+                leaf advertise-default-gw {
+                  type boolean;
+                  default "false";
+                  description
+                    "In centralize routing, advertises gateway macip routes for a vni.";
+                }
+
+                leaf advertise-svi-ip {
+                  type boolean;
+                  default "false";
+                  description
+                    "Advertise addresses of SVIs per  EVI as MAC-IP routes in EVPN.";
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     /*
      * Debug options
      */

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -92,6 +92,111 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
+			.xpath = "/frr-zebra:zebra/evpn/global/enable-evpn/enable",
+			.cbs = {
+				.modify = zebra_evpn_global_enable_evpn_enable_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/enable-evpn/vrf",
+			.cbs = {
+				.modify = zebra_evpn_global_enable_evpn_vrf_modify,
+				.destroy = zebra_evpn_global_enable_evpn_vrf_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap",
+			.cbs = {
+				.create = zebra_evpn_global_encapsulations_encap_create,
+				.destroy = zebra_evpn_global_encapsulations_encap_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/advertise-default-gw",
+			.cbs = {
+				.modify = zebra_evpn_global_encapsulations_encap_advertise_default_gw_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/advertise-svi-ip",
+			.cbs = {
+				.modify = zebra_evpn_global_encapsulations_encap_advertise_svi_ip_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/advertise-pip",
+			.cbs = {
+				.modify = zebra_evpn_global_encapsulations_encap_advertise_pip_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/dup-addr-detect",
+			.cbs = {
+				.create = zebra_evpn_global_encapsulations_encap_dup_addr_detect_create,
+				.destroy = zebra_evpn_global_encapsulations_encap_dup_addr_detect_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/dup-addr-detect/enable",
+			.cbs = {
+				.modify = zebra_evpn_global_encapsulations_encap_dup_addr_detect_enable_modify,
+				.destroy = zebra_evpn_global_encapsulations_encap_dup_addr_detect_enable_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/dup-addr-detect/timeout",
+			.cbs = {
+				.modify = zebra_evpn_global_encapsulations_encap_dup_addr_detect_timeout_modify,
+				.destroy = zebra_evpn_global_encapsulations_encap_dup_addr_detect_timeout_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/dup-addr-detect/move-threshold",
+			.cbs = {
+				.modify = zebra_evpn_global_encapsulations_encap_dup_addr_detect_move_threshold_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi",
+			.cbs = {
+				.create = zebra_evpn_global_encapsulations_encap_evpn_instances_evi_create,
+				.destroy = zebra_evpn_global_encapsulations_encap_evpn_instances_evi_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi/vni-id",
+			.cbs = {
+				.modify = zebra_evpn_global_encapsulations_encap_evpn_instances_evi_vni_id_modify,
+				.destroy = zebra_evpn_global_encapsulations_encap_evpn_instances_evi_vni_id_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi/br-vlan/bridge-id",
+			.cbs = {
+				.modify = zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_bridge_id_modify,
+				.destroy = zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_bridge_id_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi/br-vlan/vlan-id",
+			.cbs = {
+				.create = zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_vlan_id_create,
+				.destroy = zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_vlan_id_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi/advertise-default-gw",
+			.cbs = {
+				.modify = zebra_evpn_global_encapsulations_encap_evpn_instances_evi_advertise_default_gw_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi/advertise-svi-ip",
+			.cbs = {
+				.modify = zebra_evpn_global_encapsulations_encap_evpn_instances_evi_advertise_svi_ip_modify,
+			}
+		},
+		{
 			.xpath = "/frr-zebra:zebra/debugs/debug-events",
 			.cbs = {
 				.modify = zebra_debugs_debug_events_modify,

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -57,6 +57,53 @@ int zebra_import_kernel_table_route_map_destroy(
 int zebra_allow_external_route_update_create(struct nb_cb_create_args *args);
 int zebra_allow_external_route_update_destroy(struct nb_cb_destroy_args *args);
 int zebra_dplane_queue_limit_modify(struct nb_cb_modify_args *args);
+int zebra_evpn_global_enable_evpn_enable_modify(struct nb_cb_modify_args *args);
+int zebra_evpn_global_enable_evpn_vrf_modify(struct nb_cb_modify_args *args);
+int zebra_evpn_global_enable_evpn_vrf_destroy(struct nb_cb_destroy_args *args);
+int zebra_evpn_global_encapsulations_encap_create(
+	struct nb_cb_create_args *args);
+int zebra_evpn_global_encapsulations_encap_destroy(
+	struct nb_cb_destroy_args *args);
+int zebra_evpn_global_encapsulations_encap_advertise_default_gw_modify(
+	struct nb_cb_modify_args *args);
+int zebra_evpn_global_encapsulations_encap_advertise_svi_ip_modify(
+	struct nb_cb_modify_args *args);
+int zebra_evpn_global_encapsulations_encap_advertise_pip_modify(
+	struct nb_cb_modify_args *args);
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_create(
+	struct nb_cb_create_args *args);
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_destroy(
+	struct nb_cb_destroy_args *args);
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_enable_modify(
+	struct nb_cb_modify_args *args);
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_enable_destroy(
+	struct nb_cb_destroy_args *args);
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_timeout_modify(
+	struct nb_cb_modify_args *args);
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_timeout_destroy(
+	struct nb_cb_destroy_args *args);
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_move_threshold_modify(
+	struct nb_cb_modify_args *args);
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_create(
+	struct nb_cb_create_args *args);
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_destroy(
+	struct nb_cb_destroy_args *args);
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_vni_id_modify(
+	struct nb_cb_modify_args *args);
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_vni_id_destroy(
+	struct nb_cb_destroy_args *args);
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_bridge_id_modify(
+	struct nb_cb_modify_args *args);
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_bridge_id_destroy(
+	struct nb_cb_destroy_args *args);
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_vlan_id_create(
+	struct nb_cb_create_args *args);
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_vlan_id_destroy(
+	struct nb_cb_destroy_args *args);
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_advertise_default_gw_modify(
+	struct nb_cb_modify_args *args);
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_advertise_svi_ip_modify(
+	struct nb_cb_modify_args *args);
 int zebra_debugs_debug_events_modify(struct nb_cb_modify_args *args);
 int zebra_debugs_debug_events_destroy(struct nb_cb_destroy_args *args);
 int zebra_debugs_debug_zapi_send_modify(struct nb_cb_modify_args *args);

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -275,6 +275,434 @@ int zebra_dplane_queue_limit_modify(struct nb_cb_modify_args *args)
 }
 
 /*
+ * XPath: /frr-zebra:zebra/evpn/global/enable-evpn/enable
+ */
+int zebra_evpn_global_enable_evpn_enable_modify(struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/evpn/global/enable-evpn/vrf
+ */
+int zebra_evpn_global_enable_evpn_vrf_modify(struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_evpn_global_enable_evpn_vrf_destroy(struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/evpn/global/encapsulations/encap
+ */
+int zebra_evpn_global_encapsulations_encap_create(
+	struct nb_cb_create_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_evpn_global_encapsulations_encap_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/evpn/global/encapsulations/encap/advertise-default-gw
+ */
+int zebra_evpn_global_encapsulations_encap_advertise_default_gw_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/evpn/global/encapsulations/encap/advertise-svi-ip
+ */
+int zebra_evpn_global_encapsulations_encap_advertise_svi_ip_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/evpn/global/encapsulations/encap/advertise-pip
+ */
+int zebra_evpn_global_encapsulations_encap_advertise_pip_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/evpn/global/encapsulations/encap/dup-addr-detect
+ */
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_create(
+	struct nb_cb_create_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-zebra:zebra/evpn/global/encapsulations/encap/dup-addr-detect/enable
+ */
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_enable_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_enable_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-zebra:zebra/evpn/global/encapsulations/encap/dup-addr-detect/timeout
+ */
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_timeout_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_timeout_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-zebra:zebra/evpn/global/encapsulations/encap/dup-addr-detect/move-threshold
+ */
+int zebra_evpn_global_encapsulations_encap_dup_addr_detect_move_threshold_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi
+ */
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_create(
+	struct nb_cb_create_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi/vni-id
+ */
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_vni_id_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_vni_id_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi/br-vlan/bridge-id
+ */
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_bridge_id_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_bridge_id_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi/br-vlan/vlan-id
+ */
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_vlan_id_create(
+	struct nb_cb_create_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_br_vlan_vlan_id_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi/advertise-default-gw
+ */
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_advertise_default_gw_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-zebra:zebra/evpn/global/encapsulations/encap/evpn-instances/evi/advertise-svi-ip
+ */
+int zebra_evpn_global_encapsulations_encap_evpn_instances_evi_advertise_svi_ip_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-zebra:zebra/debugs/debug-events
  */
 int zebra_debugs_debug_events_modify(struct nb_cb_modify_args *args)


### PR DESCRIPTION
EVPN yang data model:

# Following objectives are kept in mind:

1. Simplicity of user configuration via data model.
2. To deviate EVPN as a protocol from BGP, decouple the long standing knot between the duo,
   by moving evpn specific L2 config under zebra's (yang modules) “global” config.
3. Make adjustments to the data model to facilitate (multiple) services like EVPN-MPLS
   and Vlan aware Bundle Service (VAB) features along with  existing EVPN-VxLAN.
4. Align (to some degree) to standard EVPN models 

- The new EVI instance  is similar to VNI construct in evpn vxlan domain
  and composition of VAB and EVPN-MPLS services. 
  Named EVI is chosen to composite  multiple vlans mapped to bridge-domain. 
  The name field is overloaded but for evpn-VxLAN service it can simply be “VNI-<vni-id>” -> “VNI-1001” 
   (where 1001 is vni-id). 
 For existing feature one can think *EVI == VNI*.

- EVPN is L2/L3 feature so it truly does not characterized as routing
  protocol.  It uses bgp (multi-protocol) as transport mechanism.

- With the new config model, move all the evpn knobs under zebra's global
  evpn hierarchy.
  Zebra is aware of the L2 properties like vlans and associated bridge-ids. For VAB and
  EVPN-MPLS is best suited in zebra's config model. 
- evpn multihoming configuration is already hosted in zebra's global config model and parts per interface level.

- Route distinguisher (RD) and Route-target (RT) configuration remains in bgp.
  EVI model would be augmented to host under each EVI (vni). 

- advertise-pip knob is moved under global evpn configuration which can be enabled for all VRFs (L3vnis)

Why move existing bgp based config  to zebra. As we have all seen FRR evpn code, majority of configuration do take actions from zebra vxlan 
-	Zebra-vxlan code base is aware of vxlan devices (VNI) up/down events, bridge-vlan associations. It is ideal to consolidate to the data model to host unified Config model. 
-  advertise default-gw, advertise-svi-ip and ad


# For backward compatibility:
- bgp based configuration clis will not be removed or converted to northbound transactional CLI. 
  Eventually, the vtysh clis will be phased out and superseded by evpn data model.
- EVI name is accepted in format of "VNI-<vni-id> form.
  Example: vni-1001 would have evni name as "VNI-1001".
  Backend will extract the vni-id from evi name to map id  based datastructure
  eventually evi name will be accepted in more relax form to accept
  different format of names.

# Operational data:
Zebra per vni operational outputs will be anchored under per EVI as state data tree.
BGP continue to host global evpn route table under bgp rib (state) data tree.

# Impact to existing configuration:
Since the existing evpn clis (under router bgp) are not converted to northbound transactional clis. The existing deployment is not impacted by the new data model. 
If the user chooses to use evpn data model it is expacted to have transition/conversion of existing configuration (frr.conf) to new data model. 

# Data model tree 
```
     +--rw evpn 
     |  +--rw global
     |  |  +--rw enable-evpn?            boolean <false>     <-- analogy to advertise-all-vni global knob
     |  |  +--rw advertise-default-gw?   boolean <false>
     |  |  +--rw advertise-pip?          boolean <true>      <-- enable for all vrfs (for type-5 routes)
     |  |  +--rw advertise-svi-ip?       boolean <false>
     |  |  +--rw dup-addr-detect!
     |  |  |  +--rw (freeze)?
     |  |  |  |  +--:(permanent)
     |  |  |  |  |  +--rw enable?   boolean
     |  |  |  |  +--:(duration)
     |  |  |  |     +--rw timeout?   uint32
     |  |  |  +--rw move-threshold?   uint32 <5>
     |  |  +--rw encapsulation
     |  |     +--rw encap-type?   enumeration
     |  +--rw evpn-instances
     |     +--rw evi* [name]
     |        +--rw name                      string
     |        +--rw vni-id?                   vni-id-type    <-- mostly filled by the backed based on the name conversion or system configured vni 
     |        +--rw br-vlan
     |        |  +--rw bridge-id?   uint32
     |        |  +--rw vlan-id*     uint16
     |        +--rw advertise-default-gw?     boolean <false>
     |        +--rw advertise-svi-ip?         boolean <false>
                             *Hosted in bgpd* 
     |        +--rw frr-bgp:bgp-parameters
     |           +--rw frr-bgp:rd?               ietf-routing-types:route-distinguisher
     |           +--rw frr-bgp:import-rt-list*   ietf-routing-types:route-target
     |           +--rw frr-bgp:export-rt-list*   ietf-routing-types:route-target
```

Once bgp yang model is available following would append RD/RT config.

```
  augment "/frr-zebra:zebra/frr-zebra:evpn/frr-zebra:evpn-instances/frr-zebra:evi" {
    container bgp-parameters {
      uses route-distinguisher-params;
      uses rt-list;
    }

 }
```


Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>