### PR TITLE
nhrpd: cache config may disappear if iface not present at startup

### DIFF
--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -23,6 +23,10 @@
 
 DEFINE_MTYPE_STATIC(NHRPD, NHRP_IF, "NHRP interface")
 
+static void nhrp_interface_update_cache_config(struct interface *ifp,
+					       bool available,
+					       uint8_t family);
+
 static int nhrp_if_new_hook(struct interface *ifp)
 {
 	struct nhrp_interface *nifp;
@@ -311,9 +315,66 @@ int nhrp_ifp_destroy(struct interface *ifp)
 {
 	debugf(NHRP_DEBUG_IF, "if-delete: %s", ifp->name);
 
+	nhrp_interface_update_cache_config(ifp, false, AF_INET);
+	nhrp_interface_update_cache_config(ifp, false, AF_INET6);
 	nhrp_interface_update(ifp);
 
 	return 0;
+}
+
+struct map_ctx {
+	int family;
+	bool enabled;
+};
+
+static void interface_config_update_nhrp_map(struct nhrp_cache_config *cc, void *data)
+{
+	struct map_ctx *ctx = data;
+	struct interface *ifp = cc->ifp;
+	struct nhrp_cache *c;
+	union sockunion nbma_addr;
+
+	if (sockunion_family(&cc->remote_addr) != ctx->family)
+		return;
+
+	/* gre layer not ready */
+	if (ifp->vrf_id == VRF_UNKNOWN)
+		return;
+
+	c = nhrp_cache_get(ifp, &cc->remote_addr, ctx->enabled ? 1 : 0);
+	if (!c && !ctx->enabled)
+		return;
+	/* suppress */
+	if (!ctx->enabled) {
+		if (c && c->map) {
+			nhrp_cache_update_binding(c, c->cur.type, -1,
+						  nhrp_peer_get(ifp, &nbma_addr), 0, NULL);
+		}
+		return;
+	}
+	/* create */
+	c->map = 1;
+	if (cc->type == NHRP_CACHE_LOCAL)
+		nhrp_cache_update_binding(c, NHRP_CACHE_LOCAL, 0, NULL, 0,
+					  NULL);
+	else {
+		nhrp_cache_update_binding(c, NHRP_CACHE_STATIC, 0,
+					  nhrp_peer_get(ifp, &cc->nbma), 0,
+					  NULL);
+	}
+}
+
+static void nhrp_interface_update_cache_config(struct interface *ifp, bool available, uint8_t family)
+{
+	struct map_ctx mapctx;
+
+	mapctx = (struct map_ctx){
+		.family = family,
+		.enabled = available
+	};
+	nhrp_cache_config_foreach(ifp, interface_config_update_nhrp_map,
+				  &mapctx);
+
 }
 
 int nhrp_ifp_up(struct interface *ifp)
@@ -345,7 +406,7 @@ int nhrp_interface_address_add(ZAPI_CALLBACK_ARGS)
 
 	nhrp_interface_update_address(
 		ifc->ifp, family2afi(PREFIX_FAMILY(ifc->address)), 0);
-
+	nhrp_interface_update_cache_config(ifc->ifp, true, PREFIX_FAMILY(ifc->address));
 	return 0;
 }
 

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -197,6 +197,13 @@ enum nhrp_cache_type {
 extern const char *const nhrp_cache_type_str[];
 extern unsigned long nhrp_cache_counts[NHRP_CACHE_NUM_TYPES];
 
+struct nhrp_cache_config {
+	struct interface *ifp;
+	union sockunion remote_addr;
+	enum nhrp_cache_type type;
+	union sockunion nbma;
+};
+
 struct nhrp_cache {
 	struct interface *ifp;
 	union sockunion remote_addr;
@@ -280,6 +287,7 @@ struct nhrp_interface {
 	uint32_t grekey;
 
 	struct hash *peer_hash;
+	struct hash *cache_config_hash;
 	struct hash *cache_hash;
 
 	struct notifier_list notifier_list;
@@ -358,10 +366,16 @@ void nhrp_shortcut_foreach(afi_t afi,
 void nhrp_shortcut_purge(struct nhrp_shortcut *s, int force);
 void nhrp_shortcut_prefix_change(const struct prefix *p, int deleted);
 
+void nhrp_cache_config_free(struct nhrp_cache_config *c);
+struct nhrp_cache_config *nhrp_cache_config_get(struct interface *ifp,
+						union sockunion *remote_addr,
+						int create);
 struct nhrp_cache *nhrp_cache_get(struct interface *ifp,
 				  union sockunion *remote_addr, int create);
 void nhrp_cache_foreach(struct interface *ifp,
 			void (*cb)(struct nhrp_cache *, void *), void *ctx);
+void nhrp_cache_config_foreach(struct interface *ifp,
+			       void (*cb)(struct nhrp_cache_config *, void *), void *ctx);
 void nhrp_cache_set_used(struct nhrp_cache *, int);
 int nhrp_cache_update_binding(struct nhrp_cache *, enum nhrp_cache_type type,
 			      int holding_time, struct nhrp_peer *p,


### PR DESCRIPTION
When interface not present at config time, store separately the list of
 config parameters. Then, when interface is ready, inherit from this configuration.
