### PR TITLE
bgpd: withdraw default route when route-map has no match

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -781,6 +781,9 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 		 */
 		for (dest = bgp_table_top(bgp->rib[afi][safi]); dest;
 		     dest = bgp_route_next(dest)) {
+			if (!bgp_dest_has_bgp_path_info_data(dest))
+				continue;
+
 			ret = route_map_apply(peer->default_rmap[afi][safi].map,
 					      bgp_dest_get_prefix(dest),
 					      RMAP_BGP, &bpi_rmap);


### PR DESCRIPTION
If you advertise a default route (via default-originate) only if some
prefix is present in the BGP RIB (route-map specified) and this prefix
becomes unavailable, the default route keeps being advertised.

With this change, when we iterate over the BGP RIB to check if we can
advertise the default route, skip unavailable prefixes.

Signed-off-by: Alexander Chernavin <achernavin@netgate.com>