### PR TITLE
zebra: don't process LSPs with backups immediately

### DIFF
--- a/zebra/debug.c
+++ b/zebra/debug.c
@@ -94,8 +94,11 @@ DEFUN_NOSH (show_debugging_zebra,
 		vty_out(vty, "  Zebra detailed next-hop tracking debugging is on\n");
 	else if (IS_ZEBRA_DEBUG_NHT)
 		vty_out(vty, "  Zebra next-hop tracking debugging is on\n");
-	if (IS_ZEBRA_DEBUG_MPLS)
+	if (IS_ZEBRA_DEBUG_MPLS_DETAIL)
+		vty_out(vty, "  Zebra detailed MPLS debugging is on\n");
+	else if (IS_ZEBRA_DEBUG_MPLS)
 		vty_out(vty, "  Zebra MPLS debugging is on\n");
+
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		vty_out(vty, "  Zebra VXLAN debugging is on\n");
 	if (IS_ZEBRA_DEBUG_PW)
@@ -159,14 +162,19 @@ DEFUN (debug_zebra_nht,
 	return CMD_SUCCESS;
 }
 
-DEFUN (debug_zebra_mpls,
+DEFPY (debug_zebra_mpls,
        debug_zebra_mpls_cmd,
-       "debug zebra mpls",
+       "debug zebra mpls [detailed$detail]",
        DEBUG_STR
        "Zebra configuration\n"
-       "Debug option set for zebra MPLS LSPs\n")
+       "Debug option set for zebra MPLS LSPs\n"
+       "Debug option for detailed info\n")
 {
 	zebra_debug_mpls = ZEBRA_DEBUG_MPLS;
+
+	if (detail)
+		zebra_debug_mpls |= ZEBRA_DEBUG_MPLS_DETAILED;
+
 	return CMD_SUCCESS;
 }
 
@@ -422,11 +430,12 @@ DEFUN (no_debug_zebra_nht,
 
 DEFUN (no_debug_zebra_mpls,
        no_debug_zebra_mpls_cmd,
-       "no debug zebra mpls",
+       "no debug zebra mpls [detailed]",
        NO_STR
        DEBUG_STR
        "Zebra configuration\n"
-       "Debug option set for zebra MPLS LSPs\n")
+       "Debug option set for zebra MPLS LSPs\n"
+       "Debug option for zebra detailed info\n")
 {
 	zebra_debug_mpls = 0;
 	return CMD_SUCCESS;
@@ -628,10 +637,14 @@ static int config_write_debug(struct vty *vty)
 		write++;
 	}
 
-	if (IS_ZEBRA_DEBUG_MPLS) {
+	if (IS_ZEBRA_DEBUG_MPLS_DETAIL) {
+		vty_out(vty, "debug zebra mpls detailed\n");
+		write++;
+	} else if (IS_ZEBRA_DEBUG_MPLS) {
 		vty_out(vty, "debug zebra mpls\n");
 		write++;
 	}
+
 	if (IS_ZEBRA_DEBUG_VXLAN) {
 		vty_out(vty, "debug zebra vxlan\n");
 		write++;

--- a/zebra/debug.h
+++ b/zebra/debug.h
@@ -48,7 +48,8 @@ extern "C" {
 #define ZEBRA_DEBUG_NHT 0x01
 #define ZEBRA_DEBUG_NHT_DETAILED 0x02
 
-#define ZEBRA_DEBUG_MPLS    0x01
+#define ZEBRA_DEBUG_MPLS             0x01
+#define ZEBRA_DEBUG_MPLS_DETAILED    0x02
 
 #define ZEBRA_DEBUG_VXLAN   0x01
 
@@ -93,6 +94,8 @@ extern "C" {
 #define IS_ZEBRA_DEBUG_NHT_DETAILED (zebra_debug_nht & ZEBRA_DEBUG_NHT_DETAILED)
 
 #define IS_ZEBRA_DEBUG_MPLS  (zebra_debug_mpls & ZEBRA_DEBUG_MPLS)
+#define IS_ZEBRA_DEBUG_MPLS_DETAIL \
+	(zebra_debug_mpls & ZEBRA_DEBUG_MPLS_DETAILED)
 #define IS_ZEBRA_DEBUG_VXLAN (zebra_debug_vxlan & ZEBRA_DEBUG_VXLAN)
 #define IS_ZEBRA_DEBUG_PW  (zebra_debug_pw & ZEBRA_DEBUG_PW)
 

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -872,6 +872,22 @@ static void lsp_schedule(struct hash_bucket *bucket, void *ctxt)
 	zebra_lsp_t *lsp;
 
 	lsp = (zebra_lsp_t *)bucket->data;
+
+	/* In the common flow, this is used when external events occur. For
+	 * LSPs with backup nhlfes, we'll assume that the forwarding
+	 * plane will use the backups to handle these events, until the
+	 * owning protocol can react.
+	 */
+	if (ctxt == NULL) {
+		/* Skip LSPs with backups */
+		if (nhlfe_list_first(&lsp->backup_nhlfe_list) != NULL) {
+			if (IS_ZEBRA_DEBUG_MPLS_DETAIL)
+				zlog_debug("%s: skip LSP in-label %u",
+					   __func__, lsp->ile.in_label);
+			return;
+		}
+	}
+
 	(void)lsp_processq_add(lsp);
 }
 


### PR DESCRIPTION
When certain events occur (interface/connected route changes e.g.) zebra examines LSPs to see if they might have been affected. For LSPs with backup nhlfes, skip this immediate processing and wait for the owning protocol daemon to react. Also added a 'debug mpls detail' control.