### PR TITLE
bgpd: Fix crash when we don't have a nexthop

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -970,7 +970,7 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 			/*
 			 * Peering cannot occur across a blackhole nexthop
 			 */
-			if (bnc->nexthop_num == 1
+			if (bnc->nexthop_num == 1 && bnc->nexthop
 			    && bnc->nexthop->type == NEXTHOP_TYPE_BLACKHOLE) {
 				peer->last_reset = PEER_DOWN_WAITING_NHT;
 				valid_nexthops = 0;


### PR DESCRIPTION
Recent changes to allow bgpd to handle v6 LL slightly
differently in the nexthop tracking code has not
interacted well with the blackhole nexthop change
for peers.  Modify the code to do the right thing

Signed-off-by: Donald Sharp <sharpd@nvidia.com>