### PR TITLE
tools: Remove zebra commands that have never existed

### DIFF
--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -38,8 +38,6 @@ PROC_NAME:zebra
 CMD_LIST_START
 show zebra
 show zebra client summary
-show ip zebra route dump json
-show ipv6 zebra route dump json
 show ip nht vrf all
 show route-map
 show memory


### PR DESCRIPTION
The support bundle feature(tm) asks for some data
from zebra in the form of a command that has
never existed in FRR.  Looks like some
cruft snuck in remove.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>