### PR TITLE
lib: Reset rt_table top to NULL if all nodes are deleted.

### DIFF
--- a/lib/table.c
+++ b/lib/table.c
@@ -131,6 +131,7 @@ static void route_table_free(struct route_table *rt)
 			else
 				node->l_right = NULL;
 		} else {
+			rt->top = NULL;
 			break;
 		}
 	}


### PR DESCRIPTION
zebra crashed in my environment by receiving a SIGSEGV and through digging the core file with gdb I found iteration over a broken rt_table.

After comparing code accessing table->count and table->top, I found `route_table_free` is deleting all nodes in the tree without resetting rt->top. This might be the cause of the broken rt_table. I could not verify this because I could not reproduce the crash for now, but in my view, this is still a defect.

gdb trace:

```
(gdb) bt
#0  0x00007f8039a11fff in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f8039a1342a in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f803aa6ab4f in core_handler (signo=11, siginfo=0x7fffcecb1330, context=<optimized out>) at lib/sigevent.c:228
#3  <signal handler called>
#4  0x00007f803aa74b75 in route_table_get_next_internal (table=<optimized out>, p=0x7f8037b97688 <zfpm_glob_space+168>) at lib/table.c:620
#5  route_table_get_next (table=<optimized out>, pu=..., pu@entry=...) at lib/table.c:716
#6  0x00007f8037992a4f in route_table_iter_next (iter=0x7f8037b97670 <zfpm_glob_space+144>) at ./lib/table.h:293
#7  zfpm_rnodes_iter_next (iter=<optimized out>) at zebra/zebra_fpm.c:369
#8  zfpm_conn_down_thread_cb (thread=0x7fffcecb1990) at zebra/zebra_fpm.c:646
#9  0x00007f803aa791e0 in thread_call (thread=thread@entry=0x7fffcecb1990) at lib/thread.c:1550
#10 0x00007f803aa41710 in frr_run (master=0x558fa290c900) at lib/libfrr.c:1094
#11 0x0000558fa15d30b8 in main ()
(gdb) frame 6
#6  0x00007f8037992a4f in route_table_iter_next (iter=0x7f8037b97670 <zfpm_glob_space+144>) at ./lib/table.h:293
293	in ./lib/table.h
(gdb) p iter->table->top
$1 = (struct route_node *) 0x558fa3af1d60
(gdb) p iter->table->top->link[0]
$2 = (struct route_node *) 0xfe
(gdb) p iter->table->top->link[1]
$3 = (struct route_node *) 0x0
(gdb) p iter->table->count
$4 = 0
```

Signed-off-by: zyxwvu Shi <i@shiyc.cn>