### PR TITLE
[7.3] pimd: fix IGMP querier election

### DIFF
--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -312,7 +312,7 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 		return 0;
 	}
 
-	if (if_lookup_address(&from, AF_INET, ifp->vrf_id)) {
+	if (if_lookup_exact_address(&from, AF_INET, ifp->vrf_id)) {
 		if (PIM_DEBUG_IGMP_PACKETS)
 			zlog_debug("Recv IGMP query on interface: %s from ourself %s",
 				   ifp->name, from_str);


### PR DESCRIPTION
Match by exact address rather than by prefix match to
determine if we generated the IGMP query. Othwerwise
we will be ignoring IGMP queries coming from other
hosts on the same subnet.

Signed-off-by: Nathan Bahr <nbahr@atcorp.com>
Reviewed-by: Jafar Al-Gharaibeh <jafar@atcorp.com>