### PR TITLE
bfdd: fix parameter length

### DIFF
--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -109,7 +109,7 @@ DEFPY_YANG_NOSH(
 	VRF_NAME_STR)
 {
 	int ret, slen;
-	char source_str[INET6_ADDRSTRLEN];
+	char source_str[INET6_ADDRSTRLEN + 32];
 	char xpath[XPATH_MAXLEN], xpath_srcaddr[XPATH_MAXLEN + 32];
 
 	if (multihop)
@@ -168,7 +168,7 @@ DEFPY_YANG(
 {
 	int slen;
 	char xpath[XPATH_MAXLEN];
-	char source_str[INET6_ADDRSTRLEN];
+	char source_str[INET6_ADDRSTRLEN + 32];
 
 	if (multihop)
 		snprintf(source_str, sizeof(source_str), "[source-addr='%s']",


### PR DESCRIPTION
There is no space reserved for `[source-addr='']`.

Fixes https://github.com/FRRouting/frr/issues/6973.