### PR TITLE
pbrd: Fix memory leak

### DIFF
--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -82,6 +82,8 @@ static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 
+	pbr_vrf_terminate();
+
 	frr_fini();
 
 	exit(0);

--- a/pbrd/pbr_vrf.c
+++ b/pbrd/pbr_vrf.c
@@ -26,6 +26,7 @@
 #include "pbr_map.h"
 #include "pbr_debug.h"
 #include "pbr_nht.h"
+#include "pbr_zebra.h"
 
 DEFINE_MTYPE_STATIC(PBRD, PBR_MAP_VRF, "PBR Map VRF")
 
@@ -136,4 +137,15 @@ void pbr_vrf_init(void)
 {
 	vrf_init(pbr_vrf_new, pbr_vrf_enable, pbr_vrf_disable, pbr_vrf_delete,
 		 NULL);
+}
+
+void pbr_vrf_terminate(void)
+{
+	struct vrf *vrf;
+	struct interface *ifp;
+
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		FOR_ALL_INTERFACES (vrf, ifp)
+			pbr_if_del(ifp);
+	}
 }

--- a/pbrd/pbr_vrf.h
+++ b/pbrd/pbr_vrf.h
@@ -40,4 +40,5 @@ extern bool pbr_vrf_is_valid(const struct pbr_vrf *pbr_vrf);
 extern bool pbr_vrf_is_enabled(const struct pbr_vrf *pbr_vrf);
 
 extern void pbr_vrf_init(void);
+extern void pbr_vrf_terminate(void);
 #endif

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -59,6 +59,11 @@ struct pbr_interface *pbr_if_new(struct interface *ifp)
 	return pbr_ifp;
 }
 
+void pbr_if_del(struct interface *ifp)
+{
+	XFREE(MTYPE_PBR_INTERFACE, ifp->info);
+}
+
 /* Inteface addition message from zebra. */
 int pbr_ifp_create(struct interface *ifp)
 {

--- a/pbrd/pbr_zebra.h
+++ b/pbrd/pbr_zebra.h
@@ -46,4 +46,7 @@ extern int pbr_ifp_up(struct interface *ifp);
 extern int pbr_ifp_down(struct interface *ifp);
 extern int pbr_ifp_destroy(struct interface *ifp);
 
+/* Free the ifp->info pointer */
+extern void pbr_if_del(struct interface *ifp);
+
 #endif


### PR DESCRIPTION
On shutdown pbr was leaking the ifp->info ( struct pbr_interface *)
pointer.

Add some code to notice we are being shutdown and cleanup the memory

Signed-off-by: Donald Sharp <sharpd@nvidia.com>