### PR TITLE
tests: improve topotest stop logic

### DIFF
--- a/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
+++ b/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
@@ -263,6 +263,22 @@ def test_error_messages_daemons():
             if log:
                 error_logs += "r%s LDPd StdErr Output:\n" % i
                 error_logs += log
+
+        log = net['r1'].getStdErr('nhrpd')
+        if log:
+            error_logs += "r%s NHRPd StdErr Output:\n" % i
+            error_logs += log
+
+        log = net['r1'].getStdErr('babeld')
+        if log:
+            error_logs += "r%s BABELd StdErr Output:\n" % i
+            error_logs += log
+
+        log = net['r1'].getStdErr('pbrd')
+        if log:
+            error_logs += "r%s PBRd StdErr Output:\n" % i
+            error_logs += log
+
         log = net['r%s' % i].getStdErr('zebra')
         if log:
             error_logs += "r%s Zebra StdErr Output:\n"
@@ -1182,6 +1198,19 @@ def test_shutdown_check_stderr():
     log = net['r1'].getStdErr('bgpd')
     if log:
         print("\nBGPd StdErr Log:\n" + log)
+
+    log = net['r1'].getStdErr('nhrpd')
+    if log:
+        print("\nNHRPd StdErr Log:\n" + log)
+
+    log = net['r1'].getStdErr('pbrd')
+    if log:
+        print("\nPBRd StdErr Log:\n" + log)
+
+    log = net['r1'].getStdErr('babeld')
+    if log:
+        print("\nBABELd StdErr Log:\n" + log)
+
     if (net['r1'].daemon_available('ldpd')):
         log = net['r1'].getStdErr('ldpd')
         if log:

--- a/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
+++ b/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
@@ -70,7 +70,6 @@ from lib.common_config import (
     create_route_maps,
     shutdown_bringup_interface,
     start_router_daemons,
-    kill_router_daemons,
     create_static_routes,
     create_vrf_cfg,
     create_interfaces_cfg,

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
@@ -62,7 +62,6 @@ from lib.common_config import (
     verify_rib,
     step,
     start_router_daemons,
-    kill_router_daemons,
     create_static_routes,
     create_vrf_cfg,
     create_route_maps,

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
@@ -68,7 +68,6 @@ from lib.common_config import (
     create_route_maps,
     verify_cli_json,
     start_router_daemons,
-    kill_router_daemons,
     create_static_routes,
     stop_router,
     start_router,


### PR DESCRIPTION
Change the public topogen stop() method to always do the two-phase stop that we need in order to avoid shutdown failures.  We send daemons a shutdown signal once without waiting, and then a second time, waiting and reporting an error if a daemon fails to stop. Move the internal logic to a private method that tests shouldn't call directly.
Also included a couple of minor fixes.