### PR TITLE
ospfd: show ip ospf interface displays only BDR info, Added DR info.

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3737,6 +3737,31 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 				vty_out(vty,
 					"  No backup designated router on this network\n");
 		} else {
+			nbr = ospf_nbr_lookup_by_addr(oi->nbrs, &DR(oi));
+			if (nbr) {
+				if (use_json) {
+					json_object_string_add(
+						json_interface_sub, "drId",
+						inet_ntop(AF_INET,
+							  &nbr->router_id, buf,
+							  sizeof(buf)));
+					json_object_string_add(
+						json_interface_sub, "drAddress",
+						inet_ntop(
+							AF_INET,
+							&nbr->address.u.prefix4,
+							buf, sizeof(buf)));
+				} else {
+					vty_out(vty,
+						"  Designated Router (ID) %pI4",
+						&nbr->router_id);
+					vty_out(vty,
+						" Interface Address %pFX\n",
+						&nbr->address);
+				}
+			}
+			nbr = NULL;
+
 			nbr = ospf_nbr_lookup_by_addr(oi->nbrs, &BDR(oi));
 			if (nbr == NULL) {
 				if (!use_json)

--- a/tests/topotests/all-protocol-startup/r1/show_ip_ospf_interface.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_ip_ospf_interface.ref
@@ -4,6 +4,7 @@ r1-eth0 is up
   MTU mismatch detection: enabled
   Router ID 192.168.0.1, Network Type BROADCAST, Cost: 10
   Transmit Delay is 1 sec, State DR, Priority 1
+  Designated Router (ID) 192.168.0.1 Interface Address 192.168.0.1/24
   No backup designated router on this network
   Multicast group memberships: OSPFAllRouters OSPFDesignatedRouters
   Timer intervals configured, Hello 10s, Dead 40s, Wait 40s, Retransmit 5
@@ -15,6 +16,7 @@ r1-eth3 is up
   MTU mismatch detection: enabled
   Router ID 192.168.0.1, Network Type BROADCAST, Cost: 10
   Transmit Delay is 1 sec, State DR, Priority 1
+  Designated Router (ID) 192.168.0.1 Interface Address 192.168.3.1/26
   No backup designated router on this network
   Multicast group memberships: OSPFAllRouters OSPFDesignatedRouters
   Timer intervals configured, Hello 10s, Dead 40s, Wait 40s, Retransmit 5


### PR DESCRIPTION
Description:
	DR information is missing under "show ip ospf interface [json]".
	Added DR infomation to display in "show ip ospf interface".

Signed-off-by: Rajesh Girada <rgirada@vmware.com>