### PR TITLE
ospf6d : Socket change for ospf6d vrf support.

### DIFF
--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -55,7 +55,7 @@
 #define OSPF6_VTY_PORT             2606
 
 /* ospf6d privileges */
-zebra_capabilities_t _caps_p[] = {ZCAP_NET_RAW, ZCAP_BIND};
+zebra_capabilities_t _caps_p[] = {ZCAP_NET_RAW, ZCAP_BIND, ZCAP_SYS_ADMIN};
 
 struct zebra_privs_t ospf6d_privs = {
 #if defined(FRR_USER)
@@ -68,7 +68,7 @@ struct zebra_privs_t ospf6d_privs = {
 	.vty_group = VTY_GROUP,
 #endif
 	.caps_p = _caps_p,
-	.cap_num_p = 2,
+	.cap_num_p = array_size(_caps_p),
 	.cap_num_i = 0};
 
 /* ospf6d options, we use GNU getopt library. */
@@ -86,6 +86,7 @@ static void __attribute__((noreturn)) ospf6_exit(int status)
 
 	if (ospf6) {
 		vrf = vrf_lookup_by_id(ospf6->vrf_id);
+		ospf6_serv_close(&ospf6->fd);
 		ospf6_delete(ospf6);
 		ospf6 = NULL;
 	} else
@@ -101,7 +102,6 @@ static void __attribute__((noreturn)) ospf6_exit(int status)
 	ospf6_asbr_terminate();
 	ospf6_lsa_terminate();
 
-	ospf6_serv_close();
 	/* reverse access_list_init */
 	access_list_reset();
 

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1532,10 +1532,14 @@ int ospf6_receive(struct thread *thread)
 	struct iovec iovector[2];
 	struct ospf6_interface *oi;
 	struct ospf6_header *oh;
+	struct ospf6 *ospf6;
 
 	/* add next read thread */
+	ospf6 = THREAD_ARG(thread);
 	sockfd = THREAD_FD(thread);
-	thread_add_read(master, ospf6_receive, NULL, sockfd, NULL);
+
+	thread_add_read(master, ospf6_receive, ospf6, ospf6->fd,
+			&ospf6->t_ospf6_receive);
 
 	/* initialize */
 	memset(&src, 0, sizeof(src));
@@ -1548,7 +1552,7 @@ int ospf6_receive(struct thread *thread)
 	iovector[1].iov_len = 0;
 
 	/* receive message */
-	len = ospf6_recvmsg(&src, &dst, &ifindex, iovector);
+	len = ospf6_recvmsg(&src, &dst, &ifindex, iovector, sockfd);
 	if (len > iobuflen) {
 		flog_err(EC_LIB_DEVELOPMENT, "Excess message read");
 		return 0;
@@ -1696,9 +1700,13 @@ static void ospf6_send(struct in6_addr *src, struct in6_addr *dst,
 	}
 
 	/* send message */
-	len = ospf6_sendmsg(src, dst, &oi->interface->ifindex, iovector);
-	if (len != ntohs(oh->length))
-		flog_err(EC_LIB_DEVELOPMENT, "Could not send entire message");
+	if (oi->area->ospf6->fd != -1) {
+		len = ospf6_sendmsg(src, dst, &oi->interface->ifindex, iovector,
+				    oi->area->ospf6->fd);
+		if (len != ntohs(oh->length))
+			flog_err(EC_LIB_DEVELOPMENT,
+				 "Could not send entire message");
+	}
 }
 
 static uint32_t ospf6_packet_max(struct ospf6_interface *oi)

--- a/ospf6d/ospf6_network.h
+++ b/ospf6d/ospf6_network.h
@@ -21,17 +21,17 @@
 #ifndef OSPF6_NETWORK_H
 #define OSPF6_NETWORK_H
 
-extern int ospf6_sock;
+struct ospf6 *ospf6;
 extern struct in6_addr allspfrouters6;
 extern struct in6_addr alldrouters6;
 
-extern int ospf6_serv_sock(void);
-extern void ospf6_serv_close(void);
+extern int ospf6_serv_sock(struct ospf6 *ospf6);
+extern void ospf6_serv_close(int *ospf6_sock);
 extern int ospf6_sso(ifindex_t ifindex, struct in6_addr *group, int option);
 
 extern int ospf6_sendmsg(struct in6_addr *, struct in6_addr *, ifindex_t *,
-			 struct iovec *);
+			 struct iovec *, int ospf6_sock);
 extern int ospf6_recvmsg(struct in6_addr *, struct in6_addr *, ifindex_t *,
-			 struct iovec *);
+			 struct iovec *, int ospf6_sock);
 
 #endif /* OSPF6_NETWORK_H */

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -40,6 +40,8 @@ struct ospf6 {
 	/* The relevant vrf_id */
 	vrf_id_t vrf_id;
 
+	char *name; /* VRF name */
+
 	/* my router id */
 	in_addr_t router_id;
 
@@ -92,11 +94,13 @@ struct ospf6 {
 	struct timeval ts_spf_duration; /* Execution time of last SPF */
 	unsigned int last_spf_reason;   /* Last SPF reason */
 
+	int fd;
 	/* Threads */
 	struct thread *t_spf_calc; /* SPF calculation timer. */
 	struct thread *t_ase_calc; /* ASE calculation timer. */
 	struct thread *maxage_remover;
 	struct thread *t_distribute_update; /* Distirbute update timer. */
+	struct thread *t_ospf6_receive; /* OSPF6 receive timer */
 
 	uint32_t ref_bandwidth;
 
@@ -130,5 +134,6 @@ extern void ospf6_delete(struct ospf6 *o);
 extern void ospf6_router_id_update(void);
 
 extern void ospf6_maxage_remove(struct ospf6 *o);
+extern void ospf6_instance_create(const char *name);
 
 #endif /* OSPF6_TOP_H */

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -1268,9 +1268,8 @@ void ospf6_init(void)
 		&show_ipv6_ospf6_database_type_self_originated_linkstate_id_cmd);
 	install_element(VIEW_NODE, &show_ipv6_ospf6_database_aggr_router_cmd);
 
-	/* Make ospf protocol socket. */
-	ospf6_serv_sock();
-	thread_add_read(master, ospf6_receive, NULL, ospf6_sock, NULL);
+	if (ospf6 == NULL)
+		ospf6_instance_create(VRF_DEFAULT_NAME);
 }
 
 void ospf6_clean(void)


### PR DESCRIPTION
1. The global ospf6 socket is removed and stored in ospf6 structure.
2. The socket() call is changed to vrf_socket().
3. The global ospf6 socket dependencies is resolved.

Co-authored-by: harios <hari@niralnetworks.com>
Signed-off-by: Kaushik <kaushik@niralnetworks.com>