### PR TITLE
eigrpd: Replace inet_ntoa with %pI4

### DIFF
--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -122,8 +122,8 @@ void eigrp_ip_header_dump(struct ip *iph)
 	zlog_debug("ip_ttl %u", iph->ip_ttl);
 	zlog_debug("ip_p %u", iph->ip_p);
 	zlog_debug("ip_sum 0x%x", (uint32_t)iph->ip_sum);
-	zlog_debug("ip_src %s", inet_ntoa(iph->ip_src));
-	zlog_debug("ip_dst %s", inet_ntoa(iph->ip_dst));
+	zlog_debug("ip_src %pI4", &iph->ip_src);
+	zlog_debug("ip_dst %pI4", &iph->ip_dst);
 }
 
 /*
@@ -204,8 +204,7 @@ void show_ip_eigrp_neighbor_sub(struct vty *vty, struct eigrp_neighbor *nbr,
 				int detail)
 {
 
-	vty_out(vty, "%-3u %-17s %-21s", 0, eigrp_neigh_ip_string(nbr),
-		IF_NAME(nbr->ei));
+	vty_out(vty, "%-3u %-17pI4 %-21s", 0, &nbr->src, IF_NAME(nbr->ei));
 	if (nbr->t_holddown)
 		vty_out(vty, "%-7lu",
 			thread_timer_remain_second(nbr->t_holddown));
@@ -231,8 +230,8 @@ void show_ip_eigrp_neighbor_sub(struct vty *vty, struct eigrp_neighbor *nbr,
  */
 void show_ip_eigrp_topology_header(struct vty *vty, struct eigrp *eigrp)
 {
-	vty_out(vty, "\nEIGRP Topology Table for AS(%d)/ID(%s)\n\n", eigrp->AS,
-		inet_ntoa(eigrp->router_id));
+	vty_out(vty, "\nEIGRP Topology Table for AS(%d)/ID(%pI4)\n\n",
+		eigrp->AS, &eigrp->router_id);
 	vty_out(vty,
 		"Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply\n       r - reply Status, s - sia Status\n\n");
 }
@@ -269,8 +268,8 @@ void show_ip_eigrp_nexthop_entry(struct vty *vty, struct eigrp *eigrp,
 		vty_out(vty, "%-7s%s, %s\n", " ", "via Connected",
 			IF_NAME(te->ei));
 	else {
-		vty_out(vty, "%-7s%s%s (%u/%u), %s\n", " ", "via ",
-			inet_ntoa(te->adv_router->src), te->distance,
+		vty_out(vty, "%-7s%s%pI4 (%u/%u), %s\n", " ", "via ",
+			&te->adv_router->src, te->distance,
 			te->reported_distance, IF_NAME(te->ei));
 	}
 }

--- a/eigrpd/eigrp_dump.h
+++ b/eigrpd/eigrp_dump.h
@@ -138,21 +138,6 @@ extern unsigned long term_debug_eigrp_zebra;
 
 /* Prototypes. */
 extern const char *eigrp_if_name_string(struct eigrp_interface *);
-static inline const char
-*eigrp_topology_ip_string(struct eigrp_prefix_entry *tn)
-{
-	return inet_ntoa(tn->destination->u.prefix4);
-}
-
-static inline const char *eigrp_if_ip_string(struct eigrp_interface *ei)
-{
-	return ei ? inet_ntoa(ei->address.u.prefix4) : "inactive";
-}
-
-static inline const char *eigrp_neigh_ip_string(struct eigrp_neighbor *nbr)
-{
-	return inet_ntoa(nbr->src);
-}
 
 extern void eigrp_ip_header_dump(struct ip *);
 extern void eigrp_header_dump(struct eigrp_header *);

--- a/eigrpd/eigrp_fsm.c
+++ b/eigrpd/eigrp_fsm.c
@@ -417,9 +417,9 @@ int eigrp_fsm_event(struct eigrp_fsm_action_message *msg)
 	enum eigrp_fsm_events event = eigrp_get_fsm_event(msg);
 
 	zlog_info(
-		"EIGRP AS: %d State: %s Event: %s Network: %s Packet Type: %s Reply RIJ Count: %d change: %s",
+		"EIGRP AS: %d State: %s Event: %s Network: %pI4 Packet Type: %s Reply RIJ Count: %d change: %s",
 		msg->eigrp->AS, prefix_state2str(msg->prefix->state),
-		fsm_state2str(event), eigrp_topology_ip_string(msg->prefix),
+		fsm_state2str(event), &msg->prefix->destination->u.prefix4,
 		packet_type2str(msg->packet_type), msg->prefix->rij->count,
 		change2str(msg->change));
 	(*(NSM[msg->prefix->state][event].func))(msg);

--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -144,10 +144,11 @@ eigrp_hello_parameter_decode(struct eigrp_neighbor *nbr,
 	    && (eigrp->k_values[4] == nbr->K5)) {
 
 		if (eigrp_nbr_state_get(nbr) == EIGRP_NEIGHBOR_DOWN) {
-			zlog_info("Neighbor %s (%s) is pending: new adjacency",
-				  inet_ntoa(nbr->src),
-				  ifindex2ifname(nbr->ei->ifp->ifindex,
-						 eigrp->vrf_id));
+			zlog_info(
+				"Neighbor %pI4 (%s) is pending: new adjacency",
+				&nbr->src,
+				ifindex2ifname(nbr->ei->ifp->ifindex,
+					       eigrp->vrf_id));
 
 			/* Expedited hello sent */
 			eigrp_hello_send(nbr->ei, EIGRP_HELLO_NORMAL, NULL);
@@ -164,16 +165,16 @@ eigrp_hello_parameter_decode(struct eigrp_neighbor *nbr,
 			     & param->K5)
 			    == 255) {
 				zlog_info(
-					"Neighbor %s (%s) is down: Interface PEER-TERMINATION received",
-					inet_ntoa(nbr->src),
+					"Neighbor %pI4 (%s) is down: Interface PEER-TERMINATION received",
+					&nbr->src,
 					ifindex2ifname(nbr->ei->ifp->ifindex,
 						       eigrp->vrf_id));
 				eigrp_nbr_delete(nbr);
 				return NULL;
 			} else {
 				zlog_info(
-					"Neighbor %s (%s) going down: Kvalue mismatch",
-					inet_ntoa(nbr->src),
+					"Neighbor %pI4 (%s) going down: Kvalue mismatch",
+					&nbr->src,
 					ifindex2ifname(nbr->ei->ifp->ifindex,
 						       eigrp->vrf_id));
 				eigrp_nbr_state_set(nbr, EIGRP_NEIGHBOR_DOWN);
@@ -253,9 +254,10 @@ static void eigrp_peer_termination_decode(struct eigrp_neighbor *nbr,
 	uint32_t received_ip = param->neighbor_ip;
 
 	if (my_ip == received_ip) {
-		zlog_info("Neighbor %s (%s) is down: Peer Termination received",
-			  inet_ntoa(nbr->src),
-			  ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id));
+		zlog_info(
+			"Neighbor %pI4 (%s) is down: Peer Termination received",
+			&nbr->src,
+			ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id));
 		/* set neighbor to DOWN */
 		nbr->state = EIGRP_NEIGHBOR_DOWN;
 		/* delete neighbor */
@@ -330,9 +332,9 @@ void eigrp_hello_receive(struct eigrp *eigrp, struct ip *iph,
 	assert(nbr);
 
 	if (IS_DEBUG_EIGRP_PACKET(eigrph->opcode - 1, RECV))
-		zlog_debug("Processing Hello size[%u] int(%s) nbr(%s)", size,
+		zlog_debug("Processing Hello size[%u] int(%s) nbr(%pI4)", size,
 			   ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id),
-			   inet_ntoa(nbr->src));
+			   &nbr->src);
 
 	size -= EIGRP_HEADER_LEN;
 	if (size < 0)
@@ -403,8 +405,7 @@ void eigrp_hello_receive(struct eigrp *eigrp, struct ip *iph,
 	}
 
 	if (IS_DEBUG_EIGRP_PACKET(0, RECV))
-		zlog_debug("Hello Packet received from %s",
-			   inet_ntoa(nbr->src));
+		zlog_debug("Hello Packet received from %pI4", &nbr->src);
 }
 
 uint32_t FRR_MAJOR;
@@ -708,9 +709,8 @@ void eigrp_hello_send_ack(struct eigrp_neighbor *nbr)
 
 	if (ep) {
 		if (IS_DEBUG_EIGRP_PACKET(0, SEND))
-			zlog_debug("Queueing [Hello] Ack Seq [%u] nbr [%s]",
-				   nbr->recv_sequence_number,
-				   inet_ntoa(nbr->src));
+			zlog_debug("Queueing [Hello] Ack Seq [%u] nbr [%pI4]",
+				   nbr->recv_sequence_number, &nbr->src);
 
 		/* Add packet to the top of the interface output queue*/
 		eigrp_fifo_push(nbr->ei->obuf, ep);

--- a/eigrpd/eigrp_neighbor.c
+++ b/eigrpd/eigrp_neighbor.c
@@ -87,10 +87,6 @@ static struct eigrp_neighbor *eigrp_nbr_add(struct eigrp_interface *ei,
 	nbr = eigrp_nbr_new(ei);
 	nbr->src = iph->ip_src;
 
-	//  if (IS_DEBUG_EIGRP_EVENT)
-	//    zlog_debug("NSM[%s:%s]: start", IF_NAME (nbr->oi),
-	//               inet_ntoa (nbr->router_id));
-
 	return nbr;
 }
 
@@ -197,8 +193,7 @@ int holddown_timer_expired(struct thread *thread)
 	struct eigrp_neighbor *nbr = THREAD_ARG(thread);
 	struct eigrp *eigrp = nbr->ei->eigrp;
 
-	zlog_info("Neighbor %s (%s) is down: holding time expired",
-		  inet_ntoa(nbr->src),
+	zlog_info("Neighbor %pI4 (%s) is down: holding time expired", &nbr->src,
 		  ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id));
 	nbr->state = EIGRP_NEIGHBOR_DOWN;
 	eigrp_nbr_delete(nbr);
@@ -330,13 +325,12 @@ void eigrp_nbr_hard_restart(struct eigrp_neighbor *nbr, struct vty *vty)
 {
 	struct eigrp *eigrp = nbr->ei->eigrp;
 
-	zlog_debug("Neighbor %s (%s) is down: manually cleared",
-		   inet_ntoa(nbr->src),
+	zlog_debug("Neighbor %pI4 (%s) is down: manually cleared", &nbr->src,
 		   ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id));
 	if (vty != NULL) {
 		vty_time_print(vty, 0);
-		vty_out(vty, "Neighbor %s (%s) is down: manually cleared\n",
-			inet_ntoa(nbr->src),
+		vty_out(vty, "Neighbor %pI4 (%s) is down: manually cleared\n",
+			&nbr->src,
 			ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id));
 	}
 

--- a/eigrpd/eigrp_network.c
+++ b/eigrpd/eigrp_network.c
@@ -160,9 +160,8 @@ int eigrp_if_ipmulticast(struct eigrp *top, struct prefix *p,
 	ret = setsockopt_ipv4_multicast_if(top->fd, p->u.prefix4, ifindex);
 	if (ret < 0)
 		zlog_warn(
-			"can't setsockopt IP_MULTICAST_IF (fd %d, addr %s, ifindex %u): %s",
-			top->fd, inet_ntoa(p->u.prefix4), ifindex,
-			safe_strerror(errno));
+			"can't setsockopt IP_MULTICAST_IF (fd %d, addr %pI4, ifindex %u): %s",
+			top->fd, &p->u.prefix4, ifindex, safe_strerror(errno));
 
 	return ret;
 }
@@ -178,12 +177,11 @@ int eigrp_if_add_allspfrouters(struct eigrp *top, struct prefix *p,
 		htonl(EIGRP_MULTICAST_ADDRESS), ifindex);
 	if (ret < 0)
 		zlog_warn(
-			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllSPFRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
-			top->fd, inet_ntoa(p->u.prefix4), ifindex,
-			safe_strerror(errno));
+			"can't setsockopt IP_ADD_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllSPFRouters): %s; perhaps a kernel limit on # of multicast group memberships has been exceeded?",
+			top->fd, &p->u.prefix4, ifindex, safe_strerror(errno));
 	else
-		zlog_debug("interface %s [%u] join EIGRP Multicast group.",
-			   inet_ntoa(p->u.prefix4), ifindex);
+		zlog_debug("interface %pI4 [%u] join EIGRP Multicast group.",
+			   &p->u.prefix4, ifindex);
 
 	return ret;
 }
@@ -198,12 +196,11 @@ int eigrp_if_drop_allspfrouters(struct eigrp *top, struct prefix *p,
 		htonl(EIGRP_MULTICAST_ADDRESS), ifindex);
 	if (ret < 0)
 		zlog_warn(
-			"can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %s, ifindex %u, AllSPFRouters): %s",
-			top->fd, inet_ntoa(p->u.prefix4), ifindex,
-			safe_strerror(errno));
+			"can't setsockopt IP_DROP_MEMBERSHIP (fd %d, addr %pI4, ifindex %u, AllSPFRouters): %s",
+			top->fd, &p->u.prefix4, ifindex, safe_strerror(errno));
 	else
-		zlog_debug("interface %s [%u] leave EIGRP Multicast group.",
-			   inet_ntoa(p->u.prefix4), ifindex);
+		zlog_debug("interface %pI4 [%u] leave EIGRP Multicast group.",
+			   &p->u.prefix4, ifindex);
 
 	return ret;
 }

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -360,14 +360,14 @@ DEFPY (clear_ip_eigrp_neighbors,
 		for (ALL_LIST_ELEMENTS(ei->nbrs, node2, nnode2, nbr)) {
 			if (nbr->state != EIGRP_NEIGHBOR_DOWN) {
 				zlog_debug(
-					"Neighbor %s (%s) is down: manually cleared",
-					inet_ntoa(nbr->src),
+					"Neighbor %pI4 (%s) is down: manually cleared",
+					&nbr->src,
 					ifindex2ifname(nbr->ei->ifp->ifindex,
 						       eigrp->vrf_id));
 				vty_time_print(vty, 0);
 				vty_out(vty,
-					"Neighbor %s (%s) is down: manually cleared\n",
-					inet_ntoa(nbr->src),
+					"Neighbor %pI4 (%s) is down: manually cleared\n",
+					&nbr->src,
 					ifindex2ifname(nbr->ei->ifp->ifindex,
 						       eigrp->vrf_id));
 
@@ -420,14 +420,15 @@ DEFPY (clear_ip_eigrp_neighbors_int,
 	/* iterate over all neighbors on eigrp interface */
 	for (ALL_LIST_ELEMENTS(ei->nbrs, node2, nnode2, nbr)) {
 		if (nbr->state != EIGRP_NEIGHBOR_DOWN) {
-			zlog_debug("Neighbor %s (%s) is down: manually cleared",
-				   inet_ntoa(nbr->src),
-				   ifindex2ifname(nbr->ei->ifp->ifindex,
-						  eigrp->vrf_id));
+			zlog_debug(
+				"Neighbor %pI4 (%s) is down: manually cleared",
+				&nbr->src,
+				ifindex2ifname(nbr->ei->ifp->ifindex,
+					       eigrp->vrf_id));
 			vty_time_print(vty, 0);
 			vty_out(vty,
-				"Neighbor %s (%s) is down: manually cleared\n",
-				inet_ntoa(nbr->src),
+				"Neighbor %pI4 (%s) is down: manually cleared\n",
+				&nbr->src,
 				ifindex2ifname(nbr->ei->ifp->ifindex,
 					       eigrp->vrf_id));
 

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -110,10 +110,6 @@ void eigrp_router_id_update(struct eigrp *eigrp)
 
 	eigrp->router_id = router_id;
 	if (router_id_old.s_addr != router_id.s_addr) {
-		//      if (IS_DEBUG_EIGRP_EVENT)
-		//        zlog_debug("Router-ID[NEW:%s]: Update",
-		//        inet_ntoa(eigrp->router_id));
-
 		/* update eigrp_interface's */
 		FOR_ALL_INTERFACES (vrf, ifp)
 			eigrp_if_update(ifp);


### PR DESCRIPTION
Search and destroy the inet_ntoa usage in eigrp

Signed-off-by: Donald Sharp <sharpd@nvidia.com>