### PR TITLE
lib: restore previous access/prefix list behaviour

### DIFF
--- a/lib/filter.h
+++ b/lib/filter.h
@@ -203,6 +203,33 @@ struct acl_dup_args {
  */
 bool acl_is_dup(const struct lyd_node *dnode, struct acl_dup_args *ada);
 
+struct plist_dup_args {
+	/** Access list type ("ipv4" or "ipv6"). */
+	const char *pda_type;
+	/** Access list name. */
+	const char *pda_name;
+
+#define PDA_MAX_VALUES 4
+	/** Entry XPath for value. */
+	const char *pda_xpath[PDA_MAX_VALUES];
+	/** Entry value to match. */
+	const char *pda_value[PDA_MAX_VALUES];
+
+	/** Duplicated entry found in list? */
+	bool pda_found;
+
+	/** (Optional) Already existing `dnode`. */
+	const struct lyd_node *pda_entry_dnode;
+};
+
+/**
+ * Check for duplicated entries using the candidate configuration.
+ *
+ * \param vty so we can get the candidate config.
+ * \param pda the arguments to check.
+ */
+bool plist_is_dup(const struct lyd_node *dnode, struct plist_dup_args *pda);
+
 /* filter_cli.c */
 struct lyd_node;
 struct vty;

--- a/lib/filter.h
+++ b/lib/filter.h
@@ -176,6 +176,33 @@ enum yang_prefix_list_action {
 	YPLA_PERMIT = 1,
 };
 
+struct acl_dup_args {
+	/** Access list type ("ipv4", "ipv6" or "mac"). */
+	const char *ada_type;
+	/** Access list name. */
+	const char *ada_name;
+
+#define ADA_MAX_VALUES 4
+	/** Entry XPath for value. */
+	const char *ada_xpath[ADA_MAX_VALUES];
+	/** Entry value to match. */
+	const char *ada_value[ADA_MAX_VALUES];
+
+	/** Duplicated entry found in list? */
+	bool ada_found;
+
+	/** (Optional) Already existing `dnode`. */
+	const struct lyd_node *ada_entry_dnode;
+};
+
+/**
+ * Check for duplicated entries using the candidate configuration.
+ *
+ * \param vty so we can get the candidate config.
+ * \param ada the arguments to check.
+ */
+bool acl_is_dup(const struct lyd_node *dnode, struct acl_dup_args *ada);
+
 /* filter_cli.c */
 struct lyd_node;
 struct vty;

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -162,8 +162,34 @@ DEFPY_YANG(
 	"Wildcard bits\n")
 {
 	int64_t sseq;
+	struct acl_dup_args ada = {};
 	char xpath[XPATH_MAXLEN];
 	char xpath_entry[XPATH_MAXLEN + 128];
+
+	/*
+	 * Backward compatibility: don't complain about duplicated values,
+	 * just silently accept.
+	 */
+	if (seq_str == NULL) {
+		ada.ada_type = "ipv4";
+		ada.ada_name = name;
+		if (host_str && mask_str == NULL) {
+			ada.ada_xpath[0] = "./host";
+			ada.ada_value[0] = host_str;
+		} else if (host_str && mask_str) {
+			ada.ada_xpath[0] = "./network/address";
+			ada.ada_value[0] = host_str;
+			ada.ada_xpath[1] = "./network/mask";
+			ada.ada_value[1] = mask_str;
+		} else {
+			ada.ada_xpath[0] = "./source-any";
+			ada.ada_value[0] = "true";
+		}
+
+		/* Duplicated entry without sequence, just quit. */
+		if (acl_is_dup(vty->candidate_config->dnode, &ada))
+			return CMD_SUCCESS;
+	}
 
 	/*
 	 * Create the access-list first, so we can generate sequence if
@@ -270,9 +296,57 @@ DEFPY_YANG(
 	"Destination address to match\n"
 	"Any destination host\n")
 {
+	int idx = 0;
 	int64_t sseq;
+	struct acl_dup_args ada = {};
 	char xpath[XPATH_MAXLEN];
 	char xpath_entry[XPATH_MAXLEN + 128];
+
+	/*
+	 * Backward compatibility: don't complain about duplicated values,
+	 * just silently accept.
+	 */
+	if (seq_str == NULL) {
+		ada.ada_type = "ipv4";
+		ada.ada_name = name;
+		if (src_str && src_mask_str == NULL) {
+			ada.ada_xpath[idx] = "./host";
+			ada.ada_value[idx] = src_str;
+			idx++;
+		} else if (src_str && src_mask_str) {
+			ada.ada_xpath[idx] = "./network/address";
+			ada.ada_value[idx] = src_str;
+			idx++;
+			ada.ada_xpath[idx] = "./network/mask";
+			ada.ada_value[idx] = src_mask_str;
+			idx++;
+		} else {
+			ada.ada_xpath[idx] = "./source-any";
+			ada.ada_value[idx] = "true";
+			idx++;
+		}
+
+		if (dst_str && dst_mask_str == NULL) {
+			ada.ada_xpath[idx] = "./destination-host";
+			ada.ada_value[idx] = dst_str;
+			idx++;
+		} else if (dst_str && dst_mask_str) {
+			ada.ada_xpath[idx] = "./destination-network/address";
+			ada.ada_value[idx] = dst_str;
+			idx++;
+			ada.ada_xpath[idx] = "./destination-network/mask";
+			ada.ada_value[idx] = dst_mask_str;
+			idx++;
+		} else {
+			ada.ada_xpath[idx] = "./destination-any";
+			ada.ada_value[idx] = "true";
+			idx++;
+		}
+
+		/* Duplicated entry without sequence, just quit. */
+		if (acl_is_dup(vty->candidate_config->dnode, &ada))
+			return CMD_SUCCESS;
+	}
 
 	/*
 	 * Create the access-list first, so we can generate sequence if
@@ -419,8 +493,34 @@ DEFPY_YANG(
 	"Match any IPv4\n")
 {
 	int64_t sseq;
+	struct acl_dup_args ada = {};
 	char xpath[XPATH_MAXLEN];
 	char xpath_entry[XPATH_MAXLEN + 128];
+
+	/*
+	 * Backward compatibility: don't complain about duplicated values,
+	 * just silently accept.
+	 */
+	if (seq_str == NULL) {
+		ada.ada_type = "ipv4";
+		ada.ada_name = name;
+
+		if (prefix_str) {
+			ada.ada_xpath[0] = "./ipv4-prefix";
+			ada.ada_value[0] = prefix_str;
+			if (exact) {
+				ada.ada_xpath[1] = "./ipv4-exact-match";
+				ada.ada_value[1] = "true";
+			}
+		} else {
+			ada.ada_xpath[0] = "./any";
+			ada.ada_value[0] = "true";
+		}
+
+		/* Duplicated entry without sequence, just quit. */
+		if (acl_is_dup(vty->candidate_config->dnode, &ada))
+			return CMD_SUCCESS;
+	}
 
 	/*
 	 * Create the access-list first, so we can generate sequence if
@@ -590,8 +690,34 @@ DEFPY_YANG(
 	"Match any IPv6\n")
 {
 	int64_t sseq;
+	struct acl_dup_args ada = {};
 	char xpath[XPATH_MAXLEN];
 	char xpath_entry[XPATH_MAXLEN + 128];
+
+	/*
+	 * Backward compatibility: don't complain about duplicated values,
+	 * just silently accept.
+	 */
+	if (seq_str == NULL) {
+		ada.ada_type = "ipv6";
+		ada.ada_name = name;
+
+		if (prefix_str) {
+			ada.ada_xpath[0] = "./ipv6-prefix";
+			ada.ada_value[0] = prefix_str;
+			if (exact) {
+				ada.ada_xpath[1] = "./ipv6-exact-match";
+				ada.ada_value[1] = "true";
+			}
+		} else {
+			ada.ada_xpath[0] = "./any";
+			ada.ada_value[0] = "true";
+		}
+
+		/* Duplicated entry without sequence, just quit. */
+		if (acl_is_dup(vty->candidate_config->dnode, &ada))
+			return CMD_SUCCESS;
+	}
 
 	/*
 	 * Create the access-list first, so we can generate sequence if
@@ -765,8 +891,30 @@ DEFPY_YANG(
 	"Match any MAC address\n")
 {
 	int64_t sseq;
+	struct acl_dup_args ada = {};
 	char xpath[XPATH_MAXLEN];
 	char xpath_entry[XPATH_MAXLEN + 128];
+
+	/*
+	 * Backward compatibility: don't complain about duplicated values,
+	 * just silently accept.
+	 */
+	if (seq_str == NULL) {
+		ada.ada_type = "mac";
+		ada.ada_name = name;
+
+		if (mac_str) {
+			ada.ada_xpath[0] = "./mac";
+			ada.ada_value[0] = mac_str;
+		} else {
+			ada.ada_xpath[0] = "./any";
+			ada.ada_value[0] = "true";
+		}
+
+		/* Duplicated entry without sequence, just quit. */
+		if (acl_is_dup(vty->candidate_config->dnode, &ada))
+			return CMD_SUCCESS;
+	}
 
 	/*
 	 * Create the access-list first, so we can generate sequence if

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -1319,8 +1319,43 @@ DEFPY_YANG(
 	"Maximum prefix length\n")
 {
 	int64_t sseq;
+	int arg_idx = 0;
+	struct plist_dup_args pda = {};
 	char xpath[XPATH_MAXLEN];
 	char xpath_entry[XPATH_MAXLEN + 128];
+
+	/*
+	 * Backward compatibility: don't complain about duplicated values,
+	 * just silently accept.
+	 */
+	if (seq_str == NULL) {
+		pda.pda_type = "ipv4";
+		pda.pda_name = name;
+		if (prefix_str) {
+			pda.pda_xpath[arg_idx] = "./ipv4-prefix";
+			pda.pda_value[arg_idx] = prefix_str;
+			arg_idx++;
+			if (ge_str) {
+				pda.pda_xpath[arg_idx] =
+					"./ipv4-prefix-length-greater-or-equal";
+				pda.pda_value[arg_idx] = ge_str;
+				arg_idx++;
+			}
+			if (le_str) {
+				pda.pda_xpath[arg_idx] =
+					"./ipv4-prefix-length-lesser-or-equal";
+				pda.pda_value[arg_idx] = le_str;
+				arg_idx++;
+			}
+		} else {
+			pda.pda_xpath[0] = "./any";
+			pda.pda_value[0] = "";
+		}
+
+		/* Duplicated entry without sequence, just quit. */
+		if (plist_is_dup(vty->candidate_config->dnode, &pda))
+			return CMD_SUCCESS;
+	}
 
 	/*
 	 * Create the prefix-list first, so we can generate sequence if
@@ -1479,8 +1514,43 @@ DEFPY_YANG(
 	"Minimum prefix length\n")
 {
 	int64_t sseq;
+	int arg_idx = 0;
+	struct plist_dup_args pda = {};
 	char xpath[XPATH_MAXLEN];
 	char xpath_entry[XPATH_MAXLEN + 128];
+
+	/*
+	 * Backward compatibility: don't complain about duplicated values,
+	 * just silently accept.
+	 */
+	if (seq_str == NULL) {
+		pda.pda_type = "ipv6";
+		pda.pda_name = name;
+		if (prefix_str) {
+			pda.pda_xpath[arg_idx] = "./ipv6-prefix";
+			pda.pda_value[arg_idx] = prefix_str;
+			arg_idx++;
+			if (ge_str) {
+				pda.pda_xpath[arg_idx] =
+					"./ipv6-prefix-length-greater-or-equal";
+				pda.pda_value[arg_idx] = ge_str;
+				arg_idx++;
+			}
+			if (le_str) {
+				pda.pda_xpath[arg_idx] =
+					"./ipv6-prefix-length-lesser-or-equal";
+				pda.pda_value[arg_idx] = le_str;
+				arg_idx++;
+			}
+		} else {
+			pda.pda_xpath[0] = "./any";
+			pda.pda_value[0] = "";
+		}
+
+		/* Duplicated entry without sequence, just quit. */
+		if (plist_is_dup(vty->candidate_config->dnode, &pda))
+			return CMD_SUCCESS;
+	}
 
 	/*
 	 * Create the prefix-list first, so we can generate sequence if

--- a/lib/filter_nb.c
+++ b/lib/filter_nb.c
@@ -133,6 +133,138 @@ static void cisco_unset_addr_mask(struct in_addr *addr, struct in_addr *mask)
 	mask->s_addr = CISCO_BIN_HOST_WILDCARD_MASK;
 }
 
+static int _acl_is_dup(const struct lyd_node *dnode, void *arg)
+{
+	struct acl_dup_args *ada = arg;
+	int idx;
+
+	/* This entry is the caller, so skip it. */
+	if (ada->ada_entry_dnode
+	    && ada->ada_entry_dnode == dnode)
+		return YANG_ITER_CONTINUE;
+
+	/* Check if all values match. */
+	for (idx = 0; idx < ADA_MAX_VALUES; idx++) {
+		/* No more values. */
+		if (ada->ada_xpath[idx] == NULL)
+			break;
+
+		/* Not same type, just skip it. */
+		if (!yang_dnode_exists(dnode, ada->ada_xpath[idx]))
+			return YANG_ITER_CONTINUE;
+
+		/* Check if different value. */
+		if (strcmp(yang_dnode_get_string(dnode, ada->ada_xpath[idx]),
+			   ada->ada_value[idx]))
+			return YANG_ITER_CONTINUE;
+	}
+
+	ada->ada_found = true;
+
+	return YANG_ITER_STOP;
+}
+
+bool acl_is_dup(const struct lyd_node *dnode, struct acl_dup_args *ada)
+{
+	ada->ada_found = false;
+
+	yang_dnode_iterate(
+		_acl_is_dup, ada, dnode,
+		"/frr-filter:lib/access-list[type='%s'][name='%s']/entry",
+		ada->ada_type, ada->ada_name);
+
+	return ada->ada_found;
+}
+
+static bool acl_cisco_is_dup(const struct lyd_node *dnode)
+{
+	const struct lyd_node *entry_dnode =
+		yang_dnode_get_parent(dnode, "entry");
+	struct acl_dup_args ada = {};
+	int idx = 0, arg_idx = 0;
+	static const char *cisco_entries[] = {
+		"./host",
+		"./network/address",
+		"./network/mask",
+		"./source-any",
+		"./destination-host",
+		"./destination-network/address",
+		"./destination-network/mask",
+		"./destination-any",
+		NULL
+	};
+
+	/* Initialize. */
+	ada.ada_type = "ipv4";
+	ada.ada_name = yang_dnode_get_string(entry_dnode, "../name");
+	ada.ada_entry_dnode = entry_dnode;
+
+	/* Load all values/XPaths. */
+	while (cisco_entries[idx] != NULL) {
+		if (!yang_dnode_exists(entry_dnode, cisco_entries[idx])) {
+			idx++;
+			continue;
+		}
+
+		ada.ada_xpath[arg_idx] = cisco_entries[idx];
+		ada.ada_value[arg_idx] =
+			yang_dnode_get_string(entry_dnode, cisco_entries[idx]);
+		arg_idx++;
+		idx++;
+	}
+
+	return acl_is_dup(entry_dnode, &ada);
+}
+
+static bool acl_zebra_is_dup(const struct lyd_node *dnode,
+			     enum yang_access_list_type type)
+{
+	const struct lyd_node *entry_dnode =
+		yang_dnode_get_parent(dnode, "entry");
+	struct acl_dup_args ada = {};
+	int idx = 0, arg_idx = 0;
+	static const char *zebra_entries[] = {
+		"./ipv4-prefix",
+		"./ipv4-exact-match",
+		"./ipv6-prefix",
+		"./ipv6-exact-match",
+		"./mac",
+		"./any",
+		NULL
+	};
+
+	/* Initialize. */
+	switch (type) {
+	case YALT_IPV4:
+		ada.ada_type = "ipv4";
+		break;
+	case YALT_IPV6:
+		ada.ada_type = "ipv6";
+		break;
+	case YALT_MAC:
+		ada.ada_type = "mac";
+		break;
+	}
+	ada.ada_name = yang_dnode_get_string(entry_dnode, "../name");
+	ada.ada_entry_dnode = entry_dnode;
+
+	/* Load all values/XPaths. */
+	while (zebra_entries[idx] != NULL) {
+		if (!yang_dnode_exists(entry_dnode, zebra_entries[idx])) {
+			idx++;
+			continue;
+		}
+
+		ada.ada_xpath[arg_idx] = zebra_entries[idx];
+		ada.ada_value[arg_idx] =
+			yang_dnode_get_string(entry_dnode, zebra_entries[idx]);
+		arg_idx++;
+		idx++;
+	}
+
+	return acl_is_dup(entry_dnode, &ada);
+}
+
 /*
  * XPath: /frr-filter:lib/access-list
  */
@@ -290,6 +422,19 @@ lib_access_list_entry_ipv4_prefix_modify(struct nb_cb_modify_args *args)
 	struct filter_zebra *fz;
 	struct filter *f;
 
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_zebra_is_dup(
+			    args->dnode,
+			    yang_dnode_get_enum(args->dnode, "../../type"))) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
@@ -330,6 +475,19 @@ lib_access_list_entry_ipv4_exact_match_modify(struct nb_cb_modify_args *args)
 	struct filter_zebra *fz;
 	struct filter *f;
 
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_zebra_is_dup(
+			    args->dnode,
+			    yang_dnode_get_enum(args->dnode, "../../type"))) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
@@ -368,6 +526,17 @@ lib_access_list_entry_host_modify(struct nb_cb_modify_args *args)
 {
 	struct filter_cisco *fc;
 	struct filter *f;
+
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_cisco_is_dup(args->dnode)) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -410,6 +579,17 @@ lib_access_list_entry_network_address_modify(struct nb_cb_modify_args *args)
 	struct filter_cisco *fc;
 	struct filter *f;
 
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_cisco_is_dup(args->dnode)) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
@@ -432,6 +612,17 @@ lib_access_list_entry_network_mask_modify(struct nb_cb_modify_args *args)
 	struct filter_cisco *fc;
 	struct filter *f;
 
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_cisco_is_dup(args->dnode)) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
@@ -453,6 +644,17 @@ lib_access_list_entry_source_any_create(struct nb_cb_create_args *args)
 {
 	struct filter_cisco *fc;
 	struct filter *f;
+
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_cisco_is_dup(args->dnode)) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -494,6 +696,17 @@ static int lib_access_list_entry_destination_host_modify(
 {
 	struct filter_cisco *fc;
 	struct filter *f;
+
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_cisco_is_dup(args->dnode)) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -537,6 +750,17 @@ static int lib_access_list_entry_destination_network_address_modify(
 	struct filter_cisco *fc;
 	struct filter *f;
 
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_cisco_is_dup(args->dnode)) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
@@ -559,6 +783,17 @@ static int lib_access_list_entry_destination_network_mask_modify(
 	struct filter_cisco *fc;
 	struct filter *f;
 
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_cisco_is_dup(args->dnode)) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
@@ -580,6 +815,17 @@ static int lib_access_list_entry_destination_any_create(
 {
 	struct filter_cisco *fc;
 	struct filter *f;
+
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_cisco_is_dup(args->dnode)) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -622,6 +868,19 @@ static int lib_access_list_entry_any_create(struct nb_cb_create_args *args)
 	struct filter_zebra *fz;
 	struct filter *f;
 	int type;
+
+	/* Don't allow duplicated values. */
+	if (args->event == NB_EV_VALIDATE) {
+		if (acl_zebra_is_dup(
+			    args->dnode,
+			    yang_dnode_get_enum(args->dnode, "../../type"))) {
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "duplicated access list value: %s",
+				   yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -468,7 +468,7 @@ void yang_dnode_iterate(yang_dnode_iter_cb cb, void *arg,
 		dnode = set->set.d[i];
 		ret = (*cb)(dnode, arg);
 		if (ret == YANG_ITER_STOP)
-			return;
+			break;
 	}
 
 	ly_set_free(set);


### PR DESCRIPTION
Summary
---

This is a work in progress to restore the previous behavior.

Fixes #7297


ToDo
---

- [x] deny access list duplicated values
- [x] silently ignore duplicated values without sequence
- [x] deny prefix list duplicated values
- [x] silently ignore duplucated values without sequence