### PR TITLE
bgpd: Make the process_queue per bgp process

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -740,11 +740,12 @@ void bgp_update_delay_end(struct bgp *bgp)
 	bgp->main_zebra_update_hold = 1;
 	bgp->main_peers_update_hold = 1;
 
-	/* Resume the queue processing. This should trigger the event that would
-	   take
-	   care of processing any work that was queued during the read-only
-	   mode. */
-	work_queue_unplug(bm->process_main_queue);
+	/*
+	 * Resume the queue processing. This should trigger the event that would
+	 * take care of processing any work that was queued during the read-only
+	 * mode.
+	 */
+	work_queue_unplug(bgp->process_queue);
 }
 
 /**
@@ -997,7 +998,7 @@ static void bgp_update_delay_begin(struct bgp *bgp)
 	struct peer *peer;
 
 	/* Stop the processing of queued work. Enqueue shall continue */
-	work_queue_plug(bm->process_main_queue);
+	work_queue_plug(bgp->process_queue);
 
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))
 		peer->update_delay_over = 0;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -527,7 +527,7 @@ DECLARE_HOOK(bgp_process,
 /* Prototypes. */
 extern void bgp_rib_remove(struct bgp_dest *dest, struct bgp_path_info *pi,
 			   struct peer *peer, afi_t afi, safi_t safi);
-extern void bgp_process_queue_init(void);
+extern void bgp_process_queue_init(struct bgp *bgp);
 extern void bgp_route_init(void);
 extern void bgp_route_finish(void);
 extern void bgp_cleanup_routes(struct bgp *);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -122,9 +122,6 @@ struct bgp_master {
 	/* BGP thread master.  */
 	struct thread_master *master;
 
-	/* work queues */
-	struct work_queue *process_main_queue;
-
 	/* Listening sockets */
 	struct list *listen_sockets;
 
@@ -681,6 +678,9 @@ struct bgp {
 
 	/* Weighted ECMP related config. */
 	enum bgp_link_bw_handling lb_handling;
+
+	/* Process Queue for handling routes */
+	struct work_queue *process_queue;
 
 	QOBJ_FIELDS
 };


### PR DESCRIPTION
We currently have a global process queue for handling route
updates in bgp.  This is fine, in general, except there are
places and times where we plug the queue for no new work
during certain peer states of bgp update delay.  If we
happen to be processing multiple bgp instances on startup
why do we want to stop processing in vrf A when vrf B
is in a bit of a pickle?

Also this separation will allow us to start forward thinking
about how to fully integrate pthreads into route processing
in bgp.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>