### PR TITLE
zebra: fix possible uninitialized value

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -277,7 +277,7 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 	 * resolve to the same network and mask
 	 */
 	for (ALL_LIST_ELEMENTS_RO(ifp->connected, cnode, c)) {
-		struct prefix cp;
+		struct prefix cp = {0};
 
 		PREFIX_COPY(&cp, CONNECTED_PREFIX(c));
 		apply_mask(&cp);


### PR DESCRIPTION
Found by Coverity.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>