### PR TITLE
ospfd: fix NSSA translate-always

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1603,7 +1603,8 @@ int ospf_area_nssa_unset(struct ospf *ospf, struct in_addr area_id, int argc)
 			OSPF_NSSA_TRANS_STABLE_DEFAULT;
 		ospf_area_type_set(area, OSPF_AREA_DEFAULT);
 	} else {
-		area->NSSATranslatorRole = OSPF_NSSA_ROLE_CANDIDATE;
+		ospf_area_nssa_translator_role_set(ospf, area_id,
+						   OSPF_NSSA_ROLE_CANDIDATE);
 	}
 
 	ospf_area_check_free(ospf, area_id);
@@ -1620,7 +1621,19 @@ int ospf_area_nssa_translator_role_set(struct ospf *ospf,
 	if (area == NULL)
 		return 0;
 
-	area->NSSATranslatorRole = role;
+	if (role != area->NSSATranslatorRole) {
+		if ((area->NSSATranslatorRole == OSPF_NSSA_ROLE_ALWAYS)
+		    || (role == OSPF_NSSA_ROLE_ALWAYS)) {
+			/* RFC 3101 3.1
+			 * if new role is OSPF_NSSA_ROLE_ALWAYS we need to set
+			 * Nt bit, if the role was OSPF_NSSA_ROLE_ALWAYS we need
+			 * to clear Nt bit
+			 */
+			area->NSSATranslatorRole = role;
+			ospf_router_lsa_update_area(area);
+		} else
+			area->NSSATranslatorRole = role;
+	}
 
 	return 1;
 }


### PR DESCRIPTION
When an ABR NSSA router is configured to be ALWAYS the translator:
```  
r22(config-router)# area 1 nssa translate-always
```
It will advertise this condition in the type-1 LSA setting the Nt bit, taking 
over the translator role from r33
```
  r22# show ip ospf
     We are an ABR and always an NSSA Translator.
  r33# show ip ospf
     We are an ABR, but not the NSSA Elected Translator.
```
However when the command above is removed:
```
  r22(config-router)# no area 1 nssa translate-always
```
the bit Nt needs to be cleared otherwise we end up with no translator
in the area
```
  r22# show ip ospf
     We are an ABR, but not the NSSA Elected Translator.
  r33# show ip ospf
     We are an ABR, but not the NSSA Elected Translator.
```
This PR forces the ABR to send a type-1 LSA with the Nt bit updated
according to the translator role

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>