### PR TITLE
bgpd: handle socket read errors in the main pthread

### DIFF
--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -83,4 +83,8 @@ extern int bgp_generate_updgrp_packets(struct thread *);
 extern int bgp_process_packet(struct thread *);
 
 extern void bgp_send_delayed_eor(struct bgp *bgp);
+
+/* Task callback to handle socket error encountered in the io pthread */
+int bgp_packet_process_error(struct thread *thread);
+
 #endif /* _QUAGGA_BGP_PACKET_H */


### PR DESCRIPTION
Add a handler for socket errors that runs in the main pthread, rather than the io pthread. When the io pthread encounters a read error, capture the error and schedule a task for the main pthread.

Fixes: #8213 