### PR TITLE
ospfd: preparation for TI-LFA

### DIFF
--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -375,7 +375,7 @@ void ospf_intra_add_router(struct route_table *rt, struct vertex *v,
 	else
 		route_unlock_node(rn);
 
-	ospf_route_copy_nexthops_from_vertex(or, v);
+	ospf_route_copy_nexthops_from_vertex(area, or, v);
 
 	listnode_add(rn->info, or);
 
@@ -438,7 +438,7 @@ void ospf_intra_add_transit(struct route_table *rt, struct vertex *v,
 	or->type = OSPF_DESTINATION_NETWORK;
 	or->u.std.origin = (struct lsa_header *)lsa;
 
-	ospf_route_copy_nexthops_from_vertex(or, v);
+	ospf_route_copy_nexthops_from_vertex(area, or, v);
 
 	rn->info = or ;
 }
@@ -453,7 +453,7 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 	struct ospf_route * or ;
 	struct prefix_ipv4 p;
 	struct router_lsa *lsa;
-	struct ospf_interface *oi;
+	struct ospf_interface *oi = NULL;
 	struct ospf_path *path;
 
 	if (IS_DEBUG_OSPF_EVENT)
@@ -538,7 +538,7 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 				zlog_debug(
 					"ospf_intra_add_stub(): routes are equal, merge");
 
-			ospf_route_copy_nexthops_from_vertex(cur_or, v);
+			ospf_route_copy_nexthops_from_vertex(area, cur_or, v);
 
 			if (IPV4_ADDR_CMP(&cur_or->u.std.origin->id,
 					  &lsa->header.id)
@@ -563,7 +563,7 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 
 			list_delete_all_node(cur_or->paths);
 
-			ospf_route_copy_nexthops_from_vertex(cur_or, v);
+			ospf_route_copy_nexthops_from_vertex(area, cur_or, v);
 
 			cur_or->u.std.origin = (struct lsa_header *)lsa;
 			return;
@@ -588,24 +588,35 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
 				"ospf_intra_add_stub(): this network is on remote router");
-		ospf_route_copy_nexthops_from_vertex(or, v);
+		ospf_route_copy_nexthops_from_vertex(area, or, v);
 	} else {
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
 				"ospf_intra_add_stub(): this network is on this router");
 
-		if ((oi = ospf_if_lookup_by_lsa_pos(area, lsa_pos))) {
+		/*
+		 * Only deal with interface data when we
+		 * don't do a dry run
+		 */
+		if (!area->spf_dry_run)
+			oi = ospf_if_lookup_by_lsa_pos(area, lsa_pos);
+
+		if (oi || area->spf_dry_run) {
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(
-					"ospf_intra_add_stub(): the interface is %s",
-					IF_NAME(oi));
+					"ospf_intra_add_stub(): the lsa pos is %d",
+					lsa_pos);
 
 			path = ospf_path_new();
 			path->nexthop.s_addr = INADDR_ANY;
-			path->ifindex = oi->ifp->ifindex;
-			if (CHECK_FLAG(oi->connected->flags,
-				       ZEBRA_IFA_UNNUMBERED))
-				path->unnumbered = 1;
+
+			if (oi) {
+				path->ifindex = oi->ifp->ifindex;
+				if (CHECK_FLAG(oi->connected->flags,
+					       ZEBRA_IFA_UNNUMBERED))
+					path->unnumbered = 1;
+			}
+
 			listnode_add(or->paths, path);
 		} else {
 			if (IS_DEBUG_OSPF_EVENT)
@@ -734,30 +745,41 @@ static int ospf_path_exist(struct list *plist, struct in_addr nexthop,
 	return 0;
 }
 
-void ospf_route_copy_nexthops_from_vertex(struct ospf_route *to,
+void ospf_route_copy_nexthops_from_vertex(struct ospf_area *area,
+					  struct ospf_route *to,
 					  struct vertex *v)
 {
 	struct listnode *node;
 	struct ospf_path *path;
 	struct vertex_nexthop *nexthop;
 	struct vertex_parent *vp;
+	struct ospf_interface *oi = NULL;
 
 	assert(to->paths);
 
 	for (ALL_LIST_ELEMENTS_RO(v->parents, node, vp)) {
 		nexthop = vp->nexthop;
 
-		if (nexthop->oi != NULL) {
-			if (!ospf_path_exist(to->paths, nexthop->router,
-					     nexthop->oi)) {
-				path = ospf_path_new();
-				path->nexthop = nexthop->router;
-				path->ifindex = nexthop->oi->ifp->ifindex;
-				if (CHECK_FLAG(nexthop->oi->connected->flags,
+		/*
+		 * Only deal with interface data when we
+		 * don't do a dry run
+		 */
+		if (!area->spf_dry_run)
+			oi = ospf_if_lookup_by_lsa_pos(area, nexthop->lsa_pos);
+
+		if ((oi && !ospf_path_exist(to->paths, nexthop->router, oi))
+		    || area->spf_dry_run) {
+			path = ospf_path_new();
+			path->nexthop = nexthop->router;
+
+			if (oi) {
+				path->ifindex = oi->ifp->ifindex;
+				if (CHECK_FLAG(oi->connected->flags,
 					       ZEBRA_IFA_UNNUMBERED))
 					path->unnumbered = 1;
-				listnode_add(to->paths, path);
 			}
+
+			listnode_add(to->paths, path);
 		}
 	}
 }

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -665,6 +665,37 @@ void ospf_route_table_dump(struct route_table *rt)
 	zlog_debug("========================================");
 }
 
+void ospf_route_table_print(struct vty *vty, struct route_table *rt)
+{
+	struct route_node *rn;
+	struct ospf_route * or ;
+	struct listnode *pnode;
+	struct ospf_path *path;
+
+	vty_out(vty, "========== OSPF routing table ==========\n");
+	for (rn = route_top(rt); rn; rn = route_next(rn))
+		if ((or = rn->info) != NULL) {
+			if (or->type == OSPF_DESTINATION_NETWORK) {
+				vty_out(vty, "N %-18pFX %-15pI4 %s %d\n",
+					&rn->p, & or->u.std.area_id,
+					ospf_path_type_str[or->path_type],
+					or->cost);
+				for (ALL_LIST_ELEMENTS_RO(or->paths, pnode,
+							  path))
+					vty_out(vty, "  -> %s\n",
+						path->nexthop.s_addr != 0
+							? inet_ntoa(
+								path->nexthop)
+							: "directly connected");
+			} else
+				vty_out(vty, "R %-18pI4 %-15pI4 %s %d\n",
+					&rn->p.u.prefix4, & or->u.std.area_id,
+					ospf_path_type_str[or->path_type],
+					or->cost);
+		}
+	vty_out(vty, "========================================\n");
+}
+
 /* This is 16.4.1 implementation.
    o Intra-area paths using non-backbone areas are always the most preferred.
    o The other paths, intra-area backbone paths and inter-area paths,

--- a/ospfd/ospf_route.h
+++ b/ospfd/ospf_route.h
@@ -132,6 +132,7 @@ extern void ospf_route_table_free(struct route_table *);
 
 extern void ospf_route_install(struct ospf *, struct route_table *);
 extern void ospf_route_table_dump(struct route_table *);
+extern void ospf_route_table_print(struct vty *vty, struct route_table *rt);
 
 extern void ospf_intra_add_router(struct route_table *, struct vertex *,
 				  struct ospf_area *);

--- a/ospfd/ospf_route.h
+++ b/ospfd/ospf_route.h
@@ -146,7 +146,8 @@ extern void ospf_intra_add_stub(struct route_table *, struct router_lsa_link *,
 extern int ospf_route_cmp(struct ospf *, struct ospf_route *,
 			  struct ospf_route *);
 extern void ospf_route_copy_nexthops(struct ospf_route *, struct list *);
-extern void ospf_route_copy_nexthops_from_vertex(struct ospf_route *,
+extern void ospf_route_copy_nexthops_from_vertex(struct ospf_area *area,
+						 struct ospf_route *,
 						 struct vertex *);
 
 extern void ospf_route_subst(struct route_node *, struct ospf_route *,

--- a/ospfd/ospf_spf.h
+++ b/ospfd/ospf_spf.h
@@ -82,5 +82,7 @@ extern int ospf_spf_calculate_areas(struct ospf *ospf,
 				    bool is_dry_run);
 extern void ospf_rtrs_free(struct route_table *);
 
+extern void ospf_spf_print(struct vty *vty, struct vertex *v, int i);
+
 /* void ospf_spf_calculate_timer_add (); */
 #endif /* _QUAGGA_OSPF_SPF_H */

--- a/ospfd/ospf_spf.h
+++ b/ospfd/ospf_spf.h
@@ -49,15 +49,14 @@ struct vertex {
 
 /* A nexthop taken on the root node to get to this (parent) vertex */
 struct vertex_nexthop {
-	struct ospf_interface *oi; /* output intf on root node */
 	struct in_addr router;     /* router address to send to */
+	int lsa_pos; /* LSA position for resolving the interface */
 };
 
 struct vertex_parent {
-	struct vertex_nexthop
-		*nexthop;      /* link to nexthop info for this parent */
-	struct vertex *parent; /* parent vertex */
-	int backlink;	  /* index back to parent for router-lsa's */
+	struct vertex_nexthop *nexthop; /* nexthop address for this parent */
+	struct vertex *parent;		/* parent vertex */
+	int backlink; /* index back to parent for router-lsa's */
 };
 
 /* What triggered the SPF ? */
@@ -73,6 +72,14 @@ typedef enum {
 } ospf_spf_reason_t;
 
 extern void ospf_spf_calculate_schedule(struct ospf *, ospf_spf_reason_t);
+extern void ospf_spf_calculate(struct ospf_area *area,
+			       struct ospf_lsa *root_lsa,
+			       struct route_table *new_table,
+			       struct route_table *new_rtrs, bool is_dry_run);
+extern int ospf_spf_calculate_areas(struct ospf *ospf,
+				    struct route_table *new_table,
+				    struct route_table *new_rtrs,
+				    bool is_dry_run);
 extern void ospf_rtrs_free(struct route_table *);
 
 /* void ospf_spf_calculate_timer_add (); */

--- a/ospfd/ospf_spf.h
+++ b/ospfd/ospf_spf.h
@@ -75,11 +75,12 @@ extern void ospf_spf_calculate_schedule(struct ospf *, ospf_spf_reason_t);
 extern void ospf_spf_calculate(struct ospf_area *area,
 			       struct ospf_lsa *root_lsa,
 			       struct route_table *new_table,
-			       struct route_table *new_rtrs, bool is_dry_run);
+			       struct route_table *new_rtrs, bool is_dry_run,
+			       bool is_root_node);
 extern int ospf_spf_calculate_areas(struct ospf *ospf,
 				    struct route_table *new_table,
 				    struct route_table *new_rtrs,
-				    bool is_dry_run);
+				    bool is_dry_run, bool is_root_node);
 extern void ospf_rtrs_free(struct route_table *);
 
 extern void ospf_spf_print(struct vty *vty, struct vertex *v, int i);

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -410,6 +410,8 @@ struct ospf_area {
 
 	/* Shortest Path Tree. */
 	struct vertex *spf;
+	bool spf_dry_run; /* flag for checking if the SPF calculation is
+			     intended for the local RIB */
 
 	/* Threads. */
 	struct thread *t_stub_router;     /* Stub-router timer */

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -410,8 +410,10 @@ struct ospf_area {
 
 	/* Shortest Path Tree. */
 	struct vertex *spf;
-	bool spf_dry_run; /* flag for checking if the SPF calculation is
-			     intended for the local RIB */
+	bool spf_dry_run;   /* flag for checking if the SPF calculation is
+			       intended for the local RIB */
+	bool spf_root_node; /* flag for checking if the calculating node is the
+			       root node of the SPF tree */
 
 	/* Threads. */
 	struct thread *t_stub_router;     /* Stub-router timer */


### PR DESCRIPTION
This PR is is split into 3 parts/commits:

1. A rather cosmetic cleanup of SPF code, no functional changes (might be a bit tricky to review)
2. Introduction of a 'dry run' mode to the SPF code, more about this below
3. Some print helper utility to print route tables and SPF trees

Background: I'm working on TI-LFA (which, in a nutshell, is about generating backup paths in case of failure scenarios) for OSPF and a major part of the involved work concerns so called P and Q spaces which are used to generate backup paths. To generate these spaces one needs to execute the SPF algorithm for arbitrary roots, e.g. not just the local (calculating) router itself. For this purpose this PR introduces a 'dry run' mode which can be used to execute SPF for arbitrary nodes without touching unwanted or unneeded things like local interface data. Later on this mode is supposed to be extended to OSPF's post-processing of the SPF (e.g. inter-area dependencies).

I also have a little test framework for SPF here in place which is supposed to be part of the unit tests later on (first unit tests for OSPF, yay).