### PR TITLE
isisd: detect Prefix-SID collisions and handle them  appropriately

### DIFF
--- a/isisd/isis_errors.c
+++ b/isisd/isis_errors.c
@@ -44,6 +44,12 @@ static struct log_ref ferr_isis_err[] = {
 		.suggestion = "Configure a larger SRGB"
 	},
 	{
+		.code = EC_ISIS_SID_COLLISION,
+		.title = "SID collision",
+		.description = "Isis has detected that two different prefixes share the same SID index",
+		.suggestion = "Identify the routers that are advertising the same SID index and fix the collision accordingly"
+	},
+	{
 		.code = END_FERR,
 	}
 };

--- a/isisd/isis_errors.h
+++ b/isisd/isis_errors.h
@@ -27,6 +27,7 @@ enum isis_log_refs {
 	EC_ISIS_PACKET = ISIS_FERR_START,
 	EC_ISIS_CONFIG,
 	EC_ISIS_SID_OVERFLOW,
+	EC_ISIS_SID_COLLISION,
 };
 
 extern void isis_error_init(void);

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -1483,7 +1483,8 @@ int isis_instance_segment_routing_srgb_pre_validate(
 
 	/* Check that the block size does not exceed 65535 */
 	if ((srgb_ubound - srgb_lbound + 1) > 65535) {
-		zlog_warn(
+		snprintf(
+			args->errmsg, args->errmsg_len,
 			"New SR Global Block (%u/%u) exceed the limit of 65535",
 			srgb_lbound, srgb_ubound);
 		return NB_ERR_VALIDATION;
@@ -1491,7 +1492,8 @@ int isis_instance_segment_routing_srgb_pre_validate(
 
 	/* Validate SRGB against SRLB */
 	if (!((srgb_ubound < srlb_lbound) || (srgb_lbound > srlb_ubound))) {
-		zlog_warn(
+		snprintf(
+			args->errmsg, args->errmsg_len,
 			"New SR Global Block (%u/%u) conflict with Local Block (%u/%u)",
 			srgb_lbound, srgb_ubound, srlb_lbound, srlb_ubound);
 		return NB_ERR_VALIDATION;
@@ -1524,8 +1526,8 @@ int isis_instance_segment_routing_srgb_lower_bound_modify(
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if (!IS_MPLS_UNRESERVED_LABEL(lower_bound)) {
-			zlog_warn("Invalid SRGB lower bound: %u",
-				  lower_bound);
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Invalid SRGB lower bound: %u", lower_bound);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -1549,8 +1551,8 @@ int isis_instance_segment_routing_srgb_upper_bound_modify(
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if (!IS_MPLS_UNRESERVED_LABEL(upper_bound)) {
-			zlog_warn("Invalid SRGB upper bound: %u",
-				  upper_bound);
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Invalid SRGB upper bound: %u", upper_bound);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -1581,15 +1583,16 @@ int isis_instance_segment_routing_srlb_pre_validate(
 
 	/* Check that the block size does not exceed 65535 */
 	if ((srlb_ubound - srlb_lbound + 1) > 65535) {
-		zlog_warn(
-			"New SR Local Block (%u/%u) exceed the limit of 65535",
-			srlb_lbound, srlb_ubound);
+		snprintf(args->errmsg, args->errmsg_len,
+			 "New SR Local Block (%u/%u) exceed the limit of 65535",
+			 srlb_lbound, srlb_ubound);
 		return NB_ERR_VALIDATION;
 	}
 
 	/* Validate SRLB against SRGB */
 	if (!((srlb_ubound < srgb_lbound) || (srlb_lbound > srgb_ubound))) {
-		zlog_warn(
+		snprintf(
+			args->errmsg, args->errmsg_len,
 			"New SR Local Block (%u/%u) conflict with Global Block (%u/%u)",
 			srlb_lbound, srlb_ubound, srgb_lbound, srgb_ubound);
 		return NB_ERR_VALIDATION;
@@ -1622,8 +1625,8 @@ int isis_instance_segment_routing_srlb_lower_bound_modify(
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if (!IS_MPLS_UNRESERVED_LABEL(lower_bound)) {
-			zlog_warn("Invalid SRLB lower bound: %u",
-				  lower_bound);
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Invalid SRLB lower bound: %u", lower_bound);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -1647,8 +1650,8 @@ int isis_instance_segment_routing_srlb_upper_bound_modify(
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if (!IS_MPLS_UNRESERVED_LABEL(upper_bound)) {
-			zlog_warn("Invalid SRLB upper bound: %u",
-				  upper_bound);
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Invalid SRLB upper bound: %u", upper_bound);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -1764,14 +1767,16 @@ int isis_instance_segment_routing_prefix_sid_map_prefix_sid_pre_validate(
 	switch (sid_type) {
 	case SR_SID_VALUE_TYPE_INDEX:
 		if (sid >= srgb_range) {
-			zlog_warn("SID index %u falls outside local SRGB range",
-				  sid);
+			snprintf(args->errmsg, args->errmsg_len,
+				 "SID index %u falls outside local SRGB range",
+				 sid);
 			return NB_ERR_VALIDATION;
 		}
 		break;
 	case SR_SID_VALUE_TYPE_ABSOLUTE:
 		if (!IS_MPLS_UNRESERVED_LABEL(sid)) {
-			zlog_warn("Invalid absolute SID %u", sid);
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Invalid absolute SID %u", sid);
 			return NB_ERR_VALIDATION;
 		}
 		SET_FLAG(psid.flags, ISIS_PREFIX_SID_VALUE);

--- a/isisd/isis_spf.h
+++ b/isisd/isis_spf.h
@@ -53,6 +53,8 @@ struct isis_spftree *isis_spftree_new(struct isis_area *area,
 				      const uint8_t *sysid, int level,
 				      enum spf_tree_id tree_id,
 				      enum spf_type type, uint8_t flags);
+struct isis_vertex *isis_spf_prefix_sid_lookup(struct isis_spftree *spftree,
+					       struct isis_prefix_sid *psid);
 void isis_spf_invalidate_routes(struct isis_spftree *tree);
 void isis_spf_verify_routes(struct isis_area *area,
 			    struct isis_spftree **trees);

--- a/isisd/isis_spf_private.h
+++ b/isisd/isis_spf_private.h
@@ -313,6 +313,7 @@ struct isis_spftree {
 	struct route_table *route_table;
 	struct route_table *route_table_backup;
 	struct lspdb_head *lspdb; /* link-state db */
+	struct hash *prefix_sids; /* SR Prefix-SIDs. */
 	struct list *sadj_list;
 	struct isis_spf_nodes adj_nodes;
 	struct isis_area *area;    /* back pointer to area */

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -95,9 +95,9 @@ static int isis_zebra_if_address_add(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 #ifdef EXTREME_DEBUG
-	if (p->family == AF_INET)
+	if (c->address->family == AF_INET)
 		zlog_debug("connected IP address %pFX", c->address);
-	if (p->family == AF_INET6)
+	if (c->address->family == AF_INET6)
 		zlog_debug("connected IPv6 address %pFX", c->address);
 #endif /* EXTREME_DEBUG */
 
@@ -122,9 +122,9 @@ static int isis_zebra_if_address_del(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 #ifdef EXTREME_DEBUG
-	if (p->family == AF_INET)
+	if (c->address->family == AF_INET)
 		zlog_debug("disconnected IP address %pFX", c->address);
-	if (p->family == AF_INET6)
+	if (c->address->family == AF_INET6)
 		zlog_debug("disconnected IPv6 address %pFX", c->address);
 #endif /* EXTREME_DEBUG */
 


### PR DESCRIPTION
isisd relies on its YANG module to prevent the same SID index
from being configured multiple times for different prefixes. It's
possible, however, to have different routers assigning the same SID
index for different prefixes. When that happens, we say we have a
Prefix-SID collision, which is ultimately a misconfiguration issue.

The problem with Prefix-SID collisions is that the Prefix-SID that
is processed later overwrites the previous ones. Then, once the
Prefix-SID collision is fixed in the configuration, the overwritten
Prefix-SID isn't reinstalled since it's already marked as installed
and it didn't change. To prevent such inconsistency from happening,
add a safeguard in the SPF code to detect Prefix-SID collisions and
handle them appropriately (i.e. log a warning + ignore the Prefix-SID
Sub-TLV since it's already in use by another prefix). That way,
once the configuration is fixed, no Prefix-SID label entry will be
missing in the LFIB.

Reported-by: Emanuele Di Pascale <emanuele@voltanet.io>
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>