### PR TITLE
vrf: mark vrf as configured when entering vrf node

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -1064,6 +1064,7 @@ static int lib_vrf_create(struct nb_cb_create_args *args)
 
 	vrfp = vrf_get(VRF_UNKNOWN, vrfname);
 
+	SET_FLAG(vrfp->status, VRF_CONFIGURED);
 	nb_running_set_entry(args->dnode, vrfp);
 
 	return NB_OK;

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -1064,7 +1064,7 @@ static int lib_vrf_create(struct nb_cb_create_args *args)
 
 	vrfp = vrf_get(VRF_UNKNOWN, vrfname);
 
-	SET_FLAG(vrfp->status, VRF_CONFIGURED);
+	vrf_set_user_cfged(vrfp);
 	nb_running_set_entry(args->dnode, vrfp);
 
 	return NB_OK;
@@ -1090,7 +1090,7 @@ static int lib_vrf_destroy(struct nb_cb_destroy_args *args)
 		vrfp = nb_running_unset_entry(args->dnode);
 
 		/* Clear configured flag and invoke delete. */
-		UNSET_FLAG(vrfp->status, VRF_CONFIGURED);
+		vrf_reset_user_cfged(vrfp);
 		vrf_delete(vrfp);
 		break;
 	}


### PR DESCRIPTION
The VRF must be marked as configured when user enters "vrf NAME" command.

Otherwise, the following problem occurs:

`ip link add red type vrf table 1`

  VRF structure is allocated.

`vtysh -c "conf t" -c "vrf red"`

  `lib_vrf_create` is called, and pointer to the VRF structure is stored
  to the nb_config_entry.

`ip link del red`

  VRF structure is freed (because it is not marked as configured), but
  the pointer is still stored in the nb_config_entry.

`vtysh -c "conf t" -c "no vrf red"`

  Nothing happens, because VRF structure doesn't exist. It means that
  `lib_vrf_destroy` is not called, and nb_config_entry still exists in
  the running config with incorrect pointer.

`ip link add red type vrf table 1`

  New VRF structure is allocated.

`vtysh -c "conf t" -c "vrf red"`

  `lib_vrf_create` is NOT called, because the nb_config_entry for that
  VRF name still exists in the running config.

After that all NB commands for this VRF will use incorrect pointer to
the freed VRF structure.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>