### PR TITLE
lib: change limit of netns name from 15 to 35 characters

### DIFF
--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -43,7 +43,7 @@ enum { IFLA_VRF_UNSPEC, IFLA_VRF_TABLE, __IFLA_VRF_MAX };
 #endif
 
 #define VRF_NAMSIZ      36
-#define NS_NAMSIZ       16
+#define NS_NAMSIZ 36
 
 /*
  * The command strings


### PR DESCRIPTION
Extend the size of netns name to match linux permitted netns name size

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>