### PR TITLE
bgpd: clear ip bgp dampening was not triggering the route calculation…

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -545,7 +545,8 @@ int bgp_damp_enable(struct bgp *bgp, afi_t afi, safi_t safi, time_t half,
 }
 
 /* Clean all the bgp_damp_info stored in reuse_list and no_reuse_list. */
-void bgp_damp_info_clean(struct bgp_damp_config *bdc, afi_t afi, safi_t safi)
+void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
+			 afi_t afi, safi_t safi)
 {
 	struct bgp_damp_info *bdi;
 	struct reuselist_node *rn;
@@ -557,6 +558,13 @@ void bgp_damp_info_clean(struct bgp_damp_config *bdc, afi_t afi, safi_t safi)
 		list = &bdc->reuse_list[i];
 		while ((rn = SLIST_FIRST(list)) != NULL) {
 			bdi = rn->info;
+			if (bdi->lastrecord == BGP_RECORD_UPDATE) {
+				bgp_aggregate_increment(bgp, &bdi->dest->p,
+							bdi->path, bdi->afi,
+							bdi->safi);
+				bgp_process(bgp, bdi->dest, bdi->afi,
+					    bdi->safi);
+			}
 			bgp_reuselist_del(list, &rn);
 			bgp_damp_info_free(&bdi, bdc, 1, afi, safi);
 		}
@@ -607,7 +615,7 @@ int bgp_damp_disable(struct bgp *bgp, afi_t afi, safi_t safi)
 	thread_cancel(&bdc->t_reuse);
 
 	/* Clean BGP dampening information.  */
-	bgp_damp_info_clean(bdc, afi, safi);
+	bgp_damp_info_clean(bgp, bdc, afi, safi);
 
 	UNSET_FLAG(bgp->af_flags[afi][safi], BGP_CONFIG_DAMPENING);
 
@@ -896,7 +904,7 @@ void bgp_peer_damp_disable(struct peer *peer, afi_t afi, safi_t safi)
 	bdc = &peer->damp[afi][safi];
 	if (!bdc)
 		return;
-	bgp_damp_info_clean(bdc, afi, safi);
+	bgp_damp_info_clean(peer->bgp, bdc, afi, safi);
 	UNSET_FLAG(peer->af_flags[afi][safi], PEER_FLAG_CONFIG_DAMPENING);
 }
 

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -151,8 +151,8 @@ extern int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
 extern void bgp_damp_info_free(struct bgp_damp_info **path,
 			       struct bgp_damp_config *bdc, int withdraw,
 			       afi_t afi, safi_t safi);
-extern void bgp_damp_info_clean(struct bgp_damp_config *bdc, afi_t afi,
-				safi_t safi);
+extern void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
+				afi_t afi, safi_t safi);
 extern void bgp_damp_config_clean(struct bgp_damp_config *bdc);
 extern int bgp_damp_decay(time_t, int, struct bgp_damp_config *damp);
 extern void bgp_config_write_damp(struct vty *vty, struct bgp *bgp, afi_t afi,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14216,6 +14216,21 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 				while (pi) {
 					if (pi->extra && pi->extra->damp_info) {
 						pi_temp = pi->next;
+						struct bgp_damp_info *bdi =
+							pi->extra->damp_info;
+						if (bdi->lastrecord
+						    == BGP_RECORD_UPDATE) {
+							bgp_aggregate_increment(
+								bgp,
+								&bdi->dest->p,
+								bdi->path,
+								bdi->afi,
+								bdi->safi);
+							bgp_process(bgp,
+								    bdi->dest,
+								    bdi->afi,
+								    bdi->safi);
+						}
 						bgp_damp_info_free(
 							&pi->extra->damp_info,
 							&bgp->damp[afi][safi],
@@ -14242,7 +14257,7 @@ DEFUN (clear_ip_bgp_dampening,
        "Clear route flap dampening information\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_damp_info_clean(&bgp->damp[AFI_IP][SAFI_UNICAST], AFI_IP,
+	bgp_damp_info_clean(bgp, &bgp->damp[AFI_IP][SAFI_UNICAST], AFI_IP,
 			    SAFI_UNICAST);
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
… for the prefix

    clear ip bgp dampening was not triggering the route
    calculation for the prefix, Due to this prefix are not install in
    RIB(Zebra) and not adv to neighbor

    Fix: When clear ip bgp dampening, route are put for route-calculation as
    that it is install in the Zebra and adv to neighbor.

Signed-off-by: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>