### PR TITLE
ldpd: defer register for info until configured

### DIFF
--- a/ldpd/ldp_vty_conf.c
+++ b/ldpd/ldp_vty_conf.c
@@ -429,6 +429,9 @@ ldp_vty_mpls_ldp(struct vty *vty, const char *negate)
 		vty_conf->flags |= F_LDPD_ENABLED;
 	}
 
+	/* register / de-register to recv info from zebra */
+	ldp_zebra_regdereg_zebra_info(!negate);
+
 	ldp_config_apply(vty, vty_conf);
 
 	return (CMD_SUCCESS);

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -906,6 +906,8 @@ int		 ldp_sync_zebra_send_state_update(struct ldp_igp_sync_if_state *);
 int		 ldp_zebra_send_rlfa_labels(struct zapi_rlfa_response *
 		    rlfa_labels);
 
+void ldp_zebra_regdereg_zebra_info(bool want_register);
+
 /* compatibility */
 #ifndef __OpenBSD__
 #define __IPV6_ADDR_MC_SCOPE(a)		((a)->s6_addr[1] & 0x0f)

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -369,6 +369,14 @@ void zebra_redistribute_delete(ZAPI_HANDLER_ARGS)
 	STREAM_GETC(msg, type);
 	STREAM_GETW(msg, instance);
 
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug(
+			"%s: client proto %s afi=%d, no longer wants %s, vrf %s(%u), instance=%d",
+			__func__, zebra_route_string(client->proto), afi,
+			zebra_route_string(type), VRF_LOGNAME(zvrf->vrf),
+			zvrf_id(zvrf), instance);
+
+
 	if (afi == 0 || afi >= AFI_MAX) {
 		flog_warn(EC_ZEBRA_REDISTRIBUTE_UNKNOWN_AF,
 			  "%s: Specified afi %d does not exist", __func__, afi);


### PR DESCRIPTION
Instead of registering to receive default-VRF information and routes when first connected to zebra, defer the registration until some ldp configuration is entered. This avoids redistributing IPv4/IPv6 routes to ldpd if it's not needed.

Also add a zebra debug event message when calling zebra_redistribute_delete, same as we do for the add case.