### PR TITLE
Fix several Alpine build issues related to ELF parsing

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -18,7 +18,7 @@ makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
     ncurses-libs ncurses-terminfo ncurses-terminfo-base patch pax-utils pcre
     perl pkgconf python3 python3-dev readline readline-dev sqlite-libs
     squashfs-tools sudo tar texinfo xorriso xz-libs py-pip rtrlib rtrlib-dev
-    py3-sphinx"
+    py3-sphinx elfutils elfutils-dev"
 checkdepends="pytest py-setuptools"
 install="$pkgname.pre-install $pkgname.pre-deinstall $pkgname.post-deinstall"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-dbg"

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # This stage builds a dist tarball from the source
-FROM alpine:latest as source-builder
+FROM alpine:3.13 as source-builder
 
 RUN mkdir -p /src/alpine
 COPY alpine/APKBUILD.in /src/alpine
@@ -21,7 +21,7 @@ RUN cd /src \
 	&& make dist
 
 # This stage builds an apk from the dist tarball
-FROM alpine:latest as alpine-builder
+FROM alpine:3.13 as alpine-builder
 # Don't use nocache here so that abuild can use the cache
 RUN apk add \
 		--update-cache \
@@ -44,7 +44,7 @@ RUN cd /dist \
 	&& abuild -r -P /pkgs/apk
 
 # This stage installs frr from the apk
-FROM alpine:latest
+FROM alpine:3.13
 RUN mkdir -p /pkgs/apk
 COPY --from=alpine-builder /pkgs/apk/ /pkgs/apk/
 RUN apk add \


### PR DESCRIPTION
Several issues:

1. `libelf-dev` dependency was not added to `APKBUILD.in` for Alpine packaging
2. Our Alpine base image was using the `latest` tag, which is unstable and not appropriate for us
3. Once `libelf-dev` is added, our FRR Alpine images no longer build because `libelf-dev` hasn't been available in Alpine since 3.9; work around this by adding 3.9 Alpine repository to the 3.13 base image before building FRR

Fixes: #8489 