### PR TITLE
topotests: all_protocol_startup, consider optionally stderr of daemons

### DIFF
--- a/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
+++ b/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
@@ -286,7 +286,11 @@ def test_error_messages_daemons():
             error_logs += "r%s PBRd StdErr Output:\n" % i
             error_logs += log
 
+        # ZEBRA netns mode may trigger a message
+        # 2021/01/11 16:43:53 warnings: ZEBRA: NS notify : NS vrf0 is already default VRF.Cancel VRF Creation
+        # Remove this messages
         log = net["r%s" % i].getStdErr("zebra")
+        log = re.sub(r'^.*is already default VRF.Cancel VRF Creation\r\n$', r'', log).rstrip()
         if log:
             error_logs += "r%s Zebra StdErr Output:\n" % i
             error_logs += log


### PR DESCRIPTION
At daemon startup, some stderr log messages may be displated by daemons.
this is the case with '-o ' option that forces the default vrf name to a
defined name, and a warning may be displayed, if that value was still
present. Consequently, the test fails because it considers stderr as
fatal.
From now, proposition to consider to check for daemon stderr, only if it
is configured on topotests.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>