### PR TITLE
ospf6d: Release last dbdesc packet after router dead interval

### DIFF
--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -89,6 +89,9 @@ struct ospf6_neighbor {
 	/* Inactivity timer */
 	struct thread *inactivity_timer;
 
+	/* Timer to release the last dbdesc packet */
+	struct thread *last_dbdesc_release_timer;
+
 	/* Thread for sending message */
 	struct thread *thread_send_dbdesc;
 	struct thread *thread_send_lsreq;


### PR DESCRIPTION
During the database description exchange process, the slave
releases the last dbdesc packet after router_dead_interval.
This was not implemented in the code.
I have written the function ospf6_neighbor_last_dbdesc_release,
which releases the last dbdesc packet after router_dead_interval.
This change was required as per the conformance test 13.11:

In state Full reception of a Database Description packet from
the master after this interval (RouterDeadInterval) will
generate a SeqNumberMismatch neighbor event.

Test Actions
1.
2. 3.
ANVL: Establish full adjacency with DUT for neighbor Rtr-0-A on DIface-0, with DUT as slave.
ANVL: Wait (for <RouterDeadInterval> seconds).
ANVL: Send <OSPF-DD> packet from neighbor Rtr-0-A to DIface-0 containing:
• •
I-bit field not set
M-bit field not set
MS-bit field set
DD sequence number same as the one last sent by ANVL.

. ANVL: Listen (for upto 2 * <RxmtInterval> seconds) on DIface-0.
5. DUT: Trigger the event SeqNumberMismatch and set the neighbor state for neighbor Rtr-0-A to ExStart.
6. DUT: Send <OSPF-DD> packet.
7. ANVL: Verify that the received <OSPF-DD> packet contains:
• I-bit field set
• M-bit field set
• M-bit field set
• MS-bit field set.

Test Reference
• RFC 5340, s4.2.1.2 p19 Sending Database Description Packets
  RFC 2328, s10.8 p104 Sending Database Description Packets.

Signed-off-by: Yash Ranjan <ranjany@vmware.com>