### PR TITLE
ospf6d: Do not delete external table when configure max-path

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -890,7 +890,6 @@ static void ospf6_restart_spf(struct ospf6 *ospf6)
 {
 	ospf6_route_remove_all(ospf6->route_table);
 	ospf6_route_remove_all(ospf6->brouter_table);
-	ospf6_route_remove_all(ospf6->external_table);
 
 	/* Trigger SPF */
 	ospf6_spf_schedule(ospf6, OSPF6_SPF_FLAGS_CONFIG_CHANGE);


### PR DESCRIPTION
Issue: When maximum-path is configured in ospf6 view, the
function ospf6_restart_spf deletes the external table as well
which is not required since that stores the redistribute routes.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>