### PR TITLE
vtysh: dynamically generate the list of daemons for commands

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -112,6 +112,7 @@ dist_examples_DATA =
 dist_yangmodels_DATA =
 man_MANS =
 vtysh_scan =
+vtysh_daemons =
 clippy_scan =
 
 ## libtool, the self-made GNU scourge

--- a/babeld/subdir.am
+++ b/babeld/subdir.am
@@ -11,6 +11,7 @@ vtysh_scan += \
 	babeld/babel_zebra.c \
 	babeld/babeld.c \
 	# end
+vtysh_daemons += babeld
 endif
 
 babeld_libbabel_a_SOURCES = \

--- a/bfdd/subdir.am
+++ b/bfdd/subdir.am
@@ -8,6 +8,7 @@ sbin_PROGRAMS += bfdd/bfdd
 dist_examples_DATA += bfdd/bfdd.conf.sample
 vtysh_scan += bfdd/bfdd_vty.c
 vtysh_scan += bfdd/bfdd_cli.c
+vtysh_daemons += bfdd
 man8 += $(MANBUILD)/frr-bfdd.8
 endif
 

--- a/bgpd/subdir.am
+++ b/bgpd/subdir.am
@@ -30,6 +30,8 @@ vtysh_scan += \
 vtysh_scan += bgpd/bgp_rpki.c
 vtysh_scan += bgpd/bgp_bmp.c
 
+vtysh_daemons += bgpd
+
 if ENABLE_BGP_VNC
 vtysh_scan += \
 	bgpd/rfapi/bgp_rfapi_cfg.c \

--- a/eigrpd/subdir.am
+++ b/eigrpd/subdir.am
@@ -12,6 +12,7 @@ vtysh_scan += \
 	eigrpd/eigrp_vty.c \
 	# end
 #	eigrpd/eigrp_routemap.c
+vtysh_daemons += eigrpd
 man8 += $(MANBUILD)/frr-eigrpd.8
 endif
 

--- a/isisd/subdir.am
+++ b/isisd/subdir.am
@@ -16,6 +16,7 @@ vtysh_scan += \
 	isisd/isis_vty_fabricd.c \
 	isisd/isisd.c \
 	# end
+vtysh_daemons += isisd
 man8 += $(MANBUILD)/frr-isisd.8
 endif
 
@@ -35,6 +36,7 @@ vtysh_scan += \
 	isisd/isisd.c \
 	# end
 endif
+vtysh_daemons += fabricd
 endif
 
 noinst_HEADERS += \

--- a/ldpd/subdir.am
+++ b/ldpd/subdir.am
@@ -7,6 +7,7 @@ noinst_LIBRARIES += ldpd/libldp.a
 sbin_PROGRAMS += ldpd/ldpd
 dist_examples_DATA += ldpd/ldpd.conf.sample
 vtysh_scan += ldpd/ldp_vty_cmds.c
+vtysh_daemons += ldpd
 man8 += $(MANBUILD)/frr-ldpd.8
 endif
 

--- a/lib/command.h
+++ b/lib/command.h
@@ -437,12 +437,6 @@ struct cmd_node {
 #define NEIGHBOR_ADDR_STR2 "Neighbor address\nNeighbor IPv6 address\nInterface name or neighbor tag\n"
 #define NEIGHBOR_ADDR_STR3 "Neighbor address\nIPv6 address\nInterface name\n"
 
-/* Daemons lists */
-#define DAEMONS_STR                                                            \
-	"For the zebra daemon\nFor the rip daemon\nFor the ripng daemon\nFor the ospf daemon\nFor the ospfv6 daemon\nFor the bgp daemon\nFor the isis daemon\nFor the pbr daemon\nFor the fabricd daemon\nFor the pim daemon\nFor the static daemon\nFor the sharpd daemon\nFor the vrrpd daemon\nFor the ldpd daemon\n"
-#define DAEMONS_LIST                                                           \
-	"<zebra|ripd|ripngd|ospfd|ospf6d|bgpd|isisd|pbrd|fabricd|pimd|staticd|sharpd|vrrpd|ldpd>"
-
 /* Graceful Restart cli help strings */
 #define GR_CMD "Global Graceful Restart command\n"
 #define NO_GR_CMD "Undo Global Graceful Restart command\n"

--- a/nhrpd/subdir.am
+++ b/nhrpd/subdir.am
@@ -5,6 +5,7 @@
 if NHRPD
 sbin_PROGRAMS += nhrpd/nhrpd
 vtysh_scan += nhrpd/nhrp_vty.c
+vtysh_daemons += nhrpd
 man8 += $(MANBUILD)/frr-nhrpd.8
 endif
 

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -23,6 +23,7 @@ vtysh_scan += \
 	ospf6d/ospf6_zebra.c \
 	ospf6d/ospf6d.c \
 	# end
+vtysh_daemons += ospf6d
 if SNMP
 module_LTLIBRARIES += ospf6d/ospf6d_snmp.la
 endif

--- a/ospfd/subdir.am
+++ b/ospfd/subdir.am
@@ -17,6 +17,7 @@ vtysh_scan += \
 	ospfd/ospf_sr.c \
 	ospfd/ospf_vty.c \
 	# end
+vtysh_daemons += ospfd
 if SNMP
 module_LTLIBRARIES += ospfd/ospfd_snmp.la
 endif

--- a/pbrd/subdir.am
+++ b/pbrd/subdir.am
@@ -10,6 +10,7 @@ vtysh_scan += \
 	pbrd/pbr_vty.c \
 	pbrd/pbr_debug.c \
 	# end
+vtysh_daemons += pbrd
 man8 += $(MANBUILD)/frr-pbrd.8
 endif
 

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -9,6 +9,7 @@ bin_PROGRAMS += pimd/mtracebis
 noinst_PROGRAMS += pimd/test_igmpv3_join
 dist_examples_DATA += pimd/pimd.conf.sample
 vtysh_scan += pimd/pim_cmd.c
+vtysh_daemons += pimd
 man8 += $(MANBUILD)/frr-pimd.8
 man8 += $(MANBUILD)/mtracebis.8
 endif

--- a/ripd/subdir.am
+++ b/ripd/subdir.am
@@ -11,6 +11,7 @@ vtysh_scan += \
 	ripd/rip_debug.c \
 	ripd/ripd.c \
 	# end
+vtysh_daemons += ripd
 
 if SNMP
 module_LTLIBRARIES += ripd/ripd_snmp.la

--- a/ripngd/subdir.am
+++ b/ripngd/subdir.am
@@ -10,6 +10,7 @@ vtysh_scan += \
 	ripngd/ripng_debug.c \
 	ripngd/ripngd.c \
 	# end
+vtysh_daemons += ripngd
 man8 += $(MANBUILD)/frr-ripngd.8
 endif
 

--- a/sharpd/subdir.am
+++ b/sharpd/subdir.am
@@ -7,6 +7,7 @@ noinst_LIBRARIES += sharpd/libsharp.a
 sbin_PROGRAMS += sharpd/sharpd
 dist_examples_DATA += sharpd/sharpd.conf.sample
 vtysh_scan += sharpd/sharp_vty.c
+vtysh_daemons += sharpd
 man8 += $(MANBUILD)/frr-sharpd.8
 endif
 

--- a/staticd/subdir.am
+++ b/staticd/subdir.am
@@ -7,6 +7,7 @@ noinst_LIBRARIES += staticd/libstatic.a
 sbin_PROGRAMS += staticd/staticd
 dist_examples_DATA += staticd/staticd.conf.sample
 vtysh_scan += staticd/static_vty.c
+vtysh_daemons += staticd
 man8 += $(MANBUILD)/frr-staticd.8
 endif
 

--- a/vrrpd/subdir.am
+++ b/vrrpd/subdir.am
@@ -7,6 +7,7 @@ noinst_LIBRARIES += vrrpd/libvrrp.a
 sbin_PROGRAMS += vrrpd/vrrpd
 # dist_examples_DATA += staticd/staticd.conf.sample
 vtysh_scan += vrrpd/vrrp_vty.c
+vtysh_daemons += vrrpd
 man8 += $(MANBUILD)/frr-vrrpd.8
 endif
 

--- a/vtysh/daemons.pl
+++ b/vtysh/daemons.pl
@@ -1,0 +1,36 @@
+#!/usr/bin/perl
+##
+## generate daemons list and help strings
+##
+## Copyright (C) 2020 NFWare Inc.
+##
+## This file is part of FRR.
+##
+## FRR is free software; you can redistribute it and/or modify it
+## under the terms of the GNU General Public License as published by the
+## Free Software Foundation; either version 2, or (at your option) any
+## later version.
+##
+## FRR is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with FRR; see the file COPYING; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301, USA.
+##
+
+use strict;
+
+my @daemons_list = ();
+my @daemons_str = ();
+
+foreach (@ARGV) {
+	push (@daemons_list, $_);
+	push (@daemons_str, "For the $_ daemon\\n");
+}
+
+print "#define DAEMONS_LIST \"<" . join('|', @daemons_list) . ">\"\n";
+print "#define DAEMONS_STR \"" . join('', @daemons_str) . "\"\n";

--- a/vtysh/subdir.am
+++ b/vtysh/subdir.am
@@ -26,6 +26,16 @@ noinst_HEADERS += \
 
 vtysh_vtysh_LDADD = lib/libfrr.la $(LIBCAP) $(LIBREADLINE) $(LIBS) $(LIBPAM)
 
+EXTRA_DIST += vtysh/daemons.pl
+
+BUILT_SOURCES += vtysh/vtysh_daemons.h
+
+# force vtysh_daemons.h
+$(vtysh_vtysh_OBJECTS): vtysh/vtysh_daemons.h
+
+vtysh/vtysh_daemons.h:
+	$(PERL) vtysh/daemons.pl $(vtysh_daemons) > vtysh/vtysh_daemons.h
+
 AM_V_EXTRACT = $(am__v_EXTRACT_$(V))
 am__v_EXTRACT_ = $(am__v_EXTRACT_$(AM_DEFAULT_VERBOSITY))
 am__v_EXTRACT_0 = @echo "  EXTRACT " $@;

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -38,6 +38,7 @@
 #include "memory.h"
 #include "filter.h"
 #include "vtysh/vtysh.h"
+#include "vtysh/vtysh_daemons.h"
 #include "log.h"
 #include "bgpd/bgp_vty.h"
 #include "ns.h"

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -25,6 +25,8 @@ vtysh_scan += \
 vtysh_scan += zebra/irdp_interface.c
 vtysh_scan += zebra/zebra_fpm.c
 
+vtysh_daemons += zebra
+
 if IRDP
 module_LTLIBRARIES += zebra/zebra_irdp.la
 endif


### PR DESCRIPTION
Some daemons were actually missing from the static definitions: nhrpd,
babeld, eigrpd and bfdd.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>