### PR TITLE
isisd: fix memory leak for non-freed spftrees

### DIFF
--- a/isisd/isis_lfa.c
+++ b/isisd/isis_lfa.c
@@ -1148,10 +1148,13 @@ static void lfa_calc_pq_spaces(struct isis_spftree *spftree_pc,
 
 			/*
 			 * Compute the reverse SPF in the behalf of the node
-			 * adjacent to the failure.
+			 * adjacent to the failure, if we haven't done that
+			 * before
 			 */
-			adj_node->lfa.spftree_reverse =
-				isis_spf_reverse_run(adj_node->lfa.spftree);
+			if (!adj_node->lfa.spftree_reverse)
+				adj_node->lfa.spftree_reverse =
+					isis_spf_reverse_run(
+						adj_node->lfa.spftree);
 
 			lfa_calc_reach_nodes(adj_node->lfa.spftree_reverse,
 					     spftree_reverse, adj_nodes, false,


### PR DESCRIPTION
When enabling TI-LFA the forward SPF for neighbors adjacent to the
PLR is computed. Later, when computing the PQ spaces, the reverse
SPF trees for those adjacent neighbors affected by the protected
interface are computed.

When node protection is enabled, TI-LFA link protection is run
immediately afterwards to compute repairs in case no
node-protecting backup path exists. In this second run, the
existing code tries to compute the reverse SPF tree for the same
node, without freeing the SPF tree of the prior run.

This patch fixes this by not computing the reverse SPF again, thus
avoiding a memory leak and an unnecessary SPF run.

Signed-off-by: Fredi Raspall <fredi@voltanet.io>