### PR TITLE
bgpd: fix bgp_get_vty return values

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5382,11 +5382,12 @@ int bgp_evpn_local_l3vni_add(vni_t l3vni, vrf_id_t vrf_id,
 		switch (ret) {
 		case BGP_ERR_AS_MISMATCH:
 			flog_err(EC_BGP_EVPN_AS_MISMATCH,
-				 "BGP is already running; AS is %u", as);
+				 "BGP instance is already running; AS is %u",
+				 as);
 			return -1;
 		case BGP_ERR_INSTANCE_MISMATCH:
 			flog_err(EC_BGP_EVPN_INSTANCE_MISMATCH,
-				 "BGP instance name and AS number mismatch");
+				 "BGP instance type mismatch");
 			return -1;
 		}
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3376,7 +3376,7 @@ int bgp_lookup_by_as_name_type(struct bgp **bgp_val, as_t *as, const char *name,
 	if (bgp) {
 		if (bgp->as != *as) {
 			*as = bgp->as;
-			return BGP_ERR_INSTANCE_MISMATCH;
+			return BGP_ERR_AS_MISMATCH;
 		}
 		if (bgp->inst_type != inst_type)
 			return BGP_ERR_INSTANCE_MISMATCH;
@@ -3397,13 +3397,8 @@ int bgp_get(struct bgp **bgp_val, as_t *as, const char *name,
 	int ret = 0;
 
 	ret = bgp_lookup_by_as_name_type(bgp_val, as, name, inst_type);
-	switch (ret) {
-	case BGP_ERR_INSTANCE_MISMATCH:
+	if (ret || *bgp_val)
 		return ret;
-	case BGP_SUCCESS:
-		if (*bgp_val)
-			return BGP_INSTANCE_EXISTS;
-	}
 
 	bgp = bgp_create(as, name, inst_type);
 	if (bgp_option_check(BGP_OPT_NO_ZEBRA) && name)

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1844,7 +1844,6 @@ enum bgp_clear_type {
 /* BGP error codes.  */
 #define BGP_SUCCESS                               0
 #define BGP_CREATED                               1
-#define BGP_INSTANCE_EXISTS                       2
 #define BGP_ERR_INVALID_VALUE                    -1
 #define BGP_ERR_INVALID_FLAG                     -2
 #define BGP_ERR_INVALID_AS                       -3


### PR DESCRIPTION
There are multiple problems:
- commit ef7c53e2 introduced a new return value 2 which broke things,
  because a lot of code treats non-zero return as an error,
- there is an incorrect error returned when AS number mismatches.

This commit fixes both.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>