### PR TITLE
yang: fix BGP multicast prefix specification

### DIFF
--- a/yang/frr-bgp.yang
+++ b/yang/frr-bgp.yang
@@ -11,16 +11,16 @@ module frr-bgp {
     prefix inet;
   }
 
-  import ietf-routing-types {
-    prefix rt-types;
-  }
-
   import frr-interface {
     prefix frr-interface;
   }
 
   import frr-bgp-types {
     prefix frr-bt;
+  }
+
+  import frr-route-types {
+    prefix frr-route-types;
   }
 
   include "frr-bgp-common";
@@ -405,7 +405,7 @@ module frr-bgp {
       description
         "A list of network routes.";
       leaf prefix {
-        type rt-types:ipv4-multicast-group-address;
+        type frr-route-types:ipv4-multicast-group-prefix;
         description
           "IPv4 multicast destination prefix.";
       }
@@ -425,7 +425,7 @@ module frr-bgp {
       description
         "A list of aggregated routes.";
       leaf prefix {
-        type rt-types:ipv4-multicast-group-address;
+        type frr-route-types:ipv4-multicast-group-prefix;
         description
           "IPv4 multicast destination prefix.";
       }
@@ -438,7 +438,7 @@ module frr-bgp {
       description
         "A list of routes with a particular admin distance.";
       leaf prefix {
-        type rt-types:ipv4-multicast-group-address;
+        type frr-route-types:ipv4-multicast-group-prefix;
         description
           "IPv4 multicast destination prefix.";
       }
@@ -459,7 +459,7 @@ module frr-bgp {
       description
         "A list of network routes.";
       leaf prefix {
-        type rt-types:ipv6-multicast-group-address;
+        type frr-route-types:ipv6-multicast-group-prefix;
         description
           "IPv6 multicast destination prefix.";
       }
@@ -479,7 +479,7 @@ module frr-bgp {
       description
         "A list of aggregated routes.";
       leaf prefix {
-        type rt-types:ipv6-multicast-group-address;
+        type frr-route-types:ipv6-multicast-group-prefix;
         description
           "IPv6 multicast destination prefix.";
       }
@@ -492,7 +492,7 @@ module frr-bgp {
       description
         "A list of routes with a particular admin distance.";
       leaf prefix {
-        type rt-types:ipv6-multicast-group-address;
+        type frr-route-types:ipv6-multicast-group-prefix;
         description
           "IPv6 multicast destination prefix.";
       }

--- a/yang/frr-pim-rp.yang
+++ b/yang/frr-pim-rp.yang
@@ -8,16 +8,16 @@ module frr-pim-rp {
     prefix "inet";
   }
 
-  import ietf-routing-types {
-    prefix "rt-types";
-  }
-
   import frr-routing {
     prefix "frr-rt";
   }
 
   import frr-pim {
     prefix "frr-pim";
+  }
+
+  import frr-route-types {
+    prefix frr-route-types;
   }
 
   organization
@@ -63,37 +63,6 @@ module frr-pim-rp {
       "RFC XXXX: A YANG Data Model for PIM RP";
   }
 
-  typedef ipv4-multicast-group-address-prefix {
-    type inet:ipv4-prefix{
-      pattern '(2((2[4-9])|(3[0-9]))\.)(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){2}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(/(([4-9])|([1-2][0-9])|(3[0-2])))';
-    }
-    description
-      "This type represents an IPv4 multicast group prefix,
-       which is in the range from 224.0.0.0 to 239.255.255.255.";
-    }
-
-  typedef ipv6-multicast-group-address-prefix {
-    type inet:ipv6-prefix {
-      pattern
-        '(((FF|ff)[0-9a-fA-F]{2}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(/((1[6-9])|([2-9][0-9])|(1[0-1][0-9])|(12[0-8])))';
-      pattern
-        '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(/.+)';
-    }
-    description
-      "This type represents an IPv6 multicast group prefix,
-       which is in the range of FF00::/8.";
-  }
-
-  typedef ip-multicast-group-address-prefix {
-    description "The IP-Multicast-Group-Address-Prefix type represents an IP multicast address
-    prefix and is IP version neutral. The format of the textual representations implies the IP
-    version. It includes a prefix-length, separated by a '/' sign.";
-    type union {
-      type ipv4-multicast-group-address-prefix;
-      type ipv6-multicast-group-address-prefix;
-    }
-  } // typedef ip-multicast-group-address-prefix
-
   typedef plist-ref {
     type string;
   }
@@ -124,7 +93,7 @@ module frr-pim-rp {
           description "Use group-list or prefix-list";
           case group-list {
             leaf-list group-list{
-              type ip-multicast-group-address-prefix;  
+              type frr-route-types:ip-multicast-group-prefix;
               description
                 "List of multicast group address.";
             }

--- a/yang/frr-route-types.yang
+++ b/yang/frr-route-types.yang
@@ -3,6 +3,10 @@ module frr-route-types {
   namespace "http://frrouting.org/yang/route-types";
   prefix frr-route-types;
 
+  import ietf-inet-types {
+    prefix inet;
+  }
+
   organization
     "FRRouting";
   contact
@@ -143,6 +147,37 @@ module frr-route-types {
     type union {
       type frr-route-types-v4;
       type frr-route-types-v6;
+    }
+  }
+
+  typedef ipv4-multicast-group-prefix {
+    type inet:ipv4-prefix {
+      pattern '(2((2[4-9])|(3[0-9]))\.)(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){2}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(/(([4-9])|([1-2][0-9])|(3[0-2])))';
+    }
+    description
+      "This type represents an IPv4 multicast group prefix,
+       which is in the range from 224.0.0.0 to 239.255.255.255.";
+  }
+
+  typedef ipv6-multicast-group-prefix {
+    type inet:ipv6-prefix {
+      pattern
+        '(((FF|ff)[0-9a-fA-F]{2}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(/((1[6-9])|([2-9][0-9])|(1[0-1][0-9])|(12[0-8])))';
+      pattern
+        '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(/.+)';
+    }
+    description
+      "This type represents an IPv6 multicast group prefix,
+       which is in the range of FF00::/8.";
+  }
+
+  typedef ip-multicast-group-prefix {
+    description "The IP-Multicast-Group-Address-Prefix type represents an IP multicast address
+    prefix and is IP version neutral. The format of the textual representations implies the IP
+    version. It includes a prefix-length, separated by a '/' sign.";
+    type union {
+      type ipv4-multicast-group-prefix;
+      type ipv6-multicast-group-prefix;
     }
   }
 }


### PR DESCRIPTION
Summary
---

Fix the command `network` for multicast prefixes in `address-family ipv4 multicast`.

The YANG model was using the pattern for **address** instead of **prefix**.


Example
---

```
router bgp 65000
 address-family ipv4 multicast
  network 224.0.10.0/24
% Failed to edit configuration.

YANG error(s):
 Value "224.0.10.0/24" does not satisfy the constraint "(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?" (range, length, or pattern).
 Value "224.0.10.0/24" does not satisfy the constraint "(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?" (range, length, or pattern).
 YANG path: /frr-bgp:prefix
```