### PR TITLE
lib: fix crashes with leafrefs that point to non-implemented modules

### DIFF
--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -573,7 +573,7 @@ void nb_cli_show_dnode_cmds(struct vty *vty, struct lyd_node *root,
 		struct nb_node *nb_node;
 
 		nb_node = child->schema->priv;
-		if (!nb_node->cbs.cli_show)
+		if (!nb_node || !nb_node->cbs.cli_show)
 			goto next;
 
 		/* Skip default values. */
@@ -591,7 +591,7 @@ void nb_cli_show_dnode_cmds(struct vty *vty, struct lyd_node *root,
 		parent = ly_iter_next_up(child);
 		if (parent != NULL) {
 			nb_node = parent->schema->priv;
-			if (nb_node->cbs.cli_show_end)
+			if (nb_node && nb_node->cbs.cli_show_end)
 				(*nb_node->cbs.cli_show_end)(vty, parent);
 		}
 

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -119,7 +119,6 @@ static struct quagga_signal_t sighandlers[] = {
 static const struct frr_yang_module_info *const nhrpd_yang_modules[] = {
 	&frr_filter_info,
 	&frr_interface_info,
-	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(nhrpd, NHRP, .vty_port = NHRP_VTY_PORT,

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -117,7 +117,6 @@ struct quagga_signal_t pbr_signals[] = {
 static const struct frr_yang_module_info *const pbrd_yang_modules[] = {
 	&frr_filter_info,
 	&frr_interface_info,
-	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(pbrd, PBR, .vty_port = PBR_VTY_PORT,


### PR DESCRIPTION
Whenever libyang loads a module that contains a leafref, it will
also implicitly load the module of the referring node if it's
not loaded already. That makes sense as otherwise it wouldn't be
possible to validate the leafref value correctly.

The problem is that loading a module implicitly violates the
assumption of the northbound layer that all loaded modules
are implemented (i.e. they have a northbound node associated
to each schema node). This means that loading a module that
isn't implemented can lead to crashes as the "priv" pointer
of schema nodes is no longer guaranteed to be valid. To fix this
problem, add a few null checks to ignore data nodes associated
to non-implemented modules.

The side effect of this change is harmless. If a daemon receives
configuration it doesn't support (e.g. BFD peers on staticd),
that configuration will be stored but otherwise ignored. This can
only happen when using a northbound client like gRPC, as the CLI
will never send to a daemon a command it doesn't support. This
minor problem should go away in the long run as FRR migrates to
a centralized management model, at which point the YANG-modeled
configuration of all daemons will be maintained in a single place.

Finally, update some daemons to stop implementing YANG modules
they don't need to (i.e. revert 1b741a01c and a74b47f5).

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>