### PR TITLE
pimd: SPT-bit is not set to false as per RFC section in one flow

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -628,7 +628,7 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 		ifaddr = connected_src->u.prefix4;
 		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list, ifaddr);
 
-		if (PIM_DEBUG_MROUTE) {
+		if (PIM_DEBUG_IGMP_PACKETS) {
 			zlog_debug(
 				"%s(%s): igmp kernel upcall on %s(%p) for %pI4 -> %pI4",
 				__func__, pim->vrf->name, ifp->name, igmp,

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -749,6 +749,13 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 		bool send_xg_jp = false;
 
 		forward_off(up);
+		/*
+		 * RFC 4601 Sec 4.5.7:
+		 * JoinDesired(S,G) -> False, set SPTbit to false.
+		 */
+		if (up->sg.src.s_addr != INADDR_ANY)
+			up->sptbit = PIM_UPSTREAM_SPTBIT_FALSE;
+
 		if (old_state == PIM_UPSTREAM_JOINED)
 			pim_msdp_up_join_state_changed(pim, up);
 


### PR DESCRIPTION
1. As per RFC 4601 Sec 4.5.7:
    * JoinDesired(S,G) -> False, set SPTbit to false.
    
2. Change the debug type.

Signed-Off-by: Mobashshera Rasool <mrasool@vmware.com>