### PR TITLE
bgpd: Display RPKI validation state if we have it

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -562,6 +562,7 @@ static int bgp_rpki_module_init(void)
 {
 	lrtr_set_alloc_functions(malloc_wrapper, realloc_wrapper, free_wrapper);
 
+	hook_register(bgp_rpki_prefix_status, rpki_validate_prefix);
 	hook_register(frr_late_init, bgp_rpki_init);
 	hook_register(frr_early_fini, &bgp_rpki_fini);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2371,6 +2371,11 @@ DECLARE_HOOK(bgp_snmp_update_last_changed, (struct bgp *bgp), (bgp))
 DECLARE_HOOK(bgp_snmp_update_stats,
 	     (struct bgp_node *rn, struct bgp_path_info *pi, bool added),
 	     (rn, pi, added))
+DECLARE_HOOK(bgp_rpki_prefix_status,
+	     (struct peer * peer, struct attr *attr,
+	      const struct prefix *prefix),
+	     (peer, attr, prefix))
+
 void peer_nsf_stop(struct peer *peer);
 
 #endif /* _QUAGGA_BGPD_H */


### PR DESCRIPTION
When dumping data about prefixes in bgp.  Let's dump the
rpki validation state as well:

Output if rpki is turned on:
janelle# show rpki prefix 2003::/19
Prefix                                   Prefix Length  Origin-AS
2003::                                      19 -  19         3320
janelle# show bgp ipv6 uni 2003::/19
BGP routing table entry for 2003::/19
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  15096 6939 3320
    ::ffff:4113:867a from 65.19.134.122 (193.72.216.231)
    (fe80::e063:daff:fe79:1dab) (used)
      Origin IGP, valid, external, best (First path received), validation-state: valid
      Last update: Sat Mar  6 09:20:51 2021
janelle# show rpki prefix 8.8.8.0/24
Prefix                                   Prefix Length  Origin-AS
janelle# show bgp ipv4 uni 8.8.8.0/24
BGP routing table entry for 8.8.8.0/24
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  100.99.229.142
  15096 6939 15169
    65.19.134.122 from 65.19.134.122 (193.72.216.231)
      Origin IGP, valid, external, best (First path received), validation-state: not found
      Last update: Sat Mar  6 09:21:25 2021

Example output when rpki is not configured:
eva# show bgp ipv4 uni 8.8.8.0/24
BGP routing table entry for 8.8.8.0/24
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  janelle(192.168.161.137)
  64539 15096 6939 15169
    192.168.161.137(janelle) from janelle(192.168.161.137) (192.168.44.1)
      Origin IGP, valid, external, bestpath-from-AS 64539, best (First path received)
      Last update: Sat Mar  6 09:33:51 2021

Signed-off-by: Donald Sharp <sharpd@nvidia.com>