### PR TITLE
Fix aborts when using nb_running_get_entry during validation stage

### DIFF
--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -131,7 +131,7 @@ int isis_instance_area_address_create(struct nb_cb_create_args *args)
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		area = nb_running_get_entry(args->dnode, NULL, true);
+		area = nb_running_get_entry(args->dnode, NULL, false);
 		if (area == NULL)
 			return NB_ERR_VALIDATION;
 		addr.addr_len = dotformat2buff(buff, net_title);

--- a/pathd/path_nb_config.c
+++ b/pathd/path_nb_config.c
@@ -302,7 +302,6 @@ int pathd_srte_policy_binding_sid_modify(struct nb_cb_modify_args *args)
 	struct srte_policy *policy;
 	mpls_label_t binding_sid;
 
-	policy = nb_running_get_entry(args->dnode, NULL, true);
 	binding_sid = yang_dnode_get_uint32(args->dnode, NULL);
 
 	switch (args->event) {
@@ -315,6 +314,7 @@ int pathd_srte_policy_binding_sid_modify(struct nb_cb_modify_args *args)
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
+		policy = nb_running_get_entry(args->dnode, NULL, true);
 		srte_policy_update_binding_sid(policy, binding_sid);
 		SET_FLAG(policy->flags, F_POLICY_MODIFIED);
 		break;
@@ -668,11 +668,11 @@ int pathd_srte_policy_candidate_path_segment_list_name_modify(
 	struct srte_candidate *candidate;
 	const char *segment_list_name;
 
-	candidate = nb_running_get_entry(args->dnode, NULL, true);
-	segment_list_name = yang_dnode_get_string(args->dnode, NULL);
-
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
+
+	candidate = nb_running_get_entry(args->dnode, NULL, true);
+	segment_list_name = yang_dnode_get_string(args->dnode, NULL);
 
 	candidate->segment_list = srte_segment_list_find(segment_list_name);
 	candidate->lsp->segment_list = candidate->segment_list;

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2394,13 +2394,6 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 	struct ipaddr group_addr;
 	const struct lyd_node *if_dnode;
 
-	iif = nb_running_get_entry(args->dnode, NULL, true);
-	pim_iifp = iif->info;
-	pim = pim_iifp->pim;
-
-	oifname = yang_dnode_get_string(args->dnode, NULL);
-	oif = if_lookup_by_name(oifname, pim->vrf_id);
-
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
@@ -2411,6 +2404,17 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 		}
 
 #ifdef PIM_ENFORCE_LOOPFREE_MFC
+		iif = nb_running_get_entry(args->dnode, NULL, false);
+		if (!iif) {
+			return NB_OK;
+		}
+
+		pim_iifp = iif->info;
+		pim = pim_iifp->pim;
+
+		oifname = yang_dnode_get_string(args->dnode, NULL);
+		oif = if_lookup_by_name(oifname, pim->vrf_id);
+
 		if (oif && (iif->ifindex == oif->ifindex)) {
 			strlcpy(args->errmsg,
 				"% IIF same as OIF and loopfree enforcement is enabled; rejecting",
@@ -2423,6 +2427,12 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
+		iif = nb_running_get_entry(args->dnode, NULL, true);
+		pim_iifp = iif->info;
+		pim = pim_iifp->pim;
+
+		oifname = yang_dnode_get_string(args->dnode, NULL);
+		oif = if_lookup_by_name(oifname, pim->vrf_id);
 		if (!oif) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "No such interface name %s",

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -597,6 +597,7 @@ module frr-zebra {
 
   grouping ribs {
     container ribs {
+      config false;
       description
         "RIBs supported by FRR.";
       list rib {
@@ -617,7 +618,6 @@ module frr-zebra {
 
         list route {
           key "prefix";
-          config false;
           leaf prefix {
             type inet:ip-prefix;
             description

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -401,11 +401,21 @@ const struct frr_yang_module_info frr_zebra_info = {
 		{
 			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib",
 			.cbs = {
-				.create = lib_vrf_zebra_ribs_rib_create,
-				.destroy = lib_vrf_zebra_ribs_rib_destroy,
 				.get_next = lib_vrf_zebra_ribs_rib_get_next,
 				.get_keys = lib_vrf_zebra_ribs_rib_get_keys,
 				.lookup_entry = lib_vrf_zebra_ribs_rib_lookup_entry,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/afi-safi-name",
+			.cbs = {
+				.get_elem = lib_vrf_zebra_ribs_rib_afi_safi_name_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/table-id",
+			.cbs = {
+				.get_elem = lib_vrf_zebra_ribs_rib_table_id_get_elem,
 			}
 		},
 		{

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -149,12 +149,14 @@ struct yang_data *lib_interface_zebra_state_remote_vtep_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *lib_interface_zebra_state_mcast_group_get_elem(
 	struct nb_cb_get_elem_args *args);
-int lib_vrf_zebra_ribs_rib_create(struct nb_cb_create_args *args);
-int lib_vrf_zebra_ribs_rib_destroy(struct nb_cb_destroy_args *args);
 const void *lib_vrf_zebra_ribs_rib_get_next(struct nb_cb_get_next_args *args);
 int lib_vrf_zebra_ribs_rib_get_keys(struct nb_cb_get_keys_args *args);
 const void *
 lib_vrf_zebra_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_afi_safi_name_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_table_id_get_elem(struct nb_cb_get_elem_args *args);
 const void *
 lib_vrf_zebra_ribs_rib_route_get_next(struct nb_cb_get_next_args *args);
 int lib_vrf_zebra_ribs_rib_route_get_keys(struct nb_cb_get_keys_args *args);

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1140,61 +1140,6 @@ int lib_interface_zebra_bandwidth_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib
- */
-int lib_vrf_zebra_ribs_rib_create(struct nb_cb_create_args *args)
-{
-	struct vrf *vrf;
-	afi_t afi;
-	safi_t safi;
-	struct zebra_vrf *zvrf;
-	struct zebra_router_table *zrt;
-	uint32_t table_id;
-	const char *afi_safi_name;
-
-	vrf = nb_running_get_entry(args->dnode, NULL, false);
-	zvrf = vrf_info_lookup(vrf->vrf_id);
-	table_id = yang_dnode_get_uint32(args->dnode, "./table-id");
-	if (!table_id)
-		table_id = zvrf->table_id;
-
-	afi_safi_name = yang_dnode_get_string(args->dnode, "./afi-safi-name");
-	yang_afi_safi_identity2value(afi_safi_name, &afi, &safi);
-
-	zrt = zebra_router_find_zrt(zvrf, table_id, afi, safi);
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-		if (!zrt) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "vrf %s table is not found.", vrf->name);
-			return NB_ERR_VALIDATION;
-		}
-		break;
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-		break;
-	case NB_EV_APPLY:
-
-		nb_running_set_entry(args->dnode, zrt);
-
-		break;
-	}
-
-	return NB_OK;
-}
-
-int lib_vrf_zebra_ribs_rib_destroy(struct nb_cb_destroy_args *args)
-{
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
-
-	nb_running_unset_entry(args->dnode);
-
-	return NB_OK;
-}
-
-/*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:zebra/l3vni-id
  */
 int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -214,6 +214,29 @@ lib_vrf_zebra_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args)
 }
 
 /*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/afi-safi-name
+ */
+struct yang_data *
+lib_vrf_zebra_ribs_rib_afi_safi_name_get_elem(struct nb_cb_get_elem_args *args)
+{
+	const struct zebra_router_table *zrt = args->list_entry;
+
+	return yang_data_new_string(args->xpath,
+		yang_afi_safi_value2identity(zrt->afi, zrt->safi));
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/table-id
+ */
+struct yang_data *
+lib_vrf_zebra_ribs_rib_table_id_get_elem(struct nb_cb_get_elem_args *args)
+{
+	const struct zebra_router_table *zrt = args->list_entry;
+
+	return yang_data_new_uint32(args->xpath, zrt->tableid);
+}
+
+/*
  * XPath: /frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route
  */
 const void *


### PR DESCRIPTION
There are places in the code where function `nb_running_get_entry` is used
with `abort_if_not_found` set to `true` during the config validation stage.
This is incorrect because when used in transactional CLI, the running
entry won't be set until the apply stage, and such usage leads to a crash.

The first commit fixes simple things like moving the usage of `nb_running_get_entry`
to the apply stage, or changing `abort_if_not_found` to `false` where possible.

The second one also fixes the incorrect usage of `nb_running_get_entry` by
making zebra RIBs state-only in the YANG model. The detailed description is in the commit.

This PR fixes https://github.com/FRRouting/frr/issues/8228 at least partially – there should be
no crashes anymore.