### PR TITLE
a lot of isis fixes

### DIFF
--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -172,7 +172,7 @@ ISIS interface
 
 .. _ip-router-isis-word:
 
-.. clicmd:: <ip|ipv6> router isis WORD [vrf NAME]
+.. clicmd:: <ip|ipv6> router isis WORD
 
    Activate ISIS adjacency on this interface. Note that the name of ISIS
    instance must be the same as the one used to configure the ISIS process (see

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -735,6 +735,9 @@ int isis_circuit_up(struct isis_circuit *circuit)
 
 	circuit->last_uptime = time(NULL);
 
+	if (circuit->area->mta && circuit->area->mta->status)
+		isis_link_params_update(circuit, circuit->interface);
+
 #ifndef FABRICD
 	/* send northbound notification */
 	isis_notif_if_state_change(circuit, false);
@@ -1302,8 +1305,6 @@ struct isis_circuit *isis_circuit_create(struct isis_area *area,
 	if (circuit->state != C_STATE_CONF && circuit->state != C_STATE_UP)
 		return circuit;
 	isis_circuit_if_bind(circuit, ifp);
-	if (circuit->area->mta && circuit->area->mta->status)
-		isis_link_params_update(circuit, ifp);
 
 	return circuit;
 }

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -238,4 +238,7 @@ DECLARE_HOOK(isis_circuit_config_write,
 DECLARE_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *circuit),
 	     (circuit));
 
+DECLARE_HOOK(isis_circuit_new_hook, (struct isis_circuit *circuit), (circuit));
+DECLARE_HOOK(isis_circuit_del_hook, (struct isis_circuit *circuit), (circuit));
+
 #endif /* _ZEBRA_ISIS_CIRCUIT_H */

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -122,6 +122,7 @@ struct isis_circuit {
 	/*
 	 * Configurables
 	 */
+	char *tag;		       /* area tag */
 	struct isis_passwd passwd;     /* Circuit rx/tx password */
 	int is_type;		       /* circuit is type == level of circuit
 					* differentiated from circuit type (media) */
@@ -180,7 +181,7 @@ struct isis_circuit {
 DECLARE_QOBJ_TYPE(isis_circuit);
 
 void isis_circuit_init(void);
-struct isis_circuit *isis_circuit_new(struct isis *isis);
+struct isis_circuit *isis_circuit_new(struct interface *ifp, const char *tag);
 void isis_circuit_del(struct isis_circuit *circuit);
 struct isis_circuit *circuit_lookup_by_ifp(struct interface *ifp,
 					   struct list *list);
@@ -207,8 +208,6 @@ void isis_circuit_print_vty(struct isis_circuit *circuit, struct vty *vty,
 size_t isis_circuit_pdu_size(struct isis_circuit *circuit);
 void isis_circuit_stream(struct isis_circuit *circuit, struct stream **stream);
 
-struct isis_circuit *isis_circuit_create(struct isis_area *area,
-					 struct interface *ifp);
 void isis_circuit_af_set(struct isis_circuit *circuit, bool ip_router,
 			 bool ipv6_router);
 ferr_r isis_circuit_passive_set(struct isis_circuit *circuit, bool passive);

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -3057,23 +3057,11 @@ DEFPY(isis_mpls_if_ldp_sync, isis_mpls_if_ldp_sync_cmd,
       NO_STR "IS-IS routing protocol\n" MPLS_STR MPLS_LDP_SYNC_STR)
 {
 	const struct lyd_node *dnode;
-	struct interface *ifp;
 
 	dnode = yang_dnode_get(vty->candidate_config->dnode,
 			       "%s/frr-isisd:isis", VTY_CURR_XPATH);
 	if (dnode == NULL) {
 		vty_out(vty, "ISIS is not enabled on this circuit\n");
-		return CMD_SUCCESS;
-	}
-
-	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
-	if (if_is_loopback(ifp)) {
-		vty_out(vty, "ldp-sync does not run on loopback interface\n");
-		return CMD_SUCCESS;
-	}
-
-	if (ifp->vrf_id != VRF_DEFAULT) {
-		vty_out(vty, "ldp-sync only runs on DEFAULT VRF\n");
 		return CMD_SUCCESS;
 	}
 
@@ -3100,23 +3088,11 @@ DEFPY(isis_mpls_if_ldp_sync_holddown, isis_mpls_if_ldp_sync_holddown_cmd,
       "Time in seconds\n")
 {
 	const struct lyd_node *dnode;
-	struct interface *ifp;
 
 	dnode = yang_dnode_get(vty->candidate_config->dnode,
 			       "%s/frr-isisd:isis", VTY_CURR_XPATH);
 	if (dnode == NULL) {
 		vty_out(vty, "ISIS is not enabled on this circuit\n");
-		return CMD_SUCCESS;
-	}
-
-	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
-	if (if_is_loopback(ifp)) {
-		vty_out(vty, "ldp-sync does not run on loopback interface\n");
-		return CMD_SUCCESS;
-	}
-
-	if (ifp->vrf_id != VRF_DEFAULT) {
-		vty_out(vty, "ldp-sync only runs on DEFAULT VRF\n");
 		return CMD_SUCCESS;
 	}
 
@@ -3132,23 +3108,11 @@ DEFPY(no_isis_mpls_if_ldp_sync_holddown, no_isis_mpls_if_ldp_sync_holddown_cmd,
 	      NO_MPLS_LDP_SYNC_HOLDDOWN_STR "Time in seconds\n")
 {
 	const struct lyd_node *dnode;
-	struct interface *ifp;
 
 	dnode = yang_dnode_get(vty->candidate_config->dnode,
 			       "%s/frr-isisd:isis", VTY_CURR_XPATH);
 	if (dnode == NULL) {
 		vty_out(vty, "ISIS is not enabled on this circuit\n");
-		return CMD_SUCCESS;
-	}
-
-	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
-	if (if_is_loopback(ifp)) {
-		vty_out(vty, "ldp-sync does not run on loopback interface\n");
-		return CMD_SUCCESS;
-	}
-
-	if (ifp->vrf_id != VRF_DEFAULT) {
-		vty_out(vty, "ldp-sync only runs on DEFAULT VRF\n");
 		return CMD_SUCCESS;
 	}
 

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -153,15 +153,16 @@ void cli_show_router_isis(struct vty *vty, struct lyd_node *dnode,
  * XPath: /frr-isisd:isis/instance
  */
 DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
-	   "ip router isis WORD$tag [vrf NAME$vrf_name]",
+	   "ip router isis WORD$tag",
 	   "Interface Internet Protocol config commands\n"
 	   "IP router interface commands\n"
 	   "IS-IS routing protocol\n"
-	   "Routing process tag\n" VRF_CMD_HELP_STR)
+	   "Routing process tag\n")
 {
 	char inst_xpath[XPATH_MAXLEN];
 	struct lyd_node *if_dnode, *inst_dnode;
 	const char *circ_type = NULL;
+	const char *vrf_name;
 	struct interface *ifp;
 
 	if_dnode = yang_dnode_get(vty->candidate_config->dnode, VTY_CURR_XPATH);
@@ -186,8 +187,6 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE, NULL);
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag", NB_OP_MODIFY,
 			      tag);
-	nb_cli_enqueue_change(vty, "./frr-isisd:isis/vrf", NB_OP_MODIFY,
-			      vrf_name);
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv4-routing",
 			      NB_OP_MODIFY, "true");
 	if (circ_type)
@@ -203,16 +202,24 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+ALIAS_HIDDEN(ip_router_isis, ip_router_isis_vrf_cmd,
+	     "ip router isis WORD$tag vrf NAME$vrf_name",
+	     "Interface Internet Protocol config commands\n"
+	     "IP router interface commands\n"
+	     "IS-IS routing protocol\n"
+	     "Routing process tag\n" VRF_CMD_HELP_STR)
+
 DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
-	   "ipv6 router isis WORD$tag [vrf NAME$vrf_name]",
+	   "ipv6 router isis WORD$tag",
 	   "Interface Internet Protocol config commands\n"
 	   "IP router interface commands\n"
 	   "IS-IS routing protocol\n"
-	   "Routing process tag\n" VRF_CMD_HELP_STR)
+	   "Routing process tag\n")
 {
 	char inst_xpath[XPATH_MAXLEN];
 	struct lyd_node *if_dnode, *inst_dnode;
 	const char *circ_type = NULL;
+	const char *vrf_name;
 	struct interface *ifp;
 
 	if_dnode = yang_dnode_get(vty->candidate_config->dnode, VTY_CURR_XPATH);
@@ -237,8 +244,6 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE, NULL);
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag", NB_OP_MODIFY,
 			      tag);
-	nb_cli_enqueue_change(vty, "./frr-isisd:isis/vrf", NB_OP_MODIFY,
-			      vrf_name);
 	nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv6-routing",
 			      NB_OP_MODIFY, "true");
 	if (circ_type)
@@ -254,15 +259,21 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+ALIAS_HIDDEN(ip6_router_isis, ip6_router_isis_vrf_cmd,
+	     "ipv6 router isis WORD$tag vrf NAME$vrf_name",
+	     "Interface Internet Protocol config commands\n"
+	     "IP router interface commands\n"
+	     "IS-IS routing protocol\n"
+	     "Routing process tag\n" VRF_CMD_HELP_STR)
+
 DEFPY_YANG(no_ip_router_isis, no_ip_router_isis_cmd,
-	   "no <ip|ipv6>$ip router isis [WORD]$tag [vrf NAME$vrf_name]",
+	   "no <ip|ipv6>$ip router isis [WORD]$tag",
 	   NO_STR
 	   "Interface Internet Protocol config commands\n"
 	   "IP router interface commands\n"
 	   "IP router interface commands\n"
 	   "IS-IS routing protocol\n"
-	   "Routing process tag\n"
-	   VRF_CMD_HELP_STR)
+	   "Routing process tag\n")
 {
 	const struct lyd_node *dnode;
 
@@ -295,36 +306,32 @@ DEFPY_YANG(no_ip_router_isis, no_ip_router_isis_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+ALIAS_HIDDEN(no_ip_router_isis, no_ip_router_isis_vrf_cmd,
+	     "no <ip|ipv6>$ip router isis WORD$tag vrf NAME$vrf_name",
+	     NO_STR
+	     "Interface Internet Protocol config commands\n"
+	     "IP router interface commands\n"
+	     "IP router interface commands\n"
+	     "IS-IS routing protocol\n"
+	     "Routing process tag\n"
+	     VRF_CMD_HELP_STR)
+
 void cli_show_ip_isis_ipv4(struct vty *vty, struct lyd_node *dnode,
 			   bool show_defaults)
 {
-	const char *vrf;
-
-	vrf = yang_dnode_get_string(dnode, "../vrf");
-
 	if (!yang_dnode_get_bool(dnode, NULL))
 		vty_out(vty, " no");
-	vty_out(vty, " ip router isis %s",
+	vty_out(vty, " ip router isis %s\n",
 		yang_dnode_get_string(dnode, "../area-tag"));
-	if (!strmatch(vrf, VRF_DEFAULT_NAME))
-		vty_out(vty, " vrf %s", vrf);
-	vty_out(vty, "\n");
 }
 
 void cli_show_ip_isis_ipv6(struct vty *vty, struct lyd_node *dnode,
 			   bool show_defaults)
 {
-	const char *vrf;
-
-	vrf = yang_dnode_get_string(dnode, "../vrf");
-
 	if (!yang_dnode_get_bool(dnode, NULL))
 		vty_out(vty, " no");
-	vty_out(vty, " ipv6 router isis %s",
+	vty_out(vty, " ipv6 router isis %s\n",
 		yang_dnode_get_string(dnode, "../area-tag"));
-	if (!strmatch(vrf, VRF_DEFAULT_NAME))
-		vty_out(vty, " vrf %s", vrf);
-	vty_out(vty, "\n");
 }
 
 /*
@@ -3174,8 +3181,11 @@ void isis_cli_init(void)
 	install_element(CONFIG_NODE, &no_router_isis_cmd);
 
 	install_element(INTERFACE_NODE, &ip_router_isis_cmd);
+	install_element(INTERFACE_NODE, &ip_router_isis_vrf_cmd);
 	install_element(INTERFACE_NODE, &ip6_router_isis_cmd);
+	install_element(INTERFACE_NODE, &ip6_router_isis_vrf_cmd);
 	install_element(INTERFACE_NODE, &no_ip_router_isis_cmd);
+	install_element(INTERFACE_NODE, &no_ip_router_isis_vrf_cmd);
 	install_element(INTERFACE_NODE, &isis_bfd_cmd);
 	install_element(INTERFACE_NODE, &isis_bfd_profile_cmd);
 

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -62,19 +62,7 @@ DEFPY_YANG_NOSH(router_isis, router_isis_cmd,
 		 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']", tag,
 		 vrf_name);
 	nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
-	/* default value in yang for is-type is level-1, but in FRR
-	 * the first instance is assigned is-type level-1-2. We
-	 * need to make sure to set it in the yang model so that it
-	 * is consistent with what FRR sees.
-	 */
 
-	if (!im) {
-		return CMD_SUCCESS;
-	}
-
-	if (listcount(im->isis) == 0)
-		nb_cli_enqueue_change(vty, "./is-type", NB_OP_MODIFY,
-				      "level-1-2");
 	ret = nb_cli_apply_changes(vty, base_xpath);
 	if (ret == CMD_SUCCESS)
 		VTY_PUSH_XPATH(ISIS_NODE, base_xpath);
@@ -190,13 +178,6 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 			 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
 			 tag, vrf_name);
 		nb_cli_enqueue_change(vty, temp_xpath, NB_OP_CREATE, tag);
-		snprintf(
-			temp_xpath, XPATH_MAXLEN,
-			"/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']/is-type",
-			tag, vrf_name);
-		nb_cli_enqueue_change(vty, temp_xpath, NB_OP_MODIFY,
-				      listcount(im->isis) == 0 ? "level-1-2"
-							       : NULL);
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE,
 				      NULL);
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag",
@@ -206,9 +187,6 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 				      vrf_name);
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv4-routing",
 				      NB_OP_MODIFY, "true");
-		nb_cli_enqueue_change(
-			vty, "./frr-isisd:isis/circuit-type", NB_OP_MODIFY,
-			listcount(im->isis) == 0 ? "level-1-2" : "level-1");
 	} else {
 		/* area exists, circuit type defaults to its area's is_type */
 		switch (area->is_type) {
@@ -287,13 +265,6 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 			 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
 			 tag, vrf_name);
 		nb_cli_enqueue_change(vty, temp_xpath, NB_OP_CREATE, tag);
-		snprintf(
-			temp_xpath, XPATH_MAXLEN,
-			"/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']/is-type",
-			tag, vrf_name);
-		nb_cli_enqueue_change(vty, temp_xpath, NB_OP_MODIFY,
-				      listcount(im->isis) == 0 ? "level-1-2"
-							       : NULL);
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis", NB_OP_CREATE,
 				      NULL);
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/area-tag",
@@ -303,9 +274,6 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/ipv6-routing",
 				      NB_OP_MODIFY, "true");
-		nb_cli_enqueue_change(
-			vty, "./frr-isisd:isis/circuit-type", NB_OP_MODIFY,
-			listcount(im->isis) == 0 ? "level-1-2" : "level-1");
 	} else {
 		/* area exists, circuit type defaults to its area's is_type */
 		switch (area->is_type) {

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -188,7 +188,6 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 
 	area = isis_area_lookup_by_vrf(tag, vrf_name);
 	if (!area) {
-		isis_global_instance_create(vrf_name);
 		snprintf(temp_xpath, XPATH_MAXLEN,
 			 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
 			 tag, vrf_name);
@@ -275,7 +274,6 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 
 	area = isis_area_lookup_by_vrf(tag, vrf_name);
 	if (!area) {
-		isis_global_instance_create(vrf_name);
 		snprintf(temp_xpath, XPATH_MAXLEN,
 			 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']",
 			 tag, vrf_name);

--- a/isisd/isis_ldp_sync.h
+++ b/isisd/isis_ldp_sync.h
@@ -29,13 +29,15 @@
 			zlog_debug(__VA_ARGS__);                               \
 	} while (0)
 
-extern void isis_if_set_ldp_sync_enable(struct isis_circuit *circuit);
+extern void isis_area_ldp_sync_enable(struct isis_area *area);
+extern void isis_area_ldp_sync_disable(struct isis_area *area);
+extern void isis_area_ldp_sync_set_holddown(struct isis_area *area,
+					    uint16_t holddown);
+extern void isis_if_ldp_sync_enable(struct isis_circuit *circuit);
+extern void isis_if_ldp_sync_disable(struct isis_circuit *circuit);
 extern void isis_if_set_ldp_sync_holddown(struct  isis_circuit *circuit);
-extern void isis_ldp_sync_if_init(struct isis_circuit *circuit,
-				  struct isis *isis);
 extern void isis_ldp_sync_if_start(struct isis_circuit *circuit,
 				   bool send_state_req);
-extern void isis_ldp_sync_if_remove(struct isis_circuit *circuit, bool remove);
 extern void isis_ldp_sync_if_complete(struct isis_circuit *circuit);
 extern void isis_ldp_sync_holddown_timer_add(struct isis_circuit *circuit);
 extern void
@@ -49,5 +51,4 @@ extern void isis_ldp_sync_set_if_metric(struct isis_circuit *circuit,
 extern bool isis_ldp_sync_if_metric_config(struct isis_circuit *circuit,
 					   int level, int metric);
 extern void isis_ldp_sync_init(void);
-extern void isis_ldp_sync_gbl_exit(bool remove);
 #endif /* _ZEBRA_ISIS_LDP_SYNC_H */

--- a/isisd/isis_nb.c
+++ b/isisd/isis_nb.c
@@ -686,13 +686,6 @@ const struct frr_yang_module_info frr_isisd_info = {
 			},
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/vrf",
-			.cbs = {
-				.modify = lib_interface_isis_vrf_modify,
-			},
-		},
-
-		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/circuit-type",
 			.cbs = {
 				.cli_show = cli_show_ip_isis_circ_type,

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -214,7 +214,6 @@ int isis_instance_mpls_te_router_address_destroy(
 int lib_interface_isis_create(struct nb_cb_create_args *args);
 int lib_interface_isis_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_isis_area_tag_modify(struct nb_cb_modify_args *args);
-int lib_interface_isis_vrf_modify(struct nb_cb_modify_args *args);
 int lib_interface_isis_ipv4_routing_modify(struct nb_cb_modify_args *args);
 int lib_interface_isis_ipv6_routing_modify(struct nb_cb_modify_args *args);
 int lib_interface_isis_circuit_type_modify(struct nb_cb_modify_args *args);

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2544,24 +2544,8 @@ int lib_interface_isis_create(struct nb_cb_create_args *args)
 		}
 		break;
 	case NB_EV_APPLY:
-		area = isis_area_lookup_by_vrf(area_tag, vrf_name);
-		/* The area should have already be created. We are
-		 * setting the priority of the global isis area creation
-		 * slightly lower, so it should be executed first, but I
-		 * cannot rely on that so here I have to check.
-		 */
-		if (!area) {
-			flog_err(
-				EC_LIB_NB_CB_CONFIG_APPLY,
-				"%s: attempt to create circuit for area %s before the area has been created",
-				__func__, area_tag);
-			abort();
-		}
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
-		circuit = isis_circuit_create(area, ifp);
-		assert(circuit
-		       && (circuit->state == C_STATE_CONF
-			   || circuit->state == C_STATE_UP));
+		circuit = isis_circuit_new(ifp, area_tag);
 		nb_running_set_entry(args->dnode, circuit);
 		break;
 	}
@@ -2577,18 +2561,12 @@ int lib_interface_isis_destroy(struct nb_cb_destroy_args *args)
 		return NB_OK;
 
 	circuit = nb_running_unset_entry(args->dnode);
-	if (!circuit)
-		return NB_ERR_INCONSISTENCY;
 
 	/* remove ldp-sync config */
 	isis_ldp_sync_if_remove(circuit, true);
 
-	/* disable both AFs for this circuit. this will also update the
-	 * CSM state by sending an ISIS_DISABLED signal. If there is no
-	 * area associated to the circuit there is nothing to do
-	 */
-	if (circuit->area)
-		isis_circuit_af_set(circuit, false, false);
+	isis_circuit_del(circuit);
+
 	return NB_OK;
 }
 
@@ -2678,7 +2656,6 @@ int lib_interface_isis_circuit_type_modify(struct nb_cb_modify_args *args)
 	struct interface *ifp;
 	struct vrf *vrf;
 	const char *ifname, *vrfname;
-	struct isis *isis = NULL;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -2694,11 +2671,7 @@ int lib_interface_isis_circuit_type_modify(struct nb_cb_modify_args *args)
 		if (!ifp)
 			break;
 
-		isis = isis_lookup_by_vrfid(ifp->vrf_id);
-		if (isis == NULL)
-			return NB_ERR_VALIDATION;
-
-		circuit = circuit_lookup_by_ifp(ifp, isis->init_circ_list);
+		circuit = circuit_scan_by_ifp(ifp);
 		if (circuit && circuit->state == C_STATE_UP
 		    && circuit->area->is_type != IS_LEVEL_1_AND_2
 		    && circuit->area->is_type != circ_type) {
@@ -3085,7 +3058,6 @@ int lib_interface_isis_network_type_modify(struct nb_cb_modify_args *args)
 int lib_interface_isis_passive_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_circuit *circuit;
-	struct isis_area *area;
 	struct interface *ifp;
 	bool passive = yang_dnode_get_bool(args->dnode, NULL);
 
@@ -3108,14 +3080,7 @@ int lib_interface_isis_passive_modify(struct nb_cb_modify_args *args)
 		return NB_OK;
 
 	circuit = nb_running_get_entry(args->dnode, NULL, true);
-	if (circuit->state != C_STATE_UP) {
-		circuit->is_passive = passive;
-	} else {
-		area = circuit->area;
-		isis_csm_state_change(ISIS_DISABLE, circuit, area);
-		circuit->is_passive = passive;
-		isis_csm_state_change(ISIS_ENABLE, circuit, area);
-	}
+	isis_circuit_passive_set(circuit, passive);
 
 	return NB_OK;
 }
@@ -3473,15 +3438,18 @@ int lib_interface_isis_fast_reroute_level_1_lfa_enable_modify(
 
 	circuit = nb_running_get_entry(args->dnode, NULL, true);
 	circuit->lfa_protection[0] = yang_dnode_get_bool(args->dnode, NULL);
-	if (circuit->lfa_protection[0])
-		circuit->area->lfa_protected_links[0]++;
-	else {
-		assert(circuit->area->lfa_protected_links[0] > 0);
-		circuit->area->lfa_protected_links[0]--;
-	}
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area) {
+		if (circuit->lfa_protection[0])
+			area->lfa_protected_links[0]++;
+		else {
+			assert(area->lfa_protected_links[0] > 0);
+			area->lfa_protected_links[0]--;
+		}
+
+		lsp_regenerate_schedule(area, area->is_type, 0);
+	}
 
 	return NB_OK;
 }
@@ -3505,7 +3473,8 @@ int lib_interface_isis_fast_reroute_level_1_lfa_exclude_interface_create(
 
 	isis_lfa_excluded_iface_add(circuit, ISIS_LEVEL1, exclude_ifname);
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -3525,7 +3494,8 @@ int lib_interface_isis_fast_reroute_level_1_lfa_exclude_interface_destroy(
 
 	isis_lfa_excluded_iface_delete(circuit, ISIS_LEVEL1, exclude_ifname);
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -3545,15 +3515,18 @@ int lib_interface_isis_fast_reroute_level_1_remote_lfa_enable_modify(
 
 	circuit = nb_running_get_entry(args->dnode, NULL, true);
 	circuit->rlfa_protection[0] = yang_dnode_get_bool(args->dnode, NULL);
-	if (circuit->rlfa_protection[0])
-		circuit->area->rlfa_protected_links[0]++;
-	else {
-		assert(circuit->area->rlfa_protected_links[0] > 0);
-		circuit->area->rlfa_protected_links[0]--;
-	}
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area) {
+		if (circuit->rlfa_protection[0])
+			area->rlfa_protected_links[0]++;
+		else {
+			assert(area->rlfa_protected_links[0] > 0);
+			area->rlfa_protected_links[0]--;
+		}
+
+		lsp_regenerate_schedule(area, area->is_type, 0);
+	}
 
 	return NB_OK;
 }
@@ -3575,7 +3548,8 @@ int lib_interface_isis_fast_reroute_level_1_remote_lfa_maximum_metric_modify(
 	circuit->rlfa_max_metric[0] = yang_dnode_get_uint32(args->dnode, NULL);
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -3593,7 +3567,8 @@ int lib_interface_isis_fast_reroute_level_1_remote_lfa_maximum_metric_destroy(
 	circuit->rlfa_max_metric[0] = 0;
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -3613,15 +3588,18 @@ int lib_interface_isis_fast_reroute_level_1_ti_lfa_enable_modify(
 
 	circuit = nb_running_get_entry(args->dnode, NULL, true);
 	circuit->tilfa_protection[0] = yang_dnode_get_bool(args->dnode, NULL);
-	if (circuit->tilfa_protection[0])
-		circuit->area->tilfa_protected_links[0]++;
-	else {
-		assert(circuit->area->tilfa_protected_links[0] > 0);
-		circuit->area->tilfa_protected_links[0]--;
-	}
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area) {
+		if (circuit->tilfa_protection[0])
+			area->tilfa_protected_links[0]++;
+		else {
+			assert(area->tilfa_protected_links[0] > 0);
+			area->tilfa_protected_links[0]--;
+		}
+
+		lsp_regenerate_schedule(area, area->is_type, 0);
+	}
 
 	return NB_OK;
 }
@@ -3644,7 +3622,8 @@ int lib_interface_isis_fast_reroute_level_1_ti_lfa_node_protection_modify(
 		yang_dnode_get_bool(args->dnode, NULL);
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -3664,15 +3643,18 @@ int lib_interface_isis_fast_reroute_level_2_lfa_enable_modify(
 
 	circuit = nb_running_get_entry(args->dnode, NULL, true);
 	circuit->lfa_protection[1] = yang_dnode_get_bool(args->dnode, NULL);
-	if (circuit->lfa_protection[1])
-		circuit->area->lfa_protected_links[1]++;
-	else {
-		assert(circuit->area->lfa_protected_links[1] > 0);
-		circuit->area->lfa_protected_links[1]--;
-	}
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area) {
+		if (circuit->lfa_protection[1])
+			area->lfa_protected_links[1]++;
+		else {
+			assert(area->lfa_protected_links[1] > 0);
+			area->lfa_protected_links[1]--;
+		}
+
+		lsp_regenerate_schedule(area, area->is_type, 0);
+	}
 
 	return NB_OK;
 }
@@ -3696,7 +3678,8 @@ int lib_interface_isis_fast_reroute_level_2_lfa_exclude_interface_create(
 
 	isis_lfa_excluded_iface_add(circuit, ISIS_LEVEL2, exclude_ifname);
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -3716,7 +3699,8 @@ int lib_interface_isis_fast_reroute_level_2_lfa_exclude_interface_destroy(
 
 	isis_lfa_excluded_iface_delete(circuit, ISIS_LEVEL2, exclude_ifname);
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -3736,15 +3720,18 @@ int lib_interface_isis_fast_reroute_level_2_remote_lfa_enable_modify(
 
 	circuit = nb_running_get_entry(args->dnode, NULL, true);
 	circuit->rlfa_protection[1] = yang_dnode_get_bool(args->dnode, NULL);
-	if (circuit->rlfa_protection[1])
-		circuit->area->rlfa_protected_links[1]++;
-	else {
-		assert(circuit->area->rlfa_protected_links[1] > 0);
-		circuit->area->rlfa_protected_links[1]--;
-	}
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area) {
+		if (circuit->rlfa_protection[1])
+			area->rlfa_protected_links[1]++;
+		else {
+			assert(area->rlfa_protected_links[1] > 0);
+			area->rlfa_protected_links[1]--;
+		}
+
+		lsp_regenerate_schedule(area, area->is_type, 0);
+	}
 
 	return NB_OK;
 }
@@ -3766,7 +3753,8 @@ int lib_interface_isis_fast_reroute_level_2_remote_lfa_maximum_metric_modify(
 	circuit->rlfa_max_metric[1] = yang_dnode_get_uint32(args->dnode, NULL);
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -3784,7 +3772,8 @@ int lib_interface_isis_fast_reroute_level_2_remote_lfa_maximum_metric_destroy(
 	circuit->rlfa_max_metric[1] = 0;
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -3804,15 +3793,18 @@ int lib_interface_isis_fast_reroute_level_2_ti_lfa_enable_modify(
 
 	circuit = nb_running_get_entry(args->dnode, NULL, true);
 	circuit->tilfa_protection[1] = yang_dnode_get_bool(args->dnode, NULL);
-	if (circuit->tilfa_protection[1])
-		circuit->area->tilfa_protected_links[1]++;
-	else {
-		assert(circuit->area->tilfa_protected_links[1] > 0);
-		circuit->area->tilfa_protected_links[1]--;
-	}
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area) {
+		if (circuit->tilfa_protection[1])
+			area->tilfa_protected_links[1]++;
+		else {
+			assert(area->tilfa_protected_links[1] > 0);
+			area->tilfa_protected_links[1]--;
+		}
+
+		lsp_regenerate_schedule(area, area->is_type, 0);
+	}
 
 	return NB_OK;
 }
@@ -3835,7 +3827,8 @@ int lib_interface_isis_fast_reroute_level_2_ti_lfa_node_protection_modify(
 		yang_dnode_get_bool(args->dnode, NULL);
 
 	area = circuit->area;
-	lsp_regenerate_schedule(area, area->is_type, 0);
+	if (area)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -3171,9 +3171,20 @@ int lib_interface_isis_mpls_ldp_sync_modify(struct nb_cb_modify_args *args)
 	struct isis_circuit *circuit;
 	struct ldp_sync_info *ldp_sync_info;
 	bool ldp_sync_enable;
+	struct interface *ifp;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		ifp = nb_running_get_entry(args->dnode->parent->parent->parent,
+					   NULL, false);
+		if (ifp == NULL)
+			return NB_ERR_VALIDATION;
+		if (if_is_loopback(ifp)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "LDP-Sync does not run on loopback interface");
+			return NB_ERR_VALIDATION;
+		}
+
 		circuit = nb_running_get_entry(args->dnode, NULL, false);
 		if (circuit == NULL || circuit->area == NULL)
 			break;
@@ -3215,9 +3226,20 @@ int lib_interface_isis_mpls_holddown_modify(struct nb_cb_modify_args *args)
 	struct isis_circuit *circuit;
 	struct ldp_sync_info *ldp_sync_info;
 	uint16_t holddown;
+	struct interface *ifp;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		ifp = nb_running_get_entry(args->dnode->parent->parent->parent,
+					   NULL, false);
+		if (ifp == NULL)
+			return NB_ERR_VALIDATION;
+		if (if_is_loopback(ifp)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "LDP-Sync does not run on loopback interface");
+			return NB_ERR_VALIDATION;
+		}
+
 		circuit = nb_running_get_entry(args->dnode, NULL, false);
 		if (circuit == NULL || circuit->area == NULL)
 			break;
@@ -3248,9 +3270,20 @@ int lib_interface_isis_mpls_holddown_destroy(struct nb_cb_destroy_args *args)
 {
 	struct isis_circuit *circuit;
 	struct ldp_sync_info *ldp_sync_info;
+	struct interface *ifp;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		ifp = nb_running_get_entry(args->dnode->parent->parent->parent,
+					   NULL, false);
+		if (ifp == NULL)
+			return NB_ERR_VALIDATION;
+		if (if_is_loopback(ifp)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "LDP-Sync does not run on loopback interface");
+			return NB_ERR_VALIDATION;
+		}
+
 		circuit = nb_running_get_entry(args->dnode, NULL, false);
 		if (circuit == NULL || circuit->area == NULL)
 			break;

--- a/isisd/isis_vty_fabricd.c
+++ b/isisd/isis_vty_fabricd.c
@@ -229,10 +229,10 @@ DEFUN (ip_router_isis,
 
 	area = isis_area_lookup(area_tag, VRF_DEFAULT);
 	if (!area)
-		area = isis_area_create(area_tag, VRF_DEFAULT_NAME);
+		isis_area_create(area_tag, VRF_DEFAULT_NAME);
 
-	if (!circuit || !circuit->area) {
-		circuit = isis_circuit_create(area, ifp);
+	if (!circuit) {
+		circuit = isis_circuit_new(ifp, area_tag);
 
 		if (circuit->state != C_STATE_CONF
 		    && circuit->state != C_STATE_UP) {
@@ -288,7 +288,7 @@ DEFUN (no_ip_router_isis,
 		return CMD_ERR_NO_MATCH;
 	}
 
-	circuit = circuit_lookup_by_ifp(ifp, area->circuit_list);
+	circuit = circuit_scan_by_ifp(ifp);
 	if (!circuit) {
 		vty_out(vty, "ISIS is not enabled on circuit %s\n", ifp->name);
 		return CMD_ERR_NO_MATCH;
@@ -301,6 +301,10 @@ DEFUN (no_ip_router_isis,
 		ip = false;
 
 	isis_circuit_af_set(circuit, ip, ipv6);
+
+	if (!ip && !ipv6)
+		isis_circuit_del(circuit);
+
 	return CMD_SUCCESS;
 }
 

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -728,6 +728,8 @@ static void isis_zebra_connected(struct zclient *zclient)
 {
 	zclient_send_reg_requests(zclient, VRF_DEFAULT);
 	zclient_register_opaque(zclient, LDP_RLFA_LABELS);
+	zclient_register_opaque(zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
+	zclient_register_opaque(zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
 }
 
 /*
@@ -818,6 +820,8 @@ void isis_zebra_init(struct thread_master *master, int instance)
 void isis_zebra_stop(void)
 {
 	zclient_unregister_opaque(zclient, LDP_RLFA_LABELS);
+	zclient_unregister_opaque(zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
+	zclient_unregister_opaque(zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
 	zclient_stop(zclient_sync);
 	zclient_free(zclient_sync);
 	zclient_stop(zclient);

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -89,7 +89,6 @@ struct isis {
 	uint8_t sysid[ISIS_SYS_ID_LEN]; /* SystemID for this IS */
 	uint32_t router_id;		/* Router ID from zebra */
 	struct list *area_list;	/* list of IS-IS areas */
-	struct list *init_circ_list;
 	uint8_t max_area_addrs;		  /* maximumAreaAdresses */
 	struct area_addr *man_area_addrs; /* manualAreaAddresses */
 	time_t uptime;			  /* when did we start */
@@ -244,7 +243,6 @@ DECLARE_MTYPE(ISIS_AREA_ADDR);	/* isis_area->area_addrs */
 DECLARE_HOOK(isis_area_overload_bit_update, (struct isis_area * area), (area));
 
 void isis_terminate(void);
-void isis_finish(struct isis *isis);
 void isis_master_init(struct thread_master *master);
 void isis_vrf_link(struct isis *isis, struct vrf *vrf);
 void isis_vrf_unlink(struct isis *isis, struct vrf *vrf);
@@ -257,6 +255,13 @@ void isis_init(void);
 void isis_vrf_init(void);
 
 struct isis *isis_new(const char *vrf_name);
+void isis_finish(struct isis *isis);
+
+void isis_area_add_circuit(struct isis_area *area,
+			   struct isis_circuit *circuit);
+void isis_area_del_circuit(struct isis_area *area,
+			   struct isis_circuit *circuit);
+
 struct isis_area *isis_area_create(const char *, const char *);
 struct isis_area *isis_area_lookup(const char *, vrf_id_t vrf_id);
 struct isis_area *isis_area_lookup_by_vrf(const char *area_tag,

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -97,7 +97,6 @@ struct isis {
 	int snmp_notifications;
 
 	struct route_table *ext_info[REDIST_PROTOCOL_COUNT];
-	struct ldp_sync_info_cmd ldp_sync_cmd; 	/* MPLS LDP-IGP Sync */
 };
 
 extern struct isis_master *im;
@@ -209,6 +208,8 @@ struct isis_area {
 	struct prefix_list *rlfa_plist[ISIS_LEVELS];
 	size_t rlfa_protected_links[ISIS_LEVELS];
 	size_t tilfa_protected_links[ISIS_LEVELS];
+	/* MPLS LDP-IGP Sync */
+	struct ldp_sync_info_cmd ldp_sync_cmd;
 	/* Counters */
 	uint32_t circuit_state_changes;
 	struct isis_redist redist_settings[REDIST_PROTOCOL_COUNT]

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -65,8 +65,6 @@ extern void isis_cli_init(void);
 		all_vrf = strmatch(vrf_name, "all");                           \
 	}
 
-#define SNMP_CIRCUITS_MAX (512)
-
 extern struct zebra_privs_t isisd_privs;
 
 /* uncomment if you are a developer in bug hunt */
@@ -97,8 +95,6 @@ struct isis {
 	time_t uptime;			  /* when did we start */
 	struct thread *t_dync_clean;      /* dynamic hostname cache cleanup thread */
 	uint32_t circuit_ids_used[8];     /* 256 bits to track circuit ids 1 through 255 */
-	struct isis_circuit *snmp_circuits[SNMP_CIRCUITS_MAX];
-	uint32_t snmp_circuit_id_last;
 	int snmp_notifications;
 
 	struct route_table *ext_info[REDIST_PROTOCOL_COUNT];

--- a/tests/isisd/test_isis_spf.c
+++ b/tests/isisd/test_isis_spf.c
@@ -556,7 +556,6 @@ int main(int argc, char **argv)
 	/* IS-IS inits. */
 	yang_module_load("frr-isisd");
 	isis = isis_new(VRF_DEFAULT_NAME);
-	listnode_add(im->isis, isis);
 	SET_FLAG(im->options, F_ISIS_UNIT_TEST);
 	debug_spf_events |= DEBUG_SPF_EVENTS;
 	debug_lfa |= DEBUG_LFA;

--- a/tests/topotests/isis-snmp/test_isis_snmp.py
+++ b/tests/topotests/isis-snmp/test_isis_snmp.py
@@ -243,15 +243,15 @@ def test_r1_scalar_snmp():
 
 
 circtable_test = {
-    "isisCircAdminState": ["on(1)", "on(1)", "on(1)"],
-    "isisCircExistState": ["active(1)", "active(1)", "active(1)"],
-    "isisCircType": ["broadcast(1)", "ptToPt(2)", "staticIn(3)"],
-    "isisCircExtDomain": ["false(2)", "false(2)", "false(2)"],
-    "isisCircLevelType": ["level1(1)", "level1(1)", "level1and2(3)"],
-    "isisCircPassiveCircuit": ["false(2)", "false(2)", "true(1)"],
-    "isisCircMeshGroupEnabled": ["inactive(1)", "inactive(1)", "inactive(1)"],
-    "isisCircSmallHellos": ["false(2)", "false(2)", "false(2)"],
-    "isisCirc3WayEnabled": ["false(2)", "false(2)", "false(2)"],
+    "isisCircAdminState": ["on(1)", "on(1)"],
+    "isisCircExistState": ["active(1)", "active(1)"],
+    "isisCircType": ["broadcast(1)", "ptToPt(2)"],
+    "isisCircExtDomain": ["false(2)", "false(2)"],
+    "isisCircLevelType": ["level1(1)", "level1(1)"],
+    "isisCircPassiveCircuit": ["false(2)", "false(2)"],
+    "isisCircMeshGroupEnabled": ["inactive(1)", "inactive(1)"],
+    "isisCircSmallHellos": ["false(2)", "false(2)"],
+    "isisCirc3WayEnabled": ["false(2)", "false(2)"],
 }
 
 
@@ -266,7 +266,6 @@ def test_r1_isisCircTable():
     oids = []
     oids.append(generate_oid(1, 1, 0))
     oids.append(generate_oid(1, 2, 0))
-    oids.append(generate_oid(1, 3, 0))
 
     # check items
     for item in circtable_test.keys():
@@ -277,21 +276,17 @@ def test_r1_isisCircTable():
 
 
 circleveltable_test = {
-    "isisCircLevelMetric": ["10", "10", "10", "10"],
-    "isisCircLevelWideMetric": ["10", "10", "0", "0"],
-    "isisCircLevelISPriority": ["64", "64", "64", "64"],
-    "isisCircLevelHelloMultiplier": ["10", "10", "10", "10"],
+    "isisCircLevelMetric": ["10", "10"],
+    "isisCircLevelWideMetric": ["10", "10"],
+    "isisCircLevelISPriority": ["64", "64"],
+    "isisCircLevelHelloMultiplier": ["10", "10"],
     "isisCircLevelHelloTimer": [
-        "3000 milliseconds",
-        "3000 milliseconds",
         "3000 milliseconds",
         "3000 milliseconds",
     ],
     "isisCircLevelMinLSPRetransInt": [
         "1 seconds",
         "1 seconds",
-        "0 seconds",
-        "0 seconds",
     ],
 }
 
@@ -307,8 +302,6 @@ def test_r1_isislevelCircTable():
     oids = []
     oids.append(generate_oid(2, 1, "area"))
     oids.append(generate_oid(2, 2, "area"))
-    oids.append(generate_oid(2, 3, "area"))
-    oids.append(generate_oid(2, 3, "domain"))
 
     # check items
     for item in circleveltable_test.keys():

--- a/tests/topotests/isis-sr-topo1/test_isis_sr_topo1.py
+++ b/tests/topotests/isis-sr-topo1/test_isis_sr_topo1.py
@@ -1002,6 +1002,12 @@ def test_isis_adjacencies_step12():
     tgen.net["rt4"].cmd(
         'vtysh -c "conf t" -c "interface eth-rt5" -c "ipv6 router isis 1"'
     )
+    tgen.net["rt4"].cmd(
+        'vtysh -c "conf t" -c "interface eth-rt5" -c "isis network point-to-point"'
+    )
+    tgen.net["rt4"].cmd(
+        'vtysh -c "conf t" -c "interface eth-rt5" -c "isis hello-multiplier 3"'
+    )
     tgen.net["rt6"].cmd(
         'vtysh -c "conf t" -c "router isis 1" -c "segment-routing global-block 16000 23999"'
     )

--- a/tests/topotests/ldp-sync-isis-topo1/r3/show_isis_ldp_sync.ref
+++ b/tests/topotests/ldp-sync-isis-topo1/r3/show_isis_ldp_sync.ref
@@ -1,7 +1,7 @@
 {
   "r3-eth1":{
     "ldpIgpSyncEnabled":false,
-    "holdDownTimeInSec":50,
+    "holdDownTimeInSec":0,
     "ldpIgpSyncState":"Sync not required"
   },
   "r3-eth2":{

--- a/tests/topotests/ldp-sync-isis-topo1/r3/show_isis_ldp_sync_r1_eth1_shutdown.ref
+++ b/tests/topotests/ldp-sync-isis-topo1/r3/show_isis_ldp_sync_r1_eth1_shutdown.ref
@@ -1,7 +1,7 @@
 {
   "r3-eth1":{
     "ldpIgpSyncEnabled":false,
-    "holdDownTimeInSec":50,
+    "holdDownTimeInSec":0,
     "ldpIgpSyncState":"Sync not required"
   },
   "r3-eth2":{

--- a/tests/topotests/ldp-sync-isis-topo1/r3/show_isis_ldp_sync_r2_eth1_shutdown.ref
+++ b/tests/topotests/ldp-sync-isis-topo1/r3/show_isis_ldp_sync_r2_eth1_shutdown.ref
@@ -1,7 +1,7 @@
 {
   "r3-eth1":{
     "ldpIgpSyncEnabled":false,
-    "holdDownTimeInSec":50,
+    "holdDownTimeInSec":0,
     "ldpIgpSyncState":"Sync not required"
   },
   "r3-eth2":{

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -506,13 +506,6 @@ module frr-isisd {
         "Area-tag associated to this circuit.";
     }
 
-    leaf vrf {
-      type frr-vrf:vrf-ref;
-      default "default";
-      description
-        "VRF NAME.";
-    }
-
     leaf ipv4-routing {
       type boolean;
       default "false";

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -791,10 +791,10 @@ module frr-isisd {
       leaf holddown {
         type uint16 {
           range "0..10000";
-      }
-      units "seconds";
-      description
-        "Time to wait for LDP-Sync to occur before restoring interface metric.";
+        }
+        units "seconds";
+        description
+          "Time to wait for LDP-Sync to occur before restoring interface metric.";
       }
     }
 


### PR DESCRIPTION
There are a lot of ISIS fixes in this PR. Main parts are:

1. Fix for circuit SNMP ID generation. Details in commit 58a339f.
2. Allow an arbitrary order of configuration - in particular allow an interface config to be created without an area config. This is necessary for the correct processing of interface moves between VRFs. Details in commit b525ceb.
3. Fix configuration of LDP-sync. The config is per-area but actually controls the whole VRF. Details in 936cdbd. Fixes #8578.
4. Fixes for CLI - it incorrectly uses the operational data instead of NB config nodes. Last 7 commits.