### PR TITLE
ospfd: fix debug ospf nssa prints wrong info

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -1796,7 +1796,15 @@ struct ospf_lsa *ospf_translated_nssa_originate(struct ospf *ospf,
 		return NULL;
 	}
 
-	extnew = (struct as_external_lsa *)new;
+	extnew = (struct as_external_lsa *)new->data;
+
+	if ((new = ospf_lsa_install(ospf, NULL, new)) == NULL) {
+		flog_warn(
+			EC_OSPF_LSA_INSTALL_FAILURE,
+			"ospf_lsa_translated_nssa_originate(): Could not install LSA id %s",
+			inet_ntoa(type7->data->id));
+		return NULL;
+	}
 
 	if (IS_DEBUG_OSPF_NSSA) {
 		zlog_debug(
@@ -1805,13 +1813,6 @@ struct ospf_lsa *ospf_translated_nssa_originate(struct ospf *ospf,
 		zlog_debug("   Network mask: %d", ip_masklen(extnew->mask));
 		zlog_debug("   Forward addr: %s",
 			   inet_ntoa(extnew->e[0].fwd_addr));
-	}
-
-	if ((new = ospf_lsa_install(ospf, NULL, new)) == NULL) {
-		flog_warn(EC_OSPF_LSA_INSTALL_FAILURE,
-			  "ospf_lsa_translated_nssa_originate(): Could not install LSA id %s",
-			  inet_ntoa(type7->data->id));
-		return NULL;
 	}
 
 	ospf->lsa_originate_count++;


### PR DESCRIPTION
The command `debug ospf nssa` is printing wrong LSA information when LSA type 7 is translated to Type 5. Comparing the output with `show ip ospf database external` we can see checksum, forward address and mask are not correct. 

```
Sep 10 12:32:11 r2 ospfd[28733]: ospf_translated_nssa_originate(): translated Type 7, installed:
Sep 10 12:32:11 r2 ospfd[28733]:   LSA Header
Sep 10 12:32:11 r2 ospfd[28733]:     LS age 0
Sep 10 12:32:11 r2 ospfd[28733]:     Options 2 (*|-|-|-|-|-|E|-)
Sep 10 12:32:11 r2 ospfd[28733]:     LS type 5 (AS-external-LSA)
Sep 10 12:32:11 r2 ospfd[28733]:     Link State ID 5.5.5.5
Sep 10 12:32:11 r2 ospfd[28733]:     Advertising Router 2.2.2.2
Sep 10 12:32:11 r2 ospfd[28733]:     LS sequence number 0x80000001
Sep 10 12:32:11 r2 ospfd[28733]:     LS checksum 0x0                  <--- *** should be 0x29c8
Sep 10 12:32:11 r2 ospfd[28733]:     length 36
Sep 10 12:32:11 r2 ospfd[28733]:    Network mask: 0                   <--- *** should be 32
Sep 10 12:32:11 r2 ospfd[28733]:    Forward addr: 0.0.0.0             <--- *** should be 44.44.44.44
Sep 10 12:32:11 r2 ospfd[28733]: Flood/AS: NSSA TRANSLATED LSA

r1# sh ip os database external

       OSPF Router with ID (1.1.1.1)

                AS External Link States

  LS age: 5
  Options: 0x2  : *|-|-|-|-|-|E|-
  LS Flags: 0x6
  LS Type: AS-external-LSA
  Link State ID: 5.5.5.5 (External Network Number)
  Advertising Router: 2.2.2.2
  LS Seq Number: 80000001
  Checksum: 0x29c8
  Length: 36

  Network Mask: /32
        Metric Type: 2 (Larger than any link state path)
        TOS: 0
        Metric: 20
        Forward Address: 44.44.44.44
        External Route Tag: 0
```
Signed-off-by: ckishimo <carles.kishimoto@gmail.com>