### PR TITLE
tests: restore route scale test to 1M routes

### DIFF
--- a/tests/topotests/route-scale/r1/installed.routes.json
+++ b/tests/topotests/route-scale/r1/installed.routes.json
@@ -6,11 +6,11 @@
       "type":"connected"
     },
     {
-      "fib":200000,
-      "rib":200000,
+      "fib":1000000,
+      "rib":1000000,
       "type":"sharp"
     }
   ],
-  "routesTotal":200032,
-  "routesTotalFib":200032
+  "routesTotal":1000032,
+  "routesTotalFib":1000032
 }


### PR DESCRIPTION
Restore the scale topotest config to use 1M routes. I'd reduced the scale because we had frequent out-of-memory problems. Now that the zapi buffering changes are in, the mem footprint issues we had been having may be resolved.
