### PR TITLE
vtysh: fix searching commands in parent nodes

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1049,6 +1049,7 @@ int cmd_execute_command(vector vline, struct vty *vty,
 		return saved_ret;
 
 	if (ret != CMD_SUCCESS && ret != CMD_WARNING
+	    && ret != CMD_ERR_AMBIGUOUS && ret != CMD_ERR_INCOMPLETE
 	    && ret != CMD_NOT_MY_INSTANCE && ret != CMD_WARNING_CONFIG_FAILED) {
 		/* This assumes all nodes above CONFIG_NODE are childs of
 		 * CONFIG_NODE */
@@ -1062,6 +1063,7 @@ int cmd_execute_command(vector vline, struct vty *vty,
 			ret = cmd_execute_command_real(vline, FILTER_RELAXED,
 						       vty, cmd, 0);
 			if (ret == CMD_SUCCESS || ret == CMD_WARNING
+			    || ret == CMD_ERR_AMBIGUOUS || ret == CMD_ERR_INCOMPLETE
 			    || ret == CMD_NOT_MY_INSTANCE
 			    || ret == CMD_WARNING_CONFIG_FAILED)
 				return ret;
@@ -1260,6 +1262,7 @@ int command_config_read_one_line(struct vty *vty,
 	while (!(use_daemon && ret == CMD_SUCCESS_DAEMON)
 	       && !(!use_daemon && ret == CMD_ERR_NOTHING_TODO)
 	       && ret != CMD_SUCCESS && ret != CMD_WARNING
+	       && ret != CMD_ERR_AMBIGUOUS && ret != CMD_ERR_INCOMPLETE
 	       && ret != CMD_NOT_MY_INSTANCE && ret != CMD_WARNING_CONFIG_FAILED
 	       && ret != CMD_NO_LEVEL_UP)
 		ret = cmd_execute_command_real(vline, FILTER_STRICT, vty, cmd,

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -493,6 +493,7 @@ static int vtysh_execute_func(const char *line, int pager)
 	 */
 	while (ret != CMD_SUCCESS && ret != CMD_SUCCESS_DAEMON
 	       && ret != CMD_WARNING && ret != CMD_WARNING_CONFIG_FAILED
+	       && ret != CMD_ERR_AMBIGUOUS && ret != CMD_ERR_INCOMPLETE
 	       && vty->node > CONFIG_NODE) {
 		vty->node = node_parent(vty->node);
 		ret = cmd_execute(vty, line, &cmd, 1);
@@ -794,6 +795,7 @@ int vtysh_mark_file(const char *filename)
 		 */
 		while (ret != CMD_SUCCESS && ret != CMD_SUCCESS_DAEMON
 		       && ret != CMD_WARNING && ret != CMD_WARNING_CONFIG_FAILED
+		       && ret != CMD_ERR_AMBIGUOUS && ret != CMD_ERR_INCOMPLETE
 		       && vty->node > CONFIG_NODE) {
 			vty->node = node_parent(vty->node);
 			ret = cmd_execute_command_strict(vline, vty, &cmd);


### PR DESCRIPTION
Do not check parent command nodes in case of ambiguous and incomplete commands

Signed-off-by: Pavel Ivashchenko <pivashchenko@nfware.com>

Imagine we have commands `interface foo bar` and `interface foo baz` commands in some node.
The user enters `interface foo`. This is an ambiguous command and it is unexpected to find and execute
this command in the previous node.