### PR TITLE
bgpd: Respect `-e X` value for multipath

### DIFF
--- a/bgpd/bgp_nb_config.c
+++ b/bgpd/bgp_nb_config.c
@@ -9079,10 +9079,10 @@ int bgp_global_afi_safis_afi_safi_ipv4_unicast_use_multiple_paths_ebgp_maximum_p
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		maxpaths = yang_dnode_get_uint16(args->dnode, NULL);
-		if (maxpaths > MULTIPATH_NUM) {
+		if (maxpaths > multipath_num) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "maxpaths %u is out of range %u", maxpaths,
-				 MULTIPATH_NUM);
+				 multipath_num);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -9150,10 +9150,10 @@ int bgp_global_afi_safis_afi_safi_ipv4_unicast_use_multiple_paths_ibgp_maximum_p
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		maxpaths = yang_dnode_get_uint16(args->dnode, NULL);
-		if (maxpaths > MULTIPATH_NUM) {
+		if (maxpaths > multipath_num) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "maxpaths %u is out of range %u", maxpaths,
-				 MULTIPATH_NUM);
+				 multipath_num);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -10997,10 +10997,10 @@ int bgp_global_afi_safis_afi_safi_ipv6_unicast_use_multiple_paths_ebgp_maximum_p
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		maxpaths = yang_dnode_get_uint16(args->dnode, NULL);
-		if (maxpaths > MULTIPATH_NUM) {
+		if (maxpaths > multipath_num) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "maxpaths %u is out of range %u", maxpaths,
-				 MULTIPATH_NUM);
+				 multipath_num);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -11759,10 +11759,10 @@ int bgp_global_afi_safis_afi_safi_ipv4_labeled_unicast_use_multiple_paths_ebgp_m
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		maxpaths = yang_dnode_get_uint16(args->dnode, NULL);
-		if (maxpaths > MULTIPATH_NUM) {
+		if (maxpaths > multipath_num) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "maxpaths %u is out of range %u", maxpaths,
-				 MULTIPATH_NUM);
+				 multipath_num);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -11997,10 +11997,10 @@ int bgp_global_afi_safis_afi_safi_ipv6_labeled_unicast_use_multiple_paths_ebgp_m
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		maxpaths = yang_dnode_get_uint16(args->dnode, NULL);
-		if (maxpaths > MULTIPATH_NUM) {
+		if (maxpaths > multipath_num) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "maxpaths %u is out of range %u", maxpaths,
-				 MULTIPATH_NUM);
+				 multipath_num);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -12027,10 +12027,10 @@ int bgp_global_afi_safis_afi_safi_ipv6_labeled_unicast_use_multiple_paths_ibgp_m
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		maxpaths = yang_dnode_get_uint16(args->dnode, NULL);
-		if (maxpaths > MULTIPATH_NUM) {
+		if (maxpaths > multipath_num) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "maxpaths %u is out of range %u", maxpaths,
-				 MULTIPATH_NUM);
+				 multipath_num);
 			return NB_ERR_VALIDATION;
 		}
 		break;


### PR DESCRIPTION
When entering values for maximum-path if the user
has entered a value to respect from the bgp cli `-e X`
that is the maximum value we should use when accepting
values from the user.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>