### PR TITLE
ospf6d: Json support added for command "show ipv6 ospf6 interface traffic [json]"

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -185,6 +185,13 @@ Showing OSPF6 information
    Shows state and chosen (Backup) DR of neighbor. JSON output can be
    obtained by appending 'json' at the end.
 
+.. index:: show ipv6 ospf6 interface traffic [json]
+.. clicmd:: show ipv6 ospf6 interface traffic [json]
+
+   Shows counts of different packets that have been recieved and transmitted
+   by the interfaces. JSON output can be obtained by appending "json" at the
+   end.
+
 .. index:: show ipv6 ospf6 request-list A.B.C.D
 .. clicmd:: show ipv6 ospf6 request-list A.B.C.D
 


### PR DESCRIPTION
Modify code to add JSON format output in show command
"show ipv6 ospf6 interface traffic" with proper formating

Signed-off-by: Yash Ranjan <ranjany@vmware.com>