### PR TITLE
tests: report kernel version check failures

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -4119,6 +4119,9 @@ def required_linux_kernel_version(required_version):
             'These tests will not run on kernel "{}", '
             "they require kernel >= {})".format(system_kernel, required_version)
         )
+
+        logger.info(error_msg)
+
         return error_msg
     return True
 


### PR DESCRIPTION
Report kernel version check failures in the test log. We're skipping some tests on platforms that should support them...
