### PR TITLE
ospf6d: turn some info->debug

### DIFF
--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -649,14 +649,10 @@ static int ospf6_spf_calculation_thread(struct thread *t)
 	ospf6_spf_reason_string(ospf6->spf_reason, rbuf, sizeof(rbuf));
 
 	if (IS_OSPF6_DEBUG_SPF(PROCESS) || IS_OSPF6_DEBUG_SPF(TIME))
-		zlog_debug("SPF runtime: %lld sec %lld usec",
-			   (long long)runtime.tv_sec,
-			   (long long)runtime.tv_usec);
-
-	zlog_info(
-		"SPF processing: # Areas: %d, SPF runtime: %lld sec %lld usec, Reason: %s",
-		areas_processed, (long long)runtime.tv_sec,
-		(long long)runtime.tv_usec, rbuf);
+		zlog_debug(
+			"SPF processing: # Areas: %d, SPF runtime: %lld sec %lld usec, Reason: %s",
+			areas_processed, (long long)runtime.tv_sec,
+			(long long)runtime.tv_usec, rbuf);
 
 	ospf6->last_spf_reason = ospf6->spf_reason;
 	ospf6_reset_spf_reason(ospf6);
@@ -718,9 +714,7 @@ void ospf6_spf_schedule(struct ospf6 *ospf6, unsigned int reason)
 	}
 
 	if (IS_OSPF6_DEBUG_SPF(PROCESS) || IS_OSPF6_DEBUG_SPF(TIME))
-		zlog_debug("SPF: calculation timer delay = %ld", delay);
-
-	zlog_info("SPF: Scheduled in %ld msec", delay);
+		zlog_debug("SPF: Rescheduling in %ld msec", delay);
 
 	ospf6->t_spf_calc = NULL;
 	thread_add_timer_msec(master, ospf6_spf_calculation_thread, ospf6,


### PR DESCRIPTION
The log is being spammed every spf interval:

Feb 27 16:19:34  ospf6d[462371]: SPF processing: # Areas: 1, SPF runtime: 0 sec 2043 usec, Reason: R+, R-, N+
Feb 27 16:20:59  ospf6d[462371]: SPF: Scheduled in 0 msec
Feb 27 16:20:59  ospf6d[462371]: SPF processing: # Areas: 1, SPF runtime: 0 sec 2284 usec, Reason: R+, R-
Feb 27 16:21:01  ospf6d[462371]: SPF: Scheduled in 0 msec
Feb 27 16:21:01  ospf6d[462371]: SPF processing: # Areas: 1, SPF runtime: 0 sec 2153 usec, Reason: R+, R-, N-

There is no reason to do this

Signed-off-by: Donald Sharp <sharpd@nvidia.com>