### PR TITLE
ospf6d: Json support added for command "show ipv6 ospf6 zebra [json]"

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -195,10 +195,11 @@ Showing OSPF6 information
 
    This command shows internal routing table.
 
-.. index:: show ipv6 ospf6 zebra
-.. clicmd:: show ipv6 ospf6 zebra
+.. index:: show ipv6 ospf6 zebra [json]
+.. clicmd:: show ipv6 ospf6 zebra [json]
 
-   Shows state about what is being redistributed between zebra and OSPF6
+   Shows state about what is being redistributed between zebra and OSPF6.
+   JSON output can be obtained by appending "json" at the end.
 
 OSPF6 Configuration Examples
 ============================


### PR DESCRIPTION
Modify code to add JSON format output in show command
"show ipv6 ospf6 zebra" with proper formating

Signed-off-by: Yash Ranjan <ranjany@vmware.com>