### PR TITLE
lib: remove nexthop_same_firsthop() api

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -202,43 +202,6 @@ int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
 	return ret;
 }
 
-bool nexthop_same_firsthop(const struct nexthop *next1,
-			   const struct nexthop *next2)
-{
-	/* Map the TYPE_IPx types to TYPE_IPx_IFINDEX */
-	int type1 = NEXTHOP_FIRSTHOPTYPE(next1->type);
-	int type2 = NEXTHOP_FIRSTHOPTYPE(next2->type);
-
-	if (type1 != type2)
-		return false;
-
-	if (next1->vrf_id != next2->vrf_id)
-		return false;
-
-	switch (type1) {
-	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		if (!IPV4_ADDR_SAME(&next1->gate.ipv4, &next2->gate.ipv4))
-			return false;
-		if (next1->ifindex != next2->ifindex)
-			return false;
-		break;
-	case NEXTHOP_TYPE_IFINDEX:
-		if (next1->ifindex != next2->ifindex)
-			return false;
-		break;
-	case NEXTHOP_TYPE_IPV6_IFINDEX:
-		if (!IPV6_ADDR_SAME(&next1->gate.ipv6, &next2->gate.ipv6))
-			return false;
-		if (next1->ifindex != next2->ifindex)
-			return false;
-		break;
-	default:
-		/* do nothing */
-		break;
-	}
-	return true;
-}
-
 /*
  * nexthop_type_to_str
  */

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -55,12 +55,6 @@ enum blackhole_type {
 	BLACKHOLE_ADMINPROHIB,
 };
 
-/* IPV[46] -> IPV[46]_IFINDEX */
-#define NEXTHOP_FIRSTHOPTYPE(type)                                             \
-	((type) == NEXTHOP_TYPE_IFINDEX || (type) == NEXTHOP_TYPE_BLACKHOLE)   \
-		? (type)                                                       \
-		: ((type) | 1)
-
 enum nh_encap_type {
 	NET_VXLAN = 100, /* value copied from FPM_NH_ENCAP_VXLAN. */
 };
@@ -216,8 +210,6 @@ extern int nexthop_g_addr_cmp(enum nexthop_types_t type,
 extern const char *nexthop_type_to_str(enum nexthop_types_t nh_type);
 extern bool nexthop_labels_match(const struct nexthop *nh1,
 				 const struct nexthop *nh2);
-extern bool nexthop_same_firsthop(const struct nexthop *next1,
-				  const struct nexthop *next2);
 
 extern const char *nexthop2str(const struct nexthop *nexthop,
 			       char *str, int size);

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -481,7 +481,7 @@ void nexthop_group_mark_duplicates(struct nexthop_group *nhg)
 		for (ALL_NEXTHOPS_PTR(nhg, prev)) {
 			if (prev == nexthop)
 				break;
-			if (nexthop_same_firsthop(nexthop, prev)) {
+			if (nexthop_same(nexthop, prev)) {
 				SET_FLAG(nexthop->flags,
 					 NEXTHOP_FLAG_DUPLICATE);
 				break;


### PR DESCRIPTION
Remove the nexthop_same_firsthop() api and just call nexthop_same().
Not entirely sure why we were using this function in the first place,
but now we are just marking dupes with it so lets just call a
common function and avoid issues.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>