### PR TITLE
Offload/Trap

### DIFF
--- a/include/linux/rtnetlink.h
+++ b/include/linux/rtnetlink.h
@@ -164,6 +164,20 @@ enum {
 	RTM_GETNEXTHOP,
 #define RTM_GETNEXTHOP	RTM_GETNEXTHOP
 
+	RTM_NEWLINKPROP = 108,
+#define RTM_NEWLINKPROP	RTM_NEWLINKPROP
+	RTM_DELLINKPROP,
+#define RTM_DELLINKPROP	RTM_DELLINKPROP
+	RTM_GETLINKPROP,
+#define RTM_GETLINKPROP	RTM_GETLINKPROP
+
+	RTM_NEWVLAN = 112,
+#define RTM_NEWNVLAN	RTM_NEWVLAN
+	RTM_DELVLAN,
+#define RTM_DELVLAN	RTM_DELVLAN
+	RTM_GETVLAN,
+#define RTM_GETVLAN	RTM_GETVLAN
+
 	__RTM_MAX,
 #define RTM_MAX		(((__RTM_MAX + 3) & ~3) - 1)
 };
@@ -172,7 +186,7 @@ enum {
 #define RTM_NR_FAMILIES	(RTM_NR_MSGTYPES >> 2)
 #define RTM_FAM(cmd)	(((cmd) - RTM_BASE) >> 2)
 
-/*
+/* 
    Generic structure for encapsulation of optional route information.
    It is reminiscent of sockaddr, but with sa_family replaced
    with attribute type.
@@ -212,7 +226,7 @@ struct rtmsg {
 
 	unsigned char		rtm_table;	/* Routing table id */
 	unsigned char		rtm_protocol;	/* Routing protocol; see below	*/
-	unsigned char		rtm_scope;	/* See below */
+	unsigned char		rtm_scope;	/* See below */	
 	unsigned char		rtm_type;	/* See below	*/
 
 	unsigned		rtm_flags;
@@ -243,12 +257,12 @@ enum {
 
 /* rtm_protocol */
 
-#define RTPROT_UNSPEC	0
-#define RTPROT_REDIRECT	1	/* Route installed by ICMP redirects;
-				   not used by current IPv4 */
-#define RTPROT_KERNEL	2	/* Route installed by kernel		*/
-#define RTPROT_BOOT	3	/* Route installed during boot		*/
-#define RTPROT_STATIC	4	/* Route installed by administrator	*/
+#define RTPROT_UNSPEC		0
+#define RTPROT_REDIRECT		1	/* Route installed by ICMP redirects;
+					   not used by current IPv4 */
+#define RTPROT_KERNEL		2	/* Route installed by kernel		*/
+#define RTPROT_BOOT		3	/* Route installed during boot		*/
+#define RTPROT_STATIC		4	/* Route installed by administrator	*/
 
 /* Values of protocol >= RTPROT_STATIC are not interpreted by kernel;
    they are just passed from user and back as is.
@@ -257,22 +271,23 @@ enum {
    avoid conflicts.
  */
 
-#define RTPROT_GATED	8	/* Apparently, GateD */
-#define RTPROT_RA	9	/* RDISC/ND router advertisements */
-#define RTPROT_MRT	10	/* Merit MRT */
-#define RTPROT_ZEBRA	11	/* Zebra */
-#define RTPROT_BIRD	12	/* BIRD */
-#define RTPROT_DNROUTED	13	/* DECnet routing daemon */
-#define RTPROT_XORP	14	/* XORP */
-#define RTPROT_NTK	15	/* Netsukuku */
-#define RTPROT_DHCP	16      /* DHCP client */
-#define RTPROT_MROUTED	17      /* Multicast daemon */
-#define RTPROT_BABEL	42      /* Babel daemon */
-#define RTPROT_BGP	186     /* BGP Routes */
-#define RTPROT_ISIS	187     /* ISIS Routes */
-#define RTPROT_OSPF	188     /* OSPF Routes */
-#define RTPROT_RIP	189     /* RIP Routes */
-#define RTPROT_EIGRP	192     /* EIGRP Routes */
+#define RTPROT_GATED		8	/* Apparently, GateD */
+#define RTPROT_RA		9	/* RDISC/ND router advertisements */
+#define RTPROT_MRT		10	/* Merit MRT */
+#define RTPROT_ZEBRA		11	/* Zebra */
+#define RTPROT_BIRD		12	/* BIRD */
+#define RTPROT_DNROUTED		13	/* DECnet routing daemon */
+#define RTPROT_XORP		14	/* XORP */
+#define RTPROT_NTK		15	/* Netsukuku */
+#define RTPROT_DHCP		16	/* DHCP client */
+#define RTPROT_MROUTED		17	/* Multicast daemon */
+#define RTPROT_KEEPALIVED	18	/* Keepalived daemon */
+#define RTPROT_BABEL		42	/* Babel daemon */
+#define RTPROT_BGP		186	/* BGP Routes */
+#define RTPROT_ISIS		187	/* ISIS Routes */
+#define RTPROT_OSPF		188	/* OSPF Routes */
+#define RTPROT_RIP		189	/* RIP Routes */
+#define RTPROT_EIGRP		192	/* EIGRP Routes */
 
 /* rtm_scope
 
@@ -302,6 +317,8 @@ enum rt_scope_t {
 #define RTM_F_PREFIX		0x800	/* Prefix addresses		*/
 #define RTM_F_LOOKUP_TABLE	0x1000	/* set rtm_table to FIB lookup result */
 #define RTM_F_FIB_MATCH	        0x2000	/* return full fib lookup match */
+#define RTM_F_OFFLOAD		0x4000	/* route is offloaded */
+#define RTM_F_TRAP		0x8000	/* route is trapping packets */
 
 /* Reserved table identifiers */
 
@@ -523,7 +540,7 @@ struct ifinfomsg {
 };
 
 /********************************************************************
- *		prefix information
+ *		prefix information 
  ****/
 
 struct prefixmsg {
@@ -537,7 +554,7 @@ struct prefixmsg {
 	unsigned char	prefix_pad3;
 };
 
-enum
+enum 
 {
 	PREFIX_UNSPEC,
 	PREFIX_ADDRESS,
@@ -593,10 +610,16 @@ enum {
 	TCA_HW_OFFLOAD,
 	TCA_INGRESS_BLOCK,
 	TCA_EGRESS_BLOCK,
+	TCA_DUMP_FLAGS,
 	__TCA_MAX
 };
 
 #define TCA_MAX (__TCA_MAX - 1)
+
+#define TCA_DUMP_FLAGS_TERSE (1 << 0) /* Means that in dump user gets only basic
+				       * data necessary to identify the objects
+				       * (handle, cookie, etc.) and stats.
+				       */
 
 #define TCA_RTA(r)  ((struct rtattr*)(((char*)(r)) + NLMSG_ALIGN(sizeof(struct tcmsg))))
 #define TCA_PAYLOAD(n) NLMSG_PAYLOAD(n,sizeof(struct tcmsg))
@@ -714,6 +737,8 @@ enum rtnetlink_groups {
 #define RTNLGRP_IPV6_MROUTE_R	RTNLGRP_IPV6_MROUTE_R
 	RTNLGRP_NEXTHOP,
 #define RTNLGRP_NEXTHOP		RTNLGRP_NEXTHOP
+	RTNLGRP_BRVLAN,
+#define RTNLGRP_BRVLAN		RTNLGRP_BRVLAN
 	__RTNLGRP_MAX
 };
 #define RTNLGRP_MAX	(__RTNLGRP_MAX - 1)
@@ -753,6 +778,7 @@ enum {
 #define RTEXT_FILTER_BRVLAN	(1 << 1)
 #define RTEXT_FILTER_BRVLAN_COMPRESSED	(1 << 2)
 #define	RTEXT_FILTER_SKIP_STATS	(1 << 3)
+#define RTEXT_FILTER_MRP	(1 << 4)
 
 /* End of information exported to user level */
 

--- a/lib/route_types.pl
+++ b/lib/route_types.pl
@@ -121,7 +121,10 @@ sub codelist {
 	}
 	$str =~ s/ $//;
 	push @lines, $str . "\\n\" \\\n";
-	push @lines, "  \"       > - selected route, * - FIB route, q - queued, r - rejected, b - backup\\n\\n\"";
+	push @lines, "  \"       > - selected route, * - FIB route, q - queued, r - rejected, b - backup\\n\"";
+	push @lines, "  \"       t - trapped, o - offload failure\\n\"";
+
+
 	return join("", @lines);
 }
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -480,6 +480,20 @@ struct zapi_route {
  * route entry.  This mainly is used for backup static routes.
  */
 #define ZEBRA_FLAG_RR_USE_DISTANCE    0x40
+/*
+ * This flag tells everyone that the route was intentionally
+ * not offloaded and the route will be sent to the cpu for
+ * forwarding.  This flag makes no sense unless you are in
+ * an asic offload situation
+ */
+#define ZEBRA_FLAG_TRAPPED            0x80
+/*
+ * This flag tells everyone that the route has been
+ * successfully offloaded to an asic for forwarding.
+ * This flag makes no sense unless you are in an asic
+ * offload situation.
+ */
+#define ZEBRA_FLAG_OFFLOADED          0x100
 
 	/* The older XXX_MESSAGE flags live here */
 	uint32_t message;

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -628,7 +628,7 @@ def ip4_route_zebra(node, vrf_name=None):
     lines = output.splitlines()
     header_found = False
     while lines and (not lines[0].strip() or not header_found):
-        if "> - selected route" in lines[0]:
+        if "o - offload failure" in lines[0]:
             header_found = True
         lines = lines[1:]
     return "\n".join(lines)
@@ -654,7 +654,7 @@ def ip6_route_zebra(node, vrf_name=None):
     lines = output.splitlines()
     header_found = False
     while lines and (not lines[0].strip() or not header_found):
-        if "> - selected route" in lines[0]:
+        if "o - offload failure" in lines[0]:
             header_found = True
         lines = lines[1:]
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -643,6 +643,11 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 			return 0;
 	}
 
+	if (rtm->rtm_flags & RTM_F_TRAP)
+		flags |= ZEBRA_FLAG_TRAPPED;
+	if (rtm->rtm_flags & RTM_F_OFFLOAD)
+		flags |= ZEBRA_FLAG_OFFLOADED;
+
 	/* Route which inserted by Zebra. */
 	if (selfroute) {
 		flags |= ZEBRA_FLAG_SELFROUTE;

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -290,4 +290,6 @@ void zebra_router_init(void)
 	zrouter.nhgs_id =
 		hash_create_size(8, zebra_nhg_id_key, zebra_nhg_hash_id_equal,
 				 "Zebra Router Nexthop Groups ID index");
+
+	zrouter.asic_offloaded = false;
 }

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -182,6 +182,11 @@ struct zebra_router {
 	 */
 	struct hash *nhgs;
 	struct hash *nhgs_id;
+
+	/*
+	 * Does the underlying system provide an asic offload
+	 */
+	bool asic_offloaded;
 };
 
 #define GRACEFUL_RESTART_TIME 60

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3414,6 +3414,9 @@ DEFUN (show_zebra,
 {
 	struct vrf *vrf;
 
+	if (zrouter.asic_offloaded)
+		vty_out(vty, "Asic Offload is being used\n");
+
 	vty_out(vty,
 		"                            Route      Route      Neighbor   LSP        LSP\n");
 	vty_out(vty,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -192,6 +192,14 @@ static char re_status_output_char(const struct route_entry *re,
 				star_p = true;
 		}
 
+		if (zrouter.asic_offloaded
+		    && CHECK_FLAG(re->flags, ZEBRA_FLAG_TRAPPED))
+			return 't';
+
+		if (zrouter.asic_offloaded
+		    && !CHECK_FLAG(re->flags, ZEBRA_FLAG_OFFLOADED))
+			return 'o';
+
 		if (star_p)
 			return '*';
 		else
@@ -861,6 +869,12 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 
 		if (CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED))
 			json_object_boolean_true_add(json_route, "queued");
+
+		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_TRAPPED))
+			json_object_boolean_true_add(json_route, "trapped");
+
+		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_OFFLOADED))
+			json_object_boolean_true_add(json_route, "offloaded");
 
 		if (re->tag)
 			json_object_int_add(json_route, "tag", re->tag);


### PR DESCRIPTION
The linux kernel has the ability to notice if a route has been offloaded to an asic for forwarding or if the route has been setup to trap to the kernel.  Write the code to *notice* that this is happening.  At this time we do not really do anything with this data other than to keep track of it.  Future commits will take advantage of this.

At this point in time I have not written any topotests for this because the kernel is so new that will support this that it really is not in any distribution.  I will be writing these tests once we get features that start to take advantage of this knowledge