### PR TITLE
libs: add api to enable immediate output of zlog

### DIFF
--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -188,6 +188,12 @@ Basic Config Commands
    This command clears all current filters in the log-filter table. Can be
    daemon independent.
 
+
+.. clicmd:: log immediate-mode
+
+   Use unbuffered output for log and debug messages; normally there is
+   some internal buffering.
+
 .. clicmd:: service password-encryption
 
    Encrypt password.

--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -647,6 +647,18 @@ DEFPY (show_log_filter,
 	return CMD_SUCCESS;
 }
 
+/* Enable/disable 'immediate' mode, with no output buffering */
+DEFPY (log_immediate_mode,
+       log_immediate_mode_cmd,
+       "[no] log immediate-mode",
+       NO_STR
+       "Logging control"
+       "Output immediately, without buffering")
+{
+	zlog_set_immediate(!no);
+	return CMD_SUCCESS;
+}
+
 void log_config_write(struct vty *vty)
 {
 	bool show_cmdline_hint = false;
@@ -775,4 +787,5 @@ void log_cmd_init(void)
 	install_element(CONFIG_NODE, &log_filter_clear_cmd);
 	install_element(CONFIG_NODE, &config_log_filterfile_cmd);
 	install_element(CONFIG_NODE, &no_config_log_filterfile_cmd);
+	install_element(CONFIG_NODE, &log_immediate_mode_cmd);
 }

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -81,6 +81,11 @@ static gid_t zlog_gid = -1;
 DECLARE_ATOMLIST(zlog_targets, struct zlog_target, head);
 static struct zlog_targets_head zlog_targets;
 
+/* Global setting for buffered vs immediate output. The default is
+ * per-pthread buffering.
+ */
+static bool default_immediate;
+
 /* cf. zlog.h for additional comments on this struct.
  *
  * Note: you MUST NOT pass the format string + va_list to non-FRR format
@@ -395,7 +400,7 @@ static void vzlog_tls(struct zlog_tls *zlog_tls, const struct xref_logmsg *xref,
 	struct zlog_msg *msg;
 	char *buf;
 	bool ignoremsg = true;
-	bool immediate = false;
+	bool immediate = default_immediate;
 
 	/* avoid further processing cost if no target wants this message */
 	rcu_read_lock();
@@ -714,6 +719,14 @@ struct zlog_target *zlog_target_replace(struct zlog_target *oldzt,
 	return oldzt;
 }
 
+/*
+ * Enable or disable 'immediate' output - default is to buffer
+ * each pthread's messages.
+ */
+void zlog_set_immediate(bool set_p)
+{
+	default_immediate = set_p;
+}
 
 /* common init */
 

--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -249,6 +249,9 @@ extern void zlog_tls_buffer_init(void);
 extern void zlog_tls_buffer_flush(void);
 extern void zlog_tls_buffer_fini(void);
 
+/* Enable or disable 'immediate' output - default is to buffer messages. */
+extern void zlog_set_immediate(bool set_p);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The log module buffers outgoing messages by default; add an api to turn that off, and emit messages immediately. This can be useful when debugging, etc. I haven't proposed a cli control here, but that might be useful too?
