### PR TITLE
zebra: support preemptive deletes for v6 route adds

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1115,7 +1115,8 @@ static int nl_batch_read_resp(struct nl_batch *bth)
 
 			/*
 			 * 'update' context objects take two consecutive
-			 * sequence numbers.
+			 * sequence numbers. the DELETE operation uses the
+			 * second, higher seq value.
 			 */
 			if (dplane_ctx_is_update(ctx)
 			    && dplane_ctx_get_ns(ctx)->nls.seq + 1 == seq) {
@@ -1279,6 +1280,10 @@ enum netlink_msg_status netlink_batch_add_msg(
 			return FRR_NETLINK_ERROR;
 	}
 
+	/* Some operations use two messages - a preemptive 'delete' associated
+	 * with an add/update for a route, for example. This preemptive message
+	 * uses a second netlink sequence number.
+	 */
 	seq = dplane_ctx_get_ns(ctx)->nls.seq;
 	if (ignore_res)
 		seq++;

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -70,7 +70,7 @@ struct thread_master *master;
 /* Route retain mode flag. */
 int retain_mode = 0;
 
-/* Allow non-quagga entities to delete quagga routes */
+/* Allow non-FRR entities to delete FRR routes */
 int allow_delete = 0;
 
 int graceful_restart;
@@ -418,9 +418,6 @@ int main(int argc, char **argv)
 	zebra_pbr_init();
 	zebra_opaque_init();
 	zebra_srte_init();
-
-	/* For debug purpose. */
-	/* SET_FLAG (zebra_debug_event, ZEBRA_DEBUG_EVENT); */
 
 	/* Process the configuration file. Among other configuration
 	*  directives we can meet those installing static routes. Such

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -75,7 +75,11 @@ int allow_delete = 0;
 
 int graceful_restart;
 
+/* IPv6 route semantics allow 'replace' */
 bool v6_rr_semantics = false;
+
+/* IPv6 route updates preceded by preemptive delete. */
+bool v6_preempt_delete;
 
 #ifdef HAVE_NETLINK
 /* Receive buffer size for netlink socket */
@@ -84,6 +88,7 @@ uint32_t nl_rcvbufsize = 4194304;
 
 #define OPTION_V6_RR_SEMANTICS 2000
 #define OPTION_ASIC_OFFLOAD    2001
+#define OPTION_V6_PREEMPT      2002
 
 /* Command line options. */
 const struct option longopts[] = {
@@ -99,6 +104,7 @@ const struct option longopts[] = {
 	{"vrfwnetns", no_argument, NULL, 'n'},
 	{"nl-bufsize", required_argument, NULL, 's'},
 	{"v6-rr-semantics", no_argument, NULL, OPTION_V6_RR_SEMANTICS},
+	{"v6-preempt", no_argument, NULL, OPTION_V6_PREEMPT},
 #endif /* HAVE_NETLINK */
 	{0}};
 
@@ -288,6 +294,8 @@ int main(int argc, char **argv)
 	bool asic_offload = false;
 	bool notify_on_ack = true;
 
+	v6_preempt_delete = false;
+
 	graceful_restart = 0;
 	vrf_configure_backend(VRF_BACKEND_VRF_LITE);
 
@@ -312,6 +320,7 @@ int main(int argc, char **argv)
 		"  -n, --vrfwnetns          Use NetNS as VRF backend\n"
 		"  -s, --nl-bufsize         Set netlink receive buffer size\n"
 		"      --v6-rr-semantics    Use v6 RR semantics\n"
+		"      --v6-preempt         Preemptive deletes for v6 route updates\n"
 #endif /* HAVE_NETLINK */
 	);
 
@@ -372,6 +381,9 @@ int main(int argc, char **argv)
 			break;
 		case OPTION_V6_RR_SEMANTICS:
 			v6_rr_semantics = true;
+			break;
+		case OPTION_V6_PREEMPT:
+			v6_preempt_delete = true;
 			break;
 		case OPTION_ASIC_OFFLOAD:
 			if (!strcmp(optarg, "notify_on_offload"))

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -574,6 +574,9 @@ extern pid_t pid;
 
 extern bool v6_rr_semantics;
 
+/* Perform preemptive deletes for v6 route updates. */
+extern bool v6_preempt_delete;
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1675,9 +1675,17 @@ ssize_t netlink_route_multipath_msg_encode(int cmd,
 	req->r.rtm_src_len = src_p ? src_p->prefixlen : 0;
 	req->r.rtm_scope = RT_SCOPE_UNIVERSE;
 
-	if (cmd == RTM_DELROUTE)
-		req->r.rtm_protocol = zebra2proto(dplane_ctx_get_old_type(ctx));
-	else
+	if (cmd == RTM_DELROUTE) {
+		/* Special case for ipv6 route install: we're sending a
+		 * preemptive delete operation, and there's no 'old' proto info.
+		 */
+		if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_INSTALL &&
+		    p->family == AF_INET6)
+			req->r.rtm_protocol = RTPROT_UNSPEC;
+		else
+			req->r.rtm_protocol =
+				zebra2proto(dplane_ctx_get_old_type(ctx));
+	} else
 		req->r.rtm_protocol = zebra2proto(dplane_ctx_get_type(ctx));
 
 	/*
@@ -2331,6 +2339,19 @@ netlink_put_route_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx)
 	if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_DELETE) {
 		cmd = RTM_DELROUTE;
 	} else if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_INSTALL) {
+		if (p->family == AF_INET6 && !v6_rr_semantics &&
+		    v6_preempt_delete) {
+			/* For v6 routes, let's do a preemptive delete,
+			 * as we do for updates. We want the fib to look
+			 * like the incoming rib ctx. We'll need to create
+			 * a delete message even though we don't have
+			 * 'old' context data,
+			 */
+			netlink_batch_add_msg(
+				bth, ctx, netlink_delroute_msg_encoder,
+				true);
+		}
+
 		cmd = RTM_NEWROUTE;
 	} else if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_UPDATE) {
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2052,6 +2052,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	zebra_l3vni_t *zl3vni;
 	const struct interface *ifp;
 	struct dplane_intf_extra *if_extra;
+	bool update_p = false;
 
 	if (!ctx || !rn || !re)
 		goto done;
@@ -2149,10 +2150,23 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		goto done;
 	}
 
-	/* Extract ns info - can't use pointers to 'core' structs */
+	/* Extract ns info - can't use pointers to 'core' structs in dplane. */
 	zvrf = vrf_info_lookup(re->vrf_id);
 	zns = zvrf->zns;
-	dplane_ctx_ns_init(ctx, zns, (op == DPLANE_OP_ROUTE_UPDATE));
+
+	/* For route update, or v6 route add with configure option,
+	 * we take two sequence numbers.
+	 */
+	if (op == DPLANE_OP_ROUTE_UPDATE)
+		update_p = true;
+	else if (op == DPLANE_OP_ROUTE_INSTALL &&
+		 ctx->u.rinfo.zd_dest.family == AF_INET6 &&
+		 v6_preempt_delete) {
+
+		update_p = true;
+	}
+
+	dplane_ctx_ns_init(ctx, zns, update_p);
 
 #ifdef HAVE_NETLINK
 	{

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1826,7 +1826,7 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 	 * Update is a bit of a special case, where we may have both old and new
 	 * routes to post-process.
 	 */
-	is_update = dplane_ctx_is_update(ctx);
+	is_update = (op == DPLANE_OP_ROUTE_UPDATE);
 
 	/*
 	 * Take a pass through the routes, look for matches with the context


### PR DESCRIPTION
The netlink ipv6 route semantics are not 'replace', so for some time zebra has performed a preemptive 'delete' when updating ipv6 routes, to ensure that the installed route matches zebra's internal data. This adds a similar 'delete' for ipv6 route adds, again to ensure that what ends up in the kernel matches zebra's internals. The preemptive delete is enabled by a zebra command-line option (the default is 'off').

We use a remote dataplane (on a switch) in addition to the local kernel hosting zebra. In some route update cases, zebra has discarded the "old" route info by the time we get results about the "new" route that we want to have installed locally. For v4, that works fine, because the v4 installs have "replace" semantics. For v6, however, we have trouble getting the desired behavior: zebra wants a route to be installed that matches its internal data.