### PR TITLE
ospfd: Fixing few valgrind issues

### DIFF
--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -314,20 +314,29 @@ void ospf_redistribute_withdraw(struct ospf *ospf, uint8_t type,
 	if (EXTERNAL_INFO(ext))
 		for (rn = route_top(EXTERNAL_INFO(ext)); rn;
 		     rn = route_next(rn))
-			if ((ei = rn->info))
-				if (ospf_external_info_find_lsa(ospf, &ei->p)) {
-					if (is_prefix_default(&ei->p)
-					    && ospf->default_originate
-						       != DEFAULT_ORIGINATE_NONE)
-						continue;
+			if ((ei = rn->info)) {
+				struct ospf_external_aggr_rt *aggr;
+
+				if (is_prefix_default(&ei->p)
+				    && ospf->default_originate
+					       != DEFAULT_ORIGINATE_NONE)
+					continue;
+
+				aggr = ei->aggr_route;
+
+				if (aggr)
+					ospf_unlink_ei_from_aggr(ospf, aggr,
+								 ei);
+				else if (ospf_external_info_find_lsa(ospf,
+								     &ei->p))
 					ospf_external_lsa_flush(
 						ospf, type, &ei->p,
 						ei->ifindex /*, ei->nexthop */);
 
-					ospf_external_info_free(ei);
-					route_unlock_node(rn);
-					rn->info = NULL;
-				}
+				ospf_external_info_free(ei);
+				route_unlock_node(rn);
+				rn->info = NULL;
+			}
 }
 
 /* External Route Aggregator Handlers */


### PR DESCRIPTION
Description:
	All matching external routes are added to matching external hash table
        of aggregate route when aggregation is enabled.
        But these external info pointers are not delinked from this hash table
        before freeing the corresponding memory  while disabling redistribution.
        Addressing these memory issues in this change.

Valgrind issues : 
=73472== Invalid read of size 4
==73472==    at 0x48E87FF: prefix_same (prefix.c:367)
==73472==    by 0x1C5C30: ospf_external_rt_hash_cmp (ospf_asbr.c:371)
==73472==    by 0x48C2319: hash_get (hash.c:157)
==73472==    by 0x1C6BAE: ospf_link_ei_to_aggr (ospf_asbr.c:572)
==73472==    by 0x1C6BAE: ospf_originate_summary_lsa (ospf_asbr.c:602)
==73472==    by 0x1B76D0: ospf_zebra_read_route (ospf_zebra.c:1294)
==73472==    by 0x491DFF8: zclient_read (zclient.c:3751)
==73472==    by 0x49084C2: thread_call (thread.c:1815)
==73472==    by 0x48CCDB7: frr_run (libfrr.c:1149)
==73472==    by 0x167DE7: main (ospf_main.c:231)
==73472==  Address 0x5e0ea88 is 8 bytes inside a block of size 64 free'd
==73472==    at 0x48399AB: free (vg_replace_malloc.c:538)
==73472==    by 0x1C67A1: ospf_external_info_free (ospf_asbr.c:91)
==73472==    by 0x1C67A1: ospf_redistribute_withdraw (ospf_asbr.c:327)
==73472==    by 0x1B65FA: ospf_redistribute_unset (ospf_zebra.c:852)
==73472==    by 0x48A7A27: cmd_execute_command_real.constprop.0 (command.c:964)
==73472==    by 0x48A9103: cmd_execute_command (command.c:1024)
==73472==    by 0x48A933F: cmd_execute (command.c:1188)
==73472==    by 0x490DD2C: vty_command (vty.c:508)
==73472==    by 0x490E3B0: vty_execute (vty.c:1268)
==73472==    by 0x491104F: vtysh_read (vty.c:2108)
==73472==    by 0x49084C2: thread_call (thread.c:1815)
==73472==    by 0x48CCDB7: frr_run (libfrr.c:1149)
==73472==    by 0x167DE7: main (ospf_main.c:231)
==73472==  Block was alloc'd at
==73472==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==73472==    by 0x48D472F: qcalloc (memory.c:115)
==73472==    by 0x1C61D0: ospf_external_info_new (ospf_asbr.c:80)
==73472==    by 0x1C61D0: ospf_external_info_add (ospf_asbr.c:145)
==73472==    by 0x1B7657: ospf_zebra_read_route (ospf_zebra.c:1258)
==73472==    by 0x491DFF8: zclient_read (zclient.c:3751)
==73472==    by 0x49084C2: thread_call (thread.c:1815)
==73472==    by 0x48CCDB7: frr_run (libfrr.c:1149)
==73472==    by 0x167DE7: main (ospf_main.c:231)
==73472==

Signed-off-by: Rajesh Girada <rgirada@vmware.com>