### PR TITLE
bgpd: Show RPKI short state in `show bgp <afi> <safi>`

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8340,8 +8340,11 @@ bgp_path_selection_reason2str(enum bgp_path_selection_reason reason)
 /* Print the short form route status for a bgp_path_info */
 static void route_vty_short_status_out(struct vty *vty,
 				       struct bgp_path_info *path,
+				       const struct prefix *p,
 				       json_object *json_path)
 {
+	enum rpki_states rpki_state = RPKI_NOT_BEING_USED;
+
 	if (json_path) {
 
 		/* Route status display. */
@@ -8386,6 +8389,17 @@ static void route_vty_short_status_out(struct vty *vty,
 
 		return;
 	}
+
+	/* RPKI validation state */
+	rpki_state =
+		hook_call(bgp_rpki_prefix_status, path->peer, path->attr, p);
+
+	if (rpki_state == RPKI_VALID)
+		vty_out(vty, "V");
+	else if (rpki_state == RPKI_INVALID)
+		vty_out(vty, "I");
+	else if (rpki_state == RPKI_NOTFOUND)
+		vty_out(vty, "N");
 
 	/* Route status display. */
 	if (CHECK_FLAG(path->flags, BGP_PATH_REMOVED))
@@ -8455,7 +8469,7 @@ void route_vty_out(struct vty *vty, const struct prefix *p,
 		json_path = json_object_new_object();
 
 	/* short status lead text */
-	route_vty_short_status_out(vty, path, json_path);
+	route_vty_short_status_out(vty, path, p, json_path);
 
 	if (!json_paths) {
 		/* print prefix and mask */
@@ -9101,7 +9115,7 @@ void route_vty_out_tag(struct vty *vty, const struct prefix *p,
 		json_out = json_object_new_object();
 
 	/* short status lead text */
-	route_vty_short_status_out(vty, path, json_out);
+	route_vty_short_status_out(vty, path, p, json_out);
 
 	/* print prefix and mask */
 	if (json == NULL) {
@@ -9204,7 +9218,7 @@ void route_vty_out_overlay(struct vty *vty, const struct prefix *p,
 	}
 
 	/* short status lead text */
-	route_vty_short_status_out(vty, path, json_path);
+	route_vty_short_status_out(vty, path, p, json_path);
 
 	/* print prefix and mask */
 	if (!display)
@@ -9308,7 +9322,7 @@ static void damp_route_vty_out(struct vty *vty, const struct prefix *p,
 	char timebuf[BGP_UPTIME_LEN];
 
 	/* short status lead text */
-	route_vty_short_status_out(vty, path, json);
+	route_vty_short_status_out(vty, path, p, json);
 
 	/* print prefix and mask */
 	if (!use_json) {
@@ -9379,7 +9393,7 @@ static void flap_route_vty_out(struct vty *vty, const struct prefix *p,
 	bdi = path->extra->damp_info;
 
 	/* short status lead text */
-	route_vty_short_status_out(vty, path, json);
+	route_vty_short_status_out(vty, path, p, json);
 
 	/* print prefix and mask */
 	if (!use_json) {
@@ -10791,6 +10805,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				vty_out(vty, BGP_SHOW_SCODE_HEADER);
 				vty_out(vty, BGP_SHOW_NCODE_HEADER);
 				vty_out(vty, BGP_SHOW_OCODE_HEADER);
+				vty_out(vty, BGP_SHOW_RPKI_HEADER);
 				if (type == bgp_show_type_dampend_paths
 				    || type == bgp_show_type_damp_neighbor)
 					vty_out(vty, BGP_SHOW_DAMP_HEADER);
@@ -13137,6 +13152,7 @@ static void show_adj_route_header(struct vty *vty, struct bgp *bgp,
 			vty_out(vty, BGP_SHOW_SCODE_HEADER);
 			vty_out(vty, BGP_SHOW_NCODE_HEADER);
 			vty_out(vty, BGP_SHOW_OCODE_HEADER);
+			vty_out(vty, BGP_SHOW_RPKI_HEADER);
 		}
 		*header1 = 0;
 	}
@@ -13223,6 +13239,7 @@ show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table *table,
 			vty_out(vty, BGP_SHOW_SCODE_HEADER);
 			vty_out(vty, BGP_SHOW_NCODE_HEADER);
 			vty_out(vty, BGP_SHOW_OCODE_HEADER);
+			vty_out(vty, BGP_SHOW_RPKI_HEADER);
 
 			vty_out(vty, "Originating default network %s\n\n",
 				(afi == AFI_IP) ? "0.0.0.0/0" : "::/0");

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -72,8 +72,11 @@ enum bgp_show_adj_route_type {
 	"Status codes:  s suppressed, d damped, "                              \
 	"h history, * valid, > best, = multipath,\n"                           \
 	"               i internal, r RIB-failure, S Stale, R Removed\n"
-#define BGP_SHOW_OCODE_HEADER "Origin codes:  i - IGP, e - EGP, ? - incomplete\n\n"
+#define BGP_SHOW_OCODE_HEADER                                                  \
+	"Origin codes:  i - IGP, e - EGP, ? - incomplete\n"
 #define BGP_SHOW_NCODE_HEADER "Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self\n"
+#define BGP_SHOW_RPKI_HEADER                                                   \
+	"RPKI validation codes: V valid, I invalid, N Not found\n\n"
 #define BGP_SHOW_HEADER "   Network          Next Hop            Metric LocPrf Weight Path\n"
 #define BGP_SHOW_HEADER_WIDE "   Network                                      Next Hop                                  Metric LocPrf Weight Path\n"
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2849,6 +2849,7 @@ When default route is present in R2'2 BGP table, 10.139.224.0/20 and 192.0.2.1/3
                   i internal, r RIB-failure, S Stale, R Removed
    Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
    Origin codes:  i - IGP, e - EGP, ? - incomplete
+   RPKI validation codes: V valid, I invalid, N Not found
 
       Network          Next Hop            Metric LocPrf Weight Path
    *> 0.0.0.0/0        10.10.10.1               0             0 1 i
@@ -2878,6 +2879,7 @@ When default route is present in R2'2 BGP table, 10.139.224.0/20 and 192.0.2.1/3
                i internal, r RIB-failure, S Stale, R Removed
    Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
    Origin codes:  i - IGP, e - EGP, ? - incomplete
+   RPKI validation codes: V valid, I invalid, N Not found
 
       Network          Next Hop            Metric LocPrf Weight Path
    *> 0.0.0.0/0        0.0.0.0                                0 1 i
@@ -2896,6 +2898,7 @@ When default route is not present in R2'2 BGP table, 10.139.224.0/20 and 192.0.2
                   i internal, r RIB-failure, S Stale, R Removed
    Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
    Origin codes:  i - IGP, e - EGP, ? - incomplete
+   RPKI validation codes: V valid, I invalid, N Not found
 
       Network          Next Hop            Metric LocPrf Weight Path
    *> 10.139.224.0/20  10.10.10.1               0             0 1 ?
@@ -2925,6 +2928,7 @@ When default route is not present in R2'2 BGP table, 10.139.224.0/20 and 192.0.2
                   i internal, r RIB-failure, S Stale, R Removed
    Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
    Origin codes:  i - IGP, e - EGP, ? - incomplete
+   RPKI validation codes: V valid, I invalid, N Not found
 
       Network          Next Hop            Metric LocPrf Weight Path
    *> 10.139.224.0/20  0.0.0.0                                0 1 ?

--- a/tests/topotests/all-protocol-startup/r1/show_bgp_ipv4-post4.1.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_bgp_ipv4-post4.1.ref
@@ -3,6 +3,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *> 192.168.0.0      0.0.0.0                  0         32768 i

--- a/tests/topotests/all-protocol-startup/r1/show_bgp_ipv4-post5.0.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_bgp_ipv4-post5.0.ref
@@ -3,6 +3,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *> 192.168.0.0/24   0.0.0.0                  0         32768 i

--- a/tests/topotests/all-protocol-startup/r1/show_bgp_ipv4-post6.1.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_bgp_ipv4-post6.1.ref
@@ -4,6 +4,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *> 192.168.0.0/24   0.0.0.0                  0         32768 i

--- a/tests/topotests/all-protocol-startup/r1/show_bgp_ipv6-post4.1.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_bgp_ipv6-post4.1.ref
@@ -3,6 +3,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *> fc00::/64        ::                       0         32768 i

--- a/tests/topotests/all-protocol-startup/r1/show_bgp_ipv6_post6.1.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_bgp_ipv6_post6.1.ref
@@ -4,6 +4,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *> fc00::/64        ::                       0         32768 i

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post4.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post4.1.ref
@@ -3,6 +3,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *  10.0.1.0/24      172.16.1.5                             0 65005 i

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post6.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post6.1.ref
@@ -4,6 +4,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *  10.0.1.0/24      172.16.1.5                             0 65005 i

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post4.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post4.1.ref
@@ -3,6 +3,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *  10.0.1.0/24      172.16.1.4                             0 65004 i

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post6.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post6.1.ref
@@ -4,6 +4,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *  10.0.1.0/24      172.16.1.4                             0 65004 i

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post4.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post4.1.ref
@@ -3,6 +3,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *  10.0.1.0/24      172.16.1.8                             0 65008 i

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post6.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post6.1.ref
@@ -4,6 +4,7 @@ Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
 
    Network          Next Hop            Metric LocPrf Weight Path
 *  10.0.1.0/24      172.16.1.8                             0 65008 i


### PR DESCRIPTION
Just to be more informant, copying from Cisco.

```
exit1-debian-9# sh ip bgp
BGP table version is 4, local router ID is 192.168.100.1, vrf id 0
Default local pref 100, local AS 65534
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
N*> 10.0.2.0/24      0.0.0.0                  0         32768 ?
N*> 192.168.0.0/24   0.0.0.0                  0         32768 ?
N*> 192.168.10.0/24  0.0.0.0                  0         32768 ?
N*> 192.168.100.1/32 0.0.0.0                  0         32768 ?

Displayed  4 routes and 4 total paths
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>