### PR TITLE
bgpd: recalc peer's sort after changing confed peers

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -671,6 +671,7 @@ int bgp_confederation_peers_add(struct bgp *bgp, as_t as)
 	if (bgp_config_check(bgp, BGP_CONFIG_CONFEDERATION)) {
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 			if (peer->as == as) {
+				(void)peer_sort(peer);
 				peer->local_as = bgp->as;
 				if (BGP_IS_VALID_STATE_FOR_NOTIF(
 					    peer->status)) {
@@ -722,6 +723,7 @@ int bgp_confederation_peers_remove(struct bgp *bgp, as_t as)
 	if (bgp_config_check(bgp, BGP_CONFIG_CONFEDERATION)) {
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 			if (peer->as == as) {
+				(void)peer_sort(peer);
 				peer->local_as = bgp->confed_id;
 				if (BGP_IS_VALID_STATE_FOR_NOTIF(
 					    peer->status)) {


### PR DESCRIPTION
Currently, when AS number of an existing BGP neighbor is added in a BGP
confederation, `AS_CONFED_SEQUENCE` segment attribute will be missing in
prefixes advertised to the neighbor. Also, receiving prefixes from the
neighbor will be withdrawn because of "Malformed AS path from A.B.C.D".

    neighbor 10.100.200.3 remote-as 123
    bgp confederation identifier 65001
    bgp confederation peers 123

With this change, update peer's sort after adding or removing its AS
number in a BGP confederation.