### PR TITLE
build: detect ICC, only try ICC options if ICC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,6 +191,11 @@ CXXFLAGS="$orig_cxxflags"
 AC_PROG_CC_C99
 dnl NB: see C11 below
 
+dnl Some special handling for ICC later on
+if test "$CC" = "icc"; then
+    cc_is_icc="yes"
+fi
+
 PKG_PROG_PKG_CONFIG
 
 dnl it's 2019, sed is sed.
@@ -252,7 +257,9 @@ AC_DEFUN([AC_LINK_IFELSE_FLAGS], [{
 
 dnl ICC won't bail on unknown options without -diag-error 10006
 dnl need to do this first so we get useful results for the other options
-AC_C_FLAG([-diag-error 10006])
+if test "$cc_is_icc" = "yes"; then
+    AC_C_FLAG([-diag-error 10006])
+fi
 
 dnl AC_PROG_CC_C99 may change CC to include -std=gnu99 or something
 ac_cc="$CC"
@@ -335,7 +342,9 @@ AC_SUBST([CXX_COMPAT_CFLAGS])
 dnl ICC emits a broken warning for const char *x = a ? "b" : "c";
 dnl for some reason the string consts get 'promoted' to char *,
 dnl triggering a const to non-const conversion warning.
-AC_C_FLAG([-diag-disable 3179])
+if test "$cc_is_icc" = "yes"; then
+    AC_C_FLAG([-diag-disable 3179])
+fi
 
 if test "$enable_werror" = "yes" ; then
   WERROR="-Werror"


### PR DESCRIPTION
Some ICC command-line options can cause confusion for other compilers: test for ICC specifically, and only try to use those options if ICC is being used.

Fixes: #8086 