### PR TITLE
tests: fix bug in handling of daemons to start

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1340,7 +1340,9 @@ class Router(Node):
         # If `daemons` was specified then some upper API called us with
         # specific daemons, otherwise just use our own configuration.
         daemons_list = []
-        if daemons is None:
+        if daemons != None:
+            daemons_list = daemons
+        else:
             # Append all daemons configured.
             for daemon in self.daemons:
                 if self.daemons[daemon] == 1:


### PR DESCRIPTION
Ensure the list of daemons to start is either the one specified by a caller or the default one from the router configuration. I introduced a subtle bug in an earlier change.
