### PR TITLE
[7.5] lib: fix interface nb stale pointers

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1206,15 +1206,30 @@ ifaddr_ipv4_lookup (struct in_addr *addr, ifindex_t ifindex)
 void if_terminate(struct vrf *vrf)
 {
 	struct interface *ifp;
+	bool delete;
+
+	/*
+	 * If the default VRF is being terminated or has
+	 * already been terminated it means that
+	 * the program is shutting down and we need to
+	 * delete all the interfaces. Otherwise, we only
+	 * need to move VRF's interfaces to the default VRF.
+	 */
+	delete = vrf_is_backend_netns() || vrf->vrf_id == VRF_DEFAULT
+		 || !vrf_lookup_by_id(VRF_DEFAULT);
 
 	while (!RB_EMPTY(if_name_head, &vrf->ifaces_by_name)) {
 		ifp = RB_ROOT(if_name_head, &vrf->ifaces_by_name);
 
-		if (ifp->node) {
-			ifp->node->info = NULL;
-			route_unlock_node(ifp->node);
+		if (delete) {
+			if (ifp->node) {
+				ifp->node->info = NULL;
+				route_unlock_node(ifp->node);
+			}
+			if_delete(&ifp);
+		} else {
+			if_update_to_new_vrf(ifp, VRF_DEFAULT);
 		}
-		if_delete(&ifp);
 	}
 }
 

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1578,8 +1578,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		else if (IS_ZEBRA_IF_VXLAN(ifp))
 			zebra_l2_vxlanif_del(ifp);
 
-		if (!IS_ZEBRA_IF_VRF(ifp))
-			if_delete_update(ifp);
+		if_delete_update(ifp);
 	}
 
 	return 0;


### PR DESCRIPTION
The first change in this commit is the processing of the VRF termination.
When we terminate the VRF, we should not delete the underlying interfaces,
because there may be pointers to them in the northbound configuration. We
should move them to the default VRF instead.

Because of the first change, the VRF interface itself is also not deleted
when deleting the VRF. It should be handled in netlink_link_change. This
is done by the second change.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>