### PR TITLE
bgpd: fix display of timers when only 1 is changed

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17754,7 +17754,7 @@ int bgp_config_write(struct vty *vty)
 
 		/* BGP timers configuration. */
 		if (bgp->default_keepalive != SAVE_BGP_KEEPALIVE
-		    && bgp->default_holdtime != SAVE_BGP_HOLDTIME)
+		    || bgp->default_holdtime != SAVE_BGP_HOLDTIME)
 			vty_out(vty, " timers bgp %u %u\n",
 				bgp->default_keepalive, bgp->default_holdtime);
 


### PR DESCRIPTION
When only one of the keepalive or hold timers is changed from the
default, bgp won't print the timers command in the config.

Signed-off-by: Quentin Young <qlyoung@nvidia.com>