### PR TITLE
ospf6d: Fix when an "export-list" or "filter-list out" is configured

### DIFF
--- a/ospf6d/ospf6_abr.h
+++ b/ospf6d/ospf6_abr.h
@@ -73,6 +73,7 @@ extern void ospf6_abr_examin_brouter(uint32_t router_id,
 				     struct ospf6_route *route,
 				     struct ospf6 *ospf6);
 extern void ospf6_abr_reimport(struct ospf6_area *oa);
+extern void ospf6_abr_reexport(struct ospf6_area *oa);
 extern void ospf6_abr_range_reset_cost(struct ospf6 *ospf6);
 extern void ospf6_abr_prefix_resummarize(struct ospf6 *ospf6);
 
@@ -86,5 +87,6 @@ extern void ospf6_abr_old_path_update(struct ospf6_route *old_route,
 				      struct ospf6_route *route,
 				      struct ospf6_route_table *table);
 extern void ospf6_abr_init(void);
+extern void ospf6_abr_reexport(struct ospf6_area *oa);
 
 #endif /*OSPF6_ABR_H*/

--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -148,6 +148,7 @@ extern void ospf6_area_show(struct vty *, struct ospf6_area *,
 			    json_object *json_areas, bool use_json);
 
 extern void ospf6_area_plist_update(struct prefix_list *plist, int add);
+extern void ospf6_filter_update(struct access_list *access);
 extern void ospf6_area_config_write(struct vty *vty, struct ospf6 *ospf6);
 extern void ospf6_area_init(void);
 struct ospf6_interface;

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -381,7 +381,8 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 		} else {
 			/* (d) add retrans-list, schedule retransmission */
 			if (is_debug)
-				zlog_debug("Add retrans-list of this neighbor");
+				zlog_debug("Add retrans-list of neighbor %s ",
+					   on->name);
 			ospf6_increment_retrans_count(lsa);
 			ospf6_lsdb_add(ospf6_lsa_copy(lsa), on->retrans_list);
 			thread_add_timer(master, ospf6_lsupdate_send_neighbor,
@@ -395,7 +396,8 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 	if (retrans_added == 0) {
 		if (is_debug)
 			zlog_debug(
-				"No retransmission scheduled, next interface");
+				"No retransmission scheduled, next interface %s",
+				oi->interface->name);
 		return;
 	}
 

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1672,7 +1672,7 @@ void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 
 			if (IS_OSPF6_DEBUG_EXAMIN(INTRA_PREFIX))
 				zlog_debug(
-					"%s: route %pFX %p with final effective paths %u nh%u",
+					"%s: route %pFX %p with final effective paths %u nh %u",
 					__func__, &route->prefix,
 					(void *)old_route,
 					old_route->paths

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -25,6 +25,7 @@
 #include "vty.h"
 #include "command.h"
 #include "plist.h"
+#include "filter.h"
 
 #include "ospf6_proto.h"
 #include "ospf6_top.h"
@@ -1123,8 +1124,11 @@ void ospf6_init(struct thread_master *master)
 	ospf6_asbr_init();
 	ospf6_abr_init();
 
+	/* initialize hooks for modifying filter rules */
 	prefix_list_add_hook(ospf6_plist_add);
 	prefix_list_delete_hook(ospf6_plist_del);
+	access_list_add_hook(ospf6_filter_update);
+	access_list_delete_hook(ospf6_filter_update);
 
 	ospf6_bfd_init();
 	install_node(&debug_node);


### PR DESCRIPTION
When an "export-list" or "filter-list out" was configured on an area the
filter was not applied to existing database.    The user would either have
to restart the neighboring router in the other area or issue a "clear ipv6
ospf6 interface" to cause the neighbor router to resend it's LSAs.   The
new filter would then be applied to these LSAs and permit or deny summary
LSAs from being added/removed from the database.  The code now applies the
filters to the existing database without user needing to take any action
to clear ospfv3 adjacencies.

The second part of the problem was if a rule changed the updated filter was
not reapplied.  The code has been modified to now process the rule update and
reapply the filter.


Signed-off-by: Lynne Morrison <lynne@voltanet.io>