### PR TITLE
ldpd: Add support for the read-only snmp mib objects that are statistics

### DIFF
--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -435,7 +435,25 @@ struct ldp_stats {
 	uint32_t		 labelrel_rcvd;
 	uint32_t		 labelabreq_sent;
 	uint32_t		 labelabreq_rcvd;
+	uint32_t		 unknown_tlv;
+	uint32_t		 unknown_msg;
 
+};
+
+struct ldp_entity_stats {
+	uint32_t		 session_attempts;
+	uint32_t		 session_rejects_hello;
+	uint32_t		 session_rejects_ad;
+	uint32_t		 session_rejects_max_pdu;
+	uint32_t		 session_rejects_lr;
+	uint32_t		 bad_ldp_id;
+	uint32_t		 bad_pdu_len;
+	uint32_t		 bad_msg_len;
+	uint32_t		 bad_tlv_len;
+	uint32_t		 malformed_tlv;
+	uint32_t		 keepalive_timer_exp;
+	uint32_t		 shutdown_rcv_notify;
+	uint32_t		 shutdown_send_notify;
 };
 
 struct l2vpn_if {
@@ -565,6 +583,7 @@ struct ldpd_conf {
 	uint16_t		 wait_for_sync_interval;
 	int			 flags;
 	time_t			 config_change_time;
+	struct ldp_entity_stats  stats;
 	QOBJ_FIELDS
 };
 DECLARE_QOBJ_TYPE(ldpd_conf)

--- a/ldpd/notification.c
+++ b/ldpd/notification.c
@@ -69,6 +69,36 @@ send_notification_full(struct tcp_conn *tcp, struct notify_msg *nm)
 		tcp->nbr->stats.notif_sent++;
 	}
 
+	/* update SNMP session counters */
+	switch (nm->status_code) {
+	case S_NO_HELLO:
+		leconf->stats.session_rejects_hello++;
+		break;
+	case S_BAD_LDP_ID:
+		leconf->stats.bad_ldp_id++;
+		break;
+	case S_BAD_PDU_LEN:
+		leconf->stats.bad_pdu_len++;
+		break;
+	case S_BAD_MSG_LEN:
+		leconf->stats.bad_msg_len++;
+		break;
+	case S_BAD_TLV_LEN:
+		leconf->stats.bad_tlv_len++;
+		break;
+	case S_BAD_TLV_VAL:
+		leconf->stats.malformed_tlv++;
+		break;
+	case S_KEEPALIVE_TMR:
+		leconf->stats.keepalive_timer_exp++;
+		break;
+	case S_SHUTDOWN:
+		leconf->stats.shutdown_send_notify++;
+		break;
+	default:
+		break;
+	}
+
 	evbuf_enqueue(&tcp->wbuf, buf);
 }
 
@@ -122,6 +152,7 @@ recv_notification(struct nbr *nbr, char *buf, uint16_t len)
 
 	if (len < STATUS_SIZE) {
 		session_shutdown(nbr, S_BAD_MSG_LEN, msg.id, msg.type);
+		leconf->stats.bad_msg_len++;
 		return (-1);
 	}
 	memcpy(&st, buf, sizeof(st));
@@ -129,6 +160,7 @@ recv_notification(struct nbr *nbr, char *buf, uint16_t len)
 	if (ntohs(st.length) > STATUS_SIZE - TLV_HDR_SIZE ||
 	    ntohs(st.length) > len - TLV_HDR_SIZE) {
 		session_shutdown(nbr, S_BAD_TLV_LEN, msg.id, msg.type);
+		leconf->stats.bad_tlv_len++;
 		return (-1);
 	}
 	buf += STATUS_SIZE;
@@ -145,6 +177,7 @@ recv_notification(struct nbr *nbr, char *buf, uint16_t len)
 
 		if (len < sizeof(tlv)) {
 			session_shutdown(nbr, S_BAD_TLV_LEN, msg.id, msg.type);
+			leconf->stats.bad_tlv_len++;
 			return (-1);
 		}
 
@@ -153,6 +186,7 @@ recv_notification(struct nbr *nbr, char *buf, uint16_t len)
 		tlv_len = ntohs(tlv.length);
 		if (tlv_len + TLV_HDR_SIZE > len) {
 			session_shutdown(nbr, S_BAD_TLV_LEN, msg.id, msg.type);
+			leconf->stats.bad_tlv_len++;
 			return (-1);
 		}
 		buf += TLV_HDR_SIZE;
@@ -182,14 +216,17 @@ recv_notification(struct nbr *nbr, char *buf, uint16_t len)
 			if (tlen != tlv_len) {
 				session_shutdown(nbr, S_BAD_TLV_VAL,
 				    msg.id, msg.type);
+				leconf->stats.bad_tlv_len++;
 				return (-1);
 			}
 			nm.flags |= F_NOTIF_FEC;
 			break;
 		default:
-			if (!(ntohs(tlv.type) & UNKNOWN_FLAG))
+			if (!(ntohs(tlv.type) & UNKNOWN_FLAG)) {
+				nbr->stats.unknown_tlv++;
 				send_notification_rtlvs(nbr, S_UNKNOWN_TLV,
 				    msg.id, msg.type, tlv_type, tlv_len, buf);
+			}
 			/* ignore unknown tlv */
 			break;
 		}
@@ -243,20 +280,56 @@ recv_notification(struct nbr *nbr, char *buf, uint16_t len)
 		 * initialization, it SHOULD transmit a Shutdown message and
 		 * then close the transport connection".
 		 */
-		if (nbr->state != NBR_STA_OPER && nm.status_code == S_SHUTDOWN)
+		if (nbr->state != NBR_STA_OPER &&
+		    nm.status_code == S_SHUTDOWN) {
+			leconf->stats.session_attempts++;
 			send_notification(nbr->tcp, S_SHUTDOWN,
 			    msg.id, msg.type);
+		}
 
+		leconf->stats.shutdown_rcv_notify++;
 		nbr_fsm(nbr, NBR_EVT_CLOSE_SESSION);
 		return (-1);
 	}
 
-	/* lde needs to know about a few notification messages */
+	/* lde needs to know about a few notification messages
+	 * and update SNMP session counters
+	 */
 	switch (nm.status_code) {
 	case S_PW_STATUS:
 	case S_ENDOFLIB:
 		ldpe_imsg_compose_lde(IMSG_NOTIFICATION, nbr->peerid, 0,
 		    &nm, sizeof(nm));
+		break;
+	case S_NO_HELLO:
+		leconf->stats.session_rejects_hello++;
+		break;
+	case S_PARM_ADV_MODE:
+		leconf->stats.session_rejects_ad++;
+		break;
+	case S_MAX_PDU_LEN:
+		leconf->stats.session_rejects_max_pdu++;
+		break;
+	case S_PARM_L_RANGE:
+		leconf->stats.session_rejects_lr++;
+		break;
+	case S_BAD_LDP_ID:
+		leconf->stats.bad_ldp_id++;
+		break;
+	case S_BAD_PDU_LEN:
+		leconf->stats.bad_pdu_len++;
+		break;
+	case S_BAD_MSG_LEN:
+		leconf->stats.bad_msg_len++;
+		break;
+	case S_BAD_TLV_LEN:
+		leconf->stats.bad_tlv_len++;
+		break;
+	case S_BAD_TLV_VAL:
+		leconf->stats.malformed_tlv++;
+		break;
+	case S_SHUTDOWN:
+		leconf->stats.shutdown_rcv_notify++;
 		break;
 	default:
 		break;

--- a/tests/topotests/ldp-snmp/test_ldp_snmp_topo1.py
+++ b/tests/topotests/ldp-snmp/test_ldp_snmp_topo1.py
@@ -301,6 +301,41 @@ def test_r1_ldp_entity_table():
         'mplsLdpEntityRowStatus', ['createAndGo(4)'])
 
 
+def test_r1_ldp_entity_stats_table():
+    "Test mplsLdpEntityStatsTable"
+    tgen = get_topogen()
+
+    r1 = tgen.net.get("r1")
+    r1_snmp = SnmpTester(r1, "1.1.1.1", "public", "2c")
+
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsSessionAttempts', ['0'])
+    assert r1_snmp.test_oid_walk(
+       'mplsLdpEntityStatsSessionRejectedNoHelloErrors', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsSessionRejectedAdErrors', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsSessionRejectedMaxPduErrors', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsSessionRejectedLRErrors', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsBadLdpIdentifierErrors', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsBadPduLengthErrors', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsBadMessageLengthErrors', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsBadTlvLengthErrors', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsMalformedTlvValueErrors', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsKeepAliveTimerExpErrors', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsShutdownReceivedNotifications', ['0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpEntityStatsShutdownSentNotifications', ['0'])
+
+
 def test_r1_ldp_peer_table():
     "Test mplsLdpPeerTable"
     tgen = get_topogen()
@@ -340,6 +375,19 @@ def test_r1_ldp_session_table():
         ['4096 octets', '4096 octets'])
     assert r1_snmp.test_oid_walk('mplsLdpSessionDiscontinuityTime',
         ['(0) 0:00:00.00', '(0) 0:00:00.00'])
+
+
+def test_r1_ldp_session_stats_table():
+    "Test mplsLdpSessionStatsTable"
+    tgen = get_topogen()
+
+    r1 = tgen.net.get("r1")
+    r1_snmp = SnmpTester(r1, "1.1.1.1", "public", "2c")
+
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpSessionStatsUnknownMesTypeErrors', ['0', '0'])
+    assert r1_snmp.test_oid_walk(
+        'mplsLdpSessionStatsUnknownTlvErrors', ['0', '0'])
 
 
 def test_r1_ldp_hello_adjacency_table():


### PR DESCRIPTION
ldpd: Add support for the read-only snmp mib objects that are statistics

Add support for the read-only snmp mib objects as described in RFC 3815
that are statistics.

Signed-off-by: Lynne Morrison <lynne@voltanet.io>
Signed-off-by: Karen Schoener <karen@voltanet.io>