### PR TITLE
zebra: Allow interface up events to read speed

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1074,6 +1074,9 @@ void if_up(struct interface *ifp)
 
 	if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK)
 		zebra_evpn_mh_uplink_oper_update(zif);
+
+	thread_add_timer(zrouter.master, if_zebra_speed_update, ifp, 0,
+			 &zif->speed_update);
 }
 
 /* Interface goes down.  We have to manage different behavior of based


### PR DESCRIPTION
Initially the reading of the speed of an interface happened
upon interface creation and happened until the speed of a link
settled down to a single value.  The speed of an interface
can also change as that a new optic can be inserted that
changes the speed, in which case FRR would see a interface
down (optic removal) and then a interface up (optic insertion).

In this case FRR would not treat this as an event that changed
the speed.  Let's expand the checking a bit more.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>