### PR TITLE
isisd: add vrf support for redistribution function in ISIS

### DIFF
--- a/isisd/isis_redist.c
+++ b/isisd/isis_redist.c
@@ -374,9 +374,11 @@ static void isis_redist_update_zebra_subscriptions(struct isis *isis)
 			afi_t afi = afi_for_redist_protocol(protocol);
 
 			if (do_subscribe[protocol][type])
-				isis_zebra_redistribute_set(afi, type, isis->vrf_id);
+				isis_zebra_redistribute_set(afi, type,
+						isis->vrf_id);
 			else
-				isis_zebra_redistribute_unset(afi, type, isis->vrf_id);
+				isis_zebra_redistribute_unset(afi, type,
+						isis->vrf_id);
 		}
 }
 

--- a/isisd/isis_redist.c
+++ b/isisd/isis_redist.c
@@ -374,9 +374,9 @@ static void isis_redist_update_zebra_subscriptions(struct isis *isis)
 			afi_t afi = afi_for_redist_protocol(protocol);
 
 			if (do_subscribe[protocol][type])
-				isis_zebra_redistribute_set(afi, type);
+				isis_zebra_redistribute_set(afi, type, isis->vrf_id);
 			else
-				isis_zebra_redistribute_unset(afi, type);
+				isis_zebra_redistribute_unset(afi, type, isis->vrf_id);
 		}
 }
 

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -522,24 +522,24 @@ int isis_distribute_list_update(int routetype)
 	return 0;
 }
 
-void isis_zebra_redistribute_set(afi_t afi, int type)
+void isis_zebra_redistribute_set(afi_t afi, int type, vrf_id_t vrf_id)
 {
 	if (type == DEFAULT_ROUTE)
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_ADD,
-					     zclient, afi, VRF_DEFAULT);
+					     zclient, afi, vrf_id);
 	else
 		zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, zclient, afi, type,
-				     0, VRF_DEFAULT);
+				     0, vrf_id);
 }
 
-void isis_zebra_redistribute_unset(afi_t afi, int type)
+void isis_zebra_redistribute_unset(afi_t afi, int type, vrf_id_t vrf_id)
 {
 	if (type == DEFAULT_ROUTE)
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_DELETE,
-					     zclient, afi, VRF_DEFAULT);
+					     zclient, afi, vrf_id);
 	else
 		zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, zclient, afi,
-				     type, 0, VRF_DEFAULT);
+				     type, 0, vrf_id);
 }
 
 /**

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -57,8 +57,8 @@ void isis_zebra_prefix_sid_uninstall(struct isis_area *area,
 				     struct isis_sr_psid_info *psid);
 void isis_zebra_send_adjacency_sid(int cmd, const struct sr_adjacency *sra);
 int isis_distribute_list_update(int routetype);
-void isis_zebra_redistribute_set(afi_t afi, int type);
-void isis_zebra_redistribute_unset(afi_t afi, int type);
+void isis_zebra_redistribute_set(afi_t afi, int type, vrf_id_t vrf_id);
+void isis_zebra_redistribute_unset(afi_t afi, int type, vrf_id_t vrf_id);
 int isis_zebra_rlfa_register(struct isis_spftree *spftree, struct rlfa *rlfa);
 void isis_zebra_rlfa_unregister_all(struct isis_spftree *spftree);
 bool isis_zebra_label_manager_ready(void);


### PR DESCRIPTION
Now it's possible to redistribute from another protocol routes which are
inside a specific vrf.

Example of possible configuration:

```
!
vrf isis-l1
 ipv6 route fd00::/60 blackhole
 exit-vrf
!
interface one vrf isis-l1
 ipv6 router isis COMMON vrf isis-l1
 isis circuit-type level-1
!
router isis COMMON vrf isis-l1
 is-type level-1
 net fd.0000.0000.0000.0001.00
 redistribute ipv6 static level-1
 topology ipv6-unicast
!
```

Signed-off-by: Emanuele Altomare <emanuele@common-net.org>