### PR TITLE
lib: restore blank line after show route header

### DIFF
--- a/lib/route_types.pl
+++ b/lib/route_types.pl
@@ -130,7 +130,7 @@ sub codelist {
 	$str =~ s/ $//;
 	push @lines, $str . "\\n\" \\\n";
 	push @lines, "  \"       > - selected route, * - FIB route, q - queued, r - rejected, b - backup\\n\"";
-	push @lines, "  \"       t - trapped, o - offload failure\\n\"";
+	push @lines, "  \"       t - trapped, o - offload failure\\n\\n\"";
 
 
 	return join("", @lines);

--- a/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
+++ b/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
@@ -344,7 +344,7 @@ def test_converge_protocols():
         actual = (
             net["r%s" % i]
             .cmd(
-                'vtysh -c "show ip route" | /usr/bin/tail -n +7 | env LC_ALL=en_US.UTF-8 sort 2> /dev/null'
+                'vtysh -c "show ip route" | sed -e \'/^Codes: /,/^\s*$/d\' | env LC_ALL=en_US.UTF-8 sort 2> /dev/null'
             )
             .rstrip()
         )
@@ -375,7 +375,7 @@ def test_converge_protocols():
         actual = (
             net["r%s" % i]
             .cmd(
-                'vtysh -c "show ipv6 route" | /usr/bin/tail -n +7 | env LC_ALL=en_US.UTF-8 sort 2> /dev/null'
+                'vtysh -c "show ipv6 route" | sed -e \'/^Codes: /,/^\s*$/d\' | env LC_ALL=en_US.UTF-8 sort 2> /dev/null'
             )
             .rstrip()
         )


### PR DESCRIPTION
Noticed this due to some internal DANOS test failures, where the tests were expecting the blank line.

Looks like it was changed in PR #7155. Was the change intentional @donaldsharp?

Before:
```
$ show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure
K>* 0.0.0.0/0 [0/1] via 192.168.252.253, ens2, 00:02:05
C>* 10.10.1.0/24 is directly connected, dp0p1s1, 00:01:04
C>* 192.168.252.0/24 is directly connected, ens2, 00:02:05
```
After:
```
$ show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

K>* 0.0.0.0/0 [0/1] via 192.168.252.253, ens2, 00:00:35
C>* 10.10.1.0/24 is directly connected, dp0p1s1, 00:00:29
C>* 192.168.252.0/24 is directly connected, ens2, 00:00:35
```