### PR TITLE
[7.5]bgpd: When deleting a neighbor from a peer-group the PGNAME is optional

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -4429,7 +4429,7 @@ ALIAS_HIDDEN(neighbor_set_peer_group, neighbor_set_peer_group_hidden_cmd,
 
 DEFUN (no_neighbor_set_peer_group,
        no_neighbor_set_peer_group_cmd,
-       "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group PGNAME",
+       "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group [PGNAME]",
        NO_STR
        NEIGHBOR_STR
        NEIGHBOR_ADDR_STR2
@@ -4438,20 +4438,12 @@ DEFUN (no_neighbor_set_peer_group,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int idx_peer = 2;
-	int idx_word = 4;
 	int ret;
 	struct peer *peer;
-	struct peer_group *group;
 
 	peer = peer_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
-
-	group = peer_group_lookup(bgp, argv[idx_word]->arg);
-	if (!group) {
-		vty_out(vty, "%% Configure the peer-group first\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
 
 	if (CHECK_FLAG(peer->flags, PEER_FLAG_CAPABILITY_ENHE))
 		bgp_zebra_terminate_radv(peer->bgp, peer);
@@ -4463,7 +4455,7 @@ DEFUN (no_neighbor_set_peer_group,
 }
 
 ALIAS_HIDDEN(no_neighbor_set_peer_group, no_neighbor_set_peer_group_hidden_cmd,
-	     "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group PGNAME",
+	     "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group [PGNAME]",
 	     NO_STR NEIGHBOR_STR NEIGHBOR_ADDR_STR2
 	     "Member of the peer-group\n"
 	     "Peer-group name\n")


### PR DESCRIPTION
Currently when deleting a neighbor from a peer-group:
no neighbor A.B.C.D peer-group FOO

We must specify FOO, while A.B.C.D is sufficient enough of an
identifier to know what to do.

Make PGNAME optional on this command and just delete the peer.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>