### PR TITLE
lib,zebra: Use a flag to track down status for connected addrs

### DIFF
--- a/lib/if.h
+++ b/lib/if.h
@@ -393,6 +393,7 @@ struct connected {
 #define ZEBRA_IFC_REAL         (1 << 0)
 #define ZEBRA_IFC_CONFIGURED   (1 << 1)
 #define ZEBRA_IFC_QUEUED       (1 << 2)
+#define ZEBRA_IFC_DOWN         (1 << 3)
 	/*
 	   The ZEBRA_IFC_REAL flag should be set if and only if this address
 	   exists in the kernel and is actually usable. (A case where it exists
@@ -406,6 +407,8 @@ struct connected {
 	   in the kernel. It may and should be set although the address might
 	   not be
 	   usable yet. (compare with ZEBRA_IFC_REAL)
+	   The ZEBRA_IFC_DOWN flag is used to record that an address is
+	   present, but down/unavailable.
 	 */
 
 	/* Flags for connected address. */


### PR DESCRIPTION
Track 'down' state of connected addresses with a new flag. We may have multiple addresses on an interface that share a prefix; in those cases, we need to determine when the first address is valid, to install a connected route, and similarly detect when the last address goes 'down', to remove the connected route.

If we have multiple addresses and  `shut` the interface, the code checks the list of connecteds and finds more than one - so it doesn't remove the zebra connected route. The list of connecteds only changes when address are actually added or removed, and the existing code does handle that.

Fixes #8611 
(I think)