### PR TITLE
lib: Add ZCAP_IPC_LOCK

### DIFF
--- a/lib/privs.c
+++ b/lib/privs.c
@@ -159,6 +159,10 @@ static struct {
 			{
 				1, (pvalue_t[]){CAP_FOWNER},
 			},
+		[ZCAP_IPC_LOCK] =
+			{
+				1, (pvalue_t[]){CAP_IPC_LOCK},
+			},
 #endif /* HAVE_LCAPS */
 };
 

--- a/lib/privs.h
+++ b/lib/privs.h
@@ -44,6 +44,7 @@ typedef enum {
 	ZCAP_DAC_OVERRIDE,
 	ZCAP_READ_SEARCH,
 	ZCAP_FOWNER,
+	ZCAP_IPC_LOCK,
 	ZCAP_MAX
 } zebra_capabilities_t;
 


### PR DESCRIPTION
We'll need ZCAP_IPC_LOCK for future work coming down the pike
related to dataplane work being done.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>