### PR TITLE
zebra: notify installing protocol when nexthops cannot be resolved

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2120,7 +2120,6 @@ static unsigned nexthop_active_check(struct route_node *rn,
 	struct interface *ifp;
 	route_map_result_t ret = RMAP_PERMITMATCH;
 	int family;
-	char buf[SRCDEST2STR_BUFFER];
 	const struct prefix *p, *src_p;
 	struct zebra_vrf *zvrf;
 
@@ -2230,10 +2229,9 @@ static unsigned nexthop_active_check(struct route_node *rn,
 				    zvrf, re->tag);
 	if (ret == RMAP_DENYMATCH) {
 		if (IS_ZEBRA_DEBUG_RIB) {
-			srcdest_rnode2str(rn, buf, sizeof(buf));
 			zlog_debug(
-				"%u:%s: Filtering out with NH out %s due to route map",
-				re->vrf_id, buf,
+				"%u:%pRN: Filtering out with NH out %s due to route map",
+				re->vrf_id, rn,
 				ifindex2ifname(nexthop->ifindex,
 					       nexthop->vrf_id));
 		}

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1107,6 +1107,9 @@ static void rib_process(struct route_node *rn)
 		 */
 		if (CHECK_FLAG(re->status, ROUTE_ENTRY_CHANGED)) {
 			if (!nexthop_active_update(rn, re)) {
+				const struct prefix *p;
+				struct rib_table_info *info;
+
 				if (re->type == ZEBRA_ROUTE_TABLE) {
 					/* XXX: HERE BE DRAGONS!!!!!
 					 * In all honesty, I have not yet
@@ -1136,6 +1139,11 @@ static void rib_process(struct route_node *rn)
 							 ROUTE_ENTRY_REMOVED);
 				}
 
+				info = srcdest_rnode_table_info(rn);
+				srcdest_rnode_prefixes(rn, &p, NULL);
+				zsend_route_notify_owner(re, p,
+							 ZAPI_ROUTE_FAIL_INSTALL,
+							 info->afi, info->safi);
 				continue;
 			}
 		} else {


### PR DESCRIPTION
In the case where a routes nexthops cannot be resolved as part
of route processing, immmediately notify the upper level protocol
that their routes failed to install if they are interested in
being informed about this issue.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>