### PR TITLE
staticd: To set the default value of blackhole type correctly

### DIFF
--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -283,6 +283,7 @@ static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
 
 		break;
 	case STATIC_BLACKHOLE:
+		nh->bh_type = STATIC_BLACKHOLE_NULL;
 		break;
 	case STATIC_IFNAME:
 		ifp = if_lookup_by_name(ifname, nh_svrf->vrf->vrf_id);


### PR DESCRIPTION
When nexthop is allocated, default value of blockhole type
was not getting set, this leads to below problem. The default
value should be in-sync with the deafult value in yang model.

c t
ip route 131.1.1.0/24 Null0

do show running-config
...
!
ip route 131.1.1.0/24 blackhole
!
end

Signed-off-by: vishaldhingra vdhingra@vmware.com