### PR TITLE
Added pathd to the init files

### DIFF
--- a/tools/etc/frr/daemons
+++ b/tools/etc/frr/daemons
@@ -30,6 +30,7 @@ pbrd=no
 bfdd=no
 fabricd=no
 vrrpd=no
+pathd=no
 
 #
 # If this option is set the /etc/init.d/frr script automatically loads
@@ -55,6 +56,7 @@ staticd_options="-A 127.0.0.1"
 bfdd_options="   -A 127.0.0.1"
 fabricd_options="-A 127.0.0.1"
 vrrpd_options="  -A 127.0.0.1"
+pathd_options="  -A 127.0.0.1"
 
 # configuration profile
 #

--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -35,7 +35,7 @@ FRR_DEFAULT_PROFILE="@DFLT_NAME@" # traditional / datacenter
 # - keep zebra first
 # - watchfrr does NOT belong in this list
 
-DAEMONS="zebra bgpd ripd ripngd ospfd ospf6d isisd babeld pimd ldpd nhrpd eigrpd sharpd pbrd staticd bfdd fabricd vrrpd"
+DAEMONS="zebra bgpd ripd ripngd ospfd ospf6d isisd babeld pimd ldpd nhrpd eigrpd sharpd pbrd staticd bfdd fabricd vrrpd pathd"
 RELOAD_SCRIPT="$D_PATH/frr-reload.py"
 
 #


### PR DESCRIPTION
Currently when compiling from source, the frrinit is not able to start pathd because it is missing in some example files. This patch adds pathd to the daemons example file, and adds it to the frrcommon DAEMONS list so frrwatch can start it. 

Signed-off-by: Erik Kooistra <me@erikkooistra.nl>