### PR TITLE
zebra: Fix pseudowires with backup nexthops

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -401,7 +401,7 @@ extern void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 		       bool fromkernel);
 
 extern struct route_entry *rib_match(afi_t afi, safi_t safi, vrf_id_t vrf_id,
-				     union g_addr *addr,
+				     const union g_addr *addr,
 				     struct route_node **rn_out);
 extern struct route_entry *rib_match_ipv4_multicast(vrf_id_t vrf_id,
 						    struct in_addr addr,

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -437,6 +437,10 @@ const union pw_protocol_fields *dplane_ctx_get_pw_proto(
 	const struct zebra_dplane_ctx *ctx);
 const struct nexthop_group *dplane_ctx_get_pw_nhg(
 	const struct zebra_dplane_ctx *ctx);
+const struct nexthop_group *
+dplane_ctx_get_pw_primary_nhg(const struct zebra_dplane_ctx *ctx);
+const struct nexthop_group *
+dplane_ctx_get_pw_backup_nhg(const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for interface information */
 uint32_t dplane_ctx_get_intf_metric(const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -54,6 +54,7 @@ DEFINE_MTYPE_STATIC(ZEBRA, FEC, "MPLS FEC object");
 DEFINE_MTYPE_STATIC(ZEBRA, NHLFE, "MPLS nexthop object");
 
 int mpls_enabled;
+bool mpls_pw_reach_strict; /* Strict reachability checking */
 
 /* static function declarations */
 
@@ -3977,6 +3978,7 @@ void zebra_mpls_init_tables(struct zebra_vrf *zvrf)
 void zebra_mpls_init(void)
 {
 	mpls_enabled = 0;
+	mpls_pw_reach_strict = false;
 
 	if (mpls_kernel_init() < 0) {
 		flog_warn(EC_ZEBRA_MPLS_SUPPORT_DISABLED,

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -576,6 +576,7 @@ static inline int mpls_should_lsps_be_processed(struct route_node *rn)
 
 /* Global variables. */
 extern int mpls_enabled;
+extern bool mpls_pw_reach_strict; /* Strict pseudowire reachability checking */
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -458,6 +458,9 @@ int mpls_kernel_init(void)
 
 	kr_state.rtseq = 1;
 
+	/* Strict pseudowire reachability checking required for obsd */
+	mpls_pw_reach_strict = true;
+
 	return 0;
 }
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -332,7 +332,8 @@ void rib_handle_nhg_replace(struct nhg_hash_entry *old_entry,
 }
 
 struct route_entry *rib_match(afi_t afi, safi_t safi, vrf_id_t vrf_id,
-			      union g_addr *addr, struct route_node **rn_out)
+			      const union g_addr *addr,
+			      struct route_node **rn_out)
 {
 	struct prefix p;
 	struct route_table *table;


### PR DESCRIPTION
Modify the pseudowire reachability logic so that it returns success if there is at least one installed labelled nexthop (primary or backup) for the route resolving the pw destination. The old test required that _all_ nexthops be labelled, and that's not necessary. Also include more info about backups in the pw dataplane contexts.
