### PR TITLE
tools: add PIDFile option in frr.service

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2466,6 +2466,8 @@ AC_CONFIG_FILES([tools/frr], [chmod +x tools/frr])
 AC_CONFIG_FILES([tools/watchfrr.sh], [chmod +x tools/watchfrr.sh])
 AC_CONFIG_FILES([tools/frrinit.sh], [chmod +x tools/frrinit.sh])
 AC_CONFIG_FILES([tools/frrcommon.sh])
+AC_CONFIG_FILES([tools/frr.service])
+AC_CONFIG_FILES([tools/frr@.service])
 
 AC_CONFIG_COMMANDS([lib/route_types.h], [
 	dst="${ac_abs_top_builddir}/lib/route_types.h"

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -6,3 +6,5 @@
 /watchfrr.sh
 /frrinit.sh
 /frrcommon.sh
+/frr.service
+/frr@.service

--- a/tools/frr.service.in
+++ b/tools/frr.service.in
@@ -17,9 +17,10 @@ WatchdogSec=60s
 RestartSec=5
 Restart=on-abnormal
 LimitNOFILE=1024
-ExecStart=/usr/lib/frr/frrinit.sh start
-ExecStop=/usr/lib/frr/frrinit.sh stop
-ExecReload=/usr/lib/frr/frrinit.sh reload
+PIDFile=@CFG_STATE@/watchfrr.pid
+ExecStart=@CFG_SBIN@/frrinit.sh start
+ExecStop=@CFG_SBIN@/frrinit.sh stop
+ExecReload=@CFG_SBIN@/frrinit.sh reload
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/frr@.service.in
+++ b/tools/frr@.service.in
@@ -17,9 +17,10 @@ WatchdogSec=60s
 RestartSec=5
 Restart=on-abnormal
 LimitNOFILE=1024
-ExecStart=/usr/lib/frr/frrinit.sh start %I
-ExecStop=/usr/lib/frr/frrinit.sh stop %I
-ExecReload=/usr/lib/frr/frrinit.sh reload %I
+PIDFile=@CFG_STATE@/%I/watchfrr.pid
+ExecStart=@CFG_SBIN@/frrinit.sh start %I
+ExecStop=@CFG_SBIN@/frrinit.sh stop %I
+ExecReload=@CFG_SBIN@/frrinit.sh reload %I
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
when type is forking, it is recommended to also use the PIDFile= option,
so that systemd can reliably identify the main process of the service.
