### PR TITLE
bgpd: Correctly calculate threshold being reached

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3167,7 +3167,8 @@ bool bgp_maximum_prefix_overflow(struct peer *peer, afi_t afi, safi_t safi,
 		UNSET_FLAG(peer->af_sflags[afi][safi],
 			   PEER_STATUS_PREFIX_LIMIT);
 
-	if (pcount > (pcount * peer->pmax_threshold[afi][safi] / 100)) {
+	if (pcount
+	    > (peer->pmax[afi][safi] * peer->pmax_threshold[afi][safi] / 100)) {
 		if (CHECK_FLAG(peer->af_sflags[afi][safi],
 			       PEER_STATUS_PREFIX_THRESHOLD)
 		    && !always)


### PR DESCRIPTION
if (pcout > (pcount * peer->max_threshold[afi][safi] / 100 ))
is always true.  So the very first route received will always
trigger the warning.  We actually want the warning to happen
when we hit the threshold.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>