### PR TITLE
(Don't Review, work in progress)zebra: core dump in PTM interface

### DIFF
--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -642,6 +642,7 @@ int zebra_ptm_sock_read(struct thread *thread)
 	do {
 		rc = ptm_lib_process_msg(ptm_hdl, sock, ptm_cb.in_data,
 					 ZEBRA_PTM_MAX_SOCKBUF, NULL);
+		memset(ptm_cb.in_data, 0, ZEBRA_PTM_MAX_SOCKBUF);
 	} while (rc > 0);
 
 	if (((rc == 0) && !errno)


### PR DESCRIPTION
Problem Statement:
Decoding issue with CSV formatted data.
Zebra uses the in_data buffer of size ZEBRA_PTM_MAX_SOCKBUF, to read the
message from the PTM socket. PTM interface sends the message in
CSV format (Records and Fields).
Records is separated by '\n' and Fields are separated by ','.
First the header comes from the PTM interface as one record with other fields.
Now Zebra decodes this and reads next bytes based upon the size
present in header field. Till this point every thing is good.
Now consider this scenario :
First message comes of X bytes.
Second message comes of X+Y bytes.
Third message comes of X or < (X+Y) then CSV decoding logic
creates an issue. The reason is buffer contains extra bytes and mislead
the CSV parsing.  As CSV totally depends on Fields ('\n', ',')
and doesn't consider the length of valid message.

Fix:
Reset the buffer after processing the message and
make it ready to read next set of data.

Signed-off-by: vishaldhingra <vdhingra@vmware.com>