### PR TITLE
access-list and prefix-list fixes

### DIFF
--- a/lib/filter.h
+++ b/lib/filter.h
@@ -182,6 +182,9 @@ struct acl_dup_args {
 	/** Access list name. */
 	const char *ada_name;
 
+	/** Entry action. */
+	const char *ada_action;
+
 #define ADA_MAX_VALUES 4
 	/** Entry XPath for value. */
 	const char *ada_xpath[ADA_MAX_VALUES];

--- a/lib/filter.h
+++ b/lib/filter.h
@@ -212,6 +212,9 @@ struct plist_dup_args {
 	/** Access list name. */
 	const char *pda_name;
 
+	/** Entry action. */
+	const char *pda_action;
+
 #define PDA_MAX_VALUES 4
 	/** Entry XPath for value. */
 	const char *pda_xpath[PDA_MAX_VALUES];

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -1336,6 +1336,7 @@ DEFPY_YANG(
 	if (seq_str == NULL) {
 		pda.pda_type = "ipv4";
 		pda.pda_name = name;
+		pda.pda_action = action;
 		if (prefix_str) {
 			pda.pda_xpath[arg_idx] = "./ipv4-prefix";
 			pda.pda_value[arg_idx] = prefix_str;
@@ -1531,6 +1532,7 @@ DEFPY_YANG(
 	if (seq_str == NULL) {
 		pda.pda_type = "ipv6";
 		pda.pda_name = name;
+		pda.pda_action = action;
 		if (prefix_str) {
 			pda.pda_xpath[arg_idx] = "./ipv6-prefix";
 			pda.pda_value[arg_idx] = prefix_str;

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -173,6 +173,7 @@ DEFPY_YANG(
 	if (seq_str == NULL) {
 		ada.ada_type = "ipv4";
 		ada.ada_name = name;
+		ada.ada_action = action;
 		if (host_str && mask_str == NULL) {
 			ada.ada_xpath[0] = "./host";
 			ada.ada_value[0] = host_str;
@@ -309,6 +310,7 @@ DEFPY_YANG(
 	if (seq_str == NULL) {
 		ada.ada_type = "ipv4";
 		ada.ada_name = name;
+		ada.ada_action = action;
 		if (src_str && src_mask_str == NULL) {
 			ada.ada_xpath[idx] = "./host";
 			ada.ada_value[idx] = src_str;
@@ -504,6 +506,7 @@ DEFPY_YANG(
 	if (seq_str == NULL) {
 		ada.ada_type = "ipv4";
 		ada.ada_name = name;
+		ada.ada_action = action;
 
 		if (prefix_str) {
 			ada.ada_xpath[0] = "./ipv4-prefix";
@@ -701,6 +704,7 @@ DEFPY_YANG(
 	if (seq_str == NULL) {
 		ada.ada_type = "ipv6";
 		ada.ada_name = name;
+		ada.ada_action = action;
 
 		if (prefix_str) {
 			ada.ada_xpath[0] = "./ipv6-prefix";
@@ -902,6 +906,7 @@ DEFPY_YANG(
 	if (seq_str == NULL) {
 		ada.ada_type = "mac";
 		ada.ada_name = name;
+		ada.ada_action = action;
 
 		if (mac_str) {
 			ada.ada_xpath[0] = "./mac";

--- a/lib/filter_nb.c
+++ b/lib/filter_nb.c
@@ -396,6 +396,9 @@ static int _plist_is_dup(const struct lyd_node *dnode, void *arg)
 	    && pda->pda_entry_dnode == dnode)
 		return YANG_ITER_CONTINUE;
 
+	if (strcmp(yang_dnode_get_string(dnode, "action"), pda->pda_action))
+		return YANG_ITER_CONTINUE;
+
 	/* Check if all values match. */
 	for (idx = 0; idx < PDA_MAX_VALUES; idx++) {
 		/* No more values. */
@@ -449,6 +452,7 @@ static bool plist_is_dup_nb(const struct lyd_node *dnode)
 	/* Initialize. */
 	pda.pda_type = yang_dnode_get_string(entry_dnode, "../type");
 	pda.pda_name = yang_dnode_get_string(entry_dnode, "../name");
+	pda.pda_action = yang_dnode_get_string(entry_dnode, "action");
 	pda.pda_entry_dnode = entry_dnode;
 
 	/* Load all values/XPaths. */

--- a/lib/filter_nb.c
+++ b/lib/filter_nb.c
@@ -238,6 +238,9 @@ static int _acl_is_dup(const struct lyd_node *dnode, void *arg)
 	    && ada->ada_entry_dnode == dnode)
 		return YANG_ITER_CONTINUE;
 
+	if (strcmp(yang_dnode_get_string(dnode, "action"), ada->ada_action))
+		return YANG_ITER_CONTINUE;
+
 	/* Check if all values match. */
 	for (idx = 0; idx < ADA_MAX_VALUES; idx++) {
 		/* No more values. */
@@ -292,6 +295,7 @@ static bool acl_cisco_is_dup(const struct lyd_node *dnode)
 	/* Initialize. */
 	ada.ada_type = "ipv4";
 	ada.ada_name = yang_dnode_get_string(entry_dnode, "../name");
+	ada.ada_action = yang_dnode_get_string(entry_dnode, "action");
 	ada.ada_entry_dnode = entry_dnode;
 
 	/* Load all values/XPaths. */
@@ -341,6 +345,7 @@ static bool acl_zebra_is_dup(const struct lyd_node *dnode,
 		break;
 	}
 	ada.ada_name = yang_dnode_get_string(entry_dnode, "../name");
+	ada.ada_action = yang_dnode_get_string(entry_dnode, "action");
 	ada.ada_entry_dnode = entry_dnode;
 
 	/* Load all values/XPaths. */


### PR DESCRIPTION
Fixes for checking duplicated entries:
* restore incorrectly removed checks for prefix-lists
* take `action` into account when comparing entries – currently we treat `permit SMTH` and `deny SMTH` as same entries