### PR TITLE
zebra: dplane FPM LSP support

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -43,6 +43,7 @@
 #include "zebra/debug.h"
 #include "zebra/interface.h"
 #include "zebra/zebra_dplane.h"
+#include "zebra/zebra_mpls.h"
 #include "zebra/zebra_router.h"
 #include "zebra/zebra_evpn.h"
 #include "zebra/zebra_evpn_mac.h"
@@ -790,6 +791,15 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_LSP_INSTALL:
 	case DPLANE_OP_LSP_UPDATE:
 	case DPLANE_OP_LSP_DELETE:
+		rv = netlink_lsp_msg_encoder(ctx, nl_buf, sizeof(nl_buf));
+		if (rv <= 0) {
+			zlog_err("%s: netlink_lsp_msg_encoder failed", __func__);
+			return 0;
+		}
+
+		nl_buf_len += (size_t)rv;
+		break;
+
 	case DPLANE_OP_PW_INSTALL:
 	case DPLANE_OP_PW_UNINSTALL:
 	case DPLANE_OP_ADDR_INSTALL:

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -86,6 +86,9 @@ extern ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 					  const struct zebra_dplane_ctx *ctx,
 					  void *buf, size_t buflen);
 
+extern ssize_t netlink_lsp_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
+				       size_t buflen);
+
 extern int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id);
 extern int netlink_macfdb_read(struct zebra_ns *zns);
 extern int netlink_macfdb_read_for_bridge(struct zebra_ns *zns,

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -116,6 +116,7 @@ struct zebra_lsp_t_ {
 #define LSP_FLAG_SCHEDULED        (1 << 0)
 #define LSP_FLAG_INSTALLED        (1 << 1)
 #define LSP_FLAG_CHANGED          (1 << 2)
+#define LSP_FLAG_FPM              (1 << 3)
 
 	/* Address-family of NHLFE - saved here for delete. All NHLFEs */
 	/* have to be of the same AF */

--- a/zebra/zebra_mpls_netlink.c
+++ b/zebra/zebra_mpls_netlink.c
@@ -28,8 +28,8 @@
 #include "zebra/zebra_mpls.h"
 #include "zebra/kernel_netlink.h"
 
-static ssize_t netlink_lsp_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
-				       size_t buflen)
+ssize_t netlink_lsp_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
+				size_t buflen)
 {
 	int cmd;
 


### PR DESCRIPTION
Add support for LSP updates to the zebra dataplane netlink FPM plugin.

With this change on top of FRR 7.5, and using DANOS and its [brokerd](http://github.com/danos/vyatta-route-broker) FPM consumer as a testbed; zebra:
```
vyatta@vm-dan-ldp-1# sudo vtysh -c "show mpls table"
 Inbound Label  Type  Nexthop      Outbound Label  
 --------------------------------------------------
 16             LDP   192.168.1.2  implicit-null   
 17             LDP   192.168.1.2  17              
 17             LDP   192.168.2.2  18              
 18             LDP   192.168.1.2  18              
 18             LDP   192.168.2.2  19              
 19             LDP   192.168.2.2  implicit-null   
 20             LDP   192.168.1.2  19              
 20             LDP   192.168.2.2  20  
```
kernel:
```
 vyatta@vm-dan-ldp-1# ip -M route
16 via inet 192.168.1.2 dev dp0p1s2 proto ldp 
17 proto ldp 
        nexthop as to 18 via inet 192.168.2.2 dev dp0p1s3 
        nexthop as to 17 via inet 192.168.1.2 dev dp0p1s2 
18 proto ldp 
        nexthop as to 19 via inet 192.168.2.2 dev dp0p1s3 
        nexthop as to 18 via inet 192.168.1.2 dev dp0p1s2 
19 via inet 192.168.2.2 dev dp0p1s3 proto ldp 
20 proto ldp 
        nexthop as to 20 via inet 192.168.2.2 dev dp0p1s3 
        nexthop as to 19 via inet 192.168.1.2 dev dp0p1s2 
```
and DANOS dataplane (programmed by `brokerd`):
```
vyatta@vm-dan-ldp-1:~$ show dataplane mpls label-table 
Label Space: 0
in label: exp-null, fec:ipv4, outgoing label: imp-null 
in label: rtr-alrt, outgoing label: imp-null 
in label: exp6-null, fec:ipv6, outgoing label: imp-null 
in label: 16
        nexthop via 192.168.1.2, dp0p1s2, outgoing label: imp-null 
in label: 17
        nexthop via 192.168.2.2, dp0p1s3, outgoing label: 18 
        nexthop via 192.168.1.2, dp0p1s2, outgoing label: 17 
in label: 18
        nexthop via 192.168.2.2, dp0p1s3, outgoing label: 19 
        nexthop via 192.168.1.2, dp0p1s2, outgoing label: 18 
in label: 19
        nexthop via 192.168.2.2, dp0p1s3, outgoing label: imp-null 
in label: 20
        nexthop via 192.168.2.2, dp0p1s3, outgoing label: 20 
        nexthop via 192.168.1.2, dp0p1s2, outgoing label: 19 
```
all agree on the label table.