### PR TITLE
tests: fix build warning

### DIFF
--- a/lib/printfrr.h
+++ b/lib/printfrr.h
@@ -305,8 +305,8 @@ struct va_format {
 
 #define FMT_NSTD(expr)                                                         \
 	({                                                                     \
-		typeof(expr) _v;                                               \
 		FMT_NSTD_BEGIN                                                 \
+		typeof(expr) _v;                                               \
 		_v = expr;                                                     \
 		FMT_NSTD_END                                                   \
 		_v;                                                            \


### PR DESCRIPTION
FMT_NSTD_BEGIN should be before the first use of "expr".

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>