### PR TITLE
isisd: add support for SR Anycast-SIDs

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -1561,7 +1561,7 @@ DEFPY_YANG (isis_sr_prefix_sid,
        "segment-routing prefix\
           <A.B.C.D/M|X:X::X:X/M>$prefix\
 	  <absolute$sid_type (16-1048575)$sid_value|index$sid_type (0-65535)$sid_value>\
-	  [<no-php-flag|explicit-null>$lh_behavior]",
+	  [<no-php-flag|explicit-null>$lh_behavior] [n-flag-unset$n_flag_unset]",
        SR_STR
        "Prefix SID\n"
        "IPv4 Prefix\n"
@@ -1571,7 +1571,8 @@ DEFPY_YANG (isis_sr_prefix_sid,
        "Specify the index of Prefix Segement ID\n"
        "The Prefix Segment ID index\n"
        "Don't request Penultimate Hop Popping (PHP)\n"
-       "Upstream neighbor must replace prefix-sid with explicit null label\n")
+       "Upstream neighbor must replace prefix-sid with explicit null label\n"
+       "Not a node SID\n")
 {
 	nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 	nb_cli_enqueue_change(vty, "./sid-value-type", NB_OP_MODIFY, sid_type);
@@ -1589,6 +1590,8 @@ DEFPY_YANG (isis_sr_prefix_sid,
 	} else
 		nb_cli_enqueue_change(vty, "./last-hop-behavior", NB_OP_MODIFY,
 				      NULL);
+	nb_cli_enqueue_change(vty, "./n-flag-unset", NB_OP_MODIFY,
+			      n_flag_unset ? "true" : "false");
 
 	return nb_cli_apply_changes(
 		vty, "./segment-routing/prefix-sid-map/prefix-sid[prefix='%s']",
@@ -1598,7 +1601,8 @@ DEFPY_YANG (isis_sr_prefix_sid,
 DEFPY_YANG (no_isis_sr_prefix_sid,
        no_isis_sr_prefix_sid_cmd,
        "no segment-routing prefix <A.B.C.D/M|X:X::X:X/M>$prefix\
-         [<absolute$sid_type (16-1048575)|index (0-65535)> [<no-php-flag|explicit-null>]]",
+         [<absolute$sid_type (16-1048575)|index (0-65535)> [<no-php-flag|explicit-null>]]\
+	 [n-flag-unset]",
        NO_STR
        SR_STR
        "Prefix SID\n"
@@ -1609,7 +1613,8 @@ DEFPY_YANG (no_isis_sr_prefix_sid,
        "Specify the index of Prefix Segement ID\n"
        "The Prefix Segment ID index\n"
        "Don't request Penultimate Hop Popping (PHP)\n"
-       "Upstream neighbor must replace prefix-sid with explicit null label\n")
+       "Upstream neighbor must replace prefix-sid with explicit null label\n"
+       "Not a node SID\n")
 {
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
@@ -1625,11 +1630,13 @@ void cli_show_isis_prefix_sid(struct vty *vty, struct lyd_node *dnode,
 	const char *lh_behavior;
 	const char *sid_value_type;
 	const char *sid_value;
+	bool n_flag_unset;
 
 	prefix = yang_dnode_get_string(dnode, "./prefix");
 	lh_behavior = yang_dnode_get_string(dnode, "./last-hop-behavior");
 	sid_value_type = yang_dnode_get_string(dnode, "./sid-value-type");
 	sid_value = yang_dnode_get_string(dnode, "./sid-value");
+	n_flag_unset = yang_dnode_get_bool(dnode, "./n-flag-unset");
 
 	vty_out(vty, " segment-routing prefix %s", prefix);
 	if (strmatch(sid_value_type, "absolute"))
@@ -1641,6 +1648,8 @@ void cli_show_isis_prefix_sid(struct vty *vty, struct lyd_node *dnode,
 		vty_out(vty, " no-php-flag");
 	else if (strmatch(lh_behavior, "explicit-null"))
 		vty_out(vty, " explicit-null");
+	if (n_flag_unset)
+		vty_out(vty, " n-flag-unset");
 	vty_out(vty, "\n");
 }
 

--- a/isisd/isis_nb.c
+++ b/isisd/isis_nb.c
@@ -538,6 +538,12 @@ const struct frr_yang_module_info frr_isisd_info = {
 			},
 		},
 		{
+			.xpath = "/frr-isisd:isis/instance/segment-routing/prefix-sid-map/prefix-sid/n-flag-unset",
+			.cbs = {
+				.modify = isis_instance_segment_routing_prefix_sid_map_prefix_sid_n_flag_unset_modify,
+			}
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis",
 			.cbs = {
 				.create = lib_interface_isis_create,

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -205,6 +205,8 @@ int isis_instance_segment_routing_prefix_sid_map_prefix_sid_sid_value_modify(
 	struct nb_cb_modify_args *args);
 int isis_instance_segment_routing_prefix_sid_map_prefix_sid_last_hop_behavior_modify(
 	struct nb_cb_modify_args *args);
+int isis_instance_segment_routing_prefix_sid_map_prefix_sid_n_flag_unset_modify(
+	struct nb_cb_modify_args *args);
 int lib_interface_isis_csnp_interval_level_1_modify(
 	struct nb_cb_modify_args *args);
 int lib_interface_isis_csnp_interval_level_2_modify(

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -1824,6 +1824,23 @@ int isis_instance_segment_routing_prefix_sid_map_prefix_sid_last_hop_behavior_mo
 }
 
 /*
+ * XPath: /frr-isisd:isis/instance/segment-routing/prefix-sid-map/prefix-sid/n-flag-unset
+ */
+int isis_instance_segment_routing_prefix_sid_map_prefix_sid_n_flag_unset_modify(
+	struct nb_cb_modify_args *args)
+{
+	struct sr_prefix_cfg *pcfg;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	pcfg = nb_running_get_entry(args->dnode, NULL, true);
+	pcfg->n_flag_unset = yang_dnode_get_bool(args->dnode, NULL);
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis
  */
 int lib_interface_isis_create(struct nb_cb_create_args *args)

--- a/isisd/isis_sr.h
+++ b/isisd/isis_sr.h
@@ -127,6 +127,9 @@ struct sr_prefix {
 	struct srdb_node_prefix_item node_entry;
 	struct srdb_area_prefix_item area_entry;
 
+	/* IS-IS level: ISIS_LEVEL1 or ISIS_LEVEL2. */
+	int level;
+
 	/* IP prefix. */
 	struct prefix prefix;
 
@@ -149,11 +152,14 @@ struct sr_prefix {
 		} remote;
 	} u;
 
-	/* Backpointer to Segment Routing node. */
-	struct sr_node *srn;
+	/* Backpointer to IS-IS area. */
+	struct isis_area *area;
 
 	/* SR-Prefix State used while the LSPDB is being parsed. */
 	enum srdb_state state;
+
+	/* Reference counter (for Anycast-SIDs). */
+	unsigned int refcnt;
 };
 
 /* Segment Routing node. */
@@ -208,6 +214,9 @@ struct sr_prefix_cfg {
 
 	/* SID value type. */
 	enum sr_sid_value_type sid_type;
+
+	/* Indicates whether this is a node SID or not. */
+	bool n_flag_unset;
 
 	/* SID last hop behavior. */
 	enum sr_last_hop_behavior last_hop_behavior;

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -1308,6 +1308,12 @@ module frr-isisd {
               description
                 "Configure last hop behavior.";
             }
+            leaf n-flag-unset {
+              type boolean;
+              default "false";
+              description
+                "Not a node SID";
+            }
           }
         }
       }


### PR DESCRIPTION
Add the "n-flag-unset" option to the "prefix-sid" command to allow the
configuration of Anycast-SIDs. Also, make the required code changes
to support multiple nodes advertising the same Prefix-SID.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>