### PR TITLE
tests: Skip comparing neighbor-extended-circuit-id in yang output.

### DIFF
--- a/tests/topotests/isis-sr-topo1/rt1/step1/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt1/step1/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0003",
-                  "neighbor-extended-circuit-id": 2,
                   "hold-timer": 9,
                   "neighbor-priority": 64,
                   "state": "up"
@@ -19,7 +18,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0002",
-                  "neighbor-extended-circuit-id": 2,
                   "hold-timer": 9,
                   "neighbor-priority": 64,
                   "state": "up"

--- a/tests/topotests/isis-sr-topo1/rt2/step1/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt2/step1/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0004",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -31,7 +30,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0004",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -51,7 +49,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0003",
-                  "neighbor-extended-circuit-id": 2,
                   "hold-timer": 9,
                   "neighbor-priority": 64,
                   "state": "up"
@@ -59,7 +56,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0001",
-                  "neighbor-extended-circuit-id": 2,
                   "hold-timer": 9,
                   "neighbor-priority": 64,
                   "state": "up"

--- a/tests/topotests/isis-sr-topo1/rt3/step1/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt3/step1/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0005",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -31,7 +30,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0005",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -51,7 +49,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0001",
-                  "neighbor-extended-circuit-id": 2,
                   "hold-timer": 9,
                   "neighbor-priority": 64,
                   "state": "up"
@@ -59,7 +56,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0002",
-                  "neighbor-extended-circuit-id": 2,
                   "hold-timer": 9,
                   "neighbor-priority": 64,
                   "state": "up"

--- a/tests/topotests/isis-sr-topo1/rt4/step1/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt4/step1/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0002",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -31,7 +30,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0002",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -51,7 +49,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0005",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -71,7 +68,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0006",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"

--- a/tests/topotests/isis-sr-topo1/rt4/step2/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt4/step2/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0002",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -31,7 +30,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0002",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -51,7 +49,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0006",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"

--- a/tests/topotests/isis-sr-topo1/rt4/step3/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt4/step3/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0002",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -31,7 +30,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0002",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"

--- a/tests/topotests/isis-sr-topo1/rt5/step1/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt5/step1/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0003",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -31,7 +30,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0003",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -51,7 +49,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0004",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -71,7 +68,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0006",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"

--- a/tests/topotests/isis-sr-topo1/rt5/step2/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt5/step2/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0003",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -31,7 +30,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0003",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -51,7 +49,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0006",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"

--- a/tests/topotests/isis-sr-topo1/rt5/step3/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt5/step3/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0003",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -31,7 +30,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0003",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"

--- a/tests/topotests/isis-sr-topo1/rt5/step4/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt5/step4/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0003",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -31,7 +30,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0003",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -51,7 +49,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0006",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"

--- a/tests/topotests/isis-sr-topo1/rt6/step1/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis-sr-topo1/rt6/step1/show_yang_interface_isis_adjacencies.ref
@@ -11,7 +11,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0004",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"
@@ -31,7 +30,6 @@
                 {
                   "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0005",
-                  "neighbor-extended-circuit-id": 0,
                   "hold-timer": 9,
                   "neighbor-priority": 0,
                   "state": "up"


### PR DESCRIPTION
Another inconsistent id which should not be compared and started to fail tests

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>