### PR TITLE
ospfd: clean up SA (7.5 version)

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -610,7 +610,7 @@ void ospf_finish(struct ospf *ospf)
 /* Final cleanup of ospf instance */
 static void ospf_finish_final(struct ospf *ospf)
 {
-	struct vrf *vrf = vrf_lookup_by_id(ospf->vrf_id);
+	struct vrf *vrf;
 	struct route_node *rn;
 	struct ospf_nbr_nbma *nbr_nbma;
 	struct ospf_lsa *lsa;


### PR DESCRIPTION
Clean up a dead initialization in ospf_finish_final() that's triggering an SA warning.
