### PR TITLE
pathd: fix some format strings

### DIFF
--- a/pathd/path_pcep_debug.c
+++ b/pathd/path_pcep_debug.c
@@ -1288,7 +1288,7 @@ void _format_path_hop(int ps, struct path_hop *hop)
 				     &hop->nai.remote_addr.ipaddr_v6);
 			break;
 		case PCEP_SR_SUBOBJ_NAI_UNNUMBERED_IPV4_ADJACENCY:
-			PATHD_FORMAT("%*sNAI: %pI4(%u)/%pI4(%u)\n", ps, "",
+			PATHD_FORMAT("%*sNAI: %pI6(%u)/%pI6(%u)\n", ps, "",
 				     &hop->nai.local_addr.ipaddr_v6,
 				     hop->nai.local_iface,
 				     &hop->nai.remote_addr.ipaddr_v6,

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -363,16 +363,14 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 	if (!CHECK_FLAG(pcc_state->flags, F_PCC_STATE_HAS_IPV4)) {
 		if (pcc_state->retry_count < OTHER_FAMILY_MAX_RETRIES) {
 			flog_warn(EC_PATH_PCEP_MISSING_SOURCE_ADDRESS,
-				  "skipping connection to PCE %pIA:%d due to "
-				  "missing PCC IPv4 address",
+				  "skipping connection to PCE %pIA:%d due to missing PCC IPv4 address",
 				  &pcc_state->pce_opts->addr,
 				  pcc_state->pce_opts->port);
 			schedule_reconnect(ctrl_state, pcc_state);
 			return 0;
 		} else {
 			flog_warn(EC_PATH_PCEP_MISSING_SOURCE_ADDRESS,
-				  "missing IPv4 PCC address, IPv4 candidate "
-				  "paths will be ignored");
+				  "missing IPv4 PCC address, IPv4 candidate paths will be ignored");
 		}
 	}
 
@@ -381,16 +379,14 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 	if (!CHECK_FLAG(pcc_state->flags, F_PCC_STATE_HAS_IPV6)) {
 		if (pcc_state->retry_count < OTHER_FAMILY_MAX_RETRIES) {
 			flog_warn(EC_PATH_PCEP_MISSING_SOURCE_ADDRESS,
-				  "skipping connection to PCE %pIA:%d due to "
-				  "missing PCC IPv6 address",
+				  "skipping connection to PCE %pIA:%d due to missing PCC IPv6 address",
 				  &pcc_state->pce_opts->addr,
 				  pcc_state->pce_opts->port);
 			schedule_reconnect(ctrl_state, pcc_state);
 			return 0;
 		} else {
 			flog_warn(EC_PATH_PCEP_MISSING_SOURCE_ADDRESS,
-				  "missing IPv6 PCC address, IPv6 candidate "
-				  "paths will be ignored");
+				  "missing IPv6 PCC address, IPv6 candidate paths will be ignored");
 		}
 	}
 
@@ -398,8 +394,7 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 	 * have been spent, we still need the one for the transport familly */
 	if (pcc_state->pcc_addr_tr.ipa_type == IPADDR_NONE) {
 		flog_warn(EC_PATH_PCEP_MISSING_SOURCE_ADDRESS,
-			  "skipping connection to PCE %pIA:%d due to missing "
-			  "PCC address",
+			  "skipping connection to PCE %pIA:%d due to missing PCC address",
 			  &pcc_state->pce_opts->addr,
 			  pcc_state->pce_opts->port);
 		schedule_reconnect(ctrl_state, pcc_state);
@@ -490,8 +485,7 @@ void pcep_pcc_sync_path(struct ctrl_state *ctrl_state,
 			send_report(pcc_state, path);
 		} else {
 			PCEP_DEBUG(
-				"%s Skipping %s candidate path %s "
-				"synchronization",
+				"%s Skipping %s candidate path %s synchronization",
 				pcc_state->tag,
 				ipaddr_type_name(&path->nbkey.endpoint),
 				path->name);
@@ -1235,8 +1229,7 @@ void handle_pcep_comp_reply(struct ctrl_state *ctrl_state,
 		 * the connection if more that a given rate.
 		 */
 		PCEP_DEBUG(
-			"%s Received computation reply for unknown request "
-			"%d",
+			"%s Received computation reply for unknown request %d",
 			pcc_state->tag, path->req_id);
 		PCEP_DEBUG_PATH("%s", format_path(path));
 		send_pcep_error(pcc_state, PCEP_ERRT_UNKNOWN_REQ_REF,

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -348,9 +348,6 @@ void pcep_pcc_reconnect(struct ctrl_state *ctrl_state,
 
 int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 {
-	char pcc_buff[40];
-	char pce_buff[40];
-
 	assert(pcc_state->status == PCEP_PCC_DISCONNECTED);
 	assert(pcc_state->sess == NULL);
 
@@ -366,10 +363,9 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 	if (!CHECK_FLAG(pcc_state->flags, F_PCC_STATE_HAS_IPV4)) {
 		if (pcc_state->retry_count < OTHER_FAMILY_MAX_RETRIES) {
 			flog_warn(EC_PATH_PCEP_MISSING_SOURCE_ADDRESS,
-				  "skipping connection to PCE %s:%d due to "
+				  "skipping connection to PCE %pIA:%d due to "
 				  "missing PCC IPv4 address",
-				  ipaddr2str(&pcc_state->pce_opts->addr,
-					     pce_buff, sizeof(pce_buff)),
+				  &pcc_state->pce_opts->addr,
 				  pcc_state->pce_opts->port);
 			schedule_reconnect(ctrl_state, pcc_state);
 			return 0;
@@ -385,10 +381,9 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 	if (!CHECK_FLAG(pcc_state->flags, F_PCC_STATE_HAS_IPV6)) {
 		if (pcc_state->retry_count < OTHER_FAMILY_MAX_RETRIES) {
 			flog_warn(EC_PATH_PCEP_MISSING_SOURCE_ADDRESS,
-				  "skipping connection to PCE %s:%d due to "
+				  "skipping connection to PCE %pIA:%d due to "
 				  "missing PCC IPv6 address",
-				  ipaddr2str(&pcc_state->pce_opts->addr,
-					     pce_buff, sizeof(pce_buff)),
+				  &pcc_state->pce_opts->addr,
 				  pcc_state->pce_opts->port);
 			schedule_reconnect(ctrl_state, pcc_state);
 			return 0;
@@ -403,10 +398,9 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 	 * have been spent, we still need the one for the transport familly */
 	if (pcc_state->pcc_addr_tr.ipa_type == IPADDR_NONE) {
 		flog_warn(EC_PATH_PCEP_MISSING_SOURCE_ADDRESS,
-			  "skipping connection to PCE %s:%d due to missing "
+			  "skipping connection to PCE %pIA:%d due to missing "
 			  "PCC address",
-			  ipaddr2str(&pcc_state->pce_opts->addr, pce_buff,
-				     sizeof(pce_buff)),
+			  &pcc_state->pce_opts->addr,
 			  pcc_state->pce_opts->port);
 		schedule_reconnect(ctrl_state, pcc_state);
 		return 0;
@@ -420,12 +414,10 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 
 	if (pcc_state->sess == NULL) {
 		flog_warn(EC_PATH_PCEP_LIB_CONNECT,
-			  "failed to connect to PCE %s:%d from %s:%d",
-			  ipaddr2str(&pcc_state->pce_opts->addr, pce_buff,
-				     sizeof(pce_buff)),
+			  "failed to connect to PCE %pIA:%d from %pIA:%d",
+			  &pcc_state->pce_opts->addr,
 			  pcc_state->pce_opts->port,
-			  ipaddr2str(&pcc_state->pcc_addr_tr, pcc_buff,
-				     sizeof(pcc_buff)),
+			  &pcc_state->pcc_addr_tr,
 			  pcc_state->pcc_opts->port);
 		schedule_reconnect(ctrl_state, pcc_state);
 		return 0;
@@ -1574,7 +1566,6 @@ void send_comp_request(struct ctrl_state *ctrl_state,
 	assert(lookup_reqid(pcc_state, req->path) == req->path->req_id);
 
 	int timeout;
-	char buff[40];
 	struct pcep_message *msg;
 
 	if (!pcc_state->is_best) {
@@ -1585,10 +1576,9 @@ void send_comp_request(struct ctrl_state *ctrl_state,
 	specialize_outgoing_path(pcc_state, req->path);
 
 	PCEP_DEBUG(
-		"%s Sending computation request %d for path %s to %s (retry %d)",
+		"%s Sending computation request %d for path %s to %pIA (retry %d)",
 		pcc_state->tag, req->path->req_id, req->path->name,
-		ipaddr2str(&req->path->nbkey.endpoint, buff, sizeof(buff)),
-		req->retry_count);
+		&req->path->nbkey.endpoint, req->retry_count);
 	PCEP_DEBUG_PATH("%s Computation request path %s: %s", pcc_state->tag,
 			req->path->name, format_path(req->path));
 
@@ -1621,7 +1611,6 @@ void cancel_comp_requests(struct ctrl_state *ctrl_state,
 void cancel_comp_request(struct ctrl_state *ctrl_state,
 			 struct pcc_state *pcc_state, struct req_entry *req)
 {
-	char buff[40];
 	struct pcep_message *msg;
 
 	if (req->was_sent) {
@@ -1631,10 +1620,9 @@ void cancel_comp_request(struct ctrl_state *ctrl_state,
 	}
 
 	PCEP_DEBUG(
-		"%s Canceling computation request %d for path %s to %s (retry %d)",
+		"%s Canceling computation request %d for path %s to %pIA (retry %d)",
 		pcc_state->tag, req->path->req_id, req->path->name,
-		ipaddr2str(&req->path->nbkey.endpoint, buff, sizeof(buff)),
-		req->retry_count);
+		&req->path->nbkey.endpoint, req->retry_count);
 	PCEP_DEBUG_PATH("%s Canceled computation request path %s: %s",
 			pcc_state->tag, req->path->name,
 			format_path(req->path));

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -624,8 +624,7 @@ void srte_candidate_set_metric(struct srte_candidate *candidate,
 	char endpoint[46];
 	ipaddr2str(&policy->endpoint, endpoint, sizeof(endpoint));
 	zlog_debug(
-		"SR-TE(%s, %u): candidate %s %sconfig metric %s (%u) set to %f "
-		"(is-bound: %s; is_computed: %s)",
+		"SR-TE(%s, %u): candidate %s %sconfig metric %s (%u) set to %f (is-bound: %s; is_computed: %s)",
 		endpoint, policy->color, candidate->name,
 		required ? "required " : "", srte_candidate_metric_name(type),
 		type, value, is_bound ? "true" : "false",
@@ -659,8 +658,7 @@ void srte_lsp_set_metric(struct srte_lsp *lsp,
 	char endpoint[46];
 	ipaddr2str(&policy->endpoint, endpoint, sizeof(endpoint));
 	zlog_debug(
-		"SR-TE(%s, %u): candidate %s %slsp metric %s (%u) set to %f "
-		"(is-bound: %s; is_computed: %s)",
+		"SR-TE(%s, %u): candidate %s %slsp metric %s (%u) set to %f (is-bound: %s; is_computed: %s)",
 		endpoint, policy->color, candidate->name,
 		required ? "required " : "", srte_candidate_metric_name(type),
 		type, value, is_bound ? "true" : "false",
@@ -981,8 +979,7 @@ void srte_candidate_unset_segment_list(const char *originator, bool force)
 			if (segment_list->protocol_origin
 			    == SRTE_ORIGIN_LOCAL) {
 				zlog_warn(
-					"Cannot unset segment list %s because it "
-					"was created locally",
+					"Cannot unset segment list %s because it was created locally",
 					segment_list->name);
 				continue;
 			}

--- a/pceplib/pcep_session_logic_states.c
+++ b/pceplib/pcep_session_logic_states.c
@@ -813,8 +813,7 @@ void handle_timer_event(pcep_session_event *event)
 
 	pcep_log(
 		LOG_INFO,
-		"%s: [%ld-%ld] pcep_session_logic handle_timer_event: session [%d] event timer_id [%d] "
-		"session timers [OKW, OKA, DT, KA] [%d, %d, %d, %d]",
+		"%s: [%ld-%ld] pcep_session_logic handle_timer_event: session [%d] event timer_id [%d] session timers [OKW, OKA, DT, KA] [%d, %d, %d, %d]",
 		__func__, time(NULL), pthread_self(), session->session_id,
 		event->expired_timer_id, session->timer_id_open_keep_wait,
 		session->timer_id_open_keep_alive, session->timer_id_dead_timer,


### PR DESCRIPTION
just some :broom: :broom: :broom:

cf. individual commits.  one `%pI4` <> `%pI6` confusion, a bunch of `%pIA` for `struct ipaddr *`, and a bunch of removed line breaks in the middle of messages.