### PR TITLE
zebra: clean up all router id lists

### DIFF
--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -315,6 +315,9 @@ static int zebra_vrf_delete(struct vrf *vrf)
 	list_delete_all_node(zvrf->rid_all_sorted_list);
 	list_delete_all_node(zvrf->rid_lo_sorted_list);
 
+	list_delete_all_node(zvrf->rid6_all_sorted_list);
+	list_delete_all_node(zvrf->rid6_lo_sorted_list);
+
 	otable_fini(&zvrf->other_tables);
 	XFREE(MTYPE_ZEBRA_VRF, zvrf);
 	vrf->info = NULL;


### PR DESCRIPTION
Clean up the ipv6 router-id lists associated with a zvrf - these were being leaked. Zebra was leaking one ipv6 router id for each v6 address configured on an interface.

This was the asan signature:

```
=================================================================
==22264==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f7c0d8eadc6 in calloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10ddc6)
    #1 0x7f7c0d6031fe in qcalloc lib/memory.c:110
    #2 0x7f7c0d5fa56c in listnode_new lib/linklist.c:54
    #3 0x7f7c0d5fb1b7 in listnode_new lib/linklist.c:206
    #4 0x7f7c0d5fb1b7 in listnode_add_sort lib/linklist.c:177
    #5 0x5555ab741aae in router_id_add_address zebra/router-id.c:185
    #6 0x5555ab73c470 in zebra_interface_address_add_update zebra/redistribute.c:559
    #7 0x5555ab712998 in connected_announce zebra/connected.c:91
    #8 0x5555ab712998 in connected_update zebra/connected.c:195
    #9 0x5555ab713bd4 in connected_add_ipv6 zebra/connected.c:525
    #10 0x5555ab71824e in netlink_interface_addr zebra/if_netlink.c:1245
    #11 0x5555ab733807 in netlink_parse_info zebra/kernel_netlink.c:941
    #12 0x5555ab71e33c in interface_addr_lookup_netlink zebra/if_netlink.c:956
    #13 0x5555ab71e33c in interface_list zebra/if_netlink.c:1624
    #14 0x5555ab7e3b4a in zebra_ns_enable zebra/zebra_ns.c:127
    #15 0x5555ab7e4040 in zebra_ns_init zebra/zebra_ns.c:217
    #16 0x5555ab70e7f3 in main zebra/main.c:386
    #17 0x7f7c0d2d80b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
```
