### PR TITLE
watchfrr: fix crash on missing optional argument

### DIFF
--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -1414,7 +1414,7 @@ int main(int argc, char **argv)
 		} break;
 		case OPTION_NETNS:
 			netns_en = true;
-			if (strchr(optarg, '/')) {
+			if (optarg && strchr(optarg, '/')) {
 				fprintf(stderr,
 					"invalid network namespace name \"%s\" (may not contain slashes)\n",
 					optarg);

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -1080,6 +1080,9 @@ static int valid_command(const char *cmd)
 {
 	char *p;
 
+	if (cmd == NULL)
+		return 0;
+
 	return ((p = strchr(cmd, '%')) != NULL) && (*(p + 1) == 's')
 	       && !strchr(p + 1, '%');
 }


### PR DESCRIPTION
Fix `netns` command line handling for missing argument (it's optional).

gdb output
---

Command line: `/usr/lib/frr/watchfrr -N r1 --netns --log stdout --log-level debug zebra bgpd bfdd`

Option:

```c
// in watchfrr/watchfrr.c line 196
static const struct option longopts[] = {
         // other options ....
#ifdef GNU_LINUX
	{"netns", optional_argument, NULL, OPTION_NETNS},
#endif
};
```

```
Program received signal SIGSEGV, Segmentation fault.
__strchr_avx2 () at ../sysdeps/x86_64/multiarch/strchr-avx2.S:57
57      ../sysdeps/x86_64/multiarch/strchr-avx2.S: No such file or directory.
(gdb) bt
#0  __strchr_avx2 () at ../sysdeps/x86_64/multiarch/strchr-avx2.S:57
#1  0x000055555555b98b in main (argc=11, argv=0x7fffffffe5a8) at ../watchfrr/watchfrr.c:1417
(gdb) up
#1  0x000055555555b98b in main (argc=11, argv=0x7fffffffe5a8) at ../watchfrr/watchfrr.c:1417
1417                            if (strchr(optarg, '/')) {
(gdb) l
1412                                    frr_help_exit(1);
1413                            }
1414                    } break;
1415                    case OPTION_NETNS:
1416                            netns_en = true;
1417                            if (strchr(optarg, '/')) {
1418                                    fprintf(stderr,
1419                                            "invalid network namespace name \"%s\" (may not contain slashes)\n",
1420                                            optarg);
1421                                    frr_help_exit(1);
(gdb) p optarg
$1 = 0x0
```