### PR TITLE
isisd: configure SRGB and SRLB together

### DIFF
--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -364,17 +364,19 @@ Known limitations:
 
    Enable Segment Routing.
 
-.. clicmd:: segment-routing global-block (0-1048575) (0-1048575)
+.. clicmd:: segment-routing global-block (16-1048575) (16-1048575) [local-block (16-1048575) (16-1048575)]
 
    Set the Segment Routing Global Block i.e. the label range used by MPLS
    to store label in the MPLS FIB for Prefix SID. Note that the block size
-   may not exceed 65535.
+   may not exceed 65535. Optionally sets also the Segment Routing Local Block.
+   The negative command always unsets both.
 
-.. clicmd:: segment-routing local-block (0-1048575) (0-1048575)
+.. clicmd:: segment-routing local-block (16-1048575) (16-1048575)
 
    Set the Segment Routing Local Block i.e. the label range used by MPLS
    to store label in the MPLS FIB for Adjacency SID. Note that the block size
-   may not exceed 65535.
+   may not exceed 65535. This command is deprecated in favor of the combined
+   'segment-routing global-block A B local-block C D' command.
 
 .. clicmd:: segment-routing node-msd (1-16)
 

--- a/isisd/isis_nb.c
+++ b/isisd/isis_nb.c
@@ -573,41 +573,44 @@ const struct frr_yang_module_info frr_isisd_info = {
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/segment-routing/srgb",
+			.xpath = "/frr-isisd:isis/instance/segment-routing/label-blocks",
 			.cbs = {
-				.apply_finish = isis_instance_segment_routing_srgb_apply_finish,
-				.pre_validate = isis_instance_segment_routing_srgb_pre_validate,
-				.cli_show = cli_show_isis_srgb,
+				.pre_validate = isis_instance_segment_routing_label_blocks_pre_validate,
+				.cli_show = cli_show_isis_label_blocks,
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/segment-routing/srgb/lower-bound",
+			.xpath = "/frr-isisd:isis/instance/segment-routing/label-blocks/srgb",
+			.cbs = {
+				.apply_finish = isis_instance_segment_routing_srgb_apply_finish,
+			},
+		},
+		{
+			.xpath = "/frr-isisd:isis/instance/segment-routing/label-blocks/srgb/lower-bound",
 			.cbs = {
 				.modify = isis_instance_segment_routing_srgb_lower_bound_modify,
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/segment-routing/srgb/upper-bound",
+			.xpath = "/frr-isisd:isis/instance/segment-routing/label-blocks/srgb/upper-bound",
 			.cbs = {
 				.modify = isis_instance_segment_routing_srgb_upper_bound_modify,
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/segment-routing/srlb",
+			.xpath = "/frr-isisd:isis/instance/segment-routing/label-blocks/srlb",
 			.cbs = {
 				.apply_finish = isis_instance_segment_routing_srlb_apply_finish,
-				.pre_validate = isis_instance_segment_routing_srlb_pre_validate,
-				.cli_show = cli_show_isis_srlb,
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/segment-routing/srlb/lower-bound",
+			.xpath = "/frr-isisd:isis/instance/segment-routing/label-blocks/srlb/lower-bound",
 			.cbs = {
 				.modify = isis_instance_segment_routing_srlb_lower_bound_modify,
 			},
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/segment-routing/srlb/upper-bound",
+			.xpath = "/frr-isisd:isis/instance/segment-routing/label-blocks/srlb/upper-bound",
 			.cbs = {
 				.modify = isis_instance_segment_routing_srlb_upper_bound_modify,
 			},

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -387,9 +387,7 @@ lib_interface_state_isis_event_counters_authentication_fails_get_elem(
 /* Optional 'pre_validate' callbacks. */
 int isis_instance_segment_routing_prefix_sid_map_prefix_sid_pre_validate(
 	struct nb_cb_pre_validate_args *args);
-int isis_instance_segment_routing_srgb_pre_validate(
-	struct nb_cb_pre_validate_args *args);
-int isis_instance_segment_routing_srlb_pre_validate(
+int isis_instance_segment_routing_label_blocks_pre_validate(
 	struct nb_cb_pre_validate_args *args);
 
 /* Optional 'apply_finish' callbacks. */
@@ -476,10 +474,8 @@ void cli_show_isis_mt_ipv6_dstsrc(struct vty *vty, struct lyd_node *dnode,
 				  bool show_defaults);
 void cli_show_isis_sr_enabled(struct vty *vty, struct lyd_node *dnode,
 			      bool show_defaults);
-void cli_show_isis_srgb(struct vty *vty, struct lyd_node *dnode,
-			bool show_defaults);
-void cli_show_isis_srlb(struct vty *vty, struct lyd_node *dnode,
-			bool show_defaults);
+void cli_show_isis_label_blocks(struct vty *vty, struct lyd_node *dnode,
+				bool show_defaults);
 void cli_show_isis_node_msd(struct vty *vty, struct lyd_node *dnode,
 			    bool show_defaults);
 void cli_show_isis_prefix_sid(struct vty *vty, struct lyd_node *dnode,

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -1943,9 +1943,9 @@ int isis_instance_segment_routing_enabled_modify(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/segment-routing/srgb
+ * XPath: /frr-isisd:isis/instance/segment-routing/label-blocks
  */
-int isis_instance_segment_routing_srgb_pre_validate(
+int isis_instance_segment_routing_label_blocks_pre_validate(
 	struct nb_cb_pre_validate_args *args)
 {
 	uint32_t srgb_lbound;
@@ -1953,10 +1953,10 @@ int isis_instance_segment_routing_srgb_pre_validate(
 	uint32_t srlb_lbound;
 	uint32_t srlb_ubound;
 
-	srgb_lbound = yang_dnode_get_uint32(args->dnode, "./lower-bound");
-	srgb_ubound = yang_dnode_get_uint32(args->dnode, "./upper-bound");
-	srlb_lbound = yang_dnode_get_uint32(args->dnode, "../srlb/lower-bound");
-	srlb_ubound = yang_dnode_get_uint32(args->dnode, "../srlb/upper-bound");
+	srgb_lbound = yang_dnode_get_uint32(args->dnode, "./srgb/lower-bound");
+	srgb_ubound = yang_dnode_get_uint32(args->dnode, "./srgb/upper-bound");
+	srlb_lbound = yang_dnode_get_uint32(args->dnode, "./srlb/lower-bound");
+	srlb_ubound = yang_dnode_get_uint32(args->dnode, "./srlb/upper-bound");
 
 	/* Check that the block size does not exceed 65535 */
 	if ((srgb_ubound - srgb_lbound + 1) > 65535) {
@@ -1966,18 +1966,28 @@ int isis_instance_segment_routing_srgb_pre_validate(
 			srgb_lbound, srgb_ubound);
 		return NB_ERR_VALIDATION;
 	}
+	if ((srlb_ubound - srlb_lbound + 1) > 65535) {
+		snprintf(args->errmsg, args->errmsg_len,
+			 "New SR Local Block (%u/%u) exceed the limit of 65535",
+			 srlb_lbound, srlb_ubound);
+		return NB_ERR_VALIDATION;
+	}
 
 	/* Validate SRGB against SRLB */
 	if (!((srgb_ubound < srlb_lbound) || (srgb_lbound > srlb_ubound))) {
 		snprintf(
 			args->errmsg, args->errmsg_len,
-			"New SR Global Block (%u/%u) conflict with Local Block (%u/%u)",
+			"SR Global Block (%u/%u) conflicts with Local Block (%u/%u)",
 			srgb_lbound, srgb_ubound, srlb_lbound, srlb_ubound);
 		return NB_ERR_VALIDATION;
 	}
 
 	return NB_OK;
 }
+
+/*
+ * XPath: /frr-isisd:isis/instance/segment-routing/label-blocks/srgb
+ */
 
 void isis_instance_segment_routing_srgb_apply_finish(
 	struct nb_cb_apply_finish_args *args)
@@ -1993,7 +2003,7 @@ void isis_instance_segment_routing_srgb_apply_finish(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/segment-routing/srgb/lower-bound
+ * XPath: /frr-isisd:isis/instance/segment-routing/label-blocks/srgb/lower-bound
  */
 int isis_instance_segment_routing_srgb_lower_bound_modify(
 	struct nb_cb_modify_args *args)
@@ -2018,7 +2028,7 @@ int isis_instance_segment_routing_srgb_lower_bound_modify(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/segment-routing/srgb/upper-bound
+ * XPath: /frr-isisd:isis/instance/segment-routing/label-blocks/srgb/upper-bound
  */
 int isis_instance_segment_routing_srgb_upper_bound_modify(
 	struct nb_cb_modify_args *args)
@@ -2043,41 +2053,8 @@ int isis_instance_segment_routing_srgb_upper_bound_modify(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/segment-routing/srlb
+ * XPath: /frr-isisd:isis/instance/segment-routing/label-blocks/srlb
  */
-int isis_instance_segment_routing_srlb_pre_validate(
-	struct nb_cb_pre_validate_args *args)
-{
-	uint32_t srgb_lbound;
-	uint32_t srgb_ubound;
-	uint32_t srlb_lbound;
-	uint32_t srlb_ubound;
-
-	srgb_lbound = yang_dnode_get_uint32(args->dnode, "../srgb/lower-bound");
-	srgb_ubound = yang_dnode_get_uint32(args->dnode, "../srgb/upper-bound");
-	srlb_lbound = yang_dnode_get_uint32(args->dnode, "./lower-bound");
-	srlb_ubound = yang_dnode_get_uint32(args->dnode, "./upper-bound");
-
-	/* Check that the block size does not exceed 65535 */
-	if ((srlb_ubound - srlb_lbound + 1) > 65535) {
-		snprintf(args->errmsg, args->errmsg_len,
-			 "New SR Local Block (%u/%u) exceed the limit of 65535",
-			 srlb_lbound, srlb_ubound);
-		return NB_ERR_VALIDATION;
-	}
-
-	/* Validate SRLB against SRGB */
-	if (!((srlb_ubound < srgb_lbound) || (srlb_lbound > srgb_ubound))) {
-		snprintf(
-			args->errmsg, args->errmsg_len,
-			"New SR Local Block (%u/%u) conflict with Global Block (%u/%u)",
-			srlb_lbound, srlb_ubound, srgb_lbound, srgb_ubound);
-		return NB_ERR_VALIDATION;
-	}
-
-	return NB_OK;
-}
-
 void isis_instance_segment_routing_srlb_apply_finish(
 	struct nb_cb_apply_finish_args *args)
 {
@@ -2092,7 +2069,7 @@ void isis_instance_segment_routing_srlb_apply_finish(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/segment-routing/srlb/lower-bound
+ * XPath: /frr-isisd:isis/instance/segment-routing/label-blocks/srlb/lower-bound
  */
 int isis_instance_segment_routing_srlb_lower_bound_modify(
 	struct nb_cb_modify_args *args)
@@ -2117,7 +2094,7 @@ int isis_instance_segment_routing_srlb_lower_bound_modify(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/segment-routing/srlb/upper-bound
+ * XPath: /frr-isisd:isis/instance/segment-routing/label-blocks/srlb/upper-bound
  */
 int isis_instance_segment_routing_srlb_upper_bound_modify(
 	struct nb_cb_modify_args *args)
@@ -2231,10 +2208,10 @@ int isis_instance_segment_routing_prefix_sid_map_prefix_sid_pre_validate(
 	struct isis_prefix_sid psid = {};
 
 	yang_dnode_get_prefix(&prefix, args->dnode, "./prefix");
-	srgb_lbound = yang_dnode_get_uint32(args->dnode,
-					    "../../srgb/lower-bound");
-	srgb_ubound = yang_dnode_get_uint32(args->dnode,
-					    "../../srgb/upper-bound");
+	srgb_lbound = yang_dnode_get_uint32(
+		args->dnode, "../../label-blocks/srgb/lower-bound");
+	srgb_ubound = yang_dnode_get_uint32(
+		args->dnode, "../../label-blocks/srgb/upper-bound");
 	sid = yang_dnode_get_uint32(args->dnode, "./sid-value");
 	sid_type = yang_dnode_get_enum(args->dnode, "./sid-value-type");
 

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -1213,14 +1213,14 @@ void isis_sr_area_init(struct isis_area *area)
 	/* Pull defaults from the YANG module. */
 #ifndef FABRICD
 	srdb->config.enabled = yang_get_default_bool("%s/enabled", ISIS_SR);
-	srdb->config.srgb_lower_bound =
-		yang_get_default_uint32("%s/srgb/lower-bound", ISIS_SR);
-	srdb->config.srgb_upper_bound =
-		yang_get_default_uint32("%s/srgb/upper-bound", ISIS_SR);
-	srdb->config.srlb_lower_bound =
-		yang_get_default_uint32("%s/srlb/lower-bound", ISIS_SR);
-	srdb->config.srlb_upper_bound =
-		yang_get_default_uint32("%s/srlb/upper-bound", ISIS_SR);
+	srdb->config.srgb_lower_bound = yang_get_default_uint32(
+		"%s/label-blocks/srgb/lower-bound", ISIS_SR);
+	srdb->config.srgb_upper_bound = yang_get_default_uint32(
+		"%s/label-blocks/srgb/upper-bound", ISIS_SR);
+	srdb->config.srlb_lower_bound = yang_get_default_uint32(
+		"%s/label-blocks/srlb/lower-bound", ISIS_SR);
+	srdb->config.srlb_upper_bound = yang_get_default_uint32(
+		"%s/label-blocks/srlb/upper-bound", ISIS_SR);
 #else
 	srdb->config.enabled = false;
 	srdb->config.srgb_lower_bound = SRGB_LOWER_BOUND;

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -60,6 +60,11 @@ module frr-isisd {
      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2021-02-15 {
+    description
+      "Group SRGB and SRLB in a container so that they can be displayed
+       and configured together";
+  }
   revision 2020-04-06 {
     description
       "Group LSP timers in a container so that they can be displayed and
@@ -1491,38 +1496,42 @@ module frr-isisd {
           description
             "Enables segment-routing protocol extensions.";
         }
-        container srgb {
+        container label-blocks {
           description
-            "Global blocks to be advertised.";
-          must "./upper-bound > ./lower-bound";
-          leaf lower-bound {
-              type uint32;
-              default "16000";
-              description
-                "Lower value in the label range.";
+            "Local and global label blocks.";
+          container srgb {
+            description
+              "Global blocks to be advertised.";
+            must "./upper-bound > ./lower-bound";
+            leaf lower-bound {
+                type uint32;
+                default "16000";
+                description
+                  "Lower value in the label range.";
+            }
+            leaf upper-bound {
+                type uint32;
+                default "23999";
+                description
+                  "Upper value in the label range.";
+            }
           }
-          leaf upper-bound {
-              type uint32;
-              default "23999";
-              description
-                "Upper value in the label range.";
-          }
-        }
-        container srlb {
-          description
-            "Local blocks to be advertised.";
-          must "./upper-bound > ./lower-bound";
-          leaf lower-bound {
-              type uint32;
-              default "15000";
-              description
-                "Lower value in the label range.";
-          }
-          leaf upper-bound {
-              type uint32;
-              default "15999";
-              description
-                "Upper value in the label range.";
+          container srlb {
+            description
+              "Local blocks to be advertised.";
+            must "./upper-bound > ./lower-bound";
+            leaf lower-bound {
+                type uint32;
+                default "15000";
+                description
+                  "Lower value in the label range.";
+            }
+            leaf upper-bound {
+                type uint32;
+                default "15999";
+                description
+                  "Upper value in the label range.";
+            }
           }
         }
         container msd {


### PR DESCRIPTION
when changing both ranges at the same time the order of the commands matters, as we need to make sure that the intermediate state is valid. This represents a problem when pushing configuration via frr-reload. 
Add a new command 'segment-routing label-blocks global XX XX local XX XX' and use this to show the configuration, so that we can process both changes in a single sweep. The existing individual commands are left there both for backwards compatibility and as utility to set/unset a single range.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>