### PR TITLE
bgpd: Add `show bgp json detail` command

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10830,9 +10830,17 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				flap_route_vty_out(vty, dest_p, pi, display,
 						   AFI_IP, safi, use_json,
 						   json_paths);
-			else
-				route_vty_out(vty, dest_p, pi, display, safi,
-					      json_paths, wide);
+			else {
+				if (CHECK_FLAG(show_flags, BGP_SHOW_OPT_DETAIL))
+					route_vty_out_detail(
+						vty, bgp, dest, pi,
+						family2afi(dest_p->family),
+						safi, RPKI_NOT_BEING_USED,
+						json_paths);
+				else
+					route_vty_out(vty, dest_p, pi, display,
+						      safi, json_paths, wide);
+			}
 			display++;
 		}
 
@@ -11905,7 +11913,7 @@ DEFPY (show_ip_bgp_json,
                      |route-filter-translated-v4] [exact-match]\
           |rpki <invalid|valid|notfound>\
           |version (1-4294967295)\
-          ] [json$uj | wide$wide]",
+          ] [json$uj [detail$detail] | wide$wide]",
        SHOW_STR
        IP_STR
        BGP_STR
@@ -11941,6 +11949,7 @@ DEFPY (show_ip_bgp_json,
        "Display prefixes with matching version numbers\n"
        "Version number and above\n"
        JSON_STR
+       "Display detailed version of JSON output\n"
        "Increase table width for longer prefixes\n")
 {
 	afi_t afi = AFI_IP6;
@@ -11959,6 +11968,9 @@ DEFPY (show_ip_bgp_json,
 		argc--;
 		SET_FLAG(show_flags, BGP_SHOW_OPT_JSON);
 	}
+
+	if (detail)
+		SET_FLAG(show_flags, BGP_SHOW_OPT_DETAIL);
 
 	/* [<ipv4|ipv6> [all]] */
 	if (all) {

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -586,6 +586,7 @@ DECLARE_HOOK(bgp_process,
 #define BGP_SHOW_OPT_AFI_IP6 (1 << 4)
 #define BGP_SHOW_OPT_ESTABLISHED (1 << 5)
 #define BGP_SHOW_OPT_FAILED (1 << 6)
+#define BGP_SHOW_OPT_DETAIL (1 << 7)
 
 /* Prototypes. */
 extern void bgp_rib_remove(struct bgp_dest *dest, struct bgp_path_info *pi,

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3115,11 +3115,11 @@ daemon project, while :clicmd:`show bgp` command is the new format. The choice
 has been done to keep old format with IPv4 routing table, while new format
 displays IPv6 routing table.
 
-.. clicmd:: show ip bgp [all] [wide|json]
+.. clicmd:: show ip bgp [all] [wide|json [detail]]
 
 .. clicmd:: show ip bgp A.B.C.D [json]
 
-.. clicmd:: show bgp [all] [wide|json]
+.. clicmd:: show bgp [all] [wide|json [detail]]
 
 .. clicmd:: show bgp X:X::X:X [json]
 
@@ -3147,6 +3147,9 @@ displays IPv6 routing table.
    show ip bgp all commands display routes for all AFIs and SAFIs.
 
    If ``json`` option is specified, output is displayed in JSON format.
+
+   If ``detail`` option is specified after ``json``, more verbose JSON output
+   will be displayed.
 
 Some other commands provide additional options for filtering the output.
 


### PR DESCRIPTION
Print detailed version for JSON output when dumping ALL BGP table with
`show bgp <afi> <safi> json detail`.

This output should be at some sort of identical to show_ip_bgp_route_cmd.

To avoid breaking backward-compatibility for `show bgp json`, adding
'detail' keyword for that.

In long-term it's easier for operators to compare stuff just looking at global
view instead of per-prefix for details.

Before:

```
],"192.168.100.1/32": [
  {
    "valid":true,
    "bestpath":true,
    "selectionReason":"First path received",
    "pathFrom":"external",
    "prefix":"192.168.100.1",
    "prefixLen":32,
    "network":"192.168.100.1\/32",
    "metric":0,
    "weight":32768,
    "peerId":"(unspec)",
    "path":"",
    "origin":"incomplete",
    "nexthops":[
      {
        "ip":"0.0.0.0",
        "hostname":"exit1-debian-9",
        "afi":"ipv4",
        "used":true
      }
    ]
  }
] }  }
```

After:
```
],"192.168.100.1/32": [
  {
    "aspath":{
      "string":"Local",
      "segments":[
      ],
      "length":0
    },
    "origin":"incomplete",
    "metric":0,
    "weight":32768,
    "valid":true,
    "sourced":true,
    "bestpath":{
      "overall":true,
      "selectionReason":"First path received"
    },
    "lastUpdate":{
      "epoch":1618040124,
      "string":"Sat Apr 10 07:35:24 2021\n"
    },
    "nexthops":[
      {
        "ip":"0.0.0.0",
        "hostname":"exit1-debian-9",
        "afi":"ipv4",
        "metric":0,
        "accessible":true,
        "used":true
      }
    ],
    "peer":{
      "peerId":"0.0.0.0",
      "routerId":"192.168.100.1"
    }
  }
] }  }
```