### PR TITLE
ospf6d: fix SA warning

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1031,7 +1031,10 @@ static int ospf6_interface_show_traffic(struct vty *vty,
 	struct vrf *vrf = NULL;
 	struct ospf6_interface *oi = NULL;
 
-	vrf = vrf_lookup_by_id(intf_ifp->vrf_id);
+	if (intf_ifp)
+		vrf = vrf_lookup_by_id(intf_ifp->vrf_id);
+	else
+		vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	if (!display_once) {
 		vty_out(vty, "\n");


### PR DESCRIPTION
Fix an SA issue in ospf6_interface.c:ospf6_interface_show_traffic()
