### PR TITLE
Isis cleanup

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -627,8 +627,8 @@ int isis_circuit_up(struct isis_circuit *circuit)
 	}
 
 	if (circuit->circ_type == CIRCUIT_T_BROADCAST) {
-		circuit->circuit_id = isis_circuit_id_gen(circuit->area->isis,
-							  circuit->interface);
+		circuit->circuit_id =
+			isis_circuit_id_gen(circuit->isis, circuit->interface);
 		if (!circuit->circuit_id) {
 			flog_err(
 				EC_ISIS_CONFIG,
@@ -812,7 +812,7 @@ void isis_circuit_down(struct isis_circuit *circuit)
 		circuit->lsp_regenerate_pending[0] = 0;
 		circuit->lsp_regenerate_pending[1] = 0;
 
-		_ISIS_CLEAR_FLAG(circuit->area->isis->circuit_ids_used,
+		_ISIS_CLEAR_FLAG(circuit->isis->circuit_ids_used,
 				 circuit->circuit_id);
 		circuit->circuit_id = 0;
 	} else if (circuit->circ_type == CIRCUIT_T_P2P) {

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -71,13 +71,14 @@ DEFINE_HOOK(isis_if_new_hook, (struct interface *ifp), (ifp))
 int isis_if_new_hook(struct interface *);
 int isis_if_delete_hook(struct interface *);
 
-struct isis_circuit *isis_circuit_new(void)
+struct isis_circuit *isis_circuit_new(struct isis *isis)
 {
 	struct isis_circuit *circuit;
 	int i;
 
 	circuit = XCALLOC(MTYPE_ISIS_CIRCUIT, sizeof(struct isis_circuit));
 
+	circuit->isis = isis;
 	/*
 	 * Default values
 	 */

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -164,7 +164,7 @@ struct isis_circuit {
 DECLARE_QOBJ_TYPE(isis_circuit)
 
 void isis_circuit_init(void);
-struct isis_circuit *isis_circuit_new(void);
+struct isis_circuit *isis_circuit_new(struct isis *isis);
 void isis_circuit_del(struct isis_circuit *circuit);
 struct isis_circuit *circuit_lookup_by_ifp(struct interface *ifp,
 					   struct list *list);

--- a/isisd/isis_dr.c
+++ b/isisd/isis_dr.c
@@ -225,7 +225,7 @@ int isis_dr_resign(struct isis_circuit *circuit, int level)
 	THREAD_TIMER_OFF(circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
 	circuit->lsp_regenerate_pending[level - 1] = 0;
 
-	memcpy(id, circuit->area->isis->sysid, ISIS_SYS_ID_LEN);
+	memcpy(id, circuit->isis->sysid, ISIS_SYS_ID_LEN);
 	LSP_PSEUDO_ID(id) = circuit->circuit_id;
 	LSP_FRAGMENT(id) = 0;
 	lsp_purge_pseudo(id, circuit, level);
@@ -278,7 +278,7 @@ int isis_dr_commence(struct isis_circuit *circuit, int level)
 			/* there was a dr elected, purge its LSPs from the db */
 			lsp_purge_pseudo(old_dr, circuit, level);
 		}
-		memcpy(circuit->u.bc.l1_desig_is, circuit->area->isis->sysid,
+		memcpy(circuit->u.bc.l1_desig_is, circuit->isis->sysid,
 		       ISIS_SYS_ID_LEN);
 		*(circuit->u.bc.l1_desig_is + ISIS_SYS_ID_LEN) =
 			circuit->circuit_id;
@@ -300,7 +300,7 @@ int isis_dr_commence(struct isis_circuit *circuit, int level)
 			/* there was a dr elected, purge its LSPs from the db */
 			lsp_purge_pseudo(old_dr, circuit, level);
 		}
-		memcpy(circuit->u.bc.l2_desig_is, circuit->area->isis->sysid,
+		memcpy(circuit->u.bc.l2_desig_is, circuit->isis->sysid,
 		       ISIS_SYS_ID_LEN);
 		*(circuit->u.bc.l2_desig_is + ISIS_SYS_ID_LEN) =
 			circuit->circuit_id;

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1611,7 +1611,7 @@ int lsp_generate_pseudo(struct isis_circuit *circuit, int level)
 	    || (circuit->u.bc.is_dr[level - 1] == 0))
 		return ISIS_ERROR;
 
-	memcpy(lsp_id, circuit->area->isis->sysid, ISIS_SYS_ID_LEN);
+	memcpy(lsp_id, circuit->isis->sysid, ISIS_SYS_ID_LEN);
 	LSP_FRAGMENT(lsp_id) = 0;
 	LSP_PSEUDO_ID(lsp_id) = circuit->circuit_id;
 
@@ -1671,7 +1671,7 @@ static int lsp_regenerate_pseudo(struct isis_circuit *circuit, int level)
 	    || (circuit->u.bc.is_dr[level - 1] == 0))
 		return ISIS_ERROR;
 
-	memcpy(lsp_id, circuit->area->isis->sysid, ISIS_SYS_ID_LEN);
+	memcpy(lsp_id, circuit->isis->sysid, ISIS_SYS_ID_LEN);
 	LSP_PSEUDO_ID(lsp_id) = circuit->circuit_id;
 	LSP_FRAGMENT(lsp_id) = 0;
 
@@ -1728,7 +1728,7 @@ static int lsp_l1_refresh_pseudo(struct thread *thread)
 
 	if ((circuit->u.bc.is_dr[0] == 0)
 	    || (circuit->is_type & IS_LEVEL_1) == 0) {
-		memcpy(id, circuit->area->isis->sysid, ISIS_SYS_ID_LEN);
+		memcpy(id, circuit->isis->sysid, ISIS_SYS_ID_LEN);
 		LSP_PSEUDO_ID(id) = circuit->circuit_id;
 		LSP_FRAGMENT(id) = 0;
 		lsp_purge_pseudo(id, circuit, IS_LEVEL_1);
@@ -1750,7 +1750,7 @@ static int lsp_l2_refresh_pseudo(struct thread *thread)
 
 	if ((circuit->u.bc.is_dr[1] == 0)
 	    || (circuit->is_type & IS_LEVEL_2) == 0) {
-		memcpy(id, circuit->area->isis->sysid, ISIS_SYS_ID_LEN);
+		memcpy(id, circuit->isis->sysid, ISIS_SYS_ID_LEN);
 		LSP_PSEUDO_ID(id) = circuit->circuit_id;
 		LSP_FRAGMENT(id) = 0;
 		lsp_purge_pseudo(id, circuit, IS_LEVEL_2);

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2135,11 +2135,11 @@ int lib_interface_isis_vrf_modify(struct nb_cb_modify_args *args)
 
 		vrf_name = yang_dnode_get_string(args->dnode, NULL);
 		circuit = circuit_scan_by_ifp(ifp);
-		if (circuit && circuit->area && circuit->area->isis
-		    && strcmp(circuit->area->isis->name, vrf_name)) {
+		if (circuit && circuit->area && circuit->isis
+		    && strcmp(circuit->isis->name, vrf_name)) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "ISIS circuit is already defined on vrf  %s",
-				 circuit->area->isis->name);
+				 circuit->isis->name);
 			return NB_ERR_VALIDATION;
 		}
 	}
@@ -2805,7 +2805,7 @@ int lib_interface_isis_mpls_ldp_sync_modify(struct nb_cb_modify_args *args)
 		if (circuit == NULL || circuit->area == NULL)
 			return NB_ERR_VALIDATION;
 
-		if (circuit->area->isis->vrf_id != VRF_DEFAULT) {
+		if (circuit->isis->vrf_id != VRF_DEFAULT) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "LDP-Sync only runs on Default VRF");
 			return NB_ERR_VALIDATION;
@@ -2817,7 +2817,7 @@ int lib_interface_isis_mpls_ldp_sync_modify(struct nb_cb_modify_args *args)
 	case NB_EV_APPLY:
 		circuit = nb_running_get_entry(args->dnode, NULL, true);
 		ldp_sync_enable = yang_dnode_get_bool(args->dnode, NULL);
-		isis = circuit->area->isis;
+		isis = circuit->isis;
 
 		if (circuit->ldp_sync_info == NULL)
 			isis_ldp_sync_if_init(circuit, isis);
@@ -2873,7 +2873,7 @@ int lib_interface_isis_mpls_holddown_modify(struct nb_cb_modify_args *args)
 		if (circuit == NULL || circuit->area == NULL)
 			return NB_ERR_VALIDATION;
 
-		if (circuit->area->isis->vrf_id != VRF_DEFAULT) {
+		if (circuit->isis->vrf_id != VRF_DEFAULT) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "LDP-Sync only runs on Default VRF");
 			return NB_ERR_VALIDATION;
@@ -2885,7 +2885,7 @@ int lib_interface_isis_mpls_holddown_modify(struct nb_cb_modify_args *args)
 	case NB_EV_APPLY:
 		circuit = nb_running_get_entry(args->dnode, NULL, true);
 		holddown = yang_dnode_get_uint16(args->dnode, NULL);
-		isis = circuit->area->isis;
+		isis = circuit->isis;
 
 		if (circuit->ldp_sync_info == NULL)
 			isis_ldp_sync_if_init(circuit, isis);
@@ -2912,7 +2912,7 @@ int lib_interface_isis_mpls_holddown_destroy(struct nb_cb_destroy_args *args)
 		    || circuit->area == NULL)
 			return NB_ERR_VALIDATION;
 
-		if (circuit->area->isis->vrf_id != VRF_DEFAULT) {
+		if (circuit->isis->vrf_id != VRF_DEFAULT) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "LDP-Sync only runs on Default VRF");
 			return NB_ERR_VALIDATION;
@@ -2923,7 +2923,7 @@ int lib_interface_isis_mpls_holddown_destroy(struct nb_cb_destroy_args *args)
 		break;
 	case NB_EV_APPLY:
 		circuit = nb_running_get_entry(args->dnode, NULL, true);
-		isis = circuit->area->isis;
+		isis = circuit->isis;
 		ldp_sync_info = circuit->ldp_sync_info;
 		UNSET_FLAG(ldp_sync_info->flags, LDP_SYNC_FLAG_HOLDDOWN);
 


### PR DESCRIPTION
1) Ensure that when circuit is created we have a isis pointer to set it too by making it part of the isis_circuit_new function.
2) shortcuircuit some of the long pointer chains we have to a much shorter one