### PR TITLE
pimd: Warn when we try to build MAXVIFS > 256

### DIFF
--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -44,6 +44,10 @@
 #include "pim_zebra.h"
 #include "pim_mlag.h"
 
+#if MAXVIFS > 256
+CPP_NOTICE("Work needs to be done to make this work properly via the pim mroute socket\n");
+#endif /* MAXVIFS > 256 */
+
 const char *const PIM_ALL_SYSTEMS = MCAST_ALL_SYSTEMS;
 const char *const PIM_ALL_ROUTERS = MCAST_ALL_ROUTERS;
 const char *const PIM_ALL_PIM_ROUTERS = MCAST_ALL_PIM_ROUTERS;


### PR DESCRIPTION
We use the pim mroute socket for kernel notifications of events.
Currently this is limited to 8 bits of data.  There are patches
coming down the pike in kernel land to allow this to expand.
Rather than fix this and all the other places we assume MAXVIFS < 256
in the pim code right now.  Leave a land mine for the developer
doing this work to point them in the right direction.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>