### PR TITLE
doc: clarify python and pip2 for ubuntu 20

### DIFF
--- a/doc/developer/building-frr-for-ubuntu2004.rst
+++ b/doc/developer/building-frr-for-ubuntu2004.rst
@@ -28,7 +28,7 @@ ubuntu apt repositories; in order to install it:
 .. code-block:: shell
 
    curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
-   sudo ./get-pip.py
+   sudo python2 ./get-pip.py
 
    # And verify the installation
    pip2 --version


### PR DESCRIPTION
Must run the pip2 install script with python2 on ubuntu 20; make that explicit in the dev doc. Thanks to Don Slice for pointing this out!
