### PR TITLE
tests: Speed up bgp_features topotests by a lot

### DIFF
--- a/tests/topotests/bgp_features/r1/bgpd.conf
+++ b/tests/topotests/bgp_features/r1/bgpd.conf
@@ -3,14 +3,18 @@ hostname r1
 log file bgpd.log
 !
 router bgp 65000
+ timers bgp 3 10
+ coalesce-time 0
  bgp router-id 192.168.0.1
  bgp log-neighbor-changes
  no bgp ebgp-requires-policy
  neighbor 192.168.0.2 remote-as 65000
  neighbor 192.168.0.2 description Router R2 (iBGP)
  neighbor 192.168.0.2 update-source lo
+ neighbor 192.168.0.2 timers connect 5
  neighbor 192.168.101.2 remote-as 65100
  neighbor 192.168.101.2 description Router R4 (eBGP AS 65100)
+ neighbor 192.168.101.2 timers connect 5
  !
  address-family ipv4 unicast
   network 192.168.0.0/24

--- a/tests/topotests/bgp_features/r1/ospfd.conf
+++ b/tests/topotests/bgp_features/r1/ospfd.conf
@@ -7,6 +7,17 @@ router ospf
  ospf router-id 192.168.0.1
  log-adjacency-changes
  network 192.168.0.0/20 area 0.0.0.0
+ timers throttle spf 0 0 0
+ timers lsa min-arrival 10
+ timers throttle lsa all 0
+ refresh timer 10
 !
 line vty
+interface r1-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+interface r1-eth2
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
 !

--- a/tests/topotests/bgp_features/r2/bgpd.conf
+++ b/tests/topotests/bgp_features/r2/bgpd.conf
@@ -4,13 +4,17 @@ log file bgpd.log
 !
 router bgp 65000
  bgp router-id 192.168.0.2
+ timers bgp 3 10
+ coalesce-time 0
  bgp log-neighbor-changes
  no bgp ebgp-requires-policy
  neighbor 192.168.0.1 remote-as 65000
  neighbor 192.168.0.1 description Router R1 (iBGP)
  neighbor 192.168.0.1 update-source lo
+ neighbor 192.168.0.1 timers connect 5
  neighbor 192.168.201.2 remote-as 65200
  neighbor 192.168.201.2 description Router R5 (eBGP AS 65200)
+ neighbor 192.168.201.2 timers connect 5
  !
  address-family ipv4 unicast
   network 192.168.0.0/24

--- a/tests/topotests/bgp_features/r2/ospfd.conf
+++ b/tests/topotests/bgp_features/r2/ospfd.conf
@@ -7,6 +7,17 @@ router ospf
  ospf router-id 192.168.0.2
  log-adjacency-changes
  network 192.168.0.0/20 area 0.0.0.0
+ timers throttle spf 0 0 0
+ timers lsa min-arrival 10
+ timers throttle lsa all 0
+ refresh timer 10
+!
+int r2-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+int r2-eth2
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
 !
 line vty
 !

--- a/tests/topotests/bgp_features/r3/ospfd.conf
+++ b/tests/topotests/bgp_features/r3/ospfd.conf
@@ -7,6 +7,17 @@ router ospf
  ospf router-id 192.168.0.3
  log-adjacency-changes
  network 192.168.0.0/20 area 0.0.0.0
+ timers throttle spf 0 0 0
+ timers lsa min-arrival 10
+ timers throttle lsa all 0
+ refresh timer 10
+!
+int r3-eth1
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
+int r3-eth2
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
 !
 line vty
 !

--- a/tests/topotests/bgp_features/r4/bgpd.conf
+++ b/tests/topotests/bgp_features/r4/bgpd.conf
@@ -4,10 +4,13 @@ log file bgpd.log
 !
 router bgp 65100
  bgp router-id 192.168.100.1
+ timers bgp 3 10
+ coalesce-time 0
  bgp log-neighbor-changes
  no bgp ebgp-requires-policy
  neighbor 192.168.101.1 remote-as 65000
  neighbor 192.168.101.1 description Router R1 (eBGP AS 65000)
+ neighbor 192.168.101.1 timers connect 5
  !
  address-family ipv4 unicast
   network 192.168.100.0/24

--- a/tests/topotests/bgp_features/r5/bgpd.conf
+++ b/tests/topotests/bgp_features/r5/bgpd.conf
@@ -4,10 +4,13 @@ log file bgpd.log
 !
 router bgp 65200
  bgp router-id 192.168.200.1
+ timers bgp 3 10
+ coalesce-time 0
  bgp log-neighbor-changes
  no bgp ebgp-requires-policy
  neighbor 192.168.201.1 remote-as 65000
  neighbor 192.168.201.1 description Router R2 (eBGP AS 65000)
+ neighbor 192.168.201.1 timers connect 5
  !
  address-family ipv4 unicast
   network 192.168.200.0/24


### PR DESCRIPTION
Initial run of topotests on my machine takes ~210 seconds
With these changes we are at ~40 seconds

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>