### PR TITLE
bgpd: fix deconfig of conditional advertisement

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6891,7 +6891,7 @@ static void peer_advertise_map_filter_update(struct peer *peer, afi_t afi,
 
 	/* Removed advertise-map configuration */
 	if (!set) {
-		memset(filter, 0, sizeof(struct bgp_filter));
+		memset(&filter->advmap, 0, sizeof(filter->advmap));
 
 		/* decrement condition_filter_count delete timer if
 		 * this is the last advertise-map to be removed.


### PR DESCRIPTION
Deconfiguring conditional advertisement resulted in all other policy
settings on the peer getting removed due to an excessively large memset.

This also created a desync with the northbound config tree, which caused
its own set of problems...

Fix the memset to just remove the conditional advertisement config.

Signed-off-by: Quentin Young <qlyoung@nvidia.com>