### PR TITLE
tests: add `lsp-gen-interval 2` to isis configuration

### DIFF
--- a/tests/topotests/bfd-isis-topo1/rt1/isisd.conf
+++ b/tests/topotests/bfd-isis-topo1/rt1/isisd.conf
@@ -30,6 +30,7 @@ interface eth-rt3
  isis bfd
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0001.00
  is-type level-1
 !

--- a/tests/topotests/bfd-isis-topo1/rt2/isisd.conf
+++ b/tests/topotests/bfd-isis-topo1/rt2/isisd.conf
@@ -25,6 +25,7 @@ interface eth-rt5
  isis hello-multiplier 3
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0002.00
  is-type level-1
 !

--- a/tests/topotests/bfd-isis-topo1/rt3/isisd.conf
+++ b/tests/topotests/bfd-isis-topo1/rt3/isisd.conf
@@ -26,6 +26,7 @@ interface eth-rt4
  isis hello-multiplier 3
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0003.00
  is-type level-1
 !

--- a/tests/topotests/bfd-isis-topo1/rt4/isisd.conf
+++ b/tests/topotests/bfd-isis-topo1/rt4/isisd.conf
@@ -24,6 +24,7 @@ interface eth-rt5
  isis hello-multiplier 3
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0004.00
  is-type level-1
 !

--- a/tests/topotests/bfd-isis-topo1/rt5/isisd.conf
+++ b/tests/topotests/bfd-isis-topo1/rt5/isisd.conf
@@ -24,6 +24,7 @@ interface eth-rt4
  isis hello-multiplier 3
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0005.00
  is-type level-1
 !

--- a/tests/topotests/bfd-profiles-topo1/r3/isisd.conf
+++ b/tests/topotests/bfd-profiles-topo1/r3/isisd.conf
@@ -11,6 +11,7 @@ interface r3-eth1
  isis bfd profile fasttx
 !
 router isis lan
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0001.00
  redistribute ipv6 connected level-1
 !

--- a/tests/topotests/bfd-profiles-topo1/r4/isisd.conf
+++ b/tests/topotests/bfd-profiles-topo1/r4/isisd.conf
@@ -11,6 +11,7 @@ interface r4-eth0
  isis bfd profile DOES_NOT_EXIST
 !
 router isis lan
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0002.00
  redistribute ipv6 connected level-1
 !

--- a/tests/topotests/isis-sr-topo1/rt1/isisd.conf
+++ b/tests/topotests/isis-sr-topo1/rt1/isisd.conf
@@ -19,9 +19,9 @@ interface eth-sw1
  isis hello-multiplier 3
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0001.00
  is-type level-1
- lsp-gen-interval 2
  topology ipv6-unicast
  segment-routing on
  segment-routing global-block 16000 23999

--- a/tests/topotests/isis-sr-topo1/rt2/isisd.conf
+++ b/tests/topotests/isis-sr-topo1/rt2/isisd.conf
@@ -30,9 +30,9 @@ interface eth-rt4-2
  isis hello-multiplier 3
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0002.00
  is-type level-1
- lsp-gen-interval 2
  topology ipv6-unicast
  segment-routing on
  segment-routing global-block 16000 23999

--- a/tests/topotests/isis-sr-topo1/rt3/isisd.conf
+++ b/tests/topotests/isis-sr-topo1/rt3/isisd.conf
@@ -30,9 +30,9 @@ interface eth-rt5-2
  isis hello-multiplier 3
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0003.00
  is-type level-1
- lsp-gen-interval 2
  topology ipv6-unicast
  segment-routing on
  segment-routing global-block 17000 24999

--- a/tests/topotests/isis-sr-topo1/rt4/isisd.conf
+++ b/tests/topotests/isis-sr-topo1/rt4/isisd.conf
@@ -37,9 +37,9 @@ interface eth-rt6
  isis hello-multiplier 3
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0004.00
  is-type level-1
- lsp-gen-interval 2
  topology ipv6-unicast
  segment-routing on
  segment-routing global-block 16000 23999

--- a/tests/topotests/isis-sr-topo1/rt5/isisd.conf
+++ b/tests/topotests/isis-sr-topo1/rt5/isisd.conf
@@ -37,9 +37,9 @@ interface eth-rt6
  isis hello-multiplier 3
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0005.00
  is-type level-1
- lsp-gen-interval 2
  topology ipv6-unicast
  segment-routing on
  segment-routing global-block 16000 23999

--- a/tests/topotests/isis-sr-topo1/rt6/isisd.conf
+++ b/tests/topotests/isis-sr-topo1/rt6/isisd.conf
@@ -25,9 +25,9 @@ interface eth-rt5
  isis hello-multiplier 3
 !
 router isis 1
+ lsp-gen-interval 2
  net 49.0000.0000.0000.0006.00
  is-type level-1
- lsp-gen-interval 2
  topology ipv6-unicast
  segment-routing on
  segment-routing global-block 16000 23999

--- a/tests/topotests/isis-topo1-vrf/r1/isisd.conf
+++ b/tests/topotests/isis-topo1-vrf/r1/isisd.conf
@@ -8,6 +8,7 @@ interface r1-eth0
  isis circuit-type level-2-only
 !
 router isis 1 vrf r1-cust1 
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0000.00
  metric-style wide
  redistribute ipv4 connected level-2

--- a/tests/topotests/isis-topo1-vrf/r2/isisd.conf
+++ b/tests/topotests/isis-topo1-vrf/r2/isisd.conf
@@ -8,6 +8,7 @@ interface r2-eth0
  isis circuit-type level-2-only
 !
 router isis 1 vrf r2-cust1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0001.00
  metric-style wide
  redistribute ipv4 connected level-2

--- a/tests/topotests/isis-topo1-vrf/r3/isisd.conf
+++ b/tests/topotests/isis-topo1-vrf/r3/isisd.conf
@@ -13,6 +13,7 @@ interface r3-eth1
  isis circuit-type level-1
 !
 router isis 1 vrf r3-cust1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0002.00
  metric-style wide
  redistribute ipv4 connected level-1

--- a/tests/topotests/isis-topo1-vrf/r4/isisd.conf
+++ b/tests/topotests/isis-topo1-vrf/r4/isisd.conf
@@ -16,6 +16,7 @@ interface r4-eth1
  isis circuit-type level-1
 !
 router isis 1 vrf r4-cust1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0004.00
  metric-style wide
  redistribute ipv4 connected level-1

--- a/tests/topotests/isis-topo1-vrf/r5/isisd.conf
+++ b/tests/topotests/isis-topo1-vrf/r5/isisd.conf
@@ -13,6 +13,7 @@ interface r5-eth1
  isis circuit-type level-1
 !
 router isis 1 vrf r5-cust1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0005.00
  metric-style wide
  is-type level-1

--- a/tests/topotests/isis-topo1/r1/isisd.conf
+++ b/tests/topotests/isis-topo1/r1/isisd.conf
@@ -4,10 +4,12 @@ debug isis events
 debug isis update-packets
 interface r1-eth0
  ip router isis 1
+ isis hello-interval 2
  ipv6 router isis 1
  isis circuit-type level-2-only
 !
 router isis 1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0000.00
  metric-style wide
  redistribute ipv4 connected level-2

--- a/tests/topotests/isis-topo1/r2/isisd.conf
+++ b/tests/topotests/isis-topo1/r2/isisd.conf
@@ -4,10 +4,12 @@ debug isis events
 debug isis update-packets
 interface r2-eth0
  ip router isis 1
+ isis hello-interval 2
  ipv6 router isis 1
  isis circuit-type level-2-only
 !
 router isis 1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0001.00
  metric-style wide
  redistribute ipv4 connected level-2

--- a/tests/topotests/isis-topo1/r3/isisd.conf
+++ b/tests/topotests/isis-topo1/r3/isisd.conf
@@ -4,6 +4,7 @@ debug isis events
 debug isis update-packets
 interface r3-eth0
  ip router isis 1
+ isis hello-interval 2
  ipv6 router isis 1
  isis circuit-type level-2-only
 !
@@ -13,6 +14,7 @@ interface r3-eth1
  isis circuit-type level-1
 !
 router isis 1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0002.00
  metric-style wide
  redistribute ipv4 connected level-1

--- a/tests/topotests/isis-topo1/r4/isisd.conf
+++ b/tests/topotests/isis-topo1/r4/isisd.conf
@@ -4,6 +4,7 @@ debug isis events
 debug isis update-packets
 interface r4-eth0
  ip router isis 1
+ isis hello-interval 2
  ipv6 router isis 1
  isis circuit-type level-2-only
 !
@@ -13,6 +14,7 @@ interface r4-eth1
  isis circuit-type level-1
 !
 router isis 1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0004.00
  metric-style wide
  redistribute ipv4 connected level-1

--- a/tests/topotests/isis-topo1/r5/isisd.conf
+++ b/tests/topotests/isis-topo1/r5/isisd.conf
@@ -4,6 +4,7 @@ debug isis events
 debug isis update-packets
 interface r5-eth0
  ip router isis 1
+ isis hello-interval 2
  ipv6 router isis 1
  isis circuit-type level-1
 !
@@ -13,6 +14,7 @@ interface r5-eth1
  isis circuit-type level-1
 !
 router isis 1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0005.00
  metric-style wide
  is-type level-1

--- a/tests/topotests/ldp-sync-isis-topo1/r1/isisd.conf
+++ b/tests/topotests/ldp-sync-isis-topo1/r1/isisd.conf
@@ -6,6 +6,7 @@ debug isis update-packets
 debug isis ldp-sync
 !
 router isis 1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0001.00
  metric-style wide
  redistribute ipv4 connected level-1

--- a/tests/topotests/ldp-sync-isis-topo1/r2/isisd.conf
+++ b/tests/topotests/ldp-sync-isis-topo1/r2/isisd.conf
@@ -6,6 +6,7 @@ debug isis update-packets
 debug isis ldp-sync
 !
 router isis 1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0002.00
  metric-style wide
  redistribute ipv4 connected level-1

--- a/tests/topotests/ldp-sync-isis-topo1/r3/isisd.conf
+++ b/tests/topotests/ldp-sync-isis-topo1/r3/isisd.conf
@@ -6,6 +6,7 @@ debug isis update-packets
 debug isis ldp-sync
 !
 router isis 1
+ lsp-gen-interval 2
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0003.00
  metric-style wide
  redistribute ipv4 connected level-1


### PR DESCRIPTION
Force faster generation of lsp's and also cause the
networks to converge faster.  All affected tests
run faster now.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>