### PR TITLE
End configuration changes

### DIFF
--- a/lib/lib_vty.c
+++ b/lib/lib_vty.c
@@ -222,7 +222,7 @@ static struct call_back {
 
 DEFUN_HIDDEN (start_config,
 	      start_config_cmd,
-	      "start_configuration",
+	      "XFRR_start_configuration",
 	      "The Beginning of Configuration\n")
 {
 	callback.readin_time = monotime(NULL);
@@ -235,7 +235,7 @@ DEFUN_HIDDEN (start_config,
 
 DEFUN_HIDDEN (end_config,
 	      end_config_cmd,
-	      "end_configuration",
+	      "XFRR_end_configuration",
 	      "The End of Configuration\n")
 {
 	time_t readin_time;

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3187,7 +3187,7 @@ DEFUN (vtysh_copy_to_running,
 	int ret;
 	const char *fname = argv[1]->arg;
 
-	ret = vtysh_read_config(fname);
+	ret = vtysh_read_config(fname, true);
 
 	/* Return to enable mode - the 'read_config' api leaves us up a level */
 	vtysh_execute_no_pager("enable");

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -92,7 +92,7 @@ void config_add_line(struct list *, const char *);
 
 int vtysh_mark_file(const char *filename);
 
-int vtysh_read_config(const char *);
+int vtysh_read_config(const char *filename, bool dry_run);
 int vtysh_write_config_integrated(void);
 
 void vtysh_config_parse_line(void *, const char *);

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -528,12 +528,12 @@ static int vtysh_read_file(FILE *confp)
 	vtysh_execute_no_pager("enable");
 	vtysh_execute_no_pager("configure terminal");
 
-	vtysh_execute_no_pager("start_configuration");
+	vtysh_execute_no_pager("XFRR_start_configuration");
 
 	/* Execute configuration file. */
 	ret = vtysh_config_from_file(vty, confp);
 
-	vtysh_execute_no_pager("end_configuration");
+	vtysh_execute_no_pager("XFRR_end_configuration");
 
 	vtysh_execute_no_pager("end");
 	vtysh_execute_no_pager("disable");

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -515,7 +515,7 @@ void vtysh_config_dump(void)
 }
 
 /* Read up configuration file from file_name. */
-static int vtysh_read_file(FILE *confp)
+static int vtysh_read_file(FILE *confp, bool dry_run)
 {
 	struct vty *vty;
 	int ret;
@@ -528,12 +528,14 @@ static int vtysh_read_file(FILE *confp)
 	vtysh_execute_no_pager("enable");
 	vtysh_execute_no_pager("configure terminal");
 
-	vtysh_execute_no_pager("XFRR_start_configuration");
+	if (!dry_run)
+		vtysh_execute_no_pager("XFRR_start_configuration");
 
 	/* Execute configuration file. */
 	ret = vtysh_config_from_file(vty, confp);
 
-	vtysh_execute_no_pager("XFRR_end_configuration");
+	if (!dry_run)
+		vtysh_execute_no_pager("XFRR_end_configuration");
 
 	vtysh_execute_no_pager("end");
 	vtysh_execute_no_pager("disable");
@@ -544,7 +546,7 @@ static int vtysh_read_file(FILE *confp)
 }
 
 /* Read up configuration file from config_default_dir. */
-int vtysh_read_config(const char *config_default_dir)
+int vtysh_read_config(const char *config_default_dir, bool dry_run)
 {
 	FILE *confp = NULL;
 	int ret;
@@ -557,7 +559,7 @@ int vtysh_read_config(const char *config_default_dir)
 		return CMD_ERR_NO_FILE;
 	}
 
-	ret = vtysh_read_file(confp);
+	ret = vtysh_read_file(confp, dry_run);
 	fclose(confp);
 
 	return (ret);

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -459,7 +459,7 @@ int main(int argc, char **argv, char **env)
 		/* Read vtysh configuration file before connecting to daemons.
 		 * (file may not be readable to calling user in SUID mode) */
 		suid_on();
-		vtysh_read_config(vtysh_config);
+		vtysh_read_config(vtysh_config, dryrun);
 		suid_off();
 	}
 	/* Error code library system */
@@ -478,9 +478,9 @@ int main(int argc, char **argv, char **env)
 	/* Start execution only if not in dry-run mode */
 	if (dryrun && !cmd) {
 		if (inputfile) {
-			ret = vtysh_read_config(inputfile);
+			ret = vtysh_read_config(inputfile, dryrun);
 		} else {
-			ret = vtysh_read_config(frr_config);
+			ret = vtysh_read_config(frr_config, dryrun);
 		}
 
 		exit(ret);
@@ -561,7 +561,7 @@ int main(int argc, char **argv, char **env)
 
 	if (inputfile) {
 		vtysh_flock_config(inputfile);
-		ret = vtysh_read_config(inputfile);
+		ret = vtysh_read_config(inputfile, dryrun);
 		vtysh_unflock_config();
 		exit(ret);
 	}
@@ -670,7 +670,7 @@ int main(int argc, char **argv, char **env)
 	/* Boot startup configuration file. */
 	if (boot_flag) {
 		vtysh_flock_config(frr_config);
-		ret = vtysh_read_config(frr_config);
+		ret = vtysh_read_config(frr_config, dryrun);
 		vtysh_unflock_config();
 		if (ret) {
 			fprintf(stderr,


### PR DESCRIPTION
See individual commits

a) Move end_configuration to a completely different hidden name to remove small chance of accidental typing the hidden command
b) Remove the start/end send points when doing dry runs