### PR TITLE
BMP tracepoints

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -49,6 +49,7 @@
 #include "bgpd/bgp_fsm.h"
 #include "bgpd/bgp_updgrp.h"
 #include "bgpd/bgp_vty.h"
+#include "bgpd/bgp_trace.h"
 
 static void bmp_close(struct bmp *bmp);
 static struct bmp_bgp *bmp_bgp_find(struct bgp *bgp);
@@ -545,6 +546,8 @@ static int bmp_mirror_packet(struct peer *peer, uint8_t type, bgp_size_t size,
 	struct bmp_targets *bt;
 	struct bmp *bmp;
 
+	frrtrace(3, frr_bgp, bmp_mirror_packet, peer, type, packet);
+
 	gettimeofday(&tv, NULL);
 
 	if (type == BGP_MSG_OPEN) {
@@ -662,6 +665,8 @@ static int bmp_outgoing_packet(struct peer *peer, uint8_t type, bgp_size_t size,
 		struct stream *packet)
 {
 	if (type == BGP_MSG_OPEN) {
+		frrtrace(2, frr_bgp, bmp_update_saved_open, peer, packet);
+
 		struct bmp_bgp_peer *bbpeer = bmp_bgp_peer_get(peer);
 
 		XFREE(MTYPE_BMP_OPEN, bbpeer->open_tx);
@@ -676,6 +681,8 @@ static int bmp_outgoing_packet(struct peer *peer, uint8_t type, bgp_size_t size,
 static int bmp_peer_established(struct peer *peer)
 {
 	struct bmp_bgp *bmpbgp = bmp_bgp_find(peer->bgp);
+
+	frrtrace(1, frr_bgp, bmp_peer_status_changed, peer);
 
 	if (!bmpbgp)
 		return 0;
@@ -712,6 +719,8 @@ static int bmp_peer_backward(struct peer *peer)
 	struct bmp_bgp *bmpbgp = bmp_bgp_find(peer->bgp);
 	struct bmp_bgp_peer *bbpeer;
 
+	frrtrace(1, frr_bgp, bmp_peer_backward_transition, peer);
+
 	if (!bmpbgp)
 		return 0;
 
@@ -734,6 +743,8 @@ static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags)
 	struct stream *s, *s2;
 	iana_afi_t pkt_afi;
 	iana_safi_t pkt_safi;
+
+	frrtrace(3, frr_bgp, bmp_eor, afi, safi, flags);
 
 	s = stream_new(BGP_MAX_PACKET_SIZE);
 
@@ -1250,6 +1261,14 @@ static int bmp_process(struct bgp *bgp, afi_t afi, safi_t safi,
 	struct bmp_bgp *bmpbgp = bmp_bgp_find(peer->bgp);
 	struct bmp_targets *bt;
 	struct bmp *bmp;
+
+	if (frrtrace_enabled(frr_bgp, bmp_process)) {
+		char pfxprint[PREFIX2STR_BUFFER];
+
+		prefix2str(&bn->p, pfxprint, sizeof(pfxprint));
+		frrtrace(5, frr_bgp, bmp_process, peer, pfxprint, afi, safi,
+			 withdraw);
+	}
 
 	if (!bmpbgp)
 		return 0;

--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -43,7 +43,7 @@ TRACEPOINT_EVENT_CLASS(
 	packet_process,
 	TP_ARGS(struct peer *, peer, bgp_size_t, size),
 	TP_FIELDS(
-		ctf_string(peer, peer->host ? peer->host : "(unknown peer)")
+		ctf_string(peer, PEER_HOSTNAME(peer))
 	)
 )
 
@@ -65,7 +65,7 @@ TRACEPOINT_EVENT(
 	packet_read,
 	TP_ARGS(struct peer *, peer, struct stream *, pkt),
 	TP_FIELDS(
-		ctf_string(peer, peer->host ? peer->host : "(unknown peer)")
+		ctf_string(peer, PEER_HOSTNAME(peer))
 		ctf_sequence_hex(uint8_t, packet, pkt->data, size_t,
 				 STREAM_READABLE(pkt))
 	)
@@ -79,7 +79,7 @@ TRACEPOINT_EVENT(
 	TP_ARGS(struct peer *, peer, char *, pfx, uint32_t, addpath_id, afi_t,
 		afi, safi_t, safi, struct attr *, attr),
 	TP_FIELDS(
-		ctf_string(peer, peer->host ? peer->host : "(unknown peer)")
+		ctf_string(peer, PEER_HOSTNAME(peer))
 		ctf_string(prefix, pfx)
 		ctf_integer(uint32_t, addpath_id, addpath_id)
 		ctf_integer(afi_t, afi, afi)
@@ -96,7 +96,7 @@ TRACEPOINT_EVENT(
 	TP_ARGS(struct peer *, peer, char *, pfx, afi_t, afi, safi_t, safi,
 		const char *, result),
 	TP_FIELDS(
-		ctf_string(peer, peer->host ? peer->host : "(unknown peer)")
+		ctf_string(peer, PEER_HOSTNAME(peer))
 		ctf_string(prefix, pfx)
 		ctf_integer(afi_t, afi, afi)
 		ctf_integer(safi_t, safi, safi)
@@ -112,7 +112,7 @@ TRACEPOINT_EVENT(
 	TP_ARGS(struct peer *, peer, char *, pfx, afi_t, afi, safi_t, safi,
 		const char *, result),
 	TP_FIELDS(
-		ctf_string(peer, peer->host ? peer->host : "(unknown peer)")
+		ctf_string(peer, PEER_HOSTNAME(peer))
 		ctf_string(prefix, pfx)
 		ctf_integer(afi_t, afi, afi)
 		ctf_integer(safi_t, safi, safi)

--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -122,6 +122,102 @@ TRACEPOINT_EVENT(
 
 TRACEPOINT_LOGLEVEL(frr_bgp, output_filter, TRACE_INFO)
 
+/* BMP tracepoints */
+
+/* BMP mirrors a packet to all mirror-enabled targets */
+TRACEPOINT_EVENT(
+	frr_bgp,
+	bmp_mirror_packet,
+	TP_ARGS(struct peer *, peer, uint8_t, type, struct stream *, pkt),
+	TP_FIELDS(
+		ctf_string(peer, PEER_HOSTNAME(peer))
+		ctf_integer(uint8_t, type, type)
+		ctf_sequence_hex(uint8_t, packet, pkt->data, size_t,
+				 STREAM_READABLE(pkt))
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_bgp, bmp_mirror_packet, TRACE_INFO)
+
+
+/* BMP sends an EOR */
+TRACEPOINT_EVENT(
+	frr_bgp,
+	bmp_eor,
+	TP_ARGS(afi_t, afi, safi_t, safi, uint8_t, flags),
+	TP_FIELDS(
+		ctf_integer(afi_t, afi, afi)
+		ctf_integer(safi_t, safi, safi)
+		ctf_integer(uint8_t, flags, flags)
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_bgp, bmp_eor, TRACE_INFO)
+
+
+/* BMP updates its copy of the last OPEN a peer sent */
+TRACEPOINT_EVENT(
+	frr_bgp,
+	bmp_update_saved_open,
+	TP_ARGS(struct peer *, peer, struct stream *, pkt),
+	TP_FIELDS(
+		ctf_string(peer, PEER_HOSTNAME(peer))
+		ctf_sequence_hex(uint8_t, packet, pkt->data, size_t,
+				 STREAM_READABLE(pkt))
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_bgp, bmp_update_saved_open, TRACE_DEBUG)
+
+
+/* BMP is notified of a peer status change internally */
+TRACEPOINT_EVENT(
+	frr_bgp,
+	bmp_peer_status_changed,
+	TP_ARGS(struct peer *, peer),
+	TP_FIELDS(
+		ctf_string(peer, PEER_HOSTNAME(peer))
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_bgp, bmp_peer_status_changed, TRACE_DEBUG)
+
+
+/*
+ * BMP is notified that a peer has transitioned in the opposite direction of
+ * Established internally
+ */
+TRACEPOINT_EVENT(
+	frr_bgp,
+	bmp_peer_backward_transition,
+	TP_ARGS(struct peer *, peer),
+	TP_FIELDS(
+		ctf_string(peer, PEER_HOSTNAME(peer))
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_bgp, bmp_peer_backward, TRACE_DEBUG)
+
+
+/*
+ * BMP is hooked for a route process
+ */
+TRACEPOINT_EVENT(
+	frr_bgp,
+	bmp_process,
+	TP_ARGS(struct peer *, peer, char *, pfx, afi_t,
+		afi, safi_t, safi, bool, withdraw),
+	TP_FIELDS(
+		ctf_string(peer, PEER_HOSTNAME(peer))
+		ctf_string(prefix, pfx)
+		ctf_integer(afi_t, afi, afi)
+		ctf_integer(safi_t, safi, safi)
+		ctf_integer(bool, withdraw, withdraw)
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_bgp, bmp_process, TRACE_DEBUG)
+
 /* clang-format on */
 
 #include <lttng/tracepoint-event.h>

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -955,6 +955,8 @@ enum bgp_fsm_status {
 	BGP_STATUS_MAX,
 };
 
+#define PEER_HOSTNAME(peer) ((peer)->host ? (peer)->host : "(unknown peer)")
+
 /* BGP neighbor structure. */
 struct peer {
 	/* BGP structure.  */


### PR DESCRIPTION
Adds the following tracepoints:
- `frr_bgp:bmp_mirror_packet` (info)
- `frr_bgp:bmp_eor` (info)
- `frr_bgp:bmp_process` (info)
- `frr_bgp:bmp_update_saved_open` (debug)
- `frr_bgp:bmp_status_changed` (debug)
- `frr_bgp:bmp_peer_backward_transition` (debug)