### PR TITLE
pbrd: cleanup pbr ifp info if not sent to zebra

### DIFF
--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -721,12 +721,23 @@ void pbr_map_policy_delete(struct pbr_map *pbrm, struct pbr_map_interface *pmi)
 {
 	struct listnode *node;
 	struct pbr_map_sequence *pbrms;
+	bool sent = false;
 
 
 	for (ALL_LIST_ELEMENTS_RO(pbrm->seqnumbers, node, pbrms))
-		pbr_send_pbr_map(pbrms, pmi, false, false);
+		if (!pbr_send_pbr_map(pbrms, pmi, false, true))
+			sent = true; /* rule removal sent to zebra */
 
 	pmi->delete = true;
+
+	/*
+	 * If we actually sent something for deletion, wait on zapi callback
+	 * before clearing data.
+	 */
+	if (sent)
+		return;
+
+	pbr_map_final_interface_deletion(pbrm, pmi);
 }
 
 /*

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -725,7 +725,7 @@ void pbr_map_policy_delete(struct pbr_map *pbrm, struct pbr_map_interface *pmi)
 
 
 	for (ALL_LIST_ELEMENTS_RO(pbrm->seqnumbers, node, pbrms))
-		if (!pbr_send_pbr_map(pbrms, pmi, false, true))
+		if (pbr_send_pbr_map(pbrms, pmi, false, true))
 			sent = true; /* rule removal sent to zebra */
 
 	pmi->delete = true;

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -549,8 +549,8 @@ static void pbr_encode_pbr_map_sequence(struct stream *s,
 	stream_put(s, ifp->name, INTERFACE_NAMSIZ);
 }
 
-void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
-		      struct pbr_map_interface *pmi, bool install, bool changed)
+int pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
+		     struct pbr_map_interface *pmi, bool install, bool changed)
 {
 	struct pbr_map *pbrm = pbrms->parent;
 	struct stream *s;
@@ -569,10 +569,10 @@ void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 	 * to delete just return.
 	 */
 	if (install && is_installed && !changed)
-		return;
+		return 1;
 
 	if (!install && !is_installed)
-		return;
+		return 1;
 
 	s = zclient->obuf;
 	stream_reset(s);
@@ -595,4 +595,6 @@ void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	zclient_send_message(zclient);
+
+	return 0;
 }

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -549,8 +549,8 @@ static void pbr_encode_pbr_map_sequence(struct stream *s,
 	stream_put(s, ifp->name, INTERFACE_NAMSIZ);
 }
 
-int pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
-		     struct pbr_map_interface *pmi, bool install, bool changed)
+bool pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
+		      struct pbr_map_interface *pmi, bool install, bool changed)
 {
 	struct pbr_map *pbrm = pbrms->parent;
 	struct stream *s;
@@ -569,10 +569,10 @@ int pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 	 * to delete just return.
 	 */
 	if (install && is_installed && !changed)
-		return 1;
+		return false;
 
 	if (!install && !is_installed)
-		return 1;
+		return false;
 
 	s = zclient->obuf;
 	stream_reset(s);
@@ -596,5 +596,5 @@ int pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 
 	zclient_send_message(zclient);
 
-	return 0;
+	return true;
 }

--- a/pbrd/pbr_zebra.h
+++ b/pbrd/pbr_zebra.h
@@ -35,9 +35,9 @@ extern void route_delete(struct pbr_nexthop_group_cache *pnhgc,
 
 extern void pbr_send_rnh(struct nexthop *nhop, bool reg);
 
-extern int pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
-			    struct pbr_map_interface *pmi, bool install,
-			    bool changed);
+extern bool pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
+			     struct pbr_map_interface *pmi, bool install,
+			     bool changed);
 
 extern struct pbr_interface *pbr_if_new(struct interface *ifp);
 

--- a/pbrd/pbr_zebra.h
+++ b/pbrd/pbr_zebra.h
@@ -35,9 +35,9 @@ extern void route_delete(struct pbr_nexthop_group_cache *pnhgc,
 
 extern void pbr_send_rnh(struct nexthop *nhop, bool reg);
 
-extern void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
-			     struct pbr_map_interface *pmi, bool install,
-			     bool changed);
+extern int pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
+			    struct pbr_map_interface *pmi, bool install,
+			    bool changed);
 
 extern struct pbr_interface *pbr_if_new(struct interface *ifp);
 


### PR DESCRIPTION
Properly cleanup the pbr interface data if nothing actually
gets sent to zebra, since we will never get the callback
notification from zapi to issue final deletion.