### PR TITLE
lib: fix handling of rmap prefix-tree default node

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1982,7 +1982,15 @@ static void route_map_add_plist_entries(afi_t afi,
 		return;
 	}
 
-	route_map_pfx_table_del_default(afi, index);
+	/* Default entry should be deleted only if the first entry of the
+	 * prefix-list is created.
+	 */
+	if (entry) {
+		if (plist->count == 1)
+			route_map_pfx_table_del_default(afi, index);
+	} else {
+		route_map_pfx_table_del_default(afi, index);
+	}
 
 	if (entry) {
 		if (afi == AFI_IP) {


### PR DESCRIPTION
Prior to this commit, updating a prefix-list that is referenced by a
route-map clause will unconditionally delete the root node of that
route-map's prefix-tree (used with route-map optimization).
This is problematic because routes not matching a more specific node
in the tree (i.e. other prefix-list sequences) will not fall-back to
the default node, thus they will not hit any route-map sequences.
This commit ensures that an update to a prefix-list will only delete
the default node while adding the first/only seq to the list.

Example config:
========
ip prefix-list peer475-out-pfxlist seq 45 permit 2.138.0.0/16
ip prefix-list peer475-out-pfxlist seq 50 permit 0.0.0.0/0
!
route-map peer475-out permit 5
 match ip address prefix-list peer475-out-pfxlist

Before:
========
ub20# do show route-map peer475-out prefix-table
ZEBRA:

IPv4 Prefix                                           Route-map Index List
_______________                                       ____________________
    0.0.0.0/0 (2)
(P)
                                                      peer475-out seq 5

    2.138.0.0/16 (2)
(P) 0.0.0.0/0

                                                      peer475-out seq 5
IPv6 Prefix                                           Route-map Index List
_______________                                       ____________________
BGP:
IPv4 Prefix                                           Route-map Index List
_______________                                       ____________________
    0.0.0.0/0 (2)
(P)
                                                      peer475-out seq 5
    2.138.0.0/16 (2)
(P) 0.0.0.0/0
                                                      peer475-out seq 5
IPv6 Prefix                                           Route-map Index List
_______________                                       ____________________
ub20# conf t
ub20(config)# ip prefix-list peer475-out-pfxlist seq 45 permit 2.138.0.0/16 le 32
ub20(config)# do show route-map peer475-out prefix-table
ZEBRA:
IPv4 Prefix                                           Route-map Index List
_______________                                       ____________________
    2.138.0.0/16 (2)
(P)
                                                      peer475-out seq 5
IPv6 Prefix                                           Route-map Index List
_______________                                       ____________________
BGP:
IPv4 Prefix                                           Route-map Index List
_______________                                       ____________________
    2.138.0.0/16 (2)
(P)
                                                      peer475-out seq 5
IPv6 Prefix                                           Route-map Index List
_______________                                       ____________________
ub20(config)#

After:
========
ub20(config)# do show route-map peer475-out prefix-table
ZEBRA:

IPv4 Prefix                                           Route-map Index List
_______________                                       ____________________
    0.0.0.0/0 (2)
(P)
                                                      peer475-out seq 5

    2.138.0.0/16 (2)
(P) 0.0.0.0/0

                                                      peer475-out seq 5

IPv6 Prefix                                           Route-map Index List
_______________                                       ____________________

BGP:

IPv4 Prefix                                           Route-map Index List
_______________                                       ____________________
    0.0.0.0/0 (2)
(P)
                                                      peer475-out seq 5

    2.138.0.0/16 (2)
(P) 0.0.0.0/0

                                                      peer475-out seq 5

IPv6 Prefix                                           Route-map Index List
_______________                                       ____________________

ub20(config)# ip prefix-list peer475-out-pfxlist seq 45 permit 2.138.0.0/16 le 32
ub20(config)# do show route-map peer475-out prefix-table
ZEBRA:

IPv4 Prefix                                           Route-map Index List
_______________                                       ____________________
    0.0.0.0/0 (2)
(P)
                                                      peer475-out seq 5

    2.138.0.0/16 (2)
(P) 0.0.0.0/0

                                                      peer475-out seq 5

IPv6 Prefix                                           Route-map Index List
_______________                                       ____________________

BGP:

IPv4 Prefix                                           Route-map Index List
_______________                                       ____________________
    0.0.0.0/0 (2)
(P)
                                                      peer475-out seq 5

    2.138.0.0/16 (2)
(P) 0.0.0.0/0

                                                      peer475-out seq 5

IPv6 Prefix                                           Route-map Index List
_______________                                       ____________________

ub20(config)#

Fixes: 8410
Signed-off-by: Trey Aspelund <taspelund@nvidia.com>