### PR TITLE
ospfd: install Type-7 when NSSA area is configured after redistribution

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -1818,7 +1818,6 @@ static int ospf_abr_task_timer(struct thread *thread)
 
 	ospf_abr_task(ospf);
 	ospf_abr_nssa_task(ospf); /* if nssa-abr, then scan Type-7 LSDB */
-	ospf_asbr_nssa_redist_task(ospf);
 
 	return 0;
 }

--- a/ospfd/ospf_asbr.h
+++ b/ospfd/ospf_asbr.h
@@ -104,6 +104,7 @@ struct ospf_external_aggr_rt {
 };
 
 #define OSPF_ASBR_CHECK_DELAY 30
+#define OSPF_ASBR_NSSA_REDIST_UPDATE_DELAY 9
 
 extern void ospf_external_route_remove(struct ospf *, struct prefix_ipv4 *);
 extern struct external_info *ospf_external_info_new(uint8_t, unsigned short);
@@ -121,7 +122,7 @@ extern struct external_info *ospf_external_info_lookup(struct ospf *, uint8_t,
 						       unsigned short,
 						       struct prefix_ipv4 *);
 extern void ospf_asbr_status_update(struct ospf *, uint8_t);
-extern void ospf_asbr_nssa_redist_task(struct ospf *ospf);
+extern void ospf_schedule_asbr_nssa_redist_update(struct ospf *ospf);
 
 extern void ospf_redistribute_withdraw(struct ospf *, uint8_t, unsigned short);
 extern void ospf_asbr_check(void);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1546,6 +1546,7 @@ static int ospf_area_nssa_cmd_handler(struct vty *vty, int argc,
 	/* Flush the external LSA for the specified area */
 	ospf_flush_lsa_from_area(ospf, area_id, OSPF_AS_EXTERNAL_LSA);
 	ospf_schedule_abr_task(ospf);
+	ospf_schedule_asbr_nssa_redist_update(ospf);
 
 	return CMD_SUCCESS;
 }

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -791,6 +791,7 @@ static void ospf_finish_final(struct ospf *ospf)
 	OSPF_TIMER_OFF(ospf->t_maxage_walker);
 	OSPF_TIMER_OFF(ospf->t_abr_task);
 	OSPF_TIMER_OFF(ospf->t_asbr_check);
+	OSPF_TIMER_OFF(ospf->t_asbr_nssa_redist_update);
 	OSPF_TIMER_OFF(ospf->t_distribute_update);
 	OSPF_TIMER_OFF(ospf->t_lsa_refresher);
 	OSPF_TIMER_OFF(ospf->t_opaque_lsa_self);

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -242,6 +242,8 @@ struct ospf {
 	/* Threads. */
 	struct thread *t_abr_task;	  /* ABR task timer. */
 	struct thread *t_asbr_check;	/* ASBR check timer. */
+	struct thread *t_asbr_nssa_redist_update; /* ASBR NSSA redistribution
+						     update timer. */
 	struct thread *t_distribute_update; /* Distirbute list update timer. */
 	struct thread *t_spf_calc;	  /* SPF calculation timer. */
 	struct thread *t_ase_calc;	  /* ASE calculation timer. */


### PR DESCRIPTION
Currently, if NSSA area is configured before redistribution is enabled,
Type-7 LSA's are installed and flooded. But if NSSA area is configured
after redistribution is enabled, Type-7 LSA's are not installed.

With this change, when NSSA area is configured, schedule a task that
scans for external LSA's. If they exist, install Type-7 and flood to
all NSSA Areas.

There already was an attempt to fix this problem in 0f321812f where
`ospf_asbr_nssa_redist_task()` was triggered in `ospf_abr_task_timer()`.
This turns out to be incorrect place for this operation because it's
a one-off operation needed only after "area <ID> nssa" execution. And
`ospf_abr_task_timer()` is a periodic operation. Triggering
`ospf_asbr_nssa_redist_task()` in `ospf_abr_task_timer()` caused a problem
that was fixed in 945eec2b6 making the problem with NSSA area
configured after redistribution actual again.

Signed-off-by: Alexander Chernavin <achernavin@netgate.com>