### PR TITLE
zebra: fix fd going out of scope leaks the handle

### DIFF
--- a/zebra/zebra_netns_id.c
+++ b/zebra/zebra_netns_id.c
@@ -185,7 +185,7 @@ ns_id_t zebra_ns_id_get(const char *netnspath, int fd_param)
 	if (sock < 0) {
 		flog_err_sys(EC_LIB_SOCKET, "netlink( %u) socket() error: %s",
 			     sock, safe_strerror(errno));
-		if (fd_param == -1)
+		if (netnspath)
 			close(fd);
 		return NS_UNKNOWN;
 	}
@@ -199,7 +199,7 @@ ns_id_t zebra_ns_id_get(const char *netnspath, int fd_param)
 			     "netlink( %u) socket() bind error: %s", sock,
 			     safe_strerror(errno));
 		close(sock);
-		if (fd_param == -1)
+		if (netnspath)
 			close(fd);
 		return NS_UNKNOWN;
 	}
@@ -222,7 +222,7 @@ ns_id_t zebra_ns_id_get(const char *netnspath, int fd_param)
 	ret = send_receive(sock, nlh, seq, buf);
 	if (ret < 0) {
 		close(sock);
-		if (fd_param == -1)
+		if (netnspath)
 			close(fd);
 		return NS_UNKNOWN;
 	}
@@ -267,7 +267,7 @@ ns_id_t zebra_ns_id_get(const char *netnspath, int fd_param)
 				"netlink( %u) recvfrom() error 2 when reading: %s",
 				fd, safe_strerror(errno));
 			close(sock);
-			if (fd_param == -1)
+			if (netnspath)
 				close(fd);
 			if (errno == ENOTSUP) {
 				zlog_debug("NEWNSID locally generated");
@@ -289,7 +289,7 @@ ns_id_t zebra_ns_id_get(const char *netnspath, int fd_param)
 		ret = send_receive(sock, nlh, seq, buf);
 		if (ret < 0) {
 			close(sock);
-			if (fd_param == -1)
+			if (netnspath)
 				close(fd);
 			return NS_UNKNOWN;
 		}
@@ -321,7 +321,7 @@ ns_id_t zebra_ns_id_get(const char *netnspath, int fd_param)
 		} while (len != 0 && ret == 0);
 	}
 
-	if (fd_param == -1)
+	if (netnspath)
 		close(fd);
 	close(sock);
 	return return_nsid;


### PR DESCRIPTION
the file descriptor is closed if it has been locally created.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>