### PR TITLE
fix xrelfo on ARM(32) & cross-compile

### DIFF
--- a/pathd/subdir.am
+++ b/pathd/subdir.am
@@ -22,7 +22,6 @@ pathd_libpath_a_SOURCES = \
 	pathd/path_cli.c \
 	pathd/path_debug.c \
 	pathd/path_errors.c \
-	pathd/path_main.c \
 	pathd/path_nb.c \
 	pathd/path_nb_config.c \
 	pathd/path_nb_state.c \
@@ -50,7 +49,9 @@ noinst_HEADERS += \
 	pathd/pathd.h \
 	# end
 
-pathd_pathd_SOURCES = pathd/path_main.c
+pathd_pathd_SOURCES = \
+	pathd/path_main.c \
+	# end
 nodist_pathd_pathd_SOURCES = \
 	yang/frr-pathd.yang.c \
 	# end

--- a/pceplib/pcep_msg_tlvs_encoding.c
+++ b/pceplib/pcep_msg_tlvs_encoding.c
@@ -25,6 +25,15 @@
  * Encoding and decoding for PCEP Object TLVs.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#else
+#include <endian.h>
+#endif /* __FreeBSD__ */
 #include <stdlib.h>
 #include <string.h>
 

--- a/pceplib/test/pcep_msg_tlvs_test.c
+++ b/pceplib/test/pcep_msg_tlvs_test.c
@@ -21,6 +21,15 @@
  */
 
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#else
+#include <endian.h>
+#endif /* __FreeBSD__ */
 #include <stdlib.h>
 
 #include <CUnit/CUnit.h>

--- a/python/clippy/elf.py
+++ b/python/clippy/elf.py
@@ -162,7 +162,10 @@ class ELFDissectData(object):
         for field in parent._efields[self.elfclass]:
             if field[0] == fieldname:
                 break
-            offset += struct.calcsize(field[1])
+            spec = field[1]
+            if spec == 'P':
+                spec = 'I' if self.elfclass == 32 else 'Q'
+            offset += struct.calcsize(spec)
         else:
             raise AttributeError('%r not found in %r.fields' % (fieldname, parent))
 


### PR DESCRIPTION
- some ARM 32bit ABIs use DT_REL, which the elf_py code in clippy previously just ignored
- a bug in the python code used the buildhost's pointer size rather than the target's, breaking crosscompile of 32-bit targets on 64-bit hosts

Fixes: #8355