### PR TITLE
isisd: fix show LFA debug in show debugging cmd

### DIFF
--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -1376,6 +1376,9 @@ DEFUN_NOSH (show_debugging,
 		print_debug(vty, DEBUG_BFD, 1);
 	if (IS_DEBUG_LDP_SYNC)
 		print_debug(vty, DEBUG_LDP_SYNC, 1);
+	if (IS_DEBUG_LFA)
+		print_debug(vty, DEBUG_LFA, 1);
+
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
When enabling 'debug isis lfa', the option was correctly enabled
but not displayed by 'show debugging' command.

Signed-off-by: Fredi Raspall <fredi@voltanet.io>