### PR TITLE
lib, ripngd: Remove inet6_ntoa

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1198,15 +1198,6 @@ int netmask_str2prefix_str(const char *net_str, const char *mask_str,
 	return 1;
 }
 
-/* Utility function for making IPv6 address string. */
-const char *inet6_ntoa(struct in6_addr addr)
-{
-	static char buf[INET6_ADDRSTRLEN];
-
-	inet_ntop(AF_INET6, &addr, buf, INET6_ADDRSTRLEN);
-	return buf;
-}
-
 /* converts to internal representation of mac address
  * returns 1 on success, 0 otherwise
  * format accepted: AA:BB:CC:DD:EE:FF

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -504,8 +504,6 @@ extern void apply_mask_ipv6(struct prefix_ipv6 *);
 extern int ip6_masklen(struct in6_addr);
 extern void masklen2ip6(const int, struct in6_addr *);
 
-extern const char *inet6_ntoa(struct in6_addr);
-
 extern int is_zero_mac(const struct ethaddr *mac);
 extern bool is_mcast_mac(const struct ethaddr *mac);
 extern bool is_bcast_mac(const struct ethaddr *mac);

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -163,8 +163,8 @@ void ripng_peer_display(struct vty *vty, struct ripng *ripng)
 	char timebuf[RIPNG_UPTIME_LEN];
 
 	for (ALL_LIST_ELEMENTS(ripng->peer_list, node, nnode, peer)) {
-		vty_out(vty, "    %s \n%14s %10d %10d %10d      %s\n",
-			inet6_ntoa(peer->addr), " ", peer->recv_badpackets,
+		vty_out(vty, "    %pI6 \n%14s %10d %10d %10d      %s\n",
+			&peer->addr, " ", peer->recv_badpackets,
 			peer->recv_badroutes, ZEBRA_RIPNG_DISTANCE_DEFAULT,
 			ripng_peer_uptime(peer, timebuf, RIPNG_UPTIME_LEN));
 	}


### PR DESCRIPTION
Remove the inet6_ntoa() api from lib/prefix.c - it used a static buffer, etc etc. Looks like it was only used in ripng...