### PR TITLE
ospfd: Set Curr_mtu to when we get the mtu

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -647,12 +647,8 @@ void ospf_if_update_params(struct interface *ifp, struct in_addr addr)
 int ospf_if_new_hook(struct interface *ifp)
 {
 	int rc = 0;
-	struct ospf_if_info *oii;
 
 	ifp->info = XCALLOC(MTYPE_OSPF_IF_INFO, sizeof(struct ospf_if_info));
-
-	oii = ifp->info;
-	oii->curr_mtu = ifp->mtu;
 
 	IF_OIFS(ifp) = route_table_init();
 	IF_OIFS_PARAMS(ifp) = route_table_init();
@@ -1280,6 +1276,7 @@ static int ospf_ifp_create(struct interface *ifp)
 	struct ospf_if_params *params;
 	struct route_node *rn;
 	uint32_t count = 0;
+	struct ospf_if_info *oii;
 
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
 		zlog_debug(
@@ -1290,6 +1287,9 @@ static int ospf_ifp_create(struct interface *ifp)
 			ifp->speed);
 
 	assert(ifp->info);
+
+	oii = ifp->info;
+	oii->curr_mtu = ifp->mtu;
 
 	if (IF_DEF_PARAMS(ifp)
 	    && !OSPF_IF_PARAM_CONFIGURED(IF_DEF_PARAMS(ifp), type)) {


### PR DESCRIPTION
Currently if you start ospfd, bring up neighbors and then issue
a tcpdump on a interface ospf is peering over, this causes the neighbor
relationship to be restarted:

root@spectrum301(mlx-4600c-01):mgmt:~# tcpdump -i vlan402
2020-11-13T21:25:38.059671+00:00 spectrum301 ospfd[29953]: AdjChg: Nbr 202.0.0.3(default) on vlan402:200.0.3.1: Full -> Deleted (KillNbr)
2020-11-13T21:25:38.065520+00:00 spectrum301 ospfd[29953]: ospfTrapNbrStateChange: trap sent: 200.0.3.2 now Deleted/DROther
2020-11-13T21:25:38.065922+00:00 spectrum301 ospfd[29953]: ospfTrapIfStateChange: trap sent: 200.0.3.1 now Down
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on vlan402, link-type EN10MB (Ethernet), capture size 262144 bytes
21:25:38.072330 IP 200.0.3.1 > igmp.mcast.net: igmp v3 report, 1 group record(s)
2020-11-13T21:25:38.080430+00:00 spectrum301 ospfd[29953]: ospfTrapIfStateChange: trap sent: 200.0.3.1 now Point-To-Point
2020-11-13T21:25:38.080654+00:00 spectrum301 ospfd[29953]: SPF Processing Time(usecs): 9734
2020-11-13T21:25:38.080829+00:00 spectrum301 ospfd[29953]:             SPF Time: 6422
2020-11-13T21:25:38.080991+00:00 spectrum301 ospfd[29953]:            InterArea: 1572
2020-11-13T21:25:38.081152+00:00 spectrum301 ospfd[29953]:                Prune: 67
2020-11-13T21:25:38.081329+00:00 spectrum301 ospfd[29953]:         RouteInstall: 1396
2020-11-13T21:25:38.081548+00:00 spectrum301 ospfd[29953]: Reason(s) for SPF: N, S, ABR, ASBR
21:25:38.092510 IP 200.0.3.1 > ospf-all.mcast.net: OSPFv2, Hello, length 44

This is happening because the curr_mtu is not being properly stored.  It was being set
on interface creation( but we have not actually read in the mtu part of the interface data, so
it is still 0 ).

Modify the code to store the curr_mtu at a point in interface creation *After* we have read
in interface data.

Ticket: CM-32276
Signed-off-by: Donald Sharp <sharpd@nvidia.com>