### PR TITLE
pceplib. Clean scan-build static analyzer messages.

### DIFF
--- a/pceplib/test/pcep_msg_messages_test.c
+++ b/pceplib/test/pcep_msg_messages_test.c
@@ -26,6 +26,7 @@
 #endif
 
 #include <stdlib.h>
+#include <assert.h>
 
 #include <CUnit/CUnit.h>
 
@@ -79,13 +80,16 @@ void test_pcep_msg_create_open()
 		pcep_msg_create_open(keepalive, deadtimer, sid);
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 1);
 	CU_ASSERT_EQUAL(message->encoded_message_length,
 			MESSAGE_HEADER_LENGTH
 				+ pcep_object_get_length(PCEP_OBJ_CLASS_OPEN,
 							 PCEP_OBJ_TYPE_OPEN));
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_OPEN);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -122,6 +126,7 @@ void test_pcep_msg_create_request()
 
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 2);
@@ -130,6 +135,7 @@ void test_pcep_msg_create_request()
 		MESSAGE_HEADER_LENGTH
 			+ pcep_object_get_length_by_hdr(&rp_obj->header)
 			+ pcep_object_get_length_by_hdr(&ipv4_obj->header));
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_PCREQ);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -144,14 +150,17 @@ void test_pcep_msg_create_request()
 
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 2);
 	CU_ASSERT_EQUAL(
 		message->encoded_message_length,
 		MESSAGE_HEADER_LENGTH
 			+ pcep_object_get_length_by_hdr(&rp_obj->header)
 			+ pcep_object_get_length_by_hdr(&ipv6_obj->header));
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_PCREQ);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -169,8 +178,10 @@ void test_pcep_msg_create_request()
 
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 3);
 	CU_ASSERT_EQUAL(
 		message->encoded_message_length,
@@ -179,6 +190,7 @@ void test_pcep_msg_create_request()
 			+ pcep_object_get_length_by_hdr(&ipv4_obj->header)
 			+ pcep_object_get_length_by_hdr(
 				&bandwidth_obj->header));
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_PCREQ);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -203,13 +215,16 @@ void test_pcep_msg_create_reply_nopath()
 	struct pcep_message *message = pcep_msg_create_reply(rp_obj, obj_list);
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 2);
 	CU_ASSERT_EQUAL(message->encoded_message_length,
 			(MESSAGE_HEADER_LENGTH
 			 + pcep_object_get_length_by_hdr(&rp_obj->header)
 			 + pcep_object_get_length_by_hdr(&nopath_obj->header)));
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_PCREP);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -224,10 +239,12 @@ void test_pcep_msg_create_reply()
 
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 0);
 	CU_ASSERT_EQUAL(message->encoded_message_length, MESSAGE_HEADER_LENGTH);
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_PCREP);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -249,6 +266,7 @@ void test_pcep_msg_create_reply()
 	pcep_encode_message(message, versioning);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 2);
 	CU_ASSERT_EQUAL(message->encoded_message_length,
 			MESSAGE_HEADER_LENGTH
@@ -270,13 +288,16 @@ void test_pcep_msg_create_close()
 	struct pcep_message *message = pcep_msg_create_close(reason);
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 1);
 	CU_ASSERT_EQUAL(message->encoded_message_length,
 			MESSAGE_HEADER_LENGTH
 				+ pcep_object_get_length(PCEP_OBJ_CLASS_CLOSE,
 							 PCEP_OBJ_TYPE_CLOSE));
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_CLOSE);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -285,6 +306,7 @@ void test_pcep_msg_create_close()
 	 * are verified in pcep-objects-test.c */
 	struct pcep_object_close *close_obj =
 		(struct pcep_object_close *)message->obj_list->head->data;
+	assert(close_obj != NULL);
 	CU_ASSERT_EQUAL(close_obj->header.object_class, PCEP_OBJ_CLASS_CLOSE);
 	CU_ASSERT_EQUAL(close_obj->header.object_type, PCEP_OBJ_TYPE_CLOSE);
 	CU_ASSERT_EQUAL(close_obj->reason, reason);
@@ -301,13 +323,16 @@ void test_pcep_msg_create_error()
 		pcep_msg_create_error(error_type, error_value);
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 1);
 	CU_ASSERT_EQUAL(message->encoded_message_length,
 			MESSAGE_HEADER_LENGTH
 				+ pcep_object_get_length(PCEP_OBJ_CLASS_ERROR,
 							 PCEP_OBJ_TYPE_ERROR));
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_ERROR);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -330,10 +355,13 @@ void test_pcep_msg_create_keepalive()
 	struct pcep_message *message = pcep_msg_create_keepalive();
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 0);
 	CU_ASSERT_EQUAL(message->encoded_message_length, MESSAGE_HEADER_LENGTH);
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_KEEPALIVE);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -355,12 +383,15 @@ void test_pcep_msg_create_report()
 	message = pcep_msg_create_report(obj_list);
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 1);
 	CU_ASSERT_EQUAL(message->encoded_message_length,
 			MESSAGE_HEADER_LENGTH
 				+ lsp->header.encoded_object_length);
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_REPORT);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -405,14 +436,17 @@ void test_pcep_msg_create_update()
 	message = pcep_msg_create_update(obj_list);
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 3);
 	CU_ASSERT_EQUAL(message->encoded_message_length,
 			MESSAGE_HEADER_LENGTH
 				+ srp->header.encoded_object_length
 				+ lsp->header.encoded_object_length
 				+ ero->header.encoded_object_length);
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_UPDATE);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -454,14 +488,17 @@ void test_pcep_msg_create_initiate()
 	message = pcep_msg_create_initiate(obj_list);
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->msg_header);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 3);
 	CU_ASSERT_EQUAL(message->encoded_message_length,
 			MESSAGE_HEADER_LENGTH
 				+ srp->header.encoded_object_length
 				+ lsp->header.encoded_object_length
 				+ ero->header.encoded_object_length);
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_INITIATE);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -482,11 +519,14 @@ void test_pcep_msg_create_notify(void)
 	message = pcep_msg_create_notify(notify_obj, NULL);
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 1);
 	CU_ASSERT_EQUAL(message->encoded_message_length,
 			MESSAGE_HEADER_LENGTH
 				+ notify_obj->header.encoded_object_length);
+	assert(message->msg_header != NULL);
 	CU_ASSERT_EQUAL(message->msg_header->type, PCEP_TYPE_PCNOTF);
 	CU_ASSERT_EQUAL(message->msg_header->pcep_version,
 			PCEP_MESSAGE_HEADER_VERSION);
@@ -504,7 +544,9 @@ void test_pcep_msg_create_notify(void)
 	message = pcep_msg_create_notify(notify_obj, obj_list);
 	CU_ASSERT_PTR_NOT_NULL(message);
 	pcep_encode_message(message, versioning);
+	assert(message != NULL);
 	CU_ASSERT_PTR_NOT_NULL(message->obj_list);
+	assert(message->obj_list != NULL);
 	CU_ASSERT_EQUAL(message->obj_list->num_entries, 2);
 	CU_ASSERT_EQUAL(message->encoded_message_length,
 			MESSAGE_HEADER_LENGTH

--- a/pceplib/test/pcep_msg_objects_test.c
+++ b/pceplib/test/pcep_msg_objects_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <stdlib.h>
 
 #include <CUnit/CUnit.h>
@@ -128,6 +129,7 @@ static void verify_pcep_obj_header2(uint8_t obj_class, uint8_t obj_type,
 static void verify_pcep_obj_header(uint8_t obj_class, uint8_t obj_type,
 				   struct pcep_object_header *obj_hdr)
 {
+	assert(obj_hdr != NULL);
 	verify_pcep_obj_header2(obj_class, obj_type,
 				pcep_object_get_length_by_hdr(obj_hdr),
 				obj_hdr->encoded_object);
@@ -172,12 +174,14 @@ void test_pcep_obj_create_open_with_tlvs()
 		pcep_obj_create_open(keepalive, deadtimer, sid, tlv_list);
 
 	CU_ASSERT_PTR_NOT_NULL(open);
+	assert(open != NULL);
 	pcep_encode_object(&open->header, versioning, object_buf);
 	verify_pcep_obj_header2(PCEP_OBJ_CLASS_OPEN, PCEP_OBJ_TYPE_OPEN,
 				pcep_object_get_length_by_hdr(&open->header)
 					+ sizeof(uint32_t) * 2,
 				open->header.encoded_object);
 	CU_ASSERT_PTR_NOT_NULL(open->header.tlv_list);
+	assert(open->header.tlv_list != NULL);
 	CU_ASSERT_EQUAL(open->header.tlv_list->num_entries, 1);
 
 	CU_ASSERT_EQUAL(open->header.encoded_object[4],
@@ -240,6 +244,8 @@ void test_pcep_obj_create_nopath()
 	CU_ASSERT_EQUAL(nopath->header.encoded_object[7], 0);
 
 	/* Verify the TLV */
+	assert(nopath != NULL);
+	assert(nopath->header.tlv_list != NULL);
 	CU_ASSERT_PTR_NOT_NULL(nopath->header.tlv_list);
 	struct pcep_object_tlv_nopath_vector *tlv =
 		(struct pcep_object_tlv_nopath_vector *)
@@ -269,6 +275,7 @@ void test_pcep_obj_create_association_ipv4()
 			false, PCEP_ASSOCIATION_TYPE_SR_POLICY_ASSOCIATION_TYPE,
 			all_assoc_groups, src);
 	CU_ASSERT_PTR_NOT_NULL(assoc);
+	assert(assoc != NULL);
 	CU_ASSERT_EQUAL(assoc->association_type,
 			PCEP_ASSOCIATION_TYPE_SR_POLICY_ASSOCIATION_TYPE);
 	CU_ASSERT_EQUAL(assoc->association_id, all_assoc_groups);
@@ -291,6 +298,7 @@ void test_pcep_obj_create_association_ipv6()
 			false, PCEP_ASSOCIATION_TYPE_SR_POLICY_ASSOCIATION_TYPE,
 			all_assoc_groups, src);
 	CU_ASSERT_PTR_NOT_NULL(assoc);
+	assert(assoc != NULL);
 	CU_ASSERT_EQUAL(assoc->association_type,
 			PCEP_ASSOCIATION_TYPE_SR_POLICY_ASSOCIATION_TYPE);
 	CU_ASSERT_EQUAL(assoc->association_id, all_assoc_groups);
@@ -466,6 +474,7 @@ void test_pcep_obj_create_svec()
 
 	svec = pcep_obj_create_svec(true, true, true, id_list);
 	CU_ASSERT_PTR_NOT_NULL(svec);
+	assert(svec != NULL);
 	pcep_encode_object(&svec->header, versioning, object_buf);
 	verify_pcep_obj_header2(PCEP_OBJ_CLASS_SVEC, PCEP_OBJ_TYPE_SVEC,
 				(OBJECT_HEADER_LENGTH + sizeof(uint32_t) * 2),
@@ -614,6 +623,7 @@ static void test_pcep_obj_create_object_common(ro_func func_to_test,
 
 	struct pcep_object_ro *ero = func_to_test(NULL);
 	CU_ASSERT_PTR_NOT_NULL(ero);
+	assert(ero != NULL);
 	pcep_encode_object(&ero->header, versioning, object_buf);
 	verify_pcep_obj_header2(object_class, object_type, OBJECT_HEADER_LENGTH,
 				ero->header.encoded_object);
@@ -622,6 +632,7 @@ static void test_pcep_obj_create_object_common(ro_func func_to_test,
 	reset_objects_buffer();
 	ero = func_to_test(ero_list);
 	CU_ASSERT_PTR_NOT_NULL(ero);
+	assert(ero != NULL);
 	pcep_encode_object(&ero->header, versioning, object_buf);
 	verify_pcep_obj_header2(object_class, object_type, OBJECT_HEADER_LENGTH,
 				ero->header.encoded_object);
@@ -634,6 +645,7 @@ static void test_pcep_obj_create_object_common(ro_func func_to_test,
 	dll_append(ero_list, ro_subobj);
 	ero = func_to_test(ero_list);
 	CU_ASSERT_PTR_NOT_NULL(ero);
+	assert(ero != NULL);
 	pcep_encode_object(&ero->header, versioning, object_buf);
 	/* 4 bytes for obj header +
 	 * 2 bytes for ro_subobj header +
@@ -917,6 +929,7 @@ void test_pcep_obj_create_ro_subobj_sr_ipv4_node()
 	sr = pcep_obj_create_ro_subobj_sr_ipv4_node(true, true, false, false,
 						    sid, &ipv4_node_id);
 	CU_ASSERT_PTR_NOT_NULL(sr);
+	assert(sr != NULL);
 	struct pcep_object_ro *ro = encode_ro_subobj(&sr->ro_subobj);
 	verify_pcep_obj_ro_sr_header(ro, &sr->ro_subobj,
 				     PCEP_SR_SUBOBJ_NAI_IPV4_NODE, true,
@@ -936,10 +949,12 @@ void test_pcep_obj_create_ro_subobj_sr_ipv4_node()
 	sr = pcep_obj_create_ro_subobj_sr_ipv4_node(false, false, true, true,
 						    sid, &ipv4_node_id);
 	CU_ASSERT_PTR_NOT_NULL(sr);
+	assert(sr != NULL);
 	ro = encode_ro_subobj(&sr->ro_subobj);
 	verify_pcep_obj_ro_sr_header(ro, &sr->ro_subobj,
 				     PCEP_SR_SUBOBJ_NAI_IPV4_NODE, false,
 				     sizeof(uint32_t) * 4);
+	assert(ro != NULL);
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & OBJECT_SUBOBJ_SR_FLAG_C);
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & OBJECT_SUBOBJ_SR_FLAG_M);
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & ~OBJECT_SUBOBJ_SR_FLAG_S);
@@ -1040,6 +1055,7 @@ void test_pcep_obj_create_ro_subobj_sr_ipv4_adj()
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & ~OBJECT_SUBOBJ_SR_FLAG_F);
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & ~OBJECT_SUBOBJ_SR_FLAG_C);
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & ~OBJECT_SUBOBJ_SR_FLAG_M);
+	assert(sr != NULL);
 	CU_ASSERT_EQUAL(sr->sid, 0);
 	uint32_t *uint32_ptr = (uint32_t *)(ro->header.encoded_object + 8);
 	CU_ASSERT_EQUAL(uint32_ptr[0], local_ipv4.s_addr);
@@ -1094,6 +1110,7 @@ void test_pcep_obj_create_ro_subobj_sr_ipv6_adj()
 	sr = pcep_obj_create_ro_subobj_sr_ipv6_adj(true, true, true, true, sid,
 						   &local_ipv6, &remote_ipv6);
 	CU_ASSERT_PTR_NOT_NULL(sr);
+	assert(sr != NULL);
 	struct pcep_object_ro *ro = encode_ro_subobj(&sr->ro_subobj);
 	verify_pcep_obj_ro_sr_header(ro, &sr->ro_subobj,
 				     PCEP_SR_SUBOBJ_NAI_IPV6_ADJACENCY, true,
@@ -1168,6 +1185,7 @@ void test_pcep_obj_create_ro_subobj_sr_unnumbered_ipv4_adj()
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & ~OBJECT_SUBOBJ_SR_FLAG_F);
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & ~OBJECT_SUBOBJ_SR_FLAG_C);
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & ~OBJECT_SUBOBJ_SR_FLAG_M);
+	assert(sr != NULL);
 	CU_ASSERT_EQUAL(sr->sid, 0);
 	uint32_t *uint32_ptr = (uint32_t *)(ro->header.encoded_object + 8);
 	CU_ASSERT_EQUAL(uint32_ptr[0], local_node_id);
@@ -1244,6 +1262,7 @@ void test_pcep_obj_create_ro_subobj_sr_linklocal_ipv6_adj()
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & ~OBJECT_SUBOBJ_SR_FLAG_F);
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & ~OBJECT_SUBOBJ_SR_FLAG_C);
 	CU_ASSERT_TRUE(ro->header.encoded_object[7] & ~OBJECT_SUBOBJ_SR_FLAG_M);
+	assert(sr != NULL);
 	CU_ASSERT_EQUAL(sr->sid, 0);
 	uint32_t *uint32_ptr = (uint32_t *)(ro->header.encoded_object + 8);
 	CU_ASSERT_EQUAL(uint32_ptr[0], local_ipv6.__in6_u.__u6_addr32[0]);

--- a/pceplib/test/pcep_msg_tlvs_test.c
+++ b/pceplib/test/pcep_msg_tlvs_test.c
@@ -30,6 +30,7 @@
 #else
 #include <endian.h>
 #endif /* __FreeBSD__ */
+#include <assert.h>
 #include <stdlib.h>
 
 #include <CUnit/CUnit.h>
@@ -88,6 +89,7 @@ void test_pcep_tlv_create_stateful_pce_capability()
 		pcep_tlv_create_stateful_pce_capability(true, true, true, true,
 							true, true);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type,
@@ -126,11 +128,13 @@ void test_pcep_tlv_create_speaker_entity_id()
 	dll_append(list, speaker_entity);
 	tlv = pcep_tlv_create_speaker_entity_id(list);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, PCEP_OBJ_TLV_TYPE_SPEAKER_ENTITY_ID);
 	CU_ASSERT_EQUAL(tlv->header.encoded_tlv_length, sizeof(uint32_t));
 	CU_ASSERT_PTR_NOT_NULL(tlv->speaker_entity_id_list);
+	assert(tlv->speaker_entity_id_list != NULL);
 	CU_ASSERT_EQUAL(tlv->speaker_entity_id_list->num_entries, 1);
 	uint32_t *uint32_ptr = (uint32_t *)tlv->header.encoded_tlv;
 	CU_ASSERT_EQUAL(uint32_ptr[1], htonl(*speaker_entity));
@@ -144,6 +148,7 @@ void test_pcep_tlv_create_lsp_db_version()
 	struct pcep_object_tlv_lsp_db_version *tlv =
 		pcep_tlv_create_lsp_db_version(lsp_db_version);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, PCEP_OBJ_TLV_TYPE_LSP_DB_VERSION);
@@ -162,6 +167,7 @@ void test_pcep_tlv_create_path_setup_type()
 	struct pcep_object_tlv_path_setup_type *tlv =
 		pcep_tlv_create_path_setup_type(pst);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, PCEP_OBJ_TLV_TYPE_PATH_SETUP_TYPE);
 	CU_ASSERT_EQUAL(tlv->header.encoded_tlv_length, sizeof(uint32_t));
@@ -231,6 +237,7 @@ void test_pcep_tlv_create_path_setup_type_capability()
 			PCEP_OBJ_TLV_TYPE_PATH_SETUP_TYPE_CAPABILITY);
 	CU_ASSERT_EQUAL(tlv->header.encoded_tlv_length, sizeof(uint32_t) * 2);
 	CU_ASSERT_PTR_NOT_NULL(tlv->pst_list);
+	assert(tlv != NULL);
 	CU_ASSERT_EQUAL(tlv->pst_list->num_entries, 3);
 	uint32_t *uint32_ptr = (uint32_t *)tlv->header.encoded_tlv;
 	CU_ASSERT_EQUAL(uint32_ptr[1], htonl(0x00000003));
@@ -251,6 +258,7 @@ void test_pcep_tlv_create_path_setup_type_capability()
 	tlv = pcep_tlv_create_path_setup_type_capability(pst_list,
 							 sub_tlv_list);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type,
@@ -283,6 +291,7 @@ void test_pcep_tlv_create_sr_pce_capability()
 	struct pcep_object_tlv_sr_pce_capability *tlv =
 		pcep_tlv_create_sr_pce_capability(true, true, 8);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, PCEP_OBJ_TLV_TYPE_SR_PCE_CAPABILITY);
@@ -305,6 +314,7 @@ void test_pcep_tlv_create_symbolic_path_name()
 	struct pcep_object_tlv_symbolic_path_name *tlv =
 		pcep_tlv_create_symbolic_path_name(path_name, path_name_length);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, PCEP_OBJ_TLV_TYPE_SYMBOLIC_PATH_NAME);
@@ -325,6 +335,8 @@ void test_pcep_tlv_create_symbolic_path_name()
 	reset_tlv_buffer();
 	tlv = pcep_tlv_create_symbolic_path_name(path_name, 3);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	printf("El tlv es %p", tlv);
+	assert(tlv != NULL); // crash si FALSE
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, PCEP_OBJ_TLV_TYPE_SYMBOLIC_PATH_NAME);
 	CU_ASSERT_EQUAL(tlv->header.encoded_tlv_length, 3);
@@ -359,6 +371,7 @@ void test_pcep_tlv_create_ipv4_lsp_identifiers()
 	tlv = pcep_tlv_create_ipv4_lsp_identifiers(
 		NULL, NULL, lsp_id, tunnel_id, &extended_tunnel_id);
 	CU_ASSERT_PTR_NULL(tlv);
+	assert(tlv == NULL);
 
 	tlv = pcep_tlv_create_ipv4_lsp_identifiers(&sender_ip, &endpoint_ip,
 						   lsp_id, tunnel_id,
@@ -381,6 +394,7 @@ void test_pcep_tlv_create_ipv4_lsp_identifiers()
 	tlv = pcep_tlv_create_ipv4_lsp_identifiers(&sender_ip, &endpoint_ip,
 						   lsp_id, tunnel_id, NULL);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type,
@@ -424,11 +438,13 @@ void test_pcep_tlv_create_ipv6_lsp_identifiers()
 		NULL, NULL, lsp_id, tunnel_id,
 		(struct in6_addr *)&extended_tunnel_id);
 	CU_ASSERT_PTR_NULL(tlv);
+	assert(tlv == NULL);
 
 	tlv = pcep_tlv_create_ipv6_lsp_identifiers(
 		&sender_ip, &endpoint_ip, lsp_id, tunnel_id,
 		(struct in6_addr *)&extended_tunnel_id);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type,
@@ -449,6 +465,7 @@ void test_pcep_tlv_create_srpag_pol_id_ipv4()
 	struct pcep_object_tlv_srpag_pol_id *tlv =
 		pcep_tlv_create_srpag_pol_id_ipv4(color, (void *)&src);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, (PCEP_OBJ_TLV_TYPE_SRPOLICY_POL_ID));
@@ -506,6 +523,7 @@ void test_pcep_tlv_create_srpag_pol_name()
 	struct pcep_object_tlv_srpag_pol_name *tlv =
 		pcep_tlv_create_srpag_pol_name(pol_name, strlen(pol_name));
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type,
@@ -559,6 +577,7 @@ void test_pcep_tlv_create_srpag_cp_pref()
 	struct pcep_object_tlv_srpag_cp_pref *tlv =
 		pcep_tlv_create_srpag_cp_pref(preference_default);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type,
@@ -586,6 +605,7 @@ void test_pcep_tlv_create_lsp_error_code()
 		pcep_tlv_create_lsp_error_code(
 			PCEP_TLV_LSP_ERROR_CODE_RSVP_SIGNALING_ERROR);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, PCEP_OBJ_TLV_TYPE_LSP_ERROR_CODE);
@@ -612,6 +632,7 @@ void test_pcep_tlv_create_rsvp_ipv4_error_spec()
 	tlv = pcep_tlv_create_rsvp_ipv4_error_spec(&error_node_ip, error_code,
 						   error_value);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, PCEP_OBJ_TLV_TYPE_RSVP_ERROR_SPEC);
@@ -635,6 +656,7 @@ void test_pcep_tlv_create_rsvp_ipv6_error_spec()
 	tlv = pcep_tlv_create_rsvp_ipv6_error_spec(&error_node_ip, error_code,
 						   error_value);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, PCEP_OBJ_TLV_TYPE_RSVP_ERROR_SPEC);
@@ -651,6 +673,7 @@ void test_pcep_tlv_create_nopath_vector()
 	struct pcep_object_tlv_vendor_info *tlv = pcep_tlv_create_vendor_info(
 		enterprise_number, enterprise_specific_info);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, PCEP_OBJ_TLV_TYPE_VENDOR_INFO);
@@ -670,6 +693,7 @@ void test_pcep_tlv_create_arbitrary()
 	struct pcep_object_tlv_arbitrary *tlv = pcep_tlv_create_tlv_arbitrary(
 		data, data_length, tlv_id_unknown);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, tlv_id_unknown);
@@ -688,6 +712,7 @@ void test_pcep_tlv_create_arbitrary()
 	reset_tlv_buffer();
 	tlv = pcep_tlv_create_tlv_arbitrary(data, 3, tlv_id_unknown);
 	CU_ASSERT_PTR_NOT_NULL(tlv);
+	assert(tlv != NULL);
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type, tlv_id_unknown);
 	CU_ASSERT_EQUAL(tlv->header.encoded_tlv_length, 3);

--- a/pceplib/test/pcep_msg_tools_test.c
+++ b/pceplib/test/pcep_msg_tools_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -213,6 +214,7 @@ void test_pcep_msg_read_pcep_initiate()
 	}
 	double_linked_list *msg_list = pcep_msg_read(fd);
 	CU_ASSERT_PTR_NOT_NULL(msg_list);
+	assert(msg_list != NULL);
 	CU_ASSERT_EQUAL(msg_list->num_entries, 1);
 
 	struct pcep_message *msg = (struct pcep_message *)msg_list->head->data;
@@ -274,6 +276,7 @@ void test_pcep_msg_read_pcep_initiate()
 	double_linked_list *ero_subobj_list =
 		((struct pcep_object_ro *)obj_hdr)->sub_objects;
 	CU_ASSERT_PTR_NOT_NULL(ero_subobj_list);
+	assert(ero_subobj_list != NULL);
 	CU_ASSERT_EQUAL(ero_subobj_list->num_entries, 2);
 	double_linked_list_node *subobj_node = ero_subobj_list->head;
 	struct pcep_object_ro_subobj *subobj_hdr =
@@ -312,6 +315,7 @@ void test_pcep_msg_read_pcep_initiate2()
 	}
 	double_linked_list *msg_list = pcep_msg_read(fd);
 	CU_ASSERT_PTR_NOT_NULL(msg_list);
+	assert(msg_list != NULL);
 	CU_ASSERT_EQUAL(msg_list->num_entries, 1);
 
 	struct pcep_message *msg = (struct pcep_message *)msg_list->head->data;
@@ -367,6 +371,7 @@ void test_pcep_msg_read_pcep_initiate2()
 	double_linked_list *ero_subobj_list =
 		((struct pcep_object_ro *)obj_hdr)->sub_objects;
 	CU_ASSERT_PTR_NOT_NULL(ero_subobj_list);
+	assert(ero_subobj_list != NULL);
 	CU_ASSERT_EQUAL(ero_subobj_list->num_entries, 0);
 	double_linked_list_node *subobj_node = ero_subobj_list->head;
 	CU_ASSERT_PTR_NULL(subobj_node);
@@ -399,6 +404,7 @@ void test_pcep_msg_read_pcep_open()
 	}
 	double_linked_list *msg_list = pcep_msg_read(fd);
 	CU_ASSERT_PTR_NOT_NULL(msg_list);
+	assert(msg_list != NULL);
 	CU_ASSERT_EQUAL(msg_list->num_entries, 1);
 
 	struct pcep_message *msg = (struct pcep_message *)msg_list->head->data;
@@ -443,6 +449,7 @@ void test_pcep_msg_read_pcep_update()
 	}
 	double_linked_list *msg_list = pcep_msg_read(fd);
 	CU_ASSERT_PTR_NOT_NULL(msg_list);
+	assert(msg_list != NULL);
 	CU_ASSERT_EQUAL(msg_list->num_entries, 1);
 
 	struct pcep_message *msg = (struct pcep_message *)msg_list->head->data;
@@ -492,6 +499,7 @@ void test_pcep_msg_read_pcep_update()
 	double_linked_list *ero_subobj_list =
 		((struct pcep_object_ro *)obj_hdr)->sub_objects;
 	CU_ASSERT_PTR_NOT_NULL(ero_subobj_list);
+	assert(ero_subobj_list != NULL);
 	CU_ASSERT_EQUAL(ero_subobj_list->num_entries, 0);
 	double_linked_list_node *subobj_node = ero_subobj_list->head;
 	CU_ASSERT_PTR_NULL(subobj_node);
@@ -525,6 +533,7 @@ void test_pcep_msg_read_pcep_open_initiate()
 	}
 	double_linked_list *msg_list = pcep_msg_read(fd);
 	CU_ASSERT_PTR_NOT_NULL(msg_list);
+	assert(msg_list != NULL);
 	CU_ASSERT_EQUAL(msg_list->num_entries, 2);
 
 	struct pcep_message *msg = (struct pcep_message *)msg_list->head->data;
@@ -554,6 +563,7 @@ void test_pcep_msg_read_pcep_open_cisco_pce()
 	}
 	double_linked_list *msg_list = pcep_msg_read(fd);
 	CU_ASSERT_PTR_NOT_NULL(msg_list);
+	assert(msg_list != NULL);
 	CU_ASSERT_EQUAL(msg_list->num_entries, 1);
 
 	struct pcep_message *msg = (struct pcep_message *)msg_list->head->data;
@@ -573,6 +583,7 @@ void test_pcep_msg_read_pcep_open_cisco_pce()
 	CU_ASSERT_EQUAL(open->open_sid, 0);
 	CU_ASSERT_EQUAL(open->open_version, 1);
 	CU_ASSERT_PTR_NOT_NULL(open->header.tlv_list);
+	assert(open->header.tlv_list != NULL);
 	CU_ASSERT_EQUAL(open->header.tlv_list->num_entries, 2);
 
 	/* Stateful PCE Capability TLV */
@@ -616,6 +627,7 @@ void test_pcep_msg_read_pcep_update_cisco_pce()
 	}
 	double_linked_list *msg_list = pcep_msg_read(fd);
 	CU_ASSERT_PTR_NOT_NULL(msg_list);
+	assert(msg_list != NULL);
 	CU_ASSERT_EQUAL(msg_list->num_entries, 1);
 
 	struct pcep_message *msg = (struct pcep_message *)msg_list->head->data;
@@ -631,6 +643,7 @@ void test_pcep_msg_read_pcep_update_cisco_pce()
 	CU_ASSERT_EQUAL(srp->header.object_type, PCEP_OBJ_TYPE_SRP);
 	CU_ASSERT_EQUAL(srp->header.encoded_object_length, 20);
 	CU_ASSERT_PTR_NOT_NULL(srp->header.tlv_list);
+	assert(srp->header.tlv_list != NULL);
 	CU_ASSERT_EQUAL(srp->header.tlv_list->num_entries, 1);
 	CU_ASSERT_EQUAL(srp->srp_id_number, 1);
 	CU_ASSERT_FALSE(srp->flag_lsp_remove);
@@ -651,6 +664,7 @@ void test_pcep_msg_read_pcep_update_cisco_pce()
 	CU_ASSERT_EQUAL(lsp->header.object_type, PCEP_OBJ_TYPE_LSP);
 	CU_ASSERT_EQUAL(lsp->header.encoded_object_length, 24);
 	CU_ASSERT_PTR_NOT_NULL(lsp->header.tlv_list);
+	assert(lsp->header.tlv_list != NULL);
 	CU_ASSERT_EQUAL(lsp->header.tlv_list->num_entries, 1);
 	CU_ASSERT_EQUAL(lsp->plsp_id, 524303);
 	CU_ASSERT_EQUAL(lsp->operational_status, PCEP_LSP_OPERATIONAL_DOWN);
@@ -677,6 +691,7 @@ void test_pcep_msg_read_pcep_update_cisco_pce()
 	CU_ASSERT_EQUAL(ero->header.encoded_object_length, 40);
 	CU_ASSERT_PTR_NULL(ero->header.tlv_list);
 	CU_ASSERT_PTR_NOT_NULL(ero->sub_objects);
+	assert(ero->sub_objects != NULL);
 	CU_ASSERT_EQUAL(ero->sub_objects->num_entries, 3);
 
 	/* ERO Subobjects */
@@ -757,6 +772,7 @@ void test_pcep_msg_read_pcep_report_cisco_pcc()
 	}
 	double_linked_list *msg_list = pcep_msg_read(fd);
 	CU_ASSERT_PTR_NOT_NULL(msg_list);
+	assert(msg_list != NULL);
 	CU_ASSERT_EQUAL(msg_list->num_entries, 1);
 
 	struct pcep_message *msg = (struct pcep_message *)msg_list->head->data;
@@ -772,6 +788,7 @@ void test_pcep_msg_read_pcep_report_cisco_pcc()
 	CU_ASSERT_EQUAL(srp->header.object_type, PCEP_OBJ_TYPE_SRP);
 	CU_ASSERT_EQUAL(srp->header.encoded_object_length, 20);
 	CU_ASSERT_PTR_NOT_NULL(srp->header.tlv_list);
+	assert(srp->header.tlv_list != NULL);
 	CU_ASSERT_EQUAL(srp->header.tlv_list->num_entries, 1);
 	CU_ASSERT_EQUAL(srp->srp_id_number, 0);
 	CU_ASSERT_FALSE(srp->flag_lsp_remove);
@@ -838,6 +855,7 @@ void test_pcep_msg_read_pcep_report_cisco_pcc()
 	CU_ASSERT_EQUAL(ero->header.encoded_object_length, 4);
 	CU_ASSERT_PTR_NULL(ero->header.tlv_list);
 	CU_ASSERT_PTR_NOT_NULL(ero->sub_objects);
+	assert(ero->sub_objects != NULL);
 	CU_ASSERT_EQUAL(ero->sub_objects->num_entries, 0);
 
 	/* LSPA object */
@@ -916,6 +934,7 @@ void test_pcep_msg_read_pcep_initiate_cisco_pcc()
 	}
 	double_linked_list *msg_list = pcep_msg_read(fd);
 	CU_ASSERT_PTR_NOT_NULL(msg_list);
+	assert(msg_list != NULL);
 	CU_ASSERT_EQUAL(msg_list->num_entries, 1);
 
 	struct pcep_message *msg = (struct pcep_message *)msg_list->head->data;
@@ -931,6 +950,7 @@ void test_pcep_msg_read_pcep_initiate_cisco_pcc()
 	CU_ASSERT_EQUAL(srp->header.object_type, PCEP_OBJ_TYPE_SRP);
 	CU_ASSERT_EQUAL(srp->header.encoded_object_length, 20);
 	CU_ASSERT_PTR_NOT_NULL(srp->header.tlv_list);
+	assert(srp->header.tlv_list != NULL);
 	CU_ASSERT_EQUAL(srp->header.tlv_list->num_entries, 1);
 	CU_ASSERT_EQUAL(srp->srp_id_number, 1);
 	CU_ASSERT_FALSE(srp->flag_lsp_remove);
@@ -942,6 +962,7 @@ void test_pcep_msg_read_pcep_initiate_cisco_pcc()
 	CU_ASSERT_EQUAL(lsp->header.object_type, PCEP_OBJ_TYPE_LSP);
 	CU_ASSERT_EQUAL(lsp->header.encoded_object_length, 48);
 	CU_ASSERT_PTR_NOT_NULL(lsp->header.tlv_list);
+	assert(lsp->header.tlv_list != NULL);
 	CU_ASSERT_EQUAL(lsp->header.tlv_list->num_entries, 2);
 	CU_ASSERT_EQUAL(lsp->plsp_id, 0);
 	CU_ASSERT_EQUAL(lsp->operational_status, PCEP_LSP_OPERATIONAL_DOWN);
@@ -988,7 +1009,9 @@ void test_pcep_msg_read_pcep_initiate_cisco_pcc()
 			PCEP_OBJ_TYPE_SWITCH_LAYER);
 	CU_ASSERT_EQUAL(switch_layer->header.encoded_object_length, 8);
 	CU_ASSERT_PTR_NULL(switch_layer->header.tlv_list);
+	assert(switch_layer->header.tlv_list == NULL);
 	CU_ASSERT_PTR_NOT_NULL(switch_layer->switch_layer_rows);
+	assert(switch_layer->switch_layer_rows != NULL);
 	CU_ASSERT_EQUAL(switch_layer->switch_layer_rows->num_entries, 1);
 	struct pcep_object_switch_layer_row *switch_layer_row =
 		(struct pcep_object_switch_layer_row *)

--- a/pceplib/test/pcep_pcc_api_test.c
+++ b/pceplib/test/pcep_pcc_api_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <netdb.h> // gethostbyname
 #include <pthread.h>
 #include <stdlib.h>
@@ -108,6 +109,8 @@ void test_connect_pce()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	struct pcep_message *open_msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(open_msg);
+	assert(open_msg != NULL);
+	assert(open_msg->msg_header != NULL);
 	CU_ASSERT_EQUAL(open_msg->msg_header->type, PCEP_TYPE_OPEN);
 
 	pcep_msg_free_message(open_msg);
@@ -134,6 +137,7 @@ void test_connect_pce_ipv6()
 	pcep_session *session = connect_pce_ipv6(config, &dest_address);
 
 	CU_ASSERT_PTR_NOT_NULL(session);
+	assert(session != NULL);
 	CU_ASSERT_TRUE(session->socket_comm_session->is_ipv6);
 	CU_ASSERT_EQUAL(mock_info->sent_message_list->num_entries, 1);
 	/* What gets saved in the mock is the msg byte buffer. The msg struct
@@ -144,6 +148,7 @@ void test_connect_pce_ipv6()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	struct pcep_message *open_msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(open_msg);
+	assert(open_msg != NULL);
 	CU_ASSERT_EQUAL(open_msg->msg_header->type, PCEP_TYPE_OPEN);
 
 	pcep_msg_free_message(open_msg);
@@ -175,6 +180,8 @@ void test_connect_pce_with_src_ip()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	struct pcep_message *open_msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(open_msg);
+	assert(open_msg != NULL);
+	assert(open_msg->msg_header != NULL);
 	CU_ASSERT_EQUAL(open_msg->msg_header->type, PCEP_TYPE_OPEN);
 
 	pcep_msg_free_message(open_msg);
@@ -207,6 +214,7 @@ void test_disconnect_pce()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	struct pcep_message *msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(msg);
+	assert(msg != NULL);
 	CU_ASSERT_EQUAL(msg->msg_header->type, PCEP_TYPE_OPEN);
 	pcep_msg_free_message(msg);
 	pceplib_free(PCEPLIB_MESSAGES, encoded_msg);
@@ -216,6 +224,8 @@ void test_disconnect_pce()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(msg);
+	assert(msg != NULL);
+	assert(msg->msg_header != NULL);
 	CU_ASSERT_EQUAL(msg->msg_header->type, PCEP_TYPE_CLOSE);
 
 	pcep_msg_free_message(msg);

--- a/pceplib/test/pcep_session_logic_loop_test.c
+++ b/pceplib/test/pcep_session_logic_loop_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
@@ -161,6 +162,7 @@ void test_session_logic_msg_ready_handler()
 	pcep_session_event *socket_event = (pcep_session_event *)queue_dequeue(
 		session_logic_handle_->session_event_queue);
 	CU_ASSERT_PTR_NOT_NULL(socket_event);
+	assert(socket_event != NULL);
 	CU_ASSERT_TRUE(socket_event->socket_closed);
 	pceplib_free(PCEPLIB_INFRA, socket_event);
 
@@ -179,6 +181,7 @@ void test_session_logic_msg_ready_handler()
 	socket_event = (pcep_session_event *)queue_dequeue(
 		session_logic_handle_->session_event_queue);
 	CU_ASSERT_PTR_NOT_NULL(socket_event);
+	assert(socket_event != NULL);
 	CU_ASSERT_FALSE(socket_event->socket_closed);
 	CU_ASSERT_PTR_EQUAL(socket_event->session, &session);
 	CU_ASSERT_EQUAL(socket_event->expired_timer_id, TIMER_ID_NOT_SET);
@@ -206,6 +209,7 @@ void test_session_logic_conn_except_notifier()
 	pcep_session_event *socket_event = (pcep_session_event *)queue_dequeue(
 		session_logic_handle_->session_event_queue);
 	CU_ASSERT_PTR_NOT_NULL_FATAL(socket_event);
+	assert(socket_event != NULL);
 	CU_ASSERT_TRUE(socket_event->socket_closed);
 	CU_ASSERT_PTR_EQUAL(socket_event->session, &session);
 	CU_ASSERT_EQUAL(socket_event->expired_timer_id, TIMER_ID_NOT_SET);
@@ -230,6 +234,7 @@ void test_session_logic_timer_expire_handler()
 	pcep_session_event *socket_event = (pcep_session_event *)queue_dequeue(
 		session_logic_handle_->session_event_queue);
 	CU_ASSERT_PTR_NOT_NULL_FATAL(socket_event);
+	assert(socket_event != NULL);
 	CU_ASSERT_FALSE(socket_event->socket_closed);
 	CU_ASSERT_PTR_EQUAL(socket_event->session, &session);
 	CU_ASSERT_EQUAL(socket_event->expired_timer_id, 42);

--- a/pceplib/test/pcep_session_logic_states_test.c
+++ b/pceplib/test/pcep_session_logic_states_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -394,6 +395,7 @@ void test_handle_socket_comm_event_open()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	struct pcep_message *msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(msg);
+	assert(msg != NULL);
 	CU_ASSERT_EQUAL(PCEP_TYPE_ERROR, msg->msg_header->type);
 	/* Verify the error object */
 	CU_ASSERT_EQUAL(1, msg->obj_list->num_entries);
@@ -456,6 +458,7 @@ void test_handle_socket_comm_event_open_error()
 	uint8_t *encoded_msg =
 		dll_delete_first_node(mock_info->sent_message_list);
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
+	assert(encoded_msg != NULL);
 	struct pcep_message *open_msg_corrected =
 		pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(open_msg_corrected);
@@ -463,6 +466,7 @@ void test_handle_socket_comm_event_open_error()
 		(struct pcep_object_open *)pcep_obj_get(
 			open_msg_corrected->obj_list, PCEP_OBJ_CLASS_OPEN);
 	CU_ASSERT_PTR_NOT_NULL(open_object_corrected);
+	assert(open_object_corrected != NULL);
 	/* Verify the Keep-alive and Dead timers have been negotiated */
 	CU_ASSERT_EQUAL(error_open_object->open_keepalive,
 			open_object_corrected->open_keepalive);
@@ -596,6 +600,7 @@ void test_handle_socket_comm_event_pcreq()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	struct pcep_message *error_msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(error_msg);
+	assert(error_msg != NULL);
 	CU_ASSERT_EQUAL(PCEP_TYPE_ERROR, error_msg->msg_header->type);
 	/* Verify the error object */
 	CU_ASSERT_EQUAL(1, error_msg->obj_list->num_entries);
@@ -627,6 +632,7 @@ void test_handle_socket_comm_event_report()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	struct pcep_message *error_msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(error_msg);
+	assert(error_msg != NULL);
 	CU_ASSERT_EQUAL(PCEP_TYPE_ERROR, error_msg->msg_header->type);
 	/* Verify the error object */
 	CU_ASSERT_EQUAL(1, error_msg->obj_list->num_entries);
@@ -744,6 +750,7 @@ void test_handle_socket_comm_event_unknown_msg()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	struct pcep_message *msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(msg);
+	assert(msg != NULL);
 	CU_ASSERT_EQUAL(PCEP_TYPE_ERROR, msg->msg_header->type);
 	/* Verify the error object */
 	CU_ASSERT_EQUAL(1, msg->obj_list->num_entries);
@@ -776,6 +783,7 @@ void test_handle_socket_comm_event_unknown_msg()
 	/* Verify the error message */
 	encoded_msg = dll_delete_first_node(mock_info->sent_message_list);
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
+	assert(encoded_msg != NULL);
 	msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(msg);
 	CU_ASSERT_EQUAL(PCEP_TYPE_ERROR, msg->msg_header->type);
@@ -793,8 +801,10 @@ void test_handle_socket_comm_event_unknown_msg()
 	/* Verify the Close message */
 	encoded_msg = dll_delete_first_node(mock_info->sent_message_list);
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
+	assert(encoded_msg != NULL);
 	msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(msg);
+	assert(msg != NULL);
 	CU_ASSERT_EQUAL(PCEP_TYPE_CLOSE, msg->msg_header->type);
 	/* Verify the error object */
 	CU_ASSERT_EQUAL(1, msg->obj_list->num_entries);

--- a/pceplib/test/pcep_session_logic_test.c
+++ b/pceplib/test/pcep_session_logic_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -134,6 +135,7 @@ void test_create_destroy_pcep_session()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	struct pcep_message *open_msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(open_msg);
+	assert(open_msg != NULL);
 	/* Should be an Open, with no TLVs: length = 12 */
 	CU_ASSERT_EQUAL(open_msg->msg_header->type, PCEP_TYPE_OPEN);
 	CU_ASSERT_EQUAL(open_msg->encoded_message_length, 12);
@@ -166,6 +168,7 @@ void test_create_destroy_pcep_session_ipv6()
 	mock_info->send_message_save_message = true;
 	session = create_pcep_session_ipv6(&config, &pce_ip);
 	CU_ASSERT_PTR_NOT_NULL(session);
+	assert(session != NULL);
 	CU_ASSERT_TRUE(session->socket_comm_session->is_ipv6);
 	/* What gets saved in the mock is the msg byte buffer. The msg struct
 	 * was deleted when it was sent. Instead of inspecting the msg byte
@@ -175,6 +178,7 @@ void test_create_destroy_pcep_session_ipv6()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	struct pcep_message *open_msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(open_msg);
+	assert(open_msg != NULL);
 	/* Should be an Open, with no TLVs: length = 12 */
 	CU_ASSERT_EQUAL(open_msg->msg_header->type, PCEP_TYPE_OPEN);
 	CU_ASSERT_EQUAL(open_msg->encoded_message_length, 12);
@@ -215,14 +219,17 @@ void test_create_pcep_session_open_tlvs()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	open_msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(open_msg);
+	assert(open_msg != NULL);
 	/* Get and verify the Open Message objects */
 	CU_ASSERT_PTR_NOT_NULL(open_msg->obj_list);
+	assert(open_msg->obj_list != NULL);
 	CU_ASSERT_TRUE(open_msg->obj_list->num_entries > 0);
 	/* Get and verify the Open object */
 	open_obj = pcep_obj_get(open_msg->obj_list, PCEP_OBJ_CLASS_OPEN);
 	CU_ASSERT_PTR_NOT_NULL(open_obj);
 	/* Get and verify the Open object TLVs */
 	CU_ASSERT_PTR_NOT_NULL(open_obj->tlv_list);
+	assert(open_obj->tlv_list != NULL);
 	CU_ASSERT_EQUAL(open_obj->tlv_list->num_entries, 1);
 	CU_ASSERT_EQUAL(((struct pcep_object_tlv_header *)
 				 open_obj->tlv_list->head->data)
@@ -250,12 +257,14 @@ void test_create_pcep_session_open_tlvs()
 	CU_ASSERT_PTR_NOT_NULL(open_msg);
 	/* Get and verify the Open Message objects */
 	CU_ASSERT_PTR_NOT_NULL(open_msg->obj_list);
+	assert(open_msg != NULL);
 	CU_ASSERT_TRUE(open_msg->obj_list->num_entries > 0);
 	/* Get and verify the Open object */
 	open_obj = pcep_obj_get(open_msg->obj_list, PCEP_OBJ_CLASS_OPEN);
 	CU_ASSERT_PTR_NOT_NULL(open_obj);
 	/* Get and verify the Open object TLVs */
 	CU_ASSERT_PTR_NOT_NULL(open_obj->tlv_list);
+	assert(open_obj->tlv_list != NULL);
 	CU_ASSERT_EQUAL(open_obj->tlv_list->num_entries, 2);
 	CU_ASSERT_EQUAL(((struct pcep_object_tlv_header *)
 				 open_obj->tlv_list->head->data)
@@ -287,14 +296,17 @@ void test_create_pcep_session_open_tlvs()
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
 	open_msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(open_msg);
+	assert(open_msg != NULL);
 	/* Get and verify the Open Message objects */
 	CU_ASSERT_PTR_NOT_NULL(open_msg->obj_list);
+	assert(open_msg->obj_list != NULL);
 	CU_ASSERT_TRUE(open_msg->obj_list->num_entries > 0);
 	/* Get and verify the Open object */
 	open_obj = pcep_obj_get(open_msg->obj_list, PCEP_OBJ_CLASS_OPEN);
 	CU_ASSERT_PTR_NOT_NULL(open_obj);
 	/* Get and verify the Open object TLVs */
 	CU_ASSERT_PTR_NOT_NULL(open_obj->tlv_list);
+	assert(open_obj->tlv_list != NULL);
 	CU_ASSERT_EQUAL(open_obj->tlv_list->num_entries, 3);
 	double_linked_list_node *tlv_node = open_obj->tlv_list->head;
 	CU_ASSERT_EQUAL(((struct pcep_object_tlv_header *)tlv_node->data)->type,
@@ -324,16 +336,21 @@ void test_create_pcep_session_open_tlvs()
 	/* Get and verify the Open Message */
 	encoded_msg = dll_delete_first_node(mock_info->sent_message_list);
 	CU_ASSERT_PTR_NOT_NULL(encoded_msg);
+	assert(encoded_msg != NULL);
 	open_msg = pcep_decode_message(encoded_msg);
 	CU_ASSERT_PTR_NOT_NULL(open_msg);
+	assert(open_msg != NULL);
 	/* Get and verify the Open Message objects */
 	CU_ASSERT_PTR_NOT_NULL(open_msg->obj_list);
+	assert(open_msg->obj_list != NULL);
 	CU_ASSERT_TRUE(open_msg->obj_list->num_entries > 0);
 	/* Get and verify the Open object */
 	open_obj = pcep_obj_get(open_msg->obj_list, PCEP_OBJ_CLASS_OPEN);
 	CU_ASSERT_PTR_NOT_NULL(open_obj);
+	assert(open_obj != NULL);
 	/* Get and verify the Open object TLVs */
 	CU_ASSERT_PTR_NOT_NULL(open_obj->tlv_list);
+	assert(open_obj->tlv_list != NULL);
 	CU_ASSERT_EQUAL(open_obj->tlv_list->num_entries, 4);
 	tlv_node = open_obj->tlv_list->head;
 	CU_ASSERT_EQUAL(((struct pcep_object_tlv_header *)tlv_node->data)->type,

--- a/pceplib/test/pcep_socket_comm_test.c
+++ b/pceplib/test/pcep_socket_comm_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <netinet/in.h>
 
 #include <CUnit/CUnit.h>
@@ -112,6 +113,7 @@ void test_pcep_socket_comm_initialize()
 		test_connection_except_notifier, &test_host_ip, test_port,
 		connect_timeout_millis, NULL, false, NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_FALSE(test_session->is_ipv6);
 }
 
@@ -123,6 +125,7 @@ void test_pcep_socket_comm_initialize_ipv6()
 		test_connection_except_notifier, &test_host_ipv6, test_port,
 		connect_timeout_millis, NULL, false, NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_TRUE(test_session->is_ipv6);
 }
 
@@ -135,6 +138,7 @@ void test_pcep_socket_comm_initialize_with_src()
 		test_connection_except_notifier, NULL, 0, &test_host_ip,
 		test_port, connect_timeout_millis, NULL, false, NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_EQUAL(
 		test_session->src_sock_addr.src_sock_addr_ipv4.sin_addr.s_addr,
 		INADDR_ANY);
@@ -147,6 +151,7 @@ void test_pcep_socket_comm_initialize_with_src()
 		&test_host_ip, test_port, connect_timeout_millis, NULL, false,
 		NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_EQUAL(
 		test_session->src_sock_addr.src_sock_addr_ipv4.sin_addr.s_addr,
 		test_src_ip.s_addr);
@@ -164,6 +169,7 @@ void test_pcep_socket_comm_initialize_with_src_ipv6()
 		test_connection_except_notifier, NULL, 0, &test_host_ipv6,
 		test_port, connect_timeout_millis, NULL, false, NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_EQUAL(memcmp(&test_session->src_sock_addr.src_sock_addr_ipv6
 					.sin6_addr,
 			       &in6addr_any, sizeof(struct in6_addr)),
@@ -177,6 +183,7 @@ void test_pcep_socket_comm_initialize_with_src_ipv6()
 		&test_host_ipv6, test_port, connect_timeout_millis, NULL, false,
 		NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_EQUAL(memcmp(&test_session->src_sock_addr.src_sock_addr_ipv6
 					.sin6_addr,
 			       &test_src_ipv6, sizeof(struct in6_addr)),
@@ -198,6 +205,7 @@ void test_pcep_socket_comm_initialize_tcpmd5()
 		test_connection_except_notifier, &test_host_ip, test_port, 1,
 		tcp_md5_str, true, NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_EQUAL(0, strncmp(tcp_md5_str,
 				   test_session->tcp_authentication_str,
 				   tcp_md5_strlen));
@@ -213,6 +221,7 @@ void test_pcep_socket_comm_initialize_tcpmd5()
 		test_connection_except_notifier, &test_host_ip, test_port, 1,
 		tcp_md5_str, false, NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_EQUAL(0, strncmp(tcp_md5_str,
 				   test_session->tcp_authentication_str,
 				   tcp_md5_strlen));
@@ -231,6 +240,7 @@ void test_pcep_socket_comm_initialize_ipv6_tcpmd5()
 		test_connection_except_notifier, &test_host_ipv6, test_port, 1,
 		tcp_md5_str, true, NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_EQUAL(0, strncmp(tcp_md5_str,
 				   test_session->tcp_authentication_str,
 				   tcp_md5_strlen));
@@ -246,6 +256,7 @@ void test_pcep_socket_comm_initialize_ipv6_tcpmd5()
 		test_connection_except_notifier, &test_host_ipv6, test_port, 1,
 		tcp_md5_str, false, NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_EQUAL(0, strncmp(tcp_md5_str,
 				   test_session->tcp_authentication_str,
 				   tcp_md5_strlen));
@@ -300,7 +311,9 @@ void test_pcep_socket_comm_session_destroy()
 		test_connection_except_notifier, &test_host_ip, test_port,
 		connect_timeout_millis, NULL, false, NULL);
 	CU_ASSERT_PTR_NOT_NULL(test_session);
+	assert(test_session != NULL);
 	CU_ASSERT_PTR_NOT_NULL(socket_comm_handle_);
+	assert(socket_comm_handle_ != NULL);
 	CU_ASSERT_EQUAL(socket_comm_handle_->num_active_sessions, 1);
 
 	CU_ASSERT_TRUE(socket_comm_session_teardown(test_session));

--- a/pceplib/test/pcep_utils_counters_test.c
+++ b/pceplib/test/pcep_utils_counters_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <stdlib.h>
 
 #include <CUnit/CUnit.h>
@@ -47,6 +48,7 @@ void test_create_counters_group()
 
 	group = create_counters_group(group_name, num_subgroups);
 	CU_ASSERT_PTR_NOT_NULL(group);
+	assert(group != NULL);
 
 	CU_ASSERT_EQUAL(group->num_subgroups, 0);
 	CU_ASSERT_EQUAL(group->max_subgroups, num_subgroups);
@@ -76,6 +78,7 @@ void test_create_counters_subgroup()
 	subgroup = create_counters_subgroup(subgroup_name, subgroup_id,
 					    num_counters);
 	CU_ASSERT_PTR_NOT_NULL(subgroup);
+	assert(subgroup != NULL);
 
 	CU_ASSERT_EQUAL(subgroup->subgroup_id, subgroup_id);
 	CU_ASSERT_EQUAL(subgroup->num_counters, 0);

--- a/pceplib/test/pcep_utils_double_linked_list_test.c
+++ b/pceplib/test/pcep_utils_double_linked_list_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <CUnit/CUnit.h>
 
 #include "pcep_utils_double_linked_list.h"
@@ -72,16 +73,22 @@ void test_dll_prepend_data()
 	CU_ASSERT_EQUAL(handle->num_entries, 3);
 
 	double_linked_list_node *node = handle->head;
+	CU_ASSERT_PTR_NOT_NULL(node);
+	assert(node != NULL);
 	CU_ASSERT_PTR_EQUAL(node->data, &data1);
 	CU_ASSERT_PTR_NULL(node->prev_node);
 	CU_ASSERT_PTR_NOT_NULL(node->next_node);
 
 	node = node->next_node;
+	CU_ASSERT_PTR_NOT_NULL(node);
+	assert(node != NULL);
 	CU_ASSERT_PTR_EQUAL(node->data, &data2);
 	CU_ASSERT_PTR_NOT_NULL(node->prev_node);
 	CU_ASSERT_PTR_NOT_NULL(node->next_node);
 
 	node = node->next_node;
+	CU_ASSERT_PTR_NOT_NULL(node);
+	assert(node != NULL);
 	CU_ASSERT_PTR_EQUAL(node->data, &data3);
 	CU_ASSERT_PTR_NOT_NULL(node->prev_node);
 	CU_ASSERT_PTR_NULL(node->next_node);
@@ -112,11 +119,15 @@ void test_dll_append_data()
 	CU_ASSERT_PTR_NOT_NULL(node->next_node);
 
 	node = node->next_node;
+	CU_ASSERT_PTR_NOT_NULL(node);
+	assert(node != NULL);
 	CU_ASSERT_PTR_EQUAL(node->data, &data2);
 	CU_ASSERT_PTR_NOT_NULL(node->prev_node);
 	CU_ASSERT_PTR_NOT_NULL(node->next_node);
 
 	node = node->next_node;
+	CU_ASSERT_PTR_NOT_NULL(node);
+	assert(node != NULL);
 	CU_ASSERT_PTR_EQUAL(node->data, &data3);
 	CU_ASSERT_PTR_NOT_NULL(node->prev_node);
 	CU_ASSERT_PTR_NULL(node->next_node);
@@ -278,8 +289,11 @@ void test_dll_delete_node()
 	node2 = dll_append(handle, &data2);
 	node3 = dll_append(handle, &data3);
 	CU_ASSERT_PTR_NOT_NULL(node1);
+	assert(node1 != NULL);
 	CU_ASSERT_PTR_NOT_NULL(node2);
+	assert(node2 != NULL);
 	CU_ASSERT_PTR_NOT_NULL(node3);
+	assert(node3 != NULL);
 	CU_ASSERT_EQUAL(handle->num_entries, 3);
 
 	/* Delete the middle entry */

--- a/pceplib/test/pcep_utils_ordered_list_test.c
+++ b/pceplib/test/pcep_utils_ordered_list_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <CUnit/CUnit.h>
 
 #include "pcep_utils_ordered_list.h"
@@ -55,6 +56,7 @@ void test_empty_list()
 		ordered_list_initialize(node_data_compare);
 
 	CU_ASSERT_PTR_NOT_NULL(handle);
+	assert(handle != NULL);
 	CU_ASSERT_PTR_NULL(handle->head);
 	CU_ASSERT_PTR_NOT_NULL(handle->compare_function);
 	CU_ASSERT_EQUAL(handle->num_entries, 0);
@@ -134,14 +136,17 @@ void test_find()
 
 	ordered_list_node *node = ordered_list_find(handle, &data1);
 	CU_ASSERT_PTR_NOT_NULL(node);
+	assert(node != NULL);
 	CU_ASSERT_PTR_EQUAL(node->data, &data1);
 
 	node = ordered_list_find(handle, &data2);
 	CU_ASSERT_PTR_NOT_NULL(node);
+	assert(node != NULL);
 	CU_ASSERT_PTR_EQUAL(node->data, &data2);
 
 	node = ordered_list_find(handle, &data3);
 	CU_ASSERT_PTR_NOT_NULL(node);
+	assert(node != NULL);
 	CU_ASSERT_PTR_EQUAL(node->data, &data3);
 
 	node = ordered_list_find(handle, &data_not_inList);

--- a/pceplib/test/pcep_utils_queue_test.c
+++ b/pceplib/test/pcep_utils_queue_test.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <CUnit/CUnit.h>
 
 #include "pcep_utils_queue.h"
@@ -41,6 +42,7 @@ void test_empty_queue()
 	queue_handle *handle = queue_initialize();
 
 	CU_ASSERT_PTR_NOT_NULL(handle);
+	assert(handle != NULL);
 	CU_ASSERT_PTR_NULL(handle->head);
 	CU_ASSERT_EQUAL(handle->num_entries, 0);
 


### PR DESCRIPTION
Cleaning a list of messages (basically dereference null pointer) that has raised with scan-build.

As they are unit test and those cases are not suppose to happen, asserts has been added.

Signed-off-by: Javier Garcia <javier.garcia@voltanet.io>