### PR TITLE
bgpd: fix compiler warnings in nbr cmd

### DIFF
--- a/bgpd/bgp_nb_config.c
+++ b/bgpd/bgp_nb_config.c
@@ -3033,9 +3033,17 @@ int bgp_neighbors_neighbor_update_source_interface_modify(
 	struct bgp *bgp;
 	const char *peer_str, *source_str;
 	struct peer *peer;
+	struct prefix p;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		source_str = yang_dnode_get_string(args->dnode, NULL);
+		if (str2prefix(source_str, &p)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Invalid update-source, remove prefix length");
+			return NB_ERR_VALIDATION;
+		}
+		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		return NB_OK;
@@ -5071,9 +5079,17 @@ int bgp_neighbors_unnumbered_neighbor_update_source_interface_modify(
 	struct bgp *bgp;
 	const char *peer_str, *source_str;
 	struct peer *peer;
+	struct prefix p;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		source_str = yang_dnode_get_string(args->dnode, NULL);
+		if (str2prefix(source_str, &p)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Invalid update-source, remove prefix length");
+			return NB_ERR_VALIDATION;
+		}
+		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		return NB_OK;
@@ -6963,9 +6979,17 @@ int bgp_peer_groups_peer_group_update_source_interface_modify(
 	struct bgp *bgp;
 	const char *peer_str, *source_str;
 	struct peer *peer;
+	struct prefix p;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		source_str = yang_dnode_get_string(args->dnode, NULL);
+		if (str2prefix(source_str, &p)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Invalid update-source, remove prefix length");
+			return NB_ERR_VALIDATION;
+		}
+		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		return NB_OK;


### PR DESCRIPTION
Addressed the gcc-10 buffer overflow warnings.
Put a sanity check of not using prefix for
neighbor update-source with interface option.

```
bgpd/bgp_vty.c: In function ‘neighbor_activate’:
bgpd/bgp_vty.c:4815:46: warning: ‘/enabled’ directive output may be truncated writing 8 bytes into a region of size between 1 and 1024 [-Wformat-truncation=]
 4815 |  snprintf(abs_xpath, sizeof(abs_xpath), "%s%s/enabled", VTY_CURR_XPATH,
      |                                              ^~~~~~~~
bgpd/bgp_vty.c:4815:2: note: ‘snprintf’ output 9 or more bytes (assuming 1032) into a destination of size 1024
 4815 |  snprintf(abs_xpath, sizeof(abs_xpath), "%s%s/enabled", VTY_CURR_XPATH,
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 4816 |    nbr_xpath + 1);
      |    ~~~~~~~~~~~~~~
bgpd/bgp_vty.c: In function ‘no_neighbor_update_source’:
bgpd/bgp_vty.c:6976:52: warning: ‘/update-source/ip’ directive output may be truncated writing 17 bytes into a region of size between 1 and 1024 [-Wformat-truncation=]
 6976 |  snprintf(abs_xpath_ip, sizeof(abs_xpath_ip), "%s%s/update-source/ip",
      |                                                    ^~~~~~~~~~~~~~~~~
bgpd/bgp_vty.c:6976:2: note: ‘snprintf’ output 18 or more bytes (assuming 1041) into a destination of size 1024
 6976 |  snprintf(abs_xpath_ip, sizeof(abs_xpath_ip), "%s%s/update-source/ip",
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 6977 |    VTY_CURR_XPATH, base_xpath + 1);
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
bgpd/bgp_vty.c:6979:9: warning: ‘/update-source/interface’ directive output may be truncated writing 24 bytes into a region of size between 1 and 1024 [-Wformat-truncation=]
 6979 |    "%s%s/update-source/interface", VTY_CURR_XPATH,
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
bgpd/bgp_vty.c:6978:2: note: ‘snprintf’ output 25 or more bytes (assuming 1048) into a destination of size 1024
 6978 |  snprintf(abs_xpath_intf, sizeof(abs_xpath_intf),
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 6979 |    "%s%s/update-source/interface", VTY_CURR_XPATH,
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 6980 |    base_xpath + 1);
      |    ~~~~~~~~~~~~~~~
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>