### PR TITLE
isisd: Fix memory leak on shutdown

### DIFF
--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -583,6 +583,8 @@ void isis_finish(struct isis *isis)
 			isis_vrf_unlink(isis, vrf);
 	}
 
+	list_delete(&isis->area_list);
+	list_delete(&isis->init_circ_list);
 	XFREE(MTYPE_ISIS, isis);
 }
 


### PR DESCRIPTION
==935465== 40 bytes in 1 blocks are definitely lost in loss record 71 of 546
==935465==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==935465==    by 0x48D6611: qcalloc (memory.c:110)
==935465==    by 0x48CFE02: list_new (linklist.c:32)
==935465==    by 0x15DBF0: isis_new (isisd.c:213)
==935465==    by 0x15DAC4: isis_global_instance_create (isisd.c:179)
==935465==    by 0x121892: main (isis_main.c:264)
==935465== 64 (40 direct, 24 indirect) bytes in 1 blocks are definitely lost in loss record 101 of 546
==935465==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==935465==    by 0x48D6611: qcalloc (memory.c:110)
==935465==    by 0x48CFE02: list_new (linklist.c:32)
==935465==    by 0x15DBE3: isis_new (isisd.c:212)
==935465==    by 0x15DAC4: isis_global_instance_create (isisd.c:179)
==935465==    by 0x121892: main (isis_main.c:264)

On isis shutdown we are seeing the above memory leaks.  Modify
the code to start cleaning this up.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>