### PR TITLE
bgpd: rename bgp_fsm_event_update

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -361,7 +361,7 @@ static void bgp_bfd_peer_status_update(struct peer *peer, int status,
 	if ((status == BFD_STATUS_UP) && (old_status == BFD_STATUS_DOWN)
 	    && peer->status != Established) {
 		if (!BGP_PEER_START_SUPPRESSED(peer)) {
-			bgp_fsm_event_update(peer, 1);
+			bgp_fsm_nht_update(peer, true);
 			BGP_EVENT_ADD(peer, BGP_Start);
 		}
 	}

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2037,24 +2037,24 @@ static int bgp_fsm_exeption(struct peer *peer)
 	return (bgp_stop(peer));
 }
 
-void bgp_fsm_event_update(struct peer *peer, int valid)
+void bgp_fsm_nht_update(struct peer *peer, bool has_valid_nexthops)
 {
 	if (!peer)
 		return;
 
 	switch (peer->status) {
 	case Idle:
-		if (valid)
+		if (has_valid_nexthops)
 			BGP_EVENT_ADD(peer, BGP_Start);
 		break;
 	case Connect:
-		if (!valid) {
+		if (!has_valid_nexthops) {
 			BGP_TIMER_OFF(peer->t_connect);
 			BGP_EVENT_ADD(peer, TCP_fatal_error);
 		}
 		break;
 	case Active:
-		if (valid) {
+		if (has_valid_nexthops) {
 			BGP_TIMER_OFF(peer->t_connect);
 			BGP_EVENT_ADD(peer, ConnectRetry_timer_expired);
 		}
@@ -2062,7 +2062,8 @@ void bgp_fsm_event_update(struct peer *peer, int valid)
 	case OpenSent:
 	case OpenConfirm:
 	case Established:
-		if (!valid && (peer->gtsm_hops == BGP_GTSM_HOPS_CONNECTED))
+		if (!has_valid_nexthops
+		    && (peer->gtsm_hops == BGP_GTSM_HOPS_CONNECTED))
 			BGP_EVENT_ADD(peer, TCP_fatal_error);
 	case Clearing:
 	case Deleted:

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -109,7 +109,11 @@
 	 && !CHECK_FLAG(peer->cap, PEER_CAP_RESTART_BIT_ADV))
 
 /* Prototypes. */
-extern void bgp_fsm_event_update(struct peer *peer, int valid);
+
+/*
+ * Update FSM for peer based on whether we have valid nexthops or not.
+ */
+extern void bgp_fsm_nht_update(struct peer *peer, bool has_valid_nexthops);
 extern int bgp_event(struct thread *);
 extern int bgp_event_update(struct peer *, enum bgp_fsm_events event);
 extern int bgp_stop(struct peer *peer);

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -846,7 +846,7 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 					"%s: Updating peer (%s(%s)) status with NHT",
 					__func__, peer->host,
 					peer->bgp->name_pretty);
-			bgp_fsm_event_update(peer, valid_nexthops);
+			bgp_fsm_nht_update(peer, !!valid_nexthops);
 			SET_FLAG(bnc->flags, BGP_NEXTHOP_PEER_NOTIFIED);
 		}
 	}


### PR DESCRIPTION
This function is poorly named; it's really used to allow the FSM to
decide the next valid state based on whether a peer has valid /
reachable nexthops as determined by NHT or BFD.

Signed-off-by: Quentin Young <qlyoung@nvidia.com>