### PR TITLE
pimd: support bundle commands added

### DIFF
--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -80,6 +80,25 @@ CMD_LIST_END
 # CMD_LIST_END
 
 # PIM Support Bundle Command List
-# PROC_NAME:pim
-# CMD_LIST_START
-# CMD_LIST_END
+PROC_NAME:pim
+CMD_LIST_START
+show ip multicast
+show ip pim interface
+show ip pim interface traffic
+show ip pim nexthop
+show ip pim neighbor
+show ip pim bsr
+show ip pim bsrp-info
+show ip pim bsm-database
+show ip pim rp-info
+show ip igmp groups
+show ip igmp interface
+show ip igmp join
+show ip igmp sources
+show ip pim upstream
+show ip mroute
+show ip pim join
+show ip pim state
+show ip pim statistics
+show ip pim rpf
+CMD_LIST_END


### PR DESCRIPTION
PIM Support Bundle commands are added in support_bundle_commands.conf file.
It will help us in debugging PIM test Failures.

Signed-off-by: Sai Gomathi <nsaigomathi@vmware.com>