### PR TITLE
tests: use .items instead of .iteritems in topotests

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -722,7 +722,7 @@ Example:
 .. code:: py
 
    # For all registered routers, load the zebra configuration file
-   for rname, router in router_list.iteritems():
+   for rname, router in router_list.items():
        router.load_config(
            TopoRouter.RD_ZEBRA,
            os.path.join(CWD, '{}/zebra.conf'.format(rname))

--- a/tests/topotests/bfd-bgp-cbit-topo3/test_bfd_bgp_cbit_topo3.py
+++ b/tests/topotests/bfd-bgp-cbit-topo3/test_bfd_bgp_cbit_topo3.py
@@ -72,7 +72,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname)),
         )

--- a/tests/topotests/bfd-isis-topo1/test_bfd_isis_topo1.py
+++ b/tests/topotests/bfd-isis-topo1/test_bfd_isis_topo1.py
@@ -136,7 +136,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bfd-profiles-topo1/test_bfd_profiles_topo1.py
+++ b/tests/topotests/bfd-profiles-topo1/test_bfd_profiles_topo1.py
@@ -84,7 +84,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         daemon_file = "{}/{}/bfdd.conf".format(CWD, rname)
         if os.path.isfile(daemon_file):
             router.load_config(TopoRouter.RD_BFD, daemon_file)

--- a/tests/topotests/bfd-topo1/test_bfd_topo1.py
+++ b/tests/topotests/bfd-topo1/test_bfd_topo1.py
@@ -76,7 +76,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bfd-topo2/test_bfd_topo2.py
+++ b/tests/topotests/bfd-topo2/test_bfd_topo2.py
@@ -77,7 +77,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bfd-topo3/test_bfd_topo3.py
+++ b/tests/topotests/bfd-topo3/test_bfd_topo3.py
@@ -76,7 +76,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         daemon_file = "{}/{}/bfdd.conf".format(CWD, rname)
         if os.path.isfile(daemon_file):
             router.load_config(TopoRouter.RD_BFD, daemon_file)

--- a/tests/topotests/bfd-vrf-topo1/test_bfd_vrf_topo1.py
+++ b/tests/topotests/bfd-vrf-topo1/test_bfd_vrf_topo1.py
@@ -79,7 +79,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # check for zebra capability
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         if router.check_capability(TopoRouter.RD_ZEBRA, "--vrfwnetns") == False:
             return pytest.skip(
                 "Skipping BFD Topo1 VRF NETNS feature. VRF NETNS backend not available on FRR"
@@ -105,7 +105,7 @@ def setup_module(mod):
         "ip netns exec {0}-cust1 ifconfig {0}-eth2 up",
     ]
 
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         # create VRF rx-cust1 and link rx-eth0 to rx-cust1
         for cmd in cmds:
             output = tgen.net[rname].cmd(cmd.format(rname))
@@ -113,7 +113,7 @@ def setup_module(mod):
             for cmd in cmds2:
                 output = tgen.net[rname].cmd(cmd.format(rname))
 
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA,
             os.path.join(CWD, "{}/zebra.conf".format(rname)),
@@ -145,7 +145,7 @@ def teardown_module(_mod):
     ]
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         if rname == "r2":
             for cmd in cmds2:
                 tgen.net[rname].cmd(cmd.format(rname))

--- a/tests/topotests/bgp-auth/test_bgp_auth.py
+++ b/tests/topotests/bgp-auth/test_bgp_auth.py
@@ -217,7 +217,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # For all registred routers, load the zebra configuration file
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )
@@ -273,7 +273,7 @@ def print_diag(vrf):
     
     tgen = get_topogen()
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         print(rname + ":")
         print(router.vtysh_cmd("show run"))
         print(router.vtysh_cmd("show ip route {}".format(vrf_str(vrf))))
@@ -285,7 +285,7 @@ def configure(conf_file):
 
     tgen = get_topogen()
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         with open(
             os.path.join(CWD, "{}/{}").format(router.name, conf_file), "r+"
         ) as cfg:
@@ -321,7 +321,7 @@ def clear_ospf(vrf=""):
 
     tgen = get_topogen()
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         if vrf == "":
             router.vtysh_cmd("conf t\nno router ospf")
         else:

--- a/tests/topotests/bgp-ecmp-topo1/test_bgp_ecmp_topo1.py
+++ b/tests/topotests/bgp-ecmp-topo1/test_bgp_ecmp_topo1.py
@@ -95,7 +95,7 @@ def setup_module(module):
 
     # Starting Routers
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )
@@ -107,7 +107,7 @@ def setup_module(module):
     # Starting Hosts and init ExaBGP on each of them
     topotest.sleep(10, "starting BGP on all {} peers".format(total_ebgp_peers))
     peer_list = tgen.exabgp_peers()
-    for pname, peer in peer_list.iteritems():
+    for pname, peer in peer_list.items():
         peer_dir = os.path.join(CWD, pname)
         env_file = os.path.join(CWD, "exabgp.env")
         peer.start(peer_dir, env_file)

--- a/tests/topotests/bgp-ecmp-topo2/test_ebgp_ecmp_topo2.py
+++ b/tests/topotests/bgp-ecmp-topo2/test_ebgp_ecmp_topo2.py
@@ -145,7 +145,7 @@ def setup_module(mod):
 
     link_data = [
         val
-        for links, val in topo["routers"]["r2"]["links"].iteritems()
+        for links, val in topo["routers"]["r2"]["links"].items()
         if "r3" in links
     ]
     for adt in ADDR_TYPES:
@@ -162,7 +162,7 @@ def setup_module(mod):
 
     link_data = [
         val
-        for links, val in topo["routers"]["r3"]["links"].iteritems()
+        for links, val in topo["routers"]["r3"]["links"].items()
         if "r2" in links
     ]
     INTF_LIST_R3 = [val["interface"].split("/")[0] for val in link_data]

--- a/tests/topotests/bgp-ecmp-topo2/test_ibgp_ecmp_topo2.py
+++ b/tests/topotests/bgp-ecmp-topo2/test_ibgp_ecmp_topo2.py
@@ -146,7 +146,7 @@ def setup_module(mod):
 
     link_data = [
         val
-        for links, val in topo["routers"]["r2"]["links"].iteritems()
+        for links, val in topo["routers"]["r2"]["links"].items()
         if "r3" in links
     ]
     for adt in ADDR_TYPES:
@@ -163,7 +163,7 @@ def setup_module(mod):
 
     link_data = [
         val
-        for links, val in topo["routers"]["r3"]["links"].iteritems()
+        for links, val in topo["routers"]["r3"]["links"].items()
         if "r2" in links
     ]
     INTF_LIST_R3 = [val["interface"].split("/")[0] for val in link_data]

--- a/tests/topotests/bgp-evpn-mh/test_evpn_mh.py
+++ b/tests/topotests/bgp-evpn-mh/test_evpn_mh.py
@@ -384,7 +384,7 @@ def setup_module(module):
     # tgen.mininet_cli()
     # This is a sample of configuration loading.
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )
@@ -416,7 +416,7 @@ def check_local_es(esi, vtep_ips, dut_name, down_vteps):
     else:
         tor_ips_rack = tor_ips_rack_2
 
-    for tor_name, tor_ip in tor_ips_rack.iteritems():
+    for tor_name, tor_ip in tor_ips_rack.items():
         if dut_name not in tor_name:
             peer_ips.append(tor_ip)
 
@@ -442,7 +442,7 @@ def check_remote_es(esi, vtep_ips, dut_name, down_vteps):
     else:
         tor_ips_rack = tor_ips_rack_1
 
-    for tor_name, tor_ip in tor_ips_rack.iteritems():
+    for tor_name, tor_ip in tor_ips_rack.items():
         remote_ips.append(tor_ip)
 
     # remove down VTEPs from the remote check list
@@ -464,7 +464,7 @@ def check_es(dut):
 
     result = None
 
-    expected_es_set = set([v for k, v in host_es_map.iteritems()])
+    expected_es_set = set([v for k, v in host_es_map.items()])
     curr_es_set = []
 
     # check is ES content is correct
@@ -588,7 +588,7 @@ def check_mac(dut, vni, mac, m_type, esi, intf):
     out = dut.vtysh_cmd("show evpn mac vni %d mac %s json" % (vni, mac))
 
     mac_js = json.loads(out)
-    for mac, info in mac_js.iteritems():
+    for mac, info in mac_js.items():
         tmp_esi = info.get("esi", "")
         tmp_m_type =  info.get("type", "")
         tmp_intf = info.get("intf", "") if tmp_m_type == "local" else ""

--- a/tests/topotests/bgp-evpn-vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -122,7 +122,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # For all registred routers, load the zebra configuration file
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp-vrf-route-leak-basic/test_bgp-vrf-route-leak-basic.py
+++ b/tests/topotests/bgp-vrf-route-leak-basic/test_bgp-vrf-route-leak-basic.py
@@ -57,7 +57,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         router.run("/bin/bash {}/setup_vrfs".format(CWD))
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))

--- a/tests/topotests/bgp_aggregate-address_origin/test_bgp_aggregate-address_origin.py
+++ b/tests/topotests/bgp_aggregate-address_origin/test_bgp_aggregate-address_origin.py
@@ -66,7 +66,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_aggregate-address_route-map/test_bgp_aggregate-address_route-map.py
+++ b/tests/topotests/bgp_aggregate-address_route-map/test_bgp_aggregate-address_route-map.py
@@ -69,7 +69,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_as_wide_bgp_identifier/test_bgp_as_wide_bgp_identifier.py
+++ b/tests/topotests/bgp_as_wide_bgp_identifier/test_bgp_as_wide_bgp_identifier.py
@@ -65,7 +65,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_comm-list_delete/test_bgp_comm-list_delete.py
+++ b/tests/topotests/bgp_comm-list_delete/test_bgp_comm-list_delete.py
@@ -64,7 +64,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_default-route_route-map/test_bgp_default-originate_route-map.py
+++ b/tests/topotests/bgp_default-route_route-map/test_bgp_default-originate_route-map.py
@@ -69,7 +69,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_distance_change/test_bgp_distance_change.py
+++ b/tests/topotests/bgp_distance_change/test_bgp_distance_change.py
@@ -68,7 +68,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_ebgp_requires_policy/test_bgp_ebgp_requires_policy.py
+++ b/tests/topotests/bgp_ebgp_requires_policy/test_bgp_ebgp_requires_policy.py
@@ -82,7 +82,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -102,7 +102,7 @@ def setup_module(module):
 
     # Starting Routers
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_flowspec/test_bgp_flowspec_topo.py
+++ b/tests/topotests/bgp_flowspec/test_bgp_flowspec_topo.py
@@ -124,7 +124,7 @@ def setup_module(module):
     router.start()
 
     peer_list = tgen.exabgp_peers()
-    for pname, peer in peer_list.iteritems():
+    for pname, peer in peer_list.items():
         peer_dir = os.path.join(CWD, pname)
         env_file = os.path.join(CWD, "exabgp.env")
         peer.start(peer_dir, env_file)

--- a/tests/topotests/bgp_ipv6_rtadv/test_bgp_ipv6_rtadv.py
+++ b/tests/topotests/bgp_ipv6_rtadv/test_bgp_ipv6_rtadv.py
@@ -69,7 +69,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_link_bw_ip/test_bgp_linkbw_ip.py
+++ b/tests/topotests/bgp_link_bw_ip/test_bgp_linkbw_ip.py
@@ -119,7 +119,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA,
             os.path.join(CWD, '{}/zebra.conf'.format(rname))

--- a/tests/topotests/bgp_local_as_private_remove/test_bgp_local_as_private_remove.py
+++ b/tests/topotests/bgp_local_as_private_remove/test_bgp_local_as_private_remove.py
@@ -66,7 +66,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_maximum_prefix_invalid_update/test_bgp_maximum_prefix_invalid_update.py
+++ b/tests/topotests/bgp_maximum_prefix_invalid_update/test_bgp_maximum_prefix_invalid_update.py
@@ -66,7 +66,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_maximum_prefix_out/test_bgp_maximum_prefix_out.py
+++ b/tests/topotests/bgp_maximum_prefix_out/test_bgp_maximum_prefix_out.py
@@ -62,7 +62,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_prefix_sid/test_bgp_prefix_sid.py
+++ b/tests/topotests/bgp_prefix_sid/test_bgp_prefix_sid.py
@@ -75,7 +75,7 @@ def setup_module(module):
 
     logger.info("starting exaBGP on peer1")
     peer_list = tgen.exabgp_peers()
-    for pname, peer in peer_list.iteritems():
+    for pname, peer in peer_list.items():
         peer_dir = os.path.join(CWD, pname)
         env_file = os.path.join(CWD, "exabgp.env")
         logger.info("Running ExaBGP peer")

--- a/tests/topotests/bgp_reject_as_sets/test_bgp_reject_as_sets.py
+++ b/tests/topotests/bgp_reject_as_sets/test_bgp_reject_as_sets.py
@@ -73,7 +73,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_rr_ibgp/test_bgp_rr_ibgp_topo1.py
+++ b/tests/topotests/bgp_rr_ibgp/test_bgp_rr_ibgp_topo1.py
@@ -104,7 +104,7 @@ def setup_module(module):
 
     # This is a sample of configuration loading.
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_sender-as-path-loop-detection/test_bgp_sender-as-path-loop-detection.py
+++ b/tests/topotests/bgp_sender-as-path-loop-detection/test_bgp_sender-as-path-loop-detection.py
@@ -66,7 +66,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_set_local-preference_add_subtract/test_bgp_set_local-preference_add_subtract.py
+++ b/tests/topotests/bgp_set_local-preference_add_subtract/test_bgp_set_local-preference_add_subtract.py
@@ -64,7 +64,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_update_delay/test_bgp_update_delay.py
+++ b/tests/topotests/bgp_update_delay/test_bgp_update_delay.py
@@ -104,7 +104,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+    for i, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/test_bgp_vrf_lite_ipv6_rtadv.py
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/test_bgp_vrf_lite_ipv6_rtadv.py
@@ -95,7 +95,7 @@ def setup_module(mod):
         "ip link set {0}-eth0 master {0}-cust1",
     ]
 
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         for cmd in cmds:
             output = tgen.net[rname].cmd(cmd.format(rname))
 
@@ -109,7 +109,7 @@ def setup_module(mod):
                 "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept)
             )
 
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_vrf_netns/test_bgp_vrf_netns_topo.py
+++ b/tests/topotests/bgp_vrf_netns/test_bgp_vrf_netns_topo.py
@@ -140,7 +140,7 @@ def setup_module(module):
     # Starting Hosts and init ExaBGP on each of them
     logger.info("starting exaBGP on peer1")
     peer_list = tgen.exabgp_peers()
-    for pname, peer in peer_list.iteritems():
+    for pname, peer in peer_list.items():
         peer_dir = os.path.join(CWD, pname)
         env_file = os.path.join(CWD, "exabgp.env")
         logger.info("Running ExaBGP peer")

--- a/tests/topotests/eigrp-topo1/test_eigrp_topo1.py
+++ b/tests/topotests/eigrp-topo1/test_eigrp_topo1.py
@@ -99,7 +99,7 @@ def setup_module(module):
 
     # This is a sample of configuration loading.
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/evpn-pim-1/test_evpn_pim_topo1.py
+++ b/tests/topotests/evpn-pim-1/test_evpn_pim_topo1.py
@@ -123,7 +123,7 @@ def setup_module(module):
     # tgen.mininet_cli()
     # This is a sample of configuration loading.
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/example-test/test_template.py
+++ b/tests/topotests/example-test/test_template.py
@@ -82,7 +82,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # For all registred routers, load the zebra configuration file
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA,
             # Uncomment next line to load configuration from ./router/zebra.conf

--- a/tests/topotests/isis-sr-topo1/test_isis_sr_topo1.py
+++ b/tests/topotests/isis-sr-topo1/test_isis_sr_topo1.py
@@ -140,7 +140,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA,
             os.path.join(CWD, '{}/zebra.conf'.format(rname))

--- a/tests/topotests/isis-topo1-vrf/test_isis_topo1_vrf.py
+++ b/tests/topotests/isis-topo1-vrf/test_isis_topo1_vrf.py
@@ -113,7 +113,7 @@ def setup_module(mod):
     ]
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         # create VRF rx-cust1 and link rx-eth0 to rx-cust1
         for cmd in cmds:
             output = tgen.net[rname].cmd(cmd.format(rname))
@@ -127,7 +127,7 @@ def setup_module(mod):
                 "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept)
             )
 
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         router.load_config(
             TopoRouter.RD_ZEBRA, 
             os.path.join(CWD, "{}/zebra.conf".format(rname))
@@ -164,7 +164,7 @@ def test_isis_convergence():
 
     logger.info("waiting for ISIS protocol to converge")
  
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         filename = "{0}/{1}/{1}_topology.json".format(CWD, rname)
         expected = json.loads(open(filename).read())
         def compare_isis_topology(router, expected):
@@ -186,13 +186,13 @@ def test_isis_route_installation():
 
     logger.info("Checking routers for installed ISIS vrf routes")
     # Check for routes in 'show ip route vrf {}-cust1 json'
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         filename = "{0}/{1}/{1}_route.json".format(CWD, rname)
         expected = json.loads(open(filename, "r").read())
         actual = router.vtysh_cmd("show ip route vrf {0}-cust1 json".format(rname) , isjson=True)
         # Older FRR versions don't list interfaces in some ISIS routes
         if router.has_version("<", "3.1"):
-            for network, routes in expected.iteritems():
+            for network, routes in expected.items():
                 for route in routes:
                     if route["protocol"] != "isis":
                         continue
@@ -220,14 +220,14 @@ def test_isis_linux_route_installation():
 
     logger.info("Checking routers for installed ISIS vrf routes in OS")
     # Check for routes in `ip route show vrf {}-cust1`
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         filename = "{0}/{1}/{1}_route_linux.json".format(CWD, rname)
         expected = json.loads(open(filename, "r").read())
         actual = topotest.ip4_vrf_route(router)
 
         # Older FRR versions install routes using different proto
         if router.has_version("<", "3.1"):
-            for network, netoptions in expected.iteritems():
+            for network, netoptions in expected.items():
                 if "proto" in netoptions and netoptions["proto"] == "187":
                     netoptions["proto"] = "zebra"
 
@@ -243,14 +243,14 @@ def test_isis_route6_installation():
 
     logger.info("Checking routers for installed ISIS vrf IPv6 routes")
     # Check for routes in 'show ipv6 route vrf {}-cust1 json'
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         filename = "{0}/{1}/{1}_route6.json".format(CWD, rname)
         expected = json.loads(open(filename, "r").read())
         actual = router.vtysh_cmd("show ipv6 route vrf {}-cust1 json".format(rname) , isjson=True)
 
         # Older FRR versions don't list interfaces in some ISIS routes
         if router.has_version("<", "3.1"):
-            for network, routes in expected.iteritems():
+            for network, routes in expected.items():
                 for route in routes:
                     if route["protocol"] != "isis":
                         continue
@@ -277,14 +277,14 @@ def test_isis_linux_route6_installation():
 
     logger.info("Checking routers for installed ISIS vrf IPv6 routes in OS")
     # Check for routes in `ip -6 route show vrf {}-cust1`
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         filename = "{0}/{1}/{1}_route6_linux.json".format(CWD, rname)
         expected = json.loads(open(filename, "r").read())
         actual = topotest.ip6_vrf_route(router)
 
         # Older FRR versions install routes using different proto
         if router.has_version("<", "3.1"):
-            for network, netoptions in expected.iteritems():
+            for network, netoptions in expected.items():
                 if "proto" in netoptions and netoptions["proto"] == "187":
                     netoptions["proto"] = "zebra"
 
@@ -323,7 +323,7 @@ def dict_merge(dct, merge_dct):
     Source:
     https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
     """
-    for k, v in merge_dct.iteritems():
+    for k, v in merge_dct.items():
         if (
             k in dct
             and isinstance(dct[k], dict)

--- a/tests/topotests/isis-topo1/test_isis_topo1.py
+++ b/tests/topotests/isis-topo1/test_isis_topo1.py
@@ -91,7 +91,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )
@@ -129,12 +129,12 @@ def test_isis_convergence():
 
     logger.info("waiting for ISIS protocol to converge")
     # Code to generate the json files.
-    # for rname, router in tgen.routers().iteritems():
+    # for rname, router in tgen.routers().items():
     #     open('/tmp/{}_topology.json'.format(rname), 'w').write(
     #         json.dumps(show_isis_topology(router), indent=2, sort_keys=True)
     #     )
 
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         filename = "{0}/{1}/{1}_topology.json".format(CWD, rname)
         expected = json.loads(open(filename).read())
 
@@ -158,14 +158,14 @@ def test_isis_route_installation():
     logger.info("Checking routers for installed ISIS routes")
 
     # Check for routes in 'show ip route json'
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         filename = "{0}/{1}/{1}_route.json".format(CWD, rname)
         expected = json.loads(open(filename, "r").read())
         actual = router.vtysh_cmd("show ip route json", isjson=True)
 
         # Older FRR versions don't list interfaces in some ISIS routes
         if router.has_version("<", "3.1"):
-            for network, routes in expected.iteritems():
+            for network, routes in expected.items():
                 for route in routes:
                     if route["protocol"] != "isis":
                         continue
@@ -188,14 +188,14 @@ def test_isis_linux_route_installation():
     logger.info("Checking routers for installed ISIS routes in OS")
 
     # Check for routes in `ip route`
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         filename = "{0}/{1}/{1}_route_linux.json".format(CWD, rname)
         expected = json.loads(open(filename, "r").read())
         actual = topotest.ip4_route(router)
 
         # Older FRR versions install routes using different proto
         if router.has_version("<", "3.1"):
-            for network, netoptions in expected.iteritems():
+            for network, netoptions in expected.items():
                 if "proto" in netoptions and netoptions["proto"] == "187":
                     netoptions["proto"] = "zebra"
 
@@ -213,14 +213,14 @@ def test_isis_route6_installation():
     logger.info("Checking routers for installed ISIS IPv6 routes")
 
     # Check for routes in 'show ip route json'
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         filename = "{0}/{1}/{1}_route6.json".format(CWD, rname)
         expected = json.loads(open(filename, "r").read())
         actual = router.vtysh_cmd("show ipv6 route json", isjson=True)
 
         # Older FRR versions don't list interfaces in some ISIS routes
         if router.has_version("<", "3.1"):
-            for network, routes in expected.iteritems():
+            for network, routes in expected.items():
                 for route in routes:
                     # Older versions display different metrics for IPv6 routes
                     route.pop("metric", None)
@@ -246,14 +246,14 @@ def test_isis_linux_route6_installation():
     logger.info("Checking routers for installed ISIS IPv6 routes in OS")
 
     # Check for routes in `ip route`
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         filename = "{0}/{1}/{1}_route6_linux.json".format(CWD, rname)
         expected = json.loads(open(filename, "r").read())
         actual = topotest.ip6_route(router)
 
         # Older FRR versions install routes using different proto
         if router.has_version("<", "3.1"):
-            for network, netoptions in expected.iteritems():
+            for network, netoptions in expected.items():
                 if "proto" in netoptions and netoptions["proto"] == "187":
                     netoptions["proto"] = "zebra"
 
@@ -293,7 +293,7 @@ def dict_merge(dct, merge_dct):
     Source:
     https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
     """
-    for k, v in merge_dct.iteritems():
+    for k, v in merge_dct.items():
         if (
             k in dct
             and isinstance(dct[k], dict)

--- a/tests/topotests/ldp-oc-acl-topo1/test_ldp_oc_acl_topo1.py
+++ b/tests/topotests/ldp-oc-acl-topo1/test_ldp_oc_acl_topo1.py
@@ -117,7 +117,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/ldp-oc-topo1/test_ldp_oc_topo1.py
+++ b/tests/topotests/ldp-oc-topo1/test_ldp_oc_topo1.py
@@ -117,7 +117,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/ldp-sync-isis-topo1/test_ldp_sync_isis_topo1.py
+++ b/tests/topotests/ldp-sync-isis-topo1/test_ldp_sync_isis_topo1.py
@@ -130,7 +130,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/ldp-sync-ospf-topo1/test_ldp_sync_ospf_topo1.py
+++ b/tests/topotests/ldp-sync-ospf-topo1/test_ldp_sync_ospf_topo1.py
@@ -129,7 +129,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/ldp-vpls-topo1/test_ldp_vpls_topo1.py
+++ b/tests/topotests/ldp-vpls-topo1/test_ldp_vpls_topo1.py
@@ -130,7 +130,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -367,7 +367,7 @@ def __create_bgp_unicast_neighbor(
 
     bgp_data = input_dict["address_family"]
 
-    for addr_type, addr_dict in bgp_data.iteritems():
+    for addr_type, addr_dict in bgp_data.items():
         if not addr_dict:
             continue
 
@@ -470,7 +470,7 @@ def __create_bgp_unicast_neighbor(
             )
             config_data.extend(neigh_data)
 
-    for addr_type, addr_dict in bgp_data.iteritems():
+    for addr_type, addr_dict in bgp_data.items():
         if not addr_dict or not check_address_types(addr_type):
             continue
 
@@ -508,7 +508,7 @@ def __create_l2vpn_evpn_address_family(
 
     bgp_data = input_dict["address_family"]
 
-    for family_type, family_dict in bgp_data.iteritems():
+    for family_type, family_dict in bgp_data.items():
         if family_type != "l2vpn":
             continue
 
@@ -664,8 +664,8 @@ def __create_bgp_neighbor(topo, input_dict, router, addr_type, add_neigh=True):
     bgp_data = input_dict["address_family"]
     neigh_data = bgp_data[addr_type]["unicast"]["neighbor"]
 
-    for name, peer_dict in neigh_data.iteritems():
-        for dest_link, peer in peer_dict["dest_link"].iteritems():
+    for name, peer_dict in neigh_data.items():
+        for dest_link, peer in peer_dict["dest_link"].items():
             nh_details = topo[name]
 
             if "vrfs" in topo[router] or type(nh_details["bgp"]) is list:
@@ -769,8 +769,8 @@ def __create_bgp_unicast_address_family(
     bgp_data = input_dict["address_family"]
     neigh_data = bgp_data[addr_type]["unicast"]["neighbor"]
 
-    for peer_name, peer_dict in deepcopy(neigh_data).iteritems():
-        for dest_link, peer in peer_dict["dest_link"].iteritems():
+    for peer_name, peer_dict in deepcopy(neigh_data).items():
+        for dest_link, peer in peer_dict["dest_link"].items():
             deactivate = None
             activate = None
             nh_details = topo[peer_name]
@@ -778,7 +778,7 @@ def __create_bgp_unicast_address_family(
             deactivate_addr_family = peer.setdefault("deactivate", None)
             # Loopback interface
             if "source_link" in peer and peer["source_link"] == "lo":
-                for destRouterLink, data in sorted(nh_details["links"].iteritems()):
+                for destRouterLink, data in sorted(nh_details["links"].items()):
                     if "type" in data and data["type"] == "loopback":
                         if dest_link == destRouterLink:
                             ip_addr = nh_details["links"][destRouterLink][
@@ -960,7 +960,7 @@ def modify_bgp_config_when_bgpd_down(tgen, topo, input_dict):
         # Copy bgp config file to /etc/frr
         for dut in input_dict.keys():
             router_list = tgen.routers()
-            for router, rnode in router_list.iteritems():
+            for router, rnode in router_list.items():
                 if router != dut:
                     continue
 
@@ -1082,7 +1082,7 @@ def verify_bgp_convergence(tgen, topo, dut=None):
     """
 
     logger.debug("Entering lib API: verify_bgp_convergence()")
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         if "bgp" not in topo["routers"][router]:
             continue
 
@@ -1461,9 +1461,9 @@ def verify_as_numbers(tgen, topo, input_dict):
 
             bgp_neighbors = bgp_addr_type[addr_type]["unicast"]["neighbor"]
 
-            for bgp_neighbor, peer_data in bgp_neighbors.iteritems():
+            for bgp_neighbor, peer_data in bgp_neighbors.items():
                 remote_as = input_dict[bgp_neighbor]["bgp"]["local_as"]
-                for dest_link, peer_dict in peer_data["dest_link"].iteritems():
+                for dest_link, peer_dict in peer_data["dest_link"].items():
                     neighbor_ip = None
                     data = topo["routers"][bgp_neighbor]["links"]
 
@@ -1533,7 +1533,7 @@ def verify_bgp_convergence_from_running_config(tgen, dut=None):
 
     logger.debug("Entering lib API: {}".format(sys._getframe().f_code.co_name))
 
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         if dut is not None and dut != router:
             continue
 
@@ -1685,8 +1685,8 @@ def clear_bgp_and_verify(tgen, topo, router):
         for addr_type in bgp_addr_type:
             bgp_neighbors = bgp_addr_type[addr_type]["unicast"]["neighbor"]
 
-            for bgp_neighbor, peer_data in bgp_neighbors.iteritems():
-                for dest_link, peer_dict in peer_data["dest_link"].iteritems():
+            for bgp_neighbor, peer_data in bgp_neighbors.items():
+                for dest_link, peer_dict in peer_data["dest_link"].items():
                     data = topo["routers"][bgp_neighbor]["links"]
 
                     if dest_link in data:
@@ -1767,8 +1767,8 @@ def clear_bgp_and_verify(tgen, topo, router):
         for addr_type in bgp_addr_type:
             bgp_neighbors = bgp_addr_type[addr_type]["unicast"]["neighbor"]
 
-            for bgp_neighbor, peer_data in bgp_neighbors.iteritems():
-                for dest_link, peer_dict in peer_data["dest_link"].iteritems():
+            for bgp_neighbor, peer_data in bgp_neighbors.items():
+                for dest_link, peer_dict in peer_data["dest_link"].items():
                     data = topo["routers"][bgp_neighbor]["links"]
 
                     if dest_link in data:
@@ -1872,8 +1872,8 @@ def verify_bgp_timers_and_functionality(tgen, topo, input_dict):
                 continue
 
             bgp_neighbors = bgp_addr_type[addr_type]["unicast"]["neighbor"]
-            for bgp_neighbor, peer_data in bgp_neighbors.iteritems():
-                for dest_link, peer_dict in peer_data["dest_link"].iteritems():
+            for bgp_neighbor, peer_data in bgp_neighbors.items():
+                for dest_link, peer_dict in peer_data["dest_link"].items():
                     data = topo["routers"][bgp_neighbor]["links"]
 
                     keepalivetimer = peer_dict["keepalivetimer"]
@@ -2115,7 +2115,7 @@ def verify_bgp_attributes(
     """
 
     logger.debug("Entering lib API: verify_bgp_attributes()")
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         if router != dut:
             continue
 
@@ -2329,7 +2329,7 @@ def verify_best_path_as_per_bgp_attribute(
                         # - rule is IGP>EGP>INCOMPLETE
                         _next_hop = [
                             key
-                            for (key, value) in attribute_dict.iteritems()
+                            for (key, value) in attribute_dict.items()
                             if value == "IGP"
                         ][0]
                         compare = ""
@@ -2549,7 +2549,7 @@ def verify_bgp_rib(tgen, addr_type, dut, input_dict, next_hop=None, aspath=None)
     list1 = []
     list2 = []
     for routerInput in input_dict.keys():
-        for router, rnode in router_list.iteritems():
+        for router, rnode in router_list.items():
             if router != dut:
                 continue
 
@@ -2833,7 +2833,7 @@ def verify_graceful_restart(tgen, topo, addr_type, input_dict, dut, peer):
 
     logger.debug("Entering lib API: {}".format(sys._getframe().f_code.co_name))
 
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         if router != dut:
             continue
 
@@ -3081,7 +3081,7 @@ def verify_r_bit(tgen, topo, addr_type, input_dict, dut, peer):
 
     logger.debug("Entering lib API: {}".format(sys._getframe().f_code.co_name))
 
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         if router != dut:
             continue
 
@@ -3199,7 +3199,7 @@ def verify_eor(tgen, topo, addr_type, input_dict, dut, peer):
     """
     logger.debug("Entering lib API: {}".format(sys._getframe().f_code.co_name))
 
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         if router != dut:
             continue
 
@@ -3364,7 +3364,7 @@ def verify_f_bit(tgen, topo, addr_type, input_dict, dut, peer):
 
     logger.debug("Entering lib API: {}".format(sys._getframe().f_code.co_name))
 
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         if router != dut:
             continue
 
@@ -3490,7 +3490,7 @@ def verify_graceful_restart_timers(tgen, topo, addr_type, input_dict, dut, peer)
 
     logger.debug("Entering lib API: {}".format(sys._getframe().f_code.co_name))
 
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         if router != dut:
             continue
 
@@ -3594,7 +3594,7 @@ def verify_gr_address_family(tgen, topo, addr_type, addr_family, dut):
 
     logger.debug("Entering lib API: {}".format(sys._getframe().f_code.co_name))
 
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         if router != dut:
             continue
 

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -354,7 +354,7 @@ def kill_mininet_routers_process(tgen):
     """
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         daemon_list = [
             "zebra",
             "ospfd",
@@ -381,7 +381,7 @@ def check_router_status(tgen):
 
     try:
         router_list = tgen.routers()
-        for router, rnode in router_list.iteritems():
+        for router, rnode in router_list.items():
 
             result = rnode.check_router_running()
             if result != "":
@@ -611,7 +611,7 @@ def get_frr_ipv6_linklocal(tgen, router, intf=None, vrf=None):
     """
 
     router_list = tgen.routers()
-    for rname, rnode in router_list.iteritems():
+    for rname, rnode in router_list.items():
         if rname != router:
             continue
 
@@ -669,7 +669,7 @@ def generate_support_bundle():
     test_name = sys._getframe(2).f_code.co_name
     TMPDIR = os.path.join(LOGDIR, tgen.modname)
 
-    for rname, rnode in router_list.iteritems():
+    for rname, rnode in router_list.items():
         logger.info("Generating support bundle for {}".format(rname))
         rnode.run("mkdir -p /var/log/frr")
         bundle_log = rnode.run("python2 /usr/lib/frr/generate_support_bundle.py")
@@ -878,7 +878,7 @@ def create_vrf_cfg(tgen, topo, input_dict=None, build=False):
         input_dict = deepcopy(input_dict)
 
     try:
-        for c_router, c_data in input_dict.iteritems():
+        for c_router, c_data in input_dict.items():
             rnode = tgen.routers()[c_router]
             if "vrfs" in c_data:
                 for vrf in c_data["vrfs"]:
@@ -923,7 +923,7 @@ def create_vrf_cfg(tgen, topo, input_dict=None, build=False):
 
                             if "links" in c_data:
                                 for destRouterLink, data in sorted(
-                                    c_data["links"].iteritems()
+                                    c_data["links"].items()
                                 ):
                                     # Loopback interfaces
                                     if "type" in data and data["type"] == "loopback":
@@ -1158,7 +1158,7 @@ def find_interface_with_greater_ip(topo, router, loopback=True, interface=True):
     lo_list = []
     interfaces_list = []
     lo_exists = False
-    for destRouterLink, data in sorted(link_data.iteritems()):
+    for destRouterLink, data in sorted(link_data.items()):
         if loopback:
             if "type" in data and data["type"] == "loopback":
                 lo_exists = True
@@ -1352,9 +1352,9 @@ def create_interfaces_cfg(tgen, topo, build=False):
     topo = deepcopy(topo)
 
     try:
-        for c_router, c_data in topo.iteritems():
+        for c_router, c_data in topo.items():
             interface_data = []
-            for destRouterLink, data in sorted(c_data["links"].iteritems()):
+            for destRouterLink, data in sorted(c_data["links"].items()):
                 # Loopback interfaces
                 if "type" in data and data["type"] == "loopback":
                     interface_name = destRouterLink
@@ -1576,11 +1576,11 @@ def create_prefix_lists(tgen, input_dict, build=False):
 
             config_data = []
             prefix_lists = input_dict[router]["prefix_lists"]
-            for addr_type, prefix_data in prefix_lists.iteritems():
+            for addr_type, prefix_data in prefix_lists.items():
                 if not check_address_types(addr_type):
                     continue
 
-                for prefix_name, prefix_list in prefix_data.iteritems():
+                for prefix_name, prefix_list in prefix_data.items():
                     for prefix_dict in prefix_list:
                         if "action" not in prefix_dict or "network" not in prefix_dict:
                             errormsg = "'action' or network' missing in" " input_dict"
@@ -1717,7 +1717,7 @@ def create_route_maps(tgen, input_dict, build=False):
                 logger.debug("route_maps not present in input_dict")
                 continue
             rmap_data = []
-            for rmap_name, rmap_value in input_dict[router]["route_maps"].iteritems():
+            for rmap_name, rmap_value in input_dict[router]["route_maps"].items():
 
                 for rmap_dict in rmap_value:
                     del_action = rmap_dict.setdefault("delete", False)
@@ -2529,7 +2529,7 @@ def verify_rib(
     additional_nexthops_in_required_nhs = []
     found_hops = []
     for routerInput in input_dict.keys():
-        for router, rnode in router_list.iteritems():
+        for router, rnode in router_list.items():
             if router != dut:
                 continue
 
@@ -2882,7 +2882,7 @@ def verify_fib_routes(tgen, addr_type, dut, input_dict, next_hop=None):
 
     router_list = tgen.routers()
     for routerInput in input_dict.keys():
-        for router, rnode in router_list.iteritems():
+        for router, rnode in router_list.items():
             if router != dut:
                 continue
 
@@ -3138,7 +3138,7 @@ def verify_fib_routes(tgen, addr_type, dut, input_dict, next_hop=None):
 
     router_list = tgen.routers()
     for routerInput in input_dict.keys():
-        for router, rnode in router_list.iteritems():
+        for router, rnode in router_list.items():
             if router != dut:
                 continue
 

--- a/tests/topotests/lib/ltemplate.py
+++ b/tests/topotests/lib/ltemplate.py
@@ -82,7 +82,7 @@ class LTemplate():
         router_list = tgen.routers()
 
         # For all registred routers, load the zebra configuration file
-        for rname, router in router_list.iteritems():
+        for rname, router in router_list.items():
             logger.info("Setting up %s" % rname)
             for rd_val in TopoRouter.RD:
                 config = os.path.join(self.testdir, '{}/{}.conf'.format(rname,TopoRouter.RD[rd_val]))

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -254,7 +254,7 @@ class Topogen(object):
         ```py
         tgen = get_topogen()
         router_dict = tgen.get_gears(TopoRouter)
-        for router_name, router in router_dict.iteritems():
+        for router_name, router in router_dict.items():
             # Do stuff
         ```
         * List iteration:
@@ -267,7 +267,7 @@ class Topogen(object):
         """
         return dict(
             (name, gear)
-            for name, gear in self.gears.iteritems()
+            for name, gear in self.gears.items()
             if isinstance(gear, geartype)
         )
 
@@ -316,7 +316,7 @@ class Topogen(object):
         """
         if router is None:
             # pylint: disable=r1704
-            for _, router in self.routers().iteritems():
+            for _, router in self.routers().items():
                 router.start()
         else:
             if isinstance(router, str):
@@ -430,7 +430,7 @@ class TopoGear(object):
 
     def __str__(self):
         links = ""
-        for myif, dest in self.links.iteritems():
+        for myif, dest in self.links.items():
             _, destif = dest
             if links != "":
                 links += ","
@@ -684,7 +684,7 @@ class TopoRouter(TopoGear):
 
         # Enable all daemon command logging, logging files
         # and set them to the start dir.
-        for daemon, enabled in nrouter.daemons.iteritems():
+        for daemon, enabled in nrouter.daemons.items():
             if enabled == 0:
                 continue
             self.vtysh_cmd(
@@ -733,7 +733,7 @@ class TopoRouter(TopoGear):
 
         # Enable all daemon command logging, logging files
         # and set them to the start dir.
-        for daemon, enabled in nrouter.daemons.iteritems():
+        for daemon, enabled in nrouter.daemons.items():
             for d in daemons:
                 if enabled == 0:
                     continue

--- a/tests/topotests/lib/topojson.py
+++ b/tests/topotests/lib/topojson.py
@@ -91,7 +91,7 @@ def build_topo_from_json(tgen, topo):
                     return int(re_search("\d+", x).group(0))
 
             for destRouterLink, data in sorted(
-                topo["routers"][curRouter]["links"].iteritems(),
+                topo["routers"][curRouter]["links"].items(),
                 key=lambda x: link_sort(x[0]),
             ):
                 currRouter_lo_json = topo["routers"][curRouter]["links"][destRouterLink]

--- a/tests/topotests/ospf-sr-topo1/test_ospf_sr_topo1.py
+++ b/tests/topotests/ospf-sr-topo1/test_ospf_sr_topo1.py
@@ -93,7 +93,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/ospf-topo1-vrf/test_ospf_topo1_vrf.py
+++ b/tests/topotests/ospf-topo1-vrf/test_ospf_topo1_vrf.py
@@ -84,7 +84,7 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     # check for zebra capability
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         if router.check_capability(TopoRouter.RD_ZEBRA, "--vrfwnetns") == False:
             return pytest.skip(
                 "Skipping OSPF VRF NETNS feature. VRF NETNS backend not available on FRR"
@@ -106,7 +106,7 @@ def setup_module(mod):
         "ip netns exec {0}-cust1 ifconfig {0}-eth1 up",
     ]
 
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
 
         # create VRF rx-cust1 and link rx-eth0 to rx-cust1
         for cmd in cmds:
@@ -141,7 +141,7 @@ def teardown_module(mod):
     ]
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         for cmd in cmds:
             tgen.net[rname].cmd(cmd.format(rname))
     tgen.stop_topology()
@@ -169,7 +169,7 @@ def test_ospf_convergence():
     if tgen.routers_have_failure():
         pytest.skip("skipped because of router(s) failure")
 
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence', rname)
 
         # Load expected results from the command
@@ -216,7 +216,7 @@ def test_ospf_json():
     if tgen.routers_have_failure():
         pytest.skip("skipped because of router(s) failure")
 
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         logger.info(
             'Comparing router "%s" "show ip ospf vrf %s-cust1 json" output',
             router.name,
@@ -283,7 +283,7 @@ def test_ospf_link_down():
     )
 
     # Expect convergence on all routers
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence after link failure', rname)
         # Load expected results from the command
         reffile = os.path.join(CWD, "{}/ospfroute_down.txt".format(rname))

--- a/tests/topotests/ospf-topo1/test_ospf_topo1.py
+++ b/tests/topotests/ospf-topo1/test_ospf_topo1.py
@@ -95,7 +95,7 @@ def setup_module(mod):
         ospf6_config = "ospf6d.conf-pre-v4"
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )
@@ -146,7 +146,7 @@ def test_ospf_convergence():
     if tgen.routers_have_failure():
         pytest.skip("skipped because of router(s) failure")
 
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence', router)
 
         # Load expected results from the command
@@ -335,7 +335,7 @@ def test_ospf_link_down():
     router3.peer_link_enable("r3-eth0", False)
 
     # Expect convergence on all routers
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence after link failure', router)
         # Load expected results from the command
         reffile = os.path.join(CWD, "{}/ospfroute_down.txt".format(router))

--- a/tests/topotests/ospf-topo2/test_ospf_topo2.py
+++ b/tests/topotests/ospf-topo2/test_ospf_topo2.py
@@ -76,7 +76,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA,
             os.path.join(CWD, '{}/zebra.conf'.format(rname))
@@ -118,7 +118,7 @@ def test_ospf_convergence():
     if tgen.routers_have_failure():
         pytest.skip('skipped because of router(s) failure')
 
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence', router)
 
         json_file = '{}/{}/ospf-route.json'.format(CWD, router)

--- a/tests/topotests/ospf6-topo1/test_ospf6_topo1.py
+++ b/tests/topotests/ospf6-topo1/test_ospf6_topo1.py
@@ -164,7 +164,7 @@ def setup_module(mod):
     # tgen.mininet_cli()
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )
@@ -209,7 +209,7 @@ def test_ospf6_converged():
         sys.stdout.flush()
 
         # Look for any node not yet converged
-        for router, rnode in tgen.routers().iteritems():
+        for router, rnode in tgen.routers().items():
             resStr = rnode.vtysh_cmd("show ipv6 ospf neigh")
 
             isConverged = False
@@ -287,7 +287,7 @@ def test_ospfv3_routingTable():
     # tgen.mininet_cli()
 
     # Verify OSPFv3 Routing Table
-    for router, rnode in tgen.routers().iteritems():
+    for router, rnode in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence', router)
 
         # Load expected results from the command

--- a/tests/topotests/pbr-topo1/test_pbr_topo1.py
+++ b/tests/topotests/pbr-topo1/test_pbr_topo1.py
@@ -92,7 +92,7 @@ def setup_module(module):
 	pytest.skip(tgen.errors)
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         # Install vrf into the kernel and slave eth3
         router.run("ip link add vrf-chiyoda type vrf table 1000")
         router.run("ip link set dev {}-eth3 master vrf-chiyoda".format(rname))

--- a/tests/topotests/pim-basic/test_pim.py
+++ b/tests/topotests/pim-basic/test_pim.py
@@ -87,7 +87,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     # For all registered routers, load the zebra configuration file
-    for rname, router in tgen.routers().iteritems():
+    for rname, router in tgen.routers().items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/route-scale/test_route_scale.py
+++ b/tests/topotests/route-scale/test_route_scale.py
@@ -86,7 +86,7 @@ def setup_module(module):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/zebra_netlink/test_zebra_netlink.py
+++ b/tests/topotests/zebra_netlink/test_zebra_netlink.py
@@ -81,7 +81,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -73,7 +73,7 @@ def setup_module(mod):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.iteritems():
+    for rname, router in router_list.items():
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )


### PR DESCRIPTION
Avoid python2-only .iteritems() api. This is a mechanical replacement, part of making topotests python3-compatible. It'd be nice to be able to prevent future PRs from re-introducing this issue...