### PR TITLE
zebra: the mlag_rd_buf_offset variable was write only

### DIFF
--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -49,7 +49,6 @@ DEFINE_HOOK(zebra_mlag_private_cleanup_data, (), ())
 
 uint8_t mlag_wr_buffer[ZEBRA_MLAG_BUF_LIMIT];
 uint8_t mlag_rd_buffer[ZEBRA_MLAG_BUF_LIMIT];
-uint32_t mlag_rd_buf_offset;
 
 static bool test_mlag_in_progress;
 

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -42,12 +42,10 @@ DECLARE_HOOK(zebra_mlag_private_cleanup_data, (), ())
 
 extern uint8_t mlag_wr_buffer[ZEBRA_MLAG_BUF_LIMIT];
 extern uint8_t mlag_rd_buffer[ZEBRA_MLAG_BUF_LIMIT];
-extern uint32_t mlag_rd_buf_offset;
 
 static inline void zebra_mlag_reset_read_buffer(void)
 {
 	memset(mlag_wr_buffer, 0, ZEBRA_MLAG_BUF_LIMIT);
-	mlag_rd_buf_offset = 0;
 }
 
 enum zebra_mlag_state {

--- a/zebra/zebra_mlag_private.c
+++ b/zebra/zebra_mlag_private.c
@@ -76,7 +76,7 @@ static int zebra_mlag_read(struct thread *thread)
 {
 	uint32_t *msglen;
 	uint32_t h_msglen;
-	uint32_t tot_len, curr_len = mlag_rd_buf_offset;
+	uint32_t tot_len, curr_len = 0;
 
 	zrouter.mlag_info.t_read = NULL;
 
@@ -101,7 +101,6 @@ static int zebra_mlag_read(struct thread *thread)
 			zebra_mlag_handle_process_state(MLAG_DOWN);
 			return -1;
 		}
-		mlag_rd_buf_offset += data_len;
 		if (data_len != (ssize_t)(ZEBRA_MLAG_LEN_SIZE - curr_len)) {
 			/* Try again later */
 			zebra_mlag_sched_read();
@@ -139,7 +138,6 @@ static int zebra_mlag_read(struct thread *thread)
 			zebra_mlag_handle_process_state(MLAG_DOWN);
 			return -1;
 		}
-		mlag_rd_buf_offset += data_len;
 		if (data_len != (ssize_t)(tot_len - curr_len)) {
 			/* Try again later */
 			zebra_mlag_sched_read();


### PR DESCRIPTION
The mlag_rd_buf_offset function was only ever being set to 0
in the mlag_read function and only written in that function.
There is no need for this global variable.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>