### PR TITLE
bgpd: Remove a deadcode freeing JSON in bgp_show_all_instances_neighbors_vty

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -12800,11 +12800,8 @@ static void bgp_show_all_instances_neighbors_vty(struct vty *vty,
 		json = NULL;
 	}
 
-	if (use_json) {
+	if (use_json)
 		vty_out(vty, "}\n");
-		if (json)
-			json_object_free(json);
-	}
 	else if (!nbr_output)
 		vty_out(vty, "%% BGP instance not found\n");
 }


### PR DESCRIPTION
`json = NULL;` is set in a loop above and here we are trying to check and
free the object again which is never be reached.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>