### PR TITLE
bgpd: fix bgp statistics for l2vpn evpn

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12385,6 +12385,9 @@ static int bgp_table_stats_walker(struct thread *t)
 	case AFI_IP6:
 		space = IPV6_MAX_BITLEN;
 		break;
+	case AFI_L2VPN:
+		space = EVPN_ROUTE_PREFIXLEN;
+		break;
 	default:
 		return 0;
 	}


### PR DESCRIPTION
'show bgp l2vpn evpn statistics' was returning 0 for all stats
because bgp_table_stats_walker bailed out if afi != AFI_IP or AFI_IP6.
Add case condition to catch AFI_L2VPN.

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>