### PR TITLE
Revert "bgpd: When deleting a neighbor from a peer-group the PGNAME i…

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5070,7 +5070,7 @@ ALIAS_HIDDEN(neighbor_set_peer_group, neighbor_set_peer_group_hidden_cmd,
 
 DEFUN_YANG (no_neighbor_set_peer_group,
 	    no_neighbor_set_peer_group_cmd,
-	    "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group [PGNAME]",
+	    "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group PGNAME",
 	    NO_STR
 	    NEIGHBOR_STR
 	    NEIGHBOR_ADDR_STR2
@@ -5091,7 +5091,7 @@ DEFUN_YANG (no_neighbor_set_peer_group,
 }
 
 ALIAS_HIDDEN(no_neighbor_set_peer_group, no_neighbor_set_peer_group_hidden_cmd,
-	     "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group [PGNAME]",
+	     "no neighbor <A.B.C.D|X:X::X:X|WORD> peer-group PGNAME",
 	     NO_STR NEIGHBOR_STR NEIGHBOR_ADDR_STR2
 	     "Member of the peer-group\n"
 	     "Peer-group name\n")


### PR DESCRIPTION
…s optional"

This reverts commit 2cbd181ac99801f2fb6b5b820ad66626c0f7168a.

We also have "no neighbor WORD peer-group" command and it's impossible
to distinguish between those two commands if PGNAME is optional.