### PR TITLE
lib, zebra: use zebra workqueue for NHG updates

### DIFF
--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -742,6 +742,29 @@ enum zclient_send_status {
 };
 
 static inline const char *
+zapi_nhg_notify_owner2str(enum zapi_nhg_notify_owner note)
+{
+	const char *ret = "UNKNOWN";
+
+	switch (note) {
+	case ZAPI_NHG_FAIL_INSTALL:
+		ret = "ZAPI_NHG_FAIL_INSTALL";
+		break;
+	case ZAPI_NHG_INSTALLED:
+		ret = "ZAPI_NHG_INSTALLED";
+		break;
+	case ZAPI_NHG_REMOVE_FAIL:
+		ret = "ZAPI_NHG_REMOVE_FAIL";
+		break;
+	case ZAPI_NHG_REMOVED:
+		ret = "ZAPI_NHG_REMOVED";
+		break;
+	}
+
+	return ret;
+}
+
+static inline const char *
 zapi_rule_notify_owner2str(enum zapi_rule_notify_owner note)
 {
 	const char *ret = "UNKNOWN";

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -426,7 +426,11 @@ extern int rib_queue_add(struct route_node *rn);
 
 struct nhg_ctx; /* Forward declaration */
 
-extern int rib_queue_nhg_add(struct nhg_ctx *ctx);
+/* Enqueue incoming nhg from OS for processing */
+extern int rib_queue_nhg_ctx_add(struct nhg_ctx *ctx);
+
+/* Enqueue incoming nhg from proto daemon for processing */
+extern int rib_queue_nhe_add(struct nhg_hash_entry *nhe);
 
 extern void meta_queue_free(struct meta_queue *mq);
 extern int zebra_rib_labeled_unicast(struct route_entry *re);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -727,8 +727,8 @@ int zsend_nhg_notify(uint16_t type, uint16_t instance, uint32_t session_id,
 	}
 
 	if (IS_ZEBRA_DEBUG_SEND)
-		zlog_debug("%s: type %d, id %d, note %d",
-			   __func__, type, id, note);
+		zlog_debug("%s: type %d, id %d, note %s",
+			   __func__, type, id, zapi_nhg_notify_owner2str(note));
 
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 	stream_reset(s);
@@ -1890,27 +1890,35 @@ static void zread_nhg_add(ZAPI_HANDLER_ARGS)
 		return;
 	}
 
-	/*
-	 * Create the nhg
-	 */
-	nhe = zebra_nhg_proto_add(api_nhg.id, api_nhg.proto, client->instance,
-				  client->session_id, nhg, 0);
+	/* Create a temporary nhe */
+	nhe = zebra_nhg_alloc();
+	nhe->id = api_nhg.id;
+	nhe->type = api_nhg.proto;
+	nhe->zapi_instance = client->instance;
+	nhe->zapi_session = client->session_id;
 
-	nexthop_group_delete(&nhg);
-	zebra_nhg_backup_free(&bnhg);
+	/* Take over the list(s) of nexthops */
+	nhe->nhg.nexthop = nhg->nexthop;
+	nhg->nexthop = NULL;
+
+	if (bnhg) {
+		nhe->backup_info = bnhg;
+		bnhg = NULL;
+	}
 
 	/*
 	 * TODO:
 	 * Assume fully resolved for now and install.
-	 *
 	 * Resolution is going to need some more work.
 	 */
 
-	/* If there's a failure, notify sender immediately */
-	if (nhe == NULL)
-		zsend_nhg_notify(api_nhg.proto, client->instance,
-				 client->session_id, api_nhg.id,
-				 ZAPI_NHG_FAIL_INSTALL);
+	/* Enqueue to workqueue for processing */
+	rib_queue_nhe_add(nhe);
+
+	/* Free any local allocations */
+	nexthop_group_delete(&nhg);
+	zebra_nhg_backup_free(&bnhg);
+
 }
 
 static void zread_route_add(ZAPI_HANDLER_ARGS)

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -990,7 +990,7 @@ static struct nhg_ctx *nhg_ctx_new(void)
 	return new;
 }
 
-static void nhg_ctx_free(struct nhg_ctx **ctx)
+void nhg_ctx_free(struct nhg_ctx **ctx)
 {
 	struct nexthop *nh;
 
@@ -1233,7 +1233,7 @@ static int queue_add(struct nhg_ctx *ctx)
 	if (nhg_ctx_get_status(ctx) == NHG_CTX_QUEUED)
 		return 0;
 
-	if (rib_queue_nhg_add(ctx)) {
+	if (rib_queue_nhg_ctx_add(ctx)) {
 		nhg_ctx_set_status(ctx, NHG_CTX_FAILURE);
 		return -1;
 	}

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -269,6 +269,7 @@ extern bool zebra_nhg_hash_id_equal(const void *arg1, const void *arg2);
  * the rib meta queue.
  */
 extern int nhg_ctx_process(struct nhg_ctx *ctx);
+void nhg_ctx_free(struct nhg_ctx **ctx);
 
 /* Find via kernel nh creation */
 extern int zebra_nhg_kernel_find(uint32_t id, struct nexthop *nh,


### PR DESCRIPTION
Daemon-sourced nexthop-group changes were being done directly from the zapi message-handlers. Extend the zebra workqueue/meta-queues to allow these NHG changes to be done from the workqueue instead.