### PR TITLE
lib, vtysh: re-add support for spaces in 'find'

### DIFF
--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -513,31 +513,42 @@ Terminal Mode Commands
    Send a message to all logging destinations that are enabled for messages of
    the given severity.
 
-.. clicmd:: find COMMAND...
+.. clicmd:: find REGEX...
 
-   This command performs a simple substring search across all defined commands
-   in all modes. As an example, suppose you're in enable mode and can't
-   remember where the command to turn OSPF segment routing on is:
+   This command performs a regex search across all defined commands in all
+   modes. As an example, suppose you're in enable mode and can't remember where
+   the command to turn OSPF segment routing on is:
 
    ::
 
       frr# find segment-routing on
         (ospf)  segment-routing on
+        (isis)  segment-routing on
+
 
    The CLI mode is displayed next to each command. In this example,
    :clicmd:`segment-routing on` is under the `router ospf` mode.
 
-   Similarly, suppose you want a listing of all commands that contain "l2vpn":
+   Similarly, suppose you want a listing of all commands that contain "l2vpn"
+   and "neighbor":
 
    ::
 
-      frr# find l2vpn
-        (view)  show [ip] bgp l2vpn evpn [json]
-        (view)  show [ip] bgp l2vpn evpn all <A.B.C.D|A.B.C.D/M> [json]
-        (view)  show [ip] bgp l2vpn evpn all neighbors A.B.C.D advertised-routes [json]
-        (view)  show [ip] bgp l2vpn evpn all neighbors A.B.C.D routes [json]
-        (view)  show [ip] bgp l2vpn evpn all overlay
+      frr# find l2vpn.*neighbor
+        (view)  show [ip] bgp l2vpn evpn neighbors <A.B.C.D|X:X::X:X|WORD> advertised-routes [json]
+        (view)  show [ip] bgp l2vpn evpn neighbors <A.B.C.D|X:X::X:X|WORD> routes [json]
+        (view)  show [ip] bgp l2vpn evpn rd ASN:NN_OR_IP-ADDRESS:NN neighbors <A.B.C.D|X:X::X:X|WORD> advertised-routes [json]
+        (view)  show [ip] bgp l2vpn evpn rd ASN:NN_OR_IP-ADDRESS:NN neighbors <A.B.C.D|X:X::X:X|WORD> routes [json]
         ...
+
+
+   Note that when entering spaces as part of a regex specification, repeated
+   spaces will be compressed into a single space for matching purposes. This is
+   a consequence of spaces being used to delimit CLI tokens. If you need to
+   match more than one space, use the ``\s`` escape.
+
+   POSIX Extended Regular Expressions are supported.
+
 
 .. _common-show-commands:
 

--- a/lib/command.c
+++ b/lib/command.c
@@ -2226,18 +2226,19 @@ DEFUN (no_banner_motd,
 
 DEFUN(find,
       find_cmd,
-      "find REGEX",
+      "find REGEX...",
       "Find CLI command matching a regular expression\n"
       "Search pattern (POSIX regex)\n")
 {
-	char *pattern = argv[1]->arg;
 	const struct cmd_node *node;
 	const struct cmd_element *cli;
 	vector clis;
 
 	regex_t exp = {};
 
+	char *pattern = argv_concat(argv, argc, 1);
 	int cr = regcomp(&exp, pattern, REG_NOSUB | REG_EXTENDED);
+	XFREE(MTYPE_TMP, pattern);
 
 	if (cr != 0) {
 		switch (cr) {

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3719,18 +3719,18 @@ DEFUN (no_vtysh_output_file,
 
 DEFUN(find,
       find_cmd,
-      "find REGEX",
+      "find REGEX...",
       "Find CLI command matching a regular expression\n"
       "Search pattern (POSIX regex)\n")
 {
-	char *pattern = argv[1]->arg;
 	const struct cmd_node *node;
 	const struct cmd_element *cli;
 	vector clis;
-
 	regex_t exp = {};
-
+	char *pattern = argv_concat(argv, argc, 1);
 	int cr = regcomp(&exp, pattern, REG_NOSUB | REG_EXTENDED);
+
+	XFREE(MTYPE_TMP, pattern);
 
 	if (cr != 0) {
 		switch (cr) {


### PR DESCRIPTION
Lost ability to handle them in the regex patch

Signed-off-by: Quentin Young <qlyoung@nvidia.com>