### PR TITLE
isisd, ospfd: fix missing/excessive docstrings

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -340,7 +340,8 @@ DEFPY_YANG(no_ip_router_isis, no_ip_router_isis_cmd,
 	   "IP router interface commands\n"
 	   "IP router interface commands\n"
 	   "IS-IS routing protocol\n"
-	   "Routing process tag\n")
+	   "Routing process tag\n"
+	   VRF_CMD_HELP_STR)
 {
 	const struct lyd_node *dnode;
 
@@ -2425,7 +2426,7 @@ DEFPY(isis_mpls_ldp_sync_holddown, isis_mpls_ldp_sync_holddown_cmd,
 
 DEFPY(no_isis_mpls_ldp_sync_holddown, no_isis_mpls_ldp_sync_holddown_cmd,
       "no mpls ldp-sync holddown [<(1-10000)>]",
-      NO_STR MPLS_STR MPLS_LDP_SYNC_STR NO_MPLS_LDP_SYNC_HOLDDOWN_STR)
+      NO_STR MPLS_STR MPLS_LDP_SYNC_STR NO_MPLS_LDP_SYNC_HOLDDOWN_STR "Time in seconds\n")
 {
 	nb_cli_enqueue_change(vty, "./mpls/ldp-sync/holddown", NB_OP_DESTROY,
 			      NULL);
@@ -2521,7 +2522,7 @@ DEFPY(isis_mpls_if_ldp_sync_holddown, isis_mpls_if_ldp_sync_holddown_cmd,
 DEFPY(no_isis_mpls_if_ldp_sync_holddown, no_isis_mpls_if_ldp_sync_holddown_cmd,
       "no isis mpls ldp-sync holddown [<(1-10000)>]",
       NO_STR "IS-IS routing protocol\n" MPLS_STR NO_MPLS_LDP_SYNC_STR
-	      NO_MPLS_LDP_SYNC_HOLDDOWN_STR)
+	      NO_MPLS_LDP_SYNC_HOLDDOWN_STR "Time in seconds\n")
 {
 	const struct lyd_node *dnode;
 	struct interface *ifp;

--- a/isisd/isis_ldp_sync.c
+++ b/isisd/isis_ldp_sync.c
@@ -748,7 +748,9 @@ DEFUN (show_isis_mpls_ldp_interface,
        PROTO_HELP
        MPLS_STR
        "LDP-IGP Sync information\n"
-       "Interface name\n")
+       "Interface information\n"
+       "Interface name\n"
+       "All interfaces\n")
 {
 	char *ifname = NULL;
 	int idx_intf = 0;

--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -890,7 +890,8 @@ DEFPY (no_ospf_mpls_ldp_sync_holddown,
        NO_STR
        "MPLS specific commands\n"
        "Disable MPLS LDP-IGP Sync\n"
-       "holddown timer disable\n")
+       "holddown timer disable\n"
+       "Time in seconds\n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 	struct vrf *vrf = vrf_lookup_by_id(ospf->vrf_id);
@@ -913,7 +914,6 @@ DEFPY (mpls_ldp_sync,
        IP_STR
        "OSPF interface commands\n"
        MPLS_STR
-       MPLS_LDP_SYNC_STR
        MPLS_LDP_SYNC_STR)
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
@@ -1035,7 +1035,8 @@ DEFPY (no_mpls_ldp_sync_holddown,
        "OSPF interface commands\n"
        MPLS_STR
        NO_MPLS_LDP_SYNC_STR
-       NO_MPLS_LDP_SYNC_HOLDDOWN_STR)
+       NO_MPLS_LDP_SYNC_HOLDDOWN_STR
+       "Time in seconds\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct ospf_if_params *params;
@@ -1078,7 +1079,9 @@ DEFPY (show_ip_ospf_mpls_ldp_interface,
        "OSPF information\n"
        MPLS_STR
        "LDP-IGP Sync information\n"
+       "Interface information\n"
        "Interface name\n"
+       "All interfaces\n"
        JSON_STR)
 {
 	struct ospf *ospf;


### PR DESCRIPTION
Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>