### PR TITLE
build: fix assert() use in .pb-c.c files

### DIFF
--- a/qpb/subdir.am
+++ b/qpb/subdir.am
@@ -44,6 +44,7 @@ am__v_PROTOC_C_1 =
 
 .proto.pb-c.c:
 	$(AM_V_PROTOC_C)$(PROTOC_C) -I$(top_srcdir) --c_out=$(top_builddir) $^
+	$(AM_V_GEN)$(SED) -e '1i#include "config.h"' -i $@
 .pb-c.c.pb-c.h:
 	@/bin/true
 


### PR DESCRIPTION
The .pb-c.c files pick up our assert() override, but that needs config.h
to be included too, and that needs to go at the very top of the file...

---

Oops :sweat_smile: