### PR TITLE
zebra : fix loop in resolving nexthop through itself

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -712,15 +712,10 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 			*prn = rn;
 			return re;
 		}
-
-		if (!CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED))
-			rn = rn->parent;
-		else {
-			if (IS_ZEBRA_DEBUG_NHT_DETAILED)
-				zlog_debug(
-					"        Nexthop must be connected, cannot recurse up");
-			return NULL;
-		}
+		/* Resolve the nexthop recursively by finding matching
+		 * route with lower prefix length
+		 */
+		rn = rn->parent;
 	}
 
 	return NULL;


### PR DESCRIPTION
problem statement :
Zebra nexthop resolution stucks in the loop oscillating
from resolved/unresolved.

C>* 120.254.120.0/30 is directly connected, ens225, 00:07:30
B>* 120.254.120.1/32 [20/0] via 120.254.120.2, ens225, weight 1, 00:00:00
B   120.254.120.2/32 [20/0] via 120.254.120.2 inactive, weight 1, 00:00:00

Once we have above set of routes in a particular order, NHT goes in loop.

RCA :
1. Connected route comes up 120.254.120.0/30, this route goes to FIB.
2. Now BGP routes coming, these gets resolved over above connected FIB route.
3. 120.254.120.2/32 route comes, this is more specific route.
   As it is going to resolved through itself.
   This route remains in RIB and in inactive state.
4. 120.254.120.1/32 route comes, after route processing,
   Zebra triggers the nexthop resolution again.
   This results in resolution on 120.254.120.2/32 route and this
   route is inactive. This leads to nexthop resolution unreachable.
   This point starts the loop.

Fix :
While resolving nexthop, walk up the tree without any ZEBRA_NHT_CONNECTED check.

Signed-off-by: vishaldhingra <vdhingra@vmware.com>