### PR TITLE
isisd: add vrf support for redistribution function in ISIS

### DIFF
--- a/isisd/isis_redist.h
+++ b/isisd/isis_redist.h
@@ -21,6 +21,8 @@
 #ifndef ISIS_REDIST_H
 #define ISIS_REDIST_H
 
+#include "vrf.h"
+
 #define REDIST_PROTOCOL_COUNT 2
 
 #define DEFAULT_ROUTE ZEBRA_ROUTE_MAX
@@ -39,6 +41,11 @@ struct isis_redist {
 	uint32_t metric;
 	char *map_name;
 	struct route_map *map;
+	struct isis_area *area;
+	int family;
+	int type;
+	int level;
+	char vrf_name[VRF_NAMSIZ + 1];
 };
 
 struct isis;

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -522,24 +522,24 @@ int isis_distribute_list_update(int routetype)
 	return 0;
 }
 
-void isis_zebra_redistribute_set(afi_t afi, int type)
+void isis_zebra_redistribute_set(afi_t afi, int type, vrf_id_t vrf_id)
 {
 	if (type == DEFAULT_ROUTE)
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_ADD,
-					     zclient, afi, VRF_DEFAULT);
+					     zclient, afi, vrf_id);
 	else
-		zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, zclient, afi, type,
-				     0, VRF_DEFAULT);
+		zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, zclient, afi,
+				     type, 0, vrf_id);
 }
 
-void isis_zebra_redistribute_unset(afi_t afi, int type)
+void isis_zebra_redistribute_unset(afi_t afi, int type, vrf_id_t vrf_id)
 {
 	if (type == DEFAULT_ROUTE)
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_DELETE,
-					     zclient, afi, VRF_DEFAULT);
+					     zclient, afi, vrf_id);
 	else
 		zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, zclient, afi,
-				     type, 0, VRF_DEFAULT);
+				     type, 0, vrf_id);
 }
 
 /**

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -57,8 +57,8 @@ void isis_zebra_prefix_sid_uninstall(struct isis_area *area,
 				     struct isis_sr_psid_info *psid);
 void isis_zebra_send_adjacency_sid(int cmd, const struct sr_adjacency *sra);
 int isis_distribute_list_update(int routetype);
-void isis_zebra_redistribute_set(afi_t afi, int type);
-void isis_zebra_redistribute_unset(afi_t afi, int type);
+void isis_zebra_redistribute_set(afi_t afi, int type, vrf_id_t vrf_id);
+void isis_zebra_redistribute_unset(afi_t afi, int type, vrf_id_t vrf_id);
 int isis_zebra_rlfa_register(struct isis_spftree *spftree, struct rlfa *rlfa);
 void isis_zebra_rlfa_unregister_all(struct isis_spftree *spftree);
 bool isis_zebra_label_manager_ready(void);

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -91,6 +91,9 @@ DEFINE_MTYPE(ISISD, ISIS_ACL_NAME,    "ISIS access-list name");
 
 DEFINE_QOBJ_TYPE(isis_area);
 
+DEFINE_HOOK(isis_vrf_enable_hook, (struct vrf *vrf), (vrf));
+DEFINE_HOOK(isis_vrf_disable_hook, (struct vrf *vrf), (vrf));
+
 /* ISIS process wide configuration. */
 static struct isis_master isis_master;
 
@@ -583,6 +586,9 @@ static int isis_vrf_enable(struct vrf *vrf)
 			zlog_debug(
 				"%s: isis linked to vrf %s vrf_id %u (old id %u)",
 				__func__, vrf->name, isis->vrf_id, old_vrf_id);
+
+		hook_call(isis_vrf_enable_hook, vrf);
+
 		if (old_vrf_id != isis->vrf_id) {
 			frr_with_privs (&isisd_privs) {
 				/* stop zebra redist to us for old vrf */
@@ -619,6 +625,8 @@ static int isis_vrf_disable(struct vrf *vrf)
 		if (IS_DEBUG_EVENTS)
 			zlog_debug("%s: isis old_vrf_id %d unlinked", __func__,
 				   old_vrf_id);
+
+		hook_call(isis_vrf_disable_hook, vrf);
 	}
 
 	return 0;

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -67,6 +67,9 @@ extern void isis_cli_init(void);
 
 #define SNMP_CIRCUITS_MAX (512)
 
+DECLARE_HOOK(isis_vrf_enable_hook, (struct vrf *vrf), (vrf));
+DECLARE_HOOK(isis_vrf_disable_hook, (struct vrf *vrf), (vrf));
+
 extern struct zebra_privs_t isisd_privs;
 
 /* uncomment if you are a developer in bug hunt */


### PR DESCRIPTION
Now it's possible to redistribute from another protocol routes which are
inside a specific vrf.

Example of possible configuration:

```
!
vrf isis-l1
 ipv6 route fd00::/60 blackhole
 exit-vrf
!
interface one vrf isis-l1
 ipv6 router isis COMMON vrf isis-l1
 isis circuit-type level-1
!
router isis COMMON vrf isis-l1
 is-type level-1
 net fd.0000.0000.0000.0001.00
 redistribute ipv6 static level-1
 topology ipv6-unicast
!
```

Signed-off-by: Emanuele Altomare <emanuele@common-net.org>