### PR TITLE
bgpd: Replace 65535 with UINT16_MAX

### DIFF
--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -32,7 +32,7 @@
 
 /* Private AS range defined in RFC2270.  */
 #define BGP_PRIVATE_AS_MIN       64512U
-#define BGP_PRIVATE_AS_MAX       65535U
+#define BGP_PRIVATE_AS_MAX UINT16_MAX
 
 /* Private 4 byte AS range defined in RFC6996.  */
 #define BGP_PRIVATE_AS4_MIN     4200000000U
@@ -40,7 +40,7 @@
 
 /* we leave BGP_AS_MAX as the 16bit AS MAX number.  */
 #define BGP_AS_ZERO		          0
-#define BGP_AS_MAX		     65535U
+#define BGP_AS_MAX UINT16_MAX
 #define BGP_AS4_MAX		4294967295U
 /* Transition 16Bit AS as defined by IANA */
 #define BGP_AS_TRANS		 23456U

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3901,7 +3901,7 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 
 			/* Is ASN representable in 2-bytes? Or must AS_TRANS be
 			 * used? */
-			if (attr->aggregator_as > 65535) {
+			if (attr->aggregator_as > UINT16_MAX) {
 				stream_putw(s, BGP_AS_TRANS);
 
 				/* we have to send AS4_AGGREGATOR, too.

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -5216,10 +5216,10 @@ int peer_timers_set(struct peer *peer, uint32_t keepalive, uint32_t holdtime)
 	struct peer *member;
 	struct listnode *node, *nnode;
 
-	if (keepalive > 65535)
+	if (keepalive > UINT16_MAX)
 		return BGP_ERR_INVALID_VALUE;
 
-	if (holdtime > 65535)
+	if (holdtime > UINT16_MAX)
 		return BGP_ERR_INVALID_VALUE;
 
 	if (holdtime < 3 && holdtime != 0)
@@ -5296,7 +5296,7 @@ int peer_timers_connect_set(struct peer *peer, uint32_t connect)
 	struct peer *member;
 	struct listnode *node, *nnode;
 
-	if (connect > 65535)
+	if (connect > UINT16_MAX)
 		return BGP_ERR_INVALID_VALUE;
 
 	/* Set flag and configuration on peer. */


### PR DESCRIPTION
Just consistent.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>