### PR TITLE
tools: fix frr-reload BFD profile support

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -580,6 +580,18 @@ end
             if line.startswith("!") or line.startswith("#"):
                 continue
 
+            if (len(ctx_keys) == 2
+                and ctx_keys[0].startswith('bfd')
+                and ctx_keys[1].startswith('profile ')
+                and line == 'end'):
+                log.debug('LINE %-50s: popping from sub context, %-50s', line, ctx_keys)
+
+                if main_ctx_key:
+                    self.save_contexts(ctx_keys, current_context_lines)
+                    ctx_keys = copy.deepcopy(main_ctx_key)
+                    current_context_lines = []
+                    continue
+
             # one line contexts
             # there is one exception though: ldpd accepts a 'router-id' clause
             # as part of its 'mpls ldp' config context. If we are processing
@@ -879,6 +891,22 @@ end
                 main_ctx_key = copy.deepcopy(ctx_keys)
                 log.debug(
                     "LINE %-50s: entering pcc sub-context, append to ctx_keys", line
+                )
+                ctx_keys.append(line)
+
+            elif (
+                line.startswith('profile ')
+                and len(ctx_keys) == 1
+                and ctx_keys[0].startswith('bfd')
+            ):
+
+                # Save old context first
+                self.save_contexts(ctx_keys, current_context_lines)
+                current_context_lines = []
+                main_ctx_key = copy.deepcopy(ctx_keys)
+                log.debug(
+                    "LINE %-50s: entering BFD profile sub-context, append to ctx_keys",
+                    line
                 )
                 ctx_keys.append(line)
 


### PR DESCRIPTION
Summary
---

Fix the handling of multiple BFD profiles by adding the appropriated code to push/pop contexts inside BFD configuration node.


Sample Output of the Problem
---

Configuration in `/etc/frr/frr.conf`:

```
bfd
 profile slowtx
  transmit-interval 1000
  receive-interval 2000
 !
 profile fasttx
  transmit-interval 250
  receive-interval 250
 !
!
```

Configuration in `show running-config`:

```
bfd
 profile slowtx
  transmit-interval 1000
  receive-interval 1234
 !
 profile midtx
  passive-mode
 !
!
```

  Before this PR:

  ```
  Lines To Delete
  ===============
  no hostname frr
  no profile midtx
  bfd
  no receive-interval 1234

  Lines To Add
  ============
  bfd
  receive-interval 2000
  profile fasttx
  profile fasttx
  transmit-interval 250
  profile fasttx
  receive-interval 250
  ```

  With this PR fix:

  ```
  Lines To Delete
  ===============
  no hostname frr
  bfd
  no profile midtx
  bfd
  profile slowtx
  no receive-interval 1234

  Lines To Add
  ============
  bfd
  profile slowtx
  receive-interval 2000
  bfd
  profile fasttx
  bfd
  profile fasttx
  transmit-interval 250
  bfd
  profile fasttx
  receive-interval 250
  ```