### PR TITLE
bfdd: Make new multihop peer if local-address is unique

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1745,18 +1745,19 @@ struct bfd_session *bfd_key_lookup(struct bfd_key key)
 	 * input has no iface nor local-address, but a context may
 	 * exist
 	 */
-	ctx.result = NULL;
-	ctx.given = &bs;
-	hash_walk(bfd_key_hash,
-		  &bfd_key_lookup_ignore_partial_walker,
-		  &ctx);
-	/* change key */
-	if (ctx.result) {
-		bsp = ctx.result;
-		if (bglobal.debug_peer_event)
-			zlog_debug(
-				" peer %s found, but ifp and/or loc-addr params ignored",
-				peer_buf);
+	if (!bs.key.mhop) {
+		ctx.result = NULL;
+		ctx.given = &bs;
+		hash_walk(bfd_key_hash, &bfd_key_lookup_ignore_partial_walker,
+			  &ctx);
+		/* change key */
+		if (ctx.result) {
+			bsp = ctx.result;
+			if (bglobal.debug_peer_event)
+				zlog_debug(
+					" peer %s found, but ifp and/or loc-addr params ignored",
+					peer_buf);
+		}
 	}
 	return bsp;
 }


### PR DESCRIPTION
Previously if there were two multihop peers created that had the same
peer address but different local addresses then the second peer to be
created would be merged with the first one and niether would be able to
be deleted. This was due to an issue in the function bfd_key_lookup().
When the second peer was created its key would be sent into the lookup
function and would reach the last section, even though it shouldn't
have. A check has been placed around the section so that it will not be
entered if a peer is multihop.