### PR TITLE
*: move all userdata when changing node xpath

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -2158,6 +2158,7 @@ void bfd_session_update_vrf_name(struct bfd_session *bs, struct vrf *vrf)
 	if (yang_module_find("frr-bfdd") && bs->key.vrfname[0]) {
 		struct lyd_node *bfd_dnode;
 		char xpath[XPATH_MAXLEN], xpath_srcaddr[XPATH_MAXLEN + 32];
+		char oldpath[XPATH_MAXLEN], newpath[XPATH_MAXLEN];
 		char addr_buf[INET6_ADDRSTRLEN];
 		int slen;
 
@@ -2185,7 +2186,12 @@ void bfd_session_update_vrf_name(struct bfd_session *bs, struct vrf *vrf)
 		bfd_dnode = yang_dnode_get(running_config->dnode, xpath,
 					   bs->key.vrfname);
 		if (bfd_dnode) {
+			yang_dnode_get_path(bfd_dnode->parent, oldpath,
+					    sizeof(oldpath));
 			yang_dnode_change_leaf(bfd_dnode, vrf->name);
+			yang_dnode_get_path(bfd_dnode->parent, newpath,
+					    sizeof(newpath));
+			nb_running_move_tree(oldpath, newpath);
 			running_config->version++;
 		}
 	}

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3667,13 +3667,20 @@ static int rip_vrf_enable(struct vrf *vrf)
 		 */
 		if (yang_module_find("frr-ripd") && old_vrf_name) {
 			struct lyd_node *rip_dnode;
+			char oldpath[XPATH_MAXLEN];
+			char newpath[XPATH_MAXLEN];
 
 			rip_dnode = yang_dnode_get(
 				running_config->dnode,
 				"/frr-ripd:ripd/instance[vrf='%s']/vrf",
 				old_vrf_name);
 			if (rip_dnode) {
+				yang_dnode_get_path(rip_dnode->parent, oldpath,
+						    sizeof(oldpath));
 				yang_dnode_change_leaf(rip_dnode, vrf->name);
+				yang_dnode_get_path(rip_dnode->parent, newpath,
+						    sizeof(newpath));
+				nb_running_move_tree(oldpath, newpath);
 				running_config->version++;
 			}
 		}

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2791,13 +2791,20 @@ static int ripng_vrf_enable(struct vrf *vrf)
 		 */
 		if (yang_module_find("frr-ripngd") && old_vrf_name) {
 			struct lyd_node *ripng_dnode;
+			char oldpath[XPATH_MAXLEN];
+			char newpath[XPATH_MAXLEN];
 
 			ripng_dnode = yang_dnode_get(
 				running_config->dnode,
 				"/frr-ripngd:ripngd/instance[vrf='%s']/vrf",
 				old_vrf_name);
 			if (ripng_dnode) {
+				yang_dnode_get_path(ripng_dnode->parent, oldpath,
+						    sizeof(oldpath));
 				yang_dnode_change_leaf(ripng_dnode, vrf->name);
+				yang_dnode_get_path(ripng_dnode->parent, newpath,
+						    sizeof(newpath));
+				nb_running_move_tree(oldpath, newpath);
 				running_config->version++;
 			}
 		}


### PR DESCRIPTION
The same thing was done for interfaces in commit f7c20aa1f.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>