### PR TITLE
ospfd: reset mpls-te prior to ospf router removal

### DIFF
--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -126,6 +126,8 @@ void ospf_opaque_term(void)
 
 void ospf_opaque_finish(void)
 {
+	ospf_mpls_te_finish();
+
 	ospf_router_info_finish();
 
 	ospf_ext_finish();

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -187,6 +187,7 @@ void ospf_mpls_te_finish(void)
 	// list_delete_all_node(OspfMplsTE.iflist);
 
 	OspfMplsTE.enabled = false;
+	ospf_mpls_te_unregister();
 	OspfMplsTE.inter_as = Off;
 }
 
@@ -2228,6 +2229,17 @@ DEFUN (no_ospf_mpls_te,
 	for (ALL_LIST_ELEMENTS(OspfMplsTE.iflist, node, nnode, lp))
 		if (CHECK_FLAG(lp->flags, LPFLG_LSA_ENGAGED))
 			ospf_mpls_te_lsa_schedule(lp, FLUSH_THIS_LSA);
+
+	/*
+	 * This resets the OspfMplsTE.inter_as to its initial state.
+	 * This is to avoid having an inter-as value different from
+	 * Off when mpls-te gets restarted (after being removed)
+	 */
+	if (OspfMplsTE.inter_as != Off) {
+		/* Deregister the Callbacks for Inter-AS support */
+		ospf_mpls_te_unregister();
+		OspfMplsTE.inter_as = Off;
+	}
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
This commits attempts to fix a problem that occurs when mpls-te gets
removed from ospfd config. Mpls-te has an inter-as option, which can be
set to Off/Area/AS. Whenever the inter-as takes "Area" or "AS" as a
value, this value will not be cleaned after removing mpls-te or after
removing the ospf router. Therefore, if mpls-te is configured with
inter-as AS or Area and we remove mpls-te or the ospf router, the
inter-as will still preserve its value; therefore, next time mpls-te is
enabled, it will automatically inherits the previous inter-as value
(either Area or AS). This leads to wrong configuration, which can be a
problem for frr_reload.py.
The commits forces mpls-te to reset inter-as to Off before it mpls-te
gets removed from the configuration and before the ospf router gets
removed.

Signed-off-by: Carlo Galiotto <carlo@voltanet.io>