### PR TITLE
bgpd: aggregate-address on matching MED only

### DIFF
--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -379,6 +379,25 @@ struct bgp_aggregate {
 
 	/* SAFI configuration. */
 	safi_t safi;
+
+	/** Match only equal MED. */
+	bool match_med;
+	/* MED matching state. */
+	/** Did we get the first MED value? */
+	bool med_initialized;
+	/** Are there MED mismatches? */
+	bool med_mismatched;
+	/** MED value found in current group. */
+	uint32_t med_matched_value;
+
+	/**
+	 * Test if aggregated address MED of all route match, otherwise
+	 * returns `false`. This macro will also return `true` if MED
+	 * matching is disabled.
+	 */
+#define AGGREGATE_MED_VALID(aggregate)                                         \
+	(((aggregate)->match_med && !(aggregate)->med_mismatched)              \
+	 || !(aggregate)->match_med)
 };
 
 #define BGP_NEXTHOP_AFI_FROM_NHLEN(nhlen)                                      \

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -999,6 +999,12 @@ Route Aggregation-IPv4 Address Family
    This command specifies an aggregate address. Aggregated routes will
    not be announced.
 
+.. index:: aggregate-address A.B.C.D/M matching-MED-only
+.. clicmd:: aggregate-address A.B.C.D/M matching-MED-only
+
+   Configure the aggregated address to only be created when the routes MED
+   match, otherwise no aggregated route will be created.
+
 .. index:: no aggregate-address A.B.C.D/M
 .. clicmd:: no aggregate-address A.B.C.D/M
 
@@ -1050,6 +1056,13 @@ Route Aggregation-IPv6 Address Family
 
    This command specifies an aggregate address. Aggregated routes will
    not be announced.
+
+.. index:: aggregate-address X:X::X:X/M matching-MED-only
+.. clicmd:: aggregate-address X:X::X:X/M matching-MED-only
+
+   Configure the aggregated address to only be created when the routes MED
+   match, otherwise no aggregated route will be created.
+
 
 .. index:: no aggregate-address X:X::X:X/M
 .. clicmd:: no aggregate-address X:X::X:X/M

--- a/tests/topotests/bgp_aggregate_address_topo1/exabgp.env
+++ b/tests/topotests/bgp_aggregate_address_topo1/exabgp.env
@@ -1,0 +1,53 @@
+[exabgp.api]
+encoder = text
+highres = false
+respawn = false
+socket = ''
+
+[exabgp.bgp]
+openwait = 60
+
+[exabgp.cache]
+attributes = true
+nexthops = true
+
+[exabgp.daemon]
+daemonize = true
+pid = '/var/run/exabgp/exabgp.pid'
+user = 'exabgp'
+##daemonize = false
+
+[exabgp.log]
+all = false
+configuration = true
+daemon = true
+destination = '/var/log/exabgp.log'
+enable = true
+level = INFO
+message = false
+network = true
+packets = false
+parser = false
+processes = true
+reactor = true
+rib = false
+routes = false
+short = false
+timers = false
+
+[exabgp.pdb]
+enable = false
+
+[exabgp.profile]
+enable = false
+file = ''
+
+[exabgp.reactor]
+speed = 1.0
+
+[exabgp.tcp]
+acl = false
+bind = ''
+delay = 0
+once = false
+port = 179

--- a/tests/topotests/bgp_aggregate_address_topo1/peer1/exabgp.cfg
+++ b/tests/topotests/bgp_aggregate_address_topo1/peer1/exabgp.cfg
@@ -1,0 +1,17 @@
+neighbor 10.0.0.1 {
+  router-id 10.254.254.3;
+  local-address 10.0.0.2;
+  local-as 65001;
+  peer-as 65000;
+  static {
+    route 10.254.254.3/32 next-hop 10.0.0.2;
+
+    route 192.168.0.1/32 next-hop 10.0.0.2 med 10;
+    route 192.168.0.2/32 next-hop 10.0.0.2 med 10;
+    route 192.168.0.3/32 next-hop 10.0.0.2 med 10;
+
+    route 192.168.1.1/32 next-hop 10.0.0.2 med 10;
+    route 192.168.1.2/32 next-hop 10.0.0.2 med 10;
+    route 192.168.1.3/32 next-hop 10.0.0.2 med 20;
+  }
+}

--- a/tests/topotests/bgp_aggregate_address_topo1/r1/bgpd.conf
+++ b/tests/topotests/bgp_aggregate_address_topo1/r1/bgpd.conf
@@ -1,0 +1,12 @@
+router bgp 65000
+  no bgp ebgp-requires-policy
+  neighbor 10.0.0.2 remote-as 65001
+  neighbor 10.0.0.2 timers 3 10
+  neighbor 10.0.1.2 remote-as internal
+  neighbor 10.0.1.2 timers 3 10
+  address-family ipv4 unicast
+   redistribute connected
+   aggregate-address 192.168.0.0/24 matching-MED-only
+   aggregate-address 192.168.1.0/24 matching-MED-only
+  exit-address-family
+!

--- a/tests/topotests/bgp_aggregate_address_topo1/r1/zebra.conf
+++ b/tests/topotests/bgp_aggregate_address_topo1/r1/zebra.conf
@@ -1,0 +1,13 @@
+!
+interface lo
+ ip address 10.254.254.1/32
+!
+interface r1-eth0
+ ip address 10.0.0.1/24
+!
+interface r1-eth1
+ ip address 10.0.1.1/24
+!
+ip forwarding
+ipv6 forwarding
+!

--- a/tests/topotests/bgp_aggregate_address_topo1/r2/bgpd.conf
+++ b/tests/topotests/bgp_aggregate_address_topo1/r2/bgpd.conf
@@ -1,0 +1,7 @@
+router bgp 65000
+  neighbor 10.0.1.1 remote-as internal
+  neighbor 10.0.1.1 timers 3 10
+  address-family ipv4 unicast
+    redistribute connected
+  exit-address-family
+!

--- a/tests/topotests/bgp_aggregate_address_topo1/r2/zebra.conf
+++ b/tests/topotests/bgp_aggregate_address_topo1/r2/zebra.conf
@@ -1,0 +1,10 @@
+!
+interface lo
+ ip address 10.254.254.2/32
+!
+interface r2-eth0
+ ip address 10.0.1.2/24
+!
+ip forwarding
+ipv6 forwarding
+!

--- a/tests/topotests/bgp_aggregate_address_topo1/test_bgp_aggregate_address_topo1.py
+++ b/tests/topotests/bgp_aggregate_address_topo1/test_bgp_aggregate_address_topo1.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_aggregate_address_topo1.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2020 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+Test BGP aggregate address features.
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from mininet.topo import Topo
+
+
+class BgpAggregateAddressTopo1(Topo):
+    def build(self, *_args, **_opts):
+        tgen = get_topogen(self)
+
+        r1 = tgen.add_router('r1')
+        r2 = tgen.add_router('r2')
+        peer1 = tgen.add_exabgp_peer('peer1', ip='10.0.0.2',
+                                     defaultRoute='via 10.0.0.1')
+
+        switch = tgen.add_switch('s1')
+        switch.add_link(r1)
+        switch.add_link(peer1)
+
+        switch = tgen.add_switch('s2')
+        switch.add_link(r1)
+        switch.add_link(r2)
+
+
+def setup_module(mod):
+    tgen = Topogen(BgpAggregateAddressTopo1, mod.__name__)
+    tgen.start_topology()
+
+    router = tgen.gears['r1']
+    router.load_config(TopoRouter.RD_ZEBRA, os.path.join(CWD, "r1/zebra.conf"))
+    router.load_config(TopoRouter.RD_BGP, os.path.join(CWD, "r1/bgpd.conf"))
+    router.start()
+
+    router = tgen.gears['r2']
+    router.load_config(TopoRouter.RD_ZEBRA, os.path.join(CWD, "r2/zebra.conf"))
+    router.load_config(TopoRouter.RD_BGP, os.path.join(CWD, "r2/bgpd.conf"))
+    router.start()
+
+    peer = tgen.gears['peer1']
+    peer.start(os.path.join(CWD, "peer1"), os.path.join(CWD, "exabgp.env"))
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_expect_convergence():
+    "Test that BGP protocol converged."
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for protocols to converge")
+    def expect_loopback_route(router, iptype, route, proto):
+        "Wait until route is present on RIB for protocol."
+        logger.info('waiting route {} in {}'.format(route, router))
+        test_func = functools.partial(
+            topotest.router_json_cmp,
+            tgen.gears[router],
+            'show {} route json'.format(iptype),
+            { route: [{ 'protocol': proto }] }
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=130, wait=1)
+        assertmsg = '"{}" BGP convergence failure'.format(router)
+        assert result is None, assertmsg
+
+    expect_loopback_route('r2', 'ip', '10.254.254.1/32', 'bgp')
+    expect_loopback_route('r2', 'ip', '10.254.254.3/32', 'bgp')
+
+
+def test_bgp_aggregate_address_matching_med_only():
+    "Test that the command matching-MED-only works."
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    routes_expected = {
+        # All MED matches, aggregation must exist.
+        "192.168.0.0/24": [{"protocol": "bgp", "metric": 0}],
+        "192.168.0.1/32": [{"protocol": "bgp", "metric": 10}],
+        "192.168.0.2/32": [{"protocol": "bgp", "metric": 10}],
+        "192.168.0.3/32": [{"protocol": "bgp", "metric": 10}],
+
+        # Non matching MED: aggregation must not exist.
+        "192.168.1.0/24": None,
+        "192.168.1.1/32": [{"protocol": "bgp", "metric": 10}],
+        "192.168.1.2/32": [{"protocol": "bgp", "metric": 10}],
+        "192.168.1.3/32": [{"protocol": "bgp", "metric": 20}]
+    }
+
+    test_func = functools.partial(
+        topotest.router_json_cmp,
+        tgen.gears['r2'],
+        'show ip route json',
+        routes_expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assertmsg = '"r2" BGP convergence failure'
+    assert result is None, assertmsg
+
+
+def test_bgp_aggregate_address_match_and_supress():
+    "Test that the command matching-MED-only with suppression works."
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears['r1'].vtysh_multicmd("""
+configure terminal
+router bgp 65000
+address-family ipv4 unicast
+no aggregate-address 192.168.0.0/24 matching-MED-only
+no aggregate-address 192.168.1.0/24 matching-MED-only
+aggregate-address 192.168.0.0/24 matching-MED-only summary-only
+aggregate-address 192.168.1.0/24 matching-MED-only summary-only
+""")
+
+    routes_expected = {
+        # All MED matches, aggregation must exist.
+        "192.168.0.0/24": [{"protocol": "bgp", "metric": 0}],
+        "192.168.0.1/32": None,
+        "192.168.0.2/32": None,
+        "192.168.0.3/32": None,
+
+        # Non matching MED: aggregation must not exist.
+        "192.168.1.0/24": None,
+        "192.168.1.1/32": [{"protocol": "bgp", "metric": 10}],
+        "192.168.1.2/32": [{"protocol": "bgp", "metric": 10}],
+        "192.168.1.3/32": [{"protocol": "bgp", "metric": 20}]
+    }
+
+    test_func = functools.partial(
+        topotest.router_json_cmp,
+        tgen.gears['r2'],
+        'show ip route json',
+        routes_expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=1)
+    assertmsg = '"r2" BGP convergence failure'
+    assert result is None, assertmsg
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Summary
------------

Add new command variation for `aggregate-address` to only execute this action when the MED of all routes match, otherwise the aggregate route should not be created (and if there are suppresed routes they should be installed back).

While here I did some refactory in the `aggregate-address` command to use less code (`DEFUN` -> `DEFPY`).


ToDo
------

- [x] Code
- [x] Documentation
- [x] Topotests