### PR TITLE
[7.5] Routes stuck with 'q' flag when dplane_fpm_nl is in use

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1355,7 +1355,7 @@ static int fpm_nl_process(struct zebra_dplane_provider *prov)
 			if (peak_queue < cur_queue)
 				atomic_store_explicit(
 					&fnc->counters.ctxqueue_len_peak,
-					peak_queue, memory_order_relaxed);
+					cur_queue, memory_order_relaxed);
 			continue;
 		}
 

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1174,6 +1174,15 @@ static int fpm_process_queue(struct thread *t)
 		thread_add_timer(fnc->fthread->master, fpm_process_queue,
 				 fnc, 0, &fnc->t_dequeue);
 
+	/*
+	 * Let the dataplane thread know if there are items in the
+	 * output queue to be processed. Otherwise they may sit
+	 * until the dataplane thread gets scheduled for new,
+	 * unrelated work.
+	 */
+	if (dplane_provider_out_ctx_queue_len(fnc->prov) > 0)
+		dplane_provider_work_ready();
+
 	return 0;
 }
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3643,6 +3643,12 @@ int dplane_provider_dequeue_in_list(struct zebra_dplane_provider *prov,
 	return ret;
 }
 
+uint32_t dplane_provider_out_ctx_queue_len(struct zebra_dplane_provider *prov)
+{
+	return atomic_load_explicit(&(prov->dp_out_counter),
+				    memory_order_relaxed);
+}
+
 /*
  * Enqueue and maintain associated counter
  */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -715,6 +715,9 @@ struct zebra_dplane_ctx *dplane_provider_dequeue_in_ctx(
 int dplane_provider_dequeue_in_list(struct zebra_dplane_provider *prov,
 				    struct dplane_ctx_q *listp);
 
+/* Current completed work queue length */
+uint32_t dplane_provider_out_ctx_queue_len(struct zebra_dplane_provider *prov);
+
 /* Enqueue completed work, maintain associated counter and locking */
 void dplane_provider_enqueue_out_ctx(struct zebra_dplane_provider *prov,
 				     struct zebra_dplane_ctx *ctx);


### PR DESCRIPTION
Cherry pick of #7721 for stable/7.5.