### PR TITLE
bgpd: Fix IP-VRF ext-comm check for MACIP routes

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -1670,8 +1670,9 @@ static inline bool bgp_evpn_route_add_l3_ecomm_ok(struct bgpevpn *vpn,
 {
 	return p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE
 	       && (is_evpn_prefix_ipaddr_v4(p)
-		   || !IN6_IS_ADDR_LINKLOCAL(
-			   &p->prefix.macip_addr.ip.ipaddr_v6))
+		   || (is_evpn_prefix_ipaddr_v6(p)
+		       && !IN6_IS_ADDR_LINKLOCAL(
+			       &p->prefix.macip_addr.ip.ipaddr_v6)))
 	       && CHECK_FLAG(vpn->flags, VNI_FLAG_USE_TWO_LABELS)
 	       && bgpevpn_get_l3vni(vpn) && bgp_evpn_es_add_l3_ecomm_ok(esi);
 }


### PR DESCRIPTION
When validating a MACIP route's IP address,
bgp_evpn_route_add_l3_ecomm_ok checked for a non link-local v6 address
without checking if the v6 address existed.  Since empty v6 addresses
do not fall into the fe80 range, MAC-Only routes were always passing
this check and getting IP-VRF extended communities (RMAC/IP-VRF RT)
added to the routes.
This commit requires ipaddr_v6 to exist AND fall outside of the
link-local range for IP-VRF ext-comms to be added.

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>


Before:
--------
```
[4:14:32] root@ub18:~                     
 # bridge fdb add aa:bb:cc:cc:bb:aa dev dummy20 master dynamic
                                                                                    
[4:14:35] root@ub18:~                                                               
 # vtysh                                                                            

Hello, this is FRRouting (version 7.7-dev).
Copyright 1996-2005 Kunihiro Ishiguro, et al.                                                                                                                            
                                          
ub18# show evpn mac vni 20                                                                                                                                               
Number of MACs (local and remote) known for this VNI: 3
Flags: N=sync-neighs, I=local-inactive, P=peer-active, X=peer-proxy
MAC               Type   Flags Intf/Remote ES/VTEP            VLAN  Seq #'s
aa:bb:cc:cc:bb:aa local        dummy20                        1     0/0                                                                                                  
aa:bb:cc:00:22:22 remote       2.2.2.2                              0/0
aa:bb:cc:00:21:21 local        br20                           1     0/0
ub18# show evpn arp-cache vni 20                                                    
Number of ARPs (local and remote) known for this VNI: 4
Flags: I=local-inactive, P=peer-active, X=peer-proxy
Neighbor                  Type   Flags State    MAC               Remote ES/VTEP                 Seq #'s
20.0.0.2                  remote       active   aa:bb:cc:00:22:22 2.2.2.2                        0/0
fe80::a8bb:ccff:fe00:2222 remote       active   aa:bb:cc:00:22:22 2.2.2.2                        0/0
fe80::a8bb:ccff:fe00:2121 local        active   aa:bb:cc:00:21:21                                0/0
20.0.0.1                  local        active   aa:bb:cc:00:21:21                                0/0
ub18# show bgp l2vpn evpn route rd all mac aa:bb:cc:cc:bb:aa
Route Distinguisher: 100.64.0.111:3
BGP routing table entry for 100.64.0.111:3:[2]:[0]:[48]:[aa:bb:cc:cc:bb:aa]
Paths: (1 available, best #1)
  Advertised to non peer-group peers:
  192.168.122.99
  Route [2]:[0]:[48]:[aa:bb:cc:cc:bb:aa] VNI 20/10
  Local
    1.1.1.1 from 0.0.0.0 (100.64.0.111)
      Origin IGP, weight 32768, valid, sourced, local, best (First path received)
      Extended Community: ET:8 RT:1:20 RT:1:10 Rmac:aa:bb:cc:00:11:11  <<<<<  IP-VRF ext-comms present on mac-only route
      Last update: Tue Apr 13 04:14:36 2021

Displayed 1 prefixes (1 paths)
ub18# show bgp l2vpn evpn route rd all mac aa:bb:cc:00:21:21 ip 20.0.0.1
Route Distinguisher: 100.64.0.111:3
BGP routing table entry for 100.64.0.111:3:[2]:[0]:[48]:[aa:bb:cc:00:21:21]:[32]:[20.0.0.1]
Paths: (1 available, best #1)
  Advertised to non peer-group peers:
  192.168.122.99
  Route [2]:[0]:[48]:[aa:bb:cc:00:21:21]:[32]:[20.0.0.1] VNI 20/10
  Local
    1.1.1.1 from 0.0.0.0 (100.64.0.111)
      Origin IGP, weight 32768, valid, sourced, local, best (First path received)
      Extended Community: ET:8 RT:1:20 RT:1:10 Rmac:aa:bb:cc:00:11:11
      Last update: Tue Apr 13 04:14:29 2021

Displayed 1 prefixes (1 paths)
ub18# show bgp l2vpn evpn route rd all mac aa:bb:cc:00:21:21 ip fe80::a8bb:ccff:fe00:2121
Route Distinguisher: 100.64.0.111:3
BGP routing table entry for 100.64.0.111:3:[2]:[0]:[48]:[aa:bb:cc:00:21:21]:[128]:[fe80::a8bb:ccff:fe00:2121]
Paths: (1 available, best #1)
  Advertised to non peer-group peers:
  192.168.122.99
  Route [2]:[0]:[48]:[aa:bb:cc:00:21:21]:[128]:[fe80::a8bb:ccff:fe00:2121] VNI 20/10 
  Local
    1.1.1.1 from 0.0.0.0 (100.64.0.111)
      Origin IGP, weight 32768, valid, sourced, local, best (First path received)
      Extended Community: ET:8 RT:1:20
      Last update: Tue Apr 13 04:14:28 2021

Displayed 1 prefixes (1 paths)
```


After:
-------
```
[4:08:01] root@ub18:~
 # bridge fdb add aa:bb:cc:cc:bb:aa dev dummy20 master dynamic
                                                                                    
[4:08:03] root@ub18:~                                                               
 # vtysh                                                                            

Hello, this is FRRouting (version 7.7-dev).
Copyright 1996-2005 Kunihiro Ishiguro, et al.                                                                                                                            
                                          
ub18# show evpn mac vni 20                                                                                                                                               
Number of MACs (local and remote) known for this VNI: 3
Flags: N=sync-neighs, I=local-inactive, P=peer-active, X=peer-proxy
MAC               Type   Flags Intf/Remote ES/VTEP            VLAN  Seq #'s
aa:bb:cc:cc:bb:aa local        dummy20                        1     0/0                                                                                                  
aa:bb:cc:00:22:22 remote       2.2.2.2                              0/0
aa:bb:cc:00:21:21 local        br20                           1     0/0
ub18# show evpn arp-cache vni 20                                                    
Number of ARPs (local and remote) known for this VNI: 4
Flags: I=local-inactive, P=peer-active, X=peer-proxy
Neighbor                  Type   Flags State    MAC               Remote ES/VTEP                 Seq #'s
20.0.0.2                  remote       active   aa:bb:cc:00:22:22 2.2.2.2                        0/0
fe80::a8bb:ccff:fe00:2222 remote       active   aa:bb:cc:00:22:22 2.2.2.2                        0/0
fe80::a8bb:ccff:fe00:2121 local        active   aa:bb:cc:00:21:21                                0/0
20.0.0.1                  local        active   aa:bb:cc:00:21:21                                0/0
ub18# show bgp l2vpn evpn route rd all mac aa:bb:cc:cc:bb:aa
Route Distinguisher: 100.64.0.111:3
BGP routing table entry for 100.64.0.111:3:[2]:[0]:[48]:[aa:bb:cc:cc:bb:aa]
Paths: (1 available, best #1)
  Advertised to non peer-group peers:
  192.168.122.99
  Route [2]:[0]:[48]:[aa:bb:cc:cc:bb:aa] VNI 20/10
  Local
    1.1.1.1 from 0.0.0.0 (100.64.0.111)
      Origin IGP, weight 32768, valid, sourced, local, best (First path received)
      Extended Community: ET:8 RT:1:20      <<<<<  no more IP-VRF ext-comm on mac-only
      Last update: Tue Apr 13 04:08:04 2021

Displayed 1 prefixes (1 paths)
ub18# show bgp l2vpn evpn route rd all mac aa:bb:cc:00:21:21 ip 20.0.0.1
Route Distinguisher: 100.64.0.111:3
BGP routing table entry for 100.64.0.111:3:[2]:[0]:[48]:[aa:bb:cc:00:21:21]:[32]:[20.0.0.1]
Paths: (1 available, best #1)
  Advertised to non peer-group peers:
  192.168.122.99
  Route [2]:[0]:[48]:[aa:bb:cc:00:21:21]:[32]:[20.0.0.1] VNI 20/10
  Local
    1.1.1.1 from 0.0.0.0 (100.64.0.111)
      Origin IGP, weight 32768, valid, sourced, local, best (First path received)
      Extended Community: ET:8 RT:1:20 RT:1:10 Rmac:aa:bb:cc:00:11:11   <<<<  IP-VRF ext-comm still present for v4
      Last update: Tue Apr 13 04:07:53 2021

Displayed 1 prefixes (1 paths)
ub18# show bgp l2vpn evpn route rd all mac aa:bb:cc:00:21:21 ip fe80::a8bb:ccff:fe00:2121
Route Distinguisher: 100.64.0.111:3
BGP routing table entry for 100.64.0.111:3:[2]:[0]:[48]:[aa:bb:cc:00:21:21]:[128]:[fe80::a8bb:ccff:fe00:2121]
Paths: (1 available, best #1)
  Advertised to non peer-group peers:
  192.168.122.99
  Route [2]:[0]:[48]:[aa:bb:cc:00:21:21]:[128]:[fe80::a8bb:ccff:fe00:2121] VNI 20/10 
  Local
    1.1.1.1 from 0.0.0.0 (100.64.0.111)
      Origin IGP, weight 32768, valid, sourced, local, best (First path received)
      Extended Community: ET:8 RT:1:20      <<<<<  still no IP-VRF ext-comm on v6-LL
      Last update: Tue Apr 13 04:07:53 2021

Displayed 1 prefixes (1 paths)
```