### PR TITLE
*: remove tabs & newlines from log messages

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -693,7 +693,7 @@ interface_recalculate(struct interface *ifp)
 
     rc = resize_receive_buffer(mtu);
     if(rc < 0)
-        zlog_warn("couldn't resize receive buffer for interface %s (%d) (%d bytes).\n",
+        zlog_warn("couldn't resize receive buffer for interface %s (%d) (%d bytes).",
                   ifp->name, ifp->ifindex, mtu);
 
     memset(&mreq, 0, sizeof(mreq));

--- a/babeld/message.c
+++ b/babeld/message.c
@@ -643,7 +643,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
             return;
 
         rtt = MAX(0, local_waiting_us - remote_waiting_us);
-        debugf(BABEL_DEBUG_COMMON, "RTT to %s on %s sample result: %d us.\n",
+        debugf(BABEL_DEBUG_COMMON, "RTT to %s on %s sample result: %d us.",
                format_address(from), ifp->name, rtt);
 
         old_rttcost = neighbour_rttcost(neigh);

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5370,11 +5370,11 @@ int bgp_evpn_local_l3vni_add(vni_t l3vni, vrf_id_t vrf_id,
 		switch (ret) {
 		case BGP_ERR_AS_MISMATCH:
 			flog_err(EC_BGP_EVPN_AS_MISMATCH,
-				 "BGP is already running; AS is %u\n", as);
+				 "BGP is already running; AS is %u", as);
 			return -1;
 		case BGP_ERR_INSTANCE_MISMATCH:
 			flog_err(EC_BGP_EVPN_INSTANCE_MISMATCH,
-				 "BGP instance name and AS number mismatch\n");
+				 "BGP instance name and AS number mismatch");
 			return -1;
 		}
 

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -637,7 +637,7 @@ int bgp_flowspec_match_rules_fill(uint8_t *nlri_content, int len,
 			offset += ret;
 			break;
 		default:
-			flog_err(EC_LIB_DEVELOPMENT, "%s: unknown type %d\n",
+			flog_err(EC_LIB_DEVELOPMENT, "%s: unknown type %d",
 				 __func__, type);
 		}
 	}

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -1177,19 +1177,19 @@ static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 
 		if (!rfg->rt_export_list || !rfg->rfapi_import_table) {
 			vnc_zlog_debug_verbose(
-				"%s: VRF \"%s\" is missing RT import/export configuration.\n",
+				"%s: VRF \"%s\" is missing RT import/export configuration.",
 				__func__, rfg->name);
 			return;
 		}
 		if (!rfg->rd.prefixlen) {
 			vnc_zlog_debug_verbose(
-				"%s: VRF \"%s\" is missing RD configuration.\n",
+				"%s: VRF \"%s\" is missing RD configuration.",
 				__func__, rfg->name);
 			return;
 		}
 		if (rfg->label > MPLS_LABEL_MAX) {
 			vnc_zlog_debug_verbose(
-				"%s: VRF \"%s\" is missing default label configuration.\n",
+				"%s: VRF \"%s\" is missing default label configuration.",
 				__func__, rfg->name);
 			return;
 		}

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -167,7 +167,7 @@ static int process_p2p_hello(struct iih_info *iih)
 	if (adj) {
 		if (memcmp(iih->sys_id, adj->sysid, ISIS_SYS_ID_LEN)) {
 			zlog_debug(
-				"hello source and adjacency do not match, set adj down\n");
+				"hello source and adjacency do not match, set adj down");
 			isis_adj_state_change(&adj, ISIS_ADJ_DOWN,
 					      "adj do not exist");
 			return ISIS_OK;

--- a/lib/command_parse.y
+++ b/lib/command_parse.y
@@ -496,7 +496,7 @@ terminate_graph (CMD_YYLTYPE *locp, struct parser_ctx *ctx,
     zlog_err ("----------");
     while (ctx->docstr && ctx->docstr[1] != '\0')
       zlog_err ("%s", strsep(&ctx->docstr, "\n"));
-    zlog_err ("----------\n");
+    zlog_err ("----------");
   }
 
   graph_add_edge (finalnode, end_token_node);

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -1234,7 +1234,7 @@ void ls_dump_ted(struct ls_ted *ted)
 	/* Loop TED, start printing Node, then Attributes and finally Prefix */
 	frr_each(vertices, &ted->vertices, vertex) {
 		ls_vertex2msg(&msg, vertex);
-		zlog_debug("\tTed node (%s %pI4 %s)",
+		zlog_debug("    Ted node (%s %pI4 %s)",
 			   vertex->node->name[0] ? vertex->node->name
 						 : "no name node",
 			   &vertex->node->router_id,
@@ -1246,7 +1246,7 @@ void ls_dump_ted(struct ls_ted *ted)
 		for (ALL_LIST_ELEMENTS_RO(vertex->incoming_edges, lst_node,
 					  vertex_edge)) {
 			zlog_debug(
-				"\t\tinc edge key:%lldn attr key:%pI4 loc:(%pI4) rmt:(%pI4)",
+				"        inc edge key:%lldn attr key:%pI4 loc:(%pI4) rmt:(%pI4)",
 				vertex_edge->key,
 				&vertex_edge->attributes->adv.id.ip.addr,
 				&vertex_edge->attributes->standard.local,
@@ -1255,7 +1255,7 @@ void ls_dump_ted(struct ls_ted *ted)
 		for (ALL_LIST_ELEMENTS_RO(vertex->outgoing_edges, lst_node,
 					  vertex_edge)) {
 			zlog_debug(
-				"\t\tout edge key:%lld  attr key:%pI4  loc:(%pI4) rmt:(%pI4)",
+				"        out edge key:%lld  attr key:%pI4  loc:(%pI4) rmt:(%pI4)",
 				vertex_edge->key,
 				&vertex_edge->attributes->adv.id.ip.addr,
 				&vertex_edge->attributes->standard.local,
@@ -1264,7 +1264,7 @@ void ls_dump_ted(struct ls_ted *ted)
 	}
 	frr_each(edges, &ted->edges, edge) {
 		ls_edge2msg(&msg, edge);
-		zlog_debug("\tTed edge key:%lld src:%s dst:%s", edge->key,
+		zlog_debug("    Ted edge key:%lld src:%s dst:%s", edge->key,
 			   edge->source ? edge->source->node->name
 					: "no_source",
 			   edge->destination ? edge->destination->node->name
@@ -1273,7 +1273,7 @@ void ls_dump_ted(struct ls_ted *ted)
 	frr_each(subnets, &ted->subnets, subnet) {
 		ls_subnet2msg(&msg, subnet);
 		zlog_debug(
-			"\tTed subnet key:%pFX vertex:%pI4 pfx:%pFX",
+			"    Ted subnet key:%pFX vertex:%pI4 pfx:%pFX",
 			&subnet->key,
 			&subnet->vertex->node->adv.id.ip.addr,
 			&subnet->ls_pref->pref);

--- a/lib/stream.c
+++ b/lib/stream.c
@@ -57,7 +57,7 @@ DEFINE_MTYPE_STATIC(LIB, STREAM_FIFO, "Stream FIFO")
 #define STREAM_WARN_OFFSETS(S)                                                 \
 	do {                                                                   \
 		flog_warn(EC_LIB_STREAM,				       \
-			  "&(struct stream): %p, size: %lu, getp: %lu, endp: %lu\n", \
+			  "&(struct stream): %p, size: %lu, getp: %lu, endp: %lu", \
 			  (void *)(S), (unsigned long)(S)->size,	       \
 			  (unsigned long)(S)->getp, (unsigned long)(S)->endp); \
 		zlog_backtrace(LOG_WARNING);				       \
@@ -93,7 +93,7 @@ DEFINE_MTYPE_STATIC(LIB, STREAM_FIFO, "Stream FIFO")
 		if (((S)->endp + (Z)) > (S)->size) {                           \
 			flog_warn(                                             \
 				EC_LIB_STREAM,                                 \
-				"CHECK_SIZE: truncating requested size %lu\n", \
+				"CHECK_SIZE: truncating requested size %lu",   \
 				(unsigned long)(Z));                           \
 			STREAM_WARN_OFFSETS(S);                                \
 			(Z) = (S)->size - (S)->endp;                           \

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -1365,7 +1365,7 @@ static int thread_process_io_helper(struct thread_master *m,
 	if (!thread) {
 		if ((actual_state & (POLLHUP|POLLIN)) != POLLHUP)
 			flog_err(EC_LIB_NO_THREAD,
-				 "Attempting to process an I/O event but for fd: %d(%d) no thread to handle this!\n",
+				 "Attempting to process an I/O event but for fd: %d(%d) no thread to handle this!",
 				 m->handler.pfds[pos].fd, actual_state);
 		return 0;
 	}

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -675,12 +675,12 @@ int vrf_handler_create(struct vty *vty, const char *vrfname,
 	if (strlen(vrfname) > VRF_NAMSIZ) {
 		if (vty)
 			vty_out(vty,
-				"%% VRF name %s invalid: length exceeds %d bytes\n",
+				"%% VRF name %s invalid: length exceeds %d bytes",
 				vrfname, VRF_NAMSIZ);
 		else
 			flog_warn(
 				EC_LIB_VRF_LENGTH,
-				"%% VRF name %s invalid: length exceeds %d bytes\n",
+				"%% VRF name %s invalid: length exceeds %d bytes",
 				vrfname, VRF_NAMSIZ);
 		return CMD_WARNING_CONFIG_FAILED;
 	}

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1002,7 +1002,7 @@ static int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
 
 	if (cmd != ZEBRA_NHG_DEL && cmd != ZEBRA_NHG_ADD) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
-			 "%s: Specified zapi NHG command (%d) doesn't exist\n",
+			 "%s: Specified zapi NHG command (%d) doesn't exist",
 			 __func__, cmd);
 		return -1;
 	}
@@ -1010,7 +1010,7 @@ static int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
 	if (api_nhg->nexthop_num >= MULTIPATH_NUM ||
 	    api_nhg->backup_nexthop_num >= MULTIPATH_NUM) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
-			 "%s: zapi NHG encode with invalid input\n", __func__);
+			 "%s: zapi NHG encode with invalid input", __func__);
 		return -1;
 	}
 
@@ -1065,7 +1065,7 @@ int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 
 	if (api->type >= ZEBRA_ROUTE_MAX) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
-			 "%s: Specified route type (%u) is not a legal value\n",
+			 "%s: Specified route type (%u) is not a legal value",
 			 __func__, api->type);
 		return -1;
 	}
@@ -1077,7 +1077,7 @@ int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 
 	if (api->safi < SAFI_UNICAST || api->safi >= SAFI_MAX) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
-			 "%s: Specified route SAFI (%u) is not a legal value\n",
+			 "%s: Specified route SAFI (%u) is not a legal value",
 			 __func__, api->safi);
 		return -1;
 	}
@@ -1292,7 +1292,7 @@ int zapi_route_decode(struct stream *s, struct zapi_route *api)
 	STREAM_GETC(s, api->type);
 	if (api->type >= ZEBRA_ROUTE_MAX) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
-			 "%s: Specified route type: %d is not a legal value\n",
+			 "%s: Specified route type: %d is not a legal value",
 			 __func__, api->type);
 		return -1;
 	}
@@ -1303,7 +1303,7 @@ int zapi_route_decode(struct stream *s, struct zapi_route *api)
 	STREAM_GETC(s, api->safi);
 	if (api->safi < SAFI_UNICAST || api->safi >= SAFI_MAX) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
-			 "%s: Specified route SAFI (%u) is not a legal value\n",
+			 "%s: Specified route SAFI (%u) is not a legal value",
 			 __func__, api->safi);
 		return -1;
 	}
@@ -3304,7 +3304,7 @@ static void zclient_capability_decode(ZAPI_CALLBACK_ARGS)
 
 	if (vrf_backend < 0 || vrf_configure_backend(vrf_backend)) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
-			 "%s: Garbage VRF backend type: %d\n", __func__,
+			 "%s: Garbage VRF backend type: %d", __func__,
 			 vrf_backend);
 		goto stream_failure;
 	}

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -654,7 +654,7 @@ static int ospf6_spf_calculation_thread(struct thread *t)
 			   (long long)runtime.tv_usec);
 
 	zlog_info(
-		"SPF processing: # Areas: %d, SPF runtime: %lld sec %lld usec, Reason: %s\n",
+		"SPF processing: # Areas: %d, SPF runtime: %lld sec %lld usec, Reason: %s",
 		areas_processed, (long long)runtime.tv_sec,
 		(long long)runtime.tv_usec, rbuf);
 

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -517,7 +517,7 @@ struct ospf_external_aggr_rt *ospf_external_aggr_match(struct ospf *ospf,
 				struct ospf_external_aggr_rt *ag = node->info;
 
 				zlog_debug(
-					"%s: Matching aggregator found.prefix:%pI4/%d Aggregator %pI4/%d\n",
+					"%s: Matching aggregator found.prefix:%pI4/%d Aggregator %pI4/%d",
 					__func__, &p->prefix, p->prefixlen,
 					&ag->p.prefix, ag->p.prefixlen);
 			}
@@ -956,7 +956,7 @@ static void ospf_handle_external_aggr_update(struct ospf *ospf)
 	struct route_node *rn = NULL;
 
 	if (IS_DEBUG_OSPF(lsa, EXTNL_LSA_AGGR))
-		zlog_debug("%s: Process modified aggregators.\n", __func__);
+		zlog_debug("%s: Process modified aggregators.", __func__);
 
 	for (rn = route_top(ospf->rt_aggr_tbl); rn; rn = route_next(rn)) {
 		struct ospf_external_aggr_rt *aggr;
@@ -1047,7 +1047,7 @@ static int ospf_asbr_external_aggr_process(struct thread *thread)
 	operation = ospf->aggr_action;
 
 	if (IS_DEBUG_OSPF(lsa, EXTNL_LSA_AGGR))
-		zlog_debug("%s: operation:%d\n", __func__, operation);
+		zlog_debug("%s: operation:%d", __func__, operation);
 
 	switch (operation) {
 	case OSPF_ROUTE_AGGR_ADD:

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2645,7 +2645,7 @@ struct ospf_lsa *ospf_lsa_install(struct ospf *ospf, struct ospf_interface *oi,
 		} else {
 			if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 				zlog_debug(
-					"ospf_lsa_install() got an lsa with seq 0x80000000 that was not self originated. Ignoring\n");
+					"ospf_lsa_install() got an lsa with seq 0x80000000 that was not self originated. Ignoring");
 				ospf_lsa_header_dump(lsa->data);
 			}
 			return old;

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -1451,9 +1451,7 @@ static uint16_t show_vty_sr_range(struct vty *vty, struct tlv_header *tlvh)
 			GET_LABEL(ntohl(range->lower.value)));
 	} else {
 		zlog_debug(
-			"  Segment Routing %s Range TLV:\n"
-			"    Range Size = %d\n"
-			"    SID Label = %d\n\n",
+			"  Segment Routing %s Range TLV:  Range Size = %d  SID Label = %d",
 			ntohs(range->header.type) == RI_SR_TLV_SRGB_LABEL_RANGE
 				? "Global"
 				: "Local",
@@ -1476,8 +1474,7 @@ static uint16_t show_vty_sr_msd(struct vty *vty, struct tlv_header *tlvh)
 			msd->value);
 	} else {
 		zlog_debug(
-			"  Segment Routing MSD TLV:\n"
-			"    Node Maximum Stack Depth = %d\n",
+			"  Segment Routing MSD TLV:  Node Maximum Stack Depth = %d",
 			msd->value);
 	}
 

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -304,7 +304,7 @@ static void pbrms_vrf_update(struct pbr_map_sequence *pbrms,
 	if (pbrms->vrf_lookup
 	    && (strncmp(vrf_name, pbrms->vrf_name, sizeof(pbrms->vrf_name))
 		== 0)) {
-		DEBUGD(&pbr_dbg_map, "\tSeq %u uses vrf %s (%u), updating map",
+		DEBUGD(&pbr_dbg_map, "    Seq %u uses vrf %s (%u), updating map",
 		       pbrms->seqno, vrf_name, pbr_vrf_id(pbr_vrf));
 
 		pbr_map_check(pbrms, false);
@@ -666,7 +666,7 @@ void pbr_map_schedule_policy_from_nhg(const char *nh_group, bool installed)
 	RB_FOREACH (pbrm, pbr_map_entry_head, &pbr_maps) {
 		DEBUGD(&pbr_dbg_map, "%s: Looking at %s", __func__, pbrm->name);
 		for (ALL_LIST_ELEMENTS_RO(pbrm->seqnumbers, node, pbrms)) {
-			DEBUGD(&pbr_dbg_map, "\tNH Grp name: %s",
+			DEBUGD(&pbr_dbg_map, "    NH Grp name: %s",
 			       pbrms->nhgrp_name ?
 			       pbrms->nhgrp_name : pbrms->internal_nhg_name);
 
@@ -707,7 +707,7 @@ void pbr_map_policy_install(const char *name)
 
 		if (pbrm->valid && pbrms->nhs_installed
 		    && pbrm->incoming->count) {
-			DEBUGD(&pbr_dbg_map, "\tInstalling %s %u", pbrm->name,
+			DEBUGD(&pbr_dbg_map, "    Installing %s %u", pbrm->name,
 			       pbrms->seqno);
 			for (ALL_LIST_ELEMENTS_RO(pbrm->incoming, inode, pmi))
 				if (pbr_map_interface_is_valid(pmi))
@@ -861,7 +861,7 @@ void pbr_map_check(struct pbr_map_sequence *pbrms, bool changed)
 		DEBUGD(&pbr_dbg_map, "%s: Installing %s(%u) reason: %" PRIu64,
 		       __func__, pbrm->name, pbrms->seqno, pbrms->reason);
 		DEBUGD(&pbr_dbg_map,
-		       "\tSending PBR_MAP_POLICY_INSTALL event");
+		       "    Sending PBR_MAP_POLICY_INSTALL event");
 	} else {
 		install = false;
 		DEBUGD(&pbr_dbg_map, "%s: Removing %s(%u) reason: %" PRIu64,

--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -213,7 +213,7 @@ void pbr_nhgroup_add_cb(const char *name)
 	nhgc = nhgc_find(name);
 
 	if (!nhgc) {
-		DEBUGD(&pbr_dbg_nht, "%s: Could not find nhgc with name: %s\n",
+		DEBUGD(&pbr_dbg_nht, "%s: Could not find nhgc with name: %s",
 		       __func__, name);
 		return;
 	}
@@ -620,7 +620,7 @@ struct pbr_nexthop_group_cache *pbr_nht_add_group(const char *name)
 	nhgc = nhgc_find(name);
 
 	if (!nhgc) {
-		DEBUGD(&pbr_dbg_nht, "%s: Could not find nhgc with name: %s\n",
+		DEBUGD(&pbr_dbg_nht, "%s: Could not find nhgc with name: %s",
 		       __func__, name);
 		return NULL;
 	}
@@ -686,7 +686,7 @@ bool pbr_nht_nexthop_group_valid(const char *name)
 	pnhgc = hash_get(pbr_nhg_hash, &lookup, NULL);
 	if (!pnhgc)
 		return false;
-	DEBUGD(&pbr_dbg_nht, "%s: \t%d %d", __func__, pnhgc->valid,
+	DEBUGD(&pbr_dbg_nht, "%s:    %d %d", __func__, pnhgc->valid,
 	       pnhgc->installed);
 	if (pnhgc->valid && pnhgc->installed)
 		return true;
@@ -851,7 +851,7 @@ static void pbr_nht_individual_nexthop_update_lookup(struct hash_bucket *b,
 
 	pbr_nht_individual_nexthop_update(pnhc, pnhi);
 
-	DEBUGD(&pbr_dbg_nht, "\tFound %pFX: old: %d new: %d",
+	DEBUGD(&pbr_dbg_nht, "    Found %pFX: old: %d new: %d",
 	       &pnhi->nhr->prefix, old_valid, pnhc->valid);
 
 	if (pnhc->valid)
@@ -1102,7 +1102,7 @@ pbr_nht_individual_nexthop_interface_update_lookup(struct hash_bucket *b,
 
 	pbr_nht_individual_nexthop_update(pnhc, pnhi);
 
-	DEBUGD(&pbr_dbg_nht, "\tFound %s: old: %d new: %d", pnhi->ifp->name,
+	DEBUGD(&pbr_dbg_nht, "    Found %s: old: %d new: %d", pnhi->ifp->name,
 	       old_valid, pnhc->valid);
 
 	if (pnhc->valid)

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -266,7 +266,7 @@ static void route_add_helper(struct zapi_route *api, struct nexthop_group nhg,
 
 	api->prefix.family = install_afi;
 
-	DEBUGD(&pbr_dbg_zebra, "\tEncoding %pFX", &api->prefix);
+	DEBUGD(&pbr_dbg_zebra, "    Encoding %pFX", &api->prefix);
 
 	i = 0;
 	for (ALL_NEXTHOPS(nhg, nhop)) {
@@ -409,12 +409,12 @@ static int pbr_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
 		DEBUGD(&pbr_dbg_zebra, "%s: Received Nexthop update: %pFX",
 		       __func__, &nhr.prefix);
 
-		DEBUGD(&pbr_dbg_zebra, "%s: (\tNexthops(%u)", __func__,
+		DEBUGD(&pbr_dbg_zebra, "%s:   (Nexthops(%u)", __func__,
 		       nhr.nexthop_num);
 
 		for (i = 0; i < nhr.nexthop_num; i++) {
 			DEBUGD(&pbr_dbg_zebra,
-			       "%s: \tType: %d: vrf: %d, ifindex: %d gate: %pI4",
+			       "%s:     Type: %d: vrf: %d, ifindex: %d gate: %pI4",
 			       __func__, nhr.nexthops[i].type,
 			       nhr.nexthops[i].vrf_id, nhr.nexthops[i].ifindex,
 			       &nhr.nexthops[i].gate.ipv4);
@@ -585,7 +585,7 @@ bool pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 	 */
 	stream_putl(s, 1);
 
-	DEBUGD(&pbr_dbg_zebra, "%s: \t%s %s seq %u %d %s %u", __func__,
+	DEBUGD(&pbr_dbg_zebra, "%s:    %s %s seq %u %d %s %u", __func__,
 	       install ? "Installing" : "Deleting", pbrm->name, pbrms->seqno,
 	       install, pmi->ifp->name, pmi->delete);
 

--- a/pimd/pim_msdp_socket.c
+++ b/pimd/pim_msdp_socket.c
@@ -44,7 +44,7 @@ static void pim_msdp_update_sock_send_buffer_size(int fd)
 
 	if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &optval, &optlen) < 0) {
 		flog_err_sys(EC_LIB_SOCKET,
-			     "getsockopt of SO_SNDBUF failed %s\n",
+			     "getsockopt of SO_SNDBUF failed %s",
 			     safe_strerror(errno));
 		return;
 	}
@@ -53,7 +53,7 @@ static void pim_msdp_update_sock_send_buffer_size(int fd)
 		if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size))
 		    < 0) {
 			flog_err_sys(EC_LIB_SOCKET,
-				     "Couldn't increase send buffer: %s\n",
+				     "Couldn't increase send buffer: %s",
 				     safe_strerror(errno));
 		}
 	}

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -242,7 +242,7 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
 	if (!rn) {
 		flog_err(
 			EC_LIB_DEVELOPMENT,
-			"%s: BUG We should have found default group information\n",
+			"%s: BUG We should have found default group information",
 			__func__);
 		return best;
 	}

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -854,7 +854,7 @@ static int vrrp_recv_advertisement(struct vrrp_router *r, struct ipaddr *src,
 	vrrp_pkt_adver_dump(dumpbuf, sizeof(dumpbuf), pkt);
 	DEBUGD(&vrrp_dbg_proto,
 	       VRRP_LOGPFX VRRP_LOGPFX_VRID VRRP_LOGPFX_FAM
-	       "Received VRRP Advertisement from %s:\n%s",
+	       "Received VRRP Advertisement from %s: %s",
 	       r->vr->vrid, family2str(r->family), sipstr, dumpbuf);
 
 	/* Check that VRID matches our configured VRID */

--- a/vrrpd/vrrp_arp.c
+++ b/vrrpd/vrrp_arp.c
@@ -170,7 +170,7 @@ void vrrp_garp_send_all(struct vrrp_router *r)
 	if (ifp->flags & IFF_NOARP) {
 		zlog_warn(
 			VRRP_LOGPFX VRRP_LOGPFX_VRID VRRP_LOGPFX_FAM
-			"Unable to send gratuitous ARP on %s; has IFF_NOARP\n",
+			"Unable to send gratuitous ARP on %s; has IFF_NOARP",
 			r->vr->vrid, family2str(r->family), ifp->name);
 		return;
 	}

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1029,7 +1029,7 @@ void if_up(struct interface *ifp)
 	/* Notify the protocol daemons. */
 	if (ifp->ptm_enable && (ifp->ptm_status == ZEBRA_PTM_STATUS_DOWN)) {
 		flog_warn(EC_ZEBRA_PTM_NOT_READY,
-			  "%s: interface %s hasn't passed ptm check\n",
+			  "%s: interface %s hasn't passed ptm check",
 			  __func__, ifp->name);
 		return;
 	}
@@ -2977,7 +2977,7 @@ int if_ip_address_install(struct interface *ifp, struct prefix *prefix,
 		dplane_res = dplane_intf_addr_set(ifp, ifc);
 		if (dplane_res == ZEBRA_DPLANE_REQUEST_FAILURE) {
 			zlog_debug(
-				"dplane can't set interface IP address: %s.\n",
+				"dplane can't set interface IP address: %s.",
 				dplane_res2str(dplane_res));
 			return NB_ERR;
 		}
@@ -3095,7 +3095,7 @@ int if_ip_address_uinstall(struct interface *ifp, struct prefix *prefix)
 		/* Check current interface address. */
 		ifc = connected_check_ptp(ifp, prefix, NULL);
 		if (!ifc) {
-			zlog_debug("interface %s Can't find address\n",
+			zlog_debug("interface %s Can't find address",
 				   ifp->name);
 			return -1;
 		}
@@ -3106,7 +3106,7 @@ int if_ip_address_uinstall(struct interface *ifp, struct prefix *prefix)
 	}
 
 	if (!ifc) {
-		zlog_debug("interface %s Can't find address\n", ifp->name);
+		zlog_debug("interface %s Can't find address", ifp->name);
 		return -1;
 	}
 	UNSET_FLAG(ifc->conf, ZEBRA_IFC_CONFIGURED);
@@ -3122,7 +3122,7 @@ int if_ip_address_uinstall(struct interface *ifp, struct prefix *prefix)
 	/* This is real route. */
 	dplane_res = dplane_intf_addr_unset(ifp, ifc);
 	if (dplane_res == ZEBRA_DPLANE_REQUEST_FAILURE) {
-		zlog_debug("Can't unset interface IP address: %s.\n",
+		zlog_debug("Can't unset interface IP address: %s.",
 			   dplane_res2str(dplane_res));
 		return -1;
 	}
@@ -3335,7 +3335,7 @@ int if_ipv6_address_install(struct interface *ifp, struct prefix *prefix,
 		dplane_res = dplane_intf_addr_set(ifp, ifc);
 		if (dplane_res == ZEBRA_DPLANE_REQUEST_FAILURE) {
 			zlog_debug(
-				"dplane can't set interface IP address: %s.\n",
+				"dplane can't set interface IP address: %s.",
 				dplane_res2str(dplane_res));
 			return NB_ERR;
 		}

--- a/zebra/irdp_packet.c
+++ b/zebra/irdp_packet.c
@@ -105,7 +105,7 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 
 	if (iplen < ICMP_MINLEN) {
 		flog_err(EC_ZEBRA_IRDP_LEN_MISMATCH,
-			 "IRDP: RX ICMP packet too short from %pI4\n",
+			 "IRDP: RX ICMP packet too short from %pI4",
 			 &src);
 		return;
 	}
@@ -116,7 +116,7 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	 len of IP-header) 14+20 */
 	if (iplen > IRDP_RX_BUF - 34) {
 		flog_err(EC_ZEBRA_IRDP_LEN_MISMATCH,
-			 "IRDP: RX ICMP packet too long from %pI4\n",
+			 "IRDP: RX ICMP packet too long from %pI4",
 			 &src);
 		return;
 	}
@@ -153,7 +153,7 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 		&& !(irdp->flags & IF_BROADCAST))) {
 		flog_warn(
 			EC_ZEBRA_IRDP_BAD_RX_FLAGS,
-			"IRDP: RX illegal from %pI4 to %s while %s operates in %s; Please correct settings\n",
+			"IRDP: RX illegal from %pI4 to %s while %s operates in %s; Please correct settings",
 			&src,
 			ntohl(ip->ip_dst.s_addr) == INADDR_ALLRTRS_GROUP
 				? "multicast"

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -383,7 +383,7 @@ static int netlink_information_fetch(struct nlmsghdr *h, ns_id_t ns_id,
 		 * it to be sent up to us
 		 */
 		flog_err(EC_ZEBRA_UNKNOWN_NLMSG,
-			 "Unknown netlink nlmsg_type %s(%d) vrf %u\n",
+			 "Unknown netlink nlmsg_type %s(%d) vrf %u",
 			 nl_msg_type_to_str(h->nlmsg_type), h->nlmsg_type,
 			 ns_id);
 		break;
@@ -485,7 +485,7 @@ static void netlink_install_filter(int sock, __u32 pid, __u32 dplane_pid)
 
 	if (setsockopt(sock, SOL_SOCKET, SO_ATTACH_FILTER, &prog, sizeof(prog))
 	    < 0)
-		flog_err_sys(EC_LIB_SOCKET, "Can't install socket filter: %s\n",
+		flog_err_sys(EC_LIB_SOCKET, "Can't install socket filter: %s",
 			     safe_strerror(errno));
 }
 

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -206,7 +206,7 @@ void redistribute_update(const struct prefix *p, const struct prefix *src_p,
 	afi = family2afi(p->family);
 	if (!afi) {
 		flog_warn(EC_ZEBRA_REDISTRIBUTE_UNKNOWN_AF,
-			  "%s: Unknown AFI/SAFI prefix received\n", __func__);
+			  "%s: Unknown AFI/SAFI prefix received", __func__);
 		return;
 	}
 	if (!zebra_check_addr(p)) {
@@ -276,7 +276,7 @@ void redistribute_delete(const struct prefix *p, const struct prefix *src_p,
 	afi = family2afi(p->family);
 	if (!afi) {
 		flog_warn(EC_ZEBRA_REDISTRIBUTE_UNKNOWN_AF,
-			  "%s: Unknown AFI/SAFI prefix received\n",
+			  "%s: Unknown AFI/SAFI prefix received",
 			  __func__);
 		return;
 	}

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3343,7 +3343,7 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 		netlink_handle_5549(ndm, zif, ifp, &ip, false);
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
-				"\tNeighbor Entry Received is a 5549 entry, finished");
+				"    Neighbor Entry Received is a 5549 entry, finished");
 		return 0;
 	}
 
@@ -3372,7 +3372,7 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	else {
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
-				"\tNeighbor Entry received is not on a VLAN or a BRIDGE, ignoring");
+				"    Neighbor Entry received is not on a VLAN or a BRIDGE, ignoring");
 		return 0;
 	}
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1146,7 +1146,7 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 		} else {
 			flog_err(
 				EC_ZEBRA_UNKNOWN_FAMILY,
-				"rnh_register: Received unknown family type %d\n",
+				"rnh_register: Received unknown family type %d",
 				p.family);
 			return;
 		}
@@ -1237,7 +1237,7 @@ static void zread_rnh_unregister(ZAPI_HANDLER_ARGS)
 		} else {
 			flog_err(
 				EC_ZEBRA_UNKNOWN_FAMILY,
-				"rnh_register: Received unknown family type %d\n",
+				"rnh_register: Received unknown family type %d",
 				p.family);
 			return;
 		}
@@ -1287,7 +1287,7 @@ static void zread_fec_register(ZAPI_HANDLER_ARGS)
 		if (p.family != AF_INET && p.family != AF_INET6) {
 			flog_err(
 				EC_ZEBRA_UNKNOWN_FAMILY,
-				"fec_register: Received unknown family type %d\n",
+				"fec_register: Received unknown family type %d",
 				p.family);
 			return;
 		}
@@ -1353,7 +1353,7 @@ static void zread_fec_unregister(ZAPI_HANDLER_ARGS)
 		if (p.family != AF_INET && p.family != AF_INET6) {
 			flog_err(
 				EC_ZEBRA_UNKNOWN_FAMILY,
-				"fec_unregister: Received unknown family type %d\n",
+				"fec_unregister: Received unknown family type %d",
 				p.family);
 			return;
 		}

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -745,7 +745,7 @@ void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq)
 			if (rnh->seqno == seq) {
 				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 					zlog_debug(
-						"\tNode processed and moved already");
+						"    Node processed and moved already");
 				continue;
 			}
 

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1124,7 +1124,7 @@ int zebra_send_rnh_update(struct rnh *rnh, struct zserv *client,
 		break;
 	default:
 		flog_err(EC_ZEBRA_RNH_UNKNOWN_FAMILY,
-			 "%s: Unknown family (%d) notification attempted\n",
+			 "%s: Unknown family (%d) notification attempted",
 			 __func__, rn->p.family);
 		goto failure;
 	}

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3333,7 +3333,7 @@ int zebra_vxlan_clear_dup_detect_vni(struct zebra_vrf *zvrf, vni_t vni)
 
 	zevpn = zebra_evpn_lookup(vni);
 	if (!zevpn) {
-		zlog_warn("VNI %u does not exist\n", vni);
+		zlog_warn("VNI %u does not exist", vni);
 		return CMD_WARNING;
 	}
 


### PR DESCRIPTION
Neither tabs nor newlines are acceptable in syslog messages.  They also break line-based parsing of file logs.

`xrelfo.py` will warn about these when #6807 is merged.