### PR TITLE
ospfd: fix SID/Label Sub TLV size

### DIFF
--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -447,8 +447,7 @@ static void set_sr_global_label_range(struct sr_block srgb)
 {
 	/* Set Header */
 	TLV_TYPE(OspfRI.sr_info.srgb) = htons(RI_SR_TLV_SRGB_LABEL_RANGE);
-	TLV_LEN(OspfRI.sr_info.srgb) =
-		htons(SUBTLV_SID_LABEL_SIZE + sizeof(uint32_t));
+	TLV_LEN(OspfRI.sr_info.srgb) = htons(RI_SR_TLV_LABEL_RANGE_SIZE);
 	/* Set Range Size */
 	OspfRI.sr_info.srgb.size = htonl(SET_RANGE_SIZE(srgb.range_size));
 	/* Set Lower bound label SubTLV */
@@ -471,8 +470,7 @@ static void set_sr_local_label_range(struct sr_block srlb)
 {
 	/* Set Header */
 	TLV_TYPE(OspfRI.sr_info.srlb) = htons(RI_SR_TLV_SRLB_LABEL_RANGE);
-	TLV_LEN(OspfRI.sr_info.srlb) =
-		htons(SUBTLV_SID_LABEL_SIZE + sizeof(uint32_t));
+	TLV_LEN(OspfRI.sr_info.srlb) = htons(RI_SR_TLV_LABEL_RANGE_SIZE);
 	/* Set Range Size */
 	OspfRI.sr_info.srlb.size = htonl(SET_RANGE_SIZE(srlb.range_size));
 	/* Set Lower bound label SubTLV */

--- a/ospfd/ospf_sr.h
+++ b/ospfd/ospf_sr.h
@@ -61,7 +61,7 @@
 
 /* SID/Label Sub TLV - section 2.1 */
 #define SUBTLV_SID_LABEL		1
-#define SUBTLV_SID_LABEL_SIZE		8
+#define SUBTLV_SID_LABEL_SIZE		4
 struct subtlv_sid_label {
 	/* Length is 3 (20 rightmost bits MPLS label) or 4 (32 bits SID) */
 	struct tlv_header header;
@@ -88,6 +88,7 @@ struct ri_sr_tlv_sr_algorithm {
 /* RI SID/Label Range TLV used for SRGB & SRLB - section 3.2 & 3.3 */
 #define RI_SR_TLV_SRGB_LABEL_RANGE	9
 #define RI_SR_TLV_SRLB_LABEL_RANGE	14
+#define RI_SR_TLV_LABEL_RANGE_SIZE	12
 struct ri_sr_tlv_sid_label_range {
 	struct tlv_header header;
 /* Only 24 upper most bits are significant */


### PR DESCRIPTION
Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>

I think this may be the reason for `ospf_sr_topo1` frequent fails.