### PR TITLE
bgpd: [7.5] Backport maximum-prefix and show bgp neighbor routes for LU fixes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12658,10 +12658,6 @@ static int bgp_show_neighbor_route(struct vty *vty, struct peer *peer,
 				   afi_t afi, safi_t safi,
 				   enum bgp_show_type type, bool use_json)
 {
-	/* labeled-unicast routes live in the unicast table */
-	if (safi == SAFI_LABELED_UNICAST)
-		safi = SAFI_UNICAST;
-
 	if (!peer || !peer->afc[afi][safi]) {
 		if (use_json) {
 			json_object *json_no = NULL;
@@ -12676,6 +12672,10 @@ static int bgp_show_neighbor_route(struct vty *vty, struct peer *peer,
 			vty_out(vty, "%% No such neighbor or address family\n");
 		return CMD_WARNING;
 	}
+
+	/* labeled-unicast routes live in the unicast table */
+	if (safi == SAFI_LABELED_UNICAST)
+		safi = SAFI_UNICAST;
 
 	return bgp_show(vty, peer->bgp, afi, safi, type, &peer->su, use_json,
 			false);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3167,7 +3167,8 @@ bool bgp_maximum_prefix_overflow(struct peer *peer, afi_t afi, safi_t safi,
 		UNSET_FLAG(peer->af_sflags[afi][safi],
 			   PEER_STATUS_PREFIX_LIMIT);
 
-	if (pcount > (pcount * peer->pmax_threshold[afi][safi] / 100)) {
+	if (pcount
+	    > (peer->pmax[afi][safi] * peer->pmax_threshold[afi][safi] / 100)) {
 		if (CHECK_FLAG(peer->af_sflags[afi][safi],
 			       PEER_STATUS_PREFIX_THRESHOLD)
 		    && !always)


### PR DESCRIPTION
b1823b69f602c4e9a10f15c92f1c3a2fcb836a30
7daf25a3a833b4b0353d3c6fa445ec9a52a30512