### PR TITLE
ospf: fix instance initialization when using multi-instance mode

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -384,11 +384,49 @@ struct ospf *ospf_lookup_by_inst_name(unsigned short instance, const char *name)
 	return NULL;
 }
 
+static void ospf_init(struct ospf *ospf)
+{
+	struct vrf *vrf;
+	struct interface *ifp;
+
+	ospf_opaque_type11_lsa_init(ospf);
+
+	if (ospf->vrf_id != VRF_UNKNOWN)
+		ospf->oi_running = 1;
+
+	/* Activate 'ip ospf area x' configured interfaces for given
+	 * vrf. Activate area on vrf x aware interfaces.
+	 * vrf_enable callback calls router_id_update which
+	 * internally will call ospf_if_update to trigger
+	 * network_run_state
+	 */
+	vrf = vrf_lookup_by_id(ospf->vrf_id);
+
+	FOR_ALL_INTERFACES (vrf, ifp) {
+		struct ospf_if_params *params;
+		struct route_node *rn;
+		uint32_t count = 0;
+
+		params = IF_DEF_PARAMS(ifp);
+		if (OSPF_IF_PARAM_CONFIGURED(params, if_area))
+			count++;
+
+		for (rn = route_top(IF_OIFS_PARAMS(ifp)); rn; rn = route_next(rn))
+			if ((params = rn->info) && OSPF_IF_PARAM_CONFIGURED(params, if_area))
+				count++;
+
+		if (count > 0) {
+			ospf_interface_area_set(ospf, ifp);
+			ospf->if_ospf_cli_count += count;
+		}
+	}
+
+	ospf_router_id_update(ospf);
+}
+
 struct ospf *ospf_get(unsigned short instance, const char *name, bool *created)
 {
 	struct ospf *ospf;
-	struct vrf *vrf;
-	struct interface *ifp;
 
 	/* vrf name provided call inst and name based api
 	 * in case of no name pass default ospf instance */
@@ -402,39 +440,7 @@ struct ospf *ospf_get(unsigned short instance, const char *name, bool *created)
 		ospf = ospf_new(instance, name);
 		ospf_add(ospf);
 
-		ospf_opaque_type11_lsa_init(ospf);
-
-		if (ospf->vrf_id != VRF_UNKNOWN)
-			ospf->oi_running = 1;
-
-		/* Activate 'ip ospf area x' configured interfaces for given
-		 * vrf. Activate area on vrf x aware interfaces.
-		 * vrf_enable callback calls router_id_update which
-		 * internally will call ospf_if_update to trigger
-		 * network_run_state
-		 */
-		vrf = vrf_lookup_by_id(ospf->vrf_id);
-
-		FOR_ALL_INTERFACES (vrf, ifp) {
-			struct ospf_if_params *params;
-			struct route_node *rn;
-			uint32_t count = 0;
-
-			params = IF_DEF_PARAMS(ifp);
-			if (OSPF_IF_PARAM_CONFIGURED(params, if_area))
-				count++;
-
-			for (rn = route_top(IF_OIFS_PARAMS(ifp)); rn; rn = route_next(rn))
-				if ((params = rn->info) && OSPF_IF_PARAM_CONFIGURED(params, if_area))
-					count++;
-
-			if (count > 0) {
-				ospf_interface_area_set(ospf, ifp);
-				ospf->if_ospf_cli_count += count;
-			}
-		}
-
-		ospf_router_id_update(ospf);
+		ospf_init(ospf);
 	}
 
 	return ospf;
@@ -450,7 +456,7 @@ struct ospf *ospf_get_instance(unsigned short instance, bool *created)
 		ospf = ospf_new(instance, NULL /* VRF_DEFAULT*/);
 		ospf_add(ospf);
 
-		ospf_opaque_type11_lsa_init(ospf);
+		ospf_init(ospf);
 	}
 
 	return ospf;

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -604,7 +604,6 @@ extern int ospf_nbr_nbma_poll_interval_set(struct ospf *, struct in_addr,
 					   unsigned int);
 extern int ospf_nbr_nbma_poll_interval_unset(struct ospf *, struct in_addr);
 extern void ospf_prefix_list_update(struct prefix_list *);
-extern void ospf_init(void);
 extern void ospf_if_update(struct ospf *, struct interface *);
 extern void ospf_ls_upd_queue_empty(struct ospf_interface *);
 extern void ospf_terminate(void);


### PR DESCRIPTION
OSPF instance initialization was moved from "router ospf" vty command to
ospf_get function some time ago but the same thing must be done in
ospf_get_instance function used when multi-instance mode is enabled.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>