### PR TITLE
tests: dict_values are not lists in version 3

### DIFF
--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -2129,7 +2129,9 @@ def verify_bgp_attributes(
             dict_to_test = []
             tmp_list = []
 
-            if "route_maps" in input_dict.values()[0]:
+            dict_list = list(input_dict.values())[0]
+
+            if "route_maps" in dict_list:
                 for rmap_router in input_dict.keys():
                     for rmap, values in input_dict[rmap_router]["route_maps"].items():
                         if rmap == rmap_name:


### PR DESCRIPTION
While accidently running the topotests with version 3
I keep getting:

TypeError: `dict_values` object does not support indexing..

version 2 of python dict.values() returns a list.
version 3 does not

Write some code to allow both to be handled.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>