### PR TITLE
ospf6d: Fix the prefix walking for show database command for intra-prefix and link

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -609,9 +609,8 @@ static char *ospf6_link_lsa_get_prefix_str(struct ospf6_lsa *lsa, char *buf,
 				return NULL;
 			}
 
-			if (cnt < pos) {
-				current =
-					start + pos * OSPF6_PREFIX_SIZE(prefix);
+			if (cnt < (pos - 1)) {
+				current += OSPF6_PREFIX_SIZE(prefix);
 				cnt++;
 			} else {
 				memset(&in6, 0, sizeof(in6));

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -796,7 +796,7 @@ static char *ospf6_intra_prefix_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 				    + sizeof(struct ospf6_lsa_header));
 
 		prefixnum = ntohs(intra_prefix_lsa->prefix_num);
-		if (pos > prefixnum)
+		if ((pos + 1) > prefixnum)
 			return NULL;
 
 		start = (char *)intra_prefix_lsa
@@ -812,8 +812,7 @@ static char *ospf6_intra_prefix_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 			}
 
 			if (cnt < pos) {
-				current =
-					start + pos * OSPF6_PREFIX_SIZE(prefix);
+				current += OSPF6_PREFIX_SIZE(prefix);
 				cnt++;
 			} else {
 				memset(&in6, 0, sizeof(in6));


### PR DESCRIPTION
For "show ipv6 ospf6 database intra-prefix" and "show ipv6 ospf6 database link"
commands, many prefixes were not getting shown. The pointer calculation to get
to the prefixes is fixed.

Signed-off-by: Yash Ranjan <ranjany@vmware.com>