### PR TITLE
evpn-mh: mac-ip sync hold timers

### DIFF
--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -2099,7 +2099,7 @@ int zebra_evpn_mh_neigh_holdtime_update(struct vty *vty,
 		uint32_t duration, bool set_default)
 {
 	if (set_default)
-		zmh_info->neigh_hold_time = EVPN_MH_NEIGH_HOLD_TIME_DEF;
+		duration = EVPN_MH_NEIGH_HOLD_TIME_DEF;
 
 	zmh_info->neigh_hold_time = duration;
 

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -614,6 +614,9 @@ int zebra_evpn_neigh_del(zebra_evpn_t *zevpn, zebra_neigh_t *n)
 	/* Cancel auto recovery */
 	THREAD_OFF(n->dad_ip_auto_recovery_timer);
 
+	/* Cancel proxy hold timer */
+	zebra_evpn_neigh_stop_hold_timer(n);
+
 	/* Free the VNI hash entry and allocated memory. */
 	tmp_n = hash_release(zevpn->neigh_table, n);
 	XFREE(MTYPE_NEIGH, tmp_n);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -54,6 +54,7 @@
 #include "zebra/zebra_vxlan_private.h"
 #include "zebra/zebra_pbr.h"
 #include "zebra/zebra_nhg.h"
+#include "zebra/zebra_evpn_mh.h"
 #include "zebra/interface.h"
 #include "northbound_cli.h"
 #include "zebra/zebra_nb.h"
@@ -2355,6 +2356,33 @@ DEFUN (show_vrf,
 	return CMD_SUCCESS;
 }
 
+DEFPY (evpn_mh_mac_holdtime,
+       evpn_mh_mac_holdtime_cmd,
+       "[no$no] evpn mh mac-holdtime (0-86400)$duration",
+       NO_STR
+       "EVPN\n"
+       "Multihoming\n"
+       "MAC hold time\n"
+       "Duration in seconds\n")
+{
+	return zebra_evpn_mh_mac_holdtime_update(vty, duration,
+			no ? true : false);
+}
+
+DEFPY (evpn_mh_neigh_holdtime,
+       evpn_mh_neigh_holdtime_cmd,
+       "[no$no] evpn mh neigh-holdtime (0-86400)$duration",
+       NO_STR
+       "EVPN\n"
+       "Multihoming\n"
+       "Neighbor entry hold time\n"
+       "Duration in seconds\n")
+{
+
+	return zebra_evpn_mh_neigh_holdtime_update(vty, duration, 
+			no ? true : false);
+}
+
 DEFUN (default_vrf_vni_mapping,
        default_vrf_vni_mapping_cmd,
        "vni " CMD_VNI_RANGE "[prefix-routes-only]",
@@ -3403,6 +3431,8 @@ static int config_write_protocol(struct vty *vty)
 	/* Include dataplane info */
 	dplane_config_write_helper(vty);
 
+	zebra_evpn_mh_config_write(vty);
+
 	/* Include nexthop-group config */
 	if (!zebra_nhg_kernel_nexthops_enabled())
 		vty_out(vty, "no zebra nexthop kernel enable\n");
@@ -3899,6 +3929,8 @@ void zebra_vty_init(void)
 	install_element(VIEW_NODE, &show_pbr_ipset_cmd);
 	install_element(VIEW_NODE, &show_pbr_iptable_cmd);
 
+	install_element(CONFIG_NODE, &evpn_mh_mac_holdtime_cmd);
+	install_element(CONFIG_NODE, &evpn_mh_neigh_holdtime_cmd);
 	install_element(CONFIG_NODE, &default_vrf_vni_mapping_cmd);
 	install_element(CONFIG_NODE, &no_default_vrf_vni_mapping_cmd);
 	install_element(VRF_NODE, &vrf_vni_mapping_cmd);


### PR DESCRIPTION
When an Ethernet Segment peer withdraws a MAC-IP route we hold the entry for N seconds to allow the switch to independently/locally establish host reach-ability.

This PR has -
1. A commit to configure the hold-timer values
2. Couple of bugs fixes in the hold-timer handling.