### PR TITLE
evpn-mh: uplink tracking and startup delay

### DIFF
--- a/tests/topotests/bgp-evpn-mh/torm11/zebra.conf
+++ b/tests/topotests/bgp-evpn-mh/torm11/zebra.conf
@@ -4,11 +4,15 @@ debug zebra evpn mh neigh
 debug zebra evpn mh nh
 debug zebra vxlan
 !
+evpn mh startup-delay 1
+!
 int torm11-eth0
   ip addr 192.168.1.2/24
+  evpn mh uplink
 !
 int torm11-eth1
   ip addr 192.168.5.2/24
+  evpn mh uplink
 !
 int lo
   ip addr 192.168.100.15/32

--- a/tests/topotests/bgp-evpn-mh/torm12/zebra.conf
+++ b/tests/topotests/bgp-evpn-mh/torm12/zebra.conf
@@ -4,11 +4,16 @@ debug zebra evpn mh neigh
 debug zebra evpn mh nh
 debug zebra vxlan
 !
+evpn mh startup-delay 1
+!
 int torm12-eth0
   ip addr 192.168.2.2/24
+  evpn mh uplink
 !
 int torm12-eth1
   ip addr 192.168.6.2/24
+  evpn mh uplink
+!
 !
 int lo
   ip addr 192.168.100.16/32

--- a/tests/topotests/bgp-evpn-mh/torm21/zebra.conf
+++ b/tests/topotests/bgp-evpn-mh/torm21/zebra.conf
@@ -4,11 +4,17 @@ debug zebra evpn mh neigh
 debug zebra evpn mh nh
 debug zebra vxlan
 !
+evpn mh startup-delay 1
+!
 int torm21-eth0
   ip addr 192.168.3.2/24
+  evpn mh uplink
+!
 !
 int torm21-eth1
   ip addr 192.168.7.2/24
+  evpn mh uplink
+!
 !
 int lo
   ip addr 192.168.100.17/32

--- a/tests/topotests/bgp-evpn-mh/torm22/evpn.conf
+++ b/tests/topotests/bgp-evpn-mh/torm22/evpn.conf
@@ -5,7 +5,6 @@ debug bgp evpn mh es
 debug bgp evpn mh route
 debug bgp zebra
 !
-!
 router bgp 65005
   bgp router-id 192.168.100.18
   no bgp ebgp-requires-policy

--- a/tests/topotests/bgp-evpn-mh/torm22/zebra.conf
+++ b/tests/topotests/bgp-evpn-mh/torm22/zebra.conf
@@ -4,11 +4,17 @@ debug zebra evpn mh neigh
 debug zebra evpn mh nh
 debug zebra vxlan
 !
+evpn mh startup-delay 1
+!
 int torm22-eth0
   ip addr 192.168.4.2/24
+  evpn mh uplink
+!
 !
 int torm22-eth1
   ip addr 192.168.8.2/24
+  evpn mh uplink
+!
 !
 int lo
   ip addr 192.168.100.18/32

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1069,6 +1069,9 @@ void if_up(struct interface *ifp)
 
 	if (zif->es_info.es)
 		zebra_evpn_es_if_oper_state_change(zif, true /*up*/);
+
+	if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK)
+		zebra_evpn_mh_uplink_oper_update(zif);
 }
 
 /* Interface goes down.  We have to manage different behavior of based
@@ -1105,6 +1108,9 @@ void if_down(struct interface *ifp)
 
 	if (zif->es_info.es)
 		zebra_evpn_es_if_oper_state_change(zif, false /*up*/);
+
+	if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK)
+		zebra_evpn_mh_uplink_oper_update(zif);
 
 	/* Notify to the protocol daemons. */
 	zebra_interface_down_update(ifp);
@@ -1156,6 +1162,18 @@ void zebra_if_update_all_links(void)
 		if (!ifp)
 			continue;
 		zif = ifp->info;
+		/* update bond-member to bond linkages */
+		if ((IS_ZEBRA_IF_BOND_SLAVE(ifp))
+		    && (zif->bondslave_info.bond_ifindex != IFINDEX_INTERNAL)
+		    && !zif->bondslave_info.bond_if) {
+			if (IS_ZEBRA_DEBUG_EVPN_MH_ES || IS_ZEBRA_DEBUG_KERNEL)
+				zlog_debug("bond mbr %s map to bond %d",
+					   zif->ifp->name,
+					   zif->bondslave_info.bond_ifindex);
+			zebra_l2_map_slave_to_bond(zif, ifp->vrf_id);
+		}
+
+		/* update SVI linkages */
 		if ((zif->link_ifindex != IFINDEX_INTERNAL) && !zif->link) {
 			zif->link = if_lookup_by_index_per_ns(ns,
 							 zif->link_ifindex);
@@ -1382,6 +1400,40 @@ static void ifs_dump_brief_vty(struct vty *vty, struct vrf *vrf)
 	vty_out(vty, "\n");
 }
 
+char *zebra_protodown_rc_str(enum protodown_reasons protodown_rc, char *pd_buf,
+			     uint32_t pd_buf_len)
+{
+	bool first = true;
+
+	pd_buf[0] = '\0';
+
+	snprintf(pd_buf + strlen(pd_buf), pd_buf_len - strlen(pd_buf), "(");
+
+	if (protodown_rc & ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY) {
+		if (first)
+			first = false;
+		else
+			snprintf(pd_buf + strlen(pd_buf),
+				 pd_buf_len - strlen(pd_buf), ",");
+		snprintf(pd_buf + strlen(pd_buf), pd_buf_len - strlen(pd_buf),
+			 "startup-delay");
+	}
+
+	if (protodown_rc & ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN) {
+		if (first)
+			first = false;
+		else
+			snprintf(pd_buf + strlen(pd_buf),
+				 pd_buf_len - strlen(pd_buf), ",");
+		snprintf(pd_buf + strlen(pd_buf), pd_buf_len - strlen(pd_buf),
+			 "uplinks-down");
+	}
+
+	snprintf(pd_buf + strlen(pd_buf), pd_buf_len - strlen(pd_buf), ")");
+
+	return pd_buf;
+}
+
 /* Interface's information print out to vty interface. */
 static void if_dump_vty(struct vty *vty, struct interface *ifp)
 {
@@ -1391,6 +1443,7 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 	struct route_node *rn;
 	struct zebra_if *zebra_if;
 	struct vrf *vrf;
+	char pd_buf[ZEBRA_PROTODOWN_RC_STR_LEN];
 
 	zebra_if = ifp->info;
 
@@ -1545,6 +1598,14 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 	}
 
 	zebra_evpn_if_es_print(vty, zebra_if);
+	vty_out(vty, "  protodown: %s",
+		(zebra_if->flags & ZIF_FLAG_PROTODOWN) ? "on" : "off");
+	if (zebra_if->protodown_rc)
+		vty_out(vty, " rc: %s\n",
+			zebra_protodown_rc_str(zebra_if->protodown_rc, pd_buf,
+					       sizeof(pd_buf)));
+	else
+		vty_out(vty, "\n");
 
 	if (zebra_if->link_ifindex != IFINDEX_INTERNAL) {
 		if (zebra_if->link)

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -29,6 +29,7 @@
 
 #include "zebra/zebra_l2.h"
 #include "zebra/zebra_nhg_private.h"
+#include "zebra/zebra_router.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -284,10 +285,23 @@ struct zebra_es_if_info {
 	struct zebra_evpn_es *es; /* local ES */
 };
 
+enum zebra_if_flags {
+	/* device has been configured as an uplink for
+	 * EVPN multihoming
+	 */
+	ZIF_FLAG_EVPN_MH_UPLINK = (1 << 0),
+	ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP = (1 << 1),
+
+	/* Dataplane protodown-on */
+	ZIF_FLAG_PROTODOWN = (1 << 2)
+};
+
 /* `zebra' daemon local interface structure. */
 struct zebra_if {
 	/* back pointer to the interface */
 	struct interface *ifp;
+
+	enum zebra_if_flags flags;
 
 	/* Shutdown configuration. */
 	uint8_t shutdown;
@@ -352,12 +366,21 @@ struct zebra_if {
 	struct zebra_l2info_brslave brslave_info;
 
 	struct zebra_l2info_bondslave bondslave_info;
+	struct zebra_l2info_bond bond_info;
 
 	/* ethernet segment */
 	struct zebra_es_if_info es_info;
 
 	/* bitmap of vlans associated with this interface */
 	bitfield_t vlan_bitmap;
+
+	/* An interface can be error-disabled if a protocol (such as EVPN or
+	 * VRRP) detects a problem with keeping it operationally-up.
+	 * If any of the protodown bits are set protodown-on is programmed
+	 * in the dataplane. This results in a carrier/L1 down on the
+	 * physical device.
+	 */
+	enum protodown_reasons protodown_rc;
 
 	/* Link fields - for sub-interfaces. */
 	ifindex_t link_ifindex;
@@ -399,6 +422,9 @@ DECLARE_HOOK(zebra_if_config_wr, (struct vty * vty, struct interface *ifp),
 
 #define IS_ZEBRA_IF_VETH(ifp)                                               \
 	(((struct zebra_if *)(ifp->info))->zif_type == ZEBRA_IF_VETH)
+
+#define IS_ZEBRA_IF_BOND(ifp)                                                  \
+	(((struct zebra_if *)(ifp->info))->zif_type == ZEBRA_IF_BOND)
 
 #define IS_ZEBRA_IF_BRIDGE_SLAVE(ifp)					\
 	(((struct zebra_if *)(ifp->info))->zif_slave_type                      \
@@ -463,6 +489,10 @@ extern unsigned int if_nhg_dependents_count(const struct interface *ifp);
 extern bool if_nhg_dependents_is_empty(const struct interface *ifp);
 
 extern void vrf_add_update(struct vrf *vrfp);
+extern void zebra_l2_map_slave_to_bond(struct zebra_if *zif, vrf_id_t vrf);
+extern void zebra_l2_unmap_slave_from_bond(struct zebra_if *zif);
+extern char *zebra_protodown_rc_str(enum protodown_reasons protodown_rc,
+				    char *pd_buf, uint32_t pd_buf_len);
 
 #ifdef HAVE_PROC_NET_DEV
 extern void ifstat_update_proc(void);

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -38,6 +38,7 @@
 #include "zebra/rib.h"
 #include "zebra/rt.h"
 #include "zebra/rt_netlink.h"
+#include "zebra/if_netlink.h"
 #include "zebra/zebra_errors.h"
 #include "zebra/zebra_l2.h"
 #include "zebra/zebra_memory.h"
@@ -65,6 +66,9 @@ static int zebra_evpn_local_es_update(struct zebra_if *zif, uint32_t lid,
 		struct ethaddr *sysmac);
 static bool zebra_evpn_es_br_port_dplane_update(struct zebra_evpn_es *es,
 						const char *caller);
+static void zebra_evpn_mh_uplink_cfg_update(struct zebra_if *zif, bool set);
+static void zebra_evpn_mh_update_protodown_es(struct zebra_evpn_es *es);
+static void zebra_evpn_mh_clear_protodown_es(struct zebra_evpn_es *es);
 
 esi_t zero_esi_buf, *zero_esi = &zero_esi_buf;
 
@@ -1713,6 +1717,9 @@ static void zebra_evpn_es_local_info_set(struct zebra_evpn_es *es,
 	 */
 	zebra_evpn_es_local_mac_update(es,
 			false /* force_clear_static */);
+
+	/* inherit EVPN protodown flags on the access port */
+	zebra_evpn_mh_update_protodown_es(es);
 }
 
 static void zebra_evpn_es_local_info_clear(struct zebra_evpn_es **esp)
@@ -1728,6 +1735,9 @@ static void zebra_evpn_es_local_info_clear(struct zebra_evpn_es **esp)
 
 	/* remove the DF filter */
 	dplane_updated = zebra_evpn_es_run_df_election(es, __func__);
+
+	/* clear EVPN protodown flags on the access port */
+	zebra_evpn_mh_clear_protodown_es(es);
 
 	/* if there any local macs referring to the ES as dest we
 	 * need to clear the static reference on them
@@ -2144,12 +2154,34 @@ bool zebra_evpn_is_if_es_capable(struct zebra_if *zif)
 void zebra_evpn_if_es_print(struct vty *vty, struct zebra_if *zif)
 {
 	char buf[ETHER_ADDR_STRLEN];
+	char mh_buf[80];
+	bool vty_print = false;
 
-	if (zif->es_info.lid || !is_zero_mac(&zif->es_info.sysmac))
-		vty_out(vty, "  EVPN MH: ES id %u ES sysmac %s\n",
-				zif->es_info.lid,
-				prefix_mac2str(&zif->es_info.sysmac,
-					buf, sizeof(buf)));
+	mh_buf[0] = '\0';
+	snprintf(mh_buf + strlen(mh_buf), sizeof(mh_buf) - strlen(mh_buf),
+		 "  EVPN-MH:");
+	if (zif->es_info.lid || !is_zero_mac(&zif->es_info.sysmac)) {
+		vty_print = true;
+		snprintf(
+			mh_buf + strlen(mh_buf),
+			sizeof(mh_buf) - strlen(mh_buf),
+			" ES id %u ES sysmac %s", zif->es_info.lid,
+			prefix_mac2str(&zif->es_info.sysmac, buf, sizeof(buf)));
+	}
+
+	if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK) {
+		vty_print = true;
+		if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP)
+			snprintf(mh_buf + strlen(mh_buf),
+				 sizeof(mh_buf) - strlen(mh_buf), " uplink-up");
+		else
+			snprintf(mh_buf + strlen(mh_buf),
+				 sizeof(mh_buf) - strlen(mh_buf),
+				 " uplink-down");
+	}
+
+	if (vty_print)
+		vty_out(vty, "%s\n", mh_buf);
 }
 
 void zebra_evpn_es_if_oper_state_change(struct zebra_if *zif, bool up)
@@ -2478,6 +2510,9 @@ int zebra_evpn_mh_if_write(struct vty *vty, struct interface *ifp)
 	if (zif->es_info.df_pref)
 		vty_out(vty, " evpn mh es-df-pref %u\n", zif->es_info.df_pref);
 
+	if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK)
+		vty_out(vty, " evpn mh uplink\n");
+
 	return 0;
 }
 
@@ -2600,6 +2635,70 @@ DEFPY(zebra_evpn_es_id,
 	return CMD_SUCCESS;
 }
 
+/* CLI for tagging an interface as an uplink */
+DEFPY(zebra_evpn_mh_uplink, zebra_evpn_mh_uplink_cmd, "[no] evpn mh uplink",
+      NO_STR "EVPN\n" EVPN_MH_VTY_STR "uplink to the VxLAN core\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct zebra_if *zif;
+
+	zif = ifp->info;
+	zebra_evpn_mh_uplink_cfg_update(zif, no ? false : true);
+
+	return CMD_SUCCESS;
+}
+
+void zebra_evpn_mh_json(json_object *json)
+{
+	json_object *json_array;
+	char thread_buf[THREAD_TIMER_STRLEN];
+
+	json_object_int_add(json, "macHoldtime", zmh_info->mac_hold_time);
+	json_object_int_add(json, "neighHoldtime", zmh_info->neigh_hold_time);
+	json_object_int_add(json, "startupDelay", zmh_info->startup_delay_time);
+	json_object_string_add(
+		json, "startupDelayTimer",
+		thread_timer_to_hhmmss(thread_buf, sizeof(thread_buf),
+				       zmh_info->startup_delay_timer));
+	json_object_int_add(json, "uplinkConfigCount",
+			    zmh_info->uplink_cfg_cnt);
+	json_object_int_add(json, "uplinkActiveCount",
+			    zmh_info->uplink_oper_up_cnt);
+
+	if (zmh_info->protodown_rc) {
+		json_array = json_object_new_array();
+		if (zmh_info->protodown_rc & ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY)
+			json_object_array_add(
+				json_array,
+				json_object_new_string("startupDelay"));
+		if (zmh_info->protodown_rc & ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN)
+			json_object_array_add(
+				json_array,
+				json_object_new_string("uplinkDown"));
+		json_object_object_add(json, "protodownReasons", json_array);
+	}
+}
+
+void zebra_evpn_mh_print(struct vty *vty)
+{
+	char pd_buf[ZEBRA_PROTODOWN_RC_STR_LEN];
+	char thread_buf[THREAD_TIMER_STRLEN];
+
+	vty_out(vty, "EVPN MH:\n");
+	vty_out(vty, "  mac-holdtime: %ds, neigh-holdtime: %ds\n",
+		zmh_info->mac_hold_time, zmh_info->neigh_hold_time);
+	vty_out(vty, "  startup-delay: %ds, start-delay-timer: %s\n",
+		zmh_info->startup_delay_time,
+		thread_timer_to_hhmmss(thread_buf, sizeof(thread_buf),
+				       zmh_info->startup_delay_timer));
+	vty_out(vty, "  uplink-cfg-cnt: %u, uplink-active-cnt: %u\n",
+		zmh_info->uplink_cfg_cnt, zmh_info->uplink_oper_up_cnt);
+	if (zmh_info->protodown_rc)
+		vty_out(vty, "  protodown: %s\n",
+			zebra_protodown_rc_str(zmh_info->protodown_rc, pd_buf,
+					       sizeof(pd_buf)));
+}
+
 /*****************************************************************************/
 /* A base L2-VNI is maintained to derive parameters such as ES originator-IP.
  * XXX: once single vxlan device model becomes available this will not be
@@ -2705,23 +2804,316 @@ static void zebra_evpn_es_get_one_base_evpn(void)
 	hash_walk(zvrf->evpn_table, zebra_evpn_es_get_one_base_evpn_cb, NULL);
 }
 
+/*****************************************************************************
+ * local ethernet segments can be error-disabled if the switch is not
+ * ready to start transmitting traffic via the VxLAN overlay
+ */
+bool zebra_evpn_is_es_bond(struct interface *ifp)
+{
+	struct zebra_if *zif = ifp->info;
+
+	return !!(struct zebra_if *)zif->es_info.es;
+}
+
+bool zebra_evpn_is_es_bond_member(struct interface *ifp)
+{
+	struct zebra_if *zif = ifp->info;
+
+	return IS_ZEBRA_IF_BOND_SLAVE(zif->ifp) && zif->bondslave_info.bond_if
+	       && ((struct zebra_if *)zif->bondslave_info.bond_if->info)
+			  ->es_info.es;
+}
+
+void zebra_evpn_mh_update_protodown_bond_mbr(struct zebra_if *zif, bool clear,
+					     const char *caller)
+{
+	bool old_protodown;
+	bool new_protodown;
+	enum protodown_reasons old_protodown_rc = 0;
+	enum protodown_reasons protodown_rc = 0;
+
+	if (!clear) {
+		struct zebra_if *bond_zif;
+
+		bond_zif = zif->bondslave_info.bond_if->info;
+		protodown_rc = bond_zif->protodown_rc;
+	}
+
+	if (zif->protodown_rc == protodown_rc)
+		return;
+
+	old_protodown = !!(zif->flags & ZIF_FLAG_PROTODOWN);
+	old_protodown_rc = zif->protodown_rc;
+	zif->protodown_rc &= ~ZEBRA_PROTODOWN_EVPN_ALL;
+	zif->protodown_rc |= (protodown_rc & ZEBRA_PROTODOWN_EVPN_ALL);
+	new_protodown = !!zif->protodown_rc;
+
+	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+		zlog_debug(
+			"%s bond mbr %s protodown_rc changed; old 0x%x new 0x%x",
+			caller, zif->ifp->name, old_protodown_rc,
+			zif->protodown_rc);
+
+	if (old_protodown == new_protodown)
+		return;
+
+	if (new_protodown)
+		zif->flags |= ZIF_FLAG_PROTODOWN;
+	else
+		zif->flags &= ~ZIF_FLAG_PROTODOWN;
+
+	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+		zlog_debug("%s protodown %s", zif->ifp->name,
+			   new_protodown ? "on" : "off");
+
+	zebra_if_set_protodown(zif->ifp, new_protodown);
+}
+
+/* The bond members inherit the protodown reason code from the bond */
+static void zebra_evpn_mh_update_protodown_bond(struct zebra_if *bond_zif)
+{
+	struct zebra_if *zif;
+	struct listnode *node;
+
+	if (!bond_zif->bond_info.mbr_zifs)
+		return;
+
+	for (ALL_LIST_ELEMENTS_RO(bond_zif->bond_info.mbr_zifs, node, zif)) {
+		zebra_evpn_mh_update_protodown_bond_mbr(zif, false /*clear*/,
+							__func__);
+	}
+}
+
+/* The global EVPN MH protodown rc is applied to all local ESs */
+static void zebra_evpn_mh_update_protodown_es(struct zebra_evpn_es *es)
+{
+	struct zebra_if *zif;
+	enum protodown_reasons old_protodown_rc;
+
+	zif = es->zif;
+	if ((zif->protodown_rc & ZEBRA_PROTODOWN_EVPN_ALL)
+	    == (zmh_info->protodown_rc & ZEBRA_PROTODOWN_EVPN_ALL))
+		return;
+
+	old_protodown_rc = zif->protodown_rc;
+	zif->protodown_rc &= ~ZEBRA_PROTODOWN_EVPN_ALL;
+	zif->protodown_rc |=
+		(zmh_info->protodown_rc & ZEBRA_PROTODOWN_EVPN_ALL);
+
+	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+		zlog_debug(
+			"es %s ifp %s protodown_rc changed; old 0x%x new 0x%x",
+			es->esi_str, zif->ifp->name, old_protodown_rc,
+			zif->protodown_rc);
+
+	/* update dataplane with the new protodown setting */
+	zebra_evpn_mh_update_protodown_bond(zif);
+}
+
+static void zebra_evpn_mh_clear_protodown_es(struct zebra_evpn_es *es)
+{
+	struct zebra_if *zif;
+	enum protodown_reasons old_protodown_rc;
+
+	zif = es->zif;
+	if (!(zif->protodown_rc & ZEBRA_PROTODOWN_EVPN_ALL))
+		return;
+
+	old_protodown_rc = zif->protodown_rc;
+	zif->protodown_rc &= ~ZEBRA_PROTODOWN_EVPN_ALL;
+
+	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+		zlog_debug(
+			"clear: es %s ifp %s protodown_rc cleared; old 0x%x new 0x%x",
+			es->esi_str, zif->ifp->name, old_protodown_rc,
+			zif->protodown_rc);
+
+	/* update dataplane with the new protodown setting */
+	zebra_evpn_mh_update_protodown_bond(zif);
+}
+
+static void zebra_evpn_mh_update_protodown_es_all(void)
+{
+	struct listnode *node;
+	struct zebra_evpn_es *es;
+
+	for (ALL_LIST_ELEMENTS_RO(zmh_info->local_es_list, node, es))
+		zebra_evpn_mh_update_protodown_es(es);
+}
+
+static void zebra_evpn_mh_update_protodown(enum protodown_reasons protodown_rc,
+					   bool set)
+{
+	enum protodown_reasons old_protodown_rc = zmh_info->protodown_rc;
+
+	if (set) {
+		if ((protodown_rc & zmh_info->protodown_rc) == protodown_rc)
+			return;
+
+		zmh_info->protodown_rc |= protodown_rc;
+	} else {
+		if (!(protodown_rc & zmh_info->protodown_rc))
+			return;
+		zmh_info->protodown_rc &= ~protodown_rc;
+	}
+
+	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+		zlog_debug("mh protodown_rc changed; old 0x%x new 0x%x",
+			   old_protodown_rc, zmh_info->protodown_rc);
+	zebra_evpn_mh_update_protodown_es_all();
+}
+
+static inline bool zebra_evpn_mh_is_all_uplinks_down(void)
+{
+	return zmh_info->uplink_cfg_cnt && !zmh_info->uplink_oper_up_cnt;
+}
+
+static void zebra_evpn_mh_uplink_oper_flags_update(struct zebra_if *zif,
+						   bool set)
+{
+	if (set) {
+		if (if_is_operative(zif->ifp)) {
+			if (!(zif->flags & ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP)) {
+				zif->flags |= ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP;
+				++zmh_info->uplink_oper_up_cnt;
+			}
+		} else {
+			if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP) {
+				zif->flags &= ~ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP;
+				if (zmh_info->uplink_oper_up_cnt)
+					--zmh_info->uplink_oper_up_cnt;
+			}
+		}
+	} else {
+		if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP) {
+			zif->flags &= ~ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP;
+			if (zmh_info->uplink_oper_up_cnt)
+				--zmh_info->uplink_oper_up_cnt;
+		}
+	}
+}
+
+static void zebra_evpn_mh_uplink_cfg_update(struct zebra_if *zif, bool set)
+{
+	bool old_protodown = zebra_evpn_mh_is_all_uplinks_down();
+	bool new_protodown;
+
+	if (set) {
+		if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK)
+			return;
+
+		zif->flags |= ZIF_FLAG_EVPN_MH_UPLINK;
+		++zmh_info->uplink_cfg_cnt;
+	} else {
+		if (!(zif->flags & ZIF_FLAG_EVPN_MH_UPLINK))
+			return;
+
+		zif->flags &= ~ZIF_FLAG_EVPN_MH_UPLINK;
+		if (zmh_info->uplink_cfg_cnt)
+			--zmh_info->uplink_cfg_cnt;
+	}
+
+	zebra_evpn_mh_uplink_oper_flags_update(zif, set);
+	new_protodown = zebra_evpn_mh_is_all_uplinks_down();
+	if (old_protodown == new_protodown)
+		return;
+
+	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+		zlog_debug(
+			"mh-uplink-cfg-chg on if %s/%d %s uplinks cfg %u up %u",
+			zif->ifp->name, zif->ifp->ifindex, set ? "set" : "down",
+			zmh_info->uplink_cfg_cnt, zmh_info->uplink_oper_up_cnt);
+
+	zebra_evpn_mh_update_protodown(ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN,
+				       new_protodown);
+}
+
+void zebra_evpn_mh_uplink_oper_update(struct zebra_if *zif)
+{
+	bool old_protodown = zebra_evpn_mh_is_all_uplinks_down();
+	bool new_protodown;
+
+	zebra_evpn_mh_uplink_oper_flags_update(zif, true /*set*/);
+
+	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+		zlog_debug(
+			"mh-uplink-oper-chg on if %s/%d %s; uplinks cfg %u up %u",
+			zif->ifp->name, zif->ifp->ifindex,
+			if_is_operative(zif->ifp) ? "up" : "down",
+			zmh_info->uplink_cfg_cnt, zmh_info->uplink_oper_up_cnt);
+
+	new_protodown = zebra_evpn_mh_is_all_uplinks_down();
+	if (old_protodown == new_protodown)
+		return;
+
+	zebra_evpn_mh_update_protodown(ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN,
+				       new_protodown);
+}
+
+static int zebra_evpn_mh_startup_delay_exp_cb(struct thread *t)
+{
+	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+		zlog_debug("startup-delay expired");
+
+	zebra_evpn_mh_update_protodown(ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY,
+				       false /* set */);
+
+	return 0;
+}
+
+static void zebra_evpn_mh_startup_delay_timer_start(bool init)
+{
+	/* 1. This timer can be started during init.
+	 * 2. It can also be restarted if it is alreay running and the
+	 * admin wants to increase or decrease its value
+	 */
+	if (!init && !zmh_info->startup_delay_timer)
+		return;
+
+	if (zmh_info->startup_delay_timer) {
+		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+			zlog_debug("startup-delay timer cancelled");
+		thread_cancel(&zmh_info->startup_delay_timer);
+		zmh_info->startup_delay_timer = NULL;
+	}
+
+	if (zmh_info->startup_delay_time) {
+		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+			zlog_debug("startup-delay timer started for %d sec",
+				   zmh_info->startup_delay_time);
+		thread_add_timer(zrouter.master,
+				 zebra_evpn_mh_startup_delay_exp_cb, NULL,
+				 zmh_info->startup_delay_time,
+				 &zmh_info->startup_delay_timer);
+		zebra_evpn_mh_update_protodown(
+			ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY, true /* set */);
+	} else {
+		zebra_evpn_mh_update_protodown(
+			ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY, false /* set */);
+	}
+}
+
 /*****************************************************************************/
 void zebra_evpn_mh_config_write(struct vty *vty)
 {
-	if (zmh_info->mac_hold_time != EVPN_MH_MAC_HOLD_TIME_DEF)
-		vty_out(vty, "evpn mh mac-holdtime %ld\n",
+	if (zmh_info->mac_hold_time != ZEBRA_EVPN_MH_MAC_HOLD_TIME_DEF)
+		vty_out(vty, "evpn mh mac-holdtime %d\n",
 			zmh_info->mac_hold_time);
 
-	if (zmh_info->neigh_hold_time != EVPN_MH_NEIGH_HOLD_TIME_DEF)
-		vty_out(vty, "evpn mh neigh-holdtime %ld\n",
+	if (zmh_info->neigh_hold_time != ZEBRA_EVPN_MH_NEIGH_HOLD_TIME_DEF)
+		vty_out(vty, "evpn mh neigh-holdtime %d\n",
 			zmh_info->neigh_hold_time);
+
+	if (zmh_info->startup_delay_time != ZEBRA_EVPN_MH_STARTUP_DELAY_DEF)
+		vty_out(vty, "evpn mh startup-delay %d\n",
+			zmh_info->startup_delay_time);
 }
 
 int zebra_evpn_mh_neigh_holdtime_update(struct vty *vty,
 		uint32_t duration, bool set_default)
 {
 	if (set_default)
-		duration = EVPN_MH_NEIGH_HOLD_TIME_DEF;
+		duration = ZEBRA_EVPN_MH_NEIGH_HOLD_TIME_DEF;
 
 	zmh_info->neigh_hold_time = duration;
 
@@ -2732,9 +3124,21 @@ int zebra_evpn_mh_mac_holdtime_update(struct vty *vty,
 		uint32_t duration, bool set_default)
 {
 	if (set_default)
-		duration = EVPN_MH_MAC_HOLD_TIME_DEF;
+		duration = ZEBRA_EVPN_MH_MAC_HOLD_TIME_DEF;
 
 	zmh_info->mac_hold_time = duration;
+
+	return 0;
+}
+
+int zebra_evpn_mh_startup_delay_update(struct vty *vty, uint32_t duration,
+				       bool set_default)
+{
+	if (set_default)
+		duration = ZEBRA_EVPN_MH_STARTUP_DELAY_DEF;
+
+	zmh_info->startup_delay_time = duration;
+	zebra_evpn_mh_startup_delay_timer_start(false /* init */);
 
 	return 0;
 }
@@ -2744,14 +3148,15 @@ void zebra_evpn_interface_init(void)
 	install_element(INTERFACE_NODE, &zebra_evpn_es_id_cmd);
 	install_element(INTERFACE_NODE, &zebra_evpn_es_sys_mac_cmd);
 	install_element(INTERFACE_NODE, &zebra_evpn_es_pref_cmd);
+	install_element(INTERFACE_NODE, &zebra_evpn_mh_uplink_cmd);
 }
 
 void zebra_evpn_mh_init(void)
 {
 	zrouter.mh_info = XCALLOC(MTYPE_ZMH_INFO, sizeof(*zrouter.mh_info));
 
-	zmh_info->mac_hold_time = EVPN_MH_MAC_HOLD_TIME_DEF;
-	zmh_info->neigh_hold_time = EVPN_MH_NEIGH_HOLD_TIME_DEF;
+	zmh_info->mac_hold_time = ZEBRA_EVPN_MH_MAC_HOLD_TIME_DEF;
+	zmh_info->neigh_hold_time = ZEBRA_EVPN_MH_NEIGH_HOLD_TIME_DEF;
 	/* setup ES tables */
 	RB_INIT(zebra_es_rb_head, &zmh_info->es_rb_tree);
 	zmh_info->local_es_list = list_new();
@@ -2763,6 +3168,9 @@ void zebra_evpn_mh_init(void)
 	/* setup broadcast domain tables */
 	zmh_info->evpn_vlan_table = hash_create(zebra_evpn_acc_vl_hash_keymake,
 			zebra_evpn_acc_vl_cmp, "access VLAN hash table");
+
+	zmh_info->startup_delay_time = ZEBRA_EVPN_MH_STARTUP_DELAY_DEF;
+	zebra_evpn_mh_startup_delay_timer_start(true /*init*/);
 }
 
 void zebra_evpn_mh_terminate(void)

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -195,10 +195,25 @@ struct zebra_evpn_mh_info {
 #define EVPN_NHG_ID_TYPE_BIT (2 << EVPN_NH_ID_TYPE_POS)
 
 	/* XXX - re-visit the default hold timer value */
-#define EVPN_MH_MAC_HOLD_TIME_DEF (18 * 60)
-	long mac_hold_time;
-#define EVPN_MH_NEIGH_HOLD_TIME_DEF (18 * 60)
-	long neigh_hold_time;
+	int mac_hold_time;
+#define ZEBRA_EVPN_MH_MAC_HOLD_TIME_DEF (18 * 60)
+	int neigh_hold_time;
+#define ZEBRA_EVPN_MH_NEIGH_HOLD_TIME_DEF (18 * 60)
+
+	/* During this period access ports will be held in a protodown
+	 * state
+	 */
+	int startup_delay_time; /* seconds */
+#define ZEBRA_EVPN_MH_STARTUP_DELAY_DEF (3 * 60)
+	struct thread *startup_delay_timer;
+
+	/* Number of configured uplinks */
+	uint32_t uplink_cfg_cnt;
+	/* Number of operationally-up uplinks */
+	uint32_t uplink_oper_up_cnt;
+
+	/* These protodown bits are inherited by all ES bonds */
+	enum protodown_reasons protodown_rc;
 };
 
 static inline bool zebra_evpn_mac_is_es_local(zebra_mac_t *mac)
@@ -258,5 +273,16 @@ void zebra_evpn_mh_config_write(struct vty *vty);
 int zebra_evpn_mh_neigh_holdtime_update(struct vty *vty,
 		uint32_t duration, bool set_default);
 void zebra_evpn_es_local_br_port_update(struct zebra_if *zif);
+extern int zebra_evpn_mh_startup_delay_update(struct vty *vty,
+					      uint32_t duration,
+					      bool set_default);
+extern void zebra_evpn_mh_uplink_oper_update(struct zebra_if *zif);
+extern void zebra_evpn_mh_update_protodown_bond_mbr(struct zebra_if *zif,
+						    bool clear,
+						    const char *caller);
+extern bool zebra_evpn_is_es_bond(struct interface *ifp);
+extern bool zebra_evpn_is_es_bond_member(struct interface *ifp);
+extern void zebra_evpn_mh_print(struct vty *vty);
+extern void zebra_evpn_mh_json(json_object *json);
 
 #endif /* _ZEBRA_EVPN_MH_H */

--- a/zebra/zebra_l2.h
+++ b/zebra/zebra_l2.h
@@ -40,6 +40,10 @@ struct zebra_l2info_brslave {
 	ns_id_t ns_id; /* network namespace where bridge is */
 };
 
+struct zebra_l2info_bond {
+	struct list *mbr_zifs; /* slaves using this bond as a master */
+};
+
 /* zebra L2 interface information - bridge interface */
 struct zebra_l2info_bridge {
 	uint8_t vlan_aware; /* VLAN-aware bridge? */
@@ -86,10 +90,6 @@ extern void zebra_l2_map_slave_to_bridge(struct zebra_l2info_brslave *br_slave,
 					 struct zebra_ns *zns);
 extern void
 zebra_l2_unmap_slave_from_bridge(struct zebra_l2info_brslave *br_slave);
-extern void
-zebra_l2_map_slave_to_bond(struct zebra_l2info_bondslave *bond_slave, vrf_id_t);
-extern void
-zebra_l2_unmap_slave_from_bond(struct zebra_l2info_bondslave *bond_slave);
 extern void zebra_l2_bridge_add_update(struct interface *ifp,
 				       struct zebra_l2info_bridge *bridge_info,
 				       int add);
@@ -112,6 +112,7 @@ extern void zebra_vlan_bitmap_compute(struct interface *ifp,
 		uint32_t vid_start, uint16_t vid_end);
 extern void zebra_vlan_mbr_re_eval(struct interface *ifp,
 		bitfield_t vlan_bitmap);
+extern void zebra_l2if_update_bond(struct interface *ifp, bool add);
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -61,6 +61,29 @@ enum multicast_mode {
 			      /* on equal value, MRIB wins for last 2 */
 };
 
+/* An interface can be error-disabled if a protocol (such as EVPN or
+ * VRRP) detects a problem with keeping it operationally-up.
+ * If any of the protodown bits are set protodown-on is programmed
+ * in the dataplane. This results in a carrier/L1 down on the
+ * physical device.
+ */
+enum protodown_reasons {
+	/* On startup local ESs are held down for some time to
+	 * allow the underlay to converge and EVPN routes to
+	 * get learnt
+	 */
+	ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY = (1 << 0),
+	/* If all the uplinks are down the switch has lost access
+	 * to the VxLAN overlay and must shut down the access
+	 * ports to allow servers to re-direct their traffic to
+	 * other switches on the Ethernet Segment
+	 */
+	ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN = (1 << 1),
+	ZEBRA_PROTODOWN_EVPN_ALL = (ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN
+				    | ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY)
+};
+#define ZEBRA_PROTODOWN_RC_STR_LEN 80
+
 struct zebra_mlag_info {
 	/* Role this zebra router is playing */
 	enum mlag_role role;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2433,6 +2433,20 @@ DEFPY (evpn_mh_neigh_holdtime,
 			no ? true : false);
 }
 
+DEFPY (evpn_mh_startup_delay,
+       evpn_mh_startup_delay_cmd,
+       "[no] evpn mh startup-delay(0-3600)$duration",
+       NO_STR
+       "EVPN\n"
+       "Multihoming\n"
+       "Startup delay\n"
+       "duration in seconds\n")
+{
+
+	return zebra_evpn_mh_startup_delay_update(vty, duration,
+			no ? true : false);
+}
+
 DEFUN (default_vrf_vni_mapping,
        default_vrf_vni_mapping_cmd,
        "vni " CMD_VNI_RANGE "[prefix-routes-only]",
@@ -3990,6 +4004,7 @@ void zebra_vty_init(void)
 
 	install_element(CONFIG_NODE, &evpn_mh_mac_holdtime_cmd);
 	install_element(CONFIG_NODE, &evpn_mh_neigh_holdtime_cmd);
+	install_element(CONFIG_NODE, &evpn_mh_startup_delay_cmd);
 	install_element(CONFIG_NODE, &default_vrf_vni_mapping_cmd);
 	install_element(CONFIG_NODE, &no_default_vrf_vni_mapping_cmd);
 	install_element(VRF_NODE, &vrf_vni_mapping_cmd);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3427,7 +3427,7 @@ void zebra_vxlan_print_evpn(struct vty *vty, bool uj)
 		json_object_int_add(json, "detectionTime", zvrf->dad_time);
 		json_object_int_add(json, "detectionFreezeTime",
 				    zvrf->dad_freeze_time);
-
+		zebra_evpn_mh_json(json);
 	} else {
 		vty_out(vty, "L2 VNIs: %u\n", num_l2vnis);
 		vty_out(vty, "L3 VNIs: %u\n", num_l3vnis);
@@ -3447,6 +3447,7 @@ void zebra_vxlan_print_evpn(struct vty *vty, bool uj)
 				vty_out(vty, "  Detection freeze %s\n",
 					"permanent");
 		}
+		zebra_evpn_mh_print(vty);
 	}
 
 	if (uj) {


### PR DESCRIPTION
Local ethernet segments are held in a protodown or error-disabled state
if access to the VxLAN overlay is not ready -
1. When FRR comes up the local-ESs/access-port are kept protodown
    for the startup-delay duration. During this time the underlay and
    EVPN routes via it are expected to converge.
2. When all the uplinks/core-links attached to the underlay go down
    the access-ports are similarly protodowned.

The ES-bond protodown state is propagated to each ES-bond member/slave
and programmed in the dataplane/kernel (per-bond-member).