### PR TITLE
ldpd: fix printfrr format specifiers in the child processes

### DIFF
--- a/ldpd/log.c
+++ b/ldpd/log.c
@@ -22,6 +22,7 @@
 #include "ldpe.h"
 #include "lde.h"
 #include "log.h"
+#include "printfrr.h"
 
 #include <lib/log.h>
 
@@ -44,12 +45,12 @@ vlog(int pri, const char *fmt, va_list ap)
 
 	switch (ldpd_process) {
 	case PROC_LDE_ENGINE:
-		vsnprintf(buf, sizeof(buf), fmt, ap);
+		vsnprintfrr(buf, sizeof(buf), fmt, ap);
 		lde_imsg_compose_parent_sync(IMSG_LOG, pri, buf,
 		    strlen(buf) + 1);
 		break;
 	case PROC_LDP_ENGINE:
-		vsnprintf(buf, sizeof(buf), fmt, ap);
+		vsnprintfrr(buf, sizeof(buf), fmt, ap);
 		ldpe_imsg_compose_parent_sync(IMSG_LOG, pri, buf,
 		    strlen(buf) + 1);
 		break;


### PR DESCRIPTION
In ldpd, the child processes send IPC messages to the main process to
perform logging in their behalf (access to the file descriptor used
for logging needs to be serialized). This commit fixes a problem
that was preventing the printfrr format specifiers from working in
the child processes, since vsnprintf() was being used instead of
vsnprintfrr() before sending the log messages to the parent process.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>