### PR TITLE
lib, pathd PCEP: creating threads before forking does _not_ work

### DIFF
--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -134,6 +134,8 @@ lde(void)
 	log_procname = log_procnames[PROC_LDE_ENGINE];
 
 	master = frr_init();
+	/* no frr_config_fork() here, allow frr_pthread to create threads */
+	frr_is_after_fork = true;
 
 	/* setup signal handler */
 	signal_init(master, array_size(lde_signals), lde_signals);

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -111,6 +111,8 @@ ldpe(void)
 	log_procname = log_procnames[ldpd_process];
 
 	master = frr_init();
+	/* no frr_config_fork() here, allow frr_pthread to create threads */
+	frr_is_after_fork = true;
 
 	/* setup signal handler */
 	signal_init(master, array_size(ldpe_signals), ldpe_signals);

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -28,6 +28,7 @@
 #include "memory.h"
 #include "linklist.h"
 #include "zlog.h"
+#include "libfrr.h"
 #include "libfrr_trace.h"
 
 DEFINE_MTYPE_STATIC(LIB, FRR_PTHREAD, "FRR POSIX Thread");
@@ -161,6 +162,8 @@ int frr_pthread_run(struct frr_pthread *fpt, const pthread_attr_t *attr)
 {
 	int ret;
 	sigset_t oldsigs, blocksigs;
+
+	assert(frr_is_after_fork || !"trying to start thread before fork()");
 
 	/* Ensure we never handle signals on a background thread by blocking
 	 * everything here (new thread inherits signal mask)

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -46,6 +46,7 @@
 #include "frrscript.h"
 
 DEFINE_HOOK(frr_late_init, (struct thread_master * tm), (tm));
+DEFINE_HOOK(frr_config_pre, (struct thread_master * tm), (tm));
 DEFINE_HOOK(frr_config_post, (struct thread_master * tm), (tm));
 DEFINE_KOOH(frr_early_fini, (), ());
 DEFINE_KOOH(frr_fini, (), ());
@@ -931,6 +932,8 @@ static void frr_daemonize(void)
  */
 static int frr_config_read_in(struct thread *t)
 {
+	hook_call(frr_config_pre, master);
+
 	if (!vty_read_config(vty_shared_candidate_config, di->config_file,
 			     config_default)
 	    && di->backup_config_file) {

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -70,6 +70,8 @@ static char dbfile_default[512];
 #endif
 static char vtypath_default[512];
 
+/* cleared in frr_preinit(), then re-set after daemonizing */
+bool frr_is_after_fork = true;
 bool debug_memstats_at_exit = false;
 static bool nodetach_term, nodetach_daemon;
 static uint64_t startup_fds;
@@ -308,6 +310,7 @@ void frr_init_vtydir(void)
 void frr_preinit(struct frr_daemon_info *daemon, int argc, char **argv)
 {
 	di = daemon;
+	frr_is_after_fork = false;
 
 	/* basename(), opencoded. */
 	char *p = strrchr(argv[0], '/');
@@ -989,6 +992,8 @@ void frr_config_fork(void)
 
 	if (di->daemon_mode || di->terminal)
 		frr_daemonize();
+
+	frr_is_after_fork = true;
 
 	if (!di->pid_file)
 		di->pid_file = pidfile_default;

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -46,7 +46,7 @@
 #include "frrscript.h"
 
 DEFINE_HOOK(frr_late_init, (struct thread_master * tm), (tm));
-DEFINE_HOOK(frr_very_late_init, (struct thread_master * tm), (tm));
+DEFINE_HOOK(frr_config_post, (struct thread_master * tm), (tm));
 DEFINE_KOOH(frr_early_fini, (), ());
 DEFINE_KOOH(frr_fini, (), ());
 
@@ -964,7 +964,7 @@ static int frr_config_read_in(struct thread *t)
 				__func__, nb_err_name(ret), errmsg);
 	}
 
-	hook_call(frr_very_late_init, master);
+	hook_call(frr_config_post, master);
 
 	return 0;
 }

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -172,6 +172,8 @@ extern const char frr_scriptdir[];
 
 extern char frr_protoname[];
 extern char frr_protonameinst[];
+/* always set in the spot where we *would* fork even if we don't do so */
+extern bool frr_is_after_fork;
 
 extern bool debug_memstats_at_exit;
 

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -141,8 +141,12 @@ extern enum frr_cli_mode frr_get_cli_mode(void);
 extern uint32_t frr_get_fd_limit(void);
 extern bool frr_is_startup_fd(int fd);
 
+/* call order of these hooks is as ordered here */
 DECLARE_HOOK(frr_late_init, (struct thread_master * tm), (tm));
+/* fork() happens between late_init and config_pre */
+DECLARE_HOOK(frr_config_pre, (struct thread_master * tm), (tm));
 DECLARE_HOOK(frr_config_post, (struct thread_master * tm), (tm));
+
 extern void frr_config_fork(void);
 
 extern void frr_run(struct thread_master *master);

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -142,7 +142,7 @@ extern uint32_t frr_get_fd_limit(void);
 extern bool frr_is_startup_fd(int fd);
 
 DECLARE_HOOK(frr_late_init, (struct thread_master * tm), (tm));
-DECLARE_HOOK(frr_very_late_init, (struct thread_master * tm), (tm));
+DECLARE_HOOK(frr_config_post, (struct thread_master * tm), (tm));
 extern void frr_config_fork(void);
 
 extern void frr_run(struct thread_master *master);

--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -736,7 +736,7 @@ static int frr_sr_finish(void)
 	return 0;
 }
 
-static int frr_sr_module_very_late_init(struct thread_master *tm)
+static int frr_sr_module_config_loaded(struct thread_master *tm)
 {
 	master = tm;
 
@@ -761,7 +761,7 @@ static int frr_sr_module_late_init(struct thread_master *tm)
 static int frr_sr_module_init(void)
 {
 	hook_register(frr_late_init, frr_sr_module_late_init);
-	hook_register(frr_very_late_init, frr_sr_module_very_late_init);
+	hook_register(frr_config_post, frr_sr_module_config_loaded);
 
 	return 0;
 }


### PR DESCRIPTION
Threads created before we fork() for `-d` are running in the parent & will exit with that.  Which is very much not what's needed.

Shuffle around hooks a bit so we have something *after* fork but *before* config load.  Also make the frr_pthread code refuse to create threads before forking.