### PR TITLE
ospf6: backport from 7.5 series for 7.3

### DIFF
--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -298,17 +298,13 @@ struct ospf6_lsa *ospf6_lsdb_next(const struct route_node *iterend,
 
 void ospf6_lsdb_remove_all(struct ospf6_lsdb *lsdb)
 {
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	if (lsdb == NULL)
 		return;
 
-	for (iterend = ospf6_lsdb_head(lsdb, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(lsdb, lsa))
 		ospf6_lsdb_remove(lsa, lsdb);
-	}
 }
 
 void ospf6_lsdb_lsa_unlock(struct ospf6_lsa *lsa)
@@ -323,12 +319,9 @@ void ospf6_lsdb_lsa_unlock(struct ospf6_lsa *lsa)
 int ospf6_lsdb_maxage_remover(struct ospf6_lsdb *lsdb)
 {
 	int reschedule = 0;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
-	for (iterend = ospf6_lsdb_head(lsdb, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(lsdb, lsa)) {
 		if (!OSPF6_LSA_IS_MAXAGE(lsa))
 			continue;
 		if (lsa->retrans_count != 0) {

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1866,8 +1866,7 @@ int ospf6_dbdesc_send(struct thread *thread)
 int ospf6_dbdesc_send_newone(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 	unsigned int size = 0;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
@@ -1877,10 +1876,7 @@ int ospf6_dbdesc_send_newone(struct thread *thread)
 	   structure)
 	   so that ospf6_send_dbdesc () can send those LSAs */
 	size = sizeof(struct ospf6_lsa_header) + sizeof(struct ospf6_dbdesc);
-
-	for (iterend = ospf6_lsdb_head(on->summary_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->summary_list, lsa)) {
 		if (size + sizeof(struct ospf6_lsa_header)
 		    > ospf6_packet_max(on->ospf6_if)) {
 			ospf6_lsdb_lsa_unlock(lsa);
@@ -2023,8 +2019,7 @@ int ospf6_lsupdate_send_neighbor(struct thread *thread)
 	struct ospf6_lsupdate *lsupdate;
 	uint8_t *p;
 	int lsa_cnt;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	on->thread_send_lsupdate = (struct thread *)NULL;
@@ -2049,9 +2044,7 @@ int ospf6_lsupdate_send_neighbor(struct thread *thread)
 
 	/* lsupdate_list lists those LSA which doesn't need to be
 	   retransmitted. remove those from the list */
-	for (iterend = ospf6_lsdb_head(on->lsupdate_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->lsupdate_list, lsa)) {
 		/* MTU check */
 		if ((p - sendbuf + (unsigned int)OSPF6_LSA_SIZE(lsa->header))
 		    > ospf6_packet_max(on->ospf6_if)) {
@@ -2081,7 +2074,7 @@ int ospf6_lsupdate_send_neighbor(struct thread *thread)
 		p += OSPF6_LSA_SIZE(lsa->header);
 		lsa_cnt++;
 
-		assert(lsa->lock == 1);
+		assert(lsa->lock == 2);
 		ospf6_lsdb_remove(lsa, on->lsupdate_list);
 	}
 
@@ -2209,8 +2202,7 @@ int ospf6_lsupdate_send_interface(struct thread *thread)
 	struct ospf6_lsupdate *lsupdate;
 	uint8_t *p;
 	int lsa_cnt;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
 	oi->thread_send_lsupdate = (struct thread *)NULL;
@@ -2236,9 +2228,7 @@ int ospf6_lsupdate_send_interface(struct thread *thread)
 	p = (uint8_t *)((caddr_t)lsupdate + sizeof(struct ospf6_lsupdate));
 	lsa_cnt = 0;
 
-	for (iterend = ospf6_lsdb_head(oi->lsupdate_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(oi->lsupdate_list, lsa)) {
 		/* MTU check */
 		if ((p - sendbuf + ((unsigned int)OSPF6_LSA_SIZE(lsa->header)))
 		    > ospf6_packet_max(oi)) {
@@ -2273,7 +2263,7 @@ int ospf6_lsupdate_send_interface(struct thread *thread)
 		p += OSPF6_LSA_SIZE(lsa->header);
 		lsa_cnt++;
 
-		assert(lsa->lock == 1);
+		assert(lsa->lock == 2);
 		ospf6_lsdb_remove(lsa, oi->lsupdate_list);
 	}
 
@@ -2299,8 +2289,7 @@ int ospf6_lsack_send_neighbor(struct thread *thread)
 	struct ospf6_neighbor *on;
 	struct ospf6_header *oh;
 	uint8_t *p;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 	int lsa_cnt = 0;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
@@ -2323,9 +2312,7 @@ int ospf6_lsack_send_neighbor(struct thread *thread)
 
 	p = (uint8_t *)((caddr_t)oh + sizeof(struct ospf6_header));
 
-	for (iterend = ospf6_lsdb_head(on->lsack_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->lsack_list, lsa)) {
 		/* MTU check */
 		if (p - sendbuf + sizeof(struct ospf6_lsa_header)
 		    > ospf6_packet_max(on->ospf6_if)) {
@@ -2353,7 +2340,7 @@ int ospf6_lsack_send_neighbor(struct thread *thread)
 		memcpy(p, lsa->header, sizeof(struct ospf6_lsa_header));
 		p += sizeof(struct ospf6_lsa_header);
 
-		assert(lsa->lock == 1);
+		assert(lsa->lock == 2);
 		ospf6_lsdb_remove(lsa, on->lsack_list);
 		lsa_cnt++;
 	}
@@ -2380,8 +2367,7 @@ int ospf6_lsack_send_interface(struct thread *thread)
 	struct ospf6_interface *oi;
 	struct ospf6_header *oh;
 	uint8_t *p;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 	int lsa_cnt = 0;
 
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
@@ -2405,9 +2391,7 @@ int ospf6_lsack_send_interface(struct thread *thread)
 
 	p = (uint8_t *)((caddr_t)oh + sizeof(struct ospf6_header));
 
-	for (iterend = ospf6_lsdb_head(oi->lsack_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(oi->lsack_list, lsa)) {
 		/* MTU check */
 		if (p - sendbuf + sizeof(struct ospf6_lsa_header)
 		    > ospf6_packet_max(oi)) {
@@ -2425,7 +2409,7 @@ int ospf6_lsack_send_interface(struct thread *thread)
 		memcpy(p, lsa->header, sizeof(struct ospf6_lsa_header));
 		p += sizeof(struct ospf6_lsa_header);
 
-		assert(lsa->lock == 1);
+		assert(lsa->lock == 2);
 		ospf6_lsdb_remove(lsa, oi->lsack_list);
 		lsa_cnt++;
 	}

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -118,15 +118,11 @@ struct ospf6_neighbor *ospf6_neighbor_create(uint32_t router_id,
 
 void ospf6_neighbor_delete(struct ospf6_neighbor *on)
 {
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	ospf6_lsdb_remove_all(on->summary_list);
 	ospf6_lsdb_remove_all(on->request_list);
-
-	for (iterend = ospf6_lsdb_head(on->retrans_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->retrans_list, lsa)) {
 		ospf6_decrement_retrans_count(lsa);
 		ospf6_lsdb_remove(lsa, on->retrans_list);
 	}
@@ -297,8 +293,7 @@ int twoway_received(struct thread *thread)
 int negotiation_done(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	assert(on);
@@ -312,10 +307,7 @@ int negotiation_done(struct thread *thread)
 	/* clear ls-list */
 	ospf6_lsdb_remove_all(on->summary_list);
 	ospf6_lsdb_remove_all(on->request_list);
-
-	for (iterend = ospf6_lsdb_head(on->retrans_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->retrans_list, lsa)) {
 		ospf6_decrement_retrans_count(lsa);
 		ospf6_lsdb_remove(lsa, on->retrans_list);
 	}
@@ -509,8 +501,7 @@ int seqnumber_mismatch(struct thread *thread)
 int bad_lsreq(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	assert(on);
@@ -529,10 +520,7 @@ int bad_lsreq(struct thread *thread)
 
 	ospf6_lsdb_remove_all(on->summary_list);
 	ospf6_lsdb_remove_all(on->request_list);
-
-	for (iterend = ospf6_lsdb_head(on->retrans_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->retrans_list, lsa)) {
 		ospf6_decrement_retrans_count(lsa);
 		ospf6_lsdb_remove(lsa, on->retrans_list);
 	}
@@ -550,8 +538,7 @@ int bad_lsreq(struct thread *thread)
 int oneway_received(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_lsa *lsa, *lsa_next;
-	const struct route_node *iterend;
+	struct ospf6_lsa *lsa;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	assert(on);
@@ -568,9 +555,7 @@ int oneway_received(struct thread *thread)
 
 	ospf6_lsdb_remove_all(on->summary_list);
 	ospf6_lsdb_remove_all(on->request_list);
-	for (iterend = ospf6_lsdb_head(on->retrans_list, 0, 0, 0, &lsa); lsa;
-	     lsa = lsa_next) {
-		lsa_next = ospf6_lsdb_next(iterend, lsa);
+	for (ALL_LSDB(on->retrans_list, lsa)) {
 		ospf6_decrement_retrans_count(lsa);
 		ospf6_lsdb_remove(lsa, on->retrans_list);
 	}


### PR DESCRIPTION
This reverts commit 0f9f74baeb97f437d7acf7feda0f400d50943c4c.

This commit was causing crashes and the goal of this commit
was to make coverity sanity happy.  I'd rather have coverity
sad and not have ospfv3 crash

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
(cherry picked from commit e2e60c48bfeee0b9f5486952e37c3602e214f7f1)