### PR TITLE
bgpd: [7.5] Removing "neighbor <peer-group> allowas-in"

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -5415,11 +5415,6 @@ int peer_allowas_in_unset(struct peer *peer, afi_t afi, safi_t safi)
 			       PEER_FLAG_ALLOWAS_IN))
 			continue;
 
-		/* Skip peers where flag is already disabled. */
-		if (!CHECK_FLAG(member->af_flags[afi][safi],
-				PEER_FLAG_ALLOWAS_IN))
-			continue;
-
 		/* Remove flags and configuration on peer-group member. */
 		UNSET_FLAG(member->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN);
 		UNSET_FLAG(member->af_flags[afi][safi],


### PR DESCRIPTION
Unconfig not resetting the peer-group member allowas_in[afi][safi]
This is causing remote route to be accept.

Signed-off-by: Kishore Kunal <kishorekunal01@broadcom.com>