### PR TITLE
bgpd: fix help for ipv6 under distance src command

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13822,7 +13822,8 @@ DEFPY_YANG(bgp_distance_source,
 	   NO_STR
 	   "Define an administrative distance\n"
 	   "Distance value\n"
-	   "IP source prefix\n"
+	   "IPv4 source prefix\n"
+	   "IPv6 source prefix\n"
 	   "Access list name\n")
 {
 	afi_t afi;


### PR DESCRIPTION
We were missing the help docstring for IPV6 under the
distance src command in for bgp.

```
[root@alfred frr-2]# /usr/lib/frr/bgpd --log stdout --log-level debug
2020/10/30 16:02:26 BGP: Ran out of docstring while parsing '[no] distance (1-255) <A.B.C.D/M | X:X::X:X/M>$prefix [WORD$acl]'
2020/10/30 16:02:26 BGP: Ran out of docstring while parsing '[no] distance (1-255) <A.B.C.D/M | X:X::X:X/M>$prefix [WORD$acl]'
2020/10/30 16:02:26 BGP: Ran out of docstring while parsing '[no] distance (1-255) <A.B.C.D/M | X:X::X:X/M>$prefix [WORD$acl]'
2020/10/30 16:02:26 BGP: Ran out of docstring while parsing '[no] distance (1-255) <A.B.C.D/M | X:X::X:X/M>$prefix [WORD$acl]'
2020/10/30 16:02:26 BGP: Ran out of docstring while parsing '[no] distance (1-255) <A.B.C.D/M | X:X::X:X/M>$prefix [WORD$acl]'
```

Signed-off-by: Stephen Worley <sworley@nvidia.com>