### PR TITLE
bgpd: Dump BGP attrs to check what's the actual prefix with aggr_as 0

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1754,12 +1754,21 @@ static int bgp_attr_aggregator(struct bgp_attr_parser_args *args)
 	attr->aggregator_addr.s_addr = stream_get_ipv4(peer->curr);
 
 	/* Codification of AS 0 Processing */
-	if (aggregator_as == BGP_AS_ZERO)
+	if (aggregator_as == BGP_AS_ZERO) {
 		flog_err(EC_BGP_ATTR_LEN,
 			 "%s: AGGREGATOR AS number is 0 for aspath: %s",
 			 peer->host, aspath_print(attr->aspath));
-	else
+
+		if (bgp_debug_update(peer, NULL, NULL, 1)) {
+			char attr_str[BUFSIZ] = {0};
+
+			bgp_dump_attr(attr, attr_str, sizeof(attr_str));
+
+			zlog_debug("%s: attributes: %s", __func__, attr_str);
+		}
+	} else {
 		attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR);
+	}
 
 	return BGP_ATTR_PARSE_PROCEED;
 }
@@ -1788,12 +1797,21 @@ bgp_attr_as4_aggregator(struct bgp_attr_parser_args *args,
 	as4_aggregator_addr->s_addr = stream_get_ipv4(peer->curr);
 
 	/* Codification of AS 0 Processing */
-	if (aggregator_as == BGP_AS_ZERO)
+	if (aggregator_as == BGP_AS_ZERO) {
 		flog_err(EC_BGP_ATTR_LEN,
 			 "%s: AS4_AGGREGATOR AS number is 0 for aspath: %s",
 			 peer->host, aspath_print(attr->aspath));
-	else
+
+		if (bgp_debug_update(peer, NULL, NULL, 1)) {
+			char attr_str[BUFSIZ] = {0};
+
+			bgp_dump_attr(attr, attr_str, sizeof(attr_str));
+
+			zlog_debug("%s: attributes: %s", __func__, attr_str);
+		}
+	} else {
 		attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AS4_AGGREGATOR);
+	}
 
 	return BGP_ATTR_PARSE_PROCEED;
 }


### PR DESCRIPTION
Just for more debug information regarding malformed aggregator_as.

```
bgpd[5589]: [EC 33554434] 192.168.10.25: AGGREGATOR AS number is 0 for aspath: 65030
bgpd[5589]: bgp_attr_aggregator: attributes: nexthop 192.168.10.25, origin i, path 65030
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>