### PR TITLE
bgpd: fix redistribution in vrf

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -316,9 +316,6 @@ static int bgp_vrf_enable(struct vrf *vrf)
 		bgp_vrf_link(bgp, vrf);
 
 		bgp_handle_socket(bgp, vrf, old_vrf_id, true);
-		/* Update any redistribution if vrf_id changed */
-		if (old_vrf_id != bgp->vrf_id)
-			bgp_redistribute_redo(bgp);
 		bgp_instance_up(bgp);
 		vpn_leak_zebra_vrf_label_update(bgp, AFI_IP);
 		vpn_leak_zebra_vrf_label_update(bgp, AFI_IP6);
@@ -338,7 +335,6 @@ static int bgp_vrf_enable(struct vrf *vrf)
 static int bgp_vrf_disable(struct vrf *vrf)
 {
 	struct bgp *bgp;
-	vrf_id_t old_vrf_id;
 
 	if (vrf->vrf_id == VRF_DEFAULT)
 		return 0;
@@ -360,15 +356,11 @@ static int bgp_vrf_disable(struct vrf *vrf)
 		vpn_leak_prechange(BGP_VPN_POLICY_DIR_FROMVPN, AFI_IP6,
 				   bgp_get_default(), bgp);
 
-		old_vrf_id = bgp->vrf_id;
 		bgp_handle_socket(bgp, vrf, VRF_UNKNOWN, false);
 		/* We have instance configured, unlink from VRF and make it
 		 * "down". */
-		bgp_vrf_unlink(bgp, vrf);
-		/* Delete any redistribute vrf bitmaps if the vrf_id changed */
-		if (old_vrf_id != bgp->vrf_id)
-			bgp_unset_redist_vrf_bitmaps(bgp, old_vrf_id);
 		bgp_instance_down(bgp);
+		bgp_vrf_unlink(bgp, vrf);
 	}
 
 	/* Note: This is a callback, the VRF will be deleted by the caller. */

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1700,6 +1700,9 @@ int bgp_redistribute_set(struct bgp *bgp, afi_t afi, int type,
 
 		redist_add_instance(&zclient->mi_redist[afi][type], instance);
 	} else {
+		if (vrf_bitmap_check(zclient->redist[afi][type], bgp->vrf_id))
+			return CMD_WARNING;
+
 #ifdef ENABLE_BGP_VNC
 		if (EVPN_ENABLED(bgp) && type == ZEBRA_ROUTE_VNC_DIRECT) {
 			vnc_export_bgp_enable(

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1912,22 +1912,6 @@ void bgp_redistribute_redo(struct bgp *bgp)
 	}
 }
 
-/* Unset redistribute vrf bitmap during triggers like
-   restart networking or delete VRFs */
-void bgp_unset_redist_vrf_bitmaps(struct bgp *bgp, vrf_id_t old_vrf_id)
-{
-	int i;
-	afi_t afi;
-
-	for (afi = AFI_IP; afi < AFI_MAX; afi++)
-		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
-			if (vrf_bitmap_check(zclient->redist[afi][i],
-					     old_vrf_id))
-				vrf_bitmap_unset(zclient->redist[afi][i],
-						 old_vrf_id);
-	return;
-}
-
 void bgp_zclient_reset(void)
 {
 	zclient_reset(zclient);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2386,8 +2386,6 @@ static inline bool bgp_in_graceful_shutdown(struct bgp *bgp)
 	        !!CHECK_FLAG(bm->flags, BM_FLAG_GRACEFUL_SHUTDOWN));
 }
 
-extern void bgp_unset_redist_vrf_bitmaps(struct bgp *, vrf_id_t);
-
 /* For benefit of rfapi */
 extern struct peer *peer_new(struct bgp *bgp);
 

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -337,12 +337,17 @@ void zebra_redistribute_add(ZAPI_HANDLER_ARGS)
 					   zvrf_id(zvrf), afi);
 		}
 	} else {
-		if (IS_ZEBRA_DEBUG_EVENT)
-			zlog_debug("%s: setting vrf %s(%u) redist bitmap",
-				   __func__, VRF_LOGNAME(zvrf->vrf),
-				   zvrf_id(zvrf));
-		vrf_bitmap_set(client->redist[afi][type], zvrf_id(zvrf));
-		zebra_redistribute(client, type, 0, zvrf_id(zvrf), afi);
+		if (!vrf_bitmap_check(client->redist[afi][type],
+				      zvrf_id(zvrf))) {
+			if (IS_ZEBRA_DEBUG_EVENT)
+				zlog_debug(
+					"%s: setting vrf %s(%u) redist bitmap",
+					__func__, VRF_LOGNAME(zvrf->vrf),
+					zvrf_id(zvrf));
+			vrf_bitmap_set(client->redist[afi][type],
+				       zvrf_id(zvrf));
+			zebra_redistribute(client, type, 0, zvrf_id(zvrf), afi);
+		}
 	}
 
 stream_failure:


### PR DESCRIPTION
There was a fix some time ago for redistribution in VRF in commit https://github.com/FRRouting/frr/commit/6b2433c63f7fd3027cea8e06ca45f85bd3eea6f2.
Instead of fixing the real issue, this commit just removed a couple of necessary checks from the code.

The real issue is that the BGP instance is not deregistered from zebra when the VRF is deleted. Therefore, when the VRF is readded, the redistribution config is not replayed.

This PR reverts the incorrect "fix" and fixes the real issue in a new commit.