### PR TITLE
[7.5] pbrd: add frr-vrf to the list of implemented yang modules

### DIFF
--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -117,6 +117,7 @@ struct quagga_signal_t pbr_signals[] = {
 static const struct frr_yang_module_info *const pbrd_yang_modules[] = {
 	&frr_filter_info,
 	&frr_interface_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(pbrd, PBR, .vty_port = PBR_VTY_PORT,


### PR DESCRIPTION
PR #6376 introduced a VRF leafref in the frr-interface YANG module.
That change exposed a bug in the northbound layer that is causing
pbrd to crash under certain circumstances. Even though pbrd wasn't
converted to the new northbound model yet, make it implement the
frr-vrf module in order to work around this problem. This is a
temporary fix until a better solution is available.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>