### PR TITLE
lib/xref: fix C++ issues

### DIFF
--- a/doc/developer/xrefs.rst
+++ b/doc/developer/xrefs.rst
@@ -161,3 +161,10 @@ the xref array is in the file.  Also note the owner is clearly marked as
 For SystemTap's use of ELF notes, refer to
 https://libstapsdt.readthedocs.io/en/latest/how-it-works/internals.html as an
 entry point.
+
+.. note::
+
+   Due to GCC bug 41091, the "xref_array" section is not correctly generated
+   for C++ code when compiled by GCC.  A workaround is present for runtime
+   functionality, but to extract the xrefs from a C++ source file, it needs
+   to be built with clang (or a future fixed version of GCC) instead.

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -633,9 +633,6 @@ unsigned long thread_timer_remain_second(struct thread *thread)
 	return thread_timer_remain_msec(thread) / 1000LL;
 }
 
-#define debugargdef  const char *funcname, const char *schedfrom, int fromln
-#define debugargpass funcname, schedfrom, fromln
-
 struct timeval thread_timer_remain(struct thread *thread)
 {
 	struct timeval remain;
@@ -841,11 +838,13 @@ struct thread *_thread_add_read_write(const struct xref_threadsched *xref,
 	struct thread **thread_array;
 
 	if (dir == THREAD_READ)
-		frrtrace(9, frr_libfrr, schedule_read, m, funcname, schedfrom,
-			 fromln, t_ptr, fd, 0, arg, 0);
+		frrtrace(9, frr_libfrr, schedule_read, m,
+			 xref->funcname, xref->xref.file, xref->xref.line,
+			 t_ptr, fd, 0, arg, 0);
 	else
-		frrtrace(9, frr_libfrr, schedule_write, m, funcname, schedfrom,
-			 fromln, t_ptr, fd, 0, arg, 0);
+		frrtrace(9, frr_libfrr, schedule_write, m,
+			 xref->funcname, xref->xref.file, xref->xref.line,
+			 t_ptr, fd, 0, arg, 0);
 
 	assert(fd >= 0 && fd < m->fd_limit);
 	frr_with_mutex(&m->mtx) {
@@ -921,7 +920,8 @@ _thread_add_timer_timeval(const struct xref_threadsched *xref,
 	assert(type == THREAD_TIMER);
 	assert(time_relative);
 
-	frrtrace(9, frr_libfrr, schedule_timer, m, funcname, schedfrom, fromln,
+	frrtrace(9, frr_libfrr, schedule_timer, m,
+		 xref->funcname, xref->xref.file, xref->xref.line,
 		 t_ptr, 0, 0, arg, (long)time_relative->tv_sec);
 
 	frr_with_mutex(&m->mtx) {
@@ -1003,7 +1003,8 @@ struct thread *_thread_add_event(const struct xref_threadsched *xref,
 {
 	struct thread *thread = NULL;
 
-	frrtrace(9, frr_libfrr, schedule_event, m, funcname, schedfrom, fromln,
+	frrtrace(9, frr_libfrr, schedule_event, m,
+		 xref->funcname, xref->xref.file, xref->xref.line,
 		 t_ptr, 0, val, arg, 0);
 
 	assert(m != NULL);
@@ -1239,8 +1240,9 @@ void thread_cancel(struct thread **thread)
 
 	master = (*thread)->master;
 
-	frrtrace(9, frr_libfrr, thread_cancel, master, (*thread)->funcname,
-		 (*thread)->schedfrom, (*thread)->schedfrom_line, NULL, (*thread)->u.fd,
+	frrtrace(9, frr_libfrr, thread_cancel, master,
+		 (*thread)->xref->funcname, (*thread)->xref->xref.file,
+		 (*thread)->xref->xref.line, NULL, (*thread)->u.fd,
 		 (*thread)->u.val, (*thread)->arg, (*thread)->u.sands.tv_sec);
 
 	assert(master->owner == pthread_self());
@@ -1287,8 +1289,8 @@ void thread_cancel_async(struct thread_master *master, struct thread **thread,
 
 	if (thread && *thread)
 		frrtrace(9, frr_libfrr, thread_cancel_async, master,
-			 (*thread)->funcname, (*thread)->schedfrom,
-			 (*thread)->schedfrom_line, NULL, (*thread)->u.fd,
+			 (*thread)->xref->funcname, (*thread)->xref->xref.file,
+			 (*thread)->xref->xref.line, NULL, (*thread)->u.fd,
 			 (*thread)->u.val, (*thread)->arg,
 			 (*thread)->u.sands.tv_sec);
 	else
@@ -1673,8 +1675,9 @@ void thread_call(struct thread *thread)
 	GETRUSAGE(&before);
 	thread->real = before.real;
 
-	frrtrace(9, frr_libfrr, thread_call, thread->master, thread->funcname,
-		 thread->schedfrom, thread->schedfrom_line, NULL, thread->u.fd,
+	frrtrace(9, frr_libfrr, thread_call, thread->master,
+		 thread->xref->funcname, thread->xref->xref.file,
+		 thread->xref->xref.line, NULL, thread->u.fd,
 		 thread->u.val, thread->arg, thread->u.sands.tv_sec);
 
 	pthread_setspecific(thread_current, thread);

--- a/lib/xref.c
+++ b/lib/xref.c
@@ -63,60 +63,68 @@ static void base32(uint8_t **inpos, int *bitpos,
 	*bitpos = bp;
 }
 
+static void xref_add_one(const struct xref *xref)
+{
+	SHA256_CTX sha;
+	struct xrefdata *xrefdata;
+
+	const char *filename, *p, *q;
+	uint8_t hash[32], *h = hash;
+	uint32_t be_val;
+	int bitpos;
+
+	if (!xref || !xref->xrefdata)
+		return;
+
+	xrefdata = xref->xrefdata;
+	xrefdata->xref = xref;
+
+	if (!xrefdata->hashstr)
+		return;
+
+	/* as far as the unique ID is concerned, only use the last
+	 * directory name + filename, e.g. "bgpd/bgp_route.c".  This
+	 * gives a little leeway in moving things and avoids IDs being
+	 * screwed up by out of tree builds or absolute pathnames.
+	 */
+	filename = xref->file;
+	p = strrchr(filename, '/');
+	if (p) {
+		q = memrchr(filename, '/', p - filename);
+		if (q)
+			filename = q + 1;
+		else
+			filename = p + 1;
+	}
+
+	SHA256_Init(&sha);
+	SHA256_Update(&sha, filename, strlen(filename));
+	SHA256_Update(&sha, xrefdata->hashstr,
+		      strlen(xrefdata->hashstr));
+	be_val = htonl(xrefdata->hashu32[0]);
+	SHA256_Update(&sha, &be_val, sizeof(be_val));
+	be_val = htonl(xrefdata->hashu32[1]);
+	SHA256_Update(&sha, &be_val, sizeof(be_val));
+	SHA256_Final(hash, &sha);
+
+	bitpos = -1;
+	base32(&h, &bitpos, &xrefdata->uid[0], 5);
+	xrefdata->uid[5] = '-';
+	base32(&h, &bitpos, &xrefdata->uid[6], 5);
+}
+
+void xref_gcc_workaround(const struct xref *xref)
+{
+	xref_add_one(xref);
+}
+
 void xref_block_add(struct xref_block *block)
 {
 	const struct xref * const *xrefp;
-	SHA256_CTX sha;
 
 	*xref_block_last = block;
 	xref_block_last = &block->next;
 
-	for (xrefp = block->start; xrefp < block->stop; xrefp++) {
-		const struct xref *xref = *xrefp;
-		struct xrefdata *xrefdata;
-
-		const char *filename, *p, *q;
-		uint8_t hash[32], *h = hash;
-		uint32_t be_val;
-		int bitpos;
-
-		if (!xref || !xref->xrefdata)
-			continue;
-
-		xrefdata = xref->xrefdata;
-		xrefdata->xref = xref;
-
-		if (!xrefdata->hashstr)
-			continue;
-
-		/* as far as the unique ID is concerned, only use the last
-		 * directory name + filename, e.g. "bgpd/bgp_route.c".  This
-		 * gives a little leeway in moving things and avoids IDs being
-		 * screwed up by out of tree builds or absolute pathnames.
-		 */
-		filename = xref->file;
-		p = strrchr(filename, '/');
-		if (p) {
-			q = memrchr(filename, '/', p - filename);
-			if (q)
-				filename = q + 1;
-			else
-				filename = p + 1;
-		}
-
-		SHA256_Init(&sha);
-		SHA256_Update(&sha, filename, strlen(filename));
-		SHA256_Update(&sha, xrefdata->hashstr,
-			      strlen(xrefdata->hashstr));
-		be_val = htonl(xrefdata->hashu32[0]);
-		SHA256_Update(&sha, &be_val, sizeof(be_val));
-		be_val = htonl(xrefdata->hashu32[1]);
-		SHA256_Update(&sha, &be_val, sizeof(be_val));
-		SHA256_Final(hash, &sha);
-
-		bitpos = -1;
-		base32(&h, &bitpos, &xrefdata->uid[0], 5);
-		xrefdata->uid[5] = '-';
-		base32(&h, &bitpos, &xrefdata->uid[6], 5);
-	}
+	for (xrefp = block->start; xrefp < block->stop; xrefp++)
+		xref_add_one(*xrefp);
 }

--- a/lib/xref.h
+++ b/lib/xref.h
@@ -23,6 +23,10 @@
 #include <errno.h>
 #include "compiler.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum xref_type {
 	XREFT_NONE = 0,
 

--- a/lib/xref.h
+++ b/lib/xref.h
@@ -144,8 +144,11 @@ extern const struct xref * const __stop_xref_array[1] DSO_LOCAL;
  */
 #define XREF_SETUP()                                                           \
 	static const struct xref _dummy_xref = {                               \
-			.file = __FILE__, .line = __LINE__, .func = "dummy",   \
-			.type = XREFT_NONE,                                    \
+			/* .xrefdata = */ NULL,                                \
+			/* .type = */ XREFT_NONE,                              \
+			/* .line = */ __LINE__,                                \
+			/* .file = */ __FILE__,                                \
+			/* .func = */ "dummy",                                 \
 	};                                                                     \
 	static const struct xref * const _dummy_xref_p                         \
 			__attribute__((used, section("xref_array")))           \
@@ -251,8 +254,11 @@ struct _xref_p {
 /* initializer for a "struct xref" */
 #define XREF_INIT(type_, xrefdata_, func_)                                     \
 	{                                                                      \
-		.type = (type_), .xrefdata = (xrefdata_),                      \
-		.file = __FILE__, .line = __LINE__, .func = func_,             \
+		/* .xrefdata = */ (xrefdata_),                                 \
+		/* .type = */ (type_),                                         \
+		/* .line = */ __LINE__,                                        \
+		/* .file = */ __FILE__,                                        \
+		/* .func = */ func_,                                           \
 	}                                                                      \
 	/* end */
 

--- a/lib/xref.h
+++ b/lib/xref.h
@@ -119,6 +119,7 @@ struct xref_block {
 
 extern struct xref_block *xref_blocks;
 extern void xref_block_add(struct xref_block *block);
+extern void xref_gcc_workaround(const struct xref *xref);
 
 #ifndef HAVE_SECTION_SYMS
 /* we have a build system patch to use GNU ld on Solaris;  if that doesn't
@@ -218,11 +219,34 @@ extern const struct xref * const __stop_xref_array[1] DSO_LOCAL;
 #endif /* HAVE_SECTION_SYMS */
 
 /* emit the array entry / pointer to xref */
+#if defined(__clang__) || !defined(__cplusplus)
 #define XREF_LINK(dst)                                                         \
 	static const struct xref * const NAMECTR(xref_p_)                      \
 			__attribute__((used, section("xref_array")))           \
 		= &(dst)                                                       \
 	/* end */
+
+#else /* GCC && C++ */
+/* workaround for GCC bug 41091 (dated 2009), added in 2021...
+ *
+ * this breaks extraction of xrefs with xrelfo.py (because the xref_array
+ * entry will be missing), but provides full runtime functionality.  To get
+ * the proper list of xrefs from C++ code, build with clang...
+ */
+struct _xref_p {
+	const struct xref * const ptr;
+
+	_xref_p(const struct xref *_ptr) : ptr(_ptr)
+	{
+		xref_gcc_workaround(_ptr);
+	}
+};
+
+#define XREF_LINK(dst)                                                         \
+	static const struct _xref_p __attribute__((used))                      \
+			NAMECTR(xref_p_)(&(dst))                               \
+	/* end */
+#endif
 
 /* initializer for a "struct xref" */
 #define XREF_INIT(type_, xrefdata_, func_)                                     \


### PR DESCRIPTION
Well, I hadn't tried this stuff in C++…

Turns out it's running headfirst into a GCC bug, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=41091 - caused by the unceasingly complicated mechanics of C++ template instantiation.

2 other small fixes piled on (initializer order & frrtrace derp'ing)