### PR TITLE
ospf6d: Do not flood unknown LSAs if U-bit is clear

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -463,6 +463,19 @@ static void ospf6_flood_process(struct ospf6_neighbor *from,
 	struct ospf6_area *oa;
 
 	for (ALL_LIST_ELEMENTS(process->area_list, node, nnode, oa)) {
+
+		/* If unknown LSA and U-bit clear, treat as link local
+		 * flooding scope
+		 */
+		if (!OSPF6_LSA_IS_KNOWN(lsa->header->type)
+		    && !(ntohs(lsa->header->type) & OSPF6_LSTYPE_UBIT_MASK)
+		    && (oa != OSPF6_INTERFACE(lsa->lsdb->data)->area)) {
+
+			if (IS_OSPF6_DEBUG_FLOODING)
+				zlog_debug("Unknown LSA, do not flood");
+			continue;
+		}
+
 		if (OSPF6_LSA_SCOPE(lsa->header->type) == OSPF6_SCOPE_AREA
 		    && oa != OSPF6_AREA(lsa->lsdb->data))
 			continue;


### PR DESCRIPTION
Do not flood unknown LSAs if U-bit is clear.

Signed-off-by: Karen Schoener <karen@voltanet.io>