### PR TITLE
ospf6d: ospf6_interface_delete crashes

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -823,7 +823,6 @@ DEFUN (no_ospf6_interface_area,
 
 	oa = oi->area;
 	listnode_delete(oi->area->if_list, oi);
-	oi->area = (struct ospf6_area *)NULL;
 
 	/* Withdraw inter-area routes from this area, if necessary */
 	if (oa->if_list->count == 0) {


### PR DESCRIPTION
ospf6_interface_delete crashes when called in the code flow of "no interface IFNAME area <A.B.C.D|(0-4294967295)>".
oi->area is set to NULL, but is further being used in ospf6_interface_delete.

Signed-off-by: Yash Ranjan <ranjany@vmware.com>