### PR TITLE
Parse rtattr

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -312,7 +312,6 @@ static void netlink_vrf_change(struct nlmsghdr *h, struct rtattr *tb,
 
 	ifi = NLMSG_DATA(h);
 
-	memset(linkinfo, 0, sizeof(linkinfo));
 	parse_rtattr_nested(linkinfo, IFLA_INFO_MAX, tb);
 
 	if (!linkinfo[IFLA_INFO_DATA]) {
@@ -323,7 +322,6 @@ static void netlink_vrf_change(struct nlmsghdr *h, struct rtattr *tb,
 		return;
 	}
 
-	memset(attr, 0, sizeof(attr));
 	parse_rtattr_nested(attr, IFLA_VRF_MAX, linkinfo[IFLA_INFO_DATA]);
 	if (!attr[IFLA_VRF_TABLE]) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
@@ -544,7 +542,6 @@ static int netlink_extract_bridge_info(struct rtattr *link_data,
 	struct rtattr *attr[IFLA_BR_MAX + 1];
 
 	memset(bridge_info, 0, sizeof(*bridge_info));
-	memset(attr, 0, sizeof(attr));
 	parse_rtattr_nested(attr, IFLA_BR_MAX, link_data);
 	if (attr[IFLA_BR_VLAN_FILTERING])
 		bridge_info->vlan_aware =
@@ -559,7 +556,6 @@ static int netlink_extract_vlan_info(struct rtattr *link_data,
 	vlanid_t vid_in_msg;
 
 	memset(vlan_info, 0, sizeof(*vlan_info));
-	memset(attr, 0, sizeof(attr));
 	parse_rtattr_nested(attr, IFLA_VLAN_MAX, link_data);
 	if (!attr[IFLA_VLAN_ID]) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
@@ -579,7 +575,7 @@ static int netlink_extract_gre_info(struct rtattr *link_data,
 
 	memset(gre_info, 0, sizeof(*gre_info));
 	memset(attr, 0, sizeof(attr));
-	parse_rtattr_nested(attr, IFLA_GRE_MAX, link_data);
+	netlink_parse_rtattr_nested(attr, IFLA_GRE_MAX, link_data);
 
 	if (!attr[IFLA_GRE_LOCAL]) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
@@ -622,7 +618,6 @@ static int netlink_extract_vxlan_info(struct rtattr *link_data,
 	ifindex_t ifindex_link;
 
 	memset(vxl_info, 0, sizeof(*vxl_info));
-	memset(attr, 0, sizeof(attr));
 	parse_rtattr_nested(attr, IFLA_VXLAN_MAX, link_data);
 	if (!attr[IFLA_VXLAN_ID]) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
@@ -716,7 +711,6 @@ static int netlink_bridge_vxlan_update(struct interface *ifp,
 	/* There is a 1-to-1 mapping of VLAN to VxLAN - hence
 	 * only 1 access VLAN is accepted.
 	 */
-	memset(aftb, 0, sizeof(aftb));
 	parse_rtattr_nested(aftb, IFLA_BRIDGE_MAX, af_spec);
 	if (!aftb[IFLA_BRIDGE_VLAN_INFO])
 		return 0;
@@ -786,7 +780,6 @@ static int netlink_bridge_interface(struct nlmsghdr *h, int len, ns_id_t ns_id,
 
 	/* Fetch name and ifindex */
 	ifi = NLMSG_DATA(h);
-	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), len);
 
 	if (tb[IFLA_IFNAME] == NULL)
@@ -854,7 +847,6 @@ static uint8_t netlink_parse_lacp_bypass(struct rtattr **linkinfo)
 	uint8_t bypass = 0;
 	struct rtattr *mbrinfo[IFLA_BOND_SLAVE_MAX + 1];
 
-	memset(mbrinfo, 0, sizeof(mbrinfo));
 	parse_rtattr_nested(mbrinfo, IFLA_BOND_SLAVE_MAX,
 			    linkinfo[IFLA_INFO_SLAVE_DATA]);
 	if (mbrinfo[IFLA_BOND_SLAVE_AD_RX_BYPASS])
@@ -910,7 +902,6 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return netlink_bridge_interface(h, len, ns_id, startup);
 
 	/* Looking up interface name. */
-	memset(tb, 0, sizeof(tb));
 	memset(linkinfo, 0, sizeof(linkinfo));
 	netlink_parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), len);
 
@@ -1303,7 +1294,6 @@ int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return -1;
 	}
 
-	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, IFA_MAX, IFA_RTA(ifa), len);
 
 	ifp = if_lookup_by_index_per_ns(zns, ifa->ifa_index);
@@ -1519,7 +1509,6 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return netlink_bridge_interface(h, len, ns_id, startup);
 
 	/* Looking up interface name. */
-	memset(tb, 0, sizeof(tb));
 	memset(linkinfo, 0, sizeof(linkinfo));
 	netlink_parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), len);
 

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -493,6 +493,7 @@ void netlink_parse_rtattr_flags(struct rtattr **tb, int max,
 {
 	unsigned short type;
 
+	memset(tb, 0, sizeof(struct rtattr *) * (max + 1));
 	while (RTA_OK(rta, len)) {
 		type = rta->rta_type & ~flags;
 		if ((type <= max) && (!tb[type]))
@@ -504,6 +505,7 @@ void netlink_parse_rtattr_flags(struct rtattr **tb, int max,
 void netlink_parse_rtattr(struct rtattr **tb, int max, struct rtattr *rta,
 			  int len)
 {
+	memset(tb, 0, sizeof(struct rtattr *) * (max + 1));
 	while (RTA_OK(rta, len)) {
 		if (rta->rta_type <= max)
 			tb[rta->rta_type] = rta;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -509,8 +509,6 @@ static uint8_t parse_multipath_nexthops_unicast(ns_id_t ns_id,
 			nh_vrf_id = vrf_id;
 
 		if (rtnh->rtnh_len > sizeof(*rtnh)) {
-			memset(rtnh_tb, 0, sizeof(rtnh_tb));
-
 			netlink_parse_rtattr(rtnh_tb, RTA_MAX, RTNH_DATA(rtnh),
 					     rtnh->rtnh_len - sizeof(*rtnh));
 			if (rtnh_tb[RTA_GATEWAY])
@@ -628,7 +626,6 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 		return -1;
 	}
 
-	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, RTA_MAX, RTM_RTA(rtm), len);
 
 	if (rtm->rtm_flags & RTM_F_CLONED)
@@ -713,7 +710,6 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 	if (tb[RTA_METRICS]) {
 		struct rtattr *mxrta[RTAX_MAX + 1];
 
-		memset(mxrta, 0, sizeof(mxrta));
 		netlink_parse_rtattr(mxrta, RTAX_MAX, RTA_DATA(tb[RTA_METRICS]),
 				     RTA_PAYLOAD(tb[RTA_METRICS]));
 
@@ -920,7 +916,6 @@ static int netlink_route_change_read_multicast(struct nlmsghdr *h,
 
 	len = h->nlmsg_len - NLMSG_LENGTH(sizeof(struct rtmsg));
 
-	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, RTA_MAX, RTM_RTA(rtm), len);
 
 	if (tb[RTA_TABLE])
@@ -2875,7 +2870,6 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	/* Parse attributes and extract fields of interest. Do basic
 	 * validation of the fields.
 	 */
-	memset(tb, 0, sizeof tb);
 	netlink_parse_rtattr_flags(tb, NDA_MAX, NDA_RTA(ndm), len,
 				   NLA_F_NESTED);
 
@@ -3348,7 +3342,6 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	zif = (struct zebra_if *)ifp->info;
 
 	/* Parse attributes and extract fields of interest. */
-	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, NDA_MAX, NDA_RTA(ndm), len);
 
 	if (!tb[NDA_DST]) {


### PR DESCRIPTION
Cleanup usage of the parse_rtattr code in zebra.

a) in some places we memset tb before and in some places we don't.  This is a crash waiting to happen.  Move memset to inside function to ensure it always happens

b) if_netlink.c had a duplicate function that was a define.  consolidate down to 1.