### PR TITLE
bgpd: If we have a SAFI conflict do not allow labeled unicast to reset

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2081,7 +2081,7 @@ int peer_activate(struct peer *peer, afi_t afi, safi_t safi)
 
 	/* If this is the first peer to be activated for this
 	 * afi/labeled-unicast recalc bestpaths to trigger label allocation */
-	if (safi == SAFI_LABELED_UNICAST
+	if (ret != BGP_ERR_PEER_SAFI_CONFLICT && safi == SAFI_LABELED_UNICAST
 	    && !bgp->allocate_mpls_labels[afi][SAFI_UNICAST]) {
 
 		if (BGP_DEBUG(zebra, ZEBRA))


### PR DESCRIPTION
If we have a SAFI conflict, ie we are trying to activate safi's
UNICAST and LABELED_UNICAST at the same time, we should not
cause bestpath to be rerun and we should not try to put
labels on everything.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>
(cherry picked from commit 0f3ac8198ac082cc86b1e544054da0cb1dcfed36)


Backport to 7.5 series for PR#8275

A backport of the second commit a59803d0603d277269c4c5c1511cad68684752ae is not required as 7.5 series lacks the ENUM to error string helper.