### PR TITLE
zebra: zebra2proto() handle kernel/connect type

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -266,6 +266,10 @@ static inline int zebra2proto(int proto)
 	case ZEBRA_ROUTE_NHG:
 		proto = RTPROT_ZEBRA;
 		break;
+	case ZEBRA_ROUTE_CONNECT:
+	case ZEBRA_ROUTE_KERNEL:
+		proto = RTPROT_KERNEL;
+		break;
 	default:
 		/*
 		 * When a user adds a new protocol this will show up


### PR DESCRIPTION
When dplane_fpm_nl is used the "Please add this protocol(n) to proper
rt_netlink.c handling" debug message is emitted for any route of type
kernel or connected.

This severely reduces performance of dplane_fpm_nl when large numbers
of these routes are present in the RIB.

The messages are not observed when using the original fpm module since
this uses a custom function, netlink_proto_from_route_type().

zebra2proto() now returns RTPROT_KERNEL for ZEBRA_ROUTE_CONNECT and
ZEBRA_ROUTE_KERNEL. This should only impact dplane_fpm_nl's use of
the common netlink routines since these routes generally ignored via
checking of RSYSTEM_ROUTE().

Signed-off-by: Duncan Eastoe <duncan.eastoe@att.com>