### PR TITLE
zebra, tests: Fix `show ip nht`

### DIFF
--- a/tests/topotests/all-protocol-startup/r1/ip_nht.ref
+++ b/tests/topotests/all-protocol-startup/r1/ip_nht.ref
@@ -1,0 +1,60 @@
+1.1.1.1
+ resolved via static
+ is directly connected, r1-eth1
+ Client list: pbr(fd XX)
+1.1.1.2
+ resolved via static
+ is directly connected, r1-eth2
+ Client list: pbr(fd XX)
+1.1.1.3
+ resolved via static
+ is directly connected, r1-eth3
+ Client list: pbr(fd XX)
+1.1.1.4
+ resolved via static
+ is directly connected, r1-eth4
+ Client list: pbr(fd XX)
+1.1.1.5
+ resolved via static
+ is directly connected, r1-eth5
+ Client list: pbr(fd XX)
+1.1.1.6
+ resolved via static
+ is directly connected, r1-eth6
+ Client list: pbr(fd XX)
+1.1.1.7
+ resolved via static
+ is directly connected, r1-eth7
+ Client list: pbr(fd XX)
+1.1.1.8
+ resolved via static
+ is directly connected, r1-eth8
+ Client list: pbr(fd XX)
+2.2.2.1
+ unresolved
+ Client list: pbr(fd XX)
+4.4.4.1
+ unresolved
+ Client list: pbr(fd XX)
+4.4.4.2
+ unresolved
+ Client list: pbr(fd XX)
+192.168.0.2
+ resolved via connected
+ is directly connected, r1-eth0
+ Client list: static(fd XX)
+192.168.0.4
+ resolved via connected
+ is directly connected, r1-eth0
+ Client list: static(fd XX)
+192.168.7.10
+ resolved via connected
+ is directly connected, r1-eth7
+ Client list: bgp(fd XX)
+192.168.7.20(Connected)
+ resolved via connected
+ is directly connected, r1-eth7
+ Client list: bgp(fd XX)
+192.168.161.4
+ unresolved
+ Client list: pbr(fd XX)

--- a/tests/topotests/all-protocol-startup/r1/ipv6_nht.ref
+++ b/tests/topotests/all-protocol-startup/r1/ipv6_nht.ref
@@ -1,0 +1,13 @@
+fc00::2
+ resolved via connected
+ is directly connected, r1-eth0
+ Client list: static(fd XX)
+fc00:0:0:8::1000
+ resolved via connected
+ is directly connected, r1-eth8
+ Client list: bgp(fd XX)
+fc00:0:0:8::2000(Connected)
+ resolved via connected
+ is directly connected, r1-eth8
+ Client list: bgp(fd XX)
+ 

--- a/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
+++ b/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
@@ -1016,6 +1016,45 @@ def test_bgp_ipv6_summary():
     # For debugging after starting FRR daemons, uncomment the next line
     # CLI(net)
 
+def test_nht():
+    print("\n\n**** Test that nexthop tracking is at least nominally working ****\n")
+
+    thisDir = os.path.dirname(os.path.realpath(__file__))
+
+    for i in range(1, 2):
+        nhtFile = "%s/r%s/ip_nht.ref" % (thisDir, i)
+        expected = open(nhtFile).read().rstrip()
+        expected = ("\n".join(expected.splitlines()) + "\n").splitlines(1)
+
+        actual = (net["r%s" %i].cmd('vtysh -c "show ip nht" 2> /dev/null').rstrip())
+        actual = re.sub(r"fd [0-9][0-9]", "fd XX", actual)
+        actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
+
+        diff = topotest.get_textdiff(actual, expected,
+                                     title1="Actual `show ip nht`",
+                                     title2="Expected `show ip nht`")
+
+        if diff:
+            assert 0, "r%s failed ip nht check:\n%s\n" % (i, diff)
+        else:
+            print("show ip nht is ok\n")
+
+        nhtFile = "%s/r%s/ipv6_nht.ref" % (thisDir, i)
+        expected = open(nhtFile).read().rstrip()
+        expected = ("\n".join(expected.splitlines()) + "\n").splitlines(1)
+
+        actual = (net["r%s" %i].cmd('vtysh -c "show ipv6 nht" 2> /dev/null').rstrip())
+        actual = re.sub(r"fd [0-9][0-9]", "fd XX", actual)
+        actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
+
+        diff = topotest.get_textdiff(actual, expected,
+                                     title1="Actual `show ip nht`",
+                                     title2="Expected `show ip nht`")
+
+        if diff:
+            assert 0, "r%s failed ipv6 nht check:\n%s\n" % (i, diff)
+        else:
+            print("show ipv6 nht is ok\n")
 
 def test_bgp_ipv4():
     global fatal_error

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1274,11 +1274,11 @@ DEFPY (show_ip_nht,
 		VRF_GET_ID(vrf_id, vrf_name, false);
 
 	memset(&prefix, 0, sizeof(prefix));
-	if (addr)
+	if (addr) {
 		p = sockunion2hostprefix(addr, &prefix);
-
-	if (!p)
-		return CMD_WARNING;
+		if (!p)
+			return CMD_WARNING;
+	}
 
 	zebra_print_rnh_table(vrf_id, afi, vty, rtype, p);
 	return CMD_SUCCESS;


### PR DESCRIPTION
The `show ip nht` and `show ipv6 nht` commands were broken.
This is because recent code commit: 0154d8ce45a5099d2d0b9dd3de4e

assumed that p must not be NULL and this is not the case.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>