### PR TITLE
zebra: don't set connection-up event pointer directly

### DIFF
--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -517,8 +517,6 @@ static int zfpm_conn_up_thread_cb(struct thread *thread)
 	struct zfpm_rnodes_iter *iter;
 	rib_dest_t *dest;
 
-	zfpm_g->t_conn_up = NULL;
-
 	iter = &zfpm_g->t_conn_up_state.iter;
 
 	if (zfpm_g->state != ZFPM_STATE_ESTABLISHED) {
@@ -547,7 +545,6 @@ static int zfpm_conn_up_thread_cb(struct thread *thread)
 
 		zfpm_g->stats.t_conn_up_yields++;
 		zfpm_rnodes_iter_pause(iter);
-		zfpm_g->t_conn_up = NULL;
 		thread_add_timer_msec(zfpm_g->master, zfpm_conn_up_thread_cb,
 				      NULL, 0, &zfpm_g->t_conn_up);
 		return 0;
@@ -575,12 +572,12 @@ static void zfpm_connection_up(const char *detail)
 	/*
 	 * Start thread to push existing routes to the FPM.
 	 */
-	assert(!zfpm_g->t_conn_up);
+	thread_cancel(&zfpm_g->t_conn_up);
 
 	zfpm_rnodes_iter_init(&zfpm_g->t_conn_up_state.iter);
 
 	zfpm_debug("Starting conn_up thread");
-	zfpm_g->t_conn_up = NULL;
+
 	thread_add_timer_msec(zfpm_g->master, zfpm_conn_up_thread_cb, NULL, 0,
 			      &zfpm_g->t_conn_up);
 	zfpm_g->stats.t_conn_up_starts++;


### PR DESCRIPTION
Use thread_cancel to reset the connection-up processing timer, don't just set a pointer to NULL
