### PR TITLE
tools: Allow read in of config 1 time on startup

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -67,7 +67,7 @@ chownfrr() {
 vtysh_b () {
 	[ "$1" = "watchfrr" ] && return 0
 	[ -r "$C_PATH/frr.conf" ] || return 0
-	if [ -n "$1" ]; then
+	if [ -n "$1" && "$1" != "all" ]; then
 		"$VTYSH" `echo $nsopt` -b -d "$1"
 	else
 		"$VTYSH" `echo $nsopt` -b
@@ -150,6 +150,7 @@ daemon_prep() {
 daemon_start() {
 	local dmninst daemon inst args instopt wrap bin
 	daemon_inst "$1"
+	all="$2"
 
 	ulimit -n $MAX_FDS > /dev/null 2> /dev/null
 	daemon_prep "$daemon" "$inst" || return 1
@@ -165,7 +166,11 @@ daemon_start() {
 
 	if eval "$all_wrap $wrap $bin $nsopt -d $frr_global_options $instopt $args"; then
 		log_success_msg "Started $dmninst"
-		vtysh_b "$daemon"
+		if [ $all != "all" ]; then
+			vtysh_b "$daemon"
+		else
+			debug "Skipping startup of vtysh until all have started"
+		fi
 	else
 		log_failure_msg "Failed to start $dmninst!"
 	fi
@@ -237,8 +242,9 @@ print_status() {
 all_start() {
 	daemon_list daemons
 	for dmninst in $daemons; do
-		daemon_start "$dmninst"
+		daemon_start "$dmninst" "all"
 	done
+	vtysh_b "all"
 }
 
 all_stop() {
@@ -348,11 +354,11 @@ frrcommon_main() {
 		esac
 	else
 		case "$cmd" in
-		start)	daemon_start "$@";;
+		start)	daemon_start "$@" "$@";;
 		stop)	daemon_stop "$@";;
 		restart)
 			daemon_stop "$@"
-			daemon_start "$@"
+			daemon_start "$@" "$@"
 			;;
 		*)	$cmd "$@";;
 		esac

--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -44,7 +44,7 @@ case "$1" in
 start)
 	daemon_list daemons
 	watchfrr_options="$watchfrr_options $daemons"
-	daemon_start watchfrr
+	daemon_start watchfrr watchfrr
 	;;
 stop)
 	daemon_stop watchfrr
@@ -58,7 +58,7 @@ restart|force-reload)
 
 	daemon_list daemons
 	watchfrr_options="$watchfrr_options $daemons"
-	daemon_start watchfrr
+	daemon_start watchfrr watchfrr
 	;;
 
 status)
@@ -89,7 +89,7 @@ reload)
 	daemon_list daemons
 	watchfrr_options="$watchfrr_options $daemons"
 	daemon_stop watchfrr && \
-		daemon_start watchfrr
+		daemon_start watchfrr watchfrr
 
 	# make systemd not kill watchfrr after ExecReload completes
 	# 3 goats were sacrificed to restore sanity after coding this


### PR DESCRIPTION
When FRR is starting all daemons( or restarting them all )
FRR is reading in the configuration 1 time for each daemon
specified to run.  This is not a big deal if you have a very
small configuration.  But with large configurations FRR is
taking long enough that watchfrr is not establishing connection
to all the daemons and starting some over.

Modify the code so that vtysh is only read in at the end
of a `all` sequence.  If we are restarting an individual
daemon allow the read in of the whole config.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>