### PR TITLE
ospf6d: Limit the number of interface addresses being supported in ospfv3

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -305,3 +305,13 @@ Larger example with policy and various options set:
     ipv6 access-class access6
     exec-timeout 0 0
    !
+
+
+Configuration Limits
+====================
+
+Ospf6d currently supports 100 interfaces addresses if MTU is set to
+default value, and 200 interface addresses if MTU is set to jumbo
+packet size or larger.
+
+  

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -188,6 +188,7 @@ extern void ospf6_interface_disable(struct ospf6_interface *);
 extern void ospf6_interface_if_add(struct interface *);
 extern void ospf6_interface_state_update(struct interface *);
 extern void ospf6_interface_connected_route_update(struct interface *);
+extern void ospf6_interface_connected_route_add(struct connected *);
 
 /* interface event */
 extern int interface_up(struct thread *);

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -850,6 +850,7 @@ DEFUN (ospf6_interface_area,
 	struct ospf6_interface *oi;
 	struct interface *ifp;
 	vrf_id_t vrf_id = VRF_DEFAULT;
+	int ipv6_count = 0;
 
 	if (ospf6->vrf_id != VRF_UNKNOWN)
 		vrf_id = ospf6->vrf_id;
@@ -863,6 +864,23 @@ DEFUN (ospf6_interface_area,
 		vty_out(vty, "%s already attached to Area %s\n",
 			oi->interface->name, oi->area->name);
 		return CMD_SUCCESS;
+	}
+
+	/* if more than OSPF6_MAX_IF_ADDRS are configured on this interface
+	 * then don't allow ospfv3 to be configured
+	 */
+	ipv6_count = connected_count_by_family(ifp, AF_INET6);
+	if (oi->ifmtu == OSPF6_DEFAULT_MTU && ipv6_count > OSPF6_MAX_IF_ADDRS) {
+		vty_out(vty,
+			"can not configure OSPFv3 on if %s, must have less than %d interface addresses but has %d addresses\n",
+			ifp->name, OSPF6_MAX_IF_ADDRS, ipv6_count);
+		return CMD_WARNING_CONFIG_FAILED;
+	} else if (oi->ifmtu >= OSPF6_JUMBO_MTU
+		   && ipv6_count > OSPF6_MAX_IF_ADDRS_JUMBO) {
+		vty_out(vty,
+			"can not configure OSPFv3 on if %s, must have less than %d interface addresses but has %d addresses\n",
+			ifp->name, OSPF6_MAX_IF_ADDRS_JUMBO, ipv6_count);
+		return CMD_WARNING_CONFIG_FAILED;
 	}
 
 	/* parse Area-ID */

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -153,6 +153,10 @@ DECLARE_QOBJ_TYPE(ospf6);
 #define OSPF6_DISABLED    0x01
 #define OSPF6_STUB_ROUTER 0x02
 #define OSPF6_FLAG_ASBR   0x04
+#define OSPF6_MAX_IF_ADDRS 100
+#define OSPF6_MAX_IF_ADDRS_JUMBO 200
+#define OSPF6_DEFAULT_MTU 1500
+#define OSPF6_JUMBO_MTU 9000
 
 /* global pointer for OSPF top data structure */
 extern struct ospf6 *ospf6;

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -130,16 +130,37 @@ void ospf6_zebra_no_redistribute(int type, vrf_id_t vrf_id)
 static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
+	struct ospf6_interface *oi;
+	int ipv6_count = 0;
 
 	c = zebra_interface_address_read(ZEBRA_INTERFACE_ADDRESS_ADD,
 					 zclient->ibuf, vrf_id);
 	if (c == NULL)
 		return 0;
 
+	oi = (struct ospf6_interface *)c->ifp->info;
+	if (oi == NULL)
+		oi = ospf6_interface_create(c->ifp);
+	assert(oi);
+
 	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
 		zlog_debug("Zebra Interface address add: %s %5s %pFX",
 			   c->ifp->name, prefix_family_str(c->address),
 			   c->address);
+
+	ipv6_count = connected_count_by_family(c->ifp, AF_INET6);
+	if (oi->ifmtu == OSPF6_DEFAULT_MTU && ipv6_count > OSPF6_MAX_IF_ADDRS) {
+		zlog_warn(
+			"Zebra Interface : %s has too many interface addresses %d only support %d, increase MTU",
+			c->ifp->name, ipv6_count, OSPF6_MAX_IF_ADDRS);
+		return 0;
+	} else if (oi->ifmtu >= OSPF6_JUMBO_MTU
+		   && ipv6_count > OSPF6_MAX_IF_ADDRS_JUMBO) {
+		zlog_warn(
+			"Zebra Interface : %s has too many interface addresses %d only support %d",
+			c->ifp->name, ipv6_count, OSPF6_MAX_IF_ADDRS_JUMBO);
+		return 0;
+	}
 
 	if (c->address->family == AF_INET6) {
 		ospf6_interface_state_update(c->ifp);
@@ -303,7 +324,7 @@ static void ospf6_zebra_route_update(int type, struct ospf6_route *request,
 	struct prefix *dest;
 
 	if (IS_OSPF6_DEBUG_ZEBRA(SEND))
-		zlog_debug("Send %s route: %pFX",
+		zlog_debug("Zebra Send %s route: %pFX",
 			   (type == REM ? "remove" : "add"), &request->prefix);
 
 	if (zclient->sock < 0) {


### PR DESCRIPTION
The code had no limits on addresses configured on an interface running
ospfv3.  The code would crash when more than 100 addresses were added.
This change limits the number of interface address to 100 if mtu is set
to the default value.  If the mtu is set to a jumbo packet size or larger
we will support 200 interface addresses.

Signed-off-by: Lynne Morrison <lynne@voltanet.io>