### PR TITLE
zebra: dup detected mac avoid update to bgpd

### DIFF
--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -2060,6 +2060,7 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf, zebra_evpn_t *zevpn,
 			if (is_dup_detect) {
 				inform_client = false;
 				upd_neigh = false;
+				es_change = false;
 			}
 		}
 	}
@@ -2092,7 +2093,8 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf, zebra_evpn_t *zevpn,
 				mac->es ? mac->es->esi_str : "", mac->loc_seq,
 				mac->flags,
 				local_inactive ? " local-inactive" : "");
-		inform_client = true;
+		if (!is_dup_detect)
+			inform_client = true;
 	}
 
 	if (es_change) {


### PR DESCRIPTION
When a MAC is detected duplicate on a local learn event (with freeze action),
do not send update to bgp to advertise into evpn control plane.

With evpn mh, inform_client flag is set and sends notification to bgp albeit dup detect
is set.

Check mac are detected as duplicate before setting inform_client to true.

Testing Done:

Enable DAD with freeze action 
Upon local learn MAC detected as duplicate.

Signed-off-by: Chirag Shah <chirag@nvidia.com>