### PR TITLE
* : clean up format specifiers for gcc-10

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -265,7 +265,7 @@ int bgp_nlri_parse_vpn(struct peer *peer, struct attr *attr,
 	if (STREAM_READABLE(data) != 0) {
 		flog_err(
 			EC_BGP_UPDATE_RCV,
-			"%s [Error] Update packet error / VPN (%td data remaining after parsing)",
+			"%s [Error] Update packet error / VPN (%zu data remaining after parsing)",
 			peer->host, STREAM_READABLE(data));
 		return BGP_NLRI_PARSE_ERROR_PACKET_LENGTH;
 	}

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -115,10 +115,9 @@ static void vty_out_cpu_thread_history(struct vty *vty,
 				       struct cpu_thread_history *a)
 {
 	vty_out(vty, "%5zu %10zu.%03zu %9zu %8zu %9zu %8zu %9zu",
-		(size_t)a->total_active, a->cpu.total / 1000,
-		a->cpu.total % 1000, (size_t)a->total_calls,
-		(size_t)(a->cpu.total / a->total_calls), a->cpu.max,
-		(size_t)(a->real.total / a->total_calls), a->real.max);
+		a->total_active, a->cpu.total / 1000, a->cpu.total % 1000,
+		a->total_calls,	(a->cpu.total / a->total_calls), a->cpu.max,
+		(a->real.total / a->total_calls), a->real.max);
 	vty_out(vty, " %c%c%c%c%c %s\n",
 		a->types & (1 << THREAD_READ) ? 'R' : ' ',
 		a->types & (1 << THREAD_WRITE) ? 'W' : ' ',

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -115,8 +115,8 @@ struct thread {
 
 struct cpu_thread_history {
 	int (*func)(struct thread *);
-	atomic_uint_fast32_t total_calls;
-	atomic_uint_fast32_t total_active;
+	atomic_size_t total_calls;
+	atomic_size_t total_active;
 	struct time_stats {
 		atomic_size_t total, max;
 	} real;

--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -196,7 +196,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		if (ADV_ROUTER_IN_PREFIX(&route->prefix)
 		    == area->ospf6->router_id) {
 			zlog_debug(
-				"%s: Skipping ASBR announcement for ABR (%pFX)",
+				"%s: Skipping ASBR announcement for ABR (%pI4)",
 				__func__,
 				&ADV_ROUTER_IN_PREFIX(&route->prefix));
 			return 0;
@@ -208,7 +208,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		    || IS_OSPF6_DEBUG_ORIGINATE(INTER_ROUTER)) {
 			is_debug++;
 			zlog_debug(
-				"Originating summary in area %s for ASBR %pFX",
+				"Originating summary in area %s for ASBR %pI4",
 				area->name,
 				&ADV_ROUTER_IN_PREFIX(&route->prefix));
 		}
@@ -225,9 +225,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 				if (is_debug)
 					zlog_debug(
 						"%s: route %pFX with cost %u is not best, ignore.",
-						__func__,
-						&ADV_ROUTER_IN_PREFIX(
-							&route->prefix),
+						__func__, &route->prefix,
 						route->path.cost);
 				return 0;
 			}
@@ -402,8 +400,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 				if (is_debug)
 					zlog_debug(
 						"prefix %pFX was denied by export list",
-						&ADV_ROUTER_IN_PREFIX(
-							&route->prefix));
+						&route->prefix);
 				return 0;
 			}
 	}
@@ -415,7 +412,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 			if (is_debug)
 				zlog_debug(
 					"prefix %pFX was denied by filter-list out",
-					&ADV_ROUTER_IN_PREFIX(&route->prefix));
+					&route->prefix);
 			return 0;
 		}
 

--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -251,7 +251,7 @@ static int ospf_extract_grace_lsa_fields(struct ospf_lsa *lsa,
 		/* Check TLV len against overall LSA */
 		if (sum + TLV_SIZE(tlvh) > length) {
 			if (IS_DEBUG_OSPF_GR_HELPER)
-				zlog_debug("%s: Malformed packet: Invalid TLV len:%zu",
+				zlog_debug("%s: Malformed packet: Invalid TLV len:%u",
 					   __func__, TLV_SIZE(tlvh));
 			return OSPF_GR_FAILURE;
 		}
@@ -260,7 +260,7 @@ static int ospf_extract_grace_lsa_fields(struct ospf_lsa *lsa,
 		case GRACE_PERIOD_TYPE:
 			if (TLV_SIZE(tlvh) <
 			    sizeof(struct grace_tlv_graceperiod)) {
-				zlog_debug("%s: Malformed packet: Invalid grace TLV len:%zu",
+				zlog_debug("%s: Malformed packet: Invalid grace TLV len:%u",
 					   __func__, TLV_SIZE(tlvh));
 				return OSPF_GR_FAILURE;
 			}
@@ -277,7 +277,7 @@ static int ospf_extract_grace_lsa_fields(struct ospf_lsa *lsa,
 		case RESTART_REASON_TYPE:
 			if (TLV_SIZE(tlvh) <
 			    sizeof(struct grace_tlv_restart_reason)) {
-				zlog_debug("%s: Malformed packet: Invalid reason TLV len:%zu",
+				zlog_debug("%s: Malformed packet: Invalid reason TLV len:%u",
 					   __func__, TLV_SIZE(tlvh));
 				return OSPF_GR_FAILURE;
 			}
@@ -292,7 +292,7 @@ static int ospf_extract_grace_lsa_fields(struct ospf_lsa *lsa,
 		case RESTARTER_IP_ADDR_TYPE:
 			if (TLV_SIZE(tlvh) <
 			    sizeof(struct grace_tlv_restart_addr)) {
-				zlog_debug("%s: Malformed packet: Invalid addr TLV len:%zu",
+				zlog_debug("%s: Malformed packet: Invalid addr TLV len:%u",
 					   __func__, TLV_SIZE(tlvh));
 				return OSPF_GR_FAILURE;
 			}
@@ -1018,7 +1018,7 @@ static void show_ospf_grace_lsa_info(struct vty *vty, struct ospf_lsa *lsa)
 	     tlvh = TLV_HDR_NEXT(tlvh)) {
 		/* Check TLV len */
 		if (sum + TLV_SIZE(tlvh) > length) {
-			vty_out(vty, "%% Invalid TLV length: %zu\n",
+			vty_out(vty, "%% Invalid TLV length: %u\n",
 				TLV_SIZE(tlvh));
 			return;
 		}
@@ -1028,7 +1028,7 @@ static void show_ospf_grace_lsa_info(struct vty *vty, struct ospf_lsa *lsa)
 			if (TLV_SIZE(tlvh) <
 			    sizeof(struct grace_tlv_graceperiod)) {
 				vty_out(vty,
-					"%% Invalid grace TLV length %zu\n",
+					"%% Invalid grace TLV length %u\n",
 					TLV_SIZE(tlvh));
 				return;
 			}
@@ -1043,7 +1043,7 @@ static void show_ospf_grace_lsa_info(struct vty *vty, struct ospf_lsa *lsa)
 			if (TLV_SIZE(tlvh) <
 			    sizeof(struct grace_tlv_restart_reason)) {
 				vty_out(vty,
-					"%% Invalid reason TLV length %zu\n",
+					"%% Invalid reason TLV length %u\n",
 					TLV_SIZE(tlvh));
 				return;
 			}
@@ -1058,7 +1058,7 @@ static void show_ospf_grace_lsa_info(struct vty *vty, struct ospf_lsa *lsa)
 			if (TLV_SIZE(tlvh) <
 			    sizeof(struct grace_tlv_restart_addr)) {
 				vty_out(vty,
-					"%% Invalid addr TLV length %zu\n",
+					"%% Invalid addr TLV length %u\n",
 					TLV_SIZE(tlvh));
 				return;
 			}

--- a/ospfd/ospf_opaque.h
+++ b/ospfd/ospf_opaque.h
@@ -93,7 +93,7 @@ struct tlv_header {
 
 #define TLV_BODY_SIZE(tlvh) (ROUNDUP(ntohs((tlvh)->length), sizeof(uint32_t)))
 
-#define TLV_SIZE(tlvh)	(TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh))
+#define TLV_SIZE(tlvh)	(uint32_t)(TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh))
 
 #define TLV_HDR_TOP(lsah)                                                      \
 	(struct tlv_header *)((char *)(lsah) + OSPF_LSA_HEADER_SIZE)


### PR DESCRIPTION
gcc 10 complains about some of our format specs, fix them. I think there also may have been a bit of collateral damage from the "great inet_ntop" conversion.
