### PR TITLE
lib, pimd: move bsm code to typesafe lists

### DIFF
--- a/doc/developer/lists.rst
+++ b/doc/developer/lists.rst
@@ -108,6 +108,8 @@ Functions provided:
 | _first, _next, _next_safe,         | yes  | yes  | yes  | yes     | yes        |
 | _const_first, _const_next          |      |      |      |         |            |
 +------------------------------------+------+------+------+---------+------------+
+| _swap_all                          | yes  | yes  | yes  | yes     | yes        |
++------------------------------------+------+------+------+---------+------------+
 | _add_head, _add_tail, _add_after   | yes  | --   | --   | --      | --         |
 +------------------------------------+------+------+------+---------+------------+
 | _add                               | --   | yes  | yes  | yes     | yes        |
@@ -321,6 +323,14 @@ The following documentation assumes that a list has been defined using
       on the list.  Some structures return ``NULL`` in this case while others
       return ``item``.  The function may also call ``assert()`` (but most
       don't.)
+
+.. c:function:: itemtype *Z_swap_all(struct Z_head *, struct Z_head *)
+
+   Swap the contents of 2 containers (of identical type).  This exchanges the
+   contents of the two head structures and updates pointers if necessary for
+   the particular data structure.  Fast for all structures.
+
+   (Not currently available on atomic containers.)
 
 .. todo::
 

--- a/lib/linklist.c
+++ b/lib/linklist.c
@@ -320,23 +320,6 @@ void list_delete_all_node(struct list *list)
 	list->count = 0;
 }
 
-void list_filter_out_nodes(struct list *list, bool (*cond)(void *data))
-{
-	struct listnode *node;
-	struct listnode *next;
-	void *data;
-
-	assert(list);
-
-	for (ALL_LIST_ELEMENTS(list, node, next, data)) {
-		if ((cond && cond(data)) || (!cond)) {
-			if (*list->del)
-				(*list->del)(data);
-			list_delete_node(list, node);
-		}
-	}
-}
-
 void list_delete(struct list **list)
 {
 	assert(*list);

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -295,19 +295,6 @@ extern void list_delete_all_node(struct list *list);
 extern void list_delete_node(struct list *list, struct listnode *node);
 
 /*
- * Delete all nodes which satisfy a condition from a list.
- * Deletes the node if cond function returns true for the node.
- * If function ptr passed is NULL, it deletes all nodes
- *
- * list
- *    list to operate on
- * cond
- *    function pointer which takes node data as input and return true or false
- */
-
-extern void list_filter_out_nodes(struct list *list, bool (*cond)(void *data));
-
-/*
  * Insert a new element into a list with insertion sort if there is no
  * duplicate element present in the list. This assumes the input list is
  * sorted. If unsorted, it will check for duplicate until it finds out

--- a/lib/typerb.h
+++ b/lib/typerb.h
@@ -117,6 +117,7 @@ macro_inline type *prefix ## _pop(struct prefix##_head *h)                     \
 	typed_rb_remove(&h->rr, re);                                           \
 	return container_of(re, type, field.re);                               \
 }                                                                              \
+TYPESAFE_SWAP_ALL_SIMPLE(prefix)                                               \
 macro_pure const type *prefix ## _const_first(const struct prefix##_head *h)   \
 {                                                                              \
 	const struct typed_rb_entry *re;                                       \

--- a/pimd/pim_bsm.h
+++ b/pimd/pim_bsm.h
@@ -69,7 +69,6 @@ struct bsm_scope {
 	struct list *bsm_list;		/* list of bsm frag for frowarding */
 	struct route_table *bsrp_table; /* group2rp mapping rcvd from BSR */
 	struct thread *bs_timer;	/* Boot strap timer */
-	struct thread *sz_timer;
 };
 
 /* BSM packet - this is stored as list in bsm_list inside scope

--- a/pimd/pim_bsm.h
+++ b/pimd/pim_bsm.h
@@ -26,7 +26,6 @@
 #include "if.h"
 #include "vty.h"
 #include "typesafe.h"
-#include "linklist.h"
 #include "table.h"
 #include "pim_rp.h"
 #include "pim_msg.h"
@@ -89,22 +88,29 @@ struct bsm_frag {
 
 DECLARE_DLIST(bsm_frags, struct bsm_frag, item);
 
+PREDECL_SORTLIST_UNIQ(bsm_rpinfos);
+
 /* This is the group node of the bsrp table in scope.
  * this node maintains the list of rp for the group.
  */
 struct bsgrp_node {
 	struct prefix group;		/* Group range */
 	struct bsm_scope *scope;	/* Back ptr to scope */
-	struct list *bsrp_list;		/* list of RPs adv by BSR */
-	struct list *partial_bsrp_list; /* maintained until all RPs received */
+
+	/* RPs advertised by BSR, and temporary list while receiving new set */
+	struct bsm_rpinfos_head bsrp_list[1];
+	struct bsm_rpinfos_head partial_bsrp_list[1];
+
 	int pend_rp_cnt;		/* Total RP - Received RP */
 	uint16_t frag_tag;		/* frag tag to identify the fragment */
 };
 
-/* This is the list node of bsrp_list and partial bsrp list in
- * bsgrp_node. Hold info of each RP received for the group
+/* Items on [partial_]bsrp_list above.
+ * Holds info of each candidate RP received for the bsgrp_node's prefix.
  */
 struct bsm_rpinfo {
+	struct bsm_rpinfos_item item;
+
 	uint32_t hash;                  /* Hash Value as per RFC 7761 4.7.2 */
 	uint32_t elapse_time;           /* upd at expiry of elected RP node */
 	uint16_t rp_prio;               /* RP priority */
@@ -113,6 +119,10 @@ struct bsm_rpinfo {
 	struct bsgrp_node *bsgrp_node;  /* Back ptr to bsgrp_node */
 	struct thread *g2rp_timer;      /* Run only for elected RP node */
 };
+
+extern int pim_bsm_rpinfo_cmp(const struct bsm_rpinfo *a,
+			      const struct bsm_rpinfo *b);
+DECLARE_SORTLIST_UNIQ(bsm_rpinfos, struct bsm_rpinfo, item, pim_bsm_rpinfo_cmp);
 
 /*  Structures to extract Bootstrap Message header and Grp to RP Mappings
  *  =====================================================================
@@ -206,6 +216,7 @@ struct bsgrp_node *pim_bsm_get_bsgrp_node(struct bsm_scope *scope,
 					  struct prefix *grp);
 void pim_bs_timer_stop(struct bsm_scope *scope);
 void pim_bsm_frags_free(struct bsm_scope *scope);
+void pim_bsm_rpinfos_free(struct bsm_rpinfos_head *head);
 void pim_free_bsgrp_data(struct bsgrp_node *bsgrp_node);
 void pim_free_bsgrp_node(struct route_table *rt, struct prefix *grp);
 #endif

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3000,15 +3000,14 @@ static void pim_show_nexthop(struct pim_instance *pim, struct vty *vty)
 /* Display the bsm database details */
 static void pim_show_bsm_db(struct pim_instance *pim, struct vty *vty, bool uj)
 {
-	struct listnode *bsmnode;
 	int count = 0;
 	int fragment = 1;
-	struct bsm_info *bsm;
+	struct bsm_frag *bsfrag;
 	json_object *json = NULL;
 	json_object *json_group = NULL;
 	json_object *json_row = NULL;
 
-	count = pim->global_scope.bsm_list->count;
+	count = bsm_frags_count(pim->global_scope.bsm_frags);
 
 	if (uj) {
 		json = json_object_new_object();
@@ -3019,7 +3018,7 @@ static void pim_show_bsm_db(struct pim_instance *pim, struct vty *vty, bool uj)
 		vty_out(vty, "\n");
 	}
 
-	for (ALL_LIST_ELEMENTS_RO(pim->global_scope.bsm_list, bsmnode, bsm)) {
+	frr_each (bsm_frags, pim->global_scope.bsm_frags, bsfrag) {
 		char grp_str[PREFIX_STRLEN];
 		char rp_str[INET_ADDRSTRLEN];
 		char bsr_str[INET_ADDRSTRLEN];
@@ -3032,8 +3031,8 @@ static void pim_show_bsm_db(struct pim_instance *pim, struct vty *vty, bool uj)
 		uint32_t len = 0;
 		uint32_t frag_rp_cnt = 0;
 
-		buf = bsm->bsm;
-		len = bsm->size;
+		buf = bsfrag->data;
+		len = bsfrag->size;
 
 		/* skip pim header */
 		buf += PIM_MSG_HEADER_LEN;
@@ -4083,7 +4082,7 @@ static void clear_pim_bsr_db(struct pim_instance *pim)
 	pim->global_scope.current_bsr_first_ts = 0;
 	pim->global_scope.current_bsr_last_ts = 0;
 	pim->global_scope.bsm_frag_tag = 0;
-	list_delete_all_node(pim->global_scope.bsm_list);
+	pim_bsm_frags_free(&pim->global_scope);
 
 	pim_bs_timer_stop(&pim->global_scope);
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3159,7 +3159,6 @@ static void pim_show_group_rp_mappings_info(struct pim_instance *pim,
 					    struct vty *vty, bool uj)
 {
 	struct bsgrp_node *bsgrp;
-	struct listnode *rpnode;
 	struct bsm_rpinfo *bsm_rp;
 	struct route_node *rn;
 	char bsr_str[INET_ADDRSTRLEN];
@@ -3208,42 +3207,33 @@ static void pim_show_group_rp_mappings_info(struct pim_instance *pim,
 			vty_out(vty, "(ACTIVE)\n");
 		}
 
-		if (bsgrp->bsrp_list) {
-			for (ALL_LIST_ELEMENTS_RO(bsgrp->bsrp_list, rpnode,
-						  bsm_rp)) {
-				char rp_str[INET_ADDRSTRLEN];
+		frr_each (bsm_rpinfos, bsgrp->bsrp_list, bsm_rp) {
+			char rp_str[INET_ADDRSTRLEN];
 
-				pim_inet4_dump("<Rp Address?>",
-					       bsm_rp->rp_address, rp_str,
-					       sizeof(rp_str));
+			pim_inet4_dump("<Rp Address?>", bsm_rp->rp_address,
+				       rp_str, sizeof(rp_str));
 
-				if (uj) {
-					json_row = json_object_new_object();
-					json_object_string_add(
-						json_row, "Rp Address", rp_str);
-					json_object_int_add(
-						json_row, "Rp HoldTime",
-						bsm_rp->rp_holdtime);
-					json_object_int_add(json_row,
-							    "Rp Priority",
-							    bsm_rp->rp_prio);
-					json_object_int_add(json_row,
-							    "Hash Val",
-							    bsm_rp->hash);
-					json_object_object_add(
-						json_group, rp_str, json_row);
+			if (uj) {
+				json_row = json_object_new_object();
+				json_object_string_add(json_row, "Rp Address",
+						       rp_str);
+				json_object_int_add(json_row, "Rp HoldTime",
+						    bsm_rp->rp_holdtime);
+				json_object_int_add(json_row, "Rp Priority",
+						    bsm_rp->rp_prio);
+				json_object_int_add(json_row, "Hash Val",
+						    bsm_rp->hash);
+				json_object_object_add(json_group, rp_str,
+						       json_row);
 
-				} else {
-					vty_out(vty,
-						"%-15s %-15u %-15u %-15u\n",
-						rp_str, bsm_rp->rp_prio,
-						bsm_rp->rp_holdtime,
-						bsm_rp->hash);
-				}
+			} else {
+				vty_out(vty, "%-15s %-15u %-15u %-15u\n",
+					rp_str, bsm_rp->rp_prio,
+					bsm_rp->rp_holdtime, bsm_rp->hash);
 			}
-			if (!bsgrp->bsrp_list->count && !uj)
-				vty_out(vty, "Active List is empty.\n");
 		}
+		if (!bsm_rpinfos_count(bsgrp->bsrp_list) && !uj)
+			vty_out(vty, "Active List is empty.\n");
 
 		if (uj) {
 			json_object_int_add(json_group, "Pending RP count",
@@ -3258,40 +3248,32 @@ static void pim_show_group_rp_mappings_info(struct pim_instance *pim,
 					"Hash");
 		}
 
-		if (bsgrp->partial_bsrp_list) {
-			for (ALL_LIST_ELEMENTS_RO(bsgrp->partial_bsrp_list,
-						  rpnode, bsm_rp)) {
-				char rp_str[INET_ADDRSTRLEN];
+		frr_each (bsm_rpinfos, bsgrp->partial_bsrp_list, bsm_rp) {
+			char rp_str[INET_ADDRSTRLEN];
 
-				pim_inet4_dump("<Rp Addr?>", bsm_rp->rp_address,
-					       rp_str, sizeof(rp_str));
+			pim_inet4_dump("<Rp Addr?>", bsm_rp->rp_address, rp_str,
+				       sizeof(rp_str));
 
-				if (uj) {
-					json_row = json_object_new_object();
-					json_object_string_add(
-						json_row, "Rp Address", rp_str);
-					json_object_int_add(
-						json_row, "Rp HoldTime",
-						bsm_rp->rp_holdtime);
-					json_object_int_add(json_row,
-							    "Rp Priority",
-							    bsm_rp->rp_prio);
-					json_object_int_add(json_row,
-							    "Hash Val",
-							    bsm_rp->hash);
-					json_object_object_add(
-						json_group, rp_str, json_row);
-				} else {
-					vty_out(vty,
-						"%-15s %-15u %-15u %-15u\n",
-						rp_str, bsm_rp->rp_prio,
-						bsm_rp->rp_holdtime,
-						bsm_rp->hash);
-				}
+			if (uj) {
+				json_row = json_object_new_object();
+				json_object_string_add(json_row, "Rp Address",
+						       rp_str);
+				json_object_int_add(json_row, "Rp HoldTime",
+						    bsm_rp->rp_holdtime);
+				json_object_int_add(json_row, "Rp Priority",
+						    bsm_rp->rp_prio);
+				json_object_int_add(json_row, "Hash Val",
+						    bsm_rp->hash);
+				json_object_object_add(json_group, rp_str,
+						       json_row);
+			} else {
+				vty_out(vty, "%-15s %-15u %-15u %-15u\n",
+					rp_str, bsm_rp->rp_prio,
+					bsm_rp->rp_holdtime, bsm_rp->hash);
 			}
-			if (!bsgrp->partial_bsrp_list->count && !uj)
-				vty_out(vty, "Partial List is empty\n");
 		}
+		if (!bsm_rpinfos_count(bsgrp->partial_bsrp_list) && !uj)
+			vty_out(vty, "Partial List is empty\n");
 
 		if (!uj)
 			vty_out(vty, "\n");

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -702,7 +702,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 		bsgrp = pim_bsm_get_bsgrp_node(&pim->global_scope, &group);
 
 		if (bsgrp) {
-			bsrp = listnode_head(bsgrp->bsrp_list);
+			bsrp = bsm_rpinfos_first(bsgrp->bsrp_list);
 			if (bsrp) {
 				if (PIM_DEBUG_PIM_TRACE) {
 					char bsrp_str[INET_ADDRSTRLEN];

--- a/tests/lib/test_typelist.h
+++ b/tests/lib/test_typelist.h
@@ -17,6 +17,7 @@
 /* C++ called, they want their templates back */
 #define item		concat(item_, TYPE)
 #define itm		concat(itm_, TYPE)
+#define itmswap		concat(itmswap_, TYPE)
 #define head		concat(head_, TYPE)
 #define list		concat(TYPE, )
 #define list_head	concat(TYPE, _head)
@@ -40,8 +41,9 @@
 #define list_find_gteq	concat(TYPE, _find_gteq)
 #define list_del	concat(TYPE, _del)
 #define list_pop	concat(TYPE, _pop)
+#define list_swap_all	concat(TYPE, _swap_all)
 
-#define ts_hash		concat(ts_hash_, TYPE)
+#define ts_hash_head	concat(ts_hash_head_, TYPE)
 
 #ifndef REALTYPE
 #define REALTYPE TYPE
@@ -89,10 +91,12 @@ DECLARE(REALTYPE, list, struct item, itm);
 #endif
 
 #define NITEM 10000
-struct item itm[NITEM];
+#define NITEM_SWAP 100 /* other container for swap */
+struct item itm[NITEM], itmswap[NITEM_SWAP];
 static struct list_head head = concat(INIT_, REALTYPE)(head);
 
-static void ts_hash(const char *text, const char *expect)
+static void ts_hash_head(struct list_head *h, const char *text,
+			 const char *expect)
 {
 	int64_t us = monotime_since(&ref, NULL);
 	SHA256_CTX ctx;
@@ -102,13 +106,13 @@ static void ts_hash(const char *text, const char *expect)
 	char hashtext[65];
 	uint32_t swap_count, count;
 
-	count = list_count(&head);
+	count = list_count(h);
 	swap_count = htonl(count);
 
 	SHA256_Init(&ctx);
 	SHA256_Update(&ctx, &swap_count, sizeof(swap_count));
 
-	frr_each (list, &head, item) {
+	frr_each (list, h, item) {
 		struct {
 			uint32_t val_upper, val_lower, index;
 		} hashitem = {
@@ -135,21 +139,30 @@ static void ts_hash(const char *text, const char *expect)
 }
 /* hashes will have different item ordering */
 #if IS_HASH(REALTYPE) || IS_HEAP(REALTYPE)
-#define ts_hashx(pos, csum) ts_hash(pos, NULL)
+#define ts_hash(pos, csum) ts_hash_head(&head, pos, NULL)
+#define ts_hashx(pos, csum) ts_hash_head(&head, pos, NULL)
+#define ts_hash_headx(head, pos, csum) ts_hash_head(head, pos, NULL)
 #else
-#define ts_hashx(pos, csum) ts_hash(pos, csum)
+#define ts_hash(pos, csum) ts_hash_head(&head, pos, csum)
+#define ts_hashx(pos, csum) ts_hash_head(&head, pos, csum)
+#define ts_hash_headx(head, pos, csum) ts_hash_head(head, pos, csum)
 #endif
 
 static void concat(test_, TYPE)(void)
 {
 	size_t i, j, k, l;
 	struct prng *prng;
+	struct prng *prng_swap __attribute__((unused));
 	struct item *item, *prev __attribute__((unused));
 	struct item dummy __attribute__((unused));
 
 	memset(itm, 0, sizeof(itm));
 	for (i = 0; i < NITEM; i++)
 		itm[i].val = i;
+
+	memset(itmswap, 0, sizeof(itmswap));
+	for (i = 0; i < NITEM_SWAP; i++)
+		itmswap[i].val = i;
 
 	printfrr("%s start\n", str(TYPE));
 	ts_start();
@@ -177,6 +190,56 @@ static void concat(test_, TYPE)(void)
 	assert(list_count(&head) == k);
 	assert(list_first(&head) != NULL);
 	ts_hashx("fill", "a538546a6e6ab0484e925940aa8dd02fd934408bbaed8cb66a0721841584d838");
+
+#if !IS_ATOMIC(REALTYPE)
+	struct list_head other;
+
+	list_init(&other);
+	list_swap_all(&head, &other);
+
+	assert(list_count(&head) == 0);
+	assert(!list_first(&head));
+	assert(list_count(&other) == k);
+	assert(list_first(&other) != NULL);
+	ts_hash_headx(
+		&other, "swap1",
+		"a538546a6e6ab0484e925940aa8dd02fd934408bbaed8cb66a0721841584d838");
+
+	prng_swap = prng_new(0x1234dead);
+	l = 0;
+	for (i = 0; i < NITEM_SWAP; i++) {
+		j = prng_rand(prng_swap) % NITEM_SWAP;
+		if (itmswap[j].scratchpad == 0) {
+			list_add(&head, &itmswap[j]);
+			itmswap[j].scratchpad = 1;
+			l++;
+		}
+#if !IS_HEAP(REALTYPE)
+		else {
+			struct item *rv = list_add(&head, &itmswap[j]);
+			assert(rv == &itmswap[j]);
+		}
+#endif
+	}
+	assert(list_count(&head) == l);
+	assert(list_first(&head) != NULL);
+	ts_hash_headx(
+		&head, "swap-fill",
+		"26df437174051cf305d1bbb62d779ee450ca764167a1e7a94be1aece420008e6");
+
+	list_swap_all(&head, &other);
+
+	assert(list_count(&other) == l);
+	assert(list_first(&other));
+	ts_hash_headx(
+		&other, "swap2a",
+		"26df437174051cf305d1bbb62d779ee450ca764167a1e7a94be1aece420008e6");
+	assert(list_count(&head) == k);
+	assert(list_first(&head) != NULL);
+	ts_hash_headx(
+		&head, "swap2b",
+		"a538546a6e6ab0484e925940aa8dd02fd934408bbaed8cb66a0721841584d838");
+#endif /* !IS_ATOMIC */
 
 	k = 0;
 
@@ -343,6 +406,50 @@ static void concat(test_, TYPE)(void)
 	assert(list_count(&head) == k);
 	assert(list_first(&head) != NULL);
 	ts_hash("fill / add_tail", "eabfcf1413936daaf20965abced95762f45110a6619b84aac7d38481bce4ea19");
+
+#if !IS_ATOMIC(REALTYPE)
+	struct list_head other;
+
+	list_init(&other);
+	list_swap_all(&head, &other);
+
+	assert(list_count(&head) == 0);
+	assert(!list_first(&head));
+	assert(list_count(&other) == k);
+	assert(list_first(&other) != NULL);
+	ts_hash_head(
+		&other, "swap1",
+		"eabfcf1413936daaf20965abced95762f45110a6619b84aac7d38481bce4ea19");
+
+	prng_swap = prng_new(0x1234dead);
+	l = 0;
+	for (i = 0; i < NITEM_SWAP; i++) {
+		j = prng_rand(prng_swap) % NITEM_SWAP;
+		if (itmswap[j].scratchpad == 0) {
+			list_add_tail(&head, &itmswap[j]);
+			itmswap[j].scratchpad = 1;
+			l++;
+		}
+	}
+	assert(list_count(&head) == l);
+	assert(list_first(&head) != NULL);
+	ts_hash_head(
+		&head, "swap-fill",
+		"833e6ae437e322dfbd36eda8cfc33a61109be735b43f15d256c05e52d1b01909");
+
+	list_swap_all(&head, &other);
+
+	assert(list_count(&other) == l);
+	assert(list_first(&other));
+	ts_hash_head(
+		&other, "swap2a",
+		"833e6ae437e322dfbd36eda8cfc33a61109be735b43f15d256c05e52d1b01909");
+	assert(list_count(&head) == k);
+	assert(list_first(&head) != NULL);
+	ts_hash_head(
+		&head, "swap2b",
+		"eabfcf1413936daaf20965abced95762f45110a6619b84aac7d38481bce4ea19");
+#endif
 
 	for (i = 0; i < NITEM / 2; i++) {
 		j = prng_rand(prng) % NITEM;
@@ -546,10 +653,14 @@ static void concat(test_, TYPE)(void)
 	printfrr("%s end\n", str(TYPE));
 }
 
+#undef ts_hash
 #undef ts_hashx
+#undef ts_hash_head
+#undef ts_hash_headx
 
 #undef item
 #undef itm
+#undef itmswap
 #undef head
 #undef list
 #undef list_head
@@ -571,6 +682,7 @@ static void concat(test_, TYPE)(void)
 #undef list_find_gteq
 #undef list_del
 #undef list_pop
+#undef list_swap_all
 
 #undef REALTYPE
 #undef TYPE

--- a/tests/topotests/Dockerfile
+++ b/tests/topotests/Dockerfile
@@ -44,6 +44,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         xterm \
     && pip install \
         exabgp==3.4.17 \
+        "scapy>=2.4.2" \
         ipaddr \
         pytest \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Been asked to look at candidate-rp support, so here's some cleanup before starting on that.

Includes 2 bonus `lib/` bits:

- add `bla_swap_all()` for the TYPESAFE bits to swap the contents of 2 containers
- remove `list_filter_out_nodes` from the old code which is unused after this

Also fix the topotests docker image :disappointed: