### PR TITLE
zebra: free dplane ctx after pw update

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3728,6 +3728,7 @@ static int handle_pw_result(struct zebra_dplane_ctx *ctx)
 	}
 
 done:
+	dplane_ctx_fini(&ctx);
 
 	return 0;
 }


### PR DESCRIPTION
Free the dplane contexts used for pseudowire updates; we were leaking these.
