### PR TITLE
lib: better support for nested YANG augmentations

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -122,8 +122,8 @@ static int nb_node_new_cb(const struct lys_node *snode, void *arg)
 	if (CHECK_FLAG(snode->nodetype, LYS_CONTAINER | LYS_LIST)) {
 		bool config_only = true;
 
-		yang_snodes_iterate_subtree(snode, nb_node_check_config_only,
-					    YANG_ITER_ALLOW_AUGMENTATIONS,
+		yang_snodes_iterate_subtree(snode, NULL,
+					    nb_node_check_config_only, 0,
 					    &config_only);
 		if (config_only)
 			SET_FLAG(nb_node->flags, F_NB_NODE_CONFIG_ONLY);
@@ -141,6 +141,7 @@ static int nb_node_new_cb(const struct lys_node *snode, void *arg)
 	 * another.
 	 */
 	nb_node->snode = snode;
+	assert(snode->priv == NULL);
 	lys_set_private(snode, nb_node);
 
 	return YANG_ITER_CONTINUE;

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -102,9 +102,6 @@ enum yang_iter_flags {
 
 	/* Filter implicitely created nodes. */
 	YANG_ITER_FILTER_IMPLICIT = (1<<3),
-
-	/* Allow iteration over augmentations. */
-	YANG_ITER_ALLOW_AUGMENTATIONS = (1<<4),
 };
 
 /* Callback used by the yang_snodes_iterate_*() family of functions. */
@@ -168,6 +165,9 @@ extern void yang_module_embed(struct yang_module_embed *embed);
  * snode
  *    YANG schema node to operate on.
  *
+ * module
+ *    When set, iterate over all nodes of the specified module only.
+ *
  * cb
  *    Function to call with each schema node.
  *
@@ -181,6 +181,7 @@ extern void yang_module_embed(struct yang_module_embed *embed);
  *    The return value of the last called callback.
  */
 extern int yang_snodes_iterate_subtree(const struct lys_node *snode,
+				       const struct lys_module *module,
 				       yang_iterate_cb cb, uint16_t flags,
 				       void *arg);
 


### PR DESCRIPTION
Change the way the YANG schema node iteration functions work so that
the northbound layer won't have issues with more complex YANG modules
that contain multiple levels of YANG augmentations or modules that
augment themselves indirectly (by augmenting groupings).

Summary of the changes:
* Change the `yang_snodes_iterate_subtree()` function to always follow
  augmentations and add an optional "module" parameter to narrow down
  the iteration to nodes of a single module (which is necessary in
  some cases). Also, remove the `YANG_ITER_ALLOW_AUGMENTATIONS` flag
  as it's no longer necessary.
* Change `yang_snodes_iterate_all()` to do a DFS iteration on the resolved
  YANG data hierarchy instead of iterating over each module and their
  augmentations sequentially.

Reported-by: Rafael Zalamena <rzalamena@opensourcerouting.org>
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>