### PR TITLE
Zebra mlag bugs

### DIFF
--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -111,10 +111,13 @@ void zebra_mlag_send_deregister(void)
 void zebra_mlag_process_mlag_data(uint8_t *data, uint32_t len)
 {
 	struct stream *s = NULL;
-	struct stream *s1 = NULL;
 	int msg_type = 0;
 
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	/*
+	 * Place holder we need the message type first
+	 */
+	stream_putl(s, msg_type);
 	msg_type = zebra_mlag_protobuf_decode_message(s, data, len);
 
 	if (msg_type <= 0) {
@@ -128,12 +131,9 @@ void zebra_mlag_process_mlag_data(uint8_t *data, uint32_t len)
 	/*
 	 * additional four bytes are for message type
 	 */
-	s1 = stream_new(stream_get_endp(s) + ZEBRA_MLAG_METADATA_LEN);
-	stream_putl(s1, msg_type);
-	stream_put(s1, s->data, stream_get_endp(s));
+	stream_putl_at(s, 0, msg_type);
 	thread_add_event(zrouter.master, zebra_mlag_post_data_from_main_thread,
-			 s1, 0, NULL);
-	stream_free(s);
+			 s, 0, NULL);
 }
 
 /**********************End of MLAG Interaction********************************/

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -30,7 +30,7 @@
 extern "C" {
 #endif
 
-#define ZEBRA_MLAG_BUF_LIMIT 2048
+#define ZEBRA_MLAG_BUF_LIMIT 32768
 #define ZEBRA_MLAG_LEN_SIZE 4
 
 DECLARE_HOOK(zebra_mlag_private_write_data,

--- a/zebra/zebra_mlag_private.c
+++ b/zebra/zebra_mlag_private.c
@@ -117,6 +117,15 @@ static int zebra_mlag_read(struct thread *thread)
 	/* This will be the actual length of the packet */
 	tot_len = h_msglen + ZEBRA_MLAG_LEN_SIZE;
 
+	/*
+	 * If the buffer read we are about to do is too large
+	 * we are really really really not double plus good
+	 *
+	 * I'm not sure what to do here other than to bail
+	 * We'll need to revisit this in the future.
+	 */
+	assert(tot_len < ZEBRA_MLAG_BUF_LIMIT);
+
 	if (curr_len < tot_len) {
 		ssize_t data_len;
 


### PR DESCRIPTION
1) Clean up needing 2 streams when 1 is needed
2) Prevent accidental buffer overwrite and increase read/write buffer sizes for mlag communication