### PR TITLE
zebra: [7.4] Allow `set src X` to work on startup

### DIFF
--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1455,11 +1455,14 @@ int lib_route_map_entry_set_action_source_v4_modify(
 			if (pif != NULL)
 				break;
 		}
-		if (pif == NULL) {
-			zlog_warn("%s: is not a local adddress: %s", __func__,
-				  yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
+		/*
+		 * On startup the local address *may* not have come up
+		 * yet.  We need to allow startup configuration of
+		 * set src or we are fudged.  Log it for future fun
+		 */
+		if (pif == NULL)
+			zlog_warn("set src %pI4 is not a local address",
+				  &p.u.prefix4);
 		return NB_OK;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
@@ -1521,11 +1524,14 @@ int lib_route_map_entry_set_action_source_v6_modify(
 			if (pif != NULL)
 				break;
 		}
-		if (pif == NULL) {
-			zlog_warn("%s: is not a local adddress: %s", __func__,
-				  yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
+		/*
+		 * On startup the local address *may* not have come up
+		 * yet.  We need to allow startup configuration of
+		 * set src or we are fudged.  Log it for future fun
+		 */
+		if (pif == NULL)
+			zlog_warn("set src %pI6 is not a local address",
+				  &p.u.prefix6);
 		return NB_OK;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:


### PR DESCRIPTION
If a route-map in zebra has `set src X` and the interface
X is on has not been configured yet, we are rejecting the command
outright.  This is a problem on boot up especially( and where I
found this issue ) in that interfaces *can* and *will* be slow
on startup and config can easily be read in *before* the
interface has an ip address.

Let's modify zebra to just warn to the user we may have a problem
and let the chips fall where they may.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>