### PR TITLE
[7.5] ospf: fix instance initialization when using multi-instance mode

### DIFF
--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -556,7 +556,6 @@ extern int ospf_nbr_nbma_poll_interval_set(struct ospf *, struct in_addr,
 					   unsigned int);
 extern int ospf_nbr_nbma_poll_interval_unset(struct ospf *, struct in_addr);
 extern void ospf_prefix_list_update(struct prefix_list *);
-extern void ospf_init(void);
 extern void ospf_if_update(struct ospf *, struct interface *);
 extern void ospf_ls_upd_queue_empty(struct ospf_interface *);
 extern void ospf_terminate(void);


### PR DESCRIPTION
OSPF instance initialization was moved from "router ospf" vty command to
ospf_get function some time ago but the same thing must be done in
ospf_get_instance function used when multi-instance mode is enabled.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>