### PR TITLE
tests: fix redistribute key in ospf tests

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -1659,7 +1659,7 @@ def create_interfaces_cfg(tgen, topo, build=False):
                             interface_data.append("no ip ospf " " hello-interval")
                         else:
                             interface_data.append(
-                                "ip ospf " " hello-interval {}".format(intf_ospf_hello)
+                                "ip ospf" " hello-interval {}".format(intf_ospf_hello)
                             )
 
                     if "dead_interval" in ospf_data:
@@ -1670,7 +1670,7 @@ def create_interfaces_cfg(tgen, topo, build=False):
                             interface_data.append("no ip ospf" " dead-interval")
                         else:
                             interface_data.append(
-                                "ip ospf " " dead-interval {}".format(intf_ospf_dead)
+                                "ip ospf" " dead-interval {}".format(intf_ospf_dead)
                             )
 
                     if "network" in ospf_data:
@@ -3065,7 +3065,11 @@ def verify_rib(
                                     errormsg = (
                                         "[DUT: {}]: tag value {}"
                                         " is not matched for"
-                                        " route {} in RIB \n".format(dut, _tag, st_rt,)
+                                        " route {} in RIB \n".format(
+                                            dut,
+                                            _tag,
+                                            st_rt,
+                                        )
                                     )
                                     return errormsg
 
@@ -3082,7 +3086,11 @@ def verify_rib(
                                     errormsg = (
                                         "[DUT: {}]: metric value "
                                         "{} is not matched for "
-                                        "route {} in RIB \n".format(dut, metric, st_rt,)
+                                        "route {} in RIB \n".format(
+                                            dut,
+                                            metric,
+                                            st_rt,
+                                        )
                                     )
                                     return errormsg
 

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -462,6 +462,32 @@ def clear_ospf(tgen, router):
     logger.debug("Exiting lib API: clear_ospf()")
 
 
+def redistribute_ospf(tgen, topo, dut, route_type, **kwargs):
+    """
+    Redstribution of routes inside ospf.
+
+    Parameters
+    ----------
+    * `tgen`: Topogen object
+    * `topo` : json file data
+    * `dut`: device under test
+    * `route_type`: "static" or "connected" or ....
+    * `kwargs`: pass extra information (see below)
+
+    Usage
+    -----
+    redistribute_ospf(tgen, topo, "r0", "static", delete=True)
+    redistribute_ospf(tgen, topo, "r0", "static", route_map="rmap_ipv4")
+    """
+
+    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
+    for k, v in kwargs.items():
+        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
+
+    result = create_router_ospf(tgen, topo, ospf_red)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+
 ################################
 # Verification procs
 ################################

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -62,7 +62,7 @@ def create_router_ospf(tgen, topo, input_dict=None, build=False, load_config=Tru
         "r1": {
             "ospf": {
                 "router_id": "22.22.22.22",
-                "area": [{ "id":0.0.0.0, "type": "nssa"}]
+                "area": [{ "id": "0.0.0.0", "type": "nssa"}]
         }
     }
 
@@ -327,7 +327,7 @@ def config_ospf_interface(tgen, topo, input_dict=None, build=False, load_config=
                         "links": {
                             "r2": {
                                 "ospf": {
-                                    "authentication": 'message-digest',
+                                    "authentication": "message-digest",
                                     "authentication-key": "ospf",
                                     "message-digest-key": "10"
                                 }
@@ -376,6 +376,7 @@ def config_ospf_interface(tgen, topo, input_dict=None, build=False, load_config=
             if data_ospf_area:
                 cmd = "ip ospf area {}".format(data_ospf_area)
                 config_data.append(cmd)
+
             # interface ospf auth
             if data_ospf_auth:
                 if data_ospf_auth == "null":
@@ -522,7 +523,7 @@ def verify_ospf_neighbor(tgen, topo, dut=None, input_dict=None, lan=False):
 
             logger.info("Verifying OSPF neighborship on router %s:", router)
             show_ospf_json = run_frr_cmd(
-                rnode, "show ip ospf neighbor  all json", isjson=True
+                rnode, "show ip ospf neighbor all json", isjson=True
             )
 
             # Verifying output dictionary show_ospf_json is empty or not
@@ -844,19 +845,23 @@ def verify_ospf_rib(
                                 if "routeType" not in ospf_rib_json[st_rt]:
                                     errormsg = (
                                         "[DUT: {}]: routeType missing"
-                                        "for route {} in OSPF RIB \n".format(dut, st_rt)
+                                        " for route {} in OSPF RIB \n".format(
+                                            dut, st_rt
+                                        )
                                     )
                                     return errormsg
                                 elif _rtype != ospf_rib_json[st_rt]["routeType"]:
                                     errormsg = (
                                         "[DUT: {}]: routeType mismatch"
-                                        "for route {} in OSPF RIB \n".format(dut, st_rt)
+                                        " for route {} in OSPF RIB \n".format(
+                                            dut, st_rt
+                                        )
                                     )
                                     return errormsg
                                 else:
                                     logger.info(
-                                        "DUT: {}]: Found routeType {}"
-                                        "for route {}".format(dut, _rtype, st_rt)
+                                        "[DUT: {}]: Found routeType {}"
+                                        " for route {}".format(dut, _rtype, st_rt)
                                     )
                             if tag:
                                 if "tag" not in ospf_rib_json[st_rt]:

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
@@ -184,38 +184,6 @@ def teardown_module(mod):
     logger.info("=" * 40)
 
 
-def red_static(dut, config=True):
-    """Local def for Redstribute static routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-    if config:
-        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "static"}]}}}
-    else:
-        ospf_red = {
-            dut: {"ospf": {"redistribute": [{"redist_type": "static", "delete": True}]}}
-        }
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
-
-
-def red_connected(dut, config=True):
-    """Local def for Redstribute connected routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-    if config:
-        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "connected"}]}}}
-    else:
-        ospf_red = {
-            dut: {
-                "ospf": {
-                    "redistribute": [{"redist_type": "connected", "del_action": True}]
-                }
-            }
-        }
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase: Failed \n Error: {}".format(result)
-
-
 def redistribute(dut, route_type, **kwargs):
     """Local def for redstribution of routes inside ospf."""
     global topo

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
@@ -216,6 +216,19 @@ def red_connected(dut, config=True):
     assert result is True, "Testcase: Failed \n Error: {}".format(result)
 
 
+def redistribute(dut, route_type, **kwargs):
+    """Local def for redstribution of routes inside ospf."""
+    global topo
+    tgen = get_topogen()
+
+    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
+    for k, v in kwargs.items():
+        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
+
+    result = create_router_ospf(tgen, topo, ospf_red)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+
 # ##################################
 # Test cases start here.
 # ##################################

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
@@ -277,7 +277,7 @@ def test_ospf_ecmp_tc16_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     dut = "r0"
-    red_static(dut)
+    redistribute(dut, "static")
 
     step("Verify that route in R2 in stalled with 8 next hops.")
     nh = []
@@ -358,7 +358,7 @@ def test_ospf_ecmp_tc16_p0(request):
     step(" Un configure static route on R0")
 
     dut = "r0"
-    red_static(dut, config=False)
+    redistribute(dut, "static", delete=True)
 
     # Wait for R0 to flush external LSAs.
     sleep(10)
@@ -389,7 +389,7 @@ def test_ospf_ecmp_tc16_p0(request):
 
     step("Re configure the static route in R0.")
     dut = "r0"
-    red_static(dut)
+    redistribute(dut, "static")
 
     dut = "r1"
     result = verify_ospf_rib(tgen, dut, input_dict, next_hop=nh)
@@ -444,7 +444,7 @@ def test_ospf_ecmp_tc17_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     dut = "r0"
-    red_static(dut)
+    redistribute(dut, "static")
 
     step("Verify that route in R2 in stalled with 2 next hops.")
 
@@ -463,7 +463,7 @@ def test_ospf_ecmp_tc17_p0(request):
     step(" Un configure static route on R0")
 
     dut = "r0"
-    red_static(dut, config=False)
+    redistribute(dut, "static", delete=True)
     # sleep till the route gets withdrawn
     sleep(10)
 
@@ -493,7 +493,7 @@ def test_ospf_ecmp_tc17_p0(request):
 
     step("Reconfigure the static route in R0.Change ECMP value to 2.")
     dut = "r0"
-    red_static(dut)
+    redistribute(dut, "static")
 
     step("Configure cost on R0 as 100")
     r0_ospf_cost = {"r0": {"links": {"r1": {"ospf": {"cost": 100}}}}}

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
@@ -65,6 +65,7 @@ from lib.ospf import (
     verify_ospf_rib,
     create_router_ospf,
     verify_ospf_interface,
+    redistribute_ospf,
 )
 
 topo = None
@@ -184,19 +185,6 @@ def teardown_module(mod):
     logger.info("=" * 40)
 
 
-def redistribute(dut, route_type, **kwargs):
-    """Local def for redstribution of routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-
-    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
-    for k, v in kwargs.items():
-        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
-
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
-
-
 # ##################################
 # Test cases start here.
 # ##################################
@@ -245,7 +233,7 @@ def test_ospf_ecmp_tc16_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     dut = "r0"
-    redistribute(dut, "static")
+    redistribute_ospf(tgen, topo, dut, "static")
 
     step("Verify that route in R2 in stalled with 8 next hops.")
     nh = []
@@ -326,7 +314,7 @@ def test_ospf_ecmp_tc16_p0(request):
     step(" Un configure static route on R0")
 
     dut = "r0"
-    redistribute(dut, "static", delete=True)
+    redistribute_ospf(tgen, topo, dut, "static", delete=True)
 
     # Wait for R0 to flush external LSAs.
     sleep(10)
@@ -357,7 +345,7 @@ def test_ospf_ecmp_tc16_p0(request):
 
     step("Re configure the static route in R0.")
     dut = "r0"
-    redistribute(dut, "static")
+    redistribute_ospf(tgen, topo, dut, "static")
 
     dut = "r1"
     result = verify_ospf_rib(tgen, dut, input_dict, next_hop=nh)
@@ -412,7 +400,7 @@ def test_ospf_ecmp_tc17_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     dut = "r0"
-    redistribute(dut, "static")
+    redistribute_ospf(tgen, topo, dut, "static")
 
     step("Verify that route in R2 in stalled with 2 next hops.")
 
@@ -431,7 +419,7 @@ def test_ospf_ecmp_tc17_p0(request):
     step(" Un configure static route on R0")
 
     dut = "r0"
-    redistribute(dut, "static", delete=True)
+    redistribute_ospf(tgen, topo, dut, "static", delete=True)
     # sleep till the route gets withdrawn
     sleep(10)
 
@@ -461,7 +449,7 @@ def test_ospf_ecmp_tc17_p0(request):
 
     step("Reconfigure the static route in R0.Change ECMP value to 2.")
     dut = "r0"
-    redistribute(dut, "static")
+    redistribute_ospf(tgen, topo, dut, "static")
 
     step("Configure cost on R0 as 100")
     r0_ospf_cost = {"r0": {"links": {"r1": {"ospf": {"cost": 100}}}}}

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
@@ -187,42 +187,6 @@ def teardown_module():
         pass
 
 
-def red_static(dut, config=True):
-    """Local def for Redstribute static routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-    if config:
-        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "static"}]}}}
-    else:
-        ospf_red = {
-            dut: {
-                "ospf": {
-                    "redistribute": [{"redist_type": "static", "del_action": True}]
-                }
-            }
-        }
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
-
-
-def red_connected(dut, config=True):
-    """Local def for Redstribute connected routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-    if config:
-        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "connected"}]}}}
-    else:
-        ospf_red = {
-            dut: {
-                "ospf": {
-                    "redistribute": [{"redist_type": "connected", "del_action": True}]
-                }
-            }
-        }
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase: Failed \n Error: {}".format(result)
-
-
 def redistribute(dut, route_type, **kwargs):
     """Local def for redstribution of routes inside ospf."""
     global topo

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
@@ -288,7 +288,7 @@ def test_ospf_lan_ecmp_tc18_p0(request):
         )
 
         dut = rtr
-        red_static(dut)
+        redistribute(dut, "static")
 
     step(
         "Verify that route in R0 in stalled with 8 hops. "

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
@@ -223,6 +223,19 @@ def red_connected(dut, config=True):
     assert result is True, "Testcase: Failed \n Error: {}".format(result)
 
 
+def redistribute(dut, route_type, **kwargs):
+    """Local def for redstribution of routes inside ospf."""
+    global topo
+    tgen = get_topogen()
+
+    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
+    for k, v in kwargs.items():
+        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
+
+    result = create_router_ospf(tgen, topo, ospf_red)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+
 # ##################################
 # Test cases start here.
 # ##################################

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
@@ -66,6 +66,7 @@ from lib.ospf import (
     verify_ospf_rib,
     create_router_ospf,
     verify_ospf_interface,
+    redistribute_ospf,
 )
 from ipaddress import IPv4Address
 
@@ -187,19 +188,6 @@ def teardown_module():
         pass
 
 
-def redistribute(dut, route_type, **kwargs):
-    """Local def for redstribution of routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-
-    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
-    for k, v in kwargs.items():
-        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
-
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
-
-
 # ##################################
 # Test cases start here.
 # ##################################
@@ -252,7 +240,7 @@ def test_ospf_lan_ecmp_tc18_p0(request):
         )
 
         dut = rtr
-        redistribute(dut, "static")
+        redistribute_ospf(tgen, topo, dut, "static")
 
     step(
         "Verify that route in R0 in stalled with 8 hops. "

--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -219,6 +219,19 @@ def red_connected(dut, config=True):
     assert result is True, "Testcase: Failed \n Error: {}".format(result)
 
 
+def redistribute(dut, route_type, **kwargs):
+    """Local def for redstribution of routes inside ospf."""
+    global topo
+    tgen = get_topogen()
+
+    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
+    for k, v in kwargs.items():
+        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
+
+    result = create_router_ospf(tgen, topo, ospf_red)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+
 # ##################################
 # Test cases start here.
 # ##################################

--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -183,19 +183,6 @@ def teardown_module():
         pass
 
 
-def redistribute(dut, route_type, **kwargs):
-    """Local def for redstribution of routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-
-    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
-    for k, v in kwargs.items():
-        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
-
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
-
-
 # ##################################
 # Test cases start here.
 # ##################################

--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -183,42 +183,6 @@ def teardown_module():
         pass
 
 
-def red_static(dut, config=True):
-    """Local def for Redstribute static routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-    if config:
-        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "static"}]}}}
-    else:
-        ospf_red = {
-            dut: {
-                "ospf": {
-                    "redistribute": [{"redist_type": "static", "del_action": True}]
-                }
-            }
-        }
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
-
-
-def red_connected(dut, config=True):
-    """Local def for Redstribute connected routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-    if config:
-        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "connected"}]}}}
-    else:
-        ospf_red = {
-            dut: {
-                "ospf": {
-                    "redistribute": [{"redist_type": "connected", "del_action": True}]
-                }
-            }
-        }
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase: Failed \n Error: {}".format(result)
-
-
 def redistribute(dut, route_type, **kwargs):
     """Local def for redstribution of routes inside ospf."""
     global topo

--- a/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
@@ -181,38 +181,6 @@ def teardown_module(mod):
     logger.info("=" * 40)
 
 
-def red_static(dut, config=True):
-    """Local def for Redstribute static routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-    if config:
-        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "static"}]}}}
-    else:
-        ospf_red = {
-            dut: {"ospf": {"redistribute": [{"redist_type": "static", "delete": True}]}}
-        }
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
-
-
-def red_connected(dut, config=True):
-    """Local def for Redstribute connected routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-    if config:
-        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "connected"}]}}}
-    else:
-        ospf_red = {
-            dut: {
-                "ospf": {
-                    "redistribute": [{"redist_type": "connected", "del_action": True}]
-                }
-            }
-        }
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase: Failed \n Error: {}".format(result)
-
-
 def redistribute(dut, route_type, **kwargs):
     """Local def for redstribution of routes inside ospf."""
     global topo

--- a/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
@@ -213,6 +213,19 @@ def red_connected(dut, config=True):
     assert result is True, "Testcase: Failed \n Error: {}".format(result)
 
 
+def redistribute(dut, route_type, **kwargs):
+    """Local def for redstribution of routes inside ospf."""
+    global topo
+    tgen = get_topogen()
+
+    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
+    for k, v in kwargs.items():
+        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
+
+    result = create_router_ospf(tgen, topo, ospf_red)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+
 # ##################################
 # Test cases start here.
 # ##################################

--- a/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
@@ -281,7 +281,7 @@ def test_ospf_learning_tc15_p0(request):
 
     step("Redistribute static route in R2 ospf.")
     dut = "r2"
-    red_static(dut)
+    redistribute(dut, "static")
 
     step("Verify that Type 5 LSA is originated by R2.")
     dut = "r0"

--- a/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
@@ -30,6 +30,7 @@ from lib.ospf import (
     verify_ospf_rib,
     create_router_ospf,
     verify_ospf_interface,
+    redistribute_ospf,
 )
 from lib.topojson import build_topo_from_json, build_config_from_json
 from lib.topolog import logger
@@ -181,19 +182,6 @@ def teardown_module(mod):
     logger.info("=" * 40)
 
 
-def redistribute(dut, route_type, **kwargs):
-    """Local def for redstribution of routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-
-    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
-    for k, v in kwargs.items():
-        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
-
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
-
-
 # ##################################
 # Test cases start here.
 # ##################################
@@ -249,7 +237,7 @@ def test_ospf_learning_tc15_p0(request):
 
     step("Redistribute static route in R2 ospf.")
     dut = "r2"
-    redistribute(dut, "static")
+    redistribute_ospf(tgen, topo, dut, "static")
 
     step("Verify that Type 5 LSA is originated by R2.")
     dut = "r0"

--- a/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
@@ -193,6 +193,19 @@ def teardown_module(mod):
     logger.info("=" * 40)
 
 
+def redistribute(dut, route_type, **kwargs):
+    """Local def for redstribution of routes inside ospf."""
+    global topo
+    tgen = get_topogen()
+
+    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
+    for k, v in kwargs.items():
+        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
+
+    result = create_router_ospf(tgen, topo, ospf_red)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+
 # ##################################
 # Test cases start here.
 # ##################################

--- a/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
@@ -62,6 +62,7 @@ from lib.ospf import (
     verify_ospf_rib,
     create_router_ospf,
     verify_ospf_database,
+    redistribute_ospf,
 )
 
 # Global variables
@@ -193,19 +194,6 @@ def teardown_module(mod):
     logger.info("=" * 40)
 
 
-def redistribute(dut, route_type, **kwargs):
-    """Local def for redstribution of routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-
-    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
-    for k, v in kwargs.items():
-        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
-
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
-
-
 # ##################################
 # Test cases start here.
 # ##################################
@@ -239,7 +227,7 @@ def test_ospf_routemaps_functionality_tc19_p0(request):
     result = create_static_routes(tgen, input_dict)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    redistribute("r0", "static")
+    redistribute_ospf(tgen, topo, "r0", "static")
 
     dut = "r1"
     lsid = NETWORK["ipv4"][0].split("/")[0]
@@ -251,7 +239,7 @@ def test_ospf_routemaps_functionality_tc19_p0(request):
     result = verify_rib(tgen, "ipv4", dut, input_dict, protocol=protocol)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    redistribute("r0", "static", delete=True)
+    redistribute_ospf(tgen, topo, "r0", "static", delete=True)
 
     step(
         "Create prefix-list in R0 to permit 10.0.20.1/32 prefix &" " deny 10.0.20.2/32"
@@ -298,7 +286,7 @@ def test_ospf_routemaps_functionality_tc19_p0(request):
         " ospf using route map rmap1"
     )
 
-    redistribute("r0", "static", route_map="rmap_ipv4")
+    redistribute_ospf(tgen, topo, "r0", "static", route_map="rmap_ipv4")
 
     step("Change prefix rules to permit 10.0.20.2 and deny 10.0.20.1")
     # Create ip prefix list
@@ -492,7 +480,7 @@ def test_ospf_routemaps_functionality_tc20_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     step("Redistribute to ospf using route map ( non existent route map)")
-    redistribute("r0", "static", route_map="rmap_ipv4")
+    redistribute_ospf(tgen, topo, "r0", "static", route_map="rmap_ipv4")
 
     step(
         "Verify that routes are not allowed in OSPF even tough no "
@@ -622,7 +610,7 @@ def test_ospf_routemaps_functionality_tc21_p0(request):
     result = create_static_routes(tgen, input_dict)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    redistribute("r0", "static", route_map="rmap_ipv4")
+    redistribute_ospf(tgen, topo, "r0", "static", route_map="rmap_ipv4")
 
     # Create route map
     routemaps = {
@@ -858,7 +846,7 @@ def test_ospf_routemaps_functionality_tc24_p0(request):
     result = create_static_routes(tgen, input_dict)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    redistribute("r0", "static", route_map="rmap_ipv4")
+    redistribute_ospf(tgen, topo, "r0", "static", route_map="rmap_ipv4")
 
     # Create ip prefix list
     pfx_list = {

--- a/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
@@ -239,9 +239,7 @@ def test_ospf_routemaps_functionality_tc19_p0(request):
     result = create_static_routes(tgen, input_dict)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    ospf_red_r1 = {"r0": {"ospf": {"redistribute": [{"redist_type": "static"}]}}}
-    result = create_router_ospf(tgen, topo, ospf_red_r1)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    redistribute("r0", "static")
 
     dut = "r1"
     lsid = NETWORK["ipv4"][0].split("/")[0]
@@ -253,13 +251,7 @@ def test_ospf_routemaps_functionality_tc19_p0(request):
     result = verify_rib(tgen, "ipv4", dut, input_dict, protocol=protocol)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    ospf_red_r1 = {
-        "r0": {
-            "ospf": {"redistribute": [{"redist_type": "static", "del_action": True}]}
-        }
-    }
-    result = create_router_ospf(tgen, topo, ospf_red_r1)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    redistribute("r0", "static", delete=True)
 
     step(
         "Create prefix-list in R0 to permit 10.0.20.1/32 prefix &" " deny 10.0.20.2/32"
@@ -306,15 +298,7 @@ def test_ospf_routemaps_functionality_tc19_p0(request):
         " ospf using route map rmap1"
     )
 
-    ospf_red_r1 = {
-        "r0": {
-            "ospf": {
-                "redistribute": [{"redist_type": "static", "route_map": "rmap_ipv4"}]
-            }
-        }
-    }
-    result = create_router_ospf(tgen, topo, ospf_red_r1)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    redistribute("r0", "static", route_map="rmap_ipv4")
 
     step("Change prefix rules to permit 10.0.20.2 and deny 10.0.20.1")
     # Create ip prefix list
@@ -508,15 +492,7 @@ def test_ospf_routemaps_functionality_tc20_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     step("Redistribute to ospf using route map ( non existent route map)")
-    ospf_red_r1 = {
-        "r0": {
-            "ospf": {
-                "redistribute": [{"redist_type": "static", "route_map": "rmap_ipv4"}]
-            }
-        }
-    }
-    result = create_router_ospf(tgen, topo, ospf_red_r1)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    redistribute("r0", "static", route_map="rmap_ipv4")
 
     step(
         "Verify that routes are not allowed in OSPF even tough no "
@@ -646,15 +622,7 @@ def test_ospf_routemaps_functionality_tc21_p0(request):
     result = create_static_routes(tgen, input_dict)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    ospf_red_r0 = {
-        "r0": {
-            "ospf": {
-                "redistribute": [{"redist_type": "static", "route_map": "rmap_ipv4"}]
-            }
-        }
-    }
-    result = create_router_ospf(tgen, topo, ospf_red_r0)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    redistribute("r0", "static", route_map="rmap_ipv4")
 
     # Create route map
     routemaps = {
@@ -890,15 +858,7 @@ def test_ospf_routemaps_functionality_tc24_p0(request):
     result = create_static_routes(tgen, input_dict)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    ospf_red_r0 = {
-        "r0": {
-            "ospf": {
-                "redistribute": [{"redist_type": "static", "route_map": "rmap_ipv4"}]
-            }
-        }
-    }
-    result = create_router_ospf(tgen, topo, ospf_red_r0)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    redistribute("r0", "static", route_map="rmap_ipv4")
 
     # Create ip prefix list
     pfx_list = {

--- a/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
@@ -499,8 +499,8 @@ def test_ospf_redistribution_tc8_p1(request):
         "advertised/exchaged via ospf"
     )
     for rtr in topo["routers"]:
-        red_static(rtr)
-        red_connected(rtr)
+        redistribute(rtr, "static")
+        redistribute(rtr, "connected")
     for node in topo["routers"]:
         input_dict = {
             "r0": {
@@ -557,13 +557,7 @@ def test_ospf_redistribution_tc8_p1(request):
     )
 
     for rtr in topo["routers"]:
-        ospf_red = {
-            rtr: {"ospf": {"redistribute": [{"redist_type": "static", "delete": True}]}}
-        }
-        result = create_router_ospf(tgen, topo, ospf_red)
-        assert result is True, "Testcase {} : Failed \n Error: {}".format(
-            tc_name, result
-        )
+        redistribute(rtr, "static", delete=True)
 
     input_dict = {
         "r0": {

--- a/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
@@ -61,6 +61,7 @@ from lib.ospf import (
     clear_ospf,
     verify_ospf_rib,
     create_router_ospf,
+    redistribute_ospf,
 )
 
 # Global variables
@@ -181,19 +182,6 @@ def teardown_module(mod):
         "Testsuite end time: {}".format(time.asctime(time.localtime(time.time())))
     )
     logger.info("=" * 40)
-
-
-def redistribute(dut, route_type, **kwargs):
-    """Local def for redstribution of routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-
-    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
-    for k, v in kwargs.items():
-        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
-
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
 
 
 # ##################################
@@ -463,8 +451,8 @@ def test_ospf_redistribution_tc8_p1(request):
         "advertised/exchaged via ospf"
     )
     for rtr in topo["routers"]:
-        redistribute(rtr, "static")
-        redistribute(rtr, "connected")
+        redistribute_ospf(tgen, topo, rtr, "static")
+        redistribute_ospf(tgen, topo, rtr, "connected")
     for node in topo["routers"]:
         input_dict = {
             "r0": {
@@ -521,7 +509,7 @@ def test_ospf_redistribution_tc8_p1(request):
     )
 
     for rtr in topo["routers"]:
-        redistribute(rtr, "static", delete=True)
+        redistribute_ospf(tgen, topo, rtr, "static", delete=True)
 
     input_dict = {
         "r0": {

--- a/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
@@ -219,6 +219,19 @@ def red_connected(dut, config=True):
     assert result is True, "Testcase: Failed \n Error: {}".format(result)
 
 
+def redistribute(dut, route_type, **kwargs):
+    """Local def for redstribution of routes inside ospf."""
+    global topo
+    tgen = get_topogen()
+
+    ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": route_type}]}}}
+    for k, v in kwargs.items():
+        ospf_red[dut]["ospf"]["redistribute"][0][k] = v
+
+    result = create_router_ospf(tgen, topo, ospf_red)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+
 # ##################################
 # Test cases start here.
 # ##################################

--- a/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
@@ -183,42 +183,6 @@ def teardown_module(mod):
     logger.info("=" * 40)
 
 
-def red_static(dut, config=True):
-    """Local def for Redstribute static routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-    if config:
-        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "static"}]}}}
-    else:
-        ospf_red = {
-            dut: {
-                "ospf": {
-                    "redistribute": [{"redist_type": "static", "del_action": True}]
-                }
-            }
-        }
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase : Failed \n Error: {}".format(result)
-
-
-def red_connected(dut, config=True):
-    """Local def for Redstribute connected routes inside ospf."""
-    global topo
-    tgen = get_topogen()
-    if config:
-        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "connected"}]}}}
-    else:
-        ospf_red = {
-            dut: {
-                "ospf": {
-                    "redistribute": [{"redist_type": "connected", "del_action": True}]
-                }
-            }
-        }
-    result = create_router_ospf(tgen, topo, ospf_red)
-    assert result is True, "Testcase: Failed \n Error: {}".format(result)
-
-
 def redistribute(dut, route_type, **kwargs):
     """Local def for redstribution of routes inside ospf."""
     global topo


### PR DESCRIPTION
In OSPF tests there are a couple of local functions for the redistribution of `statics` and `connected` routes. This PR fixes the key `"del_action"` that should be called `"delete"`

At the end I ended up merging both functions (`red_static` and `red_connected`) into a single function called `redistribute`. Also 3 different commits were performed to ease the review

Also this PR fixes a few typos in the output when running OSPF tests:

```
Output for command [ show ip ospf neighbor  all ] (double space)
ip ospf  hello-interval 1 (double space)
ip ospf  dead-interval 4 (double space)
DUT: r0]: Found routeType N IAfor route 10.0.5.0/24 (missing [ and space)
```
Signed-off-by: ckishimo <carles.kishimoto@gmail.com>