### PR TITLE
lib,yang: allow cisco access lists to use names plus fixes

### DIFF
--- a/lib/filter.h
+++ b/lib/filter.h
@@ -32,6 +32,16 @@ extern "C" {
 /* Maximum ACL name length */
 #define ACL_NAMSIZ                128
 
+/** Cisco host wildcard mask. */
+#define CISCO_HOST_WILDCARD_MASK  "0.0.0.0"
+/** Cisco host wildcard binary mask. */
+#define CISCO_BIN_HOST_WILDCARD_MASK INADDR_ANY
+
+/** Cisco any wildcard mask. */
+#define CISCO_ANY_WILDCARD_MASK   "255.255.255.255"
+/** Cisco binary any wildcard mask. */
+#define CISCO_BIN_ANY_WILDCARD_MASK INADDR_NONE
+
 /* Filter direction.  */
 #define FILTER_IN                 0
 #define FILTER_OUT                1

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -37,14 +37,8 @@
 
 #define ACCESS_LIST_STR "Access list entry\n"
 #define ACCESS_LIST_LEG_STR "IP standard access list\n"
-#define ACCESS_LIST_LEG_EXT_STR "IP standard access list (expanded range)\n"
 #define ACCESS_LIST_ELEG_STR "IP extended access list\n"
 #define ACCESS_LIST_ELEG_EXT_STR "IP extended access list (expanded range)\n"
-#define ACCESS_LIST_XLEG_STR                                                   \
-	ACCESS_LIST_LEG_STR                                                    \
-	ACCESS_LIST_LEG_EXT_STR                                                \
-	ACCESS_LIST_ELEG_STR                                                   \
-	ACCESS_LIST_ELEG_EXT_STR
 #define ACCESS_LIST_ZEBRA_STR "Access list entry\n"
 #define ACCESS_LIST_SEQ_STR                                                    \
 	"Sequence number of an entry\n"                                        \
@@ -171,10 +165,9 @@ static long acl_get_seq(struct vty *vty, const char *xpath)
  */
 DEFPY_YANG(
 	access_list_std, access_list_std_cmd,
-	"access-list <(1-99)|(1300-1999)>$number [seq (1-4294967295)$seq] <deny|permit>$action <[host] A.B.C.D$host|A.B.C.D$host A.B.C.D$mask|any>",
+	"access-list WORD$name [seq (1-4294967295)$seq] <deny|permit>$action <[host] A.B.C.D$host|A.B.C.D$host A.B.C.D$mask|any>",
 	ACCESS_LIST_STR
 	ACCESS_LIST_LEG_STR
-	ACCESS_LIST_LEG_EXT_STR
 	ACCESS_LIST_SEQ_STR
 	ACCESS_LIST_ACTION_STR
 	"A single host address\n"
@@ -193,8 +186,7 @@ DEFPY_YANG(
 	 * none given (backward compatibility).
 	 */
 	snprintf(xpath, sizeof(xpath),
-		 "/frr-filter:lib/access-list[type='ipv4'][name='%s']",
-		 number_str);
+		 "/frr-filter:lib/access-list[type='ipv4'][name='%s']", name);
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
 	if (seq_str == NULL) {
 		/* Use XPath to find the next sequence number. */
@@ -222,11 +214,10 @@ DEFPY_YANG(
 
 DEFPY_YANG(
 	no_access_list_std, no_access_list_std_cmd,
-	"no access-list <(1-99)|(1300-1999)>$number [seq (1-4294967295)$seq] <deny|permit>$action <[host] A.B.C.D$host|A.B.C.D$host A.B.C.D$mask|any>",
+	"no access-list WORD$name [seq (1-4294967295)$seq] <deny|permit>$action <[host] A.B.C.D$host|A.B.C.D$host A.B.C.D$mask|any>",
 	NO_STR
 	ACCESS_LIST_STR
 	ACCESS_LIST_LEG_STR
-	ACCESS_LIST_LEG_EXT_STR
 	ACCESS_LIST_SEQ_STR
 	ACCESS_LIST_ACTION_STR
 	"A single host address\n"
@@ -246,15 +237,14 @@ DEFPY_YANG(
 		snprintf(
 			xpath, sizeof(xpath),
 			"/frr-filter:lib/access-list[type='ipv4'][name='%s']/entry[sequence='%s']",
-			number_str, seq_str);
+			name, seq_str);
 		nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 		return nb_cli_apply_changes(vty, NULL);
 	}
 
 	/* Otherwise, to keep compatibility, we need to figure it out. */
 	snprintf(xpath, sizeof(xpath),
-		 "/frr-filter:lib/access-list[type='ipv4'][name='%s']",
-		 number_str);
+		 "/frr-filter:lib/access-list[type='ipv4'][name='%s']", name);
 
 	/* Access-list must exist before entries. */
 	if (yang_dnode_exists(running_config->dnode, xpath) == false)
@@ -282,10 +272,9 @@ DEFPY_YANG(
 
 DEFPY_YANG(
 	access_list_ext, access_list_ext_cmd,
-	"access-list <(100-199)|(2000-2699)>$number [seq (1-4294967295)$seq] <deny|permit>$action ip <A.B.C.D$src A.B.C.D$src_mask|host A.B.C.D$src|any> <A.B.C.D$dst A.B.C.D$dst_mask|host A.B.C.D$dst|any>",
+	"access-list WORD$name [seq (1-4294967295)$seq] <deny|permit>$action ip <A.B.C.D$src A.B.C.D$src_mask|host A.B.C.D$src|any> <A.B.C.D$dst A.B.C.D$dst_mask|host A.B.C.D$dst|any>",
 	ACCESS_LIST_STR
 	ACCESS_LIST_ELEG_STR
-	ACCESS_LIST_ELEG_EXT_STR
 	ACCESS_LIST_SEQ_STR
 	ACCESS_LIST_ACTION_STR
 	"IPv4 address\n"
@@ -310,8 +299,7 @@ DEFPY_YANG(
 	 * none given (backward compatibility).
 	 */
 	snprintf(xpath, sizeof(xpath),
-		 "/frr-filter:lib/access-list[type='ipv4'][name='%s']",
-		 number_str);
+		 "/frr-filter:lib/access-list[type='ipv4'][name='%s']", name);
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
 	if (seq_str == NULL) {
 		/* Use XPath to find the next sequence number. */
@@ -353,11 +341,10 @@ DEFPY_YANG(
 
 DEFPY_YANG(
 	no_access_list_ext, no_access_list_ext_cmd,
-	"no access-list <(100-199)|(2000-2699)>$number [seq (1-4294967295)$seq] <deny|permit>$action ip <A.B.C.D$src A.B.C.D$src_mask|host A.B.C.D$src|any> <A.B.C.D$dst A.B.C.D$dst_mask|host A.B.C.D$dst|any>",
+	"no access-list WORD$name [seq (1-4294967295)$seq] <deny|permit>$action ip <A.B.C.D$src A.B.C.D$src_mask|host A.B.C.D$src|any> <A.B.C.D$dst A.B.C.D$dst_mask|host A.B.C.D$dst|any>",
 	NO_STR
 	ACCESS_LIST_STR
 	ACCESS_LIST_ELEG_STR
-	ACCESS_LIST_ELEG_EXT_STR
 	ACCESS_LIST_SEQ_STR
 	ACCESS_LIST_ACTION_STR
 	"Any Internet Protocol\n"
@@ -383,15 +370,14 @@ DEFPY_YANG(
 		snprintfrr(
 			xpath, sizeof(xpath),
 			"/frr-filter:lib/access-list[type='ipv4'][name='%s']/entry[sequence='%s']",
-			number_str, seq_str);
+			name, seq_str);
 		nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 		return nb_cli_apply_changes(vty, NULL);
 	}
 
 	/* Otherwise, to keep compatibility, we need to figure it out. */
 	snprintf(xpath, sizeof(xpath),
-		 "/frr-filter:lib/access-list[type='ipv4'][name='%s']",
-		 number_str);
+		 "/frr-filter:lib/access-list[type='ipv4'][name='%s']", name);
 
 	/* Access-list must exist before entries. */
 	if (yang_dnode_exists(running_config->dnode, xpath) == false)

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -290,7 +290,7 @@ DEFPY_YANG(
 	"Any destination host\n")
 {
 	int64_t sseq;
-	char ipmask[64];
+	char ipmask[64], ipmask_dst[64];
 	char xpath[XPATH_MAXLEN];
 	char xpath_entry[XPATH_MAXLEN + 128];
 
@@ -325,12 +325,12 @@ DEFPY_YANG(
 
 	if (dst_str != NULL && dst_mask_str == NULL) {
 		nb_cli_enqueue_change(vty, "./destination-host", NB_OP_MODIFY,
-				      src_str);
+				      dst_str);
 	} else if (dst_str != NULL && dst_mask_str != NULL) {
-		concat_addr_mask_v4(dst_str, dst_mask_str, ipmask,
-				    sizeof(ipmask));
+		concat_addr_mask_v4(dst_str, dst_mask_str, ipmask_dst,
+				    sizeof(ipmask_dst));
 		nb_cli_enqueue_change(vty, "./destination-network",
-				      NB_OP_MODIFY, ipmask);
+				      NB_OP_MODIFY, ipmask_dst);
 	} else {
 		nb_cli_enqueue_change(vty, "./destination-any", NB_OP_CREATE,
 				      NULL);

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -165,7 +165,7 @@ static long acl_get_seq(struct vty *vty, const char *xpath)
  */
 DEFPY_YANG(
 	access_list_std, access_list_std_cmd,
-	"access-list WORD$name [seq (1-4294967295)$seq] <deny|permit>$action <[host] A.B.C.D$host|A.B.C.D$host A.B.C.D$mask|any>",
+	"access-list WORD$name [seq (1-4294967295)$seq] <deny|permit>$action <[host] A.B.C.D$host|A.B.C.D$host A.B.C.D$mask>",
 	ACCESS_LIST_STR
 	ACCESS_LIST_LEG_STR
 	ACCESS_LIST_SEQ_STR
@@ -173,8 +173,7 @@ DEFPY_YANG(
 	"A single host address\n"
 	"Address to match\n"
 	"Address to match\n"
-	"Wildcard bits\n"
-	"Any source host\n")
+	"Wildcard bits\n")
 {
 	int64_t sseq;
 	char ipmask[64];
@@ -214,7 +213,7 @@ DEFPY_YANG(
 
 DEFPY_YANG(
 	no_access_list_std, no_access_list_std_cmd,
-	"no access-list WORD$name [seq (1-4294967295)$seq] <deny|permit>$action <[host] A.B.C.D$host|A.B.C.D$host A.B.C.D$mask|any>",
+	"no access-list WORD$name [seq (1-4294967295)$seq] <deny|permit>$action <[host] A.B.C.D$host|A.B.C.D$host A.B.C.D$mask>",
 	NO_STR
 	ACCESS_LIST_STR
 	ACCESS_LIST_LEG_STR
@@ -223,8 +222,7 @@ DEFPY_YANG(
 	"A single host address\n"
 	"Address to match\n"
 	"Address to match\n"
-	"Wildcard bits\n"
-	"Any source host\n")
+	"Wildcard bits\n")
 {
 	struct access_list *acl;
 	struct lyd_node *dnode;

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -104,7 +104,8 @@ static int64_t acl_zebra_get_seq(struct access_list *acl, const char *action,
 		f.type = FILTER_DENY;
 
 	fz = &f.u.zfilter;
-	fz->prefix = *p;
+	if (p->family)
+		prefix_copy(&fz->prefix, p);
 	fz->exact = exact;
 
 	fn = filter_lookup_zebra(acl, &f);

--- a/yang/frr-filter.yang
+++ b/yang/frr-filter.yang
@@ -170,31 +170,22 @@ module frr-filter {
                   description "Match any";
                   type empty;
                 }
-              }
 
-              choice extended-value {
-                /*
-                 * Legacy note: before using the new access-list format the
-                 * cisco styled list only accepted identifiers using numbers
-                 * and they had the following restriction:
-                 *
-                 * when "../number >= 100 and ../number <= 199 or
-                 *     ../number >= 2000 and ../number <= 2699";
-                 */
-                description "Destination value to match";
-                mandatory true;
+                choice extended-value {
+                  description "Destination value to match";
 
-                leaf destination-host {
-                  description "Host to match";
-                  type inet:ipv4-address;
-                }
-                leaf destination-network {
-                  description "Network to match";
-                  type inet:ipv4-prefix;
-                }
-                leaf destination-any {
-                  description "Match any";
-                  type empty;
+                  leaf destination-host {
+                    description "Host to match";
+                    type inet:ipv4-address;
+                  }
+                  leaf destination-network {
+                    description "Network to match";
+                    type inet:ipv4-prefix;
+                  }
+                  leaf destination-any {
+                    description "Match any";
+                    type empty;
+                  }
                 }
               }
             }


### PR DESCRIPTION
Summary
------------

The YANG model was already changed when the cisco/zebra mixing was fixed, so now lets build upon that to allow cisco access list rules to use names.


ToDo
------

* [x] Fix cisco extended YANG `choice` usage
* [x] Fix some CLI bugs
* [x] Cisco mask handling refactory (at the moment half the code expects inverted masks, while the rest expects normal masks)

   Problem example:

   Old syntax mask syntax was: 192.168.0.0/24 == `192.168.0.0 0.0.255.255` but the current implementation is wrongly expecting `192.168.0.0 255.255.0.0`.

   Even the command help says so:

   ```c
   "access-list WORD$name [seq (1-4294967295)$seq] <deny|permit>$action <[host] A.B.C.D$host|A.B.C.D$host A.B.C.D$mask>",
          ACCESS_LIST_STR                                                         
          ACCESS_LIST_LEG_STR                                                     
          ACCESS_LIST_SEQ_STR                                                     
          ACCESS_LIST_ACTION_STR                                                  
          "A single host address\n"                                               
          "Address to match\n"                                                    
          "Address to match\n"                                                    
          "Wildcard bits\n"
   ```

   **"Wildcard bits"** so no network mask.

* [x] Cisco rules testing (see [acl.txt](https://github.com/FRRouting/frr/files/5131032/acl.txt) for my test scripts )