### PR TITLE
lib: fix local variable shadowing global one

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -531,8 +531,8 @@ extern int cmd_execute_command(vector, struct vty *,
 extern int cmd_execute_command_strict(vector, struct vty *,
 				      const struct cmd_element **);
 extern void cmd_init(int terminal);
-extern void cmd_init_config_callbacks(void (*start_config)(void),
-				      void (*end_config)(void));
+extern void cmd_init_config_callbacks(void (*start_config_cb)(void),
+				      void (*end_config_cb)(void));
 extern void cmd_terminate(void);
 extern void cmd_exit(struct vty *vty);
 extern int cmd_list_cmds(struct vty *vty, int do_permute);

--- a/lib/lib_vty.c
+++ b/lib/lib_vty.c
@@ -255,11 +255,11 @@ DEFUN_HIDDEN (end_config,
 	return CMD_SUCCESS;
 }
 
-void cmd_init_config_callbacks(void (*start_config)(void),
-			       void (*end_config)(void))
+void cmd_init_config_callbacks(void (*start_config_cb)(void),
+			       void (*end_config_cb)(void))
 {
-	callback.start_config = start_config;
-	callback.end_config = end_config;
+	callback.start_config = start_config_cb;
+	callback.end_config = end_config_cb;
 }
 
 


### PR DESCRIPTION
start_config and end_config are already used as function names in DEFUN,
so the current naming is a little bit confusing. Let's use different
names for arguments.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>