### PR TITLE
ospfd: Debug race condition in Segment Routing

### DIFF
--- a/ospfd/ospf_sr.h
+++ b/ospfd/ospf_sr.h
@@ -233,9 +233,6 @@ struct ospf_sr_db {
 	/* List of neighbour SR nodes */
 	struct hash *neighbors;
 
-	/* List of SR prefix */
-	struct route_table *prefix;
-
 	/* Local SR info announced in Router Info LSA */
 
 	/* Algorithms supported by the node */

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -541,9 +541,6 @@ void ospf_zebra_update_prefix_sid(const struct sr_prefix *srp)
 	struct listnode *node;
 	struct ospf_path *path;
 
-	osr_debug("SR (%s): Update Labels %u for Prefix %pFX", __func__,
-		  srp->label_in, (struct prefix *)&srp->prefv4);
-
 	/* Prepare message. */
 	memset(&zl, 0, sizeof(zl));
 	zl.type = ZEBRA_LSP_OSPF_SR;
@@ -557,6 +554,11 @@ void ospf_zebra_update_prefix_sid(const struct sr_prefix *srp)
 		znh->ifindex = srp->nhlfe.ifindex;
 		znh->label_num = 1;
 		znh->labels[0] = srp->nhlfe.label_out;
+
+		osr_debug("SR (%s): Configure Prefix %pFX with labels %u/%u",
+			  __func__, (struct prefix *)&srp->prefv4,
+			  srp->label_in, srp->nhlfe.label_out);
+
 		break;
 
 	case PREF_SID:
@@ -572,6 +574,10 @@ void ospf_zebra_update_prefix_sid(const struct sr_prefix *srp)
 		if (srp->route == NULL) {
 			return;
 		}
+
+		osr_debug("SR (%s): Configure Prefix %pFX with",
+			  __func__, (struct prefix *)&srp->prefv4);
+
 		for (ALL_LIST_ELEMENTS_RO(srp->route->paths, node, path)) {
 			if (path->srni.label_out == MPLS_INVALID_LABEL)
 				continue;
@@ -614,6 +620,9 @@ void ospf_zebra_update_prefix_sid(const struct sr_prefix *srp)
 			znh->ifindex = path->ifindex;
 			znh->label_num = 1;
 			znh->labels[0] = path->srni.label_out;
+
+			osr_debug("  |- labels %u/%u", srp->label_in,
+				  srp->nhlfe.label_out);
 
 			/* Set TI-LFA backup nexthop info if present */
 			if (path->srni.backup_label_stack) {


### PR DESCRIPTION
Issue #7926 hilight a race condition in Segment Routing processing.

The problem occurs when Router Information Opaque LSA is received late, in
particular after SPF run and after ospf_sr_nhlfe_update() was called. This
scenario is unfrequent and takes place due to a slow DR election.
In this particular case, SR Prefix are handle but not fully fill. In fact,
SRGB for the nexthop is not yet received and thus, output label could not
be computed.

When Router Information Opaque LSA is received and processed, if the
corresponding SR node is a direct neighbor of the self node, update_out_nhlfe()
is called against all SR nodes to adjust SR prefix if the next hop is the new
SR node. The function wrongly computes output label and configure a bad MPLS
LFIB entries.

Another way to hilight the problem is to change through CLI the SRGB of a node
and look to MPLS LFIB of direct neighbor, in particular those who announce
EXPLICIT NULL Prefix SID.

This patch correct the update_out_nhlfe() function by calling the appropriate
function (sr_prefix_out_label() instead of index2label()) to compute the output
label. Some log debugs were adjusted too.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>