### PR TITLE
bgpd: EVPN D-VNI L3 RT Config Enhancements

### DIFF
--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -194,6 +194,17 @@ struct evpn_remote_ip {
 	struct list *macip_path_list;
 };
 
+/*
+ * Wrapper struct for l3 RT's
+ */
+struct vrf_route_target {
+	/* flags based on config to determine how RTs are handled */
+	uint8_t flags;
+#define BGP_VRF_RT_AUTO (1 << 0)
+
+	struct ecommunity *ecom;
+};
+
 static inline int is_vrf_rd_configured(struct bgp *bgp_vrf)
 {
 	return (CHECK_FLAG(bgp_vrf->vrf_flags, BGP_VRF_RD_CFGD));
@@ -590,7 +601,8 @@ extern struct zclient *zclient;
 extern void bgp_evpn_install_uninstall_default_route(struct bgp *bgp_vrf,
 						     afi_t afi, safi_t safi,
 						     bool add);
-extern void evpn_rt_delete_auto(struct bgp *, vni_t, struct list *);
+extern void evpn_rt_delete_auto(struct bgp *bgp, vni_t vni, struct list *rtl,
+				bool is_l3);
 extern void bgp_evpn_configure_export_rt_for_vrf(struct bgp *bgp_vrf,
 						 struct ecommunity *ecomadd);
 extern void bgp_evpn_unconfigure_export_rt_for_vrf(struct bgp *bgp_vrf,

--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -201,6 +201,7 @@ struct vrf_route_target {
 	/* flags based on config to determine how RTs are handled */
 	uint8_t flags;
 #define BGP_VRF_RT_AUTO (1 << 0)
+#define BGP_VRF_RT_WILD (1 << 1)
 
 	struct ecommunity *ecom;
 };
@@ -605,12 +606,17 @@ extern void evpn_rt_delete_auto(struct bgp *bgp, vni_t vni, struct list *rtl,
 				bool is_l3);
 extern void bgp_evpn_configure_export_rt_for_vrf(struct bgp *bgp_vrf,
 						 struct ecommunity *ecomadd);
+extern void bgp_evpn_configure_export_auto_rt_for_vrf(struct bgp *bgp_vrf);
 extern void bgp_evpn_unconfigure_export_rt_for_vrf(struct bgp *bgp_vrf,
 						   struct ecommunity *ecomdel);
+extern void bgp_evpn_unconfigure_export_auto_rt_for_vrf(struct bgp *bgp_vrf);
 extern void bgp_evpn_configure_import_rt_for_vrf(struct bgp *bgp_vrf,
-						 struct ecommunity *ecomadd);
+						 struct ecommunity *ecomadd,
+						 bool is_wildcard);
+extern void bgp_evpn_configure_import_auto_rt_for_vrf(struct bgp *bgp_vrf);
 extern void bgp_evpn_unconfigure_import_rt_for_vrf(struct bgp *bgp_vrf,
 						   struct ecommunity *ecomdel);
+extern void bgp_evpn_unconfigure_import_auto_rt_for_vrf(struct bgp *bgp_vrf);
 extern int bgp_evpn_handle_export_rt_change(struct bgp *bgp,
 					    struct bgpevpn *vpn);
 extern void bgp_evpn_handle_autort_change(struct bgp *bgp);

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -6014,9 +6014,9 @@ DEFUN (bgp_evpn_vrf_rt,
 	return ret;
 }
 
-DEFUN (bgp_evpn_vrf_rt_auto,
+DEFPY (bgp_evpn_vrf_rt_auto,
        bgp_evpn_vrf_rt_auto_cmd,
-       "route-target <both|import|export> auto",
+       "route-target <both|import|export>$type auto",
        "Route Target\n"
        "import and export\n"
        "import\n"
@@ -6029,11 +6029,11 @@ DEFUN (bgp_evpn_vrf_rt_auto,
 	if (!bgp)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	if (!strcmp(argv[1]->arg, "import"))
+	if (strmatch(type, "import"))
 		rt_type = RT_TYPE_IMPORT;
-	else if (!strcmp(argv[1]->arg, "export"))
+	else if (strmatch(type, "export"))
 		rt_type = RT_TYPE_EXPORT;
-	else if (!strcmp(argv[1]->arg, "both"))
+	else if (strmatch(type, "both"))
 		rt_type = RT_TYPE_BOTH;
 	else {
 		vty_out(vty, "%% Invalid Route Target type\n");
@@ -6119,9 +6119,9 @@ DEFUN (no_bgp_evpn_vrf_rt,
 	return ret;
 }
 
-DEFUN (no_bgp_evpn_vrf_rt_auto,
+DEFPY (no_bgp_evpn_vrf_rt_auto,
        no_bgp_evpn_vrf_rt_auto_cmd,
-       "no route-target <both|import|export> auto",
+       "no route-target <both|import|export>$type auto",
        NO_STR
        "Route Target\n"
        "import and export\n"
@@ -6135,11 +6135,11 @@ DEFUN (no_bgp_evpn_vrf_rt_auto,
 	if (!bgp)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	if (!strcmp(argv[2]->arg, "import"))
+	if (strmatch(type, "import"))
 		rt_type = RT_TYPE_IMPORT;
-	else if (!strcmp(argv[2]->arg, "export"))
+	else if (strmatch(type, "export"))
 		rt_type = RT_TYPE_EXPORT;
-	else if (!strcmp(argv[2]->arg, "both"))
+	else if (strmatch(type, "both"))
 		rt_type = RT_TYPE_BOTH;
 	else {
 		vty_out(vty, "%% Invalid Route Target type\n");

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -373,7 +373,7 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 	char buf1[INET6_ADDRSTRLEN];
 	char *ecom_str;
 	struct listnode *node, *nnode;
-	struct ecommunity *ecom;
+	struct vrf_route_target *l3rt;
 	json_object *json_import_rtl = NULL;
 	json_object *json_export_rtl = NULL;
 	char buf2[ETHER_ADDR_STRLEN];
@@ -434,8 +434,8 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 	if (!json)
 		vty_out(vty, "  Import Route Target:\n");
 
-	for (ALL_LIST_ELEMENTS(bgp_vrf->vrf_import_rtl, node, nnode, ecom)) {
-		ecom_str = ecommunity_ecom2str(ecom,
+	for (ALL_LIST_ELEMENTS(bgp_vrf->vrf_import_rtl, node, nnode, l3rt)) {
+		ecom_str = ecommunity_ecom2str(l3rt->ecom,
 					       ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 
 		if (json)
@@ -452,8 +452,8 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 	else
 		vty_out(vty, "  Export Route Target:\n");
 
-	for (ALL_LIST_ELEMENTS(bgp_vrf->vrf_export_rtl, node, nnode, ecom)) {
-		ecom_str = ecommunity_ecom2str(ecom,
+	for (ALL_LIST_ELEMENTS(bgp_vrf->vrf_export_rtl, node, nnode, l3rt)) {
+		ecom_str = ecommunity_ecom2str(l3rt->ecom,
 					       ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 
 		if (json)
@@ -928,7 +928,7 @@ static void show_l3vni_entry(struct vty *vty, struct bgp *bgp,
 	char rt_buf[25];
 	char *ecom_str;
 	struct listnode *node, *nnode;
-	struct ecommunity *ecom;
+	struct vrf_route_target *l3rt;
 
 	if (!bgp->l3vni)
 		return;
@@ -971,8 +971,8 @@ static void show_l3vni_entry(struct vty *vty, struct bgp *bgp,
 			prefix_rd2str(&bgp->vrf_prd, buf2, RD_ADDRSTRLEN));
 	}
 
-	for (ALL_LIST_ELEMENTS(bgp->vrf_import_rtl, node, nnode, ecom)) {
-		ecom_str = ecommunity_ecom2str(ecom,
+	for (ALL_LIST_ELEMENTS(bgp->vrf_import_rtl, node, nnode, l3rt)) {
+		ecom_str = ecommunity_ecom2str(l3rt->ecom,
 					       ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 
 		if (json) {
@@ -999,8 +999,8 @@ static void show_l3vni_entry(struct vty *vty, struct bgp *bgp,
 	if (json)
 		json_object_object_add(json_vni, "importRTs", json_import_rtl);
 
-	for (ALL_LIST_ELEMENTS(bgp->vrf_export_rtl, node, nnode, ecom)) {
-		ecom_str = ecommunity_ecom2str(ecom,
+	for (ALL_LIST_ELEMENTS(bgp->vrf_export_rtl, node, nnode, l3rt)) {
+		ecom_str = ecommunity_ecom2str(l3rt->ecom,
 					       ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 
 		if (json) {
@@ -2009,12 +2009,12 @@ DEFUN(no_evpnrt5_network,
 
 static void evpn_import_rt_delete_auto(struct bgp *bgp, struct bgpevpn *vpn)
 {
-	evpn_rt_delete_auto(bgp, vpn->vni, vpn->import_rtl);
+	evpn_rt_delete_auto(bgp, vpn->vni, vpn->import_rtl, false);
 }
 
 static void evpn_export_rt_delete_auto(struct bgp *bgp, struct bgpevpn *vpn)
 {
-	evpn_rt_delete_auto(bgp, vpn->vni, vpn->export_rtl);
+	evpn_rt_delete_auto(bgp, vpn->vni, vpn->export_rtl, false);
 }
 
 /*
@@ -5698,18 +5698,35 @@ DEFUN (no_bgp_evpn_vni_rd_without_val,
  * Loop over all extended-communities in the route-target list rtl and
  * return 1 if we find ecomtarget
  */
-static int bgp_evpn_rt_matches_existing(struct list *rtl,
-					struct ecommunity *ecomtarget)
+static bool bgp_evpn_rt_matches_existing(struct list *rtl,
+					 struct ecommunity *ecomtarget)
 {
-	struct listnode *node, *nnode;
+	struct listnode *node;
 	struct ecommunity *ecom;
 
-	for (ALL_LIST_ELEMENTS(rtl, node, nnode, ecom)) {
+	for (ALL_LIST_ELEMENTS_RO(rtl, node, ecom)) {
 		if (ecommunity_match(ecom, ecomtarget))
-			return 1;
+			return true;
 	}
 
-	return 0;
+	return false;
+}
+
+/*
+ * L3 RT version of above.
+ */
+static bool bgp_evpn_vrf_rt_matches_existing(struct list *rtl,
+					     struct ecommunity *ecomtarget)
+{
+	struct listnode *node;
+	struct vrf_route_target *l3rt;
+
+	for (ALL_LIST_ELEMENTS_RO(rtl, node, l3rt)) {
+		if (ecommunity_match(l3rt->ecom, ecomtarget))
+			return true;
+	}
+
+	return false;
 }
 
 /* display L3VNI related info for a VRF instance */
@@ -5730,7 +5747,7 @@ DEFUN (show_bgp_vrf_l3vni_info,
 	struct bgp *bgp = NULL;
 	struct listnode *node = NULL;
 	struct bgpevpn *vpn = NULL;
-	struct ecommunity *ecom = NULL;
+	struct vrf_route_target *l3rt;
 	json_object *json = NULL;
 	json_object *json_vnis = NULL;
 	json_object *json_export_rts = NULL;
@@ -5780,13 +5797,13 @@ DEFUN (show_bgp_vrf_l3vni_info,
 		vty_out(vty, "\n");
 		vty_out(vty, "  Export-RTs:\n");
 		vty_out(vty, "    ");
-		for (ALL_LIST_ELEMENTS_RO(bgp->vrf_export_rtl, node, ecom))
-			vty_out(vty, "%s  ", ecommunity_str(ecom));
+		for (ALL_LIST_ELEMENTS_RO(bgp->vrf_export_rtl, node, l3rt))
+			vty_out(vty, "%s  ", ecommunity_str(l3rt->ecom));
 		vty_out(vty, "\n");
 		vty_out(vty, "  Import-RTs:\n");
 		vty_out(vty, "    ");
-		for (ALL_LIST_ELEMENTS_RO(bgp->vrf_import_rtl, node, ecom))
-			vty_out(vty, "%s  ", ecommunity_str(ecom));
+		for (ALL_LIST_ELEMENTS_RO(bgp->vrf_import_rtl, node, l3rt))
+			vty_out(vty, "%s  ", ecommunity_str(l3rt->ecom));
 		vty_out(vty, "\n");
 		vty_out(vty, "  RD: %s\n",
 			prefix_rd2str(&bgp->vrf_prd, buf1, RD_ADDRSTRLEN));
@@ -5811,17 +5828,19 @@ DEFUN (show_bgp_vrf_l3vni_info,
 		json_object_object_add(json, "l2vnis", json_vnis);
 
 		/* export rts */
-		for (ALL_LIST_ELEMENTS_RO(bgp->vrf_export_rtl, node, ecom))
+		for (ALL_LIST_ELEMENTS_RO(bgp->vrf_export_rtl, node, l3rt))
 			json_object_array_add(
 				json_export_rts,
-				json_object_new_string(ecommunity_str(ecom)));
+				json_object_new_string(
+					ecommunity_str(l3rt->ecom)));
 		json_object_object_add(json, "export-rts", json_export_rts);
 
 		/* import rts */
-		for (ALL_LIST_ELEMENTS_RO(bgp->vrf_import_rtl, node, ecom))
+		for (ALL_LIST_ELEMENTS_RO(bgp->vrf_import_rtl, node, l3rt))
 			json_object_array_add(
 				json_import_rts,
-				json_object_new_string(ecommunity_str(ecom)));
+				json_object_new_string(
+					ecommunity_str(l3rt->ecom)));
 		json_object_object_add(json, "import-rts", json_import_rts);
 		json_object_string_add(
 			json, "rd",
@@ -5837,12 +5856,14 @@ static int add_rt(struct bgp *bgp, struct ecommunity *ecom, bool is_import)
 {
 	/* Do nothing if we already have this route-target */
 	if (is_import) {
-		if (!bgp_evpn_rt_matches_existing(bgp->vrf_import_rtl, ecom))
+		if (!bgp_evpn_vrf_rt_matches_existing(bgp->vrf_import_rtl,
+						      ecom))
 			bgp_evpn_configure_import_rt_for_vrf(bgp, ecom);
 		else
 			return -1;
 	} else {
-		if (!bgp_evpn_rt_matches_existing(bgp->vrf_export_rtl, ecom))
+		if (!bgp_evpn_vrf_rt_matches_existing(bgp->vrf_export_rtl,
+						      ecom))
 			bgp_evpn_configure_export_rt_for_vrf(bgp, ecom);
 		else
 			return -1;
@@ -5855,12 +5876,14 @@ static int del_rt(struct bgp *bgp, struct ecommunity *ecom, bool is_import)
 {
 	/* Verify we already have this route-target */
 	if (is_import) {
-		if (!bgp_evpn_rt_matches_existing(bgp->vrf_import_rtl, ecom))
+		if (!bgp_evpn_vrf_rt_matches_existing(bgp->vrf_import_rtl,
+						      ecom))
 			return -1;
 
 		bgp_evpn_unconfigure_import_rt_for_vrf(bgp, ecom);
 	} else {
-		if (!bgp_evpn_rt_matches_existing(bgp->vrf_export_rtl, ecom))
+		if (!bgp_evpn_vrf_rt_matches_existing(bgp->vrf_export_rtl,
+						      ecom))
 			return -1;
 
 		bgp_evpn_unconfigure_export_rt_for_vrf(bgp, ecom);
@@ -6532,12 +6555,12 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 	if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_IMPORT_RT_CFGD)) {
 		char *ecom_str;
 		struct listnode *node, *nnode;
-		struct ecommunity *ecom;
+		struct vrf_route_target *l3rt;
 
 		for (ALL_LIST_ELEMENTS(bgp->vrf_import_rtl, node, nnode,
-				       ecom)) {
+				       l3rt)) {
 			ecom_str = ecommunity_ecom2str(
-				ecom, ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
+				l3rt->ecom, ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 			vty_out(vty, "  route-target import %s\n", ecom_str);
 			XFREE(MTYPE_ECOMMUNITY_STR, ecom_str);
 		}
@@ -6547,12 +6570,12 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 	if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_EXPORT_RT_CFGD)) {
 		char *ecom_str;
 		struct listnode *node, *nnode;
-		struct ecommunity *ecom;
+		struct vrf_route_target *l3rt;
 
 		for (ALL_LIST_ELEMENTS(bgp->vrf_export_rtl, node, nnode,
-				       ecom)) {
+				       l3rt)) {
 			ecom_str = ecommunity_ecom2str(
-				ecom, ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
+				l3rt->ecom, ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 			vty_out(vty, "  route-target export %s\n", ecom_str);
 			XFREE(MTYPE_ECOMMUNITY_STR, ecom_str);
 		}

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -4024,11 +4024,13 @@ DEFUN (bgp_evpn_advertise_type5,
 
 DEFUN (no_bgp_evpn_advertise_type5,
        no_bgp_evpn_advertise_type5_cmd,
-       "no advertise " BGP_AFI_CMD_STR "" BGP_SAFI_CMD_STR,
+       "no advertise " BGP_AFI_CMD_STR "" BGP_SAFI_CMD_STR " [route-map WORD]",
        NO_STR
        "Advertise prefix routes\n"
        BGP_AFI_HELP_STR
-       BGP_SAFI_HELP_STR)
+       BGP_SAFI_HELP_STR
+       "route-map for filtering specific routes\n"
+       "Name of the route map\n")
 {
 	struct bgp *bgp_vrf = VTY_GET_CONTEXT(bgp); /* bgp vrf instance */
 	int idx_afi = 0;

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -643,6 +643,20 @@ route_match_prefix_list_flowspec(afi_t afi, struct prefix_list *plist,
 }
 
 static enum route_map_cmd_result_t
+route_match_prefix_list_evpn(afi_t afi, struct prefix_list *plist,
+			     const struct prefix *p)
+{
+	/* Convert to match a general plist */
+	struct prefix new;
+
+	if (evpn_prefix2prefix(p, &new))
+		return RMAP_NOMATCH;
+
+	return (prefix_list_apply(plist, &new) == PREFIX_DENY ? RMAP_NOMATCH
+							      : RMAP_MATCH);
+}
+
+static enum route_map_cmd_result_t
 route_match_address_prefix_list(void *rule, afi_t afi,
 				const struct prefix *prefix, void *object)
 {
@@ -655,6 +669,10 @@ route_match_address_prefix_list(void *rule, afi_t afi,
 	if (prefix->family == AF_FLOWSPEC)
 		return route_match_prefix_list_flowspec(afi, plist,
 							prefix);
+
+	else if (prefix->family == AF_EVPN)
+		return route_match_prefix_list_evpn(afi, plist, prefix);
+
 	return (prefix_list_apply(plist, prefix) == PREFIX_DENY ? RMAP_NOMATCH
 								: RMAP_MATCH);
 }

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -719,8 +719,10 @@ struct bgp {
 #define BGP_VRF_AUTO                        (1 << 0)
 #define BGP_VRF_IMPORT_RT_CFGD              (1 << 1)
 #define BGP_VRF_EXPORT_RT_CFGD              (1 << 2)
-#define BGP_VRF_RD_CFGD                     (1 << 3)
-#define BGP_VRF_L3VNI_PREFIX_ROUTES_ONLY    (1 << 4)
+#define BGP_VRF_IMPORT_AUTO_RT_CFGD         (1 << 3) /* retain auto when cfgd */
+#define BGP_VRF_EXPORT_AUTO_RT_CFGD         (1 << 4) /* retain auto when cfgd */
+#define BGP_VRF_RD_CFGD                     (1 << 5)
+#define BGP_VRF_L3VNI_PREFIX_ROUTES_ONLY    (1 << 6)
 
 	/* unique ID for auto derivation of RD for this vrf */
 	uint16_t vrf_rd_id;

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2869,6 +2869,20 @@ sysctl configurations:
 
 For more information, see ``man 7 arp``.
 
+.. _bgp-evpn-l3-route-targets:
+
+EVPN L3 Route-Targets
+^^^^^^^^^^^^^^^^^^^^^
+
+.. clicmd:: route-target <import|export|both> <RTLIST|auto>
+
+Modifty the route-target set for EVPN advertised type-2/type-5 routes.
+RTLIST is a list of any of matching
+``(A.B.C.D:MN|EF:OPQR|GHJK:MN|*:OPQR|*:MN)`` where ``*`` indicates wildcard
+matching for the AS number. It will be set to match any AS number. This is
+useful in datacenter deployments with Downstream VNI. ``auto`` is used to
+retain the autoconfigure that is default behavior for L3 RTs.
+
 .. _bgp-evpn-advertise-pip:
 
 EVPN advertise-PIP

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2876,7 +2876,7 @@ EVPN L3 Route-Targets
 
 .. clicmd:: route-target <import|export|both> <RTLIST|auto>
 
-Modifty the route-target set for EVPN advertised type-2/type-5 routes.
+Modify the route-target set for EVPN advertised type-2/type-5 routes.
 RTLIST is a list of any of matching
 ``(A.B.C.D:MN|EF:OPQR|GHJK:MN|*:OPQR|*:MN)`` where ``*`` indicates wildcard
 matching for the AS number. It will be set to match any AS number. This is

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1404,6 +1404,63 @@ bool ipv4_unicast_valid(const struct in_addr *addr)
 	return true;
 }
 
+static int ipaddr2prefix(const struct ipaddr *ip, uint16_t prefixlen,
+			 struct prefix *p)
+{
+	switch (ip->ipa_type) {
+	case (IPADDR_V4):
+		p->family = AF_INET;
+		p->u.prefix4 = ip->ipaddr_v4;
+		p->prefixlen = prefixlen;
+		break;
+	case (IPADDR_V6):
+		p->family = AF_INET6;
+		p->u.prefix6 = ip->ipaddr_v6;
+		p->prefixlen = prefixlen;
+		break;
+	case (IPADDR_NONE):
+		p->family = AF_UNSPEC;
+		break;
+	}
+
+	return 0;
+}
+
+/*
+ * Convert type-2 and type-5 evpn route prefixes into the more
+ * general ipv4/ipv6 prefix types so we can match prefix lists
+ * and such.
+ */
+int evpn_prefix2prefix(const struct prefix *evpn, struct prefix *to)
+{
+	const struct evpn_addr *addr;
+
+	if (evpn->family != AF_EVPN)
+		return -1;
+
+	addr = &evpn->u.prefix_evpn;
+
+	switch (addr->route_type) {
+	case (2):
+		if (IS_IPADDR_V4(&addr->macip_addr.ip))
+			ipaddr2prefix(&addr->macip_addr.ip, 32, to);
+		else if (IS_IPADDR_V6(&addr->macip_addr.ip))
+			ipaddr2prefix(&addr->macip_addr.ip, 128, to);
+		else
+			return -1; /* mac only? */
+
+		break;
+	case (5):
+		ipaddr2prefix(&addr->prefix_addr.ip,
+			      addr->prefix_addr.ip_prefix_length, to);
+		break;
+	default:
+		return -1;
+	}
+
+	return 0;
+}
+
 printfrr_ext_autoreg_p("EA", printfrr_ea);
 static ssize_t printfrr_ea(struct fbuf *buf, struct printfrr_eargs *ea,
 			   const void *ptr)

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1441,7 +1441,7 @@ int evpn_prefix2prefix(const struct prefix *evpn, struct prefix *to)
 	addr = &evpn->u.prefix_evpn;
 
 	switch (addr->route_type) {
-	case (2):
+	case BGP_EVPN_MAC_IP_ROUTE:
 		if (IS_IPADDR_V4(&addr->macip_addr.ip))
 			ipaddr2prefix(&addr->macip_addr.ip, 32, to);
 		else if (IS_IPADDR_V6(&addr->macip_addr.ip))
@@ -1450,7 +1450,7 @@ int evpn_prefix2prefix(const struct prefix *evpn, struct prefix *to)
 			return -1; /* mac only? */
 
 		break;
-	case (5):
+	case BGP_EVPN_IP_PREFIX_ROUTE:
 		ipaddr2prefix(&addr->prefix_addr.ip,
 			      addr->prefix_addr.ip_prefix_length, to);
 		break;

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -510,6 +510,7 @@ extern char *esi_to_str(const esi_t *esi, char *buf, int size);
 extern char *evpn_es_df_alg2str(uint8_t df_alg, char *buf, int buf_len);
 extern void prefix_evpn_hexdump(const struct prefix_evpn *p);
 extern bool ipv4_unicast_valid(const struct in_addr *addr);
+extern int evpn_prefix2prefix(const struct prefix *evpn, struct prefix *to);
 
 static inline int ipv6_martian(const struct in6_addr *addr)
 {

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1820,7 +1820,24 @@ route_map_get_index(struct route_map *map, const struct prefix *prefix,
 	struct route_map_index *index = NULL, *best_index = NULL;
 	struct route_map_index *head_index = NULL;
 	struct route_table *table = NULL;
-	unsigned char family = prefix->family;
+	struct prefix conv;
+	unsigned char family;
+
+	/*
+	 * Handling for matching evpn_routes in the prefix table.
+	 *
+	 * We convert type2/5 prefix to ipv4/6 prefix to do longest
+	 * prefix matching on.
+	 */
+	if (prefix->family == AF_EVPN) {
+		if (evpn_prefix2prefix(prefix, &conv) != 0)
+			return NULL;
+
+		prefix = &conv;
+	}
+
+
+	family = prefix->family;
 
 	if (family == AF_INET)
 		table = map->ipv4_prefix_table;


### PR DESCRIPTION
### This PR is a precursor to EVPN Downstream VNI changes coming in a later PR.



------------------------------------------------------------------------------
These patches add support a few different things with L3 Route-Targets.

- Add user configured import/export RTs and still retain auto configuration via new `route-target [import|export|both] auto` command

- Add multiple RTs via list format in the `route-target [import|export|both] RTLIST command`
- Add new WILDCARD import RT type specified via `route-target import *:101004` which allows you to import an L3 RT from any AS. This behaves very similarly to the auto RT and is implemented the same way as well by just setting the beginning port of the RT to 0.
- Add a `no` form of command to `advertise ipvX route-map MAP`
- Add support for filtering outbound Type5 and Type2 routes via a prefix list in a route-map of the default l2vpn evpn instance.


