### PR TITLE
ospfd: fix output of dead-interval in show running

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -11708,6 +11708,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 
 			/* Router Dead Interval print. */
 			if (OSPF_IF_PARAM_CONFIGURED(params, v_wait)
+			    && params->is_v_wait_set
 			    && params->v_wait
 				       != OSPF_ROUTER_DEAD_INTERVAL_DEFAULT) {
 				vty_out(vty, " ip ospf dead-interval ");


### PR DESCRIPTION
When you set OSPF hello-interval for an interface and dead-interval is
not set for this interface, dead-interval will be calculated and set
automatically. "show running-config" will contain an invalid command:

    test(config)# interface vpp1
    test(config-if)# ip ospf area 0
    test(config-if)# ip ospf hello-interval 1
    test(config-if)# exit
    test(config)#
    test(config)# do show running-config
    ...
    interface if1
     ip ospf area 0
     ip ospf dead-interval minimal hello-multiplier 0
     ip ospf hello-interval 1
    !
    ...

It causes frr-reload.py to fail because of this:

    # vtysh -c "show running-config no-header" | vtysh -m -f -
    line 9: % Unknown command:  ip ospf dead-interval minimal hello-multiplier 0
    ...

With this change, output "ip ospf dead-interval" only if it has value
configured explicitly.