### PR TITLE
zebra: FPM should not send system routes to remote end

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -703,6 +703,9 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	switch (op) {
 	case DPLANE_OP_ROUTE_UPDATE:
 	case DPLANE_OP_ROUTE_DELETE:
+		if (RSYSTEM_ROUTE(dplane_ctx_get_type(ctx)))
+			break;
+
 		rv = netlink_route_multipath_msg_encode(RTM_DELROUTE, ctx,
 							nl_buf, sizeof(nl_buf),
 							true, fnc->use_nhg);
@@ -721,6 +724,9 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 
 		/* FALL THROUGH */
 	case DPLANE_OP_ROUTE_INSTALL:
+		if (RSYSTEM_ROUTE(dplane_ctx_get_type(ctx)))
+			break;
+
 		rv = netlink_route_multipath_msg_encode(
 			RTM_NEWROUTE, ctx, &nl_buf[nl_buf_len],
 			sizeof(nl_buf) - nl_buf_len, true, fnc->use_nhg);

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -166,6 +166,11 @@ struct route_entry {
 	struct opaque *opaque;
 };
 
+#define RKERNEL_ROUTE(type) ((type) == ZEBRA_ROUTE_KERNEL)
+
+#define RSYSTEM_ROUTE(type)                                                    \
+	((RKERNEL_ROUTE(type)) || (type) == ZEBRA_ROUTE_CONNECT)
+
 #define RIB_SYSTEM_ROUTE(R) RSYSTEM_ROUTE((R)->type)
 
 #define RIB_KERNEL_ROUTE(R) RKERNEL_ROUTE((R)->type)

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1452,6 +1452,12 @@ static int zfpm_trigger_update(struct route_node *rn, const char *reason)
 		return 0;
 	}
 
+	if (dest->selected_fib && RIB_SYSTEM_ROUTE(dest->selected_fib)) {
+		zfpm_debug("%pRN Skipping update for System Route", rn);
+		zfpm_g->stats.redundant_triggers++;
+		return 0;
+	}
+
 	if (reason) {
 		zfpm_debug("%pFX triggering update to FPM - Reason: %s", &rn->p,
 			   reason);


### PR DESCRIPTION
A while back in order to make system routes behave more
naturaly in FRR, zebra was modified to attempt to send
the system route changes to the underlying data plane.
The underlying linux and *bsd data planes were modified
to safely ignore these routes, but the fpm's were not.

Modify those to not send these route changes down either

Signed-off-by: Donald Sharp <sharpd@nvidia.com>