### PR TITLE
lib: add agentx_enabled hook

### DIFF
--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -36,6 +36,8 @@
 
 XREF_SETUP()
 
+DEFINE_HOOK(agentx_enabled, (), ())
+
 static int agentx_enabled = 0;
 
 static struct thread_master *agentx_tm;
@@ -226,6 +228,7 @@ DEFUN (agentx_enable,
 		events = list_new();
 		agentx_events_update();
 		agentx_enabled = 1;
+		hook_call(agentx_enabled);
 	}
 
 	return CMD_SUCCESS;
@@ -257,6 +260,16 @@ void smux_init(struct thread_master *tm)
 	install_node(&agentx_node);
 	install_element(CONFIG_NODE, &agentx_enable_cmd);
 	install_element(CONFIG_NODE, &no_agentx_cmd);
+}
+
+void smux_agentx_enable(void)
+{
+	if (!agentx_enabled) {
+		init_snmp(FRR_SMUX_NAME);
+		events = list_new();
+		agentx_events_update();
+		agentx_enabled = 1;
+	}
 }
 
 void smux_register_mib(const char *descr, struct variable *var, size_t width,

--- a/lib/smux.h
+++ b/lib/smux.h
@@ -25,6 +25,7 @@
 #include <net-snmp/agent/snmp_vars.h>
 
 #include "thread.h"
+#include "hook.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -70,6 +71,7 @@ struct trap_object {
 	 (uint8_t *)&snmp_in_addr_val)
 
 extern void smux_init(struct thread_master *tm);
+extern void smux_agentx_enable(void);
 extern void smux_register_mib(const char *, struct variable *, size_t, int,
 			      oid[], size_t);
 extern int smux_header_generic(struct variable *, oid[], size_t *, int,
@@ -106,6 +108,8 @@ extern int oid_compare(const oid *, int, const oid *, int);
 extern void oid2in_addr(oid[], int, struct in_addr *);
 extern void *oid_copy(void *, const void *, size_t);
 extern void oid_copy_addr(oid[], const struct in_addr *, int);
+
+DECLARE_HOOK(agentx_enabled, (), ())
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adding agentx_enabled hook.

This permits the main LDP process to signal the lde and ldpe processes when agentx is enabled.

Signed-off-by: Karen Schoener <karen@voltanet.io>