### PR TITLE
ospfd: fix lsa type-7 continuously refreshed

### DIFF
--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -292,8 +292,9 @@ void ospf_asbr_nssa_redist_task(struct ospf *ospf)
 			continue;
 
 		for (ALL_LIST_ELEMENTS_RO(red_list, node, red))
-			ospf_external_lsa_refresh_type(
-				ospf, type, red->instance, LSA_REFRESH_FORCE);
+			ospf_external_lsa_refresh_type(ospf, type,
+						       red->instance,
+						       LSA_REFRESH_IF_CHANGED);
 	}
 
 	ospf_external_lsa_refresh_default(ospf);


### PR DESCRIPTION
Having an NSSA ABR redistributing statics, the type-7 LSA are being
continuously refreshed (every ~14 secs). The LSA Seq number keeps
incrementing and the LSA age is going back to 0 when reaching ~14s.

This PR fixes the issue by not forcing the LSA update

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>

--
However I ignore if the "force" parameter was used in purpose. With this 
PR updates are sent in case the metric or metric type are changed

```
# The logs
Sep 24 08:54:48 r2 ospfd[7137]: ospf_flood_through: LOCAL NSSA FLOOD of Type-7.
Sep 24 08:55:02 r2 ospfd[7137]: ospf_flood_through: LOCAL NSSA FLOOD of Type-7.
Sep 24 08:55:16 r2 ospfd[7137]: ospf_flood_through: LOCAL NSSA FLOOD of Type-7.
Sep 24 08:55:30 r2 ospfd[7137]: ospf_flood_through: LOCAL NSSA FLOOD of Type-7.
Sep 24 08:55:44 r2 ospfd[7137]: ospf_flood_through: LOCAL NSSA FLOOD of Type-7.
Sep 24 08:55:58 r2 ospfd[7137]: ospf_flood_through: LOCAL NSSA FLOOD of Type-7.
Sep 24 08:56:12 r2 ospfd[7137]: ospf_flood_through: LOCAL NSSA FLOOD of Type-7.
Sep 24 08:56:26 r2 ospfd[7137]: ospf_flood_through: LOCAL NSSA FLOOD of Type-7.
Sep 24 08:56:40 r2 ospfd[7137]: ospf_flood_through: LOCAL NSSA FLOOD of Type-7.

# The configuration
ip route 2.2.2.2/32 blackhole
router ospf
 network 10.0.23.0/24 area 1
 area 1 nssa
!

# Trigger the issue
r2# conf t
r2(config)# router ospf
r2(config-router)# redistribute static

r2# sh ip os da

                NSSA-external Link States (Area 0.0.0.1 [NSSA])

Link ID         ADV Router      Age  Seq#       CkSum  Route
2.2.2.2         10.0.25.2         13 0x8000000f 0x3f17 E2 2.2.2.2/32 [0x0]   <<< Seq: f, age 13

r2# sh ip os da

                NSSA-external Link States (Area 0.0.0.1 [NSSA])

Link ID         ADV Router      Age  Seq#       CkSum  Route
2.2.2.2         10.0.25.2          0 0x80000010 0x3d18 E2 2.2.2.2/32 [0x0]   <<< Seq: 10, age 0

# after some time...
r2# sh ip os da

                NSSA-external Link States (Area 0.0.0.1 [NSSA])

Link ID         ADV Router      Age  Seq#       CkSum  Route
2.2.2.2         10.0.25.2          3 0x8000001b 0x2723 E2 2.2.2.2/32 [0x0]   <<< Seq: 1b, age 3

```
