### PR TITLE
ldpd: Prevent usage after free

### DIFF
--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -73,6 +73,7 @@ struct ldpd_conf	*ldeconf;
 struct nbr_tree		 lde_nbrs = RB_INITIALIZER(&lde_nbrs);
 
 static struct imsgev	*iev_ldpe;
+static struct imsgev    iev_main_sync_data;
 static struct imsgev	*iev_main, *iev_main_sync;
 
 /* lde privileges */
@@ -148,8 +149,8 @@ lde(void)
 		        &iev_main->ev_read);
 	iev_main->handler_write = ldp_write_handler;
 
-	if ((iev_main_sync = calloc(1, sizeof(struct imsgev))) == NULL)
-		fatal(NULL);
+	memset(&iev_main_sync_data, 0, sizeof(iev_main_sync_data));
+	iev_main_sync = &iev_main_sync_data;
 	imsg_init(&iev_main_sync->ibuf, LDPD_FD_SYNC);
 
 	/* create base configuration */
@@ -203,7 +204,6 @@ lde_shutdown(void)
 	if (iev_ldpe)
 		free(iev_ldpe);
 	free(iev_main);
-	free(iev_main_sync);
 
 	log_info("label decision engine exiting");
 


### PR DESCRIPTION
We are using data after it has been freed and handed back to the
OS.
Address Sanitizer output:

error	23-Nov-2020 18:53:57	ERROR: AddressSanitizer: heap-use-after-free on address 0x631000024838 at pc 0x55f825998f58 bp 0x7fffa5b0f5b0 sp 0x7fffa5b0f5a0
error	23-Nov-2020 18:53:57	READ of size 4 at 0x631000024838 thread T0
error	23-Nov-2020 18:53:57	    #0 0x55f825998f57 in lde_imsg_compose_parent_sync ldpd/lde.c:226
error	23-Nov-2020 18:53:57	    #1 0x55f8259ca9ed in vlog ldpd/log.c:48
error	23-Nov-2020 18:53:57	    #2 0x55f8259cb1c8 in log_info ldpd/log.c:102
error	23-Nov-2020 18:53:57	    #3 0x55f82599e841 in lde_shutdown ldpd/lde.c:208
error	23-Nov-2020 18:53:57	    #4 0x55f8259a2703 in lde_dispatch_parent ldpd/lde.c:666
error	23-Nov-2020 18:53:57	    #5 0x55f825ac3815 in thread_call lib/thread.c:1681
error	23-Nov-2020 18:53:57	    #6 0x55f825998d5e in lde ldpd/lde.c:160
error	23-Nov-2020 18:53:57	    #7 0x55f82598a289 in main ldpd/ldpd.c:320
error	23-Nov-2020 18:53:57	    #8 0x7fe3f749db96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
error	23-Nov-2020 18:53:57	    #9 0x55f825982579 in _start (/usr/lib/frr/ldpd+0xb3579)
error	23-Nov-2020 18:53:57
error	23-Nov-2020 18:53:57	0x631000024838 is located 65592 bytes inside of 65632-byte region [0x631000014800,0x631000024860)
error	23-Nov-2020 18:53:57	freed by thread T0 here:
error	23-Nov-2020 18:53:57	    #0 0x7fe3f8a4d7a8 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7a8)
error	23-Nov-2020 18:53:57	    #1 0x55f82599e830 in lde_shutdown ldpd/lde.c:206
error	23-Nov-2020 18:53:57	    #2 0x55f8259a2703 in lde_dispatch_parent ldpd/lde.c:666
error	23-Nov-2020 18:53:57	    #3 0x55f825ac3815 in thread_call lib/thread.c:1681
error	23-Nov-2020 18:53:57	    #4 0x55f825998d5e in lde ldpd/lde.c:160
error	23-Nov-2020 18:53:57	    #5 0x55f82598a289 in main ldpd/ldpd.c:320
error	23-Nov-2020 18:53:57	    #6 0x7fe3f749db96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
error	23-Nov-2020 18:53:57
error	23-Nov-2020 18:53:57	previously allocated by thread T0 here:
error	23-Nov-2020 18:53:57	    #0 0x7fe3f8a4dd28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
error	23-Nov-2020 18:53:57	    #1 0x55f825998cb7 in lde ldpd/lde.c:151
error	23-Nov-2020 18:53:57	    #2 0x55f82598a289 in main ldpd/ldpd.c:320
error	23-Nov-2020 18:53:57	    #3 0x7fe3f749db96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
error	23-Nov-2020 18:53:57

The fix is to put this in global space.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>