### PR TITLE
lib: Free memory leak in error path in clippy

### DIFF
--- a/lib/clippy.c
+++ b/lib/clippy.c
@@ -68,6 +68,8 @@ int main(int argc, char **argv)
 		fp = fopen(pyfile, "r");
 		if (!fp) {
 			fprintf(stderr, "%s: %s\n", pyfile, strerror(errno));
+
+			free(name);
 			return 1;
 		}
 	} else {
@@ -86,6 +88,8 @@ int main(int argc, char **argv)
 	if (PyRun_AnyFile(fp, pyfile)) {
 		if (PyErr_Occurred())
 			PyErr_Print();
+
+		free(name);
 		return 1;
 	}
 	Py_Finalize();


### PR DESCRIPTION
When running clippy, the main function in it's
error path could leak the memory pointed to by name.
Fix this.  This was/is reported by clang SA.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>