### PR TITLE
bgpd: vrf route leaking related fixes

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1295,15 +1295,19 @@ bool ecommunity_del_val(struct ecommunity *ecom, struct ecommunity_val *eval)
 
 	/* Delete the selected value */
 	ecom->size--;
-	p = XMALLOC(MTYPE_ECOMMUNITY_VAL, ecom->size * ecom->unit_size);
-	if (c != 0)
-		memcpy(p, ecom->val, c * ecom->unit_size);
-	if ((ecom->size - c) != 0)
-		memcpy(p + (c)*ecom->unit_size,
-		       ecom->val + (c + 1) * ecom->unit_size,
-		       (ecom->size - c) * ecom->unit_size);
-	XFREE(MTYPE_ECOMMUNITY_VAL, ecom->val);
-	ecom->val = p;
+	if (ecom->size) {
+		p = XMALLOC(MTYPE_ECOMMUNITY_VAL, ecom->size * ecom->unit_size);
+		if (c != 0)
+			memcpy(p, ecom->val, c * ecom->unit_size);
+		if ((ecom->size - c) != 0)
+			memcpy(p + (c)*ecom->unit_size,
+		       	       ecom->val + (c + 1) * ecom->unit_size,
+		       	       (ecom->size - c) * ecom->unit_size);
+		XFREE(MTYPE_ECOMMUNITY_VAL, ecom->val);
+		ecom->val = p;
+	} else
+		ecom->val = NULL;
+
 	return true;
 }
 

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -180,6 +180,19 @@ int bgp_path_info_nexthop_cmp(struct bgp_path_info *bpi1,
 			}
 		}
 	}
+	/*
+	 * If both nexthops are same then check
+	 * if they belong to same VRF
+	 */
+	if (!compare) {
+		if (bpi1->extra && bpi1->extra->bgp_orig && bpi2->extra
+		    && bpi2->extra->bgp_orig) {
+			if (bpi1->extra->bgp_orig->vrf_id
+			    != bpi2->extra->bgp_orig->vrf_id) {
+				compare = 1;
+			}
+		}
+	}
 
 	return compare;
 }

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1027,6 +1027,8 @@ void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn, /* to */
 					if (debug)
 						zlog_debug("%s: deleting it",
 							   __func__);
+					/* withdraw from leak-to vrfs as well */
+					vpn_leak_to_vrf_withdraw(bgp_vpn, bpi);
 					bgp_aggregate_decrement(
 						bgp_vpn,
 						bgp_dest_get_prefix(bn), bpi,

--- a/bgpd/bgp_nb_config.c
+++ b/bgpd/bgp_nb_config.c
@@ -121,7 +121,12 @@ int bgp_router_create(struct nb_cb_create_args *args)
 		if (is_new_bgp && inst_type == BGP_INSTANCE_TYPE_DEFAULT)
 			vpn_leak_postchange_all();
 
-		if (inst_type == BGP_INSTANCE_TYPE_VRF)
+		/*
+		 * Check if we need to export to other VRF(s).
+		 * Leak the routes to importing bgp vrf instances,
+		 * only when new bgp vrf instance is configured.
+		 */
+		if (ret != BGP_INSTANCE_EXISTS)
 			bgp_vpn_leak_export(bgp);
 
 		UNSET_FLAG(bgp->vrf_flags, BGP_VRF_AUTO);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1097,7 +1097,7 @@ route_match_vrl_source_vrf(void *rule, const struct prefix *prefix,
 	if (strncmp(vrf_name, "n/a", VRF_NAMSIZ) == 0)
 		return RMAP_NOMATCH;
 
-	if (path->extra == NULL)
+	if (path->extra == NULL || path->extra->bgp_orig == NULL)
 		return RMAP_NOMATCH;
 
 	if (strncmp(vrf_name, vrf_id_to_name(path->extra->bgp_orig->vrf_id),

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1679,9 +1679,6 @@ int bgp_redistribute_set(struct bgp *bgp, afi_t afi, int type,
 
 		redist_add_instance(&zclient->mi_redist[afi][type], instance);
 	} else {
-		if (vrf_bitmap_check(zclient->redist[afi][type], bgp->vrf_id))
-			return CMD_WARNING;
-
 #ifdef ENABLE_BGP_VNC
 		if (EVPN_ENABLED(bgp) && type == ZEBRA_ROUTE_VNC_DIRECT) {
 			vnc_export_bgp_enable(

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -26,6 +26,13 @@
 /* Default weight for next hop, if doing weighted ECMP. */
 #define BGP_ZEBRA_DEFAULT_NHOP_WEIGHT 1
 
+/* Macro to update bgp_original based on bpg_path_info */
+#define BGP_ORIGINAL_UPDATE(_bgp_orig, _mpinfo, _bgp)                          \
+	((_mpinfo->extra && _mpinfo->extra->bgp_orig                           \
+	  && _mpinfo->sub_type == BGP_ROUTE_IMPORTED)                          \
+		 ? (_bgp_orig = _mpinfo->extra->bgp_orig)                      \
+		 : (_bgp_orig = _bgp))
+
 extern void bgp_zebra_init(struct thread_master *master,
 			   unsigned short instance);
 extern void bgp_zebra_init_tm_connect(struct bgp *bgp);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3379,7 +3379,7 @@ int bgp_get(struct bgp **bgp_val, as_t *as, const char *name,
 		return ret;
 	case BGP_SUCCESS:
 		if (*bgp_val)
-			return ret;
+			return BGP_INSTANCE_EXISTS;
 	}
 
 	bgp = bgp_create(as, name, inst_type);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1757,6 +1757,7 @@ enum bgp_clear_type {
 /* BGP error codes.  */
 #define BGP_SUCCESS                               0
 #define BGP_CREATED                               1
+#define BGP_INSTANCE_EXISTS 2
 #define BGP_ERR_INVALID_VALUE                    -1
 #define BGP_ERR_INVALID_FLAG                     -2
 #define BGP_ERR_INVALID_AS                       -3

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -348,17 +348,12 @@ void zebra_redistribute_add(ZAPI_HANDLER_ARGS)
 					   zvrf_id(zvrf), afi);
 		}
 	} else {
-		if (!vrf_bitmap_check(client->redist[afi][type],
-				      zvrf_id(zvrf))) {
-			if (IS_ZEBRA_DEBUG_EVENT)
-				zlog_debug(
-					"%s: setting vrf %s(%u) redist bitmap",
-					__func__, VRF_LOGNAME(zvrf->vrf),
-					zvrf_id(zvrf));
-			vrf_bitmap_set(client->redist[afi][type],
-				       zvrf_id(zvrf));
-			zebra_redistribute(client, type, 0, zvrf_id(zvrf), afi);
-		}
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s: setting vrf %s(%u) redist bitmap",
+				   __func__, VRF_LOGNAME(zvrf->vrf),
+				   zvrf_id(zvrf));
+		vrf_bitmap_set(client->redist[afi][type], zvrf_id(zvrf));
+		zebra_redistribute(client, type, 0, zvrf_id(zvrf), afi);
 	}
 
 stream_failure:


### PR DESCRIPTION
Description:
Change is intended for fixing the following issues related to vrf route leaking:
1. FRR doesn't re-install the routes, imported from a tenant VRF,
when bgp instance for source vrf is deleted and re-added again.
When bgp instance is removed and re-added, when import statement is already there,
then route leaking stops between two VRFs.
2. Imported/leak-from routes do not get withdrawn/removed even if the source VRF is deleted.
Deleting and re-adding a tenant vrf, does not refresh the RIB.
3. Incorrect behavior during best path selection for the imported routes.
Imported routes were always treated as eBGP routes.
4. After FRR restart, routes are not getting redistributed;
when routes added first and then 'redistribute static' cmd is issued.
5. While withdrawal of exported routes is in-progress, routes are marked as being removed and invalid.
In the mean time, if router bgp config is updated, which triggers exports routes from configured bgp vrf to VPN.
So withdraw-in-progress routes are again leaked to bgp vrf instance(s) importing routes (stale routes).
6. If the interface comes up after route leaking is configured, in the case of vpn router id update,
we delete the ecommunity value and never reconfigure the rtlist.
This results in skipping route leak to non-default vrfs (vpn to vrf).

Co-authored-by: Santosh P K <sapk@vmware.com>
Co-authored-by: Kantesh Mundaragi <kmundaragi@vmware.com>
Signed-off-by: Kantesh Mundaragi <kmundaragi@vmware.com>