### PR TITLE
ospf6d : Preparing for ospf6d VRF support.

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -72,7 +72,7 @@ static int ospf6_abr_nexthops_belong_to_area(struct ospf6_route *route,
 	struct ospf6_interface *oi;
 
 	oi = ospf6_interface_lookup_by_ifindex(
-		ospf6_route_get_first_nh_index(route));
+		ospf6_route_get_first_nh_index(route), area->ospf6->vrf_id);
 	if (oi && oi->area && oi->area == area)
 		return 1;
 	else

--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -88,7 +88,7 @@ extern void ospf6_asbr_redistribute_remove(int type, ifindex_t ifindex,
 extern int ospf6_redistribute_config_write(struct vty *vty);
 
 extern void ospf6_asbr_init(void);
-extern void ospf6_asbr_redistribute_reset(void);
+extern void ospf6_asbr_redistribute_reset(vrf_id_t vrf_id);
 extern void ospf6_asbr_terminate(void);
 extern void ospf6_asbr_send_externals_to_area(struct ospf6_area *);
 

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -89,8 +89,8 @@ void ospf6_bfd_reg_dereg_nbr(struct ospf6_neighbor *on, int command)
 	cbit = CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CBIT_ON);
 
 	bfd_peer_sendmsg(zclient, bfd_info, AF_INET6, &on->linklocal_addr,
-			 on->ospf6_if->linklocal_addr, ifp->name, 0, 0,
-			 cbit, command, 0, VRF_DEFAULT);
+			 on->ospf6_if->linklocal_addr, ifp->name, 0, 0, cbit,
+			 command, 0, ifp->vrf_id);
 
 	if (command == ZEBRA_BFD_DEST_DEREGISTER)
 		bfd_info_free((struct bfd_info **)&on->bfd_info);
@@ -143,7 +143,7 @@ static void ospf6_bfd_reg_dereg_all_nbr(struct ospf6_interface *oi, int command)
  */
 static int ospf6_bfd_nbr_replay(ZAPI_CALLBACK_ARGS)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 	struct listnode *node;
 	struct interface *ifp;
 	struct ospf6_interface *oi;

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -56,12 +56,13 @@ const char *const ospf6_interface_state_str[] = {
 	"None",    "Down", "Loopback", "Waiting", "PointToPoint",
 	"DROther", "BDR",  "DR",       NULL};
 
-struct ospf6_interface *ospf6_interface_lookup_by_ifindex(ifindex_t ifindex)
+struct ospf6_interface *ospf6_interface_lookup_by_ifindex(ifindex_t ifindex,
+							  vrf_id_t vrf_id)
 {
 	struct ospf6_interface *oi;
 	struct interface *ifp;
 
-	ifp = if_lookup_by_index(ifindex, VRF_DEFAULT);
+	ifp = if_lookup_by_index(ifindex, vrf_id);
 	if (ifp == NULL)
 		return (struct ospf6_interface *)NULL;
 
@@ -1022,7 +1023,7 @@ DEFUN (show_ipv6_ospf6_interface,
 	return CMD_SUCCESS;
 }
 
-static int ospf6_interface_show_traffic(struct vty *vty, uint32_t vrf_id,
+static int ospf6_interface_show_traffic(struct vty *vty,
 					struct interface *intf_ifp,
 					int display_once)
 {
@@ -1030,7 +1031,7 @@ static int ospf6_interface_show_traffic(struct vty *vty, uint32_t vrf_id,
 	struct vrf *vrf = NULL;
 	struct ospf6_interface *oi = NULL;
 
-	vrf = vrf_lookup_by_id(vrf_id);
+	vrf = vrf_lookup_by_id(intf_ifp->vrf_id);
 
 	if (!display_once) {
 		vty_out(vty, "\n");
@@ -1105,7 +1106,7 @@ DEFUN (show_ipv6_ospf6_interface_traffic,
 		}
 	}
 
-	ospf6_interface_show_traffic(vty, VRF_DEFAULT, ifp, display_once);
+	ospf6_interface_show_traffic(vty, ifp, display_once);
 
 
 	return CMD_SUCCESS;

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -170,7 +170,8 @@ extern const char *const ospf6_interface_state_str[];
 
 /* Function Prototypes */
 
-extern struct ospf6_interface *ospf6_interface_lookup_by_ifindex(ifindex_t);
+extern struct ospf6_interface *
+ospf6_interface_lookup_by_ifindex(ifindex_t, vrf_id_t vrf_id);
 extern struct ospf6_interface *ospf6_interface_create(struct interface *);
 extern void ospf6_interface_delete(struct ospf6_interface *);
 

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1569,8 +1569,8 @@ void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 				if (intra_prefix_lsa->ref_adv_router
 				     == oa->ospf6->router_id) {
 					ifp = if_lookup_prefix(
-							&old_route->prefix,
-							VRF_DEFAULT);
+						&old_route->prefix,
+						oa->ospf6->vrf_id);
 					if (ifp)
 						ospf6_route_add_nexthop(
 								old_route,
@@ -1714,7 +1714,8 @@ void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa)
 		memcpy(&route->path.ls_prefix, &ls_prefix,
 		       sizeof(struct prefix));
 		if (direct_connect) {
-			ifp = if_lookup_prefix(&route->prefix, VRF_DEFAULT);
+			ifp = if_lookup_prefix(&route->prefix,
+					       oa->ospf6->vrf_id);
 			if (ifp)
 				ospf6_route_add_nexthop(route, ifp->ifindex,
 							NULL);

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -79,15 +79,17 @@ struct thread_master *master;
 
 static void __attribute__((noreturn)) ospf6_exit(int status)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf;
 	struct interface *ifp;
 
 	frr_early_fini();
 
 	if (ospf6) {
+		vrf = vrf_lookup_by_id(ospf6->vrf_id);
 		ospf6_delete(ospf6);
 		ospf6 = NULL;
-	}
+	} else
+		vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	bfd_gbl_exit();
 

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1554,7 +1554,7 @@ int ospf6_receive(struct thread *thread)
 		return 0;
 	}
 
-	oi = ospf6_interface_lookup_by_ifindex(ifindex);
+	oi = ospf6_interface_lookup_by_ifindex(ifindex, ospf6->vrf_id);
 	if (oi == NULL || oi->area == NULL
 	    || CHECK_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE)) {
 		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_UNKNOWN, RECV))

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -307,14 +307,14 @@ void ospf6_route_zebra_copy_nexthops(struct ospf6_route *route,
 				inet_ntop(AF_INET6, &nh->address, buf,
 					  sizeof(buf));
 				ifname = ifindex2ifname(nh->ifindex,
-							VRF_DEFAULT);
+							ospf6->vrf_id);
 				zlog_debug("  nexthop: %s%%%.*s(%d)", buf,
 					   IFNAMSIZ, ifname, nh->ifindex);
 			}
 			if (i >= entries)
 				return;
 
-			nexthops[i].vrf_id = VRF_DEFAULT;
+			nexthops[i].vrf_id = ospf6->vrf_id;
 			nexthops[i].ifindex = nh->ifindex;
 			if (!IN6_IS_ADDR_UNSPECIFIED(&nh->address)) {
 				nexthops[i].gate.ipv6 = nh->address;
@@ -1042,6 +1042,11 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route)
 	struct listnode *node;
 	struct ospf6_nexthop *nh;
 
+	if (ospf6 == NULL) {
+		vty_out(vty, "OSPFv3 is not running\n");
+		return;
+	}
+
 	monotime(&now);
 	timersub(&now, &route->changed, &res);
 	timerstring(&res, duration, sizeof(duration));
@@ -1060,7 +1065,7 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route)
 	for (ALL_LIST_ELEMENTS_RO(route->nh_list, node, nh)) {
 		/* nexthop */
 		inet_ntop(AF_INET6, &nh->address, nexthop, sizeof(nexthop));
-		ifname = ifindex2ifname(nh->ifindex, VRF_DEFAULT);
+		ifname = ifindex2ifname(nh->ifindex, ospf6->vrf_id);
 
 		if (!i) {
 			vty_out(vty, "%c%1s %2s %-30s %-25s %6.*s %s\n",
@@ -1085,6 +1090,11 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route)
 	char duration[64];
 	struct listnode *node;
 	struct ospf6_nexthop *nh;
+
+	if (ospf6 == NULL) {
+		vty_out(vty, "OSPFv3 is not running\n");
+		return;
+	}
 
 	monotime(&now);
 
@@ -1160,7 +1170,7 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route)
 	for (ALL_LIST_ELEMENTS_RO(route->nh_list, node, nh)) {
 		/* nexthop */
 		inet_ntop(AF_INET6, &nh->address, nexthop, sizeof(nexthop));
-		ifname = ifindex2ifname(nh->ifindex, VRF_DEFAULT);
+		ifname = ifindex2ifname(nh->ifindex, ospf6->vrf_id);
 		vty_out(vty, "  %s %.*s\n", nexthop, IFNAMSIZ, ifname);
 	}
 	vty_out(vty, "\n");

--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -837,7 +837,7 @@ static uint8_t *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 				  int exact, size_t *var_len,
 				  WriteMethod **write_method)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf;
 	struct ospf6_lsa *lsa = NULL;
 	ifindex_t ifindex;
 	uint32_t area_id, id, instid, adv_router;
@@ -861,6 +861,7 @@ static uint8_t *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 	if (ospf6 == NULL)
 		return NULL;
 
+	vrf = vrf_lookup_by_id(ospf6->vrf_id);
 	/* Get variable length. */
 	offset = name + v->namelen;
 	offsetlen = *length - v->namelen;
@@ -926,7 +927,8 @@ static uint8_t *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 				return NULL;
 			lsa = ospf6_lsdb_lookup(type, id, adv_router, oa->lsdb);
 		} else if (v->magic & OSPFv3WWLINKTABLE) {
-			oi = ospf6_interface_lookup_by_ifindex(ifindex);
+			oi = ospf6_interface_lookup_by_ifindex(ifindex,
+							       ospf6->vrf_id);
 			if (!oi || oi->instance_id != instid)
 				return NULL;
 			lsa = ospf6_lsdb_lookup(type, id, adv_router, oi->lsdb);
@@ -963,7 +965,7 @@ static uint8_t *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 				if (!iif->ifindex)
 					continue;
 				oi = ospf6_interface_lookup_by_ifindex(
-					iif->ifindex);
+					iif->ifindex, iif->vrf_id);
 				if (!oi)
 					continue;
 				if (iif->ifindex < ifindex)
@@ -1038,7 +1040,7 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 			      int exact, size_t *var_len,
 			      WriteMethod **write_method)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf;
 	ifindex_t ifindex = 0;
 	unsigned int instid = 0;
 	struct ospf6_interface *oi = NULL;
@@ -1058,6 +1060,7 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 	if (ospf6 == NULL)
 		return NULL;
 
+	vrf = vrf_lookup_by_id(ospf6->vrf_id);
 	/* Get variable length. */
 	offset = name + v->namelen;
 	offsetlen = *length - v->namelen;
@@ -1080,7 +1083,7 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 	// offsetlen -= len;
 
 	if (exact) {
-		oi = ospf6_interface_lookup_by_ifindex(ifindex);
+		oi = ospf6_interface_lookup_by_ifindex(ifindex, ospf6->vrf_id);
 		if (!oi || oi->instance_id != instid)
 			return NULL;
 	} else {
@@ -1095,7 +1098,8 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 		for (ALL_LIST_ELEMENTS_RO(ifslist, i, iif)) {
 			if (!iif->ifindex)
 				continue;
-			oi = ospf6_interface_lookup_by_ifindex(iif->ifindex);
+			oi = ospf6_interface_lookup_by_ifindex(iif->ifindex,
+							       iif->vrf_id);
 			if (!oi)
 				continue;
 			if (iif->ifindex > ifindex
@@ -1191,7 +1195,7 @@ static uint8_t *ospfv3NbrEntry(struct variable *v, oid *name, size_t *length,
 			       int exact, size_t *var_len,
 			       WriteMethod **write_method)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf;
 	ifindex_t ifindex = 0;
 	unsigned int instid, rtrid;
 	struct ospf6_interface *oi = NULL;
@@ -1212,6 +1216,7 @@ static uint8_t *ospfv3NbrEntry(struct variable *v, oid *name, size_t *length,
 	if (ospf6 == NULL)
 		return NULL;
 
+	vrf = vrf_lookup_by_id(ospf6->vrf_id);
 	/* Get variable length. */
 	offset = name + v->namelen;
 	offsetlen = *length - v->namelen;
@@ -1241,7 +1246,7 @@ static uint8_t *ospfv3NbrEntry(struct variable *v, oid *name, size_t *length,
 	// offsetlen -= len;
 
 	if (exact) {
-		oi = ospf6_interface_lookup_by_ifindex(ifindex);
+		oi = ospf6_interface_lookup_by_ifindex(ifindex, ospf6->vrf_id);
 		if (!oi || oi->instance_id != instid)
 			return NULL;
 		on = ospf6_neighbor_lookup(rtrid, oi);
@@ -1257,7 +1262,8 @@ static uint8_t *ospfv3NbrEntry(struct variable *v, oid *name, size_t *length,
 		for (ALL_LIST_ELEMENTS_RO(ifslist, i, iif)) {
 			if (!iif->ifindex)
 				continue;
-			oi = ospf6_interface_lookup_by_ifindex(iif->ifindex);
+			oi = ospf6_interface_lookup_by_ifindex(iif->ifindex,
+							       iif->vrf_id);
 			if (!oi)
 				continue;
 			for (ALL_LIST_ELEMENTS_RO(oi->neighbor_list, j, on)) {

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -278,7 +278,7 @@ static void ospf6_nexthop_calc(struct ospf6_vertex *w, struct ospf6_vertex *v,
 		return;
 	}
 
-	oi = ospf6_interface_lookup_by_ifindex(ifindex);
+	oi = ospf6_interface_lookup_by_ifindex(ifindex, ospf6->vrf_id);
 	if (oi == NULL) {
 		if (IS_OSPF6_DEBUG_SPF(PROCESS))
 			zlog_debug("Can't find interface in SPF: ifindex %d",

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -232,7 +232,7 @@ static void ospf6_disable(struct ospf6 *o)
 			ospf6_area_disable(oa);
 
 		/* XXX: This also changes persistent settings */
-		ospf6_asbr_redistribute_reset();
+		ospf6_asbr_redistribute_reset(o->vrf_id);
 
 		ospf6_lsdb_remove_all(o->lsdb);
 		ospf6_route_remove_all(o->route_table);

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -75,25 +75,25 @@ static int ospf6_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 }
 
 /* redistribute function */
-void ospf6_zebra_redistribute(int type)
+void ospf6_zebra_redistribute(int type, vrf_id_t vrf_id)
 {
-	if (vrf_bitmap_check(zclient->redist[AFI_IP6][type], VRF_DEFAULT))
+	if (vrf_bitmap_check(zclient->redist[AFI_IP6][type], vrf_id))
 		return;
-	vrf_bitmap_set(zclient->redist[AFI_IP6][type], VRF_DEFAULT);
+	vrf_bitmap_set(zclient->redist[AFI_IP6][type], vrf_id);
 
 	if (zclient->sock > 0)
 		zebra_redistribute_send(ZEBRA_REDISTRIBUTE_ADD, zclient,
-					AFI_IP6, type, 0, VRF_DEFAULT);
+					AFI_IP6, type, 0, vrf_id);
 }
 
-void ospf6_zebra_no_redistribute(int type)
+void ospf6_zebra_no_redistribute(int type, vrf_id_t vrf_id)
 {
-	if (!vrf_bitmap_check(zclient->redist[AFI_IP6][type], VRF_DEFAULT))
+	if (!vrf_bitmap_check(zclient->redist[AFI_IP6][type], vrf_id))
 		return;
-	vrf_bitmap_unset(zclient->redist[AFI_IP6][type], VRF_DEFAULT);
+	vrf_bitmap_unset(zclient->redist[AFI_IP6][type], vrf_id);
 	if (zclient->sock > 0)
 		zebra_redistribute_send(ZEBRA_REDISTRIBUTE_DELETE, zclient,
-					AFI_IP6, type, 0, VRF_DEFAULT);
+					AFI_IP6, type, 0, vrf_id);
 }
 
 static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
@@ -279,7 +279,7 @@ static void ospf6_zebra_route_update(int type, struct ospf6_route *request)
 	dest = &request->prefix;
 
 	memset(&api, 0, sizeof(api));
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id = ospf6->vrf_id;
 	api.type = ZEBRA_ROUTE_OSPF6;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *dest;
@@ -330,7 +330,7 @@ void ospf6_zebra_add_discard(struct ospf6_route *request)
 
 	if (!CHECK_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
 		memset(&api, 0, sizeof(api));
-		api.vrf_id = VRF_DEFAULT;
+		api.vrf_id = ospf6->vrf_id;
 		api.type = ZEBRA_ROUTE_OSPF6;
 		api.safi = SAFI_UNICAST;
 		api.prefix = *dest;
@@ -363,7 +363,7 @@ void ospf6_zebra_delete_discard(struct ospf6_route *request)
 
 	if (CHECK_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
 		memset(&api, 0, sizeof(api));
-		api.vrf_id = VRF_DEFAULT;
+		api.vrf_id = ospf6->vrf_id;
 		api.type = ZEBRA_ROUTE_OSPF6;
 		api.safi = SAFI_UNICAST;
 		api.prefix = *dest;

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -45,10 +45,10 @@ extern struct zclient *zclient;
 extern void ospf6_zebra_route_update_add(struct ospf6_route *request);
 extern void ospf6_zebra_route_update_remove(struct ospf6_route *request);
 
-extern void ospf6_zebra_redistribute(int);
-extern void ospf6_zebra_no_redistribute(int);
-#define ospf6_zebra_is_redistribute(type)                                      \
-	vrf_bitmap_check(zclient->redist[AFI_IP6][type], VRF_DEFAULT)
+extern void ospf6_zebra_redistribute(int, vrf_id_t vrf_id);
+extern void ospf6_zebra_no_redistribute(int, vrf_id_t vrf_id);
+#define ospf6_zebra_is_redistribute(type, vrf_id)                              \
+	vrf_bitmap_check(zclient->redist[AFI_IP6][type], vrf_id)
 extern void ospf6_zebra_init(struct thread_master *);
 extern void ospf6_zebra_add_discard(struct ospf6_route *request);
 extern void ospf6_zebra_delete_discard(struct ospf6_route *request);


### PR DESCRIPTION
PR1 for #5539 

1. Removed the VRF_DEFAULT dependency from ospf6d.
2. The dependency on show command still exist
   will be fixed when the ospf6 master is available.

Co-authored-by: Harios <hari@niralnetworks.com>
Signed-off-by: Kaushik <kaushik@niralnetworks.com>