### PR TITLE
bgpd: withdraw any exported routes when deleting a vrf

### DIFF
--- a/bgpd/bgp_nb_config.c
+++ b/bgpd/bgp_nb_config.c
@@ -173,7 +173,6 @@ int bgp_router_destroy(struct nb_cb_destroy_args *args)
 	case NB_EV_APPLY:
 		bgp = nb_running_unset_entry(args->dnode);
 
-		bgp_vpn_leak_unimport(bgp);
 		bgp_delete(bgp);
 
 		break;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3382,6 +3382,14 @@ int bgp_delete(struct bgp *bgp)
 
 	assert(bgp);
 
+	/* make sure we withdraw any exported routes */
+	vpn_leak_prechange(BGP_VPN_POLICY_DIR_TOVPN, AFI_IP, bgp_get_default(),
+			   bgp);
+	vpn_leak_prechange(BGP_VPN_POLICY_DIR_TOVPN, AFI_IP6, bgp_get_default(),
+			   bgp);
+
+	bgp_vpn_leak_unimport(bgp);
+
 	hook_call(bgp_inst_delete, bgp);
 
 	THREAD_OFF(bgp->t_startup);


### PR DESCRIPTION
When a BGP vrf instance is deleted, the routes it exported into the
main VPN table are not deleted and they remain as stale routes
attached to an unknown bgp instance. When the new vrf instance comes
along, it imports these routes from the main table and thus we see
duplicates alongside its own identical routes.
The solution is to call the unexport logic when a BGP vrf instance is
being deleted.

Signed-off-by: Pat Ruddy <pat@voltanet.io>