### PR TITLE
lib: support mallinfo2() if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2366,6 +2366,29 @@ if test "$frr_cv_mallinfo" = "yes"; then
   AC_DEFINE([HAVE_MALLINFO], [1], [mallinfo])
 fi
 
+AC_CACHE_CHECK([whether mallinfo2 is available], [frr_cv_mallinfo2], [
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([FRR_INCLUDES [
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
+#ifdef HAVE_MALLOC_NP_H
+#include <malloc_np.h>
+#endif
+#ifdef HAVE_MALLOC_MALLOC_H
+#include <malloc/malloc.h>
+#endif
+]], [[
+struct mallinfo2 ac_x; ac_x = mallinfo2 ();
+]])], [
+    frr_cv_mallinfo2=yes
+  ], [
+    frr_cv_mallinfo2=no
+  ])
+])
+if test "$frr_cv_mallinfo2" = "yes"; then
+  AC_DEFINE([HAVE_MALLINFO2], [1], [mallinfo2])
+fi
+
 AC_MSG_CHECKING([whether malloc_usable_size is available])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([FRR_INCLUDES [
 #ifdef HAVE_MALLOC_H

--- a/lib/lib_vty.c
+++ b/lib/lib_vty.c
@@ -43,10 +43,14 @@
 #include "vty.h"
 #include "command.h"
 
-#ifdef HAVE_MALLINFO
+#if defined(HAVE_MALLINFO2) || defined(HAVE_MALLINFO)
 static int show_memory_mallinfo(struct vty *vty)
 {
+#if defined(HAVE_MALLINFO2)
+	struct mallinfo2 minfo = mallinfo2();
+#elif defined(HAVE_MALLINFO)
 	struct mallinfo minfo = mallinfo();
+#endif
 	char buf[MTYPE_MEMSTR_LEN];
 
 	vty_out(vty, "System allocator statistics:\n");


### PR DESCRIPTION
mallinfo() is deprecated as of glibc 2.33 and emits a warning if used. Support mallinfo2() if available.

Signed-off-by: Quentin Young <qlyoung@qlyoung.net>