### PR TITLE
[7.5] ospf6d: fix crash on message receive

### DIFF
--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -101,7 +101,6 @@ static void __attribute__((noreturn)) ospf6_exit(int status)
 	ospf6_asbr_terminate();
 	ospf6_lsa_terminate();
 
-	ospf6_serv_close();
 	/* reverse access_list_init */
 	access_list_reset();
 

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1535,7 +1535,7 @@ int ospf6_receive(struct thread *thread)
 
 	/* add next read thread */
 	sockfd = THREAD_FD(thread);
-	thread_add_read(master, ospf6_receive, NULL, sockfd, NULL);
+	thread_add_read(master, ospf6_receive, NULL, sockfd, &ospf6->t_ospf6_receive);
 
 	/* initialize */
 	memset(&src, 0, sizeof(src));

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -97,6 +97,7 @@ struct ospf6 {
 	struct thread *t_ase_calc; /* ASE calculation timer. */
 	struct thread *maxage_remover;
 	struct thread *t_distribute_update; /* Distirbute update timer. */
+	struct thread *t_ospf6_receive; /* OSPF6 receive timer */
 
 	uint32_t ref_bandwidth;
 

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -1267,10 +1267,6 @@ void ospf6_init(void)
 		VIEW_NODE,
 		&show_ipv6_ospf6_database_type_self_originated_linkstate_id_cmd);
 	install_element(VIEW_NODE, &show_ipv6_ospf6_database_aggr_router_cmd);
-
-	/* Make ospf protocol socket. */
-	ospf6_serv_sock();
-	thread_add_read(master, ospf6_receive, NULL, ospf6_sock, NULL);
 }
 
 void ospf6_clean(void)


### PR DESCRIPTION
OSPF6 daemon starts listening on its socket and reading messages right
after the initialization before the ospf6 router is created. If any
message is received, ospf6d crashes because ospf6_receive doesn't
NULL-check ospf6 pointer.

Fix this by opening the socket and reading messages only after the
creation of ospf6 router.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>