### PR TITLE
ripd, ripngd: info -> debug

### DIFF
--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -427,10 +427,11 @@ static int rip_ifp_destroy(struct interface *ifp)
 		rip_if_down(ifp);
 	}
 
-	zlog_info(
-		"interface delete %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
-		ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
-		(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
+	if (IS_RIP_DEBUG_ZEBRA)
+		zlog_debug(
+			"interface delete %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
+			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
+			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
 
 	return 0;
 }

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -274,10 +274,11 @@ static int ripng_ifp_destroy(struct interface *ifp)
 		ripng_if_down(ifp);
 	}
 
-	zlog_info(
-		"interface delete %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
-		ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
-		(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
+	if (IS_RIPNG_DEBUG_ZEBRA)
+		zlog_debug(
+			"interface delete %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
+			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
+			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
 
 	return 0;
 }


### PR DESCRIPTION
There are a couple info messages in rip/ripng that really should
be debugs.  Modify code to be so.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>