### PR TITLE
tests: Sort expected and actual to avoid locale issues

### DIFF
--- a/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
+++ b/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
@@ -346,13 +346,15 @@ def test_converge_protocols():
 
         print("Show that v4 routes are right\n")
         v4_routesFile = "%s/r%s/ipv4_routes.ref" % (thisDir, i)
-        expected = open(v4_routesFile).read().rstrip()
+        expected = net["r%s" % i].cmd(
+            "sort {} 2> /dev/null".format(v4_routesFile)
+        ).rstrip()
         expected = ("\n".join(expected.splitlines()) + "\n").splitlines(1)
 
         actual = (
             net["r%s" % i]
             .cmd(
-                "vtysh -c \"show ip route\" | sed -e '/^Codes: /,/^\s*$/d' | env LC_ALL=en_US.UTF-8 sort 2> /dev/null"
+                "vtysh -c \"show ip route\" | sed -e '/^Codes: /,/^\s*$/d' | sort 2> /dev/null"
             )
             .rstrip()
         )
@@ -377,13 +379,15 @@ def test_converge_protocols():
 
         print("Show that v6 routes are right\n")
         v6_routesFile = "%s/r%s/ipv6_routes.ref" % (thisDir, i)
-        expected = open(v6_routesFile).read().rstrip()
+        expected = net["r%s" % i].cmd(
+            "sort {} 2> /dev/null".format(v6_routesFile)
+        ).rstrip()
         expected = ("\n".join(expected.splitlines()) + "\n").splitlines(1)
 
         actual = (
             net["r%s" % i]
             .cmd(
-                "vtysh -c \"show ipv6 route\" | sed -e '/^Codes: /,/^\s*$/d' | env LC_ALL=en_US.UTF-8 sort 2> /dev/null"
+                "vtysh -c \"show ipv6 route\" | sed -e '/^Codes: /,/^\s*$/d' | sort 2> /dev/null"
             )
             .rstrip()
         )


### PR DESCRIPTION
Avoid undocumented topotest dependency on installing en_US locale.
With this change dependency is removed.

Signed-off-by: Christian Hopps <chopps@labn.net>