### PR TITLE
bgpd: BGP large community-list configuration with regex is failing.

### DIFF
--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -1117,9 +1117,6 @@ int lcommunity_list_set(struct community_list_handler *ch, const char *name,
 	}
 
 	if (str) {
-		if (!lcommunity_list_valid(str, style))
-			return COMMUNITY_LIST_ERR_MALFORMED_VAL;
-
 		if (style == LARGE_COMMUNITY_LIST_STANDARD)
 			lcom = lcommunity_str2com(str);
 		else


### PR DESCRIPTION
frr(config)# bgp large-community-list expanded com1 permit .*
% Malformed community-list value

The check to validate large-community against UINT_MAX is added for
both standard and expanded community. But however it needs to be
validated only for standard community.

Signed-off-by: Prerana-GB <prerana@vmware.com>