### PR TITLE
bfdd: make sessions administratively up by default

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -85,7 +85,7 @@ struct bfd_profile *bfd_profile_lookup(const char *name)
 
 static void bfd_profile_set_default(struct bfd_profile *bp)
 {
-	bp->admin_shutdown = true;
+	bp->admin_shutdown = false;
 	bp->detection_multiplier = BFD_DEFDETECTMULT;
 	bp->echo_mode = false;
 	bp->passive = false;
@@ -206,7 +206,7 @@ void bfd_session_apply(struct bfd_session *bs)
 		bfd_set_passive_mode(bs, bs->peer_profile.passive);
 
 	/* Toggle 'no shutdown' if default value. */
-	if (bs->peer_profile.admin_shutdown)
+	if (bs->peer_profile.admin_shutdown == false)
 		bfd_set_shutdown(bs, bp->admin_shutdown);
 	else
 		bfd_set_shutdown(bs, bs->peer_profile.admin_shutdown);

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -274,7 +274,7 @@ void bfd_cli_show_shutdown(struct vty *vty, struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	if (show_defaults)
-		vty_out(vty, "  shutdown\n");
+		vty_out(vty, "  no shutdown\n");
 	else
 		vty_out(vty, "  %sshutdown\n",
 			yang_dnode_get_bool(dnode, NULL) ? "" : "no ");

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -840,7 +840,7 @@ static int bfd_configure_peer(struct bfd_peer_cfg *bpc, bool mhop,
 	memset(bpc, 0, sizeof(*bpc));
 
 	/* Defaults */
-	bpc->bpc_shutdown = true;
+	bpc->bpc_shutdown = false;
 	bpc->bpc_detectmultiplier = BPC_DEF_DETECTMULTIPLIER;
 	bpc->bpc_recvinterval = BPC_DEF_RECEIVEINTERVAL;
 	bpc->bpc_txinterval = BPC_DEF_TRANSMITINTERVAL;

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -492,9 +492,6 @@ static void bfdd_dest_register(struct stream *msg, vrf_id_t vrf_id)
 					"ptm-add-dest: failed to create BFD session");
 			return;
 		}
-
-		/* Protocol created peers are 'no shutdown' by default. */
-		bs->peer_profile.admin_shutdown = false;
 	} else {
 		/*
 		 * BFD session was already created, we are just updating the

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -185,7 +185,7 @@ module frr-bfdd {
 
     leaf administrative-down {
       type boolean;
-      default true;
+      default false;
       description "Disables or enables the session administratively";
     }
 


### PR DESCRIPTION
Current behavior is inconsistent. When the session is created by another
daemon, it is up by default. When we later configure peer in bfdd, the
session is still up, but the NB layer thinks that it is down.

More than that, even when the session is created in bfdd using peer
command, it is created in DOWN state, not ADM_DOWN. And it actually
starts sending and receiving packets. The sessions is marked with
SHUTDOWN flag only when we try to reconfigure some parameter. This
behavior is also very unexpected.

Fixes #7780.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>