### PR TITLE
doc: fix sphinx complaint about indent levels

### DIFF
--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -26,7 +26,7 @@ forms the initial command set for a routing beast as it is starting.
 Config files are generally found in |INSTALL_PREFIX_ETC|.
 
 Config Methods
-^^^^^^^^^^^^^^
+--------------
 
 There are two ways of configuring FRR.
 


### PR DESCRIPTION
Recent edit to `basic.rst` introduced an inconsistency in the characters used for the second level of title/section hierarchy - (try to) fix it.