### PR TITLE
pimd: fix recursive lookup for RP

### DIFF
--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -400,8 +400,6 @@ int zclient_lookup_nexthop(struct pim_instance *pim,
 			   int max_lookup)
 {
 	int lookup;
-	uint32_t route_metric = 0xFFFFFFFF;
-	uint8_t protocol_distance = 0xFF;
 
 	pim->nexthop_lookups++;
 
@@ -423,13 +421,6 @@ int zclient_lookup_nexthop(struct pim_instance *pim,
 					pim->vrf->name);
 			}
 			return -1;
-		}
-
-		if (lookup < 1) {
-			/* this is the non-recursive lookup - save original
-			 * metric/distance */
-			route_metric = nexthop_tab[0].route_metric;
-			protocol_distance = nexthop_tab[0].protocol_distance;
 		}
 
 		/*
@@ -464,14 +455,6 @@ int zclient_lookup_nexthop(struct pim_instance *pim,
 							.protocol_distance,
 						nexthop_tab[0].route_metric);
 				}
-
-				/* use last address as nexthop address */
-				nexthop_tab[0].nexthop_addr.u.prefix4 = addr;
-
-				/* report original route metric/distance */
-				nexthop_tab[0].route_metric = route_metric;
-				nexthop_tab[0].protocol_distance =
-					protocol_distance;
 			}
 
 			return num_ifindex;


### PR DESCRIPTION
Topology:
Client---R1(1.1.1.1)---4link---R2(2.2.2.2)---cisco(3.3.3.3)
3.3.3.3 is RP.
R1(1.1.1.1) is bgp neighbor with R2(2.2.2.2) and configure static
route 2.2.2.2 via 4 links in order to establish the bgp neighborship.
R1 :B>  3.3.3.0/24 [20/0] via 2.2.2.2 (recursive), 00:13:34
  *                     via 20.0.0.2, ens192, 00:13:34
  *                     via 30.0.0.2, ens224, 00:13:34
  *                     via 40.0.0.2, ens256, 00:13:34
  *                     via 50.0.0.2, ens161, 00:13:34

Issue:
R1 > rp info incoming interface is ens224 and (*, G ) mroute pointing to ens192
This is not expected.

Root Cause:
In R1, RP(3.3.3.3) is a recursive route. zclient_lookup_nexthop() lookup
for 3.3.3.3 which will give the nexthop as 2.2.2.2 which is a recursive route.
So it will lookup for 2.2.2.2 and will get 4 non-recursive nexthops 20.0.0.2,
30.0.0.2, 40.0.0.2 and 50.0.0.2. Since it is a recursive lookup, 20.0.0.2 is
replaced by 2.2.2.2. The final nexthop we will get as 2.2.2.2, 30.0.0.2, 40.0.0.2
and 50.0.0.2. Since 2.2.2.2(1st nexthop) we dont have any pim neighbor,
30.0.0.2(2nd nexthop) will be choosen as nexthop for route 3.3.3.3 and rp iif
updated as ens224.

Where as pim nexthop cache will have the 3.3.3.3 nexthops as 20.0.0.2, 30.0.0.2,
40.0.0.2, 50.0.0.2. That's why (*,G) mroute iif will be set as ens192(first nexthop).

Fix: zclient_lookup_nexthop() dont replace the first nexthop with the recursive route.

Signed-off-by: Sarita Patra <saritap@vmware.com>