### PR TITLE
staticd: add support for SR Policies

### DIFF
--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -128,3 +128,15 @@ but this time, the route command will apply to the VRF.
     ip route 10.0.0.0/24 10.0.0.2
    exit-vrf
 
+
+SR-TE Route Commands
+====================
+
+It is possible to specify a route using a SR-TE policy configured in Zebra.
+
+e.g. to use the SR-TE policy with endpoint 6.6.6.6 and color 123 to reach the
+network 9.9.9.9/24:
+
+.. code-block:: frr
+
+  ip route 9.9.9.9/24 6.6.6.6 color 123

--- a/staticd/static_nb.c
+++ b/staticd/static_nb.c
@@ -76,6 +76,13 @@ const struct frr_yang_module_info frr_staticd_info = {
 			}
 		},
 		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/srte-color",
+			.cbs = {
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/mpls-label-stack/entry",
 			.cbs = {
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_create,
@@ -151,6 +158,13 @@ const struct frr_yang_module_info frr_staticd_info = {
 			.cbs = {
 				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_onlink_modify,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_onlink_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/src-list/path-list/frr-nexthops/nexthop/srte-color",
+			.cbs = {
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_color_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_color_destroy,
 			}
 		},
 		{

--- a/staticd/static_nb.h
+++ b/staticd/static_nb.h
@@ -45,6 +45,10 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_onlink_destroy(
 	struct nb_cb_destroy_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_modify(
+	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_destroy(
+	struct nb_cb_destroy_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_create(
 	struct nb_cb_create_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_destroy(
@@ -84,6 +88,10 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_onlink_modify(
 	struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_onlink_destroy(
+	struct nb_cb_destroy_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_color_modify(
+	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_color_destroy(
 	struct nb_cb_destroy_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_create(
 	struct nb_cb_create_args *args);
@@ -139,6 +147,8 @@ int routing_control_plane_protocols_name_validate(
 	"nexthop[nh-type='%s'][vrf='%s'][gateway='%s'][interface='%s']"
 
 #define FRR_STATIC_ROUTE_NH_ONLINK_XPATH "/onlink"
+
+#define FRR_STATIC_ROUTE_NH_COLOR_XPATH "/srte-color"
 
 #define FRR_STATIC_ROUTE_NH_BH_XPATH "/bh-type"
 

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -162,7 +162,7 @@ static bool static_nexthop_create(struct nb_cb_create_args *args,
 				yang_dnode_get_string(args->dnode,
 						      "./gateway"));
 		nh = static_add_nexthop(rn, pn, info->safi, info->svrf, nh_type,
-					&ipaddr, ifname, nh_vrf);
+					&ipaddr, ifname, nh_vrf, 0);
 		if (!nh) {
 			char buf[SRCDEST2STR_BUFFER];
 
@@ -298,6 +298,26 @@ static int static_nexthop_onlink_modify(struct nb_cb_modify_args *args)
 
 	nh = nb_running_get_entry(args->dnode, NULL, true);
 	nh->onlink = yang_dnode_get_bool(args->dnode, NULL);
+
+	return NB_OK;
+}
+
+static int static_nexthop_color_modify(struct nb_cb_modify_args *args)
+{
+	struct static_nexthop *nh;
+
+	nh = nb_running_get_entry(args->dnode, NULL, true);
+	nh->color = yang_dnode_get_uint32(args->dnode, NULL);
+
+	return NB_OK;
+}
+
+static int static_nexthop_color_destroy(struct nb_cb_destroy_args *args)
+{
+	struct static_nexthop *nh;
+
+	nh = nb_running_unset_entry(args->dnode);
+	nh->color = 0;
 
 	return NB_OK;
 }
@@ -705,6 +725,44 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	}
 	return NB_OK;
 }
+
+/*
+ * XPath:
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/srte-color
+ */
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		if (static_nexthop_color_modify(args) != NB_OK)
+			return NB_ERR;
+
+		break;
+	}
+	return NB_OK;
+}
+
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		if (static_nexthop_color_destroy(args) != NB_OK)
+			return NB_ERR;
+		break;
+	}
+	return NB_OK;
+}
+
 /*
  * XPath:
  * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/mpls-label-stack/entry
@@ -1117,6 +1175,44 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 	case NB_EV_APPLY:
+		break;
+	}
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/src-list/path-list/frr-nexthops/nexthop/srte-color
+ */
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_color_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		if (static_nexthop_color_modify(args) != NB_OK)
+			return NB_ERR;
+
+		break;
+	}
+	return NB_OK;
+}
+
+
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_color_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		if (static_nexthop_color_destroy(args) != NB_OK)
+			return NB_ERR;
 		break;
 	}
 	return NB_OK;

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -200,7 +200,7 @@ struct static_nexthop *
 static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
 		   struct static_vrf *svrf, static_types type,
 		   struct ipaddr *ipaddr, const char *ifname,
-		   const char *nh_vrf)
+		   const char *nh_vrf, uint32_t color)
 {
 	struct static_nexthop *nh;
 	struct static_vrf *nh_svrf;
@@ -218,6 +218,7 @@ static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
 	nh = XCALLOC(MTYPE_STATIC_NEXTHOP, sizeof(struct static_nexthop));
 
 	nh->type = type;
+	nh->color = color;
 
 	nh->nh_vrf_id = nh_svrf->vrf->vrf_id;
 	strlcpy(nh->nh_vrfname, nh_svrf->vrf->name, sizeof(nh->nh_vrfname));

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -132,6 +132,9 @@ struct static_nexthop {
 	 * are specified.
 	 */
 	bool onlink;
+
+	/* SR-TE color */
+	uint32_t color;
 };
 
 DECLARE_DLIST(static_nexthop_list, struct static_nexthop, list);
@@ -156,7 +159,7 @@ extern struct static_nexthop *
 static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
 		   struct static_vrf *svrf, static_types type,
 		   struct ipaddr *ipaddr, const char *ifname,
-		   const char *nh_vrf);
+		   const char *nh_vrf, uint32_t color);
 extern void static_install_nexthop(struct route_node *rn,
 				   struct static_path *pn,
 				   struct static_nexthop *nh, safi_t safi,

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -431,6 +431,10 @@ extern void static_zebra_route_add(struct route_node *rn,
 		api_nh->vrf_id = nh->nh_vrf_id;
 		if (nh->onlink)
 			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
+		if (nh->color != 0) {
+			SET_FLAG(api.message, ZAPI_MESSAGE_SRTE);
+			api_nh->srte_color = nh->color;
+		}
 
 		nh->state = STATIC_SENT_TO_ZEBRA;
 

--- a/yang/frr-nexthop.yang
+++ b/yang/frr-nexthop.yang
@@ -188,6 +188,16 @@ module frr-nexthop {
         "Nexthop is directly connected.";
     }
 
+    leaf srte-color {
+      when "../nh-type = 'ip4' or
+            ../nh-type = 'ip6' or
+            ../nh-type = 'ip4-ifindex' or
+            ../nh-type = 'ip6-ifindex'";
+      type uint32;
+      description
+        "The nexthop SR-TE color";
+    }
+
     uses rt-types:mpls-label-stack {
       description
         "Nexthop's MPLS label stack.";

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -553,6 +553,12 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/nexthop/srte-color",
+			.cbs = {
+				.get_elem = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_color_get_elem,
+			}
+		},
+		{
 			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/nexthop/mpls-label-stack/entry",
 			.cbs = {
 				.get_next = lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_mpls_label_stack_entry_get_next,

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -275,6 +275,9 @@ lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_bh_type_get_elem(
 struct yang_data *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_onlink_get_elem(
 	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_color_get_elem(
+	struct nb_cb_get_elem_args *args);
 const void *
 lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_mpls_label_stack_entry_get_next(
 	struct nb_cb_get_next_args *args);

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -808,6 +808,22 @@ lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_onlink_get_elem(
 
 /*
  * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/nexthop/srte-color
+ */
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_color_get_elem(
+	struct nb_cb_get_elem_args *args)
+{
+	struct nexthop *nexthop = (struct nexthop *)args->list_entry;
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_SRTE))
+		return yang_data_new_uint32(args->xpath, nexthop->srte_color);
+
+	return NULL;
+}
+
+/*
+ * XPath:
  * /frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route/route-entry/nexthop-group/nexthop/mpls-label-stack/entry
  */
 const void *


### PR DESCRIPTION
Configuration example:

    ip route 9.9.9.9/32 6.6.6.6 color 123

The SR Policy to be chosen is uniquely identified by the policy
endpoint (6.6.6.6) and the SR-TE color (123). Traffic will be
augmented with an MPLS label stack according to the active
candidate path of that particular policy.