### PR TITLE
ospf6d: Json support added for command "show ipv6 ospf6 database [json]"

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -170,10 +170,34 @@ Showing OSPF6 information
    instance ID, simply type "show ipv6 ospf6 <cr>". JSON output can be
    obtained by appending 'json' to the end of command.
 
-.. index:: show ipv6 ospf6 database
-.. clicmd:: show ipv6 ospf6 database
+.. index:: show ipv6 ospf6 database [<detail|dump|internal>] [json]
+.. clicmd:: show ipv6 ospf6 database [<detail|dump|internal>] [json]
 
-   This command shows LSA database summary. You can specify the type of LSA.
+   This command shows LSAs present in the LSDB. There are three view options.
+   These options helps in viewing all the parameters of the LSAs. JSON output
+   can be obtained by appending 'json' to the end of command. JSON option is
+   not applicable with 'dump' option.
+
+.. index:: show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> [json]
+.. clicmd:: show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> [json]
+
+   These options filters out the LSA based on its type. The three views options
+   works here as well. JSON output can be obtained by appending 'json' to the
+   end of command.
+
+.. index:: show ipv6 ospf6 database adv-router A.B.C.D linkstate-id A.B.C.D [json]
+.. clicmd:: show ipv6 ospf6 database adv-router A.B.C.D linkstate-id A.B.C.D [json]
+
+   The LSAs additinally can also be filtered with the linkstate-id and
+   advertising-router fields. We can use the LSA type filter and views with
+   this command as well and visa-versa. JSON output can be obtained by
+   appending 'json' to the end of command.
+
+.. index:: show ipv6 ospf6 database self-originated [json]
+.. clicmd:: show ipv6 ospf6 database self-originated [json]
+
+   This command is used to filter the LSAs which are originated by the present
+   router. All the other filters are applicable here as well.
 
 .. index:: show ipv6 ospf6 interface [json]
 .. clicmd:: show ipv6 ospf6 interface [json]

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -21,6 +21,7 @@
 #ifndef OSPF6_LSA_H
 #define OSPF6_LSA_H
 #include "ospf6_top.h"
+#include "lib/json.h"
 
 /* Debug option */
 #define OSPF6_LSA_DEBUG           0x01
@@ -141,9 +142,10 @@ struct ospf6_lsa_handler {
 	uint16_t lh_type; /* host byte order */
 	const char *lh_name;
 	const char *lh_short_name;
-	int (*lh_show)(struct vty *, struct ospf6_lsa *);
-	char *(*lh_get_prefix_str)(struct ospf6_lsa *, char *buf,
-				   int buflen, int pos);
+	int (*lh_show)(struct vty *, struct ospf6_lsa *, json_object *json_obj,
+		       bool use_json);
+	char *(*lh_get_prefix_str)(struct ospf6_lsa *, char *buf, int buflen,
+				   int pos);
 
 	uint8_t lh_debug;
 };
@@ -206,10 +208,14 @@ extern char *ospf6_lsa_printbuf(struct ospf6_lsa *lsa, char *buf, int size);
 extern void ospf6_lsa_header_print_raw(struct ospf6_lsa_header *header);
 extern void ospf6_lsa_header_print(struct ospf6_lsa *lsa);
 extern void ospf6_lsa_show_summary_header(struct vty *vty);
-extern void ospf6_lsa_show_summary(struct vty *vty, struct ospf6_lsa *lsa);
-extern void ospf6_lsa_show_dump(struct vty *vty, struct ospf6_lsa *lsa);
-extern void ospf6_lsa_show_internal(struct vty *vty, struct ospf6_lsa *lsa);
-extern void ospf6_lsa_show(struct vty *vty, struct ospf6_lsa *lsa);
+extern void ospf6_lsa_show_summary(struct vty *vty, struct ospf6_lsa *lsa,
+				   json_object *json, bool use_json);
+extern void ospf6_lsa_show_dump(struct vty *vty, struct ospf6_lsa *lsa,
+				json_object *json, bool use_json);
+extern void ospf6_lsa_show_internal(struct vty *vty, struct ospf6_lsa *lsa,
+				    json_object *json, bool use_json);
+extern void ospf6_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
+			   json_object *json, bool use_json);
 
 extern struct ospf6_lsa *ospf6_lsa_create(struct ospf6_lsa_header *header);
 extern struct ospf6_lsa *

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -346,55 +346,6 @@ int ospf6_lsdb_maxage_remover(struct ospf6_lsdb *lsdb)
 	return (reschedule);
 }
 
-void ospf6_lsdb_show(struct vty *vty, enum ospf_lsdb_show_level level,
-		     uint16_t *type, uint32_t *id, uint32_t *adv_router,
-		     struct ospf6_lsdb *lsdb)
-{
-	struct ospf6_lsa *lsa;
-	const struct route_node *end = NULL;
-	void (*showfunc)(struct vty *, struct ospf6_lsa *) = NULL;
-
-	switch (level) {
-	case OSPF6_LSDB_SHOW_LEVEL_DETAIL:
-		showfunc = ospf6_lsa_show;
-		break;
-	case OSPF6_LSDB_SHOW_LEVEL_INTERNAL:
-		showfunc = ospf6_lsa_show_internal;
-		break;
-	case OSPF6_LSDB_SHOW_LEVEL_DUMP:
-		showfunc = ospf6_lsa_show_dump;
-		break;
-	case OSPF6_LSDB_SHOW_LEVEL_NORMAL:
-	default:
-		showfunc = ospf6_lsa_show_summary;
-	}
-
-	if (type && id && adv_router) {
-		lsa = ospf6_lsdb_lookup(*type, *id, *adv_router, lsdb);
-		if (lsa) {
-			if (level == OSPF6_LSDB_SHOW_LEVEL_NORMAL)
-				ospf6_lsa_show(vty, lsa);
-			else
-				(*showfunc)(vty, lsa);
-		}
-		return;
-	}
-
-	if (level == OSPF6_LSDB_SHOW_LEVEL_NORMAL)
-		ospf6_lsa_show_summary_header(vty);
-
-	end = ospf6_lsdb_head(lsdb, !!type + !!(type && adv_router),
-			      type ? *type : 0, adv_router ? *adv_router : 0,
-			      &lsa);
-	while (lsa) {
-		if ((!adv_router || lsa->header->adv_router == *adv_router)
-		    && (!id || lsa->header->id == *id))
-			(*showfunc)(vty, lsa);
-
-		lsa = ospf6_lsdb_next(end, lsa);
-	}
-}
-
 uint32_t ospf6_new_ls_id(uint16_t type, uint32_t adv_router,
 			 struct ospf6_lsdb *lsdb)
 {

--- a/ospf6d/ospf6_lsdb.h
+++ b/ospf6d/ospf6_lsdb.h
@@ -92,7 +92,8 @@ enum ospf_lsdb_show_level {
 
 extern void ospf6_lsdb_show(struct vty *vty, enum ospf_lsdb_show_level level,
 			    uint16_t *type, uint32_t *id, uint32_t *adv_router,
-			    struct ospf6_lsdb *lsdb);
+			    struct ospf6_lsdb *lsdb, json_object *json,
+			    bool use_json);
 
 extern uint32_t ospf6_new_ls_id(uint16_t type, uint32_t adv_router,
 				struct ospf6_lsdb *lsdb);


### PR DESCRIPTION
Modify code to add JSON format output in show command
"show ipv6 ospf6 database" with proper formating.
Removes the code redundancy for the show ipv6 ospf6 database
command.

Signed-off-by: Yash Ranjan <ranjany@vmware.com>