### PR TITLE
bgpd: aggregate-address suppress-map

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6257,6 +6257,10 @@ static bool aggr_suppress_path(struct bgp_aggregate *aggregate,
 
 	/* Only mark for processing if suppressed. */
 	if (listcount(pie->aggr_suppressors) == 1) {
+		if (BGP_DEBUG(update, UPDATE_OUT))
+			zlog_debug("aggregate-address suppressing: %pFX",
+				   bgp_dest_get_prefix(pi->net));
+
 		bgp_path_info_set_flag(pi->net, pi, BGP_PATH_ATTR_CHANGED);
 		return true;
 	}
@@ -6280,6 +6284,10 @@ static bool aggr_unsuppress_path(struct bgp_aggregate *aggregate,
 
 	/* Unsuppress and free extra memory if last item. */
 	if (listcount(pi->extra->aggr_suppressors) == 0) {
+		if (BGP_DEBUG(update, UPDATE_OUT))
+			zlog_debug("aggregate-address unsuppressing: %pFX",
+				   bgp_dest_get_prefix(pi->net));
+
 		list_delete(&pi->extra->aggr_suppressors);
 		bgp_path_info_set_flag(pi->net, pi, BGP_PATH_ATTR_CHANGED);
 		return true;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -110,8 +110,8 @@ struct bgp_path_info_extra {
 	/* Pointer to dampening structure.  */
 	struct bgp_damp_info *damp_info;
 
-	/* This route is suppressed with aggregation.  */
-	int suppress;
+	/** List of aggregations that suppress this path. */
+	struct list *aggr_suppressors;
 
 	/* Nexthop reachability check.  */
 	uint32_t igpmetric;
@@ -715,4 +715,8 @@ extern bool bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
 				       struct attr *attr, struct bgp_dest *dest);
 extern int bgp_evpn_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 			     struct bgp_path_info *exist, int *paths_eq);
+extern void bgp_aggregate_toggle_suppressed(struct bgp_aggregate *aggregate,
+					    struct bgp *bgp,
+					    const struct prefix *p, afi_t afi,
+					    safi_t safi, bool suppress);
 #endif /* _QUAGGA_BGP_ROUTE_H */

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -398,6 +398,11 @@ struct bgp_aggregate {
 #define AGGREGATE_MED_VALID(aggregate)                                         \
 	(((aggregate)->match_med && !(aggregate)->med_mismatched)              \
 	 || !(aggregate)->match_med)
+
+	/** Suppress map route map name (`NULL` when disabled). */
+	char *suppress_map_name;
+	/** Suppress map route map pointer. */
+	struct route_map *suppress_map;
 };
 
 #define BGP_NEXTHOP_AFI_FROM_NHLEN(nhlen)                                      \

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3746,6 +3746,7 @@ static void bgp_route_map_process_update(struct bgp *bgp, const char *rmap_name,
 					 int route_update)
 {
 	int i;
+	bool matched;
 	afi_t afi;
 	safi_t safi;
 	struct peer *peer;
@@ -3845,26 +3846,35 @@ static void bgp_route_map_process_update(struct bgp *bgp, const char *rmap_name,
 			if (!aggregate)
 				continue;
 
+			matched = false;
+
 			/* Update suppress map pointer. */
 			if (aggregate->suppress_map_name
 			    && strmatch(aggregate->suppress_map_name,
 					rmap_name)) {
-				if (!aggregate->rmap.map)
+				if (aggregate->rmap.map == NULL)
 					route_map_counter_increment(map);
 
 				aggregate->suppress_map = map;
+
+				bgp_aggregate_toggle_suppressed(
+					aggregate, bgp, bgp_dest_get_prefix(bn),
+					afi, safi, false);
+
+				matched = true;
 			}
 
-			if (!aggregate->rmap.name
-			    || (strcmp(rmap_name, aggregate->rmap.name) != 0))
-				continue;
+			if (aggregate->rmap.name
+			    && strmatch(rmap_name, aggregate->rmap.name)) {
+				if (aggregate->rmap.map == NULL)
+					route_map_counter_increment(map);
 
-			if (!aggregate->rmap.map)
-				route_map_counter_increment(map);
+				aggregate->rmap.map = map;
 
-			aggregate->rmap.map = map;
+				matched = true;
+			}
 
-			if (route_update) {
+			if (matched && route_update) {
 				const struct prefix *bn_p =
 					bgp_dest_get_prefix(bn);
 

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3845,6 +3845,16 @@ static void bgp_route_map_process_update(struct bgp *bgp, const char *rmap_name,
 			if (!aggregate)
 				continue;
 
+			/* Update suppress map pointer. */
+			if (aggregate->suppress_map_name
+			    && strmatch(aggregate->suppress_map_name,
+					rmap_name)) {
+				if (!aggregate->rmap.map)
+					route_map_counter_increment(map);
+
+				aggregate->suppress_map = map;
+			}
+
 			if (!aggregate->rmap.name
 			    || (strcmp(rmap_name, aggregate->rmap.name) != 0))
 				continue;

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1005,6 +1005,12 @@ Route Aggregation-IPv4 Address Family
    Configure the aggregated address to only be created when the routes MED
    match, otherwise no aggregated route will be created.
 
+.. index:: aggregate-address A.B.C.D/M suppress-map NAME
+.. clicmd:: aggregate-address A.B.C.D/M suppress-map NAME
+
+   Similar to `summary-only`, but will only suppress more specific routes that
+   are matched by the selected route-map.
+
 .. index:: no aggregate-address A.B.C.D/M
 .. clicmd:: no aggregate-address A.B.C.D/M
 
@@ -1063,6 +1069,11 @@ Route Aggregation-IPv6 Address Family
    Configure the aggregated address to only be created when the routes MED
    match, otherwise no aggregated route will be created.
 
+.. index:: aggregate-address X:X::X:X/M suppress-map NAME
+.. clicmd:: aggregate-address X:X::X:X/M suppress-map NAME
+
+   Similar to `summary-only`, but will only suppress more specific routes that
+   are matched by the selected route-map.
 
 .. index:: no aggregate-address X:X::X:X/M
 .. clicmd:: no aggregate-address X:X::X:X/M

--- a/tests/topotests/bgp_aggregate_address_topo1/peer1/exabgp.cfg
+++ b/tests/topotests/bgp_aggregate_address_topo1/peer1/exabgp.cfg
@@ -13,5 +13,9 @@ neighbor 10.0.0.1 {
     route 192.168.1.1/32 next-hop 10.0.0.2 med 10;
     route 192.168.1.2/32 next-hop 10.0.0.2 med 10;
     route 192.168.1.3/32 next-hop 10.0.0.2 med 20;
+
+    route 192.168.2.1/32 next-hop 10.0.0.2;
+    route 192.168.2.2/32 next-hop 10.0.0.2;
+    route 192.168.2.3/32 next-hop 10.0.0.2;
   }
 }

--- a/tests/topotests/bgp_aggregate_address_topo1/r1/bgpd.conf
+++ b/tests/topotests/bgp_aggregate_address_topo1/r1/bgpd.conf
@@ -1,3 +1,5 @@
+debug bgp updates
+!
 access-list acl-sup-one seq 5 permit 192.168.2.1/32
 access-list acl-sup-one seq 10 deny any
 !

--- a/tests/topotests/bgp_aggregate_address_topo1/r1/bgpd.conf
+++ b/tests/topotests/bgp_aggregate_address_topo1/r1/bgpd.conf
@@ -1,3 +1,18 @@
+access-list acl-sup-one seq 5 permit 192.168.2.1/32
+access-list acl-sup-one seq 10 deny any
+!
+access-list acl-sup-two seq 5 permit 192.168.2.2/32
+access-list acl-sup-two seq 10 deny any
+!
+access-list acl-sup-three seq 5 permit 192.168.2.3/32
+access-list acl-sup-three seq 10 deny any
+!
+route-map rm-sup-one permit 10
+ match ip address acl-sup-one
+!
+route-map rm-sup-two permit 10
+ match ip address acl-sup-two
+!
 router bgp 65000
   no bgp ebgp-requires-policy
   neighbor 10.0.0.2 remote-as 65001
@@ -8,5 +23,6 @@ router bgp 65000
    redistribute connected
    aggregate-address 192.168.0.0/24 matching-MED-only
    aggregate-address 192.168.1.0/24 matching-MED-only
+   aggregate-address 192.168.2.0/24 suppress-map rm-sup-one
   exit-address-family
 !


### PR DESCRIPTION
Summary
------------

New BGP command option for aggregate-address: `suppress-map`. `suppress-map` works similary to `summary-only` but instead of suppressing all more specific routes, it will only suppress what is matched on the specified route map.


ToDo
------

* [x] A bit more of local testing