### PR TITLE
bgpd: Show pfxSnt in JSON output for show bgp summary even if not established

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10810,9 +10810,12 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 						    peer->pcount[afi][pfx_rcd_safi]);
 
 				if (paf && PAF_SUBGRP(paf))
-					json_object_int_add(json_peer,
-							    "pfxSnt",
-							    (PAF_SUBGRP(paf))->scount);
+					json_object_int_add(
+						json_peer, "pfxSnt",
+						(PAF_SUBGRP(paf))->scount);
+				else
+					json_object_int_add(json_peer, "pfxSnt",
+							    0);
 
 				/* BGP FSM state */
 				if (CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN)


### PR DESCRIPTION
spine1-debian-9# show ip bgp summary json
{
"ipv4Unicast":{
  "routerId":"192.168.3.2",
  "as":200,
  "vrfId":0,
  "vrfName":"default",
  "tableVersion":4,
  "ribCount":1,
  "ribMemory":184,
  "peerCount":1,
  "peerMemory":23384,
  "peers":{
    "192.168.0.1":{
      "hostname":"exit1-debian-9",
      "remoteAs":100,
      "version":4,
      "msgRcvd":5,
      "msgSent":6,
      "tableVersion":0,
      "outq":0,
      "inq":0,
      "peerUptime":"00:00:09",
      "peerUptimeMsec":9000,
      "peerUptimeEstablishedEpoch":1606206209,
      "pfxRcd":0,
      "pfxSnt":0,
      "state":"Idle (Admin)",
      "connectionsEstablished":1,
      "connectionsDropped":1,
      "idType":"ipv4"
    }
  },
  "failedPeers":1,
  "totalPeers":1,
  "dynamicPeers":0,
  "bestPath":{
    "multiPathRelax":"false"
  }
}
}

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>