### PR TITLE
ospf6d: Default Route functionality

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -163,6 +163,12 @@ Redistribute routes to OSPF6
 .. index:: redistribute ripng
 .. clicmd:: redistribute ripng
 
+.. index:: [no] default-route originate [{always|metric (0-16777214)|metric-type (1-2)|route-map WORD}]
+.. clicmd:: [no] default-route originate [{always|metric (0-16777214)|metric-type (1-2)|route-map WORD}]
+
+   The command injects default route in the connected areas. The always
+   argument injects the default route regardless of it being present in the
+   router. Metric values and route-map can also be specified optionally.
 
 .. _showing-ospf6-information:
 

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1208,7 +1208,12 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 				       sizeof(struct in6_addr));
 			info->tag = tinfo.tag;
 		} else {
-			/* If there is no route-map, simply update the tag */
+			/* If there is no route-map, simply update the tag and
+			 * metric fields*/
+			match->path.metric_type =
+				metric_type(ospf6, DEFAULT_ROUTE, 0);
+			match->path.cost =
+				metric_value(ospf6, DEFAULT_ROUTE, 0);
 			info->tag = tag;
 		}
 
@@ -1261,7 +1266,10 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 			       sizeof(struct in6_addr));
 		info->tag = tinfo.tag;
 	} else {
-		/* If there is no route-map, simply set the tag */
+		/* If there is no route-map, simply update the tag and metric
+		 * fields*/
+		route->path.metric_type = metric_type(ospf6, DEFAULT_ROUTE, 0);
+		route->path.cost = metric_value(ospf6, DEFAULT_ROUTE, 0);
 		info->tag = tag;
 	}
 

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -53,6 +53,10 @@ static void ospf6_asbr_redistribute_set(int type, vrf_id_t vrf_id);
 static void ospf6_asbr_redistribute_unset(struct ospf6 *ospf6,
 					  struct ospf6_redist *red, int type);
 
+#ifndef VTYSH_EXTRACT_PL
+#include "ospf6d/ospf6_asbr_clippy.c"
+#endif
+
 unsigned char conf_debug_ospf6_asbr = 0;
 
 #define ZROUTE_NAME(x) zebra_route_string(x)
@@ -1122,7 +1126,8 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 	if (!red)
 		return;
 
-	if (!ospf6_zebra_is_redistribute(type, ospf6->vrf_id))
+	if ((type != DEFAULT_ROUTE)
+	    && !ospf6_zebra_is_redistribute(type, ospf6->vrf_id))
 		return;
 
 	memset(&troute, 0, sizeof(troute));
@@ -1505,6 +1510,136 @@ static void ospf6_redistribute_show_config(struct vty *vty, struct ospf6 *ospf6,
 		vty_out(vty, "Total %d routes\n", total);
 }
 
+static void ospf6_redistribute_default_set(struct ospf6 *ospf6, int originate)
+{
+	struct prefix p;
+	struct in6_addr nexthop;
+	int cur_originate = ospf6->default_originate;
+
+	p.family = AF_INET6;
+	p.prefixlen = 0;
+
+	memset(&p, 0, sizeof(p));
+	memset(&nexthop, 0, sizeof(nexthop));
+
+	ospf6->default_originate = originate;
+
+	switch (cur_originate) {
+	case DEFAULT_ORIGINATE_NONE:
+		break;
+	case DEFAULT_ORIGINATE_ZEBRA:
+		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_DELETE,
+					     zclient, AFI_IP, ospf6->vrf_id);
+		break;
+	case DEFAULT_ORIGINATE_ALWAYS:
+		ospf6_asbr_redistribute_remove(DEFAULT_ROUTE, 0, &p, ospf6);
+		break;
+	}
+
+	switch (originate) {
+	case DEFAULT_ORIGINATE_NONE:
+		break;
+	case DEFAULT_ORIGINATE_ZEBRA:
+		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_ADD,
+					     zclient, AFI_IP, ospf6->vrf_id);
+		break;
+	case DEFAULT_ORIGINATE_ALWAYS:
+		ospf6_asbr_redistribute_add(DEFAULT_ROUTE, 0, &p, 0, &nexthop,
+					    0, ospf6);
+		break;
+	}
+	// Add logic for changing the ASBR flag
+}
+
+/* Default Route originate. */
+DEFPY (ospf6_default_route_originate,
+       ospf6_default_route_originate_cmd,
+       "default-route originate [{always|metric (0-16777214)$mval|metric-type (1-2)$mtype|route-map WORD$rtmap}]",
+       "Control distribution of default route\n"
+       "Distribute a default route\n"
+       "Always advertise default route\n"
+       "OSPFv3 default metric\n"
+       "OSPFv3 metric\n"
+       "OSPFv3 metric type for default routes\n"
+       "Set OSPFv3 External Type 1/2 metrics\n"
+       "Route map reference\n"
+       "Pointer to route-map entries\n")
+{
+	int default_originate = DEFAULT_ORIGINATE_ZEBRA;
+	int idx = 0;
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	struct ospf6_redist *red;
+	bool sameRtmap = false;
+	int cur_originate = ospf6->default_originate;
+
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
+
+	red = ospf6_redist_add(ospf6, DEFAULT_ROUTE, 0);
+
+	if (argv_find(argv, argc, "always", &idx))
+		default_originate = DEFAULT_ORIGINATE_ALWAYS;
+
+	if (!argv_find(argv, argc, "metric", &idx))
+		mval = -1;
+	if (!argv_find(argv, argc, "metric-type", &idx))
+		mtype = -1;
+
+	/* To check ,if user is providing same route map */
+	if ((rtmap == ROUTEMAP_NAME(red))
+	    || (rtmap && ROUTEMAP_NAME(red)
+		&& (strcmp(rtmap, ROUTEMAP_NAME(red)) == 0)))
+		sameRtmap = true;
+
+	/* Don't allow if the same lsa is aleardy originated. */
+	if ((sameRtmap) && (red->dmetric.type == mtype)
+	    && (red->dmetric.value == mval)
+	    && (cur_originate == default_originate))
+		return CMD_SUCCESS;
+
+	/* Updating Metric details */
+	red->dmetric.type = mtype;
+	red->dmetric.value = mval;
+
+	/* updating route map details */
+	if (rtmap)
+		ospf6_asbr_routemap_set(red, rtmap);
+	else
+		ospf6_asbr_routemap_unset(red);
+
+	// implement route map
+	ospf6_redistribute_default_set(ospf6, default_originate);
+	return CMD_SUCCESS;
+}
+
+DEFPY (no_ospf6_default_information_originate,
+       no_ospf6_default_information_originate_cmd,
+       "no default-route originate [{always|metric (0-16777214)|metric-type (1-2)|route-map WORD}]",
+       NO_STR
+       "Control distribution of default information\n"
+       "Distribute a default route\n"
+       "Always advertise default route\n"
+       "OSPFv3 default metric\n"
+       "OSPFv3 metric\n"
+       "OSPFv3 metric type for default routes\n"
+       "Set OSPFv3 External Type 1/2 metrics\n"
+       "Route map reference\n"
+       "Pointer to route-map entries\n")
+{
+	struct ospf6_redist *red;
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+
+	OSPF6_CMD_CHECK_RUNNING(ospf6);
+
+	red = ospf6_redist_lookup(ospf6, DEFAULT_ROUTE, 0);
+	if (!red)
+		return CMD_SUCCESS;
+
+	ospf6_asbr_routemap_unset(red);
+	ospf6_redist_del(ospf6, red, DEFAULT_ROUTE);
+
+	ospf6_redistribute_default_set(ospf6, DEFAULT_ORIGINATE_NONE);
+	return CMD_SUCCESS;
+}
 
 /* Routemap Functions */
 static enum route_map_cmd_result_t
@@ -2084,6 +2219,9 @@ void ospf6_asbr_init(void)
 
 	install_element(VIEW_NODE, &show_ipv6_ospf6_redistribute_cmd);
 
+	install_element(OSPF6_NODE, &ospf6_default_route_originate_cmd);
+	install_element(OSPF6_NODE,
+			&no_ospf6_default_information_originate_cmd);
 	install_element(OSPF6_NODE, &ospf6_redistribute_cmd);
 	install_element(OSPF6_NODE, &ospf6_redistribute_routemap_cmd);
 	install_element(OSPF6_NODE, &no_ospf6_redistribute_cmd);
@@ -2142,6 +2280,38 @@ int config_write_ospf6_debug_asbr(struct vty *vty)
 {
 	if (IS_OSPF6_DEBUG_ASBR)
 		vty_out(vty, "debug ospf6 asbr\n");
+	return 0;
+}
+
+int ospf6_distribute_config_write(struct vty *vty, struct ospf6 *ospf6)
+{
+	struct ospf6_redist *red;
+	if (ospf6) {
+		/* default-route print. */
+		if (ospf6->default_originate != DEFAULT_ORIGINATE_NONE) {
+			vty_out(vty, " default-route originate");
+			if (ospf6->default_originate
+			    == DEFAULT_ORIGINATE_ALWAYS)
+				vty_out(vty, " always");
+
+			red = ospf6_redist_lookup(ospf6, DEFAULT_ROUTE, 0);
+			if (red) {
+				if (red->dmetric.value >= 0)
+					vty_out(vty, " metric %d",
+						red->dmetric.value);
+
+				if (red->dmetric.type >= 0)
+					vty_out(vty, " metric-type %d",
+						red->dmetric.type);
+
+				if (ROUTEMAP_NAME(red))
+					vty_out(vty, " route-map %s",
+						ROUTEMAP_NAME(red));
+			}
+
+			vty_out(vty, "\n");
+		}
+	}
 	return 0;
 }
 

--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -97,6 +97,7 @@ extern void ospf6_asbr_terminate(void);
 extern void ospf6_asbr_send_externals_to_area(struct ospf6_area *);
 
 extern int config_write_ospf6_debug_asbr(struct vty *vty);
+extern int ospf6_distribute_config_write(struct vty *vty, struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_asbr(void);
 extern void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 					      struct ospf6_route *route,

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -34,6 +34,8 @@
 #include "ospf6_lsa.h"
 #include "ospf6_lsdb.h"
 #include "ospf6_message.h"
+#include "ospf6_asbr.h"
+#include "ospf6_zebra.h"
 
 #include "ospf6_top.h"
 #include "ospf6_area.h"
@@ -157,6 +159,34 @@ uint8_t ospf6_lstype_debug(uint16_t type)
 	const struct ospf6_lsa_handler *handler;
 	handler = ospf6_get_lsa_handler(type);
 	return handler->lh_debug;
+}
+
+int metric_type(struct ospf6 *ospf6, int type, uint8_t instance)
+{
+	struct ospf6_redist *red;
+
+	red = ospf6_redist_lookup(ospf6, type, instance);
+
+	return ((!red || red->dmetric.type < 0) ? DEFAULT_METRIC_TYPE
+						: red->dmetric.type);
+}
+
+int metric_value(struct ospf6 *ospf6, int type, uint8_t instance)
+{
+	struct ospf6_redist *red;
+
+	red = ospf6_redist_lookup(ospf6, type, instance);
+	if (!red || red->dmetric.value < 0) {
+		if (type == DEFAULT_ROUTE) {
+			if (ospf6->default_originate == DEFAULT_ORIGINATE_ZEBRA)
+				return DEFAULT_DEFAULT_ORIGINATE_METRIC;
+			else
+				return DEFAULT_DEFAULT_ALWAYS_METRIC;
+		} else
+			return DEFAULT_DEFAULT_METRIC;
+	}
+
+	return red->dmetric.value;
 }
 
 /* RFC2328: Section 13.2 */

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -29,6 +29,12 @@
 #define OSPF6_LSA_DEBUG_EXAMIN    0x04
 #define OSPF6_LSA_DEBUG_FLOOD     0x08
 
+/* OSPF LSA Default metric values */
+#define DEFAULT_DEFAULT_METRIC 20
+#define DEFAULT_DEFAULT_ORIGINATE_METRIC 10
+#define DEFAULT_DEFAULT_ALWAYS_METRIC 1
+#define DEFAULT_METRIC_TYPE 2
+
 #define IS_OSPF6_DEBUG_LSA(name)                                               \
 	(ospf6_lstype_debug(htons(OSPF6_LSTYPE_##name)) & OSPF6_LSA_DEBUG)
 #define IS_OSPF6_DEBUG_ORIGINATE(name)                                         \
@@ -197,6 +203,8 @@ extern vector ospf6_lsa_handler_vector;
 extern const char *ospf6_lstype_name(uint16_t type);
 extern const char *ospf6_lstype_short_name(uint16_t type);
 extern uint8_t ospf6_lstype_debug(uint16_t type);
+extern int metric_type(struct ospf6 *ospf6, int type, uint8_t instance);
+extern int metric_value(struct ospf6 *ospf6, int type, uint8_t instance);
 extern int ospf6_lsa_is_differ(struct ospf6_lsa *lsa1, struct ospf6_lsa *lsa2);
 extern int ospf6_lsa_is_changed(struct ospf6_lsa *lsa1, struct ospf6_lsa *lsa2);
 extern uint16_t ospf6_lsa_age_current(struct ospf6_lsa *);

--- a/ospf6d/ospf6_spf.h
+++ b/ospf6d/ospf6_spf.h
@@ -89,6 +89,7 @@ struct ospf6_vertex {
 #define OSPF6_SPF_FLAGS_ROUTER_LSA_ORIGINATED    (1 << 6)
 #define OSPF6_SPF_FLAGS_NETWORK_LSA_ORIGINATED   (1 << 7)
 #define OSPF6_SPF_FLAGS_CONFIG_CHANGE            (1 << 8)
+#define OSPF6_SPF_FLAGS_ASBR_STATUS_CHANGE       (1 << 9)
 
 static inline void ospf6_set_spf_reason(struct ospf6 *ospf, unsigned int reason)
 {

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -245,6 +245,7 @@ static struct ospf6 *ospf6_create(const char *name)
 	o->spf_max_holdtime = OSPF_SPF_MAX_HOLDTIME_DEFAULT;
 	o->spf_hold_multiplier = 1;
 
+	o->default_originate = DEFAULT_ORIGINATE_NONE;
 	/* LSA timers value init */
 	o->lsa_minarrival = OSPF_MIN_LS_ARRIVAL;
 
@@ -1327,6 +1328,7 @@ static int config_write_ospf6(struct vty *vty)
 		ospf6_area_config_write(vty, ospf6);
 		ospf6_spf_config_write(vty, ospf6);
 		ospf6_distance_config_write(vty, ospf6);
+		ospf6_distribute_config_write(vty, ospf6);
 
 		for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, j, oa)) {
 			for (ALL_LIST_ELEMENTS_RO(oa->if_list, k, oi))

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -246,6 +246,7 @@ static struct ospf6 *ospf6_create(const char *name)
 	o->spf_hold_multiplier = 1;
 
 	o->default_originate = DEFAULT_ORIGINATE_NONE;
+	o->redistribute = 0;
 	/* LSA timers value init */
 	o->lsa_minarrival = OSPF_MIN_LS_ARRIVAL;
 

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -40,6 +40,14 @@ enum {
 
 struct ospf6_redist {
 	uint8_t instance;
+
+	/* Redistribute metric info. */
+	struct {
+		int type;  /* External metric type (E1 or E2).  */
+		int value; /* Value for static metric (24-bit).
+			      -1 means metric value is not set. */
+	} dmetric;
+
 	/* For redistribute route map. */
 	struct {
 		char *name;
@@ -83,13 +91,16 @@ struct ospf6 {
 	uint32_t external_id;
 
 	/* OSPF6 redistribute configuration */
-	struct list *redist[ZEBRA_ROUTE_MAX];
+	struct list *redist[ZEBRA_ROUTE_MAX + 1];
 
 	uint8_t flag;
 
 	/* Configuration bitmask, refer to enum above */
 	uint8_t config_flags;
-
+	int default_originate; /* Default information originate. */
+#define DEFAULT_ORIGINATE_NONE 0
+#define DEFAULT_ORIGINATE_ZEBRA 1
+#define DEFAULT_ORIGINATE_ALWAYS 2
 	/* LSA timer parameters */
 	unsigned int lsa_minarrival; /* LSA minimum arrival in milliseconds. */
 

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -95,6 +95,8 @@ struct ospf6 {
 
 	uint8_t flag;
 
+	int redistribute; /* Num of redistributed protocols. */
+
 	/* Configuration bitmask, refer to enum above */
 	uint8_t config_flags;
 	int default_originate; /* Default information originate. */
@@ -149,6 +151,7 @@ DECLARE_QOBJ_TYPE(ospf6)
 
 #define OSPF6_DISABLED    0x01
 #define OSPF6_STUB_ROUTER 0x02
+#define OSPF6_FLAG_ASBR   0x03
 
 /* global pointer for OSPF top data structure */
 extern struct ospf6 *ospf6;

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -23,6 +23,8 @@
 
 #include "zclient.h"
 
+#define DEFAULT_ROUTE ZEBRA_ROUTE_MAX
+
 /* Debug option */
 extern unsigned char conf_debug_ospf6_zebra;
 #define OSPF6_DEBUG_ZEBRA_SEND 0x01

--- a/ospf6d/ospf6d.h
+++ b/ospf6d/ospf6d.h
@@ -94,6 +94,7 @@ extern struct thread_master *master;
 		return CMD_SUCCESS;                                            \
 	}
 
+#define IS_OSPF6_ASBR(O) ((O)->flag & OSPF6_FLAG_ASBR)
 extern struct zebra_privs_t ospf6d_privs;
 
 /* Function Prototypes */

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -83,3 +83,6 @@ ospf6d_ospf6d_snmp_la_SOURCES = ospf6d/ospf6_snmp.c
 ospf6d_ospf6d_snmp_la_CFLAGS = $(WERROR) $(SNMP_CFLAGS) -std=gnu99
 ospf6d_ospf6d_snmp_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
 ospf6d_ospf6d_snmp_la_LIBADD = lib/libfrrsnmp.la
+
+ospf6d/ospf6_asbr_clippy.c: $(CLIPPY_DEPS)
+ospf6d/ospf6_asbr.$(OBJEXT): ospf6d/ospf6_asbr_clippy.c


### PR DESCRIPTION
Added default route functionality. Changed some logic of how metric values are assigned.
If metric values are not specified and route-map does not match then metric-type will be
E2 and metric value will be 1 for the default route. 

Signed-off-by: Yash Ranjan <ranjany@vmware.com>