### PR TITLE
tests: update EVPN VXLAN for SVI behaviour change

### DIFF
--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE1/bgpd.conf
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE1/bgpd.conf
@@ -8,3 +8,4 @@ router bgp 65000
  address-family l2vpn evpn
   neighbor 10.30.30.30 activate
   advertise-all-vni
+  advertise-svi-ip

--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE1/evpn.vni.json
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE1/evpn.vni.json
@@ -6,8 +6,8 @@
   "vtepIp":"10.10.10.10",
   "mcastGroup":"0.0.0.0",
   "advertiseGatewayMacip":"No",
-  "numMacs":5,
-  "numArpNd":3,
+  "numMacs":6,
+  "numArpNd":6,
   "numRemoteVteps":[
     "10.30.30.30"
   ]

--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE2/bgpd.conf
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE2/bgpd.conf
@@ -9,3 +9,4 @@ router bgp 65000
  address-family l2vpn evpn
   neighbor 10.10.10.10 activate
   advertise-all-vni
+  advertise-svi-ip

--- a/tests/topotests/bgp-evpn-vxlan_topo1/PE2/evpn.vni.json
+++ b/tests/topotests/bgp-evpn-vxlan_topo1/PE2/evpn.vni.json
@@ -6,8 +6,8 @@
   "vtepIp":"10.30.30.30",
   "mcastGroup":"0.0.0.0",
   "advertiseGatewayMacip":"No",
-  "numMacs":5,
-  "numArpNd":3,
+  "numMacs":6,
+  "numArpNd":6,
   "numRemoteVteps":[
     "10.10.10.10"
   ]


### PR DESCRIPTION
This test relied on the default addition of SVI MAC in zebra
now this has been fixed the test needs to be updated to work
with the new behaviour.

Signed-off-by: Pat Ruddy <pat@voltanet.io>