### PR TITLE
bgpd: Print IPv4 nexthop for IPv6 prefixes under bgp_table_map_apply()

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -953,8 +953,11 @@ static bool bgp_table_map_apply(struct route_map *map, const struct prefix *p,
 			zlog_debug(
 				"Zebra rmap deny: IPv6 route %pFX nexthop %s",
 				p,
-				inet_ntop(AF_INET6, nexthop, buf[1],
-					  sizeof(buf[1])));
+				nexthop ? inet_ntop(AF_INET6, nexthop, buf[1],
+						    sizeof(buf[1]))
+					: inet_ntop(AF_INET,
+						    &path->attr->nexthop,
+						    buf[1], sizeof(buf[1])));
 		}
 	}
 	return false;


### PR DESCRIPTION
With latest kernels that's possible to have IPv6 routes with IPv4 nexthops.

We already handled this in bgp_zebra_announce():

	nexthop = bgp_path_info_to_ipv6_nexthop(mpinfo_cp,
						&ifindex);

	if (!nexthop)
		nh_updated = update_ipv4nh_for_route_install(
			nh_othervrf,
			nh_othervrf ? info->extra->bgp_orig
				    : bgp,
			&mpinfo_cp->attr->nexthop,
			mpinfo_cp->attr, is_evpn, api_nh);
	else
		nh_updated = update_ipv6nh_for_route_install(
			nh_othervrf,
			nh_othervrf ? info->extra->bgp_orig
				    : bgp,
			nexthop, ifindex, mpinfo, info, is_evpn,
			api_nh);

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>