### PR TITLE
bgpd: add show bgp summary filter by neighbor or AS

### DIFF
--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -185,7 +185,8 @@ extern int bgp_vty_find_and_parse_afi_safi_bgp(struct vty *vty,
 int bgp_vty_find_and_parse_bgp(struct vty *vty, struct cmd_token **argv,
 			       int argc, struct bgp **bgp, bool use_json);
 extern int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
-				safi_t safi, uint8_t show_flags);
+				safi_t safi, const char *neighbor, int as_type,
+				as_t as, uint8_t show_flags);
 extern int bgp_clear_star_soft_in(const char *name, char *errmsg,
 				  size_t errmsg_len);
 extern int bgp_clear_star_soft_out(const char *name, char *errmsg,

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3284,6 +3284,19 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
    Show a bgp peer summary for peers that are succesfully exchanging routes
    for the specified address family, and subsequent address-family.
 
+.. clicmd:: show bgp [afi] [safi] [all] summary neighbor [PEER] [json]
+
+   Show a bgp summary for the specified peer, address family, and
+   subsequent address-family. The neighbor filter can be used in combination
+   with the failed, established filters.
+
+.. clicmd:: show bgp [afi] [safi] [all] summary remote-as <internal|external|ASN> [json]
+
+   Show a bgp peer summary for the specified remote-as ASN or type (``internal``
+   for iBGP and ``external`` for eBGP sessions), address family, and subsequent
+   address-family. The remote-as filter can be used in combination with the
+   failed, established filters.
+
 .. clicmd:: show bgp [afi] [safi] [neighbor [PEER] [routes|advertised-routes|received-routes] [json]
 
    This command shows information on a specific BGP peer of the relevant


### PR DESCRIPTION
Add ability to filter session on show bgp summary by neighbor or
remote AS:

ubuntu# show bgp summary ?
  neighbor     Show only the specified neighbor session
  remote-as    Show only the specified remote AS session
ubuntu# show bgp summary neighbor ?
  A.B.C.D   Neighbor to display information about
  WORD      Neighbor on BGP configured interface
  X:X::X:X  Neighbor to display information about
ubuntu# show bgp summary remote-as ?
  (1-4294967295)  AS number
  external        External (eBGP) AS sessions
  internal        Internal (iBGP) AS sessions

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>