### PR TITLE
doc: fix several issues, remind about 'no' in cli index statements

### DIFF
--- a/doc/developer/index.rst
+++ b/doc/developer/index.rst
@@ -18,4 +18,5 @@ FRRouting Developer's Guide
    ospf
    zebra
    vtysh
-   pathd
+   path
+   link-state

--- a/doc/developer/logging.rst
+++ b/doc/developer/logging.rst
@@ -83,7 +83,7 @@ Extensions
 +-----------+--------------------------+----------------------------------------------+
 | ``%pNHs`` | ``struct nexthop *``     | ``1.2.3.4 if 15``                            |
 +-----------+--------------------------+----------------------------------------------+
-| ``%pFX``  + ``struct bgp_dest *``    | ``fe80::1234/64`` available in BGP only      |
+| ``%pFX``  | ``struct bgp_dest *``    | ``fe80::1234/64`` (available in BGP only)    |
 +-----------+--------------------------+----------------------------------------------+
 
 Printf features like field lengths can be used normally with these extensions,

--- a/doc/developer/subdir.am
+++ b/doc/developer/subdir.am
@@ -33,6 +33,7 @@ dev_RSTFILES = \
 	doc/developer/include-compile.rst \
 	doc/developer/index.rst \
 	doc/developer/library.rst \
+	doc/developer/link-state.rst \
 	doc/developer/lists.rst \
 	doc/developer/locking.rst \
 	doc/developer/logging.rst \
@@ -52,6 +53,7 @@ dev_RSTFILES = \
 	doc/developer/path.rst \
 	doc/developer/rcu.rst \
 	doc/developer/static-linking.rst \
+	doc/developer/tracing.rst \
 	doc/developer/testing.rst \
 	doc/developer/topotests-snippets.rst \
 	doc/developer/topotests.rst \

--- a/doc/developer/tracing.rst
+++ b/doc/developer/tracing.rst
@@ -57,7 +57,7 @@ run the target in non-forking mode (no ``-d``) and use LTTng as usual (refer to
 LTTng user manual). When using USDT probes with LTTng, follow the example in
 `this article
 <https://lttng.org/blog/2019/10/15/new-dynamic-user-space-tracing-in-lttng/>`_.
-To trace with dtrace or SystemTap, compile with :option:`--enable-usdt=yes` and
+To trace with dtrace or SystemTap, compile with `--enable-usdt=yes` and
 use your tracer as usual.
 
 To see available USDT probes::

--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -1262,6 +1262,9 @@ When documented this way, CLI commands can be cross referenced with the
 This is very helpful for users who want to quickly remind themselves what a
 particular command does.
 
+When documenting a cli that has a ``no`` form, please do not include
+the ``no`` in the ``.. index::`` line.
+
 Configuration Snippets
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -457,7 +457,7 @@ Reject routes with AS_SET or AS_CONFED_SET types
 Suppress duplicate updates
 --------------------------
 
-.. index:: [no] bgp suppress-duplicates
+.. index:: bgp suppress-duplicates
 .. clicmd:: [no] bgp suppress-duplicates
 
    For example, BGP routers can generate multiple identical announcements with
@@ -1639,7 +1639,7 @@ Configuring Peers
    peer in question.  This number is between 0 and 600 seconds,
    with the default advertisement interval being 0.
 
-.. index:: [no] neighbor PEER timers delayopen (1-240)
+.. index:: neighbor PEER timers delayopen (1-240)
 .. clicmd:: [no] neighbor PEER timers delayopen (1-240)
 
    This command allows the user enable the
@@ -3539,7 +3539,7 @@ starting the daemon and the configuration gets saved, the option will persist
 unless removed from the configuration with the negating command prior to the
 configuration write operation.
 
-.. index:: [no] bgp send-extra-data zebra
+.. index:: bgp send-extra-data zebra
 .. clicmd:: [no] bgp send-extra-data zebra
 
 This Command turns off the ability of BGP to send extra data to zebra.

--- a/doc/user/pathd.rst
+++ b/doc/user/pathd.rst
@@ -115,19 +115,19 @@ Configuration Commands
 
    Configure segment routing traffic engineering.
 
-.. index:: [no] segment-list NAME
+.. index:: segment-list NAME
 .. clicmd:: [no] segment-list NAME
 
    Delete or start a segment list definition.
 
 
-.. index:: [no] index INDEX mpls label LABEL [nai node ADDRESS]
+.. index:: index INDEX mpls label LABEL [nai node ADDRESS]
 .. clicmd:: [no] index INDEX mpls label LABEL [nai node ADDRESS]
 
    Delete or specify a segment in a segment list definition.
 
 
-.. index:: [no] policy color COLOR endpoint ENDPOINT
+.. index:: policy color COLOR endpoint ENDPOINT
 .. clicmd:: [no] policy color COLOR endpoint ENDPOINT
 
    Delete or start a policy definition.
@@ -145,31 +145,31 @@ Configuration Commands
    Specify the policy SID.
 
 
-.. index:: [no] candidate-path preference PREFERENCE name NAME explicit segment-list SEGMENT-LIST-NAME
+.. index:: candidate-path preference PREFERENCE name NAME explicit segment-list SEGMENT-LIST-NAME
 .. clicmd:: [no] candidate-path preference PREFERENCE name NAME explicit segment-list SEGMENT-LIST-NAME
 
    Delete or define an explicit candidate path.
 
 
-.. index:: [no] candidate-path preference PREFERENCE name NAME dynamic
+.. index:: candidate-path preference PREFERENCE name NAME dynamic
 .. clicmd:: [no] candidate-path preference PREFERENCE name NAME dynamic
 
    Delete or start a dynamic candidate path definition.
 
 
-.. index:: [no] affinity {exclude-any|include-any|include-all} BITPATTERN
+.. index:: affinity {exclude-any|include-any|include-all} BITPATTERN
 .. clicmd:: [no] affinity {exclude-any|include-any|include-all} BITPATTERN
 
    Delete or specify an affinity constraint for a dynamic candidate path.
 
 
-.. index:: [no] bandwidth BANDWIDTH [required]
+.. index:: bandwidth BANDWIDTH [required]
 .. clicmd:: [no] bandwidth BANDWIDTH [required]
 
    Delete or specify a bandwidth constraint for a dynamic candidate path.
 
 
-.. index:: [no] metric [bound] METRIC VALUE [required]
+.. index:: metric [bound] METRIC VALUE [required]
 .. clicmd:: [no] metric [bound] METRIC VALUE [required]
 
    Delete or specify a metric constraint for a dynamic candidate path.
@@ -198,7 +198,7 @@ Configuration Commands
     - bnc: Border Node Count metric
 
 
-.. index:: [no] objective-function OBJFUN1 [required]
+.. index:: objective-function OBJFUN1 [required]
 .. clicmd:: [no] objective-function OBJFUN1 [required]
 
    Delete or specify a PCEP objective function constraint for a dynamic
@@ -224,7 +224,7 @@ Configuration Commands
      - msn: Minimize the number of Shared Nodes [RFC8800]
 
 
-.. index:: [no] debug pathd pcep [basic|path|message|pceplib]
+.. index:: debug pathd pcep [basic|path|message|pceplib]
 .. clicmd:: [no] debug pathd pcep [basic|path|message|pceplib]
 
    Enable or disable debugging for the pcep module:
@@ -241,14 +241,14 @@ Configuration Commands
    Configure PCEP support.
 
 
-.. index:: [no] cep-config NAME
+.. index:: cep-config NAME
 .. clicmd:: [no] pce-config NAME
 
    Define a shared PCE configuration that can be used in multiple PCE
    declarations.
 
 
-.. index:: [no] pce NAME
+.. index:: pce NAME
 .. clicmd:: [no] pce NAME
 
    Define or delete a PCE definition.
@@ -321,7 +321,7 @@ Configuration Commands
    configuration group.
 
 
-.. index:: [no] pcc
+.. index:: pcc
 .. clicmd:: [no] pcc
 
    Disable or start the definition of a PCC.
@@ -333,7 +333,7 @@ Configuration Commands
    Specify the maximum SID depth in a PCC definition.
 
 
-.. index:: [no] peer WORD [precedence (1-255)]
+.. index:: peer WORD [precedence (1-255)]
 .. clicmd:: [no] peer WORD [precedence (1-255)]
 
    Specify a peer and its precedence in a PCC definition.


### PR DESCRIPTION
Fix several issues in the developer docs - some files missing from subdir.am or index, some sphinx issues with source syntax. Add a note reminding folks not to include 'no' in the index statement line for clis that have a 'no' form.