### PR TITLE
zebra: unexpose label-manager util-funcs as static

### DIFF
--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -91,8 +91,11 @@ static int label_manager_get_chunk(struct label_manager_chunk **lmc,
 				   vrf_id_t vrf_id);
 static int label_manager_release_label_chunk(struct zserv *client,
 					     uint32_t start, uint32_t end);
+static int release_label_chunk(uint8_t proto, unsigned short instance,
+			       uint32_t session_id, uint32_t start,
+			       uint32_t end);
 
-void delete_label_chunk(void *val)
+static void delete_label_chunk(void *val)
 {
 	XFREE(MTYPE_LM_CHUNK, val);
 }
@@ -175,11 +178,11 @@ void label_manager_init(void)
 }
 
 /* alloc and fill a label chunk */
-struct label_manager_chunk *create_label_chunk(uint8_t proto,
-					       unsigned short instance,
-					       uint32_t session_id,
-					       uint8_t keep, uint32_t start,
-					       uint32_t end)
+static struct label_manager_chunk *create_label_chunk(uint8_t proto,
+						      unsigned short instance,
+						      uint32_t session_id,
+						      uint8_t keep, uint32_t start,
+						      uint32_t end)
 {
 	/* alloc chunk, fill it and return it */
 	struct label_manager_chunk *lmc =
@@ -302,11 +305,11 @@ assign_specific_label_chunk(uint8_t proto, unsigned short instance,
  * @param base Desired starting label of the chunk; if MPLS_LABEL_BASE_ANY it does not apply
  * @return Pointer to the assigned label chunk, or NULL if the request could not be satisfied
  */
-struct label_manager_chunk *assign_label_chunk(uint8_t proto,
-					       unsigned short instance,
-					       uint32_t session_id,
-					       uint8_t keep, uint32_t size,
-					       uint32_t base)
+static struct label_manager_chunk *assign_label_chunk(uint8_t proto,
+						      unsigned short instance,
+						      uint32_t session_id,
+						      uint8_t keep, uint32_t size,
+						      uint32_t base)
 {
 	struct label_manager_chunk *lmc;
 	struct listnode *node;
@@ -390,11 +393,12 @@ static int label_manager_release_label_chunk(struct zserv *client,
  *
  * @param proto Daemon protocol of client, to identify the owner
  * @param instance Instance, to identify the owner
+ * @param session_id Zclient session ID, to identify the zclient session
  * @param start First label of the chunk
  * @param end Last label of the chunk
  * @return 0 on success, -1 otherwise
  */
-int release_label_chunk(uint8_t proto, unsigned short instance,
+static int release_label_chunk(uint8_t proto, unsigned short instance,
 			uint32_t session_id, uint32_t start, uint32_t end)
 {
 	struct listnode *node;

--- a/zebra/label_manager.h
+++ b/zebra/label_manager.h
@@ -94,14 +94,6 @@ int lm_client_connect_response(uint8_t proto, uint16_t instance,
 int lm_get_chunk_response(struct label_manager_chunk *lmc, struct zserv *client,
 			  vrf_id_t vrf_id);
 
-/* convenience function to allocate an lmc to be consumed by the above API */
-struct label_manager_chunk *create_label_chunk(uint8_t proto,
-					       unsigned short instance,
-					       uint32_t session_id,
-					       uint8_t keep, uint32_t start,
-					       uint32_t end);
-void delete_label_chunk(void *val);
-
 /* register/unregister callbacks for hooks */
 void lm_hooks_register(void);
 void lm_hooks_unregister(void);
@@ -115,13 +107,6 @@ struct label_manager {
 };
 
 void label_manager_init(void);
-struct label_manager_chunk *assign_label_chunk(uint8_t proto,
-					       unsigned short instance,
-					       uint32_t session_id,
-					       uint8_t keep, uint32_t size,
-					       uint32_t base);
-int release_label_chunk(uint8_t proto, unsigned short instance,
-			uint32_t session_id, uint32_t start, uint32_t end);
 int lm_client_disconnect_cb(struct zserv *client);
 int release_daemon_label_chunks(struct zserv *client);
 void label_manager_close(void);


### PR DESCRIPTION
Following functions which is a piece of label-maanager implementation
isn't called from out side of its file. And all lines of label-manager
are coded on zebra/label_manager.c at this time. So these functions
should be unexposed.

Functions:
- create_label_chunk
- assign_label_chunk
- delete_label_chunk
- release_label_chunk

Signed-off-by: Hiroki Shirokura <slank.dev@gmail.com>