### PR TITLE
lib: fix some misc SA warnings

### DIFF
--- a/lib/clippy.c
+++ b/lib/clippy.c
@@ -51,7 +51,8 @@ int main(int argc, char **argv)
 #if PY_VERSION_HEX >= 0x03040000 /* 3.4 */
 	Py_SetStandardStreamEncoding("UTF-8", NULL);
 #endif
-	Py_SetProgramName(wconv(argv[0]));
+	char *name = wconv(argv[0]);
+	Py_SetProgramName(name);
 	PyImport_AppendInittab("_clippy", command_py_init);
 
 	Py_Initialize();
@@ -93,6 +94,7 @@ int main(int argc, char **argv)
 	for (int i = 1; i < argc; i++)
 		free(wargv[i - 1]);
 #endif
+	free(name);
 	free(wargv);
 	return 0;
 }

--- a/lib/defun_lex.l
+++ b/lib/defun_lex.l
@@ -80,6 +80,8 @@ static void extendbuf(char **what, const char *arg)
 }
 #define extend(x) extendbuf(&value, x)
 
+#ifndef __clang_analyzer__
+
 %}
 
 ID		[A-Za-z0-9_]+
@@ -156,6 +158,8 @@ SPECIAL		[(),]
 .				/* printf("-- '%s' in init\n", yytext); */ BEGIN(INITIAL); return yytext[0];
 
 %%
+
+#endif /* __clang_analyzer__ */
 
 static int yylex_clr(char **retbuf)
 {

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -600,7 +600,19 @@ void nb_cli_show_dnode_cmds(struct vty *vty, struct lyd_node *root,
 				(*nb_node->cbs.cli_show_end)(vty, parent);
 		}
 
+		/*
+		 * There is a possible path in this macro that ends up
+		 * dereferencing child->parent->parent. We just null checked
+		 * child->parent by checking (ly_iter_next_up(child) != NULL)
+		 * above.
+		 *
+		 * I am not sure whether it is possible for the other
+		 * conditions within this macro guarding the problem
+		 * dereference to be satisfied when child->parent == NULL.
+		 */
+#ifndef __clang_analyzer__
 		LY_TREE_DFS_END(root, next, child);
+#endif
 	}
 }
 


### PR DESCRIPTION
- clippy.c: fix valid memleak
- defun_lex.l: suppress warnings in generated code
- northbound_cli.c: suppress warning in eldritch libyang macro

Signed-off-by: Quentin Young <qlyoung@nvidia.com>