### PR TITLE
bgpd: add config knobs to disable rx and tx of ead-per-evi routes

### DIFF
--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -261,6 +261,15 @@ struct bgp_evpn_mh_info {
 	/* Use L3 NHGs for host routes in symmetric IRB */
 	bool install_l3nhg;
 	bool host_routes_use_l3nhg;
+	/* Some vendors are not generating the EAD-per-EVI route. This knob
+	 * can be turned off to activate a remote ES-PE when the EAD-per-ES
+	 * route is rxed i.e. not wait on the EAD-per-EVI route
+	 */
+	bool ead_evi_rx;
+#define BGP_EVPN_MH_EAD_EVI_RX_DEF true
+	/* Skip EAD-EVI advertisements by turning off this knob */
+	bool ead_evi_tx;
+#define BGP_EVPN_MH_EAD_EVI_TX_DEF true
 };
 
 /****************************************************************************/

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3757,6 +3757,26 @@ DEFPY (bgp_evpn_use_es_l3nhg,
 	return CMD_SUCCESS;
 }
 
+DEFPY (bgp_evpn_ead_evi_rx_disable,
+       bgp_evpn_ead_evi_rx_disable_cmd,
+       "[no$no] disable-ead-evi-rx",
+       NO_STR
+       "Activate PE on EAD-ES even if EAD-EVI is not received\n")
+{
+	bgp_mh_info->ead_evi_rx = no? true :false;
+	return CMD_SUCCESS;
+}
+
+DEFPY (bgp_evpn_ead_evi_tx_disable,
+       bgp_evpn_ead_evi_tx_disable_cmd,
+       "[no$no] disable-ead-evi-tx",
+       NO_STR
+       "Don't advertise EAD-EVI for local ESs\n")
+{
+	bgp_mh_info->ead_evi_tx = no? true :false;
+	return CMD_SUCCESS;
+}
+
 DEFPY (bgp_evpn_advertise_pip_ip_mac,
        bgp_evpn_advertise_pip_ip_mac_cmd,
        "[no$no] advertise-pip [ip <A.B.C.D> [mac <X:X:X:X:X:X|X:X:X:X:X:X/M>]]",
@@ -5751,6 +5771,20 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 			vty_out(vty, "  no use-es-l3nhg\n");
 	}
 
+	if (bgp_mh_info->ead_evi_rx != BGP_EVPN_MH_EAD_EVI_RX_DEF) {
+		if (bgp_mh_info->ead_evi_rx)
+			vty_out(vty, "  no disable-ead-evi-rx\n");
+		else
+			vty_out(vty, "  disable-ead-evi-rx\n");
+	}
+
+	if (bgp_mh_info->ead_evi_tx != BGP_EVPN_MH_EAD_EVI_TX_DEF) {
+		if (bgp_mh_info->ead_evi_tx)
+			vty_out(vty, "  no disable-ead-evi-tx\n");
+		else
+			vty_out(vty, "  disable-ead-evi-tx\n");
+	}
+
 	if (!bgp->evpn_info->dup_addr_detect)
 		vty_out(vty, "  no dup-addr-detection\n");
 
@@ -5896,6 +5930,8 @@ void bgp_ethernetvpn_init(void)
 	install_element(BGP_EVPN_NODE, &bgp_evpn_flood_control_cmd);
 	install_element(BGP_EVPN_NODE, &bgp_evpn_advertise_pip_ip_mac_cmd);
 	install_element(BGP_EVPN_NODE, &bgp_evpn_use_es_l3nhg_cmd);
+	install_element(BGP_EVPN_NODE, &bgp_evpn_ead_evi_rx_disable_cmd);
+	install_element(BGP_EVPN_NODE, &bgp_evpn_ead_evi_tx_disable_cmd);
 
 	/* test commands */
 	install_element(BGP_EVPN_NODE, &test_es_add_cmd);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2682,6 +2682,20 @@ the traffic.
 Similarly traffic received from ES peers via the overlay cannot be forwarded
 to the server. This is split-horizon-filtering with local bias.
 
+Knobs for interop
+"""""""""""""""""
+Some vendors do not send EAD-per-EVI routes. To interop with them we
+need to relax the dependency on EAD-per-EVI routes and activate a remote
+ES-PE based on just the EAD-per-ES route.
+
+Note that by default we advertise and expect EAD-per-EVI routes.
+
+.. index:: disable-ead-evi-rx
+.. clicmd:: [no] disable-ead-evi-rx
+
+.. index:: disable-ead-evi-tx
+.. clicmd:: [no] disable-ead-evi-tx
+
 Fast failover
 """""""""""""
 As the primary purpose of EVPN-MH is redundancy keeping the failover efficient

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2644,11 +2644,11 @@ Ethernet Segments
 An Ethernet Segment can be configured by specifying a system-MAC and a
 local discriminatior against the bond interface on the PE (via zebra) -
 
-.. index:: evpn mh es-id [(1-16777215)$es_lid]
-.. clicmd:: [no] evpn mh es-id [(1-16777215)$es_lid]
+.. index:: evpn mh es-id (1-16777215)
+.. clicmd:: [no] evpn mh es-id (1-16777215)
 
-.. index:: evpn mh es-sys-mac [X:X:X:X:X:X$mac]
-.. clicmd:: [no$no] evpn mh es-sys-mac [X:X:X:X:X:X$mac]
+.. index:: evpn mh es-sys-mac X:X:X:X:X:X
+.. clicmd:: [no] evpn mh es-sys-mac X:X:X:X:X:X
 
 The sys-mac and local discriminator are used for generating a 10-byte,
 Type-3 Ethernet Segment ID.
@@ -2671,8 +2671,8 @@ forward BUM traffic received via the overlay network. This implementation
 uses a preference based DF election specified by draft-ietf-bess-evpn-pref-df.
 The DF preference is configurable per-ES (via zebra) -
 
-.. index:: evpn mh es-df-pref [(1-16777215)$df_pref]
-.. clicmd:: [no] evpn mh es-df-pref [(1-16777215)$df_pref]
+.. index:: evpn mh es-df-pref (1-16777215)
+.. clicmd:: [no] evpn mh es-df-pref (1-16777215)
 
 BUM traffic is rxed via the overlay by all PEs attached to a server but
 only the DF can forward the de-capsulated traffic to the access port. To
@@ -2709,14 +2709,14 @@ been introduced for the express purpose of efficient ES failovers.
   on via the following BGP config -
 
 .. index:: use-es-l3nhg
-.. clicmd:: [no$no] use-es-l3nhg
+.. clicmd:: [no] use-es-l3nhg
 
 - Local ES (MAC/Neigh) failover via ES-redirect.
   On dataplanes that do not have support for ES-redirect the feature can be
   turned off via the following zebra config -
 
 .. index:: evpn mh redirect-off
-.. clicmd:: [no$no] evpn mh redirect-off
+.. clicmd:: [no] evpn mh redirect-off
 
 Uplink/Core tracking
 """"""""""""""""""""
@@ -2737,11 +2737,11 @@ the ES peer (PE2) goes down PE1 continues to advertise hosts learnt from PE2
 for a holdtime during which it attempts to establish local reachability of
 the host. This holdtime is configurable via the following zebra commands -
 
-.. index:: evpn mh neigh-holdtime (0-86400)$duration
-.. clicmd:: [no$no] evpn mh neigh-holdtime (0-86400)$duration
+.. index:: evpn mh neigh-holdtime (0-86400)
+.. clicmd:: [no] evpn mh neigh-holdtime (0-86400)
 
-.. index:: evpn mh mac-holdtime (0-86400)$duration
-.. clicmd:: [no$no] evpn mh mac-holdtime (0-86400)$duration
+.. index:: evpn mh mac-holdtime (0-86400)
+.. clicmd:: [no] evpn mh mac-holdtime (0-86400)
 
 Startup delay
 """""""""""""
@@ -2750,8 +2750,8 @@ and EVPN network to converge before enabling the ESs. For this duration the
 ES bonds are held protodown. The startup delay is configurable via the
 following zebra command -
 
-.. index:: evpn mh startup-delay(0-3600)$duration
-.. clicmd:: [no] evpn mh startup-delay(0-3600)$duration
+.. index:: evpn mh startup-delay (0-3600)
+.. clicmd:: [no] evpn mh startup-delay (0-3600)
 
 +Support with VRF network namespace backend
 +^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Some vendors only advertise EAD-per-ES routes i.e. they do not
advertise EAD-per-EVI routes. To interop with these vendors we need
to relax the dependancy on EAD-per-EVI routes to activate a remote ES-PE.

Sample config -
>>>>>>>>>>>>>>>>>>>>>>>>>>>>
router bgp 5553
 address-family l2vpn evpn
  disable-ead-evi-rx
>>>>>>>>>>>>>>>>>>>>>>>>>>>>

Ticket: CM-31177

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>