### PR TITLE
rip(ng)d: fix interfaces cleaning (leads to crash #6477)

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3422,6 +3422,8 @@ static void rip_distribute_update_all_wrapper(struct access_list *notused)
 /* Delete all added rip route. */
 void rip_clean(struct rip *rip)
 {
+	rip_interfaces_clean(rip);
+
 	if (rip->enabled)
 		rip_instance_disable(rip);
 
@@ -3443,7 +3445,6 @@ void rip_clean(struct rip *rip)
 	route_table_finish(rip->enable_network);
 	vector_free(rip->passive_nondefault);
 	list_delete(&rip->offset_list_master);
-	rip_interfaces_clean(rip);
 	route_table_finish(rip->distance_table);
 
 	RB_REMOVE(rip_instance_head, &rip_instances, rip);

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2533,6 +2533,8 @@ static void ripng_distribute_update_all_wrapper(struct access_list *notused)
 /* delete all the added ripng routes. */
 void ripng_clean(struct ripng *ripng)
 {
+	ripng_interface_clean(ripng);
+
 	if (ripng->enabled)
 		ripng_instance_disable(ripng);
 
@@ -2554,7 +2556,6 @@ void ripng_clean(struct ripng *ripng)
 	agg_table_finish(ripng->enable_network);
 	vector_free(ripng->passive_interface);
 	list_delete(&ripng->offset_list_master);
-	ripng_interface_clean(ripng);
 
 	RB_REMOVE(ripng_instance_head, &ripng_instances, ripng);
 	XFREE(MTYPE_RIPNG_VRF_NAME, ripng->vrf_name);


### PR DESCRIPTION
rip(ng)d_instance_disable unlinks the vrf from the instance which means
that rip(ng)_interfaces_clean never works, because rip(ng)->vrf is
always NULL there. This leads to the crash #6477.

Clean interfaces before disabling the instance to fix the issue.

Fixes #6477.