### PR TITLE
zebra: Proto-NHG Fix Graceful-Restart-Retain Crash Loop

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2559,7 +2559,7 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 	struct nhg_hash_entry *curr_nhe;
 	uint32_t curr_active = 0, backup_active = 0;
 
-	if (re->nhe->id >= ZEBRA_NHG_PROTO_LOWER)
+	if (PROTO_OWNED(re->nhe))
 		return proto_nhg_nexthop_active_update(&re->nhe->nhg);
 
 	afi_t rt_afi = family2afi(rn->p.family);
@@ -2861,13 +2861,13 @@ void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx)
 			zebra_nhg_handle_install(nhe);
 
 			/* If daemon nhg, send it an update */
-			if (nhe->id >= ZEBRA_NHG_PROTO_LOWER)
+			if (PROTO_OWNED(nhe))
 				zsend_nhg_notify(nhe->type, nhe->zapi_instance,
 						 nhe->zapi_session, nhe->id,
 						 ZAPI_NHG_INSTALLED);
 		} else {
 			/* If daemon nhg, send it an update */
-			if (nhe->id >= ZEBRA_NHG_PROTO_LOWER)
+			if (PROTO_OWNED(nhe))
 				zsend_nhg_notify(nhe->type, nhe->zapi_instance,
 						 nhe->zapi_session, nhe->id,
 						 ZAPI_NHG_FAIL_INSTALL);
@@ -3201,7 +3201,7 @@ static void zebra_nhg_score_proto_entry(struct hash_bucket *bucket, void *arg)
 	iter = arg;
 
 	/* Needs to match type and outside zebra ID space */
-	if (nhe->type == iter->type && nhe->id >= ZEBRA_NHG_PROTO_LOWER) {
+	if (nhe->type == iter->type && PROTO_OWNED(nhe)) {
 		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 			zlog_debug(
 				"%s: found nhe %p (%u), vrf %d, type %s after client disconnect",

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -845,6 +845,8 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 		SET_FLAG(backup_nhe->flags, NEXTHOP_GROUP_RECURSIVE);
 
 done:
+	/* Reset time since last update */
+	(*nhe)->uptime = monotime(NULL);
 
 	return created;
 }

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1193,6 +1193,13 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 		zlog_debug("%s: nhe %p (%u) is new", __func__, nhe, nhe->id);
 
+	/*
+	 * If daemon nhg from the kernel, add a refcnt here to indicate the
+	 * daemon owns it.
+	 */
+	if (PROTO_OWNED(nhe))
+		zebra_nhg_increment_ref(nhe);
+
 	SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
 	SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
 
@@ -2929,7 +2936,31 @@ static void zebra_nhg_sweep_entry(struct hash_bucket *bucket, void *arg)
 
 	nhe = (struct nhg_hash_entry *)bucket->data;
 
-	/* If its being ref'd, just let it be uninstalled via a route removal */
+	/*
+	 * same logic as with routes.
+	 *
+	 * If older than startup time, we know we read them in from the
+	 * kernel and have not gotten and update for them since startup
+	 * from an upper level proto.
+	 */
+	if (zrouter.startup_time < nhe->uptime)
+		return;
+
+	/*
+	 * If it's proto-owned and not being used by a route, remove it since
+	 * we haven't gotten an update about it from the proto since startup.
+	 * This means that either the config for it was removed or the daemon
+	 * didn't get started. This handles graceful restart & retain scenario.
+	 */
+	if (PROTO_OWNED(nhe) && nhe->refcnt == 1) {
+		zebra_nhg_decrement_ref(nhe);
+		return;
+	}
+
+	/*
+	 * If its being ref'd by routes, just let it be uninstalled via a route
+	 * removal.
+	 */
 	if (ZEBRA_NHG_CREATED(nhe) && nhe->refcnt <= 0)
 		zebra_nhg_uninstall_kernel(nhe);
 }

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -147,6 +147,8 @@ enum nhg_type {
 /* Is this an NHE owned by zebra and not an upper level protocol? */
 #define ZEBRA_OWNED(NHE) (NHE->type == ZEBRA_ROUTE_NHG)
 
+#define PROTO_OWNED(NHE) (NHE->id >= ZEBRA_NHG_PROTO_LOWER)
+
 /*
  * Backup nexthops: this is a group object itself, so
  * that the backup nexthops can use the same code as a normal object.

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -51,6 +51,9 @@ struct nhg_hash_entry {
 	afi_t afi;
 	vrf_id_t vrf_id;
 
+	/* Time since last update */
+	time_t uptime;
+
 	/* Source protocol - zebra or another daemon */
 	int type;
 


### PR DESCRIPTION
@donaldsharp reported a zebra crash loop during topotest runs. It was caused by graceful restart and retain being turned on while using sharpd to install proto-owned NHGs. We were incorrectly handling the refcnts for proto-owned NHGs we find in the kernel on restart so when we get an update for that ID later, we fail in an assert() we put in to make sure we haven't screwed up the refcnts. 

This PR also includes some QOL patches with including uptime on the NHGs like we do for routes and adding a macro for code read-ability.


The crash:

```
ZEBRA: __assert_fail+0x42                 7f670d43a662     7ffdfc30cf10 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7f670d406000)
ZEBRA: zebra_nhg_proto_add+0x349          55a643e945ca     7ffdfc30cf40 /usr/lib/frr/zebra (mapped at 0x55a643dc0000)
ZEBRA: zread_nhg_add+0x1e1                55a643e5ceaf     7ffdfc30d000 /usr/lib/frr/zebra (mapped at 0x55a643dc0000)
ZEBRA: zserv_handle_commands+0x1fb        55a643e60f2b     7ffdfc315060 /usr/lib/frr/zebra (mapped at 0x55a643dc0000)
ZEBRA: zserv_process_messages+0x107       55a643edd7d4     7ffdfc3150f0 /usr/lib/frr/zebra (mapped at 0x55a643dc0000)
ZEBRA: thread_call+0x1af                  7f670d70c7a0     7ffdfc315160 /lib/libfrr.so.0 (mapped at 0x7f670d616000)
ZEBRA: frr_run+0x217                      7f670d6af266     7ffdfc3153a0 /lib/libfrr.so.0 (mapped at 0x7f670d616000)
ZEBRA: main+0x3da                         55a643e3fe34     7ffdfc3154b0 /usr/lib/frr/zebra (mapped at 0x55a643dc0000)
ZEBRA: __libc_start_main+0xea             7f670d42cd0a     7ffdfc315580 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7f670d406000)
ZEBRA: _start+0x2a                        55a643e2923a     7ffdfc315650 /usr/lib/frr/zebra (mapped at 0x55a643dc0000)
```



To reproduce:

install some sharpd proto NHGs:


```
alfred# c                                                                                                              
alfred(config)# nexthop-group red                                                                                      
alfred(config-nh-group)# nexthop 1.1.1.1 dummy1                                                                                                                                                                                               
alfred(config-nh-group)# nexthop 1.1.1.2 dummy2                                                                                                                                                                                               
alfred(config-nh-group)# 
```


Kill -9 zebra and sharpd.


restart zebra and sharpd with --retain and --graceful_restart 500 on for zebra


Redo the above config and it will crash when sharpd sends the group to zebra due to the bad refcnt.