### PR TITLE
EIGRP: authentication endianess problem

### DIFF
--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -187,16 +187,16 @@ eigrp_hello_parameter_decode(struct eigrp_neighbor *nbr,
 static uint8_t
 eigrp_hello_authentication_decode(struct stream *s,
 				  struct eigrp_tlv_hdr_type *tlv_header,
-				  struct eigrp_neighbor *nbr)
+				  struct eigrp_neighbor *nbr, struct eigrp_header *eigrph)
 {
 	struct TLV_MD5_Authentication_Type *md5;
 
 	md5 = (struct TLV_MD5_Authentication_Type *)tlv_header;
 
-	if (md5->auth_type == EIGRP_AUTH_TYPE_MD5)
-		return eigrp_check_md5_digest(s, md5, nbr,
+	if (ntohs(md5->auth_type) == EIGRP_AUTH_TYPE_MD5)
+		return eigrp_check_md5_digest(s, md5, nbr, eigrph, 
 					      EIGRP_AUTH_BASIC_HELLO_FLAG);
-	else if (md5->auth_type == EIGRP_AUTH_TYPE_SHA256)
+	else if (ntohs(md5->auth_type) == EIGRP_AUTH_TYPE_SHA256)
 		return eigrp_check_sha256_digest(
 			s, (struct TLV_SHA256_Authentication_Type *)tlv_header,
 			nbr, EIGRP_AUTH_BASIC_HELLO_FLAG);
@@ -361,7 +361,7 @@ void eigrp_hello_receive(struct eigrp *eigrp, struct ip *iph,
 				break;
 			case EIGRP_TLV_AUTH: {
 				if (eigrp_hello_authentication_decode(
-					    s, tlv_header, nbr)
+					    s, tlv_header, nbr, eigrph)
 				    == 0)
 					return;
 				else

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -172,7 +172,7 @@ int eigrp_check_md5_digest(struct stream *s,
 	uint8_t *ibuf;
 	size_t backup_end;
 	struct TLV_MD5_Authentication_Type *auth_TLV;
-	//struct eigrp_header *eigrph;
+	
 
 	if (ntohl(nbr->crypt_seqnum) > ntohl(authTLV->key_sequence)) {
 		zlog_warn(
@@ -182,7 +182,7 @@ int eigrp_check_md5_digest(struct stream *s,
 		return 0;
 	}
 
-	//eigrph = (struct eigrp_header *)s->data;
+	
 	eigrph->checksum = 0;
 
 	auth_TLV = (struct TLV_MD5_Authentication_Type*)eigrph->tlv;

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -162,7 +162,7 @@ int eigrp_make_md5_digest(struct eigrp_interface *ei, struct stream *s,
 
 int eigrp_check_md5_digest(struct stream *s,
 			   struct TLV_MD5_Authentication_Type *authTLV,
-			   struct eigrp_neighbor *nbr, uint8_t flags)
+			   struct eigrp_neighbor *nbr, struct eigrp_header *eigrph , uint8_t flags)
 {
 	MD5_CTX ctx;
 	unsigned char digest[EIGRP_AUTH_TYPE_MD5_LEN];
@@ -172,7 +172,7 @@ int eigrp_check_md5_digest(struct stream *s,
 	uint8_t *ibuf;
 	size_t backup_end;
 	struct TLV_MD5_Authentication_Type *auth_TLV;
-	struct eigrp_header *eigrph;
+	//struct eigrp_header *eigrph;
 
 	if (ntohl(nbr->crypt_seqnum) > ntohl(authTLV->key_sequence)) {
 		zlog_warn(
@@ -182,16 +182,15 @@ int eigrp_check_md5_digest(struct stream *s,
 		return 0;
 	}
 
-	eigrph = (struct eigrp_header *)s->data;
+	//eigrph = (struct eigrp_header *)s->data;
 	eigrph->checksum = 0;
 
-	auth_TLV = (struct TLV_MD5_Authentication_Type *)(s->data
-							  + EIGRP_HEADER_LEN);
+	auth_TLV = (struct TLV_MD5_Authentication_Type*)eigrph->tlv;
 	memcpy(orig, auth_TLV->digest, EIGRP_AUTH_TYPE_MD5_LEN);
 	memset(digest, 0, EIGRP_AUTH_TYPE_MD5_LEN);
 	memset(auth_TLV->digest, 0, EIGRP_AUTH_TYPE_MD5_LEN);
 
-	ibuf = s->data;
+	ibuf = eigrph;
 	backup_end = s->endp;
 
 	keychain = keychain_lookup(nbr->ei->params.auth_keychain);

--- a/eigrpd/eigrp_packet.h
+++ b/eigrpd/eigrp_packet.h
@@ -146,7 +146,7 @@ extern int eigrp_make_md5_digest(struct eigrp_interface *, struct stream *,
 				 uint8_t);
 extern int eigrp_check_md5_digest(struct stream *,
 				  struct TLV_MD5_Authentication_Type *,
-				  struct eigrp_neighbor *, uint8_t);
+				  struct eigrp_neighbor *,struct eigrp_header *, uint8_t);
 extern int eigrp_make_sha256_digest(struct eigrp_interface *, struct stream *,
 				    uint8_t);
 extern int eigrp_check_sha256_digest(struct stream *,


### PR DESCRIPTION
Fixes #7144 endianess problem
Add ntohs funciton for the md5->type . Meanwhile, s->data in function eigrp_check_md5_digest() point to the ip header not the eigrp header, so I change it.