### PR TITLE
ospf6d: Show metric in intra-prefix LSA detail

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -989,10 +989,15 @@ static int ospf6_intra_prefix_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 				 buf, prefix->prefix_length);
 			json_object_string_add(json_loop, "prefix",
 					       prefix_string);
+			json_object_int_add(json_loop, "metric",
+					    ntohs(prefix->prefix_metric));
 			json_object_array_add(json_arr, json_loop);
-		} else
+		} else {
 			vty_out(vty, "     Prefix: %s/%d\n", buf,
 				prefix->prefix_length);
+			vty_out(vty, "     Metric: %d\n",
+				ntohs(prefix->prefix_metric));
+		}
 	}
 	if (use_json)
 		json_object_object_add(json_obj, "prefix", json_arr);


### PR DESCRIPTION
```
frr# do show ipv6 ospf6 database intra-prefix detail

Age: 4 Type: Intra-Prefix
Link State ID: 0.0.0.0
Advertising Router: 10.10.10.180
LS Sequence Number: 0x8000405d
CheckSum: 0xbc61 Length: 52
Duration: 00:00:03
Number of Prefix: 1
Reference: Router Id: 0.0.0.0 Adv: 10.10.10.180
Prefix Options: -|||-
Prefix: 12::2/128

Metric is missing
```
Signed-off-by: Yash Ranjan <ranjany@vmware.com>