### PR TITLE
tests: Remove kill_mininet_router_process

### DIFF
--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1.py
@@ -134,7 +134,6 @@ from lib.common_config import (
     check_router_status,
     shutdown_bringup_interface,
     step,
-    kill_mininet_routers_process,
     get_frr_ipv6_linklocal,
     create_route_maps,
     required_linux_kernel_version,
@@ -203,9 +202,6 @@ def setup_module(mod):
     # This function initiates the topology build with Topogen...
     tgen = Topogen(GenerateTopo, mod.__name__)
     # ... and here it calls Mininet initialization functions.
-
-    # Kill stale mininet routers and process
-    kill_mininet_routers_process(tgen)
 
     # Starting topology, create tmp files which are loaded to routers
     #  to start deamons and then start routers

--- a/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2.py
+++ b/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2.py
@@ -133,7 +133,6 @@ from lib.common_config import (
     check_router_status,
     shutdown_bringup_interface,
     step,
-    kill_mininet_routers_process,
     get_frr_ipv6_linklocal,
     create_route_maps,
     required_linux_kernel_version,

--- a/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
+++ b/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
@@ -128,7 +128,6 @@ from lib.common_config import (
     create_static_routes,
     create_prefix_lists,
     create_interface_in_kernel,
-    kill_mininet_routers_process,
     create_bgp_community_lists,
     check_router_status,
     apply_raw_config,
@@ -228,9 +227,6 @@ def setup_module(mod):
     # This function initiates the topology build with Topogen...
     tgen = Topogen(CreateTopo, mod.__name__)
     # ... and here it calls Mininet initialization functions.
-
-    # Kill stale mininet routers and process
-    kill_mininet_routers_process(tgen)
 
     # Starting topology, create tmp files which are loaded to routers
     #  to start deamons and then start routers

--- a/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
+++ b/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
@@ -87,7 +87,6 @@ from lib.common_config import (
     create_vrf_cfg,
     create_interfaces_cfg,
     create_interface_in_kernel,
-    kill_mininet_routers_process,
     get_frr_ipv6_linklocal,
     check_router_status,
     apply_raw_config,
@@ -181,9 +180,6 @@ def setup_module(mod):
     # This function initiates the topology build with Topogen...
     tgen = Topogen(CreateTopo, mod.__name__)
     # ... and here it calls Mininet initialization functions.
-
-    # Kill stale mininet routers and process
-    kill_mininet_routers_process(tgen)
 
     # Starting topology, create tmp files which are loaded to routers
     #  to start deamons and then start routers

--- a/tests/topotests/bgp_recursive_route_ebgp_multi_hop/test_bgp_recursive_route_ebgp_multi_hop.py
+++ b/tests/topotests/bgp_recursive_route_ebgp_multi_hop/test_bgp_recursive_route_ebgp_multi_hop.py
@@ -71,7 +71,6 @@ from lib.common_config import (
     shutdown_bringup_interface,
     addKernelRoute,
     delete_route_maps,
-    kill_mininet_routers_process,
 )
 from lib.topolog import logger
 from lib.bgp import (

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -401,30 +401,6 @@ def start_router_daemons(tgen, router, daemons):
     return res
 
 
-def kill_mininet_routers_process(tgen):
-    """
-    Kill all mininet stale router' processes
-    * `tgen`  : topogen object
-    """
-
-    router_list = tgen.routers()
-    for rname, router in router_list.items():
-        daemon_list = [
-            "zebra",
-            "ospfd",
-            "ospf6d",
-            "bgpd",
-            "ripd",
-            "ripngd",
-            "isisd",
-            "pimd",
-            "ldpd",
-            "staticd",
-        ]
-        for daemon in daemon_list:
-            router.run("killall -9 {}".format(daemon))
-
-
 def check_router_status(tgen):
     """
     Check if all daemons are running for all routers in topology


### PR DESCRIPTION
This function kills all processes that happen to have the same
name to frr processes and it was only ever used in the setup.
Setup should not be used to kill old runs.  That should be a
separate process.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>