### PR TITLE
bgpd: increase the maximum number of neighbors in a listen group

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3990,7 +3990,7 @@ void cli_show_router_global_neighbor_config(struct vty *vty,
 
 DEFUN_YANG(bgp_listen_limit,
 	   bgp_listen_limit_cmd,
-	   "bgp listen limit (1-5000)",
+	   "bgp listen limit (1-65535)",
 	   "BGP specific commands\n"
 	   "BGP Dynamic Neighbors listen commands\n"
 	   "Maximum number of BGP Dynamic Neighbors that can be created\n"
@@ -4007,7 +4007,7 @@ DEFUN_YANG(bgp_listen_limit,
 
 DEFUN_YANG(no_bgp_listen_limit,
 	   no_bgp_listen_limit_cmd,
-	   "no bgp listen limit [(1-5000)]",
+	   "no bgp listen limit [(1-65535)]",
 	   NO_STR
 	   "BGP specific commands\n"
 	   "BGP Dynamic Neighbors listen commands\n"

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1824,7 +1824,7 @@ struct bgp_nlri {
 /* BGP Dynamic Neighbors feature */
 #define BGP_DYNAMIC_NEIGHBORS_LIMIT_DEFAULT    100
 #define BGP_DYNAMIC_NEIGHBORS_LIMIT_MIN          1
-#define BGP_DYNAMIC_NEIGHBORS_LIMIT_MAX       5000
+#define BGP_DYNAMIC_NEIGHBORS_LIMIT_MAX      65535
 
 /* Flag for peer_clear_soft().  */
 enum bgp_clear_type {

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1363,6 +1363,15 @@ Defining Peers
    ``net.core.optmem_max`` to allow the kernel to allocate the necessary option
    memory.
 
+.. clicmd:: bgp listen limit <1-65535>
+
+   Define the maximum number of peers accepted for one BGP instance. This
+   limit is set to 100 by default. Increasing this value will really be
+   possible if more file descriptors are available in the BGP process. This
+   value is defined by the underlying system (ulimit value), and can be
+   overriden by `--limit-fds`. More information is available in chapter
+   (:ref:`common-invocation-options`).
+
 .. clicmd:: coalesce-time (0-4294967295)
 
    The time in milliseconds that BGP will delay before deciding what peers

--- a/yang/frr-bgp-common.yang
+++ b/yang/frr-bgp-common.yang
@@ -393,7 +393,7 @@ submodule frr-bgp-common {
     container global-neighbor-config {
       leaf dynamic-neighbors-limit {
         type uint32 {
-          range "1..5000";
+          range "1..65535";
         }
         description
           "Maximum number of BGP Dynamic Neighbors that can be created.";


### PR DESCRIPTION
increase the maximum number of neighbors in a bgp group.
Set the maximum value to 50000 instead of 5000.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>