### PR TITLE
Northbound_Sysrepo  relative bug fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1862,7 +1862,7 @@ dnl ---------------
 dnl sysrepo
 dnl ---------------
 if test "$enable_sysrepo" = "yes"; then
-  PKG_CHECK_MODULES([SYSREPO], [libsysrepo],
+  PKG_CHECK_MODULES([SYSREPO], [sysrepo],
       [AC_DEFINE([HAVE_SYSREPO], [1], [Enable sysrepo integration])
       SYSREPO=true],
       [SYSREPO=false


### PR DESCRIPTION
northbound_sysrepo: relative bug fix 

1. Correct sysrepo link library name

Signed-off-by: Bo Zhang <logbob0401@gmail.com>
