### PR TITLE
zebra: build the sample dataplane plugin

### DIFF
--- a/zebra/sample_plugin.c
+++ b/zebra/sample_plugin.c
@@ -92,7 +92,6 @@ static int sample_process(struct zebra_dplane_provider *prov)
 static int init_sample_plugin(struct thread_master *tm)
 {
 	int ret;
-	struct zebra_dplane_provider *prov = NULL;
 
 	/* Note that we don't use or store the thread_master 'tm'. We
 	 * don't use the zebra main pthread: our plugin code will run in

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -40,6 +40,11 @@ if LINUX
 module_LTLIBRARIES += zebra/zebra_cumulus_mlag.la
 endif
 
+# Dataplane sample plugin
+if DEV_BUILD
+module_LTLIBRARIES += zebra/dplane_sample_plugin.la
+endif
+
 man8 += $(MANBUILD)/frr-zebra.8
 ## endif ZEBRA
 endif
@@ -204,6 +209,12 @@ if DEV_BUILD
 zebra_zebra_fpm_la_SOURCES += zebra/zebra_fpm_dt.c
 zebra/zebra_fpm_dt.lo: fpm/fpm.pb-c.h qpb/qpb.pb-c.h
 endif
+endif
+
+# Sample dataplane plugin
+if DEV_BUILD
+zebra_dplane_sample_plugin_la_SOURCES = zebra/sample_plugin.c
+zebra_dplane_sample_plugin_la_LDFLAGS = -module -shared -avoid-version -export-dynamic
 endif
 
 nodist_zebra_zebra_SOURCES = \


### PR DESCRIPTION
Add the sample zebra dataplane plugin module to the build for debug/dev builds. The idea is to build it more regularly and catch any issues with the sample code; it's not used or loaded. Also removed an unused local.