### PR TITLE
tests: fix community-list invalid command

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -2390,14 +2390,7 @@ def create_bgp_community_lists(tgen, input_dict, build=False):
                     logger.error(errormsg)
                     return False
 
-                try:
-                    community_type = int(community_type)
-                    cmd = "{} {} {} {}".format(cmd, community_type, action, value)
-                except ValueError:
-
-                    cmd = "{} {} {} {} {}".format(
-                        cmd, community_type, name, action, value
-                    )
+                cmd = "{} {} {} {} {}".format(cmd, community_type, name, action, value)
 
                 if del_action:
                     cmd = "no {}".format(cmd)


### PR DESCRIPTION
Didn't test this but it's already randomly broken so cant be worse

Hopefully fixes:
```
raise InvalidCLIError("%s" % output)
InvalidCLIError: line 2: % Command incomplete[4]: bgplarge-community-list standard Test1 permit
```

