### PR TITLE
snapcraft: Update libyang version

### DIFF
--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -273,12 +273,12 @@ parts:
            - libpcre3
         source: https://github.com/CESNET/libyang.git
         source-type: git
-        source-tag: v0.16-r3
+        source-tag: v1.0.184
         plugin: cmake
         configflags:
            - -DCMAKE_INSTALL_PREFIX:PATH=/usr
            - -DENABLE_LYD_PRIV=ON
-           - -DENABLE_CACHE=OFF
+           - -DENABLE_CACHE=ON
            - -DCMAKE_BUILD_TYPE:String="Release"
     frr: 
         after: [rtrlib,libyang]


### PR DESCRIPTION
Update the snapcraft build of libyang to the version we
actually want to be using v1.0.184

Signed-off-by: Donald Sharp <sharpd@nvidia.com>