### PR TITLE
bgpd: Bgp static routes memory leak

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5747,9 +5747,9 @@ void bgp_static_delete(struct bgp *bgp)
 							bgp_dest_get_prefix(
 								dest));
 					bgp_static_free(bgp_static);
-					bgp_dest_set_bgp_static_info(dest,
+					bgp_dest_set_bgp_static_info(rm,
 								     NULL);
-					bgp_dest_unlock_node(dest);
+					bgp_dest_unlock_node(rm);
 				}
 			} else {
 				bgp_static = bgp_dest_get_bgp_static_info(dest);


### PR DESCRIPTION
When using MPLS_VPN/EVPN ( or really any two level table/route data structure setup )
FRR is leaking memory on shutdown:

eva# conf
eva(config)# router bgp 329
eva(config-router)# address-family ipv4 vpn
eva(config-router-af)# network 5.6.7.8/32 rd 44:55 label 3293
eva(config-router-af)# end
eva# exit
sharpd@eva ~/frr_coverity (master)> ps -ef | grep frr
root     1186423   10793  0 07:51 pts/1    00:00:00 sudo /usr/lib/frr/zebra --log stdout --log-level debug
frr      1186425 1186423  0 07:51 pts/1    00:00:00 /usr/lib/frr/zebra --log stdout --log-level debug
root     1263168  491694  0 11:10 pts/20   00:00:00 sudo valgrind --leak-check=full /usr/lib/frr/bgpd --log stdout --log-level debug
frr      1263169 1263168 22 11:10 pts/20   00:00:04 /usr/bin/valgrind.bin --leak-check=full /usr/lib/frr/bgpd --log stdout --log-level debug
sharpd   1263214  845829  0 11:10 pts/9    00:00:00 grep --color=auto frr
sharpd@eva ~/frr_coverity (master)> sudo kill -SIGTERM 1263169
sharpd@eva ~/frr_coverity (master)>

gives us this:

==1263169== 304 (40 direct, 264 indirect) bytes in 1 blocks are definitely lost in loss record 61 of 78
==1263169==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==1263169==    by 0x48DD878: qcalloc (memory.c:110)
==1263169==    by 0x5116D5: bgp_table_init (bgp_table.c:110)
==1263169==    by 0x4EB5C4: bgp_static_set_safi (bgp_route.c:5927)
==1263169==    by 0x4C3382: vpnv4_network (bgp_mplsvpn.c:1911)
==1263169==    by 0x489FBEC: cmd_execute_command_real (command.c:916)
==1263169==    by 0x489F7CB: cmd_execute_command (command.c:976)
==1263169==    by 0x489FD04: cmd_execute (command.c:1138)
==1263169==    by 0x493AF73: vty_command (vty.c:517)
==1263169==    by 0x493AA07: vty_execute (vty.c:1282)
==1263169==    by 0x4939B54: vtysh_read (vty.c:2115)
==1263169==    by 0x492E63C: thread_call (thread.c:1585)

The bgp_static_delete function was not unlocking the right bgp_dest.  This
problem goes away after fixing this.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>