### PR TITLE
Correct sysrepo library name in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1862,7 +1862,7 @@ dnl ---------------
 dnl sysrepo
 dnl ---------------
 if test "$enable_sysrepo" = "yes"; then
-  PKG_CHECK_MODULES([SYSREPO], [libsysrepo],
+  PKG_CHECK_MODULES([SYSREPO], [sysrepo],
       [AC_DEFINE([HAVE_SYSREPO], [1], [Enable sysrepo integration])
       SYSREPO=true],
       [SYSREPO=false


### PR DESCRIPTION

When using --enable-sysrepo at config, it will fail as below even sysrepo already be installed properly. Several issues reported are about this problem, like Unable to configure sysrepo in frr #6102, I found it's caused by wrong sysrepo library name. after modify from libsysrepo to sysrepo, it can works well. I guess this problem caused by new version of sysrepo, it maybe changed its pkg-config file.

checking for netinet6/in6.h... no
checking for netinet/in6_var.h... no
checking for netinet6/in6_var.h... no
checking for netinet6/nd6.h... no
checking for LIBYANG (libyang >= 1.0.184)... yes
checking for struct lyd_node.priv... yes
checking for SYSREPO (libsysrepo)... no
configure: error: sysrepo was not found on your system.
Makefile:4403: recipe for target 'config.status' failed
make: *** [config.status] Error 1
bozhang# sysrepoctl -V
sysrepoctl - sysrepo YANG schema manipulation tool, compiled with libsysrepo v1.4.70 (SO v5.5.12)

Signed-off-by: Bo Zhang <logbob0401@gmail.com>