### PR TITLE
ospf6d: Fix crash on shutdown

### DIFF
--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -37,6 +37,7 @@
 #include "ospf6d.h"
 #include "ospf6_message.h"
 #include "ospf6_neighbor.h"
+#include "ospf6_top.h"
 #include "ospf6_interface.h"
 #include "ospf6_route.h"
 #include "ospf6_zebra.h"

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -233,7 +233,7 @@ struct ospf6_interface *ospf6_interface_create(struct interface *ifp)
 	return oi;
 }
 
-void ospf6_interface_delete(struct ospf6_interface *oi)
+void ospf6_interface_delete(struct ospf6 *ospf6, struct ospf6_interface *oi)
 {
 	struct listnode *node, *nnode;
 	struct ospf6_neighbor *on;
@@ -260,7 +260,7 @@ void ospf6_interface_delete(struct ospf6_interface *oi)
 	ospf6_lsdb_delete(oi->lsupdate_list);
 	ospf6_lsdb_delete(oi->lsack_list);
 
-	ospf6_route_table_delete(oi->route_connected, oi->area->ospf6);
+	ospf6_route_table_delete(oi->route_connected, ospf6);
 
 	/* cut link */
 	oi->interface->info = NULL;

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -173,7 +173,8 @@ extern const char *const ospf6_interface_state_str[];
 extern struct ospf6_interface *
 ospf6_interface_lookup_by_ifindex(ifindex_t, vrf_id_t vrf_id);
 extern struct ospf6_interface *ospf6_interface_create(struct interface *);
-extern void ospf6_interface_delete(struct ospf6_interface *);
+extern void ospf6_interface_delete(struct ospf6 *ospf6,
+				   struct ospf6_interface *oi);
 
 extern void ospf6_interface_enable(struct ospf6_interface *);
 extern void ospf6_interface_disable(struct ospf6_interface *);

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -89,10 +89,10 @@ static void __attribute__((noreturn)) ospf6_exit(int status)
 	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6)) {
 		vrf = vrf_lookup_by_id(ospf6->vrf_id);
 		ospf6_serv_close(&ospf6->fd);
+		ospf6_delete(ospf6);
 		FOR_ALL_INTERFACES (vrf, ifp)
 			if (ifp->info != NULL)
-				ospf6_interface_delete(ifp->info);
-		ospf6_delete(ospf6);
+				ospf6_interface_delete(ospf6, ifp->info);
 		ospf6 = NULL;
 	}
 


### PR DESCRIPTION
Running all-protocol-startup topotest I am seeing this crash:

(gdb) bt
    at lib/sigevent.c:253
    ap=0x7ffee6ed0cb8) at lib/printf/vfprintf.c:586
    out=0x7f2be0d6703c <error: Cannot access memory at address 0x7f2be0d6703c>, outsz=8131,
    fmt=0x558865c398d9 "  nexthop: %s%%%.*s(%d)", ap=0x7ffee6ed0cb8) at lib/printf/glue.c:103
    ap=0x7ffee6ed0d88) at lib/zlog.c:423
    at lib/zlog.c:483
    at ospf6d/ospf6_route.c:310
    at ospf6d/ospf6_zebra.c:313
    at ospf6d/ospf6_zebra.c:349
    at ospf6d/ospf6_top.c:163
    at ospf6d/ospf6_route.c:885
    at ospf6d/ospf6_area.c:134
    at ospf6d/ospf6_route.c:885
(gdb)

This fixes this issue.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>