### PR TITLE
[7.5] *: modify VRF_CONFIGURED flag only in VRF NB layer

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -1063,7 +1063,7 @@ static int lib_vrf_create(struct nb_cb_create_args *args)
 
 	vrfp = vrf_get(VRF_UNKNOWN, vrfname);
 
-	vrf_set_user_cfged(vrfp);
+	SET_FLAG(vrfp->status, VRF_CONFIGURED);
 	nb_running_set_entry(args->dnode, vrfp);
 
 	return NB_OK;
@@ -1089,7 +1089,7 @@ static int lib_vrf_destroy(struct nb_cb_destroy_args *args)
 		vrfp = nb_running_unset_entry(args->dnode);
 
 		/* Clear configured flag and invoke delete. */
-		vrf_reset_user_cfged(vrfp);
+		UNSET_FLAG(vrfp->status, VRF_CONFIGURED);
 		vrf_delete(vrfp);
 		break;
 	}

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -158,18 +158,6 @@ static inline int vrf_is_user_cfged(struct vrf *vrf)
 	return vrf && CHECK_FLAG(vrf->status, VRF_CONFIGURED);
 }
 
-/* Mark that VRF has user configuration */
-static inline void vrf_set_user_cfged(struct vrf *vrf)
-{
-	SET_FLAG(vrf->status, VRF_CONFIGURED);
-}
-
-/* Mark that VRF no longer has any user configuration */
-static inline void vrf_reset_user_cfged(struct vrf *vrf)
-{
-	UNSET_FLAG(vrf->status, VRF_CONFIGURED);
-}
-
 /*
  * Utilities to obtain the user data
  */

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -77,9 +77,6 @@ struct route_node *static_add_route(afi_t afi, safi_t safi, struct prefix *p,
 
 	rn->info = si;
 
-	/* Mark as having FRR configuration */
-	vrf_set_user_cfged(svrf->vrf);
-
 	return rn;
 }
 
@@ -98,9 +95,6 @@ static void static_del_src_route(struct route_node *rn, safi_t safi,
 
 	XFREE(MTYPE_STATIC_ROUTE, rn->info);
 	route_unlock_node(rn);
-	/* If no other FRR config for this VRF, mark accordingly. */
-	if (!static_vrf_has_config(svrf))
-		vrf_reset_user_cfged(svrf->vrf);
 }
 
 void static_del_route(struct route_node *rn, safi_t safi,
@@ -130,9 +124,6 @@ void static_del_route(struct route_node *rn, safi_t safi,
 	}
 	XFREE(MTYPE_STATIC_ROUTE, rn->info);
 	route_unlock_node(rn);
-	/* If no other FRR config for this VRF, mark accordingly. */
-	if (!static_vrf_has_config(svrf))
-		vrf_reset_user_cfged(svrf->vrf);
 }
 
 bool static_add_nexthop_validate(const char *nh_vrf_name, static_types type,

--- a/staticd/static_vrf.c
+++ b/staticd/static_vrf.c
@@ -228,29 +228,6 @@ static int static_vrf_config_write(struct vty *vty)
 	return 0;
 }
 
-int static_vrf_has_config(struct static_vrf *svrf)
-{
-	struct route_table *table;
-	safi_t safi;
-	afi_t afi;
-
-	/*
-	 * NOTE: This is a don't care for the default VRF, but we go through
-	 * the motions to keep things consistent.
-	 */
-	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
-		for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
-			table = svrf->stable[afi][safi];
-			if (!table)
-				continue;
-			if (route_table_count(table))
-				return 1;
-		}
-	}
-
-	return 0;
-}
-
 void static_vrf_init(void)
 {
 	vrf_init(static_vrf_new, static_vrf_enable,

--- a/staticd/static_vrf.h
+++ b/staticd/static_vrf.h
@@ -37,8 +37,6 @@ struct stable_info {
 struct static_vrf *static_vrf_lookup_by_name(const char *vrf_name);
 struct static_vrf *static_vrf_lookup_by_id(vrf_id_t vrf_id);
 
-int static_vrf_has_config(struct static_vrf *svrf);
-
 void static_vrf_init(void);
 
 struct route_table *static_vrf_static_table(afi_t afi, safi_t safi,

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1265,9 +1265,6 @@ int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)
 			return NB_ERR;
 		}
 
-		/* Mark as having FRR configuration */
-		vrf_set_user_cfged(vrf);
-
 		break;
 	}
 
@@ -1314,10 +1311,6 @@ int lib_vrf_zebra_l3vni_id_destroy(struct nb_cb_destroy_args *args)
 					vni, err);
 			return NB_ERR;
 		}
-
-		/* If no other FRR config for this VRF, mark accordingly. */
-		if (!zebra_vrf_has_config(zvrf))
-			vrf_reset_user_cfged(vrf);
 
 		break;
 	}

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -339,20 +339,6 @@ static int zebra_vrf_update(struct vrf *vrf)
 	return 0;
 }
 
-
-/* Return if this VRF has any FRR configuration or not.
- * IMPORTANT: This function needs to be updated when additional configuration
- * is added for a VRF.
- */
-int zebra_vrf_has_config(struct zebra_vrf *zvrf)
-{
-	/* EVPN L3-VNI? */
-	if (zvrf->l3vni)
-		return 1;
-
-	return 0;
-}
-
 /* Lookup the routing table in a VRF based on both VRF-Id and table-id.
  * NOTE: Table-id is relevant on two modes:
  * - case VRF backend is default : on default VRF only

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -254,7 +254,6 @@ extern struct zebra_vrf *zebra_vrf_lookup_by_name(const char *);
 extern struct zebra_vrf *zebra_vrf_alloc(void);
 extern struct route_table *zebra_vrf_table(afi_t, safi_t, vrf_id_t);
 
-extern int zebra_vrf_has_config(struct zebra_vrf *zvrf);
 extern void zebra_vrf_init(void);
 
 extern void zebra_rtable_node_cleanup(struct route_table *table,


### PR DESCRIPTION
This is to fix the crash reproduced by the following steps:

* ip link add red type vrf table 1

  Creates VRF.

* vtysh -c "conf" -c "vrf red"

  Creates VRF NB node and marks VRF as configured.

* ip route 1.1.1.0/24 2.2.2.2 vrf red
* no ip route 1.1.1.0/24 2.2.2.2 vrf red
  (or similar l3vni set/unset in zebra)

  Marks VRF as NOT configured.

* ip link del red

  VRF is deleted, because it is marked as not configured, but NB node
  stays.

Subsequent attempt to configure something in the VRF leads to a crash
because of the stale pointer in NB layer.

Fixes #8357.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>