### PR TITLE
Fix for #3973: GRE / VTI tunnels on FreeBSD always unnumbered, ignoring destination mask.

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -77,10 +77,17 @@ static void connected_announce(struct interface *ifp, struct connected *ifc)
 
 	if (!if_is_loopback(ifp) && ifc->address->family == AF_INET &&
 	    !IS_ZEBRA_IF_VRF(ifp)) {
-		if (ifc->address->prefixlen == 32)
-			SET_FLAG(ifc->flags, ZEBRA_IFA_UNNUMBERED);
-		else
-			UNSET_FLAG(ifc->flags, ZEBRA_IFA_UNNUMBERED);
+		if(CONNECTED_PEER(ifc)) {
+			if (ifc->destination->prefixlen == 32)
+				SET_FLAG(ifc->flags, ZEBRA_IFA_UNNUMBERED);
+			else
+				UNSET_FLAG(ifc->flags, ZEBRA_IFA_UNNUMBERED);
+		} else {
+			if (ifc->address->prefixlen == 32)
+				SET_FLAG(ifc->flags, ZEBRA_IFA_UNNUMBERED);
+			else
+				UNSET_FLAG(ifc->flags, ZEBRA_IFA_UNNUMBERED);
+		}
 	}
 
 	listnode_add(ifp->connected, ifc);


### PR DESCRIPTION
For interfaces with a peer address (tunnels, etc.), use the netmask of the peer destination, rather than local end, to establish if the interface should be treated as unnumbered. Affects frr on FreeBSD and anywhere else where tunnels have a peer / destination address.