### PR TITLE
bgpd,lib: small improvement in BGP read

### DIFF
--- a/lib/ringbuf.h
+++ b/lib/ringbuf.h
@@ -126,6 +126,17 @@ void ringbuf_reset(struct ringbuf *buf);
  */
 void ringbuf_wipe(struct ringbuf *buf);
 
+/**
+ * Perform a socket/file `read()` in to the ring buffer.
+ *
+ * \param buf the ring buffer pointer.
+ * \param sock the file descriptor.
+ * \returns the number of bytes read, `0` on connection close or `-1` with
+ *          `errno` pointing the error (see `readv()` man page for more
+ *          information.)
+ */
+ssize_t ringbuf_read(struct ringbuf *buf, int sock);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
As noticed here:
https://github.com/FRRouting/frr/pull/8196#discussion_r587971345

The buffer allocated in stack got quite big with the BGP extended message. I think we don't even need to use the stack and save a `memcpy`, so here is a PR to address that.

Changes
---

- New ringbuffer function to read descriptors directly into the buffer using `readv` (instead of two reads)
- Use the new function in BGP to avoid using stack memory and save a `memcpy`