### PR TITLE
lib: Fix short printfrr buf

### DIFF
--- a/lib/printf/vfprintf.c
+++ b/lib/printf/vfprintf.c
@@ -138,7 +138,7 @@ __wcsconv(wchar_t *wcsarg, int prec)
  * write a uintmax_t in octal (plus one byte).
  */
 #if UINTMAX_MAX <= UINT64_MAX
-#define	BUF	64
+#define	BUF	80
 #else
 #error "BUF must be large enough to format a uintmax_t"
 #endif

--- a/tests/lib/test_table.c
+++ b/tests/lib/test_table.c
@@ -20,7 +20,7 @@
  */
 
 #include <zebra.h>
-
+#include "printfrr.h"
 #include "prefix.h"
 #include "table.h"
 
@@ -113,7 +113,7 @@ static void print_subtree(struct route_node *rn, const char *legend,
 		printf("  ");
 	}
 
-	printf("%s: %pFX", legend, &rn->p);
+	printfrr("%s: %pFX", legend, &rn->p);
 	if (!rn->info) {
 		printf(" (internal)");
 	}


### PR DESCRIPTION
Issue #8315 reported problems with the small local buffer offered to the printfrr extension callbacks - make that buffer a little bigger. Also found an oops in a test, where `%pFX` was being offered to vanilla `printf()` ...