### PR TITLE
*: fix format string SNAFUs

### DIFF
--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -169,8 +169,8 @@ static void bfd_dplane_debug_message(const struct bfddp_message *msg)
 				   &msg->data.session.dst);
 		else
 			snprintfrr(addrs, sizeof(addrs), "src=%pI4 dst=%pI4",
-				   &msg->data.session.src,
-				   &msg->data.session.dst);
+				   (struct in_addr *)&msg->data.session.src,
+				   (struct in_addr *)&msg->data.session.dst);
 
 		buf[0] = 0;
 		if (flags & SESSION_CBIT)

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -1246,7 +1246,7 @@ void ls_dump_ted(struct ls_ted *ted)
 		for (ALL_LIST_ELEMENTS_RO(vertex->incoming_edges, lst_node,
 					  vertex_edge)) {
 			zlog_debug(
-				"        inc edge key:%lldn attr key:%pI4 loc:(%pI4) rmt:(%pI4)",
+				"        inc edge key:%"PRIu64"n attr key:%pI4 loc:(%pI4) rmt:(%pI4)",
 				vertex_edge->key,
 				&vertex_edge->attributes->adv.id.ip.addr,
 				&vertex_edge->attributes->standard.local,
@@ -1255,7 +1255,7 @@ void ls_dump_ted(struct ls_ted *ted)
 		for (ALL_LIST_ELEMENTS_RO(vertex->outgoing_edges, lst_node,
 					  vertex_edge)) {
 			zlog_debug(
-				"        out edge key:%lld  attr key:%pI4  loc:(%pI4) rmt:(%pI4)",
+				"        out edge key:%"PRIu64"  attr key:%pI4  loc:(%pI4) rmt:(%pI4)",
 				vertex_edge->key,
 				&vertex_edge->attributes->adv.id.ip.addr,
 				&vertex_edge->attributes->standard.local,
@@ -1264,7 +1264,8 @@ void ls_dump_ted(struct ls_ted *ted)
 	}
 	frr_each(edges, &ted->edges, edge) {
 		ls_edge2msg(&msg, edge);
-		zlog_debug("    Ted edge key:%lld src:%s dst:%s", edge->key,
+		zlog_debug("    Ted edge key:%"PRIu64" src:%s dst:%s",
+			   edge->key,
 			   edge->source ? edge->source->node->name
 					: "no_source",
 			   edge->destination ? edge->destination->node->name

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2248,10 +2248,9 @@ void ospf_external_lsa_refresh_type(struct ospf *ospf, uint8_t type,
 							    lsa,
 							    EXTNL_LSA_AGGR))
 							zlog_debug(
-								"%s: Send Aggreate LSA (%pFX/%d)",
+								"%s: Send Aggreate LSA (%pFX)",
 								__func__,
-								&aggr->p.prefix,
-								aggr->p.prefixlen);
+								&aggr->p);
 
 						ospf_originate_summary_lsa(
 							ospf, aggr, ei);


### PR DESCRIPTION
Just a few minor format string confusions.  (The bfdd one just needs a cast to avoid the warning, it's correct.  The link_state one also confused unsigned<>signed.)

I've poked @mwinter-osr & these will be hard fails in CI very soon, checks are already in place but weren't armed yet :disappointed: