### PR TITLE
staticd: fix warning when creating routes without SR-TE colors

### DIFF
--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -257,8 +257,9 @@ static int static_route_leak(struct vty *vty, const char *svrf,
 			strlcpy(ab_xpath, xpath_nexthop, sizeof(ab_xpath));
 			strlcat(ab_xpath, FRR_STATIC_ROUTE_NH_COLOR_XPATH,
 				sizeof(ab_xpath));
-			nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY,
-					      color_str);
+			if (color_str)
+				nb_cli_enqueue_change(vty, ab_xpath,
+						      NB_OP_MODIFY, color_str);
 		}
 		if (label_str) {
 			/* copy of label string (start) */


### PR DESCRIPTION
The SR-TE color YANG leaf is optional so it shouldn't be created
unconditionally (it doesn't have a default value).

Fixes warnings like this when routes are created without specifying
a SR-TE color:
```
STATIC: libyang: Invalid value "" in "srte-color" element.
(/frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-s
taticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[p
refix='99.0.0.1/32'][afi-safi='frr-routing:ipv4-unicast']/path-list[distance='1'
]/frr-nexthops/nexthop[nh-type='ip4'][vrf='default'][gateway='192.168.1.2'][inte
rface='(null)']/srte-color)
```

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>