### PR TITLE
zebra: support for type-0 ESI

### DIFF
--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -279,8 +279,12 @@ struct irdp_interface;
 /* Ethernet segment info used for setting up EVPN multihoming */
 struct zebra_evpn_es;
 struct zebra_es_if_info {
+	/* type-3 esi config */
 	struct ethaddr sysmac;
 	uint32_t lid; /* local-id; has to be unique per-ES-sysmac */
+
+	esi_t esi;
+
 	uint16_t df_pref;
 	struct zebra_evpn_es *es; /* local ES */
 };


### PR DESCRIPTION
Earlier type-3 ESI was the only format support for evpn-mh. Updated the
CLI to allow a 10-byte type-0 ESI.

Both type-0 and type-3 ESI are statically configured; just in two different
ways -
1. type-0 is configured as a complete 10-byte string
2. type-3 is configured as a 6-byte es-sys-mac and a 3-byte
local-discriminator.

Sample config -
!
interface hostbond1
 evpn mh es-id 00:44:38:39:ff:ff:01:00:00:01
!

This is just a CLI-only change and has no functional impact.

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>