### PR TITLE
ospfd: do not generate type 4 LSA from NSSA ABR

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -1153,6 +1153,15 @@ static void ospf_abr_announce_rtr(struct ospf *ospf, struct prefix_ipv4 *p,
 		if (ospf_abr_nexthops_belong_to_area(or, area))
 			continue;
 
+		/* RFC3101: Do not generate ASBR type 4 LSA if NSSA ABR */
+		if (or->u.std.external_routing == OSPF_AREA_NSSA) {
+			if (IS_DEBUG_OSPF_EVENT)
+				zlog_debug(
+					"ospf_abr_announce_rtr(): do not generate LSA Type-4 %s from NSSA",
+					inet_ntoa(p->prefix));
+			continue;
+		}
+
 		if (area->external_routing != OSPF_AREA_DEFAULT) {
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(


### PR DESCRIPTION
In a topology like R1 -- R2 -- R5, with R2 being NSSA ABR and R5 being
ASBR redistributing external routes, the ABR R2 will translate type-7
LSA into type-5 and advertise to the backbone. In the current implementation
R2 is also advertising a type-4 LSA when there is no need.

RFC 3101: "...NSSA's border routers never originate Type-4 summary-LSAs
for the NSSA's AS boundary routers, since Type-7 AS-external-LSAs are
never flooded beyond the NSSA's border..."

With this PR a type-4 LSA will not be advertised

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>