### PR TITLE
topotests: fix 'parse_topology' function in test_isis_topo1_vrf.py

### DIFF
--- a/tests/topotests/isis-topo1-vrf/r1/r1_topology.json
+++ b/tests/topotests/isis-topo1-vrf/r1/r1_topology.json
@@ -5,73 +5,73 @@
         {
           "vertex": "r1"
         }
-      ], 
+      ],
       "ipv6": [
         {
           "vertex": "r1"
         }
       ]
-    }, 
+    },
     "level-2": {
       "ipv4": [
         {
           "vertex": "r1"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP", 
+          "metric": "0",
+          "parent": "r1(4)",
+          "type": "IP internal",
           "vertex": "10.0.20.0/24"
-        }, 
+        },
         {
-          "interface": "r1-eth0", 
-          "metric": "10", 
-          "next-hop": "r3", 
-          "parent": "r1(4)", 
-          "type": "TE-IS", 
+          "interface": "r1-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r1(4)",
+          "type": "TE-IS",
           "vertex": "r3"
-        }, 
+        },
         {
-          "interface": "r3", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r1-eth0", 
-          "type": "IP", 
+          "interface": "r1-eth0",
+          "metric": "20",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.20.0/24"
-        }, 
+        },
         {
-          "interface": "r3", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r1-eth0", 
-          "type": "IP", 
+          "interface": "r1-eth0",
+          "metric": "20",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.10.0/24"
         }
-      ], 
+      ],
       "ipv6": [
         {
           "vertex": "r1"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP6", 
+          "metric": "0",
+          "parent": "r1(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:1::/64"
-        }, 
+        },
         {
-          "interface": "r1-eth0", 
-          "metric": "10", 
-          "next-hop": "r3", 
-          "parent": "r1(4)", 
-          "type": "TE-IS", 
+          "interface": "r1-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r1(4)",
+          "type": "TE-IS",
           "vertex": "r3"
-        }, 
+        },
         {
-          "interface": "r3", 
-          "metric": "internal", 
-          "next-hop": "20", 
-          "parent": "r1-eth0", 
-          "type": "IP6", 
+          "interface": "r1-eth0",
+          "metric": "20",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:1::/64"
         }
       ]

--- a/tests/topotests/isis-topo1-vrf/r2/r2_topology.json
+++ b/tests/topotests/isis-topo1-vrf/r2/r2_topology.json
@@ -5,73 +5,73 @@
         {
           "vertex": "r2"
         }
-      ], 
+      ],
       "ipv6": [
         {
           "vertex": "r2"
         }
       ]
-    }, 
+    },
     "level-2": {
       "ipv4": [
         {
           "vertex": "r2"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP", 
+          "metric": "0",
+          "parent": "r2(4)",
+          "type": "IP internal",
           "vertex": "10.0.21.0/24"
-        }, 
+        },
         {
-          "interface": "r2-eth0", 
-          "metric": "10", 
-          "next-hop": "r4", 
-          "parent": "r2(4)", 
-          "type": "TE-IS", 
+          "interface": "r2-eth0",
+          "metric": "10",
+          "next-hop": "r4",
+          "parent": "r2(4)",
+          "type": "TE-IS",
           "vertex": "r4"
-        }, 
+        },
         {
-          "interface": "r4", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r2-eth0", 
-          "type": "IP", 
+          "interface": "r2-eth0",
+          "metric": "20",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.0.21.0/24"
-        }, 
+        },
         {
-          "interface": "r4", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r2-eth0", 
-          "type": "IP", 
+          "interface": "r2-eth0",
+          "metric": "20",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.0.11.0/24"
         }
-      ], 
+      ],
       "ipv6": [
         {
           "vertex": "r2"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP6", 
+          "metric": "0",
+          "parent": "r2(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:2::/64"
-        }, 
+        },
         {
-          "interface": "r2-eth0", 
-          "metric": "10", 
-          "next-hop": "r4", 
-          "parent": "r2(4)", 
-          "type": "TE-IS", 
+          "interface": "r2-eth0",
+          "metric": "10",
+          "next-hop": "r4",
+          "parent": "r2(4)",
+          "type": "TE-IS",
           "vertex": "r4"
-        }, 
+        },
         {
-          "interface": "r4", 
-          "metric": "internal", 
-          "next-hop": "20", 
-          "parent": "r2-eth0", 
-          "type": "IP6", 
+          "interface": "r2-eth0",
+          "metric": "20",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:2::/64"
         }
       ]

--- a/tests/topotests/isis-topo1-vrf/r3/r3_topology.json
+++ b/tests/topotests/isis-topo1-vrf/r3/r3_topology.json
@@ -4,126 +4,126 @@
       "ipv4": [
         {
           "vertex": "r3"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP", 
+          "metric": "0",
+          "parent": "r3(4)",
+          "type": "IP internal",
           "vertex": "10.0.10.0/24"
-        }, 
+        },
         {
-          "interface": "r3-eth1", 
-          "metric": "10", 
-          "next-hop": "r5", 
-          "parent": "r3(4)", 
-          "type": "TE-IS", 
+          "interface": "r3-eth1",
+          "metric": "10",
+          "next-hop": "r5",
+          "parent": "r3(4)",
+          "type": "TE-IS",
           "vertex": "r5"
-        }, 
+        },
         {
-          "interface": "r5", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r3-eth1", 
-          "type": "IP", 
+          "interface": "r3-eth1",
+          "metric": "20",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP TE",
           "vertex": "10.0.10.0/24"
-        }, 
+        },
         {
-          "interface": "r5", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r3-eth1", 
-          "type": "IP", 
+          "interface": "r3-eth1",
+          "metric": "20",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP TE",
           "vertex": "10.0.11.0/24"
-        }, 
+        },
         {
-          "interface": "r5", 
-          "metric": "TE", 
-          "next-hop": "30", 
-          "parent": "r3-eth1", 
-          "type": "IP", 
+          "interface": "r3-eth1",
+          "metric": "30",
+          "next-hop": "r5",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.0.21.0/24"
         }
-      ], 
+      ],
       "ipv6": [
         {
           "vertex": "r3"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP6", 
+          "metric": "0",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:1::/64"
-        }, 
+        },
         {
-          "interface": "r3-eth1", 
-          "metric": "10", 
-          "next-hop": "r5", 
-          "parent": "r3(4)", 
-          "type": "TE-IS", 
+          "interface": "r3-eth1",
+          "metric": "10",
+          "next-hop": "r5",
+          "parent": "r3(4)",
+          "type": "TE-IS",
           "vertex": "r5"
-        }, 
+        },
         {
-          "interface": "r5", 
-          "metric": "internal", 
-          "next-hop": "20", 
-          "parent": "r3-eth1", 
-          "type": "IP6", 
+          "interface": "r3-eth1",
+          "metric": "20",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:2::/64"
-        }, 
+        },
         {
-          "interface": "r5", 
-          "metric": "internal", 
-          "next-hop": "30", 
-          "parent": "r3-eth1", 
-          "type": "IP6", 
+          "interface": "r3-eth1",
+          "metric": "30",
+          "next-hop": "r5",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:2::/64"
         }
       ]
-    }, 
+    },
     "level-2": {
       "ipv4": [
         {
           "vertex": "r3"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP", 
+          "metric": "0",
+          "parent": "r3(4)",
+          "type": "IP internal",
           "vertex": "10.0.20.0/24"
-        }, 
+        },
         {
-          "interface": "r3-eth0", 
-          "metric": "10", 
-          "next-hop": "r3", 
-          "parent": "r3(4)", 
-          "type": "TE-IS", 
+          "interface": "r3-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "TE-IS",
           "vertex": "r3"
-        }, 
+        },
         {
-          "interface": "r3", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r3-eth0", 
-          "type": "IP", 
+          "interface": "r3-eth0",
+          "metric": "20",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.20.0/24"
         }
-      ], 
+      ],
       "ipv6": [
         {
           "vertex": "r3"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP6", 
+          "metric": "0",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:1::/64"
-        }, 
+        },
         {
-          "interface": "r3-eth0", 
-          "metric": "10", 
-          "next-hop": "r3", 
-          "parent": "r3(4)", 
-          "type": "TE-IS", 
+          "interface": "r3-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "TE-IS",
           "vertex": "r3"
         }
       ]

--- a/tests/topotests/isis-topo1-vrf/r4/r4_topology.json
+++ b/tests/topotests/isis-topo1-vrf/r4/r4_topology.json
@@ -4,126 +4,126 @@
       "ipv4": [
         {
           "vertex": "r4"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP", 
+          "metric": "0",
+          "parent": "r4(4)",
+          "type": "IP internal",
           "vertex": "10.0.11.0/24"
-        }, 
+        },
         {
-          "interface": "r4-eth1", 
-          "metric": "10", 
-          "next-hop": "r5", 
-          "parent": "r4(4)", 
-          "type": "TE-IS", 
+          "interface": "r4-eth1",
+          "metric": "10",
+          "next-hop": "r5",
+          "parent": "r4(4)",
+          "type": "TE-IS",
           "vertex": "r5"
-        }, 
+        },
         {
-          "interface": "r5", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r4-eth1", 
-          "type": "IP", 
+          "interface": "r4-eth1",
+          "metric": "20",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP TE",
           "vertex": "10.0.10.0/24"
-        }, 
+        },
         {
-          "interface": "r5", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r4-eth1", 
-          "type": "IP", 
+          "interface": "r4-eth1",
+          "metric": "20",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP TE",
           "vertex": "10.0.11.0/24"
-        }, 
+        },
         {
-          "interface": "r5", 
-          "metric": "TE", 
-          "next-hop": "30", 
-          "parent": "r4-eth1", 
-          "type": "IP", 
+          "interface": "r4-eth1",
+          "metric": "30",
+          "next-hop": "r5",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.20.0/24"
         }
-      ], 
+      ],
       "ipv6": [
         {
           "vertex": "r4"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP6", 
+          "metric": "0",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:2::/64"
-        }, 
+        },
         {
-          "interface": "r4-eth1", 
-          "metric": "10", 
-          "next-hop": "r5", 
-          "parent": "r4(4)", 
-          "type": "TE-IS", 
+          "interface": "r4-eth1",
+          "metric": "10",
+          "next-hop": "r5",
+          "parent": "r4(4)",
+          "type": "TE-IS",
           "vertex": "r5"
-        }, 
+        },
         {
-          "interface": "r5", 
-          "metric": "internal", 
-          "next-hop": "20", 
-          "parent": "r4-eth1", 
-          "type": "IP6", 
+          "interface": "r4-eth1",
+          "metric": "20",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:1::/64"
-        }, 
+        },
         {
-          "interface": "r5", 
-          "metric": "internal", 
-          "next-hop": "30", 
-          "parent": "r4-eth1", 
-          "type": "IP6", 
+          "interface": "r4-eth1",
+          "metric": "30",
+          "next-hop": "r5",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:1::/64"
         }
       ]
-    }, 
+    },
     "level-2": {
       "ipv4": [
         {
           "vertex": "r4"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP", 
+          "metric": "0",
+          "parent": "r4(4)",
+          "type": "IP internal",
           "vertex": "10.0.21.0/24"
-        }, 
+        },
         {
-          "interface": "r4-eth0", 
-          "metric": "10", 
-          "next-hop": "r2", 
-          "parent": "r4(4)", 
-          "type": "TE-IS", 
+          "interface": "r4-eth0",
+          "metric": "10",
+          "next-hop": "r2",
+          "parent": "r4(4)",
+          "type": "TE-IS",
           "vertex": "r2"
-        }, 
+        },
         {
-          "interface": "r2", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r4-eth0", 
-          "type": "IP", 
+          "interface": "r4-eth0",
+          "metric": "20",
+          "next-hop": "r2",
+          "parent": "r2(4)",
+          "type": "IP TE",
           "vertex": "10.0.21.0/24"
         }
-      ], 
+      ],
       "ipv6": [
         {
           "vertex": "r4"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP6", 
+          "metric": "0",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:2::/64"
-        }, 
+        },
         {
-          "interface": "r4-eth0", 
-          "metric": "10", 
-          "next-hop": "r2", 
-          "parent": "r4(4)", 
-          "type": "TE-IS", 
+          "interface": "r4-eth0",
+          "metric": "10",
+          "next-hop": "r2",
+          "parent": "r4(4)",
+          "type": "TE-IS",
           "vertex": "r2"
         }
       ]

--- a/tests/topotests/isis-topo1-vrf/r5/r5_topology.json
+++ b/tests/topotests/isis-topo1-vrf/r5/r5_topology.json
@@ -4,120 +4,120 @@
       "ipv4": [
         {
           "vertex": "r5"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP", 
+          "metric": "0",
+          "parent": "r5(4)",
+          "type": "IP internal",
           "vertex": "10.0.10.0/24"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP", 
+          "metric": "0",
+          "parent": "r5(4)",
+          "type": "IP internal",
           "vertex": "10.0.11.0/24"
-        }, 
+        },
         {
-          "interface": "r5-eth0", 
-          "metric": "10", 
-          "next-hop": "r3", 
-          "parent": "r5(4)", 
-          "type": "TE-IS", 
+          "interface": "r5-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r5(4)",
+          "type": "TE-IS",
           "vertex": "r3"
-        }, 
+        },
         {
-          "interface": "r5-eth1", 
-          "metric": "10", 
-          "next-hop": "r4", 
-          "parent": "r5(4)", 
-          "type": "TE-IS", 
+          "interface": "r5-eth1",
+          "metric": "10",
+          "next-hop": "r4",
+          "parent": "r5(4)",
+          "type": "TE-IS",
           "vertex": "r4"
-        }, 
+        },
         {
-          "interface": "r3", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r5-eth0", 
-          "type": "IP", 
+          "interface": "r5-eth0",
+          "metric": "20",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.20.0/24"
-        }, 
+        },
         {
-          "interface": "r3", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r5-eth0", 
-          "type": "IP", 
+          "interface": "r5-eth0",
+          "metric": "20",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.10.0/24"
-        }, 
+        },
         {
-          "interface": "r4", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r5-eth1", 
-          "type": "IP", 
+          "interface": "r5-eth1",
+          "metric": "20",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.0.21.0/24"
-        }, 
+        },
         {
-          "interface": "r4", 
-          "metric": "TE", 
-          "next-hop": "20", 
-          "parent": "r5-eth1", 
-          "type": "IP", 
+          "interface": "r5-eth1",
+          "metric": "20",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.0.11.0/24"
         }
-      ], 
+      ],
       "ipv6": [
         {
           "vertex": "r5"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP6", 
+          "metric": "0",
+          "parent": "r5(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:1::/64"
-        }, 
+        },
         {
-          "metric": "internal", 
-          "parent": "0", 
-          "type": "IP6", 
+          "metric": "0",
+          "parent": "r5(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:2::/64"
-        }, 
+        },
         {
-          "interface": "r5-eth0", 
-          "metric": "10", 
-          "next-hop": "r3", 
-          "parent": "r5(4)", 
-          "type": "TE-IS", 
+          "interface": "r5-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r5(4)",
+          "type": "TE-IS",
           "vertex": "r3"
-        }, 
+        },
         {
-          "interface": "r5-eth1", 
-          "metric": "10", 
-          "next-hop": "r4", 
-          "parent": "r5(4)", 
-          "type": "TE-IS", 
+          "interface": "r5-eth1",
+          "metric": "10",
+          "next-hop": "r4",
+          "parent": "r5(4)",
+          "type": "TE-IS",
           "vertex": "r4"
-        }, 
+        },
         {
-          "interface": "r3", 
-          "metric": "internal", 
-          "next-hop": "20", 
-          "parent": "r5-eth0", 
-          "type": "IP6", 
+          "interface": "r5-eth0",
+          "metric": "20",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:1::/64"
-        }, 
+        },
         {
-          "interface": "r4", 
-          "metric": "internal", 
-          "next-hop": "20", 
-          "parent": "r5-eth1", 
-          "type": "IP6", 
+          "interface": "r5-eth1",
+          "metric": "20",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:2::/64"
         }
       ]
-    }, 
+    },
     "level-2": {
-      "ipv4": [], 
+      "ipv4": [],
       "ipv6": []
     }
   }

--- a/tests/topotests/isis-topo1-vrf/test_isis_topo1_vrf.py
+++ b/tests/topotests/isis-topo1-vrf/test_isis_topo1_vrf.py
@@ -47,6 +47,19 @@ from mininet.topo import Topo
 
 pytestmark = [pytest.mark.isisd]
 
+VERTEX_TYPE_LIST = [
+		"pseudo_IS",
+		"pseudo_TE-IS",
+		"IS",
+		"TE-IS",
+		"ES",
+		"IP internal",
+		"IP external",
+		"IP TE",
+		"IP6 internal",
+		"IP6 external",
+		"UNKNOWN"
+	      ]
 
 class ISISTopo1(Topo):
     "Simple two layer ISIS vrf topology"
@@ -316,6 +329,7 @@ def parse_topology(lines, level):
     areas = {}
     area = None
     ipv = None
+    vertex_type_regex = "|".join(VERTEX_TYPE_LIST)
 
     for line in lines:
         area_match = re.match(r"Area (.+):", line)
@@ -335,44 +349,50 @@ def parse_topology(lines, level):
             ipv = "ipv4"
             continue
 
-        item_match = re.match(r"([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)", line)
-        if item_match is not None:
+        item_match = re.match(r"([^\s]+) ([^\s]+) ([^\s]+) ([^\s]+) ([^\s]+) ([^\s]+)"
+                              , line)
+        if (
+            item_match is not None
+            and item_match.group(1) == "Vertex"
+            and item_match.group(2) == "Type"
+            and item_match.group(3) == "Metric"
+            and item_match.group(4) == "Next-Hop"
+            and item_match.group(5) == "Interface"
+            and item_match.group(6) == "Parent"
+        ):
             # Skip header
-            if (
-                item_match.group(1) == "Vertex"
-                and item_match.group(2) == "Type"
-                and item_match.group(3) == "Metric"
-                and item_match.group(4) == "Next-Hop"
-                and item_match.group(5) == "Interface"
-                and item_match.group(6) == "Parent"
-            ):
-                continue
-
-            areas[area][level][ipv].append(
-                {
-                    "vertex": item_match.group(1),
-                    "type": item_match.group(2),
-                    "metric": item_match.group(3),
-                    "next-hop": item_match.group(4),
-                    "interface": item_match.group(5),
-                    "parent": item_match.group(6),
-                }
-            )
             continue
 
-        item_match = re.match(r"([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)", line)
+        item_match = re.match(r"([^\s]+) ({}) ([0]|([1-9][0-9]*)) ([^\s]+) ([^\s]+) ([^\s]+)"
+                              .format(vertex_type_regex), line)
         if item_match is not None:
             areas[area][level][ipv].append(
                 {
                     "vertex": item_match.group(1),
                     "type": item_match.group(2),
                     "metric": item_match.group(3),
-                    "parent": item_match.group(4),
+                    "next-hop": item_match.group(5),
+                    "interface": item_match.group(6),
+                    "parent": item_match.group(7),
                 }
             )
             continue
 
-        item_match = re.match(r"([^ ]+)", line)
+        item_match = re.match(r"([^\s]+) ({}) ([0]|([1-9][0-9]*)) ([^\s]+)"
+                              .format(vertex_type_regex), line)
+
+        if item_match is not None:
+            areas[area][level][ipv].append(
+                {
+                    "vertex": item_match.group(1),
+                    "type": item_match.group(2),
+                    "metric": item_match.group(3),
+                    "parent": item_match.group(5),
+                }
+            )
+            continue
+
+        item_match = re.match(r"([^\s]+)", line)
         if item_match is not None:
             areas[area][level][ipv].append({"vertex": item_match.group(1)})
             continue


### PR DESCRIPTION
Now the parse_topology function handles well the vertex type identifier.

Signed-off-by: Emanuele Altomare <emanuele@common-net.org>