### PR TITLE
tests: Topotest fixes to skip comparing InterfaceIndex and Internal status

### DIFF
--- a/tests/topotests/bfd-topo2/r1/ipv4_routes.json
+++ b/tests/topotests/bfd-topo2/r1/ipv4_routes.json
@@ -3,16 +3,13 @@
         {
             "distance": 20,
             "protocol": "bgp",
-            "internalFlags": 8,
             "metric": 0,
             "selected": true,
             "installed": true,
             "prefix": "10.0.3.0/24",
-            "internalStatus": 16,
             "nexthops": [
                 {
                     "interfaceName": "r1-eth0",
-                    "interfaceIndex": 2,
                     "fib": true,
                     "flags": 3,
                     "active": true,
@@ -25,16 +22,13 @@
         {
             "distance": 20,
             "protocol": "bgp",
-            "internalFlags": 8,
             "metric": 0,
             "selected": true,
             "installed": true,
             "prefix": "10.254.254.2/32",
-            "internalStatus": 16,
             "nexthops": [
                 {
                     "interfaceName": "r1-eth0",
-                    "interfaceIndex": 2,
                     "fib": true,
                     "flags": 3,
                     "active": true,
@@ -47,17 +41,14 @@
         {
             "distance": 0,
             "protocol": "connected",
-            "internalFlags": 8,
             "metric": 0,
             "selected": true,
             "installed": true,
             "prefix": "10.254.254.1/32",
-            "internalStatus": 16,
             "nexthops": [
                 {
                     "directlyConnected": true,
                     "interfaceName": "lo",
-                    "interfaceIndex": 1,
                     "fib": true,
                     "flags": 3,
                     "active": true

--- a/tests/topotests/bfd-topo2/r1/ipv6_routes.json
+++ b/tests/topotests/bfd-topo2/r1/ipv6_routes.json
@@ -3,16 +3,13 @@
     {
       "distance": 20,
       "protocol": "bgp",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "2001:db8:4::/64",
-      "internalStatus": 16,
       "nexthops": [
         {
           "interfaceName": "r1-eth0",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true,
@@ -25,14 +22,11 @@
     {
       "distance": 20,
       "protocol": "bgp",
-      "internalFlags": 0,
       "metric": 0,
-      "internalStatus": 0,
       "prefix": "2001:db8:1::/64",
       "nexthops": [
         {
           "interfaceName": "r1-eth0",
-          "interfaceIndex": 2,
           "active": true,
           "afi": "ipv6"
         }
@@ -41,17 +35,14 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "2001:db8:1::/64",
-      "internalStatus": 16,
       "nexthops": [
         {
           "directlyConnected": true,
           "interfaceName": "r1-eth0",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true

--- a/tests/topotests/bfd-topo2/r2/ipv4_routes.json
+++ b/tests/topotests/bfd-topo2/r2/ipv4_routes.json
@@ -3,15 +3,12 @@
     {
       "distance": 110,
       "protocol": "ospf",
-      "internalFlags": 0,
       "metric": 10,
-      "internalStatus": 0,
       "prefix": "10.0.3.0/24",
       "nexthops": [
         {
           "active": true,
           "directlyConnected": true,
-          "interfaceIndex": 3,
           "interfaceName": "r2-eth1"
         }
       ]
@@ -19,17 +16,14 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "10.0.3.0/24",
-      "internalStatus": 16,
       "nexthops": [
         {
           "directlyConnected": true,
           "interfaceName": "r2-eth1",
-          "interfaceIndex": 3,
           "fib": true,
           "flags": 3,
           "active": true
@@ -41,17 +35,14 @@
     {
       "distance": 110,
       "protocol": "ospf",
-      "internalFlags": 8,
       "metric": 20,
       "selected": true,
       "installed": true,
       "prefix": "10.254.254.3/32",
-      "internalStatus": 16,
       "nexthops": [
         {
           "interfaceName": "r2-eth1",
           "ip": "10.0.3.1",
-          "interfaceIndex": 3,
           "fib": true,
           "flags": 3,
           "active": true,
@@ -64,17 +55,14 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "10.254.254.2/32",
-      "internalStatus": 16,
       "nexthops": [
         {
           "directlyConnected": true,
           "interfaceName": "lo",
-          "interfaceIndex": 1,
           "fib": true,
           "flags": 3,
           "active": true
@@ -86,16 +74,13 @@
     {
       "distance": 20,
       "protocol": "bgp",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "10.254.254.1/32",
-      "internalStatus": 16,
       "nexthops": [
         {
           "interfaceName": "r2-eth0",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true,

--- a/tests/topotests/bfd-topo2/r2/ipv6_routes.json
+++ b/tests/topotests/bfd-topo2/r2/ipv6_routes.json
@@ -3,15 +3,12 @@
     {
       "distance": 110,
       "protocol": "ospf6",
-      "internalFlags": 0,
       "metric": 10,
-      "internalStatus": 0,
       "prefix": "2001:db8:4::/64",
       "nexthops": [
         {
           "active": true,
           "directlyConnected": true,
-          "interfaceIndex": 4,
           "interfaceName": "r2-eth2"
         }
       ]
@@ -19,17 +16,14 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "2001:db8:4::/64",
-      "internalStatus": 16,
       "nexthops": [
         {
           "directlyConnected": true,
           "interfaceName": "r2-eth2",
-          "interfaceIndex": 4,
           "fib": true,
           "flags": 3,
           "active": true
@@ -41,17 +35,14 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "2001:db8:1::/64",
-      "internalStatus": 16,
       "nexthops": [
         {
           "directlyConnected": true,
           "interfaceName": "r2-eth0",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true

--- a/tests/topotests/bfd-topo2/r3/ipv4_routes.json
+++ b/tests/topotests/bfd-topo2/r3/ipv4_routes.json
@@ -3,15 +3,12 @@
     {
       "distance": 110,
       "protocol": "ospf",
-      "internalFlags": 0,
       "metric": 10,
-      "internalStatus": 0,
       "prefix": "10.0.3.0/24",
       "nexthops": [
         {
           "active": true,
           "directlyConnected": true,
-          "interfaceIndex": 2,
           "interfaceName": "r3-eth0"
         }
       ]
@@ -19,17 +16,14 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "10.0.3.0/24",
-      "internalStatus": 16,
       "nexthops": [
         {
           "directlyConnected": true,
           "interfaceName": "r3-eth0",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true
@@ -41,17 +35,14 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "10.254.254.3/32",
-      "internalStatus": 16,
       "nexthops": [
         {
           "directlyConnected": true,
           "interfaceName": "lo",
-          "interfaceIndex": 1,
           "fib": true,
           "flags": 3,
           "active": true
@@ -63,17 +54,14 @@
     {
       "distance": 110,
       "protocol": "ospf",
-      "internalFlags": 8,
       "metric": 20,
       "selected": true,
       "installed": true,
       "prefix": "10.254.254.2/32",
-      "internalStatus": 16,
       "nexthops": [
         {
           "interfaceName": "r3-eth0",
           "ip": "10.0.3.2",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true,
@@ -86,17 +74,14 @@
     {
       "distance": 110,
       "protocol": "ospf",
-      "internalFlags": 8,
       "metric": 20,
       "selected": true,
       "installed": true,
       "prefix": "10.254.254.1/32",
-      "internalStatus": 16,
       "nexthops": [
         {
           "interfaceName": "r3-eth0",
           "ip": "10.0.3.2",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true,

--- a/tests/topotests/bfd-topo2/r4/ipv4_routes.json
+++ b/tests/topotests/bfd-topo2/r4/ipv4_routes.json
@@ -3,17 +3,14 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "10.254.254.4/32",
-      "internalStatus": 16,
       "nexthops": [
         {
           "directlyConnected": true,
           "interfaceName": "lo",
-          "interfaceIndex": 1,
           "fib": true,
           "flags": 3,
           "active": true

--- a/tests/topotests/bfd-topo2/r4/ipv6_routes.json
+++ b/tests/topotests/bfd-topo2/r4/ipv6_routes.json
@@ -3,15 +3,12 @@
     {
       "distance": 110,
       "protocol": "ospf6",
-      "internalFlags": 0,
       "metric": 10,
-      "internalStatus": 0,
       "prefix": "2001:db8:4::/64",
       "nexthops": [
         {
           "active": true,
           "directlyConnected": true,
-          "interfaceIndex": 2,
           "interfaceName": "r4-eth0"
         }
       ]
@@ -19,17 +16,14 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "installed": true,
       "prefix": "2001:db8:4::/64",
-      "internalStatus": 16,
       "nexthops": [
         {
           "directlyConnected": true,
           "interfaceName": "r4-eth0",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true
@@ -41,16 +35,13 @@
     {
       "distance": 110,
       "protocol": "ospf6",
-      "internalFlags": 8,
       "metric": 10,
       "selected": true,
       "installed": true,
       "prefix": "2001:db8:1::/64",
-      "internalStatus": 16,
       "nexthops": [
         {
           "interfaceName": "r4-eth0",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true,

--- a/tests/topotests/bgp_features/r1/ip_route.json
+++ b/tests/topotests/bgp_features/r1/ip_route.json
@@ -14,7 +14,6 @@
           "fib":true,
           "ip":"192.168.101.2",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r1-eth3",
           "active":true,
           "weight":1
@@ -32,7 +31,6 @@
         {
           "flags":1,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true,
           "weight":1
@@ -52,7 +50,6 @@
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -74,7 +71,6 @@
           "fib":true,
           "ip":"192.168.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true,
           "weight":1
@@ -97,7 +93,6 @@
           "fib":true,
           "ip":"192.168.3.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth2",
           "active":true,
           "weight":1
@@ -116,7 +111,6 @@
         {
           "flags":1,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true,
           "weight":1
@@ -136,7 +130,6 @@
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -158,7 +151,6 @@
           "fib":true,
           "ip":"192.168.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true,
           "weight":1
@@ -168,7 +160,6 @@
           "fib":true,
           "ip":"192.168.3.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth2",
           "active":true,
           "weight":1
@@ -186,7 +177,6 @@
         {
           "flags":1,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth2",
           "active":true,
           "weight":1
@@ -206,7 +196,6 @@
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth2",
           "active":true
         }
@@ -223,7 +212,6 @@
         {
           "flags":1,
           "directlyConnected":true,
-          "interfaceIndex":5,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -243,7 +231,6 @@
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":5,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -269,7 +256,6 @@
           "flags":1,
           "ip":"192.168.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true,
           "weight":1
@@ -290,7 +276,6 @@
           "fib":true,
           "ip":"192.168.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true,
           "weight":1
@@ -313,7 +298,6 @@
           "fib":true,
           "ip":"192.168.3.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth2",
           "active":true,
           "weight":1
@@ -349,7 +333,6 @@
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r1-eth3",
           "active":true
         }
@@ -371,7 +354,6 @@
           "fib":true,
           "ip":"192.168.101.2",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r1-eth3",
           "active":true,
           "weight":1

--- a/tests/topotests/bgp_features/r1/ip_route_norib.json
+++ b/tests/topotests/bgp_features/r1/ip_route_norib.json
@@ -9,7 +9,6 @@
         {
           "flags":1,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true,
           "weight":1
@@ -29,7 +28,6 @@
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -51,7 +49,6 @@
           "fib":true,
           "ip":"192.168.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true,
           "weight":1
@@ -74,7 +71,6 @@
           "fib":true,
           "ip":"192.168.3.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth2",
           "active":true,
           "weight":1
@@ -92,7 +88,6 @@
         {
           "flags":1,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true,
           "weight":1
@@ -112,7 +107,6 @@
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -134,7 +128,6 @@
           "fib":true,
           "ip":"192.168.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true,
           "weight":1
@@ -144,7 +137,6 @@
           "fib":true,
           "ip":"192.168.3.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth2",
           "active":true,
           "weight":1
@@ -162,7 +154,6 @@
         {
           "flags":1,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth2",
           "active":true,
           "weight":1
@@ -182,7 +173,6 @@
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth2",
           "active":true
         }
@@ -199,7 +189,6 @@
         {
           "flags":1,
           "directlyConnected":true,
-          "interfaceIndex":5,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -219,7 +208,6 @@
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":5,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -241,7 +229,6 @@
           "fib":true,
           "ip":"192.168.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth1",
           "active":true,
           "weight":1
@@ -264,7 +251,6 @@
           "fib":true,
           "ip":"192.168.3.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth2",
           "active":true,
           "weight":1
@@ -286,7 +272,6 @@
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r1-eth3",
           "active":true
         }

--- a/tests/topotests/bgp_ipv6_rtadv/r1/ipv4_routes.json
+++ b/tests/topotests/bgp_ipv6_rtadv/r1/ipv4_routes.json
@@ -3,7 +3,6 @@
         {
             "distance": 20,
             "protocol": "bgp",
-            "internalFlags": 8,
             "metric": 0,
             "selected": true,
             "destSelected": true,
@@ -11,7 +10,6 @@
             "nexthops": [
                 {
                     "interfaceName": "r1-eth0",
-                    "interfaceIndex": 2,
                     "fib": true,
                     "flags": 3,
                     "active": true,
@@ -24,7 +22,6 @@
         {
             "distance": 0,
             "protocol": "connected",
-            "internalFlags": 8,
             "metric": 0,
             "selected": true,
             "destSelected": true,
@@ -33,7 +30,6 @@
                 {
                     "directlyConnected": true,
                     "interfaceName": "lo",
-                    "interfaceIndex": 1,
                     "fib": true,
                     "flags": 3,
                     "active": true

--- a/tests/topotests/bgp_ipv6_rtadv/r1/ipv6_routes.json
+++ b/tests/topotests/bgp_ipv6_rtadv/r1/ipv6_routes.json
@@ -3,13 +3,11 @@
     {
       "distance": 20,
       "protocol": "bgp",
-      "internalFlags": 0,
       "metric": 0,
       "prefix": "2001:db8:1::/64",
       "nexthops": [
         {
           "interfaceName": "r1-eth0",
-          "interfaceIndex": 2,
           "active": true,
           "afi": "ipv6"
         }
@@ -18,7 +16,6 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "destSelected": true,
@@ -27,7 +24,6 @@
         {
           "directlyConnected": true,
           "interfaceName": "r1-eth0",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true

--- a/tests/topotests/bgp_ipv6_rtadv/r2/ipv4_routes.json
+++ b/tests/topotests/bgp_ipv6_rtadv/r2/ipv4_routes.json
@@ -3,7 +3,6 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "destSelected": true,
@@ -12,7 +11,6 @@
         {
           "directlyConnected": true,
           "interfaceName": "lo",
-          "interfaceIndex": 1,
           "fib": true,
           "flags": 3,
           "active": true
@@ -24,7 +22,6 @@
     {
       "distance": 20,
       "protocol": "bgp",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "destSelected": true,
@@ -32,7 +29,6 @@
       "nexthops": [
         {
           "interfaceName": "r2-eth0",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true,

--- a/tests/topotests/bgp_ipv6_rtadv/r2/ipv6_routes.json
+++ b/tests/topotests/bgp_ipv6_rtadv/r2/ipv6_routes.json
@@ -3,7 +3,6 @@
     {
       "distance": 0,
       "protocol": "connected",
-      "internalFlags": 8,
       "metric": 0,
       "selected": true,
       "destSelected": true,
@@ -12,7 +11,6 @@
         {
           "directlyConnected": true,
           "interfaceName": "r2-eth0",
-          "interfaceIndex": 2,
           "fib": true,
           "flags": 3,
           "active": true

--- a/tests/topotests/bgp_link_bw_ip/r1/v4_route.json
+++ b/tests/topotests/bgp_link_bw_ip/r1/v4_route.json
@@ -6,16 +6,11 @@
       "distance":110,
       "metric":10,
       "table":254,
-      "internalStatus":0,
-      "internalFlags":0,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":9,
           "ip":"0.0.0.0",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "onLink":true
@@ -31,16 +26,11 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -57,16 +47,11 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -83,17 +68,12 @@
       "metric":20,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":11,
           "fib":true,
           "ip":"10.0.3.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true,
           "onLink":true

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r1/ipv4_routes.json
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r1/ipv4_routes.json
@@ -9,14 +9,11 @@
             "distance": 20,
             "metric": 0,
             "installed": true,
-            "internalStatus": 16,
-            "internalFlags": 8,
             "nexthops": [
                 {
                     "flags": 3,
                     "fib": true,
                     "afi": "ipv6",
-                    "interfaceIndex": 2,
                     "interfaceName": "r1-eth0",
                     "active": true
                 }
@@ -33,14 +30,11 @@
             "distance": 0,
             "metric": 0,
             "installed": true,
-            "internalStatus": 16,
-            "internalFlags": 8,
             "nexthops": [
                 {
                     "flags": 3,
                     "fib": true,
                     "directlyConnected": true,
-                    "interfaceIndex": 4,
                     "interfaceName": "loop1",
                     "active": true
                 }

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r1/ipv6_routes.json
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r1/ipv6_routes.json
@@ -6,12 +6,9 @@
       "vrfId":3,
       "distance": 20,
       "metric": 0,
-      "internalStatus": 0,
-      "internalFlags": 0,
       "nexthops": [
         {
           "afi": "ipv6",
-          "interfaceIndex": 2,
           "interfaceName": "r1-eth0",
           "active": true
         }
@@ -26,14 +23,11 @@
       "distance": 0,
       "metric": 0,
       "installed": true,
-      "internalStatus": 16,
-      "internalFlags": 8,
       "nexthops": [
         {
           "flags": 3,
           "fib": true,
           "directlyConnected": true,
-          "interfaceIndex": 2,
           "interfaceName": "r1-eth0",
           "active": true
         }

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r2/ipv4_routes.json
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r2/ipv4_routes.json
@@ -9,14 +9,11 @@
       "distance": 0,
       "metric": 0,
       "installed": true,
-      "internalStatus": 16,
-      "internalFlags": 8,
        "nexthops": [
         {
           "flags": 3,
           "fib": true,
           "directlyConnected": true,
-          "interfaceIndex": 4,
           "interfaceName": "loop1",
           "active": true
         }
@@ -33,14 +30,11 @@
       "distance": 20,
       "metric": 0,
       "installed": true,
-      "internalStatus": 16,
-      "internalFlags": 8,
       "nexthops": [
         {
           "flags": 3,
           "fib": true,
           "afi": "ipv6",
-          "interfaceIndex": 2,
           "interfaceName": "r2-eth0",
           "active": true
         }

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r2/ipv6_routes.json
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r2/ipv6_routes.json
@@ -9,14 +9,11 @@
       "distance": 0,
       "metric": 0,
       "installed": true,
-      "internalStatus": 16,
-      "internalFlags": 8,
       "nexthops": [
         {
           "flags": 3,
           "fib": true,
           "directlyConnected": true,
-          "interfaceIndex": 2,
           "interfaceName": "r2-eth0",
           "active": true
         }

--- a/tests/topotests/isis-topo1-vrf/r1/r1_route.json
+++ b/tests/topotests/isis-topo1-vrf/r1/r1_route.json
@@ -8,7 +8,6 @@
           "active": true, 
           "afi": "ipv4", 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r1-eth0", 
           "ip": "10.0.20.1" 
         }
@@ -27,7 +26,6 @@
       "nexthops": [
         {
           "afi": "ipv4", 
-          "interfaceIndex": 2, 
           "interfaceName": "r1-eth0", 
           "ip": "10.0.20.1" 
         }
@@ -43,7 +41,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r1-eth0"
         }
       ], 

--- a/tests/topotests/isis-topo1-vrf/r1/r1_route6.json
+++ b/tests/topotests/isis-topo1-vrf/r1/r1_route6.json
@@ -6,7 +6,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r1-eth0"
         }
       ], 
@@ -26,7 +25,6 @@
           "active": true, 
           "afi": "ipv6", 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r1-eth0" 
         }
       ], 

--- a/tests/topotests/isis-topo1-vrf/r2/r2_route.json
+++ b/tests/topotests/isis-topo1-vrf/r2/r2_route.json
@@ -8,7 +8,6 @@
           "active": true, 
           "afi": "ipv4", 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r2-eth0", 
           "ip": "10.0.21.1" 
         }
@@ -27,7 +26,6 @@
       "nexthops": [
         {
           "afi": "ipv4", 
-          "interfaceIndex": 2, 
           "interfaceName": "r2-eth0", 
           "ip": "10.0.21.1" 
         }
@@ -43,7 +41,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r2-eth0"
         }
       ], 

--- a/tests/topotests/isis-topo1-vrf/r2/r2_route6.json
+++ b/tests/topotests/isis-topo1-vrf/r2/r2_route6.json
@@ -6,7 +6,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r2-eth0"
         }
       ], 
@@ -26,7 +25,6 @@
           "active": true, 
           "afi": "ipv6", 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r2-eth0" 
         }
       ], 

--- a/tests/topotests/isis-topo1-vrf/r3/r3_route.json
+++ b/tests/topotests/isis-topo1-vrf/r3/r3_route.json
@@ -6,7 +6,6 @@
       "nexthops": [
         {
           "afi": "ipv4", 
-          "interfaceIndex": 3, 
           "interfaceName": "r3-eth1", 
           "ip": "10.0.10.1" 
         }
@@ -22,7 +21,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r3-eth1"
         }
       ], 
@@ -42,7 +40,6 @@
           "active": true, 
           "afi": "ipv4", 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r3-eth1", 
           "ip": "10.0.10.1" 
         }
@@ -61,7 +58,6 @@
       "nexthops": [
         {
           "afi": "ipv4", 
-          "interfaceIndex": 2, 
           "interfaceName": "r3-eth0", 
           "ip": "10.0.20.2" 
         }
@@ -77,7 +73,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r3-eth0"
         }
       ], 
@@ -97,7 +92,6 @@
           "active": true, 
           "afi": "ipv4", 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r3-eth1", 
           "ip": "10.0.10.1" 
         }

--- a/tests/topotests/isis-topo1-vrf/r3/r3_route6.json
+++ b/tests/topotests/isis-topo1-vrf/r3/r3_route6.json
@@ -6,7 +6,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r3-eth0"
         }
       ], 
@@ -26,7 +25,6 @@
           "active": true, 
           "afi": "ipv6", 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r3-eth1" 
         }
       ], 
@@ -44,7 +42,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r3-eth1"
         }
       ], 
@@ -64,7 +61,6 @@
           "active": true, 
           "afi": "ipv6", 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r3-eth1" 
         }
       ], 

--- a/tests/topotests/isis-topo1-vrf/r4/r4_route.json
+++ b/tests/topotests/isis-topo1-vrf/r4/r4_route.json
@@ -7,7 +7,6 @@
           "active": true, 
           "afi": "ipv4", 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r4-eth1", 
           "ip": "10.0.11.1" 
         }
@@ -24,7 +23,6 @@
       "nexthops": [
         {
           "afi": "ipv4", 
-          "interfaceIndex": 3, 
           "interfaceName": "r4-eth1", 
           "ip": "10.0.11.1" 
         }
@@ -40,7 +38,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r4-eth1"
         }
       ], 
@@ -58,7 +55,6 @@
           "active": true, 
           "afi": "ipv4", 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r4-eth1", 
           "ip": "10.0.11.1" 
         }
@@ -75,7 +71,6 @@
       "nexthops": [
         {
           "afi": "ipv4", 
-          "interfaceIndex": 2, 
           "interfaceName": "r4-eth0", 
           "ip": "10.0.21.2" 
         }
@@ -91,7 +86,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r4-eth0"
         }
       ], 

--- a/tests/topotests/isis-topo1-vrf/r4/r4_route6.json
+++ b/tests/topotests/isis-topo1-vrf/r4/r4_route6.json
@@ -8,7 +8,6 @@
           "active": true, 
           "afi": "ipv6", 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r4-eth1" 
         }
       ], 
@@ -26,7 +25,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r4-eth0"
         }
       ], 
@@ -46,7 +44,6 @@
           "active": true, 
           "afi": "ipv6", 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r4-eth1" 
         }
       ], 
@@ -64,7 +61,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r4-eth1"
         }
       ], 

--- a/tests/topotests/isis-topo1-vrf/r5/r5_route.json
+++ b/tests/topotests/isis-topo1-vrf/r5/r5_route.json
@@ -6,7 +6,6 @@
       "nexthops": [
         {
           "afi": "ipv4", 
-          "interfaceIndex": 2, 
           "interfaceName": "r5-eth0", 
           "ip": "10.0.10.2" 
         }
@@ -22,7 +21,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r5-eth0"
         }
       ], 
@@ -38,7 +36,6 @@
       "nexthops": [
         {
           "afi": "ipv4", 
-          "interfaceIndex": 3, 
           "interfaceName": "r5-eth1", 
           "ip": "10.0.11.2" 
         }
@@ -54,7 +51,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r5-eth1"
         }
       ], 
@@ -72,7 +68,6 @@
           "active": true, 
           "afi": "ipv4", 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r5-eth0", 
           "ip": "10.0.10.2" 
         }
@@ -91,7 +86,6 @@
           "active": true, 
           "afi": "ipv4", 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r5-eth1", 
           "ip": "10.0.11.2" 
         }

--- a/tests/topotests/isis-topo1-vrf/r5/r5_route6.json
+++ b/tests/topotests/isis-topo1-vrf/r5/r5_route6.json
@@ -8,7 +8,6 @@
           "active": true, 
           "afi": "ipv6", 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r5-eth0" 
         }
       ], 
@@ -28,7 +27,6 @@
           "active": true, 
           "afi": "ipv6", 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r5-eth1" 
         }
       ], 
@@ -46,7 +44,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 2, 
           "interfaceName": "r5-eth0"
         }
       ], 
@@ -64,7 +61,6 @@
           "active": true, 
           "directlyConnected": true, 
           "fib": true, 
-          "interfaceIndex": 3, 
           "interfaceName": "r5-eth1"
         }
       ], 

--- a/tests/topotests/isis-topo1/r1/r1_route.json
+++ b/tests/topotests/isis-topo1/r1/r1_route.json
@@ -8,7 +8,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r1-eth0",
           "ip": "10.0.20.1"
         }
@@ -25,7 +24,6 @@
       "nexthops": [
         {
           "afi": "ipv4",
-          "interfaceIndex": 2,
           "interfaceName": "r1-eth0",
           "ip": "10.0.20.1"
         }
@@ -39,7 +37,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r1-eth0"
         }
       ],
@@ -55,7 +52,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 1,
           "interfaceName": "lo"
         }
       ],
@@ -73,7 +69,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r1-eth0",
           "ip": "10.0.20.1"
         }

--- a/tests/topotests/isis-topo1/r1/r1_route6.json
+++ b/tests/topotests/isis-topo1/r1/r1_route6.json
@@ -6,7 +6,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r1-eth0"
         }
       ],
@@ -24,7 +23,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r1-eth0"
         }
       ],
@@ -40,7 +38,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 1,
           "interfaceName": "lo"
         }
       ],
@@ -58,7 +55,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r1-eth0"
         }
       ],

--- a/tests/topotests/isis-topo1/r2/r2_route.json
+++ b/tests/topotests/isis-topo1/r2/r2_route.json
@@ -8,7 +8,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r2-eth0",
           "ip": "10.0.21.1"
         }
@@ -25,7 +24,6 @@
       "nexthops": [
         {
           "afi": "ipv4",
-          "interfaceIndex": 2,
           "interfaceName": "r2-eth0",
           "ip": "10.0.21.1"
         }
@@ -39,7 +37,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r2-eth0"
         }
       ],
@@ -55,7 +52,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 1,
           "interfaceName": "lo"
         }
       ],
@@ -73,7 +69,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r2-eth0",
           "ip": "10.0.21.1"
         }

--- a/tests/topotests/isis-topo1/r2/r2_route6.json
+++ b/tests/topotests/isis-topo1/r2/r2_route6.json
@@ -6,7 +6,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r2-eth0"
         }
       ],
@@ -24,7 +23,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r2-eth0"
         }
       ],
@@ -40,7 +38,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 1,
           "interfaceName": "lo"
         }
       ],
@@ -58,7 +55,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r2-eth0"
         }
       ],

--- a/tests/topotests/isis-topo1/r3/r3_route.json
+++ b/tests/topotests/isis-topo1/r3/r3_route.json
@@ -6,7 +6,6 @@
       "nexthops": [
         {
           "afi": "ipv4",
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1",
           "ip": "10.0.10.1"
         }
@@ -20,7 +19,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1"
         }
       ],
@@ -38,7 +36,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1",
           "ip": "10.0.10.1"
         }
@@ -55,7 +52,6 @@
       "nexthops": [
         {
           "afi": "ipv4",
-          "interfaceIndex": 2,
           "interfaceName": "r3-eth0",
           "ip": "10.0.20.2"
         }
@@ -69,7 +65,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r3-eth0"
         }
       ],
@@ -87,7 +82,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1",
           "ip": "10.0.10.1"
         }
@@ -106,7 +100,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r3-eth0",
           "ip": "10.0.20.2"
         }
@@ -123,7 +116,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 1,
           "interfaceName": "lo"
         }
       ],
@@ -141,7 +133,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1",
           "ip": "10.0.10.1"
         }
@@ -160,7 +151,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1",
           "ip": "10.0.10.1"
         }

--- a/tests/topotests/isis-topo1/r3/r3_route6.json
+++ b/tests/topotests/isis-topo1/r3/r3_route6.json
@@ -6,7 +6,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r3-eth0"
         }
       ],
@@ -24,7 +23,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1"
         }
       ],
@@ -40,7 +38,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1"
         }
       ],
@@ -58,7 +55,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1"
         }
       ],
@@ -76,7 +72,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r3-eth0"
         }
       ],
@@ -92,7 +87,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 1,
           "interfaceName": "lo"
         }
       ],
@@ -110,7 +104,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1"
         }
       ],
@@ -128,7 +121,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r3-eth1"
         }
       ],

--- a/tests/topotests/isis-topo1/r4/r4_route.json
+++ b/tests/topotests/isis-topo1/r4/r4_route.json
@@ -6,7 +6,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r4-eth1"
         }
       ],
@@ -22,7 +21,6 @@
       "nexthops": [
         {
           "afi": "ipv4",
-          "interfaceIndex": 2,
           "interfaceName": "r4-eth0",
           "ip": "10.0.21.2"
         }
@@ -36,7 +34,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r4-eth0"
         }
       ],
@@ -54,7 +51,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r4-eth0",
           "ip": "10.0.21.2"
         }
@@ -71,7 +67,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 1,
           "interfaceName": "lo"
         }
       ],

--- a/tests/topotests/isis-topo1/r4/r4_route6.json
+++ b/tests/topotests/isis-topo1/r4/r4_route6.json
@@ -8,7 +8,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r4-eth1"
         }
       ],
@@ -24,7 +23,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r4-eth0"
         }
       ],
@@ -42,7 +40,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r4-eth1"
         }
       ],
@@ -58,7 +55,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r4-eth1"
         }
       ],
@@ -76,7 +72,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r4-eth0"
         }
       ],
@@ -94,7 +89,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r4-eth1"
         }
       ],
@@ -110,7 +104,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 1,
           "interfaceName": "lo"
         }
       ],
@@ -128,7 +121,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r4-eth1"
         }
       ],

--- a/tests/topotests/isis-topo1/r5/r5_route.json
+++ b/tests/topotests/isis-topo1/r5/r5_route.json
@@ -6,7 +6,6 @@
       "nexthops": [
         {
           "afi": "ipv4",
-          "interfaceIndex": 2,
           "interfaceName": "r5-eth0",
           "ip": "10.0.10.2"
         }
@@ -20,7 +19,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r5-eth0"
         }
       ],
@@ -36,7 +34,6 @@
       "nexthops": [
         {
           "afi": "ipv4",
-          "interfaceIndex": 3,
           "interfaceName": "r5-eth1",
           "ip": "10.0.11.2"
         }
@@ -50,7 +47,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r5-eth1"
         }
       ],
@@ -68,7 +64,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r5-eth0",
           "ip": "10.0.10.2"
         }
@@ -87,7 +82,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r5-eth1",
           "ip": "10.0.11.2"
         }
@@ -106,7 +100,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r5-eth0",
           "ip": "10.0.10.2"
         }
@@ -125,7 +118,6 @@
           "active": true,
           "afi": "ipv4",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r5-eth1",
           "ip": "10.0.11.2"
         }
@@ -142,7 +134,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 1,
           "interfaceName": "lo"
         }
       ],

--- a/tests/topotests/isis-topo1/r5/r5_route6.json
+++ b/tests/topotests/isis-topo1/r5/r5_route6.json
@@ -6,7 +6,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r5-eth0"
         }
       ],
@@ -22,7 +21,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r5-eth1"
         }
       ],
@@ -40,7 +38,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r5-eth0"
         }
       ],
@@ -58,7 +55,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r5-eth1"
         }
       ],
@@ -76,7 +72,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 2,
           "interfaceName": "r5-eth0"
         }
       ],
@@ -94,7 +89,6 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceIndex": 3,
           "interfaceName": "r5-eth1"
         }
       ],
@@ -110,7 +104,6 @@
           "active": true,
           "directlyConnected": true,
           "fib": true,
-          "interfaceIndex": 1,
           "interfaceName": "lo"
         }
       ],

--- a/tests/topotests/ldp-oc-acl-topo1/r1/show_ip_route.ref
+++ b/tests/topotests/ldp-oc-acl-topo1/r1/show_ip_route.ref
@@ -6,7 +6,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -20,7 +19,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -37,7 +35,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -54,7 +51,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -71,7 +67,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -85,7 +80,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -99,7 +93,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -116,7 +109,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -133,7 +125,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -147,7 +138,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -161,7 +151,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }

--- a/tests/topotests/ldp-oc-acl-topo1/r2/show_ip_route.ref
+++ b/tests/topotests/ldp-oc-acl-topo1/r2/show_ip_route.ref
@@ -13,7 +13,6 @@
           "fib":true,
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r2-eth0",
           "active":true
         }
@@ -29,7 +28,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -47,7 +45,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -68,7 +65,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -89,7 +85,6 @@
           "fib":true,
           "ip":"10.0.2.4",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -105,7 +100,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r2-eth0",
           "active":true
         }
@@ -123,7 +117,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r2-eth0",
           "active":true
         }
@@ -139,7 +132,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -157,7 +149,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -178,7 +169,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -199,7 +189,6 @@
           "fib":true,
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r2-eth0",
           "active":true
         }

--- a/tests/topotests/ldp-oc-acl-topo1/r3/show_ip_route.ref
+++ b/tests/topotests/ldp-oc-acl-topo1/r3/show_ip_route.ref
@@ -13,7 +13,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -34,7 +33,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -50,7 +48,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -68,7 +65,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -89,7 +85,6 @@
           "fib":true,
           "ip":"10.0.2.4",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -110,7 +105,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -126,7 +120,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -144,7 +137,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -160,7 +152,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -178,7 +169,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -199,7 +189,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }

--- a/tests/topotests/ldp-oc-acl-topo1/r4/show_ip_route.ref
+++ b/tests/topotests/ldp-oc-acl-topo1/r4/show_ip_route.ref
@@ -13,7 +13,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -34,7 +33,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -55,7 +53,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -71,7 +68,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -89,7 +85,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -110,7 +105,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -126,7 +120,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -144,7 +137,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -165,7 +157,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -186,7 +177,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }

--- a/tests/topotests/ldp-oc-topo1/r1/show_ip_route.ref
+++ b/tests/topotests/ldp-oc-topo1/r1/show_ip_route.ref
@@ -6,7 +6,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -20,7 +19,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -37,7 +35,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -54,7 +51,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -71,7 +67,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -85,7 +80,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -99,7 +93,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -116,7 +109,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -133,7 +125,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -147,7 +138,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -161,7 +151,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }

--- a/tests/topotests/ldp-oc-topo1/r2/show_ip_route.ref
+++ b/tests/topotests/ldp-oc-topo1/r2/show_ip_route.ref
@@ -13,7 +13,6 @@
           "fib":true,
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r2-eth0",
           "active":true
         }
@@ -29,7 +28,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -47,7 +45,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -68,7 +65,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -89,7 +85,6 @@
           "fib":true,
           "ip":"10.0.2.4",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -105,7 +100,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r2-eth0",
           "active":true
         }
@@ -123,7 +117,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r2-eth0",
           "active":true
         }
@@ -139,7 +132,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -157,7 +149,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -178,7 +169,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -199,7 +189,6 @@
           "fib":true,
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r2-eth0",
           "active":true
         }

--- a/tests/topotests/ldp-oc-topo1/r3/show_ip_route.ref
+++ b/tests/topotests/ldp-oc-topo1/r3/show_ip_route.ref
@@ -13,7 +13,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -34,7 +33,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -50,7 +48,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -68,7 +65,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -89,7 +85,6 @@
           "fib":true,
           "ip":"10.0.2.4",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -110,7 +105,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -126,7 +120,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -144,7 +137,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }
@@ -160,7 +152,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -178,7 +169,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -199,7 +189,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r3-eth0",
           "active":true
         }

--- a/tests/topotests/ldp-oc-topo1/r4/show_ip_route.ref
+++ b/tests/topotests/ldp-oc-topo1/r4/show_ip_route.ref
@@ -13,7 +13,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -34,7 +33,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -55,7 +53,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -71,7 +68,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -89,7 +85,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -110,7 +105,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -126,7 +120,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -144,7 +137,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -165,7 +157,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }
@@ -186,7 +177,6 @@
           "fib":true,
           "ip":"10.0.2.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r4-eth0",
           "active":true
         }

--- a/tests/topotests/ldp-sync-isis-topo1/r1/show_ip_route.ref
+++ b/tests/topotests/ldp-sync-isis-topo1/r1/show_ip_route.ref
@@ -8,7 +8,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -27,7 +26,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -46,7 +44,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }
@@ -63,7 +60,6 @@
         {
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1"
         }
       ]
@@ -76,7 +72,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -93,7 +88,6 @@
         {
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2"
         }
       ]
@@ -106,7 +100,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }
@@ -125,7 +118,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         },
@@ -133,7 +125,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }

--- a/tests/topotests/ldp-sync-isis-topo1/r2/show_ip_route.ref
+++ b/tests/topotests/ldp-sync-isis-topo1/r2/show_ip_route.ref
@@ -11,7 +11,6 @@
           "fib":true,
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -27,7 +26,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -46,7 +44,6 @@
           "fib":true,
           "ip":"10.0.3.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }
@@ -63,7 +60,6 @@
         {
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1"
         }
       ]
@@ -76,7 +72,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -95,7 +90,6 @@
           "fib":true,
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         },
@@ -103,7 +97,6 @@
           "fib":true,
           "ip":"10.0.3.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }
@@ -120,7 +113,6 @@
         {
           "ip":"10.0.3.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2"
         }
       ]
@@ -133,7 +125,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }

--- a/tests/topotests/ldp-sync-isis-topo1/r3/show_ip_route.ref
+++ b/tests/topotests/ldp-sync-isis-topo1/r3/show_ip_route.ref
@@ -11,7 +11,6 @@
           "fib":true,
           "ip":"10.0.2.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -30,7 +29,6 @@
           "fib":true,
           "ip":"10.0.3.2",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }
@@ -46,7 +44,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -65,7 +62,6 @@
           "fib":true,
           "ip":"10.0.2.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         },
@@ -73,7 +69,6 @@
           "fib":true,
           "ip":"10.0.3.2",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }
@@ -90,7 +85,6 @@
         {
           "ip":"10.0.2.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1"
         }
       ]
@@ -103,7 +97,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -120,7 +113,6 @@
         {
           "ip":"10.0.3.2",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2"
         }
       ]
@@ -133,7 +125,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }

--- a/tests/topotests/ldp-sync-ospf-topo1/r1/show_ip_route.ref
+++ b/tests/topotests/ldp-sync-ospf-topo1/r1/show_ip_route.ref
@@ -8,7 +8,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -22,7 +21,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -41,7 +39,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -60,7 +57,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }
@@ -76,7 +72,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -90,7 +85,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -106,7 +100,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }
@@ -120,7 +113,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }
@@ -139,7 +131,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         },
@@ -147,7 +138,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }

--- a/tests/topotests/ldp-sync-ospf-topo1/r2/show_ip_route.ref
+++ b/tests/topotests/ldp-sync-ospf-topo1/r2/show_ip_route.ref
@@ -11,7 +11,6 @@
           "fib":true,
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -27,7 +26,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -41,7 +39,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -60,7 +57,6 @@
           "fib":true,
           "ip":"10.0.3.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }
@@ -76,7 +72,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -90,7 +85,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -109,7 +103,6 @@
           "fib":true,
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         },
@@ -117,7 +110,6 @@
           "fib":true,
           "ip":"10.0.3.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }
@@ -133,7 +125,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }
@@ -147,7 +138,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }

--- a/tests/topotests/ldp-sync-ospf-topo1/r3/show_ip_route.ref
+++ b/tests/topotests/ldp-sync-ospf-topo1/r3/show_ip_route.ref
@@ -11,7 +11,6 @@
           "fib":true,
           "ip":"10.0.2.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -30,7 +29,6 @@
           "fib":true,
           "ip":"10.0.3.2",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }
@@ -46,7 +44,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -60,7 +57,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -79,7 +75,6 @@
           "fib":true,
           "ip":"10.0.2.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         },
@@ -87,7 +82,6 @@
           "fib":true,
           "ip":"10.0.3.2",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }
@@ -103,7 +97,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -117,7 +110,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -133,7 +125,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }
@@ -147,7 +138,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }

--- a/tests/topotests/ldp-vpls-topo1/r1/show_ip_route.ref
+++ b/tests/topotests/ldp-vpls-topo1/r1/show_ip_route.ref
@@ -8,7 +8,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -22,7 +21,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -41,7 +39,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -60,7 +57,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }
@@ -76,7 +72,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -90,7 +85,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -106,7 +100,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }
@@ -120,7 +113,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }
@@ -139,7 +131,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         },
@@ -147,7 +138,6 @@
           "fib":true,
           "ip":"10.0.2.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r1-eth2",
           "active":true
         }

--- a/tests/topotests/ldp-vpls-topo1/r2/show_ip_route.ref
+++ b/tests/topotests/ldp-vpls-topo1/r2/show_ip_route.ref
@@ -11,7 +11,6 @@
           "fib":true,
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -27,7 +26,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -41,7 +39,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -60,7 +57,6 @@
           "fib":true,
           "ip":"10.0.3.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }
@@ -76,7 +72,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -90,7 +85,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -109,7 +103,6 @@
           "fib":true,
           "ip":"10.0.1.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         },
@@ -117,7 +110,6 @@
           "fib":true,
           "ip":"10.0.3.3",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }
@@ -133,7 +125,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }
@@ -147,7 +138,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r2-eth2",
           "active":true
         }

--- a/tests/topotests/ldp-vpls-topo1/r3/show_ip_route.ref
+++ b/tests/topotests/ldp-vpls-topo1/r3/show_ip_route.ref
@@ -11,7 +11,6 @@
           "fib":true,
           "ip":"10.0.2.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -30,7 +29,6 @@
           "fib":true,
           "ip":"10.0.3.2",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }
@@ -46,7 +44,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -60,7 +57,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":1,
           "interfaceName":"lo",
           "active":true
         }
@@ -79,7 +75,6 @@
           "fib":true,
           "ip":"10.0.2.1",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         },
@@ -87,7 +82,6 @@
           "fib":true,
           "ip":"10.0.3.2",
           "afi":"ipv4",
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }
@@ -103,7 +97,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -117,7 +110,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r3-eth1",
           "active":true
         }
@@ -133,7 +125,6 @@
       "nexthops":[
         {
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }
@@ -147,7 +138,6 @@
         {
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":4,
           "interfaceName":"r3-eth2",
           "active":true
         }

--- a/tests/topotests/ospf-topo2/r1/v4_route.json
+++ b/tests/topotests/ospf-topo2/r1/v4_route.json
@@ -6,16 +6,11 @@
       "distance":110,
       "metric":10,
       "table":254,
-      "internalStatus":0,
-      "internalFlags":0,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":9,
           "ip":"0.0.0.0",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "onLink":true
@@ -31,16 +26,11 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }
@@ -57,16 +47,11 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }
@@ -83,17 +68,12 @@
       "metric":20,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":11,
           "fib":true,
           "ip":"10.0.3.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true,
           "onLink":true

--- a/tests/topotests/ospf-topo2/r2/v4_route.json
+++ b/tests/topotests/ospf-topo2/r2/v4_route.json
@@ -9,17 +9,12 @@
       "metric":20,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":11,
           "fib":true,
           "ip":"10.0.3.4",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true,
           "onLink":true
@@ -37,16 +32,11 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":3,
           "interfaceName":"r2-eth1",
           "active":true
         }
@@ -60,16 +50,11 @@
       "distance":110,
       "metric":10,
       "table":254,
-      "internalStatus":0,
-      "internalFlags":0,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":9,
           "ip":"0.0.0.0",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r2-eth0",
           "active":true,
           "onLink":true
@@ -85,16 +70,11 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "directlyConnected":true,
-          "interfaceIndex":2,
           "interfaceName":"r2-eth0",
           "active":true
         }

--- a/tests/topotests/zebra_netlink/r1/v4_route.json
+++ b/tests/topotests/zebra_netlink/r1/v4_route.json
@@ -9,17 +9,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -37,17 +32,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -65,17 +55,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -93,17 +78,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -121,17 +101,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -149,17 +124,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -177,17 +147,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -205,17 +170,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -233,17 +193,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -261,17 +216,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -289,17 +239,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -317,17 +262,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -345,17 +285,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -373,17 +308,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -401,17 +331,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -429,17 +354,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -457,17 +377,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -485,17 +400,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -513,17 +423,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -541,17 +446,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -569,17 +469,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -597,17 +492,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -625,17 +515,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -653,17 +538,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -681,17 +561,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -709,17 +584,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -737,17 +607,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -765,17 +630,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -793,17 +653,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -821,17 +676,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -849,17 +699,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -877,17 +722,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -905,17 +745,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -933,17 +768,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -961,17 +791,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -989,17 +814,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1017,17 +837,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1045,17 +860,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1073,17 +883,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1101,17 +906,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1129,17 +929,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1157,17 +952,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1185,17 +975,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1213,17 +998,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1241,17 +1021,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1269,17 +1044,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1297,17 +1067,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1325,17 +1090,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1353,17 +1113,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1381,17 +1136,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1409,17 +1159,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1437,17 +1182,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1465,17 +1205,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1493,17 +1228,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1521,17 +1251,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1549,17 +1274,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1577,17 +1297,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1605,17 +1320,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1633,17 +1343,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1661,17 +1366,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1689,17 +1389,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1717,17 +1412,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1745,17 +1435,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1773,17 +1458,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1801,17 +1481,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1829,17 +1504,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1857,17 +1527,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1885,17 +1550,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1913,17 +1573,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1941,17 +1596,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1969,17 +1619,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -1997,17 +1642,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2025,17 +1665,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2053,17 +1688,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2081,17 +1711,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2109,17 +1734,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2137,17 +1757,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2165,17 +1780,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2193,17 +1803,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2221,17 +1826,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2249,17 +1849,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2277,17 +1872,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2305,17 +1895,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2333,17 +1918,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2361,17 +1941,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2389,17 +1964,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2417,17 +1987,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2445,17 +2010,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2473,17 +2033,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2501,17 +2056,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2529,17 +2079,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2557,17 +2102,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2585,17 +2125,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2613,17 +2148,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2641,17 +2171,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2669,17 +2194,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2697,17 +2217,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2725,17 +2240,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2753,17 +2263,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1
@@ -2781,17 +2286,12 @@
       "metric":0,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":9,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.1.1",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true,
           "weight":1

--- a/tests/topotests/zebra_rib/r1/v4_route_1.json
+++ b/tests/topotests/zebra_rib/r1/v4_route_1.json
@@ -9,17 +9,12 @@
       "metric":8192,
       "installed":true,
       "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.210.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }

--- a/tests/topotests/zebra_rib/r1/v4_route_1_static_override.json
+++ b/tests/topotests/zebra_rib/r1/v4_route_1_static_override.json
@@ -8,18 +8,12 @@
       "distance":1,
       "metric":0,
       "installed":true,
-      "table":254,
-      "internalStatus":16,
-      "internalFlags":73,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.216.3",
           "afi":"ipv4",
-          "interfaceIndex":8,
           "interfaceName":"r1-eth6",
           "active":true
         }
@@ -31,18 +25,12 @@
       "distance":255,
       "metric":8192,
       "installed":true,
-      "table":254,
-      "internalStatus":16,
-      "internalFlags":0,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.210.2",
           "afi":"ipv4",
-          "interfaceIndex":2,
           "interfaceName":"r1-eth0",
           "active":true
         }

--- a/tests/topotests/zebra_rib/r1/v4_route_2.json
+++ b/tests/topotests/zebra_rib/r1/v4_route_2.json
@@ -8,18 +8,12 @@
       "distance":1,
       "metric":1,
       "installed":true,
-      "table":254,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
       "nexthops":[
         {
           "flags":3,
           "fib":true,
           "ip":"192.168.211.2",
           "afi":"ipv4",
-          "interfaceIndex":3,
           "interfaceName":"r1-eth1",
           "active":true
         }


### PR DESCRIPTION
Fixed all the json reference files to remove the InterfaceIndex and Internal status from the compare

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>