### PR TITLE
Add level of confidence to show pcep-session

### DIFF
--- a/pathd/path_pcep_cli.c
+++ b/pathd/path_pcep_cli.c
@@ -1156,14 +1156,17 @@ static void print_pcep_session(struct vty *vty, struct pce_opts *pce_opts,
 	}
 
 	if (pcc_info->is_best_multi_pce) {
-		vty_out(vty, " MultiPCE precedence %d, best candidate\n",
+		vty_out(vty, " Precedence %d, best candidate\n",
 			((pcc_info->precedence > 0) ? pcc_info->precedence
 						    : DEFAULT_PCE_PRECEDENCE));
 	} else {
-		vty_out(vty, " MultiPCE precedence %d\n",
+		vty_out(vty, " Precedence %d\n",
 			((pcc_info->precedence > 0) ? pcc_info->precedence
 						    : DEFAULT_PCE_PRECEDENCE));
 	}
+	vty_out(vty, " Confidence %s\n",
+		((pcc_info->previous_best) ? "low"
+		 : "normal"));
 
 	/* PCEPlib pcep session values, get a thread safe copy of the counters
 	 */

--- a/pathd/path_pcep_controller.h
+++ b/pathd/path_pcep_controller.h
@@ -99,6 +99,7 @@ struct pcep_pcc_info {
 	uint32_t next_reqid;
 	uint32_t next_plspid;
 	bool is_best_multi_pce;
+	bool previous_best;
 	uint8_t precedence;
 };
 

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -1101,6 +1101,7 @@ void pcep_pcc_copy_pcc_info(struct pcc_state **pcc,
 	pcc_info->status = pcc_state->status;
 	pcc_info->pcc_id = pcc_state->id;
 	pcc_info->is_best_multi_pce = pcc_state->is_best;
+	pcc_info->previous_best = pcc_state->previous_best;
 	pcc_info->precedence =
 		pcc_state->pce_opts ? pcc_state->pce_opts->precedence : 0;
 	memcpy(&pcc_info->pcc_addr, &pcc_state->pcc_addr_tr,


### PR DESCRIPTION
Show 'low' if a pce has disconnect or 'normal' . It's only a boolean so
it's like a token that mark the pce that has recenty disconnect.

Signed-off-by: Javier Garcia <javier.garcia@voltanet.io>