### PR TITLE
ospf6d: Json support added for command "show ipv6 ospf6 spf tree [json]"

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -229,6 +229,15 @@ Showing OSPF6 information
    Interface name can also be given. JSON output can be obtained by appending
    'json' to the end of command.
 
+.. index:: show ipv6 ospf6 spf tree [json]
+.. clicmd:: show ipv6 ospf6 spf tree [json]
+
+   This commands shows the spf tree from the recent spf calculation with the
+   calling router as the root. If json is appended in the end, we can get the
+   tree in JSON format. Each area that the router belongs to has it's own
+   JSON object, with each router having "cost", "isLeafNode" and "children" as
+   arguments.
+   
 OSPF6 Configuration Examples
 ============================
 

--- a/ospf6d/ospf6_spf.h
+++ b/ospf6d/ospf6_spf.h
@@ -23,6 +23,7 @@
 
 #include "typesafe.h"
 #include "ospf6_top.h"
+#include "lib/json.h"
 
 /* Debug option */
 extern unsigned char conf_debug_ospf6_spf;
@@ -147,7 +148,8 @@ extern void ospf6_spf_calculation(uint32_t router_id,
 extern void ospf6_spf_schedule(struct ospf6 *ospf, unsigned int reason);
 
 extern void ospf6_spf_display_subtree(struct vty *vty, const char *prefix,
-				      int rest, struct ospf6_vertex *v);
+				      int rest, struct ospf6_vertex *v,
+				      json_object *json_obj, bool use_json);
 
 extern void ospf6_spf_config_write(struct vty *vty, struct ospf6 *ospf6);
 extern int config_write_ospf6_debug_spf(struct vty *vty);


### PR DESCRIPTION
Modify code to add JSON format output in show command
"show ipv6 ospf6 spf tree" with proper formating
```
frr(config-ospf6)# do show ipv6 ospf6 spf tree 
+-10.10.10.180 [0]
   +-10.10.10.171 Net-ID: 0.0.0.8 [10]
   |  +-10.10.10.138 [10]
   |  |  +-10.10.10.181 Net-ID: 0.0.0.8 [20]
   |  +-10.10.10.171 [10]
   |  +-10.10.10.181 [10]
   +-10.10.10.171 Net-ID: 0.0.0.9 [10]
+-10.10.10.180 [0]
   +-10.10.10.138 [10]
frr(config-ospf6)# do show ipv6 ospf6 spf tree json
{
  "0.0.0.0":{                  <== Area ID
    "10.10.10.180":{        <== Router ID
      "cost":0,
      "isLeafNode":false,
      "childs":{
        "10.10.10.171 Net-ID: 0.0.0.8":{
          "cost":10,
          "isLeafNode":false,
          "childs":{
            "10.10.10.138":{
              "cost":10,
              "isLeafNode":false,
              "childs":{
                "10.10.10.181 Net-ID: 0.0.0.8":{
                  "cost":20,
                  "isLeafNode":true
                }
              }
            },
            "10.10.10.171":{
              "cost":10,
              "isLeafNode":true
            },
            "10.10.10.181":{
              "cost":10,
              "isLeafNode":true
            }
          }
        },
        "10.10.10.171 Net-ID: 0.0.0.9":{
          "cost":10,
          "isLeafNode":true
        }
      }
    }
  },
  "1.1.1.1":{
    "10.10.10.180":{
      "cost":0,
      "isLeafNode":false,
      "childs":{
        "10.10.10.138":{
          "cost":10,
          "isLeafNode":true
        }
      }
    }
  }
}
```

Signed-off-by: Yash Ranjan <ranjany@vmware.com>