### PR TITLE
[7.4] zebra: fix FPM abort for blackhole/unreach/prohibit routes

### DIFF
--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -339,7 +339,7 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
 	}
 
 	/* If there is no useful nexthop then return. */
-	if (ri->num_nhs == 0) {
+	if (ri->rtm_type != RTN_BLACKHOLE && ri->num_nhs == 0) {
 		zfpm_debug("netlink_encode_route(): No useful nexthop.");
 		return 0;
 	}

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -338,10 +338,18 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
 		}
 	}
 
-	/* If there is no useful nexthop then return. */
-	if (ri->rtm_type != RTN_BLACKHOLE && ri->num_nhs == 0) {
-		zfpm_debug("netlink_encode_route(): No useful nexthop.");
-		return 0;
+	if (ri->num_nhs == 0) {
+		switch (ri->rtm_type) {
+		case RTN_PROHIBIT:
+		case RTN_UNREACHABLE:
+		case RTN_BLACKHOLE:
+			break;
+		default:
+			/* If there is no useful nexthop then return. */
+			zfpm_debug(
+				"netlink_encode_route(): No useful nexthop.");
+			return 0;
+		}
 	}
 
 	return 1;


### PR DESCRIPTION
Cherry pick b0e9567ed162da708f8d0b3a3caf87cd03b62e96 and 94f7786375030e08063cdae5b4577edf26adb456 for 7.4.