### PR TITLE
bgpd: fix 'neighbor X prefix-list Y in' SAFI VPN

### DIFF
--- a/bgpd/bgp_nb_config.c
+++ b/bgpd/bgp_nb_config.c
@@ -22977,8 +22977,9 @@ int bgp_neighbors_neighbor_afi_safis_afi_safi_l3vpn_ipv4_unicast_filter_config_p
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+		return NB_OK;
 	case NB_EV_APPLY:
-		/* TODO: implement me. */
+		bgp_neighbor_afi_safi_plist_modify(args, FILTER_IN);
 		break;
 	}
 


### PR DESCRIPTION
this particular callback had not been implemented in the northbound conversion, so the command had no effect.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>