### PR TITLE
tests: Fix for test failure in PR #8158

### DIFF
--- a/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo1.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo1.py
@@ -498,7 +498,6 @@ def disable_route_map_to_prefer_global_next_hop(tgen, topo):
 #
 #####################################################
 
-
 def test_dynamic_imported_routes_advertised_to_iBGP_peer_p0(request):
     """
     TC5_FUNC_5:
@@ -758,6 +757,29 @@ def test_dynamic_imported_routes_advertised_to_iBGP_peer_p0(request):
         assert (
             result is not True
         ), "Testcase {} : Failed \n Routes are still present \n Error {}".format(
+            tc_name, result
+        )
+
+    for addr_type in ADDR_TYPES:
+
+        step(
+            "On router R1 delete static routes in vrf ISR to LOOPBACK_1"
+        )
+
+        input_routes_r1 = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": [NETWORK1_3[addr_type], NETWORK1_4[addr_type]],
+                        "next_hop": (intf_r2_r1[addr_type]).split("/")[0],
+                        "delete": True
+                    }
+                ]
+            }
+        }
+
+        result = create_static_routes(tgen, input_routes_r1)
+        assert result is True, "Testcase {} :Failed \n Error: {}".format(
             tc_name, result
         )
 

--- a/tests/topotests/multicast-pim-bsm-topo1/test_mcast_pim_bsmp_01.py
+++ b/tests/topotests/multicast-pim-bsm-topo1/test_mcast_pim_bsmp_01.py
@@ -642,10 +642,13 @@ def test_BSR_CRP_with_blackhole_address_p1(request):
 
     next_hop_rp = topo["routers"]["f1"]["links"]["i1"]["ipv4"].split("/")[0]
     next_hop_lhr = topo["routers"]["i1"]["links"]["l1"]["ipv4"].split("/")[0]
+    next_hop_fhr = topo["routers"]["i1"]["links"]["f1"]["ipv4"].split("/")[0]
+    CRP = topo["routers"]["b1"]["bsm"]["bsr_packets"]["packet9"]["candidate_rp"]
 
     input_dict = {
         "i1": {"static_routes": [{"network": BSR1_ADDR, "next_hop": next_hop_rp}]},
         "l1": {"static_routes": [{"network": BSR1_ADDR, "next_hop": next_hop_lhr}]},
+        "f1": {"static_routes": [{"network": CRP, "next_hop": next_hop_fhr, "delete": True}]},
     }
 
     result = create_static_routes(tgen, input_dict)
@@ -654,7 +657,6 @@ def test_BSR_CRP_with_blackhole_address_p1(request):
     # Use scapy to send pre-defined packet from senser to receiver
 
     group = topo["routers"]["b1"]["bsm"]["bsr_packets"]["packet9"]["group"]
-    CRP = topo["routers"]["b1"]["bsm"]["bsr_packets"]["packet9"]["candidate_rp"]
     step("waiting for BSR to timeout before configuring blackhole route")
     clear_bsrp_data(tgen, topo)
 


### PR DESCRIPTION
1. There were few tests where routes were configured with blackhole and
non-blackhole nexthops simultaneously, enhanced tests accordingly and
verified in master branch and with PR #8158 changes.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>