### PR TITLE
[7.5] bfd: fix session lookup

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1694,7 +1694,7 @@ struct bfd_session *bfd_key_lookup(struct bfd_key key)
 	inet_ntop(bs.key.family, &bs.key.peer, peer_buf,
 		  sizeof(peer_buf));
 	/* Handle cases where local-address is optional. */
-	if (bs.key.family == AF_INET) {
+	if (memcmp(&bs.key.local, &zero_addr, sizeof(bs.key.local))) {
 		memset(&bs.key.local, 0, sizeof(bs.key.local));
 		bsp = hash_lookup(bfd_key_hash, &bs);
 		if (bsp) {


### PR DESCRIPTION
local-address is optional for both IPv4 and IPv6.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>