### PR TITLE
tests: Fix determination of IPv6 link-local addresses

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1723,7 +1723,7 @@ class Router(Node):
         interface = ""
         ll_per_if_count = 0
         for line in ifaces:
-            m = re.search("[0-9]+: ([^:@]+)[@if0-9:]+ <", line)
+            m = re.search("[0-9]+: ([^:@]+)[-@a-z0-9:]+ <", line)
             if m:
                 interface = m.group(1)
                 ll_per_if_count = 0


### PR DESCRIPTION
When parsing the output of "ip -6 address", allow arbitrary base interface
names (the part after "@" in the interface name), not just "if0-9". Without
this, link-local addresses sometimes are attributed to the wrong interface
because we're not matching the interface name but still handle the
interface's addresses.

Test case for this fix:
Use topotest ospf-topo1 as a basis and add some debug output:

```
diff --git a/tests/topotests/ospf6-topo1/test_ospf6_topo1.py b/tests/topotests/ospf6-topo1/test_ospf6_topo1.py
index c3efb6ff2..4a102aaa5 100644
--- a/tests/topotests/ospf6-topo1/test_ospf6_topo1.py
+++ b/tests/topotests/ospf6-topo1/test_ospf6_topo1.py
@@ -317,6 +317,7 @@ def test_linux_ipv6_kernel_routingTable():
     linklocals = []
     for i in range(1, 5):
         linklocals += tgen.net["r{}".format(i)].get_ipv6_linklocal()
+    logger.info("linklocals: {}".format(linklocals))
 
     # Now compare the routing tables (after substituting link-local addresses)
```

Without the fix, you'll get something like this:
`linklocals: [['lo', 'fe80::200:ff:fe00:0'], ['r1-stubnet', 'fe80::601a:4eff:fe0b:f06a'], ['r1-sw5', 'fe80::a0fe:c5ff:fed8:3fa1'], ['lo', 'fe80::200:ff:fe00:0'], ['lo-2', 'fe80::14f6:ccff:fe69:3c51'], ['r2-sw5', 'fe80::2cc7:28ff:fe77:1b78'], ['lo', 'fe80::200:ff:fe00:0'], ['lo-2', 'fe80::8419:3aff:fea9:7a4e'], ['r3-sw5', 'fe80::ac2b:d7ff:fea2:12fc'], ['r3-sw6', 'fe80::471:6dff:fee8:b414'], ['lo', 'fe80::200:ff:fe00:0'], ['r4-stubnet', 'fe80::f01b:92ff:fe30:eb8b'], ['r4-sw6', 'fe80::1cb0:14ff:fe02:5d88']]`

Only the interface names are relevant, addresses will change from test to test. Note entries named "lo-2": We don't really have multiple link-local addresses on loopback, these are actually addresses on another interface wrongly attributed to loopback.

With the fix, you'll get:
`linklocals: [['lo', 'fe80::200:ff:fe00:0'], ['r1-stubnet', 'fe80::4089:35ff:fe4b:9f74'], ['r1-sw5', 'fe80::f401:6fff:fef9:b045'], ['lo', 'fe80::200:ff:fe00:0'], ['r2-stubnet', 'fe80::542d:91ff:fe98:19a'], ['r2-sw5', 'fe80::bc8b:baff:feec:9d09'], ['lo', 'fe80::200:ff:fe00:0'], ['r3-stubnet', 'fe80::2c11:9cff:fef4:315f'], ['r3-sw5', 'fe80::d413:53ff:feba:9ae8'], ['r3-sw6', 'fe80::ec52:aff:fe8a:b43c'], ['lo', 'fe80::200:ff:fe00:0'], ['r4-stubnet', 'fe80::9023:8fff:fe6e:1d4e'], ['r4-sw6', 'fe80::30d1:bfff:fe96:1422']]`

"lo-2" are gone, we now see that the wrongly attributed addresses actually belong to "r2/3-stubnet".
