### PR TITLE
ospf6d: fix iface commands lost when removing from area

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1449,6 +1449,12 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
 		return CMD_WARNING;
 	}
 
+	if (CHECK_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE)) {
+		vty_out(vty, "Interface %s not attached to area\n",
+			argv[idx_ifname]->arg);
+		return CMD_WARNING;
+	}
+
 	ospf6_route_table_show(vty, idx_prefix, argc, argv, oi->route_connected,
 			       uj);
 
@@ -1482,7 +1488,7 @@ DEFUN (show_ipv6_ospf6_interface_prefix,
 
 	FOR_ALL_INTERFACES (vrf, ifp) {
 		oi = (struct ospf6_interface *)ifp->info;
-		if (oi == NULL)
+		if (oi == NULL || CHECK_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE))
 			continue;
 
 		ospf6_route_table_show(vty, idx_prefix, argc, argv,

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -809,7 +809,8 @@ DEFUN (no_ospf6_interface_area,
 
 	/* Verify Area */
 	if (oi->area == NULL) {
-		vty_out(vty, "No such Area-ID: %s\n", argv[idx_ipv4]->arg);
+		vty_out(vty, "%s not attached to area %s\n",
+			oi->interface->name, oi->area->name);
 		return CMD_SUCCESS;
 	}
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -830,7 +830,6 @@ DEFUN (no_ospf6_interface_area,
 		UNSET_FLAG(oa->flag, OSPF6_AREA_ENABLE);
 		ospf6_abr_disable_area(oa);
 	}
-	ospf6_interface_delete(oi);
 
 	return CMD_SUCCESS;
 }

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -724,7 +724,7 @@ def verify_ospf6_neighbor(tgen, topo):
                     nh_state = neighbor["state"]
                     break
             else:
-                return "[DUT: {}] OSPF6 peer {} missing".format(router, data_rid)
+                return "[DUT: {}] OSPF6 peer {} missing".format(router, ospf_nbr_rid)
 
             if nh_state == "Full":
                 no_of_peer += 1

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -344,10 +344,9 @@ def config_ospf_interface(tgen, topo, input_dict=None, build=False, load_config=
         for lnk in input_dict[router]["links"].keys():
             if "ospf" not in input_dict[router]["links"][lnk]:
                 logger.debug(
-                    "Router %s: ospf configs is not present in"
-                    "input_dict, passed input_dict",
-                    router,
-                    input_dict,
+                    "Router %s: ospf config is not present in"
+                    "input_dict",
+                    router
                 )
                 continue
             ospf_data = input_dict[router]["links"][lnk]["ospf"]


### PR DESCRIPTION
In OSPFv3 when removing the interface from an area, all ospf6 interface commands are lost, so when changing the area you need to reconfigure all ospf6 interface commands again
```
r1# sh run
interface r1-r2-eth0
 ipv6 address 2013:12::1/64
 ipv6 ospf6 dead-interval 4
 ipv6 ospf6 hello-interval 1
 ipv6 ospf6 network point-to-point
!
router ospf6
 ospf6 router-id 1.1.1.1
 interface r1-r2-eth0 area 0.0.0.0
!
r1# conf t
r1(config)# router ospf6
r1(config-ospf6)# no interface r1-r2-eth0 area 0.0.0.0
r1(config-ospf6)# exit

r1# sh run
interface r1-r2-eth0
 ipv6 address 2013:12::1/64
!                            <----- missing all ipv6 ospf6 commands
router ospf6
 ospf6 router-id 1.1.1.1
!
```
This is because the interface is being deleted instead of disabled (see #7717) I believe the interface should be left as disabled (not deleted) when removing the interface from the area

This PR avoids the removal of the interface. Also a different fix for #7717 is provided. A warning message is corrected when removing an interface from the area. Finally a minor warning is fixed in the tests. 

See individual commits for details

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>