### PR TITLE
ospfd: make proactive ARP configurable

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -310,6 +310,17 @@ To start OSPF process you have to specify the OSPF router.
    In some cases it may be more convenient to enable OSPF on a per
    interface/subnet basis (:clicmd:`ip ospf area AREA [ADDR]`).
 
+.. index:: proactive-arp
+.. clicmd:: proactive-arp
+
+.. index:: no proactive-arp
+.. clicmd:: no proactive-arp
+
+   This command enables or disables sending ARP requests to update neighbor
+   table entries. It speeds up convergence for /32 networks on a P2P
+   connection. 
+
+   This feature is enabled by default.
 
 .. _ospf-area:
 

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -4322,7 +4322,7 @@ void ospf_ls_ack_send_delayed(struct ospf_interface *oi)
  */
 void ospf_proactively_arp(struct ospf_neighbor *nbr)
 {
-	if (!nbr)
+	if (!nbr || !nbr->oi->ospf->proactive_arp)
 		return;
 
 	ospf_zebra_send_arp(nbr->oi->ifp, &nbr->address);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8925,6 +8925,31 @@ DEFUN (no_ospf_max_metric_router_lsa_shutdown,
 	return CMD_SUCCESS;
 }
 
+DEFUN (ospf_proactive_arp,
+       ospf_proactive_arp_cmd,
+       "proactive-arp",
+       "Allow sending ARP requests proactively\n")
+{
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
+
+	ospf->proactive_arp = true;
+
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_ospf_proactive_arp,
+       no_ospf_proactive_arp_cmd,
+       "no proactive-arp",
+	   NO_STR
+       "Disallow sending ARP requests proactively\n")
+{
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
+
+	ospf->proactive_arp = false;
+
+	return CMD_SUCCESS;
+}
+
 static void config_write_stub_router(struct vty *vty, struct ospf *ospf)
 {
 	struct listnode *ln;
@@ -10415,6 +10440,14 @@ static int ospf_config_write_one(struct vty *vty, struct ospf *ospf)
 	if (ospf->passive_interface_default == OSPF_IF_PASSIVE)
 		vty_out(vty, " passive-interface default\n");
 
+	/* proactive-arp print. */
+	if (ospf->proactive_arp != OSPF_PROACTIVE_ARP_DEFAULT) {
+		if (ospf->proactive_arp)
+			vty_out(vty, " proactive-arp\n");
+		else
+			vty_out(vty, " no proactive-arp\n");
+	}
+
 	FOR_ALL_INTERFACES (vrf, ifp)
 		if (OSPF_IF_PARAM_CONFIGURED(IF_DEF_PARAMS(ifp),
 					     passive_interface)
@@ -10870,6 +10903,10 @@ void ospf_vty_init(void)
 	install_element(OSPF_NODE, &write_multiplier_cmd);
 	install_element(OSPF_NODE, &no_ospf_write_multiplier_cmd);
 	install_element(OSPF_NODE, &no_write_multiplier_cmd);
+
+	/* "proactive-arp" commands. */
+	install_element(OSPF_NODE, &ospf_proactive_arp_cmd);
+	install_element(OSPF_NODE, &no_ospf_proactive_arp_cmd);
 
 	/* Init interface related vty commands. */
 	ospf_vty_if_init();

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -305,6 +305,8 @@ static struct ospf *ospf_new(unsigned short instance, const char *name)
 	new->oi_write_q = list_new();
 	new->write_oi_count = OSPF_WRITE_INTERFACE_COUNT_DEFAULT;
 
+	new->proactive_arp = OSPF_PROACTIVE_ARP_DEFAULT;
+
 	QOBJ_REG(new, ospf);
 
 	new->fd = -1;

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -312,6 +312,10 @@ struct ospf {
 	 * update to neighbors immediatly */
 	uint8_t inst_shutdown;
 
+	/* Enable or disable sending proactive ARP requests. */
+	bool proactive_arp;
+#define OSPF_PROACTIVE_ARP_DEFAULT true
+
 	/* Redistributed external information. */
 	struct list *external[ZEBRA_ROUTE_MAX + 1];
 #define EXTERNAL_INFO(E)      (E->external_info)

--- a/yang/frr-ospfd.yang
+++ b/yang/frr-ospfd.yang
@@ -346,6 +346,13 @@ module frr-ospfd {
         "The reference bandwidth in terms of Mbits per second.";
     }
 
+    leaf use-arp {
+      type boolean;
+      default "true";
+      description 
+        "ARP for neighbor table entry.";
+    }
+
     leaf capability-opaque {
       type boolean;
       default "false";


### PR DESCRIPTION
OSPFD sends ARP proactively to speed up convergence for /32 networks
on a p2p connection. It is only an optimization, so it can be disabled.

It is enabled by default.

Signed-off-by: Jakub Urbańczyk <xthaid@gmail.com>

It can be configured with:
```
router ospfd
 [no] proactive-arp
```

Fixes #6911