### PR TITLE
libs, bgpd: improve task cancellation by argument value

### DIFF
--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -31,7 +31,7 @@
 
 #define BGP_TIMER_OFF(T)                                                       \
 	do {                                                                   \
-		THREAD_OFF(T);						       \
+		THREAD_OFF((T));					       \
 	} while (0)
 
 #define BGP_EVENT_ADD(P, E)                                                    \
@@ -44,7 +44,7 @@
 #define BGP_EVENT_FLUSH(P)                                                     \
 	do {                                                                   \
 		assert(peer);                                                  \
-		thread_cancel_event(bm->master, (P));                          \
+		thread_cancel_event_ready(bm->master, (P));                    \
 	} while (0)
 
 #define BGP_UPDATE_GROUP_TIMER_ON(T, F)					       \
@@ -53,10 +53,10 @@
 		    PEER_ROUTE_ADV_DELAY(peer))				       \
 			thread_add_timer_msec(bm->master, (F), peer,	       \
 				(BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME * 1000),\
-				T);					       \
+				(T));					       \
 		else							       \
 			thread_add_timer_msec(bm->master, (F), peer,	       \
-					      0, T);			       \
+					      0, (T));			       \
 	} while (0)							       \
 
 #define BGP_MSEC_JITTER 10

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -45,6 +45,16 @@ DEFINE_MTYPE_STATIC(LIB, THREAD_STATS, "Thread stats")
 
 DECLARE_LIST(thread_list, struct thread, threaditem)
 
+struct cancel_req {
+	int flags;
+	struct thread *thread;
+	void *eventobj;
+	struct thread **threadref;
+};
+
+/* Flags for task cancellation */
+#define THREAD_CANCEL_FLAG_READY     0x01
+
 static int thread_timer_cmp(const struct thread *a, const struct thread *b)
 {
 	if (a->u.sands.tv_sec < b->u.sands.tv_sec)

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -61,12 +61,6 @@ struct fd_handler {
 	nfds_t copycount;
 };
 
-struct cancel_req {
-	struct thread *thread;
-	void *eventobj;
-	struct thread **threadref;
-};
-
 struct xref_threadsched {
 	struct xref xref;
 

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -46,8 +46,8 @@ PREDECL_HEAP(thread_timer_list)
 
 struct fd_handler {
 	/* number of pfd that fit in the allocated space of pfds. This is a
-	 * constant
-	 * and is the same for both pfds and copy. */
+	 * constant and is the same for both pfds and copy.
+	 */
 	nfds_t pfdsize;
 
 	/* file descriptors to monitor for i/o */
@@ -231,7 +231,10 @@ extern void _thread_execute(const struct xref_threadsched *xref,
 extern void thread_cancel(struct thread **event);
 extern void thread_cancel_async(struct thread_master *, struct thread **,
 				void *);
-extern void thread_cancel_event(struct thread_master *, void *);
+/* Cancel ready tasks with an arg matching 'arg' */
+extern void thread_cancel_event_ready(struct thread_master *m, void *arg);
+/* Cancel all tasks with an arg matching 'arg', including timers and io */
+extern void thread_cancel_event(struct thread_master *m, void *arg);
 extern struct thread *thread_fetch(struct thread_master *, struct thread *);
 extern void thread_call(struct thread *);
 extern unsigned long thread_timer_remain_second(struct thread *);


### PR DESCRIPTION
Extend the thread_cancel_event api so that it's more complete: look in all the lists of tasks, including io and timers, for matching tasks to cancel. Add a dedicated api that does the more limited original behavior, examining only the ready and events queues. BGP appears to require this more-limited version, so use it via the bgp macro.
