### PR TITLE
Attributes

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2785,7 +2785,7 @@ bgp_attr_pmsi_tunnel(struct bgp_attr_parser_args *args)
 	}
 
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_PMSI_TUNNEL);
-	attr->pmsi_tnl_type = tnl_type;
+	bgp_attr_set_pmsi_tnl_type(attr, tnl_type);
 	stream_get(&attr->label, peer->curr, BGP_LABEL_BYTES);
 
 	/* Forward read pointer of input stream. */
@@ -4110,7 +4110,7 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 		stream_putc(s, BGP_ATTR_PMSI_TUNNEL);
 		stream_putc(s, 9); // Length
 		stream_putc(s, 0); // Flags
-		stream_putc(s, attr->pmsi_tnl_type);
+		stream_putc(s, bgp_attr_get_pmsi_tnl_type(attr));
 		stream_put(s, &(attr->label),
 			   BGP_LABEL_BYTES); // MPLS Label / VXLAN VNI
 		stream_put_ipv4(s, attr->nexthop.s_addr);

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -257,9 +257,12 @@ void bgp_attr_flush_encap(struct attr *attr)
 		attr->encap_subtlvs = NULL;
 	}
 #ifdef ENABLE_BGP_VNC
-	if (attr->vnc_subtlvs) {
-		encap_free(attr->vnc_subtlvs);
-		attr->vnc_subtlvs = NULL;
+	struct bgp_attr_encap_subtlv *vnc_subtlvs =
+		bgp_attr_get_vnc_subtlvs(attr);
+
+	if (vnc_subtlvs) {
+		encap_free(vnc_subtlvs);
+		bgp_attr_set_vnc_subtlvs(attr, NULL);
 	}
 #endif
 }
@@ -674,8 +677,10 @@ unsigned int attrhash_key_make(const void *p)
 	if (attr->encap_subtlvs)
 		MIX(encap_hash_key_make(attr->encap_subtlvs));
 #ifdef ENABLE_BGP_VNC
-	if (attr->vnc_subtlvs)
-		MIX(encap_hash_key_make(attr->vnc_subtlvs));
+	struct bgp_attr_encap_subtlv *vnc_subtlvs =
+		bgp_attr_get_vnc_subtlvs(attr);
+	if (vnc_subtlvs)
+		MIX(encap_hash_key_make(vnc_subtlvs));
 #endif
 	MIX(attr->mp_nexthop_len);
 	key = jhash(attr->mp_nexthop_global.s6_addr, IPV6_MAX_BYTELEN, key);
@@ -716,7 +721,8 @@ bool attrhash_cmp(const void *p1, const void *p2)
 		    && (attr1->encap_tunneltype == attr2->encap_tunneltype)
 		    && encap_same(attr1->encap_subtlvs, attr2->encap_subtlvs)
 #ifdef ENABLE_BGP_VNC
-		    && encap_same(attr1->vnc_subtlvs, attr2->vnc_subtlvs)
+		    && encap_same(bgp_attr_get_vnc_subtlvs(attr1),
+				  bgp_attr_get_vnc_subtlvs(attr2))
 #endif
 		    && IPV6_ADDR_SAME(&attr1->mp_nexthop_global,
 				      &attr2->mp_nexthop_global)
@@ -802,9 +808,11 @@ static void *bgp_attr_hash_alloc(void *p)
 		val->encap_subtlvs = NULL;
 	}
 #ifdef ENABLE_BGP_VNC
-	if (val->vnc_subtlvs) {
-		val->vnc_subtlvs = NULL;
-	}
+	struct bgp_attr_encap_subtlv *vnc_subtlvs =
+		bgp_attr_get_vnc_subtlvs(val);
+
+	if (vnc_subtlvs)
+		bgp_attr_set_vnc_subtlvs(val, NULL);
 #endif
 	if (val->srv6_l3vpn)
 		val->srv6_l3vpn = NULL;
@@ -893,12 +901,16 @@ struct attr *bgp_attr_intern(struct attr *attr)
 			attr->srv6_vpn->refcnt++;
 	}
 #ifdef ENABLE_BGP_VNC
-	if (attr->vnc_subtlvs) {
-		if (!attr->vnc_subtlvs->refcnt)
-			attr->vnc_subtlvs = encap_intern(attr->vnc_subtlvs,
-							 VNC_SUBTLV_TYPE);
+	struct bgp_attr_encap_subtlv *vnc_subtlvs =
+		bgp_attr_get_vnc_subtlvs(attr);
+
+	if (vnc_subtlvs) {
+		if (!vnc_subtlvs->refcnt)
+			bgp_attr_set_vnc_subtlvs(
+				attr,
+				encap_intern(vnc_subtlvs, VNC_SUBTLV_TYPE));
 		else
-			attr->vnc_subtlvs->refcnt++;
+			vnc_subtlvs->refcnt++;
 	}
 #endif
 
@@ -1088,8 +1100,13 @@ void bgp_attr_unintern_sub(struct attr *attr)
 		encap_unintern(&attr->encap_subtlvs, ENCAP_SUBTLV_TYPE);
 
 #ifdef ENABLE_BGP_VNC
-	if (attr->vnc_subtlvs)
-		encap_unintern(&attr->vnc_subtlvs, VNC_SUBTLV_TYPE);
+	struct bgp_attr_encap_subtlv *vnc_subtlvs =
+		bgp_attr_get_vnc_subtlvs(attr);
+
+	if (vnc_subtlvs) {
+		encap_unintern(&vnc_subtlvs, VNC_SUBTLV_TYPE);
+		bgp_attr_set_vnc_subtlvs(attr, vnc_subtlvs);
+	}
 #endif
 
 	if (attr->srv6_l3vpn)
@@ -1183,9 +1200,12 @@ void bgp_attr_flush(struct attr *attr)
 		attr->encap_subtlvs = NULL;
 	}
 #ifdef ENABLE_BGP_VNC
-	if (attr->vnc_subtlvs && !attr->vnc_subtlvs->refcnt) {
-		encap_free(attr->vnc_subtlvs);
-		attr->vnc_subtlvs = NULL;
+	struct bgp_attr_encap_subtlv *vnc_subtlvs =
+		bgp_attr_get_vnc_subtlvs(attr);
+
+	if (vnc_subtlvs && !vnc_subtlvs->refcnt) {
+		encap_free(vnc_subtlvs);
+		bgp_attr_set_vnc_subtlvs(attr, NULL);
 	}
 #endif
 }
@@ -2451,15 +2471,17 @@ static int bgp_attr_encap(uint8_t type, struct peer *peer, /* IN */
 #ifdef ENABLE_BGP_VNC
 		} else {
 			struct bgp_attr_encap_subtlv *stlv_last;
-			for (stlv_last = attr->vnc_subtlvs;
+			struct bgp_attr_encap_subtlv *vnc_subtlvs =
+				bgp_attr_get_vnc_subtlvs(attr);
+
+			for (stlv_last = vnc_subtlvs;
 			     stlv_last && stlv_last->next;
 			     stlv_last = stlv_last->next)
 				;
-			if (stlv_last) {
+			if (stlv_last)
 				stlv_last->next = tlv;
-			} else {
-				attr->vnc_subtlvs = tlv;
-			}
+			else
+				bgp_attr_set_vnc_subtlvs(attr, tlv);
 #endif
 		}
 	}
@@ -3329,9 +3351,13 @@ done:
 			attr->encap_subtlvs = encap_intern(attr->encap_subtlvs,
 							   ENCAP_SUBTLV_TYPE);
 #ifdef ENABLE_BGP_VNC
-		if (attr->vnc_subtlvs)
-			attr->vnc_subtlvs = encap_intern(attr->vnc_subtlvs,
-							 VNC_SUBTLV_TYPE);
+		struct bgp_attr_encap_subtlv *vnc_subtlvs =
+			bgp_attr_get_vnc_subtlvs(attr);
+
+		if (vnc_subtlvs)
+			bgp_attr_set_vnc_subtlvs(
+				attr,
+				encap_intern(vnc_subtlvs, VNC_SUBTLV_TYPE));
 #endif
 	} else {
 		if (transit) {
@@ -3349,8 +3375,11 @@ done:
 	if (attr->encap_subtlvs)
 		assert(attr->encap_subtlvs->refcnt > 0);
 #ifdef ENABLE_BGP_VNC
-	if (attr->vnc_subtlvs)
-		assert(attr->vnc_subtlvs->refcnt > 0);
+	struct bgp_attr_encap_subtlv *vnc_subtlvs =
+		bgp_attr_get_vnc_subtlvs(attr);
+
+	if (vnc_subtlvs)
+		assert(vnc_subtlvs->refcnt > 0);
 #endif
 
 	return ret;
@@ -3602,7 +3631,7 @@ static void bgp_packet_mpattr_tea(struct bgp *bgp, struct peer *peer,
 #ifdef ENABLE_BGP_VNC_ATTR
 	case BGP_ATTR_VNC:
 		attrname = "VNC";
-		subtlvs = attr->vnc_subtlvs;
+		subtlvs = bgp_attr_get_vnc_subtlvs(attr);
 		if (subtlvs == NULL) /* nothing to do */
 			return;
 		attrlenfield = 0;   /* no outer T + L */

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1045,12 +1045,10 @@ void bgp_attr_unintern_sub(struct attr *attr)
 		community_unintern(&attr->community);
 	UNSET_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES));
 
-	if (attr->ecommunity)
-		ecommunity_unintern(&attr->ecommunity);
+	ecommunity_unintern(&attr->ecommunity);
 	UNSET_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES));
 
-	if (attr->ipv6_ecommunity)
-		ecommunity_unintern(&attr->ipv6_ecommunity);
+	ecommunity_unintern(&attr->ipv6_ecommunity);
 	UNSET_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_IPV6_EXT_COMMUNITIES));
 
 	if (attr->lcommunity)
@@ -1137,7 +1135,7 @@ void bgp_attr_flush(struct attr *attr)
 		community_free(&attr->community);
 	if (attr->ecommunity && !attr->ecommunity->refcnt)
 		ecommunity_free(&attr->ecommunity);
-	if (attr->ipv6_ecommunity && !attr->ipv6_ecommunity->refcnt)
+	if (attr->ipv6_ecommunity && !attr->ecommunity->refcnt)
 		ecommunity_free(&attr->ipv6_ecommunity);
 	if (attr->lcommunity && !attr->lcommunity->refcnt)
 		lcommunity_free(&attr->lcommunity);

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -761,6 +761,11 @@ static void attrhash_init(void)
  */
 static void attr_vfree(void *attr)
 {
+	struct attr *a = attr;
+
+	if (a->extra)
+		XFREE(MTYPE_ATTR, a->extra);
+
 	XFREE(MTYPE_ATTR, attr);
 }
 
@@ -821,6 +826,11 @@ static void *bgp_attr_hash_alloc(void *p)
 
 	attr->refcnt = 0;
 	return attr;
+}
+
+struct attr_extra *bgp_attr_extra_alloc(void)
+{
+	return XCALLOC(MTYPE_ATTR, sizeof(struct attr_extra));
 }
 
 /* Internet argument attribute. */
@@ -1157,6 +1167,8 @@ void bgp_attr_unintern(struct attr **pattr)
 	if (attr->refcnt == 0) {
 		ret = hash_release(attrhash, attr);
 		assert(ret != NULL);
+		if (attr->extra)
+			XFREE(MTYPE_ATTR, attr->extra);
 		XFREE(MTYPE_ATTR, attr);
 		*pattr = NULL;
 	}

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -403,7 +403,9 @@ static bool overlay_index_same(const struct attr *a1, const struct attr *a2)
 		return false;
 	if (!a1 && !a2)
 		return true;
-	return !memcmp(&(a1->evpn_overlay), &(a2->evpn_overlay),
+
+	return !memcmp(bgp_attr_get_evpn_overlay(a1),
+		       bgp_attr_get_evpn_overlay(a2),
 		       sizeof(struct bgp_route_evpn));
 }
 

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -138,8 +138,29 @@ struct bgp_attr_srv6_l3vpn {
 	struct in6_addr sid;
 };
 
+struct attr_extra {
+	/* PMSI tunnel type (RFC 6514). */
+	enum pta_type pmsi_tnl_type;
+
+	/* Extended Communities attribute. */
+	struct ecommunity *ipv6_ecommunity;
+
+	/* Route-Reflector Cluster attribute */
+	struct cluster_list *cluster1;
+
+	/* EVPN */
+	struct bgp_route_evpn evpn_overlay;
+
+#ifdef ENABLE_BGP_VNC
+	struct bgp_attr_encap_subtlv *vnc_subtlvs; /* VNC-specific */
+#endif
+
+};
+
 /* BGP core attribute structure. */
 struct attr {
+	struct attr_extra *extra;
+
 	/* AS Path structure */
 	struct aspath *aspath;
 
@@ -161,9 +182,6 @@ struct attr {
 	/* Path origin attribute */
 	uint8_t origin;
 
-	/* PMSI tunnel type (RFC 6514). */
-	enum pta_type pmsi_tnl_type;
-
 	/* has the route-map changed any attribute?
 	   Used on the peer outbound side. */
 	uint32_t rmap_change_flags;
@@ -178,14 +196,8 @@ struct attr {
 	/* Extended Communities attribute. */
 	struct ecommunity *ecommunity;
 
-	/* Extended Communities attribute. */
-	struct ecommunity *ipv6_ecommunity;
-
 	/* Large Communities attribute. */
 	struct lcommunity *lcommunity;
-
-	/* Route-Reflector Cluster attribute */
-	struct cluster_list *cluster1;
 
 	/* Unknown transitive attribute. */
 	struct transit *transit;
@@ -260,12 +272,6 @@ struct attr {
 
 	uint16_t encap_tunneltype;		     /* grr */
 	struct bgp_attr_encap_subtlv *encap_subtlvs; /* rfc5512 */
-
-#ifdef ENABLE_BGP_VNC
-	struct bgp_attr_encap_subtlv *vnc_subtlvs; /* VNC-specific */
-#endif
-	/* EVPN */
-	struct bgp_route_evpn evpn_overlay;
 
 	/* EVPN MAC Mobility sequence number, if any. */
 	uint32_t mm_seqnum;
@@ -458,27 +464,45 @@ static inline uint32_t mac_mobility_seqnum(struct attr *attr)
 	return (attr) ? attr->mm_seqnum : 0;
 }
 
+extern struct attr_extra *bgp_attr_extra_alloc(void);
+
 static inline enum pta_type bgp_attr_get_pmsi_tnl_type(struct attr *attr)
 {
-	return attr->pmsi_tnl_type;
+	if (attr->extra)
+		return attr->extra->pmsi_tnl_type;
+
+	return 0;
 }
 
 static inline void bgp_attr_set_pmsi_tnl_type(struct attr *attr,
 					      enum pta_type pmsi_tnl_type)
 {
-	attr->pmsi_tnl_type = pmsi_tnl_type;
+	if (!attr->extra)
+		attr->extra = bgp_attr_extra_alloc();
+
+	attr->extra->pmsi_tnl_type = pmsi_tnl_type;
 }
 
 static inline struct ecommunity *
 bgp_attr_get_ipv6_ecommunity(const struct attr *attr)
 {
-	return attr->ipv6_ecommunity;
+	if (attr->extra)
+		return attr->extra->ipv6_ecommunity;
+
+	return NULL;
 }
 
 static inline void bgp_attr_set_ipv6_ecommunity(struct attr *attr,
 						struct ecommunity *ipv6_ecomm)
 {
-	attr->ipv6_ecommunity = ipv6_ecomm;
+	if (!attr->extra) {
+		if (!ipv6_ecomm)
+			return;
+
+		attr->extra = bgp_attr_extra_alloc();
+	}
+
+	attr->extra->ipv6_ecommunity = ipv6_ecomm;
 }
 
 static inline struct transit *bgp_attr_get_transit(const struct attr *attr)
@@ -494,38 +518,70 @@ static inline void bgp_attr_set_transit(struct attr *attr,
 
 static inline struct cluster_list *bgp_attr_get_cluster(const struct attr *attr)
 {
-	return attr->cluster1;
+	if (attr->extra)
+		return attr->extra->cluster1;
+
+	return NULL;
 }
 
 static inline void bgp_attr_set_cluster(struct attr *attr,
 					struct cluster_list *cl)
 {
-	attr->cluster1 = cl;
+	if (!attr->extra) {
+		if (!cl)
+			return;
+		attr->extra = bgp_attr_extra_alloc();
+	}
+
+	attr->extra->cluster1 = cl;
 }
 
 static inline const struct bgp_route_evpn *
 bgp_attr_get_evpn_overlay(const struct attr *attr)
 {
-	return &attr->evpn_overlay;
+	static struct bgp_route_evpn no_evpn_overlay;
+
+	if (!attr->extra) {
+		memset(&no_evpn_overlay, 0, sizeof(no_evpn_overlay));
+		return &no_evpn_overlay;
+	}
+
+	return &attr->extra->evpn_overlay;
 }
 
 static inline void bgp_attr_set_evpn_overlay(struct attr *attr,
 					     struct bgp_route_evpn *eo)
 {
-	memcpy(&attr->evpn_overlay, eo, sizeof(struct bgp_route_evpn));
+	if (!attr->extra) {
+		if (!eo)
+			return;
+		attr->extra = bgp_attr_extra_alloc();
+	}
+
+	memcpy(&attr->extra->evpn_overlay, eo, sizeof(struct bgp_route_evpn));
 }
 
 static inline struct bgp_attr_encap_subtlv *
 bgp_attr_get_vnc_subtlvs(const struct attr *attr)
 {
-	return attr->vnc_subtlvs;
+	if (attr->extra)
+		return attr->extra->vnc_subtlvs;
+
+	return NULL;
 }
 
 static inline void
 bgp_attr_set_vnc_subtlvs(struct attr *attr,
 			 struct bgp_attr_encap_subtlv *vnc_subtlvs)
 {
-	attr->vnc_subtlvs = vnc_subtlvs;
+	if (!attr->extra) {
+		if (!vnc_subtlvs)
+			return;
+
+		attr->extra = bgp_attr_extra_alloc();
+	}
+
+	attr->extra->vnc_subtlvs = vnc_subtlvs;
 }
 
 #endif /* _QUAGGA_BGP_ATTR_H */

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -457,4 +457,16 @@ static inline uint32_t mac_mobility_seqnum(struct attr *attr)
 {
 	return (attr) ? attr->mm_seqnum : 0;
 }
+
+static inline enum pta_type bgp_attr_get_pmsi_tnl_type(struct attr *attr)
+{
+	return attr->pmsi_tnl_type;
+}
+
+static inline void bgp_attr_set_pmsi_tnl_type(struct attr *attr,
+					      enum pta_type pmsi_tnl_type)
+{
+	attr->pmsi_tnl_type = pmsi_tnl_type;
+}
+
 #endif /* _QUAGGA_BGP_ATTR_H */

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -515,4 +515,17 @@ static inline void bgp_attr_set_evpn_overlay(struct attr *attr,
 	memcpy(&attr->evpn_overlay, eo, sizeof(struct bgp_route_evpn));
 }
 
+static inline struct bgp_attr_encap_subtlv *
+bgp_attr_get_vnc_subtlvs(const struct attr *attr)
+{
+	return attr->vnc_subtlvs;
+}
+
+static inline void
+bgp_attr_set_vnc_subtlvs(struct attr *attr,
+			 struct bgp_attr_encap_subtlv *vnc_subtlvs)
+{
+	attr->vnc_subtlvs = vnc_subtlvs;
+}
+
 #endif /* _QUAGGA_BGP_ATTR_H */

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -469,4 +469,16 @@ static inline void bgp_attr_set_pmsi_tnl_type(struct attr *attr,
 	attr->pmsi_tnl_type = pmsi_tnl_type;
 }
 
+static inline struct ecommunity *
+bgp_attr_get_ipv6_ecommunity(const struct attr *attr)
+{
+	return attr->ipv6_ecommunity;
+}
+
+static inline void bgp_attr_set_ipv6_ecommunity(struct attr *attr,
+						struct ecommunity *ipv6_ecomm)
+{
+	attr->ipv6_ecommunity = ipv6_ecomm;
+}
+
 #endif /* _QUAGGA_BGP_ATTR_H */

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -185,7 +185,7 @@ struct attr {
 	struct lcommunity *lcommunity;
 
 	/* Route-Reflector Cluster attribute */
-	struct cluster_list *cluster;
+	struct cluster_list *cluster1;
 
 	/* Unknown transitive attribute. */
 	struct transit *transit;
@@ -331,7 +331,7 @@ struct transit {
 
 #define BGP_CLUSTER_LIST_LENGTH(attr)                                          \
 	(((attr)->flag & ATTR_FLAG_BIT(BGP_ATTR_CLUSTER_LIST))                 \
-		 ? (attr)->cluster->length                                     \
+		 ? bgp_attr_get_cluster((attr))->length                        \
 		 : 0)
 
 typedef enum {
@@ -490,5 +490,16 @@ static inline void bgp_attr_set_transit(struct attr *attr,
 					struct transit *transit)
 {
 	attr->transit = transit;
+}
+
+static inline struct cluster_list *bgp_attr_get_cluster(const struct attr *attr)
+{
+	return attr->cluster1;
+}
+
+static inline void bgp_attr_set_cluster(struct attr *attr,
+					struct cluster_list *cl)
+{
+	attr->cluster1 = cl;
 }
 #endif /* _QUAGGA_BGP_ATTR_H */

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -481,4 +481,14 @@ static inline void bgp_attr_set_ipv6_ecommunity(struct attr *attr,
 	attr->ipv6_ecommunity = ipv6_ecomm;
 }
 
+static inline struct transit *bgp_attr_get_transit(const struct attr *attr)
+{
+	return attr->transit;
+}
+
+static inline void bgp_attr_set_transit(struct attr *attr,
+					struct transit *transit)
+{
+	attr->transit = transit;
+}
 #endif /* _QUAGGA_BGP_ATTR_H */

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -502,4 +502,17 @@ static inline void bgp_attr_set_cluster(struct attr *attr,
 {
 	attr->cluster1 = cl;
 }
+
+static inline const struct bgp_route_evpn *
+bgp_attr_get_evpn_overlay(const struct attr *attr)
+{
+	return &attr->evpn_overlay;
+}
+
+static inline void bgp_attr_set_evpn_overlay(struct attr *attr,
+					     struct bgp_route_evpn *eo)
+{
+	memcpy(&attr->evpn_overlay, eo, sizeof(struct bgp_route_evpn));
+}
+
 #endif /* _QUAGGA_BGP_ATTR_H */

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -440,7 +440,7 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_PMSI_TUNNEL)))
 		snprintf(buf + strlen(buf), size - strlen(buf),
-			 ", pmsi tnltype %u", attr->pmsi_tnl_type);
+			 ", pmsi tnltype %u", bgp_attr_get_pmsi_tnl_type(attr));
 
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_AS_PATH)))
 		snprintf(buf + strlen(buf), size - strlen(buf), ", path %s",

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -429,13 +429,16 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 			   ", originator %pI4", &attr->originator_id);
 
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_CLUSTER_LIST))) {
+		struct cluster_list *cluster;
 		int i;
 
 		snprintf(buf + strlen(buf), size - strlen(buf),
 			 ", clusterlist");
-		for (i = 0; i < attr->cluster->length / 4; i++)
+
+		cluster = bgp_attr_get_cluster(attr);
+		for (i = 0; i < cluster->length / 4; i++)
 			snprintfrr(buf + strlen(buf), size - strlen(buf),
-				   " %pI4", &attr->cluster->list[i]);
+				   " %pI4", &cluster->list[i]);
 	}
 
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_PMSI_TUNNEL)))

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -327,6 +327,9 @@ void ecommunity_unintern(struct ecommunity **ecom)
 {
 	struct ecommunity *ret;
 
+	if (!*ecom)
+		return;
+
 	if ((*ecom)->refcnt)
 		(*ecom)->refcnt--;
 

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -227,7 +227,7 @@ extern struct ecommunity *ecommunity_merge(struct ecommunity *,
 extern struct ecommunity *ecommunity_uniq_sort(struct ecommunity *);
 extern struct ecommunity *ecommunity_intern(struct ecommunity *);
 extern bool ecommunity_cmp(const void *arg1, const void *arg2);
-extern void ecommunity_unintern(struct ecommunity **);
+extern void ecommunity_unintern(struct ecommunity **ecommunity);
 extern unsigned int ecommunity_hash_make(const void *);
 extern struct ecommunity *ecommunity_str2com(const char *, int, int);
 extern struct ecommunity *ecommunity_str2com_ipv6(const char *str, int type,

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3943,11 +3943,13 @@ static void evpn_mpattr_encode_type5(struct stream *s, const struct prefix *p,
 	else
 		stream_put(s, &p_evpn_p->prefix_addr.ip.ipaddr_v6, 16);
 	if (attr) {
+		const struct bgp_route_evpn *evpn_overlay =
+			bgp_attr_get_evpn_overlay(attr);
+
 		if (IS_IPADDR_V4(&p_evpn_p->prefix_addr.ip))
-			stream_put_ipv4(s,
-					attr->evpn_overlay.gw_ip.ipv4.s_addr);
+			stream_put_ipv4(s, evpn_overlay->gw_ip.ipv4.s_addr);
 		else
-			stream_put(s, &(attr->evpn_overlay.gw_ip.ipv6), 16);
+			stream_put(s, &(evpn_overlay->gw_ip.ipv6), 16);
 	} else {
 		if (IS_IPADDR_V4(&p_evpn_p->prefix_addr.ip))
 			stream_put_ipv4(s, 0);

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -268,6 +268,7 @@ void route_vty_out_flowspec(struct vty *vty, const struct prefix *p,
 	json_object *json_ecom_path = NULL;
 	json_object *json_time_path = NULL;
 	char timebuf[BGP_UPTIME_LEN];
+	struct ecommunity *ipv6_ecomm;
 
 	if (p == NULL || p->family != AF_FLOWSPEC)
 		return;
@@ -298,16 +299,17 @@ void route_vty_out_flowspec(struct vty *vty, const struct prefix *p,
 		json_object_array_add(json_paths, json_nlri_path);
 	if (!path)
 		return;
-	if (path->attr &&
-	    (path->attr->ecommunity || path->attr->ipv6_ecommunity)) {
+
+	ipv6_ecomm = bgp_attr_get_ipv6_ecommunity(path->attr);
+	if (path->attr && (path->attr->ecommunity || ipv6_ecomm)) {
 		/* Print attribute */
 		attr = path->attr;
 		if (attr->ecommunity)
 			s1 = ecommunity_ecom2str(attr->ecommunity,
 						ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
-		if (attr->ipv6_ecommunity)
-			s2 = ecommunity_ecom2str(attr->ipv6_ecommunity,
-						ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
+		if (ipv6_ecomm)
+			s2 = ecommunity_ecom2str(
+				ipv6_ecomm, ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 		if (!s1 && !s2)
 			return;
 		if (display == NLRI_STRING_FORMAT_LARGE)

--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -156,7 +156,7 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 			struct prefix_rd prd;
 			uint32_t num_labels = 0;
 			mpls_label_t *label_pnt = NULL;
-			struct bgp_route_evpn evpn;
+			struct bgp_route_evpn *evpn;
 
 			if (pevpn->family == AF_EVPN
 			    && pevpn->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE
@@ -209,14 +209,15 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 				continue;
 			}
 
-			memcpy(&evpn, &pi->attr->evpn_overlay, sizeof(evpn));
+			memcpy(&evpn, bgp_attr_get_evpn_overlay(pi->attr),
+			       sizeof(evpn));
 			int32_t ret = bgp_update(peer, p,
 						 pi->addpath_rx_id,
 						 pi->attr, AFI_L2VPN, SAFI_EVPN,
 						 ZEBRA_ROUTE_BGP,
 						 BGP_ROUTE_NORMAL, &prd,
 						 label_pnt, num_labels,
-						 1, &evpn);
+						 1, evpn);
 
 			if (ret < 0)
 				bgp_dest_unlock_node(dest);

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -915,10 +915,10 @@ int bgp_pbr_build_and_validate_entry(const struct prefix *p,
 			api->action_num++;
 		}
 	}
-	if (path && path->attr && path->attr->ipv6_ecommunity) {
+	if (path && path->attr && bgp_attr_get_ipv6_ecommunity(path->attr)) {
 		struct ecommunity_val_ipv6 *ipv6_ecom_eval;
 
-		ecom = path->attr->ipv6_ecommunity;
+		ecom = bgp_attr_get_ipv6_ecommunity(path->attr);
 		for (i = 0; i < ecom->size; i++) {
 			ipv6_ecom_eval = (struct ecommunity_val_ipv6 *)
 				(ecom->val + (i * ecom->unit_size));

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10184,9 +10184,9 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 
 	/* Line 10 display PMSI tunnel attribute, if present */
 	if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_PMSI_TUNNEL)) {
-		const char *str =
-			lookup_msg(bgp_pmsi_tnltype_str, attr->pmsi_tnl_type,
-				   PMSI_TNLTYPE_STR_DEFAULT);
+		const char *str = lookup_msg(bgp_pmsi_tnltype_str,
+					     bgp_attr_get_pmsi_tnl_type(attr),
+					     PMSI_TNLTYPE_STR_DEFAULT);
 
 		if (json_paths) {
 			json_pmsi = json_object_new_object();

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3372,17 +3372,22 @@ static void overlay_index_update(struct attr *attr,
 	if (!attr)
 		return;
 	if (gw_ip == NULL) {
-		memset(&(attr->evpn_overlay.gw_ip), 0, sizeof(union gw_addr));
+		struct bgp_route_evpn eo;
+
+		memset(&eo, 0, sizeof(eo));
+		bgp_attr_set_evpn_overlay(attr, &eo);
 	} else {
-		memcpy(&(attr->evpn_overlay.gw_ip), gw_ip,
-		       sizeof(union gw_addr));
+		struct bgp_route_evpn eo = {.gw_ip = *gw_ip};
+
+		bgp_attr_set_evpn_overlay(attr, &eo);
 	}
 }
 
 static bool overlay_index_equal(afi_t afi, struct bgp_path_info *path,
 				union gw_addr *gw_ip)
 {
-	union gw_addr *path_gw_ip, *path_gw_ip_remote;
+	const struct bgp_route_evpn *eo = bgp_attr_get_evpn_overlay(path->attr);
+	union gw_addr path_gw_ip, *path_gw_ip_remote;
 	union {
 		esi_t esi;
 		union gw_addr ip;
@@ -3391,7 +3396,7 @@ static bool overlay_index_equal(afi_t afi, struct bgp_path_info *path,
 	if (afi != AFI_L2VPN)
 		return true;
 
-	path_gw_ip = &(path->attr->evpn_overlay.gw_ip);
+	path_gw_ip = eo->gw_ip;
 
 	if (gw_ip == NULL) {
 		memset(&temp, 0, sizeof(temp));
@@ -3399,7 +3404,7 @@ static bool overlay_index_equal(afi_t afi, struct bgp_path_info *path,
 	} else
 		path_gw_ip_remote = gw_ip;
 
-	return !!memcmp(path_gw_ip, path_gw_ip_remote, sizeof(union gw_addr));
+	return !!memcmp(&path_gw_ip, path_gw_ip_remote, sizeof(union gw_addr));
 }
 
 /* Check if received nexthop is valid or not. */
@@ -4470,7 +4475,7 @@ static void bgp_soft_reconfig_table(struct peer *peer, afi_t afi, safi_t safi,
 			struct bgp_path_info *pi;
 			uint32_t num_labels = 0;
 			mpls_label_t *label_pnt = NULL;
-			struct bgp_route_evpn evpn;
+			struct bgp_route_evpn evpn = {0};
 
 			for (pi = bgp_dest_get_bgp_path_info(dest); pi;
 			     pi = pi->next)
@@ -4482,10 +4487,9 @@ static void bgp_soft_reconfig_table(struct peer *peer, afi_t afi, safi_t safi,
 			if (num_labels)
 				label_pnt = &pi->extra->label[0];
 			if (pi)
-				memcpy(&evpn, &pi->attr->evpn_overlay,
+				memcpy(&evpn,
+				       bgp_attr_get_evpn_overlay(pi->attr),
 				       sizeof(evpn));
-			else
-				memset(&evpn, 0, sizeof(evpn));
 
 			ret = bgp_update(peer, bgp_dest_get_prefix(dest),
 					 ain->addpath_rx_id, ain->attr, afi,
@@ -8928,12 +8932,11 @@ void route_vty_out_overlay(struct vty *vty, const struct prefix *p,
 		}
 	}
 
+	const struct bgp_route_evpn *eo = bgp_attr_get_evpn_overlay(attr);
 	if (is_evpn_prefix_ipaddr_v4((struct prefix_evpn *)p)) {
-		inet_ntop(AF_INET, &(attr->evpn_overlay.gw_ip.ipv4), buf,
-			  BUFSIZ);
+		inet_ntop(AF_INET, &eo->gw_ip.ipv4, buf, BUFSIZ);
 	} else if (is_evpn_prefix_ipaddr_v6((struct prefix_evpn *)p)) {
-		inet_ntop(AF_INET6, &(attr->evpn_overlay.gw_ip.ipv6), buf,
-			  BUFSIZ);
+		inet_ntop(AF_INET6, &eo->gw_ip.ipv6, buf, BUFSIZ);
 	}
 
 	if (!json_path)

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -744,7 +744,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 		encaptlv->length = 4;
 		lt = htonl(*lifetime);
 		memcpy(encaptlv->value, &lt, 4);
-		attr.vnc_subtlvs = encaptlv;
+		bgp_attr_set_vnc_subtlvs(&attr, encaptlv);
 		vnc_zlog_debug_verbose(
 			"%s: set Encap Attr Prefix Lifetime to %d", __func__,
 			*lifetime);
@@ -754,7 +754,8 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	if (rfp_options) {
 
 		if (flags & RFAPI_AHR_RFPOPT_IS_VNCTLV) {
-
+			struct bgp_attr_encap_subtlv *vnc_subtlvs =
+				bgp_attr_get_vnc_subtlvs(&attr);
 			/*
 			 * this flag means we're passing a pointer to an
 			 * existing encap tlv chain which we should copy.
@@ -763,16 +764,15 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 			 */
 			encaptlv = encap_tlv_dup(
 				(struct bgp_attr_encap_subtlv *)rfp_options);
-			if (attr.vnc_subtlvs) {
-				attr.vnc_subtlvs->next = encaptlv;
-			} else {
-				attr.vnc_subtlvs = encaptlv;
-			}
-
+			if (vnc_subtlvs)
+				vnc_subtlvs->next = encaptlv;
+			else
+				bgp_attr_set_vnc_subtlvs(&attr, encaptlv);
 		} else {
 			struct bgp_tea_options *hop;
 			/* XXX max of one tlv present so far from above code */
-			struct bgp_attr_encap_subtlv *tail = attr.vnc_subtlvs;
+			struct bgp_attr_encap_subtlv *tail =
+				bgp_attr_get_vnc_subtlvs(&attr);
 
 			for (hop = rfp_options; hop; hop = hop->next) {
 
@@ -798,11 +798,11 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 				/*
 				 * add to end of subtlv chain
 				 */
-				if (tail) {
+				if (tail)
 					tail->next = encaptlv;
-				} else {
-					attr.vnc_subtlvs = encaptlv;
-				}
+				else
+					bgp_attr_set_vnc_subtlvs(&attr,
+								 encaptlv);
 				tail = encaptlv;
 			}
 		}

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -298,10 +298,9 @@ static wq_item_status rfapi_deferred_close_workfunc(struct work_queue *q,
 int rfapiGetL2o(struct attr *attr, struct rfapi_l2address_option *l2o)
 {
 	if (attr) {
-
 		struct bgp_attr_encap_subtlv *pEncap;
 
-		for (pEncap = attr->vnc_subtlvs; pEncap;
+		for (pEncap = bgp_attr_get_vnc_subtlvs(attr); pEncap;
 		     pEncap = pEncap->next) {
 
 			if (pEncap->type == BGP_VNC_SUBTLV_TYPE_RFPOPTION) {
@@ -358,7 +357,7 @@ int rfapiGetVncLifetime(struct attr *attr, uint32_t *lifetime)
 
 	if (attr) {
 
-		for (pEncap = attr->vnc_subtlvs; pEncap;
+		for (pEncap = bgp_attr_get_vnc_subtlvs(attr); pEncap;
 		     pEncap = pEncap->next) {
 
 			if (pEncap->type
@@ -1337,7 +1336,8 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 		return NULL;
 	}
 
-	for (pEncap = bpi->attr->vnc_subtlvs; pEncap; pEncap = pEncap->next) {
+	for (pEncap = bgp_attr_get_vnc_subtlvs(bpi->attr); pEncap;
+	     pEncap = pEncap->next) {
 		switch (pEncap->type) {
 		case BGP_VNC_SUBTLV_TYPE_LIFETIME:
 			/* use configured lifetime, not attr lifetime */

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -622,7 +622,8 @@ static void rfapiRibBi2Ri(struct bgp_path_info *bpi, struct rfapi_info *ri,
 	ri->lifetime = lifetime;
 
 	/* This loop based on rfapiRouteInfo2NextHopEntry() */
-	for (pEncap = bpi->attr->vnc_subtlvs; pEncap; pEncap = pEncap->next) {
+	for (pEncap = bgp_attr_get_vnc_subtlvs(bpi->attr); pEncap;
+	     pEncap = pEncap->next) {
 		struct bgp_tea_options *hop;
 
 		switch (pEncap->type) {

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -457,6 +457,7 @@ void rfapiPrintAttrPtrs(void *stream, struct attr *attr)
 	void *out;
 	const char *vty_newline;
 	struct transit *transit;
+	struct cluster_list *cluster;
 	char buf[BUFSIZ];
 
 	if (rfapiStream2Vty(stream, &fp, &vty, &out, &vty_newline) == 0)
@@ -477,8 +478,10 @@ void rfapiPrintAttrPtrs(void *stream, struct attr *attr)
 
 	fp(out, "  ecommunity=%p, refcnt=%d%s", attr->ecommunity,
 	   (attr->ecommunity ? attr->ecommunity->refcnt : 0), HVTYNL);
-	fp(out, "  cluster=%p, refcnt=%d%s", attr->cluster,
-	   (attr->cluster ? attr->cluster->refcnt : 0), HVTYNL);
+
+	cluster = bgp_attr_get_cluster(attr);
+	fp(out, "  cluster=%p, refcnt=%d%s", cluster,
+	   (cluster ? cluster->refcnt : 0), HVTYNL);
 
 	transit = bgp_attr_get_transit(attr);
 	fp(out, "  transit=%p, refcnt=%d%s", transit,

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -456,7 +456,7 @@ void rfapiPrintAttrPtrs(void *stream, struct attr *attr)
 	struct vty *vty;
 	void *out;
 	const char *vty_newline;
-
+	struct transit *transit;
 	char buf[BUFSIZ];
 
 	if (rfapiStream2Vty(stream, &fp, &vty, &out, &vty_newline) == 0)
@@ -479,8 +479,10 @@ void rfapiPrintAttrPtrs(void *stream, struct attr *attr)
 	   (attr->ecommunity ? attr->ecommunity->refcnt : 0), HVTYNL);
 	fp(out, "  cluster=%p, refcnt=%d%s", attr->cluster,
 	   (attr->cluster ? attr->cluster->refcnt : 0), HVTYNL);
-	fp(out, "  transit=%p, refcnt=%d%s", attr->transit,
-	   (attr->transit ? attr->transit->refcnt : 0), HVTYNL);
+
+	transit = bgp_attr_get_transit(attr);
+	fp(out, "  transit=%p, refcnt=%d%s", transit,
+	   (transit ? transit->refcnt : 0), HVTYNL);
 }
 
 /*

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -596,7 +596,8 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bpi)
 	}
 
 	/* RFP option lengths */
-	for (pEncap = bpi->attr->vnc_subtlvs; pEncap; pEncap = pEncap->next) {
+	for (pEncap = bgp_attr_get_vnc_subtlvs(bpi->attr); pEncap;
+	     pEncap = pEncap->next) {
 
 		if (pEncap->type == BGP_VNC_SUBTLV_TYPE_RFPOPTION) {
 			if (printed_1st_gol) {

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -468,7 +468,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve_one_bi(
 		plifetime = &lifetime;
 	}
 
-	encaptlvs = bpi->attr->vnc_subtlvs;
+	encaptlvs = bgp_attr_get_vnc_subtlvs(bpi->attr);
 	if (bpi->attr->encap_tunneltype != BGP_ENCAP_TYPE_RESERVED
 	    && bpi->attr->encap_tunneltype != BGP_ENCAP_TYPE_MPLS) {
 		opt = &optary[cur_opt++];


### PR DESCRIPTION
Start a process of allowing the `struct attr` to be broken up with this change in api:

All attr->XXX pointer functions must be used only through `bgp_attr_[set|get]_XXX` ( this is still a work in progress )
Move appropriate `attr->XXX` data into `struct attr_extra` (still a work in progress )

Since only accessors are allowed to get/set, we can safely encapsulate the move into a different data structure.

Currently we this saves ~10mb of data over a full bgp feed.  I am sure that this will help long term as we get everything converted over.
