### PR TITLE
bgpd: fix show bgp neighbor routes for labeled-unicast

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12996,10 +12996,6 @@ static int bgp_show_neighbor_route(struct vty *vty, struct peer *peer,
 	if (use_json)
 		SET_FLAG(show_flags, BGP_SHOW_OPT_JSON);
 
-	/* labeled-unicast routes live in the unicast table */
-	if (safi == SAFI_LABELED_UNICAST)
-		safi = SAFI_UNICAST;
-
 	if (!peer || !peer->afc[afi][safi]) {
 		if (use_json) {
 			json_object *json_no = NULL;
@@ -13014,6 +13010,10 @@ static int bgp_show_neighbor_route(struct vty *vty, struct peer *peer,
 			vty_out(vty, "%% No such neighbor or address family\n");
 		return CMD_WARNING;
 	}
+
+	/* labeled-unicast routes live in the unicast table */
+	if (safi == SAFI_LABELED_UNICAST)
+		safi = SAFI_UNICAST;
 
 	return bgp_show(vty, peer->bgp, afi, safi, type, &peer->su, show_flags);
 }


### PR DESCRIPTION
bgp_show_neighbor_route() was rewriting safi from LU to uni
before checking if the peer was enabled for LU.  This resulted
in the peer's address-family check looking for unicast, which
would always fail for LU peers since unicast + LU are
mutually-exclusive AFIs.
This moves this safi reassignment after the peer AFI check,
ensuring that the peer's address-family check looks for LU
while the call to bgp_show() still uses uni.

Signed-off-by: Trey Aspelund <taspelund@cumulusnetworks.com>