### PR TITLE
build: move the xref cleanup report to its own build target

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -461,7 +461,7 @@ SUFFIXES += .xref
 # dependencies added in python/makefile.py
 frr.xref:
 	$(AM_V_XRELFO) $(CLIPPY) $(top_srcdir)/python/xrelfo.py -o $@ $^
-all-am: frr.xref
+all-xref: frr.xref
 
 clean-xref:
 	-rm -rf $(xrefs) frr.xref


### PR DESCRIPTION
Generating the cleanup report is nice; move it to its own build target.
