### PR TITLE
doc: fix url for pip 2 in dev doc

### DIFF
--- a/doc/developer/building-frr-for-ubuntu2004.rst
+++ b/doc/developer/building-frr-for-ubuntu2004.rst
@@ -27,7 +27,7 @@ ubuntu apt repositories; in order to install it:
 
 .. code-block:: shell
 
-   curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py
+   curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
    sudo python2 ./get-pip.py
 
    # And verify the installation


### PR DESCRIPTION
Use updated url for python2 version of pip.
