### PR TITLE
BGP: "no neighbor <peer-group> allowas-in" is not resetting the peer-group member allowas_in[afi][safi].

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -5684,11 +5684,6 @@ int peer_allowas_in_unset(struct peer *peer, afi_t afi, safi_t safi)
 			       PEER_FLAG_ALLOWAS_IN))
 			continue;
 
-		/* Skip peers where flag is already disabled. */
-		if (!CHECK_FLAG(member->af_flags[afi][safi],
-				PEER_FLAG_ALLOWAS_IN))
-			continue;
-
 		/* Remove flags and configuration on peer-group member. */
 		UNSET_FLAG(member->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN);
 		UNSET_FLAG(member->af_flags[afi][safi],


### PR DESCRIPTION
In function peer_allowas_in_unset, when API peer_af_flag_unset() is called it already reset the PEER_FLAG_ALLOWAS_IN flag for all the member peer, hence when loop through peer it will not reset member->allowas_in[afi][safi] to 0. This is causing remote route accepted.

Signed-off-by: Kishore Kunal <kishorekunal01@broadcom.com>