### PR TITLE
lib: remove enabled flag for bfd sessions

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -308,8 +308,6 @@ void bgp_peer_configure_bfd(struct peer *p, bool manual)
 	if (p->nexthop.ifp)
 		bfd_sess_set_interface(p->bfd_config->session,
 				       p->nexthop.ifp->name);
-
-	bfd_sess_enable(p->bfd_config->session, true);
 }
 
 static void bgp_peer_remove_bfd(struct peer *p)

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -185,14 +185,6 @@ struct bfd_session_params *bfd_sess_new(bsp_status_update updatecb, void *args);
 void bfd_sess_free(struct bfd_session_params **bsp);
 
 /**
- * Enable/disable session installation.
- *
- * \param bsp session parameters.
- * \param enable knob variable.
- */
-void bfd_sess_enable(struct bfd_session_params *bsp, bool enable);
-
-/**
  * Set the local and peer address of the BFD session.
  *
  * \param bsp BFD session parameters.

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -99,7 +99,6 @@ void ospf_neighbor_bfd_apply(struct ospf_neighbor *nbr)
 		bfd_sess_set_ipv4_addrs(nbr->bfd_session, NULL, &nbr->src);
 		bfd_sess_set_interface(nbr->bfd_session, oi->ifp->name);
 		bfd_sess_set_vrf(nbr->bfd_session, oi->ospf->vrf_id);
-		bfd_sess_enable(nbr->bfd_session, true);
 	}
 
 	/* Set new configuration. */


### PR DESCRIPTION
Currently this flag is only helpful in an extremely rare situation when
the BFD session registration was unsuccessful and after that zebra is
restarted. Let's remove this flag to simplify the API. If we ever want
to solve the problem of unsuccessful registration/deregistration, this
can be done using internal flags, without API modification.

Also add the error log to help user understand why the BFD session is
not working.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>