### PR TITLE
bgpd: BGP neighbor password change doesn't take effect with a a particular config on reboot

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -270,8 +270,16 @@ static __attribute__((__noreturn__)) void bgp_exit(int status)
 
 static int bgp_vrf_new(struct vrf *vrf)
 {
+	struct interface *ifp;
+
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("VRF Created: %s(%u)", vrf->name, vrf->vrf_id);
+	ifp = if_get_by_name(vrf->name, vrf->vrf_id);
+	if (ifp) {
+		if (BGP_DEBUG(zebra, ZEBRA))
+			zlog_debug("VRF interface Created: %s(%u) ifindex %d",
+				   ifp->name, ifp->vrf_id, ifp->ifindex);
+	}
 
 	return 0;
 }
@@ -280,6 +288,11 @@ static int bgp_vrf_delete(struct vrf *vrf)
 {
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("VRF Deletion: %s(%u)", vrf->name, vrf->vrf_id);
+
+	/*
+	   No need to delete vrf here as it will be deleted when BGP client
+	   receives ZEBRA_VRF_DELETE message from zebra
+	*/
 
 	return 0;
 }

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -1006,7 +1006,7 @@ int vrf_bind(vrf_id_t vrf_id, int fd, const char *name)
 	 * case ifname = vrf in netns mode => return
 	 */
 	ifp = if_lookup_by_name(name, vrf_id);
-	if (!ifp)
+	if (!ifp || ifp->ifindex == IFINDEX_INTERNAL)
 		return fd;
 #ifdef SO_BINDTODEVICE
 	ret = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, name, strlen(name)+1);


### PR DESCRIPTION
bgpd: BGP neighbor password change doesn't take effect with a a particular config on reboot

Description: when vrf add is received, add Vrf-name to the interface database. This is needed while binding the VRF interface to the BGP socket.
In this case, the global bgp config containing vrf is received before zebra sends vrf add message to BGP. When we receive the global bgp vrf message
first, vrf interface is not present in the interface database of BGP. So, while creating the global bgp socket with vrf, interface bind to the vrf interface fails. This creates a BGP socket without vrf binding(i.e. socket in default VRF). The socket is used by another BGP instance (if present for default VRF) to send out BGP packets.


Problem Description/Summary :
changing the neighbor password resets the session immediately but it doesn't use the password. It continues to operate without password.

Managed to recreate the issue with below reduced config.

Setup:
Sonic1------Sonic2

Test Steps:
1. Configure eBGP session between Sonic-1 and Sonic2 in default vrf using Peer-group.
2. Create a dummy non-default vrf BGP instance on Sonic1 device.
3. Save and reload Sonic1 device.
4. Once the device is up, try to configure 'password <string>' on Sonic1 BGP neighbor alone.
5. The eBGP session should go down and must not come up until matching password is configured on Sonic2 device. But it comes up. This is because BGP packets are sent using other BGP socket (which was created using dummy non-default vrf BGP instance where vrf binding to the BGP socket had failed).

Expected Behavior :
The eBGP session should go down and must not come up until matching password is configured on Sonic2 device.

Signed-off-by: sudhanshukumar22 sudhanshu.kumar@broadcom.com