### PR TITLE
Fix nht update decode wrong return code

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -441,9 +441,8 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 	}
 
 	if (!zapi_nexthop_update_decode(zclient->ibuf, &nhr)) {
-		if (BGP_DEBUG(nht, NHT))
-			zlog_debug("%s[%s]: Failure to decode nexthop update",
-				   __PRETTY_FUNCTION__, bgp->name_pretty);
+		zlog_err("%s[%s]: Failure to decode nexthop update",
+			 __PRETTY_FUNCTION__, bgp->name_pretty);
 		return;
 	}
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1765,7 +1765,7 @@ bool zapi_nexthop_update_decode(struct stream *s, struct zapi_route *nhr)
 
 	for (i = 0; i < nhr->nexthop_num; i++) {
 		if (zapi_nexthop_decode(s, &(nhr->nexthops[i]), 0, 0) != 0)
-			return -1;
+			return false;
 	}
 
 	return true;

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -401,7 +401,7 @@ static int pbr_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
 	uint32_t i;
 
 	if (!zapi_nexthop_update_decode(zclient->ibuf, &nhr)) {
-		zlog_warn("Failure to decode Nexthop update message");
+		zlog_err("Failure to decode Nexthop update message");
 		return 0;
 	}
 

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -735,10 +735,8 @@ int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS)
 	pim = vrf->info;
 
 	if (!zapi_nexthop_update_decode(zclient->ibuf, &nhr)) {
-		if (PIM_DEBUG_PIM_NHT)
-			zlog_debug(
-				"%s: Decode of nexthop update from zebra failed",
-				__func__);
+		zlog_err("%s: Decode of nexthop update from zebra failed",
+			 __func__);
 		return 0;
 	}
 

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -547,8 +547,7 @@ static int sharp_nexthop_update(ZAPI_CALLBACK_ARGS)
 	struct zapi_route nhr;
 
 	if (!zapi_nexthop_update_decode(zclient->ibuf, &nhr)) {
-		zlog_warn("%s: Decode of update failed", __func__);
-
+		zlog_err("%s: Decode of update failed", __func__);
 		return 0;
 	}
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -184,7 +184,7 @@ static int static_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
 	afi_t afi = AFI_IP;
 
 	if (!zapi_nexthop_update_decode(zclient->ibuf, &nhr)) {
-		zlog_warn("Failure to decode nexthop update message");
+		zlog_err("Failure to decode nexthop update message");
 		return 1;
 	}
 


### PR DESCRIPTION
- Fix returning -1 in an error case from `zapi_nexthop_update_decode` which returns `false` for errors
- Update all call sites to make zlogs about this case `error` severity, since it is