### PR TITLE
zebra: cleanup zebra_rnh.c debugs

### DIFF
--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -61,7 +61,6 @@ extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 			       enum rnh_type type, struct prefix *p);
 extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
 				  enum rnh_type type, struct prefix *p);
-extern char *rnh_str(struct rnh *rnh, char *buf, int size);
 
 extern int rnh_resolve_via_default(struct zebra_vrf *zvrf, int family);
 


### PR DESCRIPTION
a) Use appropriate %p modifiers for output
2) Display vrf name in addition to vrf id
c) Remove now unused function

Signed-off-by: Donald Sharp <sharpd@nvidia.com>