### PR TITLE
tools: fix frr-reload l2vpn delete

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1301,6 +1301,12 @@ def compare_context_objects(newconf, running):
             ):
                 continue
 
+            # same thing for a pseudowire sub-context inside an l2vpn context
+            elif (len(running_ctx_keys) > 1 and running_ctx_keys[0].startswith('l2vpn') and
+                  running_ctx_keys[1].startswith('member pseudowire') and
+                  (running_ctx_keys[:1], None) in lines_to_del):
+                continue
+
             # Non-global context
             elif running_ctx_keys and not any(
                 "address-family" in key for key in running_ctx_keys


### PR DESCRIPTION
when deleting a whole l2vpn context in ldpd which also had pseudowires in it, we were first deleting the l2vpn with a `no l2vpn XXX` command, and then adding it again by running `l2vpn XXX\n no member pseudowire YYY` which obviously was not needed. As a result the l2vpn would be reinstated.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>