### PR TITLE
ospf6d, tests, doc : OSPFv3 vrf support

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -851,34 +851,21 @@ DEFUN (no_area_export_list,
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_spf_tree,
-       show_ipv6_ospf6_spf_tree_cmd,
-       "show ipv6 ospf6 spf tree [json]",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       "Shortest Path First calculation\n"
-       "Show SPF tree\n"
-        JSON_STR)
+static int ipv6_ospf6_spf_tree_common(struct vty *vty, struct ospf6 *ospf6,
+				      bool uj)
 {
 	struct listnode *node;
 	struct ospf6_area *oa;
+	struct prefix prefix;
 	struct ospf6_vertex *root;
 	struct ospf6_route *route;
-	struct prefix prefix;
-	struct ospf6 *ospf6;
 	json_object *json = NULL;
 	json_object *json_area = NULL;
 	json_object *json_head = NULL;
-	bool uj = use_json(argc, argv);
-
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	if (uj)
 		json = json_object_new_object();
 	ospf6_linkstate_prefix(ospf6->router_id, htonl(0), &prefix);
-
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
 		if (uj) {
 			json_area = json_object_new_object();
@@ -918,35 +905,50 @@ DEFUN (show_ipv6_ospf6_spf_tree,
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_area_spf_tree,
-       show_ipv6_ospf6_area_spf_tree_cmd,
-       "show ipv6 ospf6 area A.B.C.D spf tree",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       OSPF6_AREA_STR
-       OSPF6_AREA_ID_STR
-       "Shortest Path First calculation\n"
-       "Show SPF tree\n")
+DEFUN(show_ipv6_ospf6_spf_tree, show_ipv6_ospf6_spf_tree_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] spf tree [json]",
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Shortest Path First calculation\n"
+      "Show SPF tree\n" JSON_STR)
 {
-	int idx_ipv4 = 4;
-	uint32_t area_id;
+	struct listnode *node;
+	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+	bool uj = use_json(argc, argv);
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ipv6_ospf6_spf_tree_common(vty, ospf6, uj);
+			if (!all_vrf)
+				break;
+		}
+	}
+
+	return CMD_SUCCESS;
+}
+
+static int show_ospf6_area_spf_tree_common(struct vty *vty,
+					   struct cmd_token **argv,
+					   struct ospf6 *ospf6,
+					   uint32_t area_id, int idx_ipv4)
+{
+
 	struct ospf6_area *oa;
+	struct prefix prefix;
 	struct ospf6_vertex *root;
 	struct ospf6_route *route;
-	struct prefix prefix;
-	struct ospf6 *ospf6;
-
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
 	ospf6_linkstate_prefix(ospf6->router_id, htonl(0), &prefix);
 
-	if (inet_pton(AF_INET, argv[idx_ipv4]->arg, &area_id) != 1) {
-		vty_out(vty, "Malformed Area-ID: %s\n", argv[idx_ipv4]->arg);
-		return CMD_SUCCESS;
-	}
 	oa = ospf6_area_lookup(area_id, ospf6);
 	if (oa == NULL) {
 		vty_out(vty, "No such Area: %s\n", argv[idx_ipv4]->arg);
@@ -965,41 +967,58 @@ DEFUN (show_ipv6_ospf6_area_spf_tree,
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_simulate_spf_tree_root,
-       show_ipv6_ospf6_simulate_spf_tree_root_cmd,
-       "show ipv6 ospf6 simulate spf-tree A.B.C.D area A.B.C.D",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       "Shortest Path First calculation\n"
-       "Show SPF tree\n"
-       "Specify root's router-id to calculate another router's SPF tree\n"
-       "OSPF6 area parameters\n"
-       OSPF6_AREA_ID_STR)
+DEFUN(show_ipv6_ospf6_area_spf_tree, show_ipv6_ospf6_area_spf_tree_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] area A.B.C.D spf tree",
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n" OSPF6_AREA_STR OSPF6_AREA_ID_STR
+      "Shortest Path First calculation\n"
+      "Show SPF tree\n")
 {
-	int idx_ipv4 = 5;
-	int idx_ipv4_2 = 7;
+	int idx_ipv4 = 4;
 	uint32_t area_id;
+	struct ospf6 *ospf6;
+	struct listnode *node;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0)
+		idx_ipv4 += 2;
+
+	if (inet_pton(AF_INET, argv[idx_ipv4]->arg, &area_id) != 1) {
+		vty_out(vty, "Malformed Area-ID: %s\n", argv[idx_ipv4]->arg);
+		return CMD_SUCCESS;
+	}
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			show_ospf6_area_spf_tree_common(vty, argv, ospf6,
+							area_id, idx_ipv4);
+			if (!all_vrf)
+				break;
+		}
+	}
+
+	return CMD_SUCCESS;
+}
+
+static int
+show_ospf6_simulate_spf_tree_commen(struct vty *vty, struct cmd_token **argv,
+				    struct ospf6 *ospf6, uint32_t router_id,
+				    uint32_t area_id, struct prefix prefix,
+				    int idx_ipv4, int idx_ipv4_2)
+{
 	struct ospf6_area *oa;
 	struct ospf6_vertex *root;
 	struct ospf6_route *route;
-	struct prefix prefix;
-	uint32_t router_id;
 	struct ospf6_route_table *spf_table;
 	unsigned char tmp_debug_ospf6_spf = 0;
-	struct ospf6 *ospf6;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
-
-	inet_pton(AF_INET, argv[idx_ipv4]->arg, &router_id);
-	ospf6_linkstate_prefix(router_id, htonl(0), &prefix);
-
-	if (inet_pton(AF_INET, argv[idx_ipv4_2]->arg, &area_id) != 1) {
-		vty_out(vty, "Malformed Area-ID: %s\n", argv[idx_ipv4_2]->arg);
-		return CMD_SUCCESS;
-	}
 	oa = ospf6_area_lookup(area_id, ospf6);
 	if (oa == NULL) {
 		vty_out(vty, "No such Area: %s\n", argv[idx_ipv4_2]->arg);
@@ -1025,6 +1044,57 @@ DEFUN (show_ipv6_ospf6_simulate_spf_tree_root,
 
 	ospf6_spf_table_finish(spf_table);
 	ospf6_route_table_delete(spf_table);
+
+	return CMD_SUCCESS;
+}
+
+DEFUN(show_ipv6_ospf6_simulate_spf_tree_root,
+      show_ipv6_ospf6_simulate_spf_tree_root_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] simulate spf-tree A.B.C.D area A.B.C.D",
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Shortest Path First calculation\n"
+      "Show SPF tree\n"
+      "Specify root's router-id to calculate another router's SPF tree\n"
+      "OSPF6 area parameters\n" OSPF6_AREA_ID_STR)
+{
+	int idx_ipv4 = 5;
+	int idx_ipv4_2 = 7;
+	uint32_t area_id;
+	struct prefix prefix;
+	uint32_t router_id;
+	struct ospf6 *ospf6;
+	struct listnode *node;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_ipv4 += 2;
+		idx_ipv4_2 += 2;
+	}
+	inet_pton(AF_INET, argv[idx_ipv4]->arg, &router_id);
+	ospf6_linkstate_prefix(router_id, htonl(0), &prefix);
+
+	if (inet_pton(AF_INET, argv[idx_ipv4_2]->arg, &area_id) != 1) {
+		vty_out(vty, "Malformed Area-ID: %s\n", argv[idx_ipv4_2]->arg);
+		return CMD_SUCCESS;
+	}
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			show_ospf6_simulate_spf_tree_commen(
+				vty, argv, ospf6, router_id, area_id, prefix,
+				idx_ipv4, idx_ipv4_2);
+			if (!all_vrf)
+				break;
+		}
+	}
 
 	return CMD_SUCCESS;
 }
@@ -1158,8 +1228,9 @@ void ospf6_area_interface_delete(struct ospf6_interface *oi)
 
 	if (!om6->ospf6)
 		return;
-	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6))
+	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6)) {
 		for (ALL_LIST_ELEMENTS(ospf6->area_list, node, nnode, oa))
 			if (listnode_lookup(oa->if_list, oi))
 				listnode_delete(oa->if_list, oi);
+	}
 }

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -41,6 +41,7 @@
 #include "ospf6_spf.h"
 
 #include "ospf6_top.h"
+#include "ospf6d.h"
 #include "ospf6_area.h"
 #include "ospf6_interface.h"
 #include "ospf6_neighbor.h"
@@ -1397,7 +1398,11 @@ DEFUN (ospf6_redistribute,
 	struct ospf6_redist *red;
 
 	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	if (ospf6 == NULL) {
+		vty_out(vty, "%% OSPF6 instance not found\n");
+		return CMD_SUCCESS;
+	}
+
 	char *proto = argv[argc - 1]->text;
 	type = proto_redistnum(AFI_IP6, proto);
 	if (type < 0)
@@ -1427,7 +1432,10 @@ DEFUN (ospf6_redistribute_routemap,
 	struct ospf6_redist *red;
 
 	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	if (ospf6 == NULL) {
+		vty_out(vty, "%% OSPF6 instance not found\n");
+		return CMD_SUCCESS;
+	}
 
 	char *proto = argv[idx_protocol]->text;
 	type = proto_redistnum(AFI_IP6, proto);
@@ -1459,8 +1467,10 @@ DEFUN (no_ospf6_redistribute,
 	struct ospf6_redist *red;
 
 	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
-
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	if (ospf6 == NULL) {
+		vty_out(vty, "%% OSPF6 instance not found\n");
+		return CMD_SUCCESS;
+	}
 
 	char *proto = argv[idx_protocol]->text;
 	type = proto_redistnum(AFI_IP6, proto);
@@ -1639,7 +1649,7 @@ DEFPY (ospf6_default_route_originate,
 
 	int cur_originate = ospf6->default_originate;
 
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
 
 	red = ospf6_redist_add(ospf6, DEFAULT_ROUTE, 0);
 
@@ -1696,7 +1706,7 @@ DEFPY (no_ospf6_default_information_originate,
 
 	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
 
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
 
 	red = ospf6_redist_lookup(ospf6, DEFAULT_ROUTE, 0);
 	if (!red)
@@ -2215,46 +2225,61 @@ static void ospf6_asbr_external_route_show(struct vty *vty,
 			forwarding);
 }
 
-DEFUN (show_ipv6_ospf6_redistribute,
-       show_ipv6_ospf6_redistribute_cmd,
-       "show ipv6 ospf6 redistribute [json]",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       "redistributing External information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_redistribute, show_ipv6_ospf6_redistribute_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] redistribute [json]",
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "redistributing External information\n" JSON_STR)
 {
 	struct ospf6_route *route;
 	struct ospf6 *ospf6 = NULL;
 	json_object *json = NULL;
 	bool uj = use_json(argc, argv);
+	struct listnode *node;
+	const char *vrf_name = VRF_DEFAULT_NAME;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
 	json_object *json_array_routes = NULL;
 	json_object *json_array_redistribute = NULL;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
 
 	if (uj) {
 		json = json_object_new_object();
 		json_array_routes = json_object_new_array();
 		json_array_redistribute = json_object_new_array();
 	}
-	ospf6_redistribute_show_config(vty, ospf6, json_array_redistribute,
-				       json, uj);
 
-	for (route = ospf6_route_head(ospf6->external_table); route;
-	     route = ospf6_route_next(route)) {
-		ospf6_asbr_external_route_show(vty, route, json_array_routes,
-					       uj);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_redistribute_show_config(
+				vty, ospf6, json_array_redistribute, json, uj);
+
+			for (route = ospf6_route_head(ospf6->external_table);
+			     route; route = ospf6_route_next(route)) {
+				ospf6_asbr_external_route_show(
+					vty, route, json_array_routes, uj);
+			}
+
+			if (uj) {
+				json_object_object_add(json, "routes",
+						       json_array_routes);
+				vty_out(vty, "%s\n",
+					json_object_to_json_string_ext(
+						json, JSON_C_TO_STRING_PRETTY));
+				json_object_free(json);
+			}
+
+			if (!all_vrf)
+				break;
+		}
 	}
 
-	if (uj) {
-		json_object_object_add(json, "routes", json_array_routes);
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
 	return CMD_SUCCESS;
 }
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1152,19 +1152,13 @@ static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 	return 0;
 }
 
-/* show interface */
-DEFUN(show_ipv6_ospf6_interface,
-      show_ipv6_ospf6_interface_ifname_cmd,
-      "show ipv6 ospf6 interface [IFNAME] [json]",
-      SHOW_STR
-      IP6_STR
-      OSPF6_STR
-      INTERFACE_STR
-      IFNAME_STR
-      JSON_STR)
+static int show_ospf6_interface_common(struct vty *vty, vrf_id_t vrf_id,
+				       int argc, struct cmd_token **argv,
+				       int idx_ifname, int intf_idx,
+				       int json_idx)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
-	int idx_ifname = 4;
+
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 	struct interface *ifp;
 	json_object *json;
 	json_object *json_int;
@@ -1172,9 +1166,8 @@ DEFUN(show_ipv6_ospf6_interface,
 
 	if (uj) {
 		json = json_object_new_object();
-		if (argc == 6) {
-			ifp = if_lookup_by_name(argv[idx_ifname]->arg,
-						VRF_DEFAULT);
+		if (argc == json_idx) {
+			ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id);
 			json_int = json_object_new_object();
 			if (ifp == NULL) {
 				json_object_string_add(json, "noSuchInterface",
@@ -1201,9 +1194,8 @@ DEFUN(show_ipv6_ospf6_interface,
 				json, JSON_C_TO_STRING_PRETTY));
 		json_object_free(json);
 	} else {
-		if (argc == 5) {
-			ifp = if_lookup_by_name(argv[idx_ifname]->arg,
-						VRF_DEFAULT);
+		if (argc == intf_idx) {
+			ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id);
 			if (ifp == NULL) {
 				vty_out(vty, "No such Interface: %s\n",
 					argv[idx_ifname]->arg);
@@ -1215,6 +1207,45 @@ DEFUN(show_ipv6_ospf6_interface,
 				ospf6_interface_show(vty, ifp, NULL, uj);
 		}
 	}
+	return CMD_SUCCESS;
+}
+
+/* show interface */
+DEFUN(show_ipv6_ospf6_interface, show_ipv6_ospf6_interface_ifname_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] interface [IFNAME] [json]",
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n" INTERFACE_STR IFNAME_STR JSON_STR)
+{
+	int idx_ifname = 4;
+	int intf_idx = 5;
+	int json_idx = 6;
+	struct listnode *node;
+	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_ifname += 2;
+		intf_idx += 2;
+		json_idx += 2;
+	}
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			show_ospf6_interface_common(vty, ospf6->vrf_id, argc,
+						    argv, idx_ifname, intf_idx,
+						    json_idx);
+
+			if (!all_vrf)
+				break;
+		}
+	}
 
 	return CMD_SUCCESS;
 }
@@ -1222,7 +1253,7 @@ DEFUN(show_ipv6_ospf6_interface,
 static int ospf6_interface_show_traffic(struct vty *vty,
 					struct interface *intf_ifp,
 					int display_once, json_object *json,
-					bool use_json)
+					bool use_json, vrf_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct vrf *vrf = NULL;
@@ -1232,7 +1263,7 @@ static int ospf6_interface_show_traffic(struct vty *vty,
 	if (intf_ifp)
 		vrf = vrf_lookup_by_id(intf_ifp->vrf_id);
 	else
-		vrf = vrf_lookup_by_id(VRF_DEFAULT);
+		vrf = vrf_lookup_by_id(vrf_id);
 
 	if (!display_once && !use_json) {
 		vty_out(vty, "\n");
@@ -1333,17 +1364,9 @@ static int ospf6_interface_show_traffic(struct vty *vty,
 	return CMD_SUCCESS;
 }
 
-/* show interface */
-DEFUN(show_ipv6_ospf6_interface_traffic,
-      show_ipv6_ospf6_interface_traffic_cmd,
-      "show ipv6 ospf6 interface traffic [IFNAME] [json]",
-      SHOW_STR
-      IP6_STR
-      OSPF6_STR
-      INTERFACE_STR
-      "Protocol Packet counters\n"
-      IFNAME_STR
-      JSON_STR)
+static int ospf6_interface_show_traffic_common(struct vty *vty, int argc,
+					       struct cmd_token **argv,
+					       vrf_id_t vrf_id)
 {
 	int idx_ifname = 0;
 	int display_once = 0;
@@ -1357,7 +1380,7 @@ DEFUN(show_ipv6_ospf6_interface_traffic,
 
 	if (argv_find(argv, argc, "IFNAME", &idx_ifname)) {
 		intf_name = argv[idx_ifname]->arg;
-		ifp = if_lookup_by_name(intf_name, VRF_DEFAULT);
+		ifp = if_lookup_by_name(intf_name, vrf_id);
 		if (uj) {
 			if (ifp == NULL) {
 				json_object_string_add(json, "status",
@@ -1397,7 +1420,7 @@ DEFUN(show_ipv6_ospf6_interface_traffic,
 		}
 	}
 
-	ospf6_interface_show_traffic(vty, ifp, display_once, json, uj);
+	ospf6_interface_show_traffic(vty, ifp, display_once, json, uj, vrf_id);
 
 	if (uj) {
 		vty_out(vty, "%s\n",
@@ -1406,94 +1429,156 @@ DEFUN(show_ipv6_ospf6_interface_traffic,
 		json_object_free(json);
 	}
 
+	return CMD_SUCCESS;
+}
+
+/* show interface */
+DEFUN(show_ipv6_ospf6_interface_traffic, show_ipv6_ospf6_interface_traffic_cmd,
+      "show ipv6 ospf6 interface traffic [IFNAME] [json]",
+      SHOW_STR IP6_STR OSPF6_STR INTERFACE_STR
+      "Protocol Packet counters\n" IFNAME_STR JSON_STR)
+{
+	struct ospf6 *ospf6;
+	struct listnode *node;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_interface_show_traffic_common(vty, argc, argv,
+							    ospf6->vrf_id);
+
+			if (!all_vrf)
+				break;
+		}
+	}
 
 	return CMD_SUCCESS;
 }
 
 
-DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
-       show_ipv6_ospf6_interface_ifname_prefix_cmd,
-       "show ipv6 ospf6 interface IFNAME prefix\
+DEFUN(show_ipv6_ospf6_interface_ifname_prefix,
+      show_ipv6_ospf6_interface_ifname_prefix_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] interface IFNAME prefix\
           [<\
 	    detail\
 	    |<X:X::X:X|X:X::X:X/M> [<match|detail>]\
 	  >] [json]",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       INTERFACE_STR
-       IFNAME_STR
-       "Display connected prefixes to advertise\n"
-       "Display details of the prefixes\n"
-       OSPF6_ROUTE_ADDRESS_STR
-       OSPF6_ROUTE_PREFIX_STR
-       OSPF6_ROUTE_MATCH_STR
-       "Display details of the prefixes\n"
-       JSON_STR)
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n" INTERFACE_STR IFNAME_STR
+      "Display connected prefixes to advertise\n"
+      "Display details of the prefixes\n" OSPF6_ROUTE_ADDRESS_STR
+	      OSPF6_ROUTE_PREFIX_STR OSPF6_ROUTE_MATCH_STR
+      "Display details of the prefixes\n" JSON_STR)
 {
 	int idx_ifname = 4;
 	int idx_prefix = 6;
-	struct interface *ifp;
 	struct ospf6_interface *oi;
 	bool uj = use_json(argc, argv);
 
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
-	if (ifp == NULL) {
-		vty_out(vty, "No such Interface: %s\n", argv[idx_ifname]->arg);
-		return CMD_WARNING;
+	struct ospf6 *ospf6;
+	struct listnode *node;
+	struct interface *ifp;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_ifname += 2;
+		idx_prefix += 2;
 	}
 
-	oi = ifp->info;
-	if (oi == NULL) {
-		vty_out(vty, "OSPFv3 is not enabled on %s\n",
-			argv[idx_ifname]->arg);
-		return CMD_WARNING;
-	}
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+						ospf6->vrf_id);
+			if (ifp == NULL) {
+				vty_out(vty, "No such Interface: %s\n",
+					argv[idx_ifname]->arg);
+				return CMD_WARNING;
+			}
 
-	if (CHECK_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE)) {
-		vty_out(vty, "Interface %s not attached to area\n",
-			argv[idx_ifname]->arg);
-		return CMD_WARNING;
-	}
+			oi = ifp->info;
+			if (oi == NULL
+			    || CHECK_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE)) {
+				vty_out(vty,
+					"Interface %s not attached to area\n",
+					argv[idx_ifname]->arg);
+				return CMD_WARNING;
+			}
 
-	ospf6_route_table_show(vty, idx_prefix, argc, argv, oi->route_connected,
-			       uj);
+			ospf6_route_table_show(vty, idx_prefix, argc, argv,
+					       oi->route_connected, uj);
+
+			if (!all_vrf)
+				break;
+		}
+	}
 
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_interface_prefix,
-       show_ipv6_ospf6_interface_prefix_cmd,
-       "show ipv6 ospf6 interface prefix\
+DEFUN(show_ipv6_ospf6_interface_prefix, show_ipv6_ospf6_interface_prefix_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] interface prefix\
           [<\
 	    detail\
 	    |<X:X::X:X|X:X::X:X/M> [<match|detail>]\
 	  >] [json]",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       INTERFACE_STR
-       "Display connected prefixes to advertise\n"
-       "Display details of the prefixes\n"
-       OSPF6_ROUTE_ADDRESS_STR
-       OSPF6_ROUTE_PREFIX_STR
-       OSPF6_ROUTE_MATCH_STR
-       "Display details of the prefixes\n"
-       JSON_STR)
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n" INTERFACE_STR
+      "Display connected prefixes to advertise\n"
+      "Display details of the prefixes\n" OSPF6_ROUTE_ADDRESS_STR
+	      OSPF6_ROUTE_PREFIX_STR OSPF6_ROUTE_MATCH_STR
+      "Display details of the prefixes\n" JSON_STR)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = NULL;
 	int idx_prefix = 5;
 	struct ospf6_interface *oi;
 	struct interface *ifp;
 	bool uj = use_json(argc, argv);
+	struct listnode *node;
+	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
-	FOR_ALL_INTERFACES (vrf, ifp) {
-		oi = (struct ospf6_interface *)ifp->info;
-		if (oi == NULL || CHECK_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE))
-			continue;
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0)
+		idx_prefix += 2;
 
-		ospf6_route_table_show(vty, idx_prefix, argc, argv,
-				       oi->route_connected, uj);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			vrf = vrf_lookup_by_id(ospf6->vrf_id);
+			FOR_ALL_INTERFACES (vrf, ifp) {
+				oi = (struct ospf6_interface *)ifp->info;
+				if (oi == NULL
+				    || CHECK_FLAG(oi->flag,
+						  OSPF6_INTERFACE_DISABLE))
+					continue;
+
+				ospf6_route_table_show(vty, idx_prefix, argc,
+						       argv,
+						       oi->route_connected, uj);
+			}
+			if (!all_vrf)
+				break;
+		}
 	}
 
 	return CMD_SUCCESS;
@@ -2188,9 +2273,8 @@ DEFUN (no_ipv6_ospf6_network,
 	return CMD_SUCCESS;
 }
 
-static int config_write_ospf6_interface(struct vty *vty)
+static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	struct ospf6_interface *oi;
 	struct interface *ifp;
 
@@ -2199,7 +2283,11 @@ static int config_write_ospf6_interface(struct vty *vty)
 		if (oi == NULL)
 			continue;
 
-		vty_frame(vty, "interface %s\n", oi->interface->name);
+		if (vrf->vrf_id == VRF_DEFAULT)
+			vty_frame(vty, "interface %s\n", oi->interface->name);
+		else
+			vty_frame(vty, "interface %s vrf %s\n",
+				  oi->interface->name, vrf->name);
 
 		if (ifp->desc)
 			vty_out(vty, " description %s\n", ifp->desc);
@@ -2254,13 +2342,27 @@ static int config_write_ospf6_interface(struct vty *vty)
 	return 0;
 }
 
-static int config_write_ospf6_interface(struct vty *vty);
+/* Configuration write function for ospfd. */
+static int config_write_interface(struct vty *vty)
+{
+	int write = 0;
+	struct vrf *vrf = NULL;
+
+	/* Display all VRF aware OSPF interface configuration */
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		write += config_write_ospf6_interface(vty, vrf);
+	}
+
+	return write;
+}
+
+static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf);
 static struct cmd_node interface_node = {
 	.name = "interface",
 	.node = INTERFACE_NODE,
 	.parent_node = CONFIG_NODE,
 	.prompt = "%s(config-if)# ",
-	.config_write = config_write_ospf6_interface,
+	.config_write = config_write_interface,
 };
 
 static int ospf6_ifp_create(struct interface *ifp)

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -225,7 +225,7 @@ int main(int argc, char *argv[], char *envp[])
 	/* thread master */
 	master = om6->master;
 
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	ospf6_vrf_init();
 	access_list_init();
 	prefix_list_init();
 

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -969,35 +969,24 @@ static void ospf6_neighbor_show_detail(struct vty *vty,
 	}
 }
 
-DEFUN (show_ipv6_ospf6_neighbor,
-       show_ipv6_ospf6_neighbor_cmd,
-       "show ipv6 ospf6 neighbor [<detail|drchoice>] [json]",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       "Neighbor list\n"
-       "Display details\n"
-       "Display DR choices\n"
-       JSON_STR)
+static void ospf6_neighbor_show_detail_common(struct vty *vty, int argc,
+					      struct cmd_token **argv,
+					      struct ospf6 *ospf6, int idx_type,
+					      int detail_idx, int json_idx)
 {
-	int idx_type = 4;
 	struct ospf6_neighbor *on;
 	struct ospf6_interface *oi;
 	struct ospf6_area *oa;
 	struct listnode *i, *j, *k;
-	struct ospf6 *ospf6;
 	json_object *json = NULL;
 	json_object *json_array = NULL;
 	bool uj = use_json(argc, argv);
 	void (*showfunc)(struct vty *, struct ospf6_neighbor *,
 			 json_object *json, bool use_json);
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	showfunc = ospf6_neighbor_show;
 
-	if ((uj && argc == 6) || (!uj && argc == 5)) {
+	if ((uj && argc == detail_idx) || (!uj && argc == json_idx)) {
 		if (!strncmp(argv[idx_type]->arg, "de", 2))
 			showfunc = ospf6_neighbor_show_detail;
 		else if (!strncmp(argv[idx_type]->arg, "dr", 2))
@@ -1037,21 +1026,53 @@ DEFUN (show_ipv6_ospf6_neighbor,
 				json, JSON_C_TO_STRING_PRETTY));
 		json_object_free(json);
 	}
+}
+
+DEFUN(show_ipv6_ospf6_neighbor, show_ipv6_ospf6_neighbor_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] neighbor [<detail|drchoice>] [json]",
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Neighbor list\n"
+      "Display details\n"
+      "Display DR choices\n" JSON_STR)
+{
+	int idx_type = 4;
+	int detail_idx = 5;
+	int json_idx = 6;
+	struct ospf6 *ospf6;
+	struct listnode *node;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_type += 2;
+		detail_idx += 2;
+		json_idx += 2;
+	}
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_neighbor_show_detail_common(vty, argc, argv,
+							  ospf6, idx_type,
+							  detail_idx, json_idx);
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-
-DEFUN (show_ipv6_ospf6_neighbor_one,
-       show_ipv6_ospf6_neighbor_one_cmd,
-       "show ipv6 ospf6 neighbor A.B.C.D [json]",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       "Neighbor list\n"
-       "Specify Router-ID as IPv4 address notation\n"
-       JSON_STR)
+static int ospf6_neighbor_show_common(struct vty *vty, int argc,
+				      struct cmd_token **argv,
+				      struct ospf6 *ospf6, int idx_ipv4)
 {
-	int idx_ipv4 = 4;
 	struct ospf6_neighbor *on;
 	struct ospf6_interface *oi;
 	struct ospf6_area *oa;
@@ -1059,12 +1080,9 @@ DEFUN (show_ipv6_ospf6_neighbor_one,
 	void (*showfunc)(struct vty *, struct ospf6_neighbor *,
 			 json_object *json, bool use_json);
 	uint32_t router_id;
-	struct ospf6 *ospf6;
 	json_object *json = NULL;
 	bool uj = use_json(argc, argv);
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	showfunc = ospf6_neighbor_show_detail;
 	if (uj)
 		json = json_object_new_object();
@@ -1088,6 +1106,42 @@ DEFUN (show_ipv6_ospf6_neighbor_one,
 				json, JSON_C_TO_STRING_PRETTY));
 		json_object_free(json);
 	}
+
+	return CMD_SUCCESS;
+}
+
+DEFUN(show_ipv6_ospf6_neighbor_one, show_ipv6_ospf6_neighbor_one_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] neighbor A.B.C.D [json]",
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Neighbor list\n"
+      "Specify Router-ID as IPv4 address notation\n" JSON_STR)
+{
+	int idx_ipv4 = 4;
+	struct ospf6 *ospf6;
+	struct listnode *node;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0)
+		idx_ipv4 += 2;
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_neighbor_show_common(vty, argc, argv, ospf6,
+						   idx_ipv4);
+
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -171,5 +171,6 @@ void ospf6_vrf_unlink(struct ospf6 *ospf6, struct vrf *vrf);
 struct ospf6 *ospf6_lookup_by_vrf_id(vrf_id_t vrf_id);
 struct ospf6 *ospf6_lookup_by_vrf_name(const char *name);
 const char *ospf6_vrf_id_to_name(vrf_id_t vrf_id);
-
+void ospf6_vrf_init(void);
+void ospf6_set_redist_vrf_bitmaps(struct ospf6 *ospf6);
 #endif /* OSPF6_TOP_H */

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -49,6 +49,23 @@ unsigned char conf_debug_ospf6_zebra = 0;
 /* information about zebra. */
 struct zclient *zclient = NULL;
 
+void ospf6_set_redist_vrf_bitmaps(struct ospf6 *ospf6)
+{
+	int type;
+	struct list *red_list;
+
+	for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
+		red_list = ospf6->redist[type];
+		if (!red_list)
+			continue;
+		if (IS_OSPF6_DEBUG_ZEBRA(RECV))
+			zlog_debug(
+				"%s: setting redist vrf %d bitmap for type %d",
+				__func__, ospf6->vrf_id, type);
+		ospf6_zebra_redistribute(type, ospf6->vrf_id);
+	}
+}
+
 void ospf6_zebra_vrf_register(struct ospf6 *ospf6)
 {
 	if (!zclient || zclient->sock < 0 || !ospf6)

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -73,4 +73,5 @@ extern int config_write_ospf6_debug_zebra(struct vty *vty);
 extern void install_element_ospf6_debug_zebra(void);
 extern void ospf6_zebra_vrf_register(struct ospf6 *ospf6);
 extern void ospf6_zebra_vrf_deregister(struct ospf6 *ospf6);
+extern void ospf_set_redist_vrf_bitmaps(struct ospf6 *ospf6);
 #endif /*OSPF6_ZEBRA_H*/

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -388,161 +388,202 @@ static void ospf6_lsdb_type_show_wrapper(struct vty *vty,
 		vty_out(vty, "\n");
 }
 
-DEFUN (show_ipv6_ospf6_database,
-       show_ipv6_ospf6_database_cmd,
-       "show ipv6 ospf6 database [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-        JSON_STR)
+DEFUN(show_ipv6_ospf6_database, show_ipv6_ospf6_database_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database [<detail|dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
-	int idx_level = 4;
 	int level;
-	bool uj = use_json(argc, argv);
+	int idx_level = 4;
+	struct listnode *node;
 	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+	bool uj = use_json(argc, argv);
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0)
+		idx_level += 2;
 
 	level = parse_show_level(idx_level, argc, argv);
-	ospf6_lsdb_show_wrapper(vty, level, NULL, NULL, NULL, uj, ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_show_wrapper(vty, level, NULL, NULL, NULL,
+						uj, ospf6);
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_database_type, show_ipv6_ospf6_database_type_cmd,
-       "show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Display Router LSAs\n"
-       "Display Network LSAs\n"
-       "Display Inter-Area-Prefix LSAs\n"
-       "Display Inter-Area-Router LSAs\n"
-       "Display As-External LSAs\n"
-       "Display Group-Membership LSAs\n"
-       "Display Type-7 LSAs\n"
-       "Display Link LSAs\n"
-       "Display Intra-Area-Prefix LSAs\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_type, show_ipv6_ospf6_database_type_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> [<detail|dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Display Router LSAs\n"
+      "Display Network LSAs\n"
+      "Display Inter-Area-Prefix LSAs\n"
+      "Display Inter-Area-Router LSAs\n"
+      "Display As-External LSAs\n"
+      "Display Group-Membership LSAs\n"
+      "Display Type-7 LSAs\n"
+      "Display Link LSAs\n"
+      "Display Intra-Area-Prefix LSAs\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_lsa = 4;
 	int idx_level = 5;
 	int level;
-	uint16_t type = 0;
 	bool uj = use_json(argc, argv);
+	struct listnode *node;
 	struct ospf6 *ospf6;
+	uint16_t type = 0;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
-
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_lsa += 2;
+		idx_level += 2;
+	}
 
 	type = parse_type_spec(idx_lsa, argc, argv);
 	level = parse_show_level(idx_level, argc, argv);
 
-	ospf6_lsdb_type_show_wrapper(vty, level, &type, NULL, NULL, uj, ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_type_show_wrapper(vty, level, &type, NULL,
+						     NULL, uj, ospf6);
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_database_id,
-       show_ipv6_ospf6_database_id_cmd,
-       "show ipv6 ospf6 database <*|linkstate-id> A.B.C.D [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Any Link state Type\n"
-       "Search by Link state ID\n"
-       "Specify Link state ID as IPv4 address notation\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_id, show_ipv6_ospf6_database_id_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database <*|linkstate-id> A.B.C.D [<detail|dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Any Link state Type\n"
+      "Search by Link state ID\n"
+      "Specify Link state ID as IPv4 address notation\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_ipv4 = 5;
 	int idx_level = 6;
 	int level;
-	uint32_t id = 0;
 	bool uj = use_json(argc, argv);
+	struct listnode *node;
 	struct ospf6 *ospf6;
+	uint32_t id = 0;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
-
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
-
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
 	if (argv[idx_ipv4]->type == IPV4_TKN)
 		inet_pton(AF_INET, argv[idx_ipv4]->arg, &id);
 
 	level = parse_show_level(idx_level, argc, argv);
-	ospf6_lsdb_show_wrapper(vty, level, NULL, &id, NULL, uj, ospf6);
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_show_wrapper(vty, level, NULL, &id, NULL, uj,
+						ospf6);
+			if (!all_vrf)
+				break;
+		}
+	}
 
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_database_router,
-       show_ipv6_ospf6_database_router_cmd,
-       "show ipv6 ospf6 database <*|adv-router> * A.B.C.D <detail|dump|internal> [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Any Link state Type\n"
-       "Search by Advertising Router\n"
-       "Any Link state ID\n"
-       "Specify Advertising Router as IPv4 address notation\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_router, show_ipv6_ospf6_database_router_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database <*|adv-router> * A.B.C.D <detail|dump|internal> [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Any Link state Type\n"
+      "Search by Advertising Router\n"
+      "Any Link state ID\n"
+      "Specify Advertising Router as IPv4 address notation\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_ipv4 = 6;
 	int idx_level = 7;
 	int level;
-	uint32_t adv_router = 0;
-	bool uj = use_json(argc, argv);
+	struct listnode *node;
 	struct ospf6 *ospf6;
+	uint32_t adv_router = 0;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+	bool uj = use_json(argc, argv);
 
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_ipv4 += 2;
+		idx_level += 2;
+	}
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &adv_router);
 	level = parse_show_level(idx_level, argc, argv);
 
-	ospf6_lsdb_show_wrapper(vty, level, NULL, NULL, &adv_router, uj, ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_show_wrapper(vty, level, NULL, NULL,
+						&adv_router, uj, ospf6);
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-DEFUN_HIDDEN (show_ipv6_ospf6_database_aggr_router,
-       show_ipv6_ospf6_database_aggr_router_cmd,
-       "show ipv6 ospf6 database aggr adv-router A.B.C.D",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Aggregated Router LSA\n"
-       "Search by Advertising Router\n"
-       "Specify Advertising Router as IPv4 address notation\n")
+static int ipv6_ospf6_database_aggr_router_common(struct vty *vty,
+						  uint32_t adv_router,
+						  struct ospf6 *ospf6)
 {
 	int level = OSPF6_LSDB_SHOW_LEVEL_DETAIL;
 	uint16_t type = htons(OSPF6_LSTYPE_ROUTER);
-	int idx_ipv4 = 6;
 	struct listnode *i;
-	struct ospf6 *ospf6;
 	struct ospf6_area *oa;
 	struct ospf6_lsdb *lsdb;
-	uint32_t adv_router = 0;
-
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
-
-	inet_pton(AF_INET, argv[idx_ipv4]->arg, &adv_router);
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa)) {
 		if (adv_router == ospf6->router_id)
@@ -561,215 +602,345 @@ DEFUN_HIDDEN (show_ipv6_ospf6_database_aggr_router,
 	}
 
 	vty_out(vty, "\n");
+	return CMD_SUCCESS;
+}
+
+DEFUN_HIDDEN(
+	show_ipv6_ospf6_database_aggr_router,
+	show_ipv6_ospf6_database_aggr_router_cmd,
+	"show ipv6 ospf6 [vrf <NAME|all>] database aggr adv-router A.B.C.D",
+	SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+	"All VRFs\n"
+	"Display Link state database\n"
+	"Aggregated Router LSA\n"
+	"Search by Advertising Router\n"
+	"Specify Advertising Router as IPv4 address notation\n")
+{
+	int idx_ipv4 = 6;
+	struct listnode *node;
+	struct ospf6 *ospf6;
+	uint32_t adv_router = 0;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0)
+		idx_ipv4 += 2;
+
+	inet_pton(AF_INET, argv[idx_ipv4]->arg, &adv_router);
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ipv6_ospf6_database_aggr_router_common(vty, adv_router,
+							       ospf6);
+
+			if (!all_vrf)
+				break;
+		}
+	}
 
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_database_type_id,
-       show_ipv6_ospf6_database_type_id_cmd,
-       "show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> linkstate-id A.B.C.D [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Display Router LSAs\n"
-       "Display Network LSAs\n"
-       "Display Inter-Area-Prefix LSAs\n"
-       "Display Inter-Area-Router LSAs\n"
-       "Display As-External LSAs\n"
-       "Display Group-Membership LSAs\n"
-       "Display Type-7 LSAs\n"
-       "Display Link LSAs\n"
-       "Display Intra-Area-Prefix LSAs\n"
-       "Search by Link state ID\n"
-       "Specify Link state ID as IPv4 address notation\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_type_id, show_ipv6_ospf6_database_type_id_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> linkstate-id A.B.C.D [<detail|dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Display Router LSAs\n"
+      "Display Network LSAs\n"
+      "Display Inter-Area-Prefix LSAs\n"
+      "Display Inter-Area-Router LSAs\n"
+      "Display As-External LSAs\n"
+      "Display Group-Membership LSAs\n"
+      "Display Type-7 LSAs\n"
+      "Display Link LSAs\n"
+      "Display Intra-Area-Prefix LSAs\n"
+      "Search by Link state ID\n"
+      "Specify Link state ID as IPv4 address notation\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_lsa = 4;
 	int idx_ipv4 = 6;
 	int idx_level = 7;
 	int level;
+	bool uj = use_json(argc, argv);
+	struct listnode *node;
+	struct ospf6 *ospf6;
 	uint16_t type = 0;
 	uint32_t id = 0;
-	bool uj = use_json(argc, argv);
-	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
-
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_lsa += 2;
+		idx_ipv4 += 2;
+		idx_level += 2;
+	}
 
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &id);
 	level = parse_show_level(idx_level, argc, argv);
 
-	ospf6_lsdb_type_show_wrapper(vty, level, &type, &id, NULL, uj, ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_type_show_wrapper(vty, level, &type, &id,
+						     NULL, uj, ospf6);
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_database_type_router,
-       show_ipv6_ospf6_database_type_router_cmd,
-       "show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> <*|adv-router> A.B.C.D [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Display Router LSAs\n"
-       "Display Network LSAs\n"
-       "Display Inter-Area-Prefix LSAs\n"
-       "Display Inter-Area-Router LSAs\n"
-       "Display As-External LSAs\n"
-       "Display Group-Membership LSAs\n"
-       "Display Type-7 LSAs\n"
-       "Display Link LSAs\n"
-       "Display Intra-Area-Prefix LSAs\n"
-       "Any Link state ID\n"
-       "Search by Advertising Router\n"
-       "Specify Advertising Router as IPv4 address notation\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_type_router,
+      show_ipv6_ospf6_database_type_router_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> <*|adv-router> A.B.C.D [<detail|dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Display Router LSAs\n"
+      "Display Network LSAs\n"
+      "Display Inter-Area-Prefix LSAs\n"
+      "Display Inter-Area-Router LSAs\n"
+      "Display As-External LSAs\n"
+      "Display Group-Membership LSAs\n"
+      "Display Type-7 LSAs\n"
+      "Display Link LSAs\n"
+      "Display Intra-Area-Prefix LSAs\n"
+      "Any Link state ID\n"
+      "Search by Advertising Router\n"
+      "Specify Advertising Router as IPv4 address notation\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_lsa = 4;
 	int idx_ipv4 = 6;
 	int idx_level = 7;
 	int level;
+	bool uj = use_json(argc, argv);
+	struct listnode *node;
+	struct ospf6 *ospf6;
 	uint16_t type = 0;
 	uint32_t adv_router = 0;
-	bool uj = use_json(argc, argv);
-	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_lsa += 2;
+		idx_ipv4 += 2;
+		idx_level += 2;
+	}
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &adv_router);
 	level = parse_show_level(idx_level, argc, argv);
 
-	ospf6_lsdb_type_show_wrapper(vty, level, &type, NULL, &adv_router, uj,
-				     ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_type_show_wrapper(vty, level, &type, NULL,
+						     &adv_router, uj, ospf6);
+
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-
-DEFUN (show_ipv6_ospf6_database_id_router,
-       show_ipv6_ospf6_database_id_router_cmd,
-       "show ipv6 ospf6 database * A.B.C.D A.B.C.D [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Any Link state Type\n"
-       "Specify Link state ID as IPv4 address notation\n"
-       "Specify Advertising Router as IPv4 address notation\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_id_router,
+      show_ipv6_ospf6_database_id_router_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database * A.B.C.D A.B.C.D [<detail|dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Any Link state Type\n"
+      "Specify Link state ID as IPv4 address notation\n"
+      "Specify Advertising Router as IPv4 address notation\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_ls_id = 5;
 	int idx_adv_rtr = 6;
 	int idx_level = 7;
 	int level;
+	bool uj = use_json(argc, argv);
+	struct listnode *node;
+	struct ospf6 *ospf6;
 	uint32_t id = 0;
 	uint32_t adv_router = 0;
-	bool uj = use_json(argc, argv);
-	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_ls_id += 2;
+		idx_adv_rtr += 2;
+		idx_level += 2;
+	}
+
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
 	inet_pton(AF_INET, argv[idx_adv_rtr]->arg, &adv_router);
 	level = parse_show_level(idx_level, argc, argv);
 
-	ospf6_lsdb_show_wrapper(vty, level, NULL, &id, &adv_router, uj, ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_show_wrapper(vty, level, NULL, &id,
+						&adv_router, uj, ospf6);
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-
-DEFUN (show_ipv6_ospf6_database_adv_router_linkstate_id,
-       show_ipv6_ospf6_database_adv_router_linkstate_id_cmd,
-       "show ipv6 ospf6 database adv-router A.B.C.D linkstate-id A.B.C.D [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Search by Advertising Router\n"
-       "Specify Advertising Router as IPv4 address notation\n"
-       "Search by Link state ID\n"
-       "Specify Link state ID as IPv4 address notation\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_adv_router_linkstate_id,
+      show_ipv6_ospf6_database_adv_router_linkstate_id_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database adv-router A.B.C.D linkstate-id A.B.C.D [<detail|dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Search by Advertising Router\n"
+      "Specify Advertising Router as IPv4 address notation\n"
+      "Search by Link state ID\n"
+      "Specify Link state ID as IPv4 address notation\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_adv_rtr = 5;
 	int idx_ls_id = 7;
 	int idx_level = 8;
 	int level;
+	bool uj = use_json(argc, argv);
+	struct listnode *node;
+	struct ospf6 *ospf6;
 	uint32_t id = 0;
 	uint32_t adv_router = 0;
-	bool uj = use_json(argc, argv);
-	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_adv_rtr += 2;
+		idx_ls_id += 2;
+		idx_level += 2;
+	}
 	inet_pton(AF_INET, argv[idx_adv_rtr]->arg, &adv_router);
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
 	level = parse_show_level(idx_level, argc, argv);
 
-	ospf6_lsdb_show_wrapper(vty, level, NULL, &id, &adv_router, uj, ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_type_show_wrapper(vty, level, NULL, &id,
+						     &adv_router, uj, ospf6);
+
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_database_type_id_router,
-       show_ipv6_ospf6_database_type_id_router_cmd,
-       "show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> A.B.C.D A.B.C.D [<dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Display Router LSAs\n"
-       "Display Network LSAs\n"
-       "Display Inter-Area-Prefix LSAs\n"
-       "Display Inter-Area-Router LSAs\n"
-       "Display As-External LSAs\n"
-       "Display Group-Membership LSAs\n"
-       "Display Type-7 LSAs\n"
-       "Display Link LSAs\n"
-       "Display Intra-Area-Prefix LSAs\n"
-       "Specify Link state ID as IPv4 address notation\n"
-       "Specify Advertising Router as IPv4 address notation\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_type_id_router,
+      show_ipv6_ospf6_database_type_id_router_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> A.B.C.D A.B.C.D [<dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Display Router LSAs\n"
+      "Display Network LSAs\n"
+      "Display Inter-Area-Prefix LSAs\n"
+      "Display Inter-Area-Router LSAs\n"
+      "Display As-External LSAs\n"
+      "Display Group-Membership LSAs\n"
+      "Display Type-7 LSAs\n"
+      "Display Link LSAs\n"
+      "Display Intra-Area-Prefix LSAs\n"
+      "Specify Link state ID as IPv4 address notation\n"
+      "Specify Advertising Router as IPv4 address notation\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_lsa = 4;
 	int idx_ls_id = 5;
 	int idx_adv_rtr = 6;
 	int idx_level = 7;
 	int level;
+	bool uj = use_json(argc, argv);
+	struct listnode *node;
+	struct ospf6 *ospf6;
 	uint16_t type = 0;
 	uint32_t id = 0;
 	uint32_t adv_router = 0;
-	bool uj = use_json(argc, argv);
-	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
-
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_lsa += 2;
+		idx_ls_id += 2;
+		idx_adv_rtr += 2;
+		idx_level += 2;
+	}
 
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
 	inet_pton(AF_INET, argv[idx_adv_rtr]->arg, &adv_router);
 	level = parse_show_level(idx_level, argc, argv);
 
-	ospf6_lsdb_type_show_wrapper(vty, level, &type, &id, &adv_router, uj,
-				     ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_type_show_wrapper(vty, level, &type, &id,
+						     &adv_router, uj, ospf6);
+
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
@@ -803,208 +974,293 @@ DEFUN (show_ipv6_ospf6_database_type_adv_router_linkstate_id,
 	int idx_ls_id = 8;
 	int idx_level = 9;
 	int level;
+	bool uj = use_json(argc, argv);
+	struct listnode *node;
+	struct ospf6 *ospf6;
 	uint16_t type = 0;
 	uint32_t id = 0;
 	uint32_t adv_router = 0;
-	bool uj = use_json(argc, argv);
-	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
-
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_lsa += 2;
+		idx_adv_rtr += 2;
+		idx_ls_id += 2;
+		idx_level += 2;
+	}
 
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_adv_rtr]->arg, &adv_router);
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
 	level = parse_show_level(idx_level, argc, argv);
 
-	ospf6_lsdb_type_show_wrapper(vty, level, &type, &id, &adv_router, uj,
-				     ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_type_show_wrapper(vty, level, &type, &id,
+						     &adv_router, uj, ospf6);
+
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_database_self_originated,
-       show_ipv6_ospf6_database_self_originated_cmd,
-       "show ipv6 ospf6 database self-originated [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Display Self-originated LSAs\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_self_originated,
+      show_ipv6_ospf6_database_self_originated_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database self-originated [<detail|dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Display Self-originated LSAs\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_level = 5;
 	int level;
+	struct listnode *node;
+	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 	uint32_t adv_router = 0;
 	bool uj = use_json(argc, argv);
-	struct ospf6 *ospf6;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0)
+		idx_level += 2;
+
 	level = parse_show_level(idx_level, argc, argv);
-	adv_router = ospf6->router_id;
 
-	ospf6_lsdb_show_wrapper(vty, level, NULL, NULL, &adv_router, uj, ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		adv_router = ospf6->router_id;
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			ospf6_lsdb_show_wrapper(vty, level, NULL, NULL,
+						&adv_router, uj, ospf6);
+
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
 
-DEFUN (show_ipv6_ospf6_database_type_self_originated,
-       show_ipv6_ospf6_database_type_self_originated_cmd,
-       "show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> self-originated [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Display Router LSAs\n"
-       "Display Network LSAs\n"
-       "Display Inter-Area-Prefix LSAs\n"
-       "Display Inter-Area-Router LSAs\n"
-       "Display As-External LSAs\n"
-       "Display Group-Membership LSAs\n"
-       "Display Type-7 LSAs\n"
-       "Display Link LSAs\n"
-       "Display Intra-Area-Prefix LSAs\n"
-       "Display Self-originated LSAs\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_type_self_originated,
+      show_ipv6_ospf6_database_type_self_originated_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> self-originated [<detail|dump|internal>]  [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Display Router LSAs\n"
+      "Display Network LSAs\n"
+      "Display Inter-Area-Prefix LSAs\n"
+      "Display Inter-Area-Router LSAs\n"
+      "Display As-External LSAs\n"
+      "Display Group-Membership LSAs\n"
+      "Display Type-7 LSAs\n"
+      "Display Link LSAs\n"
+      "Display Intra-Area-Prefix LSAs\n"
+      "Display Self-originated LSAs\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_lsa = 4;
 	int idx_level = 6;
 	int level;
+	struct listnode *node;
+	struct ospf6 *ospf6;
 	uint16_t type = 0;
 	uint32_t adv_router = 0;
 	bool uj = use_json(argc, argv);
-	struct ospf6 *ospf6;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_lsa += 2;
+		idx_level += 2;
+	}
+
 	type = parse_type_spec(idx_lsa, argc, argv);
 	level = parse_show_level(idx_level, argc, argv);
 
-	adv_router = ospf6->router_id;
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			adv_router = ospf6->router_id;
+			ospf6_lsdb_type_show_wrapper(vty, level, &type, NULL,
+						     &adv_router, uj, ospf6);
 
-	ospf6_lsdb_type_show_wrapper(vty, level, &type, NULL, &adv_router, uj,
-				     ospf6);
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_database_type_self_originated_linkstate_id,
-       show_ipv6_ospf6_database_type_self_originated_linkstate_id_cmd,
-       "show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> self-originated linkstate-id A.B.C.D [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Display Router LSAs\n"
-       "Display Network LSAs\n"
-       "Display Inter-Area-Prefix LSAs\n"
-       "Display Inter-Area-Router LSAs\n"
-       "Display As-External LSAs\n"
-       "Display Group-Membership LSAs\n"
-       "Display Type-7 LSAs\n"
-       "Display Link LSAs\n"
-       "Display Intra-Area-Prefix LSAs\n"
-       "Display Self-originated LSAs\n"
-       "Search by Link state ID\n"
-       "Specify Link state ID as IPv4 address notation\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_type_self_originated_linkstate_id,
+      show_ipv6_ospf6_database_type_self_originated_linkstate_id_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> self-originated linkstate-id A.B.C.D [<detail|dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Display Router LSAs\n"
+      "Display Network LSAs\n"
+      "Display Inter-Area-Prefix LSAs\n"
+      "Display Inter-Area-Router LSAs\n"
+      "Display As-External LSAs\n"
+      "Display Group-Membership LSAs\n"
+      "Display Type-7 LSAs\n"
+      "Display Link LSAs\n"
+      "Display Intra-Area-Prefix LSAs\n"
+      "Display Self-originated LSAs\n"
+      "Search by Link state ID\n"
+      "Specify Link state ID as IPv4 address notation\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_lsa = 4;
 	int idx_ls_id = 7;
 	int idx_level = 8;
 	int level;
+	bool uj = use_json(argc, argv);
+	struct listnode *node;
+	struct ospf6 *ospf6;
 	uint16_t type = 0;
 	uint32_t adv_router = 0;
 	uint32_t id = 0;
-	bool uj = use_json(argc, argv);
-	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_lsa += 2;
+		idx_ls_id += 2;
+		idx_level += 2;
+	}
+
+
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
 	level = parse_show_level(idx_level, argc, argv);
-	adv_router = ospf6->router_id;
 
-	ospf6_lsdb_type_show_wrapper(vty, level, &type, &id, &adv_router, uj,
-				     ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			adv_router = ospf6->router_id;
+			ospf6_lsdb_type_show_wrapper(vty, level, &type, &id,
+						     &adv_router, uj, ospf6);
+
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_database_type_id_self_originated,
-       show_ipv6_ospf6_database_type_id_self_originated_cmd,
-       "show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> A.B.C.D self-originated [<detail|dump|internal>] [json]",
-       SHOW_STR
-       IPV6_STR
-       OSPF6_STR
-       "Display Link state database\n"
-       "Display Router LSAs\n"
-       "Display Network LSAs\n"
-       "Display Inter-Area-Prefix LSAs\n"
-       "Display Inter-Area-Router LSAs\n"
-       "Display As-External LSAs\n"
-       "Display Group-Membership LSAs\n"
-       "Display Type-7 LSAs\n"
-       "Display Link LSAs\n"
-       "Display Intra-Area-Prefix LSAs\n"
-       "Specify Link state ID as IPv4 address notation\n"
-       "Display Self-originated LSAs\n"
-       "Display details of LSAs\n"
-       "Dump LSAs\n"
-       "Display LSA's internal information\n"
-       JSON_STR)
+DEFUN(show_ipv6_ospf6_database_type_id_self_originated,
+      show_ipv6_ospf6_database_type_id_self_originated_cmd,
+      "show ipv6 ospf6  [vrf <NAME|all>] database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> A.B.C.D self-originated [<detail|dump|internal>] [json]",
+      SHOW_STR IPV6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display Link state database\n"
+      "Display Router LSAs\n"
+      "Display Network LSAs\n"
+      "Display Inter-Area-Prefix LSAs\n"
+      "Display Inter-Area-Router LSAs\n"
+      "Display As-External LSAs\n"
+      "Display Group-Membership LSAs\n"
+      "Display Type-7 LSAs\n"
+      "Display Link LSAs\n"
+      "Display Intra-Area-Prefix LSAs\n"
+      "Specify Link state ID as IPv4 address notation\n"
+      "Display Self-originated LSAs\n"
+      "Display details of LSAs\n"
+      "Dump LSAs\n"
+      "Display LSA's internal information\n" JSON_STR)
 {
 	int idx_lsa = 4;
 	int idx_ls_id = 5;
 	int idx_level = 7;
 	int level;
+	bool uj = use_json(argc, argv);
+	struct listnode *node;
+	struct ospf6 *ospf6;
 	uint16_t type = 0;
 	uint32_t adv_router = 0;
 	uint32_t id = 0;
-	bool uj = use_json(argc, argv);
-	struct ospf6 *ospf6;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_lsa += 2;
+		idx_ls_id += 2;
+		idx_level += 2;
+	}
+
 	type = parse_type_spec(idx_lsa, argc, argv);
 	inet_pton(AF_INET, argv[idx_ls_id]->arg, &id);
 	level = parse_show_level(idx_level, argc, argv);
-	adv_router = ospf6->router_id;
 
-	ospf6_lsdb_type_show_wrapper(vty, level, &type, &id, &adv_router, uj,
-				     ospf6);
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			adv_router = ospf6->router_id;
+			ospf6_lsdb_type_show_wrapper(vty, level, &type, &id,
+						     &adv_router, uj, ospf6);
+
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ipv6_ospf6_border_routers,
-       show_ipv6_ospf6_border_routers_cmd,
-       "show ipv6 ospf6 border-routers [<A.B.C.D|detail>]",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       "Display routing table for ABR and ASBR\n"
-       "Router ID\n"
-       "Show detailed output\n")
+static int show_ospf6_border_routers_common(struct vty *vty, int argc,
+					    struct cmd_token **argv,
+					    struct ospf6 *ospf6, int idx_ipv4,
+					    int idx_argc)
 {
-	int idx_ipv4 = 4;
 	uint32_t adv_router;
 	struct ospf6_route *ro;
 	struct prefix prefix;
-	struct ospf6 *ospf6 = NULL;
 
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
-	if (argc == 5) {
+	if (argc == idx_argc) {
 		if (strmatch(argv[idx_ipv4]->text, "detail")) {
 			for (ro = ospf6_route_head(ospf6->brouter_table); ro;
 			     ro = ospf6_route_next(ro))
@@ -1017,7 +1273,7 @@ DEFUN (show_ipv6_ospf6_border_routers,
 			if (!ro) {
 				vty_out(vty,
 					"No Route found for Router ID: %s\n",
-					argv[4]->arg);
+					argv[idx_ipv4]->arg);
 				return CMD_SUCCESS;
 			}
 
@@ -1035,62 +1291,134 @@ DEFUN (show_ipv6_ospf6_border_routers,
 	return CMD_SUCCESS;
 }
 
-
-DEFUN (show_ipv6_ospf6_linkstate,
-       show_ipv6_ospf6_linkstate_cmd,
-       "show ipv6 ospf6 linkstate <router A.B.C.D|network A.B.C.D A.B.C.D>",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       "Display linkstate routing table\n"
-       "Display Router Entry\n"
-       "Specify Router ID as IPv4 address notation\n"
-       "Display Network Entry\n"
-       "Specify Router ID as IPv4 address notation\n"
-       "Specify Link state ID as IPv4 address notation\n")
+DEFUN(show_ipv6_ospf6_border_routers, show_ipv6_ospf6_border_routers_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] border-routers [<A.B.C.D|detail>]",
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display routing table for ABR and ASBR\n"
+      "Router ID\n"
+      "Show detailed output\n")
 {
-	int idx_ipv4 = 5;
-	struct listnode *node;
-	struct ospf6_area *oa;
+	int idx_ipv4 = 4;
 	struct ospf6 *ospf6 = NULL;
+	struct listnode *node;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+	int idx_argc = 5;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
-	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
-		vty_out(vty, "\n        SPF Result in Area %s\n\n", oa->name);
-		ospf6_linkstate_table_show(vty, idx_ipv4, argc, argv,
-					   oa->spf_table);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0) {
+		idx_argc += 2;
+		idx_ipv4 += 2;
 	}
 
-	vty_out(vty, "\n");
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			show_ospf6_border_routers_common(vty, argc, argv, ospf6,
+							 idx_ipv4, idx_argc);
+
+			if (!all_vrf)
+				break;
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 
 
-DEFUN (show_ipv6_ospf6_linkstate_detail,
-       show_ipv6_ospf6_linkstate_detail_cmd,
-       "show ipv6 ospf6 linkstate detail",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       "Display linkstate routing table\n"
-       "Display detailed information\n")
+DEFUN(show_ipv6_ospf6_linkstate, show_ipv6_ospf6_linkstate_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] linkstate <router A.B.C.D|network A.B.C.D A.B.C.D>",
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display linkstate routing table\n"
+      "Display Router Entry\n"
+      "Specify Router ID as IPv4 address notation\n"
+      "Display Network Entry\n"
+      "Specify Router ID as IPv4 address notation\n"
+      "Specify Link state ID as IPv4 address notation\n")
+{
+	int idx_ipv4 = 5;
+	struct listnode *node, *nnode;
+	struct ospf6_area *oa;
+	struct ospf6 *ospf6 = NULL;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
+
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0)
+		idx_ipv4 += 2;
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, nnode, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
+				vty_out(vty,
+					"\n        SPF Result in Area %s\n\n",
+					oa->name);
+				ospf6_linkstate_table_show(vty, idx_ipv4, argc,
+							   argv, oa->spf_table);
+			}
+			vty_out(vty, "\n");
+
+			if (!all_vrf)
+				break;
+		}
+	}
+
+	return CMD_SUCCESS;
+}
+
+
+DEFUN(show_ipv6_ospf6_linkstate_detail, show_ipv6_ospf6_linkstate_detail_cmd,
+      "show ipv6 ospf6 [vrf <NAME|all>] linkstate detail",
+      SHOW_STR IP6_STR OSPF6_STR VRF_CMD_HELP_STR
+      "All VRFs\n"
+      "Display linkstate routing table\n"
+      "Display detailed information\n")
 {
 	int idx_detail = 4;
 	struct listnode *node;
 	struct ospf6_area *oa;
 	struct ospf6 *ospf6 = NULL;
+	char *vrf_name = NULL;
+	bool all_vrf = false;
+	int idx_vrf = 0;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
 
-	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
-		vty_out(vty, "\n        SPF Result in Area %s\n\n", oa->name);
-		ospf6_linkstate_table_show(vty, idx_detail, argc, argv,
-					   oa->spf_table);
+	OSPF6_CMD_CHECK_RUNNING();
+	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+	if (idx_vrf > 0)
+		idx_detail += 2;
+
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+		if (all_vrf
+		    || ((ospf6->name == NULL && vrf_name == NULL)
+			|| (ospf6->name && vrf_name
+			    && strcmp(ospf6->name, vrf_name) == 0))) {
+			for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
+				vty_out(vty,
+					"\n        SPF Result in Area %s\n\n",
+					oa->name);
+				ospf6_linkstate_table_show(vty, idx_detail,
+							   argc, argv,
+							   oa->spf_table);
+			}
+			vty_out(vty, "\n");
+
+			if (!all_vrf)
+				break;
+		}
 	}
 
-	vty_out(vty, "\n");
 	return CMD_SUCCESS;
 }
 

--- a/ospf6d/ospf6d.h
+++ b/ospf6d/ospf6d.h
@@ -89,13 +89,19 @@ extern struct thread_master *master;
 #define OSPF6_ROUTER_ID_STR "Specify Router-ID\n"
 #define OSPF6_LS_ID_STR     "Specify Link State ID\n"
 
-#define OSPF6_CMD_CHECK_RUNNING(ospf6)                                         \
-	if (ospf6 == NULL) {                                                   \
+#define OSPF6_CMD_CHECK_RUNNING()                                              \
+	if (om6->ospf6 == NULL) {                                              \
 		vty_out(vty, "OSPFv3 is not running\n");                       \
 		return CMD_SUCCESS;                                            \
 	}
 
 #define IS_OSPF6_ASBR(O) ((O)->flag & OSPF6_FLAG_ASBR)
+#define OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf)            \
+	if (argv_find(argv, argc, "vrf", &idx_vrf)) {                          \
+		vrf_name = argv[idx_vrf + 1]->arg;                             \
+		all_vrf = strmatch(vrf_name, "all");                           \
+	}
+
 extern struct zebra_privs_t ospf6d_privs;
 
 /* Function Prototypes */

--- a/tests/topotests/ospf6-topo1-vrf/README.md
+++ b/tests/topotests/ospf6-topo1-vrf/README.md
@@ -1,0 +1,132 @@
+# OSPFv3 (IPv6) Topology Test
+
+## Topology
+	                                                  -----\
+	  SW1 - Stub Net 1            SW2 - Stub Net 2          \
+	  fc00:1:1:1::/64             fc00:2:2:2::/64            \
+	\___________________/      \___________________/          |
+	          |                          |                    |
+	          |                          |                    |
+	          | ::1                      | ::2                |
+	+---------+---------+      +---------+---------+          |
+	|        R1         |      |        R2         |          |
+	|     FRRouting     |      |     FRRouting     |          |
+	| Rtr-ID: 10.0.0.1  |      | Rtr-ID: 10.0.0.2  |          |
+	+---------+---------+      +---------+---------+          |
+	          | ::1                      | ::2                 \
+	           \______        ___________/                      OSPFv3
+	                  \      /                               Area 0.0.0.0
+	                   \    /                                  /
+	             ~~~~~~~~~~~~~~~~~~                           |
+	           ~~       SW5        ~~                         |
+	         ~~       Switch         ~~                       |
+	           ~~  fc00:A:A:A::/64 ~~                         |
+	             ~~~~~~~~~~~~~~~~~~                           |
+	                     |                 /----              |
+	                     | ::3            | SW3 - Stub Net 3  | 
+	           +---------+---------+    /-+ fc00:3:3:3::/64   |
+	           |        R3         |   /  |                  /
+	           |     FRRouting     +--/    \----            /
+	           | Rtr-ID: 10.0.0.3  | ::3        ___________/
+	           +---------+---------+                       \
+	                     | ::3                              \
+	                     |                                   \
+	             ~~~~~~~~~~~~~~~~~~                           |
+	           ~~       SW6        ~~                         |
+	         ~~       Switch         ~~                       |
+	           ~~  fc00:B:B:B::/64 ~~                          \
+	             ~~~~~~~~~~~~~~~~~~                             OSPFv3
+	                     |                                   Area 0.0.0.1
+	                     | ::4                                 /
+	           +---------+---------+       /----              |
+	           |        R4         |      | SW4 - Stub Net 4  |
+	           |     FRRouting     +------+ fc00:4:4:4::/64   |
+	           | Rtr-ID: 10.0.0.4  | ::4  |                   /
+	           +-------------------+       \----             /
+	                                                   -----/
+
+## FRR Configuration
+
+Full config as used is in r1 / r2 / r3 / r4 / r5 subdirectories
+
+Simplified `R1` config (R1 is similar)
+
+	hostname r1
+	!
+	interface r1-stubnet vrf r1-cust1
+	 ipv6 address fc00:1:1:1::1/64
+	 ipv6 ospf6 network broadcast
+	!
+	interface r1-sw5 vrf r1-cust1
+	 ipv6 address fc00:a:a:a::1/64
+	 ipv6 ospf6 network broadcast
+	!
+	router ospf6 vrf r1-cust1
+	 router-id 10.0.0.1
+	 log-adjacency-changes detail
+	 redistribute static
+	 interface r1-stubnet area 0.0.0.0
+	 interface r1-sw5 area 0.0.0.0
+	!
+	ipv6 route fc00:1111:1111:1111::/64 fc00:1:1:1::1234 vrf r1-cust1
+
+Simplified `R3` config
+
+	hostname r3
+	!
+	interface r3-stubnet vrf r3-cust1
+	 ipv6 address fc00:3:3:3::3/64
+	 ipv6 ospf6 network broadcast
+	!
+	interface r3-sw5 vrf r3-cust1
+	 ipv6 address fc00:a:a:a::3/64
+	 ipv6 ospf6 network broadcast
+	!
+	interface r3-sw6 vrf r3-cust1
+	 ipv6 address fc00:b:b:b::3/64
+	 ipv6 ospf6 network broadcast
+	!
+	router ospf6 vrf r3-cust1
+	 router-id 10.0.0.3
+	 log-adjacency-changes detail
+	 redistribute static
+	 interface r3-stubnet area 0.0.0.0
+	 interface r3-sw5 area 0.0.0.0
+	 interface r3-sw6 area 0.0.0.1
+	!
+	ipv6 route fc00:3333:3333:3333::/64 fc00:3:3:3::1234 vrf r3-cust1
+
+## Tests executed
+
+### Check if FRR is running
+
+Test is executed by running 
+
+	vtysh -c "show logging" | grep "Logging configuration for"
+	
+on each FRR router. This should return the logging information for all daemons registered
+to Zebra and the list of running daemons is compared to the daemons started for this test (`zebra` and `ospf6d`)
+
+### Verify for OSPFv3 to converge
+
+OSPFv3 is expected to converge on each view within 60s total time. Convergence is verified by executing (on each node)
+
+	vtysh -c "show ipv6 ospf vrf r1-cust1 neigh"
+
+and checking for "Full" neighbor status in the output. An additional 15 seconds after the full converge is waited for routes to populate before the following routing table checks are executed
+
+### Verifying OSPFv3 Routing Tables
+
+Routing table is verified by running 
+
+	vtysh -c "show ipv6 route vrf r1-cust1"
+
+on each node and comparing the result to the stored example config (see `show_ipv6_route.ref` in r1 / r2 / r3 / r4 directories). Link-Local addresses are masked out before the compare.
+
+### Verifying Linux Kernel Routing Table
+
+Linux Kernel IPv6 Routing table is verified on each FRR node with
+
+	ip -6 route vrf r1-cust1
+
+Tables are compared with reference routing table (see `ip_6_address.ref` in r1 / r2 / r3 / r4 directories). Link-Local addresses are translated after getting collected on each node with interface name to make them consistent

--- a/tests/topotests/ospf6-topo1-vrf/r1/ip_6_address.nhg.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r1/ip_6_address.nhg.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 nhid XXXX via fc00:1:1:1::1234 dev r1-stubnet proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 dev r1-stubnet proto XXXX metric 256 pref medium
+fc00:2222:2222:2222::/64 nhid XXXX via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 nhid XXXX via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:4444:4444:4444::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r1-sw5 proto XXXX metric 256 pref medium
+fc00:b:b:b::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium

--- a/tests/topotests/ospf6-topo1-vrf/r1/ip_6_address.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r1/ip_6_address.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 via fc00:1:1:1::1234 dev r1-stubnet proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 dev r1-stubnet proto XXXX metric 256 pref medium
+fc00:2222:2222:2222::/64 via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:4444:4444:4444::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r1-sw5 proto XXXX metric 256 pref medium
+fc00:b:b:b::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium

--- a/tests/topotests/ospf6-topo1-vrf/r1/ospf6d.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r1/ospf6d.conf
@@ -1,0 +1,31 @@
+hostname r1
+log file ospf6d.log
+!
+debug ospf6 message all
+debug ospf6 lsa unknown
+debug ospf6 zebra
+debug ospf6 interface
+debug ospf6 neighbor
+debug ospf6 route table
+debug ospf6 flooding
+!
+interface r1-stubnet vrf r1-cust1
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+interface r1-sw5 vrf r1-cust1
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+router ospf6 vrf r1-cust1 
+ ospf6 router-id 10.0.0.1
+ log-adjacency-changes detail
+ redistribute static
+ interface r1-stubnet area 0.0.0.0
+ interface r1-sw5 area 0.0.0.0
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6-topo1-vrf/r1/show_ipv6_vrf_route.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r1/show_ipv6_vrf_route.ref
@@ -1,0 +1,9 @@
+O   fc00:1:1:1::/64 [110/10] is directly connected, r1-stubnet, weight 1, XX:XX:XX
+O>* fc00:2:2:2::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:3:3:3::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:4:4:4::/64 [110/30] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O   fc00:a:a:a::/64 [110/10] is directly connected, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:b:b:b::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:2222:2222:2222::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:3333:3333:3333::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:4444:4444:4444::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6-topo1-vrf/r1/zebra.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r1/zebra.conf
@@ -1,0 +1,20 @@
+!
+hostname r1
+log file zebra.log
+!
+debug zebra events
+debug zebra rib
+!
+interface r1-stubnet vrf r1-cust1
+ ipv6 address fc00:1:1:1::1/64
+!
+interface r1-sw5 vrf r1-cust1
+ ipv6 address fc00:a:a:a::1/64
+!
+interface lo
+!
+ipv6 route fc00:1111:1111:1111::/64 fc00:1:1:1::1234 vrf r1-cust1
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6-topo1-vrf/r2/ip_6_address.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r2/ip_6_address.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 via fe80::__(r1-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 via fe80::__(r1-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:2222:2222:2222::/64 via fc00:2:2:2::1234 dev r2-stubnet proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 dev r2-stubnet proto XXXX metric 256 pref medium
+fc00:3333:3333:3333::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:4444:4444:4444::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r2-sw5 proto XXXX metric 256 pref medium
+fc00:b:b:b::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium

--- a/tests/topotests/ospf6-topo1-vrf/r2/ospf6d.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r2/ospf6d.conf
@@ -1,0 +1,31 @@
+hostname r2
+log file ospf6d.log
+!
+debug ospf6 message all
+debug ospf6 lsa unknown
+debug ospf6 zebra
+debug ospf6 interface
+debug ospf6 neighbor
+debug ospf6 route table
+debug ospf6 flooding
+!
+interface r2-stubnet vrf r2-cust1
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 hello-interval 2
+!
+interface r2-sw5 vrf r2-cust1
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 hello-interval 2
+!
+router ospf6 vrf r2-cust1
+ ospf6 router-id 10.0.0.2
+ log-adjacency-changes detail
+ redistribute static
+ interface r2-stubnet area 0.0.0.0
+ interface r2-sw5 area 0.0.0.0
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6-topo1-vrf/r2/show_ipv6_vrf_route.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r2/show_ipv6_vrf_route.ref
@@ -1,0 +1,9 @@
+O>* fc00:1:1:1::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O   fc00:2:2:2::/64 [110/10] is directly connected, r2-stubnet, weight 1, XX:XX:XX
+O>* fc00:3:3:3::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:4:4:4::/64 [110/30] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O   fc00:a:a:a::/64 [110/10] is directly connected, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:b:b:b::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:1111:1111:1111::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:3333:3333:3333::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:4444:4444:4444::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6-topo1-vrf/r2/zebra.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r2/zebra.conf
@@ -1,0 +1,20 @@
+!
+hostname r2
+log file zebra.log
+!
+debug zebra events
+debug zebra rib
+!
+interface r2-stubnet vrf r2-cust1
+ ipv6 address fc00:2:2:2::2/64
+!
+interface r2-sw5 vrf r2-cust1
+ ipv6 address fc00:a:a:a::2/64
+!
+interface lo
+!
+ipv6 route fc00:2222:2222:2222::/64 fc00:2:2:2::1234 vrf r2-cust1
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6-topo1-vrf/r3/ip_6_address.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r3/ip_6_address.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 via fe80::__(r1-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 via fe80::__(r1-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:2222:2222:2222::/64 via fe80::__(r2-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 via fe80::__(r2-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 via fc00:3:3:3::1234 dev r3-stubnet proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 dev r3-stubnet proto XXXX metric 256 pref medium
+fc00:4444:4444:4444::/64 via fe80::__(r4-sw6)__ dev r3-sw6 proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 via fe80::__(r4-sw6)__ dev r3-sw6 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r3-sw5 proto XXXX metric 256 pref medium
+fc00:b:b:b::/64 dev r3-sw6 proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6-topo1-vrf/r3/ospf6d.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r3/ospf6d.conf
@@ -1,0 +1,37 @@
+hostname r3
+log file ospf6d.log
+!
+debug ospf6 message all
+debug ospf6 lsa unknown
+debug ospf6 zebra
+debug ospf6 interface
+debug ospf6 neighbor
+debug ospf6 route table
+debug ospf6 flooding
+!
+interface r3-stubnet vrf r3-cust1 
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 hello-interval 2
+!
+interface r3-sw5 vrf r3-cust1
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 hello-interval 2
+!
+interface r3-sw6 vrf r3-cust1
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 hello-interval 2
+!
+router ospf6 vrf r3-cust1
+ ospf6 router-id 10.0.0.3
+ log-adjacency-changes detail
+ redistribute static
+ interface r3-stubnet area 0.0.0.0
+ interface r3-sw5 area 0.0.0.0
+ interface r3-sw6 area 0.0.0.1
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6-topo1-vrf/r3/show_ipv6_vrf_route.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r3/show_ipv6_vrf_route.ref
@@ -1,0 +1,9 @@
+O>* fc00:1:1:1::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O>* fc00:2:2:2::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O   fc00:3:3:3::/64 [110/10] is directly connected, r3-stubnet, weight 1, XX:XX:XX
+O>* fc00:4:4:4::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw6, weight 1, XX:XX:XX
+O   fc00:a:a:a::/64 [110/10] is directly connected, r3-sw5, weight 1, XX:XX:XX
+O   fc00:b:b:b::/64 [110/10] is directly connected, r3-sw6, weight 1, XX:XX:XX
+O>* fc00:1111:1111:1111::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O>* fc00:2222:2222:2222::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O>* fc00:4444:4444:4444::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw6, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6-topo1-vrf/r3/zebra.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r3/zebra.conf
@@ -1,0 +1,23 @@
+!
+hostname r3
+log file zebra.log
+!
+debug zebra events
+debug zebra rib
+!
+interface r3-stubnet vrf r3-cust1 
+ ipv6 address fc00:3:3:3::3/64
+!
+interface r3-sw5 vrf r3-cust1
+ ipv6 address fc00:a:a:a::3/64
+!
+interface r3-sw6 vrf r3-cust1
+ ipv6 address fc00:b:b:b::3/64
+!
+interface lo
+!
+ipv6 route fc00:3333:3333:3333::/64 fc00:3:3:3::1234 vrf r3-cust1
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6-topo1-vrf/r4/ip_6_address.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r4/ip_6_address.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:2222:2222:2222::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:4444:4444:4444::/64 via fc00:4:4:4::1234 dev r4-stubnet proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 dev r4-stubnet proto XXXX metric 256 pref medium
+fc00:a:a:a::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:b:b:b::/64 dev r4-sw6 proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6-topo1-vrf/r4/ospf6d.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r4/ospf6d.conf
@@ -1,0 +1,27 @@
+hostname r4
+log file ospf6d.log
+!
+debug ospf6 message all
+debug ospf6 lsa unknown
+debug ospf6 zebra
+debug ospf6 interface
+debug ospf6 neighbor
+debug ospf6 route table
+debug ospf6 flooding
+!
+interface r4-stubnet vrf r4-cust1 
+ ipv6 ospf6 network broadcast
+!
+interface r4-sw6 vrf r4-cust1
+ ipv6 ospf6 network broadcast
+!
+router ospf6 vrf r4-cust1
+ ospf6 router-id 10.0.0.4
+ log-adjacency-changes detail
+ redistribute static
+ interface r4-stubnet area 0.0.0.1
+ interface r4-sw6 area 0.0.0.1
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6-topo1-vrf/r4/show_ipv6_vrf_route.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r4/show_ipv6_vrf_route.ref
@@ -1,0 +1,9 @@
+O>* fc00:1:1:1::/64 [110/30] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O>* fc00:2:2:2::/64 [110/30] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O>* fc00:3:3:3::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O   fc00:4:4:4::/64 [110/10] is directly connected, r4-stubnet, weight 1, XX:XX:XX
+O>* fc00:a:a:a::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O   fc00:b:b:b::/64 [110/10] is directly connected, r4-sw6, weight 1, XX:XX:XX
+O>* fc00:1111:1111:1111::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O>* fc00:2222:2222:2222::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O>* fc00:3333:3333:3333::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6-topo1-vrf/r4/zebra.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r4/zebra.conf
@@ -1,0 +1,20 @@
+!
+hostname r4
+log file zebra.log
+!
+debug zebra events
+debug zebra rib
+!
+interface r4-stubnet vrf r4-cust1 
+ ipv6 address fc00:4:4:4::4/64
+!
+interface r4-sw6 vrf r4-cust1
+ ipv6 address fc00:b:b:b::4/64
+!
+interface lo
+!
+ipv6 route fc00:4444:4444:4444::/64 fc00:4:4:4::1234 vrf r4-cust1
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6-topo1-vrf/test_ospf6_topo1_vrf.py
+++ b/tests/topotests/ospf6-topo1-vrf/test_ospf6_topo1_vrf.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python
+
+#
+# test_ospf6_topo1_vrf.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2021 by Niral Networks, Inc. ("Niral Networks")
+# Used Copyright (c) 2016 by Network Device Education Foundation, 
+# Inc. ("NetDEF") in this file.
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+test_ospf6_topo1_vrf.py:
+
+                                                  -----\
+  SW1 - Stub Net 1            SW2 - Stub Net 2          \
+  fc00:1:1:1::/64             fc00:2:2:2::/64            \
+\___________________/      \___________________/          |
+          |                          |                    |
+          |                          |                    |
+          | ::1                      | ::2                |
++---------+---------+      +---------+---------+          |
+|        R1         |      |        R2         |          |
+|     FRRouting     |      |     FRRouting     |          |
+| Rtr-ID: 10.0.0.1  |      | Rtr-ID: 10.0.0.2  |          |
++---------+---------+      +---------+---------+          |
+          | ::1                      | ::2                 \
+           \______        ___________/                      OSPFv3
+                  \      /                               Area 0.0.0.0
+                   \    /                                  /
+             ~~~~~~~~~~~~~~~~~~                           |
+           ~~       SW5        ~~                         |
+         ~~       Switch         ~~                       |
+           ~~  fc00:A:A:A::/64 ~~                         |
+             ~~~~~~~~~~~~~~~~~~                           |
+                     |                 /----              |
+                     | ::3            | SW3 - Stub Net 3  | 
+           +---------+---------+    /-+ fc00:3:3:3::/64   |
+           |        R3         |   /  |                  /
+           |     FRRouting     +--/    \----            /
+           | Rtr-ID: 10.0.0.3  | ::3        ___________/
+           +---------+---------+                       \
+                     | ::3                              \
+                     |                                   \
+             ~~~~~~~~~~~~~~~~~~                           |
+           ~~       SW6        ~~                         |
+         ~~       Switch         ~~                       |
+           ~~  fc00:B:B:B::/64 ~~                          \
+             ~~~~~~~~~~~~~~~~~~                             OSPFv3
+                     |                                   Area 0.0.0.1
+                     | ::4                                 /
+           +---------+---------+       /----              |
+           |        R4         |      | SW4 - Stub Net 4  |
+           |     FRRouting     +------+ fc00:4:4:4::/64   |
+           | Rtr-ID: 10.0.0.4  | ::4  |                   /
+           +-------------------+       \----             /
+                                                   -----/
+"""
+
+import os
+import re
+import sys
+import pytest
+import platform
+from time import sleep
+
+from functools import partial
+
+from mininet.topo import Topo
+from lib.topotest import iproute2_is_vrf_capable
+
+# Save the Current Working Directory to find configuration files later.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+import platform
+
+#####################################################
+##
+##   Network Topology Definition
+##
+#####################################################
+
+
+class NetworkTopo(Topo):
+    "OSPFv3 (IPv6) Test Topology 1"
+
+    def build(self, **_opts):
+        "Build function"
+
+        tgen = get_topogen(self)
+
+        # Create 4 routers
+        for routern in range(1, 5):
+            tgen.add_router("r{}".format(routern))
+
+        #
+        # Wire up the switches and routers
+        # Note that we specify the link names so we match the config files
+        #
+
+        # Create a empty network for router 1
+        switch = tgen.add_switch("s1")
+        switch.add_link(tgen.gears["r1"], nodeif="r1-stubnet")
+
+        # Create a empty network for router 2
+        switch = tgen.add_switch("s2")
+        switch.add_link(tgen.gears["r2"], nodeif="r2-stubnet")
+
+        # Create a empty network for router 3
+        switch = tgen.add_switch("s3")
+        switch.add_link(tgen.gears["r3"], nodeif="r3-stubnet")
+
+        # Create a empty network for router 4
+        switch = tgen.add_switch("s4")
+        switch.add_link(tgen.gears["r4"], nodeif="r4-stubnet")
+
+        # Interconnect routers 1, 2, and 3
+        switch = tgen.add_switch("s5")
+        switch.add_link(tgen.gears["r1"], nodeif="r1-sw5")
+        switch.add_link(tgen.gears["r2"], nodeif="r2-sw5")
+        switch.add_link(tgen.gears["r3"], nodeif="r3-sw5")
+
+        # Interconnect routers 3 and 4
+        switch = tgen.add_switch("s6")
+        switch.add_link(tgen.gears["r3"], nodeif="r3-sw6")
+        switch.add_link(tgen.gears["r4"], nodeif="r4-sw6")
+
+
+#####################################################
+##
+##   Tests starting
+##
+#####################################################
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+
+    tgen = Topogen(NetworkTopo, mod.__name__)
+    tgen.start_topology()
+
+    logger.info("** %s: Setup Topology" % mod.__name__)
+    logger.info("******************************************")
+
+    # For debugging after starting net, but before starting FRR,
+    # uncomment the next line
+    # tgen.mininet_cli()
+
+    router_list = tgen.routers()
+    logger.info("Testing with VRF Lite support")
+    krel = platform.release()
+
+    # May need to adjust handling of vrf traffic depending on kernel version
+    l3mdev_accept = 0
+    if (
+        topotest.version_cmp(krel, "4.15") >= 0
+        and topotest.version_cmp(krel, "4.18") <= 0
+    ):
+        l3mdev_accept = 1
+
+    if topotest.version_cmp(krel, "5.0") >= 0:
+        l3mdev_accept = 1
+
+    logger.info(
+        "krel '{0}' setting net.ipv6.tcp_l3mdev_accept={1}".format(krel, l3mdev_accept)
+    )
+
+    cmds = [
+        "ip link add {0}-cust1 type vrf table 1001",
+        "ip link add loop1 type dummy",
+        "ip link set {0}-stubnet master {0}-cust1",
+    ]
+
+    cmds1 = [
+        "ip link set {0}-sw5 master {0}-cust1",
+    ]
+
+    cmds2 = [
+        "ip link set {0}-sw6 master {0}-cust1",
+    ]
+
+    # For all registered routers, load the zebra configuration file
+    for rname, router in router_list.iteritems():
+        # create VRF rx-cust1 and link rx-eth0 to rx-cust1
+        for cmd in cmds:
+            output = tgen.net[rname].cmd(cmd.format(rname))
+        if rname == "r1" or rname == "r2" or rname == "r3":
+            for cmd in cmds1:
+                output = tgen.net[rname].cmd(cmd.format(rname))
+        if rname == "r3" or rname == "r4":
+            for cmd in cmds2:
+                output = tgen.net[rname].cmd(cmd.format(rname))
+
+        output = tgen.net[rname].cmd("sysctl -n net.ipv4.tcp_l3mdev_accept")
+        logger.info(
+            "router {0}: existing tcp_l3mdev_accept was {1}".format(rname, output)
+        )
+
+        if l3mdev_accept:
+            output = tgen.net[rname].cmd(
+                "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept)
+            )
+
+   
+    for rname, router in router_list.iteritems():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_OSPF6, os.path.join(CWD, "{}/ospf6d.conf".format(rname))
+        )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+    # For debugging after starting FRR daemons, uncomment the next line
+    # tgen.mininet_cli()
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_wait_protocol_convergence():
+    "Wait for OSPFv3 to converge"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for protocols to converge")
+
+    def expect_neighbor_full(router, neighbor):
+        "Wait until OSPFv3 convergence."
+        logger.info("waiting OSPFv3 router '{}'".format(router))
+        test_func = partial(
+            topotest.router_json_cmp,
+            tgen.gears[router],
+            "show ipv6 ospf6 vrf {0}-cust1 neighbor json".format(router),
+            {"neighbors": [{"neighborId": neighbor, "state": "Full"}]},
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=130, wait=1)
+        assertmsg = '"{}" convergence failure'.format(router)
+        assert result is None, assertmsg
+
+    expect_neighbor_full("r1", "10.0.0.2")
+    expect_neighbor_full("r1", "10.0.0.3")
+
+    expect_neighbor_full("r2", "10.0.0.1")
+    expect_neighbor_full("r2", "10.0.0.3")
+
+    expect_neighbor_full("r3", "10.0.0.1")
+    expect_neighbor_full("r3", "10.0.0.2")
+    expect_neighbor_full("r3", "10.0.0.4")
+
+
+def compare_show_ipv6_vrf(rname, expected):
+    """
+    Calls 'show ipv6 route' for router `rname` and compare the obtained
+    result with the expected output.
+    """
+    tgen = get_topogen()
+
+    # Use the vtysh output, with some masking to make comparison easy
+    vrf_name = "{0}-cust1".format(rname)
+    current = topotest.ip6_route_zebra(tgen.gears[rname], vrf_name)
+    
+    # Use just the 'O'spf lines of the output
+    linearr = []
+    for line in current.splitlines():
+        if re.match("^O", line):
+            linearr.append(line)
+
+    current = "\n".join(linearr)
+
+    return topotest.difflines(
+        topotest.normalize_text(current),
+        topotest.normalize_text(expected),
+        title1="Current output",
+        title2="Expected output",
+    )
+
+
+def test_ospfv3_routingTable():
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # For debugging, uncomment the next line
+    # tgen.mininet_cli()
+    # Verify OSPFv3 Routing Table
+    for router, rnode in tgen.routers().iteritems():
+        logger.info('Waiting for router "%s" convergence', router)
+
+        # Load expected results from the command
+        reffile = os.path.join(CWD, "{}/show_ipv6_vrf_route.ref".format(router))
+        expected = open(reffile).read()
+
+        # Run test function until we get an result. Wait at most 60 seconds.
+        test_func = partial(compare_show_ipv6_vrf, router, expected)
+        result, diff = topotest.run_and_expect(test_func, "", count=120, wait=0.5)
+        assert result, "OSPFv3 did not converge on {}:\n{}".format(router, diff)
+
+
+def test_linux_ipv6_kernel_routingTable():
+
+    if not iproute2_is_vrf_capable():
+        pytest.skip("Installed iproute2 version does not support VRFs")
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # Verify Linux Kernel Routing Table
+    logger.info("Verifying Linux IPv6 Kernel Routing Table")
+
+    failures = 0
+
+    # Get a list of all current link-local addresses first as they change for
+    # each run and we need to translate them
+    linklocals = []
+    for i in range(1, 5):
+        linklocals += tgen.net["r{}".format(i)].get_ipv6_linklocal()
+
+    # Now compare the routing tables (after substituting link-local addresses)
+
+    for i in range(1, 5):
+        # Actual output from router
+        actual = tgen.gears["r{}".format(i)].run("ip -6 route show vrf r{}-cust1".format(i)).rstrip()
+        if "nhid" in actual:
+            refTableFile = os.path.join(CWD, "r{}/ip_6_address.nhg.ref".format(i))
+        else:
+            refTableFile = os.path.join(CWD, "r{}/ip_6_address.ref".format(i))
+
+        if os.path.isfile(refTableFile):
+            expected = open(refTableFile).read().rstrip()
+            # Fix newlines (make them all the same)
+            expected = ("\n".join(expected.splitlines())).splitlines(1)
+
+            # Mask out Link-Local mac addresses
+            for ll in linklocals:
+                actual = actual.replace(ll[1], "fe80::__(%s)__" % ll[0])
+            # Mask out protocol name or number
+            actual = re.sub(r"[ ]+proto [0-9a-z]+ +", "  proto XXXX ", actual)
+            actual = re.sub(r"[ ]+nhid [0-9]+ +", " nhid XXXX ", actual)
+            # Remove ff00::/8 routes (seen on some kernels - not from FRR)
+            actual = re.sub(r"ff00::/8.*", "", actual)
+
+            # Strip empty lines
+            actual = actual.lstrip()
+            actual = actual.rstrip()
+            actual = re.sub(r"  +", " ", actual)
+
+            filtered_lines = []
+            for line in sorted(actual.splitlines()):
+                if line.startswith("fe80::/64 ") or line.startswith(
+                    "unreachable fe80::/64 "
+                ):
+                    continue
+                if 'anycast' in line:
+                    continue
+                filtered_lines.append(line)
+            actual = "\n".join(filtered_lines).splitlines(1)
+
+            # Print Actual table
+            # logger.info("Router r%s table" % i)
+            # for line in actual:
+            #     logger.info(line.rstrip())
+
+            # Generate Diff
+            diff = topotest.get_textdiff(
+                actual,
+                expected,
+                title1="actual OSPFv3 IPv6 routing table",
+                title2="expected OSPFv3 IPv6 routing table",
+            )
+
+            # Empty string if it matches, otherwise diff contains unified diff
+            if diff:
+                sys.stderr.write(
+                    "r%s failed Linux IPv6 Kernel Routing Table Check:\n%s\n"
+                    % (i, diff)
+                )
+                failures += 1
+            else:
+                logger.info("r%s ok" % i)
+
+            assert failures == 0, (
+                "Linux Kernel IPv6 Routing Table verification failed for router r%s:\n%s"
+                % (i, diff)
+            )
+
+
+def test_shutdown_check_stderr():
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    if os.environ.get("TOPOTESTS_CHECK_STDERR") is None:
+        logger.info(
+            "SKIPPED final check on StdErr output: Disabled (TOPOTESTS_CHECK_STDERR undefined)\n"
+        )
+        pytest.skip("Skipping test for Stderr output")
+
+    net = tgen.net
+
+    logger.info("\n\n** Verifying unexpected STDERR output from daemons")
+    logger.info("******************************************")
+
+    for i in range(1, 5):
+        net["r%s" % i].stopRouter()
+        log = net["r%s" % i].getStdErr("ospf6d")
+        if log:
+            logger.info("\nRouter r%s OSPF6d StdErr Log:\n%s" % (i, log))
+        log = net["r%s" % i].getStdErr("zebra")
+        if log:
+            logger.info("\nRouter r%s Zebra StdErr Log:\n%s" % (i, log))
+
+
+def test_shutdown_check_memleak():
+    "Run the memory leak test and report results."
+
+    if os.environ.get("TOPOTESTS_CHECK_MEMLEAK") is None:
+        logger.info(
+            "SKIPPED final check on Memory leaks: Disabled (TOPOTESTS_CHECK_MEMLEAK undefined)"
+        )
+        pytest.skip("Skipping test for memory leaks")
+
+    tgen = get_topogen()
+
+    net = tgen.net
+
+    for i in range(1, 5):
+        net["r%s" % i].stopRouter()
+        net["r%s" % i].report_memory_leaks(
+            os.environ.get("TOPOTESTS_CHECK_MEMLEAK"), os.path.basename(__file__)
+        )
+
+
+if __name__ == "__main__":
+
+    # To suppress tracebacks, either use the following pytest call or
+    # add "--tb=no" to cli
+    # retval = pytest.main(["-s", "--tb=no"])
+
+    retval = pytest.main(["-s"])
+    sys.exit(retval)

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1976,8 +1976,8 @@ DEFUNSH(VTYSH_BABELD, router_babel, router_babel_cmd, "router babel",
 #endif /* HAVE_BABELD */
 
 #ifdef HAVE_OSPF6D
-DEFUNSH(VTYSH_OSPF6D, router_ospf6, router_ospf6_cmd, "router ospf6",
-	ROUTER_STR OSPF6_STR)
+DEFUNSH(VTYSH_OSPF6D, router_ospf6, router_ospf6_cmd, "router ospf6 [vrf NAME]",
+	ROUTER_STR OSPF6_STR VRF_CMD_HELP_STR)
 {
 	vty->node = OSPF6_NODE;
 	return CMD_SUCCESS;


### PR DESCRIPTION
1. ospfv3 support with different vrf.
2. topotest added for ospfv3 vrf.

Co-authored-by: Kaushik Nath <kaushiknath.null@gmail.com>
Signed-off-by: harios_niral <hari@niralnetworks.com>