### PR TITLE
isisd: fix null pointer dereference when parsing LSP

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -4850,7 +4850,7 @@ void isis_tlvs_add_spine_leaf(struct isis_tlvs *tlvs, uint8_t tier,
 struct isis_mt_router_info *
 isis_tlvs_lookup_mt_router_info(struct isis_tlvs *tlvs, uint16_t mtid)
 {
-	if (tlvs->mt_router_info_empty)
+	if (!tlvs || tlvs->mt_router_info_empty)
 		return NULL;
 
 	struct isis_mt_router_info *rv;


### PR DESCRIPTION
In some extraordinary circumstances an LSP might not have any
TLV. Add a null check to prevent a crash when that happens.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>