### PR TITLE
bgpd, pimd: fix coverity SA warnings

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1701,7 +1701,7 @@ static void bgp_evpn_local_es_activate(struct bgp *bgp, struct bgp_evpn_es *es,
 		/* generate EAD-ES */
 		build_evpn_type1_prefix(&p, BGP_EVPN_AD_ES_ETH_TAG, &es->esi,
 					es->originator_ip);
-		bgp_evpn_type1_route_update(bgp, es, NULL, &p);
+		(void)bgp_evpn_type1_route_update(bgp, es, NULL, &p);
 	}
 }
 

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2411,7 +2411,7 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 		}
 
 #ifdef PIM_ENFORCE_LOOPFREE_MFC
-		if (iif->ifindex == oif->ifindex) {
+		if (oif && iif && (iif->ifindex == oif->ifindex)) {
 			strlcpy(args->errmsg,
 				"% IIF same as OIF and loopfree enforcement is enabled; rejecting",
 				args->errmsg_len);


### PR DESCRIPTION
Fix a couple of coverity warnings in pim and bgp.
