### PR TITLE
[7.5] bgpd, nhrpd: fix clang static analysis warnings

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -801,6 +801,10 @@ static void bgp_evpn_type1_es_route_extcomm_build(struct bgp_evpn_es *es,
 				evi_node, es_evi)) {
 		if (!CHECK_FLAG(es_evi->flags, BGP_EVPNES_EVI_LOCAL))
 			continue;
+
+		/* Help SA understand the following loop */
+		assert(es_evi->vpn != NULL);
+
 		for (ALL_LIST_ELEMENTS_RO(es_evi->vpn->export_rtl,
 					rt_node, ecom))
 			attr->ecommunity = ecommunity_merge(attr->ecommunity,

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -146,6 +146,7 @@ int main(int argc, char **argv)
 
 	/* Run with elevated capabilities, as for all netlink activity
 	 * we need privileges anyway. */
+	assert(nhrpd_privs.change);
 	nhrpd_privs.change(ZPRIVS_RAISE);
 
 	netlink_init();


### PR DESCRIPTION
Clean up a couple of SA warnings in the 7.5 branch.
