### PR TITLE
ripd, ripngd: fix interface wakeup after shutdown

### DIFF
--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -493,6 +493,9 @@ int rip_if_down(struct interface *ifp)
 	struct listnode *listnode = NULL, *nextnode = NULL;
 
 	ri = ifp->info;
+
+	THREAD_OFF(ri->t_wakeup);
+
 	rip = ri->rip;
 	if (rip) {
 		for (rp = route_top(rip->table); rp; rp = route_next(rp))

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -169,6 +169,9 @@ static int ripng_if_down(struct interface *ifp)
 	struct listnode *listnode = NULL, *nextnode = NULL;
 
 	ri = ifp->info;
+
+	THREAD_OFF(ri->t_wakeup);
+
 	ripng = ri->ripng;
 
 	if (ripng)


### PR DESCRIPTION
RIP schedules a call to `rip_interface_wakeup` in 1 second after
receiving the interface UP event from zebra. The function is called even
if the interface was shut down during this interval.

This is incorrect and also leads to a crash in the following scenario:
```
vtysh -c "conf" -c "router rip vrf red" -c "network enp2s0"
ip link add red type vrf table 1
ip link set enp2s0 vrf red
ip link set enp2s0 down
ip link set enp2s0 up && ip link del red
```