### PR TITLE
bgpd: correctly store allocated ES struct

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1422,7 +1422,7 @@ void bgp_evpn_path_es_link(struct bgp_path_info *pi, vni_t vni, esi_t *esi)
 	/* find-create ES */
 	es = bgp_evpn_es_find(esi);
 	if (!es)
-		bgp_evpn_es_new(bgp_evpn, esi);
+		es = bgp_evpn_es_new(bgp_evpn, esi);
 
 	/* dup check */
 	if (es_info->es == es)


### PR DESCRIPTION
in the rare situation where we allocate the ES during the path link
we fail to check/store the allocated ES pointer thus leading to a
NULL dereference later in the function.

Signed-off-by: Pat Ruddy <pat@voltanet.io>