### PR TITLE
lib, tools: fix reloading of key sub-context in key chains

### DIFF
--- a/lib/keychain.c
+++ b/lib/keychain.c
@@ -1041,6 +1041,8 @@ static int keychain_config_write(struct vty *vty)
 				}
 				vty_out(vty, "\n");
 			}
+
+			vty_out(vty, " exit\n");
 		}
 		vty_out(vty, "!\n");
 	}

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -591,6 +591,7 @@ end
                   line.startswith("vnc l2-group") or
                   line.startswith("vnc nve-group") or
                   line.startswith("peer") or
+                  line.startswith("key ") or
                   line.startswith("member pseudowire")):
                 main_ctx_key = []
 


### PR DESCRIPTION
When you add a key chain in the RIP configuration file and reload the
configurations via the frr-reload.py script, the script will fail and
the key chain will not appear in the running configuration. The reason
is that frr-reload.py doesn't recognize key as a sub-context.

Before this change, keys were generated this way:

    key chain test
     key 2
      key-string 123
     key 3
      key-string 456

With this change, keys will be generated this way:

    key chain test
     key 2
      key-string 123
     exit
     key 3
      key-string 456
     exit

This will allow frr-reload.py to see the key sub-context and correctly
reload them.

Signed-off-by: Alexander Chernavin <achernavin@netgate.com>