### PR TITLE
bgpd: add seqno in bgp as-path access-list policy

### DIFF
--- a/bgpd/bgp_filter.h
+++ b/bgpd/bgp_filter.h
@@ -21,6 +21,8 @@
 #ifndef _QUAGGA_BGP_FILTER_H
 #define _QUAGGA_BGP_FILTER_H
 
+#define ASPATH_SEQ_NUMBER_AUTO -1
+
 enum as_filter_type { AS_FILTER_DENY, AS_FILTER_PERMIT };
 
 extern void bgp_filter_init(void);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1783,7 +1783,7 @@ AS Path Access Lists
 
 AS path access list is user defined AS path.
 
-.. clicmd:: bgp as-path access-list WORD permit|deny LINE
+.. clicmd:: bgp as-path access-list WORD [seq (0-4294967295)] permit|deny LINE
 
    This command defines a new AS path access list.
 
@@ -1799,6 +1799,7 @@ Bogon ASN filter policy configuration example
    bgp as-path access-list 99 permit _0_
    bgp as-path access-list 99 permit _23456_
    bgp as-path access-list 99 permit _1310[0-6][0-9]_|_13107[0-1]_
+   bgp as-path access-list 99 seq 20 permit ^65
 
 .. _bgp-using-as-path-in-route-map:
 
@@ -3597,8 +3598,8 @@ certainly contains silly mistakes, if not serious flaws.
    ip prefix-list pl-peer2-network permit 192.168.2.0/24
    ip prefix-list pl-peer2-network permit 172.16.1/24
    !
-   bgp as-path access-list asp-own-as permit ^$
-   bgp as-path access-list asp-own-as permit _64512_
+   bgp as-path access-list seq 5 asp-own-as permit ^$
+   bgp as-path access-list seq 10 asp-own-as permit _64512_
    !
    ! #################################################################
    ! Match communities we provide actions for, on routes receives from


### PR DESCRIPTION
Add optional parameter seqno to bgp as-patch policy
to inline with other bgp policies commands at same
level.

Testing Done:

```
config t
bgp as-path access-list foo1 permit _40_
bgp as-path access-list foo1 seq 5 permit _41_
bgp as-path access-list foo1 seq 8 permit _42_
bgp as-path access-list foo2 permit _43_
no bgp as-path access-list foo1 permit _41_
bgp as-path access-list foo1 permit 41$

show run:
bgp as-path access-list foo1 seq 8 permit _42_
bgp as-path access-list foo1 seq 10 permit 41$
bgp as-path access-list foo2 seq 5 permit _43_
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>