### PR TITLE
Use __func__ instead of __PRETTY_FUNCTION__

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -620,8 +620,8 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 	}
 
 	if (!zapi_nexthop_update_decode(zclient->ibuf, &nhr)) {
-		zlog_err("%s[%s]: Failure to decode nexthop update",
-			 __PRETTY_FUNCTION__, bgp->name_pretty);
+		zlog_err("%s[%s]: Failure to decode nexthop update", __func__,
+			 bgp->name_pretty);
 		return;
 	}
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2394,7 +2394,7 @@ static int bgp_zebra_route_notify_owner(int command, struct zclient *zclient,
 
 	if (!zapi_route_notify_decode(zclient->ibuf, &p, &table_id, &note,
 				      &afi, &safi)) {
-		zlog_err("%s : error in msg decode", __PRETTY_FUNCTION__);
+		zlog_err("%s : error in msg decode", __func__);
 		return -1;
 	}
 
@@ -2402,8 +2402,8 @@ static int bgp_zebra_route_notify_owner(int command, struct zclient *zclient,
 	bgp = bgp_lookup_by_vrf_id(vrf_id);
 	if (!bgp) {
 		flog_err(EC_BGP_INVALID_BGP_INSTANCE,
-			 "%s : bgp instance not found vrf %d",
-			 __PRETTY_FUNCTION__, vrf_id);
+			 "%s : bgp instance not found vrf %d", __func__,
+			 vrf_id);
 		return -1;
 	}
 

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -692,8 +692,7 @@ struct ospf_lsa *ospf_originate_summary_lsa(struct ospf *ospf,
 		if (IS_DEBUG_OSPF(lsa, EXTNL_LSA_AGGR))
 			zlog_debug(
 				"%s: LSA is in MAX-AGE so refreshing LSA(%pI4/%d)",
-				__PRETTY_FUNCTION__, &aggr->p.prefix,
-				aggr->p.prefixlen);
+				__func__, &aggr->p.prefix, aggr->p.prefixlen);
 
 		ospf_external_lsa_refresh(ospf, lsa, &ei_aggr,
 					  LSA_REFRESH_FORCE, 1);
@@ -711,8 +710,7 @@ struct ospf_lsa *ospf_originate_summary_lsa(struct ospf *ospf,
 		if (IS_DEBUG_OSPF(lsa, EXTNL_LSA_AGGR))
 			zlog_debug(
 				"%s: External route prefix is same as aggr so refreshing LSA(%pI4/%d)",
-				__PRETTY_FUNCTION__, &aggr->p.prefix,
-				aggr->p.prefixlen);
+				__func__, &aggr->p.prefix, aggr->p.prefixlen);
 		ospf_external_lsa_refresh(ospf, lsa, &ei_aggr,
 					  LSA_REFRESH_FORCE, 1);
 		SET_FLAG(aggr->flags, OSPF_EXTERNAL_AGGRT_ORIGINATED);

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -388,8 +388,7 @@ int ospf_flood(struct ospf *ospf, struct ospf_neighbor *nbr,
 			if (IS_DEBUG_OSPF_GR_HELPER)
 				zlog_debug(
 					"%s, Received a maxage GRACE-LSA from router %pI4",
-					__PRETTY_FUNCTION__,
-					&new->data->adv_router);
+					__func__, &new->data->adv_router);
 
 			if (current) {
 				ospf_process_maxage_grace_lsa(ospf, new, nbr);
@@ -397,22 +396,21 @@ int ospf_flood(struct ospf *ospf, struct ospf_neighbor *nbr,
 				if (IS_DEBUG_OSPF_GR_HELPER)
 					zlog_debug(
 						"%s, Grace LSA doesn't exist in lsdb, so discarding grace lsa",
-						__PRETTY_FUNCTION__);
+						__func__);
 				return -1;
 			}
 		} else {
 			if (IS_DEBUG_OSPF_GR_HELPER)
 				zlog_debug(
 					"%s, Received a GRACE-LSA from router %pI4",
-					__PRETTY_FUNCTION__,
-					&new->data->adv_router);
+					__func__, &new->data->adv_router);
 
 			if (ospf_process_grace_lsa(ospf, new, nbr)
 			    == OSPF_GR_NOT_HELPER) {
 				if (IS_DEBUG_OSPF_GR_HELPER)
 					zlog_debug(
 						"%s, Not moving to HELPER role, So discarding grace LSA",
-						__PRETTY_FUNCTION__);
+						__func__);
 				return -1;
 			}
 		}

--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -164,7 +164,7 @@ void ospf_gr_helper_init(struct ospf *ospf)
 	int rc;
 
 	if (IS_DEBUG_OSPF_GR_HELPER)
-		zlog_debug("%s, GR Helper init.", __PRETTY_FUNCTION__);
+		zlog_debug("%s, GR Helper init.", __func__);
 
 	ospf->is_helper_supported = OSPF_GR_FALSE;
 	ospf->strict_lsa_check = OSPF_GR_TRUE;
@@ -201,7 +201,7 @@ void ospf_gr_helper_stop(struct ospf *ospf)
 {
 
 	if (IS_DEBUG_OSPF_GR_HELPER)
-		zlog_debug("%s, GR helper deinit.", __PRETTY_FUNCTION__);
+		zlog_debug("%s, GR helper deinit.", __func__);
 
 	ospf_enable_rtr_hash_destroy(ospf);
 
@@ -305,7 +305,7 @@ static int ospf_extract_grace_lsa_fields(struct ospf_lsa *lsa,
 			if (IS_DEBUG_OSPF_GR_HELPER)
 				zlog_debug(
 					"%s, Malformed packet.Invalid TLV type:%d",
-					__PRETTY_FUNCTION__, ntohs(tlvh->type));
+					__func__, ntohs(tlvh->type));
 			return OSPF_GR_FAILURE;
 		}
 	}
@@ -370,16 +370,14 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 					    &restart_reason);
 	if (ret != OSPF_GR_SUCCESS) {
 		if (IS_DEBUG_OSPF_GR_HELPER)
-			zlog_debug("%s, Wrong Grace LSA packet.",
-				   __PRETTY_FUNCTION__);
+			zlog_debug("%s, Wrong Grace LSA packet.", __func__);
 		return OSPF_GR_NOT_HELPER;
 	}
 
 	if (IS_DEBUG_OSPF_GR_HELPER)
 		zlog_debug(
 			"%s, Grace LSA received from %pI4, grace interval:%u, restartreason :%s",
-			__PRETTY_FUNCTION__, &restart_addr,
-			grace_interval,
+			__func__, &restart_addr, grace_interval,
 			ospf_restart_reason2str(restart_reason));
 
 	/* Incase of broadcast links, if RESTARTER is DR_OTHER,
@@ -393,8 +391,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 			if (IS_DEBUG_OSPF_GR_HELPER)
 				zlog_debug(
 					"%s, Restarter is not a nbr(%pI4) for this router.",
-					__PRETTY_FUNCTION__,
-					&restart_addr);
+					__func__, &restart_addr);
 			return OSPF_GR_NOT_HELPER;
 		}
 	} else
@@ -411,7 +408,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 			if (IS_DEBUG_OSPF_GR_HELPER)
 				zlog_debug(
 					"%s, HELPER support is disabled, So not a HELPER",
-					__PRETTY_FUNCTION__);
+					__func__);
 			restarter->gr_helper_info.rejected_reason =
 				OSPF_HELPER_SUPPORT_DISABLED;
 			return OSPF_GR_NOT_HELPER;
@@ -426,7 +423,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug(
 				"%s, This Neighbour %pI4 is not in FULL state.",
-				__PRETTY_FUNCTION__, &restarter->src);
+				__func__, &restarter->src);
 		restarter->gr_helper_info.rejected_reason =
 			OSPF_HELPER_NOT_A_VALID_NEIGHBOUR;
 		return OSPF_GR_NOT_HELPER;
@@ -440,7 +437,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug(
 				"%s, Router supports only planned restarts but received the GRACE LSA for an unplanned restart.",
-				__PRETTY_FUNCTION__);
+				__func__);
 		restarter->gr_helper_info.rejected_reason =
 			OSPF_HELPER_PLANNED_ONLY_RESTART;
 		return OSPF_GR_NOT_HELPER;
@@ -454,7 +451,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug(
 				"%s, Changed LSA in Rxmt list. So not Helper.",
-				__PRETTY_FUNCTION__);
+				__func__);
 		restarter->gr_helper_info.rejected_reason =
 			OSPF_HELPER_TOPO_CHANGE_RTXMT_LIST;
 		return OSPF_GR_NOT_HELPER;
@@ -465,8 +462,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug(
 				"%s, Grace LSA age(%d) is more than the graceinterval(%d)",
-				__PRETTY_FUNCTION__, lsa->data->ls_age,
-				grace_interval);
+				__func__, lsa->data->ls_age, grace_interval);
 		restarter->gr_helper_info.rejected_reason =
 			OSPF_HELPER_LSA_AGE_MORE;
 		return OSPF_GR_NOT_HELPER;
@@ -482,7 +478,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug(
 				"%s, Received grace period %d is larger than supported grace %d",
-				__PRETTY_FUNCTION__, grace_interval,
+				__func__, grace_interval,
 				ospf->supported_grace_time);
 		actual_grace_interval = ospf->supported_grace_time;
 	}
@@ -497,12 +493,12 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug(
 				"%s, Router is already acting as a HELPER for this nbr,so restart the grace timer",
-				__PRETTY_FUNCTION__);
+				__func__);
 	} else {
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug(
 				"%s, This Router becomes a HELPER for the neighbour %pI4",
-				__PRETTY_FUNCTION__, &restarter->src);
+				__func__, &restarter->src);
 	}
 
 	/* Became a Helper to the RESTART neighbour.
@@ -518,8 +514,8 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	ospf->active_restarter_cnt++;
 
 	if (IS_DEBUG_OSPF_GR_HELPER)
-		zlog_debug("%s, Grace timer started.interval:%d",
-			   __PRETTY_FUNCTION__, actual_grace_interval);
+		zlog_debug("%s, Grace timer started.interval:%d", __func__,
+			   actual_grace_interval);
 
 	/* Start the grace timer */
 	thread_add_timer(master, ospf_handle_grace_timer_expiry, restarter,
@@ -607,8 +603,7 @@ void ospf_helper_handle_topo_chg(struct ospf *ospf, struct ospf_lsa *lsa)
 	if (IS_DEBUG_OSPF_GR_HELPER)
 		zlog_debug(
 			"%s, Topo change detected due to lsa LSID:%pI4 type:%d",
-			__PRETTY_FUNCTION__, &lsa->data->id,
-			lsa->data->type);
+			__func__, &lsa->data->id, lsa->data->type);
 
 	lsa->to_be_acknowledged = OSPF_GR_TRUE;
 
@@ -671,8 +666,7 @@ void ospf_gr_helper_exit(struct ospf_neighbor *nbr,
 
 	if (IS_DEBUG_OSPF_GR_HELPER)
 		zlog_debug("%s, Exiting from HELPER support to %pI4, due to %s",
-			   __PRETTY_FUNCTION__, &nbr->src,
-			   ospf_exit_reason2str(reason));
+			   __func__, &nbr->src, ospf_exit_reason2str(reason));
 
 	/* Reset helper status*/
 	nbr->gr_helper_info.gr_helper_status = OSPF_GR_NOT_HELPER;
@@ -704,7 +698,7 @@ void ospf_gr_helper_exit(struct ospf_neighbor *nbr,
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug(
 				"%s, Failed GR exit, so bringing down the neighbour",
-				__PRETTY_FUNCTION__);
+				__func__);
 		OSPF_NSM_EVENT_EXECUTE(nbr, NSM_KillNbr);
 	}
 
@@ -752,14 +746,13 @@ void ospf_process_maxage_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 					    &restartReason);
 	if (ret != OSPF_GR_SUCCESS) {
 		if (IS_DEBUG_OSPF_GR_HELPER)
-			zlog_debug("%s, Wrong Grace LSA packet.",
-				   __PRETTY_FUNCTION__);
+			zlog_debug("%s, Wrong Grace LSA packet.", __func__);
 		return;
 	}
 
 	if (IS_DEBUG_OSPF_GR_HELPER)
-		zlog_debug("%s, GraceLSA received for neighbour %pI4",
-			   __PRETTY_FUNCTION__, &restartAddr);
+		zlog_debug("%s, GraceLSA received for neighbour %pI4", __func__,
+			   &restartAddr);
 
 	/* In case of broadcast links, if RESTARTER is DR_OTHER,
 	 * grace LSA might be received from DR, so fetching the
@@ -772,7 +765,7 @@ void ospf_process_maxage_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 			if (IS_DEBUG_OSPF_GR_HELPER)
 				zlog_debug(
 					"%s, Restarter is not a neighbour for this router.",
-					__PRETTY_FUNCTION__);
+					__func__);
 			return;
 		}
 	} else {

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -78,7 +78,7 @@ static int ospf_inactivity_timer(struct thread *thread)
 	else if (IS_DEBUG_OSPF_GR_HELPER)
 		zlog_debug(
 			"%s, Acting as HELPER for this neighbour, So inactivitytimer event will not be fired.",
-			__PRETTY_FUNCTION__);
+			__func__);
 
 	return 0;
 }

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -4266,7 +4266,7 @@ void ospf_ls_ack_send(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 	if (IS_GRACE_LSA(lsa)) {
 		if (IS_DEBUG_OSPF_GR_HELPER)
 			zlog_debug("%s, Sending GRACE ACK to Restarter.",
-				   __PRETTY_FUNCTION__);
+				   __func__);
 	}
 
 	if (listcount(oi->ls_ack_direct.ls_ack) == 0)

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1994,7 +1994,7 @@ void ospf_spf_calculate_schedule(struct ospf *ospf, ospf_spf_reason_t reason)
 void ospf_restart_spf(struct ospf *ospf)
 {
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("%s: Restart SPF.", __PRETTY_FUNCTION__);
+		zlog_debug("%s: Restart SPF.", __func__);
 
 	/* Handling inter area and intra area routes*/
 	if (ospf->new_table) {

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -743,7 +743,7 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
 				if (!ch->upstream->channel_oil->installed)
 					pim_upstream_mroute_add(
 						ch->upstream->channel_oil,
-						__PRETTY_FUNCTION__);
+						__func__);
 			}
 		}
 		/* from here ch may have been deleted */

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -985,8 +985,7 @@ void zsend_nhrp_neighbor_notify(int cmd, struct interface *ifp,
 	union sockunion ip;
 
 	if (IS_ZEBRA_DEBUG_PACKET)
-		zlog_debug("%s: Notifying Neighbor entry (%u)",
-			   __PRETTY_FUNCTION__, cmd);
+		zlog_debug("%s: Notifying Neighbor entry (%u)", __func__, cmd);
 
 	sockunion_family(&ip) = ipaddr_family(ipaddr);
 	afi = family2afi(sockunion_family(&ip));
@@ -2509,7 +2508,7 @@ static void zread_sr_policy_set(ZAPI_HANDLER_ARGS)
 	if (zapi_sr_policy_decode(s, &zp) < 0) {
 		if (IS_ZEBRA_DEBUG_RECV)
 			zlog_debug("%s: Unable to decode zapi_sr_policy sent",
-				   __PRETTY_FUNCTION__);
+				   __func__);
 		return;
 	}
 	zt = &zp.segment_list;
@@ -2517,7 +2516,7 @@ static void zread_sr_policy_set(ZAPI_HANDLER_ARGS)
 		if (IS_ZEBRA_DEBUG_RECV)
 			zlog_debug(
 				"%s: SR-TE tunnel must contain at least one label",
-				__PRETTY_FUNCTION__);
+				__func__);
 		return;
 	}
 
@@ -2544,7 +2543,7 @@ static void zread_sr_policy_delete(ZAPI_HANDLER_ARGS)
 	if (zapi_sr_policy_decode(s, &zp) < 0) {
 		if (IS_ZEBRA_DEBUG_RECV)
 			zlog_debug("%s: Unable to decode zapi_sr_policy sent",
-				   __PRETTY_FUNCTION__);
+				   __func__);
 		return;
 	}
 
@@ -2554,8 +2553,7 @@ static void zread_sr_policy_delete(ZAPI_HANDLER_ARGS)
 	policy = zebra_sr_policy_find(zp.color, &zp.endpoint);
 	if (!policy) {
 		if (IS_ZEBRA_DEBUG_RECV)
-			zlog_debug("%s: Unable to find SR-TE policy",
-				   __PRETTY_FUNCTION__);
+			zlog_debug("%s: Unable to find SR-TE policy", __func__);
 		return;
 	}
 

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -2476,8 +2476,8 @@ void zebra_evpn_proc_remote_es(ZAPI_HANDLER_ARGS)
 
 	if (!is_evpn_enabled()) {
 		zlog_debug(
-				"%s: EVPN not enabled yet we received a es_add zapi call",
-				__PRETTY_FUNCTION__);
+			"%s: EVPN not enabled yet we received a es_add zapi call",
+			__func__);
 		return;
 	}
 

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -512,7 +512,7 @@ void zebra_pbr_add_rule(struct zebra_pbr_rule *rule)
 		if (pbr_rule_release(found))
 			zlog_debug(
 				"%s: Rule being updated we know nothing about",
-				__PRETTY_FUNCTION__);
+				__func__);
 
 	} else {
 		if (IS_ZEBRA_DEBUG_PBR)


### PR DESCRIPTION
Some snuck back in.  Search and replace.

ospf6d left alone at the moment because of an active PR.  