### PR TITLE
staticd: decouple operational and config VRF data

### DIFF
--- a/staticd/static_nb.c
+++ b/staticd/static_nb.c
@@ -27,6 +27,13 @@ const struct frr_yang_module_info frr_staticd_info = {
 	.name = "frr-staticd",
 	.nodes = {
 		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd",
+			.cbs = {
+				.create = routing_control_plane_protocols_control_plane_protocol_staticd_create,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list",
 			.cbs = {
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_create,

--- a/staticd/static_nb.h
+++ b/staticd/static_nb.h
@@ -21,6 +21,10 @@
 extern const struct frr_yang_module_info frr_staticd_info;
 
 /* Mandatory callbacks. */
+int routing_control_plane_protocols_control_plane_protocol_staticd_create(
+	struct nb_cb_create_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_destroy(
+	struct nb_cb_destroy_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_create(
 	struct nb_cb_create_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_destroy(

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -153,46 +153,42 @@ extern bool mpls_enabled;
 
 extern struct zebra_privs_t static_privs;
 
-void static_fixup_vrf_ids(struct static_vrf *svrf);
+extern void static_start_vrf(struct static_vrf *svrf);
+extern void static_stop_vrf(struct static_vrf *svrf);
+
+extern void static_fixup_vrf_ids(struct vrf *vrf);
 
 extern struct static_nexthop *
 static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
-		   struct static_vrf *svrf, static_types type,
-		   struct ipaddr *ipaddr, const char *ifname,
-		   const char *nh_vrf, uint32_t color);
+		   static_types type, struct ipaddr *ipaddr, const char *ifname,
+		   const char *nh_vrf_name, uint32_t color);
 extern void static_install_nexthop(struct route_node *rn,
 				   struct static_path *pn,
 				   struct static_nexthop *nh, safi_t safi,
-				   struct static_vrf *svrf, const char *ifname,
-				   static_types type, const char *nh_vrf);
+				   const char *ifname, static_types type,
+				   const char *nh_vrf_name);
 
 extern int static_delete_nexthop(struct route_node *rn, struct static_path *pn,
-				 safi_t safi, struct static_vrf *svrf,
-				 struct static_nexthop *nh);
-
-extern void static_cleanup_vrf_ids(struct static_vrf *disable_svrf);
-
-extern void static_install_intf_nh(struct interface *ifp);
+				 safi_t safi, struct static_nexthop *nh);
 
 extern void static_ifindex_update(struct interface *ifp, bool up);
 
 extern void static_install_path(struct route_node *rn, struct static_path *pn,
-				safi_t safi, struct static_vrf *svrf);
+				safi_t safi);
 
 extern struct route_node *static_add_route(afi_t afi, safi_t safi,
 					   struct prefix *p,
 					   struct prefix_ipv6 *src_p,
 					   struct static_vrf *svrf);
-extern void static_del_route(struct route_node *rn, safi_t safi,
-			     struct static_vrf *svrf);
+extern void static_del_route(struct route_node *rn, safi_t safi);
 
 extern struct static_path *static_add_path(struct route_node *rn,
 					   uint32_t table_id, uint8_t distance);
 extern void static_del_path(struct route_node *rn, struct static_path *pn,
-			    safi_t safi, struct static_vrf *svrf);
+			    safi_t safi);
 
 extern void static_get_nh_type(static_types stype, char *type, size_t size);
-extern bool static_add_nexthop_validate(struct static_vrf *svrf,
+extern bool static_add_nexthop_validate(const char *nh_vrf_name,
 					static_types type,
 					struct ipaddr *ipaddr);
 extern struct stable_info *static_get_stable_info(struct route_node *rn);

--- a/staticd/static_vrf.h
+++ b/staticd/static_vrf.h
@@ -20,8 +20,11 @@
 #ifndef __STATIC_VRF_H__
 #define __STATIC_VRF_H__
 
+extern struct list *static_vrf_list;
+
 struct static_vrf {
-	struct vrf *vrf;
+	char *name;
+	vrf_id_t vrf_id;
 
 	struct route_table *stable[AFI_MAX][SAFI_MAX];
 };
@@ -32,12 +35,13 @@ struct stable_info {
 	safi_t safi;
 };
 
-#define GET_STABLE_VRF_ID(info) info->svrf->vrf->vrf_id
+#define GET_STABLE_VRF_ID(info) info->svrf->vrf_id
 
 struct static_vrf *static_vrf_lookup_by_name(const char *vrf_name);
 struct static_vrf *static_vrf_lookup_by_id(vrf_id_t vrf_id);
 
-int static_vrf_has_config(struct static_vrf *svrf);
+struct static_vrf *static_vrf_get(const char *name);
+void static_vrf_destroy(struct static_vrf *svrf);
 
 void static_vrf_init(void);
 
@@ -45,5 +49,4 @@ struct route_table *static_vrf_static_table(afi_t afi, safi_t safi,
 					    struct static_vrf *svrf);
 extern void static_vrf_terminate(void);
 
-struct static_vrf *static_vty_get_unknown_vrf(const char *vrf_name);
 #endif

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -343,7 +343,7 @@ int static_config(struct vty *vty, struct static_vrf *svrf, afi_t afi,
 		return write;
 
 	snprintf(spacing, sizeof(spacing), "%s%s",
-		 (svrf->vrf->vrf_id == VRF_DEFAULT) ? "" : " ", cmd);
+		 (svrf->vrf_id == VRF_DEFAULT) ? "" : " ", cmd);
 
 	for (rn = route_top(stable); rn; rn = srcdest_route_next(rn)) {
 		si = static_route_info_from_rnode(rn);
@@ -415,8 +415,7 @@ int static_config(struct vty *vty, struct static_vrf *svrf, afi_t afi,
 							nh->snh_label.label,
 							buf, sizeof(buf), 0));
 
-				if (!strmatch(nh->nh_vrfname,
-					      info->svrf->vrf->name))
+				if (!strmatch(nh->nh_vrfname, info->svrf->name))
 					vty_out(vty, " nexthop-vrf %s",
 						nh->nh_vrfname);
 
@@ -424,9 +423,7 @@ int static_config(struct vty *vty, struct static_vrf *svrf, afi_t afi,
 				 * table ID from VRF overrides
 				 * configured
 				 */
-				if (pn->table_id
-				    && svrf->vrf->data.l.table_id
-					       == RT_TABLE_MAIN)
+				if (pn->table_id)
 					vty_out(vty, " table %u", pn->table_id);
 
 				if (nh->onlink)

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -84,14 +84,6 @@ static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 
 static int static_ifp_up(struct interface *ifp)
 {
-	if (if_is_vrf(ifp)) {
-		struct static_vrf *svrf = static_vrf_lookup_by_id(ifp->vrf_id);
-
-		static_fixup_vrf_ids(svrf);
-	}
-
-	/* Install any static reliant on this interface coming up */
-	static_install_intf_nh(ifp);
 	static_ifindex_update(ifp, true);
 
 	return 0;

--- a/yang/frr-staticd.yang
+++ b/yang/frr-staticd.yang
@@ -94,6 +94,7 @@ module frr-staticd {
           "This container is only valid for the 'staticd' routing
            protocol.";
       }
+      presence "Enables configuration of static routes";
       description
         "Support for a 'staticd' pseudo-protocol instance
          consists of a list of routes.";


### PR DESCRIPTION
Currently, staticd VRF configuration and NB layer stores pointers to
operational VRF data (struct vrf). This can lead to a crash, because
struct vrf can be deleted by the user, and all the pointers become stale.

This commits separates staticd configuration (struct static_vrf) and NB
layer from operational data (struct vrf) like it is done in other daemons.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>