### PR TITLE
lib: fix issue with interface node access with different namespace

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1193,7 +1193,10 @@ DEFPY_YANG_NOSH (interface,
 	 * VRF.
 	 */
 	VRF_GET_ID(vrf_id, vrf_name, false);
-	ifp = if_lookup_by_name_all_vrf(ifname);
+	if (vrf_name)
+		ifp = if_lookup_by_name(ifname, vrf_id);
+	else
+		ifp = if_lookup_by_name_all_vrf(ifname);
 	if (ifp && ifp->vrf_id != vrf_id) {
 		struct vrf *vrf;
 


### PR DESCRIPTION
when duplicate name is on two network namespaces, at startup, the
wrong interface is picked up. Get the appropriate interface pointer.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>