### PR TITLE
[7.5]ospfd: Prevent crash by accessing memory not owned.

### DIFF
--- a/ospfd/ospf_routemap.c
+++ b/ospfd/ospf_routemap.c
@@ -445,7 +445,7 @@ static void *route_set_metric_compile(const char *arg)
 {
 	struct ospf_metric *metric;
 
-	metric = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(uint32_t));
+	metric = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(*metric));
 	metric->used = false;
 
 	if (all_digit(arg))


### PR DESCRIPTION
When allocating memory for the `struct ospf_metric` we
were using `uint32_t` instead of the actual size of this
structure.  When we wrote to it we would be writing
into other people's memory.

Found-by: Amol Lad
Signed-off-by: Donald Sharp <sharpd@nvidia.com>