### PR TITLE
pimd: fix coverity SA warning in pim_nb_config.c

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2411,7 +2411,7 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 		}
 
 #ifdef PIM_ENFORCE_LOOPFREE_MFC
-		if (oif && iif && (iif->ifindex == oif->ifindex)) {
+		if (oif && (iif->ifindex == oif->ifindex)) {
 			strlcpy(args->errmsg,
 				"% IIF same as OIF and loopfree enforcement is enabled; rejecting",
 				args->errmsg_len);


### PR DESCRIPTION
Fix a recent/new coverity warning that a variable couldn't be NULL but was being tested for NULL anyway.