### PR TITLE
vtysh: fix commands when building only isisd or fabricd

### DIFF
--- a/isisd/subdir.am
+++ b/isisd/subdir.am
@@ -23,6 +23,18 @@ if FABRICD
 noinst_LIBRARIES += isisd/libfabric.a
 sbin_PROGRAMS += isisd/fabricd
 dist_examples_DATA += isisd/fabricd.conf.sample
+if !ISISD
+vtysh_scan += \
+	isisd/isis_cli.c \
+	isisd/isis_ldp_sync.c \
+	isisd/isis_redist.c \
+	isisd/isis_spf.c \
+	isisd/isis_te.c \
+	isisd/isis_sr.c \
+	isisd/isis_vty_fabricd.c \
+	isisd/isisd.c \
+	# end
+endif
 endif
 
 noinst_HEADERS += \

--- a/vtysh/extract.pl.in
+++ b/vtysh/extract.pl.in
@@ -23,6 +23,8 @@
 ## 02111-1307, USA.  
 ##
 
+use Getopt::Long;
+
 print <<EOF;
 #include <zebra.h>
 
@@ -199,18 +201,31 @@ sub scan_file {
     }
 }
 
+my $have_isisd = 0;
+my $have_fabricd = 0;
+
+GetOptions('have-isisd' => \$have_isisd, 'have-fabricd' => \$have_fabricd);
+
 foreach (@ARGV) {
     if (/(^|\/)isisd\//) {
         # We scan all the IS-IS files twice, once for isisd,
         # once for fabricd. Exceptions are made for the files
         # that are not shared between the two.
         if (/isis_vty_isisd.c/) {
-            scan_file($_, 0);
+            if ( $have_isisd ) {
+                scan_file($_, 0);
+            }
         } elsif (/isis_vty_fabricd.c/) {
-            scan_file($_, 1);
+            if ( $have_fabricd ) {
+                scan_file($_, 1);
+            }
         } else {
-            scan_file($_, 0);
-            scan_file($_, 1);
+            if ( $have_isisd ) {
+                scan_file($_, 0);
+            }
+            if ( $have_fabricd ) {
+                scan_file($_, 1);
+            }
         }
     } else {
         scan_file($_, 0);

--- a/vtysh/subdir.am
+++ b/vtysh/subdir.am
@@ -31,5 +31,17 @@ am__v_EXTRACT_ = $(am__v_EXTRACT_$(AM_DEFAULT_VERBOSITY))
 am__v_EXTRACT_0 = @echo "  EXTRACT " $@;
 am__v_EXTRACT_1 =
 
+if ISISD
+HAVE_ISISD = --have-isisd
+else
+HAVE_ISISD =
+endif
+
+if FABRICD
+HAVE_FABRICD = --have-fabricd
+else
+HAVE_FABRICD =
+endif
+
 vtysh/vtysh_cmd.c: vtysh/extract.pl $(vtysh_scan)
-	$(AM_V_EXTRACT) $^ > vtysh/vtysh_cmd.c
+	$(AM_V_EXTRACT) $^ $(HAVE_ISISD) $(HAVE_FABRICD) > vtysh/vtysh_cmd.c


### PR DESCRIPTION
 * add files to vtysh_scan when building only fabricd
 * don't add isisd/fabricd commands when daemon build is disabled

Attaching four vesions of `vtysh_cmd.c` generated with different configure flags (both daemons enabled, only isisd, only fabricd, both disabled):
[vtysh_cmd.zip](https://github.com/FRRouting/frr/files/5302103/vtysh_cmd.zip)

