### PR TITLE
bfdd: fix echo receive timer and disable echo mode

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -494,8 +494,10 @@ void ptm_bfd_echo_stop(struct bfd_session *bfd)
 void ptm_bfd_echo_start(struct bfd_session *bfd)
 {
 	bfd->echo_detect_TO = (bfd->remote_detect_mult * bfd->echo_xmt_TO);
-	if (bfd->echo_detect_TO > 0)
+	if (bfd->echo_detect_TO > 0) {
+		bfd_echo_recvtimer_update(bfd);
 		ptm_bfd_echo_xmt_TO(bfd);
+	}
 }
 
 void ptm_bfd_sess_up(struct bfd_session *bfd)

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -433,6 +433,10 @@ DEFPY_YANG(
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
+	if (!no && !bglobal.bg_use_dplane) {
+		vty_out(vty, "%% Current implementation of echo mode works only when the peer is also FRR.\n");
+	}
+
 	nb_cli_enqueue_change(vty, "./echo-mode", NB_OP_MODIFY,
 			      no ? "false" : "true");
 	return nb_cli_apply_changes(vty, NULL);

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -174,7 +174,8 @@ BFD peers and profiles share the same BFD session configuration commands.
 .. clicmd:: echo-mode
 
    Enables or disables the echo transmission mode. This mode is disabled
-   by default.
+   by default. If you are not using distributed BFD then echo mode works
+   only when the peer is also FRR.
 
    It is recommended that the transmission interval of control packets
    to be increased after enabling echo-mode to reduce bandwidth usage.


### PR DESCRIPTION
The first commit fixes the echo receive timer, which was never started until bfdd receives at least one echo packet.
Although this commit fixes the issue, it actually shows that echo mode never worked correctly and was always broken.
The current implementation of echo mode sends echo packets to a peer's address instead of its own address.
It never receives echo packets back (when testing not with FRR as a peer) and never starts the detection timer.
That's why it may seem to work even when testing with other vendors.

To prevent users from enabling the broken echo mode, the second commit hides the `echo-mode` command and throws a warning when anyone tries to enable it.