### PR TITLE
General docs cleanup

### DIFF
--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -1229,9 +1229,9 @@ towards making documentation easier to use, write and maintain.
 CLI Commands
 ^^^^^^^^^^^^
 
-When documenting CLI please use a combination of the ``.. index::`` and
-``.. clicmd::`` directives. For example, the command :clicmd:`show pony` would
-be documented as follows:
+When documenting CLI please use the ``.. clicmd::`` directive. This directive
+will format the command and generate index entries automatically. For example,
+the command :clicmd:`show pony` would be documented as follows:
 
 .. code-block:: rest
 
@@ -1252,6 +1252,7 @@ be documented as follows:
          hjw    |_>|>     /_] //
                   /_]        /_]
 
+
 When documented this way, CLI commands can be cross referenced with the
 ``:clicmd:`` inline markup like so:
 
@@ -1262,8 +1263,27 @@ When documented this way, CLI commands can be cross referenced with the
 This is very helpful for users who want to quickly remind themselves what a
 particular command does.
 
-When documenting a cli that has a ``no`` form, please do not include
-the ``no`` in the ``.. index::`` line.
+When documenting a cli that has a ``no`` form, please do not include the ``no``
+form. I.e. ``no show pony`` would not be documented anywhere. Since most
+commands have ``no`` forms, users should be able to infer these or get help
+from vtysh's completions.
+
+When documenting commands that have lots of possible variants, just document
+the single command in summary rather than enumerating each possible variant.
+E.g. for ``show pony [foo|bar]``, do not:
+
+.. code-block:: rest
+
+   .. clicmd:: show pony
+   .. clicmd:: show pony foo
+   .. clicmd:: show pony bar
+
+Do:
+
+.. code-block:: rest
+
+   .. clicmd:: show pony [foo|bar]
+
 
 Configuration Snippets
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/user/babeld.rst
+++ b/doc/user/babeld.rst
@@ -34,16 +34,16 @@ Configuration of *babeld* is done in its configuration file
 Babel configuration
 ===================
 
-.. clicmd:: [no] router babel
+.. clicmd:: router babel
 
    Enable or disable Babel routing.
 
-.. clicmd:: [no] babel resend-delay (20-655340)
+.. clicmd:: babel resend-delay (20-655340)
 
    Specifies the time after which important messages are resent when
    avoiding a black-hole. The default is 2000 ms.
 
-.. clicmd:: [no] babel diversity
+.. clicmd:: babel diversity
 
    Enable or disable routing using radio frequency diversity.  This is
    highly recommended in networks with many wireless nodes.
@@ -59,7 +59,7 @@ Babel configuration
    no role in route selection; you will probably want to set that to 128
    or less on nodes with multiple independent radios.
 
-.. clicmd:: [no] network IFNAME
+.. clicmd:: network IFNAME
 
    Enable or disable Babel on the given interface.
 
@@ -71,7 +71,7 @@ Babel configuration
    Specifying `wireless` (the default) is always correct, but may
    cause slower convergence and extra routing traffic.
 
-.. clicmd:: [no] babel split-horizon
+.. clicmd:: babel split-horizon
 
    Specifies whether to perform split-horizon on the interface.  Specifying
    ``no babel split-horizon`` is always correct, while ``babel
@@ -153,7 +153,7 @@ Babel configuration
    effectively disables the use of a RTT-based cost.
 
 
-.. clicmd:: [no] babel enable-timestamps
+.. clicmd:: babel enable-timestamps
 
    Enable or disable sending timestamps with each Hello and IHU message in
    order to compute RTT values.  The default is `no babel enable-timestamps`.
@@ -179,7 +179,7 @@ Babel redistribution
 ====================
 
 
-.. clicmd:: [no] redistribute <ipv4|ipv6> KIND
+.. clicmd:: redistribute <ipv4|ipv6> KIND
 
    Specify which kind of routes should be redistributed into Babel.
 
@@ -223,7 +223,7 @@ Babel debugging commands
    simple: debug babel KIND
    simple: no debug babel KIND
 
-.. clicmd:: [no] debug babel KIND
+.. clicmd:: debug babel KIND
 
    Enable or disable debugging messages of a given kind. ``KIND`` can
    be one of:

--- a/doc/user/babeld.rst
+++ b/doc/user/babeld.rst
@@ -34,18 +34,15 @@ Configuration of *babeld* is done in its configuration file
 Babel configuration
 ===================
 
-.. index:: router babel
 .. clicmd:: [no] router babel
 
    Enable or disable Babel routing.
 
-.. index:: babel resend-delay (20-655340)
 .. clicmd:: [no] babel resend-delay (20-655340)
 
    Specifies the time after which important messages are resent when
    avoiding a black-hole. The default is 2000 ms.
 
-.. index:: babel diversity
 .. clicmd:: [no] babel diversity
 
    Enable or disable routing using radio frequency diversity.  This is
@@ -53,7 +50,6 @@ Babel configuration
    If you enable this, you will probably want to set `babel
    diversity-factor` and `babel channel` below.
 
-.. index:: babel diversity-factor (1-256)
 
 .. clicmd:: babel diversity-factor (1-256)
 
@@ -63,12 +59,10 @@ Babel configuration
    no role in route selection; you will probably want to set that to 128
    or less on nodes with multiple independent radios.
 
-.. index:: network IFNAME
 .. clicmd:: [no] network IFNAME
 
    Enable or disable Babel on the given interface.
 
-.. index:: babel <wired|wireless>
 
 .. clicmd:: babel <wired|wireless>
 
@@ -77,7 +71,6 @@ Babel configuration
    Specifying `wireless` (the default) is always correct, but may
    cause slower convergence and extra routing traffic.
 
-.. index:: babel split-horizon
 .. clicmd:: [no] babel split-horizon
 
    Specifies whether to perform split-horizon on the interface.  Specifying
@@ -88,7 +81,6 @@ Babel configuration
    interfaces.  This flag is reset when the wired/wireless status of an
    interface is changed.
 
-.. index:: babel hello-interval (20-655340)
 
 .. clicmd:: babel hello-interval (20-655340)
 
@@ -97,7 +89,6 @@ Babel configuration
    on wireless links, the link quality value is reestimated at every
    hello interval.  The default is 4000 ms.
 
-.. index:: babel update-interval (20-655340)
 
 .. clicmd:: babel update-interval (20-655340)
 
@@ -105,7 +96,6 @@ Babel configuration
    Babel makes extensive use of triggered updates, this can be set to fairly
    high values on links with little packet loss.  The default is 20000 ms.
 
-.. index:: babel channel
 
 .. clicmd:: babel channel (1-254)
 .. clicmd:: babel channel interfering
@@ -121,7 +111,6 @@ Babel configuration
    interfaces.  This is reset when the wired/wireless status of an interface is
    changed.
 
-.. index:: babel rxcost (1-65534)
 
 .. clicmd:: babel rxcost (1-65534)
 
@@ -136,7 +125,6 @@ Babel configuration
    networks, acting directly on the cost using route maps is a better
    technique.
 
-.. index:: babel rtt-decay (1-256)
 
 .. clicmd:: babel rtt-decay (1-256)
 
@@ -144,7 +132,6 @@ Babel configuration
    RTT samples, in units of 1/256.  Higher values discard old samples
    faster.  The default is 42.
 
-.. index:: babel rtt-min (1-65535)
 
 .. clicmd:: babel rtt-min (1-65535)
 
@@ -152,14 +139,12 @@ Babel configuration
    increase the cost to a neighbour. The additional cost is linear in
    (rtt - rtt-min).  The default is 100 ms.
 
-.. index:: babel rtt-max (1-65535)
 
 .. clicmd:: babel rtt-max (1-65535)
 
    This specifies the maximum RTT, in milliseconds, above which we don't
    increase the cost to a neighbour. The default is 120 ms.
 
-.. index:: babel max-rtt-penalty (0-65535)
 
 .. clicmd:: babel max-rtt-penalty (0-65535)
 
@@ -167,14 +152,12 @@ Babel configuration
    when the RTT is higher or equal than rtt-max.  The default is 0, which
    effectively disables the use of a RTT-based cost.
 
-.. index:: babel enable-timestamps
 
 .. clicmd:: [no] babel enable-timestamps
 
    Enable or disable sending timestamps with each Hello and IHU message in
    order to compute RTT values.  The default is `no babel enable-timestamps`.
 
-.. index:: babel resend-delay (20-655340)
 
 .. clicmd:: babel resend-delay (20-655340)
 
@@ -182,7 +165,6 @@ Babel configuration
    update will be resent.  The default is 2000 ms.  You probably don't want to
    tweak this value.
 
-.. index:: babel smoothing-half-life (0-65534)
 
 .. clicmd:: babel smoothing-half-life (0-65534)
 
@@ -196,7 +178,6 @@ Babel configuration
 Babel redistribution
 ====================
 
-.. index:: redistribute <ipv4|ipv6> KIND
 
 .. clicmd:: [no] redistribute <ipv4|ipv6> KIND
 
@@ -209,46 +190,36 @@ Show Babel information
 
 These commands dump various parts of *babeld*'s internal state.
 
-.. index:: show babel route
 
 .. clicmd:: show babel route
 
-.. index:: show babel route A.B.C.D
 
 .. clicmd:: show babel route A.B.C.D
 
-.. index:: show babel route X:X::X:X
 
 .. clicmd:: show babel route X:X::X:X
 
-.. index:: show babel route A.B.C.D/M
 
 .. clicmd:: show babel route A.B.C.D/M
 
-.. index:: show babel route X:X::X:X/M
 
 .. clicmd:: show babel route X:X::X:X/M
 
-.. index:: show babel interface
 
 .. clicmd:: show babel interface
 
-.. index:: show babel interface IFNAME
 
 .. clicmd:: show babel interface IFNAME
 
-.. index:: show babel neighbor
 
 .. clicmd:: show babel neighbor
 
-.. index:: show babel parameters
 
 .. clicmd:: show babel parameters
 
 Babel debugging commands
 ========================
 
-.. index::
    simple: debug babel KIND
    simple: no debug babel KIND
 

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -60,17 +60,17 @@ Basic Config Commands
 
    Set hostname of the router.
 
-.. clicmd:: [no] password PASSWORD
+.. clicmd:: password PASSWORD
 
    Set password for vty interface. The ``no`` form of the command deletes the
    password. If there is no password, a vty won't accept connections.
 
-.. clicmd:: [no] enable password PASSWORD
+.. clicmd:: enable password PASSWORD
 
    Set enable password. The ``no`` form of the command deletes the enable
    password.
 
-.. clicmd:: [no] log trap LEVEL
+.. clicmd:: log trap LEVEL
 
    These commands are deprecated and are present only for historical
    compatibility. The log trap command sets the current logging level for all
@@ -81,7 +81,7 @@ Basic Config Commands
    level of existing logging destinations.
 
 
-.. clicmd:: [no] log stdout LEVEL
+.. clicmd:: log stdout LEVEL
 
    Enable logging output to stdout. If the optional second argument specifying
    the logging level is not present, the default logging level (typically
@@ -100,7 +100,7 @@ Basic Config Commands
       terminal output.  Use a log file and ``tail -f`` if this rare chance is
       inacceptable to your setup.
 
-.. clicmd:: [no] log file [FILENAME [LEVEL]]
+.. clicmd:: log file [FILENAME [LEVEL]]
 
    If you want to log into a file, please specify ``filename`` as
    in this example:
@@ -114,14 +114,14 @@ Basic Config Commands
    deprecated ``log trap`` command) will be used. The ``no`` form of the command
    disables logging to a file.
 
-.. clicmd:: [no] log syslog [LEVEL]
+.. clicmd:: log syslog [LEVEL]
 
    Enable logging output to syslog. If the optional second argument specifying
    the logging level is not present, the default logging level (typically
    debugging, but can be changed using the deprecated ``log trap`` command) will
    be used. The ``no`` form of the command disables logging to syslog.
 
-.. clicmd:: [no] log monitor [LEVEL]
+.. clicmd:: log monitor [LEVEL]
 
    Enable logging output to vty terminals that have enabled logging using the
    ``terminal monitor`` command. By default, monitor logging is enabled at the
@@ -131,13 +131,13 @@ Basic Config Commands
    level (typically debugging) will be used. The ``no`` form of the command
    disables logging to terminal monitors.
 
-.. clicmd:: [no] log facility [FACILITY]
+.. clicmd:: log facility [FACILITY]
 
    This command changes the facility used in syslog messages. The default
    facility is ``daemon``. The ``no`` form of the command resets the facility
    to the default ``daemon`` facility.
 
-.. clicmd:: [no] log record-priority
+.. clicmd:: log record-priority
 
    To include the severity in all messages logged to a file, to stdout, or to
    a terminal monitor (i.e. anything except syslog),
@@ -147,7 +147,7 @@ Basic Config Commands
    versions of syslogd can be configured to include the facility and
    level in the messages emitted.
 
-.. clicmd:: [no] log timestamp precision [(0-6)]
+.. clicmd:: log timestamp precision [(0-6)]
 
    This command sets the precision of log message timestamps to the given
    number of digits after the decimal point. Currently, the value must be in
@@ -162,7 +162,7 @@ Basic Config Commands
    In this example, the precision is set to provide timestamps with
    millisecond accuracy.
 
-.. clicmd:: [no] log commands
+.. clicmd:: log commands
 
    This command enables the logging of all commands typed by a user to all
    enabled log destinations. The note that logging includes full command lines,
@@ -170,7 +170,7 @@ Basic Config Commands
    is used to start the daemon then this command is turned on by default
    and cannot be turned off and the [no] form of the command is dissallowed.
 
-.. clicmd:: [no] log-filter WORD [DAEMON]
+.. clicmd:: log-filter WORD [DAEMON]
 
    This command forces logs to be filtered on a specific string. A log message
    will only be printed if it matches on one of the filters in the log-filter
@@ -218,10 +218,6 @@ Basic Config Commands
 
    Set motd string from an input.
 
-.. clicmd:: no banner motd
-
-   No motd banner string will be printed.
-
 .. clicmd:: exec-timeout MINUTE [SECOND]
 
    Set VTY connection timeout value. When only one argument is specified
@@ -229,10 +225,8 @@ Basic Config Commands
    used for timeout value in seconds. Default timeout value is 10 minutes.
    When timeout value is zero, it means no timeout.
 
-.. clicmd:: no exec-timeout
-
-   Do not perform timeout at all. This command is as same as
-   ``exec-timeout 0 0``.
+   Not setting this, or setting the values to 0 0, means a timeout will not be
+   enabled.
 
 .. clicmd:: access-class ACCESS-LIST
 

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -11,13 +11,9 @@ The following sections discuss commands common to all the routing daemons.
 Config Commands
 ===============
 
-.. index:: Configuration files for running the software
 
-.. index:: Files for running configurations
 
-.. index:: Modifying the herd's behavior
 
-.. index:: Getting the herd running
 
 In a config file, you can write the debugging options, a vty's password,
 routing daemon configurations, a log file name, and so forth. This information
@@ -60,24 +56,20 @@ If desired, you can specify a config file using the :option:`-f` or
 Basic Config Commands
 ---------------------
 
-.. index:: hostname HOSTNAME
 .. clicmd:: hostname HOSTNAME
 
    Set hostname of the router.
 
-.. index:: password PASSWORD
 .. clicmd:: [no] password PASSWORD
 
    Set password for vty interface. The ``no`` form of the command deletes the
    password. If there is no password, a vty won't accept connections.
 
-.. index:: enable password PASSWORD
 .. clicmd:: [no] enable password PASSWORD
 
    Set enable password. The ``no`` form of the command deletes the enable
    password.
 
-.. index:: log trap LEVEL
 .. clicmd:: [no] log trap LEVEL
 
    These commands are deprecated and are present only for historical
@@ -88,7 +80,6 @@ Basic Config Commands
    future logging commands to debugging, but it does not change the logging
    level of existing logging destinations.
 
-.. index:: log stdout [LEVEL]
 
 .. clicmd:: [no] log stdout LEVEL
 
@@ -109,7 +100,6 @@ Basic Config Commands
       terminal output.  Use a log file and ``tail -f`` if this rare chance is
       inacceptable to your setup.
 
-.. index:: log file FILENAME [LEVEL]
 .. clicmd:: [no] log file [FILENAME [LEVEL]]
 
    If you want to log into a file, please specify ``filename`` as
@@ -124,7 +114,6 @@ Basic Config Commands
    deprecated ``log trap`` command) will be used. The ``no`` form of the command
    disables logging to a file.
 
-.. index:: log syslog [LEVEL]
 .. clicmd:: [no] log syslog [LEVEL]
 
    Enable logging output to syslog. If the optional second argument specifying
@@ -132,7 +121,6 @@ Basic Config Commands
    debugging, but can be changed using the deprecated ``log trap`` command) will
    be used. The ``no`` form of the command disables logging to syslog.
 
-.. index:: log monitor [LEVEL]
 .. clicmd:: [no] log monitor [LEVEL]
 
    Enable logging output to vty terminals that have enabled logging using the
@@ -143,14 +131,12 @@ Basic Config Commands
    level (typically debugging) will be used. The ``no`` form of the command
    disables logging to terminal monitors.
 
-.. index:: log facility [FACILITY]
 .. clicmd:: [no] log facility [FACILITY]
 
    This command changes the facility used in syslog messages. The default
    facility is ``daemon``. The ``no`` form of the command resets the facility
    to the default ``daemon`` facility.
 
-.. index:: log record-priority
 .. clicmd:: [no] log record-priority
 
    To include the severity in all messages logged to a file, to stdout, or to
@@ -161,7 +147,6 @@ Basic Config Commands
    versions of syslogd can be configured to include the facility and
    level in the messages emitted.
 
-.. index:: log timestamp precision (0-6)
 .. clicmd:: [no] log timestamp precision [(0-6)]
 
    This command sets the precision of log message timestamps to the given
@@ -177,7 +162,6 @@ Basic Config Commands
    In this example, the precision is set to provide timestamps with
    millisecond accuracy.
 
-.. index:: log commands
 .. clicmd:: [no] log commands
 
    This command enables the logging of all commands typed by a user to all
@@ -186,7 +170,6 @@ Basic Config Commands
    is used to start the daemon then this command is turned on by default
    and cannot be turned off and the [no] form of the command is dissallowed.
 
-.. index:: log-filter WORD [DAEMON]
 .. clicmd:: [no] log-filter WORD [DAEMON]
 
    This command forces logs to be filtered on a specific string. A log message
@@ -200,55 +183,45 @@ Basic Config Commands
       Log filters prevent this but you should still expect a small performance
       hit due to filtering each of all those logs.
 
-.. index:: log-filter clear [DAEMON]
 .. clicmd:: log-filter clear [DAEMON]
 
    This command clears all current filters in the log-filter table. Can be
    daemon independent.
 
-.. index:: service password-encryption
 .. clicmd:: service password-encryption
 
    Encrypt password.
 
-.. index:: service advanced-vty
 .. clicmd:: service advanced-vty
 
    Enable advanced mode VTY.
 
-.. index:: service terminal-length (0-512)
 .. clicmd:: service terminal-length (0-512)
 
    Set system wide line configuration. This configuration command applies to
    all VTY interfaces.
 
-.. index:: line vty
 .. clicmd:: line vty
 
    Enter vty configuration mode.
 
-.. index:: banner motd default
 .. clicmd:: banner motd default
 
    Set default motd string.
 
-.. index:: banner motd file FILE
 .. clicmd:: banner motd file FILE
 
    Set motd string from file. The file must be in directory specified
    under ``--sysconfdir``.
 
-.. index:: banner motd line LINE
 .. clicmd:: banner motd line LINE
 
    Set motd string from an input.
 
-.. index:: banner motd
 .. clicmd:: no banner motd
 
    No motd banner string will be printed.
 
-.. index:: exec-timeout MINUTE [SECOND]
 .. clicmd:: exec-timeout MINUTE [SECOND]
 
    Set VTY connection timeout value. When only one argument is specified
@@ -256,13 +229,11 @@ Basic Config Commands
    used for timeout value in seconds. Default timeout value is 10 minutes.
    When timeout value is zero, it means no timeout.
 
-.. index:: exec-timeout
 .. clicmd:: no exec-timeout
 
    Do not perform timeout at all. This command is as same as
    ``exec-timeout 0 0``.
 
-.. index:: access-class ACCESS-LIST
 .. clicmd:: access-class ACCESS-LIST
 
    Restrict vty connections with an access list.
@@ -440,55 +411,45 @@ Puppet, etc.), upgrade considerations differ somewhat:
 Terminal Mode Commands
 ======================
 
-.. index:: write terminal
 .. clicmd:: write terminal
 
    Displays the current configuration to the vty interface.
 
-.. index:: write file
 .. clicmd:: write file
 
    Write current configuration to configuration file.
 
-.. index:: configure [terminal]
 .. clicmd:: configure [terminal]
 
    Change to configuration mode. This command is the first step to
    configuration.
 
-.. index:: terminal length (0-512)
 .. clicmd:: terminal length (0-512)
 
    Set terminal display length to ``(0-512)``. If length is 0, no display
    control is performed.
 
-.. index:: who
 .. clicmd:: who
 
    Show a list of currently connected vty sessions.
 
-.. index:: list
 .. clicmd:: list
 
    List all available commands.
 
-.. index:: show version
 .. clicmd:: show version
 
    Show the current version of |PACKAGE_NAME| and its build host information.
 
-.. index:: show logging
 .. clicmd:: show logging
 
    Shows the current configuration of the logging system. This includes the
    status of all logging destinations.
 
-.. index:: show log-filter
 .. clicmd:: show log-filter
 
    Shows the current log filters applied to each daemon.
 
-.. index:: show memory
 .. clicmd:: show memory
 
    Show information on how much memory is used for which specific things in
@@ -549,18 +510,15 @@ Terminal Mode Commands
    When executing this command from ``vtysh``, each of the daemons' memory
    usage is printed sequentially.
 
-.. index:: show history
 .. clicmd:: show history
 
    Dump the vtysh cli history.
 
-.. index:: logmsg LEVEL MESSAGE
 .. clicmd:: logmsg LEVEL MESSAGE
 
    Send a message to all logging destinations that are enabled for messages of
    the given severity.
 
-.. index:: find COMMAND...
 .. clicmd:: find COMMAND...
 
    This command performs a simple substring search across all defined commands
@@ -589,7 +547,6 @@ Terminal Mode Commands
 
 .. _common-show-commands:
 
-.. index:: show thread cpu
 .. clicmd:: show thread cpu [r|w|t|e|x]
 
    This command displays system run statistics for all the different event
@@ -598,7 +555,6 @@ Terminal Mode Commands
    (e)vent and e(x)ecute thread event types.  If you have compiled with
    disable-cpu-time then this command will not show up.
 
-.. index:: show thread poll
 .. clicmd:: show thread poll
 
    This command displays FRR's poll data.  It allows a glimpse into how

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -111,20 +111,13 @@ BFDd Commands
 
    `vrf` selects which domain we want to use.
 
-.. clicmd:: no peer <A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname|vrf NAME$vrf_name}]
-
-    Stops and removes the selected peer.
-
 
 .. clicmd:: profile WORD
 
    Creates a peer profile that can be configured in multiple peers.
 
-
-.. clicmd:: no profile WORD
-
-   Deletes a peer profile. Any peer using the profile will have their
-   configurations reset to the default values.
+   Deleting the profile will cause all peers using it to reset to the default
+   values.
 
 
 .. clicmd:: show bfd [vrf NAME] peers [json]
@@ -178,7 +171,7 @@ BFD peers and profiles share the same BFD session configuration commands.
    Configures the minimal echo receive transmission interval that this
    system is capable of handling.
 
-.. clicmd:: [no] echo-mode
+.. clicmd:: echo-mode
 
    Enables or disables the echo transmission mode. This mode is disabled
    by default.
@@ -190,13 +183,13 @@ BFD peers and profiles share the same BFD session configuration commands.
    Echo mode is not supported on multi-hop setups (see :rfc:`5883`
    section 3).
 
-.. clicmd:: [no] shutdown
+.. clicmd:: shutdown
 
    Enables or disables the peer. When the peer is disabled an
    'administrative down' message is sent to the remote peer.
 
 
-.. clicmd:: [no] passive-mode
+.. clicmd:: passive-mode
 
    Mark session as passive: a passive session will not attempt to start
    the connection and will wait for control packets from peer before it
@@ -208,7 +201,7 @@ BFD peers and profiles share the same BFD session configuration commands.
 
    The default is active-mode (or ``no passive-mode``).
 
-.. clicmd:: [no] minimum-ttl (1-254)
+.. clicmd:: minimum-ttl (1-254)
 
    For multi hop sessions only: configure the minimum expected TTL for
    an incoming BFD control packet.
@@ -258,9 +251,6 @@ The following commands are available inside the BGP configuration node.
    the connection with its neighbor and, when it goes back up, notify
    BGP to try to connect to it.
 
-.. clicmd:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd
-
-   Removes any notification registration for this neighbor.
 
 .. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd check-control-plane-failure
 
@@ -271,21 +261,14 @@ The following commands are available inside the BGP configuration node.
    This is the case when graceful restart is enabled, and it is wished to
    ignore the BD event while waiting for the remote router to restart.
 
-.. clicmd:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd check-control-plane-failure
-
-   Disallow to write CBIT independence in BFD outgoing packets. Also disallow
-   to ignore BFD down notification. This is the default behaviour.
+   Disabling this disables presence of CBIT independence in BFD outgoing
+   packets and pays attention to BFD down notifications. This is the default.
 
 
 .. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd profile BFDPROF
 
    Same as command ``neighbor <A.B.C.D|X:X::X:X|WORD> bfd``, but applies the
    BFD profile to the sessions it creates or that already exist.
-
-
-.. clicmd:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd profile BFDPROF
-
-   Removes the BFD profile configuration from peer session(s).
 
 
 .. _bfd-isis-peer-config:
@@ -301,10 +284,6 @@ The following commands are available inside the interface configuration node.
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-.. clicmd:: no isis bfd
-
-   Removes any notification registration for this interface peers.
-
    Note that there will be just one BFD session per interface. In case both
    IPv4 and IPv6 support are configured then just a IPv6 based session is
    created.
@@ -313,9 +292,6 @@ The following commands are available inside the interface configuration node.
 
    Use a BFD profile BFDPROF as provided in the BFD configuration.
 
-.. clicmd:: no isis bfd profile BFDPROF
-
-   Removes any BFD profile if present.
 
 .. _bfd-ospf-peer-config:
 
@@ -329,10 +305,6 @@ The following commands are available inside the interface configuration node.
    Listen for BFD events on peers created on the interface. Every time
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
-
-.. clicmd:: no ip ospf bfd
-
-   Removes any notification registration for this interface peers.
 
 
 .. _bfd-ospf6-peer-config:
@@ -348,10 +320,6 @@ The following commands are available inside the interface configuration node.
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-.. clicmd:: no ipv6 ospf6 bfd
-
-   Removes any notification registration for this interface peers.
-
 
 .. _bfd-pim-peer-config:
 
@@ -365,10 +333,6 @@ The following commands are available inside the interface configuration node.
    Listen for BFD events on peers created on the interface. Every time
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
-
-.. clicmd:: no ip pim bfd
-
-   Removes any notification registration for this interface peers.
 
 
 .. _bfd-configuration:
@@ -686,7 +650,7 @@ sure you have `debugging` level enabled:
 You may also fine tune the debug messages by selecting one or more of the
 debug levels:
 
-.. clicmd:: [no] debug bfd distributed
+.. clicmd:: debug bfd distributed
 
    Toggle BFD data plane (distributed BFD) debugging.
 
@@ -695,17 +659,17 @@ debug levels:
    * Data plane received / send messages
    * Connection events
 
-.. clicmd:: [no] debug bfd network
+.. clicmd:: debug bfd network
 
    Toggle network events: show messages about socket failures and unexpected
    BFD messages that may not belong to registered peers.
 
-.. clicmd:: [no] debug bfd peer
+.. clicmd:: debug bfd peer
 
    Toggle peer event log messages: show messages about peer creation/removal
    and state changes.
 
-.. clicmd:: [no] debug bfd zebra
+.. clicmd:: debug bfd zebra
 
    Toggle zebra message events: show messages about interfaces, local
    addresses, VRF and daemon peer registrations.

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -90,12 +90,10 @@ may also be specified (:ref:`common-invocation-options`).
 BFDd Commands
 =============
 
-.. index:: bfd
 .. clicmd:: bfd
 
    Opens the BFD daemon configuration node.
 
-.. index:: peer <A.B.C.D|X:X::X:X> [{multihop|local-address <A.B.C.D|X:X::X:X>|interface IFNAME|vrf NAME}]
 .. clicmd:: peer <A.B.C.D|X:X::X:X> [{multihop|local-address <A.B.C.D|X:X::X:X>|interface IFNAME|vrf NAME}]
 
    Creates and configures a new BFD peer to listen and talk to.
@@ -113,41 +111,34 @@ BFDd Commands
 
    `vrf` selects which domain we want to use.
 
-.. index:: peer <A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname|vrf NAME$vrf_name}]
 .. clicmd:: no peer <A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname|vrf NAME$vrf_name}]
 
     Stops and removes the selected peer.
 
 
-.. index:: profile WORD
 .. clicmd:: profile WORD
 
    Creates a peer profile that can be configured in multiple peers.
 
 
-.. index:: profile WORD
 .. clicmd:: no profile WORD
 
    Deletes a peer profile. Any peer using the profile will have their
    configurations reset to the default values.
 
 
-.. index:: show bfd [vrf NAME] peers [json]
 .. clicmd:: show bfd [vrf NAME] peers [json]
 
     Show all configured BFD peers information and current status.
 
-.. index:: show bfd [vrf NAME$vrf_name] peer <WORD$label|<A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname}]> [json]
 .. clicmd:: show bfd [vrf NAME$vrf_name] peer <WORD$label|<A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname}]> [json]
 
     Show status for a specific BFD peer.
 
-.. index:: show bfd [vrf NAME] peers brief [json]
 .. clicmd:: show bfd [vrf NAME] peers brief [json]
 
     Show all configured BFD peers information and current status in brief.
 
-.. index:: show bfd distributed
 .. clicmd:: show bfd distributed
 
    Show the BFD data plane (distributed BFD) statistics.
@@ -160,7 +151,6 @@ Peer / Profile Configuration
 
 BFD peers and profiles share the same BFD session configuration commands.
 
-.. index:: detect-multiplier (2-255)
 .. clicmd:: detect-multiplier (2-255)
 
    Configures the detection multiplier to determine packet loss. The
@@ -173,25 +163,21 @@ BFD peers and profiles share the same BFD session configuration commands.
    detect failures only after 900 milliseconds without receiving
    packets.
 
-.. index:: receive-interval (10-60000)
 .. clicmd:: receive-interval (10-60000)
 
    Configures the minimum interval that this system is capable of
    receiving control packets. The default value is 300 milliseconds.
 
-.. index:: transmit-interval (10-60000)
 .. clicmd:: transmit-interval (10-60000)
 
    The minimum transmission interval (less jitter) that this system
    wants to use to send BFD control packets. Defaults to 300ms.
 
-.. index:: echo-interval (10-60000)
 .. clicmd:: echo-interval (10-60000)
 
    Configures the minimal echo receive transmission interval that this
    system is capable of handling.
 
-.. index:: echo-mode
 .. clicmd:: [no] echo-mode
 
    Enables or disables the echo transmission mode. This mode is disabled
@@ -204,14 +190,12 @@ BFD peers and profiles share the same BFD session configuration commands.
    Echo mode is not supported on multi-hop setups (see :rfc:`5883`
    section 3).
 
-.. index:: shutdown
 .. clicmd:: [no] shutdown
 
    Enables or disables the peer. When the peer is disabled an
    'administrative down' message is sent to the remote peer.
 
 
-.. index:: passive-mode
 .. clicmd:: [no] passive-mode
 
    Mark session as passive: a passive session will not attempt to start
@@ -224,7 +208,6 @@ BFD peers and profiles share the same BFD session configuration commands.
 
    The default is active-mode (or ``no passive-mode``).
 
-.. index:: minimum-ttl (1-254)
 .. clicmd:: [no] minimum-ttl (1-254)
 
    For multi hop sessions only: configure the minimum expected TTL for
@@ -241,14 +224,12 @@ BFD peers and profiles share the same BFD session configuration commands.
 BFD Peer Specific Commands
 --------------------------
 
-.. index:: label WORD
 .. clicmd:: label WORD
 
    Labels a peer with the provided word. This word can be referenced
    later on other daemons to refer to a specific peer.
 
 
-.. index:: profile BFDPROF
 .. clicmd:: profile BFDPROF
 
    Configure peer to use the profile configurations.
@@ -270,7 +251,6 @@ BGP BFD Configuration
 
 The following commands are available inside the BGP configuration node.
 
-.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd
 .. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd
 
    Listen for BFD events registered on the same target as this BGP
@@ -278,12 +258,10 @@ The following commands are available inside the BGP configuration node.
    the connection with its neighbor and, when it goes back up, notify
    BGP to try to connect to it.
 
-.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd
 .. clicmd:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd
 
    Removes any notification registration for this neighbor.
 
-.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd check-control-plane-failure
 .. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd check-control-plane-failure
 
    Allow to write CBIT independence in BFD outgoing packets. Also allow to
@@ -293,21 +271,18 @@ The following commands are available inside the BGP configuration node.
    This is the case when graceful restart is enabled, and it is wished to
    ignore the BD event while waiting for the remote router to restart.
 
-.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd check-control-plane-failure
 .. clicmd:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd check-control-plane-failure
 
    Disallow to write CBIT independence in BFD outgoing packets. Also disallow
    to ignore BFD down notification. This is the default behaviour.
 
 
-.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd profile BFDPROF
 .. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd profile BFDPROF
 
    Same as command ``neighbor <A.B.C.D|X:X::X:X|WORD> bfd``, but applies the
    BFD profile to the sessions it creates or that already exist.
 
 
-.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> bfd profile BFDPROF
 .. clicmd:: no neighbor <A.B.C.D|X:X::X:X|WORD> bfd profile BFDPROF
 
    Removes the BFD profile configuration from peer session(s).
@@ -320,14 +295,12 @@ IS-IS BFD Configuration
 
 The following commands are available inside the interface configuration node.
 
-.. index:: isis bfd
 .. clicmd:: isis bfd
 
    Listen for BFD events on peers created on the interface. Every time
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-.. index:: isis bfd
 .. clicmd:: no isis bfd
 
    Removes any notification registration for this interface peers.
@@ -336,12 +309,10 @@ The following commands are available inside the interface configuration node.
    IPv4 and IPv6 support are configured then just a IPv6 based session is
    created.
 
-.. index:: isis bfd profile BFDPROF
 .. clicmd:: isis bfd profile BFDPROF
 
    Use a BFD profile BFDPROF as provided in the BFD configuration.
 
-.. index:: isis bfd profile BFDPROF
 .. clicmd:: no isis bfd profile BFDPROF
 
    Removes any BFD profile if present.
@@ -353,14 +324,12 @@ OSPF BFD Configuration
 
 The following commands are available inside the interface configuration node.
 
-.. index:: ip ospf bfd
 .. clicmd:: ip ospf bfd
 
    Listen for BFD events on peers created on the interface. Every time
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-.. index:: ip ospf bfd
 .. clicmd:: no ip ospf bfd
 
    Removes any notification registration for this interface peers.
@@ -373,14 +342,12 @@ OSPF6 BFD Configuration
 
 The following commands are available inside the interface configuration node.
 
-.. index:: ipv6 ospf6 bfd
 .. clicmd:: ipv6 ospf6 bfd
 
    Listen for BFD events on peers created on the interface. Every time
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-.. index:: ipv6 ospf6 bfd
 .. clicmd:: no ipv6 ospf6 bfd
 
    Removes any notification registration for this interface peers.
@@ -393,14 +360,12 @@ PIM BFD Configuration
 
 The following commands are available inside the interface configuration node.
 
-.. index:: ip pim bfd
 .. clicmd:: ip pim bfd
 
    Listen for BFD events on peers created on the interface. Every time
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-.. index:: ip pim bfd
 .. clicmd:: no ip pim bfd
 
    Removes any notification registration for this interface peers.
@@ -721,7 +686,6 @@ sure you have `debugging` level enabled:
 You may also fine tune the debug messages by selecting one or more of the
 debug levels:
 
-.. index:: debug bfd distributed
 .. clicmd:: [no] debug bfd distributed
 
    Toggle BFD data plane (distributed BFD) debugging.
@@ -731,19 +695,16 @@ debug levels:
    * Data plane received / send messages
    * Connection events
 
-.. index:: debug bfd network
 .. clicmd:: [no] debug bfd network
 
    Toggle network events: show messages about socket failures and unexpected
    BFD messages that may not belong to registered peers.
 
-.. index:: debug bfd peer
 .. clicmd:: [no] debug bfd peer
 
    Toggle peer event log messages: show messages about peer creation/removal
    and state changes.
 
-.. index:: debug bfd zebra
 .. clicmd:: [no] debug bfd zebra
 
    Toggle zebra message events: show messages about interfaces, local

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -257,9 +257,6 @@ internal or external.
    Enable a BGP protocol process with the specified ASN. After
    this statement you can input any `BGP Commands`.
 
-
-   Destroy a BGP protocol process with the specified ASN.
-
 .. clicmd:: bgp router-id A.B.C.D
 
    This command specifies the router-ID. If *bgpd* connects to *zebra* it gets
@@ -1204,6 +1201,13 @@ Route Aggregation-IPv6 Address Family
 
 Redistribution
 --------------
+
+Redistribution configuration should be placed under the ``address-family``
+section for the specific AF to redistribute into. Protocol availability for
+redistribution is determined by BGP AF; for example, you cannot redistribute
+OSPFv3 into ``address-family ipv4 unicast`` as OSPFv3 supports IPv6.
+
+.. clicmd:: redistribute <babel|connected|eigrp|isis|kernel|openfabric|ospf|ospf6|rip|ripng|sharp|static|table> [metric (0-4294967295)] [route-map WORD]
 
 Redistribute routes from other protocols into BGP.
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -257,7 +257,6 @@ internal or external.
    Enable a BGP protocol process with the specified ASN. After
    this statement you can input any `BGP Commands`.
 
-.. clicmd:: no router bgp ASN
 
    Destroy a BGP protocol process with the specified ASN.
 
@@ -420,7 +419,7 @@ Administrative Distance Metrics
 Require policy on EBGP
 -------------------------------
 
-.. clicmd:: [no] bgp ebgp-requires-policy
+.. clicmd:: bgp ebgp-requires-policy
 
    This command requires incoming and outgoing filters to be applied
    for eBGP sessions as part of RFC-8212 compliance. Without the incoming
@@ -468,14 +467,14 @@ Require policy on EBGP
 Reject routes with AS_SET or AS_CONFED_SET types
 ------------------------------------------------
 
-.. clicmd:: [no] bgp reject-as-sets
+.. clicmd:: bgp reject-as-sets
 
    This command enables rejection of incoming and outgoing routes having AS_SET or AS_CONFED_SET type.
 
 Suppress duplicate updates
 --------------------------
 
-.. clicmd:: [no] bgp suppress-duplicates
+.. clicmd:: bgp suppress-duplicates
 
    For example, BGP routers can generate multiple identical announcements with
    empty community attributes if stripped at egress. This is an undesired behavior.
@@ -485,7 +484,7 @@ Suppress duplicate updates
 Disable checking if nexthop is connected on EBGP sessions
 ---------------------------------------------------------
 
-.. clicmd:: [no] bgp disable-ebgp-connected-route-check
+.. clicmd:: bgp disable-ebgp-connected-route-check
 
    This command is used to disable the connection verification process for EBGP peering sessions
    that are reachable by a single hop but are configured on a loopback interface or otherwise
@@ -496,17 +495,17 @@ Disable checking if nexthop is connected on EBGP sessions
 Route Flap Dampening
 --------------------
 
-.. clicmd:: [no] bgp dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
+.. clicmd:: bgp dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
 
    This command enables (with optionally specified dampening parameters) or
    disables route-flap dampening for all routes of a BGP instance.
 
-.. clicmd:: [no] neighbor PEER dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
+.. clicmd:: neighbor PEER dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
 
    This command enables (with optionally specified dampening parameters) or
    disables route-flap dampening for all routes learned from a BGP peer.
 
-.. clicmd:: [no] neighbor GROUP dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
+.. clicmd:: neighbor GROUP dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
 
    This command enables (with optionally specified dampening parameters) or
    disables route-flap dampening for all routes learned from peers of a peer
@@ -1001,7 +1000,7 @@ BGP GR Peer Mode Commands
 Administrative Shutdown
 -----------------------
 
-.. clicmd:: [no] bgp shutdown [message MSG...]
+.. clicmd:: bgp shutdown [message MSG...]
 
    Administrative shutdown of all peers of a bgp instance. Drop all BGP peers,
    but preserve their configurations. The peers are notified in accordance with
@@ -1035,9 +1034,8 @@ Networks
    routes if they aren't present in their IGP routing tables; `bgpd`
    doesn't care about IGP routes when announcing its routes.
 
-.. clicmd:: no network A.B.C.D/M
 
-.. clicmd:: [no] bgp network import-check
+.. clicmd:: bgp network import-check
 
    This configuration modifies the behavior of the network statement.
    If you have this configured the underlying network must exist in
@@ -1052,7 +1050,7 @@ Networks
 IPv6 Support
 ------------
 
-.. clicmd:: [no] neighbor A.B.C.D activate
+.. clicmd:: neighbor A.B.C.D activate
 
    This configuration modifies whether to enable an address family for a
    specific neighbor. By default only the IPv4 unicast address family is
@@ -1135,13 +1133,9 @@ Route Aggregation-IPv4 Address Family
    Similar to `summary-only`, but will only suppress more specific routes that
    are matched by the selected route-map.
 
-.. clicmd:: no aggregate-address A.B.C.D/M
 
-   This command removes an aggregate address.
-
-
-   This configuration example setup the aggregate-address under
-   ipv4 address-family.
+   This configuration example sets up an ``aggregate-address`` under the ipv4
+   address-family.
 
    .. code-block:: frr
 
@@ -1191,13 +1185,9 @@ Route Aggregation-IPv6 Address Family
    Similar to `summary-only`, but will only suppress more specific routes that
    are matched by the selected route-map.
 
-.. clicmd:: no aggregate-address X:X::X:X/M
 
-   This command removes an aggregate address.
-
-
-   This configuration example setup the aggregate-address under
-   ipv6 address-family.
+   This configuration example sets up an ``aggregate-address`` under the ipv6
+   address-family.
 
    .. code-block:: frr
 
@@ -1209,13 +1199,13 @@ Route Aggregation-IPv6 Address Family
         aggregate-address 50::0/64 route-map aggr-rmap
        exit-address-family
 
+
 .. _bgp-redistribute-to-bgp:
 
 Redistribution
 --------------
 
-
-   Redistribute routes from other protocols into BGP.
+Redistribute routes from other protocols into BGP.
 
 .. clicmd:: redistribute vnc-direct
 
@@ -1336,7 +1326,7 @@ Defining Peers
    peers ASN is the same as mine as specified under the :clicmd:`router bgp ASN`
    command the connection will be denied.
 
-.. clicmd:: [no] bgp listen range <A.B.C.D/M|X:X::X:X/M> peer-group PGNAME
+.. clicmd:: bgp listen range <A.B.C.D/M|X:X::X:X/M> peer-group PGNAME
 
    Accept connections from any peers in the specified prefix. Configuration
    from the specified peer-group is used to configure these peers.
@@ -1359,7 +1349,7 @@ Defining Peers
    ``net.core.optmem_max`` to allow the kernel to allocate the necessary option
    memory.
 
-.. clicmd:: [no] coalesce-time (0-4294967295)
+.. clicmd:: coalesce-time (0-4294967295)
 
    The time in milliseconds that BGP will delay before deciding what peers
    can be put into an update-group together in order to generate a single
@@ -1370,7 +1360,7 @@ Defining Peers
 Configuring Peers
 ^^^^^^^^^^^^^^^^^
 
-.. clicmd:: [no] neighbor PEER shutdown [message MSG...] [rtt (1-65535) [count (1-255)]]
+.. clicmd:: neighbor PEER shutdown [message MSG...] [rtt (1-65535) [count (1-255)]]
 
    Shutdown the peer. We can delete the neighbor's configuration by
    ``no neighbor PEER remote-as ASN`` but all configuration of the neighbor
@@ -1385,12 +1375,12 @@ Configuring Peers
    Additional ``count`` parameter is the number of keepalive messages to count
    before shutdown the peer if round-trip-time becomes higher than defined.
 
-.. clicmd:: [no] neighbor PEER disable-connected-check
+.. clicmd:: neighbor PEER disable-connected-check
 
    Allow peerings between directly connected eBGP peers using loopback
    addresses.
 
-.. clicmd:: [no] neighbor PEER ebgp-multihop
+.. clicmd:: neighbor PEER ebgp-multihop
 
    Specifying ``ebgp-multihop`` allows sessions with eBGP neighbors to
    establish when they are multiple hops away. When the neighbor is not
@@ -1400,11 +1390,11 @@ Configuring Peers
    If the peer's IP address is not in the RIB and is reachable via the
    default route, then you have to enable ``ip nht resolve-via-default``.
 
-.. clicmd:: [no] neighbor PEER description ...
+.. clicmd:: neighbor PEER description ...
 
    Set description of the peer.
 
-.. clicmd:: [no] neighbor PEER version VERSION
+.. clicmd:: neighbor PEER version VERSION
 
    Set up the neighbor's BGP version. `version` can be `4`, `4+` or `4-`. BGP
    version `4` is the default value used for BGP peering. BGP version `4+`
@@ -1413,7 +1403,7 @@ Configuring Peers
    revision 00's Multiprotocol Extensions for BGP-4. Some routing software is
    still using this version.
 
-.. clicmd:: [no] neighbor PEER interface IFNAME
+.. clicmd:: neighbor PEER interface IFNAME
 
    When you connect to a BGP peer over an IPv6 link-local address, you have to
    specify the IFNAME of the interface used for the connection. To specify
@@ -1423,7 +1413,7 @@ Configuring Peers
    This command is deprecated and may be removed in a future release. Its use
    should be avoided.
 
-.. clicmd:: [no] neighbor PEER next-hop-self [all]
+.. clicmd:: neighbor PEER next-hop-self [all]
 
    This command specifies an announced route's nexthop as being equivalent to
    the address of the bgp router if it is learned via eBGP.  If the optional
@@ -1437,7 +1427,7 @@ Configuring Peers
    configurations, as the route-map directive to leave the next-hop unchanged
    is only available for ipv4.
 
-.. clicmd:: [no] neighbor PEER update-source <IFNAME|ADDRESS>
+.. clicmd:: neighbor PEER update-source <IFNAME|ADDRESS>
 
    Specify the IPv4 source address to use for the :abbr:`BGP` session to this
    neighbour, may be specified as either an IPv4 address directly or as an
@@ -1451,7 +1441,7 @@ Configuring Peers
        neighbor bar update-source lo0
 
 
-.. clicmd:: [no] neighbor PEER default-originate
+.. clicmd:: neighbor PEER default-originate
 
    *bgpd*'s default is to not announce the default route (0.0.0.0/0) even if it
    is in routing table. When you want to announce default routes to the peer,
@@ -1459,7 +1449,7 @@ Configuring Peers
 
 .. clicmd:: neighbor PEER port PORT
 
-.. clicmd:: [no] neighbor PEER password PASSWORD
+.. clicmd:: neighbor PEER password PASSWORD
 
    Set a MD5 password to be used with the tcp socket that is being used
    to connect to the remote peer.  Please note if you are using this
@@ -1469,11 +1459,11 @@ Configuring Peers
 
 .. clicmd:: neighbor PEER send-community
 
-.. clicmd:: [no] neighbor PEER weight WEIGHT
+.. clicmd:: neighbor PEER weight WEIGHT
 
    This command specifies a default `weight` value for the neighbor's routes.
 
-.. clicmd:: [no] neighbor PEER maximum-prefix NUMBER [force]
+.. clicmd:: neighbor PEER maximum-prefix NUMBER [force]
 
    Sets a maximum number of prefixes we can receive from a given peer. If this
    number is exceeded, the BGP session will be destroyed.
@@ -1490,14 +1480,14 @@ Configuring Peers
    but you want maximum-prefix to act on ALL (including filtered) prefixes. This
    option requires `soft-reconfiguration inbound` to be enabled for the peer.
 
-.. clicmd:: [no] neighbor PEER maximum-prefix-out NUMBER
+.. clicmd:: neighbor PEER maximum-prefix-out NUMBER
 
    Sets a maximum number of prefixes we can send to a given peer.
 
    Since sent prefix count is managed by update-groups, this option
    creates a separate update-group for outgoing updates.
 
-.. clicmd:: [no] neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
+.. clicmd:: neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
 
    Specify an alternate AS for this BGP process when interacting with the
    specified peer. With no modifiers, the specified local-as is prepended to
@@ -1515,7 +1505,7 @@ Configuring Peers
 
    This command is only allowed for eBGP peers.
 
-.. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> as-override
+.. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> as-override
 
    Override AS number of the originating router with the local AS number.
 
@@ -1527,7 +1517,7 @@ Configuring Peers
 
    This command is only allowed for eBGP peers.
 
-.. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]
+.. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]
 
    Accept incoming routes with AS path containing AS number with the same value
    as the current system AS.
@@ -1544,24 +1534,24 @@ Configuring Peers
 
    This command is only allowed for eBGP peers.
 
-.. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-all-paths
+.. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-all-paths
 
    Configure BGP to send all known paths to neighbor in order to preserve multi
    path capabilities inside a network.
 
-.. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-bestpath-per-AS
+.. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-bestpath-per-AS
 
    Configure BGP to send best known paths to neighbor in order to preserve multi
    path capabilities inside a network.
 
-.. clicmd:: [no] neighbor PEER ttl-security hops NUMBER
+.. clicmd:: neighbor PEER ttl-security hops NUMBER
 
    This command enforces Generalized TTL Security Mechanism (GTSM), as
    specified in RFC 5082. With this command, only neighbors that are the
    specified number of hops away will be allowed to become neighbors. This
    command is mutually exclusive with *ebgp-multihop*.
 
-.. clicmd:: [no] neighbor PEER capability extended-nexthop
+.. clicmd:: neighbor PEER capability extended-nexthop
 
    Allow bgp to negotiate the extended-nexthop capability with it's peer.
    If you are peering over a v6 LL address then this capability is turned
@@ -1569,37 +1559,37 @@ Configuring Peers
    turning on this command will allow BGP to install v4 routes with
    v6 nexthops if you do not have v4 configured on interfaces.
 
-.. clicmd:: [no] bgp fast-external-failover
+.. clicmd:: bgp fast-external-failover
 
    This command causes bgp to not take down ebgp peers immediately
    when a link flaps.  `bgp fast-external-failover` is the default
    and will not be displayed as part of a `show run`.  The no form
    of the command turns off this ability.
 
-.. clicmd:: [no] bgp default ipv4-unicast
+.. clicmd:: bgp default ipv4-unicast
 
    This command allows the user to specify that v4 peering is turned
    on by default or not.  This command defaults to on and is not displayed.
    The `no bgp default ipv4-unicast` form of the command is displayed.
 
-.. clicmd:: [no] bgp default show-hostname
+.. clicmd:: bgp default show-hostname
 
    This command shows the hostname of the peer in certain BGP commands
    outputs. It's easier to troubleshoot if you have a number of BGP peers.
 
-.. clicmd:: [no] bgp default show-nexthop-hostname
+.. clicmd:: bgp default show-nexthop-hostname
 
    This command shows the hostname of the next-hop in certain BGP commands
    outputs. It's easier to troubleshoot if you have a number of BGP peers
    and a number of routes to check.
 
-.. clicmd:: [no] neighbor PEER advertisement-interval (0-600)
+.. clicmd:: neighbor PEER advertisement-interval (0-600)
 
    Setup the minimum route advertisement interval(mrai) for the
    peer in question.  This number is between 0 and 600 seconds,
    with the default advertisement interval being 0.
 
-.. clicmd:: [no] neighbor PEER timers delayopen (1-240)
+.. clicmd:: neighbor PEER timers delayopen (1-240)
 
    This command allows the user enable the
    `RFC 4271 <https://tools.ietf.org/html/rfc4271/>` DelayOpenTimer with the
@@ -1639,7 +1629,7 @@ Peer Filtering
    on reflected routes. This option allows the modifications to be reflected as
    well. Once enabled, it affects all reflected routes.
 
-.. clicmd:: [no] neighbor PEER sender-as-path-loop-detection
+.. clicmd:: neighbor PEER sender-as-path-loop-detection
 
    Enable the detection of sender side AS path loops and filter the
    bad routes before they are sent.
@@ -1678,7 +1668,6 @@ Capability Negotiation
 
 .. clicmd:: neighbor PEER strict-capability-match
 
-.. clicmd:: no neighbor PEER strict-capability-match
 
    Strictly compares remote capabilities and local capabilities. If
    capabilities are different, send Unsupported Capability error then reset
@@ -1689,7 +1678,7 @@ Capability Negotiation
    Negotiation. Please use *dont-capability-negotiate* command to disable the
    feature.
 
-.. clicmd:: [no] neighbor PEER dont-capability-negotiate
+.. clicmd:: neighbor PEER dont-capability-negotiate
 
    Suppress sending Capability Negotiation as OPEN message optional parameter
    to the peer. This command only affects the peer is configured other than
@@ -1711,7 +1700,6 @@ Capability Negotiation
 
 .. clicmd:: neighbor PEER override-capability
 
-.. clicmd:: no neighbor PEER override-capability
 
    Override the result of Capability Negotiation with local configuration.
    Ignore remote peer's capability value.
@@ -1727,9 +1715,7 @@ AS path access list is user defined AS path.
 
    This command defines a new AS path access list.
 
-.. clicmd:: no bgp as-path access-list WORD
 
-.. clicmd:: no bgp as-path access-list WORD permit|deny LINE
 
 .. _bgp-bogon-filter-example:
 
@@ -1747,18 +1733,18 @@ Bogon ASN filter policy configuration example
 Using AS Path in Route Map
 --------------------------
 
-.. clicmd:: [no] match as-path WORD
+.. clicmd:: match as-path WORD
 
    For a given as-path, WORD, match it on the BGP as-path given for the prefix
    and if it matches do normal route-map actions.  The no form of the command
    removes this match from the route-map.
 
-.. clicmd:: [no] set as-path prepend AS-PATH
+.. clicmd:: set as-path prepend AS-PATH
 
    Prepend the given string of AS numbers to the AS_PATH of the BGP path's NLRI.
    The no form of this command removes this set operation from the route-map.
 
-.. clicmd:: [no] set as-path prepend last-as NUM
+.. clicmd:: set as-path prepend last-as NUM
 
    Prepend the existing last AS number (the leftmost ASN) to the AS_PATH.
    The no form of this command removes this set operation from the route-map.
@@ -1933,12 +1919,9 @@ expanded
    Otherwise it is defined as an expanded community list. This feature is left
    for backward compatibility. Use of this feature is not recommended.
 
-
-.. clicmd:: no bgp community-list [standard|expanded] NAME
-
-   Deletes the community list specified by ``NAME``. All community lists share
-   the same namespace, so it's not necessary to specify ``standard`` or
-   ``expanded``; these modifiers are purely aesthetic.
+   Note that all community lists share the same namespace, so it's not
+   necessary to specify ``standard`` or ``expanded``; these modifiers are
+   purely aesthetic.
 
 .. clicmd:: show bgp community-list [NAME detail]
 
@@ -2207,24 +2190,13 @@ Extended Community Lists
    expression (:ref:`bgp-regular-expressions`) to match an extended communities
    attribute in BGP updates.
 
-.. clicmd:: no bgp extcommunity-list NAME
+   Note that all extended community lists shares a single name space, so it's
+   not necessary to specify their type when creating or destroying them.
 
-.. clicmd:: no bgp extcommunity-list standard NAME
-
-.. clicmd:: no bgp extcommunity-list expanded NAME
-
-   These commands delete extended community lists specified by `name`. All of
-   extended community lists shares a single name space. So extended community
-   lists can be removed simply specifying the name.
-
-.. clicmd:: show bgp extcommunity-list
-
-.. clicmd:: show bgp extcommunity-list NAME detail
+.. clicmd:: show bgp extcommunity-list [NAME detail]
 
    This command displays current extcommunity-list information. When `name` is
-   specified the community list's information is shown.::
-
-      # show bgp extcommunity-list
+   specified the community list's information is shown.
 
 
 .. _bgp-extended-communities-in-route-map:
@@ -2311,15 +2283,9 @@ Two types of large community lists are supported, namely `standard` and
    lowest to highest.  `line` can also be a regular expression which matches
    this Large Community attribute.
 
-.. clicmd:: no bgp large-community-list NAME
-
-.. clicmd:: no bgp large-community-list standard NAME
-
-.. clicmd:: no bgp large-community-list expanded NAME
-
-   These commands delete Large Community lists specified by `name`. All Large
-   Community lists share a single namespace.  This means Large Community lists
-   can be removed by simply specifying the name.
+   Note that all community lists share the same namespace, so it's not
+   necessary to specify ``standard`` or ``expanded``; these modifiers are
+   purely aesthetic.
 
 .. clicmd:: show bgp large-community-list
 
@@ -2436,10 +2402,6 @@ address-family:
    Specifies the route distinguisher to be added to a route exported from the
    current unicast VRF to VPN.
 
-.. clicmd:: no rd vpn export [AS:NN|IP:nn]
-
-   Deletes any previously-configured export route distinguisher.
-
 .. clicmd:: rt vpn import|export|both RTLIST...
 
    Specifies the route-target list to be attached to a route (export) or the
@@ -2450,10 +2412,6 @@ address-family:
    extended community values as described in
    :ref:`bgp-extended-communities-attribute`.
 
-.. clicmd:: no rt vpn import|export|both [RTLIST...]
-
-   Deletes any previously-configured import or export route-target list.
-
 .. clicmd:: label vpn export (0..1048575)|auto
 
    Enables an MPLS label to be attached to a route exported from the current
@@ -2462,36 +2420,20 @@ address-family:
    is not running, or if this command is not configured, automatic label
    assignment will not complete, which will block corresponding route export.
 
-.. clicmd:: no label vpn export [(0..1048575)|auto]
-
-   Deletes any previously-configured export label.
-
 .. clicmd:: nexthop vpn export A.B.C.D|X:X::X:X
 
    Specifies an optional nexthop value to be assigned to a route exported from
    the current unicast VRF to VPN. If left unspecified, the nexthop will be set
    to 0.0.0.0 or 0:0::0:0 (self).
 
-.. clicmd:: no nexthop vpn export [A.B.C.D|X:X::X:X]
-
-   Deletes any previously-configured export nexthop.
-
 .. clicmd:: route-map vpn import|export MAP
 
    Specifies an optional route-map to be applied to routes imported or exported
    between the current unicast VRF and VPN.
 
-.. clicmd:: no route-map vpn import|export [MAP]
-
-   Deletes any previously-configured import or export route-map.
-
 .. clicmd:: import|export vpn
 
    Enables import or export of routes between the current unicast VRF and VPN.
-
-.. clicmd:: no import|export vpn
-
-   Disables import or export of routes between the current unicast VRF and VPN.
 
 .. clicmd:: import vrf VRFNAME
 
@@ -2504,11 +2446,6 @@ address-family:
    `import vpn` and `export vpn` statements for the two VRF's involved.
    The CLI will disallow attempts to configure incompatible leaking
    modes.
-
-.. clicmd:: no import vrf VRFNAME
-
-   Disables automatic leaking from vrf VRFNAME to the current VRF using
-   the VPN RIB as intermediary.
 
 
 .. _bgp-evpn:
@@ -2560,7 +2497,7 @@ disable the feature via configuration CLI. Once the feature is disable under
 bgp vrf instance or MAC-VLAN interface is not configured, all the routes follow
 the same behavior of using same next-hop and RMAC values.
 
-.. clicmd:: [no] advertise-pip [ip <addr> [mac <addr>]]
+.. clicmd:: advertise-pip [ip <addr> [mac <addr>]]
 
 Enables or disables advertise-pip feature, specifiy system-IP and/or system-MAC
 parameters.
@@ -2577,9 +2514,9 @@ Ethernet Segments
 An Ethernet Segment can be configured by specifying a system-MAC and a
 local discriminatior against the bond interface on the PE (via zebra) -
 
-.. clicmd:: [no] evpn mh es-id (1-16777215)
+.. clicmd:: evpn mh es-id (1-16777215)
 
-.. clicmd:: [no] evpn mh es-sys-mac X:X:X:X:X:X
+.. clicmd:: evpn mh es-sys-mac X:X:X:X:X:X
 
 The sys-mac and local discriminator are used for generating a 10-byte,
 Type-3 Ethernet Segment ID.
@@ -2602,7 +2539,7 @@ forward BUM traffic received via the overlay network. This implementation
 uses a preference based DF election specified by draft-ietf-bess-evpn-pref-df.
 The DF preference is configurable per-ES (via zebra) -
 
-.. clicmd:: [no] evpn mh es-df-pref (1-16777215)
+.. clicmd:: evpn mh es-df-pref (1-16777215)
 
 BUM traffic is rxed via the overlay by all PEs attached to a server but
 only the DF can forward the de-capsulated traffic to the access port. To
@@ -2620,9 +2557,9 @@ ES-PE based on just the EAD-per-ES route.
 
 Note that by default we advertise and expect EAD-per-EVI routes.
 
-.. clicmd:: [no] disable-ead-evi-rx
+.. clicmd:: disable-ead-evi-rx
 
-.. clicmd:: [no] disable-ead-evi-tx
+.. clicmd:: disable-ead-evi-tx
 
 Fast failover
 """""""""""""
@@ -2636,13 +2573,13 @@ been introduced for the express purpose of efficient ES failovers.
   On dataplanes that support layer3 nexthop groups the feature can be turned
   on via the following BGP config -
 
-.. clicmd:: [no] use-es-l3nhg
+.. clicmd:: use-es-l3nhg
 
 - Local ES (MAC/Neigh) failover via ES-redirect.
   On dataplanes that do not have support for ES-redirect the feature can be
   turned off via the following zebra config -
 
-.. clicmd:: [no] evpn mh redirect-off
+.. clicmd:: evpn mh redirect-off
 
 Uplink/Core tracking
 """"""""""""""""""""
@@ -2651,7 +2588,7 @@ When all the underlay links go down the PE no longer has access to the VxLAN
 protodowned on the PE. A link can be setup for uplink tracking via the
 following zebra configuration -
 
-.. clicmd:: [no] evpn mh uplink
+.. clicmd:: evpn mh uplink
 
 Proxy advertisements
 """"""""""""""""""""
@@ -2662,9 +2599,9 @@ the ES peer (PE2) goes down PE1 continues to advertise hosts learnt from PE2
 for a holdtime during which it attempts to establish local reachability of
 the host. This holdtime is configurable via the following zebra commands -
 
-.. clicmd:: [no] evpn mh neigh-holdtime (0-86400)
+.. clicmd:: evpn mh neigh-holdtime (0-86400)
 
-.. clicmd:: [no] evpn mh mac-holdtime (0-86400)
+.. clicmd:: evpn mh mac-holdtime (0-86400)
 
 Startup delay
 """""""""""""
@@ -2673,7 +2610,7 @@ and EVPN network to converge before enabling the ESs. For this duration the
 ES bonds are held protodown. The startup delay is configurable via the
 following zebra command -
 
-.. clicmd:: [no] evpn mh startup-delay (0-3600)
+.. clicmd:: evpn mh startup-delay (0-3600)
 
 +Support with VRF network namespace backend
 +^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2731,7 +2668,7 @@ advertisement to take effect is 60 seconds. The conditional advertisement can ta
 effect depending on when the tracked route is removed from the BGP table and
 when the next instance of the BGP scanner occurs.
 
-.. clicmd:: [no] neighbor A.B.C.D advertise-map NAME [exist-map|non-exist-map] NAME
+.. clicmd:: neighbor A.B.C.D advertise-map NAME [exist-map|non-exist-map] NAME
 
    This command enables BGP scanner process to monitor routes specified by
    exist-map or non-exist-map command in BGP table and conditionally advertises
@@ -2897,38 +2834,38 @@ Debugging
    Display Listen sockets and the vrf that created them.  Useful for debugging of when
    listen is not working and this is considered a developer debug statement.
 
-.. clicmd:: [no] debug bgp neighbor-events
+.. clicmd:: debug bgp neighbor-events
 
    Enable or disable debugging for neighbor events. This provides general
    information on BGP events such as peer connection / disconnection, session
    establishment / teardown, and capability negotiation.
 
-.. clicmd:: [no] debug bgp updates
+.. clicmd:: debug bgp updates
 
    Enable or disable debugging for BGP updates. This provides information on
    BGP UPDATE messages transmitted and received between local and remote
    instances.
 
-.. clicmd:: [no] debug bgp keepalives
+.. clicmd:: debug bgp keepalives
 
    Enable or disable debugging for BGP keepalives. This provides information on
    BGP KEEPALIVE messages transmitted and received between local and remote
    instances.
 
-.. clicmd:: [no] debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>
+.. clicmd:: debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>
 
    Enable or disable debugging for bestpath selection on the specified prefix.
 
-.. clicmd:: [no] debug bgp nht
+.. clicmd:: debug bgp nht
 
    Enable or disable debugging of BGP nexthop tracking.
 
-.. clicmd:: [no] debug bgp update-groups
+.. clicmd:: debug bgp update-groups
 
    Enable or disable debugging of dynamic update groups. This provides general
    information on group creation, deletion, join and prune events.
 
-.. clicmd:: [no] debug bgp zebra
+.. clicmd:: debug bgp zebra
 
    Enable or disable debugging of communications between *bgpd* and *zebra*.
 
@@ -2939,7 +2876,6 @@ Dumping Messages and Routing Tables
 
 .. clicmd:: dump bgp all-et PATH [INTERVAL]
 
-.. clicmd:: no dump bgp all [PATH] [INTERVAL]
 
    Dump all BGP packet and events to `path` file.
    If `interval` is set, a new file will be created for echo `interval` of
@@ -2951,7 +2887,6 @@ Dumping Messages and Routing Tables
 
 .. clicmd:: dump bgp updates-et PATH [INTERVAL]
 
-.. clicmd:: no dump bgp updates [PATH] [INTERVAL]
 
    Dump only BGP updates messages to `path` file.
    If `interval` is set, a new file will be created for echo `interval` of
@@ -2963,7 +2898,6 @@ Dumping Messages and Routing Tables
 
 .. clicmd:: dump bgp routes-mrt PATH INTERVAL
 
-.. clicmd:: no dump bgp route-mrt [PATH] [INTERVAL]
 
    Dump whole BGP routing table to `path`. This is heavy process. The path
    `path` can be set with date and time formatting (strftime). If `interval` is
@@ -3357,7 +3291,6 @@ with:
 
 .. clicmd:: neighbor PEER route-reflector-client
 
-.. clicmd:: no neighbor PEER route-reflector-client
 
 To avoid single points of failure, multiple route reflectors can be configured.
 
@@ -3366,7 +3299,7 @@ by route reflectors to avoid looping.
 
 .. clicmd:: bgp cluster-id A.B.C.D
 
-.. clicmd:: [no] bgp no-rib
+.. clicmd:: bgp no-rib
 
 To set and unset the BGP daemon ``-n`` / ``--no_kernel`` options during runtime
 to disable BGP route installation to the RIB (Zebra), the ``[no] bgp no-rib``
@@ -3379,7 +3312,7 @@ starting the daemon and the configuration gets saved, the option will persist
 unless removed from the configuration with the negating command prior to the
 configuration write operation.
 
-.. clicmd:: [no] bgp send-extra-data zebra
+.. clicmd:: bgp send-extra-data zebra
 
 This Command turns off the ability of BGP to send extra data to zebra.
 In this case it's the AS-Path being used for the path.  The default behavior
@@ -3428,7 +3361,7 @@ status in FIB:
 7. If the route which is already installed in dataplane is removed for some
    reason, sending withdraw message to peers is not currently supported.
 
-.. clicmd:: [no] bgp suppress-fib-pending
+.. clicmd:: bgp suppress-fib-pending
 
    This command is applicable at the global level and at an individual
    bgp level.  If applied at the global level all bgp instances will

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1264,35 +1264,10 @@ Route Aggregation-IPv6 Address Family
 Redistribution
 --------------
 
-.. index:: redistribute kernel
-.. clicmd:: redistribute kernel
+.. index:: redistribute <babel|connected|eigrp|isis|kernel|openfabric|ospf|rip|sharp|static|table> [(1-65535)] [metric (0-4294967295)] [route-map WORD]
+.. index:: redistribute <babel|connected|eigrp|isis|kernel|openfabric|ospf|rip|sharp|static|table> [(1-65535)] [metric (0-4294967295)] [route-map WORD]
 
-   Redistribute kernel route to BGP process.
-
-.. index:: redistribute static
-.. clicmd:: redistribute static
-
-   Redistribute static route to BGP process.
-
-.. index:: redistribute connected
-.. clicmd:: redistribute connected
-
-   Redistribute connected route to BGP process.
-
-.. index:: redistribute rip
-.. clicmd:: redistribute rip
-
-   Redistribute RIP route to BGP process.
-
-.. index:: redistribute ospf
-.. clicmd:: redistribute ospf
-
-   Redistribute OSPF route to BGP process.
-
-.. index:: redistribute vnc
-.. clicmd:: redistribute vnc
-
-   Redistribute VNC routes to BGP process.
+   Redistribute routes from other protocols into BGP.
 
 .. index:: redistribute vnc-direct
 .. clicmd:: redistribute vnc-direct

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -252,18 +252,15 @@ command. The AS number is an identifier for the autonomous system. The BGP
 protocol uses the AS number for detecting whether the BGP connection is
 internal or external.
 
-.. index:: router bgp ASN
 .. clicmd:: router bgp ASN
 
    Enable a BGP protocol process with the specified ASN. After
    this statement you can input any `BGP Commands`.
 
-.. index:: router bgp ASN
 .. clicmd:: no router bgp ASN
 
    Destroy a BGP protocol process with the specified ASN.
 
-.. index:: bgp router-id A.B.C.D
 .. clicmd:: bgp router-id A.B.C.D
 
    This command specifies the router-ID. If *bgpd* connects to *zebra* it gets
@@ -301,7 +298,6 @@ However, the same AS can be used with different VRFs.
 Configuration of additional autonomous systems, or of a router that targets a
 specific VRF, is accomplished with the following command:
 
-.. index:: router bgp ASN vrf VRFNAME
 .. clicmd:: router bgp ASN vrf VRFNAME
 
    ``VRFNAME`` is matched against VRFs configured in the kernel. When ``vrf
@@ -344,7 +340,6 @@ via BGP. Multiple views can be supported, and BGP view information is always
 independent from other routing protocols and Zebra/kernel routes. BGP views use
 the core instance (i.e., default VRF) for communication with peers.
 
-.. index:: router bgp AS-NUMBER view NAME
 .. clicmd:: router bgp AS-NUMBER view NAME
 
    Make a new BGP view. You can use an arbitrary word for the ``NAME``. Routes
@@ -363,7 +358,6 @@ the core instance (i.e., default VRF) for communication with peers.
        neighbor 10.0.0.3 remote-as 4
        neighbor 10.0.0.4 remote-as 5
 
-.. index:: show [ip] bgp view NAME
 .. clicmd:: show [ip] bgp view NAME
 
    Display the routing table of BGP view ``NAME``.
@@ -372,14 +366,12 @@ the core instance (i.e., default VRF) for communication with peers.
 Route Selection
 ---------------
 
-.. index:: bgp bestpath as-path confed
 .. clicmd:: bgp bestpath as-path confed
 
    This command specifies that the length of confederation path sets and
    sequences should should be taken into account during the BGP best path
    decision process.
 
-.. index:: bgp bestpath as-path multipath-relax
 .. clicmd:: bgp bestpath as-path multipath-relax
 
    This command specifies that BGP decision process should consider paths
@@ -411,17 +403,14 @@ Route Selection
 Administrative Distance Metrics
 -------------------------------
 
-.. index:: distance bgp (1-255) (1-255) (1-255)
 .. clicmd:: distance bgp (1-255) (1-255) (1-255)
 
    This command change distance value of BGP. The arguments are the distance
    values for for external routes, internal routes and local routes
    respectively.
 
-.. index:: distance (1-255) A.B.C.D/M
 .. clicmd:: distance (1-255) A.B.C.D/M
 
-.. index:: distance (1-255) A.B.C.D/M WORD
 .. clicmd:: distance (1-255) A.B.C.D/M WORD
 
    Sets the administrative distance for a particular route.
@@ -431,7 +420,6 @@ Administrative Distance Metrics
 Require policy on EBGP
 -------------------------------
 
-.. index:: bgp ebgp-requires-policy
 .. clicmd:: [no] bgp ebgp-requires-policy
 
    This command requires incoming and outgoing filters to be applied
@@ -480,7 +468,6 @@ Require policy on EBGP
 Reject routes with AS_SET or AS_CONFED_SET types
 ------------------------------------------------
 
-.. index:: bgp reject-as-sets
 .. clicmd:: [no] bgp reject-as-sets
 
    This command enables rejection of incoming and outgoing routes having AS_SET or AS_CONFED_SET type.
@@ -488,7 +475,6 @@ Reject routes with AS_SET or AS_CONFED_SET types
 Suppress duplicate updates
 --------------------------
 
-.. index:: bgp suppress-duplicates
 .. clicmd:: [no] bgp suppress-duplicates
 
    For example, BGP routers can generate multiple identical announcements with
@@ -499,7 +485,6 @@ Suppress duplicate updates
 Disable checking if nexthop is connected on EBGP sessions
 ---------------------------------------------------------
 
-.. index:: bgp disable-ebgp-connected-route-check
 .. clicmd:: [no] bgp disable-ebgp-connected-route-check
 
    This command is used to disable the connection verification process for EBGP peering sessions
@@ -511,19 +496,16 @@ Disable checking if nexthop is connected on EBGP sessions
 Route Flap Dampening
 --------------------
 
-.. index:: [no] bgp dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
 .. clicmd:: [no] bgp dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
 
    This command enables (with optionally specified dampening parameters) or
    disables route-flap dampening for all routes of a BGP instance.
 
-.. index:: [no] neighbor PEER dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
 .. clicmd:: [no] neighbor PEER dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
 
    This command enables (with optionally specified dampening parameters) or
    disables route-flap dampening for all routes learned from a BGP peer.
 
-.. index:: [no] neighbor GROUP dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
 .. clicmd:: [no] neighbor GROUP dampening [(1-45) [(1-20000) (1-20000) (1-255)]]
 
    This command enables (with optionally specified dampening parameters) or
@@ -769,7 +751,6 @@ topologies are at cross-purposes with each other - see the Flavel and Roughan
 paper above for an example. Hence the guideline that the iBGP topology should
 follow the IGP topology.
 
-.. index:: bgp deterministic-med
 .. clicmd:: bgp deterministic-med
 
    Carry out route-selection in way that produces deterministic answers
@@ -789,7 +770,6 @@ Note that there are other sources of indeterminism in the route selection
 process, specifically, the preference for older and already selected routes
 from eBGP peers, :ref:`bgp-route-selection`.
 
-.. index:: bgp always-compare-med
 .. clicmd:: bgp always-compare-med
 
    Always compare the MED on routes, even when they were received from
@@ -893,7 +873,6 @@ forwarding state has been preserved.
 The remaining bits are reserved and MUST be set to zero by the sender and
 ignored by the receiver.
 
-.. index:: bgp graceful-restart preserve-fw-state
 .. clicmd:: bgp graceful-restart preserve-fw-state
 
 FRR gives us the option to enable/disable the "F" flag using this specific
@@ -943,18 +922,15 @@ However, it MUST defer route selection for an address family until it either.
    that do not advertise the graceful restart capability).
 2. The Selection_Deferral_Timer timeout.
 
-.. index:: bgp graceful-restart select-defer-time (0-3600)
 .. clicmd:: bgp graceful-restart select-defer-time (0-3600)
 
    This is command, will set deferral time to value specified.
 
 
-.. index:: bgp graceful-restart rib-stale-time (1-3600)
 .. clicmd:: bgp graceful-restart rib-stale-time (1-3600)
 
    This is command, will set the time for which stale routes are kept in RIB.
 
-.. index:: bgp graceful-restart stalepath-time (1-4095)
 .. clicmd:: bgp graceful-restart stalepath-time (1-4095)
 
    This is command, will set the max time (in seconds) to hold onto
@@ -988,13 +964,11 @@ override the global mode.
 BGP GR Global Mode Commands
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: bgp graceful-restart
 .. clicmd:: bgp graceful-restart
 
    This command will enable BGP graceful restart ifunctionality at the global
    level.
 
-.. index:: bgp graceful-restart disable
 .. clicmd:: bgp graceful-restart disable
 
    This command will disable both the functionality graceful restart and helper
@@ -1006,19 +980,16 @@ BGP GR Global Mode Commands
 BGP GR Peer Mode Commands
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: neighbor A.B.C.D graceful-restart
 .. clicmd:: neighbor A.B.C.D graceful-restart
 
    This command will enable BGP graceful restart ifunctionality at the peer
    level.
 
-.. index:: neighbor A.B.C.D graceful-restart-helper
 .. clicmd:: neighbor A.B.C.D graceful-restart-helper
 
    This command will enable BGP graceful restart helper only functionality
    at the peer level.
 
-.. index:: neighbor A.B.C.D graceful-restart-disable
 .. clicmd:: neighbor A.B.C.D graceful-restart-disable
 
    This command will disable the entire BGP graceful restart functionality
@@ -1030,7 +1001,6 @@ BGP GR Peer Mode Commands
 Administrative Shutdown
 -----------------------
 
-.. index:: bgp shutdown [message MSG...]
 .. clicmd:: [no] bgp shutdown [message MSG...]
 
    Administrative shutdown of all peers of a bgp instance. Drop all BGP peers,
@@ -1049,7 +1019,6 @@ Administrative Shutdown
 Networks
 --------
 
-.. index:: network A.B.C.D/M
 .. clicmd:: network A.B.C.D/M
 
    This command adds the announcement network.
@@ -1066,10 +1035,8 @@ Networks
    routes if they aren't present in their IGP routing tables; `bgpd`
    doesn't care about IGP routes when announcing its routes.
 
-.. index:: network A.B.C.D/M
 .. clicmd:: no network A.B.C.D/M
 
-.. index:: bgp network import-check
 .. clicmd:: [no] bgp network import-check
 
    This configuration modifies the behavior of the network statement.
@@ -1085,7 +1052,6 @@ Networks
 IPv6 Support
 ------------
 
-.. index:: neighbor A.B.C.D activate
 .. clicmd:: [no] neighbor A.B.C.D activate
 
    This configuration modifies whether to enable an address family for a
@@ -1137,46 +1103,38 @@ Route Aggregation
 Route Aggregation-IPv4 Address Family
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: aggregate-address A.B.C.D/M
 .. clicmd:: aggregate-address A.B.C.D/M
 
    This command specifies an aggregate address.
 
-.. index:: aggregate-address A.B.C.D/M route-map NAME
 .. clicmd:: aggregate-address A.B.C.D/M route-map NAME
 
    Apply a route-map for an aggregated prefix.
 
-.. index:: aggregate-address A.B.C.D/M origin <egp|igp|incomplete>
 .. clicmd:: aggregate-address A.B.C.D/M origin <egp|igp|incomplete>
 
    Override ORIGIN for an aggregated prefix.
 
-.. index:: aggregate-address A.B.C.D/M as-set
 .. clicmd:: aggregate-address A.B.C.D/M as-set
 
    This command specifies an aggregate address. Resulting routes include
    AS set.
 
-.. index:: aggregate-address A.B.C.D/M summary-only
 .. clicmd:: aggregate-address A.B.C.D/M summary-only
 
    This command specifies an aggregate address. Aggregated routes will
    not be announced.
 
-.. index:: aggregate-address A.B.C.D/M matching-MED-only
 .. clicmd:: aggregate-address A.B.C.D/M matching-MED-only
 
    Configure the aggregated address to only be created when the routes MED
    match, otherwise no aggregated route will be created.
 
-.. index:: aggregate-address A.B.C.D/M suppress-map NAME
 .. clicmd:: aggregate-address A.B.C.D/M suppress-map NAME
 
    Similar to `summary-only`, but will only suppress more specific routes that
    are matched by the selected route-map.
 
-.. index:: aggregate-address A.B.C.D/M
 .. clicmd:: no aggregate-address A.B.C.D/M
 
    This command removes an aggregate address.
@@ -1201,46 +1159,38 @@ Route Aggregation-IPv4 Address Family
 Route Aggregation-IPv6 Address Family
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: aggregate-address X:X::X:X/M
 .. clicmd:: aggregate-address X:X::X:X/M
 
    This command specifies an aggregate address.
 
-.. index:: aggregate-address X:X::X:X/M route-map NAME
 .. clicmd:: aggregate-address X:X::X:X/M route-map NAME
 
    Apply a route-map for an aggregated prefix.
 
-.. index:: aggregate-address X:X::X:X/M origin <egp|igp|incomplete>
 .. clicmd:: aggregate-address X:X::X:X/M origin <egp|igp|incomplete>
 
    Override ORIGIN for an aggregated prefix.
 
-.. index:: aggregate-address X:X::X:X/M as-set
 .. clicmd:: aggregate-address X:X::X:X/M as-set
 
    This command specifies an aggregate address. Resulting routes include
    AS set.
 
-.. index:: aggregate-address X:X::X:X/M summary-only
 .. clicmd:: aggregate-address X:X::X:X/M summary-only
 
    This command specifies an aggregate address. Aggregated routes will
    not be announced.
 
-.. index:: aggregate-address X:X::X:X/M matching-MED-only
 .. clicmd:: aggregate-address X:X::X:X/M matching-MED-only
 
    Configure the aggregated address to only be created when the routes MED
    match, otherwise no aggregated route will be created.
 
-.. index:: aggregate-address X:X::X:X/M suppress-map NAME
 .. clicmd:: aggregate-address X:X::X:X/M suppress-map NAME
 
    Similar to `summary-only`, but will only suppress more specific routes that
    are matched by the selected route-map.
 
-.. index:: aggregate-address X:X::X:X/M
 .. clicmd:: no aggregate-address X:X::X:X/M
 
    This command removes an aggregate address.
@@ -1264,20 +1214,15 @@ Route Aggregation-IPv6 Address Family
 Redistribution
 --------------
 
-.. index:: redistribute <babel|connected|eigrp|isis|kernel|openfabric|ospf|rip|sharp|static|table> [(1-65535)] [metric (0-4294967295)] [route-map WORD]
-.. index:: redistribute <babel|connected|eigrp|isis|kernel|openfabric|ospf|rip|sharp|static|table> [(1-65535)] [metric (0-4294967295)] [route-map WORD]
 
    Redistribute routes from other protocols into BGP.
 
-.. index:: redistribute vnc-direct
 .. clicmd:: redistribute vnc-direct
 
    Redistribute VNC direct (not via zebra) routes to BGP process.
 
-.. index:: bgp update-delay MAX-DELAY
 .. clicmd:: bgp update-delay MAX-DELAY
 
-.. index:: bgp update-delay MAX-DELAY ESTABLISH-WAIT
 .. clicmd:: bgp update-delay MAX-DELAY ESTABLISH-WAIT
 
    This feature is used to enable read-only mode on BGP process restart or when
@@ -1309,10 +1254,8 @@ Redistribution
    Default max-delay is 0, i.e. the feature is off by default.
 
 
-.. index:: update-delay MAX-DELAY
 .. clicmd:: update-delay MAX-DELAY
 
-.. index:: update-delay MAX-DELAY ESTABLISH-WAIT
 .. clicmd:: update-delay MAX-DELAY ESTABLISH-WAIT
 
    This feature is used to enable read-only mode on BGP process restart or when
@@ -1343,7 +1286,6 @@ Redistribution
 
    Default max-delay is 0, i.e. the feature is off by default.
 
-.. index:: table-map ROUTE-MAP-NAME
 .. clicmd:: table-map ROUTE-MAP-NAME
 
    This feature is used to apply a route-map on route updates from BGP to
@@ -1365,7 +1307,6 @@ Peers
 Defining Peers
 ^^^^^^^^^^^^^^
 
-.. index:: neighbor PEER remote-as ASN
 .. clicmd:: neighbor PEER remote-as ASN
 
    Creates a new neighbor whose remote-as is ASN. PEER can be an IPv4 address
@@ -1383,21 +1324,18 @@ Defining Peers
 
       can't find neighbor 10.0.0.1
 
-.. index:: neighbor PEER remote-as internal
 .. clicmd:: neighbor PEER remote-as internal
 
    Create a peer as you would when you specify an ASN, except that if the
    peers ASN is different than mine as specified under the :clicmd:`router bgp ASN`
    command the connection will be denied.
 
-.. index:: neighbor PEER remote-as external
 .. clicmd:: neighbor PEER remote-as external
 
    Create a peer as you would when you specify an ASN, except that if the
    peers ASN is the same as mine as specified under the :clicmd:`router bgp ASN`
    command the connection will be denied.
 
-.. index:: bgp listen range <A.B.C.D/M|X:X::X:X/M> peer-group PGNAME
 .. clicmd:: [no] bgp listen range <A.B.C.D/M|X:X::X:X/M> peer-group PGNAME
 
    Accept connections from any peers in the specified prefix. Configuration
@@ -1421,7 +1359,6 @@ Defining Peers
    ``net.core.optmem_max`` to allow the kernel to allocate the necessary option
    memory.
 
-.. index:: coalesce-time (0-4294967295)
 .. clicmd:: [no] coalesce-time (0-4294967295)
 
    The time in milliseconds that BGP will delay before deciding what peers
@@ -1433,7 +1370,6 @@ Defining Peers
 Configuring Peers
 ^^^^^^^^^^^^^^^^^
 
-.. index:: neighbor PEER shutdown [message MSG...] [rtt (1-65535) [count (1-255)]]
 .. clicmd:: [no] neighbor PEER shutdown [message MSG...] [rtt (1-65535) [count (1-255)]]
 
    Shutdown the peer. We can delete the neighbor's configuration by
@@ -1449,13 +1385,11 @@ Configuring Peers
    Additional ``count`` parameter is the number of keepalive messages to count
    before shutdown the peer if round-trip-time becomes higher than defined.
 
-.. index:: neighbor PEER disable-connected-check
 .. clicmd:: [no] neighbor PEER disable-connected-check
 
    Allow peerings between directly connected eBGP peers using loopback
    addresses.
 
-.. index:: neighbor PEER ebgp-multihop
 .. clicmd:: [no] neighbor PEER ebgp-multihop
 
    Specifying ``ebgp-multihop`` allows sessions with eBGP neighbors to
@@ -1466,12 +1400,10 @@ Configuring Peers
    If the peer's IP address is not in the RIB and is reachable via the
    default route, then you have to enable ``ip nht resolve-via-default``.
 
-.. index:: neighbor PEER description ...
 .. clicmd:: [no] neighbor PEER description ...
 
    Set description of the peer.
 
-.. index:: neighbor PEER version VERSION
 .. clicmd:: [no] neighbor PEER version VERSION
 
    Set up the neighbor's BGP version. `version` can be `4`, `4+` or `4-`. BGP
@@ -1481,7 +1413,6 @@ Configuring Peers
    revision 00's Multiprotocol Extensions for BGP-4. Some routing software is
    still using this version.
 
-.. index:: neighbor PEER interface IFNAME
 .. clicmd:: [no] neighbor PEER interface IFNAME
 
    When you connect to a BGP peer over an IPv6 link-local address, you have to
@@ -1492,7 +1423,6 @@ Configuring Peers
    This command is deprecated and may be removed in a future release. Its use
    should be avoided.
 
-.. index:: neighbor PEER next-hop-self [all]
 .. clicmd:: [no] neighbor PEER next-hop-self [all]
 
    This command specifies an announced route's nexthop as being equivalent to
@@ -1500,7 +1430,6 @@ Configuring Peers
    keyword `all` is specified the modification is done also for routes learned
    via iBGP.
 
-.. index:: neighbor PEER attribute-unchanged [{as-path|next-hop|med}]
 .. clicmd:: neighbor PEER attribute-unchanged [{as-path|next-hop|med}]
 
    This command specifies attributes to be left unchanged for advertisements
@@ -1508,7 +1437,6 @@ Configuring Peers
    configurations, as the route-map directive to leave the next-hop unchanged
    is only available for ipv4.
 
-.. index:: neighbor PEER update-source <IFNAME|ADDRESS>
 .. clicmd:: [no] neighbor PEER update-source <IFNAME|ADDRESS>
 
    Specify the IPv4 source address to use for the :abbr:`BGP` session to this
@@ -1523,17 +1451,14 @@ Configuring Peers
        neighbor bar update-source lo0
 
 
-.. index:: neighbor PEER default-originate
 .. clicmd:: [no] neighbor PEER default-originate
 
    *bgpd*'s default is to not announce the default route (0.0.0.0/0) even if it
    is in routing table. When you want to announce default routes to the peer,
    use this command.
 
-.. index:: neighbor PEER port PORT
 .. clicmd:: neighbor PEER port PORT
 
-.. index:: neighbor PEER password PASSWORD
 .. clicmd:: [no] neighbor PEER password PASSWORD
 
    Set a MD5 password to be used with the tcp socket that is being used
@@ -1542,15 +1467,12 @@ Configuring Peers
    modifying the `net.core.optmem_max` sysctl to a larger value to
    avoid out of memory errors from the linux kernel.
 
-.. index:: neighbor PEER send-community
 .. clicmd:: neighbor PEER send-community
 
-.. index:: neighbor PEER weight WEIGHT
 .. clicmd:: [no] neighbor PEER weight WEIGHT
 
    This command specifies a default `weight` value for the neighbor's routes.
 
-.. index:: neighbor PEER maximum-prefix NUMBER [force]
 .. clicmd:: [no] neighbor PEER maximum-prefix NUMBER [force]
 
    Sets a maximum number of prefixes we can receive from a given peer. If this
@@ -1568,7 +1490,6 @@ Configuring Peers
    but you want maximum-prefix to act on ALL (including filtered) prefixes. This
    option requires `soft-reconfiguration inbound` to be enabled for the peer.
 
-.. index:: neighbor PEER maximum-prefix-out NUMBER
 .. clicmd:: [no] neighbor PEER maximum-prefix-out NUMBER
 
    Sets a maximum number of prefixes we can send to a given peer.
@@ -1576,7 +1497,6 @@ Configuring Peers
    Since sent prefix count is managed by update-groups, this option
    creates a separate update-group for outgoing updates.
 
-.. index:: neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
 .. clicmd:: [no] neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
 
    Specify an alternate AS for this BGP process when interacting with the
@@ -1595,7 +1515,6 @@ Configuring Peers
 
    This command is only allowed for eBGP peers.
 
-.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> as-override
 .. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> as-override
 
    Override AS number of the originating router with the local AS number.
@@ -1608,7 +1527,6 @@ Configuring Peers
 
    This command is only allowed for eBGP peers.
 
-.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]
 .. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]
 
    Accept incoming routes with AS path containing AS number with the same value
@@ -1626,19 +1544,16 @@ Configuring Peers
 
    This command is only allowed for eBGP peers.
 
-.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-all-paths
 .. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-all-paths
 
    Configure BGP to send all known paths to neighbor in order to preserve multi
    path capabilities inside a network.
 
-.. index:: neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-bestpath-per-AS
 .. clicmd:: [no] neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-bestpath-per-AS
 
    Configure BGP to send best known paths to neighbor in order to preserve multi
    path capabilities inside a network.
 
-.. index:: neighbor PEER ttl-security hops NUMBER
 .. clicmd:: [no] neighbor PEER ttl-security hops NUMBER
 
    This command enforces Generalized TTL Security Mechanism (GTSM), as
@@ -1646,7 +1561,6 @@ Configuring Peers
    specified number of hops away will be allowed to become neighbors. This
    command is mutually exclusive with *ebgp-multihop*.
 
-.. index:: neighbor PEER capability extended-nexthop
 .. clicmd:: [no] neighbor PEER capability extended-nexthop
 
    Allow bgp to negotiate the extended-nexthop capability with it's peer.
@@ -1655,7 +1569,6 @@ Configuring Peers
    turning on this command will allow BGP to install v4 routes with
    v6 nexthops if you do not have v4 configured on interfaces.
 
-.. index:: bgp fast-external-failover
 .. clicmd:: [no] bgp fast-external-failover
 
    This command causes bgp to not take down ebgp peers immediately
@@ -1663,34 +1576,29 @@ Configuring Peers
    and will not be displayed as part of a `show run`.  The no form
    of the command turns off this ability.
 
-.. index:: bgp default ipv4-unicast
 .. clicmd:: [no] bgp default ipv4-unicast
 
    This command allows the user to specify that v4 peering is turned
    on by default or not.  This command defaults to on and is not displayed.
    The `no bgp default ipv4-unicast` form of the command is displayed.
 
-.. index:: bgp default show-hostname
 .. clicmd:: [no] bgp default show-hostname
 
    This command shows the hostname of the peer in certain BGP commands
    outputs. It's easier to troubleshoot if you have a number of BGP peers.
 
-.. index:: bgp default show-nexthop-hostname
 .. clicmd:: [no] bgp default show-nexthop-hostname
 
    This command shows the hostname of the next-hop in certain BGP commands
    outputs. It's easier to troubleshoot if you have a number of BGP peers
    and a number of routes to check.
 
-.. index:: neighbor PEER advertisement-interval (0-600)
 .. clicmd:: [no] neighbor PEER advertisement-interval (0-600)
 
    Setup the minimum route advertisement interval(mrai) for the
    peer in question.  This number is between 0 and 600 seconds,
    with the default advertisement interval being 0.
 
-.. index:: neighbor PEER timers delayopen (1-240)
 .. clicmd:: [no] neighbor PEER timers delayopen (1-240)
 
    This command allows the user enable the
@@ -1702,7 +1610,6 @@ Configuring Peers
 Displaying Information about Peers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: show bgp <afi> <safi> neighbors WORD bestpath-routes [json] [wide]
 .. clicmd:: show bgp <afi> <safi> neighbors WORD bestpath-routes [json] [wide]
 
    For the given neighbor, WORD, that is specified list the routes selected
@@ -1713,31 +1620,25 @@ Displaying Information about Peers
 Peer Filtering
 ^^^^^^^^^^^^^^
 
-.. index:: neighbor PEER distribute-list NAME [in|out]
 .. clicmd:: neighbor PEER distribute-list NAME [in|out]
 
    This command specifies a distribute-list for the peer. `direct` is
    ``in`` or ``out``.
 
-.. index:: neighbor PEER prefix-list NAME [in|out]
 .. clicmd:: neighbor PEER prefix-list NAME [in|out]
 
-.. index:: neighbor PEER filter-list NAME [in|out]
 .. clicmd:: neighbor PEER filter-list NAME [in|out]
 
-.. index:: neighbor PEER route-map NAME [in|out]
 .. clicmd:: neighbor PEER route-map NAME [in|out]
 
    Apply a route-map on the neighbor. `direct` must be `in` or `out`.
 
-.. index:: bgp route-reflector allow-outbound-policy
 .. clicmd:: bgp route-reflector allow-outbound-policy
 
    By default, attribute modification via route-map policy out is not reflected
    on reflected routes. This option allows the modifications to be reflected as
    well. Once enabled, it affects all reflected routes.
 
-.. index:: neighbor PEER sender-as-path-loop-detection
 .. clicmd:: [no] neighbor PEER sender-as-path-loop-detection
 
    Enable the detection of sender side AS path loops and filter the
@@ -1758,17 +1659,14 @@ indicated the originating peer.  All peers not associated with a
 specific peer group are treated as belonging to a default peer group,
 and will share updates.
 
-.. index:: neighbor WORD peer-group
 .. clicmd:: neighbor WORD peer-group
 
    This command defines a new peer group.
 
-.. index:: neighbor PEER peer-group PGNAME
 .. clicmd:: neighbor PEER peer-group PGNAME
 
    This command bind specific peer to peer group WORD.
 
-.. index:: neighbor PEER solo
 .. clicmd:: neighbor PEER solo
 
    This command is used to indicate that routes advertised by the peer
@@ -1778,10 +1676,8 @@ and will share updates.
 Capability Negotiation
 ^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: neighbor PEER strict-capability-match
 .. clicmd:: neighbor PEER strict-capability-match
 
-.. index:: neighbor PEER strict-capability-match
 .. clicmd:: no neighbor PEER strict-capability-match
 
    Strictly compares remote capabilities and local capabilities. If
@@ -1793,7 +1689,6 @@ Capability Negotiation
    Negotiation. Please use *dont-capability-negotiate* command to disable the
    feature.
 
-.. index:: neighbor PEER dont-capability-negotiate
 .. clicmd:: [no] neighbor PEER dont-capability-negotiate
 
    Suppress sending Capability Negotiation as OPEN message optional parameter
@@ -1814,10 +1709,8 @@ Capability Negotiation
    hostname support, AS4, Addpath, Route Refresh, ORF, Dynamic Capabilities,
    and graceful restart.
 
-.. index:: neighbor PEER override-capability
 .. clicmd:: neighbor PEER override-capability
 
-.. index:: neighbor PEER override-capability
 .. clicmd:: no neighbor PEER override-capability
 
    Override the result of Capability Negotiation with local configuration.
@@ -1830,15 +1723,12 @@ AS Path Access Lists
 
 AS path access list is user defined AS path.
 
-.. index:: bgp as-path access-list WORD permit|deny LINE
 .. clicmd:: bgp as-path access-list WORD permit|deny LINE
 
    This command defines a new AS path access list.
 
-.. index:: bgp as-path access-list WORD
 .. clicmd:: no bgp as-path access-list WORD
 
-.. index:: bgp as-path access-list WORD permit|deny LINE
 .. clicmd:: no bgp as-path access-list WORD permit|deny LINE
 
 .. _bgp-bogon-filter-example:
@@ -1857,20 +1747,17 @@ Bogon ASN filter policy configuration example
 Using AS Path in Route Map
 --------------------------
 
-.. index:: match as-path WORD
 .. clicmd:: [no] match as-path WORD
 
    For a given as-path, WORD, match it on the BGP as-path given for the prefix
    and if it matches do normal route-map actions.  The no form of the command
    removes this match from the route-map.
 
-.. index:: set as-path prepend AS-PATH
 .. clicmd:: [no] set as-path prepend AS-PATH
 
    Prepend the given string of AS numbers to the AS_PATH of the BGP path's NLRI.
    The no form of this command removes this set operation from the route-map.
 
-.. index:: set as-path prepend last-as NUM
 .. clicmd:: [no] set as-path prepend last-as NUM
 
    Prepend the existing last AS number (the leftmost ASN) to the AS_PATH.
@@ -2017,7 +1904,6 @@ expanded
    interpreted on each use expanded community lists are slower than standard
    lists.
 
-.. index:: bgp community-list standard NAME permit|deny COMMUNITY
 .. clicmd:: bgp community-list standard NAME permit|deny COMMUNITY
 
    This command defines a new standard community list. ``COMMUNITY`` is
@@ -2028,7 +1914,6 @@ expanded
    community list definition. When there is no matched entry, deny will be
    returned. When ``COMMUNITY`` is empty it matches to any routes.
 
-.. index:: bgp community-list expanded NAME permit|deny COMMUNITY
 .. clicmd:: bgp community-list expanded NAME permit|deny COMMUNITY
 
    This command defines a new expanded community list. ``COMMUNITY`` is a
@@ -2040,7 +1925,6 @@ expanded
 .. deprecated:: 5.0
    It is recommended to use the more explicit versions of this command.
 
-.. index:: bgp community-list NAME permit|deny COMMUNITY
 .. clicmd:: bgp community-list NAME permit|deny COMMUNITY
 
    When the community list type is not specified, the community list type is
@@ -2050,14 +1934,12 @@ expanded
    for backward compatibility. Use of this feature is not recommended.
 
 
-.. index:: bgp community-list [standard|expanded] NAME
 .. clicmd:: no bgp community-list [standard|expanded] NAME
 
    Deletes the community list specified by ``NAME``. All community lists share
    the same namespace, so it's not necessary to specify ``standard`` or
    ``expanded``; these modifiers are purely aesthetic.
 
-.. index:: show bgp community-list [NAME detail]
 .. clicmd:: show bgp community-list [NAME detail]
 
    Displays community list information. When ``NAME`` is specified the
@@ -2090,13 +1972,11 @@ to 199 is expanded community list. These community lists are called
 as numbered community lists. On the other hand normal community lists
 is called as named community lists.
 
-.. index:: bgp community-list (1-99) permit|deny COMMUNITY
 .. clicmd:: bgp community-list (1-99) permit|deny COMMUNITY
 
    This command defines a new community list. The argument to (1-99) defines
    the list identifier.
 
-.. index:: bgp community-list (100-199) permit|deny COMMUNITY
 .. clicmd:: bgp community-list (100-199) permit|deny COMMUNITY
 
    This command defines a new expanded community list. The argument to
@@ -2113,7 +1993,6 @@ communities attribute.
 
 The following commands can be used in route maps:
 
-.. index:: match community WORD exact-match [exact-match]
 .. clicmd:: match community WORD exact-match [exact-match]
 
    This command perform match to BGP updates using community list WORD. When
@@ -2122,7 +2001,6 @@ The following commands can be used in route maps:
    happen only when BGP updates have completely same communities value
    specified in the community list.
 
-.. index:: set community <none|COMMUNITY> additive
 .. clicmd:: set community <none|COMMUNITY> additive
 
    This command sets the community value in BGP updates.  If the attribute is
@@ -2135,7 +2013,6 @@ The following commands can be used in route maps:
 
    It is not possible to set an expanded community list.
 
-.. index:: set comm-list WORD delete
 .. clicmd:: set comm-list WORD delete
 
    This command remove communities value from BGP communities attribute.  The
@@ -2312,7 +2189,6 @@ the other is IP address based format.
 Extended Community Lists
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: bgp extcommunity-list standard NAME permit|deny EXTCOMMUNITY
 .. clicmd:: bgp extcommunity-list standard NAME permit|deny EXTCOMMUNITY
 
    This command defines a new standard extcommunity-list. `extcommunity` is
@@ -2324,7 +2200,6 @@ Extended Community Lists
    there is no matched entry, deny will be returned. When `extcommunity` is
    empty it matches to any routes.
 
-.. index:: bgp extcommunity-list expanded NAME permit|deny LINE
 .. clicmd:: bgp extcommunity-list expanded NAME permit|deny LINE
 
    This command defines a new expanded extcommunity-list. `line` is a string
@@ -2332,23 +2207,18 @@ Extended Community Lists
    expression (:ref:`bgp-regular-expressions`) to match an extended communities
    attribute in BGP updates.
 
-.. index:: bgp extcommunity-list NAME
 .. clicmd:: no bgp extcommunity-list NAME
 
-.. index:: bgp extcommunity-list standard NAME
 .. clicmd:: no bgp extcommunity-list standard NAME
 
-.. index:: bgp extcommunity-list expanded NAME
 .. clicmd:: no bgp extcommunity-list expanded NAME
 
    These commands delete extended community lists specified by `name`. All of
    extended community lists shares a single name space. So extended community
    lists can be removed simply specifying the name.
 
-.. index:: show bgp extcommunity-list
 .. clicmd:: show bgp extcommunity-list
 
-.. index:: show bgp extcommunity-list NAME detail
 .. clicmd:: show bgp extcommunity-list NAME detail
 
    This command displays current extcommunity-list information. When `name` is
@@ -2362,20 +2232,16 @@ Extended Community Lists
 BGP Extended Communities in Route Map
 """""""""""""""""""""""""""""""""""""
 
-.. index:: match extcommunity WORD
 .. clicmd:: match extcommunity WORD
 
-.. index:: set extcommunity rt EXTCOMMUNITY
 .. clicmd:: set extcommunity rt EXTCOMMUNITY
 
    This command set Route Target value.
 
-.. index:: set extcommunity soo EXTCOMMUNITY
 .. clicmd:: set extcommunity soo EXTCOMMUNITY
 
    This command set Site of Origin value.
 
-.. index:: set extcommunity bandwidth <(1-25600) | cumulative | num-multipaths> [non-transitive]
 .. clicmd:: set extcommunity bandwidth <(1-25600) | cumulative | num-multipaths> [non-transitive]
 
    This command sets the BGP link-bandwidth extended community for the prefix
@@ -2427,7 +2293,6 @@ Large Community Lists
 Two types of large community lists are supported, namely `standard` and
 `expanded`.
 
-.. index:: bgp large-community-list standard NAME permit|deny LARGE-COMMUNITY
 .. clicmd:: bgp large-community-list standard NAME permit|deny LARGE-COMMUNITY
 
    This command defines a new standard large-community-list.  `large-community`
@@ -2438,7 +2303,6 @@ Two types of large community lists are supported, namely `standard` and
    definition. When there is no matched entry, a deny will be returned. When
    `large-community` is empty it matches any routes.
 
-.. index:: bgp large-community-list expanded NAME permit|deny LINE
 .. clicmd:: bgp large-community-list expanded NAME permit|deny LINE
 
    This command defines a new expanded large-community-list. Where `line` is a
@@ -2447,29 +2311,23 @@ Two types of large community lists are supported, namely `standard` and
    lowest to highest.  `line` can also be a regular expression which matches
    this Large Community attribute.
 
-.. index:: bgp large-community-list NAME
 .. clicmd:: no bgp large-community-list NAME
 
-.. index:: bgp large-community-list standard NAME
 .. clicmd:: no bgp large-community-list standard NAME
 
-.. index:: bgp large-community-list expanded NAME
 .. clicmd:: no bgp large-community-list expanded NAME
 
    These commands delete Large Community lists specified by `name`. All Large
    Community lists share a single namespace.  This means Large Community lists
    can be removed by simply specifying the name.
 
-.. index:: show bgp large-community-list
 .. clicmd:: show bgp large-community-list
 
-.. index:: show bgp large-community-list NAME detail
 .. clicmd:: show bgp large-community-list NAME detail
 
    This command display current large-community-list information. When
    `name` is specified the community list information is shown.
 
-.. index:: show ip bgp large-community-info
 .. clicmd:: show ip bgp large-community-info
 
    This command displays the current large communities in use.
@@ -2479,7 +2337,6 @@ Two types of large community lists are supported, namely `standard` and
 Large Communities in Route Map
 """"""""""""""""""""""""""""""
 
-.. index:: match large-community LINE [exact-match]
 .. clicmd:: match large-community LINE [exact-match]
 
    Where `line` can be a simple string to match, or a regular expression. It
@@ -2489,13 +2346,10 @@ Large Communities in Route Map
    happen only when BGP updates have completely same large communities value
    specified in the large community list.
 
-.. index:: set large-community LARGE-COMMUNITY
 .. clicmd:: set large-community LARGE-COMMUNITY
 
-.. index:: set large-community LARGE-COMMUNITY LARGE-COMMUNITY
 .. clicmd:: set large-community LARGE-COMMUNITY LARGE-COMMUNITY
 
-.. index:: set large-community LARGE-COMMUNITY additive
 .. clicmd:: set large-community LARGE-COMMUNITY additive
 
    These commands are used for setting large-community values. The first
@@ -2577,18 +2431,15 @@ Configuration of route leaking between a unicast VRF RIB and the VPN SAFI RIB
 of the default VRF is accomplished via commands in the context of a VRF
 address-family:
 
-.. index:: rd vpn export AS:NN|IP:nn
 .. clicmd:: rd vpn export AS:NN|IP:nn
 
    Specifies the route distinguisher to be added to a route exported from the
    current unicast VRF to VPN.
 
-.. index:: rd vpn export [AS:NN|IP:nn]
 .. clicmd:: no rd vpn export [AS:NN|IP:nn]
 
    Deletes any previously-configured export route distinguisher.
 
-.. index:: rt vpn import|export|both RTLIST...
 .. clicmd:: rt vpn import|export|both RTLIST...
 
    Specifies the route-target list to be attached to a route (export) or the
@@ -2599,12 +2450,10 @@ address-family:
    extended community values as described in
    :ref:`bgp-extended-communities-attribute`.
 
-.. index:: rt vpn import|export|both [RTLIST...]
 .. clicmd:: no rt vpn import|export|both [RTLIST...]
 
    Deletes any previously-configured import or export route-target list.
 
-.. index:: label vpn export (0..1048575)|auto
 .. clicmd:: label vpn export (0..1048575)|auto
 
    Enables an MPLS label to be attached to a route exported from the current
@@ -2613,45 +2462,37 @@ address-family:
    is not running, or if this command is not configured, automatic label
    assignment will not complete, which will block corresponding route export.
 
-.. index:: label vpn export [(0..1048575)|auto]
 .. clicmd:: no label vpn export [(0..1048575)|auto]
 
    Deletes any previously-configured export label.
 
-.. index:: nexthop vpn export A.B.C.D|X:X::X:X
 .. clicmd:: nexthop vpn export A.B.C.D|X:X::X:X
 
    Specifies an optional nexthop value to be assigned to a route exported from
    the current unicast VRF to VPN. If left unspecified, the nexthop will be set
    to 0.0.0.0 or 0:0::0:0 (self).
 
-.. index:: nexthop vpn export [A.B.C.D|X:X::X:X]
 .. clicmd:: no nexthop vpn export [A.B.C.D|X:X::X:X]
 
    Deletes any previously-configured export nexthop.
 
-.. index:: route-map vpn import|export MAP
 .. clicmd:: route-map vpn import|export MAP
 
    Specifies an optional route-map to be applied to routes imported or exported
    between the current unicast VRF and VPN.
 
-.. index:: route-map vpn import|export [MAP]
 .. clicmd:: no route-map vpn import|export [MAP]
 
    Deletes any previously-configured import or export route-map.
 
-.. index:: import|export vpn
 .. clicmd:: import|export vpn
 
    Enables import or export of routes between the current unicast VRF and VPN.
 
-.. index:: import|export vpn
 .. clicmd:: no import|export vpn
 
    Disables import or export of routes between the current unicast VRF and VPN.
 
-.. index:: import vrf VRFNAME
 .. clicmd:: import vrf VRFNAME
 
    Shortcut syntax for specifying automatic leaking from vrf VRFNAME to
@@ -2664,7 +2505,6 @@ address-family:
    The CLI will disallow attempts to configure incompatible leaking
    modes.
 
-.. index:: import vrf VRFNAME
 .. clicmd:: no import vrf VRFNAME
 
    Disables automatic leaking from vrf VRFNAME to the current VRF using
@@ -2720,7 +2560,6 @@ disable the feature via configuration CLI. Once the feature is disable under
 bgp vrf instance or MAC-VLAN interface is not configured, all the routes follow
 the same behavior of using same next-hop and RMAC values.
 
-.. index:: advertise-pip [ip <addr> [mac <addr>]]
 .. clicmd:: [no] advertise-pip [ip <addr> [mac <addr>]]
 
 Enables or disables advertise-pip feature, specifiy system-IP and/or system-MAC
@@ -2738,10 +2577,8 @@ Ethernet Segments
 An Ethernet Segment can be configured by specifying a system-MAC and a
 local discriminatior against the bond interface on the PE (via zebra) -
 
-.. index:: evpn mh es-id (1-16777215)
 .. clicmd:: [no] evpn mh es-id (1-16777215)
 
-.. index:: evpn mh es-sys-mac X:X:X:X:X:X
 .. clicmd:: [no] evpn mh es-sys-mac X:X:X:X:X:X
 
 The sys-mac and local discriminator are used for generating a 10-byte,
@@ -2765,7 +2602,6 @@ forward BUM traffic received via the overlay network. This implementation
 uses a preference based DF election specified by draft-ietf-bess-evpn-pref-df.
 The DF preference is configurable per-ES (via zebra) -
 
-.. index:: evpn mh es-df-pref (1-16777215)
 .. clicmd:: [no] evpn mh es-df-pref (1-16777215)
 
 BUM traffic is rxed via the overlay by all PEs attached to a server but
@@ -2784,10 +2620,8 @@ ES-PE based on just the EAD-per-ES route.
 
 Note that by default we advertise and expect EAD-per-EVI routes.
 
-.. index:: disable-ead-evi-rx
 .. clicmd:: [no] disable-ead-evi-rx
 
-.. index:: disable-ead-evi-tx
 .. clicmd:: [no] disable-ead-evi-tx
 
 Fast failover
@@ -2802,14 +2636,12 @@ been introduced for the express purpose of efficient ES failovers.
   On dataplanes that support layer3 nexthop groups the feature can be turned
   on via the following BGP config -
 
-.. index:: use-es-l3nhg
 .. clicmd:: [no] use-es-l3nhg
 
 - Local ES (MAC/Neigh) failover via ES-redirect.
   On dataplanes that do not have support for ES-redirect the feature can be
   turned off via the following zebra config -
 
-.. index:: evpn mh redirect-off
 .. clicmd:: [no] evpn mh redirect-off
 
 Uplink/Core tracking
@@ -2819,7 +2651,6 @@ When all the underlay links go down the PE no longer has access to the VxLAN
 protodowned on the PE. A link can be setup for uplink tracking via the
 following zebra configuration -
 
-.. index:: evpn mh uplink
 .. clicmd:: [no] evpn mh uplink
 
 Proxy advertisements
@@ -2831,10 +2662,8 @@ the ES peer (PE2) goes down PE1 continues to advertise hosts learnt from PE2
 for a holdtime during which it attempts to establish local reachability of
 the host. This holdtime is configurable via the following zebra commands -
 
-.. index:: evpn mh neigh-holdtime (0-86400)
 .. clicmd:: [no] evpn mh neigh-holdtime (0-86400)
 
-.. index:: evpn mh mac-holdtime (0-86400)
 .. clicmd:: [no] evpn mh mac-holdtime (0-86400)
 
 Startup delay
@@ -2844,7 +2673,6 @@ and EVPN network to converge before enabling the ESs. For this duration the
 ES bonds are held protodown. The startup delay is configurable via the
 following zebra command -
 
-.. index:: evpn mh startup-delay (0-3600)
 .. clicmd:: [no] evpn mh startup-delay (0-3600)
 
 +Support with VRF network namespace backend
@@ -2903,7 +2731,6 @@ advertisement to take effect is 60 seconds. The conditional advertisement can ta
 effect depending on when the tracked route is removed from the BGP table and
 when the next instance of the BGP scanner occurs.
 
-.. index:: neighbor A.B.C.D advertise-map NAME [exist-map|non-exist-map] NAME
 .. clicmd:: [no] neighbor A.B.C.D advertise-map NAME [exist-map|non-exist-map] NAME
 
    This command enables BGP scanner process to monitor routes specified by
@@ -3061,55 +2888,46 @@ When default route is not present in R2'2 BGP table, 10.139.224.0/20 and 192.0.2
 Debugging
 ---------
 
-.. index:: show debug
 .. clicmd:: show debug
 
    Show all enabled debugs.
 
-.. index:: show bgp listeners
 .. clicmd:: show bgp listeners
 
    Display Listen sockets and the vrf that created them.  Useful for debugging of when
    listen is not working and this is considered a developer debug statement.
 
-.. index:: debug bgp neighbor-events
 .. clicmd:: [no] debug bgp neighbor-events
 
    Enable or disable debugging for neighbor events. This provides general
    information on BGP events such as peer connection / disconnection, session
    establishment / teardown, and capability negotiation.
 
-.. index:: debug bgp updates
 .. clicmd:: [no] debug bgp updates
 
    Enable or disable debugging for BGP updates. This provides information on
    BGP UPDATE messages transmitted and received between local and remote
    instances.
 
-.. index:: debug bgp keepalives
 .. clicmd:: [no] debug bgp keepalives
 
    Enable or disable debugging for BGP keepalives. This provides information on
    BGP KEEPALIVE messages transmitted and received between local and remote
    instances.
 
-.. index:: debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>
 .. clicmd:: [no] debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>
 
    Enable or disable debugging for bestpath selection on the specified prefix.
 
-.. index:: debug bgp nht
 .. clicmd:: [no] debug bgp nht
 
    Enable or disable debugging of BGP nexthop tracking.
 
-.. index:: debug bgp update-groups
 .. clicmd:: [no] debug bgp update-groups
 
    Enable or disable debugging of dynamic update groups. This provides general
    information on group creation, deletion, join and prune events.
 
-.. index:: debug bgp zebra
 .. clicmd:: [no] debug bgp zebra
 
    Enable or disable debugging of communications between *bgpd* and *zebra*.
@@ -3117,13 +2935,10 @@ Debugging
 Dumping Messages and Routing Tables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: dump bgp all PATH [INTERVAL]
 .. clicmd:: dump bgp all PATH [INTERVAL]
 
-.. index:: dump bgp all-et PATH [INTERVAL]
 .. clicmd:: dump bgp all-et PATH [INTERVAL]
 
-.. index:: dump bgp all [PATH] [INTERVAL]
 .. clicmd:: no dump bgp all [PATH] [INTERVAL]
 
    Dump all BGP packet and events to `path` file.
@@ -3132,13 +2947,10 @@ Dumping Messages and Routing Tables
    (strftime).  The type ‘all-et’ enables support for Extended Timestamp Header
    (:ref:`packet-binary-dump-format`).
 
-.. index:: dump bgp updates PATH [INTERVAL]
 .. clicmd:: dump bgp updates PATH [INTERVAL]
 
-.. index:: dump bgp updates-et PATH [INTERVAL]
 .. clicmd:: dump bgp updates-et PATH [INTERVAL]
 
-.. index:: dump bgp updates [PATH] [INTERVAL]
 .. clicmd:: no dump bgp updates [PATH] [INTERVAL]
 
    Dump only BGP updates messages to `path` file.
@@ -3147,13 +2959,10 @@ Dumping Messages and Routing Tables
    (strftime).  The type ‘updates-et’ enables support for Extended Timestamp
    Header (:ref:`packet-binary-dump-format`).
 
-.. index:: dump bgp routes-mrt PATH
 .. clicmd:: dump bgp routes-mrt PATH
 
-.. index:: dump bgp routes-mrt PATH INTERVAL
 .. clicmd:: dump bgp routes-mrt PATH INTERVAL
 
-.. index:: dump bgp route-mrt [PATH] [INTERVAL]
 .. clicmd:: no dump bgp route-mrt [PATH] [INTERVAL]
 
    Dump whole BGP routing table to `path`. This is heavy process. The path
@@ -3170,44 +2979,36 @@ Other BGP Commands
 
 The following are available in the top level *enable* mode:
 
-.. index:: clear bgp \*
 .. clicmd:: clear bgp \*
 
    Clear all peers.
 
-.. index:: clear bgp ipv4|ipv6 \*
 .. clicmd:: clear bgp ipv4|ipv6 \*
 
    Clear all peers with this address-family activated.
 
-.. index:: clear bgp ipv4|ipv6 unicast \*
 .. clicmd:: clear bgp ipv4|ipv6 unicast \*
 
    Clear all peers with this address-family and sub-address-family activated.
 
-.. index:: clear bgp ipv4|ipv6 PEER
 .. clicmd:: clear bgp ipv4|ipv6 PEER
 
    Clear peers with address of X.X.X.X and this address-family activated.
 
-.. index:: clear bgp ipv4|ipv6 unicast PEER
 .. clicmd:: clear bgp ipv4|ipv6 unicast PEER
 
    Clear peer with address of X.X.X.X and this address-family and sub-address-family activated.
 
-.. index:: clear bgp ipv4|ipv6 PEER soft|in|out
 .. clicmd:: clear bgp ipv4|ipv6 PEER soft|in|out
 
    Clear peer using soft reconfiguration in this address-family.
 
-.. index:: clear bgp ipv4|ipv6 unicast PEER soft|in|out
 .. clicmd:: clear bgp ipv4|ipv6 unicast PEER soft|in|out
 
    Clear peer using soft reconfiguration in this address-family and sub-address-family.
 
 The following are available in the ``router bgp`` mode:
 
-.. index:: write-quanta (1-64)
 .. clicmd:: write-quanta (1-64)
 
    BGP message Tx I/O is vectored. This means that multiple packets are written
@@ -3217,7 +3018,6 @@ The following are available in the ``router bgp`` mode:
    less 'bursty'. In practice, leave this settings on the default (64) unless
    you truly know what you are doing.
 
-.. index:: read-quanta (1-10)
 .. clicmd:: read-quanta (1-10)
 
    Unlike Tx, BGP Rx traffic is not vectored. Packets are read off the wire one
@@ -3227,7 +3027,6 @@ The following are available in the ``router bgp`` mode:
 The following command is available in ``config`` mode as well as in the
 ``router bgp`` mode:
 
-.. index:: bgp graceful-shutdown
 .. clicmd:: bgp graceful-shutdown
 
    The purpose of this command is to initiate BGP Graceful Shutdown which
@@ -3262,16 +3061,12 @@ daemon project, while :clicmd:`show bgp` command is the new format. The choice
 has been done to keep old format with IPv4 routing table, while new format
 displays IPv6 routing table.
 
-.. index:: show ip bgp [all] [wide|json]
 .. clicmd:: show ip bgp [all] [wide|json]
 
-.. index:: show ip bgp A.B.C.D [json]
 .. clicmd:: show ip bgp A.B.C.D [json]
 
-.. index:: show bgp [all] [wide|json]
 .. clicmd:: show bgp [all] [wide|json]
 
-.. index:: show bgp X:X::X:X [json]
 .. clicmd:: show bgp X:X::X:X [json]
 
    These commands display BGP routes. When no route is specified, the default
@@ -3301,13 +3096,11 @@ displays IPv6 routing table.
 
 Some other commands provide additional options for filtering the output.
 
-.. index:: show [ip] bgp regexp LINE
 .. clicmd:: show [ip] bgp regexp LINE
 
    This command displays BGP routes using AS path regular expression
    (:ref:`bgp-regular-expressions`).
 
-.. index:: show [ip] bgp [all] summary [wide] [json]
 .. clicmd:: show [ip] bgp [all] summary [wide] [json]
 
    Show a bgp peer summary for the specified address family.
@@ -3336,10 +3129,8 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
       Total number of neighbors 1
       exit1#
 
-.. index:: show bgp [afi] [safi] [all] [wide|json]
 .. clicmd:: show bgp [afi] [safi] [all] [wide|json]
 
-.. index:: show bgp <ipv4|ipv6> <unicast|multicast|vpn|labeled-unicast>
 .. clicmd:: show bgp <ipv4|ipv6> <unicast|multicast|vpn|labeled-unicast>
 
    These commands display BGP routes for the specific routing table indicated by
@@ -3348,62 +3139,51 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
    For EVPN prefixes, you can display the full BGP table for this AFI/SAFI
    using the standard `show bgp [afi] [safi]` syntax.
 
-.. index:: show bgp l2vpn evpn route [type <macip|2|multicast|3|es|4|prefix|5>]
 .. clicmd:: show bgp l2vpn evpn route [type <macip|2|multicast|3|es|4|prefix|5>]
 
    Additionally, you can also filter this output by route type.
 
-.. index:: show bgp [afi] [safi] [all] summary [json]
 .. clicmd:: show bgp [afi] [safi] [all] summary [json]
 
    Show a bgp peer summary for the specified address family, and subsequent
    address-family.
 
-.. index:: show bgp [afi] [safi] [all] summary failed [json]
 .. clicmd:: show bgp [afi] [safi] [all] summary failed [json]
 
    Show a bgp peer summary for peers that are not succesfully exchanging routes
    for the specified address family, and subsequent address-family.
 
-.. index:: show bgp [afi] [safi] [all] summary established [json]
 .. clicmd:: show bgp [afi] [safi] [all] summary established [json]
 
    Show a bgp peer summary for peers that are succesfully exchanging routes
    for the specified address family, and subsequent address-family.
 
-.. index:: show bgp [afi] [safi] neighbor [PEER]
 .. clicmd:: show bgp [afi] [safi] neighbor [PEER]
 
    This command shows information on a specific BGP peer of the relevant
    afi and safi selected.
 
-.. index:: show bgp [afi] [safi] [all] dampening dampened-paths [wide|json]
 .. clicmd:: show bgp [afi] [safi] [all] dampening dampened-paths [wide|json]
 
    Display paths suppressed due to dampening of the selected afi and safi
    selected.
 
-.. index:: show bgp [afi] [safi] [all] dampening flap-statistics [wide|json]
 .. clicmd:: show bgp [afi] [safi] [all] dampening flap-statistics [wide|json]
 
    Display flap statistics of routes of the selected afi and safi selected.
 
-.. index:: show bgp [afi] [safi] statistics
 .. clicmd:: show bgp [afi] [safi] statistics
 
    Display statistics of routes of the selected afi and safi.
 
-.. index:: show bgp statistics-all
 .. clicmd:: show bgp statistics-all
 
    Display statistics of routes of all the afi and safi.
 
-.. index:: show [ip] bgp [afi] [safi] [all] cidr-only [wide|json]
 .. clicmd:: show [ip] bgp [afi] [safi] [all] cidr-only [wide|json]
 
    Display routes with non-natural netmasks.
 
-.. index:: show [ip] bgp [afi] [safi] [all] neighbors A.B.C.D [advertised-routes|received-routes|filtered-routes] [json|wide]
 .. clicmd:: show [ip] bgp [afi] [safi] [all] neighbors A.B.C.D [advertised-routes|received-routes|filtered-routes] [json|wide]
 
    Display the routes advertised to a BGP neighbor or received routes
@@ -3431,13 +3211,10 @@ Displaying Routes by Community Attribute
 The following commands allow displaying routes based on their community
 attribute.
 
-.. index:: show [ip] bgp <ipv4|ipv6> [all] community [wide|json]
 .. clicmd:: show [ip] bgp <ipv4|ipv6> [all] community [wide|json]
 
-.. index:: show [ip] bgp <ipv4|ipv6> [all] community COMMUNITY [wide|json]
 .. clicmd:: show [ip] bgp <ipv4|ipv6> [all] community COMMUNITY [wide|json]
 
-.. index:: show [ip] bgp <ipv4|ipv6> [all] community COMMUNITY exact-match [wide|json]
 .. clicmd:: show [ip] bgp <ipv4|ipv6> [all] community COMMUNITY exact-match [wide|json]
 
    These commands display BGP routes which have the community attribute.
@@ -3445,10 +3222,8 @@ attribute.
    community are displayed. When `exact-match` is specified, it display only
    routes that have an exact match.
 
-.. index:: show [ip] bgp <ipv4|ipv6> community-list WORD
 .. clicmd:: show [ip] bgp <ipv4|ipv6> community-list WORD
 
-.. index:: show [ip] bgp <ipv4|ipv6> community-list WORD exact-match
 .. clicmd:: show [ip] bgp <ipv4|ipv6> community-list WORD exact-match
 
    These commands display BGP routes for the address family specified that
@@ -3468,7 +3243,6 @@ attribute.
 
    If ``json`` option is specified, output is displayed in JSON format.
 
-.. index:: show bgp labelpool <chunks|inuse|ledger|requests|summary> [json]
 .. clicmd:: show bgp labelpool <chunks|inuse|ledger|requests|summary> [json]
 
    These commands display information about the BGP labelpool used for
@@ -3502,16 +3276,12 @@ Displaying Routes by Large Community Attribute
 The following commands allow displaying routes based on their
 large community attribute.
 
-.. index:: show [ip] bgp <ipv4|ipv6> large-community
 .. clicmd:: show [ip] bgp <ipv4|ipv6> large-community
 
-.. index:: show [ip] bgp <ipv4|ipv6> large-community LARGE-COMMUNITY
 .. clicmd:: show [ip] bgp <ipv4|ipv6> large-community LARGE-COMMUNITY
 
-.. index:: show [ip] bgp <ipv4|ipv6> large-community LARGE-COMMUNITY exact-match
 .. clicmd:: show [ip] bgp <ipv4|ipv6> large-community LARGE-COMMUNITY exact-match
 
-.. index:: show [ip] bgp <ipv4|ipv6> large-community LARGE-COMMUNITY json
 .. clicmd:: show [ip] bgp <ipv4|ipv6> large-community LARGE-COMMUNITY json
 
    These commands display BGP routes which have the large community attribute.
@@ -3520,13 +3290,10 @@ large community attribute.
    only routes that have an exact match. When `json` is specified, it display
    routes in json format.
 
-.. index:: show [ip] bgp <ipv4|ipv6> large-community-list WORD
 .. clicmd:: show [ip] bgp <ipv4|ipv6> large-community-list WORD
 
-.. index:: show [ip] bgp <ipv4|ipv6> large-community-list WORD exact-match
 .. clicmd:: show [ip] bgp <ipv4|ipv6> large-community-list WORD exact-match
 
-.. index:: show [ip] bgp <ipv4|ipv6> large-community-list WORD json
 .. clicmd:: show [ip] bgp <ipv4|ipv6> large-community-list WORD json
 
    These commands display BGP routes for the address family specified that
@@ -3540,24 +3307,19 @@ large community attribute.
 Displaying Routes by AS Path
 ----------------------------
 
-.. index:: show bgp ipv4|ipv6 regexp LINE
 .. clicmd:: show bgp ipv4|ipv6 regexp LINE
 
    This commands displays BGP routes that matches a regular
    expression `line` (:ref:`bgp-regular-expressions`).
 
-.. index:: show [ip] bgp ipv4 vpn
 .. clicmd:: show [ip] bgp ipv4 vpn
 
-.. index:: show [ip] bgp ipv6 vpn
 .. clicmd:: show [ip] bgp ipv6 vpn
 
    Print active IPV4 or IPV6 routes advertised via the VPN SAFI.
 
-.. index:: show bgp ipv4 vpn summary
 .. clicmd:: show bgp ipv4 vpn summary
 
-.. index:: show bgp ipv6 vpn summary
 .. clicmd:: show bgp ipv6 vpn summary
 
    Print a summary of neighbor connections for the specified AFI/SAFI combination.
@@ -3565,7 +3327,6 @@ Displaying Routes by AS Path
 Displaying Update Group Information
 -----------------------------------
 
-.. index:: show bgp update-groups SUBGROUP-ID [advertise-queue|advertised-routes|packet-queue]
 .. clicmd:: show bgp update-groups [advertise-queue|advertised-routes|packet-queue]
 
    Display Information about each individual update-group being used.
@@ -3575,7 +3336,6 @@ Displaying Update Group Information
    the list of routes we have sent to the peers in the update-group and
    packet-queue specifies the list of packets in the queue to be sent.
 
-.. index:: show bgp update-groups statistics
 .. clicmd:: show bgp update-groups statistics
 
    Display Information about update-group events in FRR.
@@ -3595,10 +3355,8 @@ When route reflectors are configured, these will reflect the routes announced
 by the peers configured as clients. A route reflector client is configured
 with:
 
-.. index:: neighbor PEER route-reflector-client
 .. clicmd:: neighbor PEER route-reflector-client
 
-.. index:: neighbor PEER route-reflector-client
 .. clicmd:: no neighbor PEER route-reflector-client
 
 To avoid single points of failure, multiple route reflectors can be configured.
@@ -3606,10 +3364,8 @@ To avoid single points of failure, multiple route reflectors can be configured.
 A cluster is a collection of route reflectors and their clients, and is used
 by route reflectors to avoid looping.
 
-.. index:: bgp cluster-id A.B.C.D
 .. clicmd:: bgp cluster-id A.B.C.D
 
-.. index:: bgp no-rib
 .. clicmd:: [no] bgp no-rib
 
 To set and unset the BGP daemon ``-n`` / ``--no_kernel`` options during runtime
@@ -3623,7 +3379,6 @@ starting the daemon and the configuration gets saved, the option will persist
 unless removed from the configuration with the negating command prior to the
 configuration write operation.
 
-.. index:: bgp send-extra-data zebra
 .. clicmd:: [no] bgp send-extra-data zebra
 
 This Command turns off the ability of BGP to send extra data to zebra.
@@ -3673,7 +3428,6 @@ status in FIB:
 7. If the route which is already installed in dataplane is removed for some
    reason, sending withdraw message to peers is not currently supported.
 
-.. index:: bgp suppress-fib-pending
 .. clicmd:: [no] bgp suppress-fib-pending
 
    This command is applicable at the global level and at an individual

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -73,7 +73,6 @@ setup.
 
 There is one option that applies to the BGP instance as a whole:
 
-.. index:: bmp mirror buffer-limit(0-4294967294)
 .. clicmd:: [no] bmp mirror buffer-limit(0-4294967294)
 
    This sets the maximum amount of memory used for buffering BGP messages
@@ -94,7 +93,6 @@ There is one option that applies to the BGP instance as a whole:
 
 All other configuration is managed per targets:
 
-.. index:: bmp targets NAME
 .. clicmd:: [no] bmp targets NAME
 
    Create/delete a targets group.  As implied by the plural name, targets may
@@ -110,7 +108,6 @@ BMP session configuration
 Inside a ``bmp targets`` block, the following commands control session
 establishment:
 
-.. index:: bmp connect HOSTNAME port (1-65535) {min-retry MSEC|max-retry MSEC}
 .. clicmd:: [no] bmp connect HOSTNAME port (1-65535) {min-retry MSEC|max-retry MSEC}
 
    Add/remove an active outbound BMP session.  HOSTNAME is resolved via DNS,
@@ -124,7 +121,6 @@ establishment:
    ``ip access-list`` and ``ipv6 access-list`` are checked for outbound
    connections resulting from ``bmp connect`` statements.
 
-.. index:: bmp listener <X:X::X:X|A.B.C.D> port (1-65535)
 .. clicmd:: [no] bmp listener <X:X::X:X|A.B.C.D> port (1-65535)
 
    Accept incoming BMP sessions on the specified address and port.  You can
@@ -143,13 +139,11 @@ BMP data feed configuration
 The following commands configure what BMP messages are sent on sessions
 associated with a particular ``bmp targets``:
 
-.. index:: bmp stats [interval (100-86400000)]
 .. clicmd:: [no] bmp stats [interval (100-86400000)]
 
    Send BMP Statistics (counter) messages at the specified interval (in
    milliseconds.)
 
-.. index:: bmp monitor AFI SAFI <pre-policy|post-policy>
 .. clicmd:: [no] bmp monitor AFI SAFI <pre-policy|post-policy>
 
    Perform Route Monitoring for the specified AFI and SAFI.  Only IPv4 and
@@ -159,7 +153,6 @@ associated with a particular ``bmp targets``:
    All BGP neighbors are included in Route Monitoring.  Options to select
    a subset of BGP sessions may be added in the future.
 
-.. index:: bmp mirror
 .. clicmd:: [no] bmp mirror
 
    Perform Route Mirroring for all BGP neighbors.  Since this provides a

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -73,7 +73,7 @@ setup.
 
 There is one option that applies to the BGP instance as a whole:
 
-.. clicmd:: [no] bmp mirror buffer-limit(0-4294967294)
+.. clicmd:: bmp mirror buffer-limit(0-4294967294)
 
    This sets the maximum amount of memory used for buffering BGP messages
    (updates, keepalives, ...) for sending in BMP Route Mirroring.
@@ -93,7 +93,7 @@ There is one option that applies to the BGP instance as a whole:
 
 All other configuration is managed per targets:
 
-.. clicmd:: [no] bmp targets NAME
+.. clicmd:: bmp targets NAME
 
    Create/delete a targets group.  As implied by the plural name, targets may
    cover multiple outbound active BMP sessions as well as inbound passive
@@ -108,7 +108,7 @@ BMP session configuration
 Inside a ``bmp targets`` block, the following commands control session
 establishment:
 
-.. clicmd:: [no] bmp connect HOSTNAME port (1-65535) {min-retry MSEC|max-retry MSEC}
+.. clicmd:: bmp connect HOSTNAME port (1-65535) {min-retry MSEC|max-retry MSEC}
 
    Add/remove an active outbound BMP session.  HOSTNAME is resolved via DNS,
    if multiple addresses are returned they are tried in nondeterministic
@@ -121,13 +121,13 @@ establishment:
    ``ip access-list`` and ``ipv6 access-list`` are checked for outbound
    connections resulting from ``bmp connect`` statements.
 
-.. clicmd:: [no] bmp listener <X:X::X:X|A.B.C.D> port (1-65535)
+.. clicmd:: bmp listener <X:X::X:X|A.B.C.D> port (1-65535)
 
    Accept incoming BMP sessions on the specified address and port.  You can
    use ``0.0.0.0`` and ``::`` to listen on all IPv4/IPv6 addresses.
 
-.. clicmd:: [no] ip access-list NAME
-.. clicmd:: [no] ipv6 access-list NAME
+.. clicmd:: ip access-list NAME
+.. clicmd:: ipv6 access-list NAME
 
    Restrict BMP sessions to the addresses allowed by the respective access
    lists.  The access lists are checked for both passive and active BMP
@@ -139,12 +139,12 @@ BMP data feed configuration
 The following commands configure what BMP messages are sent on sessions
 associated with a particular ``bmp targets``:
 
-.. clicmd:: [no] bmp stats [interval (100-86400000)]
+.. clicmd:: bmp stats [interval (100-86400000)]
 
    Send BMP Statistics (counter) messages at the specified interval (in
    milliseconds.)
 
-.. clicmd:: [no] bmp monitor AFI SAFI <pre-policy|post-policy>
+.. clicmd:: bmp monitor AFI SAFI <pre-policy|post-policy>
 
    Perform Route Monitoring for the specified AFI and SAFI.  Only IPv4 and
    IPv6 are currently valid for AFI, and only unicast and multicast are valid
@@ -153,7 +153,7 @@ associated with a particular ``bmp targets``:
    All BGP neighbors are included in Route Monitoring.  Options to select
    a subset of BGP sessions may be added in the future.
 
-.. clicmd:: [no] bmp mirror
+.. clicmd:: bmp mirror
 
    Perform Route Mirroring for all BGP neighbors.  Since this provides a
    direct feed of BGP messages, there are no AFI/SAFI options to be

--- a/doc/user/bugs.rst
+++ b/doc/user/bugs.rst
@@ -1,5 +1,3 @@
-.. index:: Bug Reports
-.. index:: Reporting bugs
 
 .. _bug-reports:
 

--- a/doc/user/bugs.rst
+++ b/doc/user/bugs.rst
@@ -1,3 +1,5 @@
+.. index::
+   pair: bug reports; contact
 
 .. _bug-reports:
 

--- a/doc/user/conf.py
+++ b/doc/user/conf.py
@@ -384,7 +384,7 @@ def vparse(s):
 def setup(app):
     # object type for FRR CLI commands, can be extended to document parent CLI
     # node later on
-    app.add_object_type("clicmd", "clicmd")
+    app.add_object_type("clicmd", "clicmd", indextemplate="pair: %s; configuration command")
 
     # css overrides for HTML theme
     # Note sphinx version differences

--- a/doc/user/eigrpd.rst
+++ b/doc/user/eigrpd.rst
@@ -65,7 +65,6 @@ Certain signals have special meanings to *eigrpd*.
 EIGRP Configuration
 ===================
 
-.. index:: router eigrp (1-65535) [vrf NAME]
 .. clicmd:: router eigrp (1-65535) [vrf NAME]
 
    The `router eigrp` command is necessary to enable EIGRP. To disable EIGRP,
@@ -73,15 +72,12 @@ EIGRP Configuration
    carrying out any of the EIGRP commands.  Specify vrf NAME if you want
    eigrp to work within the specified vrf.
 
-.. index:: router eigrp (1-65535) [vrf NAME]
 .. clicmd:: no router eigrp (1-65535) [vrf NAME]
 
    Disable EIGRP.
 
-.. index:: network NETWORK
 .. clicmd:: network NETWORK
 
-.. index:: network NETWORK
 .. clicmd:: no network NETWORK
 
    Set the EIGRP enable interface by `network`. The interfaces which
@@ -104,10 +100,8 @@ EIGRP Configuration
       !
 
 
-.. index:: passive-interface (IFNAME|default)
 .. clicmd:: passive-interface (IFNAME|default)
 
-.. index:: passive-interface IFNAME
 .. clicmd:: no passive-interface IFNAME
 
    This command sets the specified interface to passive mode. On passive mode
@@ -125,7 +119,6 @@ How to Announce EIGRP route
 
 Redistribute routes into EIGRP:
 
-.. index:: redistribute <babel|bgp|connected|isis|kernel|openfabric|ospf|rip|sharp|static|table> [metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)]
 .. clicmd:: redistribute <babel|bgp|connected|isis|kernel|openfabric|ospf|rip|sharp|static|table> [metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)]
 
    The ``redistribute`` family of commands imports routing information from
@@ -144,7 +137,6 @@ Redistribute routes into EIGRP:
 Show EIGRP Information
 ======================
 
-.. index:: show ip eigrp [vrf NAME] topology
 .. clicmd:: show ip eigrp [vrf NAME] topology
 
    Display current EIGRP status.
@@ -162,7 +154,6 @@ Show EIGRP Information
       P  10.0.2.0/24, 1 successors, FD is 256256, serno: 0
              via Connected, enp0s3
 
-.. index:: show ip eigrp [vrf NAME] interface
 .. clicmd:: show ip eigrp [vrf NAME] interface
 
    Display the list of interfaces associated with a particular eigrp
@@ -179,14 +170,12 @@ EIGRP Debug Commands
 
 Debug for EIGRP protocol.
 
-.. index:: debug eigrp packets
 .. clicmd:: debug eigrp packets
 
    Debug eigrp packets
 
    ``debug eigrp`` will show EIGRP packets that are sent and received.
 
-.. index:: debug eigrp transmit
 .. clicmd:: debug eigrp transmit
 
    Debug eigrp transmit events
@@ -194,7 +183,6 @@ Debug for EIGRP protocol.
    ``debug eigrp transmit`` will display detailed information about the EIGRP
    transmit events.
 
-.. index:: show debugging eigrp
 .. clicmd:: show debugging eigrp
 
    Display *eigrpd*'s debugging option.

--- a/doc/user/eigrpd.rst
+++ b/doc/user/eigrpd.rst
@@ -123,67 +123,21 @@ EIGRP Configuration
 How to Announce EIGRP route
 ===========================
 
-.. index:: redistribute kernel
-.. clicmd:: redistribute kernel
+Redistribute routes into EIGRP:
 
-.. index:: redistribute kernel metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
-.. clicmd:: redistribute kernel metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
+.. index:: redistribute <babel|bgp|connected|isis|kernel|openfabric|ospf|rip|sharp|static|table> [metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)]
+.. clicmd:: redistribute <babel|bgp|connected|isis|kernel|openfabric|ospf|rip|sharp|static|table> [metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)]
 
-.. index:: redistribute kernel
-.. clicmd:: no redistribute kernel
+   The ``redistribute`` family of commands imports routing information from
+   other sources into EIGRP's tables. Redistribution may be disabled with the
+   ``no`` form of the commands.
 
-   `redistribute kernel` redistributes routing information from kernel route
-   entries into the EIGRP tables. `no redistribute kernel` disables the routes.
+   Note that connected routes on interfaces EIGRP is enabled on are announced
+   by default.
 
-.. index:: redistribute static
-.. clicmd:: redistribute static
+   Optionally, various EIGRP metrics may be specified. These metrics will be
+   applied to the imported routes.
 
-.. index:: redistribute static metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
-.. clicmd:: redistribute static metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
-
-.. index:: redistribute static
-.. clicmd:: no redistribute static
-
-   `redistribute static` redistributes routing information from static route
-   entries into the EIGRP tables. `no redistribute static` disables the routes.
-
-.. index:: redistribute connected
-.. clicmd:: redistribute connected
-
-.. index:: redistribute connected metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
-.. clicmd:: redistribute connected metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
-
-.. index:: redistribute connected
-.. clicmd:: no redistribute connected
-
-   Redistribute connected routes into the EIGRP tables. `no redistribute
-   connected` disables the connected routes in the EIGRP tables. This command
-   redistribute connected of the interface which EIGRP disabled. The connected
-   route on EIGRP enabled interface is announced by default.
-
-.. index:: redistribute ospf
-.. clicmd:: redistribute ospf
-
-.. index:: redistribute ospf metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
-.. clicmd:: redistribute ospf metric (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
-
-.. index:: redistribute ospf
-.. clicmd:: no redistribute ospf
-
-   `redistribute ospf` redistributes routing information from ospf route
-   entries into the EIGRP tables. `no redistribute ospf` disables the routes.
-
-.. index:: redistribute bgp
-.. clicmd:: redistribute bgp
-
-.. index:: redistribute bgp metric  (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
-.. clicmd:: redistribute bgp metric  (1-4294967295) (0-4294967295) (0-255) (1-255) (1-65535)
-
-.. index:: redistribute bgp
-.. clicmd:: no redistribute bgp
-
-   `redistribute bgp` redistributes routing information from bgp route entries
-   into the EIGRP tables. `no redistribute bgp` disables the routes.
 
 .. _show-eigrp-information:
 

--- a/doc/user/eigrpd.rst
+++ b/doc/user/eigrpd.rst
@@ -72,13 +72,7 @@ EIGRP Configuration
    carrying out any of the EIGRP commands.  Specify vrf NAME if you want
    eigrp to work within the specified vrf.
 
-.. clicmd:: no router eigrp (1-65535) [vrf NAME]
-
-   Disable EIGRP.
-
 .. clicmd:: network NETWORK
-
-.. clicmd:: no network NETWORK
 
    Set the EIGRP enable interface by `network`. The interfaces which
    have addresses matching with `network` are enabled.
@@ -102,7 +96,6 @@ EIGRP Configuration
 
 .. clicmd:: passive-interface (IFNAME|default)
 
-.. clicmd:: no passive-interface IFNAME
 
    This command sets the specified interface to passive mode. On passive mode
    interface, all receiving packets are ignored and eigrpd does not send either

--- a/doc/user/fabricd.rst
+++ b/doc/user/fabricd.rst
@@ -34,26 +34,18 @@ in the configuration:
 
 .. clicmd:: router openfabric WORD
 
-.. clicmd:: no router openfabric WORD
-
    Enable or disable the OpenFabric process by specifying the OpenFabric domain with
    'WORD'.
 
 .. clicmd:: net XX.XXXX. ... .XXX.XX
 
-.. clicmd:: no net XX.XXXX. ... .XXX.XX
-
    Set/Unset network entity title (NET) provided in ISO format.
 
 .. clicmd:: domain-password [clear | md5] <password>
 
-.. clicmd:: no domain-password
-
    Configure the authentication password for a domain, as clear text or md5 one.
 
 .. clicmd:: attached-bit [receive ignore | send]
-
-.. clicmd:: no attached-bit
 
    Set attached bit for inter-area traffic:
 
@@ -64,25 +56,20 @@ in the configuration:
    
 .. clicmd:: log-adjacency-changes
 
-.. clicmd:: no log-adjacency-changes
-
    Log changes in adjacency state.
      
 .. clicmd:: set-overload-bit
 
-.. clicmd:: no set-overload-bit
 
    Set overload bit to avoid any transit traffic.
 
 .. clicmd:: purge-originator
 
-.. clicmd:: no purge-originator
 
    Enable or disable :rfc:`6232` purge originator identification.
 
 .. clicmd:: fabric-tier (0-14)
 
-.. clicmd:: no fabric-tier
 
    Configure a static tier number to advertise as location in the fabric
 
@@ -93,25 +80,21 @@ OpenFabric Timer
 
 .. clicmd:: lsp-gen-interval (1-120)
 
-.. clicmd:: no lsp-gen-interval
 
    Set minimum interval in seconds between regenerating same LSP.
 
 .. clicmd:: lsp-refresh-interval (1-65235)
 
-.. clicmd:: no lsp-refresh-interval
 
    Set LSP refresh interval in seconds.
 
 .. clicmd:: max-lsp-lifetime (360-65535)
 
-.. clicmd:: no max-lsp-lifetime
 
    Set LSP maximum LSP lifetime in seconds.
 
 .. clicmd:: spf-interval (1-120)
 
-.. clicmd:: no spf-interval
 
    Set minimum interval between consecutive SPF calculations in seconds.
 
@@ -122,7 +105,6 @@ OpenFabric interface
 
 .. clicmd:: ip router openfabric WORD
 
-.. clicmd:: no ip router openfabric WORD
 
 .. _ip-router-openfabric-word:
 
@@ -132,44 +114,37 @@ OpenFabric interface
 
 .. clicmd:: openfabric csnp-interval (1-600)
 
-.. clicmd:: no openfabric csnp-interval
 
    Set CSNP interval in seconds.
 
 .. clicmd:: openfabric hello-interval (1-600)
 
-.. clicmd:: no openfabric hello-interval
 
    Set Hello interval in seconds.
 
 .. clicmd:: openfabric hello-multiplier (2-100)
 
-.. clicmd:: no openfabric hello-multiplier
 
    Set multiplier for Hello holding time.
 
 .. clicmd:: openfabric metric (0-16777215)
 
-.. clicmd:: no openfabric metric
 
    Set interface metric value.
 
 .. clicmd:: openfabric passive
 
-.. clicmd:: no openfabric passive
 
    Configure the passive mode for this interface.
 
 .. clicmd:: openfabric password [clear | md5] <password>
 
-.. clicmd:: no openfabric password
 
    Configure the authentication password (clear or encoded text) for the
    interface.
 
 .. clicmd:: openfabric psnp-interval (1-120)
 
-.. clicmd:: no openfabric psnp-interval
 
    Set PSNP interval in seconds.
 
@@ -226,63 +201,43 @@ Debugging OpenFabric
 
 .. clicmd:: debug openfabric adj-packets
 
-.. clicmd:: no debug openfabric adj-packets
-
-OpenFabric Adjacency related packets.
+   OpenFabric Adjacency related packets.
 
 .. clicmd:: debug openfabric checksum-errors
 
-.. clicmd:: no debug openfabric checksum-errors
-
-OpenFabric LSP checksum errors.
+   OpenFabric LSP checksum errors.
 
 .. clicmd:: debug openfabric events
 
-.. clicmd:: no debug openfabric events
-
-OpenFabric Events.
+   OpenFabric Events.
 
 .. clicmd:: debug openfabric local-updates
 
-.. clicmd:: no debug openfabric local-updates
-
-OpenFabric local update packets.
+   OpenFabric local update packets.
 
 .. clicmd:: debug openfabric lsp-gen
 
-.. clicmd:: no debug openfabric lsp-gen
-
-Generation of own LSPs.
+   Generation of own LSPs.
 
 .. clicmd:: debug openfabric lsp-sched
 
-.. clicmd:: no debug openfabric lsp-sched
-
-Debug scheduling of generation of own LSPs.
+   Debug scheduling of generation of own LSPs.
 
 .. clicmd:: debug openfabric packet-dump
 
-.. clicmd:: no debug openfabric packet-dump
-
-OpenFabric packet dump.
+   OpenFabric packet dump.
 
 .. clicmd:: debug openfabric protocol-errors
 
-.. clicmd:: no debug openfabric protocol-errors
-
-OpenFabric LSP protocol errors.
+   OpenFabric LSP protocol errors.
 
 .. clicmd:: debug openfabric route-events
 
-.. clicmd:: no debug openfabric route-events
-
-OpenFabric Route related events.
+   OpenFabric Route related events.
 
 .. clicmd:: debug openfabric snp-packets
 
-.. clicmd:: no debug openfabric snp-packets
-
-OpenFabric CSNP/PSNP packets.
+   OpenFabric CSNP/PSNP packets.
 
 .. clicmd:: debug openfabric spf-events
 
@@ -290,24 +245,17 @@ OpenFabric CSNP/PSNP packets.
 
 .. clicmd:: debug openfabric spf-triggers
 
-.. clicmd:: no debug openfabric spf-events
-
-.. clicmd:: no debug openfabric spf-statistics
-
-.. clicmd:: no debug openfabric spf-triggers
-
-OpenFabric Shortest Path First Events, Timing and Statistic Data and triggering
-events.
+   OpenFabric Shortest Path First Events, Timing and Statistic Data and
+   triggering events.
 
 .. clicmd:: debug openfabric update-packets
 
-.. clicmd:: no debug openfabric update-packets
-
-Update related packets.
+   Update-related packets.
 
 .. clicmd:: show debugging openfabric
 
    Print which OpenFabric debug levels are active.
+
 
 OpenFabric configuration example
 ================================

--- a/doc/user/fabricd.rst
+++ b/doc/user/fabricd.rst
@@ -32,35 +32,27 @@ OpenFabric router
 To enable the OpenFabric routing protocol, an OpenFabric router needs to be created
 in the configuration:
 
-.. index:: router openfabric WORD
 .. clicmd:: router openfabric WORD
 
-.. index:: router openfabric WORD
 .. clicmd:: no router openfabric WORD
 
    Enable or disable the OpenFabric process by specifying the OpenFabric domain with
    'WORD'.
 
-.. index:: net XX.XXXX. ... .XXX.XX
 .. clicmd:: net XX.XXXX. ... .XXX.XX
 
-.. index:: net XX.XXXX. ... .XXX.XX
 .. clicmd:: no net XX.XXXX. ... .XXX.XX
 
    Set/Unset network entity title (NET) provided in ISO format.
 
-.. index:: domain-password [clear | md5] <password>
 .. clicmd:: domain-password [clear | md5] <password>
 
-.. index:: domain-password
 .. clicmd:: no domain-password
 
    Configure the authentication password for a domain, as clear text or md5 one.
 
-.. index:: attached-bit [receive ignore | send]
 .. clicmd:: attached-bit [receive ignore | send]
 
-.. index:: attached-bit
 .. clicmd:: no attached-bit
 
    Set attached bit for inter-area traffic:
@@ -70,34 +62,26 @@ in the configuration:
    - send
      If L1|L2 router, set attached bit in LSP sent to L1 router
    
-.. index:: log-adjacency-changes
 .. clicmd:: log-adjacency-changes
 
-.. index:: log-adjacency-changes
 .. clicmd:: no log-adjacency-changes
 
    Log changes in adjacency state.
      
-.. index:: set-overload-bit
 .. clicmd:: set-overload-bit
 
-.. index:: set-overload-bit
 .. clicmd:: no set-overload-bit
 
    Set overload bit to avoid any transit traffic.
 
-.. index:: purge-originator
 .. clicmd:: purge-originator
 
-.. index:: purge-originator
 .. clicmd:: no purge-originator
 
    Enable or disable :rfc:`6232` purge originator identification.
 
-.. index:: fabric-tier (0-14)
 .. clicmd:: fabric-tier (0-14)
 
-.. index:: fabric-tier
 .. clicmd:: no fabric-tier
 
    Configure a static tier number to advertise as location in the fabric
@@ -107,34 +91,26 @@ in the configuration:
 OpenFabric Timer
 ================
 
-.. index:: lsp-gen-interval (1-120)
 .. clicmd:: lsp-gen-interval (1-120)
 
-.. index:: lsp-gen-interval
 .. clicmd:: no lsp-gen-interval
 
    Set minimum interval in seconds between regenerating same LSP.
 
-.. index:: lsp-refresh-interval (1-65235)
 .. clicmd:: lsp-refresh-interval (1-65235)
 
-.. index:: lsp-refresh-interval
 .. clicmd:: no lsp-refresh-interval
 
    Set LSP refresh interval in seconds.
 
-.. index:: max-lsp-lifetime (360-65535)
 .. clicmd:: max-lsp-lifetime (360-65535)
 
-.. index:: max-lsp-lifetime
 .. clicmd:: no max-lsp-lifetime
 
    Set LSP maximum LSP lifetime in seconds.
 
-.. index:: spf-interval (1-120)
 .. clicmd:: spf-interval (1-120)
 
-.. index:: spf-interval
 .. clicmd:: no spf-interval
 
    Set minimum interval between consecutive SPF calculations in seconds.
@@ -144,10 +120,8 @@ OpenFabric Timer
 OpenFabric interface
 ====================
 
-.. index:: ip router openfabric WORD
 .. clicmd:: ip router openfabric WORD
 
-.. index:: ip router openfabric WORD
 .. clicmd:: no ip router openfabric WORD
 
 .. _ip-router-openfabric-word:
@@ -156,59 +130,45 @@ OpenFabric interface
    of OpenFabric instance must be the same as the one used to configure the
    routing process (see command :clicmd:`router openfabric WORD`).
 
-.. index:: openfabric csnp-interval (1-600)
 .. clicmd:: openfabric csnp-interval (1-600)
 
-.. index:: openfabric csnp-interval
 .. clicmd:: no openfabric csnp-interval
 
    Set CSNP interval in seconds.
 
-.. index:: openfabric hello-interval (1-600)
 .. clicmd:: openfabric hello-interval (1-600)
 
-.. index:: openfabric hello-interval
 .. clicmd:: no openfabric hello-interval
 
    Set Hello interval in seconds.
 
-.. index:: openfabric hello-multiplier (2-100)
 .. clicmd:: openfabric hello-multiplier (2-100)
 
-.. index:: openfabric hello-multiplier
 .. clicmd:: no openfabric hello-multiplier
 
    Set multiplier for Hello holding time.
 
-.. index:: openfabric metric (0-16777215)
 .. clicmd:: openfabric metric (0-16777215)
 
-.. index:: openfabric metric
 .. clicmd:: no openfabric metric
 
    Set interface metric value.
 
-.. index:: openfabric passive
 .. clicmd:: openfabric passive
 
-.. index:: openfabric passive
 .. clicmd:: no openfabric passive
 
    Configure the passive mode for this interface.
 
-.. index:: openfabric password [clear | md5] <password>
 .. clicmd:: openfabric password [clear | md5] <password>
 
-.. index:: openfabric password
 .. clicmd:: no openfabric password
 
    Configure the authentication password (clear or encoded text) for the
    interface.
 
-.. index:: openfabric psnp-interval (1-120)
 .. clicmd:: openfabric psnp-interval (1-120)
 
-.. index:: openfabric psnp-interval
 .. clicmd:: no openfabric psnp-interval
 
    Set PSNP interval in seconds.
@@ -218,56 +178,43 @@ OpenFabric interface
 Showing OpenFabric information
 ==============================
 
-.. index:: show openfabric summary
 .. clicmd:: show openfabric summary
 
    Show summary information about OpenFabric.
 
-.. index:: show openfabric hostname
 .. clicmd:: show openfabric hostname
 
    Show which hostnames are associated with which OpenFabric system ids.
 
-.. index:: show openfabric interface
 .. clicmd:: show openfabric interface
 
-.. index:: show openfabric interface detail
 .. clicmd:: show openfabric interface detail
 
-.. index:: show openfabric interface <interface name>
 .. clicmd:: show openfabric interface <interface name>
 
    Show state and configuration of specified OpenFabric interface, or all interfaces
    if no interface is given with or without details.
 
-.. index:: show openfabric neighbor
 .. clicmd:: show openfabric neighbor
 
-.. index:: show openfabric neighbor <System Id>
 .. clicmd:: show openfabric neighbor <System Id>
 
-.. index:: show openfabric neighbor detail
 .. clicmd:: show openfabric neighbor detail
 
    Show state and information of specified OpenFabric neighbor, or all neighbors if
    no system id is given with or without details.
 
-.. index:: show openfabric database
 .. clicmd:: show openfabric database
 
-.. index:: show openfabric database [detail]
 .. clicmd:: show openfabric database [detail]
 
-.. index:: show openfabric database <LSP id> [detail]
 .. clicmd:: show openfabric database <LSP id> [detail]
 
-.. index:: show openfabric database detail <LSP id>
 .. clicmd:: show openfabric database detail <LSP id>
 
    Show the OpenFabric database globally, for a specific LSP id without or with
    details.
 
-.. index:: show openfabric topology
 .. clicmd:: show openfabric topology
 
    Show calculated OpenFabric paths and associated topology information.
@@ -277,116 +224,87 @@ Showing OpenFabric information
 Debugging OpenFabric
 ====================
 
-.. index:: debug openfabric adj-packets
 .. clicmd:: debug openfabric adj-packets
 
-.. index:: debug openfabric adj-packets
 .. clicmd:: no debug openfabric adj-packets
 
 OpenFabric Adjacency related packets.
 
-.. index:: debug openfabric checksum-errors
 .. clicmd:: debug openfabric checksum-errors
 
-.. index:: debug openfabric checksum-errors
 .. clicmd:: no debug openfabric checksum-errors
 
 OpenFabric LSP checksum errors.
 
-.. index:: debug openfabric events
 .. clicmd:: debug openfabric events
 
-.. index:: debug openfabric events
 .. clicmd:: no debug openfabric events
 
 OpenFabric Events.
 
-.. index:: debug openfabric local-updates
 .. clicmd:: debug openfabric local-updates
 
-.. index:: debug openfabric local-updates
 .. clicmd:: no debug openfabric local-updates
 
 OpenFabric local update packets.
 
-.. index:: debug openfabric lsp-gen
 .. clicmd:: debug openfabric lsp-gen
 
-.. index:: debug openfabric lsp-gen
 .. clicmd:: no debug openfabric lsp-gen
 
 Generation of own LSPs.
 
-.. index:: debug openfabric lsp-sched
 .. clicmd:: debug openfabric lsp-sched
 
-.. index:: debug openfabric lsp-sched
 .. clicmd:: no debug openfabric lsp-sched
 
 Debug scheduling of generation of own LSPs.
 
-.. index:: debug openfabric packet-dump
 .. clicmd:: debug openfabric packet-dump
 
-.. index:: debug openfabric packet-dump
 .. clicmd:: no debug openfabric packet-dump
 
 OpenFabric packet dump.
 
-.. index:: debug openfabric protocol-errors
 .. clicmd:: debug openfabric protocol-errors
 
-.. index:: debug openfabric protocol-errors
 .. clicmd:: no debug openfabric protocol-errors
 
 OpenFabric LSP protocol errors.
 
-.. index:: debug openfabric route-events
 .. clicmd:: debug openfabric route-events
 
-.. index:: debug openfabric route-events
 .. clicmd:: no debug openfabric route-events
 
 OpenFabric Route related events.
 
-.. index:: debug openfabric snp-packets
 .. clicmd:: debug openfabric snp-packets
 
-.. index:: debug openfabric snp-packets
 .. clicmd:: no debug openfabric snp-packets
 
 OpenFabric CSNP/PSNP packets.
 
-.. index:: debug openfabric spf-events
 .. clicmd:: debug openfabric spf-events
 
-.. index:: debug openfabric spf-statistics
 .. clicmd:: debug openfabric spf-statistics
 
-.. index:: debug openfabric spf-triggers
 .. clicmd:: debug openfabric spf-triggers
 
-.. index:: debug openfabric spf-events
 .. clicmd:: no debug openfabric spf-events
 
-.. index:: debug openfabric spf-statistics
 .. clicmd:: no debug openfabric spf-statistics
 
-.. index:: debug openfabric spf-triggers
 .. clicmd:: no debug openfabric spf-triggers
 
 OpenFabric Shortest Path First Events, Timing and Statistic Data and triggering
 events.
 
-.. index:: debug openfabric update-packets
 .. clicmd:: debug openfabric update-packets
 
-.. index:: debug openfabric update-packets
 .. clicmd:: no debug openfabric update-packets
 
 Update related packets.
 
-.. index:: show debugging openfabric
 .. clicmd:: show debugging openfabric
 
    Print which OpenFabric debug levels are active.

--- a/doc/user/filter.rst
+++ b/doc/user/filter.rst
@@ -9,10 +9,8 @@ defined, it can be applied in any direction.
 IP Access List
 ==============
 
-.. index:: access-list NAME [seq (1-4294967295)] permit IPV4-NETWORK
 .. clicmd:: access-list NAME [seq (1-4294967295)] permit IPV4-NETWORK
 
-.. index:: access-list NAME [seq (1-4294967295)] deny IPV4-NETWORK
 .. clicmd:: access-list NAME [seq (1-4294967295)] deny IPV4-NETWORK
 
    seq
@@ -50,10 +48,8 @@ filters to arbitrary points of prefix-list using sequential number specification
 If no ip prefix-list is specified, it acts as permit. If *ip prefix-list*
 is defined, and no match is found, default deny is applied.
 
-.. index:: ip prefix-list NAME (permit|deny) PREFIX [le LEN] [ge LEN]
 .. clicmd:: ip prefix-list NAME (permit|deny) PREFIX [le LEN] [ge LEN]
 
-.. index:: ip prefix-list NAME seq NUMBER (permit|deny) PREFIX [le LEN] [ge LEN]
 .. clicmd:: ip prefix-list NAME seq NUMBER (permit|deny) PREFIX [le LEN] [ge LEN]
 
    You can create *ip prefix-list* using above commands.
@@ -98,7 +94,6 @@ is defined, and no match is found, default deny is applied.
    In the case of no le or ge command, the prefix length must match exactly the
    length specified in the prefix list.
 
-.. index:: ip prefix-list NAME
 .. clicmd:: no ip prefix-list NAME
 
 .. _ip-prefix-list-description:
@@ -106,13 +101,11 @@ is defined, and no match is found, default deny is applied.
 ip prefix-list description
 --------------------------
 
-.. index:: ip prefix-list NAME description DESC
 .. clicmd:: ip prefix-list NAME description DESC
 
    Descriptions may be added to prefix lists. This command adds a
    description to the prefix list.
 
-.. index:: ip prefix-list NAME description [DESC]
 .. clicmd:: no ip prefix-list NAME description [DESC]
 
    Deletes the description from a prefix list. It is possible to use the
@@ -123,13 +116,11 @@ ip prefix-list description
 ip prefix-list sequential number control
 ----------------------------------------
 
-.. index:: ip prefix-list sequence-number
 .. clicmd:: ip prefix-list sequence-number
 
    With this command, the IP prefix list sequential number is displayed.
    This is the default behavior.
 
-.. index:: ip prefix-list sequence-number
 .. clicmd:: no ip prefix-list sequence-number
 
    With this command, the IP prefix list sequential number is not
@@ -140,46 +131,35 @@ ip prefix-list sequential number control
 Showing ip prefix-list
 ----------------------
 
-.. index:: show ip prefix-list
 .. clicmd:: show ip prefix-list
 
    Display all IP prefix lists.
 
-.. index:: show ip prefix-list NAME
 .. clicmd:: show ip prefix-list NAME
 
    Show IP prefix list can be used with a prefix list name.
 
-.. index:: show ip prefix-list NAME seq NUM
 .. clicmd:: show ip prefix-list NAME seq NUM
 
    Show IP prefix list can be used with a prefix list name and sequential
    number.
 
-.. index:: show ip prefix-list NAME A.B.C.D/M
 .. clicmd:: show ip prefix-list NAME A.B.C.D/M
 
    If the command longer is used, all prefix lists with prefix lengths equal to
    or longer than the specified length will be displayed. If the command first
    match is used, the first prefix length match will be displayed.
 
-.. index:: show ip prefix-list NAME A.B.C.D/M longer
 .. clicmd:: show ip prefix-list NAME A.B.C.D/M longer
-.. index:: show ip prefix-list NAME A.B.C.D/M first-match
 .. clicmd:: show ip prefix-list NAME A.B.C.D/M first-match
-.. index:: show ip prefix-list summary
 .. clicmd:: show ip prefix-list summary
-.. index:: show ip prefix-list summary NAME
 .. clicmd:: show ip prefix-list summary NAME
-.. index:: show ip prefix-list detail
 .. clicmd:: show ip prefix-list detail
-.. index:: show ip prefix-list detail NAME
 .. clicmd:: show ip prefix-list detail NAME
 
 Clear counter of ip prefix-list
 -------------------------------
 
-.. index:: clear ip prefix-list [NAME [A.B.C.D/M]]
 .. clicmd:: clear ip prefix-list [NAME [A.B.C.D/M]]
 
    Clears the counters of all IP prefix lists. Clear IP Prefix List can be used

--- a/doc/user/filter.rst
+++ b/doc/user/filter.rst
@@ -94,7 +94,6 @@ is defined, and no match is found, default deny is applied.
    In the case of no le or ge command, the prefix length must match exactly the
    length specified in the prefix list.
 
-.. clicmd:: no ip prefix-list NAME
 
 .. _ip-prefix-list-description:
 
@@ -106,10 +105,6 @@ ip prefix-list description
    Descriptions may be added to prefix lists. This command adds a
    description to the prefix list.
 
-.. clicmd:: no ip prefix-list NAME description [DESC]
-
-   Deletes the description from a prefix list. It is possible to use the
-   command without the full description.
 
 .. _ip-prefix-list-sequential-number-control:
 
@@ -121,10 +116,6 @@ ip prefix-list sequential number control
    With this command, the IP prefix list sequential number is displayed.
    This is the default behavior.
 
-.. clicmd:: no ip prefix-list sequence-number
-
-   With this command, the IP prefix list sequential number is not
-   displayed.
 
 .. _showing-ip-prefix-list:
 

--- a/doc/user/flowspec.rst
+++ b/doc/user/flowspec.rst
@@ -123,10 +123,8 @@ As of today, it is only possible to configure Flowspec on the default VRF.
 
 You can see Flowspec entries, by using one of the following show commands:
 
-.. index:: show bgp ipv4 flowspec [detail | A.B.C.D]
 .. clicmd:: show bgp ipv4 flowspec [detail | A.B.C.D]
 
-.. index:: show bgp ipv6 flowspec [detail | A:B::C:D]
 .. clicmd:: show bgp ipv6 flowspec [detail | A:B::C:D]
 
 Per-interface configuration
@@ -141,7 +139,6 @@ twice the traffic, or slow down the traffic (filtering costs). To limit
 Flowspec to one specific interface, use the following command, under
 `flowspec address-family` node.
 
-.. index:: local-install <IFNAME | any>
 .. clicmd:: [no] local-install <IFNAME | any>
 
 By default, Flowspec is activated on all interfaces. Installing it to a named
@@ -168,7 +165,6 @@ following:
 - The first VRF with the matching Route Target will be selected to route traffic
   to. Use the following command under ipv4 unicast address-family node
 
-.. index:: rt redirect import RTLIST...
 .. clicmd:: [no] rt redirect import RTLIST...
 
 In order to illustrate, if the Route Target configured in the Flowspec entry is
@@ -223,7 +219,6 @@ Those command rely on the filtering contexts configured from BGP, and get the
 statistics information retrieved from the underlying system. In other words,
 those statistics are retrieved from ``Netfilter``.
 
-.. index:: show pbr ipset IPSETNAME | iptable
 .. clicmd:: show pbr ipset IPSETNAME | iptable
 
 ``IPSETNAME`` is the policy routing object name created by ``ipset``.  About
@@ -235,20 +230,17 @@ match.
 
 .. code-block:: frr
 
-.. index:: show ip route table TABLEID
 .. clicmd:: show ip route table TABLEID
 
    ``TABLEID`` is the table number identifier referencing the non standard
    routing table used in this example.
 
-.. index:: debug bgp flowspec
 .. clicmd:: [no] debug bgp flowspec
 
    You can troubleshoot Flowspec, or BGP policy based routing. For instance, if
    you encounter some issues when decoding a Flowspec entry, you should enable
    :clicmd:`debug bgp flowspec`.
 
-.. index:: debug bgp pbr [error]
 .. clicmd:: [no] debug bgp pbr [error]
 
    If you fail to apply the flowspec entry into *zebra*, there should be some

--- a/doc/user/flowspec.rst
+++ b/doc/user/flowspec.rst
@@ -139,7 +139,7 @@ twice the traffic, or slow down the traffic (filtering costs). To limit
 Flowspec to one specific interface, use the following command, under
 `flowspec address-family` node.
 
-.. clicmd:: [no] local-install <IFNAME | any>
+.. clicmd:: local-install <IFNAME | any>
 
 By default, Flowspec is activated on all interfaces. Installing it to a named
 interface will result in allowing only this interface. Conversely, enabling any
@@ -165,7 +165,7 @@ following:
 - The first VRF with the matching Route Target will be selected to route traffic
   to. Use the following command under ipv4 unicast address-family node
 
-.. clicmd:: [no] rt redirect import RTLIST...
+.. clicmd:: rt redirect import RTLIST...
 
 In order to illustrate, if the Route Target configured in the Flowspec entry is
 ``E.F.G.H:II``, then a BGP VRF instance with the same Route Target will be set
@@ -235,13 +235,13 @@ match.
    ``TABLEID`` is the table number identifier referencing the non standard
    routing table used in this example.
 
-.. clicmd:: [no] debug bgp flowspec
+.. clicmd:: debug bgp flowspec
 
    You can troubleshoot Flowspec, or BGP policy based routing. For instance, if
    you encounter some issues when decoding a Flowspec entry, you should enable
    :clicmd:`debug bgp flowspec`.
 
-.. clicmd:: [no] debug bgp pbr [error]
+.. clicmd:: debug bgp pbr [error]
 
    If you fail to apply the flowspec entry into *zebra*, there should be some
    relationship with policy routing mechanism. Here,

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -1,15 +1,15 @@
+.. index::
+   single: How to install FRR
+   single: Installing FRR
+   single: Building FRR
+
 .. _installation:
 
 Installation
 ============
 
-.. index:: How to install FRR
-.. index:: Installation
-.. index:: Installing FRR
-.. index:: Building the system
-.. index:: Making FRR
-
 This section covers the basics of building, installing and setting up FRR.
+
 
 From Packages
 -------------
@@ -55,14 +55,18 @@ is the release version.
 In addition, release tarballs are published on the GitHub releases page
 `here <https://github.com/FRRouting/frr/releases>`_.
 
-Configuration
-^^^^^^^^^^^^^
 
-.. index:: Configuration options
-.. index:: Options for configuring
-.. index:: Build options
-.. index:: Distribution configuration
-.. index:: Options to `./configure`
+.. index::
+   single: Configuration options
+   single: Options for configuring
+   single: Build options
+   single: Distribution configuration
+   single: Options to `./configure`
+
+.. _build-configuration:
+
+Build Configuration
+^^^^^^^^^^^^^^^^^^^
 
 FRR has an excellent configure script which automatically detects most host
 configurations. There are several additional configure options to customize the
@@ -420,13 +424,14 @@ The `sphinx` and `pytest` dependencies can be avoided by not building
 documentation / not running ``make check``, but the CPython dependency is a
 hard dependency of the FRR build process (for the `clippy` tool.)
 
+.. index::
+   single: FRR Least-Privileges
+   single: FRR Privileges
+
 .. _least-privilege-support:
 
 Least-Privilege Support
 """""""""""""""""""""""
-
-.. index:: FRR Least-Privileges
-.. index:: FRR Privileges
 
 Additionally, you may configure zebra to drop its elevated privileges
 shortly after startup and switch to another user. The configure script will
@@ -460,11 +465,13 @@ only Linux), FRR will retain only minimal capabilities required and will only
 raise these capabilities for brief periods. On systems without libcap, FRR will
 run as the user specified and only raise its UID to 0 for brief periods.
 
+
+.. index::
+   pair: building; Linux
+   pair: configuration; Linux
+
 Linux Notes
 """""""""""
-
-.. index:: Building on Linux boxes
-.. index:: Linux configurations
 
 There are several options available only to GNU/Linux systems.  If you use
 GNU/Linux, make sure that the current kernel configuration is what you want.

--- a/doc/user/ipv6.rst
+++ b/doc/user/ipv6.rst
@@ -17,13 +17,10 @@ no longer possible.
 Router Advertisement
 ====================
 
-.. clicmd:: no ipv6 nd suppress-ra
-
-   Send router advertisement messages.
-
 .. clicmd:: ipv6 nd suppress-ra
 
-   Don't send router advertisement messages.
+   Don't send router advertisement messages. The ``no`` form of this command
+   enables sending RA messages.
 
 .. clicmd:: ipv6 nd prefix ipv6prefix [valid-lifetime] [preferred-lifetime] [off-link] [no-autoconfig] [router-address]
 
@@ -54,19 +51,19 @@ Router Advertisement
 
      Default: not set, i.e. hosts do not assume a complete IP address is placed.
 
-.. clicmd:: [no] ipv6 nd ra-interval [(1-1800)]
+.. clicmd:: ipv6 nd ra-interval [(1-1800)]
 
    The maximum time allowed between sending unsolicited multicast router
    advertisements from the interface, in seconds.
    Default: ``600``
 
-.. clicmd:: [no] ipv6 nd ra-interval [msec (70-1800000)]
+.. clicmd:: ipv6 nd ra-interval [msec (70-1800000)]
 
    The maximum time allowed between sending unsolicited multicast router
    advertisements from the interface, in milliseconds.
    Default: ``600000``
 
-.. clicmd:: [no] ipv6 nd ra-fast-retrans
+.. clicmd:: ipv6 nd ra-fast-retrans
 
    RFC4861 states that consecutive RA packets should be sent no more
    frequently than three seconds apart. FRR by default allows faster
@@ -77,7 +74,7 @@ Router Advertisement
    and neighbor establishment.
    Default: enabled
 
-.. clicmd:: [no] ipv6 nd ra-retrans-interval [(0-4294967295)]
+.. clicmd:: ipv6 nd ra-retrans-interval [(0-4294967295)]
 
    The value to be placed in the retrans timer field of router advertisements
    sent from the interface, in msec. Indicates the interval between router
@@ -86,7 +83,7 @@ Router Advertisement
    msec.
    Default: ``0``
 
-.. clicmd:: [no] ipv6 nd ra-hop-limit [(0-255)]
+.. clicmd:: ipv6 nd ra-hop-limit [(0-255)]
 
    The value to be placed in the hop count field of router advertisements sent
    from the interface, in hops. Indicates the maximum diameter of the network.
@@ -94,7 +91,7 @@ Router Advertisement
    router.  Must be between zero or 255 hops.
    Default: ``64``
 
-.. clicmd:: [no] ipv6 nd ra-lifetime [(0-9000)]
+.. clicmd:: ipv6 nd ra-lifetime [(0-9000)]
 
    The value to be placed in the Router Lifetime field of router advertisements
    sent from the interface, in seconds. Indicates the usefulness of the router
@@ -104,7 +101,7 @@ Router Advertisement
    (or default) and 9000 seconds.
    Default: ``1800``
 
-.. clicmd:: [no] ipv6 nd reachable-time [(1-3600000)]
+.. clicmd:: ipv6 nd reachable-time [(1-3600000)]
 
    The value to be placed in the Reachable Time field in the Router
    Advertisement messages sent by the router, in milliseconds. The configured
@@ -112,7 +109,7 @@ Router Advertisement
    means unspecified (by this router).
    Default: ``0``
 
-.. clicmd:: [no] ipv6 nd managed-config-flag
+.. clicmd:: ipv6 nd managed-config-flag
 
    Set/unset flag in IPv6 router advertisements which indicates to hosts that
    they should use managed (stateful) protocol for addresses autoconfiguration
@@ -120,28 +117,28 @@ Router Advertisement
    autoconfiguration.
    Default: not set
 
-.. clicmd:: [no] ipv6 nd other-config-flag
+.. clicmd:: ipv6 nd other-config-flag
 
    Set/unset flag in IPv6 router advertisements which indicates to hosts that
    they should use administered (stateful) protocol to obtain autoconfiguration
    information other than addresses.
    Default: not set
 
-.. clicmd:: [no] ipv6 nd home-agent-config-flag
+.. clicmd:: ipv6 nd home-agent-config-flag
 
    Set/unset flag in IPv6 router advertisements which indicates to hosts that
    the router acts as a Home Agent and includes a Home Agent Option.
    Default: not set
 
 
-.. clicmd:: [no] ipv6 nd home-agent-preference [(0-65535)]
+.. clicmd:: ipv6 nd home-agent-preference [(0-65535)]
 
    The value to be placed in Home Agent Option, when Home Agent config flag is
    set, which indicates to hosts Home Agent preference. The default value of 0
    stands for the lowest preference possible.
    Default: ``0``
 
-.. clicmd:: [no] ipv6 nd home-agent-lifetime [(0-65520)]
+.. clicmd:: ipv6 nd home-agent-lifetime [(0-65520)]
 
    The value to be placed in Home Agent Option, when Home Agent config flag is set,
    which indicates to hosts Home Agent Lifetime. The default value of 0 means to
@@ -149,18 +146,18 @@ Router Advertisement
 
    Default: ``0``
 
-.. clicmd:: [no] ipv6 nd adv-interval-option
+.. clicmd:: ipv6 nd adv-interval-option
 
    Include an Advertisement Interval option which indicates to hosts the maximum time,
    in milliseconds, between successive unsolicited Router Advertisements.
    Default: not set
 
-.. clicmd:: [no] ipv6 nd router-preference [(high|medium|low)]
+.. clicmd:: ipv6 nd router-preference [(high|medium|low)]
 
    Set default router preference in IPv6 router advertisements per RFC4191.
    Default: medium
 
-.. clicmd:: [no] ipv6 nd mtu [(1-65535)]
+.. clicmd:: ipv6 nd mtu [(1-65535)]
 
    Include an MTU (type 5) option in each RA packet to assist the attached
    hosts in proper interface configuration. The announced value is not verified
@@ -168,7 +165,7 @@ Router Advertisement
 
    Default: don't advertise any MTU option.
 
-.. clicmd:: [no] ipv6 nd rdnss ipv6address [lifetime]
+.. clicmd:: ipv6 nd rdnss ipv6address [lifetime]
 
    Recursive DNS server address to advertise using the RDNSS (type 25) option
    described in RFC8106. Can be specified more than once to advertise multiple
@@ -185,7 +182,7 @@ Router Advertisement
 
    Default: do not emit RDNSS option
 
-.. clicmd:: [no] ipv6 nd dnssl domain-name-suffix [lifetime]
+.. clicmd:: ipv6 nd dnssl domain-name-suffix [lifetime]
 
    Advertise DNS search list using the DNSSL (type 31) option described in
    RFC8106. Specify more than once to advertise multiple domain name suffixes.

--- a/doc/user/ipv6.rst
+++ b/doc/user/ipv6.rst
@@ -17,17 +17,14 @@ no longer possible.
 Router Advertisement
 ====================
 
-.. index:: ipv6 nd suppress-ra
 .. clicmd:: no ipv6 nd suppress-ra
 
    Send router advertisement messages.
 
-.. index:: ipv6 nd suppress-ra
 .. clicmd:: ipv6 nd suppress-ra
 
    Don't send router advertisement messages.
 
-.. index:: ipv6 nd prefix ipv6prefix [valid-lifetime] [preferred-lifetime] [off-link] [no-autoconfig] [router-address]
 .. clicmd:: ipv6 nd prefix ipv6prefix [valid-lifetime] [preferred-lifetime] [off-link] [no-autoconfig] [router-address]
 
    Configuring the IPv6 prefix to include in router advertisements. Several prefix
@@ -57,21 +54,18 @@ Router Advertisement
 
      Default: not set, i.e. hosts do not assume a complete IP address is placed.
 
-.. index:: ipv6 nd ra-interval [(1-1800)]
 .. clicmd:: [no] ipv6 nd ra-interval [(1-1800)]
 
    The maximum time allowed between sending unsolicited multicast router
    advertisements from the interface, in seconds.
    Default: ``600``
 
-.. index:: ipv6 nd ra-interval msec (70-1800000)
 .. clicmd:: [no] ipv6 nd ra-interval [msec (70-1800000)]
 
    The maximum time allowed between sending unsolicited multicast router
    advertisements from the interface, in milliseconds.
    Default: ``600000``
 
-.. index:: ipv6 nd ra-fast-retrans
 .. clicmd:: [no] ipv6 nd ra-fast-retrans
 
    RFC4861 states that consecutive RA packets should be sent no more
@@ -83,7 +77,6 @@ Router Advertisement
    and neighbor establishment.
    Default: enabled
 
-.. index:: ipv6 nd ra-retrans-interval (0-4294967295)
 .. clicmd:: [no] ipv6 nd ra-retrans-interval [(0-4294967295)]
 
    The value to be placed in the retrans timer field of router advertisements
@@ -93,7 +86,6 @@ Router Advertisement
    msec.
    Default: ``0``
 
-.. index:: ipv6 nd ra-hop-limit (0-255)
 .. clicmd:: [no] ipv6 nd ra-hop-limit [(0-255)]
 
    The value to be placed in the hop count field of router advertisements sent
@@ -102,7 +94,6 @@ Router Advertisement
    router.  Must be between zero or 255 hops.
    Default: ``64``
 
-.. index:: ipv6 nd ra-lifetime (0-9000)
 .. clicmd:: [no] ipv6 nd ra-lifetime [(0-9000)]
 
    The value to be placed in the Router Lifetime field of router advertisements
@@ -113,7 +104,6 @@ Router Advertisement
    (or default) and 9000 seconds.
    Default: ``1800``
 
-.. index:: ipv6 nd reachable-time (1-3600000)
 .. clicmd:: [no] ipv6 nd reachable-time [(1-3600000)]
 
    The value to be placed in the Reachable Time field in the Router
@@ -122,7 +112,6 @@ Router Advertisement
    means unspecified (by this router).
    Default: ``0``
 
-.. index:: ipv6 nd managed-config-flag
 .. clicmd:: [no] ipv6 nd managed-config-flag
 
    Set/unset flag in IPv6 router advertisements which indicates to hosts that
@@ -131,7 +120,6 @@ Router Advertisement
    autoconfiguration.
    Default: not set
 
-.. index:: ipv6 nd other-config-flag
 .. clicmd:: [no] ipv6 nd other-config-flag
 
    Set/unset flag in IPv6 router advertisements which indicates to hosts that
@@ -139,16 +127,13 @@ Router Advertisement
    information other than addresses.
    Default: not set
 
-.. index:: ipv6 nd home-agent-config-flag
 .. clicmd:: [no] ipv6 nd home-agent-config-flag
 
    Set/unset flag in IPv6 router advertisements which indicates to hosts that
    the router acts as a Home Agent and includes a Home Agent Option.
    Default: not set
 
-.. index:: ipv6 nd home-agent-preference (0-65535)
 
-.. index:: ipv6 nd home-agent-preference (0-65535)
 .. clicmd:: [no] ipv6 nd home-agent-preference [(0-65535)]
 
    The value to be placed in Home Agent Option, when Home Agent config flag is
@@ -156,7 +141,6 @@ Router Advertisement
    stands for the lowest preference possible.
    Default: ``0``
 
-.. index:: ipv6 nd home-agent-lifetime (0-65520)
 .. clicmd:: [no] ipv6 nd home-agent-lifetime [(0-65520)]
 
    The value to be placed in Home Agent Option, when Home Agent config flag is set,
@@ -165,20 +149,17 @@ Router Advertisement
 
    Default: ``0``
 
-.. index:: ipv6 nd adv-interval-option
 .. clicmd:: [no] ipv6 nd adv-interval-option
 
    Include an Advertisement Interval option which indicates to hosts the maximum time,
    in milliseconds, between successive unsolicited Router Advertisements.
    Default: not set
 
-.. index:: ipv6 nd router-preference (high|medium|low)
 .. clicmd:: [no] ipv6 nd router-preference [(high|medium|low)]
 
    Set default router preference in IPv6 router advertisements per RFC4191.
    Default: medium
 
-.. index:: ipv6 nd mtu (1-65535)
 .. clicmd:: [no] ipv6 nd mtu [(1-65535)]
 
    Include an MTU (type 5) option in each RA packet to assist the attached
@@ -187,7 +168,6 @@ Router Advertisement
 
    Default: don't advertise any MTU option.
 
-.. index:: ipv6 nd rdnss ipv6address [lifetime]
 .. clicmd:: [no] ipv6 nd rdnss ipv6address [lifetime]
 
    Recursive DNS server address to advertise using the RDNSS (type 25) option
@@ -205,7 +185,6 @@ Router Advertisement
 
    Default: do not emit RDNSS option
 
-.. index:: ipv6 nd dnssl domain-name-suffix [lifetime]
 .. clicmd:: [no] ipv6 nd dnssl domain-name-suffix [lifetime]
 
    Advertise DNS search list using the DNSSL (type 31) option described in

--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -33,7 +33,7 @@ ISIS router
 To start the ISIS process you have to specify the ISIS router. As of this
 writing, *isisd* does not support multiple ISIS processes.
 
-.. clicmd:: [no] router isis WORD [vrf NAME]
+.. clicmd:: router isis WORD [vrf NAME]
 
    Enable or disable the ISIS process by specifying the ISIS domain with
    'WORD'.  *isisd* does not yet support multiple ISIS processes but you must
@@ -42,13 +42,9 @@ writing, *isisd* does not support multiple ISIS processes.
 
 .. clicmd:: net XX.XXXX. ... .XXX.XX
 
-.. clicmd:: no net XX.XXXX. ... .XXX.XX
-
    Set/Unset network entity title (NET) provided in ISO format.
 
 .. clicmd:: hostname dynamic
-
-.. clicmd:: no hostname dynamic
 
    Enable support for dynamic hostname.
 
@@ -56,16 +52,10 @@ writing, *isisd* does not support multiple ISIS processes.
 
 .. clicmd:: domain-password [clear | md5] <password>
 
-.. clicmd:: no area-password
-
-.. clicmd:: no domain-password
-
    Configure the authentication password for an area, respectively a domain, as
    clear text or md5 one.
 
 .. clicmd:: attached-bit [receive ignore | send]
-
-.. clicmd:: no attached-bit
 
    Set attached bit for inter-area traffic:
 
@@ -76,13 +66,9 @@ writing, *isisd* does not support multiple ISIS processes.
 
 .. clicmd:: log-adjacency-changes
 
-.. clicmd:: no log-adjacency-changes
-
    Log changes in adjacency state.
 
 .. clicmd:: metric-style [narrow | transition | wide]
-
-.. clicmd:: no metric-style
 
    Set old-style (ISO 10589) or new-style packet formats:
 
@@ -95,17 +81,13 @@ writing, *isisd* does not support multiple ISIS processes.
 
 .. clicmd:: set-overload-bit
 
-.. clicmd:: no set-overload-bit
-
    Set overload bit to avoid any transit traffic.
 
 .. clicmd:: purge-originator
 
-.. clicmd:: no purge-originator
-
    Enable or disable :rfc:`6232` purge originator identification.
 
-.. clicmd:: [no] lsp-mtu (128-4352)
+.. clicmd:: lsp-mtu (128-4352)
 
    Configure the maximum size of generated LSPs, in bytes.
 
@@ -115,42 +97,22 @@ writing, *isisd* does not support multiple ISIS processes.
 ISIS Timer
 ==========
 
-.. clicmd:: lsp-gen-interval (1-120)
-
 .. clicmd:: lsp-gen-interval [level-1 | level-2] (1-120)
-
-.. clicmd:: no lsp-gen-interval
-
-.. clicmd:: no lsp-gen-interval [level-1 | level-2]
 
    Set minimum interval in seconds between regenerating same LSP,
    globally, for an area (level-1) or a domain (level-2).
 
 .. clicmd:: lsp-refresh-interval [level-1 | level-2] (1-65235)
 
-.. clicmd:: no lsp-refresh-interval [level-1 | level-2]
-
    Set LSP refresh interval in seconds, globally, for an area (level-1) or a
    domain (level-2).
 
-.. clicmd:: max-lsp-lifetime (360-65535)
-
 .. clicmd:: max-lsp-lifetime [level-1 | level-2] (360-65535)
-
-.. clicmd:: no max-lsp-lifetime
-
-.. clicmd:: no max-lsp-lifetime [level-1 | level-2]
 
    Set LSP maximum LSP lifetime in seconds, globally, for an area (level-1) or
    a domain (level-2).
 
-.. clicmd:: spf-interval (1-120)
-
 .. clicmd:: spf-interval [level-1 | level-2] (1-120)
-
-.. clicmd:: no spf-interval
-
-.. clicmd:: no spf-interval [level-1 | level-2]
 
    Set minimum interval between consecutive SPF calculations in seconds.
 
@@ -161,22 +123,17 @@ ISIS Fast-Reroute
 
 .. clicmd:: spf prefix-priority [critical | high | medium] WORD
 
-.. clicmd:: no spf prefix-priority [critical | high | medium] [WORD]
-
    Assign a priority to the prefixes that match the specified access-list.
 
-.. clicmd:: [no] fast-reroute priority-limit [critical | high | medium] [level-1 | level-2]
+.. clicmd:: fast-reroute priority-limit [critical | high | medium] [level-1 | level-2]
 
    Limit LFA backup computation up to the specified prefix priority.
 
-
-   first.
-
-.. clicmd:: [no] fast-reroute load-sharing disable [level-1 | level-2]
+.. clicmd:: fast-reroute load-sharing disable [level-1 | level-2]
 
    Disable load sharing across multiple LFA backups.
 
-.. clicmd:: [no] fast-reroute remote-lfa prefix-list [WORD] [level-1 | level-2]
+.. clicmd:: fast-reroute remote-lfa prefix-list [WORD] [level-1 | level-2]
 
    Configure a prefix-list to select eligible PQ nodes (valid for all protected
    interfaces).
@@ -187,8 +144,6 @@ ISIS region
 ===========
 
 .. clicmd:: is-type [level-1 | level-1-2 | level-2-only]
-
-.. clicmd:: no is-type
 
    Define the ISIS router behavior:
 
@@ -206,7 +161,7 @@ ISIS interface
 
 .. _ip-router-isis-word:
 
-.. clicmd:: [no] <ip|ipv6> router isis WORD [vrf NAME]
+.. clicmd:: <ip|ipv6> router isis WORD [vrf NAME]
 
    Activate ISIS adjacency on this interface. Note that the name of ISIS
    instance must be the same as the one used to configure the ISIS process (see
@@ -214,8 +169,6 @@ ISIS interface
    WORD``; to enable IPv6, issue ``ipv6 router isis WORD``.
 
 .. clicmd:: isis circuit-type [level-1 | level-1-2 | level-2]
-
-.. clicmd:: no isis circuit-type
 
    Configure circuit type for interface:
 
@@ -226,13 +179,7 @@ ISIS interface
    - level-2-only
      Level-2 only adjacencies are formed
 
-.. clicmd:: isis csnp-interval (1-600)
-
 .. clicmd:: isis csnp-interval (1-600) [level-1 | level-2]
-
-.. clicmd:: no isis csnp-interval
-
-.. clicmd:: no isis csnp-interval [level-1 | level-2]
 
    Set CSNP interval in seconds globally, for an area (level-1) or a domain
    (level-2).
@@ -241,35 +188,17 @@ ISIS interface
 
    Add padding to IS-IS hello packets.
 
-.. clicmd:: isis hello-interval (1-600)
-
 .. clicmd:: isis hello-interval (1-600) [level-1 | level-2]
-
-.. clicmd:: no isis hello-interval
-
-.. clicmd:: no isis hello-interval [level-1 | level-2]
 
    Set Hello interval in seconds globally, for an area (level-1) or a domain
    (level-2).
 
-.. clicmd:: isis hello-multiplier (2-100)
-
 .. clicmd:: isis hello-multiplier (2-100) [level-1 | level-2]
-
-.. clicmd:: no isis hello-multiplier
-
-.. clicmd:: no isis hello-multiplier [level-1 | level-2]
 
    Set multiplier for Hello holding time globally, for an area (level-1) or a
    domain (level-2).
 
-.. clicmd:: isis metric [(0-255) | (0-16777215)]
-
 .. clicmd:: isis metric [(0-255) | (0-16777215)] [level-1 | level-2]
-
-.. clicmd:: no isis metric
-
-.. clicmd:: no isis metric [level-1 | level-2]
 
    Set default metric value globally, for an area (level-1) or a domain
    (level-2).  Max value depend if metric support narrow or wide value (see
@@ -277,73 +206,54 @@ ISIS interface
 
 .. clicmd:: isis network point-to-point
 
-.. clicmd:: no isis network point-to-point
-
    Set network type to 'Point-to-Point' (broadcast by default).
 
 .. clicmd:: isis passive
-
-.. clicmd:: no isis passive
 
    Configure the passive mode for this interface.
 
 .. clicmd:: isis password [clear | md5] <password>
 
-.. clicmd:: no isis password
-
    Configure the authentication password (clear or encoded text) for the
    interface.
 
-.. clicmd:: isis priority (0-127)
-
 .. clicmd:: isis priority (0-127) [level-1 | level-2]
-
-.. clicmd:: no isis priority
-
-.. clicmd:: no isis priority [level-1 | level-2]
 
    Set priority for Designated Router election, globally, for the area
    (level-1) or the domain (level-2).
 
-.. clicmd:: isis psnp-interval (1-120)
-
 .. clicmd:: isis psnp-interval (1-120) [level-1 | level-2]
-
-.. clicmd:: no isis psnp-interval
-
-.. clicmd:: no isis psnp-interval [level-1 | level-2]
 
    Set PSNP interval in seconds globally, for an area (level-1) or a domain
    (level-2).
 
 .. clicmd:: isis three-way-handshake
 
-.. clicmd:: no isis three-way-handshake
-
    Enable or disable :rfc:`5303` Three-Way Handshake for P2P adjacencies.
    Three-Way Handshake is enabled by default.
 
-.. clicmd:: [no] isis fast-reroute lfa [level-1 | level-2]
+.. clicmd:: isis fast-reroute lfa [level-1 | level-2]
 
    Enable per-prefix LFA fast reroute link protection.
 
-.. clicmd:: [no] isis fast-reroute lfa [level-1 | level-2] exclude interface IFNAME
+.. clicmd:: isis fast-reroute lfa [level-1 | level-2] exclude interface IFNAME
 
    Exclude an interface from the LFA backup nexthop computation.
 
-.. clicmd:: [no] isis fast-reroute ti-lfa [level-1|level-2] [node-protection]
+.. clicmd:: isis fast-reroute ti-lfa [level-1|level-2] [node-protection]
 
    Enable per-prefix TI-LFA fast reroute link or node protection.
 
-.. clicmd:: [no] isis fast-reroute remote-lfa tunnel mpls-ldp [level-1 | level-2]
+.. clicmd:: isis fast-reroute remote-lfa tunnel mpls-ldp [level-1 | level-2]
 
    Enable per-prefix Remote LFA fast reroute link protection. Note that other
    routers in the network need to be configured to accept LDP targeted hello
    messages in order for RLFA to work.
 
-.. clicmd:: [no] isis fast-reroute remote-lfa maximum-metric (1-16777215) [level-1 | level-2]
+.. clicmd:: isis fast-reroute remote-lfa maximum-metric (1-16777215) [level-1 | level-2]
 
    Limit Remote LFA PQ node selection within the specified metric.
+
 
 .. _showing-isis-information:
 
@@ -358,36 +268,20 @@ Showing ISIS information
 
    Show information about ISIS node.
 
-.. clicmd:: show isis interface
-
-.. clicmd:: show isis interface detail
-
-.. clicmd:: show isis interface <interface name>
+.. clicmd:: show isis interface [detail] [IFNAME]
 
    Show state and configuration of ISIS specified interface, or all interfaces
    if no interface is given with or without details.
 
-.. clicmd:: show isis neighbor
-
-.. clicmd:: show isis neighbor <System Id>
-
-.. clicmd:: show isis neighbor detail
+.. clicmd:: show isis neighbor [detail] [SYSTEMID]
 
    Show state and information of ISIS specified neighbor, or all neighbors if
    no system id is given with or without details.
 
-.. clicmd:: show isis database
-
-.. clicmd:: show isis database [detail]
-
-.. clicmd:: show isis database <LSP id> [detail]
-
-.. clicmd:: show isis database detail <LSP id>
+.. clicmd:: show isis database [detail] [LSPID]
 
    Show the ISIS database globally, for a specific LSP id without or with
    details.
-
-.. clicmd:: show isis topology
 
 .. clicmd:: show isis topology [level-1|level-2]
 
@@ -404,6 +298,7 @@ Showing ISIS information
    Show information about the number of prefixes having LFA protection,
    and network-wide LFA coverage.
 
+
 .. _isis-traffic-engineering:
 
 Traffic Engineering
@@ -411,19 +306,15 @@ Traffic Engineering
 
 .. note::
 
-   At this time, FRR offers partial support for some of the routing
-   protocol extensions that can be used with MPLS-TE. FRR does not
-   support a complete RSVP-TE solution currently.
+   At this time, FRR offers partial support for some of the routing protocol
+   extensions that can be used with MPLS-TE. FRR does not currently support a
+   complete RSVP-TE solution.
 
 .. clicmd:: mpls-te on
-
-.. clicmd:: no mpls-te
 
    Enable Traffic Engineering LSP flooding.
 
 .. clicmd:: mpls-te router-address <A.B.C.D>
-
-.. clicmd:: no mpls-te router-address
 
    Configure stable IP address for MPLS-TE.
 
@@ -441,6 +332,7 @@ Traffic Engineering
 
    :ref:`ospf-traffic-engineering`
 
+
 .. _debugging-isis:
 
 Segment Routing
@@ -457,29 +349,29 @@ Known limitations:
  - No support for SRLB
  - Only one SRGB and default SPF Algorithm is supported
 
-.. clicmd:: [no] segment-routing on
+.. clicmd:: segment-routing on
 
    Enable Segment Routing.
 
-.. clicmd:: [no] segment-routing global-block (0-1048575) (0-1048575)
+.. clicmd:: segment-routing global-block (0-1048575) (0-1048575)
 
    Set the Segment Routing Global Block i.e. the label range used by MPLS
    to store label in the MPLS FIB for Prefix SID. Note that the block size
    may not exceed 65535.
 
-.. clicmd:: [no] segment-routing local-block (0-1048575) (0-1048575)
+.. clicmd:: segment-routing local-block (0-1048575) (0-1048575)
 
    Set the Segment Routing Local Block i.e. the label range used by MPLS
    to store label in the MPLS FIB for Adjacency SID. Note that the block size
    may not exceed 65535.
 
-.. clicmd:: [no] segment-routing node-msd (1-16)
+.. clicmd:: segment-routing node-msd (1-16)
 
    Set the Maximum Stack Depth supported by the router. The value depend of the
    MPLS dataplane. E.g. for Linux kernel, since version 4.13 the maximum value
    is 32.
 
-.. clicmd:: [no] segment-routing prefix <A.B.C.D/M|X:X::X:X/M> <absolute (16-1048575)|index (0-65535) [no-php-flag|explicit-null] [n-flag-clear]
+.. clicmd:: segment-routing prefix <A.B.C.D/M|X:X::X:X/M> <absolute (16-1048575)|index (0-65535) [no-php-flag|explicit-null] [n-flag-clear]
 
    prefix. The 'no-php-flag' means NO Penultimate Hop Popping that allows SR
    node to request to its neighbor to not pop the label. The 'explicit-null'
@@ -501,88 +393,63 @@ Debugging ISIS
 
 .. clicmd:: debug isis adj-packets
 
-.. clicmd:: no debug isis adj-packets
-
    IS-IS Adjacency related packets.
 
 .. clicmd:: debug isis checksum-errors
-
-.. clicmd:: no debug isis checksum-errors
 
    IS-IS LSP checksum errors.
 
 .. clicmd:: debug isis events
 
-.. clicmd:: no debug isis events
-
    IS-IS Events.
 
 .. clicmd:: debug isis local-updates
-
-.. clicmd:: no debug isis local-updates
 
    IS-IS local update packets.
 
 .. clicmd:: debug isis packet-dump
 
-.. clicmd:: no debug isis packet-dump
-
    IS-IS packet dump.
 
 .. clicmd:: debug isis protocol-errors
-
-.. clicmd:: no debug isis protocol-errors
 
    IS-IS LSP protocol errors.
 
 .. clicmd:: debug isis route-events
 
-.. clicmd:: no debug isis route-events
-
    IS-IS Route related events.
 
 .. clicmd:: debug isis snp-packets
 
-.. clicmd:: no debug isis snp-packets
-
    IS-IS CSNP/PSNP packets.
 
 .. clicmd:: debug isis spf-events
-
 .. clicmd:: debug isis spf-statistics
-
 .. clicmd:: debug isis spf-triggers
-
-.. clicmd:: no debug isis spf-events
-
-.. clicmd:: no debug isis spf-statistics
-
-.. clicmd:: no debug isis spf-triggers
 
    IS-IS Shortest Path First Events, Timing and Statistic Data and triggering
    events.
 
 .. clicmd:: debug isis update-packets
 
-.. clicmd:: no debug isis update-packets
 
    Update related packets.
 
 .. clicmd:: debug isis sr-events
 
-.. clicmd:: no debug isis sr-events
 
    IS-IS Segment Routing events.
 
 .. clicmd:: debug isis lfa
 
-.. clicmd:: no debug isis lfa
 
    IS-IS LFA events.
 
 .. clicmd:: show debugging isis
 
    Print which ISIS debug level is activate.
+
+.. _isis-config-examples:
 
 ISIS Configuration Examples
 ===========================
@@ -695,6 +562,9 @@ A Segment Routing configuration, with IPv4, IPv6, SRGB and MSD configuration.
     segment-routing node-msd 8
    !
 
+
+.. _isis-vrf-config-examples:
+
 ISIS Vrf Configuration Examples
 ===============================
 
@@ -712,5 +582,3 @@ A simple vrf example:
     net 47.0023.0000.0000.0000.0000.0000.0000.1900.0004.00
     metric-style wide
     is-type level-2-only
-
-

--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -33,7 +33,6 @@ ISIS router
 To start the ISIS process you have to specify the ISIS router. As of this
 writing, *isisd* does not support multiple ISIS processes.
 
-.. index:: router isis WORD [vrf NAME]
 .. clicmd:: [no] router isis WORD [vrf NAME]
 
    Enable or disable the ISIS process by specifying the ISIS domain with
@@ -41,41 +40,31 @@ writing, *isisd* does not support multiple ISIS processes.
    specify the name of ISIS process. The ISIS process name 'WORD' is then used
    for interface (see command :clicmd:`ip router isis WORD`).
 
-.. index:: net XX.XXXX. ... .XXX.XX
 .. clicmd:: net XX.XXXX. ... .XXX.XX
 
-.. index:: net XX.XXXX. ... .XXX.XX
 .. clicmd:: no net XX.XXXX. ... .XXX.XX
 
    Set/Unset network entity title (NET) provided in ISO format.
 
-.. index:: hostname dynamic
 .. clicmd:: hostname dynamic
 
-.. index:: hostname dynamic
 .. clicmd:: no hostname dynamic
 
    Enable support for dynamic hostname.
 
-.. index:: area-password [clear | md5] <password>
 .. clicmd:: area-password [clear | md5] <password>
 
-.. index:: domain-password [clear | md5] <password>
 .. clicmd:: domain-password [clear | md5] <password>
 
-.. index:: area-password
 .. clicmd:: no area-password
 
-.. index:: domain-password
 .. clicmd:: no domain-password
 
    Configure the authentication password for an area, respectively a domain, as
    clear text or md5 one.
 
-.. index:: attached-bit [receive ignore | send]
 .. clicmd:: attached-bit [receive ignore | send]
 
-.. index:: attached-bit
 .. clicmd:: no attached-bit
 
    Set attached bit for inter-area traffic:
@@ -85,18 +74,14 @@ writing, *isisd* does not support multiple ISIS processes.
    - send
      If L1|L2 router, set attached bit in LSP sent to L1 router
 
-.. index:: log-adjacency-changes
 .. clicmd:: log-adjacency-changes
 
-.. index:: log-adjacency-changes
 .. clicmd:: no log-adjacency-changes
 
    Log changes in adjacency state.
 
-.. index:: metric-style [narrow | transition | wide]
 .. clicmd:: metric-style [narrow | transition | wide]
 
-.. index:: metric-style
 .. clicmd:: no metric-style
 
    Set old-style (ISO 10589) or new-style packet formats:
@@ -108,23 +93,18 @@ writing, *isisd* does not support multiple ISIS processes.
    - wide
      Use new style of TLVs to carry wider metric
 
-.. index:: set-overload-bit
 .. clicmd:: set-overload-bit
 
-.. index:: set-overload-bit
 .. clicmd:: no set-overload-bit
 
    Set overload bit to avoid any transit traffic.
 
-.. index:: purge-originator
 .. clicmd:: purge-originator
 
-.. index:: purge-originator
 .. clicmd:: no purge-originator
 
    Enable or disable :rfc:`6232` purge originator identification.
 
-.. index:: lsp-mtu (128-4352)
 .. clicmd:: [no] lsp-mtu (128-4352)
 
    Configure the maximum size of generated LSPs, in bytes.
@@ -135,55 +115,41 @@ writing, *isisd* does not support multiple ISIS processes.
 ISIS Timer
 ==========
 
-.. index:: lsp-gen-interval (1-120)
 .. clicmd:: lsp-gen-interval (1-120)
 
-.. index:: lsp-gen-interval [level-1 | level-2] (1-120)
 .. clicmd:: lsp-gen-interval [level-1 | level-2] (1-120)
 
-.. index:: lsp-gen-interval
 .. clicmd:: no lsp-gen-interval
 
-.. index:: lsp-gen-interval [level-1 | level-2]
 .. clicmd:: no lsp-gen-interval [level-1 | level-2]
 
    Set minimum interval in seconds between regenerating same LSP,
    globally, for an area (level-1) or a domain (level-2).
 
-.. index:: lsp-refresh-interval [level-1 | level-2] (1-65235)
 .. clicmd:: lsp-refresh-interval [level-1 | level-2] (1-65235)
 
-.. index:: lsp-refresh-interval [level-1 | level-2]
 .. clicmd:: no lsp-refresh-interval [level-1 | level-2]
 
    Set LSP refresh interval in seconds, globally, for an area (level-1) or a
    domain (level-2).
 
-.. index:: max-lsp-lifetime (360-65535)
 .. clicmd:: max-lsp-lifetime (360-65535)
 
-.. index:: max-lsp-lifetime [level-1 | level-2] (360-65535)
 .. clicmd:: max-lsp-lifetime [level-1 | level-2] (360-65535)
 
-.. index:: max-lsp-lifetime
 .. clicmd:: no max-lsp-lifetime
 
-.. index:: max-lsp-lifetime [level-1 | level-2]
 .. clicmd:: no max-lsp-lifetime [level-1 | level-2]
 
    Set LSP maximum LSP lifetime in seconds, globally, for an area (level-1) or
    a domain (level-2).
 
-.. index:: spf-interval (1-120)
 .. clicmd:: spf-interval (1-120)
 
-.. index:: spf-interval [level-1 | level-2] (1-120)
 .. clicmd:: spf-interval [level-1 | level-2] (1-120)
 
-.. index:: spf-interval
 .. clicmd:: no spf-interval
 
-.. index:: spf-interval [level-1 | level-2]
 .. clicmd:: no spf-interval [level-1 | level-2]
 
    Set minimum interval between consecutive SPF calculations in seconds.
@@ -193,31 +159,23 @@ ISIS Timer
 ISIS Fast-Reroute
 =================
 
-.. index:: spf prefix-priority [critical | high | medium] WORD
 .. clicmd:: spf prefix-priority [critical | high | medium] WORD
 
-.. index:: spf prefix-priority [critical | high | medium] WORD
 .. clicmd:: no spf prefix-priority [critical | high | medium] [WORD]
 
    Assign a priority to the prefixes that match the specified access-list.
 
-.. index:: fast-reroute priority-limit [critical | high | medium] [level-1 | level-2]
 .. clicmd:: [no] fast-reroute priority-limit [critical | high | medium] [level-1 | level-2]
 
    Limit LFA backup computation up to the specified prefix priority.
 
-.. index:: fast-reroute lfa tiebreaker [downstream | lowest-backup-metric | node-protecting] index (1-255) [level-1 | level-2]
-.. clicmd:: [no] fast-reroute lfa tiebreaker [downstream | lowest-backup-metric | node-protecting] index (1-255) [level-1 | level-2]
 
-   Configure a tie-breaker for multiple LFA backups. Lower indexes are processed
    first.
 
-.. index:: fast-reroute load-sharing disable [level-1 | level-2]
 .. clicmd:: [no] fast-reroute load-sharing disable [level-1 | level-2]
 
    Disable load sharing across multiple LFA backups.
 
-.. index:: fast-reroute remote-lfa prefix-list WORD [level-1 | level-2]
 .. clicmd:: [no] fast-reroute remote-lfa prefix-list [WORD] [level-1 | level-2]
 
    Configure a prefix-list to select eligible PQ nodes (valid for all protected
@@ -228,10 +186,8 @@ ISIS Fast-Reroute
 ISIS region
 ===========
 
-.. index:: is-type [level-1 | level-1-2 | level-2-only]
 .. clicmd:: is-type [level-1 | level-1-2 | level-2-only]
 
-.. index:: is-type
 .. clicmd:: no is-type
 
    Define the ISIS router behavior:
@@ -250,8 +206,6 @@ ISIS interface
 
 .. _ip-router-isis-word:
 
-.. index:: ip router isis WORD [vrf NAME]
-.. index:: ipv6 router isis WORD [vrf NAME]
 .. clicmd:: [no] <ip|ipv6> router isis WORD [vrf NAME]
 
    Activate ISIS adjacency on this interface. Note that the name of ISIS
@@ -259,10 +213,8 @@ ISIS interface
    command :clicmd:`router isis WORD`). To enable IPv4, issue ``ip router isis
    WORD``; to enable IPv6, issue ``ipv6 router isis WORD``.
 
-.. index:: isis circuit-type [level-1 | level-1-2 | level-2]
 .. clicmd:: isis circuit-type [level-1 | level-1-2 | level-2]
 
-.. index:: isis circuit-type
 .. clicmd:: no isis circuit-type
 
    Configure circuit type for interface:
@@ -274,159 +226,121 @@ ISIS interface
    - level-2-only
      Level-2 only adjacencies are formed
 
-.. index:: isis csnp-interval (1-600)
 .. clicmd:: isis csnp-interval (1-600)
 
-.. index:: isis csnp-interval (1-600) [level-1 | level-2]
 .. clicmd:: isis csnp-interval (1-600) [level-1 | level-2]
 
-.. index:: isis csnp-interval
 .. clicmd:: no isis csnp-interval
 
-.. index:: isis csnp-interval [level-1 | level-2]
 .. clicmd:: no isis csnp-interval [level-1 | level-2]
 
    Set CSNP interval in seconds globally, for an area (level-1) or a domain
    (level-2).
 
-.. index:: isis hello padding
 .. clicmd:: isis hello padding
 
    Add padding to IS-IS hello packets.
 
-.. index:: isis hello-interval (1-600)
 .. clicmd:: isis hello-interval (1-600)
 
-.. index:: isis hello-interval (1-600) [level-1 | level-2]
 .. clicmd:: isis hello-interval (1-600) [level-1 | level-2]
 
-.. index:: isis hello-interval
 .. clicmd:: no isis hello-interval
 
-.. index:: isis hello-interval [level-1 | level-2]
 .. clicmd:: no isis hello-interval [level-1 | level-2]
 
    Set Hello interval in seconds globally, for an area (level-1) or a domain
    (level-2).
 
-.. index:: isis hello-multiplier (2-100)
 .. clicmd:: isis hello-multiplier (2-100)
 
-.. index:: isis hello-multiplier (2-100) [level-1 | level-2]
 .. clicmd:: isis hello-multiplier (2-100) [level-1 | level-2]
 
-.. index:: isis hello-multiplier
 .. clicmd:: no isis hello-multiplier
 
-.. index:: isis hello-multiplier [level-1 | level-2]
 .. clicmd:: no isis hello-multiplier [level-1 | level-2]
 
    Set multiplier for Hello holding time globally, for an area (level-1) or a
    domain (level-2).
 
-.. index:: isis metric [(0-255) | (0-16777215)]
 .. clicmd:: isis metric [(0-255) | (0-16777215)]
 
-.. index:: isis metric [(0-255) | (0-16777215)] [level-1 | level-2]
 .. clicmd:: isis metric [(0-255) | (0-16777215)] [level-1 | level-2]
 
-.. index:: isis metric
 .. clicmd:: no isis metric
 
-.. index:: isis metric [level-1 | level-2]
 .. clicmd:: no isis metric [level-1 | level-2]
 
    Set default metric value globally, for an area (level-1) or a domain
    (level-2).  Max value depend if metric support narrow or wide value (see
    command :clicmd:`metric-style [narrow | transition | wide]`).
 
-.. index:: isis network point-to-point
 .. clicmd:: isis network point-to-point
 
-.. index:: isis network point-to-point
 .. clicmd:: no isis network point-to-point
 
    Set network type to 'Point-to-Point' (broadcast by default).
 
-.. index:: isis passive
 .. clicmd:: isis passive
 
-.. index:: isis passive
 .. clicmd:: no isis passive
 
    Configure the passive mode for this interface.
 
-.. index:: isis password [clear | md5] <password>
 .. clicmd:: isis password [clear | md5] <password>
 
-.. index:: isis password
 .. clicmd:: no isis password
 
    Configure the authentication password (clear or encoded text) for the
    interface.
 
-.. index:: isis priority (0-127)
 .. clicmd:: isis priority (0-127)
 
-.. index:: isis priority (0-127) [level-1 | level-2]
 .. clicmd:: isis priority (0-127) [level-1 | level-2]
 
-.. index:: isis priority
 .. clicmd:: no isis priority
 
-.. index:: isis priority [level-1 | level-2]
 .. clicmd:: no isis priority [level-1 | level-2]
 
    Set priority for Designated Router election, globally, for the area
    (level-1) or the domain (level-2).
 
-.. index:: isis psnp-interval (1-120)
 .. clicmd:: isis psnp-interval (1-120)
 
-.. index:: isis psnp-interval (1-120) [level-1 | level-2]
 .. clicmd:: isis psnp-interval (1-120) [level-1 | level-2]
 
-.. index:: isis psnp-interval
 .. clicmd:: no isis psnp-interval
 
-.. index:: isis psnp-interval [level-1 | level-2]
 .. clicmd:: no isis psnp-interval [level-1 | level-2]
 
    Set PSNP interval in seconds globally, for an area (level-1) or a domain
    (level-2).
 
-.. index:: isis three-way-handshake
 .. clicmd:: isis three-way-handshake
 
-.. index:: isis three-way-handshake
 .. clicmd:: no isis three-way-handshake
 
    Enable or disable :rfc:`5303` Three-Way Handshake for P2P adjacencies.
    Three-Way Handshake is enabled by default.
 
-.. index:: isis fast-reroute lfa [level-1 | level-2]
 .. clicmd:: [no] isis fast-reroute lfa [level-1 | level-2]
 
    Enable per-prefix LFA fast reroute link protection.
 
-.. index:: isis fast-reroute lfa [level-1 | level-2] exclude interface IFNAME
 .. clicmd:: [no] isis fast-reroute lfa [level-1 | level-2] exclude interface IFNAME
 
    Exclude an interface from the LFA backup nexthop computation.
 
-.. index:: isis fast-reroute ti-lfa [level-1|level-2] [node-protection]
 .. clicmd:: [no] isis fast-reroute ti-lfa [level-1|level-2] [node-protection]
 
    Enable per-prefix TI-LFA fast reroute link or node protection.
 
-.. index:: isis fast-reroute remote-lfa tunnel mpls-ldp [level-1 | level-2]
 .. clicmd:: [no] isis fast-reroute remote-lfa tunnel mpls-ldp [level-1 | level-2]
 
    Enable per-prefix Remote LFA fast reroute link protection. Note that other
    routers in the network need to be configured to accept LDP targeted hello
    messages in order for RLFA to work.
 
-.. index:: isis fast-reroute remote-lfa maximum-metric (1-16777215) [level-1 | level-2]
 .. clicmd:: [no] isis fast-reroute remote-lfa maximum-metric (1-16777215) [level-1 | level-2]
 
    Limit Remote LFA PQ node selection within the specified metric.
@@ -436,71 +350,55 @@ ISIS interface
 Showing ISIS information
 ========================
 
-.. index:: show isis summary
 .. clicmd:: show isis summary
 
    Show summary information about ISIS.
 
-.. index:: show isis hostname
 .. clicmd:: show isis hostname
 
    Show information about ISIS node.
 
-.. index:: show isis interface
 .. clicmd:: show isis interface
 
-.. index:: show isis interface detail
 .. clicmd:: show isis interface detail
 
-.. index:: show isis interface <interface name>
 .. clicmd:: show isis interface <interface name>
 
    Show state and configuration of ISIS specified interface, or all interfaces
    if no interface is given with or without details.
 
-.. index:: show isis neighbor
 .. clicmd:: show isis neighbor
 
-.. index:: show isis neighbor <System Id>
 .. clicmd:: show isis neighbor <System Id>
 
-.. index:: show isis neighbor detail
 .. clicmd:: show isis neighbor detail
 
    Show state and information of ISIS specified neighbor, or all neighbors if
    no system id is given with or without details.
 
-.. index:: show isis database
 .. clicmd:: show isis database
 
-.. index:: show isis database [detail]
 .. clicmd:: show isis database [detail]
 
-.. index:: show isis database <LSP id> [detail]
 .. clicmd:: show isis database <LSP id> [detail]
 
-.. index:: show isis database detail <LSP id>
 .. clicmd:: show isis database detail <LSP id>
 
    Show the ISIS database globally, for a specific LSP id without or with
    details.
 
-.. index:: show isis topology
 .. clicmd:: show isis topology
 
-.. index:: show isis topology [level-1|level-2]
 .. clicmd:: show isis topology [level-1|level-2]
 
    Show topology IS-IS paths to Intermediate Systems, globally, in area
    (level-1) or domain (level-2).
 
-.. index:: show isis route [level-1|level-2] [prefix-sid|backup]
 .. clicmd:: show isis route [level-1|level-2] [prefix-sid|backup]
 
    Show the ISIS routing table, as determined by the most recent SPF
    calculation.
 
-.. index:: show isis fast-reroute summary [level-1|level-2]
 .. clicmd:: show isis fast-reroute summary [level-1|level-2]
 
    Show information about the number of prefixes having LFA protection,
@@ -517,31 +415,24 @@ Traffic Engineering
    protocol extensions that can be used with MPLS-TE. FRR does not
    support a complete RSVP-TE solution currently.
 
-.. index:: mpls-te on
 .. clicmd:: mpls-te on
 
-.. index:: mpls-te
 .. clicmd:: no mpls-te
 
    Enable Traffic Engineering LSP flooding.
 
-.. index:: mpls-te router-address <A.B.C.D>
 .. clicmd:: mpls-te router-address <A.B.C.D>
 
-.. index:: mpls-te router-address
 .. clicmd:: no mpls-te router-address
 
    Configure stable IP address for MPLS-TE.
 
-.. index:: show isis mpls-te interface
 .. clicmd:: show isis mpls-te interface
 
-.. index:: show isis mpls-te interface INTERFACE
 .. clicmd:: show isis mpls-te interface INTERFACE
 
    Show MPLS Traffic Engineering parameters for all or specified interface.
 
-.. index:: show isis mpls-te router
 .. clicmd:: show isis mpls-te router
 
    Show Traffic Engineering router parameters.
@@ -566,36 +457,30 @@ Known limitations:
  - No support for SRLB
  - Only one SRGB and default SPF Algorithm is supported
 
-.. index:: segment-routing on
 .. clicmd:: [no] segment-routing on
 
    Enable Segment Routing.
 
-.. index:: segment-routing global-block (0-1048575) (0-1048575)
 .. clicmd:: [no] segment-routing global-block (0-1048575) (0-1048575)
 
    Set the Segment Routing Global Block i.e. the label range used by MPLS
    to store label in the MPLS FIB for Prefix SID. Note that the block size
    may not exceed 65535.
 
-.. index:: segment-routing local-block (0-1048575) (0-1048575)
 .. clicmd:: [no] segment-routing local-block (0-1048575) (0-1048575)
 
    Set the Segment Routing Local Block i.e. the label range used by MPLS
    to store label in the MPLS FIB for Adjacency SID. Note that the block size
    may not exceed 65535.
 
-.. index:: segment-routing node-msd (1-16)
 .. clicmd:: [no] segment-routing node-msd (1-16)
 
    Set the Maximum Stack Depth supported by the router. The value depend of the
    MPLS dataplane. E.g. for Linux kernel, since version 4.13 the maximum value
    is 32.
 
-.. index:: segment-routing prefix <A.B.C.D/M|X:X::X:X/M> <absolute (16-1048575)|index (0-65535)> [no-php-flag|explicit-null] [n-flag-clear]
 .. clicmd:: [no] segment-routing prefix <A.B.C.D/M|X:X::X:X/M> <absolute (16-1048575)|index (0-65535) [no-php-flag|explicit-null] [n-flag-clear]
 
-   Set the Segment Routing index or absolute label value for the specified
    prefix. The 'no-php-flag' means NO Penultimate Hop Popping that allows SR
    node to request to its neighbor to not pop the label. The 'explicit-null'
    flag allows SR node to request to its neighbor to send IP packet with the
@@ -603,12 +488,10 @@ Known limitations:
    clear the Node flag that is set by default for Prefix-SIDs associated to
    loopback addresses. This option is necessary to configure Anycast-SIDs.
 
-.. index:: show isis segment-routing prefix-sids
 .. clicmd:: show isis segment-routing prefix-sids
 
    Show detailed information about all learned Segment Routing Prefix-SIDs.
 
-.. index:: show isis segment-routing nodes
 .. clicmd:: show isis segment-routing nodes
 
    Show detailed information about all learned Segment Routing Nodes.
@@ -616,116 +499,87 @@ Known limitations:
 Debugging ISIS
 ==============
 
-.. index:: debug isis adj-packets
 .. clicmd:: debug isis adj-packets
 
-.. index:: debug isis adj-packets
 .. clicmd:: no debug isis adj-packets
 
    IS-IS Adjacency related packets.
 
-.. index:: debug isis checksum-errors
 .. clicmd:: debug isis checksum-errors
 
-.. index:: debug isis checksum-errors
 .. clicmd:: no debug isis checksum-errors
 
    IS-IS LSP checksum errors.
 
-.. index:: debug isis events
 .. clicmd:: debug isis events
 
-.. index:: debug isis events
 .. clicmd:: no debug isis events
 
    IS-IS Events.
 
-.. index:: debug isis local-updates
 .. clicmd:: debug isis local-updates
 
-.. index:: debug isis local-updates
 .. clicmd:: no debug isis local-updates
 
    IS-IS local update packets.
 
-.. index:: debug isis packet-dump
 .. clicmd:: debug isis packet-dump
 
-.. index:: debug isis packet-dump
 .. clicmd:: no debug isis packet-dump
 
    IS-IS packet dump.
 
-.. index:: debug isis protocol-errors
 .. clicmd:: debug isis protocol-errors
 
-.. index:: debug isis protocol-errors
 .. clicmd:: no debug isis protocol-errors
 
    IS-IS LSP protocol errors.
 
-.. index:: debug isis route-events
 .. clicmd:: debug isis route-events
 
-.. index:: debug isis route-events
 .. clicmd:: no debug isis route-events
 
    IS-IS Route related events.
 
-.. index:: debug isis snp-packets
 .. clicmd:: debug isis snp-packets
 
-.. index:: debug isis snp-packets
 .. clicmd:: no debug isis snp-packets
 
    IS-IS CSNP/PSNP packets.
 
-.. index:: debug isis spf-events
 .. clicmd:: debug isis spf-events
 
-.. index:: debug isis spf-statistics
 .. clicmd:: debug isis spf-statistics
 
-.. index:: debug isis spf-triggers
 .. clicmd:: debug isis spf-triggers
 
-.. index:: debug isis spf-events
 .. clicmd:: no debug isis spf-events
 
-.. index:: debug isis spf-statistics
 .. clicmd:: no debug isis spf-statistics
 
-.. index:: debug isis spf-triggers
 .. clicmd:: no debug isis spf-triggers
 
    IS-IS Shortest Path First Events, Timing and Statistic Data and triggering
    events.
 
-.. index:: debug isis update-packets
 .. clicmd:: debug isis update-packets
 
-.. index:: debug isis update-packets
 .. clicmd:: no debug isis update-packets
 
    Update related packets.
 
-.. index:: debug isis sr-events
 .. clicmd:: debug isis sr-events
 
-.. index:: debug isis sr-events
 .. clicmd:: no debug isis sr-events
 
    IS-IS Segment Routing events.
 
-.. index:: debug isis lfa
 .. clicmd:: debug isis lfa
 
-.. index:: debug isis lfa
 .. clicmd:: no debug isis lfa
 
    IS-IS LFA events.
 
-.. index:: show debugging isis
 .. clicmd:: show debugging isis
 
    Print which ISIS debug level is activate.
@@ -839,8 +693,6 @@ A Segment Routing configuration, with IPv4, IPv6, SRGB and MSD configuration.
     lsp-gen-interval 2
     segment-routing on
     segment-routing node-msd 8
-    segment-routing prefix 10.1.1.1/32 index 100 explicit-null
-    segment-routing prefix 2001:db8:1000::1/128 index 101 explicit-null
    !
 
 ISIS Vrf Configuration Examples

--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -129,6 +129,11 @@ ISIS Fast-Reroute
 
    Limit LFA backup computation up to the specified prefix priority.
 
+.. clicmd:: fast-reroute lfa tiebreaker [downstream | lowest-backup-metric | node-protecting] index (1-255) [level-1 | level-2]
+
+   Configure a tie-breaker for multiple LFA backups. Lower indexes are
+   processed first.
+
 .. clicmd:: fast-reroute load-sharing disable [level-1 | level-2]
 
    Disable load sharing across multiple LFA backups.
@@ -560,6 +565,8 @@ A Segment Routing configuration, with IPv4, IPv6, SRGB and MSD configuration.
     lsp-gen-interval 2
     segment-routing on
     segment-routing node-msd 8
+    segment-routing prefix 10.1.1.1/32 index 100 explicit-null
+    segment-routing prefix 2001:db8:1000::1/128 index 101 explicit-null
    !
 
 

--- a/doc/user/ldpd.rst
+++ b/doc/user/ldpd.rst
@@ -97,29 +97,24 @@ implementation.
 LDP Configuration
 ===================
 
-.. index:: mpls ldp
 .. clicmd:: [no] mpls ldp
 
    Enable or disable LDP daemon
 
-.. index:: router-id A.B.C.D
 .. clicmd:: [no] router-id A.B.C.D
 
    The following command located under MPLS router node configures the MPLS
    router-id of the local device.
 
-.. index:: ordered-control
 .. clicmd:: [no] ordered-control
 
    Configure LDP Ordered Label Distribution Control.
 
-.. index:: address-family [ipv4 | ipv6]
 .. clicmd:: [no] address-family [ipv4 | ipv6]
 
    Configure LDP for IPv4 or IPv6 address-family. Located under MPLS route node,
    this subnode permits configuring the LDP neighbors.
 
-.. index:: interface IFACE
 .. clicmd:: [no] interface IFACE
 
    Located under MPLS address-family node, use this command to enable or disable
@@ -127,14 +122,12 @@ LDP Configuration
    enabled. By default it is disabled. Once this command executed, the
    address-family interface node is configured.
 
-.. index:: discovery transport-address A.B.C.D | A:B::C:D
 .. clicmd:: [no] discovery transport-address A.B.C.D | A:B::C:D
 
    Located under mpls address-family interface node, use this command to set
    the IPv4 or IPv6 transport-address used by the LDP protocol to talk on this
    interface.
 
-.. index:: neighbor A.B.C.D password PASSWORD
 .. clicmd:: [no] neighbor A.B.C.D password PASSWORD
 
    The following command located under MPLS router node configures the router
@@ -142,7 +135,6 @@ LDP Configuration
    configured password. PASSWORD is a clear text password wit its digest sent
    through the network.
 
-.. index:: neighbor A.B.C.D holdtime HOLDTIME
 .. clicmd:: [no] neighbor A.B.C.D holdtime HOLDTIME
 
    The following command located under MPLS router node configures the holdtime
@@ -151,10 +143,8 @@ LDP Configuration
    this time of non response, the LDP established session will be considered as
    set to down. By default, no holdtime is configured for the LDP devices.
 
-.. index:: discovery hello holdtime HOLDTIME
 .. clicmd:: [no] discovery hello holdtime HOLDTIME
 
-.. index:: discovery hello interval INTERVAL
 .. clicmd:: [no] discovery hello interval INTERVAL
 
    INTERVAL value ranges from 1 to 65535 seconds. Default value is 5 seconds.
@@ -162,7 +152,6 @@ LDP Configuration
    HOLDTIME value ranges from 1 to 65535 seconds. Default value is 15 seconds.
    That value is added as a TLV in the LDP messages.
 
-.. index:: dual-stack transport-connection prefer ipv4
 .. clicmd:: [no] dual-stack transport-connection prefer ipv4
 
    When *ldpd* is configured for dual-stack operation, the transport connection
@@ -179,7 +168,6 @@ Show LDP Information
 
 These commands dump various parts of *ldpd*.
 
-.. index:: show mpls ldp neighbor [A.B.C.D]
 .. clicmd:: show mpls ldp neighbor [A.B.C.D]
 
    This command dumps the various neighbors discovered. Below example shows that
@@ -192,29 +180,22 @@ These commands dump various parts of *ldpd*.
       ipv4 1.1.1.1         OPERATIONAL 1.1.1.1         00:01:37
       west-vm#
 
-.. index:: show mpls ldp neighbor [A.B.C.D] capabilities
 .. clicmd:: show mpls ldp neighbor [A.B.C.D] capabilities
 
-.. index:: show mpls ldp neighbor [A.B.C.D] detail
 .. clicmd:: show mpls ldp neighbor [A.B.C.D] detail
 
    Above commands dump other neighbor information.
 
-.. index:: show mpls ldp discovery [detail]
 .. clicmd:: show mpls ldp discovery [detail]
 
-.. index:: show mpls ldp ipv4 discovery [detail]
 .. clicmd:: show mpls ldp ipv4 discovery [detail]
 
-.. index:: show mpls ldp ipv6 discovery [detail]
 .. clicmd:: show mpls ldp ipv6 discovery [detail]
 
    Above commands dump discovery information.
 
-.. index:: show mpls ldp ipv4 interface
 .. clicmd:: show mpls ldp ipv4 interface
 
-.. index:: show mpls ldp ipv6 interface
 .. clicmd:: show mpls ldp ipv6 interface
 
    Above command dumps the IPv4 or IPv6 interface per where LDP is enabled.
@@ -228,7 +209,6 @@ These commands dump various parts of *ldpd*.
       ipv4 eth3       ACTIVE 00:08:35 5/15           1
 
 
-.. index:: show mpls ldp ipv4|ipv6 binding
 .. clicmd:: show mpls ldp ipv4|ipv6 binding
 
    Above command dumps the binding obtained through MPLS exchanges with LDP.
@@ -245,12 +225,10 @@ These commands dump various parts of *ldpd*.
       ipv4 10.200.0.0/24        1.1.1.1         17          imp-null         yes
       west-vm#
 
+
 LDP debugging commands
 ========================
 
-.. index::
-   simple: debug mpls ldp KIND
-   simple: no debug mpls ldp KIND
 
 .. clicmd:: [no] debug mpls ldp KIND
 

--- a/doc/user/ldpd.rst
+++ b/doc/user/ldpd.rst
@@ -97,45 +97,45 @@ implementation.
 LDP Configuration
 ===================
 
-.. clicmd:: [no] mpls ldp
+.. clicmd:: mpls ldp
 
    Enable or disable LDP daemon
 
-.. clicmd:: [no] router-id A.B.C.D
+.. clicmd:: router-id A.B.C.D
 
    The following command located under MPLS router node configures the MPLS
    router-id of the local device.
 
-.. clicmd:: [no] ordered-control
+.. clicmd:: ordered-control
 
    Configure LDP Ordered Label Distribution Control.
 
-.. clicmd:: [no] address-family [ipv4 | ipv6]
+.. clicmd:: address-family [ipv4 | ipv6]
 
    Configure LDP for IPv4 or IPv6 address-family. Located under MPLS route node,
    this subnode permits configuring the LDP neighbors.
 
-.. clicmd:: [no] interface IFACE
+.. clicmd:: interface IFACE
 
    Located under MPLS address-family node, use this command to enable or disable
    LDP discovery per interface. IFACE stands for the interface name where LDP is
    enabled. By default it is disabled. Once this command executed, the
    address-family interface node is configured.
 
-.. clicmd:: [no] discovery transport-address A.B.C.D | A:B::C:D
+.. clicmd:: discovery transport-address A.B.C.D | A:B::C:D
 
    Located under mpls address-family interface node, use this command to set
    the IPv4 or IPv6 transport-address used by the LDP protocol to talk on this
    interface.
 
-.. clicmd:: [no] neighbor A.B.C.D password PASSWORD
+.. clicmd:: neighbor A.B.C.D password PASSWORD
 
    The following command located under MPLS router node configures the router
    of a LDP device. This device, if found, will have to comply with the
    configured password. PASSWORD is a clear text password wit its digest sent
    through the network.
 
-.. clicmd:: [no] neighbor A.B.C.D holdtime HOLDTIME
+.. clicmd:: neighbor A.B.C.D holdtime HOLDTIME
 
    The following command located under MPLS router node configures the holdtime
    value in seconds of the LDP neighbor ID. Configuring it triggers a keepalive
@@ -143,16 +143,16 @@ LDP Configuration
    this time of non response, the LDP established session will be considered as
    set to down. By default, no holdtime is configured for the LDP devices.
 
-.. clicmd:: [no] discovery hello holdtime HOLDTIME
+.. clicmd:: discovery hello holdtime HOLDTIME
 
-.. clicmd:: [no] discovery hello interval INTERVAL
+.. clicmd:: discovery hello interval INTERVAL
 
    INTERVAL value ranges from 1 to 65535 seconds. Default value is 5 seconds.
    This is the value between each hello timer message sent.
    HOLDTIME value ranges from 1 to 65535 seconds. Default value is 15 seconds.
    That value is added as a TLV in the LDP messages.
 
-.. clicmd:: [no] dual-stack transport-connection prefer ipv4
+.. clicmd:: dual-stack transport-connection prefer ipv4
 
    When *ldpd* is configured for dual-stack operation, the transport connection
    preference is IPv6 by default (as specified by :rfc:`7552`). On such
@@ -230,7 +230,7 @@ LDP debugging commands
 ========================
 
 
-.. clicmd:: [no] debug mpls ldp KIND
+.. clicmd:: debug mpls ldp KIND
 
    Enable or disable debugging messages of a given kind. ``KIND`` can
    be one of:

--- a/doc/user/nhrpd.rst
+++ b/doc/user/nhrpd.rst
@@ -77,7 +77,6 @@ command defines the GRE subnet):
 Configuring NHRP
 ================
 
-.. index::  ip nhrp holdtime (1-65000)
 .. clicmd:: ip nhrp holdtime (1-65000)
 
    Holdtime is the number of seconds that have to pass before stopping to
@@ -85,12 +84,10 @@ Configuring NHRP
    registration requests are sent. By default registrations are sent every one
    third of the holdtime.
 
-.. index::  ip nhrp map A.B.C.D|X:X::X:X A.B.C.D|local
 .. clicmd:: ip nhrp map A.B.C.D|X:X::X:X A.B.C.D|local
 
    Map an IP address of a station to the station's NBMA address.
 
-.. index::  ip nhrp network-id (1-4294967295)
 .. clicmd:: ip nhrp network-id (1-4294967295)
 
    Enable NHRP on this interface and set the interface's network ID.  The
@@ -101,30 +98,25 @@ Configuring NHRP
    different nodes do not need to match. When NHRP packets are received on an
    interface they are assigned to the local NHRP domain for that interface.
 
-.. index::  ip nhrp nhs A.B.C.D nbma A.B.C.D|FQDN
 .. clicmd:: ip nhrp nhs A.B.C.D nbma A.B.C.D|FQDN
 
    Configure the Next Hop Server address and its NBMA address.
 
-.. index::  ip nhrp nhs dynamic nbma A.B.C.D
 .. clicmd:: ip nhrp nhs dynamic nbma A.B.C.D
 
    Configure the Next Hop Server to have a dynamic address and set its NBMA
    address.
 
-.. index::  ip nhrp registration no-unique
 .. clicmd:: ip nhrp registration no-unique
 
    Allow the client to not set the unique flag in the NHRP packets. This is
    useful when a station has a dynamic IP address that could change over time.
 
-.. index::  ip nhrp shortcut
 .. clicmd:: ip nhrp shortcut
 
    Enable shortcut (spoke-to-spoke) tunnels to allow NHC to talk to each others
    directly after establishing a connection without going through the hub.
 
-.. index::  ip nhrp mtu
 .. clicmd:: ip nhrp mtu
 
    Configure NHRP advertised MTU.
@@ -159,13 +151,11 @@ However, the above should be good in most cases.
 This kernel NFLOG target's nflog-group is configured in global nhrp config
 with:
 
-.. index::  nhrp nflog-group (1-65535)
 .. clicmd:: nhrp nflog-group (1-65535)
 
 To start sending these traffic notices out from hubs, use the nhrp
 per-interface directive:
 
-.. index::  ip nhrp redirect
 .. clicmd:: ip nhrp redirect
 
 This enable redirect replies on the NHS similar to ICMP redirects except this
@@ -195,7 +185,6 @@ https://gitlab.alpinelinux.org/alpine/aports/-/tree/master/main/strongswan
 NHRP Events
 ===========
 
-.. index::  nhrp event socket SOCKET
 .. clicmd:: nhrp event socket SOCKET
 
    Configure the Unix path for the event socket.
@@ -205,22 +194,18 @@ NHRP Events
 Show  NHRP
 ==========
 
-.. index::  show [ip|ipv6] nhrp cache [json]
 .. clicmd:: show [ip|ipv6] nhrp cache [json]
 
    Dump the cache entries.
 
-.. index::  show [ip|ipv6] nhrp opennhrp [json]
 .. clicmd:: show [ip|ipv6] nhrp opennhrp [json]
 
    Dump the cache entries with opennhrp format.
 
-.. index::  show [ip|ipv6] nhrp nhs [json]
 .. clicmd:: show [ip|ipv6] nhrp nhs [json]
 
    Dump the hub context.
 
-.. index::  show dmvpn [json]
 .. clicmd:: show dmvpn [json]
 
    Dump the security contexts.

--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -12,24 +12,19 @@ described in :rfc:`2740`.
 OSPF6 router
 ============
 
-.. index:: router ospf6
 .. clicmd:: router ospf6
 
-.. index:: ospf6 router-id A.B.C.D
 .. clicmd:: ospf6 router-id A.B.C.D
 
    Set router's Router-ID.
 
-.. index:: interface IFNAME area (0-4294967295)
 .. clicmd:: interface IFNAME area (0-4294967295)
 
-.. index:: interface IFNAME area A.B.C.D
 .. clicmd:: interface IFNAME area A.B.C.D
 
    Bind interface to specified area, and start sending OSPF packets. `area` can
    be specified as 0.
 
-.. index:: timers throttle spf (0-600000) (0-600000) (0-600000)
 .. clicmd:: timers throttle spf (0-600000) (0-600000) (0-600000)
 
    This command sets the initial `delay`, the `initial-holdtime`
@@ -65,10 +60,8 @@ OSPF6 router
    time an SPF-triggering event occurs within the hold-time of the previous
    SPF calculation.
 
-.. index:: auto-cost reference-bandwidth COST
 .. clicmd:: auto-cost reference-bandwidth COST
 
-.. index:: auto-cost reference-bandwidth
 .. clicmd:: no auto-cost reference-bandwidth
 
    This sets the reference bandwidth for cost calculations, where this
@@ -80,7 +73,6 @@ OSPF6 router
    This configuration setting MUST be consistent across all routers
    within the OSPF domain.
 
-.. index:: maximum-paths (1-64)
 .. clicmd::[no] maximum-paths (1-64)
 
    Use this command to control the maximum number of parallel routes that
@@ -98,38 +90,31 @@ Area support for OSPFv3 is not yet implemented.
 OSPF6 interface
 ===============
 
-.. index:: ipv6 ospf6 cost COST
 .. clicmd:: ipv6 ospf6 cost COST
 
    Sets interface's output cost. Default value depends on the interface
    bandwidth and on the auto-cost reference bandwidth.
 
-.. index:: ipv6 ospf6 hello-interval HELLOINTERVAL
 .. clicmd:: ipv6 ospf6 hello-interval HELLOINTERVAL
 
    Sets interface's Hello Interval. Default 10
 
-.. index:: ipv6 ospf6 dead-interval DEADINTERVAL
 .. clicmd:: ipv6 ospf6 dead-interval DEADINTERVAL
 
    Sets interface's Router Dead Interval. Default value is 40.
 
-.. index:: ipv6 ospf6 retransmit-interval RETRANSMITINTERVAL
 .. clicmd:: ipv6 ospf6 retransmit-interval RETRANSMITINTERVAL
 
    Sets interface's Rxmt Interval. Default value is 5.
 
-.. index:: ipv6 ospf6 priority PRIORITY
 .. clicmd:: ipv6 ospf6 priority PRIORITY
 
    Sets interface's Router Priority. Default value is 1.
 
-.. index:: ipv6 ospf6 transmit-delay TRANSMITDELAY
 .. clicmd:: ipv6 ospf6 transmit-delay TRANSMITDELAY
 
    Sets interface's Inf-Trans-Delay. Default value is 1.
 
-.. index:: ipv6 ospf6 network (broadcast|point-to-point)
 .. clicmd:: ipv6 ospf6 network (broadcast|point-to-point)
 
    Set explicitly network type for specified interface.
@@ -139,7 +124,6 @@ OSPF6 route-map
 
 Usage of *ospfd6*'s route-map support.
 
-.. index:: set metric [+|-](0-4294967295)
 .. clicmd:: set metric [+|-](0-4294967295)
 
    Set a metric for matched route when sending announcement. Use plus (+) sign
@@ -151,7 +135,6 @@ Usage of *ospfd6*'s route-map support.
 Redistribute routes to OSPF6
 ============================
 
-.. index:: redistribute <babel|bgp|connected|isis|kernel|openfabric|ripng|sharp|static|table> [route-map WORD]
 .. clicmd:: redistribute <babel|bgp|connected|isis|kernel|openfabric|ripng|sharp|static|table> [route-map WORD]
 
    Redistribute routes from other protocols into OSPFv3.
@@ -162,14 +145,12 @@ Redistribute routes to OSPF6
 Showing OSPF6 information
 =========================
 
-.. index:: show ipv6 ospf6 [INSTANCE_ID] [json]
 .. clicmd:: show ipv6 ospf6 [INSTANCE_ID] [json]
 
    INSTANCE_ID is an optional OSPF instance ID. To see router ID and OSPF
    instance ID, simply type "show ipv6 ospf6 <cr>". JSON output can be
    obtained by appending 'json' to the end of command.
 
-.. index:: show ipv6 ospf6 database [<detail|dump|internal>] [json]
 .. clicmd:: show ipv6 ospf6 database [<detail|dump|internal>] [json]
 
    This command shows LSAs present in the LSDB. There are three view options.
@@ -177,14 +158,12 @@ Showing OSPF6 information
    can be obtained by appending 'json' to the end of command. JSON option is
    not applicable with 'dump' option.
 
-.. index:: show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> [json]
 .. clicmd:: show ipv6 ospf6 database <router|network|inter-prefix|inter-router|as-external|group-membership|type-7|link|intra-prefix> [json]
 
    These options filters out the LSA based on its type. The three views options
    works here as well. JSON output can be obtained by appending 'json' to the
    end of command.
 
-.. index:: show ipv6 ospf6 database adv-router A.B.C.D linkstate-id A.B.C.D [json]
 .. clicmd:: show ipv6 ospf6 database adv-router A.B.C.D linkstate-id A.B.C.D [json]
 
    The LSAs additinally can also be filtered with the linkstate-id and
@@ -192,54 +171,45 @@ Showing OSPF6 information
    this command as well and visa-versa. JSON output can be obtained by
    appending 'json' to the end of command.
 
-.. index:: show ipv6 ospf6 database self-originated [json]
 .. clicmd:: show ipv6 ospf6 database self-originated [json]
 
    This command is used to filter the LSAs which are originated by the present
    router. All the other filters are applicable here as well.
 
-.. index:: show ipv6 ospf6 interface [json]
 .. clicmd:: show ipv6 ospf6 interface [json]
 
    To see OSPF interface configuration like costs. JSON output can be
    obtained by appending "json" in the end.
 
-.. index:: show ipv6 ospf6 neighbor [json]
 .. clicmd:: show ipv6 ospf6 neighbor [json]
 
    Shows state and chosen (Backup) DR of neighbor. JSON output can be
    obtained by appending 'json' at the end.
 
-.. index:: show ipv6 ospf6 interface traffic [json]
 .. clicmd:: show ipv6 ospf6 interface traffic [json]
 
    Shows counts of different packets that have been recieved and transmitted
    by the interfaces. JSON output can be obtained by appending "json" at the
    end.
 
-.. index:: show ipv6 ospf6 request-list A.B.C.D
 .. clicmd:: show ipv6 ospf6 request-list A.B.C.D
 
    Shows requestlist of neighbor.
 
-.. index:: show ipv6 route ospf6
 .. clicmd:: show ipv6 route ospf6
 
    This command shows internal routing table.
 
-.. index:: show ipv6 ospf6 zebra [json]
 .. clicmd:: show ipv6 ospf6 zebra [json]
 
    Shows state about what is being redistributed between zebra and OSPF6.
    JSON output can be obtained by appending "json" at the end.
 
-.. index:: show ipv6 ospf6 redistribute [json]
 .. clicmd:: show ipv6 ospf6 redistribute [json]
 
    Shows the routes which are redistributed by the router. JSON output can
    be obtained by appending 'json' at the end.
 
-.. index:: show ipv6 ospf6 route [<intra-area|inter-area|external-1|external-2|X:X::X:X|X:X::X:X/M|detail|summary>] [json]
 .. clicmd:: show ipv6 ospf6 route [<intra-area|inter-area|external-1|external-2|X:X::X:X|X:X::X:X/M|detail|summary>] [json]
 
    This command displays the ospfv3 routing table as determined by the most
@@ -248,13 +218,11 @@ Showing OSPF6 information
    and summary. JSON output can be obtained by appending 'json' to the end of
    command.
 
-.. index:: show ipv6 ospf6 route X:X::X:X/M match [detail] [json]
 .. clicmd:: show ipv6 ospf6 route X:X::X:X/M match [detail] [json]
 
    The additional match option will match the given address to the destination
    of the routes, and return the result accordingly.
 
-.. index:: show ipv6 ospf6 interface [IFNAME] prefix [detail|<X:X::X:X|X:X::X:X/M> [<match|detail>]] [json]
 .. clicmd:: show ipv6 ospf6 interface [IFNAME] prefix [detail|<X:X::X:X|X:X::X:X/M> [<match|detail>]] [json]
 
    This command shows the prefixes present in the interface routing table.

--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -29,11 +29,8 @@ OSPF6 router
    Bind interface to specified area, and start sending OSPF packets. `area` can
    be specified as 0.
 
-.. index:: timers throttle spf DELAY INITIAL-HOLDTIME MAX-HOLDTIME
-.. clicmd:: timers throttle spf DELAY INITIAL-HOLDTIME MAX-HOLDTIME
-
-.. index:: timers throttle spf
-.. clicmd:: no timers throttle spf
+.. index:: timers throttle spf (0-600000) (0-600000) (0-600000)
+.. clicmd:: timers throttle spf (0-600000) (0-600000) (0-600000)
 
    This command sets the initial `delay`, the `initial-holdtime`
    and the `maximum-holdtime` between when SPF is calculated and the
@@ -154,14 +151,10 @@ Usage of *ospfd6*'s route-map support.
 Redistribute routes to OSPF6
 ============================
 
-.. index:: redistribute static
-.. clicmd:: redistribute static
+.. index:: redistribute <babel|bgp|connected|isis|kernel|openfabric|ripng|sharp|static|table> [route-map WORD]
+.. clicmd:: redistribute <babel|bgp|connected|isis|kernel|openfabric|ripng|sharp|static|table> [route-map WORD]
 
-.. index:: redistribute connected
-.. clicmd:: redistribute connected
-
-.. index:: redistribute ripng
-.. clicmd:: redistribute ripng
+   Redistribute routes from other protocols into OSPFv3.
 
 
 .. _showing-ospf6-information:

--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -72,10 +72,11 @@ OSPF6 router
    This configuration setting MUST be consistent across all routers
    within the OSPF domain.
 
-.. clicmd::[no] maximum-paths (1-64)
+.. clicmd:: maximum-paths (1-64)
 
    Use this command to control the maximum number of parallel routes that
    OSPFv3 can support. The default is 64.
+
 
 .. _ospf6-area:
 

--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -62,7 +62,6 @@ OSPF6 router
 
 .. clicmd:: auto-cost reference-bandwidth COST
 
-.. clicmd:: no auto-cost reference-bandwidth
 
    This sets the reference bandwidth for cost calculations, where this
    bandwidth is considered equivalent to an OSPF cost of 1, specified in

--- a/doc/user/ospf_fundamentals.rst
+++ b/doc/user/ospf_fundamentals.rst
@@ -271,6 +271,7 @@ called `intra-area routes`.
     | Transit        | Link IP address of the :abbr:`DR` | Interface IP address                     |
     +----------------+-----------------------------------+------------------------------------------+
     | Point-to-Point | Router ID of the remote router    | Local interface IP address, or the       |
+    |                |                                   | :abbr:`ifindex (MIB-II interface index)` |
     |                |                                   | for unnumbered links                     |
     +----------------+-----------------------------------+------------------------------------------+
     | Stub           | IP address                        | Subnet Mask                              |

--- a/doc/user/ospf_fundamentals.rst
+++ b/doc/user/ospf_fundamentals.rst
@@ -3,8 +3,10 @@
 OSPF Fundamentals
 =================
 
-.. index:: Link-state routing protocol
-.. index:: Distance-vector routing protocol
+.. index::
+   pair: Link-state routing protocol; OSPF
+   pair: Distance-vector routing protocol; OSPF
+
 
 :abbr:`OSPF` is, mostly, a link-state routing protocol. In contrast to
 :term:`distance-vector` protocols, such as :abbr:`RIP` or :abbr:`BGP`, where
@@ -12,10 +14,12 @@ routers describe available `paths` (i.e. routes) to each other, in
 :term:`link-state` protocols routers instead describe the state of their links
 to their immediate neighbouring routers.
 
-.. index:: Link State Announcement
-.. index:: Link State Advertisement
-.. index:: LSA flooding
-.. index:: Link State Database
+.. index::
+   single: Link State Announcement
+   single: Link State Advertisement
+   single: LSA flooding
+   single: Link State Database
+
 
 Each router describes their link-state information in a message known as an
 :abbr:`LSA (Link State Advertisement)`, which is then propagated through to all
@@ -27,7 +31,8 @@ metric, by using an algorithm such as
 `Edsger Dijkstra's <http://www.cs.utexas.edu/users/EWD/>`_
 :abbr:`SPF (Shortest Path First)` algorithm.
 
-.. index:: Link-state routing protocol advantages
+.. index::
+   pair: Link-state routing protocol; advantages
 
 By describing connectivity of a network in this way, in terms of
 routers and links rather than in terms of the paths through a network,
@@ -39,7 +44,8 @@ reconverge on the best paths through the network. In contrast, distance
 vector protocols can require a progression of different path update
 messages from a series of different routers in order to converge.
 
-.. index:: Link-state routing protocol disadvantages
+.. index::
+   pair: Link-state routing protocol; disadvantages
 
 The disadvantage to a link-state protocol is that the process of
 computing the best paths can be relatively intensive when compared to
@@ -64,7 +70,8 @@ will nearly all be covered in greater detail further on. They may be
 broadly classed as:
 
 
-.. index:: OSPF Hello Protocol
+.. index::
+   pair: Hello protocol; OSPF
 
 The Hello Protocol
 ^^^^^^^^^^^^^^^^^^
@@ -86,7 +93,10 @@ sharing a link, for example:
 The Hello protocol is comparatively trivial and will not be explored in more
 detail.
 
-.. index:: OSPF LSA overview
+
+.. index::
+   pair: LSA; OSPF
+
 .. _ospf-lsas:
 
 LSAs
@@ -120,7 +130,9 @@ OSPF defines several related mechanisms, used to manage synchronisation of
 :abbr:`LSDB` s between neighbours as neighbours form adjacencies and the
 propagation, or `flooding` of new or updated :abbr:`LSA` s.
 
-.. index:: OSPF Areas overview
+
+.. index::
+   pair: Area; OSPF
 
 .. _ospf-areas:
 
@@ -259,7 +271,6 @@ called `intra-area routes`.
     | Transit        | Link IP address of the :abbr:`DR` | Interface IP address                     |
     +----------------+-----------------------------------+------------------------------------------+
     | Point-to-Point | Router ID of the remote router    | Local interface IP address, or the       |
-    |                |                                   | :abbr:`ifindex (MIB-II interface index)` |
     |                |                                   | for unnumbered links                     |
     +----------------+-----------------------------------+------------------------------------------+
     | Stub           | IP address                        | Subnet Mask                              |

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -82,13 +82,11 @@ To start OSPF process you have to specify the OSPF router.
 
 .. clicmd:: router ospf [(1-65535)] vrf NAME
 
-.. clicmd:: no router ospf [(1-65535)] vrf NAME
 
    Enable or disable the OSPF process.
 
 .. clicmd:: ospf router-id A.B.C.D
 
-.. clicmd:: no ospf router-id [A.B.C.D]
 
    This sets the router-ID of the OSPF process. The router-ID may be an IP
    address of the router, but need not be - it can be any arbitrary 32bit
@@ -99,7 +97,6 @@ To start OSPF process you have to specify the OSPF router.
 
 .. clicmd:: ospf abr-type TYPE
 
-.. clicmd:: no ospf abr-type TYPE
 
    `type` can be cisco|ibm|shortcut|standard. The "Cisco" and "IBM" types
    are equivalent.
@@ -133,7 +130,6 @@ To start OSPF process you have to specify the OSPF router.
 
 .. clicmd:: ospf rfc1583compatibility
 
-.. clicmd:: no ospf rfc1583compatibility
 
    :rfc:`2328`, the successor to :rfc:`1583`, suggests according
    to section G.2 (changes) in section 16.4 a change to the path
@@ -146,7 +142,6 @@ To start OSPF process you have to specify the OSPF router.
 
 .. clicmd:: log-adjacency-changes [detail]
 
-.. clicmd:: no log-adjacency-changes [detail]
 
    Configures ospfd to log changes in adjacency. With the optional
    detail argument, all changes in adjacency status are shown. Without detail,
@@ -154,7 +149,6 @@ To start OSPF process you have to specify the OSPF router.
 
 .. clicmd:: passive-interface INTERFACE
 
-.. clicmd:: no passive-interface INTERFACE
 
    Do not speak OSPF interface on the
    given interface, but do advertise the interface as a stub link in the
@@ -209,7 +203,6 @@ To start OSPF process you have to specify the OSPF router.
 
 .. clicmd:: max-metric router-lsa administrative
 
-.. clicmd:: no max-metric router-lsa [on-startup|on-shutdown|administrative]
 
    This enables :rfc:`3137` support, where the OSPF process describes its
    transit links in its router-LSA as having infinite distance so that other
@@ -240,7 +233,6 @@ To start OSPF process you have to specify the OSPF router.
 
 .. clicmd:: auto-cost reference-bandwidth (1-4294967)
 
-.. clicmd:: no auto-cost reference-bandwidth
 
    This sets the reference
    bandwidth for cost calculations, where this bandwidth is considered
@@ -256,9 +248,7 @@ To start OSPF process you have to specify the OSPF router.
 
 .. clicmd:: network A.B.C.D/M area (0-4294967295)
 
-.. clicmd:: no network A.B.C.D/M area A.B.C.D
 
-.. clicmd:: no network A.B.C.D/M area (0-4294967295)
 
    This command specifies the OSPF enabled interface(s). If the interface has
    an address from range 192.168.1.0/24 then the command below enables ospf
@@ -287,7 +277,6 @@ To start OSPF process you have to specify the OSPF router.
 
 .. clicmd:: proactive-arp
 
-.. clicmd:: no proactive-arp
 
    This command enables or disables sending ARP requests to update neighbor
    table entries. It speeds up convergence for /32 networks on a P2P
@@ -319,9 +308,7 @@ Areas
 
 .. clicmd:: area (0-4294967295) range A.B.C.D/M
 
-.. clicmd:: no area A.B.C.D range A.B.C.D/M
 
-.. clicmd:: no area (0-4294967295) range A.B.C.D/M
 
    Summarize intra area paths from specified area into one Type-3 summary-LSA
    announced to other areas. This command can be used only in ABR and ONLY
@@ -343,7 +330,6 @@ Areas
 
 .. clicmd:: area A.B.C.D range IPV4_PREFIX not-advertise
 
-.. clicmd:: no area A.B.C.D range IPV4_PREFIX not-advertise
 
    Instead of summarizing intra area paths filter them - i.e. intra area paths from this
    range are not advertised into other areas.
@@ -351,7 +337,6 @@ Areas
 
 .. clicmd:: area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
 
-.. clicmd:: no area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
 
    Substitute summarized prefix with another prefix.
 
@@ -372,17 +357,13 @@ Areas
 
 .. clicmd:: area (0-4294967295) virtual-link A.B.C.D
 
-.. clicmd:: no area A.B.C.D virtual-link A.B.C.D
 
-.. clicmd:: no area (0-4294967295) virtual-link A.B.C.D
 
 .. clicmd:: area A.B.C.D shortcut
 
 .. clicmd:: area (0-4294967295) shortcut
 
-.. clicmd:: no area A.B.C.D shortcut
 
-.. clicmd:: no area (0-4294967295) shortcut
 
    Configure the area as Shortcut capable. See :rfc:`3509`. This requires
    that the 'abr-type' be set to 'shortcut'.
@@ -391,9 +372,7 @@ Areas
 
 .. clicmd:: area (0-4294967295) stub
 
-.. clicmd:: no area A.B.C.D stub
 
-.. clicmd:: no area (0-4294967295) stub
 
    Configure the area to be a stub area. That is, an area where no router
    originates routes external to OSPF and hence an area where all external
@@ -406,16 +385,13 @@ Areas
 
 .. clicmd:: area (0-4294967295) stub no-summary
 
-.. clicmd:: no area A.B.C.D stub no-summary
 
-.. clicmd:: no area (0-4294967295) stub no-summary
 
     Prevents an *ospfd* ABR from injecting inter-area
     summaries into the specified stub area.
 
 .. clicmd:: area A.B.C.D default-cost (0-16777215)
 
-.. clicmd:: no area A.B.C.D default-cost (0-16777215)
 
    Set the cost of default-summary LSAs announced to stubby areas.
 
@@ -423,9 +399,7 @@ Areas
 
 .. clicmd:: area (0-4294967295) export-list NAME
 
-.. clicmd:: no area A.B.C.D export-list NAME
 
-.. clicmd:: no area (0-4294967295) export-list NAME
 
    Filter Type-3 summary-LSAs announced to other areas originated from intra-
    area paths from specified area.
@@ -452,9 +426,7 @@ Areas
 
 .. clicmd:: area (0-4294967295) import-list NAME
 
-.. clicmd:: no area A.B.C.D import-list NAME
 
-.. clicmd:: no area (0-4294967295) import-list NAME
 
    Same as export-list, but it applies to paths announced into specified area
    as Type-3 summary-LSAs.
@@ -467,13 +439,9 @@ Areas
 
 .. clicmd:: area (0-4294967295) filter-list prefix NAME out
 
-.. clicmd:: no area A.B.C.D filter-list prefix NAME in
 
-.. clicmd:: no area A.B.C.D filter-list prefix NAME out
 
-.. clicmd:: no area (0-4294967295) filter-list prefix NAME in
 
-.. clicmd:: no area (0-4294967295) filter-list prefix NAME out
 
    Filtering Type-3 summary-LSAs to/from area using prefix lists. This command
    makes sense in ABR only.
@@ -482,9 +450,7 @@ Areas
 
 .. clicmd:: area (0-4294967295) authentication
 
-.. clicmd:: no area A.B.C.D authentication
 
-.. clicmd:: no area (0-4294967295) authentication
 
    Specify that simple password authentication should be used for the given
    area.
@@ -508,7 +474,6 @@ Interfaces
 
 .. clicmd:: ip ospf area AREA [ADDR]
 
-.. clicmd:: no ip ospf area [ADDR]
 
    Enable OSPF on the interface, optionally restricted to just the IP address
    given by `ADDR`, putting it in the `AREA` area. Per interface area settings
@@ -520,7 +485,6 @@ Interfaces
 
 .. clicmd:: ip ospf authentication-key AUTH_KEY
 
-.. clicmd:: no ip ospf authentication-key
 
    Set OSPF authentication key to a simple password. After setting `AUTH_KEY`,
    all OSPF packets are authenticated. `AUTH_KEY` has length up to 8 chars.
@@ -546,7 +510,6 @@ Interfaces
 
 .. clicmd:: ip ospf message-digest-key KEYID md5 KEY
 
-.. clicmd:: no ip ospf message-digest-key
 
    Set OSPF authentication key to a cryptographic password. The cryptographic
    algorithm is MD5.
@@ -559,7 +522,6 @@ Interfaces
 
 .. clicmd:: ip ospf cost (1-65535)
 
-.. clicmd:: no ip ospf cost
 
    Set link cost for the specified interface. The cost value is set to
    router-LSA's metric field and used for SPF calculation.
@@ -568,7 +530,6 @@ Interfaces
 
 .. clicmd:: ip ospf dead-interval minimal hello-multiplier (2-20)
 
-.. clicmd:: no ip ospf dead-interval
 
    Set number of seconds for RouterDeadInterval timer value used for Wait Timer
    and Inactivity Timer. This value must be the same for all routers attached
@@ -585,7 +546,6 @@ Interfaces
 
 .. clicmd:: ip ospf hello-interval (1-65535)
 
-.. clicmd:: no ip ospf hello-interval
 
    Set number of seconds for HelloInterval timer value. Setting this value,
    Hello packet will be sent every timer value seconds on the specified interface.
@@ -604,13 +564,11 @@ Interfaces
    net.ipv4.conf.<interface name>.rp_filter value to 0.  In order for
    the ospf multicast packets to be delivered by the kernel.
 
-.. clicmd:: no ip ospf network
 
    Set explicitly network type for specified interface.
 
 .. clicmd:: ip ospf priority (0-255)
 
-.. clicmd:: no ip ospf priority
 
    Set RouterPriority integer value. The router with the highest priority will
    be more eligible to become Designated Router. Setting the value to 0, makes
@@ -618,7 +576,6 @@ Interfaces
 
 .. clicmd:: ip ospf retransmit-interval (1-65535)
 
-.. clicmd:: no ip ospf retransmit interval
 
    Set number of seconds for RxmtInterval timer value. This value is used when
    retransmitting Database Description and Link State Request packets. The
@@ -626,14 +583,12 @@ Interfaces
 
 .. clicmd:: ip ospf transmit-delay (1-65535) [A.B.C.D]
 
-.. clicmd:: no ip ospf transmit-delay [(1-65535)] [A.B.C.D]
 
    Set number of seconds for InfTransDelay value. LSAs' age should be
    incremented by this value when transmitting. The default value is 1 second.
 
 .. clicmd:: ip ospf area (A.B.C.D|(0-4294967295))
 
-.. clicmd:: no ip ospf area
 
    Enable ospf on an interface and set associated area.
 
@@ -691,7 +646,6 @@ Redistribution
 
 .. clicmd:: default-information originate always metric (0-16777214) metric-type (1|2) route-map WORD
 
-.. clicmd:: no default-information originate
 
    Originate an AS-External (type-5) LSA describing a default route into all
    external-routing capable areas, of the specified metric and metric type. If
@@ -700,7 +654,6 @@ Redistribution
 
 .. clicmd:: distribute-list NAME out (kernel|connected|static|rip|ospf
 
-.. clicmd:: no distribute-list NAME out (kernel|connected|static|rip|ospf
 
 .. _ospf-distribute-list:
 
@@ -710,15 +663,12 @@ Redistribution
 
 .. clicmd:: default-metric (0-16777214)
 
-.. clicmd:: no default-metric
 
 .. clicmd:: distance (1-255)
 
-.. clicmd:: no distance (1-255)
 
 .. clicmd:: distance ospf (intra-area|inter-area|external) (1-255)
 
-.. clicmd:: no distance ospf
 
 
 Graceful Restart Helper
@@ -726,7 +676,6 @@ Graceful Restart Helper
 
 .. clicmd:: graceful-restart helper-only [A.B.C.D]
 
-.. clicmd:: no graceful-restart helper-only [A.B.C.D]
 
    Configure Graceful Restart (RFC 3623) helper support.
    By default, helper support is disabled for all neighbours.
@@ -737,7 +686,6 @@ Graceful Restart Helper
 
 .. clicmd:: graceful-restart helper strict-lsa-checking
 
-.. clicmd:: no graceful-restart helper strict-lsa-checking
 
    If 'strict-lsa-checking' is configured then the helper will
    abort the Graceful Restart when a LSA change occurs which
@@ -746,13 +694,11 @@ Graceful Restart Helper
 
 .. clicmd:: graceful-restart helper supported-grace-time
 
-.. clicmd:: no graceful-restart helper supported-grace-time
 
    Supports as HELPER for configured grace period.
 
 .. clicmd:: graceful-restart helper planned-only
 
-.. clicmd:: no graceful-restart helper planned-only
 
    It helps to support as HELPER only for planned
    restarts. By default, it supports both planned and
@@ -824,9 +770,7 @@ Opaque LSA
 
 .. clicmd:: capability opaque
 
-.. clicmd:: no ospf opaque-lsa
 
-.. clicmd:: no capability opaque
 
    *ospfd* supports Opaque LSA (:rfc:`2370`) as partial support for
    MPLS Traffic Engineering LSAs. The opaque-lsa capability must be
@@ -863,7 +807,6 @@ Traffic Engineering
 
 .. clicmd:: mpls-te on
 
-.. clicmd:: no mpls-te
 
    Enable Traffic Engineering LSA flooding.
 
@@ -874,7 +817,6 @@ Traffic Engineering
 
 .. clicmd:: mpls-te inter-as area <area-id>|as
 
-.. clicmd:: no mpls-te inter-as
 
    Enable :rfc:`5392` support - Inter-AS TE v2 - to flood Traffic Engineering
    parameters of Inter-AS link.  2 modes are supported: AREA and AS; LSA are
@@ -898,7 +840,6 @@ Router Information
 
 .. clicmd:: router-info [as | area]
 
-.. clicmd:: no router-info
 
    Enable Router Information (:rfc:`4970`) LSA advertisement with AS scope
    (default) or Area scope flooding when area is specified. Old syntax
@@ -908,23 +849,18 @@ Router Information
 
 .. clicmd:: pce address <A.B.C.D>
 
-.. clicmd:: no pce address
 
 .. clicmd:: pce domain as (0-65535)
 
-.. clicmd:: no pce domain as (0-65535)
 
 .. clicmd:: pce neighbor as (0-65535)
 
-.. clicmd:: no pce neighbor as (0-65535)
 
 .. clicmd:: pce flag BITPATTERN
 
-.. clicmd:: no pce flag
 
 .. clicmd:: pce scope BITPATTERN
 
-.. clicmd:: no pce scope
 
    The commands are conform to :rfc:`5088` and allow OSPF router announce Path
    Computation Element (PCE) capabilities through the Router Information (RI)
@@ -950,28 +886,28 @@ Segment Routing
 This is an EXPERIMENTAL support of Segment Routing as per `RFC 8665` for MPLS
 dataplane.
 
-.. clicmd:: [no] segment-routing on
+.. clicmd:: segment-routing on
 
    Enable Segment Routing. Even if this also activate routing information
    support, it is preferable to also activate routing information, and set
    accordingly the Area or AS flooding.
 
-.. clicmd:: [no] segment-routing global-block (0-1048575) (0-1048575)
+.. clicmd:: segment-routing global-block (0-1048575) (0-1048575)
 
    Fix the Segment Routing Global Block i.e. the label range used by MPLS to
    store label in the MPLS FIB for Prefix SID.
 
-.. clicmd:: [no] segment-routing local-block (0-1048575) (0-1048575)
+.. clicmd:: segment-routing local-block (0-1048575) (0-1048575)
 
    Fix the Segment Routing Local Block i.e. the label range used by MPLS to
    store label in the MPLS FIB for Adjacency SID.
 
-.. clicmd:: [no] segment-routing node-msd (1-16)
+.. clicmd:: segment-routing node-msd (1-16)
 
    Fix the Maximum Stack Depth supported by the router. The value depend of the
    MPLS dataplane. E.g. for Linux kernel, since version 4.13 it is 32.
 
-.. clicmd:: [no] segment-routing prefix A.B.C.D/M [index (0-65535)|no-php-flag|explicit-null]
+.. clicmd:: segment-routing prefix A.B.C.D/M [index (0-65535)|no-php-flag|explicit-null]
 
    prefix with /32 corresponding to a loopback interface are currently
    supported. The 'no-php-flag' means NO Penultimate Hop Popping that allows SR
@@ -990,13 +926,13 @@ External Route Summarisation
 This feature summarises originated external LSAs(Type-5 and Type-7).
 Summary Route will be originated on-behalf of all matched external LSAs.
 
-.. clicmd:: [no] summary-address A.B.C.D/M [tag (1-4294967295)]
+.. clicmd:: summary-address A.B.C.D/M [tag (1-4294967295)]
 
    This command enable/disables summarisation for the configured address
    range. Tag is the optional parameter. If tag configured Summary route
    will be originated with the configured tag.
 
-.. clicmd:: [no] summary-address A.B.C.D/M no-advertise
+.. clicmd:: summary-address A.B.C.D/M no-advertise
 
    This command to ensure not advertise the summary lsa for the matched
    external LSAs.
@@ -1006,7 +942,6 @@ Summary Route will be originated on-behalf of all matched external LSAs.
    Configure aggregation delay timer interval. Summarisation starts only after
    this delay timer expiry. By default, delay interval is 5 secs.
 
-.. clicmd:: no aggregation timer
 
    Resetting the aggregation delay interval to default value.
 
@@ -1033,7 +968,6 @@ Debugging OSPF
 
 .. clicmd:: debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 
-.. clicmd:: no debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 
    Dump Packet for debugging
 
@@ -1041,9 +975,7 @@ Debugging OSPF
 
 .. clicmd:: debug ospf ism (status|events|timers)
 
-.. clicmd:: no debug ospf ism
 
-.. clicmd:: no debug ospf ism (status|events|timers)
 
    Show debug information of Interface State Machine
 
@@ -1051,21 +983,17 @@ Debugging OSPF
 
 .. clicmd:: debug ospf nsm (status|events|timers)
 
-.. clicmd:: no debug ospf nsm
 
-.. clicmd:: no debug ospf nsm (status|events|timers)
 
    Show debug information of Network State Machine
 
 .. clicmd:: debug ospf event
 
-.. clicmd:: no debug ospf event
 
    Show debug information of OSPF event
 
 .. clicmd:: debug ospf nssa
 
-.. clicmd:: no debug ospf nssa
 
    Show debug information about Not So Stub Area
 
@@ -1073,15 +1001,12 @@ Debugging OSPF
 
 .. clicmd:: debug ospf lsa (generate|flooding|refresh)
 
-.. clicmd:: no debug ospf lsa
 
-.. clicmd:: no debug ospf lsa (generate|flooding|refresh)
 
    Show debug detail of Link State messages
 
 .. clicmd:: debug ospf te
 
-.. clicmd:: no debug ospf te
 
    Show debug information about Traffic Engineering LSA
 
@@ -1089,21 +1014,18 @@ Debugging OSPF
 
 .. clicmd:: debug ospf zebra (interface|redistribute)
 
-.. clicmd:: no debug ospf zebra
 
-.. clicmd:: no debug ospf zebra (interface|redistribute)
 
    Show debug information of ZEBRA API
 
 .. clicmd:: debug ospf graceful-restart helper
 
-.. clicmd:: no debug ospf graceful-restart helper
 
    Enable/disable debug information for OSPF Graceful Restart Helper
 
 .. clicmd:: show debugging ospf
 
-.. clicmd:: [no] debug ospf lsa aggregate
+.. clicmd:: debug ospf lsa aggregate
 
    Debug commnd to enable/disable external route summarisation specific debugs.
 

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -180,9 +180,6 @@ To start OSPF process you have to specify the OSPF router.
 .. index:: timers throttle spf (0-600000) (0-600000) (0-600000)
 .. clicmd:: timers throttle spf (0-600000) (0-600000) (0-600000)
 
-.. index:: timers throttle spf
-.. clicmd:: no timers throttle spf
-
    This command sets the initial `delay`, the `initial-holdtime`
    and the `maximum-holdtime` between when SPF is calculated and the
    event which triggered the calculation. The times are specified in
@@ -755,34 +752,10 @@ Usage of *ospfd*'s route-map support.
 Redistribution
 --------------
 
-.. index:: redistribute (kernel|connected|static|rip|bgp)
-.. clicmd:: redistribute (kernel|connected|static|rip|bgp)
-
-.. index:: redistribute (kernel|connected|static|rip|bgp) ROUTE-MAP
-.. clicmd:: redistribute (kernel|connected|static|rip|bgp) ROUTE-MAP
-
-.. index:: redistribute (kernel|connected|static|rip|bgp) metric-type (1|2)
-.. clicmd:: redistribute (kernel|connected|static|rip|bgp) metric-type (1|2)
-
-.. index:: redistribute (kernel|connected|static|rip|bgp) metric-type (1|2) route-map WORD
-.. clicmd:: redistribute (kernel|connected|static|rip|bgp) metric-type (1|2) route-map WORD
-
-.. index:: redistribute (kernel|connected|static|rip|bgp) metric (0-16777214)
-.. clicmd:: redistribute (kernel|connected|static|rip|bgp) metric (0-16777214)
-
-.. index:: redistribute (kernel|connected|static|rip|bgp) metric (0-16777214) route-map WORD
-.. clicmd:: redistribute (kernel|connected|static|rip|bgp) metric (0-16777214) route-map WORD
-
-.. index:: redistribute (kernel|connected|static|rip|bgp) metric-type (1|2) metric (0-16777214)
-.. clicmd:: redistribute (kernel|connected|static|rip|bgp) metric-type (1|2) metric (0-16777214)
-
-.. index:: redistribute (kernel|connected|static|rip|bgp) metric-type (1|2) metric (0-16777214) route-map WORD
-.. clicmd:: redistribute (kernel|connected|static|rip|bgp) metric-type (1|2) metric (0-16777214) route-map WORD
-
-.. index:: redistribute (kernel|connected|static|rip|bgp)
-.. clicmd:: no redistribute (kernel|connected|static|rip|bgp)
-
 .. _ospf-redistribute:
+
+.. index:: redistribute <babel|bgp|connected|eigrp|isis|kernel|openfabric|ospf|rip|sharp|static|table> [metric-type (1-2)] [metric (0-16777214)] [route-map WORD]
+.. clicmd:: redistribute <babel|bgp|connected|eigrp|isis|kernel|openfabric|ospf|rip|sharp|static|table> [metric-type (1-2)] [metric (0-16777214)] [route-map WORD]
 
    Redistribute routes of the specified protocol or kind into OSPF, with the
    metric type and metric set if specified, filtering the routes using the
@@ -864,11 +837,6 @@ Redistribution
 .. index:: distance ospf
 .. clicmd:: no distance ospf
 
-.. index:: router zebra
-.. clicmd:: router zebra
-
-.. index:: router zebra
-.. clicmd:: no router zebra
 
 Graceful Restart Helper
 =======================

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -80,18 +80,14 @@ Routers
 
 To start OSPF process you have to specify the OSPF router.
 
-.. index:: router ospf [(1-65535)] vrf NAME
 .. clicmd:: router ospf [(1-65535)] vrf NAME
 
-.. index:: router ospf [(1-65535)] vrf NAME
 .. clicmd:: no router ospf [(1-65535)] vrf NAME
 
    Enable or disable the OSPF process.
 
-.. index:: ospf router-id A.B.C.D
 .. clicmd:: ospf router-id A.B.C.D
 
-.. index:: ospf router-id [A.B.C.D]
 .. clicmd:: no ospf router-id [A.B.C.D]
 
    This sets the router-ID of the OSPF process. The router-ID may be an IP
@@ -101,10 +97,8 @@ To start OSPF process you have to specify the OSPF router.
    with the same router-ID! If one is not specified then *ospfd* will obtain a
    router-ID automatically from *zebra*.
 
-.. index:: ospf abr-type TYPE
 .. clicmd:: ospf abr-type TYPE
 
-.. index:: ospf abr-type TYPE
 .. clicmd:: no ospf abr-type TYPE
 
    `type` can be cisco|ibm|shortcut|standard. The "Cisco" and "IBM" types
@@ -137,10 +131,8 @@ To start OSPF process you have to specify the OSPF router.
    OSPF domain, is dropped. This document describes alternative ABR
    behaviors implemented in Cisco and IBM routers."
 
-.. index:: ospf rfc1583compatibility
 .. clicmd:: ospf rfc1583compatibility
 
-.. index:: ospf rfc1583compatibility
 .. clicmd:: no ospf rfc1583compatibility
 
    :rfc:`2328`, the successor to :rfc:`1583`, suggests according
@@ -152,20 +144,16 @@ To start OSPF process you have to specify the OSPF router.
 
    This command should NOT be set normally.
 
-.. index:: log-adjacency-changes [detail]
 .. clicmd:: log-adjacency-changes [detail]
 
-.. index:: log-adjacency-changes [detail]
 .. clicmd:: no log-adjacency-changes [detail]
 
    Configures ospfd to log changes in adjacency. With the optional
    detail argument, all changes in adjacency status are shown. Without detail,
    only changes to full or regressions are shown.
 
-.. index:: passive-interface INTERFACE
 .. clicmd:: passive-interface INTERFACE
 
-.. index:: passive-interface INTERFACE
 .. clicmd:: no passive-interface INTERFACE
 
    Do not speak OSPF interface on the
@@ -177,7 +165,6 @@ To start OSPF process you have to specify the OSPF router.
    OSPF (:ref:`redistribute-routes-to-ospf`). This is the only way to
    advertise non-OSPF links into stub areas.
 
-.. index:: timers throttle spf (0-600000) (0-600000) (0-600000)
 .. clicmd:: timers throttle spf (0-600000) (0-600000) (0-600000)
 
    This command sets the initial `delay`, the `initial-holdtime`
@@ -218,13 +205,10 @@ To start OSPF process you have to specify the OSPF router.
    This command supersedes the *timers spf* command in previous FRR
    releases.
 
-.. index:: max-metric router-lsa [on-startup|on-shutdown] (5-86400)
 .. clicmd:: max-metric router-lsa [on-startup|on-shutdown] (5-86400)
 
-.. index:: max-metric router-lsa administrative
 .. clicmd:: max-metric router-lsa administrative
 
-.. index:: max-metric router-lsa [on-startup|on-shutdown|administrative]
 .. clicmd:: no max-metric router-lsa [on-startup|on-shutdown|administrative]
 
    This enables :rfc:`3137` support, where the OSPF process describes its
@@ -254,10 +238,8 @@ To start OSPF process you have to specify the OSPF router.
    number of second remaining till on-startup or on-shutdown ends, can be
    viewed with the :clicmd:`show ip ospf` command.
 
-.. index:: auto-cost reference-bandwidth (1-4294967)
 .. clicmd:: auto-cost reference-bandwidth (1-4294967)
 
-.. index:: auto-cost reference-bandwidth
 .. clicmd:: no auto-cost reference-bandwidth
 
    This sets the reference
@@ -270,16 +252,12 @@ To start OSPF process you have to specify the OSPF router.
    This configuration setting MUST be consistent across all routers within the
    OSPF domain.
 
-.. index:: network A.B.C.D/M area A.B.C.D
 .. clicmd:: network A.B.C.D/M area A.B.C.D
 
-.. index:: network A.B.C.D/M area (0-4294967295)
 .. clicmd:: network A.B.C.D/M area (0-4294967295)
 
-.. index:: network A.B.C.D/M area A.B.C.D
 .. clicmd:: no network A.B.C.D/M area A.B.C.D
 
-.. index:: network A.B.C.D/M area (0-4294967295)
 .. clicmd:: no network A.B.C.D/M area (0-4294967295)
 
    This command specifies the OSPF enabled interface(s). If the interface has
@@ -307,10 +285,8 @@ To start OSPF process you have to specify the OSPF router.
    In some cases it may be more convenient to enable OSPF on a per
    interface/subnet basis (:clicmd:`ip ospf area AREA [ADDR]`).
 
-.. index:: proactive-arp
 .. clicmd:: proactive-arp
 
-.. index:: proactive-arp
 .. clicmd:: no proactive-arp
 
    This command enables or disables sending ARP requests to update neighbor
@@ -319,7 +295,6 @@ To start OSPF process you have to specify the OSPF router.
 
    This feature is enabled by default.
 
-.. index:: clear ip ospf [(1-65535)] process
 .. clicmd:: clear ip ospf [(1-65535)] process
 
    This command can be used to clear the ospf process data structures. This
@@ -328,7 +303,6 @@ To start OSPF process you have to specify the OSPF router.
    in router-id and if user wants the router-id change to take effect, user can
    use this cli instead of restarting the ospfd daemon.
 
-.. index:: clear ip ospf [(1-65535)] neighbor
 .. clicmd:: clear ip ospf [(1-65535)] neighbor
 
    This command can be used to clear the ospf neighbor data structures. This
@@ -341,16 +315,12 @@ To start OSPF process you have to specify the OSPF router.
 Areas
 -----
 
-.. index:: area A.B.C.D range A.B.C.D/M
 .. clicmd:: area A.B.C.D range A.B.C.D/M
 
-.. index:: area (0-4294967295) range A.B.C.D/M
 .. clicmd:: area (0-4294967295) range A.B.C.D/M
 
-.. index:: area A.B.C.D range A.B.C.D/M
 .. clicmd:: no area A.B.C.D range A.B.C.D/M
 
-.. index:: area (0-4294967295) range A.B.C.D/M
 .. clicmd:: no area (0-4294967295) range A.B.C.D/M
 
    Summarize intra area paths from specified area into one Type-3 summary-LSA
@@ -371,20 +341,16 @@ Areas
    announced into backbone area if area 0.0.0.10 contains at least one intra-area
    network (i.e. described with router or network LSA) from this range.
 
-.. index:: area A.B.C.D range IPV4_PREFIX not-advertise
 .. clicmd:: area A.B.C.D range IPV4_PREFIX not-advertise
 
-.. index:: area A.B.C.D range IPV4_PREFIX not-advertise
 .. clicmd:: no area A.B.C.D range IPV4_PREFIX not-advertise
 
    Instead of summarizing intra area paths filter them - i.e. intra area paths from this
    range are not advertised into other areas.
    This command makes sense in ABR only.
 
-.. index:: area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
 .. clicmd:: area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
 
-.. index:: area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
 .. clicmd:: no area A.B.C.D range IPV4_PREFIX substitute IPV4_PREFIX
 
    Substitute summarized prefix with another prefix.
@@ -402,43 +368,31 @@ Areas
    network-LSA) from range 10.0.0.0/8.
    This command makes sense in ABR only.
 
-.. index:: area A.B.C.D virtual-link A.B.C.D
 .. clicmd:: area A.B.C.D virtual-link A.B.C.D
 
-.. index:: area (0-4294967295) virtual-link A.B.C.D
 .. clicmd:: area (0-4294967295) virtual-link A.B.C.D
 
-.. index:: area A.B.C.D virtual-link A.B.C.D
 .. clicmd:: no area A.B.C.D virtual-link A.B.C.D
 
-.. index:: area (0-4294967295) virtual-link A.B.C.D
 .. clicmd:: no area (0-4294967295) virtual-link A.B.C.D
 
-.. index:: area A.B.C.D shortcut
 .. clicmd:: area A.B.C.D shortcut
 
-.. index:: area (0-4294967295) shortcut
 .. clicmd:: area (0-4294967295) shortcut
 
-.. index:: area A.B.C.D shortcut
 .. clicmd:: no area A.B.C.D shortcut
 
-.. index:: area (0-4294967295) shortcut
 .. clicmd:: no area (0-4294967295) shortcut
 
    Configure the area as Shortcut capable. See :rfc:`3509`. This requires
    that the 'abr-type' be set to 'shortcut'.
 
-.. index:: area A.B.C.D stub
 .. clicmd:: area A.B.C.D stub
 
-.. index:: area (0-4294967295) stub
 .. clicmd:: area (0-4294967295) stub
 
-.. index:: area A.B.C.D stub
 .. clicmd:: no area A.B.C.D stub
 
-.. index:: area (0-4294967295) stub
 .. clicmd:: no area (0-4294967295) stub
 
    Configure the area to be a stub area. That is, an area where no router
@@ -448,39 +402,29 @@ Areas
    area. They need only pass Network-Summary (type-3) LSAs into such an area,
    along with a default-route summary.
 
-.. index:: area A.B.C.D stub no-summary
 .. clicmd:: area A.B.C.D stub no-summary
 
-.. index:: area (0-4294967295) stub no-summary
 .. clicmd:: area (0-4294967295) stub no-summary
 
-.. index:: area A.B.C.D stub no-summary
 .. clicmd:: no area A.B.C.D stub no-summary
 
-.. index:: area (0-4294967295) stub no-summary
 .. clicmd:: no area (0-4294967295) stub no-summary
 
     Prevents an *ospfd* ABR from injecting inter-area
     summaries into the specified stub area.
 
-.. index:: area A.B.C.D default-cost (0-16777215)
 .. clicmd:: area A.B.C.D default-cost (0-16777215)
 
-.. index:: area A.B.C.D default-cost (0-16777215)
 .. clicmd:: no area A.B.C.D default-cost (0-16777215)
 
    Set the cost of default-summary LSAs announced to stubby areas.
 
-.. index:: area A.B.C.D export-list NAME
 .. clicmd:: area A.B.C.D export-list NAME
 
-.. index:: area (0-4294967295) export-list NAME
 .. clicmd:: area (0-4294967295) export-list NAME
 
-.. index:: area A.B.C.D export-list NAME
 .. clicmd:: no area A.B.C.D export-list NAME
 
-.. index:: area (0-4294967295) export-list NAME
 .. clicmd:: no area (0-4294967295) export-list NAME
 
    Filter Type-3 summary-LSAs announced to other areas originated from intra-
@@ -504,67 +448,49 @@ Areas
    This command is only relevant if the router is an ABR for the specified
    area.
 
-.. index:: area A.B.C.D import-list NAME
 .. clicmd:: area A.B.C.D import-list NAME
 
-.. index:: area (0-4294967295) import-list NAME
 .. clicmd:: area (0-4294967295) import-list NAME
 
-.. index:: area A.B.C.D import-list NAME
 .. clicmd:: no area A.B.C.D import-list NAME
 
-.. index:: area (0-4294967295) import-list NAME
 .. clicmd:: no area (0-4294967295) import-list NAME
 
    Same as export-list, but it applies to paths announced into specified area
    as Type-3 summary-LSAs.
 
-.. index:: area A.B.C.D filter-list prefix NAME in
 .. clicmd:: area A.B.C.D filter-list prefix NAME in
 
-.. index:: area A.B.C.D filter-list prefix NAME out
 .. clicmd:: area A.B.C.D filter-list prefix NAME out
 
-.. index:: area (0-4294967295) filter-list prefix NAME in
 .. clicmd:: area (0-4294967295) filter-list prefix NAME in
 
-.. index:: area (0-4294967295) filter-list prefix NAME out
 .. clicmd:: area (0-4294967295) filter-list prefix NAME out
 
-.. index:: area A.B.C.D filter-list prefix NAME in
 .. clicmd:: no area A.B.C.D filter-list prefix NAME in
 
-.. index:: area A.B.C.D filter-list prefix NAME out
 .. clicmd:: no area A.B.C.D filter-list prefix NAME out
 
-.. index:: area (0-4294967295) filter-list prefix NAME in
 .. clicmd:: no area (0-4294967295) filter-list prefix NAME in
 
-.. index:: area (0-4294967295) filter-list prefix NAME out
 .. clicmd:: no area (0-4294967295) filter-list prefix NAME out
 
    Filtering Type-3 summary-LSAs to/from area using prefix lists. This command
    makes sense in ABR only.
 
-.. index:: area A.B.C.D authentication
 .. clicmd:: area A.B.C.D authentication
 
-.. index:: area (0-4294967295) authentication
 .. clicmd:: area (0-4294967295) authentication
 
-.. index:: area A.B.C.D authentication
 .. clicmd:: no area A.B.C.D authentication
 
-.. index:: area (0-4294967295) authentication
 .. clicmd:: no area (0-4294967295) authentication
 
    Specify that simple password authentication should be used for the given
    area.
 
-.. index:: area A.B.C.D authentication message-digest
 .. clicmd:: area A.B.C.D authentication message-digest
 
-.. index:: area (0-4294967295) authentication message-digest
 .. clicmd:: area (0-4294967295) authentication message-digest
 
    Specify that OSPF packets must be authenticated with MD5 HMACs within the
@@ -580,10 +506,8 @@ Areas
 Interfaces
 ----------
 
-.. index:: ip ospf area AREA [ADDR]
 .. clicmd:: ip ospf area AREA [ADDR]
 
-.. index:: ip ospf area [ADDR]
 .. clicmd:: no ip ospf area [ADDR]
 
    Enable OSPF on the interface, optionally restricted to just the IP address
@@ -594,10 +518,8 @@ Interfaces
    If you have a lot of interfaces, and/or a lot of subnets, then enabling OSPF
    via this command may result in a slight performance improvement.
 
-.. index:: ip ospf authentication-key AUTH_KEY
 .. clicmd:: ip ospf authentication-key AUTH_KEY
 
-.. index:: ip ospf authentication-key
 .. clicmd:: no ip ospf authentication-key
 
    Set OSPF authentication key to a simple password. After setting `AUTH_KEY`,
@@ -606,7 +528,6 @@ Interfaces
    Simple text password authentication is insecure and deprecated in favour of
    MD5 HMAC authentication.
 
-.. index:: ip ospf authentication message-digest
 .. clicmd:: ip ospf authentication message-digest
 
    Specify that MD5 HMAC authentication must be used on this interface. MD5
@@ -623,10 +544,8 @@ Interfaces
    non-volatile storage and restored at boot if MD5 authentication is to be
    expected to work reliably.
 
-.. index:: ip ospf message-digest-key KEYID md5 KEY
 .. clicmd:: ip ospf message-digest-key KEYID md5 KEY
 
-.. index:: ip ospf message-digest-key
 .. clicmd:: no ip ospf message-digest-key
 
    Set OSPF authentication key to a cryptographic password. The cryptographic
@@ -638,22 +557,17 @@ Interfaces
    KEY is the actual message digest key, of up to 16 chars (larger strings will
    be truncated), and is associated with the given KEYID.
 
-.. index:: ip ospf cost (1-65535)
 .. clicmd:: ip ospf cost (1-65535)
 
-.. index:: ip ospf cost
 .. clicmd:: no ip ospf cost
 
    Set link cost for the specified interface. The cost value is set to
    router-LSA's metric field and used for SPF calculation.
 
-.. index:: ip ospf dead-interval (1-65535)
 .. clicmd:: ip ospf dead-interval (1-65535)
 
-.. index:: ip ospf dead-interval minimal hello-multiplier (2-20)
 .. clicmd:: ip ospf dead-interval minimal hello-multiplier (2-20)
 
-.. index:: ip ospf dead-interval
 .. clicmd:: no ip ospf dead-interval
 
    Set number of seconds for RouterDeadInterval timer value used for Wait Timer
@@ -669,10 +583,8 @@ Interfaces
    hello-multiplier need NOT be the same across multiple routers on a common
    link.
 
-.. index:: ip ospf hello-interval (1-65535)
 .. clicmd:: ip ospf hello-interval (1-65535)
 
-.. index:: ip ospf hello-interval
 .. clicmd:: no ip ospf hello-interval
 
    Set number of seconds for HelloInterval timer value. Setting this value,
@@ -684,7 +596,6 @@ Interfaces
    :clicmd:`ip ospf dead-interval minimal hello-multiplier (2-20)` is also
    specified for the interface.
 
-.. index:: ip ospf network (broadcast|non-broadcast|point-to-multipoint|point-to-point)
 .. clicmd:: ip ospf network (broadcast|non-broadcast|point-to-multipoint|point-to-point)
 
    When configuring a point-to-point network on an interface and the interface
@@ -693,44 +604,35 @@ Interfaces
    net.ipv4.conf.<interface name>.rp_filter value to 0.  In order for
    the ospf multicast packets to be delivered by the kernel.
 
-.. index:: ip ospf network
 .. clicmd:: no ip ospf network
 
    Set explicitly network type for specified interface.
 
-.. index:: ip ospf priority (0-255)
 .. clicmd:: ip ospf priority (0-255)
 
-.. index:: ip ospf priority
 .. clicmd:: no ip ospf priority
 
    Set RouterPriority integer value. The router with the highest priority will
    be more eligible to become Designated Router. Setting the value to 0, makes
    the router ineligible to become Designated Router. The default value is 1.
 
-.. index:: ip ospf retransmit-interval (1-65535)
 .. clicmd:: ip ospf retransmit-interval (1-65535)
 
-.. index:: ip ospf retransmit interval
 .. clicmd:: no ip ospf retransmit interval
 
    Set number of seconds for RxmtInterval timer value. This value is used when
    retransmitting Database Description and Link State Request packets. The
    default value is 5 seconds.
 
-.. index:: ip ospf transmit-delay (1-65535) [A.B.C.D]
 .. clicmd:: ip ospf transmit-delay (1-65535) [A.B.C.D]
 
-.. index:: ip ospf transmit-delay [(1-65535)] [A.B.C.D]
 .. clicmd:: no ip ospf transmit-delay [(1-65535)] [A.B.C.D]
 
    Set number of seconds for InfTransDelay value. LSAs' age should be
    incremented by this value when transmitting. The default value is 1 second.
 
-.. index:: ip ospf area (A.B.C.D|(0-4294967295))
 .. clicmd:: ip ospf area (A.B.C.D|(0-4294967295))
 
-.. index:: ip ospf area
 .. clicmd:: no ip ospf area
 
    Enable ospf on an interface and set associated area.
@@ -740,7 +642,6 @@ OSPF route-map
 
 Usage of *ospfd*'s route-map support.
 
-.. index:: set metric [+|-](0-4294967295)
 .. clicmd:: set metric [+|-](0-4294967295)
 
    Set a metric for matched route when sending announcement. Use plus (+) sign
@@ -754,7 +655,6 @@ Redistribution
 
 .. _ospf-redistribute:
 
-.. index:: redistribute <babel|bgp|connected|eigrp|isis|kernel|openfabric|ospf|rip|sharp|static|table> [metric-type (1-2)] [metric (0-16777214)] [route-map WORD]
 .. clicmd:: redistribute <babel|bgp|connected|eigrp|isis|kernel|openfabric|ospf|rip|sharp|static|table> [metric-type (1-2)] [metric (0-16777214)] [route-map WORD]
 
    Redistribute routes of the specified protocol or kind into OSPF, with the
@@ -775,31 +675,22 @@ Redistribution
 
    clicmd:`passive-interface INTERFACE`.
 
-.. index:: default-information originate
 .. clicmd:: default-information originate
 
-.. index:: default-information originate metric (0-16777214)
 .. clicmd:: default-information originate metric (0-16777214)
 
-.. index:: default-information originate metric (0-16777214) metric-type (1|2)
 .. clicmd:: default-information originate metric (0-16777214) metric-type (1|2)
 
-.. index:: default-information originate metric (0-16777214) metric-type (1|2) route-map WORD
 .. clicmd:: default-information originate metric (0-16777214) metric-type (1|2) route-map WORD
 
-.. index:: default-information originate always
 .. clicmd:: default-information originate always
 
-.. index:: default-information originate always metric (0-16777214)
 .. clicmd:: default-information originate always metric (0-16777214)
 
-.. index:: default-information originate always metric (0-16777214) metric-type (1|2)
 .. clicmd:: default-information originate always metric (0-16777214) metric-type (1|2)
 
-.. index:: default-information originate always metric (0-16777214) metric-type (1|2) route-map WORD
 .. clicmd:: default-information originate always metric (0-16777214) metric-type (1|2) route-map WORD
 
-.. index:: default-information originate
 .. clicmd:: no default-information originate
 
    Originate an AS-External (type-5) LSA describing a default route into all
@@ -807,10 +698,8 @@ Redistribution
    the 'always' keyword is given then the default is always advertised, even
    when there is no default present in the routing table.
 
-.. index:: distribute-list NAME out (kernel|connected|static|rip|ospf
 .. clicmd:: distribute-list NAME out (kernel|connected|static|rip|ospf
 
-.. index:: distribute-list NAME out (kernel|connected|static|rip|ospf
 .. clicmd:: no distribute-list NAME out (kernel|connected|static|rip|ospf
 
 .. _ospf-distribute-list:
@@ -819,32 +708,24 @@ Redistribution
    type before allowing the routes to redistributed into OSPF
    (:ref:`ospf redistribution <ospf-redistribute>`).
 
-.. index:: default-metric (0-16777214)
 .. clicmd:: default-metric (0-16777214)
 
-.. index:: default-metric
 .. clicmd:: no default-metric
 
-.. index:: distance (1-255)
 .. clicmd:: distance (1-255)
 
-.. index:: distance (1-255)
 .. clicmd:: no distance (1-255)
 
-.. index:: distance ospf (intra-area|inter-area|external) (1-255)
 .. clicmd:: distance ospf (intra-area|inter-area|external) (1-255)
 
-.. index:: distance ospf
 .. clicmd:: no distance ospf
 
 
 Graceful Restart Helper
 =======================
 
-.. index:: graceful-restart helper-only [A.B.C.D]
 .. clicmd:: graceful-restart helper-only [A.B.C.D]
 
-.. index:: graceful-restart helper-only [A.B.C.D]
 .. clicmd:: no graceful-restart helper-only [A.B.C.D]
 
    Configure Graceful Restart (RFC 3623) helper support.
@@ -854,10 +735,8 @@ Graceful Restart Helper
    To enable/disable helper support for a specific
    neighbour, the router-id (A.B.C.D) has to be specified.
 
-.. index:: graceful-restart helper strict-lsa-checking
 .. clicmd:: graceful-restart helper strict-lsa-checking
 
-.. index:: graceful-restart helper strict-lsa-checking
 .. clicmd:: no graceful-restart helper strict-lsa-checking
 
    If 'strict-lsa-checking' is configured then the helper will
@@ -865,18 +744,14 @@ Graceful Restart Helper
    affects the restarting router.
    By default 'strict-lsa-checking' is enabled"
 
-.. index:: graceful-restart helper supported-grace-time
 .. clicmd:: graceful-restart helper supported-grace-time
 
-.. index:: graceful-restart helper supported-grace-time
 .. clicmd:: no graceful-restart helper supported-grace-time
 
    Supports as HELPER for configured grace period.
 
-.. index:: graceful-restart helper planned-only
 .. clicmd:: graceful-restart helper planned-only
 
-.. index:: graceful-restart helper planned-only
 .. clicmd:: no graceful-restart helper planned-only
 
    It helps to support as HELPER only for planned
@@ -890,68 +765,51 @@ Showing Information
 
 .. _show-ip-ospf:
 
-.. index:: show ip ospf [json]
 .. clicmd:: show ip ospf [json]
 
    Show information on a variety of general OSPF and area state and
    configuration information.
 
-.. index:: show ip ospf interface [INTERFACE] [json]
 .. clicmd:: show ip ospf interface [INTERFACE] [json]
 
    Show state and configuration of OSPF the specified interface, or all
    interfaces if no interface is given.
 
-.. index:: show ip ospf neighbor [json]
 .. clicmd:: show ip ospf neighbor [json]
 
-.. index:: show ip ospf neighbor INTERFACE [json]
 .. clicmd:: show ip ospf neighbor INTERFACE [json]
 
-.. index:: show ip ospf neighbor detail [json]
 .. clicmd:: show ip ospf neighbor detail [json]
 
-.. index:: show ip ospf neighbor INTERFACE detail [json]
 .. clicmd:: show ip ospf neighbor INTERFACE detail [json]
 
    Display lsa information of LSDB.
    Json o/p of this command covers base route information
    i.e all LSAs except opaque lsa info.
 
-.. index:: show ip ospf database [json]
 .. clicmd:: show ip ospf database [json]
 
-.. index:: show ip ospf database (asbr-summary|external|network|router|summary) [json]
 .. clicmd:: show ip ospf database (asbr-summary|external|network|router|summary) [json]
 
-.. index:: show ip ospf database (asbr-summary|external|network|router|summary) LINK-STATE-ID [json]
 .. clicmd:: show ip ospf database (asbr-summary|external|network|router|summary) LINK-STATE-ID [json]
 
-.. index:: show ip ospf database (asbr-summary|external|network|router|summary) LINK-STATE-ID adv-router ADV-ROUTER [json]
 .. clicmd:: show ip ospf database (asbr-summary|external|network|router|summary) LINK-STATE-ID adv-router ADV-ROUTER [json]
 
-.. index:: show ip ospf database (asbr-summary|external|network|router|summary) adv-router ADV-ROUTER [json]
 .. clicmd:: show ip ospf database (asbr-summary|external|network|router|summary) adv-router ADV-ROUTER [json]
 
-.. index:: show ip ospf database (asbr-summary|external|network|router|summary) LINK-STATE-ID self-originate [json]
 .. clicmd:: show ip ospf database (asbr-summary|external|network|router|summary) LINK-STATE-ID self-originate [json]
 
-.. index:: show ip ospf database (asbr-summary|external|network|router|summary) self-originate [json]
 .. clicmd:: show ip ospf database (asbr-summary|external|network|router|summary) self-originate [json]
 
-.. index:: show ip ospf database max-age [json]
 .. clicmd:: show ip ospf database max-age [json]
 
-.. index:: show ip ospf database self-originate [json]
 .. clicmd:: show ip ospf database self-originate [json]
 
-.. index:: show ip ospf route [json]
 .. clicmd:: show ip ospf route [json]
 
    Show the OSPF routing table, as determined by the most recent SPF
    calculation.
 
-.. index:: show ip ospf graceful-restart helper [detail] [json]
 .. clicmd:: show ip ospf graceful-restart helper [detail] [json]
 
    Displays the Grcaeful Restart Helper details including helper
@@ -962,16 +820,12 @@ Showing Information
 Opaque LSA
 ==========
 
-.. index:: ospf opaque-lsa
 .. clicmd:: ospf opaque-lsa
 
-.. index:: capability opaque
 .. clicmd:: capability opaque
 
-.. index:: ospf opaque-lsa
 .. clicmd:: no ospf opaque-lsa
 
-.. index:: capability opaque
 .. clicmd:: no capability opaque
 
    *ospfd* supports Opaque LSA (:rfc:`2370`) as partial support for
@@ -982,22 +836,16 @@ Opaque LSA
    extensions that are used with MPLS-TE; it does not support a
    complete RSVP-TE solution.
 
-.. index:: show ip ospf database (opaque-link|opaque-area|opaque-external)
 .. clicmd:: show ip ospf database (opaque-link|opaque-area|opaque-external)
 
-.. index:: show ip ospf database (opaque-link|opaque-area|opaque-external) LINK-STATE-ID
 .. clicmd:: show ip ospf database (opaque-link|opaque-area|opaque-external) LINK-STATE-ID
 
-.. index:: show ip ospf database (opaque-link|opaque-area|opaque-external) LINK-STATE-ID adv-router ADV-ROUTER
 .. clicmd:: show ip ospf database (opaque-link|opaque-area|opaque-external) LINK-STATE-ID adv-router ADV-ROUTER
 
-.. index:: show ip ospf database (opaque-link|opaque-area|opaque-external) adv-router ADV-ROUTER
 .. clicmd:: show ip ospf database (opaque-link|opaque-area|opaque-external) adv-router ADV-ROUTER
 
-.. index:: show ip ospf database (opaque-link|opaque-area|opaque-external) LINK-STATE-ID self-originate
 .. clicmd:: show ip ospf database (opaque-link|opaque-area|opaque-external) LINK-STATE-ID self-originate
 
-.. index:: show ip ospf database (opaque-link|opaque-area|opaque-external) self-originate
 .. clicmd:: show ip ospf database (opaque-link|opaque-area|opaque-external) self-originate
 
    Show Opaque LSA from the database.
@@ -1013,24 +861,19 @@ Traffic Engineering
    protocol extensions that can be used with MPLS-TE. FRR does not
    support a complete RSVP-TE solution currently.
 
-.. index:: mpls-te on
 .. clicmd:: mpls-te on
 
-.. index:: mpls-te
 .. clicmd:: no mpls-te
 
    Enable Traffic Engineering LSA flooding.
 
-.. index:: mpls-te router-address <A.B.C.D>
 .. clicmd:: mpls-te router-address <A.B.C.D>
 
    Configure stable IP address for MPLS-TE. This IP address is then advertise
    in Opaque LSA Type-10 TLV=1 (TE) option 1 (Router-Address).
 
-.. index:: mpls-te inter-as area <area-id>|as
 .. clicmd:: mpls-te inter-as area <area-id>|as
 
-.. index:: mpls-te inter-as
 .. clicmd:: no mpls-te inter-as
 
    Enable :rfc:`5392` support - Inter-AS TE v2 - to flood Traffic Engineering
@@ -1038,15 +881,12 @@ Traffic Engineering
    flood in AREA <area-id> with Opaque Type-10, respectively in AS with Opaque
    Type-11. In all case, Opaque-LSA TLV=6.
 
-.. index:: show ip ospf mpls-te interface
 .. clicmd:: show ip ospf mpls-te interface
 
-.. index:: show ip ospf mpls-te interface INTERFACE
 .. clicmd:: show ip ospf mpls-te interface INTERFACE
 
    Show MPLS Traffic Engineering parameters for all or specified interface.
 
-.. index:: show ip ospf mpls-te router
 .. clicmd:: show ip ospf mpls-te router
 
    Show Traffic Engineering router parameters.
@@ -1056,10 +896,8 @@ Traffic Engineering
 Router Information
 ==================
 
-.. index:: router-info [as | area]
 .. clicmd:: router-info [as | area]
 
-.. index:: router-info
 .. clicmd:: no router-info
 
    Enable Router Information (:rfc:`4970`) LSA advertisement with AS scope
@@ -1068,34 +906,24 @@ Router Information
    as the area ID is no more necessary. Indeed, router information support
    multi-area and detect automatically the areas.
 
-.. index:: pce address <A.B.C.D>
 .. clicmd:: pce address <A.B.C.D>
 
-.. index:: pce address
 .. clicmd:: no pce address
 
-.. index:: pce domain as (0-65535)
 .. clicmd:: pce domain as (0-65535)
 
-.. index:: pce domain as (0-65535)
 .. clicmd:: no pce domain as (0-65535)
 
-.. index:: pce neighbor as (0-65535)
 .. clicmd:: pce neighbor as (0-65535)
 
-.. index:: pce neighbor as (0-65535)
 .. clicmd:: no pce neighbor as (0-65535)
 
-.. index:: pce flag BITPATTERN
 .. clicmd:: pce flag BITPATTERN
 
-.. index:: pce flag
 .. clicmd:: no pce flag
 
-.. index:: pce scope BITPATTERN
 .. clicmd:: pce scope BITPATTERN
 
-.. index:: pce scope
 .. clicmd:: no pce scope
 
    The commands are conform to :rfc:`5088` and allow OSPF router announce Path
@@ -1106,12 +934,10 @@ Router Information
    refer to :rfc`5088` for the BITPATTERN recognition. Multiple 'pce neighbor'
    command could be specified in order to specify all PCE neighbours.
 
-.. index:: show ip ospf router-info
 .. clicmd:: show ip ospf router-info
 
    Show Router Capabilities flag.
 
-.. index:: show ip ospf router-info pce
 .. clicmd:: show ip ospf router-info pce
 
    Show Router Capabilities PCE parameters.
@@ -1124,42 +950,35 @@ Segment Routing
 This is an EXPERIMENTAL support of Segment Routing as per `RFC 8665` for MPLS
 dataplane.
 
-.. index:: segment-routing on
 .. clicmd:: [no] segment-routing on
 
    Enable Segment Routing. Even if this also activate routing information
    support, it is preferable to also activate routing information, and set
    accordingly the Area or AS flooding.
 
-.. index:: segment-routing global-block (0-1048575) (0-1048575)
 .. clicmd:: [no] segment-routing global-block (0-1048575) (0-1048575)
 
    Fix the Segment Routing Global Block i.e. the label range used by MPLS to
    store label in the MPLS FIB for Prefix SID.
 
-.. index:: segment-routing local-block (0-1048575) (0-1048575)
 .. clicmd:: [no] segment-routing local-block (0-1048575) (0-1048575)
 
    Fix the Segment Routing Local Block i.e. the label range used by MPLS to
    store label in the MPLS FIB for Adjacency SID.
 
-.. index:: segment-routing node-msd (1-16)
 .. clicmd:: [no] segment-routing node-msd (1-16)
 
    Fix the Maximum Stack Depth supported by the router. The value depend of the
    MPLS dataplane. E.g. for Linux kernel, since version 4.13 it is 32.
 
-.. index:: segment-routing prefix A.B.C.D/M index (0-65535) [no-php-flag|explicit-null]
 .. clicmd:: [no] segment-routing prefix A.B.C.D/M [index (0-65535)|no-php-flag|explicit-null]
 
-   Set the Segment Routing index for the specified prefix. Note that, only
    prefix with /32 corresponding to a loopback interface are currently
    supported. The 'no-php-flag' means NO Penultimate Hop Popping that allows SR
    node to request to its neighbor to not pop the label. The 'explicit-null' means that
    neighbor nodes must swap the incoming label by the MPLS Explicit Null label
    before delivering the packet.
 
-.. index:: show ip ospf database segment-routing <adv-router ADVROUTER|self-originate> [json]
 .. clicmd:: show ip ospf database segment-routing <adv-router ADVROUTER|self-originate> [json]
 
    Show Segment Routing Data Base, all SR nodes, specific advertised router or
@@ -1171,31 +990,26 @@ External Route Summarisation
 This feature summarises originated external LSAs(Type-5 and Type-7).
 Summary Route will be originated on-behalf of all matched external LSAs.
 
-.. index:: summary-address A.B.C.D/M [tag (1-4294967295)]
 .. clicmd:: [no] summary-address A.B.C.D/M [tag (1-4294967295)]
 
    This command enable/disables summarisation for the configured address
    range. Tag is the optional parameter. If tag configured Summary route
    will be originated with the configured tag.
 
-.. index:: summary-address A.B.C.D/M no-advertise
 .. clicmd:: [no] summary-address A.B.C.D/M no-advertise
 
    This command to ensure not advertise the summary lsa for the matched
    external LSAs.
 
-.. index:: aggregation timer (5-1800)
 .. clicmd:: aggregation timer (5-1800)
 
    Configure aggregation delay timer interval. Summarisation starts only after
    this delay timer expiry. By default, delay interval is 5 secs.
 
-.. index:: aggregation timer
 .. clicmd:: no aggregation timer
 
    Resetting the aggregation delay interval to default value.
 
-.. index:: show ip ospf [vrf <NAME|all>] summary-address [detail] [json]
 .. clicmd:: show ip ospf [vrf <NAME|all>] summary-address [detail] [json]
 
    Show configuration for display all configured summary routes with
@@ -1208,7 +1022,6 @@ Experimental support for Topology Independent LFA (Loop-Free Alternate), see
 for example 'draft-bashandy-rtgwg-segment-routing-ti-lfa-05'. Note that
 TI-LFA requires a proper Segment Routing configuration.
 
-.. index:: fast-reroute ti-lfa [node-protection]
 .. clicmd:: fast-reroute ti-lfa [node-protection]
 
    Configured on the router level. Activates TI-LFA for all interfaces.
@@ -1218,106 +1031,78 @@ TI-LFA requires a proper Segment Routing configuration.
 Debugging OSPF
 ==============
 
-.. index:: debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 .. clicmd:: debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 
-.. index:: debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 .. clicmd:: no debug ospf packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 
    Dump Packet for debugging
 
-.. index:: debug ospf ism
 .. clicmd:: debug ospf ism
 
-.. index:: debug ospf ism (status|events|timers)
 .. clicmd:: debug ospf ism (status|events|timers)
 
-.. index:: debug ospf ism
 .. clicmd:: no debug ospf ism
 
-.. index:: debug ospf ism (status|events|timers)
 .. clicmd:: no debug ospf ism (status|events|timers)
 
    Show debug information of Interface State Machine
 
-.. index:: debug ospf nsm
 .. clicmd:: debug ospf nsm
 
-.. index:: debug ospf nsm (status|events|timers)
 .. clicmd:: debug ospf nsm (status|events|timers)
 
-.. index:: debug ospf nsm
 .. clicmd:: no debug ospf nsm
 
-.. index:: debug ospf nsm (status|events|timers)
 .. clicmd:: no debug ospf nsm (status|events|timers)
 
    Show debug information of Network State Machine
 
-.. index:: debug ospf event
 .. clicmd:: debug ospf event
 
-.. index:: debug ospf event
 .. clicmd:: no debug ospf event
 
    Show debug information of OSPF event
 
-.. index:: debug ospf nssa
 .. clicmd:: debug ospf nssa
 
-.. index:: debug ospf nssa
 .. clicmd:: no debug ospf nssa
 
    Show debug information about Not So Stub Area
 
-.. index:: debug ospf lsa
 .. clicmd:: debug ospf lsa
 
-.. index:: debug ospf lsa (generate|flooding|refresh)
 .. clicmd:: debug ospf lsa (generate|flooding|refresh)
 
-.. index:: debug ospf lsa
 .. clicmd:: no debug ospf lsa
 
-.. index:: debug ospf lsa (generate|flooding|refresh)
 .. clicmd:: no debug ospf lsa (generate|flooding|refresh)
 
    Show debug detail of Link State messages
 
-.. index:: debug ospf te
 .. clicmd:: debug ospf te
 
-.. index:: debug ospf te
 .. clicmd:: no debug ospf te
 
    Show debug information about Traffic Engineering LSA
 
-.. index:: debug ospf zebra
 .. clicmd:: debug ospf zebra
 
-.. index:: debug ospf zebra (interface|redistribute)
 .. clicmd:: debug ospf zebra (interface|redistribute)
 
-.. index:: debug ospf zebra
 .. clicmd:: no debug ospf zebra
 
-.. index:: debug ospf zebra (interface|redistribute)
 .. clicmd:: no debug ospf zebra (interface|redistribute)
 
    Show debug information of ZEBRA API
 
-.. index:: debug ospf graceful-restart helper
 .. clicmd:: debug ospf graceful-restart helper
 
-.. index:: debug ospf graceful-restart helper
 .. clicmd:: no debug ospf graceful-restart helper
 
    Enable/disable debug information for OSPF Graceful Restart Helper
 
-.. index:: show debugging ospf
 .. clicmd:: show debugging ospf
 
-.. index:: debug ospf lsa aggregate
 .. clicmd:: [no] debug ospf lsa aggregate
 
    Debug commnd to enable/disable external route summarisation specific debugs.

--- a/doc/user/overview.rst
+++ b/doc/user/overview.rst
@@ -474,11 +474,6 @@ changes, updates to the Development list and either this file or information
 posted at `FRR`_.
 
 
-.. index::
-   pair: bug reports; contact
-
-.. _bug-reports:
-
 Bug Reports
 ===========
 

--- a/doc/user/overview.rst
+++ b/doc/user/overview.rst
@@ -62,9 +62,8 @@ Feature support varies by platform; see the :ref:`feature-matrix`.
 System Architecture
 -------------------
 
-.. index:: System architecture
-.. index:: Software architecture
-.. index:: Software internals
+.. index::
+   pair: architecture; FRR
 
 Traditional routing software is made as a one process program which provides
 all of the routing protocol functionalities. FRR takes a different approach.
@@ -114,15 +113,15 @@ data models. When this work is completed, FRR will be a fully programmable
 routing stack.
 
 
+.. index::
+   pair: platforms; FRR
+   pair: operating systems; FRR
+
 .. _supported-platforms:
 
 Supported Platforms
 -------------------
 
-.. index:: Supported platforms
-.. index:: FRR on other systems
-.. index:: Compatibility with other systems
-.. index:: Operating systems that support FRR
 
 Currently FRR supports GNU/Linux and BSD. Porting FRR to other platforms is not
 too difficult as platform dependent code should be mostly limited to the
@@ -149,10 +148,8 @@ Recent versions of the following compilers are well tested:
 
 .. _unsupported-platforms:
 
-UnSupported Platforms
+Unsupported Platforms
 ---------------------
-
-.. index:: UnSupported platforms
 
 In General if the platform you are attempting to use is not listed above then
 FRR does not support being run on that platform.  The only caveat here is that
@@ -263,6 +260,10 @@ Known Kernel Issues
   route deletion when you have ECMP routes installed into the kernel. This
   especially becomes apparent if the route is being transformed from one ECMP
   path to another.
+
+
+.. index::
+   pair: rfcs; FRR
 
 .. _supported-rfcs:
 
@@ -439,13 +440,14 @@ SNMP
 - :rfc:`2741`
   :t:`Agent Extensibility (AgentX) Protocol. M. Daniele, B. Wijnen. January 2000.`
 
+
+.. index::
+   pair: mailing lists; contact
+
+.. _mailing-lists:
+
 Mailing Lists
 =============
-
-.. index:: How to get in touch with FRR
-.. index:: Contact information
-.. index:: Mailing lists
-
 
 Italicized lists are private.
 
@@ -470,6 +472,12 @@ results of such discussions are reflected in updates, as appropriate, to code
 (i.e., merges), `GitHub issues`_ tracked issues, and for governance or process
 changes, updates to the Development list and either this file or information
 posted at `FRR`_.
+
+
+.. index::
+   pair: bug reports; contact
+
+.. _bug-reports:
 
 Bug Reports
 ===========

--- a/doc/user/pathd.rst
+++ b/doc/user/pathd.rst
@@ -339,16 +339,6 @@ The asterisk (*) marks the best, e.g. active, candidate path. Note that for segm
 retrieved via PCEP a random number based name is generated.
 
 
-.. clicmd:: show debugging pathd
-
-   Display the current status of the pathd debugging.
-
-
-.. clicmd:: show debugging pathd-pcep
-
-   Display the current status of the pcep module debugging.
-
-
 .. clicmd:: show sr-te pcep counters
 
    Display the counters from pceplib.

--- a/doc/user/pathd.rst
+++ b/doc/user/pathd.rst
@@ -113,7 +113,7 @@ Configuration Commands
 
    Configure segment routing traffic engineering.
 
-.. clicmd:: [no] segment-list NAME
+.. clicmd:: segment-list NAME
 
    Delete or start a segment list definition.
 
@@ -122,7 +122,7 @@ Configuration Commands
    Delete or specify a segment in a segment list definition.
 
 
-.. clicmd:: [no] policy color COLOR endpoint ENDPOINT
+.. clicmd:: policy color COLOR endpoint ENDPOINT
 
    Delete or start a policy definition.
 
@@ -137,27 +137,27 @@ Configuration Commands
    Specify the policy SID.
 
 
-.. clicmd:: [no] candidate-path preference PREFERENCE name NAME explicit segment-list SEGMENT-LIST-NAME
+.. clicmd:: candidate-path preference PREFERENCE name NAME explicit segment-list SEGMENT-LIST-NAME
 
    Delete or define an explicit candidate path.
 
 
-.. clicmd:: [no] candidate-path preference PREFERENCE name NAME dynamic
+.. clicmd:: candidate-path preference PREFERENCE name NAME dynamic
 
    Delete or start a dynamic candidate path definition.
 
 
-.. clicmd:: [no] affinity {exclude-any|include-any|include-all} BITPATTERN
+.. clicmd:: affinity {exclude-any|include-any|include-all} BITPATTERN
 
    Delete or specify an affinity constraint for a dynamic candidate path.
 
 
-.. clicmd:: [no] bandwidth BANDWIDTH [required]
+.. clicmd:: bandwidth BANDWIDTH [required]
 
    Delete or specify a bandwidth constraint for a dynamic candidate path.
 
 
-.. clicmd:: [no] metric [bound] METRIC VALUE [required]
+.. clicmd:: metric [bound] METRIC VALUE [required]
 
    Delete or specify a metric constraint for a dynamic candidate path.
 
@@ -185,7 +185,7 @@ Configuration Commands
     - bnc: Border Node Count metric
 
 
-.. clicmd:: [no] objective-function OBJFUN1 [required]
+.. clicmd:: objective-function OBJFUN1 [required]
 
    Delete or specify a PCEP objective function constraint for a dynamic
    candidate path.
@@ -210,7 +210,7 @@ Configuration Commands
      - msn: Minimize the number of Shared Nodes [RFC8800]
 
 
-.. clicmd:: [no] debug pathd pcep [basic|path|message|pceplib]
+.. clicmd:: debug pathd pcep [basic|path|message|pceplib]
 
    Enable or disable debugging for the pcep module:
 
@@ -225,13 +225,13 @@ Configuration Commands
    Configure PCEP support.
 
 
-.. clicmd:: [no] pce-config NAME
+.. clicmd:: pce-config NAME
 
    Define a shared PCE configuration that can be used in multiple PCE
    declarations.
 
 
-.. clicmd:: [no] pce NAME
+.. clicmd:: pce NAME
 
    Define or delete a PCE definition.
 
@@ -296,7 +296,7 @@ Configuration Commands
    configuration group.
 
 
-.. clicmd:: [no] pcc
+.. clicmd:: pcc
 
    Disable or start the definition of a PCC.
 
@@ -306,7 +306,7 @@ Configuration Commands
    Specify the maximum SID depth in a PCC definition.
 
 
-.. clicmd:: [no] peer WORD [precedence (1-255)]
+.. clicmd:: peer WORD [precedence (1-255)]
 
    Specify a peer and its precedence in a PCC definition.
 

--- a/doc/user/pathd.rst
+++ b/doc/user/pathd.rst
@@ -105,71 +105,58 @@ Example:
 Configuration Commands
 ----------------------
 
-.. index:: segment-routing
 .. clicmd:: segment-routing
 
    Configure segment routing.
 
-.. index:: traffic-eng
 .. clicmd:: traffic-eng
 
    Configure segment routing traffic engineering.
 
-.. index:: segment-list NAME
 .. clicmd:: [no] segment-list NAME
 
    Delete or start a segment list definition.
 
-
-.. index:: index INDEX mpls label LABEL [nai node ADDRESS]
-.. clicmd:: [no] index INDEX mpls label LABEL [nai node ADDRESS]
+.. clicmd:: index INDEX mpls label LABEL [nai node ADDRESS]
 
    Delete or specify a segment in a segment list definition.
 
 
-.. index:: policy color COLOR endpoint ENDPOINT
 .. clicmd:: [no] policy color COLOR endpoint ENDPOINT
 
    Delete or start a policy definition.
 
 
-.. index:: name NAME
 .. clicmd:: name NAME
 
    Specify the policy name.
 
 
-.. index:: binding-sid LABEL
 .. clicmd:: binding-sid LABEL
 
    Specify the policy SID.
 
 
-.. index:: candidate-path preference PREFERENCE name NAME explicit segment-list SEGMENT-LIST-NAME
 .. clicmd:: [no] candidate-path preference PREFERENCE name NAME explicit segment-list SEGMENT-LIST-NAME
 
    Delete or define an explicit candidate path.
 
 
-.. index:: candidate-path preference PREFERENCE name NAME dynamic
 .. clicmd:: [no] candidate-path preference PREFERENCE name NAME dynamic
 
    Delete or start a dynamic candidate path definition.
 
 
-.. index:: affinity {exclude-any|include-any|include-all} BITPATTERN
 .. clicmd:: [no] affinity {exclude-any|include-any|include-all} BITPATTERN
 
    Delete or specify an affinity constraint for a dynamic candidate path.
 
 
-.. index:: bandwidth BANDWIDTH [required]
 .. clicmd:: [no] bandwidth BANDWIDTH [required]
 
    Delete or specify a bandwidth constraint for a dynamic candidate path.
 
 
-.. index:: metric [bound] METRIC VALUE [required]
 .. clicmd:: [no] metric [bound] METRIC VALUE [required]
 
    Delete or specify a metric constraint for a dynamic candidate path.
@@ -198,7 +185,6 @@ Configuration Commands
     - bnc: Border Node Count metric
 
 
-.. index:: objective-function OBJFUN1 [required]
 .. clicmd:: [no] objective-function OBJFUN1 [required]
 
    Delete or specify a PCEP objective function constraint for a dynamic
@@ -224,7 +210,6 @@ Configuration Commands
      - msn: Minimize the number of Shared Nodes [RFC8800]
 
 
-.. index:: debug pathd pcep [basic|path|message|pceplib]
 .. clicmd:: [no] debug pathd pcep [basic|path|message|pceplib]
 
    Enable or disable debugging for the pcep module:
@@ -235,33 +220,28 @@ Configuration Commands
      - pceplib: Enable pceplib logging
 
 
-.. index:: pcep
 .. clicmd:: pcep
 
    Configure PCEP support.
 
 
-.. index:: cep-config NAME
 .. clicmd:: [no] pce-config NAME
 
    Define a shared PCE configuration that can be used in multiple PCE
    declarations.
 
 
-.. index:: pce NAME
 .. clicmd:: [no] pce NAME
 
    Define or delete a PCE definition.
 
 
-.. index:: config WORD
 .. clicmd:: config WORD
 
    Select a shared configuration. If not defined, the default
    configuration will be used.
 
 
-.. index:: address <ip A.B.C.D | ipv6 X:X::X:X> [port (1024-65535)]
 .. clicmd:: address <ip A.B.C.D | ipv6 X:X::X:X> [port (1024-65535)]
 
    Define the address and port of the PCE.
@@ -271,7 +251,6 @@ Configuration Commands
    This should be specified in the PCC peer definition.
 
 
-.. index:: source-address [ip A.B.C.D | ipv6 X:X::X:X] [port PORT]
 .. clicmd:: source-address [ip A.B.C.D | ipv6 X:X::X:X] [port PORT]
 
    Define the address and/or port of the PCC as seen by the PCE.
@@ -284,7 +263,6 @@ Configuration Commands
    configuration group.
 
 
-.. index:: tcp-md5-auth WORD
 .. clicmd:: tcp-md5-auth WORD
 
    Enable TCP MD5 security with the given secret.
@@ -293,7 +271,6 @@ Configuration Commands
    configuration group.
 
 
-.. index:: sr-draft07
 .. clicmd:: sr-draft07
 
    Specify if a PCE only support segment routing draft 7, this flag will limit
@@ -303,7 +280,6 @@ Configuration Commands
    configuration group.
 
 
-.. index:: pce-initiated
 .. clicmd:: pce-initiated
 
    Specify if PCE-initiated LSP should be allowed for this PCE.
@@ -312,7 +288,6 @@ Configuration Commands
    configuration group.
 
 
-.. index:: timer [keep-alive (1-63)] [min-peer-keep-alive (1-255)] [max-peer-keep-alive (1-255)] [dead-timer (4-255)] [min-peer-dead-timer (4-255)] [max-peer-dead-timer (4-255)] [pcep-request (1-120)] [session-timeout-interval (1-120)] [delegation-timeout (1-60)]
 .. clicmd:: timer [keep-alive (1-63)] [min-peer-keep-alive (1-255)] [max-peer-keep-alive (1-255)] [dead-timer (4-255)] [min-peer-dead-timer (4-255)] [max-peer-dead-timer (4-255)] [pcep-request (1-120)] [session-timeout-interval (1-120)] [delegation-timeout (1-60)]
 
    Specify the PCEP timers.
@@ -321,19 +296,16 @@ Configuration Commands
    configuration group.
 
 
-.. index:: pcc
 .. clicmd:: [no] pcc
 
    Disable or start the definition of a PCC.
 
 
-.. index:: msd (1-32)
 .. clicmd:: msd (1-32)
 
    Specify the maximum SID depth in a PCC definition.
 
 
-.. index:: peer WORD [precedence (1-255)]
 .. clicmd:: [no] peer WORD [precedence (1-255)]
 
    Specify a peer and its precedence in a PCC definition.
@@ -342,7 +314,6 @@ Configuration Commands
 Introspection Commands
 ----------------------
 
-.. index:: show sr-te policy [detail]
 .. clicmd:: show sr-te policy [detail]
 
    Display the segment routing policies.
@@ -368,38 +339,32 @@ The asterisk (*) marks the best, e.g. active, candidate path. Note that for segm
 retrieved via PCEP a random number based name is generated.
 
 
-.. index:: show debugging pathd
 .. clicmd:: show debugging pathd
 
    Display the current status of the pathd debugging.
 
 
-.. index:: show debugging pathd-pcep
 .. clicmd:: show debugging pathd-pcep
 
    Display the current status of the pcep module debugging.
 
 
-.. index:: show sr-te pcep counters
 .. clicmd:: show sr-te pcep counters
 
    Display the counters from pceplib.
 
 
-.. index:: show sr-te pcep pce-config [NAME]
 .. clicmd:: show sr-te pcep pce-config [NAME]
 
    Display a shared configuration. if no name is specified, the default
    configuration will be displayed.
 
 
-.. index:: show sr-te pcep pcc
 .. clicmd:: show sr-te pcep pcc
 
    Display PCC information.
 
 
-.. index:: show sr-te pcep session [NAME]
 .. clicmd:: show sr-te pcep session [NAME]
 
    Display the information of a PCEP session, if not name is specified all the
@@ -409,7 +374,6 @@ retrieved via PCEP a random number based name is generated.
 Utility Commands
 ----------------
 
-.. index:: clear sr-te pcep session [NAME]
 .. clicmd:: clear sr-te pcep session [NAME]
 
    Reset the pcep session by disconnecting from the PCE and performing the

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -220,6 +220,10 @@ end destination.
    | installedInternally | Do we think this group is installed? | Integer |
    +---------------------+--------------------------------------+---------+
 
+
+.. index::
+   pair: policy; PBR
+
 .. _pbr-policy:
 
 PBR Policy
@@ -229,7 +233,6 @@ After you have specified a PBR map, in order for it to be turned on, you must
 apply the PBR map to an interface.  This policy application to an interface
 causes the policy to be installed into the kernel.
 
-.. index:: pbr-policy
 .. clicmd:: pbr-policy NAME
 
    This command is available under interface sub-mode.  This turns
@@ -252,7 +255,7 @@ causes the policy to be installed into the kernel.
    | name   | Interface name             | String  |
    +--------+----------------------------+---------+
    | index  | Device Index               | Integer |
-   +--------+----------------------------+---------+
+   +--------+---------------------------+----------+
    | policy | PBR map for this interface | String  |
    +--------+----------------------------+---------+
    | valid  | Is the map well-formed?    | Boolean |
@@ -263,12 +266,10 @@ causes the policy to be installed into the kernel.
 PBR Debugs
 ===========
 
-.. index:: debug pbr
 .. clicmd:: debug pbr events|map|nht|zebra
 
    Debug pbr in pbrd daemon. You specify what types of debugs to turn on.
 
-.. index:: debug zebra pbr
 .. clicmd:: debug zebra pbr
 
    Debug pbr in zebra daemon.
@@ -281,12 +282,10 @@ PBR Details
 Under the covers a PBR map is translated into two separate constructs in the
 Linux kernel.
 
-.. index:: PBR Rules
 
 The PBR map specified creates a `ip rule ...` that is inserted into the Linux
 kernel that points to a table to use for forwarding once the rule matches.
 
-.. index:: PBR Tables
 
 The creation of a nexthop or nexthop-group is translated to a default route in a
 table with the nexthops specified as the nexthops for the default route.

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -255,7 +255,7 @@ causes the policy to be installed into the kernel.
    | name   | Interface name             | String  |
    +--------+----------------------------+---------+
    | index  | Device Index               | Integer |
-   +--------+---------------------------+----------+
+   +--------+----------------------------+---------+
    | policy | PBR map for this interface | String  |
    +--------+----------------------------+---------+
    | valid  | Is the map well-formed?    | Boolean |

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -45,7 +45,7 @@ listing of ECMP nexthops used to forward packets for when a pbr-map is matched.
    are used to are allowed here.  The syntax was intentionally kept the same as
    creating nexthops as you would for static routes.
 
-.. clicmd:: [no] pbr table range (10000-4294966272) (10000-4294966272)
+.. clicmd:: pbr table range (10000-4294966272) (10000-4294966272)
 
    Set or unset the range used to assign numeric table ID's to new
    nexthop-group tables. Existing tables will not be modified to fit in this

--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -56,7 +56,6 @@ Certain signals have special meanings to *pimd*.
 *pimd* invocation options. Common options that can be specified
 (:ref:`common-invocation-options`).
 
-.. index:: ip pim rp A.B.C.D A.B.C.D/M
 .. clicmd:: ip pim rp A.B.C.D A.B.C.D/M
 
    In order to use pim, it is necessary to configure a RP for join messages to
@@ -66,7 +65,6 @@ Certain signals have special meanings to *pimd*.
    prefix of group ranges covered. This command is vrf aware, to configure for
    a vrf, enter the vrf submode.
 
-.. index:: ip pim register-accept-list PLIST
 .. clicmd:: ip pim register-accept-list PLIST
 
    When pim receives a register packet the source of the packet will be compared
@@ -74,14 +72,12 @@ Certain signals have special meanings to *pimd*.
    processing continues.  If a deny is returned for the source address of the
    register packet a register stop message is sent to the source.
 
-.. index:: ip pim spt-switchover infinity-and-beyond
 .. clicmd:: ip pim spt-switchover infinity-and-beyond
 
    On the last hop router if it is desired to not switch over to the SPT tree.
    Configure this command. This command is vrf aware, to configure for a vrf,
    enter the vrf submode.
 
-.. index:: ip pim ecmp
 .. clicmd:: ip pim ecmp
 
    If pim has the a choice of ECMP nexthops for a particular RPF, pim will
@@ -89,7 +85,6 @@ Certain signals have special meanings to *pimd*.
    not specified then the first nexthop found will be used. This command is vrf
    aware, to configure for a vrf, enter the vrf submode.
 
-.. index:: ip pim ecmp rebalance
 .. clicmd:: ip pim ecmp rebalance
 
    If pim is using ECMP and an interface goes down, cause pim to rebalance all
@@ -98,14 +93,12 @@ Certain signals have special meanings to *pimd*.
    down. This command is vrf aware, to configure for a vrf, enter the vrf
    submode.
 
-.. index:: ip pim join-prune-interval (60-600)
 .. clicmd:: ip pim join-prune-interval (60-600)
 
    Modify the join/prune interval that pim uses to the new value. Time is
    specified in seconds. This command is vrf aware, to configure for a vrf,
    enter the vrf submode.
 
-.. index:: ip pim keep-alive-timer (31-60000)
 .. clicmd:: ip pim keep-alive-timer (31-60000)
 
    Modify the time out value for a S,G flow from 31-60000 seconds. 31 seconds
@@ -113,7 +106,6 @@ Certain signals have special meanings to *pimd*.
    flowing in better than 30 second chunks. This command is vrf aware, to
    configure for a vrf, enter the vrf submode.
 
-.. index:: ip pim packets (1-100)
 .. clicmd:: ip pim packets (1-100)
 
    When processing packets from a neighbor process the number of packets
@@ -122,14 +114,12 @@ Certain signals have special meanings to *pimd*.
    a large number of pim control packets flowing. This command is vrf aware, to
    configure for a vrf, enter the vrf submode.
 
-.. index:: ip pim register-suppress-time (5-60000)
 .. clicmd:: ip pim register-suppress-time (5-60000)
 
    Modify the time that pim will register suppress a FHR will send register
    notifications to the kernel. This command is vrf aware, to configure for a
    vrf, enter the vrf submode.
 
-.. index:: ip pim send-v6-secondary
 .. clicmd:: ip pim send-v6-secondary
 
    When sending pim hello packets tell pim to send any v6 secondary addresses
@@ -137,14 +127,12 @@ Certain signals have special meanings to *pimd*.
    in it's decision for RPF lookup. This command is vrf aware, to configure for
    a vrf, enter the vrf submode.
 
-.. index:: ip pim ssm prefix-list WORD
 .. clicmd:: ip pim ssm prefix-list WORD
 
    Specify a range of group addresses via a prefix-list that forces pim to
    never do SM over. This command is vrf aware, to configure for a vrf, enter
    the vrf submode.
 
-.. index:: ip multicast rpf-lookup-mode WORD
 .. clicmd:: ip multicast rpf-lookup-mode WORD
 
    Modify how PIM does RPF lookups in the zebra routing table.  You can use
@@ -166,31 +154,26 @@ Certain signals have special meanings to *pimd*.
    urib-only
       Lookup in the Unicast Rib only.
 
-.. index:: ip msdp mesh-group [WORD]
 .. clicmd:: [no] ip msdp mesh-group [WORD]
 
    Create or Delete a multicast source discovery protocol mesh-group using
    [WORD] as the group name.
 
-.. index:: ip msdp mesh-group WORD member A.B.C.D
 .. clicmd:: [no] ip msdp mesh-group WORD member A.B.C.D
 
    Attach or Delete A.B.C.D to the MSDP mesh group WORD specified.
 
-.. index:: ip msdp mesh-group WORD source A.B.C.D
 .. clicmd:: [no] ip msdp mesh-group WORD source A.B.C.D
 
    For the address specified A.B.C.D use that as the source address for
    mesh group packets being sent.
 
-.. index:: ip igmp generate-query-once [version (2-3)]
 .. clicmd:: ip igmp generate-query-once [version (2-3)]
 
    Generate IGMP query (v2/v3) on user requirement. This will not depend on
    the existing IGMP general query timer.If no version is provided in the cli,
    it will be considered as default v2 query.This is a hidden command.
 
-.. index:: ip igmp watermark-warn (10-60000)
 .. clicmd:: [no] ip igmp watermark-warn (10-60000)
 
    Configure watermark warning generation for an igmp group limit. Generates
@@ -207,39 +190,33 @@ PIM interface commands allow you to configure an interface as either a Receiver
 or a interface that you would like to form pim neighbors on. If the interface
 is in a vrf, enter the interface command with the vrf keyword at the end.
 
-.. index:: ip pim active-active
 .. clicmd:: ip pim active-active
 
    Turn on pim active-active configuration for a Vxlan interface.  This
    command will not do anything if you do not have the underlying ability
    of a mlag implementation.
 
-.. index:: ip pim bsm
 .. clicmd:: ip pim bsm
 
    Tell pim that we would like to use this interface to process bootstrap
    messages. This is enabled by default. 'no' form of this command is used to
    restrict bsm messages on this interface.
 
-.. index:: ip pim unicast-bsm
 .. clicmd:: ip pim unicast-bsm
 
    Tell pim that we would like to allow interface to process unicast bootstrap
    messages. This is enabled by default. 'no' form of this command is used to
    restrict processing of unicast bsm messages on this interface.
 
-.. index:: ip pim drpriority (1-4294967295)
 .. clicmd:: ip pim drpriority (1-4294967295)
 
    Set the DR Priority for the interface. This command is useful to allow the
    user to influence what node becomes the DR for a lan segment.
 
-.. index:: ip pim hello (1-180) (1-180)
 .. clicmd:: ip pim hello (1-180) (1-180)
 
    Set the pim hello and hold interval for a interface.
 
-.. index:: ip pim
 .. clicmd:: ip pim
 
    Tell pim that we would like to use this interface to form pim neighbors
@@ -247,61 +224,51 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    reports on the interface. Refer to the next `ip igmp` command for IGMP
    management.
 
-.. index:: ip pim use-source A.B.C.D
 .. clicmd:: [no] ip pim use-source A.B.C.D
 
    If you have multiple addresses configured on a particular interface
    and would like pim to use a specific source address associated with
    that interface.
 
-.. index:: ip igmp
 .. clicmd:: ip igmp
 
    Tell pim to receive IGMP reports and Query on this interface. The default
    version is v3. This command is useful on a LHR.
 
-.. index:: ip igmp join A.B.C.D [A.B.C.D]
 .. clicmd:: ip igmp join A.B.C.D [A.B.C.D]
 
    Join multicast group or source-group on an interface.
 
-.. index:: ip igmp query-interval (1-1800)
 .. clicmd:: ip igmp query-interval (1-1800)
 
    Set the IGMP query interval that PIM will use.
 
-.. index:: ip igmp query-max-response-time (10-250)
 .. clicmd:: ip igmp query-max-response-time (10-250)
 
    Set the IGMP query response timeout value. If an report is not returned in
    the specified time we will assume the S,G or \*,G has timed out.
 
-.. index:: ip igmp version (2-3)
 .. clicmd:: ip igmp version (2-3)
 
    Set the IGMP version used on this interface. The default value is 3.
 
-.. index:: ip multicast boundary oil WORD
 .. clicmd:: ip multicast boundary oil WORD
 
    Set a pim multicast boundary, based upon the WORD prefix-list. If a pim join
    or IGMP report is received on this interface and the Group is denied by the
    prefix-list, PIM will ignore the join or report.
 
-.. index:: ip igmp last-member-query-count (1-7)
 .. clicmd:: ip igmp last-member-query-count (1-7)
 
    Set the IGMP last member query count. The default value is 2. 'no' form of
    this command is used to to configure back to the default value.
 
-.. index:: ip igmp last-member-query-interval (1-255)
 .. clicmd:: ip igmp last-member-query-interval (1-255)
 
    Set the IGMP last member query interval in deciseconds. The default value is
    10 deciseconds. 'no' form of this command is used to to configure back to the
    default value.
 
-.. index:: ip mroute INTERFACE A.B.C.D [A.B.C.D]
 .. clicmd:: ip mroute INTERFACE A.B.C.D [A.B.C.D]
 
    Set a static multicast route for a traffic coming on the current interface to
@@ -326,13 +293,11 @@ into the kernel *or* for normal rib processing. As such it is
 possible to create weird states with these commands. Use with
 caution. Most of the time this will not be necessary.
 
-.. index:: ip mroute A.B.C.D/M A.B.C.D (1-255)
 .. clicmd:: ip mroute A.B.C.D/M A.B.C.D (1-255)
 
    Insert into the Multicast Rib Route A.B.C.D/M with specified nexthop. The
    distance can be specified as well if desired.
 
-.. index:: ip mroute A.B.C.D/M INTERFACE (1-255)
 .. clicmd:: ip mroute A.B.C.D/M INTERFACE (1-255)
 
    Insert into the Multicast Rib Route A.B.C.D/M using the specified INTERFACE.
@@ -343,33 +308,27 @@ caution. Most of the time this will not be necessary.
 Multicast Source Discovery Protocol (MSDP) Configuration
 ========================================================
 
-.. index:: ip msdp mesh-group [WORD] member A.B.C.D
 .. clicmd:: ip msdp mesh-group [WORD] member A.B.C.D
 
    Include a MSDP peer as a member of a MSDP mesh-group.
 
-.. index:: ip msdp mesh-group [WORD] source A.B.C.D
 .. clicmd:: ip msdp mesh-group [WORD] source A.B.C.D
 
    Create a MSDP mesh-group, defining a name for it and an associated local source
    address.
 
-.. index:: ip msdp peer A.B.C.D source A.B.C.D
 .. clicmd:: ip msdp peer A.B.C.D source A.B.C.D
 
    Establish a MSDP connection with a peer.
 
-.. index:: ip msdp mesh-group [WORD] member A.B.C.D
 .. clicmd:: no ip msdp mesh-group [WORD] member A.B.C.D
 
    Remove a MSDP peer member from a MSDP mesh-group.
 
-.. index:: ip msdp mesh-group [WORD] source A.B.C.D
 .. clicmd:: no ip msdp mesh-group [WORD] source A.B.C.D
 
    Delete a MSDP mesh-group.
 
-.. index:: ip msdp peer A.B.C.D
 .. clicmd:: no ip msdp peer A.B.C.D
 
    Delete a MSDP peer connection.
@@ -385,48 +344,39 @@ vrf is specified then the default vrf is assumed. Finally the special keyword
 'all' allows you to look at all vrfs for the command. Naming a vrf 'all' will
 cause great confusion.
 
-.. index:: show ip igmp interface
 .. clicmd:: show ip igmp interface
 
    Display IGMP interface information.
 
-.. index:: show ip igmp [vrf NAME] join [json]
 .. clicmd:: show ip igmp [vrf NAME] join [json]
 
    Display IGMP static join information for a specific vrf.
    If "vrf all" is provided, it displays information for all the vrfs present.
 
-.. index:: show ip igmp groups
 .. clicmd:: show ip igmp groups
 
    Display IGMP groups information.
 
-.. index:: show ip igmp groups retransmissions
 .. clicmd:: show ip igmp groups retransmissions
 
    Display IGMP group retransmission information.
 
-.. index:: show ip igmp sources
 .. clicmd:: show ip igmp sources
 
    Display IGMP sources information.
 
-.. index:: show ip igmp sources retransmissions
 .. clicmd:: show ip igmp sources retransmissions
 
    Display IGMP source retransmission information.
 
-.. index:: show ip igmp statistics
 .. clicmd:: show ip igmp statistics
 
    Display IGMP statistics information.
 
-.. index:: show ip multicast
 .. clicmd:: show ip multicast
 
    Display various information about the interfaces used in this pim instance.
 
-.. index:: show ip mroute [vrf NAME] [A.B.C.D [A.B.C.D]] [fill] [json]
 .. clicmd:: show ip mroute [vrf NAME] [A.B.C.D [A.B.C.D]] [fill] [json]
 
    Display information about installed into the kernel S,G mroutes.  If
@@ -435,191 +385,157 @@ cause great confusion.
    Source Group.  The keyword `fill` says to fill in all assumed data
    for test/data gathering purposes.
 
-.. index:: show ip mroute [vrf NAME] count [json]
 .. clicmd:: show ip mroute [vrf NAME] count [json]
 
    Display information about installed into the kernel S,G mroutes and in
    addition display data about packet flow for the mroutes for a specific
    vrf.
 
-.. index:: show ip mroute vrf all count [json]
 .. clicmd:: show ip mroute vrf all count [json]
 
    Display information about installed into the kernel S,G mroutes and in
    addition display data about packet flow for the mroutes for all vrfs.
 
-.. index:: show ip mroute [vrf NAME] summary [json]
 .. clicmd:: show ip mroute [vrf NAME] summary [json]
 
    Display total number of S,G mroutes and number of S,G mroutes installed
    into the kernel for a specific vrf.
 
-.. index:: show ip mroute vrf all summary [json]
 .. clicmd:: show ip mroute vrf all summary [json]
 
    Display total number of S,G mroutes and number of S,G mroutes
    installed into the kernel for all vrfs.
 
-.. index:: show ip msdp mesh-group
 .. clicmd:: show ip msdp mesh-group
 
    Display the configured mesh-groups, the local address associated with each
    mesh-group, the peer members included in each mesh-group, and their status.
 
-.. index:: show ip msdp peer
 .. clicmd:: show ip msdp peer
 
    Display information about the MSDP peers. That includes the peer address,
    the local address used to establish the connection to the peer, the
    connection status, and the number of active sources.
 
-.. index:: show ip pim assert
 .. clicmd:: show ip pim assert
 
    Display information about asserts in the PIM system for S,G mroutes.
 
-.. index:: show ip pim assert-internal
 .. clicmd:: show ip pim assert-internal
 
    Display internal assert state for S,G mroutes
 
-.. index:: show ip pim assert-metric
 .. clicmd:: show ip pim assert-metric
 
    Display metric information about assert state for S,G mroutes
 
-.. index:: show ip pim assert-winner-metric
 .. clicmd:: show ip pim assert-winner-metric
 
    Display winner metric for assert state for S,G mroutes
 
-.. index:: show ip pim group-type
 .. clicmd:: show ip pim group-type
 
    Display SSM group ranges.
 
-.. index:: show ip pim interface
 .. clicmd:: show ip pim interface
 
    Display information about interfaces PIM is using.
 
-.. index:: show ip pim mlag [vrf NAME] interface [detail|WORD] [json]
 .. clicmd:: show ip pim mlag [vrf NAME|all] interface [detail|WORD] [json]
 
    Display mlag interface information.
 
-.. index:: show ip pim [vrf NAME] join [A.B.C.D [A.B.C.D]] [json]
 .. clicmd:: show ip pim join
 
    Display information about PIM joins received.  If one address is specified
    then we assume it is the Group we are interested in displaying data on.
    If the second address is specified then it is Source Group.
 
-.. index:: show ip pim local-membership
 .. clicmd:: show ip pim local-membership
 
    Display information about PIM interface local-membership.
 
-.. index:: show ip pim mlag summary [json]
 .. clicmd:: show ip pim mlag summary [json]
 
    Display mlag information state that PIM is keeping track of.
 
-.. index:: show ip pim neighbor
 .. clicmd:: show ip pim neighbor
 
    Display information about PIM neighbors.
 
-.. index:: show ip pim nexthop
 .. clicmd:: show ip pim nexthop
 
    Display information about pim nexthops that are being used.
 
-.. index:: show ip pim nexthop-lookup
 .. clicmd:: show ip pim nexthop-lookup
 
    Display information about a S,G pair and how the RPF would be chosen. This
    is especially useful if there are ECMP's available from the RPF lookup.
 
-.. index:: show ip pim rp-info
 .. clicmd:: show ip pim rp-info
 
    Display information about RP's that are configured on this router.
 
-.. index:: show ip pim rpf
 .. clicmd:: show ip pim rpf
 
    Display information about currently being used S,G's and their RPF lookup
    information. Additionally display some statistics about what has been
    happening on the router.
 
-.. index:: show ip pim secondary
 .. clicmd:: show ip pim secondary
 
    Display information about an interface and all the secondary addresses
    associated with it.
 
-.. index:: show ip pim state
 .. clicmd:: show ip pim state
 
    Display information about known S,G's and incoming interface as well as the
    OIL and how they were chosen.
 
-.. index:: show ip pim [vrf NAME] upstream [A.B.C.D [A.B.C.D]] [json]
 .. clicmd:: show ip pim upstream
 
    Display upstream information about a S,G mroute.  Allow the user to
    specify sub Source and Groups that we are only interested in.
 
-.. index:: show ip pim upstream-join-desired
 .. clicmd:: show ip pim upstream-join-desired
 
    Display upstream information for S,G's and if we desire to
    join the multicast tree
 
-.. index:: show ip pim upstream-rpf
 .. clicmd:: show ip pim upstream-rpf
 
    Display upstream information for S,G's and the RPF data associated with them.
 
-.. index:: show ip pim [vrf NAME] mlag upstream [A.B.C.D [A.B.C.D]] [json]
 .. clicmd:: show ip pim mlag upstream
 
    Display upstream entries that are synced across MLAG switches.
    Allow the user to specify sub Source and Groups address filters.
 
-.. index:: show ip pim mlag summary
 .. clicmd:: show ip pim mlag summary
 
    Display PIM MLAG (multi-chassis link aggregation) session status and
    control message statistics.
 
-.. index:: show ip pim bsr
 .. clicmd:: show ip pim bsr
 
    Display current bsr, its uptime and last received bsm age.
 
-.. index:: show ip pim bsrp-info
 .. clicmd:: show ip pim bsrp-info
 
    Display group-to-rp mappings received from E-BSR.
 
-.. index:: show ip pim bsm-database
 .. clicmd:: show ip pim bsm-database
 
    Display all fragments ofstored bootstrap message in user readable format.
 
-.. index:: mtrace A.B.C.D [A.B.C.D]
 .. clicmd:: mtrace A.B.C.D [A.B.C.D]
 
    Display multicast traceroute towards source, optionally for particular group.
 
-.. index:: show ip multicast count [vrf NAME] [json]
 .. clicmd:: show ip multicast count [vrf NAME] [json]
 
    Display multicast data packets count per interface for a vrf.
 
-.. index:: show ip multicast count vrf all [json]
 .. clicmd:: show ip multicast count vrf all [json]
 
    Display multicast data packets count per interface for all vrf.
@@ -639,56 +555,46 @@ configure CLI mode. If you specify debug commands in the configuration cli
 mode, the debug commands can be persistent across restarts of the FRR pimd if
 the config was written out.
 
-.. index:: debug igmp
 .. clicmd:: debug igmp
 
    This turns on debugging for IGMP protocol activity.
 
-.. index:: debug mtrace
 .. clicmd:: debug mtrace
 
    This turns on debugging for mtrace protocol activity.
 
-.. index:: debug mroute
 .. clicmd:: debug mroute
 
    This turns on debugging for PIM interaction with kernel MFC cache.
 
-.. index:: debug pim events
 .. clicmd:: debug pim events
 
    This turns on debugging for PIM system events. Especially timers.
 
-.. index:: debug pim nht
 .. clicmd:: debug pim nht
 
    This turns on debugging for PIM nexthop tracking. It will display
    information about RPF lookups and information about when a nexthop changes.
 
-.. index:: debug pim packet-dump
 .. clicmd:: debug pim packet-dump
 
    This turns on an extraordinary amount of data. Each pim packet sent and
    received is dumped for debugging purposes. This should be considered a
    developer only command.
 
-.. index:: debug pim packets
 .. clicmd:: debug pim packets
 
    This turns on information about packet generation for sending and about
    packet handling from a received packet.
 
-.. index:: debug pim trace
 .. clicmd:: debug pim trace
 
    This traces pim code and how it is running.
 
-.. index:: debug pim bsm
 .. clicmd:: debug pim bsm
 
    This turns on debugging for BSR message processing.
 
-.. index:: debug pim zebra
 .. clicmd:: debug pim zebra
 
    This gathers data about events from zebra that come up through the ZAPI.
@@ -697,39 +603,32 @@ PIM Clear Commands
 ==================
 Clear commands reset various variables.
 
-.. index:: clear ip interfaces
 .. clicmd:: clear ip interfaces
 
    Reset interfaces.
 
-.. index:: clear ip igmp interfaces
 .. clicmd:: clear ip igmp interfaces
 
    Reset IGMP interfaces.
 
-.. index:: clear ip mroute
 .. clicmd:: clear ip mroute
 
    Reset multicast routes.
 
-.. index:: clear ip mroute [vrf NAME] count
 .. clicmd:: clear ip mroute [vrf NAME] count
 
    When this command is issued, reset the counts of data shown for
    packet count, byte count and wrong interface to 0 and start count
    up from this spot.
 
-.. index:: clear ip pim interfaces
 .. clicmd:: clear ip pim interfaces
 
    Reset PIM interfaces.
 
-.. index:: clear ip pim oil
 .. clicmd:: clear ip pim oil
 
    Rescan PIM OIL (output interface list).
 
-.. index:: clear ip pim [vrf NAME] bsr-data
 .. clicmd:: clear ip pim [vrf NAME] bsr-data
 
    This command will clear the BSM scope data struct. This command also

--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -214,11 +214,6 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    command will not do anything if you do not have the underlying ability
    of a mlag implementation.
 
-.. index:: ip pim bfd
-.. clicmd:: ip pim bfd
-
-   Turns on BFD support for PIM for this interface.
-
 .. index:: ip pim bsm
 .. clicmd:: ip pim bsm
 
@@ -312,6 +307,12 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    Set a static multicast route for a traffic coming on the current interface to
    be forwarded on the given interface if the traffic matches the group address
    and optionally the source address.
+
+
+.. seealso::
+
+   :ref:`bfd-pim-peer-config`
+
 
 .. _pim-multicast-rib-insertion:
 
@@ -608,11 +609,6 @@ cause great confusion.
 
    Display all fragments ofstored bootstrap message in user readable format.
 
-.. index:: show ip rpf
-.. clicmd:: show ip rpf
-
-   Display the multicast RIB created in zebra.
-
 .. index:: mtrace A.B.C.D [A.B.C.D]
 .. clicmd:: mtrace A.B.C.D [A.B.C.D]
 
@@ -627,6 +623,12 @@ cause great confusion.
 .. clicmd:: show ip multicast count vrf all [json]
 
    Display multicast data packets count per interface for all vrf.
+
+
+.. seealso::
+
+   :ref:`multicast-rib-commands`
+
 
 PIM Debug Commands
 ==================

--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -489,7 +489,7 @@ cause great confusion.
    Display information about known S,G's and incoming interface as well as the
    OIL and how they were chosen.
 
-.. clicmd:: show ip pim upstream
+.. clicmd:: show ip pim [vrf NAME] upstream [A.B.C.D [A.B.C.D]] [json]
 
    Display upstream information about a S,G mroute.  Allow the user to
    specify sub Source and Groups that we are only interested in.
@@ -503,7 +503,7 @@ cause great confusion.
 
    Display upstream information for S,G's and the RPF data associated with them.
 
-.. clicmd:: show ip pim mlag upstream
+.. clicmd:: show ip pim [vrf NAME] mlag upstream [A.B.C.D [A.B.C.D]] [json]
 
    Display upstream entries that are synced across MLAG switches.
    Allow the user to specify sub Source and Groups address filters.

--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -154,16 +154,16 @@ Certain signals have special meanings to *pimd*.
    urib-only
       Lookup in the Unicast Rib only.
 
-.. clicmd:: [no] ip msdp mesh-group [WORD]
+.. clicmd:: ip msdp mesh-group [WORD]
 
    Create or Delete a multicast source discovery protocol mesh-group using
    [WORD] as the group name.
 
-.. clicmd:: [no] ip msdp mesh-group WORD member A.B.C.D
+.. clicmd:: ip msdp mesh-group WORD member A.B.C.D
 
    Attach or Delete A.B.C.D to the MSDP mesh group WORD specified.
 
-.. clicmd:: [no] ip msdp mesh-group WORD source A.B.C.D
+.. clicmd:: ip msdp mesh-group WORD source A.B.C.D
 
    For the address specified A.B.C.D use that as the source address for
    mesh group packets being sent.
@@ -174,7 +174,7 @@ Certain signals have special meanings to *pimd*.
    the existing IGMP general query timer.If no version is provided in the cli,
    it will be considered as default v2 query.This is a hidden command.
 
-.. clicmd:: [no] ip igmp watermark-warn (10-60000)
+.. clicmd:: ip igmp watermark-warn (10-60000)
 
    Configure watermark warning generation for an igmp group limit. Generates
    warning once the configured group limit is reached while adding new groups.
@@ -224,7 +224,7 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    reports on the interface. Refer to the next `ip igmp` command for IGMP
    management.
 
-.. clicmd:: [no] ip pim use-source A.B.C.D
+.. clicmd:: ip pim use-source A.B.C.D
 
    If you have multiple addresses configured on a particular interface
    and would like pim to use a specific source address associated with
@@ -321,15 +321,12 @@ Multicast Source Discovery Protocol (MSDP) Configuration
 
    Establish a MSDP connection with a peer.
 
-.. clicmd:: no ip msdp mesh-group [WORD] member A.B.C.D
 
    Remove a MSDP peer member from a MSDP mesh-group.
 
-.. clicmd:: no ip msdp mesh-group [WORD] source A.B.C.D
 
    Delete a MSDP mesh-group.
 
-.. clicmd:: no ip msdp peer A.B.C.D
 
    Delete a MSDP peer connection.
 

--- a/doc/user/ripd.rst
+++ b/doc/user/ripd.rst
@@ -93,13 +93,11 @@ RIP Configuration
    `no router rip` command. RIP must be enabled before carrying out any of the
    RIP commands.
 
-.. clicmd:: no router rip
 
    Disable RIP.
 
 .. clicmd:: network NETWORK
 
-.. clicmd:: no network NETWORK
 
    Set the RIP enable interface by NETWORK. The interfaces which have addresses
    matching with NETWORK are enabled.
@@ -112,7 +110,6 @@ RIP Configuration
 
 .. clicmd:: network IFNAME
 
-.. clicmd:: no network IFNAME
 
    Set a RIP enabled interface by IFNAME. Both the sending and
    receiving of RIP packets will be enabled on the port specified in the
@@ -121,7 +118,6 @@ RIP Configuration
 
 .. clicmd:: neighbor A.B.C.D
 
-.. clicmd:: no neighbor A.B.C.D
 
    Specify RIP neighbor. When a neighbor doesn't understand multicast, this
    command is used to specify neighbors. In some cases, not all routers will be
@@ -146,7 +142,6 @@ RIP Configuration
 
 .. clicmd:: passive-interface (IFNAME|default)
 
-.. clicmd:: no passive-interface IFNAME
 
    This command sets the specified interface to passive mode. On passive mode
    interface, all receiving packets are processed as normal and ripd does not
@@ -158,7 +153,6 @@ RIP Configuration
 
 .. clicmd:: ip split-horizon
 
-.. clicmd:: no ip split-horizon
 
    Control split-horizon on the interface. Default is `ip split-horizon`. If
    you don't perform split-horizon on the interface, please specify `no ip
@@ -189,10 +183,6 @@ discussion on the security implications of RIPv1 see :ref:`rip-authentication`.
    :ref:`rip-authentication`. This may become the default in a future release.
 
    Default: Send Version 2, and accept either version.
-
-.. clicmd:: no version
-
-   Reset the global version setting back to the default.
 
 .. clicmd:: ip rip send version VERSION
 
@@ -232,7 +222,6 @@ If you want to specify RIP only static routes:
 
 .. clicmd:: route A.B.C.D/M
 
-.. clicmd:: no route A.B.C.D/M
 
    This command is specific to FRR. The `route` command makes a static route
    only inside RIP. This command should be used only by advanced users who are
@@ -290,7 +279,6 @@ received. Redistributed routes' metric is set to 1.
 
 .. clicmd:: default-metric (1-16)
 
-.. clicmd:: no default-metric (1-16)
 
    This command modifies the default metric value for redistributed routes.
    The default value is 1. This command does not affect connected route even if
@@ -312,20 +300,17 @@ Distance value is used in zebra daemon. Default RIP distance is 120.
 
 .. clicmd:: distance (1-255)
 
-.. clicmd:: no distance (1-255)
 
    Set default RIP distance to specified value.
 
 .. clicmd:: distance (1-255) A.B.C.D/M
 
-.. clicmd:: no distance (1-255) A.B.C.D/M
 
    Set default RIP distance to specified value when the route's source IP
    address matches the specified prefix.
 
 .. clicmd:: distance (1-255) A.B.C.D/M ACCESS-LIST
 
-.. clicmd:: no distance (1-255) A.B.C.D/M ACCESS-LIST
 
    Set default RIP distance to specified value when the route's source IP
    address matches the specified prefix and the specified access-list.
@@ -427,26 +412,22 @@ To prevent such unauthenticated querying of routes disable RIPv1,
 
 .. clicmd:: ip rip authentication mode md5
 
-.. clicmd:: no ip rip authentication mode md5
 
    Set the interface with RIPv2 MD5 authentication.
 
 .. clicmd:: ip rip authentication mode text
 
-.. clicmd:: no ip rip authentication mode text
 
    Set the interface with RIPv2 simple password authentication.
 
 .. clicmd:: ip rip authentication string STRING
 
-.. clicmd:: no ip rip authentication string STRING
 
    RIP version 2 has simple text authentication. This command sets
    authentication string. The string must be shorter than 16 characters.
 
 .. clicmd:: ip rip authentication key-chain KEY-CHAIN
 
-.. clicmd:: no ip rip authentication key-chain KEY-CHAIN
 
    Specify Keyed MD5 chain.
 
@@ -490,10 +471,6 @@ RIP Timers
    The ``timers basic`` command allows the the default values of the timers
    listed above to be changed.
 
-.. clicmd:: no timers basic
-
-   The `no timers basic` command will reset the timers to the default settings
-   listed above.
 
 .. _show-rip-information:
 

--- a/doc/user/ripd.rst
+++ b/doc/user/ripd.rst
@@ -87,22 +87,18 @@ multipath routing.
 RIP Configuration
 =================
 
-.. index:: router rip
 .. clicmd:: router rip
 
    The `router rip` command is necessary to enable RIP. To disable RIP, use the
    `no router rip` command. RIP must be enabled before carrying out any of the
    RIP commands.
 
-.. index:: router rip
 .. clicmd:: no router rip
 
    Disable RIP.
 
-.. index:: network NETWORK
 .. clicmd:: network NETWORK
 
-.. index:: network NETWORK
 .. clicmd:: no network NETWORK
 
    Set the RIP enable interface by NETWORK. The interfaces which have addresses
@@ -114,10 +110,8 @@ RIP Configuration
    10.0.0.0 to 10.0.0.255 being enabled for RIP. The `no network` command will
    disable RIP for the specified network.
 
-.. index:: network IFNAME
 .. clicmd:: network IFNAME
 
-.. index:: network IFNAME
 .. clicmd:: no network IFNAME
 
    Set a RIP enabled interface by IFNAME. Both the sending and
@@ -125,10 +119,8 @@ RIP Configuration
    `network ifname` command. The `no network ifname` command will disable
    RIP on the specified interface.
 
-.. index:: neighbor A.B.C.D
 .. clicmd:: neighbor A.B.C.D
 
-.. index:: neighbor A.B.C.D
 .. clicmd:: no neighbor A.B.C.D
 
    Specify RIP neighbor. When a neighbor doesn't understand multicast, this
@@ -152,10 +144,8 @@ RIP Configuration
       !
 
 
-.. index:: passive-interface (IFNAME|default)
 .. clicmd:: passive-interface (IFNAME|default)
 
-.. index:: passive-interface IFNAME
 .. clicmd:: no passive-interface IFNAME
 
    This command sets the specified interface to passive mode. On passive mode
@@ -166,10 +156,8 @@ RIP Configuration
 
    The default is to be passive on all interfaces.
 
-.. index:: ip split-horizon
 .. clicmd:: ip split-horizon
 
-.. index:: ip split-horizon
 .. clicmd:: no ip split-horizon
 
    Control split-horizon on the interface. Default is `ip split-horizon`. If
@@ -192,7 +180,6 @@ is enabled then RIP will reply to REQUEST packets, sending the state of its RIP
 routing table to any remote routers that ask on demand. For a more detailed
 discussion on the security implications of RIPv1 see :ref:`rip-authentication`.
 
-.. index:: version VERSION
 .. clicmd:: version VERSION
 
    Set RIP version to accept for reads and send. ``VERSION`` can be either 1 or
@@ -203,12 +190,10 @@ discussion on the security implications of RIPv1 see :ref:`rip-authentication`.
 
    Default: Send Version 2, and accept either version.
 
-.. index:: version
 .. clicmd:: no version
 
    Reset the global version setting back to the default.
 
-.. index:: ip rip send version VERSION
 .. clicmd:: ip rip send version VERSION
 
    VERSION can be ``1``, ``2``, or ``1 2``.
@@ -221,7 +206,6 @@ discussion on the security implications of RIPv1 see :ref:`rip-authentication`.
 
    Default: Send packets according to the global version (version 2)
 
-.. index:: ip rip receive version VERSION
 .. clicmd:: ip rip receive version VERSION
 
    VERSION can be ``1``, ``2``, or ``1 2``.
@@ -238,20 +222,16 @@ discussion on the security implications of RIPv1 see :ref:`rip-authentication`.
 How to Announce RIP route
 =========================
 
-.. index:: redistribute <babel|bgp|connected|eigrp|isis|kernel|openfabric|ospf|sharp|static|table> [metric (0-16)] [route-map WORD]
 .. clicmd:: redistribute <babel|bgp|connected|eigrp|isis|kernel|openfabric|ospf|sharp|static|table> [metric (0-16)] [route-map WORD]
 
    Redistribute routes from other sources into RIP.
 
 If you want to specify RIP only static routes:
 
-.. index:: default-information originate
 .. clicmd:: default-information originate
 
-.. index:: route A.B.C.D/M
 .. clicmd:: route A.B.C.D/M
 
-.. index:: route A.B.C.D/M
 .. clicmd:: no route A.B.C.D/M
 
    This command is specific to FRR. The `route` command makes a static route
@@ -267,7 +247,6 @@ Filtering RIP Routes
 
 RIP routes can be filtered by a distribute-list.
 
-.. index:: distribute-list ACCESS_LIST DIRECT IFNAME
 .. clicmd:: distribute-list ACCESS_LIST DIRECT IFNAME
 
    You can apply access lists to the interface with a `distribute-list` command.
@@ -293,7 +272,6 @@ RIP routes can be filtered by a distribute-list.
 
    `distribute-list` can be applied to both incoming and outgoing data.
 
-.. index:: distribute-list prefix PREFIX_LIST (in|out) IFNAME
 .. clicmd:: distribute-list prefix PREFIX_LIST (in|out) IFNAME
 
    You can apply prefix lists to the interface with a `distribute-list`
@@ -310,10 +288,8 @@ RIP metric is a value for distance for the network. Usually
 *ripd* increment the metric when the network information is
 received. Redistributed routes' metric is set to 1.
 
-.. index:: default-metric (1-16)
 .. clicmd:: default-metric (1-16)
 
-.. index:: default-metric (1-16)
 .. clicmd:: no default-metric (1-16)
 
    This command modifies the default metric value for redistributed routes.
@@ -322,10 +298,8 @@ received. Redistributed routes' metric is set to 1.
    metric value, please use ``redistribute connected metric`` or *route-map*.
    *offset-list* also affects connected routes.
 
-.. index:: offset-list ACCESS-LIST (in|out)
 .. clicmd:: offset-list ACCESS-LIST (in|out)
 
-.. index:: offset-list ACCESS-LIST (in|out) IFNAME
 .. clicmd:: offset-list ACCESS-LIST (in|out) IFNAME
 
 
@@ -336,27 +310,21 @@ RIP distance
 
 Distance value is used in zebra daemon. Default RIP distance is 120.
 
-.. index:: RIP - distance (1-255)
 .. clicmd:: distance (1-255)
 
-.. index:: RIP - distance (1-255)
 .. clicmd:: no distance (1-255)
 
    Set default RIP distance to specified value.
 
-.. index:: distance (1-255) A.B.C.D/M
 .. clicmd:: distance (1-255) A.B.C.D/M
 
-.. index:: distance (1-255) A.B.C.D/M
 .. clicmd:: no distance (1-255) A.B.C.D/M
 
    Set default RIP distance to specified value when the route's source IP
    address matches the specified prefix.
 
-.. index:: distance (1-255) A.B.C.D/M ACCESS-LIST
 .. clicmd:: distance (1-255) A.B.C.D/M ACCESS-LIST
 
-.. index:: distance (1-255) A.B.C.D/M ACCESS-LIST
 .. clicmd:: no distance (1-255) A.B.C.D/M ACCESS-LIST
 
    Set default RIP distance to specified value when the route's source IP
@@ -388,7 +356,6 @@ it may be changed at future.
 Route-map statement (:ref:`route-map`) is needed to use route-map
 functionality.
 
-.. index:: match interface WORD
 .. clicmd:: match interface WORD
 
    This command match to incoming interface. Notation of this match is
@@ -400,37 +367,30 @@ functionality.
    sends to different interfaces must be different. Maybe it'd be better to
    made new matches - say "match interface-out NAME" or something like that.
 
-.. index:: match ip address WORD
 .. clicmd:: match ip address WORD
 
-.. index:: match ip address prefix-list WORD
 .. clicmd:: match ip address prefix-list WORD
 
    Match if route destination is permitted by access-list.
 
-.. index:: match ip next-hop WORD
 .. clicmd:: match ip next-hop WORD
 
-.. index:: match ip next-hop prefix-list WORD
 .. clicmd:: match ip next-hop prefix-list WORD
 
    Match if route next-hop (meaning next-hop listed in the rip route-table as
    displayed by "show ip rip") is permitted by access-list.
 
-.. index:: match metric (0-4294967295)
 .. clicmd:: match metric (0-4294967295)
 
    This command match to the metric value of RIP updates. For other protocol
    compatibility metric range is shown as (0-4294967295). But for RIP protocol
    only the value range (0-16) make sense.
 
-.. index:: set ip next-hop A.B.C.D
 .. clicmd:: set ip next-hop A.B.C.D
 
    This command set next hop value in RIPv2 protocol. This command does not
    affect RIPv1 because there is no next hop field in the packet.
 
-.. index:: set metric (0-4294967295)
 .. clicmd:: set metric (0-4294967295)
 
    Set a metric for matched route when sending announcement. The metric value
@@ -465,35 +425,27 @@ on the internet, via RIPv1.
 To prevent such unauthenticated querying of routes disable RIPv1,
 :ref:`rip-version-control`.
 
-.. index:: ip rip authentication mode md5
 .. clicmd:: ip rip authentication mode md5
 
-.. index:: ip rip authentication mode md5
 .. clicmd:: no ip rip authentication mode md5
 
    Set the interface with RIPv2 MD5 authentication.
 
-.. index:: ip rip authentication mode text
 .. clicmd:: ip rip authentication mode text
 
-.. index:: ip rip authentication mode text
 .. clicmd:: no ip rip authentication mode text
 
    Set the interface with RIPv2 simple password authentication.
 
-.. index:: ip rip authentication string STRING
 .. clicmd:: ip rip authentication string STRING
 
-.. index:: ip rip authentication string STRING
 .. clicmd:: no ip rip authentication string STRING
 
    RIP version 2 has simple text authentication. This command sets
    authentication string. The string must be shorter than 16 characters.
 
-.. index:: ip rip authentication key-chain KEY-CHAIN
 .. clicmd:: ip rip authentication key-chain KEY-CHAIN
 
-.. index:: ip rip authentication key-chain KEY-CHAIN
 .. clicmd:: no ip rip authentication key-chain KEY-CHAIN
 
    Specify Keyed MD5 chain.
@@ -516,7 +468,6 @@ To prevent such unauthenticated querying of routes disable RIPv1,
 RIP Timers
 ==========
 
-.. index:: timers basic UPDATE TIMEOUT GARBAGE
 .. clicmd:: timers basic UPDATE TIMEOUT GARBAGE
 
 
@@ -539,7 +490,6 @@ RIP Timers
    The ``timers basic`` command allows the the default values of the timers
    listed above to be changed.
 
-.. index:: timers basic
 .. clicmd:: no timers basic
 
    The `no timers basic` command will reset the timers to the default settings
@@ -552,7 +502,6 @@ Show RIP Information
 
 To display RIP routes.
 
-.. index:: show ip rip
 .. clicmd:: show ip rip
 
    Show RIP routes.
@@ -562,7 +511,6 @@ through RIP, this command will display the time the packet was sent and
 the tag information. This command will also display this information
 for routes redistributed into RIP.
 
-.. index:: show ip rip status
 .. clicmd:: show ip rip status
 
    The command displays current RIP status. It includes RIP timer,
@@ -594,26 +542,22 @@ RIP Debug Commands
 
 Debug for RIP protocol.
 
-.. index:: debug rip events
 .. clicmd:: debug rip events
 
    Shows RIP events. Sending and receiving packets, timers, and changes in
    interfaces are events shown with *ripd*.
 
-.. index:: debug rip packet
 .. clicmd:: debug rip packet
 
    Shows display detailed information about the RIP packets. The origin and
    port number of the packet as well as a packet dump is shown.
 
-.. index:: debug rip zebra
 .. clicmd:: debug rip zebra
 
    This command will show the communication between *ripd* and *zebra*. The
    main information will include addition and deletion of paths to the kernel
    and the sending and receiving of interface information.
 
-.. index:: show debugging rip
 .. clicmd:: show debugging rip
 
    Shows all information currently set for ripd debug.

--- a/doc/user/ripd.rst
+++ b/doc/user/ripd.rst
@@ -232,89 +232,18 @@ discussion on the security implications of RIPv1 see :ref:`rip-authentication`.
 
    Default: Accept packets according to the global setting (both 1 and 2).
 
+
 .. _how-to-announce-rip-route:
 
 How to Announce RIP route
 =========================
 
-.. index:: redistribute kernel
-.. clicmd:: redistribute kernel
+.. index:: redistribute <babel|bgp|connected|eigrp|isis|kernel|openfabric|ospf|sharp|static|table> [metric (0-16)] [route-map WORD]
+.. clicmd:: redistribute <babel|bgp|connected|eigrp|isis|kernel|openfabric|ospf|sharp|static|table> [metric (0-16)] [route-map WORD]
 
-.. index:: redistribute kernel metric (0-16)
-.. clicmd:: redistribute kernel metric (0-16)
+   Redistribute routes from other sources into RIP.
 
-.. index:: redistribute kernel route-map ROUTE-MAP
-.. clicmd:: redistribute kernel route-map ROUTE-MAP
-
-.. index:: redistribute kernel
-.. clicmd:: no redistribute kernel
-
-   `redistribute kernel` redistributes routing information from kernel route
-   entries into the RIP tables. `no redistribute kernel` disables the routes.
-
-.. index:: redistribute static
-.. clicmd:: redistribute static
-
-.. index:: redistribute static metric (0-16)
-.. clicmd:: redistribute static metric (0-16)
-
-.. index:: redistribute static route-map ROUTE-MAP
-.. clicmd:: redistribute static route-map ROUTE-MAP
-
-.. index:: redistribute static
-.. clicmd:: no redistribute static
-
-   `redistribute static` redistributes routing information from static route
-   entries into the RIP tables. `no redistribute static` disables the routes.
-
-.. index:: redistribute connected
-.. clicmd:: redistribute connected
-
-.. index:: redistribute connected metric (0-16)
-.. clicmd:: redistribute connected metric (0-16)
-
-.. index:: redistribute connected route-map ROUTE-MAP
-.. clicmd:: redistribute connected route-map ROUTE-MAP
-
-.. index:: redistribute connected
-.. clicmd:: no redistribute connected
-
-   Redistribute connected routes into the RIP tables. `no redistribute
-   connected` disables the connected routes in the RIP tables.  This command
-   redistribute connected of the interface which RIP disabled.  The connected
-   route on RIP enabled interface is announced by default.
-
-.. index:: redistribute ospf
-.. clicmd:: redistribute ospf
-
-.. index:: redistribute ospf metric (0-16)
-.. clicmd:: redistribute ospf metric (0-16)
-
-.. index:: redistribute ospf route-map ROUTE-MAP
-.. clicmd:: redistribute ospf route-map ROUTE-MAP
-
-.. index:: redistribute ospf
-.. clicmd:: no redistribute ospf
-
-   `redistribute ospf` redistributes routing information from ospf route
-   entries into the RIP tables. `no redistribute ospf` disables the routes.
-
-.. index:: redistribute bgp
-.. clicmd:: redistribute bgp
-
-.. index:: redistribute bgp metric (0-16)
-.. clicmd:: redistribute bgp metric (0-16)
-
-.. index:: redistribute bgp route-map ROUTE-MAP
-.. clicmd:: redistribute bgp route-map ROUTE-MAP
-
-.. index:: redistribute bgp
-.. clicmd:: no redistribute bgp
-
-   `redistribute bgp` redistributes routing information from bgp route entries
-   into the RIP tables. `no redistribute bgp` disables the routes.
-
-   If you want to specify RIP only static routes:
+If you want to specify RIP only static routes:
 
 .. index:: default-information originate
 .. clicmd:: default-information originate
@@ -407,10 +336,10 @@ RIP distance
 
 Distance value is used in zebra daemon. Default RIP distance is 120.
 
-.. index:: distance (1-255)
+.. index:: RIP - distance (1-255)
 .. clicmd:: distance (1-255)
 
-.. index:: distance (1-255)
+.. index:: RIP - distance (1-255)
 .. clicmd:: no distance (1-255)
 
    Set default RIP distance to specified value.

--- a/doc/user/ripngd.rst
+++ b/doc/user/ripngd.rst
@@ -47,11 +47,6 @@ Currently ripngd supports the following commands:
 
    Set RIPng static routing announcement of NETWORK.
 
-.. index:: router zebra
-.. clicmd:: router zebra
-
-   This command is the default and does not appear in the configuration. With
-   this statement, RIPng routes go to the *zebra* daemon.
 
 .. _ripngd-terminal-mode-commands:
 

--- a/doc/user/ripngd.rst
+++ b/doc/user/ripngd.rst
@@ -22,27 +22,22 @@ ripngd Configuration
 
 Currently ripngd supports the following commands:
 
-.. index:: router ripng
 .. clicmd:: router ripng
 
    Enable RIPng.
 
-.. index:: flush_timer TIME
 .. clicmd:: flush_timer TIME
 
    Set flush timer.
 
-.. index:: network NETWORK
 .. clicmd:: network NETWORK
 
    Set RIPng enabled interface by NETWORK.
 
-.. index:: network IFNAME
 .. clicmd:: network IFNAME
 
    Set RIPng enabled interface by IFNAME.
 
-.. index:: route NETWORK
 .. clicmd:: route NETWORK
 
    Set RIPng static routing announcement of NETWORK.
@@ -53,26 +48,20 @@ Currently ripngd supports the following commands:
 ripngd Terminal Mode Commands
 =============================
 
-.. index:: show ip ripng
 .. clicmd:: show ip ripng
 
-.. index:: show debugging ripng
 .. clicmd:: show debugging ripng
 
-.. index:: debug ripng events
 .. clicmd:: debug ripng events
 
-.. index:: debug ripng packet
 .. clicmd:: debug ripng packet
 
-.. index:: debug ripng zebra
 .. clicmd:: debug ripng zebra
 
 
 ripngd Filtering Commands
 =========================
 
-.. index:: distribute-list ACCESS_LIST (in|out) IFNAME
 .. clicmd:: distribute-list ACCESS_LIST (in|out) IFNAME
 
    You can apply an access-list to the interface using the `distribute-list`

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -257,7 +257,7 @@ Route Map Set Command
 
    Subtract the BGP local preference from an existing `local_pref`.
 
-.. clicmd:: [no] set distance DISTANCE
+.. clicmd:: set distance DISTANCE
 
    Set the Administrative distance to DISTANCE to use for the route.
    This is only locally significant and will not be dispersed to peers.
@@ -266,7 +266,7 @@ Route Map Set Command
 
    Set the route's weight.
 
-.. clicmd:: [no] set metric <[+|-](1-4294967295)|rtt|+rtt|-rtt>
+.. clicmd:: set metric <[+|-](1-4294967295)|rtt|+rtt|-rtt>
 
    Set the BGP attribute MED to a specific value. Use `+`/`-` to add or subtract
    the specified value to/from the MED. Use `rtt` to set the MED to the round
@@ -298,6 +298,7 @@ Route Map Set Command
    Set the color of a SR-TE Policy to be applied to a learned route. The SR-TE
    Policy is uniquely determined by the color and the BGP nexthop.
 
+
 .. _route-map-call-command:
 
 Route Map Call Command
@@ -307,6 +308,7 @@ Route Map Call Command
 
    Call route-map `name`. If it returns deny, deny the route and
    finish processing the route-map.
+
 
 .. _route-map-exit-action-command:
 
@@ -325,6 +327,7 @@ Route Map Exit Action Command
 
    Proceed processing the route-map at the first entry whose order is >= N
 
+
 .. _route-map-optimization-command:
 
 Route Map Optimization Command
@@ -341,9 +344,6 @@ Route Map Optimization Command
    of all the prefixes in all the prefix-lists that are included in the
    match rule of all the sequences of a route-map.
 
-.. clicmd:: no route-map optimization
-
-   Disable the route-map processing optimization.
 
 Route Map Examples
 ==================

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -90,7 +90,6 @@ cont
 
 .. _route-map-show-command:
 
-.. index:: show route-map [WORD]
 .. clicmd:: show route-map [WORD]
 
    Display data about each daemons knowledge of individual route-maps.
@@ -98,7 +97,6 @@ cont
 
 .. _route-map-clear-counter-command:
 
-.. index:: clear route-map counter [WORD]
 .. clicmd:: clear route-map counter [WORD]
 
    Clear counters that are being stored about the route-map utilization
@@ -110,7 +108,6 @@ cont
 Route Map Command
 =================
 
-.. index:: route-map ROUTE-MAP-NAME (permit|deny) ORDER
 .. clicmd:: route-map ROUTE-MAP-NAME (permit|deny) ORDER
 
    Configure the `order`'th entry in `route-map-name` with ``Match Policy`` of
@@ -121,98 +118,80 @@ Route Map Command
 Route Map Match Command
 =======================
 
-.. index:: match ip address ACCESS_LIST
 .. clicmd:: match ip address ACCESS_LIST
 
    Matches the specified `access_list`
 
-.. index:: match ip address prefix-list PREFIX_LIST
 .. clicmd:: match ip address prefix-list PREFIX_LIST
 
    Matches the specified `PREFIX_LIST`
 
-.. index:: match ip address prefix-len 0-32
 .. clicmd:: match ip address prefix-len 0-32
 
    Matches the specified `prefix-len`. This is a Zebra specific command.
 
-.. index:: match ipv6 address ACCESS_LIST
 .. clicmd:: match ipv6 address ACCESS_LIST
 
    Matches the specified `access_list`
 
-.. index:: match ipv6 address prefix-list PREFIX_LIST
 .. clicmd:: match ipv6 address prefix-list PREFIX_LIST
 
    Matches the specified `PREFIX_LIST`
 
-.. index:: match ipv6 address prefix-len 0-128
 .. clicmd:: match ipv6 address prefix-len 0-128
 
    Matches the specified `prefix-len`. This is a Zebra specific command.
 
-.. index:: match ip next-hop address IPV4_ADDR
 .. clicmd:: match ip next-hop address IPV4_ADDR
 
    This is a BGP specific match command. Matches the specified `ipv4_addr`.
 
-.. index:: match ipv6 next-hop IPV6_ADDR
 .. clicmd:: match ipv6 next-hop IPV6_ADDR
 
    This is a BGP specific match command. Matches the specified `ipv6_addr`.
 
-.. index:: match as-path AS_PATH
 .. clicmd:: match as-path AS_PATH
 
    Matches the specified `as_path`.
 
-.. index:: match metric METRIC
 .. clicmd:: match metric METRIC
 
    Matches the specified `metric`.
 
-.. index:: match tag TAG
 .. clicmd:: match tag TAG
 
    Matches the specified tag value associated with the route. This tag value
    can be in the range of (1-4294967295).
 
-.. index:: match local-preference METRIC
 .. clicmd:: match local-preference METRIC
 
    Matches the specified `local-preference`.
 
-.. index:: match community COMMUNITY_LIST
 .. clicmd:: match community COMMUNITY_LIST
 
    Matches the specified  `community_list`
 
-.. index:: match peer IPV4_ADDR
 .. clicmd:: match peer IPV4_ADDR
 
    This is a BGP specific match command. Matches the peer ip address
    if the neighbor was specified in this manner.
 
-.. index:: match peer IPV6_ADDR
 .. clicmd:: match peer IPV6_ADDR
 
    This is a BGP specific match command. Matches the peer ipv6
    address if the neighbor was specified in this manner.
 
-.. index:: match peer INTERFACE_NAME
 .. clicmd:: match peer INTERFACE_NAME
 
   This is a BGP specific match command. Matches the peer
   interface name specified if the neighbor was specified
   in this manner.
 
-.. index:: match source-protocol PROTOCOL_NAME
 .. clicmd:: match source-protocol PROTOCOL_NAME
 
   This is a ZEBRA specific match command.  Matches the
   originating protocol specified.
 
-.. index:: match source-instance NUMBER
 .. clicmd:: match source-instance NUMBER
 
   This is a ZEBRA specific match command.  The number is a range from (0-255).
@@ -225,7 +204,6 @@ Route Map Set Command
 
 .. program:: configure
 
-.. index:: set tag TAG
 .. clicmd:: set tag TAG
 
    Set a tag on the matched route. This tag value can be from (1-4294967295).
@@ -233,13 +211,11 @@ Route Map Set Command
    configure option. Tag values from (1-255) are sent to the Linux kernel as a
    realm value. Then route policy can be applied. See the tc man page.
 
-.. index:: set ip next-hop IPV4_ADDRESS
 .. clicmd:: set ip next-hop IPV4_ADDRESS
 
    Set the BGP nexthop address to the specified IPV4_ADDRESS.  For both
    incoming and outgoing route-maps.
 
-.. index:: set ip next-hop peer-address
 .. clicmd:: set ip next-hop peer-address
 
    Set the BGP nexthop address to the address of the peer.  For an incoming
@@ -247,13 +223,11 @@ Route Map Set Command
    route-map this means the ip address of our self is used to establish the
    peering with our neighbor.
 
-.. index:: set ip next-hop unchanged
 .. clicmd:: set ip next-hop unchanged
 
    Set the route-map as unchanged.  Pass the route-map through without
    changing it's value.
 
-.. index:: set ipv6 next-hop peer-address
 .. clicmd:: set ipv6 next-hop peer-address
 
    Set the BGP nexthop address to the address of the peer.  For an incoming
@@ -261,45 +235,37 @@ Route Map Set Command
    route-map this means the ip address of our self is used to establish the
    peering with our neighbor.
 
-.. index:: set ipv6 next-hop prefer-global
 .. clicmd:: set ipv6 next-hop prefer-global
 
    For Incoming and Import Route-maps if we receive a v6 global and v6 LL
    address for the route, then prefer to use the global address as the nexthop.
 
-.. index:: set ipv6 next-hop global IPV6_ADDRESS
 .. clicmd:: set ipv6 next-hop global IPV6_ADDRESS
 
    Set the next-hop to the specified IPV6_ADDRESS for both incoming and
    outgoing route-maps.
 
-.. index:: set local-preference LOCAL_PREF
 .. clicmd:: set local-preference LOCAL_PREF
 
    Set the BGP local preference to `local_pref`.
 
-.. index:: set local-preference +LOCAL_PREF
 .. clicmd:: set local-preference +LOCAL_PREF
 
    Add the BGP local preference to an existing `local_pref`.
 
-.. index:: set local-preference -LOCAL_PREF
 .. clicmd:: set local-preference -LOCAL_PREF
 
    Subtract the BGP local preference from an existing `local_pref`.
 
-.. index:: set distance DISTANCE
 .. clicmd:: [no] set distance DISTANCE
 
    Set the Administrative distance to DISTANCE to use for the route.
    This is only locally significant and will not be dispersed to peers.
 
-.. index:: set weight WEIGHT
 .. clicmd:: set weight WEIGHT
 
    Set the route's weight.
 
-.. index:: set metric <[+|-](1-4294967295)|rtt|+rtt|-rtt>
 .. clicmd:: [no] set metric <[+|-](1-4294967295)|rtt|+rtt|-rtt>
 
    Set the BGP attribute MED to a specific value. Use `+`/`-` to add or subtract
@@ -307,32 +273,26 @@ Route Map Set Command
    trip time or `+rtt`/`-rtt` to add/subtract the round trip time to/from the
    MED.
 
-.. index:: set as-path prepend AS_PATH
 .. clicmd:: set as-path prepend AS_PATH
 
    Set the BGP AS path to prepend.
 
-.. index:: set community COMMUNITY
 .. clicmd:: set community COMMUNITY
 
    Set the BGP community attribute.
 
-.. index:: set ipv6 next-hop local IPV6_ADDRESS
 .. clicmd:: set ipv6 next-hop local IPV6_ADDRESS
 
    Set the BGP-4+ link local IPv6 nexthop address.
 
-.. index:: set origin ORIGIN <egp|igp|incomplete>
 .. clicmd:: set origin ORIGIN <egp|igp|incomplete>
 
    Set BGP route origin.
 
-.. index:: set table (1-4294967295)
 .. clicmd:: set table (1-4294967295)
 
    Set the BGP table to a given table identifier
 
-.. index:: set sr-te color (1-4294967295)
 .. clicmd:: set sr-te color (1-4294967295)
 
    Set the color of a SR-TE Policy to be applied to a learned route. The SR-TE
@@ -343,7 +303,6 @@ Route Map Set Command
 Route Map Call Command
 ======================
 
-.. index:: call NAME
 .. clicmd:: call NAME
 
    Call route-map `name`. If it returns deny, deny the route and
@@ -354,18 +313,14 @@ Route Map Call Command
 Route Map Exit Action Command
 =============================
 
-.. index:: on-match next
 .. clicmd:: on-match next
 
-.. index:: continue
 .. clicmd:: continue
 
    Proceed on to the next entry in the route-map.
 
-.. index:: on-match goto N
 .. clicmd:: on-match goto N
 
-.. index:: continue N
 .. clicmd:: continue N
 
    Proceed processing the route-map at the first entry whose order is >= N
@@ -375,7 +330,6 @@ Route Map Exit Action Command
 Route Map Optimization Command
 ==============================
 
-.. index:: route-map optimization
 .. clicmd:: route-map optimization
 
    Enable route-map processing optimization. The optimization is
@@ -387,7 +341,6 @@ Route Map Optimization Command
    of all the prefixes in all the prefix-lists that are included in the
    match rule of all the sequences of a route-map.
 
-.. index:: route-map optimization
 .. clicmd:: no route-map optimization
 
    Disable the route-map processing optimization.

--- a/doc/user/routeserver.rst
+++ b/doc/user/routeserver.rst
@@ -163,13 +163,10 @@ Commands for configuring a Route Server
 Now we will describe the commands that have been added to frr
 in order to support the route server features.
 
-.. index:: neighbor PEER-GROUP route-server-client
 .. clicmd:: neighbor PEER-GROUP route-server-client
 
-.. index:: neighbor A.B.C.D route-server-client
 .. clicmd:: neighbor A.B.C.D route-server-client
 
-.. index:: neighbor X:X::X:X route-server-client
 .. clicmd:: neighbor X:X::X:X route-server-client
 
    This command configures the peer given by `peer`, `A.B.C.D` or `X:X::X:X` as
@@ -186,14 +183,12 @@ in order to support the route server features.
    that moment, every announcement received by the route server will be also
    considered for the new Loc-RIB.
 
-.. index:: neigbor A.B.C.D|X.X::X.X|peer-group route-map WORD import|export
 .. clicmd:: neigbor A.B.C.D|X.X::X.X|peer-group route-map WORD import|export
 
    This set of commands can be used to specify the route-map that represents
    the Import or Export policy of a peer which is configured as a RS-client
    (with the previous command).
 
-.. index:: match peer A.B.C.D|X:X::X:X
 .. clicmd:: match peer A.B.C.D|X:X::X:X
 
    This is a new *match* statement for use in route-maps, enabling them to
@@ -210,7 +205,6 @@ in order to support the route server features.
    announce is going to be inserted (how the same export policy is applied
    before different Loc-RIBs is shown in :ref:`fig-rs-processing`.).
 
-.. index:: call WORD
 .. clicmd:: call WORD
 
    This command (also used inside a route-map) jumps into a different

--- a/doc/user/rpki.rst
+++ b/doc/user/rpki.rst
@@ -54,7 +54,6 @@ In a nutshell, the current implementation provides the following features
 Enabling RPKI
 -------------
 
-.. index:: rpki
 .. clicmd:: rpki
 
    This command enables the RPKI configuration mode. Most commands that start
@@ -67,7 +66,6 @@ Enabling RPKI
    to configure at least one reachable cache server. See section
    :ref:`configuring-rpki-rtr-cache-servers` for configuring a cache server.
 
-.. index:: RPKI and daemons
 
 When first installing FRR with RPKI support from the pre-packaged binaries.
 Remember to add ``-M rpki`` to the variable ``bgpd_options`` in
@@ -101,10 +99,8 @@ Configuring RPKI/RTR Cache Servers
 
 The following commands are independent of a specific cache server.
 
-.. index:: rpki polling_period (1-3600)
 .. clicmd:: rpki polling_period (1-3600)
 
-.. index:: rpki polling_period
 .. clicmd:: no rpki polling_period
 
    Set the number of seconds the router waits until the router asks the cache
@@ -114,10 +110,8 @@ The following commands are independent of a specific cache server.
 
    The following commands configure one or multiple cache servers.
 
-.. index:: rpki cache (A.B.C.D|WORD) PORT [SSH_USERNAME] [SSH_PRIVKEY_PATH] [SSH_PUBKEY_PATH] [KNOWN_HOSTS_PATH] PREFERENCE
 .. clicmd:: rpki cache (A.B.C.D|WORD) PORT [SSH_USERNAME] [SSH_PRIVKEY_PATH] [SSH_PUBKEY_PATH] [KNOWN_HOSTS_PATH] PREFERENCE
 
-.. index:: rpki cache (A.B.C.D|WORD) [PORT] PREFERENCE
 .. clicmd:: no rpki cache (A.B.C.D|WORD) [PORT] PREFERENCE
 
    Add a cache server to the socket. By default, the connection between router
@@ -154,10 +148,8 @@ The following commands are independent of a specific cache server.
 Validating BGP Updates
 ----------------------
 
-.. index:: match rpki notfound|invalid|valid
 .. clicmd:: match rpki notfound|invalid|valid
 
-.. index:: match rpki notfound|invalid|valid
 .. clicmd:: no match rpki notfound|invalid|valid
 
     Create a clause for a route map to match prefixes with the specified RPKI
@@ -187,10 +179,8 @@ Validating BGP Updates
 Debugging
 ---------
 
-.. index:: debug rpki
 .. clicmd:: debug rpki
 
-.. index:: debug rpki
 .. clicmd:: no debug rpki
 
    Enable or disable debugging output for RPKI.
@@ -200,26 +190,22 @@ Debugging
 Displaying RPKI
 ---------------
 
-.. index:: show rpki prefix <A.B.C.D/M|X:X::X:X/M> [(1-4294967295)]
 .. clicmd:: show rpki prefix <A.B.C.D/M|X:X::X:X/M> [(1-4294967295)]
 
    Display validated prefixes received from the cache servers filtered
    by the specified prefix.
 
-.. index:: show rpki as-number ASN
 .. clicmd:: show rpki as-number ASN
 
    Display validated prefixes received from the cache servers filtered
    by ASN.
 
-.. index:: show rpki prefix-table
 .. clicmd:: show rpki prefix-table
 
    Display all validated prefix to origin AS mappings/records which have been
    received from the cache servers and stored in the router. Based on this data,
    the router validates BGP Updates.
 
-.. index:: show rpki cache-connection
 .. clicmd:: show rpki cache-connection
 
    Display all configured cache servers, whether active or not.

--- a/doc/user/rpki.rst
+++ b/doc/user/rpki.rst
@@ -101,7 +101,6 @@ The following commands are independent of a specific cache server.
 
 .. clicmd:: rpki polling_period (1-3600)
 
-.. clicmd:: no rpki polling_period
 
    Set the number of seconds the router waits until the router asks the cache
    again for updated data.
@@ -112,7 +111,6 @@ The following commands are independent of a specific cache server.
 
 .. clicmd:: rpki cache (A.B.C.D|WORD) PORT [SSH_USERNAME] [SSH_PRIVKEY_PATH] [SSH_PUBKEY_PATH] [KNOWN_HOSTS_PATH] PREFERENCE
 
-.. clicmd:: no rpki cache (A.B.C.D|WORD) [PORT] PREFERENCE
 
    Add a cache server to the socket. By default, the connection between router
    and cache server is based on plain TCP. Protecting the connection between
@@ -150,7 +148,6 @@ Validating BGP Updates
 
 .. clicmd:: match rpki notfound|invalid|valid
 
-.. clicmd:: no match rpki notfound|invalid|valid
 
     Create a clause for a route map to match prefixes with the specified RPKI
     state.
@@ -181,7 +178,6 @@ Debugging
 
 .. clicmd:: debug rpki
 
-.. clicmd:: no debug rpki
 
    Enable or disable debugging output for RPKI.
 

--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -67,7 +67,7 @@ keyword. At present, no sharp commands will be preserved in the config.
    Install a label into the kernel that causes the specified vrf NAME table to
    be used for pop and forward operations when the specified label is seen.
 
-.. clicmd:: [no] sharp watch <nexthop <A.B.C.D|X:X::X:X>|import <A.B.C.D/M:X:X::X:X/M> [connected]
+.. clicmd:: sharp watch <nexthop <A.B.C.D|X:X::X:X>|import <A.B.C.D/M:X:X::X:X/M> [connected]
 
    Instruct zebra to monitor and notify sharp when the specified nexthop is
    changed. The notification from zebra is written into the debug log.

--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -32,7 +32,6 @@ Using SHARP
 All sharp commands are under the enable node and preceded by the ``sharp``
 keyword. At present, no sharp commands will be preserved in the config.
 
-.. index:: sharp install
 .. clicmd:: sharp install routes A.B.C.D <nexthop <E.F.G.H|X:X::X:X>|nexthop-group NAME> (1-1000000) [instance (0-255)] [repeat (2-1000)] [opaque WORD]
 
    Install up to 1,000,000 (one million) /32 routes starting at ``A.B.C.D``
@@ -49,7 +48,6 @@ keyword. At present, no sharp commands will be preserved in the config.
    number of times specified.  If the keyword opaque is specified then the
    next word is sent down to zebra as part of the route installation.
 
-.. index:: sharp remove
 .. clicmd:: sharp remove routes A.B.C.D (1-1000000)
 
    Remove up to 1,000,000 (one million) /32 routes starting at ``A.B.C.D``. The
@@ -57,7 +55,6 @@ keyword. At present, no sharp commands will be preserved in the config.
    log and when all routes have been successfully deleted the debug log will be
    updated with this information as well.
 
-.. index:: sharp data route
 .. clicmd:: sharp data route
 
    Allow end user doing route install and deletion to get timing information
@@ -65,13 +62,11 @@ keyword. At present, no sharp commands will be preserved in the config.
    is informational only and you should look at sharp_vty.c for explanation
    of the output as that it may change.
 
-.. index:: sharp label
 .. clicmd:: sharp label <ipv4|ipv6> vrf NAME label (0-1000000)
 
    Install a label into the kernel that causes the specified vrf NAME table to
    be used for pop and forward operations when the specified label is seen.
 
-.. index:: sharp watch
 .. clicmd:: [no] sharp watch <nexthop <A.B.C.D|X:X::X:X>|import <A.B.C.D/M:X:X::X:X/M> [connected]
 
    Instruct zebra to monitor and notify sharp when the specified nexthop is
@@ -83,13 +78,11 @@ keyword. At present, no sharp commands will be preserved in the config.
    for the import keyword connected means exact match.  The no form of
    the command obviously turns this watching off.
 
-.. index:: sharp data nexthop
 .. clicmd:: sharp data nexthop
 
    Allow end user to dump associated data with the nexthop tracking that
    may have been turned on.
 
-.. index:: sharp lsp
 .. clicmd:: sharp lsp [update] (0-100000) nexthop-group NAME [prefix A.B.C.D/M TYPE [instance (0-255)]]
 
    Install an LSP using the specified in-label, with nexthops as
@@ -98,7 +91,6 @@ keyword. At present, no sharp commands will be preserved in the config.
    If ``prefix`` is specified, an existing route with type ``TYPE``
    (and optional ``instance`` id) will be updated to use the LSP.
 
-.. index:: sharp remove lsp
 .. clicmd:: sharp remove lsp (0-100000) nexthop-group NAME [prefix A.B.C.D/M TYPE [instance (0-255)]]
 
    Remove a SHARPD LSP that uses the specified in-label, where the
@@ -106,13 +98,11 @@ keyword. At present, no sharp commands will be preserved in the config.
    specified, remove label bindings from the route of type ``TYPE``
    also.
 
-.. index:: sharp send opaque
 .. clicmd:: sharp send opaque type (1-255) (1-1000)
 
    Send opaque ZAPI messages with subtype ``type``. Sharpd will send
    a stream of messages if the count is greater than one.
 
-.. index:: sharp send opaque unicast
 .. clicmd:: sharp send opaque unicast type (1-255) $proto_str [{instance (0-1000) | session (1-1000)}] (1-1000)
 
    Send unicast opaque ZAPI messages with subtype ``type``. The
@@ -120,7 +110,6 @@ keyword. At present, no sharp commands will be preserved in the config.
    client. Sharpd will send a stream of messages if the count is
    greater than one.
 
-.. index:: sharp send opaque reg unreg
 .. clicmd:: sharp send opaque <reg | unreg> $proto_str [{instance (0-1000) | session (1-1000)}] type (1-1000)
 
    Send opaque ZAPI registration and unregistration messages for a
@@ -128,19 +117,16 @@ keyword. At present, no sharp commands will be preserved in the config.
    name, and can include optional zapi ``instance`` and ``session``
    values.
 
-.. index:: sharp create session
 .. clicmd:: sharp create session (1-1024)
 
    Create an additional zapi client session for testing, using the
    specified session id.
 
-.. index:: sharp remove session
 .. clicmd:: sharp remove session (1-1024)
 
    Remove a test zapi client session that was created with the
    specified session id.
 
-.. index:: sharp neigh discover
 .. clicmd:: sharp neigh discover [vrf NAME] <A.B.C.D|X:X::X:X> IFNAME
 
    Send an ARP/NDP request to trigger the addition of a neighbor in the ARP

--- a/doc/user/snmp.rst
+++ b/doc/user/snmp.rst
@@ -130,9 +130,7 @@ need to configure FRR to use another transport, you can configure it through
 
 Here is the syntax for using AgentX:
 
-.. index:: agentx
 .. clicmd:: agentx
-.. index:: agentx
 .. clicmd:: no agentx
 
 

--- a/doc/user/snmp.rst
+++ b/doc/user/snmp.rst
@@ -131,7 +131,6 @@ need to configure FRR to use another transport, you can configure it through
 Here is the syntax for using AgentX:
 
 .. clicmd:: agentx
-.. clicmd:: no agentx
 
 
 .. include:: snmptrap.rst

--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -35,10 +35,8 @@ Static Route Commands
 Static routing is a very fundamental feature of routing technology. It defines
 a static prefix and gateway.
 
-.. index:: ip route NETWORK GATEWAY table TABLENO nexthop-vrf VRFNAME DISTANCE vrf VRFNAME
 .. clicmd:: ip route NETWORK GATEWAY table TABLENO nexthop-vrf VRFNAME DISTANCE vrf VRFNAME
 
-.. index:: ipv6 route NETWORK from SRCPREFIX GATEWAY table TABLENO nexthop-vrf VRFNAME DISTANCE vrf VRFNAME
 .. clicmd:: ipv6 route NETWORK from SRCPREFIX GATEWAY table TABLENO nexthop-vrf VRFNAME DISTANCE vrf VRFNAME
 
    NETWORK is destination prefix with a valid v4 or v6 network based upon

--- a/doc/user/vnc.rst
+++ b/doc/user/vnc.rst
@@ -147,11 +147,7 @@ Defaults section.
      exit-vnc
 
 
-.. clicmd:: no vnc nve-group NAME
-
-   Delete the NVE group named `name`.
-
-   The following statements are valid in an NVE group definition:
+The following statements are valid in an NVE group definition:
 
 .. clicmd:: l2rd NVE-ID-VALUE
 
@@ -307,7 +303,6 @@ L2 Group Configuration.
        exit-vnc
 
 
-.. clicmd:: no vnc l2-group NAME
 
    Delete the L2 group named `name`.
 
@@ -320,7 +315,6 @@ The following statements are valid in a L2 group definition:
 
 .. clicmd:: labels LABEL-LIST
 
-.. clicmd:: no labels LABEL-LIST
 
    Add or remove labels associated with the group. `label-list` is a
    space separated list of label values in the range of 0-1048575.
@@ -466,7 +460,6 @@ Redistribution Command Syntax
 
 .. clicmd:: vnc redistribute ipv4|ipv6 bgp-direct-to-nve-groups view VIEWNAME
 
-.. clicmd:: no vnc redistribute ipv4|ipv6 bgp|bgp-direct|bgp-direct-to-nve-groups|connected|kernel|ospf|rip|static
 
    Import (or do not import) prefixes from another routing protocols. Specify
    both the address family to import (`ipv4` or `ipv6`) and the protocol
@@ -484,7 +477,6 @@ Redistribution Command Syntax
 
 .. clicmd:: vnc redistribute nve-group GROUP-NAME
 
-.. clicmd:: no vnc redistribute nve-group GROUP-NAME
 
    When using `nve-group` mode, assign (or do not assign) the NVE group
    `group-name` to routes redistributed from another routing protocol.

--- a/doc/user/vnc.rst
+++ b/doc/user/vnc.rst
@@ -110,7 +110,6 @@ These are the statements that can appear between ``vnc defaults`` and
 - :clicmd:`export bgp|zebra route-map MAP-NAME`
 - :clicmd:`export bgp|zebra no route-map`
 
-.. index:: exit-vnc
 .. clicmd:: exit-vnc
 
    Exit VNC configuration mode.
@@ -136,7 +135,6 @@ Defaults section.
 
 **At least one `nve-group` is mandatory for useful VNC operation.**
 
-.. index:: vnc nve-group NAME
 .. clicmd:: vnc nve-group NAME
 
   Enter VNC configuration mode for defining the NVE group `name`.
@@ -149,14 +147,12 @@ Defaults section.
      exit-vnc
 
 
-.. index:: vnc nve-group NAME
 .. clicmd:: no vnc nve-group NAME
 
    Delete the NVE group named `name`.
 
    The following statements are valid in an NVE group definition:
 
-.. index:: l2rd NVE-ID-VALUE
 .. clicmd:: l2rd NVE-ID-VALUE
 
    Set the value used to distinguish NVEs connected to the same physical
@@ -166,7 +162,6 @@ Defaults section.
    1-255, or it may be specified as `auto:vn`, which means to use the
    least-significant octet of the originating NVE's VN address.
 
-.. index:: prefix vn|un A.B.C.D/M|X:X::X:X/M
 .. clicmd:: prefix vn|un A.B.C.D/M|X:X::X:X/M
 
    Specify the matching prefix for this NVE group by either virtual-network
@@ -178,7 +173,6 @@ Defaults section.
    These prefixes are used only for determining assignments of NVEs to NVE
    Groups.
 
-.. index:: rd ROUTE-DISTINGUISHER
 .. clicmd:: rd ROUTE-DISTINGUISHER
 
    Specify the route distinguisher for routes advertised via BGP
@@ -202,7 +196,6 @@ Defaults section.
    `route-distinguisher` is configured, then the advertised RD is set to
    ``two-byte-autonomous-system-number=0:four-byte-integer=0``.
 
-.. index:: response-lifetime LIFETIME|infinite
 .. clicmd:: response-lifetime LIFETIME|infinite
 
    Specify the response lifetime, in seconds, to be included in RFP response
@@ -218,13 +211,10 @@ Defaults section.
    `response-lifetime` is configured, the value 3600 will be used. The maximum
    response lifetime is 2147483647.
 
-.. index:: rt export RT-LIST
 .. clicmd:: rt export RT-LIST
 
-.. index:: rt import RT-LIST
 .. clicmd:: rt import RT-LIST
 
-.. index:: rt both RT-LIST
 .. clicmd:: rt both RT-LIST
 
    Specify route target import and export lists. `rt-list` is a
@@ -258,7 +248,6 @@ Defaults section.
    simultaneously, and is equivalent to `rt export `rt-list`` followed by
    `rt import `rt-list``.
 
-.. index:: export bgp|zebra route-map MAP-NAME
 .. clicmd:: export bgp|zebra route-map MAP-NAME
 
    Specify that the named route-map should be applied to routes being exported
@@ -266,7 +255,6 @@ Defaults section.
    :ref:`configuring-export-of-routes-to-other-routing-protocols`.  This item
    is optional.
 
-.. index:: export bgp|zebra no route-map
 .. clicmd:: export bgp|zebra no route-map
 
    Specify that no route-map should be applied to routes being exported to bgp
@@ -274,7 +262,6 @@ Defaults section.
    :ref:`configuring-export-of-routes-to-other-routing-protocols`.  This item
    is optional.
 
-.. index:: export bgp|zebra ipv4|ipv6 prefix-list LIST-NAME
 .. clicmd:: export bgp|zebra ipv4|ipv6 prefix-list LIST-NAME
 
    Specify that the named prefix-list filter should be applied to routes being
@@ -283,7 +270,6 @@ Defaults section.
    :ref:`configuring-export-of-routes-to-other-routing-protocols`.  This item
    is optional.
 
-.. index:: export bgp|zebra no ipv4|ipv6 prefix-list
 .. clicmd:: export bgp|zebra no ipv4|ipv6 prefix-list
 
    Specify that no prefix-list filter should be applied to routes being
@@ -309,7 +295,6 @@ Note that a corresponding NVE group configuration must be present, and that
 other NVE associated configuration information, notably RD, is not impacted by
 L2 Group Configuration.
 
-.. index:: vnc l2-group NAME
 .. clicmd:: vnc l2-group NAME
 
    Enter VNC configuration mode for defining the L2 group `name`.
@@ -322,35 +307,28 @@ L2 Group Configuration.
        exit-vnc
 
 
-.. index:: vnc l2-group NAME
 .. clicmd:: no vnc l2-group NAME
 
    Delete the L2 group named `name`.
 
 The following statements are valid in a L2 group definition:
 
-.. index:: logical-network-id VALUE
 .. clicmd:: logical-network-id VALUE
 
    Define the Logical Network Identifier with a value in the range of
    0-4294967295 that identifies the logical Ethernet segment.
 
-.. index:: labels LABEL-LIST
 .. clicmd:: labels LABEL-LIST
 
-.. index:: labels LABEL-LIST
 .. clicmd:: no labels LABEL-LIST
 
    Add or remove labels associated with the group. `label-list` is a
    space separated list of label values in the range of 0-1048575.
 
-.. index:: rt import RT-TARGET
 .. clicmd:: rt import RT-TARGET
 
-.. index:: rt export RT-TARGET
 .. clicmd:: rt export RT-TARGET
 
-.. index:: rt both RT-TARGET
 .. clicmd:: rt both RT-TARGET
 
    Specify the route target import and export value associated with the group.
@@ -484,13 +462,10 @@ There is currently no policy (prefix-list or route-map) support for
 Redistribution Command Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: vnc redistribute ipv4|ipv6 bgp|bgp-direct|ipv6 bgp-direct-to-nve-groups|connected|kernel|ospf|rip|static
 .. clicmd:: vnc redistribute ipv4|ipv6 bgp|bgp-direct|ipv6 bgp-direct-to-nve-groups|connected|kernel|ospf|rip|static
 
-.. index:: vnc redistribute ipv4|ipv6 bgp-direct-to-nve-groups view VIEWNAME
 .. clicmd:: vnc redistribute ipv4|ipv6 bgp-direct-to-nve-groups view VIEWNAME
 
-.. index:: vnc redistribute ipv4|ipv6 bgp|bgp-direct|bgp-direct-to-nve-groups|connected|kernel|ospf|rip|static
 .. clicmd:: no vnc redistribute ipv4|ipv6 bgp|bgp-direct|bgp-direct-to-nve-groups|connected|kernel|ospf|rip|static
 
    Import (or do not import) prefixes from another routing protocols. Specify
@@ -502,16 +477,13 @@ Redistribution Command Syntax
    Prefixes from all other protocols (including `bgp`) are imported via the
    `zebra` kernel routing process.
 
-.. index:: vnc redistribute mode plain|nve-group|resolve-nve
 .. clicmd:: vnc redistribute mode plain|nve-group|resolve-nve
 
    Redistribute routes from other protocols into VNC using the specified mode.
    Not all combinations of modes and protocols are supported.
 
-.. index:: vnc redistribute nve-group GROUP-NAME
 .. clicmd:: vnc redistribute nve-group GROUP-NAME
 
-.. index:: vnc redistribute nve-group GROUP-NAME
 .. clicmd:: no vnc redistribute nve-group GROUP-NAME
 
    When using `nve-group` mode, assign (or do not assign) the NVE group
@@ -522,7 +494,6 @@ Redistribution Command Syntax
    prefix must be specified as a full-length (/32 for IPv4, /128 for IPv6)
    prefix.
 
-.. index:: vnc redistribute lifetime LIFETIME|infinite
 .. clicmd:: vnc redistribute lifetime LIFETIME|infinite
 
    Assign a registration lifetime, either `lifetime` seconds or `infinite`, to
@@ -530,7 +501,6 @@ Redistribution Command Syntax
    received via RFP registration messages from an NVE. `lifetime` can be any
    integer between 1 and 4294967295, inclusive.
 
-.. index:: vnc redistribute resolve-nve roo-ec-local-admin 0-65536
 .. clicmd:: vnc redistribute resolve-nve roo-ec-local-admin 0-65536
 
    Assign a value to the local-administrator subfield used in the
@@ -545,25 +515,21 @@ specified outside the context of an nve-group, then they apply only for
 redistribution modes `plain` and `resolve-nve`, and then only for routes
 being redistributed from `bgp-direct`.
 
-.. index:: vnc redistribute bgp-direct (ipv4|ipv6) prefix-list LIST-NAME
 .. clicmd:: vnc redistribute bgp-direct (ipv4|ipv6) prefix-list LIST-NAME
 
    When redistributing `bgp-direct` routes,
    specifies that the named prefix-list should be applied.
 
-.. index:: vnc redistribute bgp-direct no (ipv4|ipv6) prefix-list
 .. clicmd:: vnc redistribute bgp-direct no (ipv4|ipv6) prefix-list
 
    When redistributing `bgp-direct` routes,
    specifies that no prefix-list should be applied.
 
-.. index:: vnc redistribute bgp-direct route-map  MAP-NAME
 .. clicmd:: vnc redistribute bgp-direct route-map  MAP-NAME
 
    When redistributing `bgp-direct` routes,
    specifies that the named route-map should be applied.
 
-.. index:: vnc redistribute bgp-direct no route-map
 .. clicmd:: vnc redistribute bgp-direct no route-map
 
    When redistributing `bgp-direct` routes,
@@ -582,7 +548,6 @@ downstream protocol must also be configured to import the routes.  For example,
 when VNC routes are exported to unicast BGP, the BGP configuration must include
 a corresponding `redistribute vnc-direct` statement.
 
-.. index:: export bgp|zebra mode none|group-nve|registering-nve|ce
 .. clicmd:: export bgp|zebra mode none|group-nve|registering-nve|ce
 
    Specify how routes should be exported to bgp or zebra.  If the mode is
@@ -600,10 +565,8 @@ a corresponding `redistribute vnc-direct` statement.
 
    The default for both bgp and zebra is mode `none`.
 
-.. index:: vnc export bgp|zebra group-nve group GROUP-NAME
 .. clicmd:: vnc export bgp|zebra group-nve group GROUP-NAME
 
-.. index:: vnc export bgp|zebra group-nve no group GROUP-NAME
 .. clicmd:: vnc export bgp|zebra group-nve no group GROUP-NAME
 
    When export mode is `group-nve`, export (or do not export) prefixes from the
@@ -702,14 +665,12 @@ manually and dynamically added information.
    `local-next-hop` parameter is used to delete specific local nexthop
    information.
 
-.. index:: clear vnc mac (\\*|xx:xx:xx:xx:xx:xx) virtual-network-identifier (\\*|(1-4294967295)) (\\*|[(vn|un) (A.B.C.D|X:X::X:X|\\*) [(un|vn) (A.B.C.D|X:X::X:X|\*)] [prefix (\\*|A.B.C.D/M|X:X::X:X/M)])
 .. clicmd:: clear vnc mac (\*|xx:xx:xx:xx:xx:xx) virtual-network-identifier (\*|(1-4294967295)) (\*|[(vn|un) (A.B.C.D|X:X::X:X|\*) [(un|vn) (A.B.C.D|X:X::X:X|\*)] [prefix (\*|A.B.C.D/M|X:X::X:X/M)])
 
    Delete mac forwarding information. Any or all of these parameters may be
    wildcarded to (potentially) match more than one registration. The default
    value for the `prefix` parameter is the wildcard value `*`.
 
-.. index:: clear vnc nve (\*|((vn|un) (A.B.C.D|X:X::X:X) [(un|vn) (A.B.C.D|X:X::X:X)]))
 .. clicmd:: clear vnc nve (\*|((vn|un) (A.B.C.D|X:X::X:X) [(un|vn) (A.B.C.D|X:X::X:X)]))
 
    Delete prefixes associated with the NVE specified by the given VN and UN
@@ -729,24 +690,20 @@ running-configuration` command when in `enable` mode.
 The following commands are used to clear and display Virtual Network Control
 related information:
 
-.. index:: clear vnc counters
 .. clicmd:: clear vnc counters
 
    Reset the counter values stored by the NVA. Counter
    values can be seen using the `show vnc` commands listed above. This
    command is only available in `enable` mode.
 
-.. index:: show vnc summary
 .. clicmd:: show vnc summary
 
    Print counter values and other general information
    about the NVA. Counter values can be reset
    using the `clear vnc counters` command listed below.
 
-.. index:: show vnc nves
 .. clicmd:: show vnc nves
 
-.. index:: show vnc nves vn|un ADDRESS
 .. clicmd:: show vnc nves vn|un ADDRESS
 
    Display the NVA's current clients. Specifying `address` limits the output to
@@ -754,10 +711,8 @@ related information:
    communicated with the NVE, per-NVE summary counters and each NVE's addresses
    will be displayed.
 
-.. index:: show vnc queries
 .. clicmd:: show vnc queries
 
-.. index:: show vnc queries PREFIX
 .. clicmd:: show vnc queries PREFIX
 
    Display active Query information. Queries remain valid for the default
@@ -768,10 +723,8 @@ related information:
    Query information is provided for each querying NVE, and includes the Query
    Target and the time remaining before the information is removed.
 
-.. index:: show vnc registrations [all|local|remote|holddown|imported]
 .. clicmd:: show vnc registrations [all|local|remote|holddown|imported]
 
-.. index:: show vnc registrations [all|local|remote|holddown|imported] PREFIX
 .. clicmd:: show vnc registrations [all|local|remote|holddown|imported] PREFIX
 
    Display local, remote, holddown, and/or imported registration information.
@@ -791,10 +744,8 @@ related information:
    registrations, the amount of time remaining before the information is
    removed.
 
-.. index:: show vnc responses [active|removed]
 .. clicmd:: show vnc responses [active|removed]
 
-.. index:: show vnc responses [active|removed] PREFIX
 .. clicmd:: show vnc responses [active|removed] PREFIX
 
    Display all, active and/or removed response information which are
@@ -811,7 +762,6 @@ related information:
    the administrative cost, the provided response lifetime and the time
    remaining before the information is to be removed or will become inactive.
 
-.. index:: show memory vnc
 .. clicmd:: show memory vnc
 
    Print the number of memory items allocated by the NVA.

--- a/doc/user/vrrp.rst
+++ b/doc/user/vrrp.rst
@@ -358,21 +358,18 @@ using VRRPv2.
 
 All interface configuration commands are documented below.
 
-.. index:: vrrp (1-255) [version (2-3)]
 .. clicmd:: [no] vrrp (1-255) [version (2-3)]
 
    Create a VRRP router with the specified VRID on the interface. Optionally
    specify the protocol version. If the protocol version is not specified, the
    default is VRRPv3.
 
-.. index:: vrrp (1-255) advertisement-interval (10-40950)
 .. clicmd:: [no] vrrp (1-255) advertisement-interval (10-40950)
 
    Set the advertisement interval. This is the interval at which VRRP
    advertisements will be sent. Values are given in milliseconds, but must be
    multiples of 10, as VRRP itself uses centiseconds.
 
-.. index:: vrrp (1-255) ip A.B.C.D
 .. clicmd:: [no] vrrp (1-255) ip A.B.C.D
 
    Add an IPv4 address to the router. This address must already be configured
@@ -380,7 +377,6 @@ All interface configuration commands are documented below.
    implicitly activate the router; see :clicmd:`[no] vrrp (1-255) shutdown` to
    override this behavior.
 
-.. index:: vrrp (1-255) ipv6 X:X::X:X
 .. clicmd:: [no] vrrp (1-255) ipv6 X:X::X:X
 
    Add an IPv6 address to the router. This address must already be configured
@@ -391,14 +387,12 @@ All interface configuration commands are documented below.
    This command will fail if the protocol version is set to VRRPv2, as VRRPv2
    does not support IPv6.
 
-.. index:: vrrp (1-255) preempt
 .. clicmd:: [no] vrrp (1-255) preempt
 
    Toggle preempt mode. When enabled, preemption allows Backup routers with
    higher priority to take over Master status from the existing Master. Enabled
    by default.
 
-.. index:: vrrp (1-255) priority (1-254)
 .. clicmd:: [no] vrrp (1-255) priority (1-254)
 
    Set the router priority. The router with the highest priority is elected as
@@ -406,7 +400,6 @@ All interface configuration commands are documented below.
    the same priority, the router with the highest primary IP address is elected
    as the Master. Priority value 255 is reserved for the acting Master router.
 
-.. index:: vrrp (1-255) shutdown
 .. clicmd:: [no] vrrp (1-255) shutdown
 
    Place the router into administrative shutdown. VRRP will not activate for
@@ -419,7 +412,6 @@ Global Configuration
 
 Show commands, global defaults and debugging configuration commands.
 
-.. index:: show vrrp [interface INTERFACE] [(1-255)] [json]
 .. clicmd:: show vrrp [interface INTERFACE] [(1-255)] [json]
 
    Shows VRRP status for some or all configured VRRP routers. Specifying an
@@ -427,7 +419,6 @@ Show commands, global defaults and debugging configuration commands.
    VRID will only show routers with that VRID. Specifying ``json`` will dump
    each router state in a JSON array.
 
-.. index:: debug vrrp [{protocol|autoconfigure|packets|sockets|ndisc|arp|zebra}]
 .. clicmd:: [no] debug vrrp [{protocol|autoconfigure|packets|sockets|ndisc|arp|zebra}]
 
    Toggle debugging logs for VRRP components.
@@ -457,7 +448,6 @@ Show commands, global defaults and debugging configuration commands.
    zebra
       Logs communications with Zebra.
 
-.. index:: vrrp default <advertisement-interval (1-4096)|preempt|priority (1-254)|shutdown>
 .. clicmd:: [no] vrrp default <advertisement-interval (1-4096)|preempt|priority (1-254)|shutdown>
 
    Configure defaults for new VRRP routers. These values will not affect
@@ -480,7 +470,6 @@ After configuring the interfaces as described in
 :ref:`vrrp-system-configuration`, and configuring any defaults you may want,
 execute the following command:
 
-.. index:: vrrp autoconfigure [version (2-3)]
 .. clicmd:: [no] vrrp autoconfigure [version (2-3)]
 
    Generates VRRP configuration based on the interface configuration on the

--- a/doc/user/vrrp.rst
+++ b/doc/user/vrrp.rst
@@ -358,26 +358,26 @@ using VRRPv2.
 
 All interface configuration commands are documented below.
 
-.. clicmd:: [no] vrrp (1-255) [version (2-3)]
+.. clicmd:: vrrp (1-255) [version (2-3)]
 
    Create a VRRP router with the specified VRID on the interface. Optionally
    specify the protocol version. If the protocol version is not specified, the
    default is VRRPv3.
 
-.. clicmd:: [no] vrrp (1-255) advertisement-interval (10-40950)
+.. clicmd:: vrrp (1-255) advertisement-interval (10-40950)
 
    Set the advertisement interval. This is the interval at which VRRP
    advertisements will be sent. Values are given in milliseconds, but must be
    multiples of 10, as VRRP itself uses centiseconds.
 
-.. clicmd:: [no] vrrp (1-255) ip A.B.C.D
+.. clicmd:: vrrp (1-255) ip A.B.C.D
 
    Add an IPv4 address to the router. This address must already be configured
    on the appropriate macvlan device. Adding an IP address to the router will
    implicitly activate the router; see :clicmd:`[no] vrrp (1-255) shutdown` to
    override this behavior.
 
-.. clicmd:: [no] vrrp (1-255) ipv6 X:X::X:X
+.. clicmd:: vrrp (1-255) ipv6 X:X::X:X
 
    Add an IPv6 address to the router. This address must already be configured
    on the appropriate macvlan device. Adding an IP address to the router will
@@ -387,20 +387,20 @@ All interface configuration commands are documented below.
    This command will fail if the protocol version is set to VRRPv2, as VRRPv2
    does not support IPv6.
 
-.. clicmd:: [no] vrrp (1-255) preempt
+.. clicmd:: vrrp (1-255) preempt
 
    Toggle preempt mode. When enabled, preemption allows Backup routers with
    higher priority to take over Master status from the existing Master. Enabled
    by default.
 
-.. clicmd:: [no] vrrp (1-255) priority (1-254)
+.. clicmd:: vrrp (1-255) priority (1-254)
 
    Set the router priority. The router with the highest priority is elected as
    the Master. If all routers in the VRRP virtual router are configured with
    the same priority, the router with the highest primary IP address is elected
    as the Master. Priority value 255 is reserved for the acting Master router.
 
-.. clicmd:: [no] vrrp (1-255) shutdown
+.. clicmd:: vrrp (1-255) shutdown
 
    Place the router into administrative shutdown. VRRP will not activate for
    this router until this command is removed with the ``no`` form.
@@ -419,7 +419,7 @@ Show commands, global defaults and debugging configuration commands.
    VRID will only show routers with that VRID. Specifying ``json`` will dump
    each router state in a JSON array.
 
-.. clicmd:: [no] debug vrrp [{protocol|autoconfigure|packets|sockets|ndisc|arp|zebra}]
+.. clicmd:: debug vrrp [{protocol|autoconfigure|packets|sockets|ndisc|arp|zebra}]
 
    Toggle debugging logs for VRRP components.
    If no component is specified, debugging for all components are turned on/off.
@@ -448,7 +448,7 @@ Show commands, global defaults and debugging configuration commands.
    zebra
       Logs communications with Zebra.
 
-.. clicmd:: [no] vrrp default <advertisement-interval (1-4096)|preempt|priority (1-254)|shutdown>
+.. clicmd:: vrrp default <advertisement-interval (1-4096)|preempt|priority (1-254)|shutdown>
 
    Configure defaults for new VRRP routers. These values will not affect
    already configured VRRP routers, but will be applied to newly configured
@@ -470,7 +470,7 @@ After configuring the interfaces as described in
 :ref:`vrrp-system-configuration`, and configuring any defaults you may want,
 execute the following command:
 
-.. clicmd:: [no] vrrp autoconfigure [version (2-3)]
+.. clicmd:: vrrp autoconfigure [version (2-3)]
 
    Generates VRRP configuration based on the interface configuration on the
    base system. If the protocol version is not specified, the default is VRRPv3.

--- a/doc/user/vtysh.rst
+++ b/doc/user/vtysh.rst
@@ -22,7 +22,6 @@ administrator with an external editor.
    have effect for vtysh) need to be manually updated in :file:`vtysh.conf`.
 
 
-.. index:: copy FILENAME running-config
 .. clicmd:: copy FILENAME running-config
 
    Process and load a configuration file manually; each line in the
@@ -52,7 +51,6 @@ and the :clicmd:`terminal paginate` command:
    This variable should be set by the user according to their preferences,
    in their :file:`~/.profile` file.
 
-.. index:: terminal paginate
 .. clicmd:: [no] terminal paginate
 
    Enables/disables vtysh output pagination.  This command is intended to
@@ -100,7 +98,6 @@ could be made SGID (set group ID) to the |INSTALL_VTY_GROUP| group.
    No security guarantees are made for this configuration.
 
 
-.. index:: username USERNAME nopassword
 .. clicmd:: username USERNAME nopassword
 
   If PAM support is enabled at build-time, this command allows disabling the
@@ -162,10 +159,8 @@ it can lead to /all/ of your daemons being unable to start up. Per daemon files
 are more robust as impact of errors in configuration are limited to the daemon
 in whose file the error is made.
 
-.. index:: service integrated-vtysh-config
 .. clicmd:: service integrated-vtysh-config
 
-.. index:: service integrated-vtysh-config
 .. clicmd:: no service integrated-vtysh-config
 
    Control whether integrated :file:`frr.conf` file is written when
@@ -195,7 +190,6 @@ in whose file the error is made.
    preset one of the two operating modes and ensure consistent operation across
    installations.
 
-.. index:: write integrated
 .. clicmd:: write integrated
 
    Unconditionally (regardless of ``service integrated-vtysh-config`` setting)

--- a/doc/user/vtysh.rst
+++ b/doc/user/vtysh.rst
@@ -51,7 +51,7 @@ and the :clicmd:`terminal paginate` command:
    This variable should be set by the user according to their preferences,
    in their :file:`~/.profile` file.
 
-.. clicmd:: [no] terminal paginate
+.. clicmd:: terminal paginate
 
    Enables/disables vtysh output pagination.  This command is intended to
    be placed in :file:`vtysh.conf` to set a system-wide default.  If this
@@ -161,7 +161,6 @@ in whose file the error is made.
 
 .. clicmd:: service integrated-vtysh-config
 
-.. clicmd:: no service integrated-vtysh-config
 
    Control whether integrated :file:`frr.conf` file is written when
    'write file' is issued.

--- a/doc/user/watchfrr.rst
+++ b/doc/user/watchfrr.rst
@@ -16,13 +16,11 @@ require end users management.
 WATCHFRR commands
 =================
 
-.. index:: show watchfrr
 .. clicmd:: show watchfrr
 
    Give status information about the state of the different daemons being
    watched by WATCHFRR
 
-.. index:: watchfrr ignore DAEMON
 .. clicmd:: [no] watchfrr ignore DAEMON
 
    Tell WATCHFRR to ignore a particular DAEMON if it goes unresponsive.

--- a/doc/user/watchfrr.rst
+++ b/doc/user/watchfrr.rst
@@ -21,7 +21,7 @@ WATCHFRR commands
    Give status information about the state of the different daemons being
    watched by WATCHFRR
 
-.. clicmd:: [no] watchfrr ignore DAEMON
+.. clicmd:: watchfrr ignore DAEMON
 
    Tell WATCHFRR to ignore a particular DAEMON if it goes unresponsive.
    This is particularly useful when you are a developer and need to debug

--- a/doc/user/wecmp_linkbw.rst
+++ b/doc/user/wecmp_linkbw.rst
@@ -173,7 +173,6 @@ ECMP as recommended in [Draft-IETF-idr-link-bandwidth]_.
 
 The operator can change these behaviors with the following configuration:
 
-.. index:: bgp bestpath bandwidth <ignore | skip-missing | default-weight-for-missing>
 .. clicmd:: bgp bestpath bandwidth <ignore | skip-missing | default-weight-for-missing>
 
 The different options imply behavior as follows:

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -843,7 +843,7 @@ FPM Commands
    Use the new netlink messages ``RTM_NEWNEXTHOP`` / ``RTM_DELNEXTHOP`` to
    group repeated route next hop information.
 
-   The ``no` form uses the old known FPM behavior of including next hop
+   The ``no`` form uses the old known FPM behavior of including next hop
    information in the route (e.g. ``RTM_NEWROUTE``) messages.
 
 .. clicmd:: show fpm counters [json]

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -650,6 +650,7 @@ unicast topology!
       what the default behavior is.
 
 .. warning::
+
    Unreachable routes do not receive special treatment and do not cause
    fallback to a second lookup.
 

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -124,7 +124,6 @@ Standard Commands
 
 .. clicmd:: shutdown
 
-.. clicmd:: no shutdown
 
    Up or down the current interface.
 
@@ -133,16 +132,13 @@ Standard Commands
 
 .. clicmd:: ipv6 address ADDRESS/PREFIX
 
-.. clicmd:: no ip address ADDRESS/PREFIX
 
-.. clicmd:: no ipv6 address ADDRESS/PREFIX
 
    Set the IPv4 or IPv6 address/prefix for the interface.
 
 
 .. clicmd:: ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
 
-.. clicmd:: no ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
 
    Configure an IPv4 Point-to-Point address on the interface. (The concept of
    PtP addressing does not exist for IPv6.)
@@ -160,14 +156,12 @@ Standard Commands
 
 .. clicmd:: multicast
 
-.. clicmd:: no multicast
 
    Enable or disables multicast flag for the interface.
 
 
 .. clicmd:: bandwidth (1-10000000)
 
-.. clicmd:: no bandwidth (1-10000000)
 
    Set bandwidth value of the interface in kilobits/sec. This is for
    calculating OSPF cost. This command does not affect the actual device
@@ -176,7 +170,6 @@ Standard Commands
 
 .. clicmd:: link-detect
 
-.. clicmd:: no link-detect
 
    Enable/disable link-detect on platforms which support this. Currently only
    Linux, and only where network interface drivers support reporting
@@ -197,7 +190,6 @@ Link Parameters Commands
 
 .. clicmd:: link-params
 
-.. clicmd:: no link-param
 
    Enter into the link parameters sub node. At least 'enable' must be
    set to activate the link parameters, and consequently routing
@@ -497,7 +489,7 @@ The push action is generally used for LER devices, which want to encapsulate
 all traffic for a wished destination into an MPLS label. This action is stored
 in routing entry, and can be configured like a route:
 
-.. clicmd:: [no] ip route NETWORK MASK GATEWAY|INTERFACE label LABEL
+.. clicmd:: ip route NETWORK MASK GATEWAY|INTERFACE label LABEL
 
    NETWORK and MASK stand for the IP prefix entry to be added as static
    route entry.
@@ -527,7 +519,7 @@ The swap action is generally used for LSR devices, which swap a packet with a
 label, with an other label. The Pop action is used on LER devices, at the
 termination of the MPLS traffic; this is used to remove MPLS header.
 
-.. clicmd:: [no] mpls lsp INCOMING_LABEL GATEWAY OUTGOING_LABEL|explicit-null|implicit-null
+.. clicmd:: mpls lsp INCOMING_LABEL GATEWAY OUTGOING_LABEL|explicit-null|implicit-null
 
    INCOMING_LABEL and OUTGOING_LABEL are MPLS labels with values ranging from 16
    to 1048575.
@@ -575,7 +567,6 @@ unicast topology!
 
 .. clicmd:: ip multicast rpf-lookup-mode MODE
 
-.. clicmd:: no ip multicast rpf-lookup-mode [MODE]
 
    MODE sets the method used to perform RPF lookups. Supported modes:
 
@@ -635,7 +626,6 @@ unicast topology!
 
 .. clicmd:: ip mroute PREFIX NEXTHOP [DISTANCE]
 
-.. clicmd:: no ip mroute PREFIX NEXTHOP [DISTANCE]
 
    Adds a static route entry to the Multicast RIB. This performs exactly as the
    ``ip route`` command, except that it inserts the route in the Multicast RIB
@@ -717,7 +707,7 @@ IPv6 example for OSPFv3.
    not created at startup.  On Debian, FRR might start before ifupdown
    completes. Consider a reboot test.
 
-.. clicmd:: [no] zebra route-map delay-timer (0-600)
+.. clicmd:: zebra route-map delay-timer (0-600)
 
    Set the delay before any route-maps are processed in zebra.  The
    default time for this is 5 seconds.
@@ -793,15 +783,8 @@ FPM Commands
 
 .. clicmd:: fpm connection ip A.B.C.D port (1-65535)
 
-   Configure ``zebra`` to connect to a different FPM server than
-   ``127.0.0.1`` port ``2620``.
-
-
-.. clicmd:: no fpm connection ip A.B.C.D port (1-65535)
-
-  Configure ``zebra`` to connect to the default FPM server at ``127.0.0.1``
-  port ``2620``.
-
+   Configure ``zebra`` to connect to a different FPM server than the default of
+   ``127.0.0.1:2060``
 
 .. clicmd:: show zebra fpm stats
 
@@ -852,24 +835,16 @@ FPM Commands
    Configures the FPM server address. Once configured ``zebra`` will attempt
    to connect to it immediately.
 
-
-.. clicmd:: no fpm address [<A.B.C.D|X:X::X:X> [port (1-65535)]]
-
-   Disables FPM entirely. ``zebra`` will close any current connections and
-   will not attempt to connect to it anymore.
-
+   The ``no`` form disables FPM entirely. ``zebra`` will close any current
+   connections and will not attempt to connect to it anymore.
 
 .. clicmd:: fpm use-next-hop-groups
 
    Use the new netlink messages ``RTM_NEWNEXTHOP`` / ``RTM_DELNEXTHOP`` to
    group repeated route next hop information.
 
-
-.. clicmd:: no fpm use-next-hop-groups
-
-   Use the old known FPM behavior of including next hop information in the
-   route (e.g. ``RTM_NEWROUTE``) messages.
-
+   The ``no` form uses the old known FPM behavior of including next hop
+   information in the route (e.g. ``RTM_NEWROUTE``) messages.
 
 .. clicmd:: show fpm counters [json]
 
@@ -1019,12 +994,12 @@ Many routing protocols require a router-id to be configured. To have a
 consistent router-id across all daemons, the following commands are available
 to configure and display the router-id:
 
-.. clicmd:: [no] [ip] router-id A.B.C.D
+.. clicmd:: [ip] router-id A.B.C.D
 
    Allow entering of the router-id.  This command also works under the
    vrf subnode, to allow router-id's per vrf.
 
-.. clicmd:: [no] [ip] router-id A.B.C.D vrf NAME
+.. clicmd:: [ip] router-id A.B.C.D vrf NAME
 
    Configure the router-id of this router from the configure NODE.
    A show run of this command will display the router-id command
@@ -1037,7 +1012,7 @@ to configure and display the router-id:
 
 For protocols requiring an IPv6 router-id, the following commands are available:
 
-.. clicmd:: [no] ipv6 router-id X:X::X:X
+.. clicmd:: ipv6 router-id X:X::X:X
 
    Configure the IPv6 router-id of this router. Like its IPv4 counterpart,
    this command works under the vrf subnode, to allow router-id's per vrf.

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -115,42 +115,32 @@ Interface Commands
 Standard Commands
 -----------------
 
-.. index:: interface IFNAME
 
 .. clicmd:: interface IFNAME
 
-.. index:: interface IFNAME vrf VRF
 
 .. clicmd:: interface IFNAME vrf VRF
 
-.. index:: shutdown
 
 .. clicmd:: shutdown
-.. index:: shutdown
 
 .. clicmd:: no shutdown
 
    Up or down the current interface.
 
-.. index:: ip address ADDRESS/PREFIX
 
 .. clicmd:: ip address ADDRESS/PREFIX
-.. index:: ipv6 address ADDRESS/PREFIX
 
 .. clicmd:: ipv6 address ADDRESS/PREFIX
-.. index:: ip address ADDRESS/PREFIX
 
 .. clicmd:: no ip address ADDRESS/PREFIX
-.. index:: ipv6 address ADDRESS/PREFIX
 
 .. clicmd:: no ipv6 address ADDRESS/PREFIX
 
    Set the IPv4 or IPv6 address/prefix for the interface.
 
-.. index:: ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
 
 .. clicmd:: ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
-.. index:: ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
 
 .. clicmd:: no ip address LOCAL-ADDR peer PEER-ADDR/PREFIX
 
@@ -162,25 +152,20 @@ Standard Commands
    behind the other end of the link (or even on the link in Point-to-Multipoint
    setups), though generally /32s are used.
 
-.. index:: description DESCRIPTION ...
 
 .. clicmd:: description DESCRIPTION ...
 
    Set description for the interface.
 
-.. index:: multicast
 
 .. clicmd:: multicast
-.. index:: multicast
 
 .. clicmd:: no multicast
 
    Enable or disables multicast flag for the interface.
 
-.. index:: bandwidth (1-10000000)
 
 .. clicmd:: bandwidth (1-10000000)
-.. index:: bandwidth (1-10000000)
 
 .. clicmd:: no bandwidth (1-10000000)
 
@@ -188,10 +173,8 @@ Standard Commands
    calculating OSPF cost. This command does not affect the actual device
    configuration.
 
-.. index:: link-detect
 
 .. clicmd:: link-detect
-.. index:: link-detect
 
 .. clicmd:: no link-detect
 
@@ -212,10 +195,8 @@ Link Parameters Commands
    protocol extensions that can be used with MPLS-TE. FRR does not
    support a complete RSVP-TE solution currently.
 
-.. index:: link-params
 .. clicmd:: link-params
 
-.. index:: link-param
 .. clicmd:: no link-param
 
    Enter into the link parameters sub node. At least 'enable' must be
@@ -228,24 +209,18 @@ Link Parameters Commands
 
    Under link parameter statement, the following commands set the different TE values:
 
-.. index:: link-params [enable]
 .. clicmd:: link-params [enable]
 
    Enable link parameters for this interface.
 
-.. index:: link-params [metric (0-4294967295)]
 .. clicmd:: link-params [metric (0-4294967295)]
 
-.. index:: link-params max-bw BANDWIDTH
 .. clicmd:: link-params max-bw BANDWIDTH
 
-.. index:: link-params max-rsv-bw BANDWIDTH
 .. clicmd:: link-params max-rsv-bw BANDWIDTH
 
-.. index:: link-params unrsv-bw (0-7) BANDWIDTH
 .. clicmd:: link-params unrsv-bw (0-7) BANDWIDTH
 
-.. index:: link-params admin-grp BANDWIDTH
 .. clicmd:: link-params admin-grp BANDWIDTH
 
    These commands specifies the Traffic Engineering parameters of the interface
@@ -258,22 +233,16 @@ Link Parameters Commands
    Note that BANDIWDTH is specified in IEEE floating point format and express
    in Bytes/second.
 
-.. index::  link-param delay (0-16777215) [min (0-16777215) | max (0-16777215)]
 .. clicmd:: link-param delay (0-16777215) [min (0-16777215) | max (0-16777215)]
 
-.. index::  link-param delay-variation (0-16777215)
 .. clicmd:: link-param delay-variation (0-16777215)
 
-.. index::  link-param packet-loss PERCENTAGE
 .. clicmd:: link-param packet-loss PERCENTAGE
 
-.. index::  link-param res-bw BANDWIDTH
 .. clicmd:: link-param res-bw BANDWIDTH
 
-.. index::  link-param ava-bw BANDWIDTH
 .. clicmd:: link-param ava-bw BANDWIDTH
 
-.. index::  link-param use-bw BANDWIDTH
 .. clicmd:: link-param use-bw BANDWIDTH
 
    These command specifies additional Traffic Engineering parameters of the
@@ -287,17 +256,14 @@ Link Parameters Commands
    (µs). Loss is specified in PERCENTAGE ranging from 0 to 50.331642% by step
    of 0.000003.
 
-.. index:: link-param neighbor <A.B.C.D> as (0-65535)
 .. clicmd:: link-param neighbor <A.B.C.D> as (0-65535)
 
-.. index:: link-param no neighbor
 .. clicmd:: link-param no neighbor
 
    Specifies the remote ASBR IP address and Autonomous System (AS) number
    for InterASv2 link in OSPF (RFC5392).  Note that this option is not yet
    supported for ISIS (RFC5316).
 
-.. index:: ip nht resolve-via-default
 .. clicmd:: ip nht resolve-via-default
 
    Allows nexthop tracking to resolve via the default route. This is useful
@@ -427,7 +393,6 @@ see https://www.kernel.org/doc/Documentation/networking/vrf.txt.
 Because of that difference, there are some subtle differences when running some
 commands in relationship to VRF. Here is an extract of some of those commands:
 
-.. index:: vrf VRF
 .. clicmd:: vrf VRF
 
    This command is available on configuration mode. By default, above command
@@ -436,7 +401,6 @@ commands in relationship to VRF. Here is an extract of some of those commands:
    The network administrator can however decide to provision this command in
    configuration file to provide more clarity about the intended configuration.
 
-.. index:: netns NAMESPACE
 .. clicmd:: netns NAMESPACE
 
    This command is based on VRF configuration mode. This command is available
@@ -447,7 +411,6 @@ commands in relationship to VRF. Here is an extract of some of those commands:
    decide to provision this command in configuration file to provide more clarity
    about the intended configuration.
 
-.. index:: show ip route vrf VRF
 .. clicmd:: show ip route vrf VRF
 
    The show command permits dumping the routing table associated to the VRF. If
@@ -457,20 +420,17 @@ commands in relationship to VRF. Here is an extract of some of those commands:
    launched with :option:`-n` option, this will be the default routing table of
    the *Linux network namespace* ``VRF``.
 
-.. index:: show ip route vrf VRF table TABLENO
 .. clicmd:: show ip route vrf VRF table TABLENO
 
    The show command is only available with :option:`-n` option. This command
    will dump the routing table ``TABLENO`` of the *Linux network namespace*
    ``VRF``.
 
-.. index:: show ip route vrf VRF tables
 .. clicmd:: show ip route vrf VRF tables
 
    This command will dump the routing tables within the vrf scope. If `vrf all`
    is executed, all routing tables will be dumped.
 
-.. index:: show <ip|ipv6> route summary [vrf VRF] [table TABLENO] [prefix]
 .. clicmd:: show <ip|ipv6> route summary [vrf VRF] [table TABLENO] [prefix]
 
    This command will dump a summary output of the specified VRF and TABLENO
@@ -537,7 +497,6 @@ The push action is generally used for LER devices, which want to encapsulate
 all traffic for a wished destination into an MPLS label. This action is stored
 in routing entry, and can be configured like a route:
 
-.. index:: ip route NETWORK MASK GATEWAY|INTERFACE label LABEL
 .. clicmd:: [no] ip route NETWORK MASK GATEWAY|INTERFACE label LABEL
 
    NETWORK and MASK stand for the IP prefix entry to be added as static
@@ -568,7 +527,6 @@ The swap action is generally used for LSR devices, which swap a packet with a
 label, with an other label. The Pop action is used on LER devices, at the
 termination of the MPLS traffic; this is used to remove MPLS header.
 
-.. index:: mpls lsp INCOMING_LABEL GATEWAY OUTGOING_LABEL|explicit-null|implicit-null
 .. clicmd:: [no] mpls lsp INCOMING_LABEL GATEWAY OUTGOING_LABEL|explicit-null|implicit-null
 
    INCOMING_LABEL and OUTGOING_LABEL are MPLS labels with values ranging from 16
@@ -582,7 +540,6 @@ termination of the MPLS traffic; this is used to remove MPLS header.
 You can check that the MPLS actions are stored in the zebra MPLS table, by looking at the
 presence of the entry.
 
-.. index:: show mpls table
 .. clicmd:: show mpls table
 
 ::
@@ -616,10 +573,8 @@ WARNING: RPF lookup results are non-responsive in this version of FRR,
 i.e. multicast routing does not actively react to changes in underlying
 unicast topology!
 
-.. index:: ip multicast rpf-lookup-mode MODE
 .. clicmd:: ip multicast rpf-lookup-mode MODE
 
-.. index:: ip multicast rpf-lookup-mode [MODE]
 .. clicmd:: no ip multicast rpf-lookup-mode [MODE]
 
    MODE sets the method used to perform RPF lookups. Supported modes:
@@ -654,7 +609,6 @@ unicast topology!
    Unreachable routes do not receive special treatment and do not cause
    fallback to a second lookup.
 
-.. index:: show ip rpf ADDR
 .. clicmd:: show ip rpf ADDR
 
    Performs a Multicast RPF lookup, as configured with ``ip multicast
@@ -673,17 +627,14 @@ unicast topology!
    Indicates that a multicast source lookup for 192.0.2.1 would use an
    Unicast RIB entry for 192.0.2.0/24 with a gateway of 198.51.100.1.
 
-.. index:: show ip rpf
 .. clicmd:: show ip rpf
 
    Prints the entire Multicast RIB. Note that this is independent of the
    configured RPF lookup mode, the Multicast RIB may be printed yet not
    used at all.
 
-.. index:: ip mroute PREFIX NEXTHOP [DISTANCE]
 .. clicmd:: ip mroute PREFIX NEXTHOP [DISTANCE]
 
-.. index:: ip mroute PREFIX NEXTHOP [DISTANCE]
 .. clicmd:: no ip mroute PREFIX NEXTHOP [DISTANCE]
 
    Adds a static route entry to the Multicast RIB. This performs exactly as the
@@ -700,7 +651,6 @@ received from other FRR components. The permit/deny facilities provided by
 these commands can be used to filter which routes zebra will install in the
 kernel.
 
-.. index:: ip protocol PROTOCOL route-map ROUTEMAP
 .. clicmd:: ip protocol PROTOCOL route-map ROUTEMAP
 
    Apply a route-map filter to routes for the specified protocol. PROTOCOL can
@@ -729,7 +679,6 @@ kernel.
    on a per vrf basis, by entering this command under vrf mode for the vrf you
    want to apply the route-map against.
 
-.. index:: set src ADDRESS
 .. clicmd:: set src ADDRESS
 
    Within a route-map, set the preferred source address for matching routes
@@ -768,7 +717,6 @@ IPv6 example for OSPFv3.
    not created at startup.  On Debian, FRR might start before ifupdown
    completes. Consider a reboot test.
 
-.. index:: zebra route-map delay-timer (0-600)
 .. clicmd:: [no] zebra route-map delay-timer (0-600)
 
    Set the delay before any route-maps are processed in zebra.  The
@@ -843,21 +791,18 @@ FPM Commands
 ``fpm`` implementation
 ----------------------
 
-.. index:: fpm connection ip A.B.C.D port (1-65535)
 .. clicmd:: fpm connection ip A.B.C.D port (1-65535)
 
    Configure ``zebra`` to connect to a different FPM server than
    ``127.0.0.1`` port ``2620``.
 
 
-.. index:: fpm connection ip A.B.C.D port (1-65535)
 .. clicmd:: no fpm connection ip A.B.C.D port (1-65535)
 
   Configure ``zebra`` to connect to the default FPM server at ``127.0.0.1``
   port ``2620``.
 
 
-.. index:: show zebra fpm stats
 .. clicmd:: show zebra fpm stats
 
    Shows the FPM statistics.
@@ -893,7 +838,6 @@ FPM Commands
        t_conn_up_finishes                                1                0
 
 
-.. index:: clear zebra fpm stats
 .. clicmd:: clear zebra fpm stats
 
    Reset statistics related to the zebra code that interacts with the
@@ -903,35 +847,30 @@ FPM Commands
 ``dplane_fpm_nl`` implementation
 --------------------------------
 
-.. index:: fpm address <A.B.C.D|X:X::X:X> [port (1-65535)]
 .. clicmd:: fpm address <A.B.C.D|X:X::X:X> [port (1-65535)]
 
    Configures the FPM server address. Once configured ``zebra`` will attempt
    to connect to it immediately.
 
 
-.. index:: fpm address [<A.B.C.D|X:X::X:X> [port (1-65535)]]
 .. clicmd:: no fpm address [<A.B.C.D|X:X::X:X> [port (1-65535)]]
 
    Disables FPM entirely. ``zebra`` will close any current connections and
    will not attempt to connect to it anymore.
 
 
-.. index:: fpm use-next-hop-groups
 .. clicmd:: fpm use-next-hop-groups
 
    Use the new netlink messages ``RTM_NEWNEXTHOP`` / ``RTM_DELNEXTHOP`` to
    group repeated route next hop information.
 
 
-.. index:: fpm use-next-hop-groups
 .. clicmd:: no fpm use-next-hop-groups
 
    Use the old known FPM behavior of including next hop information in the
    route (e.g. ``RTM_NEWROUTE``) messages.
 
 
-.. index:: show fpm counters [json]
 .. clicmd:: show fpm counters [json]
 
    Show the FPM statistics (plain text or JSON formatted).
@@ -956,7 +895,6 @@ FPM Commands
          User FPM disable requests: 0
 
 
-.. index:: clear fpm counters
 .. clicmd:: clear fpm counters
 
    Reset statistics related to the zebra code that interacts with the
@@ -975,14 +913,12 @@ interface IP addresses. The dataplane runs in its own pthread, in
 order to off-load work from the main zebra pthread.
 
 
-.. index:: show zebra dplane [detailed]
 .. clicmd:: show zebra dplane [detailed]
 
    Display statistics about the updates and events passing through the
    dataplane subsystem.
 
 
-.. index:: show zebra dplane providers
 .. clicmd:: show zebra dplane providers
 
    Display information about the running dataplane plugins that are
@@ -990,7 +926,6 @@ order to off-load work from the main zebra pthread.
    present.
 
 
-.. index:: zebra dplane limit [NUMBER]
 .. clicmd:: zebra dplane limit [NUMBER]
 
    Configure the limit on the number of pending updates that are
@@ -1000,7 +935,6 @@ order to off-load work from the main zebra pthread.
 zebra Terminal Mode Commands
 ============================
 
-.. index:: show ip route
 .. clicmd:: show ip route
 
    Display current routes which zebra holds in its database.
@@ -1017,19 +951,15 @@ zebra Terminal Mode Commands
     C* 203.181.89.240/28      eth0
 
 
-.. index:: show ipv6 route
 .. clicmd:: show ipv6 route
 
-.. index:: show [ip|ipv6] route [PREFIX] [nexthop-group]
 .. clicmd:: show [ip|ipv6] route [PREFIX] [nexthop-group]
 
    Display detailed information about a route. If [nexthop-group] is
    included, it will display the nexthop group ID the route is using as well.
 
-.. index:: show interface [NAME] [{vrf VRF|brief}] [nexthop-group]
 .. clicmd:: show interface [NAME] [{vrf VRF|brief}] [nexthop-group]
 
-.. index:: show interface [NAME] [{vrf all|brief}] [nexthop-group]
 .. clicmd:: show interface [NAME] [{vrf all|brief}] [nexthop-group]
 
    Display interface information. If no extra information is added, it will
@@ -1037,34 +967,27 @@ zebra Terminal Mode Commands
    detailed information about that single interface. If [nexthop-group] is
    specified, it will display nexthop groups pointing out that interface.
 
-.. index:: show ip prefix-list [NAME]
 .. clicmd:: show ip prefix-list [NAME]
 
-.. index:: show route-map [NAME]
 .. clicmd:: show route-map [NAME]
 
-.. index:: show ip protocol
 .. clicmd:: show ip protocol
 
-.. index:: show ip forward
 .. clicmd:: show ip forward
 
    Display whether the host's IP forwarding function is enabled or not.
    Almost any UNIX kernel can be configured with IP forwarding disabled.
    If so, the box can't work as a router.
 
-.. index:: show ipv6 forward
 .. clicmd:: show ipv6 forward
 
    Display whether the host's IP v6 forwarding is enabled or not.
 
-.. index:: show zebra
 .. clicmd:: show zebra
 
    Display various statistics related to the installation and deletion
    of routes, neighbor updates, and LSP's into the kernel.
 
-.. index:: show zebra client [summary]
 .. clicmd:: show zebra client [summary]
 
    Display statistics about clients that are connected to zebra.  This is
@@ -1072,7 +995,6 @@ zebra Terminal Mode Commands
    zebra and it's clients.  If the summary form of the command is choosen
    a table is displayed with shortened information.
 
-.. index:: show zebra router table summary
 .. clicmd:: show zebra router table summary
 
    Display summarized data about tables created, their afi/safi/tableid
@@ -1080,7 +1002,6 @@ zebra Terminal Mode Commands
    total number of route nodes in the table.  Which will be higher than
    the actual number of routes that are held.
 
-.. index:: show nexthop-group rib [ID] [vrf NAME] [singleton [ip|ip6]] [type]
 .. clicmd:: show nexthop-group rib [ID] [vrf NAME] [singleton [ip|ip6]] [type]
 
    Display nexthop groups created by zebra.  The [vrf NAME] option
@@ -1098,13 +1019,11 @@ Many routing protocols require a router-id to be configured. To have a
 consistent router-id across all daemons, the following commands are available
 to configure and display the router-id:
 
-.. index:: router-id A.B.C.D
 .. clicmd:: [no] [ip] router-id A.B.C.D
 
    Allow entering of the router-id.  This command also works under the
    vrf subnode, to allow router-id's per vrf.
 
-.. index:: router-id A.B.C.D vrf NAME
 .. clicmd:: [no] [ip] router-id A.B.C.D vrf NAME
 
    Configure the router-id of this router from the configure NODE.
@@ -1112,20 +1031,17 @@ to configure and display the router-id:
    under the vrf sub node.  This command is deprecated and will
    be removed at some point in time in the future.
 
-.. index:: show [ip] router-id [vrf NAME]
 .. clicmd:: show [ip] router-id [vrf NAME]
 
    Display the user configured router-id.
 
 For protocols requiring an IPv6 router-id, the following commands are available:
 
-.. index:: ipv6 router-id X:X::X:X
 .. clicmd:: [no] ipv6 router-id X:X::X:X
 
    Configure the IPv6 router-id of this router. Like its IPv4 counterpart,
    this command works under the vrf subnode, to allow router-id's per vrf.
 
-.. index:: show ipv6 router-id [vrf NAME]
 .. clicmd:: show ipv6 router-id [vrf NAME]
 
    Display the user configured IPv6 router-id.


### PR DESCRIPTION
- Fix some of the duplicate command warnings
- Automatically generate index entries from `.. clicmd` directive, no need for separate `.. index` directive
- remove all separate `.. index` directives for CLI commands
- improve most of the remaining manual index directives
- remove all 'no' forms of commands; these are inconsistent, everyone does them differently, and they  don't add anything to the docs since all commands have no forms 