### PR TITLE
lib: fix northbound merge code (libyang)

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -336,7 +336,7 @@ int nb_config_merge(struct nb_config *config_dst, struct nb_config *config_src,
 {
 	int ret;
 
-	ret = lyd_merge_tree(&config_dst->dnode, config_src->dnode, 0);
+	ret = lyd_merge_siblings(&config_dst->dnode, config_src->dnode, 0);
 	if (ret != 0)
 		flog_warn(EC_LIB_LIBYANG, "%s: lyd_merge() failed", __func__);
 


### PR DESCRIPTION
lyd_merge_tree replaces dest siblings with source siblings, not what we
want. Instead lyd_merge_siblings to keep both. Instead lyd_merge_siblings
to keep both.

Signed-off-by: Christian Hopps <chopps@labn.net>