### PR TITLE
tests: Start the ability to mark tests

### DIFF
--- a/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
+++ b/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
@@ -82,7 +82,8 @@ class NetworkTopo(Topo):
 ##
 #####################################################
 
-
+@pytest.mark.ospf
+@pytest.mark.rip
 def setup_module(module):
     global topo, net
     global fatal_error

--- a/tests/topotests/bgp-evpn-mh/test_evpn_mh.py
+++ b/tests/topotests/bgp-evpn-mh/test_evpn_mh.py
@@ -362,7 +362,7 @@ def config_hosts(tgen, hosts):
         host = tgen.gears[host_name]
         config_host(host_name, host)
 
-
+@pytest.mark.pim
 def setup_module(module):
     "Setup topology"
     tgen = Topogen(NetworkTopo, module.__name__)

--- a/tests/topotests/eigrp-topo1/test_eigrp_topo1.py
+++ b/tests/topotests/eigrp-topo1/test_eigrp_topo1.py
@@ -91,7 +91,7 @@ class NetworkTopo(Topo):
 ##
 #####################################################
 
-
+@pytest.mark.eigrp
 def setup_module(module):
     "Setup topology"
     tgen = Topogen(NetworkTopo, module.__name__)

--- a/tests/topotests/evpn-pim-1/test_evpn_pim_topo1.py
+++ b/tests/topotests/evpn-pim-1/test_evpn_pim_topo1.py
@@ -97,7 +97,7 @@ class NetworkTopo(Topo):
 ##
 #####################################################
 
-
+@pytest.mark.pim
 def setup_module(module):
     "Setup topology"
     tgen = Topogen(NetworkTopo, module.__name__)

--- a/tests/topotests/ldp-topo1/test_ldp_topo1.py
+++ b/tests/topotests/ldp-topo1/test_ldp_topo1.py
@@ -159,7 +159,7 @@ class NetworkTopo(Topo):
 ##
 #####################################################
 
-
+@pytest.mark.ldp
 def setup_module(module):
     global topo, net
     global fatal_error

--- a/tests/topotests/ldp-vpls-topo1/test_ldp_vpls_topo1.py
+++ b/tests/topotests/ldp-vpls-topo1/test_ldp_vpls_topo1.py
@@ -121,7 +121,8 @@ class TemplateTopo(Topo):
         switch.add_link(tgen.gears["r2"])
         switch.add_link(tgen.gears["r3"])
 
-
+@pytest.mark.ldp
+@pytest.mark.ospf
 def setup_module(mod):
     "Sets up the pytest environment"
     tgen = Topogen(TemplateTopo, mod.__name__)

--- a/tests/topotests/pim-basic/test_pim.py
+++ b/tests/topotests/pim-basic/test_pim.py
@@ -80,7 +80,7 @@ class PIMTopo(Topo):
         sw.add_link(tgen.gears["r1"])
         sw.add_link(tgen.gears["r3"])
 
-
+@pytest.mark.pim
 def setup_module(mod):
     "Sets up the pytest environment"
     tgen = Topogen(PIMTopo, mod.__name__)

--- a/tests/topotests/pytest.ini
+++ b/tests/topotests/pytest.ini
@@ -1,6 +1,13 @@
 # Skip pytests example directory
 [pytest]
 norecursedirs = .git example-test example-topojson-test lib docker
+markers =
+	babel: Tests that run against BABEL
+	eigrp: Tests that run against EIGRPD
+	ldp: Tests that run against LDPD
+	ospf: Tests that run against OSPF( v2 and v3 )
+	pim: Tests that run against pim
+	rip: Tests that run against RIP, both v4 and v6
 
 [topogen]
 # Default configuration values

--- a/tests/topotests/rip-topo1/test_rip_topo1.py
+++ b/tests/topotests/rip-topo1/test_rip_topo1.py
@@ -104,7 +104,7 @@ class NetworkTopo(Topo):
 ##
 #####################################################
 
-
+@pytest.mark.rip
 def setup_module(module):
     global topo, net
 

--- a/tests/topotests/ripng-topo1/test_ripng_topo1.py
+++ b/tests/topotests/ripng-topo1/test_ripng_topo1.py
@@ -104,7 +104,7 @@ class NetworkTopo(Topo):
 ##
 #####################################################
 
-
+@pytest.mark.rip
 def setup_module(module):
     global topo, net
 


### PR DESCRIPTION
Add the ability for our topotests to take advantage of pytest `mark`ing.
This effectively allows you to tell pytest to run against certain sets
of tests.  For a demonstration purpose I've added in marks for:
babel
eigrp
ldp
ospf
pim
rip

And setup tests to run against those tests that only test those protocols.

You can run against eigrp tests by running `pytest -k eigrp`
Other combinations are also available based upon simple boolean logic.
Just read the pytest.mark documentation.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>