### PR TITLE
lib: prioritize VRF creation

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -1214,7 +1214,8 @@ const struct frr_yang_module_info frr_vrf_info = {
 				.get_next = lib_vrf_get_next,
 				.get_keys = lib_vrf_get_keys,
 				.lookup_entry = lib_vrf_lookup_entry,
-			}
+			},
+			.priority = NB_DFLT_PRIORITY - 1,
 		},
 		{
 			.xpath = "/frr-vrf:lib/vrf/state/id",


### PR DESCRIPTION
Bump the priority of VRF creation; this way VRF related config is
applied before other things, specifically interfaces, which need VRFs to
exist.

Signed-off-by: Quentin Young <qlyoung@nvidia.com>