### PR TITLE
docker: builder fixups

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,10 +1,9 @@
 # This stage builds a dist tarball from the source
-FROM alpine:edge as source-builder
+FROM alpine:latest as source-builder
 
 RUN mkdir -p /src/alpine
 COPY alpine/APKBUILD.in /src/alpine
 RUN source /src/alpine/APKBUILD.in \
-	&& echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
 	&& apk add \
 		--no-cache \
 		--update-cache \
@@ -22,10 +21,9 @@ RUN cd /src \
 	&& make dist
 
 # This stage builds an apk from the dist tarball
-FROM alpine:edge as alpine-builder
+FROM alpine:latest as alpine-builder
 # Don't use nocache here so that abuild can use the cache
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
-	&& apk add \
+RUN apk add \
 		--update-cache \
 		abuild \
 		alpine-conf \
@@ -46,11 +44,10 @@ RUN cd /dist \
 	&& abuild -r -P /pkgs/apk
 
 # This stage installs frr from the apk
-FROM alpine:edge
+FROM alpine:latest
 RUN mkdir -p /pkgs/apk
 COPY --from=alpine-builder /pkgs/apk/ /pkgs/apk/
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
-	&& apk add \
+RUN apk add \
 		--no-cache \
 		--update-cache \
 		tini \

--- a/docker/centos-7/Dockerfile
+++ b/docker/centos-7/Dockerfile
@@ -5,8 +5,8 @@ RUN yum install -y rpm-build autoconf automake libtool make \
         readline-devel texinfo net-snmp-devel groff pkgconfig \
         json-c-devel pam-devel bison flex pytest c-ares-devel \
         python3-devel python3-sphinx systemd-devel libcap-devel \
-        https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-0.16.111-0.x86_64.rpm \
-        https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-devel-0.16.111-0.x86_64.rpm \
+        https://ci1.netdef.org/artifact/LIBYANG-LY1REL/shared/build-4/CentOS-7-x86_64-Packages/libyang1-1.0.184-0.x86_64.rpm \
+        https://ci1.netdef.org/artifact/LIBYANG-LY1REL/shared/build-4/CentOS-7-x86_64-Packages/libyang-devel-1.0.184-0.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-0.7.0-1.el7.centos.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-devel-0.7.0-1.el7.centos.x86_64.rpm
 
@@ -32,7 +32,7 @@ RUN echo '%_smp_mflags %( echo "-j$(/usr/bin/getconf _NPROCESSORS_ONLN)"; )' >> 
 # This stage installs frr from the rpm
 FROM centos:centos7
 RUN mkdir -p /pkgs/rpm \
-    && yum install -y https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-0.16.111-0.x86_64.rpm \
+    && yum install -y https://ci1.netdef.org/artifact/LIBYANG-LY1REL/shared/build-4/CentOS-7-x86_64-Packages/libyang1-1.0.184-0.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-0.7.0-1.el7.centos.x86_64.rpm
 
 COPY --from=centos-7-builder /rpmbuild/RPMS/ /pkgs/rpm/

--- a/docker/centos-8/Dockerfile
+++ b/docker/centos-8/Dockerfile
@@ -1,16 +1,14 @@
 # This stage builds an rpm from the source
 FROM centos:centos8 as centos-8-builder
 
-RUN dnf install --enablerepo=PowerTools -y rpm-build git autoconf pcre-devel \
+RUN dnf install --enablerepo=powertools -y rpm-build git autoconf pcre-devel \
         automake libtool make readline-devel texinfo net-snmp-devel pkgconfig \
-        groff pkgconfig json-c-devel pam-devel bison flex python2-pytest \
-        c-ares-devel python2-devel systemd-devel libcap-devel platform-python-devel \
-        https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-0.16.111-0.x86_64.rpm \
-        https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-devel-0.16.111-0.x86_64.rpm \
+        groff pkgconfig json-c-devel pam-devel bison flex python3-pytest \
+        c-ares-devel python3-devel python3-sphinx systemd-devel libcap-devel platform-python-devel \
+        https://ci1.netdef.org/artifact/LIBYANG-LY1REL/shared/build-4/CentOS-8-x86_64-Packages/libyang1-1.0.184-0.x86_64.rpm \
+        https://ci1.netdef.org/artifact/LIBYANG-LY1REL/shared/build-4/CentOS-8-x86_64-Packages/libyang-devel-1.0.184-0.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-0.7.0-1.el7.centos.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-devel-0.7.0-1.el7.centos.x86_64.rpm
-
-RUN pip2 install sphinx
 
 COPY . /src
 
@@ -35,7 +33,7 @@ RUN echo '%_smp_mflags %( echo "-j$(/usr/bin/getconf _NPROCESSORS_ONLN)"; )' >> 
 # This stage installs frr from the rpm
 FROM centos:centos8
 RUN mkdir -p /pkgs/rpm \
-    && yum install -y https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-0.16.111-0.x86_64.rpm \
+    && yum install -y https://ci1.netdef.org/artifact/LIBYANG-LY1REL/shared/build-4/CentOS-8-x86_64-Packages/libyang1-1.0.184-0.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-0.7.0-1.el7.centos.x86_64.rpm
 
 COPY --from=centos-8-builder /rpmbuild/RPMS/ /pkgs/rpm/


### PR DESCRIPTION
Just some housekeeping for our Docker containers, fixing issues I found while building our Docker containers for use in network simulation:

1. Use `alpine:latest` instead of `alpine:edge` tag for Alpine builds, as edge was causing automake failures
2. Exclude use of `edge` package repository in Alpine builder for above reason (they have had libyang 1.0.84 for some time in the community branch so use that)
3. Update the CentOS 7, 8 containers to use libyang 1.0.84 as well (was 0.16.111 before)
4. CentOS `PowerTools` repository was recently [renamed to `powertools`](https://bugs.centos.org/view.php?id=17920) so use that instead because that made the whole builder fail

I've verified that the containers now build on all my machines, albeit these are all Gentoo boxes :slightly_smiling_face: 