### PR TITLE
[7.4] python: Make FRR build compatible with python 2.7 and 3.x

### DIFF
--- a/python/makevars.py
+++ b/python/makevars.py
@@ -70,7 +70,7 @@ class MakeReVars(MakeVarsBase):
     repl_re = re.compile(r'\$(?:([A-Za-z])|\(([^\)]+)\))')
 
     def __init__(self, maketext):
-        super().__init__()
+        super(MakeReVars, self).__init__()
         self._vars = dict(self.var_re.findall(maketext.replace('\\\n', '')))
 
     def replacevar(self, match):


### PR DESCRIPTION
Use python super() in a python 2.7 compatible way. Fixes building of FRR with python 2.7 (required for old CentOS 6).