### PR TITLE
zebra: Add table id to debug output

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -200,8 +200,8 @@ void redistribute_update(const struct prefix *p, const struct prefix *src_p,
 
 	if (IS_ZEBRA_DEBUG_RIB) {
 		zlog_debug(
-			"%u:%s: Redist update re %p (%s), old %p (%s)",
-			re->vrf_id, prefix2str(p, buf, sizeof(buf)),
+			"(%u:%u):%s: Redist update re %p (%s), old %p (%s)",
+			re->vrf_id, re->table, prefix2str(p, buf, sizeof(buf)),
 			re, zebra_route_string(re->type), prev_re,
 			prev_re ? zebra_route_string(prev_re->type) : "None");
 	}
@@ -224,12 +224,12 @@ void redistribute_update(const struct prefix *p, const struct prefix *src_p,
 		if (zebra_redistribute_check(re, client, p, afi)) {
 			if (IS_ZEBRA_DEBUG_RIB) {
 				zlog_debug(
-					   "%s: client %s %s(%u), type=%d, distance=%d, metric=%d",
-					   __func__,
-					   zebra_route_string(client->proto),
-					   prefix2str(p, buf, sizeof(buf)),
-					   re->vrf_id, re->type,
-					   re->distance, re->metric);
+					"%s: client %s %s(%u:%u), type=%d, distance=%d, metric=%d",
+					__func__,
+					zebra_route_string(client->proto),
+					prefix2str(p, buf, sizeof(buf)),
+					re->vrf_id, re->table, re->type,
+					re->distance, re->metric);
 			}
 			zsend_redistribute_route(ZEBRA_REDISTRIBUTE_ROUTE_ADD,
 						 client, p, src_p, re);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1588,16 +1588,17 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 		return;
 	}
 
+	vrf_id = zvrf_id(zvrf);
+
 	if (IS_ZEBRA_DEBUG_RECV) {
 		char buf_prefix[PREFIX_STRLEN];
 
 		prefix2str(&api.prefix, buf_prefix, sizeof(buf_prefix));
-		zlog_debug("%s: p=%s, msg flags=0x%x, flags=0x%x",
-			   __func__, buf_prefix, (int)api.message, api.flags);
+		zlog_debug("%s: p=(%u:%u)%s, msg flags=0x%x, flags=0x%x",
+			   __func__, vrf_id, api.tableid, buf_prefix, (int)api.message, api.flags);
 	}
 
 	/* Allocate new route. */
-	vrf_id = zvrf_id(zvrf);
 	re = XCALLOC(MTYPE_RE, sizeof(struct route_entry));
 	re->type = api.type;
 	re->instance = api.instance;
@@ -1877,6 +1878,15 @@ static void zread_route_del(ZAPI_HANDLER_ARGS)
 		table_id = api.tableid;
 	else
 		table_id = zvrf->table_id;
+
+	if (IS_ZEBRA_DEBUG_RECV) {
+		char buf_prefix[PREFIX_STRLEN];
+
+		prefix2str(&api.prefix, buf_prefix, sizeof(buf_prefix));
+		zlog_debug("%s: p=(%u:%u)%s, msg flags=0x%x, flags=0x%x",
+			   __func__, zvrf_id(zvrf), table_id, buf_prefix,
+			   (int)api.message, api.flags);
+	}
 
 	rib_delete(afi, api.safi, zvrf_id(zvrf), api.type, api.instance,
 		   api.flags, &api.prefix, src_p, NULL, 0, table_id, api.metric,


### PR DESCRIPTION
There are a bunch of places where the table id is not being outputed
in debug messages for routing changes.  Add in the table id we
are operating on.  This is especially useful for the case where
pbr is working.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>