### PR TITLE
ospfd: cleanup ospf_flood debugs

### DIFF
--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -458,11 +458,11 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
-			"%s:ospf_flood_through_interface(): considering int %s, INBR(%s), LSA[%s] AGE %u",
-			ospf_get_name(oi->ospf), IF_NAME(oi),
-			inbr ?
-			inet_ntop(AF_INET, &inbr->router_id, buf, sizeof(buf)) :
-			"NULL",
+			"%s: considering int %s (%s), INBR(%s), LSA[%s] AGE %u",
+			__func__, IF_NAME(oi), ospf_get_name(oi->ospf),
+			inbr ? inet_ntop(AF_INET, &inbr->router_id, buf,
+					 sizeof(buf))
+			     : "NULL",
 			dump_lsa_key(lsa), ntohs(lsa->data->ls_age));
 
 	if (!ospf_if_is_enable(oi))
@@ -483,8 +483,8 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 		onbr = rn->info;
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
-				"ospf_flood_through_interface(): considering nbr %pI4(%s) (%s)",
-				&onbr->router_id,
+				"%s: considering nbr %pI4 via %s (%s), state: %s",
+				__func__, &onbr->router_id, IF_NAME(oi),
 				ospf_get_name(oi->ospf),
 				lookup_msg(ospf_nsm_state_msg, onbr->state,
 					   NULL));
@@ -504,7 +504,10 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 		if (onbr->state < NSM_Full) {
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(
-					"ospf_flood_through_interface(): nbr adj is not Full");
+					"%s: adj to onbr %pI4 is not Full (%s)",
+					__func__, &onbr->router_id,
+					lookup_msg(ospf_nsm_state_msg,
+						   onbr->state, NULL));
 			ls_req = ospf_ls_request_lookup(onbr, lsa);
 			if (ls_req != NULL) {
 				int ret;
@@ -534,7 +537,11 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 			if (!CHECK_FLAG(onbr->options, OSPF_OPTION_O)) {
 				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 					zlog_debug(
-						"Skip this neighbor: Not Opaque-capable.");
+						"%s: Skipping neighbor %s via %s -- Not Opaque-capable.",
+						__func__, IF_NAME(oi),
+						inet_ntop(AF_INET,
+							  &onbr->router_id, buf,
+							  sizeof(buf)));
 				continue;
 			}
 		}
@@ -550,7 +557,11 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 					   &onbr->router_id)) {
 				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 					zlog_debug(
-						"Skip this neighbor: inbr == onbr");
+						"%s: Skipping neighbor %s via %s -- inbr == onbr.",
+						__func__, IF_NAME(oi),
+						inet_ntop(AF_INET,
+							  &inbr->router_id, buf,
+							  sizeof(buf)));
 				continue;
 			}
 		} else {
@@ -562,7 +573,11 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 					   &onbr->router_id)) {
 				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 					zlog_debug(
-						"Skip this neighbor: lsah->adv_router == onbr");
+						"%s: Skipping neighbor %s via %s -- lsah->adv_router == onbr.",
+						__func__, IF_NAME(oi),
+						inet_ntop(AF_INET,
+							  &onbr->router_id, buf,
+							  sizeof(buf)));
 				continue;
 			}
 		}
@@ -591,9 +606,9 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 		   received the LSA already. */
 		if (NBR_IS_DR(inbr) || NBR_IS_BDR(inbr)) {
 			if (IS_DEBUG_OSPF_NSSA)
-				zlog_debug(
-					"ospf_flood_through_interface(): DR/BDR NOT SEND to int %s",
-					IF_NAME(oi));
+				zlog_debug("%s: DR/BDR NOT SEND to int %s (%s)",
+					   __func__, IF_NAME(oi),
+					   ospf_get_name(oi->ospf));
 			return 1;
 		}
 
@@ -606,8 +621,9 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 		if (oi->state == ISM_Backup) {
 			if (IS_DEBUG_OSPF_NSSA)
 				zlog_debug(
-					"ospf_flood_through_interface(): ISM_Backup NOT SEND to int %s",
-					IF_NAME(oi));
+					"%s: ISM_Backup NOT SEND to int %s (%s)",
+					__func__, IF_NAME(oi),
+					ospf_get_name(oi->ospf));
 			return 1;
 		}
 	}
@@ -620,9 +636,8 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 	   value of MaxAge). */
 	/* XXX HASSO: Is this IS_DEBUG_OSPF_NSSA really correct? */
 	if (IS_DEBUG_OSPF_NSSA)
-		zlog_debug(
-			"ospf_flood_through_interface(): DR/BDR sending upd to int %s",
-			IF_NAME(oi));
+		zlog_debug("%s: DR/BDR sending upd to int %s (%s)", __func__,
+			   IF_NAME(oi), ospf_get_name(oi->ospf));
 
 	/*  RFC2328  Section 13.3
 	    On non-broadcast networks, separate	Link State Update


### PR DESCRIPTION
Replaces some hard-coded function names with __func__,
adds some additional references to neighbor/interface,
and cleans up some debug strings to be more readable.

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>