### PR TITLE
nhrp: Configure vici socket path using configure --with-vici-socket=/…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,6 +139,13 @@ AC_ARG_WITH([yangmodelsdir], [AS_HELP_STRING([--with-yangmodelsdir=DIR], [yang m
 ])
 AC_SUBST([yangmodelsdir])
 
+AC_ARG_WITH([vici-socket], [AS_HELP_STRING([--with-vici-socket=PATH], [vici-socket (/var/run/charon.vici)])], [
+	vici_socket="$withval"
+], [
+	vici_socket="/var/run/charon.vici"
+])
+AC_DEFINE_UNQUOTED([VICI_SOCKET], ["$vici_socket"], [StrongSWAN vici socket path])
+
 AC_ARG_ENABLE(tcmalloc,
 	AS_HELP_STRING([--enable-tcmalloc], [Turn on tcmalloc]),
 [case "${enableval}" in
@@ -2512,6 +2519,7 @@ group for vty sockets   : ${enable_vty_group}
 config file mask        : ${enable_configfile_mask}
 log file mask           : ${enable_logfile_mask}
 zebra protobuf enabled  : ${enable_protobuf:-no}
+vici socket path        : ${vici_socket}
 
 The above user and group must have read/write access to the state file
 directory and to the config files in the config file directory."

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -380,6 +380,10 @@ options to the configuration script.
    Look for YANG modules in `dir` [`prefix`/share/yang]. Note that the FRR
    YANG modules will be installed here.
 
+.. option:: --with-vici-socket <path>
+
+   Set StrongSWAN vici interface socket path [/var/run/charon.vici].
+
 Python dependency, documentation and tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/nhrpd/README.nhrpd
+++ b/nhrpd/README.nhrpd
@@ -126,7 +126,8 @@ Integration with strongSwan
 
 Contrary to opennhrp, Quagga/NHRP has tight integration with IKE daemon.
 Currently strongSwan is supported using the VICI protocol. strongSwan
-is connected using UNIX socket (hardcoded now as /var/run/charon.vici).
+is connected using UNIX socket (default /var/run/charon.vici use configure
+argument --with-vici-socket= to change).
 Thus nhrpd needs to be run as user that can open that file.
 
 Currently, you will need patched strongSwan. The working tree is at:

--- a/nhrpd/vici.c
+++ b/nhrpd/vici.c
@@ -478,7 +478,7 @@ static int vici_reconnect(struct thread *t)
 	if (vici->fd >= 0)
 		return 0;
 
-	fd = sock_open_unix("/var/run/charon.vici");
+	fd = sock_open_unix(VICI_SOCKET);
 	if (fd < 0) {
 		debugf(NHRP_DEBUG_VICI,
 		       "%s: failure connecting VICI socket: %s", __func__,


### PR DESCRIPTION
nhrp: Configure vici socket path using configure --with-vici-socket=/var/run/charon.vici (default)