### PR TITLE
fix debug commands node inconsistencies

### DIFF
--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -251,7 +251,7 @@ void babelz_zebra_init(void)
     install_element(CONFIG_NODE, &debug_babel_cmd);
     install_element(CONFIG_NODE, &no_debug_babel_cmd);
 
-    install_element(VIEW_NODE, &show_debugging_babel_cmd);
+    install_element(ENABLE_NODE, &show_debugging_babel_cmd);
 }
 
 void

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -1109,10 +1109,11 @@ void nhrp_config_init(void)
 	access_list_init();
 
 	/* global commands */
-	install_element(VIEW_NODE, &show_debugging_nhrp_cmd);
 	install_element(VIEW_NODE, &show_ip_nhrp_cmd);
 	install_element(VIEW_NODE, &show_dmvpn_cmd);
 	install_element(ENABLE_NODE, &clear_nhrp_cmd);
+
+	install_element(ENABLE_NODE, &show_debugging_nhrp_cmd);
 
 	install_element(ENABLE_NODE, &debug_nhrp_cmd);
 	install_element(ENABLE_NODE, &no_debug_nhrp_cmd);

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -1236,7 +1236,7 @@ void ospf6_init(void)
 
 	install_element_ospf6_clear_interface();
 
-	install_element(VIEW_NODE, &show_debugging_ospf6_cmd);
+	install_element(ENABLE_NODE, &show_debugging_ospf6_cmd);
 
 	install_element(VIEW_NODE, &show_ipv6_ospf6_border_routers_cmd);
 

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -1147,7 +1147,7 @@ void pbr_vty_init(void)
 	install_node(&debug_node);
 	install_element(ENABLE_NODE, &debug_pbr_cmd);
 	install_element(CONFIG_NODE, &debug_pbr_cmd);
-	install_element(VIEW_NODE, &show_debugging_pbr_cmd);
+	install_element(ENABLE_NODE, &show_debugging_pbr_cmd);
 
 	install_default(PBRMAP_NODE);
 

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -1145,7 +1145,7 @@ void pbr_vty_init(void)
 
 	/* debug */
 	install_node(&debug_node);
-	install_element(VIEW_NODE, &debug_pbr_cmd);
+	install_element(ENABLE_NODE, &debug_pbr_cmd);
 	install_element(CONFIG_NODE, &debug_pbr_cmd);
 	install_element(VIEW_NODE, &show_debugging_pbr_cmd);
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -11236,7 +11236,6 @@ void pim_cmd_init(void)
 	install_element(VIEW_NODE, &show_ip_mroute_summary_vrf_all_cmd);
 	install_element(VIEW_NODE, &show_ip_rib_cmd);
 	install_element(VIEW_NODE, &show_ip_ssmpingd_cmd);
-	install_element(VIEW_NODE, &show_debugging_pim_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_nexthop_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_nexthop_lookup_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_bsrp_cmd);
@@ -11251,6 +11250,8 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &clear_ip_pim_interface_traffic_cmd);
 	install_element(ENABLE_NODE, &clear_ip_pim_oil_cmd);
 	install_element(ENABLE_NODE, &clear_ip_pim_statistics_cmd);
+
+	install_element(ENABLE_NODE, &show_debugging_pim_cmd);
 
 	install_element(ENABLE_NODE, &debug_igmp_cmd);
 	install_element(ENABLE_NODE, &no_debug_igmp_cmd);

--- a/ripngd/ripng_debug.c
+++ b/ripngd/ripng_debug.c
@@ -218,7 +218,7 @@ void ripng_debug_init(void)
 
 	install_node(&debug_node);
 
-	install_element(VIEW_NODE, &show_debugging_ripng_cmd);
+	install_element(ENABLE_NODE, &show_debugging_ripng_cmd);
 
 	install_element(ENABLE_NODE, &debug_ripng_events_cmd);
 	install_element(ENABLE_NODE, &debug_ripng_packet_cmd);

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -716,7 +716,7 @@ void sharp_vty_init(void)
 	install_element(ENABLE_NODE, &send_opaque_reg_cmd);
 	install_element(ENABLE_NODE, &neigh_discover_cmd);
 
-	install_element(VIEW_NODE, &show_debugging_sharpd_cmd);
+	install_element(ENABLE_NODE, &show_debugging_sharpd_cmd);
 
 	return;
 }

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -1169,7 +1169,7 @@ void static_vty_init(void)
 	install_element(CONFIG_NODE, &ipv6_route_cmd);
 	install_element(VRF_NODE, &ipv6_route_vrf_cmd);
 
-	install_element(VIEW_NODE, &show_debugging_static_cmd);
+	install_element(ENABLE_NODE, &show_debugging_static_cmd);
 	install_element(ENABLE_NODE, &debug_staticd_cmd);
 	install_element(CONFIG_NODE, &debug_staticd_cmd);
 }

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -1170,6 +1170,6 @@ void static_vty_init(void)
 	install_element(VRF_NODE, &ipv6_route_vrf_cmd);
 
 	install_element(VIEW_NODE, &show_debugging_static_cmd);
-	install_element(VIEW_NODE, &debug_staticd_cmd);
+	install_element(ENABLE_NODE, &debug_staticd_cmd);
 	install_element(CONFIG_NODE, &debug_staticd_cmd);
 }

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -775,7 +775,7 @@ void vrrp_vty_init(void)
 
 	install_element(VIEW_NODE, &vrrp_vrid_show_cmd);
 	install_element(VIEW_NODE, &vrrp_vrid_show_summary_cmd);
-	install_element(VIEW_NODE, &show_debugging_vrrp_cmd);
+	install_element(ENABLE_NODE, &show_debugging_vrrp_cmd);
 	install_element(ENABLE_NODE, &debug_vrrp_cmd);
 	install_element(CONFIG_NODE, &debug_vrrp_cmd);
 	install_element(CONFIG_NODE, &vrrp_autoconfigure_cmd);

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -776,7 +776,7 @@ void vrrp_vty_init(void)
 	install_element(VIEW_NODE, &vrrp_vrid_show_cmd);
 	install_element(VIEW_NODE, &vrrp_vrid_show_summary_cmd);
 	install_element(VIEW_NODE, &show_debugging_vrrp_cmd);
-	install_element(VIEW_NODE, &debug_vrrp_cmd);
+	install_element(ENABLE_NODE, &debug_vrrp_cmd);
 	install_element(CONFIG_NODE, &debug_vrrp_cmd);
 	install_element(CONFIG_NODE, &vrrp_autoconfigure_cmd);
 	install_element(CONFIG_NODE, &vrrp_default_cmd);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -4271,9 +4271,9 @@ void vtysh_init_vty(void)
 #endif
 
 	/* debugging */
-	install_element(VIEW_NODE, &vtysh_show_debugging_cmd);
 	install_element(VIEW_NODE, &vtysh_show_error_code_cmd);
-	install_element(VIEW_NODE, &vtysh_show_debugging_hashtable_cmd);
+	install_element(ENABLE_NODE, &vtysh_show_debugging_cmd);
+	install_element(ENABLE_NODE, &vtysh_show_debugging_hashtable_cmd);
 	install_element(ENABLE_NODE, &vtysh_debug_all_cmd);
 	install_element(CONFIG_NODE, &vtysh_debug_all_cmd);
 	install_element(ENABLE_NODE, &vtysh_debug_memstats_cmd);

--- a/zebra/debug.c
+++ b/zebra/debug.c
@@ -671,7 +671,7 @@ void zebra_debug_init(void)
 
 	install_node(&debug_node);
 
-	install_element(VIEW_NODE, &show_debugging_zebra_cmd);
+	install_element(ENABLE_NODE, &show_debugging_zebra_cmd);
 
 	install_element(ENABLE_NODE, &debug_zebra_events_cmd);
 	install_element(ENABLE_NODE, &debug_zebra_nht_cmd);


### PR DESCRIPTION
Most daemons put "debug ..." and "show debugging ..." commands into the enable node, but some of them put these commands into the view node. Let's make it consistent.