### PR TITLE
tests: don't compare internal vrfId in topotests

### DIFF
--- a/tests/topotests/isis-topo1-vrf/r3/r3_route6.json
+++ b/tests/topotests/isis-topo1-vrf/r3/r3_route6.json
@@ -12,7 +12,6 @@
       "prefix": "2001:db8:1:1::/64", 
       "protocol": "connected", 
       "selected": true, 
-      "vrfId": 4,
       "vrfName": "r3-cust1"
     }
   ], 
@@ -31,7 +30,6 @@
       "prefix": "2001:db8:1:2::/64", 
       "protocol": "isis", 
       "selected": true, 
-      "vrfId": 4,
       "vrfName": "r3-cust1"
     }
   ], 
@@ -48,7 +46,6 @@
       "prefix": "2001:db8:2:1::/64", 
       "protocol": "connected", 
       "selected": true, 
-      "vrfId": 4,
       "vrfName": "r3-cust1"
     }
   ], 
@@ -67,7 +64,6 @@
       "prefix": "2001:db8:2:2::/64", 
       "protocol": "isis", 
       "selected": true, 
-      "vrfId": 4,
       "vrfName": "r3-cust1"
     }
   ]


### PR DESCRIPTION
Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>