### PR TITLE
pimd: fix crash pim register-suppress-time command

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -755,18 +755,14 @@ int pim_join_prune_interval_modify(struct nb_cb_modify_args *args)
  */
 int pim_register_suppress_time_modify(struct nb_cb_modify_args *args)
 {
-	struct vrf *vrf;
-	struct pim_instance *pim;
-
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		vrf = nb_running_get_entry(args->dnode, NULL, true);
-		pim = vrf->info;
-		pim->keep_alive_time = yang_dnode_get_uint16(args->dnode, NULL);
+		router->register_suppress_time =
+			yang_dnode_get_uint16(args->dnode, NULL);
 		break;
 	}
 


### PR DESCRIPTION
Fix:

dev(config)# ip pim register-suppress-time 70
dev(config)# do show running-config 
Building configuration...

Current configuration:
!
frr version 7.7-dev-MyOwnFRRVersion
frr defaults traditional
hostname dev
log syslog informational
ip pim register-suppress-time 70
ip pim rp keep-alive-timer 185
!
line vty
!
end
dev(config)# no ip pim register-suppress-time 70
dev(config)# do show running-config 
Building configuration...

Current configuration:
!
frr version 7.7-dev-MyOwnFRRVersion
frr defaults traditional
hostname dev
log syslog informational
!
line vty
!
end
dev(config)# 

Signed-off-by: Sarita Patra <saritap@vmware.com>