### PR TITLE
Rules and why they are made to be broken

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2390,6 +2390,7 @@ static void bgp_encode_pbr_rule_action(struct stream *s,
 {
 	struct prefix pfx;
 	uint8_t fam = AF_INET;
+	char ifname[INTERFACE_NAMSIZ];
 
 	if (pbra->nh.type == NEXTHOP_TYPE_IPV6)
 		fam = AF_INET6;
@@ -2431,7 +2432,7 @@ static void bgp_encode_pbr_rule_action(struct stream *s,
 	stream_put(s, &pfx.u.prefix, prefix_blen(&pfx));
 
 	stream_putw(s, 0);  /* dst port */
-
+	stream_putc(s, 0);  /* dsfield */
 	/* if pbr present, fwmark is not used */
 	if (pbr)
 		stream_putl(s, 0);
@@ -2440,7 +2441,8 @@ static void bgp_encode_pbr_rule_action(struct stream *s,
 
 	stream_putl(s, pbra->table_id);
 
-	stream_putl(s, 0); /* ifindex unused */
+	memset(ifname, 0, sizeof(ifname));
+	stream_put(s, ifname, INTERFACE_NAMSIZ); /* ifname unused */
 }
 
 static void bgp_encode_pbr_ipset_match(struct stream *s,

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -907,16 +907,22 @@ DEFPY (show_pbr_interface,
 			if (j)
 				this_iface = json_object_new_object();
 
-			if (!ifp->info)
+			if (!ifp->info) {
+				json_object_free(this_iface);
 				continue;
+			}
 
-			if (name && strcmp(ifp->name, name) != 0)
+			if (name && strcmp(ifp->name, name) != 0) {
+				json_object_free(this_iface);
 				continue;
+			}
 
 			pbr_ifp = ifp->info;
 
-			if (strcmp(pbr_ifp->mapname, "") == 0)
+			if (strcmp(pbr_ifp->mapname, "") == 0) {
+				json_object_free(this_iface);
 				continue;
+			}
 
 			pbrm = pbrm_find(pbr_ifp->mapname);
 


### PR DESCRIPTION
1) pbr memory leak w/ json
2) flowspec rule sending to zebra was wrong.