### PR TITLE
ospf6d: More lists being leaked

### DIFF
--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -963,8 +963,6 @@ static uint8_t *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 		else if (v->magic & OSPFv3WWLINKTABLE) {
 			/* We build a sorted list of interfaces */
 			ifslist = list_new();
-			if (!ifslist)
-				return NULL;
 			ifslist->cmp = (int (*)(void *, void *))if_icmp_func;
 			FOR_ALL_INTERFACES (vrf, iif)
 				listnode_add_sort(ifslist, iif);
@@ -993,6 +991,7 @@ static uint8_t *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 			}
 
 			list_delete_all_node(ifslist);
+			list_delete(&ifslist);
 		}
 	}
 
@@ -1100,8 +1099,6 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 	} else {
 		/* We build a sorted list of interfaces */
 		ifslist = list_new();
-		if (!ifslist)
-			return NULL;
 		ifslist->cmp = (int (*)(void *, void *))if_icmp_func;
 		FOR_ALL_INTERFACES (vrf, iif)
 			listnode_add_sort(ifslist, iif);
@@ -1121,6 +1118,7 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 		}
 
 		list_delete_all_node(ifslist);
+		list_delete(&ifslist);
 	}
 
 	if (!oi)


### PR DESCRIPTION
Apparently the person who wrote this code was big into
cut-n-paste.  Commit 710a61d57c8f1b0ea66a37f09bad2161d7e2ddb7
found the first instance, but upon code inspection this morning
it became evident that 2 other functions had the exact same
problem.

Fix.  Note I have not cleaned up the cut-n-paste code for
two reasons: a) I'm chasing something else b) this code
has been fairly un-maintained for a very long time.  No
need to start up now.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>