### PR TITLE
doc, zebra: remove keep_kernel option everywhere

### DIFF
--- a/doc/manpages/frr-zebra.rst
+++ b/doc/manpages/frr-zebra.rst
@@ -25,10 +25,6 @@ OPTIONS available for the |DAEMON| command:
 
    Runs in batch mode, zebra parses its config and exits.
 
-.. option:: -k, --keep_kernel
-
-   On startup, don't delete self inserted routes.
-
 .. option:: -s, --nl-bufsize <netlink-buffer-size>
 
    Set netlink receive buffer size. There are cases where zebra daemon can't handle flood of netlink messages from kernel. If you ever see "recvmsg overrun" messages in zebra log, you are in trouble.

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -87,7 +87,6 @@ uint32_t nl_rcvbufsize = 4194304;
 const struct option longopts[] = {
 	{"batch", no_argument, NULL, 'b'},
 	{"allow_delete", no_argument, NULL, 'a'},
-	{"keep_kernel", no_argument, NULL, 'k'},
 	{"socket", required_argument, NULL, 'z'},
 	{"ecmp", required_argument, NULL, 'e'},
 	{"retain", no_argument, NULL, 'r'},


### PR DESCRIPTION
remove all remaining pieces of code related to keep_kernel option