### PR TITLE
pimd: (*,G) Prune processing doesn't remove SGRpt ifchannel

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -258,7 +258,7 @@ void pim_ifchannel_delete_all(struct interface *ifp)
 	}
 }
 
-static void delete_on_noinfo(struct pim_ifchannel *ch)
+void delete_on_noinfo(struct pim_ifchannel *ch)
 {
 	if (ch->local_ifmembership == PIM_IFMEMBERSHIP_NOINFO
 	    && ch->ifjoin_state == PIM_IFJOIN_NOINFO

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -173,4 +173,5 @@ int pim_ifchannel_compare(const struct pim_ifchannel *ch1,
 			  const struct pim_ifchannel *ch2);
 
 unsigned int pim_ifchannel_hash_key(const void *arg);
+void delete_on_noinfo(struct pim_ifchannel *ch);
 #endif /* PIM_IFCHANNEL_H */

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -350,8 +350,11 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 					    == PIM_IFJOIN_PRUNE_PENDING_TMP)
 						THREAD_OFF(
 							child->t_ifjoin_prune_pending_timer);
+					THREAD_OFF(
+						child->t_ifjoin_expiry_timer);
 					PIM_IF_FLAG_UNSET_S_G_RPT(child->flags);
 					child->ifjoin_state = PIM_IFJOIN_NOINFO;
+					delete_on_noinfo(child);
 				}
 			}
 


### PR DESCRIPTION
problem :
=========
When (*,G) prune received where we have SGRpt state,
ifchannel goes to NO_INFO state and doesn't get removed.

Root cause :
============
During the processing of (*,G) prune, we are not removing the
ifchannel on PruneTmp or PrunePendingTmp state.

Fix :
=====
In that scenario, stop joinExpiry timer and delete the ifchannel.

issue #7347

I have explained the detailed sequence of events on issue #7347. 
Please check comment section on issue #7347.