### PR TITLE
isisd: if IS-IS is configured for v6, prefer v6 bfd sessions

### DIFF
--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -139,5 +139,6 @@ void isis_adj_print_vty(struct isis_adjacency *adj, struct vty *vty,
 void isis_adj_build_neigh_list(struct list *adjdb, struct list *list);
 void isis_adj_build_up_list(struct list *adjdb, struct list *list);
 int isis_adj_usage2levels(enum isis_adj_usage usage);
+int isis_bfd_startup_timer(struct thread *thread);
 
 #endif /* ISIS_ADJACENCY_H */

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -248,6 +248,9 @@ struct isis_circuit *circuit_scan_by_ifp(struct interface *ifp)
 	return circuit_lookup_by_ifp(ifp, isis->init_circ_list);
 }
 
+DEFINE_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *circuit),
+	    (circuit))
+
 void isis_circuit_add_addr(struct isis_circuit *circuit,
 			   struct connected *connected)
 {
@@ -318,6 +321,9 @@ void isis_circuit_add_addr(struct isis_circuit *circuit,
 			   connected->address, circuit->interface->name);
 #endif /* EXTREME_DEBUG */
 	}
+
+	hook_call(isis_circuit_add_addr_hook, circuit);
+
 	return;
 }
 

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -221,4 +221,7 @@ DECLARE_HOOK(isis_circuit_config_write,
 	    (circuit, vty))
 #endif
 
+DECLARE_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *circuit),
+	     (circuit))
+
 #endif /* _ZEBRA_ISIS_CIRCUIT_H */


### PR DESCRIPTION
This change fixes one of the issues from BFD-support for IS-IS #6386.   When ipv4 and ipv6 are both configured on an IS-IS interface the BFD session was starting up using the ipv4 addresses.   This fix prefers using ipv6 address if both address families are configured on the interface.

Signed-off-by: Lynne Morrison <lynne@voltanet.io>
Signed-off-by: Karen Schoener <karen@voltanet.io>