### PR TITLE
tests: fix typos in zebra_rib and _netlink

### DIFF
--- a/tests/topotests/zebra_netlink/test_zebra_netlink.py
+++ b/tests/topotests/zebra_netlink/test_zebra_netlink.py
@@ -109,7 +109,7 @@ def test_zebra_netlink_batching():
     )
     tgen = get_topogen()
     if tgen.routers_have_failure():
-        ptyest.skip("skipped because of preview test failure")
+        pytest.skip("skipped because of previous test failure")
     r1 = tgen.gears["r1"]
 
     # Reduce the size of the buffer to hit the limit.

--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -131,7 +131,7 @@ def test_zebra_kernel_override():
     logger.info("Test kernel override with a better admin distance")
     tgen = get_topogen()
     if tgen.routers_have_failure():
-        ptyest.skip("skipped because of preview test failure")
+        pytest.skip("skipped because of previous test failure")
 
     r1 = tgen.gears["r1"]
     r1.vtysh_cmd("conf\nip route 4.5.1.0/24 192.168.216.3")


### PR DESCRIPTION
Fix a couple of typos in the zebra_rib and _netlink topotest suites.