### PR TITLE
.github: improve bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,37 +7,91 @@ assignees: ''
 
 ---
 
+<!--
+
+*** ATTENTION ***
+
+YOU MUST READ THIS TO HAVE YOUR ISSUE ADDRESSED
+
+PLEASE READ AND FILL OUT THIS TEMPLATE
+
+NEGLECTING TO PROVIDE INFORMATION REQUESTED HERE WILL RESULT IN
+SIGNIFICANT DELAYS ADDRESSING YOUR ISSUE
+
+ALWAYS PROVIDE:
+- FRR VERSION
+- OPERATING SYSTEM VERSION
+- KERNEL VERSION
+
+FAILURE TO PROVIDE THIS MAY RESULT IN YOUR ISSUE BEING IGNORED
+
+FOLLOW THESE GUIDELINES:
+
 - When reporting a crash, provide a backtrace
-- When pasting configs, logs, shell output, backtraces, and other large chunks of text use Markdown code blocks
-- Include the FRR version; if you built from Git, please provide the commit hash
+- When pasting configs, logs, shell output, backtraces, and other large chunks
+  of text, surround this text with triple backtics
+
+  ```
+  like this
+  ```
+
+- Include the FRR version; if you built from Git, please provide the commit
+  hash
 - Write your issue in English
+
+-->
 
 ---------------
 
 **Describe the bug**
+<!--
 A clear and concise description of what the bug is.
 
-(put "x" in "[ ]" if you already tried following)
+Put "x" in "[ ]" if you already tried following:
+-->
+
 [ ] Did you check if this is a duplicate issue?
 [ ] Did you test it on the latest FRRouting/frr master branch?
 
 
 **To Reproduce**
-Steps to reproduce the behavior:
+<!--
+Describe the steps to reproduce the behavior.
+Be as descriptive as possible.
+
+For example:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+-->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!--
+Write here a clear and concise description of what you expected to happen when
+using the reproduction steps you provided above
+-->
 
 **Screenshots**
+<!--
 If applicable, add screenshots to help explain your problem.
+-->
 
 **Versions**
- - OS Kernel: [e.g. Linux, OpenBSD, etc] [version]
- - FRR Version: [version]
+<!--
+Include your operating system type and version here
+
+FAILURE TO PROVIDE THIS MAY RESULT IN YOUR ISSUE BEING IGNORED
+-->
+<!-- e.g. Fedora 24, Debian 10] -->
+ - OS Version:
+<!-- [e.g. Linux 5.4, OpenBSD 6.6] -->
+ - Kernel:
+<!-- e.g. 6.0, 7.4 -->
+ - FRR Version:
 
 **Additional context**
+<!--
 Add any other context about the problem here.
+-->


### PR DESCRIPTION
- Enclose template help text in HTML comments so that it does not show
up in issues
- Add more help text explaining what is requested
- Yell to increase visibility

Signed-off-by: Quentin Young <qlyoung@nvidia.com>