### PR TITLE
bgpd: fix ecom leak handling l3vni update

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -519,6 +519,8 @@ static void form_auto_rt(struct bgp *bgp, vni_t vni, struct list *rtl)
 
 	if (!ecom_found)
 		listnode_add_sort(rtl, ecomadd);
+	else
+		ecommunity_free(&ecomadd);
 }
 
 /*


### PR DESCRIPTION
This was a part of pending commits on evpn-mh branch -
[
bgpd: fix ecom leak handling l3vni update
Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>
]

Tagging @qlyoung 
