### PR TITLE
eigrpd: Correctly set the mtu for eigrp packets sent

### DIFF
--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -229,6 +229,20 @@ void eigrp_del_if_params(struct eigrp_if_params *eip)
 		free(eip->auth_keychain);
 }
 
+/*
+ * Set the network byte order of the 3 bytes we send
+ * of the mtu of the link.
+ */
+static void eigrp_mtu_convert(struct eigrp_metrics *metric, uint32_t host_mtu)
+{
+	uint32_t network_mtu = htonl(host_mtu);
+	uint8_t *nm = (uint8_t *)&network_mtu;
+
+	metric->mtu[0] = nm[1];
+	metric->mtu[1] = nm[2];
+	metric->mtu[2] = nm[3];
+}
+
 int eigrp_if_up(struct eigrp_interface *ei)
 {
 	struct eigrp_prefix_descriptor *pe;
@@ -256,9 +270,7 @@ int eigrp_if_up(struct eigrp_interface *ei)
 	metric.delay = eigrp_delay_to_scaled(ei->params.delay);
 	metric.load = ei->params.load;
 	metric.reliability = ei->params.reliability;
-	metric.mtu[0] = 0xDC;
-	metric.mtu[1] = 0x05;
-	metric.mtu[2] = 0x00;
+	eigrp_mtu_convert(&metric, ei->ifp->mtu);
 	metric.hop_count = 0;
 	metric.flags = 0;
 	metric.tag = 0;

--- a/eigrpd/eigrp_structs.h
+++ b/eigrpd/eigrp_structs.h
@@ -40,7 +40,7 @@
 struct eigrp_metrics {
 	uint32_t delay;
 	uint32_t bandwidth;
-	unsigned char mtu[3];
+	uint8_t mtu[3];
 	uint8_t hop_count;
 	uint8_t reliability;
 	uint8_t load;


### PR DESCRIPTION
This version of eigrp pre-calculated the eigrp metric
to be a default of 1500 bytes, but unfortunately it
had entered the byte order wrong.

Modify the code to properly set the byte order
according to the eigrp rfc as well as actually
read in and transmit the mtu of the interface
instead of hard coding it to 1500 bytes.

Fixes: #7986
Signed-off-by: Donald Sharp <sharpd@nvidia.com>