### PR TITLE
tests: fix regex in all_proto test

### DIFF
--- a/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
+++ b/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
@@ -688,7 +688,8 @@ def test_isis_interfaces():
             # Mask out SNPA mac address portion. They are random...
             actual = re.sub(r"SNPA: [0-9a-f\.]+", "SNPA: XXXX.XXXX.XXXX", actual)
             # Mask out Circuit ID number
-            actual = re.sub(r"Circuit Id: 0x[0-9]+", "Circuit Id: 0xXX", actual)
+            actual = re.sub(r"Circuit Id: 0x[0-9a-f]+", "Circuit Id: 0xXX",
+                            actual)
             # Fix newlines (make them all the same)
             actual = ('\n'.join(actual.splitlines()) + '\n').splitlines(1)
 


### PR DESCRIPTION
Make sure the all-protocols test_isis_interfaces testcase uses a regex substitution that includes all the hex characters. Saw this in some failed CI runs:

```
 -  Interface: r1-eth5, State: Up, Active, Circuit Id: 0xa
  +  Interface: r1-eth5, State: Up, Active, Circuit Id: 0xXX
```
