### PR TITLE
bgpd: changing graceful-restart parameters should not be considered as error

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -731,9 +731,6 @@ int bgp_vty_return(struct vty *vty, int ret)
 	case BGP_ERR_GR_OPERATION_FAILED:
 		str = "The Graceful Restart Operation failed due to an err.";
 		break;
-	case BGP_GR_NO_OPERATION:
-		str = GR_NO_OPER;
-		break;
 	}
 	if (str) {
 		vty_out(vty, "%% %s\n", str);


### PR DESCRIPTION
vtysh will return an informational message to the user that changing any
graceful-shutdown related parameter either globally or per-neighbor/peer-group
will emit a message. This message is only informational for the user and should
not create a return code of 1 which signals "error"!

This fixes GitHub issue https://github.com/FRRouting/frr/issues/8403