### PR TITLE
vtysh: hide "show configuration running" command

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2851,7 +2851,7 @@ DEFUN (vtysh_show_error_code,
 }
 
 /* Northbound. */
-DEFUN (show_config_running,
+DEFUN_HIDDEN (show_config_running,
        show_config_running_cmd,
        "show configuration running\
           [<json|xml> [translate WORD]]\


### PR DESCRIPTION
This command is currently useful only for developers.
Let's hide it to not confuse end users by having both
"show runnning-config" and "show configuration running".

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>