### PR TITLE
bgpd: vrf route leaking related fixes

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1294,15 +1294,19 @@ bool ecommunity_del_val(struct ecommunity *ecom, struct ecommunity_val *eval)
 
 	/* Delete the selected value */
 	ecom->size--;
-	p = XMALLOC(MTYPE_ECOMMUNITY_VAL, ecom->size * ecom->unit_size);
-	if (c != 0)
-		memcpy(p, ecom->val, c * ecom->unit_size);
-	if ((ecom->size - c) != 0)
-		memcpy(p + (c)*ecom->unit_size,
-		       ecom->val + (c + 1) * ecom->unit_size,
-		       (ecom->size - c) * ecom->unit_size);
-	XFREE(MTYPE_ECOMMUNITY_VAL, ecom->val);
-	ecom->val = p;
+	if (ecom->size) {
+		p = XMALLOC(MTYPE_ECOMMUNITY_VAL, ecom->size * ecom->unit_size);
+		if (c != 0)
+			memcpy(p, ecom->val, c * ecom->unit_size);
+		if ((ecom->size - c) != 0)
+			memcpy(p + (c)*ecom->unit_size,
+			       ecom->val + (c + 1) * ecom->unit_size,
+			       (ecom->size - c) * ecom->unit_size);
+		XFREE(MTYPE_ECOMMUNITY_VAL, ecom->val);
+		ecom->val = p;
+	} else
+		ecom->val = NULL;
+
 	return true;
 }
 

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -540,6 +540,17 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	if (bpi) {
 		bool labelssame = labels_same(bpi, label, num_labels);
 
+		if (CHECK_FLAG(source_bpi->flags, BGP_PATH_REMOVED)
+		    && CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
+			if (debug) {
+				zlog_debug(
+					"%s: ->%s(s_flags: 0x%x b_flags: 0x%x): %pFX: Found route, being removed, not leaking",
+					__func__, bgp->name_pretty,
+					source_bpi->flags, bpi->flags, p);
+			}
+			return NULL;
+		}
+
 		if (attrhash_cmp(bpi->attr, new_attr) && labelssame
 		    && !CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
 
@@ -611,6 +622,16 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 				   __func__, bgp->name_pretty, bn);
 
 		return bpi;
+	}
+
+	if (CHECK_FLAG(source_bpi->flags, BGP_PATH_REMOVED)) {
+		if (debug) {
+			zlog_debug(
+				"%s: ->%s(s_flags: 0x%x): %pFX: New route, being removed, not leaking",
+				__func__, bgp->name_pretty,
+				source_bpi->flags, p);
+		}
+		return NULL;
 	}
 
 	new = info_make(ZEBRA_ROUTE_BGP, BGP_ROUTE_IMPORTED, 0,

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1027,6 +1027,8 @@ void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn, /* to */
 					if (debug)
 						zlog_debug("%s: deleting it",
 							   __func__);
+					/* withdraw from leak-to vrfs as well */
+					vpn_leak_to_vrf_withdraw(bgp_vpn, bpi);
 					bgp_aggregate_decrement(
 						bgp_vpn,
 						bgp_dest_get_prefix(bn), bpi,

--- a/bgpd/bgp_nb_config.c
+++ b/bgpd/bgp_nb_config.c
@@ -123,7 +123,12 @@ int bgp_router_create(struct nb_cb_create_args *args)
 		if (is_new_bgp && inst_type == BGP_INSTANCE_TYPE_DEFAULT)
 			vpn_leak_postchange_all();
 
-		if (inst_type == BGP_INSTANCE_TYPE_VRF)
+		/*
+		 * Check if we need to export to other VRF(s).
+		 * Leak the routes to importing bgp vrf instances,
+		 * only when new bgp vrf instance is configured.
+		 */
+		if (ret != BGP_INSTANCE_EXISTS)
 			bgp_vpn_leak_export(bgp);
 
 		UNSET_FLAG(bgp->vrf_flags, BGP_VRF_AUTO);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1700,9 +1700,6 @@ int bgp_redistribute_set(struct bgp *bgp, afi_t afi, int type,
 
 		redist_add_instance(&zclient->mi_redist[afi][type], instance);
 	} else {
-		if (vrf_bitmap_check(zclient->redist[afi][type], bgp->vrf_id))
-			return CMD_WARNING;
-
 #ifdef ENABLE_BGP_VNC
 		if (EVPN_ENABLED(bgp) && type == ZEBRA_ROUTE_VNC_DIRECT) {
 			vnc_export_bgp_enable(

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3402,7 +3402,7 @@ int bgp_get(struct bgp **bgp_val, as_t *as, const char *name,
 		return ret;
 	case BGP_SUCCESS:
 		if (*bgp_val)
-			return ret;
+			return BGP_INSTANCE_EXISTS;
 	}
 
 	bgp = bgp_create(as, name, inst_type);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1844,6 +1844,7 @@ enum bgp_clear_type {
 /* BGP error codes.  */
 #define BGP_SUCCESS                               0
 #define BGP_CREATED                               1
+#define BGP_INSTANCE_EXISTS                       2
 #define BGP_ERR_INVALID_VALUE                    -1
 #define BGP_ERR_INVALID_FLAG                     -2
 #define BGP_ERR_INVALID_AS                       -3

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -347,17 +347,12 @@ void zebra_redistribute_add(ZAPI_HANDLER_ARGS)
 					   zvrf_id(zvrf), afi);
 		}
 	} else {
-		if (!vrf_bitmap_check(client->redist[afi][type],
-				      zvrf_id(zvrf))) {
-			if (IS_ZEBRA_DEBUG_EVENT)
-				zlog_debug(
-					"%s: setting vrf %s(%u) redist bitmap",
-					__func__, VRF_LOGNAME(zvrf->vrf),
-					zvrf_id(zvrf));
-			vrf_bitmap_set(client->redist[afi][type],
-				       zvrf_id(zvrf));
-			zebra_redistribute(client, type, 0, zvrf_id(zvrf), afi);
-		}
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s: setting vrf %s(%u) redist bitmap",
+				   __func__, VRF_LOGNAME(zvrf->vrf),
+				   zvrf_id(zvrf));
+		vrf_bitmap_set(client->redist[afi][type], zvrf_id(zvrf));
+		zebra_redistribute(client, type, 0, zvrf_id(zvrf), afi);
 	}
 
 stream_failure:


### PR DESCRIPTION
Description:
Change is intended for fixing the following issues related to vrf route leaking:

1. FRR doesn't re-install the routes, imported from a tenant VRF,
when bgp instance for source vrf is deleted and re-added again.
When bgp instance is removed and re-added, when import statement is already there,
then route leaking stops between two VRFs.

2. Imported/leak-from routes do not get withdrawn/removed even if the source VRF is deleted.
Deleting and re-adding a tenant vrf, does not refresh the RIB.

3. After FRR restart, routes are not getting redistributed;
when routes added first and then 'redistribute static' cmd is issued.

4. While withdrawal of exported routes is in-progress, routes are marked as being removed and invalid.
In the mean time, if router bgp config is updated, which triggers exports routes from configured bgp vrf to VPN.
So withdraw-in-progress routes are again leaked to bgp vrf instance(s) importing routes (stale routes).

5. If the interface comes up after route leaking is configured, in the case of vpn router id update,
we delete the ecommunity value and never reconfigure the rtlist.
This results in skipping route leak to non-default vrfs (vpn to vrf).

Co-authored-by: Santosh P K sapk@vmware.com
Co-authored-by: Kantesh Mundaragi kmundaragi@vmware.com
Signed-off-by: Abhinay Ramesh rabhinay@vmware.com