### PR TITLE
bgpd: always allow no advertise-svi-ip/default-gw

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3452,12 +3452,6 @@ DEFUN (no_bgp_evpn_advertise_default_gw,
 	if (!bgp)
 		return CMD_WARNING;
 
-	if (!EVPN_ENABLED(bgp)) {
-		vty_out(vty,
-			"This command is only supported under the EVPN VRF\n");
-		return CMD_WARNING;
-	}
-
 	evpn_unset_advertise_default_gw(bgp, NULL);
 
 	return CMD_SUCCESS;
@@ -3718,16 +3712,16 @@ DEFPY(bgp_evpn_advertise_svi_ip,
 	if (!bgp)
 		return CMD_WARNING;
 
-	if (!EVPN_ENABLED(bgp)) {
-		vty_out(vty,
-			"This command is only supported under EVPN VRF\n");
-		return CMD_WARNING;
-	}
-
 	if (no)
 		evpn_set_advertise_svi_macip(bgp, NULL, 0);
-	else
+	else {
+		if (!EVPN_ENABLED(bgp)) {
+			vty_out(vty,
+				"This command is only supported under EVPN VRF\n");
+			return CMD_WARNING;
+		}
 		evpn_set_advertise_svi_macip(bgp, NULL, 1);
+	}
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
Current behavior has an EVPN_ENABLED check for both standard and 'no'
forms of 'advertise-svi-ip' and 'advertise-default-gw'. This prevents a
user from removing either command from running config if
'advertise-all-vni' is not present.
This commit removes/adjusts the EVPN_ENABLED checks to always allow the
'no' command so config doesn't get stuck.

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>

Before:
```
ub20(config)# router bgp 1
ub20(config-router)# add l2 e  
ub20(config-router-af)# advertise-all-vni 
ub20(config-router-af)# advertise-svi-ip 
ub20(config-router-af)# advertise-default-gw 
ub20(config-router-af)# do sh run
Building configuration... 
                                          
Current configuration:
!                   
frr version 7.7-dev
frr defaults traditional
hostname ub20
log file /var/log/frr/frr.log
log syslog informational
log facility syslog
service integrated-vtysh-config
!
router bgp 1
 no bgp suppress-duplicates
 !
 address-family l2vpn evpn
  advertise-all-vni
  advertise-default-gw
  advertise-svi-ip
 exit-address-family
!
line vty
!
end
ub20(config-router-af)# no advertise-all-vni 
ub20(config-router-af)# no advertise-svi-ip                                          
This command is only supported under EVPN VRF
ub20(config-router-af)# no advertise-default-gw                                      
This command is only supported under the EVPN VRF
ub20(config-router-af)# do sh run
Building configuration...

Current configuration:
!
frr version 7.7-dev
frr defaults traditional
hostname ub20
log file /var/log/frr/frr.log
log syslog informational
log facility syslog
service integrated-vtysh-config
!
router bgp 1
 no bgp suppress-duplicates
 !
 address-family l2vpn evpn
  advertise-default-gw
  advertise-svi-ip
 exit-address-family
!
line vty
!
end
ub20(config-router-af)#
```

After:
```
ub20# conf t
ub20(config)# router bgp 1
ub20(config-router)# add l2 e
ub20(config-router-af)# advertise-default-gw 
ub20(config-router-af)# no advertise-all-vni 
ub20(config-router-af)# no advertise-default-gw 
ub20(config-router-af)# no advertise-svi-ip 
ub20(config-router-af)# advertise-default-gw 
This command is only supported under the EVPN VRF
ub20(config-router-af)# advertise-svi-ip 
This command is only supported under EVPN VRF
ub20(config-router-af)# advertise-all-vni 
ub20(config-router-af)# advertise-default-gw 
ub20(config-router-af)# advertise-svi-ip 
ub20(config-router-af)# 
```