### PR TITLE
ospfd: Fix quick interface down up event handling in ospf

### DIFF
--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -208,6 +208,9 @@ int ospf_route_match_same(struct route_table *rt, struct prefix_ipv4 *prefix,
 
 	or = rn->info;
 	if (or->type == newor->type && or->cost == newor->cost) {
+		if (or->changed)
+			return 0;
+
 		if (or->type == OSPF_DESTINATION_NETWORK) {
 			if (or->paths->count != newor->paths->count)
 				return 0;

--- a/ospfd/ospf_route.h
+++ b/ospfd/ospf_route.h
@@ -124,6 +124,8 @@ struct ospf_route {
 		struct route_standard std;
 		struct route_external ext;
 	} u;
+
+	bool changed;
 };
 
 extern struct ospf_path *ospf_path_new(void);


### PR DESCRIPTION
When we get a very quick set of down/up events in ospf, ospf
will run spf *after* both of these events and come to the determination
that there is nothing to send to zebra.

Modify the code such that on an interface down event, mark the routes
as changed so that when ospf is deciding what to do it will automatically
resend the data to zebra.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>