### PR TITLE
tests: Fix for multicast_pim_sm test failure

### DIFF
--- a/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
+++ b/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
@@ -1676,7 +1676,8 @@ def test_verify_mroute_when_5_different_receiver_joining_same_sources_p0(request
 
     source = topo["routers"]["i3"]["links"]["r2"]["ipv4"].split("/")[0]
     input_dict_all = [
-        {"dut": "l1", "src_address": source, "iif": "l1-r2-eth4", "oil": "l1-i1-eth1"},
+        {"dut": "l1", "src_address": source, "iif": ["l1-r2-eth4", "l1-c1-eth0"],
+            "oil": ["l1-i1-eth1", "l1-i6-eth2"]},
         {"dut": "f1", "src_address": source, "iif": "f1-r2-eth3", "oil": "f1-i8-eth2"},
     ]
     for data in input_dict_all:


### PR DESCRIPTION
Test case test_verify_mroute_when_5_different_receiver_joining_same_sources_p0
is failing intermittently in master. Fixed the issue.

Weekly statistics for the reference:
===== WEEK FROM 2021-05-04 TO 2021-05-11 (108637) FRR-FRR =====
===== TESTS BY FAILURE RATE [rank: name (total, passed, failed, failure rate)] (126) =====
 1: bgp_ipv6_rtadv (235, 234, 1,  0.43%)
    * test_protocols_convergence (https://ci1.netdef.org/browse/FRR-FRR-4633)
 2: bfd-topo3 (359, 358, 1,  0.28%)
    * test_wait_bfd_convergence (https://ci1.netdef.org/browse/FRR-FRR-4653)
 3: ospf6-topo2 (359, 358, 1,  0.28%)
    * test_ospf6_default_route (https://ci1.netdef.org/browse/FRR-FRR-4632)
 4: bgp_gr_functionality_topo1 (2246, 2241, 5,  0.22%)
    * test_BGP_GR_TC_46_p1 (https://ci1.netdef.org/browse/FRR-FRR-4630)
    * test_BGP_GR_TC_46_p1 (https://ci1.netdef.org/browse/FRR-FRR-4634)
    * test_BGP_GR_TC_46_p1 (https://ci1.netdef.org/browse/FRR-FRR-4645)
    * test_BGP_GR_TC_46_p1 (https://ci1.netdef.org/browse/FRR-FRR-4646)
    * test_BGP_GR_TC_46_p1 (https://ci1.netdef.org/browse/FRR-FRR-4647)
 5: ospf-sr-topo1 (2450, 2445, 5,  0.20%)
    * test_rib_ipv4_step4 (https://ci1.netdef.org/browse/FRR-FRR-4625)
    * test_rib_ipv4_step4 (https://ci1.netdef.org/browse/FRR-FRR-4627)
    * test_rib_ipv4_step4 (https://ci1.netdef.org/browse/FRR-FRR-4634)
    * test_rib_ipv4_step4 (https://ci1.netdef.org/browse/FRR-FRR-4640)
    * test_rib_ipv4_step4 (https://ci1.netdef.org/browse/FRR-FRR-4643)
 6: bgp-auth (2278, 2274, 4,  0.18%)
    * test_prefix_peer_remove_passwords (https://ci1.netdef.org/browse/FRR-FRR-4632)
    * test_prefix_peer_remove_passwords (https://ci1.netdef.org/browse/FRR-FRR-4633)
    * test_vrf_prefix_peer_change_passwords (https://ci1.netdef.org/browse/FRR-FRR-4645)
    * test_vrf_prefix_peer_remove_passwords (https://ci1.netdef.org/browse/FRR-FRR-4646)
 7: multicast-pim-sm-topo2 (951, 950, 1,  0.11%)
    * test_verify_mroute_when_5_different_receiver_joining_same_sources_p0 (https://ci1.netdef.org/browse/FRR-FRR-4632)
 8: bgp_features (3310, 3308, 2,  0.06%)
    * test_bgp_delayopen_dual (https://ci1.netdef.org/browse/FRR-FRR-4629)
    * test_bgp_delayopen_dual (https://ci1.netdef.org/browse/FRR-FRR-4630)

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>