### PR TITLE
bgpd: Use sizeof() in bgp_dump_attr()

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1161,7 +1161,7 @@ bgp_attr_malformed(struct bgp_attr_parser_args *args, uint8_t subcode,
 	if (bgp_debug_update(peer, NULL, NULL, 1)) {
 		char attr_str[BUFSIZ] = {0};
 
-		bgp_dump_attr(attr, attr_str, BUFSIZ);
+		bgp_dump_attr(attr, attr_str, sizeof(attr_str));
 
 		zlog_debug("%s: attributes: %s", __func__, attr_str);
 	}


### PR DESCRIPTION
Missed this in 5022c8331d0119886a08dcef7b1eee4525b4d63a

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>