### PR TITLE
tests: Fix for blackhole test in test_mcast_pim_bsmp suite

### DIFF
--- a/tests/topotests/multicast-pim-bsm-topo1/test_mcast_pim_bsmp_01.py
+++ b/tests/topotests/multicast-pim-bsm-topo1/test_mcast_pim_bsmp_01.py
@@ -644,7 +644,6 @@ def test_BSR_CRP_with_blackhole_address_p1(request):
     next_hop_lhr = topo["routers"]["i1"]["links"]["l1"]["ipv4"].split("/")[0]
 
     input_dict = {
-        "f1": {"static_routes": [{"network": BSR1_ADDR, "next_hop": NEXT_HOP1}]},
         "i1": {"static_routes": [{"network": BSR1_ADDR, "next_hop": next_hop_rp}]},
         "l1": {"static_routes": [{"network": BSR1_ADDR, "next_hop": next_hop_lhr}]},
     }
@@ -706,7 +705,8 @@ def test_BSR_CRP_with_blackhole_address_p1(request):
     input_dict = {
         "f1": {
             "static_routes": [
-                {"network": [BSR1_ADDR, CRP], "next_hop": "blackhole", "delete": True}
+                {"network": [BSR1_ADDR, CRP], "next_hop": "blackhole", "delete": True},
+                {"network": BSR1_ADDR, "next_hop": NEXT_HOP1}
             ]
         }
     }


### PR DESCRIPTION
We were installing same route with regular and blackhole nexthops.

Changes done:
Removed static routes with regular nexthop. Test is working fine with changes in PR https://github.com/FRRouting/frr/pull/8152 and in master also.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>