### PR TITLE
OSPFv3 socket rework

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -70,6 +70,13 @@ OSPF6 router
    Use this command to control the maximum number of parallel routes that
    OSPFv3 can support. The default is 64.
 
+.. clicmd:: write-multiplier (1-100)
+
+   Use this command to tune the amount of work done in the packet read and
+   write threads before relinquishing control. The parameter is the number
+   of packets to process before returning. The default value of this parameter
+   is 20.
+
 
 .. _ospf6-area:
 

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -299,6 +299,13 @@ To start OSPF process you have to specify the OSPF router.
    a specific destination. The upper limit may differ if you change the value
    of MULTIPATH_NUM during compilation. The default is MULTIPATH_NUM (64).
 
+.. clicmd:: write-multiplier (1-100)
+
+   Use this command to tune the amount of work done in the packet read and
+   write threads before relinquishing control. The parameter is the number
+   of packets to process before returning. The defult value of this parameter
+   is 20.
+
 .. _ospf-area:
 
 Areas

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1985,6 +1985,38 @@ DEFUN (no_auto_cost_reference_bandwidth,
 }
 
 
+DEFUN (ospf6_write_multiplier,
+       ospf6_write_multiplier_cmd,
+       "write-multiplier (1-100)",
+       "Write multiplier\n"
+       "Maximum number of interface serviced per write\n")
+{
+	VTY_DECLVAR_CONTEXT(ospf6, o);
+	uint32_t write_oi_count;
+
+	write_oi_count = strtol(argv[1]->arg, NULL, 10);
+	if (write_oi_count < 1 || write_oi_count > 100) {
+		vty_out(vty, "write-multiplier value is invalid\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	o->write_oi_count = write_oi_count;
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_ospf6_write_multiplier,
+       no_ospf6_write_multiplier_cmd,
+       "no write-multiplier (1-100)",
+       NO_STR
+       "Write multiplier\n"
+       "Maximum number of interface serviced per write\n")
+{
+	VTY_DECLVAR_CONTEXT(ospf6, o);
+
+	o->write_oi_count = OSPF6_WRITE_INTERFACE_COUNT_DEFAULT;
+	return CMD_SUCCESS;
+}
+
 DEFUN (ipv6_ospf6_hellointerval,
        ipv6_ospf6_hellointerval_cmd,
        "ipv6 ospf6 hello-interval (1-65535)",
@@ -2657,6 +2689,9 @@ void ospf6_interface_init(void)
 	/* reference bandwidth commands */
 	install_element(OSPF6_NODE, &auto_cost_reference_bandwidth_cmd);
 	install_element(OSPF6_NODE, &no_auto_cost_reference_bandwidth_cmd);
+	/* write-multiplier commands */
+	install_element(OSPF6_NODE, &ospf6_write_multiplier_cmd);
+	install_element(OSPF6_NODE, &no_ospf6_write_multiplier_cmd);
 }
 
 /* Clear the specified interface structure */

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -121,6 +121,9 @@ struct ospf6_interface {
 
 	struct ospf6_route_table *route_connected;
 
+	/* last hello sent */
+	struct timeval last_hello;
+
 	/* prefix-list name to filter connected prefix */
 	char *plist_name;
 

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -56,6 +56,9 @@ struct ospf6_interface {
 	/* I/F transmission delay */
 	uint32_t transdelay;
 
+	/* Packet send buffer. */
+	struct ospf6_fifo *obuf; /* Output queue */
+
 	/* Network Type */
 	uint8_t type;
 	bool type_cfg;
@@ -129,6 +132,8 @@ struct ospf6_interface {
 		uint32_t min_tx;
 		char *profile;
 	} bfd_config;
+
+	int on_write_q;
 
 	/* Statistics Fields */
 	uint32_t hello_in;

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -264,7 +264,7 @@ static struct ospf6_packet *ospf6_packet_new(size_t size)
 	return new;
 }
 
-void ospf6_packet_free(struct ospf6_packet *op)
+static void ospf6_packet_free(struct ospf6_packet *op)
 {
 	if (op->s)
 		stream_free(op->s);
@@ -327,7 +327,7 @@ static struct ospf6_packet *ospf6_fifo_pop(struct ospf6_fifo *fifo)
 }
 
 /* Return first fifo entry. */
-struct ospf6_packet *ospf6_fifo_head(struct ospf6_fifo *fifo)
+static struct ospf6_packet *ospf6_fifo_head(struct ospf6_fifo *fifo)
 {
 	return fifo->head;
 }
@@ -354,7 +354,8 @@ void ospf6_fifo_free(struct ospf6_fifo *fifo)
 	XFREE(MTYPE_OSPF6_FIFO, fifo);
 }
 
-void ospf6_packet_add(struct ospf6_interface *oi, struct ospf6_packet *op)
+static void ospf6_packet_add(struct ospf6_interface *oi,
+			     struct ospf6_packet *op)
 {
 	/* Add packet to end of queue. */
 	ospf6_fifo_push(oi->obuf, op);
@@ -2137,25 +2138,66 @@ int ospf6_hello_send(struct thread *thread)
 	thread_add_timer(master, ospf6_hello_send, oi, oi->hello_interval,
 			 &oi->thread_send_hello);
 
-	OSPF6_MESSAGE_WRITE_ON(oi->area->ospf6);
+	OSPF6_MESSAGE_WRITE_ON(oi);
 
 	return 0;
+}
+
+static uint16_t ospf6_make_dbdesc(struct ospf6_neighbor *on, struct stream *s)
+{
+	uint16_t length = OSPF6_DB_DESC_MIN_SIZE;
+	struct ospf6_lsa *lsa, *lsanext;
+
+	/* if this is initial one, initialize sequence number for DbDesc */
+	if (CHECK_FLAG(on->dbdesc_bits, OSPF6_DBDESC_IBIT)
+	    && (on->dbdesc_seqnum == 0)) {
+		on->dbdesc_seqnum = monotime(NULL);
+	}
+
+	/* reserved */
+	stream_putc(s, 0); /* reserved 1 */
+	stream_putc(s, on->ospf6_if->area->options[0]);
+	stream_putc(s, on->ospf6_if->area->options[1]);
+	stream_putc(s, on->ospf6_if->area->options[2]);
+	stream_putw(s, on->ospf6_if->ifmtu);
+	stream_putc(s, 0); /* reserved 2 */
+	stream_putc(s, on->dbdesc_bits);
+	stream_putl(s, on->dbdesc_seqnum);
+
+	/* if this is not initial one, set LSA headers in dbdesc */
+	if (!CHECK_FLAG(on->dbdesc_bits, OSPF6_DBDESC_IBIT)) {
+		for (ALL_LSDB(on->dbdesc_list, lsa, lsanext)) {
+			ospf6_lsa_age_update_to_send(lsa,
+						     on->ospf6_if->transdelay);
+
+			/* MTU check */
+			if ((length + sizeof(struct ospf6_lsa_header)
+			     + OSPF6_HEADER_SIZE)
+			    > ospf6_packet_max(on->ospf6_if)) {
+				ospf6_lsa_unlock(lsa);
+				if (lsanext)
+					ospf6_lsa_unlock(lsanext);
+				break;
+			}
+			stream_put(s, lsa->header,
+				   sizeof(struct ospf6_lsa_header));
+			length += sizeof(struct ospf6_lsa_header);
+		}
+	}
+	return length;
 }
 
 int ospf6_dbdesc_send(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_header *oh;
-	struct ospf6_dbdesc *dbdesc;
-	uint8_t *p;
-	struct ospf6_lsa *lsa, *lsanext;
-	struct in6_addr *dst;
+	uint16_t length = OSPF6_HEADER_SIZE;
+	struct ospf6_packet *op;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	on->thread_send_dbdesc = (struct thread *)NULL;
 
 	if (on->state < OSPF6_NEIGHBOR_EXSTART) {
-		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_DBDESC, SEND_HDR))
+		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_DBDESC, SEND))
 			zlog_debug(
 				"Quit to send DbDesc to neighbor %s state %s",
 				on->name, ospf6_neighbor_state_str[on->state]);
@@ -2168,56 +2210,23 @@ int ospf6_dbdesc_send(struct thread *thread)
 				 on->ospf6_if->rxmt_interval,
 				 &on->thread_send_dbdesc);
 
-	memset(sendbuf, 0, iobuflen);
-	oh = (struct ospf6_header *)sendbuf;
-	dbdesc = (struct ospf6_dbdesc *)((caddr_t)oh
-					 + sizeof(struct ospf6_header));
+	op = ospf6_packet_new(on->ospf6_if->ifmtu);
+	ospf6_make_header(OSPF6_MESSAGE_TYPE_DBDESC, on->ospf6_if, op->s);
 
-	/* if this is initial one, initialize sequence number for DbDesc */
-	if (CHECK_FLAG(on->dbdesc_bits, OSPF6_DBDESC_IBIT)
-	    && (on->dbdesc_seqnum == 0)) {
-		on->dbdesc_seqnum = monotime(NULL);
-	}
+	length += ospf6_make_dbdesc(on, op->s);
+	ospf6_fill_header(on->ospf6_if, op->s, length);
 
-	dbdesc->options[0] = on->ospf6_if->area->options[0];
-	dbdesc->options[1] = on->ospf6_if->area->options[1];
-	dbdesc->options[2] = on->ospf6_if->area->options[2];
-	dbdesc->ifmtu = htons(on->ospf6_if->ifmtu);
-	dbdesc->bits = on->dbdesc_bits;
-	dbdesc->seqnum = htonl(on->dbdesc_seqnum);
-
-	/* if this is not initial one, set LSA headers in dbdesc */
-	p = (uint8_t *)((caddr_t)dbdesc + sizeof(struct ospf6_dbdesc));
-	if (!CHECK_FLAG(on->dbdesc_bits, OSPF6_DBDESC_IBIT)) {
-		for (ALL_LSDB(on->dbdesc_list, lsa, lsanext)) {
-			ospf6_lsa_age_update_to_send(lsa,
-						     on->ospf6_if->transdelay);
-
-			/* MTU check */
-			if (p - sendbuf + sizeof(struct ospf6_lsa_header)
-			    > ospf6_packet_max(on->ospf6_if)) {
-				ospf6_lsa_unlock(lsa);
-				if (lsanext)
-					ospf6_lsa_unlock(lsanext);
-				break;
-			}
-			memcpy(p, lsa->header, sizeof(struct ospf6_lsa_header));
-			p += sizeof(struct ospf6_lsa_header);
-		}
-	}
-
-	oh->type = OSPF6_MESSAGE_TYPE_DBDESC;
-	oh->length = htons(p - sendbuf);
-
+	/* Set packet length. */
+	op->length = length;
 
 	if (on->ospf6_if->state == OSPF6_INTERFACE_POINTTOPOINT)
-		dst = &allspfrouters6;
+		op->dst = allspfrouters6;
 	else
-		dst = &on->linklocal_addr;
+		op->dst = on->linklocal_addr;
 
-	on->ospf6_if->db_desc_out++;
+	ospf6_packet_add(on->ospf6_if, op);
 
-	ospf6_send(on->ospf6_if->linklocal_addr, dst, on->ospf6_if, oh);
+	OSPF6_MESSAGE_WRITE_ON(on->ospf6_if);
 
 	return 0;
 }

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -2311,6 +2311,47 @@ static uint16_t ospf6_make_lsreq(struct ospf6_neighbor *on, struct stream *s)
 	return length;
 }
 
+static uint16_t ospf6_make_lsack_neighbor(struct ospf6_neighbor *on,
+					  struct ospf6_packet **op)
+{
+	uint16_t length = 0;
+	struct ospf6_lsa *lsa, *lsanext;
+	int lsa_cnt = 0;
+
+	for (ALL_LSDB(on->lsack_list, lsa, lsanext)) {
+		if ((length + sizeof(struct ospf6_lsa_header)
+		     + OSPF6_HEADER_SIZE)
+		    > ospf6_packet_max(on->ospf6_if)) {
+			/* if we run out of packet size/space here,
+			   better to try again soon. */
+			if (lsa_cnt) {
+				ospf6_fill_header(on->ospf6_if, (*op)->s,
+						  length + OSPF6_HEADER_SIZE);
+
+				(*op)->length = length + OSPF6_HEADER_SIZE;
+				(*op)->dst = on->linklocal_addr;
+				ospf6_packet_add(on->ospf6_if, *op);
+				OSPF6_MESSAGE_WRITE_ON(on->ospf6_if);
+				/* new packet */
+				*op = ospf6_packet_new(on->ospf6_if->ifmtu);
+				ospf6_make_header(OSPF6_MESSAGE_TYPE_LSACK,
+						  on->ospf6_if, (*op)->s);
+				length = 0;
+				lsa_cnt = 0;
+			}
+		}
+		ospf6_lsa_age_update_to_send(lsa, on->ospf6_if->transdelay);
+		stream_put((*op)->s, lsa->header,
+			   sizeof(struct ospf6_lsa_header));
+		length += sizeof(struct ospf6_lsa_header);
+
+		assert(lsa->lock == 2);
+		ospf6_lsdb_remove(lsa, on->lsack_list);
+		lsa_cnt++;
+	}
+	return length;
+}
+
 int ospf6_lsreq_send(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
@@ -2350,7 +2391,7 @@ int ospf6_lsreq_send(struct thread *thread)
 	/* Fill OSPF header. */
 	ospf6_fill_header(on->ospf6_if, op->s, length);
 
-	/* Set packet length. */
+	/* Set packet length */
 	op->length = length;
 
 	if (on->ospf6_if->state == OSPF6_INTERFACE_POINTTOPOINT)
@@ -2679,10 +2720,8 @@ int ospf6_lsupdate_send_interface(struct thread *thread)
 int ospf6_lsack_send_neighbor(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_header *oh;
-	uint8_t *p;
-	struct ospf6_lsa *lsa, *lsanext;
-	int lsa_cnt = 0;
+	struct ospf6_packet *op;
+	uint16_t length = OSPF6_HEADER_SIZE;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	on->thread_send_lsack = (struct thread *)NULL;
@@ -2699,53 +2738,24 @@ int ospf6_lsack_send_neighbor(struct thread *thread)
 	if (on->lsack_list->count == 0)
 		return 0;
 
-	memset(sendbuf, 0, iobuflen);
-	oh = (struct ospf6_header *)sendbuf;
+	op = ospf6_packet_new(on->ospf6_if->ifmtu);
+	ospf6_make_header(OSPF6_MESSAGE_TYPE_LSACK, on->ospf6_if, op->s);
 
-	p = (uint8_t *)((caddr_t)oh + sizeof(struct ospf6_header));
+	length += ospf6_make_lsack_neighbor(on, &op);
 
-	for (ALL_LSDB(on->lsack_list, lsa, lsanext)) {
-		/* MTU check */
-		if (p - sendbuf + sizeof(struct ospf6_lsa_header)
-		    > ospf6_packet_max(on->ospf6_if)) {
-			/* if we run out of packet size/space here,
-			   better to try again soon. */
-			if (lsa_cnt) {
-				oh->type = OSPF6_MESSAGE_TYPE_LSACK;
-				oh->length = htons(p - sendbuf);
-
-				on->ospf6_if->ls_ack_out++;
-
-				ospf6_send(on->ospf6_if->linklocal_addr,
-					   &on->linklocal_addr, on->ospf6_if,
-					   oh);
-
-				memset(sendbuf, 0, iobuflen);
-				oh = (struct ospf6_header *)sendbuf;
-				p = (uint8_t *)((caddr_t)oh
-						+ sizeof(struct ospf6_header));
-				lsa_cnt = 0;
-			}
-		}
-
-		ospf6_lsa_age_update_to_send(lsa, on->ospf6_if->transdelay);
-		memcpy(p, lsa->header, sizeof(struct ospf6_lsa_header));
-		p += sizeof(struct ospf6_lsa_header);
-
-		assert(lsa->lock == 2);
-		ospf6_lsdb_remove(lsa, on->lsack_list);
-		lsa_cnt++;
+	if (length == OSPF6_HEADER_SIZE) {
+		ospf6_packet_free(op);
+		return 0;
 	}
 
-	if (lsa_cnt) {
-		oh->type = OSPF6_MESSAGE_TYPE_LSACK;
-		oh->length = htons(p - sendbuf);
+	/* Fill OSPF header. */
+	ospf6_fill_header(on->ospf6_if, op->s, length);
 
-		on->ospf6_if->ls_ack_out++;
-
-		ospf6_send(on->ospf6_if->linklocal_addr, &on->linklocal_addr,
-			   on->ospf6_if, oh);
-	}
+	/* Set packet length, dst and queue to FIFO. */
+	op->length = length;
+	op->dst = on->linklocal_addr;
+	ospf6_packet_add(on->ospf6_if, op);
+	OSPF6_MESSAGE_WRITE_ON(on->ospf6_if);
 
 	if (on->lsack_list->count > 0)
 		thread_add_event(master, ospf6_lsack_send_neighbor, on, 0,
@@ -2754,13 +2764,42 @@ int ospf6_lsack_send_neighbor(struct thread *thread)
 	return 0;
 }
 
+static uint16_t ospf6_make_lsack_interface(struct ospf6_interface *oi,
+					   struct ospf6_packet *op)
+{
+	uint16_t length = 0;
+	struct ospf6_lsa *lsa, *lsanext;
+
+	for (ALL_LSDB(oi->lsack_list, lsa, lsanext)) {
+		if ((length + sizeof(struct ospf6_lsa_header)
+		     + OSPF6_HEADER_SIZE)
+		    > ospf6_packet_max(oi)) {
+			/* if we run out of packet size/space here,
+			   better to try again soon. */
+			THREAD_OFF(oi->thread_send_lsack);
+			thread_add_event(master, ospf6_lsack_send_interface, oi,
+					 0, &oi->thread_send_lsack);
+
+			ospf6_lsa_unlock(lsa);
+			if (lsanext)
+				ospf6_lsa_unlock(lsanext);
+			break;
+		}
+		ospf6_lsa_age_update_to_send(lsa, oi->transdelay);
+		stream_put(op->s, lsa->header, sizeof(struct ospf6_lsa_header));
+		length += sizeof(struct ospf6_lsa_header);
+
+		assert(lsa->lock == 2);
+		ospf6_lsdb_remove(lsa, oi->lsack_list);
+	}
+	return length;
+}
+
 int ospf6_lsack_send_interface(struct thread *thread)
 {
 	struct ospf6_interface *oi;
-	struct ospf6_header *oh;
-	uint8_t *p;
-	struct ospf6_lsa *lsa, *lsanext;
-	int lsa_cnt = 0;
+	struct ospf6_packet *op;
+	uint16_t length = OSPF6_HEADER_SIZE;
 
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
 	oi->thread_send_lsack = (struct thread *)NULL;
@@ -2778,47 +2817,29 @@ int ospf6_lsack_send_interface(struct thread *thread)
 	if (oi->lsack_list->count == 0)
 		return 0;
 
-	memset(sendbuf, 0, iobuflen);
-	oh = (struct ospf6_header *)sendbuf;
+	op = ospf6_packet_new(oi->ifmtu);
+	ospf6_make_header(OSPF6_MESSAGE_TYPE_LSACK, oi, op->s);
 
-	p = (uint8_t *)((caddr_t)oh + sizeof(struct ospf6_header));
+	length += ospf6_make_lsack_interface(oi, op);
 
-	for (ALL_LSDB(oi->lsack_list, lsa, lsanext)) {
-		/* MTU check */
-		if (p - sendbuf + sizeof(struct ospf6_lsa_header)
-		    > ospf6_packet_max(oi)) {
-			/* if we run out of packet size/space here,
-			   better to try again soon. */
-			THREAD_OFF(oi->thread_send_lsack);
-			thread_add_event(master, ospf6_lsack_send_interface, oi,
-					 0, &oi->thread_send_lsack);
-
-			ospf6_lsa_unlock(lsa);
-			if (lsanext)
-				ospf6_lsa_unlock(lsanext);
-			break;
-		}
-
-		ospf6_lsa_age_update_to_send(lsa, oi->transdelay);
-		memcpy(p, lsa->header, sizeof(struct ospf6_lsa_header));
-		p += sizeof(struct ospf6_lsa_header);
-
-		assert(lsa->lock == 2);
-		ospf6_lsdb_remove(lsa, oi->lsack_list);
-		lsa_cnt++;
+	if (length == OSPF6_HEADER_SIZE) {
+		ospf6_packet_free(op);
+		return 0;
 	}
+	/* Fill OSPF header. */
+	ospf6_fill_header(oi, op->s, length);
 
-	if (lsa_cnt) {
-		oh->type = OSPF6_MESSAGE_TYPE_LSACK;
-		oh->length = htons(p - sendbuf);
+	/* Set packet length, dst and queue to FIFO. */
+	op->length = length;
+	if ((oi->state == OSPF6_INTERFACE_POINTTOPOINT)
+	    || (oi->state == OSPF6_INTERFACE_DR)
+	    || (oi->state == OSPF6_INTERFACE_BDR))
+		op->dst = allspfrouters6;
+	else
+		op->dst = alldrouters6;
 
-		if ((oi->state == OSPF6_INTERFACE_POINTTOPOINT)
-		    || (oi->state == OSPF6_INTERFACE_DR)
-		    || (oi->state == OSPF6_INTERFACE_BDR))
-			ospf6_send(oi->linklocal_addr, &allspfrouters6, oi, oh);
-		else
-			ospf6_send(oi->linklocal_addr, &alldrouters6, oi, oh);
-	}
+	ospf6_packet_add(oi, op);
+	OSPF6_MESSAGE_WRITE_ON(oi);
 
 	if (oi->lsack_list->count > 0)
 		thread_add_event(master, ospf6_lsack_send_interface, oi, 0,

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1874,6 +1874,18 @@ static void ospf6_fill_header(struct ospf6_interface *oi, struct stream *s,
 	oh->length = htons(length);
 }
 
+static void ospf6_fill_lsupdate_header(struct stream *s, uint32_t lsa_num)
+{
+	struct ospf6_header *oh;
+	struct ospf6_lsupdate *lsu;
+
+	oh = (struct ospf6_header *)STREAM_DATA(s);
+
+	lsu = (struct ospf6_lsupdate *)((caddr_t)oh
+					+ sizeof(struct ospf6_header));
+	lsu->lsa_number = htonl(lsa_num);
+}
+
 static uint32_t ospf6_packet_max(struct ospf6_interface *oi)
 {
 	assert(oi->ifmtu > sizeof(struct ip6_hdr));
@@ -2023,74 +2035,6 @@ static int ospf6_write(struct thread *thread)
 				 &ospf6->t_write);
 
 	return 0;
-}
-
-static void ospf6_send(struct in6_addr *src, struct in6_addr *dst,
-		       struct ospf6_interface *oi, struct ospf6_header *oh)
-{
-	unsigned int len;
-	char srcname[64];
-	struct iovec iovector[2];
-
-	/* initialize */
-	iovector[0].iov_base = (caddr_t)oh;
-	iovector[0].iov_len = ntohs(oh->length);
-	iovector[1].iov_base = NULL;
-	iovector[1].iov_len = 0;
-
-	/* fill OSPF header */
-	oh->version = OSPFV3_VERSION;
-	/* message type must be set before */
-	/* message length must be set before */
-	oh->router_id = oi->area->ospf6->router_id;
-	oh->area_id = oi->area->area_id;
-	/* checksum is calculated by kernel */
-	oh->instance_id = oi->instance_id;
-	oh->reserved = 0;
-
-	/* Log */
-	if (IS_OSPF6_DEBUG_MESSAGE(oh->type, SEND_HDR)) {
-		if (src)
-			inet_ntop(AF_INET6, src, srcname, sizeof(srcname));
-		else
-			memset(srcname, 0, sizeof(srcname));
-		zlog_debug("%s send on %s",
-			   lookup_msg(ospf6_message_type_str, oh->type, NULL),
-			   oi->interface->name);
-		zlog_debug("    src: %s", srcname);
-		zlog_debug("    dst: %pI6", dst);
-
-		switch (oh->type) {
-		case OSPF6_MESSAGE_TYPE_HELLO:
-			ospf6_hello_print(oh, OSPF6_ACTION_RECV);
-			break;
-		case OSPF6_MESSAGE_TYPE_DBDESC:
-			ospf6_dbdesc_print(oh, OSPF6_ACTION_RECV);
-			break;
-		case OSPF6_MESSAGE_TYPE_LSREQ:
-			ospf6_lsreq_print(oh, OSPF6_ACTION_RECV);
-			break;
-		case OSPF6_MESSAGE_TYPE_LSUPDATE:
-			ospf6_lsupdate_print(oh, OSPF6_ACTION_RECV);
-			break;
-		case OSPF6_MESSAGE_TYPE_LSACK:
-			ospf6_lsack_print(oh, OSPF6_ACTION_RECV);
-			break;
-		default:
-			zlog_debug("Unknown message");
-			assert(0);
-			break;
-		}
-	}
-
-	/* send message */
-	if (oi->area->ospf6->fd != -1) {
-		len = ospf6_sendmsg(src, dst, oi->interface->ifindex, iovector,
-				    oi->area->ospf6->fd);
-		if (len != ntohs(oh->length))
-			flog_err(EC_LIB_DEVELOPMENT,
-				 "Could not send entire message");
-	}
 }
 
 int ospf6_hello_send(struct thread *thread)
@@ -2416,43 +2360,117 @@ int ospf6_lsreq_send(struct thread *thread)
 
 static void ospf6_send_lsupdate(struct ospf6_neighbor *on,
 				struct ospf6_interface *oi,
-				struct ospf6_header *oh)
+				struct ospf6_packet *op)
 {
 
 	if (on) {
-		on->ospf6_if->ls_upd_out++;
 
 		if ((on->ospf6_if->state == OSPF6_INTERFACE_POINTTOPOINT)
 		    || (on->ospf6_if->state == OSPF6_INTERFACE_DR)
-		    || (on->ospf6_if->state == OSPF6_INTERFACE_BDR)) {
-			ospf6_send(on->ospf6_if->linklocal_addr,
-				   &allspfrouters6, on->ospf6_if, oh);
-		} else {
-			ospf6_send(on->ospf6_if->linklocal_addr,
-				   &on->linklocal_addr, on->ospf6_if, oh);
-		}
+		    || (on->ospf6_if->state == OSPF6_INTERFACE_BDR))
+			op->dst = allspfrouters6;
+		else
+			op->dst = on->linklocal_addr;
+		oi = on->ospf6_if;
 	} else if (oi) {
-
-		oi->ls_upd_out++;
-
 		if ((oi->state == OSPF6_INTERFACE_POINTTOPOINT)
 		    || (oi->state == OSPF6_INTERFACE_DR)
-		    || (oi->state == OSPF6_INTERFACE_BDR)) {
-			ospf6_send(oi->linklocal_addr, &allspfrouters6, oi, oh);
-		} else {
-			ospf6_send(oi->linklocal_addr, &alldrouters6, oi, oh);
-		}
+		    || (oi->state == OSPF6_INTERFACE_BDR))
+			op->dst = allspfrouters6;
+		else
+			op->dst = alldrouters6;
 	}
+	if (oi) {
+		ospf6_packet_add(oi, op);
+		OSPF6_MESSAGE_WRITE_ON(oi);
+	}
+}
+
+static uint16_t ospf6_make_lsupdate_list(struct ospf6_neighbor *on,
+					 struct ospf6_packet **op, int *lsa_cnt)
+{
+	uint16_t length = OSPF6_LS_UPD_MIN_SIZE;
+	struct ospf6_lsa *lsa, *lsanext;
+
+	/* skip over fixed header */
+	stream_forward_endp((*op)->s, OSPF6_LS_UPD_MIN_SIZE);
+
+	for (ALL_LSDB(on->lsupdate_list, lsa, lsanext)) {
+		if ((length + (unsigned int)OSPF6_LSA_SIZE(lsa->header)
+		     + OSPF6_HEADER_SIZE)
+		    > ospf6_packet_max(on->ospf6_if)) {
+			ospf6_fill_header(on->ospf6_if, (*op)->s,
+					  length + OSPF6_HEADER_SIZE);
+			(*op)->length = length + OSPF6_HEADER_SIZE;
+			ospf6_fill_lsupdate_header((*op)->s, *lsa_cnt);
+			ospf6_send_lsupdate(on, NULL, *op);
+
+			/* refresh packet */
+			*op = ospf6_packet_new(on->ospf6_if->ifmtu);
+			length = OSPF6_LS_UPD_MIN_SIZE;
+			*lsa_cnt = 0;
+			ospf6_make_header(OSPF6_MESSAGE_TYPE_LSUPDATE,
+					  on->ospf6_if, (*op)->s);
+			stream_forward_endp((*op)->s, OSPF6_LS_UPD_MIN_SIZE);
+		}
+		ospf6_lsa_age_update_to_send(lsa, on->ospf6_if->transdelay);
+		stream_put((*op)->s, lsa->header, OSPF6_LSA_SIZE(lsa->header));
+		(*lsa_cnt)++;
+		length += OSPF6_LSA_SIZE(lsa->header);
+		assert(lsa->lock == 2);
+		ospf6_lsdb_remove(lsa, on->lsupdate_list);
+	}
+	return length;
+}
+
+static uint16_t ospf6_make_ls_retrans_list(struct ospf6_neighbor *on,
+					   struct ospf6_packet **op,
+					   int *lsa_cnt)
+{
+	uint16_t length = OSPF6_LS_UPD_MIN_SIZE;
+	struct ospf6_lsa *lsa, *lsanext;
+
+	/* skip over fixed header */
+	stream_forward_endp((*op)->s, OSPF6_LS_UPD_MIN_SIZE);
+
+	for (ALL_LSDB(on->retrans_list, lsa, lsanext)) {
+		if ((length + (unsigned int)OSPF6_LSA_SIZE(lsa->header)
+		     + OSPF6_HEADER_SIZE)
+		    > ospf6_packet_max(on->ospf6_if)) {
+			ospf6_fill_header(on->ospf6_if, (*op)->s,
+					  length + OSPF6_HEADER_SIZE);
+			(*op)->length = length + OSPF6_HEADER_SIZE;
+			ospf6_fill_lsupdate_header((*op)->s, *lsa_cnt);
+			if (on->ospf6_if->state == OSPF6_INTERFACE_POINTTOPOINT)
+				(*op)->dst = allspfrouters6;
+			else
+				(*op)->dst = on->linklocal_addr;
+
+			ospf6_packet_add(on->ospf6_if, *op);
+			OSPF6_MESSAGE_WRITE_ON(on->ospf6_if);
+
+			/* refresh packet */
+			*op = ospf6_packet_new(on->ospf6_if->ifmtu);
+			length = OSPF6_LS_UPD_MIN_SIZE;
+			*lsa_cnt = 0;
+			ospf6_make_header(OSPF6_MESSAGE_TYPE_LSUPDATE,
+					  on->ospf6_if, (*op)->s);
+			stream_forward_endp((*op)->s, OSPF6_LS_UPD_MIN_SIZE);
+		}
+		ospf6_lsa_age_update_to_send(lsa, on->ospf6_if->transdelay);
+		stream_put((*op)->s, lsa->header, OSPF6_LSA_SIZE(lsa->header));
+		(*lsa_cnt)++;
+		length += OSPF6_LSA_SIZE(lsa->header);
+	}
+	return length;
 }
 
 int ospf6_lsupdate_send_neighbor(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_header *oh;
-	struct ospf6_lsupdate *lsupdate;
-	uint8_t *p;
-	int lsa_cnt;
-	struct ospf6_lsa *lsa, *lsanext;
+	struct ospf6_packet *op;
+	uint16_t length = OSPF6_HEADER_SIZE;
+	int lsa_cnt = 0;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	on->thread_send_lsupdate = (struct thread *)NULL;
@@ -2468,119 +2486,41 @@ int ospf6_lsupdate_send_neighbor(struct thread *thread)
 		return 0;
 	}
 
-	memset(sendbuf, 0, iobuflen);
-	oh = (struct ospf6_header *)sendbuf;
-	lsupdate = (struct ospf6_lsupdate *)((caddr_t)oh
-					     + sizeof(struct ospf6_header));
-
-	p = (uint8_t *)((caddr_t)lsupdate + sizeof(struct ospf6_lsupdate));
-	lsa_cnt = 0;
-
-	/* lsupdate_list lists those LSA which doesn't need to be
-	   retransmitted. remove those from the list */
-	for (ALL_LSDB(on->lsupdate_list, lsa, lsanext)) {
-		/* MTU check */
-		if ((p - sendbuf + (unsigned int)OSPF6_LSA_SIZE(lsa->header))
-		    > ospf6_packet_max(on->ospf6_if)) {
-			if (lsa_cnt) {
-				oh->type = OSPF6_MESSAGE_TYPE_LSUPDATE;
-				oh->length = htons(p - sendbuf);
-				lsupdate->lsa_number = htonl(lsa_cnt);
-
-				ospf6_send_lsupdate(on, NULL, oh);
-
-				memset(sendbuf, 0, iobuflen);
-				oh = (struct ospf6_header *)sendbuf;
-				lsupdate = (struct ospf6_lsupdate
-						    *)((caddr_t)oh
-						       + sizeof(struct
-								ospf6_header));
-
-				p = (uint8_t *)((caddr_t)lsupdate
-						+ sizeof(struct
-							 ospf6_lsupdate));
-				lsa_cnt = 0;
-			}
-		}
-
-		ospf6_lsa_age_update_to_send(lsa, on->ospf6_if->transdelay);
-		memcpy(p, lsa->header, OSPF6_LSA_SIZE(lsa->header));
-		p += OSPF6_LSA_SIZE(lsa->header);
-		lsa_cnt++;
-
-		assert(lsa->lock == 2);
-		ospf6_lsdb_remove(lsa, on->lsupdate_list);
-	}
-
+	/* first do lsupdate_list */
+	op = ospf6_packet_new(on->ospf6_if->ifmtu);
+	ospf6_make_header(OSPF6_MESSAGE_TYPE_LSUPDATE, on->ospf6_if, op->s);
+	length += ospf6_make_lsupdate_list(on, &op, &lsa_cnt);
 	if (lsa_cnt) {
-		oh->type = OSPF6_MESSAGE_TYPE_LSUPDATE;
-		oh->length = htons(p - sendbuf);
-		lsupdate->lsa_number = htonl(lsa_cnt);
-		ospf6_send_lsupdate(on, NULL, oh);
+		/* Fill OSPF header. */
+		ospf6_fill_header(on->ospf6_if, op->s, length);
+		ospf6_fill_lsupdate_header(op->s, lsa_cnt);
+		op->length = length;
+		ospf6_send_lsupdate(on, NULL, op);
+
+		/* prepare new packet */
+		op = ospf6_packet_new(on->ospf6_if->ifmtu);
+		length = OSPF6_HEADER_SIZE;
+		lsa_cnt = 0;
+	} else {
+		stream_reset(op->s);
+		length = OSPF6_HEADER_SIZE;
 	}
 
-	/* The addresses used for retransmissions are different from those sent
-	   the
-	   first time and so we need to separate them here.
-	*/
-	memset(sendbuf, 0, iobuflen);
-	oh = (struct ospf6_header *)sendbuf;
-	lsupdate = (struct ospf6_lsupdate *)((caddr_t)oh
-					     + sizeof(struct ospf6_header));
-	p = (uint8_t *)((caddr_t)lsupdate + sizeof(struct ospf6_lsupdate));
-	lsa_cnt = 0;
-
-	for (ALL_LSDB(on->retrans_list, lsa, lsanext)) {
-		/* MTU check */
-		if ((p - sendbuf + (unsigned int)OSPF6_LSA_SIZE(lsa->header))
-		    > ospf6_packet_max(on->ospf6_if)) {
-			if (lsa_cnt) {
-				oh->type = OSPF6_MESSAGE_TYPE_LSUPDATE;
-				oh->length = htons(p - sendbuf);
-				lsupdate->lsa_number = htonl(lsa_cnt);
-
-				if (on->ospf6_if->state
-				    == OSPF6_INTERFACE_POINTTOPOINT) {
-					ospf6_send(on->ospf6_if->linklocal_addr,
-						   &allspfrouters6,
-						   on->ospf6_if, oh);
-				} else {
-					ospf6_send(on->ospf6_if->linklocal_addr,
-						   &on->linklocal_addr,
-						   on->ospf6_if, oh);
-				}
-
-				memset(sendbuf, 0, iobuflen);
-				oh = (struct ospf6_header *)sendbuf;
-				lsupdate = (struct ospf6_lsupdate
-						    *)((caddr_t)oh
-						       + sizeof(struct
-								ospf6_header));
-				p = (uint8_t *)((caddr_t)lsupdate
-						+ sizeof(struct
-							 ospf6_lsupdate));
-				lsa_cnt = 0;
-			}
-		}
-
-		ospf6_lsa_age_update_to_send(lsa, on->ospf6_if->transdelay);
-		memcpy(p, lsa->header, OSPF6_LSA_SIZE(lsa->header));
-		p += OSPF6_LSA_SIZE(lsa->header);
-		lsa_cnt++;
-	}
-
+	ospf6_make_header(OSPF6_MESSAGE_TYPE_LSUPDATE, on->ospf6_if, op->s);
+	/* now do retransmit list */
+	length += ospf6_make_ls_retrans_list(on, &op, &lsa_cnt);
 	if (lsa_cnt) {
-		oh->type = OSPF6_MESSAGE_TYPE_LSUPDATE;
-		oh->length = htons(p - sendbuf);
-		lsupdate->lsa_number = htonl(lsa_cnt);
-
+		ospf6_fill_header(on->ospf6_if, op->s, length);
+		ospf6_fill_lsupdate_header(op->s, lsa_cnt);
+		op->length = length;
 		if (on->ospf6_if->state == OSPF6_INTERFACE_POINTTOPOINT)
-			ospf6_send(on->ospf6_if->linklocal_addr,
-				   &allspfrouters6, on->ospf6_if, oh);
+			op->dst = allspfrouters6;
 		else
-			ospf6_send(on->ospf6_if->linklocal_addr,
-				   &on->linklocal_addr, on->ospf6_if, oh);
-	}
+			op->dst = on->linklocal_addr;
+		ospf6_packet_add(on->ospf6_if, op);
+		OSPF6_MESSAGE_WRITE_ON(on->ospf6_if);
+	} else
+		ospf6_packet_free(op);
 
 	if (on->lsupdate_list->count != 0) {
 		on->thread_send_lsupdate = NULL;
@@ -2598,44 +2538,78 @@ int ospf6_lsupdate_send_neighbor(struct thread *thread)
 int ospf6_lsupdate_send_neighbor_now(struct ospf6_neighbor *on,
 				     struct ospf6_lsa *lsa)
 {
-	struct ospf6_header *oh;
-	struct ospf6_lsupdate *lsupdate;
-	uint8_t *p;
-	int lsa_cnt = 0;
+	struct ospf6_packet *op;
+	uint16_t length = OSPF6_HEADER_SIZE;
 
-	memset(sendbuf, 0, iobuflen);
-	oh = (struct ospf6_header *)sendbuf;
-	lsupdate = (struct ospf6_lsupdate *)((caddr_t)oh
-					     + sizeof(struct ospf6_header));
+	op = ospf6_packet_new(on->ospf6_if->ifmtu);
+	ospf6_make_header(OSPF6_MESSAGE_TYPE_LSUPDATE, on->ospf6_if, op->s);
 
-	p = (uint8_t *)((caddr_t)lsupdate + sizeof(struct ospf6_lsupdate));
+	/* skip over fixed header */
+	stream_forward_endp(op->s, OSPF6_LS_UPD_MIN_SIZE);
 	ospf6_lsa_age_update_to_send(lsa, on->ospf6_if->transdelay);
-	memcpy(p, lsa->header, OSPF6_LSA_SIZE(lsa->header));
-	p += OSPF6_LSA_SIZE(lsa->header);
-	lsa_cnt++;
-
-	oh->type = OSPF6_MESSAGE_TYPE_LSUPDATE;
-	oh->length = htons(p - sendbuf);
-	lsupdate->lsa_number = htonl(lsa_cnt);
+	stream_put(op->s, lsa->header, OSPF6_LSA_SIZE(lsa->header));
+	length = OSPF6_HEADER_SIZE + OSPF6_LS_UPD_MIN_SIZE
+		 + OSPF6_LSA_SIZE(lsa->header);
+	ospf6_fill_header(on->ospf6_if, op->s, length);
+	ospf6_fill_lsupdate_header(op->s, 1);
+	op->length = length;
 
 	if (IS_OSPF6_DEBUG_FLOODING
 	    || IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_LSUPDATE, SEND_HDR))
 		zlog_debug("%s: Send lsupdate with lsa %s (age %u)", __func__,
 			   lsa->name, ntohs(lsa->header->age));
 
-	ospf6_send_lsupdate(on, NULL, oh);
+	ospf6_send_lsupdate(on, NULL, op);
 
 	return 0;
+}
+
+static uint16_t ospf6_make_lsupdate_interface(struct ospf6_interface *oi,
+					      struct ospf6_packet **op,
+					      int *lsa_cnt)
+{
+	uint16_t length = OSPF6_LS_UPD_MIN_SIZE;
+	struct ospf6_lsa *lsa, *lsanext;
+
+	/* skip over fixed header */
+	stream_forward_endp((*op)->s, OSPF6_LS_UPD_MIN_SIZE);
+
+	for (ALL_LSDB(oi->lsupdate_list, lsa, lsanext)) {
+		if (length + (unsigned int)OSPF6_LSA_SIZE(lsa->header)
+			    + OSPF6_HEADER_SIZE
+		    > ospf6_packet_max(oi)) {
+			ospf6_fill_header(oi, (*op)->s,
+					  length + OSPF6_HEADER_SIZE);
+			(*op)->length = length + OSPF6_HEADER_SIZE;
+			ospf6_fill_lsupdate_header((*op)->s, *lsa_cnt);
+			ospf6_send_lsupdate(NULL, oi, *op);
+
+			/* refresh packet */
+			*op = ospf6_packet_new(oi->ifmtu);
+			length = OSPF6_LS_UPD_MIN_SIZE;
+			*lsa_cnt = 0;
+			ospf6_make_header(OSPF6_MESSAGE_TYPE_LSUPDATE, oi,
+					  (*op)->s);
+			stream_forward_endp((*op)->s, OSPF6_LS_UPD_MIN_SIZE);
+		}
+
+		ospf6_lsa_age_update_to_send(lsa, oi->transdelay);
+		stream_put((*op)->s, lsa->header, OSPF6_LSA_SIZE(lsa->header));
+		(*lsa_cnt)++;
+		length += OSPF6_LSA_SIZE(lsa->header);
+
+		assert(lsa->lock == 2);
+		ospf6_lsdb_remove(lsa, oi->lsupdate_list);
+	}
+	return length;
 }
 
 int ospf6_lsupdate_send_interface(struct thread *thread)
 {
 	struct ospf6_interface *oi;
-	struct ospf6_header *oh;
-	struct ospf6_lsupdate *lsupdate;
-	uint8_t *p;
-	int lsa_cnt;
-	struct ospf6_lsa *lsa, *lsanext;
+	struct ospf6_packet *op;
+	uint16_t length = OSPF6_HEADER_SIZE;
+	int lsa_cnt = 0;
 
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
 	oi->thread_send_lsupdate = (struct thread *)NULL;
@@ -2654,59 +2628,17 @@ int ospf6_lsupdate_send_interface(struct thread *thread)
 	if (oi->lsupdate_list->count == 0)
 		return 0;
 
-	memset(sendbuf, 0, iobuflen);
-	oh = (struct ospf6_header *)sendbuf;
-	lsupdate = (struct ospf6_lsupdate *)((caddr_t)oh
-					     + sizeof(struct ospf6_header));
-
-	p = (uint8_t *)((caddr_t)lsupdate + sizeof(struct ospf6_lsupdate));
-	lsa_cnt = 0;
-
-	for (ALL_LSDB(oi->lsupdate_list, lsa, lsanext)) {
-		/* MTU check */
-		if ((p - sendbuf + ((unsigned int)OSPF6_LSA_SIZE(lsa->header)))
-		    > ospf6_packet_max(oi)) {
-			if (lsa_cnt) {
-				oh->type = OSPF6_MESSAGE_TYPE_LSUPDATE;
-				oh->length = htons(p - sendbuf);
-				lsupdate->lsa_number = htonl(lsa_cnt);
-
-				ospf6_send_lsupdate(NULL, oi, oh);
-				if (IS_OSPF6_DEBUG_MESSAGE(
-					    OSPF6_MESSAGE_TYPE_LSUPDATE, SEND))
-					zlog_debug("%s: LSUpdate length %d",
-						   __func__, ntohs(oh->length));
-
-				memset(sendbuf, 0, iobuflen);
-				oh = (struct ospf6_header *)sendbuf;
-				lsupdate = (struct ospf6_lsupdate
-						    *)((caddr_t)oh
-						       + sizeof(struct
-								ospf6_header));
-
-				p = (uint8_t *)((caddr_t)lsupdate
-						+ sizeof(struct
-							 ospf6_lsupdate));
-				lsa_cnt = 0;
-			}
-		}
-
-		ospf6_lsa_age_update_to_send(lsa, oi->transdelay);
-		memcpy(p, lsa->header, OSPF6_LSA_SIZE(lsa->header));
-		p += OSPF6_LSA_SIZE(lsa->header);
-		lsa_cnt++;
-
-		assert(lsa->lock == 2);
-		ospf6_lsdb_remove(lsa, oi->lsupdate_list);
-	}
-
+	op = ospf6_packet_new(oi->ifmtu);
+	ospf6_make_header(OSPF6_MESSAGE_TYPE_LSUPDATE, oi, op->s);
+	length += ospf6_make_lsupdate_interface(oi, &op, &lsa_cnt);
 	if (lsa_cnt) {
-		oh->type = OSPF6_MESSAGE_TYPE_LSUPDATE;
-		oh->length = htons(p - sendbuf);
-		lsupdate->lsa_number = htonl(lsa_cnt);
-
-		ospf6_send_lsupdate(NULL, oi, oh);
-	}
+		/* Fill OSPF header. */
+		ospf6_fill_header(oi, op->s, length);
+		ospf6_fill_lsupdate_header(op->s, lsa_cnt);
+		op->length = length;
+		ospf6_send_lsupdate(NULL, oi, op);
+	} else
+		ospf6_packet_free(op);
 
 	if (oi->lsupdate_list->count > 0) {
 		oi->thread_send_lsupdate = NULL;

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1848,7 +1848,7 @@ int ospf6_receive(struct thread *thread)
 	thread_add_read(master, ospf6_receive, ospf6, ospf6->fd,
 			&ospf6->t_ospf6_receive);
 
-	while (count < OSPF6_WRITE_INTERFACE_COUNT_DEFAULT) {
+	while (count < ospf6->write_oi_count) {
 		count++;
 		switch (ospf6_read_helper(sockfd, ospf6)) {
 		case OSPF6_READ_ERROR:
@@ -1966,7 +1966,7 @@ static int ospf6_write(struct thread *thread)
 	assert(node);
 	oi = listgetdata(node);
 
-	while ((pkt_count < OSPF6_WRITE_INTERFACE_COUNT_DEFAULT) && oi
+	while ((pkt_count < ospf6->write_oi_count) && oi
 	       && (last_serviced_oi != oi)) {
 
 		op = ospf6_fifo_head(oi->obuf);

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -2279,13 +2279,43 @@ int ospf6_dbdesc_send_newone(struct thread *thread)
 	return 0;
 }
 
+static uint16_t ospf6_make_lsreq(struct ospf6_neighbor *on, struct stream *s)
+{
+	uint16_t length = 0;
+	struct ospf6_lsa *lsa, *lsanext, *last_req = NULL;
+
+	for (ALL_LSDB(on->request_list, lsa, lsanext)) {
+		if ((length + OSPF6_HEADER_SIZE)
+		    > ospf6_packet_max(on->ospf6_if)) {
+			ospf6_lsa_unlock(lsa);
+			if (lsanext)
+				ospf6_lsa_unlock(lsanext);
+			break;
+		}
+		stream_putw(s, 0); /* reserved */
+		stream_putw(s, ntohs(lsa->header->type));
+		stream_putl(s, ntohl(lsa->header->id));
+		stream_putl(s, ntohl(lsa->header->adv_router));
+		length += sizeof(struct ospf6_lsreq_entry);
+		last_req = lsa;
+	}
+
+	if (last_req != NULL) {
+		if (on->last_ls_req != NULL)
+			on->last_ls_req = ospf6_lsa_unlock(on->last_ls_req);
+
+		ospf6_lsa_lock(last_req);
+		on->last_ls_req = last_req;
+	}
+
+	return length;
+}
+
 int ospf6_lsreq_send(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
-	struct ospf6_header *oh;
-	struct ospf6_lsreq_entry *e;
-	uint8_t *p;
-	struct ospf6_lsa *lsa, *lsanext, *last_req;
+	struct ospf6_packet *op;
+	uint16_t length = OSPF6_HEADER_SIZE;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
 	on->thread_send_lsreq = (struct thread *)NULL;
@@ -2306,49 +2336,31 @@ int ospf6_lsreq_send(struct thread *thread)
 		return 0;
 	}
 
-	memset(sendbuf, 0, iobuflen);
-	oh = (struct ospf6_header *)sendbuf;
-	last_req = NULL;
+	op = ospf6_packet_new(on->ospf6_if->ifmtu);
+	ospf6_make_header(OSPF6_MESSAGE_TYPE_LSREQ, on->ospf6_if, op->s);
 
-	/* set Request entries in lsreq */
-	p = (uint8_t *)((caddr_t)oh + sizeof(struct ospf6_header));
-	for (ALL_LSDB(on->request_list, lsa, lsanext)) {
-		/* MTU check */
-		if (p - sendbuf + sizeof(struct ospf6_lsreq_entry)
-		    > ospf6_packet_max(on->ospf6_if)) {
-			ospf6_lsa_unlock(lsa);
-			if (lsanext)
-				ospf6_lsa_unlock(lsanext);
-			break;
-		}
+	length += ospf6_make_lsreq(on, op->s);
 
-		e = (struct ospf6_lsreq_entry *)p;
-		e->type = lsa->header->type;
-		e->id = lsa->header->id;
-		e->adv_router = lsa->header->adv_router;
-		p += sizeof(struct ospf6_lsreq_entry);
-		last_req = lsa;
+	if (length == OSPF6_HEADER_SIZE) {
+		/* Hello overshooting MTU */
+		ospf6_packet_free(op);
+		return 0;
 	}
 
-	if (last_req != NULL) {
-		if (on->last_ls_req != NULL)
-			on->last_ls_req = ospf6_lsa_unlock(on->last_ls_req);
+	/* Fill OSPF header. */
+	ospf6_fill_header(on->ospf6_if, op->s, length);
 
-		ospf6_lsa_lock(last_req);
-		on->last_ls_req = last_req;
-	}
-
-	oh->type = OSPF6_MESSAGE_TYPE_LSREQ;
-	oh->length = htons(p - sendbuf);
-
-	on->ospf6_if->ls_req_out++;
+	/* Set packet length. */
+	op->length = length;
 
 	if (on->ospf6_if->state == OSPF6_INTERFACE_POINTTOPOINT)
-		ospf6_send(on->ospf6_if->linklocal_addr, &allspfrouters6,
-			   on->ospf6_if, oh);
+		op->dst = allspfrouters6;
 	else
-		ospf6_send(on->ospf6_if->linklocal_addr, &on->linklocal_addr,
-			   on->ospf6_if, oh);
+		op->dst = on->linklocal_addr;
+
+	ospf6_packet_add(on->ospf6_if, op);
+
+	OSPF6_MESSAGE_WRITE_ON(on->ospf6_if);
 
 	/* set next thread */
 	if (on->request_list->count != 0) {

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -271,7 +271,7 @@ struct ospf6_fifo *ospf6_fifo_new(void)
 }
 
 /* Add new packet to fifo. */
-void ospf6_fifo_push(struct ospf6_fifo *fifo, struct ospf6_packet *op)
+static void ospf6_fifo_push(struct ospf6_fifo *fifo, struct ospf6_packet *op)
 {
 	if (fifo->tail)
 		fifo->tail->next = op;
@@ -284,7 +284,8 @@ void ospf6_fifo_push(struct ospf6_fifo *fifo, struct ospf6_packet *op)
 }
 
 /* Add new packet to head of fifo. */
-void ospf6_fifo_push_head(struct ospf6_fifo *fifo, struct ospf6_packet *op)
+static void ospf6_fifo_push_head(struct ospf6_fifo *fifo,
+				 struct ospf6_packet *op)
 {
 	op->next = fifo->head;
 
@@ -297,7 +298,7 @@ void ospf6_fifo_push_head(struct ospf6_fifo *fifo, struct ospf6_packet *op)
 }
 
 /* Delete first packet from fifo. */
-struct ospf6_packet *ospf6_fifo_pop(struct ospf6_fifo *fifo)
+static struct ospf6_packet *ospf6_fifo_pop(struct ospf6_fifo *fifo)
 {
 	struct ospf6_packet *op;
 
@@ -342,6 +343,35 @@ void ospf6_fifo_free(struct ospf6_fifo *fifo)
 
 	XFREE(MTYPE_OSPF6_FIFO, fifo);
 }
+
+void ospf6_packet_add(struct ospf6_interface *oi, struct ospf6_packet *op)
+{
+	/* Add packet to end of queue. */
+	ospf6_fifo_push(oi->obuf, op);
+
+	/* Debug of packet fifo*/
+	/* ospf_fifo_debug (oi->obuf); */
+}
+
+void ospf6_packet_add_top(struct ospf6_interface *oi, struct ospf6_packet *op)
+{
+	/* Add packet to head of queue. */
+	ospf6_fifo_push_head(oi->obuf, op);
+
+	/* Debug of packet fifo*/
+	/* ospf_fifo_debug (oi->obuf); */
+}
+
+void ospf6_packet_delete(struct ospf6_interface *oi)
+{
+	struct ospf6_packet *op;
+
+	op = ospf6_fifo_pop(oi->obuf);
+
+	if (op)
+		ospf6_packet_free(op);
+}
+
 
 static void ospf6_hello_recv(struct in6_addr *src, struct in6_addr *dst,
 			     struct ospf6_interface *oi,

--- a/ospf6d/ospf6_message.h
+++ b/ospf6d/ospf6_message.h
@@ -63,6 +63,27 @@ extern unsigned char conf_debug_ospf6_message[];
 #define OSPF6_MESSAGE_TYPE_LSACK    0x5  /* Flooding acknowledgment */
 #define OSPF6_MESSAGE_TYPE_ALL      0x6  /* For debug option */
 
+struct ospf6_packet {
+	struct ospf6_packet *next;
+
+	/* Pointer to data stream. */
+	struct stream *s;
+
+	/* IP destination address. */
+	struct in6_addr dst;
+
+	/* OSPF6 packet length. */
+	uint16_t length;
+};
+
+/* OSPF packet queue structure. */
+struct ospf6_fifo {
+	unsigned long count;
+
+	struct ospf6_packet *head;
+	struct ospf6_packet *tail;
+};
+
 /* OSPFv3 packet header */
 #define OSPF6_HEADER_SIZE                     16U
 struct ospf6_header {
@@ -135,6 +156,15 @@ extern void ospf6_dbdesc_print(struct ospf6_header *, int action);
 extern void ospf6_lsreq_print(struct ospf6_header *, int action);
 extern void ospf6_lsupdate_print(struct ospf6_header *, int action);
 extern void ospf6_lsack_print(struct ospf6_header *, int action);
+
+extern void ospf6_packet_free(struct ospf6_packet *op);
+extern struct ospf6_fifo *ospf6_fifo_new(void);
+extern void ospf6_fifo_push(struct ospf6_fifo *fifo, struct ospf6_packet *op);
+void ospf6_fifo_push_head(struct ospf6_fifo *fifo, struct ospf6_packet *op);
+extern struct ospf6_packet *ospf6_fifo_pop(struct ospf6_fifo *fifo);
+extern struct ospf6_packet *ospf6_fifo_head(struct ospf6_fifo *fifo);
+extern void ospf6_fifo_flush(struct ospf6_fifo *fifo);
+extern void ospf6_fifo_free(struct ospf6_fifo *fifo);
 
 extern int ospf6_iobuf_size(unsigned int size);
 extern void ospf6_message_terminate(void);

--- a/ospf6d/ospf6_message.h
+++ b/ospf6d/ospf6_message.h
@@ -159,12 +159,17 @@ extern void ospf6_lsack_print(struct ospf6_header *, int action);
 
 extern void ospf6_packet_free(struct ospf6_packet *op);
 extern struct ospf6_fifo *ospf6_fifo_new(void);
-extern void ospf6_fifo_push(struct ospf6_fifo *fifo, struct ospf6_packet *op);
-void ospf6_fifo_push_head(struct ospf6_fifo *fifo, struct ospf6_packet *op);
-extern struct ospf6_packet *ospf6_fifo_pop(struct ospf6_fifo *fifo);
-extern struct ospf6_packet *ospf6_fifo_head(struct ospf6_fifo *fifo);
 extern void ospf6_fifo_flush(struct ospf6_fifo *fifo);
 extern void ospf6_fifo_free(struct ospf6_fifo *fifo);
+struct ospf6_packet *ospf6_fifo_head(struct ospf6_fifo *fifo);
+
+/* temporary inclusinon of ospf6_interface.h for compile will be removed */
+#include "ospf6_interface.h"
+extern void ospf6_packet_add(struct ospf6_interface *oi,
+			     struct ospf6_packet *op);
+extern void ospf6_packet_add_top(struct ospf6_interface *oi,
+				 struct ospf6_packet *op);
+extern void ospf6_packet_delete(struct ospf6_interface *oi);
 
 extern int ospf6_iobuf_size(unsigned int size);
 extern void ospf6_message_terminate(void);

--- a/ospf6d/ospf6_message.h
+++ b/ospf6d/ospf6_message.h
@@ -167,9 +167,6 @@ struct ospf6_packet *ospf6_fifo_head(struct ospf6_fifo *fifo);
 #include "ospf6_interface.h"
 extern void ospf6_packet_add(struct ospf6_interface *oi,
 			     struct ospf6_packet *op);
-extern void ospf6_packet_add_top(struct ospf6_interface *oi,
-				 struct ospf6_packet *op);
-extern void ospf6_packet_delete(struct ospf6_interface *oi);
 
 extern int ospf6_iobuf_size(unsigned int size);
 extern void ospf6_message_terminate(void);

--- a/ospf6d/ospf6_message.h
+++ b/ospf6d/ospf6_message.h
@@ -157,16 +157,9 @@ extern void ospf6_lsreq_print(struct ospf6_header *, int action);
 extern void ospf6_lsupdate_print(struct ospf6_header *, int action);
 extern void ospf6_lsack_print(struct ospf6_header *, int action);
 
-extern void ospf6_packet_free(struct ospf6_packet *op);
 extern struct ospf6_fifo *ospf6_fifo_new(void);
 extern void ospf6_fifo_flush(struct ospf6_fifo *fifo);
 extern void ospf6_fifo_free(struct ospf6_fifo *fifo);
-struct ospf6_packet *ospf6_fifo_head(struct ospf6_fifo *fifo);
-
-/* temporary inclusinon of ospf6_interface.h for compile will be removed */
-#include "ospf6_interface.h"
-extern void ospf6_packet_add(struct ospf6_interface *oi,
-			     struct ospf6_packet *op);
 
 extern int ospf6_iobuf_size(unsigned int size);
 extern void ospf6_message_terminate(void);

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -47,6 +47,10 @@ struct ospf6_neighbor {
 	uint32_t state_change;
 	struct timeval last_changed;
 
+	/* last received hello */
+	struct timeval last_hello;
+	uint32_t hello_in;
+
 	/* Neighbor Router ID */
 	in_addr_t router_id;
 

--- a/ospf6d/ospf6_network.h
+++ b/ospf6d/ospf6_network.h
@@ -36,4 +36,19 @@ extern int ospf6_recvmsg(struct in6_addr *src, struct in6_addr *dst,
 			 ifindex_t *ifindex, struct iovec *message,
 			 int ospf6_sock);
 
+#define OSPF6_MESSAGE_WRITE_ON(O)                                              \
+	do {                                                                   \
+		bool list_was_empty =                                          \
+			list_isempty(oi->area->ospf6->oi_write_q);             \
+		if ((oi)->on_write_q == 0) {                                   \
+			listnode_add(oi->area->ospf6->oi_write_q, (oi));       \
+			(oi)->on_write_q = 1;                                  \
+		}                                                              \
+		if (list_was_empty                                             \
+		    && !list_isempty(oi->area->ospf6->oi_write_q))             \
+			thread_add_write(master, ospf6_write, oi->area->ospf6, \
+					 oi->area->ospf6->fd,                  \
+					 &oi->area->ospf6->t_write);           \
+	} while (0)
+
 #endif /* OSPF6_NETWORK_H */

--- a/ospf6d/ospf6_network.h
+++ b/ospf6d/ospf6_network.h
@@ -36,7 +36,7 @@ extern int ospf6_recvmsg(struct in6_addr *src, struct in6_addr *dst,
 			 ifindex_t *ifindex, struct iovec *message,
 			 int ospf6_sock);
 
-#define OSPF6_MESSAGE_WRITE_ON(O)                                              \
+#define OSPF6_MESSAGE_WRITE_ON(oi)                                             \
 	do {                                                                   \
 		bool list_was_empty =                                          \
 			list_isempty(oi->area->ospf6->oi_write_q);             \

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -413,6 +413,8 @@ static struct ospf6 *ospf6_create(const char *name)
 
 	o->max_multipath = MULTIPATH_NUM;
 
+	o->oi_write_q = list_new();
+
 	QOBJ_REG(o, ospf6);
 
 	/* Make ospf protocol socket. */
@@ -482,6 +484,7 @@ void ospf6_delete(struct ospf6 *o)
 
 	ospf6_distance_reset(o);
 	route_table_finish(o->distance_table);
+	list_delete(&o->oi_write_q);
 
 	if (o->vrf_id != VRF_UNKNOWN) {
 		vrf = vrf_lookup_by_id(o->vrf_id);

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -406,6 +406,7 @@ static struct ospf6 *ospf6_create(const char *name)
 
 	o->external_id_table = route_table_init();
 
+	o->write_oi_count = OSPF6_WRITE_INTERFACE_COUNT_DEFAULT;
 	o->ref_bandwidth = OSPF6_REFERENCE_BANDWIDTH;
 
 	o->distance_table = route_table_init();
@@ -1667,6 +1668,11 @@ static int config_write_ospf6(struct vty *vty)
 		if (ospf6->ref_bandwidth != OSPF6_REFERENCE_BANDWIDTH)
 			vty_out(vty, " auto-cost reference-bandwidth %d\n",
 				ospf6->ref_bandwidth);
+
+		if (ospf6->write_oi_count
+		    != OSPF6_WRITE_INTERFACE_COUNT_DEFAULT)
+			vty_out(vty, " write-multiplier %d\n",
+				ospf6->write_oi_count);
 
 		/* LSA timers print. */
 		if (ospf6->lsa_minarrival != OSPF_MIN_LS_ARRIVAL)

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -131,6 +131,7 @@ struct ospf6 {
 #define OSPF6_WRITE_INTERFACE_COUNT_DEFAULT 20
 	struct thread *t_write;
 
+	int write_oi_count; /* Num of packets sent per thread invocation */
 	uint32_t ref_bandwidth;
 
 	/* Distance parameters */

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -128,6 +128,7 @@ struct ospf6 {
 	struct thread *maxage_remover;
 	struct thread *t_distribute_update; /* Distirbute update timer. */
 	struct thread *t_ospf6_receive; /* OSPF6 receive timer */
+#define OSPF6_WRITE_INTERFACE_COUNT_DEFAULT 20
 	struct thread *t_write;
 
 	uint32_t ref_bandwidth;

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -128,6 +128,7 @@ struct ospf6 {
 	struct thread *maxage_remover;
 	struct thread *t_distribute_update; /* Distirbute update timer. */
 	struct thread *t_ospf6_receive; /* OSPF6 receive timer */
+	struct thread *t_write;
 
 	uint32_t ref_bandwidth;
 
@@ -150,6 +151,7 @@ struct ospf6 {
 	/* Count of NSSA areas */
 	uint8_t anyNSSA;
 	struct thread *t_abr_task; /* ABR task timer. */
+	struct list *oi_write_q;
 
 	uint32_t redist_count;
 	QOBJ_FIELDS;


### PR DESCRIPTION
make socket read non-blocking
rewrite OSPF6 messages to use packet FIFO rather than write directly to socket
queue hello messages to head of FIFO to reduce hello latency
add write-multiplier config (as in OSPFv2) to allow tuning of read/write threads