### PR TITLE
Global bgp wait

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1514,6 +1514,18 @@ void cli_show_router_bgp_router_id(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, " bgp router-id %s\n", yang_dnode_get_string(dnode, NULL));
 }
 
+DEFPY (bgp_global_suppress_fib_pending,
+       bgp_global_suppress_fib_pending_cmd,
+       "[no] bgp suppress-fib-pending",
+       NO_STR
+       BGP_STR
+       "Advertise only routes that are programmed in kernel to peers globally\n")
+{
+	bm_wait_for_fib_set(!no);
+
+	return CMD_SUCCESS;
+}
+
 DEFPY (bgp_suppress_fib_pending,
        bgp_suppress_fib_pending_cmd,
        "[no] bgp suppress-fib-pending",
@@ -16936,6 +16948,9 @@ int bgp_config_write(struct vty *vty)
 		vty_out(vty, "\n");
 	}
 
+	if (bm->wait_for_fib)
+		vty_out(vty, "bgp suppress-fib-pending\n");
+
 	if (CHECK_FLAG(bm->flags, BM_FLAG_GRACEFUL_SHUTDOWN))
 		vty_out(vty, "bgp graceful-shutdown\n");
 
@@ -17463,6 +17478,9 @@ void bgp_vty_init(void)
 	/* "bgp local-mac" hidden commands. */
 	install_element(CONFIG_NODE, &bgp_local_mac_cmd);
 	install_element(CONFIG_NODE, &no_bgp_local_mac_cmd);
+
+	/* "bgp suppress-fib-pending" global */
+	install_element(CONFIG_NODE, &bgp_global_suppress_fib_pending_cmd);
 
 	/* bgp route-map delay-timer commands. */
 	install_element(CONFIG_NODE, &bgp_set_route_map_delay_timer_cmd);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -159,6 +159,9 @@ struct bgp_master {
 	/* How big should we set the socket buffer size */
 	uint32_t socket_buffer;
 
+	/* Should we do wait for fib install globally? */
+	bool wait_for_fib;
+
 	/* EVPN multihoming */
 	struct bgp_evpn_mh_info *mh_info;
 
@@ -719,8 +722,9 @@ struct afi_safi_info {
 #define BGP_SELECT_DEFER_DISABLE(bgp)                                          \
 	(CHECK_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE))
 
-#define BGP_SUPPRESS_FIB_ENABLED(bgp)					       \
-	(CHECK_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING))
+#define BGP_SUPPRESS_FIB_ENABLED(bgp)                                          \
+	(CHECK_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING)                 \
+	 || bm->wait_for_fib)
 
 /* BGP peer-group support. */
 struct peer_group {
@@ -1879,6 +1883,7 @@ extern int bgp_handle_socket(struct bgp *bgp, struct vrf *vrf,
 extern void bgp_router_id_zebra_bump(vrf_id_t, const struct prefix *);
 extern void bgp_router_id_static_set(struct bgp *, struct in_addr);
 
+extern void bm_wait_for_fib_set(bool set);
 extern void bgp_suppress_fib_pending_set(struct bgp *bgp, bool set);
 extern int bgp_cluster_id_set(struct bgp *, struct in_addr *);
 extern int bgp_cluster_id_unset(struct bgp *);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3523,6 +3523,11 @@ status in FIB:
 .. index:: bgp suppress-fib-pending
 .. clicmd:: [no] bgp suppress-fib-pending
 
+   This command is applicable at the global level and at an individual
+   bgp level.  If applied at the global level all bgp instances will
+   wait for fib installation before announcing routes and there is no
+   way to turn it off for a particular bgp vrf.
+
 .. _routing-policy:
 
 Routing Policy

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1033,6 +1033,9 @@ static void zebra_show_client_detail(struct vty *vty, struct zserv *client)
 	} else
 		vty_out(vty, "Not registered for Nexthop Updates\n");
 
+	vty_out(vty, "Client will %sbe notified about it's routes status\n",
+		client->notify_owner ? "" : "Not ");
+
 	last_read_time = (time_t)atomic_load_explicit(&client->last_read_time,
 						      memory_order_relaxed);
 	last_write_time = (time_t)atomic_load_explicit(&client->last_write_time,


### PR DESCRIPTION
Add `bgp suppress-fib-pending` to CONFIG_NODE level to add a new bgp global knob that turns this feature on automatically for all bgp instances/views/vrfs in one go.