### PR TITLE
doc: isis: document default value for metric-style

### DIFF
--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -77,7 +77,7 @@ writing, *isisd* does not support multiple ISIS processes.
    - transition
      Send and accept both styles of TLVs during transition
    - wide
-     Use new style of TLVs to carry wider metric
+     Use new style of TLVs to carry wider metric. FRR uses this as a default value
 
 .. clicmd:: set-overload-bit
 


### PR DESCRIPTION
This PR aims to add documentation for the default metric-style used for IS-IS.