### PR TITLE
pimd : Added the command to clear the pim bsr data.

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -726,6 +726,13 @@ Clear commands reset various variables.
 
    Rescan PIM OIL (output interface list).
 
+.. index:: clear ip pim [vrf NAME] bsr-data
+.. clicmd:: clear ip pim [vrf NAME] bsr-data
+
+   This command will clear the BSM scope data struct. This command also
+   removes the next hop tracking for the bsr and resets the upstreams
+   for the dynamically learnt RPs.
+
 PIM EVPN configuration
 ======================
 To use PIM in the underlay for overlay BUM forwarding associate a multicast

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -63,7 +63,7 @@ void pim_bsm_write_config(struct vty *vty, struct interface *ifp)
 	}
 }
 
-static void pim_free_bsgrp_data(struct bsgrp_node *bsgrp_node)
+void pim_free_bsgrp_data(struct bsgrp_node *bsgrp_node)
 {
 	if (bsgrp_node->bsrp_list)
 		list_delete(&bsgrp_node->bsrp_list);
@@ -72,7 +72,7 @@ static void pim_free_bsgrp_data(struct bsgrp_node *bsgrp_node)
 	XFREE(MTYPE_PIM_BSGRP_NODE, bsgrp_node);
 }
 
-static void pim_free_bsgrp_node(struct route_table *rt, struct prefix *grp)
+void pim_free_bsgrp_node(struct route_table *rt, struct prefix *grp)
 {
 	struct route_node *rn;
 
@@ -222,7 +222,7 @@ static int pim_on_bs_timer(struct thread *t)
 	return 0;
 }
 
-static void pim_bs_timer_stop(struct bsm_scope *scope)
+void pim_bs_timer_stop(struct bsm_scope *scope)
 {
 	if (PIM_DEBUG_BSM)
 		zlog_debug("%s : BS timer being stopped of sz: %d", __func__,

--- a/pimd/pim_bsm.h
+++ b/pimd/pim_bsm.h
@@ -195,4 +195,7 @@ int  pim_bsm_process(struct interface *ifp,
 bool pim_bsm_new_nbr_fwd(struct pim_neighbor *neigh, struct interface *ifp);
 struct bsgrp_node *pim_bsm_get_bsgrp_node(struct bsm_scope *scope,
 					  struct prefix *grp);
+void pim_bs_timer_stop(struct bsm_scope *scope);
+void pim_free_bsgrp_data(struct bsgrp_node *bsgrp_node);
+void pim_free_bsgrp_node(struct route_table *rt, struct prefix *grp);
 #endif

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -271,7 +271,7 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
  *
  * This is a placeholder function for now.
  */
-static void pim_rp_refresh_group_to_rp_mapping(struct pim_instance *pim)
+void pim_rp_refresh_group_to_rp_mapping(struct pim_instance *pim)
 {
 	pim_msdp_i_am_rp_changed(pim);
 	pim_upstream_reeval_use_rpt(pim);

--- a/pimd/pim_rp.h
+++ b/pimd/pim_rp.h
@@ -86,4 +86,5 @@ int pim_rp_list_cmp(void *v1, void *v2);
 struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
 					const struct prefix *group);
 void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up);
+void pim_rp_refresh_group_to_rp_mapping(struct pim_instance *pim);
 #endif


### PR DESCRIPTION
This command has been added in the context of
PIM BSM functionality. This command will clear the
data structs having bsr information.

Co-authored-by: Sarita Patra <saritap@vmware.com>
Signed-off-by: vishaldhingra <vdhingra@vmware.com>