### PR TITLE
lib: use platform-neutral value for TCP MD5 signature len

### DIFF
--- a/pathd/path_pcep.h
+++ b/pathd/path_pcep.h
@@ -84,7 +84,7 @@ DECLARE_MTYPE(PCEP);
 
 struct pcep_config_group_opts {
 	char name[64];
-	char tcp_md5_auth[TCP_MD5SIG_MAXKEYLEN];
+	char tcp_md5_auth[PCEP_MD5SIG_MAXKEYLEN];
 	struct ipaddr source_ip;
 	short source_port;
 	bool draft07;

--- a/pceplib/pcep.h
+++ b/pceplib/pcep.h
@@ -28,12 +28,10 @@
 #endif
 
 #if defined(linux) || defined(GNU_LINUX)
-//#include <netinet/in.h>
+
 #define ipv6_u __in6_u
 #else
-// bsd family
-#define TCP_MD5SIG_MAXKEYLEN 80
-//#include <netinet/in.h>
+/* bsd family */
 #define ipv6_u __u6_addr
 #ifdef __FreeBSD__
 #include <sys/endian.h>
@@ -45,4 +43,12 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <pthread.h>
+
+/* Cross-compilation seems to have trouble finding this */
+#if defined(TCP_MD5SIG_MAXKEYLEN)
+#define PCEP_MD5SIG_MAXKEYLEN TCP_MD5SIG_MAXKEYLEN
+#else
+#define PCEP_MD5SIG_MAXKEYLEN 80
+#endif
+
 #endif

--- a/pceplib/pcep_pcc.c
+++ b/pceplib/pcep_pcc.c
@@ -53,7 +53,7 @@ struct cmd_line_args {
 	char dest_ip_str[MAX_DST_IP_STR];
 	short src_tcp_port;
 	short dest_tcp_port;
-	char tcp_md5_str[TCP_MD5SIG_MAXKEYLEN]; /* RFC 2385 */
+	char tcp_md5_str[PCEP_MD5SIG_MAXKEYLEN]; /* RFC 2385 */
 	bool is_ipv6;
 	bool eventpoll; /* poll for pcep_event's, or use callback (default) */
 };

--- a/pceplib/pcep_session_logic.h
+++ b/pceplib/pcep_session_logic.h
@@ -122,7 +122,7 @@ typedef struct pcep_configuration_ {
 
 	struct pcep_versioning *pcep_msg_versioning;
 
-	char tcp_authentication_str[TCP_MD5SIG_MAXKEYLEN];
+	char tcp_authentication_str[PCEP_MD5SIG_MAXKEYLEN];
 	bool is_tcp_auth_md5; /* true: RFC 2385, false: RFC 5925 */
 
 } pcep_configuration;

--- a/pceplib/pcep_socket_comm.h
+++ b/pceplib/pcep_socket_comm.h
@@ -91,9 +91,9 @@ typedef struct pcep_socket_comm_session_ {
 	int received_bytes;
 	bool close_after_write;
 	void *external_socket_data; /* used for external socket infra */
-	char tcp_authentication_str[TCP_MD5SIG_MAXKEYLEN
-				    + 1]; /* should be used with is_tcp_auth_md5
-					     flag */
+	/* should be used with is_tcp_auth_md5 flag */
+	char tcp_authentication_str[PCEP_MD5SIG_MAXKEYLEN + 1];
+
 	bool is_tcp_auth_md5; /* flag to distinguish between rfc 2385 (md5) and
 				 rfc 5925 (tcp-ao) */
 


### PR DESCRIPTION
Use a pcep-specific value for MD5SIG_MAXLEN, using the OS value if present. #8355 reported some issues using the raw OS value when cross-compiling.
