### PR TITLE
bgpd: Add `show bgp version <version>` command

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11086,16 +11086,22 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 		}
 	} else {
 		if (!json) {
-			vty_out(vty, "BGP routing table entry for %s%s%pFX\n",
+			vty_out(vty,
+				"BGP routing table entry for %s%s%pFX, version %" PRIu64
+				"\n",
 				((safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP)
 					 ? prefix_rd2str(prd, buf1,
 							 sizeof(buf1))
 					 : ""),
-				safi == SAFI_MPLS_VPN ? ":" : "", p);
+				safi == SAFI_MPLS_VPN ? ":" : "", p,
+				dest->version);
 
-		} else
+		} else {
 			json_object_string_add(json, "prefix",
 				prefix2str(p, prefix_str, sizeof(prefix_str)));
+			json_object_int_add(json, "version", dest->version);
+
+		}
 	}
 
 	if (has_valid_label) {

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -58,6 +58,7 @@ enum bgp_show_type {
 	bgp_show_type_damp_neighbor,
 	bgp_show_type_detail,
 	bgp_show_type_rpki,
+	bgp_show_type_prefix_version,
 };
 
 enum bgp_show_adj_route_type {
@@ -714,9 +715,10 @@ extern void route_vty_out(struct vty *vty, const struct prefix *p,
 extern void route_vty_out_tag(struct vty *vty, const struct prefix *p,
 			      struct bgp_path_info *path, int display,
 			      safi_t safi, json_object *json);
-extern void route_vty_out_tmp(struct vty *vty, const struct prefix *p,
-			      struct attr *attr, safi_t safi, bool use_json,
-			      json_object *json_ar, bool wide);
+extern void route_vty_out_tmp(struct vty *vty, struct bgp_dest *dest,
+			      const struct prefix *p, struct attr *attr,
+			      safi_t safi, bool use_json, json_object *json_ar,
+			      bool wide);
 extern void route_vty_out_overlay(struct vty *vty, const struct prefix *p,
 				  struct bgp_path_info *path, int display,
 				  json_object *json);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -267,7 +267,7 @@ static void subgrp_show_adjq_vty(struct update_subgroup *subgrp,
 				}
 				if ((flags & UPDWALK_FLAGS_ADVQUEUE) && adj->adv
 				    && adj->adv->baa) {
-					route_vty_out_tmp(vty, dest_p,
+					route_vty_out_tmp(vty, dest, dest_p,
 							  adj->adv->baa->attr,
 							  SUBGRP_SAFI(subgrp),
 							  0, NULL, false);
@@ -275,7 +275,7 @@ static void subgrp_show_adjq_vty(struct update_subgroup *subgrp,
 				}
 				if ((flags & UPDWALK_FLAGS_ADVERTISED)
 				    && adj->attr) {
-					route_vty_out_tmp(vty, dest_p,
+					route_vty_out_tmp(vty, dest, dest_p,
 							  adj->attr,
 							  SUBGRP_SAFI(subgrp),
 							  0, NULL, false);

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -229,8 +229,9 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 				}
 				rd_header = 0;
 			}
-			route_vty_out_tmp(vty, bgp_dest_get_prefix(rm), attr,
-					  safi, use_json, json_routes, false);
+			route_vty_out_tmp(vty, rm, bgp_dest_get_prefix(rm),
+					  attr, safi, use_json, json_routes,
+					  false);
 			output_count++;
 		}
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3234,6 +3234,26 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
 
    Display flap statistics of routes of the selected afi and safi selected.
 
+.. clicmd:: show bgp [afi] [safi] [all] version (1-4294967295) [wide|json]
+
+   Display prefixes with matching version numbers. The version number and
+   above having prefixes will be listed here.
+
+   It helps to identify which prefixes were installed at some point.
+
+   Here is an example of how to check what prefixes were installed starting
+   with an arbitrary version::
+
+   .. code-block:: frr
+
+      ~# vtysh -c 'show bgp ipv4 unicast json' | jq '.tableVersion'
+      9
+      ~# vtysh -c 'show ip bgp version 9 json' | jq -r '.routes | keys[]'
+      192.168.3.0/24
+      ~# vtysh -c 'show ip bgp version 8 json' | jq -r '.routes | keys[]'
+      192.168.2.0/24
+      192.168.3.0/24
+
 .. clicmd:: show bgp [afi] [safi] statistics
 
    Display statistics of routes of the selected afi and safi.


### PR DESCRIPTION
The idea is to find out prefixes including specific BGP table version and
above.

I want to look at what new prefixes arrived with a specific BGP table version.

It's kinda useful in some cases like finding out hijacks ad-hoc or so. 

I used this command suddenly last week with Cisco devices and it was handy.