### PR TITLE
docker: prefer CMD to ENTRYPOINT for flexibility

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -56,4 +56,4 @@ RUN apk add \
 		--allow-untrusted /pkgs/apk/*/*.apk \
 	&& rm -rf /pkgs
 COPY docker/alpine/docker-start /usr/lib/frr/docker-start
-ENTRYPOINT [ "/sbin/tini", "--", "/usr/lib/frr/docker-start" ]
+CMD [ "/sbin/tini", "--", "/usr/lib/frr/docker-start" ]

--- a/docker/centos-7/Dockerfile
+++ b/docker/centos-7/Dockerfile
@@ -40,4 +40,4 @@ COPY --from=centos-7-builder /rpmbuild/RPMS/ /pkgs/rpm/
 RUN yum install -y /pkgs/rpm/*/*.rpm \
     && rm -rf /pkgs
 COPY docker/centos-7/docker-start /usr/lib/frr/docker-start
-ENTRYPOINT [ "/usr/lib/frr/docker-start" ]
+CMD [ "/usr/lib/frr/docker-start" ]

--- a/docker/centos-8/Dockerfile
+++ b/docker/centos-8/Dockerfile
@@ -41,4 +41,4 @@ COPY --from=centos-8-builder /rpmbuild/RPMS/ /pkgs/rpm/
 RUN yum install -y /pkgs/rpm/*/*.rpm \
     && rm -rf /pkgs
 COPY docker/centos-8/docker-start /usr/lib/frr/docker-start
-ENTRYPOINT [ "/usr/lib/frr/docker-start" ]
+CMD [ "/usr/lib/frr/docker-start" ]

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -17,4 +17,4 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 ADD docker-start /usr/sbin/docker-start
-ENTRYPOINT ["/usr/sbin/docker-start"]
+CMD ["/usr/sbin/docker-start"]

--- a/docker/debian/docker-start
+++ b/docker/debian/docker-start
@@ -7,4 +7,6 @@ set -e
 ##
 chown -R frr:frr /etc/frr
 /etc/init.d/frr start
-exec sleep 10000d
+
+# Sleep forever
+exec tail -f /dev/null

--- a/docker/ubuntu18-ci/Dockerfile
+++ b/docker/ubuntu18-ci/Dockerfile
@@ -68,4 +68,4 @@ RUN cd ~/frr && \
 RUN cd ~/frr && make check || true
 
 COPY docker/ubuntu18-ci/docker-start /usr/sbin/docker-start
-ENTRYPOINT ["/usr/sbin/docker-start"]
+CMD ["/usr/sbin/docker-start"]

--- a/docker/ubuntu20-ci/Dockerfile
+++ b/docker/ubuntu20-ci/Dockerfile
@@ -71,4 +71,4 @@ RUN cd ~/frr && \
 RUN cd ~/frr && make check || true
 
 COPY docker/ubuntu20-ci/docker-start /usr/sbin/docker-start
-ENTRYPOINT ["/usr/sbin/docker-start"]
+CMD ["/usr/sbin/docker-start"]


### PR DESCRIPTION
Specifying watchfrr in Dockerfiles as CMD instead of ENTRYPOINT allows one to easily override the watchfrr command when starting a docker container. This allows simple, manual testing via (e.g.) bash. With ENTRYPOINT only the container will simply explode with an exit code if watchfrr exits.

If you tried to do this before you'd see this from `docker ps`:

```
COMMAND
"/sbin/tini -- /usr/lib/frr/docker-start bash"
```

Which shows that /usr/lib/frr/docker-start (a wrapper around frrinit.sh) tried to start frrinit.sh with the `bash` parameter which clearly won't do anything. Now, one could start a shell session in this container via:

```
docker run --name test --rm -i -t <frr-container> bash
```

The default behavior (`docker run <frr-container>` with no command specified) is not changed.