### PR TITLE
bgpd: reject malformed large-communities

### DIFF
--- a/bgpd/bgp_clist.h
+++ b/bgpd/bgp_clist.h
@@ -154,6 +154,7 @@ extern int extcommunity_list_unset(struct community_list_handler *ch,
 extern int lcommunity_list_set(struct community_list_handler *ch,
 			       const char *name, const char *str,
 			       const char *seq, int direct, int style);
+extern bool lcommunity_list_valid(const char *community, int style);
 extern int lcommunity_list_unset(struct community_list_handler *ch,
 				 const char *name, const char *str,
 				 const char *seq, int direct, int style);

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -348,16 +348,12 @@ void lcommunity_finish(void)
 	lcomhash = NULL;
 }
 
-/* Large Communities token enum. */
-enum lcommunity_token {
-	lcommunity_token_unknown = 0,
-	lcommunity_token_val,
-};
-
-/* Get next Large Communities token from the string. */
+/* Get next Large Communities token from the string.
+ * Assumes str is space-delimeted and describes 0 or more
+ * valid large communities
+ */
 static const char *lcommunity_gettoken(const char *str,
-				       struct lcommunity_val *lval,
-				       enum lcommunity_token *token)
+				       struct lcommunity_val *lval)
 {
 	const char *p = str;
 
@@ -372,60 +368,55 @@ static const char *lcommunity_gettoken(const char *str,
 		return NULL;
 
 	/* Community value. */
-	if (isdigit((unsigned char)*p)) {
-		int separator = 0;
-		int digit = 0;
-		uint32_t globaladmin = 0;
-		uint32_t localdata1 = 0;
-		uint32_t localdata2 = 0;
+	int separator = 0;
+	int digit = 0;
+	uint32_t globaladmin = 0;
+	uint32_t localdata1 = 0;
+	uint32_t localdata2 = 0;
 
-		while (isdigit((unsigned char)*p) || *p == ':') {
-			if (*p == ':') {
-				if (separator == 2) {
-					*token = lcommunity_token_unknown;
-					return NULL;
-				} else {
-					separator++;
-					digit = 0;
-					if (separator == 1) {
-						globaladmin = localdata2;
-					} else {
-						localdata1 = localdata2;
-					}
-					localdata2 = 0;
-				}
+	while (*p && *p != ' ') {
+		/* large community valid chars */
+		assert(isdigit((unsigned char)*p) || *p == ':');
+
+		if (*p == ':') {
+			separator++;
+			digit = 0;
+			if (separator == 1) {
+				globaladmin = localdata2;
 			} else {
-				digit = 1;
-				localdata2 *= 10;
-				localdata2 += (*p - '0');
+				localdata1 = localdata2;
 			}
-			p++;
+			localdata2 = 0;
+		} else {
+			digit = 1;
+			/* left shift the accumulated value and add current
+			 * digit
+			 */
+			localdata2 *= 10;
+			localdata2 += (*p - '0');
 		}
-		if (!digit) {
-			*token = lcommunity_token_unknown;
-			return NULL;
-		}
-
-		/*
-		 * Copy the large comm.
-		 */
-		lval->val[0] = (globaladmin >> 24) & 0xff;
-		lval->val[1] = (globaladmin >> 16) & 0xff;
-		lval->val[2] = (globaladmin >> 8) & 0xff;
-		lval->val[3] = globaladmin & 0xff;
-		lval->val[4] = (localdata1 >> 24) & 0xff;
-		lval->val[5] = (localdata1 >> 16) & 0xff;
-		lval->val[6] = (localdata1 >> 8) & 0xff;
-		lval->val[7] = localdata1 & 0xff;
-		lval->val[8] = (localdata2 >> 24) & 0xff;
-		lval->val[9] = (localdata2 >> 16) & 0xff;
-		lval->val[10] = (localdata2 >> 8) & 0xff;
-		lval->val[11] = localdata2 & 0xff;
-
-		*token = lcommunity_token_val;
-		return p;
+		p++;
 	}
-	*token = lcommunity_token_unknown;
+
+	/* Assert str was a valid large community */
+	assert(separator == 2 && digit == 1);
+
+	/*
+	 * Copy the large comm.
+	 */
+	lval->val[0] = (globaladmin >> 24) & 0xff;
+	lval->val[1] = (globaladmin >> 16) & 0xff;
+	lval->val[2] = (globaladmin >> 8) & 0xff;
+	lval->val[3] = globaladmin & 0xff;
+	lval->val[4] = (localdata1 >> 24) & 0xff;
+	lval->val[5] = (localdata1 >> 16) & 0xff;
+	lval->val[6] = (localdata1 >> 8) & 0xff;
+	lval->val[7] = localdata1 & 0xff;
+	lval->val[8] = (localdata2 >> 24) & 0xff;
+	lval->val[9] = (localdata2 >> 16) & 0xff;
+	lval->val[10] = (localdata2 >> 8) & 0xff;
+	lval->val[11] = localdata2 & 0xff;
+
 	return p;
 }
 
@@ -439,23 +430,16 @@ static const char *lcommunity_gettoken(const char *str,
 struct lcommunity *lcommunity_str2com(const char *str)
 {
 	struct lcommunity *lcom = NULL;
-	enum lcommunity_token token = lcommunity_token_unknown;
 	struct lcommunity_val lval;
 
+	if (!lcommunity_list_valid(str, LARGE_COMMUNITY_LIST_STANDARD))
+		return NULL;
+
 	do {
-		str = lcommunity_gettoken(str, &lval, &token);
-		switch (token) {
-		case lcommunity_token_val:
-			if (lcom == NULL)
-				lcom = lcommunity_new();
-			lcommunity_add_val(lcom, &lval);
-			break;
-		case lcommunity_token_unknown:
-		default:
-			if (lcom)
-				lcommunity_free(&lcom);
-			return NULL;
-		}
+		str = lcommunity_gettoken(str, &lval);
+		if (lcom == NULL)
+			lcom = lcommunity_new();
+		lcommunity_add_val(lcom, &lval);
 	} while (str);
 
 	return lcom;

--- a/bgpd/bgp_lcommunity.h
+++ b/bgpd/bgp_lcommunity.h
@@ -23,6 +23,7 @@
 
 #include "lib/json.h"
 #include "bgpd/bgp_route.h"
+#include "bgpd/bgp_clist.h"
 
 /* Large Communities value is twelve octets long.  */
 #define LCOMMUNITY_SIZE                        12

--- a/tests/topotests/bgp_large_community/test_bgp_large_community_topo_1.py
+++ b/tests/topotests/bgp_large_community/test_bgp_large_community_topo_1.py
@@ -1174,6 +1174,39 @@ def test_large_community_boundary_values(request):
     )
 
 
+def test_large_community_invalid_chars(request):
+    """
+    BGP canonical lcommunities must only be digits
+    """
+    tc_name = request.node.name
+    write_test_header(tc_name)
+    tgen = get_topogen()
+
+    # Don"t run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    input_dict = {
+        "r4": {
+            "bgp_community_lists": [
+                {
+                    "community_type": "standard",
+                    "action": "permit",
+                    "name": "ANY",
+                    "value": "1:a:2",
+                    "large": True,
+                }
+            ]
+        }
+    }
+
+    step("Checking boundary value for community 1:a:2")
+    result = create_bgp_community_lists(tgen, input_dict)
+    assert result is not True, "Test case {} : Failed \n Error: {}".format(
+        tc_name, result
+    )
+
+
 def test_large_community_after_clear_bgp(request):
     """
     Clear BGP neighbor-ship and check if large community and community


### PR DESCRIPTION
We now check that (1) we have all three numbers in a given large-community and (2) A, B, and C do not overflow their 32bit representations. This ensures that large-communities are canonically represented and any other representations input to bgpd are rejected as malformed. This plays out as below:

```
kvm-gentoo(config)# route-map TEST permit 1
kvm-gentoo(config-route-map)# set large-community 4294967296:1:2
% [BGP] Argument form is unsupported or malformed.
kvm-gentoo(config-route-map)# set large-community 4294967295:1:2
kvm-gentoo(config-route-map)# set large-community 3:4
% [BGP] Argument form is unsupported or malformed.
kvm-gentoo(config-route-map)# set large-community 3:4:5
kvm-gentoo(config-route-map)#
```

... this change enforces the canonical form of the large-community attribute where before FRR accepted some malformed large-communities (e.g. 1:2) but the resultant behavior was not well-defined.