### PR TITLE
ospf redistribution fixes

### DIFF
--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -773,45 +773,36 @@ int ospf_is_type_redistributed(struct ospf *ospf, int type,
 					  ospf->vrf_id))));
 }
 
-int ospf_redistribute_set(struct ospf *ospf, int type, unsigned short instance,
-			  int mtype, int mvalue)
+int ospf_redistribute_update(struct ospf *ospf, struct ospf_redist *red,
+			     int type, unsigned short instance, int mtype,
+			     int mvalue)
 {
 	int force = 0;
-	struct ospf_redist *red;
 
-	red = ospf_redist_lookup(ospf, type, instance);
-
-	if (red == NULL) {
-		zlog_err(
-			 "Redistribute[%s][%d]: Lookup failed  Type[%d] , Metric[%d]",
-			 ospf_redist_string(type), instance,
-			 metric_type(ospf, type, instance),
-			 metric_value(ospf, type, instance));
-		return CMD_WARNING_CONFIG_FAILED;
+	if (mtype != red->dmetric.type) {
+		red->dmetric.type = mtype;
+		force = LSA_REFRESH_FORCE;
+	}
+	if (mvalue != red->dmetric.value) {
+		red->dmetric.value = mvalue;
+		force = LSA_REFRESH_FORCE;
 	}
 
-	if (ospf_is_type_redistributed(ospf, type, instance)) {
-		if (mtype != red->dmetric.type) {
-			red->dmetric.type = mtype;
-			force = LSA_REFRESH_FORCE;
-		}
-		if (mvalue != red->dmetric.value) {
-			red->dmetric.value = mvalue;
-			force = LSA_REFRESH_FORCE;
-		}
+	ospf_external_lsa_refresh_type(ospf, type, instance, force);
 
-		ospf_external_lsa_refresh_type(ospf, type, instance, force);
+	if (IS_DEBUG_OSPF(zebra, ZEBRA_REDISTRIBUTE))
+		zlog_debug(
+			"Redistribute[%s][%d]: Refresh  Type[%d], Metric[%d]",
+			ospf_redist_string(type), instance,
+			metric_type(ospf, type, instance),
+			metric_value(ospf, type, instance));
 
-		if (IS_DEBUG_OSPF(zebra, ZEBRA_REDISTRIBUTE))
-			zlog_debug(
-				"Redistribute[%s][%d]: Refresh  Type[%d], Metric[%d]",
-				ospf_redist_string(type), instance,
-				metric_type(ospf, type, instance),
-				metric_value(ospf, type, instance));
+	return CMD_SUCCESS;
+}
 
-		return CMD_SUCCESS;
-	}
-
+int ospf_redistribute_set(struct ospf *ospf, struct ospf_redist *red, int type,
+			  unsigned short instance, int mtype, int mvalue)
+{
 	red->dmetric.type = mtype;
 	red->dmetric.value = mvalue;
 
@@ -836,9 +827,6 @@ int ospf_redistribute_unset(struct ospf *ospf, int type,
 			    unsigned short instance)
 {
 	if (type == zclient->redist_default && instance == zclient->instance)
-		return CMD_SUCCESS;
-
-	if (!ospf_is_type_redistributed(ospf, type, instance))
 		return CMD_SUCCESS;
 
 	zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, zclient, AFI_IP, type,

--- a/ospfd/ospf_zebra.h
+++ b/ospfd/ospf_zebra.h
@@ -78,10 +78,12 @@ extern struct ospf_redist *ospf_redist_add(struct ospf *, uint8_t,
 					   unsigned short);
 extern void ospf_redist_del(struct ospf *, uint8_t, unsigned short);
 
-extern int ospf_redistribute_set(struct ospf *, int, unsigned short, int, int);
+extern int ospf_redistribute_update(struct ospf *, struct ospf_redist *, int,
+				    unsigned short, int, int);
+extern int ospf_redistribute_set(struct ospf *, struct ospf_redist *, int,
+				 unsigned short, int, int);
 extern int ospf_redistribute_unset(struct ospf *, int, unsigned short);
 extern int ospf_redistribute_default_set(struct ospf *, int, int, int);
-extern int ospf_redistribute_default_unset(struct ospf *);
 extern int ospf_distribute_list_out_set(struct ospf *, int, const char *);
 extern int ospf_distribute_list_out_unset(struct ospf *, int, const char *);
 extern void ospf_routemap_set(struct ospf_redist *, const char *);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -2158,7 +2158,7 @@ static int ospf_vrf_delete(struct vrf *vrf)
 	return 0;
 }
 
-static void ospf_set_redist_vrf_bitmaps(struct ospf *ospf)
+static void ospf_set_redist_vrf_bitmaps(struct ospf *ospf, bool set)
 {
 	int type;
 	struct list *red_list;
@@ -2171,7 +2171,12 @@ static void ospf_set_redist_vrf_bitmaps(struct ospf *ospf)
 			zlog_debug(
 				"%s: setting redist vrf %d bitmap for type %d",
 				__func__, ospf->vrf_id, type);
-		vrf_bitmap_set(zclient->redist[AFI_IP][type], ospf->vrf_id);
+		if (set)
+			vrf_bitmap_set(zclient->redist[AFI_IP][type],
+				       ospf->vrf_id);
+		else
+			vrf_bitmap_unset(zclient->redist[AFI_IP][type],
+					 ospf->vrf_id);
 	}
 }
 
@@ -2201,18 +2206,12 @@ static int ospf_vrf_enable(struct vrf *vrf)
 				__func__, vrf->name, ospf->vrf_id, old_vrf_id);
 
 		if (old_vrf_id != ospf->vrf_id) {
-			frr_with_privs(&ospfd_privs) {
-				/* stop zebra redist to us for old vrf */
-				zclient_send_dereg_requests(zclient,
-							    old_vrf_id);
+			ospf_set_redist_vrf_bitmaps(ospf, true);
 
-				ospf_set_redist_vrf_bitmaps(ospf);
+			/* start zebra redist to us for new vrf */
+			ospf_zebra_vrf_register(ospf);
 
-				/* start zebra redist to us for new vrf */
-				ospf_zebra_vrf_register(ospf);
-
-				ret = ospf_sock_init(ospf);
-			}
+			ret = ospf_sock_init(ospf);
 			if (ret < 0 || ospf->fd <= 0)
 				return 0;
 			thread_add_read(master, ospf_read, ospf, ospf->fd,
@@ -2241,6 +2240,10 @@ static int ospf_vrf_disable(struct vrf *vrf)
 	ospf = ospf_lookup_by_name(vrf->name);
 	if (ospf) {
 		old_vrf_id = ospf->vrf_id;
+
+		ospf_zebra_vrf_deregister(ospf);
+
+		ospf_set_redist_vrf_bitmaps(ospf, false);
 
 		/* We have instance configured, unlink
 		 * from VRF and make it "down".


### PR DESCRIPTION
```
ospfd: deregister vrf from zebra when vrf is disabled

Currently the VRF is deregistered only when it is re-enabled again.
```
```
ospfd: fix redistribution config when vrf doesn't exist

Currently ospfd relies on vrf bitmaps in zclient to check that the
redistribution is configured. This doesn't work when the VRF for OSPF
instance doesn't exist yet, because vrf bitmaps ignore VRF_UNKNOWN id.

Because of this, the following problems occur when the VRF doesn't exist:
- repeated "redistribute smth" command is processed as a first-time
  instead of an update
- "no redistribute smth" doesn't work at all

This commit fixes both issues by relying on internal redistribution
config instead of zclient vrf bitmaps.
```