### PR TITLE
tests: Fix isis_snmp to not look at ifindex

### DIFF
--- a/tests/topotests/isis-snmp/test_isis_snmp.py
+++ b/tests/topotests/isis-snmp/test_isis_snmp.py
@@ -236,7 +236,6 @@ def test_r1_scalar_snmp():
 
 
 circtable_test = {
-    "isisCircIfIndex": ["2", "3", "1"],
     "isisCircAdminState": ["on(1)", "on(1)", "on(1)"],
     "isisCircExistState": ["active(1)", "active(1)", "active(1)"],
     "isisCircType": ["broadcast(1)", "ptToPt(2)", "staticIn(3)"],


### PR DESCRIPTION
Fix the test to not look at the ifindex at all.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>