### PR TITLE
isisd: When adjacencies go up and down add support to modify attached-bit

### DIFF
--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1047,15 +1047,17 @@ lspfragloop:
 
 end:
 
-	/* if attach bit set and we are a level-1 router
-	 * and attach-bit-rcv-ignore is not configured
-	 * add a default route toward this neighbor
+	/* if attach bit set in LSP, attached-bit receive ignore is
+	 * not configured, we are a level-1 area and we have no other
+	 * level-2 | level1-2 areas then add a default route toward
+	 * this neighbor
 	 */
 	if ((lsp->hdr.lsp_bits & LSPBIT_ATT) == LSPBIT_ATT
 	    && !spftree->area->attached_bit_rcv_ignore
-	    && spftree->area->is_type == IS_LEVEL_1) {
+	    && spftree->area->is_type == IS_LEVEL_1
+	    && !isis_area_count(spftree->area->isis, IS_LEVEL_2)) {
 		struct prefix_pair ip_info = { {0} };
-		if (IS_DEBUG_SPF_EVENTS)
+		if (IS_DEBUG_RTE_EVENTS)
 			zlog_debug("ISIS-Spf (%s): add default %s route",
 				   rawlspid_print(lsp->hdr.lsp_id),
 				   spftree->family == AF_INET ? "ipv4"

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -424,6 +424,22 @@ int isis_area_get(struct vty *vty, const char *area_tag)
 	return CMD_SUCCESS;
 }
 
+/* return the number of Level1 and level-1-2 routers or
+ * the number of Level2 and level-1-2 routers configured
+ */
+int isis_area_count(const struct isis *isis, int levels)
+{
+	struct isis_area *area;
+	struct listnode *node;
+	int count = 0;
+
+	for (ALL_LIST_ELEMENTS_RO(isis->area_list, node, area))
+		if (area->is_type & levels)
+			count++;
+
+	return count;
+}
+
 void isis_area_destroy(struct isis_area *area)
 {
 	struct listnode *node, *nnode;

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -243,6 +243,7 @@ struct isis_area *isis_area_lookup(const char *, vrf_id_t vrf_id);
 struct isis_area *isis_area_lookup_by_vrf(const char *area_tag,
 					  const char *vrf_name);
 int isis_area_get(struct vty *vty, const char *area_tag);
+int isis_area_count(const struct isis *isis, int levels);
 void isis_area_destroy(struct isis_area *area);
 void isis_filter_update(struct access_list *access);
 void isis_prefix_list_update(struct prefix_list *plist);

--- a/tests/topotests/pytest.ini
+++ b/tests/topotests/pytest.ini
@@ -1,6 +1,6 @@
 # Skip pytests example directory
 [pytest]
-norecursedirs = .git example-test example-topojson-test lib docker isis-lsp-bits-topo1
+norecursedirs = .git example-test example-topojson-test lib docker
 
 # Markers
 #


### PR DESCRIPTION
    isisd: When adjacencies go up and down add support to modify attached-bit
    
    When adjacencies change state the attached-bits in LSPs in other areas
    on the router may need to be modified.
    
     1. If a router no longer has a L2 adjacency to another area the
        attached-bit must no longer be sent in the LSP
     2. If a new L2 adjacency comes up in a different area then the
        attached-bit should be sent in the LSP
 