### PR TITLE
bgpd: [7.5] Drop aggregator_as attribute if malformed in case of BGP_AS_ZERO

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1697,17 +1697,18 @@ static int bgp_attr_aggregator(struct bgp_attr_parser_args *args)
 	else
 		aggregator_as = stream_getw(peer->curr);
 
-	attr->aggregator_as = aggregator_as;
-	attr->aggregator_addr.s_addr = stream_get_ipv4(peer->curr);
-
-	/* Set atomic aggregate flag. */
-	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR);
-
 	/* Codification of AS 0 Processing */
-	if (aggregator_as == BGP_AS_ZERO)
+	if (aggregator_as == BGP_AS_ZERO) {
 		flog_err(EC_BGP_ATTR_LEN,
-			 "AGGREGATOR AS number is 0 for aspath: %s",
-			 aspath_print(attr->aspath));
+			 "%s: AGGREGATOR AS number is 0 for aspath: %s",
+			 peer->host, aspath_print(attr->aspath));
+	} else {
+		attr->aggregator_as = aggregator_as;
+		attr->aggregator_addr.s_addr = stream_get_ipv4(peer->curr);
+
+		/* Set atomic aggregate flag. */
+		attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR);
+	}
 
 	return BGP_ATTR_PARSE_PROCEED;
 }
@@ -1731,16 +1732,18 @@ bgp_attr_as4_aggregator(struct bgp_attr_parser_args *args,
 	}
 
 	aggregator_as = stream_getl(peer->curr);
-	*as4_aggregator_as = aggregator_as;
-	as4_aggregator_addr->s_addr = stream_get_ipv4(peer->curr);
-
-	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AS4_AGGREGATOR);
 
 	/* Codification of AS 0 Processing */
-	if (aggregator_as == BGP_AS_ZERO)
+	if (aggregator_as == BGP_AS_ZERO) {
 		flog_err(EC_BGP_ATTR_LEN,
-			 "AS4_AGGREGATOR AS number is 0 for aspath: %s",
-			 aspath_print(attr->aspath));
+			 "%s: AS4_AGGREGATOR AS number is 0 for aspath: %s",
+			 peer->host, aspath_print(attr->aspath));
+	} else {
+		*as4_aggregator_as = aggregator_as;
+		as4_aggregator_addr->s_addr = stream_get_ipv4(peer->curr);
+
+		attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AS4_AGGREGATOR);
+	}
 
 	return BGP_ATTR_PARSE_PROCEED;
 }

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1697,18 +1697,16 @@ static int bgp_attr_aggregator(struct bgp_attr_parser_args *args)
 	else
 		aggregator_as = stream_getw(peer->curr);
 
+	attr->aggregator_as = aggregator_as;
+	attr->aggregator_addr.s_addr = stream_get_ipv4(peer->curr);
+
 	/* Codification of AS 0 Processing */
-	if (aggregator_as == BGP_AS_ZERO) {
+	if (aggregator_as == BGP_AS_ZERO)
 		flog_err(EC_BGP_ATTR_LEN,
 			 "%s: AGGREGATOR AS number is 0 for aspath: %s",
 			 peer->host, aspath_print(attr->aspath));
-	} else {
-		attr->aggregator_as = aggregator_as;
-		attr->aggregator_addr.s_addr = stream_get_ipv4(peer->curr);
-
-		/* Set atomic aggregate flag. */
+	else
 		attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR);
-	}
 
 	return BGP_ATTR_PARSE_PROCEED;
 }
@@ -1733,17 +1731,16 @@ bgp_attr_as4_aggregator(struct bgp_attr_parser_args *args,
 
 	aggregator_as = stream_getl(peer->curr);
 
+	*as4_aggregator_as = aggregator_as;
+	as4_aggregator_addr->s_addr = stream_get_ipv4(peer->curr);
+
 	/* Codification of AS 0 Processing */
-	if (aggregator_as == BGP_AS_ZERO) {
+	if (aggregator_as == BGP_AS_ZERO)
 		flog_err(EC_BGP_ATTR_LEN,
 			 "%s: AS4_AGGREGATOR AS number is 0 for aspath: %s",
 			 peer->host, aspath_print(attr->aspath));
-	} else {
-		*as4_aggregator_as = aggregator_as;
-		as4_aggregator_addr->s_addr = stream_get_ipv4(peer->curr);
-
+	else
 		attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AS4_AGGREGATOR);
-	}
 
 	return BGP_ATTR_PARSE_PROCEED;
 }


### PR DESCRIPTION
An UPDATE message that contains the AS number of zero in the AS_PATH
   or AGGREGATOR attribute MUST be considered as malformed and be
   handled by the procedures specified in [RFC7606].

An UPDATE message with a malformed AGGREGATOR attribute SHALL be
   handled using the approach of "attribute discard".

Attribute discard: In this approach, the malformed attribute MUST
      be discarded and the UPDATE message continues to be processed.
      This approach MUST NOT be used except in the case of an attribute
      that has no effect on route selection or installation.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>