### PR TITLE
Flowspec leak

### DIFF
--- a/bgpd/bgp_flowspec.c
+++ b/bgpd/bgp_flowspec.c
@@ -104,7 +104,6 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 	int psize = 0;
 	struct prefix p;
 	int ret;
-	void *temp;
 
 	/* Start processing the NLRI - there may be multiple in the MP_REACH */
 	pnt = packet->nlri;
@@ -150,12 +149,8 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 		p.family = AF_FLOWSPEC;
 		p.prefixlen = 0;
 		/* Flowspec encoding is in bytes */
-		p.u.prefix_flowspec.prefixlen = psize;
 		p.u.prefix_flowspec.family = afi2family(afi);
-		temp = XCALLOC(MTYPE_TMP, psize);
-		memcpy(temp, pnt, psize);
-		p.u.prefix_flowspec.ptr = (uintptr_t) temp;
-
+		prefix_flowspec_allocate(&p, pnt, psize);
 		if (BGP_DEBUG(flowspec, FLOWSPEC)) {
 			char return_string[BGP_FLOWSPEC_NLRI_STRING_MAX];
 			char local_string[BGP_FLOWSPEC_NLRI_STRING_MAX*2+16];

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1126,6 +1126,15 @@ void prefix_flowspec_allocate(struct prefix *p, uint8_t *pnt, int size)
 /* Free prefix structure. */
 void prefix_free(struct prefix **p)
 {
+	struct prefix *pp = *p;
+	void *ptr = NULL;
+
+	if (!pp)
+		return;
+	if (pp->family == AF_FLOWSPEC) {
+		ptr = (void *)pp->u.prefix_flowspec.ptr;
+		XFREE(MTYPE_PREFIX_FLOWSPEC, ptr);
+	}
 	XFREE(MTYPE_PREFIX, *p);
 }
 

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1114,6 +1114,15 @@ void prefix_free_lists(void *arg)
 	prefix_free(&p);
 }
 
+void prefix_flowspec_allocate(struct prefix *p, uint8_t *pnt, int size)
+{
+	char *temp = XCALLOC(MTYPE_PREFIX_FLOWSPEC, size);
+
+	memcpy(temp, pnt, size);
+	p->u.prefix_flowspec.ptr = (uintptr_t)temp;
+	p->u.prefix_flowspec.prefixlen = size;
+}
+
 /* Free prefix structure. */
 void prefix_free(struct prefix **p)
 {

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -432,6 +432,7 @@ extern unsigned int prefix_bit(const uint8_t *prefix, const uint16_t bit_index);
 
 extern struct prefix *prefix_new(void);
 extern void prefix_free(struct prefix **p);
+extern void prefix_flowspec_allocate(struct prefix *p, uint8_t *pnt, int size);
 /*
  * Function to handle prefix_free being used as a del function.
  */


### PR DESCRIPTION

==837256== 56 bytes in 2 blocks are definitely lost in loss record 45 of 97
==837256==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==837256==    by 0x48D961F: qcalloc (memory.c:115)
==837256==    by 0x2FAA55: bgp_nlri_parse_flowspec (bgp_flowspec.c:155)
==837256==    by 0x1F2F74: bgp_nlri_parse (bgp_packet.c:323)
==837256==    by 0x1F5DD1: bgp_update_receive (bgp_packet.c:1673)
==837256==    by 0x1F78A6: bgp_process_packet (bgp_packet.c:2389)
==837256==    by 0x4924373: thread_call (thread.c:1675)
==837256==    by 0x48D2AE6: frr_run (libfrr.c:1099)
==837256==    by 0x18F79F: main (bgp_main.c:521)
==837256== 
==837256== 56 bytes in 2 blocks are definitely lost in loss record 46 of 97
==837256==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==837256==    by 0x48D961F: qcalloc (memory.c:115)
==837256==    by 0x48F51FA: prefix_copy (prefix.c:336)
==837256==    by 0x491CB59: route_node_get (table.c:289)
==837256==    by 0x200D63: bgp_node_get (bgp_table.h:230)
==837256==    by 0x204BDE: bgp_afi_node_get (bgp_route.c:152)
==837256==    by 0x20CD3C: bgp_update (bgp_route.c:3526)
==837256==    by 0x2FAC48: bgp_nlri_parse_flowspec (bgp_flowspec.c:192)
==837256==    by 0x1F2F74: bgp_nlri_parse (bgp_packet.c:323)
==837256==    by 0x1F5DD1: bgp_update_receive (bgp_packet.c:1673)
==837256==    by 0x1F78A6: bgp_process_packet (bgp_packet.c:2389)
==837256==    by 0x4924373: thread_call (thread.c:1675)
