### PR TITLE
zebra: quiet the zebra opaque message debugs

### DIFF
--- a/zebra/zebra_opaque.c
+++ b/zebra/zebra_opaque.c
@@ -258,7 +258,7 @@ uint32_t zebra_opaque_enqueue_batch(struct stream_fifo *batch)
 
 	/* Schedule module pthread to process the batch */
 	if (counter > 0) {
-		if (IS_ZEBRA_DEBUG_RECV)
+		if (IS_ZEBRA_DEBUG_RECV && IS_ZEBRA_DEBUG_DETAIL)
 			zlog_debug("%s: received %u messages",
 				   __func__, counter);
 		thread_add_event(zo_info.master, process_messages, NULL, 0,
@@ -315,7 +315,7 @@ static int process_messages(struct thread *event)
 		goto done;
 	}
 
-	if (IS_ZEBRA_DEBUG_RECV)
+	if (IS_ZEBRA_DEBUG_RECV && IS_ZEBRA_DEBUG_DETAIL)
 		zlog_debug("%s: processing %u messages", __func__, i);
 
 	/*
@@ -381,7 +381,7 @@ static int dispatch_opq_messages(struct stream_fifo *msg_fifo)
 		/* Look up registered ZAPI client(s) */
 		reg = opq_reg_lookup(info.type);
 		if (reg == NULL) {
-			if (IS_ZEBRA_DEBUG_RECV)
+			if (IS_ZEBRA_DEBUG_RECV && IS_ZEBRA_DEBUG_DETAIL)
 				zlog_debug("%s: no registrations for opaque type %u, flags %#x",
 					   __func__, info.type, info.flags);
 			goto drop_it;
@@ -401,7 +401,8 @@ static int dispatch_opq_messages(struct stream_fifo *msg_fifo)
 				    client->session_id != info.session_id)
 					continue;
 
-				if (IS_ZEBRA_DEBUG_RECV)
+				if (IS_ZEBRA_DEBUG_RECV &&
+				    IS_ZEBRA_DEBUG_DETAIL)
 					zlog_debug("%s: found matching unicast client %s",
 						   __func__,
 						   opq_client2str(buf,
@@ -423,7 +424,8 @@ static int dispatch_opq_messages(struct stream_fifo *msg_fifo)
 						       client->instance,
 						       client->session_id);
 			if (zclient) {
-				if (IS_ZEBRA_DEBUG_RECV)
+				if (IS_ZEBRA_DEBUG_SEND &&
+				    IS_ZEBRA_DEBUG_DETAIL)
 					zlog_debug("%s: sending %s to client %s",
 						   __func__,
 						   (dup ? "dup" : "msg"),
@@ -444,7 +446,8 @@ static int dispatch_opq_messages(struct stream_fifo *msg_fifo)
 
 				zserv_release_client(zclient);
 			} else {
-				if (IS_ZEBRA_DEBUG_RECV)
+				if (IS_ZEBRA_DEBUG_RECV &&
+				    IS_ZEBRA_DEBUG_DETAIL)
 					zlog_debug("%s: type %u: no zclient for %s",
 						   __func__, info.type,
 						   opq_client2str(buf,
@@ -615,10 +618,6 @@ static int handle_opq_unregistration(const struct zmsghdr *hdr,
 
 	/* Is registration empty now? */
 	if (reg->clients == NULL) {
-		if (IS_ZEBRA_DEBUG_RECV)
-			zlog_debug("%s: free empty reg %u", __func__,
-				   reg->type);
-
 		opq_regh_del(&opq_reg_hash, reg);
 		opq_reg_free(&reg);
 	}


### PR DESCRIPTION
Put most of the debugs about opaque ZAPI messages under 'detail' to reduce the noise.
