### PR TITLE
zebra: Fix vrf/bridge race condition on startup

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -559,7 +559,7 @@ static void netlink_interface_update_l2info(struct interface *ifp,
 		struct zebra_l2info_bridge bridge_info;
 
 		netlink_extract_bridge_info(link_data, &bridge_info);
-		zebra_l2_bridge_add_update(ifp, &bridge_info, add);
+		zebra_l2_bridge_add_update(ifp, &bridge_info, add, link_nsid);
 	} else if (IS_ZEBRA_IF_VLAN(ifp)) {
 		struct zebra_l2info_vlan vlan_info;
 
@@ -1637,7 +1637,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			zebra_l2if_update_bond(ifp, false);
 		/* Special handling for bridge or VxLAN interfaces. */
 		if (IS_ZEBRA_IF_BRIDGE(ifp))
-			zebra_l2_bridge_del(ifp);
+			zebra_l2_bridge_del(ifp, link_nsid);
 		else if (IS_ZEBRA_IF_VXLAN(ifp))
 			zebra_l2_vxlanif_del(ifp);
 

--- a/zebra/zebra_l2.h
+++ b/zebra/zebra_l2.h
@@ -92,8 +92,8 @@ extern void
 zebra_l2_unmap_slave_from_bridge(struct zebra_l2info_brslave *br_slave);
 extern void zebra_l2_bridge_add_update(struct interface *ifp,
 				       struct zebra_l2info_bridge *bridge_info,
-				       int add);
-extern void zebra_l2_bridge_del(struct interface *ifp);
+				       int add, ns_id_t ns_id);
+extern void zebra_l2_bridge_del(struct interface *ifp, ns_id_t ns_id);
 extern void zebra_l2_vlanif_update(struct interface *ifp,
 				   struct zebra_l2info_vlan *vlan_info);
 extern void zebra_l2_vxlanif_add_update(struct interface *ifp,


### PR DESCRIPTION
On startup, if the enslaved bridge is handled before the master VRF, the
zns object of the vrf is nil, making zebra crash.
Pass the namespace ID from parent caller, so we don't need to rely on
this struct.

Signed-off-by: Lucas BEE <pouulet@gmail.com>