### PR TITLE
[7.5] changelog: add debian revision

### DIFF
--- a/changelog-auto.in
+++ b/changelog-auto.in
@@ -6,7 +6,7 @@ frr (@VERSION@-0) UNRELEASED; urgency=medium
 
  -- FRRouting-Dev <dev@lists.frrouting.org>  Wed, 3 Nov 2020 23:10:00 +0200
 
-frr (7.5) RELEASED; urgency=medium
+frr (7.5-0) RELEASED; urgency=medium
   BFD
     Profile support
     Minimum ttl support


### PR DESCRIPTION
It is optional, but lintian complains when a package mixes versions with
and without revision number. All previous versions have it so 7.5 should
have it too.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>