### PR TITLE
tests: Set default timers to 3/10 for bgp using create_router_bgp

### DIFF
--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -692,8 +692,8 @@ def __create_bgp_neighbor(topo, input_dict, router, addr_type, add_neigh=True):
                 config_data.append("{} activate".format(neigh_cxt))
 
             disable_connected = peer.setdefault("disable_connected_check", False)
-            keep_alive = peer.setdefault("keepalivetimer", 60)
-            hold_down = peer.setdefault("holddowntimer", 180)
+            keep_alive = peer.setdefault("keepalivetimer", 3)
+            hold_down = peer.setdefault("holddowntimer", 10)
             password = peer.setdefault("password", None)
             no_password = peer.setdefault("no_password", None)
             max_hop_limit = peer.setdefault("ebgp_multihop", 1)


### PR DESCRIPTION
Tests were timing out in our test system due to lost packets and
flakiness of the lower end systems.  Just set the timers to 3/10
and give them plenty of time to converge.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>