### PR TITLE
bgpd: Clear peering if unable to send packets for time greater than h…

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1503,7 +1503,8 @@ class Router(Node):
                 ) + "/var/run/{}/snmpd.pid -x /etc/frr/agentx".format(self.routertype)
             else:
                 binary = os.path.join(self.daemondir, daemon)
-                cmdenv = "ASAN_OPTIONS=log_path={0}.asan".format(daemon)
+                cmdenv = "ASAN_OPTIONS=log_path={0}.asan /usr/bin/valgrind --log-file={1}/{2}.valgrind.%p --leak-check=full --suppressions=/tmp/valgrind/suppressions ".format(daemon, self.logdir, self.name)
+                #cmdenv = "ASAN_OPTIONS=log_path={0}.asan".format(daemon)
                 cmdopt = "{} --log file:{}.log --log-level debug".format(
                     daemon_opts, daemon
                 )


### PR DESCRIPTION
…oldtime

There are situations where BGP is unable to send packets, but
we are still receiving keepalives from the peer just fine.  In
this situation the other side has stalled reading( for whatever
reason ) and the other sides kernel buffers have filled up
and our sides kernel buffers have filled up and data is not flowing
at all.  In this situation if we have not been able to send
data to the other side for greater than the hold time
established for the peer.  Kill the session to get things cleaned
up in some fashion.

Tested by modifying iptables to drop both incoming and outgoing
tcp packets.  After the hold time being unable to send packets
we drop the connection:

sharpd@eva ~/frr7 (bgp_keepalive_wouldblock)> sudo /sbin/iptables -A OUTPUT -p tcp --destination-port 179 -j DROP ; sudo /sbin/iptables -A INPUT -p tcp --destination-port 33084 -j DROP

sharpd@eva ~/frr7 (bgp_keepalive_wouldblock)>
sharpd@eva ~/frr7 (bgp_keepalive_wouldblock)>
sharpd@eva ~/frr7 (bgp_keepalive_wouldblock)> 2021/04/21 09:46:47 BGP: [V1CHF-JSGRR] %NOTIFICATION: sent to neighbor 192.168.161.137 4/0 (Hold Timer Expired) 0 bytes

Signed-off-by: Donald Sharp <sharpd@nvidia.com>