### PR TITLE
lib/printf: disable `%n` specifier

### DIFF
--- a/lib/printf/printf-pos.c
+++ b/lib/printf/printf-pos.c
@@ -384,6 +384,7 @@ reswitch:	switch (ch) {
 				goto error;
 			break;
 #endif /* !NO_FLOATING_POINT */
+#ifdef DANGEROUS_PERCENT_N
 		case 'n':
 			if (flags & INTMAXT)
 				error = addtype(&types, TP_INTMAXT);
@@ -404,6 +405,7 @@ reswitch:	switch (ch) {
 			if (error)
 				goto error;
 			continue;	/* no output */
+#endif
 		case 'O':
 			flags |= LONGINT;
 			/*FALLTHROUGH*/
@@ -576,6 +578,7 @@ reswitch:	switch (ch) {
 				goto error;
 			break;
 #endif /* !NO_FLOATING_POINT */
+#ifdef DANGEROUS_PERCENT_N
 		case 'n':
 			if (flags & INTMAXT)
 				error = addtype(&types, TP_INTMAXT);
@@ -596,6 +599,7 @@ reswitch:	switch (ch) {
 			if (error)
 				goto error;
 			continue;	/* no output */
+#endif
 		case 'O':
 			flags |= LONGINT;
 			/*FALLTHROUGH*/

--- a/lib/printf/vfprintf.c
+++ b/lib/printf/vfprintf.c
@@ -503,6 +503,11 @@ reswitch:	switch (ch) {
 			size = (prec >= 0) ? strnlen(cp, prec) : strlen(cp);
 			sign = '\0';
 			break;
+#ifdef DANGEROUS_PERCENT_N
+		/* FRR does not use %n in printf formats.  This is just left
+		 * here in case someone tries to use %n and starts debugging
+		 * why the f* it doesn't work
+		 */
 		case 'n':
 			/*
 			 * Assignment-like behavior is specified if the
@@ -526,6 +531,7 @@ reswitch:	switch (ch) {
 			else
 				*GETARG(int *) = ret;
 			continue;	/* no output */
+#endif
 		case 'O':
 			flags |= LONGINT;
 			/*FALLTHROUGH*/


### PR DESCRIPTION
We don't use `%n` anywhere, so the only purpose it serves is enabling
exploits.

(I thought about this initially when adding printfrr, but I wasn't sure
we don't use `%n` anywhere, and thought I'll check later, and then just
forgot it...)

---

I was just randomly reminded about this and before I forget it **again** (narf!) here's a PR.  This should really be a no-brainer, `%n` is pure unadulterated footgun C.