### PR TITLE
bgpd: Reevaluate es_evi_vtep active state on disable-ead-evi-rx config flap

### DIFF
--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -376,5 +376,6 @@ extern bool bgp_evpn_path_es_use_nhg(struct bgp *bgp_vrf,
 extern void bgp_evpn_es_vrf_show(struct vty *vty, bool uj,
 				 struct bgp_evpn_es *es);
 extern void bgp_evpn_es_vrf_show_esi(struct vty *vty, esi_t *esi, bool uj);
+extern void bgp_evpn_switch_ead_evi_rx(void);
 
 #endif /* _FRR_BGP_EVPN_MH_H */

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3767,7 +3767,12 @@ DEFPY (bgp_evpn_ead_evi_rx_disable,
        NO_STR
        "Activate PE on EAD-ES even if EAD-EVI is not received\n")
 {
-	bgp_mh_info->ead_evi_rx = no? true :false;
+	bool ead_evi_rx = no? true :false;
+
+	if (ead_evi_rx != bgp_mh_info->ead_evi_rx) {
+		bgp_mh_info->ead_evi_rx = ead_evi_rx;
+		bgp_evpn_switch_ead_evi_rx();
+	}
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION


Update es_evi_vtep active state and add/delete es_vtep accordingly to
zebra for remote ES.

Signed-off-by: Ameya Dharkar <adharkar@vmware.com>