### PR TITLE
evpn : add autort as option

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -512,7 +512,11 @@ static void form_auto_rt(struct bgp *bgp, vni_t vni, struct list *rtl)
 
 	if (bgp->advertise_autort_rfc8365)
 		vni |= EVPN_AUTORT_VXLAN;
-	encode_route_target_as((bgp->as & 0xFFFF), vni, &eval);
+	if (bgp->autort_as) {
+		encode_route_target_as((bgp->autort_as & 0xFFFF), vni, &eval);
+	} else {
+		encode_route_target_as((bgp->as & 0xFFFF), vni, &eval);
+	}
 
 	ecomadd = ecommunity_new();
 	ecommunity_add_val(ecomadd, &eval, false, false);
@@ -4238,7 +4242,11 @@ void evpn_rt_delete_auto(struct bgp *bgp, vni_t vni, struct list *rtl)
 
 	if (bgp->advertise_autort_rfc8365)
 		vni |= EVPN_AUTORT_VXLAN;
-	encode_route_target_as((bgp->as & 0xFFFF), vni, &eval);
+	if (bgp->autort_as) {
+		encode_route_target_as((bgp->autort_as & 0xFFFF), vni, &eval);
+	} else {
+		encode_route_target_as((bgp->as & 0xFFFF), vni, &eval);
+	}
 
 	ecom_auto = ecommunity_new();
 	ecommunity_add_val(ecom_auto, &eval, false, false);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -614,6 +614,9 @@ struct bgp {
 	/* EVPN - use RFC 8365 to auto-derive RT */
 	int advertise_autort_rfc8365;
 
+	/* EVPN - auto-derive RT AS */
+	uint16_t autort_as;
+
 	/*
 	 * Flooding mechanism for BUM packets for VxLAN-EVPN.
 	 */

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2574,6 +2574,32 @@ address-family:
 Ethernet Virtual Network - EVPN
 -------------------------------
 
+.. _bgp-evpn-route-target-auto-derivation:
+
+EVPN route target auto-derivation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+   When FRR learns about a local VNI and there is no explicit configuration
+   for that VNI in FRR, the route distinguisher (RD) and import
+   and export route targets (RTs) for this VNI are automatically derived;
+   the RD uses RouterId:VNI-Index and the import and export RTs use AS:VNI.
+
+.. index:: [no] autort rfc8365-compatible
+.. clicmd:: [no] autort rfc8365-compatible
+
+   RFC 8635 explains how RT auto-derivation should be done in section
+   5.1.2.1. In addition to encoding the VNI in the lowest bytes, a
+   3-bit field is used to encode a namespace. For VXLAN, we have to put 1
+   in this field. This is needed for proper interoperability with RT
+   auto-derivation in JunOS.
+
+.. index:: [no] autort as (1-65536)
+.. clicmd:: [no] autort as (1-65536)
+
+   By default, the auto derived AS (AS:VNI), use the bgp router AS.
+   This command allow to define another AS. Usefull for ebgp, when peers have
+   differents AS, but need to have same route-target AS:VNI.
+
 .. _bgp-evpn-advertise-pip:
 
 EVPN advertise-PIP

--- a/tests/topotests/bgp_evpn_autort/r1/bgpd.conf
+++ b/tests/topotests/bgp_evpn_autort/r1/bgpd.conf
@@ -1,0 +1,12 @@
+router bgp 65000
+  no bgp ebgp-requires-policy
+  neighbor 192.168.255.2 remote-as 65001
+  address-family ipv4 unicast
+   neighbor 192.168.255.2 activate
+  exit-address-family
+  !
+  address-family l2vpn evpn
+   neighbor 192.168.255.2 activate
+   advertise-all-vni
+  exit-address-family
+!

--- a/tests/topotests/bgp_evpn_autort/r1/zebra.conf
+++ b/tests/topotests/bgp_evpn_autort/r1/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r1-eth0
+  ip address 192.168.255.1/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_evpn_autort/r2/bgpd.conf
+++ b/tests/topotests/bgp_evpn_autort/r2/bgpd.conf
@@ -1,0 +1,12 @@
+router bgp 65001
+  no bgp ebgp-requires-policy
+  neighbor 192.168.255.1 remote-as 65000
+  address-family ipv4 unicast
+   neighbor 192.168.255.1 activate
+  exit-address-family
+  !
+  address-family l2vpn evpn
+   neighbor 192.168.255.1 activate
+   advertise-all-vni
+  exit-address-family
+!

--- a/tests/topotests/bgp_evpn_autort/r2/zebra.conf
+++ b/tests/topotests/bgp_evpn_autort/r2/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r2-eth0
+  ip address 192.168.255.2/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_evpn_autort/test_bgp_evpn_autort.py
+++ b/tests/topotests/bgp_evpn_autort/test_bgp_evpn_autort.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+
+#
+# bgp_evpn_autort.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2019 by
+# Alexandre Derumier <aderumier@odiso.com>
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+bgp_evpn_autort.py:
+
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from mininet.topo import Topo
+
+
+class TemplateTopo(Topo):
+    def build(self, *_args, **_opts):
+        tgen = get_topogen(self)
+
+        for routern in range(1, 3):
+            tgen.add_router("r{}".format(routern))
+
+        switch = tgen.add_switch("s1")
+        switch.add_link(tgen.gears["r1"])
+        switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(TemplateTopo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
+
+    tgen.start_router()
+
+    router = tgen.gears["r2"]
+
+    cmds_r2 = [  # config routing 101
+        "ip link add name bridge-101 up type bridge stp_state 0",
+        "ip link set bridge-101 master {}-vrf-101",
+        "ip link set dev bridge-101 up",
+        "ip link add name vxlan-101 type vxlan id 101 dstport 4789 dev r2-eth0 local 192.168.255.2",
+        "ip link set dev vxlan-101 master bridge-101",
+        "ip link set vxlan-101 up type bridge_slave learning off flood off mcast_flood off",
+    ]
+
+    for cmd in cmds_r2:
+        logger.info("cmd to r2: " + cmd.format("r2"))
+        output = router.run(cmd.format("r2"))
+        logger.info("result: " + output)
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_evpn_autort():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _verify_vni_65000(router):
+        output = json.loads(router.vtysh_cmd("sh bgp l2vpn evpn vni 101 json"))
+        expected = {
+            "vni":101,
+            "type":"L2",
+            "inKernel":"True",
+            "rd":"192.168.255.2:2",
+            "originatorIp":"192.168.255.2",
+            "mcastGroup":"0.0.0.0",
+            "advertiseGatewayMacip":"Disabled",
+            "advertiseSviMacIp":"Disabled",
+            "importRts":[
+              "65000:101"
+            ],
+            "exportRts":[
+              "65000:101"
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _verify_vni_65001(router):
+        output = json.loads(router.vtysh_cmd("sh bgp l2vpn evpn vni 101 json"))
+        expected = {
+            "vni":101,
+            "type":"L2",
+            "inKernel":"True",
+            "rd":"192.168.255.2:2",
+            "originatorIp":"192.168.255.2",
+            "mcastGroup":"0.0.0.0",
+            "advertiseGatewayMacip":"Disabled",
+            "advertiseSviMacIp":"Disabled",
+            "importRts":[
+              "65001:101"
+            ],
+            "exportRts":[
+              "65001:101"
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _verify_vni_65001_rfc8365(router):
+        output = json.loads(router.vtysh_cmd("sh bgp l2vpn evpn vni 101 json"))
+        expected = {
+            "vni":101,
+            "type":"L2",
+            "inKernel":"True",
+            "rd":"192.168.255.2:2",
+            "originatorIp":"192.168.255.2",
+            "mcastGroup":"0.0.0.0",
+            "advertiseGatewayMacip":"Disabled",
+            "advertiseSviMacIp":"Disabled",
+            "importRts":[
+              "65001:268435557"
+            ],
+            "exportRts":[
+              "65001:268435557"
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _remove_autort_as(router):
+        router.vtysh_cmd(
+            """
+          configure terminal
+            router bgp 65001
+              address-family l2vpn evpn
+                no autort as 65000
+        """
+        )
+
+    def _add_autort_as(router):
+        router.vtysh_cmd(
+            """
+          configure terminal
+            router bgp 65001
+              address-family l2vpn evpn
+                autort as 65000
+        """
+        )
+
+    def _add_autort_rfc8365(router):
+        router.vtysh_cmd(
+            """
+          configure terminal
+            router bgp 65001
+              address-family l2vpn evpn
+                autort rfc8365-compatible
+        """
+        )
+
+    def _remove_autort_rfc8365(router):
+        router.vtysh_cmd(
+            """
+          configure terminal
+            router bgp 65001
+              address-family l2vpn evpn
+                no autort rfc8365-compatible
+        """
+        )
+
+    router = tgen.gears["r2"]
+
+    test_func = functools.partial(_verify_vni_65001, router)
+    success, result = topotest.run_and_expect(test_func, None, count=15, wait=0.5)
+
+    assert result is None, 'wrong auto route-target "{}"'.format(
+        router
+    )
+
+    _add_autort_as(router)
+
+    test_func = functools.partial(_verify_vni_65000, router)
+    success, result = topotest.run_and_expect(test_func, None, count=15, wait=0.5)
+
+    assert result is None, 'wrong auto route-target "{}"'.format(router)
+
+    _remove_autort_as(router)
+
+    test_func = functools.partial(_verify_vni_65001, router)
+    success, result = topotest.run_and_expect(test_func, None, count=15, wait=0.5)
+
+    assert result is None, 'wrong auto route-target "{}"'.format(
+        router
+    )
+
+    _add_autort_rfc8365(router)
+
+    test_func = functools.partial(_verify_vni_65001_rfc8365, router)
+    success, result = topotest.run_and_expect(test_func, None, count=15, wait=0.5)
+
+    assert result is None, 'wrong auto route-target "{}"'.format(router)
+
+    _remove_autort_rfc8365(router)
+
+    test_func = functools.partial(_verify_vni_65001, router)
+    success, result = topotest.run_and_expect(test_func, None, count=15, wait=0.5)
+
+    assert result is None, 'wrong auto route-target "{}"'.format(
+        router
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Allow to defined a custom AS for autort

Usefull for evpn with ebgp, where we can't auto-derivated from main AS

Signed-off-by: Alexandre Derumier <aderumier@odiso.com>