### PR TITLE
Pimd timer fixes

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7276,7 +7276,8 @@ DEFUN (no_ip_pim_rp_keep_alive,
 	char rp_ka_timer[5];
 	char rp_ka_timer_xpath[XPATH_MAXLEN];
 
-	snprintf(rp_ka_timer, sizeof(rp_ka_timer), "%d", PIM_KEEPALIVE_PERIOD);
+	snprintf(rp_ka_timer, sizeof(rp_ka_timer), "%d",
+				PIM_RP_KEEPALIVE_PERIOD);
 
 	if (vty->xpath_index) {
 		vrf_dnode =
@@ -11412,9 +11413,7 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &ip_pim_ssm_prefix_list_cmd);
 	install_element(VRF_NODE, &ip_pim_ssm_prefix_list_cmd);
 	install_element(CONFIG_NODE, &ip_pim_register_suppress_cmd);
-	install_element(VRF_NODE, &ip_pim_register_suppress_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_register_suppress_cmd);
-	install_element(VRF_NODE, &no_ip_pim_register_suppress_cmd);
 	install_element(CONFIG_NODE, &ip_pim_spt_switchover_infinity_cmd);
 	install_element(VRF_NODE, &ip_pim_spt_switchover_infinity_cmd);
 	install_element(CONFIG_NODE, &ip_pim_spt_switchover_infinity_plist_cmd);
@@ -11427,9 +11426,7 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &pim_register_accept_list_cmd);
 	install_element(VRF_NODE, &pim_register_accept_list_cmd);
 	install_element(CONFIG_NODE, &ip_pim_joinprune_time_cmd);
-	install_element(VRF_NODE, &ip_pim_joinprune_time_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_joinprune_time_cmd);
-	install_element(VRF_NODE, &no_ip_pim_joinprune_time_cmd);
 	install_element(CONFIG_NODE, &ip_pim_keep_alive_cmd);
 	install_element(VRF_NODE, &ip_pim_keep_alive_cmd);
 	install_element(CONFIG_NODE, &ip_pim_rp_keep_alive_cmd);
@@ -11439,9 +11436,7 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_ip_pim_rp_keep_alive_cmd);
 	install_element(VRF_NODE, &no_ip_pim_rp_keep_alive_cmd);
 	install_element(CONFIG_NODE, &ip_pim_packets_cmd);
-	install_element(VRF_NODE, &ip_pim_packets_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_packets_cmd);
-	install_element(VRF_NODE, &no_ip_pim_packets_cmd);
 	install_element(CONFIG_NODE, &ip_pim_v6_secondary_cmd);
 	install_element(VRF_NODE, &ip_pim_v6_secondary_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_v6_secondary_cmd);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -763,8 +763,8 @@ int pim_register_suppress_time_modify(struct nb_cb_modify_args *args)
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		router->register_suppress_time =
-			yang_dnode_get_uint16(args->dnode, NULL);
+		pim_update_suppress_timers(
+			yang_dnode_get_uint16(args->dnode, NULL));
 		break;
 	}
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -407,6 +407,28 @@ static void pim_upstream_join_timer_restart_msec(struct pim_upstream *up,
 			      &up->t_join_timer);
 }
 
+void pim_update_suppress_timers(uint32_t suppress_time)
+{
+	struct pim_instance *pim;
+	struct vrf *vrf;
+	unsigned int old_rp_ka_time;
+
+	/* stash the old one so we know which values were manually configured */
+	old_rp_ka_time =  (3 * router->register_suppress_time
+			   + router->register_probe_time);
+	router->register_suppress_time = suppress_time;
+
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		pim = vrf->info;
+		if (!pim)
+			continue;
+
+		/* Only adjust if not manually configured */
+		if (pim->rp_keep_alive_time == old_rp_ka_time)
+			pim->rp_keep_alive_time = PIM_RP_KEEPALIVE_PERIOD;
+	}
+}
+
 void pim_upstream_join_suppress(struct pim_upstream *up,
 				struct in_addr rpf_addr, int holdtime)
 {

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -317,6 +317,7 @@ int pim_upstream_eval_inherit_if(struct pim_upstream *up,
 void pim_upstream_update_join_desired(struct pim_instance *pim,
 				      struct pim_upstream *up);
 
+void pim_update_suppress_timers(uint32_t suppress_time);
 void pim_upstream_join_suppress(struct pim_upstream *up,
 				struct in_addr rpf_addr, int holdtime);
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -185,16 +185,24 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 
 	writes += pim_rp_config_write(pim, vty, spaces);
 
-	if (router->register_suppress_time
-	    != PIM_REGISTER_SUPPRESSION_TIME_DEFAULT) {
-		vty_out(vty, "%sip pim register-suppress-time %d\n", spaces,
-			router->register_suppress_time);
-		++writes;
-	}
-	if (router->t_periodic != PIM_DEFAULT_T_PERIODIC) {
-		vty_out(vty, "%sip pim join-prune-interval %d\n", spaces,
-			router->t_periodic);
-		++writes;
+	if (pim->vrf_id == VRF_DEFAULT) {
+		if (router->register_suppress_time
+		    != PIM_REGISTER_SUPPRESSION_TIME_DEFAULT) {
+			vty_out(vty, "%sip pim register-suppress-time %d\n",
+					spaces, router->register_suppress_time);
+			++writes;
+		}
+		if (router->t_periodic != PIM_DEFAULT_T_PERIODIC) {
+			vty_out(vty, "%sip pim join-prune-interval %d\n",
+				spaces, router->t_periodic);
+			++writes;
+		}
+
+		if (router->packet_process != PIM_DEFAULT_PACKET_PROCESS) {
+			vty_out(vty, "%sip pim packets %d\n", spaces,
+				router->packet_process);
+			++writes;
+		}
 	}
 	if (pim->keep_alive_time != PIM_KEEPALIVE_PERIOD) {
 		vty_out(vty, "%sip pim keep-alive-timer %d\n", spaces,
@@ -204,11 +212,6 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 	if (pim->rp_keep_alive_time != (unsigned int)PIM_RP_KEEPALIVE_PERIOD) {
 		vty_out(vty, "%sip pim rp keep-alive-timer %d\n", spaces,
 			pim->rp_keep_alive_time);
-		++writes;
-	}
-	if (router->packet_process != PIM_DEFAULT_PACKET_PROCESS) {
-		vty_out(vty, "%sip pim packets %d\n", spaces,
-			router->packet_process);
 		++writes;
 	}
 	if (ssm->plist_name) {


### PR DESCRIPTION
Includes a couple of commits to resolve issues with displaying or reacting to particular pimd commands.  It was noted that when vrfs are in use, several commands that were only global in scope would display in every vrf (pim packets, pim join-prune-interval, etc.)  Moved these to only display in the global since that's where they reside.  Additionally while testing found that when the register-suppress-time was modified, the rp_keepalive_time was not adjusted accordingly (even though the rp_keepalive_time is derived from the register-suppress-time.)  Also found a bug that when "no ip pim rp keep-alive-timer" was issued, reset back to "PIM_KEEPALIVE_PERIOD" instead of "PIM_RP_KEEPALIVE_PERIOD" as intended.