### PR TITLE
alpine: Remove old docker deps for alpine

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -6,7 +6,7 @@ pkgrel=0
 pkgdesc="FRRouting is a fork of quagga"
 url="https://frrouting.org/"
 license="GPL-2.0"
-depends="json-c c-ares ipsec-tools iproute2 python3 py-ipaddr bash"
+depends="json-c c-ares iproute2 python3 bash"
 makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
     acct autoconf automake bash binutils bison bsd-compat-headers build-base
     c-ares c-ares-dev ca-certificates cryptsetup-libs curl device-mapper-libs


### PR DESCRIPTION
Remove py-ipaddr and ipsec-tools as deps in the Alpine build container as these were both Python 2 libraries and are not used / needed here anymore.

`ipsec-tools` is also no longer available in Alpine's test repos and was causing breakage on this builder (#6902)