### PR TITLE
ospf6d: Router-ID filter is not filtering the show command "do show i…

### DIFF
--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -1075,9 +1075,10 @@ DEFUN (show_ipv6_ospf6_neighbor_one,
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa))
 		for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi))
-			for (ALL_LIST_ELEMENTS_RO(oi->neighbor_list, k, on))
-				(*showfunc)(vty, on, json, uj);
-
+			for (ALL_LIST_ELEMENTS_RO(oi->neighbor_list, k, on)) {
+				if (router_id == on->router_id)
+					(*showfunc)(vty, on, json, uj);
+			}
 
 	if (uj) {
 		vty_out(vty, "%s\n",


### PR DESCRIPTION
…pv6 ospf6 neighbour A.B.C.D"

frr# do show ipv6 ospf6 neighbor 10.10.10.181
 Neighbor 10.10.10.171%ens193
    Area 0.0.0.0 via interface ens193 (ifindex 5)
    His IfIndex: 8 Link-local address: fe80::250:56ff:feb7:f76d
    State Twoway for a duration of 00:20:08
    His choice of DR/BDR 10.10.10.181/10.10.10.138, Priority 1
    DbDesc status: Slave SeqNum: 0
    Summary-List: 0 LSAs
    Request-List: 0 LSAs
    Retrans-List: 0 LSAs
    0 Pending LSAs for DbDesc in Time 00:00:00 [thread off]
    0 Pending LSAs for LSReq in Time 00:00:00 [thread off]
    0 Pending LSAs for LSUpdate in Time 00:00:00 [thread off]
    0 Pending LSAs for LSAck in Time 00:00:00 [thread off]
 Neighbor 10.10.10.181%ens193
    Area 0.0.0.0 via interface ens193 (ifindex 5)
    His IfIndex: 10 Link-local address: fe80::250:56ff:feb7:a8a0
    State Full for a duration of 00:20:06
    His choice of DR/BDR 10.10.10.181/10.10.10.138, Priority 1
    DbDesc status: Slave SeqNum: 0x4f1e0500
    Summary-List: 0 LSAs
    Request-List: 0 LSAs
    Retrans-List: 2 LSAs
      [Router Id:0.0.0.0 Adv:10.10.10.180]
      [Intra-Prefix Id:0.0.0.0 Adv:10.10.10.180]

All the neighbours are shown in the output. There is no checking for
the neighbour router id.  Compare the neighbour id string from the 
argv to the router_id of the neighbor. If equal then only we will 
call show function.

Signed-off-by: Yash Ranjan <ranjany@vmware.com>