### PR TITLE
ospfd: External lsa handling in opaque capabilities enable/disable

### DIFF
--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -407,6 +407,9 @@ void ospf_renegotiate_optional_capabilities(struct ospf *top)
 		}
 	}
 
+	/* Refresh/Re-originate external LSAs (Type-7 and Type-5).*/
+	ospf_external_lsa_rid_change(top);
+
 	return;
 }
 


### PR DESCRIPTION
Description:
	When opaque capability disabled/enabled , all the self-originated lsa will be
	flushed and it will make the neighbours to renegotiate.
	But here, external lsas are not being re-originated after negotiation.
Fix:
	Refresh/re-originate external lsas(Type-5 and Type-7) explicitly after
	re-negotiation.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>