### PR TITLE
zebra: add type specifier to show nexthop-group

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1033,14 +1033,15 @@ zebra Terminal Mode Commands
    total number of route nodes in the table.  Which will be higher than
    the actual number of routes that are held.
 
-.. index:: show nexthop-group rib [ID] [vrf NAME] [singleton [ip|ip6]]
-.. clicmd:: show nexthop-group rib [ID] [vrf NAME]
+.. index:: show nexthop-group rib [ID] [vrf NAME] [singleton [ip|ip6]] [type]
+.. clicmd:: show nexthop-group rib [ID] [vrf NAME] [singleton [ip|ip6]] [type]
 
    Display nexthop groups created by zebra.  The [vrf NAME] option
    is only meaningful if you have started zebra with the --vrfwnetns
    option as that nexthop groups are per namespace in linux.
    If you specify singleton you would like to see the singleton
-   nexthop groups that do have an afi.
+   nexthop groups that do have an afi. [type] allows you to filter those
+   only coming from a specific NHG type (protocol).
 
 
 Router-id


### PR DESCRIPTION
Add a type specifier to the `show nexthop-group` command
so we can easily filter by type when using proto created
nexthop groups.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>