### PR TITLE
 fix rpmbuild 

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -44,6 +44,9 @@
 # defines for configure
 %define     rundir  %{_localstatedir}/run/%{name}
 
+# ignore libfrrzm.so's q when zeromq isn't installed
+%define     _unpackaged_files_terminate_build 0
+
 ############################################################################
 
 #### Version String tweak


### PR DESCRIPTION
This fixes issues seen oncentos7 box that previously was used to build a 7.3 rpm.


Processing files: frr-debuginfo-7.5-01.el7.x86_64
Provides: frr-debuginfo = 7.5-01.el7 frr-debuginfo(x86-64) = 7.5-01.el7
Requires(rpmlib): rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1 rpmlib(CompressedFileNames) <= 3.0.4-1
Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/lberger/frr/rpmbuild/BUILDROOT/frr-7.5-01.el7.x86_64
error: Installed (but unpackaged) file(s) found:
   /usr/lib64/libfrrzmq.so.0
   /usr/lib64/libfrrzmq.so.0.0.0

RPM build errors:
    bogus date in %changelog: Tue Nov 2 2020 Donald Sharp <sharpd@nvidia.com> - 7.5
    Installed (but unpackaged) file(s) found:
   /usr/lib64/libfrrzmq.so.0
   /usr/lib64/libfrrzmq.so.0.0.0
