### PR TITLE
ospf6d: ospfv3 disable on the interface, but interface prefix still s…

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -849,7 +849,7 @@ DEFUN (no_ospf6_interface_area,
 		return CMD_SUCCESS;
 	}
 
-	thread_execute(master, interface_down, oi, 0);
+	ospf6_interface_disable(oi);
 
 	oa = oi->area;
 	listnode_delete(oi->area->if_list, oi);
@@ -860,6 +860,7 @@ DEFUN (no_ospf6_interface_area,
 		UNSET_FLAG(oa->flag, OSPF6_AREA_ENABLE);
 		ospf6_abr_disable_area(oa);
 	}
+	ospf6_interface_delete(oi);
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
…hown in the output

```
!
interface ens192
ip address 5.5.5.2/24
ipv6 address 12::2/128
!
interface ens193
ip address 4.4.4.2/24
!
interface ens224
ip address 6.6.6.1/24
ipv6 ospf6 network point-to-point
!
router ospf6
ospf6 router-id 10.10.10.180
interface ens224 area 0.0.0.0
interface ens193 area 0.0.0.0
interface ens192 area 0.0.0.0          <===  undo this by no interface ens192 area 0.0.0.0 
!
```
 

```
frr# do show ipv6 ospf6 interface prefix
*N IA 12::2/128 ::1 ens192 00:07:59   <=== This is still present
```

When the ospfv3 interface is disabled by the command "no interface <eth> area <area-id>
the linked interface prefixes does not get flushed

Signed-off-by: Yash Ranjan <ranjany@vmware.com>