### PR TITLE
evpn-mh: Advertise SVI MAC as a type-2 route if EVPN MH is enabled

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -561,6 +561,8 @@ static void netlink_interface_update_l2info(struct interface *ifp,
 
 		netlink_extract_vlan_info(link_data, &vlan_info);
 		zebra_l2_vlanif_update(ifp, &vlan_info);
+		zebra_evpn_acc_bd_svi_set(ifp->info, NULL,
+					  !!if_is_operative(ifp));
 	} else if (IS_ZEBRA_IF_VXLAN(ifp)) {
 		struct zebra_l2info_vxlan vxlan_info;
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1183,6 +1183,11 @@ void zebra_if_update_all_links(void)
 						zif->link?zif->link->name:"unk",
 						zif->link_ifindex);
 		}
+
+		/* Update VLAN<=>SVI map */
+		if (IS_ZEBRA_IF_VLAN(ifp))
+			zebra_evpn_acc_bd_svi_set(zif, NULL,
+						  !!if_is_operative(ifp));
 	}
 }
 

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -434,7 +434,7 @@ int zebra_evpn_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
 	vxl = &zif->l2info.vxl;
 
 	if (zebra_evpn_mac_gw_macip_add(ifp, zevpn, ip, &mac, macaddr,
-					vxl->access_vlan)
+					vxl->access_vlan, true)
 	    != 0)
 		return -1;
 

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -932,6 +932,8 @@ void zebra_evpn_read_mac_neigh(zebra_evpn_t *zevpn, struct interface *ifp)
 	macfdb_read_for_bridge(zns, ifp, zif->brslave_info.br_if);
 	vlan_if = zvni_map_to_svi(vxl->access_vlan, zif->brslave_info.br_if);
 	if (vlan_if) {
+		/* Add SVI MAC */
+		zebra_evpn_acc_bd_svi_mac_add(vlan_if);
 
 		/* Add SVI MAC-IP */
 		if (advertise_svi_macip_enabled(zevpn)

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -2382,7 +2382,8 @@ int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, zebra_mac_t *mac)
 
 int zebra_evpn_mac_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
 				struct ipaddr *ip, zebra_mac_t **macp,
-				struct ethaddr *macaddr, vlanid_t vlan_id)
+				struct ethaddr *macaddr, vlanid_t vlan_id,
+				bool def_gw)
 {
 	char buf[ETHER_ADDR_STRLEN];
 	zebra_mac_t *mac;
@@ -2408,7 +2409,8 @@ int zebra_evpn_mac_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
 	/* Set "local" forwarding info. */
 	SET_FLAG(mac->flags, ZEBRA_MAC_LOCAL);
 	SET_FLAG(mac->flags, ZEBRA_MAC_AUTO);
-	SET_FLAG(mac->flags, ZEBRA_MAC_DEF_GW);
+	if (def_gw)
+		SET_FLAG(mac->flags, ZEBRA_MAC_DEF_GW);
 	memset(&mac->fwd_info, 0, sizeof(mac->fwd_info));
 	mac->fwd_info.local.ifindex = ifp->ifindex;
 	mac->fwd_info.local.ns_id = local_ns_id;
@@ -2423,6 +2425,7 @@ void zebra_evpn_mac_svi_del(struct interface *ifp, zebra_evpn_t *zevpn)
 {
 	zebra_mac_t *mac;
 	struct ethaddr macaddr;
+	bool old_bgp_ready;
 
 	if (!zebra_evpn_mh_do_adv_svi_mac())
 		return;
@@ -2433,7 +2436,10 @@ void zebra_evpn_mac_svi_del(struct interface *ifp, zebra_evpn_t *zevpn)
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 			zlog_debug("SVI %s mac free", ifp->name);
 
+		old_bgp_ready = zebra_evpn_mac_is_ready_for_bgp(mac->flags);
 		UNSET_FLAG(mac->flags, ZEBRA_MAC_SVI);
+		zebra_evpn_mac_send_add_del_to_client(mac, old_bgp_ready,
+						      false);
 		zebra_evpn_deref_ip2mac(mac->zevpn, mac);
 	}
 }
@@ -2443,8 +2449,11 @@ void zebra_evpn_mac_svi_add(struct interface *ifp, zebra_evpn_t *zevpn)
 	zebra_mac_t *mac = NULL;
 	struct ethaddr macaddr;
 	struct zebra_if *zif = ifp->info;
+	bool old_bgp_ready;
+	bool new_bgp_ready;
 
-	if (!zebra_evpn_mh_do_adv_svi_mac())
+	if (!zebra_evpn_mh_do_adv_svi_mac()
+	    || !zebra_evpn_send_to_client_ok(zevpn))
 		return;
 
 	memcpy(&macaddr.octet, ifp->hw_addr, ETH_ALEN);
@@ -2458,8 +2467,16 @@ void zebra_evpn_mac_svi_add(struct interface *ifp, zebra_evpn_t *zevpn)
 	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 		zlog_debug("SVI %s mac add", zif->ifp->name);
 
+	old_bgp_ready = (mac && zebra_evpn_mac_is_ready_for_bgp(mac->flags))
+				? true
+				: false;
+
 	mac = NULL;
-	zebra_evpn_mac_gw_macip_add(ifp, zevpn, NULL, &mac, &macaddr, 0);
+	zebra_evpn_mac_gw_macip_add(ifp, zevpn, NULL, &mac, &macaddr, 0, false);
 	if (mac)
 		SET_FLAG(mac->flags, ZEBRA_MAC_SVI);
+
+	new_bgp_ready = zebra_evpn_mac_is_ready_for_bgp(mac->flags);
+	zebra_evpn_mac_send_add_del_to_client(mac, old_bgp_ready,
+					      new_bgp_ready);
 }

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -264,7 +264,8 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf, zebra_evpn_t *zevpn,
 int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, zebra_mac_t *mac);
 int zebra_evpn_mac_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
 				struct ipaddr *ip, zebra_mac_t **macp,
-				struct ethaddr *macaddr, vlanid_t vlan_id);
+				struct ethaddr *macaddr, vlanid_t vlan_id,
+				bool def_gw);
 void zebra_evpn_mac_svi_add(struct interface *ifp, zebra_evpn_t *zevpn);
 void zebra_evpn_mac_svi_del(struct interface *ifp, zebra_evpn_t *zevpn);
 

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -80,6 +80,8 @@ struct zebra_mac_t_ {
  * to advertise it as locally attached but with a "proxy" flag
  */
 #define ZEBRA_MAC_LOCAL_INACTIVE 0x800
+/* The MAC entry was created because of advertise_svi_mac */
+#define ZEBRA_MAC_SVI 0x1000
 
 #define ZEBRA_MAC_ALL_LOCAL_FLAGS (ZEBRA_MAC_LOCAL | ZEBRA_MAC_LOCAL_INACTIVE)
 #define ZEBRA_MAC_ALL_PEER_FLAGS                                               \
@@ -201,6 +203,12 @@ static inline void zebra_evpn_mac_clear_sync_info(zebra_mac_t *mac)
 	zebra_evpn_mac_stop_hold_timer(mac);
 }
 
+static inline bool zebra_evpn_mac_in_use(zebra_mac_t *mac)
+{
+	return !list_isempty(mac->neigh_list)
+	       || CHECK_FLAG(mac->flags, ZEBRA_MAC_SVI);
+}
+
 struct hash *zebra_mac_db_create(const char *desc);
 uint32_t num_valid_macs(zebra_evpn_t *zevi);
 uint32_t num_dup_detected_macs(zebra_evpn_t *zevi);
@@ -257,6 +265,8 @@ int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, zebra_mac_t *mac);
 int zebra_evpn_mac_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
 				struct ipaddr *ip, zebra_mac_t **macp,
 				struct ethaddr *macaddr, vlanid_t vlan_id);
+void zebra_evpn_mac_svi_add(struct interface *ifp, zebra_evpn_t *zevpn);
+void zebra_evpn_mac_svi_del(struct interface *ifp, zebra_evpn_t *zevpn);
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -609,7 +609,7 @@ void zebra_evpn_acc_bd_svi_set(struct zebra_if *vlan_zif,
 	struct zebra_if *tmp_br_zif = br_zif;
 
 	if (!tmp_br_zif) {
-		if (!vlan_zif->link)
+		if (!vlan_zif->link || !vlan_zif->link->info)
 			return;
 
 		tmp_br_zif = vlan_zif->link->info;

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -1039,7 +1039,6 @@ void zebra_evpn_if_cleanup(struct zebra_if *zif)
 	vlanid_t vid;
 	struct zebra_evpn_es *es;
 
-	zebra_evpn_acc_bd_svi_set(zif, NULL, false);
 	if (!bf_is_inited(zif->vlan_bitmap))
 		return;
 

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -180,6 +180,8 @@ struct zebra_evpn_access_bd {
 	struct list *mbr_zifs;
 	/* presence of zevpn activates the EVI on all the ESs in mbr_zifs */
 	zebra_evpn_t *zevpn;
+	/* SVI associated with the VLAN */
+	struct zebra_if *vlan_zif;
 };
 
 /* multihoming information stored in zrouter */
@@ -200,6 +202,10 @@ struct zebra_evpn_mh_info {
  * this flag when the first local ES is detected.
  */
 #define ZEBRA_EVPN_MH_ADV_REACHABLE_NEIGH_ONLY (1 << 2)
+/* If EVPN MH is enabled we advertise the SVI MAC address to avoid
+ * flooding of ARP replies rxed from the multi-homed host
+ */
+#define ZEBRA_EVPN_MH_ADV_SVI_MAC (1 << 3)
 
 	/* RB tree of Ethernet segments (used for EVPN-MH)  */
 	struct zebra_es_rb_head es_rb_tree;
@@ -285,6 +291,10 @@ static inline bool zebra_evpn_mh_do_adv_reachable_neigh_only(void)
 	return !!(zmh_info->flags & ZEBRA_EVPN_MH_ADV_REACHABLE_NEIGH_ONLY);
 }
 
+static inline bool zebra_evpn_mh_do_adv_svi_mac(void)
+{
+	return zmh_info && (zmh_info->flags & ZEBRA_EVPN_MH_ADV_SVI_MAC);
+}
 
 /*****************************************************************************/
 extern esi_t *zero_esi;
@@ -357,5 +367,8 @@ extern bool zebra_evpn_is_es_bond_member(struct interface *ifp);
 extern void zebra_evpn_mh_print(struct vty *vty);
 extern void zebra_evpn_mh_json(json_object *json);
 extern void zebra_evpn_l2_nh_show(struct vty *vty, bool uj);
+extern void zebra_evpn_acc_bd_svi_set(struct zebra_if *vlan_zif,
+				      struct zebra_if *br_zif, bool is_up);
+extern void zebra_evpn_acc_bd_svi_mac_add(struct interface *vlan_if);
 
 #endif /* _ZEBRA_EVPN_MH_H */

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -262,6 +262,12 @@ struct zebra_evpn_mh_info {
 	enum protodown_reasons protodown_rc;
 };
 
+/* returns TRUE if the EVPN is ready to be sent to BGP */
+static inline bool zebra_evpn_send_to_client_ok(zebra_evpn_t *zevpn)
+{
+	return !!(zevpn->flags & ZEVPN_READY_FOR_BGP);
+}
+
 static inline bool zebra_evpn_mac_is_es_local(zebra_mac_t *mac)
 {
 	return mac->es && (mac->es->flags & ZEBRA_EVPNES_LOCAL);

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -2464,7 +2464,7 @@ int zebra_evpn_neigh_del_ip(zebra_evpn_t *zevpn, struct ipaddr *ip)
 
 	/* see if the AUTO mac needs to be deleted */
 	if (CHECK_FLAG(zmac->flags, ZEBRA_MAC_AUTO)
-	    && !listcount(zmac->neigh_list))
+	    && !zebra_evpn_mac_in_use(zmac))
 		zebra_evpn_mac_del(zevpn, zmac);
 
 	return 0;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3503,6 +3503,8 @@ void zebra_vxlan_print_evpn(struct vty *vty, bool uj)
 			zvrf->advertise_gw_macip ? "Yes" : "No");
 		vty_out(vty, "Advertise svi mac-ip: %s\n",
 			zvrf->advertise_svi_macip ? "Yes" : "No");
+		vty_out(vty, "Advertise svi mac: %s\n",
+			zebra_evpn_mh_do_adv_svi_mac() ? "Yes" : "No");
 		vty_out(vty, "Duplicate address detection: %s\n",
 			zebra_evpn_do_dup_addr_detect(zvrf) ? "Enable"
 							    : "Disable");
@@ -4549,10 +4551,14 @@ int zebra_vxlan_svi_down(struct interface *ifp, struct interface *link_if)
 	} else {
 		zebra_evpn_t *zevpn = NULL;
 
+		/* Unlink the SVI from the access VLAN */
+		zebra_evpn_acc_bd_svi_set(ifp->info, link_if->info, false);
+
 		/* since we dont have svi corresponding to zevpn, we associate it
 		 * to default vrf. Note: the corresponding neigh entries on the
 		 * SVI would have already been deleted */
 		zevpn = zebra_evpn_from_svi(ifp, link_if);
+
 		if (zevpn) {
 			zevpn->vrf_id = VRF_DEFAULT;
 
@@ -4616,6 +4622,9 @@ int zebra_vxlan_svi_up(struct interface *ifp, struct interface *link_if)
 		n_wctx.zevpn = zevpn;
 		hash_iterate(zevpn->neigh_table, zebra_evpn_install_neigh_hash,
 			     &n_wctx);
+
+		/* Link the SVI from the access VLAN */
+		zebra_evpn_acc_bd_svi_set(ifp->info, link_if->info, true);
 	}
 
 	return 0;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4493,6 +4493,16 @@ int zebra_vxlan_add_del_gw_macip(struct interface *ifp, struct prefix *p,
 		return -1;
 	}
 
+	/* VRR IP is advertised only if gw-macip-adv-enabled */
+	if (IS_ZEBRA_IF_MACVLAN(ifp)) {
+		if (!advertise_gw_macip_enabled(zevpn))
+			return 0;
+	} else {
+		/* SVI IP is advertised if gw or svi macip-adv-enabled */
+		if (!advertise_svi_macip_enabled(zevpn)
+		    && !advertise_gw_macip_enabled(zevpn))
+			return 0;
+	}
 
 	memcpy(&macaddr.octet, ifp->hw_addr, ETH_ALEN);
 


### PR DESCRIPTION
zebra: fix problem with SVI IP being advertised even if disabled
zebra: changes to advertise SVI mac by default if evpn-mh is enabled
zebra: prevent crash in evpn if cleanup
