### PR TITLE
zebra: hide backup-nexthop activations in nht

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -52,6 +52,11 @@
 
 DEFINE_MTYPE_STATIC(ZEBRA, RNH, "Nexthop tracking object");
 
+/* UI controls whether to notify about changes that only involve backup
+ * nexthops. Default is to notify all changes.
+ */
+static bool rnh_hide_backups;
+
 static void free_state(vrf_id_t vrf_id, struct route_entry *re,
 		       struct route_node *rn);
 static void copy_state(struct rnh *rnh, const struct route_entry *re,
@@ -1320,4 +1325,17 @@ int rnh_resolve_via_default(struct zebra_vrf *zvrf, int family)
 		return 1;
 	else
 		return 0;
+}
+
+/*
+ * UI control to avoid notifications if backup nexthop status changes
+ */
+void rnh_set_hide_backups(bool hide_p)
+{
+	rnh_hide_backups = hide_p;
+}
+
+bool rnh_get_hide_backups(void)
+{
+	return rnh_hide_backups;
 }

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -64,6 +64,10 @@ extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
 
 extern int rnh_resolve_via_default(struct zebra_vrf *zvrf, int family);
 
+/* UI control to avoid notifications if backup nexthop status changes */
+void rnh_set_hide_backups(bool hide_p);
+bool rnh_get_hide_backups(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1696,7 +1696,6 @@ DEFUN (no_ipv6_nht_default_route,
        "Filter Next Hop tracking route resolution\n"
        "Resolve via default route\n")
 {
-
 	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
 
 	if (!zvrf)
@@ -1707,6 +1706,17 @@ DEFUN (no_ipv6_nht_default_route,
 
 	zvrf->zebra_rnh_ipv6_default_route = 0;
 	zebra_evaluate_rnh(zvrf, AFI_IP6, 0, RNH_NEXTHOP_TYPE, NULL);
+	return CMD_SUCCESS;
+}
+
+DEFPY_HIDDEN(rnh_hide_backups, rnh_hide_backups_cmd,
+	     "[no] ip nht hide-backup-events",
+	     NO_STR
+	     IP_STR
+	     "Nexthop-tracking configuration\n"
+	     "Hide notification about backup nexthops\n")
+{
+	rnh_set_hide_backups(!no);
 	return CMD_SUCCESS;
 }
 
@@ -3656,6 +3666,9 @@ static int config_write_protocol(struct vty *vty)
 	if (!zebra_nhg_recursive_use_backups())
 		vty_out(vty, "no zebra nexthop resolve-via-backup\n");
 
+	if (rnh_get_hide_backups())
+		vty_out(vty, "ip nht hide-backup-events\n");
+
 #ifdef HAVE_NETLINK
 	/* Include netlink info */
 	netlink_config_write_helper(vty);
@@ -4115,6 +4128,8 @@ void zebra_vty_init(void)
 	install_element(VRF_NODE, &no_ip_nht_default_route_cmd);
 	install_element(VRF_NODE, &ipv6_nht_default_route_cmd);
 	install_element(VRF_NODE, &no_ipv6_nht_default_route_cmd);
+	install_element(CONFIG_NODE, &rnh_hide_backups_cmd);
+
 	install_element(VIEW_NODE, &show_ipv6_mroute_cmd);
 
 	/* Commands for VRF */


### PR DESCRIPTION
Optionally hide route changes that only involve backup nexthop activation/deactivation. The goal is to avoid route churn during backup nexthop switchover events, before the resolving routes re-converge. A UI config enables this 'hiding' behavior.
If the new behavior is enabled, zebra will not send nht notifications if a primary nexthop that's part of a tracked route is deactivated in favor of a backup nexthop. zebra will send notifications if the primary or backup nexthops change, or of course if the route for a tracked destination changes.