### PR TITLE
sharpd,lib,zebra: Improve sharpd route scale

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -262,9 +262,19 @@ static int zclient_failed(struct zclient *zclient)
  */
 static int zclient_flush_data_cb(struct thread *thread)
 {
+	int ret;
 	struct zclient *zclient = THREAD_ARG(thread);
 
-	zclient_flush_data(zclient);
+	ret = zclient_flush_data(zclient);
+
+	if (ret == BUFFER_EMPTY && zclient->zclient_writeable_cb) {
+		/*
+		 * Client has registered a callback,
+		 * and there's no more buffered data pending.
+		 */
+		zclient->zclient_writeable_cb(zclient,
+					      zclient->zclient_writeable_ctxt);
+	}
 
 	return 0;
 }

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -763,45 +763,10 @@ int zclient_send_rnh(struct zclient *zclient, int command,
  * The corresponding read ("xdr_decode") function on the server
  * side is zapi_route_decode().
  *
- *  0 1 2 3 4 5 6 7 8 9 A B C D E F 0 1 2 3 4 5 6 7 8 9 A B C D E F
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * |            Length (2)         |    Command    | Route Type    |
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * | ZEBRA Flags   | Message Flags | Prefix length |
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * | Destination IPv4 Prefix for route                             |
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * | Nexthop count |
- * +-+-+-+-+-+-+-+-+
- *
- *
- * A number of IPv4 nexthop(s) or nexthop interface index(es) are then
- * described, as per the Nexthop count. Each nexthop described as:
- *
- * +-+-+-+-+-+-+-+-+
- * | Nexthop Type  |  Set to one of ZEBRA_NEXTHOP_*
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * |       IPv4 Nexthop address or Interface Index number          |
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- *
- * Alternatively, if the route is a blackhole route, then Nexthop count
- * is set to 1 and a nexthop of type NEXTHOP_TYPE_BLACKHOLE is the sole
- * nexthop.
- *
- * The original struct zapi_route_*() infrastructure was built around
- * the traditional (32-bit "gate OR ifindex") nexthop data unit.
- * A special encoding can be used to feed onlink (64-bit "gate AND ifindex")
- * nexthops into zapi_route_encode() using the same zapi_route structure.
- * This is done by setting zapi_route fields as follows:
- *  - .message |= ZAPI_MESSAGE_NEXTHOP | ZAPI_MESSAGE_ONLINK
- *  - .nexthop_num == .ifindex_num
- *  - .nexthop and .ifindex are filled with gate and ifindex parts of
- *    each compound nexthop, both in the same order
- *
  * If ZAPI_MESSAGE_DISTANCE is set, the distance value is written as a 1
  * byte value.
  *
- * If ZAPI_MESSAGE_METRIC is set, the metric value is written as an 8
+ * If ZAPI_MESSAGE_METRIC is set, the metric value is written as a 4
  * byte value.
  *
  * If ZAPI_MESSAGE_TAG is set, the tag value is written as a 4 byte value

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -782,7 +782,13 @@ extern void zclient_redistribute_default(int command, struct zclient *,
 
 /* Send the message in zclient->obuf to the zebra daemon (or enqueue it).
    Returns 0 for success or -1 on an I/O error. */
-extern int zclient_send_message(struct zclient *);
+extern int zclient_send_message(struct zclient *zclient);
+
+/* Send the message in zclient->obuf to the zebra daemon (or enqueue it).
+ * Returns 0 for success, BUFFER_PENDING if the write socket is blocked,
+ * and < 0 on an I/O error.
+ */
+int zclient_send_message_result(struct zclient *zclient);
 
 /* Attempt to send any queued, pending zapi messages. */
 int zclient_flush_data(struct zclient *zclient);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -784,6 +784,9 @@ extern void zclient_redistribute_default(int command, struct zclient *,
    Returns 0 for success or -1 on an I/O error. */
 extern int zclient_send_message(struct zclient *);
 
+/* Attempt to send any queued, pending zapi messages. */
+int zclient_flush_data(struct zclient *zclient);
+
 /* create header for command, length to be filled in by user later */
 extern void zclient_create_header(struct stream *, uint16_t, vrf_id_t);
 /*

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -304,13 +304,24 @@ struct zclient {
 	/* Thread to write buffered data to zebra. */
 	struct thread *t_write;
 
+	/* The socket to zebra becomes full if the client is
+	 * sending messages faster than zebra can read and process them.
+	 * A client can get the PENDING result and supply a callback
+	 * indicating that the socket has become writable again.
+	 * The callback is called after any buffered data is written,
+	 * so the client callback should be able to actually write something
+	 * before the socket fills again.
+	 */
+	int (*zclient_writeable_cb)(struct zclient *zclient, void *ctxt);
+	void *zclient_writeable_ctxt;
+
 	/* Redistribute information. */
-	uint8_t redist_default; /* clients protocol */
+	uint8_t redist_default; /* Client's protocol */
 	unsigned short instance;
 	struct redist_proto mi_redist[AFI_MAX][ZEBRA_ROUTE_MAX];
 	vrf_bitmap_t redist[AFI_MAX][ZEBRA_ROUTE_MAX];
 
-	/* Redistribute defauilt. */
+	/* Redistribute default. */
 	vrf_bitmap_t default_information[AFI_MAX];
 
 #define ZAPI_CALLBACK_ARGS                                                     \

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -299,6 +299,11 @@ DEFPY (install_routes,
 	sg.r.inst = instance;
 	sg.r.vrf_id = vrf->vrf_id;
 	rts = routes;
+
+	/* Capture start time */
+	monotime(&sg.r.t_start);
+
+	zlog_debug("Inserting %u routes", rts);
 	sharp_install_routes_helper(&prefix, sg.r.vrf_id, sg.r.inst, nhgid,
 				    &sg.r.nhop_group, &sg.r.backup_nhop_group,
 				    rts);
@@ -379,6 +384,11 @@ DEFPY (remove_routes,
 	sg.r.inst = instance;
 	sg.r.vrf_id = vrf->vrf_id;
 	rts = routes;
+
+	/* Capture start time */
+	monotime(&sg.r.t_start);
+
+	zlog_debug("Removing %u routes", rts);
 	sharp_remove_routes_helper(&prefix, sg.r.vrf_id,
 				   sg.r.inst, rts);
 

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -240,6 +240,11 @@ void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 	monotime(&sg.r.t_start);
 	for (i = 0; i < routes; i++) {
 		route_add(p, vrf_id, (uint8_t)instance, nhgid, nhg, backup_nhg);
+
+		/* Periodically try sending some of the buffered messages */
+		if (i > 0 && (i % 100 == 0))
+			zclient_flush_data(zclient);
+
 		if (v4)
 			p->u.prefix4.s_addr = htonl(++temp);
 		else
@@ -264,6 +269,11 @@ void sharp_remove_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 	monotime(&sg.r.t_start);
 	for (i = 0; i < routes; i++) {
 		route_delete(p, vrf_id, (uint8_t)instance);
+
+		/* Periodically try sending some of the buffered messages */
+		if (i > 0 && (i % 1000 == 0))
+			zclient_flush_data(zclient);
+
 		if (v4)
 			p->u.prefix4.s_addr = htonl(++temp);
 		else
@@ -411,12 +421,11 @@ void route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
 	       uint32_t nhgid, const struct nexthop_group *nhg,
 	       const struct nexthop_group *backup_nhg)
 {
-	struct zapi_route api;
+	struct zapi_route api = {};
 	struct zapi_nexthop *api_nh;
 	struct nexthop *nh;
 	int i = 0;
 
-	memset(&api, 0, sizeof(api));
 	api.vrf_id = vrf_id;
 	api.type = ZEBRA_ROUTE_SHARP;
 	api.instance = instance;
@@ -462,9 +471,8 @@ void route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
 
 void route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance)
 {
-	struct zapi_route api;
+	struct zapi_route api = {};
 
-	memset(&api, 0, sizeof(api));
 	api.vrf_id = vrf_id;
 	api.type = ZEBRA_ROUTE_SHARP;
 	api.safi = SAFI_UNICAST;

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -32,9 +32,9 @@ extern void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label);
 extern void nhg_add(uint32_t id, const struct nexthop_group *nhg,
 		    const struct nexthop_group *backup_nhg);
 extern void nhg_del(uint32_t id);
-extern void route_add(const struct prefix *p, vrf_id_t, uint8_t instance,
-		      uint32_t nhgid, const struct nexthop_group *nhg,
-		      const struct nexthop_group *backup_nhg);
+extern int route_add(const struct prefix *p, vrf_id_t, uint8_t instance,
+		     uint32_t nhgid, const struct nexthop_group *nhg,
+		     const struct nexthop_group *backup_nhg);
 extern void route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance);
 extern void sharp_zebra_nexthop_watch(struct prefix *p, vrf_id_t vrf_id,
 				      bool import, bool watch, bool connected);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -776,7 +776,11 @@ static int route_notify_internal(const struct prefix *p, int type,
 			   vrf_id);
 	}
 
-	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	/* We're just allocating a small-ish buffer here, since we only
+	 * encode a small amount of data.
+	 */
+	s = stream_new(200);
+
 	stream_reset(s);
 
 	zclient_create_header(s, ZEBRA_ROUTE_NOTIFY_OWNER, vrf_id);


### PR DESCRIPTION
Improve the behavior and memory footprint of sharpd when working with large numbers of route updates. The way the zapi client code interacts with the internal 'stream' and 'buffer' apis meant that sharpd would basically accumulate all of the updates it was trying to send before actually attempting to send them. This could be hundreds of MBs in higher-scale tests. I've added a zclient api path that allows a client to see that messages have become buffered, and an api that calls a client callback once the zapi socket becomes writeable again. Sharpd uses this when it's producing route adds and deletes. I've also reduced the size of the stream/buffer zebra uses when sending route-owner status notifications; those are small messages, but they were using max-packet-sized buffers.

Note that the stream of commits here includes a version of the zclient code that allows a client to explicitly try to send some of the buffered messages. If we determine that that's not interesting, then I'll revise the branch - or just squash some things away.

Here's an example of the difference in memory footprint, using 1M x 32 ecmp ipv4 routes.

Before:
```
--- qmem libfrr ---
Type                          : Current#   Size       Total     Max#  MaxBytes
Buffer                        :        3     24          72        3        72
Buffer data                   :        1   4120        4120   100645 414657400
```

After:
```
--- qmem libfrr ---
Type                          : Current#   Size       Total     Max#  MaxBytes
Buffer                        :        3     24          72        3        72
Buffer data                   :        1   4120        4120        2      8240
```