### PR TITLE
test: add snmp skip test

### DIFF
--- a/tests/topotests/simple-snmp-test/test_simple_snmp.py
+++ b/tests/topotests/simple-snmp-test/test_simple_snmp.py
@@ -76,6 +76,11 @@ class TemplateTopo(Topo):
 
 def setup_module(mod):
     "Sets up the pytest environment"
+
+    # skip tests is SNMP not installed
+    if not os.path.isfile("/usr/sbin/snmpd"):
+        error_msg = "SNMP not installed - skipping"
+        pytest.skip(error_msg)
     # This function initiates the topology build with Topogen...
     tgen = Topogen(TemplateTopo, mod.__name__)
     # ... and here it calls Mininet initialization functions.
@@ -120,7 +125,7 @@ def test_r1_bgp_version():
     "Wait for protocol convergence"
     tgen = get_topogen()
 
-    #tgen.mininet_cli()
+    # tgen.mininet_cli()
     r1 = tgen.net.get("r1")
     r1_snmp = SnmpTester(r1, "1.1.1.1", "public", "2c")
     assert r1_snmp.test_oid("bgpVersin", None)


### PR DESCRIPTION
Since SNMP is a pain to install add a check which will be used
in all SNMP tests in future to silently skip SNMP tests if SNMP
has not been installed on the base system.

I promised this addition to the initial SNMP topotest PR but it got merged before I managed to add it.