### PR TITLE
tests: reduce scale of the route scale test

### DIFF
--- a/tests/topotests/route-scale/r1/installed.routes.json
+++ b/tests/topotests/route-scale/r1/installed.routes.json
@@ -6,11 +6,11 @@
       "type":"connected"
     },
     {
-      "fib":1000000,
-      "rib":1000000,
+      "fib":200000,
+      "rib":200000,
       "type":"sharp"
     }
   ],
-  "routesTotal":1000032,
-  "routesTotalFib":1000032
+  "routesTotal":200032,
+  "routesTotalFib":200032
 }


### PR DESCRIPTION
Reduce the number of routes used in the route-scale test. We're having memory troubles, and this may help the CI run with fewer false failures. Also re-orged the route-scale test code a bit so it can be driven from the json file, with fewer hard-coded values. The change in scale is temporary - once we've improved the footprint of sharpd in this test, we should be able to return to the full 1M routes.
