### PR TITLE
doc: Move BGP community alias under a separate section

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2022,24 +2022,6 @@ expanded
    attribute in BGP updates. The expanded community is only used to filter,
    not `set` actions.
 
-.. clicmd:: bgp community alias NAME ALIAS
-
-   This command creates an alias name for a community that will be used
-   later in various CLI outputs in a human-readable format.
-
-   .. code-block:: frr
-
-      ~# show ip bgp 172.16.16.1/32
-      BGP routing table entry for 172.16.16.1/32, version 21
-      Paths: (2 available, best #2, table default)
-        Advertised to non peer-group peers:
-        65030
-          192.168.0.2 from 192.168.0.2 (172.16.16.1)
-            Origin incomplete, metric 0, valid, external, best (Neighbor IP)
-            Community: 65001:12 65001:13 community-1 65001:65534
-            Large Community: lcommunity-1 65001:123:2
-            Last update: Fri Apr 16 12:51:27 2021
-
 .. deprecated:: 5.0
    It is recommended to use the more explicit versions of this command.
 
@@ -2096,6 +2078,38 @@ is called as named community lists.
 
    This command defines a new expanded community list. The argument to
    (100-199) defines the list identifier.
+
+.. _bgp-community-alias:
+
+Community alias
+^^^^^^^^^^^^^^^
+
+BGP community aliases are useful to quickly identify what communities are set
+for a specific prefix in a human-readable format. Especially handy for a huge
+amount of communities. Accurately defined aliases can help you faster spot
+things on the wire.
+
+.. clicmd:: bgp community alias NAME ALIAS
+
+   This command creates an alias name for a community that will be used
+   later in various CLI outputs in a human-readable format.
+
+   .. code-block:: frr
+
+      ~# vtysh -c 'show run' | grep 'bgp community alias'
+      bgp community alias 65001:14 community-1
+      bgp community alias 65001:123:1 lcommunity-1
+
+      ~# vtysh -c 'show ip bgp 172.16.16.1/32'
+      BGP routing table entry for 172.16.16.1/32, version 21
+      Paths: (2 available, best #2, table default)
+        Advertised to non peer-group peers:
+        65030
+          192.168.0.2 from 192.168.0.2 (172.16.16.1)
+            Origin incomplete, metric 0, valid, external, best (Neighbor IP)
+            Community: 65001:12 65001:13 community-1 65001:65534
+            Large Community: lcommunity-1 65001:123:2
+            Last update: Fri Apr 16 12:51:27 2021
 
 .. _bgp-using-communities-in-route-map:
 


### PR DESCRIPTION
There are more useful CLI commands coming, thus it's desired to have it's
own section.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

Fixes https://github.com/FRRouting/frr/issues/8651