### PR TITLE
lib: zapi nexthop sort fixes

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -871,6 +871,37 @@ static int zapi_nexthop_cmp_no_labels(const struct zapi_nexthop *next1,
 		break;
 	}
 
+	if (next1->srte_color < next2->srte_color)
+		return -1;
+	if (next1->srte_color > next2->srte_color)
+		return 1;
+
+	if (CHECK_FLAG(next1->flags, NEXTHOP_FLAG_HAS_BACKUP) ||
+	    CHECK_FLAG(next2->flags, NEXTHOP_FLAG_HAS_BACKUP)) {
+
+		if (!CHECK_FLAG(next1->flags, NEXTHOP_FLAG_HAS_BACKUP) &&
+		    CHECK_FLAG(next2->flags, NEXTHOP_FLAG_HAS_BACKUP))
+			return -1;
+
+		if (CHECK_FLAG(next1->flags, NEXTHOP_FLAG_HAS_BACKUP) &&
+		    !CHECK_FLAG(next2->flags, NEXTHOP_FLAG_HAS_BACKUP))
+			return 1;
+
+		if (next1->backup_num > 0 || next2->backup_num > 0) {
+
+			if (next1->backup_num < next2->backup_num)
+				return -1;
+
+			if (next1->backup_num > next2->backup_num)
+				return 1;
+
+			ret = memcmp(next1->backup_idx,
+				     next2->backup_idx, next1->backup_num);
+			if (ret != 0)
+				return ret;
+		}
+	}
+
 	return 0;
 }
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -391,6 +391,11 @@ struct zmsghdr {
 } __attribute__((packed));
 #define ZAPI_HEADER_CMD_LOCATION offsetof(struct zmsghdr, command)
 
+/*
+ * ZAPI nexthop. Note that these are sorted when associated with ZAPI routes,
+ * and that sorting must be aligned with the sorting of nexthops in
+ * lib/nexthop.c. Any new fields must be accounted for in zapi_nexthop_cmp().
+ */
 struct zapi_nexthop {
 	enum nexthop_types_t type;
 	vrf_id_t vrf_id;


### PR DESCRIPTION
The sorting for zapi nexthops in zapi routes needs to match the sorting of nexthops done in zebra. Ensure all zapi_nexthop attributes are included in the sort. Added a comment in lib/zclient.h to try to remind folks who modify zapi_nexthop about this issue.
