### PR TITLE
bgpd: fix SA warning

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3538,6 +3538,9 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	else
 		has_valid_label = bgp_is_valid_label(label);
 
+	if (has_valid_label)
+		assert(label != NULL);
+
 	/* The flag BGP_NODE_FIB_INSTALL_PENDING is for the following
 	 * condition :
 	 * Suppress fib is enabled


### PR DESCRIPTION
Fix a coverity warning about an obscure path involving labels (or try to fix it, with an assert).