### PR TITLE
bgpd: Multipath is always being allocated

### DIFF
--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -412,8 +412,9 @@ static void bgp_path_info_mpath_lb_update(struct bgp_path_info *path, bool set,
 	struct bgp_path_info_mpath *mpath;
 
 	if ((mpath = path->mpath) == NULL) {
-		if (!set)
+		if (!set || (cum_bw == 0 && !all_paths_lb))
 			return;
+
 		mpath = bgp_path_info_mpath_get(path);
 		if (!mpath)
 			return;


### PR DESCRIPTION
The multipath arrays are always being allocated, irrelevant
if we actually have multipath information for a prefix.

This is because the link bandwidth code was always adding the
data structure.  We should not be allocated multipath information
unless we actually have multipath information

Signed-off-by: Donald Sharp <sharpd@nvidia.com>