### PR TITLE
tests: fix bfd-bgp-cbit-topo3 test

### DIFF
--- a/tests/topotests/bfd-bgp-cbit-topo3/r1/peers_down.json
+++ b/tests/topotests/bfd-bgp-cbit-topo3/r1/peers_down.json
@@ -3,13 +3,13 @@
         "multihop":true,
         "peer":"2001:db8:4::1",
         "local":"2001:db8:1::1",
-        "status":"up",
+        "status":"init",
         "receive-interval":300,
         "transmit-interval":300,
         "echo-receive-interval":50,
         "echo-transmit-interval":0,
-        "remote-receive-interval":300,
-        "remote-transmit-interval":300,
+        "remote-receive-interval":1000,
+        "remote-transmit-interval":1000,
         "remote-echo-receive-interval":50
     }
 ]


### PR DESCRIPTION
This test is completely incorrect on test_bfd_loss_intermediate step.
It shuts down the interface and then "waiting" for the BGP session to
fail. But instead of the actual wait it compares the output of "show bfd
peers" with the "up" state. As it does this comparison right after the
interface shutdown, the BFD session has not yet failed and the comparison
is always successful except very rare cases when the command takes a lot
of time to execute (due to the heavy load on CI system I suppose).

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>