### PR TITLE
ospfd: Store neighbor Adjacency SID in SR database

### DIFF
--- a/ospfd/ospf_sr.h
+++ b/ospfd/ospf_sr.h
@@ -269,7 +269,7 @@ struct sr_node {
 
 	/* List of Prefix & Link advertise by this node */
 	struct list *ext_prefix; /* For Node SID */
-	struct list *ext_link;   /* For Adj and LAN SID */
+	struct list *ext_link;   /* For Adjacency SID */
 
 	/* Pointer to FRR SR-Node or NULL if it is not a neighbor */
 	struct sr_node *neighbor;


### PR DESCRIPTION
For TI-LFA, it is necessay to known the Adjacency SID advetise by the nieghbor
routers. However, the current Segment Routing code skip neighbor Adjacency SID
and thus, don't store them into the Segment Routing database.

This PR takes care of neighbor Adjacency SID by allowing to store them in the
Segment Routing database. Corresponding MPLS table entry is only configured if
the advertised Adjacency SID is global i.e. with L-Flag unset.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>