### PR TITLE
fpm: frr-reload, IPv6 and an improvement

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -531,6 +531,7 @@ end
             "dump ",
             "enable ",
             "frr ",
+            "fpm ",
             "hostname ",
             "ip ",
             "ipv6 ",

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -377,7 +377,6 @@ static int fpm_write_config(struct vty *vty)
 	struct sockaddr_in *sin;
 	struct sockaddr_in6 *sin6;
 	int written = 0;
-	char addrstr[INET6_ADDRSTRLEN];
 
 	if (gfnc->disabled)
 		return written;
@@ -386,8 +385,7 @@ static int fpm_write_config(struct vty *vty)
 	case AF_INET:
 		written = 1;
 		sin = (struct sockaddr_in *)&gfnc->addr;
-		inet_ntop(AF_INET, &sin->sin_addr, addrstr, sizeof(addrstr));
-		vty_out(vty, "fpm address %s", addrstr);
+		vty_out(vty, "fpm address %pI4", &sin->sin_addr);
 		if (sin->sin_port != htons(SOUTHBOUND_DEFAULT_PORT))
 			vty_out(vty, " port %d", ntohs(sin->sin_port));
 
@@ -396,8 +394,7 @@ static int fpm_write_config(struct vty *vty)
 	case AF_INET6:
 		written = 1;
 		sin6 = (struct sockaddr_in6 *)&gfnc->addr;
-		inet_ntop(AF_INET, &sin6->sin6_addr, addrstr, sizeof(addrstr));
-		vty_out(vty, "fpm address %s", addrstr);
+		vty_out(vty, "fpm address %pI6", &sin6->sin6_addr);
 		if (sin6->sin6_port != htons(SOUTHBOUND_DEFAULT_PORT))
 			vty_out(vty, " port %d", ntohs(sin6->sin6_port));
 


### PR DESCRIPTION
`frr-reload`
---

Handle `fpm` configurations in `frr-reload.py` so it doesn't think `fpm` is a new node.

Here is the problem the commit fixes:

```
/usr/lib/frr/frr-reload.py --test commands.txt            
                                                                         
Lines To Delete
===============
ipv6 forwarding

Lines To Add
============                                                       
no fpm use-next-hop-group
fpm address 127.0.0.1
fpm address 127.0.0.1
 router bgp 100
fpm address 127.0.0.1
 neighbor 192.168.1.1 remote-as internal
```


IPv6 in `show running`
---

Use the proper print format.

```
@@ -414,8 +412,7 @@ static int fpm_write_config(struct vty *vty)
        case AF_INET6:
                written = 1;
                sin6 = (struct sockaddr_in6 *)&gfnc->addr;
-               inet_ntop(AF_INET, &sin6->sin6_addr, addrstr, sizeof(addrstr));
-               vty_out(vty, "fpm address %s", addrstr);
+               vty_out(vty, "fpm address %pI6", &sin6->sin6_addr);
                if (sin6->sin6_port != htons(SOUTHBOUND_DEFAULT_PORT))
                        vty_out(vty, " port %d", ntohs(sin6->sin6_port));
 


```


Improvement
---

Don't walk the route/next hop data structures if we are not connected to the FPM server and simplify the walk procedure (always start at next hop groups even if we have it disabled).

Fixes the following problem:

```
2020/11/06 15:25:45 ZEBRA: fpm_connect: attempting to connect to ::1:2620
2020/11/06 15:25:45 ZEBRA: fpm_write: connection failed: Connection refused
2020/11/06 15:25:45 ZEBRA: fpm_process_event: RIB walk finished
2020/11/06 15:25:45 ZEBRA: fpm_process_event: RMAC walk finished
2020/11/06 15:25:48 ZEBRA: fpm_connect: attempting to connect to ::1:2620
2020/11/06 15:25:48 ZEBRA: fpm_write: connection failed: Connection refused
2020/11/06 15:25:48 ZEBRA: fpm_process_event: RIB walk finished
2020/11/06 15:25:48 ZEBRA: fpm_process_event: RMAC walk finished
```