### PR TITLE
vtysh: fix build-time errors for some --enable flags

### DIFF
--- a/vtysh/.gitignore
+++ b/vtysh/.gitignore
@@ -1,3 +1,4 @@
 vtysh
 vtysh_cmd.c
 extract.pl
+vtysh_daemons.h

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1773,6 +1773,24 @@ DEFUNSH(VTYSH_BGPD, vnc_l2_group, vnc_l2_group_cmd, "vnc l2-group NAME",
 	vty->node = BGP_VNC_L2_GROUP_NODE;
 	return CMD_SUCCESS;
 }
+
+DEFUNSH(VTYSH_BGPD, exit_vnc_config, exit_vnc_config_cmd, "exit-vnc",
+	"Exit from VNC configuration mode\n")
+{
+	if (vty->node == BGP_VNC_DEFAULTS_NODE
+	    || vty->node == BGP_VNC_NVE_GROUP_NODE
+	    || vty->node == BGP_VNC_L2_GROUP_NODE)
+		vty->node = BGP_NODE;
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_BGPD, exit_vrf_policy, exit_vrf_policy_cmd, "exit-vrf-policy",
+	"Exit from VRF policy configuration mode\n")
+{
+	if (vty->node == BGP_VRF_POLICY_NODE)
+		vty->node = BGP_NODE;
+	return CMD_SUCCESS;
+}
 #endif
 #endif /* HAVE_BGPD */
 
@@ -2106,17 +2124,6 @@ DEFUNSH(VTYSH_BGPD, exit_vni, exit_vni_cmd, "exit-vni", "Exit from VNI mode\n")
 	return CMD_SUCCESS;
 }
 
-DEFUNSH(VTYSH_BGPD, exit_vnc_config, exit_vnc_config_cmd, "exit-vnc",
-	"Exit from VNC configuration mode\n")
-{
-	if (vty->node == BGP_VNC_DEFAULTS_NODE
-	    || vty->node == BGP_VNC_NVE_GROUP_NODE
-	    || vty->node == BGP_VNC_L2_GROUP_NODE)
-		vty->node = BGP_NODE;
-	return CMD_SUCCESS;
-
-}
-
 DEFUNSH(VTYSH_BGPD, rpki_exit, rpki_exit_cmd, "exit",
 	"Exit current mode and down to previous mode\n")
 {
@@ -2141,14 +2148,6 @@ DEFUNSH(VTYSH_BGPD, bmp_quit, bmp_quit_cmd, "quit",
 	"Exit current mode and down to previous mode\n")
 {
 	return bmp_exit(self, vty, argc, argv);
-}
-
-DEFUNSH(VTYSH_BGPD, exit_vrf_policy, exit_vrf_policy_cmd, "exit-vrf-policy",
-	"Exit from VRF policy configuration mode\n")
-{
-	if (vty->node == BGP_VRF_POLICY_NODE)
-		vty->node = BGP_NODE;
-	return CMD_SUCCESS;
 }
 #endif /* HAVE_BGPD */
 


### PR DESCRIPTION
Fix build warnings generated by `--enable-bgp-vnc=no` caused builds to fail using this flag, rooted in some recent refactoring in vtysh from #7228. Only two variables (`exit_vrf_policy_cmd` and `exit_vnc_config_cmd`) exhibited this behavior and they've been moved to be under more appropriate `#ifdef` directives.

`vtysh/vtysh_daemons.h` is also exempt from tracking as it is a generated source file