### PR TITLE
pimd: correcting the  definition for  Mroute flag "R"

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5858,7 +5858,7 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 		vty_out(vty, "IP Multicast Routing Table\n");
 		vty_out(vty, "Flags: S - Sparse, C - Connected, P - Pruned\n");
 		vty_out(vty,
-			"       R - RP-bit set, F - Register flag, T - SPT-bit set\n");
+			"       R - SGRpt Pruned, F - Register flag, T - SPT-bit set\n");
 		vty_out(vty,
 			"\nSource          Group           Flags   Proto  Input            Output           TTL  Uptime\n");
 	}


### PR DESCRIPTION
The flag "R" in below display description denotes the
SGRpt Pruned but the description shows something else
hence correcting the definition.

R2(config)# do show ip mroute
IP Multicast Routing Table
Flags: S- Sparse, C - Connected, P - Pruned
R - RP-bit set, F - Register flag

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>