### PR TITLE
zebra: re-name some mh functions to make the code more readable

### DIFF
--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -921,7 +921,7 @@ zebra_evpn_t *zebra_evpn_add(vni_t vni)
 	zevpn = hash_get(zvrf->evpn_table, &tmp_zevpn, zebra_evpn_alloc);
 	assert(zevpn);
 
-	zebra_evpn_evpn_es_init(zevpn);
+	zebra_evpn_es_evi_init(zevpn);
 
 	/* Create hash table for MAC */
 	zevpn->mac_table = zebra_mac_db_create("Zebra EVPN MAC Table");
@@ -951,7 +951,7 @@ int zebra_evpn_del(zebra_evpn_t *zevpn)
 	hash_free(zevpn->mac_table);
 	zevpn->mac_table = NULL;
 
-	zebra_evpn_evpn_es_cleanup(zevpn);
+	zebra_evpn_es_evi_cleanup(zevpn);
 
 	/* Free the EVPN hash entry and allocated memory. */
 	tmp_zevpn = hash_release(zvrf->evpn_table, zevpn);

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -363,7 +363,7 @@ void zebra_evpn_es_evi_show_vni(struct vty *vty, bool uj, vni_t vni, int detail)
 }
 
 /* Initialize the ES tables maintained per-L2_VNI */
-void zebra_evpn_evpn_es_init(zebra_evpn_t *zevpn)
+void zebra_evpn_es_evi_init(zebra_evpn_t *zevpn)
 {
 	/* Initialize the ES-EVI RB tree */
 	RB_INIT(zebra_es_evi_rb_head, &zevpn->es_evi_rb_tree);
@@ -376,7 +376,7 @@ void zebra_evpn_evpn_es_init(zebra_evpn_t *zevpn)
 }
 
 /* Cleanup the ES info maintained per- EVPN */
-void zebra_evpn_evpn_es_cleanup(zebra_evpn_t *zevpn)
+void zebra_evpn_es_evi_cleanup(zebra_evpn_t *zevpn)
 {
 	struct zebra_evpn_es_evi *es_evi;
 	struct zebra_evpn_es_evi *es_evi_next;

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -198,8 +198,8 @@ extern void zebra_evpn_mh_terminate(void);
 extern bool zebra_evpn_is_if_es_capable(struct zebra_if *zif);
 extern void zebra_evpn_if_init(struct zebra_if *zif);
 extern void zebra_evpn_if_cleanup(struct zebra_if *zif);
-extern void zebra_evpn_evpn_es_init(zebra_evpn_t *zevpn);
-extern void zebra_evpn_evpn_es_cleanup(zebra_evpn_t *zevpn);
+extern void zebra_evpn_es_evi_init(zebra_evpn_t *zevpn);
+extern void zebra_evpn_es_evi_cleanup(zebra_evpn_t *zevpn);
 extern void zebra_evpn_vxl_evpn_set(struct zebra_if *zif, zebra_evpn_t *zevpn,
 		bool set);
 extern void zebra_evpn_es_set_base_evpn(zebra_evpn_t *zevpn);


### PR DESCRIPTION
As a part of the re-factoring some of the evpn_vni_es apis got re-named
as evpn_evpn_es. Changed them to evpn_es_evi to make it common to
vxlan and mpls.

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>