### PR TITLE
tests: Fix to use global variable for pim marking

### DIFF
--- a/tests/topotests/bgp-evpn-mh/test_evpn_mh.py
+++ b/tests/topotests/bgp-evpn-mh/test_evpn_mh.py
@@ -35,6 +35,8 @@ import json
 import platform
 from functools import partial
 
+pytestmark = pytest.mark.pimd
+
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
@@ -362,7 +364,7 @@ def config_hosts(tgen, hosts):
         host = tgen.gears[host_name]
         config_host(host_name, host)
 
-@pytest.mark.pim
+
 def setup_module(module):
     "Setup topology"
     tgen = Topogen(NetworkTopo, module.__name__)

--- a/tests/topotests/evpn-pim-1/test_evpn_pim_topo1.py
+++ b/tests/topotests/evpn-pim-1/test_evpn_pim_topo1.py
@@ -34,6 +34,8 @@ import pytest
 import json
 from functools import partial
 
+pytestmark = pytest.mark.pimd
+
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
@@ -97,7 +99,7 @@ class NetworkTopo(Topo):
 ##
 #####################################################
 
-@pytest.mark.pim
+
 def setup_module(module):
     "Setup topology"
     tgen = Topogen(NetworkTopo, module.__name__)

--- a/tests/topotests/multicast-pim-sm-topo3/test_multicast_pim_sm_topo3.py
+++ b/tests/topotests/multicast-pim-sm-topo3/test_multicast_pim_sm_topo3.py
@@ -56,6 +56,8 @@ import time
 import datetime
 import pytest
 
+pytestmark = pytest.mark.pimd
+
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/multicast-pim-sm-topo3/test_multicast_pim_sm_topo4.py
+++ b/tests/topotests/multicast-pim-sm-topo3/test_multicast_pim_sm_topo4.py
@@ -49,6 +49,8 @@ import datetime
 from time import sleep
 import pytest
 
+pytestmark = pytest.mark.pimd
+
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/pim-basic/test_pim.py
+++ b/tests/topotests/pim-basic/test_pim.py
@@ -31,6 +31,8 @@ import pytest
 import json
 from functools import partial
 
+pytestmark = pytest.mark.pimd
+
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 
@@ -80,7 +82,7 @@ class PIMTopo(Topo):
         sw.add_link(tgen.gears["r1"])
         sw.add_link(tgen.gears["r3"])
 
-@pytest.mark.pim
+
 def setup_module(mod):
     "Sets up the pytest environment"
     tgen = Topogen(PIMTopo, mod.__name__)


### PR DESCRIPTION
Use the preferred methodology of marking
for pim tests and update new pim tests with
appropriate mark

Signed-off-by: Donald Sharp <sharpd@nvidia.com>