### PR TITLE
More gRPC logging + errmsg for no changes

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -680,8 +680,12 @@ int nb_candidate_commit_prepare(struct nb_context *context,
 
 	RB_INIT(nb_config_cbs, &changes);
 	nb_config_diff(running_config, candidate, &changes);
-	if (RB_EMPTY(nb_config_cbs, &changes))
+	if (RB_EMPTY(nb_config_cbs, &changes)) {
+		snprintf(
+			errmsg, errmsg_len,
+			"No changes to apply were found during preparation phase");
 		return NB_ERR_NO_CHANGES;
+	}
 
 	if (nb_candidate_validate_code(context, candidate, &changes, errmsg,
 				       errmsg_len)

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -714,46 +714,38 @@ class NorthboundImpl
 			grpc::Status status;
 			switch (ret) {
 			case NB_OK:
-				zlog_debug("`-> Result: OK");
 				status = grpc::Status::OK;
 				break;
 			case NB_ERR_NO_CHANGES:
-				zlog_debug("`-> Result: ERR_NO_CHANGES (message: '%s')",
-					   errmsg);
 				status = grpc::Status(grpc::StatusCode::ABORTED,
 						      errmsg);
 				break;
 			case NB_ERR_LOCKED:
-				zlog_debug("`-> Result: ERR_LOCKED (message: '%s')",
-					   errmsg);
 				status = grpc::Status(
 					grpc::StatusCode::UNAVAILABLE, errmsg);
 				break;
 			case NB_ERR_VALIDATION:
-				zlog_debug(
-					"`-> Result: ERR_VALIDATION (message: '%s')",
-					errmsg);
 				status = grpc::Status(
 					grpc::StatusCode::INVALID_ARGUMENT,
 					errmsg);
 				break;
 			case NB_ERR_RESOURCE:
-				zlog_debug(
-					"`-> Result: ERR_RESOURCE (message: '%s')",
-					errmsg);
 				status = grpc::Status(
 					grpc::StatusCode::RESOURCE_EXHAUSTED,
 					errmsg);
 				break;
 			case NB_ERR:
 			default:
-				zlog_debug(
-					"`-> Result: Generic error (message: '%s')",
-					errmsg);
 				status = grpc::Status(
 					grpc::StatusCode::INTERNAL, errmsg);
 				break;
 			}
+
+			if (nb_dbg_client_grpc)
+				zlog_debug("`-> Result: %s (message: '%s')",
+					   nb_err_name((enum nb_error)ret),
+					   errmsg);
+
 			if (ret == NB_OK) {
 				// Response: uint32 transaction_id = 1;
 				if (transaction_id)

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -677,11 +677,13 @@ class NorthboundImpl
 
 			switch (phase) {
 			case frr::CommitRequest::VALIDATE:
+				zlog_debug("`-> Performing VALIDATE");
 				ret = nb_candidate_validate(
 					&context, candidate->config, errmsg,
 					sizeof(errmsg));
 				break;
 			case frr::CommitRequest::PREPARE:
+				zlog_debug("`-> Performing PREPARE");
 				ret = nb_candidate_commit_prepare(
 					&context, candidate->config,
 					comment.c_str(),
@@ -689,15 +691,18 @@ class NorthboundImpl
 					sizeof(errmsg));
 				break;
 			case frr::CommitRequest::ABORT:
+				zlog_debug("`-> Performing ABORT");
 				nb_candidate_commit_abort(
 					candidate->transaction);
 				break;
 			case frr::CommitRequest::APPLY:
+				zlog_debug("`-> Performing ABORT");
 				nb_candidate_commit_apply(
 					candidate->transaction, true,
 					&transaction_id);
 				break;
 			case frr::CommitRequest::ALL:
+				zlog_debug("`-> Performing ALL");
 				ret = nb_candidate_commit(
 					&context, candidate->config, true,
 					comment.c_str(), &transaction_id,
@@ -709,28 +714,42 @@ class NorthboundImpl
 			grpc::Status status;
 			switch (ret) {
 			case NB_OK:
+				zlog_debug("`-> Result: OK");
 				status = grpc::Status::OK;
 				break;
 			case NB_ERR_NO_CHANGES:
+				zlog_debug("`-> Result: ERR_NO_CHANGES (message: '%s')",
+					   errmsg);
 				status = grpc::Status(grpc::StatusCode::ABORTED,
 						      errmsg);
 				break;
 			case NB_ERR_LOCKED:
+				zlog_debug("`-> Result: ERR_LOCKED (message: '%s')",
+					   errmsg);
 				status = grpc::Status(
 					grpc::StatusCode::UNAVAILABLE, errmsg);
 				break;
 			case NB_ERR_VALIDATION:
+				zlog_debug(
+					"`-> Result: ERR_VALIDATION (message: '%s')",
+					errmsg);
 				status = grpc::Status(
 					grpc::StatusCode::INVALID_ARGUMENT,
 					errmsg);
 				break;
 			case NB_ERR_RESOURCE:
+				zlog_debug(
+					"`-> Result: ERR_RESOURCE (message: '%s')",
+					errmsg);
 				status = grpc::Status(
 					grpc::StatusCode::RESOURCE_EXHAUSTED,
 					errmsg);
 				break;
 			case NB_ERR:
 			default:
+				zlog_debug(
+					"`-> Result: Generic error (message: '%s')",
+					errmsg);
 				status = grpc::Status(
 					grpc::StatusCode::INTERNAL, errmsg);
 				break;


### PR DESCRIPTION
* Add more granular logging for the Commit RPC
* Populate errmsg buffer when there are no changes to apply in a transaction