### PR TITLE
ldpd: fix sporadic failures in the ldp-topo1 topotest

### DIFF
--- a/ldpd/lde.h
+++ b/ldpd/lde.h
@@ -129,9 +129,7 @@ struct fec_node {
 	uint32_t		 pw_remote_status;
 
 	void			*data;		/* fec specific data */
-	uint8_t			 flags;
 };
-#define F_FEC_NHS_CHANGED	0x01
 
 #define CHUNK_SIZE		64
 struct label_chunk {

--- a/ldpd/lde_lib.c
+++ b/ldpd/lde_lib.c
@@ -340,8 +340,6 @@ lde_kernel_insert(struct fec *fec, int af, union ldpd_addr *nexthop,
 
 	fnh = fec_nh_find(fn, af, nexthop, ifindex, route_type, route_instance);
 	if (fnh == NULL) {
-		fn->flags |= F_FEC_NHS_CHANGED;
-
 		fnh = fec_nh_add(fn, af, nexthop, ifindex, route_type,
 		    route_instance);
 		/*
@@ -418,16 +416,10 @@ lde_kernel_update(struct fec *fec)
 			} else
 				fnh->flags |= F_FEC_NH_NO_LDP;
 		} else {
-			fn->flags |= F_FEC_NHS_CHANGED;
 			lde_send_delete_klabel(fn, fnh);
 			fec_nh_del(fnh);
 		}
 	}
-
-	if (!(fn->flags & F_FEC_NHS_CHANGED))
-		/* return earlier if nothing has changed */
-		return;
-	fn->flags &= ~F_FEC_NHS_CHANGED;
 
 	if (LIST_EMPTY(&fn->nexthops)) {
 		RB_FOREACH(ln, nbr_tree, &lde_nbrs)


### PR DESCRIPTION
Commit 220e848cc5 introduced an optimization that would prevent ldpd
from sending redundant label mappings when it receives notifications
from zebra about routes that didn't effectively change (such
notifications can happen under certain circumstances).

The problem is that that commit didn't take into account the metric
of the received routes, so it would dismiss a notification of a
route with a better metric taking the place of another route in the
RIB, preventing the newly selected route from receiving the label
mappings it needs.

Revert 220e848cc5 temporarily to fix sporadic failures in the CI
system until we have a better solution.

Debugged-by: Lynne Morrison lynne@voltanet.io
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>