### PR TITLE
bgpd: fix evpn route-map vni filter at origin

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -743,6 +743,7 @@ static void build_evpn_type5_route_extcomm(struct bgp *bgp_vrf,
 	} else
 		ecom = ecommunity_dup(&ecom_encap);
 	attr->ecommunity = ecom;
+	attr->encap_tunneltype = tnl_type;
 
 	/* Add the export RTs for L3VNI/VRF */
 	vrf_export_rtl = bgp_vrf->vrf_export_rtl;
@@ -799,6 +800,7 @@ static void build_evpn_route_extcomm(struct bgpevpn *vpn, struct attr *attr,
 
 	/* Add Encap */
 	attr->ecommunity = ecommunity_dup(&ecom_encap);
+	attr->encap_tunneltype = tnl_type;
 
 	/* Add the export RTs for L2VNI */
 	for (ALL_LIST_ELEMENTS(vpn->export_rtl, node, nnode, ecom))


### PR DESCRIPTION
evpn route-map match (filter) on vni is not working
at the origin of the routes.

evpn match vni route checks for encap type as vxlan.
the source route attribute is not set with vxlan encap
thus the match filter wouldn't work.

Testing Done:

At source have match vni plus set statement in route-map.
Validate the origin of the route's outbound correctly sets
the 'set' statement based on match vni filter.

At origin:
route-map RM-EVPN-TE-Matches permit 10
 match evpn vni 4001
  set large-community 10:10:119

Receiving end:

Route [5]:[0]:[24]:[78.41.1.0] VNI 4001
5550
  27.0.0.15 from TORS1(downlink-5) (27.0.0.15)
    Origin incomplete, metric 0, valid, external, bestpath-from-AS 5550, best (First path received)
    Extended Community: RT:5550:4001 ET:8 Rmac:00:02:00:00:00:4d
    Large Community: 10:10:119    <--- Large community stamped
    Last update: Thu Dec 10 22:19:26 2020

Signed-off-by: Chirag Shah <chirag@nvidia.com>