### PR TITLE
Fix augment path problem in frr-vrrpd.yang to comply with rfc 7950

### DIFF
--- a/yang/frr-vrrpd.yang
+++ b/yang/frr-vrrpd.yang
@@ -246,7 +246,7 @@ module frr-vrrpd {
           }
 
           uses ip-vrrp-state {
-            augment "./counter/tx" {
+            augment "counter/tx" {
               leaf gratuitous-arp {
                 type yang:zero-based-counter32;
                 description
@@ -266,7 +266,7 @@ module frr-vrrpd {
           }
 
           uses ip-vrrp-state {
-            augment "./counter/tx" {
+            augment "counter/tx" {
               leaf neighbor-advertisement {
                 type yang:zero-based-counter32;
                 description


### PR DESCRIPTION
When use pyang to analyze all frr-*.yang, it complains as below:

pyang --tree-print-groupings --tree-print-structures -o bgp.tree -f tree $all -p .:./ietf:../../../yang
frr-bfdd.yang:18: warning: imported module "frr-route-types" not used
frr-bgp-peer-group.yang:12: warning: imported module "frr-bgp-types" not used
frr-eigrpd.yang:9: warning: imported module "ietf-yang-types" not used
frr-pathd.yang:9: warning: imported module "ietf-yang-types" not used
frr-pathd.yang:15: warning: imported module "frr-interface" not used
frr-pim-rp.yang:11: warning: imported module "ietf-routing-types" not used
frr-test-module.yang:9: warning: imported module "ietf-yang-types" not used
frr-vrrpd.yang:249: error: bad value "./counter/tx" (should be schema-nodeid)
frr-vrrpd.yang:269: error: bad value "./counter/tx" (should be schema-nodeid)

Augment argument './counter/tx' is not valid, it can be only absolute path; or descendant if used in uses

This PR fixes this err, reference: https://tools.ietf.org/html/rfc7950#page-119

Signed-off-by: Bo Zhang <logbob0401@gmail.com>
