### PR TITLE
tests: increase timeout to avoid intermittent LDP Sync test failure

### DIFF
--- a/tests/topotests/ldp-sync-isis-topo1/test_ldp_sync_isis_topo1.py
+++ b/tests/topotests/ldp-sync-isis-topo1/test_ldp_sync_isis_topo1.py
@@ -163,9 +163,9 @@ def router_compare_json_output(rname, command, reference):
     filename = "{}/{}/{}".format(CWD, rname, reference)
     expected = json.loads(open(filename).read())
 
-    # Run test function until we get an result. Wait at most 80 seconds.
+    # Run test function until we get an result.
     test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=160, wait=0.5)
+    _, diff = topotest.run_and_expect(test_func, None, count=320, wait=0.5)
     assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
     assert diff is None, assertmsg
 

--- a/tests/topotests/ldp-sync-ospf-topo1/test_ldp_sync_ospf_topo1.py
+++ b/tests/topotests/ldp-sync-ospf-topo1/test_ldp_sync_ospf_topo1.py
@@ -162,9 +162,9 @@ def router_compare_json_output(rname, command, reference):
     filename = "{}/{}/{}".format(CWD, rname, reference)
     expected = json.loads(open(filename).read())
 
-    # Run test function until we get an result. Wait at most 80 seconds.
+    # Run test function until we get an result.
     test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=160, wait=0.5)
+    _, diff = topotest.run_and_expect(test_func, None, count=320, wait=0.5)
     assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
     assert diff is None, assertmsg
 


### PR DESCRIPTION
tests: increase timeout to avoid intermittent LDP Sync test failure

Signed-off-by: Karen Schoener <karen@voltanet.io>