### PR TITLE
zebra: Allow redistribution for routes selected

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -91,8 +91,7 @@ static void zebra_redistribute_default(struct zserv *client, vrf_id_t vrf_id)
 			continue;
 
 		RNODE_FOREACH_RE (rn, newre) {
-			if (CHECK_FLAG(newre->flags, ZEBRA_FLAG_SELECTED)
-			    && newre->distance != DISTANCE_INFINITY)
+			if (CHECK_FLAG(newre->flags, ZEBRA_FLAG_SELECTED))
 				zsend_redistribute_route(
 					ZEBRA_REDISTRIBUTE_ROUTE_ADD, client,
 					&rn->p, NULL, newre);
@@ -137,8 +136,6 @@ static void zebra_redistribute(struct zserv *client, int type,
 			if ((type != ZEBRA_ROUTE_ALL
 			     && (newre->type != type
 				 || newre->instance != instance)))
-				continue;
-			if (newre->distance == DISTANCE_INFINITY)
 				continue;
 			if (!zebra_check_addr(dst_p))
 				continue;
@@ -263,13 +260,6 @@ void redistribute_delete(const struct prefix *p, const struct prefix *src_p,
 			   old_re ? zebra_route_string(old_re->type) : "None",
 			   new_re,
 			   new_re ? zebra_route_string(new_re->type) : "None");
-	}
-
-	/* Add DISTANCE_INFINITY check. */
-	if (old_re && (old_re->distance == DISTANCE_INFINITY)) {
-		if (IS_ZEBRA_DEBUG_RIB)
-			zlog_debug("        Skipping due to Infinite Distance");
-		return;
 	}
 
 	afi = family2afi(p->family);


### PR DESCRIPTION
Current code has an inconsistent behavior with redistribute routes.
Suppose you have a kernel route that is being read w/ a distance
of 255:

eva# show ip route kernel
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

K>* 0.0.0.0/0 [0/100] via 192.168.161.1, enp39s0, 00:06:39
K>* 4.4.4.4/32 [255/8192] via 192.168.161.1, enp39s0, 00:01:26
eva#

If you have redistribution already turned on for kernel routes
you will be notified of the 4.4.4.4/32 route.  If you turn
on kernel route redistribution watching after the 4.4.4.4/32 route
has been read by zebra you will never learn of it.

There is no need to look for infinite distance in the redistribution
code.  Either we are selected or not.  In other words non kernel routes
with an 255 distance are never installed so the checks were pointless.

So let's just remove the distance checking and tell interested parties
about the 255 kernel route if it exists.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>