### PR TITLE
zebra: fix double clearing of zif->es_info.es

### DIFF
--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -810,6 +810,7 @@ void zebra_evpn_if_init(struct zebra_if *zif)
 void zebra_evpn_if_cleanup(struct zebra_if *zif)
 {
 	vlanid_t vid;
+	struct zebra_evpn_es *es;
 
 	if (!bf_is_inited(zif->vlan_bitmap))
 		return;
@@ -821,8 +822,9 @@ void zebra_evpn_if_cleanup(struct zebra_if *zif)
 	bf_free(zif->vlan_bitmap);
 
 	/* Delete associated Ethernet Segment */
-	if (zif->es_info.es)
-		zebra_evpn_local_es_del(&zif->es_info.es);
+	es = zif->es_info.es;
+	if (es)
+		zebra_evpn_local_es_del(&es);
 }
 
 /*****************************************************************************
@@ -1450,7 +1452,7 @@ static int zebra_evpn_local_es_update(struct zebra_if *zif, uint32_t lid,
 	if (!lid || is_zero_mac(sysmac)) {
 		/* if in ES is attached to zif delete it */
 		if (old_es)
-			zebra_evpn_local_es_del(&zif->es_info.es);
+			zebra_evpn_local_es_del(&old_es);
 		return 0;
 	}
 
@@ -1475,7 +1477,7 @@ static int zebra_evpn_local_es_update(struct zebra_if *zif, uint32_t lid,
 
 	/* release the old_es against the zif */
 	if (old_es)
-		zebra_evpn_local_es_del(&zif->es_info.es);
+		zebra_evpn_local_es_del(&old_es);
 
 	es = zebra_evpn_es_find(&esi);
 	if (es) {


### PR DESCRIPTION
This problem was accidentally introduced as a part of another fixup -
[
commit e378f5020d1af1aee587659e5602ee8c07eb05f4 (anuradhak/mh-misc-fixes, mh-misc-fixes)
Author: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>
Date:   Tue Sep 15 16:50:14 2020 -0700

    zebra: fix use of freed es during zebra shutdown
]

zif->es_info.es is cleared as a part of zebra_evpn_es_local_info_clear so it
cannot be passed around as a pointer from zebra_evpn_local_es_update/del.

Because of this bug removing ES from an interface resulted in
a zebra crash.

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>