### PR TITLE
[lib, yang] : multiple fixes in prefix-list northbound conversion 

### DIFF
--- a/lib/filter_nb.c
+++ b/lib/filter_nb.c
@@ -1167,12 +1167,19 @@ static int
 lib_prefix_list_entry_ipv4_prefix_modify(struct nb_cb_modify_args *args)
 {
 
+	int af_type;
+
 	if (args->event == NB_EV_VALIDATE) {
+		const struct lyd_node *plist_dnode =
+			yang_dnode_get_parent(args->dnode, "prefix-list");
+		af_type = yang_dnode_get_enum(plist_dnode, "./type");
+		if (af_type != YPLT_IPV4) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "prefix-list type %u is mismatched.", af_type);
+			return NB_ERR_VALIDATION;
+		}
 		return NB_OK;
 	}
-
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
 
 	return lib_prefix_list_entry_prefix_modify(args);
 }
@@ -1180,10 +1187,6 @@ lib_prefix_list_entry_ipv4_prefix_modify(struct nb_cb_modify_args *args)
 static int
 lib_prefix_list_entry_ipv4_prefix_destroy(struct nb_cb_destroy_args *args)
 {
-
-	if (args->event == NB_EV_VALIDATE) {
-		return NB_OK;
-	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -1198,12 +1201,19 @@ static int
 lib_prefix_list_entry_ipv6_prefix_modify(struct nb_cb_modify_args *args)
 {
 
+	int af_type;
+
 	if (args->event == NB_EV_VALIDATE) {
+		const struct lyd_node *plist_dnode =
+			yang_dnode_get_parent(args->dnode, "prefix-list");
+		af_type = yang_dnode_get_enum(plist_dnode, "./type");
+		if (af_type != YPLT_IPV6) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "prefix-list type %u is mismatched.", af_type);
+			return NB_ERR_VALIDATION;
+		}
 		return NB_OK;
 	}
-
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
 
 	return lib_prefix_list_entry_prefix_modify(args);
 }
@@ -1211,9 +1221,6 @@ lib_prefix_list_entry_ipv6_prefix_modify(struct nb_cb_modify_args *args)
 static int
 lib_prefix_list_entry_ipv6_prefix_destroy(struct nb_cb_destroy_args *args)
 {
-
-	if (args->event == NB_EV_VALIDATE) {
-	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -1253,15 +1260,15 @@ static int lib_prefix_list_entry_ipv4_prefix_length_greater_or_equal_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	struct prefix_list_entry *ple;
-	const char *af_type;
+	int af_type;
 
 	if (args->event == NB_EV_VALIDATE) {
-		const struct lyd_node *entry_dnode =
+		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
-		af_type = yang_dnode_get_string(entry_dnode, "./type");
-		if (strcmp(af_type, "ipv4")) {
+		af_type = yang_dnode_get_enum(plist_dnode, "./type");
+		if (af_type != YPLT_IPV4) {
 			snprintf(args->errmsg, args->errmsg_len,
-				 "prefix-list type %s is mismatched.", af_type);
+				 "prefix-list type %u is mismatched.", af_type);
 			return NB_ERR_VALIDATION;
 		}
 		return NB_OK;
@@ -1315,15 +1322,15 @@ static int lib_prefix_list_entry_ipv4_prefix_length_lesser_or_equal_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	struct prefix_list_entry *ple;
-	const char *af_type;
+	int af_type;
 
 	if (args->event == NB_EV_VALIDATE) {
-		const struct lyd_node *entry_dnode =
+		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
-		af_type = yang_dnode_get_string(entry_dnode, "./type");
-		if (strcmp(af_type, "ipv4")) {
+		af_type = yang_dnode_get_enum(plist_dnode, "./type");
+		if (af_type != YPLT_IPV4) {
 			snprintf(args->errmsg, args->errmsg_len,
-				 "prefix-list type %s is mismatched.", af_type);
+				 "prefix-list type %u is mismatched.", af_type);
 			return NB_ERR_VALIDATION;
 		}
 		return NB_OK;
@@ -1352,19 +1359,19 @@ static int lib_prefix_list_entry_ipv6_prefix_length_greater_or_equal_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct prefix_list_entry *ple;
-	const char *af_type;
+	int af_type;
 
 	if (args->event == NB_EV_VALIDATE
 	    && prefix_list_length_validate(args) != NB_OK)
 		return NB_ERR_VALIDATION;
 
 	if (args->event == NB_EV_VALIDATE) {
-		const struct lyd_node *entry_dnode =
+		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
-		af_type = yang_dnode_get_string(entry_dnode, "./type");
-		if (strcmp(af_type, "ipv6")) {
+		af_type = yang_dnode_get_enum(plist_dnode, "./type");
+		if (af_type != YPLT_IPV6) {
 			snprintf(args->errmsg, args->errmsg_len,
-				 "prefix-list type %s is mismatched.", af_type);
+				 "prefix-list type %u is mismatched.", af_type);
 			return NB_ERR_VALIDATION;
 		}
 
@@ -1391,15 +1398,15 @@ static int lib_prefix_list_entry_ipv6_prefix_length_greater_or_equal_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	struct prefix_list_entry *ple;
-	const char *af_type;
+	int af_type;
 
 	if (args->event == NB_EV_VALIDATE) {
-		const struct lyd_node *entry_dnode =
+		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
-		af_type = yang_dnode_get_string(entry_dnode, "./type");
-		if (strcmp(af_type, "ipv6")) {
+		af_type = yang_dnode_get_enum(plist_dnode, "./type");
+		if (af_type != YPLT_IPV6) {
 			snprintf(args->errmsg, args->errmsg_len,
-				 "prefix-list type %s is mismatched.", af_type);
+				 "prefix-list type %u is mismatched.", af_type);
 			return NB_ERR_VALIDATION;
 		}
 		return NB_OK;
@@ -1428,19 +1435,19 @@ static int lib_prefix_list_entry_ipv6_prefix_length_lesser_or_equal_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct prefix_list_entry *ple;
-	const char *af_type;
+	int af_type;
 
 	if (args->event == NB_EV_VALIDATE
 	    && prefix_list_length_validate(args) != NB_OK)
 		return NB_ERR_VALIDATION;
 
 	if (args->event == NB_EV_VALIDATE) {
-		const struct lyd_node *entry_dnode =
+		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
-		af_type = yang_dnode_get_string(entry_dnode, "./type");
-		if (strcmp(af_type, "ipv6")) {
+		af_type = yang_dnode_get_enum(plist_dnode, "./type");
+		if (af_type != YPLT_IPV6) {
 			snprintf(args->errmsg, args->errmsg_len,
-				 "prefix-list type %s is mismatched.", af_type);
+				 "prefix-list type %u is mismatched.", af_type);
 			return NB_ERR_VALIDATION;
 		}
 
@@ -1467,15 +1474,15 @@ static int lib_prefix_list_entry_ipv6_prefix_length_lesser_or_equal_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	struct prefix_list_entry *ple;
-	const char *af_type;
+	int af_type;
 
 	if (args->event == NB_EV_VALIDATE) {
-		const struct lyd_node *entry_dnode =
+		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
-		af_type = yang_dnode_get_string(entry_dnode, "./type");
-		if (strcmp(af_type, "ipv6")) {
+		af_type = yang_dnode_get_enum(plist_dnode, "./type");
+		if (af_type != YPLT_IPV6) {
 			snprintf(args->errmsg, args->errmsg_len,
-				 "prefix-list type %s is mismatched.", af_type);
+				 "prefix-list type %u is mismatched.", af_type);
 			return NB_ERR_VALIDATION;
 		}
 		return NB_OK;

--- a/lib/filter_nb.c
+++ b/lib/filter_nb.c
@@ -1344,7 +1344,7 @@ static int lib_prefix_list_entry_ipv4_prefix_length_lesser_or_equal_destroy(
 	/* Start prefix entry update procedure. */
 	prefix_list_entry_update_start(ple);
 
-	ple->ge = 0;
+	ple->le = 0;
 
 	/* Finish prefix entry update procedure. */
 	prefix_list_entry_update_finish(ple);
@@ -1420,7 +1420,7 @@ static int lib_prefix_list_entry_ipv6_prefix_length_greater_or_equal_destroy(
 	/* Start prefix entry update procedure. */
 	prefix_list_entry_update_start(ple);
 
-	ple->le = 0;
+	ple->ge = 0;
 
 	/* Finish prefix entry update procedure. */
 	prefix_list_entry_update_finish(ple);

--- a/lib/filter_nb.c
+++ b/lib/filter_nb.c
@@ -1148,24 +1148,10 @@ static int lib_prefix_list_entry_action_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-/*
- * XPath: /frr-filter:lib/prefix-list/entry/ipv4-prefix
- */
-static int
-lib_prefix_list_entry_ipv4_prefix_modify(struct nb_cb_modify_args *args)
+static int lib_prefix_list_entry_prefix_modify(struct nb_cb_modify_args *args)
 {
 	struct prefix_list_entry *ple;
 	struct prefix p;
-
-	if (args->event == NB_EV_VALIDATE) {
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
-		return NB_OK;
-	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -1193,8 +1179,7 @@ lib_prefix_list_entry_ipv4_prefix_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-static int
-lib_prefix_list_entry_ipv4_prefix_destroy(struct nb_cb_destroy_args *args)
+static int lib_prefix_list_entry_prefix_destroy(struct nb_cb_destroy_args *args)
 {
 	struct prefix_list_entry *ple;
 
@@ -1212,6 +1197,67 @@ lib_prefix_list_entry_ipv4_prefix_destroy(struct nb_cb_destroy_args *args)
 	prefix_list_entry_update_finish(ple);
 
 	return NB_OK;
+}
+
+/*
+ * XPath: /frr-filter:lib/prefix-list/entry/ipv4-prefix
+ */
+static int
+lib_prefix_list_entry_ipv4_prefix_modify(struct nb_cb_modify_args *args)
+{
+
+	if (args->event == NB_EV_VALIDATE) {
+		return NB_OK;
+	}
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	return lib_prefix_list_entry_prefix_modify(args);
+}
+
+static int
+lib_prefix_list_entry_ipv4_prefix_destroy(struct nb_cb_destroy_args *args)
+{
+
+	if (args->event == NB_EV_VALIDATE) {
+		return NB_OK;
+	}
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	return lib_prefix_list_entry_prefix_destroy(args);
+}
+
+/*
+ * XPath: /frr-filter:lib/prefix-list/entry/ipv6-prefix
+ */
+static int
+lib_prefix_list_entry_ipv6_prefix_modify(struct nb_cb_modify_args *args)
+{
+
+	if (args->event == NB_EV_VALIDATE) {
+		return NB_OK;
+	}
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	return lib_prefix_list_entry_prefix_modify(args);
+}
+
+static int
+lib_prefix_list_entry_ipv6_prefix_destroy(struct nb_cb_destroy_args *args)
+{
+
+	if (args->event == NB_EV_VALIDATE) {
+	}
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	return lib_prefix_list_entry_prefix_destroy(args);
 }
 
 /*
@@ -1256,6 +1302,19 @@ static int lib_prefix_list_entry_ipv4_prefix_length_greater_or_equal_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	struct prefix_list_entry *ple;
+	const char *af_type;
+
+	if (args->event == NB_EV_VALIDATE) {
+		const struct lyd_node *entry_dnode =
+			yang_dnode_get_parent(args->dnode, "prefix-list");
+		af_type = yang_dnode_get_string(entry_dnode, "./type");
+		if (strcmp(af_type, "ipv4")) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "prefix-list type %s is mismatched.", af_type);
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -1315,7 +1374,182 @@ static int lib_prefix_list_entry_ipv4_prefix_length_lesser_or_equal_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	struct prefix_list_entry *ple;
+	const char *af_type;
 
+	if (args->event == NB_EV_VALIDATE) {
+		const struct lyd_node *entry_dnode =
+			yang_dnode_get_parent(args->dnode, "prefix-list");
+		af_type = yang_dnode_get_string(entry_dnode, "./type");
+		if (strcmp(af_type, "ipv4")) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "prefix-list type %s is mismatched.", af_type);
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	ple = nb_running_get_entry(args->dnode, NULL, true);
+
+	/* Start prefix entry update procedure. */
+	prefix_list_entry_update_start(ple);
+
+	ple->ge = 0;
+
+	/* Finish prefix entry update procedure. */
+	prefix_list_entry_update_finish(ple);
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-filter:lib/prefix-list/entry/ipv6-prefix-length-greater-or-equal
+ */
+static int lib_prefix_list_entry_ipv6_prefix_length_greater_or_equal_modify(
+	struct nb_cb_modify_args *args)
+{
+	struct prefix_list_entry *ple;
+	const char *af_type;
+
+	if (args->event == NB_EV_VALIDATE
+	    && prefix_list_length_validate(args) != NB_OK)
+		return NB_ERR_VALIDATION;
+
+	if (args->event == NB_EV_VALIDATE) {
+		const struct lyd_node *entry_dnode =
+			yang_dnode_get_parent(args->dnode, "prefix-list");
+		af_type = yang_dnode_get_string(entry_dnode, "./type");
+		if (strcmp(af_type, "ipv6")) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "prefix-list type %s is mismatched.", af_type);
+			return NB_ERR_VALIDATION;
+		}
+
+		if (plist_is_dup_nb(args->dnode)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "duplicated prefix list value: %s",
+				 yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	ple = nb_running_get_entry(args->dnode, NULL, true);
+
+	/* Start prefix entry update procedure. */
+	prefix_list_entry_update_start(ple);
+
+	ple->ge = yang_dnode_get_uint8(args->dnode, NULL);
+
+	/* Finish prefix entry update procedure. */
+	prefix_list_entry_update_finish(ple);
+
+	return NB_OK;
+}
+
+static int lib_prefix_list_entry_ipv6_prefix_length_greater_or_equal_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	struct prefix_list_entry *ple;
+	const char *af_type;
+
+	if (args->event == NB_EV_VALIDATE) {
+		const struct lyd_node *entry_dnode =
+			yang_dnode_get_parent(args->dnode, "prefix-list");
+		af_type = yang_dnode_get_string(entry_dnode, "./type");
+		if (strcmp(af_type, "ipv6")) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "prefix-list type %s is mismatched.", af_type);
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	ple = nb_running_get_entry(args->dnode, NULL, true);
+
+	/* Start prefix entry update procedure. */
+	prefix_list_entry_update_start(ple);
+
+	ple->le = 0;
+
+	/* Finish prefix entry update procedure. */
+	prefix_list_entry_update_finish(ple);
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-filter:lib/prefix-list/entry/ipv6-prefix-length-lesser-or-equal
+ */
+static int lib_prefix_list_entry_ipv6_prefix_length_lesser_or_equal_modify(
+	struct nb_cb_modify_args *args)
+{
+	struct prefix_list_entry *ple;
+	const char *af_type;
+
+	if (args->event == NB_EV_VALIDATE
+	    && prefix_list_length_validate(args) != NB_OK)
+		return NB_ERR_VALIDATION;
+
+	if (args->event == NB_EV_VALIDATE) {
+		const struct lyd_node *entry_dnode =
+			yang_dnode_get_parent(args->dnode, "prefix-list");
+		af_type = yang_dnode_get_string(entry_dnode, "./type");
+		if (strcmp(af_type, "ipv6")) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "prefix-list type %s is mismatched.", af_type);
+			return NB_ERR_VALIDATION;
+		}
+		if (plist_is_dup_nb(args->dnode)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "duplicated prefix list value: %s",
+				 yang_dnode_get_string(args->dnode, NULL));
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	ple = nb_running_get_entry(args->dnode, NULL, true);
+
+	/* Start prefix entry update procedure. */
+	prefix_list_entry_update_start(ple);
+
+	ple->le = yang_dnode_get_uint8(args->dnode, NULL);
+
+	/* Finish prefix entry update procedure. */
+	prefix_list_entry_update_finish(ple);
+
+	return NB_OK;
+}
+
+static int lib_prefix_list_entry_ipv6_prefix_length_lesser_or_equal_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	struct prefix_list_entry *ple;
+	const char *af_type;
+
+	if (args->event == NB_EV_VALIDATE) {
+		const struct lyd_node *entry_dnode =
+			yang_dnode_get_parent(args->dnode, "prefix-list");
+		af_type = yang_dnode_get_string(entry_dnode, "./type");
+		if (strcmp(af_type, "ipv6")) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "prefix-list type %s is mismatched.", af_type);
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
@@ -1583,22 +1817,22 @@ const struct frr_yang_module_info frr_filter_info = {
 		{
 			.xpath = "/frr-filter:lib/prefix-list/entry/ipv6-prefix",
 			.cbs = {
-				.modify = lib_prefix_list_entry_ipv4_prefix_modify,
-				.destroy = lib_prefix_list_entry_ipv4_prefix_destroy,
+				.modify = lib_prefix_list_entry_ipv6_prefix_modify,
+				.destroy = lib_prefix_list_entry_ipv6_prefix_destroy,
 			}
 		},
 		{
 			.xpath = "/frr-filter:lib/prefix-list/entry/ipv6-prefix-length-greater-or-equal",
 			.cbs = {
-				.modify = lib_prefix_list_entry_ipv4_prefix_length_greater_or_equal_modify,
-				.destroy = lib_prefix_list_entry_ipv4_prefix_length_greater_or_equal_destroy,
+				.modify = lib_prefix_list_entry_ipv6_prefix_length_greater_or_equal_modify,
+				.destroy = lib_prefix_list_entry_ipv6_prefix_length_greater_or_equal_destroy,
 			}
 		},
 		{
 			.xpath = "/frr-filter:lib/prefix-list/entry/ipv6-prefix-length-lesser-or-equal",
 			.cbs = {
-				.modify = lib_prefix_list_entry_ipv4_prefix_length_lesser_or_equal_modify,
-				.destroy = lib_prefix_list_entry_ipv4_prefix_length_lesser_or_equal_destroy,
+				.modify = lib_prefix_list_entry_ipv6_prefix_length_lesser_or_equal_modify,
+				.destroy = lib_prefix_list_entry_ipv6_prefix_length_lesser_or_equal_destroy,
 			}
 		},
 		{

--- a/lib/filter_nb.c
+++ b/lib/filter_nb.c
@@ -308,45 +308,6 @@ bool plist_is_dup(const struct lyd_node *dnode, struct plist_dup_args *pda)
 	return pda->pda_found;
 }
 
-static bool plist_is_dup_nb(const struct lyd_node *dnode)
-{
-	const struct lyd_node *entry_dnode =
-		yang_dnode_get_parent(dnode, "entry");
-	struct plist_dup_args pda = {};
-	int idx = 0, arg_idx = 0;
-	static const char *entries[] = {
-		"./ipv4-prefix",
-		"./ipv4-prefix-length-greater-or-equal",
-		"./ipv4-prefix-length-lesser-or-equal",
-		"./ipv6-prefix",
-		"./ipv6-prefix-length-greater-or-equal",
-		"./ipv6-prefix-length-lesser-or-equal",
-		"./any",
-		NULL
-	};
-
-	/* Initialize. */
-	pda.pda_type = yang_dnode_get_string(entry_dnode, "../type");
-	pda.pda_name = yang_dnode_get_string(entry_dnode, "../name");
-	pda.pda_entry_dnode = entry_dnode;
-
-	/* Load all values/XPaths. */
-	while (entries[idx] != NULL) {
-		if (!yang_dnode_exists(entry_dnode, entries[idx])) {
-			idx++;
-			continue;
-		}
-
-		pda.pda_xpath[arg_idx] = entries[idx];
-		pda.pda_value[arg_idx] =
-			yang_dnode_get_string(entry_dnode, entries[idx]);
-		arg_idx++;
-		idx++;
-	}
-
-	return plist_is_dup(entry_dnode, &pda);
-}
-
 /*
  * XPath: /frr-filter:lib/access-list
  */
@@ -1272,16 +1233,6 @@ static int lib_prefix_list_entry_ipv4_prefix_length_greater_or_equal_modify(
 	    prefix_list_length_validate(args) != NB_OK)
 		return NB_ERR_VALIDATION;
 
-	if (args->event == NB_EV_VALIDATE) {
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
-		return NB_OK;
-	}
-
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
@@ -1343,16 +1294,6 @@ static int lib_prefix_list_entry_ipv4_prefix_length_lesser_or_equal_modify(
 	if (args->event == NB_EV_VALIDATE &&
 	    prefix_list_length_validate(args) != NB_OK)
 		return NB_ERR_VALIDATION;
-
-	if (args->event == NB_EV_VALIDATE) {
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
-		return NB_OK;
-	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -1427,12 +1368,6 @@ static int lib_prefix_list_entry_ipv6_prefix_length_greater_or_equal_modify(
 			return NB_ERR_VALIDATION;
 		}
 
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
 		return NB_OK;
 	}
 
@@ -1508,12 +1443,7 @@ static int lib_prefix_list_entry_ipv6_prefix_length_lesser_or_equal_modify(
 				 "prefix-list type %s is mismatched.", af_type);
 			return NB_ERR_VALIDATION;
 		}
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
+
 		return NB_OK;
 	}
 
@@ -1573,16 +1503,6 @@ static int lib_prefix_list_entry_any_create(struct nb_cb_create_args *args)
 {
 	struct prefix_list_entry *ple;
 	int type;
-
-	if (args->event == NB_EV_VALIDATE) {
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
-		return NB_OK;
-	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -684,6 +684,7 @@ void prefix_list_entry_update_start(struct prefix_list_entry *ple)
 	if (pl->head || pl->tail || pl->desc)
 		pl->master->recent = pl;
 
+	ple->next_best = NULL;
 	ple->installed = false;
 }
 

--- a/yang/frr-filter.yang
+++ b/yang/frr-filter.yang
@@ -292,8 +292,6 @@ module frr-filter {
           mandatory true;
 
           case ipv4-prefix {
-            when "../type = 'ipv4'";
-
             leaf ipv4-prefix {
               description "Configure IPv4 prefix to match";
               type inet:ipv4-prefix;
@@ -318,8 +316,6 @@ module frr-filter {
             }
           }
           case ipv6-prefix {
-            when "../type = 'ipv6'";
-
             leaf ipv6-prefix {
               description "Configure IPv6 prefix to match";
               type inet:ipv6-prefix;


### PR DESCRIPTION
The PR contains multiple fixes in prfix-list northbound conversions. 

1. To improve performance
2. Fix a crash in prefix-list northbound handler.

```
yang: remove when statement from prefix-list

Remove when statements from prefix-list yang OM, 
and do the same check in frr validation phase.
This helps a bit in perfomance of prefix-lists
scale config.

Ticket:CM-32035
Reviewed By:CCR-11096
Testing Done:

Signed-off-by: Chirag Shah <chirag@nvidia.com>
```

```
lib: remove prefix-list dup api in validation phase

Following patch
" lib: disallow access list duplicated values"
introduce a libyang dnode iterator for every prefix-list
config which adds an overhead of traversal all prefix dnodes
and degrades the performance in scaled prefix-list config.

This check is not necessary in prefix-list northbound callbacks
as there won't be a case where prefix-list config comes to nb
callback without sequence number.

The dup check is only necessary for the vtysh case for backward
compatiblity reason where cli can be accepted without sequence number.

Signed-off-by: Chirag Shah <chirag@nvidia.com>
```

```
lib: fix a crash in plist update

Problem:
Prefix-list with mulitiple rules, an update to
a rule/sequence with different prefix/prefixlen 
reset prefix-list next-base pointer to avoid
having stale value.            

In some case the old next-bast's reference leads 
to an assert in tri (trie_install_fn ) add.

bt:
(object=0x55576a4c8a00, updptr=0x55576a4b97e0) at lib/plist.c:560
(plist=0x55576a4a1770, pentry=0x55576a4c8a00) at lib/plist.c:585
(ple=0x55576a4c8a00) at lib/plist.c:745
(args=0x7fffe04beb50) at lib/filter_nb.c:1181

Solution:                      
Reset prefix-list next-base pointer whenver a
sequence/rule is updated.      

Signed-off-by: Chirag Shah <chirag@nvidia.com> 
Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>
```