### PR TITLE
tests: Do not sleep(5) when verifying bgp communities

### DIFF
--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -1309,7 +1309,6 @@ def verify_bgp_community(
 
     command = "show bgp"
 
-    sleep(5)
     for net in network:
         if vrf:
             cmd = "{} vrf {} {} {} json".format(command, vrf, addr_type, net)


### PR DESCRIPTION
There are better ways of ensuring that the remote side
has your change instead of sleeping

Signed-off-by: Donald Sharp <sharpd@nvidia.com>