### PR TITLE
ospfclient: Provide some protection against blindly trusting input

### DIFF
--- a/ospfclient/ospf_apiclient.c
+++ b/ospfclient/ospf_apiclient.c
@@ -49,6 +49,7 @@
 #include "ospfd/ospf_route.h"
 #include "ospfd/ospf_zebra.h"
 #include "ospfd/ospf_api.h"
+#include "ospfd/ospf_errors.h"
 
 #include "ospf_apiclient.h"
 
@@ -564,12 +565,19 @@ static void ospf_apiclient_handle_lsa_update(struct ospf_apiclient *oclient,
 {
 	struct msg_lsa_change_notify *cn;
 	struct lsa_header *lsa;
-	int lsalen;
+	uint16_t lsalen;
 
 	cn = (struct msg_lsa_change_notify *)STREAM_DATA(msg->s);
 
 	/* Extract LSA from message */
 	lsalen = ntohs(cn->data.length);
+	if (lsalen > OSPF_MAX_LSA_SIZE) {
+		flog_warn(
+			EC_OSPF_LARGE_LSA,
+			"%s: message received size: %d is greater than a LSA size: %d",
+			__func__, lsalen, OSPF_MAX_LSA_SIZE);
+		return;
+	}
 	lsa = XMALLOC(MTYPE_OSPF_APICLIENT, lsalen);
 
 	memcpy(lsa, &(cn->data), lsalen);
@@ -589,12 +597,19 @@ static void ospf_apiclient_handle_lsa_delete(struct ospf_apiclient *oclient,
 {
 	struct msg_lsa_change_notify *cn;
 	struct lsa_header *lsa;
-	int lsalen;
+	uint16_t lsalen;
 
 	cn = (struct msg_lsa_change_notify *)STREAM_DATA(msg->s);
 
 	/* Extract LSA from message */
 	lsalen = ntohs(cn->data.length);
+	if (lsalen > OSPF_MAX_LSA_SIZE) {
+		flog_warn(
+			EC_OSPF_LARGE_LSA,
+			"%s: message received size: %d is greater than a LSA size: %d",
+			__func__, lsalen, OSPF_MAX_LSA_SIZE);
+		return;
+	}
 	lsa = XMALLOC(MTYPE_OSPF_APICLIENT, lsalen);
 
 	memcpy(lsa, &(cn->data), lsalen);


### PR DESCRIPTION
Coverity rightly points out that blindly trusting the lsalen
from received data may not be the smartest thing to do.  Add
a bit of code to prevent us from blindly malloc'ing
too much memory.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>