### PR TITLE
tests: only test count of nexthops in bgp max-paths test

### DIFF
--- a/tests/topotests/bgp-ecmp-topo2/test_ebgp_ecmp_topo2.py
+++ b/tests/topotests/bgp-ecmp-topo2/test_ebgp_ecmp_topo2.py
@@ -292,6 +292,10 @@ def test_modify_ecmp_max_paths(request, ecmp_num, test_type):
         input_dict_1 = {"r3": {"static_routes": [{"network": NETWORK[addr_type]}]}}
 
         logger.info("Verifying %s routes on r3", addr_type)
+
+        # Only test the count of nexthops; the actual nexthop addresses
+        # can vary and are not deterministic.
+        #
         result = verify_rib(
             tgen,
             addr_type,
@@ -299,7 +303,9 @@ def test_modify_ecmp_max_paths(request, ecmp_num, test_type):
             input_dict_1,
             next_hop=NEXT_HOPS[addr_type][: int(ecmp_num)],
             protocol=protocol,
+            count_only=True
         )
+
         assert result is True, "Testcase {} : Failed \n Error: {}".format(
             tc_name, result
         )

--- a/tests/topotests/bgp-ecmp-topo2/test_ibgp_ecmp_topo2.py
+++ b/tests/topotests/bgp-ecmp-topo2/test_ibgp_ecmp_topo2.py
@@ -293,6 +293,10 @@ def test_modify_ecmp_max_paths(request, ecmp_num, test_type):
         input_dict_1 = {"r3": {"static_routes": [{"network": NETWORK[addr_type]}]}}
 
         logger.info("Verifying %s routes on r3", addr_type)
+
+        # Test only the count of nexthops, not the specific nexthop addresses -
+        # they're not deterministic
+        #
         result = verify_rib(
             tgen,
             addr_type,
@@ -300,7 +304,9 @@ def test_modify_ecmp_max_paths(request, ecmp_num, test_type):
             input_dict_1,
             next_hop=NEXT_HOPS[addr_type][: int(ecmp_num)],
             protocol=protocol,
+            count_only=True
         )
+
         assert result is True, "Testcase {} : Failed \n Error: {}".format(
             tc_name, result
         )

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -2559,6 +2559,7 @@ def verify_rib(
     tag=None,
     metric=None,
     fib=None,
+    count_only=False
 ):
     """
     Data will be read from input_dict or input JSON file, API will generate
@@ -2576,6 +2577,8 @@ def verify_rib(
     * `next_hop`[optional]: next_hop which needs to be verified,
                            default: static
     * `protocol`[optional]: protocol, default = None
+    * `count_only`[optional]: count of nexthops only, not specific addresses,
+                              default = False
 
     Usage
     -----
@@ -2739,7 +2742,23 @@ def verify_rib(
                                     for rib_r in rib_routes_json[st_rt][0]["nexthops"]
                                 ]
 
-                                if found_hops:
+                                # Check only the count of nexthops
+                                if count_only:
+                                    if len(next_hop) == len(found_hops):
+                                        nh_found = True
+                                    else:
+                                        errormsg = (
+                                            "Nexthops are missing for "
+                                            "route {} in RIB of router {}: "
+                                            "expected {}, found {}\n".format(
+                                                st_rt, dut, len(next_hop),
+                                                len(found_hops)
+                                            )
+                                        )
+                                        return errormsg
+
+                                # Check the actual nexthops
+                                elif found_hops:
                                     missing_list_of_nexthops = set(
                                         found_hops
                                     ).difference(next_hop)


### PR DESCRIPTION
Add support to compare the number of RIB nexthops, rather than the specific nexthop addresses. Use this in the bgp_ecmp topotests that test maximum-paths - testing the specific nexthops is wrong there, it's not deterministic and we get spurious failures. This is sort of a minimal version, to see if it improves the CI.
