### PR TITLE
*: Use proper semantics for turning off thread

### DIFF
--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -31,8 +31,7 @@
 
 #define BGP_TIMER_OFF(T)                                                       \
 	do {                                                                   \
-		if (T)                                                         \
-			THREAD_TIMER_OFF(T);                                   \
+		THREAD_TIMER_OFF(T);                                           \
 	} while (0)
 
 #define BGP_EVENT_ADD(P, E)                                                    \

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3960,8 +3960,7 @@ static void bgp_route_map_mark_update(const char *rmap_name)
 	/* If new update is received before the current timer timed out,
 	 * turn it off and start a new timer.
 	 */
-	if (bm->t_rmap_update != NULL)
-		THREAD_OFF(bm->t_rmap_update);
+	THREAD_OFF(bm->t_rmap_update);
 
 	/* rmap_update_timer of 0 means don't do route updates */
 	if (bm->rmap_update_timer) {

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -795,17 +795,14 @@ static void update_subgroup_delete(struct update_subgroup *subgrp)
 	if (subgrp->update_group)
 		UPDGRP_INCR_STAT(subgrp->update_group, subgrps_deleted);
 
-	if (subgrp->t_merge_check)
-		THREAD_OFF(subgrp->t_merge_check);
+	THREAD_OFF(subgrp->t_merge_check);
 
-	if (subgrp->t_coalesce)
-		THREAD_TIMER_OFF(subgrp->t_coalesce);
+	THREAD_TIMER_OFF(subgrp->t_coalesce);
 
 	bpacket_queue_cleanup(SUBGRP_PKTQ(subgrp));
 	subgroup_clear_table(subgrp);
 
-	if (subgrp->t_coalesce)
-		THREAD_TIMER_OFF(subgrp->t_coalesce);
+	THREAD_TIMER_OFF(subgrp->t_coalesce);
 	sync_delete(subgrp);
 
 	if (BGP_DEBUG(update_groups, UPDATE_GROUPS) && subgrp->update_group)

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -331,8 +331,7 @@ int eigrp_if_down(struct eigrp_interface *ei)
 		return 0;
 
 	/* Shutdown packet reception and sending */
-	if (ei->t_hello)
-		THREAD_OFF(ei->t_hello);
+	THREAD_OFF(ei->t_hello);
 
 	eigrp_if_stream_unset(ei);
 

--- a/isisd/isis_ldp_sync.c
+++ b/isisd/isis_ldp_sync.c
@@ -300,10 +300,7 @@ void isis_ldp_sync_ldp_fail(struct isis_circuit *circuit)
 	if (ldp_sync_info &&
 	    ldp_sync_info->enabled == LDP_IGP_SYNC_ENABLED &&
 	    ldp_sync_info->state != LDP_IGP_SYNC_STATE_NOT_REQUIRED) {
-		if (ldp_sync_info->t_holddown != NULL) {
-			THREAD_TIMER_OFF(ldp_sync_info->t_holddown);
-			ldp_sync_info->t_holddown = NULL;
-		}
+		THREAD_TIMER_OFF(ldp_sync_info->t_holddown);
 		ldp_sync_info->state = LDP_IGP_SYNC_STATE_REQUIRED_NOT_UP;
 		isis_ldp_sync_set_if_metric(circuit, true);
 	}
@@ -326,8 +323,7 @@ void isis_ldp_sync_if_remove(struct isis_circuit *circuit, bool remove)
 	ils_debug("ldp_sync: remove if %s", circuit->interface
 		  ? circuit->interface->name : "");
 
-	if (ldp_sync_info->t_holddown)
-		THREAD_TIMER_OFF(ldp_sync_info->t_holddown);
+	THREAD_TIMER_OFF(ldp_sync_info->t_holddown);
 	ldp_sync_info->state = LDP_IGP_SYNC_STATE_NOT_REQUIRED;
 	isis_ldp_sync_set_if_metric(circuit, true);
 	if (remove) {

--- a/lib/ldp_sync.c
+++ b/lib/ldp_sync.c
@@ -79,10 +79,8 @@ bool ldp_sync_if_down(struct ldp_sync_info *ldp_sync_info)
 	 *   update state
 	 */
 	if (ldp_sync_info && ldp_sync_info->enabled == LDP_IGP_SYNC_ENABLED) {
-		if (ldp_sync_info->t_holddown != NULL) {
-			THREAD_TIMER_OFF(ldp_sync_info->t_holddown);
-			ldp_sync_info->t_holddown = NULL;
-		}
+		THREAD_TIMER_OFF(ldp_sync_info->t_holddown);
+
 		if (ldp_sync_info->state == LDP_IGP_SYNC_STATE_REQUIRED_UP)
 			ldp_sync_info->state =
 				LDP_IGP_SYNC_STATE_REQUIRED_NOT_UP;

--- a/lib/spf_backoff.c
+++ b/lib/spf_backoff.c
@@ -132,7 +132,6 @@ static int spf_backoff_holddown_elapsed(struct thread *thread)
 {
 	struct spf_backoff *backoff = THREAD_ARG(thread);
 
-	backoff->t_holddown = NULL;
 	THREAD_TIMER_OFF(backoff->t_timetolearn);
 	timerclear(&backoff->first_event_time);
 	backoff->state = SPF_BACKOFF_QUIET;

--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -274,10 +274,7 @@ void ospf_ldp_sync_ldp_fail(struct interface *ifp)
 	if (ldp_sync_info &&
 	    ldp_sync_info->enabled == LDP_IGP_SYNC_ENABLED &&
 	    ldp_sync_info->state != LDP_IGP_SYNC_STATE_NOT_REQUIRED) {
-		if (ldp_sync_info->t_holddown != NULL) {
-			THREAD_TIMER_OFF(ldp_sync_info->t_holddown);
-			ldp_sync_info->t_holddown = NULL;
-		}
+		THREAD_TIMER_OFF(ldp_sync_info->t_holddown);
 		ldp_sync_info->state = LDP_IGP_SYNC_STATE_REQUIRED_NOT_UP;
 		ospf_if_recalculate_output_cost(ifp);
 	}
@@ -340,8 +337,7 @@ void ospf_ldp_sync_if_remove(struct interface *ifp, bool remove)
 	 *  restore cost
 	 */
 	ols_debug("ldp_sync: Removed from if %s", ifp->name);
-	if (ldp_sync_info->t_holddown)
-		THREAD_TIMER_OFF(ldp_sync_info->t_holddown);
+	THREAD_TIMER_OFF(ldp_sync_info->t_holddown);
 	ldp_sync_info->state = LDP_IGP_SYNC_STATE_NOT_REQUIRED;
 	ospf_if_recalculate_output_cost(ifp);
 	if (!CHECK_FLAG(ldp_sync_info->flags, LDP_SYNC_FLAG_IF_CONFIG))

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -117,8 +117,7 @@ static int pim_g2rp_list_compare(struct bsm_rpinfo *node1,
 
 static void pim_free_bsrp_node(struct bsm_rpinfo *bsrp_info)
 {
-	if (bsrp_info->g2rp_timer)
-		THREAD_OFF(bsrp_info->g2rp_timer);
+	THREAD_OFF(bsrp_info->g2rp_timer);
 	XFREE(MTYPE_PIM_BSRP_NODE, bsrp_info);
 }
 

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -804,9 +804,7 @@ void igmp_group_delete(struct igmp_group *group)
 		igmp_source_delete(src);
 	}
 
-	if (group->t_group_query_retransmit_timer) {
-		THREAD_OFF(group->t_group_query_retransmit_timer);
-	}
+	THREAD_OFF(group->t_group_query_retransmit_timer);
 
 	group_timer_off(group);
 	igmp_group_count_decr(group->group_igmp_sock);

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -585,8 +585,7 @@ static void restart_done(struct daemon *dmn)
 			dmn->name, state_str[dmn->state]);
 		return;
 	}
-	if (dmn->t_wakeup)
-		THREAD_OFF(dmn->t_wakeup);
+	THREAD_OFF(dmn->t_wakeup);
 	if (try_connect(dmn) < 0)
 		SET_WAKEUP_DOWN(dmn);
 }


### PR DESCRIPTION
We have this pattern in the code base:

if (thread)
	THREAD_OFF(thread);

If we look at THREAD_OFF we check to see if thread
is non-null too.  So we have a double check.
This is unnecessary.  Convert to just using THREAD_OFF

Signed-off-by: Donald Sharp <sharpd@nvidia.com>