### PR TITLE
isisd: fix BFD session when IPv6 not configured

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -260,22 +260,26 @@ void isis_adj_process_threeway(struct isis_adjacency *adj,
 
 	adj->threeway_state = next_tw_state;
 }
-void isis_log_adj_change(struct isis_adjacency *adj,
-			 enum isis_adj_state old_state,
-			 enum isis_adj_state new_state, const char *reason)
+const char *isis_adj_name(const struct isis_adjacency *adj)
 {
-	const char *adj_name;
+	if (!adj)
+		return "NONE";
+
 	struct isis_dynhn *dyn;
 
 	dyn = dynhn_find_by_id(adj->sysid);
 	if (dyn)
-		adj_name = dyn->hostname;
+		return dyn->hostname;
 	else
-		adj_name = sysid_print(adj->sysid);
-
+		return sysid_print(adj->sysid);
+}
+void isis_log_adj_change(struct isis_adjacency *adj,
+			 enum isis_adj_state old_state,
+			 enum isis_adj_state new_state, const char *reason)
+{
 	zlog_info(
 		"%%ADJCHANGE: Adjacency to %s (%s) for %s changed from %s to %s, %s",
-		adj_name, adj->circuit->interface->name,
+		isis_adj_name(adj), adj->circuit->interface->name,
 		adj_level2string(adj->level), adj_state2string(old_state),
 		adj_state2string(new_state), reason ? reason : "unspecified");
 }
@@ -462,11 +466,7 @@ void isis_adj_print_vty(struct isis_adjacency *adj, struct vty *vty,
 	struct isis_dynhn *dyn;
 	int level;
 
-	dyn = dynhn_find_by_id(adj->sysid);
-	if (dyn)
-		vty_out(vty, "  %-20s", dyn->hostname);
-	else
-		vty_out(vty, "  %-20s", sysid_print(adj->sysid));
+	vty_out(vty, " %-20s", isis_adj_name(adj));
 
 	if (detail == ISIS_UI_LEVEL_BRIEF) {
 		if (adj->circuit)

--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -142,5 +142,6 @@ void isis_adj_build_neigh_list(struct list *adjdb, struct list *list);
 void isis_adj_build_up_list(struct list *adjdb, struct list *list);
 int isis_adj_usage2levels(enum isis_adj_usage usage);
 int isis_bfd_startup_timer(struct thread *thread);
+const char *isis_adj_name(const struct isis_adjacency *adj);
 
 #endif /* ISIS_ADJACENCY_H */

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -332,9 +332,15 @@ static void bfd_handle_adj_up(struct isis_adjacency *adj, int command)
 	/* If IS-IS IPv6 is configured wait for IPv6 address to be programmed
 	 * before starting up BFD
 	 */
-	if ((circuit->ipv6_router && listcount(circuit->ipv6_link) == 0)
-	    || adj->ipv6_address_count == 0)
+	if (circuit->ipv6_router
+	    && (listcount(circuit->ipv6_link) == 0
+		|| adj->ipv6_address_count == 0)) {
+		if (IS_DEBUG_BFD)
+			zlog_debug(
+				"ISIS-BFD: skipping BFD initialization on adjacency with %s because IPv6 is enabled but not ready",
+				isis_adj_name(adj));
 		return;
+	}
 
 	/*
 	 * If IS-IS is enabled for both IPv4 and IPv6 on the circuit, prefer


### PR DESCRIPTION
a wrong check was silently skipping the initialization of the bfd_session struct in the adjacency if the router was not configured for IPv6. This would cause BFD events to be ignored regardless of the configuration.

Also add more debug messages to troublshoot discarded updates in the future.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>