### PR TITLE
ldpd, isisd, ospfd: Remove periodic ldp-sync hello message

### DIFF
--- a/isisd/isis_ldp_sync.h
+++ b/isisd/isis_ldp_sync.h
@@ -40,11 +40,9 @@ extern void isis_ldp_sync_if_complete(struct isis_circuit *circuit);
 extern void isis_ldp_sync_holddown_timer_add(struct isis_circuit *circuit);
 extern void
 isis_ldp_sync_handle_client_close(struct zapi_client_close_info *info);
-extern void isis_ldp_sync_hello_timer_add(void);
 extern void isis_ldp_sync_ldp_fail(struct isis_circuit *circuit);
 extern int isis_ldp_sync_state_update(struct ldp_igp_sync_if_state state);
 extern int isis_ldp_sync_announce_update(struct ldp_igp_sync_announce announce);
-extern int isis_ldp_sync_hello_update(struct ldp_igp_sync_hello hello);
 extern void isis_ldp_sync_state_req_msg(struct isis_circuit *circuit);
 extern void isis_ldp_sync_set_if_metric(struct isis_circuit *circuit,
 					bool run_regen);

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2305,7 +2305,6 @@ int isis_instance_mpls_ldp_sync_create(struct nb_cb_create_args *args)
 		/* register with opaque client to recv LDP-IGP Sync msgs */
 		zclient_register_opaque(zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
 		zclient_register_opaque(zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
-		zclient_register_opaque(zclient, LDP_IGP_SYNC_HELLO_UPDATE);
 
 		if (!CHECK_FLAG(isis->ldp_sync_cmd.flags,
 				LDP_SYNC_FLAG_ENABLE)) {

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -670,7 +670,6 @@ static int isis_opaque_msg_handler(ZAPI_CALLBACK_ARGS)
 	struct zapi_opaque_msg info;
 	struct ldp_igp_sync_if_state state;
 	struct ldp_igp_sync_announce announce;
-	struct ldp_igp_sync_hello hello;
 	int ret = 0;
 
 	s = zclient->ibuf;
@@ -685,10 +684,6 @@ static int isis_opaque_msg_handler(ZAPI_CALLBACK_ARGS)
 	case LDP_IGP_SYNC_ANNOUNCE_UPDATE:
 		STREAM_GET(&announce, s, sizeof(announce));
 		ret = isis_ldp_sync_announce_update(announce);
-		break;
-	case LDP_IGP_SYNC_HELLO_UPDATE:
-		STREAM_GET(&hello, s, sizeof(hello));
-		ret = isis_ldp_sync_hello_update(hello);
 		break;
 	default:
 		break;

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -51,8 +51,6 @@ static void 	ldp_zebra_opaque_register(void);
 static void 	ldp_zebra_opaque_unregister(void);
 static int 	ldp_sync_zebra_send_announce(void);
 static int 	ldp_zebra_opaque_msg_handler(ZAPI_CALLBACK_ARGS);
-static void 	ldp_sync_zebra_start_hello_timer(void);
-static int 	ldp_sync_zebra_hello(struct thread *thread);
 static void 	ldp_sync_zebra_init(void);
 
 static struct zclient	*zclient;
@@ -176,38 +174,10 @@ stream_failure:
 }
 
 static void
-ldp_sync_zebra_start_hello_timer(void)
-{
-	thread_add_timer_msec(master, ldp_sync_zebra_hello, NULL, 250, NULL);
-}
-
-static int
-ldp_sync_zebra_hello(struct thread *thread)
-{
-	static unsigned int sequence = 0;
-	struct ldp_igp_sync_hello hello;
-
-	sequence++;
-
-	hello.proto = ZEBRA_ROUTE_LDP;
-	hello.sequence = sequence;
-
-	zclient_send_opaque(zclient, LDP_IGP_SYNC_HELLO_UPDATE,
-		(const uint8_t *) &hello, sizeof(hello));
-
-	ldp_sync_zebra_start_hello_timer();
-
-	return (0);
-}
-
-static void
 ldp_sync_zebra_init(void)
 {
 	ldp_sync_zebra_send_announce();
-
-	ldp_sync_zebra_start_hello_timer();
 }
-
 
 static int
 ldp_zebra_send_mpls_labels(int cmd, struct kroute *kr)

--- a/lib/ldp_sync.h
+++ b/lib/ldp_sync.h
@@ -39,14 +39,10 @@ extern "C" {
 
 #define LDP_IGP_SYNC_HOLDDOWN_DEFAULT 0
 
-#define LDP_IGP_SYNC_HELLO_TIMEOUT 5
-
 /* LDP-IGP Sync structures */
 struct ldp_sync_info_cmd {
 	uint16_t flags;
 	uint16_t holddown;       /* timer value */
-	uint32_t sequence;       /* hello sequence number */
-	struct thread *t_hello;  /* hello timer for detecting LDP going down */
 };
 
 struct ldp_sync_info {
@@ -77,11 +73,6 @@ struct ldp_igp_sync_if_state_req {
 	int proto;
 	ifindex_t ifindex;
 	char name[INTERFACE_NAMSIZ];
-};
-
-struct ldp_igp_sync_hello {
-	int proto;
-	unsigned int sequence;
 };
 
 #ifdef __cplusplus

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1085,8 +1085,6 @@ enum zapi_opaque_registry {
 	LDP_IGP_SYNC_IF_STATE_UPDATE = 4,
 	/* Announce that LDP is up  */
 	LDP_IGP_SYNC_ANNOUNCE_UPDATE = 5,
-	/* Heartbeat indicating that LDP is running */
-	LDP_IGP_SYNC_HELLO_UPDATE = 6,
 };
 
 /* Send the hello message.

--- a/ospfd/ospf_ldp_sync.h
+++ b/ospfd/ospf_ldp_sync.h
@@ -40,7 +40,6 @@ extern void ospf_ldp_sync_if_remove(struct interface *ifp, bool remove);
 extern void ospf_ldp_sync_if_down(struct interface *ifp);
 extern void ospf_ldp_sync_if_complete(struct interface *ifp);
 extern void ospf_ldp_sync_holddown_timer_add(struct interface *ifp);
-extern void ospf_ldp_sync_hello_timer_add(struct ospf *ospf);
 extern void ospf_ldp_sync_ldp_fail(struct interface *ifp);
 extern void ospf_ldp_sync_show_info(struct vty *vty, struct ospf *ospf,
 				    json_object *json_vrf, bool use_json);
@@ -49,7 +48,6 @@ extern void ospf_ldp_sync_if_write_config(struct vty *vty,
 					  struct ospf_if_params *params);
 extern int ospf_ldp_sync_state_update(struct ldp_igp_sync_if_state state);
 extern int ospf_ldp_sync_announce_update(struct ldp_igp_sync_announce announce);
-extern int ospf_ldp_sync_hello_update(struct ldp_igp_sync_hello hello);
 extern void
 ospf_ldp_sync_handle_client_close(struct zapi_client_close_info *info);
 extern void ospf_ldp_sync_state_req_msg(struct interface *ifp);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1956,7 +1956,6 @@ static int ospf_opaque_msg_handler(ZAPI_CALLBACK_ARGS)
 	struct zapi_opaque_msg info;
 	struct ldp_igp_sync_if_state state;
 	struct ldp_igp_sync_announce announce;
-	struct ldp_igp_sync_hello hello;
 	int ret = 0;
 
 	s = zclient->ibuf;
@@ -1972,10 +1971,6 @@ static int ospf_opaque_msg_handler(ZAPI_CALLBACK_ARGS)
 	case LDP_IGP_SYNC_ANNOUNCE_UPDATE:
 		STREAM_GET(&announce, s, sizeof(announce));
 		ret = ospf_ldp_sync_announce_update(announce);
-		break;
-	case LDP_IGP_SYNC_HELLO_UPDATE:
-		STREAM_GET(&hello, s, sizeof(hello));
-		ret = ospf_ldp_sync_hello_update(hello);
 		break;
 	default:
 		break;


### PR DESCRIPTION
Removing the obsolete ldp-sync periodic 'hello' message.

When ldp-sync is configured, IGPs take action if the LDP process goes down.

The IGPs have been updated to use the zapi client close callback to detect
the LDP process going down.

Signed-off-by: Karen Schoener <karen@voltanet.io>