### PR TITLE
[zebra] bugfix of error quit of zebra, due to no nexthop ACTIVE

### DIFF
--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -995,7 +995,6 @@ static int zfpm_build_route_updates(void)
 			data_len = zfpm_encode_route(dest, re, (char *)data,
 						     buf_end - data, &msg_type);
 
-			assert(data_len);
 			if (data_len) {
 				hdr->msg_type = msg_type;
 				msg_len = fpm_data_len_to_msg_len(data_len);
@@ -1006,6 +1005,8 @@ static int zfpm_build_route_updates(void)
 					zfpm_g->stats.route_adds++;
 				else
 					zfpm_g->stats.route_dels++;
+			} else {
+				zlog_debug("%s: data_len is 0.", __func__);
 			}
 		}
 


### PR DESCRIPTION
bugfix of error quit of zebra, due to no nexthop ACTIVE, refer to https://github.com/FRRouting/frr/issues/7588

TEST report:
1) compile OK
2) test as bellow.

TEST:
1. DUT connect router with 8 ECMP, router announce 100,000 route to DUT
```
root@dut-testbed:~# vtysh -c 'show ru'
Building configuration...

Current configuration:
!
frr version 7.2.1-sonic
frr defaults traditional
hostname dut-testbed
log syslog informational
log facility local4
service integrated-vtysh-config
!
password zebra
!
router bgp 65100
 bgp router-id 10.1.0.32
 bgp log-neighbor-changes
 no bgp default ipv4-unicast
 bgp bestpath as-path multipath-relax
 neighbor 10.0.0.5 remote-as 65200
 neighbor 10.0.0.9 remote-as 65200
 neighbor 10.0.0.9 description ARISTA05T2
 neighbor 10.0.0.9 timers 3 10
 neighbor 10.0.0.11 remote-as 65200
 neighbor 10.0.0.11 description ARISTA06T2
 neighbor 10.0.0.11 timers 3 10
 neighbor 10.0.0.13 remote-as 65200
 neighbor 10.0.0.13 description ARISTA07T2
 neighbor 10.0.0.13 timers 3 10
 neighbor 10.0.0.17 remote-as 65200
 neighbor 10.0.0.17 description ARISTA09T2
 neighbor 10.0.0.17 timers 3 10
 neighbor 10.0.0.19 remote-as 65200
 neighbor 10.0.0.19 description ARISTA10T2
 neighbor 10.0.0.19 timers 3 10
 neighbor 10.0.0.31 remote-as 65200
 neighbor 10.0.0.31 description ARISTA16T2
 neighbor 10.0.0.31 timers 3 10
 neighbor 10.0.0.33 remote-as 64001
 neighbor 10.0.0.33 description ARISTA01T0
 neighbor 10.0.0.33 timers 3 10
 neighbor 10.0.0.35 remote-as 64002
 neighbor 10.0.0.35 description ARISTA02T0
 neighbor 10.0.0.35 timers 3 10
 neighbor 10.0.0.37 remote-as 64003
 neighbor 10.0.0.37 description ARISTA03T0
 neighbor 10.0.0.37 timers 3 10
 neighbor 10.0.0.39 remote-as 64004
 neighbor 10.0.0.39 description ARISTA04T0
 neighbor 10.0.0.39 timers 3 10
 neighbor 10.0.0.41 remote-as 64005
 neighbor 10.0.0.41 description ARISTA05T0
 neighbor 10.0.0.41 timers 3 10
 neighbor 10.0.0.43 remote-as 64006
 neighbor 10.0.0.43 description ARISTA06T0
 neighbor 10.0.0.43 timers 3 10
 neighbor 10.0.0.45 remote-as 64007
 neighbor 10.0.0.45 description ARISTA07T0
 neighbor 10.0.0.45 timers 3 10
 neighbor 10.0.0.47 remote-as 64008
 neighbor 10.0.0.47 description ARISTA08T0
 neighbor 10.0.0.47 timers 3 10
 neighbor fc00::2 remote-as 65200
 neighbor fc00::2 description ARISTA01T2
 neighbor fc00::2 timers 3 10
 neighbor fc00::6 remote-as 65200
 neighbor fc00::6 description ARISTA02T2
 neighbor fc00::6 timers 3 10
 neighbor fc00::e remote-as 65200
 neighbor fc00::e description ARISTA04T2
 neighbor fc00::e timers 3 10
 neighbor fc00::12 remote-as 65200
 neighbor fc00::12 description ARISTA05T2
 neighbor fc00::12 timers 3 10
 neighbor fc00::16 remote-as 65200
 neighbor fc00::16 description ARISTA06T2
 neighbor fc00::16 timers 3 10
 neighbor fc00::1a remote-as 65200
 neighbor fc00::1a description ARISTA07T2
 neighbor fc00::1a timers 3 10
 neighbor fc00::1e remote-as 65200
 neighbor fc00::1e description ARISTA08T2
 neighbor fc00::1e timers 3 10
 neighbor fc00::22 remote-as 65200
 neighbor fc00::22 description ARISTA09T2
 neighbor fc00::22 timers 3 10
 neighbor fc00::26 remote-as 65200
 neighbor fc00::26 description ARISTA10T2
 neighbor fc00::26 timers 3 10
 neighbor fc00::2a remote-as 65200
 neighbor fc00::2a description ARISTA11T2
 neighbor fc00::2a timers 3 10
 neighbor fc00::2e remote-as 65200
 neighbor fc00::2e description ARISTA12T2
 neighbor fc00::2e timers 3 10
 neighbor fc00::32 remote-as 65200
 neighbor fc00::32 description ARISTA13T2
 neighbor fc00::32 timers 3 10
 neighbor fc00::36 remote-as 65200
 neighbor fc00::36 description ARISTA14T2
 neighbor fc00::36 timers 3 10
 neighbor fc00::3a remote-as 65200
 neighbor fc00::3a description ARISTA15T2
 neighbor fc00::3a timers 3 10
 neighbor fc00::3e remote-as 65200
 neighbor fc00::3e description ARISTA16T2
 neighbor fc00::3e timers 3 10
 neighbor fc00::4a remote-as 64003
 neighbor fc00::4a description ARISTA03T0
 neighbor fc00::4a timers 3 10
 neighbor fc00::4e remote-as 64004
 neighbor fc00::4e description ARISTA04T0
 neighbor fc00::4e timers 3 10
 neighbor fc00::52 remote-as 64005
 neighbor fc00::52 description ARISTA05T0
 neighbor fc00::52 timers 3 10
 neighbor fc00::56 remote-as 64006
 neighbor fc00::56 description ARISTA06T0
 neighbor fc00::56 timers 3 10
 !
 address-family ipv4 unicast
  network 10.1.0.32/32
  neighbor 10.0.0.5 activate
  neighbor 10.0.0.9 activate
  neighbor 10.0.0.11 activate
  neighbor 10.0.0.13 activate
  neighbor 10.0.0.17 activate
  neighbor 10.0.0.19 activate
  neighbor 10.0.0.31 activate
  neighbor 10.0.0.33 activate
  neighbor 10.0.0.35 activate
  neighbor 10.0.0.37 activate
  neighbor 10.0.0.39 activate
  neighbor 10.0.0.41 activate
  neighbor 10.0.0.43 activate
  neighbor 10.0.0.45 activate
  neighbor 10.0.0.47 activate
 exit-address-family
 !
 address-family ipv6 unicast
  network fc00:1:211::32/128
  neighbor fc00::2 activate
  neighbor fc00::6 activate
  neighbor fc00::e activate
  neighbor fc00::12 activate
  neighbor fc00::16 activate
  neighbor fc00::1a activate
  neighbor fc00::1e activate
  neighbor fc00::22 activate
  neighbor fc00::26 activate
  neighbor fc00::2a activate
  neighbor fc00::2e activate
  neighbor fc00::32 activate
  neighbor fc00::36 activate
  neighbor fc00::3a activate
  neighbor fc00::3e activate
  neighbor fc00::4a activate
  neighbor fc00::4e activate
  neighbor fc00::52 activate
  neighbor fc00::56 activate
 exit-address-family
!
line vty
!
end
root@dut-testbed:~# vtysh -c 'show ip bgp sum'

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 12863
RIB entries 12919, using 2321 KiB of memory
Peers 19, using 388 KiB of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
10.0.0.1        4      65200    3206    2412        0    0  814 00:00:05         6402
10.0.0.3        4      65200    3207    2643        0    0  584 00:00:04         6402
10.0.0.5        4      65200    3208    3230        0    0    0 00:00:07         6402
10.0.0.7        4      65200    3206    1763        0    0 1464 00:00:06         6402
10.0.0.9        4      65200    3209    3231        0    0    0 00:00:09         6402
10.0.0.11       4      65200    3215    6443        0    0    0 00:00:29         6402
10.0.0.13       4      65200    3206    3231        0    0    0 00:00:15         6402
10.0.0.15       4      65200       0       0        0    0    0    never         Idle
10.0.0.17       4      65200    3211    3236        0    0    0 00:00:17         6402
10.0.0.19       4      65200    3209    3232        0    0    0 00:00:12         6402
10.0.0.31       4      65200    3212    3238        0    0    0 00:00:20         6402
10.0.0.33       4      64001       7    6434        0    0    0 00:00:21            7
10.0.0.35       4      64002      11    3237        0    0    0 00:00:18            6
10.0.0.37       4      64003      13    3238        0    0    0 00:00:19            7
10.0.0.39       4      64004       6    6434        0    0    0 00:00:23            6
10.0.0.41       4      64005      17    6445        0    0    0 00:00:35            6
10.0.0.43       4      64006      17    6445        0    0    0 00:00:36            6
10.0.0.45       4      64007       6    6434        0    0    0 00:00:34            6
10.0.0.47       4      64008      17    6445        0    0    0 00:00:34            6

Total number of neighbors 19
root@dut-testbed:~# vtysh -c 'show ip route' | wc -l
116059
root@dut-testbed:~# vtysh -c 'show ipv6 route' | wc -l
102537

# I don't know how to show ipv6 neighbor summary...
```
2. then DOWN all ports, then UP all ports
3. then repeat for several times 
```
# NOTICE, this is testbed command from SONiC testbed project (https://github.com/Azure/sonic-mgmt), what this do is same as step-2 and step-3.
$ for i in {0..20}; do echo "......$i......"; sudo ./testbed-cli.sh start-test vms-t1 port_toggle dut -v  > port_toggle.log; rt=$?;if [ ${rt} -ne 0 ]; then break; fi; done
......0......
......1......
......2......
......3......
......4......
......5......
......6......
......7......
......8......
......9......
......10......
......11......
......12......
......13......
......14......
......15......
......16......
......17......
......18......
......19......
......20......
```

At last, We could see no error quit. It's OK.