### PR TITLE
tests: iproute2 VRF capability check for topotests

### DIFF
--- a/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
+++ b/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
@@ -115,7 +115,7 @@ sys.path.append(os.path.join(CWD, "../lib/"))
 # Import topogen and topotest helpers
 from lib.topogen import Topogen, get_topogen
 from mininet.topo import Topo
-
+from lib.topotest import iproute2_is_vrf_capable
 from lib.common_config import (
     step,
     verify_rib,
@@ -214,6 +214,10 @@ def setup_module(mod):
     result = required_linux_kernel_version("4.15")
     if result is not True:
         pytest.skip("Kernel requirements are not met")
+
+    # iproute2 needs to support VRFs for this suite to run.
+    if not iproute2_is_vrf_capable():
+        pytest.skip("Installed iproute2 version does not support VRFs")
 
     testsuite_run_time = time.asctime(time.localtime(time.time()))
     logger.info("Testsuite start time: {}".format(testsuite_run_time))

--- a/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
+++ b/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
@@ -71,7 +71,7 @@ sys.path.append(os.path.join(CWD, "../lib/"))
 # Import topogen and topotest helpers
 from lib.topogen import Topogen, get_topogen
 from mininet.topo import Topo
-
+from lib.topotest import iproute2_is_vrf_capable
 from lib.common_config import (
     step,
     verify_rib,
@@ -163,6 +163,10 @@ def setup_module(mod):
     result = required_linux_kernel_version("4.14")
     if result is not True:
         pytest.skip("Kernel requirements are not met")
+
+    # iproute2 needs to support VRFs for this suite to run.
+    if not iproute2_is_vrf_capable():
+        pytest.skip("Installed iproute2 version does not support VRFs")
 
     testsuite_run_time = time.asctime(time.localtime(time.time()))
     logger.info("Testsuite start time: {}".format(testsuite_run_time))

--- a/tests/topotests/isis-topo1-vrf/test_isis_topo1_vrf.py
+++ b/tests/topotests/isis-topo1-vrf/test_isis_topo1_vrf.py
@@ -40,6 +40,8 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
+from lib.topotest import iproute2_is_vrf_capable
+from lib.common_config import required_linux_kernel_version
 
 from mininet.topo import Topo
 
@@ -193,17 +195,20 @@ def test_isis_route_installation():
 
 
 def test_isis_linux_route_installation():
-
-    dist = platform.dist()
-
-    if dist[1] == "16.04":
-        pytest.skip("Kernel not supported for vrf")
-
     "Check whether all expected routes are present and installed in the OS"
     tgen = get_topogen()
     # Don't run this test if we have any failure.
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
+
+    # Required linux kernel version for this suite to run.
+    result = required_linux_kernel_version("4.15")
+    if result is not True:
+        pytest.skip("Kernel requirements are not met")
+
+    # iproute2 needs to support VRFs for this suite to run.
+    if not iproute2_is_vrf_capable():
+        pytest.skip("Installed iproute2 version does not support VRFs")
 
     logger.info("Checking routers for installed ISIS vrf routes in OS")
     # Check for routes in `ip route show vrf {}-cust1`
@@ -236,17 +241,20 @@ def test_isis_route6_installation():
 
 
 def test_isis_linux_route6_installation():
-
-    dist = platform.dist()
-
-    if dist[1] == "16.04":
-        pytest.skip("Kernel not supported for vrf")
-
     "Check whether all expected routes are present and installed in the OS"
     tgen = get_topogen()
     # Don't run this test if we have any failure.
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
+
+    # Required linux kernel version for this suite to run.
+    result = required_linux_kernel_version("4.15")
+    if result is not True:
+        pytest.skip("Kernel requirements are not met")
+
+    # iproute2 needs to support VRFs for this suite to run.
+    if not iproute2_is_vrf_capable():
+        pytest.skip("Installed iproute2 version does not support VRFs")
 
     logger.info("Checking routers for installed ISIS vrf IPv6 routes in OS")
     # Check for routes in `ip -6 route show vrf {}-cust1`

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -516,6 +516,44 @@ def normalize_text(text):
     return text
 
 
+def is_linux():
+    """
+    Parses unix name output to check if running on GNU/Linux.
+
+    Returns True if running on Linux, returns False otherwise.
+    """
+
+    if os.uname()[0] == "Linux":
+        return True
+    return False
+
+
+def iproute2_is_vrf_capable():
+    """
+    Checks if the iproute2 version installed on the system is capable of
+    handling VRFs by interpreting the output of the 'ip' utility found in PATH.
+
+    Returns True if capability can be detected, returns False otherwise.
+    """
+
+    if is_linux():
+        try:
+            subp = subprocess.Popen(
+                ["ip", "route", "show", "vrf"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                encoding="utf-8"
+            )
+            iproute2_err = subp.communicate()[1].splitlines()[0].split()[0]
+
+            if iproute2_err != "Error:":
+                return True
+        except Exception:
+            pass
+    return False
+
+
 def module_present_linux(module, load):
     """
     Returns whether `module` is present.


### PR DESCRIPTION
On older releases of certain distributions (i.e. Ubuntu 16.04 LTS) the ``iproute2`` utility does not have support for VRFs. This can lead to test failures on systems with backported kernels (Ubuntu HWE, Debian backports, etc.), since the tests are skipped solely based on kernel versions. This PR introduces a check for VRF handling capabilities on the ``iproute2`` utility present in the PATH and example applications in the ``bgp_multi_vrf_topo1`` and  ``bgp_multi_vrf_topo2`` topotests.