### PR TITLE
bgpd, yang: fix replace-as yang leaf

### DIFF
--- a/bgpd/bgp_nb.c
+++ b/bgpd/bgp_nb.c
@@ -635,9 +635,9 @@ const struct frr_yang_module_info frr_bgp_info = {
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/neighbors/neighbor/local-as/no-replace-as",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/neighbors/neighbor/local-as/replace-as",
 			.cbs = {
-				.modify = bgp_neighbors_neighbor_local_as_no_replace_as_modify,
+				.modify = bgp_neighbors_neighbor_local_as_replace_as_modify,
 			}
 		},
 		{
@@ -925,9 +925,9 @@ const struct frr_yang_module_info frr_bgp_info = {
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/neighbors/unnumbered-neighbor/local-as/no-replace-as",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/neighbors/unnumbered-neighbor/local-as/replace-as",
 			.cbs = {
-				.modify = bgp_neighbors_unnumbered_neighbor_local_as_no_replace_as_modify,
+				.modify = bgp_neighbors_unnumbered_neighbor_local_as_replace_as_modify,
 			}
 		},
 		{
@@ -1216,9 +1216,9 @@ const struct frr_yang_module_info frr_bgp_info = {
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/peer-groups/peer-group/local-as/no-replace-as",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/peer-groups/peer-group/local-as/replace-as",
 			.cbs = {
-				.modify = bgp_peer_groups_peer_group_local_as_no_replace_as_modify,
+				.modify = bgp_peer_groups_peer_group_local_as_replace_as_modify,
 			}
 		},
 		{

--- a/bgpd/bgp_nb.h
+++ b/bgpd/bgp_nb.h
@@ -233,7 +233,7 @@ int bgp_neighbors_neighbor_local_as_local_as_destroy(
 	struct nb_cb_destroy_args *args);
 int bgp_neighbors_neighbor_local_as_no_prepend_modify(
 	struct nb_cb_modify_args *args);
-int bgp_neighbors_neighbor_local_as_no_replace_as_modify(
+int bgp_neighbors_neighbor_local_as_replace_as_modify(
 	struct nb_cb_modify_args *args);
 int bgp_neighbors_neighbor_bfd_options_enable_modify(
 	struct nb_cb_modify_args *args);
@@ -365,7 +365,7 @@ int bgp_neighbors_unnumbered_neighbor_local_as_local_as_destroy(
 	struct nb_cb_destroy_args *args);
 int bgp_neighbors_unnumbered_neighbor_local_as_no_prepend_modify(
 	struct nb_cb_modify_args *args);
-int bgp_neighbors_unnumbered_neighbor_local_as_no_replace_as_modify(
+int bgp_neighbors_unnumbered_neighbor_local_as_replace_as_modify(
 	struct nb_cb_modify_args *args);
 int bgp_neighbors_unnumbered_neighbor_bfd_options_enable_modify(
 	struct nb_cb_modify_args *args);
@@ -497,7 +497,7 @@ int bgp_peer_groups_peer_group_local_as_local_as_destroy(
 	struct nb_cb_destroy_args *args);
 int bgp_peer_groups_peer_group_local_as_no_prepend_modify(
 	struct nb_cb_modify_args *args);
-int bgp_peer_groups_peer_group_local_as_no_replace_as_modify(
+int bgp_peer_groups_peer_group_local_as_replace_as_modify(
 	struct nb_cb_modify_args *args);
 int bgp_peer_groups_peer_group_bfd_options_enable_modify(
 	struct nb_cb_modify_args *args);

--- a/bgpd/bgp_nb_config.c
+++ b/bgpd/bgp_nb_config.c
@@ -3472,9 +3472,8 @@ void bgp_neighbors_neighbor_local_as_apply_finish(
 		as = yang_dnode_get_uint32(args->dnode, "./local-as");
 	if (yang_dnode_exists(args->dnode, "./no-prepend"))
 		no_prepend = yang_dnode_get_bool(args->dnode, "./no-prepend");
-	if (yang_dnode_exists(args->dnode, "./no-replace-as"))
-		replace_as =
-			yang_dnode_get_bool(args->dnode, "./no-replace-as");
+	if (yang_dnode_exists(args->dnode, "./replace-as"))
+		replace_as = yang_dnode_get_bool(args->dnode, "./replace-as");
 
 	if (!as && !no_prepend && !replace_as)
 		ret = peer_local_as_unset(peer);
@@ -3557,9 +3556,9 @@ int bgp_neighbors_neighbor_local_as_no_prepend_modify(
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/neighbors/neighbor/local-as/no-replace-as
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/neighbors/neighbor/local-as/replace-as
  */
-int bgp_neighbors_neighbor_local_as_no_replace_as_modify(
+int bgp_neighbors_neighbor_local_as_replace_as_modify(
 	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
@@ -5491,9 +5490,8 @@ void bgp_neighbors_unnumbered_neighbor_local_as_apply_finish(
 		as = yang_dnode_get_uint32(args->dnode, "./local-as");
 	if (yang_dnode_exists(args->dnode, "./no-prepend"))
 		no_prepend = yang_dnode_get_bool(args->dnode, "./no-prepend");
-	if (yang_dnode_exists(args->dnode, "./no-replace-as"))
-		replace_as =
-			yang_dnode_get_bool(args->dnode, "./no-replace-as");
+	if (yang_dnode_exists(args->dnode, "./replace-as"))
+		replace_as = yang_dnode_get_bool(args->dnode, "./replace-as");
 
 	if (!as && !no_prepend && !replace_as)
 		ret = peer_local_as_unset(peer);
@@ -5558,9 +5556,9 @@ int bgp_neighbors_unnumbered_neighbor_local_as_no_prepend_modify(
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/neighbors/unnumbered-neighbor/local-as/no-replace-as
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/neighbors/unnumbered-neighbor/local-as/replace-as
  */
-int bgp_neighbors_unnumbered_neighbor_local_as_no_replace_as_modify(
+int bgp_neighbors_unnumbered_neighbor_local_as_replace_as_modify(
 	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
@@ -7378,9 +7376,8 @@ void bgp_peer_groups_peer_group_local_as_apply_finish(
 		as = yang_dnode_get_uint32(args->dnode, "./local-as");
 	if (yang_dnode_exists(args->dnode, "./no-prepend"))
 		no_prepend = yang_dnode_get_bool(args->dnode, "./no-prepend");
-	if (yang_dnode_exists(args->dnode, "./no-replace-as"))
-		replace_as =
-			yang_dnode_get_bool(args->dnode, "./no-replace-as");
+	if (yang_dnode_exists(args->dnode, "./replace-as"))
+		replace_as = yang_dnode_get_bool(args->dnode, "./replace-as");
 
 	if (!as && !no_prepend && !replace_as)
 		ret = peer_local_as_unset(peer);
@@ -7460,9 +7457,9 @@ int bgp_peer_groups_peer_group_local_as_no_prepend_modify(
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/peer-groups/peer-group/local-as/no-replace-as
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-bgp:bgp/peer-groups/peer-group/local-as/replace-as
  */
-int bgp_peer_groups_peer_group_local_as_no_replace_as_modify(
+int bgp_peer_groups_peer_group_local_as_replace_as_modify(
 	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -4829,7 +4829,7 @@ DEFUN_YANG(
 			      argv[idx_number]->arg);
 	nb_cli_enqueue_change(vty, "./local-as/no-prepend", NB_OP_MODIFY,
 			      "true");
-	nb_cli_enqueue_change(vty, "./local-as/no-replace-as", NB_OP_MODIFY,
+	nb_cli_enqueue_change(vty, "./local-as/replace-as", NB_OP_MODIFY,
 			      "true");
 
 	return nb_cli_apply_changes(vty, base_xpath);
@@ -4855,7 +4855,7 @@ DEFUN_YANG(no_neighbor_local_as,
 	nb_cli_enqueue_change(vty, "./local-as/local-as", NB_OP_DESTROY, NULL);
 	nb_cli_enqueue_change(vty, "./local-as/no-prepend", NB_OP_MODIFY,
 			      "false");
-	nb_cli_enqueue_change(vty, "./local-as/no-replace-as", NB_OP_MODIFY,
+	nb_cli_enqueue_change(vty, "./local-as/replace-as", NB_OP_MODIFY,
 			      "false");
 
 	return nb_cli_apply_changes(vty, base_xpath);

--- a/yang/frr-bgp-common-structure.yang
+++ b/yang/frr-bgp-common-structure.yang
@@ -124,7 +124,7 @@ submodule frr-bgp-common-structure {
            set to 'false' it will prepend local-as to updates.";
       }
 
-      leaf no-replace-as {
+      leaf replace-as {
         type boolean;
         default "false";
         description


### PR DESCRIPTION
The leaf is called "no-replace-as" in the model but is used reversed in
all the code. Let's rename it to comply with the actual behavior.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>