### PR TITLE
bgpd: [7.6] Check for peer->su_remote if not NULL when handling IPv6 nexthop

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -896,6 +896,7 @@ bgp_path_info_to_ipv6_nexthop(struct bgp_path_info *path, ifindex_t *ifindex)
 			/* Workaround for Cisco's nexthop bug.  */
 			if (IN6_IS_ADDR_UNSPECIFIED(
 				    &path->attr->mp_nexthop_global)
+			    && path->peer->su_remote
 			    && path->peer->su_remote->sa.sa_family
 				       == AF_INET6) {
 				nexthop =


### PR DESCRIPTION
```
(gdb) bt
0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
1  0x00007fe57ca4a42a in __GI_abort () at abort.c:89
2  0x00007fe57ddd1935 in core_handler (signo=6, siginfo=0x7ffc81067570, context=<optimized out>) at lib/sigevent.c:255
3  <signal handler called>
4  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
5  0x00007fe57ca4a42a in __GI_abort () at abort.c:89
6  0x00007fe57ddd1935 in core_handler (signo=11, siginfo=0x7ffc81067e30, context=<optimized out>) at lib/sigevent.c:255
7  <signal handler called>
8  0x000055a7b25b923f in bgp_path_info_to_ipv6_nexthop (ifindex=ifindex@entry=0x7ffc810683c0, path=<optimized out>, path=<optimized out>) at bgpd/bgp_zebra.c:909
9  0x000055a7b25bb2e5 in bgp_zebra_announce (dest=dest@entry=0x55a7b5239c10, p=p@entry=0x55a7b5239c10, info=info@entry=0x55a7b5239cd0, bgp=bgp@entry=0x55a7b518b090, afi=afi@entry=AFI_IP6, safi=safi@entry=SAFI_UNICAST) at bgpd/bgp_zebra.c:1358
10 0x000055a7b256af6a in bgp_process_main_one (bgp=0x55a7b518b090, dest=0x55a7b5239c10, afi=AFI_IP6, safi=SAFI_UNICAST) at bgpd/bgp_route.c:2918
11 0x000055a7b256b0ee in bgp_process_wq (wq=<optimized out>, data=0x55a7b5221800) at bgpd/bgp_route.c:3027
12 0x00007fe57ddea2e0 in work_queue_run (thread=0x7ffc8106cd60) at lib/workqueue.c:291
13 0x00007fe57dde0781 in thread_call (thread=thread@entry=0x7ffc8106cd60) at lib/thread.c:1684
14 0x00007fe57dda84b8 in frr_run (master=0x55a7b48aaf00) at lib/libfrr.c:1126
15 0x000055a7b250a7da in main (argc=<optimized out>, argv=<optimized out>) at bgpd/bgp_main.c:540
(gdb)
```

This crashes with configs like:

```
router bgp 65534
 no bgp ebgp-requires-policy
 no bgp network import-check
 !
 address-family ipv6 unicast
  import vrf donatas <<<<<< Crashes when entering this command
 exit-address-family
!
router bgp 65534 vrf donatas
 no bgp ebgp-requires-policy
 no bgp network import-check
 neighbor fe80::c15a:ddab:1689:db86 remote-as 65025
 neighbor fe80::c15a:ddab:1689:db86 interface eth2
 neighbor fe80::c15a:ddab:1689:db86 update-source eth2
 neighbor fe80::c15a:ddab:1689:db86 capability extended-nexthop
 !
 address-family ipv6 unicast
  network 2a02:face::/32    <<<<<< Crashes due to static networks
  neighbor fe80::c15a:ddab:1689:db86 activate
 exit-address-family
!
```

Locally configured routes do not have peer->su_remote.

```
exit1-debian-9# show bgp ipv6 unicast
BGP table version is 3, local router ID is 192.168.100.1, vrf id 0
Default local pref 100, local AS 65534
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*> 2a02:abc::/64    fe80::c15a:ddab:1689:db86@5<
                                                           0 65025 i
   2a02:face::/32   ::@5<                    0         32768 i

Displayed  2 routes and 2 total paths
exit1-debian-9#

```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>