### PR TITLE
Fix #8567 OSPFv3-26.13 ANVL failure

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -1016,18 +1016,20 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 					if (is_debug)
 						zlog_debug(
 							"%s: Current copy of LSA %s is MAXAGE, but new has recent age, flooding/installing.",
-							old->name, __PRETTY_FUNCTION__);
+							__PRETTY_FUNCTION__, old->name);
 					ospf6_lsa_purge(old);
 					ospf6_flood(from, new);
 					ospf6_install_lsa(new);
-				} else {
-					if (is_debug)
-						zlog_debug(
-							"%s: Current copy of self-originated LSA %s is MAXAGE, but new has recent age, ignoring new.",
-							old->name, __PRETTY_FUNCTION__);
-					ospf6_lsa_delete(new);
+					return;
 				}
-				return;
+				/* For self-originated LSA, only trust
+				 * ourselves. Fall through and send
+				 * LS Update with our current copy.
+				 */
+				if (is_debug)
+					zlog_debug(
+						"%s: Current copy of self-originated LSA %s is MAXAGE, but new has recent age, re-sending current one.",
+						__PRETTY_FUNCTION__, old->name);
 			}
 
 			/* XXX, MinLSArrival check !? RFC 2328 13 (8) */


### PR DESCRIPTION
This should fix the ANVL failure reported in #8567 I added in 4c63a76a63fd02ae2aa73e4e66b04b37b10fdd99 while trying to fix #7030. It passes my manual ANVL-like test performing the steps listed in ANVL-26.13_Failed.txt attached to the bug report. It also passes my topotest for #7030 submitted (but still pending) in #7168.

@Manikandaprab: Could you re-run the real ANVL test with this fix applied, please?

BTW, I still don't understand what commit 76249532faadfb429f46dd94cf6bbc61d78b3f26 was trying to achieve exactly. The code from this commit is still used for the non-self-originated LSA case, but I'm not sure it does anything useful. But at least it doesn't seem to cause harm in typical cases or we would have noticed in the meantime...
