### PR TITLE
ospfd: fix processing of SR RI LSAs

### DIFF
--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -1048,32 +1048,25 @@ void ospf_sr_ri_lsa_update(struct ospf_lsa *lsa)
 		}
 		/* update LSA ID */
 		srn->instance = ntohl(lsah->id.s_addr);
-		/* Copy SRGB */
-		srn->srgb.range_size = srgb.range_size;
-		srn->srgb.lower_bound = srgb.lower_bound;
-		/* Set Algorithm */
-		if (algo != NULL) {
-			int i;
-			for (i = 0; i < ntohs(algo->header.length); i++)
-				srn->algo[i] = algo->value[0];
-			for (; i < ALGORITHM_COUNT; i++)
-				srn->algo[i] = SR_ALGORITHM_UNSET;
-		} else {
-			srn->algo[0] = SR_ALGORITHM_SPF;
-		}
-		/* set MSD */
-		srn->msd = msd;
-		return;
 	}
 
-	/* Check if SRGB has changed */
-	if ((srn->srgb.range_size == srgb.range_size)
-	    && (srn->srgb.lower_bound == srgb.lower_bound))
-		return;
+	/* Set Algorithm */
+	if (algo != NULL) {
+		int i;
+		for (i = 0; i < ntohs(algo->header.length); i++)
+			srn->algo[i] = algo->value[0];
+		for (; i < ALGORITHM_COUNT; i++)
+			srn->algo[i] = SR_ALGORITHM_UNSET;
+	} else {
+		srn->algo[0] = SR_ALGORITHM_SPF;
+	}
 
-	/* Update SRGB ... */
+	srn->msd = msd;
+
+	/* Copy SRGB */
 	srn->srgb.range_size = srgb.range_size;
 	srn->srgb.lower_bound = srgb.lower_bound;
+
 	/* ... and NHLFE if it is a neighbor SR node */
 	if (srn->neighbor == OspfSR.self)
 		hash_iterate(OspfSR.neighbors, update_out_nhlfe, srn);


### PR DESCRIPTION
Router Information are contained in opaque LSAs and when such a LSA
is received a new SR node for the advertising router is created.

However, the RI related data is currently not set when such a SR node
already exists. This can happen when e.g. link and prefix information
arrive before the RI and therefore an SR node is created.

This is now fixed by setting the data everytime the RI is received,
independent of the SR node already existing or not.

Signed-off-by: GalaxyGorilla <sascha@netdef.org>