### PR TITLE
zebra: evpn check vni oper state in svi up/down event

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4530,7 +4530,8 @@ int zebra_vxlan_svi_down(struct interface *ifp, struct interface *link_if)
 			zevpn->vrf_id = VRF_DEFAULT;
 
 			/* update the tenant vrf in BGP */
-			zebra_evpn_send_add_to_client(zevpn);
+			if (if_is_operative(zevpn->vxlan_if))
+				zebra_evpn_send_add_to_client(zevpn);
 		}
 	}
 	return 0;
@@ -4582,7 +4583,9 @@ int zebra_vxlan_svi_up(struct interface *ifp, struct interface *link_if)
 
 		/* update the vrf information for l2-vni and inform bgp */
 		zevpn->vrf_id = ifp->vrf_id;
-		zebra_evpn_send_add_to_client(zevpn);
+
+		if (if_is_operative(zevpn->vxlan_if))
+			zebra_evpn_send_add_to_client(zevpn);
 
 		/* Install any remote neighbors for this VNI. */
 		memset(&n_wctx, 0, sizeof(struct neigh_walk_ctx));


### PR DESCRIPTION
When clagd is stopped on secondary device, all vxlan interfaces (vnis) are kept in protodown state.
FRR treats protodown vxlan interfaces (vnis) as interface down and sends vni delete to bgpd.

In the event of clagd down, SVIs are flapping as underlying
bridge is going through churn.
When FRR receives SVI up notification do not trigger vni up event to bgpd, if vnis are operationally down.

Testing Done:
Performed CLAG stop/start on secondary device, all vxlan devices remained in protodown along with
this validated the vnis are cleaned up and added back in bgpd.

Signed-off-by: Chirag Shah <chirag@nvidia.com>