### PR TITLE
Fix bgp metric

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -454,17 +454,21 @@ static void bgp_nht_ifp_table_handle(struct bgp *bgp,
 		bnc->last_update = bgp_clock();
 		bnc->change_flags = 0;
 
+		/*
+		 * For interface based routes ( ala the v6 LL routes
+		 * that this was written for ) the metric received
+		 * for the connected route is 0 not 1.
+		 */
+		bnc->metric = 0;
 		if (up) {
 			SET_FLAG(bnc->flags, BGP_NEXTHOP_VALID);
 			SET_FLAG(bnc->change_flags, BGP_NEXTHOP_CHANGED);
-			bnc->metric = 1;
 			bnc->nexthop_num = 1;
 		} else {
 			UNSET_FLAG(bnc->flags, BGP_NEXTHOP_PEER_NOTIFIED);
 			UNSET_FLAG(bnc->flags, BGP_NEXTHOP_VALID);
 			SET_FLAG(bnc->change_flags, BGP_NEXTHOP_CHANGED);
 			bnc->nexthop_num = 0;
-			bnc->metric = 0;
 		}
 
 		evaluate_paths(bnc);

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -685,7 +685,8 @@ static int sharp_nexthop_update(ZAPI_CALLBACK_ARGS)
 		return 0;
 	}
 
-	zlog_debug("Received update for %pFX", &nhr.prefix);
+	zlog_debug("Received update for %pFX metric: %u", &nhr.prefix,
+		   nhr.metric);
 
 	nht = sharp_nh_tracker_get(&nhr.prefix);
 	nht->nhop_num = nhr.nexthop_num;


### PR DESCRIPTION
see individual commits.  But the recent change to handling v6 LL nexthop tracking via interface up/down events modified the metric received.  put it back to what it was before