### PR TITLE
pimd: Prevent use after free

### DIFF
--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -71,6 +71,8 @@ static void pim_instance_terminate(struct pim_instance *pim)
 
 	XFREE(MTYPE_PIM_PLIST_NAME, pim->spt.plist);
 	XFREE(MTYPE_PIM_PLIST_NAME, pim->register_plist);
+
+	pim->vrf = NULL;
 	XFREE(MTYPE_PIM_PIM_INSTANCE, pim);
 }
 
@@ -153,10 +155,16 @@ static int pim_vrf_delete(struct vrf *vrf)
 {
 	struct pim_instance *pim = vrf->info;
 
+	if (!pim)
+		return 0;
+
 	zlog_debug("VRF Deletion: %s(%u)", vrf->name, vrf->vrf_id);
 
 	pim_ssmpingd_destroy(pim);
 	pim_instance_terminate(pim);
+
+	vrf->info = NULL;
+
 	return 0;
 }
 


### PR DESCRIPTION
Valgrind is reporting this:
==22220== Invalid read of size 4
==22220==    at 0x11DC2B: pim_if_delete (pim_iface.c:215)
==22220==    by 0x11DD71: pim_if_terminate (pim_iface.c:76)
==22220==    by 0x128E03: pim_instance_terminate (pim_instance.c:66)
==22220==    by 0x128E03: pim_vrf_delete (pim_instance.c:159)
==22220==    by 0x48E0010: vrf_delete (vrf.c:251)
==22220==    by 0x48E0010: vrf_delete (vrf.c:225)
==22220==    by 0x48E02FE: vrf_terminate (vrf.c:551)
==22220==    by 0x149495: pim_terminate (pimd.c:142)
==22220==    by 0x13C61B: pim_sigint (pim_signals.c:44)
==22220==    by 0x48CF862: quagga_sigevent_process (sigevent.c:103)
==22220==    by 0x48DD324: thread_fetch (thread.c:1404)
==22220==    by 0x48A926A: frr_run (libfrr.c:1122)
==22220==    by 0x11B85E: main (pim_main.c:167)
==22220==  Address 0x5912160 is 1,200 bytes inside a block of size 1,624 free'd
==22220==    at 0x48369AB: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==22220==    by 0x128E52: pim_instance_terminate (pim_instance.c:74)
==22220==    by 0x128E52: pim_vrf_delete (pim_instance.c:159)
==22220==    by 0x48E0010: vrf_delete (vrf.c:251)
==22220==    by 0x48E0010: vrf_delete (vrf.c:225)
==22220==    by 0x48F1353: zclient_vrf_delete (zclient.c:1896)
==22220==    by 0x48F1353: zclient_read (zclient.c:3511)
==22220==    by 0x48DD826: thread_call (thread.c:1585)
==22220==    by 0x48A925F: frr_run (libfrr.c:1123)
==22220==    by 0x11B85E: main (pim_main.c:167)
==22220==  Block was alloc'd at
==22220==    at 0x4837B65: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==22220==    by 0x48ADA4F: qcalloc (memory.c:110)
==22220==    by 0x128B9B: pim_instance_init (pim_instance.c:82)
==22220==    by 0x128B9B: pim_vrf_new (pim_instance.c:142)
==22220==    by 0x48E0C5A: vrf_get (vrf.c:217)
==22220==    by 0x48F13C9: zclient_vrf_add (zclient.c:1863)
==22220==    by 0x48F13C9: zclient_read (zclient.c:3508)
==22220==    by 0x48DD826: thread_call (thread.c:1585)
==22220==    by 0x48A925F: frr_run (libfrr.c:1123)
==22220==    by 0x11B85E: main (pim_main.c:167)

On pim vrf deletion, ensure that the vrf->info pointers are NULL as well
as the free'd pim pointer for ->vrf is NULL as well.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>