### PR TITLE
[7.5] lib: Fix label-stack comparison for nexthops

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -62,7 +62,8 @@ static int _nexthop_labels_cmp(const struct nexthop *nh1,
 	if (nhl1->num_labels < nhl2->num_labels)
 		return -1;
 
-	return memcmp(nhl1->label, nhl2->label, nhl1->num_labels);
+	return memcmp(nhl1->label, nhl2->label,
+		      (nhl1->num_labels * sizeof(mpls_label_t)));
 }
 
 int nexthop_g_addr_cmp(enum nexthop_types_t type, const union g_addr *addr1,


### PR DESCRIPTION
Use the correct number of octets in the comparison of nexthops' label stacks.
