### PR TITLE
fix python error object vs. value compare

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -829,7 +829,7 @@ def check_for_exit_vrf(lines_to_add, lines_to_del):
                 add_exit_vrf = False
 
         if ctx_keys[0].startswith("vrf") and line:
-            if line is not "exit-vrf":
+            if line != "exit-vrf":
                 add_exit_vrf = True
                 prior_ctx_key = ctx_keys[0]
             else:


### PR DESCRIPTION
if you define a vrf and use a newer python it bails out with an error and wants you to switch to !=