### PR TITLE
lib: [DON'T MERGE] test zapi_nexthop size

### DIFF
--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -417,7 +417,7 @@ struct zapi_nexthop {
 	uint32_t srte_color;
 
 	/* Debug Area */
-	uint8_t _space[16 * 4];
+	uint8_t _space[16 * 2];
 };
 
 /*

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -417,7 +417,7 @@ struct zapi_nexthop {
 	uint32_t srte_color;
 
 	/* Debug Area */
-	uint8_t _space[16 * 16];
+	uint8_t _space[16 * 8];
 };
 
 /*

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -417,7 +417,7 @@ struct zapi_nexthop {
 	uint32_t srte_color;
 
 	/* Debug Area */
-	uint8_t _space[64 * 16];
+	uint8_t _space[16 * 16];
 };
 
 /*

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -417,7 +417,7 @@ struct zapi_nexthop {
 	uint32_t srte_color;
 
 	/* Debug Area */
-	uint8_t _space[16 * 8];
+	uint8_t _space[16 * 4];
 };
 
 /*

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -415,6 +415,9 @@ struct zapi_nexthop {
 
 	/* SR-TE color. */
 	uint32_t srte_color;
+
+	/* Debug Area */
+	uint8_t _space[64 * 16];
 };
 
 /*


### PR DESCRIPTION
## What is it?

- This is for my experience to check the CI machines' memory limitation
- When I submit [PR to make zapi_nexthop bigger](https://github.com/FRRouting/frr/pull/5865), topotests/route-scale step is always failed with qmalloc-miss.

## Test Detail

```diff
diff --git a/lib/zclient.h b/lib/zclient.h
index dab384d..66d1cbc 100644
--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -415,6 +415,9 @@ struct zapi_nexthop {

        /* SR-TE color. */
        uint32_t srte_color;
+
+       /* Debug Area */
+       uint8_t _space[N]; // N is (64*64),(16*64),etc..
 };
```

## Test Results

- `N=64*64`: https://ci1.netdef.org/browse/FRR-FRRPULLREQ-13660
  - `Topo Tests Part 0 on Ubuntu 16.04 i386 ` -> failed (1 million routes X 1 ecmp) qmalloc
  - `Topo Tests Part 0 on Ubuntu 16.04 amd64` -> failed (1 million routes X 2 ecmp) no-detail
  - `Topo Tests Part 0 on Ubuntu 18.04 amd64` -> failed (1 million routes X 4 ecmp) no-detail
- `N=16*16`: https://ci1.netdef.org/browse/FRR-FRRPULLREQ-13661
  - `Topo Tests Part 0 on Ubuntu 16.04 i386 ` -> fialed (1 million routes X 1 ecmp) qmalloc
- `N=16*8`: https://ci1.netdef.org/browse/FRR-FRRPULLREQ-13663
  - `Topo Tests Part 0 on Ubuntu 16.04 i386 ` -> failed (1 million routes X 2 ecmp) qmalloc
- `N=16*4`: https://ci1.netdef.org/browse/FRR-FRRPULLREQ-13664 -> pass
- `N=16*2`: https://ci1.netdef.org/browse/FRR-FRRPULLREQ-13665 -> pass

## References

- https://frrouting.slack.com/archives/C4SEHQQ3S/p1597403742358200
- https://frrouting.slack.com/archives/C4SEHQQ3S/p1597629504390200
- https://github.com/opensourcerouting/frr-lxc-templates