### PR TITLE
dplane_fpm_nl: routes stuck with 'q' flag (revisited)

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1467,6 +1467,10 @@ static int fpm_nl_process(struct zebra_dplane_provider *prov)
 		thread_add_timer(fnc->fthread->master, fpm_process_queue,
 				 fnc, 0, &fnc->t_dequeue);
 
+	/* Ensure dataplane thread is rescheduled if we hit the work limit */
+	if (counter >= limit)
+		dplane_provider_work_ready();
+
 	return 0;
 }
 


### PR DESCRIPTION
#7766 exacerbated an pre-existing issue where the dplane_fpm_nl output queue is not drained if the contexts in the output queue exceeds the work limit, and no new work is incoming.

The output queue will be drained in bits and pieces as/if new work comes, however at scale (eg. 1 million routes) this might not complete in a timely fashion.