### PR TITLE
doc: don't index 'no' forms of commands

### DIFF
--- a/doc/user/babeld.rst
+++ b/doc/user/babeld.rst
@@ -34,27 +34,18 @@ Configuration of *babeld* is done in its configuration file
 Babel configuration
 ===================
 
-.. index::
-   single: router babel
-   single: no router babel
-
+.. index:: router babel
 .. clicmd:: [no] router babel
 
    Enable or disable Babel routing.
 
-.. index::
-   single: babel resend-delay (20-655340)
-   single: no babel resend-delay [(20-655340)]
-
+.. index:: babel resend-delay (20-655340)
 .. clicmd:: [no] babel resend-delay (20-655340)
 
    Specifies the time after which important messages are resent when
    avoiding a black-hole. The default is 2000 ms.
 
-.. index::
-   single: babel diversity
-   single: no babel diversity
-
+.. index:: babel diversity
 .. clicmd:: [no] babel diversity
 
    Enable or disable routing using radio frequency diversity.  This is
@@ -72,11 +63,8 @@ Babel configuration
    no role in route selection; you will probably want to set that to 128
    or less on nodes with multiple independent radios.
 
-.. index::
-   single: network IFNAME
-   single: no network IFNAME
-
-.. clicmd:: no network IFNAME
+.. index:: network IFNAME
+.. clicmd:: [no] network IFNAME
 
    Enable or disable Babel on the given interface.
 
@@ -89,10 +77,7 @@ Babel configuration
    Specifying `wireless` (the default) is always correct, but may
    cause slower convergence and extra routing traffic.
 
-.. index::
-   single: babel split-horizon
-   single: no babel split-horizon
-
+.. index:: babel split-horizon
 .. clicmd:: [no] babel split-horizon
 
    Specifies whether to perform split-horizon on the interface.  Specifying
@@ -120,10 +105,7 @@ Babel configuration
    Babel makes extensive use of triggered updates, this can be set to fairly
    high values on links with little packet loss.  The default is 20000 ms.
 
-.. index::
-   single: babel channel (1-254)
-   single: babel channel interfering
-   single: babel channel noninterfering
+.. index:: babel channel
 
 .. clicmd:: babel channel (1-254)
 .. clicmd:: babel channel interfering
@@ -185,9 +167,7 @@ Babel configuration
    when the RTT is higher or equal than rtt-max.  The default is 0, which
    effectively disables the use of a RTT-based cost.
 
-.. index::
-   single: babel enable-timestamps
-   single: no babel enable-timestamps
+.. index:: babel enable-timestamps
 
 .. clicmd:: [no] babel enable-timestamps
 
@@ -216,9 +196,7 @@ Babel configuration
 Babel redistribution
 ====================
 
-.. index::
-   single: redistribute <ipv4|ipv6> KIND
-   single: no redistribute <ipv4|ipv6> KIND
+.. index:: redistribute <ipv4|ipv6> KIND
 
 .. clicmd:: [no] redistribute <ipv4|ipv6> KIND
 

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -65,28 +65,19 @@ Basic Config Commands
 
    Set hostname of the router.
 
-.. index::
-   single: no password PASSWORD
-   single: password PASSWORD
-
+.. index:: password PASSWORD
 .. clicmd:: [no] password PASSWORD
 
    Set password for vty interface. The ``no`` form of the command deletes the
    password. If there is no password, a vty won't accept connections.
 
-.. index::
-   single: no enable password PASSWORD
-   single: enable password PASSWORD
-
+.. index:: enable password PASSWORD
 .. clicmd:: [no] enable password PASSWORD
 
    Set enable password. The ``no`` form of the command deletes the enable
    password.
 
-.. index::
-   single: no log trap [LEVEL]
-   single: log trap LEVEL
-
+.. index:: log trap LEVEL
 .. clicmd:: [no] log trap LEVEL
 
    These commands are deprecated and are present only for historical
@@ -97,9 +88,7 @@ Basic Config Commands
    future logging commands to debugging, but it does not change the logging
    level of existing logging destinations.
 
-.. index::
-   single: no log stdout [LEVEL]
-   single: log stdout [LEVEL]
+.. index:: log stdout [LEVEL]
 
 .. clicmd:: [no] log stdout LEVEL
 
@@ -120,10 +109,7 @@ Basic Config Commands
       terminal output.  Use a log file and ``tail -f`` if this rare chance is
       inacceptable to your setup.
 
-.. index::
-   single: no log file [FILENAME [LEVEL]]
-   single: log file FILENAME [LEVEL]
-
+.. index:: log file FILENAME [LEVEL]
 .. clicmd:: [no] log file [FILENAME [LEVEL]]
 
    If you want to log into a file, please specify ``filename`` as
@@ -138,10 +124,7 @@ Basic Config Commands
    deprecated ``log trap`` command) will be used. The ``no`` form of the command
    disables logging to a file.
 
-.. index::
-   single: no log syslog [LEVEL]
-   single: log syslog [LEVEL]
-
+.. index:: log syslog [LEVEL]
 .. clicmd:: [no] log syslog [LEVEL]
 
    Enable logging output to syslog. If the optional second argument specifying
@@ -149,10 +132,7 @@ Basic Config Commands
    debugging, but can be changed using the deprecated ``log trap`` command) will
    be used. The ``no`` form of the command disables logging to syslog.
 
-.. index::
-   single: no log monitor [LEVEL]
-   single: log monitor [LEVEL]
-
+.. index:: log monitor [LEVEL]
 .. clicmd:: [no] log monitor [LEVEL]
 
    Enable logging output to vty terminals that have enabled logging using the
@@ -163,20 +143,14 @@ Basic Config Commands
    level (typically debugging) will be used. The ``no`` form of the command
    disables logging to terminal monitors.
 
-.. index::
-   single: no log facility [FACILITY]
-   single: log facility [FACILITY]
-
+.. index:: log facility [FACILITY]
 .. clicmd:: [no] log facility [FACILITY]
 
    This command changes the facility used in syslog messages. The default
    facility is ``daemon``. The ``no`` form of the command resets the facility
    to the default ``daemon`` facility.
 
-.. index::
-   single: no log record-priority
-   single: log record-priority
-
+.. index:: log record-priority
 .. clicmd:: [no] log record-priority
 
    To include the severity in all messages logged to a file, to stdout, or to
@@ -187,10 +161,7 @@ Basic Config Commands
    versions of syslogd can be configured to include the facility and
    level in the messages emitted.
 
-.. index::
-   single: log timestamp precision (0-6)
-   single: [no] log timestamp precision (0-6)
-
+.. index:: log timestamp precision (0-6)
 .. clicmd:: [no] log timestamp precision [(0-6)]
 
    This command sets the precision of log message timestamps to the given
@@ -206,7 +177,7 @@ Basic Config Commands
    In this example, the precision is set to provide timestamps with
    millisecond accuracy.
 
-.. index:: [no] log commands
+.. index:: log commands
 .. clicmd:: [no] log commands
 
    This command enables the logging of all commands typed by a user to all
@@ -215,10 +186,7 @@ Basic Config Commands
    is used to start the daemon then this command is turned on by default
    and cannot be turned off and the [no] form of the command is dissallowed.
 
-.. index::
-   single: no log-filter WORD [DAEMON]
-   single: log-filter WORD [DAEMON]
-
+.. index:: log-filter WORD [DAEMON]
 .. clicmd:: [no] log-filter WORD [DAEMON]
 
    This command forces logs to be filtered on a specific string. A log message
@@ -275,7 +243,7 @@ Basic Config Commands
 
    Set motd string from an input.
 
-.. index:: no banner motd
+.. index:: banner motd
 .. clicmd:: no banner motd
 
    No motd banner string will be printed.
@@ -288,7 +256,7 @@ Basic Config Commands
    used for timeout value in seconds. Default timeout value is 10 minutes.
    When timeout value is zero, it means no timeout.
 
-.. index:: no exec-timeout
+.. index:: exec-timeout
 .. clicmd:: no exec-timeout
 
    Do not perform timeout at all. This command is as same as

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -79,7 +79,7 @@ BFDd Commands
 
    `vrf` selects which domain we want to use.
 
-.. index:: no peer <A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname|vrf NAME$vrf_name}]
+.. index:: peer <A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname|vrf NAME$vrf_name}]
 .. clicmd:: no peer <A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname|vrf NAME$vrf_name}]
 
     Stops and removes the selected peer.
@@ -91,7 +91,7 @@ BFDd Commands
    Creates a peer profile that can be configured in multiple peers.
 
 
-.. index:: no profile WORD
+.. index:: profile WORD
 .. clicmd:: no profile WORD
 
    Deletes a peer profile. Any peer using the profile will have their
@@ -151,7 +151,7 @@ BFD peers and profiles share the same BFD session configuration commands.
    Configures the minimal echo receive transmission interval that this
    system is capable of handling.
 
-.. index:: [no] echo-mode
+.. index:: echo-mode
 .. clicmd:: [no] echo-mode
 
    Enables or disables the echo transmission mode. This mode is disabled
@@ -164,14 +164,14 @@ BFD peers and profiles share the same BFD session configuration commands.
    Echo mode is not supported on multi-hop setups (see :rfc:`5883`
    section 3).
 
-.. index:: [no] shutdown
+.. index:: shutdown
 .. clicmd:: [no] shutdown
 
    Enables or disables the peer. When the peer is disabled an
    'administrative down' message is sent to the remote peer.
 
 
-.. index:: [no] passive-mode
+.. index:: passive-mode
 .. clicmd:: [no] passive-mode
 
    Mark session as passive: a passive session will not attempt to start
@@ -184,7 +184,7 @@ BFD peers and profiles share the same BFD session configuration commands.
 
    The default is active-mode (or ``no passive-mode``).
 
-.. index:: [no] minimum-ttl (1-254)
+.. index:: minimum-ttl (1-254)
 .. clicmd:: [no] minimum-ttl (1-254)
 
    For multi hop sessions only: configure the minimum expected TTL for
@@ -238,7 +238,7 @@ The following commands are available inside the BGP configuration node.
    the connection with its neighbor and, when it goes back up, notify
    BGP to try to connect to it.
 
-.. index:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd
+.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd
 .. clicmd:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd
 
    Removes any notification registration for this neighbor.
@@ -253,7 +253,7 @@ The following commands are available inside the BGP configuration node.
    This is the case when graceful restart is enabled, and it is wished to
    ignore the BD event while waiting for the remote router to restart.
 
-.. index:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd check-control-plane-failure
+.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd check-control-plane-failure
 .. clicmd:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd check-control-plane-failure
 
    Disallow to write CBIT independence in BFD outgoing packets. Also disallow
@@ -267,7 +267,7 @@ The following commands are available inside the BGP configuration node.
    BFD profile to the sessions it creates or that already exist.
 
 
-.. index:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd profile BFDPROF
+.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd profile BFDPROF
 .. clicmd:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd profile BFDPROF
 
    Removes the BFD profile configuration from peer session(s).
@@ -287,7 +287,7 @@ The following commands are available inside the interface configuration node.
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-.. index:: no isis bfd
+.. index:: isis bfd
 .. clicmd:: no isis bfd
 
    Removes any notification registration for this interface peers.
@@ -301,7 +301,7 @@ The following commands are available inside the interface configuration node.
 
    Use a BFD profile BFDPROF as provided in the BFD configuration.
 
-.. index:: no isis bfd profile BFDPROF
+.. index:: isis bfd profile BFDPROF
 .. clicmd:: no isis bfd profile BFDPROF
 
    Removes any BFD profile if present.
@@ -320,7 +320,7 @@ The following commands are available inside the interface configuration node.
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-.. index:: no ip ospf bfd
+.. index:: ip ospf bfd
 .. clicmd:: no ip ospf bfd
 
    Removes any notification registration for this interface peers.
@@ -340,7 +340,7 @@ The following commands are available inside the interface configuration node.
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-.. index:: no ipv6 ospf6 bfd
+.. index:: ipv6 ospf6 bfd
 .. clicmd:: no ipv6 ospf6 bfd
 
    Removes any notification registration for this interface peers.
@@ -360,7 +360,7 @@ The following commands are available inside the interface configuration node.
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-.. index:: no ip pim bfd
+.. index:: ip pim bfd
 .. clicmd:: no ip pim bfd
 
    Removes any notification registration for this interface peers.
@@ -619,19 +619,19 @@ sure you have `debugging` level enabled:
 You may also fine tune the debug messages by selecting one or more of the
 debug levels:
 
-.. index:: [no] debug bfd network
+.. index:: debug bfd network
 .. clicmd:: [no] debug bfd network
 
    Toggle network events: show messages about socket failures and unexpected
    BFD messages that may not belong to registered peers.
 
-.. index:: [no] debug bfd peer
+.. index:: debug bfd peer
 .. clicmd:: [no] debug bfd peer
 
    Toggle peer event log messages: show messages about peer creation/removal
    and state changes.
 
-.. index:: [no] debug bfd zebra
+.. index:: debug bfd zebra
 .. clicmd:: [no] debug bfd zebra
 
    Toggle zebra message events: show messages about interfaces, local

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -245,7 +245,7 @@ internal or external.
    Enable a BGP protocol process with the specified ASN. After
    this statement you can input any `BGP Commands`.
 
-.. index:: no router bgp ASN
+.. index:: router bgp ASN
 .. clicmd:: no router bgp ASN
 
    Destroy a BGP protocol process with the specified ASN.
@@ -418,7 +418,7 @@ Administrative Distance Metrics
 Require policy on EBGP
 -------------------------------
 
-.. index:: [no] bgp ebgp-requires-policy
+.. index:: bgp ebgp-requires-policy
 .. clicmd:: [no] bgp ebgp-requires-policy
 
    This command requires incoming and outgoing filters to be applied
@@ -447,7 +447,7 @@ Require policy on EBGP
 Reject routes with AS_SET or AS_CONFED_SET types
 ------------------------------------------------
 
-.. index:: [no] bgp reject-as-sets
+.. index:: bgp reject-as-sets
 .. clicmd:: [no] bgp reject-as-sets
 
    This command enables rejection of incoming and outgoing routes having AS_SET or AS_CONFED_SET type.
@@ -455,7 +455,7 @@ Reject routes with AS_SET or AS_CONFED_SET types
 Disable checking if nexthop is connected on EBGP sessions
 ---------------------------------------------------------
 
-.. index:: [no] bgp disable-ebgp-connected-route-check
+.. index:: bgp disable-ebgp-connected-route-check
 .. clicmd:: [no] bgp disable-ebgp-connected-route-check
 
    This command is used to disable the connection verification process for EBGP peering sessions
@@ -912,7 +912,7 @@ BGP GR Peer Mode Commands
 Administrative Shutdown
 -----------------------
 
-.. index:: [no] bgp shutdown [message MSG...]
+.. index:: bgp shutdown [message MSG...]
 .. clicmd:: [no] bgp shutdown [message MSG...]
 
    Administrative shutdown of all peers of a bgp instance. Drop all BGP peers,
@@ -948,10 +948,10 @@ Networks
    routes if they aren't present in their IGP routing tables; `bgpd`
    doesn't care about IGP routes when announcing its routes.
 
-.. index:: no network A.B.C.D/M
+.. index:: network A.B.C.D/M
 .. clicmd:: no network A.B.C.D/M
 
-.. index:: [no] bgp network import-check
+.. index:: bgp network import-check
 .. clicmd:: [no] bgp network import-check
 
    This configuration modifies the behavior of the network statement.
@@ -967,7 +967,7 @@ Networks
 IPv6 Support
 ------------
 
-.. index:: [no] neighbor A.B.C.D activate
+.. index:: neighbor A.B.C.D activate
 .. clicmd:: [no] neighbor A.B.C.D activate
 
    This configuration modifies whether to enable an address family for a
@@ -984,9 +984,6 @@ IPv6 Support
 
    This configuration example says that network 2001:0DB8:5009::/64 will be
    announced and enables the neighbor 2001:0DB8::1 to receive this announcement.
-
-.. index:: [no] bgp default ipv4-unicast
-.. clicmd:: [no] bgp default ipv4-unicast
 
    By default, only the IPv4 unicast address family is announced to all
    neighbors. Using the 'no bgp default ipv4-unicast' configuration overrides
@@ -1061,7 +1058,7 @@ Route Aggregation-IPv4 Address Family
    Similar to `summary-only`, but will only suppress more specific routes that
    are matched by the selected route-map.
 
-.. index:: no aggregate-address A.B.C.D/M
+.. index:: aggregate-address A.B.C.D/M
 .. clicmd:: no aggregate-address A.B.C.D/M
 
    This command removes an aggregate address.
@@ -1125,7 +1122,7 @@ Route Aggregation-IPv6 Address Family
    Similar to `summary-only`, but will only suppress more specific routes that
    are matched by the selected route-map.
 
-.. index:: no aggregate-address X:X::X:X/M
+.. index:: aggregate-address X:X::X:X/M
 .. clicmd:: no aggregate-address X:X::X:X/M
 
    This command removes an aggregate address.
@@ -1307,7 +1304,7 @@ Defining Peers
    peers ASN is the same as mine as specified under the :clicmd:`router bgp ASN`
    command the connection will be denied.
 
-.. index:: [no] bgp listen range <A.B.C.D/M|X:X::X:X/M> peer-group PGNAME
+.. index:: bgp listen range <A.B.C.D/M|X:X::X:X/M> peer-group PGNAME
 .. clicmd:: [no] bgp listen range <A.B.C.D/M|X:X::X:X/M> peer-group PGNAME
 
    Accept connections from any peers in the specified prefix. Configuration
@@ -1331,7 +1328,7 @@ Defining Peers
    ``net.core.optmem_max`` to allow the kernel to allocate the necessary option
    memory.
 
-.. index:: [no] coalesce-time (0-4294967295)
+.. index:: coalesce-time (0-4294967295)
 .. clicmd:: [no] coalesce-time (0-4294967295)
 
    The time in milliseconds that BGP will delay before deciding what peers
@@ -1343,7 +1340,7 @@ Defining Peers
 Configuring Peers
 ^^^^^^^^^^^^^^^^^
 
-.. index:: [no] neighbor PEER shutdown [message MSG...] [rtt (1-65535) [count (1-255)]]
+.. index:: neighbor PEER shutdown [message MSG...] [rtt (1-65535) [count (1-255)]]
 .. clicmd:: [no] neighbor PEER shutdown [message MSG...] [rtt (1-65535) [count (1-255)]]
 
    Shutdown the peer. We can delete the neighbor's configuration by
@@ -1359,13 +1356,13 @@ Configuring Peers
    Additional ``count`` parameter is the number of keepalive messages to count
    before shutdown the peer if round-trip-time becomes higher than defined.
 
-.. index:: [no] neighbor PEER disable-connected-check
+.. index:: neighbor PEER disable-connected-check
 .. clicmd:: [no] neighbor PEER disable-connected-check
 
    Allow peerings between directly connected eBGP peers using loopback
    addresses.
 
-.. index:: [no] neighbor PEER ebgp-multihop
+.. index:: neighbor PEER ebgp-multihop
 .. clicmd:: [no] neighbor PEER ebgp-multihop
 
    Specifying ``ebgp-multihop`` allows sessions with eBGP neighbors to
@@ -1373,12 +1370,12 @@ Configuring Peers
    directly connected and this knob is not enabled, the session will not
    establish.
 
-.. index:: [no] neighbor PEER description ...
+.. index:: neighbor PEER description ...
 .. clicmd:: [no] neighbor PEER description ...
 
    Set description of the peer.
 
-.. index:: [no] neighbor PEER version VERSION
+.. index:: neighbor PEER version VERSION
 .. clicmd:: [no] neighbor PEER version VERSION
 
    Set up the neighbor's BGP version. `version` can be `4`, `4+` or `4-`. BGP
@@ -1388,7 +1385,7 @@ Configuring Peers
    revision 00's Multiprotocol Extensions for BGP-4. Some routing software is
    still using this version.
 
-.. index:: [no] neighbor PEER interface IFNAME
+.. index:: neighbor PEER interface IFNAME
 .. clicmd:: [no] neighbor PEER interface IFNAME
 
    When you connect to a BGP peer over an IPv6 link-local address, you have to
@@ -1399,7 +1396,7 @@ Configuring Peers
    This command is deprecated and may be removed in a future release. Its use
    should be avoided.
 
-.. index:: [no] neighbor PEER next-hop-self [all]
+.. index:: neighbor PEER next-hop-self [all]
 .. clicmd:: [no] neighbor PEER next-hop-self [all]
 
    This command specifies an announced route's nexthop as being equivalent to
@@ -1415,7 +1412,7 @@ Configuring Peers
    configurations, as the route-map directive to leave the next-hop unchanged
    is only available for ipv4.
 
-.. index:: [no] neighbor PEER update-source <IFNAME|ADDRESS>
+.. index:: neighbor PEER update-source <IFNAME|ADDRESS>
 .. clicmd:: [no] neighbor PEER update-source <IFNAME|ADDRESS>
 
    Specify the IPv4 source address to use for the :abbr:`BGP` session to this
@@ -1430,7 +1427,7 @@ Configuring Peers
        neighbor bar update-source lo0
 
 
-.. index:: [no] neighbor PEER default-originate
+.. index:: neighbor PEER default-originate
 .. clicmd:: [no] neighbor PEER default-originate
 
    *bgpd*'s default is to not announce the default route (0.0.0.0/0) even if it
@@ -1440,7 +1437,7 @@ Configuring Peers
 .. index:: neighbor PEER port PORT
 .. clicmd:: neighbor PEER port PORT
 
-.. index:: [no] neighbor PEER password PASSWORD
+.. index:: neighbor PEER password PASSWORD
 .. clicmd:: [no] neighbor PEER password PASSWORD
 
    Set a MD5 password to be used with the tcp socket that is being used
@@ -1452,12 +1449,12 @@ Configuring Peers
 .. index:: neighbor PEER send-community
 .. clicmd:: neighbor PEER send-community
 
-.. index:: [no] neighbor PEER weight WEIGHT
+.. index:: neighbor PEER weight WEIGHT
 .. clicmd:: [no] neighbor PEER weight WEIGHT
 
    This command specifies a default `weight` value for the neighbor's routes.
 
-.. index:: [no] neighbor PEER maximum-prefix NUMBER [force]
+.. index:: neighbor PEER maximum-prefix NUMBER [force]
 .. clicmd:: [no] neighbor PEER maximum-prefix NUMBER [force]
 
    Sets a maximum number of prefixes we can receive from a given peer. If this
@@ -1475,7 +1472,7 @@ Configuring Peers
    but you want maximum-prefix to act on ALL (including filtered) prefixes. This
    option requires `soft-reconfiguration inbound` to be enabled for the peer.
 
-.. index:: [no] neighbor PEER maximum-prefix-out NUMBER
+.. index:: neighbor PEER maximum-prefix-out NUMBER
 .. clicmd:: [no] neighbor PEER maximum-prefix-out NUMBER
 
    Sets a maximum number of prefixes we can send to a given peer.
@@ -1483,7 +1480,7 @@ Configuring Peers
    Since sent prefix count is managed by update-groups, this option
    creates a separate update-group for outgoing updates.
 
-.. index:: [no] neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
+.. index:: neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
 .. clicmd:: [no] neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
 
    Specify an alternate AS for this BGP process when interacting with the
@@ -1502,7 +1499,7 @@ Configuring Peers
 
    This command is only allowed for eBGP peers.
 
-.. index:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> as-override
+.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> as-override
 .. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> as-override
 
    Override AS number of the originating router with the local AS number.
@@ -1515,7 +1512,7 @@ Configuring Peers
 
    This command is only allowed for eBGP peers.
 
-.. index:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]
+.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]
 .. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]
 
    Accept incoming routes with AS path containing AS number with the same value
@@ -1533,19 +1530,19 @@ Configuring Peers
 
    This command is only allowed for eBGP peers.
 
-.. index:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-all-paths
+.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-all-paths
 .. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-all-paths
 
    Configure BGP to send all known paths to neighbor in order to preserve multi
    path capabilities inside a network.
 
-.. index:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-bestpath-per-AS
+.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-bestpath-per-AS
 .. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-bestpath-per-AS
 
    Configure BGP to send best known paths to neighbor in order to preserve multi
    path capabilities inside a network.
 
-.. index:: [no] neighbor PEER ttl-security hops NUMBER
+.. index:: neighbor PEER ttl-security hops NUMBER
 .. clicmd:: [no] neighbor PEER ttl-security hops NUMBER
 
    This command enforces Generalized TTL Security Mechanism (GTSM), as
@@ -1553,7 +1550,7 @@ Configuring Peers
    specified number of hops away will be allowed to become neighbors. This
    command is mutually exclusive with *ebgp-multihop*.
 
-.. index:: [no] neighbor PEER capability extended-nexthop
+.. index:: neighbor PEER capability extended-nexthop
 .. clicmd:: [no] neighbor PEER capability extended-nexthop
 
    Allow bgp to negotiate the extended-nexthop capability with it's peer.
@@ -1562,7 +1559,7 @@ Configuring Peers
    turning on this command will allow BGP to install v4 routes with
    v6 nexthops if you do not have v4 configured on interfaces.
 
-.. index:: [no] bgp fast-external-failover
+.. index:: bgp fast-external-failover
 .. clicmd:: [no] bgp fast-external-failover
 
    This command causes bgp to not take down ebgp peers immediately
@@ -1570,27 +1567,27 @@ Configuring Peers
    and will not be displayed as part of a `show run`.  The no form
    of the command turns off this ability.
 
-.. index:: [no] bgp default ipv4-unicast
+.. index:: bgp default ipv4-unicast
 .. clicmd:: [no] bgp default ipv4-unicast
 
    This command allows the user to specify that v4 peering is turned
    on by default or not.  This command defaults to on and is not displayed.
    The `no bgp default ipv4-unicast` form of the command is displayed.
 
-.. index:: [no] bgp default show-hostname
+.. index:: bgp default show-hostname
 .. clicmd:: [no] bgp default show-hostname
 
    This command shows the hostname of the peer in certain BGP commands
    outputs. It's easier to troubleshoot if you have a number of BGP peers.
 
-.. index:: [no] bgp default show-nexthop-hostname
+.. index:: bgp default show-nexthop-hostname
 .. clicmd:: [no] bgp default show-nexthop-hostname
 
    This command shows the hostname of the next-hop in certain BGP commands
    outputs. It's easier to troubleshoot if you have a number of BGP peers
    and a number of routes to check.
 
-.. index:: [no] neighbor PEER advertisement-interval (0-600)
+.. index:: neighbor PEER advertisement-interval (0-600)
 .. clicmd:: [no] neighbor PEER advertisement-interval (0-600)
 
    Setup the minimum route advertisement interval(mrai) for the
@@ -1635,7 +1632,7 @@ Peer Filtering
    on reflected routes. This option allows the modifications to be reflected as
    well. Once enabled, it affects all reflected routes.
 
-.. index:: [no] neighbor PEER sender-as-path-loop-detection
+.. index:: neighbor PEER sender-as-path-loop-detection
 .. clicmd:: [no] neighbor PEER sender-as-path-loop-detection
 
    Enable the detection of sender side AS path loops and filter the
@@ -1679,7 +1676,7 @@ Capability Negotiation
 .. index:: neighbor PEER strict-capability-match
 .. clicmd:: neighbor PEER strict-capability-match
 
-.. index:: no neighbor PEER strict-capability-match
+.. index:: neighbor PEER strict-capability-match
 .. clicmd:: no neighbor PEER strict-capability-match
 
    Strictly compares remote capabilities and local capabilities. If
@@ -1691,7 +1688,7 @@ Capability Negotiation
    Negotiation. Please use *dont-capability-negotiate* command to disable the
    feature.
 
-.. index:: [no] neighbor PEER dont-capability-negotiate
+.. index:: neighbor PEER dont-capability-negotiate
 .. clicmd:: [no] neighbor PEER dont-capability-negotiate
 
    Suppress sending Capability Negotiation as OPEN message optional parameter
@@ -1715,7 +1712,7 @@ Capability Negotiation
 .. index:: neighbor PEER override-capability
 .. clicmd:: neighbor PEER override-capability
 
-.. index:: no neighbor PEER override-capability
+.. index:: neighbor PEER override-capability
 .. clicmd:: no neighbor PEER override-capability
 
    Override the result of Capability Negotiation with local configuration.
@@ -1733,10 +1730,10 @@ AS path access list is user defined AS path.
 
    This command defines a new AS path access list.
 
-.. index:: no bgp as-path access-list WORD
+.. index:: bgp as-path access-list WORD
 .. clicmd:: no bgp as-path access-list WORD
 
-.. index:: no bgp as-path access-list WORD permit|deny LINE
+.. index:: bgp as-path access-list WORD permit|deny LINE
 .. clicmd:: no bgp as-path access-list WORD permit|deny LINE
 
 .. _bgp-bogon-filter-example:
@@ -1755,20 +1752,20 @@ Bogon ASN filter policy configuration example
 Using AS Path in Route Map
 --------------------------
 
-.. index:: [no] match as-path WORD
+.. index:: match as-path WORD
 .. clicmd:: [no] match as-path WORD
 
    For a given as-path, WORD, match it on the BGP as-path given for the prefix
    and if it matches do normal route-map actions.  The no form of the command
    removes this match from the route-map.
 
-.. index:: [no] set as-path prepend AS-PATH
+.. index:: set as-path prepend AS-PATH
 .. clicmd:: [no] set as-path prepend AS-PATH
 
    Prepend the given string of AS numbers to the AS_PATH of the BGP path's NLRI.
    The no form of this command removes this set operation from the route-map.
 
-.. index:: [no] set as-path prepend last-as NUM
+.. index:: set as-path prepend last-as NUM
 .. clicmd:: [no] set as-path prepend last-as NUM
 
    Prepend the existing last AS number (the leftmost ASN) to the AS_PATH.
@@ -1948,7 +1945,7 @@ expanded
    for backward compatibility. Use of this feature is not recommended.
 
 
-.. index:: no bgp community-list [standard|expanded] NAME
+.. index:: bgp community-list [standard|expanded] NAME
 .. clicmd:: no bgp community-list [standard|expanded] NAME
 
    Deletes the community list specified by ``NAME``. All community lists share
@@ -2230,13 +2227,13 @@ Extended Community Lists
    expression (:ref:`bgp-regular-expressions`) to match an extended communities
    attribute in BGP updates.
 
-.. index:: no bgp extcommunity-list NAME
+.. index:: bgp extcommunity-list NAME
 .. clicmd:: no bgp extcommunity-list NAME
 
-.. index:: no bgp extcommunity-list standard NAME
+.. index:: bgp extcommunity-list standard NAME
 .. clicmd:: no bgp extcommunity-list standard NAME
 
-.. index:: no bgp extcommunity-list expanded NAME
+.. index:: bgp extcommunity-list expanded NAME
 .. clicmd:: no bgp extcommunity-list expanded NAME
 
    These commands delete extended community lists specified by `name`. All of
@@ -2345,13 +2342,13 @@ Two types of large community lists are supported, namely `standard` and
    lowest to highest.  `line` can also be a regular expression which matches
    this Large Community attribute.
 
-.. index:: no bgp large-community-list NAME
+.. index:: bgp large-community-list NAME
 .. clicmd:: no bgp large-community-list NAME
 
-.. index:: no bgp large-community-list standard NAME
+.. index:: bgp large-community-list standard NAME
 .. clicmd:: no bgp large-community-list standard NAME
 
-.. index:: no bgp large-community-list expanded NAME
+.. index:: bgp large-community-list expanded NAME
 .. clicmd:: no bgp large-community-list expanded NAME
 
    These commands delete Large Community lists specified by `name`. All Large
@@ -2481,7 +2478,7 @@ address-family:
    Specifies the route distinguisher to be added to a route exported from the
    current unicast VRF to VPN.
 
-.. index:: no rd vpn export [AS:NN|IP:nn]
+.. index:: rd vpn export [AS:NN|IP:nn]
 .. clicmd:: no rd vpn export [AS:NN|IP:nn]
 
    Deletes any previously-configured export route distinguisher.
@@ -2497,7 +2494,7 @@ address-family:
    extended community values as described in
    :ref:`bgp-extended-communities-attribute`.
 
-.. index:: no rt vpn import|export|both [RTLIST...]
+.. index:: rt vpn import|export|both [RTLIST...]
 .. clicmd:: no rt vpn import|export|both [RTLIST...]
 
    Deletes any previously-configured import or export route-target list.
@@ -2511,7 +2508,7 @@ address-family:
    is not running, or if this command is not configured, automatic label
    assignment will not complete, which will block corresponding route export.
 
-.. index:: no label vpn export [(0..1048575)|auto]
+.. index:: label vpn export [(0..1048575)|auto]
 .. clicmd:: no label vpn export [(0..1048575)|auto]
 
    Deletes any previously-configured export label.
@@ -2523,7 +2520,7 @@ address-family:
    the current unicast VRF to VPN. If left unspecified, the nexthop will be set
    to 0.0.0.0 or 0:0::0:0 (self).
 
-.. index:: no nexthop vpn export [A.B.C.D|X:X::X:X]
+.. index:: nexthop vpn export [A.B.C.D|X:X::X:X]
 .. clicmd:: no nexthop vpn export [A.B.C.D|X:X::X:X]
 
    Deletes any previously-configured export nexthop.
@@ -2534,7 +2531,7 @@ address-family:
    Specifies an optional route-map to be applied to routes imported or exported
    between the current unicast VRF and VPN.
 
-.. index:: no route-map vpn import|export [MAP]
+.. index:: route-map vpn import|export [MAP]
 .. clicmd:: no route-map vpn import|export [MAP]
 
    Deletes any previously-configured import or export route-map.
@@ -2544,7 +2541,7 @@ address-family:
 
    Enables import or export of routes between the current unicast VRF and VPN.
 
-.. index:: no import|export vpn
+.. index:: import|export vpn
 .. clicmd:: no import|export vpn
 
    Disables import or export of routes between the current unicast VRF and VPN.
@@ -2562,7 +2559,7 @@ address-family:
    The CLI will disallow attempts to configure incompatible leaking
    modes.
 
-.. index:: no import vrf VRFNAME
+.. index:: import vrf VRFNAME
 .. clicmd:: no import vrf VRFNAME
 
    Disables automatic leaking from vrf VRFNAME to the current VRF using
@@ -2618,7 +2615,7 @@ disable the feature via configuration CLI. Once the feature is disable under
 bgp vrf instance or MAC-VLAN interface is not configured, all the routes follow
 the same behavior of using same next-hop and RMAC values.
 
-.. index:: [no] advertise-pip [ip <addr> [mac <addr>]]
+.. index:: advertise-pip [ip <addr> [mac <addr>]]
 .. clicmd:: [no] advertise-pip [ip <addr> [mac <addr>]]
 
 Enables or disables advertise-pip feature, specifiy system-IP and/or system-MAC
@@ -2636,10 +2633,10 @@ Ethernet Segments
 An Ethernet Segment can be configured by specifying a system-MAC and a
 local discriminatior against the bond interface on the PE (via zebra) -
 
-.. index:: [no] evpn mh es-id [(1-16777215)$es_lid]
+.. index:: evpn mh es-id [(1-16777215)$es_lid]
 .. clicmd:: [no] evpn mh es-id [(1-16777215)$es_lid]
 
-.. index:: [no$no] evpn mh es-sys-mac [X:X:X:X:X:X$mac]
+.. index:: evpn mh es-sys-mac [X:X:X:X:X:X$mac]
 .. clicmd:: [no$no] evpn mh es-sys-mac [X:X:X:X:X:X$mac]
 
 The sys-mac and local discriminator are used for generating a 10-byte,
@@ -2663,7 +2660,7 @@ forward BUM traffic received via the overlay network. This implementation
 uses a preference based DF election specified by draft-ietf-bess-evpn-pref-df.
 The DF preference is configurable per-ES (via zebra) -
 
-.. index:: [no] evpn mh es-df-pref [(1-16777215)$df_pref]
+.. index:: evpn mh es-df-pref [(1-16777215)$df_pref]
 .. clicmd:: [no] evpn mh es-df-pref [(1-16777215)$df_pref]
 
 BUM traffic is rxed via the overlay by all PEs attached to a server but
@@ -2686,14 +2683,14 @@ been introduced for the express purpose of efficient ES failovers.
   On dataplanes that support layer3 nexthop groups the feature can be turned
   on via the following BGP config -
 
-.. index:: [no$no] use-es-l3nhg
+.. index:: use-es-l3nhg
 .. clicmd:: [no$no] use-es-l3nhg
 
 - Local ES (MAC/Neigh) failover via ES-redirect.
   On dataplanes that do not have support for ES-redirect the feature can be
   turned off via the following zebra config -
 
-.. index:: [no$no] evpn mh redirect-off
+.. index:: evpn mh redirect-off
 .. clicmd:: [no$no] evpn mh redirect-off
 
 Uplink/Core tracking
@@ -2703,7 +2700,7 @@ When all the underlay links go down the PE no longer has access to the VxLAN
 protodowned on the PE. A link can be setup for uplink tracking via the
 following zebra configuration -
 
-.. index:: [no] evpn mh uplink
+.. index:: evpn mh uplink
 .. clicmd:: [no] evpn mh uplink
 
 Proxy advertisements
@@ -2715,10 +2712,10 @@ the ES peer (PE2) goes down PE1 continues to advertise hosts learnt from PE2
 for a holdtime during which it attempts to establish local reachability of
 the host. This holdtime is configurable via the following zebra commands -
 
-.. index:: [no$no] evpn mh neigh-holdtime (0-86400)$duration
+.. index:: evpn mh neigh-holdtime (0-86400)$duration
 .. clicmd:: [no$no] evpn mh neigh-holdtime (0-86400)$duration
 
-.. index:: [no$no] evpn mh mac-holdtime (0-86400)$duration
+.. index:: evpn mh mac-holdtime (0-86400)$duration
 .. clicmd:: [no$no] evpn mh mac-holdtime (0-86400)$duration
 
 Startup delay
@@ -2728,7 +2725,7 @@ and EVPN network to converge before enabling the ESs. For this duration the
 ES bonds are held protodown. The startup delay is configurable via the
 following zebra command -
 
-.. index:: [no] evpn mh startup-delay(0-3600)$duration
+.. index:: evpn mh startup-delay(0-3600)$duration
 .. clicmd:: [no] evpn mh startup-delay(0-3600)$duration
 
 +Support with VRF network namespace backend
@@ -2787,7 +2784,7 @@ advertisement to take effect is 60 seconds. The conditional advertisement can ta
 effect depending on when the tracked route is removed from the BGP table and
 when the next instance of the BGP scanner occurs.
 
-.. index:: [no] neighbor A.B.C.D advertise-map NAME [exist-map|non-exist-map] NAME
+.. index:: neighbor A.B.C.D advertise-map NAME [exist-map|non-exist-map] NAME
 .. clicmd:: [no] neighbor A.B.C.D advertise-map NAME [exist-map|non-exist-map] NAME
 
    This command enables BGP scanner process to monitor routes specified by
@@ -2956,44 +2953,44 @@ Debugging
    Display Listen sockets and the vrf that created them.  Useful for debugging of when
    listen is not working and this is considered a developer debug statement.
 
-.. index:: [no] debug bgp neighbor-events
+.. index:: debug bgp neighbor-events
 .. clicmd:: [no] debug bgp neighbor-events
 
    Enable or disable debugging for neighbor events. This provides general
    information on BGP events such as peer connection / disconnection, session
    establishment / teardown, and capability negotiation.
 
-.. index:: [no] debug bgp updates
+.. index:: debug bgp updates
 .. clicmd:: [no] debug bgp updates
 
    Enable or disable debugging for BGP updates. This provides information on
    BGP UPDATE messages transmitted and received between local and remote
    instances.
 
-.. index:: [no] debug bgp keepalives
+.. index:: debug bgp keepalives
 .. clicmd:: [no] debug bgp keepalives
 
    Enable or disable debugging for BGP keepalives. This provides information on
    BGP KEEPALIVE messages transmitted and received between local and remote
    instances.
 
-.. index:: [no] debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>
+.. index:: debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>
 .. clicmd:: [no] debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>
 
    Enable or disable debugging for bestpath selection on the specified prefix.
 
-.. index:: [no] debug bgp nht
+.. index:: debug bgp nht
 .. clicmd:: [no] debug bgp nht
 
    Enable or disable debugging of BGP nexthop tracking.
 
-.. index:: [no] debug bgp update-groups
+.. index:: debug bgp update-groups
 .. clicmd:: [no] debug bgp update-groups
 
    Enable or disable debugging of dynamic update groups. This provides general
    information on group creation, deletion, join and prune events.
 
-.. index:: [no] debug bgp zebra
+.. index:: debug bgp zebra
 .. clicmd:: [no] debug bgp zebra
 
    Enable or disable debugging of communications between *bgpd* and *zebra*.
@@ -3007,7 +3004,7 @@ Dumping Messages and Routing Tables
 .. index:: dump bgp all-et PATH [INTERVAL]
 .. clicmd:: dump bgp all-et PATH [INTERVAL]
 
-.. index:: no dump bgp all [PATH] [INTERVAL]
+.. index:: dump bgp all [PATH] [INTERVAL]
 .. clicmd:: no dump bgp all [PATH] [INTERVAL]
 
    Dump all BGP packet and events to `path` file.
@@ -3022,7 +3019,7 @@ Dumping Messages and Routing Tables
 .. index:: dump bgp updates-et PATH [INTERVAL]
 .. clicmd:: dump bgp updates-et PATH [INTERVAL]
 
-.. index:: no dump bgp updates [PATH] [INTERVAL]
+.. index:: dump bgp updates [PATH] [INTERVAL]
 .. clicmd:: no dump bgp updates [PATH] [INTERVAL]
 
    Dump only BGP updates messages to `path` file.
@@ -3037,7 +3034,7 @@ Dumping Messages and Routing Tables
 .. index:: dump bgp routes-mrt PATH INTERVAL
 .. clicmd:: dump bgp routes-mrt PATH INTERVAL
 
-.. index:: no dump bgp route-mrt [PATH] [INTERVAL]
+.. index:: dump bgp route-mrt [PATH] [INTERVAL]
 .. clicmd:: no dump bgp route-mrt [PATH] [INTERVAL]
 
    Dump whole BGP routing table to `path`. This is heavy process. The path
@@ -3437,7 +3434,7 @@ with:
 .. index:: neighbor PEER route-reflector-client
 .. clicmd:: neighbor PEER route-reflector-client
 
-.. index:: no neighbor PEER route-reflector-client
+.. index:: neighbor PEER route-reflector-client
 .. clicmd:: no neighbor PEER route-reflector-client
 
 To avoid single points of failure, multiple route reflectors can be configured.
@@ -3448,7 +3445,7 @@ by route reflectors to avoid looping.
 .. index:: bgp cluster-id A.B.C.D
 .. clicmd:: bgp cluster-id A.B.C.D
 
-.. index:: [no] bgp no-rib
+.. index:: bgp no-rib
 .. clicmd:: [no] bgp no-rib
 
 To set and unset the BGP daemon ``-n`` / ``--no_kernel`` options during runtime
@@ -3503,7 +3500,7 @@ status in FIB:
 7. If the route which is already installed in dataplane is removed for some
    reason, sending withdraw message to peers is not currently supported.
 
-.. index:: [no] bgp suppress-fib-pending
+.. index:: bgp suppress-fib-pending
 .. clicmd:: [no] bgp suppress-fib-pending
 
 .. _routing-policy:

--- a/doc/user/eigrpd.rst
+++ b/doc/user/eigrpd.rst
@@ -73,7 +73,7 @@ EIGRP Configuration
    carrying out any of the EIGRP commands.  Specify vrf NAME if you want
    eigrp to work within the specified vrf.
 
-.. index:: no router eigrp (1-65535) [vrf NAME]
+.. index:: router eigrp (1-65535) [vrf NAME]
 .. clicmd:: no router eigrp (1-65535) [vrf NAME]
 
    Disable EIGRP.
@@ -81,7 +81,7 @@ EIGRP Configuration
 .. index:: network NETWORK
 .. clicmd:: network NETWORK
 
-.. index:: no network NETWORK
+.. index:: network NETWORK
 .. clicmd:: no network NETWORK
 
    Set the EIGRP enable interface by `network`. The interfaces which
@@ -107,7 +107,7 @@ EIGRP Configuration
 .. index:: passive-interface (IFNAME|default)
 .. clicmd:: passive-interface (IFNAME|default)
 
-.. index:: no passive-interface IFNAME
+.. index:: passive-interface IFNAME
 .. clicmd:: no passive-interface IFNAME
 
    This command sets the specified interface to passive mode. On passive mode
@@ -129,7 +129,7 @@ How to Announce EIGRP route
 .. index:: redistribute kernel metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
 .. clicmd:: redistribute kernel metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
 
-.. index:: no redistribute kernel
+.. index:: redistribute kernel
 .. clicmd:: no redistribute kernel
 
    `redistribute kernel` redistributes routing information from kernel route
@@ -141,7 +141,7 @@ How to Announce EIGRP route
 .. index:: redistribute static metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
 .. clicmd:: redistribute static metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
 
-.. index:: no redistribute static
+.. index:: redistribute static
 .. clicmd:: no redistribute static
 
    `redistribute static` redistributes routing information from static route
@@ -153,7 +153,7 @@ How to Announce EIGRP route
 .. index:: redistribute connected metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
 .. clicmd:: redistribute connected metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
 
-.. index:: no redistribute connected
+.. index:: redistribute connected
 .. clicmd:: no redistribute connected
 
    Redistribute connected routes into the EIGRP tables. `no redistribute
@@ -167,7 +167,7 @@ How to Announce EIGRP route
 .. index:: redistribute ospf metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
 .. clicmd:: redistribute ospf metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
 
-.. index:: no redistribute ospf
+.. index:: redistribute ospf
 .. clicmd:: no redistribute ospf
 
    `redistribute ospf` redistributes routing information from ospf route
@@ -179,7 +179,7 @@ How to Announce EIGRP route
 .. index:: redistribute bgp metric  (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
 .. clicmd:: redistribute bgp metric  (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
 
-.. index:: no redistribute bgp
+.. index:: redistribute bgp
 .. clicmd:: no redistribute bgp
 
    `redistribute bgp` redistributes routing information from bgp route entries

--- a/doc/user/fabricd.rst
+++ b/doc/user/fabricd.rst
@@ -35,7 +35,7 @@ in the configuration:
 .. index:: router openfabric WORD
 .. clicmd:: router openfabric WORD
 
-.. index:: no router openfabric WORD
+.. index:: router openfabric WORD
 .. clicmd:: no router openfabric WORD
 
    Enable or disable the OpenFabric process by specifying the OpenFabric domain with
@@ -44,7 +44,7 @@ in the configuration:
 .. index:: net XX.XXXX. ... .XXX.XX
 .. clicmd:: net XX.XXXX. ... .XXX.XX
 
-.. index:: no net XX.XXXX. ... .XXX.XX
+.. index:: net XX.XXXX. ... .XXX.XX
 .. clicmd:: no net XX.XXXX. ... .XXX.XX
 
    Set/Unset network entity title (NET) provided in ISO format.
@@ -52,7 +52,7 @@ in the configuration:
 .. index:: domain-password [clear | md5] <password>
 .. clicmd:: domain-password [clear | md5] <password>
 
-.. index:: no domain-password
+.. index:: domain-password
 .. clicmd:: no domain-password
 
    Configure the authentication password for a domain, as clear text or md5 one.
@@ -60,7 +60,7 @@ in the configuration:
 .. index:: log-adjacency-changes
 .. clicmd:: log-adjacency-changes
 
-.. index:: no log-adjacency-changes
+.. index:: log-adjacency-changes
 .. clicmd:: no log-adjacency-changes
 
    Log changes in adjacency state.
@@ -68,7 +68,7 @@ in the configuration:
 .. index:: set-overload-bit
 .. clicmd:: set-overload-bit
 
-.. index:: no set-overload-bit
+.. index:: set-overload-bit
 .. clicmd:: no set-overload-bit
 
    Set overload bit to avoid any transit traffic.
@@ -76,7 +76,7 @@ in the configuration:
 .. index:: purge-originator
 .. clicmd:: purge-originator
 
-.. index:: no purge-originator
+.. index:: purge-originator
 .. clicmd:: no purge-originator
 
    Enable or disable :rfc:`6232` purge originator identification.
@@ -84,7 +84,7 @@ in the configuration:
 .. index:: fabric-tier (0-14)
 .. clicmd:: fabric-tier (0-14)
 
-.. index:: no fabric-tier
+.. index:: fabric-tier
 .. clicmd:: no fabric-tier
 
    Configure a static tier number to advertise as location in the fabric
@@ -97,7 +97,7 @@ OpenFabric Timer
 .. index:: lsp-gen-interval (1-120)
 .. clicmd:: lsp-gen-interval (1-120)
 
-.. index:: no lsp-gen-interval
+.. index:: lsp-gen-interval
 .. clicmd:: no lsp-gen-interval
 
    Set minimum interval in seconds between regenerating same LSP.
@@ -105,7 +105,7 @@ OpenFabric Timer
 .. index:: lsp-refresh-interval (1-65235)
 .. clicmd:: lsp-refresh-interval (1-65235)
 
-.. index:: no lsp-refresh-interval
+.. index:: lsp-refresh-interval
 .. clicmd:: no lsp-refresh-interval
 
    Set LSP refresh interval in seconds.
@@ -113,7 +113,7 @@ OpenFabric Timer
 .. index:: max-lsp-lifetime (360-65535)
 .. clicmd:: max-lsp-lifetime (360-65535)
 
-.. index:: no max-lsp-lifetime
+.. index:: max-lsp-lifetime
 .. clicmd:: no max-lsp-lifetime
 
    Set LSP maximum LSP lifetime in seconds.
@@ -121,7 +121,7 @@ OpenFabric Timer
 .. index:: spf-interval (1-120)
 .. clicmd:: spf-interval (1-120)
 
-.. index:: no spf-interval
+.. index:: spf-interval
 .. clicmd:: no spf-interval
 
    Set minimum interval between consecutive SPF calculations in seconds.
@@ -134,7 +134,7 @@ OpenFabric interface
 .. index:: ip router openfabric WORD
 .. clicmd:: ip router openfabric WORD
 
-.. index:: no ip router openfabric WORD
+.. index:: ip router openfabric WORD
 .. clicmd:: no ip router openfabric WORD
 
 .. _ip-router-openfabric-word:
@@ -146,7 +146,7 @@ OpenFabric interface
 .. index:: openfabric csnp-interval (1-600)
 .. clicmd:: openfabric csnp-interval (1-600)
 
-.. index:: no openfabric csnp-interval
+.. index:: openfabric csnp-interval
 .. clicmd:: no openfabric csnp-interval
 
    Set CSNP interval in seconds.
@@ -154,7 +154,7 @@ OpenFabric interface
 .. index:: openfabric hello-interval (1-600)
 .. clicmd:: openfabric hello-interval (1-600)
 
-.. index:: no openfabric hello-interval
+.. index:: openfabric hello-interval
 .. clicmd:: no openfabric hello-interval
 
    Set Hello interval in seconds.
@@ -162,7 +162,7 @@ OpenFabric interface
 .. index:: openfabric hello-multiplier (2-100)
 .. clicmd:: openfabric hello-multiplier (2-100)
 
-.. index:: no openfabric hello-multiplier
+.. index:: openfabric hello-multiplier
 .. clicmd:: no openfabric hello-multiplier
 
    Set multiplier for Hello holding time.
@@ -170,7 +170,7 @@ OpenFabric interface
 .. index:: openfabric metric (0-16777215)
 .. clicmd:: openfabric metric (0-16777215)
 
-.. index:: no openfabric metric
+.. index:: openfabric metric
 .. clicmd:: no openfabric metric
 
    Set interface metric value.
@@ -178,7 +178,7 @@ OpenFabric interface
 .. index:: openfabric passive
 .. clicmd:: openfabric passive
 
-.. index:: no openfabric passive
+.. index:: openfabric passive
 .. clicmd:: no openfabric passive
 
    Configure the passive mode for this interface.
@@ -186,7 +186,7 @@ OpenFabric interface
 .. index:: openfabric password [clear | md5] <password>
 .. clicmd:: openfabric password [clear | md5] <password>
 
-.. index:: no openfabric password
+.. index:: openfabric password
 .. clicmd:: no openfabric password
 
    Configure the authentication password (clear or encoded text) for the
@@ -195,7 +195,7 @@ OpenFabric interface
 .. index:: openfabric psnp-interval (1-120)
 .. clicmd:: openfabric psnp-interval (1-120)
 
-.. index:: no openfabric psnp-interval
+.. index:: openfabric psnp-interval
 .. clicmd:: no openfabric psnp-interval
 
    Set PSNP interval in seconds.
@@ -267,7 +267,7 @@ Debugging OpenFabric
 .. index:: debug openfabric adj-packets
 .. clicmd:: debug openfabric adj-packets
 
-.. index:: no debug openfabric adj-packets
+.. index:: debug openfabric adj-packets
 .. clicmd:: no debug openfabric adj-packets
 
 OpenFabric Adjacency related packets.
@@ -275,7 +275,7 @@ OpenFabric Adjacency related packets.
 .. index:: debug openfabric checksum-errors
 .. clicmd:: debug openfabric checksum-errors
 
-.. index:: no debug openfabric checksum-errors
+.. index:: debug openfabric checksum-errors
 .. clicmd:: no debug openfabric checksum-errors
 
 OpenFabric LSP checksum errors.
@@ -283,7 +283,7 @@ OpenFabric LSP checksum errors.
 .. index:: debug openfabric events
 .. clicmd:: debug openfabric events
 
-.. index:: no debug openfabric events
+.. index:: debug openfabric events
 .. clicmd:: no debug openfabric events
 
 OpenFabric Events.
@@ -291,7 +291,7 @@ OpenFabric Events.
 .. index:: debug openfabric local-updates
 .. clicmd:: debug openfabric local-updates
 
-.. index:: no debug openfabric local-updates
+.. index:: debug openfabric local-updates
 .. clicmd:: no debug openfabric local-updates
 
 OpenFabric local update packets.
@@ -299,7 +299,7 @@ OpenFabric local update packets.
 .. index:: debug openfabric lsp-gen
 .. clicmd:: debug openfabric lsp-gen
 
-.. index:: no debug openfabric lsp-gen
+.. index:: debug openfabric lsp-gen
 .. clicmd:: no debug openfabric lsp-gen
 
 Generation of own LSPs.
@@ -307,7 +307,7 @@ Generation of own LSPs.
 .. index:: debug openfabric lsp-sched
 .. clicmd:: debug openfabric lsp-sched
 
-.. index:: no debug openfabric lsp-sched
+.. index:: debug openfabric lsp-sched
 .. clicmd:: no debug openfabric lsp-sched
 
 Debug scheduling of generation of own LSPs.
@@ -315,7 +315,7 @@ Debug scheduling of generation of own LSPs.
 .. index:: debug openfabric packet-dump
 .. clicmd:: debug openfabric packet-dump
 
-.. index:: no debug openfabric packet-dump
+.. index:: debug openfabric packet-dump
 .. clicmd:: no debug openfabric packet-dump
 
 OpenFabric packet dump.
@@ -323,7 +323,7 @@ OpenFabric packet dump.
 .. index:: debug openfabric protocol-errors
 .. clicmd:: debug openfabric protocol-errors
 
-.. index:: no debug openfabric protocol-errors
+.. index:: debug openfabric protocol-errors
 .. clicmd:: no debug openfabric protocol-errors
 
 OpenFabric LSP protocol errors.
@@ -331,7 +331,7 @@ OpenFabric LSP protocol errors.
 .. index:: debug openfabric route-events
 .. clicmd:: debug openfabric route-events
 
-.. index:: no debug openfabric route-events
+.. index:: debug openfabric route-events
 .. clicmd:: no debug openfabric route-events
 
 OpenFabric Route related events.
@@ -339,7 +339,7 @@ OpenFabric Route related events.
 .. index:: debug openfabric snp-packets
 .. clicmd:: debug openfabric snp-packets
 
-.. index:: no debug openfabric snp-packets
+.. index:: debug openfabric snp-packets
 .. clicmd:: no debug openfabric snp-packets
 
 OpenFabric CSNP/PSNP packets.
@@ -353,13 +353,13 @@ OpenFabric CSNP/PSNP packets.
 .. index:: debug openfabric spf-triggers
 .. clicmd:: debug openfabric spf-triggers
 
-.. index:: no debug openfabric spf-events
+.. index:: debug openfabric spf-events
 .. clicmd:: no debug openfabric spf-events
 
-.. index:: no debug openfabric spf-statistics
+.. index:: debug openfabric spf-statistics
 .. clicmd:: no debug openfabric spf-statistics
 
-.. index:: no debug openfabric spf-triggers
+.. index:: debug openfabric spf-triggers
 .. clicmd:: no debug openfabric spf-triggers
 
 OpenFabric Shortest Path First Events, Timing and Statistic Data and triggering
@@ -368,7 +368,7 @@ events.
 .. index:: debug openfabric update-packets
 .. clicmd:: debug openfabric update-packets
 
-.. index:: no debug openfabric update-packets
+.. index:: debug openfabric update-packets
 .. clicmd:: no debug openfabric update-packets
 
 Update related packets.

--- a/doc/user/filter.rst
+++ b/doc/user/filter.rst
@@ -98,7 +98,7 @@ is defined, and no match is found, default deny is applied.
    In the case of no le or ge command, the prefix length must match exactly the
    length specified in the prefix list.
 
-.. index:: no ip prefix-list NAME
+.. index:: ip prefix-list NAME
 .. clicmd:: no ip prefix-list NAME
 
 .. _ip-prefix-list-description:
@@ -112,7 +112,7 @@ ip prefix-list description
    Descriptions may be added to prefix lists. This command adds a
    description to the prefix list.
 
-.. index:: no ip prefix-list NAME description [DESC]
+.. index:: ip prefix-list NAME description [DESC]
 .. clicmd:: no ip prefix-list NAME description [DESC]
 
    Deletes the description from a prefix list. It is possible to use the
@@ -129,7 +129,7 @@ ip prefix-list sequential number control
    With this command, the IP prefix list sequential number is displayed.
    This is the default behavior.
 
-.. index:: no ip prefix-list sequence-number
+.. index:: ip prefix-list sequence-number
 .. clicmd:: no ip prefix-list sequence-number
 
    With this command, the IP prefix list sequential number is not

--- a/doc/user/flowspec.rst
+++ b/doc/user/flowspec.rst
@@ -141,7 +141,7 @@ twice the traffic, or slow down the traffic (filtering costs). To limit
 Flowspec to one specific interface, use the following command, under
 `flowspec address-family` node.
 
-.. index:: [no] local-install <IFNAME | any>
+.. index:: local-install <IFNAME | any>
 .. clicmd:: [no] local-install <IFNAME | any>
 
 By default, Flowspec is activated on all interfaces. Installing it to a named
@@ -168,7 +168,7 @@ following:
 - The first VRF with the matching Route Target will be selected to route traffic
   to. Use the following command under ipv4 unicast address-family node
 
-.. index:: [no] rt redirect import RTLIST...
+.. index:: rt redirect import RTLIST...
 .. clicmd:: [no] rt redirect import RTLIST...
 
 In order to illustrate, if the Route Target configured in the Flowspec entry is
@@ -241,14 +241,14 @@ match.
    ``TABLEID`` is the table number identifier referencing the non standard
    routing table used in this example.
 
-.. index:: [no] debug bgp flowspec
+.. index:: debug bgp flowspec
 .. clicmd:: [no] debug bgp flowspec
 
    You can troubleshoot Flowspec, or BGP policy based routing. For instance, if
    you encounter some issues when decoding a Flowspec entry, you should enable
    :clicmd:`debug bgp flowspec`.
 
-.. index:: [no] debug bgp pbr [error]
+.. index:: debug bgp pbr [error]
 .. clicmd:: [no] debug bgp pbr [error]
 
    If you fail to apply the flowspec entry into *zebra*, there should be some

--- a/doc/user/ipv6.rst
+++ b/doc/user/ipv6.rst
@@ -17,7 +17,7 @@ no longer possible.
 Router Advertisement
 ====================
 
-.. index:: no ipv6 nd suppress-ra
+.. index:: ipv6 nd suppress-ra
 .. clicmd:: no ipv6 nd suppress-ra
 
    Send router advertisement messages.
@@ -57,9 +57,7 @@ Router Advertisement
 
      Default: not set, i.e. hosts do not assume a complete IP address is placed.
 
-.. index::
-   single: no ipv6 nd ra-interval [(1-1800)]
-   single: no ipv6 nd ra-interval [(1-1800)]
+.. index:: ipv6 nd ra-interval [(1-1800)]
 .. clicmd:: [no] ipv6 nd ra-interval [(1-1800)]
 
    The maximum time allowed between sending unsolicited multicast router
@@ -67,18 +65,13 @@ Router Advertisement
    Default: ``600``
 
 .. index:: ipv6 nd ra-interval msec (70-1800000)
-.. index::
-   single: no ipv6 nd ra-interval [msec (70-1800000)]
-   single: ipv6 nd ra-interval msec (70-1800000)
 .. clicmd:: [no] ipv6 nd ra-interval [msec (70-1800000)]
 
    The maximum time allowed between sending unsolicited multicast router
    advertisements from the interface, in milliseconds.
    Default: ``600000``
 
-.. index::
-   single: ipv6 nd ra-fast-retrans
-   single: no ipv6 nd ra-fast-retrans
+.. index:: ipv6 nd ra-fast-retrans
 .. clicmd:: [no] ipv6 nd ra-fast-retrans
 
    RFC4861 states that consecutive RA packets should be sent no more
@@ -90,9 +83,7 @@ Router Advertisement
    and neighbor establishment.
    Default: enabled
 
-.. index::
-   single: ipv6 nd ra-retrans-interval (0-4294967295)
-   single: no ipv6 nd retrans-interval [(0-4294967295)]
+.. index:: ipv6 nd ra-retrans-interval (0-4294967295)
 .. clicmd:: [no] ipv6 nd ra-retrans-interval [(0-4294967295)]
 
    The value to be placed in the retrans timer field of router advertisements
@@ -102,9 +93,7 @@ Router Advertisement
    msec.
    Default: ``0``
 
-.. index::
-   single: ipv6 nd ra-hop-limit (0-255)
-   single: no ipv6 nd ra-hop-limit [(0-255)]
+.. index:: ipv6 nd ra-hop-limit (0-255)
 .. clicmd:: [no] ipv6 nd ra-hop-limit [(0-255)]
 
    The value to be placed in the hop count field of router advertisements sent
@@ -113,9 +102,7 @@ Router Advertisement
    router.  Must be between zero or 255 hops.
    Default: ``64``
 
-.. index::
-   single: ipv6 nd ra-lifetime (0-9000)
-   single: no ipv6 nd ra-lifetime [(0-9000)]
+.. index:: ipv6 nd ra-lifetime (0-9000)
 .. clicmd:: [no] ipv6 nd ra-lifetime [(0-9000)]
 
    The value to be placed in the Router Lifetime field of router advertisements
@@ -126,9 +113,7 @@ Router Advertisement
    (or default) and 9000 seconds.
    Default: ``1800``
 
-.. index::
-   single: no ipv6 nd reachable-time [(1-3600000)]
-   single: ipv6 nd reachable-time (1-3600000)
+.. index:: ipv6 nd reachable-time (1-3600000)
 .. clicmd:: [no] ipv6 nd reachable-time [(1-3600000)]
 
    The value to be placed in the Reachable Time field in the Router
@@ -137,9 +122,7 @@ Router Advertisement
    means unspecified (by this router).
    Default: ``0``
 
-.. index::
-   single: ipv6 nd managed-config-flag
-   single: no ipv6 nd managed-config-flag
+.. index:: ipv6 nd managed-config-flag
 .. clicmd:: [no] ipv6 nd managed-config-flag
 
    Set/unset flag in IPv6 router advertisements which indicates to hosts that
@@ -148,9 +131,7 @@ Router Advertisement
    autoconfiguration.
    Default: not set
 
-.. index::
-   single: ipv6 nd other-config-flag
-   single: no ipv6 nd other-config-flag
+.. index:: ipv6 nd other-config-flag
 .. clicmd:: [no] ipv6 nd other-config-flag
 
    Set/unset flag in IPv6 router advertisements which indicates to hosts that
@@ -158,9 +139,7 @@ Router Advertisement
    information other than addresses.
    Default: not set
 
-.. index::
-   single: ipv6 nd home-agent-config-flag
-   single: no ipv6 nd home-agent-config-flag
+.. index:: ipv6 nd home-agent-config-flag
 .. clicmd:: [no] ipv6 nd home-agent-config-flag
 
    Set/unset flag in IPv6 router advertisements which indicates to hosts that
@@ -169,9 +148,7 @@ Router Advertisement
 
 .. index:: ipv6 nd home-agent-preference (0-65535)
 
-.. index::
-   single: no ipv6 nd home-agent-preference [(0-65535)]
-   single: ipv6 nd home-agent-preference (0-65535)
+.. index:: ipv6 nd home-agent-preference (0-65535)
 .. clicmd:: [no] ipv6 nd home-agent-preference [(0-65535)]
 
    The value to be placed in Home Agent Option, when Home Agent config flag is
@@ -179,9 +156,7 @@ Router Advertisement
    stands for the lowest preference possible.
    Default: ``0``
 
-.. index::
-   single: ipv6 nd home-agent-lifetime (0-65520)
-   single: no ipv6 nd home-agent-lifetime (0-65520)
+.. index:: ipv6 nd home-agent-lifetime (0-65520)
 .. clicmd:: [no] ipv6 nd home-agent-lifetime [(0-65520)]
 
    The value to be placed in Home Agent Option, when Home Agent config flag is set,
@@ -190,26 +165,20 @@ Router Advertisement
 
    Default: ``0``
 
-.. index::
-   single: ipv6 nd adv-interval-option
-   single: no ipv6 nd adv-interval-option
+.. index:: ipv6 nd adv-interval-option
 .. clicmd:: [no] ipv6 nd adv-interval-option
 
    Include an Advertisement Interval option which indicates to hosts the maximum time,
    in milliseconds, between successive unsolicited Router Advertisements.
    Default: not set
 
-.. index::
-   single: ipv6 nd router-preference (high|medium|low)
-   single: no ipv6 nd router-preference (high|medium|low)
+.. index:: ipv6 nd router-preference (high|medium|low)
 .. clicmd:: [no] ipv6 nd router-preference [(high|medium|low)]
 
    Set default router preference in IPv6 router advertisements per RFC4191.
    Default: medium
 
-.. index::
-   single: ipv6 nd mtu (1-65535)
-   single: no ipv6 nd mtu [(1-65535)]
+.. index:: ipv6 nd mtu (1-65535)
 .. clicmd:: [no] ipv6 nd mtu [(1-65535)]
 
    Include an MTU (type 5) option in each RA packet to assist the attached
@@ -218,9 +187,7 @@ Router Advertisement
 
    Default: don't advertise any MTU option.
 
-.. index::
-   single: ipv6 nd rdnss ipv6address [lifetime]
-   single: no ipv6 nd rdnss ipv6address [lifetime]
+.. index:: ipv6 nd rdnss ipv6address [lifetime]
 .. clicmd:: [no] ipv6 nd rdnss ipv6address [lifetime]
 
    Recursive DNS server address to advertise using the RDNSS (type 25) option
@@ -238,9 +205,7 @@ Router Advertisement
 
    Default: do not emit RDNSS option
 
-.. index::
-   single: ipv6 nd dnssl domain-name-suffix [lifetime]
-   single: no ipv6 nd dnssl domain-name-suffix [lifetime]
+.. index:: ipv6 nd dnssl domain-name-suffix [lifetime]
 .. clicmd:: [no] ipv6 nd dnssl domain-name-suffix [lifetime]
 
    Advertise DNS search list using the DNSSL (type 31) option described in

--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -33,7 +33,7 @@ ISIS router
 To start the ISIS process you have to specify the ISIS router. As of this
 writing, *isisd* does not support multiple ISIS processes.
 
-.. index:: [no] router isis WORD [vrf NAME]
+.. index:: router isis WORD [vrf NAME]
 .. clicmd:: [no] router isis WORD [vrf NAME]
 
    Enable or disable the ISIS process by specifying the ISIS domain with
@@ -44,7 +44,7 @@ writing, *isisd* does not support multiple ISIS processes.
 .. index:: net XX.XXXX. ... .XXX.XX
 .. clicmd:: net XX.XXXX. ... .XXX.XX
 
-.. index:: no net XX.XXXX. ... .XXX.XX
+.. index:: net XX.XXXX. ... .XXX.XX
 .. clicmd:: no net XX.XXXX. ... .XXX.XX
 
    Set/Unset network entity title (NET) provided in ISO format.
@@ -52,7 +52,7 @@ writing, *isisd* does not support multiple ISIS processes.
 .. index:: hostname dynamic
 .. clicmd:: hostname dynamic
 
-.. index:: no hostname dynamic
+.. index:: hostname dynamic
 .. clicmd:: no hostname dynamic
 
    Enable support for dynamic hostname.
@@ -63,10 +63,10 @@ writing, *isisd* does not support multiple ISIS processes.
 .. index:: domain-password [clear | md5] <password>
 .. clicmd:: domain-password [clear | md5] <password>
 
-.. index:: no area-password
+.. index:: area-password
 .. clicmd:: no area-password
 
-.. index:: no domain-password
+.. index:: domain-password
 .. clicmd:: no domain-password
 
    Configure the authentication password for an area, respectively a domain, as
@@ -75,7 +75,7 @@ writing, *isisd* does not support multiple ISIS processes.
 .. index:: log-adjacency-changes
 .. clicmd:: log-adjacency-changes
 
-.. index:: no log-adjacency-changes
+.. index:: log-adjacency-changes
 .. clicmd:: no log-adjacency-changes
 
    Log changes in adjacency state.
@@ -83,7 +83,7 @@ writing, *isisd* does not support multiple ISIS processes.
 .. index:: metric-style [narrow | transition | wide]
 .. clicmd:: metric-style [narrow | transition | wide]
 
-.. index:: no metric-style
+.. index:: metric-style
 .. clicmd:: no metric-style
 
    Set old-style (ISO 10589) or new-style packet formats:
@@ -98,7 +98,7 @@ writing, *isisd* does not support multiple ISIS processes.
 .. index:: set-overload-bit
 .. clicmd:: set-overload-bit
 
-.. index:: no set-overload-bit
+.. index:: set-overload-bit
 .. clicmd:: no set-overload-bit
 
    Set overload bit to avoid any transit traffic.
@@ -106,12 +106,12 @@ writing, *isisd* does not support multiple ISIS processes.
 .. index:: purge-originator
 .. clicmd:: purge-originator
 
-.. index:: no purge-originator
+.. index:: purge-originator
 .. clicmd:: no purge-originator
 
    Enable or disable :rfc:`6232` purge originator identification.
 
-.. index:: [no] lsp-mtu (128-4352)
+.. index:: lsp-mtu (128-4352)
 .. clicmd:: [no] lsp-mtu (128-4352)
 
    Configure the maximum size of generated LSPs, in bytes.
@@ -128,10 +128,10 @@ ISIS Timer
 .. index:: lsp-gen-interval [level-1 | level-2] (1-120)
 .. clicmd:: lsp-gen-interval [level-1 | level-2] (1-120)
 
-.. index:: no lsp-gen-interval
+.. index:: lsp-gen-interval
 .. clicmd:: no lsp-gen-interval
 
-.. index:: no lsp-gen-interval [level-1 | level-2]
+.. index:: lsp-gen-interval [level-1 | level-2]
 .. clicmd:: no lsp-gen-interval [level-1 | level-2]
 
    Set minimum interval in seconds between regenerating same LSP,
@@ -140,7 +140,7 @@ ISIS Timer
 .. index:: lsp-refresh-interval [level-1 | level-2] (1-65235)
 .. clicmd:: lsp-refresh-interval [level-1 | level-2] (1-65235)
 
-.. index:: no lsp-refresh-interval [level-1 | level-2]
+.. index:: lsp-refresh-interval [level-1 | level-2]
 .. clicmd:: no lsp-refresh-interval [level-1 | level-2]
 
    Set LSP refresh interval in seconds, globally, for an area (level-1) or a
@@ -152,10 +152,10 @@ ISIS Timer
 .. index:: max-lsp-lifetime [level-1 | level-2] (360-65535)
 .. clicmd:: max-lsp-lifetime [level-1 | level-2] (360-65535)
 
-.. index:: no max-lsp-lifetime
+.. index:: max-lsp-lifetime
 .. clicmd:: no max-lsp-lifetime
 
-.. index:: no max-lsp-lifetime [level-1 | level-2]
+.. index:: max-lsp-lifetime [level-1 | level-2]
 .. clicmd:: no max-lsp-lifetime [level-1 | level-2]
 
    Set LSP maximum LSP lifetime in seconds, globally, for an area (level-1) or
@@ -167,10 +167,10 @@ ISIS Timer
 .. index:: spf-interval [level-1 | level-2] (1-120)
 .. clicmd:: spf-interval [level-1 | level-2] (1-120)
 
-.. index:: no spf-interval
+.. index:: spf-interval
 .. clicmd:: no spf-interval
 
-.. index:: no spf-interval [level-1 | level-2]
+.. index:: spf-interval [level-1 | level-2]
 .. clicmd:: no spf-interval [level-1 | level-2]
 
    Set minimum interval between consecutive SPF calculations in seconds.
@@ -183,7 +183,7 @@ ISIS region
 .. index:: is-type [level-1 | level-1-2 | level-2-only]
 .. clicmd:: is-type [level-1 | level-1-2 | level-2-only]
 
-.. index:: no is-type
+.. index:: is-type
 .. clicmd:: no is-type
 
    Define the ISIS router behavior:
@@ -202,7 +202,8 @@ ISIS interface
 
 .. _ip-router-isis-word:
 
-.. index:: [no] <ip|ipv6> router isis WORD [vrf NAME]
+.. index:: ip router isis WORD [vrf NAME]
+.. index:: ipv6 router isis WORD [vrf NAME]
 .. clicmd:: [no] <ip|ipv6> router isis WORD [vrf NAME]
 
    Activate ISIS adjacency on this interface. Note that the name of ISIS
@@ -213,7 +214,7 @@ ISIS interface
 .. index:: isis circuit-type [level-1 | level-1-2 | level-2]
 .. clicmd:: isis circuit-type [level-1 | level-1-2 | level-2]
 
-.. index:: no isis circuit-type
+.. index:: isis circuit-type
 .. clicmd:: no isis circuit-type
 
    Configure circuit type for interface:
@@ -231,10 +232,10 @@ ISIS interface
 .. index:: isis csnp-interval (1-600) [level-1 | level-2]
 .. clicmd:: isis csnp-interval (1-600) [level-1 | level-2]
 
-.. index:: no isis csnp-interval
+.. index:: isis csnp-interval
 .. clicmd:: no isis csnp-interval
 
-.. index:: no isis csnp-interval [level-1 | level-2]
+.. index:: isis csnp-interval [level-1 | level-2]
 .. clicmd:: no isis csnp-interval [level-1 | level-2]
 
    Set CSNP interval in seconds globally, for an area (level-1) or a domain
@@ -251,10 +252,10 @@ ISIS interface
 .. index:: isis hello-interval (1-600) [level-1 | level-2]
 .. clicmd:: isis hello-interval (1-600) [level-1 | level-2]
 
-.. index:: no isis hello-interval
+.. index:: isis hello-interval
 .. clicmd:: no isis hello-interval
 
-.. index:: no isis hello-interval [level-1 | level-2]
+.. index:: isis hello-interval [level-1 | level-2]
 .. clicmd:: no isis hello-interval [level-1 | level-2]
 
    Set Hello interval in seconds globally, for an area (level-1) or a domain
@@ -266,10 +267,10 @@ ISIS interface
 .. index:: isis hello-multiplier (2-100) [level-1 | level-2]
 .. clicmd:: isis hello-multiplier (2-100) [level-1 | level-2]
 
-.. index:: no isis hello-multiplier
+.. index:: isis hello-multiplier
 .. clicmd:: no isis hello-multiplier
 
-.. index:: no isis hello-multiplier [level-1 | level-2]
+.. index:: isis hello-multiplier [level-1 | level-2]
 .. clicmd:: no isis hello-multiplier [level-1 | level-2]
 
    Set multiplier for Hello holding time globally, for an area (level-1) or a
@@ -281,10 +282,10 @@ ISIS interface
 .. index:: isis metric [(0-255) | (0-16777215)] [level-1 | level-2]
 .. clicmd:: isis metric [(0-255) | (0-16777215)] [level-1 | level-2]
 
-.. index:: no isis metric
+.. index:: isis metric
 .. clicmd:: no isis metric
 
-.. index:: no isis metric [level-1 | level-2]
+.. index:: isis metric [level-1 | level-2]
 .. clicmd:: no isis metric [level-1 | level-2]
 
    Set default metric value globally, for an area (level-1) or a domain
@@ -294,7 +295,7 @@ ISIS interface
 .. index:: isis network point-to-point
 .. clicmd:: isis network point-to-point
 
-.. index:: no isis network point-to-point
+.. index:: isis network point-to-point
 .. clicmd:: no isis network point-to-point
 
    Set network type to 'Point-to-Point' (broadcast by default).
@@ -302,7 +303,7 @@ ISIS interface
 .. index:: isis passive
 .. clicmd:: isis passive
 
-.. index:: no isis passive
+.. index:: isis passive
 .. clicmd:: no isis passive
 
    Configure the passive mode for this interface.
@@ -310,7 +311,7 @@ ISIS interface
 .. index:: isis password [clear | md5] <password>
 .. clicmd:: isis password [clear | md5] <password>
 
-.. index:: no isis password
+.. index:: isis password
 .. clicmd:: no isis password
 
    Configure the authentication password (clear or encoded text) for the
@@ -322,10 +323,10 @@ ISIS interface
 .. index:: isis priority (0-127) [level-1 | level-2]
 .. clicmd:: isis priority (0-127) [level-1 | level-2]
 
-.. index:: no isis priority
+.. index:: isis priority
 .. clicmd:: no isis priority
 
-.. index:: no isis priority [level-1 | level-2]
+.. index:: isis priority [level-1 | level-2]
 .. clicmd:: no isis priority [level-1 | level-2]
 
    Set priority for Designated Router election, globally, for the area
@@ -337,10 +338,10 @@ ISIS interface
 .. index:: isis psnp-interval (1-120) [level-1 | level-2]
 .. clicmd:: isis psnp-interval (1-120) [level-1 | level-2]
 
-.. index:: no isis psnp-interval
+.. index:: isis psnp-interval
 .. clicmd:: no isis psnp-interval
 
-.. index:: no isis psnp-interval [level-1 | level-2]
+.. index:: isis psnp-interval [level-1 | level-2]
 .. clicmd:: no isis psnp-interval [level-1 | level-2]
 
    Set PSNP interval in seconds globally, for an area (level-1) or a domain
@@ -349,13 +350,13 @@ ISIS interface
 .. index:: isis three-way-handshake
 .. clicmd:: isis three-way-handshake
 
-.. index:: no isis three-way-handshake
+.. index:: isis three-way-handshake
 .. clicmd:: no isis three-way-handshake
 
    Enable or disable :rfc:`5303` Three-Way Handshake for P2P adjacencies.
    Three-Way Handshake is enabled by default.
 
-.. index:: [no] isis fast-reroute ti-lfa [level-1|level-2] [node-protection]
+.. index:: isis fast-reroute ti-lfa [level-1|level-2] [node-protection]
 .. clicmd:: [no] isis fast-reroute ti-lfa [level-1|level-2] [node-protection]
 
    Enable per-prefix TI-LFA fast reroute link or node protection.
@@ -443,7 +444,7 @@ Traffic Engineering
 .. index:: mpls-te on
 .. clicmd:: mpls-te on
 
-.. index:: no mpls-te
+.. index:: mpls-te
 .. clicmd:: no mpls-te
 
    Enable Traffic Engineering LSP flooding.
@@ -451,7 +452,7 @@ Traffic Engineering
 .. index:: mpls-te router-address <A.B.C.D>
 .. clicmd:: mpls-te router-address <A.B.C.D>
 
-.. index:: no mpls-te router-address
+.. index:: mpls-te router-address
 .. clicmd:: no mpls-te router-address
 
    Configure stable IP address for MPLS-TE.
@@ -489,33 +490,33 @@ Known limitations:
  - No support for SRLB
  - Only one SRGB and default SPF Algorithm is supported
 
-.. index:: [no] segment-routing on
+.. index:: segment-routing on
 .. clicmd:: [no] segment-routing on
 
    Enable Segment Routing.
 
-.. index:: [no] segment-routing global-block (0-1048575) (0-1048575)
+.. index:: segment-routing global-block (0-1048575) (0-1048575)
 .. clicmd:: [no] segment-routing global-block (0-1048575) (0-1048575)
 
    Set the Segment Routing Global Block i.e. the label range used by MPLS
    to store label in the MPLS FIB for Prefix SID. Note that the block size
    may not exceed 65535.
 
-.. index:: [no] segment-routing local-block (0-1048575) (0-1048575)
+.. index:: segment-routing local-block (0-1048575) (0-1048575)
 .. clicmd:: [no] segment-routing local-block (0-1048575) (0-1048575)
 
    Set the Segment Routing Local Block i.e. the label range used by MPLS
    to store label in the MPLS FIB for Adjacency SID. Note that the block size
    may not exceed 65535.
 
-.. index:: [no] segment-routing node-msd (1-16)
+.. index:: segment-routing node-msd (1-16)
 .. clicmd:: [no] segment-routing node-msd (1-16)
 
    Set the Maximum Stack Depth supported by the router. The value depend of the
    MPLS dataplane. E.g. for Linux kernel, since version 4.13 the maximum value
    is 32.
 
-.. index:: [no] segment-routing prefix <A.B.C.D/M|X:X::X:X/M> <absolute (16-1048575)|index (0-65535)> [no-php-flag|explicit-null] [n-flag-clear]
+.. index:: segment-routing prefix <A.B.C.D/M|X:X::X:X/M> <absolute (16-1048575)|index (0-65535)> [no-php-flag|explicit-null] [n-flag-clear]
 .. clicmd:: [no] segment-routing prefix <A.B.C.D/M|X:X::X:X/M> <absolute (16-1048575)|index (0-65535) [no-php-flag|explicit-null] [n-flag-clear]
 
    Set the Segment Routing index or absolute label value for the specified
@@ -542,7 +543,7 @@ Debugging ISIS
 .. index:: debug isis adj-packets
 .. clicmd:: debug isis adj-packets
 
-.. index:: no debug isis adj-packets
+.. index:: debug isis adj-packets
 .. clicmd:: no debug isis adj-packets
 
    IS-IS Adjacency related packets.
@@ -550,7 +551,7 @@ Debugging ISIS
 .. index:: debug isis checksum-errors
 .. clicmd:: debug isis checksum-errors
 
-.. index:: no debug isis checksum-errors
+.. index:: debug isis checksum-errors
 .. clicmd:: no debug isis checksum-errors
 
    IS-IS LSP checksum errors.
@@ -558,7 +559,7 @@ Debugging ISIS
 .. index:: debug isis events
 .. clicmd:: debug isis events
 
-.. index:: no debug isis events
+.. index:: debug isis events
 .. clicmd:: no debug isis events
 
    IS-IS Events.
@@ -566,7 +567,7 @@ Debugging ISIS
 .. index:: debug isis local-updates
 .. clicmd:: debug isis local-updates
 
-.. index:: no debug isis local-updates
+.. index:: debug isis local-updates
 .. clicmd:: no debug isis local-updates
 
    IS-IS local update packets.
@@ -574,7 +575,7 @@ Debugging ISIS
 .. index:: debug isis packet-dump
 .. clicmd:: debug isis packet-dump
 
-.. index:: no debug isis packet-dump
+.. index:: debug isis packet-dump
 .. clicmd:: no debug isis packet-dump
 
    IS-IS packet dump.
@@ -582,7 +583,7 @@ Debugging ISIS
 .. index:: debug isis protocol-errors
 .. clicmd:: debug isis protocol-errors
 
-.. index:: no debug isis protocol-errors
+.. index:: debug isis protocol-errors
 .. clicmd:: no debug isis protocol-errors
 
    IS-IS LSP protocol errors.
@@ -590,7 +591,7 @@ Debugging ISIS
 .. index:: debug isis route-events
 .. clicmd:: debug isis route-events
 
-.. index:: no debug isis route-events
+.. index:: debug isis route-events
 .. clicmd:: no debug isis route-events
 
    IS-IS Route related events.
@@ -598,7 +599,7 @@ Debugging ISIS
 .. index:: debug isis snp-packets
 .. clicmd:: debug isis snp-packets
 
-.. index:: no debug isis snp-packets
+.. index:: debug isis snp-packets
 .. clicmd:: no debug isis snp-packets
 
    IS-IS CSNP/PSNP packets.
@@ -612,13 +613,13 @@ Debugging ISIS
 .. index:: debug isis spf-triggers
 .. clicmd:: debug isis spf-triggers
 
-.. index:: no debug isis spf-events
+.. index:: debug isis spf-events
 .. clicmd:: no debug isis spf-events
 
-.. index:: no debug isis spf-statistics
+.. index:: debug isis spf-statistics
 .. clicmd:: no debug isis spf-statistics
 
-.. index:: no debug isis spf-triggers
+.. index:: debug isis spf-triggers
 .. clicmd:: no debug isis spf-triggers
 
    IS-IS Shortest Path First Events, Timing and Statistic Data and triggering
@@ -627,7 +628,7 @@ Debugging ISIS
 .. index:: debug isis update-packets
 .. clicmd:: debug isis update-packets
 
-.. index:: no debug isis update-packets
+.. index:: debug isis update-packets
 .. clicmd:: no debug isis update-packets
 
    Update related packets.
@@ -635,7 +636,7 @@ Debugging ISIS
 .. index:: debug isis sr-events
 .. clicmd:: debug isis sr-events
 
-.. index:: no debug isis sr-events
+.. index:: debug isis sr-events
 .. clicmd:: no debug isis sr-events
 
    IS-IS Segment Routing events.
@@ -643,7 +644,7 @@ Debugging ISIS
 .. index:: debug isis ti-lfa
 .. clicmd:: debug isis ti-lfa
 
-.. index:: no debug isis ti-lfa
+.. index:: debug isis ti-lfa
 .. clicmd:: no debug isis ti-lfa
 
    IS-IS TI-LFA events.

--- a/doc/user/ldpd.rst
+++ b/doc/user/ldpd.rst
@@ -97,29 +97,29 @@ implementation.
 LDP Configuration
 ===================
 
-.. index:: [no] mpls ldp
+.. index:: mpls ldp
 .. clicmd:: [no] mpls ldp
 
    Enable or disable LDP daemon
 
-.. index:: [no] router-id A.B.C.D
+.. index:: router-id A.B.C.D
 .. clicmd:: [no] router-id A.B.C.D
 
    The following command located under MPLS router node configures the MPLS
    router-id of the local device.
 
-.. index:: [no] ordered-control
+.. index:: ordered-control
 .. clicmd:: [no] ordered-control
 
    Configure LDP Ordered Label Distribution Control.
 
-.. index:: [no] address-family [ipv4 | ipv6]
+.. index:: address-family [ipv4 | ipv6]
 .. clicmd:: [no] address-family [ipv4 | ipv6]
 
    Configure LDP for IPv4 or IPv6 address-family. Located under MPLS route node,
    this subnode permits configuring the LDP neighbors.
 
-.. index:: [no] interface IFACE
+.. index:: interface IFACE
 .. clicmd:: [no] interface IFACE
 
    Located under MPLS address-family node, use this command to enable or disable
@@ -127,14 +127,14 @@ LDP Configuration
    enabled. By default it is disabled. Once this command executed, the
    address-family interface node is configured.
 
-.. index:: [no] discovery transport-address A.B.C.D | A:B::C:D
+.. index:: discovery transport-address A.B.C.D | A:B::C:D
 .. clicmd:: [no] discovery transport-address A.B.C.D | A:B::C:D
 
    Located under mpls address-family interface node, use this command to set
    the IPv4 or IPv6 transport-address used by the LDP protocol to talk on this
    interface.
 
-.. index:: [no] neighbor A.B.C.D password PASSWORD
+.. index:: neighbor A.B.C.D password PASSWORD
 .. clicmd:: [no] neighbor A.B.C.D password PASSWORD
 
    The following command located under MPLS router node configures the router
@@ -142,7 +142,7 @@ LDP Configuration
    configured password. PASSWORD is a clear text password wit its digest sent
    through the network.
 
-.. index:: [no] neighbor A.B.C.D holdtime HOLDTIME
+.. index:: neighbor A.B.C.D holdtime HOLDTIME
 .. clicmd:: [no] neighbor A.B.C.D holdtime HOLDTIME
 
    The following command located under MPLS router node configures the holdtime
@@ -151,10 +151,10 @@ LDP Configuration
    this time of non response, the LDP established session will be considered as
    set to down. By default, no holdtime is configured for the LDP devices.
 
-.. index:: [no] discovery hello holdtime HOLDTIME
+.. index:: discovery hello holdtime HOLDTIME
 .. clicmd:: [no] discovery hello holdtime HOLDTIME
 
-.. index:: [no] discovery hello interval INTERVAL
+.. index:: discovery hello interval INTERVAL
 .. clicmd:: [no] discovery hello interval INTERVAL
 
    INTERVAL value ranges from 1 to 65535 seconds. Default value is 5 seconds.
@@ -162,7 +162,7 @@ LDP Configuration
    HOLDTIME value ranges from 1 to 65535 seconds. Default value is 15 seconds.
    That value is added as a TLV in the LDP messages.
 
-.. index:: [no] dual-stack transport-connection prefer ipv4
+.. index:: dual-stack transport-connection prefer ipv4
 .. clicmd:: [no] dual-stack transport-connection prefer ipv4
 
    When *ldpd* is configured for dual-stack operation, the transport connection

--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -32,7 +32,7 @@ OSPF6 router
 .. index:: timers throttle spf DELAY INITIAL-HOLDTIME MAX-HOLDTIME
 .. clicmd:: timers throttle spf DELAY INITIAL-HOLDTIME MAX-HOLDTIME
 
-.. index:: no timers throttle spf
+.. index:: timers throttle spf
 .. clicmd:: no timers throttle spf
 
    This command sets the initial `delay`, the `initial-holdtime`
@@ -71,7 +71,7 @@ OSPF6 router
 .. index:: auto-cost reference-bandwidth COST
 .. clicmd:: auto-cost reference-bandwidth COST
 
-.. index:: no auto-cost reference-bandwidth
+.. index:: auto-cost reference-bandwidth
 .. clicmd:: no auto-cost reference-bandwidth
 
    This sets the reference bandwidth for cost calculations, where this

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -83,7 +83,7 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: router ospf [(1-65535)] vrf NAME
 .. clicmd:: router ospf [(1-65535)] vrf NAME
 
-.. index:: no router ospf [(1-65535)] vrf NAME
+.. index:: router ospf [(1-65535)] vrf NAME
 .. clicmd:: no router ospf [(1-65535)] vrf NAME
 
    Enable or disable the OSPF process.
@@ -91,7 +91,7 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: ospf router-id A.B.C.D
 .. clicmd:: ospf router-id A.B.C.D
 
-.. index:: no ospf router-id [A.B.C.D]
+.. index:: ospf router-id [A.B.C.D]
 .. clicmd:: no ospf router-id [A.B.C.D]
 
    This sets the router-ID of the OSPF process. The router-ID may be an IP
@@ -104,7 +104,7 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: ospf abr-type TYPE
 .. clicmd:: ospf abr-type TYPE
 
-.. index:: no ospf abr-type TYPE
+.. index:: ospf abr-type TYPE
 .. clicmd:: no ospf abr-type TYPE
 
    `type` can be cisco|ibm|shortcut|standard. The "Cisco" and "IBM" types
@@ -140,7 +140,7 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: ospf rfc1583compatibility
 .. clicmd:: ospf rfc1583compatibility
 
-.. index:: no ospf rfc1583compatibility
+.. index:: ospf rfc1583compatibility
 .. clicmd:: no ospf rfc1583compatibility
 
    :rfc:`2328`, the successor to :rfc:`1583`, suggests according
@@ -155,7 +155,7 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: log-adjacency-changes [detail]
 .. clicmd:: log-adjacency-changes [detail]
 
-.. index:: no log-adjacency-changes [detail]
+.. index:: log-adjacency-changes [detail]
 .. clicmd:: no log-adjacency-changes [detail]
 
    Configures ospfd to log changes in adjacency. With the optional
@@ -165,7 +165,7 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: passive-interface INTERFACE
 .. clicmd:: passive-interface INTERFACE
 
-.. index:: no passive-interface INTERFACE
+.. index:: passive-interface INTERFACE
 .. clicmd:: no passive-interface INTERFACE
 
    Do not speak OSPF interface on the
@@ -180,7 +180,7 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: timers throttle spf (0-600000) (0-600000) (0-600000)
 .. clicmd:: timers throttle spf (0-600000) (0-600000) (0-600000)
 
-.. index:: no timers throttle spf
+.. index:: timers throttle spf
 .. clicmd:: no timers throttle spf
 
    This command sets the initial `delay`, the `initial-holdtime`
@@ -227,7 +227,7 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: max-metric router-lsa administrative
 .. clicmd:: max-metric router-lsa administrative
 
-.. index:: no max-metric router-lsa [on-startup|on-shutdown|administrative]
+.. index:: max-metric router-lsa [on-startup|on-shutdown|administrative]
 .. clicmd:: no max-metric router-lsa [on-startup|on-shutdown|administrative]
 
    This enables :rfc:`3137` support, where the OSPF process describes its
@@ -260,7 +260,7 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: auto-cost reference-bandwidth (1-4294967)
 .. clicmd:: auto-cost reference-bandwidth (1-4294967)
 
-.. index:: no auto-cost reference-bandwidth
+.. index:: auto-cost reference-bandwidth
 .. clicmd:: no auto-cost reference-bandwidth
 
    This sets the reference
@@ -279,10 +279,10 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: network A.B.C.D/M area (0-4294967295)
 .. clicmd:: network A.B.C.D/M area (0-4294967295)
 
-.. index:: no network A.B.C.D/M area A.B.C.D
+.. index:: network A.B.C.D/M area A.B.C.D
 .. clicmd:: no network A.B.C.D/M area A.B.C.D
 
-.. index:: no network A.B.C.D/M area (0-4294967295)
+.. index:: network A.B.C.D/M area (0-4294967295)
 .. clicmd:: no network A.B.C.D/M area (0-4294967295)
 
    This command specifies the OSPF enabled interface(s). If the interface has
@@ -313,7 +313,7 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: proactive-arp
 .. clicmd:: proactive-arp
 
-.. index:: no proactive-arp
+.. index:: proactive-arp
 .. clicmd:: no proactive-arp
 
    This command enables or disables sending ARP requests to update neighbor
@@ -333,10 +333,10 @@ Areas
 .. index:: area (0-4294967295) range A.B.C.D/M
 .. clicmd:: area (0-4294967295) range A.B.C.D/M
 
-.. index:: no area A.B.C.D range A.B.C.D/M
+.. index:: area A.B.C.D range A.B.C.D/M
 .. clicmd:: no area A.B.C.D range A.B.C.D/M
 
-.. index:: no area (0-4294967295) range A.B.C.D/M
+.. index:: area (0-4294967295) range A.B.C.D/M
 .. clicmd:: no area (0-4294967295) range A.B.C.D/M
 
    Summarize intra area paths from specified area into one Type-3 summary-LSA
@@ -360,7 +360,7 @@ Areas
 .. index:: area A.B.C.D range IPV4_PREFIX not-advertise
 .. clicmd:: area A.B.C.D range IPV4_PREFIX not-advertise
 
-.. index:: no area A.B.C.D range IPV4_PREFIX not-advertise
+.. index:: area A.B.C.D range IPV4_PREFIX not-advertise
 .. clicmd:: no area A.B.C.D range IPV4_PREFIX not-advertise
 
    Instead of summarizing intra area paths filter them - i.e. intra area paths from this
@@ -370,7 +370,7 @@ Areas
 .. index:: area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
 .. clicmd:: area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
 
-.. index:: no area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
+.. index:: area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
 .. clicmd:: no area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
 
    Substitute summarized prefix with another prefix.
@@ -394,10 +394,10 @@ Areas
 .. index:: area (0-4294967295) virtual-link A.B.C.D
 .. clicmd:: area (0-4294967295) virtual-link A.B.C.D
 
-.. index:: no area A.B.C.D virtual-link A.B.C.D
+.. index:: area A.B.C.D virtual-link A.B.C.D
 .. clicmd:: no area A.B.C.D virtual-link A.B.C.D
 
-.. index:: no area (0-4294967295) virtual-link A.B.C.D
+.. index:: area (0-4294967295) virtual-link A.B.C.D
 .. clicmd:: no area (0-4294967295) virtual-link A.B.C.D
 
 .. index:: area A.B.C.D shortcut
@@ -406,10 +406,10 @@ Areas
 .. index:: area (0-4294967295) shortcut
 .. clicmd:: area (0-4294967295) shortcut
 
-.. index:: no area A.B.C.D shortcut
+.. index:: area A.B.C.D shortcut
 .. clicmd:: no area A.B.C.D shortcut
 
-.. index:: no area (0-4294967295) shortcut
+.. index:: area (0-4294967295) shortcut
 .. clicmd:: no area (0-4294967295) shortcut
 
    Configure the area as Shortcut capable. See :rfc:`3509`. This requires
@@ -421,10 +421,10 @@ Areas
 .. index:: area (0-4294967295) stub
 .. clicmd:: area (0-4294967295) stub
 
-.. index:: no area A.B.C.D stub
+.. index:: area A.B.C.D stub
 .. clicmd:: no area A.B.C.D stub
 
-.. index:: no area (0-4294967295) stub
+.. index:: area (0-4294967295) stub
 .. clicmd:: no area (0-4294967295) stub
 
    Configure the area to be a stub area. That is, an area where no router
@@ -440,10 +440,10 @@ Areas
 .. index:: area (0-4294967295) stub no-summary
 .. clicmd:: area (0-4294967295) stub no-summary
 
-.. index:: no area A.B.C.D stub no-summary
+.. index:: area A.B.C.D stub no-summary
 .. clicmd:: no area A.B.C.D stub no-summary
 
-.. index:: no area (0-4294967295) stub no-summary
+.. index:: area (0-4294967295) stub no-summary
 .. clicmd:: no area (0-4294967295) stub no-summary
 
     Prevents an *ospfd* ABR from injecting inter-area
@@ -452,7 +452,7 @@ Areas
 .. index:: area A.B.C.D default-cost (0-16777215)
 .. clicmd:: area A.B.C.D default-cost (0-16777215)
 
-.. index:: no area A.B.C.D default-cost (0-16777215)
+.. index:: area A.B.C.D default-cost (0-16777215)
 .. clicmd:: no area A.B.C.D default-cost (0-16777215)
 
    Set the cost of default-summary LSAs announced to stubby areas.
@@ -463,10 +463,10 @@ Areas
 .. index:: area (0-4294967295) export-list NAME
 .. clicmd:: area (0-4294967295) export-list NAME
 
-.. index:: no area A.B.C.D export-list NAME
+.. index:: area A.B.C.D export-list NAME
 .. clicmd:: no area A.B.C.D export-list NAME
 
-.. index:: no area (0-4294967295) export-list NAME
+.. index:: area (0-4294967295) export-list NAME
 .. clicmd:: no area (0-4294967295) export-list NAME
 
    Filter Type-3 summary-LSAs announced to other areas originated from intra-
@@ -496,10 +496,10 @@ Areas
 .. index:: area (0-4294967295) import-list NAME
 .. clicmd:: area (0-4294967295) import-list NAME
 
-.. index:: no area A.B.C.D import-list NAME
+.. index:: area A.B.C.D import-list NAME
 .. clicmd:: no area A.B.C.D import-list NAME
 
-.. index:: no area (0-4294967295) import-list NAME
+.. index:: area (0-4294967295) import-list NAME
 .. clicmd:: no area (0-4294967295) import-list NAME
 
    Same as export-list, but it applies to paths announced into specified area
@@ -517,16 +517,16 @@ Areas
 .. index:: area (0-4294967295) filter-list prefix NAME out
 .. clicmd:: area (0-4294967295) filter-list prefix NAME out
 
-.. index:: no area A.B.C.D filter-list prefix NAME in
+.. index:: area A.B.C.D filter-list prefix NAME in
 .. clicmd:: no area A.B.C.D filter-list prefix NAME in
 
-.. index:: no area A.B.C.D filter-list prefix NAME out
+.. index:: area A.B.C.D filter-list prefix NAME out
 .. clicmd:: no area A.B.C.D filter-list prefix NAME out
 
-.. index:: no area (0-4294967295) filter-list prefix NAME in
+.. index:: area (0-4294967295) filter-list prefix NAME in
 .. clicmd:: no area (0-4294967295) filter-list prefix NAME in
 
-.. index:: no area (0-4294967295) filter-list prefix NAME out
+.. index:: area (0-4294967295) filter-list prefix NAME out
 .. clicmd:: no area (0-4294967295) filter-list prefix NAME out
 
    Filtering Type-3 summary-LSAs to/from area using prefix lists. This command
@@ -538,10 +538,10 @@ Areas
 .. index:: area (0-4294967295) authentication
 .. clicmd:: area (0-4294967295) authentication
 
-.. index:: no area A.B.C.D authentication
+.. index:: area A.B.C.D authentication
 .. clicmd:: no area A.B.C.D authentication
 
-.. index:: no area (0-4294967295) authentication
+.. index:: area (0-4294967295) authentication
 .. clicmd:: no area (0-4294967295) authentication
 
    Specify that simple password authentication should be used for the given
@@ -569,7 +569,7 @@ Interfaces
 .. index:: ip ospf area AREA [ADDR]
 .. clicmd:: ip ospf area AREA [ADDR]
 
-.. index:: no ip ospf area [ADDR]
+.. index:: ip ospf area [ADDR]
 .. clicmd:: no ip ospf area [ADDR]
 
    Enable OSPF on the interface, optionally restricted to just the IP address
@@ -583,7 +583,7 @@ Interfaces
 .. index:: ip ospf authentication-key AUTH_KEY
 .. clicmd:: ip ospf authentication-key AUTH_KEY
 
-.. index:: no ip ospf authentication-key
+.. index:: ip ospf authentication-key
 .. clicmd:: no ip ospf authentication-key
 
    Set OSPF authentication key to a simple password. After setting `AUTH_KEY`,
@@ -612,7 +612,7 @@ Interfaces
 .. index:: ip ospf message-digest-key KEYID md5 KEY
 .. clicmd:: ip ospf message-digest-key KEYID md5 KEY
 
-.. index:: no ip ospf message-digest-key
+.. index:: ip ospf message-digest-key
 .. clicmd:: no ip ospf message-digest-key
 
    Set OSPF authentication key to a cryptographic password. The cryptographic
@@ -627,7 +627,7 @@ Interfaces
 .. index:: ip ospf cost (1-65535)
 .. clicmd:: ip ospf cost (1-65535)
 
-.. index:: no ip ospf cost
+.. index:: ip ospf cost
 .. clicmd:: no ip ospf cost
 
    Set link cost for the specified interface. The cost value is set to
@@ -639,7 +639,7 @@ Interfaces
 .. index:: ip ospf dead-interval minimal hello-multiplier (2-20)
 .. clicmd:: ip ospf dead-interval minimal hello-multiplier (2-20)
 
-.. index:: no ip ospf dead-interval
+.. index:: ip ospf dead-interval
 .. clicmd:: no ip ospf dead-interval
 
    Set number of seconds for RouterDeadInterval timer value used for Wait Timer
@@ -658,7 +658,7 @@ Interfaces
 .. index:: ip ospf hello-interval (1-65535)
 .. clicmd:: ip ospf hello-interval (1-65535)
 
-.. index:: no ip ospf hello-interval
+.. index:: ip ospf hello-interval
 .. clicmd:: no ip ospf hello-interval
 
    Set number of seconds for HelloInterval timer value. Setting this value,
@@ -679,7 +679,7 @@ Interfaces
    net.ipv4.conf.<interface name>.rp_filter value to 0.  In order for
    the ospf multicast packets to be delivered by the kernel.
 
-.. index:: no ip ospf network
+.. index:: ip ospf network
 .. clicmd:: no ip ospf network
 
    Set explicitly network type for specified interface.
@@ -687,7 +687,7 @@ Interfaces
 .. index:: ip ospf priority (0-255)
 .. clicmd:: ip ospf priority (0-255)
 
-.. index:: no ip ospf priority
+.. index:: ip ospf priority
 .. clicmd:: no ip ospf priority
 
    Set RouterPriority integer value. The router with the highest priority will
@@ -697,7 +697,7 @@ Interfaces
 .. index:: ip ospf retransmit-interval (1-65535)
 .. clicmd:: ip ospf retransmit-interval (1-65535)
 
-.. index:: no ip ospf retransmit interval
+.. index:: ip ospf retransmit interval
 .. clicmd:: no ip ospf retransmit interval
 
    Set number of seconds for RxmtInterval timer value. This value is used when
@@ -707,7 +707,7 @@ Interfaces
 .. index:: ip ospf transmit-delay (1-65535) [A.B.C.D]
 .. clicmd:: ip ospf transmit-delay (1-65535) [A.B.C.D]
 
-.. index:: no ip ospf transmit-delay [(1-65535)] [A.B.C.D]
+.. index:: ip ospf transmit-delay [(1-65535)] [A.B.C.D]
 .. clicmd:: no ip ospf transmit-delay [(1-65535)] [A.B.C.D]
 
    Set number of seconds for InfTransDelay value. LSAs' age should be
@@ -716,7 +716,7 @@ Interfaces
 .. index:: ip ospf area (A.B.C.D|(0-4294967295))
 .. clicmd:: ip ospf area (A.B.C.D|(0-4294967295))
 
-.. index:: no ip ospf area
+.. index:: ip ospf area
 .. clicmd:: no ip ospf area
 
    Enable ospf on an interface and set associated area.
@@ -762,7 +762,7 @@ Redistribution
 .. index:: redistribute (kernel|connected|static|rip|bgp) metric-type (1|2) metric (0-16777214) route-map WORD
 .. clicmd:: redistribute (kernel|connected|static|rip|bgp) metric-type (1|2) metric (0-16777214) route-map WORD
 
-.. index:: no redistribute (kernel|connected|static|rip|bgp)
+.. index:: redistribute (kernel|connected|static|rip|bgp)
 .. clicmd:: no redistribute (kernel|connected|static|rip|bgp)
 
 .. _ospf-redistribute:
@@ -809,7 +809,7 @@ Redistribution
 .. index:: default-information originate always metric (0-16777214) metric-type (1|2) route-map WORD
 .. clicmd:: default-information originate always metric (0-16777214) metric-type (1|2) route-map WORD
 
-.. index:: no default-information originate
+.. index:: default-information originate
 .. clicmd:: no default-information originate
 
    Originate an AS-External (type-5) LSA describing a default route into all
@@ -820,7 +820,7 @@ Redistribution
 .. index:: distribute-list NAME out (kernel|connected|static|rip|ospf
 .. clicmd:: distribute-list NAME out (kernel|connected|static|rip|ospf
 
-.. index:: no distribute-list NAME out (kernel|connected|static|rip|ospf
+.. index:: distribute-list NAME out (kernel|connected|static|rip|ospf
 .. clicmd:: no distribute-list NAME out (kernel|connected|static|rip|ospf
 
 .. _ospf-distribute-list:
@@ -832,25 +832,25 @@ Redistribution
 .. index:: default-metric (0-16777214)
 .. clicmd:: default-metric (0-16777214)
 
-.. index:: no default-metric
+.. index:: default-metric
 .. clicmd:: no default-metric
 
 .. index:: distance (1-255)
 .. clicmd:: distance (1-255)
 
-.. index:: no distance (1-255)
+.. index:: distance (1-255)
 .. clicmd:: no distance (1-255)
 
 .. index:: distance ospf (intra-area|inter-area|external) (1-255)
 .. clicmd:: distance ospf (intra-area|inter-area|external) (1-255)
 
-.. index:: no distance ospf
+.. index:: distance ospf
 .. clicmd:: no distance ospf
 
 .. index:: router zebra
 .. clicmd:: router zebra
 
-.. index:: no router zebra
+.. index:: router zebra
 .. clicmd:: no router zebra
 
 Graceful Restart Helper
@@ -859,7 +859,7 @@ Graceful Restart Helper
 .. index:: graceful-restart helper-only [A.B.C.D]
 .. clicmd:: graceful-restart helper-only [A.B.C.D]
 
-.. index:: no graceful-restart helper-only [A.B.C.D]
+.. index:: graceful-restart helper-only [A.B.C.D]
 .. clicmd:: no graceful-restart helper-only [A.B.C.D]
 
    Configure Graceful Restart (RFC 3623) helper support.
@@ -872,7 +872,7 @@ Graceful Restart Helper
 .. index:: graceful-restart helper strict-lsa-checking
 .. clicmd:: graceful-restart helper strict-lsa-checking
 
-.. index:: no graceful-restart helper strict-lsa-checking
+.. index:: graceful-restart helper strict-lsa-checking
 .. clicmd:: no graceful-restart helper strict-lsa-checking
 
    If 'strict-lsa-checking' is configured then the helper will
@@ -883,7 +883,7 @@ Graceful Restart Helper
 .. index:: graceful-restart helper supported-grace-time
 .. clicmd:: graceful-restart helper supported-grace-time
 
-.. index:: no graceful-restart helper supported-grace-time
+.. index:: graceful-restart helper supported-grace-time
 .. clicmd:: no graceful-restart helper supported-grace-time
 
    Supports as HELPER for configured grace period.
@@ -891,7 +891,7 @@ Graceful Restart Helper
 .. index:: graceful-restart helper planned-only
 .. clicmd:: graceful-restart helper planned-only
 
-.. index:: no graceful-restart helper planned-only
+.. index:: graceful-restart helper planned-only
 .. clicmd:: no graceful-restart helper planned-only
 
    It helps to support as HELPER only for planned
@@ -983,10 +983,10 @@ Opaque LSA
 .. index:: capability opaque
 .. clicmd:: capability opaque
 
-.. index:: no ospf opaque-lsa
+.. index:: ospf opaque-lsa
 .. clicmd:: no ospf opaque-lsa
 
-.. index:: no capability opaque
+.. index:: capability opaque
 .. clicmd:: no capability opaque
 
    *ospfd* supports Opaque LSA (:rfc:`2370`) as partial support for
@@ -1031,7 +1031,7 @@ Traffic Engineering
 .. index:: mpls-te on
 .. clicmd:: mpls-te on
 
-.. index:: no mpls-te
+.. index:: mpls-te
 .. clicmd:: no mpls-te
 
    Enable Traffic Engineering LSA flooding.
@@ -1045,7 +1045,7 @@ Traffic Engineering
 .. index:: mpls-te inter-as area <area-id>|as
 .. clicmd:: mpls-te inter-as area <area-id>|as
 
-.. index:: no mpls-te inter-as
+.. index:: mpls-te inter-as
 .. clicmd:: no mpls-te inter-as
 
    Enable :rfc:`5392` support - Inter-AS TE v2 - to flood Traffic Engineering
@@ -1074,7 +1074,7 @@ Router Information
 .. index:: router-info [as | area]
 .. clicmd:: router-info [as | area]
 
-.. index:: no router-info
+.. index:: router-info
 .. clicmd:: no router-info
 
    Enable Router Information (:rfc:`4970`) LSA advertisement with AS scope
@@ -1086,31 +1086,31 @@ Router Information
 .. index:: pce address <A.B.C.D>
 .. clicmd:: pce address <A.B.C.D>
 
-.. index:: no pce address
+.. index:: pce address
 .. clicmd:: no pce address
 
 .. index:: pce domain as (0-65535)
 .. clicmd:: pce domain as (0-65535)
 
-.. index:: no pce domain as (0-65535)
+.. index:: pce domain as (0-65535)
 .. clicmd:: no pce domain as (0-65535)
 
 .. index:: pce neighbor as (0-65535)
 .. clicmd:: pce neighbor as (0-65535)
 
-.. index:: no pce neighbor as (0-65535)
+.. index:: pce neighbor as (0-65535)
 .. clicmd:: no pce neighbor as (0-65535)
 
 .. index:: pce flag BITPATTERN
 .. clicmd:: pce flag BITPATTERN
 
-.. index:: no pce flag
+.. index:: pce flag
 .. clicmd:: no pce flag
 
 .. index:: pce scope BITPATTERN
 .. clicmd:: pce scope BITPATTERN
 
-.. index:: no pce scope
+.. index:: pce scope
 .. clicmd:: no pce scope
 
    The commands are conform to :rfc:`5088` and allow OSPF router announce Path
@@ -1139,32 +1139,32 @@ Segment Routing
 This is an EXPERIMENTAL support of Segment Routing as per `RFC 8665` for MPLS
 dataplane.
 
-.. index:: [no] segment-routing on
+.. index:: segment-routing on
 .. clicmd:: [no] segment-routing on
 
    Enable Segment Routing. Even if this also activate routing information
    support, it is preferable to also activate routing information, and set
    accordingly the Area or AS flooding.
 
-.. index:: [no] segment-routing global-block (0-1048575) (0-1048575)
+.. index:: segment-routing global-block (0-1048575) (0-1048575)
 .. clicmd:: [no] segment-routing global-block (0-1048575) (0-1048575)
 
    Fix the Segment Routing Global Block i.e. the label range used by MPLS to
    store label in the MPLS FIB for Prefix SID.
 
-.. index:: [no] segment-routing local-block (0-1048575) (0-1048575)
+.. index:: segment-routing local-block (0-1048575) (0-1048575)
 .. clicmd:: [no] segment-routing local-block (0-1048575) (0-1048575)
 
    Fix the Segment Routing Local Block i.e. the label range used by MPLS to
    store label in the MPLS FIB for Adjacency SID.
 
-.. index:: [no] segment-routing node-msd (1-16)
+.. index:: segment-routing node-msd (1-16)
 .. clicmd:: [no] segment-routing node-msd (1-16)
 
    Fix the Maximum Stack Depth supported by the router. The value depend of the
    MPLS dataplane. E.g. for Linux kernel, since version 4.13 it is 32.
 
-.. index:: [no] segment-routing prefix A.B.C.D/M index (0-65535) [no-php-flag|explicit-null]
+.. index:: segment-routing prefix A.B.C.D/M index (0-65535) [no-php-flag|explicit-null]
 .. clicmd:: [no] segment-routing prefix A.B.C.D/M [index (0-65535)|no-php-flag|explicit-null]
 
    Set the Segment Routing index for the specified prefix. Note that, only
@@ -1186,14 +1186,14 @@ External Route Summarisation
 This feature summarises originated external LSAs(Type-5 and Type-7).
 Summary Route will be originated on-behalf of all matched external LSAs.
 
-.. index:: [no] summary-address A.B.C.D/M [tag (1-4294967295)]
+.. index:: summary-address A.B.C.D/M [tag (1-4294967295)]
 .. clicmd:: [no] summary-address A.B.C.D/M [tag (1-4294967295)]
 
    This command enable/disables summarisation for the configured address
    range. Tag is the optional parameter. If tag configured Summary route
    will be originated with the configured tag.
 
-.. index:: [no] summary-address A.B.C.D/M no-advertise
+.. index:: summary-address A.B.C.D/M no-advertise
 .. clicmd:: [no] summary-address A.B.C.D/M no-advertise
 
    This command to ensure not advertise the summary lsa for the matched
@@ -1205,7 +1205,7 @@ Summary Route will be originated on-behalf of all matched external LSAs.
    Configure aggregation delay timer interval. Summarisation starts only after
    this delay timer expiry. By default, delay interval is 5 secs.
 
-.. index:: no aggregation timer
+.. index:: aggregation timer
 .. clicmd:: no aggregation timer
 
    Resetting the aggregation delay interval to default value.
@@ -1222,7 +1222,7 @@ Debugging OSPF
 .. index:: debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 .. clicmd:: debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 
-.. index:: no debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
+.. index:: debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 .. clicmd:: no debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 
    Dump Packet for debugging
@@ -1233,10 +1233,10 @@ Debugging OSPF
 .. index:: debug ospf ism (status|events|timers)
 .. clicmd:: debug ospf ism (status|events|timers)
 
-.. index:: no debug ospf ism
+.. index:: debug ospf ism
 .. clicmd:: no debug ospf ism
 
-.. index:: no debug ospf ism (status|events|timers)
+.. index:: debug ospf ism (status|events|timers)
 .. clicmd:: no debug ospf ism (status|events|timers)
 
    Show debug information of Interface State Machine
@@ -1247,10 +1247,10 @@ Debugging OSPF
 .. index:: debug ospf nsm (status|events|timers)
 .. clicmd:: debug ospf nsm (status|events|timers)
 
-.. index:: no debug ospf nsm
+.. index:: debug ospf nsm
 .. clicmd:: no debug ospf nsm
 
-.. index:: no debug ospf nsm (status|events|timers)
+.. index:: debug ospf nsm (status|events|timers)
 .. clicmd:: no debug ospf nsm (status|events|timers)
 
    Show debug information of Network State Machine
@@ -1258,7 +1258,7 @@ Debugging OSPF
 .. index:: debug ospf event
 .. clicmd:: debug ospf event
 
-.. index:: no debug ospf event
+.. index:: debug ospf event
 .. clicmd:: no debug ospf event
 
    Show debug information of OSPF event
@@ -1266,7 +1266,7 @@ Debugging OSPF
 .. index:: debug ospf nssa
 .. clicmd:: debug ospf nssa
 
-.. index:: no debug ospf nssa
+.. index:: debug ospf nssa
 .. clicmd:: no debug ospf nssa
 
    Show debug information about Not So Stub Area
@@ -1277,10 +1277,10 @@ Debugging OSPF
 .. index:: debug ospf lsa (generate|flooding|refresh)
 .. clicmd:: debug ospf lsa (generate|flooding|refresh)
 
-.. index:: no debug ospf lsa
+.. index:: debug ospf lsa
 .. clicmd:: no debug ospf lsa
 
-.. index:: no debug ospf lsa (generate|flooding|refresh)
+.. index:: debug ospf lsa (generate|flooding|refresh)
 .. clicmd:: no debug ospf lsa (generate|flooding|refresh)
 
    Show debug detail of Link State messages
@@ -1288,7 +1288,7 @@ Debugging OSPF
 .. index:: debug ospf te
 .. clicmd:: debug ospf te
 
-.. index:: no debug ospf te
+.. index:: debug ospf te
 .. clicmd:: no debug ospf te
 
    Show debug information about Traffic Engineering LSA
@@ -1299,10 +1299,10 @@ Debugging OSPF
 .. index:: debug ospf zebra (interface|redistribute)
 .. clicmd:: debug ospf zebra (interface|redistribute)
 
-.. index:: no debug ospf zebra
+.. index:: debug ospf zebra
 .. clicmd:: no debug ospf zebra
 
-.. index:: no debug ospf zebra (interface|redistribute)
+.. index:: debug ospf zebra (interface|redistribute)
 .. clicmd:: no debug ospf zebra (interface|redistribute)
 
    Show debug information of ZEBRA API
@@ -1310,7 +1310,7 @@ Debugging OSPF
 .. index:: debug ospf graceful-restart helper
 .. clicmd:: debug ospf graceful-restart helper
 
-.. index:: no debug ospf graceful-restart helper
+.. index:: debug ospf graceful-restart helper
 .. clicmd:: no debug ospf graceful-restart helper
 
    Enable/disable debug information for OSPF Graceful Restart Helper
@@ -1318,7 +1318,7 @@ Debugging OSPF
 .. index:: show debugging ospf
 .. clicmd:: show debugging ospf
 
-.. index:: [no] debug ospf lsa aggregate
+.. index:: debug ospf lsa aggregate
 .. clicmd:: [no] debug ospf lsa aggregate
 
    Debug commnd to enable/disable external route summarisation specific debugs.

--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -166,18 +166,18 @@ Certain signals have special meanings to *pimd*.
    urib-only
       Lookup in the Unicast Rib only.
 
-.. index:: [no] ip msdp mesh-group [WORD]
+.. index:: ip msdp mesh-group [WORD]
 .. clicmd:: [no] ip msdp mesh-group [WORD]
 
    Create or Delete a multicast source discovery protocol mesh-group using
    [WORD] as the group name.
 
-.. index:: [no] ip msdp mesh-group WORD member A.B.C.D
+.. index:: ip msdp mesh-group WORD member A.B.C.D
 .. clicmd:: [no] ip msdp mesh-group WORD member A.B.C.D
 
    Attach or Delete A.B.C.D to the MSDP mesh group WORD specified.
 
-.. index:: [no] ip msdp mesh-group WORD source A.B.C.D
+.. index:: ip msdp mesh-group WORD source A.B.C.D
 .. clicmd:: [no] ip msdp mesh-group WORD source A.B.C.D
 
    For the address specified A.B.C.D use that as the source address for
@@ -190,7 +190,7 @@ Certain signals have special meanings to *pimd*.
    the existing IGMP general query timer.If no version is provided in the cli,
    it will be considered as default v2 query.This is a hidden command.
 
-.. index:: [no] ip igmp watermark-warn (10-60000)
+.. index:: ip igmp watermark-warn (10-60000)
 .. clicmd:: [no] ip igmp watermark-warn (10-60000)
 
    Configure watermark warning generation for an igmp group limit. Generates
@@ -252,7 +252,7 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    reports on the interface. Refer to the next `ip igmp` command for IGMP
    management.
 
-.. index:: [no] ip pim use-source A.B.C.D
+.. index:: ip pim use-source A.B.C.D
 .. clicmd:: [no] ip pim use-source A.B.C.D
 
    If you have multiple addresses configured on a particular interface
@@ -358,17 +358,17 @@ Multicast Source Discovery Protocol (MSDP) Configuration
 
    Establish a MSDP connection with a peer.
 
-.. index:: no ip msdp mesh-group [WORD] member A.B.C.D
+.. index:: ip msdp mesh-group [WORD] member A.B.C.D
 .. clicmd:: no ip msdp mesh-group [WORD] member A.B.C.D
 
    Remove a MSDP peer member from a MSDP mesh-group.
 
-.. index:: no ip msdp mesh-group [WORD] source A.B.C.D
+.. index:: ip msdp mesh-group [WORD] source A.B.C.D
 .. clicmd:: no ip msdp mesh-group [WORD] source A.B.C.D
 
    Delete a MSDP mesh-group.
 
-.. index:: no ip msdp peer A.B.C.D
+.. index:: ip msdp peer A.B.C.D
 .. clicmd:: no ip msdp peer A.B.C.D
 
    Delete a MSDP peer connection.

--- a/doc/user/ripd.rst
+++ b/doc/user/ripd.rst
@@ -94,7 +94,7 @@ RIP Configuration
    `no router rip` command. RIP must be enabled before carrying out any of the
    RIP commands.
 
-.. index:: no router rip
+.. index:: router rip
 .. clicmd:: no router rip
 
    Disable RIP.
@@ -102,7 +102,7 @@ RIP Configuration
 .. index:: network NETWORK
 .. clicmd:: network NETWORK
 
-.. index:: no network NETWORK
+.. index:: network NETWORK
 .. clicmd:: no network NETWORK
 
    Set the RIP enable interface by NETWORK. The interfaces which have addresses
@@ -117,7 +117,7 @@ RIP Configuration
 .. index:: network IFNAME
 .. clicmd:: network IFNAME
 
-.. index:: no network IFNAME
+.. index:: network IFNAME
 .. clicmd:: no network IFNAME
 
    Set a RIP enabled interface by IFNAME. Both the sending and
@@ -128,7 +128,7 @@ RIP Configuration
 .. index:: neighbor A.B.C.D
 .. clicmd:: neighbor A.B.C.D
 
-.. index:: no neighbor A.B.C.D
+.. index:: neighbor A.B.C.D
 .. clicmd:: no neighbor A.B.C.D
 
    Specify RIP neighbor. When a neighbor doesn't understand multicast, this
@@ -155,7 +155,7 @@ RIP Configuration
 .. index:: passive-interface (IFNAME|default)
 .. clicmd:: passive-interface (IFNAME|default)
 
-.. index:: no passive-interface IFNAME
+.. index:: passive-interface IFNAME
 .. clicmd:: no passive-interface IFNAME
 
    This command sets the specified interface to passive mode. On passive mode
@@ -169,7 +169,7 @@ RIP Configuration
 .. index:: ip split-horizon
 .. clicmd:: ip split-horizon
 
-.. index:: no ip split-horizon
+.. index:: ip split-horizon
 .. clicmd:: no ip split-horizon
 
    Control split-horizon on the interface. Default is `ip split-horizon`. If
@@ -203,7 +203,7 @@ discussion on the security implications of RIPv1 see :ref:`rip-authentication`.
 
    Default: Send Version 2, and accept either version.
 
-.. index:: no version
+.. index:: version
 .. clicmd:: no version
 
    Reset the global version setting back to the default.
@@ -246,7 +246,7 @@ How to Announce RIP route
 .. index:: redistribute kernel route-map ROUTE-MAP
 .. clicmd:: redistribute kernel route-map ROUTE-MAP
 
-.. index:: no redistribute kernel
+.. index:: redistribute kernel
 .. clicmd:: no redistribute kernel
 
    `redistribute kernel` redistributes routing information from kernel route
@@ -261,7 +261,7 @@ How to Announce RIP route
 .. index:: redistribute static route-map ROUTE-MAP
 .. clicmd:: redistribute static route-map ROUTE-MAP
 
-.. index:: no redistribute static
+.. index:: redistribute static
 .. clicmd:: no redistribute static
 
    `redistribute static` redistributes routing information from static route
@@ -276,7 +276,7 @@ How to Announce RIP route
 .. index:: redistribute connected route-map ROUTE-MAP
 .. clicmd:: redistribute connected route-map ROUTE-MAP
 
-.. index:: no redistribute connected
+.. index:: redistribute connected
 .. clicmd:: no redistribute connected
 
    Redistribute connected routes into the RIP tables. `no redistribute
@@ -293,7 +293,7 @@ How to Announce RIP route
 .. index:: redistribute ospf route-map ROUTE-MAP
 .. clicmd:: redistribute ospf route-map ROUTE-MAP
 
-.. index:: no redistribute ospf
+.. index:: redistribute ospf
 .. clicmd:: no redistribute ospf
 
    `redistribute ospf` redistributes routing information from ospf route
@@ -308,7 +308,7 @@ How to Announce RIP route
 .. index:: redistribute bgp route-map ROUTE-MAP
 .. clicmd:: redistribute bgp route-map ROUTE-MAP
 
-.. index:: no redistribute bgp
+.. index:: redistribute bgp
 .. clicmd:: no redistribute bgp
 
    `redistribute bgp` redistributes routing information from bgp route entries
@@ -322,7 +322,7 @@ How to Announce RIP route
 .. index:: route A.B.C.D/M
 .. clicmd:: route A.B.C.D/M
 
-.. index:: no route A.B.C.D/M
+.. index:: route A.B.C.D/M
 .. clicmd:: no route A.B.C.D/M
 
    This command is specific to FRR. The `route` command makes a static route
@@ -384,7 +384,7 @@ received. Redistributed routes' metric is set to 1.
 .. index:: default-metric (1-16)
 .. clicmd:: default-metric (1-16)
 
-.. index:: no default-metric (1-16)
+.. index:: default-metric (1-16)
 .. clicmd:: no default-metric (1-16)
 
    This command modifies the default metric value for redistributed routes.
@@ -410,7 +410,7 @@ Distance value is used in zebra daemon. Default RIP distance is 120.
 .. index:: distance (1-255)
 .. clicmd:: distance (1-255)
 
-.. index:: no distance (1-255)
+.. index:: distance (1-255)
 .. clicmd:: no distance (1-255)
 
    Set default RIP distance to specified value.
@@ -418,7 +418,7 @@ Distance value is used in zebra daemon. Default RIP distance is 120.
 .. index:: distance (1-255) A.B.C.D/M
 .. clicmd:: distance (1-255) A.B.C.D/M
 
-.. index:: no distance (1-255) A.B.C.D/M
+.. index:: distance (1-255) A.B.C.D/M
 .. clicmd:: no distance (1-255) A.B.C.D/M
 
    Set default RIP distance to specified value when the route's source IP
@@ -427,7 +427,7 @@ Distance value is used in zebra daemon. Default RIP distance is 120.
 .. index:: distance (1-255) A.B.C.D/M ACCESS-LIST
 .. clicmd:: distance (1-255) A.B.C.D/M ACCESS-LIST
 
-.. index:: no distance (1-255) A.B.C.D/M ACCESS-LIST
+.. index:: distance (1-255) A.B.C.D/M ACCESS-LIST
 .. clicmd:: no distance (1-255) A.B.C.D/M ACCESS-LIST
 
    Set default RIP distance to specified value when the route's source IP
@@ -539,7 +539,7 @@ To prevent such unauthenticated querying of routes disable RIPv1,
 .. index:: ip rip authentication mode md5
 .. clicmd:: ip rip authentication mode md5
 
-.. index:: no ip rip authentication mode md5
+.. index:: ip rip authentication mode md5
 .. clicmd:: no ip rip authentication mode md5
 
    Set the interface with RIPv2 MD5 authentication.
@@ -547,7 +547,7 @@ To prevent such unauthenticated querying of routes disable RIPv1,
 .. index:: ip rip authentication mode text
 .. clicmd:: ip rip authentication mode text
 
-.. index:: no ip rip authentication mode text
+.. index:: ip rip authentication mode text
 .. clicmd:: no ip rip authentication mode text
 
    Set the interface with RIPv2 simple password authentication.
@@ -555,7 +555,7 @@ To prevent such unauthenticated querying of routes disable RIPv1,
 .. index:: ip rip authentication string STRING
 .. clicmd:: ip rip authentication string STRING
 
-.. index:: no ip rip authentication string STRING
+.. index:: ip rip authentication string STRING
 .. clicmd:: no ip rip authentication string STRING
 
    RIP version 2 has simple text authentication. This command sets
@@ -564,7 +564,7 @@ To prevent such unauthenticated querying of routes disable RIPv1,
 .. index:: ip rip authentication key-chain KEY-CHAIN
 .. clicmd:: ip rip authentication key-chain KEY-CHAIN
 
-.. index:: no ip rip authentication key-chain KEY-CHAIN
+.. index:: ip rip authentication key-chain KEY-CHAIN
 .. clicmd:: no ip rip authentication key-chain KEY-CHAIN
 
    Specify Keyed MD5 chain.
@@ -610,7 +610,7 @@ RIP Timers
    The ``timers basic`` command allows the the default values of the timers
    listed above to be changed.
 
-.. index:: no timers basic
+.. index:: timers basic
 .. clicmd:: no timers basic
 
    The `no timers basic` command will reset the timers to the default settings

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -288,7 +288,7 @@ Route Map Set Command
 
    Subtract the BGP local preference from an existing `local_pref`.
 
-.. index:: [no] set distance DISTANCE
+.. index:: set distance DISTANCE
 .. clicmd:: [no] set distance DISTANCE
 
    Set the Administrative distance to DISTANCE to use for the route.
@@ -299,7 +299,7 @@ Route Map Set Command
 
    Set the route's weight.
 
-.. index:: [no] set metric <[+|-](1-4294967295)|rtt|+rtt|-rtt>
+.. index:: set metric <[+|-](1-4294967295)|rtt|+rtt|-rtt>
 .. clicmd:: [no] set metric <[+|-](1-4294967295)|rtt|+rtt|-rtt>
 
    Set the BGP attribute MED to a specific value. Use `+`/`-` to add or subtract
@@ -387,7 +387,7 @@ Route Map Optimization Command
    of all the prefixes in all the prefix-lists that are included in the
    match rule of all the sequences of a route-map.
 
-.. index:: no route-map optimization
+.. index:: route-map optimization
 .. clicmd:: no route-map optimization
 
    Disable the route-map processing optimization.

--- a/doc/user/rpki.rst
+++ b/doc/user/rpki.rst
@@ -104,7 +104,7 @@ The following commands are independent of a specific cache server.
 .. index:: rpki polling_period (1-3600)
 .. clicmd:: rpki polling_period (1-3600)
 
-.. index:: no rpki polling_period
+.. index:: rpki polling_period
 .. clicmd:: no rpki polling_period
 
    Set the number of seconds the router waits until the router asks the cache
@@ -117,7 +117,7 @@ The following commands are independent of a specific cache server.
 .. index:: rpki cache (A.B.C.D|WORD) PORT [SSH_USERNAME] [SSH_PRIVKEY_PATH] [SSH_PUBKEY_PATH] [KNOWN_HOSTS_PATH] PREFERENCE
 .. clicmd:: rpki cache (A.B.C.D|WORD) PORT [SSH_USERNAME] [SSH_PRIVKEY_PATH] [SSH_PUBKEY_PATH] [KNOWN_HOSTS_PATH] PREFERENCE
 
-.. index:: no rpki cache (A.B.C.D|WORD) [PORT] PREFERENCE
+.. index:: rpki cache (A.B.C.D|WORD) [PORT] PREFERENCE
 .. clicmd:: no rpki cache (A.B.C.D|WORD) [PORT] PREFERENCE
 
    Add a cache server to the socket. By default, the connection between router
@@ -157,7 +157,7 @@ Validating BGP Updates
 .. index:: match rpki notfound|invalid|valid
 .. clicmd:: match rpki notfound|invalid|valid
 
-.. index:: no match rpki notfound|invalid|valid
+.. index:: match rpki notfound|invalid|valid
 .. clicmd:: no match rpki notfound|invalid|valid
 
     Create a clause for a route map to match prefixes with the specified RPKI
@@ -190,7 +190,7 @@ Debugging
 .. index:: debug rpki
 .. clicmd:: debug rpki
 
-.. index:: no debug rpki
+.. index:: debug rpki
 .. clicmd:: no debug rpki
 
    Enable or disable debugging output for RPKI.

--- a/doc/user/snmp.rst
+++ b/doc/user/snmp.rst
@@ -130,7 +130,7 @@ Here is the syntax for using AgentX:
 
 .. index:: agentx
 .. clicmd:: agentx
-.. index:: no agentx
+.. index:: agentx
 .. clicmd:: no agentx
 
 

--- a/doc/user/vnc.rst
+++ b/doc/user/vnc.rst
@@ -149,7 +149,7 @@ Defaults section.
      exit-vnc
 
 
-.. index:: no vnc nve-group NAME
+.. index:: vnc nve-group NAME
 .. clicmd:: no vnc nve-group NAME
 
    Delete the NVE group named `name`.
@@ -322,7 +322,7 @@ L2 Group Configuration.
        exit-vnc
 
 
-.. index:: no vnc l2-group NAME
+.. index:: vnc l2-group NAME
 .. clicmd:: no vnc l2-group NAME
 
    Delete the L2 group named `name`.
@@ -338,7 +338,7 @@ The following statements are valid in a L2 group definition:
 .. index:: labels LABEL-LIST
 .. clicmd:: labels LABEL-LIST
 
-.. index:: no labels LABEL-LIST
+.. index:: labels LABEL-LIST
 .. clicmd:: no labels LABEL-LIST
 
    Add or remove labels associated with the group. `label-list` is a
@@ -490,7 +490,7 @@ Redistribution Command Syntax
 .. index:: vnc redistribute ipv4|ipv6 bgp-direct-to-nve-groups view VIEWNAME
 .. clicmd:: vnc redistribute ipv4|ipv6 bgp-direct-to-nve-groups view VIEWNAME
 
-.. index:: no vnc redistribute ipv4|ipv6 bgp|bgp-direct|bgp-direct-to-nve-groups|connected|kernel|ospf|rip|static
+.. index:: vnc redistribute ipv4|ipv6 bgp|bgp-direct|bgp-direct-to-nve-groups|connected|kernel|ospf|rip|static
 .. clicmd:: no vnc redistribute ipv4|ipv6 bgp|bgp-direct|bgp-direct-to-nve-groups|connected|kernel|ospf|rip|static
 
    Import (or do not import) prefixes from another routing protocols. Specify
@@ -511,7 +511,7 @@ Redistribution Command Syntax
 .. index:: vnc redistribute nve-group GROUP-NAME
 .. clicmd:: vnc redistribute nve-group GROUP-NAME
 
-.. index:: no vnc redistribute nve-group GROUP-NAME
+.. index:: vnc redistribute nve-group GROUP-NAME
 .. clicmd:: no vnc redistribute nve-group GROUP-NAME
 
    When using `nve-group` mode, assign (or do not assign) the NVE group

--- a/doc/user/vrrp.rst
+++ b/doc/user/vrrp.rst
@@ -358,21 +358,21 @@ using VRRPv2.
 
 All interface configuration commands are documented below.
 
-.. index:: [no] vrrp (1-255) [version (2-3)]
+.. index:: vrrp (1-255) [version (2-3)]
 .. clicmd:: [no] vrrp (1-255) [version (2-3)]
 
    Create a VRRP router with the specified VRID on the interface. Optionally
    specify the protocol version. If the protocol version is not specified, the
    default is VRRPv3.
 
-.. index:: [no] vrrp (1-255) advertisement-interval (10-40950)
+.. index:: vrrp (1-255) advertisement-interval (10-40950)
 .. clicmd:: [no] vrrp (1-255) advertisement-interval (10-40950)
 
    Set the advertisement interval. This is the interval at which VRRP
    advertisements will be sent. Values are given in milliseconds, but must be
    multiples of 10, as VRRP itself uses centiseconds.
 
-.. index:: [no] vrrp (1-255) ip A.B.C.D
+.. index:: vrrp (1-255) ip A.B.C.D
 .. clicmd:: [no] vrrp (1-255) ip A.B.C.D
 
    Add an IPv4 address to the router. This address must already be configured
@@ -380,7 +380,7 @@ All interface configuration commands are documented below.
    implicitly activate the router; see :clicmd:`[no] vrrp (1-255) shutdown` to
    override this behavior.
 
-.. index:: [no] vrrp (1-255) ipv6 X:X::X:X
+.. index:: vrrp (1-255) ipv6 X:X::X:X
 .. clicmd:: [no] vrrp (1-255) ipv6 X:X::X:X
 
    Add an IPv6 address to the router. This address must already be configured
@@ -391,14 +391,14 @@ All interface configuration commands are documented below.
    This command will fail if the protocol version is set to VRRPv2, as VRRPv2
    does not support IPv6.
 
-.. index:: [no] vrrp (1-255) preempt
+.. index:: vrrp (1-255) preempt
 .. clicmd:: [no] vrrp (1-255) preempt
 
    Toggle preempt mode. When enabled, preemption allows Backup routers with
    higher priority to take over Master status from the existing Master. Enabled
    by default.
 
-.. index:: [no] vrrp (1-255) priority (1-254)
+.. index:: vrrp (1-255) priority (1-254)
 .. clicmd:: [no] vrrp (1-255) priority (1-254)
 
    Set the router priority. The router with the highest priority is elected as
@@ -406,7 +406,7 @@ All interface configuration commands are documented below.
    the same priority, the router with the highest primary IP address is elected
    as the Master. Priority value 255 is reserved for the acting Master router.
 
-.. index:: [no] vrrp (1-255) shutdown
+.. index:: vrrp (1-255) shutdown
 .. clicmd:: [no] vrrp (1-255) shutdown
 
    Place the router into administrative shutdown. VRRP will not activate for
@@ -427,7 +427,7 @@ Show commands, global defaults and debugging configuration commands.
    VRID will only show routers with that VRID. Specifying ``json`` will dump
    each router state in a JSON array.
 
-.. index:: [no] debug vrrp [{protocol|autoconfigure|packets|sockets|ndisc|arp|zebra}]
+.. index:: debug vrrp [{protocol|autoconfigure|packets|sockets|ndisc|arp|zebra}]
 .. clicmd:: [no] debug vrrp [{protocol|autoconfigure|packets|sockets|ndisc|arp|zebra}]
 
    Toggle debugging logs for VRRP components.
@@ -457,7 +457,7 @@ Show commands, global defaults and debugging configuration commands.
    zebra
       Logs communications with Zebra.
 
-.. index:: [no] vrrp default <advertisement-interval (1-4096)|preempt|priority (1-254)|shutdown>
+.. index:: vrrp default <advertisement-interval (1-4096)|preempt|priority (1-254)|shutdown>
 .. clicmd:: [no] vrrp default <advertisement-interval (1-4096)|preempt|priority (1-254)|shutdown>
 
    Configure defaults for new VRRP routers. These values will not affect
@@ -480,7 +480,7 @@ After configuring the interfaces as described in
 :ref:`vrrp-system-configuration`, and configuring any defaults you may want,
 execute the following command:
 
-.. index:: [no] vrrp autoconfigure [version (2-3)]
+.. index:: vrrp autoconfigure [version (2-3)]
 .. clicmd:: [no] vrrp autoconfigure [version (2-3)]
 
    Generates VRRP configuration based on the interface configuration on the

--- a/doc/user/vtysh.rst
+++ b/doc/user/vtysh.rst
@@ -52,7 +52,7 @@ and the :clicmd:`terminal paginate` command:
    This variable should be set by the user according to their preferences,
    in their :file:`~/.profile` file.
 
-.. index:: [no] terminal paginate
+.. index:: terminal paginate
 .. clicmd:: [no] terminal paginate
 
    Enables/disables vtysh output pagination.  This command is intended to
@@ -165,7 +165,7 @@ in whose file the error is made.
 .. index:: service integrated-vtysh-config
 .. clicmd:: service integrated-vtysh-config
 
-.. index:: no service integrated-vtysh-config
+.. index:: service integrated-vtysh-config
 .. clicmd:: no service integrated-vtysh-config
 
    Control whether integrated :file:`frr.conf` file is written when

--- a/doc/user/watchfrr.rst
+++ b/doc/user/watchfrr.rst
@@ -22,7 +22,7 @@ WATCHFRR commands
    Give status information about the state of the different daemons being
    watched by WATCHFRR
 
-.. index:: [no] watchfrr ignore DAEMON
+.. index:: watchfrr ignore DAEMON
 .. clicmd:: [no] watchfrr ignore DAEMON
 
    Tell WATCHFRR to ignore a particular DAEMON if it goes unresponsive.

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -126,7 +126,7 @@ Standard Commands
 .. index:: shutdown
 
 .. clicmd:: shutdown
-.. index:: no shutdown
+.. index:: shutdown
 
 .. clicmd:: no shutdown
 
@@ -138,10 +138,10 @@ Standard Commands
 .. index:: ipv6 address ADDRESS/PREFIX
 
 .. clicmd:: ipv6 address ADDRESS/PREFIX
-.. index:: no ip address ADDRESS/PREFIX
+.. index:: ip address ADDRESS/PREFIX
 
 .. clicmd:: no ip address ADDRESS/PREFIX
-.. index:: no ipv6 address ADDRESS/PREFIX
+.. index:: ipv6 address ADDRESS/PREFIX
 
 .. clicmd:: no ipv6 address ADDRESS/PREFIX
 
@@ -150,7 +150,7 @@ Standard Commands
 .. index:: ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
 
 .. clicmd:: ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
-.. index:: no ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
+.. index:: ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
 
 .. clicmd:: no ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
 
@@ -171,7 +171,7 @@ Standard Commands
 .. index:: multicast
 
 .. clicmd:: multicast
-.. index:: no multicast
+.. index:: multicast
 
 .. clicmd:: no multicast
 
@@ -180,7 +180,7 @@ Standard Commands
 .. index:: bandwidth (1-10000000)
 
 .. clicmd:: bandwidth (1-10000000)
-.. index:: no bandwidth (1-10000000)
+.. index:: bandwidth (1-10000000)
 
 .. clicmd:: no bandwidth (1-10000000)
 
@@ -191,7 +191,7 @@ Standard Commands
 .. index:: link-detect
 
 .. clicmd:: link-detect
-.. index:: no link-detect
+.. index:: link-detect
 
 .. clicmd:: no link-detect
 
@@ -215,7 +215,7 @@ Link Parameters Commands
 .. index:: link-params
 .. clicmd:: link-params
 
-.. index:: no link-param
+.. index:: link-param
 .. clicmd:: no link-param
 
    Enter into the link parameters sub node. At least 'enable' must be
@@ -510,7 +510,7 @@ The push action is generally used for LER devices, which want to encapsulate
 all traffic for a wished destination into an MPLS label. This action is stored
 in routing entry, and can be configured like a route:
 
-.. index:: [no] ip route NETWORK MASK GATEWAY|INTERFACE label LABEL
+.. index:: ip route NETWORK MASK GATEWAY|INTERFACE label LABEL
 .. clicmd:: [no] ip route NETWORK MASK GATEWAY|INTERFACE label LABEL
 
    NETWORK and MASK stand for the IP prefix entry to be added as static
@@ -541,7 +541,7 @@ The swap action is generally used for LSR devices, which swap a packet with a
 label, with an other label. The Pop action is used on LER devices, at the
 termination of the MPLS traffic; this is used to remove MPLS header.
 
-.. index:: [no] mpls lsp INCOMING_LABEL GATEWAY OUTGOING_LABEL|explicit-null|implicit-null
+.. index:: mpls lsp INCOMING_LABEL GATEWAY OUTGOING_LABEL|explicit-null|implicit-null
 .. clicmd:: [no] mpls lsp INCOMING_LABEL GATEWAY OUTGOING_LABEL|explicit-null|implicit-null
 
    INCOMING_LABEL and OUTGOING_LABEL are MPLS labels with values ranging from 16
@@ -592,7 +592,7 @@ unicast topology!
 .. index:: ip multicast rpf-lookup-mode MODE
 .. clicmd:: ip multicast rpf-lookup-mode MODE
 
-.. index:: no ip multicast rpf-lookup-mode [MODE]
+.. index:: ip multicast rpf-lookup-mode [MODE]
 .. clicmd:: no ip multicast rpf-lookup-mode [MODE]
 
    MODE sets the method used to perform RPF lookups. Supported modes:
@@ -655,7 +655,7 @@ unicast topology!
 .. index:: ip mroute PREFIX NEXTHOP [DISTANCE]
 .. clicmd:: ip mroute PREFIX NEXTHOP [DISTANCE]
 
-.. index:: no ip mroute PREFIX NEXTHOP [DISTANCE]
+.. index:: ip mroute PREFIX NEXTHOP [DISTANCE]
 .. clicmd:: no ip mroute PREFIX NEXTHOP [DISTANCE]
 
    Adds a static route entry to the Multicast RIB. This performs exactly as the
@@ -816,7 +816,7 @@ FPM Commands
    ``127.0.0.1`` port ``2620``.
 
 
-.. index:: no fpm connection ip A.B.C.D port (1-65535)
+.. index:: fpm connection ip A.B.C.D port (1-65535)
 .. clicmd:: no fpm connection ip A.B.C.D port (1-65535)
 
   Configure ``zebra`` to connect to the default FPM server at ``127.0.0.1``
@@ -876,7 +876,7 @@ FPM Commands
    to connect to it immediately.
 
 
-.. index:: no fpm address [<A.B.C.D|X:X::X:X> [port (1-65535)]]
+.. index:: fpm address [<A.B.C.D|X:X::X:X> [port (1-65535)]]
 .. clicmd:: no fpm address [<A.B.C.D|X:X::X:X> [port (1-65535)]]
 
    Disables FPM entirely. ``zebra`` will close any current connections and
@@ -890,7 +890,7 @@ FPM Commands
    group repeated route next hop information.
 
 
-.. index:: no fpm use-next-hop-groups
+.. index:: fpm use-next-hop-groups
 .. clicmd:: no fpm use-next-hop-groups
 
    Use the old known FPM behavior of including next hop information in the
@@ -1064,13 +1064,13 @@ Many routing protocols require a router-id to be configured. To have a
 consistent router-id across all daemons, the following commands are available
 to configure and display the router-id:
 
-.. index:: [no] [ip] router-id A.B.C.D
+.. index:: router-id A.B.C.D
 .. clicmd:: [no] [ip] router-id A.B.C.D
 
    Allow entering of the router-id.  This command also works under the
    vrf subnode, to allow router-id's per vrf.
 
-.. index:: [no] [ip] router-id A.B.C.D vrf NAME
+.. index:: router-id A.B.C.D vrf NAME
 .. clicmd:: [no] [ip] router-id A.B.C.D vrf NAME
 
    Configure the router-id of this router from the configure NODE.
@@ -1085,7 +1085,7 @@ to configure and display the router-id:
 
 For protocols requiring an IPv6 router-id, the following commands are available:
 
-.. index:: [no] ipv6 router-id X:X::X:X
+.. index:: ipv6 router-id X:X::X:X
 .. clicmd:: [no] ipv6 router-id X:X::X:X
 
    Configure the IPv6 router-id of this router. Like its IPv4 counterpart,


### PR DESCRIPTION
Many index entries used '[no] xxx' or 'no xxx', some had both positive and 'no' forms. Clean that up mostly - index positive form of commands only. Avoid using braces or angle-brackets at the start of an index entry - that puts the entry in the "symbols" section of the index, which isn't very useful.
