### PR TITLE
bgpd: Prevent ecomm memory leak

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -5297,6 +5297,7 @@ DEFUN (no_bgp_evpn_vrf_rt,
 	if (rt_type == RT_TYPE_IMPORT) {
 		if (!bgp_evpn_rt_matches_existing(bgp->vrf_import_rtl,
 						  ecomdel)) {
+			ecommunity_free(&ecomdel);
 			vty_out(vty,
 				"%% RT specified does not match configuration for this VRF\n");
 			return CMD_WARNING;
@@ -5305,6 +5306,7 @@ DEFUN (no_bgp_evpn_vrf_rt,
 	} else if (rt_type == RT_TYPE_EXPORT) {
 		if (!bgp_evpn_rt_matches_existing(bgp->vrf_export_rtl,
 						  ecomdel)) {
+			ecommunity_free(&ecomdel);
 			vty_out(vty,
 				"%% RT specified does not match configuration for this VRF\n");
 			return CMD_WARNING;
@@ -5326,12 +5328,14 @@ DEFUN (no_bgp_evpn_vrf_rt,
 		}
 
 		if (!found_ecomdel) {
+			ecommunity_free(&ecomdel);
 			vty_out(vty,
 				"%% RT specified does not match configuration for this VRF\n");
 			return CMD_WARNING;
 		}
 	}
 
+	ecommunity_free(&ecomdel);
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
There are some situations where we create a ecommunity for
comparing to internal state when we are deleting, but in the
failure cases we would not free up the created memory.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>