### PR TITLE
bgpd: RFC 4271 optional session attribute DelayOpenTimer

### DIFF
--- a/bgpd/bgp_nb_config.c
+++ b/bgpd/bgp_nb_config.c
@@ -1425,8 +1425,8 @@ int bgp_global_global_config_timers_hold_time_modify(
 		keepalive = yang_dnode_get_uint16(args->dnode, "../keepalive");
 		holdtime = yang_dnode_get_uint16(args->dnode, NULL);
 
-		bgp_timers_set(bgp, keepalive, holdtime,
-			       DFLT_BGP_CONNECT_RETRY);
+		bgp_timers_set(bgp, keepalive, holdtime, DFLT_BGP_CONNECT_RETRY,
+			       BGP_DEFAULT_DELAYOPEN);
 
 		break;
 	}
@@ -1466,8 +1466,8 @@ int bgp_global_global_config_timers_keepalive_modify(
 		keepalive = yang_dnode_get_uint16(args->dnode, NULL);
 		holdtime = yang_dnode_get_uint16(args->dnode, "../hold-time");
 
-		bgp_timers_set(bgp, keepalive, holdtime,
-			       DFLT_BGP_CONNECT_RETRY);
+		bgp_timers_set(bgp, keepalive, holdtime, DFLT_BGP_CONNECT_RETRY,
+			       BGP_DEFAULT_DELAYOPEN);
 
 		break;
 	}

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -457,8 +457,16 @@ static int bgp_accept(struct thread *thread)
 			BGP_TIMER_OFF(
 				peer1->t_start); /* created in peer_create() */
 
-			if (peer_active(peer1))
-				BGP_EVENT_ADD(peer1, TCP_connection_open);
+			if (peer_active(peer1)) {
+				if (CHECK_FLAG(peer1->flags,
+					       PEER_FLAG_TIMER_DELAYOPEN))
+					BGP_EVENT_ADD(
+						peer1,
+						TCP_connection_open_w_delay);
+				else
+					BGP_EVENT_ADD(peer1,
+						      TCP_connection_open);
+			}
 
 			return 0;
 		}
@@ -595,7 +603,10 @@ static int bgp_accept(struct thread *thread)
 	}
 
 	if (peer_active(peer)) {
-		BGP_EVENT_ADD(peer, TCP_connection_open);
+		if (CHECK_FLAG(peer->flags, PEER_FLAG_TIMER_DELAYOPEN))
+			BGP_EVENT_ADD(peer, TCP_connection_open_w_delay);
+		else
+			BGP_EVENT_ADD(peer, TCP_connection_open);
 	}
 
 	return 0;

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -461,7 +461,7 @@ int bgp_get_vty(struct bgp **bgp, as_t *as, const char *name,
 
 	if (ret == BGP_CREATED) {
 		bgp_timers_set(*bgp, DFLT_BGP_KEEPALIVE, DFLT_BGP_HOLDTIME,
-			       DFLT_BGP_CONNECT_RETRY);
+			       DFLT_BGP_CONNECT_RETRY, BGP_DEFAULT_DELAYOPEN);
 
 		if (DFLT_BGP_IMPORT_CHECK)
 			SET_FLAG((*bgp)->flags, BGP_FLAG_IMPORT_CHECK);
@@ -7373,6 +7373,54 @@ DEFUN_YANG (no_neighbor_timers_connect,
 	return nb_cli_apply_changes(vty, base_xpath);
 }
 
+DEFPY (neighbor_timers_delayopen,
+       neighbor_timers_delayopen_cmd,
+       "neighbor <A.B.C.D|X:X::X:X|WORD>$neighbor timers delayopen (1-240)$interval",
+       NEIGHBOR_STR
+       NEIGHBOR_ADDR_STR2
+       "BGP per neighbor timers\n"
+       "RFC 4271 DelayOpenTimer\n"
+       "DelayOpenTime timer interval\n")
+{
+	struct peer *peer;
+
+	peer = peer_and_group_lookup_vty(vty, neighbor);
+	if (!peer)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	if (!interval) {
+		if (peer_timers_delayopen_unset(peer))
+			return CMD_WARNING_CONFIG_FAILED;
+	} else {
+		if (peer_timers_delayopen_set(peer, interval))
+			return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	return CMD_SUCCESS;
+}
+
+DEFPY (no_neighbor_timers_delayopen,
+       no_neighbor_timers_delayopen_cmd,
+       "no neighbor <A.B.C.D|X:X::X:X|WORD>$neighbor timers delayopen [(0-65535)]",
+       NO_STR
+       NEIGHBOR_STR
+       NEIGHBOR_ADDR_STR2
+       "BGP per neighbor timers\n"
+       "RFC 4271 DelayOpenTimer\n"
+       "DelayOpenTime timer interval\n")
+{
+	struct peer *peer;
+
+	peer = peer_and_group_lookup_vty(vty, neighbor);
+	if (!peer)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	if (peer_timers_delayopen_unset(peer))
+		return CMD_WARNING_CONFIG_FAILED;
+
+	return CMD_SUCCESS;
+}
+
 DEFUN_YANG (neighbor_advertise_interval,
 	    neighbor_advertise_interval_cmd,
 	    "neighbor <A.B.C.D|X:X::X:X|WORD> advertisement-interval (0-600)",
@@ -12600,6 +12648,12 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 		json_object_int_add(json_neigh,
 				    "bgpTimerKeepAliveIntervalMsecs",
 				    p->v_keepalive * 1000);
+		if (CHECK_FLAG(p->flags, PEER_FLAG_TIMER_DELAYOPEN)) {
+			json_object_int_add(json_neigh,
+					    "bgpTimerDelayOpenTimeMsecs",
+					    p->v_delayopen * 1000);
+		}
+
 		if (CHECK_FLAG(p->flags, PEER_FLAG_TIMER)) {
 			json_object_int_add(json_neigh,
 					    "bgpTimerConfiguredHoldTimeMsecs",
@@ -12679,6 +12733,10 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 			vty_out(vty, ", keepalive interval is %d seconds\n",
 				bgp->default_keepalive);
 		}
+		if (CHECK_FLAG(p->flags, PEER_FLAG_TIMER_DELAYOPEN))
+			vty_out(vty,
+				"  Configured DelayOpenTime is %d seconds\n",
+				p->delayopen);
 	}
 	/* Capability. */
 	if (p->status == Established) {
@@ -16395,6 +16453,18 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 		vty_out(vty, " neighbor %s timers connect %u\n", addr,
 			peer->bgp->default_connect_retry);
 
+	/* timers delayopen */
+	if (peergroup_flag_check(peer, PEER_FLAG_TIMER_DELAYOPEN))
+		vty_out(vty, " neighbor %s timers delayopen %u\n", addr,
+			peer->delayopen);
+	/* Save config even though flag is not set if default values have been
+	 * changed
+	 */
+	else if (!peer_group_active(peer) && !peer->delayopen
+		 && peer->bgp->default_delayopen != BGP_DEFAULT_DELAYOPEN)
+		vty_out(vty, " neighbor %s timers delayopen %u\n", addr,
+			peer->bgp->default_delayopen);
+
 	/* capability dynamic */
 	if (peergroup_flag_check(peer, PEER_FLAG_DYNAMIC_CAPABILITY))
 		vty_out(vty, " neighbor %s capability dynamic\n", addr);
@@ -18253,6 +18323,10 @@ void bgp_vty_init(void)
 	/* "neighbor timers connect" commands. */
 	install_element(BGP_NODE, &neighbor_timers_connect_cmd);
 	install_element(BGP_NODE, &no_neighbor_timers_connect_cmd);
+
+	/* "neighbor timers delayopen" commands. */
+	install_element(BGP_NODE, &neighbor_timers_delayopen_cmd);
+	install_element(BGP_NODE, &no_neighbor_timers_delayopen_cmd);
 
 	/* "neighbor advertisement-interval" commands. */
 	install_element(BGP_NODE, &neighbor_advertise_interval_cmd);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1596,6 +1596,15 @@ Configuring Peers
    peer in question.  This number is between 0 and 600 seconds,
    with the default advertisement interval being 0.
 
+.. index:: [no] neighbor PEER timers delayopen (1-240)
+.. clicmd:: [no] neighbor PEER timers delayopen (1-240)
+
+   This command allows the user enable the
+   `RFC 4271 <https://tools.ietf.org/html/rfc4271/>` DelayOpenTimer with the
+   specified interval or disable it with the negating command for the peer. By
+   default, the DelayOpenTimer is disabled. The timer interval may be set to a
+   duration of 1 to 240 seconds.
+
 Displaying Information about Peers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/topotests/bgp_features/r1/bgp_delayopen_neighbor.json
+++ b/tests/topotests/bgp_features/r1/bgp_delayopen_neighbor.json
@@ -1,0 +1,6 @@
+{
+  "192.168.101.2":{
+    "remoteAs":65100,
+    "bgpTimerDelayOpenTimeMsecs":240000
+  }
+}

--- a/tests/topotests/bgp_features/r1/bgp_delayopen_summary_established.json
+++ b/tests/topotests/bgp_features/r1/bgp_delayopen_summary_established.json
@@ -1,0 +1,11 @@
+{
+"ipv4Unicast":{
+  "as":65000,
+  "peers":{
+    "192.168.101.2":{
+      "remoteAs":65100,
+      "state":"Established"
+    }
+  }
+}
+}

--- a/tests/topotests/bgp_features/r1/bgp_delayopen_summary_shutdown.json
+++ b/tests/topotests/bgp_features/r1/bgp_delayopen_summary_shutdown.json
@@ -1,0 +1,11 @@
+{
+"ipv4Unicast":{
+  "as":65000,
+  "peers":{
+    "192.168.101.2":{
+      "remoteAs":65100,
+      "state":"Idle (Admin)"
+    }
+  }
+}
+}

--- a/tests/topotests/bgp_features/r2/bgp_delayopen_neighbor.json
+++ b/tests/topotests/bgp_features/r2/bgp_delayopen_neighbor.json
@@ -1,0 +1,6 @@
+{
+  "192.168.201.2":{
+    "remoteAs":65200,
+    "bgpTimerDelayOpenTimeMsecs":60000
+  }
+}

--- a/tests/topotests/bgp_features/r2/bgp_delayopen_summary_connect.json
+++ b/tests/topotests/bgp_features/r2/bgp_delayopen_summary_connect.json
@@ -1,0 +1,11 @@
+{
+"ipv4Unicast":{
+  "as":65000,
+  "peers":{
+    "192.168.201.2":{
+      "remoteAs":65200,
+      "state":"Connect"
+    }
+  }
+}
+}

--- a/tests/topotests/bgp_features/r2/bgp_delayopen_summary_established.json
+++ b/tests/topotests/bgp_features/r2/bgp_delayopen_summary_established.json
@@ -1,0 +1,11 @@
+{
+"ipv4Unicast":{
+  "as":65000,
+  "peers":{
+    "192.168.201.2":{
+      "remoteAs":65200,
+      "state":"Established"
+    }
+  }
+}
+}

--- a/tests/topotests/bgp_features/r2/bgp_delayopen_summary_shutdown.json
+++ b/tests/topotests/bgp_features/r2/bgp_delayopen_summary_shutdown.json
@@ -1,0 +1,11 @@
+{
+"ipv4Unicast":{
+  "as":65000,
+  "peers":{
+    "192.168.201.2":{
+      "remoteAs":65200,
+      "state":"Idle (Admin)"
+    }
+  }
+}
+}

--- a/tests/topotests/bgp_features/r4/bgp_delayopen_summary_established.json
+++ b/tests/topotests/bgp_features/r4/bgp_delayopen_summary_established.json
@@ -1,0 +1,11 @@
+{
+"ipv4Unicast":{
+  "as":65100,
+  "peers":{
+    "192.168.101.1":{
+      "remoteAs":65000,
+      "state":"Established"
+    }
+  }
+}
+}

--- a/tests/topotests/bgp_features/r4/bgp_delayopen_summary_shutdown.json
+++ b/tests/topotests/bgp_features/r4/bgp_delayopen_summary_shutdown.json
@@ -1,0 +1,11 @@
+{
+"ipv4Unicast":{
+  "as":65100,
+  "peers":{
+    "192.168.101.1":{
+      "remoteAs":65000,
+      "state":"Idle (Admin)"
+    }
+  }
+}
+}

--- a/tests/topotests/bgp_features/r5/bgp_delayopen_neighbor.json
+++ b/tests/topotests/bgp_features/r5/bgp_delayopen_neighbor.json
@@ -1,0 +1,6 @@
+{
+  "192.168.201.1":{
+    "remoteAs":65000,
+    "bgpTimerDelayOpenTimeMsecs":30000
+  }
+}

--- a/tests/topotests/bgp_features/r5/bgp_delayopen_summary_connect.json
+++ b/tests/topotests/bgp_features/r5/bgp_delayopen_summary_connect.json
@@ -1,0 +1,11 @@
+{
+"ipv4Unicast":{
+  "as":65200,
+  "peers":{
+    "192.168.201.1":{
+      "remoteAs":65000,
+      "state":"Connect"
+    }
+  }
+}
+}

--- a/tests/topotests/bgp_features/r5/bgp_delayopen_summary_established.json
+++ b/tests/topotests/bgp_features/r5/bgp_delayopen_summary_established.json
@@ -1,0 +1,11 @@
+{
+"ipv4Unicast":{
+  "as":65200,
+  "peers":{
+    "192.168.201.1":{
+      "remoteAs":65000,
+      "state":"Established"
+    }
+  }
+}
+}

--- a/tests/topotests/bgp_features/r5/bgp_delayopen_summary_shutdown.json
+++ b/tests/topotests/bgp_features/r5/bgp_delayopen_summary_shutdown.json
@@ -1,0 +1,11 @@
+{
+"ipv4Unicast":{
+  "as":65200,
+  "peers":{
+    "192.168.201.1":{
+      "remoteAs":65000,
+      "state":"Idle (Admin)"
+    }
+  }
+}
+}


### PR DESCRIPTION
The changes implement the optional session attribute DelayOpenTimer proposed in [RFC 4271](https://tools.ietf.org/html/rfc4271).

Since this PR will change the behaviour of the BGP daemons finite state machine and could possibly break a lot of things, i would like to invite as many people as possible to review it.