### PR TITLE
ospfd: NSSA stability timer

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -434,6 +434,14 @@ void ospf_abr_nssa_check_status(struct ospf *ospf)
 						zlog_debug(
 							"ospf_abr_nssa_check_status: elected translator");
 				} else {
+					/* If we were translating, we need to
+					 * keep translating for some
+					 * NSSATranslatorStabilityInterval
+					 */
+					if (area->NSSATranslatorState
+					    == OSPF_NSSA_TRANSLATE_ENABLED)
+						ospf_nssa_stability_timer_set(
+							ospf, area);
 					area->NSSATranslatorState =
 						OSPF_NSSA_TRANSLATE_DISABLED;
 					if (IS_DEBUG_OSPF(nssa, NSSA))
@@ -956,7 +964,8 @@ static void ospf_abr_process_nssa_translates(struct ospf *ospf)
 		zlog_debug("ospf_abr_process_nssa_translates(): Start");
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area)) {
-		if (!area->NSSATranslatorState)
+		if ((!area->NSSATranslatorState)
+		    && (area->t_nssa_stability_timer == NULL))
 			continue; /* skip if not translator */
 
 		if (area->external_routing != OSPF_AREA_NSSA)

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2790,6 +2790,15 @@ static void show_ip_ospf_area(struct vty *vty, struct ospf_area *area,
 					vty_out(vty,
 						"never an NSSA Translator.\n");
 			}
+			if (area->t_nssa_stability_timer != NULL) {
+				char timebuf[OSPF_TIME_DUMP_SIZE];
+
+				vty_out(vty,
+					"   Still in translator role expiring in %s.\n",
+					ospf_timer_dump(
+						area->t_nssa_stability_timer,
+						timebuf, sizeof(timebuf)));
+			}
 		}
 	}
 

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -553,6 +553,7 @@ struct ospf_area {
 	/* Threads. */
 	struct thread *t_stub_router;     /* Stub-router timer */
 	struct thread *t_opaque_lsa_self; /* Type-10 Opaque-LSAs origin. */
+	struct thread *t_nssa_stability_timer; /* NSSA Stability Timer. */
 
 	/* Statistics field. */
 	uint32_t spf_calculation; /* SPF Calculation Count. */
@@ -718,6 +719,8 @@ extern void ospf_vrf_link(struct ospf *ospf, struct vrf *vrf);
 extern void ospf_vrf_unlink(struct ospf *ospf, struct vrf *vrf);
 const char *ospf_vrf_id_to_name(vrf_id_t vrf_id);
 int ospf_area_nssa_no_summary_set(struct ospf *, struct in_addr);
+
+void ospf_nssa_stability_timer_set(struct ospf *ospf, struct ospf_area *area);
 
 const char *ospf_get_name(const struct ospf *ospf);
 extern struct ospf_interface *add_ospf_interface(struct connected *co,


### PR DESCRIPTION
From RFC 3101, secction 3.1:

   "_If an elected translator determines its services are no longer
   required, it continues to perform its translation duties for the
   additional time interval defined by a new area configuration
   parameter, TranslatorStabilityInterval_"

The timer `TranslatorStabilityInterval` is defined in the code but it
is not being used

This PR adds support for this timer so the translator will continue to
perform its duties for some more time once it has determined its
translator status has been deposed.

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>
