### PR TITLE
Fix run folder permissions

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -59,6 +59,9 @@ chownfrr() {
 	[ -n "$FRR_USER" ] && chown "$FRR_USER" "$1"
 	[ -n "$FRR_GROUP" ] && chgrp "$FRR_GROUP" "$1"
 	[ -n "$FRR_CONFIG_MODE" ] && chmod "$FRR_CONFIG_MODE" "$1"
+	if [ -d "$1" ]; then
+		chmod u+x "$1"
+	fi
 }
 
 vtysh_b () {


### PR DESCRIPTION
In the case of some linux distros the /var/run dir is mounted
with tmpfs so in every reboot it's removed.
Then the frrcommon.sh will recreate it without 'x' perm
So no pid file cannot be created in /var/run/frr

Signed-off-by: Javier Garcia <rampxxxx@gmail.com>