### PR TITLE
lib, sharpd, vtysh: When reading a file in for config send start/end …

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -530,7 +530,9 @@ extern int cmd_execute_command(vector, struct vty *,
 			       const struct cmd_element **, int);
 extern int cmd_execute_command_strict(vector, struct vty *,
 				      const struct cmd_element **);
-extern void cmd_init(int);
+extern void cmd_init(int terminal);
+extern void cmd_init_config_callbacks(void (*start_config)(void),
+				      void (*end_config)(void));
 extern void cmd_terminate(void);
 extern void cmd_exit(struct vty *vty);
 extern int cmd_list_cmds(struct vty *vty, int do_permute);

--- a/lib/lib_vty.c
+++ b/lib/lib_vty.c
@@ -212,6 +212,41 @@ DEFUN (frr_version,
 	return CMD_SUCCESS;
 }
 
+static struct call_back {
+	void (*start_config)(void);
+	void (*end_config)(void);
+} callback;
+
+DEFUN_HIDDEN (start_config,
+	      start_config_cmd,
+	      "start_configuration",
+	      "The Beginning of Configuration\n")
+{
+	if (callback.start_config)
+		(*callback.start_config)();
+
+	return CMD_SUCCESS;
+}
+
+DEFUN_HIDDEN (end_config,
+	      end_config_cmd,
+	      "end_configuration",
+	      "The End of Configuration\n")
+{
+	if (callback.end_config)
+		(*callback.end_config)();
+
+	return CMD_SUCCESS;
+}
+
+void cmd_init_config_callbacks(void (*start_config)(void),
+			       void (*end_config)(void))
+{
+	callback.start_config = start_config;
+	callback.end_config = end_config;
+}
+
+
 static void defaults_autocomplete(vector comps, struct cmd_token *token)
 {
 	const char **p;
@@ -234,6 +269,9 @@ void lib_cmd_init(void)
 
 	install_element(VIEW_NODE, &show_memory_cmd);
 	install_element(VIEW_NODE, &show_modules_cmd);
+
+	install_element(CONFIG_NODE, &start_config_cmd);
+	install_element(CONFIG_NODE, &end_config_cmd);
 }
 
 /* Stats querying from users */

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -139,6 +139,16 @@ static void sharp_global_init(void)
 	sg.nhs = list_new();
 }
 
+static void sharp_start_configuration(void)
+{
+	zlog_debug("Configuration has started to be read");
+}
+
+static void sharp_end_configuration(void)
+{
+	zlog_debug("Configuration has finished being read");
+}
+
 int main(int argc, char **argv, char **envp)
 {
 	frr_preinit(&sharpd_di, argc, argv);
@@ -163,6 +173,8 @@ int main(int argc, char **argv, char **envp)
 
 	master = frr_init();
 
+	cmd_init_config_callbacks(sharp_start_configuration,
+				  sharp_end_configuration);
 	sharp_global_init();
 
 	sharp_nhgroup_init();

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -526,8 +526,12 @@ static int vtysh_read_file(FILE *confp)
 	vtysh_execute_no_pager("enable");
 	vtysh_execute_no_pager("configure terminal");
 
+	vtysh_execute_no_pager("start_configuration");
+
 	/* Execute configuration file. */
 	ret = vtysh_config_from_file(vty, confp);
+
+	vtysh_execute_no_pager("end_configuration");
 
 	vtysh_execute_no_pager("end");
 	vtysh_execute_no_pager("disable");


### PR DESCRIPTION
…indicators

When reading a file in for configuration, send start and end indicators
to interested parties.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>