### PR TITLE
tests: bgp_l3vpn_to_bgp_vrf test needed to correct order

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_routes.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_routes.py
@@ -517,7 +517,13 @@ luCommand(
     "2 available, best .*192.168.1.1.* Local.* 192.168.1.1 from 192.168.1.1 .192.168.1.1"
     + ".* Origin IGP, metric 98, localpref 123, valid, internal"
     + ".* Community: 0:67.* Extended Community: RT:52:100 RT:89:123.* Large Community: 12:34:56",
-    ".* Local.* 99.0.0.2 from 0.0.0.0 .99.0.0.2"
+    "pass",
+    "Redundant route 1 details",
+)
+luCommand(
+    "ce2",
+    'vtysh -c "show bgp ipv4 uni 6.0.1.0"',
+    "2 available, best .*192.168.1.1.* Local.* 99.0.0.2 from 0.0.0.0 .99.0.0.2"
     + ".* Origin IGP, metric 100, localpref 100, weight 32768, valid, sourced, local, best .Weight"
     + ".* Community: 0:67.* Extended Community: RT:89:123.* Large Community: 12:34:56",
     "pass",
@@ -526,10 +532,18 @@ luCommand(
 luCommand(
     "ce3",
     'vtysh -c "show bgp ipv4 uni 6.0.1.0"',
-    "2 available, best .*192.168.1.1.* Local.* 99.0.0.3 from 0.0.0.0 .99.0.0.3"
+    "2 available, best "
+    ".* Local.* 99.0.0.3 from 0.0.0.0 .99.0.0.3"
     + ".* Origin IGP, metric 200, localpref 50, weight 32768, valid, sourced, local, best .Weight"
-    + ".* Community: 0:67.* Extended Community: RT:89:123.* Large Community: 12:34:56"
-    + ".* Local.* 192.168.1.1 from 192.168.1.1 .192.168.1.1"
+    + ".* Community: 0:67.* Extended Community: RT:89:123.* Large Community: 12:34:56",
+    "pass",
+    "Redundant route 1 details",
+)
+luCommand(
+    "ce3",
+    'vtysh -c "show bgp ipv4 uni 6.0.1.0"',
+    "2 available, best "
+    ".* Local.* 192.168.1.1 from 192.168.1.1 .192.168.1.1"
     + ".* Origin IGP, metric 98, localpref 123, valid, internal"
     + ".* Community: 0:67.* Extended Community: RT:52:100 RT:89:123.* Large Community: 12:34:56",
     "pass",
@@ -571,8 +585,14 @@ luCommand(
     'vtysh -c "show bgp ipv4 uni 6.0.2.0"',
     "2 available, best .*192.168.1.1.* Local.* 99.0.0.3 from 0.0.0.0 .99.0.0.3"
     + ".* Origin IGP, metric 100, localpref 100, weight 32768, valid, sourced, local, best .Weight"
-    + ".* Community: 0:67.* Extended Community: RT:89:123.* Large Community: 12:34:13"
-    + ".* Local.* 192.168.1.1 from 192.168.1.1 .192.168.1.1"
+    + ".* Community: 0:67.* Extended Community: RT:89:123.* Large Community: 12:34:13",
+    "pass",
+    "Redundant route 2 details",
+)
+luCommand(
+    "ce3",
+    'vtysh -c "show bgp ipv4 uni 6.0.2.0"',
+    "2 available, best .*192.168.1.1.* Local.* 192.168.1.1 from 192.168.1.1 .192.168.1.1"
     + ".* Origin IGP, metric 100, localpref 100, valid, internal"
     + ".* Community: 0:67.* Extended Community: RT:52:100 RT:89:123.* Large Community: 12:34:14",
     "pass",
@@ -583,8 +603,14 @@ luCommand(
     'vtysh -c "show bgp  vrf ce4-cust2 ipv4 6.0.2.0"',
     "2 available, best .*192.168.2.1.* Local.* 192.168.2.1 from 192.168.2.1 .192.168.2.1"
     + ".* Origin IGP, metric 100, localpref 100, valid, internal"
-    + ".* Community: 0:67.* Extended Community: RT:52:100 RT:89:123.* Large Community: 12:34:13"
-    + ".* Local.* 99.0.0.4 from 0.0.0.0 .99.0.0.4"
+    + ".* Community: 0:67.* Extended Community: RT:52:100 RT:89:123.* Large Community: 12:34:13",
+    "pass",
+    "Redundant route 2 details",
+)
+luCommand(
+    "ce4",
+    'vtysh -c "show bgp  vrf ce4-cust2 ipv4 6.0.2.0"',
+    "2 available, best .*192.168.2.1.* Local.* 99.0.0.4 from 0.0.0.0 .99.0.0.4"
     + ".* Origin IGP, metric 100, localpref 100, weight 32768, valid, sourced, local, best .Weight"
     + ".* Community: 0:67.* Extended Community: RT:89:123.* Large Community: 12:34:14",
     "pass",


### PR DESCRIPTION
The bgp_l3vpn_to_bgp_vrf test is looking for a prefix
on multiple routers that the ordered received is non-deterministic.
As such the regex's are failing occassionaly when the
route is received in an unexpected order.

One possible order:
(#89) scripts/check_routes.py:120 COMMAND:ce3:vtysh -c "show bgp ipv4 uni 6.0.1.0":2 available, best .*192.168.1.1.* Local.* 99.0.0.3 from 0.0.0.0 .99.0.0.3.* Origin IGP, metric 200, localpref 50, weight 32768, valid, sourced, local, best .Weight.* Community: 0:67.* Extended Community: RT:89:123.* Large Community: 12:34:56.* Local.* 192.168.1.1 from 192.168.1.1 .192.168.1.1.* Origin IGP, metric 98, localpref 123, valid, internal.* Community: 0:67.* Extended Community: RT:52:100 RT:89:123.* Large Community: 12:34:56:pass:Redundant route 1 details c:
COMMAND OUTPUT:BGP routing table entry for 6.0.1.0/24^M
Paths: (2 available, best #1, table default)^M
  Advertised to non peer-group peers:^M
  192.168.1.1^M
  Local^M
    99.0.0.3 from 0.0.0.0 (99.0.0.3)^M
      Origin IGP, metric 200, localpref 50, weight 32768, valid, sourced, local, best (Weight)^M
      Community: 0:67^M
      Extended Community: RT:89:123^M
      Large Community: 12:34:56^M
      Last update: Wed Oct  7 11:12:22 2020^M
  Local^M
    192.168.1.1 from 192.168.1.1 (192.168.1.1)^M
      Origin IGP, metric 98, localpref 123, valid, internal^M
      Community: 0:67^M
      Extended Community: RT:52:100 RT:89:123^M
      Large Community: 12:34:56^M
      Last update: Wed Oct  7 11:12:41 2020:
R:89   ce3    Redundant route 1 details c                              1    0

Second possible order:
(#89) scripts/check_routes.py:120 COMMAND:ce3:vtysh -c "show bgp ipv4 uni 6.0.1.0":2 available, best .*192.168.1.1.* Local.* 99.0.0.3 from 0.0.0.0 .99.0.0.3.* Origin IGP, metric 200, localpref 50, weight 32768, valid, sourced, local, best .Weight.* Community: 0:67.* Extended Community: RT:89:123.* Large Community: 12:34:56.* Local.* 192.168.1.1 from 192.168.1.1 .192.168.1.1.* Origin IGP, metric 98, localpref 123, valid, internal.* Community: 0:67.* Extended Community: RT:52:100 RT:89:123.* Large Community: 12:34:56:pass:Redundant route 1 details c:
COMMAND OUTPUT:BGP routing table entry for 6.0.1.0/24^M
Paths: (2 available, best #2, table default)^M
  Advertised to non peer-group peers:^M
  192.168.1.1^M
  Local^M
    192.168.1.1 from 192.168.1.1 (192.168.1.1)^M
      Origin IGP, metric 98, localpref 123, valid, internal^M
      Community: 0:67^M
      Extended Community: RT:52:100 RT:89:123^M
      Large Community: 12:34:56^M
      Last update: Wed Oct  7 11:14:45 2020^M
  Local^M
    99.0.0.3 from 0.0.0.0 (99.0.0.3)^M
      Origin IGP, metric 200, localpref 50, weight 32768, valid, sourced, local, best (Weight)^M
      Community: 0:67^M
      Extended Community: RT:89:123^M
      Large Community: 12:34:56^M
      Last update: Wed Oct  7 11:14:27 2020:
R:89   ce3    Redundant route 1 details c                              0    1

BGP displays the paths in the order received since it's just a linked list.
For this test modify/add the luCommands to track that we may
receive the paths in a non-deterministic order.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>