### PR TITLE
ospf6d: fix setting NOAUTOCOST flag

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1622,12 +1622,11 @@ DEFUN (ipv6_ospf6_cost,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
+	SET_FLAG(oi->flag, OSPF6_INTERFACE_NOAUTOCOST);
 	if (oi->cost == lcost)
 		return CMD_SUCCESS;
 
 	oi->cost = lcost;
-	SET_FLAG(oi->flag, OSPF6_INTERFACE_NOAUTOCOST);
-
 	ospf6_interface_force_recalculate_cost(oi);
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
ospf6 keeps a flag to remember whether the cost for an interface was manually added via config or computed automatically, but if
the configured value matches the auto-computed one we were not setting this flag, meaning that the config would not show up in
the config.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>