### PR TITLE
lib: Fix crash walking up command chain in bgp commands

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -154,7 +154,8 @@ static bool vty_check_node_for_xpath_decrement(enum node_type target_node,
 		|| node == BGP_IPV4M_NODE || node == BGP_IPV6M_NODE
 		|| node == BGP_VPNV4_NODE || node == BGP_VPNV6_NODE
 		|| node == BGP_EVPN_NODE || node == BGP_IPV4L_NODE
-		|| node == BGP_IPV6L_NODE ))
+		|| node == BGP_IPV6L_NODE || node == BGP_FLOWSPECV4_NODE
+		|| node == BGP_FLOWSPECV6_NODE))
 		return false;
 
 	return true;


### PR DESCRIPTION
As part of normal processing we allow bgp commands to walk
up the command node chain.  We are experiencing this crash:

Thread 1 "bgpd" received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
    assertion=0x7ffff7f3ba4f "set", file=0x7ffff7f3ba44 "lib/yang.c", line=413, function=<optimized out>)
    at assert.c:92
    line=413, function=0x7ffff7f3bc50 <__PRETTY_FUNCTION__.9> "yang_dnode_get") at assert.c:101
    vty=0x5555561715a0, argc=3, argv=0x555558601620) at bgpd/bgp_vty.c:9568
    cmd=0x0) at lib/command.c:937
    at lib/command.c:997
    matched=0x0, vtysh=0) at lib/command.c:1161
    at lib/vty.c:517
(gdb)

9582			bgp_glb_dnode = yang_dnode_get(vty->candidate_config->dnode,
(gdb) p vty->xpath
$8 = {
  "/frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-bgp:bgp'][name='bgp'][vrf='default']/frr-bgp:bgp", '\000' <repeats 897 times>, '\000' <repeats 1023 times>, '\000' <repeats 1023 times>,
  '\000' <repeats 1023 times>, '\000' <repeats 1023 times>, '\000' <repeats 1023 times>, '\000' <repeats 1023 times>,
  '\000' <repeats 1023 times>}
(gdb) p vty->xpath_index
$9 = 0
(gdb)

We are effectively sending in an array index based upon vty->xpath_index( which is zero) but
the VTY_CURR_XPATH macro subtracts 1 from that value to find the appropriate xpath to use.
This of course subtracts 1 from 0 and we underflow the array.

The relevant section in a config file is this:

address-family ipv6 flowspec
  bgp maxim...

Effectively we were trying to walk up the command chain for flowspec to see
if the command is entered correctly.  There is a function vty_check_node_for_xpath_decrement
that was looking at bgp sub-modes to make the decision to allow us to decrement
the vty->xpath_index which did not have the v4 or v6 flowspec bgp sub modes in the
check.

Adding them in fixes the problem.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>