### PR TITLE
ospf6d: Json support added for command "show ipv6 ospf6 redistribute [json]"

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -200,6 +200,12 @@ Showing OSPF6 information
 
    Shows state about what is being redistributed between zebra and OSPF6
 
+.. index:: show ipv6 ospf6 redistribute [json]
+.. clicmd:: show ipv6 ospf6 redistribute [json]
+
+   Shows the routes which are redistributed by the router. JSON output can
+   be obtained by appending 'json' at the end.
+
 OSPF6 Configuration Examples
 ============================
 


### PR DESCRIPTION
Modify code to add JSON format output in show command
"show ipv6 ospf6 redistribute" with proper formating

Signed-off-by: Yash Ranjan <ranjany@vmware.com>