### PR TITLE
bgpd: local routes use non-default distance

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13755,9 +13755,13 @@ uint8_t bgp_distance_apply(const struct prefix *p, struct bgp_path_info *pinfo,
 		if (bgp->distance_ebgp[afi][safi])
 			return bgp->distance_ebgp[afi][safi];
 		return ZEBRA_EBGP_DISTANCE_DEFAULT;
-	} else {
+	} else if (peer->sort == BGP_PEER_IBGP) {
 		if (bgp->distance_ibgp[afi][safi])
 			return bgp->distance_ibgp[afi][safi];
+		return ZEBRA_IBGP_DISTANCE_DEFAULT;
+	} else {
+		if (bgp->distance_local[afi][safi])
+			return bgp->distance_local[afi][safi];
 		return ZEBRA_IBGP_DISTANCE_DEFAULT;
 	}
 }


### PR DESCRIPTION
Use user provided (local) AD for local routes (aggregate).

 address-family ipv4 unicast
  distance bgp 20 200 210   (ebgp, ibgp, local) 
  network 47.2.2.8/30
  aggregate-address 51.1.0.0/16

Testing Done:

Before aggr route uses default 200 AD even user provided local AD.
B>* 51.1.0.0/16 ```[200/0]``` unreachable (blackhole), weight 1, 00:01:14

After:
B>* 51.1.0.0/16 ```[210/0]``` unreachable (blackhole), weight 1, 00:00:01

Signed-off-by: Chirag Shah <chirag@nvidia.com>