### PR TITLE
tools: frr-reload refine error handling 

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -2024,6 +2024,7 @@ if __name__ == "__main__":
                                     '"%s" we failed to remove this command',
                                     " -- ".join(original_cmd),
                                 )
+                                reload_ok = False
                                 break
 
                             new_last_arg = last_arg[0:-1]

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -97,7 +97,7 @@ class Vtysh(object):
             args = ["-c", command]
         return self._call(args, stdin, stdout, stderr)
 
-    def __call__(self, command):
+    def __call__(self, command, stdouts=None):
         """
         Call a CLI command (e.g. "show running-config")
 
@@ -107,6 +107,8 @@ class Vtysh(object):
         proc = self._call_cmd(command, stdout=subprocess.PIPE)
         stdout, stderr = proc.communicate()
         if proc.wait() != 0:
+            if stdouts is not None:
+                stdouts.append(stdout.decode('UTF-8'))
             raise VtyshException(
                 'vtysh returned status %d for command "%s"' % (proc.returncode, command)
             )
@@ -2006,9 +2008,10 @@ if __name__ == "__main__":
                     # frr(config-if)# no ip ospf authentication
                     # frr(config-if)#
 
+                    stdouts = []
                     while True:
                         try:
-                            vtysh(["configure"] + cmd)
+                            vtysh(["configure"] + cmd, stdouts)
 
                         except VtyshException:
 
@@ -2024,6 +2027,9 @@ if __name__ == "__main__":
                                     '"%s" we failed to remove this command',
                                     " -- ".join(original_cmd),
                                 )
+                                # Log first error msg for original_cmd
+                                if stdouts:
+                                    log.error(stdouts[0])
                                 reload_ok = False
                                 break
 


### PR DESCRIPTION

1)
```
    tools: Mark reload failure when no form cli fails
    
    if no form of the cli fails to execute, mark frr-reload
    as failure so return code can be nonzero.
    The similar approach is done for non no-form (add case) of the cli.
```

2)
```
    tools: frr-reload capture vtysh msg upon failure
     
     Testing Done:
    
    frr reload fails to delete default bgp instance in presence of bgp vrf
    instance(s), it captures vtysh message and logs in frr-reload.log
    
    logs frr-reload
    2021-03-05 05:16:45,623  INFO: Failed to execute no router bgp 5544
    2021-03-05 05:16:45,735  INFO: Failed to execute no router bgp
    2021-03-05 05:16:45,846  INFO: Failed to execute no router
    2021-03-05 05:16:45,846 ERROR: "no router" we failed to remove this
    command
    2021-03-05 05:16:45,847 ERROR: % Cannot delete default BGP instance.
    Dependent VRF instances exist
    
    Signed-off-by: Chirag Shah <chirag@nvidia.com>
```