### PR TITLE
[7.5] zebra: fix FPM abort for unreach/prohibit routes

### DIFF
--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -335,10 +335,18 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 		}
 	}
 
-	/* If there is no useful nexthop then return. */
-	if (ri->rtm_type != RTN_BLACKHOLE && ri->num_nhs == 0) {
-		zfpm_debug("netlink_encode_route(): No useful nexthop.");
-		return 0;
+	if (ri->num_nhs == 0) {
+		switch (ri->rtm_type) {
+		case RTN_PROHIBIT:
+		case RTN_UNREACHABLE:
+		case RTN_BLACKHOLE:
+			break;
+		default:
+			/* If there is no useful nexthop then return. */
+			zfpm_debug(
+				"netlink_encode_route(): No useful nexthop.");
+			return 0;
+		}
 	}
 
 	return 1;


### PR DESCRIPTION
b0e9567ed162da708f8d0b3a3caf87cd03b62e96 fixed an issue whereby
zebra would abort while building an update for a blackhole route.

The same issue, `assert(data_len)` failing in
`zfpm_build_route_updates()`, can be observed when building updates
for unreachable and prohibit routes.

To address this `netlink_route_info_fill()` is updated to not
indicate failure, due to lack of nexthops, for any blackhole routes.

Signed-off-by: Duncan Eastoe <duncan.eastoe@att.com>
(cherry picked from commit 94f7786375030e08063cdae5b4577edf26adb456)