### PR TITLE
[7.5] Snap libyang1 fix

### DIFF
--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -259,7 +259,7 @@ parts:
            - usr/lib/x86_64-linux-gnu/libssh.so*
         source: https://github.com/rtrlib/rtrlib.git
         source-type: git
-        source-tag: v0.6.3
+        source-tag: v0.7.0
         plugin: cmake
         configflags:
            - -DCMAKE_BUILD_TYPE=Release

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -392,6 +392,6 @@ parts:
 
 passthrough:
     layout:
-         /usr/lib/x86_64-linux-gnu/libyang:
-             bind: $SNAP/usr/lib/x86_64-linux-gnu/libyang
+         /usr/lib/x86_64-linux-gnu/libyang1:
+             bind: $SNAP/usr/lib/x86_64-linux-gnu/libyang1
 


### PR DESCRIPTION
Previous Libyang1 fix and RTRlib upgrade already merged in master branch for the stable/7.5 branch