### PR TITLE
yang: fix circular chain of leafrefs

### DIFF
--- a/yang/frr-nexthop.yang
+++ b/yang/frr-nexthop.yang
@@ -275,7 +275,7 @@ module frr-nexthop {
       description
         "List of nexthop groups, each contains group of nexthops";
       leaf name {
-        type nexthop-group-ref;
+        type string;
         description
           "The nexthop-group name.";
       }


### PR DESCRIPTION
Fix the following libyang error when trying to load the "frr-nexthop"
module explicitly (e.g. using the `gen_northbound_callbacks` tool):

```
libyang: A circular chain of leafrefs detected. (/frr-nexthop:frr-nexthop-group/nexthop-groups/name)
libyang: Invalid value "frr-nexthop-grouping" of "uses". (/frr-nexthop:frr-nexthop-group/frr-nexthop-grouping)
libyang: Copying data from grouping failed. (/frr-nexthop:frr-nexthop-group/frr-nexthop-grouping)
libyang: Module "frr-nexthop" parsing failed.
```

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>