### PR TITLE
bgpd: fix to reduce the number of paths to compare in best route sele…

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -404,6 +404,29 @@ void bgp_path_info_add(struct bgp_dest *dest, struct bgp_path_info *pi)
 	bgp_dest_set_defer_flag(dest, false);
 }
 
+/* Add the selected path to the head of the list */
+void bgp_path_info_update_list(struct bgp_dest *dest,
+			       struct bgp_path_info *select)
+{
+	struct bgp_path_info *top;
+
+	if (select) {
+		top = bgp_dest_get_bgp_path_info(dest);
+
+		if (top && (top != select)) {
+			if (select->prev)
+				select->prev->next = select->next;
+			if (select->next)
+				select->next->prev = select->prev;
+
+			select->next = top;
+			select->prev = NULL;
+			top->prev = select;
+			bgp_dest_set_bgp_path_info(dest, select);
+		}
+	}
+}
+
 /* Do the actual removal of info from RIB, for use by bgp_process
    completion callback *only* */
 void bgp_path_info_reap(struct bgp_dest *dest, struct bgp_path_info *pi)
@@ -2265,6 +2288,7 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 	struct list mp_list;
 	char pfx_buf[PREFIX2STR_BUFFER];
 	char path_buf[PATH_ADDPATH_STR_BUFFER];
+	bool old_select_valid = false;
 
 	bgp_mp_list_init(&mp_list);
 	do_mpath =
@@ -2354,12 +2378,15 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 	/* Check old selected route and new selected route. */
 	old_select = NULL;
 	new_select = NULL;
+
 	for (pi = bgp_dest_get_bgp_path_info(dest);
 	     (pi != NULL) && (nextpi = pi->next, 1); pi = nextpi) {
 		enum bgp_path_selection_reason reason;
 
-		if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
+		if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED)) {
 			old_select = pi;
+			old_select_valid = true;
+		}
 
 		if (BGP_PATH_HOLDDOWN(pi)) {
 			/* reap REMOVED routes, if needs be
@@ -2373,6 +2400,8 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 				zlog_debug("%s: pi %p in holddown", __func__,
 					   pi);
 
+			if (pi == old_select)
+				old_select_valid = false;
 			continue;
 		}
 
@@ -2385,6 +2414,8 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 						"%s: pi %p non self peer %s not estab state",
 						__func__, pi, pi->peer->host);
 
+				if (pi == old_select)
+					old_select_valid = false;
 				continue;
 			}
 
@@ -2393,12 +2424,27 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 			bgp_path_info_unset_flag(dest, pi, BGP_PATH_DMED_CHECK);
 			if (debug)
 				zlog_debug("%s: pi %p dmed", __func__, pi);
+
+			if (pi == old_select)
+				old_select_valid = false;
 			continue;
 		}
 
 		bgp_path_info_unset_flag(dest, pi, BGP_PATH_DMED_CHECK);
 
 		reason = dest->reason;
+
+		/* Compare paths till the old selected path is found
+		 * in the list
+		 */
+		if ((old_select_valid) && (pi == old_select->next))
+			continue;
+
+		if (debug)
+			zlog_debug("comparing pi %s, new_select %s",
+				pi->peer->host,
+				(new_select) ? new_select->peer->host : "NULL");
+
 		if (bgp_path_info_cmp(bgp, pi, new_select, &paths_eq, mpath_cfg,
 				      debug, pfx_buf, afi, safi,
 				      &dest->reason)) {
@@ -2424,6 +2470,9 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 			dest, path_buf,
 			old_select ? old_select->peer->host : "NONE");
 	}
+
+	/* Add the new selected path to the head of the list */
+	bgp_path_info_update_list(dest, new_select);
 
 	if (do_mpath && new_select) {
 		for (pi = bgp_dest_get_bgp_path_info(dest);

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -569,6 +569,8 @@ extern struct bgp_dest *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
 extern struct bgp_path_info *bgp_path_info_lock(struct bgp_path_info *path);
 extern struct bgp_path_info *bgp_path_info_unlock(struct bgp_path_info *path);
 extern void bgp_path_info_add(struct bgp_dest *dest, struct bgp_path_info *pi);
+extern void bgp_path_info_update_list(struct bgp_dest *dest,
+				      struct bgp_path_info *select);
 extern void bgp_path_info_extra_free(struct bgp_path_info_extra **extra);
 extern void bgp_path_info_reap(struct bgp_dest *dest, struct bgp_path_info *pi);
 extern void bgp_path_info_delete(struct bgp_dest *dest,


### PR DESCRIPTION
…ction

Fix
---
Move the route selected as best to the head of path list
When paths  are added later, the subsequent best route selection process will
compare the routes in the list till the previous best is reached (which is
at the head of the list). This will help reduce the number of paths to be
compared to find best path entry

Signed-off-by: kssoman <somanks@gmail.com>