### PR TITLE
evpn-mh: miscellaneous fixes in MAC-sync and MAC-ECMP handling

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2761,10 +2761,6 @@ static ssize_t netlink_neigh_update_msg_encode(
 			return 0;
 	}
 
-	if (nhg_id) {
-		if (!nl_attr_put32(&req->n, datalen, NDA_NH_ID, nhg_id))
-			return 0;
-	}
 	if (nfy) {
 		if (!nl_attr_put(&req->n, datalen, NDA_NOTIFY,
 				&nfy_flags, sizeof(nfy_flags)))
@@ -2777,9 +2773,16 @@ static ssize_t netlink_neigh_update_msg_encode(
 			return 0;
 	}
 
-	ipa_len = IS_IPADDR_V4(ip) ? IPV4_MAX_BYTELEN : IPV6_MAX_BYTELEN;
-	if (!nl_attr_put(&req->n, datalen, NDA_DST, &ip->ip.addr, ipa_len))
-		return 0;
+	if (nhg_id) {
+		if (!nl_attr_put32(&req->n, datalen, NDA_NH_ID, nhg_id))
+			return 0;
+	} else {
+		ipa_len =
+			IS_IPADDR_V4(ip) ? IPV4_MAX_BYTELEN : IPV6_MAX_BYTELEN;
+		if (!nl_attr_put(&req->n, datalen, NDA_DST, &ip->ip.addr,
+				 ipa_len))
+			return 0;
+	}
 
 	if (op == DPLANE_OP_MAC_INSTALL || op == DPLANE_OP_MAC_DELETE) {
 		vlanid_t vid = dplane_ctx_mac_get_vlan(ctx);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2956,8 +2956,9 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 		}
 
 		if (IS_ZEBRA_IF_VXLAN(ifp))
-			return zebra_vxlan_check_del_local_mac(ifp, br_if, &mac,
-							       vid);
+			return zebra_vxlan_dp_network_mac_add(
+				ifp, br_if, &mac, vid, nhg_id, sticky,
+				!!(ndm->ndm_flags & NTF_EXT_LEARNED));
 
 		return zebra_vxlan_local_mac_add_update(ifp, br_if, &mac, vid,
 				sticky, local_inactive, dp_static);
@@ -2985,8 +2986,7 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	}
 
 	if (IS_ZEBRA_IF_VXLAN(ifp))
-		return zebra_vxlan_check_readd_remote_mac(ifp, br_if, &mac,
-							  vid);
+		return zebra_vxlan_dp_network_mac_del(ifp, br_if, &mac, vid);
 
 	return zebra_vxlan_local_mac_del(ifp, br_if, &mac, vid);
 }

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -1005,6 +1005,14 @@ int zebra_evpn_mac_del(zebra_evpn_t *zevpn, zebra_mac_t *mac)
 			   mac->flags);
 	}
 
+	/* If the MAC is freed before the neigh we will end up
+	 * with a stale pointer against the neigh
+	 */
+	if (!list_isempty(mac->neigh_list))
+		zlog_warn("%s: MAC %pEA flags 0x%x neigh list not empty %d",
+			  __func__, &mac->macaddr, mac->flags,
+			  listcount(mac->neigh_list));
+
 	/* force de-ref any ES entry linked to the MAC */
 	zebra_evpn_es_mac_deref_entry(mac);
 

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -2097,13 +2097,12 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf, zebra_evpn_t *zevpn,
 	}
 
 	/* if the dataplane thinks the entry is sync but it is
-	 * not sync in zebra we need to re-install to fixup
+	 * not sync in zebra (or vice-versa) we need to re-install
+	 * to fixup
 	 */
-	if (dp_static) {
-		new_static = zebra_evpn_mac_is_static(mac);
-		if (!new_static)
-			inform_dataplane = true;
-	}
+	new_static = zebra_evpn_mac_is_static(mac);
+	if (dp_static != new_static)
+		inform_dataplane = true;
 
 	if (local_inactive)
 		SET_FLAG(mac->flags, ZEBRA_MAC_LOCAL_INACTIVE);

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -2199,8 +2199,8 @@ int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, struct ethaddr *macaddr,
 				mac, old_bgp_ready, new_bgp_ready);
 		}
 
-		/* re-install the entry in the kernel */
-		zebra_evpn_sync_mac_dp_install(mac, false /* set_inactive */,
+		/* re-install the inactive entry in the kernel */
+		zebra_evpn_sync_mac_dp_install(mac, true /* set_inactive */,
 					       false /* force_clear_static */,
 					       __func__);
 

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -204,7 +204,8 @@ static inline void zebra_evpn_mac_clear_sync_info(zebra_mac_t *mac)
 struct hash *zebra_mac_db_create(const char *desc);
 uint32_t num_valid_macs(zebra_evpn_t *zevi);
 uint32_t num_dup_detected_macs(zebra_evpn_t *zevi);
-int zebra_evpn_rem_mac_uninstall(zebra_evpn_t *zevi, zebra_mac_t *mac);
+int zebra_evpn_rem_mac_uninstall(zebra_evpn_t *zevi, zebra_mac_t *mac,
+				 bool force);
 int zebra_evpn_rem_mac_install(zebra_evpn_t *zevi, zebra_mac_t *mac,
 			       bool was_static);
 void zebra_evpn_deref_ip2mac(zebra_evpn_t *zevi, zebra_mac_t *mac);

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -174,7 +174,6 @@ struct sync_mac_ip_ctx {
 };
 
 /**************************** SYNC MAC handling *****************************/
-/**************************** SYNC MAC handling *****************************/
 /* if the mac has been added of a mac-route from the peer
  * or if it is being referenced by a neigh added by the
  * peer we cannot let it age out i.e. we set the static bit
@@ -219,9 +218,8 @@ int zebra_evpn_macip_send_msg_to_client(uint32_t id, struct ethaddr *macaddr,
 void zebra_evpn_print_mac(zebra_mac_t *mac, void *ctxt, json_object *json);
 void zebra_evpn_print_mac_hash(struct hash_bucket *bucket, void *ctxt);
 void zebra_evpn_print_mac_hash_detail(struct hash_bucket *bucket, void *ctxt);
-void zebra_evpn_sync_mac_dp_install(zebra_mac_t *mac, bool set_inactive,
-				    bool force_clear_static,
-				    const char *caller);
+int zebra_evpn_sync_mac_dp_install(zebra_mac_t *mac, bool set_inactive,
+				   bool force_clear_static, const char *caller);
 void zebra_evpn_mac_send_add_del_to_client(zebra_mac_t *mac, bool old_bgp_ready,
 					   bool new_bgp_ready);
 

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3228,4 +3228,5 @@ void zebra_evpn_mh_terminate(void)
 	hash_iterate(zmh_info->evpn_vlan_table,
 			zebra_evpn_acc_vl_cleanup_all, NULL);
 	hash_free(zmh_info->evpn_vlan_table);
+	bf_free(zmh_info->nh_id_bitmap);
 }

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -27,6 +27,7 @@
 #include "bitfield.h"
 #include "zebra_vxlan.h"
 #include "zebra_vxlan_private.h"
+#include "zebra_nhg.h"
 
 #define EVPN_MH_VTY_STR "Multihoming\n"
 
@@ -205,18 +206,17 @@ struct zebra_evpn_mh_info {
 	struct in_addr es_originator_ip;
 
 	/* L2 NH and NHG ids -
-	 * Most significant 8 bits is type. Lower 24 bits is the value
+	 * Most significant 4 bits is type. Lower 28 bits is the value
 	 * allocated from the nh_id_bitmap.
 	 */
 	bitfield_t nh_id_bitmap;
 #define EVPN_NH_ID_MAX       (16*1024)
 #define EVPN_NH_ID_VAL_MASK  0xffffff
-#define EVPN_NH_ID_TYPE_POS  24
 /* The purpose of using different types for NHG and NH is NOT to manage the
  * id space separately. It is simply to make debugging easier.
  */
-#define EVPN_NH_ID_TYPE_BIT  (1 << EVPN_NH_ID_TYPE_POS)
-#define EVPN_NHG_ID_TYPE_BIT (2 << EVPN_NH_ID_TYPE_POS)
+#define EVPN_NH_ID_TYPE_BIT (NHG_TYPE_L2_NH << NHG_ID_TYPE_POS)
+#define EVPN_NHG_ID_TYPE_BIT (NHG_TYPE_L2 << NHG_ID_TYPE_POS)
 	/* L2-NHG table - key: nhg_id, data: zebra_evpn_es */
 	struct hash *nhg_table;
 	/* L2-NH table - key: vtep_up, data: zebra_evpn_nh */

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -126,6 +126,14 @@ struct nhg_hash_entry {
 #define NEXTHOP_GROUP_FPM (1 << 6)
 };
 
+/* Upper 4 bits of the NHG are reserved for indicating the NHG type */
+#define NHG_ID_TYPE_POS 28
+enum nhg_type {
+	NHG_TYPE_L3 = 0,
+	NHG_TYPE_L2_NH, /* NHs in a L2 NHG used as a MAC/FDB dest */
+	NHG_TYPE_L2,    /* L2 NHG used as a MAC/FDB dest */
+};
+
 /* Was this one we created, either this session or previously? */
 #define ZEBRA_NHG_CREATED(NHE)                                                 \
 	(((NHE->type) <= ZEBRA_ROUTE_MAX) && (NHE->type != ZEBRA_ROUTE_KERNEL))

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2690,6 +2690,21 @@ DEFUN (show_evpn_global,
 	return CMD_SUCCESS;
 }
 
+DEFPY(show_evpn_l2_nh,
+      show_evpn_l2_nh_cmd,
+      "show evpn l2-nh [json$json]",
+      SHOW_STR
+      "EVPN\n"
+      "Layer2 nexthops\n"
+      JSON_STR)
+{
+	bool uj = !!json;
+
+	zebra_evpn_l2_nh_show(vty, uj);
+
+	return CMD_SUCCESS;
+}
+
 DEFPY(show_evpn_es,
       show_evpn_es_cmd,
       "show evpn es [NAME$esi_str|detail$detail] [json$json]",
@@ -2697,8 +2712,8 @@ DEFPY(show_evpn_es,
       "EVPN\n"
       "Ethernet Segment\n"
       "ES ID\n"
-      JSON_STR
-      "Detailed information\n")
+      "Detailed information\n"
+      JSON_STR)
 {
 	esi_t esi;
 	bool uj = !!json;
@@ -4037,6 +4052,7 @@ void zebra_vty_init(void)
 	install_element(VIEW_NODE, &show_evpn_vni_cmd);
 	install_element(VIEW_NODE, &show_evpn_vni_detail_cmd);
 	install_element(VIEW_NODE, &show_evpn_vni_vni_cmd);
+	install_element(VIEW_NODE, &show_evpn_l2_nh_cmd);
 	install_element(VIEW_NODE, &show_evpn_es_cmd);
 	install_element(VIEW_NODE, &show_evpn_es_evi_cmd);
 	install_element(VIEW_NODE, &show_evpn_access_vlan_cmd);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2497,6 +2497,20 @@ DEFPY (evpn_mh_startup_delay,
 			no ? true : false);
 }
 
+DEFPY(evpn_mh_redirect_off, evpn_mh_redirect_off_cmd,
+      "[no$no] evpn mh redirect-off",
+      NO_STR
+      "EVPN\n"
+      "Multihoming\n"
+      "ES bond redirect for fast-failover off\n")
+{
+	bool redirect_off;
+
+	redirect_off = no ? false : true;
+
+	return zebra_evpn_mh_redirect_off(vty, redirect_off);
+}
+
 DEFUN (default_vrf_vni_mapping,
        default_vrf_vni_mapping_cmd,
        "vni " CMD_VNI_RANGE "[prefix-routes-only]",
@@ -4055,6 +4069,7 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &evpn_mh_mac_holdtime_cmd);
 	install_element(CONFIG_NODE, &evpn_mh_neigh_holdtime_cmd);
 	install_element(CONFIG_NODE, &evpn_mh_startup_delay_cmd);
+	install_element(CONFIG_NODE, &evpn_mh_redirect_off_cmd);
 	install_element(CONFIG_NODE, &default_vrf_vni_mapping_cmd);
 	install_element(CONFIG_NODE, &no_default_vrf_vni_mapping_cmd);
 	install_element(VRF_NODE, &vrf_vni_mapping_cmd);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3910,9 +3910,10 @@ int zebra_vxlan_check_readd_vtep(struct interface *ifp,
  * us, this must involve a multihoming scenario. Treat this as implicit delete
  * of any prior local MAC.
  */
-int zebra_vxlan_check_del_local_mac(struct interface *ifp,
-				    struct interface *br_if,
-				    struct ethaddr *macaddr, vlanid_t vid)
+static int zebra_vxlan_check_del_local_mac(struct interface *ifp,
+					   struct interface *br_if,
+					   struct ethaddr *macaddr,
+					   vlanid_t vid)
 {
 	struct zebra_if *zif;
 	struct zebra_l2info_vxlan *vxl;
@@ -3969,14 +3970,48 @@ int zebra_vxlan_check_del_local_mac(struct interface *ifp,
 	return 0;
 }
 
-/*
- * Handle remote MAC delete by kernel; readd the remote MAC if we have it.
- * This can happen because the remote MAC entries are also added as "dynamic",
- * so the kernel can ageout the entry.
+/* MAC notification from the dataplane with a network dest port -
+ * 1. This can be a local MAC on a down ES (if fast-failover is not possible
+ * 2. Or it can be a remote MAC
  */
-int zebra_vxlan_check_readd_remote_mac(struct interface *ifp,
-				       struct interface *br_if,
-				       struct ethaddr *macaddr, vlanid_t vid)
+int zebra_vxlan_dp_network_mac_add(struct interface *ifp,
+				   struct interface *br_if,
+				   struct ethaddr *macaddr, vlanid_t vid,
+				   uint32_t nhg_id, bool sticky, bool dp_static)
+{
+	struct zebra_evpn_es *es;
+	struct interface *acc_ifp;
+
+	/* if remote mac delete the local entry */
+	if (!nhg_id || !zebra_evpn_nhg_is_local_es(nhg_id, &es)
+	    || !zebra_evpn_es_local_mac_via_network_port(es)) {
+		if (IS_ZEBRA_DEBUG_VXLAN || IS_ZEBRA_DEBUG_EVPN_MH_MAC)
+			zlog_debug("dpAdd remote MAC %pEA VID %u", macaddr,
+				   vid);
+		return zebra_vxlan_check_del_local_mac(ifp, br_if, macaddr,
+						       vid);
+	}
+
+	/* If local MAC on a down local ES translate the network-mac-add
+	 * to a local-inactive-mac-add
+	 */
+	if (IS_ZEBRA_DEBUG_VXLAN || IS_ZEBRA_DEBUG_EVPN_MH_MAC)
+		zlog_debug("dpAdd local-nw-MAC %pEA VID %u", macaddr, vid);
+	acc_ifp = es->zif->ifp;
+	return zebra_vxlan_local_mac_add_update(
+		acc_ifp, br_if, macaddr, vid, sticky,
+		false /* local_inactive */, dp_static);
+}
+
+/*
+ * Handle network MAC delete by kernel -
+ * 1. readd the remote MAC if we have it
+ * 2. local MAC with does ES may also need to be re-installed
+ */
+static int zebra_vxlan_do_local_mac_del(zebra_evpn_t *zevpn, zebra_mac_t *mac);
+int zebra_vxlan_dp_network_mac_del(struct interface *ifp,
+				   struct interface *br_if,
+				   struct ethaddr *macaddr, vlanid_t vid)
 {
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan *vxl = NULL;
@@ -3984,7 +4019,6 @@ int zebra_vxlan_check_readd_remote_mac(struct interface *ifp,
 	zebra_evpn_t *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 	zebra_mac_t *mac = NULL;
-	char buf[ETHER_ADDR_STRLEN];
 
 	zif = ifp->info;
 	assert(zif);
@@ -4010,16 +4044,89 @@ int zebra_vxlan_check_readd_remote_mac(struct interface *ifp,
 	if (!mac)
 		return 0;
 
-	/* Is it a remote entry? */
-	if (!CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE))
-		return 0;
+	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE)) {
+		/* If remote entry simply re-install */
+		if (IS_ZEBRA_DEBUG_VXLAN || IS_ZEBRA_DEBUG_EVPN_MH_MAC)
+			zlog_debug(
+				"dpDel remote MAC %pEA intf %s(%u) VNI %u - readd",
+				macaddr, ifp->name, ifp->ifindex, vni);
+		zebra_evpn_rem_mac_install(zevpn, mac, false /* was_static */);
+	} else if (CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL) && mac->es
+		   && zebra_evpn_es_local_mac_via_network_port(mac->es)) {
+		/* If local entry via nw-port call local-del which will
+		 * re-install entry in the dataplane is needed
+		 */
+		if (IS_ZEBRA_DEBUG_VXLAN || IS_ZEBRA_DEBUG_EVPN_MH_MAC)
+			zlog_debug("dpDel local-nw-MAC %pEA VNI %u", macaddr,
+				   vni);
+		zebra_vxlan_do_local_mac_del(zevpn, mac);
+	}
+
+	return 0;
+}
+
+static int zebra_vxlan_do_local_mac_del(zebra_evpn_t *zevpn, zebra_mac_t *mac)
+{
+	bool old_bgp_ready;
+	bool new_bgp_ready;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Del remote MAC %s intf %s(%u) VNI %u - readd",
-			   prefix_mac2str(macaddr, buf, sizeof(buf)), ifp->name,
-			   ifp->ifindex, vni);
+		zlog_debug("DEL MAC %pEA VNI %u seq %u flags 0x%x nbr count %u",
+			   &mac->macaddr, zevpn->vni, mac->loc_seq, mac->flags,
+			   listcount(mac->neigh_list));
 
-	zebra_evpn_rem_mac_install(zevpn, mac, false /* was_static */);
+	old_bgp_ready = zebra_evpn_mac_is_ready_for_bgp(mac->flags);
+	if (zebra_evpn_mac_is_static(mac)) {
+		/* this is a synced entry and can only be removed when the
+		 * es-peers stop advertising it.
+		 */
+		memset(&mac->fwd_info, 0, sizeof(mac->fwd_info));
+
+		if (IS_ZEBRA_DEBUG_EVPN_MH_MAC)
+			zlog_debug(
+				"re-add sync-mac vni %u mac %pEA es %s seq %d f 0x%x",
+				zevpn->vni, &mac->macaddr,
+				mac->es ? mac->es->esi_str : "-", mac->loc_seq,
+				mac->flags);
+
+		/* inform-bgp about change in local-activity if any */
+		if (!CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL_INACTIVE)) {
+			SET_FLAG(mac->flags, ZEBRA_MAC_LOCAL_INACTIVE);
+			new_bgp_ready =
+				zebra_evpn_mac_is_ready_for_bgp(mac->flags);
+			zebra_evpn_mac_send_add_del_to_client(
+				mac, old_bgp_ready, new_bgp_ready);
+		}
+
+		/* re-install the entry in the kernel */
+		zebra_evpn_sync_mac_dp_install(mac, false /* set_inactive */,
+					       false /* force_clear_static */,
+					       __func__);
+
+		return 0;
+	}
+
+	/* Update all the neigh entries associated with this mac */
+	zebra_evpn_process_neigh_on_local_mac_del(zevpn, mac);
+
+	/* Remove MAC from BGP. */
+	zebra_evpn_mac_send_del_to_client(zevpn->vni, &mac->macaddr, mac->flags,
+					  false /* force */);
+
+	zebra_evpn_es_mac_deref_entry(mac);
+
+	/*
+	 * If there are no neigh associated with the mac delete the mac
+	 * else mark it as AUTO for forward reference
+	 */
+	if (!listcount(mac->neigh_list)) {
+		zebra_evpn_mac_del(zevpn, mac);
+	} else {
+		UNSET_FLAG(mac->flags, ZEBRA_MAC_ALL_LOCAL_FLAGS);
+		UNSET_FLAG(mac->flags, ZEBRA_MAC_STICKY);
+		SET_FLAG(mac->flags, ZEBRA_MAC_AUTO);
+	}
+
 	return 0;
 }
 
@@ -4030,6 +4137,7 @@ int zebra_vxlan_local_mac_del(struct interface *ifp, struct interface *br_if,
 			      struct ethaddr *macaddr, vlanid_t vid)
 {
 	zebra_evpn_t *zevpn;
+	zebra_mac_t *mac;
 
 	/* We are interested in MACs only on ports or (port, VLAN) that
 	 * map to a VNI.
@@ -4044,7 +4152,16 @@ int zebra_vxlan_local_mac_del(struct interface *ifp, struct interface *br_if,
 		return -1;
 	}
 
-	return zebra_evpn_del_local_mac(zevpn, macaddr, ifp);
+	/* If entry doesn't exist, nothing to do. */
+	mac = zebra_evpn_mac_lookup(zevpn, macaddr);
+	if (!mac)
+		return 0;
+
+	/* Is it a local entry? */
+	if (!CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL))
+		return 0;
+
+	return zebra_vxlan_do_local_mac_del(zevpn, mac);
 }
 
 /*

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -177,13 +177,6 @@ extern int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 extern int zebra_vxlan_local_mac_del(struct interface *ifp,
 				     struct interface *br_if,
 				     struct ethaddr *mac, vlanid_t vid);
-extern int zebra_vxlan_check_readd_remote_mac(struct interface *ifp,
-					      struct interface *br_if,
-					      struct ethaddr *mac,
-					      vlanid_t vid);
-extern int zebra_vxlan_check_del_local_mac(struct interface *ifp,
-					   struct interface *br_if,
-					   struct ethaddr *mac, vlanid_t vid);
 extern int zebra_vxlan_check_readd_vtep(struct interface *ifp,
 					struct in_addr vtep_ip);
 extern int zebra_vxlan_if_up(struct interface *ifp);
@@ -222,6 +215,15 @@ extern void zebra_evpn_init(void);
 extern void zebra_vxlan_macvlan_up(struct interface *ifp);
 extern void zebra_vxlan_macvlan_down(struct interface *ifp);
 extern int vni_list_cmp(void *p1, void *p2);
+extern int zebra_vxlan_dp_network_mac_add(struct interface *ifp,
+					  struct interface *br_if,
+					  struct ethaddr *macaddr, vlanid_t vid,
+					  uint32_t nhg_id, bool sticky,
+					  bool dp_static);
+extern int zebra_vxlan_dp_network_mac_del(struct interface *ifp,
+					  struct interface *br_if,
+					  struct ethaddr *macaddr,
+					  vlanid_t vid);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR includes a bunch of fixes for problems found during testing. And includes the following improvements -
1. Allocate one L2-NH per-VTEP -
```
zebra: allocate one nexthop id per-VTEP instead of one per-ES-VTEP

    This is an optimization to reduce the number of L2 nexthops. A
    l2 or fdb nexthop simply provides the dataplane with a nexthop ip-
    torm-12:mgmt:~# ip nexthop
    id 268435461 via 27.0.0.20 scope link fdb
    id 268435463 via 27.0.0.20 scope link fdb
    id 268435465 via 27.0.0.20 scope link fdb

    So there is no need to allocate a nexthop per-ES/per-VTEP. There
    can be 100+ ESs per-VTEP so this change cuts the scale down by a
    factor of 100.
```
2. Add support for slow failover on data-planes that do not have redirect capability -
```
    zebra: support for slow-failover of local MACs on an ES

    When a local ES flaps there are two modes in which the local
    MACs are failed over -
    1. Fast failover - A backup NHG (ES-peer group) is programmed in the
    dataplane per-access port. When a local ES flaps the MAC entries
    are left unaltered i.e. pointing to the down access port. And the
    dataplane redirects traffic destined to the oper-down access port
    via the backup NHG.
    2. Slow failover - This mode needs to be turned on to allow dataplanes
    not capable of re-directing traffic. In this mode local MAC entries
    on a down local ES are re-programmed to point to the ES-peers'
    NHG. And vice-versa i.e. when the ES comes up the MAC entries
    are re-programmed with the access port as dest.

    Fast failover is on by default. Slow failover can be enabled via the
    following config -
    evpn mh redirect-off
```