### PR TITLE
ospfd: don't rely on instance existence in vty

### DIFF
--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -616,7 +616,7 @@ DEFUN (debug_ospf_packet,
 
 	if (inst) // user passed instance ID
 	{
-		if (!ospf_lookup_instance(strtoul(argv[2]->arg, NULL, 10)))
+		if (inst != ospf_instance)
 			return CMD_NOT_MY_INSTANCE;
 	}
 
@@ -692,7 +692,7 @@ DEFUN (no_debug_ospf_packet,
 
 	if (inst) // user passed instance ID
 	{
-		if (!ospf_lookup_instance(strtoul(argv[3]->arg, NULL, 10)))
+		if (inst != ospf_instance)
 			return CMD_NOT_MY_INSTANCE;
 	}
 
@@ -763,7 +763,7 @@ DEFUN (debug_ospf_ism,
 
 	if (inst) // user passed instance ID
 	{
-		if (!ospf_lookup_instance(strtoul(argv[2]->arg, NULL, 10)))
+		if (inst != ospf_instance)
 			return CMD_NOT_MY_INSTANCE;
 	}
 
@@ -814,7 +814,7 @@ DEFUN (no_debug_ospf_ism,
 
 	if (inst) // user passed instance ID
 	{
-		if (!ospf_lookup_instance(strtoul(argv[3]->arg, NULL, 10)))
+		if (inst != ospf_instance)
 			return CMD_NOT_MY_INSTANCE;
 	}
 
@@ -909,8 +909,8 @@ DEFUN (debug_ospf_instance_nsm,
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if (!ospf_lookup_instance(instance))
-		return CMD_SUCCESS;
+	if (instance != ospf_instance)
+		return CMD_NOT_MY_INSTANCE;
 
 	return debug_ospf_nsm_common(vty, 4, argc, argv);
 }
@@ -981,7 +981,7 @@ DEFUN (no_debug_ospf_instance_nsm,
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if (!ospf_lookup_instance(instance))
+	if (instance != ospf_instance)
 		return CMD_NOT_MY_INSTANCE;
 
 	return no_debug_ospf_nsm_common(vty, 5, argc, argv);
@@ -1062,7 +1062,7 @@ DEFUN (debug_ospf_instance_lsa,
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if (!ospf_lookup_instance(instance))
+	if (instance != ospf_instance)
 		return CMD_NOT_MY_INSTANCE;
 
 	return debug_ospf_lsa_common(vty, 4, argc, argv);
@@ -1145,7 +1145,7 @@ DEFUN (no_debug_ospf_instance_lsa,
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if (!ospf_lookup_instance(instance))
+	if (instance != ospf_instance)
 		return CMD_NOT_MY_INSTANCE;
 
 	return no_debug_ospf_lsa_common(vty, 5, argc, argv);
@@ -1207,7 +1207,7 @@ DEFUN (debug_ospf_instance_zebra,
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if (!ospf_lookup_instance(instance))
+	if (instance != ospf_instance)
 		return CMD_NOT_MY_INSTANCE;
 
 	return debug_ospf_zebra_common(vty, 4, argc, argv);
@@ -1271,8 +1271,8 @@ DEFUN (no_debug_ospf_instance_zebra,
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if (!ospf_lookup_instance(instance))
-		return CMD_SUCCESS;
+	if (instance != ospf_instance)
+		return CMD_NOT_MY_INSTANCE;
 
 	return no_debug_ospf_zebra_common(vty, 5, argc, argv);
 }
@@ -1317,8 +1317,8 @@ DEFUN (debug_ospf_instance_event,
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if (!ospf_lookup_instance(instance))
-		return CMD_SUCCESS;
+	if (instance != ospf_instance)
+		return CMD_NOT_MY_INSTANCE;
 
 	if (vty->node == CONFIG_NODE)
 		CONF_DEBUG_ON(event, EVENT);
@@ -1339,8 +1339,8 @@ DEFUN (no_debug_ospf_instance_event,
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if (!ospf_lookup_instance(instance))
-		return CMD_SUCCESS;
+	if (instance != ospf_instance)
+		return CMD_NOT_MY_INSTANCE;
 
 	if (vty->node == CONFIG_NODE)
 		CONF_DEBUG_OFF(event, EVENT);
@@ -1387,8 +1387,8 @@ DEFUN (debug_ospf_instance_nssa,
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if (!ospf_lookup_instance(instance))
-		return CMD_SUCCESS;
+	if (instance != ospf_instance)
+		return CMD_NOT_MY_INSTANCE;
 
 	if (vty->node == CONFIG_NODE)
 		CONF_DEBUG_ON(nssa, NSSA);
@@ -1409,8 +1409,8 @@ DEFUN (no_debug_ospf_instance_nssa,
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if (!ospf_lookup_instance(instance))
-		return CMD_SUCCESS;
+	if (instance != ospf_instance)
+		return CMD_NOT_MY_INSTANCE;
 
 	if (vty->node == CONFIG_NODE)
 		CONF_DEBUG_OFF(nssa, NSSA);
@@ -1625,12 +1625,12 @@ DEFUN (no_debug_ospf,
 	return CMD_SUCCESS;
 }
 
-static int show_debugging_ospf_common(struct vty *vty, struct ospf *ospf)
+static int show_debugging_ospf_common(struct vty *vty)
 {
 	int i;
 
-	if (ospf->instance)
-		vty_out(vty, "\nOSPF Instance: %d\n\n", ospf->instance);
+	if (ospf_instance)
+		vty_out(vty, "\nOSPF Instance: %d\n\n", ospf_instance);
 
 	vty_out(vty, "OSPF debugging status:\n");
 
@@ -1742,13 +1742,7 @@ DEFUN_NOSH (show_debugging_ospf,
 	    DEBUG_STR
 	    OSPF_STR)
 {
-	struct ospf *ospf = NULL;
-
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
-	if (ospf == NULL)
-		return CMD_SUCCESS;
-
-	return show_debugging_ospf_common(vty, ospf);
+	return show_debugging_ospf_common(vty);
 }
 
 DEFUN_NOSH (show_debugging_ospf_instance,
@@ -1760,14 +1754,13 @@ DEFUN_NOSH (show_debugging_ospf_instance,
 	    "Instance ID\n")
 {
 	int idx_number = 3;
-	struct ospf *ospf;
 	unsigned short instance = 0;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	if ((ospf = ospf_lookup_instance(instance)) == NULL)
-		return CMD_SUCCESS;
+	if (instance != ospf_instance)
+		return CMD_NOT_MY_INSTANCE;
 
-	return show_debugging_ospf_common(vty, ospf);
+	return show_debugging_ospf_common(vty);
 }
 
 static int config_write_debug(struct vty *vty);
@@ -1790,16 +1783,11 @@ static int config_write_debug(struct vty *vty)
 		"",	" send",	" recv",	"",
 		" detail", " send detail", " recv detail", " detail"};
 
-	struct ospf *ospf;
 	char str[16];
 	memset(str, 0, 16);
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
-	if (ospf == NULL)
-		return CMD_SUCCESS;
-
-	if (ospf->instance)
-		snprintf(str, sizeof(str), " %u", ospf->instance);
+	if (ospf_instance)
+		snprintf(str, sizeof(str), " %u", ospf_instance);
 
 	/* debug ospf ism (status|events|timers). */
 	if (IS_CONF_DEBUG_OSPF(ism, ISM) == OSPF_DEBUG_ISM)

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -146,9 +146,6 @@ FRR_DAEMON_INFO(ospfd, OSPF, .vty_port = OSPF_VTY_PORT,
 /* OSPFd main routine. */
 int main(int argc, char **argv)
 {
-	unsigned short instance = 0;
-	bool created = false;
-
 #ifdef SUPPORT_OSPF_API
 	/* OSPF apiserver is disabled by default. */
 	ospf_apiserver_enable = 0;
@@ -169,8 +166,8 @@ int main(int argc, char **argv)
 
 		switch (opt) {
 		case 'n':
-			ospfd_di.instance = instance = atoi(optarg);
-			if (instance < 1)
+			ospfd_di.instance = ospf_instance = atoi(optarg);
+			if (ospf_instance < 1)
 				exit(0);
 			break;
 		case 0:
@@ -208,7 +205,7 @@ int main(int argc, char **argv)
 
 	/* OSPFd inits. */
 	ospf_if_init();
-	ospf_zebra_init(master, instance);
+	ospf_zebra_init(master, ospf_instance);
 
 	/* OSPF vty inits. */
 	ospf_vty_init();
@@ -226,17 +223,6 @@ int main(int argc, char **argv)
 
 	/* OSPF errors init */
 	ospf_error_init();
-
-	/*
-	 * Need to initialize the default ospf structure, so the interface mode
-	 * commands can be duly processed if they are received before 'router
-	 * ospf',  when ospfd is restarted
-	 */
-	if (instance && !ospf_get_instance(instance, &created)) {
-		flog_err(EC_OSPF_INIT_FAIL, "OSPF instance init failed: %s",
-			 strerror(errno));
-		exit(1);
-	}
 
 	frr_config_fork();
 	frr_run(master);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -70,6 +70,8 @@ static struct ospf_master ospf_master;
 /* OSPF process wide configuration pointer to export. */
 struct ospf_master *om;
 
+unsigned short ospf_instance;
+
 extern struct zclient *zclient;
 
 
@@ -511,36 +513,28 @@ static void ospf_init(struct ospf *ospf)
 	ospf_router_id_update(ospf);
 }
 
-struct ospf *ospf_get(unsigned short instance, const char *name, bool *created)
+struct ospf *ospf_lookup(unsigned short instance, const char *name)
 {
 	struct ospf *ospf;
 
-	/* vrf name provided call inst and name based api
-	 * in case of no name pass default ospf instance */
-	if (name)
+	if (ospf_instance) {
+		ospf = ospf_lookup_instance(instance);
+	} else {
 		ospf = ospf_lookup_by_inst_name(instance, name);
-	else
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
-
-	*created = (ospf == NULL);
-	if (ospf == NULL) {
-		ospf = ospf_new(instance, name);
-		ospf_add(ospf);
-
-		ospf_init(ospf);
 	}
 
 	return ospf;
 }
 
-struct ospf *ospf_get_instance(unsigned short instance, bool *created)
+struct ospf *ospf_get(unsigned short instance, const char *name, bool *created)
 {
 	struct ospf *ospf;
 
-	ospf = ospf_lookup_instance(instance);
+	ospf = ospf_lookup(instance, name);
+
 	*created = (ospf == NULL);
 	if (ospf == NULL) {
-		ospf = ospf_new(instance, NULL /* VRF_DEFAULT*/);
+		ospf = ospf_new(instance, name);
 		ospf_add(ospf);
 
 		ospf_init(ospf);

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -633,6 +633,7 @@ struct ospf_nbr_nbma {
 
 /* Extern variables. */
 extern struct ospf_master *om;
+extern unsigned short ospf_instance;
 extern const int ospf_redistributed_proto_max;
 extern struct zclient *zclient;
 extern struct thread_master *master;
@@ -642,10 +643,10 @@ extern struct zebra_privs_t ospfd_privs;
 /* Prototypes. */
 extern const char *ospf_redist_string(unsigned int route_type);
 extern struct ospf *ospf_lookup_instance(unsigned short);
+extern struct ospf *ospf_lookup(unsigned short instance, const char *name);
 extern struct ospf *ospf_get(unsigned short instance, const char *name,
 			     bool *created);
 extern struct ospf *ospf_new_alloc(unsigned short instance, const char *name);
-extern struct ospf *ospf_get_instance(unsigned short, bool *created);
 extern struct ospf *ospf_lookup_by_inst_name(unsigned short instance,
 					     const char *name);
 extern struct ospf *ospf_lookup_by_vrf_id(vrf_id_t vrf_id);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2693,7 +2693,7 @@ static int show_per_daemon(struct vty *vty, struct cmd_token **argv, int argc,
 	char *line = do_prepend(vty, argv, argc);
 
 	for (i = 0; i < array_size(vtysh_client); i++)
-		if (vtysh_client[i].fd >= 0) {
+		if (vtysh_client[i].fd >= 0 || vtysh_client[i].next) {
 			vty_out(vty, headline, vtysh_client[i].name);
 			ret = vtysh_client_execute(&vtysh_client[i], line);
 			vty_out(vty, "\n");


### PR DESCRIPTION
Store instance index at startup and use it when processing vty commands.
The instance itself may be created and deleted by the user in runtime
using `[no] router ospf X` command.

Fixes #7908

And a separate commit to fix vtysh for multi-instance ospfd.