### PR TITLE
lib: add errmsg to nb rpc

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -1142,7 +1142,8 @@ const void *nb_callback_lookup_entry(const struct nb_node *nb_node,
 }
 
 int nb_callback_rpc(const struct nb_node *nb_node, const char *xpath,
-		    const struct list *input, struct list *output)
+		    const struct list *input, struct list *output, char *errmsg,
+		    size_t errmsg_len)
 {
 	struct nb_cb_rpc_args args = {};
 
@@ -1151,6 +1152,8 @@ int nb_callback_rpc(const struct nb_node *nb_node, const char *xpath,
 	args.xpath = xpath;
 	args.input = input;
 	args.output = output;
+	args.errmsg = errmsg;
+	args.errmsg_len = errmsg_len;
 	return nb_node->cbs.rpc(&args);
 }
 

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -258,6 +258,12 @@ struct nb_cb_rpc_args {
 
 	/* List of output parameters to be populated by the callback. */
 	struct list *output;
+
+	/* Buffer to store human-readable error message in case of error. */
+	char *errmsg;
+
+	/* Size of errmsg. */
+	size_t errmsg_len;
 };
 
 /*
@@ -689,7 +695,8 @@ extern const void *nb_callback_lookup_entry(const struct nb_node *nb_node,
 					    const void *parent_list_entry,
 					    const struct yang_list_keys *keys);
 extern int nb_callback_rpc(const struct nb_node *nb_node, const char *xpath,
-			   const struct list *input, struct list *output);
+			   const struct list *input, struct list *output,
+			   char *errmsg, size_t errmsg_len);
 
 /*
  * Create a northbound node for all YANG schema nodes.

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -284,10 +284,12 @@ int nb_cli_apply_changes(struct vty *vty, const char *xpath_base_fmt, ...)
 	return CMD_SUCCESS;
 }
 
-int nb_cli_rpc(const char *xpath, struct list *input, struct list *output)
+int nb_cli_rpc(struct vty *vty, const char *xpath, struct list *input,
+	       struct list *output)
 {
 	struct nb_node *nb_node;
 	int ret;
+	char errmsg[BUFSIZ] = {0};
 
 	nb_node = nb_node_find(xpath);
 	if (!nb_node) {
@@ -296,11 +298,14 @@ int nb_cli_rpc(const char *xpath, struct list *input, struct list *output)
 		return CMD_WARNING;
 	}
 
-	ret = nb_callback_rpc(nb_node, xpath, input, output);
+	ret = nb_callback_rpc(nb_node, xpath, input, output, errmsg,
+			      sizeof(errmsg));
 	switch (ret) {
 	case NB_OK:
 		return CMD_SUCCESS;
 	default:
+		if (strlen(errmsg))
+			vty_show_nb_errors(vty, ret, errmsg);
 		return CMD_WARNING;
 	}
 }

--- a/lib/northbound_cli.h
+++ b/lib/northbound_cli.h
@@ -75,6 +75,9 @@ extern int nb_cli_apply_changes(struct vty *vty, const char *xpath_base_fmt,
 /*
  * Execute a YANG RPC or Action.
  *
+ * vty
+ *    The vty terminal to dump any error.
+ *
  * xpath
  *    XPath of the YANG RPC or Action node.
  *
@@ -90,7 +93,7 @@ extern int nb_cli_apply_changes(struct vty *vty, const char *xpath_base_fmt,
  * Returns:
  *    CMD_SUCCESS on success, CMD_WARNING otherwise.
  */
-extern int nb_cli_rpc(const char *xpath, struct list *input,
+extern int nb_cli_rpc(struct vty *vty, const char *xpath, struct list *input,
 		      struct list *output);
 
 /*

--- a/lib/northbound_confd.c
+++ b/lib/northbound_confd.c
@@ -1068,6 +1068,7 @@ static int frr_confd_action_execute(struct confd_user_info *uinfo,
 	struct yang_data *data;
 	confd_tag_value_t *reply;
 	int ret = CONFD_OK;
+	char errmsg[BUFSIZ] = {0};
 
 	/* Getting the XPath is tricky. */
 	if (kp) {
@@ -1115,7 +1116,9 @@ static int frr_confd_action_execute(struct confd_user_info *uinfo,
 	}
 
 	/* Execute callback registered for this XPath. */
-	if (nb_callback_rpc(nb_node, xpath, input, output) != NB_OK) {
+	if (nb_callback_rpc(nb_node, xpath, input, output, errmsg,
+			    sizeof(errmsg))
+	    != NB_OK) {
 		flog_warn(EC_LIB_NB_CB_RPC, "%s: rpc callback failed: %s",
 			  __func__, xpath);
 		ret = CONFD_ERR;

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -962,6 +962,7 @@ class NorthboundImpl
 		struct listnode *node;
 		struct yang_data *data;
 		const char *xpath;
+		char errmsg[BUFSIZ] = {0};
 
 		switch (tag->state) {
 		case CREATE:
@@ -1012,7 +1013,7 @@ class NorthboundImpl
 
 			// Execute callback registered for this XPath.
 			if (nb_callback_rpc(nb_node, xpath, input_list,
-					    output_list)
+					    output_list, errmsg, sizeof(errmsg))
 			    != NB_OK) {
 				flog_warn(EC_LIB_NB_CB_RPC,
 					  "%s: rpc callback failed: %s",

--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -414,6 +414,7 @@ static int frr_sr_config_rpc_cb(sr_session_ctx_t *session, const char *xpath,
 	struct yang_data *data;
 	size_t cb_output_cnt;
 	int ret = SR_ERR_OK;
+	char errmsg[BUFSIZ] = {0};
 
 	nb_node = nb_node_find(xpath);
 	if (!nb_node) {
@@ -436,7 +437,9 @@ static int frr_sr_config_rpc_cb(sr_session_ctx_t *session, const char *xpath,
 	}
 
 	/* Execute callback registered for this XPath. */
-	if (nb_callback_rpc(nb_node, xpath, input, output) != NB_OK) {
+	if (nb_callback_rpc(nb_node, xpath, input, output, errmsg,
+			    sizeof(errmsg))
+	    != NB_OK) {
 		flog_warn(EC_LIB_NB_CB_RPC, "%s: rpc callback failed: %s",
 			  __func__, xpath);
 		ret = SR_ERR_OPERATION_FAILED;

--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -1012,7 +1012,7 @@ DEFPY_YANG (clear_ip_rip,
 		listnode_add(input, yang_vrf);
 	}
 
-	ret = nb_cli_rpc("/frr-ripd:clear-rip-route", input, NULL);
+	ret = nb_cli_rpc(vty, "/frr-ripd:clear-rip-route", input, NULL);
 
 	list_delete(&input);
 

--- a/ripngd/ripng_cli.c
+++ b/ripngd/ripng_cli.c
@@ -496,7 +496,7 @@ DEFPY_YANG (clear_ipv6_rip,
 		listnode_add(input, yang_vrf);
 	}
 
-	ret = nb_cli_rpc("/frr-ripngd:clear-ripng-route", input, NULL);
+	ret = nb_cli_rpc(vty, "/frr-ripngd:clear-ripng-route", input, NULL);
 
 	list_delete(&input);
 

--- a/zebra/zebra_nb_rpcs.c
+++ b/zebra/zebra_nb_rpcs.c
@@ -65,19 +65,22 @@ int clear_evpn_dup_addr_rpc(struct nb_cb_rpc_args *args)
 			if (yang_dup_mac) {
 				yang_str2mac(yang_dup_mac->value, &mac);
 				ret = zebra_vxlan_clear_dup_detect_vni_mac(
-					zvrf, vni, &mac);
+					zvrf, vni, &mac, args->errmsg,
+					args->errmsg_len);
 			} else if (yang_dup_ip) {
 				yang_str2ip(yang_dup_ip->value, &host_ip);
 				ret = zebra_vxlan_clear_dup_detect_vni_ip(
-					zvrf, vni, &host_ip);
+					zvrf, vni, &host_ip, args->errmsg,
+					args->errmsg_len);
 			} else
 				ret = zebra_vxlan_clear_dup_detect_vni(zvrf,
 								       vni);
 		}
 	}
-	ret = (ret != CMD_SUCCESS) ? NB_ERR : NB_OK;
+	if (ret < 0)
+		return NB_ERR;
 
-	return ret;
+	return NB_OK;
 }
 
 /*

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3264,7 +3264,8 @@ DEFPY (clear_evpn_dup_addr,
 
 	if (yang_dup) {
 		listnode_add(input, yang_dup);
-		ret = nb_cli_rpc("/frr-zebra:clear-evpn-dup-addr", input, NULL);
+		ret = nb_cli_rpc(vty, "/frr-zebra:clear-evpn-dup-addr", input,
+				 NULL);
 	}
 
 	list_delete(&input);

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -208,9 +208,12 @@ extern void zebra_vxlan_evpn_vrf_route_del(vrf_id_t vrf_id,
 					   struct prefix *host_prefix);
 extern int zebra_vxlan_clear_dup_detect_vni_mac(struct zebra_vrf *zvrf,
 						vni_t vni,
-						struct ethaddr *macaddr);
+						struct ethaddr *macaddr,
+						char *errmsg,
+						size_t errmsg_len);
 extern int zebra_vxlan_clear_dup_detect_vni_ip(struct zebra_vrf *zvrf,
-					       vni_t vni, struct ipaddr *ip);
+					       vni_t vni, struct ipaddr *ip,
+					       char *errmsg, size_t errmsg_len);
 extern int zebra_vxlan_clear_dup_detect_vni_all(struct zebra_vrf *zvrf);
 extern int zebra_vxlan_clear_dup_detect_vni(struct zebra_vrf *zvrf, vni_t vni);
 extern void zebra_vxlan_handle_result(struct zebra_dplane_ctx *ctx);


### PR DESCRIPTION
    *: add errmsg to nb rpc
    
    Display human readable error message in northbound rpc transaction failure. In case of vtysh nb client, the error
    message will be displayed to user.
    
    Testing:    
    bharat# clear evpn dup-addr vni 1002 ip 11.11.11.11
    Error type: generic error
    Error description: Requested IP's associated MAC aa:aa:aa:aa:aa:aa is still
    in duplicate state
    
    Signed-off-by: Chirag Shah <chirag@nvidia.com>
