### PR TITLE
tools: Add some more data to ignore for valgrind

### DIFF
--- a/tools/valgrind.supp
+++ b/tools/valgrind.supp
@@ -16,3 +16,17 @@
    obj:/usr/lib/x86_64-linux-gnu/libyang.so.1.9.2
    fun:ly_load_plugins
 }
+{
+   <zprivs_init leak in a function we do not control>
+   Memcheck:Leak
+   fun:calloc
+   fun:cap_init
+   fun:zprivs_caps_init
+}
+{
+   <sqlite3 leak in a function we do not control>
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:sqlite3_step
+}


### PR DESCRIPTION
When running valgrind there are some possible memory leaks.
These memory leaks we have absolutely no control over, mark
them as not worthy of being reported.

Finally move the valgrind suppressions file from bgpd/ to tools/
this is because this suppressions file can be used beyond bgpd

Signed-off-by: Donald Sharp <sharpd@nvidia.com>