### PR TITLE
Peer afi safi mistake

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -739,7 +739,7 @@ int bgp_nb_errmsg_return(char *errmsg, size_t errmsg_len, int ret)
 		str = "Operation not allowed on a directly connected neighbor";
 		break;
 	case BGP_ERR_PEER_SAFI_CONFLICT:
-		str = GR_INVALID;
+		str = "Cannot activate peer for both 'ipv4 unicast' and 'ipv4 labeled-unicast'";
 		break;
 	case BGP_ERR_GR_INVALID_CMD:
 		str = "The Graceful Restart command used is not valid at this moment.";
@@ -831,7 +831,7 @@ int bgp_vty_return(struct vty *vty, int ret)
 		str = "Operation not allowed on a directly connected neighbor";
 		break;
 	case BGP_ERR_PEER_SAFI_CONFLICT:
-		str = GR_INVALID;
+		str = "Cannot activate peer for both 'ipv4 unicast' and 'ipv4 labeled-unicast'";
 		break;
 	case BGP_ERR_GR_INVALID_CMD:
 		str = "The Graceful Restart command used is not valid at this moment.";

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2203,7 +2203,7 @@ int peer_activate(struct peer *peer, afi_t afi, safi_t safi)
 
 	/* If this is the first peer to be activated for this
 	 * afi/labeled-unicast recalc bestpaths to trigger label allocation */
-	if (safi == SAFI_LABELED_UNICAST
+	if (ret != BGP_ERR_PEER_SAFI_CONFLICT && safi == SAFI_LABELED_UNICAST
 	    && !bgp->allocate_mpls_labels[afi][SAFI_UNICAST]) {
 
 		if (BGP_DEBUG(zebra, ZEBRA))


### PR DESCRIPTION
1) Correct error message returned when we have conflicting safi's
2) Don't cause an active peer active in unicast to request a bajillion labels when the activation is rejected.