### PR TITLE
Ospf test speedup

### DIFF
--- a/tests/topotests/bfd-profiles-topo1/r1/ospfd.conf
+++ b/tests/topotests/bfd-profiles-topo1/r1/ospfd.conf
@@ -1,5 +1,7 @@
 interface r1-eth1
  ip ospf area 0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
  ip ospf bfd
 !
 router ospf

--- a/tests/topotests/bfd-profiles-topo1/r6/ospfd.conf
+++ b/tests/topotests/bfd-profiles-topo1/r6/ospfd.conf
@@ -1,5 +1,7 @@
 interface r6-eth0
  ip ospf area 0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
  ip ospf bfd
 !
 router ospf

--- a/tests/topotests/bfd-topo2/r2/ospf6d.conf
+++ b/tests/topotests/bfd-topo2/r2/ospf6d.conf
@@ -1,5 +1,7 @@
 interface r2-eth2
  ipv6 ospf6 bfd
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
 !
 router ospf6
  ospf6 router-id 10.254.254.2

--- a/tests/topotests/bfd-topo2/r2/ospfd.conf
+++ b/tests/topotests/bfd-topo2/r2/ospfd.conf
@@ -1,5 +1,7 @@
 interface r2-eth1
  ip ospf area 0.0.0.1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
  ip ospf bfd
 !
 router ospf

--- a/tests/topotests/bfd-topo2/r3/ospfd.conf
+++ b/tests/topotests/bfd-topo2/r3/ospfd.conf
@@ -1,5 +1,7 @@
 interface r3-eth0
  ip ospf area 0.0.0.1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
  ip ospf bfd
 !
 router ospf

--- a/tests/topotests/bfd-topo2/r4/ospf6d.conf
+++ b/tests/topotests/bfd-topo2/r4/ospf6d.conf
@@ -1,5 +1,7 @@
 interface r4-eth0
  ipv6 ospf6 bfd
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
 !
 router ospf6
  ospf6 router-id 10.254.254.4

--- a/tests/topotests/bgp-evpn-vxlan_topo1/P1/ospfd.conf
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/P1/ospfd.conf
@@ -2,3 +2,12 @@
 router ospf
  network 10.20.0.0/16 area 0
  network 10.20.20.20/32 area 0
+!
+int P1-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int P1-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE1/bgpd.conf
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE1/bgpd.conf
@@ -4,6 +4,7 @@ router bgp 65000
  no bgp default ipv4-unicast
  neighbor 10.30.30.30 remote-as 65000
  neighbor 10.30.30.30 update-source lo
+ neighbor 10.30.30.30 timers 3 10
  address-family l2vpn evpn
   neighbor 10.30.30.30 activate
   advertise-all-vni

--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE1/ospfd.conf
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE1/ospfd.conf
@@ -2,3 +2,8 @@
 router ospf
  network 10.20.0.0/16 area 0
  network 10.10.10.10/32 area 0
+!
+int PE1-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE2/bgpd.conf
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE2/bgpd.conf
@@ -4,6 +4,7 @@ router bgp 65000
  no bgp default ipv4-unicast
  neighbor 10.10.10.10 remote-as 65000
  neighbor 10.10.10.10 update-source lo
+ neighbor 10.10.10.10 timers 3 10
  !
  address-family l2vpn evpn
   neighbor 10.10.10.10 activate

--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE2/ospfd.conf
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE2/ospfd.conf
@@ -2,3 +2,8 @@
 router ospf
  network 10.20.0.0/16 area 0
  network 10.30.30.30/32 area 0
+!
+int PE2-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce1/bgpd.conf
@@ -10,6 +10,7 @@ router bgp 5226
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5226
    neighbor 192.168.1.1 update-source 192.168.1.2
+   neighbor 192.168.1.1 timers 3 10
    address-family ipv4 unicast
      network 5.1.0.0/24 route-map rm-nh
      network 5.1.1.0/24 route-map rm-nh

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce2/bgpd.conf
@@ -10,6 +10,7 @@ router bgp 5226
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5226
    neighbor 192.168.1.1 update-source 192.168.1.2
+   neighbor 192.168.1.1 timers 3 10
    address-family ipv4 unicast
      network 5.1.0.0/24 route-map rm-nh
      network 5.1.1.0/24 route-map rm-nh

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/ce3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/ce3/bgpd.conf
@@ -10,6 +10,7 @@ router bgp 5226
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5226
    neighbor 192.168.1.1 update-source 192.168.1.2
+   neighbor 192.168.1.1 timers 3 10
    address-family ipv4 unicast
      network 5.1.2.0/24 route-map rm-nh
      network 5.1.3.0/24 route-map rm-nh

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r1/bgpd.conf
@@ -11,8 +11,10 @@ router bgp 5226
    neighbor 192.168.1.2 remote-as 5226
    neighbor 192.168.1.2 update-source 192.168.1.1
    neighbor 192.168.1.2 route-reflector-client
+   neighbor 192.168.1.2 timers 3 10
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 1.1.1.1
+   neighbor 2.2.2.2 timers 3 10
 !
    address-family ipv4 unicast
      redistribute vnc-direct

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r1/ospfd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r1/ospfd.conf
@@ -6,3 +6,7 @@ router ospf
  network 0.0.0.0/4 area 0
  redistribute static
 !
+int r1-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r2/bgpd.conf
@@ -10,10 +10,13 @@ router bgp 5226
    no bgp ebgp-requires-policy
    neighbor 1.1.1.1 remote-as 5226
    neighbor 1.1.1.1 update-source 2.2.2.2
+   neighbor 1.1.1.1 timers 3 10
    neighbor 3.3.3.3 remote-as 5226
    neighbor 3.3.3.3 update-source 2.2.2.2
+   neighbor 3.3.3.3 timers 3 10
    neighbor 4.4.4.4 remote-as 5226
    neighbor 4.4.4.4 update-source 2.2.2.2
+   neighbor 4.4.4.4 timers 3 10
    address-family ipv4 unicast
      no neighbor 1.1.1.1 activate
      no neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r2/ospfd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r2/ospfd.conf
@@ -5,3 +5,15 @@ router ospf
  router-id 2.2.2.2
  network 0.0.0.0/0 area 0
 !
+int r2-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth2
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r3/bgpd.conf
@@ -11,8 +11,10 @@ router bgp 5226
    neighbor 192.168.1.2 remote-as 5226
    neighbor 192.168.1.2 update-source 192.168.1.2
    neighbor 192.168.1.2 route-reflector-client
+   neighbor 192.168.1.2 timers 3 10
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 3.3.3.3
+   neighbor 2.2.2.2 timers 3 10
 !
    address-family ipv4 unicast
      redistribute vnc-direct

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r3/ospfd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r3/ospfd.conf
@@ -7,3 +7,11 @@ router ospf
  network 0.0.0.0/4 area 0
  redistribute static
 !
+int r3-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r3-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r4/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r4/bgpd.conf
@@ -11,8 +11,10 @@ router bgp 5226
    neighbor 192.168.1.2 remote-as 5226
    neighbor 192.168.1.2 update-source 192.168.1.1
    neighbor 192.168.1.2 route-reflector-client
+   neighbor 192.168.1.2 timers 3 10
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 4.4.4.4
+   neighbor 2.2.2.2 timers 3 10
 !
    address-family ipv4 unicast
      redistribute vnc-direct

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r4/ospfd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r4/ospfd.conf
@@ -6,3 +6,7 @@ router ospf
  network 0.0.0.0/4 area 0
  redistribute static
 !
+int r4-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce1/bgpd.conf
@@ -12,6 +12,7 @@ router bgp 5227
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5227
    neighbor 192.168.1.1 update-source 192.168.1.2
+   neighbor 192.168.1.1 timers 3 10
    address-family ipv4 unicast
      network 99.0.0.1/32
      network 5.1.0.0/24 route-map rm-nh

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce2/bgpd.conf
@@ -12,6 +12,7 @@ router bgp 5227
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5227
    neighbor 192.168.1.1 update-source 192.168.1.2
+   neighbor 192.168.1.1 timers 3 10
    address-family ipv4 unicast
      network 99.0.0.2/32
      network 5.1.0.0/24 route-map rm-nh

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce3/bgpd.conf
@@ -12,6 +12,7 @@ router bgp 5227
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as 5227
    neighbor 192.168.1.1 update-source 192.168.1.2
+   neighbor 192.168.1.1 timers 3 10
    address-family ipv4 unicast
      network 99.0.0.3/32
      network 5.1.2.0/24 route-map rm-nh

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce4/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/ce4/bgpd.conf
@@ -12,6 +12,7 @@ router bgp 5228 vrf ce4-cust2
    no bgp ebgp-requires-policy
    neighbor 192.168.2.1 remote-as 5228
    neighbor 192.168.2.1 update-source 192.168.2.2
+   neighbor 192.168.2.1 timers 3 10
    address-family ipv4 unicast
      network 99.0.0.4/32
      network 5.4.2.0/24 route-map rm-nh

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r1/bgpd.conf
@@ -18,6 +18,7 @@ router bgp 5226
    no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 1.1.1.1
+   neighbor 2.2.2.2 timers 3 10
 
    address-family ipv4 unicast
      no neighbor 2.2.2.2 activate
@@ -35,6 +36,7 @@ router bgp 5227 vrf r1-cust1
 
    neighbor 192.168.1.2 remote-as 5227
    neighbor 192.168.1.2 update-source 192.168.1.1
+   neighbor 192.168.1.2 timers 3 10
 
    address-family ipv4 unicast
      neighbor 192.168.1.2 activate

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r1/ospfd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r1/ospfd.conf
@@ -6,3 +6,7 @@ router ospf
  network 0.0.0.0/4 area 0
  redistribute static
 !
+int r1-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r2/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r2/bgpd.conf
@@ -12,10 +12,13 @@ router bgp 5226
    no bgp ebgp-requires-policy
    neighbor 1.1.1.1 remote-as 5226
    neighbor 1.1.1.1 update-source 2.2.2.2
+   neighbor 1.1.1.1 timers 3 10
    neighbor 3.3.3.3 remote-as 5226
    neighbor 3.3.3.3 update-source 2.2.2.2
+   neighbor 3.3.3.3 timers 3 10
    neighbor 4.4.4.4 remote-as 5226
    neighbor 4.4.4.4 update-source 2.2.2.2
+   neighbor 4.4.4.4 timers 3 10
    address-family ipv4 unicast
      no neighbor 1.1.1.1 activate
      no neighbor 3.3.3.3 activate

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r2/ospfd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r2/ospfd.conf
@@ -5,3 +5,15 @@ router ospf
  router-id 2.2.2.2
  network 0.0.0.0/0 area 0
 !
+int r2-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth2
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r3/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r3/bgpd.conf
@@ -13,6 +13,7 @@ router bgp 5226
    no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 3.3.3.3
+   neighbor 2.2.2.2 timers 3 10
 
    address-family ipv4 unicast
      no neighbor 2.2.2.2 activate
@@ -29,6 +30,7 @@ router bgp 5227 vrf r3-cust1
 
    neighbor 192.168.1.2 remote-as 5227
    neighbor 192.168.1.2 update-source 192.168.1.1
+   neighbor 192.168.1.2 timers 3 10
 
    address-family ipv4 unicast
      neighbor 192.168.1.2 activate

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r3/ospfd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r3/ospfd.conf
@@ -7,3 +7,11 @@ router ospf
  network 0.0.0.0/4 area 0
  redistribute static
 !
+int r3-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r3-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r4/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r4/bgpd.conf
@@ -16,6 +16,7 @@ router bgp 5226
    no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
    neighbor 2.2.2.2 update-source 4.4.4.4
+   neighbor 2.2.2.2 timers 3 10
 
    address-family ipv4 unicast
      no neighbor 2.2.2.2 activate
@@ -32,6 +33,7 @@ router bgp 5227 vrf r4-cust1
 
    neighbor 192.168.1.2 remote-as 5227
    neighbor 192.168.1.2 update-source 192.168.1.1
+   neighbor 192.168.1.2 timers 3 10
 
    address-family ipv4 unicast
      neighbor 192.168.1.2 activate
@@ -52,6 +54,7 @@ router bgp 5228 vrf r4-cust2
 
    neighbor 192.168.2.2 remote-as 5228
    neighbor 192.168.2.2 update-source 192.168.2.1
+   neighbor 192.168.2.2 timers 3 10
 
    address-family ipv4 unicast
      neighbor 192.168.2.2 activate

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r4/ospfd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r4/ospfd.conf
@@ -6,3 +6,7 @@ router ospf
  network 0.0.0.0/4 area 0
  redistribute static
 !
+int r4-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_rfapi_basic_sanity/r1/ospfd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r1/ospfd.conf
@@ -6,3 +6,7 @@ router ospf
  network 0.0.0.0/4 area 0
  redistribute static
 !
+int r1-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_rfapi_basic_sanity/r2/ospfd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r2/ospfd.conf
@@ -5,3 +5,15 @@ router ospf
  router-id 2.2.2.2
  network 0.0.0.0/0 area 0
 !
+int r2-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth2
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_rfapi_basic_sanity/r3/ospfd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r3/ospfd.conf
@@ -7,3 +7,11 @@ router ospf
  network 0.0.0.0/4 area 0
  redistribute static
 !
+int r3-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r3-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/bgp_rfapi_basic_sanity/r4/ospfd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r4/ospfd.conf
@@ -6,3 +6,7 @@ router ospf
  network 0.0.0.0/4 area 0
  redistribute static
 !
+int r4-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-oc-acl-topo1/r1/ospfd.conf
+++ b/tests/topotests/ldp-oc-acl-topo1/r1/ospfd.conf
@@ -5,3 +5,7 @@ router ospf
  router-id 1.1.1.1
  network 0.0.0.0/0 area 0
 !
+int r1-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-oc-acl-topo1/r2/ospfd.conf
+++ b/tests/topotests/ldp-oc-acl-topo1/r2/ospfd.conf
@@ -5,3 +5,11 @@ router ospf
  router-id 2.2.2.2
  network 0.0.0.0/0 area 0
 !
+int r2-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-oc-acl-topo1/r3/ospfd.conf
+++ b/tests/topotests/ldp-oc-acl-topo1/r3/ospfd.conf
@@ -6,3 +6,7 @@ router ospf
  router-id 3.3.3.3
  network 0.0.0.0/0 area 0
 !
+int r3-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-oc-acl-topo1/r4/ospfd.conf
+++ b/tests/topotests/ldp-oc-acl-topo1/r4/ospfd.conf
@@ -5,3 +5,7 @@ router ospf
  router-id 4.4.4.4
  network 0.0.0.0/0 area 0
 !
+int r4-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-oc-topo1/r1/ospfd.conf
+++ b/tests/topotests/ldp-oc-topo1/r1/ospfd.conf
@@ -5,3 +5,7 @@ router ospf
  router-id 1.1.1.1
  network 0.0.0.0/0 area 0
 !
+int r1-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-oc-topo1/r2/ospfd.conf
+++ b/tests/topotests/ldp-oc-topo1/r2/ospfd.conf
@@ -5,3 +5,11 @@ router ospf
  router-id 2.2.2.2
  network 0.0.0.0/0 area 0
 !
+int r2-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-oc-topo1/r3/ospfd.conf
+++ b/tests/topotests/ldp-oc-topo1/r3/ospfd.conf
@@ -6,3 +6,7 @@ router ospf
  router-id 3.3.3.3
  network 0.0.0.0/0 area 0
 !
+int r3-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-oc-topo1/r4/ospfd.conf
+++ b/tests/topotests/ldp-oc-topo1/r4/ospfd.conf
@@ -5,3 +5,7 @@ router ospf
  router-id 4.4.4.4
  network 0.0.0.0/0 area 0
 !
+int r4-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-topo1/r1/ospfd.conf
+++ b/tests/topotests/ldp-topo1/r1/ospfd.conf
@@ -5,3 +5,7 @@ router ospf
  router-id 1.1.1.1
  network 0.0.0.0/0 area 0
 !
+int r1-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-topo1/r2/ospfd.conf
+++ b/tests/topotests/ldp-topo1/r2/ospfd.conf
@@ -5,3 +5,15 @@ router ospf
  router-id 2.2.2.2
  network 0.0.0.0/0 area 0
 !
+int r2-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth2
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-topo1/r3/ospfd.conf
+++ b/tests/topotests/ldp-topo1/r3/ospfd.conf
@@ -6,3 +6,11 @@ router ospf
  router-id 3.3.3.3
  network 0.0.0.0/0 area 0
 !
+int r3-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r3-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-topo1/r4/ospfd.conf
+++ b/tests/topotests/ldp-topo1/r4/ospfd.conf
@@ -5,3 +5,7 @@ router ospf
  router-id 4.4.4.4
  network 0.0.0.0/0 area 0
 !
+int r4-eth0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-vpls-topo1/r1/ospfd.conf
+++ b/tests/topotests/ldp-vpls-topo1/r1/ospfd.conf
@@ -5,3 +5,11 @@ router ospf
  router-id 1.1.1.1
  network 0.0.0.0/0 area 0
 !
+int r1-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r1-eth2
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-vpls-topo1/r2/ospfd.conf
+++ b/tests/topotests/ldp-vpls-topo1/r2/ospfd.conf
@@ -5,3 +5,11 @@ router ospf
  router-id 2.2.2.2
  network 0.0.0.0/0 area 0
 !
+int r2-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r2-eth2
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ldp-vpls-topo1/r3/ospfd.conf
+++ b/tests/topotests/ldp-vpls-topo1/r3/ospfd.conf
@@ -5,3 +5,11 @@ router ospf
  router-id 3.3.3.3
  network 0.0.0.0/0 area 0
 !
+int r3-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+int r3-eth2
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ospf-sr-topo1/r1/ospfd.conf
+++ b/tests/topotests/ospf-sr-topo1/r1/ospfd.conf
@@ -5,10 +5,14 @@ interface lo
 !
 interface r1-eth0
   ip ospf network point-to-point
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
   ip ospf area 0.0.0.0
 !
 interface r1-eth1
   ip ospf network point-to-point
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
   ip ospf area 0.0.0.0
 !
 router ospf

--- a/tests/topotests/ospf-sr-topo1/r2/ospfd.conf
+++ b/tests/topotests/ospf-sr-topo1/r2/ospfd.conf
@@ -6,17 +6,25 @@ interface lo
 !
 interface r2-eth0
   ip ospf network point-to-point
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
   ip ospf area 0.0.0.0
 !
 interface r2-eth1
   ip ospf network point-to-point
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
   ip ospf area 0.0.0.0
 !
 interface r2-eth2
   ip ospf area 0.0.0.0
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
 !
 interface r2-eth3
   ip ospf network point-to-point
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
   ip ospf area 0.0.0.0
 !
 router ospf

--- a/tests/topotests/ospf-sr-topo1/r3/ospfd.conf
+++ b/tests/topotests/ospf-sr-topo1/r3/ospfd.conf
@@ -1,9 +1,13 @@
 !
 interface lo
   ip ospf area 0.0.0.0
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
 !
 interface r3-eth0
   ip ospf area 0.0.0.0
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
 !
 !
 router ospf

--- a/tests/topotests/ospf-sr-topo1/r4/ospfd.conf
+++ b/tests/topotests/ospf-sr-topo1/r4/ospfd.conf
@@ -1,9 +1,13 @@
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
 !
 interface r4-eth0
  ip ospf network point-to-point
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
  ip ospf area 0.0.0.0
 !
 !

--- a/tests/topotests/ospf-topo1/r1/ospf6d.conf
+++ b/tests/topotests/ospf-topo1/r1/ospf6d.conf
@@ -7,3 +7,7 @@ router ospf6
  interface r1-eth0 area 0.0.0.0
  interface r1-eth1 area 0.0.0.0
 !
+int r1-eth1
+ ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 hello-interval 2
+!

--- a/tests/topotests/ospf-topo1/r1/ospfd.conf
+++ b/tests/topotests/ospf-topo1/r1/ospfd.conf
@@ -7,3 +7,7 @@ router ospf
   network 10.0.1.0/24 area 0
   network 10.0.3.0/24 area 0
 !
+int r1-eth1
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!

--- a/tests/topotests/ospf-topo1/r2/ospf6d.conf
+++ b/tests/topotests/ospf-topo1/r2/ospf6d.conf
@@ -7,3 +7,11 @@ router ospf6
  interface r2-eth0 area 0.0.0.0
  interface r2-eth1 area 0.0.0.0
 !
+int r2-eth0
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+int r2-eth1
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!

--- a/tests/topotests/ospf-topo1/r2/ospfd.conf
+++ b/tests/topotests/ospf-topo1/r2/ospfd.conf
@@ -7,3 +7,7 @@ router ospf
   network 10.0.2.0/24 area 0
   network 10.0.3.0/24 area 0
 !
+int r2-eth1
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
+!

--- a/tests/topotests/ospf-topo1/r3/ospf6d.conf
+++ b/tests/topotests/ospf-topo1/r3/ospf6d.conf
@@ -8,3 +8,15 @@ router ospf6
  interface r3-eth1 area 0.0.0.0
  interface r3-eth2 area 0.0.0.1
 !
+int r3-eth0
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+int r3-eth1
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+int r3-eth2
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!

--- a/tests/topotests/ospf-topo1/r3/ospfd.conf
+++ b/tests/topotests/ospf-topo1/r3/ospfd.conf
@@ -8,3 +8,11 @@ router ospf
   network 10.0.10.0/24 area 0
   network 172.16.0.0/24 area 1
 !
+int r3-eth0
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
+!
+int r3-eth2
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
+!

--- a/tests/topotests/ospf-topo1/r4/ospf6d.conf
+++ b/tests/topotests/ospf-topo1/r4/ospf6d.conf
@@ -7,3 +7,11 @@ router ospf6
  interface r4-eth0 area 0.0.0.1
  interface r4-eth1 area 0.0.0.1
 !
+int r4-eth0
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+int r4-eth1
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!

--- a/tests/topotests/ospf-topo1/r4/ospfd.conf
+++ b/tests/topotests/ospf-topo1/r4/ospfd.conf
@@ -7,3 +7,7 @@ router ospf
   network 172.16.0.0/24 area 1
   network 172.16.1.0/24 area 1
 !
+int r4-eth0
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
+!

--- a/tests/topotests/ospf-topo2/r1/ospfd.conf
+++ b/tests/topotests/ospf-topo2/r1/ospfd.conf
@@ -1,6 +1,8 @@
 !
 interface r1-eth1
   ip ospf network point-to-point
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
 !
 router ospf
   ospf router-id 10.0.255.1

--- a/tests/topotests/ospf-topo2/r2/ospfd.conf
+++ b/tests/topotests/ospf-topo2/r2/ospfd.conf
@@ -1,6 +1,8 @@
 !
 interface r2-eth1
   ip ospf network point-to-point
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
 !
 router ospf
   ospf router-id 10.0.255.2


### PR DESCRIPTION
Reduce both ospf and bgp convergence of our tests by reducing hello timers to 2/10 for ospf and 3/10 for bgp

This is not all the tests but a decent chunk.  