### PR TITLE
ldpd: Fix issue when starting up LDP with no configuration.

### DIFF
--- a/ldpd/lde.h
+++ b/ldpd/lde.h
@@ -193,6 +193,9 @@ void		 lde_change_allocate_filter(int);
 void		 lde_change_advertise_filter(int);
 void		 lde_change_accept_filter(int);
 void		 lde_change_expnull_for_filter(int);
+void		 lde_route_update(struct iface *, int);
+void		 lde_route_update_release(struct iface *, int);
+void		 lde_route_update_release_all(int);
 struct lde_addr	*lde_address_find(struct lde_nbr *, int,
 		    union ldpd_addr *);
 

--- a/ldpd/ldp_vty_cmds.c
+++ b/ldpd/ldp_vty_cmds.c
@@ -616,6 +616,8 @@ DEFPY  (ldp_show_mpls_ldp_binding,
 	"Show detailed information\n"
 	JSON_STR)
 {
+	if (!(ldpd_conf->flags & F_LDPD_ENABLED))
+		return CMD_SUCCESS;
 	if (!local_label_str)
 		local_label = NO_LABEL;
 	if (!remote_label_str)

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -614,10 +614,8 @@ ldpe_dispatch_lde(struct thread *thread)
 			map = imsg.data;
 
 			nbr = nbr_find_peerid(imsg.hdr.peerid);
-			if (nbr == NULL) {
-				log_debug("ldpe_dispatch_lde: cannot find neighbor");
+			if (nbr == NULL)
 				break;
-			}
 			if (nbr->state != NBR_STA_OPER)
 				break;
 
@@ -641,10 +639,8 @@ ldpe_dispatch_lde(struct thread *thread)
 		case IMSG_REQUEST_ADD_END:
 		case IMSG_WITHDRAW_ADD_END:
 			nbr = nbr_find_peerid(imsg.hdr.peerid);
-			if (nbr == NULL) {
-				log_debug("ldpe_dispatch_lde: cannot find neighbor");
+			if (nbr == NULL)
 				break;
-			}
 			if (nbr->state != NBR_STA_OPER)
 				break;
 

--- a/lib/mpls.h
+++ b/lib/mpls.h
@@ -72,8 +72,7 @@ extern "C" {
 /* Maximum # labels that can be pushed. */
 #define MPLS_MAX_LABELS                    16
 
-#define IS_MPLS_RESERVED_LABEL(label)                                          \
-	(label >= MPLS_LABEL_RESERVED_MIN && label <= MPLS_LABEL_RESERVED_MAX)
+#define IS_MPLS_RESERVED_LABEL(label) (label <= MPLS_LABEL_RESERVED_MAX)
 
 #define IS_MPLS_UNRESERVED_LABEL(label)                                        \
 	(label >= MPLS_LABEL_UNRESERVED_MIN                                    \


### PR DESCRIPTION
LDP would mark all routes as learned on a non-ldp interface.  Then
when LDP was configured the labels were not updated correctly.  This
commit fixes the following issues:

#6841 LDP label bindings created even when 'mpls ldp' is not configured
#6842 LDP only builds implicit-null bindings upon initial config -- bindings are non-null after restarting frr with systemd

Signed-off-by: Lynne Morrison <lynne@voltanet.io>