### PR TITLE
isisd: fix redistribution in vrf

### DIFF
--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -265,9 +265,6 @@ int main(int argc, char **argv, char **envp)
 	lsp_init();
 	mt_init();
 
-	/* create the global 'isis' instance */
-	isis_global_instance_create(VRF_DEFAULT_NAME);
-
 	isis_zebra_init(master, instance);
 	isis_bfd_init(master);
 	isis_ldp_sync_init();

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -68,7 +68,7 @@ int isis_instance_create(struct nb_cb_create_args *args)
 		return NB_OK;
 	vrf_name = yang_dnode_get_string(args->dnode, "./vrf");
 	area_tag = yang_dnode_get_string(args->dnode, "./area-tag");
-	isis_global_instance_create(vrf_name);
+
 	area = isis_area_lookup_by_vrf(area_tag, vrf_name);
 	if (area)
 		return NB_ERR_INCONSISTENCY;

--- a/isisd/isis_redist.c
+++ b/isisd/isis_redist.c
@@ -56,7 +56,7 @@ static int redist_protocol(int family)
 	return 0;
 }
 
-static afi_t afi_for_redist_protocol(int protocol)
+afi_t afi_for_redist_protocol(int protocol)
 {
 	if (protocol == 0)
 		return AFI_IP;
@@ -350,6 +350,9 @@ static void isis_redist_update_zebra_subscriptions(struct isis *isis)
 	int level;
 	int protocol;
 
+	if (isis->vrf_id == VRF_UNKNOWN)
+		return;
+
 	char do_subscribe[REDIST_PROTOCOL_COUNT][ZEBRA_ROUTE_MAX + 1];
 
 	memset(do_subscribe, 0, sizeof(do_subscribe));
@@ -378,9 +381,11 @@ static void isis_redist_update_zebra_subscriptions(struct isis *isis)
 			afi_t afi = afi_for_redist_protocol(protocol);
 
 			if (do_subscribe[protocol][type])
-				isis_zebra_redistribute_set(afi, type);
+				isis_zebra_redistribute_set(afi, type,
+							    isis->vrf_id);
 			else
-				isis_zebra_redistribute_unset(afi, type);
+				isis_zebra_redistribute_unset(afi, type,
+							      isis->vrf_id);
 		}
 }
 

--- a/isisd/isis_redist.c
+++ b/isisd/isis_redist.c
@@ -359,8 +359,9 @@ static void isis_redist_update_zebra_subscriptions(struct isis *isis)
 			for (type = 0; type < ZEBRA_ROUTE_MAX + 1; type++)
 				for (level = 0; level < ISIS_LEVELS; level++)
 					if (area->redist_settings[protocol]
-								 [type]
-								 [level].redist)
+								 [type][level]
+									 .redist
+					    == 1)
 						do_subscribe[protocol][type] =
 							1;
 

--- a/isisd/isis_redist.h
+++ b/isisd/isis_redist.h
@@ -47,6 +47,8 @@ struct prefix;
 struct prefix_ipv6;
 struct vty;
 
+afi_t afi_for_redist_protocol(int protocol);
+
 struct route_table *get_ext_reach(struct isis_area *area, int family,
 				  int level);
 void isis_redist_add(struct isis *isis, int type, struct prefix *p,

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -523,24 +523,24 @@ int isis_distribute_list_update(int routetype)
 	return 0;
 }
 
-void isis_zebra_redistribute_set(afi_t afi, int type)
+void isis_zebra_redistribute_set(afi_t afi, int type, vrf_id_t vrf_id)
 {
 	if (type == DEFAULT_ROUTE)
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_ADD,
-					     zclient, afi, VRF_DEFAULT);
+					     zclient, afi, vrf_id);
 	else
 		zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, zclient, afi, type,
-				     0, VRF_DEFAULT);
+				     0, vrf_id);
 }
 
-void isis_zebra_redistribute_unset(afi_t afi, int type)
+void isis_zebra_redistribute_unset(afi_t afi, int type, vrf_id_t vrf_id)
 {
 	if (type == DEFAULT_ROUTE)
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_DELETE,
-					     zclient, afi, VRF_DEFAULT);
+					     zclient, afi, vrf_id);
 	else
 		zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, zclient, afi,
-				     type, 0, VRF_DEFAULT);
+				     type, 0, vrf_id);
 }
 
 /**

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -724,6 +724,18 @@ void isis_zebra_vrf_register(struct isis *isis)
 	}
 }
 
+void isis_zebra_vrf_deregister(struct isis *isis)
+{
+	if (!zclient || zclient->sock < 0 || !isis)
+		return;
+
+	if (isis->vrf_id != VRF_UNKNOWN) {
+		if (IS_DEBUG_EVENTS)
+			zlog_debug("%s: Deregister VRF %s id %u", __func__,
+				   isis->name, isis->vrf_id);
+		zclient_send_dereg_requests(zclient, isis->vrf_id);
+	}
+}
 
 static void isis_zebra_connected(struct zclient *zclient)
 {

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -57,8 +57,8 @@ void isis_zebra_prefix_sid_uninstall(struct isis_area *area,
 				     struct isis_sr_psid_info *psid);
 void isis_zebra_send_adjacency_sid(int cmd, const struct sr_adjacency *sra);
 int isis_distribute_list_update(int routetype);
-void isis_zebra_redistribute_set(afi_t afi, int type);
-void isis_zebra_redistribute_unset(afi_t afi, int type);
+void isis_zebra_redistribute_set(afi_t afi, int type, vrf_id_t vrf_id);
+void isis_zebra_redistribute_unset(afi_t afi, int type, vrf_id_t vrf_id);
 int isis_zebra_rlfa_register(struct isis_spftree *spftree, struct rlfa *rlfa);
 void isis_zebra_rlfa_unregister_all(struct isis_spftree *spftree);
 bool isis_zebra_label_manager_ready(void);

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -66,5 +66,6 @@ int isis_zebra_label_manager_connect(void);
 int isis_zebra_request_label_range(uint32_t base, uint32_t chunk_size);
 int isis_zebra_release_label_range(uint32_t start, uint32_t end);
 void isis_zebra_vrf_register(struct isis *isis);
+void isis_zebra_vrf_deregister(struct isis *isis);
 
 #endif /* _ZEBRA_ISIS_ZEBRA_H */

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -614,13 +614,8 @@ static int isis_vrf_enable(struct vrf *vrf)
 				"%s: isis linked to vrf %s vrf_id %u (old id %u)",
 				__func__, vrf->name, isis->vrf_id, old_vrf_id);
 		if (old_vrf_id != isis->vrf_id) {
-			frr_with_privs (&isisd_privs) {
-				/* stop zebra redist to us for old vrf */
-				zclient_send_dereg_requests(zclient,
-							    old_vrf_id);
-				/* start zebra redist to us for new vrf */
-				isis_zebra_vrf_register(isis);
-			}
+			/* start zebra redist to us for new vrf */
+			isis_zebra_vrf_register(isis);
 		}
 	}
 
@@ -641,6 +636,8 @@ static int isis_vrf_disable(struct vrf *vrf)
 	isis = isis_lookup_by_vrfname(vrf->name);
 	if (isis) {
 		old_vrf_id = isis->vrf_id;
+
+		isis_zebra_vrf_deregister(isis);
 
 		/* We have instance configured, unlink
 		 * from VRF and make it "down".

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -175,15 +175,6 @@ void isis_master_init(struct thread_master *master)
 	im->master = master;
 }
 
-void isis_global_instance_create(const char *vrf_name)
-{
-	struct isis *isis;
-
-	isis = isis_lookup_by_vrfname(vrf_name);
-	if (isis == NULL)
-		isis_new(vrf_name);
-}
-
 struct isis *isis_new(const char *vrf_name)
 {
 	struct vrf *vrf;
@@ -571,8 +562,7 @@ void isis_area_destroy(struct isis_area *area)
 	area_mt_finish(area);
 
 	if (listcount(area->isis->area_list) == 0) {
-		memset(area->isis->sysid, 0, ISIS_SYS_ID_LEN);
-		area->isis->sysid_set = 0;
+		isis_finish(area->isis);
 	}
 
 	XFREE(MTYPE_ISIS_AREA, area);

--- a/tests/isisd/test_isis_spf.c
+++ b/tests/isisd/test_isis_spf.c
@@ -51,8 +51,6 @@ enum test_type {
 #define F_LEVEL1_ONLY 0x08
 #define F_LEVEL2_ONLY 0x10
 
-static struct isis *isis;
-
 static void test_run_spf(struct vty *vty, const struct isis_topology *topology,
 			 const struct isis_test_node *root,
 			 struct isis_area *area, struct lspdb_head *lspdb,
@@ -257,8 +255,8 @@ static int test_run(struct vty *vty, const struct isis_topology *topology,
 	uint8_t fail_id[ISIS_SYS_ID_LEN] = {};
 
 	/* Init topology. */
-	memcpy(isis->sysid, root->sysid, sizeof(isis->sysid));
 	area = isis_area_create("1", NULL);
+	memcpy(area->isis->sysid, root->sysid, sizeof(area->isis->sysid));
 	area->is_type = IS_LEVEL_1_AND_2;
 	area->srdb.enabled = true;
 	if (test_topology_load(topology, area, area->lspdb) != 0) {
@@ -470,7 +468,6 @@ static void vty_do_exit(int isexit)
 {
 	printf("\nend.\n");
 
-	isis_finish(isis);
 	cmd_terminate();
 	vty_terminate();
 	yang_terminate();
@@ -555,7 +552,6 @@ int main(int argc, char **argv)
 
 	/* IS-IS inits. */
 	yang_module_load("frr-isisd");
-	isis = isis_new(VRF_DEFAULT_NAME);
 	SET_FLAG(im->options, F_ISIS_UNIT_TEST);
 	debug_spf_events |= DEBUG_SPF_EVENTS;
 	debug_lfa |= DEBUG_LFA;

--- a/tests/topotests/isis_topo1_vrf/r1/r1_route.json
+++ b/tests/topotests/isis_topo1_vrf/r1/r1_route.json
@@ -2,7 +2,7 @@
   "10.0.10.0/24": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "active": true, 

--- a/tests/topotests/isis_topo1_vrf/r1/r1_route6.json
+++ b/tests/topotests/isis_topo1_vrf/r1/r1_route6.json
@@ -18,7 +18,7 @@
   "2001:db8:2:1::/64": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "active": true, 

--- a/tests/topotests/isis_topo1_vrf/r1/r1_topology.json
+++ b/tests/topotests/isis_topo1_vrf/r1/r1_topology.json
@@ -33,7 +33,7 @@
         },
         {
           "interface": "r1-eth0",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r3",
           "parent": "r3(4)",
           "type": "IP TE",
@@ -41,7 +41,7 @@
         },
         {
           "interface": "r1-eth0",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r3",
           "parent": "r3(4)",
           "type": "IP TE",
@@ -67,8 +67,8 @@
           "vertex": "r3"
         },
         {
+          "metric": "10",
           "interface": "r1-eth0",
-          "metric": "20",
           "next-hop": "r3",
           "parent": "r3(4)",
           "type": "IP6 internal",

--- a/tests/topotests/isis_topo1_vrf/r2/r2_route.json
+++ b/tests/topotests/isis_topo1_vrf/r2/r2_route.json
@@ -2,7 +2,7 @@
   "10.0.11.0/24": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "active": true, 

--- a/tests/topotests/isis_topo1_vrf/r2/r2_route6.json
+++ b/tests/topotests/isis_topo1_vrf/r2/r2_route6.json
@@ -18,7 +18,7 @@
   "2001:db8:2:2::/64": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "active": true, 

--- a/tests/topotests/isis_topo1_vrf/r2/r2_topology.json
+++ b/tests/topotests/isis_topo1_vrf/r2/r2_topology.json
@@ -33,7 +33,7 @@
         },
         {
           "interface": "r2-eth0",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r4",
           "parent": "r4(4)",
           "type": "IP TE",
@@ -41,7 +41,7 @@
         },
         {
           "interface": "r2-eth0",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r4",
           "parent": "r4(4)",
           "type": "IP TE",
@@ -67,8 +67,8 @@
           "vertex": "r4"
         },
         {
+          "metric": "10",
           "interface": "r2-eth0",
-          "metric": "20",
           "next-hop": "r4",
           "parent": "r4(4)",
           "type": "IP6 internal",

--- a/tests/topotests/isis_topo1_vrf/r3/r3_route.json
+++ b/tests/topotests/isis_topo1_vrf/r3/r3_route.json
@@ -2,7 +2,7 @@
   "10.0.10.0/24": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "afi": "ipv4", 
@@ -32,7 +32,7 @@
   "10.0.11.0/24": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "active": true, 
@@ -67,7 +67,7 @@
   "10.0.21.0/24": [
     {
       "distance": 115, 
-      "metric": 30, 
+      "metric": 20, 
       "nexthops": [
         {
           "active": true, 

--- a/tests/topotests/isis_topo1_vrf/r3/r3_route6.json
+++ b/tests/topotests/isis_topo1_vrf/r3/r3_route6.json
@@ -18,7 +18,7 @@
   "2001:db8:1:2::/64": [
     {
       "distance": 115, 
-      "metric": 30, 
+      "metric": 20, 
       "nexthops": [
         {
           "active": true, 
@@ -52,7 +52,7 @@
   "2001:db8:2:2::/64": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "active": true, 

--- a/tests/topotests/isis_topo1_vrf/r3/r3_topology.json
+++ b/tests/topotests/isis_topo1_vrf/r3/r3_topology.json
@@ -21,7 +21,7 @@
         },
         {
           "interface": "r3-eth1",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r5",
           "parent": "r5(4)",
           "type": "IP TE",
@@ -29,7 +29,7 @@
         },
         {
           "interface": "r3-eth1",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r5",
           "parent": "r5(4)",
           "type": "IP TE",
@@ -37,7 +37,7 @@
         },
         {
           "interface": "r3-eth1",
-          "metric": "30",
+          "metric": "20",
           "next-hop": "r5",
           "parent": "r4(4)",
           "type": "IP TE",
@@ -63,16 +63,16 @@
           "vertex": "r5"
         },
         {
+          "metric": "10",
           "interface": "r3-eth1",
-          "metric": "20",
           "next-hop": "r5",
           "parent": "r5(4)",
           "type": "IP6 internal",
           "vertex": "2001:db8:2:2::/64"
         },
         {
+          "metric": "20",
           "interface": "r3-eth1",
-          "metric": "30",
           "next-hop": "r5",
           "parent": "r4(4)",
           "type": "IP6 internal",
@@ -101,7 +101,7 @@
         },
         {
           "interface": "r3-eth0",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r3",
           "parent": "r3(4)",
           "type": "IP TE",

--- a/tests/topotests/isis_topo1_vrf/r4/r4_route.json
+++ b/tests/topotests/isis_topo1_vrf/r4/r4_route.json
@@ -1,7 +1,7 @@
 {
   "10.0.10.0/24": [
     {
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "active": true, 

--- a/tests/topotests/isis_topo1_vrf/r4/r4_route6.json
+++ b/tests/topotests/isis_topo1_vrf/r4/r4_route6.json
@@ -2,7 +2,7 @@
   "2001:db8:1:1::/64": [
     {
       "distance": 115, 
-      "metric": 30, 
+      "metric": 20, 
       "nexthops": [
         {
           "active": true, 
@@ -36,7 +36,7 @@
   "2001:db8:2:1::/64": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "active": true, 

--- a/tests/topotests/isis_topo1_vrf/r4/r4_topology.json
+++ b/tests/topotests/isis_topo1_vrf/r4/r4_topology.json
@@ -21,7 +21,7 @@
         },
         {
           "interface": "r4-eth1",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r5",
           "parent": "r5(4)",
           "type": "IP TE",
@@ -29,7 +29,7 @@
         },
         {
           "interface": "r4-eth1",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r5",
           "parent": "r5(4)",
           "type": "IP TE",
@@ -37,7 +37,7 @@
         },
         {
           "interface": "r4-eth1",
-          "metric": "30",
+          "metric": "20",
           "next-hop": "r5",
           "parent": "r3(4)",
           "type": "IP TE",
@@ -63,16 +63,16 @@
           "vertex": "r5"
         },
         {
+          "metric": "10",
           "interface": "r4-eth1",
-          "metric": "20",
           "next-hop": "r5",
           "parent": "r5(4)",
           "type": "IP6 internal",
           "vertex": "2001:db8:2:1::/64"
         },
         {
+          "metric": "20",
           "interface": "r4-eth1",
-          "metric": "30",
           "next-hop": "r5",
           "parent": "r3(4)",
           "type": "IP6 internal",
@@ -101,7 +101,7 @@
         },
         {
           "interface": "r4-eth0",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r2",
           "parent": "r2(4)",
           "type": "IP TE",

--- a/tests/topotests/isis_topo1_vrf/r5/r5_route.json
+++ b/tests/topotests/isis_topo1_vrf/r5/r5_route.json
@@ -2,7 +2,7 @@
   "10.0.10.0/24": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "afi": "ipv4", 

--- a/tests/topotests/isis_topo1_vrf/r5/r5_route6.json
+++ b/tests/topotests/isis_topo1_vrf/r5/r5_route6.json
@@ -2,7 +2,7 @@
   "2001:db8:1:1::/64": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "active": true, 
@@ -20,7 +20,7 @@
   "2001:db8:1:2::/64": [
     {
       "distance": 115, 
-      "metric": 20, 
+      "metric": 10, 
       "nexthops": [
         {
           "active": true, 

--- a/tests/topotests/isis_topo1_vrf/r5/r5_topology.json
+++ b/tests/topotests/isis_topo1_vrf/r5/r5_topology.json
@@ -35,7 +35,7 @@
         },
         {
           "interface": "r5-eth0",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r3",
           "parent": "r3(4)",
           "type": "IP TE",
@@ -43,7 +43,7 @@
         },
         {
           "interface": "r5-eth0",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r3",
           "parent": "r3(4)",
           "type": "IP TE",
@@ -51,7 +51,7 @@
         },
         {
           "interface": "r5-eth1",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r4",
           "parent": "r4(4)",
           "type": "IP TE",
@@ -59,7 +59,7 @@
         },
         {
           "interface": "r5-eth1",
-          "metric": "20",
+          "metric": "10",
           "next-hop": "r4",
           "parent": "r4(4)",
           "type": "IP TE",
@@ -99,16 +99,16 @@
           "vertex": "r4"
         },
         {
+          "metric": "10",
           "interface": "r5-eth0",
-          "metric": "20",
           "next-hop": "r3",
           "parent": "r3(4)",
           "type": "IP6 internal",
           "vertex": "2001:db8:1:1::/64"
         },
         {
+          "metric": "10",
           "interface": "r5-eth1",
-          "metric": "20",
           "next-hop": "r4",
           "parent": "r4(4)",
           "type": "IP6 internal",


### PR DESCRIPTION
When the redistribution is configured in non-default VRF, isisd should
redistribute routes from this VRF instead of default.

This is an easier implementation of https://github.com/FRRouting/frr/pull/8215.