### PR TITLE
Random cleanup/fixes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10261,6 +10261,24 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 				str, label2vni(&attr->label));
 	}
 
+	/* Output some debug about internal state of the dest flags */
+	if (json_paths) {
+		if (CHECK_FLAG(bn->flags, BGP_NODE_PROCESS_SCHEDULED))
+			json_object_boolean_true_add(json_path, "processScheduled");
+		if (CHECK_FLAG(bn->flags, BGP_NODE_USER_CLEAR))
+			json_object_boolean_true_add(json_path, "userCleared");
+		if (CHECK_FLAG(bn->flags, BGP_NODE_LABEL_CHANGED))
+			json_object_boolean_true_add(json_path, "labelChanged");
+		if (CHECK_FLAG(bn->flags, BGP_NODE_REGISTERED_FOR_LABEL))
+			json_object_boolean_true_add(json_path, "registeredForLabel");
+		if (CHECK_FLAG(bn->flags, BGP_NODE_SELECT_DEFER))
+			json_object_boolean_true_add(json_path, "selectDefered");
+		if (CHECK_FLAG(bn->flags, BGP_NODE_FIB_INSTALLED))
+			json_object_boolean_true_add(json_path, "fibInstalled");
+		if (CHECK_FLAG(bn->flags, BGP_NODE_FIB_INSTALL_PENDING))
+			json_object_boolean_true_add(json_path, "fibPending");
+	}
+
 	/* We've constructed the json object for this path, add it to the json
 	 * array of paths
 	 */

--- a/pathd/path_pcep_controller.c
+++ b/pathd/path_pcep_controller.c
@@ -26,6 +26,7 @@
 #include "northbound.h"
 #include "frr_pthread.h"
 #include "jhash.h"
+#include "network.h"
 
 #include "pathd/pathd.h"
 #include "pathd/path_errors.h"
@@ -1043,7 +1044,7 @@ void remove_pcc_state(struct ctrl_state *ctrl_state,
 uint32_t backoff_delay(uint32_t max, uint32_t base, uint32_t retry_count)
 {
 	uint32_t a = min(max, base * (1 << retry_count));
-	uint64_t r = rand(), m = RAND_MAX;
+	uint64_t r = frr_weak_random(), m = RAND_MAX;
 	uint32_t b = (a / 2) + (r * (a / 2)) / m;
 	return b;
 }

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -21,6 +21,7 @@
 #include "memory.h"
 #include "log.h"
 #include "lib_errors.h"
+#include "network.h"
 
 #include "pathd/pathd.h"
 #include "pathd/path_memory.h"
@@ -480,7 +481,7 @@ struct srte_candidate *srte_candidate_add(struct srte_policy *policy,
 	candidate->preference = preference;
 	candidate->policy = policy;
 	candidate->type = SRTE_CANDIDATE_TYPE_UNDEFINED;
-	candidate->discriminator = rand();
+	candidate->discriminator = frr_weak_random();
 
 	lsp->candidate = candidate;
 	candidate->lsp = lsp;


### PR DESCRIPTION
1) don't use rand() use frr_weak_random()
2) Add some useful data to json output for internal bgp state for routes.
3) cleanup bgp's wait for install debugs for notifications received from zebra about the route.