### PR TITLE
tests: topotests/lib/lutil.py: add timestamp to log of test start

### DIFF
--- a/tests/topotests/lib/lutil.py
+++ b/tests/topotests/lib/lutil.py
@@ -23,6 +23,7 @@ import time
 import datetime
 import json
 import math
+import time
 from lib.topolog import logger
 from mininet.net import Mininet
 
@@ -194,8 +195,9 @@ Total %-4d                                                           %-4d %d\n\
         if op != "wait":
             self.l_line += 1
         self.log(
-            "(#%d) %s:%s COMMAND:%s:%s:%s:%s:%s:"
+            "%s (#%d) %s:%s COMMAND:%s:%s:%s:%s:%s:"
             % (
+                time.asctime(),
                 self.l_total + 1,
                 self.l_filename,
                 self.l_line,


### PR DESCRIPTION
    Timestamps in test logs are needed for correlation with messages in
    routing protocol log files.

    OLD:
    (#55) scripts/rip-show.py:61 COMMAND:r1:vtysh -c "show ip rip status": 00:0.* 00:0:wait:RIP Peers:

    NEW:
    Sat Dec 19 08:26:45 2020:(#55) scripts/rip-show.py:61 COMMAND:r1:vtysh -c "show ip rip status": 00:0.* 00:0:wait:RIP Peers:

Signed-off-by: G. Paul Ziemba <paulz@labn.net>