### PR TITLE
isisd, ospfd: increase timeout to fix intermittent LDP Sync test failure

### DIFF
--- a/lib/ldp_sync.h
+++ b/lib/ldp_sync.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #define LDP_IGP_SYNC_HOLDDOWN_DEFAULT 0
 
-#define LDP_IGP_SYNC_HELLO_TIMEOUT 1
+#define LDP_IGP_SYNC_HELLO_TIMEOUT 5
 
 /* LDP-IGP Sync structures */
 struct ldp_sync_info_cmd {


### PR DESCRIPTION
Currently, IGPs are coded to receive a 'hello' message from LDP every second.
Intermittently, LDP Sync topotests are failing because the IGPs fail to
receive this 'hello' message every second.
When the LDP Sync topotests fail, LDP logs show that LDP is processing
zapi messages for 1-2 seconds.

This is a shortterm fix, in order to prevent CI pipeline failures.
The longterm fix is in progress.

Signed-off-by: Karen Schoener <karen@voltanet.io>