### PR TITLE
tests: fix invocation of send_bsr_packet.py script for python 2

### DIFF
--- a/tests/topotests/lib/pim.py
+++ b/tests/topotests/lib/pim.py
@@ -2114,7 +2114,7 @@ def scapy_send_bsr_raw_packet(
             )
         else:
             cmd = (
-                "/usr/bin/python {}/send_bsr_packet.py '{}' '{}' "
+                "/usr/bin/python2 {}/send_bsr_packet.py '{}' '{}' "
                 "--interval={} --count={}".format(
                     CWD, packet, sender_interface, interval, count
                 )


### PR DESCRIPTION
The pim test script send_bsr_packet.py appears to not work properly
with scapy and python3.

sudo /usr/bin/python ./send_bsr_packet.py "01005e00000d005056961165080045c000aa5af500000167372a46000001e000000d2400f5ce165b000001004600000101000018e1010100080800000100090a090a0096650001000909090a0096660001000708090a00966700010007070907009668000100070702070096690001000705020700966a0001000702020700966b0001000202020200966c0001000020e1010101010100000100050606050096000001000020e20101010101000001000909090900960000" enp39s0 --interval=1 --count=1
Traceback (most recent call last):
  File "/home/sharpd/frr6/tests/topotests/lib/./send_bsr_packet.py", line 23, in <module>
    from scapy.all import Raw, sendp
  File "/usr/local/lib/python3.9/dist-packages/scapy/all.py", line 16, in <module>
    from scapy.arch import *
  File "/usr/local/lib/python3.9/dist-packages/scapy/arch/__init__.py", line 27, in <module>
    from scapy.arch.bpf.core import get_if_raw_addr
  File "/usr/local/lib/python3.9/dist-packages/scapy/arch/bpf/core.py", line 30, in <module>
    LIBC = cdll.LoadLibrary(find_library("libc"))
  File "/usr/lib/python3.9/ctypes/util.py", line 341, in find_library
    _get_soname(_findLib_gcc(name)) or _get_soname(_findLib_ld(name))
  File "/usr/lib/python3.9/ctypes/util.py", line 147, in _findLib_gcc
    if not _is_elf(file):
  File "/usr/lib/python3.9/ctypes/util.py", line 99, in _is_elf
    with open(filename, 'br') as thefile:

Limit running to python2

Signed-off-by: Donald Sharp <sharpd@nvidia.com>