### PR TITLE
zebra: reorg nexthop resolution code

### DIFF
--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -180,8 +180,9 @@ struct nhg_ctx {
 
 	vrf_id_t vrf_id;
 	afi_t afi;
+
 	/*
-	 * This should only every be ZEBRA_ROUTE_NHG unless we get a a kernel
+	 * This should only ever be ZEBRA_ROUTE_NHG unless we get a a kernel
 	 * created nexthop not made by us.
 	 */
 	int type;


### PR DESCRIPTION
Start reorg of zebra nexthop-resolution so that we can use the resolution logic for nexthop-groups as well as routes. Change
the signature of the core nexthop_active() api so that it does not require a route-entry or route-node. Move some of the logic around so that nexthop-specific logic is in nexthop_active(), while route-oriented logic is in nexthop_active_check().

I did make a change to the way a route's "nexthop mtu" value is captured - it seemed kind of arbitrary, and I've made it more deterministic.
