### PR TITLE
bgpd: Avoid memset when tip hash is empty

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -563,7 +563,7 @@ bool bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
 	if (addr)
 		return true;
 
-	if (new_afi == AF_INET) {
+	if (new_afi == AF_INET && hashcount(bgp->tip_hash)) {
 		memset(&tmp_tip, 0, sizeof(struct tip_addr));
 		tmp_tip.addr = attr->nexthop;
 


### PR DESCRIPTION
The tip hash is only used when we are dealing with
evpn.  In bgp_nexthop_self we are doing a memset
irrelevant of whether we will ever find data.  Yes
hash_lookup will return pretty quickly.

Modify the code to avoid doing a memset in the case
where the tip hash is empty as that we know we'll
never find anything.  With full BGP feeds this
small memset does take some time.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>