### PR TITLE
OSPF6: Multi-instance (process) support

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -410,7 +410,7 @@ struct cmd_node {
 #define IFNAME_STR "Interface name(e.g. ep0)\n"
 #define IP6_STR "IPv6 Information\n"
 #define OSPF6_STR "Open Shortest Path First (OSPF) for IPv6\n"
-#define OSPF6_INSTANCE_STR "(1-65535) Instance ID\n"
+#define OSPF6_INSTANCE_STR "Instance ID\n"
 #define SECONDS_STR "Seconds\n"
 #define ROUTE_STR "Routing Table\n"
 #define PREFIX_LIST_STR "Build a prefix list\n"

--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -59,6 +59,7 @@ static struct zlog_cfg_filterfile zt_filterfile = {
 
 static const char *zlog_progname;
 static const char *zlog_protoname;
+static uint16_t zlog_instance;
 
 static const struct facility_map {
 	int facility;
@@ -152,6 +153,9 @@ DEFUN_NOSH (show_logging,
 	    SHOW_STR
 	    "Show current logging configuration\n")
 {
+	if (zlog_instance)
+		vty_out(vty, "\nInstance: %u\n", zlog_instance);
+
 	log_show_syslog(vty);
 
 	vty_out(vty, "Stdout logging: ");
@@ -733,6 +737,7 @@ static int log_vty_init(const char *progname, const char *protoname,
 {
 	zlog_progname = progname;
 	zlog_protoname = protoname;
+	zlog_instance = instance;
 
 	zlog_set_prefix_ec(true);
 	zlog_set_prefix_xid(true);

--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -1421,33 +1421,37 @@ static int ospf6_inter_area_router_lsa_show(struct vty *vty,
 /* Debug commands */
 DEFUN (debug_ospf6_abr,
        debug_ospf6_abr_cmd,
-       "debug ospf6 abr",
+       "debug ospf6 [(1-65535)] abr",
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug OSPFv3 ABR function\n"
       )
 {
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 2, NULL);
 	OSPF6_DEBUG_ABR_ON();
 	return CMD_SUCCESS;
 }
 
 DEFUN (no_debug_ospf6_abr,
        no_debug_ospf6_abr_cmd,
-       "no debug ospf6 abr",
+       "no debug ospf6 [(1-65535)] abr",
        NO_STR
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug OSPFv3 ABR function\n"
       )
 {
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 	OSPF6_DEBUG_ABR_OFF();
 	return CMD_SUCCESS;
 }
 
-int config_write_ospf6_debug_abr(struct vty *vty)
+int config_write_ospf6_debug_abr(struct vty *vty, struct ospf6 *ospf6)
 {
 	if (IS_OSPF6_DEBUG_ABR)
-		vty_out(vty, "debug ospf6 abr\n");
+		vty_out(vty, "debug ospf6%s abr\n", ospf6->instance_str);
 	return 0;
 }
 

--- a/ospf6d/ospf6_abr.h
+++ b/ospf6d/ospf6_abr.h
@@ -76,7 +76,7 @@ extern void ospf6_abr_reimport(struct ospf6_area *oa);
 extern void ospf6_abr_range_reset_cost(struct ospf6 *ospf6);
 extern void ospf6_abr_prefix_resummarize(struct ospf6 *ospf6);
 
-extern int config_write_ospf6_debug_abr(struct vty *vty);
+extern int config_write_ospf6_debug_abr(struct vty *vty, struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_abr(void);
 extern int ospf6_abr_config_write(struct vty *vty);
 extern void ospf6_abr_old_route_remove(struct ospf6_lsa *lsa,

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -476,7 +476,7 @@ DEFUN (area_range,
 	struct ospf6_route *range;
 	uint32_t cost = OSPF_AREA_RANGE_COST_UNSPEC;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, oa, ospf6);
 
@@ -545,7 +545,7 @@ DEFUN (no_area_range,
 	struct prefix prefix;
 	struct ospf6_route *range, *route;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, oa, ospf6);
 
@@ -645,7 +645,7 @@ DEFUN (area_filter_list,
 	struct ospf6_area *area;
 	struct prefix_list *plist;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(areaid, area, ospf6);
 
@@ -686,7 +686,7 @@ DEFUN (no_area_filter_list,
 
 	struct ospf6_area *area;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 	OSPF6_CMD_AREA_GET(areaid, area, ospf6);
 
 	if (strmatch(inout, "in")) {
@@ -747,7 +747,7 @@ DEFUN (area_import_list,
 	struct ospf6_area *area;
 	struct access_list *list;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area, ospf6);
 
@@ -777,7 +777,7 @@ DEFUN (no_area_import_list,
 	int idx_ipv4 = 2;
 	struct ospf6_area *area;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area, ospf6);
 
@@ -806,7 +806,7 @@ DEFUN (area_export_list,
 	struct ospf6_area *area;
 	struct access_list *list;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area, ospf6);
 
@@ -836,7 +836,7 @@ DEFUN (no_area_export_list,
 	int idx_ipv4 = 2;
 	struct ospf6_area *area;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(argv[idx_ipv4]->arg, area, ospf6);
 
@@ -853,10 +853,11 @@ DEFUN (no_area_export_list,
 
 DEFUN (show_ipv6_ospf6_spf_tree,
        show_ipv6_ospf6_spf_tree_cmd,
-       "show ipv6 ospf6 spf tree [json]",
+       "show ipv6 ospf6 [(1-65535)] spf tree [json]",
        SHOW_STR
        IP6_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Shortest Path First calculation\n"
        "Show SPF tree\n"
         JSON_STR)
@@ -871,6 +872,8 @@ DEFUN (show_ipv6_ospf6_spf_tree,
 	json_object *json_area = NULL;
 	json_object *json_head = NULL;
 	bool uj = use_json(argc, argv);
+
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 
 	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
 	OSPF6_CMD_CHECK_RUNNING(ospf6);
@@ -920,22 +923,27 @@ DEFUN (show_ipv6_ospf6_spf_tree,
 
 DEFUN (show_ipv6_ospf6_area_spf_tree,
        show_ipv6_ospf6_area_spf_tree_cmd,
-       "show ipv6 ospf6 area A.B.C.D spf tree",
+       "show ipv6 ospf6 [(1-65535)] area A.B.C.D spf tree",
        SHOW_STR
        IP6_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        OSPF6_AREA_STR
        OSPF6_AREA_ID_STR
        "Shortest Path First calculation\n"
        "Show SPF tree\n")
 {
 	int idx_ipv4 = 4;
+	int idx_ofs = 0;
 	uint32_t area_id;
 	struct ospf6_area *oa;
 	struct ospf6_vertex *root;
 	struct ospf6_route *route;
 	struct prefix prefix;
 	struct ospf6 *ospf6;
+
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, &idx_ofs);
+	idx_ipv4 += idx_ofs;
 
 	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
 
@@ -967,10 +975,11 @@ DEFUN (show_ipv6_ospf6_area_spf_tree,
 
 DEFUN (show_ipv6_ospf6_simulate_spf_tree_root,
        show_ipv6_ospf6_simulate_spf_tree_root_cmd,
-       "show ipv6 ospf6 simulate spf-tree A.B.C.D area A.B.C.D",
+       "show ipv6 ospf6 [(1-65535)] simulate spf-tree A.B.C.D area A.B.C.D",
        SHOW_STR
        IP6_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Shortest Path First calculation\n"
        "Show SPF tree\n"
        "Specify root's router-id to calculate another router's SPF tree\n"
@@ -979,6 +988,7 @@ DEFUN (show_ipv6_ospf6_simulate_spf_tree_root,
 {
 	int idx_ipv4 = 5;
 	int idx_ipv4_2 = 7;
+	int idx_ofs = 0;
 	uint32_t area_id;
 	struct ospf6_area *oa;
 	struct ospf6_vertex *root;
@@ -988,6 +998,10 @@ DEFUN (show_ipv6_ospf6_simulate_spf_tree_root,
 	struct ospf6_route_table *spf_table;
 	unsigned char tmp_debug_ospf6_spf = 0;
 	struct ospf6 *ospf6;
+
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, &idx_ofs);
+	idx_ipv4 += idx_ofs;
+	idx_ipv4_2 += idx_ofs;
 
 	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
 
@@ -1040,7 +1054,7 @@ DEFUN (ospf6_area_stub,
 	int idx_ipv4_number = 1;
 	struct ospf6_area *area;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area, ospf6);
 
@@ -1067,7 +1081,7 @@ DEFUN (ospf6_area_stub_no_summary,
 	int idx_ipv4_number = 1;
 	struct ospf6_area *area;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area, ospf6);
 
@@ -1094,7 +1108,7 @@ DEFUN (no_ospf6_area_stub,
 	int idx_ipv4_number = 2;
 	struct ospf6_area *area;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area, ospf6);
 
@@ -1117,7 +1131,7 @@ DEFUN (no_ospf6_area_stub_no_summary,
 	int idx_ipv4_number = 2;
 	struct ospf6_area *area;
 
-	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf6);
 
 	OSPF6_CMD_AREA_GET(argv[idx_ipv4_number]->arg, area, ospf6);
 

--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -38,6 +38,8 @@ struct ospf6_external_info {
 	/* External route type */
 	int type;
 
+	uint16_t instance;
+
 	/* Originating Link State ID */
 	uint32_t id;
 
@@ -79,12 +81,14 @@ extern void ospf6_asbr_lsentry_remove(struct ospf6_route *asbr_entry,
 				      struct ospf6 *ospf6);
 
 extern int ospf6_asbr_is_asbr(struct ospf6 *o);
-extern void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
+extern void ospf6_asbr_redistribute_add(int type, uint16_t instance,
+					ifindex_t ifindex,
 					struct prefix *prefix,
 					unsigned int nexthop_num,
 					struct in6_addr *nexthop,
 					route_tag_t tag, struct ospf6 *ospf6);
-extern void ospf6_asbr_redistribute_remove(int type, ifindex_t ifindex,
+extern void ospf6_asbr_redistribute_remove(int type, uint16_t instance,
+					   ifindex_t ifindex,
 					   struct prefix *prefix,
 					   struct ospf6 *ospf6);
 
@@ -97,13 +101,14 @@ extern void ospf6_asbr_terminate(void);
 extern void ospf6_asbr_send_externals_to_area(struct ospf6_area *);
 extern void ospf6_asbr_remove_externals_from_area(struct ospf6_area *oa);
 
-extern int config_write_ospf6_debug_asbr(struct vty *vty);
+extern int config_write_ospf6_debug_asbr(struct vty *vty, struct ospf6 *ospf6);
 extern int ospf6_distribute_config_write(struct vty *vty, struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_asbr(void);
 extern void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 					      struct ospf6_route *route,
 					      struct ospf6 *ospf6);
-extern void ospf6_asbr_distribute_list_update(int type, struct ospf6 *ospf6);
-struct ospf6_redist *ospf6_redist_lookup(struct ospf6 *ospf6, int type,
-					 unsigned short instance);
+extern void ospf6_asbr_distribute_list_update(int type, uint16_t instance,
+					      struct ospf6 *ospf6);
+extern struct ospf6_redist *ospf6_redist_lookup(struct ospf6 *ospf6, int type,
+						uint16_t instance);
 #endif /* OSPF6_ASBR_H */

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -1046,33 +1046,37 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 
 DEFUN (debug_ospf6_flooding,
        debug_ospf6_flooding_cmd,
-       "debug ospf6 flooding",
+       "debug ospf6 [(1-65535)] flooding",
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug OSPFv3 flooding function\n"
       )
 {
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 2, NULL);
 	OSPF6_DEBUG_FLOODING_ON();
 	return CMD_SUCCESS;
 }
 
 DEFUN (no_debug_ospf6_flooding,
        no_debug_ospf6_flooding_cmd,
-       "no debug ospf6 flooding",
+       "no debug ospf6 [(1-65535)] flooding",
        NO_STR
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug OSPFv3 flooding function\n"
       )
 {
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 	OSPF6_DEBUG_FLOODING_OFF();
 	return CMD_SUCCESS;
 }
 
-int config_write_ospf6_debug_flood(struct vty *vty)
+int config_write_ospf6_debug_flood(struct vty *vty, struct ospf6 *ospf6)
 {
 	if (IS_OSPF6_DEBUG_FLOODING)
-		vty_out(vty, "debug ospf6 flooding\n");
+		vty_out(vty, "debug ospf6%s flooding\n", ospf6->instance_str);
 	return 0;
 }
 

--- a/ospf6d/ospf6_flood.h
+++ b/ospf6d/ospf6_flood.h
@@ -59,7 +59,7 @@ extern void ospf6_receive_lsa(struct ospf6_neighbor *from,
 			      struct ospf6_lsa_header *header);
 extern void ospf6_install_lsa(struct ospf6_lsa *lsa);
 
-extern int config_write_ospf6_debug_flood(struct vty *vty);
+extern int config_write_ospf6_debug_flood(struct vty *vty, struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_flood(void);
 extern void ospf6_flood_interface(struct ospf6_neighbor *from,
 				  struct ospf6_lsa *lsa,

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1155,24 +1155,30 @@ static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 /* show interface */
 DEFUN(show_ipv6_ospf6_interface,
       show_ipv6_ospf6_interface_ifname_cmd,
-      "show ipv6 ospf6 interface [IFNAME] [json]",
+      "show ipv6 ospf6 [(1-65535)] interface [IFNAME] [json]",
       SHOW_STR
       IP6_STR
       OSPF6_STR
+      OSPF6_INSTANCE_STR
       INTERFACE_STR
       IFNAME_STR
       JSON_STR)
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	int idx_ifname = 4;
+	int idx_ofs = 0;
 	struct interface *ifp;
 	json_object *json;
 	json_object *json_int;
 	bool uj = use_json(argc, argv);
 
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, &idx_ofs);
+	idx_ifname += idx_ofs;
+
 	if (uj) {
 		json = json_object_new_object();
-		if (argc == 6) {
+		/* +1 for to trailing "json" arg */
+		if (argc > idx_ifname + 1) {
 			ifp = if_lookup_by_name(argv[idx_ifname]->arg,
 						VRF_DEFAULT);
 			json_int = json_object_new_object();
@@ -1201,7 +1207,7 @@ DEFUN(show_ipv6_ospf6_interface,
 				json, JSON_C_TO_STRING_PRETTY));
 		json_object_free(json);
 	} else {
-		if (argc == 5) {
+		if (argc > idx_ifname) {
 			ifp = if_lookup_by_name(argv[idx_ifname]->arg,
 						VRF_DEFAULT);
 			if (ifp == NULL) {
@@ -1336,10 +1342,11 @@ static int ospf6_interface_show_traffic(struct vty *vty,
 /* show interface */
 DEFUN(show_ipv6_ospf6_interface_traffic,
       show_ipv6_ospf6_interface_traffic_cmd,
-      "show ipv6 ospf6 interface traffic [IFNAME] [json]",
+      "show ipv6 ospf6 [(1-65535)] interface traffic [IFNAME] [json]",
       SHOW_STR
       IP6_STR
       OSPF6_STR
+      OSPF6_INSTANCE_STR
       INTERFACE_STR
       "Protocol Packet counters\n"
       IFNAME_STR
@@ -1351,6 +1358,8 @@ DEFUN(show_ipv6_ospf6_interface_traffic,
 	struct interface *ifp = NULL;
 	json_object *json = NULL;
 	bool uj = use_json(argc, argv);
+
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 
 	if (uj)
 		json = json_object_new_object();
@@ -1413,7 +1422,7 @@ DEFUN(show_ipv6_ospf6_interface_traffic,
 
 DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
        show_ipv6_ospf6_interface_ifname_prefix_cmd,
-       "show ipv6 ospf6 interface IFNAME prefix\
+       "show ipv6 ospf6 [(1-65535)] interface IFNAME prefix\
           [<\
 	    detail\
 	    |<X:X::X:X|X:X::X:X/M> [<match|detail>]\
@@ -1421,6 +1430,7 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
        SHOW_STR
        IP6_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        INTERFACE_STR
        IFNAME_STR
        "Display connected prefixes to advertise\n"
@@ -1433,9 +1443,14 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
 {
 	int idx_ifname = 4;
 	int idx_prefix = 6;
+	int idx_ofs = 0;
 	struct interface *ifp;
 	struct ospf6_interface *oi;
 	bool uj = use_json(argc, argv);
+
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, &idx_ofs);
+	idx_ifname += idx_ofs;
+	idx_prefix += idx_ofs;
 
 	ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
 	if (ifp == NULL) {
@@ -1464,7 +1479,7 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
 
 DEFUN (show_ipv6_ospf6_interface_prefix,
        show_ipv6_ospf6_interface_prefix_cmd,
-       "show ipv6 ospf6 interface prefix\
+       "show ipv6 ospf6 [(1-65535)] interface prefix\
           [<\
 	    detail\
 	    |<X:X::X:X|X:X::X:X/M> [<match|detail>]\
@@ -1472,6 +1487,7 @@ DEFUN (show_ipv6_ospf6_interface_prefix,
        SHOW_STR
        IP6_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        INTERFACE_STR
        "Display connected prefixes to advertise\n"
        "Display details of the prefixes\n"
@@ -1483,9 +1499,13 @@ DEFUN (show_ipv6_ospf6_interface_prefix,
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	int idx_prefix = 5;
+	int idx_ofs = 0;
 	struct ospf6_interface *oi;
 	struct interface *ifp;
 	bool uj = use_json(argc, argv);
+
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, &idx_ofs);
+	idx_prefix += idx_ofs;
 
 	FOR_ALL_INTERFACES (vrf, ifp) {
 		oi = (struct ospf6_interface *)ifp->info;
@@ -1671,7 +1691,7 @@ DEFUN (auto_cost_reference_bandwidth,
        "Use reference bandwidth method to assign OSPF cost\n"
        "The reference bandwidth in terms of Mbits per second\n")
 {
-	VTY_DECLVAR_CONTEXT(ospf6, o);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, o);
 	int idx_number = 2;
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
@@ -1704,7 +1724,7 @@ DEFUN (no_auto_cost_reference_bandwidth,
        "Use reference bandwidth method to assign OSPF cost\n"
        "The reference bandwidth in terms of Mbits per second\n")
 {
-	VTY_DECLVAR_CONTEXT(ospf6, o);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, o);
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	struct listnode *i, *j;
@@ -2398,7 +2418,7 @@ DEFUN (clear_ipv6_ospf6_interface,
 	int idx_ifname = 4;
 	struct interface *ifp;
 
-	if (argc == 4) /* Clear all the ospfv3 interfaces. */
+	if (argc <= idx_ifname) /* Clear all the ospfv3 interfaces. */
 	{
 		FOR_ALL_INTERFACES (vrf, ifp)
 			ospf6_interface_clear(vty, ifp);
@@ -2424,33 +2444,37 @@ void install_element_ospf6_clear_interface(void)
 
 DEFUN (debug_ospf6_interface,
        debug_ospf6_interface_cmd,
-       "debug ospf6 interface",
+       "debug ospf6 [(1-65535)] interface",
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug OSPFv3 Interface\n"
       )
 {
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 2, NULL);
 	OSPF6_DEBUG_INTERFACE_ON();
 	return CMD_SUCCESS;
 }
 
 DEFUN (no_debug_ospf6_interface,
        no_debug_ospf6_interface_cmd,
-       "no debug ospf6 interface",
+       "no debug ospf6 [(1-65535)] interface",
        NO_STR
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug OSPFv3 Interface\n"
       )
 {
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 	OSPF6_DEBUG_INTERFACE_OFF();
 	return CMD_SUCCESS;
 }
 
-int config_write_ospf6_debug_interface(struct vty *vty)
+int config_write_ospf6_debug_interface(struct vty *vty, struct ospf6 *ospf6)
 {
 	if (IS_OSPF6_DEBUG_INTERFACE)
-		vty_out(vty, "debug ospf6 interface\n");
+		vty_out(vty, "debug ospf6%s interface\n", ospf6->instance_str);
 	return 0;
 }
 

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -194,7 +194,8 @@ extern void ospf6_interface_init(void);
 
 extern void install_element_ospf6_clear_interface(void);
 
-extern int config_write_ospf6_debug_interface(struct vty *vty);
+extern int config_write_ospf6_debug_interface(struct vty *vty,
+					      struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_interface(void);
 
 DECLARE_HOOK(ospf6_interface_change,

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -2367,41 +2367,51 @@ void ospf6_intra_init(void)
 
 DEFUN (debug_ospf6_brouter,
        debug_ospf6_brouter_cmd,
-       "debug ospf6 border-routers",
+       "debug ospf6 [(1-65535)] border-routers",
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug border router\n"
       )
 {
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 2, NULL);
 	OSPF6_DEBUG_BROUTER_ON();
 	return CMD_SUCCESS;
 }
 
 DEFUN (no_debug_ospf6_brouter,
        no_debug_ospf6_brouter_cmd,
-       "no debug ospf6 border-routers",
+       "no debug ospf6 [(1-65535)] border-routers",
        NO_STR
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug border router\n"
       )
 {
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 	OSPF6_DEBUG_BROUTER_OFF();
 	return CMD_SUCCESS;
 }
 
 DEFUN (debug_ospf6_brouter_router,
        debug_ospf6_brouter_router_cmd,
-       "debug ospf6 border-routers router-id A.B.C.D",
+       "debug ospf6 [(1-65535)] border-routers router-id A.B.C.D",
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug border router\n"
        "Debug specific border router\n"
        "Specify border-router's router-id\n"
       )
 {
 	int idx_ipv4 = 4;
+	int idx_ofs = 0;
 	uint32_t router_id;
+
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 2, &idx_ofs);
+	idx_ipv4 += idx_ofs;
+
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &router_id);
 	OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER_ON(router_id);
 	return CMD_SUCCESS;
@@ -2409,30 +2419,38 @@ DEFUN (debug_ospf6_brouter_router,
 
 DEFUN (no_debug_ospf6_brouter_router,
        no_debug_ospf6_brouter_router_cmd,
-       "no debug ospf6 border-routers router-id",
+       "no debug ospf6 [(1-65535)] border-routers router-id",
        NO_STR
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug border router\n"
        "Debug specific border router\n"
       )
 {
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 	OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER_OFF();
 	return CMD_SUCCESS;
 }
 
 DEFUN (debug_ospf6_brouter_area,
        debug_ospf6_brouter_area_cmd,
-       "debug ospf6 border-routers area-id A.B.C.D",
+       "debug ospf6 [(1-65535)] border-routers area-id A.B.C.D",
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug border router\n"
        "Debug border routers in specific Area\n"
        "Specify Area-ID\n"
       )
 {
 	int idx_ipv4 = 4;
+	int idx_ofs = 0;
 	uint32_t area_id;
+
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 2, &idx_ofs);
+	idx_ipv4 += idx_ofs;
+
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &area_id);
 	OSPF6_DEBUG_BROUTER_SPECIFIC_AREA_ON(area_id);
 	return CMD_SUCCESS;
@@ -2440,32 +2458,37 @@ DEFUN (debug_ospf6_brouter_area,
 
 DEFUN (no_debug_ospf6_brouter_area,
        no_debug_ospf6_brouter_area_cmd,
-       "no debug ospf6 border-routers area-id",
+       "no debug ospf6 [(1-65535)] border-routers area-id",
        NO_STR
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug border router\n"
        "Debug border routers in specific Area\n"
       )
 {
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 	OSPF6_DEBUG_BROUTER_SPECIFIC_AREA_OFF();
 	return CMD_SUCCESS;
 }
 
-int config_write_ospf6_debug_brouter(struct vty *vty)
+int config_write_ospf6_debug_brouter(struct vty *vty, struct ospf6 *ospf6)
 {
 	char buf[16];
 	if (IS_OSPF6_DEBUG_BROUTER)
-		vty_out(vty, "debug ospf6 border-routers\n");
+		vty_out(vty, "debug ospf6%s border-routers\n",
+			ospf6->instance_str);
 	if (IS_OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER) {
 		inet_ntop(AF_INET, &conf_debug_ospf6_brouter_specific_router_id,
 			  buf, sizeof(buf));
-		vty_out(vty, "debug ospf6 border-routers router-id %s\n", buf);
+		vty_out(vty, "debug ospf6%s border-routers router-id %s\n",
+			ospf6->instance_str, buf);
 	}
 	if (IS_OSPF6_DEBUG_BROUTER_SPECIFIC_AREA) {
 		inet_ntop(AF_INET, &conf_debug_ospf6_brouter_specific_area_id,
 			  buf, sizeof(buf));
-		vty_out(vty, "debug ospf6 border-routers area-id %s\n", buf);
+		vty_out(vty, "debug ospf6%s border-routers area-id %s\n",
+			ospf6->instance_str, buf);
 	}
 	return 0;
 }

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -237,7 +237,8 @@ extern void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 
 extern void ospf6_intra_init(void);
 
-extern int config_write_ospf6_debug_brouter(struct vty *vty);
+extern int config_write_ospf6_debug_brouter(struct vty *vty,
+					    struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_brouter(void);
 
 #endif /* OSPF6_LSA_H */

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -249,7 +249,7 @@ extern struct ospf6_lsa_handler *ospf6_get_lsa_handler(uint16_t type);
 extern void ospf6_lsa_init(void);
 extern void ospf6_lsa_terminate(void);
 
-extern int config_write_ospf6_debug_lsa(struct vty *vty);
+extern int config_write_ospf6_debug_lsa(struct vty *vty, struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_lsa(void);
 extern void ospf6_lsa_age_set(struct ospf6_lsa *lsa);
 extern void ospf6_flush_self_originated_lsas_now(struct ospf6 *ospf6);

--- a/ospf6d/ospf6_message.h
+++ b/ospf6d/ospf6_message.h
@@ -109,6 +109,8 @@ struct ospf6_lsupdate {
 #define OSPF6_LS_ACK_MIN_SIZE                  0U
 /* It is just a sequence of LSA Headers */
 
+struct ospf6;
+
 /* Function definition */
 extern void ospf6_hello_print(struct ospf6_header *);
 extern void ospf6_dbdesc_print(struct ospf6_header *);
@@ -129,7 +131,7 @@ extern int ospf6_lsupdate_send_neighbor(struct thread *thread);
 extern int ospf6_lsack_send_interface(struct thread *thread);
 extern int ospf6_lsack_send_neighbor(struct thread *thread);
 
-extern int config_write_ospf6_debug_message(struct vty *);
+extern int config_write_ospf6_debug_message(struct vty *, struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_message(void);
 
 #endif /* OSPF6_MESSAGE_H */

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -161,7 +161,8 @@ extern int inactivity_timer(struct thread *);
 extern void ospf6_check_nbr_loading(struct ospf6_neighbor *);
 
 extern void ospf6_neighbor_init(void);
-extern int config_write_ospf6_debug_neighbor(struct vty *vty);
+extern int config_write_ospf6_debug_neighbor(struct vty *vty,
+					     struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_neighbor(void);
 
 DECLARE_HOOK(ospf6_neighbor_change,

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1776,9 +1776,10 @@ void ospf6_brouter_show(struct vty *vty, struct ospf6_route *route)
 
 DEFUN (debug_ospf6_route,
        debug_ospf6_route_cmd,
-       "debug ospf6 route <table|intra-area|inter-area|memory>",
+       "debug ospf6 [(1-65535)] route <table|intra-area|inter-area|memory>",
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug routes\n"
        "Debug route table calculation\n"
        "Debug intra-area route calculation\n"
@@ -1787,7 +1788,11 @@ DEFUN (debug_ospf6_route,
        )
 {
 	int idx_type = 3;
+	int idx_ofs = 0;
 	unsigned char level = 0;
+
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 2, NULL);
+	idx_type += idx_ofs;
 
 	if (!strcmp(argv[idx_type]->text, "table"))
 		level = OSPF6_DEBUG_ROUTE_TABLE;
@@ -1803,10 +1808,11 @@ DEFUN (debug_ospf6_route,
 
 DEFUN (no_debug_ospf6_route,
        no_debug_ospf6_route_cmd,
-       "no debug ospf6 route <table|intra-area|inter-area|memory>",
+       "no debug ospf6 [(1-65535)] route <table|intra-area|inter-area|memory>",
        NO_STR
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug routes\n"
        "Debug route table calculation\n"
        "Debug intra-area route calculation\n"
@@ -1814,7 +1820,11 @@ DEFUN (no_debug_ospf6_route,
        "Debug route memory use\n")
 {
 	int idx_type = 4;
+	int idx_ofs = 0;
 	unsigned char level = 0;
+
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
+	idx_type += idx_ofs;
 
 	if (!strcmp(argv[idx_type]->text, "table"))
 		level = OSPF6_DEBUG_ROUTE_TABLE;
@@ -1828,16 +1838,20 @@ DEFUN (no_debug_ospf6_route,
 	return CMD_SUCCESS;
 }
 
-int config_write_ospf6_debug_route(struct vty *vty)
+int config_write_ospf6_debug_route(struct vty *vty, struct ospf6 *ospf6)
 {
 	if (IS_OSPF6_DEBUG_ROUTE(TABLE))
-		vty_out(vty, "debug ospf6 route table\n");
+		vty_out(vty, "debug ospf6%s route table\n",
+			ospf6->instance_str);
 	if (IS_OSPF6_DEBUG_ROUTE(INTRA))
-		vty_out(vty, "debug ospf6 route intra-area\n");
+		vty_out(vty, "debug ospf6%s route intra-area\n",
+			ospf6->instance_str);
 	if (IS_OSPF6_DEBUG_ROUTE(INTER))
-		vty_out(vty, "debug ospf6 route inter-area\n");
+		vty_out(vty, "debug ospf6%s route inter-area\n",
+			ospf6->instance_str);
 	if (IS_OSPF6_DEBUG_ROUTE(MEMORY))
-		vty_out(vty, "debug ospf6 route memory\n");
+		vty_out(vty, "debug ospf6%s route memory\n",
+			ospf6->instance_str);
 
 	return 0;
 }

--- a/ospf6d/ospf6_route.h
+++ b/ospf6d/ospf6_route.h
@@ -345,7 +345,7 @@ extern int ospf6_linkstate_table_show(struct vty *vty, int idx_ipv4, int argc,
 extern void ospf6_brouter_show_header(struct vty *vty);
 extern void ospf6_brouter_show(struct vty *vty, struct ospf6_route *route);
 
-extern int config_write_ospf6_debug_route(struct vty *vty);
+extern int config_write_ospf6_debug_route(struct vty *vty, struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_route(void);
 extern void ospf6_route_init(void);
 extern void ospf6_path_free(struct ospf6_path *op);

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -779,14 +779,16 @@ void ospf6_spf_display_subtree(struct vty *vty, const char *prefix, int rest,
 
 DEFUN (debug_ospf6_spf_process,
        debug_ospf6_spf_process_cmd,
-       "debug ospf6 spf process",
+       "debug ospf6 [(1-65535)] spf process",
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug SPF Calculation\n"
        "Debug Detailed SPF Process\n"
       )
 {
 	unsigned char level = 0;
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 2, NULL);
 	level = OSPF6_DEBUG_SPF_PROCESS;
 	OSPF6_DEBUG_SPF_ON(level);
 	return CMD_SUCCESS;
@@ -794,14 +796,16 @@ DEFUN (debug_ospf6_spf_process,
 
 DEFUN (debug_ospf6_spf_time,
        debug_ospf6_spf_time_cmd,
-       "debug ospf6 spf time",
+       "debug ospf6 [(1-65535)] spf time",
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug SPF Calculation\n"
        "Measure time taken by SPF Calculation\n"
       )
 {
 	unsigned char level = 0;
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 2, NULL);
 	level = OSPF6_DEBUG_SPF_TIME;
 	OSPF6_DEBUG_SPF_ON(level);
 	return CMD_SUCCESS;
@@ -809,14 +813,16 @@ DEFUN (debug_ospf6_spf_time,
 
 DEFUN (debug_ospf6_spf_database,
        debug_ospf6_spf_database_cmd,
-       "debug ospf6 spf database",
+       "debug ospf6 [(1-65535)] spf database",
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug SPF Calculation\n"
        "Log number of LSAs at SPF Calculation time\n"
       )
 {
 	unsigned char level = 0;
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 2, NULL);
 	level = OSPF6_DEBUG_SPF_DATABASE;
 	OSPF6_DEBUG_SPF_ON(level);
 	return CMD_SUCCESS;
@@ -824,15 +830,17 @@ DEFUN (debug_ospf6_spf_database,
 
 DEFUN (no_debug_ospf6_spf_process,
        no_debug_ospf6_spf_process_cmd,
-       "no debug ospf6 spf process",
+       "no debug ospf6 [(1-65535)] spf process",
        NO_STR
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Quit Debugging SPF Calculation\n"
        "Quit Debugging Detailed SPF Process\n"
       )
 {
 	unsigned char level = 0;
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 	level = OSPF6_DEBUG_SPF_PROCESS;
 	OSPF6_DEBUG_SPF_OFF(level);
 	return CMD_SUCCESS;
@@ -840,15 +848,17 @@ DEFUN (no_debug_ospf6_spf_process,
 
 DEFUN (no_debug_ospf6_spf_time,
        no_debug_ospf6_spf_time_cmd,
-       "no debug ospf6 spf time",
+       "no debug ospf6 [(1-65535)] spf time",
        NO_STR
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Quit Debugging SPF Calculation\n"
        "Quit Measuring time taken by SPF Calculation\n"
       )
 {
 	unsigned char level = 0;
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 	level = OSPF6_DEBUG_SPF_TIME;
 	OSPF6_DEBUG_SPF_OFF(level);
 	return CMD_SUCCESS;
@@ -856,15 +866,17 @@ DEFUN (no_debug_ospf6_spf_time,
 
 DEFUN (no_debug_ospf6_spf_database,
        no_debug_ospf6_spf_database_cmd,
-       "no debug ospf6 spf database",
+       "no debug ospf6 [(1-65535)] spf database",
        NO_STR
        DEBUG_STR
        OSPF6_STR
+       OSPF6_INSTANCE_STR
        "Debug SPF Calculation\n"
        "Quit Logging number of LSAs at SPF Calculation time\n"
       )
 {
 	unsigned char level = 0;
+	OSPF6_CMD_CHECK_INSTANCE_ARG(argc, argv, 3, NULL);
 	level = OSPF6_DEBUG_SPF_DATABASE;
 	OSPF6_DEBUG_SPF_OFF(level);
 	return CMD_SUCCESS;
@@ -873,7 +885,7 @@ DEFUN (no_debug_ospf6_spf_database,
 static int ospf6_timers_spf_set(struct vty *vty, unsigned int delay,
 				unsigned int hold, unsigned int max)
 {
-	VTY_DECLVAR_CONTEXT(ospf6, ospf);
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf6, ospf);
 
 	ospf->spf_delay = delay;
 	ospf->spf_holdtime = hold;
@@ -921,14 +933,16 @@ DEFUN (no_ospf6_timers_throttle_spf,
 }
 
 
-int config_write_ospf6_debug_spf(struct vty *vty)
+int config_write_ospf6_debug_spf(struct vty *vty, struct ospf6 *ospf6)
 {
 	if (IS_OSPF6_DEBUG_SPF(PROCESS))
-		vty_out(vty, "debug ospf6 spf process\n");
+		vty_out(vty, "debug ospf6%s spf process\n",
+			ospf6->instance_str);
 	if (IS_OSPF6_DEBUG_SPF(TIME))
-		vty_out(vty, "debug ospf6 spf time\n");
+		vty_out(vty, "debug ospf6%s spf time\n", ospf6->instance_str);
 	if (IS_OSPF6_DEBUG_SPF(DATABASE))
-		vty_out(vty, "debug ospf6 spf database\n");
+		vty_out(vty, "debug ospf6%s spf database\n",
+			ospf6->instance_str);
 	return 0;
 }
 

--- a/ospf6d/ospf6_spf.h
+++ b/ospf6d/ospf6_spf.h
@@ -153,7 +153,7 @@ extern void ospf6_spf_display_subtree(struct vty *vty, const char *prefix,
 				      json_object *json_obj, bool use_json);
 
 extern void ospf6_spf_config_write(struct vty *vty, struct ospf6 *ospf6);
-extern int config_write_ospf6_debug_spf(struct vty *vty);
+extern int config_write_ospf6_debug_spf(struct vty *vty, struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_spf(void);
 extern void ospf6_spf_init(void);
 extern void ospf6_spf_reason_string(unsigned int reason, char *buf, int size);

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -30,6 +30,7 @@ struct ospf6_master {
 	/* OSPFv3 thread master. */
 	struct thread_master *master;
 	in_addr_t zebra_router_id;
+	uint16_t instance;
 };
 
 /* ospf6->config_flags */
@@ -39,7 +40,7 @@ enum {
 };
 
 struct ospf6_redist {
-	uint8_t instance;
+	uint16_t instance;
 
 	/* Redistribute metric info. */
 	struct {
@@ -60,6 +61,10 @@ struct ospf6_redist {
 
 /* OSPFv3 top level data structure */
 struct ospf6 {
+	/* instance ID, string is empty (instance 0) or space plus number */
+	uint16_t instance;
+	char *instance_str;
+
 	/* The relevant vrf_id */
 	vrf_id_t vrf_id;
 
@@ -159,13 +164,13 @@ extern struct ospf6 *ospf6;
 extern struct ospf6_master *om6;
 
 /* prototypes */
-extern void ospf6_master_init(struct thread_master *master);
+extern void ospf6_master_init(struct thread_master *master, uint16_t instance);
 extern void ospf6_top_init(void);
 extern void ospf6_delete(struct ospf6 *o);
 extern void ospf6_router_id_update(struct ospf6 *ospf6);
 
 extern void ospf6_maxage_remove(struct ospf6 *o);
-extern struct ospf6 *ospf6_instance_create(const char *name);
+extern struct ospf6 *ospf6_instance_create(uint16_t instance, const char *name);
 void ospf6_vrf_link(struct ospf6 *ospf6, struct vrf *vrf);
 void ospf6_vrf_unlink(struct ospf6 *ospf6, struct vrf *vrf);
 struct ospf6 *ospf6_lookup_by_vrf_id(vrf_id_t vrf_id);

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -50,11 +50,13 @@ extern void ospf6_zebra_route_update_add(struct ospf6_route *request,
 extern void ospf6_zebra_route_update_remove(struct ospf6_route *request,
 					    struct ospf6 *ospf6);
 
-extern void ospf6_zebra_redistribute(int, vrf_id_t vrf_id);
-extern void ospf6_zebra_no_redistribute(int, vrf_id_t vrf_id);
-#define ospf6_zebra_is_redistribute(type, vrf_id)                              \
-	vrf_bitmap_check(zclient->redist[AFI_IP6][type], vrf_id)
-extern void ospf6_zebra_init(struct thread_master *);
+extern void ospf6_zebra_redistribute(int type, uint16_t instance,
+				     vrf_id_t vrf_id);
+extern void ospf6_zebra_no_redistribute(int type, uint16_t instance,
+					vrf_id_t vrf_id);
+extern int ospf6_zebra_is_redistribute(int type, uint16_t instance,
+				       vrf_id_t vrf_id);
+extern void ospf6_zebra_init(struct thread_master *, uint16_t instance);
 extern void ospf6_zebra_add_discard(struct ospf6_route *request,
 				    struct ospf6 *ospf6);
 extern void ospf6_zebra_delete_discard(struct ospf6_route *request,
@@ -69,7 +71,7 @@ extern int ospf6_distance_set(struct vty *, struct ospf6 *, const char *,
 extern int ospf6_distance_unset(struct vty *, struct ospf6 *, const char *,
 				const char *, const char *);
 
-extern int config_write_ospf6_debug_zebra(struct vty *vty);
+extern int config_write_ospf6_debug_zebra(struct vty *vty, struct ospf6 *ospf6);
 extern void install_element_ospf6_debug_zebra(void);
 extern void ospf6_zebra_vrf_register(struct ospf6 *ospf6);
 extern void ospf6_zebra_vrf_deregister(struct ospf6 *ospf6);

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -558,6 +558,8 @@ class TopoRouter(TopoGear):
     RD_SNMP = 18
     RD_OSPF_1 = 19
     RD_OSPF_2 = 20
+    RD_OSPF6_1 = 21
+    RD_OSPF6_2 = 22
     RD = {
         RD_ZEBRA: "zebra",
         RD_RIP: "ripd",
@@ -579,6 +581,8 @@ class TopoRouter(TopoGear):
         RD_SNMP: "snmpd",
         RD_OSPF_1: "ospfd-1",
         RD_OSPF_2: "ospfd-2",
+        RD_OSPF6_1: "ospf6d-1",
+        RD_OSPF6_2: "ospf6d-2",
     }
 
     def __init__(self, tgen, cls, name, **params):
@@ -664,7 +668,8 @@ class TopoRouter(TopoGear):
         TopoRouter.RD_RIPNG, TopoRouter.RD_OSPF, TopoRouter.RD_OSPF6,
         TopoRouter.RD_ISIS, TopoRouter.RD_BGP, TopoRouter.RD_LDP,
         TopoRouter.RD_PIM, TopoRouter.RD_PBR, TopoRouter.RD_SNMP,
-        TopoRouter.RD_OSPF_1, TopoRouter.RD_OSPF_2.
+        TopoRouter.RD_OSPF_1, TopoRouter.RD_OSPF_2, TopoRouter.RD_OSPF6_1,
+        TopoRouter.RD_OSPF6_2.
         """
         daemonstr = self.RD.get(daemon)
         self.logger.info('loading "{}" configuration: {}'.format(daemonstr, source))

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -556,6 +556,8 @@ class TopoRouter(TopoGear):
     RD_PBRD = 16
     RD_PATH = 17
     RD_SNMP = 18
+    RD_OSPF_1 = 19
+    RD_OSPF_2 = 20
     RD = {
         RD_ZEBRA: "zebra",
         RD_RIP: "ripd",
@@ -575,6 +577,8 @@ class TopoRouter(TopoGear):
         RD_PBRD: "pbrd",
         RD_PATH: "pathd",
         RD_SNMP: "snmpd",
+        RD_OSPF_1: "ospfd-1",
+        RD_OSPF_2: "ospfd-2",
     }
 
     def __init__(self, tgen, cls, name, **params):
@@ -659,7 +663,8 @@ class TopoRouter(TopoGear):
         Possible daemon values are: TopoRouter.RD_ZEBRA, TopoRouter.RD_RIP,
         TopoRouter.RD_RIPNG, TopoRouter.RD_OSPF, TopoRouter.RD_OSPF6,
         TopoRouter.RD_ISIS, TopoRouter.RD_BGP, TopoRouter.RD_LDP,
-        TopoRouter.RD_PIM, TopoRouter.RD_PBR, TopoRouter.RD_SNMP.
+        TopoRouter.RD_PIM, TopoRouter.RD_PBR, TopoRouter.RD_SNMP,
+        TopoRouter.RD_OSPF_1, TopoRouter.RD_OSPF_2.
         """
         daemonstr = self.RD.get(daemon)
         self.logger.info('loading "{}" configuration: {}'.format(daemonstr, source))

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1143,6 +1143,8 @@ class Router(Node):
             "ospfd-1": 0,
             "ospfd-2": 0,
             "ospf6d": 0,
+            "ospf6d-1": 0,
+            "ospf6d-2": 0,
             "isisd": 0,
             "bgpd": 0,
             "pimd": 0,

--- a/tests/topotests/ospf6_multi_instance/r1/ip_6_address.ref
+++ b/tests/topotests/ospf6_multi_instance/r1/ip_6_address.ref
@@ -1,0 +1,3 @@
+fc00::1 dev lo proto XXXX metric 256 pref medium
+fc00::2 via fe80::__(r2-sw1)__ dev r1-sw1 proto XXXX metric 20 pref medium
+fc00::3 via fe80::__(r2-sw1)__ dev r1-sw1 proto XXXX metric 20 pref medium

--- a/tests/topotests/ospf6_multi_instance/r1/ospf6d.conf
+++ b/tests/topotests/ospf6_multi_instance/r1/ospf6d.conf
@@ -1,0 +1,10 @@
+hostname r1
+!
+router ospf6
+ ospf6 router-id 0.0.0.1
+ interface lo area 0.0.0.0
+ interface r1-sw1 area 0.0.0.0
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6_multi_instance/r1/show_ipv6_route.ref
+++ b/tests/topotests/ospf6_multi_instance/r1/show_ipv6_route.ref
@@ -1,0 +1,3 @@
+O fc00::1/128 [110/10] is directly connected, lo, weight 1, XX:XX:XX
+O>* fc00::2/128 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw1, weight 1, XX:XX:XX
+O>* fc00::3/128 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw1, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6_multi_instance/r1/zebra.conf
+++ b/tests/topotests/ospf6_multi_instance/r1/zebra.conf
@@ -1,0 +1,12 @@
+hostname r1
+!
+debug zebra events
+debug zebra rib
+!
+!
+interface lo
+  ipv6 address fc00::1/128
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6_multi_instance/r2/ip_6_address.ref
+++ b/tests/topotests/ospf6_multi_instance/r2/ip_6_address.ref
@@ -1,0 +1,3 @@
+fc00::1 via fe80::__(r1-sw1)__ dev r2-sw1 proto XXXX metric 20 pref medium
+fc00::2 dev lo proto XXXX metric 256 pref medium
+fc00::3 via fe80::__(r3-sw2)__ dev r2-sw2 proto XXXX metric 20 pref medium

--- a/tests/topotests/ospf6_multi_instance/r2/ospf6d-1.conf
+++ b/tests/topotests/ospf6_multi_instance/r2/ospf6d-1.conf
@@ -1,0 +1,11 @@
+hostname r2
+!
+router ospf6 1
+ ospf6 router-id 0.0.0.2
+ interface lo area 0.0.0.0
+ interface r2-sw1 area 0.0.0.0
+ redistribute ospf6 2
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6_multi_instance/r2/ospf6d-2.conf
+++ b/tests/topotests/ospf6_multi_instance/r2/ospf6d-2.conf
@@ -1,0 +1,9 @@
+hostname r2
+!
+router ospf6 2
+ ospf6 router-id 0.0.0.2
+ interface r2-sw2 area 0.0.0.0
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6_multi_instance/r2/show_ipv6_route.ref
+++ b/tests/topotests/ospf6_multi_instance/r2/show_ipv6_route.ref
@@ -1,0 +1,3 @@
+O[1]>* fc00::1/128 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw1, weight 1, XX:XX:XX
+O[1] fc00::2/128 [110/10] is directly connected, lo, weight 1, XX:XX:XX
+O[2]>* fc00::3/128 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw2, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6_multi_instance/r2/zebra.conf
+++ b/tests/topotests/ospf6_multi_instance/r2/zebra.conf
@@ -1,0 +1,12 @@
+hostname r2
+!
+debug zebra events
+debug zebra rib
+!
+!
+interface lo
+  ipv6 address fc00::2/128
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6_multi_instance/r3/ip_6_address.ref
+++ b/tests/topotests/ospf6_multi_instance/r3/ip_6_address.ref
@@ -1,0 +1,1 @@
+fc00::3 dev lo proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6_multi_instance/r3/ospf6d.conf
+++ b/tests/topotests/ospf6_multi_instance/r3/ospf6d.conf
@@ -1,0 +1,10 @@
+hostname r3
+!
+router ospf6
+ ospf6 router-id 0.0.0.3
+ interface lo area 0.0.0.0
+ interface r3-sw2 area 0.0.0.0
+!
+line vty
+ exec-timeout 0 0
+!

--- a/tests/topotests/ospf6_multi_instance/r3/show_ipv6_route.ref
+++ b/tests/topotests/ospf6_multi_instance/r3/show_ipv6_route.ref
@@ -1,0 +1,1 @@
+O fc00::3/128 [110/10] is directly connected, lo, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6_multi_instance/r3/zebra.conf
+++ b/tests/topotests/ospf6_multi_instance/r3/zebra.conf
@@ -1,0 +1,12 @@
+hostname r3
+!
+debug zebra events
+debug zebra rib
+!
+!
+interface lo
+  ipv6 address fc00::3/128
+!
+!
+line vty
+!

--- a/tests/topotests/ospf6_multi_instance/test_ospf6_multi_instance.py
+++ b/tests/topotests/ospf6_multi_instance/test_ospf6_multi_instance.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python
+# test_ospf6_multi_instance.py
+# Based on test_ospf6_topo1.py
+#
+# Copyright (c) 2021 by Martin Buck, RUAG Schweiz AG
+# Copyright (c) 2016 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+test_ospf6_multi_instance.py:
+
++----------------+
+| r1             |
+| ID 0.0.0.1     |
+| lo fc00::1/128 |
++----------------+
+         |
+         |
+    ~~~~~~~~~~
+  ~~          ~~
+~~      sw1     ~~
+  ~~          ~~
+    ~~~~~~~~~~
+         |
+         |
++----------------+
+|     ospf6 1    |
++----------------+
+| r2             |
+| ID 0.0.0.2     |
+| ID 1.0.0.2     |
+| lo fc00::2/128 |
++----------------+
+|     ospf6 2    |
++----------------+
+         |
+         |
+    ~~~~~~~~~~
+  ~~          ~~
+~~      sw2     ~~
+  ~~          ~~
+    ~~~~~~~~~~
+         |
+         |
++----------------+
+| r3             |
+| ID 0.0.0.3     |
+| lo fc00::3/128 |
++----------------+
+"""
+
+import os
+import re
+import shutil
+import sys
+import pytest
+from time import sleep
+
+from functools import partial
+
+from mininet.topo import Topo
+
+# Save the Current Working Directory to find configuration files later.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+import platform
+
+
+pytestmark = [pytest.mark.ospf6d]
+
+#####################################################
+##
+##   Network Topology Definition
+##
+#####################################################
+
+
+class NetworkTopo(Topo):
+    "OSPFv3 (IPv6) Multi Instance Test Topology"
+
+    def build(self, **_opts):
+        tgen = get_topogen(self)
+
+        tgen.add_router("r1")
+        tgen.add_router("r2")
+        tgen.add_router("r3")
+        tgen.add_switch("sw1")
+        tgen.add_switch("sw2")
+        tgen.gears["sw1"].add_link(tgen.gears["r1"], nodeif="r1-sw1")
+        tgen.gears["sw1"].add_link(tgen.gears["r2"], nodeif="r2-sw1")
+        tgen.gears["sw2"].add_link(tgen.gears["r2"], nodeif="r2-sw2")
+        tgen.gears["sw2"].add_link(tgen.gears["r3"], nodeif="r3-sw2")
+
+
+#####################################################
+##
+##   Tests starting
+##
+#####################################################
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+
+    tgen = Topogen(NetworkTopo, mod.__name__)
+    tgen.start_topology()
+
+    logger.info("** %s: Setup Topology" % mod.__name__)
+    logger.info("******************************************")
+
+    # For debugging after starting net, but before starting FRR
+    if os.environ.get("TOPOTESTS_MININET_CLI") == "ospf6-multi-instance:pre_frr":
+        tgen.mininet_cli()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        for (rd, conf) in [(TopoRouter.RD_ZEBRA, "zebra.conf"),
+                           (TopoRouter.RD_OSPF6, "ospf6d.conf"),
+                           (TopoRouter.RD_OSPF6_1, "ospf6d-1.conf"),
+                           (TopoRouter.RD_OSPF6_2, "ospf6d-2.conf"),
+                          ]:
+            confpath = os.path.join(CWD, rname, conf)
+            if os.path.exists(confpath):
+                router.load_config(rd, confpath)
+
+    # Initialize all routers.
+    tgen.start_router()
+
+    # For debugging after starting FRR daemons
+    if os.environ.get("TOPOTESTS_MININET_CLI") == "ospf6-multi-instance:post_frr":
+        tgen.mininet_cli()
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_ospf6_converged():
+    "Check whether all routers have converged"
+
+    tgen = get_topogen()
+
+    # For debugging, uncomment the next line
+    # gen.mininet_cli()
+
+    # Wait for OSPF6 to converge  (All Neighbors in either Full or TwoWay State)
+    logger.info("Waiting for OSPF6 convergence")
+
+    # Set up for regex
+    pat1 = re.compile("^[0-9]")
+    pat2 = re.compile("Full")
+    pat3 = re.compile(r"[a-z0-9-]+\[[A-Z]+\]")
+
+    resStr = "NONE"
+    timeout = 60
+    while timeout > 0:
+        logger.info("Timeout in %s: " % timeout),
+        sys.stdout.flush()
+
+        # Look for any node not yet converged
+        dr_bdr_states = []
+        for router, rnode in tgen.routers().items():
+            isConverged = False
+            for daemon, started in sorted(rnode.net[router].daemons.items()):
+                if not daemon.startswith("ospf6d") or not started:
+                    continue
+
+                (d, instance) = topotest.split_daemon_name_instance(daemon)
+                if instance:
+                    instance_arg = " {}".format(instance)
+                else:
+                    instance_arg = ""
+
+                resStr = rnode.vtysh_cmd("show ipv6 ospf" + instance_arg + " neigh")
+
+                isConverged = False
+
+                for line in resStr.splitlines():
+                    res1 = pat1.match(line)
+                    if res1:
+                        isConverged = True
+                        res2 = pat2.search(line)
+
+                        if res2 == None:
+                            isConverged = False
+                            break
+                    
+                        res3 = pat3.search(line)
+                        if res3:
+                            dr_bdr_states.append(res3.group())
+
+                if not isConverged:
+                    logger.info("Waiting for {}{}".format(router, instance_arg))
+                    sys.stdout.flush()
+                    break
+
+            if not isConverged:
+                break
+
+        if isConverged:
+            logger.info("Done")
+            break
+        else:
+            sleep(5)
+            timeout -= 5
+
+    if timeout <= 0:
+        # Bail out with error if a router fails to converge
+        assert False, "OSPFv3 did not converge:\n{}".format(resStr)
+
+    logger.info("OSPFv3 converged.")
+    logger.info("DR/BDR summary: {}".format(" ".join(sorted(dr_bdr_states))))
+
+    # For debugging after OSPFv3 convergence
+    if os.environ.get("TOPOTESTS_MININET_CLI") == "ospf6-multi-instance:converged":
+        tgen.mininet_cli()
+
+    # Make sure that all daemons are still running
+    if tgen.routers_have_failure():
+        assert tgen.errors == "", tgen.errors
+
+
+def compare_show_ipv6(rname, expected):
+    """
+    Calls 'show ipv6 route' for router `rname` and compare the obtained
+    result with the expected output.
+    """
+    tgen = get_topogen()
+
+    # Use the vtysh output, with some masking to make comparison easy
+    current = topotest.ip6_route_zebra(tgen.gears[rname])
+
+    # Use just the 'O'spf lines of the output
+    linearr = []
+    for line in current.splitlines():
+        if re.match("^O", line):
+            linearr.append(line)
+
+    current = "\n".join(linearr)
+
+    return topotest.difflines(
+        topotest.normalize_text(current),
+        topotest.normalize_text(expected),
+        title1="Current output",
+        title2="Expected output",
+    )
+
+
+def test_ospfv3_routingTable():
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # For debugging, uncomment the next line
+    # tgen.mininet_cli()
+
+    # Verify OSPFv3 Routing Table
+    for router, rnode in tgen.routers().items():
+        logger.info('Verifying router "%s" OSPFv3 Routing Table', router)
+
+        # Load expected results from the command
+        reffile = os.path.join(CWD, "{}/show_ipv6_route.ref".format(router))
+        expected = open(reffile).read()
+
+        # Run test function until we get an result. Wait at most 60 seconds.
+        test_func = partial(compare_show_ipv6, router, expected)
+        result, diff = topotest.run_and_expect(test_func, "", count=120, wait=0.5)
+        assert result, "OSPFv3 Routing Table verification failed for router {}:\n{}".format(router, diff)
+
+
+def test_linux_ipv6_kernel_routingTable():
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # Verify Linux Kernel Routing Table
+    logger.info("Verifying Linux IPv6 Kernel Routing Table")
+
+    failures = 0
+
+    # Get a list of all current link-local addresses first as they change for
+    # each run and we need to translate them
+    linklocals = []
+    for router, rnode in tgen.routers().items():
+        linklocals += rnode.net[router].get_ipv6_linklocal()
+
+    # Now compare the routing tables (after substituting link-local addresses)
+    for router, rnode in tgen.routers().items():
+        # Actual output from router
+        actual = tgen.gears[router].run("ip -6 route").rstrip()
+        if "nhid" in actual:
+            refTableFile = os.path.join(CWD, "{}/ip_6_address.nhg.ref".format(router))
+        else:
+            refTableFile = os.path.join(CWD, "{}/ip_6_address.ref".format(router))
+
+        if os.path.isfile(refTableFile):
+            expected = open(refTableFile).read().rstrip()
+            # Fix newlines (make them all the same)
+            expected = ("\n".join(expected.splitlines())).splitlines(1)
+
+            # Mask out Link-Local mac addresses
+            for ll in linklocals:
+                actual = actual.replace(ll[1], "fe80::__(%s)__" % ll[0])
+            # Mask out protocol name or number
+            actual = re.sub(r"[ ]+proto [0-9a-z]+ +", "  proto XXXX ", actual)
+            actual = re.sub(r"[ ]+nhid [0-9]+ +", " nhid XXXX ", actual)
+            # Remove ff00::/8 routes (seen on some kernels - not from FRR)
+            actual = re.sub(r"ff00::/8.*", "", actual)
+            # Convert "unreachable loopback" routes to normal ones by
+            # stripping the unreachable and the error code. These only
+            # occur with Linux kernels < 4.18 and they work just fine for
+            # OSPF except for the different routing table output which
+            # would cause spurious test failures.
+            actual = re.sub(r"unreachable (.* dev lo .* )error -101 (.*)", r"\1\2", actual)
+
+            # Strip empty lines
+            actual = actual.lstrip()
+            actual = actual.rstrip()
+            actual = re.sub(r"  +", " ", actual)
+
+            filtered_lines = []
+            for line in sorted(actual.splitlines()):
+                if line.startswith("fe80::/64 ") or line.startswith(
+                    "unreachable fe80::/64 "
+                ):
+                    continue
+                filtered_lines.append(line)
+            actual = "\n".join(filtered_lines).splitlines(1)
+
+            # Print Actual table
+            # logger.info("Router %s table" % router)
+            # for line in actual:
+            #     logger.info(line.rstrip())
+
+            # Generate Diff
+            diff = topotest.get_textdiff(
+                actual,
+                expected,
+                title1="actual OSPFv3 IPv6 routing table",
+                title2="expected OSPFv3 IPv6 routing table",
+            )
+
+            # Empty string if it matches, otherwise diff contains unified diff
+            if diff:
+                sys.stderr.write(
+                    "%s failed Linux IPv6 Kernel Routing Table Check:\n%s\n"
+                    % (router, diff)
+                )
+                failures += 1
+            else:
+                logger.info("%s ok" % router)
+
+            assert failures == 0, (
+                "Linux Kernel IPv6 Routing Table verification failed for router %s:\n%s"
+                % (router, diff)
+            )
+
+
+def test_shutdown_check_stderr():
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    if os.environ.get("TOPOTESTS_CHECK_STDERR") is None:
+        logger.info(
+            "SKIPPED final check on StdErr output: Disabled (TOPOTESTS_CHECK_STDERR undefined)\n"
+        )
+        pytest.skip("Skipping test for Stderr output")
+
+    logger.info("\n\n** Verifying unexpected STDERR output from daemons")
+    logger.info("******************************************")
+
+    for router, rnode in tgen.routers().items():
+        rnode.net[router].stopRouter()
+
+        for daemon, started in sorted(rnode.net[router].daemons.items()):
+            if not started:
+                continue
+            log = rnode.net[router].getStdErr(daemon)
+            if log:
+                logger.info("\nRouter %s %s StdErr Log:\n%s" % (router, daemon, log))
+
+
+def test_shutdown_check_memleak():
+    "Run the memory leak test and report results."
+
+    if os.environ.get("TOPOTESTS_CHECK_MEMLEAK") is None:
+        logger.info(
+            "SKIPPED final check on Memory leaks: Disabled (TOPOTESTS_CHECK_MEMLEAK undefined)"
+        )
+        pytest.skip("Skipping test for memory leaks")
+
+    tgen = get_topogen()
+
+    for router, rnode in tgen.routers().items():
+        rnode.net[router].stopRouter()
+        rnode.net[router].report_memory_leaks(
+            os.environ.get("TOPOTESTS_CHECK_MEMLEAK"), os.path.basename(__file__)
+        )
+
+
+if __name__ == "__main__":
+    retval = pytest.main(["-s"])
+    sys.exit(retval)

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -459,6 +459,11 @@ static void vtysh_client_config(struct vtysh_client *head_client, char *line)
 	vty->of = vty->of_saved;
 }
 
+static bool any_instance_connected(struct vtysh_client *client)
+{
+	return (client->fd >= 0 || client->next);
+}
+
 /* Command execution over the vty interface. */
 static int vtysh_execute_func(const char *line, int pager)
 {
@@ -630,12 +635,8 @@ static int vtysh_execute_func(const char *line, int pager)
 				}
 				if (vtysh_client[i].fd < 0
 				    && (cmd->daemon == vtysh_client[i].flag)) {
-					bool any_inst = false;
-					for (vc = &vtysh_client[i]; vc;
-					     vc = vc->next)
-						any_inst = any_inst
-							   || (vc->fd > 0);
-					if (!any_inst) {
+					if (!any_instance_connected(
+						    &vtysh_client[i])) {
 						fprintf(stderr,
 							"%s is not running\n",
 							vtysh_client[i].name);
@@ -2693,7 +2694,7 @@ static int show_per_daemon(struct vty *vty, struct cmd_token **argv, int argc,
 	char *line = do_prepend(vty, argv, argc);
 
 	for (i = 0; i < array_size(vtysh_client); i++)
-		if (vtysh_client[i].fd >= 0 || vtysh_client[i].next) {
+		if (any_instance_connected(&vtysh_client[i])) {
 			vty_out(vty, headline, vtysh_client[i].name);
 			ret = vtysh_client_execute(&vtysh_client[i], line);
 			vty_out(vty, "\n");
@@ -3359,7 +3360,7 @@ DEFUN (vtysh_show_daemons,
 	unsigned int i;
 
 	for (i = 0; i < array_size(vtysh_client); i++)
-		if (vtysh_client[i].fd >= 0)
+		if (any_instance_connected(&vtysh_client[i]))
 			vty_out(vty, " %s", vtysh_client[i].name);
 	vty_out(vty, "\n");
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1140,7 +1140,8 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 				continue;
 
 			if (ospf_instance_id
-			    && (re->type != ZEBRA_ROUTE_OSPF
+			    && ((re->type != ZEBRA_ROUTE_OSPF
+				 && re->type != ZEBRA_ROUTE_OSPF6)
 				|| re->instance != ospf_instance_id))
 				continue;
 
@@ -1731,7 +1732,10 @@ DEFPY (show_route,
 	    tag (1-4294967295)\
 	    |X:X::X:X/M$prefix longer-prefixes\
 	   }]\
-	   [" FRR_IP6_REDIST_STR_ZEBRA "$type_str]\
+	   [<\
+	    " FRR_IP6_REDIST_STR_ZEBRA "$type_str\
+	    |ospf6$type_str (1-65535)$ospf_instance_id\
+	   >]\
 	 >\
         [json$json]",
        SHOW_STR
@@ -1762,6 +1766,8 @@ DEFPY (show_route,
        "IPv6 prefix\n"
        "Show route matching the specified Network/Mask pair only\n"
        FRR_IP6_REDIST_HELP_STR_ZEBRA
+       "Open Shortest Path First (IPv6) (OSPFv3)\n"
+       "Instance ID\n"
        JSON_STR)
 {
 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;


### PR DESCRIPTION
This PR adds support for running several parallel instances of ospf6d very similar to what's already supported for ospfd. This way, you can have separate OSPFv3 domains with distinct LSDBs which selectively exchange routes using normal redistribution. Routes from the different domains are all put into the same routing table, so this is *not* VRF support.

While I'm quite happy with the functionality, this PR is probably not ready for merging yet, so please consider this to be more a request for comments/feedback than for merging at the moment.

Things missing/to be discussed:
* Documentation (not to be discussed, just to be written ;-)
* Other routing protocols currently can't selectively redistribute from only a certain OSPF6 instance. BGP supports this for OSPF and probably should do the same way for OSPF6. But that's something that may be added in a later PR.
* "show ipv6 ospf6 SOMETHING" does not iterate over instances as its ospf couterpart does and only shows the default instance (0). I'm not sure what the expected behaviour here is.
* When running ospfd without option "-n X", it will be resposible for whatever instance the first "router ospf X" command specifies. But further instances need an explicit option "-n X". I don't see a case where this behaviour is useful, so ospf6d differs here: Plain ospf6d is responsible only for the default (0) instance and ignores others, "ospf6d -n 1" is responsible only for instance 1 and so on. Is this OK?
* This PR duplicates some changes from #8126 which I need here as well for being able to perform a multi-instance topotest. So #8126 should probably be merged first and then I'll drop the first commit from this PR.
* Anything else that needs to be changed before this can be merged?

@KaushikNiral @hariosniral: I noticed that you seem to be working of VRF support for OSPF6. This PR very likely touches the same code as you do. I hope it doesn't interfere too much with your work.
