### PR TITLE
bgpd: Centralize the dest unlocking for adj_out data structure

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -95,6 +95,10 @@ static void adj_free(struct bgp_adj_out *adj)
 {
 	TAILQ_REMOVE(&(adj->subgroup->adjq), adj, subgrp_adj_train);
 	SUBGRP_DECR_STAT(adj->subgroup, adj_count);
+
+	RB_REMOVE(bgp_adj_out_rb, &adj->dest->adj_out, adj);
+	bgp_dest_unlock_node(adj->dest);
+
 	XFREE(MTYPE_BGP_ADJ_OUT, adj);
 }
 
@@ -402,11 +406,9 @@ struct bgp_adj_out *bgp_adj_out_alloc(struct update_subgroup *subgrp,
 	adj->subgroup = subgrp;
 	adj->addpath_tx_id = addpath_tx_id;
 
-	if (dest) {
-		RB_INSERT(bgp_adj_out_rb, &dest->adj_out, adj);
-		bgp_dest_lock_node(dest);
-		adj->dest = dest;
-	}
+	RB_INSERT(bgp_adj_out_rb, &dest->adj_out, adj);
+	bgp_dest_lock_node(dest);
+	adj->dest = dest;
 
 	TAILQ_INSERT_TAIL(&(subgrp->adjq), adj, subgrp_adj_train);
 	SUBGRP_INCR_STAT(subgrp, adj_count);
@@ -601,13 +603,8 @@ void bgp_adj_out_unset_subgroup(struct bgp_dest *dest,
 			if (trigger_write)
 				subgroup_trigger_write(subgrp);
 		} else {
-			/* Remove myself from adjacency. */
-			RB_REMOVE(bgp_adj_out_rb, &dest->adj_out, adj);
-
 			/* Free allocated information.  */
 			adj_free(adj);
-
-			bgp_dest_unlock_node(dest);
 		}
 	}
 
@@ -623,7 +620,6 @@ void bgp_adj_out_remove_subgroup(struct bgp_dest *dest, struct bgp_adj_out *adj,
 	if (adj->adv)
 		bgp_advertise_clean_subgroup(subgrp, adj);
 
-	RB_REMOVE(bgp_adj_out_rb, &dest->adj_out, adj);
 	adj_free(adj);
 }
 
@@ -635,11 +631,8 @@ void subgroup_clear_table(struct update_subgroup *subgrp)
 {
 	struct bgp_adj_out *aout, *taout;
 
-	SUBGRP_FOREACH_ADJ_SAFE (subgrp, aout, taout) {
-		struct bgp_dest *dest = aout->dest;
-		bgp_adj_out_remove_subgroup(dest, aout, subgrp);
-		bgp_dest_unlock_node(dest);
-	}
+	SUBGRP_FOREACH_ADJ_SAFE (subgrp, aout, taout)
+		bgp_adj_out_remove_subgroup(aout->dest, aout, subgrp);
 }
 
 /*
@@ -927,14 +920,8 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 						bgp_advertise_clean_subgroup(
 							subgrp, adj);
 
-					/* Remove  from adjacency. */
-					RB_REMOVE(bgp_adj_out_rb,
-						  &dest->adj_out, adj);
-
 					/* Free allocated information.  */
 					adj_free(adj);
-
-					bgp_dest_unlock_node(dest);
 				}
 			}
 

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -1041,7 +1041,6 @@ struct bpacket *subgroup_withdraw_packet(struct update_subgroup *subgrp)
 		subgrp->scount--;
 
 		bgp_adj_out_remove_subgroup(dest, adj, subgrp);
-		bgp_dest_unlock_node(dest);
 	}
 
 	if (!stream_empty(s)) {


### PR DESCRIPTION
When FRR creates a adj_out data structure we lock the `struct
bgp_dest` node associated with it.  On freeing of this data
structure and removing the lock it was not associated with
the actual free of the adjacency structure.  Let's clean up
the lock/unlock to be centralized to the alloc/free of the adj_out.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>