### PR TITLE
vrrpd: add frr-vrf yang module

### DIFF
--- a/vrrpd/vrrp_main.c
+++ b/vrrpd/vrrp_main.c
@@ -114,6 +114,7 @@ struct quagga_signal_t vrrp_signals[] = {
 
 static const struct frr_yang_module_info *const vrrp_yang_modules[] = {
 	&frr_filter_info,
+	&frr_vrf_info,
 	&frr_interface_info,
 	&frr_vrrpd_info,
 };


### PR DESCRIPTION
Can't have interfaces without vrf modules, since interfaces cross
reference vrfs.

Signed-off-by: Quentin Young <qlyoung@nvidia.com>