### PR TITLE
ospf6d: fix LSA prefix options

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -684,11 +684,9 @@ static int ospf6_link_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	int prefixnum;
 	char buf[128], options[32];
 	struct ospf6_prefix *prefix;
-	const char *p, *mc, *la, *nu;
 	struct in6_addr in6;
 	json_object *json_loop;
 	json_object *json_arr = NULL;
-	char str[15];
 	char prefix_string[133];
 
 	link_lsa = (struct ospf6_link_lsa *)((caddr_t)lsa->header
@@ -720,26 +718,13 @@ static int ospf6_link_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 		    || current + OSPF6_PREFIX_SIZE(prefix) > end)
 			break;
 
-		p = (CHECK_FLAG(prefix->prefix_options, OSPF6_PREFIX_OPTION_P)
-			     ? "P"
-			     : "--");
-		mc = (CHECK_FLAG(prefix->prefix_options, OSPF6_PREFIX_OPTION_MC)
-			      ? "MC"
-			      : "--");
-		la = (CHECK_FLAG(prefix->prefix_options, OSPF6_PREFIX_OPTION_LA)
-			      ? "LA"
-			      : "--");
-		nu = (CHECK_FLAG(prefix->prefix_options, OSPF6_PREFIX_OPTION_NU)
-			      ? "NU"
-			      : "--");
+		ospf6_prefix_options_printbuf(prefix->prefix_options, buf,
+					      sizeof(buf));
 		if (use_json) {
 			json_loop = json_object_new_object();
-			snprintf(str, sizeof(str), "%s|%s|%s|%s", p, mc, la,
-				 nu);
-			json_object_string_add(json_loop, "prefixOption", str);
+			json_object_string_add(json_loop, "prefixOption", buf);
 		} else
-			vty_out(vty, "     Prefix Options: %s|%s|%s|%s\n", p,
-				mc, la, nu);
+			vty_out(vty, "     Prefix Options: %s\n", buf);
 
 		memset(&in6, 0, sizeof(in6));
 		memcpy(&in6, OSPF6_PREFIX_BODY(prefix),
@@ -916,11 +901,9 @@ static int ospf6_intra_prefix_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	char buf[128];
 	struct ospf6_prefix *prefix;
 	char id[16], adv_router[16];
-	const char *p, *mc, *la, *nu;
 	struct in6_addr in6;
 	json_object *json_loop;
 	json_object *json_arr = NULL;
-	char str[15];
 	char prefix_string[133];
 
 	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa
@@ -959,26 +942,13 @@ static int ospf6_intra_prefix_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 		    || current + OSPF6_PREFIX_SIZE(prefix) > end)
 			break;
 
-		p = (CHECK_FLAG(prefix->prefix_options, OSPF6_PREFIX_OPTION_P)
-			     ? "P"
-			     : "--");
-		mc = (CHECK_FLAG(prefix->prefix_options, OSPF6_PREFIX_OPTION_MC)
-			      ? "MC"
-			      : "--");
-		la = (CHECK_FLAG(prefix->prefix_options, OSPF6_PREFIX_OPTION_LA)
-			      ? "LA"
-			      : "--");
-		nu = (CHECK_FLAG(prefix->prefix_options, OSPF6_PREFIX_OPTION_NU)
-			      ? "NU"
-			      : "--");
+		ospf6_prefix_options_printbuf(prefix->prefix_options, buf,
+					      sizeof(buf));
 		if (use_json) {
 			json_loop = json_object_new_object();
-			snprintf(str, sizeof(str), "%s|%s|%s|%s", p, mc, la,
-				 nu);
-			json_object_string_add(json_loop, "prefixOption", str);
+			json_object_string_add(json_loop, "prefixOption", buf);
 		} else
-			vty_out(vty, "     Prefix Options: %s|%s|%s|%s\n", p,
-				mc, la, nu);
+			vty_out(vty, "     Prefix Options: %s\n", buf);
 
 		memset(&in6, 0, sizeof(in6));
 		memcpy(&in6, OSPF6_PREFIX_BODY(prefix),

--- a/ospf6d/ospf6_proto.c
+++ b/ospf6d/ospf6_proto.c
@@ -60,21 +60,14 @@ void ospf6_prefix_apply_mask(struct ospf6_prefix *op)
 
 void ospf6_prefix_options_printbuf(uint8_t prefix_options, char *buf, int size)
 {
-	const char *p, *mc, *la, *nu;
+	const char *dn, *p, *mc, *la, *nu;
 
-	p = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_P)
-		     ? "P"
-		     : "--");
-	mc = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_MC)
-		      ? "MC"
-		      : "--");
-	la = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_LA)
-		      ? "LA"
-		      : "--");
-	nu = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_NU)
-		      ? "NU"
-		      : "--");
-	snprintf(buf, size, "%s|%s|%s|%s", p, mc, la, nu);
+	dn = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_DN) ? "DN" : "--");
+	p = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_P) ? "P" : "--");
+	mc = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_MC) ? "MC" : "--");
+	la = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_LA) ? "LA" : "--");
+	nu = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_NU) ? "NU" : "--");
+	snprintf(buf, size, "%s|%s|%s|%s|%s", dn, p, mc, la, nu);
 }
 
 void ospf6_capability_printbuf(char capability, char *buf, int size)

--- a/ospf6d/ospf6_proto.c
+++ b/ospf6d/ospf6_proto.c
@@ -60,7 +60,21 @@ void ospf6_prefix_apply_mask(struct ospf6_prefix *op)
 
 void ospf6_prefix_options_printbuf(uint8_t prefix_options, char *buf, int size)
 {
-	snprintf(buf, size, "xxx");
+	const char *p, *mc, *la, *nu;
+
+	p = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_P)
+		     ? "P"
+		     : "--");
+	mc = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_MC)
+		      ? "MC"
+		      : "--");
+	la = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_LA)
+		      ? "LA"
+		      : "--");
+	nu = (CHECK_FLAG(prefix_options, OSPF6_PREFIX_OPTION_NU)
+		      ? "NU"
+		      : "--");
+	snprintf(buf, size, "%s|%s|%s|%s", p, mc, la, nu);
 }
 
 void ospf6_capability_printbuf(char capability, char *buf, int size)

--- a/ospf6d/ospf6_proto.h
+++ b/ospf6d/ospf6_proto.h
@@ -69,6 +69,8 @@ struct ospf6_prefix {
 #define OSPF6_PREFIX_OPTION_LA (1 << 1)  /* Local Address */
 #define OSPF6_PREFIX_OPTION_MC (1 << 2)  /* MultiCast */
 #define OSPF6_PREFIX_OPTION_P  (1 << 3)  /* Propagate (NSSA) */
+#define OSPF6_PREFIX_OPTION_DN                                                 \
+	(1 << 4) /* DN bit to prevent loops in VPN environment */
 
 /* caddr_t OSPF6_PREFIX_BODY (struct ospf6_prefix *); */
 #define OSPF6_PREFIX_BODY(x) ((caddr_t)(x) + sizeof(struct ospf6_prefix))


### PR DESCRIPTION
This PR fixes the Prefix options for Type 3 and Type 5 LSA where 'xxx' is printed. Then some redundant code is removed and finally bit DN is added according to RFC 5340
```
r3# sh ipv6 os database as-external self-originated detail 

        AS Scoped Link State Database

Age:   90 Type: AS-External
Link State ID: 0.0.0.0
Advertising Router: 3.3.3.3
LS Sequence Number: 0x80000001
CheckSum: 0x74a2 Length: 44
Duration: 00:01:30
     Bits: ---
     Metric:     0
     Prefix Options: xxx   <----- ***
     Referenced LSType: 0
     Prefix: 33:33::3/128     
```
Signed-off-by: ckishimo <carles.kishimoto@gmail.com>