### PR TITLE
ospfd: fix NSSA translator

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -379,7 +379,7 @@ static int ospf_abr_nssa_am_elected(struct ospf_area *area)
 /* Check NSSA ABR status
  * assumes there are nssa areas
  */
-static void ospf_abr_nssa_check_status(struct ospf *ospf)
+void ospf_abr_nssa_check_status(struct ospf *ospf)
 {
 	struct ospf_area *area;
 	struct listnode *lnode, *nnode;

--- a/ospfd/ospf_abr.h
+++ b/ospfd/ospf_abr.h
@@ -83,4 +83,5 @@ extern void ospf_schedule_abr_task(struct ospf *);
 
 extern void ospf_abr_announce_network_to_area(struct prefix_ipv4 *, uint32_t,
 					      struct ospf_area *);
+extern void ospf_abr_nssa_check_status(struct ospf *ospf);
 #endif /* _ZEBRA_OSPF_ABR_H */

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1432,8 +1432,11 @@ static int ospf_spf_calculate_schedule_worker(struct thread *thread)
 
 	/* ABRs may require additional changes, see RFC 2328 16.7. */
 	monotime(&start_time);
-	if (IS_OSPF_ABR(ospf))
+	if (IS_OSPF_ABR(ospf)) {
+		if (ospf->anyNSSA)
+			ospf_abr_nssa_check_status(ospf);
 		ospf_abr_task(ospf);
+	}
 	abr_time = monotime_since(&start_time, NULL);
 
 	/* Schedule Segment Routing update */


### PR DESCRIPTION
Having 2 ABR in NSSA area where R3 is the elected translator
```
R3# show ip ospf
  We are an ABR and the NSSA Elected Translator.
R2# show ip ospf
  We are an ABR, but not the NSSA Elected Translator.
```
When R3 loses the Border condition by shutting down the interface
to the backbone, we end up with no translator in the NSSA area. It
is expected R2 to take over the translator role
```
R3# sh ip ospf
  It is not ABR, therefore not Translator.
R2# show ip ospf
   We are an ABR, but not the NSSA Elected Translator.
```
This PR forces the ABR to reevaluate the translator condition, so
R2 becomes the elected Translator

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>