### PR TITLE
lib: iterate safely over vrf table

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -396,13 +396,13 @@ struct interface *if_lookup_by_name_vrf(const char *name, struct vrf *vrf)
 
 struct interface *if_lookup_by_name_all_vrf(const char *name)
 {
-	struct vrf *vrf;
+	struct vrf *vrf, *vrf_next;
 	struct interface *ifp;
 
 	if (!name || strnlen(name, INTERFACE_NAMSIZ) == INTERFACE_NAMSIZ)
 		return NULL;
 
-	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
+	RB_FOREACH_SAFE (vrf, vrf_id_head, &vrfs_by_id, vrf_next) {
 		ifp = if_lookup_by_name(name, vrf->vrf_id);
 		if (ifp)
 			return ifp;
@@ -413,13 +413,13 @@ struct interface *if_lookup_by_name_all_vrf(const char *name)
 
 struct interface *if_lookup_by_index_all_vrf(ifindex_t ifindex)
 {
-	struct vrf *vrf;
+	struct vrf *vrf, *vrf_next;
 	struct interface *ifp;
 
 	if (ifindex == IFINDEX_INTERNAL)
 		return NULL;
 
-	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
+	RB_FOREACH_SAFE (vrf, vrf_id_head, &vrfs_by_id, vrf_next) {
 		ifp = if_lookup_by_ifindex(ifindex, vrf->vrf_id);
 		if (ifp)
 			return ifp;


### PR DESCRIPTION
avoids a segfault that can happen if we attempt to lookup an interface while zebra is shutting down, e.g. from a dataplane provider:
```
ZEBRA: Received signal 11 at 1601335707; aborting...
ZEBRA: /build/lib/libfrr.so.0(zlog_backtrace_sigsafe+0x5b) [0x7fb992b50fb1]
ZEBRA: /build/lib/libfrr.so.0(zlog_signal+0x150) [0x7fb992b50ead]
ZEBRA: /build/lib/libfrr.so.0(+0xa137a) [0x7fb992b8a37a]
ZEBRA: /lib/x86_64-linux-gnu/libpthread.so.0(+0x110e0) [0x7fb991e880e0]
ZEBRA: /build/lib/libfrr.so.0(_rb_next+0x52) [0x7fb992b6a8e9]
ZEBRA: /build/lib/libfrr.so.0(+0x58eef) [0x7fb992b41eef]
ZEBRA: /build/lib/libfrr.so.0(if_lookup_by_index_all_vrf+0x5d) [0x7fb992b4355e]
[...]
```
Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>