### PR TITLE
ospfd : Fix for ospf dead interval and hello due.

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -539,6 +539,7 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	oip->auth_crypt = list_new();
 
 	oip->network_lsa_seqnum = htonl(OSPF_INITIAL_SEQUENCE_NUMBER);
+	oip->is_v_wait_set = false;
 
 	return oip;
 }

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -84,6 +84,7 @@ struct ospf_if_params {
 
 	DECLARE_IF_PARAM(uint32_t, v_hello); /* Hello Interval */
 	DECLARE_IF_PARAM(uint32_t, v_wait);  /* Router Dead Interval */
+	bool is_v_wait_set;                  /* Check for Dead Interval set */
 
 	/* MTU mismatch check (see RFC2328, chap 10.6) */
 	DECLARE_IF_PARAM(uint8_t, mtu_ignore);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -7310,6 +7310,7 @@ static int ospf_vty_dead_interval_set(struct vty *vty, const char *interval_str,
 
 	SET_IF_PARAM(params, v_wait);
 	params->v_wait = seconds;
+	params->is_v_wait_set = true;
 
 	/* Update timer values in neighbor structure. */
 	if (nbr_str) {
@@ -7419,6 +7420,7 @@ DEFUN (no_ip_ospf_dead_interval,
 
 	UNSET_IF_PARAM(params, v_wait);
 	params->v_wait = OSPF_ROUTER_DEAD_INTERVAL_DEFAULT;
+	params->is_v_wait_set = false;
 
 	UNSET_IF_PARAM(params, fast_hello);
 	params->fast_hello = OSPF_FAST_HELLO_DEFAULT;
@@ -7495,6 +7497,17 @@ DEFUN (ip_ospf_hello_interval,
 	SET_IF_PARAM(params, v_hello);
 	params->v_hello = seconds;
 
+	if (!params->is_v_wait_set) {
+		SET_IF_PARAM(params, v_wait);
+		/* As per RFC 4062
+		 * The router dead interval should
+		 * be some multiple of the HelloInterval (perhaps 4 times the
+		 * hello interval) and must be the same for all routers
+		 * attached to a common network.
+		 */
+		params->v_wait	= 4 * seconds;
+	}
+
 	return CMD_SUCCESS;
 }
 
@@ -7523,6 +7536,7 @@ DEFUN (no_ip_ospf_hello_interval,
 	int idx = 0;
 	struct in_addr addr;
 	struct ospf_if_params *params;
+	struct route_node *rn;
 
 	params = IF_DEF_PARAMS(ifp);
 
@@ -7540,6 +7554,25 @@ DEFUN (no_ip_ospf_hello_interval,
 
 	UNSET_IF_PARAM(params, v_hello);
 	params->v_hello = OSPF_HELLO_INTERVAL_DEFAULT;
+
+	if (!params->is_v_wait_set) {
+		UNSET_IF_PARAM(params, v_wait);
+		params->v_wait  = OSPF_ROUTER_DEAD_INTERVAL_DEFAULT;
+	}
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+
+		oi->type = IF_DEF_PARAMS(ifp)->type;
+
+		if (oi->state > ISM_Down) {
+			OSPF_ISM_EVENT_EXECUTE(oi, ISM_InterfaceDown);
+			OSPF_ISM_EVENT_EXECUTE(oi, ISM_InterfaceUp);
+		}
+	}
 
 	if (params != IF_DEF_PARAMS(ifp)) {
 		ospf_free_if_params(ifp, addr);


### PR DESCRIPTION
This fix is related to ospf dead-interval and hello due.  (issue no: #7048 ) 
1. When we change the hello-interval with " ip ospf hello-interval <hello-val> "
Based on the hello interval <hello-val> the dead interval will change.
 
2. But if we set the dead-interval before configuring the hello-interval using
"ip ospf dead-interval <dead-val>" this <dead-val> will be considered.    

3. When we do "no ip ospf hello-interval" it will reset to default for the following
a. hello-interval ( Already existed)
b. hello-due
c. dead-interval (only when it is not set by using "ip ospf dead-interval <dead-val>").

Signed-off-by: Kaushik <kaushik@niralnetworks.com>