### PR TITLE
ospfd: fix area removal at interface level

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8818,6 +8818,7 @@ DEFUN (no_ip_ospf_area,
 	struct ospf_if_params *params;
 	unsigned short instance = 0;
 	struct in_addr addr;
+	struct in_addr area_id;
 
 	if (argv_find(argv, argc, "(1-65535)", &idx))
 		instance = strtol(argv[idx]->arg, NULL, 10);
@@ -8845,6 +8846,7 @@ DEFUN (no_ip_ospf_area,
 	} else
 		params = IF_DEF_PARAMS(ifp);
 
+	area_id = params->if_area;
 	if (!OSPF_IF_PARAM_CONFIGURED(params, if_area)) {
 		vty_out(vty,
 			"Can't find specified interface area configuration.\n");
@@ -8860,6 +8862,7 @@ DEFUN (no_ip_ospf_area,
 	if (ospf) {
 		ospf_interface_area_unset(ospf, ifp);
 		ospf->if_ospf_cli_count--;
+		ospf_area_check_free(ospf, area_id);
 	}
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
Areas created via interface command are not being deleted when
executing the command `no ip ospf area x`

With the following configuration:
```
!
interface eth1
 ip address 10.0.12.2/24
 ip ospf area 0.0.0.100
!
router ospf
!
```
```
r2# sh ip ospf
 OSPF Routing Process, Router ID: 2.2.2.2
 Supports only single TOS (TOS0) routes
 ....
 Number of opaque AS LSA 0. Checksum Sum 0x00000000
 Number of areas attached to this router: 1     <--- ***
 Area ID: 0.0.0.100                             <--- ***
   Shortcutting mode: Default, S-bit consensus: ok
   Number of interfaces in this area: Total: 1, Active: 1
   Number of fully adjacent neighbors in this area: 0
   Area has no authentication
   Number of full virtual adjacencies going through this area: 0
   SPF algorithm executed 1 times
   Number of LSA 1
   Number of router LSA 1. Checksum Sum 0x0000f3d4
   Number of network LSA 0. Checksum Sum 0x00000000
   Number of summary LSA 0. Checksum Sum 0x00000000
   Number of ASBR summary LSA 0. Checksum Sum 0x00000000
   Number of NSSA LSA 0. Checksum Sum 0x00000000
   Number of opaque link LSA 0. Checksum Sum 0x00000000
   Number of opaque area LSA 0. Checksum Sum 0x00000000
```
However when removing the area from the interface, the command
above displays the same information
```
r2# conf t
r2(config)# int eth1
r2(config-if)# no ip ospf area 0.0.0.100
r2(config-if)# exit
r2(config)# exit
```
```
r2# sh ip ospf
 OSPF Routing Process, Router ID: 2.2.2.2
 Supports only single TOS (TOS0) routes
 ....
 Number of opaque AS LSA 0. Checksum Sum 0x00000000
 Number of areas attached to this router: 1       <--- ***
 Area ID: 0.0.0.100                               <--- ***
   Shortcutting mode: Default, S-bit consensus: ok
   Number of interfaces in this area: Total: 0, Active: 0
   Number of fully adjacent neighbors in this area: 0
   Area has no authentication
   Number of full virtual adjacencies going through this area: 0
   SPF algorithm executed 2 times
   Number of LSA 1
   Number of router LSA 1. Checksum Sum 0x0000e26e
   Number of network LSA 0. Checksum Sum 0x00000000
   Number of summary LSA 0. Checksum Sum 0x00000000
   Number of ASBR summary LSA 0. Checksum Sum 0x00000000
   Number of NSSA LSA 0. Checksum Sum 0x00000000
   Number of opaque link LSA 0. Checksum Sum 0x00000000
   Number of opaque area LSA 0. Checksum Sum 0x00000000
```
```
r2# sh run
!
interface eth1
 ip address 10.0.12.2/24
!
router ospf
!
end
```
This PR removes the area when executing `no ip ospf area` command
```
r2# sh ip ospf
 OSPF Routing Process, Router ID: 2.2.2.2
 Supports only single TOS (TOS0) routes
 ....
 Number of opaque AS LSA 0. Checksum Sum 0x00000000
 Number of areas attached to this router: 0
```
Signed-off-by: ckishimo <carles.kishimoto@gmail.com>