### PR TITLE
ospfd: Correct Segment Routing prefix bugs

### DIFF
--- a/ospfd/ospf_ext.c
+++ b/ospfd/ospf_ext.c
@@ -301,6 +301,8 @@ static void set_ext_prefix(struct ext_itf *exti, uint8_t route_type,
 	exti->prefix.af = 0;
 	exti->prefix.pref_length = p.prefixlen;
 	exti->prefix.address = p.prefix;
+
+	SET_FLAG(exti->flags, EXT_LPFLG_LSA_ACTIVE);
 }
 
 /* Extended Link TLV - RFC7684 section 3.1 */
@@ -766,7 +768,6 @@ static void ospf_ext_ism_change(struct ospf_interface *oi, int old_status)
 		if (OspfEXT.enabled) {
 			osr_debug("EXT (%s): Set Prefix SID to interface %s ",
 				  __func__, oi->ifp->name);
-			exti->flags = EXT_LPFLG_LSA_ACTIVE;
 			ospf_sr_update_local_prefix(oi->ifp, oi->address);
 		}
 	} else {

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -622,7 +622,7 @@ void ospf_zebra_update_prefix_sid(const struct sr_prefix *srp)
 			znh->labels[0] = path->srni.label_out;
 
 			osr_debug("  |- labels %u/%u", srp->label_in,
-				  srp->nhlfe.label_out);
+				  path->srni.label_out);
 
 			/* Set TI-LFA backup nexthop info if present */
 			if (path->srni.backup_label_stack) {


### PR DESCRIPTION
This patch solves 2 Segment Routing prefix bugs:

- If Segment Routing is not enabled in the initial configuration, Extended
  Prefix Opaque LSA is not flood. This is due to a control flag which is
  set only when Segment Routing is enabled at startup and not latter.
- Attempting to modify Segment Routing prefix flag e.g. adding or removing
  no-php or explicit-null flag, doesn't work as expected: Corresponding entry
  in the MPLS table is not updated, Extended Prefix Opaque LSA carry wrong flag
  value, and neighbor set a wrong configuration in the MPLS table for this
  Segment Routing prefix.

The first bug is corrected in ospfd/ospf_ext.c:

- Flag setting is moved from ospf_ext_ism_change() to set_ext_prefix() function

The seconf one is corrected in ospfd/ospf_sr.c:

- For self node, previous MPLS entry is removed if needed and flag reset before
  setting the new Segment Routing prefix configuration
- For neighbor node, srnext field of sr_prefix structure is always set and not
  only for new SR Prefix.

This PR is mandatory for PR #8137 and #7827

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>