### PR TITLE
bgpd: prevent doppelganger overwrite of subsuquently configured cli

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -294,7 +294,6 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	}
 
 	FOREACH_AFI_SAFI (afi, safi) {
-		peer->af_flags[afi][safi] = from_peer->af_flags[afi][safi];
 		peer->af_sflags[afi][safi] = from_peer->af_sflags[afi][safi];
 		peer->af_cap[afi][safi] = from_peer->af_cap[afi][safi];
 		peer->afc_nego[afi][safi] = from_peer->afc_nego[afi][safi];


### PR DESCRIPTION
If we have a situation where BGP is partially reading in a config
file for a neighbor, *and* the neighbor is coming up *and* we
have a doppelganger.  There exists a race condition when we transfer
the config from the doppelganger to the config peer that we will
overwrite later config because we are copying the config data
from the doppelganger peer( which was captured at the start of initiation
of the peering ).

From what I can tell the peer->af_flags variable is to hold configuration
flags for the local peer.  The doppelganger should never overwrite this.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>
