### PR TITLE
ospfd: flush type 5 when type 7 is removed

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -642,6 +642,15 @@ static int ospf_abr_translate_nssa(struct ospf_area *area, struct ospf_lsa *lsa)
 	old = ospf_external_info_find_lsa(area->ospf, &p);
 
 	if (old) {
+		/* Do not continue if type 5 LSA not approved */
+		if (!CHECK_FLAG(old->flags, OSPF_LSA_APPROVED)) {
+			if (IS_DEBUG_OSPF_NSSA)
+				zlog_debug(
+					"ospf_abr_translate_nssa(): LSA Id %s type 5 is not approved",
+					inet_ntoa(old->data->id));
+			return 1;
+		}
+
 		if (IS_DEBUG_OSPF_NSSA)
 			zlog_debug(
 				"ospf_abr_translate_nssa(): found old translated LSA Id %s, refreshing",


### PR DESCRIPTION
When the ASBR stops announcing a prefix into the NSSA area, the LSA
type 7 is removed from the area. However the ABR is refreshing the
type 5 in its LSDB while removing the Type 7 LSA. Routers outside
the area do not get an update.

With this change the LSA type 5 is flushed from the LSDB and the
change is announced to routers outside the area

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>