### PR TITLE
Test cleanup and fix evpn_type5_test_topo1

### DIFF
--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
@@ -1475,8 +1475,8 @@ def test_evpn_routes_from_VNFs_p1(request):
                     tgen, dut, intf_name, intf_ipv6, vrf, create=False
                 )
 
-    logger.info("Wait for 60 sec.")
-    sleep(60)
+    result = verify_bgp_convergence(tgen, topo, dut)
+    assert result is True, "Failed to converge on {}".format(dut)
 
     step(
         "Verify that DCG-2 receives EVPN routes corresponding to "

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
@@ -1312,14 +1312,14 @@ def test_evpn_routes_from_VNFs_p1(request):
     )
     for addr_type in ADDR_TYPES:
         input_routes = {key: topo["routers"][key] for key in ["r1"]}
-        result = verify_rib(tgen, addr_type, "d2", input_routes, expected=False)
+        result = verify_rib(tgen, addr_type, "d2", input_routes, expected=True)
         assert result is True, "Testcase {} :Failed \n Error: {}".format(
             tc_name, result
         )
 
     for addr_type in ADDR_TYPES:
         input_routes = {key: topo["routers"][key] for key in ["r2"]}
-        result = verify_rib(tgen, addr_type, "d2", input_routes, expected=False)
+        result = verify_rib(tgen, addr_type, "d2", input_routes, expected=True)
         assert result is True, "Testcase {} :Failed \n Error: {}".format(
             tc_name, result
         )


### PR DESCRIPTION
a) When modifying config that will affect convergence, actually ensure that we are converged instead of just guessing
b) Do not generate support bundles for commands that succeed as we expect them to
c) Reduce the number of show route commands we generate for static routes in verify_rib