### PR TITLE
bgpd: fix default for extended-nexthop-capability

### DIFF
--- a/yang/frr-bgp-neighbor.yang
+++ b/yang/frr-bgp-neighbor.yang
@@ -90,8 +90,6 @@ submodule frr-bgp-neighbor {
         "Don't send open messages to this neighbor.";
     }
 
-    uses structure-neighbor-group-capability-options;
-
     uses neighbor-update-source;
 
     uses structure-neighbor-group-ebgp-multihop;

--- a/yang/frr-bgp-peer-group.yang
+++ b/yang/frr-bgp-peer-group.yang
@@ -76,6 +76,8 @@ submodule frr-bgp-peer-group {
     uses neighbor-remote-as;
 
     uses neighbor-parameters;
+
+    uses structure-neighbor-group-capability-options;
   }
 
   grouping bgp-peer-group-list {

--- a/yang/frr-bgp.yang
+++ b/yang/frr-bgp.yang
@@ -230,6 +230,8 @@ module frr-bgp {
           }
 
           uses neighbor-parameters;
+
+          uses structure-neighbor-group-capability-options;
         }
 
         list unnumbered-neighbor {
@@ -264,6 +266,12 @@ module frr-bgp {
           uses neighbor-remote-as;
 
           uses neighbor-parameters;
+
+          uses structure-neighbor-group-capability-options {
+            refine "frr-bgp:capability-options/extended-nexthop-capability" {
+              default "true";
+            }
+          }
         }
       }
 


### PR DESCRIPTION
The default for extended-nexthop-capability is true for
unnumbered (interface) neighbors, false for other types. Break the inner
grouping out of the outer neighbor-parameters grouping so that we can
refine the default in that uses case.

Signed-off-by: Christian Hopps <chopps@gmail.com>