### PR TITLE
lib: allow "show config running" command for non-transactional CLI

### DIFF
--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -1894,7 +1894,6 @@ void nb_cli_init(struct thread_master *tm)
 	if (frr_get_cli_mode() == FRR_CLI_TRANSACTIONAL) {
 		install_element(ENABLE_NODE, &config_exclusive_cmd);
 		install_element(ENABLE_NODE, &config_private_cmd);
-		install_element(ENABLE_NODE, &show_config_running_cmd);
 		install_element(ENABLE_NODE,
 				&show_config_compare_without_candidate_cmd);
 		install_element(ENABLE_NODE, &show_config_transaction_cmd);
@@ -1907,6 +1906,7 @@ void nb_cli_init(struct thread_master *tm)
 	}
 
 	/* Other commands. */
+	install_element(ENABLE_NODE, &show_config_running_cmd);
 	install_element(CONFIG_NODE, &yang_module_translator_load_cmd);
 	install_element(CONFIG_NODE, &yang_module_translator_unload_cmd);
 	install_element(ENABLE_NODE, &show_yang_operational_data_cmd);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2851,6 +2851,24 @@ DEFUN (vtysh_show_error_code,
 }
 
 /* Northbound. */
+DEFUN (show_config_running,
+       show_config_running_cmd,
+       "show configuration running\
+          [<json|xml> [translate WORD]]\
+          [with-defaults]" DAEMONS_LIST,
+       SHOW_STR
+       "Configuration information\n"
+       "Running configuration\n"
+       "Change output format to JSON\n"
+       "Change output format to XML\n"
+       "Translate output\n"
+       "YANG module translator\n"
+       "Show default values\n"
+       DAEMONS_STR)
+{
+	return show_one_daemon(vty, argv, argc - 1, argv[argc - 1]->text);
+}
+
 DEFUN (show_yang_operational_data,
        show_yang_operational_data_cmd,
        "show yang operational-data XPATH\
@@ -4564,6 +4582,7 @@ void vtysh_init_vty(void)
 	install_element(CONFIG_NODE, &vtysh_debug_memstats_cmd);
 
 	/* northbound */
+	install_element(ENABLE_NODE, &show_config_running_cmd);
 	install_element(ENABLE_NODE, &show_yang_operational_data_cmd);
 	install_element(ENABLE_NODE, &debug_nb_cmd);
 	install_element(CONFIG_NODE, &debug_nb_cmd);


### PR DESCRIPTION
This command doesn't rely on transactional CLI and works perfectly for
daemons converted to northbound configuration.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>