### PR TITLE
various acl/plist cli fixes

### DIFF
--- a/lib/filter.c
+++ b/lib/filter.c
@@ -469,59 +469,6 @@ void access_list_filter_add(struct access_list *access,
   host                 A single host address
 */
 
-struct filter *filter_lookup_cisco(struct access_list *access,
-				   struct filter *mnew)
-{
-	struct filter *mfilter;
-	struct filter_cisco *filter;
-	struct filter_cisco *new;
-
-	new = &mnew->u.cfilter;
-
-	for (mfilter = access->head; mfilter; mfilter = mfilter->next) {
-		filter = &mfilter->u.cfilter;
-
-		if (filter->extended) {
-			if (mfilter->type == mnew->type
-			    && filter->addr.s_addr == new->addr.s_addr
-			    && filter->addr_mask.s_addr == new->addr_mask.s_addr
-			    && filter->mask.s_addr == new->mask.s_addr
-			    && filter->mask_mask.s_addr
-				       == new->mask_mask.s_addr)
-				return mfilter;
-		} else {
-			if (mfilter->type == mnew->type
-			    && filter->addr.s_addr == new->addr.s_addr
-			    && filter->addr_mask.s_addr
-				       == new->addr_mask.s_addr)
-				return mfilter;
-		}
-	}
-
-	return NULL;
-}
-
-struct filter *filter_lookup_zebra(struct access_list *access,
-				   struct filter *mnew)
-{
-	struct filter *mfilter;
-	struct filter_zebra *filter;
-	struct filter_zebra *new;
-
-	new = &mnew->u.zfilter;
-
-	for (mfilter = access->head; mfilter; mfilter = mfilter->next) {
-		filter = &mfilter->u.zfilter;
-
-		if (filter->exact == new->exact
-		    && mfilter->type == mnew->type) {
-			if (prefix_same(&filter->prefix, &new->prefix))
-				return mfilter;
-		}
-	}
-	return NULL;
-}
-
 static void config_write_access_zebra(struct vty *, struct filter *);
 static void config_write_access_cisco(struct vty *, struct filter *);
 

--- a/lib/filter.h
+++ b/lib/filter.h
@@ -151,10 +151,6 @@ void access_list_filter_add(struct access_list *access,
 void access_list_filter_delete(struct access_list *access,
 			       struct filter *filter);
 int64_t filter_new_seq_get(struct access_list *access);
-struct filter *filter_lookup_cisco(struct access_list *access,
-				   struct filter *mnew);
-struct filter *filter_lookup_zebra(struct access_list *access,
-				   struct filter *mnew);
 
 extern const struct frr_yang_module_info frr_filter_info;
 
@@ -194,6 +190,9 @@ struct acl_dup_args {
 	/** Duplicated entry found in list? */
 	bool ada_found;
 
+	/** Sequence number of the found entry */
+	int64_t ada_seq;
+
 	/** (Optional) Already existing `dnode`. */
 	const struct lyd_node *ada_entry_dnode;
 };
@@ -223,6 +222,9 @@ struct plist_dup_args {
 
 	/** Duplicated entry found in list? */
 	bool pda_found;
+
+	/** Sequence number of the found entry */
+	int64_t pda_seq;
 
 	/** (Optional) Already existing `dnode`. */
 	const struct lyd_node *pda_entry_dnode;

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -184,7 +184,7 @@ DEFPY_YANG(
 			ada.ada_value[1] = mask_str;
 		} else {
 			ada.ada_xpath[0] = "./source-any";
-			ada.ada_value[0] = "true";
+			ada.ada_value[0] = "";
 		}
 
 		/* Duplicated entry without sequence, just quit. */
@@ -324,7 +324,7 @@ DEFPY_YANG(
 			idx++;
 		} else {
 			ada.ada_xpath[idx] = "./source-any";
-			ada.ada_value[idx] = "true";
+			ada.ada_value[idx] = "";
 			idx++;
 		}
 
@@ -341,7 +341,7 @@ DEFPY_YANG(
 			idx++;
 		} else {
 			ada.ada_xpath[idx] = "./destination-any";
-			ada.ada_value[idx] = "true";
+			ada.ada_value[idx] = "";
 			idx++;
 		}
 
@@ -517,7 +517,7 @@ DEFPY_YANG(
 			}
 		} else {
 			ada.ada_xpath[0] = "./any";
-			ada.ada_value[0] = "true";
+			ada.ada_value[0] = "";
 		}
 
 		/* Duplicated entry without sequence, just quit. */
@@ -715,7 +715,7 @@ DEFPY_YANG(
 			}
 		} else {
 			ada.ada_xpath[0] = "./any";
-			ada.ada_value[0] = "true";
+			ada.ada_value[0] = "";
 		}
 
 		/* Duplicated entry without sequence, just quit. */
@@ -913,7 +913,7 @@ DEFPY_YANG(
 			ada.ada_value[0] = mac_str;
 		} else {
 			ada.ada_xpath[0] = "./any";
-			ada.ada_value[0] = "true";
+			ada.ada_value[0] = "";
 		}
 
 		/* Duplicated entry without sequence, just quit. */

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -1462,13 +1462,18 @@ DEFPY_YANG(
 	ACCESS_LIST_REMARK_STR)
 {
 	char xpath[XPATH_MAXLEN];
+	int rv;
 
 	snprintf(xpath, sizeof(xpath),
 		 "/frr-filter:lib/prefix-list[type='ipv4'][name='%s']/remark",
 		 name);
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, NULL);
+	rv = nb_cli_apply_changes(vty, NULL);
+	if (rv == CMD_SUCCESS)
+		return plist_remove_if_empty(vty, "ipv4", name);
+
+	return rv;
 }
 
 ALIAS(
@@ -1658,13 +1663,18 @@ DEFPY_YANG(
 	ACCESS_LIST_REMARK_STR)
 {
 	char xpath[XPATH_MAXLEN];
+	int rv;
 
 	snprintf(xpath, sizeof(xpath),
 		 "/frr-filter:lib/prefix-list[type='ipv6'][name='%s']/remark",
 		 name);
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, NULL);
+	rv = nb_cli_apply_changes(vty, NULL);
+	if (rv == CMD_SUCCESS)
+		return plist_remove_if_empty(vty, "ipv6", name);
+
+	return rv;
 }
 
 ALIAS(

--- a/lib/filter_nb.c
+++ b/lib/filter_nb.c
@@ -279,6 +279,7 @@ static int _acl_is_dup(const struct lyd_node *dnode, void *arg)
 	}
 
 	ada->ada_found = true;
+	ada->ada_seq = yang_dnode_get_uint32(dnode, "sequence");
 
 	return YANG_ITER_STOP;
 }
@@ -416,6 +417,7 @@ static int _plist_is_dup(const struct lyd_node *dnode, void *arg)
 	}
 
 	pda->pda_found = true;
+	pda->pda_seq = yang_dnode_get_uint32(dnode, "sequence");
 
 	return YANG_ITER_STOP;
 }


### PR DESCRIPTION
```
lib: fix check for duplicated access-list entries

The correct string representation for "empty" type is an empty string.
```
```
lib: fix usage of operational data in CLI

CLI must never use operational data, because this won't work in
transactional mode. Rework search for prefix-list/access-list entries
using only candidate config.
```
```
lib: fix deletion of empty prefix-lists

We delete the prefix-list when its last entry is deleted, but the check
is missed when we delete the description.
```
```
lib: delete empty access-lists

We should delete the access-list when the last entry and remark is
deleted. This is already done for prefix-lists.
```