### PR TITLE
tests: Fix gr_tests

### DIFF
--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1.py
@@ -1488,7 +1488,7 @@ def test_BGP_GR_TC_5_1_2_p1(request):
     shutdown_bringup_interface(tgen, "r2", intf)
 
     # Bring up Interface
-    shutdown_bringup_interface(tgen, dut, intf, ifaceaction=True)
+    shutdown_bringup_interface(tgen, "r2", intf, ifaceaction=True)
 
     for addr_type in ADDR_TYPES:
         result = verify_graceful_restart(
@@ -1775,7 +1775,7 @@ def test_BGP_GR_TC_6_1_2_p1(request):
     shutdown_bringup_interface(tgen, "r2", intf)
 
     # Bring up Interface
-    shutdown_bringup_interface(tgen, dut, intf, ifaceaction=True)
+    shutdown_bringup_interface(tgen, "r2", intf, ifaceaction=True)
 
     for addr_type in ADDR_TYPES:
         result = verify_graceful_restart(

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -2449,9 +2449,9 @@ def shutdown_bringup_interface(tgen, dut, intf_name, ifaceaction=False):
 
     router_list = tgen.routers()
     if ifaceaction:
-        logger.info("Bringing up interface : {}".format(intf_name))
+        logger.info("Bringing up interface {} : {}".format(dut, intf_name))
     else:
-        logger.info("Shutting down interface : {}".format(intf_name))
+        logger.info("Shutting down interface {} : {}".format(dut, intf_name))
 
     interface_set_status(router_list[dut], intf_name, ifaceaction)
 


### PR DESCRIPTION
The bgp_gr_functionality_topo1 test was shutting down an
interface on r2 and then trying to bring it up on r1.
Hijinx ensued.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>