### PR TITLE
zebra: remove fuzzing stuff

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -610,10 +610,6 @@ AC_ARG_ENABLE([cumulus],
   AS_HELP_STRING([--enable-cumulus], [enable Cumulus Switch Special Extensions]))
 AC_ARG_ENABLE([datacenter],
   AS_HELP_STRING([--enable-datacenter], [enable Compilation for Data Center Extensions]))
-AC_ARG_ENABLE([fuzzing],
-  AS_HELP_STRING([--enable-fuzzing], [enable ability to fuzz various parts of FRR]))
-AC_ARG_ENABLE([netlink_fuzzing],
-  AS_HELP_STRING([--enable-netlink-fuzzing], [enable ability to fuzz netlink listening socket in zebra]))
 AC_ARG_ENABLE([rr-semantics],
   AS_HELP_STRING([--disable-rr-semantics], [disable the v6 Route Replace semantics]))
 AC_ARG_ENABLE([protobuf],
@@ -716,14 +712,6 @@ if test "$enable_datacenter" = "yes" ; then
   DFLT_NAME="datacenter"
 else
   DFLT_NAME="traditional"
-fi
-
-if test "$enable_fuzzing" = "yes" ; then
-  AC_DEFINE([HANDLE_ZAPI_FUZZING], [1], [Compile extensions to use with a fuzzer])
-fi
-
-if test "$enable_netlink_fuzzing" = "yes" ; then
-  AC_DEFINE([HANDLE_NETLINK_FUZZING], [1], [Compile extensions to use with a fuzzer for netlink])
 fi
 
 if test "$enable_cumulus" = "yes" ; then

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -255,12 +255,6 @@ options from the list below.
    mind.  Specifically turn on -g3 -O0 for compiling options and add inclusion
    of grammar sandbox.
 
-.. option:: --enable-fuzzing
-
-   Turn on some compile options to allow you to run fuzzing tools against the
-   system. This flag is intended as a developer only tool and should not be
-   used for normal operations.
-
 .. option:: --disable-snmp
 
    Build without SNMP support.

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -86,10 +86,6 @@ extern const char *nl_rtproto_to_str(uint8_t rtproto);
 extern const char *nl_family_to_str(uint8_t family);
 extern const char *nl_rttype_to_str(uint8_t rttype);
 
-#if defined(HANDLE_NETLINK_FUZZING)
-extern bool netlink_read;
-extern void netlink_read_init(const char *fname);
-#endif /* HANDLE_NETLINK_FUZZING */
 extern int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 			      const struct nlsock *nl,
 			      const struct zebra_dplane_info *dp_info,

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -59,10 +59,6 @@
 #include "zebra/zebra_opaque.h"
 #include "zebra/zebra_srte.h"
 
-#if defined(HANDLE_NETLINK_FUZZING)
-#include "zebra/kernel_netlink.h"
-#endif /* HANDLE_NETLINK_FUZZING */
-
 #define ZEBRA_PTM_SUPPORT
 
 /* process id. */
@@ -284,12 +280,6 @@ int main(int argc, char **argv)
 	char *vrf_default_name_configured = NULL;
 	struct sockaddr_storage dummy;
 	socklen_t dummylen;
-#if defined(HANDLE_ZAPI_FUZZING)
-	char *zapi_fuzzing = NULL;
-#endif /* HANDLE_ZAPI_FUZZING */
-#if defined(HANDLE_NETLINK_FUZZING)
-	char *netlink_fuzzing = NULL;
-#endif /* HANDLE_NETLINK_FUZZING */
 
 	graceful_restart = 0;
 	vrf_configure_backend(VRF_BACKEND_VRF_LITE);
@@ -301,12 +291,6 @@ int main(int argc, char **argv)
 #ifdef HAVE_NETLINK
 		"s:n"
 #endif
-#if defined(HANDLE_ZAPI_FUZZING)
-		"c:"
-#endif /* HANDLE_ZAPI_FUZZING */
-#if defined(HANDLE_NETLINK_FUZZING)
-		"w:"
-#endif /* HANDLE_NETLINK_FUZZING */
 		,
 		longopts,
 		"  -b, --batch              Runs in batch mode\n"
@@ -321,12 +305,6 @@ int main(int argc, char **argv)
 		"  -s, --nl-bufsize         Set netlink receive buffer size\n"
 		"      --v6-rr-semantics    Use v6 RR semantics\n"
 #endif /* HAVE_NETLINK */
-#if defined(HANDLE_ZAPI_FUZZING)
-		"  -c <file>                Bypass normal startup and use this file for testing of zapi\n"
-#endif /* HANDLE_ZAPI_FUZZING */
-#if defined(HANDLE_NETLINK_FUZZING)
-		"  -w <file>                Bypass normal startup and use this file for testing of netlink input\n"
-#endif /* HANDLE_NETLINK_FUZZING */
 	);
 
 	while (1) {
@@ -388,21 +366,6 @@ int main(int argc, char **argv)
 			v6_rr_semantics = true;
 			break;
 #endif /* HAVE_NETLINK */
-#if defined(HANDLE_ZAPI_FUZZING)
-		case 'c':
-			zapi_fuzzing = optarg;
-			break;
-#endif /* HANDLE_ZAPI_FUZZING */
-#if defined(HANDLE_NETLINK_FUZZING)
-		case 'w':
-			netlink_fuzzing = optarg;
-			/* This ensures we are aren't writing any of the
-			 * startup netlink messages that happen when we
-			 * just want to read.
-			 */
-			netlink_read = true;
-			break;
-#endif /* HANDLE_NETLINK_FUZZING */
 		default:
 			frr_help_exit(1);
 			break;
@@ -488,20 +451,6 @@ int main(int argc, char **argv)
 
 	/* Error init */
 	zebra_error_init();
-
-#if defined(HANDLE_ZAPI_FUZZING)
-	if (zapi_fuzzing) {
-		zserv_read_file(zapi_fuzzing);
-		exit(0);
-	}
-#endif /* HANDLE_ZAPI_FUZZING */
-#if defined(HANDLE_NETLINK_FUZZING)
-	if (netlink_fuzzing) {
-		netlink_read_init(netlink_fuzzing);
-		exit(0);
-	}
-#endif /* HANDLE_NETLINK_FUZZING */
-
 
 	frr_run(zrouter.master);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3113,29 +3113,6 @@ void (*const zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_CLIENT_CAPABILITIES] = zread_client_capabilities,
 	[ZEBRA_NEIGH_DISCOVER] = zread_neigh_discover};
 
-#if defined(HANDLE_ZAPI_FUZZING)
-extern struct zebra_privs_t zserv_privs;
-
-static void zserv_write_incoming(struct stream *orig, uint16_t command)
-{
-	char fname[MAXPATHLEN];
-	struct stream *copy;
-	int fd = -1;
-
-	copy = stream_dup(orig);
-	stream_set_getp(copy, 0);
-
-	snprintf(fname, MAXPATHLEN, "%s/%u", frr_vtydir, command);
-
-	frr_with_privs(&zserv_privs) {
-		fd = open(fname, O_CREAT | O_WRONLY | O_EXCL, 0644);
-	}
-	stream_flush(copy, fd);
-	close(fd);
-	stream_free(copy);
-}
-#endif
-
 /*
  * Process a batch of zapi messages.
  */
@@ -3165,10 +3142,6 @@ void zserv_handle_commands(struct zserv *client, struct stream_fifo *fifo)
 		if (IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV
 		    && IS_ZEBRA_DEBUG_DETAIL)
 			zserv_log_message(NULL, msg, &hdr);
-
-#if defined(HANDLE_ZAPI_FUZZING)
-		zserv_write_incoming(msg, hdr.command);
-#endif
 
 		hdr.length -= ZEBRA_HEADER_SIZE;
 

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1294,17 +1294,6 @@ DEFUN (show_zebra_client_summary,
 	return CMD_SUCCESS;
 }
 
-#if defined(HANDLE_ZAPI_FUZZING)
-void zserv_read_file(char *input)
-{
-	int fd;
-
-	fd = open(input, O_RDONLY | O_NONBLOCK);
-
-	zserv_client_create(fd);
-}
-#endif
-
 void zserv_init(void)
 {
 	/* Client list init. */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -375,10 +375,6 @@ extern void zserv_close_client(struct zserv *client);
 void zserv_log_message(const char *errmsg, struct stream *msg,
 		       struct zmsghdr *hdr);
 
-#if defined(HANDLE_ZAPI_FUZZING)
-extern void zserv_read_file(char *input);
-#endif
-
 /* TODO */
 __attribute__((__noreturn__)) int zebra_finalize(struct thread *event);
 


### PR DESCRIPTION
The fuzzing code that is in the master branch is outdated and unused, so it
is worth to remove it to improve readablity of the code.

All code related to the fuzzing is in the `fuzz` branch.

Signed-off-by: Jakub Urbańczyk <xthaid@gmail.com>