### PR TITLE
isisd, ospfd: IGPs detect LDP down via zapi client close message

### DIFF
--- a/isisd/isis_ldp_sync.h
+++ b/isisd/isis_ldp_sync.h
@@ -20,6 +20,8 @@
 #ifndef _ZEBRA_ISIS_LDP_SYNC_H
 #define _ZEBRA_ISIS_LDP_SYNC_H
 
+#include "zclient.h"
+
 /* Macro to log debug message */
 #define ils_debug(...)                                                         \
 	do {                                                                   \
@@ -36,6 +38,8 @@ extern void isis_ldp_sync_if_start(struct isis_circuit *circuit,
 extern void isis_ldp_sync_if_remove(struct isis_circuit *circuit, bool remove);
 extern void isis_ldp_sync_if_complete(struct isis_circuit *circuit);
 extern void isis_ldp_sync_holddown_timer_add(struct isis_circuit *circuit);
+extern void
+isis_ldp_sync_handle_client_close(struct zapi_client_close_info *info);
 extern void isis_ldp_sync_hello_timer_add(void);
 extern void isis_ldp_sync_ldp_fail(struct isis_circuit *circuit);
 extern int isis_ldp_sync_state_update(struct ldp_igp_sync_if_state state);

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -699,6 +699,20 @@ stream_failure:
 	return ret;
 }
 
+static int isis_zebra_client_close_notify(ZAPI_CALLBACK_ARGS)
+{
+	int ret = 0;
+
+	struct zapi_client_close_info info;
+
+	if (zapi_client_close_notify_decode(zclient->ibuf, &info) < 0)
+		return -1;
+
+	isis_ldp_sync_handle_client_close(&info);
+
+	return ret;
+}
+
 void isis_zebra_init(struct thread_master *master, int instance)
 {
 	/* Initialize asynchronous zclient. */
@@ -727,6 +741,8 @@ void isis_zebra_init(struct thread_master *master, int instance)
 	zclient_sync->privs = &isisd_privs;
 
 	zclient->opaque_msg_handler = isis_opaque_msg_handler;
+
+	zclient->zebra_client_close_notify = isis_zebra_client_close_notify;
 }
 
 void isis_zebra_stop(void)

--- a/ospfd/ospf_ldp_sync.h
+++ b/ospfd/ospf_ldp_sync.h
@@ -50,6 +50,8 @@ extern void ospf_ldp_sync_if_write_config(struct vty *vty,
 extern int ospf_ldp_sync_state_update(struct ldp_igp_sync_if_state state);
 extern int ospf_ldp_sync_announce_update(struct ldp_igp_sync_announce announce);
 extern int ospf_ldp_sync_hello_update(struct ldp_igp_sync_hello hello);
+extern void
+ospf_ldp_sync_handle_client_close(struct zapi_client_close_info *info);
 extern void ospf_ldp_sync_state_req_msg(struct interface *ifp);
 extern void ospf_ldp_sync_init(void);
 extern void ospf_ldp_sync_gbl_exit(struct ospf *ospf, bool remove);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1986,6 +1986,20 @@ stream_failure:
 	return ret;
 }
 
+static int ospf_zebra_client_close_notify(ZAPI_CALLBACK_ARGS)
+{
+	int ret = 0;
+
+	struct zapi_client_close_info info;
+
+	if (zapi_client_close_notify_decode(zclient->ibuf, &info) < 0)
+		return -1;
+
+	ospf_ldp_sync_handle_client_close(&info);
+
+	return ret;
+}
+
 void ospf_zebra_init(struct thread_master *master, unsigned short instance)
 {
 	/* Allocate zebra structure. */
@@ -2021,6 +2035,8 @@ void ospf_zebra_init(struct thread_master *master, unsigned short instance)
 	prefix_list_delete_hook(ospf_prefix_list_update);
 
 	zclient->opaque_msg_handler = ospf_opaque_msg_handler;
+
+	zclient->zebra_client_close_notify = ospf_zebra_client_close_notify;
 }
 
 void ospf_zebra_send_arp(const struct interface *ifp, const struct prefix *p)


### PR DESCRIPTION
When ldp-sync is configured, IGPs take action if the LDP process goes down.

Currently, IGPs detect the LDP process is down if they do not receive a
periodic 'hello' message from LDP within 1 second.

Intermittently, this heartbeat mechanism causes false topotest failures.
When the failure occurs, LDP is busy receiving messages from zebra for a
few seconds.  During this time, LDP does not send the expected periodic
message.

With this change, IGPs detect LDP down via zapi client close message.

Signed-off-by: Karen Schoener <karen@voltanet.io>