### PR TITLE
tests: docker fixes & improvements

### DIFF
--- a/tests/topotests/Dockerfile
+++ b/tests/topotests/Dockerfile
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         libreadline-dev \
         libc-ares-dev \
         libcap-dev \
+        libelf-dev \
         man \
         mininet \
         pkg-config \

--- a/tests/topotests/docker/frr-topotests.sh
+++ b/tests/topotests/docker/frr-topotests.sh
@@ -132,6 +132,7 @@ if [ -z "$TOPOTEST_FRR" ]; then
 		echo "frr-topotests only works if you have your tree in git." >&2
 		exit 1
 	fi
+	git -C "$TOPOTEST_FRR" ls-files -z > "${TOPOTEST_LOGS}/git-ls-files"
 fi
 
 if [ -z "$TOPOTEST_BUILDCACHE" ]; then

--- a/tests/topotests/docker/inner/compile_frr.sh
+++ b/tests/topotests/docker/inner/compile_frr.sh
@@ -34,19 +34,15 @@ CDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [ "${TOPOTEST_CLEAN}" != "0" ]; then
 	log_info "Cleaning FRR builddir..."
-	rm -rf $FRR_SYNC_DIR $FRR_BUILD_DIR &> /dev/null
+	rm -rf $FRR_BUILD_DIR &> /dev/null
 fi
 
 log_info "Syncing FRR source with host..."
-mkdir -p $FRR_SYNC_DIR
-rsync -a --info=progress2 \
-	--exclude '*.o' \
-	--exclude '*.lo'\
-	--chown root:root \
-	$FRR_HOST_DIR/. $FRR_SYNC_DIR/
-(cd $FRR_SYNC_DIR && git clean -xdf > /dev/null)
 mkdir -p $FRR_BUILD_DIR
-rsync -a --info=progress2 --chown root:root $FRR_SYNC_DIR/. $FRR_BUILD_DIR/
+rsync -a --info=progress2 \
+	--from0 --files-from=/tmp/git-ls-files \
+	--chown root:root \
+	$FRR_HOST_DIR/. $FRR_BUILD_DIR/
 
 cd "$FRR_BUILD_DIR" || \
 	log_fatal "failed to find frr directory"

--- a/tests/topotests/docker/inner/funcs.sh
+++ b/tests/topotests/docker/inner/funcs.sh
@@ -23,7 +23,6 @@
 # SOFTWARE.
 
 FRR_HOST_DIR=/root/host-frr
-FRR_SYNC_DIR=/root/persist/frr-sync
 FRR_BUILD_DIR=/root/persist/frr-build
 
 if [ ! -L "/root/frr" ]; then


### PR DESCRIPTION
- libelf-dev was missing
- the rsync mechanism didn't support git worktrees (and was unnecessarily complicated)