### PR TITLE
vtysh: Set history file on demand

### DIFF
--- a/doc/manpages/vtysh.rst
+++ b/doc/manpages/vtysh.rst
@@ -53,6 +53,10 @@ OPTIONS available for the vtysh command:
 
    When executing cli that does not invoke a vtysh shell, if an error ocurrs ignore it for purposes of return codes from vtysh.
 
+.. option:: -H, --histfile
+
+   Override the history file for vtysh commands. You can set ``vtysh -H /dev/null`` to turn logging of at all.
+
 .. option:: -u, --user
 
    Restrict access to configuration commands by preventing use of the "enable" command. This option provides the same limited "security" as password-protected telnet access. *This security should not be relied on in production environments.*
@@ -67,6 +71,10 @@ ENVIRONMENT VARIABLES
 =====================
 VTYSH_PAGER
    This should be the name of the pager to use. Default is more.
+
+VTYSH_HISTFILE
+   Override the history file for vtysh commands. Logging can be turned off using ``VTYSH_HISTFILE=/dev/null vtysh``.
+   Environment is prefered way to override the history file path over command line argument (-H/--histfile).
 
 FILES
 =====


### PR DESCRIPTION
It's sometimes needed to disable logging all FRR commands at all.

Fixes: https://github.com/FRRouting/frr/issues/8400