### PR TITLE
yang: use leafref instead of string

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -2178,7 +2178,7 @@ void bfd_session_update_vrf_name(struct bfd_session *bs, struct vrf *vrf)
 					 "[interface='%s']", bs->key.ifname);
 		else
 			slen += snprintf(xpath + slen, sizeof(xpath) - slen,
-					 "[interface='']");
+					 "[interface='*']");
 		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']/vrf",
 			 bs->key.vrfname);
 

--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -21,6 +21,8 @@
 #include <zebra.h>
 
 #include "filter.h"
+#include "if.h"
+#include "vrf.h"
 
 #include "bfd.h"
 #include "bfdd_nb.h"

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -127,7 +127,7 @@ DEFPY_YANG_NOSH(
 				 "[interface='%s']", ifname);
 	else
 		slen += snprintf(xpath + slen, sizeof(xpath) - slen,
-				 "[interface='']");
+				 "[interface='*']");
 	if (vrf)
 		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", vrf);
 	else
@@ -185,7 +185,7 @@ DEFPY_YANG(
 				 "[interface='%s']", ifname);
 	else
 		slen += snprintf(xpath + slen, sizeof(xpath) - slen,
-				 "[interface='']");
+				 "[interface='*']");
 	if (vrf)
 		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", vrf);
 	else
@@ -218,7 +218,7 @@ static void _bfd_cli_show_peer(struct vty *vty, struct lyd_node *dnode,
 	if (strcmp(vrf, VRF_DEFAULT_NAME))
 		vty_out(vty, " vrf %s", vrf);
 
-	if (ifname[0])
+	if (strcmp(ifname, "*"))
 		vty_out(vty, " interface %s", ifname);
 
 	vty_out(vty, "\n");

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -48,6 +48,9 @@ static void bfd_session_get_key(bool mhop, const struct lyd_node *dnode,
 	ifname = yang_dnode_get_string(dnode, "./interface");
 	vrfname = yang_dnode_get_string(dnode, "./vrf");
 
+	if (strcmp(ifname, "*") == 0)
+		ifname = NULL;
+
 	/* Generate the corresponding key. */
 	gen_bfd_key(bk, &psa, &lsa, mhop, ifname, vrfname);
 }
@@ -72,7 +75,7 @@ static int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
 		ifname = yang_dnode_get_string(dnode, "./interface");
 
 		if (p.family == AF_INET6 && IN6_IS_ADDR_LINKLOCAL(&p.u.prefix6)
-		    && strlen(ifname) == 0) {
+		    && strcmp(ifname, "*") == 0) {
 			zlog_warn(
 				"%s: when using link-local you must specify an interface.",
 				__func__);

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -45,11 +45,8 @@ static void bfd_session_get_key(bool mhop, const struct lyd_node *dnode,
 	if (yang_dnode_exists(dnode, "./source-addr"))
 		strtosa(yang_dnode_get_string(dnode, "./source-addr"), &lsa);
 
-	/* Get optional interface and vrf names. */
-	if (yang_dnode_exists(dnode, "./interface"))
-		ifname = yang_dnode_get_string(dnode, "./interface");
-	if (yang_dnode_exists(dnode, "./vrf"))
-		vrfname = yang_dnode_get_string(dnode, "./vrf");
+	ifname = yang_dnode_get_string(dnode, "./interface");
+	vrfname = yang_dnode_get_string(dnode, "./vrf");
 
 	/* Generate the corresponding key. */
 	gen_bfd_key(bk, &psa, &lsa, mhop, ifname, vrfname);
@@ -72,15 +69,7 @@ static int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
 		 */
 		yang_dnode_get_prefix(&p, dnode, "./dest-addr");
 
-		/*
-		 * To support old FRR versions we must allow empty
-		 * interface to be specified, however that should
-		 * change in the future.
-		 */
-		if (yang_dnode_exists(dnode, "./interface"))
-			ifname = yang_dnode_get_string(dnode, "./interface");
-		else
-			ifname = "";
+		ifname = yang_dnode_get_string(dnode, "./interface");
 
 		if (p.family == AF_INET6 && IN6_IS_ADDR_LINKLOCAL(&p.u.prefix6)
 		    && strlen(ifname) == 0) {

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -12,6 +12,9 @@ module frr-bfdd {
   import frr-interface {
     prefix frr-interface;
   }
+  import frr-vrf {
+    prefix frr-vrf;
+  }
   import frr-route-types {
     prefix frr-route-types;
   }
@@ -396,14 +399,12 @@ module frr-bfdd {
           }
 
           leaf interface {
-            type string {
-              length "0..16";
-            }
+            type frr-interface:interface-ref;
             description "Interface to use to contact peer";
           }
 
           leaf vrf {
-            type string;
+            type frr-vrf:vrf-ref;
             description "Virtual Routing Domain name";
           }
 
@@ -441,14 +442,12 @@ module frr-bfdd {
           }
 
           leaf interface {
-            type string {
-              length "0..16";
-            }
+            type frr-interface:interface-ref;
             description "Interface to use to contact peer";
           }
 
           leaf vrf {
-            type string;
+            type frr-vrf:vrf-ref;
             description "Virtual Routing Domain name";
           }
 

--- a/yang/frr-bgp-common-structure.yang
+++ b/yang/frr-bgp-common-structure.yang
@@ -9,6 +9,10 @@ submodule frr-bgp-common-structure {
     prefix inet;
   }
 
+  import frr-route-map {
+    prefix frr-route-map;
+  }
+
   import frr-interface {
     prefix frr-interface;
   }
@@ -371,7 +375,7 @@ submodule frr-bgp-common-structure {
       }
 
       leaf rmap-policy-export {
-        type frr-bt:rmap-ref;
+        type frr-route-map:route-map-ref;
         description
           "Route-map to specify criteria to originate default.";
       }

--- a/yang/frr-bgp-common.yang
+++ b/yang/frr-bgp-common.yang
@@ -17,6 +17,10 @@ submodule frr-bgp-common {
     prefix frr-bt;
   }
 
+  import frr-route-map {
+    prefix frr-route-map;
+  }
+
   import frr-route-types {
     prefix frr-rt-type;
   }
@@ -73,25 +77,25 @@ submodule frr-bgp-common {
 
   grouping rmap-policy-import {
     leaf rmap-import {
-      type frr-bt:rmap-ref;
+      type frr-route-map:route-map-ref;
     }
   }
 
   grouping rmap-policy-export {
     leaf rmap-export {
-      type frr-bt:rmap-ref;
+      type frr-route-map:route-map-ref;
     }
   }
 
   grouping unsupress-map-policy-import {
     leaf unsupress-map-import {
-      type frr-bt:rmap-ref;
+      type frr-route-map:route-map-ref;
     }
   }
 
   grouping unsupress-map-policy-export {
     leaf unsupress-map-export {
-      type frr-bt:rmap-ref;
+      type frr-route-map:route-map-ref;
     }
   }
 
@@ -728,7 +732,7 @@ submodule frr-bgp-common {
       }
 
       leaf rmap-policy-import {
-        type frr-bt:rmap-ref;
+        type frr-route-map:route-map-ref;
         description
           "Route-map to be applied for redistributed routes into the bgp.";
       }
@@ -743,7 +747,7 @@ submodule frr-bgp-common {
     }
 
     leaf rmap-policy-export {
-      type frr-bt:rmap-ref;
+      type frr-route-map:route-map-ref;
       description
         "Route-map to modify the attributes for Routes going out
          via BGP updates.";
@@ -771,7 +775,7 @@ submodule frr-bgp-common {
     }
 
     leaf rmap-policy-export {
-      type frr-bt:rmap-ref;
+      type frr-route-map:route-map-ref;
       description
         "Apply route map to aggregate network.";
     }
@@ -1097,7 +1101,7 @@ submodule frr-bgp-common {
         }
 
         leaf rmap-policy-export {
-          type frr-bt:rmap-ref;
+          type frr-route-map:route-map-ref;
           description
             "Route-map to modify the attributes for Routes going out
              via BGP updates.";

--- a/yang/frr-bgp-types.yang
+++ b/yang/frr-bgp-types.yang
@@ -41,10 +41,6 @@ module frr-bgp-types {
       "Initial revision.";
   }
 
-  typedef rmap-ref {
-    type string;
-  }
-
   typedef plist-ref {
     type string;
   }

--- a/yang/frr-eigrpd.yang
+++ b/yang/frr-eigrpd.yang
@@ -12,6 +12,12 @@ module frr-eigrpd {
   import frr-interface {
     prefix frr-interface;
   }
+  import frr-vrf {
+    prefix frr-vrf;
+  }
+  import frr-route-map {
+    prefix frr-route-map;
+  }
   import frr-route-types {
     prefix frr-route-types;
   }
@@ -109,9 +115,7 @@ module frr-eigrpd {
 
       leaf vrf {
         description "Virtual Routing Domain name";
-        type string {
-          length "0..16";
-        }
+        type frr-vrf:vrf-ref;
       }
 
       /*
@@ -235,9 +239,7 @@ module frr-eigrpd {
             "Applies the conditions of the specified route-map to
              routes that are redistributed into the EIGRP routing
              instance";
-          type string {
-            length "1..max";
-          }
+          type frr-route-map:route-map-ref;
         }
 
         container metrics {

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -15,6 +15,14 @@ module frr-isisd {
     prefix frr-interface;
   }
 
+  import frr-vrf {
+    prefix frr-vrf;
+  }
+
+  import frr-route-map {
+    prefix frr-route-map;
+  }
+
   import frr-route-types {
     prefix frr-route-types;
   }
@@ -240,9 +248,7 @@ module frr-isisd {
     description
       "Common optional attributes of any redistribute entry.";
     leaf route-map {
-      type string {
-        length "1..max";
-      }
+      type frr-route-map:route-map-ref;
       description
         "Applies the conditions of the specified route-map to routes that
          are redistributed into this routing instance.";
@@ -341,7 +347,7 @@ module frr-isisd {
     }
 
     leaf vrf {
-      type string;
+      type frr-vrf:vrf-ref;
       default "default";
       description
         "VRF NAME.";
@@ -830,7 +836,7 @@ module frr-isisd {
       }
 
       leaf vrf {
-        type string;
+        type frr-vrf:vrf-ref;
         description
           "VRF NAME.";
       }

--- a/yang/frr-nexthop.yang
+++ b/yang/frr-nexthop.yang
@@ -156,7 +156,7 @@ module frr-nexthop {
     }
 
     leaf vrf {
-      type string;
+      type frr-vrf:vrf-ref;
       description
         "The nexthop vrf name, if different from the route.";
     }
@@ -167,7 +167,7 @@ module frr-nexthop {
     }
 
     leaf interface {
-      type string;
+      type frr-interface:interface-ref;
       description
         "The nexthop egress interface.";
     }
@@ -275,7 +275,7 @@ module frr-nexthop {
       description
         "List of nexthop groups, each contains group of nexthops";
       leaf name {
-        type string;
+        type nexthop-group-ref;
         description
           "The nexthop-group name.";
       }

--- a/yang/frr-ospfd.yang
+++ b/yang/frr-ospfd.yang
@@ -15,6 +15,10 @@ module frr-ospfd {
     prefix frr-interface;
   }
 
+  import frr-route-map {
+    prefix frr-route-map;
+  }
+
   import frr-route-types {
     prefix frr-route-types;
   }
@@ -41,10 +45,6 @@ module frr-ospfd {
   }
 
   /* Policy types to be removed later, once policy Yang finalized */
-  typedef rmap-ref {
-    type string;
-  }
-
   typedef plist-ref {
     type string;
   }
@@ -425,7 +425,7 @@ module frr-ospfd {
     }
 
     leaf route-map {
-      type rmap-ref;
+      type frr-route-map:route-map-ref;
       description
         "Route map reference.";
     }

--- a/yang/frr-ripd.yang
+++ b/yang/frr-ripd.yang
@@ -12,6 +12,12 @@ module frr-ripd {
   import frr-interface {
     prefix frr-interface;
   }
+  import frr-vrf {
+    prefix frr-vrf;
+  }
+  import frr-route-map {
+    prefix frr-route-map;
+  }
   import frr-route-types {
     prefix frr-route-types;
   }
@@ -72,7 +78,7 @@ module frr-ripd {
         "RIP routing instance.";
 
       leaf vrf {
-        type string;
+        type frr-vrf:vrf-ref;
         description
           "VRF name.";
       }
@@ -227,9 +233,7 @@ module frr-ripd {
           must '. != "rip"';
         }
         leaf route-map {
-          type string {
-            length "1..max";
-          }
+          type frr-route-map:route-map-ref;
           description
             "Applies the conditions of the specified route-map to
              routes that are redistributed into the RIP routing
@@ -396,7 +400,7 @@ module frr-ripd {
                 "Next hop IPv4 address.";
             }
             leaf interface {
-              type string;
+              type frr-interface:interface-ref;
               description
                 "The interface that the route uses.";
             }
@@ -587,7 +591,7 @@ module frr-ripd {
 
     input {
       leaf vrf {
-        type string;
+        type frr-vrf:vrf-ref;
         description
           "VRF name identifying a specific RIP instance.
            This leaf is optional for the rpc.
@@ -608,7 +612,7 @@ module frr-ripd {
        receives a PDU with the wrong authentication type
        field.";
     leaf interface-name {
-      type string;
+      type frr-interface:interface-ref;
       description
         "Describes the name of the RIP interface.";
     }
@@ -624,7 +628,7 @@ module frr-ripd {
        receives a PDU with the wrong authentication
        information.";
     leaf interface-name {
-      type string;
+      type frr-interface:interface-ref;
       description
         "Describes the name of the RIP interface.";
     }

--- a/yang/frr-ripngd.yang
+++ b/yang/frr-ripngd.yang
@@ -12,6 +12,12 @@ module frr-ripngd {
   import frr-interface {
     prefix frr-interface;
   }
+  import frr-vrf {
+    prefix frr-vrf;
+  }
+  import frr-route-map {
+    prefix frr-route-map;
+  }
   import frr-route-types {
     prefix frr-route-types;
   }
@@ -71,7 +77,7 @@ module frr-ripngd {
         "RIPng routing instance.";
 
       leaf vrf {
-        type string;
+        type frr-vrf:vrf-ref;
         description
           "VRF name.";
       }
@@ -170,9 +176,7 @@ module frr-ripngd {
           must '. != "ripng"';
         }
         leaf route-map {
-          type string {
-            length "1..max";
-          }
+          type frr-route-map:route-map-ref;
           description
             "Applies the conditions of the specified route-map to
              routes that are redistributed into the RIPng routing
@@ -298,7 +302,7 @@ module frr-ripngd {
                 "Next hop IPv6 address.";
             }
             leaf interface {
-              type string;
+              type frr-interface:interface-ref;
               description
                 "The interface that the route uses.";
             }
@@ -359,7 +363,7 @@ module frr-ripngd {
 
     input {
       leaf vrf {
-        type string;
+        type frr-vrf:vrf-ref;
         description
           "VRF name identifying a specific RIPng instance.
            This leaf is optional for the rpc.

--- a/yang/frr-routing.yang
+++ b/yang/frr-routing.yang
@@ -249,7 +249,7 @@ module frr-routing {
              instance.";
         }
         leaf vrf {
-          type string;
+          type frr-vrf:vrf-ref;
           description
             "vrf for control-plane protocol";
         }

--- a/yang/frr-test-module.yang
+++ b/yang/frr-test-module.yang
@@ -57,7 +57,7 @@ module frr-test-module {
         }
         container interfaces {
           leaf-list interface {
-            type string;
+            type frr-interface:interface-ref;
           }
         }
         container routes {
@@ -69,7 +69,7 @@ module frr-test-module {
               type inet:ipv4-address;
             }
             leaf interface {
-              type string;
+              type frr-interface:interface-ref;
             }
             leaf metric {
               type uint8;

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -2137,7 +2137,7 @@ module frr-zebra {
           "The admin distance to use for imported routes.";
       }
       leaf route-map {
-        type string;
+        type frr-route-map:route-map-ref;
         description
           "A route-map to filter imported routes.";
       }


### PR DESCRIPTION
I suppose this is the preferred way of referencing after libyang 1.x update.