### PR TITLE
tools: run `vtysh -b` once for all-startup

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -149,6 +149,10 @@ daemon_prep() {
 
 daemon_start() {
 	local dmninst daemon inst args instopt wrap bin
+
+	all=false
+	[ "$1" = "--all" ] && { all=true; shift; }
+
 	daemon_inst "$1"
 
 	ulimit -n $MAX_FDS > /dev/null 2> /dev/null
@@ -165,7 +169,11 @@ daemon_start() {
 
 	if eval "$all_wrap $wrap $bin $nsopt -d $frr_global_options $instopt $args"; then
 		log_success_msg "Started $dmninst"
-		vtysh_b "$daemon"
+		if $all; then
+			debug "Skipping startup of vtysh until all have started"
+		else
+			vtysh_b "$daemon"
+		fi
 	else
 		log_failure_msg "Failed to start $dmninst!"
 	fi
@@ -237,8 +245,9 @@ print_status() {
 all_start() {
 	daemon_list daemons
 	for dmninst in $daemons; do
-		daemon_start "$dmninst"
+		daemon_start --all "$dmninst"
 	done
+	vtysh_b
 }
 
 all_stop() {


### PR DESCRIPTION
Prettier (and shorter) version of #8281 :wink:

> When FRR is starting all daemons (or restarting them all) FRR is reading
in the configuration 1 time for each daemon specified to run. This is
not a big deal if you have a very small configuration. But with large
configurations FRR is taking long enough that watchfrr is not
establishing connection to all the daemons and starting some over.
>
> Modify the code so that vtysh is only read in at the end of a all
sequence. If we are restarting an individual daemon allow the read in of
the whole config.