### PR TITLE
pimd: checksum must be validated before accepting igmpv2 leave packet

### DIFF
--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -69,6 +69,12 @@
 
 #define IGMP_DEFAULT_VERSION (3)
 
+#define IGMP_GET_INT16(ptr, output)                                            \
+	do {                                                                   \
+		output = *(ptr) << 8;                                          \
+		output |= *((ptr) + 1);                                        \
+	} while (0)
+
 struct igmp_join {
 	struct in_addr group_addr;
 	struct in_addr source_addr;
@@ -115,6 +121,8 @@ void pim_igmp_general_query_on(struct igmp_sock *igmp);
 void pim_igmp_general_query_off(struct igmp_sock *igmp);
 void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp);
 void pim_igmp_other_querier_timer_off(struct igmp_sock *igmp);
+
+int igmp_validate_checksum(char *igmp_msg, int igmp_msg_len);
 
 #define IGMP_SOURCE_MASK_FORWARDING        (1 << 0)
 #define IGMP_SOURCE_MASK_DELETE            (1 << 1)

--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -121,6 +121,13 @@ int igmp_v2_recv_report(struct igmp_sock *igmp, struct in_addr from,
 		return -1;
 	}
 
+	if (igmp_validate_checksum(igmp_msg, igmp_msg_len) == -1) {
+		zlog_warn(
+			"Recv IGMPv2 REPORT from %s on %s: size=%d with invalid checksum",
+			from_str, ifp->name, igmp_msg_len);
+		return -1;
+	}
+
 	/* Collecting IGMP Rx stats */
 	igmp->rx_stats.report_v2++;
 
@@ -167,6 +174,13 @@ int igmp_v2_recv_leave(struct igmp_sock *igmp, struct in_addr from,
 		zlog_warn(
 			"Recv IGMPv2 LEAVE from %s on %s: size=%d other than correct=%d",
 			from_str, ifp->name, igmp_msg_len, IGMP_V12_MSG_SIZE);
+		return -1;
+	}
+
+	if (igmp_validate_checksum(igmp_msg, igmp_msg_len) == -1) {
+		zlog_warn(
+			"Recv IGMPv2 LEAVE from %s on %s with invalid checksum",
+			from_str, ifp->name);
 		return -1;
 	}
 


### PR DESCRIPTION
Issue: When an IGMPv2 leave packet is received, it did not validate
the checksum and hence the packet is accepted and group specific
query is sent out in response to this.

Due to this IGMP conformance test case 6.1 failed.

https://github.com/FRRouting/frr/issues/6868

Fix: Validate the checksum.

Signed-off-by: Mobashshera Rasool mrasool@vmware.com