### PR TITLE
lib: fix interface nb stale pointers

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1661,8 +1661,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		else if (IS_ZEBRA_IF_VXLAN(ifp))
 			zebra_l2_vxlanif_del(ifp);
 
-		if (!IS_ZEBRA_IF_VRF(ifp))
-			if_delete_update(ifp);
+		if_delete_update(ifp);
 	}
 
 	return 0;


### PR DESCRIPTION
The first change in this commit is the processing of the VRF termination.
When we terminate the VRF, we should not delete the underlying interfaces,
because there may be pointers to them in the northbound configuration. We
should move them to the default VRF instead.

Because of the first change, the VRF interface itself is also not deleted
when deleting the VRF. It should be handled in netlink_link_change. This
is done by the second change.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>