### PR TITLE
ospfd: fix counting of "ip ospf area" commands

### DIFF
--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -338,6 +338,8 @@ extern void ospf_if_set_multicast(struct ospf_interface *);
 
 extern void ospf_if_interface(struct interface *ifp);
 
+extern uint32_t ospf_if_count_area_params(struct interface *ifp);
+
 DECLARE_HOOK(ospf_vl_add, (struct ospf_vl_data * vd), (vd));
 DECLARE_HOOK(ospf_vl_delete, (struct ospf_vl_data * vd), (vd));
 

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -577,6 +577,7 @@ DEFUN (ospf_network_area,
 	struct prefix_ipv4 p;
 	struct in_addr area_id;
 	int ret, format;
+	uint32_t count;
 
 	if (ospf->instance) {
 		vty_out(vty,
@@ -584,14 +585,15 @@ DEFUN (ospf_network_area,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	if (ospf->if_ospf_cli_count > 0) {
+	count = ospf_count_area_params(ospf);
+	if (count > 0) {
 		vty_out(vty,
 			"Please remove all ip ospf area x.x.x.x commands first.\n");
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
 				"%s ospf vrf %s num of %u ip ospf area x config",
 				__func__, ospf->name ? ospf->name : "NIL",
-				ospf->if_ospf_cli_count);
+				count);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
@@ -8821,10 +8823,8 @@ DEFUN (ip_ospf_area,
 
 		if (count > 0) {
 			ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
-			if (ospf) {
+			if (ospf)
 				ospf_interface_area_unset(ospf, ifp);
-				ospf->if_ospf_cli_count -= count;
-			}
 		}
 
 		return CMD_NOT_MY_INSTANCE;
@@ -8882,10 +8882,8 @@ DEFUN (ip_ospf_area,
 		params->if_area_id_fmt = format;
 	}
 
-	if (ospf) {
+	if (ospf)
 		ospf_interface_area_set(ospf, ifp);
-		ospf->if_ospf_cli_count++;
-	}
 
 	return CMD_SUCCESS;
 }
@@ -8951,7 +8949,6 @@ DEFUN (no_ip_ospf_area,
 
 	if (ospf) {
 		ospf_interface_area_unset(ospf, ifp);
-		ospf->if_ospf_cli_count--;
 		ospf_area_check_free(ospf, area_id);
 	}
 

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -310,11 +310,6 @@ struct ospf {
 	/* Statistics for LSA used for new instantiation. */
 	uint32_t rx_lsa_count;
 
-	/* Counter of "ip ospf area x.x.x.x" used
-	 * for mutual exclusion of network command under
-	 * router ospf or ip ospf area x under interface. */
-	uint32_t if_ospf_cli_count;
-
 	struct route_table *distance_table;
 
 	/* Used during ospf instance going down send LSDB
@@ -650,6 +645,7 @@ extern struct ospf *ospf_new_alloc(unsigned short instance, const char *name);
 extern struct ospf *ospf_lookup_by_inst_name(unsigned short instance,
 					     const char *name);
 extern struct ospf *ospf_lookup_by_vrf_id(vrf_id_t vrf_id);
+extern uint32_t ospf_count_area_params(struct ospf *ospf);
 extern void ospf_finish(struct ospf *);
 extern void ospf_process_refresh_data(struct ospf *ospf, bool reset);
 extern void ospf_router_id_update(struct ospf *ospf);


### PR DESCRIPTION
Instead of trying to maintain if_ospf_cli_count, let's directly count
the number of configured interfaces when it is needed. Current approach
sometimes leads to an incorrect counter.

Fixes #8321.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>