### PR TITLE
lib/libfrr: add API frr_load_module

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -946,6 +946,20 @@ static int frr_config_read_in(struct thread *t)
 	return 0;
 }
 
+void frr_load_module(const char *name)
+{
+	const char *dir;
+	dir = di->module_path ? di->module_path : frr_moduledir;
+	char moderr[256];
+	struct frrmod_runtime *module;
+
+	module = frrmod_load(name, dir, moderr, sizeof(moderr));
+	if (!module) {
+		fprintf(stderr, "%s\n", moderr);
+		exit(1);
+	}
+}
+
 void frr_config_fork(void)
 {
 	hook_call(frr_late_init, master);

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -144,6 +144,8 @@ DECLARE_HOOK(frr_late_init, (struct thread_master * tm), (tm))
 DECLARE_HOOK(frr_very_late_init, (struct thread_master * tm), (tm))
 extern void frr_config_fork(void);
 
+extern void frr_load_module(const char *name);
+
 extern void frr_run(struct thread_master *master);
 extern void frr_detach(void);
 


### PR DESCRIPTION
Adding API frr_load_module.
This permits LDP processes lde and ldpe to load the "snmp" module.

Signed-off-by: Karen Schoener <karen@voltanet.io>