### PR TITLE
ospfd: fix crash on interface/vrf removal

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -694,6 +694,13 @@ static int ospf_if_delete_hook(struct interface *ifp)
 	struct route_node *rn;
 	rc = ospf_opaque_del_if(ifp);
 
+	/*
+	 * This function must be called before `route_table_finish` due to
+	 * BFD integration need to iterate over the interface neighbors to
+	 * remove all registrations.
+	 */
+	ospf_del_if_params(ifp, IF_DEF_PARAMS(ifp));
+
 	route_table_finish(IF_OIFS(ifp));
 
 	for (rn = route_top(IF_OIFS_PARAMS(ifp)); rn; rn = route_next(rn))
@@ -701,7 +708,6 @@ static int ospf_if_delete_hook(struct interface *ifp)
 			ospf_del_if_params(ifp, rn->info);
 	route_table_finish(IF_OIFS_PARAMS(ifp));
 
-	ospf_del_if_params(ifp, IF_DEF_PARAMS(ifp));
 	XFREE(MTYPE_OSPF_IF_INFO, ifp->info);
 
 	return rc;


### PR DESCRIPTION
Fixes #8423 .

Summary
---

The interface parameters deletion must be called before
`route_table_finish` due to the usage of the route data structures to
search neighbors in the same interface. If the route info is removed
before that we get the following crash:

```
 6  0x00007f5c6ed50394 in core_handler at lib/sigevent.c:255
 7  <signal handler called>
 8  ospf_interface_bfd_apply (ifp=<optimized out>) at ospfd/ospf_bfd.c:130
 9  0x000055d4c306d076 in ospf_interface_disable_bfd at ospfd/ospf_bfd.c:159
 10 0x000055d4c3071781 in ospf_del_if_params at ospfd/ospf_interface.c:553
 11 0x000055d4c3071900 in ospf_if_delete_hook at ospfd/ospf_interface.c:704
 12 0x00007f5c6ed17935 in hook_call_if_del at lib/if.c:59
 13 if_delete_retain at lib/if.c:290
 14 0x00007f5c6ed19bc5 in if_delete at lib/if.c:313
 15 0x00007f5c6ed19d88 in if_terminate at lib/if.c:1067
 16 0x00007f5c6ed63a04 in vrf_delete at lib/vrf.c:297
 17 0x00007f5c6ed76784 in zclient_vrf_delete at lib/zclient.c:1974
 18 zclient_read at lib/zclient.c:3686
 19 0x00007f5c6ed60f85 in thread_call at lib/thread.c:1815
 20 0x00007f5c6ed20228 in frr_run at lib/libfrr.c:1149
 21 0x000055d4c306bc70 in main at ospfd/ospf_main.c:233
```

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>