### PR TITLE
tests: Modify bgpd.conf to have faster keepalive/hold timers

### DIFF
--- a/tests/topotests/all-protocol-startup/r1/bgpd.conf
+++ b/tests/topotests/all-protocol-startup/r1/bgpd.conf
@@ -7,9 +7,13 @@ router bgp 100
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.7.10 remote-as 100
+ neighbor 192.168.7.10 timers 3 10
  neighbor 192.168.7.20 remote-as 200
+ neighbor 192.168.7.20 timers 3 10
  neighbor fc00:0:0:8::1000 remote-as 100
+ neighbor fc00:0:0:8::1000 timers 3 10
  neighbor fc00:0:0:8::2000 remote-as 200
+ neighbor fc00:0:0:8::2000 timers 3 10
  !
  address-family ipv4 unicast
   network 192.168.0.0/24

--- a/tests/topotests/bfd-bgp-cbit-topo3/r1/bgpd.conf
+++ b/tests/topotests/bfd-bgp-cbit-topo3/r1/bgpd.conf
@@ -6,6 +6,7 @@ router bgp 101
  timers bgp 8 24
  bgp graceful-restart
  neighbor 2001:db8:4::1 remote-as 102
+ neighbor 2001:db8:4::1 timers 3 10
  neighbor 2001:db8:4::1 remote-as external
  neighbor 2001:db8:4::1 bfd
  neighbor 2001:db8:4::1 bfd check-control-plane-failure

--- a/tests/topotests/bfd-bgp-cbit-topo3/r3/bgpd.conf
+++ b/tests/topotests/bfd-bgp-cbit-topo3/r3/bgpd.conf
@@ -10,6 +10,7 @@ router bgp 102
  bgp graceful-restart stalepath-time 900
  bgp graceful-restart restart-time 900
  neighbor 2001:db8:1::1 remote-as 101
+ neighbor 2001:db8:1::1 timers 3 10
  neighbor 2001:db8:1::1 remote-as external
  neighbor 2001:db8:1::1 update-source 2001:db8:4::1
  neighbor 2001:db8:1::1 bfd

--- a/tests/topotests/bfd-profiles-topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd-profiles-topo1/r2/bgpd.conf
@@ -4,8 +4,10 @@ router bgp 100
  bgp router-id 10.254.254.2
  no bgp ebgp-requires-policy
  neighbor 172.16.1.1 remote-as 100
+ neighbor 172.16.1.1 timers 3 10
  neighbor 172.16.1.1 bfd profile fasttx
  neighbor 2001:db8:2::2 remote-as 200
+ neighbor 2001:db8:2::2 timers 3 10
  neighbor 2001:db8:2::2 ebgp-multihop 2
  neighbor 2001:db8:2::2 bfd profile slowtx
  address-family ipv4 unicast

--- a/tests/topotests/bfd-profiles-topo1/r3/bgpd.conf
+++ b/tests/topotests/bfd-profiles-topo1/r3/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 100
  bgp router-id 10.254.254.3
  neighbor 172.16.1.2 remote-as 100
+ neighbor 172.16.1.2 timers 3 10
  neighbor 172.16.1.2 bfd profile DOES_NOT_EXIST
  address-family ipv4 unicast
   redistribute connected

--- a/tests/topotests/bfd-profiles-topo1/r4/bgpd.conf
+++ b/tests/topotests/bfd-profiles-topo1/r4/bgpd.conf
@@ -4,6 +4,7 @@ router bgp 200
  bgp router-id 10.254.254.4
  no bgp ebgp-requires-policy
  neighbor 2001:db8:1::2 remote-as 100
+ neighbor 2001:db8:1::2 timers 3 10
  neighbor 2001:db8:1::2 ebgp-multihop 2
  neighbor 2001:db8:1::2 bfd profile DOES_NOT_EXIST
  address-family ipv4 unicast

--- a/tests/topotests/bfd-topo1/r1/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r1/bgpd.conf
@@ -2,6 +2,7 @@ router bgp 101
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.0.2 remote-as 102
+ neighbor 192.168.0.2 timers 3 10
  neighbor 192.168.0.2 bfd
  address-family ipv4 unicast
   network 10.254.254.1/32

--- a/tests/topotests/bfd-topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r2/bgpd.conf
@@ -2,10 +2,13 @@ router bgp 102
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.0.1 remote-as 101
+ neighbor 192.168.0.1 timers 3 10
  neighbor 192.168.0.1 bfd
  neighbor 192.168.1.1 remote-as 103
+ neighbor 192.168.1.1 timers 3 10
  neighbor 192.168.1.1 bfd
  neighbor 192.168.2.1 remote-as 104
+ neighbor 192.168.2.1 timers 3 10
  neighbor 192.168.2.1 bfd
  address-family ipv4 unicast
   network 10.254.254.2/32

--- a/tests/topotests/bfd-topo1/r3/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r3/bgpd.conf
@@ -2,6 +2,7 @@ router bgp 103
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.1.2 remote-as 102
+ neighbor 192.168.1.2 timers 3 10
  neighbor 192.168.1.2 bfd
  address-family ipv4 unicast
   network 10.254.254.3/32

--- a/tests/topotests/bfd-topo1/r4/bgpd.conf
+++ b/tests/topotests/bfd-topo1/r4/bgpd.conf
@@ -2,6 +2,7 @@ router bgp 104
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.2.2 remote-as 102
+ neighbor 192.168.2.2 timers 3 10
  neighbor 192.168.2.2 bfd
  address-family ipv4 unicast
   network 10.254.254.4/32

--- a/tests/topotests/bfd-topo2/r1/bgpd.conf
+++ b/tests/topotests/bfd-topo2/r1/bgpd.conf
@@ -5,6 +5,7 @@ router bgp 101
  neighbor r2g remote-as external
  neighbor r2g bfd
  neighbor r1-eth0 interface peer-group r2g
+ neighbor r1-eth0 timers 3 10
  address-family ipv4 unicast
   redistribute connected
  exit-address-family

--- a/tests/topotests/bfd-topo2/r2/bgpd.conf
+++ b/tests/topotests/bfd-topo2/r2/bgpd.conf
@@ -5,6 +5,7 @@ router bgp 102
  neighbor r2g remote-as external
  neighbor r2g bfd
  neighbor r2-eth0 interface peer-group r2g
+ neighbor r2-eth0 timers 3 10
  !
  address-family ipv4 unicast
   redistribute connected

--- a/tests/topotests/bfd-topo3/r1/bgpd.conf
+++ b/tests/topotests/bfd-topo3/r1/bgpd.conf
@@ -1,11 +1,14 @@
 router bgp 100
  no bgp ebgp-requires-policy
  neighbor 2001:db8:1::2 remote-as internal
+ neighbor 2001:db8:1::2 timers 3 10
  neighbor 2001:db8:1::2 bfd profile fast-tx
  neighbor 192.168.2.1 remote-as external
+ neighbor 192.168.2.1 timers 3 10
  neighbor 192.168.2.1 ebgp-multihop 2
  neighbor 192.168.2.1 bfd profile slow-tx
  neighbor 2001:db8:3::1 remote-as external
+ neighbor 2001:db8:3::1 timers 3 10
  neighbor 2001:db8:3::1 ebgp-multihop 3
  neighbor 2001:db8:3::1 bfd profile slow-tx
  address-family ipv4 unicast

--- a/tests/topotests/bfd-topo3/r2/bgpd.conf
+++ b/tests/topotests/bfd-topo3/r2/bgpd.conf
@@ -1,8 +1,10 @@
 router bgp 100
  no bgp ebgp-requires-policy
  neighbor 2001:db8:1::1 remote-as internal
+ neighbor 2001:db8:1::1 timers 3 10
  neighbor 2001:db8:1::1 bfd profile fast-tx
  neighbor 2001:db8:2::1 remote-as external
+ neighbor 2001:db8:2::1 timers 3 10
  neighbor 2001:db8:2::1 bfd profile slow-tx
  address-family ipv4 unicast
   redistribute connected

--- a/tests/topotests/bfd-topo3/r3/bgpd.conf
+++ b/tests/topotests/bfd-topo3/r3/bgpd.conf
@@ -1,11 +1,14 @@
 router bgp 300
  no bgp ebgp-requires-policy
  neighbor 192.168.1.1 remote-as external
+ neighbor 192.168.1.1 timers 3 10
  neighbor 192.168.1.1 ebgp-multihop 2
  neighbor 192.168.1.1 bfd profile slow-tx
  neighbor 2001:db8:2::2 remote-as external
+ neighbor 2001:db8:2::2 timers 3 10
  neighbor 2001:db8:2::2 bfd profile slow-tx
  neighbor 2001:db8:3::1 remote-as external
+ neighbor 2001:db8:3::1 timers 3 10
  neighbor 2001:db8:3::1 bfd profile slow-tx
  address-family ipv4 unicast
   redistribute connected

--- a/tests/topotests/bfd-topo3/r4/bgpd.conf
+++ b/tests/topotests/bfd-topo3/r4/bgpd.conf
@@ -1,8 +1,10 @@
 router bgp 400
  no bgp ebgp-requires-policy
  neighbor 2001:db8:3::2 remote-as external
+ neighbor 2001:db8:3::2 timers 3 10
  neighbor 2001:db8:3::2 bfd profile slow-tx
  neighbor 2001:db8:1::1 remote-as external
+ neighbor 2001:db8:1::1 timers 3 10
  neighbor 2001:db8:1::1 ebgp-multihop 3
  neighbor 2001:db8:1::1 bfd profile slow-tx-mh
  address-family ipv4 unicast

--- a/tests/topotests/bfd-vrf-topo1/r1/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r1/bgpd.conf
@@ -2,6 +2,7 @@ router bgp 101 vrf r1-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.0.2 remote-as 102
+ neighbor 192.168.0.2 timers 3 10
 ! neighbor 192.168.0.2 ebgp-multihop 10
  neighbor 192.168.0.2 bfd
  address-family ipv4 unicast

--- a/tests/topotests/bfd-vrf-topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r2/bgpd.conf
@@ -2,10 +2,13 @@ router bgp 102 vrf r2-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.0.1 remote-as 101
+ neighbor 192.168.0.1 timers 3 10
  neighbor 192.168.0.1 bfd
  neighbor 192.168.1.1 remote-as 103
+ neighbor 192.168.1.1 timers 3 10
  neighbor 192.168.1.1 bfd
  neighbor 192.168.2.1 remote-as 104
+ neighbor 192.168.2.1 timers 3 10
  neighbor 192.168.2.1 bfd
  address-family ipv4 unicast
   network 10.254.254.2/32

--- a/tests/topotests/bfd-vrf-topo1/r3/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r3/bgpd.conf
@@ -2,6 +2,7 @@ router bgp 103 vrf r3-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.1.2 remote-as 102
+ neighbor 192.168.1.2 timers 3 10
  neighbor 192.168.1.2 bfd
  address-family ipv4 unicast
   network 10.254.254.3/32

--- a/tests/topotests/bfd-vrf-topo1/r4/bgpd.conf
+++ b/tests/topotests/bfd-vrf-topo1/r4/bgpd.conf
@@ -2,6 +2,7 @@ router bgp 104 vrf r4-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.2.2 remote-as 102
+ neighbor 192.168.2.2 timers 3 10
  neighbor 192.168.2.2 bfd
  address-family ipv4 unicast
   network 10.254.254.4/32

--- a/tests/topotests/bgp-ecmp-topo1/r1/bgpd.conf
+++ b/tests/topotests/bgp-ecmp-topo1/r1/bgpd.conf
@@ -7,25 +7,45 @@ router bgp 100
  bgp bestpath as-path multipath-relax
  no bgp ebgp-requires-policy
  neighbor 10.0.1.101 remote-as 99
+ neighbor 10.0.1.101 timers 3 10
  neighbor 10.0.1.102 remote-as 99
+ neighbor 10.0.1.102 timers 3 10
  neighbor 10.0.1.103 remote-as 99
+ neighbor 10.0.1.103 timers 3 10
  neighbor 10.0.1.104 remote-as 99
+ neighbor 10.0.1.104 timers 3 10
  neighbor 10.0.1.105 remote-as 99
+ neighbor 10.0.1.105 timers 3 10
  neighbor 10.0.2.106 remote-as 99
+ neighbor 10.0.2.106 timers 3 10
  neighbor 10.0.2.107 remote-as 99
+ neighbor 10.0.2.107 timers 3 10
  neighbor 10.0.2.108 remote-as 99
+ neighbor 10.0.2.108 timers 3 10
  neighbor 10.0.2.109 remote-as 99
+ neighbor 10.0.2.109 timers 3 10
  neighbor 10.0.2.110 remote-as 99
+ neighbor 10.0.2.110 timers 3 10
  neighbor 10.0.3.111 remote-as 111
+ neighbor 10.0.3.111 timers 3 10
  neighbor 10.0.3.112 remote-as 112
+ neighbor 10.0.3.112 timers 3 10
  neighbor 10.0.3.113 remote-as 113
+ neighbor 10.0.3.113 timers 3 10
  neighbor 10.0.3.114 remote-as 114
+ neighbor 10.0.3.114 timers 3 10
  neighbor 10.0.3.115 remote-as 115
+ neighbor 10.0.3.115 timers 3 10
  neighbor 10.0.4.116 remote-as 116
+ neighbor 10.0.4.116 timers 3 10
  neighbor 10.0.4.117 remote-as 117
+ neighbor 10.0.4.117 timers 3 10
  neighbor 10.0.4.118 remote-as 118
+ neighbor 10.0.4.118 timers 3 10
  neighbor 10.0.4.119 remote-as 119
+ neighbor 10.0.4.119 timers 3 10
  neighbor 10.0.4.120 remote-as 120
+ neighbor 10.0.4.120 timers 3 10
  !
 !
 

--- a/tests/topotests/bgp_aggregate-address_origin/r1/bgpd.conf
+++ b/tests/topotests/bgp_aggregate-address_origin/r1/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.255.2 timers 3 10
   address-family ipv4 unicast
     redistribute connected
     aggregate-address 172.16.255.0/24 origin igp

--- a/tests/topotests/bgp_aggregate-address_origin/r2/bgpd.conf
+++ b/tests/topotests/bgp_aggregate-address_origin/r2/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
+  neighbor 192.168.255.1 timers 3 10
   exit-address-family
 !

--- a/tests/topotests/bgp_aggregate-address_route-map/r1/bgpd.conf
+++ b/tests/topotests/bgp_aggregate-address_route-map/r1/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.255.2 timers 3 10
   address-family ipv4 unicast
     redistribute connected
     aggregate-address 172.16.255.0/24 route-map aggr-rmap

--- a/tests/topotests/bgp_aggregate-address_route-map/r2/bgpd.conf
+++ b/tests/topotests/bgp_aggregate-address_route-map/r2/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
+  neighbor 192.168.255.1 timers 3 10
   exit-address-family
 !

--- a/tests/topotests/bgp_as_wide_bgp_identifier/r1/bgpd.conf
+++ b/tests/topotests/bgp_as_wide_bgp_identifier/r1/bgpd.conf
@@ -3,4 +3,5 @@ router bgp 65001
   bgp router-id 10.10.10.10
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65002
+  neighbor 192.168.255.1 timers 3 10
 !

--- a/tests/topotests/bgp_as_wide_bgp_identifier/r2/bgpd.conf
+++ b/tests/topotests/bgp_as_wide_bgp_identifier/r2/bgpd.conf
@@ -3,5 +3,7 @@ router bgp 65002
   bgp router-id 10.10.10.10
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.255.2 timers 3 10
   neighbor 192.168.255.3 remote-as 65002
+  neighbor 192.168.255.3 timers 3 10
 !

--- a/tests/topotests/bgp_as_wide_bgp_identifier/r3/bgpd.conf
+++ b/tests/topotests/bgp_as_wide_bgp_identifier/r3/bgpd.conf
@@ -3,4 +3,5 @@ router bgp 65002
   bgp router-id 10.10.10.10
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65002
+  neighbor 192.168.255.1 timers 3 10
 !

--- a/tests/topotests/bgp_comm-list_delete/r1/bgpd.conf
+++ b/tests/topotests/bgp_comm-list_delete/r1/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.255.2 timers 3 10
   address-family ipv4 unicast
     redistribute connected route-map r2-out
   exit-address-family

--- a/tests/topotests/bgp_comm-list_delete/r2/bgpd.conf
+++ b/tests/topotests/bgp_comm-list_delete/r2/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
+  neighbor 192.168.255.1 timers 3 10
   address-family ipv4
     neighbor 192.168.255.1 route-map r1-in in
   exit-address-family

--- a/tests/topotests/bgp_default-route_route-map/r1/bgpd.conf
+++ b/tests/topotests/bgp_default-route_route-map/r1/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.255.2 timers 3 10
   address-family ipv4 unicast
     neighbor 192.168.255.2 default-originate route-map default
   exit-address-family

--- a/tests/topotests/bgp_default-route_route-map/r2/bgpd.conf
+++ b/tests/topotests/bgp_default-route_route-map/r2/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
+  neighbor 192.168.255.1 timers 3 10
   address-family ipv4 unicast
     redistribute connected
   exit-address-family

--- a/tests/topotests/bgp_distance_change/r1/bgpd.conf
+++ b/tests/topotests/bgp_distance_change/r1/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.255.2 timers 3 10
   exit-address-family
 !

--- a/tests/topotests/bgp_distance_change/r2/bgpd.conf
+++ b/tests/topotests/bgp_distance_change/r2/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
+  neighbor 192.168.255.1 timers 3 10
   address-family ipv4
     redistribute connected
   exit-address-family

--- a/tests/topotests/bgp_ebgp_requires_policy/r1/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r1/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 65000
   neighbor 192.168.255.2 remote-as 1000
+  neighbor 192.168.255.2 timers 3 10
   neighbor 192.168.255.2 local-as 500
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_ebgp_requires_policy/r2/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r2/bgpd.conf
@@ -1,3 +1,5 @@
 router bgp 1000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 500
+  neighbor 192.168.255.1 timers 3 10
+!

--- a/tests/topotests/bgp_ebgp_requires_policy/r3/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r3/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 65000
   neighbor 192.168.255.2 remote-as 1000
+  neighbor 192.168.255.2 timers 3 10
   neighbor 192.168.255.2 local-as 500
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_ebgp_requires_policy/r4/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r4/bgpd.conf
@@ -1,3 +1,5 @@
 router bgp 1000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 500
+  neighbor 192.168.255.1 timers 3 10
+!

--- a/tests/topotests/bgp_ebgp_requires_policy/r5/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r5/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65000
+  neighbor 192.168.255.2 timers 3 10
   address-family ipv4 unicast
     redistribute connected
 !

--- a/tests/topotests/bgp_ebgp_requires_policy/r6/bgpd.conf
+++ b/tests/topotests/bgp_ebgp_requires_policy/r6/bgpd.conf
@@ -1,2 +1,4 @@
 router bgp 65000
   neighbor 192.168.255.1 remote-as 65000
+  neighbor 192.168.255.1 timers 3 10
+!

--- a/tests/topotests/bgp_features/r1/bgpd.conf
+++ b/tests/topotests/bgp_features/r1/bgpd.conf
@@ -9,10 +9,12 @@ router bgp 65000
  bgp log-neighbor-changes
  no bgp ebgp-requires-policy
  neighbor 192.168.0.2 remote-as 65000
+ neighbor 192.168.0.2 timers 3 10
  neighbor 192.168.0.2 description Router R2 (iBGP)
  neighbor 192.168.0.2 update-source lo
  neighbor 192.168.0.2 timers connect 5
  neighbor 192.168.101.2 remote-as 65100
+ neighbor 192.168.101.2 timers 3 10
  neighbor 192.168.101.2 description Router R4 (eBGP AS 65100)
  neighbor 192.168.101.2 timers connect 5
  !

--- a/tests/topotests/bgp_features/r2/bgpd.conf
+++ b/tests/topotests/bgp_features/r2/bgpd.conf
@@ -9,10 +9,12 @@ router bgp 65000
  bgp log-neighbor-changes
  no bgp ebgp-requires-policy
  neighbor 192.168.0.1 remote-as 65000
+ neighbor 192.168.0.1 timers 3 10
  neighbor 192.168.0.1 description Router R1 (iBGP)
  neighbor 192.168.0.1 update-source lo
  neighbor 192.168.0.1 timers connect 5
  neighbor 192.168.201.2 remote-as 65200
+ neighbor 192.168.201.2 timers 3 10
  neighbor 192.168.201.2 description Router R5 (eBGP AS 65200)
  neighbor 192.168.201.2 timers connect 5
  !

--- a/tests/topotests/bgp_features/r4/bgpd.conf
+++ b/tests/topotests/bgp_features/r4/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 65100
  bgp log-neighbor-changes
  no bgp ebgp-requires-policy
  neighbor 192.168.101.1 remote-as 65000
+ neighbor 192.168.101.1 timers 3 10
  neighbor 192.168.101.1 description Router R1 (eBGP AS 65000)
  neighbor 192.168.101.1 timers connect 5
  !

--- a/tests/topotests/bgp_features/r5/bgpd.conf
+++ b/tests/topotests/bgp_features/r5/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 65200
  bgp log-neighbor-changes
  no bgp ebgp-requires-policy
  neighbor 192.168.201.1 remote-as 65000
+ neighbor 192.168.201.1 timers 3 10
  neighbor 192.168.201.1 description Router R2 (eBGP AS 65000)
  neighbor 192.168.201.1 timers connect 5
  !

--- a/tests/topotests/bgp_flowspec/r1/bgpd.conf
+++ b/tests/topotests/bgp_flowspec/r1/bgpd.conf
@@ -5,6 +5,7 @@ log stdout debugging
 router bgp 100
  bgp router-id 10.0.1.1
  neighbor 10.0.1.101 remote-as 100
+ neighbor 10.0.1.101 timers 3 10
  neighbor 10.0.1.101 update-source 10.0.1.1
  address-family ipv6 flowspec
   local-install r1-eth0

--- a/tests/topotests/bgp_ipv6_rtadv/r1/bgpd.conf
+++ b/tests/topotests/bgp_ipv6_rtadv/r1/bgpd.conf
@@ -5,6 +5,7 @@ router bgp 101
  neighbor r2g remote-as external
  neighbor r2g bfd
  neighbor r1-eth0 interface peer-group r2g
+ neighbor r1-eth0 timers 3 10
  address-family ipv4 unicast
   redistribute connected
  exit-address-family

--- a/tests/topotests/bgp_ipv6_rtadv/r2/bgpd.conf
+++ b/tests/topotests/bgp_ipv6_rtadv/r2/bgpd.conf
@@ -5,6 +5,7 @@ router bgp 102
  neighbor r2g remote-as external
  neighbor r2g bfd
  neighbor r2-eth0 interface peer-group r2g
+ neighbor r2-eth0 timers 3 10
  !
  address-family ipv4 unicast
   redistribute connected

--- a/tests/topotests/bgp_link_bw_ip/r1/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r1/bgpd.conf
@@ -5,5 +5,7 @@ router bgp 65101
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
  neighbor 11.1.1.2 remote-as external
+ neighbor 11.1.1.2 timers 3 10
  neighbor 11.1.1.6 remote-as external
+ neighbor 11.1.1.6 timers 3 10
 !

--- a/tests/topotests/bgp_link_bw_ip/r10/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r10/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 65354
  bgp router-id 11.1.6.2
  no bgp ebgp-requires-policy
  neighbor 11.1.6.1 remote-as external
+ neighbor 11.1.6.1 timers 3 10
  !
  address-family ipv4 unicast
   redistribute connected route-map redist

--- a/tests/topotests/bgp_link_bw_ip/r2/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r2/bgpd.conf
@@ -5,6 +5,9 @@ router bgp 65201
  bgp bestpath as-path multipath-relax
  no bgp ebgp-requires-policy
  neighbor 11.1.1.1 remote-as external
+ neighbor 11.1.1.1 timers 3 10
  neighbor 11.1.2.2 remote-as external
+ neighbor 11.1.2.2 timers 3 10
  neighbor 11.1.2.6 remote-as external
+ neighbor 11.1.2.6 timers 3 10
 !

--- a/tests/topotests/bgp_link_bw_ip/r3/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r3/bgpd.conf
@@ -5,5 +5,7 @@ router bgp 65202
  bgp bestpath as-path multipath-relax
  no bgp ebgp-requires-policy
  neighbor 11.1.1.5 remote-as external
+ neighbor 11.1.1.5 timers 3 10
  neighbor 11.1.3.2 remote-as external
+ neighbor 11.1.3.2 timers 3 10
 !

--- a/tests/topotests/bgp_link_bw_ip/r4/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r4/bgpd.conf
@@ -20,8 +20,11 @@ router bgp 65301
  bgp bestpath as-path multipath-relax
  no bgp ebgp-requires-policy
  neighbor 11.1.2.1 remote-as external
+ neighbor 11.1.2.1 timers 3 10
  neighbor 11.1.4.2 remote-as external
+ neighbor 11.1.4.2 timers 3 10
  neighbor 11.1.4.6 remote-as external
+ neighbor 11.1.4.6 timers 3 10
  !
  address-family ipv4 unicast
   neighbor 11.1.2.1 route-map anycast_ip out

--- a/tests/topotests/bgp_link_bw_ip/r5/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r5/bgpd.conf
@@ -13,7 +13,9 @@ router bgp 65302
  bgp bestpath as-path multipath-relax
  no bgp ebgp-requires-policy
  neighbor 11.1.2.5 remote-as external
+ neighbor 11.1.2.5 timers 3 10
  neighbor 11.1.5.2 remote-as external
+ neighbor 11.1.5.2 timers 3 10
  !
  address-family ipv4 unicast
   neighbor 11.1.2.5 route-map anycast_ip out

--- a/tests/topotests/bgp_link_bw_ip/r6/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r6/bgpd.conf
@@ -13,7 +13,9 @@ router bgp 65303
  bgp bestpath as-path multipath-relax
  no bgp ebgp-requires-policy
  neighbor 11.1.3.1 remote-as external
+ neighbor 11.1.3.1 timers 3 10
  neighbor 11.1.6.2 remote-as external
+ neighbor 11.1.6.2 timers 3 10
  !
  address-family ipv4 unicast
   neighbor 11.1.3.1 route-map anycast_ip out

--- a/tests/topotests/bgp_link_bw_ip/r7/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r7/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 65351
  bgp router-id 11.1.4.2
  no bgp ebgp-requires-policy
  neighbor 11.1.4.1 remote-as external
+ neighbor 11.1.4.1 timers 3 10
  !
  address-family ipv4 unicast
   redistribute connected route-map redist

--- a/tests/topotests/bgp_link_bw_ip/r8/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r8/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 65352
  bgp router-id 11.1.4.6
  no bgp ebgp-requires-policy
  neighbor 11.1.4.5 remote-as external
+ neighbor 11.1.4.5 timers 3 10
  !
  address-family ipv4 unicast
   redistribute connected route-map redist

--- a/tests/topotests/bgp_link_bw_ip/r9/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r9/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 65353
  bgp router-id 11.1.5.2
  no bgp ebgp-requires-policy
  neighbor 11.1.5.1 remote-as external
+ neighbor 11.1.5.1 timers 3 10
  !
  address-family ipv4 unicast
   redistribute connected route-map redist

--- a/tests/topotests/bgp_local_as_private_remove/r1/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r1/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 1000
+  neighbor 192.168.255.2 timers 3 10
   neighbor 192.168.255.2 local-as 500
   address-family ipv4 unicast
     neighbor 192.168.255.2 remove-private-AS

--- a/tests/topotests/bgp_local_as_private_remove/r2/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r2/bgpd.conf
@@ -1,3 +1,5 @@
 router bgp 1000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 500
+  neighbor 192.168.255.1 timers 3 10
+!

--- a/tests/topotests/bgp_local_as_private_remove/r3/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r3/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 3000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 1000
+  neighbor 192.168.255.2 timers 3 10
   neighbor 192.168.255.2 local-as 500
   address-family ipv4 unicast
     neighbor 192.168.255.2 remove-private-AS

--- a/tests/topotests/bgp_local_as_private_remove/r4/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r4/bgpd.conf
@@ -1,3 +1,5 @@
 router bgp 1000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 500
+  neighbor 192.168.255.1 timers 3 10
+!

--- a/tests/topotests/bgp_maximum_prefix_invalid_update/r1/bgpd.conf
+++ b/tests/topotests/bgp_maximum_prefix_invalid_update/r1/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.255.2 timers 3 10
   address-family ipv4 unicast
     redistribute connected

--- a/tests/topotests/bgp_maximum_prefix_invalid_update/r2/bgpd.conf
+++ b/tests/topotests/bgp_maximum_prefix_invalid_update/r2/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
+  neighbor 192.168.255.1 timers 3 10
   address-family ipv4
     neighbor 192.168.255.1 maximum-prefix 1

--- a/tests/topotests/bgp_maximum_prefix_out/r1/bgpd.conf
+++ b/tests/topotests/bgp_maximum_prefix_out/r1/bgpd.conf
@@ -2,6 +2,7 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65002
+  neighbor 192.168.255.1 timers 3 10
   address-family ipv4 unicast
     redistribute connected
     neighbor 192.168.255.1 maximum-prefix-out 2

--- a/tests/topotests/bgp_maximum_prefix_out/r2/bgpd.conf
+++ b/tests/topotests/bgp_maximum_prefix_out/r2/bgpd.conf
@@ -2,6 +2,7 @@
 router bgp 65002
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.255.2 timers 3 10
   exit-address-family
   !
 !

--- a/tests/topotests/bgp_multiview_topo1/r1/bgpd.conf
+++ b/tests/topotests/bgp_multiview_topo1/r1/bgpd.conf
@@ -17,8 +17,11 @@ router bgp 100 view 1
  network 172.20.0.0/28 route-map local1
  timers bgp 60 180
  neighbor 172.16.1.1 remote-as 65001
+ neighbor 172.16.1.1 timers 3 10
  neighbor 172.16.1.2 remote-as 65002
+ neighbor 172.16.1.2 timers 3 10
  neighbor 172.16.1.5 remote-as 65005
+ neighbor 172.16.1.5 timers 3 10
 !
 router bgp 100 view 2
  bgp router-id 172.30.1.1
@@ -26,7 +29,9 @@ router bgp 100 view 2
  network 172.20.0.0/28 route-map local2
  timers bgp 60 180
  neighbor 172.16.1.3 remote-as 65003
+ neighbor 172.16.1.3 timers 3 10
  neighbor 172.16.1.4 remote-as 65004
+ neighbor 172.16.1.4 timers 3 10
 !
 router bgp 100 view 3
  bgp router-id 172.30.1.1
@@ -34,8 +39,11 @@ router bgp 100 view 3
  network 172.20.0.0/28
  timers bgp 60 180
  neighbor 172.16.1.6 remote-as 65006
+ neighbor 172.16.1.6 timers 3 10
  neighbor 172.16.1.7 remote-as 65007
+ neighbor 172.16.1.7 timers 3 10
  neighbor 172.16.1.8 remote-as 65008
+ neighbor 172.16.1.8 timers 3 10
 !
 route-map local1 permit 10
  set community 100:9999 additive

--- a/tests/topotests/bgp_prefix_sid/r1/bgpd.conf
+++ b/tests/topotests/bgp_prefix_sid/r1/bgpd.conf
@@ -6,7 +6,9 @@ router bgp 1
  no bgp default ipv4-unicast
  no bgp ebgp-requires-policy
  neighbor 10.0.0.101 remote-as 2
+ neighbor 10.0.0.101 timers 3 10
  neighbor 10.0.0.102 remote-as 3
+ neighbor 10.0.0.102 timers 3 10
  !
  address-family ipv4 labeled-unicast
   neighbor 10.0.0.101 activate

--- a/tests/topotests/bgp_reject_as_sets/r1/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r1/bgpd.conf
@@ -2,6 +2,7 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65002
+  neighbor 192.168.255.1 timers 3 10
   address-family ipv4 unicast
     redistribute connected
   exit-address-family

--- a/tests/topotests/bgp_reject_as_sets/r2/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r2/bgpd.conf
@@ -3,7 +3,9 @@ router bgp 65002
   bgp reject-as-sets
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.255.2 timers 3 10
   neighbor 192.168.254.2 remote-as 65003
+  neighbor 192.168.254.2 timers 3 10
   address-family ipv4 unicast
     aggregate-address 172.16.0.0/16 as-set summary-only
   exit-address-family

--- a/tests/topotests/bgp_reject_as_sets/r3/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r3/bgpd.conf
@@ -2,6 +2,7 @@
 router bgp 65003
   no bgp ebgp-requires-policy
   neighbor 192.168.254.1 remote-as 65002
+  neighbor 192.168.254.1 timers 3 10
   address-family ipv4 unicast
     neighbor 192.168.254.1 allowas-in
     redistribute connected

--- a/tests/topotests/bgp_rfapi_basic_sanity/r1/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r1/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 5226
    bgp cluster-id 1.1.1.1
    no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
+   neighbor 2.2.2.2 timers 3 10
    neighbor 2.2.2.2 update-source 1.1.1.1
 !
    address-family ipv4 unicast

--- a/tests/topotests/bgp_rfapi_basic_sanity/r2/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r2/bgpd.conf
@@ -9,10 +9,13 @@ router bgp 5226
    bgp cluster-id 2.2.2.2
    no bgp ebgp-requires-policy
    neighbor 1.1.1.1 remote-as 5226
+   neighbor 1.1.1.1 timers 3 10
    neighbor 1.1.1.1 update-source 2.2.2.2
    neighbor 3.3.3.3 remote-as 5226
+   neighbor 3.3.3.3 timers 3 10
    neighbor 3.3.3.3 update-source 2.2.2.2
    neighbor 4.4.4.4 remote-as 5226
+   neighbor 4.4.4.4 timers 3 10
    neighbor 4.4.4.4 update-source 2.2.2.2
    address-family ipv4 unicast
      no neighbor 1.1.1.1 activate

--- a/tests/topotests/bgp_rfapi_basic_sanity/r3/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r3/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 5226
    bgp cluster-id 3.3.3.3
    no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
+   neighbor 2.2.2.2 timers 3 10
    neighbor 2.2.2.2 update-source 3.3.3.3
 !
    address-family ipv4 unicast

--- a/tests/topotests/bgp_rfapi_basic_sanity/r4/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r4/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 5226
    bgp cluster-id 4.4.4.4
    no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
+   neighbor 2.2.2.2 timers 3 10
    neighbor 2.2.2.2 update-source 4.4.4.4
 !
    address-family ipv4 unicast

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r1/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r1/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 5226
    bgp cluster-id 1.1.1.1
    no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
+   neighbor 2.2.2.2 timers 3 10
    neighbor 2.2.2.2 update-source 1.1.1.1
 !
    address-family ipv4 unicast

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r2/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r2/bgpd.conf
@@ -9,10 +9,13 @@ router bgp 5226
    bgp cluster-id 2.2.2.2
    no bgp ebgp-requires-policy
    neighbor 1.1.1.1 remote-as 5226
+   neighbor 1.1.1.1 timers 3 10
    neighbor 1.1.1.1 update-source 2.2.2.2
    neighbor 3.3.3.3 remote-as 5226
+   neighbor 3.3.3.3 timers 3 10
    neighbor 3.3.3.3 update-source 2.2.2.2
    neighbor 4.4.4.4 remote-as 5226
+   neighbor 4.4.4.4 timers 3 10
    neighbor 4.4.4.4 update-source 2.2.2.2
    address-family ipv4 unicast
      no neighbor 1.1.1.1 activate

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r3/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r3/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 5226
    bgp cluster-id 3.3.3.3
    no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
+   neighbor 2.2.2.2 timers 3 10
    neighbor 2.2.2.2 update-source 3.3.3.3
 !
    address-family ipv4 unicast

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r4/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r4/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 5226
    bgp cluster-id 4.4.4.4
    no bgp ebgp-requires-policy
    neighbor 2.2.2.2 remote-as 5226
+   neighbor 2.2.2.2 timers 3 10
    neighbor 2.2.2.2 update-source 4.4.4.4
 !
    address-family ipv4 unicast

--- a/tests/topotests/bgp_rr_ibgp/spine1/bgpd.conf
+++ b/tests/topotests/bgp_rr_ibgp/spine1/bgpd.conf
@@ -2,7 +2,9 @@ hostname spine1
 router bgp 99
   no bgp ebgp-requires-policy
   neighbor 192.168.2.1 remote-as internal
+  neighbor 192.168.2.1 timers 3 10
   neighbor 192.168.4.2 remote-as internal
+  neighbor 192.168.4.2 timers 3 10
   address-family ipv4 uni
   	redistribute connected
 	neighbor 192.168.2.1 route-reflector-client

--- a/tests/topotests/bgp_rr_ibgp/tor1/bgpd.conf
+++ b/tests/topotests/bgp_rr_ibgp/tor1/bgpd.conf
@@ -2,4 +2,5 @@ hostname tor1
 router bgp 99
   no bgp ebgp-requires-policy
   neighbor 192.168.2.3 remote-as internal
+  neighbor 192.168.2.3 timers 3 10
   redistribute connected

--- a/tests/topotests/bgp_rr_ibgp/tor2/bgpd.conf
+++ b/tests/topotests/bgp_rr_ibgp/tor2/bgpd.conf
@@ -2,4 +2,5 @@ hostname tor2
 router bgp 99
   no bgp ebgp-requires-policy
   neighbor 192.168.4.3 remote-as internal
+  neighbor 192.168.4.3 timers 3 10
   redistribute connected

--- a/tests/topotests/bgp_sender-as-path-loop-detection/r1/bgpd.conf
+++ b/tests/topotests/bgp_sender-as-path-loop-detection/r1/bgpd.conf
@@ -2,6 +2,7 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65002
+  neighbor 192.168.255.1 timers 3 10
   address-family ipv4 unicast
     neighbor 192.168.255.1 route-map prepend out
     redistribute connected

--- a/tests/topotests/bgp_sender-as-path-loop-detection/r2/bgpd.conf
+++ b/tests/topotests/bgp_sender-as-path-loop-detection/r2/bgpd.conf
@@ -2,8 +2,10 @@
 router bgp 65002
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.255.2 timers 3 10
   neighbor 192.168.255.2 solo
   neighbor 192.168.254.2 remote-as 65003
+  neighbor 192.168.254.2 timers 3 10
   neighbor 192.168.254.2 solo
   neighbor 192.168.254.2 sender-as-path-loop-detection
 !

--- a/tests/topotests/bgp_sender-as-path-loop-detection/r3/bgpd.conf
+++ b/tests/topotests/bgp_sender-as-path-loop-detection/r3/bgpd.conf
@@ -2,4 +2,5 @@
 router bgp 65003
   no bgp ebgp-requires-policy
   neighbor 192.168.254.1 remote-as 65002
+  neighbor 192.168.254.1 timers 3 10
 !

--- a/tests/topotests/bgp_set_local-preference_add_subtract/r1/bgpd.conf
+++ b/tests/topotests/bgp_set_local-preference_add_subtract/r1/bgpd.conf
@@ -1,6 +1,8 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.2 remote-as 65000
+  neighbor 192.168.255.2 timers 3 10
   neighbor 192.168.255.3 remote-as 65000
+  neighbor 192.168.255.3 timers 3 10
   exit-address-family
 !

--- a/tests/topotests/bgp_set_local-preference_add_subtract/r2/bgpd.conf
+++ b/tests/topotests/bgp_set_local-preference_add_subtract/r2/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
+  neighbor 192.168.255.1 timers 3 10
   address-family ipv4
     redistribute connected
     neighbor 192.168.255.1 route-map r1-out out

--- a/tests/topotests/bgp_set_local-preference_add_subtract/r3/bgpd.conf
+++ b/tests/topotests/bgp_set_local-preference_add_subtract/r3/bgpd.conf
@@ -1,6 +1,7 @@
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 192.168.255.1 remote-as 65000
+  neighbor 192.168.255.1 timers 3 10
   address-family ipv4
     redistribute connected
     neighbor 192.168.255.1 route-map r1-out out

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r1/bgpd.conf
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r1/bgpd.conf
@@ -5,6 +5,7 @@ router bgp 101 vrf r1-cust1
  neighbor r2g remote-as external
  neighbor r2g bfd
  neighbor r1-eth0 interface peer-group r2g
+ neighbor r1-eth0 timers 3 10
  address-family ipv4 unicast
   redistribute connected
  exit-address-family

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r2/bgpd.conf
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r2/bgpd.conf
@@ -5,6 +5,7 @@ router bgp 102 vrf r2-cust1
  neighbor r2g remote-as external
  neighbor r2g bfd
  neighbor r2-eth0 interface peer-group r2g
+ neighbor r2-eth0 timers 3 10
  !
  address-family ipv4 unicast
   redistribute connected

--- a/tests/topotests/bgp_vrf_netns/r1/bgpd.conf
+++ b/tests/topotests/bgp_vrf_netns/r1/bgpd.conf
@@ -4,6 +4,7 @@ router bgp 100 vrf r1-cust1
  bgp bestpath as-path multipath-relax
  no bgp ebgp-requires-policy
  neighbor 10.0.1.101 remote-as 99
+ neighbor 10.0.1.101 timers 3 10
  !
 !
 

--- a/tests/topotests/evpn-pim-1/leaf1/bgpd.conf
+++ b/tests/topotests/evpn-pim-1/leaf1/bgpd.conf
@@ -2,6 +2,7 @@
 router bgp 65002
    no bgp ebgp-requires-policy
    neighbor 192.168.1.1 remote-as external
+   neighbor 192.168.1.1 timers 3 10
    redistribute connected
    address-family l2vpn evpn
       neighbor 192.168.1.1 activate

--- a/tests/topotests/evpn-pim-1/leaf2/bgpd.conf
+++ b/tests/topotests/evpn-pim-1/leaf2/bgpd.conf
@@ -2,6 +2,7 @@
 router bgp 65003
   no bgp ebgp-requires-policy
   neighbor 192.168.2.1 remote-as external
+  neighbor 192.168.2.1 timers 3 10
   redistribute connected
   address-family l2vpn evpn
      neighbor 192.168.2.1 activate

--- a/tests/topotests/evpn-pim-1/spine/bgpd.conf
+++ b/tests/topotests/evpn-pim-1/spine/bgpd.conf
@@ -2,7 +2,9 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 192.168.1.2 remote-as external
+  neighbor 192.168.1.2 timers 3 10
   neighbor 192.168.2.3 remote-as external
+  neighbor 192.168.2.3 timers 3 10
   redistribute connected
   address-family l2vpn evpn
     neighbor 192.168.1.2 activate

--- a/tests/topotests/pim-basic/r1/bgpd.conf
+++ b/tests/topotests/pim-basic/r1/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65001
   no bgp ebgp-requires-policy
   neighbor 10.0.30.3 remote-as external
+  neighbor 10.0.30.3 timers 3 10
   redistribute connected

--- a/tests/topotests/pim-basic/rp/bgpd.conf
+++ b/tests/topotests/pim-basic/rp/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65003
    no bgp ebgp-requires-policy
    neighbor 10.0.30.1 remote-as external
+   neighbor 10.0.30.1 timers 3 10
    redistribute connected


### PR DESCRIPTION
Modify bgpd.conf in all easily accessible topotests to use 3 10
as their timers du jour.  This will allow the tests to converge
faster.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>