### PR TITLE
nhrpd: Fixup tab usage and sockunion2str usage

### DIFF
--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -34,7 +34,6 @@ static void nhrp_reg_reply(struct nhrp_reqid *reqid, void *arg)
 	struct zbuf extpl;
 	union sockunion cie_nbma, cie_nbma_nhs, cie_proto, cie_proto_nhs,
 		*proto;
-	char buf[64];
 	int ok = 0, holdtime;
 	unsigned short mtu = 0;
 
@@ -78,10 +77,8 @@ static void nhrp_reg_reply(struct nhrp_reqid *reqid, void *arg)
 					     &cie_proto)) {
 				nifp->nat_nbma = cie_nbma;
 				debugf(NHRP_DEBUG_IF,
-				       "%s: NAT detected, real NBMA address: %s",
-				       ifp->name,
-				       sockunion2str(&nifp->nbma, buf,
-						     sizeof(buf)));
+				       "%s: NAT detected, real NBMA address: %pSU",
+				       ifp->name, &nifp->nbma);
 			}
 			break;
 		case NHRP_EXTENSION_RESPONDER_ADDRESS:

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -422,7 +422,7 @@ static void nhrp_process_nat_extension(struct nhrp_packet_parser *pp,
 
 					if (!sockunion_cmp(proto, &cie_proto)) {
 						debugf(NHRP_DEBUG_COMMON,
-						       "\tcie_nbma for proto %pSU is %pSU",
+						       "cie_nbma for proto %pSU is %pSU",
 						       proto, cie_nbma);
 						break;
 					}


### PR DESCRIPTION
For some reason the usage of tabs in a string snuck in as well
as using a sockunion2str instead of %pSU.  Fix.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>