### PR TITLE
ospfd: make GR reason string production safer

### DIFF
--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -50,26 +50,26 @@
 #include "ospfd/ospf_ism.h"
 #include "ospfd/ospf_gr_helper.h"
 
-const char *ospf_exit_reason_desc[] = {
+static const char * const ospf_exit_reason_desc[] = {
 	"Unknown reason",
 	"Helper inprogress",
 	"Topology Change",
-	"Grace timer expairy",
+	"Grace timer expiry",
 	"Successful graceful restart",
 };
 
-const char *ospf_restart_reason_desc[] = {
+static const char * const ospf_restart_reason_desc[] = {
 	"Unknown restart",
 	"Software restart",
 	"Software reload/upgrade",
 	"Switch to redundant control processor",
 };
 
-const char *ospf_rejected_reason_desc[] = {
+static const char * const ospf_rejected_reason_desc[] = {
 	"Unknown reason",
 	"Helper support disabled",
 	"Neighbour is not in FULL state",
-	"Supports only planned restart but received for unplanned",
+	"Supports only planned restart but received unplanned",
 	"Topo change due to change in lsa rxmt list",
 	"LSA age is more than Grace interval",
 };
@@ -115,6 +115,39 @@ static void ospf_enable_rtr_hash_destroy(struct ospf *ospf)
 	hash_clean(ospf->enable_rtr_list, ospf_disable_rtr_hash_free);
 	hash_free(ospf->enable_rtr_list);
 	ospf->enable_rtr_list = NULL;
+}
+
+/*
+ * GR exit reason strings
+ */
+const char *ospf_exit_reason2str(unsigned int reason)
+{
+	if (reason < array_size(ospf_exit_reason_desc))
+		return(ospf_exit_reason_desc[reason]);
+	else
+		return "Invalid reason";
+}
+
+/*
+ * GR restart reason strings
+ */
+const char *ospf_restart_reason2str(unsigned int reason)
+{
+	if (reason < array_size(ospf_restart_reason_desc))
+		return(ospf_restart_reason_desc[reason]);
+	else
+		return "Invalid reason";
+}
+
+/*
+ * GR rejected reason strings
+ */
+const char *ospf_rejected_reason2str(unsigned int reason)
+{
+	if (reason < array_size(ospf_rejected_reason_desc))
+		return(ospf_rejected_reason_desc[reason]);
+	else
+		return "Invalid reason";
 }
 
 /*
@@ -306,7 +339,8 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		zlog_debug(
 			"%s, Grace LSA received from %s, grace interval:%u, restartreason :%s",
 			__PRETTY_FUNCTION__, inet_ntoa(restart_addr),
-			grace_interval, ospf_restart_reason_desc[restart_reason]);
+			grace_interval,
+			ospf_restart_reason2str(restart_reason));
 
 	/* Incase of broadcast links, if RESTARTER is DR_OTHER,
 	 * grace LSA might be received from DR, so need to get
@@ -598,7 +632,7 @@ void ospf_gr_helper_exit(struct ospf_neighbor *nbr,
 	if (IS_DEBUG_OSPF_GR_HELPER)
 		zlog_debug("%s, Exiting from HELPER support to %s, due to %s",
 			   __PRETTY_FUNCTION__, inet_ntoa(nbr->src),
-			   ospf_exit_reason_desc[reason]);
+			   ospf_exit_reason2str(reason));
 
 	/* Reset helper status*/
 	nbr->gr_helper_info.gr_helper_status = OSPF_GR_NOT_HELPER;
@@ -948,7 +982,7 @@ static void show_ospf_grace_lsa_info(struct vty *vty, struct ospf_lsa *lsa)
 			sum += TLV_SIZE(tlvh);
 
 			vty_out(vty, "   Restart reason:%s\n",
-				ospf_restart_reason_desc[grReason->reason]);
+				ospf_restart_reason2str(grReason->reason));
 			break;
 		case RESTARTER_IP_ADDR_TYPE:
 			restartAddr = (struct grace_tlv_restart_addr *)tlvh;

--- a/ospfd/ospf_gr_helper.h
+++ b/ospfd/ospf_gr_helper.h
@@ -152,9 +152,9 @@ struct advRtr {
 #define OSPF_GR_FAILURE 0
 #define OSPF_GR_INVALID -1
 
-extern const char *ospf_exit_reason_desc[];
-extern const char *ospf_restart_reason_desc[];
-extern const char *ospf_rejected_reason_desc[];
+const char *ospf_exit_reason2str(unsigned int reason);
+const char *ospf_restart_reason2str(unsigned int reason);
+const char *ospf_rejected_reason2str(unsigned int reason);
 
 extern void ospf_gr_helper_init(struct ospf *ospf);
 extern void ospf_gr_helper_stop(struct ospf *ospf);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -5132,9 +5132,8 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 				"      Graceful Restart grace period time: %d (seconds).\n",
 				nbr->gr_helper_info.recvd_grace_period);
 			vty_out(vty, "      Graceful Restart reason: %s.\n",
-				ospf_restart_reason_desc
-					[nbr->gr_helper_info
-						 .gr_restart_reason]);
+				ospf_restart_reason2str(
+					nbr->gr_helper_info.gr_restart_reason));
 		} else {
 			vty_out(vty,
 				"      Graceful Restart HELPER Status : None\n");
@@ -5143,15 +5142,14 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 		if (nbr->gr_helper_info.rejected_reason
 		    != OSPF_HELPER_REJECTED_NONE)
 			vty_out(vty, "      Helper rejected reason: %s.\n",
-				ospf_rejected_reason_desc
-					[nbr->gr_helper_info.rejected_reason]);
+				ospf_rejected_reason2str(
+					nbr->gr_helper_info.rejected_reason));
 
 		if (nbr->gr_helper_info.helper_exit_reason
 		    != OSPF_GR_HELPER_EXIT_NONE)
 			vty_out(vty, "      Last helper exit reason: %s.\n\n",
-				ospf_exit_reason_desc
-					[nbr->gr_helper_info
-						 .helper_exit_reason]);
+				ospf_exit_reason2str(
+					nbr->gr_helper_info.helper_exit_reason));
 		else
 			vty_out(vty, "\n");
 	} else {
@@ -5165,25 +5163,24 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 				nbr->gr_helper_info.recvd_grace_period);
 			json_object_string_add(
 				json_neigh, "grRestartReason",
-				ospf_restart_reason_desc
-					[nbr->gr_helper_info
-						 .gr_restart_reason]);
+				ospf_restart_reason2str(
+					nbr->gr_helper_info.gr_restart_reason));
 		}
 
 		if (nbr->gr_helper_info.rejected_reason
 		    != OSPF_HELPER_REJECTED_NONE)
 			json_object_string_add(
 				json_neigh, "helperRejectReason",
-				ospf_rejected_reason_desc
-					[nbr->gr_helper_info.rejected_reason]);
+				ospf_rejected_reason2str(
+					nbr->gr_helper_info.rejected_reason));
 
 		if (nbr->gr_helper_info.helper_exit_reason
 		    != OSPF_GR_HELPER_EXIT_NONE)
 			json_object_string_add(
 				json_neigh, "helperExitReason",
-				ospf_exit_reason_desc
-					[nbr->gr_helper_info
-						 .helper_exit_reason]);
+				ospf_exit_reason2str(
+					nbr->gr_helper_info
+						 .helper_exit_reason));
 	}
 
 	ospf_bfd_show_info(vty, nbr->bfd_info, json_neigh, use_json, 0);
@@ -9308,7 +9305,7 @@ static int ospf_show_gr_helper_details(struct vty *vty, struct ospf *ospf,
 
 		if (ospf->last_exit_reason != OSPF_GR_HELPER_EXIT_NONE) {
 			vty_out(vty, " Last Helper exit Reason :%s\n",
-				ospf_exit_reason_desc[ospf->last_exit_reason]);
+				ospf_exit_reason2str(ospf->last_exit_reason));
 		}
 
 		if (ospf->active_restarter_cnt)
@@ -9337,7 +9334,7 @@ static int ospf_show_gr_helper_details(struct vty *vty, struct ospf *ospf,
 		if (ospf->last_exit_reason != OSPF_GR_HELPER_EXIT_NONE)
 			json_object_string_add(
 				json_vrf, "LastExitReason",
-				ospf_exit_reason_desc[ospf->last_exit_reason]);
+				ospf_exit_reason2str(ospf->last_exit_reason));
 
 		if (ospf->active_restarter_cnt)
 			json_object_int_add(json_vrf, "activeRestarterCnt",
@@ -9402,9 +9399,9 @@ static int ospf_show_gr_helper_details(struct vty *vty, struct ospf *ospf,
 							.t_grace_timer));
 					vty_out(vty,
 						"   Graceful Restart reason: %s.\n\n",
-						ospf_restart_reason_desc
-							[nbr->gr_helper_info
-							.gr_restart_reason]);
+						ospf_restart_reason2str(
+							nbr->gr_helper_info
+							.gr_restart_reason));
 					cnt++;
 				} else {
 					json_neigh = json_object_new_object();
@@ -9432,9 +9429,9 @@ static int ospf_show_gr_helper_details(struct vty *vty, struct ospf *ospf,
 							.t_grace_timer));
 					json_object_string_add(
 						json_neigh, "restartReason",
-						ospf_restart_reason_desc
-							[nbr->gr_helper_info
-							.gr_restart_reason]);
+						ospf_restart_reason2str(
+							nbr->gr_helper_info
+							.gr_restart_reason));
 					json_object_object_add(
 						json_neighbors,
 						inet_ntoa(nbr->src),


### PR DESCRIPTION
Use to-string functions for GR message codes instead of raw string array indexing; the reason-code values used can come in packets and are not validated (and are not trustworthy...)
