### PR TITLE
[7.6] libs, ospfd: remove inet_ntoa

### DIFF
--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -1273,10 +1273,8 @@ void ls_dump_ted(struct ls_ted *ted)
 	frr_each(subnets, &ted->subnets, subnet) {
 		ls_subnet2msg(&msg, subnet);
 		zlog_debug(
-			"\tTed subnet key:%s vertex:%pI4 pfx:%pFX",
-			subnet->key.family == AF_INET
-				? inet_ntoa(subnet->key.u.prefix4)
-				: inet6_ntoa(subnet->key.u.prefix6),
+			"\tTed subnet key:%pFX vertex:%pI4 pfx:%pFX",
+			&subnet->key,
 			&subnet->vertex->node->adv.id.ip.addr,
 			&subnet->ls_pref->pref);
 	}

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2855,9 +2855,10 @@ static int ospf_maxage_lsa_remover(struct thread *thread)
 				 */
 				if (old != lsa) {
 					flog_err(EC_OSPF_LSA_MISSING,
-					"%s: LSA[Type%d:%s]: LSA not in LSDB",
-					__func__, lsa->data->type,
-					inet_ntoa(lsa->data->id));
+						 "%s: LSA[Type%d:%pI4]: LSA not in LSDB",
+						 __func__, lsa->data->type,
+						 &lsa->data->id);
+
 					continue;
 				}
 				ospf_discard_from_db(ospf, lsa->lsdb, lsa);


### PR DESCRIPTION
[7.6 version] remove calls to inet_ntoa, introduced recently.