### PR TITLE
Added socket read to bgp_bmp.c to fix https://github.com/FRRouting/fr…

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1251,6 +1251,33 @@ static int bmp_stats(struct thread *thread)
 	return 0;
 }
 
+/* read from the BMP socket to detect session termination */
+static int bmp_read(struct thread *t)
+{
+	struct bmp *bmp = THREAD_ARG(t);
+	char buf[1024];
+	ssize_t n;
+
+	bmp->t_read = NULL;
+
+	n = read(bmp->socket, buf, sizeof(buf));
+	if (n >= 1) {
+		zlog_info("bmp[%s]: unexpectedly received %zu bytes", bmp->remote, n);
+	} else if (n == 0) {
+		/* the TCP session was terminated by the far end */
+		bmp_wrerr(bmp, NULL, true);
+		return 0;
+	} else if (!(errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)) {
+		/* the TCP session experienced a fatal error, likely a timeout */
+		bmp_wrerr(bmp, NULL, false);
+		return -1;
+	}
+
+	thread_add_read(bm->master, bmp_read, bmp, bmp->socket, &bmp->t_read);
+
+	return 0;
+}
+
 static struct bmp *bmp_open(struct bmp_targets *bt, int bmp_sock)
 {
 	union sockunion su, *sumem;
@@ -1271,7 +1298,7 @@ static struct bmp *bmp_open(struct bmp_targets *bt, int bmp_sock)
 
 	set_nonblocking(bmp_sock);
 	set_cloexec(bmp_sock);
-	shutdown(bmp_sock, SHUT_RD);
+	//shutdown(bmp_sock, SHUT_RD);
 
 	sockunion2hostprefix(&su, &p);
 
@@ -1322,6 +1349,7 @@ static struct bmp *bmp_open(struct bmp_targets *bt, int bmp_sock)
 	bmp->state = BMP_PeerUp;
 	bmp->pullwr = pullwr_new(bm->master, bmp_sock, bmp, bmp_wrfill,
 			bmp_wrerr);
+	thread_add_read(bm->master, bmp_read, bmp, bmp_sock, &bmp->t_read);
 	bmp_send_initiation(bmp);
 
 	return bmp;
@@ -1353,6 +1381,8 @@ static void bmp_close(struct bmp *bmp)
 {
 	struct bmp_queue_entry *bqe;
 	struct bmp_mirrorq *bmq;
+	
+	THREAD_OFF(bmp->t_read);
 
 	if (bmp->active)
 		bmp_active_disconnected(bmp->active);


### PR DESCRIPTION
…r/issues/6623

This issue persists where FRR does not detect when the TCP session with a BMP monitoring station has died in some way.
In lab testing I also found that under normal circumstances (FRR and the monitoring station are stable), the BMP session eventually stalls after a random time, and never reconnects without restarting FRR.
This change fixes both. Sessions remain stable forever, shutdown immediately on BMP server loss, and recover immediately on BMP server recovery.

Tested and working well in production for me so far.