### PR TITLE
Abstract rn->lock accessing and cleanup usage to %pFX and %pRN

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2481,11 +2481,10 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 	bgp_dest_unlock_node(dest);
 
 	if (bgp_debug_zebra(NULL))
-		zlog_debug(
-			"... %s pi dest %p (l %d) pi %p (l %d, f 0x%x)",
-			new_pi ? "new" : "update",
-			dest, bgp_dest_to_rnode(dest)->lock,
-			pi, pi->lock, pi->flags);
+		zlog_debug("... %s pi dest %p (l %d) pi %p (l %d, f 0x%x)",
+			   new_pi ? "new" : "update", dest,
+			   bgp_dest_get_lock_count(dest), pi, pi->lock,
+			   pi->flags);
 
 	return ret;
 }
@@ -2620,10 +2619,9 @@ static int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 		return 0;
 
 	if (bgp_debug_zebra(NULL))
-		zlog_debug(
-			"... delete dest %p (l %d) pi %p (l %d, f 0x%x)",
-			dest, bgp_dest_to_rnode(dest)->lock,
-			pi, pi->lock, pi->flags);
+		zlog_debug("... delete dest %p (l %d) pi %p (l %d, f 0x%x)",
+			   dest, bgp_dest_get_lock_count(dest), pi, pi->lock,
+			   pi->flags);
 
 	/* Process for route leaking. */
 	vpn_leak_from_vrf_withdraw(bgp_get_default(), bgp_vrf, pi);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -216,7 +216,7 @@ void bgp_path_info_extra_free(struct bgp_path_info_extra **extra)
 			unsigned refcount;
 
 			bpi = bgp_path_info_lock(bpi);
-			refcount = bpi->net->lock - 1;
+			refcount = bgp_dest_get_lock_count(bpi->net) - 1;
 			bgp_dest_unlock_node((struct bgp_dest *)bpi->net);
 			if (!refcount)
 				bpi->net = NULL;

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -469,6 +469,11 @@ static inline const struct prefix *bgp_dest_get_prefix(const struct bgp_dest *de
 	return &dest->p;
 }
 
+static inline unsigned int bgp_dest_get_lock_count(const struct bgp_dest *dest)
+{
+	return dest->lock;
+}
+
 #ifdef _FRR_ATTRIBUTE_PRINTFRR
 #pragma FRR printfrr_ext "%pRN"  (struct bgp_node *)
 #pragma FRR printfrr_ext "%pBD"  (struct bgp_dest *)

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -265,11 +265,12 @@ void rfapiCheckRefcount(struct agg_node *rn, safi_t safi, int lockoffset)
 		}
 	}
 
-	if (count_bpi + count_monitor + lockoffset != rn->lock) {
+	if (count_bpi + count_monitor + lockoffset
+	    != agg_node_get_lock_count(rn)) {
 		vnc_zlog_debug_verbose(
 			"%s: count_bpi=%d, count_monitor=%d, lockoffset=%d, rn->lock=%d",
 			__func__, count_bpi, count_monitor, lockoffset,
-			rn->lock);
+			agg_node_get_lock_count(rn));
 		assert(0);
 	}
 }
@@ -3665,7 +3666,8 @@ void rfapiBgpInfoFilteredImportVPN(
 	}
 
 	vnc_zlog_debug_verbose("%s: inserting bpi %p at prefix %pRN #%d",
-			       __func__, info_new, rn, rn->lock);
+			       __func__, info_new, rn,
+			       agg_node_get_lock_count(rn));
 
 	rfapiBgpInfoAttachSorted(rn, info_new, afi, SAFI_MPLS_VPN);
 	rfapiItBiIndexAdd(rn, info_new);

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -802,7 +802,7 @@ int rfapiRibPreloadBi(
 	 */
 	trn = agg_node_get(rfd->rsp_times[afi], p); /* locks trn */
 	trn->info = (void *)(uintptr_t)bgp_clock();
-	if (trn->lock > 1)
+	if (agg_node_get_lock_count(trn) > 1)
 		agg_unlock_node(trn);
 
 	return 0;
@@ -1242,7 +1242,7 @@ callback:
 			trn = agg_node_get(rfd->rsp_times[afi],
 					   p); /* locks trn */
 			trn->info = (void *)(uintptr_t)bgp_clock();
-			if (trn->lock > 1)
+			if (agg_node_get_lock_count(trn) > 1)
 				agg_unlock_node(trn);
 
 			rfapiRfapiIpAddr2Str(&new->vn_address, buf, BUFSIZ);
@@ -1833,7 +1833,7 @@ int rfapiRibFTDFilterRecentPrefix(
 	 */
 	trn = agg_node_get(rfd->rsp_times[afi], p); /* locks trn */
 	prefix_time = (time_t)trn->info;
-	if (trn->lock > 1)
+	if (agg_node_get_lock_count(trn) > 1)
 		agg_unlock_node(trn);
 
 #ifdef DEBUG_FTD_FILTER_RECENT
@@ -2069,7 +2069,7 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		 */
 		trn = agg_node_get(rfd->rsp_times[afi], &pfx); /* locks trn */
 		trn->info = (void *)(uintptr_t)bgp_clock();
-		if (trn->lock > 1)
+		if (agg_node_get_lock_count(trn) > 1)
 			agg_unlock_node(trn);
 
 		{

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -751,7 +751,7 @@ void rfapiShowItNode(void *stream, struct agg_node *rn)
 	if (rfapiStream2Vty(stream, &fp, &vty, &out, &vty_newline) == 0)
 		return;
 
-	fp(out, "%pRN @%p #%d%s", rn, rn, rn->lock, HVTYNL);
+	fp(out, "%pRN @%p #%d%s", rn, rn, agg_node_get_lock_count(rn), HVTYNL);
 
 	for (bpi = rn->info; bpi; bpi = bpi->next) {
 		rfapiPrintBi(stream, bpi);
@@ -787,7 +787,8 @@ void rfapiShowImportTable(void *stream, const char *label, struct agg_table *rt,
 		}
 
 		fp(out, "%s/%d @%p #%d%s", buf, p->prefixlen, rn,
-		   rn->lock - 1, /* account for loop iterator locking */
+		   agg_node_get_lock_count(rn)
+			   - 1, /* account for loop iterator locking */
 		   HVTYNL);
 
 		for (bpi = rn->info; bpi; bpi = bpi->next) {

--- a/lib/agg_table.h
+++ b/lib/agg_table.h
@@ -161,6 +161,11 @@ agg_node_get_prefix(const struct agg_node *node)
 	return &node->p;
 }
 
+static inline unsigned int agg_node_get_lock_count(const struct agg_node *node)
+{
+	return node->lock;
+}
+
 #ifdef _FRR_ATTRIBUTE_PRINTFRR
 #pragma FRR printfrr_ext "%pRN"  (struct agg_node *)
 #endif

--- a/lib/if.c
+++ b/lib/if.c
@@ -826,7 +826,7 @@ DEFUN (show_address,
 			p = ifc->address;
 
 			if (p->family == AF_INET)
-				vty_out (vty, "%s/%d\n", inet_ntoa (p->u.prefix4), p->prefixlen);
+				vty_out (vty, "%pFX\n", p);
 		}
 	}
 	return CMD_SUCCESS;
@@ -858,7 +858,7 @@ DEFUN (show_address_vrf_all,
 				p = ifc->address;
 
 				if (p->family == AF_INET)
-					vty_out (vty, "%s/%d\n", inet_ntoa (p->u.prefix4), p->prefixlen);
+					vty_out (vty, "%pFX\n", p);
 			}
 		}
 	}
@@ -929,10 +929,9 @@ connected_log(struct connected *connected, char *str)
 	p = connected->address;
 
 	vrf = vrf_lookup_by_id(ifp->vrf_id);
-	snprintf(logbuf, sizeof(logbuf), "%s interface %s vrf %s(%u) %s %s/%d ",
+	snprintf(logbuf, sizeof(logbuf), "%s interface %s vrf %s(%u) %s %pFX ",
 		 str, ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id,
-		 prefix_family_str(p),
-		 inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ), p->prefixlen);
+		 prefix_family_str(p), p);
 
 	p = connected->destination;
 	if (p) {
@@ -949,14 +948,12 @@ nbr_connected_log(struct nbr_connected *connected, char *str)
 	struct prefix *p;
 	struct interface *ifp;
 	char logbuf[BUFSIZ];
-	char buf[BUFSIZ];
 
 	ifp = connected->ifp;
 	p = connected->address;
 
-	snprintf(logbuf, sizeof(logbuf), "%s interface %s %s %s/%d ", str,
-		 ifp->name, prefix_family_str(p),
-		 inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ), p->prefixlen);
+	snprintf(logbuf, sizeof(logbuf), "%s interface %s %s %pFX ", str,
+		 ifp->name, prefix_family_str(p), p);
 
 	zlog_info("%s", logbuf);
 }

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -901,14 +901,11 @@ static void __attribute__((unused)) prefix_list_print(struct prefix_list *plist)
 			printf("any %s\n", prefix_list_type_str(pentry));
 		else {
 			struct prefix *p;
-			char buf[BUFSIZ];
 
 			p = &pentry->prefix;
 
-			printf("  seq %lld %s %s/%d", (long long)pentry->seq,
-			       prefix_list_type_str(pentry),
-			       inet_ntop(p->family, p->u.val, buf, BUFSIZ),
-			       p->prefixlen);
+			printf("  seq %lld %s %pFX", (long long)pentry->seq,
+			       prefix_list_type_str(pentry), p);
 			if (pentry->ge)
 				printf(" ge %d", pentry->ge);
 			if (pentry->le)
@@ -1014,12 +1011,8 @@ static void vty_show_prefix_entry(struct vty *vty, afi_t afi,
 				vty_out(vty, "any");
 			else {
 				struct prefix *p = &pentry->prefix;
-				char buf[BUFSIZ];
 
-				vty_out(vty, "%s/%d",
-					inet_ntop(p->family, p->u.val, buf,
-						  BUFSIZ),
-					p->prefixlen);
+				vty_out(vty, "%pFX", p);
 
 				if (pentry->ge)
 					vty_out(vty, " ge %d", pentry->ge);
@@ -1121,12 +1114,8 @@ static int vty_show_prefix_list_prefix(struct vty *vty, afi_t afi,
 				vty_out(vty, "any");
 			else {
 				struct prefix *pf = &pentry->prefix;
-				char buf[BUFSIZ];
 
-				vty_out(vty, "%s/%d",
-					inet_ntop(pf->family, pf->u.val, buf,
-						  BUFSIZ),
-					pf->prefixlen);
+				vty_out(vty, "%pFX", pf);
 
 				if (pentry->ge)
 					vty_out(vty, " ge %d", pentry->ge);
@@ -1491,11 +1480,8 @@ int prefix_bgp_show_prefix_list(struct vty *vty, afi_t afi, char *name,
 		for (pentry = plist->head; pentry; pentry = pentry->next) {
 			struct prefix *p = &pentry->prefix;
 			char buf_a[BUFSIZ];
-			char buf_b[BUFSIZ];
 
-			snprintf(buf_a, sizeof(buf_a), "%s/%d",
-				 inet_ntop(p->family, p->u.val, buf_b, BUFSIZ),
-				 p->prefixlen);
+			snprintf(buf_a, sizeof(buf_a), "%pFX", p);
 
 			json_object_int_add(json_list, "seq", pentry->seq);
 			json_object_string_add(json_list, "seqPrefixListType",
@@ -1526,13 +1512,9 @@ int prefix_bgp_show_prefix_list(struct vty *vty, afi_t afi, char *name,
 
 		for (pentry = plist->head; pentry; pentry = pentry->next) {
 			struct prefix *p = &pentry->prefix;
-			char buf[BUFSIZ];
 
-			vty_out(vty, "   seq %" PRId64 " %s %s/%d",
-				pentry->seq,
-				prefix_list_type_str(pentry),
-				inet_ntop(p->family, p->u.val, buf, BUFSIZ),
-				p->prefixlen);
+			vty_out(vty, "   seq %" PRId64 " %s %pFX", pentry->seq,
+				prefix_list_type_str(pentry), p);
 
 			if (pentry->ge)
 				vty_out(vty, " ge %d", pentry->ge);

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -3176,7 +3176,8 @@ DEFUN_HIDDEN(show_route_map_pfx_tbl, show_route_map_pfx_tbl_cmd,
 				vty_out(vty, "    %s/%d (%d)\n",
 					inet_ntop(p->family, &p->u.prefix, buf,
 						  SU_ADDRSTRLEN),
-					p->prefixlen, rn->lock);
+					p->prefixlen,
+					route_node_get_lock_count(rn));
 
 				vty_out(vty, "(P) ");
 				prn = rn->parent;
@@ -3220,7 +3221,8 @@ DEFUN_HIDDEN(show_route_map_pfx_tbl, show_route_map_pfx_tbl_cmd,
 				vty_out(vty, "    %s/%d (%d)\n",
 					inet_ntop(p->family, &p->u.prefix, buf,
 						  SU_ADDRSTRLEN),
-					p->prefixlen, rn->lock);
+					p->prefixlen,
+					route_node_get_lock_count(rn));
 
 				vty_out(vty, "(P) ");
 				prn = rn->parent;

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -3156,8 +3156,6 @@ DEFUN_HIDDEN(show_route_map_pfx_tbl, show_route_map_pfx_tbl_cmd,
 	struct list *rmap_index_list = NULL;
 	struct listnode *ln = NULL, *nln = NULL;
 	struct route_map_index *index = NULL;
-	struct prefix *p = NULL, *pp = NULL;
-	char buf[SU_ADDRSTRLEN], pbuf[SU_ADDRSTRLEN];
 	uint8_t len = 54;
 
 	vty_out(vty, "%s:\n", frr_protonameinst);
@@ -3171,23 +3169,13 @@ DEFUN_HIDDEN(show_route_map_pfx_tbl, show_route_map_pfx_tbl_cmd,
 				"____________________");
 			for (rn = route_top(rm_pfx_tbl4); rn;
 			     rn = route_next(rn)) {
-				p = &rn->p;
-
-				vty_out(vty, "    %s/%d (%d)\n",
-					inet_ntop(p->family, &p->u.prefix, buf,
-						  SU_ADDRSTRLEN),
-					p->prefixlen,
+				vty_out(vty, "    %pRN (%d)\n", rn,
 					route_node_get_lock_count(rn));
 
 				vty_out(vty, "(P) ");
 				prn = rn->parent;
 				if (prn) {
-					pp = &prn->p;
-					vty_out(vty, "%s/%d\n",
-						inet_ntop(pp->family,
-							  &pp->u.prefix, pbuf,
-							  SU_ADDRSTRLEN),
-						pp->prefixlen);
+					vty_out(vty, "%pRN\n", prn);
 				}
 
 				vty_out(vty, "\n");
@@ -3216,23 +3204,13 @@ DEFUN_HIDDEN(show_route_map_pfx_tbl, show_route_map_pfx_tbl_cmd,
 				"____________________");
 			for (rn = route_top(rm_pfx_tbl6); rn;
 			     rn = route_next(rn)) {
-				p = &rn->p;
-
-				vty_out(vty, "    %s/%d (%d)\n",
-					inet_ntop(p->family, &p->u.prefix, buf,
-						  SU_ADDRSTRLEN),
-					p->prefixlen,
+				vty_out(vty, "    %pRN (%d)\n", rn,
 					route_node_get_lock_count(rn));
 
 				vty_out(vty, "(P) ");
 				prn = rn->parent;
 				if (prn) {
-					pp = &prn->p;
-					vty_out(vty, "%s/%d\n",
-						inet_ntop(pp->family,
-							  &pp->u.prefix, pbuf,
-							  SU_ADDRSTRLEN),
-						pp->prefixlen);
+					vty_out(vty, "%pRN\n", prn);
 				}
 
 				vty_out(vty, "\n");

--- a/lib/table.c
+++ b/lib/table.c
@@ -119,7 +119,8 @@ static void route_table_free(struct route_table *rt)
 		node = node->parent;
 
 		tmp_node->table->count--;
-		tmp_node->lock = 0; /* to cause assert if unlocked after this */
+		tmp_node->lock =
+			0; /* to cause assert if unlocked after this */
 		rn_hash_node_del(&rt->hash, tmp_node);
 		route_node_free(rt, tmp_node);
 

--- a/lib/table.h
+++ b/lib/table.h
@@ -262,6 +262,11 @@ static inline void route_unlock_node(struct route_node *node)
 		route_node_delete(node);
 }
 
+static inline unsigned int route_node_get_lock_count(struct route_node *node)
+{
+	return node->lock;
+}
+
 /*
  * route_table_iter_next
  *

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -714,7 +714,7 @@ struct ospf6_route *ospf6_route_add(struct ospf6_route *route,
 				"%s %p: route add %p cost %u: another path: prev %p, next %p node ref %u",
 				ospf6_route_table_name(table), (void *)table,
 				(void *)route, route->path.cost, (void *)prev,
-				(void *)next, node->lock);
+				(void *)next, route_node_get_lock_count(node));
 		else if (IS_OSPF6_DEBUG_ROUTE(TABLE))
 			zlog_debug("%s: route add cost %u: another path found",
 				   ospf6_route_table_name(table),

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -99,7 +99,6 @@ void ospf6_zebra_no_redistribute(int type, vrf_id_t vrf_id)
 static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
-	char buf[128];
 
 	c = zebra_interface_address_read(ZEBRA_INTERFACE_ADDRESS_ADD,
 					 zclient->ibuf, vrf_id);
@@ -107,11 +106,9 @@ static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
-		zlog_debug("Zebra Interface address add: %s %5s %s/%d",
+		zlog_debug("Zebra Interface address add: %s %5s %pFX",
 			   c->ifp->name, prefix_family_str(c->address),
-			   inet_ntop(c->address->family, &c->address->u.prefix,
-				     buf, sizeof(buf)),
-			   c->address->prefixlen);
+			   c->address);
 
 	if (c->address->family == AF_INET6) {
 		ospf6_interface_state_update(c->ifp);
@@ -123,7 +120,6 @@ static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 static int ospf6_zebra_if_address_update_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
-	char buf[128];
 
 	c = zebra_interface_address_read(ZEBRA_INTERFACE_ADDRESS_DELETE,
 					 zclient->ibuf, vrf_id);
@@ -131,11 +127,9 @@ static int ospf6_zebra_if_address_update_delete(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
-		zlog_debug("Zebra Interface address delete: %s %5s %s/%d",
+		zlog_debug("Zebra Interface address delete: %s %5s %pFX",
 			   c->ifp->name, prefix_family_str(c->address),
-			   inet_ntop(c->address->family, &c->address->u.prefix,
-				     buf, sizeof(buf)),
-			   c->address->prefixlen);
+			   c->address);
 
 	if (c->address->family == AF_INET6) {
 		ospf6_interface_connected_route_update(c->ifp);
@@ -325,7 +319,6 @@ void ospf6_zebra_route_update_remove(struct ospf6_route *request)
 void ospf6_zebra_add_discard(struct ospf6_route *request)
 {
 	struct zapi_route api;
-	char buf[INET6_ADDRSTRLEN];
 	struct prefix *dest = &request->prefix;
 
 	if (!CHECK_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
@@ -339,26 +332,20 @@ void ospf6_zebra_add_discard(struct ospf6_route *request)
 		zclient_route_send(ZEBRA_ROUTE_ADD, zclient, &api);
 
 		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
-			zlog_debug("Zebra: Route add discard %s/%d",
-				   inet_ntop(AF_INET6, &dest->u.prefix6, buf,
-					     INET6_ADDRSTRLEN),
-				   dest->prefixlen);
+			zlog_debug("Zebra: Route add discard %pFX", dest);
 
 		SET_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED);
 	} else {
 		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
 			zlog_debug(
-				"Zebra: Blackhole route present already %s/%d",
-				inet_ntop(AF_INET6, &dest->u.prefix6, buf,
-					  INET6_ADDRSTRLEN),
-				dest->prefixlen);
+				"Zebra: Blackhole route present already %pFX",
+				dest);
 	}
 }
 
 void ospf6_zebra_delete_discard(struct ospf6_route *request)
 {
 	struct zapi_route api;
-	char buf[INET6_ADDRSTRLEN];
 	struct prefix *dest = &request->prefix;
 
 	if (CHECK_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
@@ -372,19 +359,14 @@ void ospf6_zebra_delete_discard(struct ospf6_route *request)
 		zclient_route_send(ZEBRA_ROUTE_DELETE, zclient, &api);
 
 		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
-			zlog_debug("Zebra: Route delete discard %s/%d",
-				   inet_ntop(AF_INET6, &dest->u.prefix6, buf,
-					     INET6_ADDRSTRLEN),
-				   dest->prefixlen);
+			zlog_debug("Zebra: Route delete discard %pFX", dest);
 
 		UNSET_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED);
 	} else {
 		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
 			zlog_debug(
-				"Zebra: Blackhole route already deleted %s/%d",
-				inet_ntop(AF_INET6, &dest->u.prefix6, buf,
-					  INET6_ADDRSTRLEN),
-				dest->prefixlen);
+				"Zebra: Blackhole route already deleted %pFX",
+				dest);
 	}
 }
 

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -868,16 +868,16 @@ static void ospf_abr_announce_network(struct ospf *ospf, struct prefix_ipv4 *p,
 		if (!ospf_abr_should_accept(p, area)) {
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(
-					"ospf_abr_announce_network(): prefix %s/%d was denied by import-list",
-					inet_ntoa(p->prefix), p->prefixlen);
+					"ospf_abr_announce_network(): prefix %pFX was denied by import-list",
+					p);
 			continue;
 		}
 
 		if (!ospf_abr_plist_in_check(area, or, p)) {
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(
-					"ospf_abr_announce_network(): prefix %s/%d was denied by prefix-list",
-					inet_ntoa(p->prefix), p->prefixlen);
+					"ospf_abr_announce_network(): prefix %pFX was denied by prefix-list",
+					p);
 			continue;
 		}
 
@@ -893,8 +893,8 @@ static void ospf_abr_announce_network(struct ospf *ospf, struct prefix_ipv4 *p,
 		if (or->path_type == OSPF_PATH_INTER_AREA) {
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(
-					"ospf_abr_announce_network(): this is inter-area route to %s/%d",
-					inet_ntoa(p->prefix), p->prefixlen);
+					"ospf_abr_announce_network(): this is inter-area route to %pFX",
+					p);
 
 			if (!OSPF_IS_AREA_BACKBONE(area))
 				ospf_abr_announce_network_to_area(p, or->cost,
@@ -904,8 +904,8 @@ static void ospf_abr_announce_network(struct ospf *ospf, struct prefix_ipv4 *p,
 		if (or->path_type == OSPF_PATH_INTRA_AREA) {
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(
-					"ospf_abr_announce_network(): this is intra-area route to %s/%d",
-					inet_ntoa(p->prefix), p->prefixlen);
+					"ospf_abr_announce_network(): this is intra-area route to %pFX",
+					p);
 			if ((range = ospf_area_range_match(or_area, p))
 			    && !ospf_area_is_transit(area))
 				ospf_abr_update_aggregate(range, or, area);

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -53,8 +53,7 @@ void ospf_external_route_remove(struct ospf *ospf, struct prefix_ipv4 *p)
 	rn = route_node_lookup(ospf->old_external_route, (struct prefix *)p);
 	if (rn)
 		if ((or = rn->info)) {
-			zlog_info("Route[%s/%d]: external path deleted",
-				  inet_ntoa(p->prefix), p->prefixlen);
+			zlog_info("Route[%pFX]: external path deleted", p);
 
 			/* Remove route from zebra. */
 			if (or->type == OSPF_DESTINATION_NETWORK)
@@ -69,8 +68,7 @@ void ospf_external_route_remove(struct ospf *ospf, struct prefix_ipv4 *p)
 			return;
 		}
 
-	zlog_info("Route[%s/%d]: no such external path", inet_ntoa(p->prefix),
-		  p->prefixlen);
+	zlog_info("Route[%pFX]: no such external path", p);
 }
 
 /* Add an External info for AS-external-LSA. */

--- a/ospfd/ospf_ia.c
+++ b/ospfd/ospf_ia.c
@@ -76,8 +76,8 @@ static void ospf_ia_network_route(struct ospf *ospf, struct route_table *rt,
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
-			"ospf_ia_network_route(): processing summary route to %s/%d",
-			inet_ntoa(p->prefix), p->prefixlen);
+			"ospf_ia_network_route(): processing summary route to %pFX",
+			p);
 
 	/* Find a route to the same dest */
 	if ((rn1 = route_node_lookup(rt, (struct prefix *)p))) {
@@ -113,8 +113,8 @@ static void ospf_ia_network_route(struct ospf *ospf, struct route_table *rt,
 	else {    /* no route */
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
-				"ospf_ia_network_route(): add new route to %s/%d",
-				inet_ntoa(p->prefix), p->prefixlen);
+				"ospf_ia_network_route(): add new route to %pFX",
+				p);
 		ospf_route_add(rt, p, new_or, abr_or);
 	}
 }
@@ -129,8 +129,7 @@ static void ospf_ia_router_route(struct ospf *ospf, struct route_table *rtrs,
 	int ret;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("ospf_ia_router_route(): considering %s/%d",
-			   inet_ntoa(p->prefix), p->prefixlen);
+		zlog_debug("ospf_ia_router_route(): considering %pFX", p);
 	/* Find a route to the same dest */
 	rn = route_node_get(rtrs, (struct prefix *)p);
 

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2117,9 +2117,8 @@ void ospf_nssa_lsa_flush(struct ospf *ospf, struct prefix_ipv4 *p)
 			if (!lsa) {
 				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 					zlog_debug(
-						"LSA: There is no such AS-NSSA-LSA %s/%d in LSDB",
-						inet_ntoa(p->prefix),
-						p->prefixlen);
+						"LSA: There is no such AS-NSSA-LSA %pFX in LSDB",
+						p);
 				continue;
 			}
 			ospf_ls_retransmit_delete_nbr_area(area, lsa);
@@ -2139,15 +2138,14 @@ void ospf_external_lsa_flush(struct ospf *ospf, uint8_t type,
 	struct ospf_lsa *lsa;
 
 	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-		zlog_debug("LSA: Flushing AS-external-LSA %s/%d",
-			   inet_ntoa(p->prefix), p->prefixlen);
+		zlog_debug("LSA: Flushing AS-external-LSA %pFX", p);
 
 	/* First lookup LSA from LSDB. */
 	if (!(lsa = ospf_external_info_find_lsa(ospf, p))) {
 		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 			zlog_debug(
-				"LSA: There is no such AS-external-LSA %s/%d in LSDB",
-				inet_ntoa(p->prefix), p->prefixlen);
+				"LSA: There is no such AS-external-LSA %pFX in LSDB",
+				p);
 		return;
 	}
 
@@ -3363,8 +3361,8 @@ struct in_addr ospf_lsa_unique_id(struct ospf *ospf, struct ospf_lsdb *lsdb,
 		if (ip_masklen(al->mask) == p->prefixlen) {
 			if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
 				zlog_debug(
-					"ospf_lsa_unique_id(): Can't get Link State ID for %s/%d",
-					inet_ntoa(p->prefix), p->prefixlen);
+					"ospf_lsa_unique_id(): Can't get Link State ID for %pFX",
+					p);
 			/*	  id.s_addr = 0; */
 			id.s_addr = 0xffffffff;
 			return id;
@@ -3380,9 +3378,8 @@ struct in_addr ospf_lsa_unique_id(struct ospf *ospf, struct ospf_lsdb *lsdb,
 			if (lsa) {
 				if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
 					zlog_debug(
-						"ospf_lsa_unique_id(): Can't get Link State ID for %s/%d",
-						inet_ntoa(p->prefix),
-						p->prefixlen);
+						"ospf_lsa_unique_id(): Can't get Link State ID for %pFX",
+						p);
 				/* 	      id.s_addr = 0; */
 				id.s_addr = 0xffffffff;
 				return id;

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -285,7 +285,8 @@ void ospf_nbr_add_self(struct ospf_interface *oi, struct in_addr router_id)
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
 				"router_id %s already present in neighbor table. node refcount %u",
-				inet_ntoa(router_id), rn->lock);
+				inet_ntoa(router_id),
+				route_node_get_lock_count(rn));
 		route_unlock_node(rn);
 	} else
 		rn->info = oi->nbr_self;

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -989,9 +989,7 @@ int ospf_add_discard_route(struct ospf *ospf, struct route_table *rt,
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"ospf_add_discard_route(): adding %s/%d",
-			inet_ntoa(p->prefix), p->prefixlen);
+		zlog_debug("ospf_add_discard_route(): adding %pFX", p);
 
 	new_or = ospf_route_new();
 	new_or->type = OSPF_DESTINATION_DISCARD;
@@ -1014,9 +1012,7 @@ void ospf_delete_discard_route(struct ospf *ospf, struct route_table *rt,
 	struct ospf_route * or ;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"ospf_delete_discard_route(): deleting %s/%d",
-			inet_ntoa(p->prefix), p->prefixlen);
+		zlog_debug("ospf_delete_discard_route(): deleting %pFX", p);
 
 	rn = route_node_lookup(rt, (struct prefix *)p);
 

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3465,9 +3465,8 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 						    "ipAddressPrefixlen",
 						    oi->address->prefixlen);
 			} else
-				vty_out(vty, "  Internet Address %s/%d,",
-					inet_ntoa(oi->address->u.prefix4),
-					oi->address->prefixlen);
+				vty_out(vty, "  Internet Address %pFX,",
+					oi->address);
 
 			/* For Vlinks, showing the peer address is
 			 * probably more informative than the local

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -134,7 +134,7 @@ void pim_rp_init(struct pim_instance *pim)
 	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug(
 			"Allocated: %p for rp_info: %p(224.0.0.0/4) Lock: %d",
-			rn, rp_info, rn->lock);
+			rn, rp_info, route_node_get_lock_count(rn));
 }
 
 void pim_rp_free(struct pim_instance *pim)
@@ -254,7 +254,7 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
 		zlog_debug("Lookedup: %p for rp_info: %p(%s) Lock: %d", rn,
 			   rp_info,
 			   prefix2str(&rp_info->group, buf, sizeof(buf)),
-			   rn->lock);
+			   route_node_get_lock_count(rn));
 	}
 
 	route_unlock_node(rn);
@@ -649,7 +649,7 @@ int pim_rp_new(struct pim_instance *pim, struct in_addr rp_addr,
 		zlog_debug("Allocated: %p for rp_info: %p(%s) Lock: %d", rn,
 			   rp_info,
 			   prefix2str(&rp_info->group, buf, sizeof(buf)),
-			   rn->lock);
+			   route_node_get_lock_count(rn));
 	}
 
 	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
@@ -845,7 +845,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 					__func__, rn, rp_info,
 					prefix2str(&rp_info->group, buf,
 						   sizeof(buf)),
-					rn->lock);
+					route_node_get_lock_count(rn));
 			}
 			rn->info = NULL;
 			route_unlock_node(rn);

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -603,8 +603,7 @@ int rip_interface_address_add(ZAPI_CALLBACK_ARGS)
 
 	if (p->family == AF_INET) {
 		if (IS_RIP_DEBUG_ZEBRA)
-			zlog_debug("connected address %s/%d is added",
-				   inet_ntoa(p->u.prefix4), p->prefixlen);
+			zlog_debug("connected address %pFX is added", p);
 
 		rip_enable_apply(ifc->ifp);
 		/* Check if this prefix needs to be redistributed */
@@ -653,9 +652,8 @@ int rip_interface_address_delete(ZAPI_CALLBACK_ARGS)
 		p = ifc->address;
 		if (p->family == AF_INET) {
 			if (IS_RIP_DEBUG_ZEBRA)
-				zlog_debug("connected address %s/%d is deleted",
-					   inet_ntoa(p->u.prefix4),
-					   p->prefixlen);
+				zlog_debug("connected address %pFX is deleted",
+					   p);
 
 			hook_call(rip_ifaddr_del, ifc);
 

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -337,8 +337,7 @@ static int rip_filter(int rip_distribute, struct prefix_ipv4 *p,
 				      (struct prefix *)p)
 		    == FILTER_DENY) {
 			if (IS_RIP_DEBUG_PACKET)
-				zlog_debug("%s/%d filtered by distribute %s",
-					   inet_ntoa(p->prefix), p->prefixlen,
+				zlog_debug("%pFX filtered by distribute %s", p,
 					   inout);
 			return -1;
 		}
@@ -348,8 +347,7 @@ static int rip_filter(int rip_distribute, struct prefix_ipv4 *p,
 				      (struct prefix *)p)
 		    == PREFIX_DENY) {
 			if (IS_RIP_DEBUG_PACKET)
-				zlog_debug("%s/%d filtered by prefix-list %s",
-					   inet_ntoa(p->prefix), p->prefixlen,
+				zlog_debug("%pFX filtered by prefix-list %s", p,
 					   inout);
 			return -1;
 		}
@@ -367,9 +365,8 @@ static int rip_filter(int rip_distribute, struct prefix_ipv4 *p,
 				    == FILTER_DENY) {
 					if (IS_RIP_DEBUG_PACKET)
 						zlog_debug(
-							"%s/%d filtered by distribute %s",
-							inet_ntoa(p->prefix),
-							p->prefixlen, inout);
+							"%pFX filtered by distribute %s",
+							p, inout);
 					return -1;
 				}
 			}
@@ -383,9 +380,8 @@ static int rip_filter(int rip_distribute, struct prefix_ipv4 *p,
 				    == PREFIX_DENY) {
 					if (IS_RIP_DEBUG_PACKET)
 						zlog_debug(
-							"%s/%d filtered by prefix-list %s",
-							inet_ntoa(p->prefix),
-							p->prefixlen, inout);
+							"%pFX filtered by prefix-list %s",
+							p, inout);
 					return -1;
 				}
 			}
@@ -1603,8 +1599,7 @@ void rip_redistribute_add(struct rip *rip, int type, int sub_type,
 		(void)rip_ecmp_add(rip, &newinfo);
 
 	if (IS_RIP_DEBUG_EVENT) {
-		zlog_debug("Redistribute new prefix %s/%d",
-			   inet_ntoa(p->prefix), p->prefixlen);
+		zlog_debug("Redistribute new prefix %pFX", p);
 	}
 
 	rip_event(rip, RIP_TRIGGERED_UPDATE, 0);
@@ -1641,9 +1636,8 @@ void rip_redistribute_delete(struct rip *rip, int type, int sub_type,
 
 				if (IS_RIP_DEBUG_EVENT)
 					zlog_debug(
-						"Poison %s/%d on the interface %s with an infinity metric [delete]",
-						inet_ntoa(p->prefix),
-						p->prefixlen,
+						"Poison %pFX on the interface %s with an infinity metric [delete]",
+						p,
 						ifindex2ifname(
 							ifindex,
 							rip->vrf->vrf_id));
@@ -2266,9 +2260,8 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIP_DEBUG_PACKET)
 						zlog_debug(
-							"RIP %s/%d is filtered by route-map out",
-							inet_ntoa(p->prefix),
-							p->prefixlen);
+							"RIP %pFX is filtered by route-map out",
+							p);
 					continue;
 				}
 			}
@@ -2283,9 +2276,8 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIP_DEBUG_PACKET)
 						zlog_debug(
-							"%s/%d is filtered by route-map",
-							inet_ntoa(p->prefix),
-							p->prefixlen);
+							"%pFX is filtered by route-map",
+							p);
 					continue;
 				}
 			}
@@ -2674,9 +2666,8 @@ void rip_redistribute_withdraw(struct rip *rip, int type)
 						(struct prefix_ipv4 *)&rp->p;
 
 					zlog_debug(
-						"Poisone %s/%d on the interface %s with an infinity metric [withdraw]",
-						inet_ntoa(p->prefix),
-						p->prefixlen,
+						"Poisone %pFX on the interface %s with an infinity metric [withdraw]",
+						p,
 						ifindex2ifname(
 							rinfo->nh.ifindex,
 							rip->vrf->vrf_id));

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -375,8 +375,7 @@ int ripng_interface_address_add(ZAPI_CALLBACK_ARGS)
 		struct ripng_interface *ri = c->ifp->info;
 
 		if (IS_RIPNG_DEBUG_ZEBRA)
-			zlog_debug("RIPng connected address %s/%d add",
-				   inet6_ntoa(p->u.prefix6), p->prefixlen);
+			zlog_debug("RIPng connected address %pFX add", p);
 
 		/* Check is this prefix needs to be redistributed. */
 		ripng_apply_address_add(c);
@@ -428,7 +427,6 @@ int ripng_interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
 	struct prefix *p;
-	char buf[INET6_ADDRSTRLEN];
 
 	ifc = zebra_interface_address_read(ZEBRA_INTERFACE_ADDRESS_DELETE,
 					   zclient->ibuf, vrf_id);
@@ -439,10 +437,8 @@ int ripng_interface_address_delete(ZAPI_CALLBACK_ARGS)
 		if (p->family == AF_INET6) {
 			if (IS_RIPNG_DEBUG_ZEBRA)
 				zlog_debug(
-					"RIPng connected address %s/%d delete",
-					inet_ntop(AF_INET6, &p->u.prefix6, buf,
-						  INET6_ADDRSTRLEN),
-					p->prefixlen);
+					"RIPng connected address %pFX delete",
+					p);
 
 			/* Check wether this prefix needs to be removed. */
 			ripng_apply_address_del(ifc);

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -643,8 +643,7 @@ static int ripng_filter(int ripng_distribute, struct prefix_ipv6 *p,
 				      (struct prefix *)p)
 		    == FILTER_DENY) {
 			if (IS_RIPNG_DEBUG_PACKET)
-				zlog_debug("%s/%d filtered by distribute %s",
-					   inet6_ntoa(p->prefix), p->prefixlen,
+				zlog_debug("%pFX filtered by distribute %s", p,
 					   inout);
 			return -1;
 		}
@@ -654,8 +653,7 @@ static int ripng_filter(int ripng_distribute, struct prefix_ipv6 *p,
 				      (struct prefix *)p)
 		    == PREFIX_DENY) {
 			if (IS_RIPNG_DEBUG_PACKET)
-				zlog_debug("%s/%d filtered by prefix-list %s",
-					   inet6_ntoa(p->prefix), p->prefixlen,
+				zlog_debug("%pFX filtered by prefix-list %s", p,
 					   inout);
 			return -1;
 		}
@@ -673,9 +671,8 @@ static int ripng_filter(int ripng_distribute, struct prefix_ipv6 *p,
 				    == FILTER_DENY) {
 					if (IS_RIPNG_DEBUG_PACKET)
 						zlog_debug(
-							"%s/%d filtered by distribute %s",
-							inet6_ntoa(p->prefix),
-							p->prefixlen, inout);
+							"%pFX filtered by distribute %s",
+							p, inout);
 					return -1;
 				}
 			}
@@ -689,9 +686,8 @@ static int ripng_filter(int ripng_distribute, struct prefix_ipv6 *p,
 				    == PREFIX_DENY) {
 					if (IS_RIPNG_DEBUG_PACKET)
 						zlog_debug(
-							"%s/%d filtered by prefix-list %s",
-							inet6_ntoa(p->prefix),
-							p->prefixlen, inout);
+							"%pFX filtered by prefix-list %s",
+							p, inout);
 					return -1;
 				}
 			}
@@ -997,14 +993,12 @@ void ripng_redistribute_add(struct ripng *ripng, int type, int sub_type,
 	if (IS_RIPNG_DEBUG_EVENT) {
 		if (!nexthop)
 			zlog_debug(
-				"Redistribute new prefix %s/%d on the interface %s",
-				inet6_ntoa(p->prefix), p->prefixlen,
-				ifindex2ifname(ifindex, ripng->vrf->vrf_id));
+				"Redistribute new prefix %pFX on the interface %s",
+				p, ifindex2ifname(ifindex, ripng->vrf->vrf_id));
 		else
 			zlog_debug(
-				"Redistribute new prefix %s/%d with nexthop %s on the interface %s",
-				inet6_ntoa(p->prefix), p->prefixlen,
-				inet6_ntoa(*nexthop),
+				"Redistribute new prefix %pFX with nexthop %s on the interface %s",
+				p, inet6_ntoa(*nexthop),
 				ifindex2ifname(ifindex, ripng->vrf->vrf_id));
 	}
 
@@ -1047,9 +1041,8 @@ void ripng_redistribute_delete(struct ripng *ripng, int type, int sub_type,
 
 				if (IS_RIPNG_DEBUG_EVENT)
 					zlog_debug(
-						"Poisone %s/%d on the interface %s with an infinity metric [delete]",
-						inet6_ntoa(p->prefix),
-						p->prefixlen,
+						"Poisone %pFX on the interface %s with an infinity metric [delete]",
+						p,
 						ifindex2ifname(
 							ifindex,
 							ripng->vrf->vrf_id));
@@ -1091,9 +1084,8 @@ void ripng_redistribute_withdraw(struct ripng *ripng, int type)
 							agg_node_get_prefix(rp);
 
 					zlog_debug(
-						"Poisone %s/%d on the interface %s [withdraw]",
-						inet6_ntoa(p->prefix),
-						p->prefixlen,
+						"Poisone %pFX on the interface %s [withdraw]",
+						p,
 						ifindex2ifname(
 							rinfo->ifindex,
 							ripng->vrf->vrf_id));
@@ -1680,9 +1672,8 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIPNG_DEBUG_PACKET)
 						zlog_debug(
-							"RIPng %s/%d is filtered by route-map out",
-							inet6_ntoa(p->prefix),
-							p->prefixlen);
+							"RIPng %pFX is filtered by route-map out",
+							p);
 					continue;
 				}
 			}
@@ -1697,9 +1688,8 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIPNG_DEBUG_PACKET)
 						zlog_debug(
-							"RIPng %s/%d is filtered by route-map",
-							inet6_ntoa(p->prefix),
-							p->prefixlen);
+							"RIPng %pFX is filtered by route-map",
+							p);
 					continue;
 				}
 			}
@@ -1795,9 +1785,8 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIPNG_DEBUG_PACKET)
 						zlog_debug(
-							"RIPng %s/%d is filtered by route-map out",
-							inet6_ntoa(p->prefix),
-							p->prefixlen);
+							"RIPng %pFX is filtered by route-map out",
+							p);
 					continue;
 				}
 

--- a/tests/lib/test_srcdest_table.c
+++ b/tests/lib/test_srcdest_table.c
@@ -271,7 +271,7 @@ static void test_state_verify(struct test_state *test)
 						       associated with rn */
 				expected_lock++;
 
-			if (rn->lock != expected_lock)
+			if (route_node_get_lock_count(rn) != expected_lock)
 				test_failed(
 					test,
 					"Dest rnode lock count doesn't match expected count!",
@@ -283,7 +283,7 @@ static void test_state_verify(struct test_state *test)
 			    != NULL) /* The route node is not internal */
 				expected_lock++;
 
-			if (rn->lock != expected_lock) {
+			if (route_node_get_lock_count(rn) != expected_lock) {
 				srcdest_rnode_prefixes(
 					rn, (const struct prefix **)&dst_p,
 					(const struct prefix **)&src_p);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2294,7 +2294,7 @@ static void process_subq_route(struct listnode *lnode, uint8_t qindex)
   else
     {
       zlog_debug ("%s: called for route_node (%p, %d) with no ribs",
-                  __func__, rnode, rnode->lock);
+                  __func__, rnode, route_node_get_lock_count(rnode));
       zlog_backtrace(LOG_DEBUG);
     }
 #endif
@@ -2469,8 +2469,8 @@ int rib_queue_add(struct route_node *rn)
 	/* Pointless to queue a route_node with no RIB entries to add or remove
 	 */
 	if (!rnode_to_ribs(rn)) {
-		zlog_debug("%s: called for route_node (%p, %d) with no ribs",
-			   __func__, (void *)rn, rn->lock);
+		zlog_debug("%s: called for route_node (%p, %u) with no ribs",
+			   __func__, (void *)rn, route_node_get_lock_count(rn));
 		zlog_backtrace(LOG_DEBUG);
 		return -1;
 	}


### PR DESCRIPTION
See individual commits but there are two classes

a) Code is directly accessing the rn->lock data.  Abstract this to allow us to control/move around these data structures better in the future
b) lots of code was not using the new string formatters that were created.  Get everything converted over.