### PR TITLE
ospfd: fix cosmetic show ip ospf when NSSA

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2702,6 +2702,10 @@ static void show_ip_ospf_area(struct vty *vty, struct ospf_area *area,
 					json_object_boolean_true_add(
 						json_area,
 						"nssaTranslatorAlways");
+				else
+					json_object_boolean_true_add(
+						json_area,
+						"nssaTranslatorNever");
 			} else {
 				json_object_boolean_true_add(json_area, "abr");
 				if (area->NSSATranslatorRole
@@ -2716,29 +2720,32 @@ static void show_ip_ospf_area(struct vty *vty, struct ospf_area *area,
 			}
 		} else {
 			vty_out(vty,
-				"   It is an NSSA configuration. \n   Elected NSSA/ABR performs type-7/type-5 LSA translation. \n");
+				"   It is an NSSA configuration.\n   Elected NSSA/ABR performs type-7/type-5 LSA translation.\n");
 			if (!IS_OSPF_ABR(area->ospf))
 				vty_out(vty,
-					"   It is not ABR, therefore not Translator. \n");
+					"   It is not ABR, therefore not Translator.\n");
 			else if (area->NSSATranslatorState) {
 				vty_out(vty, "   We are an ABR and ");
 				if (area->NSSATranslatorRole
 				    == OSPF_NSSA_ROLE_CANDIDATE)
 					vty_out(vty,
-						"the NSSA Elected Translator. \n");
+						"the NSSA Elected Translator.\n");
 				else if (area->NSSATranslatorRole
 					 == OSPF_NSSA_ROLE_ALWAYS)
 					vty_out(vty,
-						"always an NSSA Translator. \n");
+						"always an NSSA Translator.\n");
+				else
+					vty_out(vty,
+						"never an NSSA Translator.\n");
 			} else {
 				vty_out(vty, "   We are an ABR, but ");
 				if (area->NSSATranslatorRole
 				    == OSPF_NSSA_ROLE_CANDIDATE)
 					vty_out(vty,
-						"not the NSSA Elected Translator. \n");
+						"not the NSSA Elected Translator.\n");
 				else
 					vty_out(vty,
-						"never an NSSA Translator. \n");
+						"never an NSSA Translator.\n");
 			}
 		}
 	}


### PR DESCRIPTION
When executing the following command to change the NSSA translator role
from OSPF_NSSA_ROLE_ALWAYS to OSPF_NSSA_ROLE_NEVER
```
r2(config-router)# area 1 nssa translate-never
```

During the time the `ospf_abr_nssa_check_status()` function is not executed,
we are in a situation where the role is OSPF_NSSA_ROLE_NEVER (just configured)
but the NSSATranslatorState is still ENABLED

During this time the output of "show ip ospf" displays the following:
```
r2# show ip ospf
 Area ID: 0.0.0.1 (NSSA)
   Shortcutting mode: Default, S-bit consensus: no
   Number of interfaces in this area: Total: 1, Active: 1
   It is an NSSA configuration.
   Elected NSSA/ABR performs type-7/type-5 LSA translation.
   We are an ABR and    Number of fully adjacent neighbors in this area: 1 (**)
```
Basically the case `TranslatorState=ENABLED` && `TranslatorRole=ROLE_NEVER` is not
covered in `ospf_vty.c`

This PR adds the case `TranslatorState=ENABLED` and `TranslatorRole=ROLE_NEVER`
which should only happen for a small period of time

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>