### PR TITLE
tests: Wait for bgp convergence *after* we re-add the interfaces

### DIFF
--- a/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
+++ b/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
@@ -2687,6 +2687,9 @@ def test_delete_and_re_add_vrf_p1(request):
             }
         }
 
+        result = verify_bgp_convergence(tgen, topo)
+        assert result is True, "Testcase {}: Failed\n Error {}".format(tc_name, result)
+
         result = verify_bgp_rib(tgen, addr_type, dut, input_dict_2)
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
 


### PR DESCRIPTION
In test_bgp_mutli_vrf_topo2.py it's clear that we remove then
re-add the vrf interfaces.  Then the test was immediately
checking to ensure that the routes were available.

BGP needs time to reconverge.  Let's ensure that first.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>