### PR TITLE
Nhg reasons

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1985,6 +1985,11 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 				    || nexthop->type == NEXTHOP_TYPE_IPV6)
 					nexthop->ifindex = newhop->ifindex;
 				else if (nexthop->ifindex != newhop->ifindex) {
+					if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+						zlog_debug(
+							"%s: %pNHv given ifindex does not match nexthops ifindex found found: %pNHv",
+							__func__, nexthop,
+							newhop);
 					/*
 					 * NEXTHOP_TYPE_*_IFINDEX but ifindex
 					 * doesn't match what we found.

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1823,13 +1823,13 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK)) {
 		ifp = if_lookup_by_index(nexthop->ifindex, nexthop->vrf_id);
 		if (!ifp) {
-			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 				zlog_debug("nexthop %pNHv marked onlink but nhif %u doesn't exist",
 					   nexthop, nexthop->ifindex);
 			return 0;
 		}
 		if (!if_is_operative(ifp)) {
-			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 				zlog_debug("nexthop %pNHv marked onlink but nhif %s is not operational",
 					   nexthop, ifp->name);
 			return 0;
@@ -1985,7 +1985,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 				    || nexthop->type == NEXTHOP_TYPE_IPV6)
 					nexthop->ifindex = newhop->ifindex;
 				else if (nexthop->ifindex != newhop->ifindex) {
-					if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+					if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 						zlog_debug(
 							"%s: %pNHv given ifindex does not match nexthops ifindex found found: %pNHv",
 							__func__, nexthop,
@@ -2011,7 +2011,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 
 			/* Only useful if installed */
 			if (!CHECK_FLAG(match->status, ROUTE_ENTRY_INSTALLED)) {
-				if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+				if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 					zlog_debug("%s: match %p (%u) not installed",
 						   __func__, match,
 						   match->nhe->id);


### PR DESCRIPTION
1) When we had active_check for nexthops in one case we were not given any debugs to the reason why a active check failed
2) When we are asking end users to debug rib installation failures we have been telling end users to use `debug zebra rib detail` for the past couple of years.  For some reason we have gone away from that and end users need to expect consistency here