### PR TITLE
lib: output unique IDs in log messages

### DIFF
--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -532,6 +532,28 @@ DEFUN (no_config_log_timestamp_precision,
 	return CMD_SUCCESS;
 }
 
+DEFPY (config_log_ec,
+       config_log_ec_cmd,
+       "[no] log error-category",
+       NO_STR
+       "Logging control\n"
+       "Prefix log message text with [EC 9999] code\n")
+{
+	zlog_set_prefix_ec(!no);
+	return CMD_SUCCESS;
+}
+
+DEFPY (config_log_xid,
+       config_log_xid_cmd,
+       "[no] log unique-id",
+       NO_STR
+       "Logging control\n"
+       "Prefix log message text with [XXXXX-XXXXX] identifier\n")
+{
+	zlog_set_prefix_xid(!no);
+	return CMD_SUCCESS;
+}
+
 DEFPY (config_log_filterfile,
        config_log_filterfile_cmd,
        "log filtered-file FILENAME [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]",
@@ -699,6 +721,11 @@ void log_config_write(struct vty *vty)
 	if (zt_file.ts_subsec > 0)
 		vty_out(vty, "log timestamp precision %d\n",
 			zt_file.ts_subsec);
+
+	if (!zlog_get_prefix_ec())
+		vty_out(vty, "no log error-category\n");
+	if (!zlog_get_prefix_xid())
+		vty_out(vty, "no log unique-id\n");
 }
 
 static int log_vty_init(const char *progname, const char *protoname,
@@ -706,6 +733,9 @@ static int log_vty_init(const char *progname, const char *protoname,
 {
 	zlog_progname = progname;
 	zlog_protoname = protoname;
+
+	zlog_set_prefix_ec(true);
+	zlog_set_prefix_xid(true);
 
 	zlog_filterfile_init(&zt_filterfile);
 
@@ -737,6 +767,8 @@ void log_cmd_init(void)
 	install_element(CONFIG_NODE, &no_config_log_record_priority_cmd);
 	install_element(CONFIG_NODE, &config_log_timestamp_precision_cmd);
 	install_element(CONFIG_NODE, &no_config_log_timestamp_precision_cmd);
+	install_element(CONFIG_NODE, &config_log_ec_cmd);
+	install_element(CONFIG_NODE, &config_log_xid_cmd);
 
 	install_element(VIEW_NODE, &show_log_filter_cmd);
 	install_element(CONFIG_NODE, &log_filter_cmd);

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -1260,27 +1260,36 @@ static int nb_callback_configuration(struct nb_context *context,
 	}
 
 	if (ret != NB_OK) {
-		int priority;
-		enum lib_log_refs ref;
-
 		yang_dnode_get_path(dnode, xpath, sizeof(xpath));
 
 		switch (event) {
 		case NB_EV_VALIDATE:
-			priority = LOG_WARNING;
-			ref = EC_LIB_NB_CB_CONFIG_VALIDATE;
+			flog_warn(EC_LIB_NB_CB_CONFIG_VALIDATE,
+				  "error processing configuration change: error [%s] event [%s] operation [%s] xpath [%s]%s%s",
+				  nb_err_name(ret), nb_event_name(event),
+				  nb_operation_name(operation), xpath,
+				  errmsg[0] ? " message: " : "", errmsg);
 			break;
 		case NB_EV_PREPARE:
-			priority = LOG_WARNING;
-			ref = EC_LIB_NB_CB_CONFIG_PREPARE;
+			flog_warn(EC_LIB_NB_CB_CONFIG_PREPARE,
+				  "error processing configuration change: error [%s] event [%s] operation [%s] xpath [%s]%s%s",
+				  nb_err_name(ret), nb_event_name(event),
+				  nb_operation_name(operation), xpath,
+				  errmsg[0] ? " message: " : "", errmsg);
 			break;
 		case NB_EV_ABORT:
-			priority = LOG_WARNING;
-			ref = EC_LIB_NB_CB_CONFIG_ABORT;
+			flog_warn(EC_LIB_NB_CB_CONFIG_ABORT,
+				  "error processing configuration change: error [%s] event [%s] operation [%s] xpath [%s]%s%s",
+				  nb_err_name(ret), nb_event_name(event),
+				  nb_operation_name(operation), xpath,
+				  errmsg[0] ? " message: " : "", errmsg);
 			break;
 		case NB_EV_APPLY:
-			priority = LOG_ERR;
-			ref = EC_LIB_NB_CB_CONFIG_APPLY;
+			flog_err(EC_LIB_NB_CB_CONFIG_APPLY,
+				 "error processing configuration change: error [%s] event [%s] operation [%s] xpath [%s]%s%s",
+				 nb_err_name(ret), nb_event_name(event),
+				 nb_operation_name(operation), xpath,
+				 errmsg[0] ? " message: " : "", errmsg);
 			break;
 		default:
 			flog_err(EC_LIB_DEVELOPMENT,
@@ -1288,15 +1297,6 @@ static int nb_callback_configuration(struct nb_context *context,
 				 event, xpath);
 			exit(1);
 		}
-
-		flog(priority, ref,
-		     "error processing configuration change: error [%s] event [%s] operation [%s] xpath [%s]",
-		     nb_err_name(ret), nb_event_name(event),
-		     nb_operation_name(operation), xpath);
-		if (strlen(errmsg) > 0)
-			flog(priority, ref,
-			     "error processing configuration change: %s",
-			     errmsg);
 	}
 
 	return ret;

--- a/lib/printfrr.h
+++ b/lib/printfrr.h
@@ -160,6 +160,30 @@ void printfrr_ext_reg(const struct printfrr_ext *);
 	}                                                                      \
 	/* end */
 
+/* fbuf helper functions */
+
+static inline ssize_t bputs(struct fbuf *buf, const char *str)
+{
+	size_t len = strlen(str);
+	size_t ncopy;
+
+	if (!buf)
+		return len;
+
+	ncopy = MIN(len, (size_t)(buf->buf + buf->len - buf->pos));
+	memcpy(buf->pos, str, ncopy);
+	buf->pos += ncopy;
+
+	return len;
+}
+
+static inline ssize_t bputch(struct fbuf *buf, char ch)
+{
+	if (buf && buf->pos < buf->buf + buf->len)
+		*buf->pos++ = ch;
+	return 1;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/xref.c
+++ b/lib/xref.c
@@ -93,8 +93,6 @@ static void xref_add_one(const struct xref *xref)
 		q = memrchr(filename, '/', p - filename);
 		if (q)
 			filename = q + 1;
-		else
-			filename = p + 1;
 	}
 
 	SHA256_Init(&sha);

--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -137,8 +137,6 @@ static inline void zlog_ref(const struct xref_logmsg *xref,
 
 #define flog_err_sys(ferr_id, format, ...)                                     \
 	flog_err(ferr_id, format, ##__VA_ARGS__)
-#define flog(priority, ferr_id, format, ...)                                   \
-	zlog(priority, "[EC %u] " format, ferr_id, ##__VA_ARGS__)
 
 extern void zlog_sigsafe(const char *text, size_t len);
 


### PR DESCRIPTION
This adds `[XXXXX-XXXXX]` in front of log messages.  Configurable (default on) via `no log unique-id`.  Also adds `[no] log error-category` to turn `[EC ...]` off (default on).

As a side effect, `flog()` is removed since it didn't jive well with recording the EC in a static variable; since there was only one use of it in the NB code, the simplicity of just removing it won out over cooking up a complicated solution :smile: