### PR TITLE
lib: add startup-time option to limit fds used

### DIFF
--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -712,6 +712,12 @@ These options apply to all |PACKAGE_NAME| daemons.
 
    Enable the transactional CLI mode.
 
+.. option:: --limit-fds <number>
+
+   Limit the number of file descriptors that will be used internally
+   by the FRR daemons. By default, the daemons use the system ulimit
+   value.
+
 .. _loadable-module-support:
 
 Loadable Module Support

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -99,6 +99,7 @@ static void opt_extend(const struct optspec *os)
 #define OPTION_TCLI      1005
 #define OPTION_DB_FILE   1006
 #define OPTION_LOGGING   1007
+#define OPTION_LIMIT_FDS 1008
 
 static const struct option lo_always[] = {
 	{"help", no_argument, NULL, 'h'},
@@ -113,6 +114,7 @@ static const struct option lo_always[] = {
 	{"log-level", required_argument, NULL, OPTION_LOGLEVEL},
 	{"tcli", no_argument, NULL, OPTION_TCLI},
 	{"command-log-always", no_argument, NULL, OPTION_LOGGING},
+	{"limit-fds", required_argument, NULL, OPTION_LIMIT_FDS},
 	{NULL}};
 static const struct optspec os_always = {
 	"hvdM:F:N:",
@@ -126,7 +128,8 @@ static const struct optspec os_always = {
 	"      --moduledir    Override modules directory\n"
 	"      --log          Set Logging to stdout, syslog, or file:<name>\n"
 	"      --log-level    Set Logging Level to use, debug, info, warn, etc\n"
-	"      --tcli         Use transaction-based CLI\n",
+	"      --tcli         Use transaction-based CLI\n"
+	"      --limit-fds    Limit number of fds supported\n",
 	lo_always};
 
 
@@ -552,6 +555,9 @@ static int frr_opt(int opt)
 	case OPTION_LOGGING:
 		di->log_always = true;
 		break;
+	case OPTION_LIMIT_FDS:
+		di->limit_fds = strtoul(optarg, &err, 0);
+		break;
 	default:
 		return 1;
 	}
@@ -737,6 +743,11 @@ const char *frr_get_progname(void)
 enum frr_cli_mode frr_get_cli_mode(void)
 {
 	return di ? di->cli_mode : FRR_CLI_CLASSIC;
+}
+
+uint32_t frr_get_fd_limit(void)
+{
+	return di ? di->limit_fds : 0;
 }
 
 static int rcvd_signal = 0;

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -102,6 +102,9 @@ struct frr_daemon_info {
 	size_t n_yang_modules;
 
 	bool log_always;
+
+	/* Optional upper limit on the number of fds used in select/poll */
+	uint32_t limit_fds;
 };
 
 /* execname is the daemon's executable (and pidfile and configfile) name,
@@ -134,6 +137,7 @@ extern __attribute__((__noreturn__)) void frr_help_exit(int status);
 extern struct thread_master *frr_init(void);
 extern const char *frr_get_progname(void);
 extern enum frr_cli_mode frr_get_cli_mode(void);
+uint32_t frr_get_fd_limit(void);
 
 DECLARE_HOOK(frr_late_init, (struct thread_master * tm), (tm))
 DECLARE_HOOK(frr_very_late_init, (struct thread_master * tm), (tm))

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -4194,7 +4194,7 @@ void vtysh_init_vty(void)
 	install_element(VRF_NODE, &vtysh_end_all_cmd);
 	install_element(VRF_NODE, &vtysh_exit_vrf_cmd);
 	install_element(VRF_NODE, &vtysh_quit_vrf_cmd);
-	
+
 	install_node(&rmap_node);
 	install_element(CONFIG_NODE, &vtysh_route_map_cmd);
 	install_element(RMAP_NODE, &vtysh_exit_rmap_cmd);


### PR DESCRIPTION
Add a new startup command-line option to limit the number of fds used in the thread/event infra; the system ulimit is used by default (as it is now).