### PR TITLE
ldpd, isisd, ospfd: Adding zapi client close notification

### DIFF
--- a/isisd/isis_ldp_sync.h
+++ b/isisd/isis_ldp_sync.h
@@ -20,6 +20,8 @@
 #ifndef _ZEBRA_ISIS_LDP_SYNC_H
 #define _ZEBRA_ISIS_LDP_SYNC_H
 
+#include "zclient.h"
+
 /* Macro to log debug message */
 #define ils_debug(...)                                                         \
 	do {                                                                   \
@@ -36,11 +38,11 @@ extern void isis_ldp_sync_if_start(struct isis_circuit *circuit,
 extern void isis_ldp_sync_if_remove(struct isis_circuit *circuit, bool remove);
 extern void isis_ldp_sync_if_complete(struct isis_circuit *circuit);
 extern void isis_ldp_sync_holddown_timer_add(struct isis_circuit *circuit);
-extern void isis_ldp_sync_hello_timer_add(void);
+extern void isis_ldp_sync_handle_client_close(
+	struct zapi_client_close_info *info);
 extern void isis_ldp_sync_ldp_fail(struct isis_circuit *circuit);
 extern int isis_ldp_sync_state_update(struct ldp_igp_sync_if_state state);
 extern int isis_ldp_sync_announce_update(struct ldp_igp_sync_announce announce);
-extern int isis_ldp_sync_hello_update(struct ldp_igp_sync_hello hello);
 extern void isis_ldp_sync_state_req_msg(struct isis_circuit *circuit);
 extern void isis_ldp_sync_set_if_metric(struct isis_circuit *circuit,
 					bool run_regen);

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2305,7 +2305,6 @@ int isis_instance_mpls_ldp_sync_create(struct nb_cb_create_args *args)
 		/* register with opaque client to recv LDP-IGP Sync msgs */
 		zclient_register_opaque(zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
 		zclient_register_opaque(zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
-		zclient_register_opaque(zclient, LDP_IGP_SYNC_HELLO_UPDATE);
 
 		if (!CHECK_FLAG(isis->ldp_sync_cmd.flags,
 				LDP_SYNC_FLAG_ENABLE)) {

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -51,8 +51,6 @@ static void 	ldp_zebra_opaque_register(void);
 static void 	ldp_zebra_opaque_unregister(void);
 static int 	ldp_sync_zebra_send_announce(void);
 static int 	ldp_zebra_opaque_msg_handler(ZAPI_CALLBACK_ARGS);
-static void 	ldp_sync_zebra_start_hello_timer(void);
-static int 	ldp_sync_zebra_hello(struct thread *thread);
 static void 	ldp_sync_zebra_init(void);
 
 static struct zclient	*zclient;
@@ -176,38 +174,10 @@ stream_failure:
 }
 
 static void
-ldp_sync_zebra_start_hello_timer(void)
-{
-	thread_add_timer_msec(master, ldp_sync_zebra_hello, NULL, 250, NULL);
-}
-
-static int
-ldp_sync_zebra_hello(struct thread *thread)
-{
-	static unsigned int sequence = 0;
-	struct ldp_igp_sync_hello hello;
-
-	sequence++;
-
-	hello.proto = ZEBRA_ROUTE_LDP;
-	hello.sequence = sequence;
-
-	zclient_send_opaque(zclient, LDP_IGP_SYNC_HELLO_UPDATE,
-		(const uint8_t *) &hello, sizeof(hello));
-
-	ldp_sync_zebra_start_hello_timer();
-
-	return (0);
-}
-
-static void
 ldp_sync_zebra_init(void)
 {
 	ldp_sync_zebra_send_announce();
-
-	ldp_sync_zebra_start_hello_timer();
 }
-
 
 static int
 ldp_zebra_send_mpls_labels(int cmd, struct kroute *kr)

--- a/lib/ldp_sync.h
+++ b/lib/ldp_sync.h
@@ -39,14 +39,10 @@ extern "C" {
 
 #define LDP_IGP_SYNC_HOLDDOWN_DEFAULT 0
 
-#define LDP_IGP_SYNC_HELLO_TIMEOUT 5
-
 /* LDP-IGP Sync structures */
 struct ldp_sync_info_cmd {
 	uint16_t flags;
 	uint16_t holddown;       /* timer value */
-	uint32_t sequence;       /* hello sequence number */
-	struct thread *t_hello;  /* hello timer for detecting LDP going down */
 };
 
 struct ldp_sync_info {
@@ -77,11 +73,6 @@ struct ldp_igp_sync_if_state_req {
 	int proto;
 	ifindex_t ifindex;
 	char name[INTERFACE_NAMSIZ];
-};
-
-struct ldp_igp_sync_hello {
-	int proto;
-	unsigned int sequence;
 };
 
 #ifdef __cplusplus

--- a/lib/log.c
+++ b/lib/log.c
@@ -456,7 +456,8 @@ static const struct zebra_desc_table command_types[] = {
 	DESC_ENTRY(ZEBRA_NHG_ADD),
 	DESC_ENTRY(ZEBRA_NHG_DEL),
 	DESC_ENTRY(ZEBRA_NHG_NOTIFY_OWNER),
-	DESC_ENTRY(ZEBRA_ROUTE_NOTIFY_REQUEST)};
+	DESC_ENTRY(ZEBRA_ROUTE_NOTIFY_REQUEST),
+	DESC_ENTRY(ZEBRA_CLIENT_CLOSE_NOTIFY)};
 #undef DESC_ENTRY
 
 static const struct zebra_desc_table unknown = {0, "unknown", '?'};

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3528,6 +3528,23 @@ stream_failure:
 	return -1;
 }
 
+/* Utility to decode client close notify info */
+int zapi_client_close_notify_decode(struct stream *s,
+                   struct zapi_client_close_info *info)
+{
+	memset(info, 0, sizeof(*info));
+
+	STREAM_GETC(s, info->proto);
+	STREAM_GETW(s, info->instance);
+	STREAM_GETL(s, info->session_id);
+
+	return 0;
+
+stream_failure:
+
+	return -1;
+}
+
 /* Zebra client message read function. */
 static int zclient_read(struct thread *thread)
 {
@@ -3868,6 +3885,12 @@ static int zclient_read(struct thread *thread)
 		if (zclient->sr_policy_notify_status)
 			(*zclient->sr_policy_notify_status)(command, zclient,
 							    length, vrf_id);
+		break;
+	case ZEBRA_CLIENT_CLOSE_NOTIFY:
+		if (zclient->zebra_client_close_notify)
+			(*zclient->zebra_client_close_notify)(command,
+						zclient, length, vrf_id);
+		break;
 	default:
 		break;
 	}

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -220,6 +220,7 @@ typedef enum {
 	ZEBRA_OPAQUE_UNREGISTER,
 	ZEBRA_NEIGH_DISCOVER,
 	ZEBRA_ROUTE_NOTIFY_REQUEST,
+	ZEBRA_CLIENT_CLOSE_NOTIFY,
 } zebra_message_types_t;
 
 enum zebra_error_types {
@@ -377,6 +378,7 @@ struct zclient {
 	int (*opaque_register_handler)(ZAPI_CALLBACK_ARGS);
 	int (*opaque_unregister_handler)(ZAPI_CALLBACK_ARGS);
 	int (*sr_policy_notify_status)(ZAPI_CALLBACK_ARGS);
+	int (*zebra_client_close_notify)(ZAPI_CALLBACK_ARGS);
 };
 
 /* Zebra API message flag. */
@@ -1083,8 +1085,6 @@ enum zapi_opaque_registry {
 	LDP_IGP_SYNC_IF_STATE_UPDATE = 4,
 	/* Announce that LDP is up  */
 	LDP_IGP_SYNC_ANNOUNCE_UPDATE = 5,
-	/* Heartbeat indicating that LDP is running */
-	LDP_IGP_SYNC_HELLO_UPDATE = 6,
 };
 
 /* Send the hello message.
@@ -1096,6 +1096,17 @@ extern enum zclient_send_status
 zclient_send_neigh_discovery_req(struct zclient *zclient,
 				 const struct interface *ifp,
 				 const struct prefix *p);
+
+struct zapi_client_close_info {
+	/* Client session tuple */
+	uint8_t proto;
+	uint16_t instance;
+	uint32_t session_id;
+};
+
+/* Decode incoming client close notify */
+extern int zapi_client_close_notify_decode(struct stream *s,
+	struct zapi_client_close_info *info);
 
 #ifdef __cplusplus
 }

--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -93,56 +93,10 @@ int ospf_ldp_sync_announce_update(struct ldp_igp_sync_announce announce)
 	/* LDP just started up:
 	 *  set cost to LSInfinity
 	 *  send request to LDP for LDP-SYNC state for each interface
-	 *  start hello timer
 	 */
 	vrf = vrf_lookup_by_id(ospf->vrf_id);
 	FOR_ALL_INTERFACES (vrf, ifp)
 		ospf_ldp_sync_if_start(ifp, true);
-
-	THREAD_OFF(ospf->ldp_sync_cmd.t_hello);
-	ospf->ldp_sync_cmd.sequence = 0;
-	ospf_ldp_sync_hello_timer_add(ospf);
-
-	return 0;
-}
-
-int ospf_ldp_sync_hello_update(struct ldp_igp_sync_hello hello)
-{
-	struct ospf *ospf;
-	struct vrf *vrf;
-	struct interface *ifp;
-
-	/* if ospf is not enabled or LDP-SYNC is not configured ignore */
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
-	if (ospf == NULL ||
-	    !CHECK_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE))
-		return 0;
-
-	if (hello.proto != ZEBRA_ROUTE_LDP)
-		return 0;
-
-	/* Received Hello from LDP:
-	 *  if current sequence number is greater than received hello
-	 *  sequence number then assume LDP restarted
-	 *  set cost to LSInfinity
-	 *  send request to LDP for LDP-SYNC state for each interface
-	 *  else all is fine just restart hello timer
-	 */
-	if (hello.sequence == 0)
-		/* rolled over */
-		ospf->ldp_sync_cmd.sequence = 0;
-
-	if (ospf->ldp_sync_cmd.sequence > hello.sequence) {
-		zlog_err("ldp_sync: LDP restarted");
-
-		vrf = vrf_lookup_by_id(ospf->vrf_id);
-		FOR_ALL_INTERFACES (vrf, ifp)
-			ospf_ldp_sync_if_start(ifp, true);
-	} else {
-		THREAD_OFF(ospf->ldp_sync_cmd.t_hello);
-		ospf_ldp_sync_hello_timer_add(ospf);
-	}
-	ospf->ldp_sync_cmd.sequence = hello.sequence;
 
 	return 0;
 }
@@ -253,6 +207,34 @@ void ospf_ldp_sync_if_complete(struct interface *ifp)
 	}
 }
 
+void ospf_ldp_sync_handle_client_close(
+	struct zapi_client_close_info *info)
+{
+	struct ospf *ospf;
+	struct vrf *vrf;
+	struct interface *ifp;
+
+	/* if ospf is not enabled or LDP-SYNC is not configured ignore */
+	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	if (ospf == NULL ||
+	    !CHECK_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE))
+		return;
+
+	/* Check if the LDP main client session closed */
+	if (info->proto != ZEBRA_ROUTE_LDP || info->session_id == 0)
+		return;
+
+	/* Handle the zebra notification that the LDP client session closed.
+	 *  set cost to LSInfinity
+	 *  send request to LDP for LDP-SYNC state for each interface
+	 */
+	zlog_err("ldp_sync: LDP down");
+
+	vrf = vrf_lookup_by_id(ospf->vrf_id);
+	FOR_ALL_INTERFACES (vrf, ifp)
+		ospf_ldp_sync_if_start(ifp, true);
+}
+
 void ospf_ldp_sync_ldp_fail(struct interface *ifp)
 {
 	struct ospf_if_params *params;
@@ -264,7 +246,7 @@ void ospf_ldp_sync_ldp_fail(struct interface *ifp)
 	params = IF_DEF_PARAMS(ifp);
 	ldp_sync_info = params->ldp_sync_info;
 
-	/* LDP failed to send hello:
+	/* LDP client close detected:
 	 *  stop holddown timer
 	 *  set cost of interface to LSInfinity so traffic will use different
 	 *  interface until LDP has learned all labels from peer
@@ -421,46 +403,6 @@ void ospf_ldp_sync_holddown_timer_add(struct interface *ifp)
 }
 
 /*
- * LDP-SYNC hello timer routines
- */
-static int ospf_ldp_sync_hello_timer(struct thread *thread)
-{
-	struct ospf *ospf;
-	struct vrf *vrf;
-	struct interface *ifp;
-
-	/* hello timer expired:
-	 *  didn't receive hello msg from LDP
-	 *  set cost of all interfaces to LSInfinity
-	 */
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
-	if (ospf) {
-		vrf = vrf_lookup_by_id(ospf->vrf_id);
-
-		FOR_ALL_INTERFACES (vrf, ifp)
-			ospf_ldp_sync_ldp_fail(ifp);
-
-		zlog_err("ldp_sync: hello timer expired, LDP down");
-	}
-	return 0;
-}
-
-void ospf_ldp_sync_hello_timer_add(struct ospf *ospf)
-{
-
-	/* Start hello timer:
-	 *  this timer is used to make sure LDP is up
-	 *  if expires set interface cost to LSInfinity
-	 */
-	if (!CHECK_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE))
-		return;
-
-	thread_add_timer(master, ospf_ldp_sync_hello_timer,
-			 NULL, LDP_IGP_SYNC_HELLO_TIMEOUT,
-			 &ospf->ldp_sync_cmd.t_hello);
-}
-
-/*
  * LDP-SYNC exit routes.
  */
 void ospf_ldp_sync_gbl_exit(struct ospf *ospf, bool remove)
@@ -469,7 +411,6 @@ void ospf_ldp_sync_gbl_exit(struct ospf *ospf, bool remove)
 	struct vrf *vrf;
 
 	/* ospf is being removed
-	 *  stop hello timer
 	 *  stop any holddown timers
 	 */
 	if (CHECK_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE)) {
@@ -478,14 +419,11 @@ void ospf_ldp_sync_gbl_exit(struct ospf *ospf, bool remove)
 					  LDP_IGP_SYNC_IF_STATE_UPDATE);
 		zclient_unregister_opaque(zclient,
 					  LDP_IGP_SYNC_ANNOUNCE_UPDATE);
-		zclient_unregister_opaque(zclient, LDP_IGP_SYNC_HELLO_UPDATE);
 
 		/* disable LDP globally */
 		UNSET_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE);
 		UNSET_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_HOLDDOWN);
 		ospf->ldp_sync_cmd.holddown = LDP_IGP_SYNC_HOLDDOWN_DEFAULT;
-
-		THREAD_OFF(ospf->ldp_sync_cmd.t_hello);
 
 		/* turn off LDP-IGP Sync on all OSPF interfaces */
 		vrf = vrf_lookup_by_id(ospf->vrf_id);
@@ -829,7 +767,6 @@ DEFPY (ospf_mpls_ldp_sync,
 	/* register with opaque client to recv LDP-IGP Sync msgs */
 	zclient_register_opaque(zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
 	zclient_register_opaque(zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
-	zclient_register_opaque(zclient, LDP_IGP_SYNC_HELLO_UPDATE);
 
 	if (!CHECK_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE)) {
 		SET_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE);

--- a/ospfd/ospf_ldp_sync.h
+++ b/ospfd/ospf_ldp_sync.h
@@ -40,7 +40,6 @@ extern void ospf_ldp_sync_if_remove(struct interface *ifp, bool remove);
 extern void ospf_ldp_sync_if_down(struct interface *ifp);
 extern void ospf_ldp_sync_if_complete(struct interface *ifp);
 extern void ospf_ldp_sync_holddown_timer_add(struct interface *ifp);
-extern void ospf_ldp_sync_hello_timer_add(struct ospf *ospf);
 extern void ospf_ldp_sync_ldp_fail(struct interface *ifp);
 extern void ospf_ldp_sync_show_info(struct vty *vty, struct ospf *ospf,
 				    json_object *json_vrf, bool use_json);
@@ -49,7 +48,8 @@ extern void ospf_ldp_sync_if_write_config(struct vty *vty,
 					  struct ospf_if_params *params);
 extern int ospf_ldp_sync_state_update(struct ldp_igp_sync_if_state state);
 extern int ospf_ldp_sync_announce_update(struct ldp_igp_sync_announce announce);
-extern int ospf_ldp_sync_hello_update(struct ldp_igp_sync_hello hello);
+extern void ospf_ldp_sync_handle_client_close(
+	struct zapi_client_close_info *info);
 extern void ospf_ldp_sync_state_req_msg(struct interface *ifp);
 extern void ospf_ldp_sync_init(void);
 extern void ospf_ldp_sync_gbl_exit(struct ospf *ospf, bool remove);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1956,7 +1956,6 @@ static int ospf_opaque_msg_handler(ZAPI_CALLBACK_ARGS)
 	struct zapi_opaque_msg info;
 	struct ldp_igp_sync_if_state state;
 	struct ldp_igp_sync_announce announce;
-	struct ldp_igp_sync_hello hello;
 	int ret = 0;
 
 	s = zclient->ibuf;
@@ -1973,10 +1972,6 @@ static int ospf_opaque_msg_handler(ZAPI_CALLBACK_ARGS)
 		STREAM_GET(&announce, s, sizeof(announce));
 		ret = ospf_ldp_sync_announce_update(announce);
 		break;
-	case LDP_IGP_SYNC_HELLO_UPDATE:
-		STREAM_GET(&hello, s, sizeof(hello));
-		ret = ospf_ldp_sync_hello_update(hello);
-		break;
 	default:
 		break;
 	}
@@ -1985,6 +1980,21 @@ stream_failure:
 
 	return ret;
 }
+
+static int ospf_zebra_client_close_notify(ZAPI_CALLBACK_ARGS)
+{
+	int ret = 0;
+
+	struct zapi_client_close_info info;
+
+	if (zapi_client_close_notify_decode(zclient->ibuf, &info) < 0)
+		return -1;
+
+	ospf_ldp_sync_handle_client_close(&info);
+
+	return ret;
+}
+
 
 void ospf_zebra_init(struct thread_master *master, unsigned short instance)
 {
@@ -2021,6 +2031,8 @@ void ospf_zebra_init(struct thread_master *master, unsigned short instance)
 	prefix_list_delete_hook(ospf_prefix_list_update);
 
 	zclient->opaque_msg_handler = ospf_opaque_msg_handler;
+
+	zclient->zebra_client_close_notify = ospf_zebra_client_close_notify;
 }
 
 void ospf_zebra_send_arp(const struct interface *ifp, const struct prefix *p)

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -153,7 +153,8 @@ static void usage(int status)
 			progname);
 	else
 		printf("Usage : %s [OPTION...]\n\n"
-		       "Integrated shell for FRR (version " FRR_VERSION "). \n\n"
+		       "Integrated shell for FRR (version " FRR_VERSION "). \n"
+		       "Configured with:\n    " FRR_CONFIG_ARGS "\n\n"
 		       "-b, --boot               Execute boot startup configuration\n"
 		       "-c, --command            Execute argument as command\n"
 		       "-d, --daemon             Connect only to the specified daemon\n"

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -153,7 +153,7 @@ static void usage(int status)
 			progname);
 	else
 		printf("Usage : %s [OPTION...]\n\n"
-		       "Integrated shell for FRR. \n\n"
+		       "Integrated shell for FRR (version " FRR_VERSION "). \n\n"
 		       "-b, --boot               Execute boot startup configuration\n"
 		       "-c, --command            Execute argument as command\n"
 		       "-d, --daemon             Connect only to the specified daemon\n"

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2522,6 +2522,23 @@ int zsend_sr_policy_notify_status(uint32_t color, struct ipaddr *endpoint,
 	return zserv_send_message(client, s);
 }
 
+/* Send client close notify to client */
+int zsend_client_close_notify(struct zserv *client,
+			      struct zserv *closed_client)
+{
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+
+	zclient_create_header(s, ZEBRA_CLIENT_CLOSE_NOTIFY, VRF_DEFAULT);
+
+	stream_putc(s, closed_client->proto);
+	stream_putw(s, closed_client->instance);
+	stream_putl(s, closed_client->session_id);
+
+	stream_putw_at(s, 0, stream_get_endp(s));
+
+	return zserv_send_message(client, s);
+}
+
 /* Send response to a table manager connect request to client */
 static void zread_table_manager_connect(struct zserv *client,
 					struct stream *msg, vrf_id_t vrf_id)

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -105,6 +105,9 @@ extern int zsend_sr_policy_notify_status(uint32_t color,
 					 struct ipaddr *endpoint, char *name,
 					 int status);
 
+extern int zsend_client_close_notify(
+	struct zserv *client, struct zserv *closed_client);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1300,6 +1300,21 @@ DEFUN (show_zebra_client_summary,
 	return CMD_SUCCESS;
 }
 
+static int zserv_client_close_cb(struct zserv *closed_client)
+{
+	struct listnode *node, *nnode;
+	struct zserv *client = NULL;
+
+	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
+		if (client->proto == closed_client->proto)
+			continue;
+
+		zsend_client_close_notify(client, closed_client);
+	}
+
+	return 0;
+}
+
 void zserv_init(void)
 {
 	/* Client list init. */
@@ -1312,4 +1327,6 @@ void zserv_init(void)
 
 	install_element(ENABLE_NODE, &show_zebra_client_cmd);
 	install_element(ENABLE_NODE, &show_zebra_client_summary_cmd);
+
+	hook_register(zserv_client_close, zserv_client_close_cb);
 }


### PR DESCRIPTION
ldpd, isisd, ospfd: Adding zapi client close notification

When ldp-sync is configured, IGPs take action if the LDP process goes down.

Currently, IGPs detect the LDP process is down if they do not receive a
periodic 'hello' message from LDP within 1 second.

Intermittently, this heartbeat mechanism causes false topotest failures.
When the failure occurs, LDP is busy receiving messages from zebra for a
few seconds.  During this time, LDP does not send the expected periodic
message.

Adding a new zapi client close notification.
When IGPs are notified of a zapi client close, they can take action if
the LDP client has closed.

Also, removing the ldp-sync periodic 'hello' message.

Signed-off-by: Karen Schoener <karen@voltanet.io>