### PR TITLE
lib: Reduce getrusage/monotime for event handling

### DIFF
--- a/lib/thread.h
+++ b/lib/thread.h
@@ -96,6 +96,9 @@ struct thread_master {
 	bool handle_signals;
 	pthread_mutex_t mtx;
 	pthread_t owner;
+
+	bool ready_run_loop;
+	RUSAGE_T last_getrusage;
 };
 
 /* Thread itself. */


### PR DESCRIPTION
When handling a large number of events at one time
FRR will call monotime and getrusage 2 times for each
event.  With this change modify the code to change
this to (X events / 2) + 1 calls of getrusage and monotime

Signed-off-by: Donald Sharp <sharpd@nvidia.com>