### PR TITLE
pimd: Fix hold time related issues

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8991,7 +8991,7 @@ DEFUN (interface_ip_pim_hello,
 
 DEFUN (interface_no_ip_pim_hello,
        interface_no_ip_pim_hello_cmd,
-       "no ip pim hello [(1-180) (1-180)]",
+       "no ip pim hello [(1-180) [(1-180)]]",
        NO_STR
        IP_STR
        PIM_STR

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1094,6 +1094,8 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 
 			json_object_int_add(json_row, "helloPeriod",
 					    pim_ifp->pim_hello_period);
+			json_object_int_add(json_row, "holdTime",
+					    PIM_IF_DEFAULT_HOLDTIME(pim_ifp));
 			json_object_string_add(json_row, "helloTimer",
 					       hello_timer);
 			json_object_string_add(json_row, "helloStatStart",
@@ -1243,6 +1245,8 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 			vty_out(vty, "------\n");
 			vty_out(vty, "Period         : %d\n",
 				pim_ifp->pim_hello_period);
+			vty_out(vty, "HoldTime       : %d\n",
+				PIM_IF_DEFAULT_HOLDTIME(pim_ifp));
 			vty_out(vty, "Timer          : %s\n", hello_timer);
 			vty_out(vty, "StatStart      : %s\n", stat_uptime);
 			vty_out(vty, "Receive        : %d\n",

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1830,6 +1830,7 @@ int lib_interface_pim_hello_interval_modify(struct nb_cb_modify_args *args)
 		pim_ifp = ifp->info;
 		pim_ifp->pim_hello_period =
 			yang_dnode_get_uint8(args->dnode, NULL);
+		pim_ifp->pim_default_holdtime = -1;
 		break;
 	}
 

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -294,6 +294,9 @@ module frr-pim {
       type uint8 {
         range "1..180";
       }
+      must ". > ./../hello-interval" {
+      error-message "HoldTime must be greater than Hello";
+      }
       description
         "Hello holdtime";
     }


### PR DESCRIPTION
Issue 1:
PIM neighbor not coming up if hold time is less than hello timer
since hello is sent every 4 sec and hold is 1 sec,
because of this nbr is flapping
Also included display of hold time in CLI 'show ip pim int <intf>' cmd
and json commands.

Issue2:
pimd: in 'no ip pim hello' make "hold time" as optional when undo config

Fix:
Do not allow configuration of hold timer less than hello timer
Also reset the value of hold timer to 3.5 times to hello whenever
only hello is modified so that the relationship holds good.
Make the hold time as optional when undo config.

Signed-off-by: Mobashshera Rasool<mrasool@vmware.com>