### PR TITLE
ospf6d: Don't advertise AS-External LSAs into stub area

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -142,11 +142,12 @@ static void ospf6_area_stub_update(struct ospf6_area *area)
 
 	if (IS_AREA_STUB(area)) {
 		if (IS_OSPF6_DEBUG_ORIGINATE(ROUTER))
-			zlog_debug("Stubbing out area for if %s", area->name);
+			zlog_debug("Stubbing out area for area %s", area->name);
 		OSPF6_OPT_CLEAR(area->options, OSPF6_OPT_E);
+		ospf6_asbr_remove_externals_from_area(area);
 	} else if (IS_AREA_ENABLED(area)) {
 		if (IS_OSPF6_DEBUG_ORIGINATE(ROUTER))
-			zlog_debug("Normal area for if %s", area->name);
+			zlog_debug("Normal area for area %s", area->name);
 		OSPF6_OPT_SET(area->options, OSPF6_OPT_E);
 		ospf6_asbr_send_externals_to_area(area);
 	}

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1099,6 +1099,27 @@ void ospf6_asbr_send_externals_to_area(struct ospf6_area *oa)
 	}
 }
 
+/* When an area is stubified, remove all the external LSAs in the area */
+void ospf6_asbr_remove_externals_from_area(struct ospf6_area *oa)
+{
+	struct ospf6_lsa *lsa, *lsanext;
+	struct listnode *node, *nnode;
+	struct ospf6_area *area;
+	struct ospf6 *ospf6 = oa->ospf6;
+
+
+	/* skip if router is in other non-stub areas */
+	for (ALL_LIST_ELEMENTS(ospf6->area_list, node, nnode, area))
+		if (!IS_AREA_STUB(area))
+			return;
+
+	/* if router is only in a stub area then purge AS-External LSAs */
+	for (ALL_LSDB(oa->ospf6->lsdb, lsa, lsanext)) {
+		if (ntohs(lsa->header->type) == OSPF6_LSTYPE_AS_EXTERNAL)
+			ospf6_lsdb_remove(lsa, ospf6->lsdb);
+	}
+}
+
 void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 				 struct prefix *prefix,
 				 unsigned int nexthop_num,

--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -95,6 +95,7 @@ extern void ospf6_asbr_init(void);
 extern void ospf6_asbr_redistribute_reset(struct ospf6 *ospf6);
 extern void ospf6_asbr_terminate(void);
 extern void ospf6_asbr_send_externals_to_area(struct ospf6_area *);
+extern void ospf6_asbr_remove_externals_from_area(struct ospf6_area *oa);
 
 extern int config_write_ospf6_debug_asbr(struct vty *vty);
 extern void install_element_ospf6_debug_asbr(void);

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1893,6 +1893,13 @@ int ospf6_dbdesc_send_newone(struct thread *thread)
 	   so that ospf6_send_dbdesc () can send those LSAs */
 	size = sizeof(struct ospf6_lsa_header) + sizeof(struct ospf6_dbdesc);
 	for (ALL_LSDB(on->summary_list, lsa, lsanext)) {
+		/* if stub area then don't advertise AS-External LSAs */
+		if (IS_AREA_STUB(on->ospf6_if->area)
+		    && ntohs(lsa->header->type) == OSPF6_LSTYPE_AS_EXTERNAL) {
+			ospf6_lsdb_remove(lsa, on->summary_list);
+			continue;
+		}
+
 		if (size + sizeof(struct ospf6_lsa_header)
 		    > ospf6_packet_max(on->ospf6_if)) {
 			ospf6_lsdb_lsa_unlock(lsa);


### PR DESCRIPTION
If area is a normal area and has adjacencies up and then the user changes
the area to a stub area, the code was leaving existing AS-External LSAs in
the database and was sending AS-External LSAs into the stub area causing
the adjacency to stay in Ex-Start.   With this change we now cleanup the
AS-External LSAs that existed when area was not a stub and do not advertise
AS-External LSAs into the stub area.

This change fixes: OSPFv3 Changing area type to stub makes the neighbor stuck at Exstart state #3812

Signed-off-by: Lynne Morrison <lynne@voltanet.io>