### PR TITLE
tests: fix bgp_l3vpn_to_bgp_vrf

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_vrf.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_vrf.py
@@ -59,8 +59,8 @@ luCommand(
     "VRF cust1 IP config",
 )
 luCommand(
-    rtr,
-    "ip route show vrf r4-cust2".format(rtr),
+    "r4",
+    "ip route show vrf r4-cust2",
     "192.168...0/24 dev r.-eth",
     "pass",
     "VRF cust2 interface route",


### PR DESCRIPTION
Too many arguments for format string.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>