### PR TITLE
[WIP] ospf6d: display LA-bit option in intra-area LSA

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -43,6 +43,7 @@
 #include "ospf6d.h"
 #include "ospf6_bfd.h"
 #include "ospf6_zebra.h"
+#include "ospf6_proto.h"
 #include "lib/json.h"
 
 DEFINE_MTYPE_STATIC(OSPF6D, CFG_PLIST_NAME, "configured prefix list names")
@@ -460,6 +461,9 @@ void ospf6_interface_connected_route_update(struct interface *ifp)
 		route->path.area_id = oi->area->area_id;
 		route->path.type = OSPF6_PATH_TYPE_INTRA;
 		route->path.cost = oi->cost;
+		if (oi->type == OSPF_IFTYPE_LOOPBACK)
+			SET_FLAG(route->path.prefix_options,
+				 OSPF6_PREFIX_OPTION_LA);
 		inet_pton(AF_INET6, "::1", &nh_addr);
 		ospf6_route_add_nexthop(route, oi->interface->ifindex,
 					&nh_addr);


### PR DESCRIPTION
Update 'show ipv6 ospf6 database intra-prefix detail' to display the 'LA'
prefix option - to indicate local-address for loopback interface routes.

Signed-off-by: Karen Schoener <karen@voltanet.io>