### PR TITLE
doc: add libsnmp-dev install line

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -60,6 +60,7 @@ following steps will get you there on Ubuntu 20.04.
 
 .. code:: shell
 	  
+   apt install libsnmp-dev
    apt install snmpd snmp
    apt install snmp-mibs-downloader
    download-mibs


### PR DESCRIPTION
Do not assume libsnmp-dev is installed.

Signed-off-by: Pat Ruddy <pat@voltanet.io>