### PR TITLE
bgpd: allow bestpath to handle mutliple locally-originated paths

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -550,6 +550,7 @@ static int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 	bool same_esi;
 	bool old_proxy;
 	bool new_proxy;
+	bool new_origin, exist_origin;
 
 	*paths_eq = 0;
 
@@ -794,8 +795,12 @@ static int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 	 *  - BGP_ROUTE_AGGREGATE
 	 *  - BGP_ROUTE_REDISTRIBUTE
 	 */
-	if (!(new->sub_type == BGP_ROUTE_NORMAL ||
-	      new->sub_type == BGP_ROUTE_IMPORTED)) {
+	new_origin = !(new->sub_type == BGP_ROUTE_NORMAL ||
+		       new->sub_type == BGP_ROUTE_IMPORTED);
+	exist_origin = !(exist->sub_type == BGP_ROUTE_NORMAL ||
+			 exist->sub_type == BGP_ROUTE_IMPORTED);
+
+	if (new_origin && !exist_origin) {
 		*reason = bgp_path_selection_local_route;
 		if (debug)
 			zlog_debug(
@@ -804,8 +809,7 @@ static int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 		return 1;
 	}
 
-	if (!(exist->sub_type == BGP_ROUTE_NORMAL ||
-	      exist->sub_type == BGP_ROUTE_IMPORTED)) {
+	if (!new_origin && exist_origin) {
 		*reason = bgp_path_selection_local_route;
 		if (debug)
 			zlog_debug(


### PR DESCRIPTION
Current code in bgp bestpath selection would accept the newest
locally originated path as the best path.  Making the selection
non-deterministic.  Modify the code to always come to the
same bestpath conclusion when you have multiple locally originated
paths in bestpath selection.

Before:

eva# conf
eva(config)# router bgp 323
eva(config-router)# address-family ipv4 uni
eva(config-router-af)# redistribute connected
eva(config-router-af)# network 192.168.161.0/24
eva(config-router-af)# do show bgp ipv4 uni 192.168.161.0
BGP routing table entry for 192.168.161.0/24
Paths: (2 available, best #1, table default)
  Not advertised to any peer
  Local
    0.0.0.0(eva) from 0.0.0.0 (192.168.161.245)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, bestpath-from-AS Local, best (Origin)
      Last update: Wed Sep 16 15:03:03 2020
  Local
    0.0.0.0(eva) from 0.0.0.0 (192.168.161.245)
      Origin incomplete, metric 0, weight 32768, valid, sourced
      Last update: Wed Sep 16 15:02:52 2020
eva(config-router-af)# no redistribute connected
eva(config-router-af)# do show bgp ipv4 uni 192.168.161.0
BGP routing table entry for 192.168.161.0/24
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    0.0.0.0(eva) from 0.0.0.0 (192.168.161.245)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, bestpath-from-AS Local, best (First path received)
      Last update: Wed Sep 16 15:03:03 2020
eva(config-router-af)#  redistribute connected
eva(config-router-af)# do show bgp ipv4 uni 192.168.161.0
BGP routing table entry for 192.168.161.0/24
Paths: (2 available, best #2, table default)
  Not advertised to any peer
  Local
    0.0.0.0(eva) from 0.0.0.0 (192.168.161.245)
      Origin incomplete, metric 0, weight 32768, valid, sourced
      Last update: Wed Sep 16 15:03:32 2020
  Local
    0.0.0.0(eva) from 0.0.0.0 (192.168.161.245)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, bestpath-from-AS Local, best (Origin)
      Last update: Wed Sep 16 15:03:03 2020
eva(config-router-af)#

Notice the route choosen depends on order received

Fixed behavior:

eva# conf
eva(config)# router bgp 323
eva(config-router)# address-family ipv4 uni
eva(config-router-af)# redistribute connected
eva(config-router-af)# network 192.168.161.0/24
eva(config-router-af)# do show bgp ipv4 uni 192.168.161.0
BGP routing table entry for 192.168.161.0/24
Paths: (2 available, best #1, table default)
  Not advertised to any peer
  Local
    0.0.0.0(eva) from 0.0.0.0 (192.168.161.245)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, bestpath-from-AS Local, best (Origin)
      Last update: Wed Sep 16 15:03:03 2020
  Local
    0.0.0.0(eva) from 0.0.0.0 (192.168.161.245)
      Origin incomplete, metric 0, weight 32768, valid, sourced
      Last update: Wed Sep 16 15:02:52 2020
eva(config-router-af)# no redistribute connected
eva(config-router-af)# do show bgp ipv4 uni 192.168.161.0
BGP routing table entry for 192.168.161.0/24
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    0.0.0.0(eva) from 0.0.0.0 (192.168.161.245)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, bestpath-from-AS Local, best (First path received)
      Last update: Wed Sep 16 15:03:03 2020
eva(config-router-af)#  redistribute connected
eva(config-router-af)# do show bgp ipv4 uni 192.168.161.0
BGP routing table entry for 192.168.161.0/24
Paths: (2 available, best #2, table default)
  Not advertised to any peer
  Local
    0.0.0.0(eva) from 0.0.0.0 (192.168.161.245)
      Origin incomplete, metric 0, weight 32768, valid, sourced
      Last update: Wed Sep 16 15:03:32 2020
  Local
    0.0.0.0(eva) from 0.0.0.0 (192.168.161.245)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, bestpath-from-AS Local, best (Origin)
      Last update: Wed Sep 16 15:03:03 2020
eva(config-router-af)#

Ticket: CM-31490
Found-by: Trey Aspelund <taspelund@nvidia.com>
Signed-off-by: Donald Sharp <sharpd@nvidia.com>