### PR TITLE
bgpd: Handle IPv6 prefixes with IPv4 nexthops for zebra

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1378,11 +1378,21 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 			}
 			nexthop = bgp_path_info_to_ipv6_nexthop(mpinfo_cp,
 								&ifindex);
-			nh_updated = update_ipv6nh_for_route_install(
-					nh_othervrf, nh_othervrf ?
-					info->extra->bgp_orig : bgp,
-					nexthop, ifindex,
-					mpinfo, info, is_evpn, api_nh);
+
+			if (!nexthop)
+				nh_updated = update_ipv4nh_for_route_install(
+					nh_othervrf,
+					nh_othervrf ? info->extra->bgp_orig
+						    : bgp,
+					&mpinfo_cp->attr->nexthop,
+					mpinfo_cp->attr, is_evpn, api_nh);
+			else
+				nh_updated = update_ipv6nh_for_route_install(
+					nh_othervrf,
+					nh_othervrf ? info->extra->bgp_orig
+						    : bgp,
+					nexthop, ifindex, mpinfo, info, is_evpn,
+					api_nh);
 		}
 
 		/* Did we get proper nexthop info to update zebra? */


### PR DESCRIPTION
Prevent from crashing as well here:

```
(gdb) bt
0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
1  0x00007ff54ec5242a in __GI_abort () at abort.c:89
2  0x00007ff54ffb1dd5 in core_handler (signo=11, siginfo=0x7fff189328f0, context=<optimized out>) at lib/sigevent.c:255
3  <signal handler called>
4  update_ipv6nh_for_route_install (api_nh=0x7fff1893309c, is_evpn=<optimized out>, best_pi=0x55c18854f220,
    pi=0x55c18854f220, ifindex=0, nexthop=0x0, nh_bgp=0x55c18850db20, nh_othervrf=<optimized out>) at bgpd/bgp_zebra.c:1099
5  bgp_zebra_announce (dest=dest@entry=0x55c188553020, p=p@entry=0x55c188553020, info=info@entry=0x55c18854f220,
    bgp=bgp@entry=0x55c18850db20, afi=afi@entry=AFI_IP6, safi=safi@entry=SAFI_UNICAST) at bgpd/bgp_zebra.c:1381
6  0x000055c1858ffa3a in bgp_process_main_one (bgp=0x55c18850db20, dest=0x55c188553020, afi=AFI_IP6, safi=SAFI_UNICAST)
    at bgpd/bgp_route.c:2908
7  0x000055c1858ffbbe in bgp_process_wq (wq=<optimized out>, data=0x55c1885550a0) at bgpd/bgp_route.c:3017
8  0x00007ff54ffca560 in work_queue_run (thread=0x7fff189373e0) at lib/workqueue.c:291
9  0x00007ff54ffc0a91 in thread_call (thread=thread@entry=0x7fff189373e0) at lib/thread.c:1681
10 0x00007ff54ff8b978 in frr_run (master=0x55c187caaed0) at lib/libfrr.c:1110
11 0x000055c1858a165b in main (argc=6, argv=0x7fff18937648) at bgpd/bgp_main.c:523
```

```
5  bgp_zebra_announce (dest=dest@entry=0x55c188553020, p=p@entry=0x55c188553020, info=info@entry=0x55c18854f220,
    bgp=bgp@entry=0x55c18850db20, afi=afi@entry=AFI_IP6, safi=safi@entry=SAFI_UNICAST) at bgpd/bgp_zebra.c:1381
        ifindex = 0
        nexthop = 0x0
        nh_weight = 0
```

Reproduce:

```
~# echo "announce route 2a02:4780:1::abdc/128 next-hop 192.168.0.2" > /run/exabgp.in
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>