### PR TITLE
doc: Latest doc generators want you to use different functions

### DIFF
--- a/doc/user/conf.py
+++ b/doc/user/conf.py
@@ -365,8 +365,8 @@ def setup(app):
     # node later on
     app.add_object_type('clicmd', 'clicmd')
     # css overrides for HTML theme
-    app.add_stylesheet('overrides.css')
-    app.add_javascript('overrides.js')
+    app.add_css_file('overrides.css')
+    app.add_js_file('overrides.js')
     # load Pygments lexer for FRR config syntax
     #
     # NB: in Pygments 2.2+ this can be done with `load_lexer_from_file`, but we


### PR DESCRIPTION
Convert to functions requested during build:

/home/sharpd/frr_coverity/doc/user/conf.py:368: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet('overrides.css')
/home/sharpd/frr_coverity/doc/user/conf.py:369: RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please use app.add_js_file() instead.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>