### PR TITLE
tests: fix for l3mdev topotests on kernel 4.19

### DIFF
--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
@@ -42,12 +42,10 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
+from lib.common_config import adjust_router_l3mdev
 
 # Required to instantiate the topology builder class.
 from mininet.topo import Topo
-
-l3mdev_accept = 0
-krel = ""
 
 
 class BGPEVPNTopo(Topo):
@@ -73,8 +71,6 @@ class BGPEVPNTopo(Topo):
 
 def setup_module(mod):
     "Sets up the pytest environment"
-    global l3mdev_accept
-    global krel
 
     tgen = Topogen(BGPEVPNTopo, mod.__name__)
     tgen.start_topology()
@@ -90,18 +86,13 @@ def setup_module(mod):
         )
         return pytest.skip("Skipping BGP EVPN RT5 NETNS Test. Kernel not supported")
 
-    l3mdev_accept = 1
-    logger.info("setting net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept))
-
     # create VRF vrf-101 on R1 and R2
     # create loop101
     cmds_vrflite = [
-        "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept),
         "ip link add {}-vrf-101 type vrf table 101",
         "ip ru add oif {}-vrf-101 table 101",
         "ip ru add iif {}-vrf-101 table 101",
         "ip link set dev {}-vrf-101 up",
-        "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept),
         "ip link add loop101 type dummy",
         "ip link set dev loop101 master {}-vrf-101",
         "ip link set dev loop101 up",
@@ -139,6 +130,7 @@ def setup_module(mod):
         logger.info("result: " + output)
 
     router = tgen.gears["r2"]
+    adjust_router_l3mdev(tgen, "r2")
     for cmd in cmds_vrflite:
         logger.info("cmd to r2: " + cmd.format("r2"))
         output = router.run(cmd.format("r2"))

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
@@ -84,6 +84,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.ltemplate import ltemplateRtrCmd
+from lib.common_config import adjust_router_l3mdev
 
 # Required to instantiate the topology builder class.
 from mininet.topo import Topo
@@ -145,26 +146,12 @@ class ThisTestTopo(Topo):
         switch[1].add_link(tgen.gears["r3"], nodeif="r3-eth1")
 
 
-l3mdev_accept = 0
-
-
 def ltemplatePreRouterStartHook():
-    global l3mdev_accept
     cc = ltemplateRtrCmd()
     krel = platform.release()
     tgen = get_topogen()
     logger.info("pre router-start hook, kernel=" + krel)
 
-    if (
-        topotest.version_cmp(krel, "4.15") >= 0
-        and topotest.version_cmp(krel, "4.18") <= 0
-    ):
-        l3mdev_accept = 1
-
-    if topotest.version_cmp(krel, "5.0") >= 0:
-        l3mdev_accept = 1
-
-    logger.info("setting net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept))
     # check for mpls
     if tgen.hasmpls != True:
         logger.info("MPLS not available, skipping setup")
@@ -187,10 +174,11 @@ def ltemplatePreRouterStartHook():
         "ip ru add oif {0}-cust1 table 10",
         "ip ru add iif {0}-cust1 table 10",
         "ip link set dev {0}-cust1 up",
-        "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept),
     ]
     for rtr in rtrs:
-        router = tgen.gears[rtr]
+        # adjust handling of VRF traffic
+        adjust_router_l3mdev(tgen, rtr)
+
         for cmd in cmds:
             cc.doCmd(tgen, rtr, cmd.format(rtr))
         cc.doCmd(tgen, rtr, "ip link set dev {0}-eth4 master {0}-cust1".format(rtr))
@@ -229,9 +217,11 @@ def ltemplatePreRouterStartHook():
         "ip ru add oif {0}-cust2 table 20",
         "ip ru add iif {0}-cust2 table 20",
         "ip link set dev {0}-cust2 up",
-        "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept),
     ]
     for rtr in rtrs:
+        # adjust handling of VRF traffic
+        adjust_router_l3mdev(tgen, rtr)
+
         for cmd in cmds:
             cc.doCmd(tgen, rtr, cmd.format(rtr))
         cc.doCmd(tgen, rtr, "ip link set dev {0}-eth0 master {0}-cust2".format(rtr))

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_vrf.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_vrf.py
@@ -1,6 +1,7 @@
 from lib.lutil import luCommand
-from customize import l3mdev_accept
+from lib.common_config import kernel_requires_l3mdev_adjustment
 
+l3mdev_accept = kernel_requires_l3mdev_adjustment()
 l3mdev_rtrs = ["r1", "r3", "r4", "ce4"]
 for rtr in l3mdev_rtrs:
     luCommand(rtr, "sysctl net.ipv4.tcp_l3mdev_accept", " = \d*", "none", "")

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/test_bgp_vrf_lite_ipv6_rtadv.py
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/test_bgp_vrf_lite_ipv6_rtadv.py
@@ -42,6 +42,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
+from lib.common_config import adjust_router_l3mdev
 
 # Required to instantiate the topology builder class.
 from mininet.topo import Topo
@@ -71,22 +72,6 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     logger.info("Testing with VRF Lite support")
-    krel = platform.release()
-
-    # May need to adjust handling of vrf traffic depending on kernel version
-    l3mdev_accept = 0
-    if (
-        topotest.version_cmp(krel, "4.15") >= 0
-        and topotest.version_cmp(krel, "4.18") <= 0
-    ):
-        l3mdev_accept = 1
-
-    if topotest.version_cmp(krel, "5.0") >= 0:
-        l3mdev_accept = 1
-
-    logger.info(
-        "krel '{0}' setting net.ipv4.tcp_l3mdev_accept={1}".format(krel, l3mdev_accept)
-    )
 
     cmds = [
         "ip link add {0}-cust1 type vrf table 1001",
@@ -99,15 +84,8 @@ def setup_module(mod):
         for cmd in cmds:
             output = tgen.net[rname].cmd(cmd.format(rname))
 
-        output = tgen.net[rname].cmd("sysctl -n net.ipv4.tcp_l3mdev_accept")
-        logger.info(
-            "router {0}: existing tcp_l3mdev_accept was {1}".format(rname, output)
-        )
-
-        if l3mdev_accept:
-            output = tgen.net[rname].cmd(
-                "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept)
-            )
+        # adjust handling of vrf traffic
+        adjust_router_l3mdev(tgen, rname)
 
     for rname, router in router_list.items():
         router.load_config(

--- a/tests/topotests/isis-topo1-vrf/test_isis_topo1_vrf.py
+++ b/tests/topotests/isis-topo1-vrf/test_isis_topo1_vrf.py
@@ -41,7 +41,10 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.topotest import iproute2_is_vrf_capable
-from lib.common_config import required_linux_kernel_version
+from lib.common_config import (
+        required_linux_kernel_version,
+        adjust_router_l3mdev,
+)
 
 from mininet.topo import Topo
 
@@ -93,22 +96,6 @@ def setup_module(mod):
     tgen.start_topology()
 
     logger.info("Testing with VRF Lite support")
-    krel = platform.release()
-
-    # May need to adjust handling of vrf traffic depending on kernel version
-    l3mdev_accept = 0
-    if (
-        topotest.version_cmp(krel, "4.15") >= 0
-        and topotest.version_cmp(krel, "4.18") <= 0
-    ):
-        l3mdev_accept = 1
-
-    if topotest.version_cmp(krel, "5.0") >= 0:
-        l3mdev_accept = 1
-
-    logger.info(
-        "krel '{0}' setting net.ipv4.tcp_l3mdev_accept={1}".format(krel, l3mdev_accept)
-    )
 
     cmds = [
         "ip link add {0}-cust1 type vrf table 1001",
@@ -122,15 +109,9 @@ def setup_module(mod):
         # create VRF rx-cust1 and link rx-eth0 to rx-cust1
         for cmd in cmds:
             output = tgen.net[rname].cmd(cmd.format(rname))
-        output = tgen.net[rname].cmd("sysctl -n net.ipv4.tcp_l3mdev_accept")
-        logger.info(
-            "router {0}: existing tcp_l3mdev_accept was {1}".format(rname, output)
-        )
 
-        if l3mdev_accept:
-            output = tgen.net[rname].cmd(
-                "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept)
-            )
+        # adjust handling of vrf traffic
+        adjust_router_l3mdev(tgen, rname)
 
     for rname, router in tgen.routers().items():
         router.load_config(

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -4372,3 +4372,53 @@ def verify_ip_nht(tgen, input_dict):
 
     logger.debug("Exiting lib API: verify_ip_nht()")
     return False
+
+
+def kernel_requires_l3mdev_adjustment():
+    """
+    Checks if the L3 master device needs to be adjusted to handle VRF traffic
+    based on kernel version.
+
+    Returns
+    -------
+    1 or 0
+    """
+
+    if version_cmp(platform.release(), "4.15") >= 0:
+        return 1
+    return 0
+
+
+def adjust_router_l3mdev(tgen, router):
+    """
+    Adjusts a routers L3 master device to handle VRF traffic depending on kernel
+    version.
+
+    Parameters
+    ----------
+    * `tgen`   : tgen object
+    * `router` : router id to be configured.
+
+    Returns
+    -------
+    True
+    """
+
+    l3mdev_accept = kernel_requires_l3mdev_adjustment()
+
+    logger.info(
+        "router {0}: setting net.ipv4.tcp_l3mdev_accept={1}".format(
+            router, l3mdev_accept
+        )
+    )
+
+    output = tgen.net[router].cmd("sysctl -n net.ipv4.tcp_l3mdev_accept")
+    logger.info(
+        "router {0}: existing tcp_l3mdev_accept was {1}".format(router, output)
+    )
+
+    tgen.net[router].cmd(
+        "sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept)
+    )
+
+    return True

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -544,8 +544,7 @@ def iproute2_is_vrf_capable():
                 ["ip", "route", "show", "vrf"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                stdin=subprocess.PIPE,
-                encoding="utf-8"
+                stdin=subprocess.PIPE
             )
             iproute2_err = subp.communicate()[1].splitlines()[0].split()[0]
 


### PR DESCRIPTION
This PR fixes Issue  [#8395](https://github.com/FRRouting/frr/issues/8395) and should also be merged in 7.5 / 7.5.1