### PR TITLE
pimd: PIMd core while doing frr restart after loading config

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -322,6 +322,23 @@ To start OSPF process you have to specify the OSPF router.
 
    This feature is enabled by default.
 
+.. index:: clear ip ospf [(1-65535)] process
+.. clicmd:: clear ip ospf [(1-65535)] process
+
+   This command can be used to clear the ospf process data structures. This
+   will clear the ospf neighborship as well and it will get re-established.
+   This will clear the LSDB too. This will be helpful when there is a change
+   in router-id and if user wants the router-id change to take effect, user can
+   use this cli instead of restarting the ospfd daemon.
+
+.. index:: clear ip ospf [(1-65535)] neighbor
+.. clicmd:: clear ip ospf [(1-65535)] neighbor
+
+   This command can be used to clear the ospf neighbor data structures. This
+   will clear the ospf neighborship and it will get re-established. This
+   command can be used when the neighbor state get stuck at some state and
+   this can be used to recover it from that state.
+
 .. _ospf-area:
 
 Areas

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -748,8 +748,14 @@ void ospf_ase_unregister_external_lsa(struct ospf_lsa *lsa, struct ospf *top)
 
 	if (rn) {
 		lst = rn->info;
-		listnode_delete(lst, lsa);
-		ospf_lsa_unlock(&lsa); /* external_lsas list */
+
+		struct listnode *node = listnode_lookup(lst, lsa);
+		/* Unlock lsa only if node is present in the list */
+		if (node) {
+			list_delete_node(lst, node);
+			ospf_lsa_unlock(&lsa); /* external_lsas list */
+		}
+
 		route_unlock_node(rn);
 	}
 }

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -280,7 +280,7 @@ DEFPY (ospf_router_id,
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area))
 		if (area->full_nbrs) {
 			vty_out(vty,
-				"For this router-id change to take effect, save config and restart ospfd\n");
+				"For this router-id change to take effect, use “clear ip ospf process” command\n");
 			return CMD_SUCCESS;
 		}
 
@@ -313,7 +313,7 @@ DEFUN_HIDDEN (ospf_router_id_old,
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area))
 		if (area->full_nbrs) {
 			vty_out(vty,
-				"For this router-id change to take effect, save config and restart ospfd\n");
+				"For this router-id change to take effect, use “clear ip ospf process” command\n");
 			return CMD_SUCCESS;
 		}
 
@@ -346,7 +346,7 @@ DEFPY (no_ospf_router_id,
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, node, area))
 		if (area->full_nbrs) {
 			vty_out(vty,
-				"For this router-id change to take effect, save config and restart ospfd\n");
+				"For this router-id change to take effect, use “clear ip ospf process” command\n");
 			return CMD_SUCCESS;
 		}
 
@@ -11177,6 +11177,70 @@ DEFUN (show_ip_ospf_vrfs,
 
 	return CMD_SUCCESS;
 }
+DEFPY (clear_ip_ospf_neighbor,
+       clear_ip_ospf_neighbor_cmd,
+       "clear ip ospf [(1-65535)]$instance neighbor [A.B.C.D$nbr_id]",
+       CLEAR_STR
+       IP_STR
+       "OSPF information\n"
+       "Instance ID\n"
+       "Reset OSPF Neighbor\n"
+       "Neighbor ID\n")
+{
+	struct listnode *node;
+	struct ospf *ospf = NULL;
+
+	/* If user does not specify the arguments,
+	 * instance = 0 and nbr_id = 0.0.0.0
+	 */
+	if (instance != 0) {
+		/* This means clear only the particular ospf process */
+		ospf = ospf_lookup_instance(instance);
+		if (ospf == NULL)
+			return CMD_NOT_MY_INSTANCE;
+	}
+
+	/* Clear all the ospf processes */
+	for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
+		if (!ospf->oi_running)
+			continue;
+
+		ospf_neighbor_reset(ospf, nbr_id, nbr_id_str);
+	}
+
+	return CMD_SUCCESS;
+}
+
+DEFPY (clear_ip_ospf_process,
+       clear_ip_ospf_process_cmd,
+       "clear ip ospf [(1-65535)]$instance process",
+       CLEAR_STR
+       IP_STR
+       "OSPF information\n"
+       "Instance ID\n"
+       "Reset OSPF Process\n")
+{
+	struct listnode *node;
+	struct ospf *ospf = NULL;
+
+	/* Check if instance is not passed as an argument */
+	if (instance != 0) {
+		/* This means clear only the particular ospf process */
+		ospf = ospf_lookup_instance(instance);
+		if (ospf == NULL)
+			return CMD_NOT_MY_INSTANCE;
+	}
+
+	/* Clear all the ospf processes */
+	for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
+		if (!ospf->oi_running)
+			continue;
+
+		ospf_process_reset(ospf);
+	}
+
+	return CMD_SUCCESS;
+}
 
 static const char *const ospf_abr_type_str[] = {
 	"unknown", "standard", "ibm", "cisco", "shortcut"
@@ -12573,6 +12637,8 @@ DEFUN (clear_ip_ospf_interface,
 void ospf_vty_clear_init(void)
 {
 	install_element(ENABLE_NODE, &clear_ip_ospf_interface_cmd);
+	install_element(ENABLE_NODE, &clear_ip_ospf_process_cmd);
+	install_element(ENABLE_NODE, &clear_ip_ospf_neighbor_cmd);
 }
 
 

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -571,7 +571,11 @@ extern struct ospf *ospf_lookup_by_inst_name(unsigned short instance,
 					     const char *name);
 extern struct ospf *ospf_lookup_by_vrf_id(vrf_id_t vrf_id);
 extern void ospf_finish(struct ospf *);
+extern void ospf_process_refresh_data(struct ospf *ospf, bool reset);
 extern void ospf_router_id_update(struct ospf *ospf);
+extern void ospf_process_reset(struct ospf *ospf);
+extern void ospf_neighbor_reset(struct ospf *ospf, struct in_addr nbr_id,
+				const char *nbr_str);
 extern int ospf_network_set(struct ospf *, struct prefix_ipv4 *, struct in_addr,
 			    int);
 extern int ospf_network_unset(struct ospf *, struct prefix_ipv4 *,
@@ -596,6 +600,7 @@ extern int ospf_area_shortcut_set(struct ospf *, struct ospf_area *, int);
 extern int ospf_area_shortcut_unset(struct ospf *, struct ospf_area *);
 extern int ospf_timers_refresh_set(struct ospf *, int);
 extern int ospf_timers_refresh_unset(struct ospf *);
+void ospf_area_lsdb_discard_delete(struct ospf_area *area);
 extern int ospf_nbr_nbma_set(struct ospf *, struct in_addr);
 extern int ospf_nbr_nbma_unset(struct ospf *, struct in_addr);
 extern int ospf_nbr_nbma_priority_set(struct ospf *, struct in_addr, uint8_t);

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -125,7 +125,9 @@ static void zclient_lookup_failed(struct zclient *zlookup)
 
 void zclient_lookup_free(void)
 {
-	THREAD_OFF(zlookup_read);
+	if (zlookup_read)
+		THREAD_OFF(zlookup_read);
+
 	zclient_stop(zlookup);
 	zclient_free(zlookup);
 	zlookup = NULL;


### PR DESCRIPTION
1) load PIM config 
2) Do systemctl restart frr

PIMD Core dump :- 
gdb) bt
#0  0x00007f94ac174428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007f94ac17602a in __GI_abort () at abort.c:89
#2  0x00007f94acda8390 in core_handler (signo=11, siginfo=0x7ffd6aeb7430, context=<optimized out>) at lib/sigevent.c:254
#3  <signal handler called>
#4  thread_cancel (thread=0x0) at lib/thread.c:1145
#5  0x000055e83f3c7d80 in zclient_lookup_free () at pimd/pim_zlookup.c:120
#6  0x000055e83f3c8705 in pim_free () at pimd/pimd.c:76
#7  pim_terminate () at pimd/pimd.c:157
#8  0x000055e83f3bdc67 in pim_sigint () at pimd/pim_signals.c:44
#9  0x00007f94acda8433 in quagga_sigevent_process () at lib/sigevent.c:105
#10 0x00007f94acdb564d in thread_fetch (m=m@entry=0x55e83fe84630, fetch=fetch@entry=0x7ffd6aeb7a60) at lib/thread.c:1379
#11 0x00007f94acd870b3 in frr_run (master=0x55e83fe84630) at lib/libfrr.c:1025
#12 0x000055e83f39e0cf in main (argc=<optimized out>, argv=0x7ffd6aeb7d78, envp=<optimized out>) at pimd/pim_main.c:169
(gdb)