### PR TITLE
Vtysh excessive/too little doc string re-instatement

### DIFF
--- a/lib/command_parse.y
+++ b/lib/command_parse.y
@@ -492,11 +492,11 @@ terminate_graph (CMD_YYLTYPE *locp, struct parser_ctx *ctx,
     graph_new_node (ctx->graph, (void *)element, NULL);
 
   if (ctx->docstr && strlen (ctx->docstr) > 1) {
-    zlog_debug ("Excessive docstring while parsing '%s'", ctx->el->string);
-    zlog_debug ("----------");
+    zlog_err ("Excessive docstring while parsing '%s'", ctx->el->string);
+    zlog_err ("----------");
     while (ctx->docstr && ctx->docstr[1] != '\0')
-      zlog_debug ("%s", strsep(&ctx->docstr, "\n"));
-    zlog_debug ("----------\n");
+      zlog_err ("%s", strsep(&ctx->docstr, "\n"));
+    zlog_err ("----------\n");
   }
 
   graph_add_edge (finalnode, end_token_node);
@@ -509,7 +509,7 @@ doc_next (struct parser_ctx *ctx)
   const char *piece = ctx->docstr ? strsep (&ctx->docstr, "\n") : "";
   if (*piece == 0x03)
   {
-    zlog_debug ("Ran out of docstring while parsing '%s'", ctx->el->string);
+    zlog_err ("Ran out of docstring while parsing '%s'", ctx->el->string);
     piece = "";
   }
 

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10155,8 +10155,8 @@ DEFUN (no_ospf_external_route_aggregation_no_adrvertise,
        "no summary-address A.B.C.D/M no-advertise",
        NO_STR
        "External summary address\n"
-       "Summary address prefix (a.b.c.d/m) \n"
-       "Adverise summary route to the AS \n.")
+       "Summary address prefix (a.b.c.d/m)\n"
+       "Advertise summary route to the AS \n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 	struct prefix_ipv4 p;


### PR DESCRIPTION
1) Fix an excess doc string issue in ospf
2) Fix an issue where vtysh had stopped outputing debug messages about this.