### PR TITLE
zebra, sharpd: async results for NHGs

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -996,7 +996,7 @@ done:
 	return ret;
 }
 
-int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
+static int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
 {
 	int i;
 
@@ -1004,6 +1004,13 @@ int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
 		flog_err(EC_LIB_ZAPI_ENCODE,
 			 "%s: Specified zapi NHG command (%d) doesn't exist\n",
 			 __func__, cmd);
+		return -1;
+	}
+
+	if (api_nhg->nexthop_num >= MULTIPATH_NUM ||
+	    api_nhg->backup_nexthop_num >= MULTIPATH_NUM) {
+		flog_err(EC_LIB_ZAPI_ENCODE,
+			 "%s: zapi NHG encode with invalid input\n", __func__);
 		return -1;
 	}
 
@@ -1024,7 +1031,6 @@ int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
 			zapi_nexthop_encode(s, &api_nhg->nexthops[i], 0, 0);
 
 		/* Backup nexthops */
-
 		stream_putw(s, api_nhg->backup_nexthop_num);
 
 		for (i = 0; i < api_nhg->backup_nexthop_num; i++)

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1021,9 +1021,7 @@ bool zapi_ipset_notify_decode(struct stream *s,
 			      uint32_t *unique,
 			     enum zapi_ipset_notify_owner *note);
 
-
-extern int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg);
-extern int zapi_nhg_decode(struct stream *s, int cmd, struct zapi_nhg *api_nhg);
+/* Nexthop-group message apis */
 extern enum zclient_send_status
 zclient_nhg_send(struct zclient *zclient, int cmd, struct zapi_nhg *api_nhg);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -62,6 +62,8 @@
 #include "zebra/zebra_opaque.h"
 #include "zebra/zebra_srte.h"
 
+static int zapi_nhg_decode(struct stream *s, int cmd, struct zapi_nhg *api_nhg);
+
 /* Encoding helpers -------------------------------------------------------- */
 
 static void zserv_encode_interface(struct stream *s, struct interface *ifp)
@@ -1742,7 +1744,7 @@ static bool zapi_read_nexthops(struct zserv *client, struct prefix *p,
 	return true;
 }
 
-int zapi_nhg_decode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
+static int zapi_nhg_decode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
 {
 	uint16_t i;
 	struct zapi_nexthop *znh;

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -108,6 +108,9 @@ extern int zsend_sr_policy_notify_status(uint32_t color,
 extern int zsend_client_close_notify(struct zserv *client,
 				     struct zserv *closed_client);
 
+int zsend_nhg_notify(uint16_t type, uint16_t instance, uint32_t session_id,
+		     uint32_t id, enum zapi_nhg_notify_owner note);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2119,7 +2119,7 @@ static unsigned nexthop_active_check(struct route_node *rn,
 {
 	struct interface *ifp;
 	route_map_result_t ret = RMAP_PERMITMATCH;
-	int family;
+	afi_t family;
 	const struct prefix *p, *src_p;
 	struct zebra_vrf *zvrf;
 

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -50,7 +50,13 @@ struct nhg_hash_entry {
 	uint32_t id;
 	afi_t afi;
 	vrf_id_t vrf_id;
+
+	/* Source protocol - zebra or another daemon */
 	int type;
+
+	/* zapi instance and session id, for groups from other daemons */
+	uint16_t zapi_instance;
+	uint32_t zapi_session;
 
 	struct nexthop_group nhg;
 
@@ -292,6 +298,7 @@ zebra_nhg_rib_find_nhe(struct nhg_hash_entry *rt_nhe, afi_t rt_afi);
  * Returns allocated NHE on success, otherwise NULL.
  */
 struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
+					   uint16_t instance, uint32_t session,
 					   struct nexthop_group *nhg,
 					   afi_t afi);
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1669,7 +1669,7 @@ void zebra_routemap_finish(void)
 }
 
 route_map_result_t
-zebra_route_map_check(int family, int rib_type, uint8_t instance,
+zebra_route_map_check(afi_t family, int rib_type, uint8_t instance,
 		      const struct prefix *p, struct nexthop *nexthop,
 		      struct zebra_vrf *zvrf, route_tag_t tag)
 {

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -42,7 +42,7 @@ zebra_import_table_route_map_check(int family, int rib_type, uint8_t instance,
 				   struct nexthop *nexthop, vrf_id_t vrf_id,
 				   route_tag_t tag, const char *rmap_name);
 extern route_map_result_t
-zebra_route_map_check(int family, int rib_type, uint8_t instance,
+zebra_route_map_check(afi_t family, int rib_type, uint8_t instance,
 		      const struct prefix *p, struct nexthop *nexthop,
 		      struct zebra_vrf *zvrf, route_tag_t tag);
 extern route_map_result_t


### PR DESCRIPTION
Return results for daemon-initiated nexthop-group updates asynchronously, when the results are actually known; don't assume success. Also add some more validation for sharpd's nhgs - there are some minimal requirements without which zebra will reject updates immediately.