### PR TITLE
bgpd: When deleting a neighbor from a peer-group the PGNAME is optional

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5020,7 +5020,7 @@ ALIAS_HIDDEN(neighbor_set_peer_group, neighbor_set_peer_group_hidden_cmd,
 
 DEFUN_YANG (no_neighbor_set_peer_group,
 	    no_neighbor_set_peer_group_cmd,
-	    "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group PGNAME",
+	    "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group [PGNAME]",
 	    NO_STR
 	    NEIGHBOR_STR
 	    NEIGHBOR_ADDR_STR2
@@ -5041,7 +5041,7 @@ DEFUN_YANG (no_neighbor_set_peer_group,
 }
 
 ALIAS_HIDDEN(no_neighbor_set_peer_group, no_neighbor_set_peer_group_hidden_cmd,
-	     "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group PGNAME",
+	     "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group [PGNAME]",
 	     NO_STR NEIGHBOR_STR NEIGHBOR_ADDR_STR2
 	     "Member of the peer-group\n"
 	     "Peer-group name\n")


### PR DESCRIPTION
Currently when deleting a neighbor from a peer-group:
no neighbor A.B.C.D peer-group FOO

We must specify FOO, while A.B.C.D is sufficient enough of an
identifier to know what to do.

Make PGNAME optional on this command and just delete the peer.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>