### PR TITLE
ospfd, zebra: Replace use of inet_ntoa

### DIFF
--- a/ospfclient/ospfclient.c
+++ b/ospfclient/ospfclient.c
@@ -30,6 +30,7 @@
 #include "prefix.h" /* needed by ospf_asbr.h */
 #include "privs.h"
 #include "log.h"
+#include "lib/printfrr.h"
 
 /* work around gcc bug 69981, disable MTYPEs in libospf */
 #define _QUAGGA_OSPF_MEMORY_H
@@ -186,8 +187,8 @@ static void lsa_update_callback(struct in_addr ifaddr, struct in_addr area_id,
 				struct lsa_header *lsa)
 {
 	printf("lsa_update_callback: ");
-	printf("ifaddr: %s ", inet_ntoa(ifaddr));
-	printf("area: %s\n", inet_ntoa(area_id));
+	printfrr("ifaddr: %pI4 ", &ifaddr);
+	printfrr("area: %pI4\n", &area_id);
 	printf("is_self_origin: %u\n", is_self_originated);
 
 	/* It is important to note that lsa_header does indeed include the
@@ -211,8 +212,8 @@ static void lsa_delete_callback(struct in_addr ifaddr, struct in_addr area_id,
 				struct lsa_header *lsa)
 {
 	printf("lsa_delete_callback: ");
-	printf("ifaddr: %s ", inet_ntoa(ifaddr));
-	printf("area: %s\n", inet_ntoa(area_id));
+	printf("ifaddr: %pI4 ", &ifaddr);
+	printf("area: %pI4\n", &area_id);
 	printf("is_self_origin: %u\n", is_self_originated);
 
 	ospf_lsa_header_dump(lsa);
@@ -221,8 +222,8 @@ static void lsa_delete_callback(struct in_addr ifaddr, struct in_addr area_id,
 static void ready_callback(uint8_t lsa_type, uint8_t opaque_type,
 			   struct in_addr addr)
 {
-	printf("ready_callback: lsa_type: %d opaque_type: %d addr=%s\n",
-	       lsa_type, opaque_type, inet_ntoa(addr));
+	printfrr("ready_callback: lsa_type: %d opaque_type: %d addr=%pI4\n",
+		 lsa_type, opaque_type, &addr);
 
 	/* Schedule opaque LSA originate in 5 secs */
 	thread_add_timer(master, lsa_inject, oclient, 5, NULL);
@@ -236,20 +237,20 @@ static void ready_callback(uint8_t lsa_type, uint8_t opaque_type,
 
 static void new_if_callback(struct in_addr ifaddr, struct in_addr area_id)
 {
-	printf("new_if_callback: ifaddr: %s ", inet_ntoa(ifaddr));
-	printf("area_id: %s\n", inet_ntoa(area_id));
+	printfrr("new_if_callback: ifaddr: %pI4 ", &ifaddr);
+	printfrr("area_id: %pI4\n", &area_id);
 }
 
 static void del_if_callback(struct in_addr ifaddr)
 {
-	printf("new_if_callback: ifaddr: %s\n ", inet_ntoa(ifaddr));
+	printfrr("new_if_callback: ifaddr: %pI4\n ", &ifaddr);
 }
 
 static void ism_change_callback(struct in_addr ifaddr, struct in_addr area_id,
 				uint8_t state)
 {
-	printf("ism_change: ifaddr: %s ", inet_ntoa(ifaddr));
-	printf("area_id: %s\n", inet_ntoa(area_id));
+	printfrr("ism_change: ifaddr: %pI4 ", &ifaddr);
+	printfrr("area_id: %pI4\n", &area_id);
 	printf("state: %d [%s]\n", state,
 	       lookup_msg(ospf_ism_state_msg, state, NULL));
 }
@@ -257,9 +258,9 @@ static void ism_change_callback(struct in_addr ifaddr, struct in_addr area_id,
 static void nsm_change_callback(struct in_addr ifaddr, struct in_addr nbraddr,
 				struct in_addr router_id, uint8_t state)
 {
-	printf("nsm_change: ifaddr: %s ", inet_ntoa(ifaddr));
-	printf("nbraddr: %s\n", inet_ntoa(nbraddr));
-	printf("router_id: %s\n", inet_ntoa(router_id));
+	printfrr("nsm_change: ifaddr: %pI4 ", &ifaddr);
+	printfrr("nbraddr: %pI4\n", &nbraddr);
+	printfrr("router_id: %pI4\n", &router_id);
 	printf("state: %d [%s]\n", state,
 	       lookup_msg(ospf_nsm_state_msg, state, NULL));
 }

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -387,8 +387,8 @@ int ospf_apiserver_read(struct thread *thread)
 		apiserv->t_sync_read = NULL;
 
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("API: ospf_apiserver_read: Peer: %s/%u",
-				   inet_ntoa(apiserv->peer_sync.sin_addr),
+			zlog_debug("API: ospf_apiserver_read: Peer: %pI4/%u",
+				   &apiserv->peer_sync.sin_addr,
 				   ntohs(apiserv->peer_sync.sin_port));
 	}
 #ifdef USE_ASYNC_READ
@@ -397,8 +397,8 @@ int ospf_apiserver_read(struct thread *thread)
 		apiserv->t_async_read = NULL;
 
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("API: ospf_apiserver_read: Peer: %s/%u",
-				   inet_ntoa(apiserv->peer_async.sin_addr),
+			zlog_debug("API: ospf_apiserver_read: Peer: %pI4/%u",
+				   &apiserv->peer_async.sin_addr,
 				   ntohs(apiserv->peer_async.sin_port));
 	}
 #endif /* USE_ASYNC_READ */
@@ -455,8 +455,8 @@ int ospf_apiserver_sync_write(struct thread *thread)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("API: ospf_apiserver_sync_write: Peer: %s/%u",
-			   inet_ntoa(apiserv->peer_sync.sin_addr),
+		zlog_debug("API: ospf_apiserver_sync_write: Peer: %pI4/%u",
+			   &apiserv->peer_sync.sin_addr,
 			   ntohs(apiserv->peer_sync.sin_port));
 
 	/* Check whether there is really a message in the fifo. */
@@ -519,8 +519,8 @@ int ospf_apiserver_async_write(struct thread *thread)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("API: ospf_apiserver_async_write: Peer: %s/%u",
-			   inet_ntoa(apiserv->peer_async.sin_addr),
+		zlog_debug("API: ospf_apiserver_async_write: Peer: %pI4/%u",
+			   &apiserv->peer_async.sin_addr,
 			   ntohs(apiserv->peer_async.sin_port));
 
 	/* Check whether there is really a message in the fifo. */
@@ -645,8 +645,8 @@ int ospf_apiserver_accept(struct thread *thread)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("API: ospf_apiserver_accept: New peer: %s/%u",
-			   inet_ntoa(peer_sync.sin_addr),
+		zlog_debug("API: ospf_apiserver_accept: New peer: %pI4/%u",
+			   &peer_sync.sin_addr,
 			   ntohs(peer_sync.sin_port));
 
 	/* Create new socket for asynchronous messages. */
@@ -657,8 +657,8 @@ int ospf_apiserver_accept(struct thread *thread)
 	 */
 	if (ntohs(peer_async.sin_port) == ospf_apiserver_getport()) {
 		zlog_warn(
-			"API: ospf_apiserver_accept: Peer(%s/%u): Invalid async port number?",
-			inet_ntoa(peer_async.sin_addr),
+			"API: ospf_apiserver_accept: Peer(%pI4/%u): Invalid async port number?",
+			&peer_async.sin_addr,
 			ntohs(peer_async.sin_port));
 		close(new_sync_sock);
 		return -1;
@@ -1409,8 +1409,8 @@ struct ospf_lsa *ospf_apiserver_opaque_lsa_new(struct ospf_area *area,
 	options |= OSPF_OPTION_O; /* Don't forget to set option bit */
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Creating an Opaque-LSA instance",
-			   protolsa->type, inet_ntoa(protolsa->id));
+		zlog_debug("LSA[Type%d:%pI4]: Creating an Opaque-LSA instance",
+			   protolsa->type, &protolsa->id);
 	}
 
 	/* Set opaque-LSA header fields. */
@@ -1510,8 +1510,8 @@ int ospf_apiserver_handle_originate_request(struct ospf_apiserver *apiserv,
 	case OSPF_OPAQUE_LINK_LSA:
 		oi = ospf_apiserver_if_lookup_by_addr(omsg->ifaddr);
 		if (!oi) {
-			zlog_warn("apiserver_originate: unknown interface %s",
-				  inet_ntoa(omsg->ifaddr));
+			zlog_warn("apiserver_originate: unknown interface %pI4",
+				  &omsg->ifaddr);
 			rc = OSPF_API_NOSUCHINTERFACE;
 			goto out;
 		}
@@ -1521,8 +1521,8 @@ int ospf_apiserver_handle_originate_request(struct ospf_apiserver *apiserv,
 	case OSPF_OPAQUE_AREA_LSA:
 		area = ospf_area_lookup_by_area_id(ospf, omsg->area_id);
 		if (!area) {
-			zlog_warn("apiserver_originate: unknown area %s",
-				  inet_ntoa(omsg->area_id));
+			zlog_warn("apiserver_originate: unknown area %pI4",
+				  &omsg->area_id);
 			rc = OSPF_API_NOSUCHAREA;
 			goto out;
 		}
@@ -1791,8 +1791,8 @@ struct ospf_lsa *ospf_apiserver_lsa_refresher(struct ospf_lsa *lsa)
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Refresh Opaque LSA",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: Refresh Opaque LSA",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1829,8 +1829,8 @@ int ospf_apiserver_handle_delete_request(struct ospf_apiserver *apiserv,
 	case OSPF_OPAQUE_AREA_LSA:
 		area = ospf_area_lookup_by_area_id(ospf, dmsg->area_id);
 		if (!area) {
-			zlog_warn("ospf_apiserver_lsa_delete: unknown area %s",
-				  inet_ntoa(dmsg->area_id));
+			zlog_warn("ospf_apiserver_lsa_delete: unknown area %pI4",
+				  &dmsg->area_id);
 			rc = OSPF_API_NOSUCHAREA;
 			goto out;
 		}
@@ -1872,8 +1872,8 @@ int ospf_apiserver_handle_delete_request(struct ospf_apiserver *apiserv,
 	old = ospf_lsa_lookup(ospf, area, dmsg->lsa_type, id, ospf->router_id);
 	if (!old) {
 		zlog_warn(
-			"ospf_apiserver_lsa_delete: LSA[Type%d:%s] not in LSDB",
-			dmsg->lsa_type, inet_ntoa(id));
+			"ospf_apiserver_lsa_delete: LSA[Type%d:%pI4] not in LSDB",
+			dmsg->lsa_type, &id);
 		rc = OSPF_API_NOSUCHLSA;
 		goto out;
 	}

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -131,13 +131,12 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 			}
 
 			inet_ntop(AF_INET, (void *)&nexthop.s_addr, inetbuf,
-				  INET6_BUFSIZ);
+				  sizeof(inetbuf));
 			if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
 				zlog_debug(
-					"Redistribute[%s][%d][%u]: %s/%d discarding old info with NH %s.",
+					"Redistribute[%s][%d][%u]: %pFX discarding old info with NH %s.",
 					ospf_redist_string(type), instance,
-					ospf->vrf_id, inet_ntoa(p.prefix),
-					p.prefixlen, inetbuf);
+					ospf->vrf_id, &p, inetbuf);
 			XFREE(MTYPE_OSPF_EXTERNAL_INFO, rn->info);
 		}
 
@@ -155,11 +154,11 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 		inet_ntop(AF_INET, (void *)&nexthop.s_addr, inetbuf,
-			  INET6_BUFSIZ);
+			  sizeof(inetbuf));
 		zlog_debug(
-			"Redistribute[%s][%u]: %s/%d external info created, with NH %s",
+			"Redistribute[%s][%u]: %pFX external info created, with NH %s",
 			ospf_redist_string(type), ospf->vrf_id,
-			inet_ntoa(p.prefix), p.prefixlen, inetbuf);
+			&p, inetbuf);
 	}
 	return new;
 }

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -179,8 +179,8 @@ ospf_ase_calculate_asbr_route (struct ospf *ospf,
   if (asbr_route == NULL)
     {
       if (IS_DEBUG_OSPF (lsa, LSA))
-	zlog_debug ("ospf_ase_calculate(): Route to ASBR %s not found",
-		    inet_ntoa (asbr.prefix));
+	zlog_debug ("ospf_ase_calculate(): Route to ASBR %pI4 not found",
+		    &asbr.prefix);
       return NULL;
     }
 
@@ -283,7 +283,6 @@ int ospf_ase_calculate_route(struct ospf *ospf, struct ospf_lsa *lsa)
 	struct prefix_ipv4 asbr, p;
 	struct route_node *rn;
 	struct ospf_route *new, * or ;
-	char buf1[INET_ADDRSTRLEN];
 	int ret;
 
 	assert(lsa);
@@ -301,11 +300,10 @@ int ospf_ase_calculate_route(struct ospf *ospf, struct ospf_lsa *lsa)
 	}
 
 	if (IS_DEBUG_OSPF(lsa, LSA)) {
-		snprintf(buf1, sizeof(buf1), "%s",
-			 inet_ntoa(al->header.adv_router));
 		zlog_debug(
-			"Route[External]: Calculate AS-external-LSA to %s/%d adv_router %s",
-			inet_ntoa(al->header.id), ip_masklen(al->mask), buf1);
+			"Route[External]: Calculate AS-external-LSA to %pI4/%d adv_router %pI4",
+			&al->header.id, ip_masklen(al->mask),
+			&al->header.adv_router);
 	}
 
 	/* (1) If the cost specified by the LSA is LSInfinity, or if the
@@ -457,9 +455,8 @@ int ospf_ase_calculate_route(struct ospf *ospf, struct ospf_lsa *lsa)
 
 	if (!rn || (or = rn->info) == NULL) {
 		if (IS_DEBUG_OSPF(lsa, LSA))
-			zlog_debug("Route[External]: Adding a new route %s/%d with paths %u",
-				   inet_ntoa(p.prefix), p.prefixlen,
-				   listcount(asbr_route->paths));
+			zlog_debug("Route[External]: Adding a new route %pFX with paths %u",
+				   &p, listcount(asbr_route->paths));
 
 		ospf_route_add(ospf->new_external_route, &p, new, asbr_route);
 
@@ -658,8 +655,8 @@ static int ospf_ase_calculate_timer(struct thread *t)
 			for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area)) {
 				if (IS_DEBUG_OSPF_NSSA)
 					zlog_debug(
-						"ospf_ase_calculate_timer(): looking at area %s",
-						inet_ntoa(area->area_id));
+						"ospf_ase_calculate_timer(): looking at area %pI4",
+						&area->area_id);
 
 				if (area->external_routing == OSPF_AREA_NSSA)
 					LSDB_LOOP (NSSA_LSDB(area), rn, lsa)

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -76,9 +76,9 @@ static void ospf_bfd_reg_dereg_nbr(struct ospf_neighbor *nbr, int command)
 	bfd_info = (struct bfd_info *)params->bfd_info;
 
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
-		zlog_debug("%s nbr (%s) with BFD. OSPF vrf %s",
+		zlog_debug("%s nbr (%pI4) with BFD. OSPF vrf %s",
 			   bfd_get_command_dbg_str(command),
-			   inet_ntoa(nbr->src),
+			   &nbr->src,
 			   ospf_vrf_id_to_name(oi->ospf->vrf_id));
 
 	cbit = CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CBIT_ON);
@@ -180,8 +180,8 @@ static int ospf_bfd_nbr_replay(ZAPI_CALLBACK_ARGS)
 					continue;
 
 				if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
-					zlog_debug("Replaying nbr (%s) to BFD",
-						   inet_ntoa(nbr->src));
+					zlog_debug("Replaying nbr (%pI4) to BFD",
+						   &nbr->src);
 
 				ospf_bfd_reg_dereg_nbr(nbr,
 						       ZEBRA_BFD_DEST_UPDATE);
@@ -266,18 +266,18 @@ static int ospf_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
 		if ((status == BFD_STATUS_DOWN)
 		    && (old_status == BFD_STATUS_UP)) {
 			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-				zlog_debug("NSM[%s:%s]: BFD Down",
+				zlog_debug("NSM[%s:%pI4]: BFD Down",
 					   IF_NAME(nbr->oi),
-					   inet_ntoa(nbr->address.u.prefix4));
+					   &nbr->address.u.prefix4);
 
 			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_InactivityTimer);
 		}
 		if ((status == BFD_STATUS_UP)
 		    && (old_status == BFD_STATUS_DOWN)) {
 			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-				zlog_debug("NSM[%s:%s]: BFD Up",
+				zlog_debug("NSM[%s:%pI4]: BFD Up",
 					   IF_NAME(nbr->oi),
-					   inet_ntoa(nbr->address.u.prefix4));
+					   &nbr->address.u.prefix4);
 		}
 	}
 

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -242,20 +242,20 @@ static void ospf_packet_hello_dump(struct stream *s, uint16_t length)
 	hello = (struct ospf_hello *)stream_pnt(s);
 
 	zlog_debug("Hello");
-	zlog_debug("  NetworkMask %s", inet_ntoa(hello->network_mask));
+	zlog_debug("  NetworkMask %pI4", &hello->network_mask);
 	zlog_debug("  HelloInterval %d", ntohs(hello->hello_interval));
 	zlog_debug("  Options %d (%s)", hello->options,
 		   ospf_options_dump(hello->options));
 	zlog_debug("  RtrPriority %d", hello->priority);
 	zlog_debug("  RtrDeadInterval %ld",
 		   (unsigned long)ntohl(hello->dead_interval));
-	zlog_debug("  DRouter %s", inet_ntoa(hello->d_router));
-	zlog_debug("  BDRouter %s", inet_ntoa(hello->bd_router));
+	zlog_debug("  DRouter %pI4", &hello->d_router);
+	zlog_debug("  BDRouter %pI4", &hello->bd_router);
 
 	length -= OSPF_HEADER_SIZE + OSPF_HELLO_MIN_SIZE;
 	zlog_debug("  # Neighbors %d", length / 4);
 	for (i = 0; length > 0; i++, length -= sizeof(struct in_addr))
-		zlog_debug("    Neighbor %s", inet_ntoa(hello->neighbors[i]));
+		zlog_debug("    Neighbor %pI4", &hello->neighbors[i]);
 }
 
 static char *ospf_dd_flags_dump(uint8_t flags, char *buf, size_t size)
@@ -292,9 +292,9 @@ static void ospf_router_lsa_dump(struct stream *s, uint16_t length)
 
 	len = ntohs(rl->header.length) - OSPF_LSA_HEADER_SIZE - 4;
 	for (i = 0; len > 0; i++) {
-		zlog_debug("    Link ID %s", inet_ntoa(rl->link[i].link_id));
-		zlog_debug("    Link Data %s",
-			   inet_ntoa(rl->link[i].link_data));
+		zlog_debug("    Link ID %pI4", &rl->link[i].link_id);
+		zlog_debug("    Link Data %pI4",
+			   &rl->link[i].link_data);
 		zlog_debug("    Type %d", (uint8_t)rl->link[i].type);
 		zlog_debug("    TOS %d", (uint8_t)rl->link[i].tos);
 		zlog_debug("    metric %d", ntohs(rl->link[i].metric));
@@ -317,11 +317,11 @@ static void ospf_network_lsa_dump(struct stream *s, uint16_t length)
 	zlog_debug ("Network-LSA size %d",
 	ntohs (nl->header.length) - OSPF_LSA_HEADER_SIZE);
 	*/
-	zlog_debug("    Network Mask %s", inet_ntoa(nl->mask));
+	zlog_debug("    Network Mask %pI4", &nl->mask);
 	zlog_debug("    # Attached Routers %d", cnt);
 	for (i = 0; i < cnt; i++)
-		zlog_debug("      Attached Router %s",
-			   inet_ntoa(nl->routers[i]));
+		zlog_debug("      Attached Router %pI4",
+			   &nl->routers[i]);
 }
 
 static void ospf_summary_lsa_dump(struct stream *s, uint16_t length)
@@ -333,7 +333,7 @@ static void ospf_summary_lsa_dump(struct stream *s, uint16_t length)
 	sl = (struct summary_lsa *)stream_pnt(s);
 
 	zlog_debug("  Summary-LSA");
-	zlog_debug("    Network Mask %s", inet_ntoa(sl->mask));
+	zlog_debug("    Network Mask %pI4", &sl->mask);
 
 	size = ntohs(sl->header.length) - OSPF_LSA_HEADER_SIZE - 4;
 	for (i = 0; size > 0; size -= 4, i++)
@@ -349,15 +349,15 @@ static void ospf_as_external_lsa_dump(struct stream *s, uint16_t length)
 
 	al = (struct as_external_lsa *)stream_pnt(s);
 	zlog_debug("  %s", ospf_lsa_type_msg[al->header.type].str);
-	zlog_debug("    Network Mask %s", inet_ntoa(al->mask));
+	zlog_debug("    Network Mask %pI4", &al->mask);
 
 	size = ntohs(al->header.length) - OSPF_LSA_HEADER_SIZE - 4;
 	for (i = 0; size > 0; size -= 12, i++) {
 		zlog_debug("    bit %s TOS=%d metric %d",
 			   IS_EXTERNAL_METRIC(al->e[i].tos) ? "E" : "-",
 			   al->e[i].tos & 0x7f, GET_METRIC(al->e[i].metric));
-		zlog_debug("    Forwarding address %s",
-			   inet_ntoa(al->e[i].fwd_addr));
+		zlog_debug("    Forwarding address %pI4",
+			   &al->e[i].fwd_addr);
 		zlog_debug("    External Route Tag %" ROUTE_TAG_PRI,
 			   al->e[i].route_tag);
 	}
@@ -427,8 +427,8 @@ static void ospf_packet_ls_req_dump(struct stream *s, uint16_t length)
 		adv_router.s_addr = stream_get_ipv4(s);
 
 		zlog_debug("  LS type %d", ls_type);
-		zlog_debug("  Link State ID %s", inet_ntoa(ls_id));
-		zlog_debug("  Advertising Router %s", inet_ntoa(adv_router));
+		zlog_debug("  Link State ID %pI4", &ls_id);
+		zlog_debug("  Advertising Router %pI4", &adv_router);
 	}
 
 	stream_set_getp(s, sp);
@@ -519,8 +519,8 @@ static void ospf_header_dump(struct ospf_header *ospfh)
 	zlog_debug("  Type %d (%s)", ospfh->type,
 		   lookup_msg(ospf_packet_type_str, ospfh->type, NULL));
 	zlog_debug("  Packet Len %d", ntohs(ospfh->length));
-	zlog_debug("  Router ID %s", inet_ntoa(ospfh->router_id));
-	zlog_debug("  Area ID %s", inet_ntoa(ospfh->area_id));
+	zlog_debug("  Router ID %pI4", &ospfh->router_id);
+	zlog_debug("  Area ID %pI4", &ospfh->area_id);
 	zlog_debug("  Checksum 0x%x", ntohs(ospfh->checksum));
 	zlog_debug("  AuType %s",
 		   lookup_msg(ospf_auth_type_str, auth_type, NULL));

--- a/ospfd/ospf_dump_api.c
+++ b/ospfd/ospf_dump_api.c
@@ -127,8 +127,8 @@ void ospf_lsa_header_dump(struct lsa_header *lsah)
 		   ospf_options_dump(lsah->options));
 	zlog_debug("    LS type %d (%s)", lsah->type,
 		   (lsah->type ? lsah_type : "unknown type"));
-	zlog_debug("    Link State ID %s", inet_ntoa(lsah->id));
-	zlog_debug("    Advertising Router %s", inet_ntoa(lsah->adv_router));
+	zlog_debug("    Link State ID %pI4", &lsah->id);
+	zlog_debug("    Advertising Router %pI4", &lsah->adv_router);
 	zlog_debug("    LS sequence number 0x%lx",
 		   (unsigned long)ntohl(lsah->ls_seqnum));
 	zlog_debug("    LS checksum 0x%x", ntohs(lsah->checksum));

--- a/ospfd/ospf_ext.c
+++ b/ospfd/ospf_ext.c
@@ -1716,8 +1716,8 @@ static uint16_t show_vty_ext_link_rmt_itf_addr(struct vty *vty,
 	top = (struct ext_subtlv_rmt_itf_addr *)tlvh;
 
 	vty_out(vty,
-		"  Remote Interface Address Sub-TLV: Length %u\n	Address: %s\n",
-		ntohs(top->header.length), inet_ntoa(top->value));
+		"  Remote Interface Address Sub-TLV: Length %u\n	Address: %pI4\n",
+		ntohs(top->header.length), &top->value);
 
 	return TLV_SIZE(tlvh);
 }
@@ -1748,9 +1748,9 @@ static uint16_t show_vty_ext_link_lan_adj_sid(struct vty *vty,
 		(struct ext_subtlv_lan_adj_sid *)tlvh;
 
 	vty_out(vty,
-		"  LAN-Adj-SID Sub-TLV: Length %u\n\tFlags: 0x%x\n\tMT-ID:0x%x\n\tWeight: 0x%x\n\tNeighbor ID: %s\n\t%s: %u\n",
+		"  LAN-Adj-SID Sub-TLV: Length %u\n\tFlags: 0x%x\n\tMT-ID:0x%x\n\tWeight: 0x%x\n\tNeighbor ID: %pI4\n\t%s: %u\n",
 		ntohs(top->header.length), top->flags, top->mtid, top->weight,
-		inet_ntoa(top->neighbor_id),
+		&top->neighbor_id,
 		CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG) ? "Label"
 								     : "Index",
 		CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG)
@@ -1778,10 +1778,10 @@ static uint16_t show_vty_link_info(struct vty *vty, struct tlv_header *ext)
 
 	vty_out(vty,
 		"  Extended Link TLV: Length %u\n	Link Type: 0x%x\n"
-		"	Link ID: %s\n",
+		"	Link ID: %pI4\n",
 		ntohs(top->header.length), top->link_type,
-		inet_ntoa(top->link_id));
-	vty_out(vty, "	Link data: %s\n", inet_ntoa(top->link_data));
+		&top->link_id);
+	vty_out(vty, "	Link data: %pI4\n", &top->link_data);
 
 	tlvh = (struct tlv_header *)((char *)(ext) + TLV_HDR_SIZE
 				     + EXT_TLV_LINK_SIZE);
@@ -1858,9 +1858,9 @@ static uint16_t show_vty_pref_info(struct vty *vty, struct tlv_header *ext)
 
 	vty_out(vty,
 		"  Extended Prefix TLV: Length %u\n\tRoute Type: %u\n"
-		"\tAddress Family: 0x%x\n\tFlags: 0x%x\n\tAddress: %s/%u\n",
+		"\tAddress Family: 0x%x\n\tFlags: 0x%x\n\tAddress: %pI4/%u\n",
 		ntohs(top->header.length), top->route_type, top->af, top->flags,
-		inet_ntoa(top->address), top->pref_length);
+		&top->address, top->pref_length);
 
 	tlvh = (struct tlv_header *)((char *)(ext) + TLV_HDR_SIZE
 				     + EXT_TLV_PREFIX_SIZE);

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -157,9 +157,9 @@ static void ospf_process_self_originated_lsa(struct ospf *ospf,
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
-			"%s:LSA[Type%d:%s]: Process self-originated LSA seq 0x%x",
+			"%s:LSA[Type%d:%pI4]: Process self-originated LSA seq 0x%x",
 			ospf_get_name(ospf), new->data->type,
-			inet_ntoa(new->data->id), ntohl(new->data->ls_seqnum));
+			&new->data->id, ntohl(new->data->ls_seqnum));
 
 	/* If we're here, we installed a self-originated LSA that we received
 	   from a neighbor, i.e. it's more recent.  We must see whether we want
@@ -276,8 +276,8 @@ int ospf_flood(struct ospf *ospf, struct ospf_neighbor *nbr,
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
-			"%s:LSA[Flooding]: start, NBR %s (%s), cur(%p), New-LSA[%s]",
-			ospf_get_name(ospf), inet_ntoa(nbr->router_id),
+			"%s:LSA[Flooding]: start, NBR %pI4 (%s), cur(%p), New-LSA[%s]",
+			ospf_get_name(ospf), &nbr->router_id,
 			lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
 			(void *)current, dump_lsa_key(new));
 
@@ -345,9 +345,9 @@ int ospf_flood(struct ospf *ospf, struct ospf_neighbor *nbr,
 			/*  Handling Max age grace LSA.*/
 			if (IS_DEBUG_OSPF_GR_HELPER)
 				zlog_debug(
-					"%s, Received a maxage GRACE-LSA from router %s",
+					"%s, Received a maxage GRACE-LSA from router %pI4",
 					__PRETTY_FUNCTION__,
-					inet_ntoa(new->data->adv_router));
+					&new->data->adv_router);
 
 			if (current) {
 				ospf_process_maxage_grace_lsa(ospf, new, nbr);
@@ -361,9 +361,9 @@ int ospf_flood(struct ospf *ospf, struct ospf_neighbor *nbr,
 		} else {
 			if (IS_DEBUG_OSPF_GR_HELPER)
 				zlog_debug(
-					"%s, Received a GRACE-LSA from router %s",
+					"%s, Received a GRACE-LSA from router %pI4",
 					__PRETTY_FUNCTION__,
-					inet_ntoa(new->data->adv_router));
+					&new->data->adv_router);
 
 			if (ospf_process_grace_lsa(ospf, new, nbr)
 			    == OSPF_GR_NOT_HELPER) {
@@ -412,11 +412,15 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 	struct ospf_neighbor *onbr;
 	struct route_node *rn;
 	int retx_flag;
+	char buf[PREFIX_STRLEN];
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
 			"%s:ospf_flood_through_interface(): considering int %s, INBR(%s), LSA[%s] AGE %u",
-			ospf_get_name(oi->ospf), IF_NAME(oi), inbr ? inet_ntoa(inbr->router_id) : "NULL",
+			ospf_get_name(oi->ospf), IF_NAME(oi),
+			inbr ?
+			inet_ntop(AF_INET, &inbr->router_id, buf, sizeof(buf)) :
+			"NULL",
 			dump_lsa_key(lsa), ntohs(lsa->data->ls_age));
 
 	if (!ospf_if_is_enable(oi))
@@ -437,8 +441,8 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 		onbr = rn->info;
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
-				"ospf_flood_through_interface(): considering nbr %s(%s) (%s)",
-				inet_ntoa(onbr->router_id),
+				"ospf_flood_through_interface(): considering nbr %pI4(%s) (%s)",
+				&onbr->router_id,
 				ospf_get_name(oi->ospf),
 				lookup_msg(ospf_nsm_state_msg, onbr->state,
 					   NULL));
@@ -773,9 +777,9 @@ void ospf_ls_request_add(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 	 * the common function "ospf_lsdb_add()" -- endo.
 	 */
 	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-		zlog_debug("RqstL(%lu)++, NBR(%s(%s)), LSA[%s]",
+		zlog_debug("RqstL(%lu)++, NBR(%pI4(%s)), LSA[%s]",
 			   ospf_ls_request_count(nbr),
-			   inet_ntoa(nbr->router_id),
+			   &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf), dump_lsa_key(lsa));
 
 	ospf_lsdb_add(&nbr->ls_req, lsa);
@@ -800,9 +804,9 @@ void ospf_ls_request_delete(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 	}
 
 	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING)) /* -- endo. */
-		zlog_debug("RqstL(%lu)--, NBR(%s(%s)), LSA[%s]",
+		zlog_debug("RqstL(%lu)--, NBR(%pI4(%s)), LSA[%s]",
 			   ospf_ls_request_count(nbr),
-			   inet_ntoa(nbr->router_id),
+			   &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf), dump_lsa_key(lsa));
 
 	ospf_lsdb_delete(&nbr->ls_req, lsa);
@@ -862,9 +866,9 @@ void ospf_ls_retransmit_add(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 		if (old) {
 			old->retransmit_counter--;
 			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-				zlog_debug("RXmtL(%lu)--, NBR(%s(%s)), LSA[%s]",
+				zlog_debug("RXmtL(%lu)--, NBR(%pI4(%s)), LSA[%s]",
 					   ospf_ls_retransmit_count(nbr),
-					   inet_ntoa(nbr->router_id),
+					   &nbr->router_id,
 					   ospf_get_name(nbr->oi->ospf),
 					   dump_lsa_key(old));
 			ospf_lsdb_delete(&nbr->ls_rxmt, old);
@@ -879,9 +883,9 @@ void ospf_ls_retransmit_add(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 		 * the common function "ospf_lsdb_add()" -- endo.
 		 */
 		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-			zlog_debug("RXmtL(%lu)++, NBR(%s(%s)), LSA[%s]",
+			zlog_debug("RXmtL(%lu)++, NBR(%pI4(%s)), LSA[%s]",
 				   ospf_ls_retransmit_count(nbr),
-				   inet_ntoa(nbr->router_id),
+				   &nbr->router_id,
 				   ospf_get_name(nbr->oi->ospf),
 				   dump_lsa_key(lsa));
 		ospf_lsdb_add(&nbr->ls_rxmt, lsa);
@@ -894,9 +898,9 @@ void ospf_ls_retransmit_delete(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 	if (ospf_ls_retransmit_lookup(nbr, lsa)) {
 		lsa->retransmit_counter--;
 		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING)) /* -- endo. */
-			zlog_debug("RXmtL(%lu)--, NBR(%s(%s)), LSA[%s]",
+			zlog_debug("RXmtL(%lu)--, NBR(%pI4(%s)), LSA[%s]",
 				   ospf_ls_retransmit_count(nbr),
-				   inet_ntoa(nbr->router_id),
+				   &nbr->router_id,
 				   ospf_get_name(nbr->oi->ospf),
 				   dump_lsa_key(lsa));
 		ospf_lsdb_delete(&nbr->ls_rxmt, lsa);
@@ -984,8 +988,8 @@ void ospf_lsa_flush_area(struct ospf_lsa *lsa, struct ospf_area *area)
 	   retransmissions */
 	lsa->data->ls_age = htons(OSPF_LSA_MAXAGE);
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("%s: MAXAGE set to LSA %s", __func__,
-			   inet_ntoa(lsa->data->id));
+		zlog_debug("%s: MAXAGE set to LSA %pI4", __func__,
+			   &lsa->data->id);
 	monotime(&lsa->tv_recv);
 	lsa->tv_orig = lsa->tv_recv;
 	ospf_flood_through_area(area, NULL, lsa);

--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -377,8 +377,8 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 
 	if (IS_DEBUG_OSPF_GR_HELPER)
 		zlog_debug(
-			"%s, Grace LSA received from %s, grace interval:%u, restartreason :%s",
-			__PRETTY_FUNCTION__, inet_ntoa(restart_addr),
+			"%s, Grace LSA received from %pI4, grace interval:%u, restartreason :%s",
+			__PRETTY_FUNCTION__, &restart_addr,
 			grace_interval,
 			ospf_restart_reason2str(restart_reason));
 
@@ -392,9 +392,9 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		if (!restarter) {
 			if (IS_DEBUG_OSPF_GR_HELPER)
 				zlog_debug(
-					"%s, Restarter is not a nbr(%s) for this router.",
+					"%s, Restarter is not a nbr(%pI4) for this router.",
 					__PRETTY_FUNCTION__,
-					inet_ntoa(restart_addr));
+					&restart_addr);
 			return OSPF_GR_NOT_HELPER;
 		}
 	} else
@@ -425,8 +425,8 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	if (!IS_NBR_STATE_FULL(restarter)) {
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug(
-				"%s, This Neighbour %s is not in FULL state.",
-				__PRETTY_FUNCTION__, inet_ntoa(restarter->src));
+				"%s, This Neighbour %pI4 is not in FULL state.",
+				__PRETTY_FUNCTION__, &restarter->src);
 		restarter->gr_helper_info.rejected_reason =
 			OSPF_HELPER_NOT_A_VALID_NEIGHBOUR;
 		return OSPF_GR_NOT_HELPER;
@@ -501,8 +501,8 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	} else {
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug(
-				"%s, This Router becomes a HELPER for the neighbour %s",
-				__PRETTY_FUNCTION__, inet_ntoa(restarter->src));
+				"%s, This Router becomes a HELPER for the neighbour %pI4",
+				__PRETTY_FUNCTION__, &restarter->src);
 	}
 
 	/* Became a Helper to the RESTART neighbour.
@@ -606,8 +606,8 @@ void ospf_helper_handle_topo_chg(struct ospf *ospf, struct ospf_lsa *lsa)
 
 	if (IS_DEBUG_OSPF_GR_HELPER)
 		zlog_debug(
-			"%s, Topo change detected due to lsa LSID:%s type:%d",
-			__PRETTY_FUNCTION__, inet_ntoa(lsa->data->id),
+			"%s, Topo change detected due to lsa LSID:%pI4 type:%d",
+			__PRETTY_FUNCTION__, &lsa->data->id,
 			lsa->data->type);
 
 	lsa->to_be_acknowledged = OSPF_GR_TRUE;
@@ -670,8 +670,8 @@ void ospf_gr_helper_exit(struct ospf_neighbor *nbr,
 		return;
 
 	if (IS_DEBUG_OSPF_GR_HELPER)
-		zlog_debug("%s, Exiting from HELPER support to %s, due to %s",
-			   __PRETTY_FUNCTION__, inet_ntoa(nbr->src),
+		zlog_debug("%s, Exiting from HELPER support to %pI4, due to %s",
+			   __PRETTY_FUNCTION__, &nbr->src,
 			   ospf_exit_reason2str(reason));
 
 	/* Reset helper status*/
@@ -758,8 +758,8 @@ void ospf_process_maxage_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	}
 
 	if (IS_DEBUG_OSPF_GR_HELPER)
-		zlog_debug("%s, GraceLSA received for neighbour %s.",
-			   __PRETTY_FUNCTION__, inet_ntoa(restartAddr));
+		zlog_debug("%s, GraceLSA received for neighbour %pI4",
+			   __PRETTY_FUNCTION__, &restartAddr);
 
 	/* In case of broadcast links, if RESTARTER is DR_OTHER,
 	 * grace LSA might be received from DR, so fetching the
@@ -1066,8 +1066,8 @@ static void show_ospf_grace_lsa_info(struct vty *vty, struct ospf_lsa *lsa)
 			restartAddr = (struct grace_tlv_restart_addr *)tlvh;
 			sum += TLV_SIZE(tlvh);
 
-			vty_out(vty, "   Restarter address:%s\n",
-				inet_ntoa(restartAddr->addr));
+			vty_out(vty, "   Restarter address:%pI4\n",
+				&restartAddr->addr);
 			break;
 		default:
 			vty_out(vty, "   Unknown TLV type %d\n",

--- a/ospfd/ospf_ia.c
+++ b/ospfd/ospf_ia.c
@@ -130,6 +130,7 @@ static void ospf_ia_router_route(struct ospf *ospf, struct route_table *rtrs,
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("ospf_ia_router_route(): considering %pFX", p);
+
 	/* Find a route to the same dest */
 	rn = route_node_get(rtrs, (struct prefix *)p);
 
@@ -201,8 +202,8 @@ static int process_summary_lsa(struct ospf_area *area, struct route_table *rt,
 	sl = (struct summary_lsa *)lsa->data;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("process_summary_lsa(): LS ID: %s",
-			   inet_ntoa(sl->header.id));
+		zlog_debug("process_summary_lsa(): LS ID: %pI4",
+			   &sl->header.id);
 
 	metric = GET_METRIC(sl->metric);
 
@@ -523,8 +524,8 @@ static int process_transit_summary_lsa(struct ospf_area *area,
 	sl = (struct summary_lsa *)lsa->data;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("process_transit_summaries(): LS ID: %s",
-			   inet_ntoa(lsa->data->id));
+		zlog_debug("process_transit_summaries(): LS ID: %pI4",
+			   &lsa->data->id);
 	metric = GET_METRIC(sl->metric);
 
 	if (metric == OSPF_LS_INFINITY) {

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -977,17 +977,17 @@ struct ospf_vl_data *ospf_vl_lookup(struct ospf *ospf, struct ospf_area *area,
 	struct listnode *node;
 
 	if (IS_DEBUG_OSPF_EVENT) {
-		zlog_debug("%s: Looking for %s", __func__, inet_ntoa(vl_peer));
+		zlog_debug("%s: Looking for %pI4", __func__, &vl_peer);
 		if (area)
-			zlog_debug("%s: in area %s", __func__,
-				   inet_ntoa(area->area_id));
+			zlog_debug("%s: in area %pI4", __func__,
+				   &area->area_id);
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->vlinks, node, vl_data)) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("%s: VL %s, peer %s", __func__,
+			zlog_debug("%s: VL %s, peer %pI4", __func__,
 				   vl_data->vl_oi->ifp->name,
-				   inet_ntoa(vl_data->vl_peer));
+				   &vl_data->vl_peer);
 
 		if (area
 		    && !IPV4_ADDR_SAME(&vl_data->vl_area_id, &area->area_id))
@@ -1109,9 +1109,9 @@ static int ospf_vl_set_params(struct ospf_area *area,
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("%s: %s peer address: %s, cost: %d,%schanged",
+		zlog_debug("%s: %s peer address: %pI4, cost: %d,%schanged",
 			   __func__, vl_data->vl_oi->ifp->name,
-			   inet_ntoa(vl_data->peer_addr), voi->output_cost,
+			   &vl_data->peer_addr, voi->output_cost,
 			   (changed ? " " : " un"));
 
 	return changed;
@@ -1128,19 +1128,19 @@ void ospf_vl_up_check(struct ospf_area *area, struct in_addr rid,
 
 	if (IS_DEBUG_OSPF_EVENT) {
 		zlog_debug("ospf_vl_up_check(): Start");
-		zlog_debug("ospf_vl_up_check(): Router ID is %s",
-			   inet_ntoa(rid));
-		zlog_debug("ospf_vl_up_check(): Area is %s",
-			   inet_ntoa(area->area_id));
+		zlog_debug("ospf_vl_up_check(): Router ID is %pI4",
+			   &rid);
+		zlog_debug("ospf_vl_up_check(): Area is %pI4",
+			   &area->area_id);
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->vlinks, node, vl_data)) {
 		if (IS_DEBUG_OSPF_EVENT) {
-			zlog_debug("%s: considering VL, %s in area %s",
+			zlog_debug("%s: considering VL, %s in area %pI4",
 				   __func__, vl_data->vl_oi->ifp->name,
-				   inet_ntoa(vl_data->vl_area_id));
-			zlog_debug("%s: peer ID: %s", __func__,
-				   inet_ntoa(vl_data->vl_peer));
+				   &vl_data->vl_area_id);
+			zlog_debug("%s: peer ID: %pI4", __func__,
+				   &vl_data->vl_peer);
 		}
 
 		if (IPV4_ADDR_SAME(&vl_data->vl_peer, &rid)
@@ -1198,8 +1198,8 @@ int ospf_full_virtual_nbrs(struct ospf_area *area)
 {
 	if (IS_DEBUG_OSPF_EVENT) {
 		zlog_debug(
-			"counting fully adjacent virtual neighbors in area %s",
-			inet_ntoa(area->area_id));
+			"counting fully adjacent virtual neighbors in area %pI4",
+			&area->area_id);
 		zlog_debug("there are %d of them", area->full_vls);
 	}
 

--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -223,8 +223,8 @@ int ospf_dr_election(struct ospf_interface *oi)
 
 	new_state = ospf_ism_state(oi);
 
-	zlog_debug("DR-Election[1st]: Backup %s", inet_ntoa(BDR(oi)));
-	zlog_debug("DR-Election[1st]: DR     %s", inet_ntoa(DR(oi)));
+	zlog_debug("DR-Election[1st]: Backup %pI4", &BDR(oi));
+	zlog_debug("DR-Election[1st]: DR     %pI4", &DR(oi));
 
 	if (new_state != old_state
 	    && !(new_state == ISM_DROther && old_state < ISM_DROther)) {
@@ -233,8 +233,8 @@ int ospf_dr_election(struct ospf_interface *oi)
 
 		new_state = ospf_ism_state(oi);
 
-		zlog_debug("DR-Election[2nd]: Backup %s", inet_ntoa(BDR(oi)));
-		zlog_debug("DR-Election[2nd]: DR     %s", inet_ntoa(DR(oi)));
+		zlog_debug("DR-Election[2nd]: Backup %pI4", &BDR(oi));
+		zlog_debug("DR-Election[2nd]: DR     %pI4", &DR(oi));
 	}
 
 	list_delete(&el_list);

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -98,8 +98,8 @@ int ospf_lsa_refresh_delay(struct ospf_lsa *lsa)
 
 		if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
 			zlog_debug(
-				"LSA[Type%d:%s]: Refresh timer delay %d seconds",
-				lsa->data->type, inet_ntoa(lsa->data->id),
+				"LSA[Type%d:%pI4]: Refresh timer delay %d seconds",
+				lsa->data->type, &lsa->data->id,
 				delay);
 
 		assert(delay > 0);
@@ -281,8 +281,8 @@ struct lsa_header *ospf_lsa_data_dup(struct lsa_header *lsah)
 void ospf_lsa_data_free(struct lsa_header *lsah)
 {
 	if (IS_DEBUG_OSPF(lsa, LSA))
-		zlog_debug("LSA[Type%d:%s]: data freed %p", lsah->type,
-			   inet_ntoa(lsah->id), (void *)lsah);
+		zlog_debug("LSA[Type%d:%pI4]: data freed %p", lsah->type,
+			   &lsah->id, (void *)lsah);
 
 	XFREE(MTYPE_OSPF_LSA_DATA, lsah);
 }
@@ -297,8 +297,8 @@ const char *dump_lsa_key(struct ospf_lsa *lsa)
 
 	if (lsa != NULL && (lsah = lsa->data) != NULL) {
 		char id[INET_ADDRSTRLEN], ar[INET_ADDRSTRLEN];
-		strlcpy(id, inet_ntoa(lsah->id), sizeof(id));
-		strlcpy(ar, inet_ntoa(lsah->adv_router), sizeof(ar));
+		inet_ntop(AF_INET, &lsah->id, id, sizeof(id));
+		inet_ntop(AF_INET, &lsah->adv_router, ar, sizeof(ar));
 
 		snprintf(buf, sizeof(buf), "Type%d,id(%s),ar(%s)", lsah->type,
 			 id, ar);
@@ -628,10 +628,8 @@ static int lsa_link_ptomp_set(struct stream **s, struct ospf_interface *oi)
 						cost);
 					if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
 						zlog_debug(
-							"PointToMultipoint: set link to %s",
-							inet_ntoa(
-								oi->address->u
-									.prefix4));
+							"PointToMultipoint: set link to %pI4",
+							&oi->address->u.prefix4);
 				}
 
 	return links;
@@ -837,8 +835,8 @@ static struct ospf_lsa *ospf_router_lsa_originate(struct ospf_area *area)
 	ospf_flood_through_area(area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Originate router-LSA %p",
-			   new->data->type, inet_ntoa(new->data->id),
+		zlog_debug("LSA[Type%d:%pI4]: Originate router-LSA %p",
+			   new->data->type, &new->data->id,
 			   (void *)new);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -876,8 +874,8 @@ static struct ospf_lsa *ospf_router_lsa_refresh(struct ospf_lsa *lsa)
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: router-LSA refresh",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: router-LSA refresh",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -929,9 +927,9 @@ int ospf_router_lsa_update(struct ospf *ospf)
 		else if (!IPV4_ADDR_SAME(&lsa->data->id, &ospf->router_id)) {
 			if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
 				zlog_debug(
-					"LSA[Type%d:%s]: Refresh router-LSA for Area %s",
+					"LSA[Type%d:%pI4]: Refresh router-LSA for Area %s",
 					lsa->data->type,
-					inet_ntoa(lsa->data->id), area_str);
+					&lsa->data->id, area_str);
 			ospf_refresher_unregister_lsa(ospf, lsa);
 			ospf_lsa_flush_area(lsa, area);
 			ospf_lsa_unlock(&area->router_lsa_self);
@@ -1059,8 +1057,8 @@ void ospf_network_lsa_update(struct ospf_interface *oi)
 	ospf_flood_through_area(oi->area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Originate network-LSA %p",
-			   new->data->type, inet_ntoa(new->data->id),
+		zlog_debug("LSA[Type%d:%pI4]: Originate network-LSA %p",
+			   new->data->type, &new->data->id,
 			   (void *)new);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -1082,8 +1080,8 @@ static struct ospf_lsa *ospf_network_lsa_refresh(struct ospf_lsa *lsa)
 	if (oi == NULL) {
 		if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 			zlog_debug(
-				"LSA[Type%d:%s]: network-LSA refresh: no oi found, ick, ignoring.",
-				lsa->data->type, inet_ntoa(lsa->data->id));
+				"LSA[Type%d:%pI4]: network-LSA refresh: no oi found, ick, ignoring.",
+				lsa->data->type, &lsa->data->id);
 			ospf_lsa_header_dump(lsa->data);
 		}
 		return NULL;
@@ -1112,8 +1110,8 @@ static struct ospf_lsa *ospf_network_lsa_refresh(struct ospf_lsa *lsa)
 	ospf_flood_through_area(area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: network-LSA refresh",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: network-LSA refresh",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1231,8 +1229,8 @@ struct ospf_lsa *ospf_summary_lsa_originate(struct prefix_ipv4 *p,
 	ospf_flood_through_area(area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Originate summary-LSA %p",
-			   new->data->type, inet_ntoa(new->data->id),
+		zlog_debug("LSA[Type%d:%pI4]: Originate summary-LSA %p",
+			   new->data->type, &new->data->id,
 			   (void *)new);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -1267,8 +1265,8 @@ static struct ospf_lsa *ospf_summary_lsa_refresh(struct ospf *ospf,
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: summary-LSA refresh",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: summary-LSA refresh",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1374,8 +1372,8 @@ struct ospf_lsa *ospf_summary_asbr_lsa_originate(struct prefix_ipv4 *p,
 	ospf_flood_through_area(area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Originate summary-ASBR-LSA %p",
-			   new->data->type, inet_ntoa(new->data->id),
+		zlog_debug("LSA[Type%d:%pI4]: Originate summary-ASBR-LSA %p",
+			   new->data->type, &new->data->id,
 			   (void *)new);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -1408,8 +1406,8 @@ static struct ospf_lsa *ospf_summary_asbr_lsa_refresh(struct ospf *ospf,
 	ospf_flood_through_area(new->area, NULL, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: summary-ASBR-LSA refresh",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: summary-ASBR-LSA refresh",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1758,8 +1756,8 @@ static struct ospf_lsa *ospf_lsa_translated_nssa_new(struct ospf *ospf,
 	    == NULL) {
 		if (IS_DEBUG_OSPF_NSSA)
 			zlog_debug(
-				"ospf_nssa_translate_originate(): Could not originate Translated Type-5 for %s",
-				inet_ntoa(ei.p.prefix));
+				"ospf_nssa_translate_originate(): Could not originate Translated Type-5 for %pI4",
+				&ei.p.prefix);
 		return NULL;
 	}
 
@@ -1792,8 +1790,8 @@ struct ospf_lsa *ospf_translated_nssa_originate(struct ospf *ospf,
 	if ((new = ospf_lsa_translated_nssa_new(ospf, type7)) == NULL) {
 		if (IS_DEBUG_OSPF_NSSA)
 			zlog_debug(
-				"ospf_translated_nssa_originate(): Could not translate Type-7, Id %s, to Type-5",
-				inet_ntoa(type7->data->id));
+				"ospf_translated_nssa_originate(): Could not translate Type-7, Id %pI4, to Type-5",
+				&type7->data->id);
 		return NULL;
 	}
 
@@ -1802,8 +1800,8 @@ struct ospf_lsa *ospf_translated_nssa_originate(struct ospf *ospf,
 	if ((new = ospf_lsa_install(ospf, NULL, new)) == NULL) {
 		flog_warn(
 			EC_OSPF_LSA_INSTALL_FAILURE,
-			"ospf_lsa_translated_nssa_originate(): Could not install LSA id %s",
-			inet_ntoa(type7->data->id));
+			"ospf_lsa_translated_nssa_originate(): Could not install LSA id %pI4",
+			&type7->data->id);
 		return NULL;
 	}
 
@@ -1812,8 +1810,8 @@ struct ospf_lsa *ospf_translated_nssa_originate(struct ospf *ospf,
 			"ospf_translated_nssa_originate(): translated Type 7, installed:");
 		ospf_lsa_header_dump(new->data);
 		zlog_debug("   Network mask: %d", ip_masklen(extnew->mask));
-		zlog_debug("   Forward addr: %s",
-			   inet_ntoa(extnew->e[0].fwd_addr));
+		zlog_debug("   Forward addr: %pI4",
+			   &extnew->e[0].fwd_addr);
 	}
 
 	ospf->lsa_originate_count++;
@@ -1878,8 +1876,8 @@ struct ospf_lsa *ospf_translated_nssa_refresh(struct ospf *ospf,
 	if (!type7) {
 		if (IS_DEBUG_OSPF_NSSA)
 			zlog_debug(
-				"ospf_translated_nssa_refresh(): no Type-7 found for Type-5 LSA Id %s",
-				inet_ntoa(type5->data->id));
+				"ospf_translated_nssa_refresh(): no Type-7 found for Type-5 LSA Id %pI4",
+				&type5->data->id);
 		return NULL;
 	}
 
@@ -1887,8 +1885,8 @@ struct ospf_lsa *ospf_translated_nssa_refresh(struct ospf *ospf,
 	if (type5 == NULL || !CHECK_FLAG(type5->flags, OSPF_LSA_LOCAL_XLT)) {
 		if (IS_DEBUG_OSPF_NSSA)
 			zlog_debug(
-				"ospf_translated_nssa_refresh(): No translated Type-5 found for Type-7 with Id %s",
-				inet_ntoa(type7->data->id));
+				"ospf_translated_nssa_refresh(): No translated Type-5 found for Type-7 with Id %pI4",
+				&type7->data->id);
 		return NULL;
 	}
 
@@ -1899,16 +1897,16 @@ struct ospf_lsa *ospf_translated_nssa_refresh(struct ospf *ospf,
 	if ((new = ospf_lsa_translated_nssa_new(ospf, type7)) == NULL) {
 		if (IS_DEBUG_OSPF_NSSA)
 			zlog_debug(
-				"ospf_translated_nssa_refresh(): Could not translate Type-7 for %s to Type-5",
-				inet_ntoa(type7->data->id));
+				"ospf_translated_nssa_refresh(): Could not translate Type-7 for %pI4 to Type-5",
+				&type7->data->id);
 		return NULL;
 	}
 
 	if (!(new = ospf_lsa_install(ospf, NULL, new))) {
 		flog_warn(
 			EC_OSPF_LSA_INSTALL_FAILURE,
-			"ospf_translated_nssa_refresh(): Could not install translated LSA, Id %s",
-			inet_ntoa(type7->data->id));
+			"ospf_translated_nssa_refresh(): Could not install translated LSA, Id %pI4",
+			&type7->data->id);
 		return NULL;
 	}
 
@@ -1987,8 +1985,8 @@ struct ospf_lsa *ospf_external_lsa_originate(struct ospf *ospf,
 	if ((new = ospf_external_lsa_new(ospf, ei, NULL)) == NULL) {
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
-				"LSA[Type5:%s]: Could not originate AS-external-LSA",
-				inet_ntoa(ei->p.prefix));
+				"LSA[Type5:%pI4]: Could not originate AS-external-LSA",
+				&ei->p.prefix);
 		return NULL;
 	}
 
@@ -2010,8 +2008,8 @@ struct ospf_lsa *ospf_external_lsa_originate(struct ospf *ospf,
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Originate AS-external-LSA %p",
-			   new->data->type, inet_ntoa(new->data->id),
+		zlog_debug("LSA[Type%d:%pI4]: Originate AS-external-LSA %p",
+			   new->data->type, &new->data->id,
 			   (void *)new);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -2254,8 +2252,8 @@ struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *ospf,
 	if (!ospf_redistribute_check(ospf, ei, &changed)) {
 		if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
 			zlog_debug(
-				"LSA[Type%d:%s]: Could not be refreshed, redist check fail",
-				lsa->data->type, inet_ntoa(lsa->data->id));
+				"LSA[Type%d:%pI4]: Could not be refreshed, redist check fail",
+				lsa->data->type, &lsa->data->id);
 		ospf_external_lsa_flush(ospf, ei->type, &ei->p,
 					ei->ifindex /*, ei->nexthop */);
 		return NULL;
@@ -2264,8 +2262,8 @@ struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *ospf,
 	if (!changed && !force) {
 		if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
 			zlog_debug(
-				"LSA[Type%d:%s]: Not refreshed, not changed/forced",
-				lsa->data->type, inet_ntoa(lsa->data->id));
+				"LSA[Type%d:%pI4]: Not refreshed, not changed/forced",
+				lsa->data->type, &lsa->data->id);
 		return NULL;
 	}
 
@@ -2279,8 +2277,8 @@ struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *ospf,
 
 	if (new == NULL) {
 		if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
-			zlog_debug("LSA[Type%d:%s]: Could not be refreshed",
-				   lsa->data->type, inet_ntoa(lsa->data->id));
+			zlog_debug("LSA[Type%d:%pI4]: Could not be refreshed",
+				   lsa->data->type, &lsa->data->id);
 		return NULL;
 	}
 
@@ -2305,8 +2303,8 @@ struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *ospf,
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: AS-external-LSA refresh",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: AS-external-LSA refresh",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -2681,8 +2679,6 @@ struct ospf_lsa *ospf_lsa_install(struct ospf *ospf, struct ospf_interface *oi,
 
 	/* Debug logs. */
 	if (IS_DEBUG_OSPF(lsa, LSA_INSTALL)) {
-		char area_str[INET_ADDRSTRLEN];
-
 		switch (lsa->data->type) {
 		case OSPF_AS_EXTERNAL_LSA:
 		case OSPF_OPAQUE_AS_LSA:
@@ -2692,13 +2688,11 @@ struct ospf_lsa *ospf_lsa_install(struct ospf *ospf, struct ospf_interface *oi,
 					      new->data->type, NULL));
 			break;
 		default:
-			strlcpy(area_str, inet_ntoa(new->area->area_id),
-				sizeof(area_str));
-			zlog_debug("LSA[%s]: Install %s to Area %s",
+			zlog_debug("LSA[%s]: Install %s to Area %pI4",
 				   dump_lsa_key(new),
 				   lookup_msg(ospf_lsa_type_msg,
 					      new->data->type, NULL),
-				   area_str);
+				   &new->area->area_id);
 			break;
 		}
 	}
@@ -2709,8 +2703,8 @@ struct ospf_lsa *ospf_lsa_install(struct ospf *ospf, struct ospf_interface *oi,
 	 */
 	if (IS_LSA_MAXAGE(new)) {
 		if (IS_DEBUG_OSPF(lsa, LSA_INSTALL))
-			zlog_debug("LSA[Type%d:%s]: Install LSA 0x%p, MaxAge",
-				   new->data->type, inet_ntoa(new->data->id),
+			zlog_debug("LSA[Type%d:%pI4]: Install LSA 0x%p, MaxAge",
+				   new->data->type, &new->data->id,
 				   (void *)lsa);
 		ospf_lsa_maxage(ospf, lsa);
 	}
@@ -2786,16 +2780,16 @@ static int ospf_maxage_lsa_remover(struct thread *thread)
 			if (IS_LSA_SELF(lsa))
 				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 					zlog_debug(
-						"LSA[Type%d:%s]: LSA 0x%lx is self-originated: ",
+						"LSA[Type%d:%pI4]: LSA 0x%lx is self-originated: ",
 						lsa->data->type,
-						inet_ntoa(lsa->data->id),
+						&lsa->data->id,
 						(unsigned long)lsa);
 
 			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 				zlog_debug(
-					"LSA[Type%d:%s]: MaxAge LSA removed from list",
+					"LSA[Type%d:%pI4]: MaxAge LSA removed from list",
 					lsa->data->type,
-					inet_ntoa(lsa->data->id));
+					&lsa->data->id);
 
 			if (CHECK_FLAG(lsa->flags, OSPF_LSA_PREMATURE_AGE)) {
 				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
@@ -2812,9 +2806,9 @@ static int ospf_maxage_lsa_remover(struct thread *thread)
 			} else {
 				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 					zlog_debug(
-						"%s: LSA[Type%d:%s]: No associated LSDB!",
+						"%s: LSA[Type%d:%pI4]: No associated LSDB!",
 						__func__, lsa->data->type,
-						inet_ntoa(lsa->data->id));
+						&lsa->data->id);
 			}
 		}
 
@@ -2871,8 +2865,8 @@ void ospf_lsa_maxage(struct ospf *ospf, struct ospf_lsa *lsa)
 	if (CHECK_FLAG(lsa->flags, OSPF_LSA_IN_MAXAGE)) {
 		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 			zlog_debug(
-				"LSA[Type%d:%s]: %p already exists on MaxAge LSA list",
-				lsa->data->type, inet_ntoa(lsa->data->id),
+				"LSA[Type%d:%pI4]: %p already exists on MaxAge LSA list",
+				lsa->data->type, &lsa->data->id,
 				(void *)lsa);
 		return;
 	}
@@ -3107,8 +3101,8 @@ struct ospf_lsa *ospf_lsa_lookup_by_header(struct ospf_area *area,
 
 	if (match == NULL)
 		if (IS_DEBUG_OSPF(lsa, LSA) == OSPF_DEBUG_LSA)
-			zlog_debug("LSA[Type%d:%s]: Lookup by header, NO MATCH",
-				   lsah->type, inet_ntoa(lsah->id));
+			zlog_debug("LSA[Type%d:%pI4]: Lookup by header, NO MATCH",
+				   lsah->type, &lsah->id);
 
 	return match;
 }
@@ -3204,8 +3198,8 @@ int ospf_lsa_flush_schedule(struct ospf *ospf, struct ospf_lsa *lsa)
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
-			"LSA[Type%d:%s]: Schedule self-originated LSA to FLUSH",
-			lsa->data->type, inet_ntoa(lsa->data->id));
+			"LSA[Type%d:%pI4]: Schedule self-originated LSA to FLUSH",
+			lsa->data->type, &lsa->data->id);
 
 	/* Force given lsa's age to MaxAge. */
 	lsa->data->ls_age = htons(OSPF_LSA_MAXAGE);
@@ -3242,9 +3236,9 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 		if ((lsa = area->router_lsa_self) != NULL) {
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(
-					"LSA[Type%d:%s]: Schedule self-originated LSA to FLUSH",
+					"LSA[Type%d:%pI4]: Schedule self-originated LSA to FLUSH",
 					lsa->data->type,
-					inet_ntoa(lsa->data->id));
+					&lsa->data->id);
 
 			ospf_refresher_unregister_lsa(ospf, lsa);
 			ospf_lsa_flush_area(lsa, area);
@@ -3257,9 +3251,9 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 			    && oi->state == ISM_DR && oi->full_nbrs > 0) {
 				if (IS_DEBUG_OSPF_EVENT)
 					zlog_debug(
-						"LSA[Type%d:%s]: Schedule self-originated LSA to FLUSH",
+						"LSA[Type%d:%pI4]: Schedule self-originated LSA to FLUSH",
 						lsa->data->type,
-						inet_ntoa(lsa->data->id));
+						&lsa->data->id);
 
 				ospf_refresher_unregister_lsa(
 					ospf, oi->network_lsa_self);
@@ -3527,8 +3521,8 @@ void ospf_refresher_register_lsa(struct ospf *ospf, struct ospf_lsa *lsa)
 
 		if (IS_DEBUG_OSPF(lsa, LSA_REFRESH))
 			zlog_debug(
-				"LSA[Refresh:Type%d:%s]: age %d, added to index %d",
-				lsa->data->type, inet_ntoa(lsa->data->id),
+				"LSA[Refresh:Type%d:%pI4]: age %d, added to index %d",
+				lsa->data->type, &lsa->data->id,
 				LS_AGE(lsa), index);
 
 		if (!ospf->lsa_refresh_queue.qs[index])
@@ -3540,8 +3534,8 @@ void ospf_refresher_register_lsa(struct ospf *ospf, struct ospf_lsa *lsa)
 
 		if (IS_DEBUG_OSPF(lsa, LSA_REFRESH))
 			zlog_debug(
-				"LSA[Refresh:Type%d:%s]: ospf_refresher_register_lsa(): setting refresh_list on lsa %p (slod %d)",
-				lsa->data->type, inet_ntoa(lsa->data->id),
+				"LSA[Refresh:Type%d:%pI4]: ospf_refresher_register_lsa(): setting refresh_list on lsa %p (slod %d)",
+				lsa->data->type, &lsa->data->id,
 				(void *)lsa, index);
 	}
 }
@@ -3612,9 +3606,9 @@ int ospf_lsa_refresh_walker(struct thread *t)
 					       lsa)) {
 				if (IS_DEBUG_OSPF(lsa, LSA_REFRESH))
 					zlog_debug(
-						"LSA[Refresh:Type%d:%s]: ospf_lsa_refresh_walker(): refresh lsa %p (slot %d)",
+						"LSA[Refresh:Type%d:%pI4]: ospf_lsa_refresh_walker(): refresh lsa %p (slot %d)",
 						lsa->data->type,
-						inet_ntoa(lsa->data->id),
+						&lsa->data->id,
 						(void *)lsa, i);
 
 				assert(lsa->lock > 0);

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -184,8 +184,8 @@ void ospf_nbr_delete(struct ospf_neighbor *nbr)
 			rn->info = NULL;
 			route_unlock_node(rn);
 		} else
-			zlog_info("Can't find neighbor %s in the interface %s",
-				  inet_ntoa(nbr->src), IF_NAME(oi));
+			zlog_info("Can't find neighbor %pI4 in the interface %s",
+				  &nbr->src, IF_NAME(oi));
 
 		route_unlock_node(rn);
 	} else {
@@ -284,9 +284,8 @@ void ospf_nbr_add_self(struct ospf_interface *oi, struct in_addr router_id)
 		/* There is already pseudo neighbor. */
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
-				"router_id %s already present in neighbor table. node refcount %u",
-				inet_ntoa(router_id),
-				route_node_get_lock_count(rn));
+				"router_id %pI4 already present in neighbor table. node refcount %u",
+				&router_id, route_node_get_lock_count(rn));
 		route_unlock_node(rn);
 	} else
 		rn->info = oi->nbr_self;
@@ -402,8 +401,8 @@ void ospf_renegotiate_optional_capabilities(struct ospf *top)
 
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(
-					"Renegotiate optional capabilities with neighbor(%s)",
-					inet_ntoa(nbr->router_id));
+					"Renegotiate optional capabilities with neighbor(%pI4)",
+					&nbr->router_id);
 
 			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_SeqNumberMismatch);
 		}
@@ -460,8 +459,8 @@ static struct ospf_neighbor *ospf_nbr_add(struct ospf_interface *oi,
 		nbr->crypt_seqnum = ospfh->u.crypt.crypt_seqnum;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("NSM[%s:%s]: start", IF_NAME(oi),
-			   inet_ntoa(nbr->router_id));
+		zlog_debug("NSM[%s:%pI4]: start", IF_NAME(oi),
+			   &nbr->router_id);
 
 	return nbr;
 }

--- a/ospfd/ospf_network.c
+++ b/ospfd/ospf_network.c
@@ -53,14 +53,14 @@ int ospf_if_add_allspfrouters(struct ospf *top, struct prefix *p,
 	if (ret < 0)
 		flog_err(
 			EC_LIB_SOCKET,
-			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllSPFRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
-			top->fd, inet_ntoa(p->u.prefix4), ifindex,
+			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllSPFRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
+			top->fd, &p->u.prefix4, ifindex,
 			safe_strerror(errno));
 	else {
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
-				"interface %s [%u] join AllSPFRouters Multicast group.",
-				inet_ntoa(p->u.prefix4), ifindex);
+				"interface %pI4 [%u] join AllSPFRouters Multicast group.",
+				&p->u.prefix4, ifindex);
 	}
 
 	return ret;
@@ -76,14 +76,14 @@ int ospf_if_drop_allspfrouters(struct ospf *top, struct prefix *p,
 					ifindex);
 	if (ret < 0)
 		flog_err(EC_LIB_SOCKET,
-			 "can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllSPFRouters): %s",
-			 top->fd, inet_ntoa(p->u.prefix4), ifindex,
+			 "can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllSPFRouters): %s",
+			 top->fd, &p->u.prefix4, ifindex,
 			 safe_strerror(errno));
 	else {
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
-				"interface %s [%u] leave AllSPFRouters Multicast group.",
-				inet_ntoa(p->u.prefix4), ifindex);
+				"interface %pI4 [%u] leave AllSPFRouters Multicast group.",
+				&p->u.prefix4, ifindex);
 	}
 
 	return ret;
@@ -101,13 +101,13 @@ int ospf_if_add_alldrouters(struct ospf *top, struct prefix *p,
 	if (ret < 0)
 		flog_err(
 			EC_LIB_SOCKET,
-			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllDRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
-			top->fd, inet_ntoa(p->u.prefix4), ifindex,
+			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllDRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
+			top->fd, &p->u.prefix4, ifindex,
 			safe_strerror(errno));
 	else
 		zlog_debug(
-			"interface %s [%u] join AllDRouters Multicast group.",
-			inet_ntoa(p->u.prefix4), ifindex);
+			"interface %pI4 [%u] join AllDRouters Multicast group.",
+			&p->u.prefix4, ifindex);
 
 	return ret;
 }
@@ -122,13 +122,13 @@ int ospf_if_drop_alldrouters(struct ospf *top, struct prefix *p,
 					ifindex);
 	if (ret < 0)
 		flog_err(EC_LIB_SOCKET,
-			 "can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllDRouters): %s",
-			 top->fd, inet_ntoa(p->u.prefix4), ifindex,
+			 "can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllDRouters): %s",
+			 top->fd, &p->u.prefix4, ifindex,
 			 safe_strerror(errno));
 	else
 		zlog_debug(
-			"interface %s [%u] leave AllDRouters Multicast group.",
-			inet_ntoa(p->u.prefix4), ifindex);
+			"interface %pI4 [%u] leave AllDRouters Multicast group.",
+			&p->u.prefix4, ifindex);
 
 	return ret;
 }
@@ -161,8 +161,8 @@ int ospf_if_ipmulticast(struct ospf *top, struct prefix *p, ifindex_t ifindex)
 	ret = setsockopt_ipv4_multicast_if(top->fd, p->u.prefix4, ifindex);
 	if (ret < 0)
 		flog_err(EC_LIB_SOCKET,
-			 "can't setsockopt IP_MULTICAST_IF(fd %d, addr %s, ifindex %u): %s",
-			 top->fd, inet_ntoa(p->u.prefix4), ifindex,
+			 "can't setsockopt IP_MULTICAST_IF(fd %d, addr %pI4, ifindex %u): %s",
+			 top->fd, &p->u.prefix4, ifindex,
 			 safe_strerror(errno));
 #endif
 

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -66,8 +66,8 @@ static int ospf_inactivity_timer(struct thread *thread)
 	nbr->t_inactivity = NULL;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_TIMERS))
-		zlog_debug("NSM[%s:%s:%s]: Timer (Inactivity timer expire)",
-			   IF_NAME(nbr->oi), inet_ntoa(nbr->router_id),
+		zlog_debug("NSM[%s:%pI4:%s]: Timer (Inactivity timer expire)",
+			   IF_NAME(nbr->oi), &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf));
 
 	/* Dont trigger NSM_InactivityTimer event , if the current
@@ -91,8 +91,8 @@ static int ospf_db_desc_timer(struct thread *thread)
 	nbr->t_db_desc = NULL;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_TIMERS))
-		zlog_debug("NSM[%s:%s:%s]: Timer (DD Retransmit timer expire)",
-			   IF_NAME(nbr->oi), inet_ntoa(nbr->src),
+		zlog_debug("NSM[%s:%pI4:%s]: Timer (DD Retransmit timer expire)",
+			   IF_NAME(nbr->oi), &nbr->src,
 			   ospf_get_name(nbr->oi->ospf));
 
 	/* resent last send DD packet. */
@@ -398,9 +398,9 @@ static int nsm_kill_nbr(struct ospf_neighbor *nbr)
 
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
 			zlog_debug(
-				"NSM[%s:%s:%s]: Down (PollIntervalTimer scheduled)",
+				"NSM[%s:%pI4:%s]: Down (PollIntervalTimer scheduled)",
 				IF_NAME(nbr->oi),
-				inet_ntoa(nbr->address.u.prefix4),
+				&nbr->address.u.prefix4,
 				ospf_get_name(nbr->oi->ospf));
 	}
 
@@ -597,8 +597,8 @@ static void nsm_notice_state_change(struct ospf_neighbor *nbr, int next_state,
 {
 	/* Logging change of status. */
 	if (IS_DEBUG_OSPF(nsm, NSM_STATUS))
-		zlog_debug("NSM[%s:%s:%s]: State change %s -> %s (%s)",
-			   IF_NAME(nbr->oi), inet_ntoa(nbr->router_id),
+		zlog_debug("NSM[%s:%pI4:%s]: State change %s -> %s (%s)",
+			   IF_NAME(nbr->oi), &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf),
 			   lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
 			   lookup_msg(ospf_nsm_state_msg, next_state, NULL),
@@ -608,8 +608,8 @@ static void nsm_notice_state_change(struct ospf_neighbor *nbr, int next_state,
 	if (CHECK_FLAG(nbr->oi->ospf->config, OSPF_LOG_ADJACENCY_CHANGES)
 	    && (CHECK_FLAG(nbr->oi->ospf->config, OSPF_LOG_ADJACENCY_DETAIL)
 		|| (next_state == NSM_Full) || (next_state < nbr->state)))
-		zlog_notice("AdjChg: Nbr %s(%s) on %s: %s -> %s (%s)",
-			    inet_ntoa(nbr->router_id),
+		zlog_notice("AdjChg: Nbr %pI4(%s) on %s: %s -> %s (%s)",
+			    &nbr->router_id,
 			    ospf_get_name(nbr->oi->ospf), IF_NAME(nbr->oi),
 			    lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
 			    lookup_msg(ospf_nsm_state_msg, next_state, NULL),
@@ -691,8 +691,8 @@ static void nsm_change_state(struct ospf_neighbor *nbr, int state)
 
 		if (CHECK_FLAG(oi->ospf->config, OSPF_LOG_ADJACENCY_DETAIL))
 			zlog_info(
-				"%s:[%s:%s], %s -> %s): scheduling new router-LSA origination",
-				__func__, inet_ntoa(nbr->router_id),
+				"%s:[%pI4:%s], %s -> %s): scheduling new router-LSA origination",
+				__func__, &nbr->router_id,
 				ospf_get_name(oi->ospf),
 				lookup_msg(ospf_nsm_state_msg, old_state, NULL),
 				lookup_msg(ospf_nsm_state_msg, state, NULL));
@@ -749,10 +749,10 @@ static void nsm_change_state(struct ospf_neighbor *nbr, int state)
 			OSPF_DD_FLAG_I | OSPF_DD_FLAG_M | OSPF_DD_FLAG_MS;
 		if (CHECK_FLAG(oi->ospf->config, OSPF_LOG_ADJACENCY_DETAIL))
 			zlog_info(
-				"%s: Initializing [DD]: %s with seqnum:%x , flags:%x",
+				"%s: Initializing [DD]: %pI4 with seqnum:%x , flags:%x",
 				(oi->ospf->name) ? oi->ospf->name
 						 : VRF_DEFAULT_NAME,
-				inet_ntoa(nbr->router_id), nbr->dd_seqnum,
+				&nbr->router_id, nbr->dd_seqnum,
 				nbr->dd_flags);
 		ospf_db_desc_send(nbr);
 	}
@@ -777,8 +777,8 @@ int ospf_nsm_event(struct thread *thread)
 	event = THREAD_VAL(thread);
 
 	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-		zlog_debug("NSM[%s:%s:%s]: %s (%s)", IF_NAME(nbr->oi),
-			   inet_ntoa(nbr->router_id),
+		zlog_debug("NSM[%s:%pI4:%s]: %s (%s)", IF_NAME(nbr->oi),
+			   &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf),
 			   lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
 			   ospf_nsm_event_str[event]);
@@ -802,8 +802,8 @@ int ospf_nsm_event(struct thread *thread)
 			 */
 			flog_err(
 				EC_OSPF_FSM_INVALID_STATE,
-				"NSM[%s:%s:%s]: %s (%s): Warning: action tried to change next_state to %s",
-				IF_NAME(nbr->oi), inet_ntoa(nbr->router_id),
+				"NSM[%s:%pI4:%s]: %s (%s): Warning: action tried to change next_state to %s",
+				IF_NAME(nbr->oi), &nbr->router_id,
 				ospf_get_name(nbr->oi->ospf),
 				lookup_msg(ospf_nsm_state_msg, nbr->state,
 					   NULL),

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1469,8 +1469,8 @@ static int ospf_opaque_type10_lsa_originate(struct thread *t)
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
-			"Timer[Type10-LSA]: Originate Opaque-LSAs for Area %s",
-			inet_ntoa(area->area_id));
+			"Timer[Type10-LSA]: Originate Opaque-LSAs for Area %pI4",
+			&area->area_id);
 
 	rc = opaque_lsa_originate_callback(ospf_opaque_type10_funclist, area);
 
@@ -1626,8 +1626,8 @@ struct ospf_lsa *ospf_opaque_lsa_refresh(struct ospf_lsa *lsa)
 		 * LSA from the routing domain.
 		 */
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("LSA[Type%d:%s]: Flush stray Opaque-LSA",
-				   lsa->data->type, inet_ntoa(lsa->data->id));
+			zlog_debug("LSA[Type%d:%pI4]: Flush stray Opaque-LSA",
+				   lsa->data->type, &lsa->data->id);
 
 		lsa->data->ls_age = htons(OSPF_LSA_MAXAGE);
 		ospf_lsa_flush(ospf, lsa);
@@ -1701,8 +1701,8 @@ void ospf_opaque_lsa_reoriginate_schedule(void *lsa_type_dependent,
 		if ((top = area->ospf) == NULL) {
 			flog_warn(
 				EC_OSPF_LSA,
-				"ospf_opaque_lsa_reoriginate_schedule: AREA(%s) -> TOP?",
-				inet_ntoa(area->area_id));
+				"ospf_opaque_lsa_reoriginate_schedule: AREA(%pI4) -> TOP?",
+				&area->area_id);
 			goto out;
 		}
 		if (!list_isempty(ospf_opaque_type10_funclist)
@@ -1710,8 +1710,8 @@ void ospf_opaque_lsa_reoriginate_schedule(void *lsa_type_dependent,
 		    && area->t_opaque_lsa_self != NULL) {
 			flog_warn(
 				EC_OSPF_LSA,
-				"Type-10 Opaque-LSA (opaque_type=%u): Common origination for AREA(%s) has already started",
-				opaque_type, inet_ntoa(area->area_id));
+				"Type-10 Opaque-LSA (opaque_type=%u): Common origination for AREA(%pI4) has already started",
+				opaque_type, &area->area_id);
 			goto out;
 		}
 		func = ospf_opaque_type10_lsa_reoriginate_timer;
@@ -1927,8 +1927,8 @@ static int ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t)
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
-			"Timer[Type10-LSA]: Re-originate Opaque-LSAs (opaque-type=%u) for Area %s",
-			oipt->opaque_type, inet_ntoa(area->area_id));
+			"Timer[Type10-LSA]: Re-originate Opaque-LSAs (opaque-type=%u) for Area %pI4",
+			oipt->opaque_type, &area->area_id);
 
 	rc = (*functab->lsa_originator)(area);
 out:

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -544,8 +544,8 @@ static void initialize_params(struct ospf_router_info *ori)
 		if (!list_isempty(OspfRI.area_info))
 			list_delete_all_node(OspfRI.area_info);
 		for (ALL_LIST_ELEMENTS(top->areas, node, nnode, area)) {
-			zlog_debug("RI (%s): Add area %s to Router Information",
-				__func__, inet_ntoa(area->area_id));
+			zlog_debug("RI (%s): Add area %pI4 to Router Information",
+				__func__, &area->area_id);
 			new = XCALLOC(MTYPE_OSPF_ROUTER_INFO,
 				sizeof(struct ospf_ri_area_info));
 			new->area = area;
@@ -795,8 +795,8 @@ static struct ospf_lsa *ospf_router_info_lsa_new(struct ospf_area *area)
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
 		zlog_debug(
-			"LSA[Type%d:%s]: Create an Opaque-LSA/ROUTER INFORMATION instance",
-			lsa_type, inet_ntoa(lsa_id));
+			"LSA[Type%d:%pI4]: Create an Opaque-LSA/ROUTER INFORMATION instance",
+			lsa_type, &lsa_id);
 
 	top = ospf_lookup_by_vrf_id(VRF_DEFAULT);
 
@@ -874,8 +874,8 @@ static int ospf_router_info_lsa_originate_as(void *arg)
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 		zlog_debug(
-			"LSA[Type%d:%s]: Originate Opaque-LSA/ROUTER INFORMATION",
-			new->data->type, inet_ntoa(new->data->id));
+			"LSA[Type%d:%pI4]: Originate Opaque-LSA/ROUTER INFORMATION",
+			new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -943,8 +943,8 @@ static int ospf_router_info_lsa_originate_area(void *arg)
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 		zlog_debug(
-			"LSA[Type%d:%s]: Originate Opaque-LSA/ROUTER INFORMATION",
-			new->data->type, inet_ntoa(new->data->id));
+			"LSA[Type%d:%pI4]: Originate Opaque-LSA/ROUTER INFORMATION",
+			new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1094,8 +1094,8 @@ static struct ospf_lsa *ospf_router_info_lsa_refresh(struct ospf_lsa *lsa)
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 		zlog_debug(
-			"LSA[Type%d:%s]: Refresh Opaque-LSA/ROUTER INFORMATION",
-			new->data->type, inet_ntoa(new->data->id));
+			"LSA[Type%d:%pI4]: Refresh Opaque-LSA/ROUTER INFORMATION",
+			new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1247,11 +1247,11 @@ static uint16_t show_vty_pce_subtlv_address(struct vty *vty,
 
 	if (ntohs(top->address.type) == PCE_ADDRESS_TYPE_IPV4) {
 		if (vty != NULL)
-			vty_out(vty, "  PCE Address: %s\n",
-				inet_ntoa(top->address.value));
+			vty_out(vty, "  PCE Address: %pI4\n",
+				&top->address.value);
 		else
-			zlog_debug("    PCE Address: %s",
-				   inet_ntoa(top->address.value));
+			zlog_debug("    PCE Address: %pI4",
+				   &top->address.value);
 	} else {
 		/* TODO: Add support to IPv6 with inet_ntop() */
 		if (vty != NULL)
@@ -1288,9 +1288,9 @@ static uint16_t show_vty_pce_subtlv_domain(struct vty *vty,
 	if (ntohs(top->type) == PCE_DOMAIN_TYPE_AREA) {
 		tmp.s_addr = top->value;
 		if (vty != NULL)
-			vty_out(vty, "  PCE domain Area: %s\n", inet_ntoa(tmp));
+			vty_out(vty, "  PCE domain Area: %pI4\n", &tmp);
 		else
-			zlog_debug("    PCE domain Area: %s", inet_ntoa(tmp));
+			zlog_debug("    PCE domain Area: %pI4", &tmp);
 	} else {
 		if (vty != NULL)
 			vty_out(vty, "  PCE domain AS: %d\n",
@@ -1312,10 +1312,10 @@ static uint16_t show_vty_pce_subtlv_neighbor(struct vty *vty,
 	if (ntohs(top->type) == PCE_DOMAIN_TYPE_AREA) {
 		tmp.s_addr = top->value;
 		if (vty != NULL)
-			vty_out(vty, "  PCE neighbor Area: %s\n",
-				inet_ntoa(tmp));
+			vty_out(vty, "  PCE neighbor Area: %pI4\n",
+				&tmp);
 		else
-			zlog_debug("    PCE neighbor Area: %s", inet_ntoa(tmp));
+			zlog_debug("    PCE neighbor Area: %pI4", &tmp);
 	} else {
 		if (vty != NULL)
 			vty_out(vty, "  PCE neighbor AS: %d\n",
@@ -1543,8 +1543,8 @@ static void ospf_router_info_config_write_router(struct vty *vty)
 	if (OspfRI.pce_info.enabled) {
 
 		if (pce->pce_address.header.type != 0)
-			vty_out(vty, "  pce address %s\n",
-				inet_ntoa(pce->pce_address.address.value));
+			vty_out(vty, "  pce address %pI4\n",
+				&pce->pce_address.address.value);
 
 		if (pce->pce_cap_flag.header.type != 0)
 			vty_out(vty, "  pce flag 0x%x\n",
@@ -1554,8 +1554,8 @@ static void ospf_router_info_config_write_router(struct vty *vty)
 			if (domain->header.type != 0) {
 				if (domain->type == PCE_DOMAIN_TYPE_AREA) {
 					tmp.s_addr = domain->value;
-					vty_out(vty, "  pce domain area %s\n",
-						inet_ntoa(tmp));
+					vty_out(vty, "  pce domain area %pI4\n",
+						&tmp);
 				} else {
 					vty_out(vty, "  pce domain as %d\n",
 						ntohl(domain->value));
@@ -1567,8 +1567,9 @@ static void ospf_router_info_config_write_router(struct vty *vty)
 			if (neighbor->header.type != 0) {
 				if (neighbor->type == PCE_DOMAIN_TYPE_AREA) {
 					tmp.s_addr = neighbor->value;
-					vty_out(vty, "  pce neighbor area %s\n",
-						inet_ntoa(tmp));
+					vty_out(vty,
+						"  pce neighbor area %pI4\n",
+						&tmp);
 				} else {
 					vty_out(vty, "  pce neighbor as %d\n",
 						ntohl(neighbor->value));

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -307,8 +307,8 @@ void ospf_intra_add_router(struct route_table *rt, struct vertex *v,
 	lsa = (struct router_lsa *)v->lsa;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("ospf_intra_add_router: LS ID: %s",
-			   inet_ntoa(lsa->header.id));
+		zlog_debug("ospf_intra_add_router: LS ID: %pI4",
+			   &lsa->header.id);
 
 	if (!OSPF_IS_AREA_BACKBONE(area))
 		ospf_vl_up_check(area, lsa->header.id, v);
@@ -364,8 +364,7 @@ void ospf_intra_add_router(struct route_table *rt, struct vertex *v,
 	apply_mask_ipv4(&p);
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("ospf_intra_add_router: talking about %s/%d",
-			   inet_ntoa(p.prefix), p.prefixlen);
+		zlog_debug("ospf_intra_add_router: talking about %pFX", &p);
 
 	rn = route_node_get(rt, (struct prefix *)&p);
 
@@ -467,8 +466,8 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 	apply_mask_ipv4(&p);
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("ospf_intra_add_stub(): processing route to %s/%d",
-			   inet_ntoa(p.prefix), p.prefixlen);
+		zlog_debug("ospf_intra_add_stub(): processing route to %pFX",
+			   &p);
 
 	/* (1) Calculate the distance D of stub network from the root.  D is
 	   equal to the distance from the root to the router vertex
@@ -488,8 +487,8 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 	if (parent_is_root && link->link_data.s_addr == 0xffffffff
 	    && ospf_if_lookup_by_local_addr(area->ospf, NULL, link->link_id)) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("%s: ignoring host route %s/32 to self.",
-				   __func__, inet_ntoa(link->link_id));
+			zlog_debug("%s: ignoring host route %pI4/32 to self.",
+				   __func__, &link->link_id);
 		return;
 	}
 
@@ -653,8 +652,8 @@ void ospf_route_table_dump(struct route_table *rt)
 					   or->cost);
 				for (ALL_LIST_ELEMENTS_RO(or->paths, pnode,
 							  path))
-					zlog_debug("  -> %s",
-						   inet_ntoa(path->nexthop));
+					zlog_debug("  -> %pI4",
+						   &path->nexthop);
 			} else
 				zlog_debug("R %-18pI4 %-15pI4 %s %d",
 					   &rn->p.u.prefix4,
@@ -682,11 +681,12 @@ void ospf_route_table_print(struct vty *vty, struct route_table *rt)
 					or->cost);
 				for (ALL_LIST_ELEMENTS_RO(or->paths, pnode,
 							  path))
-					vty_out(vty, "  -> %s\n",
-						path->nexthop.s_addr != 0
-							? inet_ntoa(
-								path->nexthop)
-							: "directly connected");
+					if (path->nexthop.s_addr != 0)
+						vty_out(vty, "  -> %pI4\n",
+							&path->nexthop);
+					else
+						vty_out(vty, "  -> %s\n",
+							"directly connected");
 			} else
 				vty_out(vty, "R %-18pI4 %-15pI4 %s %d\n",
 					&rn->p.u.prefix4, & or->u.std.area_id,
@@ -896,9 +896,8 @@ void ospf_prune_unreachable_networks(struct route_table *rt)
 			or = rn->info;
 			if (listcount(or->paths) == 0) {
 				if (IS_DEBUG_OSPF_EVENT)
-					zlog_debug("Pruning route to %s/%d",
-						   inet_ntoa(rn->p.u.prefix4),
-						   rn->p.prefixlen);
+					zlog_debug("Pruning route to %pFX",
+						   &rn->p);
 
 				ospf_route_free(or);
 				rn->info = NULL;
@@ -926,11 +925,11 @@ void ospf_prune_unreachable_routers(struct route_table *rtrs)
 		for (ALL_LIST_ELEMENTS(paths, node, nnode, or)) {
 			if (listcount(or->paths) == 0) {
 				if (IS_DEBUG_OSPF_EVENT) {
-					zlog_debug("Pruning route to rtr %s",
-						   inet_ntoa(rn->p.u.prefix4));
+					zlog_debug("Pruning route to rtr %pI4",
+						   &rn->p.u.prefix4);
 					zlog_debug(
-						"               via area %s",
-						inet_ntoa(or->u.std.area_id));
+						"               via area %pI4",
+						&or->u.std.area_id);
 				}
 
 				listnode_delete(paths, or);
@@ -940,8 +939,8 @@ void ospf_prune_unreachable_routers(struct route_table *rtrs)
 
 		if (listcount(paths) == 0) {
 			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug("Pruning router node %s",
-					   inet_ntoa(rn->p.u.prefix4));
+				zlog_debug("Pruning router node %pI4",
+					   &rn->p.u.prefix4);
 
 			list_delete(&paths);
 			rn->info = NULL;

--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -2455,8 +2455,8 @@ static void ospfTrapNbrStateChange(struct ospf_neighbor *on)
 
 	ospf_nbr_state_message(on, msgbuf, sizeof(msgbuf));
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_info("%s: trap sent: %s now %s", __func__,
-			  inet_ntoa(on->address.u.prefix4), msgbuf);
+		zlog_info("%s: trap sent: %pI4 now %s", __func__,
+			  &on->address.u.prefix4, msgbuf);
 
 	oid_copy_addr(index, &(on->address.u.prefix4), IN_ADDR_SIZE);
 	index[IN_ADDR_SIZE] = 0;
@@ -2513,8 +2513,8 @@ static void ospfTrapIfStateChange(struct ospf_interface *oi)
 	oid index[sizeof(oid) * (IN_ADDR_SIZE + 1)];
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_info("%s: trap sent: %s now %s", __func__,
-			  inet_ntoa(oi->address->u.prefix4),
+		zlog_info("%s: trap sent: %pI4 now %s", __func__,
+			  &oi->address->u.prefix4,
 			  lookup_msg(ospf_ism_state_msg, oi->state, NULL));
 
 	oid_copy_addr(index, &(oi->address->u.prefix4), IN_ADDR_SIZE);

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1043,8 +1043,8 @@ static void ospf_mpls_te_nsm_change(struct ospf_neighbor *nbr, int old_state)
 
 	if (IS_DEBUG_OSPF_TE)
 		zlog_debug(
-			"MPLS-TE (%s): Add Link-ID %s for interface %s ",
-			__func__, inet_ntoa(lp->link_id.value), oi->ifp->name);
+			"MPLS-TE (%s): Add Link-ID %pI4 for interface %s ",
+			__func__, &lp->link_id.value, oi->ifp->name);
 
 	/* Try to Schedule LSA */
 	if (OspfMplsTE.enabled) {
@@ -1187,8 +1187,8 @@ static struct ospf_lsa *ospf_mpls_te_lsa_new(struct ospf *ospf,
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE))
 		zlog_debug(
-			"LSA[Type%d:%s]: Create an Opaque-LSA/MPLS-TE instance",
-			lsa_type, inet_ntoa(lsa_id));
+			"LSA[Type%d:%pI4]: Create an Opaque-LSA/MPLS-TE instance",
+			lsa_type, &lsa_id);
 
 	/* Set opaque-LSA body fields. */
 	ospf_mpls_te_lsa_body_set(s, lp);
@@ -1243,11 +1243,9 @@ static int ospf_mpls_te_lsa_originate1(struct ospf_area *area,
 	ospf_flood_through_area(area, NULL /*nbr*/, new);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		char area_id[INET_ADDRSTRLEN];
-		strlcpy(area_id, inet_ntoa(area->area_id), sizeof(area_id));
 		zlog_debug(
-			"LSA[Type%d:%s]: Originate Opaque-LSA/MPLS-TE: Area(%s), Link(%s)",
-			new->data->type, inet_ntoa(new->data->id), area_id,
+			"LSA[Type%d:%pI4]: Originate Opaque-LSA/MPLS-TE: Area(%pI4), Link(%s)",
+			new->data->type, &new->data->id, &area->area_id,
 			lp->ifp->name);
 		ospf_lsa_header_dump(new->data);
 	}
@@ -1302,8 +1300,8 @@ static int ospf_mpls_te_lsa_originate_area(void *arg)
 		/* Ok, let's try to originate an LSA for this area and Link. */
 		if (IS_DEBUG_OSPF_TE)
 			zlog_debug(
-				"MPLS-TE(ospf_mpls_te_lsa_originate_area) Let's finally reoriginate the LSA %d through the Area %s for Link %s",
-				lp->instance, inet_ntoa(area->area_id),
+				"MPLS-TE(ospf_mpls_te_lsa_originate_area) Let's finally reoriginate the LSA %d through the Area %pI4 for Link %s",
+				lp->instance, &area->area_id,
 				lp->ifp ? lp->ifp->name : "?");
 		if (ospf_mpls_te_lsa_originate1(area, lp) != 0)
 			return rc;
@@ -1347,8 +1345,8 @@ static int ospf_mpls_te_lsa_originate2(struct ospf *top,
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 		zlog_debug(
-			"LSA[Type%d:%s]: Originate Opaque-LSA/MPLS-TE Inter-AS",
-			new->data->type, inet_ntoa(new->data->id));
+			"LSA[Type%d:%pI4]: Originate Opaque-LSA/MPLS-TE Inter-AS",
+			new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1490,8 +1488,8 @@ static struct ospf_lsa *ospf_mpls_te_lsa_refresh(struct ospf_lsa *lsa)
 
 	/* Debug logging. */
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
-		zlog_debug("LSA[Type%d:%s]: Refresh Opaque-LSA/MPLS-TE",
-			   new->data->type, inet_ntoa(new->data->id));
+		zlog_debug("LSA[Type%d:%pI4]: Refresh Opaque-LSA/MPLS-TE",
+			   new->data->type, &new->data->id);
 		ospf_lsa_header_dump(new->data);
 	}
 
@@ -1593,9 +1591,9 @@ static uint16_t show_vty_router_addr(struct vty *vty, struct tlv_header *tlvh)
 	struct te_tlv_router_addr *top = (struct te_tlv_router_addr *)tlvh;
 
 	if (vty != NULL)
-		vty_out(vty, "  Router-Address: %s\n", inet_ntoa(top->value));
+		vty_out(vty, "  Router-Address: %pI4\n", &top->value);
 	else
-		zlog_debug("    Router-Address: %s", inet_ntoa(top->value));
+		zlog_debug("    Router-Address: %pI4", &top->value);
 
 	return TLV_SIZE(tlvh);
 }
@@ -1648,9 +1646,9 @@ static uint16_t show_vty_link_subtlv_link_id(struct vty *vty,
 
 	top = (struct te_link_subtlv_link_id *)tlvh;
 	if (vty != NULL)
-		vty_out(vty, "  Link-ID: %s\n", inet_ntoa(top->value));
+		vty_out(vty, "  Link-ID: %pI4\n", &top->value);
 	else
-		zlog_debug("    Link-ID: %s", inet_ntoa(top->value));
+		zlog_debug("    Link-ID: %pI4", &top->value);
 
 	return TLV_SIZE(tlvh);
 }
@@ -1671,11 +1669,9 @@ static uint16_t show_vty_link_subtlv_lclif_ipaddr(struct vty *vty,
 
 	for (i = 0; i < n; i++) {
 		if (vty != NULL)
-			vty_out(vty, "    #%d: %s\n", i,
-				inet_ntoa(top->value[i]));
+			vty_out(vty, "    #%d: %pI4\n", i, &top->value[i]);
 		else
-			zlog_debug("      #%d: %s", i,
-				   inet_ntoa(top->value[i]));
+			zlog_debug("      #%d: %pI4", i, &top->value[i]);
 	}
 	return TLV_SIZE(tlvh);
 }
@@ -1695,11 +1691,9 @@ static uint16_t show_vty_link_subtlv_rmtif_ipaddr(struct vty *vty,
 
 	for (i = 0; i < n; i++) {
 		if (vty != NULL)
-			vty_out(vty, "    #%d: %s\n", i,
-				inet_ntoa(top->value[i]));
+			vty_out(vty, "    #%d: %pI4\n", i, &top->value[i]);
 		else
-			zlog_debug("      #%d: %s", i,
-				   inet_ntoa(top->value[i]));
+			zlog_debug("      #%d: %pI4", i, &top->value[i]);
 	}
 	return TLV_SIZE(tlvh);
 }
@@ -1811,15 +1805,15 @@ static uint16_t show_vty_link_subtlv_lrrid(struct vty *vty,
 	top = (struct te_link_subtlv_lrrid *)tlvh;
 
 	if (vty != NULL) {
-		vty_out(vty, "  Local  TE Router ID: %s\n",
-			inet_ntoa(top->local));
-		vty_out(vty, "  Remote TE Router ID: %s\n",
-			inet_ntoa(top->remote));
+		vty_out(vty, "  Local  TE Router ID: %pI4\n",
+			&top->local);
+		vty_out(vty, "  Remote TE Router ID: %pI4\n",
+			&top->remote);
 	} else {
-		zlog_debug("    Local  TE Router ID: %s",
-			   inet_ntoa(top->local));
-		zlog_debug("    Remote TE Router ID: %s",
-			   inet_ntoa(top->remote));
+		zlog_debug("    Local  TE Router ID: %pI4",
+			   &top->local);
+		zlog_debug("    Remote TE Router ID: %pI4",
+			   &top->remote);
 	}
 
 	return TLV_SIZE(tlvh);
@@ -1855,11 +1849,11 @@ static uint16_t show_vty_link_subtlv_rip(struct vty *vty,
 	top = (struct te_link_subtlv_rip *)tlvh;
 
 	if (vty != NULL)
-		vty_out(vty, "  Inter-AS TE Remote ASBR IP address: %s\n",
-			inet_ntoa(top->value));
+		vty_out(vty, "  Inter-AS TE Remote ASBR IP address: %pI4\n",
+			&top->value);
 	else
-		zlog_debug("    Inter-AS TE Remote ASBR IP address: %s",
-			   inet_ntoa(top->value));
+		zlog_debug("    Inter-AS TE Remote ASBR IP address: %pI4",
+			   &top->value);
 
 	return TLV_SIZE(tlvh);
 }
@@ -2160,15 +2154,15 @@ static void ospf_mpls_te_config_write_router(struct vty *vty)
 
 	if (OspfMplsTE.enabled) {
 		vty_out(vty, " mpls-te on\n");
-		vty_out(vty, " mpls-te router-address %s\n",
-			inet_ntoa(OspfMplsTE.router_addr.value));
+		vty_out(vty, " mpls-te router-address %pI4\n",
+			&OspfMplsTE.router_addr.value);
 	}
 
 	if (OspfMplsTE.inter_as == AS)
 		vty_out(vty, "  mpls-te inter-as as\n");
 	if (OspfMplsTE.inter_as == Area)
-		vty_out(vty, "  mpls-te inter-as area %s \n",
-			inet_ntoa(OspfMplsTE.interas_areaid));
+		vty_out(vty, "  mpls-te inter-as area %pI4 \n",
+			&OspfMplsTE.interas_areaid);
 
 	return;
 }

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -408,8 +408,8 @@ bool ospf_external_default_routemap_apply_walk(struct ospf *ospf,
 
 	if (ret && ei) {
 		if (IS_DEBUG_OSPF_DEFAULT_INFO)
-			zlog_debug("Default originate routemap permit ei: %s",
-				   inet_ntoa(ei->p.prefix));
+			zlog_debug("Default originate routemap permit ei: %pI4",
+				   &ei->p.prefix);
 		return true;
 	}
 
@@ -850,8 +850,8 @@ static int ospf_external_lsa_originate_check(struct ospf *ospf,
 	/* If prefix is multicast, then do not originate LSA. */
 	if (IN_MULTICAST(htonl(ei->p.prefix.s_addr))) {
 		zlog_info(
-			"LSA[Type5:%s]: Not originate AS-external-LSA, Prefix belongs multicast",
-			inet_ntoa(ei->p.prefix));
+			"LSA[Type5:%pI4]: Not originate AS-external-LSA, Prefix belongs multicast",
+			&ei->p.prefix);
 		return 0;
 	}
 
@@ -943,16 +943,16 @@ static bool ospf_external_lsa_default_routemap_apply(struct ospf *ospf,
 	}
 
 	if (IS_DEBUG_OSPF_DEFAULT_INFO)
-		zlog_debug("Apply default originate routemap on ei: %s cmd: %d",
-			   inet_ntoa(ei->p.prefix), cmd);
+		zlog_debug("Apply default originate routemap on ei: %pI4 cmd: %d",
+			   &ei->p.prefix, cmd);
 
 	ret = ospf_external_info_apply_default_routemap(ospf, ei, default_ei);
 
 	/* If deny then nothing to be done both in add and del case. */
 	if (!ret) {
 		if (IS_DEBUG_OSPF_DEFAULT_INFO)
-			zlog_debug("Default originte routemap deny for ei: %s",
-				   inet_ntoa(ei->p.prefix));
+			zlog_debug("Default originte routemap deny for ei: %pI4",
+				   &ei->p.prefix);
 		return false;
 	}
 
@@ -990,8 +990,8 @@ static bool ospf_external_lsa_default_routemap_apply(struct ospf *ospf,
 
 		if (IS_DEBUG_OSPF_DEFAULT_INFO)
 			zlog_debug(
-				"Running default route-map again as ei: %s deleted",
-				inet_ntoa(ei->p.prefix));
+				"Running default route-map again as ei: %pI4 deleted",
+				&ei->p.prefix);
 		/*
 		 * if this route delete was permitted then we need to check
 		 * there are any other external info which can still trigger
@@ -1192,9 +1192,8 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 							    zebra,
 							    ZEBRA_REDISTRIBUTE))
 							zlog_debug(
-								"ospf_zebra_read_route() : %s refreshing LSA",
-								inet_ntoa(
-									p.prefix));
+								"ospf_zebra_read_route() : %pI4 refreshing LSA",
+								&p.prefix);
 						ospf_external_lsa_refresh(
 							ospf, current, ei,
 							LSA_REFRESH_FORCE);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -103,8 +103,8 @@ void ospf_router_id_update(struct ospf *ospf)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("Router-ID[OLD:%s]: Update",
-			   inet_ntoa(ospf->router_id));
+		zlog_debug("Router-ID[OLD:%pI4]: Update",
+			   &ospf->router_id);
 
 	router_id_old = ospf->router_id;
 
@@ -123,8 +123,8 @@ void ospf_router_id_update(struct ospf *ospf)
 		router_id = ospf->router_id_zebra;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("Router-ID[OLD:%s]: Update to %s",
-			   inet_ntoa(ospf->router_id), inet_ntoa(router_id));
+		zlog_debug("Router-ID[OLD:%pI4]: Update to %pI4",
+			   &ospf->router_id, &router_id);
 
 	if (!IPV4_ADDR_SAME(&router_id_old, &router_id)) {
 
@@ -162,8 +162,8 @@ void ospf_router_id_update(struct ospf *ospf)
 
 		ospf->router_id = router_id;
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("Router-ID[NEW:%s]: Update",
-				   inet_ntoa(ospf->router_id));
+			zlog_debug("Router-ID[NEW:%pI4]: Update",
+				   &ospf->router_id);
 
 		/* Flush (inline) all external LSAs which now match the new
 		   router-id,
@@ -1338,10 +1338,10 @@ void ospf_if_update(struct ospf *ospf, struct interface *ifp)
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
-			"%s: interface %s ifp->vrf_id %u ospf vrf %s vrf_id %u router_id %s",
+			"%s: interface %s ifp->vrf_id %u ospf vrf %s vrf_id %u router_id %pI4",
 			__func__, ifp->name, ifp->vrf_id,
 			ospf_vrf_id_to_name(ospf->vrf_id), ospf->vrf_id,
-			inet_ntoa(ospf->router_id));
+			&ospf->router_id);
 
 	/* OSPF must be ready. */
 	if (!ospf_is_ready(ospf))
@@ -1378,16 +1378,16 @@ static void ospf_area_type_set(struct ospf_area *area, int type)
 
 	if (area->external_routing == type) {
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("Area[%s]: Types are the same, ignored.",
-				   inet_ntoa(area->area_id));
+			zlog_debug("Area[%pI4]: Types are the same, ignored.",
+				   &area->area_id);
 		return;
 	}
 
 	area->external_routing = type;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("Area[%s]: Configured as %s",
-			   inet_ntoa(area->area_id),
+		zlog_debug("Area[%pI4]: Configured as %s",
+			   &area->area_id,
 			   lookup_msg(ospf_area_type_msg, type, NULL));
 
 	switch (area->external_routing) {

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -308,8 +308,8 @@ void connected_add_ipv4(struct interface *ifp, int flags, struct in_addr *addr,
 			if (IPV4_ADDR_SAME(addr, dest))
 				flog_warn(
 					EC_ZEBRA_IFACE_SAME_LOCAL_AS_PEER,
-					"warning: interface %s has same local and peer address %s, routing protocols may malfunction",
-					ifp->name, inet_ntoa(*addr));
+					"warning: interface %s has same local and peer address %pI4, routing protocols may malfunction",
+					ifp->name, addr);
 		} else {
 			zlog_debug(
 				"warning: %s called for interface %s with peer flag set, but no peer address supplied",
@@ -322,8 +322,8 @@ void connected_add_ipv4(struct interface *ifp, int flags, struct in_addr *addr,
 	if (!dest && (prefixlen == IPV4_MAX_PREFIXLEN)
 		&& if_is_pointopoint(ifp))
 		zlog_debug(
-			"warning: PtP interface %s with addr %s/%d needs a peer address",
-			ifp->name, inet_ntoa(*addr), prefixlen);
+			"warning: PtP interface %s with addr %pI4/%d needs a peer address",
+			ifp->name, addr, prefixlen);
 
 	/* Label of this address. */
 	if (label)

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1494,14 +1494,14 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 		vxlan_info = &zebra_if->l2info.vxl;
 		vty_out(vty, "  VxLAN Id %u", vxlan_info->vni);
 		if (vxlan_info->vtep_ip.s_addr != INADDR_ANY)
-			vty_out(vty, " VTEP IP: %s",
-				inet_ntoa(vxlan_info->vtep_ip));
+			vty_out(vty, " VTEP IP: %pI4",
+				&vxlan_info->vtep_ip);
 		if (vxlan_info->access_vlan)
 			vty_out(vty, " Access VLAN Id %u\n",
 				vxlan_info->access_vlan);
 		if (vxlan_info->mcast_grp.s_addr != INADDR_ANY)
-			vty_out(vty, "  Mcast Group %s",
-					inet_ntoa(vxlan_info->mcast_grp));
+			vty_out(vty, "  Mcast Group %pI4",
+					&vxlan_info->mcast_grp);
 		if (vxlan_info->ifindex_link &&
 		    (vxlan_info->link_nsid != NS_UNKNOWN)) {
 				struct interface *ifp;
@@ -1607,8 +1607,8 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 			vty_out(vty, "    Utilized Bandwidth %g (Byte/s)\n",
 				iflp->use_bw);
 		if (IS_PARAM_SET(iflp, LP_RMT_AS))
-			vty_out(vty, "    Neighbor ASBR IP: %s AS: %u \n",
-				inet_ntoa(iflp->rmt_ip), iflp->rmt_as);
+			vty_out(vty, "    Neighbor ASBR IP: %pI4 AS: %u \n",
+				&iflp->rmt_ip, iflp->rmt_as);
 	}
 
 	hook_call(zebra_if_extra_info, vty, ifp);
@@ -3496,7 +3496,7 @@ static int link_params_config_write(struct vty *vty, struct interface *ifp)
 	if (IS_PARAM_SET(iflp, LP_USE_BW))
 		vty_out(vty, "  use-bw %g\n", iflp->use_bw);
 	if (IS_PARAM_SET(iflp, LP_RMT_AS))
-		vty_out(vty, "  neighbor %s as %u\n", inet_ntoa(iflp->rmt_ip),
+		vty_out(vty, "  neighbor %pI4 as %u\n", &iflp->rmt_ip,
 			iflp->rmt_as);
 	vty_out(vty, "  exit-link-params\n");
 	return 0;

--- a/zebra/irdp_packet.c
+++ b/zebra/irdp_packet.c
@@ -79,6 +79,7 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	struct zebra_if *zi;
 	struct irdp_interface *irdp;
 	uint16_t saved_chksum;
+	char buf[PREFIX_STRLEN];
 
 	zi = ifp->info;
 	if (!zi)
@@ -104,8 +105,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 
 	if (iplen < ICMP_MINLEN) {
 		flog_err(EC_ZEBRA_IRDP_LEN_MISMATCH,
-			 "IRDP: RX ICMP packet too short from %s\n",
-			 inet_ntoa(src));
+			 "IRDP: RX ICMP packet too short from %pI4\n",
+			 &src);
 		return;
 	}
 
@@ -115,8 +116,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	 len of IP-header) 14+20 */
 	if (iplen > IRDP_RX_BUF - 34) {
 		flog_err(EC_ZEBRA_IRDP_LEN_MISMATCH,
-			 "IRDP: RX ICMP packet too long from %s\n",
-			 inet_ntoa(src));
+			 "IRDP: RX ICMP packet too long from %pI4\n",
+			 &src);
 		return;
 	}
 
@@ -128,8 +129,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	if (in_cksum(icmp, datalen) != saved_chksum) {
 		flog_warn(
 			EC_ZEBRA_IRDP_BAD_CHECKSUM,
-			"IRDP: RX ICMP packet from %s. Bad checksum, silently ignored",
-			inet_ntoa(src));
+			"IRDP: RX ICMP packet from %pI4 Bad checksum, silently ignored",
+			&src);
 		return;
 	}
 
@@ -141,8 +142,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	if (icmp->code != 0) {
 		flog_warn(
 			EC_ZEBRA_IRDP_BAD_TYPE_CODE,
-			"IRDP: RX packet type %d from %s. Bad ICMP type code, silently ignored",
-			icmp->type, inet_ntoa(src));
+			"IRDP: RX packet type %d from %pI4 Bad ICMP type code, silently ignored",
+			icmp->type, &src);
 		return;
 	}
 
@@ -152,11 +153,12 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 		&& !(irdp->flags & IF_BROADCAST))) {
 		flog_warn(
 			EC_ZEBRA_IRDP_BAD_RX_FLAGS,
-			"IRDP: RX illegal from %s to %s while %s operates in %s; Please correct settings\n",
-			inet_ntoa(src),
+			"IRDP: RX illegal from %pI4 to %s while %s operates in %s; Please correct settings\n",
+			&src,
 			ntohl(ip->ip_dst.s_addr) == INADDR_ALLRTRS_GROUP
 				? "multicast"
-				: inet_ntoa(ip->ip_dst),
+				: inet_ntop(AF_INET, &ip->ip_dst,
+					    buf, sizeof(buf)),
 			ifp->name,
 			irdp->flags & IF_BROADCAST ? "broadcast" : "multicast");
 		return;
@@ -169,8 +171,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	case ICMP_ROUTERSOLICIT:
 
 		if (irdp->flags & IF_DEBUG_MESSAGES)
-			zlog_debug("IRDP: RX Solicit on %s from %s",
-				   ifp->name, inet_ntoa(src));
+			zlog_debug("IRDP: RX Solicit on %s from %pI4",
+				   ifp->name, &src);
 
 		process_solicit(ifp);
 		break;
@@ -178,8 +180,8 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	default:
 		flog_warn(
 			EC_ZEBRA_IRDP_BAD_TYPE_CODE,
-			"IRDP: RX packet type %d from %s. Bad ICMP type code, silently ignored",
-			icmp->type, inet_ntoa(src));
+			"IRDP: RX packet type %d from %pI4 Bad ICMP type code, silently ignored",
+			icmp->type, &src);
 	}
 }
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -903,8 +903,6 @@ static int netlink_route_change_read_multicast(struct nlmsghdr *h,
 	int count;
 	int oif[256];
 	int oif_count = 0;
-	char sbuf[40];
-	char gbuf[40];
 	char oif_list[256] = "\0";
 	vrf_id_t vrf;
 	int table;
@@ -966,8 +964,6 @@ static int netlink_route_change_read_multicast(struct nlmsghdr *h,
 		struct interface *ifp = NULL;
 		struct zebra_vrf *zvrf = NULL;
 
-		strlcpy(sbuf, inet_ntoa(m->sg.src), sizeof(sbuf));
-		strlcpy(gbuf, inet_ntoa(m->sg.grp), sizeof(gbuf));
 		for (count = 0; count < oif_count; count++) {
 			ifp = if_lookup_by_index(oif[count], vrf);
 			char temp[256];
@@ -979,9 +975,10 @@ static int netlink_route_change_read_multicast(struct nlmsghdr *h,
 		zvrf = zebra_vrf_lookup_by_id(vrf);
 		ifp = if_lookup_by_index(iif, vrf);
 		zlog_debug(
-			"MCAST VRF: %s(%d) %s (%s,%s) IIF: %s(%d) OIF: %s jiffies: %lld",
+			"MCAST VRF: %s(%d) %s (%pI4,%pI4) IIF: %s(%d) OIF: %s jiffies: %lld",
 			zvrf_name(zvrf), vrf, nl_msg_type_to_str(h->nlmsg_type),
-			sbuf, gbuf, ifp ? ifp->name : "Unknown", iif, oif_list,
+			&m->sg.src, &m->sg.grp, ifp ? ifp->name : "Unknown",
+			iif, oif_list,
 			m->lastused);
 	}
 	return 0;
@@ -2890,8 +2887,8 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 		dst_present = 1;
 		memcpy(&vtep_ip.s_addr, RTA_DATA(tb[NDA_DST]),
 		       IPV4_MAX_BYTELEN);
-		snprintf(dst_buf, sizeof(dst_buf), " dst %s",
-			 inet_ntoa(vtep_ip));
+		snprintfrr(dst_buf, sizeof(dst_buf), " dst %pI4",
+			   &vtep_ip);
 	}
 
 	if (tb[NDA_NH_ID])
@@ -3948,8 +3945,8 @@ static int netlink_fdb_nh_update(uint32_t nh_id, struct in_addr vtep_ip)
 		return -1;
 
 	if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH) {
-		zlog_debug("Tx %s fdb-nh 0x%x %s",
-			   nl_msg_type_to_str(cmd), nh_id, inet_ntoa(vtep_ip));
+		zlog_debug("Tx %s fdb-nh 0x%x %pI4",
+			   nl_msg_type_to_str(cmd), nh_id, &vtep_ip);
 	}
 
 	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns,

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3209,8 +3209,8 @@ enum zebra_dplane_result dplane_vtep_add(const struct interface *ifp,
 	struct ipaddr addr;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Install %s into flood list for VNI %u intf %s(%u)",
-			   inet_ntoa(*ip), vni, ifp->name, ifp->ifindex);
+		zlog_debug("Install %pI4 into flood list for VNI %u intf %s(%u)",
+			   ip, vni, ifp->name, ifp->ifindex);
 
 	SET_IPADDR_V4(&addr);
 	addr.ipaddr_v4 = *ip;
@@ -3234,8 +3234,8 @@ enum zebra_dplane_result dplane_vtep_delete(const struct interface *ifp,
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug(
-			"Uninstall %s from flood list for VNI %u intf %s(%u)",
-			inet_ntoa(*ip), vni, ifp->name, ifp->ifindex);
+			"Uninstall %pI4 from flood list for VNI %u intf %s(%u)",
+			ip, vni, ifp->name, ifp->ifindex);
 
 	SET_IPADDR_V4(&addr);
 	addr.ipaddr_v4 = *ip;

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1933,7 +1933,7 @@ static int fpm_remote_srv_write(struct vty *vty)
 	if ((zfpm_g->fpm_server != FPM_DEFAULT_IP
 	     && zfpm_g->fpm_server != INADDR_ANY)
 	    || (zfpm_g->fpm_port != FPM_DEFAULT_PORT && zfpm_g->fpm_port != 0))
-		vty_out(vty, "fpm connection ip %s port %d\n", inet_ntoa(in),
+		vty_out(vty, "fpm connection ip %pI4 port %d\n", &in,
 			zfpm_g->fpm_port);
 
 	return 0;

--- a/zebra/zebra_fpm_dt.c
+++ b/zebra/zebra_fpm_dt.c
@@ -181,6 +181,7 @@ static void zfpm_dt_log_fpm_message(Fpm__Message *msg)
 	char *if_name;
 	size_t i;
 	char buf[INET6_ADDRSTRLEN];
+	char addr_buf[PREFIX_STRLEN];
 	union g_addr nh_addr;
 
 	if (msg->type != FPM__MESSAGE__TYPE__ADD_ROUTE)
@@ -213,7 +214,9 @@ static void zfpm_dt_log_fpm_message(Fpm__Message *msg)
 
 		zfpm_debug("Nexthop - if_index: %d (%s), gateway: %s, ",
 			   if_index, if_name ? if_name : "name not specified",
-			   nexthop->address ? inet_ntoa(nh_addr.ipv4) : "None");
+			   nexthop->address ?
+			   inet_ntop(AF_INET, &nh_addr.ipv4,
+				     addr_buf, sizeof(addr_buf)) : "None");
 	}
 }
 

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -1502,7 +1502,8 @@ static json_object *nhlfe_json(zebra_nhlfe_t *nhlfe)
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 		json_object_string_add(json_nhlfe, "nexthop",
-				       inet_ntoa(nexthop->gate.ipv4));
+				       inet_ntop(AF_INET, &nexthop->gate.ipv4,
+						 buf, sizeof(buf)));
 		break;
 	case NEXTHOP_TYPE_IPV6:
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
@@ -1560,7 +1561,7 @@ static void nhlfe_print(zebra_nhlfe_t *nhlfe, struct vty *vty,
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		vty_out(vty, "  via %s", inet_ntoa(nexthop->gate.ipv4));
+		vty_out(vty, "  via %pI4", &nexthop->gate.ipv4);
 		if (nexthop->ifindex)
 			vty_out(vty, " dev %s",
 				ifindex2ifname(nexthop->ifindex,

--- a/zebra/zebra_mroute.c
+++ b/zebra/zebra_mroute.c
@@ -47,8 +47,8 @@ void zebra_ipmr_route_stats(ZAPI_HANDLER_ARGS)
 		char sbuf[40];
 		char gbuf[40];
 
-		strlcpy(sbuf, inet_ntoa(mroute.sg.src), sizeof(sbuf));
-		strlcpy(gbuf, inet_ntoa(mroute.sg.grp), sizeof(gbuf));
+		inet_ntop(AF_INET, &mroute.sg.src, sbuf, sizeof(sbuf));
+		inet_ntop(AF_INET, &mroute.sg.grp, gbuf, sizeof(gbuf));
 
 		zlog_debug("Asking for (%s,%s)[%s(%u)] mroute information",
 			   sbuf, gbuf, zvrf->vrf->name, zvrf->vrf->vrf_id);

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1197,7 +1197,7 @@ static void print_nh(struct nexthop *nexthop, struct vty *vty)
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		vty_out(vty, " via %s", inet_ntoa(nexthop->gate.ipv4));
+		vty_out(vty, " via %pI4", &nexthop->gate.ipv4);
 		if (nexthop->ifindex)
 			vty_out(vty, ", %s",
 				ifindex2ifname_per_ns(zns, nexthop->ifindex));

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -304,8 +304,8 @@ static void show_nexthop_detail_helper(struct vty *vty,
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		vty_out(vty, " %s",
-			inet_ntoa(nexthop->gate.ipv4));
+		vty_out(vty, " %pI4",
+			&nexthop->gate.ipv4);
 		if (nexthop->ifindex)
 			vty_out(vty, ", via %s",
 				ifindex2ifname(
@@ -508,7 +508,7 @@ static void show_route_nexthop_helper(struct vty *vty,
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		vty_out(vty, " via %s", inet_ntoa(nexthop->gate.ipv4));
+		vty_out(vty, " via %pI4", &nexthop->gate.ipv4);
 		if (nexthop->ifindex)
 			vty_out(vty, ", %s",
 				ifindex2ifname(nexthop->ifindex,
@@ -636,7 +636,8 @@ static void show_nexthop_json_helper(json_object *json_nexthop,
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 		json_object_string_add(
 			json_nexthop, "ip",
-			inet_ntoa(nexthop->gate.ipv4));
+			inet_ntop(AF_INET, &nexthop->gate.ipv4,
+				  buf, sizeof(buf)));
 		json_object_string_add(json_nexthop, "afi",
 				       "ipv4");
 


### PR DESCRIPTION
Replace all use of `inet_ntoa` in zebra and ospfd. Used `%pI4` where possible, `inet_ntop()` otherwise.