### PR TITLE
zebra: perform preemptive netlink delete with all ipv6 netlink route installs

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1115,7 +1115,8 @@ static int nl_batch_read_resp(struct nl_batch *bth)
 
 			/*
 			 * 'update' context objects take two consecutive
-			 * sequence numbers.
+			 * sequence numbers. the DELETE operation uses the
+			 * second, higher seq value.
 			 */
 			if (dplane_ctx_is_update(ctx)
 			    && dplane_ctx_get_ns(ctx)->nls.seq + 1 == seq) {
@@ -1274,6 +1275,10 @@ enum netlink_msg_status netlink_batch_add_msg(
 			return FRR_NETLINK_ERROR;
 	}
 
+	/* Some operations use two messages - a preemptive 'delete' associated
+	 * with an add/update for a route, for example. This preemptive message
+	 * uses a second netlink sequence number.
+	 */
 	seq = dplane_ctx_get_ns(ctx)->nls.seq;
 	if (ignore_res)
 		seq++;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1675,9 +1675,17 @@ ssize_t netlink_route_multipath_msg_encode(int cmd,
 	req->r.rtm_src_len = src_p ? src_p->prefixlen : 0;
 	req->r.rtm_scope = RT_SCOPE_UNIVERSE;
 
-	if (cmd == RTM_DELROUTE)
-		req->r.rtm_protocol = zebra2proto(dplane_ctx_get_old_type(ctx));
-	else
+	if (cmd == RTM_DELROUTE) {
+		/* Special case for ipv6 route install: we're sending a
+		 * preemptive delete operation, and there's no proto info.
+		 */
+		if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_INSTALL &&
+		    p->family == AF_INET6)
+			req->r.rtm_protocol = RTPROT_UNSPEC;
+		else
+			req->r.rtm_protocol =
+				zebra2proto(dplane_ctx_get_old_type(ctx));
+	} else
 		req->r.rtm_protocol = zebra2proto(dplane_ctx_get_type(ctx));
 
 	/*
@@ -2325,6 +2333,18 @@ netlink_put_route_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx)
 	if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_DELETE) {
 		cmd = RTM_DELROUTE;
 	} else if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_INSTALL) {
+		if (p->family == AF_INET6 && !v6_rr_semantics) {
+			/* For v6 routes, let's do a preemptive delete,
+			 * as we do for updates. We want the fib to look
+			 * like the incoming rib ctx. We'll need to create
+			 * a delete message even though we don't have
+			 * 'old' context data,
+			 */
+			netlink_batch_add_msg(
+				bth, ctx, netlink_delroute_msg_encoder,
+				true);
+		}
+
 		cmd = RTM_NEWROUTE;
 	} else if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_UPDATE) {
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1826,7 +1826,7 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 	 * Update is a bit of a special case, where we may have both old and new
 	 * routes to post-process.
 	 */
-	is_update = dplane_ctx_is_update(ctx);
+	is_update = (op == DPLANE_OP_ROUTE_UPDATE);
 
 	/*
 	 * Take a pass through the routes, look for matches with the context


### PR DESCRIPTION
The netlink ipv6 route semantics are not 'replace', so for some time zebra has performed a preemptive 'delete' when updating ipv6 routes, to ensure that the installed route matches zebra's internal data. This adds a similar 'delete' for ipv6 route adds, again to ensure that what ends up in the kernel matches zebra's internals.