### PR TITLE
zebra: Solve the problem of high CPU and memory usage when creating t…

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1349,6 +1349,20 @@ static void zread_interface_add(ZAPI_HANDLER_ARGS)
 	struct vrf *vrf;
 	struct interface *ifp;
 
+	vrf_id_t vrf_id = zvrf_id(zvrf);
+	if (vrf_id != VRF_DEFAULT && vrf_id != VRF_UNKNOWN) {
+		FOR_ALL_INTERFACES (zvrf->vrf, ifp) {
+			/* Skip pseudo interface. */
+			if (!CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE))
+				continue;
+
+			zsend_interface_add(client, ifp);
+			zsend_interface_link_params(client, ifp);
+			zsend_interface_addresses(client, ifp);
+		}
+		return;
+	}
+
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			/* Skip pseudo interface. */


### PR DESCRIPTION
**Versions**
Distribution: Debian 9.13
Kernel: 4.9.0-11-2-amd64
FRRouting 7.2.1-sonic 



**Describe the bug**
Running process：
frr         46     1  0 09:26 pts/0    00:00:01 /usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M fpm -M
frr         50     1  0 09:26 pts/0    00:00:00 /usr/lib/frr/staticd -A 127.0.0.1
frr         53     1  0 09:27 pts/0    00:00:00 /usr/lib/frr/bgpd -A 127.0.0.1 -M snmp
frr         60     1  0 09:27 pts/0    00:00:00 /usr/lib/frr/bfdd -A 127.0.0.1

Use the following script to create thousands of vrf:
#!/bin/bash
int=1
table=257
while(( $int<4200 ))
do
    let "int++"
    let "table++"
    echo $int
    sudo ip link add vrf$int up type vrf table $table
done 

Result：
bfbd  high CPU usage
zebra high member usage
