### PR TITLE
tests: make generate support bundle python3

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -677,7 +677,10 @@ def generate_support_bundle():
     for rname, rnode in router_list.items():
         logger.info("Generating support bundle for {}".format(rname))
         rnode.run("mkdir -p /var/log/frr")
-        bundle_log = rnode.run("python2 /usr/lib/frr/generate_support_bundle.py")
+
+        # Support only python3 going forward
+        bundle_log = rnode.run("env python3 /usr/lib/frr/generate_support_bundle.py")
+
         logger.info(bundle_log)
 
         dst_bundle = "{}/{}/support_bundles/{}".format(TMPDIR, rname, test_name)


### PR DESCRIPTION
Make the generate-support-bundle script and interactions python3-friendly and use python3 explicitly.

Should help #8014 