### PR TITLE
pimd: Allow multiple secondary addresses to work

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -341,7 +341,7 @@ pim_sec_addr_find(struct pim_interface *pim_ifp, struct prefix *addr)
 	struct listnode *node;
 
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->sec_addr_list, node, sec_addr)) {
-		if (prefix_cmp(&sec_addr->addr, addr)) {
+		if (prefix_cmp(&sec_addr->addr, addr) == 0) {
 			return sec_addr;
 		}
 	}


### PR DESCRIPTION
Suppose you have more than 2 addresses on a pim interface:
lo              up      default         10.255.0.1/32
                                        10.255.0.101/32
                                        10.255.0.254/32

A `show ip pim int lo` gives us this:

eva# show ip pim interface lo
Interface  : lo
State      : up
Address    : 10.255.0.1 (primary)
             10.255.0.101/32

When we go look at the code that pulls secondary addresses in
we are using a prefix_cmp to know if we know about a secondary already
but were expecting true values instead of -1/0/1 being returned.

Modify code so that pim sees all secondary addresses

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>