### PR TITLE
zebra: clean up SA warning in vxlan code

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -9811,6 +9811,9 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 	bool inform_dataplane = false;
 	bool new_static = false;
 
+	if (ifp == NULL)
+		return -1;
+
 	/* We are interested in MACs only on ports or (port, VLAN) that
 	 * map to a VNI.
 	 */


### PR DESCRIPTION
Resolve an SA warning in the vxlan code.
