### PR TITLE
ospf6d: Fix coredump when "no interface IFNAME area <A.B.C.D>" is called

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -814,7 +814,7 @@ DEFUN (no_ospf6_interface_area,
 	/* Verify Area */
 	if (oi->area == NULL) {
 		vty_out(vty, "%s not attached to area %s\n",
-			oi->interface->name, oi->area->name);
+			oi->interface->name, argv[idx_ipv4]->arg);
 		return CMD_SUCCESS;
 	}
 


### PR DESCRIPTION
When oi->area == NULL, it tries to print the
interface's area name, but no area is present.
Print the area name from the command argument instead.

Signed-off-by: Yash Ranjan <ranjany@vmware.com>