### PR TITLE
pimd: do static mroute loop check in NB VALIDATE

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2394,6 +2394,13 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 	struct ipaddr group_addr;
 	const struct lyd_node *if_dnode;
 
+	iif = nb_running_get_entry(args->dnode, NULL, true);
+	pim_iifp = iif->info;
+	pim = pim_iifp->pim;
+
+	oifname = yang_dnode_get_string(args->dnode, NULL);
+	oif = if_lookup_by_name(oifname, pim->vrf_id);
+
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
@@ -2402,18 +2409,20 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 				 "%% Enable PIM and/or IGMP on this interface first");
 			return NB_ERR_VALIDATION;
 		}
+
+#ifdef PIM_ENFORCE_LOOPFREE_MFC
+		if (iif->ifindex == oif->ifindex) {
+			strlcpy(args->errmsg,
+				"% IIF same as OIF and loopfree enforcement is enabled; rejecting",
+				args->errmsg_len);
+			return NB_ERR_VALIDATION;
+		}
+#endif
 		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		iif = nb_running_get_entry(args->dnode, NULL, true);
-		pim_iifp = iif->info;
-		pim = pim_iifp->pim;
-
-		oifname = yang_dnode_get_string(args->dnode, NULL);
-		oif = if_lookup_by_name(oifname, pim->vrf_id);
-
 		if (!oif) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "No such interface name %s",


### PR DESCRIPTION
We can proactively check whether this mroute will be nacked by loopfree
MFC checks so let's do it in the apply phase and emit a useful error
message.

Old:
```
ubuntu2004(config-if)# ip mroute ens18 230.0.0.69 192.168.0.216
Failed to add static mroute
```

New:
```
ubuntu2004(config-if)# ip mroute ens18 239.0.0.70 192.168.0.217 
% Configuration failed.

Error type: validation
Error description: % IIF same as OIF and loopfree enforcement is enabled; rejecting
```

Signed-off-by: Quentin Young <qlyoung@nvidia.com>