### PR TITLE
pathd: un-guard clippy files

### DIFF
--- a/pathd/subdir.am
+++ b/pathd/subdir.am
@@ -33,13 +33,8 @@ pathd_libpath_a_SOURCES = \
 
 clippy_scan += \
 	pathd/path_cli.c \
-	# end
-
-if HAVE_PATHD_PCEP
-clippy_scan += \
 	pathd/path_pcep_cli.c \
 	# end
-endif
 
 noinst_HEADERS += \
 	pathd/path_debug.h \


### PR DESCRIPTION
The relevant clippy machinery in python/makevars.py assumes to get
'raw' Makefile text containing all `clippy_scan` variables. If those
files in the `clippy_scan` variable are later on used in the
compilation process does not matter.

This PR in particular fixes the usage of the `--enable-dev-build` flag.

Signed-off-by: GalaxyGorilla <sascha@netdef.org>