### PR TITLE
various isis cli fixes

### DIFF
--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -172,7 +172,7 @@ ISIS interface
 
 .. _ip-router-isis-word:
 
-.. clicmd:: <ip|ipv6> router isis WORD [vrf NAME]
+.. clicmd:: <ip|ipv6> router isis WORD
 
    Activate ISIS adjacency on this interface. Note that the name of ISIS
    instance must be the same as the one used to configure the ISIS process (see

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -735,6 +735,9 @@ int isis_circuit_up(struct isis_circuit *circuit)
 
 	circuit->last_uptime = time(NULL);
 
+	if (circuit->area->mta && circuit->area->mta->status)
+		isis_link_params_update(circuit, circuit->interface);
+
 #ifndef FABRICD
 	/* send northbound notification */
 	isis_notif_if_state_change(circuit, false);
@@ -1302,8 +1305,6 @@ struct isis_circuit *isis_circuit_create(struct isis_area *area,
 	if (circuit->state != C_STATE_CONF && circuit->state != C_STATE_UP)
 		return circuit;
 	isis_circuit_if_bind(circuit, ifp);
-	if (circuit->area->mta && circuit->area->mta->status)
-		isis_link_params_update(circuit, ifp);
 
 	return circuit;
 }

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -76,14 +76,12 @@ int isis_if_delete_hook(struct interface *);
 DEFINE_HOOK(isis_circuit_new_hook, (struct isis_circuit *circuit), (circuit));
 DEFINE_HOOK(isis_circuit_del_hook, (struct isis_circuit *circuit), (circuit));
 
-struct isis_circuit *isis_circuit_new(struct isis *isis)
+struct isis_circuit *isis_circuit_new(void)
 {
 	struct isis_circuit *circuit;
 	int i;
 
 	circuit = XCALLOC(MTYPE_ISIS_CIRCUIT, sizeof(struct isis_circuit));
-
-	circuit->isis = isis;
 
 	/*
 	 * Default values
@@ -165,8 +163,6 @@ void isis_circuit_del(struct isis_circuit *circuit)
 
 	hook_call(isis_circuit_del_hook, circuit);
 
-	isis_circuit_if_unbind(circuit, circuit->interface);
-
 	circuit_mt_finish(circuit);
 	isis_lfa_excluded_ifaces_clear(circuit, ISIS_LEVEL1);
 	isis_lfa_excluded_ifaces_clear(circuit, ISIS_LEVEL2);
@@ -181,6 +177,7 @@ void isis_circuit_configure(struct isis_circuit *circuit,
 			    struct isis_area *area)
 {
 	assert(area);
+	circuit->isis = area->isis;
 	circuit->area = area;
 
 	/*
@@ -213,6 +210,7 @@ void isis_circuit_deconfigure(struct isis_circuit *circuit,
 	assert(circuit->area == area);
 	listnode_delete(area->circuit_list, circuit);
 	circuit->area = NULL;
+	circuit->isis = NULL;
 
 	return;
 }
@@ -237,29 +235,7 @@ struct isis_circuit *circuit_lookup_by_ifp(struct interface *ifp,
 
 struct isis_circuit *circuit_scan_by_ifp(struct interface *ifp)
 {
-	struct isis_area *area;
-	struct listnode *node;
-	struct isis_circuit *circuit;
-	struct isis *isis = NULL;
-
-	if (ifp->info)
-		return (struct isis_circuit *)ifp->info;
-
-	isis = isis_lookup_by_vrfid(ifp->vrf_id);
-	if (isis == NULL) {
-		zlog_warn(" %s : ISIS routing instance not found", __func__);
-		return NULL;
-	}
-
-	if (isis->area_list) {
-		for (ALL_LIST_ELEMENTS_RO(isis->area_list, node, area)) {
-			circuit =
-				circuit_lookup_by_ifp(ifp, area->circuit_list);
-			if (circuit)
-				return circuit;
-		}
-	}
-	return circuit_lookup_by_ifp(ifp, isis->init_circ_list);
+	return (struct isis_circuit *)ifp->info;
 }
 
 DEFINE_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *circuit),
@@ -468,8 +444,6 @@ void isis_circuit_if_add(struct isis_circuit *circuit, struct interface *ifp)
 {
 	struct listnode *node, *nnode;
 	struct connected *conn;
-
-	isis_circuit_if_bind(circuit, ifp);
 
 	if (if_is_broadcast(ifp)) {
 		if (fabricd || circuit->circ_type_config == CIRCUIT_T_P2P)
@@ -1294,19 +1268,27 @@ static int isis_interface_config_write(struct vty *vty)
 }
 #endif /* ifdef FABRICD */
 
-struct isis_circuit *isis_circuit_create(struct isis_area *area,
-					 struct interface *ifp)
+void isis_circuit_tag_set(struct isis_circuit *circuit, const char *tag)
 {
-	struct isis_circuit *circuit = circuit_scan_by_ifp(ifp);
+	struct interface *ifp = circuit->interface;
+	struct isis_area *area;
 
-	if (circuit && circuit->area)
-		return NULL;
-	circuit = isis_csm_state_change(ISIS_ENABLE, circuit, area);
-	if (circuit->state != C_STATE_CONF && circuit->state != C_STATE_UP)
-		return circuit;
-	isis_circuit_if_bind(circuit, ifp);
+	circuit->tag = XSTRDUP(MTYPE_ISIS_CIRCUIT, tag);
 
-	return circuit;
+	if (ifp->ifindex == IFINDEX_INTERNAL)
+		return;
+
+	area = isis_area_lookup(tag, ifp->vrf_id);
+	if (area)
+		isis_csm_state_change(ISIS_ENABLE, circuit, area);
+}
+
+void isis_circuit_tag_unset(struct isis_circuit *circuit)
+{
+	if (circuit->area)
+		isis_csm_state_change(ISIS_DISABLE, circuit, circuit->area);
+
+	XFREE(MTYPE_ISIS_CIRCUIT, circuit->tag);
 }
 
 void isis_circuit_af_set(struct isis_circuit *circuit, bool ip_router,
@@ -1324,24 +1306,13 @@ void isis_circuit_af_set(struct isis_circuit *circuit, bool ip_router,
 	circuit->ipv6_router = ipv6_router;
 	circuit_update_nlpids(circuit);
 
-	/* the area should always be there if we get here, but in the past
-	 * there were corner cases where the area was NULL (e.g. because the
-	 * circuit was deconfigured following a validation error). Do not
-	 * segfault if this happens again.
-	 */
-	if (!area) {
-		zlog_err("%s: NULL area for circuit %u", __func__,
-			 circuit->circuit_id);
-		return;
+	if (area) {
+		area->ip_circuits += ip_router - old_ipr;
+		area->ipv6_circuits += ipv6_router - old_ipv6r;
+
+		if (ip_router || ipv6_router)
+			lsp_regenerate_schedule(area, circuit->is_type, 0);
 	}
-
-	area->ip_circuits += ip_router - old_ipr;
-	area->ipv6_circuits += ipv6_router - old_ipv6r;
-
-	if (!ip_router && !ipv6_router)
-		isis_csm_state_change(ISIS_DISABLE, circuit, area);
-	else
-		lsp_regenerate_schedule(area, circuit->is_type, 0);
 }
 
 ferr_r isis_circuit_passive_set(struct isis_circuit *circuit, bool passive)
@@ -1463,8 +1434,9 @@ int isis_circuit_mt_enabled_set(struct isis_circuit *circuit, uint16_t mtid,
 	setting = circuit_get_mt_setting(circuit, mtid);
 	if (setting->enabled != enabled) {
 		setting->enabled = enabled;
-		lsp_regenerate_schedule(circuit->area, IS_LEVEL_1 | IS_LEVEL_2,
-					0);
+		if (circuit->area)
+			lsp_regenerate_schedule(circuit->area,
+						IS_LEVEL_1 | IS_LEVEL_2, 0);
 	}
 
 	return CMD_SUCCESS;
@@ -1472,32 +1444,40 @@ int isis_circuit_mt_enabled_set(struct isis_circuit *circuit, uint16_t mtid,
 
 int isis_if_new_hook(struct interface *ifp)
 {
+	struct isis_circuit *circuit;
+
+	circuit = isis_circuit_new();
+	isis_circuit_if_bind(circuit, ifp);
+
 	return 0;
 }
 
 int isis_if_delete_hook(struct interface *ifp)
 {
-	struct isis_circuit *circuit;
-	/* Clean up the circuit data */
-	if (ifp && ifp->info) {
-		circuit = ifp->info;
-		isis_csm_state_change(IF_DOWN_FROM_Z, circuit, ifp);
-	}
+	struct isis_circuit *circuit = ifp->info;
+
+	isis_circuit_if_unbind(circuit, ifp);
+	isis_circuit_del(circuit);
 
 	return 0;
 }
 
 static int isis_ifp_create(struct interface *ifp)
 {
-	struct vrf *vrf = NULL;
+	struct isis_circuit *circuit = ifp->info;
+	struct isis_area *area;
 
-	if (if_is_operative(ifp)) {
-		vrf = vrf_lookup_by_id(ifp->vrf_id);
-		if (vrf)
-			isis_global_instance_create(vrf->name);
-		isis_csm_state_change(IF_UP_FROM_Z, circuit_scan_by_ifp(ifp),
-				      ifp);
+	zlog_debug("%s %s", __func__, ifp->name);
+
+	if (circuit->tag) {
+		area = isis_area_lookup(circuit->tag, ifp->vrf_id);
+		if (area)
+			isis_area_add_circuit(area, circuit);
 	}
+
+	if (if_is_operative(ifp))
+		isis_csm_state_change(IF_UP_FROM_Z, circuit, ifp);
+
 	hook_call(isis_if_new_hook, ifp);
 
 	return 0;
@@ -1505,18 +1485,24 @@ static int isis_ifp_create(struct interface *ifp)
 
 static int isis_ifp_up(struct interface *ifp)
 {
-	isis_csm_state_change(IF_UP_FROM_Z, circuit_scan_by_ifp(ifp), ifp);
+	struct isis_circuit *circuit = ifp->info;
+
+	zlog_debug("%s %s", __func__, ifp->name);
+
+	isis_csm_state_change(IF_UP_FROM_Z, circuit, ifp);
 
 	return 0;
 }
 
 static int isis_ifp_down(struct interface *ifp)
 {
-	struct isis_circuit *circuit;
+	struct isis_circuit *circuit = ifp->info;
 
-	circuit = isis_csm_state_change(IF_DOWN_FROM_Z,
-					circuit_scan_by_ifp(ifp), ifp);
-	if (circuit)
+	zlog_debug("%s %s", __func__, ifp->name);
+
+	isis_csm_state_change(IF_DOWN_FROM_Z, circuit, ifp);
+
+	if (circuit->state != C_STATE_NA)
 		SET_FLAG(circuit->flags, ISIS_CIRCUIT_FLAPPED_AFTER_SPF);
 
 	return 0;
@@ -1524,15 +1510,15 @@ static int isis_ifp_down(struct interface *ifp)
 
 static int isis_ifp_destroy(struct interface *ifp)
 {
+	struct isis_circuit *circuit = ifp->info;
+
+	zlog_debug("%s %s", __func__, ifp->name);
+
 	if (if_is_operative(ifp))
-		zlog_warn("Zebra: got delete of %s, but interface is still up",
-			  ifp->name);
+		isis_csm_state_change(IF_DOWN_FROM_Z, circuit, ifp);
 
-	isis_csm_state_change(IF_DOWN_FROM_Z, circuit_scan_by_ifp(ifp), ifp);
-
-	/* Cannot call if_delete because we should retain the pseudo interface
-	   in case there is configuration info attached to it. */
-	if_delete_retain(ifp);
+	if (circuit->area)
+		isis_area_del_circuit(circuit->area, circuit);
 
 	return 0;
 }

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -238,4 +238,7 @@ DECLARE_HOOK(isis_circuit_config_write,
 DECLARE_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *circuit),
 	     (circuit));
 
+DECLARE_HOOK(isis_circuit_new_hook, (struct isis_circuit *circuit), (circuit));
+DECLARE_HOOK(isis_circuit_del_hook, (struct isis_circuit *circuit), (circuit));
+
 #endif /* _ZEBRA_ISIS_CIRCUIT_H */

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -122,6 +122,7 @@ struct isis_circuit {
 	/*
 	 * Configurables
 	 */
+	char *tag; /* area tag */
 	struct isis_passwd passwd;     /* Circuit rx/tx password */
 	int is_type;		       /* circuit is type == level of circuit
 					* differentiated from circuit type (media) */
@@ -180,7 +181,7 @@ struct isis_circuit {
 DECLARE_QOBJ_TYPE(isis_circuit);
 
 void isis_circuit_init(void);
-struct isis_circuit *isis_circuit_new(struct isis *isis);
+struct isis_circuit *isis_circuit_new(void);
 void isis_circuit_del(struct isis_circuit *circuit);
 struct isis_circuit *circuit_lookup_by_ifp(struct interface *ifp,
 					   struct list *list);
@@ -207,8 +208,8 @@ void isis_circuit_print_vty(struct isis_circuit *circuit, struct vty *vty,
 size_t isis_circuit_pdu_size(struct isis_circuit *circuit);
 void isis_circuit_stream(struct isis_circuit *circuit, struct stream **stream);
 
-struct isis_circuit *isis_circuit_create(struct isis_area *area,
-					 struct interface *ifp);
+void isis_circuit_tag_set(struct isis_circuit *circuit, const char *tag);
+void isis_circuit_tag_unset(struct isis_circuit *circuit);
 void isis_circuit_af_set(struct isis_circuit *circuit, bool ip_router,
 			 bool ipv6_router);
 ferr_r isis_circuit_passive_set(struct isis_circuit *circuit, bool passive);

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -62,19 +62,7 @@ DEFPY_YANG_NOSH(router_isis, router_isis_cmd,
 		 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']", tag,
 		 vrf_name);
 	nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
-	/* default value in yang for is-type is level-1, but in FRR
-	 * the first instance is assigned is-type level-1-2. We
-	 * need to make sure to set it in the yang model so that it
-	 * is consistent with what FRR sees.
-	 */
 
-	if (!im) {
-		return CMD_SUCCESS;
-	}
-
-	if (listcount(im->isis) == 0)
-		nb_cli_enqueue_change(vty, "./is-type", NB_OP_MODIFY,
-				      "level-1-2");
 	ret = nb_cli_apply_changes(vty, base_xpath);
 	if (ret == CMD_SUCCESS)
 		VTY_PUSH_XPATH(ISIS_NODE, base_xpath);
@@ -190,13 +178,6 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 			 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
 			 tag, vrf_name);
 		nb_cli_enqueue_change(vty, temp_xpath, NB_OP_CREATE, tag);
-		snprintf(
-			temp_xpath, XPATH_MAXLEN,
-			"/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']/is-type",
-			tag, vrf_name);
-		nb_cli_enqueue_change(vty, temp_xpath, NB_OP_MODIFY,
-				      listcount(im->isis) == 0 ? "level-1-2"
-							       : NULL);
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE,
 				      NULL);
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag",
@@ -206,9 +187,6 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 				      vrf_name);
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv4-routing",
 				      NB_OP_MODIFY, "true");
-		nb_cli_enqueue_change(
-			vty, "./frr-isisd:isis/circuit-type", NB_OP_MODIFY,
-			listcount(im->isis) == 0 ? "level-1-2" : "level-1");
 	} else {
 		/* area exists, circuit type defaults to its area's is_type */
 		switch (area->is_type) {
@@ -287,13 +265,6 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 			 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
 			 tag, vrf_name);
 		nb_cli_enqueue_change(vty, temp_xpath, NB_OP_CREATE, tag);
-		snprintf(
-			temp_xpath, XPATH_MAXLEN,
-			"/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']/is-type",
-			tag, vrf_name);
-		nb_cli_enqueue_change(vty, temp_xpath, NB_OP_MODIFY,
-				      listcount(im->isis) == 0 ? "level-1-2"
-							       : NULL);
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE,
 				      NULL);
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag",
@@ -303,9 +274,6 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv6-routing",
 				      NB_OP_MODIFY, "true");
-		nb_cli_enqueue_change(
-			vty, "./frr-isisd:isis/circuit-type", NB_OP_MODIFY,
-			listcount(im->isis) == 0 ? "level-1-2" : "level-1");
 	} else {
 		/* area exists, circuit type defaults to its area's is_type */
 		switch (area->is_type) {

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -188,7 +188,6 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 
 	area = isis_area_lookup_by_vrf(tag, vrf_name);
 	if (!area) {
-		isis_global_instance_create(vrf_name);
 		snprintf(temp_xpath, XPATH_MAXLEN,
 			 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
 			 tag, vrf_name);
@@ -275,7 +274,6 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 
 	area = isis_area_lookup_by_vrf(tag, vrf_name);
 	if (!area) {
-		isis_global_instance_create(vrf_name);
 		snprintf(temp_xpath, XPATH_MAXLEN,
 			 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
 			 tag, vrf_name);

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -2505,50 +2505,42 @@ DEFPY_YANG(no_isis_circuit_type, no_isis_circuit_type_cmd,
       "Level-1-2 adjacencies are formed\n"
       "Level-2 only adjacencies are formed\n")
 {
-	struct interface *ifp;
-	struct isis_circuit *circuit;
-	int is_type;
-	const char *circ_type;
+	char inst_xpath[XPATH_MAXLEN];
+	struct lyd_node *if_dnode, *inst_dnode;
+	const char *vrf_name;
+	const char *tag;
+	const char *circ_type = NULL;
 
 	/*
 	 * Default value depends on whether the circuit is part of an area,
 	 * and the is-type of the area if there is one. So we need to do this
 	 * here.
 	 */
-	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
-	if (!ifp)
-		goto def_val;
-
-	circuit = circuit_scan_by_ifp(ifp);
-	if (!circuit)
-		goto def_val;
-
-	if (circuit->state == C_STATE_UP)
-		is_type = circuit->area->is_type;
-	else
-		goto def_val;
-
-	switch (is_type) {
-	case IS_LEVEL_1:
-		circ_type = "level-1";
-		break;
-	case IS_LEVEL_2:
-		circ_type = "level-2";
-		break;
-	case IS_LEVEL_1_AND_2:
-		circ_type = "level-1-2";
-		break;
-	default:
-		return CMD_ERR_NO_MATCH;
+	if_dnode = yang_dnode_get(vty->candidate_config->dnode,
+				  VTY_CURR_XPATH);
+	if (!if_dnode) {
+		vty_out(vty, "%% Failed to get iface dnode in candidate DB\n");
+		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	if (!yang_dnode_exists(if_dnode, "frr-isisd:isis/area-tag")) {
+		vty_out(vty, "%% ISIS is not configured on the interface\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	vrf_name = yang_dnode_get_string(if_dnode, "vrf");
+	tag = yang_dnode_get_string(if_dnode, "frr-isisd:isis/area-tag");
+
+	snprintf(inst_xpath, XPATH_MAXLEN,
+		 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
+		 tag, vrf_name);
+
+	inst_dnode = yang_dnode_get(vty->candidate_config->dnode, inst_xpath);
+	if (inst_dnode)
+		circ_type = yang_dnode_get_string(inst_dnode, "is-type");
+
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis/circuit-type",
 			      NB_OP_MODIFY, circ_type);
-
-	return nb_cli_apply_changes(vty, NULL);
-
-def_val:
-	nb_cli_enqueue_change(vty, "./frr-isisd:isis/circuit-type",
-			      NB_OP_MODIFY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -70,16 +70,42 @@ DEFPY_YANG_NOSH(router_isis, router_isis_cmd,
 	return ret;
 }
 
+struct if_iter {
+	struct vty *vty;
+	const char *tag;
+};
+
+static int if_iter_cb(const struct lyd_node *dnode, void *arg)
+{
+	struct if_iter *iter = arg;
+	const char *tag;
+
+	if (!yang_dnode_exists(dnode, "frr-isisd:isis/area-tag"))
+		return YANG_ITER_CONTINUE;
+
+	tag = yang_dnode_get_string(dnode, "frr-isisd:isis/area-tag");
+	if (strmatch(tag, iter->tag)) {
+		char xpath[XPATH_MAXLEN];
+		const char *name = yang_dnode_get_string(dnode, "name");
+		const char *vrf = yang_dnode_get_string(dnode, "vrf");
+
+		snprintf(
+			xpath, XPATH_MAXLEN,
+			"/frr-interface:lib/interface[name='%s'][vrf='%s']/frr-isisd:isis",
+			name, vrf);
+		nb_cli_enqueue_change(iter->vty, xpath, NB_OP_DESTROY, NULL);
+	}
+
+	return YANG_ITER_CONTINUE;
+}
+
 DEFPY_YANG(no_router_isis, no_router_isis_cmd,
 	   "no router isis WORD$tag [vrf NAME$vrf_name]",
 	   NO_STR ROUTER_STR
 	   "ISO IS-IS\n"
 	   "ISO Routing area tag\n" VRF_CMD_HELP_STR)
 {
-	char temp_xpath[XPATH_MAXLEN];
-	struct listnode *node, *nnode;
-	struct isis_circuit *circuit = NULL;
-	struct isis_area *area = NULL;
+	struct if_iter iter;
 
 	if (!vrf_name)
 		vrf_name = VRF_DEFAULT_NAME;
@@ -92,24 +118,13 @@ DEFPY_YANG(no_router_isis, no_router_isis_cmd,
 		return CMD_ERR_NOTHING_TODO;
 	}
 
+	iter.vty = vty;
+	iter.tag = tag;
+
+	yang_dnode_iterate(if_iter_cb, &iter, vty->candidate_config->dnode,
+		"/frr-interface:lib/interface[vrf='%s']", vrf_name);
+
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
-	area = isis_area_lookup_by_vrf(tag, vrf_name);
-	if (area && area->circuit_list && listcount(area->circuit_list)) {
-		for (ALL_LIST_ELEMENTS(area->circuit_list, node, nnode,
-				       circuit)) {
-			/* add callbacks to delete each of the circuits listed
-			 */
-			const char *vrf_name =
-				vrf_lookup_by_id(circuit->interface->vrf_id)
-					->name;
-			snprintf(
-				temp_xpath, XPATH_MAXLEN,
-				"/frr-interface:lib/interface[name='%s'][vrf='%s']/frr-isisd:isis",
-				circuit->interface->name, vrf_name);
-			nb_cli_enqueue_change(vty, temp_xpath, NB_OP_DESTROY,
-					      NULL);
-		}
-	}
 
 	return nb_cli_apply_changes(
 		vty, "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']", tag,

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -159,78 +159,44 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 	   "IS-IS routing protocol\n"
 	   "Routing process tag\n" VRF_CMD_HELP_STR)
 {
-	char temp_xpath[XPATH_MAXLEN];
-	const char *circ_type;
-	struct isis_area *area = NULL;
+	char inst_xpath[XPATH_MAXLEN];
+	struct lyd_node *if_dnode, *inst_dnode;
+	const char *circ_type = NULL;
 	struct interface *ifp;
-	struct vrf *vrf;
 
-	/* area will be created if it is not present. make sure the yang model
-	 * is synced with FRR and call the appropriate NB cb.
-	 */
-
-	if (!im) {
-		return CMD_SUCCESS;
-	}
-	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
-	if (!vrf_name) {
-		if (ifp) {
-			if (ifp->vrf_id == VRF_DEFAULT)
-				vrf_name = VRF_DEFAULT_NAME;
-			else {
-				vrf = vrf_lookup_by_id(ifp->vrf_id);
-				if (vrf && !vrf_name)
-					vrf_name = vrf->name;
-			}
-		} else
-			vrf_name = VRF_DEFAULT_NAME;
+	if_dnode = yang_dnode_get(vty->candidate_config->dnode,
+				  VTY_CURR_XPATH);
+	if (!if_dnode) {
+		vty_out(vty, "%% Failed to get iface dnode in candidate DB\n");
+		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	area = isis_area_lookup_by_vrf(tag, vrf_name);
-	if (!area) {
-		snprintf(temp_xpath, XPATH_MAXLEN,
-			 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
-			 tag, vrf_name);
-		nb_cli_enqueue_change(vty, temp_xpath, NB_OP_CREATE, tag);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE,
-				      NULL);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag",
-				      NB_OP_MODIFY, tag);
+	vrf_name = yang_dnode_get_string(if_dnode, "vrf");
 
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/vrf", NB_OP_MODIFY,
-				      vrf_name);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv4-routing",
-				      NB_OP_MODIFY, "true");
-	} else {
-		/* area exists, circuit type defaults to its area's is_type */
-		switch (area->is_type) {
-		case IS_LEVEL_1:
-			circ_type = "level-1";
-			break;
-		case IS_LEVEL_2:
-			circ_type = "level-2";
-			break;
-		case IS_LEVEL_1_AND_2:
-			circ_type = "level-1-2";
-			break;
-		default:
-			/* just to silence compiler warnings */
-			return CMD_WARNING_CONFIG_FAILED;
-		}
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE,
-				      NULL);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag",
-				      NB_OP_MODIFY, tag);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/vrf", NB_OP_MODIFY,
-				      vrf_name);
+	snprintf(inst_xpath, XPATH_MAXLEN,
+		 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
+		 tag, vrf_name);
 
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv4-routing",
-				      NB_OP_MODIFY, "true");
+	/* if instance exists then inherit its type, create it otherwise */
+	inst_dnode = yang_dnode_get(vty->candidate_config->dnode, inst_xpath);
+	if (inst_dnode)
+		circ_type = yang_dnode_get_string(inst_dnode, "is-type");
+	else
+		nb_cli_enqueue_change(vty, inst_xpath, NB_OP_CREATE, NULL);
+
+	nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE, NULL);
+	nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag", NB_OP_MODIFY,
+			      tag);
+	nb_cli_enqueue_change(vty, "./frr-isisd:isis/vrf", NB_OP_MODIFY,
+			      vrf_name);
+	nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv4-routing",
+			      NB_OP_MODIFY, "true");
+	if (circ_type)
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/circuit-type",
 				      NB_OP_MODIFY, circ_type);
-	}
 
 	/* check if the interface is a loopback and if so set it as passive */
+	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
 	if (ifp && if_is_loopback(ifp))
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/passive",
 				      NB_OP_MODIFY, "true");
@@ -245,77 +211,44 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 	   "IS-IS routing protocol\n"
 	   "Routing process tag\n" VRF_CMD_HELP_STR)
 {
-	char temp_xpath[XPATH_MAXLEN];
-	const char *circ_type;
+	char inst_xpath[XPATH_MAXLEN];
+	struct lyd_node *if_dnode, *inst_dnode;
+	const char *circ_type = NULL;
 	struct interface *ifp;
-	struct isis_area *area;
-	struct vrf *vrf;
 
-	/* area will be created if it is not present. make sure the yang model
-	 * is synced with FRR and call the appropriate NB cb.
-	 */
-
-	if (!im)
-		return CMD_SUCCESS;
-
-	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
-	if (!vrf_name) {
-		if (ifp) {
-			if (ifp->vrf_id == VRF_DEFAULT)
-				vrf_name = VRF_DEFAULT_NAME;
-			else {
-				vrf = vrf_lookup_by_id(ifp->vrf_id);
-				if (vrf && !vrf_name)
-					vrf_name = vrf->name;
-			}
-		} else
-			vrf_name = VRF_DEFAULT_NAME;
+	if_dnode = yang_dnode_get(vty->candidate_config->dnode,
+				  VTY_CURR_XPATH);
+	if (!if_dnode) {
+		vty_out(vty, "%% Failed to get iface dnode in candidate DB\n");
+		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	area = isis_area_lookup_by_vrf(tag, vrf_name);
-	if (!area) {
-		snprintf(temp_xpath, XPATH_MAXLEN,
-			 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
-			 tag, vrf_name);
-		nb_cli_enqueue_change(vty, temp_xpath, NB_OP_CREATE, tag);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE,
-				      NULL);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag",
-				      NB_OP_MODIFY, tag);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/vrf", NB_OP_MODIFY,
-				      vrf_name);
+	vrf_name = yang_dnode_get_string(if_dnode, "vrf");
 
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv6-routing",
-				      NB_OP_MODIFY, "true");
-	} else {
-		/* area exists, circuit type defaults to its area's is_type */
-		switch (area->is_type) {
-		case IS_LEVEL_1:
-			circ_type = "level-1";
-			break;
-		case IS_LEVEL_2:
-			circ_type = "level-2";
-			break;
-		case IS_LEVEL_1_AND_2:
-			circ_type = "level-1-2";
-			break;
-		default:
-			/* just to silence compiler warnings */
-			return CMD_WARNING_CONFIG_FAILED;
-		}
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE,
-				      NULL);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag",
-				      NB_OP_MODIFY, tag);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/vrf", NB_OP_MODIFY,
-				      vrf_name);
-		nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv6-routing",
-				      NB_OP_MODIFY, "true");
+	snprintf(inst_xpath, XPATH_MAXLEN,
+		 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
+		 tag, vrf_name);
+
+	/* if instance exists then inherit its type, create it otherwise */
+	inst_dnode = yang_dnode_get(vty->candidate_config->dnode, inst_xpath);
+	if (inst_dnode)
+		circ_type = yang_dnode_get_string(inst_dnode, "is-type");
+	else
+		nb_cli_enqueue_change(vty, inst_xpath, NB_OP_CREATE, NULL);
+
+	nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE, NULL);
+	nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag", NB_OP_MODIFY,
+			      tag);
+	nb_cli_enqueue_change(vty, "./frr-isisd:isis/vrf", NB_OP_MODIFY,
+			      vrf_name);
+	nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv6-routing",
+			      NB_OP_MODIFY, "true");
+	if (circ_type)
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/circuit-type",
 				      NB_OP_MODIFY, circ_type);
-	}
 
 	/* check if the interface is a loopback and if so set it as passive */
+	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
 	if (ifp && if_is_loopback(ifp))
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/passive",
 				      NB_OP_MODIFY, "true");

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -153,15 +153,16 @@ void cli_show_router_isis(struct vty *vty, struct lyd_node *dnode,
  * XPath: /frr-isisd:isis/instance
  */
 DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
-	   "ip router isis WORD$tag [vrf NAME$vrf_name]",
+	   "ip router isis WORD$tag",
 	   "Interface Internet Protocol config commands\n"
 	   "IP router interface commands\n"
 	   "IS-IS routing protocol\n"
-	   "Routing process tag\n" VRF_CMD_HELP_STR)
+	   "Routing process tag\n")
 {
 	char inst_xpath[XPATH_MAXLEN];
 	struct lyd_node *if_dnode, *inst_dnode;
 	const char *circ_type = NULL;
+	const char *vrf_name;
 	struct interface *ifp;
 
 	if_dnode = yang_dnode_get(vty->candidate_config->dnode,
@@ -187,8 +188,6 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE, NULL);
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag", NB_OP_MODIFY,
 			      tag);
-	nb_cli_enqueue_change(vty, "./frr-isisd:isis/vrf", NB_OP_MODIFY,
-			      vrf_name);
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv4-routing",
 			      NB_OP_MODIFY, "true");
 	if (circ_type)
@@ -204,16 +203,24 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+ALIAS_HIDDEN(ip_router_isis, ip_router_isis_vrf_cmd,
+	     "ip router isis WORD$tag vrf NAME$vrf_name",
+	     "Interface Internet Protocol config commands\n"
+	     "IP router interface commands\n"
+	     "IS-IS routing protocol\n"
+	     "Routing process tag\n" VRF_CMD_HELP_STR)
+
 DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
-	   "ipv6 router isis WORD$tag [vrf NAME$vrf_name]",
+	   "ipv6 router isis WORD$tag",
 	   "Interface Internet Protocol config commands\n"
 	   "IP router interface commands\n"
 	   "IS-IS routing protocol\n"
-	   "Routing process tag\n" VRF_CMD_HELP_STR)
+	   "Routing process tag\n")
 {
 	char inst_xpath[XPATH_MAXLEN];
 	struct lyd_node *if_dnode, *inst_dnode;
 	const char *circ_type = NULL;
+	const char *vrf_name;
 	struct interface *ifp;
 
 	if_dnode = yang_dnode_get(vty->candidate_config->dnode,
@@ -239,8 +246,6 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE, NULL);
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag", NB_OP_MODIFY,
 			      tag);
-	nb_cli_enqueue_change(vty, "./frr-isisd:isis/vrf", NB_OP_MODIFY,
-			      vrf_name);
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv6-routing",
 			      NB_OP_MODIFY, "true");
 	if (circ_type)
@@ -256,15 +261,21 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+ALIAS_HIDDEN(ip6_router_isis, ip6_router_isis_vrf_cmd,
+	     "ipv6 router isis WORD$tag vrf NAME$vrf_name",
+	     "Interface Internet Protocol config commands\n"
+	     "IP router interface commands\n"
+	     "IS-IS routing protocol\n"
+	     "Routing process tag\n" VRF_CMD_HELP_STR)
+
 DEFPY_YANG(no_ip_router_isis, no_ip_router_isis_cmd,
-	   "no <ip|ipv6>$ip router isis [WORD]$tag [vrf NAME$vrf_name]",
+	   "no <ip|ipv6>$ip router isis [WORD]$tag",
 	   NO_STR
 	   "Interface Internet Protocol config commands\n"
 	   "IP router interface commands\n"
 	   "IP router interface commands\n"
 	   "IS-IS routing protocol\n"
-	   "Routing process tag\n"
-	   VRF_CMD_HELP_STR)
+	   "Routing process tag\n")
 {
 	const struct lyd_node *dnode;
 
@@ -297,36 +308,32 @@ DEFPY_YANG(no_ip_router_isis, no_ip_router_isis_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+ALIAS_HIDDEN(no_ip_router_isis, no_ip_router_isis_vrf_cmd,
+	     "no <ip|ipv6>$ip router isis WORD$tag vrf NAME$vrf_name",
+	     NO_STR
+	     "Interface Internet Protocol config commands\n"
+	     "IP router interface commands\n"
+	     "IP router interface commands\n"
+	     "IS-IS routing protocol\n"
+	     "Routing process tag\n"
+	     VRF_CMD_HELP_STR)
+
 void cli_show_ip_isis_ipv4(struct vty *vty, struct lyd_node *dnode,
 			   bool show_defaults)
 {
-	const char *vrf;
-
-	vrf = yang_dnode_get_string(dnode, "../vrf");
-
 	if (!yang_dnode_get_bool(dnode, NULL))
 		vty_out(vty, " no");
-	vty_out(vty, " ip router isis %s",
+	vty_out(vty, " ip router isis %s\n",
 		yang_dnode_get_string(dnode, "../area-tag"));
-	if (!strmatch(vrf, VRF_DEFAULT_NAME))
-		vty_out(vty, " vrf %s", vrf);
-	vty_out(vty, "\n");
 }
 
 void cli_show_ip_isis_ipv6(struct vty *vty, struct lyd_node *dnode,
 			   bool show_defaults)
 {
-	const char *vrf;
-
-	vrf = yang_dnode_get_string(dnode, "../vrf");
-
 	if (!yang_dnode_get_bool(dnode, NULL))
 		vty_out(vty, " no");
-	vty_out(vty, " ipv6 router isis %s",
+	vty_out(vty, " ipv6 router isis %s\n",
 		yang_dnode_get_string(dnode, "../area-tag"));
-	if (!strmatch(vrf, VRF_DEFAULT_NAME))
-		vty_out(vty, " vrf %s", vrf);
-	vty_out(vty, "\n");
 }
 
 /*
@@ -3176,8 +3183,11 @@ void isis_cli_init(void)
 	install_element(CONFIG_NODE, &no_router_isis_cmd);
 
 	install_element(INTERFACE_NODE, &ip_router_isis_cmd);
+	install_element(INTERFACE_NODE, &ip_router_isis_vrf_cmd);
 	install_element(INTERFACE_NODE, &ip6_router_isis_cmd);
+	install_element(INTERFACE_NODE, &ip6_router_isis_vrf_cmd);
 	install_element(INTERFACE_NODE, &no_ip_router_isis_cmd);
+	install_element(INTERFACE_NODE, &no_ip_router_isis_vrf_cmd);
 	install_element(INTERFACE_NODE, &isis_bfd_cmd);
 	install_element(INTERFACE_NODE, &isis_bfd_profile_cmd);
 

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -3060,23 +3060,11 @@ DEFPY(isis_mpls_if_ldp_sync, isis_mpls_if_ldp_sync_cmd,
       NO_STR "IS-IS routing protocol\n" MPLS_STR MPLS_LDP_SYNC_STR)
 {
 	const struct lyd_node *dnode;
-	struct interface *ifp;
 
 	dnode = yang_dnode_get(vty->candidate_config->dnode,
 			       "%s/frr-isisd:isis", VTY_CURR_XPATH);
 	if (dnode == NULL) {
 		vty_out(vty, "ISIS is not enabled on this circuit\n");
-		return CMD_SUCCESS;
-	}
-
-	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
-	if (if_is_loopback(ifp)) {
-		vty_out(vty, "ldp-sync does not run on loopback interface\n");
-		return CMD_SUCCESS;
-	}
-
-	if (ifp->vrf_id != VRF_DEFAULT) {
-		vty_out(vty, "ldp-sync only runs on DEFAULT VRF\n");
 		return CMD_SUCCESS;
 	}
 
@@ -3103,23 +3091,11 @@ DEFPY(isis_mpls_if_ldp_sync_holddown, isis_mpls_if_ldp_sync_holddown_cmd,
       "Time in seconds\n")
 {
 	const struct lyd_node *dnode;
-	struct interface *ifp;
 
 	dnode = yang_dnode_get(vty->candidate_config->dnode,
 			       "%s/frr-isisd:isis", VTY_CURR_XPATH);
 	if (dnode == NULL) {
 		vty_out(vty, "ISIS is not enabled on this circuit\n");
-		return CMD_SUCCESS;
-	}
-
-	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
-	if (if_is_loopback(ifp)) {
-		vty_out(vty, "ldp-sync does not run on loopback interface\n");
-		return CMD_SUCCESS;
-	}
-
-	if (ifp->vrf_id != VRF_DEFAULT) {
-		vty_out(vty, "ldp-sync only runs on DEFAULT VRF\n");
 		return CMD_SUCCESS;
 	}
 
@@ -3135,23 +3111,11 @@ DEFPY(no_isis_mpls_if_ldp_sync_holddown, no_isis_mpls_if_ldp_sync_holddown_cmd,
 	      NO_MPLS_LDP_SYNC_HOLDDOWN_STR "Time in seconds\n")
 {
 	const struct lyd_node *dnode;
-	struct interface *ifp;
 
 	dnode = yang_dnode_get(vty->candidate_config->dnode,
 			       "%s/frr-isisd:isis", VTY_CURR_XPATH);
 	if (dnode == NULL) {
 		vty_out(vty, "ISIS is not enabled on this circuit\n");
-		return CMD_SUCCESS;
-	}
-
-	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
-	if (if_is_loopback(ifp)) {
-		vty_out(vty, "ldp-sync does not run on loopback interface\n");
-		return CMD_SUCCESS;
-	}
-
-	if (ifp->vrf_id != VRF_DEFAULT) {
-		vty_out(vty, "ldp-sync only runs on DEFAULT VRF\n");
 		return CMD_SUCCESS;
 	}
 

--- a/isisd/isis_csm.c
+++ b/isisd/isis_csm.c
@@ -65,40 +65,29 @@ struct isis_circuit *isis_csm_state_change(enum isis_circuit_event event,
 					   void *arg)
 {
 	enum isis_circuit_state old_state;
-	struct isis *isis = NULL;
 	struct isis_area *area = NULL;
 	struct interface *ifp;
 
-	old_state = circuit ? circuit->state : C_STATE_NA;
+	assert(circuit);
+
+	old_state = circuit->state;
 	if (IS_DEBUG_EVENTS)
-		zlog_debug("CSM_EVENT: %s", EVENT2STR(event));
+		zlog_debug("CSM_EVENT for %s: %s", circuit->interface->name,
+			   EVENT2STR(event));
 
 	switch (old_state) {
 	case C_STATE_NA:
-		if (circuit)
-			zlog_warn("Non-null circuit while state C_STATE_NA");
-		assert(circuit == NULL);
 		switch (event) {
 		case ISIS_ENABLE:
 			area = arg;
 
-			circuit = isis_circuit_new(area->isis);
 			isis_circuit_configure(circuit, area);
 			circuit->state = C_STATE_CONF;
 			break;
 		case IF_UP_FROM_Z:
 			ifp = arg;
-			isis = isis_lookup_by_vrfid(ifp->vrf_id);
-			if (isis == NULL) {
-				if (IS_DEBUG_EVENTS)
-					zlog_debug(
-						" %s : ISIS routing instance not found when attempting to apply against interface %s",
-						__func__, ifp->name);
-				break;
-			}
-			circuit = isis_circuit_new(isis);
+
 			isis_circuit_if_add(circuit, ifp);
-			listnode_add(isis->init_circ_list, circuit);
 			circuit->state = C_STATE_INIT;
 			break;
 		case ISIS_DISABLE:
@@ -114,21 +103,18 @@ struct isis_circuit *isis_csm_state_change(enum isis_circuit_event event,
 		}
 		break;
 	case C_STATE_INIT:
-		assert(circuit);
 		switch (event) {
 		case ISIS_ENABLE:
-			isis_circuit_configure(circuit,
-					       (struct isis_area *)arg);
+			area = arg;
+
+			isis_circuit_configure(circuit, area);
 			if (isis_circuit_up(circuit) != ISIS_OK) {
-				isis_circuit_deconfigure(
-					circuit, (struct isis_area *)arg);
+				isis_circuit_deconfigure(circuit, area);
 				break;
 			}
 			circuit->state = C_STATE_UP;
 			isis_event_circuit_state_change(circuit, circuit->area,
 							1);
-			listnode_delete(circuit->isis->init_circ_list,
-					circuit);
 			break;
 		case IF_UP_FROM_Z:
 			if (IS_DEBUG_EVENTS)
@@ -141,16 +127,14 @@ struct isis_circuit *isis_csm_state_change(enum isis_circuit_event event,
 					   circuit->interface->name);
 			break;
 		case IF_DOWN_FROM_Z:
-			isis_circuit_if_del(circuit, (struct interface *)arg);
-			listnode_delete(circuit->isis->init_circ_list,
-					circuit);
-			isis_circuit_del(circuit);
-			circuit = NULL;
+			ifp = arg;
+
+			isis_circuit_if_del(circuit, ifp);
+			circuit->state = C_STATE_NA;
 			break;
 		}
 		break;
 	case C_STATE_CONF:
-		assert(circuit);
 		switch (event) {
 		case ISIS_ENABLE:
 			if (IS_DEBUG_EVENTS)
@@ -158,9 +142,11 @@ struct isis_circuit *isis_csm_state_change(enum isis_circuit_event event,
 					   circuit);
 			break;
 		case IF_UP_FROM_Z:
-			isis_circuit_if_add(circuit, (struct interface *)arg);
+			ifp = arg;
+
+			isis_circuit_if_add(circuit, ifp);
 			if (isis_circuit_up(circuit) != ISIS_OK) {
-				isis_circuit_if_del(circuit, (struct interface *)arg);
+				isis_circuit_if_del(circuit, ifp);
 				flog_err(
 					EC_ISIS_CONFIG,
 					"Could not bring up %s because of invalid config.",
@@ -172,10 +158,10 @@ struct isis_circuit *isis_csm_state_change(enum isis_circuit_event event,
 							1);
 			break;
 		case ISIS_DISABLE:
-			isis_circuit_deconfigure(circuit,
-						 (struct isis_area *)arg);
-			isis_circuit_del(circuit);
-			circuit = NULL;
+			area = arg;
+
+			isis_circuit_deconfigure(circuit, area);
+			circuit->state = C_STATE_NA;
 			break;
 		case IF_DOWN_FROM_Z:
 			if (IS_DEBUG_EVENTS)
@@ -185,7 +171,6 @@ struct isis_circuit *isis_csm_state_change(enum isis_circuit_event event,
 		}
 		break;
 	case C_STATE_UP:
-		assert(circuit);
 		switch (event) {
 		case ISIS_ENABLE:
 			if (IS_DEBUG_EVENTS)
@@ -198,18 +183,19 @@ struct isis_circuit *isis_csm_state_change(enum isis_circuit_event event,
 					   circuit->interface->name);
 			break;
 		case ISIS_DISABLE:
-			isis = circuit->isis;
+			area = arg;
+
 			isis_circuit_down(circuit);
-			isis_circuit_deconfigure(circuit,
-						 (struct isis_area *)arg);
+			isis_circuit_deconfigure(circuit, area);
 			circuit->state = C_STATE_INIT;
 			isis_event_circuit_state_change(
-				circuit, (struct isis_area *)arg, 0);
-			listnode_add(isis->init_circ_list, circuit);
+				circuit, area, 0);
 			break;
 		case IF_DOWN_FROM_Z:
+			ifp = arg;
+
 			isis_circuit_down(circuit);
-			isis_circuit_if_del(circuit, (struct interface *)arg);
+			isis_circuit_if_del(circuit, ifp);
 			circuit->state = C_STATE_CONF;
 			isis_event_circuit_state_change(circuit, circuit->area,
 							0);

--- a/isisd/isis_nb.c
+++ b/isisd/isis_nb.c
@@ -686,13 +686,6 @@ const struct frr_yang_module_info frr_isisd_info = {
 			},
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/vrf",
-			.cbs = {
-				.modify = lib_interface_isis_vrf_modify,
-			},
-		},
-
-		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/circuit-type",
 			.cbs = {
 				.cli_show = cli_show_ip_isis_circ_type,

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -214,7 +214,6 @@ int isis_instance_mpls_te_router_address_destroy(
 int lib_interface_isis_create(struct nb_cb_create_args *args);
 int lib_interface_isis_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_isis_area_tag_modify(struct nb_cb_modify_args *args);
-int lib_interface_isis_vrf_modify(struct nb_cb_modify_args *args);
 int lib_interface_isis_ipv4_routing_modify(struct nb_cb_modify_args *args);
 int lib_interface_isis_ipv6_routing_modify(struct nb_cb_modify_args *args);
 int lib_interface_isis_circuit_type_modify(struct nb_cb_modify_args *args);

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2498,9 +2498,7 @@ int lib_interface_isis_create(struct nb_cb_create_args *args)
 	struct isis_area *area = NULL;
 	struct interface *ifp;
 	struct isis_circuit *circuit = NULL;
-	struct vrf *vrf;
 	const char *area_tag = yang_dnode_get_string(args->dnode, "./area-tag");
-	const char *vrf_name = yang_dnode_get_string(args->dnode, "./vrf");
 	uint32_t min_mtu, actual_mtu;
 
 	switch (args->event) {
@@ -2515,14 +2513,6 @@ int lib_interface_isis_create(struct nb_cb_create_args *args)
 		/* zebra might not know yet about the MTU - nothing we can do */
 		if (!ifp || ifp->mtu == 0)
 			break;
-		vrf = vrf_lookup_by_id(ifp->vrf_id);
-		if (ifp->vrf_id != VRF_DEFAULT && vrf
-		    && strcmp(vrf->name, vrf_name) != 0) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "interface %s not in vrf %s\n", ifp->name,
-				 vrf_name);
-			return NB_ERR_VALIDATION;
-		}
 		actual_mtu =
 			if_is_broadcast(ifp) ? ifp->mtu - LLC_LEN : ifp->mtu;
 
@@ -2605,44 +2595,6 @@ int lib_interface_isis_area_tag_modify(struct nb_cb_modify_args *args)
 			snprintf(args->errmsg, args->errmsg_len,
 				 "ISIS circuit is already defined on %s",
 				 circuit->area->area_tag);
-			return NB_ERR_VALIDATION;
-		}
-	}
-
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-interface:lib/interface/frr-isisd:isis/vrf
- */
-int lib_interface_isis_vrf_modify(struct nb_cb_modify_args *args)
-{
-	struct interface *ifp;
-	struct vrf *vrf;
-	const char *ifname, *vrfname, *vrf_name;
-	struct isis_circuit *circuit;
-
-	if (args->event == NB_EV_VALIDATE) {
-		/* libyang doesn't like relative paths across module boundaries
-		 */
-		ifname = yang_dnode_get_string(args->dnode->parent->parent,
-					       "./name");
-		vrfname = yang_dnode_get_string(args->dnode->parent->parent,
-						"./vrf");
-		vrf = vrf_lookup_by_name(vrfname);
-		assert(vrf);
-		ifp = if_lookup_by_name(ifname, vrf->vrf_id);
-
-		if (!ifp)
-			return NB_OK;
-
-		vrf_name = yang_dnode_get_string(args->dnode, NULL);
-		circuit = circuit_scan_by_ifp(ifp);
-		if (circuit && circuit->area && circuit->isis
-		    && strcmp(circuit->isis->name, vrf_name)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "ISIS circuit is already defined on vrf  %s",
-				 circuit->isis->name);
 			return NB_ERR_VALIDATION;
 		}
 	}

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -3240,9 +3240,20 @@ int lib_interface_isis_mpls_ldp_sync_modify(struct nb_cb_modify_args *args)
 	struct ldp_sync_info *ldp_sync_info;
 	bool ldp_sync_enable;
 	struct isis *isis;
+	struct interface *ifp;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		ifp = nb_running_get_entry(args->dnode->parent->parent->parent,
+					   NULL, false);
+		if (ifp == NULL)
+			return NB_ERR_VALIDATION;
+		if (if_is_loopback(ifp)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "LDP-Sync does not run on loopback interface\n");
+			return NB_ERR_VALIDATION;
+		}
+
 		circuit = nb_running_get_entry(args->dnode, NULL, false);
 		if (circuit == NULL || circuit->area == NULL)
 			return NB_ERR_VALIDATION;
@@ -3307,9 +3318,20 @@ int lib_interface_isis_mpls_holddown_modify(struct nb_cb_modify_args *args)
 	struct ldp_sync_info *ldp_sync_info;
 	uint16_t holddown;
 	struct isis *isis;
+	struct interface *ifp;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		ifp = nb_running_get_entry(args->dnode->parent->parent->parent,
+					   NULL, false);
+		if (ifp == NULL)
+			return NB_ERR_VALIDATION;
+		if (if_is_loopback(ifp)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "LDP-Sync does not run on loopback interface\n");
+			return NB_ERR_VALIDATION;
+		}
+
 		circuit = nb_running_get_entry(args->dnode, NULL, false);
 		if (circuit == NULL || circuit->area == NULL)
 			return NB_ERR_VALIDATION;
@@ -3345,9 +3367,20 @@ int lib_interface_isis_mpls_holddown_destroy(struct nb_cb_destroy_args *args)
 	struct isis_circuit *circuit;
 	struct ldp_sync_info *ldp_sync_info;
 	struct isis *isis;
+	struct interface *ifp;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		ifp = nb_running_get_entry(args->dnode->parent->parent->parent,
+					   NULL, false);
+		if (ifp == NULL)
+			return NB_ERR_VALIDATION;
+		if (if_is_loopback(ifp)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "LDP-Sync does not run on loopback interface\n");
+			return NB_ERR_VALIDATION;
+		}
+
 		circuit = nb_running_get_entry(args->dnode, NULL, false);
 		if (circuit == NULL || circuit->ldp_sync_info == NULL
 		    || circuit->area == NULL)

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -96,6 +96,8 @@ static int isis_zebra_if_address_add(ZAPI_CALLBACK_ARGS)
 	if (c == NULL)
 		return 0;
 
+	zlog_debug("%s %s", __func__, c->ifp->name);
+
 #ifdef EXTREME_DEBUG
 	if (c->address->family == AF_INET)
 		zlog_debug("connected IP address %pFX", c->address);
@@ -122,6 +124,8 @@ static int isis_zebra_if_address_del(ZAPI_CALLBACK_ARGS)
 
 	if (c == NULL)
 		return 0;
+
+	zlog_debug("%s %s", __func__, c->ifp->name);
 
 #ifdef EXTREME_DEBUG
 	if (c->address->family == AF_INET)

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -114,16 +114,6 @@ int show_isis_neighbor_common(struct vty *, const char *id, char,
 int clear_isis_neighbor_common(struct vty *, const char *id, const char *vrf_name,
 			       bool all_vrf);
 
-static void isis_add(struct isis *isis)
-{
-	listnode_add(im->isis, isis);
-}
-
-static void isis_delete(struct isis *isis)
-{
-	listnode_delete(im->isis, isis);
-}
-
 /* Link ISIS instance to VRF. */
 void isis_vrf_link(struct isis *isis, struct vrf *vrf)
 {
@@ -189,10 +179,8 @@ void isis_global_instance_create(const char *vrf_name)
 	struct isis *isis;
 
 	isis = isis_lookup_by_vrfname(vrf_name);
-	if (isis == NULL) {
+	if (isis == NULL)
 		isis = isis_new(vrf_name);
-		isis_add(isis);
-	}
 }
 
 struct isis *isis_new(const char *vrf_name)
@@ -201,16 +189,15 @@ struct isis *isis_new(const char *vrf_name)
 	struct isis *isis;
 
 	isis = XCALLOC(MTYPE_ISIS, sizeof(struct isis));
+
+	isis->name = XSTRDUP(MTYPE_ISIS_NAME, vrf_name);
+
 	vrf = vrf_lookup_by_name(vrf_name);
 
-	if (vrf) {
-		isis->vrf_id = vrf->vrf_id;
+	if (vrf)
 		isis_vrf_link(isis, vrf);
-		isis->name = XSTRDUP(MTYPE_ISIS_NAME, vrf->name);
-	} else {
+	else
 		isis->vrf_id = VRF_UNKNOWN;
-		isis->name = XSTRDUP(MTYPE_ISIS_NAME, vrf_name);
-	}
 
 	if (IS_DEBUG_EVENTS)
 		zlog_debug(
@@ -224,12 +211,63 @@ struct isis *isis_new(const char *vrf_name)
 	isis->process_id = getpid();
 	isis->router_id = 0;
 	isis->area_list = list_new();
-	isis->init_circ_list = list_new();
 	isis->uptime = time(NULL);
 	isis->snmp_notifications = 1;
 	dyn_cache_init(isis);
 
+	listnode_add(im->isis, isis);
+
 	return isis;
+}
+
+void isis_finish(struct isis *isis)
+{
+	struct vrf *vrf = NULL;
+
+	listnode_delete(im->isis, isis);
+
+	vrf = vrf_lookup_by_name(isis->name);
+	if (vrf)
+		isis_vrf_unlink(isis, vrf);
+	XFREE(MTYPE_ISIS_NAME, isis->name);
+
+	isis_redist_free(isis);
+	list_delete(&isis->area_list);
+	XFREE(MTYPE_ISIS, isis);
+}
+
+void isis_area_add_circuit(struct isis_area *area,
+			   struct isis_circuit *circuit)
+{
+	isis_csm_state_change(ISIS_ENABLE, circuit, area);
+
+	area->ip_circuits += circuit->ip_router;
+	area->ipv6_circuits += circuit->ipv6_router;
+
+	area->lfa_protected_links[0] += circuit->lfa_protection[0];
+	area->rlfa_protected_links[0] += circuit->rlfa_protection[0];
+	area->tilfa_protected_links[0] += circuit->tilfa_protection[0];
+
+	area->lfa_protected_links[1] += circuit->lfa_protection[1];
+	area->rlfa_protected_links[1] += circuit->rlfa_protection[1];
+	area->tilfa_protected_links[1] += circuit->tilfa_protection[1];
+}
+
+void isis_area_del_circuit(struct isis_area *area,
+			   struct isis_circuit *circuit)
+{
+	area->ip_circuits -= circuit->ip_router;
+	area->ipv6_circuits -= circuit->ipv6_router;
+
+	area->lfa_protected_links[0] -= circuit->lfa_protection[0];
+	area->rlfa_protected_links[0] -= circuit->rlfa_protection[0];
+	area->tilfa_protected_links[0] -= circuit->tilfa_protection[0];
+
+	area->lfa_protected_links[1] -= circuit->lfa_protection[1];
+	area->rlfa_protected_links[1] -= circuit->rlfa_protection[1];
+	area->tilfa_protected_links[1] -= circuit->tilfa_protection[1];
+
+	isis_csm_state_change(ISIS_DISABLE, circuit, area);
 }
 
 struct isis_area *isis_area_create(const char *area_tag, const char *vrf_name)
@@ -237,30 +275,19 @@ struct isis_area *isis_area_create(const char *area_tag, const char *vrf_name)
 	struct isis_area *area;
 	struct isis *isis = NULL;
 	struct vrf *vrf = NULL;
+	struct interface *ifp;
+	struct isis_circuit *circuit;
+
 	area = XCALLOC(MTYPE_ISIS_AREA, sizeof(struct isis_area));
 
-	if (vrf_name) {
-		vrf = vrf_lookup_by_name(vrf_name);
-		if (vrf) {
-			isis = isis_lookup_by_vrfid(vrf->vrf_id);
-			if (isis == NULL) {
-				isis = isis_new(vrf_name);
-				isis_add(isis);
-			}
-		} else {
-			isis = isis_lookup_by_vrfid(VRF_UNKNOWN);
-			if (isis == NULL) {
-				isis = isis_new(vrf_name);
-				isis_add(isis);
-			}
-		}
-	} else {
-		isis = isis_lookup_by_vrfid(VRF_DEFAULT);
-		if (isis == NULL) {
-			isis = isis_new(VRF_DEFAULT_NAME);
-			isis_add(isis);
-		}
-	}
+	if (!vrf_name)
+		vrf_name = VRF_DEFAULT_NAME;
+
+	vrf = vrf_lookup_by_name(vrf_name);
+	isis = isis_lookup_by_vrfname(vrf_name);
+
+	if (isis == NULL)
+		isis = isis_new(vrf_name);
 
 	listnode_add(isis->area_list, area);
 	area->isis = isis;
@@ -373,11 +400,25 @@ struct isis_area *isis_area_create(const char *area_tag, const char *vrf_name)
 	area->bfd_signalled_down = false;
 	area->bfd_force_spf_refresh = false;
 
-
 	QOBJ_REG(area, isis_area);
+
+	if (vrf)
+		FOR_ALL_INTERFACES (vrf, ifp) {
+			if (ifp->ifindex == IFINDEX_INTERNAL)
+				continue;
+
+			circuit = ifp->info;
+
+			if (!circuit->tag || strcmp(circuit->tag, area_tag))
+				continue;
+
+			isis_area_add_circuit(area, circuit);
+		}
 
 	return area;
 }
+
+
 
 struct isis_area *isis_area_lookup_by_vrf(const char *area_tag,
 					  const char *vrf_name)
@@ -470,11 +511,9 @@ void isis_area_destroy(struct isis_area *area)
 
 	if (area->circuit_list) {
 		for (ALL_LIST_ELEMENTS(area->circuit_list, node, nnode,
-				       circuit)) {
-			circuit->ip_router = 0;
-			circuit->ipv6_router = 0;
-			isis_csm_state_change(ISIS_DISABLE, circuit, area);
-		}
+				       circuit))
+			isis_area_del_circuit(area, circuit);
+
 		list_delete(&area->circuit_list);
 	}
 	list_delete(&area->adjacency_list);
@@ -572,10 +611,6 @@ static int isis_vrf_enable(struct vrf *vrf)
 
 	isis = isis_lookup_by_vrfname(vrf->name);
 	if (isis) {
-		if (isis->name && strmatch(vrf->name, VRF_DEFAULT_NAME)) {
-			XFREE(MTYPE_ISIS_NAME, isis->name);
-			isis->name = NULL;
-		}
 		old_vrf_id = isis->vrf_id;
 		/* We have instance configured, link to VRF and make it "up". */
 		isis_vrf_link(isis, vrf);
@@ -628,28 +663,6 @@ void isis_vrf_init(void)
 {
 	vrf_init(isis_vrf_new, isis_vrf_enable, isis_vrf_disable,
 		 isis_vrf_delete, isis_vrf_enable);
-}
-
-void isis_finish(struct isis *isis)
-{
-	struct vrf *vrf = NULL;
-
-	isis_delete(isis);
-	if (isis->name) {
-		vrf = vrf_lookup_by_name(isis->name);
-		if (vrf)
-			isis_vrf_unlink(isis, vrf);
-		XFREE(MTYPE_ISIS_NAME, isis->name);
-	} else {
-		vrf = vrf_lookup_by_id(VRF_DEFAULT);
-		if (vrf)
-			isis_vrf_unlink(isis, vrf);
-	}
-
-	isis_redist_free(isis);
-	list_delete(&isis->area_list);
-	list_delete(&isis->init_circ_list);
-	XFREE(MTYPE_ISIS, isis);
 }
 
 void isis_terminate()

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -89,7 +89,6 @@ struct isis {
 	uint8_t sysid[ISIS_SYS_ID_LEN]; /* SystemID for this IS */
 	uint32_t router_id;		/* Router ID from zebra */
 	struct list *area_list;	/* list of IS-IS areas */
-	struct list *init_circ_list;
 	uint8_t max_area_addrs;		  /* maximumAreaAdresses */
 	struct area_addr *man_area_addrs; /* manualAreaAddresses */
 	time_t uptime;			  /* when did we start */
@@ -244,7 +243,6 @@ DECLARE_MTYPE(ISIS_AREA_ADDR);	/* isis_area->area_addrs */
 DECLARE_HOOK(isis_area_overload_bit_update, (struct isis_area * area), (area));
 
 void isis_terminate(void);
-void isis_finish(struct isis *isis);
 void isis_master_init(struct thread_master *master);
 void isis_vrf_link(struct isis *isis, struct vrf *vrf);
 void isis_vrf_unlink(struct isis *isis, struct vrf *vrf);
@@ -257,6 +255,13 @@ void isis_init(void);
 void isis_vrf_init(void);
 
 struct isis *isis_new(const char *vrf_name);
+void isis_finish(struct isis *isis);
+
+void isis_area_add_circuit(struct isis_area *area,
+			   struct isis_circuit *circuit);
+void isis_area_del_circuit(struct isis_area *area,
+			   struct isis_circuit *circuit);
+
 struct isis_area *isis_area_create(const char *, const char *);
 struct isis_area *isis_area_lookup(const char *, vrf_id_t vrf_id);
 struct isis_area *isis_area_lookup_by_vrf(const char *area_tag,

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -65,8 +65,6 @@ extern void isis_cli_init(void);
 		all_vrf = strmatch(vrf_name, "all");                           \
 	}
 
-#define SNMP_CIRCUITS_MAX (512)
-
 extern struct zebra_privs_t isisd_privs;
 
 /* uncomment if you are a developer in bug hunt */
@@ -97,8 +95,6 @@ struct isis {
 	time_t uptime;			  /* when did we start */
 	struct thread *t_dync_clean;      /* dynamic hostname cache cleanup thread */
 	uint32_t circuit_ids_used[8];     /* 256 bits to track circuit ids 1 through 255 */
-	struct isis_circuit *snmp_circuits[SNMP_CIRCUITS_MAX];
-	uint32_t snmp_circuit_id_last;
 	int snmp_notifications;
 
 	struct route_table *ext_info[REDIST_PROTOCOL_COUNT];

--- a/tests/isisd/test_isis_spf.c
+++ b/tests/isisd/test_isis_spf.c
@@ -556,7 +556,6 @@ int main(int argc, char **argv)
 	/* IS-IS inits. */
 	yang_module_load("frr-isisd");
 	isis = isis_new(VRF_DEFAULT_NAME);
-	listnode_add(im->isis, isis);
 	SET_FLAG(im->options, F_ISIS_UNIT_TEST);
 	debug_spf_events |= DEBUG_SPF_EVENTS;
 	debug_lfa |= DEBUG_LFA;

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -506,13 +506,6 @@ module frr-isisd {
         "Area-tag associated to this circuit.";
     }
 
-    leaf vrf {
-      type frr-vrf:vrf-ref;
-      default "default";
-      description
-        "VRF NAME.";
-    }
-
     leaf ipv4-routing {
       type boolean;
       default "false";


### PR DESCRIPTION
ISIS CLI is really messed up right now because it directly uses a lot of operational data.
It may work in the traditional CLI, but it completely breaks the transactional CLI.

Besides, this PR deletes a separate `vrf` leaf from the `isis` container of an interface node.
The existence of this leaf is very confusing and adds no actual functionality. I suppose it was
introduced only because of the poor initial design of ISIS VRF support.

There is one usage of operational data still left in the CLI. When we enable ISIS on the interface,
we set `passive` flag to `true` for loopbacks. It is not correct because it doesn't match the default
value from the YANG model, but I suppose it is done for backward compatibility. Any ideas on how
to get rid of this operational data usage are appreciated.