### PR TITLE
zebra: prevent from crashing if link of macvlan interface not found

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1550,6 +1550,9 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 			memcpy(old_hw_addr, ifp->hw_addr, INTERFACE_HWADDR_MAX);
 
+			/* Update link. */
+			zebra_if_update_link(ifp, link_ifindex, ns_id);
+
 			netlink_interface_update_hw_addr(tb, ifp);
 
 			if (if_is_no_ptm_operative(ifp)) {

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -974,7 +974,7 @@ int interface_lookup_netlink(struct zebra_ns *zns)
 		return ret;
 
 	/* fixup linkages */
-	zebra_if_update_all_links();
+	zebra_if_update_all_links(zns);
 	return 0;
 }
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1148,18 +1148,16 @@ void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex,
  * during initial link dump kernel does not order lower devices before
  * upper devices so we need to fixup link dependencies at the end of dump
  */
-void zebra_if_update_all_links(void)
+void zebra_if_update_all_links(struct zebra_ns *zns)
 {
 	struct route_node *rn;
 	struct interface *ifp;
 	struct zebra_if *zif;
-	struct zebra_ns *ns;
 
 	if (IS_ZEBRA_DEBUG_KERNEL)
 		zlog_info("fixup link dependencies");
 
-	ns = zebra_ns_lookup(NS_DEFAULT);
-	for (rn = route_top(ns->if_table); rn; rn = route_next(rn)) {
+	for (rn = route_top(zns->if_table); rn; rn = route_next(rn)) {
 		ifp = (struct interface *)rn->info;
 		if (!ifp)
 			continue;
@@ -1177,8 +1175,8 @@ void zebra_if_update_all_links(void)
 
 		/* update SVI linkages */
 		if ((zif->link_ifindex != IFINDEX_INTERNAL) && !zif->link) {
-			zif->link = if_lookup_by_index_per_ns(ns,
-							 zif->link_ifindex);
+			zif->link = if_lookup_by_index_per_ns(
+				zns, zif->link_ifindex);
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug("interface %s/%d's lower fixup to %s/%d",
 						ifp->name, ifp->ifindex,

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -482,7 +482,7 @@ extern int ipv6_address_configured(struct interface *ifp);
 extern void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id);
 extern void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex,
 				 ns_id_t ns_id);
-extern void zebra_if_update_all_links(void);
+extern void zebra_if_update_all_links(struct zebra_ns *zns);
 extern void zebra_if_set_protodown(struct interface *ifp, bool down);
 extern int if_ip_address_install(struct interface *ifp, struct prefix *prefix,
 				 const char *label, struct prefix *pp);


### PR DESCRIPTION
This crash can happen when updating macvlan interfaces status.
The link interface pointer is accessed, and it crashes because that link interface was null.

From FRR point of view, this update of macvlan interfaces is RTM_NEWLINK events.
This is either a new interface or an update of an interface ( eg iface goes up).

ZEBRA discovers interfaces on two ways:
(a)- at zebra startup, discover all interfaces, and once all read, refresh the link interface pointer.
(b)- during zebra life, receive incoming RTM_NEWLINK

There are cases where MACVLAN interfaces created by keepalived daemon may be created before zebra comes alive.
That means that (a) process takes place. That process happens look similar when it comes with vrflte backend.
However, the situation becomes nasty when it has to deal with non default vrf on namespace based vrf backend.

Actually, the refresh of the link interface pointer was not good.

From kernel point of view, the netlink event of macvlan creation always comes with the link index of the underlying interface. The underlying interface must be present.
ZEBRA, at startup, did not fix the link refresh for non default vrfs.

Below output of crash was that one:

Core was generated by `/usr/bin/zebra -A 127.0.0.1 --retain --keep_kernel --vrfwnetns -M snmp -M wrap_'.
Program terminated with signal SIGABRT, Aborted.
51      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
[Current thread is 1 (Thread 0x7fa79ef10400 (LWP 4018))]
(gdb) bt
    at /build/make-pkg/output/_packages/cp-routing/src/lib/sigevent.c:228
    at /build/make-pkg/output/_packages/cp-routing/src/zebra/zebra_vxlan.c:8853
    at /build/make-pkg/output/_packages/cp-routing/src/zebra/if_netlink.c:1502
    at /build/make-pkg/output/_packages/cp-routing/src/zebra/kernel_netlink.c:306
    count=5, startup=0) at /build/make-pkg/output/_packages/cp-routing/src/zebra/kernel_netlink.c:958
(gdb)

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>