### PR TITLE
zebra: EVPN avoid duplicate list-node in l3vni's l2vni-list

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4594,6 +4594,11 @@ int zebra_vxlan_if_down(struct interface *ifp)
 
 		assert(zevpn->vxlan_if == ifp);
 
+		/* remove from l3-vni list */
+		zl3vni = zl3vni_from_vrf(zevpn->vrf_id);
+		if (zl3vni)
+			listnode_delete(zl3vni->l2vnis, zevpn);
+
 		/* Delete this VNI from BGP. */
 		zebra_evpn_send_del_to_client(zevpn);
 
@@ -4668,7 +4673,7 @@ int zebra_vxlan_if_up(struct interface *ifp)
 			zevpn->vrf_id = vlan_if->vrf_id;
 			zl3vni = zl3vni_from_vrf(vlan_if->vrf_id);
 			if (zl3vni)
-				listnode_add_sort(zl3vni->l2vnis, zevpn);
+				listnode_add_sort_nodup(zl3vni->l2vnis, zevpn);
 		}
 
 		/* If part of a bridge, inform BGP about this VNI. */
@@ -5007,7 +5012,7 @@ int zebra_vxlan_if_add(struct interface *ifp)
 			zevpn->vrf_id = vlan_if->vrf_id;
 			zl3vni = zl3vni_from_vrf(vlan_if->vrf_id);
 			if (zl3vni)
-				listnode_add_sort(zl3vni->l2vnis, zevpn);
+				listnode_add_sort_nodup(zl3vni->l2vnis, zevpn);
 		}
 
 		if (IS_ZEBRA_DEBUG_VXLAN) {


### PR DESCRIPTION
With l2vni flap leading to duplicate entry creation
in l3vni's l2vni-list.
Use list sorted add with no duplicates.

```
root@TORC11:mgmt:~# show evpn vni 4001
VNI: 4001
  Type: L3
  Tenant VRF: vrf1
  State: Up
  ...
  L2 VNIs: 1000 1000 1000 0 0 1002
root@TORC11:mgmt:~# ip link set down vx-1002
root@TORC11:mgmt:~# ip link set up vx-1002
root@TORC11:mgmt:~# show evpn vni 4001
VNI: 4001
  Type: L3
  Tenant VRF: vrf1
  State: Up
  ...
  L2 VNIs: 1000 1000 1000 0 0 1002 1002
```

Testing Done:

With Fix:
Multiple time flaps vni counts remained the same.

```
root@TORC11:mgmt:~# ip link set down vx-1002
root@TORC11:mgmt:~# ip link set up vx-1002
root@TORC11:mgmt:~# ip link set down vx-1002
root@TORC11:mgmt:~# ip link set up vx-1002

root@TORC11:mgmt:~# show evpn vni 4001
VNI: 4001
  Type: L3
  Tenant VRF: vrf1
  State: Up
  ...
  L2 VNIs: 1000 1002
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>