### PR TITLE
lib, bgpd: handle NULL inputs in printfrr extensions

### DIFF
--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -205,8 +205,14 @@ static ssize_t printfrr_bd(char *buf, size_t bsz, const char *fmt,
 			   int prec, const void *ptr)
 {
 	const struct bgp_dest *dest = ptr;
-	const struct prefix *p = bgp_dest_get_prefix(dest);
+	const struct prefix *p;
 
-	prefix2str(p, buf, bsz);
+	if (dest) {
+		p = bgp_dest_get_prefix(dest);
+		prefix2str(p, buf, bsz);
+	} else {
+		strlcpy(buf, "NULL", bsz);
+	}
+
 	return 2;
 }

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1366,7 +1366,11 @@ static ssize_t printfrr_ea(char *buf, size_t bsz, const char *fmt,
 {
 	const struct ethaddr *mac = ptr;
 
-	prefix_mac2str(mac, buf, bsz);
+	if (mac)
+		prefix_mac2str(mac, buf, bsz);
+	else
+		strlcpy(buf, "NULL", bsz);
+
 	return 2;
 }
 
@@ -1376,7 +1380,11 @@ static ssize_t printfrr_ia(char *buf, size_t bsz, const char *fmt,
 {
 	const struct ipaddr *ipa = ptr;
 
-	ipaddr2str(ipa, buf, bsz);
+	if (ipa)
+		ipaddr2str(ipa, buf, bsz);
+	else
+		strlcpy(buf, "NULL", bsz);
+
 	return 2;
 }
 
@@ -1384,7 +1392,11 @@ printfrr_ext_autoreg_p("I4", printfrr_i4)
 static ssize_t printfrr_i4(char *buf, size_t bsz, const char *fmt,
 			   int prec, const void *ptr)
 {
-	inet_ntop(AF_INET, ptr, buf, bsz);
+	if (ptr)
+		inet_ntop(AF_INET, ptr, buf, bsz);
+	else
+		strlcpy(buf, "NULL", bsz);
+
 	return 2;
 }
 
@@ -1392,7 +1404,11 @@ printfrr_ext_autoreg_p("I6", printfrr_i6)
 static ssize_t printfrr_i6(char *buf, size_t bsz, const char *fmt,
 			   int prec, const void *ptr)
 {
-	inet_ntop(AF_INET6, ptr, buf, bsz);
+	if (ptr)
+		inet_ntop(AF_INET6, ptr, buf, bsz);
+	else
+		strlcpy(buf, "NULL", bsz);
+
 	return 2;
 }
 
@@ -1400,7 +1416,11 @@ printfrr_ext_autoreg_p("FX", printfrr_pfx)
 static ssize_t printfrr_pfx(char *buf, size_t bsz, const char *fmt,
 			    int prec, const void *ptr)
 {
-	prefix2str(ptr, buf, bsz);
+	if (ptr)
+		prefix2str(ptr, buf, bsz);
+	else
+		strlcpy(buf, "NULL", bsz);
+
 	return 2;
 }
 
@@ -1411,16 +1431,22 @@ static ssize_t printfrr_psg(char *buf, size_t bsz, const char *fmt,
 	const struct prefix_sg *sg = ptr;
 	struct fbuf fb = { .buf = buf, .pos = buf, .len = bsz - 1 };
 
-	if (sg->src.s_addr == INADDR_ANY)
-		bprintfrr(&fb, "(*,");
-	else
-		bprintfrr(&fb, "(%pI4,", &sg->src);
+	if (sg) {
+		if (sg->src.s_addr == INADDR_ANY)
+			bprintfrr(&fb, "(*,");
+		else
+			bprintfrr(&fb, "(%pI4,", &sg->src);
 
-	if (sg->grp.s_addr == INADDR_ANY)
-		bprintfrr(&fb, "*)");
-	else
-		bprintfrr(&fb, "%pI4)", &sg->grp);
+		if (sg->grp.s_addr == INADDR_ANY)
+			bprintfrr(&fb, "*)");
+		else
+			bprintfrr(&fb, "%pI4)", &sg->grp);
 
-	fb.pos[0] = '\0';
+		fb.pos[0] = '\0';
+
+	} else {
+		strlcpy(buf, "NULL", bsz);
+	}
+
 	return 3;
 }

--- a/lib/sockunion.c
+++ b/lib/sockunion.c
@@ -673,39 +673,44 @@ static ssize_t printfrr_psu(char *buf, size_t bsz, const char *fmt,
 	bool endflags = false;
 	ssize_t consumed = 2;
 
-	while (!endflags) {
-		switch (fmt[consumed++]) {
-		case 'p':
-			include_port = true;
+	if (su) {
+		while (!endflags) {
+			switch (fmt[consumed++]) {
+			case 'p':
+				include_port = true;
+				break;
+			default:
+				consumed--;
+				endflags = true;
+				break;
+			}
+		};
+
+		switch (sockunion_family(su)) {
+		case AF_UNSPEC:
+			bprintfrr(&fb, "(unspec)");
+			break;
+		case AF_INET:
+			inet_ntop(AF_INET, &su->sin.sin_addr, buf, bsz);
+			fb.pos += strlen(fb.buf);
+			if (include_port)
+				bprintfrr(&fb, ":%d", su->sin.sin_port);
+			break;
+		case AF_INET6:
+			inet_ntop(AF_INET6, &su->sin6.sin6_addr, buf, bsz);
+			fb.pos += strlen(fb.buf);
+			if (include_port)
+				bprintfrr(&fb, ":%d", su->sin6.sin6_port);
 			break;
 		default:
-			consumed--;
-			endflags = true;
-			break;
+			bprintfrr(&fb, "(af %d)", sockunion_family(su));
 		}
-	};
 
-	switch (sockunion_family(su)) {
-	case AF_UNSPEC:
-		bprintfrr(&fb, "(unspec)");
-		break;
-	case AF_INET:
-		inet_ntop(AF_INET, &su->sin.sin_addr, buf, bsz);
-		fb.pos += strlen(fb.buf);
-		if (include_port)
-			bprintfrr(&fb, ":%d", su->sin.sin_port);
-		break;
-	case AF_INET6:
-		inet_ntop(AF_INET6, &su->sin6.sin6_addr, buf, bsz);
-		fb.pos += strlen(fb.buf);
-		if (include_port)
-			bprintfrr(&fb, ":%d", su->sin6.sin6_port);
-		break;
-	default:
-		bprintfrr(&fb, "(af %d)", sockunion_family(su));
+		fb.pos[0] = '\0';
+	} else {
+		strlcpy(buf, "NULL", bsz);
 	}
 
-	fb.pos[0] = '\0';
 	return consumed;
 }
 

--- a/lib/srcdest_table.c
+++ b/lib/srcdest_table.c
@@ -313,8 +313,13 @@ static ssize_t printfrr_rn(char *buf, size_t bsz, const char *fmt,
 	const struct route_node *rn = ptr;
 	const struct prefix *dst_p, *src_p;
 
-	srcdest_rnode_prefixes(rn, &dst_p, &src_p);
-	srcdest2str(dst_p, (const struct prefix_ipv6 *)src_p, buf, bsz);
+	if (rn) {
+		srcdest_rnode_prefixes(rn, &dst_p, &src_p);
+		srcdest2str(dst_p, (const struct prefix_ipv6 *)src_p, buf, bsz);
+	} else {
+		strlcpy(buf, "NULL", bsz);
+	}
+
 	return 2;
 }
 


### PR DESCRIPTION
Handle a NULL input argument to printfrr extensions safely, by printing "NULL" to the output buffer.
