### PR TITLE
bgpd: Fix missed unlocks

### DIFF
--- a/bgpd/bgp_conditional_adv.c
+++ b/bgpd/bgp_conditional_adv.c
@@ -51,6 +51,7 @@ bgp_check_rmap_prefixes_in_bgp_table(struct bgp_table *table,
 			if (ret != RMAP_PERMITMATCH)
 				bgp_attr_flush(&dummy_attr);
 			else {
+				bgp_dest_unlock_node(dest);
 				if (BGP_DEBUG(update, UPDATE_OUT))
 					zlog_debug(
 						"%s: Condition map routes present in BGP table",

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2930,6 +2930,8 @@ static int install_uninstall_routes_for_vrf(struct bgp *bgp_vrf, int install)
 							evp,
 							vrf_id_to_name(
 								bgp_vrf->vrf_id));
+						bgp_dest_unlock_node(rd_dest);
+						bgp_dest_unlock_node(dest);
 						return ret;
 					}
 				}
@@ -3009,6 +3011,9 @@ static int install_uninstall_routes_for_vni(struct bgp *bgp,
 								? "MACIP"
 								: "IMET",
 							vpn->vni);
+
+						bgp_dest_unlock_node(rd_dest);
+						bgp_dest_unlock_node(dest);
 						return ret;
 					}
 				}

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -763,6 +763,9 @@ static int bgp_evpn_type4_remote_routes_import(struct bgp *bgp,
 						install ? "install"
 							: "uninstall",
 						evp, es->esi_str);
+
+					bgp_dest_unlock_node(rd_dest);
+					bgp_dest_unlock_node(dest);
 					return ret;
 				}
 			}

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -842,8 +842,10 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 					break;
 				}
 			}
-			if (ret == RMAP_PERMITMATCH)
+			if (ret == RMAP_PERMITMATCH) {
+				bgp_dest_unlock_node(dest);
 				break;
+			}
 		}
 		bgp->peer_self->rmap_type = 0;
 


### PR DESCRIPTION
When iterating over the bgp_dest table, using this pattern:

	for (dest = bgp_table_top(table); dest;
	     dest = bgp_route_next(dest)) {

If the code breaks or returns in the middle we will not have
properly unlocked the node as that bgp_table_top locks the top
dest and bgp_route_next locks the next dest and unlocks the old
dest.

From code inspection I have found a bunch of places that
we either return in the middle of or a break is issued.

Add appropriate unlocks.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>