### PR TITLE
tests: fix topotest polling log

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -351,8 +351,8 @@ def run_and_expect(func, what, count=20, wait=3):
         func_name = func.__name__
 
     logger.info(
-        "'{}' polling started (interval {} secs, maximum wait {} secs)".format(
-            func_name, wait, int(wait * count)
+        "'{}' polling started (interval {} secs, maximum {} tries)".format(
+            func_name, wait, count
         )
     )
 


### PR DESCRIPTION
The current log prints maximum wait time which is not actually correct,
because it doesn't include the command execution time. We usually have
"failed after X seconds" log with X being far longer than this maximum.

Let's print the maximum number of tries instead.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>