### PR TITLE
lib: fix access-list deletion

### DIFF
--- a/lib/filter.c
+++ b/lib/filter.c
@@ -181,6 +181,11 @@ void access_list_delete(struct access_list *access)
 	else
 		list->head = access->next;
 
+	route_map_notify_dependencies(access->name, RMAP_EVENT_FILTER_DELETED);
+
+	if (master->delete_hook)
+		master->delete_hook(access);
+
 	XFREE(MTYPE_ACCESS_LIST_STR, access->name);
 
 	XFREE(MTYPE_TMP, access->remark);

--- a/lib/filter_nb.c
+++ b/lib/filter_nb.c
@@ -508,17 +508,12 @@ static int lib_access_list_create(struct nb_cb_create_args *args)
 
 static int lib_access_list_destroy(struct nb_cb_destroy_args *args)
 {
-	struct access_master *am;
 	struct access_list *acl;
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	acl = nb_running_unset_entry(args->dnode);
-	am = acl->master;
-	if (am->delete_hook)
-		am->delete_hook(acl);
-
 	access_list_delete(acl);
 
 	return NB_OK;


### PR DESCRIPTION
Problems with the current implementation:
* Delete hook is called before the deletion of the access-list from the
  master list, which means that daemons processing this hook successfully
  find this access-list, store a pointer to it in their structures, and
  right after that the access-list is freed. Daemons end up having stale
  pointer to the freed structure.
* Route-maps are not notified of the deletion.

This commit fixes both issues.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>