### PR TITLE
nhrp: NAT fixes

### DIFF
--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -212,7 +212,8 @@ static int nhrp_cache_do_timeout(struct thread *t)
 
 	c->t_timeout = NULL;
 	if (c->cur.type != NHRP_CACHE_INVALID)
-		nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL, NULL);
+		nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL,
+					  NULL);
 	return 0;
 }
 
@@ -301,7 +302,8 @@ static void nhrp_cache_peer_notifier(struct notifier_block *n,
 	case NOTIFY_PEER_DOWN:
 	case NOTIFY_PEER_IFCONFIG_CHANGED:
 		notifier_call(&c->notifier_list, NOTIFY_CACHE_DOWN);
-		nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL, NULL);
+		nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL,
+					  NULL);
 		break;
 	case NOTIFY_PEER_NBMA_CHANGING:
 		if (c->cur.type == NHRP_CACHE_DYNAMIC)
@@ -422,7 +424,8 @@ static void nhrp_cache_newpeer_notifier(struct notifier_block *n,
 
 int nhrp_cache_update_binding(struct nhrp_cache *c, enum nhrp_cache_type type,
 			      int holding_time, struct nhrp_peer *p,
-			      uint32_t mtu, union sockunion *nbma_oa, union sockunion *nbma_claimed)
+			      uint32_t mtu, union sockunion *nbma_oa,
+			      union sockunion *nbma_claimed)
 {
 	char buf[2][SU_ADDRSTRLEN];
 

--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -474,6 +474,7 @@ int nhrp_cache_update_binding(struct nhrp_cache *c, enum nhrp_cache_type type,
 		c->new.type = type;
 		c->new.peer = p;
 		c->new.mtu = mtu;
+		c->new.holding_time = holding_time;
 		if (nbma_oa)
 			c->new.remote_nbma_natoa = *nbma_oa;
 

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -255,7 +255,7 @@ static void nhrp_interface_update_address(struct interface *ifp, afi_t afi,
 		nc = nhrp_cache_get(ifp, &if_ad->addr, 0);
 		if (nc)
 			nhrp_cache_update_binding(nc, NHRP_CACHE_LOCAL, -1,
-						  NULL, 0, NULL);
+						  NULL, 0, NULL, NULL);
 	}
 
 	debugf(NHRP_DEBUG_KERNEL, "%s: IPv%d address changed to %s", ifp->name,
@@ -267,7 +267,7 @@ static void nhrp_interface_update_address(struct interface *ifp, afi_t afi,
 		nc = nhrp_cache_get(ifp, &addr, 1);
 		if (nc)
 			nhrp_cache_update_binding(nc, NHRP_CACHE_LOCAL, 0, NULL,
-						  0, NULL);
+						  0, NULL, NULL);
 	}
 
 	notifier_call(&nifp->notifier_list, NOTIFY_INTERFACE_ADDRESS_CHANGED);
@@ -364,7 +364,7 @@ static void interface_config_update_nhrp_map(struct nhrp_cache_config *cc,
 		if (c && c->map) {
 			nhrp_cache_update_binding(
 				c, c->cur.type, -1,
-				nhrp_peer_get(ifp, &nbma_addr), 0, NULL);
+				nhrp_peer_get(ifp, &nbma_addr), 0, NULL, NULL);
 		}
 		return;
 	}
@@ -375,11 +375,11 @@ static void interface_config_update_nhrp_map(struct nhrp_cache_config *cc,
 	c->map = 1;
 	if (cc->type == NHRP_CACHE_LOCAL)
 		nhrp_cache_update_binding(c, NHRP_CACHE_LOCAL, 0, NULL, 0,
-					  NULL);
+					  NULL, NULL);
 	else {
 		nhrp_cache_update_binding(c, NHRP_CACHE_STATIC, 0,
 					  nhrp_peer_get(ifp, &cc->nbma), 0,
-					  NULL);
+					  NULL, NULL);
 	}
 }
 

--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -218,6 +218,7 @@ static int nhrp_reg_send_req(struct thread *t)
 	ext = nhrp_ext_push(zb, hdr, NHRP_EXTENSION_NAT_ADDRESS);
 	cie = nhrp_cie_push(zb, NHRP_CODE_SUCCESS, &nifp->nbma, &if_ad->addr);
 	cie->prefix_length = 8 * sockunion_get_addrlen(&if_ad->addr);
+	cie->mtu = htons(if_ad->mtu);
 	nhrp_ext_complete(zb, ext);
 
 	nhrp_packet_complete(zb, hdr);

--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -442,3 +442,24 @@ void nhrp_nhs_foreach(struct interface *ifp, afi_t afi,
 			cb(nhs, 0, ctx);
 	}
 }
+
+int nhrp_nhs_match_ip(union sockunion *in_ip, struct nhrp_interface *nifp) {
+	int i;
+	struct nhrp_nhs *nhs;
+	struct nhrp_registration *reg;
+	for (i=0; i < AFI_MAX; i++)
+	{
+		list_for_each_entry(nhs, &nifp->afi[i].nhslist_head, nhslist_entry)
+		{
+			if (!list_empty(&nhs->reglist_head)) {
+				list_for_each_entry(reg, &nhs->reglist_head,
+						    reglist_entry)
+				{
+					if (!sockunion_cmp(in_ip, &reg->peer->vc->remote.nbma))
+						return 1;
+				}
+			}
+		}
+	}
+	return 0;
+}

--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -32,7 +32,8 @@ static void nhrp_reg_reply(struct nhrp_reqid *reqid, void *arg)
 	struct nhrp_cie_header *cie;
 	struct nhrp_cache *c;
 	struct zbuf extpl;
-	union sockunion cie_nbma, cie_nbma_nhs, cie_proto, cie_proto_nhs, *proto;
+	union sockunion cie_nbma, cie_nbma_nhs, cie_proto, cie_proto_nhs,
+		*proto;
 	char buf[64];
 	int ok = 0, holdtime;
 	unsigned short mtu = 0;
@@ -85,7 +86,8 @@ static void nhrp_reg_reply(struct nhrp_reqid *reqid, void *arg)
 			break;
 		case NHRP_EXTENSION_RESPONDER_ADDRESS:
 			/* NHS adds its own record as responder address */
-			nhrp_cie_pull(&extpl, p->hdr, &cie_nbma_nhs, &cie_proto_nhs);
+			nhrp_cie_pull(&extpl, p->hdr, &cie_nbma_nhs,
+				      &cie_proto_nhs);
 			break;
 		}
 	}
@@ -104,7 +106,8 @@ static void nhrp_reg_reply(struct nhrp_reqid *reqid, void *arg)
 	c = nhrp_cache_get(ifp, &p->dst_proto, 1);
 	if (c)
 		nhrp_cache_update_binding(c, NHRP_CACHE_NHS, holdtime,
-					  nhrp_peer_ref(r->peer), mtu, NULL, &cie_nbma_nhs);
+					  nhrp_peer_ref(r->peer), mtu, NULL,
+					  &cie_nbma_nhs);
 }
 
 static int nhrp_reg_timeout(struct thread *t)
@@ -215,7 +218,9 @@ static int nhrp_reg_send_req(struct thread *t)
 	/* FIXME: push CIE for each local protocol address */
 	cie = nhrp_cie_push(zb, NHRP_CODE_SUCCESS, NULL, NULL);
 	/* RFC2332 5.2.1 if unique is set then prefix length must be 0xff */
-	cie->prefix_length = (if_ad->flags & NHRP_IFF_REG_NO_UNIQUE) ? 8 * sockunion_get_addrlen(dst_proto) : 0xff;
+	cie->prefix_length = (if_ad->flags & NHRP_IFF_REG_NO_UNIQUE)
+				     ? 8 * sockunion_get_addrlen(dst_proto)
+				     : 0xff;
 	cie->holding_time = htons(if_ad->holdtime);
 	cie->mtu = htons(if_ad->mtu);
 
@@ -237,7 +242,8 @@ static int nhrp_reg_send_req(struct thread *t)
 	hdr->flags |= htons(NHRP_FLAG_REGISTRATION_NAT);
 	ext = nhrp_ext_push(zb, hdr, NHRP_EXTENSION_NAT_ADDRESS);
 	/* push NHS details */
-	cie = nhrp_cie_push(zb, NHRP_CODE_SUCCESS, &r->peer->vc->remote.nbma, &nhs_proto);
+	cie = nhrp_cie_push(zb, NHRP_CODE_SUCCESS, &r->peer->vc->remote.nbma,
+			    &nhs_proto);
 	cie->prefix_length = 8 * sockunion_get_addrlen(&if_ad->addr);
 	cie->mtu = htons(if_ad->mtu);
 	nhrp_ext_complete(zb, ext);
@@ -465,19 +471,23 @@ void nhrp_nhs_foreach(struct interface *ifp, afi_t afi,
 	}
 }
 
-int nhrp_nhs_match_ip(union sockunion *in_ip, struct nhrp_interface *nifp) {
+int nhrp_nhs_match_ip(union sockunion *in_ip, struct nhrp_interface *nifp)
+{
 	int i;
 	struct nhrp_nhs *nhs;
 	struct nhrp_registration *reg;
-	for (i=0; i < AFI_MAX; i++)
-	{
-		list_for_each_entry(nhs, &nifp->afi[i].nhslist_head, nhslist_entry)
+	for (i = 0; i < AFI_MAX; i++) {
+		list_for_each_entry(nhs, &nifp->afi[i].nhslist_head,
+				    nhslist_entry)
 		{
 			if (!list_empty(&nhs->reglist_head)) {
 				list_for_each_entry(reg, &nhs->reglist_head,
 						    reglist_entry)
 				{
-					if (!sockunion_cmp(in_ip, &reg->peer->vc->remote.nbma))
+					if (!sockunion_cmp(
+						    in_ip,
+						    &reg->peer->vc->remote
+							     .nbma))
 						return 1;
 				}
 			}

--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -476,6 +476,7 @@ int nhrp_nhs_match_ip(union sockunion *in_ip, struct nhrp_interface *nifp)
 	int i;
 	struct nhrp_nhs *nhs;
 	struct nhrp_registration *reg;
+
 	for (i = 0; i < AFI_MAX; i++) {
 		list_for_each_entry(nhs, &nifp->afi[i].nhslist_head,
 				    nhslist_entry)

--- a/nhrpd/nhrp_packet.c
+++ b/nhrpd/nhrp_packet.c
@@ -268,6 +268,7 @@ int nhrp_ext_reply(struct zbuf *zb, struct nhrp_packet_header *hdr,
 				    &ad->addr);
 		if (!cie)
 			goto err;
+		cie->mtu = htons(ad->mtu);
 		cie->holding_time = htons(ad->holdtime);
 		break;
 	default:

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -622,6 +622,10 @@ static void nhrp_handle_resolution_req(struct nhrp_packet_parser *pp)
 						    &pp->if_ad->addr);
 				if (!cie)
 					goto err;
+				cie->prefix_length =
+					8 * sockunion_get_addrlen(
+							&pp->if_ad->addr);
+
 				cie->mtu = htons(pp->if_ad->mtu);
 				nhrp_ext_complete(zb, ext);
 			}

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -289,7 +289,7 @@ static int nhrp_peer_defer_vici_request(struct thread *t)
 	struct nhrp_vc *vc = p->vc;
 	struct interface *ifp = p->ifp;
 	struct nhrp_interface *nifp = ifp->info;
-	char buf[256];
+	char buf[SU_ADDRSTRLEN];
 	THREAD_OFF(p->t_timer);
 
 	if (p->online) {
@@ -314,7 +314,7 @@ int nhrp_peer_check(struct nhrp_peer *p, int establish)
 	struct nhrp_vc *vc = p->vc;
 	struct interface *ifp = p->ifp;
 	struct nhrp_interface *nifp = ifp->info;
-	char buf[256];
+	char buf[SU_ADDRSTRLEN];
 
 	if (p->online)
 		return 1;
@@ -387,7 +387,7 @@ static void nhrp_process_nat_extension(struct nhrp_packet_parser *pp,
 				       union sockunion *proto,
 				       union sockunion *cie_nbma)
 {
-	char buf[2][256];
+	char buf1[SU_ADDRSTRLEN], buf2[SU_ADDRSTRLEN];
 	union sockunion cie_proto;
 	struct zbuf payload;
 	struct nhrp_extension_header *ext;
@@ -413,12 +413,10 @@ static void nhrp_process_nat_extension(struct nhrp_packet_parser *pp,
 				 * the neighbor table in the kernel contains the
 				 * source NBMA address which is not reachable
 				 * since it is behind a NAT device */
+				if (!sockunion2str(proto, buf1, sizeof(buf1)))
+					strlcpy(buf1, "NULL", sizeof(buf1));
 				debugf(NHRP_DEBUG_COMMON,
-				       "Processing NAT Extension for %s",
-				       sockunion2str(proto, buf[0],
-						     sizeof(buf[0]))
-					       ? buf[0]
-					       : "NULL");
+				       "Processing NAT Extension for %s", buf1);
 				while (nhrp_cie_pull(&payload, pp->hdr,
 						     cie_nbma, &cie_proto)) {
 					if (sockunion_family(&cie_proto)
@@ -426,14 +424,14 @@ static void nhrp_process_nat_extension(struct nhrp_packet_parser *pp,
 						continue;
 
 					if (!sockunion_cmp(proto, &cie_proto)) {
+						if (!sockunion2str(cie_nbma,
+								  buf2,
+								  sizeof(buf2)))
+							strlcpy(buf2, "NULL",
+								sizeof(buf2));
 						debugf(NHRP_DEBUG_COMMON,
 						       "cie_nbma for proto %s is %s",
-						       buf[0] ? buf[0] : "NULL",
-						       sockunion2str(
-							       cie_nbma, buf[1],
-							       sizeof(buf[1]))
-							       ? buf[1]
-							       : "NULL");
+						       buf1, buf2);
 						break;
 					}
 				}

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -294,7 +294,7 @@ static int nhrp_peer_defer_vici_request(struct thread *t)
 
 	if (p->online) {
 		debugf(NHRP_DEBUG_COMMON,
-		       "IPsec connection to %pSU already established\n",
+		       "IPsec connection to %pSU already established",
 		       &vc->remote.nbma);
 	} else {
 		vici_request_vc(nifp->ipsec_profile, &vc->local.nbma,
@@ -342,7 +342,7 @@ int nhrp_peer_check(struct nhrp_peer *p, int establish)
 		int r_time_ms = rand() % 1000;
 
 		debugf(NHRP_DEBUG_COMMON,
-		       "Initiating IPsec connection request to %pSU after %d ms:\n",
+		       "Initiating IPsec connection request to %pSU after %d ms:",
 		       &vc->remote.nbma, r_time_ms);
 		thread_add_timer_msec(master, nhrp_peer_defer_vici_request,
 				      p, r_time_ms, &p->t_timer);

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -393,11 +393,13 @@ static void nhrp_process_nat_extension(struct nhrp_packet_parser *pp,
 	struct nhrp_extension_header *ext;
 	struct zbuf *extensions;
 
-
-	if (!proto || !cie_nbma || sockunion_family(proto) == AF_UNSPEC)
+	if (!cie_nbma)
 		return;
 
 	sockunion_family(cie_nbma) = AF_UNSPEC;
+
+	if (!proto || sockunion_family(proto) == AF_UNSPEC)
+		return;
 
 	/* Handle extensions */
 	extensions = zbuf_alloc(zbuf_used(&pp->extensions));

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -1083,6 +1083,7 @@ static void nhrp_peer_forward(struct nhrp_peer *p,
 err:
 	nhrp_packet_debug(pp->pkt, "FWD-FAIL");
 	zbuf_free(zb);
+	zbuf_free(zb_copy);
 }
 
 static void nhrp_packet_debug(struct zbuf *zb, const char *dir)

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -412,7 +412,7 @@ static void nhrp_process_nat_extension(struct nhrp_packet_parser *pp,
 				 * since it is behind a NAT device
 				 */
 				debugf(NHRP_DEBUG_COMMON,
-				       "Processing NAT Extension for %pSU",
+				       "shortcut res_resp: Processing NAT Extension for %pSU",
 				       proto);
 				while (nhrp_cie_pull(&payload, pp->hdr,
 						     cie_nbma, &cie_proto)) {
@@ -422,7 +422,7 @@ static void nhrp_process_nat_extension(struct nhrp_packet_parser *pp,
 
 					if (!sockunion_cmp(proto, &cie_proto)) {
 						debugf(NHRP_DEBUG_COMMON,
-						       "cie_nbma for proto %pSU is %pSU",
+						       "\tcie_nbma for proto %pSU is %pSU",
 						       proto, cie_nbma);
 						break;
 					}
@@ -507,18 +507,16 @@ static void nhrp_handle_resolution_req(struct nhrp_packet_parser *pp)
 			 * coming directly from NATTED Spoke and there is not
 			 * NAT Extension present
 			 */
-			debugf(NHRP_DEBUG_COMMON, "No NAT Extension for %pSU",
+			debugf(NHRP_DEBUG_COMMON, "shortcut res_rep: No NAT Extension for %pSU",
 			       proto_addr);
 
 			if (!sockunion_same(&pp->src_nbma,
 					    &pp->peer->vc->remote.nbma)
 			    && !nhrp_nhs_match_ip(&pp->peer->vc->remote.nbma,
 						  nifp)) {
-				debugf(NHRP_DEBUG_COMMON,
-				       "Remote Device is NATTED");
 				cie_nbma_nat = pp->peer->vc->remote.nbma;
 				debugf(NHRP_DEBUG_COMMON,
-				       "Device is natted using %pSU as cie_nbma",
+				       "shortcut res_rep: NAT detected using %pSU as cie_nbma",
 				       &cie_nbma_nat);
 			}
 		}

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -581,6 +581,7 @@ static void nhrp_handle_resolution_req(struct nhrp_packet_parser *pp)
 					    &nifp->nat_nbma, &pp->if_ad->addr);
 			if (!cie)
 				goto err;
+			cie->mtu = htons(pp->if_ad->mtu);
 			nhrp_ext_complete(zb, ext);
 			break;
 		default:
@@ -696,9 +697,10 @@ static void nhrp_handle_registration_request(struct nhrp_packet_parser *p)
 				goto err;
 			zbuf_copy(zb, &payload, zbuf_used(&payload));
 			if (natted) {
-				nhrp_cie_push(zb, NHRP_CODE_SUCCESS,
+				cie = nhrp_cie_push(zb, NHRP_CODE_SUCCESS,
 					      &p->peer->vc->remote.nbma,
 					      &p->src_proto);
+				cie->mtu = htons(p->if_ad->mtu);
 			}
 			nhrp_ext_complete(zb, ext);
 			break;
@@ -961,6 +963,7 @@ static void nhrp_peer_forward(struct nhrp_peer *p,
 						    &nifp->nbma, &if_ad->addr);
 				if (!cie)
 					goto err;
+				cie->mtu = htons(if_ad->mtu);
 				cie->holding_time = htons(if_ad->holdtime);
 			}
 			break;

--- a/nhrpd/nhrp_shortcut.c
+++ b/nhrpd/nhrp_shortcut.c
@@ -325,7 +325,7 @@ static void nhrp_shortcut_recv_resolution_rep(struct nhrp_reqid *reqid,
 			nhrp_cache_update_binding(c, NHRP_CACHE_DYNAMIC,
 						  holding_time,
 						  nhrp_peer_get(pp->ifp, nbma),
-						  htons(cie->mtu), nbma);
+						  htons(cie->mtu), nbma, &cie_nbma);
 		} else {
 			debugf(NHRP_DEBUG_COMMON,
 			       "Shortcut: no cache for nbma %s", buf[2]);
@@ -340,7 +340,7 @@ static void nhrp_shortcut_recv_resolution_rep(struct nhrp_reqid *reqid,
 				nhrp_cache_update_binding(c_dst_proto, NHRP_CACHE_DYNAMIC,
 						  holding_time,
 						  nhrp_peer_get(pp->ifp, nbma),
-						  htons(cie->mtu), nbma);
+						  htons(cie->mtu), nbma, &cie_nbma);
 			} else {
 				debugf(NHRP_DEBUG_COMMON,
 			       "Shortcut: no cache for nbma %s", buf[2]);

--- a/nhrpd/nhrp_shortcut.c
+++ b/nhrpd/nhrp_shortcut.c
@@ -282,9 +282,12 @@ static void nhrp_shortcut_recv_resolution_rep(struct nhrp_reqid *reqid,
 				union sockunion cie_nat_proto, cie_nat_nbma;
 				sockunion_family(&cie_nat_proto) = AF_UNSPEC;
 				sockunion_family(&cie_nat_nbma) = AF_UNSPEC;
-				cie_nat = nhrp_cie_pull(&extpl, pp->hdr, &cie_nat_nbma, &cie_nat_proto);
+				cie_nat = nhrp_cie_pull(&extpl, pp->hdr,
+							&cie_nat_nbma,
+							&cie_nat_proto);
 				/* We are interested only in peer CIE */
-				if (cie_nat && sockunion_same(&cie_nat_proto, proto)) {
+				if (cie_nat
+				    && sockunion_same(&cie_nat_proto, proto)) {
 					nat_nbma = cie_nat_nbma;
 				}
 			} while (cie_nat);
@@ -296,15 +299,25 @@ static void nhrp_shortcut_recv_resolution_rep(struct nhrp_reqid *reqid,
 
 	/* Update cache entry for the protocol to nbma binding */
 	if (sockunion_family(&nat_nbma) != AF_UNSPEC) {
-		debugf(NHRP_DEBUG_COMMON,"Remote Device is NATTED, NHRP NAT Extension present");
-		debugf(NHRP_DEBUG_COMMON,"Client NBMA Address %s", sockunion2str(&nat_nbma, buf[1], sizeof(buf[1])));
+		debugf(NHRP_DEBUG_COMMON,
+		       "Remote Device is NATTED, NHRP NAT Extension present");
+		debugf(NHRP_DEBUG_COMMON,
+		       "Client NBMA Address %s",
+		       sockunion2str(&nat_nbma, buf[1], sizeof(buf[1])));
 		nbma = &nat_nbma;
-    }
-	/* For NHRP resolution reply the cie_nbma in mandatory part is the address of the actual address of the sender */
-    else if (!sockunion_same(&cie_nbma, &pp->peer->vc->remote.nbma) && !nhrp_nhs_match_ip(&pp->peer->vc->remote.nbma, nifp)) {
-		debugf(NHRP_DEBUG_COMMON,"Remote Device is NATTED, NHRP NAT Extension not present for proto %s", sockunion2str(proto, buf[0], sizeof(buf[0])));
-		debugf(NHRP_DEBUG_COMMON,"cie_nbma %s", sockunion2str(&cie_nbma, buf[1], sizeof(buf[1])));
-		debugf(NHRP_DEBUG_COMMON,"remote.nbma %s", sockunion2str(&pp->peer->vc->remote.nbma, buf[1], sizeof(buf[1])));
+	}
+	/* For NHRP resolution reply the cie_nbma in mandatory part is the
+	 * address of the actual address of the sender */
+	else if (!sockunion_same(&cie_nbma, &pp->peer->vc->remote.nbma)
+		 && !nhrp_nhs_match_ip(&pp->peer->vc->remote.nbma, nifp)) {
+		debugf(NHRP_DEBUG_COMMON,
+		       "Remote Device is NATTED, NHRP NAT Extension not present for proto %s",
+		       sockunion2str(proto, buf[0], sizeof(buf[0])));
+		debugf(NHRP_DEBUG_COMMON, "cie_nbma %s",
+		       sockunion2str(&cie_nbma, buf[1], sizeof(buf[1])));
+		debugf(NHRP_DEBUG_COMMON, "remote.nbma %s",
+		       sockunion2str(&pp->peer->vc->remote.nbma, buf[1], 
+				sizeof(buf[1])));
 		nbma = &pp->peer->vc->remote.nbma;
 		nat_nbma = *nbma;
 	} else {
@@ -427,10 +440,9 @@ static void nhrp_shortcut_send_resolution_req(struct nhrp_shortcut *s)
 	/* Cisco NAT detection extension */
 	hdr->flags |= htons(NHRP_FLAG_RESOLUTION_NAT);
 	ext = nhrp_ext_push(zb, hdr, NHRP_EXTENSION_NAT_ADDRESS);
-	if (sockunion_family(&nifp->nat_nbma) != AF_UNSPEC)
-	{
-		cie = nhrp_cie_push(zb, NHRP_CODE_SUCCESS,
-						    &nifp->nat_nbma, &if_ad->addr);
+	if (sockunion_family(&nifp->nat_nbma) != AF_UNSPEC) {
+		cie = nhrp_cie_push(zb, NHRP_CODE_SUCCESS, &nifp->nat_nbma,
+				    &if_ad->addr);
 		cie->prefix_length = 8 * sockunion_get_addrlen(&if_ad->addr);
 		cie->mtu = htons(if_ad->mtu);
 		nhrp_ext_complete(zb, ext);

--- a/nhrpd/nhrp_shortcut.c
+++ b/nhrpd/nhrp_shortcut.c
@@ -301,7 +301,7 @@ static void nhrp_shortcut_recv_resolution_rep(struct nhrp_reqid *reqid,
 	/* Update cache entry for the protocol to nbma binding */
 	if (sockunion_family(&nat_nbma) != AF_UNSPEC) {
 		debugf(NHRP_DEBUG_COMMON,
-		       "Remote Device is NATed (NAT extension) proto %pSU NBMA %pSU claimed-NBMA %pSU",
+		       "Shortcut: NAT detected (NAT extension) proto %pSU NBMA %pSU claimed-NBMA %pSU",
 		       proto, &nat_nbma, &cie_nbma);
 		nbma = &nat_nbma;
 	}
@@ -311,7 +311,7 @@ static void nhrp_shortcut_recv_resolution_rep(struct nhrp_reqid *reqid,
 	else if (!sockunion_same(&cie_nbma, &pp->peer->vc->remote.nbma)
 		 && !nhrp_nhs_match_ip(&pp->peer->vc->remote.nbma, nifp)) {
 		debugf(NHRP_DEBUG_COMMON,
-		       "Remote Device is NATed (no NAT Extension) proto %pSU NBMA %pSU claimed-NBMA %pSU",
+		       "Shortcut: NAT detected (no NAT Extension) proto %pSU NBMA %pSU claimed-NBMA %pSU",
 		       proto, &pp->peer->vc->remote.nbma, &cie_nbma);
 		nbma = &pp->peer->vc->remote.nbma;
 		nat_nbma = *nbma;

--- a/nhrpd/nhrp_shortcut.c
+++ b/nhrpd/nhrp_shortcut.c
@@ -424,8 +424,9 @@ static void nhrp_shortcut_send_resolution_req(struct nhrp_shortcut *s)
 	ext = nhrp_ext_push(zb, hdr, NHRP_EXTENSION_NAT_ADDRESS);
 	if (sockunion_family(&nifp->nat_nbma) != AF_UNSPEC)
 	{
-		nhrp_cie_push(zb, NHRP_CODE_SUCCESS,
-						    &nifp->nat_nbma, &nifp->afi[family2afi(sockunion_family(&s->addr))].addr);
+		cie = nhrp_cie_push(zb, NHRP_CODE_SUCCESS,
+						    &nifp->nat_nbma, &if_ad->addr);
+		cie->prefix_length = 8 * sockunion_get_addrlen(&if_ad->addr);
 		nhrp_ext_complete(zb, ext);
 	}
 

--- a/nhrpd/nhrp_shortcut.c
+++ b/nhrpd/nhrp_shortcut.c
@@ -427,6 +427,7 @@ static void nhrp_shortcut_send_resolution_req(struct nhrp_shortcut *s)
 		cie = nhrp_cie_push(zb, NHRP_CODE_SUCCESS,
 						    &nifp->nat_nbma, &if_ad->addr);
 		cie->prefix_length = 8 * sockunion_get_addrlen(&if_ad->addr);
+		cie->mtu = htons(if_ad->mtu);
 		nhrp_ext_complete(zb, ext);
 	}
 

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -669,7 +669,7 @@ static void show_ip_nhrp_cache(struct nhrp_cache *c, void *pctx)
 
 		if (c->cur.peer
 		    && sockunion_family(&c->cur.remote_nbma_claimed)
-		    	       != AF_UNSPEC)
+		    != AF_UNSPEC)
 			sockunion2str(&c->cur.remote_nbma_claimed,
 				      buf[2], sizeof(buf[2]));
 		else

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -565,7 +565,8 @@ DEFUN(if_no_nhrp_map, if_no_nhrp_map_cmd,
 		return CMD_SUCCESS;
 
 	nhrp_cache_update_binding(c, c->cur.type, -1,
-				  nhrp_peer_get(ifp, &nbma_addr), 0, NULL, NULL);
+				  nhrp_peer_get(ifp, &nbma_addr), 0, NULL,
+				  NULL);
 	return CMD_SUCCESS;
 }
 
@@ -637,8 +638,9 @@ static void show_ip_nhrp_cache(struct nhrp_cache *c, void *pctx)
 
 
 	if (!ctx->count && !ctx->json) {
-		vty_out(vty, "%-8s %-8s %-24s %-24s %-24s %-6s %s\n", "Iface", "Type",
-			"Protocol", "NBMA", "Claimed NBMA", "Flags", "Identity");
+		vty_out(vty, "%-8s %-8s %-24s %-24s %-24s %-6s %s\n", "Iface",
+			"Type", "Protocol", "NBMA", "Claimed NBMA", "Flags",
+			"Identity");
 	}
 	ctx->count++;
 
@@ -649,7 +651,8 @@ static void show_ip_nhrp_cache(struct nhrp_cache *c, void *pctx)
 	else
 		snprintf(buf[1], sizeof(buf[1]), "-");
 
-	if (c->cur.peer && sockunion_family(&c->cur.remote_nbma_claimed) != AF_UNSPEC)
+	if (c->cur.peer
+	    && sockunion_family(&c->cur.remote_nbma_claimed) != AF_UNSPEC)
 		sockunion2str(&c->cur.remote_nbma_claimed,
 			      buf[2], sizeof(buf[2]));
 
@@ -979,7 +982,8 @@ static void clear_nhrp_cache(struct nhrp_cache *c, void *data)
 {
 	struct info_ctx *ctx = data;
 	if (c->cur.type <= NHRP_CACHE_DYNAMIC) {
-		nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL, NULL);
+		nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL,
+					  NULL);
 		ctx->count++;
 	}
 }

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -651,8 +651,7 @@ static void show_ip_nhrp_cache(struct nhrp_cache *c, void *pctx)
 		if (sockunion_family(&nifp->nbma) != AF_UNSPEC) {
 			sockunion2str(&nifp->nbma, buf[1], sizeof(buf[1]));
 			sockunion2str(&nifp->nbma, buf[2], sizeof(buf[2]));
-		}
-		else {
+		} else {
 			snprintf(buf[1], sizeof(buf[1]), "-");
 			snprintf(buf[2], sizeof(buf[2]), "-");
 		}

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -156,6 +156,7 @@ struct nhrp_peer {
 	struct nhrp_vc *vc;
 	struct thread *t_fallback;
 	struct notifier_block vc_notifier, ifp_notifier;
+	struct thread *t_timer;
 };
 
 struct nhrp_packet_parser {
@@ -228,6 +229,7 @@ struct nhrp_cache {
 		struct nhrp_peer *peer;
 		time_t expires;
 		uint32_t mtu;
+		int holding_time;
 	} cur, new;
 };
 
@@ -464,5 +466,7 @@ void nhrp_peer_notify_del(struct nhrp_peer *p, struct notifier_block *);
 void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb);
 void nhrp_peer_send(struct nhrp_peer *p, struct zbuf *zb);
 void nhrp_peer_send_indication(struct interface *ifp, uint16_t, struct zbuf *);
+
+int nhrp_nhs_match_ip(union sockunion *in_ip, struct nhrp_interface *nifp);
 
 #endif

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -226,6 +226,7 @@ struct nhrp_cache {
 	struct {
 		enum nhrp_cache_type type;
 		union sockunion remote_nbma_natoa;
+		union sockunion remote_nbma_claimed;
 		struct nhrp_peer *peer;
 		time_t expires;
 		uint32_t mtu;
@@ -385,7 +386,8 @@ void nhrp_cache_config_foreach(struct interface *ifp,
 void nhrp_cache_set_used(struct nhrp_cache *, int);
 int nhrp_cache_update_binding(struct nhrp_cache *, enum nhrp_cache_type type,
 			      int holding_time, struct nhrp_peer *p,
-			      uint32_t mtu, union sockunion *nbma_natoa);
+			      uint32_t mtu, union sockunion *nbma_natoa,
+			      union sockunion *claimed_nbma);
 void nhrp_cache_notify_add(struct nhrp_cache *c, struct notifier_block *,
 			   notifier_fn_t);
 void nhrp_cache_notify_del(struct nhrp_cache *c, struct notifier_block *);

--- a/nhrpd/zbuf.c
+++ b/nhrpd/zbuf.c
@@ -230,3 +230,15 @@ void zbuf_copy(struct zbuf *zdst, struct zbuf *zsrc, size_t len)
 		return;
 	memcpy(dst, src, len);
 }
+
+void zbuf_copy_peek(struct zbuf *zdst, struct zbuf *zsrc, size_t len)
+{
+	const void *src;
+	void *dst;
+
+	dst = zbuf_pushn(zdst, len);
+	src = zbuf_pulln(zsrc, 0);
+	if (!dst || !src)
+		return;
+	memcpy(dst, src, len);
+}

--- a/nhrpd/zbuf.h
+++ b/nhrpd/zbuf.h
@@ -190,6 +190,7 @@ static inline void zbuf_put_be32(struct zbuf *zb, uint32_t val)
 }
 
 void zbuf_copy(struct zbuf *zb, struct zbuf *src, size_t len);
+void zbuf_copy_peek(struct zbuf *zdst, struct zbuf *zsrc, size_t len);
 
 void zbufq_init(struct zbuf_queue *);
 void zbufq_reset(struct zbuf_queue *);


### PR DESCRIPTION
This series of changes fixes a bunch of errors in handling NAT extensions, causing multiple problems. Especially when inter operating with Cisco routers, the previous code was very broken.

Now NAT handling is tested and working with any combination of:
- FRR as spoke or Hub
- Spoke-Spoke with either FRR or Cisco peer
- The FRR device and/or the other device behind NAT
