### PR TITLE
bgpd: Actually respect RFC 6286 for router_id

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1214,7 +1214,6 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 	 * "Bad BGP Identifier".
 	 */
 	if (remote_id.s_addr == INADDR_ANY
-	    || IPV4_CLASS_DE(ntohl(remote_id.s_addr))
 	    || (peer->sort == BGP_PEER_IBGP
 		&& ntohl(peer->local_id.s_addr) == ntohl(remote_id.s_addr))) {
 		if (bgp_debug_neighbor_events(peer))


### PR DESCRIPTION
The RFC states:
      The BGP Identifier is a 4-octet, unsigned, non-zero integer that
      should be unique within an AS.  The value of the BGP Identifier
      for a BGP speaker is determined on startup and is the same for
      every local interface and every BGP peer.

We were going slightly beyond this and ensuring that the address
was a specific range of addresses which is no longer relevant.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>