### PR TITLE
tests: fix intermittent key error in bgp-auth topotest

### DIFF
--- a/tests/topotests/bgp-auth/test_bgp_auth.py
+++ b/tests/topotests/bgp-auth/test_bgp_auth.py
@@ -357,9 +357,10 @@ def check_neigh_state(router, peer, state, vrf=""):
                 "show bgp vrf {} neighbors {} json".format(vrf, peer)
             )
         neigh_output_json = json.loads(neigh_output)
-        if neigh_output_json[peer]["bgpState"] == state:
-            matched = True
-            break
+        if peer in neigh_output_json.keys():
+            if neigh_output_json[peer]["bgpState"] == state:
+                matched = True
+                break
         count += 1
         sleep(1)
 


### PR DESCRIPTION
There is a rare case where with prefix peers the peer is
completely absent from the json output when checking the
peer state resulting in a python key error. Check key exists
before checking the state.

Signed-off-by: Pat Ruddy <pat@voltanet.io>