### PR TITLE
staticd : Added the warning log for route when VRF is not ready.

### DIFF
--- a/staticd/static_debug.c
+++ b/staticd/static_debug.c
@@ -34,13 +34,16 @@
 
 /* clang-format off */
 struct debug static_dbg_events = {0, "Staticd events"};
+struct debug static_dbg_route = {0, "Staticd route"};
 
 struct debug *static_debug_arr[] =  {
-	&static_dbg_events
+	&static_dbg_events,
+	&static_dbg_route
 };
 
 const char *static_debugs_conflines[] = {
-	"debug static events"
+	"debug static events",
+	"debug static route"
 };
 /* clang-format on */
 
@@ -102,12 +105,14 @@ int static_debug_status_write(struct vty *vty)
  *    Debug general internal events
  *
  */
-void static_debug_set(int vtynode, bool onoff, bool events)
+void static_debug_set(int vtynode, bool onoff, bool events, bool route)
 {
 	uint32_t mode = DEBUG_NODE2MODE(vtynode);
 
 	if (events)
 		DEBUG_MODE_SET(&static_dbg_events, mode, onoff);
+	if (route)
+		DEBUG_MODE_SET(&static_dbg_route, mode, onoff);
 }
 
 /*

--- a/staticd/static_debug.h
+++ b/staticd/static_debug.h
@@ -30,6 +30,7 @@
 
 /* staticd debugging records */
 extern struct debug static_dbg_events;
+extern struct debug static_dbg_route;
 
 /*
  * Initialize staticd debugging.
@@ -67,7 +68,7 @@ int static_debug_status_write(struct vty *vty);
  *    Debug general internal events
  *
  */
-void static_debug_set(int vtynode, bool onoff, bool events);
+void static_debug_set(int vtynode, bool onoff, bool events, bool route);
 
 
 #endif /* _STATIC_DEBUG_H */

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -222,6 +222,13 @@ static int nexthop_mpls_label_stack_entry_create(struct nb_cb_create_args *args)
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		if (!mpls_enabled) {
+			snprintf(
+				args->errmsg, args->errmsg_len,
+				"%% MPLS not turned on in kernel ignoring static route");
+			return NB_ERR_VALIDATION;
+		}
+		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
@@ -481,6 +488,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_cr
 				yang_dnode_get_string(args->dnode, "./prefix"));
 			return NB_ERR;
 		}
+		if (vrf->vrf_id == VRF_UNKNOWN)
+			snprintf(
+				args->errmsg, args->errmsg_len,
+				"Static Route to %s not installed currently because dependent config not fully available",
+				yang_dnode_get_string(args->dnode, "./prefix"));
 		nb_running_set_entry(args->dnode, rn);
 		break;
 	}

--- a/staticd/static_nht.h
+++ b/staticd/static_nht.h
@@ -47,4 +47,10 @@ extern void static_nht_reset_start(struct prefix *nhp, afi_t afi,
  */
 extern void static_nht_mark_state(struct prefix *sp, vrf_id_t vrf_id,
 				  enum static_install_states state);
+
+/*
+ * For the given nexthop, returns the string
+ */
+extern void static_get_nh_str(struct static_nexthop *nh, char *nexthop,
+			      size_t size);
 #endif

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -197,4 +197,17 @@ extern bool static_add_nexthop_validate(struct static_vrf *svrf,
 					struct ipaddr *ipaddr);
 extern struct stable_info *static_get_stable_info(struct route_node *rn);
 extern void static_route_info_init(struct static_route_info *si);
+
+/*
+ * Max string return via API static_get_nh_str in size_t
+ */
+
+#define NEXTHOP_STR (INET6_ADDRSTRLEN + INTERFACE_NAMSIZ + 25)
+/*
+ * For the given nexthop, returns the string
+ * nexthop : returns the formatted string in nexthop
+ * size : max size of formatted string
+ */
+extern void static_get_nh_str(struct static_nexthop *nh, char *nexthop,
+			      size_t size);
 #endif

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -1124,19 +1124,17 @@ DEFPY_YANG(ipv6_route_vrf,
 				 ifname, flag, tag_str, distance_str, label,
 				 table_str, false, color_str);
 }
-DEFPY_YANG(debug_staticd,
-      debug_staticd_cmd,
-      "[no] debug static [{events$events}]",
-      NO_STR
-      DEBUG_STR
-      STATICD_STR
-      "Debug events\n")
+DEFPY_YANG(debug_staticd, debug_staticd_cmd,
+	   "[no] debug static [{events$events|route$route}]",
+	   NO_STR DEBUG_STR STATICD_STR
+	   "Debug events\n"
+	   "Debug route\n")
 {
 	/* If no specific category, change all */
 	if (strmatch(argv[argc - 1]->text, "static"))
-		static_debug_set(vty->node, !no, true);
+		static_debug_set(vty->node, !no, true, true);
 	else
-		static_debug_set(vty->node, !no, !!events);
+		static_debug_set(vty->node, !no, !!events, !!route);
 
 	return CMD_SUCCESS;
 }

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -42,8 +42,7 @@
 #include "static_zebra.h"
 #include "static_nht.h"
 #include "static_vty.h"
-
-bool debug;
+#include "static_debug.h"
 
 /* Zebra structure to hold current status. */
 struct zclient *zclient;
@@ -313,9 +312,9 @@ void static_zebra_nht_register(struct route_node *rn, struct static_nexthop *nh,
 				static_nht_hash_alloc);
 		nhtd->refcount++;
 
-		if (debug)
-			zlog_debug("Registered nexthop(%pFX) for %pRN %d", &p,
-				   rn, nhtd->nh_num);
+		DEBUGD(&static_dbg_route,
+		       "Registered nexthop(%pFX) for %pRN %d", &p, rn,
+		       nhtd->nh_num);
 		if (nhtd->refcount > 1 && nhtd->nh_num) {
 			static_nht_update(&rn->p, nhtd->nh, nhtd->nh_num, afi,
 					  nh->nh_vrf_id);


### PR DESCRIPTION
During the yangification of staticd, refactoring of code
around static_hold_route data struct has been done, In this
context warning log message when VRF is not ready had been
removed. This should not be removed, adding it back.

Signed-off-by: vishaldhingra vdhingra@vmware.com