### PR TITLE
ospf6d: fix ospf6_abr_examin_summary to check for a path cost change

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -1209,7 +1209,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 	 */
 	if (old_entry_updated == false) {
 		if ((old == NULL) || (old->type != route->type)
-		    || (old->path.type != route->path.type))
+		    || (old->path.type != route->path.type)
+		    || (old->path.cost != route->path.cost))
 			add_route = true;
 	}
 


### PR DESCRIPTION
Fixes a regression in test case: anvl-ospfv3-16.14.

Signed-off-by: Karen Schoener <karen@voltanet.io>