### PR TITLE
ospf6d : Transformation changes for ospf6 vrf support.

### DIFF
--- a/ospf6d/ospf6_abr.h
+++ b/ospf6d/ospf6_abr.h
@@ -64,11 +64,14 @@ extern void ospf6_abr_disable_area(struct ospf6_area *oa);
 
 extern int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 					       struct ospf6_area *area);
-extern void ospf6_abr_originate_summary(struct ospf6_route *route);
+extern void ospf6_abr_originate_summary(struct ospf6_route *route,
+					struct ospf6 *ospf6);
 extern void ospf6_abr_examin_summary(struct ospf6_lsa *lsa,
 				     struct ospf6_area *oa);
 extern void ospf6_abr_defaults_to_stub(struct ospf6 *);
-extern void ospf6_abr_examin_brouter(uint32_t router_id);
+extern void ospf6_abr_examin_brouter(uint32_t router_id,
+				     struct ospf6_route *route,
+				     struct ospf6 *ospf6);
 extern void ospf6_abr_reimport(struct ospf6_area *oa);
 extern void ospf6_abr_range_reset_cost(struct ospf6 *ospf6);
 extern void ospf6_abr_prefix_resummarize(struct ospf6 *ospf6);
@@ -78,10 +81,12 @@ extern void install_element_ospf6_debug_abr(void);
 extern int ospf6_abr_config_write(struct vty *vty);
 extern void ospf6_abr_old_route_remove(struct ospf6_lsa *lsa,
 				       struct ospf6_route *old,
-				       struct ospf6_route_table *table);
+				       struct ospf6_route_table *table,
+				       struct ospf6 *ospf6);
 extern void ospf6_abr_old_path_update(struct ospf6_route *old_route,
 				      struct ospf6_route *route,
-				      struct ospf6_route_table *table);
+				      struct ospf6_route_table *table,
+				      struct ospf6 *ospf6);
 extern void ospf6_abr_init(void);
 
 #endif /*OSPF6_ABR_H*/

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -115,21 +115,23 @@ static void ospf6_area_lsdb_hook_remove(struct ospf6_lsa *lsa)
 	}
 }
 
-static void ospf6_area_route_hook_add(struct ospf6_route *route)
+static void ospf6_area_route_hook_add(struct ospf6_route *route,
+				      struct ospf6 *ospf6)
 {
 	struct ospf6_route *copy;
 
 	copy = ospf6_route_copy(route);
-	ospf6_route_add(copy, ospf6->route_table);
+	ospf6_route_add(copy, ospf6->route_table, ospf6);
 }
 
-static void ospf6_area_route_hook_remove(struct ospf6_route *route)
+static void ospf6_area_route_hook_remove(struct ospf6_route *route,
+					 struct ospf6 *ospf6)
 {
 	struct ospf6_route *copy;
 
 	copy = ospf6_route_lookup_identical(route, ospf6->route_table);
 	if (copy)
-		ospf6_route_remove(copy, ospf6->route_table);
+		ospf6_route_remove(copy, ospf6->route_table, ospf6);
 }
 
 static void ospf6_area_stub_update(struct ospf6_area *area)
@@ -282,19 +284,33 @@ void ospf6_area_delete(struct ospf6_area *oa)
 	ospf6_lsdb_delete(oa->lsdb_self);
 	ospf6_lsdb_delete(oa->temp_router_lsa_lsdb);
 
-	ospf6_spf_table_finish(oa->spf_table);
-	ospf6_route_table_delete(oa->spf_table);
-	ospf6_route_table_delete(oa->route_table);
+	ospf6_spf_table_finish(oa->spf_table, oa->ospf6);
+	ospf6_route_table_delete(oa->spf_table, oa->ospf6);
+	ospf6_route_table_delete(oa->route_table, oa->ospf6);
 
-	ospf6_route_table_delete(oa->range_table);
-	ospf6_route_table_delete(oa->summary_prefix);
-	ospf6_route_table_delete(oa->summary_router);
+	ospf6_route_table_delete(oa->range_table, oa->ospf6);
+	ospf6_route_table_delete(oa->summary_prefix, oa->ospf6);
+	ospf6_route_table_delete(oa->summary_router, oa->ospf6);
 
 	listnode_delete(oa->ospf6->area_list, oa);
 	oa->ospf6 = NULL;
 
 	/* free area */
 	XFREE(MTYPE_OSPF6_AREA, oa);
+}
+
+struct ospf6_area *ospf6_area_lookup_by_area_id(uint32_t area_id)
+{
+	struct ospf6_area *oa;
+	struct listnode *n, *node, *nnode;
+	struct ospf6 *ospf6;
+
+	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, n, oa))
+			if (oa->area_id == area_id)
+				return oa;
+	}
+	return (struct ospf6_area *)NULL;
 }
 
 struct ospf6_area *ospf6_area_lookup(uint32_t area_id, struct ospf6 *ospf6)
@@ -335,8 +351,8 @@ void ospf6_area_disable(struct ospf6_area *oa)
 	ospf6_lsdb_remove_all(oa->lsdb);
 	ospf6_lsdb_remove_all(oa->lsdb_self);
 
-	ospf6_spf_table_finish(oa->spf_table);
-	ospf6_route_remove_all(oa->route_table);
+	ospf6_spf_table_finish(oa->spf_table, oa->ospf6);
+	ospf6_route_remove_all(oa->route_table, oa->ospf6);
 
 	THREAD_OFF(oa->thread_router_lsa);
 	THREAD_OFF(oa->thread_intra_prefix_lsa);
@@ -401,7 +417,9 @@ DEFUN (area_range,
 	struct ospf6_route *range;
 	uint32_t cost = OSPF_AREA_RANGE_COST_UNSPEC;
 
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, oa);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, oa, ospf6);
 
 	ret = str2prefix(argv[idx_ipv6_prefixlen]->arg, &prefix);
 	if (ret != 1 || prefix.family != AF_INET6) {
@@ -436,7 +454,7 @@ DEFUN (area_range,
 	zlog_debug("%s: for prefix %s, flag = %x", __func__,
 		   argv[idx_ipv6_prefixlen]->arg, range->flag);
 	if (range->rnode == NULL) {
-		ospf6_route_add(range, oa->range_table);
+		ospf6_route_add(range, oa->range_table, oa->ospf6);
 	}
 
 	if (ospf6_is_router_abr(ospf6)) {
@@ -468,7 +486,9 @@ DEFUN (no_area_range,
 	struct prefix prefix;
 	struct ospf6_route *range, *route;
 
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, oa);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, oa, ospf6);
 
 	ret = str2prefix(argv[idx_ipv6]->arg, &prefix);
 	if (ret != 1 || prefix.family != AF_INET6) {
@@ -488,19 +508,19 @@ DEFUN (no_area_range,
 		SET_FLAG(range->flag, OSPF6_ROUTE_REMOVE);
 
 		/* Redo summaries if required */
-		for (route = ospf6_route_head(ospf6->route_table); route;
+		for (route = ospf6_route_head(oa->ospf6->route_table); route;
 		     route = ospf6_route_next(route))
-			ospf6_abr_originate_summary(route);
+			ospf6_abr_originate_summary(route, oa->ospf6);
 
 		/* purge the old aggregated summary LSA */
-		ospf6_abr_originate_summary(range);
+		ospf6_abr_originate_summary(range, oa->ospf6);
 	}
-	ospf6_route_remove(range, oa->range_table);
+	ospf6_route_remove(range, oa->range_table, oa->ospf6);
 
 	return CMD_SUCCESS;
 }
 
-void ospf6_area_config_write(struct vty *vty)
+void ospf6_area_config_write(struct vty *vty, struct ospf6 *ospf6)
 {
 	struct listnode *node;
 	struct ospf6_area *oa;
@@ -567,7 +587,9 @@ DEFUN (area_filter_list,
 	struct ospf6_area *area;
 	struct prefix_list *plist;
 
-	OSPF6_CMD_AREA_GET(areaid, area);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(areaid, area, ospf6);
 
 	plist = prefix_list_lookup(AFI_IP6, plistname);
 	if (strmatch(inout, "in")) {
@@ -606,7 +628,8 @@ DEFUN (no_area_filter_list,
 
 	struct ospf6_area *area;
 
-	OSPF6_CMD_AREA_GET(areaid, area);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	OSPF6_CMD_AREA_GET(areaid, area, ospf6);
 
 	if (strmatch(inout, "in")) {
 		if (PREFIX_NAME_IN(area))
@@ -630,18 +653,25 @@ DEFUN (no_area_filter_list,
 
 void ospf6_area_plist_update(struct prefix_list *plist, int add)
 {
+	struct listnode *node, *nnode;
 	struct ospf6_area *oa;
 	struct listnode *n;
 	const char *name = prefix_list_name(plist);
+	struct ospf6 *ospf6 = NULL;
 
-	if (!ospf6)
+
+	if (!om6->ospf6)
 		return;
 
-	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, n, oa)) {
-		if (PREFIX_NAME_IN(oa) && !strcmp(PREFIX_NAME_IN(oa), name))
-			PREFIX_LIST_IN(oa) = add ? plist : NULL;
-		if (PREFIX_NAME_OUT(oa) && !strcmp(PREFIX_NAME_OUT(oa), name))
-			PREFIX_LIST_OUT(oa) = add ? plist : NULL;
+	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, n, oa)) {
+			if (PREFIX_NAME_IN(oa)
+			    && !strcmp(PREFIX_NAME_IN(oa), name))
+				PREFIX_LIST_IN(oa) = add ? plist : NULL;
+			if (PREFIX_NAME_OUT(oa)
+			    && !strcmp(PREFIX_NAME_OUT(oa), name))
+				PREFIX_LIST_OUT(oa) = add ? plist : NULL;
+		}
 	}
 }
 
@@ -659,7 +689,9 @@ DEFUN (area_import_list,
 	struct ospf6_area *area;
 	struct access_list *list;
 
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area, ospf6);
 
 	list = access_list_lookup(AFI_IP6, argv[idx_name]->arg);
 
@@ -687,7 +719,9 @@ DEFUN (no_area_import_list,
 	int idx_ipv4 = 2;
 	struct ospf6_area *area;
 
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area, ospf6);
 
 	IMPORT_LIST(area) = 0;
 
@@ -714,7 +748,9 @@ DEFUN (area_export_list,
 	struct ospf6_area *area;
 	struct access_list *list;
 
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area, ospf6);
 
 	list = access_list_lookup(AFI_IP6, argv[idx_name]->arg);
 
@@ -742,7 +778,9 @@ DEFUN (no_area_export_list,
 	int idx_ipv4 = 2;
 	struct ospf6_area *area;
 
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area, ospf6);
 
 	EXPORT_LIST(area) = 0;
 
@@ -769,9 +807,10 @@ DEFUN (show_ipv6_ospf6_spf_tree,
 	struct ospf6_vertex *root;
 	struct ospf6_route *route;
 	struct prefix prefix;
+	struct ospf6 *ospf6;
 
-	OSPF6_CMD_CHECK_RUNNING();
-
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	ospf6_linkstate_prefix(ospf6->router_id, htonl(0), &prefix);
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
@@ -805,8 +844,11 @@ DEFUN (show_ipv6_ospf6_area_spf_tree,
 	struct ospf6_vertex *root;
 	struct ospf6_route *route;
 	struct prefix prefix;
+	struct ospf6 *ospf6;
 
-	OSPF6_CMD_CHECK_RUNNING();
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	ospf6_linkstate_prefix(ospf6->router_id, htonl(0), &prefix);
 
@@ -854,8 +896,11 @@ DEFUN (show_ipv6_ospf6_simulate_spf_tree_root,
 	uint32_t router_id;
 	struct ospf6_route_table *spf_table;
 	unsigned char tmp_debug_ospf6_spf = 0;
+	struct ospf6 *ospf6;
 
-	OSPF6_CMD_CHECK_RUNNING();
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &router_id);
 	ospf6_linkstate_prefix(router_id, htonl(0), &prefix);
@@ -880,15 +925,15 @@ DEFUN (show_ipv6_ospf6_simulate_spf_tree_root,
 
 	route = ospf6_route_lookup(&prefix, spf_table);
 	if (route == NULL) {
-		ospf6_spf_table_finish(spf_table);
-		ospf6_route_table_delete(spf_table);
+		ospf6_spf_table_finish(spf_table, ospf6);
+		ospf6_route_table_delete(spf_table, ospf6);
 		return CMD_SUCCESS;
 	}
 	root = (struct ospf6_vertex *)route->route_option;
 	ospf6_spf_display_subtree(vty, "", 0, root);
 
-	ospf6_spf_table_finish(spf_table);
-	ospf6_route_table_delete(spf_table);
+	ospf6_spf_table_finish(spf_table, ospf6);
+	ospf6_route_table_delete(spf_table, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -904,7 +949,9 @@ DEFUN (ospf6_area_stub,
 	int idx_ipv4_number = 1;
 	struct ospf6_area *area;
 
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area, ospf6);
 
 	if (!ospf6_area_stub_set(ospf6, area)) {
 		vty_out(vty,
@@ -929,7 +976,9 @@ DEFUN (ospf6_area_stub_no_summary,
 	int idx_ipv4_number = 1;
 	struct ospf6_area *area;
 
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area, ospf6);
 
 	if (!ospf6_area_stub_set(ospf6, area)) {
 		vty_out(vty,
@@ -954,7 +1003,9 @@ DEFUN (no_ospf6_area_stub,
 	int idx_ipv4_number = 2;
 	struct ospf6_area *area;
 
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area, ospf6);
 
 	ospf6_area_stub_unset(ospf6, area);
 	ospf6_area_no_summary_unset(ospf6, area);
@@ -975,7 +1026,9 @@ DEFUN (no_ospf6_area_stub_no_summary,
 	int idx_ipv4_number = 2;
 	struct ospf6_area *area;
 
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area);
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area, ospf6);
 
 	ospf6_area_stub_unset(ospf6, area);
 	ospf6_area_no_summary_unset(ospf6, area);
@@ -1010,11 +1063,12 @@ void ospf6_area_interface_delete(struct ospf6_interface *oi)
 {
 	struct ospf6_area *oa;
 	struct listnode *node, *nnode;
+	struct ospf6 *ospf6;
 
-	if (!ospf6)
+	if (!om6->ospf6)
 		return;
-	for (ALL_LIST_ELEMENTS(ospf6->area_list, node, nnode, oa))
-		if(listnode_lookup(oa->if_list, oi))
-			listnode_delete(oa->if_list, oi);
-
+	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6))
+		for (ALL_LIST_ELEMENTS(ospf6->area_list, node, nnode, oa))
+			if (listnode_lookup(oa->if_list, oi))
+				listnode_delete(oa->if_list, oi);
 }

--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -117,7 +117,7 @@ struct ospf6_area {
 #define IS_AREA_TRANSIT(oa) (CHECK_FLAG ((oa)->flag, OSPF6_AREA_TRANSIT))
 #define IS_AREA_STUB(oa) (CHECK_FLAG ((oa)->flag, OSPF6_AREA_STUB))
 
-#define OSPF6_CMD_AREA_GET(str, oa)                                            \
+#define OSPF6_CMD_AREA_GET(str, oa, ospf6)                                     \
 	{                                                                      \
 		char *ep;                                                      \
 		uint32_t area_id = htonl(strtoul(str, &ep, 10));               \
@@ -138,6 +138,7 @@ extern int ospf6_area_cmp(void *va, void *vb);
 extern struct ospf6_area *ospf6_area_create(uint32_t, struct ospf6 *, int);
 extern void ospf6_area_delete(struct ospf6_area *);
 extern struct ospf6_area *ospf6_area_lookup(uint32_t, struct ospf6 *);
+extern struct ospf6_area *ospf6_area_lookup_by_area_id(uint32_t area_id);
 
 extern void ospf6_area_enable(struct ospf6_area *);
 extern void ospf6_area_disable(struct ospf6_area *);
@@ -145,7 +146,7 @@ extern void ospf6_area_disable(struct ospf6_area *);
 extern void ospf6_area_show(struct vty *, struct ospf6_area *);
 
 extern void ospf6_area_plist_update(struct prefix_list *plist, int add);
-extern void ospf6_area_config_write(struct vty *vty);
+extern void ospf6_area_config_write(struct vty *vty, struct ospf6 *ospf6);
 extern void ospf6_area_init(void);
 struct ospf6_interface;
 extern void ospf6_area_interface_delete(struct ospf6_interface *oi);

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -43,6 +43,7 @@
 #include "ospf6_interface.h"
 #include "ospf6_neighbor.h"
 #include "ospf6_asbr.h"
+#include "ospf6_abr.h"
 #include "ospf6_intra.h"
 #include "ospf6_flood.h"
 #include "ospf6d.h"
@@ -55,7 +56,8 @@ unsigned char conf_debug_ospf6_asbr = 0;
 #define ZROUTE_NAME(x) zebra_route_string(x)
 
 /* AS External LSA origination */
-static void ospf6_as_external_lsa_originate(struct ospf6_route *route)
+static void ospf6_as_external_lsa_originate(struct ospf6_route *route,
+					    struct ospf6 *ospf6)
 {
 	char buffer[OSPF6_MAX_LSASIZE];
 	struct ospf6_lsa_header *lsa_header;
@@ -165,7 +167,8 @@ int ospf6_orig_as_external_lsa(struct thread *thread)
 
 	type = htons(OSPF6_LSTYPE_AS_EXTERNAL);
 	adv_router = oi->area->ospf6->router_id;
-	for (ALL_LSDB_TYPED_ADVRTR(ospf6->lsdb, type, adv_router, lsa)) {
+	for (ALL_LSDB_TYPED_ADVRTR(oi->area->ospf6->lsdb, type, adv_router,
+				   lsa)) {
 		if (IS_OSPF6_DEBUG_ASBR)
 			zlog_debug(
 				"%s: Send update of AS-External LSA %s seq 0x%x",
@@ -204,7 +207,8 @@ static route_tag_t ospf6_as_external_lsa_get_tag(struct ospf6_lsa *lsa)
 }
 
 void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
-				       struct ospf6_route *route)
+				       struct ospf6_route *route,
+				       struct ospf6 *ospf6)
 {
 	struct ospf6_route *old_route;
 	struct ospf6_path *ecmp_path, *o_path = NULL;
@@ -284,8 +288,8 @@ void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 				 * nh_list
 				 */
 				if (ospf6->route_table->hook_add)
-					(*ospf6->route_table->hook_add)
-						(old_route);
+					(*ospf6->route_table->hook_add)(
+						old_route, ospf6);
 
 				if (old_route->path.origin.id
 					    == route->path.origin.id
@@ -313,7 +317,7 @@ void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 						route->path.cost);
 				}
 				ospf6_route_remove(old_route,
-						   ospf6->route_table);
+						   ospf6->route_table, ospf6);
 			}
 		}
 		if (route_updated)
@@ -430,7 +434,8 @@ void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 
 			/* Update RIB/FIB */
 			if (ospf6->route_table->hook_add)
-				(*ospf6->route_table->hook_add)(old_route);
+				(*ospf6->route_table->hook_add)(old_route,
+								ospf6);
 
 			/* Delete the new route its info added to existing
 			 * route.
@@ -443,11 +448,11 @@ void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 
 	if (!route_found) {
 		/* Add new route to existing node in ospf6 route table. */
-		ospf6_route_add(route, ospf6->route_table);
+		ospf6_route_add(route, ospf6->route_table, ospf6);
 	}
 }
 
-void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa)
+void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa, struct ospf6 *ospf6)
 {
 	struct ospf6_as_external_lsa *external;
 	struct prefix asbr_id;
@@ -540,14 +545,14 @@ void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa)
 	old = ospf6_route_lookup(&route->prefix, ospf6->route_table);
 	if (!old) {
 		/* Add the new route to ospf6 instance route table. */
-		ospf6_route_add(route, ospf6->route_table);
+		ospf6_route_add(route, ospf6->route_table, ospf6);
 	} else {
 		/* RFC 2328 16.4 (6)
 		 * ECMP: Keep new equal preference path in current
 		 * route's path list, update zebra with new effective
 		 * list along with addition of ECMP path.
 		 */
-		ospf6_asbr_update_route_ecmp_path(old, route);
+		ospf6_asbr_update_route_ecmp_path(old, route, ospf6);
 	}
 }
 
@@ -557,6 +562,8 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 	struct ospf6_as_external_lsa *external;
 	struct prefix prefix;
 	struct ospf6_route *route, *nroute, *route_to_del;
+	struct ospf6_area *oa = NULL;
+	struct ospf6 *ospf6;
 
 	external = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
 		lsa->header);
@@ -564,7 +571,16 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL))
 		zlog_debug("Withdraw AS-External route for %s", lsa->name);
 
-	if (lsa->header->adv_router == ospf6->router_id) {
+	ospf6 = ospf6_get_by_lsdb(lsa);
+	if (ospf6_is_router_abr(ospf6))
+		oa = ospf6->backbone;
+	else
+		oa = listgetdata(listhead(ospf6->area_list));
+
+	if (oa == NULL)
+		return;
+
+	if (lsa->header->adv_router == oa->ospf6->router_id) {
 		if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL))
 			zlog_debug("Ignore self-originated AS-External-LSA");
 		return;
@@ -603,7 +619,7 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 	prefix.prefixlen = external->prefix.prefix_length;
 	ospf6_prefix_in6_addr(&prefix.u.prefix6, external, &external->prefix);
 
-	route = ospf6_route_lookup(&prefix, ospf6->route_table);
+	route = ospf6_route_lookup(&prefix, oa->ospf6->route_table);
 	if (route == NULL) {
 		if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL)) {
 			zlog_debug("AS-External route %pFX not found", &prefix);
@@ -729,9 +745,10 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 					/* Update RIB/FIB with effective
 					 * nh_list
 					 */
-					if (ospf6->route_table->hook_add)
-						(*ospf6->route_table->hook_add)
-						(route);
+					if (oa->ospf6->route_table->hook_add)
+						(*oa->ospf6->route_table
+							  ->hook_add)(
+							route, oa->ospf6);
 
 					/* route's primary path is similar
 					 * to LSA, replace route's primary
@@ -754,8 +771,9 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 						h_path->origin.adv_router;
 					}
 				} else {
-					ospf6_route_remove(route,
-							   ospf6->route_table);
+					ospf6_route_remove(
+						route, oa->ospf6->route_table,
+						oa->ospf6);
 				}
 			}
 			continue;
@@ -795,7 +813,7 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 				&route->prefix, route->path.cost, route->path.u.cost_e2,
 				listcount(route->nh_list));
 		}
-		ospf6_route_remove(route, ospf6->route_table);
+		ospf6_route_remove(route, oa->ospf6->route_table, oa->ospf6);
 	}
 	if (route != NULL)
 		ospf6_route_unlock(route);
@@ -803,7 +821,7 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 	ospf6_route_delete(route_to_del);
 }
 
-void ospf6_asbr_lsentry_add(struct ospf6_route *asbr_entry)
+void ospf6_asbr_lsentry_add(struct ospf6_route *asbr_entry, struct ospf6 *ospf6)
 {
 	struct ospf6_lsa *lsa;
 	uint16_t type;
@@ -821,11 +839,12 @@ void ospf6_asbr_lsentry_add(struct ospf6_route *asbr_entry)
 	router = ospf6_linkstate_prefix_adv_router(&asbr_entry->prefix);
 	for (ALL_LSDB_TYPED_ADVRTR(ospf6->lsdb, type, router, lsa)) {
 		if (!OSPF6_LSA_IS_MAXAGE(lsa))
-			ospf6_asbr_lsa_add(lsa);
+			ospf6_asbr_lsa_add(lsa, ospf6);
 	}
 }
 
-void ospf6_asbr_lsentry_remove(struct ospf6_route *asbr_entry)
+void ospf6_asbr_lsentry_remove(struct ospf6_route *asbr_entry,
+			       struct ospf6 *ospf6)
 {
 	struct ospf6_lsa *lsa;
 	uint16_t type;
@@ -840,8 +859,16 @@ void ospf6_asbr_lsentry_remove(struct ospf6_route *asbr_entry)
 
 /* redistribute function */
 
-static void ospf6_asbr_routemap_set(int type, const char *mapname)
+static void ospf6_asbr_routemap_set(int type, const char *mapname,
+				    uint32_t vrf_id)
 {
+	struct ospf6 *ospf6 = NULL;
+
+	ospf6 = ospf6_lookup_by_vrf_id(vrf_id);
+
+	if (ospf6 == NULL)
+		return;
+
 	if (ospf6->rmap[type].name) {
 		route_map_counter_decrement(ospf6->rmap[type].map);
 		free(ospf6->rmap[type].name);
@@ -851,7 +878,7 @@ static void ospf6_asbr_routemap_set(int type, const char *mapname)
 	route_map_counter_increment(ospf6->rmap[type].map);
 }
 
-static void ospf6_asbr_routemap_unset(int type)
+static void ospf6_asbr_routemap_unset(int type, struct ospf6 *ospf6)
 {
 	if (ospf6->rmap[type].name)
 		free(ospf6->rmap[type].name);
@@ -866,8 +893,10 @@ static int ospf6_asbr_routemap_update_timer(struct thread *thread)
 {
 	void **arg;
 	int arg_type;
+	struct ospf6 *ospf6;
 
 	arg = THREAD_ARG(thread);
+	ospf6 = (struct ospf6 *)arg[0];
 	arg_type = (int)(intptr_t)arg[1];
 
 	ospf6->t_distribute_update = NULL;
@@ -889,7 +918,7 @@ static int ospf6_asbr_routemap_update_timer(struct thread *thread)
 	return 0;
 }
 
-void ospf6_asbr_distribute_list_update(int type)
+void ospf6_asbr_distribute_list_update(int type, struct ospf6 *ospf6)
 {
 	void **args = NULL;
 
@@ -914,62 +943,79 @@ void ospf6_asbr_distribute_list_update(int type)
 static void ospf6_asbr_routemap_update(const char *mapname)
 {
 	int type;
+	struct listnode *node, *nnode;
+	struct ospf6 *ospf6 = NULL;
 
-	if (ospf6 == NULL)
+	if (om6 == NULL)
 		return;
 
-	for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
-		if (ospf6->rmap[type].name) {
-			ospf6->rmap[type].map = route_map_lookup_by_name(
-				ospf6->rmap[type].name);
+	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6)) {
+		for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
+			if (ospf6->rmap[type].name) {
+				ospf6->rmap[type].map =
+					route_map_lookup_by_name(
+						ospf6->rmap[type].name);
 
-			if (mapname
-			    && (strcmp(ospf6->rmap[type].name, mapname) == 0)) {
-				if (ospf6->rmap[type].map) {
-					if (IS_OSPF6_DEBUG_ASBR)
-						zlog_debug(
-							"%s: route-map %s update, reset redist %s",
-							__func__, mapname,
-							ZROUTE_NAME(type));
+				if (mapname
+				    && (strcmp(ospf6->rmap[type].name, mapname)
+					== 0)) {
+					if (ospf6->rmap[type].map) {
+						if (IS_OSPF6_DEBUG_ASBR)
+							zlog_debug(
+								"%s: route-map %s update, reset redist %s",
+								__func__,
+								mapname,
+								ZROUTE_NAME(
+									type));
 
-					route_map_counter_increment(
-						ospf6->rmap[type].map);
+						route_map_counter_increment(
+							ospf6->rmap[type].map);
 
-					ospf6_asbr_distribute_list_update(type);
-				} else {
-					/*
-					 * if the mapname matches a route-map on
-					 * ospf6 but the map doesn't exist, it
-					 * is being deleted. flush and then
-					 * readvertise
-					 */
-					if (IS_OSPF6_DEBUG_ASBR)
-						zlog_debug(
-							"%s: route-map %s deleted, reset redist %s",
-							__func__, mapname,
-							ZROUTE_NAME(type));
-					ospf6_asbr_redistribute_unset(
-						type, ospf6->vrf_id);
-					ospf6_asbr_routemap_set(type, mapname);
-					ospf6_asbr_redistribute_set(
-						type, ospf6->vrf_id);
+						ospf6_asbr_distribute_list_update(
+							type, ospf6);
+					} else {
+						/*
+						 * if the mapname matches a
+						 * route-map on ospf6 but the
+						 * map doesn't exist, it is
+						 * being deleted. flush and then
+						 * readvertise
+						 */
+						if (IS_OSPF6_DEBUG_ASBR)
+							zlog_debug(
+								"%s: route-map %s deleted, reset redist %s",
+								__func__,
+								mapname,
+								ZROUTE_NAME(
+									type));
+						ospf6_asbr_redistribute_unset(
+							type, ospf6->vrf_id);
+						ospf6_asbr_routemap_set(
+							type, mapname,
+							ospf6->vrf_id);
+						ospf6_asbr_redistribute_set(
+							type, ospf6->vrf_id);
+					}
 				}
-			}
-		} else
-			ospf6->rmap[type].map = NULL;
+			} else
+				ospf6->rmap[type].map = NULL;
+		}
 	}
 }
 
 static void ospf6_asbr_routemap_event(const char *name)
 {
 	int type;
+	struct listnode *node, *nnode;
+	struct ospf6 *ospf6;
 
-	if (ospf6 == NULL)
+	if (om6 == NULL)
 		return;
-	for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
-		if ((ospf6->rmap[type].name)
-		    && (strcmp(ospf6->rmap[type].name, name) == 0)) {
-			ospf6_asbr_distribute_list_update(type);
+	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6)) {
+		for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
+			if ((ospf6->rmap[type].name)
+			    && (strcmp(ospf6->rmap[type].name, name) == 0))
+				ospf6_asbr_distribute_list_update(type, ospf6);
 		}
 	}
 }
@@ -988,6 +1034,12 @@ static void ospf6_asbr_redistribute_unset(int type, vrf_id_t vrf_id)
 {
 	struct ospf6_route *route;
 	struct ospf6_external_info *info;
+	struct ospf6 *ospf6 = NULL;
+
+	ospf6 = ospf6_lookup_by_vrf_id(vrf_id);
+
+	if (ospf6 == NULL)
+		return;
 
 	ospf6_zebra_no_redistribute(type, vrf_id);
 
@@ -997,10 +1049,11 @@ static void ospf6_asbr_redistribute_unset(int type, vrf_id_t vrf_id)
 		if (info->type != type)
 			continue;
 
-		ospf6_asbr_redistribute_remove(info->type, 0, &route->prefix);
+		ospf6_asbr_redistribute_remove(info->type, 0, &route->prefix,
+					       ospf6);
 	}
 
-	ospf6_asbr_routemap_unset(type);
+	ospf6_asbr_routemap_unset(type, ospf6);
 }
 
 /* When an area is unstubified, flood all the external LSAs in the area */
@@ -1020,7 +1073,8 @@ void ospf6_asbr_send_externals_to_area(struct ospf6_area *oa)
 void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 				 struct prefix *prefix,
 				 unsigned int nexthop_num,
-				 struct in6_addr *nexthop, route_tag_t tag)
+				 struct in6_addr *nexthop, route_tag_t tag,
+				 struct ospf6 *ospf6)
 {
 	route_map_result_t ret;
 	struct ospf6_route troute;
@@ -1068,7 +1122,8 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 			if (IS_OSPF6_DEBUG_ASBR)
 				zlog_debug("Denied by route-map \"%s\"",
 					   ospf6->rmap[type].name);
-			ospf6_asbr_redistribute_remove(type, ifindex, prefix);
+			ospf6_asbr_redistribute_remove(type, ifindex, prefix,
+						       ospf6);
 			return;
 		}
 	}
@@ -1116,7 +1171,7 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 		}
 
 		match->path.origin.id = htonl(info->id);
-		ospf6_as_external_lsa_originate(match);
+		ospf6_as_external_lsa_originate(match, ospf6);
 		return;
 	}
 
@@ -1158,7 +1213,7 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 	node = route_node_get(ospf6->external_id_table, &prefix_id);
 	node->info = route;
 
-	route = ospf6_route_add(route, ospf6->external_table);
+	route = ospf6_route_add(route, ospf6->external_table, ospf6);
 	route->route_option = info;
 
 	if (IS_OSPF6_DEBUG_ASBR) {
@@ -1169,7 +1224,7 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 	}
 
 	route->path.origin.id = htonl(info->id);
-	ospf6_as_external_lsa_originate(route);
+	ospf6_as_external_lsa_originate(route, ospf6);
 
 	/* Router-Bit (ASBR Flag) may have to be updated */
 	for (ALL_LIST_ELEMENTS(ospf6->area_list, lnode, lnnode, oa))
@@ -1177,7 +1232,7 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 }
 
 void ospf6_asbr_redistribute_remove(int type, ifindex_t ifindex,
-				    struct prefix *prefix)
+				    struct prefix *prefix, struct ospf6 *ospf6)
 {
 	struct ospf6_route *match;
 	struct ospf6_external_info *info = NULL;
@@ -1229,7 +1284,7 @@ void ospf6_asbr_redistribute_remove(int type, ifindex_t ifindex,
 	route_unlock_node(node); /* to free the lookup lock */
 	route_unlock_node(node); /* to free the original lock */
 
-	ospf6_route_remove(match, ospf6->external_table);
+	ospf6_route_remove(match, ospf6->external_table, ospf6);
 	XFREE(MTYPE_OSPF6_EXTERNAL_INFO, info);
 
 	/* Router-Bit (ASBR Flag) may have to be updated */
@@ -1245,8 +1300,8 @@ DEFUN (ospf6_redistribute,
 {
 	int type;
 
-	OSPF6_CMD_CHECK_RUNNING();
-
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	char *proto = argv[argc - 1]->text;
 	type = proto_redistnum(AFI_IP6, proto);
 	if (type < 0)
@@ -1269,7 +1324,8 @@ DEFUN (ospf6_redistribute_routemap,
 	int idx_word = 3;
 	int type;
 
-	OSPF6_CMD_CHECK_RUNNING();
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	char *proto = argv[idx_protocol]->text;
 	type = proto_redistnum(AFI_IP6, proto);
@@ -1277,7 +1333,7 @@ DEFUN (ospf6_redistribute_routemap,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	ospf6_asbr_redistribute_unset(type, ospf6->vrf_id);
-	ospf6_asbr_routemap_set(type, argv[idx_word]->arg);
+	ospf6_asbr_routemap_set(type, argv[idx_word]->arg, ospf6->vrf_id);
 	ospf6_asbr_redistribute_set(type, ospf6->vrf_id);
 	return CMD_SUCCESS;
 }
@@ -1294,7 +1350,9 @@ DEFUN (no_ospf6_redistribute,
 	int idx_protocol = 2;
 	int type;
 
-	OSPF6_CMD_CHECK_RUNNING();
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	char *proto = argv[idx_protocol]->text;
 	type = proto_redistnum(AFI_IP6, proto);
@@ -1306,7 +1364,7 @@ DEFUN (no_ospf6_redistribute,
 	return CMD_SUCCESS;
 }
 
-int ospf6_redistribute_config_write(struct vty *vty)
+int ospf6_redistribute_config_write(struct vty *vty, struct ospf6 *ospf6)
 {
 	int type;
 
@@ -1326,7 +1384,7 @@ int ospf6_redistribute_config_write(struct vty *vty)
 	return 0;
 }
 
-static void ospf6_redistribute_show_config(struct vty *vty)
+static void ospf6_redistribute_show_config(struct vty *vty, struct ospf6 *ospf6)
 {
 	int type;
 	int nroute[ZEBRA_ROUTE_MAX];
@@ -1855,10 +1913,12 @@ DEFUN (show_ipv6_ospf6_redistribute,
        )
 {
 	struct ospf6_route *route;
+	struct ospf6 *ospf6 = NULL;
 
-	OSPF6_CMD_CHECK_RUNNING();
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
-	ospf6_redistribute_show_config(vty);
+	ospf6_redistribute_show_config(vty, ospf6);
 
 	for (route = ospf6_route_head(ospf6->external_table); route;
 	     route = ospf6_route_next(route))

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -951,54 +951,50 @@ static void ospf6_asbr_routemap_update(const char *mapname)
 
 	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6)) {
 		for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
-			if (ospf6->rmap[type].name) {
-				ospf6->rmap[type].map =
-					route_map_lookup_by_name(
-						ospf6->rmap[type].name);
+			if (ospf6->rmap[type].name == NULL)
+				continue;
+			ospf6->rmap[type].map = route_map_lookup_by_name(
+					ospf6->rmap[type].name);
 
-				if (mapname
-				    && (strcmp(ospf6->rmap[type].name, mapname)
-					== 0)) {
-					if (ospf6->rmap[type].map) {
-						if (IS_OSPF6_DEBUG_ASBR)
-							zlog_debug(
-								"%s: route-map %s update, reset redist %s",
-								__func__,
-								mapname,
-								ZROUTE_NAME(
-									type));
+			if (mapname == NULL || strcmp(ospf6->rmap[type].name, mapname))
+				continue;
+			if (ospf6->rmap[type].map) {
+				if (IS_OSPF6_DEBUG_ASBR)
+					zlog_debug(
+							"%s: route-map %s update, reset redist %s",
+							__func__,
+							mapname,
+							ZROUTE_NAME(
+								type));
 
-						route_map_counter_increment(
+					route_map_counter_increment(
 							ospf6->rmap[type].map);
 
-						ospf6_asbr_distribute_list_update(
+					ospf6_asbr_distribute_list_update(
 							type, ospf6);
-					} else {
-						/*
-						 * if the mapname matches a
-						 * route-map on ospf6 but the
-						 * map doesn't exist, it is
-						 * being deleted. flush and then
-						 * readvertise
-						 */
-						if (IS_OSPF6_DEBUG_ASBR)
-							zlog_debug(
-								"%s: route-map %s deleted, reset redist %s",
-								__func__,
-								mapname,
-								ZROUTE_NAME(
-									type));
-						ospf6_asbr_redistribute_unset(
-							type, ospf6->vrf_id);
-						ospf6_asbr_routemap_set(
-							type, mapname,
-							ospf6->vrf_id);
-						ospf6_asbr_redistribute_set(
-							type, ospf6->vrf_id);
-					}
-				}
-			} else
-				ospf6->rmap[type].map = NULL;
+			} else {
+				/*
+				* if the mapname matches a
+				* route-map on ospf6 but the
+				* map doesn't exist, it is
+				* being deleted. flush and then
+				* readvertise
+				*/
+				if (IS_OSPF6_DEBUG_ASBR)
+					zlog_debug(
+							"%s: route-map %s deleted, reset redist %s",
+							__func__,
+							mapname,
+							ZROUTE_NAME(
+								type));
+				ospf6_asbr_redistribute_unset(
+						type, ospf6->vrf_id);
+				ospf6_asbr_routemap_set(
+						type, mapname,
+						ospf6->vrf_id);
+				ospf6_asbr_redistribute_set(
+						type, ospf6->vrf_id);
+			}
 		}
 	}
 }

--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -70,22 +70,26 @@ struct ospf6_as_external_lsa {
 		(E)->bits_metric |= htonl(0x00ffffff) & htonl(C);              \
 	}
 
-extern void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa);
+extern void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa, struct ospf6 *ospf6);
 extern void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 				  struct ospf6_route *asbr_entry);
-extern void ospf6_asbr_lsentry_add(struct ospf6_route *asbr_entry);
-extern void ospf6_asbr_lsentry_remove(struct ospf6_route *asbr_entry);
+extern void ospf6_asbr_lsentry_add(struct ospf6_route *asbr_entry,
+				   struct ospf6 *ospf6);
+extern void ospf6_asbr_lsentry_remove(struct ospf6_route *asbr_entry,
+				      struct ospf6 *ospf6);
 
 extern int ospf6_asbr_is_asbr(struct ospf6 *o);
 extern void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 					struct prefix *prefix,
 					unsigned int nexthop_num,
 					struct in6_addr *nexthop,
-					route_tag_t tag);
+					route_tag_t tag, struct ospf6 *ospf6);
 extern void ospf6_asbr_redistribute_remove(int type, ifindex_t ifindex,
-					   struct prefix *prefix);
+					   struct prefix *prefix,
+					   struct ospf6 *ospf6);
 
-extern int ospf6_redistribute_config_write(struct vty *vty);
+extern int ospf6_redistribute_config_write(struct vty *vty,
+					   struct ospf6 *ospf6);
 
 extern void ospf6_asbr_init(void);
 extern void ospf6_asbr_redistribute_reset(vrf_id_t vrf_id);
@@ -95,7 +99,8 @@ extern void ospf6_asbr_send_externals_to_area(struct ospf6_area *);
 extern int config_write_ospf6_debug_asbr(struct vty *vty);
 extern void install_element_ospf6_debug_asbr(void);
 extern void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
-					      struct ospf6_route *route);
-extern void ospf6_asbr_distribute_list_update(int type);
+					      struct ospf6_route *route,
+					      struct ospf6 *ospf6);
+extern void ospf6_asbr_distribute_list_update(int type, struct ospf6 *ospf6);
 
 #endif /* OSPF6_ASBR_H */

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -370,7 +370,7 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 			continue;
 		}
 
-		if (ospf6->inst_shutdown) {
+		if (oi->area->ospf6->inst_shutdown) {
 			if (is_debug)
 				zlog_debug(
 					"%s: Send LSA %s (age %d) update now",
@@ -486,6 +486,12 @@ static void ospf6_flood_process(struct ospf6_neighbor *from,
 
 void ospf6_flood(struct ospf6_neighbor *from, struct ospf6_lsa *lsa)
 {
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_get_by_lsdb(lsa);
+	if (ospf6 == NULL)
+		return;
+
 	ospf6_flood_process(from, lsa, ospf6);
 }
 
@@ -555,6 +561,9 @@ static void ospf6_flood_clear_process(struct ospf6_lsa *lsa,
 
 void ospf6_flood_clear(struct ospf6_lsa *lsa)
 {
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_get_by_lsdb(lsa);
 	ospf6_flood_clear_process(lsa, ospf6);
 }
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -118,7 +118,7 @@ static uint32_t ospf6_interface_get_cost(struct ospf6_interface *oi)
 	/* If all else fails, use default OSPF cost */
 	uint32_t cost;
 	uint32_t bw, refbw;
-
+	struct ospf6 *ospf6;
 	/* interface speed and bw can be 0 in some platforms,
 	 * use ospf default bw. If bw is configured then it would
 	 * be used.
@@ -130,6 +130,7 @@ static uint32_t ospf6_interface_get_cost(struct ospf6_interface *oi)
 					      : OSPF6_INTERFACE_BANDWIDTH;
 	}
 
+	ospf6 = ospf6_lookup_by_vrf_id(oi->interface->vrf_id);
 	refbw = ospf6 ? ospf6->ref_bandwidth : OSPF6_REFERENCE_BANDWIDTH;
 
 	/* A specifed ip ospf cost overrides a calculated one. */
@@ -259,7 +260,7 @@ void ospf6_interface_delete(struct ospf6_interface *oi)
 	ospf6_lsdb_delete(oi->lsupdate_list);
 	ospf6_lsdb_delete(oi->lsack_list);
 
-	ospf6_route_table_delete(oi->route_connected);
+	ospf6_route_table_delete(oi->route_connected, oi->area->ospf6);
 
 	/* cut link */
 	oi->interface->info = NULL;
@@ -415,7 +416,7 @@ void ospf6_interface_connected_route_update(struct interface *ifp)
 		return;
 
 	/* update "route to advertise" interface route table */
-	ospf6_route_remove_all(oi->route_connected);
+	ospf6_route_remove_all(oi->route_connected, oi->area->ospf6);
 
 	for (ALL_LIST_ELEMENTS(oi->interface->connected, node, nnode, c)) {
 		if (c->address->family != AF_INET6)
@@ -461,7 +462,7 @@ void ospf6_interface_connected_route_update(struct interface *ifp)
 		inet_pton(AF_INET6, "::1", &nh_addr);
 		ospf6_route_add_nexthop(route, oi->interface->ifindex,
 					&nh_addr);
-		ospf6_route_add(route, oi->route_connected);
+		ospf6_route_add(route, oi->route_connected, oi->area->ospf6);
 	}
 
 	/* create new Link-LSA */
@@ -474,6 +475,7 @@ static void ospf6_interface_state_change(uint8_t next_state,
 					 struct ospf6_interface *oi)
 {
 	uint8_t prev_state;
+	struct ospf6 *ospf6;
 
 	prev_state = oi->state;
 	oi->state = next_state;
@@ -489,20 +491,21 @@ static void ospf6_interface_state_change(uint8_t next_state,
 			   ospf6_interface_state_str[next_state]);
 	}
 	oi->state_change++;
+	ospf6 = ospf6_lookup_by_vrf_id(oi->interface->vrf_id);
 
 	if ((prev_state == OSPF6_INTERFACE_DR
 	     || prev_state == OSPF6_INTERFACE_BDR)
 	    && (next_state != OSPF6_INTERFACE_DR
 		&& next_state != OSPF6_INTERFACE_BDR))
 		ospf6_sso(oi->interface->ifindex, &alldrouters6,
-			  IPV6_LEAVE_GROUP);
+			  IPV6_LEAVE_GROUP, ospf6->fd);
 
 	if ((prev_state != OSPF6_INTERFACE_DR
 	     && prev_state != OSPF6_INTERFACE_BDR)
 	    && (next_state == OSPF6_INTERFACE_DR
 		|| next_state == OSPF6_INTERFACE_BDR))
 		ospf6_sso(oi->interface->ifindex, &alldrouters6,
-			  IPV6_JOIN_GROUP);
+			  IPV6_JOIN_GROUP, ospf6->fd);
 
 	OSPF6_ROUTER_LSA_SCHEDULE(oi->area);
 	if (next_state == OSPF6_INTERFACE_DOWN) {
@@ -679,6 +682,7 @@ static uint8_t dr_election(struct ospf6_interface *oi)
 int interface_up(struct thread *thread)
 {
 	struct ospf6_interface *oi;
+	struct ospf6 *ospf6;
 
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
 	assert(oi && oi->interface);
@@ -749,9 +753,14 @@ int interface_up(struct thread *thread)
 		return 0;
 	}
 #endif /* __FreeBSD__ */
+	if (oi->area->ospf6)
+		ospf6 = oi->area->ospf6;
+	else
+		ospf6 = ospf6_lookup_by_vrf_id(oi->interface->vrf_id);
 
 	/* Join AllSPFRouters */
-	if (ospf6_sso(oi->interface->ifindex, &allspfrouters6, IPV6_JOIN_GROUP)
+	if (ospf6_sso(oi->interface->ifindex, &allspfrouters6, IPV6_JOIN_GROUP,
+		      ospf6->fd)
 	    < 0) {
 		if (oi->sso_try_cnt++ < OSPF6_INTERFACE_SSO_RETRY_MAX) {
 			zlog_info(
@@ -848,6 +857,7 @@ int interface_down(struct thread *thread)
 	struct ospf6_interface *oi;
 	struct listnode *node, *nnode;
 	struct ospf6_neighbor *on;
+	struct ospf6 *ospf6;
 
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
 	assert(oi && oi->interface);
@@ -861,11 +871,11 @@ int interface_down(struct thread *thread)
 
 	/* Stop trying to set socket options. */
 	THREAD_OFF(oi->thread_sso);
-
+	ospf6 = ospf6_lookup_by_vrf_id(oi->interface->vrf_id);
 	/* Leave AllSPFRouters */
 	if (oi->state > OSPF6_INTERFACE_DOWN)
 		ospf6_sso(oi->interface->ifindex, &allspfrouters6,
-			  IPV6_LEAVE_GROUP);
+			  IPV6_LEAVE_GROUP, ospf6->fd);
 
 	ospf6_interface_state_change(OSPF6_INTERFACE_DOWN, oi);
 

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -20,6 +20,7 @@
 
 #ifndef OSPF6_LSA_H
 #define OSPF6_LSA_H
+#include "ospf6_top.h"
 
 /* Debug option */
 #define OSPF6_LSA_DEBUG           0x01
@@ -246,6 +247,6 @@ extern void ospf6_lsa_terminate(void);
 extern int config_write_ospf6_debug_lsa(struct vty *vty);
 extern void install_element_ospf6_debug_lsa(void);
 extern void ospf6_lsa_age_set(struct ospf6_lsa *lsa);
-extern void ospf6_flush_self_originated_lsas_now(void);
-
+extern void ospf6_flush_self_originated_lsas_now(struct ospf6 *ospf6);
+extern struct ospf6 *ospf6_get_by_lsdb(struct ospf6_lsa *lsa);
 #endif /* OSPF6_LSA_H */

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -781,9 +781,9 @@ static void ospf6_dbdesc_recv(struct in6_addr *src, struct in6_addr *dst,
 
 	oi->db_desc_in++;
 
-	if (ntohl(oh->router_id) < ntohl(ospf6->router_id))
+	if (ntohl(oh->router_id) < ntohl(oi->area->ospf6->router_id))
 		ospf6_dbdesc_recv_master(oh, on);
-	else if (ntohl(ospf6->router_id) < ntohl(oh->router_id))
+	else if (ntohl(oi->area->ospf6->router_id) < ntohl(oh->router_id))
 		ospf6_dbdesc_recv_slave(oh, on);
 	else {
 		if (IS_OSPF6_DEBUG_MESSAGE(oh->type, RECV))

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -786,8 +786,11 @@ DEFUN (show_ipv6_ospf6_neighbor,
 	struct ospf6_area *oa;
 	struct listnode *i, *j, *k;
 	void (*showfunc)(struct vty *, struct ospf6_neighbor *);
+	struct ospf6 *ospf6;
 
-	OSPF6_CMD_CHECK_RUNNING();
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	showfunc = ospf6_neighbor_show;
 
 	if (argc == 5) {
@@ -831,8 +834,10 @@ DEFUN (show_ipv6_ospf6_neighbor_one,
 	struct listnode *i, *j, *k;
 	void (*showfunc)(struct vty *, struct ospf6_neighbor *);
 	uint32_t router_id;
+	struct ospf6 *ospf6;
 
-	OSPF6_CMD_CHECK_RUNNING();
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	showfunc = ospf6_neighbor_show_detail;
 
 	if ((inet_pton(AF_INET, argv[idx_ipv4]->arg, &router_id)) != 1) {

--- a/ospf6d/ospf6_network.c
+++ b/ospf6d/ospf6_network.c
@@ -124,21 +124,20 @@ int ospf6_serv_sock(struct ospf6 *ospf6)
 }
 
 /* ospf6 set socket option */
-int ospf6_sso(ifindex_t ifindex, struct in6_addr *group, int option)
+int ospf6_sso(ifindex_t ifindex, struct in6_addr *group, int option, int sockfd)
 {
 	struct ipv6_mreq mreq6;
 	int ret;
 	int bufsize = (8 * 1024 * 1024);
 
-	if (ospf6->fd == -1)
+	if (sockfd == -1)
 		return -1;
 
 	assert(ifindex);
 	mreq6.ipv6mr_interface = ifindex;
 	memcpy(&mreq6.ipv6mr_multiaddr, group, sizeof(struct in6_addr));
 
-	ret = setsockopt(ospf6->fd, IPPROTO_IPV6, option, &mreq6,
-			 sizeof(mreq6));
+	ret = setsockopt(sockfd, IPPROTO_IPV6, option, &mreq6, sizeof(mreq6));
 	if (ret < 0) {
 		flog_err_sys(
 			EC_LIB_SOCKET,
@@ -147,8 +146,8 @@ int ospf6_sso(ifindex_t ifindex, struct in6_addr *group, int option)
 		return ret;
 	}
 
-	setsockopt_so_sendbuf(ospf6->fd, bufsize);
-	setsockopt_so_recvbuf(ospf6->fd, bufsize);
+	setsockopt_so_sendbuf(sockfd, bufsize);
+	setsockopt_so_recvbuf(sockfd, bufsize);
 
 	return 0;
 }

--- a/ospf6d/ospf6_network.h
+++ b/ospf6d/ospf6_network.h
@@ -26,7 +26,8 @@ extern struct in6_addr alldrouters6;
 
 extern int ospf6_serv_sock(struct ospf6 *ospf6);
 extern void ospf6_serv_close(int *ospf6_sock);
-extern int ospf6_sso(ifindex_t ifindex, struct in6_addr *group, int option);
+extern int ospf6_sso(ifindex_t ifindex, struct in6_addr *group, int option,
+		     int sockfd);
 
 extern int ospf6_sendmsg(struct in6_addr *, struct in6_addr *, ifindex_t *,
 			 struct iovec *, int ospf6_sock);

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1084,7 +1084,7 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route)
 
 void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route)
 {
-	char destination[PREFIX2STR_BUFFER], nexthop[64];
+	char destination[PREFIX2STR_BUFFER];
 	char area_id[16], id[16], adv_router[16], capa[16], options[16];
 	struct timeval now, res;
 	char duration[64];
@@ -1170,10 +1170,9 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route)
 	for (ALL_LIST_ELEMENTS_RO(route->nh_list, node, nh)) {
 		struct interface *ifp;
 		/* nexthop */
-		inet_ntop(AF_INET6, &nh->address, nexthop, sizeof(nexthop));
 
 		ifp = if_lookup_by_index_all_vrf(nh->ifindex);
-		vty_out(vty, "  %s %.*s\n", nexthop, IFNAMSIZ, ifp->name);
+		vty_out(vty, "  %pI6 %.*s\n", &nh->address, IFNAMSIZ, ifp->name);
 	}
 	vty_out(vty, "\n");
 }

--- a/ospf6d/ospf6_route.h
+++ b/ospf6d/ospf6_route.h
@@ -178,6 +178,7 @@ struct ospf6_route {
 #define OSPF6_ROUTE_DO_NOT_ADVERTISE 0x20
 #define OSPF6_ROUTE_WAS_REMOVED      0x40
 #define OSPF6_ROUTE_BLACKHOLE_ADDED  0x80
+struct ospf6;
 
 struct ospf6_route_table {
 	int scope_type;
@@ -192,9 +193,9 @@ struct ospf6_route_table {
 	bitfield_t idspace;
 
 	/* hooks */
-	void (*hook_add)(struct ospf6_route *);
+	void (*hook_add)(struct ospf6_route *, struct ospf6 *);
 	void (*hook_change)(struct ospf6_route *);
-	void (*hook_remove)(struct ospf6_route *);
+	void (*hook_remove)(struct ospf6_route *, struct ospf6 *);
 };
 
 #define OSPF6_SCOPE_TYPE_NONE      0
@@ -296,7 +297,6 @@ extern int ospf6_route_cmp(struct ospf6_route *ra, struct ospf6_route *rb);
 
 extern void ospf6_route_lock(struct ospf6_route *route);
 extern void ospf6_route_unlock(struct ospf6_route *route);
-
 extern struct ospf6_route *ospf6_route_lookup(struct prefix *prefix,
 					      struct ospf6_route_table *table);
 extern struct ospf6_route *
@@ -307,9 +307,11 @@ ospf6_route_lookup_bestmatch(struct prefix *prefix,
 			     struct ospf6_route_table *table);
 
 extern struct ospf6_route *ospf6_route_add(struct ospf6_route *route,
-					   struct ospf6_route_table *table);
+					   struct ospf6_route_table *table,
+					   struct ospf6 *ospf6);
 extern void ospf6_route_remove(struct ospf6_route *route,
-			       struct ospf6_route_table *table);
+			       struct ospf6_route_table *table,
+			       struct ospf6 *ospf6);
 
 extern struct ospf6_route *ospf6_route_head(struct ospf6_route_table *table);
 extern struct ospf6_route *ospf6_route_next(struct ospf6_route *route);
@@ -320,9 +322,10 @@ ospf6_route_match_head(struct prefix *prefix, struct ospf6_route_table *table);
 extern struct ospf6_route *ospf6_route_match_next(struct prefix *prefix,
 						  struct ospf6_route *route);
 
-extern void ospf6_route_remove_all(struct ospf6_route_table *);
+extern void ospf6_route_remove_all(struct ospf6_route_table *, struct ospf6 *);
 extern struct ospf6_route_table *ospf6_route_table_create(int s, int t);
-extern void ospf6_route_table_delete(struct ospf6_route_table *);
+extern void ospf6_route_table_delete(struct ospf6_route_table *,
+				     struct ospf6 *);
 extern void ospf6_route_dump(struct ospf6_route_table *table);
 
 
@@ -341,7 +344,6 @@ extern void ospf6_brouter_show(struct vty *vty, struct ospf6_route *route);
 extern int config_write_ospf6_debug_route(struct vty *vty);
 extern void install_element_ospf6_debug_route(void);
 extern void ospf6_route_init(void);
-extern void ospf6_clean(void);
 extern void ospf6_path_free(struct ospf6_path *op);
 extern struct ospf6_path *ospf6_path_dup(struct ospf6_path *path);
 extern void ospf6_copy_paths(struct list *dst, struct list *src);

--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -638,7 +638,9 @@ static uint8_t *ospfv3GeneralGroup(struct variable *v, oid *name,
 	uint16_t sum;
 	uint32_t count;
 	struct ospf6_lsa *lsa = NULL, *lsanext;
+	struct ospf6 *ospf6;
 
+	ospf6 = ospf6_lookup_by_vrf_id(VRF_DEFAULT);
 	/* Check whether the instance identifier is valid */
 	if (smux_header_generic(v, name, length, exact, var_len, write_method)
 	    == MATCH_FAILED)
@@ -741,6 +743,9 @@ static uint8_t *ospfv3AreaEntry(struct variable *v, oid *name, size_t *length,
 	unsigned int len;
 	char a[16];
 	struct ospf6_route *ro;
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_id(VRF_DEFAULT);
 
 	if (ospf6 == NULL)
 		return NULL;
@@ -850,6 +855,9 @@ static uint8_t *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 	struct interface *iif;
 	struct ospf6_interface *oi = NULL;
 	struct list *ifslist;
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_id(VRF_DEFAULT);
 
 	if (smux_header_table(v, name, length, exact, var_len, write_method)
 	    == MATCH_FAILED)
@@ -1051,6 +1059,9 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 	oid *offset;
 	int offsetlen, len;
 	uint32_t sum;
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_id(VRF_DEFAULT);
 
 	if (smux_header_table(v, name, length, exact, var_len, write_method)
 	    == MATCH_FAILED)
@@ -1205,6 +1216,9 @@ static uint8_t *ospfv3NbrEntry(struct variable *v, oid *name, size_t *length,
 	struct list *ifslist;
 	oid *offset;
 	int offsetlen, len;
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_id(VRF_DEFAULT);
 
 	if (smux_header_table(v, name, length, exact, var_len, write_method)
 	    == MATCH_FAILED)

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -258,7 +258,7 @@ static char *ospf6_lsdesc_backlink(struct ospf6_lsa *lsa, caddr_t lsdesc,
 }
 
 static void ospf6_nexthop_calc(struct ospf6_vertex *w, struct ospf6_vertex *v,
-			       caddr_t lsdesc)
+			       caddr_t lsdesc, struct ospf6 *ospf6)
 {
 	int i;
 	ifindex_t ifindex;
@@ -316,7 +316,8 @@ static void ospf6_nexthop_calc(struct ospf6_vertex *w, struct ospf6_vertex *v,
 }
 
 static int ospf6_spf_install(struct ospf6_vertex *v,
-			     struct ospf6_route_table *result_table)
+			     struct ospf6_route_table *result_table,
+			     struct ospf6 *ospf6)
 {
 	struct ospf6_route *route, *parent_route;
 	struct ospf6_vertex *prev;
@@ -419,11 +420,12 @@ static int ospf6_spf_install(struct ospf6_vertex *v,
 		listnode_add_sort(v->parent->child_list, v);
 	route->route_option = v;
 
-	ospf6_route_add(route, result_table);
+	ospf6_route_add(route, result_table, ospf6);
 	return 0;
 }
 
-void ospf6_spf_table_finish(struct ospf6_route_table *result_table)
+void ospf6_spf_table_finish(struct ospf6_route_table *result_table,
+			    struct ospf6 *ospf6)
 {
 	struct ospf6_route *route, *nroute;
 	struct ospf6_vertex *v;
@@ -431,7 +433,7 @@ void ospf6_spf_table_finish(struct ospf6_route_table *result_table)
 		nroute = ospf6_route_next(route);
 		v = (struct ospf6_vertex *)route->route_option;
 		ospf6_vertex_delete(v);
-		ospf6_route_remove(route, result_table);
+		ospf6_route_remove(route, result_table, ospf6);
 	}
 }
 
@@ -469,7 +471,7 @@ void ospf6_spf_calculation(uint32_t router_id,
 	struct ospf6_lsa *lsa;
 	struct in6_addr address;
 
-	ospf6_spf_table_finish(result_table);
+	ospf6_spf_table_finish(result_table, oa->ospf6);
 
 	/* Install the calculating router itself as the root of the SPF tree */
 	/* construct root vertex */
@@ -498,7 +500,7 @@ void ospf6_spf_calculation(uint32_t router_id,
 	while ((v = vertex_pqueue_pop(&candidate_list))) {
 		/* installing may result in merging or rejecting of the vertex
 		 */
-		if (ospf6_spf_install(v, result_table) < 0)
+		if (ospf6_spf_install(v, result_table, oa->ospf6) < 0)
 			continue;
 
 		/* Skip overloaded routers */
@@ -544,7 +546,7 @@ void ospf6_spf_calculation(uint32_t router_id,
 					w->nh_list,
 					ROUTER_LSDESC_GET_IFID(lsdesc), NULL);
 			else if (w->hops == 1 && v->hops == 0)
-				ospf6_nexthop_calc(w, v, lsdesc);
+				ospf6_nexthop_calc(w, v, lsdesc, oa->ospf6);
 			else
 				ospf6_copy_nexthops(w->nh_list, v->nh_list);
 
@@ -915,7 +917,7 @@ int config_write_ospf6_debug_spf(struct vty *vty)
 	return 0;
 }
 
-void ospf6_spf_config_write(struct vty *vty)
+void ospf6_spf_config_write(struct vty *vty, struct ospf6 *ospf6)
 {
 
 	if (ospf6->spf_delay != OSPF_SPF_DELAY_DEFAULT

--- a/ospf6d/ospf6_spf.h
+++ b/ospf6d/ospf6_spf.h
@@ -139,7 +139,8 @@ static inline unsigned int ospf6_lsremove_to_spf_reason(struct ospf6_lsa *lsa)
 	return (reason);
 }
 
-extern void ospf6_spf_table_finish(struct ospf6_route_table *result_table);
+extern void ospf6_spf_table_finish(struct ospf6_route_table *result_table,
+				   struct ospf6 *ospf6);
 extern void ospf6_spf_calculation(uint32_t router_id,
 				  struct ospf6_route_table *result_table,
 				  struct ospf6_area *oa);
@@ -148,7 +149,7 @@ extern void ospf6_spf_schedule(struct ospf6 *ospf, unsigned int reason);
 extern void ospf6_spf_display_subtree(struct vty *vty, const char *prefix,
 				      int rest, struct ospf6_vertex *v);
 
-extern void ospf6_spf_config_write(struct vty *vty);
+extern void ospf6_spf_config_write(struct vty *vty, struct ospf6 *ospf6);
 extern int config_write_ospf6_debug_spf(struct vty *vty);
 extern void install_element_ospf6_debug_spf(void);
 extern void ospf6_spf_init(void);

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -59,17 +59,76 @@ FRR_CFG_DEFAULT_BOOL(OSPF6_LOG_ADJACENCY_CHANGES,
 )
 
 /* global ospf6d variable */
-struct ospf6 *ospf6;
 static struct ospf6_master ospf6_master;
 struct ospf6_master *om6;
 
 static void ospf6_disable(struct ospf6 *o);
 
+static void ospf6_add(struct ospf6 *ospf6)
+{
+	listnode_add(om6->ospf6, ospf6);
+}
+
+static void ospf6_del(struct ospf6 *ospf6)
+{
+	listnode_delete(om6->ospf6, ospf6);
+}
+
+const char *ospf6_vrf_id_to_name(vrf_id_t vrf_id)
+{
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
+
+	return vrf ? vrf->name : "NIL";
+}
+
+/* Link OSPF instance to VRF. */
+void ospf6_vrf_link(struct ospf6 *ospf6, struct vrf *vrf)
+{
+	ospf6->vrf_id = vrf->vrf_id;
+	if (vrf->info != (void *)ospf6)
+		vrf->info = (void *)ospf6;
+}
+
+/* Unlink OSPF instance from VRF. */
+void ospf6_vrf_unlink(struct ospf6 *ospf6, struct vrf *vrf)
+{
+	if (vrf->info == (void *)ospf6)
+		vrf->info = NULL;
+	ospf6->vrf_id = VRF_UNKNOWN;
+}
+
+struct ospf6 *ospf6_lookup_by_vrf_id(vrf_id_t vrf_id)
+{
+	struct vrf *vrf = NULL;
+
+	vrf = vrf_lookup_by_id(vrf_id);
+	if (!vrf)
+		return NULL;
+	return (vrf->info) ? (struct ospf6 *)vrf->info : NULL;
+}
+
+struct ospf6 *ospf6_lookup_by_vrf_name(const char *name)
+{
+	struct ospf6 *o = NULL;
+	struct listnode *node, *nnode;
+
+	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, o)) {
+		if (((o->name == NULL && name == NULL)
+		     || (o->name && name && strcmp(o->name, name) == 0)))
+			return o;
+	}
+	return NULL;
+}
+
+
 static void ospf6_top_lsdb_hook_add(struct ospf6_lsa *lsa)
 {
+	struct ospf6 *ospf6 = NULL;
+
 	switch (ntohs(lsa->header->type)) {
 	case OSPF6_LSTYPE_AS_EXTERNAL:
-		ospf6_asbr_lsa_add(lsa);
+		ospf6 = ospf6_get_by_lsdb(lsa);
+		ospf6_asbr_lsa_add(lsa, ospf6);
 		break;
 
 	default:
@@ -89,20 +148,23 @@ static void ospf6_top_lsdb_hook_remove(struct ospf6_lsa *lsa)
 	}
 }
 
-static void ospf6_top_route_hook_add(struct ospf6_route *route)
+static void ospf6_top_route_hook_add(struct ospf6_route *route,
+				     struct ospf6 *ospf6)
 {
-	ospf6_abr_originate_summary(route);
-	ospf6_zebra_route_update_add(route);
+	ospf6_abr_originate_summary(route, ospf6);
+	ospf6_zebra_route_update_add(route, ospf6);
 }
 
-static void ospf6_top_route_hook_remove(struct ospf6_route *route)
+static void ospf6_top_route_hook_remove(struct ospf6_route *route,
+					struct ospf6 *ospf6)
 {
 	route->flag |= OSPF6_ROUTE_REMOVE;
-	ospf6_abr_originate_summary(route);
-	ospf6_zebra_route_update_remove(route);
+	ospf6_abr_originate_summary(route, ospf6);
+	ospf6_zebra_route_update_remove(route, ospf6);
 }
 
-static void ospf6_top_brouter_hook_add(struct ospf6_route *route)
+static void ospf6_top_brouter_hook_add(struct ospf6_route *route,
+				       struct ospf6 *ospf6)
 {
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL) ||
 	    IS_OSPF6_DEBUG_BROUTER) {
@@ -117,12 +179,14 @@ static void ospf6_top_brouter_hook_add(struct ospf6_route *route)
 			   route->path.origin.adv_router,
 			   listcount(route->nh_list));
 	}
-	ospf6_abr_examin_brouter(ADV_ROUTER_IN_PREFIX(&route->prefix));
-	ospf6_asbr_lsentry_add(route);
-	ospf6_abr_originate_summary(route);
+	ospf6_abr_examin_brouter(ADV_ROUTER_IN_PREFIX(&route->prefix), route,
+				 ospf6);
+	ospf6_asbr_lsentry_add(route, ospf6);
+	ospf6_abr_originate_summary(route, ospf6);
 }
 
-static void ospf6_top_brouter_hook_remove(struct ospf6_route *route)
+static void ospf6_top_brouter_hook_remove(struct ospf6_route *route,
+					  struct ospf6 *ospf6)
 {
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL) ||
 	    IS_OSPF6_DEBUG_BROUTER) {
@@ -138,9 +202,10 @@ static void ospf6_top_brouter_hook_remove(struct ospf6_route *route)
 			   listcount(route->nh_list));
 	}
 	route->flag |= OSPF6_ROUTE_REMOVE;
-	ospf6_abr_examin_brouter(ADV_ROUTER_IN_PREFIX(&route->prefix));
-	ospf6_asbr_lsentry_remove(route);
-	ospf6_abr_originate_summary(route);
+	ospf6_abr_examin_brouter(ADV_ROUTER_IN_PREFIX(&route->prefix), route,
+				 ospf6);
+	ospf6_asbr_lsentry_remove(route, ospf6);
+	ospf6_abr_originate_summary(route, ospf6);
 }
 
 static struct ospf6 *ospf6_create(const char *name)
@@ -153,9 +218,16 @@ static struct ospf6 *ospf6_create(const char *name)
 	vrf = vrf_lookup_by_name(name);
 	if (vrf) {
 		o->vrf_id = vrf->vrf_id;
-		/* Freed in ospf6_delete */
-		o->name = XSTRDUP(MTYPE_OSPF6_TOP, name);
-	}
+	} else
+		o->vrf_id = VRF_UNKNOWN;
+
+	/* Freed in ospf6_delete */
+	o->name = XSTRDUP(MTYPE_OSPF6_TOP, name);
+	if (vrf)
+		ospf6_vrf_link(o, vrf);
+
+	ospf6_zebra_vrf_register(o);
+
 	/* initialize */
 	monotime(&o->starttime);
 	o->area_list = list_new();
@@ -201,16 +273,20 @@ static struct ospf6 *ospf6_create(const char *name)
 	return o;
 }
 
-void ospf6_instance_create(const char *name)
+struct ospf6 *ospf6_instance_create(const char *name)
 {
+	struct ospf6 *ospf6;
+
 	ospf6 = ospf6_create(name);
 	if (DFLT_OSPF6_LOG_ADJACENCY_CHANGES)
 		SET_FLAG(ospf6->config_flags, OSPF6_LOG_ADJACENCY_CHANGES);
 	if (ospf6->router_id == 0)
-		ospf6_router_id_update();
-
+		ospf6_router_id_update(ospf6);
+	ospf6_add(ospf6);
 	thread_add_read(master, ospf6_receive, ospf6, ospf6->fd,
 			&ospf6->t_ospf6_receive);
+
+	return ospf6;
 }
 
 void ospf6_delete(struct ospf6 *o)
@@ -220,8 +296,9 @@ void ospf6_delete(struct ospf6 *o)
 
 	QOBJ_UNREG(o);
 
-	ospf6_flush_self_originated_lsas_now();
-	ospf6_disable(ospf6);
+	ospf6_flush_self_originated_lsas_now(o);
+	ospf6_disable(o);
+	ospf6_del(o);
 
 	for (ALL_LIST_ELEMENTS(o->area_list, node, nnode, oa))
 		ospf6_area_delete(oa);
@@ -232,10 +309,10 @@ void ospf6_delete(struct ospf6 *o)
 	ospf6_lsdb_delete(o->lsdb);
 	ospf6_lsdb_delete(o->lsdb_self);
 
-	ospf6_route_table_delete(o->route_table);
-	ospf6_route_table_delete(o->brouter_table);
+	ospf6_route_table_delete(o->route_table, o);
+	ospf6_route_table_delete(o->brouter_table, o);
 
-	ospf6_route_table_delete(o->external_table);
+	ospf6_route_table_delete(o->external_table, o);
 	route_table_finish(o->external_id_table);
 
 	ospf6_distance_reset(o);
@@ -260,8 +337,8 @@ static void ospf6_disable(struct ospf6 *o)
 		ospf6_asbr_redistribute_reset(o->vrf_id);
 
 		ospf6_lsdb_remove_all(o->lsdb);
-		ospf6_route_remove_all(o->route_table);
-		ospf6_route_remove_all(o->brouter_table);
+		ospf6_route_remove_all(o->route_table, o);
+		ospf6_route_remove_all(o->brouter_table, o);
 
 		THREAD_OFF(o->maxage_remover);
 		THREAD_OFF(o->t_spf_calc);
@@ -271,11 +348,13 @@ static void ospf6_disable(struct ospf6 *o)
 	}
 }
 
-void ospf6_master_init(void)
+void ospf6_master_init(struct thread_master *master)
 {
 	memset(&ospf6_master, 0, sizeof(struct ospf6_master));
 
 	om6 = &ospf6_master;
+	om6->ospf6 = list_new();
+	om6->master = master;
 }
 
 static int ospf6_maxage_remover(struct thread *thread)
@@ -333,7 +412,7 @@ void ospf6_maxage_remove(struct ospf6 *o)
 				 &o->maxage_remover);
 }
 
-void ospf6_router_id_update(void)
+void ospf6_router_id_update(struct ospf6 *ospf6)
 {
 	if (!ospf6)
 		return;
@@ -351,8 +430,11 @@ DEFUN_NOSH (router_ospf6,
        ROUTER_STR
        OSPF6_STR)
 {
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
 	if (ospf6 == NULL)
-		ospf6_instance_create(VRF_DEFAULT_NAME);
+		ospf6 = ospf6_instance_create(VRF_DEFAULT_NAME);
 
 	/* set current ospf point. */
 	VTY_PUSH_CONTEXT(OSPF6_NODE, ospf6);
@@ -368,6 +450,9 @@ DEFUN (no_router_ospf6,
        ROUTER_STR
        OSPF6_STR)
 {
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
 	if (ospf6 == NULL)
 		vty_out(vty, "OSPFv3 is not configured\n");
 	else {
@@ -672,12 +757,13 @@ DEFUN (ospf6_interface_area,
        "OSPF6 area ID in decimal notation\n"
       )
 {
-	VTY_DECLVAR_CONTEXT(ospf6, o);
 	int idx_ifname = 1;
 	int idx_ipv4 = 3;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	struct interface *ifp;
+
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
 
 	/* find/create ospf6 interface */
 	ifp = if_get_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
@@ -691,7 +777,7 @@ DEFUN (ospf6_interface_area,
 	}
 
 	/* parse Area-ID */
-	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, oa);
+	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, oa, ospf6);
 
 	/* attach interface to area */
 	listnode_add(oa->if_list, oi); /* sort ?? */
@@ -700,14 +786,14 @@ DEFUN (ospf6_interface_area,
 	SET_FLAG(oa->flag, OSPF6_AREA_ENABLE);
 
 	/* ospf6 process is currently disabled, not much more to do */
-	if (CHECK_FLAG(o->flag, OSPF6_DISABLED))
+	if (CHECK_FLAG(ospf6->flag, OSPF6_DISABLED))
 		return CMD_SUCCESS;
 
 	/* start up */
 	ospf6_interface_enable(oi);
 
 	/* If the router is ABR, originate summary routes */
-	if (ospf6_is_router_abr(o))
+	if (ospf6_is_router_abr(ospf6))
 		ospf6_abr_enable_area(oa);
 
 	return CMD_SUCCESS;
@@ -783,6 +869,8 @@ DEFUN (ospf6_stub_router_admin,
 	struct listnode *node;
 	struct ospf6_area *oa;
 
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
 	if (!CHECK_FLAG(ospf6->flag, OSPF6_STUB_ROUTER)) {
 		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
 			OSPF6_OPT_CLEAR(oa->options, OSPF6_OPT_V6);
@@ -805,6 +893,7 @@ DEFUN (no_ospf6_stub_router_admin,
 	struct listnode *node;
 	struct ospf6_area *oa;
 
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
 	if (CHECK_FLAG(ospf6->flag, OSPF6_STUB_ROUTER)) {
 		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
 			OSPF6_OPT_SET(oa->options, OSPF6_OPT_V6);
@@ -944,8 +1033,10 @@ DEFUN (show_ipv6_ospf6,
        IP6_STR
        OSPF6_STR)
 {
-	OSPF6_CMD_CHECK_RUNNING();
+	struct ospf6 *ospf6;
 
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	ospf6_show(vty, ospf6);
 	return CMD_SUCCESS;
 }
@@ -966,7 +1057,10 @@ DEFUN (show_ipv6_ospf6_route,
        "Detailed information\n"
        "Summary of route table\n")
 {
-	OSPF6_CMD_CHECK_RUNNING();
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table);
 	return CMD_SUCCESS;
@@ -983,9 +1077,13 @@ DEFUN (show_ipv6_ospf6_route_match,
        "Display routes which match the specified route\n"
        "Display routes longer than the specified route\n")
 {
-	OSPF6_CMD_CHECK_RUNNING();
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table);
+
 	return CMD_SUCCESS;
 }
 
@@ -1001,7 +1099,10 @@ DEFUN (show_ipv6_ospf6_route_match_detail,
        "Detailed information\n"
        )
 {
-	OSPF6_CMD_CHECK_RUNNING();
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table);
 	return CMD_SUCCESS;
@@ -1022,13 +1123,16 @@ DEFUN (show_ipv6_ospf6_route_type_detail,
        "Detailed information\n"
        )
 {
-	OSPF6_CMD_CHECK_RUNNING();
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table);
 	return CMD_SUCCESS;
 }
 
-static void ospf6_stub_router_config_write(struct vty *vty)
+static void ospf6_stub_router_config_write(struct vty *vty, struct ospf6 *ospf6)
 {
 	if (CHECK_FLAG(ospf6->flag, OSPF6_STUB_ROUTER)) {
 		vty_out(vty, " stub-router administrative\n");
@@ -1036,7 +1140,7 @@ static void ospf6_stub_router_config_write(struct vty *vty)
 	return;
 }
 
-static int ospf6_distance_config_write(struct vty *vty)
+static int ospf6_distance_config_write(struct vty *vty, struct ospf6 *ospf6)
 {
 	struct route_node *rn;
 	struct ospf6_distance *odistance;
@@ -1074,52 +1178,56 @@ static int ospf6_distance_config_write(struct vty *vty)
 /* OSPF configuration write function. */
 static int config_write_ospf6(struct vty *vty)
 {
-	char router_id[16];
 	struct listnode *j, *k;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
+	struct ospf6 *ospf6;
+	struct listnode *node, *nnode;
 
 	/* OSPFv3 configuration. */
-	if (ospf6 == NULL)
+	if (om6 == NULL)
 		return CMD_SUCCESS;
 
-	inet_ntop(AF_INET, &ospf6->router_id_static, router_id,
-		  sizeof(router_id));
-	vty_out(vty, "router ospf6\n");
-	if (ospf6->router_id_static != 0)
-		vty_out(vty, " ospf6 router-id %s\n", router_id);
+	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6)) {
+		vty_out(vty, "router ospf6\n");
+		if (ospf6->router_id_static != 0)
+			vty_out(vty, " ospf6 router-id %pI4\n",
+				&ospf6->router_id_static);
 
-	/* log-adjacency-changes flag print. */
-	if (CHECK_FLAG(ospf6->config_flags, OSPF6_LOG_ADJACENCY_CHANGES)) {
-		if (CHECK_FLAG(ospf6->config_flags, OSPF6_LOG_ADJACENCY_DETAIL))
-			vty_out(vty, " log-adjacency-changes detail\n");
-		else if (!SAVE_OSPF6_LOG_ADJACENCY_CHANGES)
-			vty_out(vty, " log-adjacency-changes\n");
-	} else if (SAVE_OSPF6_LOG_ADJACENCY_CHANGES) {
-		vty_out(vty, " no log-adjacency-changes\n");
+		/* log-adjacency-changes flag print. */
+		if (CHECK_FLAG(ospf6->config_flags,
+			       OSPF6_LOG_ADJACENCY_CHANGES)) {
+			if (CHECK_FLAG(ospf6->config_flags,
+				       OSPF6_LOG_ADJACENCY_DETAIL))
+				vty_out(vty, " log-adjacency-changes detail\n");
+			else if (!SAVE_OSPF6_LOG_ADJACENCY_CHANGES)
+				vty_out(vty, " log-adjacency-changes\n");
+		} else if (SAVE_OSPF6_LOG_ADJACENCY_CHANGES) {
+			vty_out(vty, " no log-adjacency-changes\n");
+		}
+
+		if (ospf6->ref_bandwidth != OSPF6_REFERENCE_BANDWIDTH)
+			vty_out(vty, " auto-cost reference-bandwidth %d\n",
+				ospf6->ref_bandwidth);
+
+		/* LSA timers print. */
+		if (ospf6->lsa_minarrival != OSPF_MIN_LS_ARRIVAL)
+			vty_out(vty, " timers lsa min-arrival %d\n",
+				ospf6->lsa_minarrival);
+
+		ospf6_stub_router_config_write(vty, ospf6);
+		ospf6_redistribute_config_write(vty, ospf6);
+		ospf6_area_config_write(vty, ospf6);
+		ospf6_spf_config_write(vty, ospf6);
+		ospf6_distance_config_write(vty, ospf6);
+
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, j, oa)) {
+			for (ALL_LIST_ELEMENTS_RO(oa->if_list, k, oi))
+				vty_out(vty, " interface %s area %s\n",
+					oi->interface->name, oa->name);
+		}
+		vty_out(vty, "!\n");
 	}
-
-	if (ospf6->ref_bandwidth != OSPF6_REFERENCE_BANDWIDTH)
-		vty_out(vty, " auto-cost reference-bandwidth %d\n",
-			ospf6->ref_bandwidth);
-
-	/* LSA timers print. */
-	if (ospf6->lsa_minarrival != OSPF_MIN_LS_ARRIVAL)
-		vty_out(vty, " timers lsa min-arrival %d\n",
-			ospf6->lsa_minarrival);
-
-	ospf6_stub_router_config_write(vty);
-	ospf6_redistribute_config_write(vty);
-	ospf6_area_config_write(vty);
-	ospf6_spf_config_write(vty);
-	ospf6_distance_config_write(vty);
-
-	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, j, oa)) {
-		for (ALL_LIST_ELEMENTS_RO(oa->if_list, k, oi))
-			vty_out(vty, " interface %s area %s\n",
-				oi->interface->name, oa->name);
-	}
-	vty_out(vty, "!\n");
 	return 0;
 }
 

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -23,9 +23,12 @@
 
 #include "qobj.h"
 #include "routemap.h"
-
 struct ospf6_master {
 
+	/* OSPFv3 instance. */
+	struct list *ospf6;
+	/* OSPFv3 thread master. */
+	struct thread_master *master;
 	in_addr_t zebra_router_id;
 };
 
@@ -128,12 +131,17 @@ extern struct ospf6 *ospf6;
 extern struct ospf6_master *om6;
 
 /* prototypes */
-extern void ospf6_master_init(void);
+extern void ospf6_master_init(struct thread_master *master);
 extern void ospf6_top_init(void);
 extern void ospf6_delete(struct ospf6 *o);
-extern void ospf6_router_id_update(void);
+extern void ospf6_router_id_update(struct ospf6 *ospf6);
 
 extern void ospf6_maxage_remove(struct ospf6 *o);
-extern void ospf6_instance_create(const char *name);
+extern struct ospf6 *ospf6_instance_create(const char *name);
+void ospf6_vrf_link(struct ospf6 *ospf6, struct vrf *vrf);
+void ospf6_vrf_unlink(struct ospf6 *ospf6, struct vrf *vrf);
+struct ospf6 *ospf6_lookup_by_vrf_id(vrf_id_t vrf_id);
+struct ospf6 *ospf6_lookup_by_vrf_name(const char *name);
+const char *ospf6_vrf_id_to_name(vrf_id_t vrf_id);
 
 #endif /* OSPF6_TOP_H */

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -39,6 +39,7 @@
 #include "ospf6_asbr.h"
 #include "ospf6_zebra.h"
 #include "ospf6d.h"
+#include "ospf6_area.h"
 
 DEFINE_MTYPE_STATIC(OSPF6D, OSPF6_DISTANCE, "OSPF6 distance")
 
@@ -47,16 +48,49 @@ unsigned char conf_debug_ospf6_zebra = 0;
 /* information about zebra. */
 struct zclient *zclient = NULL;
 
+void ospf6_zebra_vrf_register(struct ospf6 *ospf6)
+{
+	if (!zclient || zclient->sock < 0 || !ospf6)
+		return;
+
+	if (ospf6->vrf_id != VRF_UNKNOWN) {
+		if (IS_OSPF6_DEBUG_ZEBRA(RECV)) {
+			zlog_debug("%s: Register VRF %s id %u", __func__,
+				   ospf6_vrf_id_to_name(ospf6->vrf_id),
+				   ospf6->vrf_id);
+		}
+		zclient_send_reg_requests(zclient, ospf6->vrf_id);
+	}
+}
+
+void ospf6_zebra_vrf_deregister(struct ospf6 *ospf6)
+{
+	if (!zclient || zclient->sock < 0 || !ospf6)
+		return;
+
+	if (ospf6->vrf_id != VRF_DEFAULT && ospf6->vrf_id != VRF_UNKNOWN) {
+		if (IS_OSPF6_DEBUG_ZEBRA(RECV)) {
+			zlog_debug("%s: De-Register VRF %s id %u to Zebra.",
+				   __func__,
+				   ospf6_vrf_id_to_name(ospf6->vrf_id),
+				   ospf6->vrf_id);
+		}
+		/* Deregister for router-id, interfaces,
+		 * redistributed routes. */
+		zclient_send_dereg_requests(zclient, ospf6->vrf_id);
+	}
+}
+
 /* Router-id update message from zebra. */
 static int ospf6_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 {
 	struct prefix router_id;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *o;
 
 	zebra_router_id_update_read(zclient->ibuf, &router_id);
 
 	om6->zebra_router_id = router_id.u.prefix4.s_addr;
-
+	o = ospf6_lookup_by_vrf_id(vrf_id);
 	if (o == NULL)
 		return 0;
 
@@ -69,7 +103,7 @@ static int ospf6_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 				     INET_ADDRSTRLEN));
 	}
 
-	ospf6_router_id_update();
+	ospf6_router_id_update(o);
 
 	return 0;
 }
@@ -152,6 +186,9 @@ static int ospf6_zebra_read_route(ZAPI_CALLBACK_ARGS)
 	struct zapi_route api;
 	unsigned long ifindex;
 	struct in6_addr *nexthop;
+	struct ospf6 *ospf6;
+
+	ospf6 = ospf6_lookup_by_vrf_id(vrf_id);
 
 	if (ospf6 == NULL)
 		return 0;
@@ -185,9 +222,11 @@ static int ospf6_zebra_read_route(ZAPI_CALLBACK_ARGS)
 
 	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
 		ospf6_asbr_redistribute_add(api.type, ifindex, &api.prefix,
-					    api.nexthop_num, nexthop, api.tag);
+					    api.nexthop_num, nexthop, api.tag,
+					    ospf6);
 	else
-		ospf6_asbr_redistribute_remove(api.type, ifindex, &api.prefix);
+		ospf6_asbr_redistribute_remove(api.type, ifindex, &api.prefix,
+					       ospf6);
 
 	return 0;
 }
@@ -222,7 +261,8 @@ DEFUN (show_zebra,
 
 #define ADD    0
 #define REM    1
-static void ospf6_zebra_route_update(int type, struct ospf6_route *request)
+static void ospf6_zebra_route_update(int type, struct ospf6_route *request,
+				     struct ospf6 *ospf6)
 {
 	struct zapi_route api;
 	char buf[PREFIX2STR_BUFFER];
@@ -295,8 +335,8 @@ static void ospf6_zebra_route_update(int type, struct ospf6_route *request)
 	}
 
 	SET_FLAG(api.message, ZAPI_MESSAGE_DISTANCE);
-	api.distance =
-		ospf6_distance_apply((struct prefix_ipv6 *)dest, request);
+	api.distance = ospf6_distance_apply((struct prefix_ipv6 *)dest, request,
+					    ospf6);
 
 	if (type == REM)
 		ret = zclient_route_send(ZEBRA_ROUTE_DELETE, zclient, &api);
@@ -312,17 +352,19 @@ static void ospf6_zebra_route_update(int type, struct ospf6_route *request)
 	return;
 }
 
-void ospf6_zebra_route_update_add(struct ospf6_route *request)
+void ospf6_zebra_route_update_add(struct ospf6_route *request,
+				  struct ospf6 *ospf6)
 {
-	ospf6_zebra_route_update(ADD, request);
+	ospf6_zebra_route_update(ADD, request, ospf6);
 }
 
-void ospf6_zebra_route_update_remove(struct ospf6_route *request)
+void ospf6_zebra_route_update_remove(struct ospf6_route *request,
+				     struct ospf6 *ospf6)
 {
-	ospf6_zebra_route_update(REM, request);
+	ospf6_zebra_route_update(REM, request, ospf6);
 }
 
-void ospf6_zebra_add_discard(struct ospf6_route *request)
+void ospf6_zebra_add_discard(struct ospf6_route *request, struct ospf6 *ospf6)
 {
 	struct zapi_route api;
 	char buf[INET6_ADDRSTRLEN];
@@ -355,7 +397,8 @@ void ospf6_zebra_add_discard(struct ospf6_route *request)
 	}
 }
 
-void ospf6_zebra_delete_discard(struct ospf6_route *request)
+void ospf6_zebra_delete_discard(struct ospf6_route *request,
+				struct ospf6 *ospf6)
 {
 	struct zapi_route api;
 	char buf[INET6_ADDRSTRLEN];
@@ -489,7 +532,8 @@ void ospf6_distance_reset(struct ospf6 *o)
 		}
 }
 
-uint8_t ospf6_distance_apply(struct prefix_ipv6 *p, struct ospf6_route * or)
+uint8_t ospf6_distance_apply(struct prefix_ipv6 *p, struct ospf6_route * or,
+			     struct ospf6 *ospf6)
 {
 	struct ospf6 *o;
 

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -41,21 +41,26 @@ struct ospf6_distance {
 };
 
 extern struct zclient *zclient;
+struct ospf6;
 
-extern void ospf6_zebra_route_update_add(struct ospf6_route *request);
-extern void ospf6_zebra_route_update_remove(struct ospf6_route *request);
+extern void ospf6_zebra_route_update_add(struct ospf6_route *request,
+					 struct ospf6 *ospf6);
+extern void ospf6_zebra_route_update_remove(struct ospf6_route *request,
+					    struct ospf6 *ospf6);
 
 extern void ospf6_zebra_redistribute(int, vrf_id_t vrf_id);
 extern void ospf6_zebra_no_redistribute(int, vrf_id_t vrf_id);
 #define ospf6_zebra_is_redistribute(type, vrf_id)                              \
 	vrf_bitmap_check(zclient->redist[AFI_IP6][type], vrf_id)
 extern void ospf6_zebra_init(struct thread_master *);
-extern void ospf6_zebra_add_discard(struct ospf6_route *request);
-extern void ospf6_zebra_delete_discard(struct ospf6_route *request);
+extern void ospf6_zebra_add_discard(struct ospf6_route *request,
+				    struct ospf6 *ospf6);
+extern void ospf6_zebra_delete_discard(struct ospf6_route *request,
+				       struct ospf6 *ospf6);
 
-struct ospf6;
 extern void ospf6_distance_reset(struct ospf6 *);
-extern uint8_t ospf6_distance_apply(struct prefix_ipv6 *, struct ospf6_route *);
+extern uint8_t ospf6_distance_apply(struct prefix_ipv6 *, struct ospf6_route *,
+				    struct ospf6 *);
 
 extern int ospf6_distance_set(struct vty *, struct ospf6 *, const char *,
 			      const char *, const char *);
@@ -64,5 +69,6 @@ extern int ospf6_distance_unset(struct vty *, struct ospf6 *, const char *,
 
 extern int config_write_ospf6_debug_zebra(struct vty *vty);
 extern void install_element_ospf6_debug_zebra(void);
-
+extern void ospf6_zebra_vrf_register(struct ospf6 *ospf6);
+extern void ospf6_zebra_vrf_deregister(struct ospf6 *ospf6);
 #endif /*OSPF6_ZEBRA_H*/

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -168,20 +168,22 @@ DEFUN (show_ipv6_ospf6_database,
 	int idx_level = 4;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 
-	OSPF6_CMD_CHECK_RUNNING();
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	level = parse_show_level(idx_level, argc, argv);
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 		ospf6_lsdb_show(vty, level, NULL, NULL, NULL, oa->lsdb);
 	}
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 			vty_out(vty, IF_LSDB_TITLE_FORMAT, oi->interface->name,
 				oa->name);
@@ -190,7 +192,7 @@ DEFUN (show_ipv6_ospf6_database,
 	}
 
 	vty_out(vty, AS_LSDB_TITLE_FORMAT);
-	ospf6_lsdb_show(vty, level, NULL, NULL, NULL, o->lsdb);
+	ospf6_lsdb_show(vty, level, NULL, NULL, NULL, ospf6->lsdb);
 
 	vty_out(vty, "\n");
 	return CMD_SUCCESS;
@@ -221,19 +223,21 @@ DEFUN (show_ipv6_ospf6_database_type,
 	int idx_level = 5;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint16_t type = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	type = parse_type_spec(idx_lsa, argc, argv);
 	level = parse_show_level(idx_level, argc, argv);
 
 	switch (OSPF6_LSA_SCOPE(type)) {
 	case OSPF6_SCOPE_AREA:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 			ospf6_lsdb_show(vty, level, &type, NULL, NULL,
 					oa->lsdb);
@@ -241,7 +245,7 @@ DEFUN (show_ipv6_ospf6_database_type,
 		break;
 
 	case OSPF6_SCOPE_LINKLOCAL:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 				vty_out(vty, IF_LSDB_TITLE_FORMAT,
 					oi->interface->name, oa->name);
@@ -253,7 +257,7 @@ DEFUN (show_ipv6_ospf6_database_type,
 
 	case OSPF6_SCOPE_AS:
 		vty_out(vty, AS_LSDB_TITLE_FORMAT);
-		ospf6_lsdb_show(vty, level, &type, NULL, NULL, o->lsdb);
+		ospf6_lsdb_show(vty, level, &type, NULL, NULL, ospf6->lsdb);
 		break;
 
 	default:
@@ -283,24 +287,26 @@ DEFUN (show_ipv6_ospf6_database_id,
 	int idx_level = 6;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint32_t id = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	if (argv[idx_ipv4]->type == IPV4_TKN)
 		inet_pton(AF_INET, argv[idx_ipv4]->arg, &id);
 
 	level = parse_show_level(idx_level, argc, argv);
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 		ospf6_lsdb_show(vty, level, NULL, &id, NULL, oa->lsdb);
 	}
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 			vty_out(vty, IF_LSDB_TITLE_FORMAT, oi->interface->name,
 				oa->name);
@@ -309,7 +315,7 @@ DEFUN (show_ipv6_ospf6_database_id,
 	}
 
 	vty_out(vty, AS_LSDB_TITLE_FORMAT);
-	ospf6_lsdb_show(vty, level, NULL, &id, NULL, o->lsdb);
+	ospf6_lsdb_show(vty, level, NULL, &id, NULL, ospf6->lsdb);
 
 	vty_out(vty, "\n");
 	return CMD_SUCCESS;
@@ -334,21 +340,23 @@ DEFUN (show_ipv6_ospf6_database_router,
 	int idx_level = 7;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint32_t adv_router = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &adv_router);
 	level = parse_show_level(idx_level, argc, argv);
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 		ospf6_lsdb_show(vty, level, NULL, NULL, &adv_router, oa->lsdb);
 	}
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 			vty_out(vty, IF_LSDB_TITLE_FORMAT, oi->interface->name,
 				oa->name);
@@ -358,7 +366,7 @@ DEFUN (show_ipv6_ospf6_database_router,
 	}
 
 	vty_out(vty, AS_LSDB_TITLE_FORMAT);
-	ospf6_lsdb_show(vty, level, NULL, NULL, &adv_router, o->lsdb);
+	ospf6_lsdb_show(vty, level, NULL, NULL, &adv_router, ospf6->lsdb);
 
 	vty_out(vty, "\n");
 	return CMD_SUCCESS;
@@ -379,15 +387,18 @@ DEFUN_HIDDEN (show_ipv6_ospf6_database_aggr_router,
 	uint16_t type = htons(OSPF6_LSTYPE_ROUTER);
 	int idx_ipv4 = 6;
 	struct listnode *i;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_lsdb *lsdb;
 	uint32_t adv_router = 0;
 
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
+
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &adv_router);
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
-		if (adv_router == o->router_id)
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
+		if (adv_router == ospf6->router_id)
 			lsdb = oa->lsdb_self;
 		else
 			lsdb = oa->lsdb;
@@ -435,13 +446,15 @@ DEFUN (show_ipv6_ospf6_database_type_id,
 	int idx_level = 7;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint16_t type = 0;
 	uint32_t id = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &id);
@@ -449,14 +462,14 @@ DEFUN (show_ipv6_ospf6_database_type_id,
 
 	switch (OSPF6_LSA_SCOPE(type)) {
 	case OSPF6_SCOPE_AREA:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 			ospf6_lsdb_show(vty, level, &type, &id, NULL, oa->lsdb);
 		}
 		break;
 
 	case OSPF6_SCOPE_LINKLOCAL:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 				vty_out(vty, IF_LSDB_TITLE_FORMAT,
 					oi->interface->name, oa->name);
@@ -468,7 +481,7 @@ DEFUN (show_ipv6_ospf6_database_type_id,
 
 	case OSPF6_SCOPE_AS:
 		vty_out(vty, AS_LSDB_TITLE_FORMAT);
-		ospf6_lsdb_show(vty, level, &type, &id, NULL, o->lsdb);
+		ospf6_lsdb_show(vty, level, &type, &id, NULL, ospf6->lsdb);
 		break;
 
 	default:
@@ -509,21 +522,22 @@ DEFUN (show_ipv6_ospf6_database_type_router,
 	int idx_level = 7;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint16_t type = 0;
 	uint32_t adv_router = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
 
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &adv_router);
 	level = parse_show_level(idx_level, argc, argv);
 
 	switch (OSPF6_LSA_SCOPE(type)) {
 	case OSPF6_SCOPE_AREA:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 			ospf6_lsdb_show(vty, level, &type, NULL, &adv_router,
 					oa->lsdb);
@@ -531,7 +545,7 @@ DEFUN (show_ipv6_ospf6_database_type_router,
 		break;
 
 	case OSPF6_SCOPE_LINKLOCAL:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 				vty_out(vty, IF_LSDB_TITLE_FORMAT,
 					oi->interface->name, oa->name);
@@ -543,7 +557,8 @@ DEFUN (show_ipv6_ospf6_database_type_router,
 
 	case OSPF6_SCOPE_AS:
 		vty_out(vty, AS_LSDB_TITLE_FORMAT);
-		ospf6_lsdb_show(vty, level, &type, NULL, &adv_router, o->lsdb);
+		ospf6_lsdb_show(vty, level, &type, NULL, &adv_router,
+				ospf6->lsdb);
 		break;
 
 	default:
@@ -576,23 +591,24 @@ DEFUN (show_ipv6_ospf6_database_id_router,
 	int idx_level = 7;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint32_t id = 0;
 	uint32_t adv_router = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
 	inet_pton(AF_INET, argv[idx_adv_rtr]->arg, &adv_router);
 	level = parse_show_level(idx_level, argc, argv);
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 		ospf6_lsdb_show(vty, level, NULL, &id, &adv_router, oa->lsdb);
 	}
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 			vty_out(vty, IF_LSDB_TITLE_FORMAT, oi->interface->name,
 				oa->name);
@@ -602,7 +618,7 @@ DEFUN (show_ipv6_ospf6_database_id_router,
 	}
 
 	vty_out(vty, AS_LSDB_TITLE_FORMAT);
-	ospf6_lsdb_show(vty, level, NULL, &id, &adv_router, o->lsdb);
+	ospf6_lsdb_show(vty, level, NULL, &id, &adv_router, ospf6->lsdb);
 
 	vty_out(vty, "\n");
 	return CMD_SUCCESS;
@@ -629,23 +645,25 @@ DEFUN (show_ipv6_ospf6_database_adv_router_linkstate_id,
 	int idx_level = 8;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint32_t id = 0;
 	uint32_t adv_router = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	inet_pton(AF_INET, argv[idx_adv_rtr]->arg, &adv_router);
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
 	level = parse_show_level(idx_level, argc, argv);
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 		ospf6_lsdb_show(vty, level, NULL, &id, &adv_router, oa->lsdb);
 	}
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 			vty_out(vty, IF_LSDB_TITLE_FORMAT, oi->interface->name,
 				oa->name);
@@ -655,7 +673,7 @@ DEFUN (show_ipv6_ospf6_database_adv_router_linkstate_id,
 	}
 
 	vty_out(vty, AS_LSDB_TITLE_FORMAT);
-	ospf6_lsdb_show(vty, level, NULL, &id, &adv_router, o->lsdb);
+	ospf6_lsdb_show(vty, level, NULL, &id, &adv_router, ospf6->lsdb);
 
 	vty_out(vty, "\n");
 	return CMD_SUCCESS;
@@ -688,14 +706,16 @@ DEFUN (show_ipv6_ospf6_database_type_id_router,
 	int idx_level = 7;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint16_t type = 0;
 	uint32_t id = 0;
 	uint32_t adv_router = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
@@ -704,7 +724,7 @@ DEFUN (show_ipv6_ospf6_database_type_id_router,
 
 	switch (OSPF6_LSA_SCOPE(type)) {
 	case OSPF6_SCOPE_AREA:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 			ospf6_lsdb_show(vty, level, &type, &id, &adv_router,
 					oa->lsdb);
@@ -712,7 +732,7 @@ DEFUN (show_ipv6_ospf6_database_type_id_router,
 		break;
 
 	case OSPF6_SCOPE_LINKLOCAL:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 				vty_out(vty, IF_LSDB_TITLE_FORMAT,
 					oi->interface->name, oa->name);
@@ -724,7 +744,8 @@ DEFUN (show_ipv6_ospf6_database_type_id_router,
 
 	case OSPF6_SCOPE_AS:
 		vty_out(vty, AS_LSDB_TITLE_FORMAT);
-		ospf6_lsdb_show(vty, level, &type, &id, &adv_router, o->lsdb);
+		ospf6_lsdb_show(vty, level, &type, &id, &adv_router,
+				ospf6->lsdb);
 		break;
 
 	default:
@@ -766,14 +787,16 @@ DEFUN (show_ipv6_ospf6_database_type_adv_router_linkstate_id,
 	int idx_level = 9;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint16_t type = 0;
 	uint32_t id = 0;
 	uint32_t adv_router = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
+
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_adv_rtr]->arg, &adv_router);
@@ -782,7 +805,7 @@ DEFUN (show_ipv6_ospf6_database_type_adv_router_linkstate_id,
 
 	switch (OSPF6_LSA_SCOPE(type)) {
 	case OSPF6_SCOPE_AREA:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 			ospf6_lsdb_show(vty, level, &type, &id, &adv_router,
 					oa->lsdb);
@@ -790,7 +813,7 @@ DEFUN (show_ipv6_ospf6_database_type_adv_router_linkstate_id,
 		break;
 
 	case OSPF6_SCOPE_LINKLOCAL:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 				vty_out(vty, IF_LSDB_TITLE_FORMAT,
 					oi->interface->name, oa->name);
@@ -802,7 +825,8 @@ DEFUN (show_ipv6_ospf6_database_type_adv_router_linkstate_id,
 
 	case OSPF6_SCOPE_AS:
 		vty_out(vty, AS_LSDB_TITLE_FORMAT);
-		ospf6_lsdb_show(vty, level, &type, &id, &adv_router, o->lsdb);
+		ospf6_lsdb_show(vty, level, &type, &id, &adv_router,
+				ospf6->lsdb);
 		break;
 
 	default:
@@ -829,21 +853,22 @@ DEFUN (show_ipv6_ospf6_database_self_originated,
 	int idx_level = 5;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint32_t adv_router = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	level = parse_show_level(idx_level, argc, argv);
-	adv_router = o->router_id;
+	adv_router = ospf6->router_id;
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 		ospf6_lsdb_show(vty, level, NULL, NULL, &adv_router, oa->lsdb);
 	}
 
-	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 			vty_out(vty, IF_LSDB_TITLE_FORMAT, oi->interface->name,
 				oa->name);
@@ -853,7 +878,7 @@ DEFUN (show_ipv6_ospf6_database_self_originated,
 	}
 
 	vty_out(vty, AS_LSDB_TITLE_FORMAT);
-	ospf6_lsdb_show(vty, level, NULL, NULL, &adv_router, o->lsdb);
+	ospf6_lsdb_show(vty, level, NULL, NULL, &adv_router, ospf6->lsdb);
 
 	vty_out(vty, "\n");
 	return CMD_SUCCESS;
@@ -885,22 +910,22 @@ DEFUN (show_ipv6_ospf6_database_type_self_originated,
 	int idx_level = 6;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint16_t type = 0;
 	uint32_t adv_router = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
-
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	type = parse_type_spec(idx_lsa, argc, argv);
 	level = parse_show_level(idx_level, argc, argv);
 
-	adv_router = o->router_id;
+	adv_router = ospf6->router_id;
 
 	switch (OSPF6_LSA_SCOPE(type)) {
 	case OSPF6_SCOPE_AREA:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 			ospf6_lsdb_show(vty, level, &type, NULL, &adv_router,
 					oa->lsdb);
@@ -908,7 +933,7 @@ DEFUN (show_ipv6_ospf6_database_type_self_originated,
 		break;
 
 	case OSPF6_SCOPE_LINKLOCAL:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 				vty_out(vty, IF_LSDB_TITLE_FORMAT,
 					oi->interface->name, oa->name);
@@ -920,7 +945,8 @@ DEFUN (show_ipv6_ospf6_database_type_self_originated,
 
 	case OSPF6_SCOPE_AS:
 		vty_out(vty, AS_LSDB_TITLE_FORMAT);
-		ospf6_lsdb_show(vty, level, &type, NULL, &adv_router, o->lsdb);
+		ospf6_lsdb_show(vty, level, &type, NULL, &adv_router,
+				ospf6->lsdb);
 		break;
 
 	default:
@@ -960,23 +986,23 @@ DEFUN (show_ipv6_ospf6_database_type_self_originated_linkstate_id,
 	int idx_level = 8;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint16_t type = 0;
 	uint32_t adv_router = 0;
 	uint32_t id = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
-
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
 	level = parse_show_level(idx_level, argc, argv);
-	adv_router = o->router_id;
+	adv_router = ospf6->router_id;
 
 	switch (OSPF6_LSA_SCOPE(type)) {
 	case OSPF6_SCOPE_AREA:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 			ospf6_lsdb_show(vty, level, &type, &id, &adv_router,
 					oa->lsdb);
@@ -984,7 +1010,7 @@ DEFUN (show_ipv6_ospf6_database_type_self_originated_linkstate_id,
 		break;
 
 	case OSPF6_SCOPE_LINKLOCAL:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 				vty_out(vty, IF_LSDB_TITLE_FORMAT,
 					oi->interface->name, oa->name);
@@ -996,7 +1022,8 @@ DEFUN (show_ipv6_ospf6_database_type_self_originated_linkstate_id,
 
 	case OSPF6_SCOPE_AS:
 		vty_out(vty, AS_LSDB_TITLE_FORMAT);
-		ospf6_lsdb_show(vty, level, &type, &id, &adv_router, o->lsdb);
+		ospf6_lsdb_show(vty, level, &type, &id, &adv_router,
+				ospf6->lsdb);
 		break;
 
 	default:
@@ -1035,23 +1062,23 @@ DEFUN (show_ipv6_ospf6_database_type_id_self_originated,
 	int idx_level = 7;
 	int level;
 	struct listnode *i, *j;
-	struct ospf6 *o = ospf6;
+	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	uint16_t type = 0;
 	uint32_t adv_router = 0;
 	uint32_t id = 0;
 
-	OSPF6_CMD_CHECK_RUNNING();
-
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
 	level = parse_show_level(idx_level, argc, argv);
-	adv_router = o->router_id;
+	adv_router = ospf6->router_id;
 
 	switch (OSPF6_LSA_SCOPE(type)) {
 	case OSPF6_SCOPE_AREA:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			vty_out(vty, AREA_LSDB_TITLE_FORMAT, oa->name);
 			ospf6_lsdb_show(vty, level, &type, &id, &adv_router,
 					oa->lsdb);
@@ -1059,7 +1086,7 @@ DEFUN (show_ipv6_ospf6_database_type_id_self_originated,
 		break;
 
 	case OSPF6_SCOPE_LINKLOCAL:
-		for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
+		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 			for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {
 				vty_out(vty, IF_LSDB_TITLE_FORMAT,
 					oi->interface->name, oa->name);
@@ -1071,7 +1098,8 @@ DEFUN (show_ipv6_ospf6_database_type_id_self_originated,
 
 	case OSPF6_SCOPE_AS:
 		vty_out(vty, AS_LSDB_TITLE_FORMAT);
-		ospf6_lsdb_show(vty, level, &type, &id, &adv_router, o->lsdb);
+		ospf6_lsdb_show(vty, level, &type, &id, &adv_router,
+				ospf6->lsdb);
 		break;
 
 	default:
@@ -1097,9 +1125,11 @@ DEFUN (show_ipv6_ospf6_border_routers,
 	uint32_t adv_router;
 	struct ospf6_route *ro;
 	struct prefix prefix;
+	struct ospf6 *ospf6 = NULL;
 
-	OSPF6_CMD_CHECK_RUNNING();
 
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	if (argc == 5) {
 		if (strmatch(argv[idx_ipv4]->text, "detail")) {
 			for (ro = ospf6_route_head(ospf6->brouter_table); ro;
@@ -1148,9 +1178,10 @@ DEFUN (show_ipv6_ospf6_linkstate,
 	int idx_ipv4 = 5;
 	struct listnode *node;
 	struct ospf6_area *oa;
+	struct ospf6 *ospf6 = NULL;
 
-	OSPF6_CMD_CHECK_RUNNING();
-
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
 		vty_out(vty, "\n        SPF Result in Area %s\n\n", oa->name);
 		ospf6_linkstate_table_show(vty, idx_ipv4, argc, argv,
@@ -1174,8 +1205,10 @@ DEFUN (show_ipv6_ospf6_linkstate_detail,
 	int idx_detail = 4;
 	struct listnode *node;
 	struct ospf6_area *oa;
+	struct ospf6 *ospf6 = NULL;
 
-	OSPF6_CMD_CHECK_RUNNING();
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
 		vty_out(vty, "\n        SPF Result in Area %s\n\n", oa->name);
@@ -1202,8 +1235,10 @@ static void ospf6_plist_del(struct prefix_list *plist)
 }
 
 /* Install ospf related commands. */
-void ospf6_init(void)
+void ospf6_init(struct thread_master *master)
 {
+	struct ospf6 *ospf6;
+
 	ospf6_top_init();
 	ospf6_area_init();
 	ospf6_interface_init();
@@ -1268,16 +1303,7 @@ void ospf6_init(void)
 		&show_ipv6_ospf6_database_type_self_originated_linkstate_id_cmd);
 	install_element(VIEW_NODE, &show_ipv6_ospf6_database_aggr_router_cmd);
 
+	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
 	if (ospf6 == NULL)
 		ospf6_instance_create(VRF_DEFAULT_NAME);
-}
-
-void ospf6_clean(void)
-{
-	if (!ospf6)
-		return;
-	if (ospf6->route_table)
-		ospf6_route_remove_all(ospf6->route_table);
-	if (ospf6->brouter_table)
-		ospf6_route_remove_all(ospf6->brouter_table);
 }

--- a/ospf6d/ospf6d.h
+++ b/ospf6d/ospf6d.h
@@ -88,7 +88,7 @@ extern struct thread_master *master;
 #define OSPF6_ROUTER_ID_STR "Specify Router-ID\n"
 #define OSPF6_LS_ID_STR     "Specify Link State ID\n"
 
-#define OSPF6_CMD_CHECK_RUNNING()                                              \
+#define OSPF6_CMD_CHECK_RUNNING(ospf6)                                         \
 	if (ospf6 == NULL) {                                                   \
 		vty_out(vty, "OSPFv3 is not running\n");                       \
 		return CMD_SUCCESS;                                            \
@@ -100,6 +100,6 @@ extern struct zebra_privs_t ospf6d_privs;
 extern struct route_node *route_prev(struct route_node *node);
 
 extern void ospf6_debug(void);
-extern void ospf6_init(void);
+extern void ospf6_init(struct thread_master *master);
 
 #endif /* OSPF6D_H */


### PR DESCRIPTION
1. All the changes are related to handle ospf6 with different vrf.
2. The dependancy of global ospf6 is removed.

Co-authored-by: Kaushik <kaushik@niralnetworks.com>
Signed-off-by: harios_niral <hari@niralnetworks.com>