### PR TITLE
If vrf name

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -210,10 +210,12 @@ void if_down_via_zapi(struct interface *ifp)
 struct interface *if_create_name(const char *name, vrf_id_t vrf_id)
 {
 	struct interface *ifp;
+	struct vrf *vrf;
 
+	vrf = vrf_lookup_by_id(vrf_id != VRF_UNKNOWN ? vrf_id : VRF_DEFAULT);
 	ifp = if_new(vrf_id);
 
-	if_set_name(ifp, name);
+	if_set_name(ifp, name, vrf->name);
 
 	hook_call(if_add, ifp);
 	return ifp;
@@ -670,11 +672,11 @@ int if_set_index(struct interface *ifp, ifindex_t ifindex)
 	return 0;
 }
 
-void if_set_name(struct interface *ifp, const char *name)
+void if_set_name(struct interface *ifp, const char *name, const char *vrf_name)
 {
 	struct vrf *vrf;
 
-	vrf = vrf_get(ifp->vrf_id, NULL);
+	vrf = vrf_lookup_by_name(vrf_name);
 	assert(vrf);
 
 	if (if_cmp_name_func(ifp->name, name) == 0)

--- a/lib/if.c
+++ b/lib/if.c
@@ -207,13 +207,15 @@ void if_down_via_zapi(struct interface *ifp)
 		(*ifp_master.down_hook)(ifp);
 }
 
-struct interface *if_create_name(const char *name, vrf_id_t vrf_id)
+struct interface *if_create_name(const char *name, const char *vrf_name)
 {
 	struct interface *ifp;
 	struct vrf *vrf;
 
-	vrf = vrf_lookup_by_id(vrf_id != VRF_UNKNOWN ? vrf_id : VRF_DEFAULT);
-	ifp = if_new(vrf_id);
+	vrf = vrf_lookup_by_name(vrf_name);
+	assert(vrf);
+
+	ifp = if_new(vrf->vrf_id != VRF_UNKNOWN ? vrf->vrf_id : VRF_DEFAULT);
 
 	if_set_name(ifp, name, vrf->name);
 
@@ -584,6 +586,7 @@ size_t if_lookup_by_hwaddr(const uint8_t *hw_addr, size_t addrsz,
 struct interface *if_get_by_name(const char *name, vrf_id_t vrf_id)
 {
 	struct interface *ifp;
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
 	switch (vrf_get_backend()) {
 	case VRF_BACKEND_UNKNOWN:
@@ -591,7 +594,7 @@ struct interface *if_get_by_name(const char *name, vrf_id_t vrf_id)
 		ifp = if_lookup_by_name(name, vrf_id);
 		if (ifp)
 			return ifp;
-		return if_create_name(name, vrf_id);
+		return if_create_name(name, vrf->name);
 	case VRF_BACKEND_VRF_LITE:
 		ifp = if_lookup_by_name_all_vrf(name);
 		if (ifp) {
@@ -603,7 +606,7 @@ struct interface *if_get_by_name(const char *name, vrf_id_t vrf_id)
 			if_update_to_new_vrf(ifp, vrf_id);
 			return ifp;
 		}
-		return if_create_name(name, vrf_id);
+		return if_create_name(name, vrf->name);
 	}
 
 	return NULL;

--- a/lib/if.h
+++ b/lib/if.h
@@ -508,7 +508,7 @@ extern int if_cmp_name_func(const char *p1, const char *p2);
 extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
 
 /* Create new interface, adds to name list only */
-extern struct interface *if_create_name(const char *name, vrf_id_t vrf_id);
+extern struct interface *if_create_name(const char *name, const char *vrf_name);
 
 /* Create new interface, adds to index list only */
 extern struct interface *if_create_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);

--- a/lib/if.h
+++ b/lib/if.h
@@ -511,7 +511,8 @@ extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
 extern struct interface *if_create_name(const char *name, const char *vrf_name);
 
 /* Create new interface, adds to index list only */
-extern struct interface *if_create_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);
+extern struct interface *if_create_ifindex(ifindex_t ifindex,
+					   const char *vrf_name);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
 extern struct interface *if_vrf_lookup_by_index_next(ifindex_t ifindex,
 						     vrf_id_t vrf_id);

--- a/lib/if.h
+++ b/lib/if.h
@@ -535,7 +535,8 @@ extern struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);
 /* Sets the index and adds to index list */
 extern int if_set_index(struct interface *ifp, ifindex_t ifindex);
 /* Sets the name and adds to name list */
-extern void if_set_name(struct interface *ifp, const char *name);
+extern void if_set_name(struct interface *ifp, const char *name,
+			const char *vrf_name);
 
 /* Delete the interface, but do not free the structure, and leave it in the
    interface list.  It is often advisable to leave the pseudo interface

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -893,7 +893,7 @@ struct ospf_interface *ospf_vl_new(struct ospf *ospf,
 			ospf->vrf_id);
 
 	snprintf(ifname, sizeof(ifname), "VLINK%u", vlink_count);
-	vi = if_create_name(ifname, ospf->vrf_id);
+	vi = if_create_name(ifname, ospf_get_name(ospf));
 	/*
 	 * if_create_name sets ZEBRA_INTERFACE_LINKDETECTION
 	 * virtual links don't need this.

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1483,7 +1483,7 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 			snprintf(pimreg_name, sizeof(pimreg_name), "pimreg%u",
 				 pim->vrf->data.l.table_id);
 
-		pim->regiface = if_create_name(pimreg_name, pim->vrf_id);
+		pim->regiface = if_create_name(pimreg_name, pim->vrf->name);
 		pim->regiface->ifindex = PIM_OIF_PIM_REGISTER_VIF;
 
 		pim_if_new(pim->regiface, false, false, true,

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -758,6 +758,7 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	struct zebra_if *zif;
 	ns_id_t link_nsid = ns_id;
 	uint8_t bypass = 0;
+	struct vrf *vrf;
 
 	zns = zebra_ns_lookup(ns_id);
 	ifi = NLMSG_DATA(h);
@@ -856,7 +857,8 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	ifp = if_get_by_ifindex(ifi->ifi_index, vrf_id);
 	set_ifindex(ifp, ifi->ifi_index, zns); /* add it to ns struct */
 
-	if_set_name(ifp, name);
+	vrf = vrf_lookup_by_id(vrf_id);
+	if_set_name(ifp, name, vrf ? vrf->name : VRF_DEFAULT_NAME);
 
 	ifp->flags = ifi->ifi_flags & 0x0000fffff;
 	ifp->mtu6 = ifp->mtu = *(uint32_t *)RTA_DATA(tb[IFLA_MTU]);

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -624,7 +624,7 @@ int ifm_read(struct if_msghdr *ifm)
 		if (ifp == NULL) {
 			/* Interface that zebra was not previously aware of, so
 			 * create. */
-			ifp = if_create_name(ifname, VRF_DEFAULT);
+			ifp = if_create_name(ifname, VRF_DEFAULT_NAME);
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug("%s: creating ifp for ifindex %d",
 					   __func__, ifm->ifm_index);


### PR DESCRIPTION
convert code to use the vrf name instead of the vrf id for interface creation.  There are cases where we have vrf_id of unknown due to pre-creation of vrfs.  Start allowing us to associate these interfaces with the vrfs when we know the name but not the id yet.