### PR TITLE
BSD: Detect route(4) overflows

### DIFF
--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1429,6 +1429,7 @@ static void routing_socket(struct zebra_ns *zns)
 #ifdef SO_RERROR
 	/* Allow reporting of route(4) buffer overflow errors */
 	int n = 1;
+
 	if (setsockopt(routing_sock, SOL_SOCKET, SO_RERROR, &n, sizeof(n)) < 0)
 		flog_err_sys(EC_LIB_SOCKET,
 			     "Can't set SO_RERROR on routing socket");


### PR DESCRIPTION
NetBSD and DragonFlyBSD support reporting of route(4) overflows
by setting the socket option SO_RERROR.

This is handled the same as on Linux by exiting with a -1 error code.

Signed-off-by: Roy Marples <roy@marples.name>