### PR TITLE
Add more Segment Routing controls

### DIFF
--- a/ospfd/ospf_ext.c
+++ b/ospfd/ospf_ext.c
@@ -462,6 +462,10 @@ static void set_rmt_itf_addr(struct ext_itf *exti, struct in_addr rmtif)
 static void ospf_extended_lsa_delete(struct ext_itf *exti)
 {
 
+	/* Avoid deleting LSA if Extended is not enable */
+	if (!OspfEXT.enabled)
+		return;
+
 	/* Process only Active Extended Prefix/Link LSA */
 	if (!CHECK_FLAG(exti->flags, EXT_LPFLG_LSA_ACTIVE))
 		return;
@@ -755,16 +759,16 @@ static void ospf_ext_ism_change(struct ospf_interface *oi, int old_status)
 	if (oi->type == OSPF_IFTYPE_LOOPBACK) {
 		exti->stype = PREF_SID;
 		exti->type = OPAQUE_TYPE_EXTENDED_PREFIX_LSA;
-		exti->flags = EXT_LPFLG_LSA_ACTIVE;
 		exti->instance = get_ext_pref_instance_value();
 		exti->area = oi->area;
 
-		osr_debug("EXT (%s): Set Prefix SID to interface %s ",
-			  __func__, oi->ifp->name);
-
 		/* Complete SRDB if the interface belongs to a Prefix */
-		if (OspfEXT.enabled)
+		if (OspfEXT.enabled) {
+			osr_debug("EXT (%s): Set Prefix SID to interface %s ",
+				  __func__, oi->ifp->name);
+			exti->flags = EXT_LPFLG_LSA_ACTIVE;
 			ospf_sr_update_local_prefix(oi->ifp, oi->address);
+		}
 	} else {
 		/* Determine if interface is related to Adj. or LAN Adj. SID */
 		if (oi->state == ISM_DR)
@@ -780,9 +784,11 @@ static void ospf_ext_ism_change(struct ospf_interface *oi, int old_status)
 		 * Note: Adjacency SID information are completed when ospf
 		 * adjacency become up see ospf_ext_link_nsm_change()
 		 */
-		osr_debug("EXT (%s): Set %sAdjacency SID for interface %s ",
-			  __func__, exti->stype == ADJ_SID ? "" : "LAN-",
-			  oi->ifp->name);
+		if (OspfEXT.enabled)
+			osr_debug(
+				"EXT (%s): Set %sAdjacency SID for interface %s ",
+				__func__, exti->stype == ADJ_SID ? "" : "LAN-",
+				oi->ifp->name);
 	}
 }
 
@@ -817,7 +823,8 @@ static void ospf_ext_link_nsm_change(struct ospf_neighbor *nbr, int old_status)
 	}
 
 	/* Remove Extended Link if Neighbor State goes Down or Deleted */
-	if (nbr->state == NSM_Down || nbr->state == NSM_Deleted) {
+	if (OspfEXT.enabled
+	    && (nbr->state == NSM_Down || nbr->state == NSM_Deleted)) {
 		ospf_ext_link_delete_adj_sid(exti);
 		if (CHECK_FLAG(exti->flags, EXT_LPFLG_LSA_ENGAGED))
 			ospf_ext_link_lsa_schedule(exti, FLUSH_THIS_LSA);

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -516,6 +516,9 @@ static int ospf_sr_start(struct ospf *ospf)
 static void ospf_sr_stop(void)
 {
 
+	if (OspfSR.status == SR_OFF)
+		return;
+
 	osr_debug("SR (%s): Stop Segment Routing", __func__);
 
 	/* Disable any re-attempt to connect to Label Manager */
@@ -1883,7 +1886,8 @@ void ospf_sr_update_task(struct ospf *ospf)
 
 	struct timeval start_time, stop_time;
 
-	if (ospf == NULL)
+	/* Check ospf and SR status */
+	if ((ospf == NULL) || (OspfSR.status != SR_UP))
 		return;
 
 	monotime(&start_time);


### PR DESCRIPTION
When Segment Routing is not enabled, some related output messages are
printed on the console especially when Segment Routing Debug is enabled.
Some topotests output show this kind of inappropriate messages.

This patch adds additional controls to check whether segment routing
is enabled or not.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>