### PR TITLE
build: add --disable-rpath option in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -451,6 +451,11 @@ fi
 AC_SUBST([AC_LDFLAGS])
 AM_CONDITIONAL([STATIC_BIN], [test "$enable_static_bin" = "yes"])
 
+AC_ARG_ENABLE([rpath],
+  [AS_HELP_STRING([--enable-rpath], [set hardcoded rpaths in the executable @<:@default=yes@:>@])],
+  [],
+  [enable_rpath=yes])
+
 dnl $AR and $RANLIB are set by LT_INIT above
 AC_MSG_CHECKING([whether $AR supports D option])
 if $AR crD conftest.a >/dev/null 2>/dev/null; then
@@ -2498,6 +2503,14 @@ AS_IF([test "$with_pkg_git_version" = "yes"], [
 ## Hack, but working solution to avoid rebuilding of frr.info.
 ## It's already in CVS until texinfo 4.7 is more common.
 AC_OUTPUT
+
+if test "$enable_rpath" = "yes" ; then
+	true
+else
+	# See https://old-en.opensuse.org/openSUSE:Packaging_Guidelines#Removing_Rpath
+	sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
+	sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+fi
 
 echo "
 FRRouting configuration

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -273,15 +273,15 @@ options from the list below.
    With this option, we provide a way to strip out these characters for APK dev
    package builds.
 
-..option:: --disable-version-build-config
+.. option:: --disable-version-build-config
 
    Remove the "configuerd with" field that has all of the build configuration
    arguments when reporting the version string in `show version` command.
 
-..option:: --with-pkg-extra-version=VER
+.. option:: --with-pkg-extra-version=VER
    Add extra version field, for packagers/distributions
 
-..option::  --with-pkg-git-version
+.. option::  --with-pkg-git-version
 
    Add git information to MOTD and build version string
 
@@ -354,6 +354,10 @@ options from the list below.
 .. option:: --enable-pcreposix
 
    Turn on the usage of PCRE Posix libs for regex functionality.
+
+.. option:: --enable-rpath
+
+   Set hardcoded rpaths in the executable [default=yes].
 
 You may specify any combination of the above options to the configure
 script. By default, the executables are placed in :file:`/usr/local/sbin`


### PR DESCRIPTION
Add an option to remove RPATH entry from binary files.
Useful for cross-compilation, otherwise libtool hardcodes
the building path.