### PR TITLE
bgpd: allow derived router-id update if previously 0x0

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -290,7 +290,15 @@ void bgp_router_id_zebra_bump(vrf_id_t vrf_id, const struct prefix *router_id)
 							bgp->name_pretty,
 							bgp->vrf_id,
 							inet_ntoa(*addr));
-					bgp_router_id_set(bgp, addr, false);
+					/*
+					 * if old router-id was 0x0, set flag
+					 * to use this new value
+					 */
+					bgp_router_id_set(bgp, addr,
+							  (bgp->router_id.s_addr
+							   == INADDR_ANY)
+								  ? true
+								  : false);
 				}
 			}
 		}
@@ -313,7 +321,15 @@ void bgp_router_id_zebra_bump(vrf_id_t vrf_id, const struct prefix *router_id)
 							bgp->name_pretty,
 							bgp->vrf_id,
 							inet_ntoa(*addr));
-					bgp_router_id_set(bgp, addr, false);
+					/*
+					 * if old router-id was 0x0, set flag
+					 * to use this new value
+					 */
+					bgp_router_id_set(bgp, addr,
+							  (bgp->router_id.s_addr
+							   == INADDR_ANY)
+								  ? true
+								  : false);
 				}
 			}
 


### PR DESCRIPTION
Problem found that if a router-id was not defined or derived
initially, the bgp->router_id would be set to 0x0 and used
for determining auto-rd values. When bgp received a subsequent
router-id update from zebra, bgp would not completely process
the update since it was treated as updating an already derived
router-id with a new value, which is not desired.  This also
could leave the auto rd/rt inforamation missing or invalid in
some cases.  This fix allows updating the derived router-id if
the previous value was 0/0.

Ticket: CM-31441
Signed-off-by: Don Slice <dslice@nvidia.com>