### PR TITLE
zebra: disable setting weak override flag in neigh updates

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3695,14 +3695,6 @@ static ssize_t netlink_neigh_update_ctx(const struct zebra_dplane_ctx *ctx,
 		/* local neigh */
 		if (update_flags & DPLANE_NEIGH_SET_STATIC)
 			ext_flags |= NTF_E_MH_PEER_SYNC;
-
-		/* the ndm_state set for local entries can be REACHABLE or
-		 * STALE. if the dataplane has already establish reachability
-		 * (in the meantime) FRR must not over-write it with STALE.
-		 * this accidental race/over-write is avoided by using the
-		 * WEAK_OVERRIDE_STATE
-		 */
-		ext_flags |= NTF_E_WEAK_OVERRIDE_STATE;
 	}
 	if (IS_ZEBRA_DEBUG_KERNEL) {
 		char buf[INET6_ADDRSTRLEN];


### PR DESCRIPTION
This is causing problems with VM move i.e. transition from remote
neigh to local neigh. This transition involves changing the NUD_STATE
NUD_NOARP to NUD_STALE. And the weak override flag prevents changing
the state from connected (REACHABLE, NOARP, PERMANENT) to STALE.

PS: Weak-override was originally used to prevent race conditions where
FRR can end up making a REACHABLE neigh STALE. We may need to revisit
and address that case at a later point.

Ticket: CM-30273

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>