### PR TITLE
isisd: fix incorrect snmp-id gen/free

### DIFF
--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -238,4 +238,7 @@ DECLARE_HOOK(isis_circuit_config_write,
 DECLARE_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *circuit),
 	     (circuit));
 
+DECLARE_HOOK(isis_circuit_new_hook, (struct isis_circuit *circuit), (circuit));
+DECLARE_HOOK(isis_circuit_del_hook, (struct isis_circuit *circuit), (circuit));
+
 #endif /* _ZEBRA_ISIS_CIRCUIT_H */

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -65,8 +65,6 @@ extern void isis_cli_init(void);
 		all_vrf = strmatch(vrf_name, "all");                           \
 	}
 
-#define SNMP_CIRCUITS_MAX (512)
-
 extern struct zebra_privs_t isisd_privs;
 
 /* uncomment if you are a developer in bug hunt */
@@ -97,8 +95,6 @@ struct isis {
 	time_t uptime;			  /* when did we start */
 	struct thread *t_dync_clean;      /* dynamic hostname cache cleanup thread */
 	uint32_t circuit_ids_used[8];     /* 256 bits to track circuit ids 1 through 255 */
-	struct isis_circuit *snmp_circuits[SNMP_CIRCUITS_MAX];
-	uint32_t snmp_circuit_id_last;
 	int snmp_notifications;
 
 	struct route_table *ext_info[REDIST_PROTOCOL_COUNT];


### PR DESCRIPTION
Necessary structures for snmp-id generation are currently stored in
`struct isis`. When we generate the new circuit ID, we always use the
instance from the default VRF. When we free the circuit ID, we use the
instance from the circuit VRF. This causes the following problems:

1. If there is no instance in the default VRF, this code doesn't work.
2. When circuit in non-default VRF is deleted, the ID is not actually
   freed.

This is fixed by using global structures instead. The code itself is
moved to isis_snmp.c and linked to the main code using hooks. We should
not call SNMP-related code when the SNMP module is not loaded at all.

More than that, we don't allow to activate the circuit if we failed to
generate the SNMP ID. Even if SNMP support is completely disabled! This
check is removed.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>