### PR TITLE
bgpd: fix mem leak in router bgp import vrf check

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -2687,8 +2687,7 @@ void bgp_vpn_leak_export(struct bgp *from_bgp)
 	idir = BGP_VPN_POLICY_DIR_FROMVPN;
 	edir = BGP_VPN_POLICY_DIR_TOVPN;
 
-	export_name = (from_bgp->name ? XSTRDUP(MTYPE_TMP, from_bgp->name)
-			       : XSTRDUP(MTYPE_TMP, VRF_DEFAULT_NAME));
+	export_name = from_bgp->name ? from_bgp->name : VRF_DEFAULT_NAME;
 
 	for (afi = 0; afi < AFI_MAX; ++afi) {
 		/* vrf leak is for IPv4 and IPv6 Unicast only */


### PR DESCRIPTION
```
==916511== 18 bytes in 2 blocks are definitely lost in loss record 7 of 147
==916511==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==916511==    by 0x4BE0F0A: strdup (strdup.c:42)
==916511==    by 0x48D66CE: qstrdup (memory.c:122)
==916511==    by 0x1E6E31: bgp_vpn_leak_export (bgp_mplsvpn.c:2690)
==916511==    by 0x28E892: bgp_router_create (bgp_nb_config.c:124)
==916511==    by 0x48E05AB: nb_callback_create (northbound.c:869)
==916511==    by 0x48E0FA2: nb_callback_configuration (northbound.c:1183)
==916511==    by 0x48E13D0: nb_transaction_process (northbound.c:1308)
==916511==    by 0x48E0137: nb_candidate_commit_apply (northbound.c:741)
==916511==    by 0x48E024B: nb_candidate_commit (northbound.c:773)
==916511==    by 0x48E6B21: nb_cli_classic_commit (northbound_cli.c:64)
==916511==    by 0x48E757E: nb_cli_apply_changes (northbound_cli.c:281)
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>