### PR TITLE
bgpd,lib: rework BGP BFD integration

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -310,7 +310,6 @@ void bgp_peer_configure_bfd(struct peer *p, bool manual)
 				       p->nexthop.ifp->name);
 
 	bfd_sess_enable(p->bfd_config->session, true);
-	bgp_peer_config_apply(p, p->group);
 }
 
 static void bgp_peer_remove_bfd(struct peer *p)
@@ -447,6 +446,8 @@ DEFUN (neighbor_bfd,
 		bgp_group_configure_bfd(peer);
 	else
 		bgp_peer_configure_bfd(peer, true);
+
+	bgp_peer_config_apply(peer, peer->group);
 
 	return CMD_SUCCESS;
 }

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -29,6 +29,7 @@
 #include "thread.h"
 #include "buffer.h"
 #include "stream.h"
+#include "vrf.h"
 #include "zclient.h"
 #include "bfd.h"
 #include "lib/json.h"
@@ -40,325 +41,37 @@
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_vty.h"
 
+DEFINE_MTYPE_STATIC(BGPD, BFD_CONFIG, "BFD configuration data");
+
 extern struct zclient *zclient;
 
-/*
- * bgp_bfd_peer_group2peer_copy - Copy the BFD information from peer group
- * template
- *                                to peer.
- */
-void bgp_bfd_peer_group2peer_copy(struct peer *conf, struct peer *peer)
+static void bfd_session_status_update(struct bfd_session_params *bsp,
+				      const struct bfd_session_status *bss,
+				      void *arg)
 {
-	struct bfd_info *bfd_info;
-	struct bfd_info *conf_bfd_info;
-
-	if (!conf->bfd_info)
-		return;
-
-	conf_bfd_info = (struct bfd_info *)conf->bfd_info;
-	if (!peer->bfd_info)
-		peer->bfd_info = bfd_info_create();
-
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-
-	/* Copy BFD parameter values */
-	bfd_info->required_min_rx = conf_bfd_info->required_min_rx;
-	bfd_info->desired_min_tx = conf_bfd_info->desired_min_tx;
-	bfd_info->detect_mult = conf_bfd_info->detect_mult;
-	bfd_info->type = conf_bfd_info->type;
-}
-
-/*
- * bgp_bfd_is_peer_multihop - returns whether BFD peer is multi-hop or single
- * hop.
- */
-bool bgp_bfd_is_peer_multihop(struct peer *peer)
-{
-	struct bfd_info *bfd_info;
-
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-
-	if (!bfd_info)
-		return false;
-
-	if ((bfd_info->type == BFD_TYPE_MULTIHOP)
-	    || ((peer->sort == BGP_PEER_IBGP) && !peer->shared_network)
-	    || is_ebgp_multihop_configured(peer))
-		return true;
-	else
-		return false;
-}
-
-/*
- * bgp_bfd_peer_sendmsg - Format and send a Peer register/Unregister
- *                        command to Zebra to be forwarded to BFD
- */
-static void bgp_bfd_peer_sendmsg(struct peer *peer, int command)
-{
-	struct bfd_session_arg arg = {};
-	struct bfd_info *bfd_info;
-	int multihop;
-	vrf_id_t vrf_id;
-	size_t addrlen;
-
-	/*
-	 * XXX: some pointers are dangling during shutdown, so instead of
-	 * trying to send a message during signal handlers lets just wait BGP
-	 * to terminate zebra's connection and BFD will automatically find
-	 * out that we are no longer expecting notifications.
-	 *
-	 * The pointer that is causing a crash here is `peer->nexthop.ifp`.
-	 * That happens because at this point of the shutdown all interfaces are
-	 * already `free()`d.
-	 */
-	if (bm->terminating)
-		return;
-
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-
-	vrf_id = peer->bgp->vrf_id;
-
-	if (command == ZEBRA_BFD_DEST_DEREGISTER) {
-		multihop =
-			CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_TYPE_MULTIHOP);
-		UNSET_FLAG(bfd_info->flags, BFD_FLAG_BFD_TYPE_MULTIHOP);
-	} else {
-		multihop = bgp_bfd_is_peer_multihop(peer);
-		if ((command == ZEBRA_BFD_DEST_REGISTER) && multihop)
-			SET_FLAG(bfd_info->flags, BFD_FLAG_BFD_TYPE_MULTIHOP);
-	}
-	/* while graceful restart with fwd path preserved
-	 * and bfd controlplane check not configured is not kept
-	 * keep bfd independent controlplane bit set to 1
-	 */
-	if (!CHECK_FLAG(peer->bgp->flags, BGP_FLAG_GRACEFUL_RESTART)
-	    && !CHECK_FLAG(peer->bgp->flags, BGP_FLAG_GR_PRESERVE_FWD)
-	    && !CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CHECK_CONTROLPLANE))
-		SET_FLAG(bfd_info->flags, BFD_FLAG_BFD_CBIT_ON);
-
-	/* Set all message arguments. */
-	arg.family = peer->su.sa.sa_family;
-	addrlen = arg.family == AF_INET ? sizeof(struct in_addr)
-					: sizeof(struct in6_addr);
-
-	if (arg.family == AF_INET)
-		memcpy(&arg.dst, &peer->su.sin.sin_addr, addrlen);
-	else
-		memcpy(&arg.dst, &peer->su.sin6.sin6_addr, addrlen);
-
-	if (peer->su_local) {
-		if (arg.family == AF_INET)
-			memcpy(&arg.src, &peer->su_local->sin.sin_addr,
-			       addrlen);
-		else
-			memcpy(&arg.src, &peer->su_local->sin6.sin6_addr,
-			       addrlen);
-	}
-
-	if (peer->nexthop.ifp) {
-		arg.ifnamelen = strlen(peer->nexthop.ifp->name);
-		strlcpy(arg.ifname, peer->nexthop.ifp->name,
-			sizeof(arg.ifname));
-	}
-
-	if (bfd_info->profile[0]) {
-		arg.profilelen = strlen(bfd_info->profile);
-		strlcpy(arg.profile, bfd_info->profile, sizeof(arg.profile));
-	}
-
-	arg.set_flag = 1;
-	arg.mhop = multihop;
-	arg.ttl = peer->ttl;
-	arg.vrf_id = vrf_id;
-	arg.command = command;
-	arg.bfd_info = bfd_info;
-	arg.min_tx = bfd_info->desired_min_tx;
-	arg.min_rx = bfd_info->required_min_rx;
-	arg.detection_multiplier = bfd_info->detect_mult;
-	arg.cbit = CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CBIT_ON);
-
-	/* Send message. */
-	zclient_bfd_command(zclient, &arg);
-}
-
-/*
- * bgp_bfd_register_peer - register a peer with BFD through zebra
- *                         for monitoring the peer rechahability.
- */
-void bgp_bfd_register_peer(struct peer *peer)
-{
-	struct bfd_info *bfd_info;
-
-	if (!peer->bfd_info)
-		return;
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-
-	/* Check if BFD is enabled and peer has already been registered with BFD
-	 */
-	if (CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_REG))
-		return;
-
-	bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_REGISTER);
-}
-
-/**
- * bgp_bfd_deregister_peer - deregister a peer with BFD through zebra
- *                           for stopping the monitoring of the peer
- *                           rechahability.
- */
-void bgp_bfd_deregister_peer(struct peer *peer)
-{
-	struct bfd_info *bfd_info;
-
-	if (!peer->bfd_info)
-		return;
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-
-	/* Check if BFD is eanbled and peer has not been registered */
-	if (!CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_REG))
-		return;
-
-	bfd_info->status = BFD_STATUS_DOWN;
-	bfd_info->last_update = bgp_clock();
-
-	bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_DEREGISTER);
-}
-
-/*
- * bgp_bfd_update_peer - update peer with BFD with new BFD paramters
- *                       through zebra.
- */
-static void bgp_bfd_update_peer(struct peer *peer)
-{
-	struct bfd_info *bfd_info;
-
-	if (!peer->bfd_info)
-		return;
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-
-	/* Check if the peer has been registered with BFD*/
-	if (!CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_REG))
-		return;
-
-	bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_UPDATE);
-}
-
-/**
- * bgp_bfd_reset_peer - reinitialise bfd
- * ensures that bfd state machine is restarted
- * to be synced with remote bfd
- */
-void bgp_bfd_reset_peer(struct peer *peer)
-{
-	if (!peer->bfd_info)
-		return;
-
-	bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_REGISTER);
-}
-
-/*
- * bgp_bfd_update_type - update session type with BFD through zebra.
- */
-static void bgp_bfd_update_type(struct peer *peer)
-{
-	struct bfd_info *bfd_info;
-	int multihop;
-
-	if (!peer->bfd_info)
-		return;
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-
-	/* Check if the peer has been registered with BFD*/
-	if (!CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_REG))
-		return;
-
-	if (bfd_info->type == BFD_TYPE_NOT_CONFIGURED) {
-		multihop = bgp_bfd_is_peer_multihop(peer);
-		if ((multihop
-		     && !CHECK_FLAG(bfd_info->flags,
-				    BFD_FLAG_BFD_TYPE_MULTIHOP))
-		    || (!multihop && CHECK_FLAG(bfd_info->flags,
-						BFD_FLAG_BFD_TYPE_MULTIHOP))) {
-			bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_DEREGISTER);
-			bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_REGISTER);
-		}
-	} else {
-		if ((bfd_info->type == BFD_TYPE_MULTIHOP
-		     && !CHECK_FLAG(bfd_info->flags,
-				    BFD_FLAG_BFD_TYPE_MULTIHOP))
-		    || (bfd_info->type == BFD_TYPE_SINGLEHOP
-			&& CHECK_FLAG(bfd_info->flags,
-				      BFD_FLAG_BFD_TYPE_MULTIHOP))) {
-			bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_DEREGISTER);
-			bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_REGISTER);
-		}
-	}
-}
-
-/*
- * bgp_bfd_dest_replay - Replay all the peers that have BFD enabled
- *                       to zebra
- */
-static int bgp_bfd_dest_replay(ZAPI_CALLBACK_ARGS)
-{
-	struct listnode *mnode, *node, *nnode;
-	struct bgp *bgp;
-	struct peer *peer;
+	struct peer *peer = arg;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Zebra: BFD Dest replay request");
+		zlog_debug("%s: neighbor %s vrf %s(%u) bfd state %s -> %s",
+			   __func__, peer->conf_if ? peer->conf_if : peer->host,
+			   bfd_sess_vrf(bsp), bfd_sess_vrf_id(bsp),
+			   bfd_get_status_str(bss->previous_state),
+			   bfd_get_status_str(bss->state));
 
-	/* Send the client registration */
-	bfd_client_sendmsg(zclient, ZEBRA_BFD_CLIENT_REGISTER, vrf_id);
-
-	/* Replay the peer, if BFD is enabled in BGP */
-
-	for (ALL_LIST_ELEMENTS_RO(bm->bgp, mnode, bgp))
-		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-			bgp_bfd_update_peer(peer);
-		}
-
-	return 0;
-}
-
-/*
- * bgp_bfd_peer_status_update - Update the BFD status if it has changed. Bring
- *                              down the peer if the BFD session went down from
- * *                              up.
- */
-static void bgp_bfd_peer_status_update(struct peer *peer, int status,
-				       int remote_cbit)
-{
-	struct bfd_info *bfd_info;
-	int old_status;
-
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-
-	if (bfd_info->status == status)
-		return;
-
-	old_status = bfd_info->status;
-	BFD_SET_CLIENT_STATUS(bfd_info->status, status);
-
-	bfd_info->last_update = bgp_clock();
-
-	if (status != old_status) {
-		if (BGP_DEBUG(neighbor_events, NEIGHBOR_EVENTS))
-			zlog_debug("[%s]: BFD %s", peer->host,
-				   bfd_get_status_str(status));
-	}
-	if ((status == BFD_STATUS_DOWN) && (old_status == BFD_STATUS_UP)) {
-		if (CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_MODE) &&
-		    CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CHECK_CONTROLPLANE) &&
-		    !remote_cbit) {
-			zlog_info("%s BFD DOWN message ignored in the process of graceful restart when C bit is cleared",
-				  peer->host);
+	if (bss->state == BSS_DOWN && bss->previous_state == BSS_UP) {
+		if (CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_MODE)
+		    && bfd_sess_cbit(bsp) && !bss->remote_cbit) {
+			if (BGP_DEBUG(zebra, ZEBRA))
+				zlog_info(
+					"%s BFD DOWN message ignored in the process of graceful restart when C bit is cleared",
+					peer->host);
 			return;
 		}
 		peer->last_reset = PEER_DOWN_BFD_DOWN;
 		BGP_EVENT_ADD(peer, BGP_Stop);
 	}
-	if ((status == BFD_STATUS_UP) && (old_status == BFD_STATUS_DOWN)
+
+	if (bss->state == BSS_UP && bss->previous_state != BSS_UP
 	    && peer->status != Established) {
 		if (!BGP_PEER_START_SUPPRESSED(peer)) {
 			bgp_fsm_nht_update(peer, true);
@@ -367,340 +80,353 @@ static void bgp_bfd_peer_status_update(struct peer *peer, int status,
 	}
 }
 
-/*
- * bgp_bfd_dest_update - Find the peer for which the BFD status
- *                       has changed and bring down the peer
- *                       connectivity if the BFD session went down.
- */
-static int bgp_bfd_dest_update(ZAPI_CALLBACK_ARGS)
+void bgp_peer_config_apply(struct peer *p, struct peer_group *pg)
 {
-	struct interface *ifp;
-	struct prefix dp;
-	struct prefix sp;
-	int status;
-	int remote_cbit;
+	struct listnode *n;
+	struct peer *pn;
+	struct peer *gconfig;
 
-	ifp = bfd_get_peer_info(zclient->ibuf, &dp, &sp, &status,
-				&remote_cbit, vrf_id);
+	/* When called on a group, apply to all peers. */
+	if (CHECK_FLAG(p->sflags, PEER_STATUS_GROUP)) {
+		for (ALL_LIST_ELEMENTS_RO(p->group->peer, n, pn))
+			bgp_peer_config_apply(pn, pg);
+		return;
+	}
 
-	if (BGP_DEBUG(zebra, ZEBRA)) {
-		struct vrf *vrf;
+	/* No group, just use current configuration. */
+	if (pg == NULL || pg->conf->bfd_config == NULL) {
+		bfd_sess_set_timers(p->bfd_config->session,
+				    p->bfd_config->detection_multiplier,
+				    p->bfd_config->min_rx,
+				    p->bfd_config->min_tx);
+		bfd_sess_set_cbit(p->bfd_config->session, p->bfd_config->cbit);
+		bfd_sess_set_profile(p->bfd_config->session,
+				     p->bfd_config->profile);
+		bfd_sess_install(p->bfd_config->session);
+		return;
+	}
 
-		vrf = vrf_lookup_by_id(vrf_id);
+	/*
+	 * Check if the group configuration was overwritten or apply group
+	 * configuration.
+	 */
+	gconfig = pg->conf;
 
-		if (ifp)
+	/*
+	 * If using default control plane independent configuration,
+	 * then prefer group's (e.g. it means it wasn't manually configured).
+	 */
+	if (!p->bfd_config->cbit)
+		bfd_sess_set_cbit(p->bfd_config->session,
+				  gconfig->bfd_config->cbit);
+	else
+		bfd_sess_set_cbit(p->bfd_config->session, p->bfd_config->cbit);
+
+	/* If no profile was specified in peer, then use the group profile. */
+	if (p->bfd_config->profile[0] == 0)
+		bfd_sess_set_profile(p->bfd_config->session,
+				     gconfig->bfd_config->profile);
+	else
+		bfd_sess_set_profile(p->bfd_config->session,
+				     p->bfd_config->profile);
+
+	/* If no specific timers were configured, then use the group timers. */
+	if (p->bfd_config->detection_multiplier == BFD_DEF_DETECT_MULT
+	    || p->bfd_config->min_rx == BFD_DEF_MIN_RX
+	    || p->bfd_config->min_tx == BFD_DEF_MIN_TX)
+		bfd_sess_set_timers(p->bfd_config->session,
+				    gconfig->bfd_config->detection_multiplier,
+				    gconfig->bfd_config->min_rx,
+				    gconfig->bfd_config->min_tx);
+	else
+		bfd_sess_set_timers(p->bfd_config->session,
+				    p->bfd_config->detection_multiplier,
+				    p->bfd_config->min_rx,
+				    p->bfd_config->min_tx);
+
+	bfd_sess_install(p->bfd_config->session);
+}
+
+void bgp_peer_bfd_update_source(struct peer *p)
+{
+	struct bfd_session_params *session = p->bfd_config->session;
+	bool changed = false;
+	int family;
+	union {
+		struct in_addr v4;
+		struct in6_addr v6;
+	} src, dst;
+
+	/* Nothing to do for groups. */
+	if (CHECK_FLAG(p->sflags, PEER_STATUS_GROUP))
+		return;
+
+	/* Update peer's source/destination addresses. */
+	bfd_sess_addresses(session, &family, &src.v6, &dst.v6);
+	if (family == AF_INET) {
+		if ((p->su_local
+		     && p->su_local->sin.sin_addr.s_addr != src.v4.s_addr)
+		    || p->su.sin.sin_addr.s_addr != dst.v4.s_addr) {
+			if (BGP_DEBUG(zebra, ZEBRA))
+				zlog_debug(
+					"%s: address [%pI4->%pI4] to [%pI4->%pI4]",
+					__func__, &src.v4, &dst.v4,
+					p->su_local ? &p->su_local->sin.sin_addr
+						    : &src.v4,
+					&p->su.sin.sin_addr);
+
+			bfd_sess_set_ipv4_addrs(
+				session,
+				p->su_local ? &p->su_local->sin.sin_addr : NULL,
+				&p->su.sin.sin_addr);
+			changed = true;
+		}
+	} else {
+		if ((p->su_local
+		     && memcmp(&p->su_local->sin6, &src.v6, sizeof(src.v6)))
+		    || memcmp(&p->su.sin6, &dst.v6, sizeof(dst.v6))) {
+			if (BGP_DEBUG(zebra, ZEBRA))
+				zlog_debug(
+					"%s: address [%pI6->%pI6] to [%pI6->%pI6]",
+					__func__, &src.v6, &dst.v6,
+					p->su_local
+						? &p->su_local->sin6.sin6_addr
+						: &src.v6,
+					&p->su.sin6.sin6_addr);
+
+			bfd_sess_set_ipv6_addrs(
+				session,
+				p->su_local ? &p->su_local->sin6.sin6_addr
+					    : NULL,
+				&p->su.sin6.sin6_addr);
+			changed = true;
+		}
+	}
+
+	/* Update interface. */
+	if (p->nexthop.ifp && bfd_sess_interface(session) == NULL) {
+		if (BGP_DEBUG(zebra, ZEBRA))
+			zlog_debug("%s: interface none to %s", __func__,
+				   p->nexthop.ifp->name);
+
+		bfd_sess_set_interface(session, p->nexthop.ifp->name);
+		changed = true;
+	}
+
+	/*
+	 * Update TTL.
+	 *
+	 * Two cases:
+	 * - We detected that the peer is a hop away from us (remove multi hop).
+	 *   (this happens when `p->shared_network` is set to `true`)
+	 * - eBGP multi hop / TTL security changed.
+	 */
+	if (!PEER_IS_MULTIHOP(p) && bfd_sess_hop_count(session) > 1) {
+		if (BGP_DEBUG(zebra, ZEBRA))
+			zlog_debug("%s: TTL %d to 1", __func__,
+				   bfd_sess_hop_count(session));
+
+		bfd_sess_set_hop_count(session, 1);
+		changed = true;
+	}
+	if (PEER_IS_MULTIHOP(p) && p->ttl != bfd_sess_hop_count(session)) {
+		if (BGP_DEBUG(zebra, ZEBRA))
+			zlog_debug("%s: TTL %d to %d", __func__,
+				   bfd_sess_hop_count(session), p->ttl);
+
+		bfd_sess_set_hop_count(session, p->ttl);
+		changed = true;
+	}
+
+	/* Update VRF. */
+	if (bfd_sess_vrf_id(session) != p->bgp->vrf_id) {
+		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug(
-				"Zebra: vrf %s(%u) interface %s bfd destination %pFX %s %s",
-				VRF_LOGNAME(vrf), vrf_id, ifp->name, &dp,
-				bfd_get_status_str(status),
-				remote_cbit ? "(cbit on)" : "");
-		else
-			zlog_debug(
-				"Zebra: vrf %s(%u) source %pFX bfd destination %pFX %s %s",
-				VRF_LOGNAME(vrf), vrf_id, &sp, &dp,
-				bfd_get_status_str(status),
-				remote_cbit ? "(cbit on)" : "");
+				"%s: VRF %s(%d) to %s(%d)", __func__,
+				bfd_sess_vrf(session), bfd_sess_vrf_id(session),
+				vrf_id_to_name(p->bgp->vrf_id), p->bgp->vrf_id);
+
+		bfd_sess_set_vrf(session, p->bgp->vrf_id);
+		changed = true;
 	}
 
-	/* Bring the peer down if BFD is enabled in BGP */
-	{
-		struct listnode *mnode, *node, *nnode;
-		struct bgp *bgp;
-		struct peer *peer;
-
-		for (ALL_LIST_ELEMENTS_RO(bm->bgp, mnode, bgp))
-			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-				if (!peer->bfd_info)
-					continue;
-
-				if ((dp.family == AF_INET)
-				    && (peer->su.sa.sa_family == AF_INET)) {
-					if (dp.u.prefix4.s_addr
-					    != peer->su.sin.sin_addr.s_addr)
-						continue;
-				} else if ((dp.family == AF_INET6)
-					   && (peer->su.sa.sa_family
-					       == AF_INET6)) {
-					if (memcmp(&dp.u.prefix6,
-						   &peer->su.sin6.sin6_addr,
-						   sizeof(struct in6_addr)))
-						continue;
-				} else
-					continue;
-
-				if (ifp && (ifp == peer->nexthop.ifp)) {
-					bgp_bfd_peer_status_update(peer,
-								   status,
-								   remote_cbit);
-				} else {
-					if (!peer->su_local)
-						continue;
-
-					if ((sp.family == AF_INET)
-					    && (peer->su_local->sa.sa_family
-						== AF_INET)) {
-						if (sp.u.prefix4.s_addr
-						    != peer->su_local->sin
-							       .sin_addr.s_addr)
-							continue;
-					} else if ((sp.family == AF_INET6)
-						   && (peer->su_local->sa
-							       .sa_family
-						       == AF_INET6)) {
-						if (memcmp(&sp.u.prefix6,
-							   &peer->su_local->sin6
-								    .sin6_addr,
-							   sizeof(struct
-								  in6_addr)))
-							continue;
-					} else
-						continue;
-
-					if ((vrf_id != VRF_DEFAULT)
-					    && (peer->bgp->vrf_id != vrf_id))
-						continue;
-
-					bgp_bfd_peer_status_update(peer,
-								   status,
-								   remote_cbit);
-				}
-			}
-	}
-
-	return 0;
+	if (changed)
+		bfd_sess_install(session);
 }
 
-/*
- * bgp_bfd_peer_param_set - Set the configured BFD paramter values for peer.
- */
-static int bgp_bfd_peer_param_set(struct peer *peer, uint32_t min_rx,
-				  uint32_t min_tx, uint8_t detect_mult,
-				  int defaults)
-{
-	struct bfd_info *bi;
-	struct peer_group *group;
-	struct listnode *node, *nnode;
-	int command = 0;
-
-	bfd_set_param((struct bfd_info **)&(peer->bfd_info), min_rx, min_tx,
-		      detect_mult, NULL, defaults, &command);
-
-	/* This command overrides profile if it was previously applied. */
-	bi = peer->bfd_info;
-	bi->profile[0] = 0;
-
-	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
-		group = peer->group;
-		for (ALL_LIST_ELEMENTS(group->peer, node, nnode, peer)) {
-			command = 0;
-			bfd_set_param((struct bfd_info **)&(peer->bfd_info),
-				      min_rx, min_tx, detect_mult, NULL,
-				      defaults, &command);
-
-			/*
-			 * This command overrides profile if it was previously
-			 * applied.
-			 */
-			bi = peer->bfd_info;
-			bi->profile[0] = 0;
-
-			if ((peer->status == Established)
-			    && (command == ZEBRA_BFD_DEST_REGISTER))
-				bgp_bfd_register_peer(peer);
-			else if (command == ZEBRA_BFD_DEST_UPDATE)
-				bgp_bfd_update_peer(peer);
-		}
-	} else {
-		if ((peer->status == Established)
-		    && (command == ZEBRA_BFD_DEST_REGISTER))
-			bgp_bfd_register_peer(peer);
-		else if (command == ZEBRA_BFD_DEST_UPDATE)
-			bgp_bfd_update_peer(peer);
-	}
-	return 0;
-}
-
-/*
- * bgp_bfd_peer_param_unset - Delete the configured BFD paramter values for
- * peer.
- */
-static int bgp_bfd_peer_param_unset(struct peer *peer)
-{
-	struct peer_group *group;
-	struct listnode *node, *nnode;
-
-	if (!peer->bfd_info)
-		return 0;
-
-	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
-		bfd_info_free(&(peer->bfd_info));
-		group = peer->group;
-		for (ALL_LIST_ELEMENTS(group->peer, node, nnode, peer)) {
-			bgp_bfd_deregister_peer(peer);
-			bfd_info_free(&(peer->bfd_info));
-		}
-	} else {
-		bgp_bfd_deregister_peer(peer);
-		bfd_info_free(&(peer->bfd_info));
-	}
-	return 0;
-}
-
-/*
- * bgp_bfd_peer_param_type_set - set the BFD session type (multihop or
- * singlehop)
- */
-static int bgp_bfd_peer_param_type_set(struct peer *peer,
-				       enum bfd_sess_type type)
-{
-	struct peer_group *group;
-	struct listnode *node, *nnode;
-	int command = 0;
-	struct bfd_info *bfd_info;
-
-	if (!peer->bfd_info)
-		bfd_set_param((struct bfd_info **)&(peer->bfd_info),
-			      BFD_DEF_MIN_RX, BFD_DEF_MIN_TX,
-			      BFD_DEF_DETECT_MULT, NULL, 1, &command);
-
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-	bfd_info->type = type;
-
-	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
-		group = peer->group;
-		for (ALL_LIST_ELEMENTS(group->peer, node, nnode, peer)) {
-			command = 0;
-			if (!peer->bfd_info)
-				bfd_set_param(
-					(struct bfd_info **)&(peer->bfd_info),
-					BFD_DEF_MIN_RX, BFD_DEF_MIN_TX,
-					BFD_DEF_DETECT_MULT, NULL, 1, &command);
-
-			bfd_info = (struct bfd_info *)peer->bfd_info;
-			bfd_info->type = type;
-
-			if (peer->status == Established) {
-				if (command == ZEBRA_BFD_DEST_REGISTER)
-					bgp_bfd_register_peer(peer);
-				else
-					bgp_bfd_update_type(peer);
-			}
-		}
-	} else {
-		if (peer->status == Established) {
-			if (command == ZEBRA_BFD_DEST_REGISTER)
-				bgp_bfd_register_peer(peer);
-			else
-				bgp_bfd_update_type(peer);
-		}
-	}
-
-	return 0;
-}
-
-#if HAVE_BFDD > 0
 /**
- * Set peer BFD profile configuration.
+ * Reset BFD configuration data structure to its defaults settings.
  */
-static int bgp_bfd_peer_set_profile(struct peer *peer, const char *profile)
+static void bgp_peer_bfd_reset(struct peer *p)
 {
-	struct peer_group *group;
-	struct listnode *node, *nnode;
-	int command = 0;
-	struct bfd_info *bfd_info;
+	/* Set defaults. */
+	p->bfd_config->detection_multiplier = BFD_DEF_DETECT_MULT;
+	p->bfd_config->min_rx = BFD_DEF_MIN_RX;
+	p->bfd_config->min_tx = BFD_DEF_MIN_TX;
+	p->bfd_config->cbit = false;
+	p->bfd_config->profile[0] = 0;
+}
 
-	bfd_set_param((struct bfd_info **)&(peer->bfd_info), BFD_DEF_MIN_RX,
-		      BFD_DEF_MIN_TX, BFD_DEF_DETECT_MULT, NULL, 1, &command);
+void bgp_peer_configure_bfd(struct peer *p, bool manual)
+{
+	/* Groups should not call this. */
+	assert(!CHECK_FLAG(p->sflags, PEER_STATUS_GROUP));
 
-	bfd_info = (struct bfd_info *)peer->bfd_info;
+	/* Already configured, skip it. */
+	if (p->bfd_config) {
+		/* If manually active update flag. */
+		if (!p->bfd_config->manual)
+			p->bfd_config->manual = manual;
 
-	/* If profile was specified, then copy string. */
-	if (profile)
-		strlcpy(bfd_info->profile, profile, sizeof(bfd_info->profile));
-	else /* Otherwise just initialize it empty. */
-		bfd_info->profile[0] = 0;
-
-	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
-		group = peer->group;
-		for (ALL_LIST_ELEMENTS(group->peer, node, nnode, peer)) {
-			command = 0;
-			bfd_set_param((struct bfd_info **)&(peer->bfd_info),
-				      BFD_DEF_MIN_RX, BFD_DEF_MIN_TX,
-				      BFD_DEF_DETECT_MULT, NULL, 1, &command);
-
-			bfd_info = (struct bfd_info *)peer->bfd_info;
-
-			/* If profile was specified, then copy string. */
-			if (profile)
-				strlcpy(bfd_info->profile, profile,
-					sizeof(bfd_info->profile));
-			else /* Otherwise just initialize it empty. */
-				bfd_info->profile[0] = 0;
-
-			if (peer->status == Established
-			    && command == ZEBRA_BFD_DEST_REGISTER)
-				bgp_bfd_register_peer(peer);
-			else if (command == ZEBRA_BFD_DEST_UPDATE)
-				bgp_bfd_update_peer(peer);
-		}
-	} else {
-		if (peer->status == Established
-		    && command == ZEBRA_BFD_DEST_REGISTER)
-			bgp_bfd_register_peer(peer);
-		else if (command == ZEBRA_BFD_DEST_UPDATE)
-			bgp_bfd_update_peer(peer);
+		return;
 	}
 
-	return 0;
+	/* Allocate memory for configuration overrides. */
+	p->bfd_config = XCALLOC(MTYPE_BFD_CONFIG, sizeof(*p->bfd_config));
+	p->bfd_config->manual = manual;
+
+	/* Create new session and assign callback. */
+	p->bfd_config->session = bfd_sess_new(bfd_session_status_update, p);
+	bgp_peer_bfd_reset(p);
+
+	/* Configure session with basic BGP peer data. */
+	if (p->su.sa.sa_family == AF_INET)
+		bfd_sess_set_ipv4_addrs(p->bfd_config->session,
+					p->su_local ? &p->su_local->sin.sin_addr
+						    : NULL,
+					&p->su.sin.sin_addr);
+	else
+		bfd_sess_set_ipv6_addrs(
+			p->bfd_config->session,
+			p->su_local ? &p->su_local->sin6.sin6_addr : NULL,
+			&p->su.sin6.sin6_addr);
+
+	bfd_sess_set_vrf(p->bfd_config->session, p->bgp->vrf_id);
+	bfd_sess_set_hop_count(p->bfd_config->session,
+			       PEER_IS_MULTIHOP(p) ? p->ttl : 1);
+
+	if (p->nexthop.ifp)
+		bfd_sess_set_interface(p->bfd_config->session,
+				       p->nexthop.ifp->name);
+
+	bfd_sess_enable(p->bfd_config->session, true);
+	bgp_peer_config_apply(p, p->group);
 }
-#endif
+
+static void bgp_peer_remove_bfd(struct peer *p)
+{
+	/* Groups should not call this. */
+	assert(!CHECK_FLAG(p->sflags, PEER_STATUS_GROUP));
+
+	/*
+	 * Peer configuration was removed, however we must check if there
+	 * is still a group configuration to keep this running.
+	 */
+	if (p->group && p->group->conf->bfd_config) {
+		p->bfd_config->manual = false;
+		bgp_peer_bfd_reset(p);
+		bgp_peer_config_apply(p, p->group);
+		return;
+	}
+
+	bfd_sess_free(&p->bfd_config->session);
+	XFREE(MTYPE_BFD_CONFIG, p->bfd_config);
+}
+
+static void bgp_group_configure_bfd(struct peer *p)
+{
+	struct listnode *n;
+	struct peer *pn;
+
+	/* Peers should not call this. */
+	assert(CHECK_FLAG(p->sflags, PEER_STATUS_GROUP));
+
+	/* Already allocated: do nothing. */
+	if (p->bfd_config)
+		return;
+
+	p->bfd_config = XCALLOC(MTYPE_BFD_CONFIG, sizeof(*p->bfd_config));
+
+	/* Set defaults. */
+	p->bfd_config->detection_multiplier = BFD_DEF_DETECT_MULT;
+	p->bfd_config->min_rx = BFD_DEF_MIN_RX;
+	p->bfd_config->min_tx = BFD_DEF_MIN_TX;
+
+	for (ALL_LIST_ELEMENTS_RO(p->group->peer, n, pn))
+		bgp_peer_configure_bfd(pn, false);
+}
+
+static void bgp_group_remove_bfd(struct peer *p)
+{
+	struct listnode *n;
+	struct peer *pn;
+
+	/* Peers should not call this. */
+	assert(CHECK_FLAG(p->sflags, PEER_STATUS_GROUP));
+
+	/* Already freed: do nothing. */
+	if (p->bfd_config == NULL)
+		return;
+
+	/* Free configuration and point to `NULL`. */
+	XFREE(MTYPE_BFD_CONFIG, p->bfd_config);
+
+	/* Now that it is `NULL` recalculate configuration for all peers. */
+	for (ALL_LIST_ELEMENTS_RO(p->group->peer, n, pn)) {
+		if (pn->bfd_config->manual)
+			bgp_peer_config_apply(pn, NULL);
+		else
+			bgp_peer_remove_bfd(pn);
+	}
+}
+
+void bgp_peer_remove_bfd_config(struct peer *p)
+{
+	if (CHECK_FLAG(p->sflags, PEER_STATUS_GROUP))
+		bgp_group_remove_bfd(p);
+	else
+		bgp_peer_remove_bfd(p);
+}
 
 /*
  * bgp_bfd_peer_config_write - Write the peer BFD configuration.
  */
-void bgp_bfd_peer_config_write(struct vty *vty, struct peer *peer, char *addr)
+void bgp_bfd_peer_config_write(struct vty *vty, const struct peer *peer,
+			       const char *addr)
 {
-	struct bfd_info *bfd_info;
-
-	if (!peer->bfd_info)
-		return;
-
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-
-	if (CHECK_FLAG(bfd_info->flags, BFD_FLAG_PARAM_CFG))
+	/*
+	 * Always show group BFD configuration, but peer only when explicitly
+	 * configured.
+	 */
+	if ((!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)
+	     && peer->bfd_config->manual)
+	    || CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
 #if HAVE_BFDD > 0
 		vty_out(vty, " neighbor %s bfd\n", addr);
 #else
 		vty_out(vty, " neighbor %s bfd %d %d %d\n", addr,
-			bfd_info->detect_mult, bfd_info->required_min_rx,
-			bfd_info->desired_min_tx);
+			peer->bfd_config->detection_multiplier,
+			peer->bfd_config->min_rx, peer->bfd_config->min_tx);
 #endif /* HAVE_BFDD */
-
-	if (bfd_info->type != BFD_TYPE_NOT_CONFIGURED)
-		vty_out(vty, " neighbor %s bfd %s\n", addr,
-			(bfd_info->type == BFD_TYPE_MULTIHOP) ? "multihop"
-							      : "singlehop");
-
-	if (!CHECK_FLAG(bfd_info->flags, BFD_FLAG_PARAM_CFG)
-	    && (bfd_info->type == BFD_TYPE_NOT_CONFIGURED)) {
-		vty_out(vty, " neighbor %s bfd", addr);
-		if (bfd_info->profile[0])
-			vty_out(vty, " profile %s", bfd_info->profile);
-		vty_out(vty, "\n");
 	}
 
-	if (CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CHECK_CONTROLPLANE))
-		vty_out(vty, " neighbor %s bfd check-control-plane-failure\n", addr);
+	if (peer->bfd_config->profile[0])
+		vty_out(vty, " neighbor %s bfd profile %s\n", addr,
+			peer->bfd_config->profile);
+
+	if (peer->bfd_config->cbit)
+		vty_out(vty, " neighbor %s bfd check-control-plane-failure\n",
+			addr);
 }
 
 /*
  * bgp_bfd_show_info - Show the peer BFD information.
  */
-void bgp_bfd_show_info(struct vty *vty, struct peer *peer, bool use_json,
+void bgp_bfd_show_info(struct vty *vty, const struct peer *peer,
 		       json_object *json_neigh)
 {
-	bfd_show_info(vty, (struct bfd_info *)peer->bfd_info,
-		      bgp_bfd_is_peer_multihop(peer), 0, use_json, json_neigh);
+	if (peer->bfd_config->session)
+		bfd_sess_show(vty, json_neigh, peer->bfd_config->session);
 }
 
 DEFUN (neighbor_bfd,
@@ -712,16 +438,15 @@ DEFUN (neighbor_bfd,
 {
 	int idx_peer = 1;
 	struct peer *peer;
-	int ret;
 
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	ret = bgp_bfd_peer_param_set(peer, BFD_DEF_MIN_RX, BFD_DEF_MIN_TX,
-				     BFD_DEF_DETECT_MULT, 1);
-	if (ret != 0)
-		return bgp_vty_return(vty, ret);
+	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+		bgp_group_configure_bfd(peer);
+	else
+		bgp_peer_configure_bfd(peer, true);
 
 	return CMD_SUCCESS;
 }
@@ -745,88 +470,29 @@ DEFUN(
 	int idx_number_1 = 3;
 	int idx_number_2 = 4;
 	int idx_number_3 = 5;
+	long detection_multiplier, min_rx, min_tx;
 	struct peer *peer;
-	uint32_t rx_val;
-	uint32_t tx_val;
-	uint8_t dm_val;
-	int ret;
 
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	if ((ret = bfd_validate_param(
-		     vty, argv[idx_number_1]->arg, argv[idx_number_2]->arg,
-		     argv[idx_number_3]->arg, &dm_val, &rx_val, &tx_val))
-	    != CMD_SUCCESS)
-		return ret;
+	detection_multiplier = strtol(argv[idx_number_1]->arg, NULL, 10);
+	min_rx = strtol(argv[idx_number_2]->arg, NULL, 10);
+	min_tx = strtol(argv[idx_number_3]->arg, NULL, 10);
 
-	ret = bgp_bfd_peer_param_set(peer, rx_val, tx_val, dm_val, 0);
-	if (ret != 0)
-		return bgp_vty_return(vty, ret);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN_HIDDEN (neighbor_bfd_type,
-       neighbor_bfd_type_cmd,
-       "neighbor <A.B.C.D|X:X::X:X|WORD> bfd <multihop|singlehop>",
-       NEIGHBOR_STR
-       NEIGHBOR_ADDR_STR2
-       "Enables BFD support\n"
-       "Multihop session\n"
-       "Single hop session\n")
-{
-	int idx_peer = 1;
-	int idx_hop = 3;
-	struct peer *peer;
-	enum bfd_sess_type type;
-	int ret;
-
-	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
-	if (!peer)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	if (strmatch(argv[idx_hop]->text, "singlehop"))
-		type = BFD_TYPE_SINGLEHOP;
-	else if (strmatch(argv[idx_hop]->text, "multihop"))
-		type = BFD_TYPE_MULTIHOP;
+	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+		bgp_group_configure_bfd(peer);
 	else
-		return CMD_WARNING_CONFIG_FAILED;
+		bgp_peer_configure_bfd(peer, true);
 
-	ret = bgp_bfd_peer_param_type_set(peer, type);
-	if (ret != 0)
-		return bgp_vty_return(vty, ret);
+	peer->bfd_config->detection_multiplier = detection_multiplier;
+	peer->bfd_config->min_rx = min_rx;
+	peer->bfd_config->min_tx = min_tx;
+	bgp_peer_config_apply(peer, peer->group);
 
 	return CMD_SUCCESS;
 }
-
-static int bgp_bfd_set_check_controlplane_failure_peer(struct vty *vty, struct peer *peer,
-						       const char *no)
-{
-	struct bfd_info *bfd_info;
-
-	if (!peer->bfd_info) {
-		if (no)
-			return CMD_SUCCESS;
-		vty_out(vty, "%% Specify bfd command first\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-	bfd_info = (struct bfd_info *)peer->bfd_info;
-	if (!no) {
-		if (!CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CHECK_CONTROLPLANE)) {
-			SET_FLAG(bfd_info->flags,  BFD_FLAG_BFD_CHECK_CONTROLPLANE);
-			bgp_bfd_update_peer(peer);
-		}
-	} else {
-		if (CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CHECK_CONTROLPLANE)) {
-			UNSET_FLAG(bfd_info->flags,  BFD_FLAG_BFD_CHECK_CONTROLPLANE);
-			bgp_bfd_update_peer(peer);
-		}
-	}
-	return CMD_SUCCESS;
-}
-
 
 DEFUN (neighbor_bfd_check_controlplane_failure,
        neighbor_bfd_check_controlplane_failure_cmd,
@@ -840,9 +506,6 @@ DEFUN (neighbor_bfd_check_controlplane_failure,
 	const char *no = strmatch(argv[0]->text, "no") ? "no" : NULL;
 	int idx_peer = 0;
 	struct peer *peer;
-	struct peer_group *group;
-	struct listnode *node, *nnode;
-	int ret = CMD_SUCCESS;
 
 	if (no)
 		idx_peer = 2;
@@ -853,19 +516,16 @@ DEFUN (neighbor_bfd_check_controlplane_failure,
 		vty_out(vty, "%% Specify remote-as or peer-group commands first\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
-	if (!peer->bfd_info) {
-		if (no)
-			return CMD_SUCCESS;
-		vty_out(vty, "%% Specify bfd command first\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
-		group = peer->group;
-		for (ALL_LIST_ELEMENTS(group->peer, node, nnode, peer))
-			ret = bgp_bfd_set_check_controlplane_failure_peer(vty, peer, no);
-	} else
-		ret = bgp_bfd_set_check_controlplane_failure_peer(vty, peer, no);
-	return ret;
+
+	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+		bgp_group_configure_bfd(peer);
+	else
+		bgp_peer_configure_bfd(peer, true);
+
+	peer->bfd_config->cbit = no == NULL;
+	bgp_peer_config_apply(peer, peer->group);
+
+	return CMD_SUCCESS;
  }
 
 DEFUN (no_neighbor_bfd,
@@ -888,44 +548,15 @@ DEFUN (no_neighbor_bfd,
 {
 	int idx_peer = 2;
 	struct peer *peer;
-	int ret;
 
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	ret = bgp_bfd_peer_param_unset(peer);
-	if (ret != 0)
-		return bgp_vty_return(vty, ret);
-
-	return CMD_SUCCESS;
-}
-
-
-DEFUN_HIDDEN (no_neighbor_bfd_type,
-       no_neighbor_bfd_type_cmd,
-       "no neighbor <A.B.C.D|X:X::X:X|WORD> bfd <multihop|singlehop>",
-       NO_STR
-       NEIGHBOR_STR
-       NEIGHBOR_ADDR_STR2
-       "Disables BFD support\n"
-       "Multihop session\n"
-       "Singlehop session\n")
-{
-	int idx_peer = 2;
-	struct peer *peer;
-	int ret;
-
-	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
-	if (!peer)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	if (!peer->bfd_info)
-		return 0;
-
-	ret = bgp_bfd_peer_param_type_set(peer, BFD_TYPE_NOT_CONFIGURED);
-	if (ret != 0)
-		return bgp_vty_return(vty, ret);
+	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+		bgp_group_remove_bfd(peer);
+	else
+		bgp_peer_remove_bfd(peer);
 
 	return CMD_SUCCESS;
 }
@@ -941,15 +572,19 @@ DEFUN(neighbor_bfd_profile, neighbor_bfd_profile_cmd,
 {
 	int idx_peer = 1, idx_prof = 4;
 	struct peer *peer;
-	int ret;
 
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	ret = bgp_bfd_peer_set_profile(peer, argv[idx_prof]->arg);
-	if (ret != 0)
-		return bgp_vty_return(vty, ret);
+	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+		bgp_group_configure_bfd(peer);
+	else
+		bgp_peer_configure_bfd(peer, true);
+
+	strlcpy(peer->bfd_config->profile, argv[idx_prof]->arg,
+		sizeof(peer->bfd_config->profile));
+	bgp_peer_config_apply(peer, peer->group);
 
 	return CMD_SUCCESS;
 }
@@ -965,38 +600,33 @@ DEFUN(no_neighbor_bfd_profile, no_neighbor_bfd_profile_cmd,
 {
 	int idx_peer = 2;
 	struct peer *peer;
-	int ret;
 
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	if (!peer->bfd_info)
-		return 0;
+	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+		bgp_group_configure_bfd(peer);
+	else
+		bgp_peer_configure_bfd(peer, true);
 
-	ret = bgp_bfd_peer_set_profile(peer, NULL);
-	if (ret != 0)
-		return bgp_vty_return(vty, ret);
+	peer->bfd_config->profile[0] = 0;
+	bgp_peer_config_apply(peer, peer->group);
 
 	return CMD_SUCCESS;
 }
 #endif /* HAVE_BFDD */
 
-void bgp_bfd_init(void)
+void bgp_bfd_init(struct thread_master *tm)
 {
-	bfd_gbl_init();
-
 	/* Initialize BFD client functions */
-	zclient->interface_bfd_dest_update = bgp_bfd_dest_update;
-	zclient->bfd_dest_replay = bgp_bfd_dest_replay;
+	bfd_protocol_integration_init(zclient, tm);
 
 	/* "neighbor bfd" commands. */
 	install_element(BGP_NODE, &neighbor_bfd_cmd);
 	install_element(BGP_NODE, &neighbor_bfd_param_cmd);
-	install_element(BGP_NODE, &neighbor_bfd_type_cmd);
 	install_element(BGP_NODE, &neighbor_bfd_check_controlplane_failure_cmd);
 	install_element(BGP_NODE, &no_neighbor_bfd_cmd);
-	install_element(BGP_NODE, &no_neighbor_bfd_type_cmd);
 
 #if HAVE_BFDD > 0
 	install_element(BGP_NODE, &neighbor_bfd_profile_cmd);

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -51,7 +51,7 @@ static void bfd_session_status_update(struct bfd_session_params *bsp,
 {
 	struct peer *peer = arg;
 
-	if (BGP_DEBUG(zebra, ZEBRA))
+	if (BGP_DEBUG(bfd, BFD_LIB))
 		zlog_debug("%s: neighbor %s vrf %s(%u) bfd state %s -> %s",
 			   __func__, peer->conf_if ? peer->conf_if : peer->host,
 			   bfd_sess_vrf(bsp), bfd_sess_vrf_id(bsp),
@@ -61,7 +61,7 @@ static void bfd_session_status_update(struct bfd_session_params *bsp,
 	if (bss->state == BSS_DOWN && bss->previous_state == BSS_UP) {
 		if (CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_MODE)
 		    && bfd_sess_cbit(bsp) && !bss->remote_cbit) {
-			if (BGP_DEBUG(zebra, ZEBRA))
+			if (BGP_DEBUG(bfd, BFD_LIB))
 				zlog_info(
 					"%s BFD DOWN message ignored in the process of graceful restart when C bit is cleared",
 					peer->host);
@@ -167,7 +167,7 @@ void bgp_peer_bfd_update_source(struct peer *p)
 		if ((p->su_local
 		     && p->su_local->sin.sin_addr.s_addr != src.v4.s_addr)
 		    || p->su.sin.sin_addr.s_addr != dst.v4.s_addr) {
-			if (BGP_DEBUG(zebra, ZEBRA))
+			if (BGP_DEBUG(bfd, BFD_LIB))
 				zlog_debug(
 					"%s: address [%pI4->%pI4] to [%pI4->%pI4]",
 					__func__, &src.v4, &dst.v4,
@@ -185,7 +185,7 @@ void bgp_peer_bfd_update_source(struct peer *p)
 		if ((p->su_local
 		     && memcmp(&p->su_local->sin6, &src.v6, sizeof(src.v6)))
 		    || memcmp(&p->su.sin6, &dst.v6, sizeof(dst.v6))) {
-			if (BGP_DEBUG(zebra, ZEBRA))
+			if (BGP_DEBUG(bfd, BFD_LIB))
 				zlog_debug(
 					"%s: address [%pI6->%pI6] to [%pI6->%pI6]",
 					__func__, &src.v6, &dst.v6,
@@ -205,7 +205,7 @@ void bgp_peer_bfd_update_source(struct peer *p)
 
 	/* Update interface. */
 	if (p->nexthop.ifp && bfd_sess_interface(session) == NULL) {
-		if (BGP_DEBUG(zebra, ZEBRA))
+		if (BGP_DEBUG(bfd, BFD_LIB))
 			zlog_debug("%s: interface none to %s", __func__,
 				   p->nexthop.ifp->name);
 
@@ -222,7 +222,7 @@ void bgp_peer_bfd_update_source(struct peer *p)
 	 * - eBGP multi hop / TTL security changed.
 	 */
 	if (!PEER_IS_MULTIHOP(p) && bfd_sess_hop_count(session) > 1) {
-		if (BGP_DEBUG(zebra, ZEBRA))
+		if (BGP_DEBUG(bfd, BFD_LIB))
 			zlog_debug("%s: TTL %d to 1", __func__,
 				   bfd_sess_hop_count(session));
 
@@ -230,7 +230,7 @@ void bgp_peer_bfd_update_source(struct peer *p)
 		changed = true;
 	}
 	if (PEER_IS_MULTIHOP(p) && p->ttl != bfd_sess_hop_count(session)) {
-		if (BGP_DEBUG(zebra, ZEBRA))
+		if (BGP_DEBUG(bfd, BFD_LIB))
 			zlog_debug("%s: TTL %d to %d", __func__,
 				   bfd_sess_hop_count(session), p->ttl);
 
@@ -240,7 +240,7 @@ void bgp_peer_bfd_update_source(struct peer *p)
 
 	/* Update VRF. */
 	if (bfd_sess_vrf_id(session) != p->bgp->vrf_id) {
-		if (BGP_DEBUG(zebra, ZEBRA))
+		if (BGP_DEBUG(bfd, BFD_LIB))
 			zlog_debug(
 				"%s: VRF %s(%d) to %s(%d)", __func__,
 				bfd_sess_vrf(session), bfd_sess_vrf_id(session),

--- a/bgpd/bgp_bfd.h
+++ b/bgpd/bgp_bfd.h
@@ -60,6 +60,9 @@ extern void bgp_peer_config_apply(struct peer *p, struct peer_group *pg);
 /**
  * Allocates and configure BFD session for peer. If it is already configured,
  * then it does nothing.
+ *
+ * Always call `bgp_peer_config_apply` afterwards if you need the changes
+ * immediately applied.
  */
 extern void bgp_peer_configure_bfd(struct peer *p, bool manual);
 

--- a/bgpd/bgp_bfd.h
+++ b/bgpd/bgp_bfd.h
@@ -23,22 +23,55 @@
 #ifndef _QUAGGA_BGP_BFD_H
 #define _QUAGGA_BGP_BFD_H
 
-extern void bgp_bfd_init(void);
+#define PEER_IS_MULTIHOP(peer)                                                 \
+	((((peer)->sort == BGP_PEER_IBGP) && !(peer)->shared_network)          \
+	 || is_ebgp_multihop_configured((peer)))
 
-extern void bgp_bfd_peer_group2peer_copy(struct peer *conf, struct peer *peer);
+extern void bgp_bfd_init(struct thread_master *tm);
 
-extern void bgp_bfd_register_peer(struct peer *peer);
+extern void bgp_bfd_peer_config_write(struct vty *vty, const struct peer *peer,
+				      const char *addr);
 
-extern void bgp_bfd_deregister_peer(struct peer *peer);
-
-extern void bgp_bfd_reset_peer(struct peer *peer);
-
-extern void bgp_bfd_peer_config_write(struct vty *vty, struct peer *peer,
-				      char *addr);
-
-extern void bgp_bfd_show_info(struct vty *vty, struct peer *peer, bool use_json,
+/**
+ * Show BFD information helper.
+ *
+ * \param vty the VTY pointer.
+ * \param peer the BGP configuration pointer.
+ * \param use_json unused.
+ * \param json_neigh JSON object when called as JSON command.
+ */
+extern void bgp_bfd_show_info(struct vty *vty, const struct peer *peer,
 			      json_object *json_neigh);
 
-extern bool bgp_bfd_is_peer_multihop(struct peer *peer);
+/**
+ * When called on a group it applies configuration to all peers in that group,
+ * otherwise just applies the configuration to a single peer.
+ *
+ * This function should be called when configuration changes either on group
+ * or peer.
+ *
+ * \param p the BGP peer pointer.
+ * \param pg the BGP group to copy configuration from (it is usually
+ *           `p->group` exception when copying new group configuration
+ *           see `peer_group2peer_config_copy` function case).
+ */
+extern void bgp_peer_config_apply(struct peer *p, struct peer_group *pg);
+
+/**
+ * Allocates and configure BFD session for peer. If it is already configured,
+ * then it does nothing.
+ */
+extern void bgp_peer_configure_bfd(struct peer *p, bool manual);
+
+/**
+ * Removes BFD configuration from either peer or peer group.
+ */
+extern void bgp_peer_remove_bfd_config(struct peer *p);
+
+/**
+ * Special function to handle the case of changing source address. This
+ * happens when the peer/group is configured with `neigbor X update-source Y`.
+ */
+extern void bgp_peer_bfd_update_source(struct peer *p);
 
 #endif /* _QUAGGA_BGP_BFD_H */

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -78,6 +78,7 @@ extern unsigned long conf_bgp_debug_labelpool;
 extern unsigned long conf_bgp_debug_pbr;
 extern unsigned long conf_bgp_debug_graceful_restart;
 extern unsigned long conf_bgp_debug_evpn_mh;
+extern unsigned long conf_bgp_debug_bfd;
 
 extern unsigned long term_bgp_debug_as4;
 extern unsigned long term_bgp_debug_neighbor_events;
@@ -95,6 +96,7 @@ extern unsigned long term_bgp_debug_labelpool;
 extern unsigned long term_bgp_debug_pbr;
 extern unsigned long term_bgp_debug_graceful_restart;
 extern unsigned long term_bgp_debug_evpn_mh;
+extern unsigned long term_bgp_debug_bfd;
 
 extern struct list *bgp_debug_neighbor_events_peers;
 extern struct list *bgp_debug_keepalive_peers;
@@ -138,6 +140,8 @@ struct bgp_debug_filter {
 #define BGP_DEBUG_PACKET_SEND_DETAIL  0x02
 
 #define BGP_DEBUG_GRACEFUL_RESTART     0x01
+
+#define BGP_DEBUG_BFD_LIB             0x01
 
 #define CONF_DEBUG_ON(a, b)	(conf_bgp_debug_ ## a |= (BGP_DEBUG_ ## b))
 #define CONF_DEBUG_OFF(a, b)	(conf_bgp_debug_ ## a &= ~(BGP_DEBUG_ ## b))

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -162,6 +162,9 @@ __attribute__((__noreturn__)) void sigint(void)
 	assert(bm->terminating == false);
 	bm->terminating = true;	/* global flag that shutting down */
 
+	/* Disable BFD events to avoid wasting processing. */
+	bfd_protocol_integration_set_shutdown(true);
+
 	bgp_terminate();
 
 	bgp_exit(0);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -14411,7 +14411,8 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 		vty_out(vty, "\n");
 
 	/* BFD information. */
-	bgp_bfd_show_info(vty, p, use_json, json_neigh);
+	if (p->bfd_config)
+		bgp_bfd_show_info(vty, p, json_neigh);
 
 	if (use_json) {
 		if (p->conf_if) /* Configured interface name. */
@@ -16818,11 +16819,8 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 			peer->rtt_expected, peer->rtt_keepalive_conf);
 
 	/* bfd */
-	if (peer->bfd_info) {
-		if (!peer_group_active(peer) || !g_peer->bfd_info) {
-			bgp_bfd_peer_config_write(vty, peer, addr);
-		}
-	}
+	if (peer->bfd_config)
+		bgp_bfd_peer_config_write(vty, peer, addr);
 
 	/* password */
 	if (peergroup_flag_check(peer, PEER_FLAG_PASSWORD))

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -283,20 +283,9 @@ static int bgp_ifp_down(struct interface *ifp)
 	if (!CHECK_FLAG(bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER)) {
 
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-#if defined(HAVE_CUMULUS)
-			/* Take down directly connected EBGP peers as well as
-			 * 1-hop BFD
-			 * tracked (directly connected) IBGP peers.
-			 */
-			if ((peer->ttl != BGP_DEFAULT_TTL)
-			    && (peer->gtsm_hops != BGP_GTSM_HOPS_CONNECTED)
-			    && (!peer->bfd_info
-				|| bgp_bfd_is_peer_multihop(peer)))
-#else
-			/* Take down directly connected EBGP peers */
+			/* Take down directly connected peers. */
 			if ((peer->ttl != BGP_DEFAULT_TTL)
 			    && (peer->gtsm_hops != BGP_GTSM_HOPS_CONNECTED))
-#endif
 				continue;
 
 			if (ifp == peer->nexthop.ifp) {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -45,6 +45,8 @@
 #include "bgp_nexthop.h"
 #include "bgp_damp.h"
 
+#include "lib/bfd.h"
+
 #define BGP_MAX_HOSTNAME 64	/* Linux max, is larger than most other sys */
 #define BGP_PEER_MAX_HASH_SIZE 16384
 
@@ -1558,8 +1560,29 @@ struct peer {
 #define PEER_RMAP_TYPE_EXPORT         (1U << 7) /* neighbor route-map export */
 #define PEER_RMAP_TYPE_AGGREGATE      (1U << 8) /* aggregate-address route-map */
 
-	/* peer specific BFD information */
-	struct bfd_info *bfd_info;
+	/** Peer overwrite configuration. */
+	struct bfd_session_config {
+		/**
+		 * Manual configuration bit.
+		 *
+		 * This flag only makes sense for real peers (and not groups),
+		 * it keeps track if the user explicitly configured BFD for a
+		 * peer.
+		 */
+		bool manual;
+		/** Control Plane Independent. */
+		bool cbit;
+		/** Detection multiplier. */
+		uint8_t detection_multiplier;
+		/** Minimum required RX interval. */
+		uint32_t min_rx;
+		/** Minimum required TX interval. */
+		uint32_t min_tx;
+		/** Profile name. */
+		char profile[BFD_PROFILE_NAME_LEN];
+		/** Peer BFD session */
+		struct bfd_session_params *session;
+	} * bfd_config;
 
 	/* hostname and domainname advertised by host */
 	char *hostname;

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2916,6 +2916,12 @@ Debugging
    Display Listen sockets and the vrf that created them.  Useful for debugging of when
    listen is not working and this is considered a developer debug statement.
 
+.. clicmd:: debug bgp bfd
+
+   Enable or disable debugging for BFD events. This will show BFD integration
+   library messages and BGP BFD integration messages that are mostly state
+   transitions and validation problems.
+
 .. clicmd:: debug bgp neighbor-events
 
    Enable or disable debugging for neighbor events. This provides general

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -1079,6 +1079,7 @@ static int zclient_bfd_session_update(ZAPI_CALLBACK_ARGS)
 	struct interface *ifp;
 	int remote_cbit = false;
 	int state = BFD_STATUS_UNKNOWN;
+	time_t now;
 	size_t addrlen;
 	struct prefix dp;
 	struct prefix sp;
@@ -1119,6 +1120,9 @@ static int zclient_bfd_session_update(ZAPI_CALLBACK_ARGS)
 		break;
 	}
 
+	/* Cache current time to avoid multiple monotime clock calls. */
+	now = monotime(NULL);
+
 	/* Notify all matching sessions about update. */
 	TAILQ_FOREACH (bsp, &bsglobal.bsplist, entry) {
 		/* Skip disabled or not installed entries. */
@@ -1151,7 +1155,7 @@ static int zclient_bfd_session_update(ZAPI_CALLBACK_ARGS)
 		if ((int)bsp->bss.state == state)
 			continue;
 
-		bsp->bss.last_event = monotime(NULL);
+		bsp->bss.last_event = now;
 		bsp->bss.previous_state = bsp->bss.state;
 		bsp->bss.state = state;
 		bsp->bss.remote_cbit = remote_cbit;

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -128,6 +128,305 @@ extern void bfd_gbl_exit(void);
  * BFD new API.
  */
 
+/* Forward declaration of argument struct. */
+struct bfd_session_params;
+
+/** Session state definitions. */
+enum bfd_session_state {
+	/** Session state is unknown or not initialized. */
+	BSS_UNKNOWN = BFD_STATUS_UNKNOWN,
+	/** Local or remote peer administratively shutdown the session. */
+	BSS_ADMIN_DOWN = BFD_STATUS_ADMIN_DOWN,
+	/** Session is down. */
+	BSS_DOWN = BFD_STATUS_DOWN,
+	/** Session is up and working correctly. */
+	BSS_UP = BFD_STATUS_UP,
+};
+
+/** BFD session status information */
+struct bfd_session_status {
+	/** Current session state. */
+	enum bfd_session_state state;
+	/** Previous session state. */
+	enum bfd_session_state previous_state;
+	/** Remote Control Plane Independent bit state. */
+	bool remote_cbit;
+	/** Last event occurrence. */
+	time_t last_event;
+};
+
+/**
+ * Session status update callback.
+ *
+ * \param bsp BFD session parameters.
+ * \param bss BFD session status.
+ * \param arg application independent data.
+ */
+typedef void (*bsp_status_update)(struct bfd_session_params *bsp,
+				  const struct bfd_session_status *bss,
+				  void *arg);
+
+/**
+ * Allocates and initializes the session parameters.
+ *
+ * \param updatedb status update notification callback.
+ * \param args application independent data.
+ *
+ * \returns pointer to configuration storage.
+ */
+struct bfd_session_params *bfd_sess_new(bsp_status_update updatecb, void *args);
+
+/**
+ * Uninstall session if installed and free resources allocated by the
+ * parameters. Already sets pointer to `NULL` to avoid dangling references.
+ *
+ * \param bsp session parameters.
+ */
+void bfd_sess_free(struct bfd_session_params **bsp);
+
+/**
+ * Enable/disable session installation.
+ *
+ * \param bsp session parameters.
+ * \param enable knob variable.
+ */
+void bfd_sess_enable(struct bfd_session_params *bsp, bool enable);
+
+/**
+ * Set the local and peer address of the BFD session.
+ *
+ * \param bsp BFD session parameters.
+ * \param src local address (optional, can be `NULL`).
+ * \param dst remote address (mandatory).
+ */
+void bfd_sess_set_ipv4_addrs(struct bfd_session_params *bsp,
+			     struct in_addr *src, struct in_addr *dst);
+
+/**
+ * Set the local and peer address of the BFD session.
+ *
+ * \param bsp BFD session parameters.
+ * \param src local address (optional, can be `NULL`).
+ * \param dst remote address (mandatory).
+ */
+void bfd_sess_set_ipv6_addrs(struct bfd_session_params *bsp,
+			     struct in6_addr *src, struct in6_addr *dst);
+
+/**
+ * Configure the BFD session interface.
+ *
+ * \param bsp BFD session parameters.
+ * \param ifname interface name (or `NULL` to remove it).
+ */
+void bfd_sess_set_interface(struct bfd_session_params *bsp, const char *ifname);
+
+/**
+ * Configure the BFD session profile name.
+ *
+ * \param bsp BFD session parameters.
+ * \param profile profile name (or `NULL` to remove it).
+ */
+void bfd_sess_set_profile(struct bfd_session_params *bsp, const char *profile);
+
+/**
+ * Configure the BFD session VRF.
+ *
+ * \param bsp BFD session parameters.
+ * \param vrf_id the VRF identification number.
+ */
+void bfd_sess_set_vrf(struct bfd_session_params *bsp, vrf_id_t vrf_id);
+
+/**
+ * Configure the BFD session single/multi hop setting.
+ *
+ * \param bsp BFD session parameters.
+ * \param min_ttl minimum TTL value expected (255 for single hop, 254 for
+ *                multi hop with single hop, 253 for multi hop with two hops
+ *                and so on). See `BFD_SINGLE_HOP_TTL` and
+ *                `BFD_MULTI_HOP_MIN_TTL` for defaults.
+ *
+ * To simplify things if your protocol only knows the amount of hops it is
+ * better to use `bfd_sess_set_hops` instead.
+ */
+void bfd_sess_set_mininum_ttl(struct bfd_session_params *bsp, uint8_t min_ttl);
+
+/** To use single hop the minimum TTL must be set to this. */
+#define BFD_SINGLE_HOP_TTL 255
+/** To use multi hop the minimum TTL must be set to this or less. */
+#define BFD_MULTI_HOP_MIN_TTL 254
+
+/**
+ * This function is the inverted version of `bfd_sess_set_minimum_ttl`.
+ * Instead of receiving the minimum expected TTL, it receives the amount of
+ * hops the protocol will jump.
+ *
+ * \param bsp BFD session parameters.
+ * \param min_ttl minimum amount of hops expected (1 for single hop, 2 or
+ *                more for multi hop).
+ */
+void bfd_sess_set_hop_count(struct bfd_session_params *bsp, uint8_t min_ttl);
+
+/**
+ * Configure the BFD session to set the Control Plane Independent bit.
+ *
+ * \param bsp BFD session parameters.
+ * \param enable BFD Control Plane Independent state.
+ */
+void bfd_sess_set_cbit(struct bfd_session_params *bsp, bool enable);
+
+/**
+ * DEPRECATED: please avoid using timers directly and use profiles instead.
+ *
+ * Configures the BFD session timers to use. This is specially useful with
+ * `ptm-bfd` which does not support timers.
+ *
+ * \param bsp BFD session parameters.
+ * \param detection_multiplier the detection multiplier value.
+ * \param min_rx minimum required receive period.
+ * \param min_tx minimum required transmission period.
+ */
+void bfd_sess_set_timers(struct bfd_session_params *bsp,
+			 uint8_t detection_multiplier, uint32_t min_rx,
+			 uint32_t min_tx);
+
+/**
+ * Installs or updates the BFD session based on the saved session arguments.
+ *
+ * \param bsp session parameters.
+ */
+void bfd_sess_install(struct bfd_session_params *bsp);
+
+/**
+ * Uninstall the BFD session based on the saved session arguments.
+ *
+ * \param bsp session parameters.
+ */
+void bfd_sess_uninstall(struct bfd_session_params *bsp);
+
+/**
+ * Get BFD session current status.
+ *
+ * \param bsp session parameters.
+ *
+ * \returns BFD session status data structure.
+ */
+enum bfd_session_state bfd_sess_status(const struct bfd_session_params *bsp);
+
+/**
+ * Get BFD session minimum TTL configured value.
+ *
+ * \param bsp session parameters.
+ *
+ * \returns configured minimum TTL.
+ */
+uint8_t bfd_sess_minimum_ttl(const struct bfd_session_params *bsp);
+
+/**
+ * Inverted version of `bfd_sess_minimum_ttl`. Gets the amount of hops in the
+ * way to the peer.
+ *
+ * \param bsp session parameters.
+ *
+ * \returns configured amount of hops.
+ */
+uint8_t bfd_sess_hop_count(const struct bfd_session_params *bsp);
+
+/**
+ * Get BFD session profile configured value.
+ *
+ * \param bsp session parameters.
+ *
+ * \returns configured profile name (or `NULL` if empty).
+ */
+const char *bfd_sess_profile(const struct bfd_session_params *bsp);
+
+/**
+ * Get BFD session addresses.
+ *
+ * \param bsp session parameters.
+ * \param family the address family being used (AF_INET or AF_INET6).
+ * \param src source address (optional, may be `NULL`).
+ * \param dst peer address (optional, may be `NULL`).
+ */
+void bfd_sess_addresses(const struct bfd_session_params *bsp, int *family,
+			struct in6_addr *src, struct in6_addr *dst);
+/**
+ * Get BFD session interface name.
+ *
+ * \param bsp session parameters.
+ *
+ * \returns `NULL` if not set otherwise the interface name.
+ */
+const char *bfd_sess_interface(const struct bfd_session_params *bsp);
+
+/**
+ * Get BFD session VRF name.
+ *
+ * \param bsp session parameters.
+ *
+ * \returns the VRF name.
+ */
+const char *bfd_sess_vrf(const struct bfd_session_params *bsp);
+
+/**
+ * Get BFD session VRF ID.
+ *
+ * \param bsp session parameters.
+ *
+ * \returns the VRF name.
+ */
+vrf_id_t bfd_sess_vrf_id(const struct bfd_session_params *bsp);
+
+/**
+ * Get BFD session control plane independent bit configuration state.
+ *
+ * \param bsp session parameters.
+ *
+ * \returns `true` if enabled otherwise `false`.
+ */
+bool bfd_sess_cbit(const struct bfd_session_params *bsp);
+
+/**
+ * DEPRECATED: please avoid using timers directly and use profiles instead.
+ *
+ * Gets the configured timers.
+ *
+ * \param bsp BFD session parameters.
+ * \param detection_multiplier the detection multiplier value.
+ * \param min_rx minimum required receive period.
+ * \param min_tx minimum required transmission period.
+ */
+void bfd_sess_timers(const struct bfd_session_params *bsp,
+		     uint8_t *detection_multiplier, uint32_t *min_rx,
+		     uint32_t *min_tx);
+
+/**
+ * Show BFD session configuration and status. If `json` is provided (e.g. not
+ * `NULL`) then information will be inserted in object, otherwise printed to
+ * `vty`.
+ *
+ * \param vty Pointer to `vty` for outputting text.
+ * \param json (optional) JSON object pointer.
+ * \param bsp session parameters.
+ */
+void bfd_sess_show(struct vty *vty, struct json_object *json,
+		   struct bfd_session_params *bsp);
+
+/**
+ * Initializes the BFD integration library. This function executes the
+ * following actions:
+ *
+ * - Copy the `struct thread_master` pointer to use as "thread" to execute
+ *   the BFD session parameters installation.
+ * - Copy the `struct zclient` pointer to install its callbacks.
+ * - Initializes internal data structures.
+ *
+ * \param tm normally the daemon main thread event manager.
+ * \param zc the zebra client of the daemon.
+ */
+void bfd_protocol_integration_init(struct zclient *zc,
+				   struct thread_master *tm);
+
 /**
  * BFD session registration arguments.
  */
@@ -204,6 +503,34 @@ struct bfd_session_arg {
  * \see bfd_session_arg.
  */
 extern int zclient_bfd_command(struct zclient *zc, struct bfd_session_arg *arg);
+
+/**
+ * Enables or disables BFD protocol integration API debugging.
+ *
+ * \param enable new API debug state.
+ */
+extern void bfd_protocol_integration_set_debug(bool enable);
+
+/**
+ * Sets shutdown mode so no more events are processed.
+ *
+ * This is useful to avoid the event storm that happens caused by network,
+ * interfaces or VRFs removal. It should also avoid some crashes due hanging
+ * pointers left overs by protocol.
+ *
+ * \param enable new API shutdown state.
+ */
+extern void bfd_protocol_integration_set_shutdown(bool enable);
+
+/**
+ * Get API debugging state.
+ */
+extern bool bfd_protocol_integration_debug(void);
+
+/**
+ * Get API shutdown state.
+ */
+extern bool bfd_protocol_integration_shutting_down(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Summary
---

This is a rework on BGP's BFD integration using the new BFD library that first appeared here:
https://github.com/FRRouting/frr/pull/7101

(not merged yet - I'll clean up that PR after this)

Since then the API has been improved:
- Shorter function names
- More testing against already working and heavily tested implementation (a lot of topotests use BGP+BFD)
- Shutdown handler
- Last event timestamp keeping

Non API related fixes:
- BGP now handles BFD configuration hierarchy like other configurations (e.g. peer inherits configuration if not overwritten)
- Last session event is now shown in `show bgp neighbor A.B.C.D`
- Hidden commands `[no] neighbor <A.B.C.D|X:X::X:X|WORD> bfd <multihop|singlehop>` were removed (see commit `bgpd: remove cumulus specific code` and `bgpd: rework BFD integration ` for more info)


New BFD Library
---

The new library reduces the total amount of code needed to integrate a protocol with BFD and attempts to avoid the known bugs we faced with the old one. In the BGP's case the amount of code lines needed to implement the integration dropped by ~300 lines (not including the additions in `lib`).

The old library is still there because there are other daemons that need to be changed: `ospfd`, `ospf6d`, `pimd` and `isisd`.


Quickstart
---

To use the new library:

1. Initialize the API: call `bfd_protocol_integration_init(zclient, master)` on initialization

2. Configure/install new session:

   ```c
   void session_update_callback(session, state, arg) {
     struct protocol_data_struct *foo = arg;
     if (state == UP)
       protocol_session_up(foo);
     if (state == DOWN)
       protocol_session_down(foo);
   }

   void session_update_callback() {
     session = bfd_sess_new(session_update_callback, protocol_private_data_structure);
     /* minimum required config: address. */
     bfd_sess_set_ipv4(session, src, dst);
     /* enable session so it is installable. */
     bfd_sess_enable(session);
     /* Install or update session with configuration. */
     bfd_sess_install(session);
   }
   ```

3. Every time the session state changes the callback will be called until the session is disabled or deleted.

4. During the daemon shutdown we set `bfd_protocol_integration_set_shutdown(true)` to avoid triggering callback and giving us the chance to free all memory