### PR TITLE
bgpd: Add `neighbor <neigh> shutdown rtt` command

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1105,6 +1105,9 @@ void bgp_fsm_change_status(struct peer *peer, int status)
 	peer->ostatus = peer->status;
 	peer->status = status;
 
+	/* Reset received keepalives counter on every FSM change */
+	peer->rtt_keepalive_rcv = 0;
+
 	/* Fire backward transition hook if that's the case */
 	if (peer->ostatus > peer->status)
 		hook_call(peer_backward_transition, peer);

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1434,6 +1434,25 @@ static int bgp_keepalive_receive(struct peer *peer, bgp_size_t size)
 
 	peer->rtt = sockopt_tcp_rtt(peer->fd);
 
+	/* If the peer's RTT is higher than expected, shutdown
+	 * the peer automatically.
+	 */
+	if (CHECK_FLAG(peer->flags, PEER_FLAG_RTT_SHUTDOWN)
+	    && peer->rtt > peer->rtt_expected) {
+
+		peer->rtt_keepalive_rcv++;
+
+		if (peer->rtt_keepalive_rcv > peer->rtt_keepalive_conf) {
+			zlog_warn(
+				"%s shutdown due to high round-trip-time (%dms > %dms)",
+				peer->host, peer->rtt, peer->rtt_expected);
+			peer_flag_set(peer, PEER_FLAG_SHUTDOWN);
+		}
+	} else {
+		if (peer->rtt_keepalive_rcv)
+			peer->rtt_keepalive_rcv--;
+	}
+
 	return Receive_KEEPALIVE_message;
 }
 

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1432,6 +1432,8 @@ static int bgp_keepalive_receive(struct peer *peer, bgp_size_t size)
 
 	bgp_update_implicit_eors(peer);
 
+	peer->rtt = sockopt_tcp_rtt(peer->fd);
+
 	return Receive_KEEPALIVE_message;
 }
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1604,6 +1604,9 @@ struct peer *peer_create(union sockunion *su, const char *conf_if,
 	/* Default TTL set. */
 	peer->ttl = (peer->sort == BGP_PEER_IBGP) ? MAXTTL : BGP_DEFAULT_TTL;
 
+	/* Default configured keepalives count for shutdown rtt command */
+	peer->rtt_keepalive_conf = 1;
+
 	SET_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE);
 
 	if (afi && safi) {
@@ -3865,6 +3868,7 @@ struct peer_flag_action {
 static const struct peer_flag_action peer_flag_action_list[] = {
 	{PEER_FLAG_PASSIVE, 0, peer_change_reset},
 	{PEER_FLAG_SHUTDOWN, 0, peer_change_reset},
+	{PEER_FLAG_RTT_SHUTDOWN, 0, peer_change_none},
 	{PEER_FLAG_DONT_CAPABILITY, 0, peer_change_none},
 	{PEER_FLAG_OVERRIDE_CAPABILITY, 0, peer_change_none},
 	{PEER_FLAG_STRICT_CAP_MATCH, 0, peer_change_none},
@@ -3967,6 +3971,7 @@ static void peer_flag_modify_action(struct peer *peer, uint32_t flag)
 				peer_nsf_stop(peer);
 
 			UNSET_FLAG(peer->sflags, PEER_STATUS_PREFIX_OVERFLOW);
+
 			if (peer->t_pmax_restart) {
 				BGP_TIMER_OFF(peer->t_pmax_restart);
 				if (bgp_debug_neighbor_events(peer))

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -968,6 +968,9 @@ struct peer {
 	int fd;		     /* File descriptor */
 	int ttl;	     /* TTL of TCP connection to the peer. */
 	int rtt;	     /* Estimated round-trip-time from TCP_INFO */
+	int rtt_expected; /* Expected round-trip-time for a peer */
+	uint8_t rtt_keepalive_rcv; /* Received count for RTT shutdown */
+	uint8_t rtt_keepalive_conf; /* Configured count for RTT shutdown */
 	int gtsm_hops;       /* minimum hopcount to peer */
 	char *desc;	  /* Description of the peer. */
 	unsigned short port; /* Destination port for peer */
@@ -1118,6 +1121,7 @@ struct peer {
 #define PEER_FLAG_GRACEFUL_RESTART_HELPER   (1U << 23) /* Helper */
 #define PEER_FLAG_GRACEFUL_RESTART          (1U << 24) /* Graceful Restart */
 #define PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT (1U << 25) /* Global-Inherit */
+#define PEER_FLAG_RTT_SHUTDOWN (1U << 26) /* shutdown rtt */
 
 	/*
 	 *GR-Disabled mode means unset PEER_FLAG_GRACEFUL_RESTART

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1216,14 +1216,14 @@ Defining Peers
    The time in milliseconds that BGP will delay before deciding what peers
    can be put into an update-group together in order to generate a single
    update for them.  The default time is 1000.
-   
+
 .. _bgp-configuring-peers:
 
 Configuring Peers
 ^^^^^^^^^^^^^^^^^
 
-.. index:: [no] neighbor PEER shutdown [message MSG...]
-.. clicmd:: [no] neighbor PEER shutdown [message MSG...]
+.. index:: [no] neighbor PEER shutdown [message MSG...] [rtt (1-65535) [count (1-255)]]
+.. clicmd:: [no] neighbor PEER shutdown [message MSG...] [rtt (1-65535) [count (1-255)]]
 
    Shutdown the peer. We can delete the neighbor's configuration by
    ``no neighbor PEER remote-as ASN`` but all configuration of the neighbor
@@ -1231,6 +1231,12 @@ Configuring Peers
    drop the BGP peer, use this syntax.
 
    Optionally you can specify a shutdown message `MSG`.
+
+   Also, you can specify optionally _rtt_ in milliseconds to automatically
+   shutdown the peer if round-trip-time becomes higher than defined.
+
+   Additional _count_ parameter is the number of keepalive messages to count
+   before shutdown the peer if round-trip-time becomes higher than defined.
 
 .. index:: [no] neighbor PEER disable-connected-check
 .. clicmd:: [no] neighbor PEER disable-connected-check


### PR DESCRIPTION
Waiting for discussion if that's worth continuing here with this implementation.

This would be useful in cases with lots of peers and shutdown them
automatically if RTT goes above the specified limit.

A host with 512 or more IPv6 addresses has a higher latency due to
ipv6_addr_label(). This method tries to pick the best candidate address
fo outgoing connection and literally increases processing latency.

```
Samples: 28  of event 'cycles', Event count (approx.): 22131542
  Children      Self  Command  Shared Object      Symbol
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] entry_SYSCALL_64_fastpath
  +  100.00%     0.00%  ping6    [unknown]          [.] 0x0df0ad0b8047022a
  +  100.00%     0.00%  ping6    libc-2.17.so       [.] __sendto_nocancel
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] sys_sendto
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] SYSC_sendto
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] sock_sendmsg
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] inet_sendmsg
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] rawv6_sendmsg
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] ip6_dst_lookup_flow
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] ip6_dst_lookup_tail
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] ip6_route_get_saddr
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] ipv6_dev_get_saddr
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] __ipv6_dev_get_saddr
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] ipv6_get_saddr_eval
  +  100.00%     0.00%  ping6    [kernel.kallsyms]  [k] ipv6_addr_label
  +  100.00%   100.00%  ping6    [kernel.kallsyms]  [k] __ipv6_addr_label
  +    0.00%     0.00%  ping6    [kernel.kallsyms]  [k] schedule
```

This is how it works:

```
~# vtysh -c 'show bgp neigh 192.168.0.2 json' | jq '."192.168.0.2".estimatedRttInMsecs'
9
~# tc qdisc add dev eth1 root netem delay 120ms
~# vtysh -c 'show bgp neigh 192.168.0.2 json' | jq '."192.168.0.2".estimatedRttInMsecs'
89
~# vtysh -c 'show bgp neigh 192.168.0.2 json' | jq '."192.168.0.2".estimatedRttInMsecs'
null
~# vtysh -c 'show bgp neigh 192.168.0.2 json' | jq '."192.168.0.2".lastResetDueTo'
"Admin. shutdown"
```