### PR TITLE
zebra: fix unitialized msg header reading at startup

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1051,7 +1051,7 @@ static int nl_batch_read_resp(struct nl_batch *bth)
 {
 	struct nlmsghdr *h;
 	struct sockaddr_nl snl;
-	struct msghdr msg;
+	struct msghdr msg = {};
 	int status, seq;
 	const struct nlsock *nl;
 	struct zebra_dplane_ctx *ctx;


### PR DESCRIPTION
Fixes the valgrind error we were seeing on startup due to
initializing the msg header struct:

```
==2534283== Thread 3 zebra_dplane:
==2534283== Syscall param recvmsg(msg) points to uninitialised byte(s)
==2534283==    at 0x4D616DD: recvmsg (in /usr/lib64/libpthread-2.31.so)
==2534283==    by 0x43107C: netlink_recv_msg (kernel_netlink.c:744)
==2534283==    by 0x4330E4: nl_batch_read_resp (kernel_netlink.c:1070)
==2534283==    by 0x431D12: nl_batch_send (kernel_netlink.c:1201)
==2534283==    by 0x431E8B: kernel_update_multi (kernel_netlink.c:1369)
==2534283==    by 0x46019B: kernel_dplane_process_func (zebra_dplane.c:3979)
==2534283==    by 0x45EB7F: dplane_thread_loop (zebra_dplane.c:4368)
==2534283==    by 0x493F5CC: thread_call (thread.c:1585)
==2534283==    by 0x48D3450: fpt_run (frr_pthread.c:303)
==2534283==    by 0x48D3D41: frr_pthread_inner (frr_pthread.c:156)
==2534283==    by 0x4D56431: start_thread (in /usr/lib64/libpthread-2.31.so)
==2534283==    by 0x4E709D2: clone (in /usr/lib64/libc-2.31.so)
==2534283==  Address 0x85cd850 is on thread 3's stack
==2534283==  in frame #2, created by nl_batch_read_resp (kernel_netlink.c:1051)
==2534283==
==2534283== Syscall param recvmsg(msg.msg_control) points to unaddressable byte(s)
==2534283==    at 0x4D616DD: recvmsg (in /usr/lib64/libpthread-2.31.so)
==2534283==    by 0x43107C: netlink_recv_msg (kernel_netlink.c:744)
==2534283==    by 0x4330E4: nl_batch_read_resp (kernel_netlink.c:1070)
==2534283==    by 0x431D12: nl_batch_send (kernel_netlink.c:1201)
==2534283==    by 0x431E8B: kernel_update_multi (kernel_netlink.c:1369)
==2534283==    by 0x46019B: kernel_dplane_process_func (zebra_dplane.c:3979)
==2534283==    by 0x45EB7F: dplane_thread_loop (zebra_dplane.c:4368)
==2534283==    by 0x493F5CC: thread_call (thread.c:1585)
==2534283==    by 0x48D3450: fpt_run (frr_pthread.c:303)
==2534283==    by 0x48D3D41: frr_pthread_inner (frr_pthread.c:156)
==2534283==    by 0x4D56431: start_thread (in /usr/lib64/libpthread-2.31.so)
==2534283==    by 0x4E709D2: clone (in /usr/lib64/libc-2.31.so)
==2534283==  Address 0xa0 is not stack'd, malloc'd or (recently) free'd
==2534283==
```

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>