### PR TITLE
Clean up in vrf management

### DIFF
--- a/lib/netns_linux.c
+++ b/lib/netns_linux.c
@@ -43,9 +43,6 @@
 DEFINE_MTYPE_STATIC(LIB, NS, "NetNS Context")
 DEFINE_MTYPE_STATIC(LIB, NS_NAME, "NetNS Name")
 
-/* default NS ID value used when VRF backend is not NETNS */
-#define NS_DEFAULT_INTERNAL 0
-
 static inline int ns_compare(const struct ns *ns, const struct ns *ns2);
 static struct ns *ns_lookup_name_internal(const char *name);
 
@@ -100,9 +97,6 @@ static inline int setns(int fd, int nstype)
 #ifdef HAVE_NETNS
 static int have_netns_enabled = -1;
 #endif /* HAVE_NETNS */
-
-/* default NS ID value used when VRF backend is not NETNS */
-#define NS_DEFAULT_INTERNAL 0
 
 static int have_netns(void)
 {
@@ -612,15 +606,7 @@ ns_id_t ns_id_get_absolute(ns_id_t ns_id_reference, ns_id_t link_nsid)
 	return ns->ns_id;
 }
 
-ns_id_t ns_get_default_id(void)
-{
-	if (default_ns)
-		return default_ns->ns_id;
-	return NS_DEFAULT_INTERNAL;
-}
-
 struct ns *ns_get_default(void)
 {
 	return default_ns;
 }
-

--- a/lib/netns_other.c
+++ b/lib/netns_other.c
@@ -110,13 +110,6 @@ void ns_init(void)
 {
 }
 
-/* API to retrieve default NS */
-ns_id_t ns_get_default_id(void)
-{
-	return NS_UNKNOWN;
-}
-
-
 /* API that can be used to change from NS */
 int ns_switchback_to_initial(void)
 {

--- a/lib/ns.h
+++ b/lib/ns.h
@@ -161,10 +161,7 @@ extern ns_id_t ns_map_nsid_with_external(ns_id_t ns_id, bool map);
  */
 extern void ns_init(void);
 
-/* API to retrieve default NS */
-extern ns_id_t ns_get_default_id(void);
-
-#define NS_DEFAULT ns_get_default_id()
+#define NS_DEFAULT 0
 
 /* API that can be used to change from NS */
 extern int ns_switchback_to_initial(void);

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -39,8 +39,7 @@
 #include "northbound.h"
 #include "northbound_cli.h"
 
-/* default VRF ID value used when VRF backend is not NETNS */
-#define VRF_DEFAULT_INTERNAL 0
+/* default VRF name value used when VRF backend is not NETNS */
 #define VRF_DEFAULT_NAME_INTERNAL "default"
 
 DEFINE_MTYPE_STATIC(LIB, VRF, "VRF")
@@ -521,7 +520,7 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 
 		strlcpy(default_vrf->data.l.netns_name,
 			VRF_DEFAULT_NAME, NS_NAMSIZ);
-		ns = ns_lookup(ns_get_default_id());
+		ns = ns_lookup(NS_DEFAULT);
 		ns->vrf_ctxt = default_vrf;
 		default_vrf->ns_ctxt = ns;
 	}
@@ -947,17 +946,6 @@ void vrf_set_default_name(const char *default_name, bool force)
 const char *vrf_get_default_name(void)
 {
 	return vrf_default_name;
-}
-
-vrf_id_t vrf_get_default_id(void)
-{
-	/* backend netns is only known by zebra
-	 * for other daemons, we return VRF_DEFAULT_INTERNAL
-	 */
-	if (vrf_is_backend_netns())
-		return ns_get_default_id();
-	else
-		return VRF_DEFAULT_INTERNAL;
 }
 
 int vrf_bind(vrf_id_t vrf_id, int fd, const char *name)

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -331,6 +331,9 @@ const char *vrf_id_to_name(vrf_id_t vrf_id)
 {
 	struct vrf *vrf;
 
+	if (vrf_id == VRF_DEFAULT)
+		return VRF_DEFAULT_NAME;
+
 	vrf = vrf_lookup_by_id(vrf_id);
 	return VRF_LOGNAME(vrf);
 }

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -262,12 +262,8 @@ extern int vrf_getaddrinfo(const char *node, const char *service,
 
 extern int vrf_ioctl(vrf_id_t vrf_id, int d, unsigned long request, char *args);
 
-/* function called by macro VRF_DEFAULT
- * to get the default VRF_ID
- */
-extern vrf_id_t vrf_get_default_id(void);
 /* The default VRF ID */
-#define VRF_DEFAULT vrf_get_default_id()
+#define VRF_DEFAULT 0
 
 extern void vrf_set_default_name(const char *default_name, bool force);
 extern const char *vrf_get_default_name(void);

--- a/zebra/zebra_netns_id.c
+++ b/zebra/zebra_netns_id.c
@@ -39,9 +39,6 @@
 #include "zebra/zebra_netns_id.h"
 #include "zebra/zebra_errors.h"
 
-/* default NS ID value used when VRF backend is not NETNS */
-#define NS_DEFAULT_INTERNAL 0
-
 /* in case NEWNSID not available, the NSID will be locally obtained
  */
 #define NS_BASE_NSID 0
@@ -362,14 +359,14 @@ ns_id_t zebra_ns_id_get_default(void)
 	fd = open(NS_DEFAULT_NAME, O_RDONLY);
 
 	if (fd == -1)
-		return NS_DEFAULT_INTERNAL;
+		return NS_DEFAULT;
 	if (!vrf_is_backend_netns()) {
 		close(fd);
-		return NS_DEFAULT_INTERNAL;
+		return NS_DEFAULT;
 	}
 	close(fd);
 	return zebra_ns_id_get((char *)NS_DEFAULT_NAME, -1);
 #else  /* HAVE_NETNS */
-	return NS_DEFAULT_INTERNAL;
+	return NS_DEFAULT;
 #endif /* !HAVE_NETNS */
 }

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -199,7 +199,7 @@ int zebra_ns_init(const char *optional_default_name)
 	if (ns)
 		ns->relative_default_ns = ns_id;
 
-	default_ns = ns_lookup(ns_get_default_id());
+	default_ns = ns_lookup(NS_DEFAULT);
 	if (!default_ns) {
 		flog_err(EC_ZEBRA_NS_NO_DEFAULT,
 			 "%s: failed to find default ns", __func__);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -342,15 +342,8 @@ static void show_nexthop_detail_helper(struct vty *vty,
 	}
 
 	if ((re->vrf_id != nexthop->vrf_id)
-	    && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)) {
-		struct vrf *vrf =
-			vrf_lookup_by_id(nexthop->vrf_id);
-
-		if (vrf)
-			vty_out(vty, "(vrf %s)", vrf->name);
-		else
-			vty_out(vty, "(vrf UNKNOWN)");
-	}
+	    && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE))
+		vty_out(vty, "(vrf %s)", vrf_id_to_name(nexthop->vrf_id));
 
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
 		vty_out(vty, " (duplicate nexthop removed)");
@@ -548,15 +541,9 @@ static void show_route_nexthop_helper(struct vty *vty,
 		break;
 	}
 
-	if ((re == NULL || (nexthop->vrf_id != re->vrf_id)) &&
-	    (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)) {
-		struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
-
-		if (vrf)
-			vty_out(vty, " (vrf %s)", vrf->name);
-		else
-			vty_out(vty, " (vrf UNKNOWN)");
-	}
+	if ((re == NULL || (nexthop->vrf_id != re->vrf_id))
+	    && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE))
+		vty_out(vty, " (vrf %s)", vrf_id_to_name(nexthop->vrf_id));
 
 	if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
 		vty_out(vty, " inactive");
@@ -620,7 +607,6 @@ static void show_nexthop_json_helper(json_object *json_nexthop,
 				     const struct route_entry *re)
 {
 	char buf[SRCDEST2STR_BUFFER];
-	struct vrf *vrf = NULL;
 	json_object *json_labels = NULL;
 	json_object *json_backups = NULL;
 	int i;
@@ -714,11 +700,10 @@ static void show_nexthop_json_helper(json_object *json_nexthop,
 	}
 
 	if ((nexthop->vrf_id != re->vrf_id)
-	    && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)) {
-		vrf = vrf_lookup_by_id(nexthop->vrf_id);
+	    && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE))
 		json_object_string_add(json_nexthop, "vrf",
-				       vrf->name);
-	}
+				       vrf_id_to_name(nexthop->vrf_id));
+
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
 		json_object_boolean_true_add(json_nexthop,
 					     "duplicate");
@@ -813,7 +798,6 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 	json_object *json_nexthop = NULL;
 	json_object *json_route = NULL;
 	time_t uptime;
-	const struct vrf *vrf = NULL;
 	const rib_dest_t *dest = rib_dest_from_rnode(rn);
 	const struct nexthop_group *nhg;
 	char up_str[MONOTIME_STRLEN];
@@ -848,11 +832,10 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 
 		if (re->vrf_id) {
 			json_object_int_add(json_route, "vrfId", re->vrf_id);
-			vrf = vrf_lookup_by_id(re->vrf_id);
 			json_object_string_add(json_route, "vrfName",
-					       vrf->name);
-
+					       vrf_id_to_name(re->vrf_id));
 		}
+
 		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED))
 			json_object_boolean_true_add(json_route, "selected");
 
@@ -1302,18 +1285,11 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe)
 {
 	struct nexthop *nexthop = NULL;
 	struct nhg_connected *rb_node_dep = NULL;
-	struct vrf *nhe_vrf = vrf_lookup_by_id(nhe->vrf_id);
 	struct nexthop_group *backup_nhg;
 
 	vty_out(vty, "ID: %u\n", nhe->id);
 	vty_out(vty, "     RefCnt: %d\n", nhe->refcnt);
-
-	if (nhe_vrf)
-		vty_out(vty, "     VRF: %s AFI: %s\n", nhe_vrf->name,
-			afi2str(nhe->afi));
-	else
-		vty_out(vty, "     VRF: UNKNOWN AFI: %s\n",
-			afi2str(nhe->afi));
+	vty_out(vty, "     VRF: %s\n", vrf_id_to_name(nhe->vrf_id));
 
 	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_UNHASHABLE))
 		vty_out(vty, "     Duplicate - from kernel not hashable\n");

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -830,11 +830,9 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 			json_object_int_add(json_route, "instance",
 					    re->instance);
 
-		if (re->vrf_id) {
-			json_object_int_add(json_route, "vrfId", re->vrf_id);
-			json_object_string_add(json_route, "vrfName",
-					       vrf_id_to_name(re->vrf_id));
-		}
+		json_object_int_add(json_route, "vrfId", re->vrf_id);
+		json_object_string_add(json_route, "vrfName",
+				       vrf_id_to_name(re->vrf_id));
 
 		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED))
 			json_object_boolean_true_add(json_route, "selected");


### PR DESCRIPTION
- cleanup messy output of show commands in non-default vrfs, multiple vrfs or multiple tables
- always specify vrf in json outputs (including main vrf)
- optimize vrf name resolution when vrf id is VRF_DEFAULT
- remove the framework that was developed to support a default vrf
  with a non-zero vrf id. The default vrf id MUST be 0.