### PR TITLE
sharpd: Fix nexthop group name collision

### DIFF
--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -77,7 +77,8 @@ struct sharp_nhg {
 
 	uint32_t id;
 
-	char name[256];
+#define NHG_NAME_LEN 256
+	char name[NHG_NAME_LEN];
 
 	bool installed;
 };
@@ -95,7 +96,7 @@ struct sharp_nhg_rb_head nhg_head;
 static int sharp_nhg_compare_func(const struct sharp_nhg *a,
 				  const struct sharp_nhg *b)
 {
-	return strncmp(a->name, b->name, strlen(a->name));
+	return strncmp(a->name, b->name, NHG_NAME_LEN);
 }
 
 DECLARE_RBTREE_UNIQ(sharp_nhg_rb, struct sharp_nhg, mylistitem,


### PR DESCRIPTION
If you have two nexthop groups named
one
oneone

then the sharp daemon will treat them as the same nexthop
group.  This is because we are doign this:

static int sharp_nhg_compare_func(const struct sharp_nhg *a,
                                  const struct sharp_nhg *b)
{
        return strncmp(a->name, b->name, strlen(a->name));
}

The strlen should be the size of the array of name.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>