### PR TITLE
bgpd: Remove the double decleration of bgp_global_evpn_node_lookup

### DIFF
--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -630,13 +630,5 @@ extern struct bgp_dest *
 bgp_global_evpn_node_lookup(struct bgp_table *table, afi_t afi, safi_t safi,
 			    const struct prefix_evpn *evp,
 			    struct prefix_rd *prd);
-extern struct bgp_node *bgp_global_evpn_node_get(struct bgp_table *table,
-						 afi_t afi, safi_t safi,
-						 const struct prefix_evpn *evp,
-						 struct prefix_rd *prd);
-extern struct bgp_node *
-bgp_global_evpn_node_lookup(struct bgp_table *table, afi_t afi, safi_t safi,
-			    const struct prefix_evpn *evp,
-			    struct prefix_rd *prd);
 extern void bgp_evpn_import_route_in_vrfs(struct bgp_path_info *pi, int import);
 #endif /* _BGP_EVPN_PRIVATE_H */


### PR DESCRIPTION
Signed-off-by: Donald Sharp <sharpd@nvidia.com>