### PR TITLE
doc: fix link for python2 get-pip.py

### DIFF
--- a/doc/developer/building-frr-for-ubuntu2004.rst
+++ b/doc/developer/building-frr-for-ubuntu2004.rst
@@ -27,7 +27,7 @@ ubuntu apt repositories; in order to install it:
 
 .. code-block:: shell
 
-   curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
+   curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py
    sudo python2 ./get-pip.py
 
    # And verify the installation


### PR DESCRIPTION
Script by the current link doesn't work with Python 2 anymore:
```
ERROR: This script does not work on Python 2.7 The minimum supported Python version is 3.6.
Please use https://bootstrap.pypa.io/2.7/get-pip.py instead.
```

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>