### PR TITLE
ospf6d, topotest: OSPFv3 vrf support

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -849,7 +849,8 @@ DEFUN (no_area_export_list,
 	return CMD_SUCCESS;
 }
 
-static int show_ipv6_ospf6_spf_tree_common(struct vty *vty, struct ospf6 *ospf6, bool uj)
+static int show_ipv6_ospf6_spf_tree_common(struct vty *vty, 
+																struct ospf6 *ospf6, bool uj)
 {
 	struct listnode *node;
 	struct ospf6_area *oa;
@@ -918,7 +919,6 @@ DEFUN (show_ipv6_ospf6_spf_tree,
 	struct listnode *node;
 	struct ospf6 *ospf6;
 	bool uj = use_json(argc, argv);
-
 	char *vrf_name = NULL;
 	bool all_vrf = false;
 	int idx_vrf = 0;
@@ -930,7 +930,6 @@ DEFUN (show_ipv6_ospf6_spf_tree,
 			((ospf6->name == NULL && vrf_name == NULL)
 			|| (ospf6->name && vrf_name && strcmp(ospf6->name, vrf_name) == 0))) {
 			show_ipv6_ospf6_spf_tree_common(vty, ospf6, uj);
-
 			if (!all_vrf)
 				break;
 		}
@@ -1002,10 +1001,11 @@ DEFUN (show_ipv6_ospf6_area_spf_tree,
 }
 
 static int
-show_ospf6_simulate_spf_tree_common(struct vty *vty, struct cmd_token **argv,
-            struct ospf6 *ospf6, uint32_t router_id,
-            uint32_t area_id, struct prefix prefix,
-            int idx_ipv4_2)
+show_ospf6_simulate_spf_tree_common(struct vty *vty, 
+						struct cmd_token **argv,
+						struct ospf6 *ospf6, uint32_t router_id,
+						uint32_t area_id, struct prefix prefix,
+						int idx_ipv4_2)
 {
 	struct ospf6_area *oa;
 	struct ospf6_vertex *root;

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -221,7 +221,7 @@ int main(int argc, char *argv[], char *envp[])
 	/* thread master */
 	master = om6->master;
 
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	ospf6_vrf_init();
 	access_list_init();
 	prefix_list_init();
 

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -967,35 +967,24 @@ static void ospf6_neighbor_show_detail(struct vty *vty,
 	}
 }
 
-DEFUN (show_ipv6_ospf6_neighbor,
-       show_ipv6_ospf6_neighbor_cmd,
-       "show ipv6 ospf6 neighbor [<detail|drchoice>] [json]",
-       SHOW_STR
-       IP6_STR
-       OSPF6_STR
-       "Neighbor list\n"
-       "Display details\n"
-       "Display DR choices\n"
-       JSON_STR)
+static void ospf6_neighbor_show_detail_common(struct vty *vty, int argc,
+                struct cmd_token **argv,
+                struct ospf6 *ospf6, int idx_type,
+                int detail_idx, int json_idx)
 {
-	int idx_type = 4;
-	struct ospf6_neighbor *on;
-	struct ospf6_interface *oi;
-	struct ospf6_area *oa;
-	struct listnode *i, *j, *k;
-	struct ospf6 *ospf6;
-	json_object *json = NULL;
-	json_object *json_array = NULL;
-	bool uj = use_json(argc, argv);
-	void (*showfunc)(struct vty *, struct ospf6_neighbor *,
-			 json_object *json, bool use_json);
+  struct ospf6_neighbor *on;
+  struct ospf6_interface *oi;
+  struct ospf6_area *oa;
+  struct listnode *i, *j, *k;
+  json_object *json = NULL;
+  json_object *json_array = NULL;
+  bool uj = use_json(argc, argv);
+  void (*showfunc)(struct vty *, struct ospf6_neighbor *,
+       json_object *json, bool use_json);
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+  showfunc = ospf6_neighbor_show;
 
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
-	showfunc = ospf6_neighbor_show;
-
-	if ((uj && argc == 6) || (!uj && argc == 5)) {
+	if ((uj && argc == detail_idx) || (!uj && argc == json_idx)) {
 		if (!strncmp(argv[idx_type]->arg, "de", 2))
 			showfunc = ospf6_neighbor_show_detail;
 		else if (!strncmp(argv[idx_type]->arg, "dr", 2))
@@ -1035,58 +1024,130 @@ DEFUN (show_ipv6_ospf6_neighbor,
 				json, JSON_C_TO_STRING_PRETTY));
 		json_object_free(json);
 	}
-	return CMD_SUCCESS;
+
 }
 
-
-DEFUN (show_ipv6_ospf6_neighbor_one,
-       show_ipv6_ospf6_neighbor_one_cmd,
-       "show ipv6 ospf6 neighbor A.B.C.D [json]",
+DEFUN (show_ipv6_ospf6_neighbor,
+       show_ipv6_ospf6_neighbor_cmd,
+       "show ipv6 ospf6 [vrf <NAME|all>] neighbor [<detail|drchoice>] [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
+       VRF_CMD_HELP_STR
+       "All VRFs\n"
+       "Neighbor list\n"
+       "Display details\n"
+       "Display DR choices\n"
+       JSON_STR)
+{
+	int idx_type = 4;
+  int detail_idx = 5;
+  int json_idx = 6;
+	struct ospf6 *ospf6;
+  struct listnode *node;
+  char *vrf_name = NULL;
+  bool all_vrf = false;
+  int idx_vrf = 0;
+
+  OSPF6_CMD_CHECK_RUNNING();
+  OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+  if (idx_vrf > 0) {
+    idx_type += 2;
+    detail_idx += 2;
+    json_idx += 2;
+  }
+
+  for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+    if (all_vrf ||
+      ((ospf6->name == NULL && vrf_name == NULL)
+      || (ospf6->name && vrf_name && strcmp(ospf6->name, vrf_name) == 0))) {
+      ospf6_neighbor_show_detail_common(vty, argc, argv,
+        ospf6, idx_type, detail_idx, json_idx);
+      if (!all_vrf)
+        break;
+    }
+  }
+
+  return CMD_SUCCESS;
+}
+
+static int ospf6_neighbor_show_common(struct vty *vty, int argc,
+              struct cmd_token **argv,
+              struct ospf6 *ospf6, int idx_ipv4)
+{
+  struct ospf6_neighbor *on;
+  struct ospf6_interface *oi;
+  struct ospf6_area *oa;
+  struct listnode *i, *j, *k;
+  void (*showfunc)(struct vty *, struct ospf6_neighbor *,
+       json_object *json, bool use_json);
+  uint32_t router_id;
+  json_object *json = NULL;
+  bool uj = use_json(argc, argv);
+
+  showfunc = ospf6_neighbor_show_detail;
+  if (uj)
+    json = json_object_new_object();
+
+  if ((inet_pton(AF_INET, argv[idx_ipv4]->arg, &router_id)) != 1) {
+    vty_out(vty, "Router-ID is not parsable: %s\n",
+      argv[idx_ipv4]->arg);
+    return CMD_SUCCESS;
+  }
+
+  for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa))
+    for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi))
+      for (ALL_LIST_ELEMENTS_RO(oi->neighbor_list, k, on)) {
+        if (router_id == on->router_id)
+          (*showfunc)(vty, on, json, uj);
+      }
+
+  if (uj) {
+    vty_out(vty, "%s\n",
+      json_object_to_json_string_ext(
+        json, JSON_C_TO_STRING_PRETTY));
+    json_object_free(json);
+  }
+
+  return CMD_SUCCESS;
+}
+
+DEFUN (show_ipv6_ospf6_neighbor_one,
+       show_ipv6_ospf6_neighbor_one_cmd,
+       "show ipv6 ospf6 [vrf <NAME|all>] neighbor A.B.C.D [json]",
+       SHOW_STR
+       IP6_STR
+       OSPF6_STR
+       VRF_CMD_HELP_STR
+       "All VRFs\n"
        "Neighbor list\n"
        "Specify Router-ID as IPv4 address notation\n"
        JSON_STR)
 {
 	int idx_ipv4 = 4;
-	struct ospf6_neighbor *on;
-	struct ospf6_interface *oi;
-	struct ospf6_area *oa;
-	struct listnode *i, *j, *k;
-	void (*showfunc)(struct vty *, struct ospf6_neighbor *,
-			 json_object *json, bool use_json);
-	uint32_t router_id;
-	struct ospf6 *ospf6;
-	json_object *json = NULL;
-	bool uj = use_json(argc, argv);
+  struct ospf6 *ospf6;
+  struct listnode *node;
+  char *vrf_name = NULL;
+  bool all_vrf = false;
+  int idx_vrf = 0;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
-	showfunc = ospf6_neighbor_show_detail;
-	if (uj)
-		json = json_object_new_object();
+  OSPF6_CMD_CHECK_RUNNING();
+  OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+  if (idx_vrf > 0)
+    idx_ipv4 += 2;
 
-	if ((inet_pton(AF_INET, argv[idx_ipv4]->arg, &router_id)) != 1) {
-		vty_out(vty, "Router-ID is not parsable: %s\n",
-			argv[idx_ipv4]->arg);
-		return CMD_SUCCESS;
-	}
+  for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+    if (all_vrf ||
+      ((ospf6->name == NULL && vrf_name == NULL)
+      || (ospf6->name && vrf_name && strcmp(ospf6->name, vrf_name) == 0))) {
+      ospf6_neighbor_show_common(vty, argc, argv, ospf6, idx_ipv4);
 
-	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa))
-		for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi))
-			for (ALL_LIST_ELEMENTS_RO(oi->neighbor_list, k, on)) {
-				if (router_id == on->router_id)
-					(*showfunc)(vty, on, json, uj);
-			}
+      if (!all_vrf)
+        break;
+    }
+  }
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
-	return CMD_SUCCESS;
+  return CMD_SUCCESS;
 }
 
 void ospf6_neighbor_init(void)

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -122,6 +122,107 @@ struct ospf6 *ospf6_lookup_by_vrf_name(const char *name)
 	return NULL;
 }
 
+/* This is hook function for vrf create called as part of vrf_init */
+static int ospf6_vrf_new(struct vrf *vrf)
+{
+  zlog_debug("%s: VRF Created: %s(%u)", __func__, vrf->name, vrf->vrf_id);
+
+  return 0;
+}
+
+/* This is hook function for vrf delete call as part of vrf_init */
+static int ospf6_vrf_delete(struct vrf *vrf)
+{
+  zlog_debug("%s: VRF Deletion: %s(%u)", __func__, vrf->name,
+       vrf->vrf_id);
+
+  return 0;
+}
+
+/* Disable OSPF6 VRF instance */
+static int ospf6_vrf_disable(struct vrf *vrf)
+{
+  struct ospf6 *ospf6 = NULL;
+  vrf_id_t old_vrf_id = VRF_UNKNOWN;
+
+  if (vrf->vrf_id == VRF_DEFAULT)
+    return 0;
+
+  zlog_debug("%s: VRF %s id %d disabled.", __func__, vrf->name,
+       vrf->vrf_id);
+
+  ospf6 = ospf6_lookup_by_vrf_name(vrf->name);
+  if (ospf6) {
+    old_vrf_id = ospf6->vrf_id;
+
+    /* We have instance configured, unlink
+     * from VRF and make it "down".
+     */
+    ospf6_vrf_unlink(ospf6, vrf);
+    zlog_debug("%s: ospf old_vrf_id %d unlinked", __func__,
+         old_vrf_id);
+    thread_cancel(&ospf6->t_ospf6_receive);
+    close(ospf6->fd);
+    ospf6->fd = -1;
+  }
+
+  /* Note: This is a callback, the VRF will be deleted by the caller. */
+  return 0;
+}
+
+/* Enable OSPF6 VRF instance */
+static int ospf6_vrf_enable(struct vrf *vrf)
+{
+  struct ospf6 *ospf6 = NULL;
+  vrf_id_t old_vrf_id;
+  int ret = 0;
+
+  zlog_debug("%s: VRF %s id %u enabled", __func__, vrf->name,
+       vrf->vrf_id);
+  if (vrf->vrf_id == VRF_DEFAULT)
+    ospf6 = ospf6_lookup_by_vrf_id(vrf->vrf_id);
+  else
+    ospf6 = ospf6_lookup_by_vrf_name(vrf->name);
+  if (ospf6) {
+    if (ospf6->name && strmatch(vrf->name, VRF_DEFAULT_NAME)) {
+      XFREE(MTYPE_OSPF6_TOP, ospf6->name);
+      ospf6->name = NULL;
+    }
+    old_vrf_id = ospf6->vrf_id;
+    /* We have instance configured, link to VRF and make it "up". */
+    ospf6_vrf_link(ospf6, vrf);
+    zlog_debug("%s: ospf linked to vrf %s vrf_id %u (old id %u)",
+         __func__, vrf->name, ospf6->vrf_id, old_vrf_id);
+
+    if (old_vrf_id != ospf6->vrf_id) {
+      frr_with_privs(&ospf6d_privs) {
+        /* stop zebra redist to us for old vrf */
+        zclient_send_dereg_requests(zclient,
+                  old_vrf_id);
+
+        ospf6_set_redist_vrf_bitmaps(ospf6);
+        /* start zebra redist to us for new vrf */
+        ospf6_zebra_vrf_register(ospf6);
+
+        ret = ospf6_serv_sock(ospf6);
+      }
+      if (ret < 0 || ospf6->fd <= 0)
+        return 0;
+      thread_add_read(master, ospf6_receive, ospf6, ospf6->fd,
+          &ospf6->t_ospf6_receive);
+
+      ospf6_router_id_update(ospf6);
+    }
+  }
+
+  return 0;
+}
+
+void ospf6_vrf_init(void)
+{
+  vrf_init(ospf6_vrf_new, ospf6_vrf_enable, ospf6_vrf_disable,
+     ospf6_vrf_delete, ospf6_vrf_enable);
+}
 
 static void ospf6_top_lsdb_hook_add(struct ospf6_lsa *lsa)
 {
@@ -218,14 +319,18 @@ static struct ospf6 *ospf6_create(const char *name)
 
 	o = XCALLOC(MTYPE_OSPF6_TOP, sizeof(struct ospf6));
 
-	vrf = vrf_lookup_by_name(name);
+  if (name == NULL)
+    vrf = vrf_lookup_by_id(VRF_DEFAULT);
+  else
+	  vrf = vrf_lookup_by_name(name);
 	if (vrf) {
 		o->vrf_id = vrf->vrf_id;
 	} else
 		o->vrf_id = VRF_UNKNOWN;
 
 	/* Freed in ospf6_delete */
-	o->name = XSTRDUP(MTYPE_OSPF6_TOP, name);
+  if (name)
+	  o->name = XSTRDUP(MTYPE_OSPF6_TOP, name);
 	if (vrf)
 		ospf6_vrf_link(o, vrf);
 
@@ -288,6 +393,9 @@ struct ospf6 *ospf6_instance_create(const char *name)
 	if (ospf6->router_id == 0)
 		ospf6_router_id_update(ospf6);
 	ospf6_add(ospf6);
+  if (ospf6->fd < 0)
+    return ospf6;
+
 	thread_add_read(master, ospf6_receive, ospf6, ospf6->fd,
 			&ospf6->t_ospf6_receive);
 
@@ -434,15 +542,22 @@ void ospf6_router_id_update(struct ospf6 *ospf6)
 /* start ospf6 */
 DEFUN_NOSH (router_ospf6,
        router_ospf6_cmd,
-       "router ospf6",
+       "router ospf6 [vrf NAME]",
        ROUTER_STR
-       OSPF6_STR)
+       OSPF6_STR
+       VRF_CMD_HELP_STR)
 {
 	struct ospf6 *ospf6;
+  char *vrf_name = NULL;
+  int idx_vrf = 0;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+  if (argv_find(argv, argc, "vrf", &idx_vrf)) {
+    vrf_name = argv[idx_vrf + 1]->arg;
+  }
+
+	ospf6 = ospf6_lookup_by_vrf_name(vrf_name);
 	if (ospf6 == NULL)
-		ospf6 = ospf6_instance_create(VRF_DEFAULT_NAME);
+		ospf6 = ospf6_instance_create(vrf_name);
 
 	/* set current ospf point. */
 	VTY_PUSH_CONTEXT(OSPF6_NODE, ospf6);
@@ -453,14 +568,21 @@ DEFUN_NOSH (router_ospf6,
 /* stop ospf6 */
 DEFUN (no_router_ospf6,
        no_router_ospf6_cmd,
-       "no router ospf6",
+       "no router ospf6 [vrf NAME]",
        NO_STR
        ROUTER_STR
-       OSPF6_STR)
+       OSPF6_STR
+       VRF_CMD_HELP_STR)
 {
 	struct ospf6 *ospf6;
+  char *vrf_name = NULL;
+  int idx_vrf = 0;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
+  if (argv_find(argv, argc, "vrf", &idx_vrf)) {
+    vrf_name = argv[idx_vrf + 1]->arg;
+  }
+
+	ospf6 = ospf6_lookup_by_vrf_name(vrf_name);
 	if (ospf6 == NULL)
 		vty_out(vty, "OSPFv3 is not configured\n");
 	else {
@@ -736,11 +858,15 @@ DEFUN (ospf6_interface_area,
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	struct interface *ifp;
+  vrf_id_t vrf_id = VRF_DEFAULT;
 
 	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
 
+  if (ospf6->vrf_id != VRF_UNKNOWN)
+    vrf_id = ospf6->vrf_id;
+
 	/* find/create ospf6 interface */
-	ifp = if_get_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+	ifp = if_get_by_name(argv[idx_ifname]->arg, vrf_id);
 	oi = (struct ospf6_interface *)ifp->info;
 	if (oi == NULL)
 		oi = ospf6_interface_create(ifp);
@@ -784,14 +910,19 @@ DEFUN (no_ospf6_interface_area,
        "OSPF6 area ID in decimal notation\n"
        )
 {
+	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
 	int idx_ifname = 2;
 	int idx_ipv4 = 4;
 	struct ospf6_interface *oi;
 	struct ospf6_area *oa;
 	struct interface *ifp;
 	uint32_t area_id;
+  vrf_id_t vrf_id = VRF_DEFAULT;
 
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+  if (ospf6->vrf_id != VRF_UNKNOWN)
+    vrf_id = ospf6->vrf_id;
+
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id);
 	if (ifp == NULL) {
 		vty_out(vty, "No such interface %s\n", argv[idx_ifname]->arg);
 		return CMD_SUCCESS;
@@ -1119,35 +1250,53 @@ static void ospf6_show(struct vty *vty, struct ospf6 *o, json_object *json,
 /* show top level structures */
 DEFUN(show_ipv6_ospf6,
       show_ipv6_ospf6_cmd,
-      "show ipv6 ospf6 [json]",
+      "show ipv6 ospf6 [vrf <NAME|all>] [json]",
       SHOW_STR
       IP6_STR
       OSPF6_STR
+      VRF_CMD_HELP_STR
+      "All VRFs\n"
       JSON_STR)
 {
 	struct ospf6 *ospf6;
 	bool uj = use_json(argc, argv);
 	json_object *json = NULL;
+  struct listnode *node;
+  char *vrf_name = NULL;
+  bool all_vrf = false;
+  int idx_vrf = 0;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+  OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+  for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+    if (all_vrf ||
+      ((ospf6->name == NULL && vrf_name == NULL)
+      || (ospf6->name && vrf_name && strcmp(ospf6->name, vrf_name) == 0))) {
 
-	if (uj)
-		json = json_object_new_object();
+	    if (uj)
+		    json = json_object_new_object();
 
-	ospf6_show(vty, ospf6, json, uj);
+	    ospf6_show(vty, ospf6, json, uj);
 
-	if (uj)
-		json_object_free(json);
+	    if (uj)
+		    json_object_free(json);
+
+      if (!all_vrf)
+        break;
+    }
+  }
+
 	return CMD_SUCCESS;
 }
 
 DEFUN (show_ipv6_ospf6_route,
        show_ipv6_ospf6_route_cmd,
-       "show ipv6 ospf6 route [<intra-area|inter-area|external-1|external-2|X:X::X:X|X:X::X:X/M|detail|summary>] [json]",
+       "show ipv6 ospf6 [vrf <NAME|all>] route [<intra-area|inter-area|external-1|external-2|X:X::X:X|X:X::X:X/M|detail|summary>] [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
+       VRF_CMD_HELP_STR
+       "All VRFs\n"
        ROUTE_STR
        "Display Intra-Area routes\n"
        "Display Inter-Area routes\n"
@@ -1161,20 +1310,40 @@ DEFUN (show_ipv6_ospf6_route,
 {
 	struct ospf6 *ospf6;
 	bool uj = use_json(argc, argv);
+  struct listnode *node;
+  char *vrf_name = NULL;
+  bool all_vrf = false;
+  int idx_vrf = 0;
+  int idx_start_arg = 4;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+  OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+  if (idx_vrf > 0)
+    idx_start_arg += 2;
 
-	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table, uj);
+  for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+    if (all_vrf ||
+      ((ospf6->name == NULL && vrf_name == NULL)
+      || (ospf6->name && vrf_name && strcmp(ospf6->name, vrf_name) == 0))) {
+	    ospf6_route_table_show(vty, idx_start_arg, argc, argv,
+        ospf6->route_table, uj);
+
+      if (!all_vrf)
+        break;
+    }
+  }
+
 	return CMD_SUCCESS;
 }
 
 DEFUN (show_ipv6_ospf6_route_match,
        show_ipv6_ospf6_route_match_cmd,
-       "show ipv6 ospf6 route X:X::X:X/M <match|longer> [json]",
+       "show ipv6 ospf6 [vrf <NAME|all>] route X:X::X:X/M <match|longer> [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
+       VRF_CMD_HELP_STR
+       "All VRFs\n"
        ROUTE_STR
        "Specify IPv6 prefix\n"
        "Display routes which match the specified route\n"
@@ -1183,11 +1352,29 @@ DEFUN (show_ipv6_ospf6_route_match,
 {
 	struct ospf6 *ospf6;
 	bool uj = use_json(argc, argv);
+  struct listnode *node;
+  char *vrf_name = NULL;
+  bool all_vrf = false;
+  int idx_vrf = 0;
+  int idx_start_arg = 4;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+  OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+  if (idx_vrf > 0)
+    idx_start_arg += 2;
 
-	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table, uj);
+  for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+    if (all_vrf ||
+      ((ospf6->name == NULL && vrf_name == NULL)
+      || (ospf6->name && vrf_name && strcmp(ospf6->name, vrf_name) == 0))) {
+	    ospf6_route_table_show(vty, idx_start_arg, argc, argv,
+        ospf6->route_table, uj);
+
+    if (!all_vrf)
+      break;
+    }
+  }
+
 	return CMD_SUCCESS;
 }
 
@@ -1205,21 +1392,41 @@ DEFUN (show_ipv6_ospf6_route_match_detail,
 {
 	struct ospf6 *ospf6;
 	bool uj = use_json(argc, argv);
+  struct listnode *node;
+  char *vrf_name = NULL;
+  bool all_vrf = false;
+  int idx_vrf = 0;
+  int idx_start_arg = 4;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+  OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+  if (idx_vrf > 0)
+    idx_start_arg += 2;
 
-	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table, uj);
+  for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+    if (all_vrf ||
+      ((ospf6->name == NULL && vrf_name == NULL)
+      || (ospf6->name && vrf_name && strcmp(ospf6->name, vrf_name) == 0))) {
+	    ospf6_route_table_show(vty, idx_start_arg, argc, argv,
+        ospf6->route_table, uj);
+
+      if (!all_vrf)
+        break;
+    }
+  }
+
 	return CMD_SUCCESS;
 }
 
 
 DEFUN (show_ipv6_ospf6_route_type_detail,
        show_ipv6_ospf6_route_type_detail_cmd,
-       "show ipv6 ospf6 route <intra-area|inter-area|external-1|external-2> detail [json]",
+       "show ipv6 ospf6 [vrf <NAME|all>] route <intra-area|inter-area|external-1|external-2> detail [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
+       VRF_CMD_HELP_STR
+       "All VRFs\n"
        ROUTE_STR
        "Display Intra-Area routes\n"
        "Display Inter-Area routes\n"
@@ -1230,11 +1437,29 @@ DEFUN (show_ipv6_ospf6_route_type_detail,
 {
 	struct ospf6 *ospf6;
 	bool uj = use_json(argc, argv);
+  struct listnode *node;
+  char *vrf_name = NULL;
+  bool all_vrf = false;
+  int idx_vrf = 0;
+  int idx_start_arg = 4;
 
-	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING(ospf6);
+	OSPF6_CMD_CHECK_RUNNING();
+  OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
+  if (idx_vrf > 0)
+    idx_start_arg += 2;
 
-	ospf6_route_table_show(vty, 4, argc, argv, ospf6->route_table, uj);
+  for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
+    if (all_vrf ||
+      ((ospf6->name == NULL && vrf_name == NULL)
+      || (ospf6->name && vrf_name && strcmp(ospf6->name, vrf_name) == 0))) {
+	    ospf6_route_table_show(vty, idx_start_arg, argc, argv,
+        ospf6->route_table, uj);
+
+      if (!all_vrf)
+        break;
+    }
+  }
+
 	return CMD_SUCCESS;
 }
 
@@ -1291,7 +1516,10 @@ static int config_write_ospf6(struct vty *vty)
 		return CMD_SUCCESS;
 
 	for (ALL_LIST_ELEMENTS(om6->ospf6, node, nnode, ospf6)) {
-		vty_out(vty, "router ospf6\n");
+    if (ospf6->name && strcmp(ospf6->name, VRF_DEFAULT_NAME))
+      vty_out(vty, "router ospf6 vrf %s\n", ospf6->name);
+    else
+		  vty_out(vty, "router ospf6\n");
 		if (ospf6->router_id_static != 0)
 			vty_out(vty, " ospf6 router-id %pI4\n",
 				&ospf6->router_id_static);

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -156,5 +156,7 @@ void ospf6_vrf_unlink(struct ospf6 *ospf6, struct vrf *vrf);
 struct ospf6 *ospf6_lookup_by_vrf_id(vrf_id_t vrf_id);
 struct ospf6 *ospf6_lookup_by_vrf_name(const char *name);
 const char *ospf6_vrf_id_to_name(vrf_id_t vrf_id);
+void ospf6_vrf_init(void);
+void ospf6_set_redist_vrf_bitmaps(struct ospf6 *ospf6);
 
 #endif /* OSPF6_TOP_H */

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -49,6 +49,23 @@ unsigned char conf_debug_ospf6_zebra = 0;
 /* information about zebra. */
 struct zclient *zclient = NULL;
 
+void ospf6_set_redist_vrf_bitmaps(struct ospf6 *ospf6)
+{
+  int type;
+  struct list *red_list;
+
+  for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
+    red_list = ospf6->redist[type];
+    if (!red_list)
+      continue;
+    if (IS_OSPF6_DEBUG_ZEBRA(RECV))
+      zlog_debug(
+        "%s: setting redist vrf %d bitmap for type %d",
+        __func__, ospf6->vrf_id, type);
+    ospf6_zebra_redistribute(type, ospf6->vrf_id);
+  }
+}
+
 void ospf6_zebra_vrf_register(struct ospf6 *ospf6)
 {
 	if (!zclient || zclient->sock < 0 || !ospf6)

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -71,4 +71,5 @@ extern int config_write_ospf6_debug_zebra(struct vty *vty);
 extern void install_element_ospf6_debug_zebra(void);
 extern void ospf6_zebra_vrf_register(struct ospf6 *ospf6);
 extern void ospf6_zebra_vrf_deregister(struct ospf6 *ospf6);
+extern void ospf_set_redist_vrf_bitmaps(struct ospf6 *ospf6);
 #endif /*OSPF6_ZEBRA_H*/

--- a/ospf6d/ospf6d.h
+++ b/ospf6d/ospf6d.h
@@ -88,11 +88,17 @@ extern struct thread_master *master;
 #define OSPF6_ROUTER_ID_STR "Specify Router-ID\n"
 #define OSPF6_LS_ID_STR     "Specify Link State ID\n"
 
-#define OSPF6_CMD_CHECK_RUNNING(ospf6)                                         \
-	if (ospf6 == NULL) {                                                   \
+#define OSPF6_CMD_CHECK_RUNNING()                                         \
+	if (om6->ospf6 == NULL) {                                                   \
 		vty_out(vty, "OSPFv3 is not running\n");                       \
 		return CMD_SUCCESS;                                            \
 	}
+
+#define OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf)            \
+  if (argv_find(argv, argc, "vrf", &idx_vrf)) {                          \
+    vrf_name = argv[idx_vrf + 1]->arg;                             \
+    all_vrf = strmatch(vrf_name, "all");                           \
+  }
 
 extern struct zebra_privs_t ospf6d_privs;
 

--- a/tests/topotests/ospf6-topo1-vrf/README.md
+++ b/tests/topotests/ospf6-topo1-vrf/README.md
@@ -1,0 +1,132 @@
+# OSPFv3 (IPv6) Topology Test
+
+## Topology
+	                                                  -----\
+	  SW1 - Stub Net 1            SW2 - Stub Net 2          \
+	  fc00:1:1:1::/64             fc00:2:2:2::/64            \
+	\___________________/      \___________________/          |
+	          |                          |                    |
+	          |                          |                    |
+	          | ::1                      | ::2                |
+	+---------+---------+      +---------+---------+          |
+	|        R1         |      |        R2         |          |
+	|     FRRouting     |      |     FRRouting     |          |
+	| Rtr-ID: 10.0.0.1  |      | Rtr-ID: 10.0.0.2  |          |
+	+---------+---------+      +---------+---------+          |
+	          | ::1                      | ::2                 \
+	           \______        ___________/                      OSPFv3
+	                  \      /                               Area 0.0.0.0
+	                   \    /                                  /
+	             ~~~~~~~~~~~~~~~~~~                           |
+	           ~~       SW5        ~~                         |
+	         ~~       Switch         ~~                       |
+	           ~~  fc00:A:A:A::/64 ~~                         |
+	             ~~~~~~~~~~~~~~~~~~                           |
+	                     |                 /----              |
+	                     | ::3            | SW3 - Stub Net 3  | 
+	           +---------+---------+    /-+ fc00:3:3:3::/64   |
+	           |        R3         |   /  |                  /
+	           |     FRRouting     +--/    \----            /
+	           | Rtr-ID: 10.0.0.3  | ::3        ___________/
+	           +---------+---------+                       \
+	                     | ::3                              \
+	                     |                                   \
+	             ~~~~~~~~~~~~~~~~~~                           |
+	           ~~       SW6        ~~                         |
+	         ~~       Switch         ~~                       |
+	           ~~  fc00:B:B:B::/64 ~~                          \
+	             ~~~~~~~~~~~~~~~~~~                             OSPFv3
+	                     |                                   Area 0.0.0.1
+	                     | ::4                                 /
+	           +---------+---------+       /----              |
+	           |        R4         |      | SW4 - Stub Net 4  |
+	           |     FRRouting     +------+ fc00:4:4:4::/64   |
+	           | Rtr-ID: 10.0.0.4  | ::4  |                   /
+	           +-------------------+       \----             /
+	                                                   -----/
+
+## FRR Configuration
+
+Full config as used is in r1 / r2 / r3 / r4 / r5 subdirectories
+
+Simplified `R1` config (R1 is similar)
+
+	hostname r1
+	!
+	interface r1-stubnet vrf r1-cust1
+	 ipv6 address fc00:1:1:1::1/64
+	 ipv6 ospf6 network broadcast
+	!
+	interface r1-sw5 vrf r1-cust1
+	 ipv6 address fc00:a:a:a::1/64
+	 ipv6 ospf6 network broadcast
+	!
+	router ospf6 vrf r1-cust1
+	 router-id 10.0.0.1
+	 log-adjacency-changes detail
+	 redistribute static
+	 interface r1-stubnet area 0.0.0.0
+	 interface r1-sw5 area 0.0.0.0
+	!
+	ipv6 route fc00:1111:1111:1111::/64 fc00:1:1:1::1234 vrf r1-cust1
+
+Simplified `R3` config
+
+	hostname r3
+	!
+	interface r3-stubnet vrf r3-cust1
+	 ipv6 address fc00:3:3:3::3/64
+	 ipv6 ospf6 network broadcast
+	!
+	interface r3-sw5 vrf r3-cust1
+	 ipv6 address fc00:a:a:a::3/64
+	 ipv6 ospf6 network broadcast
+	!
+	interface r3-sw6 vrf r3-cust1
+	 ipv6 address fc00:b:b:b::3/64
+	 ipv6 ospf6 network broadcast
+	!
+	router ospf6 vrf r3-cust1
+	 router-id 10.0.0.3
+	 log-adjacency-changes detail
+	 redistribute static
+	 interface r3-stubnet area 0.0.0.0
+	 interface r3-sw5 area 0.0.0.0
+	 interface r3-sw6 area 0.0.0.1
+	!
+	ipv6 route fc00:3333:3333:3333::/64 fc00:3:3:3::1234 vrf r3-cust1
+
+## Tests executed
+
+### Check if FRR is running
+
+Test is executed by running 
+
+	vtysh -c "show logging" | grep "Logging configuration for"
+	
+on each FRR router. This should return the logging information for all daemons registered
+to Zebra and the list of running daemons is compared to the daemons started for this test (`zebra` and `ospf6d`)
+
+### Verify for OSPFv3 to converge
+
+OSPFv3 is expected to converge on each view within 60s total time. Convergence is verified by executing (on each node)
+
+	vtysh -c "show ipv6 ospf vrf r1-cust1 neigh"
+
+and checking for "Full" neighbor status in the output. An additional 15 seconds after the full converge is waited for routes to populate before the following routing table checks are executed
+
+### Verifying OSPFv3 Routing Tables
+
+Routing table is verified by running 
+
+	vtysh -c "show ipv6 route vrf r1-cust1"
+
+on each node and comparing the result to the stored example config (see `show_ipv6_route.ref` in r1 / r2 / r3 / r4 directories). Link-Local addresses are masked out before the compare.
+
+### Verifying Linux Kernel Routing Table
+
+Linux Kernel IPv6 Routing table is verified on each FRR node with
+
+	ip -6 route vrf r1-cust1
+
+Tables are compared with reference routing table (see `ip_6_address.ref` in r1 / r2 / r3 / r4 directories). Link-Local addresses are translated after getting collected on each node with interface name to make them consistent

--- a/tests/topotests/ospf6-topo1-vrf/r1/ip_6_address.nhg.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r1/ip_6_address.nhg.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 nhid XXXX via fc00:1:1:1::1234 dev r1-stubnet proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 dev r1-stubnet proto XXXX metric 256 pref medium
+fc00:2222:2222:2222::/64 nhid XXXX via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 nhid XXXX via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:4444:4444:4444::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r1-sw5 proto XXXX metric 256 pref medium
+fc00:b:b:b::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium

--- a/tests/topotests/ospf6-topo1-vrf/r1/ip_6_address.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r1/ip_6_address.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 via fc00:1:1:1::1234 dev r1-stubnet proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 dev r1-stubnet proto XXXX metric 256 pref medium
+fc00:2222:2222:2222::/64 via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:4444:4444:4444::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r1-sw5 proto XXXX metric 256 pref medium
+fc00:b:b:b::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium

--- a/tests/topotests/ospf6-topo1-vrf/r1/ospf6d.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r1/ospf6d.conf
@@ -1,0 +1,27 @@
+hostname r1
+log file ospf6d.log
+!
+debug ospf6 message all
+debug ospf6 lsa unknown
+debug ospf6 zebra
+debug ospf6 interface
+debug ospf6 neighbor
+debug ospf6 route table
+debug ospf6 flooding
+!
+interface r1-stubnet vrf r1-cust1
+ ipv6 ospf6 network broadcast
+!
+interface r1-sw5 vrf r1-cust1
+ ipv6 ospf6 network broadcast
+!
+router ospf6 vrf r1-cust1 
+ ospf6 router-id 10.0.0.1
+ log-adjacency-changes detail
+ redistribute static
+ interface r1-stubnet area 0.0.0.0
+ interface r1-sw5 area 0.0.0.0
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6-topo1-vrf/r1/show_ipv6_vrf_route.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r1/show_ipv6_vrf_route.ref
@@ -1,0 +1,9 @@
+O   fc00:1:1:1::/64 [110/10] is directly connected, r1-stubnet, weight 1, XX:XX:XX
+O>* fc00:2:2:2::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:3:3:3::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:4:4:4::/64 [110/30] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O   fc00:a:a:a::/64 [110/10] is directly connected, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:b:b:b::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:2222:2222:2222::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:3333:3333:3333::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:4444:4444:4444::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6-topo1-vrf/r1/zebra.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r1/zebra.conf
@@ -1,0 +1,20 @@
+!
+hostname r1
+log file zebra.log
+!
+debug zebra events
+debug zebra rib
+!
+interface r1-stubnet vrf r1-cust1
+ ipv6 address fc00:1:1:1::1/64
+!
+interface r1-sw5 vrf r1-cust1
+ ipv6 address fc00:a:a:a::1/64
+!
+interface lo
+!
+ipv6 route fc00:1111:1111:1111::/64 fc00:1:1:1::1234 vrf r1-cust1
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6-topo1-vrf/r2/ip_6_address.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r2/ip_6_address.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 via fe80::__(r1-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 via fe80::__(r1-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:2222:2222:2222::/64 via fc00:2:2:2::1234 dev r2-stubnet proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 dev r2-stubnet proto XXXX metric 256 pref medium
+fc00:3333:3333:3333::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:4444:4444:4444::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r2-sw5 proto XXXX metric 256 pref medium
+fc00:b:b:b::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium

--- a/tests/topotests/ospf6-topo1-vrf/r2/ospf6d.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r2/ospf6d.conf
@@ -1,0 +1,27 @@
+hostname r2
+log file ospf6d.log
+!
+debug ospf6 message all
+debug ospf6 lsa unknown
+debug ospf6 zebra
+debug ospf6 interface
+debug ospf6 neighbor
+debug ospf6 route table
+debug ospf6 flooding
+!
+interface r2-stubnet vrf r2-cust1
+ ipv6 ospf6 network broadcast
+!
+interface r2-sw5 vrf r2-cust1
+ ipv6 ospf6 network broadcast
+!
+router ospf6 vrf r2-cust1
+ ospf6 router-id 10.0.0.2
+ log-adjacency-changes detail
+ redistribute static
+ interface r2-stubnet area 0.0.0.0
+ interface r2-sw5 area 0.0.0.0
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6-topo1-vrf/r2/show_ipv6_vrf_route.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r2/show_ipv6_vrf_route.ref
@@ -1,0 +1,9 @@
+O>* fc00:1:1:1::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O   fc00:2:2:2::/64 [110/10] is directly connected, r2-stubnet, weight 1, XX:XX:XX
+O>* fc00:3:3:3::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:4:4:4::/64 [110/30] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O   fc00:a:a:a::/64 [110/10] is directly connected, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:b:b:b::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:1111:1111:1111::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:3333:3333:3333::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:4444:4444:4444::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6-topo1-vrf/r2/zebra.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r2/zebra.conf
@@ -1,0 +1,20 @@
+!
+hostname r2
+log file zebra.log
+!
+debug zebra events
+debug zebra rib
+!
+interface r2-stubnet vrf r2-cust1
+ ipv6 address fc00:2:2:2::2/64
+!
+interface r2-sw5 vrf r2-cust1
+ ipv6 address fc00:a:a:a::2/64
+!
+interface lo
+!
+ipv6 route fc00:2222:2222:2222::/64 fc00:2:2:2::1234 vrf r2-cust1
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6-topo1-vrf/r3/ip_6_address.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r3/ip_6_address.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 via fe80::__(r1-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 via fe80::__(r1-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:2222:2222:2222::/64 via fe80::__(r2-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 via fe80::__(r2-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 via fc00:3:3:3::1234 dev r3-stubnet proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 dev r3-stubnet proto XXXX metric 256 pref medium
+fc00:4444:4444:4444::/64 via fe80::__(r4-sw6)__ dev r3-sw6 proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 via fe80::__(r4-sw6)__ dev r3-sw6 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r3-sw5 proto XXXX metric 256 pref medium
+fc00:b:b:b::/64 dev r3-sw6 proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6-topo1-vrf/r3/ospf6d.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r3/ospf6d.conf
@@ -1,0 +1,31 @@
+hostname r3
+log file ospf6d.log
+!
+debug ospf6 message all
+debug ospf6 lsa unknown
+debug ospf6 zebra
+debug ospf6 interface
+debug ospf6 neighbor
+debug ospf6 route table
+debug ospf6 flooding
+!
+interface r3-stubnet vrf r3-cust1 
+ ipv6 ospf6 network broadcast
+!
+interface r3-sw5 vrf r3-cust1
+ ipv6 ospf6 network broadcast
+!
+interface r3-sw6 vrf r3-cust1
+ ipv6 ospf6 network broadcast
+!
+router ospf6 vrf r3-cust1
+ ospf6 router-id 10.0.0.3
+ log-adjacency-changes detail
+ redistribute static
+ interface r3-stubnet area 0.0.0.0
+ interface r3-sw5 area 0.0.0.0
+ interface r3-sw6 area 0.0.0.1
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6-topo1-vrf/r3/show_ipv6_vrf_route.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r3/show_ipv6_vrf_route.ref
@@ -1,0 +1,9 @@
+O>* fc00:1:1:1::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O>* fc00:2:2:2::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O   fc00:3:3:3::/64 [110/10] is directly connected, r3-stubnet, weight 1, XX:XX:XX
+O>* fc00:4:4:4::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw6, weight 1, XX:XX:XX
+O   fc00:a:a:a::/64 [110/10] is directly connected, r3-sw5, weight 1, XX:XX:XX
+O   fc00:b:b:b::/64 [110/10] is directly connected, r3-sw6, weight 1, XX:XX:XX
+O>* fc00:1111:1111:1111::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O>* fc00:2222:2222:2222::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O>* fc00:4444:4444:4444::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw6, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6-topo1-vrf/r3/zebra.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r3/zebra.conf
@@ -1,0 +1,23 @@
+!
+hostname r3
+log file zebra.log
+!
+debug zebra events
+debug zebra rib
+!
+interface r3-stubnet vrf r3-cust1 
+ ipv6 address fc00:3:3:3::3/64
+!
+interface r3-sw5 vrf r3-cust1
+ ipv6 address fc00:a:a:a::3/64
+!
+interface r3-sw6 vrf r3-cust1
+ ipv6 address fc00:b:b:b::3/64
+!
+interface lo
+!
+ipv6 route fc00:3333:3333:3333::/64 fc00:3:3:3::1234 vrf r3-cust1
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6-topo1-vrf/r4/ip_6_address.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r4/ip_6_address.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:2222:2222:2222::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:4444:4444:4444::/64 via fc00:4:4:4::1234 dev r4-stubnet proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 dev r4-stubnet proto XXXX metric 256 pref medium
+fc00:a:a:a::/64 via fe80::__(r3-sw6)__ dev r4-sw6 proto XXXX metric 20 pref medium
+fc00:b:b:b::/64 dev r4-sw6 proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6-topo1-vrf/r4/ospf6d.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r4/ospf6d.conf
@@ -1,0 +1,27 @@
+hostname r4
+log file ospf6d.log
+!
+debug ospf6 message all
+debug ospf6 lsa unknown
+debug ospf6 zebra
+debug ospf6 interface
+debug ospf6 neighbor
+debug ospf6 route table
+debug ospf6 flooding
+!
+interface r4-stubnet vrf r4-cust1 
+ ipv6 ospf6 network broadcast
+!
+interface r4-sw6 vrf r4-cust1
+ ipv6 ospf6 network broadcast
+!
+router ospf6 vrf r4-cust1
+ ospf6 router-id 10.0.0.4
+ log-adjacency-changes detail
+ redistribute static
+ interface r4-stubnet area 0.0.0.1
+ interface r4-sw6 area 0.0.0.1
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6-topo1-vrf/r4/show_ipv6_vrf_route.ref
+++ b/tests/topotests/ospf6-topo1-vrf/r4/show_ipv6_vrf_route.ref
@@ -1,0 +1,9 @@
+O>* fc00:1:1:1::/64 [110/30] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O>* fc00:2:2:2::/64 [110/30] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O>* fc00:3:3:3::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O   fc00:4:4:4::/64 [110/10] is directly connected, r4-stubnet, weight 1, XX:XX:XX
+O>* fc00:a:a:a::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O   fc00:b:b:b::/64 [110/10] is directly connected, r4-sw6, weight 1, XX:XX:XX
+O>* fc00:1111:1111:1111::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O>* fc00:2222:2222:2222::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX
+O>* fc00:3333:3333:3333::/64 [110/10] via fe80::XXXX:XXXX:XXXX:XXXX, r4-sw6, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6-topo1-vrf/r4/zebra.conf
+++ b/tests/topotests/ospf6-topo1-vrf/r4/zebra.conf
@@ -1,0 +1,20 @@
+!
+hostname r4
+log file zebra.log
+!
+debug zebra events
+debug zebra rib
+!
+interface r4-stubnet vrf r4-cust1 
+ ipv6 address fc00:4:4:4::4/64
+!
+interface r4-sw6 vrf r4-cust1
+ ipv6 address fc00:b:b:b::4/64
+!
+interface lo
+!
+ipv6 route fc00:4444:4444:4444::/64 fc00:4:4:4::1234 vrf r4-cust1
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6-topo1-vrf/test_ospf6_topo1_vrf.py
+++ b/tests/topotests/ospf6-topo1-vrf/test_ospf6_topo1_vrf.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python
+
+#
+# test_ospf6_topo1.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2016 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+test_ospf6_topo1.py:
+
+                                                  -----\
+  SW1 - Stub Net 1            SW2 - Stub Net 2          \
+  fc00:1:1:1::/64             fc00:2:2:2::/64            \
+\___________________/      \___________________/          |
+          |                          |                    |
+          |                          |                    |
+          | ::1                      | ::2                |
++---------+---------+      +---------+---------+          |
+|        R1         |      |        R2         |          |
+|     FRRouting     |      |     FRRouting     |          |
+| Rtr-ID: 10.0.0.1  |      | Rtr-ID: 10.0.0.2  |          |
++---------+---------+      +---------+---------+          |
+          | ::1                      | ::2                 \
+           \______        ___________/                      OSPFv3
+                  \      /                               Area 0.0.0.0
+                   \    /                                  /
+             ~~~~~~~~~~~~~~~~~~                           |
+           ~~       SW5        ~~                         |
+         ~~       Switch         ~~                       |
+           ~~  fc00:A:A:A::/64 ~~                         |
+             ~~~~~~~~~~~~~~~~~~                           |
+                     |                 /----              |
+                     | ::3            | SW3 - Stub Net 3  | 
+           +---------+---------+    /-+ fc00:3:3:3::/64   |
+           |        R3         |   /  |                  /
+           |     FRRouting     +--/    \----            /
+           | Rtr-ID: 10.0.0.3  | ::3        ___________/
+           +---------+---------+                       \
+                     | ::3                              \
+                     |                                   \
+             ~~~~~~~~~~~~~~~~~~                           |
+           ~~       SW6        ~~                         |
+         ~~       Switch         ~~                       |
+           ~~  fc00:B:B:B::/64 ~~                          \
+             ~~~~~~~~~~~~~~~~~~                             OSPFv3
+                     |                                   Area 0.0.0.1
+                     | ::4                                 /
+           +---------+---------+       /----              |
+           |        R4         |      | SW4 - Stub Net 4  |
+           |     FRRouting     +------+ fc00:4:4:4::/64   |
+           | Rtr-ID: 10.0.0.4  | ::4  |                   /
+           +-------------------+       \----             /
+                                                   -----/
+"""
+
+import os
+import re
+import sys
+import pytest
+import platform
+from time import sleep
+
+from functools import partial
+
+from mininet.topo import Topo
+
+# Save the Current Working Directory to find configuration files later.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+import platform
+
+#####################################################
+##
+##   Network Topology Definition
+##
+#####################################################
+
+
+class NetworkTopo(Topo):
+    "OSPFv3 (IPv6) Test Topology 1"
+
+    def build(self, **_opts):
+        "Build function"
+
+        tgen = get_topogen(self)
+
+        # Create 4 routers
+        for routern in range(1, 5):
+            tgen.add_router("r{}".format(routern))
+
+        #
+        # Wire up the switches and routers
+        # Note that we specify the link names so we match the config files
+        #
+
+        # Create a empty network for router 1
+        switch = tgen.add_switch("s1")
+        switch.add_link(tgen.gears["r1"], nodeif="r1-stubnet")
+
+        # Create a empty network for router 2
+        switch = tgen.add_switch("s2")
+        switch.add_link(tgen.gears["r2"], nodeif="r2-stubnet")
+
+        # Create a empty network for router 3
+        switch = tgen.add_switch("s3")
+        switch.add_link(tgen.gears["r3"], nodeif="r3-stubnet")
+
+        # Create a empty network for router 4
+        switch = tgen.add_switch("s4")
+        switch.add_link(tgen.gears["r4"], nodeif="r4-stubnet")
+
+        # Interconnect routers 1, 2, and 3
+        switch = tgen.add_switch("s5")
+        switch.add_link(tgen.gears["r1"], nodeif="r1-sw5")
+        switch.add_link(tgen.gears["r2"], nodeif="r2-sw5")
+        switch.add_link(tgen.gears["r3"], nodeif="r3-sw5")
+
+        # Interconnect routers 3 and 4
+        switch = tgen.add_switch("s6")
+        switch.add_link(tgen.gears["r3"], nodeif="r3-sw6")
+        switch.add_link(tgen.gears["r4"], nodeif="r4-sw6")
+
+
+#####################################################
+##
+##   Tests starting
+##
+#####################################################
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+
+    tgen = Topogen(NetworkTopo, mod.__name__)
+    tgen.start_topology()
+
+    logger.info("** %s: Setup Topology" % mod.__name__)
+    logger.info("******************************************")
+
+    # For debugging after starting net, but before starting FRR,
+    # uncomment the next line
+    # tgen.mininet_cli()
+
+    router_list = tgen.routers()
+    logger.info("Testing with VRF Lite support")
+    krel = platform.release()
+
+    # May need to adjust handling of vrf traffic depending on kernel version
+    l3mdev_accept = 0
+    if (
+        topotest.version_cmp(krel, "4.15") >= 0
+        and topotest.version_cmp(krel, "4.18") <= 0
+    ):
+        l3mdev_accept = 1
+
+    if topotest.version_cmp(krel, "5.0") >= 0:
+        l3mdev_accept = 1
+
+    logger.info(
+        "krel '{0}' setting net.ipv6.tcp_l3mdev_accept={1}".format(krel, l3mdev_accept)
+    )
+
+    cmds = [
+        "ip link add {0}-cust1 type vrf table 1001",
+        "ip link add loop1 type dummy",
+        "ip link set {0}-stubnet master {0}-cust1",
+    ]
+
+    cmds1 = [
+        "ip link set {0}-sw5 master {0}-cust1",
+    ]
+
+    cmds2 = [
+        "ip link set {0}-sw6 master {0}-cust1",
+    ]
+
+    # For all registered routers, load the zebra configuration file
+    for rname, router in router_list.iteritems():
+        # create VRF rx-cust1 and link rx-eth0 to rx-cust1
+        for cmd in cmds:
+            output = tgen.net[rname].cmd(cmd.format(rname))
+        if rname == "r1" or rname == "r2" or rname == "r3":
+            for cmd in cmds1:
+                output = tgen.net[rname].cmd(cmd.format(rname))
+        if rname == "r3" or rname == "r4":
+            for cmd in cmds2:
+                output = tgen.net[rname].cmd(cmd.format(rname))
+
+        output = tgen.net[rname].cmd("sysctl -n net.ipv4.tcp_l3mdev_accept")
+        logger.info(
+            "router {0}: existing tcp_l3mdev_accept was {1}".format(rname, output)
+        )
+
+        if l3mdev_accept:
+            output = tgen.net[rname].cmd(
+                "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept)
+            )
+
+   
+    for rname, router in router_list.iteritems():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_OSPF6, os.path.join(CWD, "{}/ospf6d.conf".format(rname))
+        )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+    # For debugging after starting FRR daemons, uncomment the next line
+    # tgen.mininet_cli()
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_ospf6_converged():
+
+    tgen = get_topogen()
+
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # For debugging, uncomment the next line
+    # tgen.mininet_cli()
+
+    # Wait for OSPF6 to converge  (All Neighbors in either Full or TwoWay State)
+    logger.info("Waiting for OSPF6 convergence")
+
+    # Set up for regex
+    pat1 = re.compile("^[0-9]")
+    pat2 = re.compile("Full")
+
+    timeout = 60
+    while timeout > 0:
+        logger.info("Timeout in %s: " % timeout),
+        sys.stdout.flush()
+
+        # Look for any node not yet converged
+        for router, rnode in tgen.routers().iteritems():
+            resStr = rnode.vtysh_cmd("show ipv6 ospf vrf {0}-cust1 neigh".format(router))
+
+            isConverged = False
+
+            for line in resStr.splitlines():
+                res1 = pat1.match(line)
+                if res1:
+                    isConverged = True
+                    res2 = pat2.search(line)
+
+                    if res2 == None:
+                        isConverged = False
+                        break
+
+            if isConverged == False:
+                logger.info("Waiting for {}".format(router))
+                sys.stdout.flush()
+                break
+
+        if isConverged:
+            logger.info("Done")
+            break
+        else:
+            sleep(5)
+            timeout -= 5
+
+    if timeout == 0:
+        # Bail out with error if a router fails to converge
+        ospfStatus = rnode.vtysh_cmd("show ipv6 ospf neigh")
+        assert False, "OSPFv6 did not converge:\n{}".format(ospfStatus)
+
+    logger.info("OSPFv3 converged.")
+
+    # For debugging, uncomment the next line
+    # tgen.mininet_cli()
+
+    # Make sure that all daemons are still running
+    if tgen.routers_have_failure():
+        assert tgen.errors == "", tgen.errors
+
+
+def compare_show_ipv6_vrf(rname, expected):
+    """
+    Calls 'show ipv6 route' for router `rname` and compare the obtained
+    result with the expected output.
+    """
+    tgen = get_topogen()
+
+    # Use the vtysh output, with some masking to make comparison easy
+    vrf_name = "{0}-cust1".format(rname)
+    current = topotest.ip6_route_zebra(tgen.gears[rname], vrf_name)
+    
+    # Use just the 'O'spf lines of the output
+    linearr = []
+    for line in current.splitlines():
+        if re.match("^O", line):
+            linearr.append(line)
+
+    current = "\n".join(linearr)
+
+    return topotest.difflines(
+        topotest.normalize_text(current),
+        topotest.normalize_text(expected),
+        title1="Current output",
+        title2="Expected output",
+    )
+
+
+def test_ospfv3_routingTable():
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # For debugging, uncomment the next line
+    # tgen.mininet_cli()
+    # Verify OSPFv3 Routing Table
+    for router, rnode in tgen.routers().iteritems():
+        logger.info('Waiting for router "%s" convergence', router)
+
+        # Load expected results from the command
+        reffile = os.path.join(CWD, "{}/show_ipv6_vrf_route.ref".format(router))
+        expected = open(reffile).read()
+
+        # Run test function until we get an result. Wait at most 60 seconds.
+        test_func = partial(compare_show_ipv6_vrf, router, expected)
+        result, diff = topotest.run_and_expect(test_func, "", count=120, wait=0.5)
+        assert result, "OSPFv3 did not converge on {}:\n{}".format(router, diff)
+
+
+def test_linux_ipv6_kernel_routingTable():
+
+    dist = platform.dist()
+
+    if dist[1] == "16.04":
+        pytest.skip("Kernel not supported for vrf")
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # Verify Linux Kernel Routing Table
+    logger.info("Verifying Linux IPv6 Kernel Routing Table")
+
+    failures = 0
+
+    # Get a list of all current link-local addresses first as they change for
+    # each run and we need to translate them
+    linklocals = []
+    for i in range(1, 5):
+        linklocals += tgen.net["r{}".format(i)].get_ipv6_linklocal()
+
+    # Now compare the routing tables (after substituting link-local addresses)
+
+    for i in range(1, 5):
+        # Actual output from router
+        actual = tgen.gears["r{}".format(i)].run("ip -6 route show vrf r{}-cust1".format(i)).rstrip()
+        if "nhid" in actual:
+            refTableFile = os.path.join(CWD, "r{}/ip_6_address.nhg.ref".format(i))
+        else:
+            refTableFile = os.path.join(CWD, "r{}/ip_6_address.ref".format(i))
+
+        if os.path.isfile(refTableFile):
+            expected = open(refTableFile).read().rstrip()
+            # Fix newlines (make them all the same)
+            expected = ("\n".join(expected.splitlines())).splitlines(1)
+
+            # Mask out Link-Local mac addresses
+            for ll in linklocals:
+                actual = actual.replace(ll[1], "fe80::__(%s)__" % ll[0])
+            # Mask out protocol name or number
+            actual = re.sub(r"[ ]+proto [0-9a-z]+ +", "  proto XXXX ", actual)
+            actual = re.sub(r"[ ]+nhid [0-9]+ +", " nhid XXXX ", actual)
+            # Remove ff00::/8 routes (seen on some kernels - not from FRR)
+            actual = re.sub(r"ff00::/8.*", "", actual)
+
+            # Strip empty lines
+            actual = actual.lstrip()
+            actual = actual.rstrip()
+            actual = re.sub(r"  +", " ", actual)
+
+            filtered_lines = []
+            for line in sorted(actual.splitlines()):
+                if line.startswith("fe80::/64 ") or line.startswith(
+                    "unreachable fe80::/64 "
+                ):
+                    continue
+                if 'anycast' in line:
+                    continue
+                filtered_lines.append(line)
+            actual = "\n".join(filtered_lines).splitlines(1)
+
+            # Print Actual table
+            # logger.info("Router r%s table" % i)
+            # for line in actual:
+            #     logger.info(line.rstrip())
+
+            # Generate Diff
+            diff = topotest.get_textdiff(
+                actual,
+                expected,
+                title1="actual OSPFv3 IPv6 routing table",
+                title2="expected OSPFv3 IPv6 routing table",
+            )
+
+            # Empty string if it matches, otherwise diff contains unified diff
+            if diff:
+                sys.stderr.write(
+                    "r%s failed Linux IPv6 Kernel Routing Table Check:\n%s\n"
+                    % (i, diff)
+                )
+                failures += 1
+            else:
+                logger.info("r%s ok" % i)
+
+            assert failures == 0, (
+                "Linux Kernel IPv6 Routing Table verification failed for router r%s:\n%s"
+                % (i, diff)
+            )
+
+
+def test_shutdown_check_stderr():
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    if os.environ.get("TOPOTESTS_CHECK_STDERR") is None:
+        logger.info(
+            "SKIPPED final check on StdErr output: Disabled (TOPOTESTS_CHECK_STDERR undefined)\n"
+        )
+        pytest.skip("Skipping test for Stderr output")
+
+    net = tgen.net
+
+    logger.info("\n\n** Verifying unexpected STDERR output from daemons")
+    logger.info("******************************************")
+
+    for i in range(1, 5):
+        net["r%s" % i].stopRouter()
+        log = net["r%s" % i].getStdErr("ospf6d")
+        if log:
+            logger.info("\nRouter r%s OSPF6d StdErr Log:\n%s" % (i, log))
+        log = net["r%s" % i].getStdErr("zebra")
+        if log:
+            logger.info("\nRouter r%s Zebra StdErr Log:\n%s" % (i, log))
+
+
+def test_shutdown_check_memleak():
+    "Run the memory leak test and report results."
+
+    if os.environ.get("TOPOTESTS_CHECK_MEMLEAK") is None:
+        logger.info(
+            "SKIPPED final check on Memory leaks: Disabled (TOPOTESTS_CHECK_MEMLEAK undefined)"
+        )
+        pytest.skip("Skipping test for memory leaks")
+
+    tgen = get_topogen()
+
+    net = tgen.net
+
+    for i in range(1, 5):
+        net["r%s" % i].stopRouter()
+        net["r%s" % i].report_memory_leaks(
+            os.environ.get("TOPOTESTS_CHECK_MEMLEAK"), os.path.basename(__file__)
+        )
+
+
+if __name__ == "__main__":
+
+    # To suppress tracebacks, either use the following pytest call or
+    # add "--tb=no" to cli
+    # retval = pytest.main(["-s", "--tb=no"])
+
+    retval = pytest.main(["-s"])
+    sys.exit(retval)

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1976,8 +1976,8 @@ DEFUNSH(VTYSH_BABELD, router_babel, router_babel_cmd, "router babel",
 #endif /* HAVE_BABELD */
 
 #ifdef HAVE_OSPF6D
-DEFUNSH(VTYSH_OSPF6D, router_ospf6, router_ospf6_cmd, "router ospf6",
-	ROUTER_STR OSPF6_STR)
+DEFUNSH(VTYSH_OSPF6D, router_ospf6, router_ospf6_cmd, "router ospf6 [vrf NAME]",
+	ROUTER_STR OSPF6_STR VRF_CMD_HELP_STR)
 {
 	vty->node = OSPF6_NODE;
 	return CMD_SUCCESS;


### PR DESCRIPTION
1. ospfv3 support with different vrf.
2. topotest added for ospfv3 vrf.

Co-authored-by: Kaushik Nath <kaushiknath.null@gmail.com>
Signed-off-by: harios_niral <hari@niralnetworks.com>