### PR TITLE
zebra: anticipate zns creation at vrf creation when backend is vrf-lite

### DIFF
--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -107,6 +107,8 @@ static int zebra_vrf_new(struct vrf *vrf)
 	zvrf = zebra_vrf_alloc();
 	vrf->info = zvrf;
 	zvrf->vrf = vrf;
+	if (!vrf_is_backend_netns())
+		zvrf->zns = zebra_ns_lookup(NS_DEFAULT);
 
 	otable_init(&zvrf->other_tables);
 


### PR DESCRIPTION
in the case the namespace pointer is already available, feed it at vrf
creation. this prevents from crashing if the netlink parsing already
began, and the vrf-lite is not enabled yet.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>