### PR TITLE
[7.4] pimd: fix igmp querier election and IP address mapping

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1503,14 +1503,14 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 	}
 }
 
-int pim_if_connected_to_source(struct interface *ifp, struct in_addr src)
+struct prefix *pim_if_connected_to_source(struct interface *ifp, struct in_addr src)
 {
 	struct listnode *cnode;
 	struct connected *c;
 	struct prefix p;
 
 	if (!ifp)
-		return 0;
+		return NULL;
 
 	p.family = AF_INET;
 	p.u.prefix4 = src;
@@ -1519,11 +1519,11 @@ int pim_if_connected_to_source(struct interface *ifp, struct in_addr src)
 	for (ALL_LIST_ELEMENTS_RO(ifp->connected, cnode, c)) {
 		if ((c->address->family == AF_INET)
 		    && prefix_match(CONNECTED_PREFIX(c), &p)) {
-			return 1;
+			return CONNECTED_PREFIX(c);
 		}
 	}
 
-	return 0;
+	return NULL;
 }
 
 bool pim_if_is_vrf_device(struct interface *ifp)

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -222,7 +222,7 @@ void pim_if_update_assert_tracking_desired(struct interface *ifp);
 
 void pim_if_create_pimreg(struct pim_instance *pim);
 
-int pim_if_connected_to_source(struct interface *ifp, struct in_addr src);
+struct prefix *pim_if_connected_to_source(struct interface *ifp, struct in_addr src);
 int pim_update_source_set(struct interface *ifp, struct in_addr source);
 
 bool pim_if_is_vrf_device(struct interface *ifp);

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -310,7 +310,7 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 		return 0;
 	}
 
-	if (if_lookup_address(&from, AF_INET, ifp->vrf_id)) {
+	if (if_lookup_exact_address(&from, AF_INET, ifp->vrf_id)) {
 		if (PIM_DEBUG_IGMP_PACKETS)
 			zlog_debug("Recv IGMP query on interface: %s from ourself %s",
 				   ifp->name, from_str);

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -997,6 +997,7 @@ struct igmp_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
 {
 	struct pim_interface *pim_ifp;
 	struct igmp_sock *igmp;
+	struct sockaddr_in sin;
 	int fd;
 
 	pim_ifp = ifp->info;
@@ -1004,6 +1005,15 @@ struct igmp_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
 	fd = igmp_sock_open(ifaddr, ifp, pim_ifp->options);
 	if (fd < 0) {
 		zlog_warn("Could not open IGMP socket for %s on %s",
+			  inet_ntoa(ifaddr), ifp->name);
+		return 0;
+	}
+
+	sin.sin_family = AF_INET;
+	sin.sin_addr = ifaddr;
+	sin.sin_port = 0;
+	if (bind(fd, (struct sockaddr *) &sin, sizeof(sin)) != 0) {
+		zlog_warn("Could not bind IGMP socket for %s on %s",
 			  inet_ntoa(ifaddr), ifp->name);
 		return 0;
 	}


### PR DESCRIPTION
Match exact source address to filter out self-originating queries.
Bind igmp sockets to their addresses so that queries are mapped correctly to their
configured addresses