### PR TITLE
ospfd: use a new vertex list for every SPF run

### DIFF
--- a/ospfd/ospf_spf.h
+++ b/ospfd/ospf_spf.h
@@ -82,6 +82,7 @@ extern int ospf_spf_calculate_areas(struct ospf *ospf,
 				    struct route_table *new_rtrs,
 				    bool is_dry_run, bool is_root_node);
 extern void ospf_rtrs_free(struct route_table *);
+extern void ospf_spf_cleanup(struct vertex *spf, struct list *vertex_list);
 
 extern void ospf_spf_print(struct vty *vty, struct vertex *v, int i);
 

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -414,6 +414,8 @@ struct ospf_area {
 
 	/* Shortest Path Tree. */
 	struct vertex *spf;
+	struct list *spf_vertex_list;
+
 	bool spf_dry_run;   /* flag for checking if the SPF calculation is
 			       intended for the local RIB */
 	bool spf_root_node; /* flag for checking if the calculating node is the


### PR DESCRIPTION
This is a follow-up PR to #6912.

In the context of TI-LFA it is necessary to have multiple
representations of SPFs for so called P and Q spaces. Hence it makes
sense to start with fresh vertex lists, and only delete them when
the SPF calculation is not a 'dry run'.

Signed-off-by: GalaxyGorilla <sascha@netdef.org>