### PR TITLE
bgpd: Add support for SR-TE Policies in route-maps

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -729,7 +729,8 @@ bool attrhash_cmp(const void *p1, const void *p2)
 		    && attr1->nh_lla_ifindex == attr2->nh_lla_ifindex
 		    && attr1->distance == attr2->distance
 		    && srv6_l3vpn_same(attr1->srv6_l3vpn, attr2->srv6_l3vpn)
-		    && srv6_vpn_same(attr1->srv6_vpn, attr2->srv6_vpn))
+		    && srv6_vpn_same(attr1->srv6_vpn, attr2->srv6_vpn)
+		    && attr1->srte_color == attr2->srte_color)
 			return true;
 	}
 

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -24,6 +24,7 @@
 #include "mpls.h"
 #include "bgp_attr_evpn.h"
 #include "bgpd/bgp_encap_types.h"
+#include "srte.h"
 
 /* Simple bit mapping. */
 #define BITMAP_NBBY 8
@@ -290,6 +291,9 @@ struct attr {
 
 	/* EVPN ES */
 	esi_t esi;
+
+	/* SR-TE Color */
+	uint32_t srte_color;
 };
 
 /* rmap_change_flags definition */

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -84,6 +84,19 @@ struct bgp_nexthop_cache *bnc_new(struct bgp_nexthop_cache_head *tree,
 	return bnc;
 }
 
+bool bnc_existing_for_prefix(struct bgp_nexthop_cache *bnc)
+{
+	struct bgp_nexthop_cache *bnc_tmp;
+
+	frr_each (bgp_nexthop_cache, bnc->tree, bnc_tmp) {
+		if (bnc_tmp == bnc)
+			continue;
+		if (prefix_cmp(&bnc->prefix, &bnc_tmp->prefix) == 0)
+			return true;
+	}
+	return false;
+}
+
 void bnc_free(struct bgp_nexthop_cache *bnc)
 {
 	bnc_nexthop_free(bnc);

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -35,7 +35,6 @@
 #include "filter.h"
 
 #include "bgpd/bgpd.h"
-#include "bgpd/bgp_table.h"
 #include "bgpd/bgp_route.h"
 #include "bgpd/bgp_attr.h"
 #include "bgpd/bgp_nexthop.h"
@@ -48,10 +47,15 @@
 
 DEFINE_MTYPE_STATIC(BGPD, MARTIAN_STRING, "BGP Martian Address Intf String");
 
-char *bnc_str(struct bgp_nexthop_cache *bnc, char *buf, int size)
+int bgp_nexthop_cache_compare(const struct bgp_nexthop_cache *a,
+			      const struct bgp_nexthop_cache *b)
 {
-	prefix2str(bgp_dest_get_prefix(bnc->dest), buf, size);
-	return buf;
+	return prefix_cmp(&a->prefix, &b->prefix);
+}
+
+const char *bnc_str(struct bgp_nexthop_cache *bnc, char *buf, int size)
+{
+	return prefix2str(&bnc->prefix, buf, size);
 }
 
 void bnc_nexthop_free(struct bgp_nexthop_cache *bnc)
@@ -59,32 +63,47 @@ void bnc_nexthop_free(struct bgp_nexthop_cache *bnc)
 	nexthops_free(bnc->nexthop);
 }
 
-struct bgp_nexthop_cache *bnc_new(void)
+struct bgp_nexthop_cache *bnc_new(struct bgp_nexthop_cache_head *tree,
+				  struct prefix *prefix)
 {
 	struct bgp_nexthop_cache *bnc;
 
 	bnc = XCALLOC(MTYPE_BGP_NEXTHOP_CACHE,
 		      sizeof(struct bgp_nexthop_cache));
+	bnc->prefix = *prefix;
+	bnc->tree = tree;
 	LIST_INIT(&(bnc->paths));
+	bgp_nexthop_cache_add(tree, bnc);
+
 	return bnc;
 }
 
 void bnc_free(struct bgp_nexthop_cache *bnc)
 {
 	bnc_nexthop_free(bnc);
+	bgp_nexthop_cache_del(bnc->tree, bnc);
 	XFREE(MTYPE_BGP_NEXTHOP_CACHE, bnc);
 }
 
-/* Reset and free all BGP nexthop cache. */
-static void bgp_nexthop_cache_reset(struct bgp_table *table)
+struct bgp_nexthop_cache *bnc_find(struct bgp_nexthop_cache_head *tree,
+				   struct prefix *prefix)
 {
-	struct bgp_dest *dest;
+	struct bgp_nexthop_cache bnc = {};
+
+	if (!tree)
+		return NULL;
+
+	bnc.prefix = *prefix;
+	return bgp_nexthop_cache_find(tree, &bnc);
+}
+
+/* Reset and free all BGP nexthop cache. */
+static void bgp_nexthop_cache_reset(struct bgp_nexthop_cache_head *tree)
+{
 	struct bgp_nexthop_cache *bnc;
 
-	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest)) {
-		bnc = bgp_dest_get_bgp_nexthop_info(dest);
-		if (!bnc)
-			continue;
+	while (bgp_nexthop_cache_count(tree) > 0) {
+		bnc = bgp_nexthop_cache_first(tree);
 
 		while (!LIST_EMPTY(&(bnc->paths))) {
 			struct bgp_path_info *path = LIST_FIRST(&(bnc->paths));
@@ -93,8 +112,6 @@ static void bgp_nexthop_cache_reset(struct bgp_table *table)
 		}
 
 		bnc_free(bnc);
-		bgp_dest_set_bgp_nexthop_info(dest, NULL);
-		bgp_dest_unlock_node(dest);
 	}
 }
 
@@ -773,20 +790,19 @@ static void bgp_show_nexthops_detail(struct vty *vty, struct bgp *bgp,
 }
 
 static void bgp_show_nexthop(struct vty *vty, struct bgp *bgp,
-			     struct bgp_dest *dest,
 			     struct bgp_nexthop_cache *bnc,
 			     bool specific)
 {
 	char buf[PREFIX2STR_BUFFER];
 	time_t tbuf;
 	struct peer *peer;
-	const struct prefix *p = bgp_dest_get_prefix(dest);
 
 	peer = (struct peer *)bnc->nht_info;
 
 	if (CHECK_FLAG(bnc->flags, BGP_NEXTHOP_VALID)) {
 		vty_out(vty, " %s valid [IGP metric %d], #paths %d",
-			inet_ntop(p->family, &p->u.prefix, buf, sizeof(buf)),
+			inet_ntop(bnc->prefix.family, &bnc->prefix.u.prefix,
+				  buf, sizeof(buf)),
 			bnc->metric, bnc->path_count);
 		if (peer)
 			vty_out(vty, ", peer %s", peer->host);
@@ -794,7 +810,8 @@ static void bgp_show_nexthop(struct vty *vty, struct bgp *bgp,
 		bgp_show_nexthops_detail(vty, bgp, bnc);
 	} else {
 		vty_out(vty, " %s invalid, #paths %d",
-			inet_ntop(p->family, &p->u.prefix, buf, sizeof(buf)),
+			inet_ntop(bnc->prefix.family, &bnc->prefix.u.prefix,
+				  buf, sizeof(buf)),
 			bnc->path_count);
 		if (peer)
 			vty_out(vty, ", peer %s", peer->host);
@@ -816,29 +833,21 @@ static void bgp_show_nexthop(struct vty *vty, struct bgp *bgp,
 static void bgp_show_nexthops(struct vty *vty, struct bgp *bgp,
 			      bool import_table)
 {
-	struct bgp_dest *dest;
 	struct bgp_nexthop_cache *bnc;
 	afi_t afi;
-	struct bgp_table **table;
+	struct bgp_nexthop_cache_head(*tree)[AFI_MAX];
 
 	if (import_table)
 		vty_out(vty, "Current BGP import check cache:\n");
 	else
 		vty_out(vty, "Current BGP nexthop cache:\n");
 	if (import_table)
-		table = bgp->import_check_table;
+		tree = &bgp->import_check_table;
 	else
-		table = bgp->nexthop_cache_table;
+		tree = &bgp->nexthop_cache_table;
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
-		if (!table || !table[afi])
-			continue;
-		for (dest = bgp_table_top(table[afi]); dest;
-		     dest = bgp_route_next(dest)) {
-			bnc = bgp_dest_get_bgp_nexthop_info(dest);
-			if (!bnc)
-				continue;
-			bgp_show_nexthop(vty, bgp, dest, bnc, false);
-		}
+		frr_each (bgp_nexthop_cache, &(*tree)[afi], bnc)
+			bgp_show_nexthop(vty, bgp, bnc, false);
 	}
 }
 
@@ -859,27 +868,21 @@ static int show_ip_bgp_nexthop_table(struct vty *vty, const char *name,
 
 	if (nhopip_str) {
 		struct prefix nhop;
-		struct bgp_table **table;
-		struct bgp_dest *dest;
+		struct bgp_nexthop_cache_head (*tree)[AFI_MAX];
 		struct bgp_nexthop_cache *bnc;
 
 		if (!str2prefix(nhopip_str, &nhop)) {
 			vty_out(vty, "nexthop address is malformed\n");
 			return CMD_WARNING;
 		}
-		table = import_table ? \
-			bgp->import_check_table : bgp->nexthop_cache_table;
-		dest = bgp_node_lookup(table[family2afi(nhop.family)], &nhop);
-		if (!dest) {
-			vty_out(vty, "specified nexthop is not found\n");
-			return CMD_SUCCESS;
-		}
-		bnc = bgp_dest_get_bgp_nexthop_info(dest);
+		tree = import_table ? &bgp->import_check_table
+				    : &bgp->nexthop_cache_table;
+		bnc = bnc_find(tree[family2afi(nhop.family)], &nhop, 0);
 		if (!bnc) {
 			vty_out(vty, "specified nexthop does not have entry\n");
 			return CMD_SUCCESS;
 		}
-		bgp_show_nexthop(vty, bgp, dest, bnc, true);
+		bgp_show_nexthop(vty, bgp, bnc, true);
 	} else
 		bgp_show_nexthops(vty, bgp, import_table);
 
@@ -966,12 +969,10 @@ void bgp_scan_init(struct bgp *bgp)
 	afi_t afi;
 
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
-		bgp->nexthop_cache_table[afi] =
-			bgp_table_init(bgp, afi, SAFI_UNICAST);
+		bgp_nexthop_cache_init(&bgp->nexthop_cache_table[afi]);
+		bgp_nexthop_cache_init(&bgp->import_check_table[afi]);
 		bgp->connected_table[afi] = bgp_table_init(bgp, afi,
 			SAFI_UNICAST);
-		bgp->import_check_table[afi] =
-			bgp_table_init(bgp, afi, SAFI_UNICAST);
 	}
 }
 
@@ -988,16 +989,12 @@ void bgp_scan_finish(struct bgp *bgp)
 
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
 		/* Only the current one needs to be reset. */
-		bgp_nexthop_cache_reset(bgp->nexthop_cache_table[afi]);
-		bgp_table_unlock(bgp->nexthop_cache_table[afi]);
-		bgp->nexthop_cache_table[afi] = NULL;
+		bgp_nexthop_cache_reset(&bgp->nexthop_cache_table[afi]);
+		bgp_nexthop_cache_reset(&bgp->import_check_table[afi]);
 
 		bgp->connected_table[afi]->route_table->cleanup =
 			bgp_connected_cleanup;
 		bgp_table_unlock(bgp->connected_table[afi]);
 		bgp->connected_table[afi] = NULL;
-
-		bgp_table_unlock(bgp->import_check_table[afi]);
-		bgp->import_check_table[afi] = NULL;
 	}
 }

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -118,6 +118,7 @@ extern bool bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
 extern struct bgp_nexthop_cache *bnc_new(struct bgp_nexthop_cache_head *tree,
 					 struct prefix *prefix,
 					 uint32_t srte_color);
+extern bool bnc_existing_for_prefix(struct bgp_nexthop_cache *bnc);
 extern void bnc_free(struct bgp_nexthop_cache *bnc);
 extern struct bgp_nexthop_cache *bnc_find(struct bgp_nexthop_cache_head *tree,
 					  struct prefix *prefix,

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -70,6 +70,7 @@ struct bgp_nexthop_cache {
 	/* Back pointer to the cache tree this entry belongs to. */
 	struct bgp_nexthop_cache_head *tree;
 
+	uint32_t srte_color;
 	struct prefix prefix;
 	void *nht_info; /* In BGP, peer session */
 	LIST_HEAD(path_list, bgp_path_info) paths;
@@ -115,10 +116,12 @@ extern bool bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
 			     uint8_t sub_type, struct attr *attr,
 			     struct bgp_dest *dest);
 extern struct bgp_nexthop_cache *bnc_new(struct bgp_nexthop_cache_head *tree,
-					 struct prefix *prefix);
+					 struct prefix *prefix,
+					 uint32_t srte_color);
 extern void bnc_free(struct bgp_nexthop_cache *bnc);
 extern struct bgp_nexthop_cache *bnc_find(struct bgp_nexthop_cache_head *tree,
-					  struct prefix *prefix);
+					  struct prefix *prefix,
+					  uint32_t srte_color);
 extern void bnc_nexthop_free(struct bgp_nexthop_cache *bnc);
 extern const char *bnc_str(struct bgp_nexthop_cache *bnc, char *buf, int size);
 extern void bgp_scan_init(struct bgp *bgp);

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -24,6 +24,7 @@
 #include "if.h"
 #include "queue.h"
 #include "prefix.h"
+#include "bgp_table.h"
 
 #define NEXTHOP_FAMILY(nexthop_len)                                            \
 	(((nexthop_len) == 4 || (nexthop_len) == 12                            \
@@ -36,8 +37,13 @@
 
 #define BGP_MP_NEXTHOP_FAMILY NEXTHOP_FAMILY
 
+PREDECL_RBTREE_UNIQ(bgp_nexthop_cache);
+
 /* BGP nexthop cache value structure. */
 struct bgp_nexthop_cache {
+	/* RB-tree entry. */
+	struct bgp_nexthop_cache_item entry;
+
 	/* IGP route's metric. */
 	uint32_t metric;
 
@@ -61,12 +67,20 @@ struct bgp_nexthop_cache {
 #define BGP_NEXTHOP_METRIC_CHANGED    (1 << 1)
 #define BGP_NEXTHOP_CONNECTED_CHANGED (1 << 2)
 
-	struct bgp_dest *dest;
+	/* Back pointer to the cache tree this entry belongs to. */
+	struct bgp_nexthop_cache_head *tree;
+
+	struct prefix prefix;
 	void *nht_info; /* In BGP, peer session */
 	LIST_HEAD(path_list, bgp_path_info) paths;
 	unsigned int path_count;
 	struct bgp *bgp;
 };
+
+extern int bgp_nexthop_cache_compare(const struct bgp_nexthop_cache *a,
+				     const struct bgp_nexthop_cache *b);
+DECLARE_RBTREE_UNIQ(bgp_nexthop_cache, struct bgp_nexthop_cache, entry,
+		    bgp_nexthop_cache_compare);
 
 /* Own tunnel-ip address structure */
 struct tip_addr {
@@ -78,6 +92,12 @@ struct bgp_addrv6 {
 	struct in6_addr addrv6;
 	struct list *ifp_name_list;
 };
+
+/* Forward declaration(s). */
+struct peer;
+struct update_subgroup;
+struct bgp_dest;
+struct attr;
 
 extern void bgp_connected_add(struct bgp *bgp, struct connected *c);
 extern void bgp_connected_delete(struct bgp *bgp, struct connected *c);
@@ -94,10 +114,13 @@ extern int bgp_config_write_scan_time(struct vty *);
 extern bool bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
 			     uint8_t sub_type, struct attr *attr,
 			     struct bgp_dest *dest);
-extern struct bgp_nexthop_cache *bnc_new(void);
+extern struct bgp_nexthop_cache *bnc_new(struct bgp_nexthop_cache_head *tree,
+					 struct prefix *prefix);
 extern void bnc_free(struct bgp_nexthop_cache *bnc);
+extern struct bgp_nexthop_cache *bnc_find(struct bgp_nexthop_cache_head *tree,
+					  struct prefix *prefix);
 extern void bnc_nexthop_free(struct bgp_nexthop_cache *bnc);
-extern char *bnc_str(struct bgp_nexthop_cache *bnc, char *buf, int size);
+extern const char *bnc_str(struct bgp_nexthop_cache *bnc, char *buf, int size);
 extern void bgp_scan_init(struct bgp *bgp);
 extern void bgp_scan_finish(struct bgp *bgp);
 extern void bgp_scan_vty_init(void);

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -76,8 +76,10 @@ static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 				   bnc_str(bnc, buf, PREFIX2STR_BUFFER),
 				   bnc->srte_color, bnc->bgp->name_pretty);
 		}
-		unregister_zebra_rnh(bnc,
-				     CHECK_FLAG(bnc->flags, BGP_STATIC_ROUTE));
+		/* only unregister if this is the last nh for this prefix*/
+		if (!bnc_existing_for_prefix(bnc))
+			unregister_zebra_rnh(
+				bnc, CHECK_FLAG(bnc->flags, BGP_STATIC_ROUTE));
 		bnc_free(bnc);
 	}
 }

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1265,6 +1265,9 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 		api.tableid = info->attr->rmap_table_id;
 	}
 
+	if (CHECK_FLAG(info->attr->flag, ATTR_FLAG_BIT(BGP_ATTR_SRTE_COLOR)))
+		SET_FLAG(api.message, ZAPI_MESSAGE_SRTE);
+
 	/* Metric is currently based on the best-path only */
 	metric = info->attr->med;
 
@@ -1303,6 +1306,11 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 				continue;
 		}
 		api_nh = &api.nexthops[valid_nh_count];
+
+		if (CHECK_FLAG(info->attr->flag,
+			       ATTR_FLAG_BIT(BGP_ATTR_SRTE_COLOR)))
+			api_nh->srte_color = info->attr->srte_color;
+
 		if (nh_family == AF_INET) {
 			if (bgp_debug_zebra(&api.prefix)) {
 				if (mpinfo->extra) {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1538,6 +1538,7 @@ struct bgp_nlri {
 #define BGP_ATTR_IPV6_EXT_COMMUNITIES           25
 #define BGP_ATTR_LARGE_COMMUNITIES              32
 #define BGP_ATTR_PREFIX_SID                     40
+#define BGP_ATTR_SRTE_COLOR                     51
 #ifdef ENABLE_BGP_VNC_ATTR
 #define BGP_ATTR_VNC                           255
 #endif

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -42,6 +42,7 @@
 #include "vxlan.h"
 #include "bgp_labelpool.h"
 #include "bgp_addpath_types.h"
+#include "bgp_nexthop.h"
 
 #define BGP_MAX_HOSTNAME 64	/* Linux max, is larger than most other sys */
 #define BGP_PEER_MAX_HASH_SIZE 16384
@@ -482,11 +483,11 @@ struct bgp {
 	/* BGP per AF peer count */
 	uint32_t af_peer_count[AFI_MAX][SAFI_MAX];
 
-	/* Route table for next-hop lookup cache. */
-	struct bgp_table *nexthop_cache_table[AFI_MAX];
+	/* Tree for next-hop lookup cache. */
+	struct bgp_nexthop_cache_head nexthop_cache_table[AFI_MAX];
 
-	/* Route table for import-check */
-	struct bgp_table *import_check_table[AFI_MAX];
+	/* Tree for import-check */
+	struct bgp_nexthop_cache_head import_check_table[AFI_MAX];
 
 	struct bgp_table *connected_table[AFI_MAX];
 

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -329,6 +329,12 @@ Route Map Set Command
 
    Set the BGP table to a given table identifier
 
+.. index:: set sr-te color (1-4294967295)
+.. clicmd:: set sr-te color (1-4294967295)
+
+   Set the color of a SR-TE Policy to be applied to a learned route. The SR-TE
+   Policy is uniquely determined by the color and the BGP nexthop.
+
 .. _route-map-call-command:
 
 Route Map Call Command


### PR DESCRIPTION
Example configuration:

```
    route-map SET_SR_POLICY permit 10
     set sr-te color 1
     !
    router bgp 1
     bgp router-id 1.1.1.1
     neighbor 2.2.2.2 remote-as 1
     neighbor 2.2.2.2 update-source lo
     address-family ipv4 unicast
      neighbor 2.2.2.2 next-hop-self
      neighbor 2.2.2.2 route-map SET_SR_POLICY in
     exit-address-family
     !
    !

```
Learned BGP routes from 2.2.2.2 are mapped to the SR-TE Policy
which is uniquely determined by the BGP nexthop (2.2.2.2 in this
case) and the SR-TE color in the route-map.