### PR TITLE
isisd: clear the N-flag in ext. reachability TLVs

### DIFF
--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -438,7 +438,7 @@ void isis_sr_prefix_cfg2subtlv(const struct sr_prefix_cfg *pcfg, bool external,
 	}
 	if (external)
 		SET_FLAG(psid->flags, ISIS_PREFIX_SID_READVERTISED);
-	if (pcfg->node_sid)
+	if (pcfg->node_sid && !pcfg->n_flag_clear)
 		SET_FLAG(psid->flags, ISIS_PREFIX_SID_NODE);
 
 	/* Set SID value. */

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -361,9 +361,9 @@ struct sr_prefix_cfg *isis_sr_cfg_prefix_add(struct isis_area *area,
 	pcfg->last_hop_behavior = yang_get_default_enum(
 		"%s/prefix-sid-map/prefix-sid/last-hop-behavior", ISIS_SR);
 
-	/* Set the N-flag when appropriate. */
+	/* Mark as node Sid if the prefix is host and configured in loopback */
 	ifp = if_lookup_prefix(prefix, VRF_DEFAULT);
-	if (ifp && sr_prefix_is_node_sid(ifp, prefix) && !pcfg->n_flag_clear)
+	if (ifp && sr_prefix_is_node_sid(ifp, prefix))
 		pcfg->node_sid = true;
 
 	/* Save prefix-sid configuration. */
@@ -948,8 +948,7 @@ static int sr_if_new_hook(struct interface *ifp)
 		if (!pcfg)
 			continue;
 
-		if (sr_prefix_is_node_sid(ifp, &pcfg->prefix)
-		    && !pcfg->n_flag_clear) {
+		if (sr_prefix_is_node_sid(ifp, &pcfg->prefix)) {
 			pcfg->node_sid = true;
 			lsp_regenerate_schedule(area, area->is_type, 0);
 		}


### PR DESCRIPTION
If the n-flag-clear option is set in the configuration of a prefix
segment, clear the flag in the extended ip reachability TLVs.

RFCs 7794 and 8667 are not too strict on the setting / clearing the
N-flag in prefix SIDs. However, if there exists a cmd line option
to clear it, it should be cleared in the TLVs announced, as other
vendors do.

Signed-off-by: Fredi Raspall <fredi@voltanet.io>