### PR TITLE
evpn-mh: protodown handling fixes

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -691,7 +691,7 @@ static int netlink_bridge_interface(struct nlmsghdr *h, int len, ns_id_t ns_id,
 	return 0;
 }
 
-/* If the interface is and es bond member then it must follow EVPN's
+/* If the interface is an es bond member then it must follow EVPN's
  * protodown setting
  */
 static void netlink_proc_dplane_if_protodown(struct zebra_if *zif,

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1428,6 +1428,14 @@ const char *zebra_protodown_rc_str(enum protodown_reasons protodown_rc,
 	return pd_buf;
 }
 
+static inline bool if_is_protodown_applicable(struct interface *ifp)
+{
+	if (IS_ZEBRA_IF_BOND(ifp))
+		return false;
+
+	return true;
+}
+
 /* Interface's information print out to vty interface. */
 static void if_dump_vty(struct vty *vty, struct interface *ifp)
 {
@@ -1592,14 +1600,13 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 	}
 
 	zebra_evpn_if_es_print(vty, zebra_if);
-	vty_out(vty, "  protodown: %s",
-		(zebra_if->flags & ZIF_FLAG_PROTODOWN) ? "on" : "off");
+	vty_out(vty, "  protodown: %s %s\n",
+		(zebra_if->flags & ZIF_FLAG_PROTODOWN) ? "on" : "off",
+		if_is_protodown_applicable(ifp) ? "" : "(n/a)");
 	if (zebra_if->protodown_rc)
-		vty_out(vty, " rc: %s\n",
+		vty_out(vty, "  protodown reasons: %s\n",
 			zebra_protodown_rc_str(zebra_if->protodown_rc, pd_buf,
 					       sizeof(pd_buf)));
-	else
-		vty_out(vty, "\n");
 
 	if (zebra_if->link_ifindex != IFINDEX_INTERNAL) {
 		if (zebra_if->link)

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3174,16 +3174,14 @@ void zebra_evpn_mh_update_protodown_bond_mbr(struct zebra_if *zif, bool clear,
 		protodown_rc = bond_zif->protodown_rc;
 	}
 
-	if (zif->protodown_rc == protodown_rc)
-		return;
-
 	old_protodown = !!(zif->flags & ZIF_FLAG_PROTODOWN);
 	old_protodown_rc = zif->protodown_rc;
 	zif->protodown_rc &= ~ZEBRA_PROTODOWN_EVPN_ALL;
 	zif->protodown_rc |= (protodown_rc & ZEBRA_PROTODOWN_EVPN_ALL);
 	new_protodown = !!zif->protodown_rc;
 
-	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+	if (IS_ZEBRA_DEBUG_EVPN_MH_ES
+	    && (zif->protodown_rc != old_protodown_rc))
 		zlog_debug(
 			"%s bond mbr %s protodown_rc changed; old 0x%x new 0x%x",
 			caller, zif->ifp->name, old_protodown_rc,

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3029,7 +3029,7 @@ void zebra_evpn_mh_print(struct vty *vty)
 	vty_out(vty, "  uplink-cfg-cnt: %u, uplink-active-cnt: %u\n",
 		zmh_info->uplink_cfg_cnt, zmh_info->uplink_oper_up_cnt);
 	if (zmh_info->protodown_rc)
-		vty_out(vty, "  protodown: %s\n",
+		vty_out(vty, "  protodown reasons: %s\n",
 			zebra_protodown_rc_str(zmh_info->protodown_rc, pd_buf,
 					       sizeof(pd_buf)));
 }


### PR DESCRIPTION
The MH state-machine places ES-bonds in an error-disabled/protodown state to allow a phased recovery with minimal impact on existing traffic. This PR includes misc fixes for the protodown handling.