### PR TITLE
pathd: Skip SR-TE topotests if pathd has been disabled

### DIFF
--- a/tests/topotests/isis-sr-te-topo1/test_isis_sr_te_topo1.py
+++ b/tests/topotests/isis-sr-te-topo1/test_isis_sr_te_topo1.py
@@ -150,7 +150,13 @@ class TemplateTopo(Topo):
 
 def setup_module(mod):
     "Sets up the pytest environment"
+
     tgen = Topogen(TemplateTopo, mod.__name__)
+
+    frrdir = tgen.config.get(tgen.CONFIG_SECTION, "frrdir")
+    if not os.path.isfile(os.path.join(frrdir, "pathd")):
+        pytest.skip("pathd daemon wasn't built")
+
     tgen.start_topology()
 
     router_list = tgen.routers()

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1261,6 +1261,7 @@ static struct cmd_node pw_node = {
 	.prompt = "%s(config-pw)# ",
 };
 
+#if defined(HAVE_PATHD)
 static struct cmd_node segment_routing_node = {
 	.name = "segment-routing",
 	.node = SEGMENT_ROUTING_NODE,
@@ -1296,6 +1297,7 @@ static struct cmd_node srte_candidate_dyn_node = {
 	.prompt = "%s(config-sr-te-candidate)# ",
 };
 
+#if defined(HAVE_PATHD_PCEP)
 static struct cmd_node pcep_node = {
 	.name = "srte pcep",
 	.node = PCEP_NODE,
@@ -1323,6 +1325,8 @@ static struct cmd_node pcep_pce_config_node = {
 	.parent_node = PCEP_NODE,
 	.prompt = "%s(pcep-sr-te-pcep-pce-config)# ",
 };
+#endif /* HAVE_PATHD_PCEP */
+#endif /* HAVE_PATHD */
 
 static struct cmd_node vrf_node = {
 	.name = "vrf",
@@ -2548,6 +2552,7 @@ DEFUNSH(VTYSH_KEYS, vtysh_quit_keys, vtysh_quit_keys_cmd, "quit",
 	return vtysh_exit_keys(self, vty, argc, argv);
 }
 
+#if defined(HAVE_PATHD)
 DEFUNSH(VTYSH_PATHD, vtysh_exit_pathd, vtysh_exit_pathd_cmd, "exit",
 	"Exit current mode and down to previous mode\n")
 {
@@ -2559,6 +2564,7 @@ DEFUNSH(VTYSH_PATHD, vtysh_quit_pathd, vtysh_quit_pathd_cmd, "quit",
 {
 	return vtysh_exit_pathd(self, vty, argc, argv);
 }
+#endif /* HAVE_PATHD */
 
 DEFUNSH(VTYSH_ALL, vtysh_exit_line_vty, vtysh_exit_line_vty_cmd, "exit",
 	"Exit current mode and down to previous mode\n")


### PR DESCRIPTION
 * If pathd binary is not found, skip the SR-TE topotests.
 * Fix some compilation warnings when pathd is not built.

Signed-off-by: Sebastien Merle <sebastien@netdef.org>