### PR TITLE
ospfd: install Type-7 when NSSA enabled after redistribution

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -1802,6 +1802,7 @@ static int ospf_abr_task_timer(struct thread *thread)
 
 	ospf_abr_task(ospf);
 	ospf_abr_nssa_task(ospf); /* if nssa-abr, then scan Type-7 LSDB */
+	ospf_asbr_nssa_redist_task(ospf);
 
 	return 0;
 }

--- a/ospfd/ospf_asbr.h
+++ b/ospfd/ospf_asbr.h
@@ -72,6 +72,7 @@ extern struct external_info *ospf_external_info_lookup(struct ospf *, uint8_t,
 						       unsigned short,
 						       struct prefix_ipv4 *);
 extern void ospf_asbr_status_update(struct ospf *, uint8_t);
+extern void ospf_asbr_nssa_redist_task(struct ospf *ospf);
 
 extern void ospf_redistribute_withdraw(struct ospf *, uint8_t, unsigned short);
 extern void ospf_asbr_check(void);


### PR DESCRIPTION
If NSSA is enabled before redistribution is configured, Type-7 LSA's
are installed. But if NSSA is enabled after redistribution is
configured, Type-7 LSAs are missing.

With this change, when NSSA is enabled, scan for external LSA's and
if they exist, install Type-7.

Signed-off-by: Alexander Chernavin <achernavin@netgate.com>