### PR TITLE
bgpd: send correct BMP down message when nht fails

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -434,10 +434,19 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 		case PEER_DOWN_CLOSE_SESSION:
 			type = BMP_PEERDOWN_REMOTE_CLOSE;
 			break;
+		case PEER_DOWN_WAITING_NHT:
+			type = BMP_PEERDOWN_LOCAL_FSM;
+			stream_putw(s, BGP_FSM_TcpConnectionFails);
+			break;
+		/*
+		 * TODO: Map remaining PEER_DOWN_* reasons to RFC event codes.
+		 * TODO: Implement BMP_PEERDOWN_LOCAL_NOTIFY.
+		 *
+		 * See RFC7854 ss. 4.9
+		 */
 		default:
-			type = BMP_PEERDOWN_LOCAL_NOTIFY;
-			stream_put(s, peer->last_reset_cause,
-					peer->last_reset_cause_size);
+			type = BMP_PEERDOWN_LOCAL_FSM;
+			stream_putw(s, BMP_PEER_DOWN_NO_RELEVANT_EVENT_CODE);
 			break;
 		}
 		stream_putc_at(s, type_pos, type);

--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -269,6 +269,8 @@ struct bmp_bgp_peer {
 /* per struct bgp * data */
 PREDECL_HASH(bmp_bgph)
 
+#define BMP_PEER_DOWN_NO_RELEVANT_EVENT_CODE 0x00
+
 struct bmp_bgp {
 	struct bmp_bgph_item bbi;
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -921,7 +921,47 @@ struct bgp_peer_gr {
 	bgp_peer_gr_action_ptr action_fun;
 };
 
-/* BGP finite state machine events.  */
+/*
+ * BGP FSM event codes, per RFC 4271 ss. 8.1
+ */
+enum bgp_fsm_rfc_codes {
+	BGP_FSM_ManualStart = 1,
+	BGP_FSM_ManualStop = 2,
+	BGP_FSM_AutomaticStart = 3,
+	BGP_FSM_ManualStart_with_PassiveTcpEstablishment = 4,
+	BGP_FSM_AutomaticStart_with_PassiveTcpEstablishment = 5,
+	BGP_FSM_AutomaticStart_with_DampPeerOscillations = 6,
+	BGP_FSM_AutomaticStart_with_DampPeerOscillations_and_PassiveTcpEstablishment =
+		7,
+	BGP_FSM_AutomaticStop = 8,
+	BGP_FSM_ConnectRetryTimer_Expires = 9,
+	BGP_FSM_HoldTimer_Expires = 10,
+	BGP_FSM_KeepaliveTimer_Expires = 11,
+	BGP_FSM_DelayOpenTimer_Expires = 12,
+	BGP_FSM_IdleHoldTimer_Expires = 13,
+	BGP_FSM_TcpConnection_Valid = 14,
+	BGP_FSM_Tcp_CR_Invalid = 15,
+	BGP_FSM_Tcp_CR_Acked = 16,
+	BGP_FSM_TcpConnectionConfirmed = 17,
+	BGP_FSM_TcpConnectionFails = 18,
+	BGP_FSM_BGPOpen = 19,
+	BGP_FSM_BGPOpen_with_DelayOpenTimer_running = 20,
+	BGP_FSM_BGPHeaderErr = 21,
+	BGP_FSM_BGPOpenMsgErr = 22,
+	BGP_FSM_OpenCollisionDump = 23,
+	BGP_FSM_NotifMsgVerErr = 24,
+	BGP_FSM_NotifMsg = 25,
+	BGP_FSM_KeepAliveMsg = 26,
+	BGP_FSM_UpdateMsg = 27,
+	BGP_FSM_UpdateMsgErr = 28
+};
+
+/*
+ * BGP finite state machine events
+ *
+ * Note: these do not correspond to RFC-defined event codes. Those are
+ * defined elsewhere.
+ */
 enum bgp_fsm_events {
 	BGP_Start = 1,
 	BGP_Stop,


### PR DESCRIPTION
When sending BMP messages for a status change event for a peer whose NHT
has failed, we were sending a Peer Down Reason Code of 1 (Local system
closed, NOTIFICATION follows) with no NOTIFICATION PDU (because there was
none). This is wrong. Also, the reason code of 1 is semantically off, it
should be 2 (Local system closed, FSM event follows).

This was causing BMP connections to die when we had a peer with an NHT failure, e.g. with OpenBMP:
```
2021-02-11T23:52:40.318266 | NOTICE   | parsePeerDownEventHdr | sock=23 : <redacted>: BGP peer down notification with reason code: 1
2021-02-11T23:52:40.318320 | WARN     | parseBgpHeader     | <redacted>: rtr=172.17.0.1: BGP message is being parsed is 0 but expected at least 19 in size
2021-02-11T23:52:40.318355 | ERROR    | handleDownEvent    | <redacted>: rtr=172.17.0.1: BGP message type is not a BGP notification, cannot parse the notification
2021-02-11T23:52:40.318437 | INFO     | ReadIncomingMsg    | 172.17.0.1: Caught: ERROR: Invalid BGP MSG for BMP down event, expected NOTIFICATION message.
```

This patch:

- adds definitions of all BGP FSM event codes per RFC4271
- changes the BMP reason code emitted when a peer changes state due to
  NHT failure to 2 and encodes FSM event 18 (TcpConnectionFails)
- changes the catch-all case where we have not yet
  implemented the appropriate BMP response to indicate reason code 2
  with FSM event 0 (no relevant Event code is defined).

These changes ought to prevent the BMP session from being torn down due
to an improperly formatted message.

Fixes: #6568 

Signed-off-by: Quentin Young <qlyoung@qlyoung.net>