### PR TITLE
bgpd: Initialize bgp_notify.raw_data before passing to bgp_notify_rec…

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1863,6 +1863,7 @@ static int bgp_notify_receive(struct peer *peer, bgp_size_t size)
 	bgp_notify.subcode = stream_getc(peer->curr);
 	bgp_notify.length = size - 2;
 	bgp_notify.data = NULL;
+	bgp_notify.raw_data = NULL;
 
 	/* Preserv notify code and sub code. */
 	peer->notify.code = bgp_notify.code;


### PR DESCRIPTION
…eive()

```
2523558-==2523558==
2523558-==2523558== Conditional jump or move depends on uninitialised value(s)
2523558:==2523558==    at 0x47F242: bgp_notify_admin_message (bgp_debug.c:505)
2523558-==2523558==    by 0x47F242: bgp_notify_print (bgp_debug.c:534)
2523558-==2523558==    by 0x4BA9BC: bgp_notify_receive (bgp_packet.c:1905)
2523558-==2523558==    by 0x4BA9BC: bgp_process_packet (bgp_packet.c:2602)
2523558-==2523558==    by 0x4904B7E: thread_call (thread.c:1681)
2523558-==2523558==    by 0x48CAA27: frr_run (libfrr.c:1126)
2523558-==2523558==    by 0x474B1A: main (bgp_main.c:540)
2523558-==2523558==  Uninitialised value was created by a stack allocation
2523558:==2523558==    at 0x4BA33D: bgp_process_packet (bgp_packet.c:2529)
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>