### PR TITLE
bgpd,zebra: Cleanup remote ES state when advertise-all-vni is disabled

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4065,6 +4065,12 @@ static void cleanup_vni_on_disable(struct hash_bucket *bucket, struct bgp *bgp)
 	/* Remove EVPN routes and schedule for processing. */
 	delete_routes_for_vni(bgp, vpn);
 
+	/*
+	 * Above function deletes remote type-1 routes imported into VNI.
+	 * Now cleanup remote ES states created because of these routes.
+	 */
+	bgp_evpn_evi_es_remote_cleanup(bgp, vpn);
+
 	/* Clear "live" flag and see if hash needs to be freed. */
 	UNSET_FLAG(vpn->flags, VNI_FLAG_LIVE);
 	if (!is_vni_configured(vpn))
@@ -5547,6 +5553,12 @@ int bgp_evpn_local_vni_del(struct bgp *bgp, vni_t vni)
 	 * withdraw from peers).
 	 */
 	delete_routes_for_vni(bgp, vpn);
+
+	/*
+	 * Above function deletes remote type-1 routes imported into VNI.
+	 * Now cleanup remote ES states created because of these routes.
+	 */
+	bgp_evpn_evi_es_remote_cleanup(bgp, vpn);
 
 	/*
 	 * tunnel is no longer active, del tunnel ip address from tip_hash

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -351,6 +351,8 @@ extern int bgp_evpn_remote_es_evi_add(struct bgp *bgp, struct bgpevpn *vpn,
 		const struct prefix_evpn *p);
 extern int bgp_evpn_remote_es_evi_del(struct bgp *bgp, struct bgpevpn *vpn,
 		const struct prefix_evpn *p);
+extern void bgp_evpn_evi_es_remote_cleanup(struct bgp *bgp,
+					   struct bgpevpn *vpn);
 extern void bgp_evpn_mh_init(void);
 extern void bgp_evpn_mh_finish(void);
 void bgp_evpn_vni_es_init(struct bgpevpn *vpn);

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -2631,14 +2631,15 @@ static int zebra_evpn_es_type0_esi_update(struct zebra_if *zif, esi_t *esi)
 	return rv;
 }
 
-void zebra_evpn_es_cleanup(void)
+void zebra_evpn_es_cleanup(bool remote_only)
 {
 	struct zebra_evpn_es *es;
 	struct zebra_evpn_es *es_next;
 
 	RB_FOREACH_SAFE(es, zebra_es_rb_head,
 			&zmh_info->es_rb_tree, es_next) {
-		zebra_evpn_local_es_del(&es);
+		if (!remote_only)
+			zebra_evpn_local_es_del(&es);
 		if (es)
 			zebra_evpn_remote_es_flush(&es);
 	}

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -344,7 +344,7 @@ extern void zebra_evpn_acc_vl_show(struct vty *vty, bool uj);
 extern void zebra_evpn_acc_vl_show_detail(struct vty *vty, bool uj);
 extern void zebra_evpn_acc_vl_show_vid(struct vty *vty, bool uj, vlanid_t vid);
 extern void zebra_evpn_if_es_print(struct vty *vty, struct zebra_if *zif);
-extern void zebra_evpn_es_cleanup(void);
+extern void zebra_evpn_es_cleanup(bool remote_only);
 extern int zebra_evpn_mh_mac_holdtime_update(struct vty *vty,
 		uint32_t duration, bool set_default);
 void zebra_evpn_mh_config_write(struct vty *vty);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5727,6 +5727,13 @@ void zebra_vxlan_advertise_all_vni(ZAPI_HANDLER_ARGS)
 		hash_iterate(zvrf->evpn_table, zebra_evpn_vxlan_cleanup_all,
 			     zvrf);
 
+		/*
+		 * BGP performs cleanup of remote ES info when advertise-all-vni
+		 * is disabled.
+		 * Perform this cleanup in zebra as well.
+		 */
+		zebra_evpn_es_cleanup(true);
+
 		/* Delete all ESs in BGP */
 		zebra_evpn_es_send_all_to_client(false /* add */);
 
@@ -5767,7 +5774,7 @@ void zebra_vxlan_cleanup_tables(struct zebra_vrf *zvrf)
 	zebra_vxlan_cleanup_sg_table(zvrf);
 
 	if (zvrf == evpn_zvrf)
-		zebra_evpn_es_cleanup();
+		zebra_evpn_es_cleanup(false);
 }
 
 /* Close all EVPN handling */


### PR DESCRIPTION
When advertise-all-vni is disabled, VNIs are deleted. So, remote type-1
routes imported into the VNIs are also flushed.

Perform a cleanup of remote es, es_evi, es_evi_vtep and es_vtep entries
which were created because of the above remote type-1 routes.

Signed-off-by: Ameya Dharkar <adharkar@vmware.com>