### PR TITLE
[RFC] zebra: add option to specify interfaces to work with

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -782,6 +782,12 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return -1;
 	name = (char *)RTA_DATA(tb[IFLA_IFNAME]);
 
+	if (!zebra_if_allowed(name)) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("%s: ignoring interface %s", __func__, name);
+		return 0;
+	}
+
 	if (tb[IFLA_IFALIAS])
 		desc = (char *)RTA_DATA(tb[IFLA_IFALIAS]);
 
@@ -1442,6 +1448,15 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 			if (ifp == NULL) {
 				/* unknown interface */
+
+				if (!zebra_if_allowed(name)) {
+					if (IS_ZEBRA_DEBUG_KERNEL)
+						zlog_debug(
+							"%s: ignoring interface %s",
+							__func__, name);
+					return 0;
+				}
+
 				ifp = if_get_by_name(name, vrf_id);
 			} else {
 				/* pre-configured interface, learnt now */

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -439,6 +439,8 @@ DECLARE_HOOK(zebra_if_config_wr, (struct vty * vty, struct interface *ifp),
 
 extern void zebra_if_init(void);
 
+extern bool zebra_if_allowed(const char *name);
+
 extern struct interface *if_lookup_by_index_per_ns(struct zebra_ns *, uint32_t);
 extern struct interface *if_lookup_by_name_per_ns(struct zebra_ns *,
 						  const char *);

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -77,6 +77,8 @@ int graceful_restart;
 
 bool v6_rr_semantics = false;
 
+char *interface_pattern = NULL;
+
 #ifdef HAVE_NETLINK
 /* Receive buffer size for netlink socket */
 uint32_t nl_rcvbufsize = 4194304;
@@ -99,6 +101,7 @@ const struct option longopts[] = {
 	{"vrfwnetns", no_argument, NULL, 'n'},
 	{"nl-bufsize", required_argument, NULL, 's'},
 	{"v6-rr-semantics", no_argument, NULL, OPTION_V6_RR_SEMANTICS},
+	{"interfaces", required_argument, NULL, 'I'},
 #endif /* HAVE_NETLINK */
 	{0}};
 
@@ -295,7 +298,7 @@ int main(int argc, char **argv)
 	frr_opt_add(
 		"baz:e:o:rK:"
 #ifdef HAVE_NETLINK
-		"s:n"
+		"s:nI:"
 #endif
 		,
 		longopts,
@@ -311,6 +314,7 @@ int main(int argc, char **argv)
 		"  -n, --vrfwnetns          Use NetNS as VRF backend\n"
 		"  -s, --nl-bufsize         Set netlink receive buffer size\n"
 		"      --v6-rr-semantics    Use v6 RR semantics\n"
+		"  -I, --interfaces         Set interface name pattern\n"
 #endif /* HAVE_NETLINK */
 	);
 
@@ -378,6 +382,9 @@ int main(int argc, char **argv)
 			if (!strcmp(optarg, "notify_on_ack"))
 				notify_on_ack = true;
 			asic_offload = true;
+			break;
+		case 'I':
+			interface_pattern = strdup(optarg);
 			break;
 #endif /* HAVE_NETLINK */
 		default:


### PR DESCRIPTION
This PR introduces a new option `-I`/`--interfaces` for zebra, which allows
user to tell zebra to work only with specific interfaces.

The option itself is a list of patterns to match interface names. It allows using
an asterisk (`*`) to match any symbols and a hyphen (`-`) to block interfaces
that match the pattern. Patterns are checked in a specified order. There is an
implicit "block any" (`-*`) rule at the end.

Examples:

To allow only names starting with "eth": `-I eth*`
To allow all names except starting with "ens": `-I -ens*,*`

This currently works only with netlink-based kernel communication as I don't
have any OS other than Linux.

If the idea is accepted by the community, I will add the docs.