### PR TITLE
bgpd: sh running config is not considering values provided via -e for max-paths

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2352,12 +2352,12 @@ ALIAS_HIDDEN(no_bgp_maxpaths_ibgp, no_bgp_maxpaths_ibgp_hidden_cmd,
 static void bgp_config_write_maxpaths(struct vty *vty, struct bgp *bgp,
 				      afi_t afi, safi_t safi)
 {
-	if (bgp->maxpaths[afi][safi].maxpaths_ebgp != MULTIPATH_NUM) {
+	if (bgp->maxpaths[afi][safi].maxpaths_ebgp != multipath_num) {
 		vty_out(vty, "  maximum-paths %d\n",
 			bgp->maxpaths[afi][safi].maxpaths_ebgp);
 	}
 
-	if (bgp->maxpaths[afi][safi].maxpaths_ibgp != MULTIPATH_NUM) {
+	if (bgp->maxpaths[afi][safi].maxpaths_ibgp != multipath_num) {
 		vty_out(vty, "  maximum-paths ibgp %d",
 			bgp->maxpaths[afi][safi].maxpaths_ibgp);
 		if (CHECK_FLAG(bgp->maxpaths[afi][safi].ibgp_flags,


### PR DESCRIPTION
problem
1. run the bgp with -e1 option
2. c t
   router bgp 100
3. show running config
    !
     address-family ipv6 multicast
      maximum-paths 1
      maximum-paths ibgp 1
     exit-address-family
    !
address families should not dump maximum-paths if there
value is same as value provided at run time.

fix
if the maxpaths_ebgp value is same as multipath_num global
object, don't dump maximum-paths.

Signed-off-by: vishaldhingra <vdhingra@vmware.com>