### PR TITLE
*: Remove route_map_object_t from the system

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1003,8 +1003,7 @@ struct attr *bgp_attr_aggregate_intern(
 
 		SET_FLAG(bgp->peer_self->rmap_type, PEER_RMAP_TYPE_AGGREGATE);
 
-		ret = route_map_apply(aggregate->rmap.map, p, RMAP_BGP,
-				      &rmap_path);
+		ret = route_map_apply(aggregate->rmap.map, p, &rmap_path);
 
 		bgp->peer_self->rmap_type = 0;
 

--- a/bgpd/bgp_conditional_adv.c
+++ b/bgpd/bgp_conditional_adv.c
@@ -47,7 +47,7 @@ bgp_check_rmap_prefixes_in_bgp_table(struct bgp_table *table,
 
 			RESET_FLAG(dummy_attr.rmap_change_flags);
 
-			ret = route_map_apply(rmap, dest_p, RMAP_BGP, &path);
+			ret = route_map_apply(rmap, dest_p, &path);
 			if (ret != RMAP_PERMITMATCH)
 				bgp_attr_flush(&dummy_attr);
 			else {
@@ -112,7 +112,7 @@ static void bgp_conditional_adv_routes(struct peer *peer, afi_t afi,
 
 			RESET_FLAG(dummy_attr.rmap_change_flags);
 
-			if (route_map_apply(rmap, dest_p, RMAP_BGP, &path)
+			if (route_map_apply(rmap, dest_p, &path)
 			    != RMAP_PERMITMATCH) {
 				bgp_attr_flush(&dummy_attr);
 				continue;

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4201,7 +4201,7 @@ void bgp_evpn_advertise_type5_routes(struct bgp *bgp_vrf, afi_t afi,
 						bgp_vrf->adv_cmd_rmap[afi][safi]
 							.map,
 						bgp_dest_get_prefix(dest),
-						RMAP_BGP, &tmp_pi);
+						&tmp_pi);
 					if (ret == RMAP_DENYMATCH) {
 						bgp_attr_flush(&tmp_attr);
 						continue;

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -744,7 +744,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 		info.attr = &static_attr;
 		ret = route_map_apply(
 			bgp_vrf->vpn_policy[afi].rmap[BGP_VPN_POLICY_DIR_TOVPN],
-			p, RMAP_BGP, &info);
+			p, &info);
 		if (RMAP_DENYMATCH == ret) {
 			bgp_attr_flush(&static_attr); /* free any added parts */
 			if (debug)
@@ -1190,7 +1190,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 		info.extra = path_vpn->extra; /* Used for source-vrf filter */
 		ret = route_map_apply(bgp_vrf->vpn_policy[afi]
 					      .rmap[BGP_VPN_POLICY_DIR_FROMVPN],
-				      p, RMAP_BGP, &info);
+				      p, &info);
 		if (RMAP_DENYMATCH == ret) {
 			bgp_attr_flush(&static_attr); /* free any added parts */
 			if (debug)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1500,7 +1500,7 @@ static int bgp_input_modifier(struct peer *peer, const struct prefix *p,
 		SET_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN);
 
 		/* Apply BGP route map to the attribute. */
-		ret = route_map_apply(rmap, p, RMAP_BGP, &rmap_path);
+		ret = route_map_apply(rmap, p, &rmap_path);
 
 		peer->rmap_type = 0;
 
@@ -1551,7 +1551,7 @@ static int bgp_output_modifier(struct peer *peer, const struct prefix *p,
 	SET_FLAG(peer->rmap_type, PEER_RMAP_TYPE_OUT);
 
 	/* Apply BGP route map to the attribute. */
-	ret = route_map_apply(rmap, p, RMAP_BGP, &rmap_path);
+	ret = route_map_apply(rmap, p, &rmap_path);
 
 	peer->rmap_type = rmap_type;
 
@@ -2047,10 +2047,10 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 
 		if (bgp_path_suppressed(pi))
 			ret = route_map_apply(UNSUPPRESS_MAP(filter), p,
-					      RMAP_BGP, &rmap_path);
+					      &rmap_path);
 		else
 			ret = route_map_apply(ROUTE_MAP_OUT(filter), p,
-					      RMAP_BGP, &rmap_path);
+					      &rmap_path);
 
 		peer->rmap_type = 0;
 
@@ -2633,7 +2633,7 @@ static void bgp_process_evpn_route_injection(struct bgp *bgp, afi_t afi,
 			RESET_FLAG(dummy_attr.rmap_change_flags);
 
 			ret = route_map_apply(bgp->adv_cmd_rmap[afi][safi].map,
-					      p, RMAP_BGP, &rmap_path);
+					      p, &rmap_path);
 
 			if (ret == RMAP_DENYMATCH) {
 				bgp_attr_flush(&dummy_attr);
@@ -5215,8 +5215,7 @@ void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 
 		SET_FLAG(bgp->peer_self->rmap_type, PEER_RMAP_TYPE_NETWORK);
 
-		ret = route_map_apply(bgp_static->rmap.map, p, RMAP_BGP,
-				      &rmap_path);
+		ret = route_map_apply(bgp_static->rmap.map, p, &rmap_path);
 
 		bgp->peer_self->rmap_type = 0;
 
@@ -5535,8 +5534,7 @@ static void bgp_static_update_safi(struct bgp *bgp, const struct prefix *p,
 
 		SET_FLAG(bgp->peer_self->rmap_type, PEER_RMAP_TYPE_NETWORK);
 
-		ret = route_map_apply(bgp_static->rmap.map, p, RMAP_BGP,
-				      &rmap_path);
+		ret = route_map_apply(bgp_static->rmap.map, p, &rmap_path);
 
 		bgp->peer_self->rmap_type = 0;
 
@@ -6387,7 +6385,7 @@ static bool aggr_suppress_map_test(struct bgp *bgp,
 	rmap_path.attr = &attr;
 
 	SET_FLAG(bgp->peer_self->rmap_type, PEER_RMAP_TYPE_AGGREGATE);
-	rmr = route_map_apply(aggregate->suppress_map, p, RMAP_BGP, &rmap_path);
+	rmr = route_map_apply(aggregate->suppress_map, p, &rmap_path);
 	bgp->peer_self->rmap_type = 0;
 
 	bgp_attr_flush(&attr);
@@ -7845,8 +7843,7 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 			SET_FLAG(bgp->peer_self->rmap_type,
 				 PEER_RMAP_TYPE_REDISTRIBUTE);
 
-			ret = route_map_apply(red->rmap.map, p, RMAP_BGP,
-					      &rmap_path);
+			ret = route_map_apply(red->rmap.map, p, &rmap_path);
 
 			bgp->peer_self->rmap_type = 0;
 
@@ -10392,8 +10389,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				path.peer = pi->peer;
 				path.attr = &dummy_attr;
 
-				ret = route_map_apply(rmap, dest_p, RMAP_BGP,
-						      &path);
+				ret = route_map_apply(rmap, dest_p, &path);
 				if (ret == RMAP_DENYMATCH)
 					continue;
 			}

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -244,8 +244,7 @@ struct bgp_match_peer_compiled {
     received in bgp_path_info->peer. If it is the same, or if the peer structure
     received is a peer_group containing it, returns RMAP_MATCH. */
 static enum route_map_cmd_result_t
-route_match_peer(void *rule, const struct prefix *prefix,
-		 route_map_object_t type, void *object)
+route_match_peer(void *rule, const struct prefix *prefix, void *object)
 {
 	struct bgp_match_peer_compiled *pc;
 	union sockunion *su;
@@ -255,56 +254,51 @@ route_match_peer(void *rule, const struct prefix *prefix,
 	struct peer *peer;
 	struct listnode *node, *nnode;
 
-	if (type == RMAP_BGP) {
-		pc = rule;
-		su = &pc->su;
-		peer = ((struct bgp_path_info *)object)->peer;
+	pc = rule;
+	su = &pc->su;
+	peer = ((struct bgp_path_info *)object)->peer;
 
-		if (pc->interface) {
-			if (!peer->conf_if)
-				return RMAP_NOMATCH;
-
-			if (strcmp(peer->conf_if, pc->interface) == 0)
-				return RMAP_MATCH;
-
+	if (pc->interface) {
+		if (!peer->conf_if)
 			return RMAP_NOMATCH;
-		}
 
-		/* If su='0.0.0.0' (command 'match peer local'), and it's a
-		   NETWORK,
-		    REDISTRIBUTE, AGGREGATE-ADDRESS or DEFAULT_GENERATED route
-		   => return RMAP_MATCH
-		   */
-		if (sockunion_same(su, &su_def)) {
-			int ret;
-			if (CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_NETWORK)
-			    || CHECK_FLAG(peer->rmap_type,
-					  PEER_RMAP_TYPE_REDISTRIBUTE)
-			    || CHECK_FLAG(peer->rmap_type,
-					  PEER_RMAP_TYPE_AGGREGATE)
-			    || CHECK_FLAG(peer->rmap_type,
-					  PEER_RMAP_TYPE_DEFAULT))
-				ret = RMAP_MATCH;
-			else
-				ret = RMAP_NOMATCH;
-			return ret;
-		}
+		if (strcmp(peer->conf_if, pc->interface) == 0)
+			return RMAP_MATCH;
 
-		if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
+		return RMAP_NOMATCH;
+	}
+
+	/* If su='0.0.0.0' (command 'match peer local'), and it's a
+	   NETWORK,
+	   REDISTRIBUTE, AGGREGATE-ADDRESS or DEFAULT_GENERATED route
+	   => return RMAP_MATCH
+	*/
+	if (sockunion_same(su, &su_def)) {
+		int ret;
+		if (CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_NETWORK)
+		    || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_REDISTRIBUTE)
+		    || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_AGGREGATE)
+		    || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_DEFAULT))
+			ret = RMAP_MATCH;
+		else
+			ret = RMAP_NOMATCH;
+		return ret;
+	}
+
+	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
+		if (sockunion_same(su, &peer->su))
+			return RMAP_MATCH;
+
+		return RMAP_NOMATCH;
+	} else {
+		group = peer->group;
+		for (ALL_LIST_ELEMENTS(group->peer, node, nnode, peer)) {
 			if (sockunion_same(su, &peer->su))
 				return RMAP_MATCH;
-
-			return RMAP_NOMATCH;
-		} else {
-			group = peer->group;
-			for (ALL_LIST_ELEMENTS(group->peer, node, nnode,
-					       peer)) {
-				if (sockunion_same(su, &peer->su))
-					return RMAP_MATCH;
-			}
-			return RMAP_NOMATCH;
 		}
+		return RMAP_NOMATCH;
 	}
+
 	return RMAP_NOMATCH;
 }
 
@@ -345,8 +339,7 @@ static const struct route_map_rule_cmd route_match_peer_cmd = {
 
 #if defined(HAVE_LUA)
 static enum route_map_cmd_result_t
-route_match_command(void *rule, const struct prefix *prefix,
-		    route_map_object_t type, void *object)
+route_match_command(void *rule, const struct prefix *prefix, void *object)
 {
 	int status = RMAP_NOMATCH;
 	u_int32_t locpref = 0;
@@ -443,12 +436,11 @@ static const struct route_map_rule_cmd route_match_command_cmd = {
 /* Match function should return 1 if match is success else return
    zero. */
 static enum route_map_cmd_result_t
-route_match_ip_address(void *rule, const struct prefix *prefix,
-		       route_map_object_t type, void *object)
+route_match_ip_address(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
 
-	if (type == RMAP_BGP && prefix->family == AF_INET) {
+	if (prefix->family == AF_INET) {
 		alist = access_list_lookup(AFI_IP, (char *)rule);
 		if (alist == NULL)
 			return RMAP_NOMATCH;
@@ -485,14 +477,13 @@ static const struct route_map_rule_cmd route_match_ip_address_cmd = {
 
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_ip_next_hop(void *rule, const struct prefix *prefix,
-			route_map_object_t type, void *object)
+route_match_ip_next_hop(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
 	struct bgp_path_info *path;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP && prefix->family == AF_INET) {
+	if (prefix->family == AF_INET) {
 		path = object;
 		p.family = AF_INET;
 		p.prefix = path->attr->nexthop;
@@ -534,15 +525,14 @@ static const struct route_map_rule_cmd route_match_ip_next_hop_cmd = {
 
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_ip_route_source(void *rule, const struct prefix *pfx,
-			    route_map_object_t type, void *object)
+route_match_ip_route_source(void *rule, const struct prefix *pfx, void *object)
 {
 	struct access_list *alist;
 	struct bgp_path_info *path;
 	struct peer *peer;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP && pfx->family == AF_INET) {
+	if (pfx->family == AF_INET) {
 		path = object;
 		peer = path->peer;
 
@@ -624,13 +614,9 @@ route_match_prefix_list_flowspec(afi_t afi, struct prefix_list *plist,
 
 static enum route_map_cmd_result_t
 route_match_address_prefix_list(void *rule, afi_t afi,
-				const struct prefix *prefix,
-				route_map_object_t type, void *object)
+				const struct prefix *prefix, void *object)
 {
 	struct prefix_list *plist;
-
-	if (type != RMAP_BGP)
-		return RMAP_NOMATCH;
 
 	plist = prefix_list_lookup(afi, (char *)rule);
 	if (plist == NULL)
@@ -645,10 +631,9 @@ route_match_address_prefix_list(void *rule, afi_t afi,
 
 static enum route_map_cmd_result_t
 route_match_ip_address_prefix_list(void *rule, const struct prefix *prefix,
-				   route_map_object_t type, void *object)
+				   void *object)
 {
-	return route_match_address_prefix_list(rule, AFI_IP, prefix, type,
-					       object);
+	return route_match_address_prefix_list(rule, AFI_IP, prefix, object);
 }
 
 static void *route_match_ip_address_prefix_list_compile(const char *arg)
@@ -673,13 +658,13 @@ static const struct route_map_rule_cmd
 
 static enum route_map_cmd_result_t
 route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
-				    route_map_object_t type, void *object)
+				    void *object)
 {
 	struct prefix_list *plist;
 	struct bgp_path_info *path;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP && prefix->family == AF_INET) {
+	if (prefix->family == AF_INET) {
 		path = object;
 		p.family = AF_INET;
 		p.prefix = path->attr->nexthop;
@@ -718,11 +703,11 @@ static const struct route_map_rule_cmd
 
 static enum route_map_cmd_result_t
 route_match_ip_next_hop_type(void *rule, const struct prefix *prefix,
-			     route_map_object_t type, void *object)
+			     void *object)
 {
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP && prefix->family == AF_INET) {
+	if (prefix->family == AF_INET) {
 		path = (struct bgp_path_info *)object;
 		if (!path)
 			return RMAP_NOMATCH;
@@ -759,16 +744,15 @@ static const struct route_map_rule_cmd
 /* `match ip route-source prefix-list PREFIX_LIST' */
 
 static enum route_map_cmd_result_t
-route_match_ip_route_source_prefix_list(void *rule,
-					const struct prefix *prefix,
-					route_map_object_t type, void *object)
+route_match_ip_route_source_prefix_list(void *rule, const struct prefix *prefix,
+					void *object)
 {
 	struct prefix_list *plist;
 	struct bgp_path_info *path;
 	struct peer *peer;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP && prefix->family == AF_INET) {
+	if (prefix->family == AF_INET) {
 		path = object;
 		peer = path->peer;
 
@@ -812,10 +796,9 @@ static const struct route_map_rule_cmd
 
 /* Match function should return 1 if match is success else 0 */
 static enum route_map_cmd_result_t
-route_match_evpn_default_route(void *rule, const struct prefix *p,
-			       route_map_object_t type, void *object)
+route_match_evpn_default_route(void *rule, const struct prefix *p, void *object)
 {
-	if (type == RMAP_BGP && is_evpn_prefix_default(p))
+	if (is_evpn_prefix_default(p))
 		return RMAP_MATCH;
 
 	return RMAP_NOMATCH;
@@ -835,30 +818,24 @@ static const struct route_map_rule_cmd
 /* Match function should return 1 if match is success else return
    zero. */
 static enum route_map_cmd_result_t
-route_match_mac_address(void *rule, const struct prefix *prefix,
-			route_map_object_t type, void *object)
+route_match_mac_address(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
 	struct prefix p;
 
-	if (type == RMAP_BGP) {
-		alist = access_list_lookup(AFI_L2VPN, (char *)rule);
-		if (alist == NULL)
-			return RMAP_NOMATCH;
+	alist = access_list_lookup(AFI_L2VPN, (char *)rule);
+	if (alist == NULL)
+		return RMAP_NOMATCH;
 
-		if (prefix->u.prefix_evpn.route_type != BGP_EVPN_MAC_IP_ROUTE)
-			return RMAP_NOMATCH;
+	if (prefix->u.prefix_evpn.route_type != BGP_EVPN_MAC_IP_ROUTE)
+		return RMAP_NOMATCH;
 
-		p.family = AF_ETHERNET;
-		p.prefixlen = ETH_ALEN * 8;
-		p.u.prefix_eth = prefix->u.prefix_evpn.macip_addr.mac;
+	p.family = AF_ETHERNET;
+	p.prefixlen = ETH_ALEN * 8;
+	p.u.prefix_eth = prefix->u.prefix_evpn.macip_addr.mac;
 
-		return (access_list_apply(alist, &p) == FILTER_DENY
-				? RMAP_NOMATCH
-				: RMAP_MATCH);
-	}
-
-	return RMAP_NOMATCH;
+	return (access_list_apply(alist, &p) == FILTER_DENY ? RMAP_NOMATCH
+							    : RMAP_MATCH);
 }
 
 /* Route map `mac address' match statement.  `arg' should be
@@ -889,43 +866,42 @@ static const struct route_map_rule_cmd route_match_mac_address_cmd = {
  * ...RMAP_NOOP to ignore this match check.
  */
 static enum route_map_cmd_result_t
-route_match_vni(void *rule, const struct prefix *prefix,
-		route_map_object_t type, void *object)
+route_match_vni(void *rule, const struct prefix *prefix, void *object)
 {
 	vni_t vni = 0;
 	unsigned int label_cnt = 0;
 	struct bgp_path_info *path = NULL;
 	struct prefix_evpn *evp = (struct prefix_evpn *) prefix;
 
-	if (type == RMAP_BGP) {
-		vni = *((vni_t *)rule);
-		path = (struct bgp_path_info *)object;
+	vni = *((vni_t *)rule);
+	path = (struct bgp_path_info *)object;
 
-		/*
-		 * This rmap filter is valid for vxlan tunnel type only.
-		 * For any other tunnel type, return noop to ignore
-		 * this check.
-		 */
-		if (path->attr->encap_tunneltype != BGP_ENCAP_TYPE_VXLAN)
-			return RMAP_NOOP;
+	/*
+	 * This rmap filter is valid for vxlan tunnel type only.
+	 * For any other tunnel type, return noop to ignore
+	 * this check.
+	 */
+	if (path->attr->encap_tunneltype != BGP_ENCAP_TYPE_VXLAN)
+		return RMAP_NOOP;
 
-		/*
-		 * Apply filter to type 1, 2, 5 routes only.
-		 * Other route types do not have vni label.
-		 */
-		if (evp && (evp->prefix.route_type != BGP_EVPN_AD_ROUTE &&
-			evp->prefix.route_type != BGP_EVPN_MAC_IP_ROUTE &&
-			evp->prefix.route_type != BGP_EVPN_IP_PREFIX_ROUTE))
-			return RMAP_NOOP;
+	/*
+	 * Apply filter to type 1, 2, 5 routes only.
+	 * Other route types do not have vni label.
+	 */
+	if (evp
+	    && (evp->prefix.route_type != BGP_EVPN_AD_ROUTE
+		&& evp->prefix.route_type != BGP_EVPN_MAC_IP_ROUTE
+		&& evp->prefix.route_type != BGP_EVPN_IP_PREFIX_ROUTE))
+		return RMAP_NOOP;
 
-		if (path->extra == NULL)
-			return RMAP_NOMATCH;
+	if (path->extra == NULL)
+		return RMAP_NOMATCH;
 
-		for ( ; label_cnt < BGP_MAX_LABELS &&
-			label_cnt < path->extra->num_labels; label_cnt++) {
-			if (vni == label2vni(&path->extra->label[label_cnt]))
-				return RMAP_MATCH;
-		}
+	for (;
+	     label_cnt < BGP_MAX_LABELS && label_cnt < path->extra->num_labels;
+	     label_cnt++) {
+		if (vni == label2vni(&path->extra->label[label_cnt]))
+			return RMAP_MATCH;
 	}
 
 	return RMAP_NOMATCH;
@@ -967,17 +943,14 @@ static const struct route_map_rule_cmd route_match_evpn_vni_cmd = {
 /* Match function should return 1 if match is success else return
    zero. */
 static enum route_map_cmd_result_t
-route_match_evpn_route_type(void *rule, const struct prefix *pfx,
-			    route_map_object_t type, void *object)
+route_match_evpn_route_type(void *rule, const struct prefix *pfx, void *object)
 {
 	uint8_t route_type = 0;
 
-	if (type == RMAP_BGP) {
-		route_type = *((uint8_t *)rule);
+	route_type = *((uint8_t *)rule);
 
-		if (route_type == pfx->u.prefix_evpn.route_type)
-			return RMAP_MATCH;
-	}
+	if (route_type == pfx->u.prefix_evpn.route_type)
+		return RMAP_MATCH;
 
 	return RMAP_NOMATCH;
 }
@@ -1017,28 +990,24 @@ static const struct route_map_rule_cmd route_match_evpn_route_type_cmd = {
 
 /* Match function should return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_rd(void *rule, const struct prefix *prefix,
-	       route_map_object_t type, void *object)
+route_match_rd(void *rule, const struct prefix *prefix, void *object)
 {
 	struct prefix_rd *prd_rule = NULL;
 	const struct prefix_rd *prd_route = NULL;
 	struct bgp_path_info *path = NULL;
 
-	if (type == RMAP_BGP) {
-		if (prefix->family != AF_EVPN)
-			return RMAP_NOMATCH;
+	if (prefix->family != AF_EVPN)
+		return RMAP_NOMATCH;
 
-		prd_rule = (struct prefix_rd *)rule;
-		path = (struct bgp_path_info *)object;
+	prd_rule = (struct prefix_rd *)rule;
+	path = (struct bgp_path_info *)object;
 
-		if (path->net == NULL || path->net->pdest == NULL)
-			return RMAP_NOMATCH;
+	if (path->net == NULL || path->net->pdest == NULL)
+		return RMAP_NOMATCH;
 
-		prd_route = (struct prefix_rd *)bgp_dest_get_prefix(
-			path->net->pdest);
-		if (memcmp(prd_route->val, prd_rule->val, ECOMMUNITY_SIZE) == 0)
-			return RMAP_MATCH;
-	}
+	prd_route = (struct prefix_rd *)bgp_dest_get_prefix(path->net->pdest);
+	if (memcmp(prd_route->val, prd_rule->val, ECOMMUNITY_SIZE) == 0)
+		return RMAP_MATCH;
 
 	return RMAP_NOMATCH;
 }
@@ -1077,26 +1046,24 @@ static const struct route_map_rule_cmd route_match_evpn_rd_cmd = {
 /* Route map commands for VRF route leak with source vrf matching */
 static enum route_map_cmd_result_t
 route_match_vrl_source_vrf(void *rule, const struct prefix *prefix,
-			   route_map_object_t type, void *object)
+			   void *object)
 {
 	struct bgp_path_info *path;
 	char *vrf_name;
 
-	if (type == RMAP_BGP) {
-		vrf_name = rule;
-		path = (struct bgp_path_info *)object;
+	vrf_name = rule;
+	path = (struct bgp_path_info *)object;
 
-		if (strncmp(vrf_name, "n/a", VRF_NAMSIZ) == 0)
-			return RMAP_NOMATCH;
+	if (strncmp(vrf_name, "n/a", VRF_NAMSIZ) == 0)
+		return RMAP_NOMATCH;
 
-		if (path->extra == NULL)
-			return RMAP_NOMATCH;
+	if (path->extra == NULL)
+		return RMAP_NOMATCH;
 
-		if (strncmp(vrf_name, vrf_id_to_name(
-				path->extra->bgp_orig->vrf_id), VRF_NAMSIZ)
-		    == 0)
-			return RMAP_MATCH;
-	}
+	if (strncmp(vrf_name, vrf_id_to_name(path->extra->bgp_orig->vrf_id),
+		    VRF_NAMSIZ)
+	    == 0)
+		return RMAP_MATCH;
 
 	return RMAP_NOMATCH;
 }
@@ -1127,22 +1094,18 @@ static const struct route_map_rule_cmd route_match_vrl_source_vrf_cmd = {
 
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_local_pref(void *rule, const struct prefix *prefix,
-		       route_map_object_t type, void *object)
+route_match_local_pref(void *rule, const struct prefix *prefix, void *object)
 {
 	uint32_t *local_pref;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		local_pref = rule;
-		path = object;
+	local_pref = rule;
+	path = object;
 
-		if (path->attr->local_pref == *local_pref)
-			return RMAP_MATCH;
-		else
-			return RMAP_NOMATCH;
-	}
-	return RMAP_NOMATCH;
+	if (path->attr->local_pref == *local_pref)
+		return RMAP_MATCH;
+	else
+		return RMAP_NOMATCH;
 }
 
 /*
@@ -1188,18 +1151,14 @@ static const struct route_map_rule_cmd route_match_local_pref_cmd = {
 
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_metric(void *rule, const struct prefix *prefix,
-		   route_map_object_t type, void *object)
+route_match_metric(void *rule, const struct prefix *prefix, void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		rv = rule;
-		path = object;
-		return route_value_match(rv, path->attr->med);
-	}
-	return RMAP_NOMATCH;
+	rv = rule;
+	path = object;
+	return route_value_match(rv, path->attr->med);
 }
 
 /* Route map commands for metric matching. */
@@ -1214,27 +1173,22 @@ static const struct route_map_rule_cmd route_match_metric_cmd = {
 
 /* Match function for as-path match.  I assume given object is */
 static enum route_map_cmd_result_t
-route_match_aspath(void *rule, const struct prefix *prefix,
-		   route_map_object_t type, void *object)
+route_match_aspath(void *rule, const struct prefix *prefix, void *object)
 {
 
 	struct as_list *as_list;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		as_list = as_list_lookup((char *)rule);
-		if (as_list == NULL)
-			return RMAP_NOMATCH;
+	as_list = as_list_lookup((char *)rule);
+	if (as_list == NULL)
+		return RMAP_NOMATCH;
 
-		path = object;
+	path = object;
 
-		/* Perform match. */
-		return ((as_list_apply(as_list, path->attr->aspath)
-			 == AS_FILTER_DENY)
-				? RMAP_NOMATCH
-				: RMAP_MATCH);
-	}
-	return RMAP_NOMATCH;
+	/* Perform match. */
+	return ((as_list_apply(as_list, path->attr->aspath) == AS_FILTER_DENY)
+			? RMAP_NOMATCH
+			: RMAP_MATCH);
 }
 
 /* Compile function for as-path match. */
@@ -1266,32 +1220,28 @@ struct rmap_community {
 
 /* Match function for community match. */
 static enum route_map_cmd_result_t
-route_match_community(void *rule, const struct prefix *prefix,
-		      route_map_object_t type, void *object)
+route_match_community(void *rule, const struct prefix *prefix, void *object)
 {
 	struct community_list *list;
 	struct bgp_path_info *path;
 	struct rmap_community *rcom = rule;
 
-	if (type == RMAP_BGP) {
-		path = object;
-		rcom = rule;
+	path = object;
+	rcom = rule;
 
-		list = community_list_lookup(bgp_clist, rcom->name,
-					     rcom->name_hash,
-					     COMMUNITY_LIST_MASTER);
-		if (!list)
-			return RMAP_NOMATCH;
+	list = community_list_lookup(bgp_clist, rcom->name, rcom->name_hash,
+				     COMMUNITY_LIST_MASTER);
+	if (!list)
+		return RMAP_NOMATCH;
 
-		if (rcom->exact) {
-			if (community_list_exact_match(path->attr->community,
-						       list))
-				return RMAP_MATCH;
-		} else {
-			if (community_list_match(path->attr->community, list))
-				return RMAP_MATCH;
-		}
+	if (rcom->exact) {
+		if (community_list_exact_match(path->attr->community, list))
+			return RMAP_MATCH;
+	} else {
+		if (community_list_match(path->attr->community, list))
+			return RMAP_MATCH;
 	}
+
 	return RMAP_NOMATCH;
 }
 
@@ -1355,34 +1305,27 @@ static const struct route_map_rule_cmd route_match_community_cmd = {
 
 /* Match function for lcommunity match. */
 static enum route_map_cmd_result_t
-route_match_lcommunity(void *rule, const struct prefix *prefix,
-		       route_map_object_t type, void *object)
+route_match_lcommunity(void *rule, const struct prefix *prefix, void *object)
 {
 	struct community_list *list;
 	struct bgp_path_info *path;
 	struct rmap_community *rcom = rule;
 
-	if (type == RMAP_BGP) {
-		path = object;
+	path = object;
 
-		list = community_list_lookup(bgp_clist, rcom->name,
-					     rcom->name_hash,
-					     LARGE_COMMUNITY_LIST_MASTER);
-		if (!list)
-			return RMAP_NOMATCH;
+	list = community_list_lookup(bgp_clist, rcom->name, rcom->name_hash,
+				     LARGE_COMMUNITY_LIST_MASTER);
+	if (!list)
+		return RMAP_NOMATCH;
 
-		if (rcom->exact) {
-			if (lcommunity_list_exact_match(
-						path->attr->lcommunity,
-						list))
-				return RMAP_MATCH;
-		} else {
-			if (lcommunity_list_match(
-						path->attr->lcommunity,
-						list))
-				return RMAP_MATCH;
-		}
+	if (rcom->exact) {
+		if (lcommunity_list_exact_match(path->attr->lcommunity, list))
+			return RMAP_MATCH;
+	} else {
+		if (lcommunity_list_match(path->attr->lcommunity, list))
+			return RMAP_MATCH;
 	}
+
 	return RMAP_NOMATCH;
 }
 
@@ -1431,25 +1374,22 @@ static const struct route_map_rule_cmd route_match_lcommunity_cmd = {
 
 /* Match function for extcommunity match. */
 static enum route_map_cmd_result_t
-route_match_ecommunity(void *rule, const struct prefix *prefix,
-		       route_map_object_t type, void *object)
+route_match_ecommunity(void *rule, const struct prefix *prefix, void *object)
 {
 	struct community_list *list;
 	struct bgp_path_info *path;
 	struct rmap_community *rcom = rule;
 
-	if (type == RMAP_BGP) {
-		path = object;
+	path = object;
 
-		list = community_list_lookup(bgp_clist, rcom->name,
-					     rcom->name_hash,
-					     EXTCOMMUNITY_LIST_MASTER);
-		if (!list)
-			return RMAP_NOMATCH;
+	list = community_list_lookup(bgp_clist, rcom->name, rcom->name_hash,
+				     EXTCOMMUNITY_LIST_MASTER);
+	if (!list)
+		return RMAP_NOMATCH;
 
-		if (ecommunity_list_match(path->attr->ecommunity, list))
-			return RMAP_MATCH;
-	}
+	if (ecommunity_list_match(path->attr->ecommunity, list))
+		return RMAP_MATCH;
+
 	return RMAP_NOMATCH;
 }
 
@@ -1487,19 +1427,16 @@ static const struct route_map_rule_cmd route_match_ecommunity_cmd = {
 
 /* `match origin' */
 static enum route_map_cmd_result_t
-route_match_origin(void *rule, const struct prefix *prefix,
-		   route_map_object_t type, void *object)
+route_match_origin(void *rule, const struct prefix *prefix, void *object)
 {
 	uint8_t *origin;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		origin = rule;
-		path = object;
+	origin = rule;
+	path = object;
 
-		if (path->attr->origin == *origin)
-			return RMAP_MATCH;
-	}
+	if (path->attr->origin == *origin)
+		return RMAP_MATCH;
 
 	return RMAP_NOMATCH;
 }
@@ -1537,8 +1474,7 @@ static const struct route_map_rule_cmd route_match_origin_cmd = {
 /* match probability  { */
 
 static enum route_map_cmd_result_t
-route_match_probability(void *rule, const struct prefix *prefix,
-			route_map_object_t type, void *object)
+route_match_probability(void *rule, const struct prefix *prefix, void *object)
 {
 	long r = frr_weak_random();
 
@@ -1594,26 +1530,22 @@ static const struct route_map_rule_cmd route_match_probability_cmd = {
 /* Match function should return 1 if match is success else return
    zero. */
 static enum route_map_cmd_result_t
-route_match_interface(void *rule, const struct prefix *prefix,
-		      route_map_object_t type, void *object)
+route_match_interface(void *rule, const struct prefix *prefix, void *object)
 {
 	struct interface *ifp;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		path = object;
+	path = object;
 
-		if (!path)
-			return RMAP_NOMATCH;
+	if (!path)
+		return RMAP_NOMATCH;
 
-		ifp = if_lookup_by_name_all_vrf((char *)rule);
+	ifp = if_lookup_by_name_all_vrf((char *)rule);
 
-		if (ifp == NULL || ifp->ifindex != path->attr->nh_ifindex)
-			return RMAP_NOMATCH;
+	if (ifp == NULL || ifp->ifindex != path->attr->nh_ifindex)
+		return RMAP_NOMATCH;
 
-		return RMAP_MATCH;
-	}
-	return RMAP_NOMATCH;
+	return RMAP_MATCH;
 }
 
 /* Route map `interface' match statement.  `arg' should be
@@ -1643,20 +1575,15 @@ static const struct route_map_rule_cmd route_match_interface_cmd = {
 
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_tag(void *rule, const struct prefix *prefix,
-		route_map_object_t type, void *object)
+route_match_tag(void *rule, const struct prefix *prefix, void *object)
 {
 	route_tag_t *tag;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		tag = rule;
-		path = object;
+	tag = rule;
+	path = object;
 
-		return ((path->attr->tag == *tag) ? RMAP_MATCH : RMAP_NOMATCH);
-	}
-
-	return RMAP_NOMATCH;
+	return ((path->attr->tag == *tag) ? RMAP_MATCH : RMAP_NOMATCH);
 }
 
 
@@ -1669,14 +1596,10 @@ static const struct route_map_rule_cmd route_match_tag_cmd = {
 };
 
 static enum route_map_cmd_result_t
-route_set_srte_color(void *rule, const struct prefix *prefix,
-		     route_map_object_t type, void *object)
+route_set_srte_color(void *rule, const struct prefix *prefix, void *object)
 {
 	uint32_t *srte_color = rule;
 	struct bgp_path_info *path;
-
-	if (type != RMAP_BGP)
-		return RMAP_OKAY;
 
 	path = object;
 
@@ -1716,15 +1639,11 @@ struct rmap_ip_nexthop_set {
 };
 
 static enum route_map_cmd_result_t
-route_set_ip_nexthop(void *rule, const struct prefix *prefix,
-		     route_map_object_t type, void *object)
+route_set_ip_nexthop(void *rule, const struct prefix *prefix, void *object)
 {
 	struct rmap_ip_nexthop_set *rins = rule;
 	struct bgp_path_info *path;
 	struct peer *peer;
-
-	if (type != RMAP_BGP)
-		return RMAP_OKAY;
 
 	if (prefix->family == AF_INET6)
 		return RMAP_OKAY;
@@ -1824,26 +1743,22 @@ static const struct route_map_rule_cmd route_set_ip_nexthop_cmd = {
 
 /* Set local preference. */
 static enum route_map_cmd_result_t
-route_set_local_pref(void *rule, const struct prefix *prefix,
-		     route_map_object_t type, void *object)
+route_set_local_pref(void *rule, const struct prefix *prefix, void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
 	uint32_t locpref = 0;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		rv = rule;
-		path = object;
+	/* Fetch routemap's rule information. */
+	rv = rule;
+	path = object;
 
-		/* Set local preference value. */
-		if (path->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF))
-			locpref = path->attr->local_pref;
+	/* Set local preference value. */
+	if (path->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF))
+		locpref = path->attr->local_pref;
 
-		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF);
-		path->attr->local_pref =
-			route_value_adjust(rv, locpref, path->peer);
-	}
+	path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF);
+	path->attr->local_pref = route_value_adjust(rv, locpref, path->peer);
 
 	return RMAP_OKAY;
 }
@@ -1860,20 +1775,17 @@ static const struct route_map_rule_cmd route_set_local_pref_cmd = {
 
 /* Set weight. */
 static enum route_map_cmd_result_t
-route_set_weight(void *rule, const struct prefix *prefix,
-		 route_map_object_t type, void *object)
+route_set_weight(void *rule, const struct prefix *prefix, void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		rv = rule;
-		path = object;
+	/* Fetch routemap's rule information. */
+	rv = rule;
+	path = object;
 
-		/* Set weight value. */
-		path->attr->weight = route_value_adjust(rv, 0, path->peer);
-	}
+	/* Set weight value. */
+	path->attr->weight = route_value_adjust(rv, 0, path->peer);
 
 	return RMAP_OKAY;
 }
@@ -1888,14 +1800,10 @@ static const struct route_map_rule_cmd route_set_weight_cmd = {
 
 /* `set distance DISTANCE */
 static enum route_map_cmd_result_t
-route_set_distance(void *rule, const struct prefix *prefix,
-		   route_map_object_t type, void *object)
+route_set_distance(void *rule, const struct prefix *prefix, void *object)
 {
 	struct bgp_path_info *path = object;
 	struct rmap_value *rv = rule;
-
-	if (type != RMAP_BGP)
-		return RMAP_OKAY;
 
 	path->attr->distance = rv->value;
 
@@ -1914,24 +1822,22 @@ static const struct route_map_rule_cmd route_set_distance_cmd = {
 
 /* Set metric to attribute. */
 static enum route_map_cmd_result_t
-route_set_metric(void *rule, const struct prefix *prefix,
-		 route_map_object_t type, void *object)
+route_set_metric(void *rule, const struct prefix *prefix, void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
 	uint32_t med = 0;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		rv = rule;
-		path = object;
+	/* Fetch routemap's rule information. */
+	rv = rule;
+	path = object;
 
-		if (path->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC))
-			med = path->attr->med;
+	if (path->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC))
+		med = path->attr->med;
 
-		path->attr->med = route_value_adjust(rv, med, path->peer);
-		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC);
-	}
+	path->attr->med = route_value_adjust(rv, med, path->peer);
+	path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC);
+
 	return RMAP_OKAY;
 }
 
@@ -1945,21 +1851,20 @@ static const struct route_map_rule_cmd route_set_metric_cmd = {
 
 /* `set table (1-4294967295)' */
 
-static enum route_map_cmd_result_t route_set_table_id(void *rule,
-						      const struct prefix *prefix,
-						      route_map_object_t type,
-						      void *object)
+static enum route_map_cmd_result_t
+route_set_table_id(void *rule, const struct prefix *prefix,
+
+		   void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		rv = rule;
-		path = object;
+	/* Fetch routemap's rule information. */
+	rv = rule;
+	path = object;
 
-		path->attr->rmap_table_id = rv->value;
-	}
+	path->attr->rmap_table_id = rv->value;
+
 	return RMAP_OKAY;
 }
 
@@ -1975,33 +1880,30 @@ static const struct route_map_rule_cmd route_set_table_id_cmd = {
 
 /* For AS path prepend mechanism. */
 static enum route_map_cmd_result_t
-route_set_aspath_prepend(void *rule, const struct prefix *prefix,
-			 route_map_object_t type, void *object)
+route_set_aspath_prepend(void *rule, const struct prefix *prefix, void *object)
 {
 	struct aspath *aspath;
 	struct aspath *new;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		path = object;
+	path = object;
 
-		if (path->attr->aspath->refcnt)
-			new = aspath_dup(path->attr->aspath);
-		else
-			new = path->attr->aspath;
+	if (path->attr->aspath->refcnt)
+		new = aspath_dup(path->attr->aspath);
+	else
+		new = path->attr->aspath;
 
-		if ((uintptr_t)rule > 10) {
-			aspath = rule;
-			aspath_prepend(aspath, new);
-		} else {
-			as_t as = aspath_leftmost(new);
-			if (!as)
-				as = path->peer->as;
-			new = aspath_add_seq_n(new, as, (uintptr_t)rule);
-		}
-
-		path->attr->aspath = new;
+	if ((uintptr_t)rule > 10) {
+		aspath = rule;
+		aspath_prepend(aspath, new);
+	} else {
+		as_t as = aspath_leftmost(new);
+		if (!as)
+			as = path->peer->as;
+		new = aspath_add_seq_n(new, as, (uintptr_t)rule);
 	}
+
+	path->attr->aspath = new;
 
 	return RMAP_OKAY;
 }
@@ -2039,22 +1941,19 @@ static const struct route_map_rule_cmd route_set_aspath_prepend_cmd = {
  * Make a deep copy of existing AS_PATH, but for the first ASn only.
  */
 static enum route_map_cmd_result_t
-route_set_aspath_exclude(void *rule, const struct prefix *dummy,
-			 route_map_object_t type, void *object)
+route_set_aspath_exclude(void *rule, const struct prefix *dummy, void *object)
 {
 	struct aspath *new_path, *exclude_path;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		exclude_path = rule;
-		path = object;
-		if (path->attr->aspath->refcnt)
-			new_path = aspath_dup(path->attr->aspath);
-		else
-			new_path = path->attr->aspath;
-		path->attr->aspath =
-			aspath_filter_exclude(new_path, exclude_path);
-	}
+	exclude_path = rule;
+	path = object;
+	if (path->attr->aspath->refcnt)
+		new_path = aspath_dup(path->attr->aspath);
+	else
+		new_path = path->attr->aspath;
+	path->attr->aspath = aspath_filter_exclude(new_path, exclude_path);
+
 	return RMAP_OKAY;
 }
 
@@ -2075,8 +1974,7 @@ struct rmap_com_set {
 
 /* For community set mechanism. */
 static enum route_map_cmd_result_t
-route_set_community(void *rule, const struct prefix *prefix,
-		    route_map_object_t type, void *object)
+route_set_community(void *rule, const struct prefix *prefix, void *object)
 {
 	struct rmap_com_set *rcs;
 	struct bgp_path_info *path;
@@ -2085,44 +1983,42 @@ route_set_community(void *rule, const struct prefix *prefix,
 	struct community *old;
 	struct community *merge;
 
-	if (type == RMAP_BGP) {
-		rcs = rule;
-		path = object;
-		attr = path->attr;
-		old = attr->community;
+	rcs = rule;
+	path = object;
+	attr = path->attr;
+	old = attr->community;
 
-		/* "none" case.  */
-		if (rcs->none) {
-			attr->flag &= ~(ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES));
-			attr->community = NULL;
-			/* See the longer comment down below. */
-			if (old && old->refcnt == 0)
-				community_free(&old);
-			return RMAP_OKAY;
-		}
-
-		/* "additive" case.  */
-		if (rcs->additive && old) {
-			merge = community_merge(community_dup(old), rcs->com);
-
-			new = community_uniq_sort(merge);
-			community_free(&merge);
-		} else
-			new = community_dup(rcs->com);
-
-		/* HACK: if the old community is not intern'd,
-		 * we should free it here, or all reference to it may be
-		 * lost.
-		 * Really need to cleanup attribute caching sometime.
-		 */
+	/* "none" case.  */
+	if (rcs->none) {
+		attr->flag &= ~(ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES));
+		attr->community = NULL;
+		/* See the longer comment down below. */
 		if (old && old->refcnt == 0)
 			community_free(&old);
-
-		/* will be interned by caller if required */
-		attr->community = new;
-
-		attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES);
+		return RMAP_OKAY;
 	}
+
+	/* "additive" case.  */
+	if (rcs->additive && old) {
+		merge = community_merge(community_dup(old), rcs->com);
+
+		new = community_uniq_sort(merge);
+		community_free(&merge);
+	} else
+		new = community_dup(rcs->com);
+
+	/* HACK: if the old community is not intern'd,
+	 * we should free it here, or all reference to it may be
+	 * lost.
+	 * Really need to cleanup attribute caching sometime.
+	 */
+	if (old && old->refcnt == 0)
+		community_free(&old);
+
+	/* will be interned by caller if required */
+	attr->community = new;
+
+	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES);
 
 	return RMAP_OKAY;
 }
@@ -2192,8 +2088,7 @@ struct rmap_lcom_set {
 
 /* For lcommunity set mechanism. */
 static enum route_map_cmd_result_t
-route_set_lcommunity(void *rule, const struct prefix *prefix,
-		     route_map_object_t type, void *object)
+route_set_lcommunity(void *rule, const struct prefix *prefix, void *object)
 {
 	struct rmap_lcom_set *rcs;
 	struct bgp_path_info *path;
@@ -2202,46 +2097,42 @@ route_set_lcommunity(void *rule, const struct prefix *prefix,
 	struct lcommunity *old;
 	struct lcommunity *merge;
 
-	if (type == RMAP_BGP) {
-		rcs = rule;
-		path = object;
-		attr = path->attr;
-		old = attr->lcommunity;
+	rcs = rule;
+	path = object;
+	attr = path->attr;
+	old = attr->lcommunity;
 
-		/* "none" case.  */
-		if (rcs->none) {
-			attr->flag &=
-				~(ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES));
-			attr->lcommunity = NULL;
+	/* "none" case.  */
+	if (rcs->none) {
+		attr->flag &= ~(ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES));
+		attr->lcommunity = NULL;
 
-			/* See the longer comment down below. */
-			if (old && old->refcnt == 0)
-				lcommunity_free(&old);
-			return RMAP_OKAY;
-		}
-
-		if (rcs->additive && old) {
-			merge = lcommunity_merge(lcommunity_dup(old),
-						 rcs->lcom);
-
-			new = lcommunity_uniq_sort(merge);
-			lcommunity_free(&merge);
-		} else
-			new = lcommunity_dup(rcs->lcom);
-
-		/* HACK: if the old large-community is not intern'd,
-		 * we should free it here, or all reference to it may be
-		 * lost.
-		 * Really need to cleanup attribute caching sometime.
-		 */
+		/* See the longer comment down below. */
 		if (old && old->refcnt == 0)
 			lcommunity_free(&old);
-
-		/* will be intern()'d or attr_flush()'d by bgp_update_main() */
-		attr->lcommunity = new;
-
-		attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES);
+		return RMAP_OKAY;
 	}
+
+	if (rcs->additive && old) {
+		merge = lcommunity_merge(lcommunity_dup(old), rcs->lcom);
+
+		new = lcommunity_uniq_sort(merge);
+		lcommunity_free(&merge);
+	} else
+		new = lcommunity_dup(rcs->lcom);
+
+	/* HACK: if the old large-community is not intern'd,
+	 * we should free it here, or all reference to it may be
+	 * lost.
+	 * Really need to cleanup attribute caching sometime.
+	 */
+	if (old && old->refcnt == 0)
+		lcommunity_free(&old);
+
+	/* will be intern()'d or attr_flush()'d by bgp_update_main() */
+	attr->lcommunity = new;
+
+	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES);
 
 	return RMAP_OKAY;
 }
@@ -2306,8 +2197,7 @@ static const struct route_map_rule_cmd route_set_lcommunity_cmd = {
 
 /* For large community set mechanism. */
 static enum route_map_cmd_result_t
-route_set_lcommunity_delete(void *rule, const struct prefix *pfx,
-			    route_map_object_t type, void *object)
+route_set_lcommunity_delete(void *rule, const struct prefix *pfx, void *object)
 {
 	struct community_list *list;
 	struct lcommunity *merge;
@@ -2316,40 +2206,36 @@ route_set_lcommunity_delete(void *rule, const struct prefix *pfx,
 	struct bgp_path_info *path;
 	struct rmap_community *rcom = rule;
 
-	if (type == RMAP_BGP) {
-		if (!rcom)
-			return RMAP_OKAY;
+	if (!rcom)
+		return RMAP_OKAY;
 
-		path = object;
-		list = community_list_lookup(bgp_clist, rcom->name,
-					     rcom->name_hash,
-					     LARGE_COMMUNITY_LIST_MASTER);
-		old = path->attr->lcommunity;
+	path = object;
+	list = community_list_lookup(bgp_clist, rcom->name, rcom->name_hash,
+				     LARGE_COMMUNITY_LIST_MASTER);
+	old = path->attr->lcommunity;
 
-		if (list && old) {
-			merge = lcommunity_list_match_delete(
-				lcommunity_dup(old), list);
-			new = lcommunity_uniq_sort(merge);
-			lcommunity_free(&merge);
+	if (list && old) {
+		merge = lcommunity_list_match_delete(lcommunity_dup(old), list);
+		new = lcommunity_uniq_sort(merge);
+		lcommunity_free(&merge);
 
-			/* HACK: if the old community is not intern'd,
-			 * we should free it here, or all reference to it may be
-			 * lost.
-			 * Really need to cleanup attribute caching sometime.
-			 */
-			if (old->refcnt == 0)
-				lcommunity_free(&old);
+		/* HACK: if the old community is not intern'd,
+		 * we should free it here, or all reference to it may be
+		 * lost.
+		 * Really need to cleanup attribute caching sometime.
+		 */
+		if (old->refcnt == 0)
+			lcommunity_free(&old);
 
-			if (new->size == 0) {
-				path->attr->lcommunity = NULL;
-				path->attr->flag &= ~ATTR_FLAG_BIT(
-					BGP_ATTR_LARGE_COMMUNITIES);
-				lcommunity_free(&new);
-			} else {
-				path->attr->lcommunity = new;
-				path->attr->flag |= ATTR_FLAG_BIT(
-					BGP_ATTR_LARGE_COMMUNITIES);
-			}
+		if (new->size == 0) {
+			path->attr->lcommunity = NULL;
+			path->attr->flag &=
+				~ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES);
+			lcommunity_free(&new);
+		} else {
+			path->attr->lcommunity = new;
+			path->attr->flag |=
+				ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES);
 		}
 	}
 
@@ -2399,7 +2285,7 @@ static const struct route_map_rule_cmd route_set_lcommunity_delete_cmd = {
 /* For community set mechanism. */
 static enum route_map_cmd_result_t
 route_set_community_delete(void *rule, const struct prefix *prefix,
-			   route_map_object_t type, void *object)
+			   void *object)
 {
 	struct community_list *list;
 	struct community *merge;
@@ -2408,40 +2294,35 @@ route_set_community_delete(void *rule, const struct prefix *prefix,
 	struct bgp_path_info *path;
 	struct rmap_community *rcom = rule;
 
-	if (type == RMAP_BGP) {
-		if (!rcom)
-			return RMAP_OKAY;
+	if (!rcom)
+		return RMAP_OKAY;
 
-		path = object;
-		list = community_list_lookup(bgp_clist, rcom->name,
-					     rcom->name_hash,
-					     COMMUNITY_LIST_MASTER);
-		old = path->attr->community;
+	path = object;
+	list = community_list_lookup(bgp_clist, rcom->name, rcom->name_hash,
+				     COMMUNITY_LIST_MASTER);
+	old = path->attr->community;
 
-		if (list && old) {
-			merge = community_list_match_delete(community_dup(old),
-							    list);
-			new = community_uniq_sort(merge);
-			community_free(&merge);
+	if (list && old) {
+		merge = community_list_match_delete(community_dup(old), list);
+		new = community_uniq_sort(merge);
+		community_free(&merge);
 
-			/* HACK: if the old community is not intern'd,
-			 * we should free it here, or all reference to it may be
-			 * lost.
-			 * Really need to cleanup attribute caching sometime.
-			 */
-			if (old->refcnt == 0)
-				community_free(&old);
+		/* HACK: if the old community is not intern'd,
+		 * we should free it here, or all reference to it may be
+		 * lost.
+		 * Really need to cleanup attribute caching sometime.
+		 */
+		if (old->refcnt == 0)
+			community_free(&old);
 
-			if (new->size == 0) {
-				path->attr->community = NULL;
-				path->attr->flag &=
-					~ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES);
-				community_free(&new);
-			} else {
-				path->attr->community = new;
-				path->attr->flag |=
-					ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES);
-			}
+		if (new->size == 0) {
+			path->attr->community = NULL;
+			path->attr->flag &=
+				~ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES);
+			community_free(&new);
+		} else {
+			path->attr->community = new;
+			path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES);
 		}
 	}
 
@@ -2489,42 +2370,39 @@ static const struct route_map_rule_cmd route_set_community_delete_cmd = {
 
 /* For community set mechanism.  Used by _rt and _soo. */
 static enum route_map_cmd_result_t
-route_set_ecommunity(void *rule, const struct prefix *prefix,
-		     route_map_object_t type, void *object)
+route_set_ecommunity(void *rule, const struct prefix *prefix, void *object)
 {
 	struct ecommunity *ecom;
 	struct ecommunity *new_ecom;
 	struct ecommunity *old_ecom;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		ecom = rule;
-		path = object;
+	ecom = rule;
+	path = object;
 
-		if (!ecom)
-			return RMAP_OKAY;
+	if (!ecom)
+		return RMAP_OKAY;
 
-		/* We assume additive for Extended Community. */
-		old_ecom = path->attr->ecommunity;
+	/* We assume additive for Extended Community. */
+	old_ecom = path->attr->ecommunity;
 
-		if (old_ecom) {
-			new_ecom = ecommunity_merge(ecommunity_dup(old_ecom),
-						    ecom);
+	if (old_ecom) {
+		new_ecom = ecommunity_merge(ecommunity_dup(old_ecom), ecom);
 
-			/* old_ecom->refcnt = 1 => owned elsewhere, e.g.
-			 * bgp_update_receive()
-			 *         ->refcnt = 0 => set by a previous route-map
-			 * statement */
-			if (!old_ecom->refcnt)
-				ecommunity_free(&old_ecom);
-		} else
-			new_ecom = ecommunity_dup(ecom);
+		/* old_ecom->refcnt = 1 => owned elsewhere, e.g.
+		 * bgp_update_receive()
+		 *         ->refcnt = 0 => set by a previous route-map
+		 * statement */
+		if (!old_ecom->refcnt)
+			ecommunity_free(&old_ecom);
+	} else
+		new_ecom = ecommunity_dup(ecom);
 
-		/* will be intern()'d or attr_flush()'d by bgp_update_main() */
-		path->attr->ecommunity = new_ecom;
+	/* will be intern()'d or attr_flush()'d by bgp_update_main() */
+	path->attr->ecommunity = new_ecom;
 
-		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES);
-	}
+	path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES);
+
 	return RMAP_OKAY;
 }
 
@@ -2588,8 +2466,7 @@ struct rmap_ecomm_lb_set {
 };
 
 static enum route_map_cmd_result_t
-route_set_ecommunity_lb(void *rule, const struct prefix *prefix,
-			route_map_object_t type, void *object)
+route_set_ecommunity_lb(void *rule, const struct prefix *prefix, void *object)
 {
 	struct rmap_ecomm_lb_set *rels = rule;
 	struct bgp_path_info *path;
@@ -2601,9 +2478,6 @@ route_set_ecommunity_lb(void *rule, const struct prefix *prefix,
 	struct ecommunity *new_ecom;
 	struct ecommunity *old_ecom;
 	as_t as;
-
-	if (type != RMAP_BGP)
-		return RMAP_OKAY;
 
 	path = object;
 	peer = path->peer;
@@ -2721,18 +2595,15 @@ struct route_map_rule_cmd route_set_ecommunity_lb_cmd = {
 
 /* For origin set. */
 static enum route_map_cmd_result_t
-route_set_origin(void *rule, const struct prefix *prefix,
-		 route_map_object_t type, void *object)
+route_set_origin(void *rule, const struct prefix *prefix, void *object)
 {
 	uint8_t *origin;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		origin = rule;
-		path = object;
+	origin = rule;
+	path = object;
 
-		path->attr->origin = *origin;
-	}
+	path->attr->origin = *origin;
 
 	return RMAP_OKAY;
 }
@@ -2772,15 +2643,12 @@ static const struct route_map_rule_cmd route_set_origin_cmd = {
 
 /* For atomic aggregate set. */
 static enum route_map_cmd_result_t
-route_set_atomic_aggregate(void *rule, const struct prefix *pfx,
-			   route_map_object_t type, void *object)
+route_set_atomic_aggregate(void *rule, const struct prefix *pfx, void *object)
 {
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		path = object;
-		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE);
-	}
+	path = object;
+	path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE);
 
 	return RMAP_OKAY;
 }
@@ -2812,20 +2680,17 @@ struct aggregator {
 };
 
 static enum route_map_cmd_result_t
-route_set_aggregator_as(void *rule, const struct prefix *prefix,
-			route_map_object_t type, void *object)
+route_set_aggregator_as(void *rule, const struct prefix *prefix, void *object)
 {
 	struct bgp_path_info *path;
 	struct aggregator *aggregator;
 
-	if (type == RMAP_BGP) {
-		path = object;
-		aggregator = rule;
+	path = object;
+	aggregator = rule;
 
-		path->attr->aggregator_as = aggregator->as;
-		path->attr->aggregator_addr = aggregator->address;
-		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR);
-	}
+	path->attr->aggregator_as = aggregator->as;
+	path->attr->aggregator_addr = aggregator->address;
+	path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR);
 
 	return RMAP_OKAY;
 }
@@ -2867,19 +2732,16 @@ static const struct route_map_rule_cmd route_set_aggregator_as_cmd = {
 
 /* Set tag to object. object must be pointer to struct bgp_path_info */
 static enum route_map_cmd_result_t
-route_set_tag(void *rule, const struct prefix *prefix,
-	      route_map_object_t type, void *object)
+route_set_tag(void *rule, const struct prefix *prefix, void *object)
 {
 	route_tag_t *tag;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		tag = rule;
-		path = object;
+	tag = rule;
+	path = object;
 
-		/* Set tag value */
-		path->attr->tag = *tag;
-	}
+	/* Set tag value */
+	path->attr->tag = *tag;
 
 	return RMAP_OKAY;
 }
@@ -2894,24 +2756,21 @@ static const struct route_map_rule_cmd route_set_tag_cmd = {
 
 /* Set label-index to object. object must be pointer to struct bgp_path_info */
 static enum route_map_cmd_result_t
-route_set_label_index(void *rule, const struct prefix *prefix,
-		      route_map_object_t type, void *object)
+route_set_label_index(void *rule, const struct prefix *prefix, void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
 	uint32_t label_index;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		rv = rule;
-		path = object;
+	/* Fetch routemap's rule information. */
+	rv = rule;
+	path = object;
 
-		/* Set label-index value. */
-		label_index = rv->value;
-		if (label_index) {
-			path->attr->label_index = label_index;
-			path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_PREFIX_SID);
-		}
+	/* Set label-index value. */
+	label_index = rv->value;
+	if (label_index) {
+		path->attr->label_index = label_index;
+		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_PREFIX_SID);
 	}
 
 	return RMAP_OKAY;
@@ -2928,12 +2787,11 @@ static const struct route_map_rule_cmd route_set_label_index_cmd = {
 /* `match ipv6 address IP_ACCESS_LIST' */
 
 static enum route_map_cmd_result_t
-route_match_ipv6_address(void *rule, const struct prefix *prefix,
-			 route_map_object_t type, void *object)
+route_match_ipv6_address(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
 
-	if (type == RMAP_BGP && prefix->family == AF_INET6) {
+	if (prefix->family == AF_INET6) {
 		alist = access_list_lookup(AFI_IP6, (char *)rule);
 		if (alist == NULL)
 			return RMAP_NOMATCH;
@@ -2966,25 +2824,19 @@ static const struct route_map_rule_cmd route_match_ipv6_address_cmd = {
 /* `match ipv6 next-hop IP_ADDRESS' */
 
 static enum route_map_cmd_result_t
-route_match_ipv6_next_hop(void *rule, const struct prefix *prefix,
-			  route_map_object_t type, void *object)
+route_match_ipv6_next_hop(void *rule, const struct prefix *prefix, void *object)
 {
 	struct in6_addr *addr = rule;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		path = object;
+	path = object;
 
-		if (IPV6_ADDR_SAME(&path->attr->mp_nexthop_global, addr))
-			return RMAP_MATCH;
+	if (IPV6_ADDR_SAME(&path->attr->mp_nexthop_global, addr))
+		return RMAP_MATCH;
 
-		if (path->attr->mp_nexthop_len
-			    == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL
-		    && IPV6_ADDR_SAME(&path->attr->mp_nexthop_local, rule))
-			return RMAP_MATCH;
-
-		return RMAP_NOMATCH;
-	}
+	if (path->attr->mp_nexthop_len == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL
+	    && IPV6_ADDR_SAME(&path->attr->mp_nexthop_local, rule))
+		return RMAP_MATCH;
 
 	return RMAP_NOMATCH;
 }
@@ -3020,22 +2872,17 @@ static const struct route_map_rule_cmd route_match_ipv6_next_hop_cmd = {
 /* `match ip next-hop IP_ADDRESS' */
 
 static enum route_map_cmd_result_t
-route_match_ipv4_next_hop(void *rule, const struct prefix *prefix,
-			  route_map_object_t type, void *object)
+route_match_ipv4_next_hop(void *rule, const struct prefix *prefix, void *object)
 {
 	struct in_addr *addr = rule;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		path = object;
+	path = object;
 
-		if (path->attr->nexthop.s_addr == addr->s_addr ||
-		    (path->attr->mp_nexthop_len == BGP_ATTR_NHLEN_IPV4 &&
-		     IPV4_ADDR_SAME(&path->attr->mp_nexthop_global_in, addr)))
-			return RMAP_MATCH;
-
-		return RMAP_NOMATCH;
-	}
+	if (path->attr->nexthop.s_addr == addr->s_addr
+	    || (path->attr->mp_nexthop_len == BGP_ATTR_NHLEN_IPV4
+		&& IPV4_ADDR_SAME(&path->attr->mp_nexthop_global_in, addr)))
+		return RMAP_MATCH;
 
 	return RMAP_NOMATCH;
 }
@@ -3072,10 +2919,9 @@ static const struct route_map_rule_cmd route_match_ipv4_next_hop_cmd = {
 
 static enum route_map_cmd_result_t
 route_match_ipv6_address_prefix_list(void *rule, const struct prefix *prefix,
-				     route_map_object_t type, void *object)
+				     void *object)
 {
-	return route_match_address_prefix_list(rule, AFI_IP6, prefix, type,
-					       object);
+	return route_match_address_prefix_list(rule, AFI_IP6, prefix, object);
 }
 
 static void *route_match_ipv6_address_prefix_list_compile(const char *arg)
@@ -3100,12 +2946,12 @@ static const struct route_map_rule_cmd
 
 static enum route_map_cmd_result_t
 route_match_ipv6_next_hop_type(void *rule, const struct prefix *prefix,
-			       route_map_object_t type, void *object)
+			       void *object)
 {
 	struct bgp_path_info *path;
 	struct in6_addr *addr = rule;
 
-	if (type == RMAP_BGP && prefix->family == AF_INET6) {
+	if (prefix->family == AF_INET6) {
 		path = (struct bgp_path_info *)object;
 		if (!path)
 			return RMAP_NOMATCH;
@@ -3114,6 +2960,7 @@ route_match_ipv6_next_hop_type(void *rule, const struct prefix *prefix,
 		    && !path->attr->nh_ifindex)
 			return RMAP_MATCH;
 	}
+
 	return RMAP_NOMATCH;
 }
 
@@ -3150,27 +2997,24 @@ static const struct route_map_rule_cmd
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
 static enum route_map_cmd_result_t
-route_set_ipv6_nexthop_global(void *rule, const struct prefix *p,
-			      route_map_object_t type, void *object)
+route_set_ipv6_nexthop_global(void *rule, const struct prefix *p, void *object)
 {
 	struct in6_addr *address;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		address = rule;
-		path = object;
+	/* Fetch routemap's rule information. */
+	address = rule;
+	path = object;
 
-		/* Set next hop value. */
-		path->attr->mp_nexthop_global = *address;
+	/* Set next hop value. */
+	path->attr->mp_nexthop_global = *address;
 
-		/* Set nexthop length. */
-		if (path->attr->mp_nexthop_len == 0)
-			path->attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
+	/* Set nexthop length. */
+	if (path->attr->mp_nexthop_len == 0)
+		path->attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
 
-		SET_FLAG(path->attr->rmap_change_flags,
-			 BATTR_RMAP_IPV6_GLOBAL_NHOP_CHANGED);
-	}
+	SET_FLAG(path->attr->rmap_change_flags,
+		 BATTR_RMAP_IPV6_GLOBAL_NHOP_CHANGED);
 
 	return RMAP_OKAY;
 }
@@ -3212,28 +3056,27 @@ static const struct route_map_rule_cmd
 /* Set next-hop preference value. */
 static enum route_map_cmd_result_t
 route_set_ipv6_nexthop_prefer_global(void *rule, const struct prefix *prefix,
-				     route_map_object_t type, void *object)
+				     void *object)
 {
 	struct bgp_path_info *path;
 	struct peer *peer;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		path = object;
-		peer = path->peer;
+	/* Fetch routemap's rule information. */
+	path = object;
+	peer = path->peer;
 
-		if (CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN)
-		    || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IMPORT)) {
-			/* Set next hop preference to global */
-			path->attr->mp_nexthop_prefer_global = true;
-			SET_FLAG(path->attr->rmap_change_flags,
-				 BATTR_RMAP_IPV6_PREFER_GLOBAL_CHANGED);
-		} else {
-			path->attr->mp_nexthop_prefer_global = false;
-			SET_FLAG(path->attr->rmap_change_flags,
-				 BATTR_RMAP_IPV6_PREFER_GLOBAL_CHANGED);
-		}
+	if (CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN)
+	    || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IMPORT)) {
+		/* Set next hop preference to global */
+		path->attr->mp_nexthop_prefer_global = true;
+		SET_FLAG(path->attr->rmap_change_flags,
+			 BATTR_RMAP_IPV6_PREFER_GLOBAL_CHANGED);
+	} else {
+		path->attr->mp_nexthop_prefer_global = false;
+		SET_FLAG(path->attr->rmap_change_flags,
+			 BATTR_RMAP_IPV6_PREFER_GLOBAL_CHANGED);
 	}
+
 	return RMAP_OKAY;
 }
 
@@ -3266,29 +3109,24 @@ static const struct route_map_rule_cmd
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
 static enum route_map_cmd_result_t
-route_set_ipv6_nexthop_local(void *rule, const struct prefix *p,
-			     route_map_object_t type, void *object)
+route_set_ipv6_nexthop_local(void *rule, const struct prefix *p, void *object)
 {
 	struct in6_addr *address;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		address = rule;
-		path = object;
+	/* Fetch routemap's rule information. */
+	address = rule;
+	path = object;
 
-		/* Set next hop value. */
-		path->attr->mp_nexthop_local = *address;
+	/* Set next hop value. */
+	path->attr->mp_nexthop_local = *address;
 
-		/* Set nexthop length. */
-		if (path->attr->mp_nexthop_len
-		    != BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
-			path->attr->mp_nexthop_len =
-				BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
+	/* Set nexthop length. */
+	if (path->attr->mp_nexthop_len != BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
+		path->attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
 
-		SET_FLAG(path->attr->rmap_change_flags,
-			 BATTR_RMAP_IPV6_LL_NHOP_CHANGED);
-	}
+	SET_FLAG(path->attr->rmap_change_flags,
+		 BATTR_RMAP_IPV6_LL_NHOP_CHANGED);
 
 	return RMAP_OKAY;
 }
@@ -3331,55 +3169,52 @@ static const struct route_map_rule_cmd
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
 static enum route_map_cmd_result_t
-route_set_ipv6_nexthop_peer(void *rule, const struct prefix *pfx,
-			    route_map_object_t type, void *object)
+route_set_ipv6_nexthop_peer(void *rule, const struct prefix *pfx, void *object)
 {
 	struct in6_addr peer_address;
 	struct bgp_path_info *path;
 	struct peer *peer;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		path = object;
-		peer = path->peer;
+	/* Fetch routemap's rule information. */
+	path = object;
+	peer = path->peer;
 
-		if ((CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN)
-		     || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IMPORT))
-		    && peer->su_remote
-		    && sockunion_family(peer->su_remote) == AF_INET6) {
-			peer_address = peer->su_remote->sin6.sin6_addr;
-			/* Set next hop value and length in attribute. */
-			if (IN6_IS_ADDR_LINKLOCAL(&peer_address)) {
-				path->attr->mp_nexthop_local = peer_address;
-				if (path->attr->mp_nexthop_len
-				    != BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
-					path->attr->mp_nexthop_len =
-						BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
-			} else {
-				path->attr->mp_nexthop_global = peer_address;
-				if (path->attr->mp_nexthop_len == 0)
-					path->attr->mp_nexthop_len =
-						BGP_ATTR_NHLEN_IPV6_GLOBAL;
-			}
-
-		} else if (CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_OUT)) {
-			/* The next hop value will be set as part of packet
-			 * rewrite.
-			 * Set the flags here to indicate that rewrite needs to
-			 * be done.
-			 * Also, clear the value - we clear both global and
-			 * link-local
-			 * nexthops, whether we send one or both is determined
-			 * elsewhere.
-			 */
-			SET_FLAG(path->attr->rmap_change_flags,
-				 BATTR_RMAP_NEXTHOP_PEER_ADDRESS);
-			/* clear next hop value. */
-			memset(&(path->attr->mp_nexthop_global), 0,
-			       sizeof(struct in6_addr));
-			memset(&(path->attr->mp_nexthop_local), 0,
-			       sizeof(struct in6_addr));
+	if ((CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN)
+	     || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IMPORT))
+	    && peer->su_remote
+	    && sockunion_family(peer->su_remote) == AF_INET6) {
+		peer_address = peer->su_remote->sin6.sin6_addr;
+		/* Set next hop value and length in attribute. */
+		if (IN6_IS_ADDR_LINKLOCAL(&peer_address)) {
+			path->attr->mp_nexthop_local = peer_address;
+			if (path->attr->mp_nexthop_len
+			    != BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
+				path->attr->mp_nexthop_len =
+					BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
+		} else {
+			path->attr->mp_nexthop_global = peer_address;
+			if (path->attr->mp_nexthop_len == 0)
+				path->attr->mp_nexthop_len =
+					BGP_ATTR_NHLEN_IPV6_GLOBAL;
 		}
+
+	} else if (CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_OUT)) {
+		/* The next hop value will be set as part of packet
+		 * rewrite.
+		 * Set the flags here to indicate that rewrite needs to
+		 * be done.
+		 * Also, clear the value - we clear both global and
+		 * link-local
+		 * nexthops, whether we send one or both is determined
+		 * elsewhere.
+		 */
+		SET_FLAG(path->attr->rmap_change_flags,
+			 BATTR_RMAP_NEXTHOP_PEER_ADDRESS);
+		/* clear next hop value. */
+		memset(&(path->attr->mp_nexthop_global), 0,
+		       sizeof(struct in6_addr));
+		memset(&(path->attr->mp_nexthop_local), 0,
+		       sizeof(struct in6_addr));
 	}
 
 	return RMAP_OKAY;
@@ -3414,21 +3249,18 @@ static const struct route_map_rule_cmd route_set_ipv6_nexthop_peer_cmd = {
 /* `set ipv4 vpn next-hop A.B.C.D' */
 
 static enum route_map_cmd_result_t
-route_set_vpnv4_nexthop(void *rule, const struct prefix *prefix,
-			route_map_object_t type, void *object)
+route_set_vpnv4_nexthop(void *rule, const struct prefix *prefix, void *object)
 {
 	struct in_addr *address;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		address = rule;
-		path = object;
+	/* Fetch routemap's rule information. */
+	address = rule;
+	path = object;
 
-		/* Set next hop value. */
-		path->attr->mp_nexthop_global_in = *address;
-		path->attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV4;
-	}
+	/* Set next hop value. */
+	path->attr->mp_nexthop_global_in = *address;
+	path->attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV4;
 
 	return RMAP_OKAY;
 }
@@ -3453,22 +3285,19 @@ static void *route_set_vpnv4_nexthop_compile(const char *arg)
 /* `set ipv6 vpn next-hop A.B.C.D' */
 
 static enum route_map_cmd_result_t
-route_set_vpnv6_nexthop(void *rule, const struct prefix *prefix,
-			route_map_object_t type, void *object)
+route_set_vpnv6_nexthop(void *rule, const struct prefix *prefix, void *object)
 {
 	struct in6_addr *address;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		/* Fetch routemap's rule information. */
-		address = rule;
-		path = object;
+	/* Fetch routemap's rule information. */
+	address = rule;
+	path = object;
 
-		/* Set next hop value. */
-		memcpy(&path->attr->mp_nexthop_global, address,
-		       sizeof(struct in6_addr));
-		path->attr->mp_nexthop_len = BGP_ATTR_NHLEN_VPNV6_GLOBAL;
-	}
+	/* Set next hop value. */
+	memcpy(&path->attr->mp_nexthop_global, address,
+	       sizeof(struct in6_addr));
+	path->attr->mp_nexthop_len = BGP_ATTR_NHLEN_VPNV6_GLOBAL;
 
 	return RMAP_OKAY;
 }
@@ -3514,19 +3343,16 @@ static const struct route_map_rule_cmd route_set_vpnv6_nexthop_cmd = {
 
 /* For origin set. */
 static enum route_map_cmd_result_t
-route_set_originator_id(void *rule, const struct prefix *prefix,
-			route_map_object_t type, void *object)
+route_set_originator_id(void *rule, const struct prefix *prefix, void *object)
 {
 	struct in_addr *address;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		address = rule;
-		path = object;
+	address = rule;
+	path = object;
 
-		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID);
-		path->attr->originator_id = *address;
-	}
+	path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID);
+	path->attr->originator_id = *address;
 
 	return RMAP_OKAY;
 }

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -124,7 +124,7 @@ static int is_running(void);
 static void route_match_free(void *rule);
 static enum route_map_cmd_result_t route_match(void *rule,
 					       const struct prefix *prefix,
-					       route_map_object_t type,
+
 					       void *object);
 static void *route_match_compile(const char *arg);
 static void revalidate_bgp_node(struct bgp_dest *dest, afi_t afi, safi_t safi);
@@ -213,20 +213,18 @@ static void ipv6_addr_to_host_byte_order(const uint32_t *src, uint32_t *dest)
 
 static enum route_map_cmd_result_t route_match(void *rule,
 					       const struct prefix *prefix,
-					       route_map_object_t type,
 					       void *object)
 {
 	int *rpki_status = rule;
 	struct bgp_path_info *path;
 
-	if (type == RMAP_BGP) {
-		path = object;
+	path = object;
 
-		if (rpki_validate_prefix(path->peer, path->attr, prefix)
-		    == *rpki_status) {
-			return RMAP_MATCH;
-		}
+	if (rpki_validate_prefix(path->peer, path->attr, prefix)
+	    == *rpki_status) {
+		return RMAP_MATCH;
 	}
+
 	return RMAP_NOMATCH;
 }
 

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -823,8 +823,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 
 				ret = route_map_apply(
 					peer->default_rmap[afi][safi].map,
-					bgp_dest_get_prefix(dest), RMAP_BGP,
-					&tmp_pi);
+					bgp_dest_get_prefix(dest), &tmp_pi);
 
 				if (ret == RMAP_DENYMATCH) {
 					bgp_attr_flush(&tmp_attr);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -918,7 +918,7 @@ static bool bgp_table_map_apply(struct route_map *map, const struct prefix *p,
 {
 	route_map_result_t ret;
 
-	ret = route_map_apply(map, p, RMAP_BGP, path);
+	ret = route_map_apply(map, p, path);
 	bgp_attr_flush(path->attr);
 
 	if (ret != RMAP_DENYMATCH)

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -290,7 +290,7 @@ void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
 		info.peer = peer;
 		info.attr = &hattr;
 		ret = route_map_apply(bgp->rfapi_cfg->routemap_export_bgp,
-				      prefix, RMAP_BGP, &info);
+				      prefix, &info);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
 			return;
@@ -1033,7 +1033,7 @@ void vnc_direct_bgp_add_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 						ret = route_map_apply(
 							rfgn->rfg
 								->routemap_export_bgp,
-							p, RMAP_BGP, &info);
+							p, &info);
 						if (ret == RMAP_DENYMATCH) {
 							bgp_attr_flush(&hattr);
 							continue;
@@ -1242,8 +1242,7 @@ static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 
 		info.peer = irfd->peer;
 		info.attr = &hattr;
-		ret = route_map_apply(rfg->routemap_export_bgp, p, RMAP_BGP,
-				      &info);
+		ret = route_map_apply(rfg->routemap_export_bgp, p, &info);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
 			vnc_zlog_debug_verbose(
@@ -1691,8 +1690,7 @@ void vnc_direct_bgp_rh_add_route(struct bgp *bgp, afi_t afi,
 		memset(&info, 0, sizeof(info));
 		info.peer = peer;
 		info.attr = &hattr;
-		ret = route_map_apply(hc->routemap_export_bgp, prefix, RMAP_BGP,
-				      &info);
+		ret = route_map_apply(hc->routemap_export_bgp, prefix, &info);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
 			return;
@@ -1917,8 +1915,7 @@ void vnc_direct_bgp_rh_vpn_enable(struct bgp *bgp, afi_t afi)
 						info.attr = &hattr;
 						ret = route_map_apply(
 							hc->routemap_export_bgp,
-							dest_p, RMAP_BGP,
-							&info);
+							dest_p, &info);
 						if (ret == RMAP_DENYMATCH) {
 							bgp_attr_flush(&hattr);
 							vnc_zlog_debug_verbose(

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -357,7 +357,7 @@ static int process_unicast_route(struct bgp *bgp,		 /* in */
 		memset(&info, 0, sizeof(info));
 		info.peer = peer;
 		info.attr = &hattr;
-		ret = route_map_apply(rmap, prefix, RMAP_BGP, &info);
+		ret = route_map_apply(rmap, prefix, &info);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
 			vnc_zlog_debug_verbose(
@@ -784,7 +784,7 @@ static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 		memset(&info, 0, sizeof(info));
 		info.peer = peer;
 		info.attr = &hattr;
-		ret = route_map_apply(rmap, prefix, RMAP_BGP, &info);
+		ret = route_map_apply(rmap, prefix, &info);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
 			vnc_zlog_debug_verbose(
@@ -977,7 +977,7 @@ static void vnc_import_bgp_add_route_mode_nvegroup(
 		memset(&path, 0, sizeof(path));
 		path.peer = peer;
 		path.attr = &hattr;
-		ret = route_map_apply(rmap, prefix, RMAP_BGP, &path);
+		ret = route_map_apply(rmap, prefix, &path);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
 			vnc_zlog_debug_verbose(

--- a/isisd/isis_redist.c
+++ b/isisd/isis_redist.c
@@ -167,8 +167,7 @@ static void isis_redist_update_ext_reach(struct isis_area *area, int level,
 	area_info.metric = redist->metric;
 
 	if (redist->map_name) {
-		map_ret =
-			route_map_apply(redist->map, p, RMAP_ISIS, &area_info);
+		map_ret = route_map_apply(redist->map, p, &area_info);
 		if (map_ret == RMAP_DENYMATCH)
 			area_info.distance = 255;
 	}

--- a/isisd/isis_routemap.c
+++ b/isisd/isis_routemap.c
@@ -49,13 +49,9 @@
 #include "isis_routemap.h"
 
 static enum route_map_cmd_result_t
-route_match_ip_address(void *rule, const struct prefix *prefix,
-		       route_map_object_t type, void *object)
+route_match_ip_address(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
-
-	if (type != RMAP_ISIS)
-		return RMAP_NOMATCH;
 
 	alist = access_list_lookup(AFI_IP, (char *)rule);
 	if (access_list_apply(alist, prefix) != FILTER_DENY)
@@ -85,12 +81,9 @@ static const struct route_map_rule_cmd route_match_ip_address_cmd = {
 
 static enum route_map_cmd_result_t
 route_match_ip_address_prefix_list(void *rule, const struct prefix *prefix,
-				   route_map_object_t type, void *object)
+				   void *object)
 {
 	struct prefix_list *plist;
-
-	if (type != RMAP_ISIS)
-		return RMAP_NOMATCH;
 
 	plist = prefix_list_lookup(AFI_IP, (char *)rule);
 	if (prefix_list_apply(plist, prefix) != PREFIX_DENY)
@@ -120,13 +113,9 @@ static const struct route_map_rule_cmd
 /* ------------------------------------------------------------*/
 
 static enum route_map_cmd_result_t
-route_match_ipv6_address(void *rule, const struct prefix *prefix,
-			 route_map_object_t type, void *object)
+route_match_ipv6_address(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
-
-	if (type != RMAP_ISIS)
-		return RMAP_NOMATCH;
 
 	alist = access_list_lookup(AFI_IP6, (char *)rule);
 	if (access_list_apply(alist, prefix) != FILTER_DENY)
@@ -156,12 +145,9 @@ static const struct route_map_rule_cmd route_match_ipv6_address_cmd = {
 
 static enum route_map_cmd_result_t
 route_match_ipv6_address_prefix_list(void *rule, const struct prefix *prefix,
-				     route_map_object_t type, void *object)
+				     void *object)
 {
 	struct prefix_list *plist;
-
-	if (type != RMAP_ISIS)
-		return RMAP_NOMATCH;
 
 	plist = prefix_list_lookup(AFI_IP6, (char *)rule);
 	if (prefix_list_apply(plist, prefix) != PREFIX_DENY)
@@ -191,18 +177,16 @@ static const struct route_map_rule_cmd
 /* ------------------------------------------------------------*/
 
 static enum route_map_cmd_result_t
-route_set_metric(void *rule, const struct prefix *prefix,
-		 route_map_object_t type, void *object)
+route_set_metric(void *rule, const struct prefix *prefix, void *object)
 {
 	uint32_t *metric;
 	struct isis_ext_info *info;
 
-	if (type == RMAP_ISIS) {
-		metric = rule;
-		info = object;
+	metric = rule;
+	info = object;
 
-		info->metric = *metric;
-	}
+	info->metric = *metric;
+
 	return RMAP_OKAY;
 }
 

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1530,8 +1530,7 @@ enum rmap_compile_rets route_map_delete_set(struct route_map_index *index,
 
 static enum route_map_cmd_result_t
 route_map_apply_match(struct route_map_rule_list *match_list,
-		      const struct prefix *prefix, route_map_object_t type,
-		      void *object)
+		      const struct prefix *prefix, void *object)
 {
 	enum route_map_cmd_result_t ret = RMAP_NOMATCH;
 	struct route_map_rule *match;
@@ -1555,7 +1554,7 @@ route_map_apply_match(struct route_map_rule_list *match_list,
 			 * If all result in NOOP, end-result is NOOP.
 			 */
 			ret = (*match->cmd->func_apply)(match->value, prefix,
-							type, object);
+							object);
 
 			/*
 			 * If the consolidated result of func_apply is:
@@ -1647,9 +1646,10 @@ static struct list *route_map_get_index_list(struct route_node **rn,
 /*
  * This function returns the route-map index that best matches the prefix.
  */
-static struct route_map_index *
-route_map_get_index(struct route_map *map, const struct prefix *prefix,
-		    route_map_object_t type, void *object, uint8_t *match_ret)
+static struct route_map_index *route_map_get_index(struct route_map *map,
+						   const struct prefix *prefix,
+						   void *object,
+						   uint8_t *match_ret)
 {
 	int ret = 0;
 	struct list *candidate_rmap_list = NULL;
@@ -1695,7 +1695,7 @@ route_map_get_index(struct route_map *map, const struct prefix *prefix,
 				break;
 
 			ret = route_map_apply_match(&index->match_list, prefix,
-						    type, object);
+						    object);
 
 			if (ret == RMAP_MATCH) {
 				*match_ret = ret;
@@ -2369,8 +2369,7 @@ void route_map_notify_pentry_dependencies(const char *affected_name,
    We need to make sure our route-map processing matches the above
 */
 route_map_result_t route_map_apply(struct route_map *map,
-				   const struct prefix *prefix,
-				   route_map_object_t type, void *object)
+				   const struct prefix *prefix, void *object)
 {
 	static int recursion = 0;
 	enum route_map_cmd_result_t match_ret = RMAP_NOMATCH;
@@ -2397,7 +2396,7 @@ route_map_result_t route_map_apply(struct route_map *map,
 
 	if ((!map->optimization_disabled)
 	    && (map->ipv4_prefix_table || map->ipv6_prefix_table)) {
-		index = route_map_get_index(map, prefix, type, object,
+		index = route_map_get_index(map, prefix, object,
 					    (uint8_t *)&match_ret);
 		if (index) {
 			if (rmap_debug)
@@ -2431,7 +2430,7 @@ route_map_result_t route_map_apply(struct route_map *map,
 			index->applied++;
 			/* Apply this index. */
 			match_ret = route_map_apply_match(&index->match_list,
-							  prefix, type, object);
+							  prefix, object);
 			if (rmap_debug) {
 				zlog_debug(
 					"Route-map: %s, sequence: %d, prefix: %pFX, result: %s",
@@ -2489,9 +2488,8 @@ route_map_result_t route_map_apply(struct route_map *map,
 					 * set succeeded or not. So, ignore
 					 * return code.
 					 */
-					(void) (*set->cmd->func_apply)(
-						set->value, prefix, type,
-						object);
+					(void)(*set->cmd->func_apply)(
+						set->value, prefix, object);
 
 				/* Call another route-map if available */
 				if (index->nextrm) {
@@ -2504,8 +2502,7 @@ route_map_result_t route_map_apply(struct route_map *map,
 					{
 						recursion++;
 						ret = route_map_apply(
-							nextrm, prefix, type,
-							object);
+							nextrm, prefix, object);
 						recursion--;
 					}
 

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -68,17 +68,6 @@ enum route_map_cmd_result_t {
 	RMAP_ERROR
 };
 
-
-typedef enum {
-	RMAP_RIP,
-	RMAP_RIPNG,
-	RMAP_OSPF,
-	RMAP_OSPF6,
-	RMAP_BGP,
-	RMAP_ZEBRA,
-	RMAP_ISIS,
-} route_map_object_t;
-
 typedef enum { RMAP_EXIT, RMAP_GOTO, RMAP_NEXT } route_map_end_t;
 
 typedef enum {
@@ -117,7 +106,6 @@ struct route_map_rule_cmd {
 	/* Function for value set or match. */
 	enum route_map_cmd_result_t (*func_apply)(void *rule,
 						  const struct prefix *prefix,
-						  route_map_object_t type,
 						  void *object);
 
 	/* Compile argument and return result as void *. */
@@ -299,7 +287,6 @@ struct route_map *route_map_lookup_warn_noexist(struct vty *vty, const char *nam
 /* Apply route map to the object. */
 extern route_map_result_t route_map_apply(struct route_map *map,
 					  const struct prefix *prefix,
-					  route_map_object_t object_type,
 					  void *object);
 
 extern void route_map_add_hook(void (*func)(const char *));

--- a/ospfd/ospf_routemap.c
+++ b/ospfd/ospf_routemap.c
@@ -127,27 +127,22 @@ static void ospf_route_map_event(const char *name)
 /* `match ip netxthop ' */
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_ip_nexthop(void *rule, const struct prefix *prefix,
-		       route_map_object_t type, void *object)
+route_match_ip_nexthop(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
 	struct external_info *ei = object;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_OSPF) {
-		p.family = AF_INET;
-		p.prefix = ei->nexthop;
-		p.prefixlen = IPV4_MAX_BITLEN;
+	p.family = AF_INET;
+	p.prefix = ei->nexthop;
+	p.prefixlen = IPV4_MAX_BITLEN;
 
-		alist = access_list_lookup(AFI_IP, (char *)rule);
-		if (alist == NULL)
-			return RMAP_NOMATCH;
+	alist = access_list_lookup(AFI_IP, (char *)rule);
+	if (alist == NULL)
+		return RMAP_NOMATCH;
 
-		return (access_list_apply(alist, &p) == FILTER_DENY
-				? RMAP_NOMATCH
-				: RMAP_MATCH);
-	}
-	return RMAP_NOMATCH;
+	return (access_list_apply(alist, &p) == FILTER_DENY ? RMAP_NOMATCH
+							    : RMAP_MATCH);
 }
 
 /* Route map `ip next-hop' match statement. `arg' should be
@@ -175,26 +170,22 @@ static const struct route_map_rule_cmd route_match_ip_nexthop_cmd = {
 
 static enum route_map_cmd_result_t
 route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
-				    route_map_object_t type, void *object)
+				    void *object)
 {
 	struct prefix_list *plist;
 	struct external_info *ei = object;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_OSPF) {
-		p.family = AF_INET;
-		p.prefix = ei->nexthop;
-		p.prefixlen = IPV4_MAX_BITLEN;
+	p.family = AF_INET;
+	p.prefix = ei->nexthop;
+	p.prefixlen = IPV4_MAX_BITLEN;
 
-		plist = prefix_list_lookup(AFI_IP, (char *)rule);
-		if (plist == NULL)
-			return RMAP_NOMATCH;
+	plist = prefix_list_lookup(AFI_IP, (char *)rule);
+	if (plist == NULL)
+		return RMAP_NOMATCH;
 
-		return (prefix_list_apply(plist, &p) == PREFIX_DENY
-				? RMAP_NOMATCH
-				: RMAP_MATCH);
-	}
-	return RMAP_NOMATCH;
+	return (prefix_list_apply(plist, &p) == PREFIX_DENY ? RMAP_NOMATCH
+							    : RMAP_MATCH);
 }
 
 static void *route_match_ip_next_hop_prefix_list_compile(const char *arg)
@@ -219,11 +210,11 @@ static const struct route_map_rule_cmd
 
 static enum route_map_cmd_result_t
 route_match_ip_next_hop_type(void *rule, const struct prefix *prefix,
-			     route_map_object_t type, void *object)
+			     void *object)
 {
 	struct external_info *ei = object;
 
-	if (type == RMAP_OSPF && prefix->family == AF_INET) {
+	if (prefix->family == AF_INET) {
 		ei = (struct external_info *)object;
 		if (!ei)
 			return RMAP_NOMATCH;
@@ -256,22 +247,17 @@ static const struct route_map_rule_cmd
 /* Match function should return 1 if match is success else return
    zero. */
 static enum route_map_cmd_result_t
-route_match_ip_address(void *rule, const struct prefix *prefix,
-		       route_map_object_t type, void *object)
+route_match_ip_address(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
 	/* struct prefix_ipv4 match; */
 
-	if (type == RMAP_OSPF) {
-		alist = access_list_lookup(AFI_IP, (char *)rule);
-		if (alist == NULL)
-			return RMAP_NOMATCH;
+	alist = access_list_lookup(AFI_IP, (char *)rule);
+	if (alist == NULL)
+		return RMAP_NOMATCH;
 
-		return (access_list_apply(alist, prefix) == FILTER_DENY
-				? RMAP_NOMATCH
-				: RMAP_MATCH);
-	}
-	return RMAP_NOMATCH;
+	return (access_list_apply(alist, prefix) == FILTER_DENY ? RMAP_NOMATCH
+								: RMAP_MATCH);
 }
 
 /* Route map `ip address' match statement.  `arg' should be
@@ -298,20 +284,16 @@ static const struct route_map_rule_cmd route_match_ip_address_cmd = {
 /* `match ip address prefix-list PREFIX_LIST' */
 static enum route_map_cmd_result_t
 route_match_ip_address_prefix_list(void *rule, const struct prefix *prefix,
-				   route_map_object_t type, void *object)
+				   void *object)
 {
 	struct prefix_list *plist;
 
-	if (type == RMAP_OSPF) {
-		plist = prefix_list_lookup(AFI_IP, (char *)rule);
-		if (plist == NULL)
-			return RMAP_NOMATCH;
+	plist = prefix_list_lookup(AFI_IP, (char *)rule);
+	if (plist == NULL)
+		return RMAP_NOMATCH;
 
-		return (prefix_list_apply(plist, prefix) == PREFIX_DENY
-				? RMAP_NOMATCH
-				: RMAP_MATCH);
-	}
-	return RMAP_NOMATCH;
+	return (prefix_list_apply(plist, prefix) == PREFIX_DENY ? RMAP_NOMATCH
+								: RMAP_MATCH);
 }
 
 static void *route_match_ip_address_prefix_list_compile(const char *arg)
@@ -336,22 +318,18 @@ static const struct route_map_rule_cmd
 /* Match function should return 1 if match is success else return
    zero. */
 static enum route_map_cmd_result_t
-route_match_interface(void *rule, const struct prefix *prefix,
-		      route_map_object_t type, void *object)
+route_match_interface(void *rule, const struct prefix *prefix, void *object)
 {
 	struct interface *ifp;
 	struct external_info *ei;
 
-	if (type == RMAP_OSPF) {
-		ei = object;
-		ifp = if_lookup_by_name_all_vrf((char *)rule);
+	ei = object;
+	ifp = if_lookup_by_name_all_vrf((char *)rule);
 
-		if (ifp == NULL || ifp->ifindex != ei->ifindex)
-			return RMAP_NOMATCH;
+	if (ifp == NULL || ifp->ifindex != ei->ifindex)
+		return RMAP_NOMATCH;
 
-		return RMAP_MATCH;
-	}
-	return RMAP_NOMATCH;
+	return RMAP_MATCH;
 }
 
 /* Route map `interface' match statement.  `arg' should be
@@ -377,20 +355,15 @@ static const struct route_map_rule_cmd route_match_interface_cmd = {
 
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_tag(void *rule, const struct prefix *prefix,
-		route_map_object_t type, void *object)
+route_match_tag(void *rule, const struct prefix *prefix, void *object)
 {
 	route_tag_t *tag;
 	struct external_info *ei;
 
-	if (type == RMAP_OSPF) {
-		tag = rule;
-		ei = object;
+	tag = rule;
+	ei = object;
 
-		return ((ei->tag == *tag) ? RMAP_MATCH : RMAP_NOMATCH);
-	}
-
-	return RMAP_NOMATCH;
+	return ((ei->tag == *tag) ? RMAP_MATCH : RMAP_NOMATCH);
 }
 
 /* Route map commands for tag matching. */
@@ -410,33 +383,31 @@ struct ospf_metric {
 /* `set metric METRIC' */
 /* Set metric to attribute. */
 static enum route_map_cmd_result_t
-route_set_metric(void *rule, const struct prefix *prefix,
-		 route_map_object_t type, void *object)
+route_set_metric(void *rule, const struct prefix *prefix, void *object)
 {
 	struct ospf_metric *metric;
 	struct external_info *ei;
 
-	if (type == RMAP_OSPF) {
-		/* Fetch routemap's rule information. */
-		metric = rule;
-		ei = object;
+	/* Fetch routemap's rule information. */
+	metric = rule;
+	ei = object;
 
-		/* Set metric out value. */
-		if (!metric->used)
-			return RMAP_OKAY;
+	/* Set metric out value. */
+	if (!metric->used)
+		return RMAP_OKAY;
 
-		ei->route_map_set.metric = DEFAULT_DEFAULT_METRIC;
+	ei->route_map_set.metric = DEFAULT_DEFAULT_METRIC;
 
-		if (metric->type == metric_increment)
-			ei->route_map_set.metric += metric->metric;
-		else if (metric->type == metric_decrement)
-			ei->route_map_set.metric -= metric->metric;
-		else if (metric->type == metric_absolute)
-			ei->route_map_set.metric = metric->metric;
+	if (metric->type == metric_increment)
+		ei->route_map_set.metric += metric->metric;
+	else if (metric->type == metric_decrement)
+		ei->route_map_set.metric -= metric->metric;
+	else if (metric->type == metric_absolute)
+		ei->route_map_set.metric = metric->metric;
 
-		if (ei->route_map_set.metric > OSPF_LS_INFINITY)
-			ei->route_map_set.metric = OSPF_LS_INFINITY;
-	}
+	if (ei->route_map_set.metric > OSPF_LS_INFINITY)
+		ei->route_map_set.metric = OSPF_LS_INFINITY;
+
 	return RMAP_OKAY;
 }
 
@@ -492,20 +463,18 @@ static const struct route_map_rule_cmd route_set_metric_cmd = {
 /* `set metric-type TYPE' */
 /* Set metric-type to attribute. */
 static enum route_map_cmd_result_t
-route_set_metric_type(void *rule, const struct prefix *prefix,
-		      route_map_object_t type, void *object)
+route_set_metric_type(void *rule, const struct prefix *prefix, void *object)
 {
 	uint32_t *metric_type;
 	struct external_info *ei;
 
-	if (type == RMAP_OSPF) {
-		/* Fetch routemap's rule information. */
-		metric_type = rule;
-		ei = object;
+	/* Fetch routemap's rule information. */
+	metric_type = rule;
+	ei = object;
 
-		/* Set metric out value. */
-		ei->route_map_set.metric_type = *metric_type;
-	}
+	/* Set metric out value. */
+	ei->route_map_set.metric_type = *metric_type;
+
 	return RMAP_OKAY;
 }
 
@@ -543,19 +512,16 @@ static const struct route_map_rule_cmd route_set_metric_type_cmd = {
 };
 
 static enum route_map_cmd_result_t
-route_set_tag(void *rule, const struct prefix *prefix, route_map_object_t type,
-	      void *object)
+route_set_tag(void *rule, const struct prefix *prefix, void *object)
 {
 	route_tag_t *tag;
 	struct external_info *ei;
 
-	if (type == RMAP_OSPF) {
-		tag = rule;
-		ei = object;
+	tag = rule;
+	ei = object;
 
-		/* Set tag value */
-		ei->tag = *tag;
-	}
+	/* Set tag value */
+	ei->tag = *tag;
 
 	return RMAP_OKAY;
 }

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -902,8 +902,7 @@ int ospf_external_info_apply_default_routemap(struct ospf *ospf,
 	if (red && ROUTEMAP_NAME(red)) {
 		route_map_result_t ret;
 
-		ret = route_map_apply(ROUTEMAP(red), (struct prefix *)p,
-				      RMAP_OSPF, ei);
+		ret = route_map_apply(ROUTEMAP(red), (struct prefix *)p, ei);
 
 		if (ret == RMAP_DENYMATCH) {
 			ei->route_map_set = save_values;
@@ -1056,8 +1055,7 @@ int ospf_redistribute_check(struct ospf *ospf, struct external_info *ei,
 	if (red && ROUTEMAP_NAME(red)) {
 		route_map_result_t ret;
 
-		ret = route_map_apply(ROUTEMAP(red), (struct prefix *)p,
-				      RMAP_OSPF, ei);
+		ret = route_map_apply(ROUTEMAP(red), (struct prefix *)p, ei);
 
 		if (ret == RMAP_DENYMATCH) {
 			ei->route_map_set = save_values;

--- a/ripd/rip_routemap.c
+++ b/ripd/rip_routemap.c
@@ -43,27 +43,23 @@ struct rip_metric_modifier {
 /* `match metric METRIC' */
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_metric(void *rule, const struct prefix *prefix,
-		   route_map_object_t type, void *object)
+route_match_metric(void *rule, const struct prefix *prefix, void *object)
 {
 	uint32_t *metric;
 	uint32_t check;
 	struct rip_info *rinfo;
 
-	if (type == RMAP_RIP) {
-		metric = rule;
-		rinfo = object;
+	metric = rule;
+	rinfo = object;
 
-		/* If external metric is available, the route-map should
-		   work on this one (for redistribute purpose)  */
-		check = (rinfo->external_metric) ? rinfo->external_metric
-						 : rinfo->metric;
-		if (check == *metric)
-			return RMAP_MATCH;
-		else
-			return RMAP_NOMATCH;
-	}
-	return RMAP_NOMATCH;
+	/* If external metric is available, the route-map should
+	   work on this one (for redistribute purpose)  */
+	check = (rinfo->external_metric) ? rinfo->external_metric
+					 : rinfo->metric;
+	if (check == *metric)
+		return RMAP_MATCH;
+	else
+		return RMAP_NOMATCH;
 }
 
 /* Route map `match metric' match statement. `arg' is METRIC value */
@@ -98,29 +94,25 @@ static const struct route_map_rule_cmd route_match_metric_cmd = {
 /* `match interface IFNAME' */
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_interface(void *rule, const struct prefix *prefix,
-		      route_map_object_t type, void *object)
+route_match_interface(void *rule, const struct prefix *prefix, void *object)
 {
 	struct rip_info *rinfo;
 	struct interface *ifp;
 	char *ifname;
 
-	if (type == RMAP_RIP) {
-		ifname = rule;
-		ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+	ifname = rule;
+	ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
 
-		if (!ifp)
-			return RMAP_NOMATCH;
+	if (!ifp)
+		return RMAP_NOMATCH;
 
-		rinfo = object;
+	rinfo = object;
 
-		if (rinfo->ifindex_out == ifp->ifindex
-		    || rinfo->nh.ifindex == ifp->ifindex)
-			return RMAP_MATCH;
-		else
-			return RMAP_NOMATCH;
-	}
-	return RMAP_NOMATCH;
+	if (rinfo->ifindex_out == ifp->ifindex
+	    || rinfo->nh.ifindex == ifp->ifindex)
+		return RMAP_MATCH;
+	else
+		return RMAP_NOMATCH;
 }
 
 /* Route map `match interface' match statement. `arg' is IFNAME value */
@@ -148,30 +140,25 @@ static const struct route_map_rule_cmd route_match_interface_cmd = {
 
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_ip_next_hop(void *rule, const struct prefix *prefix,
-			route_map_object_t type, void *object)
+route_match_ip_next_hop(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
 	struct rip_info *rinfo;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_RIP) {
-		rinfo = object;
-		p.family = AF_INET;
-		p.prefix = (rinfo->nh.gate.ipv4.s_addr != INADDR_ANY)
-				   ? rinfo->nh.gate.ipv4
-				   : rinfo->from;
-		p.prefixlen = IPV4_MAX_BITLEN;
+	rinfo = object;
+	p.family = AF_INET;
+	p.prefix = (rinfo->nh.gate.ipv4.s_addr != INADDR_ANY)
+			   ? rinfo->nh.gate.ipv4
+			   : rinfo->from;
+	p.prefixlen = IPV4_MAX_BITLEN;
 
-		alist = access_list_lookup(AFI_IP, (char *)rule);
-		if (alist == NULL)
-			return RMAP_NOMATCH;
+	alist = access_list_lookup(AFI_IP, (char *)rule);
+	if (alist == NULL)
+		return RMAP_NOMATCH;
 
-		return (access_list_apply(alist, &p) == FILTER_DENY
-				? RMAP_NOMATCH
-				: RMAP_MATCH);
-	}
-	return RMAP_NOMATCH;
+	return (access_list_apply(alist, &p) == FILTER_DENY ? RMAP_NOMATCH
+							    : RMAP_MATCH);
 }
 
 /* Route map `ip next-hop' match statement.  `arg' should be
@@ -199,29 +186,25 @@ static const struct route_map_rule_cmd route_match_ip_next_hop_cmd = {
 
 static enum route_map_cmd_result_t
 route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
-				    route_map_object_t type, void *object)
+				    void *object)
 {
 	struct prefix_list *plist;
 	struct rip_info *rinfo;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_RIP) {
-		rinfo = object;
-		p.family = AF_INET;
-		p.prefix = (rinfo->nh.gate.ipv4.s_addr != INADDR_ANY)
-				   ? rinfo->nh.gate.ipv4
-				   : rinfo->from;
-		p.prefixlen = IPV4_MAX_BITLEN;
+	rinfo = object;
+	p.family = AF_INET;
+	p.prefix = (rinfo->nh.gate.ipv4.s_addr != INADDR_ANY)
+			   ? rinfo->nh.gate.ipv4
+			   : rinfo->from;
+	p.prefixlen = IPV4_MAX_BITLEN;
 
-		plist = prefix_list_lookup(AFI_IP, (char *)rule);
-		if (plist == NULL)
-			return RMAP_NOMATCH;
+	plist = prefix_list_lookup(AFI_IP, (char *)rule);
+	if (plist == NULL)
+		return RMAP_NOMATCH;
 
-		return (prefix_list_apply(plist, &p) == PREFIX_DENY
-				? RMAP_NOMATCH
-				: RMAP_MATCH);
-	}
-	return RMAP_NOMATCH;
+	return (prefix_list_apply(plist, &p) == PREFIX_DENY ? RMAP_NOMATCH
+							    : RMAP_MATCH);
 }
 
 static void *route_match_ip_next_hop_prefix_list_compile(const char *arg)
@@ -246,11 +229,11 @@ static const struct route_map_rule_cmd
 
 static enum route_map_cmd_result_t
 route_match_ip_next_hop_type(void *rule, const struct prefix *prefix,
-			     route_map_object_t type, void *object)
+			     void *object)
 {
 	struct rip_info *rinfo;
 
-	if (type == RMAP_RIP && prefix->family == AF_INET) {
+	if (prefix->family == AF_INET) {
 		rinfo = (struct rip_info *)object;
 		if (!rinfo)
 			return RMAP_NOMATCH;
@@ -284,21 +267,16 @@ static const struct route_map_rule_cmd
 /* Match function should return 1 if match is success else return
    zero. */
 static enum route_map_cmd_result_t
-route_match_ip_address(void *rule, const struct prefix *prefix,
-		       route_map_object_t type, void *object)
+route_match_ip_address(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
 
-	if (type == RMAP_RIP) {
-		alist = access_list_lookup(AFI_IP, (char *)rule);
-		if (alist == NULL)
-			return RMAP_NOMATCH;
+	alist = access_list_lookup(AFI_IP, (char *)rule);
+	if (alist == NULL)
+		return RMAP_NOMATCH;
 
-		return (access_list_apply(alist, prefix) == FILTER_DENY
-				? RMAP_NOMATCH
-				: RMAP_MATCH);
-	}
-	return RMAP_NOMATCH;
+	return (access_list_apply(alist, prefix) == FILTER_DENY ? RMAP_NOMATCH
+								: RMAP_MATCH);
 }
 
 /* Route map `ip address' match statement.  `arg' should be
@@ -326,20 +304,16 @@ static const struct route_map_rule_cmd route_match_ip_address_cmd = {
 
 static enum route_map_cmd_result_t
 route_match_ip_address_prefix_list(void *rule, const struct prefix *prefix,
-				   route_map_object_t type, void *object)
+				   void *object)
 {
 	struct prefix_list *plist;
 
-	if (type == RMAP_RIP) {
-		plist = prefix_list_lookup(AFI_IP, (char *)rule);
-		if (plist == NULL)
-			return RMAP_NOMATCH;
+	plist = prefix_list_lookup(AFI_IP, (char *)rule);
+	if (plist == NULL)
+		return RMAP_NOMATCH;
 
-		return (prefix_list_apply(plist, prefix) == PREFIX_DENY
-				? RMAP_NOMATCH
-				: RMAP_MATCH);
-	}
-	return RMAP_NOMATCH;
+	return (prefix_list_apply(plist, prefix) == PREFIX_DENY ? RMAP_NOMATCH
+								: RMAP_MATCH);
 }
 
 static void *route_match_ip_address_prefix_list_compile(const char *arg)
@@ -363,25 +337,21 @@ static const struct route_map_rule_cmd
 /* `match tag TAG' */
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_tag(void *rule, const struct prefix *p, route_map_object_t type,
-		void *object)
+route_match_tag(void *rule, const struct prefix *p, void *object)
 {
 	route_tag_t *tag;
 	struct rip_info *rinfo;
 	route_tag_t rinfo_tag;
 
-	if (type == RMAP_RIP) {
-		tag = rule;
-		rinfo = object;
+	tag = rule;
+	rinfo = object;
 
-		/* The information stored by rinfo is host ordered. */
-		rinfo_tag = rinfo->tag;
-		if (rinfo_tag == *tag)
-			return RMAP_MATCH;
-		else
-			return RMAP_NOMATCH;
-	}
-	return RMAP_NOMATCH;
+	/* The information stored by rinfo is host ordered. */
+	rinfo_tag = rinfo->tag;
+	if (rinfo_tag == *tag)
+		return RMAP_MATCH;
+	else
+		return RMAP_NOMATCH;
 }
 
 /* Route map commands for tag matching. */
@@ -396,33 +366,30 @@ static const struct route_map_rule_cmd route_match_tag_cmd = {
 
 /* Set metric to attribute. */
 static enum route_map_cmd_result_t
-route_set_metric(void *rule, const struct prefix *prefix,
-		 route_map_object_t type, void *object)
+route_set_metric(void *rule, const struct prefix *prefix, void *object)
 {
-	if (type == RMAP_RIP) {
-		struct rip_metric_modifier *mod;
-		struct rip_info *rinfo;
+	struct rip_metric_modifier *mod;
+	struct rip_info *rinfo;
 
-		mod = rule;
-		rinfo = object;
+	mod = rule;
+	rinfo = object;
 
-		if (!mod->used)
-			return RMAP_OKAY;
+	if (!mod->used)
+		return RMAP_OKAY;
 
-		if (mod->type == metric_increment)
-			rinfo->metric_out += mod->metric;
-		else if (mod->type == metric_decrement)
-			rinfo->metric_out -= mod->metric;
-		else if (mod->type == metric_absolute)
-			rinfo->metric_out = mod->metric;
+	if (mod->type == metric_increment)
+		rinfo->metric_out += mod->metric;
+	else if (mod->type == metric_decrement)
+		rinfo->metric_out -= mod->metric;
+	else if (mod->type == metric_absolute)
+		rinfo->metric_out = mod->metric;
 
-		if ((signed int)rinfo->metric_out < 1)
-			rinfo->metric_out = 1;
-		if (rinfo->metric_out > RIP_METRIC_INFINITY)
-			rinfo->metric_out = RIP_METRIC_INFINITY;
+	if ((signed int)rinfo->metric_out < 1)
+		rinfo->metric_out = 1;
+	if (rinfo->metric_out > RIP_METRIC_INFINITY)
+		rinfo->metric_out = RIP_METRIC_INFINITY;
 
-		rinfo->metric_set = 1;
-	}
+	rinfo->metric_set = 1;
 	return RMAP_OKAY;
 }
 
@@ -495,22 +462,20 @@ static const struct route_map_rule_cmd route_set_metric_cmd = {
 /* `set ip next-hop IP_ADDRESS' */
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
-static enum route_map_cmd_result_t route_set_ip_nexthop(void *rule,
-						    const struct prefix *prefix,
-						    route_map_object_t type,
-						    void *object)
+static enum route_map_cmd_result_t
+route_set_ip_nexthop(void *rule, const struct prefix *prefix,
+
+		     void *object)
 {
 	struct in_addr *address;
 	struct rip_info *rinfo;
 
-	if (type == RMAP_RIP) {
-		/* Fetch routemap's rule information. */
-		address = rule;
-		rinfo = object;
+	/* Fetch routemap's rule information. */
+	address = rule;
+	rinfo = object;
 
-		/* Set next hop value. */
-		rinfo->nexthop_out = *address;
-	}
+	/* Set next hop value. */
+	rinfo->nexthop_out = *address;
 
 	return RMAP_OKAY;
 }
@@ -552,20 +517,17 @@ static const struct route_map_rule_cmd route_set_ip_nexthop_cmd = {
 
 /* Set tag to object.  ojbect must be pointer to struct attr. */
 static enum route_map_cmd_result_t
-route_set_tag(void *rule, const struct prefix *prefix, route_map_object_t type,
-	      void *object)
+route_set_tag(void *rule, const struct prefix *prefix, void *object)
 {
 	route_tag_t *tag;
 	struct rip_info *rinfo;
 
-	if (type == RMAP_RIP) {
-		/* Fetch routemap's rule information. */
-		tag = rule;
-		rinfo = object;
+	/* Fetch routemap's rule information. */
+	tag = rule;
+	rinfo = object;
 
-		/* Set next hop value. */
-		rinfo->tag_out = *tag;
-	}
+	/* Set next hop value. */
+	rinfo->tag_out = *tag;
 
 	return RMAP_OKAY;
 }

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -462,7 +462,7 @@ static void rip_rte_process(struct rte *rte, struct sockaddr_in *from,
 	if (ri->routemap[RIP_FILTER_IN]) {
 		/* The object should be of the type of rip_info */
 		ret = route_map_apply(ri->routemap[RIP_FILTER_IN],
-				      (struct prefix *)&p, RMAP_RIP, &newinfo);
+				      (struct prefix *)&p, &newinfo);
 
 		if (ret == RMAP_DENYMATCH) {
 			if (IS_RIP_DEBUG_PACKET)
@@ -2251,7 +2251,7 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 			if (ri->routemap[RIP_FILTER_OUT]) {
 				ret = route_map_apply(
 					ri->routemap[RIP_FILTER_OUT],
-					(struct prefix *)p, RMAP_RIP, rinfo);
+					(struct prefix *)p, rinfo);
 
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIP_DEBUG_PACKET)
@@ -2267,7 +2267,7 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 			    && rinfo->sub_type != RIP_ROUTE_INTERFACE) {
 				ret = route_map_apply(
 					rip->redist[rinfo->type].route_map.map,
-					(struct prefix *)p, RMAP_RIP, rinfo);
+					(struct prefix *)p, rinfo);
 
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIP_DEBUG_PACKET)

--- a/ripngd/ripng_routemap.c
+++ b/ripngd/ripng_routemap.c
@@ -39,21 +39,19 @@ struct rip_metric_modifier {
 /* `match metric METRIC' */
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_metric(void *rule, const struct prefix *prefix,
-		   route_map_object_t type, void *object)
+route_match_metric(void *rule, const struct prefix *prefix, void *object)
 {
 	uint32_t *metric;
 	struct ripng_info *rinfo;
 
-	if (type == RMAP_RIPNG) {
-		metric = rule;
-		rinfo = object;
+	metric = rule;
+	rinfo = object;
 
-		if (rinfo->metric == *metric)
-			return RMAP_MATCH;
-		else
-			return RMAP_NOMATCH;
-	}
+	if (rinfo->metric == *metric)
+		return RMAP_MATCH;
+	else
+		return RMAP_NOMATCH;
+
 	return RMAP_NOMATCH;
 }
 
@@ -89,27 +87,25 @@ static const struct route_map_rule_cmd route_match_metric_cmd = {
 /* `match interface IFNAME' */
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_interface(void *rule, const struct prefix *prefix,
-		      route_map_object_t type, void *object)
+route_match_interface(void *rule, const struct prefix *prefix, void *object)
 {
 	struct ripng_info *rinfo;
 	struct interface *ifp;
 	char *ifname;
 
-	if (type == RMAP_RIPNG) {
-		ifname = rule;
-		ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+	ifname = rule;
+	ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
 
-		if (!ifp)
-			return RMAP_NOMATCH;
+	if (!ifp)
+		return RMAP_NOMATCH;
 
-		rinfo = object;
+	rinfo = object;
 
-		if (rinfo->ifindex == ifp->ifindex)
-			return RMAP_MATCH;
-		else
-			return RMAP_NOMATCH;
-	}
+	if (rinfo->ifindex == ifp->ifindex)
+		return RMAP_MATCH;
+	else
+		return RMAP_NOMATCH;
+
 	return RMAP_NOMATCH;
 }
 
@@ -135,26 +131,23 @@ static const struct route_map_rule_cmd route_match_interface_cmd = {
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t route_match_tag(void *rule,
 						   const struct prefix *prefix,
-						   route_map_object_t type,
 						   void *object)
 {
 	route_tag_t *tag;
 	struct ripng_info *rinfo;
 	route_tag_t rinfo_tag;
 
-	if (type == RMAP_RIPNG) {
-		tag = rule;
-		rinfo = object;
+	tag = rule;
+	rinfo = object;
 
-		/* The information stored by rinfo is host ordered. */
-		rinfo_tag = rinfo->tag;
-		if (rinfo_tag == *tag)
-			return RMAP_MATCH;
-		else
-			return RMAP_NOMATCH;
-	}
-	return RMAP_NOMATCH;
+	/* The information stored by rinfo is host ordered. */
+	rinfo_tag = rinfo->tag;
+	if (rinfo_tag == *tag)
+		return RMAP_MATCH;
+	else
+		return RMAP_NOMATCH;
 }
+
 
 static const struct route_map_rule_cmd route_match_tag_cmd = {
 	"tag",
@@ -167,33 +160,31 @@ static const struct route_map_rule_cmd route_match_tag_cmd = {
 
 /* Set metric to attribute. */
 static enum route_map_cmd_result_t
-route_set_metric(void *rule, const struct prefix *prefix,
-		 route_map_object_t type, void *object)
+route_set_metric(void *rule, const struct prefix *prefix, void *object)
 {
-	if (type == RMAP_RIPNG) {
-		struct rip_metric_modifier *mod;
-		struct ripng_info *rinfo;
+	struct rip_metric_modifier *mod;
+	struct ripng_info *rinfo;
 
-		mod = rule;
-		rinfo = object;
+	mod = rule;
+	rinfo = object;
 
-		if (!mod->used)
-			return RMAP_OKAY;
+	if (!mod->used)
+		return RMAP_OKAY;
 
-		if (mod->type == metric_increment)
-			rinfo->metric_out += mod->metric;
-		else if (mod->type == metric_decrement)
-			rinfo->metric_out -= mod->metric;
-		else if (mod->type == metric_absolute)
-			rinfo->metric_out = mod->metric;
+	if (mod->type == metric_increment)
+		rinfo->metric_out += mod->metric;
+	else if (mod->type == metric_decrement)
+		rinfo->metric_out -= mod->metric;
+	else if (mod->type == metric_absolute)
+		rinfo->metric_out = mod->metric;
 
-		if (rinfo->metric_out < 1)
-			rinfo->metric_out = 1;
-		if (rinfo->metric_out > RIPNG_METRIC_INFINITY)
-			rinfo->metric_out = RIPNG_METRIC_INFINITY;
+	if (rinfo->metric_out < 1)
+		rinfo->metric_out = 1;
+	if (rinfo->metric_out > RIPNG_METRIC_INFINITY)
+		rinfo->metric_out = RIPNG_METRIC_INFINITY;
 
-		rinfo->metric_set = 1;
-	}
+	rinfo->metric_set = 1;
+
 	return RMAP_OKAY;
 }
 
@@ -265,20 +256,17 @@ static const struct route_map_rule_cmd route_set_metric_cmd = {
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
 static enum route_map_cmd_result_t
-route_set_ipv6_nexthop_local(void *rule, const struct prefix *p,
-			     route_map_object_t type, void *object)
+route_set_ipv6_nexthop_local(void *rule, const struct prefix *p, void *object)
 {
 	struct in6_addr *address;
 	struct ripng_info *rinfo;
 
-	if (type == RMAP_RIPNG) {
-		/* Fetch routemap's rule information. */
-		address = rule;
-		rinfo = object;
+	/* Fetch routemap's rule information. */
+	address = rule;
+	rinfo = object;
 
-		/* Set next hop value. */
-		rinfo->nexthop_out = *address;
-	}
+	/* Set next hop value. */
+	rinfo->nexthop_out = *address;
 
 	return RMAP_OKAY;
 }
@@ -321,20 +309,17 @@ static const struct route_map_rule_cmd
 
 /* Set tag to object.  ojbect must be pointer to struct attr. */
 static enum route_map_cmd_result_t
-route_set_tag(void *rule, const struct prefix *prefix, route_map_object_t type,
-	      void *object)
+route_set_tag(void *rule, const struct prefix *prefix, void *object)
 {
 	route_tag_t *tag;
 	struct ripng_info *rinfo;
 
-	if (type == RMAP_RIPNG) {
-		/* Fetch routemap's rule information. */
-		tag = rule;
-		rinfo = object;
+	/* Fetch routemap's rule information. */
+	tag = rule;
+	rinfo = object;
 
-		/* Set next hop value. */
-		rinfo->tag_out = *tag;
-	}
+	/* Set next hop value. */
+	rinfo->tag_out = *tag;
 
 	return RMAP_OKAY;
 }

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -748,8 +748,7 @@ static void ripng_route_process(struct rte *rte, struct sockaddr_in6 *from,
 	/* Modify entry. */
 	if (ri->routemap[RIPNG_FILTER_IN]) {
 		ret = route_map_apply(ri->routemap[RIPNG_FILTER_IN],
-				      (struct prefix *)&p, RMAP_RIPNG,
-				      &newinfo);
+				      (struct prefix *)&p, &newinfo);
 
 		if (ret == RMAP_DENYMATCH) {
 			if (IS_RIPNG_DEBUG_PACKET)
@@ -1661,7 +1660,7 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 			if (ri->routemap[RIPNG_FILTER_OUT]) {
 				ret = route_map_apply(
 					ri->routemap[RIPNG_FILTER_OUT],
-					(struct prefix *)p, RMAP_RIPNG, rinfo);
+					(struct prefix *)p, rinfo);
 
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIPNG_DEBUG_PACKET)
@@ -1677,7 +1676,7 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 				ret = route_map_apply(ripng->redist[rinfo->type]
 							      .route_map.map,
 						      (struct prefix *)p,
-						      RMAP_RIPNG, rinfo);
+						      rinfo);
 
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIPNG_DEBUG_PACKET)
@@ -1773,8 +1772,7 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 
 				ret = route_map_apply(
 					ri->routemap[RIPNG_FILTER_OUT],
-					(struct prefix *)p, RMAP_RIPNG,
-					&newinfo);
+					(struct prefix *)p, &newinfo);
 
 				if (ret == RMAP_DENYMATCH) {
 					if (IS_RIPNG_DEBUG_PACKET)


### PR DESCRIPTION
The route_map_object_t was being used to track what protocol we were
being called against.  But each protocol was only ever calling itself.
So we had a variable that was only ever being passed in from route_map_apply
that had to be carried against and everyone was testing if that variable
was for their own stack.

Clean up this route_map_object_t from the entire system.  We should
speed some stuff up.  Yes I know not a bunch but this will add up.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>