### PR TITLE
debian: fix multijob for debian dpkg-buildpackage

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -38,7 +38,7 @@ endif
 export PYTHON=python3
 
 %:
-	dh $@ $(DH_WITHOUT_SYSTEMD)
+	dh $@ $(DH_WITHOUT_SYSTEMD) --parallel
 
 override_dh_auto_configure:
 	$(shell dpkg-buildflags --export=sh); \


### PR DESCRIPTION
The -j parameter in dpkg-buildpackage is not handle in rules file so
the parallel parameter must be handle and pass it as  -j parameter
to the build process.

Signed-off-by: Javier Garcia <javier.garcia@voltanet.io>