### PR TITLE
tests: disable test_BGP_GR_TC_46_p1

### DIFF
--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1.py
@@ -3935,7 +3935,7 @@ def test_BGP_GR_TC_45_p1(request):
     write_test_footer(tc_name)
 
 
-def test_BGP_GR_TC_46_p1(request):
+def BGP_GR_TC_46_p1(request):
     """
     Test Objective : transition from Peer-level helper to Global Restarting
     Global Mode : GR Restarting


### PR DESCRIPTION
This test frequently fails and this is very annoying. There are already
a couple of test disabled (50 and 52).

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>