### PR TITLE
pathd: Clean coverity issues after merge pathd link state feature.

### DIFF
--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -351,8 +351,6 @@ static int segment_list_has_src_dst(
 		nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY,
 				      "ipv6_adjacency");
 		node_src_id = adj_src_ipv6_str;
-	} else {
-		return CMD_ERR_NO_MATCH;
 	}
 	/* addresses */
 	snprintf(xpath, XPATH_MAXLEN, "./segment[index='%s']/nai/local-address",
@@ -421,8 +419,6 @@ int segment_list_has_prefix(
 			  sizeof(buf_prefix));
 		pre_ipaddr.ipa_type = IPADDR_V6;
 		pre_ipaddr.ip._v6_addr = prefix_cli.u.prefix6;
-	} else {
-		return CMD_ERR_NO_MATCH;
 	}
 	snprintf(xpath, XPATH_MAXLEN, "./segment[index='%s']/nai/local-address",
 		 index_str);
@@ -524,7 +520,7 @@ DEFPY(srte_segment_list_segment, srte_segment_list_segment_cmd,
 		if (status != CMD_SUCCESS)
 			return status;
 	} else {
-		segment_list_has_prefix(
+		status = segment_list_has_prefix(
 			vty, xpath, index, index_str, prefix_ipv4,
 			prefix_ipv4_str, prefix_ipv6, prefix_ipv6_str, has_algo,
 			algo, algo_str, has_iface_id, iface_id, iface_id_str);

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -1273,7 +1273,8 @@ void handle_pcep_comp_reply(struct ctrl_state *ctrl_state,
 	 * pathd API is thread safe, we could get a new path */
 	if (pcc_state->caps.is_stateful) {
 		PCEP_DEBUG("%s Delegating undefined dynamic path %s to PCE %s",
-			   pcc_state->tag, path->name, pcc_state->originator);
+			   pcc_state->tag, req->path->name,
+			   pcc_state->originator);
 		path = pcep_copy_path(req->path);
 		path->is_delegated = true;
 		send_report(pcc_state, path);

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -195,13 +195,15 @@ int srte_segment_entry_set_nai(struct srte_segment_entry *segment,
 			       struct ipaddr *remote_ip, uint32_t remote_iface,
 			       uint8_t algo, uint8_t pref_len)
 {
+
 	int32_t status = 0;
 	struct prefix pre = {0};
-	segment->nai_type = type;
-	memcpy(&segment->nai_local_addr, local_ip, sizeof(struct ipaddr));
 
 	if (!segment || !local_ip || !remote_ip)
 		return 1;
+
+	segment->nai_type = type;
+	memcpy(&segment->nai_local_addr, local_ip, sizeof(struct ipaddr));
 
 	switch (type) {
 	case SRTE_SEGMENT_NAI_TYPE_IPV4_NODE:


### PR DESCRIPTION
The list of cov issues are:

path_cli.c
ln:354 DEADCODE As adj_src_ipv6_strv is previously check cannot be null and choose else path.
ln:424 DEADCODE same case as before.
ln:531 DEADCODE The fn segment_list_has_prefix return status wasn't captured so "status" is always CMD_SUCCESS.

pathd.c
ln:203: REVERSE_INULL Check of "segment" is done after dereferencing it.

path_pcep_pcc.c 
ln:1275: USE_AFTER_FREE. Access to path->name after pcep_free_path().


Signed-off-by: Javier Garcia <javier.garcia@voltanet.io>