### PR TITLE
bgpd, lib: Ensure opaque data is not too long

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1418,7 +1418,7 @@ int zapi_route_decode(struct stream *s, struct zapi_route *api)
 
 	if (CHECK_FLAG(api->message, ZAPI_MESSAGE_OPAQUE)) {
 		STREAM_GETW(s, api->opaque.length);
-		assert(api->opaque.length < ZAPI_MESSAGE_OPAQUE_LENGTH);
+		assert(api->opaque.length <= ZAPI_MESSAGE_OPAQUE_LENGTH);
 
 		STREAM_GET(api->opaque.data, s, api->opaque.length);
 	}

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -295,8 +295,9 @@ static bool route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
 	if (strlen(opaque)) {
 		SET_FLAG(api.message, ZAPI_MESSAGE_OPAQUE);
 		api.opaque.length = strlen(opaque) + 1;
-		assert(api.opaque.length <= ZAPI_MESSAGE_OPAQUE_LENGTH);
-		memcpy(api.opaque.data, opaque, api.opaque.length);
+		api.opaque.length =
+			MIN(ZAPI_MESSAGE_OPAQUE_LENGTH, strlen(opaque) + 1);
+		strlcpy((char *)api.opaque.data, opaque, api.opaque.length);
 	}
 
 	if (zclient_route_send(ZEBRA_ROUTE_ADD, zclient, &api)

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -421,25 +421,25 @@ static void show_nexthop_detail_helper(struct vty *vty,
 static void zebra_show_ip_route_opaque(struct vty *vty, struct route_entry *re,
 				       struct json_object *json)
 {
+	char obuf[ZAPI_MESSAGE_OPAQUE_LENGTH];
+
 	if (!re->opaque)
 		return;
 
 	switch (re->type) {
 	case ZEBRA_ROUTE_SHARP:
+		strlcpy(obuf, (char *)re->opaque->data, sizeof(obuf));
 		if (json)
-			json_object_string_add(json, "opaque",
-					       (char *)re->opaque->data);
+			json_object_string_add(json, "opaque", obuf);
 		else
-			vty_out(vty, "    Opaque Data: %s",
-				(char *)re->opaque->data);
+			vty_out(vty, "    Opaque Data: %s", obuf);
 		break;
 	case ZEBRA_ROUTE_BGP:
+		strlcpy(obuf, (char *)re->opaque->data, sizeof(obuf));
 		if (json)
-			json_object_string_add(json, "asPath",
-					       (char *)re->opaque->data);
+			json_object_string_add(json, "asPath", obuf);
 		else
-			vty_out(vty, "    AS-Path: %s",
-				(char *)re->opaque->data);
+			vty_out(vty, "    AS-Path: %s", obuf);
 	default:
 		break;
 	}


### PR DESCRIPTION
If the AS Path is long enough we will end up with a string of
data beyond what we can pass down.  Just hard limit the string
in bgp to the ZAPI_MESSAGE_OPAQUE_LENGTH.

Also ensure that the read of the zapi message can read the
entire length.

Fixes: #7995
Signed-off-by: Donald Sharp <sharpd@nvidia.com>