### PR TITLE
tests: Enable evpn_type5_test_topo1 suite to run in CI

### DIFF
--- a/tests/topotests/pytest.ini
+++ b/tests/topotests/pytest.ini
@@ -1,6 +1,6 @@
 # Skip pytests example directory
 [pytest]
-norecursedirs = .git example-test example-topojson-test lib docker evpn_type5_test_topo1
+norecursedirs = .git example-test example-topojson-test lib docker
 
 [topogen]
 # Default configuration values


### PR DESCRIPTION
1. Suite: evpn_type5_test_topo1 was added to pytest.ini during triaging phase as
there was bug: https://github.com/FRRouting/frr/issues/6867, which is fixed. Enabling suite to be run in CI.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>