### PR TITLE
Enable basic travis CI using new Ubuntu docker containers 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+dist: focal
+os: linux
+language: c
+services:
+  - docker
+jobs:
+  include:
+   - script:
+       - docker/centos-7/build.sh
+       - docker images
+     name: centos7
+   - script:
+       - docker/centos-8/build.sh
+       - docker images
+     name: centos8
+   - script:
+       - sudo apt install -y linux-modules-extra-$(uname -r)
+       - docker build -t frr-ubuntu18:latest -f docker/ubuntu18-ci/Dockerfile .
+       - docker images
+       - uname -a
+       - docker run -d --privileged --name frr-ubuntu18 --mount type=bind,source=/lib/modules,target=/lib/modules frr-ubuntu18:latest
+       - docker ps
+       - docker exec frr-ubuntu18 bash -c 'cd ~/frr ; make check'
+       - docker exec frr-ubuntu18 bash -c 'ps agxu ; lsmod | grep mpls || true'
+       - docker exec frr-ubuntu18 bash -c 'cd ~/frr/tests/topotests/ospf-topo1 ; sudo pytest test_ospf_topo1.py'
+       - docker exec frr-ubuntu18 bash -c 'cd ~/frr/tests/topotests/bgp_l3vpn_to_bgp_vrf ; sudo pytest test_bgp_l3vpn_to_bgp_vrf.py'
+     name: ubuntu18+minimalCI
+   - script:
+       - sudo apt install -y linux-modules-extra-$(uname -r)
+       - docker build -t frr-ubuntu20:latest -f docker/ubuntu20-ci/Dockerfile .
+       - docker images
+       - uname -a
+       - docker run -d --privileged --name frr-ubuntu20 --mount type=bind,source=/lib/modules,target=/lib/modules frr-ubuntu20:latest
+       - docker ps
+       - docker exec frr-ubuntu20 bash -c 'cd ~/frr ; make check'
+       - docker exec frr-ubuntu20 bash -c 'ps agxu ; lsmod | grep mpls || true'
+       - docker exec frr-ubuntu20 bash -c 'cd ~/frr/tests/topotests/ospf-topo1 ; sudo pytest test_ospf_topo1.py'
+       - docker exec frr-ubuntu20 bash -c 'cd ~/frr/tests/topotests/bgp_l3vpn_to_bgp_vrf ; sudo pytest test_bgp_l3vpn_to_bgp_vrf.py'
+     name: ubuntu20+minimalCI
+

--- a/doc/developer/building-docker.rst
+++ b/doc/developer/building-docker.rst
@@ -12,6 +12,13 @@ source-built FRR on the following base platforms:
 * Centos 7
 * Centos 8
 
+The following platform images are used to support Travis CI and can also
+be used to reproduce topotest failures when the docker host is Ubuntu
+(tested on 18.04 and 20.04):
+
+* Ubuntu 18.04
+* Ubuntu 20.04
+
 The following platform images may also be built, but these simply install a
 binary package from an existing repository and do not perform source builds:
 
@@ -99,3 +106,60 @@ No script::
 No script, multi-arch (ex. amd64, arm64)::
 
    docker buildx build --platform linux/amd64,linux/arm64 -f docker/centos-8/Dockerfile -t frr-centos8:latest .
+
+
+
+Building Ubuntu 18.04 Image
+---------------------------
+
+Build image (from project root directory)::
+
+   docker build -t frr-ubuntu18:latest  -f docker/ubuntu18-ci/Dockerfile .
+
+Start the container::
+
+   docker run -d --privileged --name frr-ubuntu18 --mount type=bind,source=/lib/modules,target=/lib/modules frr-ubuntu18:latest
+
+Running a topotest (when the docker host is Ubuntu)::
+
+   docker exec frr-ubuntu18 bash -c 'cd ~/frr/tests/topotests/ospf-topo1 ; sudo pytest test_ospf_topo1.py'
+
+Starting an interactive bash session::
+
+   docker exec -it frr-ubuntu18 bash
+
+Stopping an removing a container::
+
+   docker stop frr-ubuntu18 ; docker rm frr-ubuntu18
+
+Removing the built image::
+
+   docker rmi frr-ubuntu18:latest
+
+
+Building Ubuntu 20.04 Image
+---------------------------
+
+Build image (from project root directory)::
+
+   docker build -t frr-ubuntu20:latest  -f docker/ubuntu20-ci/Dockerfile .
+
+Start the container::
+
+   docker run -d --privileged --name frr-ubuntu20 --mount type=bind,source=/lib/modules,target=/lib/modules frr-ubuntu20:latest
+
+Running a topotest (when the docker host is Ubuntu)::
+
+   docker exec frr-ubuntu20 bash -c 'cd ~/frr/tests/topotests/ospf-topo1 ; sudo pytest test_ospf_topo1.py'
+
+Starting an interactive bash session::
+
+   docker exec -it frr-ubuntu20 bash
+
+Stopping an removing a container::
+
+   docker stop frr-ubuntu20 ; docker rm frr-ubuntu20
+
+Removing the built image::
+
+   docker rmi frr-ubuntu20:latest

--- a/docker/ubuntu18-ci/Dockerfile
+++ b/docker/ubuntu18-ci/Dockerfile
@@ -1,0 +1,71 @@
+FROM ubuntu:18.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
+# Update Ubuntu Software repository
+RUN apt update && \
+    apt-get install -y \
+      git autoconf automake libtool make libreadline-dev texinfo \
+      pkg-config libpam0g-dev libjson-c-dev bison flex python3-pytest \
+      libc-ares-dev python3-dev libsystemd-dev python-ipaddress python3-sphinx \
+      install-info build-essential libsystemd-dev libsnmp-dev perl libcap-dev \
+      libelf-dev \
+      sudo gdb iputils-ping time \
+      mininet python-pip iproute2 iperf && \
+      pip install ipaddr && \
+      pip install "pytest<5" && \
+      pip install "scapy>=2.4.2" && \
+      pip install exabgp==3.4.17
+
+RUN groupadd -r -g 92 frr && \
+      groupadd -r -g 85 frrvty && \
+      adduser --system --ingroup frr --home /home/frr \
+              --gecos "FRR suite" --shell /bin/bash frr && \
+      usermod -a -G frrvty frr && \
+      useradd -d /var/run/exabgp/ -s /bin/false exabgp && \
+      echo 'frr ALL = NOPASSWD: ALL' | tee /etc/sudoers.d/frr && \
+      mkdir -p /home/frr && chown frr.frr /home/frr
+
+#for libyang 1
+RUN apt-get install -y cmake libpcre3-dev
+
+USER frr:frr
+
+# build and install libyang1
+RUN cd && pwd && ls -al && \
+    git clone https://github.com/CESNET/libyang.git && \
+    cd libyang && \
+    git checkout v1.0.225 && \
+    mkdir build; cd build && \
+    cmake -DENABLE_LYD_PRIV=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+          -D CMAKE_BUILD_TYPE:String="Release" .. && \
+    make -j $(nproc) && \
+    sudo make install
+
+COPY --chown=frr:frr . /home/frr/frr/
+
+RUN cd && ls -al && ls -al frr
+
+RUN cd ~/frr && \
+    ./bootstrap.sh  && \
+    ./configure \
+       --prefix=/usr \
+       --localstatedir=/var/run/frr \
+       --sbindir=/usr/lib/frr \
+       --sysconfdir=/etc/frr \
+       --enable-vtysh \
+       --enable-pimd \
+       --enable-sharpd \
+       --enable-multipath=64 \
+       --enable-user=frr \
+       --enable-group=frr \
+       --enable-vty-group=frrvty \
+       --enable-snmp=agentx \
+       --with-pkg-extra-version=-my-manual-build && \
+    make -j $(nproc) && \
+    sudo make install
+
+RUN cd ~/frr && make check || true
+
+COPY docker/ubuntu18-ci/docker-start /usr/sbin/docker-start
+ENTRYPOINT ["/usr/sbin/docker-start"]

--- a/docker/ubuntu18-ci/README.md
+++ b/docker/ubuntu18-ci/README.md
@@ -1,0 +1,44 @@
+# Ubuntu 18.04
+
+This builds an ubuntu 18.04 container for dev / test
+
+# Build
+
+```
+docker build -t frr-ubuntu18:latest  -f docker/ubuntu18-ci/Dockerfile .
+```
+
+# Running
+
+```
+docker run -d --privileged --name frr-ubuntu18 --mount type=bind,source=/lib/modules,target=/lib/modules frr-ubuntu18:latest
+```
+
+# make check
+
+```
+docker exec frr-ubuntu18 bash -c 'cd ~/frr ; make check'
+```
+
+# interactive bash
+```
+docker exec -it frr-ubuntu18 bash
+```
+
+# topotest -- when Host O/S is Ubuntu only
+
+```
+docker exec frr-ubuntu18 bash -c 'cd ~/frr/tests/topotests/ospf-topo1 ; sudo pytest test_ospf_topo1.py'
+```
+
+# stop & remove container
+
+```
+docker stop frr-ubuntu18 ; docker rm frr-ubuntu18
+```
+
+# remove image
+
+```
+docker rmi frr-ubuntu18:latest
+```

--- a/docker/ubuntu18-ci/docker-start
+++ b/docker/ubuntu18-ci/docker-start
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ $(uname -a | grep -ci Ubuntu) -ge 1 ]; then
+    #for topotests under ubuntu host
+    sudo modprobe mpls-router mpls-iptunnel
+    sudo /etc/init.d/openvswitch-switch start
+fi
+while true ; do sleep 365d ; done

--- a/docker/ubuntu20-ci/Dockerfile
+++ b/docker/ubuntu20-ci/Dockerfile
@@ -1,0 +1,74 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
+# Update Ubuntu Software repository
+RUN apt update && \
+    apt-get install -y \
+      git autoconf automake libtool make libreadline-dev texinfo \
+      pkg-config libpam0g-dev libjson-c-dev bison flex python3-pytest \
+      libc-ares-dev python3-dev libsystemd-dev python-ipaddress python3-sphinx \
+      install-info build-essential libsystemd-dev libsnmp-dev perl \
+      libcap-dev python2 libelf-dev \
+      sudo gdb curl iputils-ping time \
+      mininet iproute2 iperf && \
+      curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output /tmp/get-pip.py && \
+      python2 /tmp/get-pip.py && \
+      rm -f  /tmp/get-pip.py && \
+      pip2 install ipaddr && \
+      pip2 install "pytest<5" && \
+      pip2 install "scapy>=2.4.2" && \
+      pip2 install exabgp==3.4.17
+
+RUN groupadd -r -g 92 frr && \
+      groupadd -r -g 85 frrvty && \
+      adduser --system --ingroup frr --home /home/frr \
+              --gecos "FRR suite" --shell /bin/bash frr && \
+      usermod -a -G frrvty frr && \
+      useradd -d /var/run/exabgp/ -s /bin/false exabgp && \
+      echo 'frr ALL = NOPASSWD: ALL' | tee /etc/sudoers.d/frr && \
+      mkdir -p /home/frr && chown frr.frr /home/frr
+
+#for libyang 1
+RUN apt-get install -y cmake libpcre3-dev
+
+USER frr:frr
+
+# build and install libyang1
+RUN cd && pwd && ls -al && \
+    git clone https://github.com/CESNET/libyang.git && \
+    cd libyang && \
+    git checkout v1.0.225 && \
+    mkdir build; cd build && \
+    cmake -DENABLE_LYD_PRIV=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+          -D CMAKE_BUILD_TYPE:String="Release" .. && \
+    make -j $(nproc) && \
+    sudo make install
+
+COPY --chown=frr:frr . /home/frr/frr/
+
+RUN cd && ls -al && ls -al frr
+
+RUN cd ~/frr && \
+    ./bootstrap.sh  && \
+    ./configure \
+       --prefix=/usr \
+       --localstatedir=/var/run/frr \
+       --sbindir=/usr/lib/frr \
+       --sysconfdir=/etc/frr \
+       --enable-vtysh \
+       --enable-pimd \
+       --enable-sharpd \
+       --enable-multipath=64 \
+       --enable-user=frr \
+       --enable-group=frr \
+       --enable-vty-group=frrvty \
+       --enable-snmp=agentx \
+       --with-pkg-extra-version=-my-manual-build && \
+    make -j $(nproc) && \
+    sudo make install
+
+RUN cd ~/frr && make check || true
+
+COPY docker/ubuntu20-ci/docker-start /usr/sbin/docker-start
+ENTRYPOINT ["/usr/sbin/docker-start"]

--- a/docker/ubuntu20-ci/README.md
+++ b/docker/ubuntu20-ci/README.md
@@ -1,0 +1,45 @@
+# Ubuntu 20.04
+
+This builds an ubuntu 20.04 container for dev / test
+
+# Build
+
+```
+docker build -t frr-ubuntu20:latest  -f docker/ubuntu20-ci/Dockerfile .
+```
+
+# Running
+
+```
+docker run -d --privileged --name frr-ubuntu20 --mount type=bind,source=/lib/modules,target=/lib/modules frr-ubuntu20:latest
+```
+
+# make check
+
+```
+docker exec frr-ubuntu20 bash -c 'cd ~/frr ; make check'
+```
+
+# interactive bash
+
+```
+docker exec -it frr-ubuntu20 bash
+```
+
+# topotest -- when Host O/S is Ubuntu only
+
+```
+docker exec frr-ubuntu20 bash -c 'cd ~/frr/tests/topotests/ospf-topo1 ; sudo pytest test_ospf_topo1.py'
+```
+
+# stop & remove container
+
+```
+docker stop frr-ubuntu20 ; docker rm frr-ubuntu18
+```
+
+# remove image
+
+```
+docker rmi frr-ubuntu20:latest
+```

--- a/docker/ubuntu20-ci/docker-start
+++ b/docker/ubuntu20-ci/docker-start
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ $(uname -a | grep -ci Ubuntu) -ge 1 ]; then
+    #for topotests under ubuntu host
+    sudo modprobe mpls-router mpls-iptunnel
+    sudo /etc/init.d/openvswitch-switch start
+fi
+while true ; do sleep 365d ; done


### PR DESCRIPTION
Ubuntu containers can also be used for dev/test - including reproducing issues found in CI

The hope is that this minimalist  / pr0of-of-concept CI usage will be expanded upon. E.g.,  publishing containers on a successful CI run for master, more sophisticated testing, etc....