### PR TITLE
lib: When aborting log data

### DIFF
--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -250,6 +250,8 @@ core_handler(int signo, siginfo_t *siginfo, void *context)
 
 	/* dump memory stats on core */
 	log_memstats(stderr, "core_handler");
+
+	zlog_tls_buffer_fini();
 	abort();
 }
 


### PR DESCRIPTION
When a FRR process dies due to SIGILL/SIGABORT/etc attempt
to drain the log buffer.  This code change is capturing
some missing logs that were not part of the log file on
a crash.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>