### PR TITLE
tests: Modify timers on bgp_blackhole_community

### DIFF
--- a/tests/topotests/bgp_blackhole_community/r1/bgpd.conf
+++ b/tests/topotests/bgp_blackhole_community/r1/bgpd.conf
@@ -1,5 +1,6 @@
 !
 router bgp 65001
+  timers bgp 3 9
   no bgp ebgp-requires-policy
   neighbor r1-eth0 interface remote-as external
   address-family ipv4 unicast

--- a/tests/topotests/bgp_blackhole_community/r2/bgpd.conf
+++ b/tests/topotests/bgp_blackhole_community/r2/bgpd.conf
@@ -1,6 +1,7 @@
 !
 router bgp 65002
   no bgp ebgp-requires-policy
+  timers bgp 3 9
   neighbor r2-eth0 interface remote-as external
   neighbor r2-eth1 interface remote-as external
   neighbor r2-eth2 interface remote-as internal

--- a/tests/topotests/bgp_blackhole_community/r3/bgpd.conf
+++ b/tests/topotests/bgp_blackhole_community/r3/bgpd.conf
@@ -1,5 +1,6 @@
 !
 router bgp 65003
+  timers bgp 3 9
   no bgp ebgp-requires-policy
   neighbor r3-eth0 interface remote-as external
 !

--- a/tests/topotests/bgp_blackhole_community/r4/bgpd.conf
+++ b/tests/topotests/bgp_blackhole_community/r4/bgpd.conf
@@ -1,5 +1,6 @@
 !
 router bgp 65002
+  timers bgp 3 9
   no bgp ebgp-requires-policy
   neighbor r4-eth0 interface remote-as internal
 !


### PR DESCRIPTION
Modify the timers on the bgp_blackhole_community test to
be more aggressive so our test system will recover faster
when we drop packets.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>