### PR TITLE
bgpd: use add_event instead of add_timer with zero timeout

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -343,8 +343,8 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 
 	bgp_reads_on(peer);
 	bgp_writes_on(peer);
-	thread_add_timer_msec(bm->master, bgp_process_packet, peer, 0,
-			      &peer->t_process_packet);
+	thread_add_event(bm->master, bgp_process_packet, peer, 0,
+			 &peer->t_process_packet);
 
 	return (peer);
 }

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -268,8 +268,8 @@ static int bgp_process_reads(struct thread *thread)
 		thread_add_read(fpt->master, bgp_process_reads, peer, peer->fd,
 				&peer->t_read);
 		if (added_pkt)
-			thread_add_timer_msec(bm->master, bgp_process_packet,
-					      peer, 0, &peer->t_process_packet);
+			thread_add_event(bm->master, bgp_process_packet,
+					 peer, 0, &peer->t_process_packet);
 	}
 
 	return 0;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2680,7 +2680,7 @@ int bgp_process_packet(struct thread *thread)
 		frr_with_mutex(&peer->io_mtx) {
 			// more work to do, come back later
 			if (peer->ibuf->count > 0)
-				thread_add_timer_msec(
+				thread_add_event(
 					bm->master, bgp_process_packet, peer, 0,
 					&peer->t_process_packet);
 		}


### PR DESCRIPTION
Just use events in a few places where timers with zero timeout were being used; timers are more costly to process than events.