### PR TITLE
[7.5] ospfd: ignore duplicated "ip ospf area" commands

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8108,9 +8108,12 @@ DEFUN (ip_ospf_area,
 		// update/create address-level params
 		params = ospf_get_if_params((ifp), (addr));
 		if (OSPF_IF_PARAM_CONFIGURED(params, if_area)) {
-			vty_out(vty,
-				"Must remove previous area/address config before changing ospf area\n");
-			return CMD_WARNING_CONFIG_FAILED;
+			if (!IPV4_ADDR_SAME(&params->if_area, &area_id)) {
+				vty_out(vty,
+					"Must remove previous area/address config before changing ospf area\n");
+				return CMD_WARNING_CONFIG_FAILED;
+			} else
+				return CMD_SUCCESS;
 		}
 		ospf_if_update_params((ifp), (addr));
 	}


### PR DESCRIPTION
Fixes #8388.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>