### PR TITLE
ospf6d : fix issue in ecmp inter area  route

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1449,6 +1449,8 @@ static void ospf6_intra_prefix_update_route_origin(struct ospf6_route *oa_route,
 			g_route->path.origin.id = h_path->origin.id;
 			g_route->path.origin.adv_router =
 				h_path->origin.adv_router;
+			if (nroute)
+				ospf6_route_unlock(nroute);
 			break;
 		}
 	}


### PR DESCRIPTION
Issue: When a path in the inter area ecmp route is deleted, the route is removed

Fix: The fix is to remove the specific path from the inter area route using
     ospf6_abr_old_route_remove() when abr route entry is not found.
     In  the function ospf6_abr_old_route_remove() the path to be removed needs
     to match adv router and link state ID

     Fixed memory leak in ospf6_intra_prefix_update_route_origin() caused by
     route node lock not getting released.

Signed-off-by: kssoman <somanks@gmail.com>