### PR TITLE
ospf6d: Json support added for command "show ipv6 ospf6 route [json]"

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -255,6 +255,13 @@ Showing OSPF6 information
    The additional match option will match the given address to the destination
    of the routes, and return the result accordingly.
 
+.. index:: show ipv6 ospf6 interface [IFNAME] prefix [detail|<X:X::X:X|X:X::X:X/M> [<match|detail>]] [json]
+.. clicmd:: show ipv6 ospf6 interface [IFNAME] prefix [detail|<X:X::X:X|X:X::X:X/M> [<match|detail>]] [json]
+
+   This command shows the prefixes present in the interface routing table.
+   Interface name can also be given. JSON output can be obtained by appending
+   'json' to the end of command.
+
 OSPF6 Configuration Examples
 ============================
 

--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -240,6 +240,21 @@ Showing OSPF6 information
    Shows the routes which are redistributed by the router. JSON output can
    be obtained by appending 'json' at the end.
 
+.. index:: show ipv6 ospf6 route [<intra-area|inter-area|external-1|external-2|X:X::X:X|X:X::X:X/M|detail|summary>] [json]
+.. clicmd:: show ipv6 ospf6 route [<intra-area|inter-area|external-1|external-2|X:X::X:X|X:X::X:X/M|detail|summary>] [json]
+
+   This command displays the ospfv3 routing table as determined by the most
+   recent SPF calculations. Options are provided to view the different types
+   of routes. Other than the standard view there are two other options, detail
+   and summary. JSON output can be obtained by appending 'json' to the end of
+   command.
+
+.. index:: show ipv6 ospf6 route X:X::X:X/M match [detail] [json]
+.. clicmd:: show ipv6 ospf6 route X:X::X:X/M match [detail] [json]
+
+   The additional match option will match the given address to the destination
+   of the routes, and return the result accordingly.
+
 OSPF6 Configuration Examples
 ============================
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1447,8 +1447,8 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
 		return CMD_WARNING;
 	}
 
-	ospf6_route_table_show(vty, idx_prefix, argc, argv,
-			       oi->route_connected);
+	ospf6_route_table_show(vty, idx_prefix, argc, argv, oi->route_connected,
+			       false);
 
 	return CMD_SUCCESS;
 }
@@ -1482,7 +1482,7 @@ DEFUN (show_ipv6_ospf6_interface_prefix,
 			continue;
 
 		ospf6_route_table_show(vty, idx_prefix, argc, argv,
-				       oi->route_connected);
+				       oi->route_connected, false);
 	}
 
 	return CMD_SUCCESS;

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1416,7 +1416,7 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
           [<\
 	    detail\
 	    |<X:X::X:X|X:X::X:X/M> [<match|detail>]\
-	  >]",
+	  >] [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
@@ -1427,12 +1427,14 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
        OSPF6_ROUTE_ADDRESS_STR
        OSPF6_ROUTE_PREFIX_STR
        OSPF6_ROUTE_MATCH_STR
-       "Display details of the prefixes\n")
+       "Display details of the prefixes\n"
+       JSON_STR)
 {
 	int idx_ifname = 4;
 	int idx_prefix = 6;
 	struct interface *ifp;
 	struct ospf6_interface *oi;
+	bool uj = use_json(argc, argv);
 
 	ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
 	if (ifp == NULL) {
@@ -1448,7 +1450,7 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
 	}
 
 	ospf6_route_table_show(vty, idx_prefix, argc, argv, oi->route_connected,
-			       false);
+			       uj);
 
 	return CMD_SUCCESS;
 }
@@ -1459,7 +1461,7 @@ DEFUN (show_ipv6_ospf6_interface_prefix,
           [<\
 	    detail\
 	    |<X:X::X:X|X:X::X:X/M> [<match|detail>]\
-	  >]",
+	  >] [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
@@ -1469,12 +1471,14 @@ DEFUN (show_ipv6_ospf6_interface_prefix,
        OSPF6_ROUTE_ADDRESS_STR
        OSPF6_ROUTE_PREFIX_STR
        OSPF6_ROUTE_MATCH_STR
-       "Display details of the prefixes\n")
+       "Display details of the prefixes\n"
+       JSON_STR)
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	int idx_prefix = 5;
 	struct ospf6_interface *oi;
 	struct interface *ifp;
+	bool uj = use_json(argc, argv);
 
 	FOR_ALL_INTERFACES (vrf, ifp) {
 		oi = (struct ospf6_interface *)ifp->info;
@@ -1482,7 +1486,7 @@ DEFUN (show_ipv6_ospf6_interface_prefix,
 			continue;
 
 		ospf6_route_table_show(vty, idx_prefix, argc, argv,
-				       oi->route_connected, false);
+				       oi->route_connected, uj);
 	}
 
 	return CMD_SUCCESS;

--- a/ospf6d/ospf6_route.h
+++ b/ospf6d/ospf6_route.h
@@ -23,6 +23,7 @@
 
 #include "command.h"
 #include "zclient.h"
+#include "lib/json.h"
 
 #define OSPF6_MULTI_PATH_LIMIT    4
 
@@ -233,6 +234,9 @@ extern const char *const ospf6_path_type_substr[OSPF6_PATH_TYPE_MAX];
 #define OSPF6_PATH_TYPE_SUBSTR(x)                                              \
 	(0 < (x) && (x) < OSPF6_PATH_TYPE_MAX ? ospf6_path_type_substr[(x)]    \
 					      : ospf6_path_type_substr[0])
+#define OSPF6_PATH_TYPE_JSON(x)                                                \
+	(0 < (x) && (x) < OSPF6_PATH_TYPE_MAX ? ospf6_path_type_json[(x)]      \
+					      : ospf6_path_type_json[0])
 
 #define OSPF6_ROUTE_ADDRESS_STR "Display the route bestmatches the address\n"
 #define OSPF6_ROUTE_PREFIX_STR  "Display the route\n"
@@ -326,11 +330,14 @@ extern void ospf6_route_table_delete(struct ospf6_route_table *table);
 extern void ospf6_route_dump(struct ospf6_route_table *table);
 
 
-extern void ospf6_route_show(struct vty *vty, struct ospf6_route *route);
-extern void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route);
+extern void ospf6_route_show(struct vty *vty, struct ospf6_route *route,
+			     json_object *json, bool use_json);
+extern void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route,
+				    json_object *json, bool use_json);
+
 
 extern int ospf6_route_table_show(struct vty *, int, int, struct cmd_token **,
-				  struct ospf6_route_table *);
+				  struct ospf6_route_table *, bool use_json);
 extern int ospf6_linkstate_table_show(struct vty *vty, int idx_ipv4, int argc,
 				      struct cmd_token **argv,
 				      struct ospf6_route_table *table);

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -51,6 +51,7 @@
 #include "ospf6_intra.h"
 #include "ospf6_spf.h"
 #include "ospf6d.h"
+#include "lib/json.h"
 
 DEFINE_QOBJ_TYPE(ospf6)
 
@@ -1165,7 +1166,7 @@ DEFUN(show_ipv6_ospf6,
 
 DEFUN (show_ipv6_ospf6_route,
        show_ipv6_ospf6_route_cmd,
-       "show ipv6 ospf6 route [<intra-area|inter-area|external-1|external-2|X:X::X:X|X:X::X:X/M|detail|summary>]",
+       "show ipv6 ospf6 route [<intra-area|inter-area|external-1|external-2|X:X::X:X|X:X::X:X/M|detail|summary>] [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
@@ -1177,41 +1178,44 @@ DEFUN (show_ipv6_ospf6_route,
        "Specify IPv6 address\n"
        "Specify IPv6 prefix\n"
        "Detailed information\n"
-       "Summary of route table\n")
+       "Summary of route table\n"
+       JSON_STR)
 {
 	struct ospf6 *ospf6;
+	bool uj = use_json(argc, argv);
 
 	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
 	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
-	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table);
+	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table, uj);
 	return CMD_SUCCESS;
 }
 
 DEFUN (show_ipv6_ospf6_route_match,
        show_ipv6_ospf6_route_match_cmd,
-       "show ipv6 ospf6 route X:X::X:X/M <match|longer>",
+       "show ipv6 ospf6 route X:X::X:X/M <match|longer> [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
        ROUTE_STR
        "Specify IPv6 prefix\n"
        "Display routes which match the specified route\n"
-       "Display routes longer than the specified route\n")
+       "Display routes longer than the specified route\n"
+       JSON_STR)
 {
 	struct ospf6 *ospf6;
+	bool uj = use_json(argc, argv);
 
 	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
 	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
-	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table);
-
+	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table, uj);
 	return CMD_SUCCESS;
 }
 
 DEFUN (show_ipv6_ospf6_route_match_detail,
        show_ipv6_ospf6_route_match_detail_cmd,
-       "show ipv6 ospf6 route X:X::X:X/M match detail",
+       "show ipv6 ospf6 route X:X::X:X/M match detail [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
@@ -1219,21 +1223,22 @@ DEFUN (show_ipv6_ospf6_route_match_detail,
        "Specify IPv6 prefix\n"
        "Display routes which match the specified route\n"
        "Detailed information\n"
-       )
+       JSON_STR)
 {
 	struct ospf6 *ospf6;
+	bool uj = use_json(argc, argv);
 
 	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
 	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
-	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table);
+	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table, uj);
 	return CMD_SUCCESS;
 }
 
 
 DEFUN (show_ipv6_ospf6_route_type_detail,
        show_ipv6_ospf6_route_type_detail_cmd,
-       "show ipv6 ospf6 route <intra-area|inter-area|external-1|external-2> detail",
+       "show ipv6 ospf6 route <intra-area|inter-area|external-1|external-2> detail [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
@@ -1243,14 +1248,15 @@ DEFUN (show_ipv6_ospf6_route_type_detail,
        "Display Type-1 External routes\n"
        "Display Type-2 External routes\n"
        "Detailed information\n"
-       )
+       JSON_STR)
 {
 	struct ospf6 *ospf6;
+	bool uj = use_json(argc, argv);
 
 	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
 	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
-	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table);
+	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table, uj);
 	return CMD_SUCCESS;
 }
 

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -1006,7 +1006,7 @@ DEFUN (show_ipv6_ospf6_border_routers,
 		if (strmatch(argv[idx_ipv4]->text, "detail")) {
 			for (ro = ospf6_route_head(ospf6->brouter_table); ro;
 			     ro = ospf6_route_next(ro))
-				ospf6_route_show_detail(vty, ro);
+				ospf6_route_show_detail(vty, ro, NULL, false);
 		} else {
 			inet_pton(AF_INET, argv[idx_ipv4]->arg, &adv_router);
 
@@ -1019,7 +1019,7 @@ DEFUN (show_ipv6_ospf6_border_routers,
 				return CMD_SUCCESS;
 			}
 
-			ospf6_route_show_detail(vty, ro);
+			ospf6_route_show_detail(vty, ro, NULL, false);
 			return CMD_SUCCESS;
 		}
 	} else {


### PR DESCRIPTION
Modify code to add JSON format output in show command
"show ipv6 ospf6 route [<intra-area|inter-area|external-1|
external-2|X:X::X:X|X:X::X:X/M|detail|summary>]"
with proper formating

Signed-off-by: Yash Ranjan <ranjany@vmware.com>