### PR TITLE
zebra: fix show ip route vrf X summary

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1963,9 +1963,6 @@ DEFPY (show_route_summary,
 	struct route_table *table;
 	bool uj = use_json(argc, argv);
 
-	if (table_id == 0)
-		table_id = RT_TABLE_MAIN;
-
 	if (vrf_all) {
 		struct vrf *vrf;
 		struct zebra_vrf *zvrf;
@@ -1974,8 +1971,13 @@ DEFPY (show_route_summary,
 			if ((zvrf = vrf->info) == NULL)
 				continue;
 
-			table = zebra_vrf_lookup_table_with_table_id(
-				afi, SAFI_UNICAST, zvrf->vrf->vrf_id, table_id);
+			if (table_id == 0)
+				table = zebra_vrf_table(afi, SAFI_UNICAST,
+							zvrf->vrf->vrf_id);
+			else
+				table = zebra_vrf_lookup_table_with_table_id(
+					afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
+					table_id);
 
 			if (!table)
 				continue;
@@ -1992,8 +1994,11 @@ DEFPY (show_route_summary,
 		if (vrf_name)
 			VRF_GET_ID(vrf_id, vrf_name, false);
 
-		table = zebra_vrf_lookup_table_with_table_id(afi, SAFI_UNICAST,
-							     vrf_id, table_id);
+		if (table_id == 0)
+			table = zebra_vrf_table(afi, SAFI_UNICAST, vrf_id);
+		else
+			table = zebra_vrf_lookup_table_with_table_id(
+				afi, SAFI_UNICAST, vrf_id, table_id);
 		if (!table)
 			return CMD_SUCCESS;
 


### PR DESCRIPTION
The lookup for non default VRFs was always using a tableId; if not provided, we were defaulting to RT_TABLE_MAIN. This is fine for the default VRF but not for others. As a result, the command was silently failing for non-default VRFs unless we also specified the correct tableId.

Fix this by only performing the lookup using the tableId if it is provided; else use zebra_vrf_table.