### PR TITLE
bgpd: fix distance for aggregate route

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13702,7 +13702,7 @@ uint8_t bgp_distance_apply(const struct prefix *p, struct bgp_path_info *pinfo,
 			   afi_t afi, safi_t safi, struct bgp *bgp)
 {
 	struct bgp_dest *dest;
-	struct prefix q;
+	struct prefix q = {0};
 	struct peer *peer;
 	struct bgp_distance *bdistance;
 	struct access_list *alist;
@@ -13716,8 +13716,11 @@ uint8_t bgp_distance_apply(const struct prefix *p, struct bgp_path_info *pinfo,
 	if (pinfo->attr->distance)
 		return pinfo->attr->distance;
 
-	/* Check source address. */
-	if (!sockunion2hostprefix(&peer->su, &q))
+	/* Check source address.
+	 * Note: for aggregate route, peer can have unspec af type.
+	 */
+	if (pinfo->sub_type != BGP_ROUTE_AGGREGATE
+	    && !sockunion2hostprefix(&peer->su, &q))
 		return 0;
 
 	dest = bgp_node_match(bgp_distance_table[afi][safi], &q);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -526,10 +526,10 @@ static int zebra_read_route(ZAPI_CALLBACK_ARGS)
 			inet_ntop(api.prefix.family, &nexthop, buf,
 				  sizeof(buf));
 			zlog_debug(
-				"Rx route ADD VRF %u %s[%d] %pFX nexthop %s (type %d if %u) metric %u tag %" ROUTE_TAG_PRI,
+				"Rx route ADD VRF %u %s[%d] %pFX nexthop %s (type %d if %u) metric %u distance %u tag %" ROUTE_TAG_PRI,
 				vrf_id, zebra_route_string(api.type),
 				api.instance, &api.prefix, buf, nhtype, ifindex,
-				api.metric, api.tag);
+				api.metric, api.distance, api.tag);
 		} else {
 			zlog_debug("Rx route DEL VRF %u %s[%d] %pFX", vrf_id,
 				   zebra_route_string(api.type), api.instance,


### PR DESCRIPTION
bgp aggregate address routes are installed with incorrect distance value. 
the aggregate route is installed via self peer which can have peer->su of unspecified type.
bgp_distance_apply bails out as it fails to parse sockunion2hostprefix for af type unspec. 

config:
 address-family ipv4 unicast
  aggregate-address 50.1.0.0/16 summary-only

Testing Done:

Before  distance is 20:
B>* 50.1.0.0/16 [20/0] unreachable (blackhole), weight 1, 00:00:02

After: (displayed 200 ) 
B>* 50.1.0.0/16 [200/0] unreachable (blackhole), weight 1, 00:01:28

Signed-off-by: Chirag Shah <chirag@nvidia.com>