### PR TITLE
bgpd: Use bgp master flags for send extra data to zebra

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1616,7 +1616,10 @@ DEFPY (no_bgp_send_extra_data,
        "Extra data to Zebra for display/use\n"
        "To zebra\n")
 {
-	bgp_option_send_extra_data(!!no);
+	if (no)
+		UNSET_FLAG(bm->flags, BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA);
+	else
+		SET_FLAG(bm->flags, BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA);
 
 	return CMD_SUCCESS;
 }
@@ -16958,7 +16961,7 @@ int bgp_config_write(struct vty *vty)
 	if (bgp_option_check(BGP_OPT_NO_FIB))
 		vty_out(vty, "bgp no-rib\n");
 
-	if (bm->send_extra_data_to_zebra)
+	if (!CHECK_FLAG(bm->flags, BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA))
 		vty_out(vty, "no bgp send-extra-data zebra\n");
 
 	/* BGP configuration. */

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1410,7 +1410,7 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 
 	is_add = (valid_nh_count || nhg_id) ? true : false;
 
-	if (is_add && bm->send_extra_data_to_zebra) {
+	if (is_add && CHECK_FLAG(bm->flags, BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA)) {
 		struct aspath *aspath = info->attr->aspath;
 
 		SET_FLAG(api.message, ZAPI_MESSAGE_OPAQUE);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7418,11 +7418,6 @@ char *peer_uptime(time_t uptime2, char *buf, size_t len, bool use_json,
 	return buf;
 }
 
-void bgp_option_send_extra_data(bool send)
-{
-	bm->send_extra_data_to_zebra = send;
-}
-
 void bgp_master_init(struct thread_master *master, const int buffer_size)
 {
 	qobj_init();
@@ -7441,8 +7436,9 @@ void bgp_master_init(struct thread_master *master, const int buffer_size)
 	bm->v_establish_wait = BGP_UPDATE_DELAY_DEF;
 	bm->terminating = false;
 	bm->socket_buffer = buffer_size;
-	bm->send_extra_data_to_zebra = true;
 	bm->wait_for_fib = false;
+
+	SET_FLAG(bm->flags, BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA);
 
 	bgp_mac_init();
 	/* init the rd id space.

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -171,9 +171,7 @@ struct bgp_master {
 
 	uint32_t flags;
 #define BM_FLAG_GRACEFUL_SHUTDOWN        (1 << 0)
-
-	/* Send extra data to zebra like aspath */
-	bool send_extra_data_to_zebra;
+#define BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA (1 << 1)
 
 	bool terminating;	/* global flag that sigint terminate seen */
 	QOBJ_FIELDS
@@ -2253,8 +2251,6 @@ static inline bool bgp_in_graceful_shutdown(struct bgp *bgp)
 }
 
 extern void bgp_unset_redist_vrf_bitmaps(struct bgp *, vrf_id_t);
-
-extern void bgp_option_send_extra_data(bool send);
 
 /* For benefit of rfapi */
 extern struct peer *peer_new(struct bgp *bgp);


### PR DESCRIPTION
```
root@exit1-debian-9:~/frr# vtysh -c 'conf' -c 'bgp send-extra-data zebra'
root@exit1-debian-9:~/frr# vtysh -c 'show run' | grep send-extra
root@exit1-debian-9:~/frr# vtysh -c 'conf' -c 'no bgp send-extra-data zebra'
root@exit1-debian-9:~/frr# vtysh -c 'show run' | grep send-extra
no bgp send-extra-data zebra
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>