### PR TITLE
ospfd: External LSA not flushed when area is configured as NSSA

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3648,3 +3648,34 @@ int ospf_lsa_refresh_walker(struct thread *t)
 
 	return 0;
 }
+
+/* Flush the LSAs for the specific area */
+void ospf_flush_lsa_from_area(struct ospf *ospf, struct in_addr area_id,
+			      int type)
+{
+	struct ospf_area *area;
+	struct route_node *rn;
+	struct ospf_lsa *lsa;
+
+	area = ospf_area_get(ospf, area_id);
+
+	switch (type) {
+	case OSPF_AS_EXTERNAL_LSA:
+		if ((area->external_routing == OSPF_AREA_NSSA) ||
+		    (area->external_routing == OSPF_AREA_STUB)) {
+			LSDB_LOOP (EXTERNAL_LSDB(ospf), rn, lsa)
+				if (IS_LSA_SELF(lsa) &&
+				    !(CHECK_FLAG(lsa->flags,
+						 OSPF_LSA_LOCAL_XLT)))
+					ospf_lsa_flush_area(lsa, area);
+		}
+		break;
+	case OSPF_AS_NSSA_LSA:
+		LSDB_LOOP (NSSA_LSDB(area), rn, lsa)
+			if (IS_LSA_SELF(lsa))
+				ospf_lsa_flush_area(lsa, area);
+		break;
+	default:
+		break;
+	}
+}

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -339,5 +339,6 @@ extern struct ospf_lsa *ospf_translated_nssa_refresh(struct ospf *,
 						     struct ospf_lsa *);
 extern struct ospf_lsa *ospf_translated_nssa_originate(struct ospf *,
 						       struct ospf_lsa *);
-
+extern void ospf_flush_lsa_from_area(struct ospf *ospf, struct in_addr area_id,
+				     int type);
 #endif /* _ZEBRA_OSPF_LSA_H */

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1445,6 +1445,8 @@ DEFUN (ospf_area_stub,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
+	/* Flush the external LSAs from the specified area */
+	ospf_flush_lsa_from_area(ospf, area_id, OSPF_AS_EXTERNAL_LSA);
 	ospf_area_no_summary_unset(ospf, area_id);
 
 	return CMD_SUCCESS;
@@ -1567,6 +1569,8 @@ static int ospf_area_nssa_cmd_handler(struct vty *vty, int argc,
 			ospf_area_no_summary_unset(ospf, area_id);
 	}
 
+	/* Flush the external LSA for the specified area */
+	ospf_flush_lsa_from_area(ospf, area_id, OSPF_AS_EXTERNAL_LSA);
 	ospf_schedule_abr_task(ospf);
 
 	return CMD_SUCCESS;
@@ -1672,6 +1676,8 @@ DEFUN (no_ospf_area_nssa,
 	VTY_GET_OSPF_AREA_ID_NO_BB("NSSA", area_id, format,
 				   argv[idx_ipv4_number]->arg);
 
+	/* Flush the NSSA LSA for the specified area */
+	ospf_flush_lsa_from_area(ospf, area_id, OSPF_AS_NSSA_LSA);
 	ospf_area_nssa_unset(ospf, area_id, argc);
 
 	ospf_schedule_abr_task(ospf);


### PR DESCRIPTION
Issue:
When the ospf area is changed from default to NSSA, the previously
advertised external LSAs are not removed from the neighbor.
The LSAs remain in database till maxage timeout.

Fix:
Advertise the external LSAs with age set to maxage and flood to the
NSSA area.

Signed-off-by: kssoman <somanks@gmail.com>