### PR TITLE
pimd: add allow-rp knob to ignore incorrect rp

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -176,6 +176,19 @@ PIM interface commands allow you to configure an interface as either a Receiver
 or a interface that you would like to form pim neighbors on. If the interface
 is in a vrf, enter the interface command with the vrf keyword at the end.
 
+.. clicmd:: ip pim allow-rp [rp-list PLIST]
+
+   When processing a (\*,G) source list entry for a particular gropu in a Join
+   message, :rfc:`7661` dictates that the source address must be set to the RP
+   address. In some network designs, the sending router's idea of the RP for a
+   particular group may not match ours. Enabling this knob disables checking
+   that the source address in (\*,G) source list entries are equal to our RP
+   address for that group. The RP specified in the source list entry is ignored
+   and our RP address is used to join that group.
+
+   Optionally, a prefix-list may be specified; only RP addresses permitted by
+   this prefix-list will be accepted.
+
 .. clicmd:: ip pim active-active
 
    Turn on pim active-active configuration for a Vxlan interface.  This

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8450,6 +8450,29 @@ DEFPY_HIDDEN (pim_test_sg_keepalive,
 	return CMD_SUCCESS;
 }
 
+DEFPY(interface_ip_pim_allowrp, interface_ip_pim_allowrp_cmd,
+      "[no] ip pim allow-rp [rp-list PLIST]",
+      NO_STR IP_STR PIM_STR
+      "Ignore mismatched RP addresses when processing (*,G) Joins\n"
+      "Specify a prefix-list which the RP address must match in order to be accepted\n"
+      "The prefix-list to check the RP address against\n")
+
+{
+	if (no) {
+		nb_cli_enqueue_change(vty, "./allow-rp", NB_OP_DESTROY, NULL);
+	} else {
+		nb_cli_enqueue_change(vty, "./allow-rp", NB_OP_CREATE, NULL);
+		if (plist) {
+			nb_cli_enqueue_change(vty, "./allow-rp/rp-list",
+					      NB_OP_MODIFY, plist);
+		}
+	}
+
+	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+
+	return CMD_SUCCESS;
+}
+
 DEFPY (interface_ip_pim_activeactive,
        interface_ip_pim_activeactive_cmd,
        "[no$no] ip pim active-active",
@@ -11172,6 +11195,7 @@ void pim_cmd_init(void)
 			&interface_ip_igmp_last_member_query_interval_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ip_igmp_last_member_query_interval_cmd);
+	install_element(INTERFACE_NODE, &interface_ip_pim_allowrp_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_activeactive_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_ssm_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ip_pim_ssm_cmd);

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -138,6 +138,10 @@ struct pim_interface {
 	bool activeactive;
 	bool am_i_dr;
 
+	/* Turn on allow-rp for this interface */
+	bool allow_rp;
+	char *allow_rp_plist;
+
 	int64_t pim_ifstat_start; /* start timestamp for stats */
 	uint64_t pim_ifstat_bsm_rx;
 	uint64_t pim_ifstat_bsm_tx;

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -284,6 +284,20 @@ const struct frr_yang_module_info frr_pim_info = {
 			}
 		},
 		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/allow-rp",
+			.cbs = {
+				.create = lib_interface_pim_allow_rp_create,
+				.destroy = lib_interface_pim_allow_rp_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/allow-rp/rp-list",
+			.cbs = {
+				.modify = lib_interface_pim_allow_rp_rp_list_modify,
+				.destroy = lib_interface_pim_allow_rp_rp_list_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family",
 			.cbs = {
 				.create = lib_interface_pim_address_family_create,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -108,6 +108,10 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_re
 	struct nb_cb_destroy_args *args);
 int lib_interface_pim_dr_priority_modify(
 	struct nb_cb_modify_args *args);
+int lib_interface_pim_allow_rp_create(struct nb_cb_create_args *args);
+int lib_interface_pim_allow_rp_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_pim_allow_rp_rp_list_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_allow_rp_rp_list_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_create(struct nb_cb_create_args *args);
 int lib_interface_pim_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_pim_enable_modify(struct nb_cb_modify_args *args);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2179,6 +2179,115 @@ int lib_interface_pim_dr_priority_modify(struct nb_cb_modify_args *args)
 }
 
 /*
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/allow-rp
+ */
+int lib_interface_pim_allow_rp_create(struct nb_cb_create_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+	const struct lyd_node *if_dnode;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
+		if (!is_pim_interface(if_dnode)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Pim not enabled on this interface");
+			return NB_ERR_VALIDATION;
+		}
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		pim_ifp->allow_rp = true;
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_pim_allow_rp_destroy(struct nb_cb_destroy_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+	const struct lyd_node *if_dnode;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
+		if (!is_pim_interface(if_dnode)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Pim not enabled on this interface");
+			return NB_ERR_VALIDATION;
+		}
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		pim_ifp->allow_rp = false;
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/allow-rp/rp-list
+ */
+int lib_interface_pim_allow_rp_rp_list_modify(struct nb_cb_modify_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+	const struct lyd_node *if_dnode;
+	const char *plist;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
+		if (!is_pim_interface(if_dnode)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Pim not enabled on this interface");
+			return NB_ERR_VALIDATION;
+		}
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		plist = yang_dnode_get_string(args->dnode, NULL);
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		XFREE(MTYPE_PIM_INTERFACE, pim_ifp->allow_rp_plist);
+		pim_ifp->allow_rp_plist = XSTRDUP(MTYPE_PIM_INTERFACE, plist);
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_pim_allow_rp_rp_list_destroy(struct nb_cb_destroy_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+	const char *plist;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		plist = yang_dnode_get_string(args->dnode, NULL);
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		XFREE(MTYPE_PIM_INTERFACE, pim_ifp->allow_rp_plist);
+		break;
+	}
+
+	return NB_OK;
+}
+
+
+/*
  * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family
  */
 int lib_interface_pim_address_family_create(struct nb_cb_create_args *args)

--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -154,3 +154,22 @@ bool pim_is_group_filtered(struct pim_interface *pim_ifp, struct in_addr *grp)
 	pl = prefix_list_lookup(AFI_IP, pim_ifp->boundary_oil_plist);
 	return pl ? prefix_list_apply(pl, &grp_pfx) == PREFIX_DENY : false;
 }
+
+bool pim_is_rp_allowed(struct pim_interface *pim_ifp, struct in_addr *rp)
+{
+	struct prefix rp_pfx;
+	struct prefix_list *pl;
+
+	/* No reason to call this if you're conforming to the RFC */
+	assert(pim_ifp->allow_rp);
+
+	if (!pim_ifp->allow_rp_plist)
+		return true;
+
+	rp_pfx.family = AF_INET;
+	rp_pfx.prefixlen = 32;
+	rp_pfx.u.prefix4 = *rp;
+
+	pl = prefix_list_lookup(AFI_IP, pim_ifp->allow_rp_plist);
+	return pl ? prefix_list_apply(pl, &rp_pfx) == PREFIX_PERMIT : false;
+}

--- a/pimd/pim_util.h
+++ b/pimd/pim_util.h
@@ -36,4 +36,21 @@ void pim_pkt_dump(const char *label, const uint8_t *buf, int size);
 int pim_is_group_224_0_0_0_24(struct in_addr group_addr);
 int pim_is_group_224_4(struct in_addr group_addr);
 bool pim_is_group_filtered(struct pim_interface *pim_ifp, struct in_addr *grp);
+
+/*
+ * For 'ip pim allow-rp'. This checks if a given RP address is allowed by the
+ * configured RP-filtering prefix list.
+ *
+ * Asserts that accept_rp is enabled; if it's not, there's no reason to call
+ * this.
+ *
+ * pim_ifp
+ *    The PIM interface the (*,G) JOIN with the RP address being checked was
+ *    received on.
+ *
+ * rp
+ *    The RP address that was received.
+ */
+bool pim_is_rp_allowed(struct pim_interface *pim_ifp, struct in_addr *rp);
+
 #endif /* PIM_UTIL_H */

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -337,6 +337,15 @@ int pim_interface_config_write(struct vty *vty)
 					++writes;
 				}
 
+				/* allow-rp */
+				if (pim_ifp->allow_rp) {
+					vty_out(vty, " ip pim allow-rp");
+					if (pim_ifp->allow_rp_plist)
+						vty_out(vty, " rp-list %s",
+							pim_ifp->allow_rp_plist);
+					vty_out(vty, "\n");
+				}
+
 				/* IF ip igmp */
 				if (PIM_IF_TEST_IGMP(pim_ifp->options)) {
 					vty_out(vty, " ip igmp\n");

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -368,6 +368,17 @@ module frr-pim {
       description
         "DR (Designated Router) priority";
     }
+
+    container allow-rp {
+      presence
+        "Ignore mismatched RP addresses when processing (*, G) joins";
+
+      leaf rp-list {
+        type plist-ref;
+        description
+          "Prefix-list used to filter which RPs will be accepted";
+      }
+    }
   } // interface-pim-config-attributes
 
   grouping per-af-interface-pim-config-attributes {


### PR DESCRIPTION
When processing a (*,G) source list entry, the RFC dictates that the
source address provided must match the RP address. In some situations
it's desirable to forego this check. This patch adds a simple boolean
knob, configurable on a per-interface basis, to disable that check.

Alternatively, one can specify a prefix-list, which will act as a
whitelist for what RP addresses to allow.

Draft mode as I don't have a topotest for this