### PR TITLE
nhrpd: Remove newline from log message

### DIFF
--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -123,7 +123,7 @@ static int nhrp_reg_timeout(struct thread *t)
 		 */
 		if (r->peer && r->peer->vc && r->peer->vc->ike_uniqueid) {
 			debugf(NHRP_DEBUG_COMMON,
-			       "Terminating IPSec Connection for %d\n",
+			       "Terminating IPSec Connection for %d",
 			       r->peer->vc->ike_uniqueid);
 			vici_terminate_vc_by_ike_id(r->peer->vc->ike_uniqueid);
 			r->peer->vc->ike_uniqueid = 0;


### PR DESCRIPTION
We should not be putting new lines in log messages.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>