### PR TITLE
bgpd: Allow 1 prefix to generate statistics

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12106,9 +12106,6 @@ static void bgp_table_stats_rn(struct bgp_dest *dest, struct bgp_dest *top,
 	struct bgp_path_info *pi;
 	const struct prefix *rn_p;
 
-	if (dest == top)
-		return;
-
 	if (!bgp_dest_has_bgp_path_info_data(dest))
 		return;
 


### PR DESCRIPTION
When generating a config with 1 prefix:

BGP IPv4 Unicast RIB statistics
Total Advertisements          :            0
Total Prefixes                :            0
Average prefix length         :         0.00
Unaggregateable prefixes      :            0
Maximum aggregateable prefixes:            0
BGP Aggregate advertisements  :            0
Address space advertised      :            0
                  % announced :         0.00
                /8 equivalent :         0.00
               /24 equivalent :         0.00

Advertisements with paths     :            0
Longest AS-Path (hops)        :            0
Average AS-Path length (hops) :         0.00
Largest AS-Path (bytes)       :            0
Average AS-Path size (bytes)  :         0.00
Highest public ASN            :            0
eva# show bgp ipv4 uni summ
BGP router identifier 10.10.3.11, local AS number 329 vrf-id 0
BGP table version 1
RIB entries 1, using 192 bytes of memory
Peers 1, using 23 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
192.168.161.131 4      60000        24        27        0    0    0 00:01:05     (Policy)        1

Total number of neighbors 1

We are not displaying it in the statistics data.  This is because FRR is walking the associated
table and comparing the current dest to the top of the tree.  I have no idea why this is
the case as that when you have 1 prefix you only have 1 node in your tree.  Looking at the
code this is the original code that was imported in 2006.  I cannot think of any reason why
FRR needs to exclude this particular node.

Fixed:
eva# show bgp ipv4 uni summ
BGP router identifier 10.10.3.11, local AS number 329 vrf-id 0
BGP table version 1
RIB entries 1, using 192 bytes of memory
Peers 1, using 23 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
192.168.161.131 4      60000        24        27        0    0    0 00:01:05     (Policy)        1

Total number of neighbors 1
eva# show bgp ipv4 statistics
BGP IPv4 Unicast RIB statistics (VRF default)
Total Advertisements          :            1
Total Prefixes                :            1
Average prefix length         :        32.00
Unaggregateable prefixes      :            1
Maximum aggregateable prefixes:            0
BGP Aggregate advertisements  :            0
Address space advertised      :            1
                  % announced :         0.00
                /8 equivalent :         0.00
               /24 equivalent :         0.00

Advertisements with paths     :            1
Longest AS-Path (hops)        :            0
Average AS-Path length (hops) :         0.00
Largest AS-Path (bytes)       :            0
Average AS-Path size (bytes)  :         0.00
Highest public ASN            :            0
eva#

Fixes: #7422
Signed-off-by: Donald Sharp <sharpd@nvidia.com>