### PR TITLE
bgpd: Prevent crash when displaying json of a vrf all command

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -12746,11 +12746,13 @@ static void bgp_show_all_instances_neighbors_vty(struct vty *vty,
 					  use_json, json);
 		}
 		json_object_free(json);
+		json = NULL;
 	}
 
 	if (use_json) {
 		vty_out(vty, "}\n");
-		json_object_free(json);
+		if (json)
+			json_object_free(json);
 	}
 	else if (!nbr_output)
 		vty_out(vty, "%% BGP instance not found\n");


### PR DESCRIPTION
When iterating over a `show ip bgp vrf all neighbors json` command
bgp is crashing.

The json variable was being double freed.  When freeing it, set it
to NULL and then check to make sure it exists before we free.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>