### PR TITLE
zebra: resolve multiple functions for local MAC delete

### DIFF
--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -2302,34 +2302,17 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf, zebra_evpn_t *zevpn,
 	return 0;
 }
 
-int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, struct ethaddr *macaddr,
-			     struct interface *ifp)
+int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, zebra_mac_t *mac)
 {
-	zebra_mac_t *mac;
 	char buf[ETHER_ADDR_STRLEN];
 	bool old_bgp_ready;
 	bool new_bgp_ready;
-	/* If entry doesn't exist, nothing to do. */
-	mac = zebra_evpn_mac_lookup(zevpn, macaddr);
-	if (!mac)
-		return 0;
 
-	/* Is it a local entry? */
-	if (!CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL))
-		return 0;
-
-	if (IS_ZEBRA_DEBUG_VXLAN) {
-		char mac_buf[MAC_BUF_SIZE];
-
-		zlog_debug(
-			"DEL MAC %s intf %s(%u) VID %u -> VNI %u seq %u flags %snbr count %u",
-			prefix_mac2str(macaddr, buf, sizeof(buf)), ifp->name,
-			ifp->ifindex, mac->fwd_info.local.vid, zevpn->vni,
-			mac->loc_seq,
-			zebra_evpn_zebra_mac_flag_dump(mac, mac_buf,
-						       sizeof(mac_buf)),
-			listcount(mac->neigh_list));
-	}
+	if (IS_ZEBRA_DEBUG_VXLAN)
+		zlog_debug("DEL MAC %s VNI %u seq %u flags 0x%x nbr count %u",
+			   prefix_mac2str(&mac->macaddr, buf, sizeof(buf)),
+			   zevpn->vni, mac->loc_seq, mac->flags,
+			   listcount(mac->neigh_list));
 
 	old_bgp_ready = zebra_evpn_mac_is_ready_for_bgp(mac->flags);
 	if (zebra_evpn_mac_is_static(mac)) {
@@ -2344,7 +2327,7 @@ int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, struct ethaddr *macaddr,
 			zlog_debug(
 				"re-add sync-mac vni %u mac %s es %s seq %d f %s",
 				zevpn->vni,
-				prefix_mac2str(macaddr, buf, sizeof(buf)),
+				prefix_mac2str(&mac->macaddr, buf, sizeof(buf)),
 				mac->es ? mac->es->esi_str : "-", mac->loc_seq,
 				zebra_evpn_zebra_mac_flag_dump(
 					mac, mac_buf, sizeof(mac_buf)));
@@ -2371,7 +2354,7 @@ int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, struct ethaddr *macaddr,
 	zebra_evpn_process_neigh_on_local_mac_del(zevpn, mac);
 
 	/* Remove MAC from BGP. */
-	zebra_evpn_mac_send_del_to_client(zevpn->vni, macaddr, mac->flags,
+	zebra_evpn_mac_send_del_to_client(zevpn->vni, &mac->macaddr, mac->flags,
 					  false /* force */);
 
 	zebra_evpn_es_mac_deref_entry(mac);

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -253,8 +253,7 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf, zebra_evpn_t *zevpn,
 				    struct ethaddr *macaddr, vlanid_t vid,
 				    bool sticky, bool local_inactive,
 				    bool dp_static);
-int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, struct ethaddr *macaddr,
-			     struct interface *ifp);
+int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, zebra_mac_t *mac);
 int zebra_evpn_mac_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
 				struct ipaddr *ip, zebra_mac_t **macp,
 				struct ethaddr *macaddr, vlanid_t vlan_id);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4071,7 +4071,6 @@ int zebra_vxlan_dp_network_mac_add(struct interface *ifp,
  * 1. readd the remote MAC if we have it
  * 2. local MAC with does ES may also need to be re-installed
  */
-static int zebra_vxlan_do_local_mac_del(zebra_evpn_t *zevpn, zebra_mac_t *mac);
 int zebra_vxlan_dp_network_mac_del(struct interface *ifp,
 				   struct interface *br_if,
 				   struct ethaddr *macaddr, vlanid_t vid)
@@ -4122,72 +4121,7 @@ int zebra_vxlan_dp_network_mac_del(struct interface *ifp,
 		if (IS_ZEBRA_DEBUG_VXLAN || IS_ZEBRA_DEBUG_EVPN_MH_MAC)
 			zlog_debug("dpDel local-nw-MAC %pEA VNI %u", macaddr,
 				   vni);
-		zebra_vxlan_do_local_mac_del(zevpn, mac);
-	}
-
-	return 0;
-}
-
-static int zebra_vxlan_do_local_mac_del(zebra_evpn_t *zevpn, zebra_mac_t *mac)
-{
-	bool old_bgp_ready;
-	bool new_bgp_ready;
-
-	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("DEL MAC %pEA VNI %u seq %u flags 0x%x nbr count %u",
-			   &mac->macaddr, zevpn->vni, mac->loc_seq, mac->flags,
-			   listcount(mac->neigh_list));
-
-	old_bgp_ready = zebra_evpn_mac_is_ready_for_bgp(mac->flags);
-	if (zebra_evpn_mac_is_static(mac)) {
-		/* this is a synced entry and can only be removed when the
-		 * es-peers stop advertising it.
-		 */
-		memset(&mac->fwd_info, 0, sizeof(mac->fwd_info));
-
-		if (IS_ZEBRA_DEBUG_EVPN_MH_MAC)
-			zlog_debug(
-				"re-add sync-mac vni %u mac %pEA es %s seq %d f 0x%x",
-				zevpn->vni, &mac->macaddr,
-				mac->es ? mac->es->esi_str : "-", mac->loc_seq,
-				mac->flags);
-
-		/* inform-bgp about change in local-activity if any */
-		if (!CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL_INACTIVE)) {
-			SET_FLAG(mac->flags, ZEBRA_MAC_LOCAL_INACTIVE);
-			new_bgp_ready =
-				zebra_evpn_mac_is_ready_for_bgp(mac->flags);
-			zebra_evpn_mac_send_add_del_to_client(
-				mac, old_bgp_ready, new_bgp_ready);
-		}
-
-		/* re-install the entry in the kernel */
-		zebra_evpn_sync_mac_dp_install(mac, false /* set_inactive */,
-					       false /* force_clear_static */,
-					       __func__);
-
-		return 0;
-	}
-
-	/* Update all the neigh entries associated with this mac */
-	zebra_evpn_process_neigh_on_local_mac_del(zevpn, mac);
-
-	/* Remove MAC from BGP. */
-	zebra_evpn_mac_send_del_to_client(zevpn->vni, &mac->macaddr, mac->flags,
-					  false /* force */);
-
-	zebra_evpn_es_mac_deref_entry(mac);
-
-	/*
-	 * If there are no neigh associated with the mac delete the mac
-	 * else mark it as AUTO for forward reference
-	 */
-	if (!listcount(mac->neigh_list)) {
-		zebra_evpn_mac_del(zevpn, mac);
-	} else {
-		UNSET_FLAG(mac->flags, ZEBRA_MAC_ALL_LOCAL_FLAGS);
-		UNSET_FLAG(mac->flags, ZEBRA_MAC_STICKY);
-		SET_FLAG(mac->flags, ZEBRA_MAC_AUTO);
+		return zebra_evpn_del_local_mac(zevpn, mac);
 	}
 
 	return 0;
@@ -4224,7 +4158,7 @@ int zebra_vxlan_local_mac_del(struct interface *ifp, struct interface *br_if,
 	if (!CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL))
 		return 0;
 
-	return zebra_vxlan_do_local_mac_del(zevpn, mac);
+	return zebra_evpn_del_local_mac(zevpn, mac);
 }
 
 /*


### PR DESCRIPTION
the old VXLAN function for local MAC deletion was still in
existence and being called from the VXLAN code whilst the new
generic function was not being called at all. Resolve this so
the generic function matches the old function and is called
exclusively.

Signed-off-by: Pat Ruddy <pat@voltanet.io>