### PR TITLE
tests: make the topogen object available when starting daemons

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1367,7 +1367,7 @@ class Router(Node):
                 logger.info("BFD Test, but no bfdd compiled or installed")
                 return "BFD Test, but no bfdd compiled or installed"
 
-        return self.startRouterDaemons()
+        return self.startRouterDaemons(tgen=tgen)
 
     def getStdErr(self, daemon):
         return self.getLog("err", daemon)
@@ -1378,7 +1378,7 @@ class Router(Node):
     def getLog(self, log, daemon):
         return self.cmd("cat {}/{}/{}.{}".format(self.logdir, self.name, daemon, log))
 
-    def startRouterDaemons(self, daemons=None):
+    def startRouterDaemons(self, daemons=None, tgen=None):
         "Starts all FRR daemons for this router."
 
         bundle_data = ""


### PR DESCRIPTION
Pass the topogen 'tgen' object into the startRouterDaemons() method. That object can be used to start a debug cli immediately after starting a daemon, and that can be handy.
