### PR TITLE
build: add more precious variables for cross-compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,13 @@ dnl -----------------------------------
 AC_CANONICAL_BUILD()
 AC_CANONICAL_HOST()
 
+AC_ARG_VAR([AR],[archiver command])
+AC_ARG_VAR([LD],[linker command])
+AC_ARG_VAR([OBJCOPY],[objcopy command])
+AC_ARG_VAR([OBJDUMP],[objdump command])
+AC_ARG_VAR([RANLIB],[ranlib command])
+AC_ARG_VAR([STRIP],[strip command])
+
 hosttools_clippy="false"
 build_clippy="true"
 


### PR DESCRIPTION
Using `AC_ARG_VAR` function, it's possible to add `LD`, `AR`, `OBJCOPY`,
`OBJDUMP`, `RANLIB` and `STRIP` to the list of precious variables in
`$ac_precious_vars` for configure tool.

Doing this, we are enabling a new set of variables (`HOST_LD`, `HOST_AR`,
`HOST_OBJCOPY`, `HOST_OBJDUMP`, `HOST_RANLIB` and `HOST_STRIP`) useful for
cross-compiling when the target toolchain is prepending a prefix
to these tools.

This was my log before fixing the issue:

```
checking if gcc -std=gnu11 static flag -static works... yes
checking if gcc -std=gnu11 supports -c -o file.o... yes
checking if gcc -std=gnu11 supports -c -o file.o... (cached) yes
checking whether the gcc -std=gnu11 linker (tile-ld  -m elf_x86_64) supports shared libraries... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... unsupported
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... no
checking whether to build shared libraries... no
checking whether to build static libraries... yes
checking how to run the C++ preprocessor... g++ -E
checking for ld used by g++... tile-ld  -m elf_x86_64
checking if the linker (tile-ld  -m elf_x86_64) is GNU ld... no
checking whether the g++ linker (**_tile-ld  -m elf_x86_64_**) supports shared libraries... yes
checking for g++ option to produce PIC... -fPIC -DPIC
checking if g++ PIC flag -fPIC -DPIC works... yes
checking if g++ static flag -static works... yes
checking if g++ supports -c -o file.o... yes
checking if g++ supports -c -o file.o... (cached) yes
checking whether the g++ linker (tile-ld  -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... unsupported
configure: error: FRR cannot be built with --disable-shared.  If you want statically linked daemons, use --enable-shared --enable-static --enable-static-bin
make[2]: *** [/home/emanu/6WINDGate-3.41.NGI.49-SDS-TILEGX-TILERAMDE-4.3.3__ngi/ports/frr/build/config.h] Error 1
make[1]: *** [frr_pmake] Error 2
make: *** [frr_pmake] Error 1
```

basically, configure was using the wrong linker (LD) for building local host tools.
The initial part of the list of precious vars was the following:

```
ac_precious_vars='build_alias
host_alias
target_alias
PKG_CONFIG
PKG_CONFIG_PATH
PKG_CONFIG_LIBDIR
CC
CFLAGS
LDFLAGS
LIBS
CPPFLAGS
CPP
...
```

After the change attached to this PR, the new list of precious vars is:

```
ac_precious_vars='build_alias
host_alias
target_alias
AR
LD
OBJCOPY
OBJDUMP
RANLIB
STRIP
PKG_CONFIG
PKG_CONFIG_PATH
PKG_CONFIG_LIBDIR
CC
CFLAGS
LDFLAGS
LIBS
CPPFLAGS
CPP
...
```

So now we have also LD and all needed tools, thus adding following vars to configure command:

`HOST_CC=gcc HOST_LD=ld HOST_AR=ar HOST_CXX=g++ HOST_OBJCOPY=objcopy HOST_OBJDUMP=objdump HOST_RANLIB=ranlib HOST_STRIP=strip
`
In this way:

`configure --sysconfdir=/var/tmp/shells --localstatedir=/tmp --sbindir=/usr/local/bin --bindir=/usr/local/bin --libdir=/lib --host=tilegx-redhat-linux --build=x86_64-linux-gnu --srcdir=/home/emanu/ports/frr/src --enable-user=root --enable-group=root --enable-vtysh --enable-multipath=4 --enable-capabilities --disable-irdp --disable-rtadv --disable-doc --disable-ripd --disable-ripngd --disable-isisd --disable-pimd --disable-babeld --disable-ospfclient --disable-eigrpd  --disable-nhrpd --disable-rr-semantics CFLAGS="-O2 -fomit-frame-pointer  -Dlinux -Dlinux -Dunix -DEMBED LIBS="-l6whas -lxml2 -lxt -lm" HOST_CC=gcc HOST_LD=ld HOST_AR=ar HOST_CXX=g++ HOST_OBJCOPY=objcopy HOST_OBJDUMP=objdump HOST_RANLIB=ranlib HOST_STRIP=strip`

I'm able to cross compile correctly.

I think that this issue is present when the target toolchain is prepending a prefix to compilation tools, thus configure mix up local tools with target ones, if not explicitly redefined.

It's possible that this PR fixes #7281, because my issue looks very similar.