### PR TITLE
tests: Update topotest Dockerfile to pick up keys from deb repo

### DIFF
--- a/tests/topotests/Dockerfile
+++ b/tests/topotests/Dockerfile
@@ -48,7 +48,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && rm -rf /var/lib/apt/lists/*
 
 RUN export DEBIAN_FRONTEND=noninteractive \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-key 5418F291D0D4A1AA \
+    && wget -qO- https://deb.frrouting.org/frr/keys.asc | apt-key add - \
     && echo "deb https://deb.frrouting.org/frr bionic frr-stable" > /etc/apt/sources.list.d/frr.list \
     && apt-get update \
     && apt-get install -y libyang-dev \


### PR DESCRIPTION
Dockerhub used old GPG key. Fixed to pull current keys from our repo.

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>