### PR TITLE
zebra: Send RMAC along with Type-5 prefix

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -620,6 +620,8 @@ void nexthop_copy_no_recurse(struct nexthop *copy,
 		nexthop_add_labels(copy, nexthop->nh_label_type,
 				   nexthop->nh_label->num_labels,
 				   &nexthop->nh_label->label[0]);
+	memcpy(&copy->nh_encap.encap_data.rmac,
+	       &nexthop->nh_encap.encap_data.rmac, ETH_ALEN);
 }
 
 void nexthop_copy(struct nexthop *copy, const struct nexthop *nexthop,

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -65,6 +65,11 @@ enum nh_encap_type {
 /* Backup index value is limited */
 #define NEXTHOP_BACKUP_IDX_MAX 255
 
+struct vxlan_nh_encap {
+	vni_t vni;
+	struct ethaddr rmac;
+};
+
 /* Nexthop structure. */
 struct nexthop {
 	struct nexthop *next;
@@ -134,7 +139,7 @@ struct nexthop {
 	/* Encapsulation information. */
 	enum nh_encap_type nh_encap_type;
 	union {
-		vni_t vni;
+		struct vxlan_nh_encap encap_data;
 	} nh_encap;
 
 	/* SR-TE color used for matching SR-TE policies */

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1623,7 +1623,7 @@ static int netlink_route_nexthop_encap(struct nlmsghdr *n, size_t nlen,
 			return false;
 
 		if (!nl_attr_put32(n, nlen, 0 /* VXLAN_VNI */,
-				   nh->nh_encap.vni))
+				   nh->nh_encap.encap_data.vni))
 			return false;
 		nl_attr_nest_end(n, nest);
 		break;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1511,6 +1511,8 @@ static struct nexthop *nexthop_from_zapi(const struct zapi_nexthop *api_nh,
 			       sizeof(struct in_addr));
 			zebra_vxlan_evpn_vrf_route_add(
 				api_nh->vrf_id, &api_nh->rmac, &vtep_ip, p);
+			memcpy(&(nexthop->nh_encap.encap_data.rmac),
+			       &api_nh->rmac, ETH_ALEN);
 		}
 		break;
 	case NEXTHOP_TYPE_IPV6:
@@ -1544,6 +1546,8 @@ static struct nexthop *nexthop_from_zapi(const struct zapi_nexthop *api_nh,
 			       sizeof(struct in6_addr));
 			zebra_vxlan_evpn_vrf_route_add(
 				api_nh->vrf_id, &api_nh->rmac, &vtep_ip, p);
+			memcpy(&(nexthop->nh_encap.encap_data.rmac),
+			       &api_nh->rmac, ETH_ALEN);
 		}
 		break;
 	case NEXTHOP_TYPE_BLACKHOLE:

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2042,7 +2042,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		zl3vni = zl3vni_from_vrf(nexthop->vrf_id);
 		if (zl3vni && is_l3vni_oper_up(zl3vni)) {
 			nexthop->nh_encap_type = NET_VXLAN;
-			nexthop->nh_encap.vni = zl3vni->vni;
+			nexthop->nh_encap.encap_data.vni = zl3vni->vni;
 		}
 	}
 

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -94,10 +94,12 @@ static const char *fpm_nh_encap_type_to_str(enum fpm_nh_encap_type_t encap_type)
 
 struct vxlan_encap_info_t {
 	vni_t vni;
+	struct ethaddr rmac;
 };
 
 enum vxlan_encap_info_type_t {
 	VXLAN_VNI = 0,
+	VXLAN_RMAC = 1,
 };
 
 struct fpm_nh_encap_info_t {
@@ -203,6 +205,8 @@ static int netlink_route_info_add_nh(struct netlink_route_info *ri,
 
 			/* Add VNI to VxLAN encap info */
 			nhi.encap_info.vxlan_encap.vni = zl3vni->vni;
+			memcpy(&nhi.encap_info.vxlan_encap.rmac,
+			       &(nexthop->nh_encap.encap_data.rmac), ETH_ALEN);
 		}
 	}
 
@@ -419,9 +423,16 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 			nl_attr_put16(&req->n, in_buf_len, RTA_ENCAP_TYPE,
 				      encap);
 			vxlan = &nhi->encap_info.vxlan_encap;
+			char buf[ETHER_ADDR_STRLEN];
+
+			zfpm_debug(
+				"%s: VNI:%d RMAC:%s", __func__, vxlan->vni,
+				prefix_mac2str(&vxlan->rmac, buf, sizeof(buf)));
 			nest = nl_attr_nest(&req->n, in_buf_len, RTA_ENCAP);
 			nl_attr_put32(&req->n, in_buf_len, VXLAN_VNI,
 				      vxlan->vni);
+			nl_attr_put(&req->n, in_buf_len, VXLAN_RMAC,
+				    &vxlan->rmac, sizeof(vxlan->rmac));
 			nl_attr_nest_end(&req->n, nest);
 			break;
 		}
@@ -455,10 +466,18 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 			nl_attr_put16(&req->n, in_buf_len, RTA_ENCAP_TYPE,
 				      encap);
 			vxlan = &nhi->encap_info.vxlan_encap;
+			char rmac_buf[ETHER_ADDR_STRLEN];
+
+			zfpm_debug("%s: Multi VNI:%d RMAC:%s", __func__,
+				   vxlan->vni,
+				   prefix_mac2str(&vxlan->rmac, rmac_buf,
+						  sizeof(rmac_buf)));
 			inner_nest =
 				nl_attr_nest(&req->n, in_buf_len, RTA_ENCAP);
 			nl_attr_put32(&req->n, in_buf_len, VXLAN_VNI,
 				      vxlan->vni);
+			nl_attr_put(&req->n, in_buf_len, VXLAN_RMAC,
+				    &vxlan->rmac, sizeof(vxlan->rmac));
 			nl_attr_nest_end(&req->n, inner_nest);
 			break;
 		}


### PR DESCRIPTION
Send RMAC along with VNI to FPM for EVPN Type-5 routes

When Zebra receive EVPN Type-5 prefix it create nexthop, adding code to copy RMAC as well in the nexthop. So that when prefix is encoded to send to the FPM, it encode RMAC as well.
In current system RMAC can be retrieved from RMAC send to FPM, It requires lot of processing in FPM, if RMAC for the tunnel changes from MAC1 to MAC2. This is overhead in FPM, we can optimize this by send RMAC as well with the prefix.

Signed-off-by: Kishore Kunal <kishorekunal01@broadcom.com>