### PR TITLE
bgpd: Assert that community_str2com("no-advertise") always returns non-NULL

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3515,6 +3515,8 @@ static void bgp_attr_add_no_advertise_community(struct attr *attr)
 	old = attr->community;
 	noadv = community_str2com("no-advertise");
 
+	assert(noadv);
+
 	if (old) {
 		merge = community_merge(community_dup(old), noadv);
 


### PR DESCRIPTION
community_str2com("no-advertise"); returns ALWAYS non-NULL.

If NULL returned here, we really have a bigger problems in the call path.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>