### PR TITLE
ospfd, ospf6d: fix "default-information originate" in non-existing vrf

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -156,6 +156,16 @@ static void ospf6_set_redist_vrf_bitmaps(struct ospf6 *ospf6, bool set)
 			vrf_bitmap_unset(zclient->redist[AFI_IP6][type],
 					 ospf6->vrf_id);
 	}
+
+	red_list = ospf6->redist[DEFAULT_ROUTE];
+	if (red_list) {
+		if (set)
+			vrf_bitmap_set(zclient->default_information[AFI_IP6],
+				       ospf6->vrf_id);
+		else
+			vrf_bitmap_unset(zclient->default_information[AFI_IP6],
+					 ospf6->vrf_id);
+	}
 }
 
 /* Disable OSPF6 VRF instance */

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -2182,6 +2182,16 @@ static void ospf_set_redist_vrf_bitmaps(struct ospf *ospf, bool set)
 			vrf_bitmap_unset(zclient->redist[AFI_IP][type],
 					 ospf->vrf_id);
 	}
+
+	red_list = ospf->redist[DEFAULT_ROUTE];
+	if (red_list) {
+		if (set)
+			vrf_bitmap_set(zclient->default_information[AFI_IP],
+				       ospf->vrf_id);
+		else
+			vrf_bitmap_unset(zclient->default_information[AFI_IP],
+					 ospf->vrf_id);
+	}
 }
 
 /* Enable OSPF VRF instance */


### PR DESCRIPTION
If the default route redistribution is configured in OSPF router before
the VRF is created, then this is not currently registered in zebra after
the VRF creation.