### PR TITLE
lib: 640k backtraces should be enough for everybody

### DIFF
--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -237,9 +237,12 @@ core_handler(int signo, siginfo_t *siginfo, void *context)
 	/* make sure we don't hang in here.  default for SIGALRM is terminate.
 	 * - if we're in backtrace for more than a second, abort. */
 	struct sigaction sa_default = {.sa_handler = SIG_DFL};
+
 	sigaction(SIGALRM, &sa_default, NULL);
+	sigaction(signo, &sa_default, NULL);
 
 	sigset_t sigset;
+
 	sigemptyset(&sigset);
 	sigaddset(&sigset, SIGALRM);
 	sigprocmask(SIG_UNBLOCK, &sigset, NULL);
@@ -252,7 +255,16 @@ core_handler(int signo, siginfo_t *siginfo, void *context)
 	log_memstats(stderr, "core_handler");
 
 	zlog_tls_buffer_fini();
-	abort();
+
+	/* give the kernel a chance to generate a coredump */
+	sigaddset(&sigset, signo);
+	sigprocmask(SIG_UNBLOCK, &sigset, NULL);
+	raise(signo);
+
+	/* only chance to end up here is if the default action for signo is
+	 * something other than kill or coredump the process
+	 */
+	_exit(128 + signo);
 }
 
 static void trap_default_signals(void)


### PR DESCRIPTION
Funny as it may be, calling `abort()` in the `SIGSEGV` handler has the side effect that `abort()` also prints a second backtrace for the resulting `SIGABRT`.  And when it doesn't make it to "funny", it'll be confusing at best :confounded: ...

While at it, also make sure we generate coredumps & avoid printing a bogus "failed to unlinkat() log buffer" error when we never even created one to begin with.

For posterity, this what it looked like before:

```
frr $ tests/lib/test_segv
Received signal 11 at 1618802713 (si_addr 0x0, PC 0x55e6f97121dd); aborting...
zlog_signal+0x18c                  7ff6d0c1a2ad     7ffe50e570d0 /home/equinox/c/frr/lib/.libs/libfrr.so.0 (mapped at 0x7ff6d0b7b000)
core_handler+0xc7                  7ff6d0c55b7a     7ffe50e571f0 /home/equinox/c/frr/lib/.libs/libfrr.so.0 (mapped at 0x7ff6d0b7b000)
killpg+0x40                        7ff6d09a5d60     7ffe50e57340 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7ff6d096a000)
    ---- signal ----
func1+0x14                         55e6f97121dd     7ffe50e579e0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xdb                         55e6f97122d0     7ffe50e579f0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57a40 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57aa0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57b00 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57b60 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57bc0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57c30 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func3+0x19                         55e6f971232f     7ffe50e57ca0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
threadfunc+0x11                    55e6f9712343     7ffe50e57cd0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
thread_call+0x202                  7ff6d0c6d592     7ffe50e57cf0 /home/equinox/c/frr/lib/.libs/libfrr.so.0 (mapped at 0x7ff6d0b7b000)
_thread_execute+0xe5               7ff6d0c6db23     7ffe50e57ec0 /home/equinox/c/frr/lib/.libs/libfrr.so.0 (mapped at 0x7ff6d0b7b000)
main+0x69                          55e6f97123b3     7ffe50e57f30 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
__libc_start_main+0xea             7ff6d0990d0a     7ffe50e57f40 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7ff6d096a000)
_start+0x2a                        55e6f97120ba     7ffe50e58010 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
in thread threadfunc scheduled from tests/lib/test_segv.c:78 main()
core_handler: showing active allocations in memory group libfrr
core_handler: memstats:  Hash                          :      2 * (variably sized)
core_handler: memstats:  Hash Bucket                   :      1 *         32
core_handler: memstats:  Hash Index                    :      1 *         64
core_handler: memstats:  Link List                     :      3 *         40
core_handler: memstats:  Link Node                     :      2 *         24
core_handler: memstats:  Thread                        :      1 *        152
core_handler: memstats:  Thread master                 :      4 * (variably sized)
core_handler: memstats:  Thread Poll Info              :      2 *       8192
core_handler: memstats:  Thread stats                  :      1 *         88
core_handler: showing active allocations in memory group logging subsystem
2021/04/19 05:25:13 [TP7QZ-14YQR] unlink logbuf: Bad file descriptor (9)
Received signal 6 at 1618802713 (si_addr 0x3e8000f0c41, PC 0x7ff6d09a5ce1); aborting...
zlog_signal+0x18c                  7ff6d0c1a2ad     7ffe50e56690 /home/equinox/c/frr/lib/.libs/libfrr.so.0 (mapped at 0x7ff6d0b7b000)
core_handler+0xc7                  7ff6d0c55b7a     7ffe50e567b0 /home/equinox/c/frr/lib/.libs/libfrr.so.0 (mapped at 0x7ff6d0b7b000)
killpg+0x40                        7ff6d09a5d60     7ffe50e56900 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7ff6d096a000)
    ---- signal ----
gsignal+0x141                      7ff6d09a5ce1     7ffe50e56fa0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7ff6d096a000)
abort+0x123                        7ff6d098f537     7ffe50e570c0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7ff6d096a000)
core_handler+0xea                  7ff6d0c55b9d     7ffe50e571f0 /home/equinox/c/frr/lib/.libs/libfrr.so.0 (mapped at 0x7ff6d0b7b000)
killpg+0x40                        7ff6d09a5d60     7ffe50e57340 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7ff6d096a000)
    ---- signal ----
func1+0x14                         55e6f97121dd     7ffe50e579e0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xdb                         55e6f97122d0     7ffe50e579f0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57a40 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57aa0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57b00 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57b60 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57bc0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func2+0xcd                         55e6f97122c2     7ffe50e57c30 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
func3+0x19                         55e6f971232f     7ffe50e57ca0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
threadfunc+0x11                    55e6f9712343     7ffe50e57cd0 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
thread_call+0x202                  7ff6d0c6d592     7ffe50e57cf0 /home/equinox/c/frr/lib/.libs/libfrr.so.0 (mapped at 0x7ff6d0b7b000)
_thread_execute+0xe5               7ff6d0c6db23     7ffe50e57ec0 /home/equinox/c/frr/lib/.libs/libfrr.so.0 (mapped at 0x7ff6d0b7b000)
main+0x69                          55e6f97123b3     7ffe50e57f30 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
__libc_start_main+0xea             7ff6d0990d0a     7ffe50e57f40 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7ff6d096a000)
_start+0x2a                        55e6f97120ba     7ffe50e58010 /home/equinox/c/frr/tests/lib/.libs/test_segv (mapped at 0x55e6f9711000)
in thread threadfunc scheduled from tests/lib/test_segv.c:78 main()
core_handler: showing active allocations in memory group libfrr
core_handler: memstats:  Hash                          :      2 * (variably sized)
core_handler: memstats:  Hash Bucket                   :      1 *         32
core_handler: memstats:  Hash Index                    :      1 *         64
core_handler: memstats:  Link List                     :      3 *         40
core_handler: memstats:  Link Node                     :      2 *         24
core_handler: memstats:  Thread                        :      1 *        152
core_handler: memstats:  Thread master                 :      4 * (variably sized)
core_handler: memstats:  Thread Poll Info              :      2 *       8192
core_handler: memstats:  Thread stats                  :      1 *         88
core_handler: showing active allocations in memory group logging subsystem
2021/04/19 05:25:13 [TP7QZ-14YQR] unlink logbuf: Bad file descriptor (9)
```