### PR TITLE
Global bgp update delay

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1642,16 +1642,91 @@ DEFUN (no_bgp_maxmed_onstartup,
 	return CMD_SUCCESS;
 }
 
-static int bgp_update_delay_config_vty(struct vty *vty, const char *delay,
-				       const char *wait)
+static int bgp_global_update_delay_config_vty(struct vty *vty,
+					      uint16_t update_delay,
+					      uint16_t establish_wait)
+{
+	struct listnode *node, *nnode;
+	struct bgp *bgp;
+	bool vrf_cfg = false;
+
+	/*
+	 * See if update-delay is set per-vrf and warn user to delete it
+	 * Note that we only need to check this if this is the first time
+	 * setting the global config.
+	 */
+	if (bm->v_update_delay == BGP_UPDATE_DELAY_DEF) {
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+			if (bgp->v_update_delay != BGP_UPDATE_DELAY_DEF) {
+				vty_out(vty,
+					"%% update-delay configuration found in vrf %s\n",
+					bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT
+						? VRF_DEFAULT_NAME
+						: bgp->name);
+				vrf_cfg = true;
+			}
+		}
+	}
+
+	if (vrf_cfg) {
+		vty_out(vty,
+			"%%Failed: global update-delay config not permitted\n");
+		return CMD_WARNING;
+	}
+
+	if (!establish_wait) { /* update-delay <delay> */
+		bm->v_update_delay = update_delay;
+		bm->v_establish_wait = bm->v_update_delay;
+	} else {
+		/* update-delay <delay> <establish-wait> */
+		if (update_delay < establish_wait) {
+			vty_out(vty,
+				"%%Failed: update-delay less than the establish-wait!\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+
+		bm->v_update_delay = update_delay;
+		bm->v_establish_wait = establish_wait;
+	}
+
+	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+		bgp->v_update_delay = bm->v_update_delay;
+		bgp->v_establish_wait = bm->v_establish_wait;
+	}
+
+	return CMD_SUCCESS;
+}
+
+static int bgp_global_update_delay_deconfig_vty(struct vty *vty)
+{
+	struct listnode *node, *nnode;
+	struct bgp *bgp;
+
+	bm->v_update_delay = BGP_UPDATE_DELAY_DEF;
+	bm->v_establish_wait = bm->v_update_delay;
+
+	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+		bgp->v_update_delay = bm->v_update_delay;
+		bgp->v_establish_wait = bm->v_establish_wait;
+	}
+
+	return CMD_SUCCESS;
+}
+
+static int bgp_update_delay_config_vty(struct vty *vty, uint16_t update_delay,
+				       uint16_t establish_wait)
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	uint16_t update_delay;
-	uint16_t establish_wait;
 
-	update_delay = strtoul(delay, NULL, 10);
+	/* if configured globally, per-instance config is not allowed */
+	if (bm->v_update_delay) {
+		vty_out(vty,
+			"%%Failed: per-vrf update-delay config not permitted with global update-delay\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
-	if (!wait) /* update-delay <delay> */
+
+	if (!establish_wait) /* update-delay <delay> */
 	{
 		bgp->v_update_delay = update_delay;
 		bgp->v_establish_wait = bgp->v_update_delay;
@@ -1659,7 +1734,6 @@ static int bgp_update_delay_config_vty(struct vty *vty, const char *delay,
 	}
 
 	/* update-delay <delay> <establish-wait> */
-	establish_wait = atoi(wait);
 	if (update_delay < establish_wait) {
 		vty_out(vty,
 			"%%Failed: update-delay less than the establish-wait!\n");
@@ -1676,6 +1750,12 @@ static int bgp_update_delay_deconfig_vty(struct vty *vty)
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
+	/* If configured globally, cannot remove from one bgp instance */
+	if (bm->v_update_delay) {
+		vty_out(vty,
+			"%%Failed: bgp update-delay configured globally. Delete per-vrf not permitted\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 	bgp->v_update_delay = BGP_UPDATE_DELAY_DEF;
 	bgp->v_establish_wait = bgp->v_update_delay;
 
@@ -1684,7 +1764,8 @@ static int bgp_update_delay_deconfig_vty(struct vty *vty)
 
 void bgp_config_write_update_delay(struct vty *vty, struct bgp *bgp)
 {
-	if (bgp->v_update_delay != BGP_UPDATE_DELAY_DEF) {
+	/* If configured globally, no need to display per-instance value */
+	if (bgp->v_update_delay != bm->v_update_delay) {
 		vty_out(vty, " update-delay %d", bgp->v_update_delay);
 		if (bgp->v_update_delay != bgp->v_establish_wait)
 			vty_out(vty, " %d", bgp->v_establish_wait);
@@ -1692,39 +1773,51 @@ void bgp_config_write_update_delay(struct vty *vty, struct bgp *bgp)
 	}
 }
 
-
-/* Update-delay configuration */
-DEFUN (bgp_update_delay,
-       bgp_update_delay_cmd,
-       "update-delay (0-3600)",
-       "Force initial delay for best-path and updates\n"
-       "Seconds\n")
+/* Global update-delay configuration */
+DEFPY (bgp_global_update_delay,
+       bgp_global_update_delay_cmd,
+       "bgp update-delay (0-3600)$delay [(1-3600)$wait]",
+       BGP_STR
+       "Force initial delay for best-path and updates for all bgp instances\n"
+       "Max delay in seconds\n"
+       "Establish wait in seconds\n")
 {
-	int idx_number = 1;
-	return bgp_update_delay_config_vty(vty, argv[idx_number]->arg, NULL);
+	return bgp_global_update_delay_config_vty(vty, delay, wait);
 }
 
-DEFUN (bgp_update_delay_establish_wait,
-       bgp_update_delay_establish_wait_cmd,
-       "update-delay (0-3600) (1-3600)",
+/* Global update-delay deconfiguration */
+DEFPY (no_bgp_global_update_delay,
+       no_bgp_global_update_delay_cmd,
+       "no bgp update-delay [(0-3600) [(1-3600)]]",
+       NO_STR
+       BGP_STR
        "Force initial delay for best-path and updates\n"
-       "Seconds\n"
-       "Seconds\n")
+       "Max delay in seconds\n"
+       "Establish wait in seconds\n")
 {
-	int idx_number = 1;
-	int idx_number_2 = 2;
-	return bgp_update_delay_config_vty(vty, argv[idx_number]->arg,
-					   argv[idx_number_2]->arg);
+	return bgp_global_update_delay_deconfig_vty(vty);
+}
+
+/* Update-delay configuration */
+
+DEFPY (bgp_update_delay,
+       bgp_update_delay_cmd,
+       "update-delay (0-3600)$delay [(1-3600)$wait]",
+       "Force initial delay for best-path and updates\n"
+       "Max delay in seconds\n"
+       "Establish wait in seconds\n")
+{
+	return bgp_update_delay_config_vty(vty, delay, wait);
 }
 
 /* Update-delay deconfiguration */
-DEFUN (no_bgp_update_delay,
+DEFPY (no_bgp_update_delay,
        no_bgp_update_delay_cmd,
        "no update-delay [(0-3600) [(1-3600)]]",
        NO_STR
        "Force initial delay for best-path and updates\n"
-       "Seconds\n"
-       "Seconds\n")
+       "Max delay in seconds\n"
+       "Establish wait in seconds\n")
 {
 	return bgp_update_delay_deconfig_vty(vty);
 }
@@ -15367,6 +15460,13 @@ int bgp_config_write(struct vty *vty)
 		vty_out(vty, "bgp route-map delay-timer %u\n",
 			bm->rmap_update_timer);
 
+	if (bm->v_update_delay != BGP_UPDATE_DELAY_DEF) {
+		vty_out(vty, "bgp update-delay %d", bm->v_update_delay);
+		if (bm->v_update_delay != bm->v_establish_wait)
+			vty_out(vty, " %d", bm->v_establish_wait);
+		vty_out(vty, "\n");
+	}
+
 	/* BGP configuration. */
 	for (ALL_LIST_ELEMENTS(bm->bgp, mnode, mnnode, bgp)) {
 
@@ -15881,6 +15981,10 @@ void bgp_vty_init(void)
 	install_element(CONFIG_NODE, &bgp_set_route_map_delay_timer_cmd);
 	install_element(CONFIG_NODE, &no_bgp_set_route_map_delay_timer_cmd);
 
+	/* global bgp update-delay command */
+	install_element(CONFIG_NODE, &bgp_global_update_delay_cmd);
+	install_element(CONFIG_NODE, &no_bgp_global_update_delay_cmd);
+
 	/* Dummy commands (Currently not supported) */
 	install_element(BGP_NODE, &no_synchronization_cmd);
 	install_element(BGP_NODE, &no_auto_summary_cmd);
@@ -15921,7 +16025,6 @@ void bgp_vty_init(void)
 	/* bgp update-delay command */
 	install_element(BGP_NODE, &bgp_update_delay_cmd);
 	install_element(BGP_NODE, &no_bgp_update_delay_cmd);
-	install_element(BGP_NODE, &bgp_update_delay_establish_wait_cmd);
 
 	install_element(BGP_NODE, &bgp_wpkt_quanta_cmd);
 	install_element(BGP_NODE, &bgp_rpkt_quanta_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2966,7 +2966,8 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 		bgp->gr_info[afi][safi].route_list = list_new();
 	}
 
-	bgp->v_update_delay = BGP_UPDATE_DELAY_DEF;
+	bgp->v_update_delay = bm->v_update_delay;
+	bgp->v_establish_wait = bm->v_establish_wait;
 	bgp->default_local_pref = BGP_DEFAULT_LOCAL_PREF;
 	bgp->default_subgroup_pkt_queue_max =
 		BGP_DEFAULT_SUBGROUP_PKT_QUEUE_MAX;
@@ -7000,6 +7001,8 @@ void bgp_master_init(struct thread_master *master, const int buffer_size)
 	bm->start_time = bgp_clock();
 	bm->t_rmap_update = NULL;
 	bm->rmap_update_timer = RMAP_DEFAULT_UPDATE_TIMER;
+	bm->v_update_delay = BGP_UPDATE_DELAY_DEF;
+	bm->v_establish_wait = BGP_UPDATE_DELAY_DEF;
 	bm->terminating = false;
 	bm->socket_buffer = buffer_size;
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -169,6 +169,10 @@ struct bgp_master {
 	/* EVPN multihoming */
 	struct bgp_evpn_mh_info *mh_info;
 
+	/* global update-delay timer values */
+	uint16_t v_update_delay;
+	uint16_t v_establish_wait;
+
 	bool terminating;	/* global flag that sigint terminate seen */
 	QOBJ_FIELDS
 };

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1103,6 +1103,41 @@ Redistribution
 
    Redistribute VNC direct (not via zebra) routes to BGP process.
 
+.. index:: bgp update-delay MAX-DELAY
+.. clicmd:: bgp update-delay MAX-DELAY
+
+.. index:: bgp update-delay MAX-DELAY ESTABLISH-WAIT
+.. clicmd:: bgp update-delay MAX-DELAY ESTABLISH-WAIT
+
+   This feature is used to enable read-only mode on BGP process restart or when
+   a BGP process is cleared using 'clear ip bgp \*'. Note that this command is
+   configured at the global level and applies to all bgp instances/vrfs.  It
+   cannot be used at the same time as the "update-delay" command described below,
+   which is entered in each bgp instance/vrf desired to delay update installation
+   and advertisements. The global and per-vrf approaches to defining update-delay
+   are mutually exclusive.
+
+   When applicable, read-only mode would begin as soon as the first peer reaches
+   Established status and a timer for max-delay seconds is started.  During this
+   mode BGP doesn't run any best-path or generate any updates to its peers. This
+   mode continues until:
+
+   1. All the configured peers, except the shutdown peers, have sent explicit EOR
+      (End-Of-RIB) or an implicit-EOR. The first keep-alive after BGP has reached
+      Established is considered an implicit-EOR.
+      If the establish-wait optional value is given, then BGP will wait for
+      peers to reach established from the beginning of the update-delay till the
+      establish-wait period is over, i.e. the minimum set of established peers for
+      which EOR is expected would be peers established during the establish-wait
+      window, not necessarily all the configured neighbors.
+   2. max-delay period is over.
+
+   On hitting any of the above two conditions, BGP resumes the decision process
+   and generates updates to its peers.
+
+   Default max-delay is 0, i.e. the feature is off by default.
+
+
 .. index:: update-delay MAX-DELAY
 .. clicmd:: update-delay MAX-DELAY
 
@@ -1110,12 +1145,17 @@ Redistribution
 .. clicmd:: update-delay MAX-DELAY ESTABLISH-WAIT
 
    This feature is used to enable read-only mode on BGP process restart or when
-   BGP process is cleared using 'clear ip bgp \*'. When applicable, read-only
-   mode would begin as soon as the first peer reaches Established status and a
-   timer for max-delay seconds is started.
+   a BGP process is cleared using 'clear ip bgp \*'.  Note that this command is
+   configured under the specific bgp instance/vrf that the feaure is enabled for.
+   It cannot be used at the same time as the global "bgp update-delay" described
+   above, which is entered at the global level and applies to all bgp instances.
+   The global and per-vrf approaches to defining update-delay are mutually
+   exclusive.
 
-   During this mode BGP doesn't run any best-path or generate any updates to its
-   peers. This mode continues until:
+   When applicable, read-only mode would begin as soon as the first peer reaches
+   Established status and a timer for max-delay seconds is started.  During this
+   mode BGP doesn't run any best-path or generate any updates to its peers. This
+   mode continues until:
 
    1. All the configured peers, except the shutdown peers, have sent explicit EOR
       (End-Of-RIB) or an implicit-EOR. The first keep-alive after BGP has reached

--- a/tests/topotests/bgp_update_delay/r1/bgpd.conf
+++ b/tests/topotests/bgp_update_delay/r1/bgpd.conf
@@ -1,0 +1,10 @@
+! exit1
+router bgp 65001
+  no bgp ebgp-requires-policy
+  neighbor 192.168.255.1 remote-as 65002
+  neighbor 192.168.255.1 timers connect 10
+  address-family ipv4 unicast
+    redistribute connected
+  exit-address-family
+  !
+!

--- a/tests/topotests/bgp_update_delay/r1/zebra.conf
+++ b/tests/topotests/bgp_update_delay/r1/zebra.conf
@@ -1,0 +1,9 @@
+! exit1
+interface lo
+ ip address 172.16.255.254/32
+!
+interface r1-eth0
+ ip address 192.168.255.2/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_update_delay/r2/bgpd.conf
+++ b/tests/topotests/bgp_update_delay/r2/bgpd.conf
@@ -1,0 +1,18 @@
+! spine
+router bgp 65002
+  no bgp ebgp-requires-policy
+  timers bgp 3 9
+  neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.254.2 remote-as 65003
+  neighbor 192.168.253.2 remote-as 65004
+  neighbor 192.168.255.2 timers connect 10
+  neighbor 192.168.254.2 timers connect 10
+  neighbor 192.168.253.2 timers connect 10
+!
+ router bgp 65002 vrf vrf1
+  no bgp ebgp-requires-policy
+  timers bgp 3 9
+  neighbor 192.168.252.2 remote-as 65005
+  neighbor 192.168.252.2 timers connect 10
+  !
+!

--- a/tests/topotests/bgp_update_delay/r2/zebra.conf
+++ b/tests/topotests/bgp_update_delay/r2/zebra.conf
@@ -1,0 +1,20 @@
+! spine
+interface r2-eth0
+ ip address 192.168.255.1/30
+!
+interface r2-eth1
+ ip address 192.168.254.1/30
+!
+interface r2-eth2
+ ip address 192.168.253.1/30
+!
+interface r2-eth3
+ ip address 192.168.252.1/30
+ vrf vrf1
+!
+auto vrf1
+iface vrf1
+  vrf-table auto
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_update_delay/r3/bgpd.conf
+++ b/tests/topotests/bgp_update_delay/r3/bgpd.conf
@@ -1,0 +1,10 @@
+! exit2
+router bgp 65003
+  no bgp ebgp-requires-policy
+  timers bgp 3 9
+  neighbor 192.168.254.1 remote-as 65002
+  neighbor 192.168.254.1 timers connect 10
+  address-family ipv4 unicast
+    redistribute connected
+  !
+!

--- a/tests/topotests/bgp_update_delay/r3/zebra.conf
+++ b/tests/topotests/bgp_update_delay/r3/zebra.conf
@@ -1,0 +1,9 @@
+! exit2
+interface lo
+ ip address 172.16.254.254/32
+!
+interface r3-eth0
+ ip address 192.168.254.2/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_update_delay/r4/bgpd.conf
+++ b/tests/topotests/bgp_update_delay/r4/bgpd.conf
@@ -1,0 +1,11 @@
+! exit2
+router bgp 65004
+  no bgp ebgp-requires-policy
+  timers bgp 3 9
+  neighbor 192.168.253.1 remote-as 65002
+  neighbor 192.168.253.1 timers connect 10
+  address-family ipv4 unicast
+    redistribute connected
+  exit-address-family
+  !
+!

--- a/tests/topotests/bgp_update_delay/r4/zebra.conf
+++ b/tests/topotests/bgp_update_delay/r4/zebra.conf
@@ -1,0 +1,9 @@
+! exit2
+interface lo
+ ip address 172.16.253.254/32
+!
+interface r4-eth0
+ ip address 192.168.253.2/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_update_delay/r5/bgpd.conf
+++ b/tests/topotests/bgp_update_delay/r5/bgpd.conf
@@ -1,0 +1,11 @@
+! exit1
+router bgp 65005
+  no bgp ebgp-requires-policy
+  timers bgp 3 9
+  neighbor 192.168.252.1 remote-as 65002
+  neighbor 192.168.252.1 timers connect 10
+  address-family ipv4 unicast
+    redistribute connected
+  exit-address-family
+  !
+!

--- a/tests/topotests/bgp_update_delay/r5/zebra.conf
+++ b/tests/topotests/bgp_update_delay/r5/zebra.conf
@@ -1,0 +1,9 @@
+! exit1
+interface lo
+ ip address 172.16.252.254/32
+!
+interface r1-eth0
+ ip address 192.168.252.2/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_update_delay/test_bgp_update_delay.py
+++ b/tests/topotests/bgp_update_delay/test_bgp_update_delay.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_update_delay.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2019 by
+# Don Slice <dslice@nvidia.com>
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+Test the ability to define update-delay to delay bestpath, rib install
+and advertisement to peers when frr is started, restarted or "clear ip
+bgp *" is performed. Test both the vrf-specific and global configuration
+and operation.
+
+r1
+|
+r2----r3
+| \
+|  \
+r5  r4
+
+
+r2 is UUT and peers with r1, r3, and r4 in default bgp instance.
+r2 peers with r5 in vrf vrf1.
+
+Check r2 initial convergence in default table
+Define update-delay with max-delay in the default bgp instance on r2
+Shutdown peering on r1 toward r2 so that delay timers can be exercised
+Clear bgp neighbors on r2 and then check for the 'in progress' indicator
+Check that r2 only installs route learned from r4 after the max-delay timer expires
+Define update-delay with max-delay and estabish-wait and check json output showing set
+Clear neighbors on r2 and check that r3 installs route from r4 after establish-wait time
+Remove update-delay timer on r2 to verify that it goes back to normal behavior
+Clear neighbors on r2 and check that route install time on r2 does not delay
+Define global bgp update-delay with max-delay and establish-wait on r2
+Check that r2 default instance and vrf1 have the max-delay and establish set
+Clear neighbors on r2 and check route-install time is after the establish-wait timer
+
+Note that the keepalive/hold times were changed to 3/9 and the connect retry timer
+to 10 to improve the odds the convergence timing in this test case is useful in the
+event of packet loss.
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from mininet.topo import Topo
+
+
+class TemplateTopo(Topo):
+    def build(self, *_args, **_opts):
+        tgen = get_topogen(self)
+
+        for routern in range(1, 6):
+            tgen.add_router("r{}".format(routern))
+
+        switch = tgen.add_switch("s1")
+        switch.add_link(tgen.gears["r1"])
+        switch.add_link(tgen.gears["r2"])
+
+        switch = tgen.add_switch("s2")
+        switch.add_link(tgen.gears["r2"])
+        switch.add_link(tgen.gears["r3"])
+
+        switch = tgen.add_switch("s3")
+        switch.add_link(tgen.gears["r2"])
+        switch.add_link(tgen.gears["r4"])
+
+        switch = tgen.add_switch("s4")
+        switch.add_link(tgen.gears["r2"])
+        switch.add_link(tgen.gears["r5"])
+
+
+def setup_module(mod):
+    tgen = Topogen(TemplateTopo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_update_delay():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router1 = tgen.gears["r1"]
+    router2 = tgen.gears["r2"]
+    router3 = tgen.gears["r3"]
+
+    # initial convergence without update-delay defined
+    def _bgp_converge(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp neighbor 192.168.255.2 json"))
+        expected = {
+            "192.168.255.2": {
+                "bgpState": "Established",
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_update_delay(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp sum json"))
+        expected = {"ipv4Unicast": {"updateDelayLimit": 20}}
+
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_update_delay_in_progress(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp sum json"))
+        expected = {"ipv4Unicast": {"updateDelayInProgress":True}}
+
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_route_install(router):
+        output = json.loads(router.vtysh_cmd("show ip route 172.16.253.254/32 json"))
+        expected = {"172.16.253.254/32": [ {"protocol": "bgp"}]}
+
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_update_delay_and_wait(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp sum json"))
+        expected = {
+                "ipv4Unicast": {
+                    "updateDelayLimit": 20,
+                    "updateDelayEstablishWait": 10}}
+
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_update_delay(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp sum json"))
+        expected = {"ipv4Unicast": {"updateDelayLimit": 20}}
+
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_vrf_update_delay_and_wait(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp vrf vrf1 sum json"))
+        expected = {
+                "ipv4Unicast": {
+                    "updateDelayLimit": 20,
+                    "updateDelayEstablishWait": 10}}
+
+
+        return topotest.json_cmp(output, expected)
+
+
+    # Check r2 initial convergence in default table
+    test_func = functools.partial(_bgp_converge, router2)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, 'Failed bgp convergence in "{}"'.format(router2)
+
+    # Define update-delay with max-delay in the default bgp instance on r2
+    router2.vtysh_cmd(
+        """
+          configure terminal
+            router bgp 65002
+              update-delay 20
+        """
+        )
+
+    # Shutdown peering on r1 toward r2 so that delay timers can be exercised
+    router1.vtysh_cmd(
+        """
+          configure terminal
+            router bgp 65001
+              neighbor 192.168.255.1 shut
+        """
+        )
+
+    # Clear bgp neighbors on r2 and then check for the 'in progress' indicator
+    router2.vtysh_cmd("""clear ip bgp *""")
+
+    test_func = functools.partial(_bgp_check_update_delay_in_progress, router2)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, 'Failed to set update-delay max-delay timer "{}"'.format(router2)
+
+    # Check that r2 only installs route learned from r4 after the max-delay timer expires
+    test_func = functools.partial(_bgp_check_route_install, router2)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, 'Failed to install route after update-delay "{}"'.format(router2)
+
+    # Define update-delay with max-delay and estabish-wait and check json output showing set
+    router2.vtysh_cmd(
+        """
+          configure terminal
+            router bgp 65002
+              update-delay 20 10
+        """
+        )
+
+    test_func = functools.partial(_bgp_check_update_delay_and_wait, router2)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, 'Failed to set max-delay and establish-weight timers in "{}"'.format(router2)
+
+    # Define update-delay with max-delay and estabish-wait and check json output showing set
+    router2.vtysh_cmd("""clear ip bgp *""")
+
+    test_func = functools.partial(_bgp_check_route_install, router3)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, 'Failed to installed advertised route after establish-wait timer espired "{}"'.format(router2)
+
+    # Remove update-delay timer on r2 to verify that it goes back to normal behavior
+    router2.vtysh_cmd(
+        """
+          configure terminal
+            router bgp 65002
+              no update-delay
+        """
+        )
+
+    # Clear neighbors on r2 and check that route install time on r2 does not delay
+    router2.vtysh_cmd("""clear ip bgp *""")
+
+    test_func = functools.partial(_bgp_check_route_install, router2)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, 'Failed to remove update-delay delay timing "{}"'.format(router2)
+
+    # Define global bgp update-delay with max-delay and establish-wait on r2
+    router2.vtysh_cmd(
+        """
+          configure terminal
+            bgp update-delay 20 10
+        """
+        )
+
+    # Check that r2 default instance and vrf1 have the max-delay and establish set
+    test_func = functools.partial(_bgp_check_update_delay_and_wait, router2)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, 'Failed to set update-delay in default instance "{}"'.format(router2)
+
+    test_func = functools.partial(_bgp_check_vrf_update_delay_and_wait, router2)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, 'Failed to set update-delay in vrf1 "{}"'.format(router2)
+
+    # Clear neighbors on r2 and check route-install time is after the establish-wait timer
+    router2.vtysh_cmd("""clear ip bgp *""")
+
+    test_func = functools.partial(_bgp_check_route_install, router3)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, 'Failed to installed advertised route after establish-wait timer espired "{}"'.format(router2)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Adds global setting of bgp update-delay (as requested by customers) and a topotest to exercise it. Note that we are not permitting setting both global and per-instance update-delay values at the same time.  You can still set per-instance if you need different timers/etc. but this disallows also setting globally.