### PR TITLE
ospfd: fix no show database output when selecting vrf

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -7316,8 +7316,8 @@ DEFUN (show_ip_ospf_instance_database_type_adv_router,
 					continue;
 				ospf_output = true;
 				ret = show_ip_ospf_database_type_adv_router_common(
-					vty, ospf, idx ? 1 : 0, argc, argv,
-					use_vrf, json, uj);
+					vty, ospf, 2, argc, argv, use_vrf, json,
+					uj);
 			}
 			if (!ospf_output)
 				vty_out(vty, "%% OSPF instance not found\n");
@@ -7329,8 +7329,7 @@ DEFUN (show_ip_ospf_instance_database_type_adv_router,
 			}
 
 			ret = show_ip_ospf_database_type_adv_router_common(
-				vty, ospf, idx ? 1 : 0, argc, argv, use_vrf,
-				json, uj);
+				vty, ospf, 2, argc, argv, use_vrf, json, uj);
 		}
 	} else {
 		/* Display default ospf (instance 0) info */


### PR DESCRIPTION
No output when selecting a vrf
frr# show ip ospf vrf default database router adv-router 10.125.0.1
VRF Name: default

       OSPF Router with ID (10.125.0.1)

In comparison with:
frr# show ip ospf database router adv-router 10.125.0.1

       OSPF Router with ID (10.125.0.1)

                Router Link States (Area 0.0.0.0)

  LS age: 155
  Options: 0x2  : *|-|-|-|-|-|E|-
(...)

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>