### PR TITLE
tests: fix isis-topo1 topologies

### DIFF
--- a/tests/topotests/isis-topo1/r1/r1_topology.json
+++ b/tests/topotests/isis-topo1/r1/r1_topology.json
@@ -18,9 +18,9 @@
           "vertex": "r1"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP",
+          "metric": "0",
+          "parent": "r1(4)",
+          "type": "IP internal",
           "vertex": "10.0.20.0/24"
         },
         {
@@ -32,27 +32,27 @@
           "vertex": "r3"
         },
         {
-          "interface": "r3",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r1-eth0",
-          "type": "IP",
+          "interface": "r1-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.10.0/24"
         },
         {
-          "interface": "r3",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r1-eth0",
-          "type": "IP",
+          "interface": "r1-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.20.0/24"
         },
         {
-          "interface": "r3",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r1-eth0",
-          "type": "IP",
+          "interface": "r1-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.254.0.3/32"
         }
       ],
@@ -61,9 +61,9 @@
           "vertex": "r1"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP6",
+          "metric": "0",
+          "parent": "r1(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:1::/64"
         },
         {
@@ -75,17 +75,19 @@
           "vertex": "r3"
         },
         {
-          "interface": "r3",
-          "next-hop": "10",
-          "parent": "r1-eth0",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r1-eth0",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:1::/64"
         },
         {
-          "interface": "r3",
-          "next-hop": "10",
-          "parent": "r1-eth0",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r1-eth0",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:f::3/128"
         }
       ]

--- a/tests/topotests/isis-topo1/r2/r2_topology.json
+++ b/tests/topotests/isis-topo1/r2/r2_topology.json
@@ -18,9 +18,9 @@
           "vertex": "r2"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP",
+          "metric": "0",
+          "parent": "r2(4)",
+          "type": "IP internal",
           "vertex": "10.0.21.0/24"
         },
         {
@@ -32,27 +32,27 @@
           "vertex": "r4"
         },
         {
-          "interface": "r4",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r2-eth0",
-          "type": "IP",
+          "interface": "r2-eth0",
+          "metric": "10",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.0.11.0/24"
         },
         {
-          "interface": "r4",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r2-eth0",
-          "type": "IP",
+          "interface": "r2-eth0",
+          "metric": "10",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.0.21.0/24"
         },
         {
-          "interface": "r4",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r2-eth0",
-          "type": "IP",
+          "interface": "r2-eth0",
+          "metric": "10",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.254.0.4/32"
         }
       ],
@@ -61,9 +61,9 @@
           "vertex": "r2"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP6",
+          "metric": "0",
+          "parent": "r2(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:2::/64"
         },
         {
@@ -75,17 +75,19 @@
           "vertex": "r4"
         },
         {
-          "interface": "r4",
-          "next-hop": "10",
-          "parent": "r2-eth0",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r2-eth0",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:2::/64"
         },
         {
-          "interface": "r4",
-          "next-hop": "10",
-          "parent": "r2-eth0",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r2-eth0",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:f::4/128"
         }
       ]

--- a/tests/topotests/isis-topo1/r3/r3_topology.json
+++ b/tests/topotests/isis-topo1/r3/r3_topology.json
@@ -6,9 +6,9 @@
           "vertex": "r3"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP",
+          "metric": "0",
+          "parent": "r3(4)",
+          "type": "IP internal",
           "vertex": "10.0.10.0/24"
         },
         {
@@ -20,27 +20,27 @@
           "vertex": "r5"
         },
         {
-          "interface": "r5",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r3-eth1",
-          "type": "IP",
+          "interface": "r3-eth1",
+          "metric": "10",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP TE",
           "vertex": "10.0.10.0/24"
         },
         {
-          "interface": "r5",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r3-eth1",
-          "type": "IP",
+          "interface": "r3-eth1",
+          "metric": "10",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP TE",
           "vertex": "10.0.11.0/24"
         },
         {
-          "interface": "r5",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r3-eth1",
-          "type": "IP",
+          "interface": "r3-eth1",
+          "metric": "10",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP TE",
           "vertex": "10.254.0.5/32"
         },
         {
@@ -51,19 +51,19 @@
           "vertex": "r4"
         },
         {
-          "interface": "r5",
-          "metric": "TE",
-          "next-hop": "20",
-          "parent": "r3-eth1",
-          "type": "IP",
+          "interface": "r3-eth1",
+          "metric": "20",
+          "next-hop": "r5",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.0.21.0/24"
         },
         {
-          "interface": "r5",
-          "metric": "TE",
-          "next-hop": "20",
-          "parent": "r3-eth1",
-          "type": "IP",
+          "interface": "r3-eth1",
+          "metric": "20",
+          "next-hop": "r5",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.254.0.4/32"
         }
       ],
@@ -72,9 +72,9 @@
           "vertex": "r3"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP6",
+          "metric": "0",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:1::/64"
         },
         {
@@ -86,17 +86,19 @@
           "vertex": "r5"
         },
         {
-          "interface": "r5",
-          "next-hop": "10",
-          "parent": "r3-eth1",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r3-eth1",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:2::/64"
         },
         {
-          "interface": "r5",
-          "next-hop": "10",
-          "parent": "r3-eth1",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r3-eth1",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:f::5/128"
         },
         {
@@ -107,17 +109,19 @@
           "vertex": "r4"
         },
         {
-          "interface": "r5",
-          "next-hop": "20",
-          "parent": "r3-eth1",
-          "type": "IP6",
+          "metric": "20",
+          "interface": "r3-eth1",
+          "next-hop": "r5",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:2::/64"
         },
         {
-          "interface": "r5",
-          "next-hop": "20",
-          "parent": "r3-eth1",
-          "type": "IP6",
+          "metric": "20",
+          "interface": "r3-eth1",
+          "next-hop": "r5",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:f::4/128"
         }
       ]
@@ -128,9 +132,9 @@
           "vertex": "r3"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP",
+          "metric": "0",
+          "parent": "r3(4)",
+          "type": "IP internal",
           "vertex": "10.0.20.0/24"
         },
         {
@@ -142,19 +146,19 @@
           "vertex": "r1"
         },
         {
-          "interface": "r1",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r3-eth0",
-          "type": "IP",
+          "interface": "r3-eth0",
+          "metric": "10",
+          "next-hop": "r1",
+          "parent": "r1(4)",
+          "type": "IP TE",
           "vertex": "10.0.20.0/24"
         },
         {
-          "interface": "r1",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r3-eth0",
-          "type": "IP",
+          "interface": "r3-eth0",
+          "metric": "10",
+          "next-hop": "r1",
+          "parent": "r1(4)",
+          "type": "IP TE",
           "vertex": "10.254.0.1/32"
         }
       ],
@@ -163,9 +167,9 @@
           "vertex": "r3"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP6",
+          "metric": "0",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:1::/64"
         },
         {
@@ -177,10 +181,11 @@
           "vertex": "r1"
         },
         {
-          "interface": "r1",
-          "next-hop": "10",
-          "parent": "r3-eth0",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r3-eth0",
+          "next-hop": "r1",
+          "parent": "r1(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:f::1/128"
         }
       ]

--- a/tests/topotests/isis-topo1/r4/r4_topology.json
+++ b/tests/topotests/isis-topo1/r4/r4_topology.json
@@ -6,9 +6,9 @@
           "vertex": "r4"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP",
+          "metric": "0",
+          "parent": "r4(4)",
+          "type": "IP internal",
           "vertex": "10.0.11.0/24"
         },
         {
@@ -20,27 +20,27 @@
           "vertex": "r5"
         },
         {
-          "interface": "r5",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r4-eth1",
-          "type": "IP",
+          "interface": "r4-eth1",
+          "metric": "10",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP TE",
           "vertex": "10.0.10.0/24"
         },
         {
-          "interface": "r5",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r4-eth1",
-          "type": "IP",
+          "interface": "r4-eth1",
+          "metric": "10",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP TE",
           "vertex": "10.0.11.0/24"
         },
         {
-          "interface": "r5",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r4-eth1",
-          "type": "IP",
+          "interface": "r4-eth1",
+          "metric": "10",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP TE",
           "vertex": "10.254.0.5/32"
         },
         {
@@ -51,19 +51,19 @@
           "vertex": "r3"
         },
         {
-          "interface": "r5",
-          "metric": "TE",
-          "next-hop": "20",
-          "parent": "r4-eth1",
-          "type": "IP",
+          "interface": "r4-eth1",
+          "metric": "20",
+          "next-hop": "r5",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.20.0/24"
         },
         {
-          "interface": "r5",
-          "metric": "TE",
-          "next-hop": "20",
-          "parent": "r4-eth1",
-          "type": "IP",
+          "interface": "r4-eth1",
+          "metric": "20",
+          "next-hop": "r5",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.254.0.3/32"
         }
       ],
@@ -72,9 +72,9 @@
           "vertex": "r4"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP6",
+          "metric": "0",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:2::/64"
         },
         {
@@ -86,17 +86,19 @@
           "vertex": "r5"
         },
         {
-          "interface": "r5",
-          "next-hop": "10",
-          "parent": "r4-eth1",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r4-eth1",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:1::/64"
         },
         {
-          "interface": "r5",
-          "next-hop": "10",
-          "parent": "r4-eth1",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r4-eth1",
+          "next-hop": "r5",
+          "parent": "r5(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:f::5/128"
         },
         {
@@ -107,17 +109,19 @@
           "vertex": "r3"
         },
         {
-          "interface": "r5",
-          "next-hop": "20",
-          "parent": "r4-eth1",
-          "type": "IP6",
+          "metric": "20",
+          "interface": "r4-eth1",
+          "next-hop": "r5",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:1::/64"
         },
         {
-          "interface": "r5",
-          "next-hop": "20",
-          "parent": "r4-eth1",
-          "type": "IP6",
+          "metric": "20",
+          "interface": "r4-eth1",
+          "next-hop": "r5",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:f::3/128"
         }
       ]
@@ -128,9 +132,9 @@
           "vertex": "r4"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP",
+          "metric": "0",
+          "parent": "r4(4)",
+          "type": "IP internal",
           "vertex": "10.0.21.0/24"
         },
         {
@@ -142,19 +146,19 @@
           "vertex": "r2"
         },
         {
-          "interface": "r2",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r4-eth0",
-          "type": "IP",
+          "interface": "r4-eth0",
+          "metric": "10",
+          "next-hop": "r2",
+          "parent": "r2(4)",
+          "type": "IP TE",
           "vertex": "10.0.21.0/24"
         },
         {
-          "interface": "r2",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r4-eth0",
-          "type": "IP",
+          "interface": "r4-eth0",
+          "metric": "10",
+          "next-hop": "r2",
+          "parent": "r2(4)",
+          "type": "IP TE",
           "vertex": "10.254.0.2/32"
         }
       ],
@@ -163,9 +167,9 @@
           "vertex": "r4"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP6",
+          "metric": "0",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:2::/64"
         },
         {
@@ -177,10 +181,11 @@
           "vertex": "r2"
         },
         {
-          "interface": "r2",
-          "next-hop": "10",
-          "parent": "r4-eth0",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r4-eth0",
+          "next-hop": "r2",
+          "parent": "r2(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:f::2/128"
         }
       ]

--- a/tests/topotests/isis-topo1/r5/r5_topology.json
+++ b/tests/topotests/isis-topo1/r5/r5_topology.json
@@ -6,15 +6,15 @@
           "vertex": "r5"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP",
+          "metric": "0",
+          "parent": "r5(4)",
+          "type": "IP internal",
           "vertex": "10.0.10.0/24"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP",
+          "metric": "0",
+          "parent": "r5(4)",
+          "type": "IP internal",
           "vertex": "10.0.11.0/24"
         },
         {
@@ -34,51 +34,51 @@
           "vertex": "r4"
         },
         {
-          "interface": "r3",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r5-eth0",
-          "type": "IP",
+          "interface": "r5-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.10.0/24"
         },
         {
-          "interface": "r3",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r5-eth0",
-          "type": "IP",
+          "interface": "r5-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.0.20.0/24"
         },
         {
-          "interface": "r3",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r5-eth0",
-          "type": "IP",
+          "interface": "r5-eth0",
+          "metric": "10",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP TE",
           "vertex": "10.254.0.3/32"
         },
         {
-          "interface": "r4",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r5-eth1",
-          "type": "IP",
+          "interface": "r5-eth1",
+          "metric": "10",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.0.11.0/24"
         },
         {
-          "interface": "r4",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r5-eth1",
-          "type": "IP",
+          "interface": "r5-eth1",
+          "metric": "10",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.0.21.0/24"
         },
         {
-          "interface": "r4",
-          "metric": "TE",
-          "next-hop": "10",
-          "parent": "r5-eth1",
-          "type": "IP",
+          "interface": "r5-eth1",
+          "metric": "10",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP TE",
           "vertex": "10.254.0.4/32"
         }
       ],
@@ -87,15 +87,15 @@
           "vertex": "r5"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP6",
+          "metric": "0",
+          "parent": "r5(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:1::/64"
         },
         {
-          "metric": "internal",
-          "parent": "0",
-          "type": "IP6",
+          "metric": "0",
+          "parent": "r5(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:2:2::/64"
         },
         {
@@ -115,31 +115,35 @@
           "vertex": "r4"
         },
         {
-          "interface": "r3",
-          "next-hop": "10",
-          "parent": "r5-eth0",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r5-eth0",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:1::/64"
         },
         {
-          "interface": "r3",
-          "next-hop": "10",
-          "parent": "r5-eth0",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r5-eth0",
+          "next-hop": "r3",
+          "parent": "r3(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:f::3/128"
         },
         {
-          "interface": "r4",
-          "next-hop": "10",
-          "parent": "r5-eth1",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r5-eth1",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:1:2::/64"
         },
         {
-          "interface": "r4",
-          "next-hop": "10",
-          "parent": "r5-eth1",
-          "type": "IP6",
+          "metric": "10",
+          "interface": "r5-eth1",
+          "next-hop": "r4",
+          "parent": "r4(4)",
+          "type": "IP6 internal",
           "vertex": "2001:db8:f::4/128"
         }
       ]


### PR DESCRIPTION
parse_topology function doesn't correctly process vertex types with
spaces. Therefore the reference topology files are completely messed up,
we have values in incorrect fields - types in metrics, metrics in
parents, etc.

This commit fixes the parsing function and the reference files.

The same fix was done for isis-topo1-vrf in #8365.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>