### PR TITLE
Revert "zebra: Remove `first_p` which is never used"

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -844,6 +844,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 	const rib_dest_t *dest = rib_dest_from_rnode(rn);
 	const struct nexthop_group *nhg;
 	char up_str[MONOTIME_STRLEN];
+	bool first_p = true;
 	bool nhg_from_backup = false;
 
 	uptime = monotime(NULL);
@@ -996,7 +997,9 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 
 	/* Nexthop information. */
 	for (ALL_NEXTHOPS_PTR(nhg, nexthop)) {
-		if (nhg_from_backup) {
+		if (first_p) {
+			first_p = false;
+		} else if (nhg_from_backup) {
 			vty_out(vty, "  b%c%*c",
 				re_status_output_char(re, nexthop, is_fib),
 				len - 3 + (2 * nexthop_level(nexthop)), ' ');


### PR DESCRIPTION
This reverts commit 8617eb7c5ff9fe9ae1efb69af1493585d69a37f5.