### PR TITLE
ospfd: fix "no ip ospf area"

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8232,7 +8232,7 @@ DEFUN (no_ip_ospf_area,
 	else
 		ospf = ospf_lookup_instance(instance);
 
-	if (ospf == NULL)
+	if (instance && ospf == NULL)
 		return CMD_NOT_MY_INSTANCE;
 
 	argv_find(argv, argc, "area", &idx);
@@ -8262,8 +8262,11 @@ DEFUN (no_ip_ospf_area,
 		ospf_if_update_params((ifp), (addr));
 	}
 
-	ospf_interface_area_unset(ospf, ifp);
-	ospf->if_ospf_cli_count--;
+	if (ospf) {
+		ospf_interface_area_unset(ospf, ifp);
+		ospf->if_ospf_cli_count--;
+	}
+
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
This commit fixes the following behavior:
```
nfware(config)# interface enp2s0
nfware(config-if)# ip ospf area 0
nfware(config-if)# no ip ospf area 0
% [ospfd]: command ignored as it targets an instance that is not running
```

We should be able to use the command without configuring the instance.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>