### PR TITLE
northbound: KISS always batch yang config, it's faster.

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1386,7 +1386,7 @@ DEFUN_YANG_NOSH(router_bgp,
 					      NB_OP_MODIFY, "false");
 		}
 
-		ret = nb_cli_apply_changes(vty, base_xpath);
+		ret = nb_cli_apply_changes_clear_pending(vty, base_xpath);
 		if (ret == CMD_SUCCESS) {
 			VTY_PUSH_XPATH(BGP_NODE, base_xpath);
 
@@ -1394,7 +1394,6 @@ DEFUN_YANG_NOSH(router_bgp,
 			 * For backward compatibility with old commands we still
 			 * need to use the qobj infrastructure.
 			 */
-			nb_cli_pending_commit_check(vty);
 			bgp = bgp_lookup(as, name);
 			if (bgp)
 				VTY_PUSH_CONTEXT(BGP_NODE, bgp);
@@ -1444,7 +1443,8 @@ DEFUN_YANG(no_router_bgp,
 
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, base_xpath);
+	/* We want to finish any classic config after a no router */
+	return nb_cli_apply_changes_clear_pending(vty, base_xpath);
 }
 
 void cli_show_router_bgp(struct vty *vty, struct lyd_node *dnode,
@@ -4675,7 +4675,11 @@ DEFUN_YANG(no_neighbor,
 
 	nb_cli_enqueue_change(vty, base_xpath, NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, NULL);
+	/*
+	 * Need to commit any pending so this command doesn't merge with a
+	 * create into a modify, which BGP can't handle
+	 */
+	return nb_cli_apply_changes_clear_pending(vty, NULL);
 }
 
 DEFUN_YANG(no_neighbor_interface_config,
@@ -4699,7 +4703,11 @@ DEFUN_YANG(no_neighbor_interface_config,
 
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, base_xpath);
+	/*
+	 * Need to commit any pending so this command doesn't merge with a
+	 * create into a modify, which BGP can't handle
+	 */
+	return nb_cli_apply_changes_clear_pending(vty, base_xpath);
 }
 
 DEFUN_YANG(no_neighbor_peer_group,
@@ -4717,7 +4725,11 @@ DEFUN_YANG(no_neighbor_peer_group,
 
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, base_xpath);
+	/*
+	 * Need to commit any pending so this command doesn't merge with a
+	 * create into a modify, which BGP can't handle
+	 */
+	return nb_cli_apply_changes_clear_pending(vty, base_xpath);
 }
 
 DEFUN_YANG(no_neighbor_interface_peer_group_remote_as,
@@ -4756,7 +4768,11 @@ DEFUN_YANG(no_neighbor_interface_peer_group_remote_as,
 
 	nb_cli_enqueue_change(vty, base_xpath, NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, NULL);
+	/*
+	 * Need to commit any pending so this command doesn't merge with a
+	 * create into a modify, which BGP can't handle
+	 */
+	return nb_cli_apply_changes_clear_pending(vty, NULL);
 }
 
 DEFUN_YANG(neighbor_local_as,
@@ -5087,7 +5103,11 @@ DEFUN_YANG (no_neighbor_set_peer_group,
 
 	nb_cli_enqueue_change(vty, "./peer-group", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, base_xpath);
+	/*
+	 * Need to commit any pending so this command doesn't merge with a
+	 * create into a modify, which BGP can't handle
+	 */
+	return nb_cli_apply_changes_clear_pending(vty, base_xpath);
 }
 
 ALIAS_HIDDEN(no_neighbor_set_peer_group, no_neighbor_set_peer_group_hidden_cmd,

--- a/eigrpd/eigrp_cli.c
+++ b/eigrpd/eigrp_cli.c
@@ -79,7 +79,7 @@ DEFPY_YANG(
 		 as_str, vrf ? vrf : VRF_DEFAULT_NAME);
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
-	return nb_cli_apply_changes(vty, NULL);
+	return nb_cli_apply_changes_clear_pending(vty, NULL);
 }
 
 void eigrp_cli_show_header(struct vty *vty, struct lyd_node *dnode,

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -126,7 +126,7 @@ DEFPY_YANG(no_router_isis, no_router_isis_cmd,
 
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(
+	return nb_cli_apply_changes_clear_pending(
 		vty, "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']", tag,
 		vrf_name);
 }

--- a/lib/command.c
+++ b/lib/command.c
@@ -980,7 +980,7 @@ static int cmd_execute_command_real(vector vline, enum cmd_filter_type filter,
 			 * non-YANG command.
 			 */
 			if (matched_element->attr != CMD_ATTR_YANG)
-				nb_cli_pending_commit_check(vty);
+				(void)nb_cli_pending_commit_check(vty);
 		}
 
 		ret = matched_element->func(matched_element, vty, argc, argv);

--- a/lib/if.c
+++ b/lib/if.c
@@ -905,8 +905,8 @@ connected_log(struct connected *connected, char *str)
 
 	p = connected->destination;
 	if (p) {
-		strncat(logbuf, inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ),
-			BUFSIZ - strlen(logbuf));
+		strlcat(logbuf, inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ),
+			BUFSIZ);
 	}
 	zlog_info("%s", logbuf);
 }
@@ -1238,7 +1238,7 @@ DEFPY_YANG_NOSH (interface,
 		 vrf_name);
 
 	nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
-	ret = nb_cli_apply_changes(vty, xpath_list);
+	ret = nb_cli_apply_changes_clear_pending(vty, xpath_list);
 	if (ret == CMD_SUCCESS) {
 		VTY_PUSH_XPATH(INTERFACE_NODE, xpath_list);
 
@@ -1248,7 +1248,6 @@ DEFPY_YANG_NOSH (interface,
 		 * all interface-level commands are converted to the new
 		 * northbound model.
 		 */
-		nb_cli_pending_commit_check(vty);
 		ifp = if_lookup_by_name(ifname, vrf_id);
 		if (ifp)
 			VTY_PUSH_CONTEXT(INTERFACE_NODE, ifp);

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -704,6 +704,7 @@ extern struct debug nb_dbg_cbs_state;
 extern struct debug nb_dbg_cbs_rpc;
 extern struct debug nb_dbg_notif;
 extern struct debug nb_dbg_events;
+extern struct debug nb_dbg_libyang;
 
 /* Global running configuration. */
 extern struct nb_config *running_config;

--- a/lib/northbound_cli.h
+++ b/lib/northbound_cli.h
@@ -57,7 +57,26 @@ extern void nb_cli_enqueue_change(struct vty *vty, const char *xpath,
 				  const char *value);
 
 /*
- * Apply enqueued changes to the candidate configuration.
+ * Apply enqueued changes to the candidate configuration, do not batch,
+ * and apply any pending commits along with the currently enqueued.
+ *
+ * vty
+ *    The vty context.
+ *
+ * xpath_base_fmt
+ *    Prepend the given XPath (absolute or relative) to all enqueued
+ *    configuration changes. This is an optional parameter.
+ *
+ * Returns:
+ *    CMD_SUCCESS on success, CMD_WARNING_CONFIG_FAILED otherwise.
+ */
+extern int nb_cli_apply_changes_clear_pending(struct vty *vty,
+					      const char *xpath_base_fmt, ...);
+
+/*
+ * Apply enqueued changes to the candidate configuration, this function
+ * may not immediately apply the changes, instead adding them to a pending
+ * queue.
  *
  * vty
  *    The vty context.
@@ -116,8 +135,12 @@ extern void nb_cli_show_dnode_cmds(struct vty *vty, struct lyd_node *dnode,
  *
  * vty
  *    The vty context.
+ *
+ * Returns
+ *    CMD_SUCCESS on success (or no pending), CMD_WARNING_CONFIG_FAILED
+ *    otherwise.
  */
-extern void nb_cli_pending_commit_check(struct vty *vty);
+extern int nb_cli_pending_commit_check(struct vty *vty);
 
 /* Prototypes of internal functions. */
 extern void nb_cli_show_config_prepare(struct nb_config *config,

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -690,10 +690,9 @@ int vrf_handler_create(struct vty *vty, const char *vrfname,
 			 vrfname);
 
 		nb_cli_enqueue_change(vty, xpath_list, NB_OP_CREATE, NULL);
-		ret = nb_cli_apply_changes(vty, xpath_list);
+		ret = nb_cli_apply_changes_clear_pending(vty, xpath_list);
 		if (ret == CMD_SUCCESS) {
 			VTY_PUSH_XPATH(VRF_NODE, xpath_list);
-			nb_cli_pending_commit_check(vty);
 			vrfp = vrf_lookup_by_name(vrfname);
 			if (vrfp)
 				VTY_PUSH_CONTEXT(VRF_NODE, vrfp);

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2622,8 +2622,8 @@ int vty_config_node_exit(struct vty *vty)
 {
 	vty->xpath_index = 0;
 
-	/* Perform pending commit if any. */
-	nb_cli_pending_commit_check(vty);
+	/* Perform any pending commits. */
+	(void)nb_cli_pending_commit_check(vty);
 
 	/* Check if there's a pending confirmed commit. */
 	if (vty->t_confirmed_commit_timeout) {

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -135,9 +135,8 @@ struct vty {
 	struct nb_config *candidate_config_base;
 
 	/* Dynamic transaction information. */
-	struct timeval backoff_start;
-	size_t backoff_cmd_count;
-	struct thread *t_pending_commit;
+	bool pending_allowed;
+	bool pending_commit;
 	char *pending_cmds_buf;
 	size_t pending_cmds_buflen;
 	size_t pending_cmds_bufpos;

--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -80,7 +80,7 @@ DEFPY_YANG (no_router_rip,
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, NULL);
+	return nb_cli_apply_changes_clear_pending(vty, NULL);
 }
 
 void cli_show_router_rip(struct vty *vty, struct lyd_node *dnode,

--- a/ripngd/ripng_cli.c
+++ b/ripngd/ripng_cli.c
@@ -80,7 +80,7 @@ DEFPY_YANG (no_router_ripng,
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, NULL);
+	return nb_cli_apply_changes_clear_pending(vty, NULL);
 }
 
 void cli_show_router_ripng(struct vty *vty, struct lyd_node *dnode,

--- a/tests/bgpd/test_peer_attr.c
+++ b/tests/bgpd/test_peer_attr.c
@@ -776,14 +776,16 @@ static void test_execute(struct test *test, const char *fmt, ...)
 
 	/* Execute command (non-strict). */
 	ret = cmd_execute_command(vline, test->vty, NULL, 0);
+	if (ret == CMD_SUCCESS) {
+		/* Commit any pending changes, irnore error */
+		ret = nb_cli_pending_commit_check(test->vty);
+	}
 	if (ret != CMD_SUCCESS) {
 		test->state = TEST_COMMAND_ERROR;
 		test->error = str_printf(
 			"execution of command [%s] has failed with code [%d]",
 			cmd, ret);
 	}
-
-	nb_cli_pending_commit_check(test->vty);
 
 	/* Free memory. */
 	cmd_free_strvec(vline);


### PR DESCRIPTION
The backoff code assumed that yang operations always completed quickly.
It checked for > 100 YANG modeled commands happening in under 1 second
to enable batching. If 100 yang modeled commands always take longer than
1 second batching is never enabled. This is the exact opposite of what
we want to happen since batching speeds the operations up.

Here are the results for libyang2 code, for static routes, without and with batching.

```
| action        |  1K rts |  2K rts | 1K rts | 2K rts | 20k rts |
|               | nobatch | nobatch |  batch |  batch |   batch |
| Add IPv4      |    .881 |    1.28 |   .703 |   1.04 |    8.16 |
| Add Same IPv4 |    28.7 |     113 |   .590 |   .860 |    6.09 |
| Rem 1/2 IPv4  |    .376 |    .442 |   .379 |   .435 |    1.44 |
| Add Same IPv4 |    28.7 |     113 |   .576 |   .841 |    6.02 |
| Rem All IPv4  |    17.4 |    71.8 |   .559 |   .813 |    5.57 |
```

(IPv6 numbers are basically the same as iPv4, a couple percent slower)

Clearly we need this. Please note the growth (1K to 2K) w/o batching is
non-linear and 100 times slower than batched.

Notes on code: The use of the new `nb_cli_apply_changes_clear_pending`
is to commit any pending changes (including the current one). This is
done when the code would not correctly handle a single diff that
included the current changes with possible following changes. For
example, a "no" command followed by a new value to replace it would be
merged into a change, and the code would not deal well with that. A good
example of this is BGP neighbor peer-group changing. The other use is
after entering a router level (e.g., "router bgp") where the follow-on
command handlers expect that router object to now exists. The code
eventually needs to be cleaned up to not fail in these cases, but that
is for future NB cleanup.