### PR TITLE
zebra: don't touch mlag read event pointer

### DIFF
--- a/zebra/zebra_mlag_private.c
+++ b/zebra/zebra_mlag_private.c
@@ -78,8 +78,6 @@ static int zebra_mlag_read(struct thread *thread)
 	uint32_t h_msglen;
 	uint32_t tot_len, curr_len = mlag_rd_buf_offset;
 
-	zrouter.mlag_info.t_read = NULL;
-
 	/*
 	 * Received message in sock_stream looks like below
 	 * | len-1 (4 Bytes) | payload-1 (len-1) |


### PR DESCRIPTION
Don't touch the mlag read event pointer outside a lock, it's not safe.
