### PR TITLE
pimd: PIMd core while doing frr restart after loading config

### DIFF
--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -125,7 +125,9 @@ static void zclient_lookup_failed(struct zclient *zlookup)
 
 void zclient_lookup_free(void)
 {
-	THREAD_OFF(zlookup_read);
+	if (zlookup_read)
+		THREAD_OFF(zlookup_read);
+
 	zclient_stop(zlookup);
 	zclient_free(zlookup);
 	zlookup = NULL;


### PR DESCRIPTION
    gdb) bt
    0  0x00007f94ac174428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
    1  0x00007f94ac17602a in __GI_abort () at abort.c:89
    2  0x00007f94acda8390 in core_handler (signo=11, siginfo=0x7ffd6aeb7430, context=<optimized out>) at lib/sigevent.c:254
    3  <signal handler called>
    4  thread_cancel (thread=0x0) at lib/thread.c:1145
    5  0x000055e83f3c7d80 in zclient_lookup_free () at pimd/pim_zlookup.c:120
    6  0x000055e83f3c8705 in pim_free () at pimd/pimd.c:76
    7  pim_terminate () at pimd/pimd.c:157
    8  0x000055e83f3bdc67 in pim_sigint () at pimd/pim_signals.c:44
    9  0x00007f94acda8433 in quagga_sigevent_process () at lib/sigevent.c:105
    10 0x00007f94acdb564d in thread_fetch (m=m@entry=0x55e83fe84630, fetch=fetch@entry=0x7ffd6aeb7a60) at lib/thread.c:1379
    11 0x00007f94acd870b3 in frr_run (master=0x55e83fe84630) at lib/libfrr.c:1025
    12 0x000055e83f39e0cf in main (argc=<optimized out>, argv=0x7ffd6aeb7d78, envp=<optimized out>) at pimd/pim_main.c:169
    (gdb)

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>