### PR TITLE
pathd: fix compile warning in path_cli

### DIFF
--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -550,7 +550,7 @@ DEFPY_NOSH(
 	"Symbolic Name\n"
 	"Dynamic Path\n")
 {
-	char xpath[XPATH_CANDIDATE_BASELEN];
+	char xpath[XPATH_MAXLEN + XPATH_CANDIDATE_BASELEN];
 	int ret;
 
 	snprintf(xpath, sizeof(xpath), "%s/candidate-path[preference='%s']",


### PR DESCRIPTION
Use a big-enough buffer in path_cli.c to avoid a compiler warning (with gcc 9, at least)
