### PR TITLE
topotests: Fix logging by redirecting it to correct file

### DIFF
--- a/tests/topotests/bgp-auth/R1/bgpd_multi_vrf.conf
+++ b/tests/topotests/bgp-auth/R1/bgpd_multi_vrf.conf
@@ -1,4 +1,3 @@
-log file /tmp/topotests/test_bgp_auth/R1/bgpd.log debugging
 debug bgp neighbor-events
 
 router bgp 65001 vrf blue

--- a/tests/topotests/bgp-auth/R1/bgpd_vrf.conf
+++ b/tests/topotests/bgp-auth/R1/bgpd_vrf.conf
@@ -1,4 +1,3 @@
-log file /tmp/topotests/test_bgp_auth/R1/bgpd.log debugging
 debug bgp neighbor-events
 
 router bgp 65001 vrf blue

--- a/tests/topotests/bgp-auth/R1/zebra.conf
+++ b/tests/topotests/bgp-auth/R1/zebra.conf
@@ -1,4 +1,3 @@
-log file zebra.log
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/bgp-auth/R2/zebra.conf
+++ b/tests/topotests/bgp-auth/R2/zebra.conf
@@ -1,4 +1,3 @@
-log file zebra.log
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/bgp-auth/R3/zebra.conf
+++ b/tests/topotests/bgp-auth/R3/zebra.conf
@@ -1,4 +1,3 @@
-log file zebra.log
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1353,7 +1353,7 @@ class Router(Node):
             zebra_path = os.path.join(self.daemondir, "zebra")
             zebra_option = self.daemons_options["zebra"]
             self.cmd(
-                "{0} {1} --log stdout --log-level debug -s 90000000 -d > zebra.out 2> zebra.err".format(
+                "{0} {1} --log file:zebra.log --log-level debug -s 90000000 -d > zebra.out 2> zebra.err".format(
                     zebra_path, zebra_option, self.logdir, self.name
                 )
             )
@@ -1368,7 +1368,7 @@ class Router(Node):
             staticd_path = os.path.join(self.daemondir, "staticd")
             staticd_option = self.daemons_options["staticd"]
             self.cmd(
-                "{0} {1} --log stdout --log-level debug -d > staticd.out 2> staticd.err".format(
+                "{0} {1} --log file:staticd.log --log-level debug -d > staticd.out 2> staticd.err".format(
                     staticd_path, staticd_option, self.logdir, self.name
                 )
             )
@@ -1392,7 +1392,7 @@ class Router(Node):
 
             daemon_path = os.path.join(self.daemondir, daemon)
             self.cmd(
-                "{0} {1} --log stdout --log-level debug -d > {2}.out 2> {2}.err".format(
+                "{0} {1} --log file:{2}.log --log-level debug -d > {2}.out 2> {2}.err".format(
                     daemon_path, self.daemons_options.get(daemon, ""), daemon
                 )
             )


### PR DESCRIPTION
Fix issue #7545 and make sure we have the startup of the daemons correctly logged

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>