### PR TITLE
bgpd: remove extra hold-timer reset

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1775,10 +1775,6 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 
 	peer->update_time = bgp_clock();
 
-	/* Rearm holdtime timer */
-	BGP_TIMER_OFF(peer->t_holdtime);
-	bgp_timer_set(peer);
-
 	return Receive_UPDATE_message;
 }
 


### PR DESCRIPTION
Handler function doesn't need to reset the hold timer, this is done
during the FSM update.

There's a double cancel-set sequence visible in a trace

![2020-09-15-201833_1598x131_scrot](https://user-images.githubusercontent.com/6827003/93277780-b7d8a000-f790-11ea-95af-0631fba92935.png)

Signed-off-by: Quentin Young <qlyoung@nvidia.com>