### PR TITLE
ospf6d: fix interface area configuration

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -18,13 +18,6 @@ OSPF6 router
 
    Set router's Router-ID.
 
-.. clicmd:: interface IFNAME area (0-4294967295)
-
-.. clicmd:: interface IFNAME area A.B.C.D
-
-   Bind interface to specified area, and start sending OSPF packets. `area` can
-   be specified as 0.
-
 .. clicmd:: timers throttle spf (0-600000) (0-600000) (0-600000)
 
    This command sets the initial `delay`, the `initial-holdtime`
@@ -107,6 +100,10 @@ The following functionalities are implemented as per RFC 3101:
 
 OSPF6 interface
 ===============
+
+.. clicmd:: ipv6 ospf6 area <A.B.C.D|(0-4294967295)>
+
+   Enable OSPFv3 on the interface and add it to the specified area.
 
 .. clicmd:: ipv6 ospf6 cost COST
 
@@ -265,12 +262,12 @@ Example of ospf6d configured on one interface and area:
 .. code-block:: frr
 
    interface eth0
+    ipv6 ospf6 area 0.0.0.0
     ipv6 ospf6 instance-id 0
    !
    router ospf6
     ospf6 router-id 212.17.55.53
     area 0.0.0.0 range 2001:770:105:2::/64
-    interface eth0 area 0.0.0.0
    !
 
 
@@ -282,6 +279,7 @@ Larger example with policy and various options set:
    debug ospf6 neighbor state
    !
    interface fxp0
+    ipv6 ospf6 area 0.0.0.0
     ipv6 ospf6 cost 1
     ipv6 ospf6 hello-interval 10
     ipv6 ospf6 dead-interval 40
@@ -302,7 +300,6 @@ Larger example with policy and various options set:
    router ospf6
     router-id 255.1.1.1
     redistribute static route-map static-ospf6
-    interface fxp0 area 0.0.0.0
    !
    access-list access4 permit 127.0.0.1/32
    !

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -50,18 +50,26 @@
 DEFINE_MTYPE_STATIC(OSPF6D, OSPF6_AREA,      "OSPF6 area");
 DEFINE_MTYPE_STATIC(OSPF6D, OSPF6_PLISTNAME, "Prefix list name");
 
-/* Utility functions. */
-int str2area_id(const char *str, struct in_addr *area_id, int *area_id_fmt)
+int str2area_id(const char *str, uint32_t *area_id, int *area_id_fmt)
 {
 	char *ep;
 
-	area_id->s_addr = htonl(strtoul(str, &ep, 10));
-	if (*ep && !inet_aton(str, area_id))
+	*area_id = htonl(strtoul(str, &ep, 10));
+	if (*ep && inet_pton(AF_INET, str, area_id) != 1)
 		return -1;
 
-	*area_id_fmt = *ep ? OSPF6_AREA_FMT_DECIMAL : OSPF6_AREA_FMT_DOTTEDQUAD;
+	*area_id_fmt =
+		!*ep ? OSPF6_AREA_FMT_DECIMAL : OSPF6_AREA_FMT_DOTTEDQUAD;
 
 	return 0;
+}
+
+void area_id2str(char *buf, int len, uint32_t area_id, int area_id_fmt)
+{
+	if (area_id_fmt == OSPF6_AREA_FMT_DECIMAL)
+		snprintf(buf, len, "%u", ntohl(area_id));
+	else
+		inet_ntop(AF_INET, &area_id, buf, len);
 }
 
 int ospf6_area_cmp(void *va, void *vb)

--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -31,6 +31,7 @@ struct ospf6_area {
 	/* Area-ID */
 	in_addr_t area_id;
 
+#define OSPF6_AREA_FMT_UNSET      0
 #define OSPF6_AREA_FMT_DOTTEDQUAD 1
 #define OSPF6_AREA_FMT_DECIMAL    2
 	/* Area-ID string */
@@ -130,20 +131,22 @@ struct ospf6_area {
 
 #define OSPF6_CMD_AREA_GET(str, oa, ospf6)                                     \
 	{                                                                      \
-		char *ep;                                                      \
-		uint32_t area_id = htonl(strtoul(str, &ep, 10));               \
-		if (*ep && inet_pton(AF_INET, str, &area_id) != 1) {           \
+		uint32_t area_id;                                              \
+		int format, ret;                                               \
+		ret = str2area_id(str, &area_id, &format);                     \
+		if (ret) {                                                     \
 			vty_out(vty, "Malformed Area-ID: %s\n", str);          \
-			return CMD_SUCCESS;                                    \
+			return CMD_WARNING;                                    \
 		}                                                              \
-		int format = !*ep ? OSPF6_AREA_FMT_DECIMAL                     \
-				  : OSPF6_AREA_FMT_DOTTEDQUAD;                 \
 		oa = ospf6_area_lookup(area_id, ospf6);                        \
 		if (oa == NULL)                                                \
 			oa = ospf6_area_create(area_id, ospf6, format);        \
 	}
 
 /* prototypes */
+extern int str2area_id(const char *str, uint32_t *area_id, int *area_id_fmt);
+extern void area_id2str(char *buf, int len, uint32_t area_id, int area_id_fmt);
+
 extern int ospf6_area_cmp(void *va, void *vb);
 
 extern struct ospf6_area *ospf6_area_create(uint32_t, struct ospf6 *, int);
@@ -163,6 +166,5 @@ extern void ospf6_area_config_write(struct vty *vty, struct ospf6 *ospf6);
 extern void ospf6_area_init(void);
 struct ospf6_interface;
 extern void ospf6_area_interface_delete(struct ospf6_interface *oi);
-int str2area_id(const char *str, struct in_addr *area_id, int *area_id_fmt);
 
 #endif /* OSPF_AREA_H */

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -36,6 +36,7 @@
 #include "ospf6_message.h"
 #include "ospf6_route.h"
 #include "ospf6_area.h"
+#include "ospf6_abr.h"
 #include "ospf6_interface.h"
 #include "ospf6_neighbor.h"
 #include "ospf6_intra.h"
@@ -328,31 +329,6 @@ ospf6_interface_get_linklocal_address(struct interface *ifp)
 			l = &c->address->u.prefix6;
 	}
 	return l;
-}
-
-void ospf6_interface_if_add(struct interface *ifp)
-{
-	struct ospf6_interface *oi;
-	unsigned int iobuflen;
-
-	oi = (struct ospf6_interface *)ifp->info;
-	if (oi == NULL)
-		return;
-
-	/* Try to adjust I/O buffer size with IfMtu */
-	if (oi->ifmtu == 0)
-		oi->ifmtu = ifp->mtu6;
-	iobuflen = ospf6_iobuf_size(ifp->mtu6);
-	if (oi->ifmtu > iobuflen) {
-		if (IS_OSPF6_DEBUG_INTERFACE)
-			zlog_debug(
-				"Interface %s: IfMtu is adjusted to I/O buffer size: %d.",
-				ifp->name, iobuflen);
-		oi->ifmtu = iobuflen;
-	}
-
-	/* interface start */
-	ospf6_interface_state_update(oi->interface);
 }
 
 void ospf6_interface_state_update(struct interface *ifp)
@@ -1638,7 +1614,143 @@ DEFUN(show_ipv6_ospf6_interface_prefix, show_ipv6_ospf6_interface_prefix_cmd,
 	return CMD_SUCCESS;
 }
 
+void ospf6_interface_start(struct ospf6_interface *oi)
+{
+	struct ospf6 *ospf6;
+	struct ospf6_area *oa;
+
+	if (oi->area_id_format == OSPF6_AREA_FMT_UNSET)
+		return;
+
+	ospf6 = ospf6_lookup_by_vrf_id(oi->interface->vrf_id);
+	if (!ospf6)
+		return;
+
+	oa = ospf6_area_lookup(oi->area_id, ospf6);
+	if (oa == NULL)
+		oa = ospf6_area_create(oi->area_id, ospf6, oi->area_id_format);
+
+	/* attach interface to area */
+	listnode_add(oa->if_list, oi);
+	oi->area = oa;
+
+	SET_FLAG(oa->flag, OSPF6_AREA_ENABLE);
+
+	/* start up */
+	ospf6_interface_enable(oi);
+
+	/* If the router is ABR, originate summary routes */
+	if (ospf6_is_router_abr(ospf6))
+		ospf6_abr_enable_area(oa);
+}
+
+void ospf6_interface_stop(struct ospf6_interface *oi)
+{
+	struct ospf6_area *oa;
+
+	oa = oi->area;
+	if (!oa)
+		return;
+
+	ospf6_interface_disable(oi);
+
+	listnode_delete(oa->if_list, oi);
+	oi->area = NULL;
+
+	if (oa->if_list->count == 0) {
+		UNSET_FLAG(oa->flag, OSPF6_AREA_ENABLE);
+		ospf6_abr_disable_area(oa);
+	}
+}
+
 /* interface variable set command */
+DEFUN (ipv6_ospf6_area,
+       ipv6_ospf6_area_cmd,
+       "ipv6 ospf6 area <A.B.C.D|(0-4294967295)>",
+       IP6_STR
+       OSPF6_STR
+       "Specify the OSPF6 area ID\n"
+       "OSPF6 area ID in IPv4 address notation\n"
+       "OSPF6 area ID in decimal notation\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf6_interface *oi;
+	int idx_ipv4 = 3;
+	uint32_t area_id;
+	int format;
+	int ipv6_count = 0;
+
+	assert(ifp);
+
+	oi = (struct ospf6_interface *)ifp->info;
+	if (oi == NULL)
+		oi = ospf6_interface_create(ifp);
+	assert(oi);
+
+	if (oi->area) {
+		vty_out(vty, "%s already attached to Area %s\n",
+			oi->interface->name, oi->area->name);
+		return CMD_SUCCESS;
+	}
+
+	/* if more than OSPF6_MAX_IF_ADDRS are configured on this interface
+	 * then don't allow ospfv3 to be configured
+	 */
+	ipv6_count = connected_count_by_family(ifp, AF_INET6);
+	if (oi->ifmtu == OSPF6_DEFAULT_MTU && ipv6_count > OSPF6_MAX_IF_ADDRS) {
+		vty_out(vty,
+			"can not configure OSPFv3 on if %s, must have less than %d interface addresses but has %d addresses\n",
+			ifp->name, OSPF6_MAX_IF_ADDRS, ipv6_count);
+		return CMD_WARNING_CONFIG_FAILED;
+	} else if (oi->ifmtu >= OSPF6_JUMBO_MTU
+		   && ipv6_count > OSPF6_MAX_IF_ADDRS_JUMBO) {
+		vty_out(vty,
+			"can not configure OSPFv3 on if %s, must have less than %d interface addresses but has %d addresses\n",
+			ifp->name, OSPF6_MAX_IF_ADDRS_JUMBO, ipv6_count);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (str2area_id(argv[idx_ipv4]->arg, &area_id, &format)) {
+		vty_out(vty, "Malformed Area-ID: %s\n", argv[idx_ipv4]->arg);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	oi->area_id = area_id;
+	oi->area_id_format = format;
+
+	ospf6_interface_start(oi);
+
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_ipv6_ospf6_area,
+       no_ipv6_ospf6_area_cmd,
+       "no ipv6 ospf6 area [<A.B.C.D|(0-4294967295)>]",
+       NO_STR
+       IP6_STR
+       OSPF6_STR
+       "Specify the OSPF6 area ID\n"
+       "OSPF6 area ID in IPv4 address notation\n"
+       "OSPF6 area ID in decimal notation\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf6_interface *oi;
+
+	assert(ifp);
+
+	oi = (struct ospf6_interface *)ifp->info;
+	if (oi == NULL)
+		oi = ospf6_interface_create(ifp);
+	assert(oi);
+
+	ospf6_interface_stop(oi);
+
+	oi->area_id = 0;
+	oi->area_id_format = OSPF6_AREA_FMT_UNSET;
+
+	return CMD_SUCCESS;
+}
+
 DEFUN (ipv6_ospf6_ifmtu,
        ipv6_ospf6_ifmtu_cmd,
        "ipv6 ospf6 ifmtu (1-65535)",
@@ -2334,6 +2446,7 @@ static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf)
 {
 	struct ospf6_interface *oi;
 	struct interface *ifp;
+	char buf[INET_ADDRSTRLEN];
 
 	FOR_ALL_INTERFACES (vrf, ifp) {
 		oi = (struct ospf6_interface *)ifp->info;
@@ -2348,6 +2461,11 @@ static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf)
 
 		if (ifp->desc)
 			vty_out(vty, " description %s\n", ifp->desc);
+		if (oi->area_id_format != OSPF6_AREA_FMT_UNSET) {
+			area_id2str(buf, sizeof(buf), oi->area_id,
+				    oi->area_id_format);
+			vty_out(vty, " ipv6 ospf6 area %s\n", buf);
+		}
 		if (oi->c_ifmtu)
 			vty_out(vty, " ipv6 ospf6 ifmtu %d\n", oi->c_ifmtu);
 
@@ -2427,7 +2545,9 @@ static int ospf6_ifp_create(struct interface *ifp)
 	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
 		zlog_debug("Zebra Interface add: %s index %d mtu %d", ifp->name,
 			   ifp->ifindex, ifp->mtu6);
-	ospf6_interface_if_add(ifp);
+
+	if (ifp->info)
+		ospf6_interface_start(ifp->info);
 
 	return 0;
 }
@@ -2468,6 +2588,9 @@ static int ospf6_ifp_destroy(struct interface *ifp)
 		zlog_debug("Zebra Interface delete: %s index %d mtu %d",
 			   ifp->name, ifp->ifindex, ifp->mtu6);
 
+	if (ifp->info)
+		ospf6_interface_stop(ifp->info);
+
 	return 0;
 }
 
@@ -2485,6 +2608,8 @@ void ospf6_interface_init(void)
 			&show_ipv6_ospf6_interface_ifname_prefix_cmd);
 	install_element(VIEW_NODE, &show_ipv6_ospf6_interface_traffic_cmd);
 
+	install_element(INTERFACE_NODE, &ipv6_ospf6_area_cmd);
+	install_element(INTERFACE_NODE, &no_ipv6_ospf6_area_cmd);
 	install_element(INTERFACE_NODE, &ipv6_ospf6_cost_cmd);
 	install_element(INTERFACE_NODE, &no_ipv6_ospf6_cost_cmd);
 	install_element(INTERFACE_NODE, &ipv6_ospf6_ifmtu_cmd);

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -39,6 +39,9 @@ struct ospf6_interface {
 	/* back pointer */
 	struct ospf6_area *area;
 
+	uint32_t area_id;
+	int area_id_format;
+
 	/* list of ospf6 neighbor */
 	struct list *neighbor_list;
 
@@ -177,6 +180,9 @@ extern const char *const ospf6_interface_state_str[];
 
 /* Function Prototypes */
 
+extern void ospf6_interface_start(struct ospf6_interface *oi);
+extern void ospf6_interface_stop(struct ospf6_interface *oi);
+
 extern struct ospf6_interface *
 ospf6_interface_lookup_by_ifindex(ifindex_t, vrf_id_t vrf_id);
 extern struct ospf6_interface *ospf6_interface_create(struct interface *);
@@ -185,7 +191,6 @@ extern void ospf6_interface_delete(struct ospf6_interface *);
 extern void ospf6_interface_enable(struct ospf6_interface *);
 extern void ospf6_interface_disable(struct ospf6_interface *);
 
-extern void ospf6_interface_if_add(struct interface *);
 extern void ospf6_interface_state_update(struct interface *);
 extern void ospf6_interface_connected_route_update(struct interface *);
 extern void ospf6_interface_connected_route_add(struct connected *);

--- a/tests/topotests/ospf6_topo1_vrf/README.md
+++ b/tests/topotests/ospf6_topo1_vrf/README.md
@@ -54,10 +54,12 @@ Simplified `R1` config (R1 is similar)
 	hostname r1
 	!
 	interface r1-stubnet vrf r1-cust1
+	 ipv6 ospf6 area 0.0.0.0
 	 ipv6 address fc00:1:1:1::1/64
 	 ipv6 ospf6 network broadcast
 	!
 	interface r1-sw5 vrf r1-cust1
+	 ipv6 ospf6 area 0.0.0.0
 	 ipv6 address fc00:a:a:a::1/64
 	 ipv6 ospf6 network broadcast
 	!
@@ -65,8 +67,6 @@ Simplified `R1` config (R1 is similar)
 	 router-id 10.0.0.1
 	 log-adjacency-changes detail
 	 redistribute static
-	 interface r1-stubnet area 0.0.0.0
-	 interface r1-sw5 area 0.0.0.0
 	!
 	ipv6 route fc00:1111:1111:1111::/64 fc00:1:1:1::1234 vrf r1-cust1
 
@@ -75,14 +75,17 @@ Simplified `R3` config
 	hostname r3
 	!
 	interface r3-stubnet vrf r3-cust1
+	 ipv6 ospf6 area 0.0.0.0
 	 ipv6 address fc00:3:3:3::3/64
 	 ipv6 ospf6 network broadcast
 	!
 	interface r3-sw5 vrf r3-cust1
+	 ipv6 ospf6 area 0.0.0.0
 	 ipv6 address fc00:a:a:a::3/64
 	 ipv6 ospf6 network broadcast
 	!
 	interface r3-sw6 vrf r3-cust1
+	 ipv6 ospf6 area 0.0.0.1
 	 ipv6 address fc00:b:b:b::3/64
 	 ipv6 ospf6 network broadcast
 	!
@@ -90,9 +93,6 @@ Simplified `R3` config
 	 router-id 10.0.0.3
 	 log-adjacency-changes detail
 	 redistribute static
-	 interface r3-stubnet area 0.0.0.0
-	 interface r3-sw5 area 0.0.0.0
-	 interface r3-sw6 area 0.0.0.1
 	!
 	ipv6 route fc00:3333:3333:3333::/64 fc00:3:3:3::1234 vrf r3-cust1
 

--- a/tests/topotests/ospf6_topo1_vrf/r1/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r1/ospf6d.conf
@@ -10,11 +10,13 @@ debug ospf6 route table
 debug ospf6 flooding
 !
 interface r1-stubnet
+ ipv6 ospf6 area 0.0.0.0
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
 interface r1-sw5
+ ipv6 ospf6 area 0.0.0.0
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
@@ -23,8 +25,6 @@ router ospf6 vrf r1-cust1
  ospf6 router-id 10.0.0.1
  log-adjacency-changes detail
  redistribute static
- interface r1-stubnet area 0.0.0.0
- interface r1-sw5 area 0.0.0.0
 !
 line vty
  exec-timeout 0 0

--- a/tests/topotests/ospf6_topo1_vrf/r1/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r1/ospf6d.conf
@@ -9,12 +9,12 @@ debug ospf6 neighbor
 debug ospf6 route table
 debug ospf6 flooding
 !
-interface r1-stubnet vrf r1-cust1
+interface r1-stubnet
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
-interface r1-sw5 vrf r1-cust1
+interface r1-sw5
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10

--- a/tests/topotests/ospf6_topo1_vrf/r2/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r2/ospf6d.conf
@@ -9,12 +9,12 @@ debug ospf6 neighbor
 debug ospf6 route table
 debug ospf6 flooding
 !
-interface r2-stubnet vrf r2-cust1
+interface r2-stubnet
  ipv6 ospf6 network broadcast
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2
 !
-interface r2-sw5 vrf r2-cust1
+interface r2-sw5
  ipv6 ospf6 network broadcast
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2

--- a/tests/topotests/ospf6_topo1_vrf/r2/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r2/ospf6d.conf
@@ -10,11 +10,13 @@ debug ospf6 route table
 debug ospf6 flooding
 !
 interface r2-stubnet
+ ipv6 ospf6 area 0.0.0.0
  ipv6 ospf6 network broadcast
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2
 !
 interface r2-sw5
+ ipv6 ospf6 area 0.0.0.0
  ipv6 ospf6 network broadcast
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2
@@ -23,8 +25,6 @@ router ospf6 vrf r2-cust1
  ospf6 router-id 10.0.0.2
  log-adjacency-changes detail
  redistribute static
- interface r2-stubnet area 0.0.0.0
- interface r2-sw5 area 0.0.0.0
 !
 line vty
  exec-timeout 0 0

--- a/tests/topotests/ospf6_topo1_vrf/r3/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r3/ospf6d.conf
@@ -9,17 +9,17 @@ debug ospf6 neighbor
 debug ospf6 route table
 debug ospf6 flooding
 !
-interface r3-stubnet vrf r3-cust1 
+interface r3-stubnet
  ipv6 ospf6 network broadcast
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2
 !
-interface r3-sw5 vrf r3-cust1
+interface r3-sw5
  ipv6 ospf6 network broadcast
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2
 !
-interface r3-sw6 vrf r3-cust1
+interface r3-sw6
  ipv6 ospf6 network broadcast
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2

--- a/tests/topotests/ospf6_topo1_vrf/r3/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r3/ospf6d.conf
@@ -10,16 +10,19 @@ debug ospf6 route table
 debug ospf6 flooding
 !
 interface r3-stubnet
+ ipv6 ospf6 area 0.0.0.0
  ipv6 ospf6 network broadcast
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2
 !
 interface r3-sw5
+ ipv6 ospf6 area 0.0.0.0
  ipv6 ospf6 network broadcast
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2
 !
 interface r3-sw6
+ ipv6 ospf6 area 0.0.0.1
  ipv6 ospf6 network broadcast
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2
@@ -28,9 +31,6 @@ router ospf6 vrf r3-cust1
  ospf6 router-id 10.0.0.3
  log-adjacency-changes detail
  redistribute static
- interface r3-stubnet area 0.0.0.0
- interface r3-sw5 area 0.0.0.0
- interface r3-sw6 area 0.0.0.1
 !
 line vty
  exec-timeout 0 0

--- a/tests/topotests/ospf6_topo1_vrf/r4/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r4/ospf6d.conf
@@ -10,11 +10,13 @@ debug ospf6 route table
 debug ospf6 flooding
 !
 interface r4-stubnet
+ ipv6 ospf6 area 0.0.0.1
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
 interface r4-sw6
+ ipv6 ospf6 area 0.0.0.1
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
@@ -23,8 +25,6 @@ router ospf6 vrf r4-cust1
  ospf6 router-id 10.0.0.4
  log-adjacency-changes detail
  redistribute static
- interface r4-stubnet area 0.0.0.1
- interface r4-sw6 area 0.0.0.1
 !
 line vty
  exec-timeout 0 0

--- a/tests/topotests/ospf6_topo1_vrf/r4/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r4/ospf6d.conf
@@ -9,12 +9,12 @@ debug ospf6 neighbor
 debug ospf6 route table
 debug ospf6 flooding
 !
-interface r4-stubnet vrf r4-cust1 
+interface r4-stubnet
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
-interface r4-sw6 vrf r4-cust1
+interface r4-sw6
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10


### PR DESCRIPTION
Currently the interface area is configured from the router node using
"interface IFNAME area ID" command. There are multiple problems with
this command:
- it is not in line with all other interface-related commands - other
  parameters are configured from the interface node using "ipv6 ospf6"
  prefix
- it is not in line with OSPFv2 - area is configured from the interface
  node using "ip ospf area" command
- most importantly, it doesn't work correctly when the interface is in
  a different VRF - instead of configuring the interface, it creates a
  new fake interface and configuring it instead

To fix all the problems, this commit adds a new command to the interface
configuration node - "ipv6 ospf6 area ID". The purpose of the command is
completely the same, but it works correctly in a multi-VRF environment.

The old command is preserved for the backward compatibility, but the
warning is added that it is deprecated because it doesn't work correctly
with VRFs.