### PR TITLE
bgpd: [7.3] Dump attributes before returning from bgp_attr_malformed()

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -965,7 +965,7 @@ bgp_attr_malformed(struct bgp_attr_parser_args *args, uint8_t subcode,
 	if (bgp_debug_update(peer, NULL, NULL, 1)) {
 		char attr_str[BUFSIZ] = {0};
 
-		bgp_dump_attr(attr, attr_str, BUFSIZ);
+		bgp_dump_attr(attr, attr_str, sizeof(attr_str));
 
 		zlog_debug("%s: attributes: %s", __func__, attr_str);
 	}

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -954,12 +954,21 @@ bgp_attr_malformed(struct bgp_attr_parser_args *args, uint8_t subcode,
 		   bgp_size_t length)
 {
 	struct peer *const peer = args->peer;
+	struct attr *const attr = args->attr;
 	const uint8_t flags = args->flags;
 	/* startp and length must be special-cased, as whether or not to
 	 * send the attribute data with the NOTIFY depends on the error,
 	 * the caller therefore signals this with the seperate length argument
 	 */
 	uint8_t *notify_datap = (length > 0 ? args->startp : NULL);
+
+	if (bgp_debug_update(peer, NULL, NULL, 1)) {
+		char attr_str[BUFSIZ] = {0};
+
+		bgp_dump_attr(attr, attr_str, BUFSIZ);
+
+		zlog_debug("%s: attributes: %s", __func__, attr_str);
+	}
 
 	/* Only relax error handling for eBGP peers */
 	if (peer->sort != BGP_PEER_EBGP) {

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3163,7 +3163,7 @@ static int bgp_evpn_route_rmac_self_check(struct bgp *bgp_vrf,
 			char buf1[PREFIX_STRLEN];
 			char attr_str[BUFSIZ] = {0};
 
-			bgp_dump_attr(pi->attr, attr_str, BUFSIZ);
+			bgp_dump_attr(pi->attr, attr_str, sizeof(attr_str));
 
 			zlog_debug("%s: bgp %u prefix %s with attr %s - DENIED due to self mac",
 				__func__, bgp_vrf->vrf_id,
@@ -5569,7 +5569,7 @@ int bgp_filter_evpn_routes_upon_martian_nh_change(struct bgp *bgp)
 					char pbuf[PREFIX_STRLEN];
 
 					bgp_dump_attr(pi->attr, attr_str,
-						      BUFSIZ);
+						      sizeof(attr_str));
 
 					if (bgp_debug_update(pi->peer, &rn->p,
 							     NULL, 1))

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1526,7 +1526,8 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 	if (attr_parse_ret == BGP_ATTR_PARSE_WITHDRAW
 	    || BGP_DEBUG(update, UPDATE_IN)
 	    || BGP_DEBUG(update, UPDATE_PREFIX)) {
-		ret = bgp_dump_attr(&attr, peer->rcvd_attr_str, BUFSIZ);
+		ret = bgp_dump_attr(&attr, peer->rcvd_attr_str,
+				    sizeof(peer->rcvd_attr_str));
 
 		peer->stat_upd_7606++;
 

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -818,7 +818,7 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 				memset(send_attr_str, 0, BUFSIZ);
 				send_attr_printed = 0;
 				bgp_dump_attr(adv->baa->attr, send_attr_str,
-					      BUFSIZ);
+					      sizeof(send_attr_str));
 			}
 		}
 
@@ -1128,7 +1128,7 @@ void subgroup_default_update_packet(struct update_subgroup *subgrp,
 
 		attrstr[0] = '\0';
 
-		bgp_dump_attr(attr, attrstr, BUFSIZ);
+		bgp_dump_attr(attr, attrstr, sizeof(attrstr));
 
 		if (addpath_encode)
 			snprintf(tx_id_buf, sizeof(tx_id_buf),


### PR DESCRIPTION
This would be handy for situations when a notification was sent, but it's
absolutely not clear who triggered that.

Just in case dumping all attributes under the debug mode would help finding
the _bad_ attribute.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>