### PR TITLE
zebra: fixup a neigh del bug introduced by a previous commit for MAC-IP sync

### DIFF
--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -2184,9 +2184,10 @@ void process_neigh_remote_macip_add(zebra_evpn_t *zevpn, struct zebra_vrf *zvrf,
 						seq, n->flags);
 				zebra_evpn_neigh_clear_sync_info(n);
 				if (IS_ZEBRA_NEIGH_ACTIVE(n))
-					zebra_evpn_mac_send_del_to_client(
-						zevpn->vni, &mac->macaddr,
-						mac->flags, false /*force*/);
+					zebra_evpn_neigh_send_del_to_client(
+						zevpn->vni, &n->ip, &n->emac,
+						n->flags, n->state,
+						false /*force*/);
 			}
 			if (memcmp(&n->emac, &mac->macaddr,
 				   sizeof(struct ethaddr))


### PR DESCRIPTION
Backport from master to 7.5 -
>>>>>>>>>>>>>>>>>>>
Problem commit -
[
b169fd6fd59ed zebra: support for MAC-IP sync routes
]

That commit had accidentally replaced a mac-ip del to bgp with a mac
del (consequence of a bad cut-paste).

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>
(cherry picked from commit fb8f609d486f132c7fab41d6bb67372d829137aa)