### PR TITLE
isisd, ospfd: update 'client close' callback to 'ldp fail' api

### DIFF
--- a/isisd/isis_ldp_sync.c
+++ b/isisd/isis_ldp_sync.c
@@ -497,7 +497,7 @@ void isis_ldp_sync_handle_client_close(struct zapi_client_close_info *info)
 				circuit_lookup_by_ifp(ifp, area->circuit_list);
 			if (circuit == NULL)
 				continue;
-			isis_ldp_sync_if_start(circuit, true);
+			isis_ldp_sync_ldp_fail(circuit);
 		}
 	}
 }

--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -231,7 +231,7 @@ void ospf_ldp_sync_handle_client_close(struct zapi_client_close_info *info)
 
 	vrf = vrf_lookup_by_id(ospf->vrf_id);
 	FOR_ALL_INTERFACES (vrf, ifp)
-		ospf_ldp_sync_if_start(ifp, true);
+		ospf_ldp_sync_ldp_fail(ifp);
 }
 
 void ospf_ldp_sync_ldp_fail(struct interface *ifp)


### PR DESCRIPTION
Update 'client close' callback to 'ldp fail' api.

Signed-off-by: Karen Schoener <karen@voltanet.io>