### PR TITLE
bgpd: avoid needless ebgp-multihop session reset

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4505,6 +4505,10 @@ int peer_ebgp_multihop_set(struct peer *peer, int ttl)
 	if (peer->sort == BGP_PEER_IBGP || peer->conf_if)
 		return 0;
 
+	/* is there anything to do? */
+	if (peer->ttl == ttl)
+		return 0;
+
 	/* see comment in peer_ttl_security_hops_set() */
 	if (ttl != MAXTTL) {
 		if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {


### PR DESCRIPTION
if a user sets the ebgp-multihop TTL value for a neighbor to the same value we currently have configured, avoid resetting the session and just return a silent success.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>