### PR TITLE
frr-reload: rpki context exiting uses exit and not end

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -629,6 +629,16 @@ end
                 ctx_keys = []
                 current_context_lines = []
 
+            elif line == "exit" and ctx_keys[0].startswith("rpki"):
+                self.save_contexts(ctx_keys, current_context_lines)
+                log.debug("LINE %-50s: exiting old context, %-50s", line, ctx_keys)
+
+                # Start a new context
+                new_ctx = True
+                main_ctx_key = []
+                ctx_keys = []
+                current_context_lines = []
+
             elif line == "exit-vrf":
                 self.save_contexts(ctx_keys, current_context_lines)
                 current_context_lines.append(line)


### PR DESCRIPTION
Issue:
The rpki subcontext uses exit instead of end to exit.
This makes issues with frr-reload in the way that frr-reload never exits
rpki context until it reaches the next end statement. this also happens when
parsing the configuration from vtysh.

Fixes: #7887
Signed-off-by: Runar Borge <runar@borge.nu>