### PR TITLE
pathd: Fix affinity command to exclude options to match implementation.

### DIFF
--- a/doc/user/pathd.rst
+++ b/doc/user/pathd.rst
@@ -149,7 +149,7 @@ Configuration Commands
    Delete or start a dynamic candidate path definition.
 
 
-.. clicmd:: affinity {exclude-any|include-any|include-all} BITPATTERN
+.. clicmd:: affinity <exclude-any|include-any|include-all> BITPATTERN
 
    Delete or specify an affinity constraint for a dynamic candidate path.
 

--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -821,9 +821,8 @@ DEFPY(srte_candidate_no_bandwidth,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-DEFPY(srte_candidate_affinity_filter,
-      srte_candidate_affinity_filter_cmd,
-      "affinity {exclude-any|include-any|include-all}$type BITPATTERN$value",
+DEFPY(srte_candidate_affinity_filter, srte_candidate_affinity_filter_cmd,
+      "affinity <exclude-any|include-any|include-all>$type BITPATTERN$value",
       "Affinity constraint\n"
       "Exclude any matching link\n"
       "Include any matching link\n"
@@ -846,9 +845,8 @@ DEFPY(srte_candidate_affinity_filter,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-DEFPY(srte_candidate_no_affinity_filter,
-      srte_candidate_no_affinity_filter_cmd,
-      "no affinity {exclude-any|include-any|include-all}$type [BITPATTERN$value]",
+DEFPY(srte_candidate_no_affinity_filter, srte_candidate_no_affinity_filter_cmd,
+      "no affinity <exclude-any|include-any|include-all>$type [BITPATTERN$value]",
       NO_STR
       "Affinity constraint\n"
       "Exclude any matching link\n"


### PR DESCRIPTION
From "{}" to "<>" to provide mutual exclusion.

Signed-off-by: Javier Garcia <javier.garcia@voltanet.io>