### PR TITLE
lib: ip prefix-list "le" and "ge" bug squish

### DIFF
--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -1360,14 +1360,31 @@ DEFPY_YANG(
 		nb_cli_enqueue_change(vty, "./ipv4-prefix", NB_OP_MODIFY,
 				      prefix_str);
 
-		if (ge_str)
+		if (ge_str) {
 			nb_cli_enqueue_change(
 				vty, "./ipv4-prefix-length-greater-or-equal",
 				NB_OP_MODIFY, ge_str);
-		if (le_str)
+		} else {
+			/*
+			 * Remove old ge if not being modified
+			 */
+			nb_cli_enqueue_change(
+				vty, "./ipv4-prefix-length-greater-or-equal",
+				NB_OP_DESTROY, NULL);
+		}
+
+		if (le_str) {
 			nb_cli_enqueue_change(
 				vty, "./ipv4-prefix-length-lesser-or-equal",
 				NB_OP_MODIFY, le_str);
+		} else {
+			/*
+			 * Remove old le if not being modified
+			 */
+			nb_cli_enqueue_change(
+				vty, "./ipv4-prefix-length-lesser-or-equal",
+				NB_OP_DESTROY, NULL);
+		}
 	} else {
 		nb_cli_enqueue_change(vty, "./any", NB_OP_CREATE, NULL);
 	}
@@ -1561,14 +1578,31 @@ DEFPY_YANG(
 		nb_cli_enqueue_change(vty, "./ipv6-prefix", NB_OP_MODIFY,
 				      prefix_str);
 
-		if (ge_str)
+		if (ge_str) {
 			nb_cli_enqueue_change(
 				vty, "./ipv6-prefix-length-greater-or-equal",
 				NB_OP_MODIFY, ge_str);
-		if (le_str)
+		} else {
+			/*
+			 * Remove old ge if not being modified
+			 */
+			nb_cli_enqueue_change(
+				vty, "./ipv6-prefix-length-greater-or-equal",
+				NB_OP_DESTROY, NULL);
+		}
+
+		if (le_str) {
 			nb_cli_enqueue_change(
 				vty, "./ipv6-prefix-length-lesser-or-equal",
 				NB_OP_MODIFY, le_str);
+		} else {
+			/*
+			 * Remove old le if not being modified
+			 */
+			nb_cli_enqueue_change(
+				vty, "./ipv6-prefix-length-lesser-or-equal",
+				NB_OP_DESTROY, NULL);
+		}
 	} else {
 		nb_cli_enqueue_change(vty, "./any", NB_OP_CREATE, NULL);
 	}

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -423,17 +423,6 @@ class Config(object):
                     re_lege.group(2),
                     re_lege.group(4),
                 )
-            re_lege = re.search(r"(.*)ge\s+(\d+)\s+le\s+(\d+)(.*)", legestr)
-
-            if re_lege and (
-                (re_key_rt.group(1) == "ip" and re_lege.group(3) == "32")
-                or (re_key_rt.group(1) == "ipv6" and re_lege.group(3) == "128")
-            ):
-                legestr = "%sge %s%s" % (
-                    re_lege.group(1),
-                    re_lege.group(2),
-                    re_lege.group(4),
-                )
 
             key[0] = "%s prefix-list%s%s %s%s" % (
                 re_key_rt.group(1),


### PR DESCRIPTION
1. When specifying prefix-list with "ge", any "le 32" (for v4) and "le 128" (for v6) instructions are essentially NOP so ignore them.
2. When specifying only an "le" for an existing ip prefix-list qualified with both an "le" and "ge" make sure to remove the "ge" property so it does not stay in the tree.

(1) was previously implemented in frr-reload and I figured its logic is better suited for the daemon itself. This settles a discrepency between what reload was producing and what FRR accepted for the same input.

The below commands are functionally the same so FRR now strips the "le 32" for v4 and "le 128" for v6 as if you never said it at all:

```
ip prefix-list test seq 1 permit 1.1.0.0/16 ge 18 le 32
ip prefix-list test seq 1 permit 1.1.0.0/16 ge 18
```

(2) Fix a bug in "ge" and "le" handline affecting modification of existing prefix list. When specifying only an "le" for an existing ip prefix-list qualified with both an "le" and "ge" make sure to remove the "ge" property so it does not stay in the tree.

E.g. Saying these two things in order:

```
ip prefix-list test seq 1 permit 1.1.0.0/16 ge 18 le 24
ip prefix-list test seq 1 permit 1.1.0.0/16 ge 18
```
    
.. should result in the second statement "overwriting" the first like this:

```
vxdev-arch# do show ip prefix-list
ZEBRA: ip prefix-list foobar: 3 entries
   seq 1 permit 15.0.0.0/16 ge 18
```

Previously this did not happen and "le 24" would stick around since it was never given `NB_OP_DESTROY` and purged from the data tree.