### PR TITLE
bfdd,lib: integration fixes

### DIFF
--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -84,10 +84,11 @@ static void bfdd_client_deregister(struct stream *msg);
 static void debug_printbpc(const struct bfd_peer_cfg *bpc, const char *fmt, ...)
 {
 	char timers[3][128] = {};
+	char minttl_str[32] = {};
 	char addr[3][128] = {};
 	char profile[128] = {};
 	char cbit_str[32];
-	char msgbuf[256];
+	char msgbuf[512];
 	va_list vl;
 
 	/* Avoid debug calculations if it's disabled. */
@@ -120,6 +121,10 @@ static void debug_printbpc(const struct bfd_peer_cfg *bpc, const char *fmt, ...)
 
 	snprintf(cbit_str, sizeof(cbit_str), " cbit:0x%02x", bpc->bpc_cbit);
 
+	if (bpc->bpc_has_minimum_ttl)
+		snprintf(minttl_str, sizeof(minttl_str), " minimum-ttl:%d",
+			 bpc->bpc_minimum_ttl);
+
 	if (bpc->bpc_has_profile)
 		snprintf(profile, sizeof(profile), " profile:%s",
 			 bpc->bpc_profile);
@@ -128,9 +133,10 @@ static void debug_printbpc(const struct bfd_peer_cfg *bpc, const char *fmt, ...)
 	vsnprintf(msgbuf, sizeof(msgbuf), fmt, vl);
 	va_end(vl);
 
-	zlog_debug("%s [mhop:%s %s%s%s%s%s%s%s%s]", msgbuf,
+	zlog_debug("%s [mhop:%s %s%s%s%s%s%s%s%s%s]", msgbuf,
 		   bpc->bpc_mhop ? "yes" : "no", addr[0], addr[1], addr[2],
-		   timers[0], timers[1], timers[2], cbit_str, profile);
+		   timers[0], timers[1], timers[2], cbit_str, minttl_str,
+		   profile);
 }
 
 static void _ptm_bfd_session_del(struct bfd_session *bs, uint8_t diag)

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -104,7 +104,10 @@ void bfd_set_param(struct bfd_info **bfd_info, uint32_t min_rx, uint32_t min_tx,
 		if (((*bfd_info)->required_min_rx != min_rx)
 		    || ((*bfd_info)->desired_min_tx != min_tx)
 		    || ((*bfd_info)->detect_mult != detect_mult)
-		    || (profile && strcmp((*bfd_info)->profile, profile)))
+		    || ((*bfd_info)->profile[0] == 0 && profile)
+		    || ((*bfd_info)->profile[0] && profile == NULL)
+		    || (profile && (*bfd_info)->profile[0]
+			&& strcmp((*bfd_info)->profile, profile)))
 			*command = ZEBRA_BFD_DEST_UPDATE;
 	}
 


### PR DESCRIPTION
Summary
---

* Simplify integration protocol: always send all information. This commit also fixed `ptm-bfd` because it removes the cbit configuration when not using `bfdd`

* Show minimum TTL information when debugging

* (Re)apply BFD profile configuration when the BFD integration configuration previously existed