### PR TITLE
ospf6d: Json support added for command "show ipv6 ospf6 interface [json]"

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -174,10 +174,11 @@ Showing OSPF6 information
 
    This command shows LSA database summary. You can specify the type of LSA.
 
-.. index:: show ipv6 ospf6 interface
-.. clicmd:: show ipv6 ospf6 interface
+.. index:: show ipv6 ospf6 interface [json]
+.. clicmd:: show ipv6 ospf6 interface [json]
 
-   To see OSPF interface configuration like costs.
+   To see OSPF interface configuration like costs. JSON output can be
+   obtained by appending "json" in the end.
 
 .. index:: show ipv6 ospf6 neighbor [json]
 .. clicmd:: show ipv6 ospf6 neighbor [json]

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -59,7 +59,7 @@ void ospf6_bfd_show_info(struct vty *vty, void *bfd_info, int param_only,
 			 json_object *json_obj, bool use_json)
 {
 	if (param_only)
-		bfd_show_param(vty, bfd_info, 1, 0, 0, NULL);
+		bfd_show_param(vty, bfd_info, 1, 0, use_json, json_obj);
 	else
 		bfd_show_info(vty, bfd_info, 0, 1, use_json, json_obj);
 }

--- a/ospf6d/ospf6_bfd.h
+++ b/ospf6d/ospf6_bfd.h
@@ -22,6 +22,7 @@
 #include "lib/json.h"
 #ifndef OSPF6_BFD_H
 #define OSPF6_BFD_H
+#include "lib/json.h"
 
 extern void ospf6_bfd_init(void);
 


### PR DESCRIPTION
Modify code to add JSON format output in show command
"show ipv6 ospf6 interface" with proper formating

Signed-off-by: Yash Ranjan <ranjany@vmware.com>