### PR TITLE
bgpd: Check for flag existense for community instead of `if not NULL`

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10260,7 +10260,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 		vty_out(vty, "\n");
 
 	/* Line 4 display Community */
-	if (attr->community) {
+	if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)) {
 		if (json_paths) {
 			if (!attr->community->json)
 				community_str(attr->community, true);


### PR DESCRIPTION
Absolutetly cosmetic change, but let it be consistent with other checks
for optional attributes.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>