### PR TITLE
lib: fix northbound batching

### DIFF
--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -147,7 +147,7 @@ static int nb_cli_schedule_command(struct vty *vty)
 	 * the maximum amount.
 	 */
 	vty->backoff_cmd_count++;
-	if (vty->backoff_cmd_count >= NB_CMD_BATCH_SIZE) {
+	if (vty->backoff_cmd_count >= vty->backoff_cmd_max) {
 		(void)nb_cli_classic_commit(vty);
 		nb_cli_pending_commit_clear(vty);
 	} else

--- a/lib/northbound_cli.h
+++ b/lib/northbound_cli.h
@@ -33,6 +33,9 @@ enum nb_cfg_format {
 	NB_CFG_FMT_XML,
 };
 
+/** Amount of commands to batch. */
+#define NB_CMD_BATCH_SIZE 100
+
 extern struct nb_config *vty_shared_candidate_config;
 
 /*

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2041,6 +2041,7 @@ static int vtysh_accept(struct thread *thread)
 	vty->wfd = sock;
 	vty->type = VTY_SHELL_SERV;
 	vty->node = VIEW_NODE;
+	vty->backoff_cmd_max = NB_CMD_BATCH_SIZE;
 
 	vty_event(VTYSH_READ, sock, vty);
 

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -135,7 +135,6 @@ struct vty {
 	struct nb_config *candidate_config_base;
 
 	/* Dynamic transaction information. */
-	struct timeval backoff_start;
 	size_t backoff_cmd_count;
 	struct thread *t_pending_commit;
 	char *pending_cmds_buf;

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -136,6 +136,7 @@ struct vty {
 
 	/* Dynamic transaction information. */
 	size_t backoff_cmd_count;
+	size_t backoff_cmd_max;
 	struct thread *t_pending_commit;
 	char *pending_cmds_buf;
 	size_t pending_cmds_buflen;


### PR DESCRIPTION
Summary
-------

Changes:
* Simplify the code to avoid monotime system calls
* Move batch size handling to schedule function
* Add define for batch maximum size

Acked-by: Chirag Shah <chirag@nvidia.com>
Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>

---

Possibly related with #7743 .