### PR TITLE
lib/thread: Add process 'max-wakeup-interval' under 'show thread cpu'.

### DIFF
--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -174,36 +174,4 @@ extern bool debug_memstats_at_exit;
 }
 #endif
 
-static inline time_t frr_get_realtime(struct timeval *tvo)
-{
-	if (tvo) {
-		gettimeofday(tvo, NULL);
-		return tvo->tv_sec;
-	}
-
-	return -1;
-}
-
-static inline ssize_t frr_realtime_to_string(struct timeval *tv, char *buf,
-					     size_t sz)
-{
-	ssize_t written = -1;
-	struct tm *lm;
-
-	lm = localtime((const time_t *)&tv->tv_sec);
-
-	if (lm) {
-		written = (ssize_t)strftime(buf, sz, "%Y-%m-%d %H:%M:%S", lm);
-		if ((written > 0) && ((size_t)written < sz)) {
-			int w;
-
-			w = snprintf(buf + written, sz - (size_t)written,
-				     ".%06lu", tv->tv_usec);
-			written = (w > 0) ? written + w : -1;
-		}
-	}
-
-	return written;
-}
-
 #endif /* _ZEBRA_FRR_H */

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -174,4 +174,36 @@ extern bool debug_memstats_at_exit;
 }
 #endif
 
+static inline time_t frr_get_realtime(struct timeval *tvo)
+{
+	if (tvo) {
+		gettimeofday(tvo, NULL);
+		return tvo->tv_sec;
+	}
+
+	return -1;
+}
+
+static inline ssize_t frr_realtime_to_string(struct timeval *tv, char *buf,
+					     size_t sz)
+{
+	ssize_t written = -1;
+	struct tm *lm;
+
+	lm = localtime((const time_t *)&tv->tv_sec);
+
+	if (lm) {
+		written = (ssize_t)strftime(buf, sz, "%Y-%m-%d %H:%M:%S", lm);
+		if ((written > 0) && ((size_t)written < sz)) {
+			int w;
+
+			w = snprintf(buf + written, sz - (size_t)written,
+				     ".%06lu", tv->tv_usec);
+			written = (w > 0) ? written + w : -1;
+		}
+	}
+
+	return written;
+}
+
 #endif /* _ZEBRA_FRR_H */

--- a/lib/monotime.h
+++ b/lib/monotime.h
@@ -132,6 +132,37 @@ static inline const char *frrtime_to_interval(time_t t, char *buf,
 	return buf;
 }
 
+static inline ssize_t frr_realtime_to_string(struct timeval *real, char *buf,
+					     size_t sz)
+{
+	ssize_t written = -1;
+	struct tm *lm;
+
+	lm = localtime((const time_t *)&real->tv_sec);
+
+	if (lm) {
+		written = (ssize_t)strftime(buf, sz, "%Y-%m-%d %H:%M:%S", lm);
+		if ((written > 0) && ((size_t)written < sz)) {
+			int w;
+
+			w = snprintf(buf + written, sz - (size_t)written,
+				     ".%06d", (int) real->tv_usec);
+			written = (w > 0) ? written + w : -1;
+		}
+	}
+
+	return written;
+}
+
+static inline ssize_t frr_monotime_to_string(struct timeval *mono, char *buf,
+					     size_t sz)
+{
+	struct timeval real;
+
+	(void) monotime_to_realtime(mono, &real);
+	return frr_realtime_to_string(&real, buf, sz);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/monotime.h
+++ b/lib/monotime.h
@@ -146,7 +146,7 @@ static inline ssize_t frr_realtime_to_string(struct timeval *real, char *buf,
 			int w;
 
 			w = snprintf(buf + written, sz - (size_t)written,
-				     ".%06d", (int) real->tv_usec);
+				     ".%06d", (int)real->tv_usec);
 			written = (w > 0) ? written + w : -1;
 		}
 	}
@@ -159,7 +159,7 @@ static inline ssize_t frr_monotime_to_string(struct timeval *mono, char *buf,
 {
 	struct timeval real;
 
-	(void) monotime_to_realtime(mono, &real);
+	(void)monotime_to_realtime(mono, &real);
 	return frr_realtime_to_string(&real, buf, sz);
 }
 

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -184,18 +184,14 @@ static void thread_dump_master_statistics(struct vty *vty,
 	if (m->last_wakeup.tv_sec || m->last_wakeup.tv_usec) {
 		vty_out(vty, " Last-Wakeup-Interval: \t\t%llu us\n",
 			m->last_wkp_intvl);
-		frr_realtime_to_string(&m->last_wakeup, buf,
-					sizeof(buf));
+		frr_realtime_to_string(&m->last_wakeup, buf, sizeof(buf));
 		vty_out(vty, " Last-Wakeup-Time:\t\t%s\n", buf);
-		if (m->last_max_wakeup.tv_sec
-			|| m->last_max_wakeup.tv_usec) {
-			vty_out(vty,
-				" Maximum-Wakeup-Interval: \t%llu us\n",
+		if (m->last_max_wakeup.tv_sec || m->last_max_wakeup.tv_usec) {
+			vty_out(vty, " Maximum-Wakeup-Interval: \t%llu us\n",
 				m->max_wkp_intvl);
 			frr_realtime_to_string(&m->last_max_wakeup, buf,
-						sizeof(buf));
-			vty_out(vty, " Last-Maximum-Wakeup-Time:\t%s\n",
-				buf);
+					       sizeof(buf));
+			vty_out(vty, " Last-Maximum-Wakeup-Time:\t%s\n", buf);
 		}
 	} else {
 		vty_out(vty, " Last-Wakeup-Time:\t\tNever\n");
@@ -1753,18 +1749,13 @@ void thread_call(struct thread *thread)
 		 */
 		(void)monotime_to_realtime(&before.real, &wkptime);
 		if (thread->master->last_wakeup.tv_sec
-			|| thread->master->last_wakeup.tv_usec) {
-			timersub(&wkptime, &thread->master->last_wakeup,
-					&diff);
-			wkpintvl_usecs =
-				(((uint64_t)diff.tv_sec * 1000000)
-					+ (uint64_t)diff.tv_usec);
-			if (wkpintvl_usecs
-				> thread->master->max_wkp_intvl) {
-				thread->master->max_wkp_intvl =
-					wkpintvl_usecs;
-				thread->master->last_max_wakeup =
-					wkptime;
+		    || thread->master->last_wakeup.tv_usec) {
+			timersub(&wkptime, &thread->master->last_wakeup, &diff);
+			wkpintvl_usecs = (((uint64_t)diff.tv_sec * 1000000)
+					  + (uint64_t)diff.tv_usec);
+			if (wkpintvl_usecs > thread->master->max_wkp_intvl) {
+				thread->master->max_wkp_intvl = wkpintvl_usecs;
+				thread->master->last_max_wakeup = wkptime;
 			}
 			thread->master->last_wkp_intvl = wkpintvl_usecs;
 		}

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -52,7 +52,7 @@ DECLARE_LIST(thread_list, struct thread, threaditem)
  * One may use thread_set_stats_collection() to enable it at the time
  * of initializing any specific daemon.
  */
-static int thread_collect_stats = true;
+static int thread_collect_stats = false;
 
 static int thread_timer_cmp(const struct thread *a, const struct thread *b)
 {

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -237,7 +237,7 @@ extern unsigned long thread_consumed_time(RUSAGE_T *after, RUSAGE_T *before,
 /* only for use in logging functions! */
 extern pthread_key_t thread_current;
 extern char *thread_timer_to_hhmmss(char *buf, int buf_size,
-				    struct thread *t_timer);
+		struct thread *t_timer);
 
 /* Debug signal mask */
 void debug_signals(const sigset_t *sigs);

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -43,6 +43,8 @@ struct rusage_t {
 PREDECL_LIST(thread_list)
 PREDECL_HEAP(thread_timer_list)
 
+struct vty;
+
 struct fd_handler {
 	/* number of pfd that fit in the allocated space of pfds. This is a
 	 * constant
@@ -87,6 +89,13 @@ struct thread_master {
 	bool handle_signals;
 	pthread_mutex_t mtx;
 	pthread_t owner;
+	struct timeval last_wakeup;
+	struct timeval last_max_wakeup;
+	struct timeval last_hog;
+	uint64_t last_wkp_intvl;
+	uint64_t max_wkp_intvl;
+	uint64_t last_hog_realtime;
+	uint64_t last_hog_cputime;
 };
 
 /* Thread itself. */
@@ -225,10 +234,14 @@ extern void thread_cmd_init(void);
 extern unsigned long thread_consumed_time(RUSAGE_T *after, RUSAGE_T *before,
 					  unsigned long *cpu_time_elapsed);
 
+extern void thread_dump_master_statistics(struct vty *vty,
+					  struct thread_master *m);
+extern void thread_dump_all_thread_statistics(struct vty *vty);
+
 /* only for use in logging functions! */
 extern pthread_key_t thread_current;
 extern char *thread_timer_to_hhmmss(char *buf, int buf_size,
-		struct thread *t_timer);
+				    struct thread *t_timer);
 
 /* Debug signal mask */
 void debug_signals(const sigset_t *sigs);

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -43,8 +43,6 @@ struct rusage_t {
 PREDECL_LIST(thread_list)
 PREDECL_HEAP(thread_timer_list)
 
-struct vty;
-
 struct fd_handler {
 	/* number of pfd that fit in the allocated space of pfds. This is a
 	 * constant
@@ -230,13 +228,11 @@ extern void thread_set_yield_time(struct thread *, unsigned long);
 extern void thread_getrusage(RUSAGE_T *);
 extern void thread_cmd_init(void);
 
+extern void thread_set_stats_collection(int enable);
+
 /* Returns elapsed real (wall clock) time. */
 extern unsigned long thread_consumed_time(RUSAGE_T *after, RUSAGE_T *before,
 					  unsigned long *cpu_time_elapsed);
-
-extern void thread_dump_master_statistics(struct vty *vty,
-					  struct thread_master *m);
-extern void thread_dump_all_thread_statistics(struct vty *vty);
 
 /* only for use in logging functions! */
 extern pthread_key_t thread_current;


### PR DESCRIPTION
Issue:
Today if BGPd or any other FRR daemon is not scheduled due to CPU starvation,
there is no way that can be detected.

Fix:
Add three more data-items 'last_wakeup', 'max_wkp_intvl' and 'last_cpu_hog' under
'struct thread_master' and enhance 'thread_call' to compute and record these
everytime any of the threads under the thread_master is invoked.

Output:
```
dev# show thread cpu
…
Thread statistics for bgpd:
Showing statistics for pthread main
 Last-Wakeup-Interval: 		1005171 us
 Last-Wakeup-Time:		2021-01-22 07:20:39.522846
 Maximum-Wakeup-Interval: 	2427640 us
 Last-Maximum-Wakeup-Time:	2021-01-22 07:20:38.465683

-----------------------------------
           CPU (user+system): Real (wall-clock):
Active  Runtime(ms)  Invoked Avg uSec Max uSecs Avg uSec Max uSecs Type Thread
  0     0.000     1    0     0    18    18  T  update_group_refresh_default_originate_route_map
  1     0.000     3    0     0    41    50 R   vtysh_accept
  0     0.000     1    0     0    32    32  E frr_config_read_in
  0     4.000     2   2000   4000   236    340  E bgp_event
  0     0.000     2    0     0    50    70  E zclient_connect
  1     0.000    17    0     0   153   1184 R   vtysh_read
  2     0.000    24    0     0    14    80 R   zclient_read
  0     0.000     1    0     0    58    58  T  (bgp_start_timer)
  0     0.000     1    0     0    37    37  T  work_queue_run
Showing statistics for pthread BGP I/O thread
 Last-Wakeup-Time:		Never
---------------------------------------------
           CPU (user+system): Real (wall-clock):
Active  Runtime(ms)  Invoked Avg uSec Max uSecs Avg uSec Max uSecs Type Thread
Showing statistics for pthread BGP Keepalives thread
 Last-Wakeup-Time:		Never
----------------------------------------------------
           CPU (user+system): Real (wall-clock):
Active  Runtime(ms)  Invoked Avg uSec Max uSecs Avg uSec Max uSecs Type Thread
No data to display yet.
Showing statistics for pthread BGP Established Tracking thread
 Last-Wakeup-Time:		Never
--------------------------------------------------------------
           CPU (user+system): Real (wall-clock):
Active  Runtime(ms)  Invoked Avg uSec Max uSecs Avg uSec Max uSecs Type Thread
No data to display yet.
Total thread statistics
-------------------------
           CPU (user+system): Real (wall-clock):
Active  Runtime(ms)  Invoked Avg uSec Max uSecs Avg uSec Max uSecs Type Thread
  4     4.000    52    76   4000    73   1184 RWTEX TOTAL
….
dev#
```

NOTE:
Offcourse it can not be used to differentiate between
1) wether a process was indeed ready but it could not be
scheduled (due to other process hogging CPU) and 
2) the process really being idle for long.

In cases if a deamon is supposed to run some timely regular
jobs, the data captured here can definitely highlight if
the process ever went through CPU starvation or not.

Signed-off-by: Pushpasis Sarkar <pushpasis@gmail.com>