### PR TITLE
bgpd: Use default VRF name if using `router bgp` command

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1227,7 +1227,7 @@ DEFUN_YANG_NOSH(router_bgp,
 		UNSET_FLAG(bgp->vrf_flags, BGP_VRF_AUTO);
 
 		snprintf(base_xpath, sizeof(base_xpath), FRR_BGP_GLOBAL_XPATH,
-			 "frr-bgp:bgp", "bgp", name ? name : VRF_DEFAULT_NAME);
+			 "frr-bgp:bgp", "bgp", VRF_DEFAULT_NAME);
 
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		snprintf(as_str, 12, "%d", bgp->as);


### PR DESCRIPTION
When we enter `router bgp` it enters non-VRF instance which is default.

No need to check for VRF/VIEW name, kinda dead code.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>