### PR TITLE
zebra: handle renamed interfaces at netlink level

### DIFF
--- a/lib/if.h
+++ b/lib/if.h
@@ -509,6 +509,7 @@ extern int if_cmp_name_func(const char *p1, const char *p2);
  * else think before you use VRF_UNKNOWN
  */
 extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
+extern void if_update_to_new_name(struct interface *ifp, const char *name);
 
 /* Create new interface, adds to name list only */
 extern struct interface *if_create_name(const char *name, vrf_id_t vrf_id);


### PR DESCRIPTION
when an interface is renamed in a given namespace, the ipv6
addresses are maintained in the new interface. The fix consists
in using the same interface context, instead of creating a new
one.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>