### PR TITLE
zebra: fix vni configuration in default vrf

### DIFF
--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -201,19 +201,6 @@ lib_vrf_zebra_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next(
 	struct nb_cb_get_next_args *args);
 int lib_vrf_zebra_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys(
 	struct nb_cb_get_keys_args *args);
-int lib_vrf_zebra_ribs_rib_create(struct nb_cb_create_args *args);
-int lib_vrf_zebra_ribs_rib_destroy(struct nb_cb_destroy_args *args);
-const void *lib_vrf_zebra_ribs_rib_get_next(struct nb_cb_get_next_args *args);
-int lib_vrf_zebra_ribs_rib_get_keys(struct nb_cb_get_keys_args *args);
-const void *
-lib_vrf_zebra_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args);
-const void *
-lib_vrf_zebra_ribs_rib_route_get_next(struct nb_cb_get_next_args *args);
-int lib_vrf_zebra_ribs_rib_route_get_keys(struct nb_cb_get_keys_args *args);
-const void *
-lib_vrf_zebra_ribs_rib_route_lookup_entry(struct nb_cb_lookup_entry_args *args);
-struct yang_data *
-lib_vrf_zebra_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args);
 const void *lib_vrf_zebra_ribs_rib_route_route_entry_get_next(
 	struct nb_cb_get_next_args *args);
 int lib_vrf_zebra_ribs_rib_route_route_entry_get_keys(

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2553,10 +2553,8 @@ DEFUN (default_vrf_vni_mapping,
        "VNI-ID\n"
        "Prefix routes only \n")
 {
-	int ret = 0;
-	char err[ERR_STR_SZ];
+	char xpath[XPATH_MAXLEN];
 	struct zebra_vrf *zvrf = NULL;
-	vni_t vni = strtoul(argv[1]->arg, NULL, 10);
 	int filter = 0;
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
@@ -2566,25 +2564,35 @@ DEFUN (default_vrf_vni_mapping,
 	if (argc == 3)
 		filter = 1;
 
-	ret = zebra_vxlan_process_vrf_vni_cmd(zvrf, vni, err, ERR_STR_SZ,
-					      filter, 1);
-	if (ret != 0) {
-		vty_out(vty, "%s\n", err);
-		return CMD_WARNING;
+	snprintf(xpath, sizeof(xpath), FRR_VRF_KEY_XPATH "/frr-zebra:zebra",
+		 VRF_DEFAULT_NAME);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+
+	snprintf(xpath, sizeof(xpath),
+		 FRR_VRF_KEY_XPATH "/frr-zebra:zebra/l3vni-id",
+		 VRF_DEFAULT_NAME);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, argv[1]->arg);
+
+	if (filter) {
+		snprintf(xpath, sizeof(xpath),
+			 FRR_VRF_KEY_XPATH "/frr-zebra:zebra/prefix-only",
+			 VRF_DEFAULT_NAME);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, "true");
 	}
 
-	return CMD_SUCCESS;
+	return nb_cli_apply_changes(vty, NULL);
 }
 
 DEFUN (no_default_vrf_vni_mapping,
        no_default_vrf_vni_mapping_cmd,
-       "no vni " CMD_VNI_RANGE,
+       "no vni " CMD_VNI_RANGE "[prefix-routes-only]",
        NO_STR
        "VNI corresponding to DEFAULT VRF\n"
-       "VNI-ID")
+       "VNI-ID\n"
+       "Prefix routes only \n")
 {
-	int ret = 0;
-	char err[ERR_STR_SZ];
+	char xpath[XPATH_MAXLEN];
+	int filter = 0;
 	vni_t vni = strtoul(argv[2]->arg, NULL, 10);
 	struct zebra_vrf *zvrf = NULL;
 
@@ -2592,13 +2600,32 @@ DEFUN (no_default_vrf_vni_mapping,
 	if (!zvrf)
 		return CMD_WARNING;
 
-	ret = zebra_vxlan_process_vrf_vni_cmd(zvrf, vni, err, ERR_STR_SZ, 0, 0);
-	if (ret != 0) {
-		vty_out(vty, "%s\n", err);
+	if (argc == 4)
+		filter = 1;
+
+	if (zvrf->l3vni != vni) {
+		vty_out(vty, "VNI %d doesn't exist in VRF: %s \n", vni,
+			zvrf->vrf->name);
 		return CMD_WARNING;
 	}
 
-	return CMD_SUCCESS;
+	snprintf(xpath, sizeof(xpath),
+		 FRR_VRF_KEY_XPATH "/frr-zebra:zebra/l3vni-id",
+		 VRF_DEFAULT_NAME);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, argv[2]->arg);
+
+	if (filter) {
+		snprintf(xpath, sizeof(xpath),
+			 FRR_VRF_KEY_XPATH "/frr-zebra:zebra/prefix-only",
+			 VRF_DEFAULT_NAME);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, "true");
+	}
+
+	snprintf(xpath, sizeof(xpath), FRR_VRF_KEY_XPATH "/frr-zebra:zebra",
+		 VRF_DEFAULT_NAME);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
 }
 
 DEFUN (vrf_vni_mapping,
@@ -2626,9 +2653,7 @@ DEFUN (vrf_vni_mapping,
 		nb_cli_enqueue_change(vty, "./frr-zebra:zebra/prefix-only",
 				      NB_OP_MODIFY, "true");
 
-	nb_cli_apply_changes(vty, NULL);
-
-	return CMD_SUCCESS;
+	return nb_cli_apply_changes(vty, NULL);
 }
 
 DEFUN (no_vrf_vni_mapping,
@@ -2665,9 +2690,7 @@ DEFUN (no_vrf_vni_mapping,
 
 	nb_cli_enqueue_change(vty, "./frr-zebra:zebra", NB_OP_DESTROY, NULL);
 
-	nb_cli_apply_changes(vty, NULL);
-
-	return CMD_SUCCESS;
+	return nb_cli_apply_changes(vty, NULL);
 }
 
 /* show vrf */


### PR DESCRIPTION
VNI configuration is done without NB layer in default VRF. It leads to
the following problems:

```
vtysh -c "conf" -c "vni 1"
vtysh -c "conf" -c "vrf default" -c "no vni"
```
Second command does nothing, because the NB node is not created by the
first command.

```
vtysh -c "conf" -c "vrf default" -c "vni 1"
vtysh -c "conf" -c "no vni 1"
```
Second command doesn't delete the NB node created by the first command.