### PR TITLE
ospf6d: fix debug message issues

### DIFF
--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -2669,23 +2669,23 @@ int config_write_ospf6_debug_message(struct vty *vty)
 
 	for (i = 1; i < 6; i++) {
 		if (IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, SEND)
-		    && IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, RECV))
+		    && IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, RECV)) {
 			vty_out(vty, "debug ospf6 message %s\n", type_str[i]);
-		else if (IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, SEND))
+			continue;
+		}
+
+		if (IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, SEND))
 			vty_out(vty, "debug ospf6 message %s send\n",
-				type_str[i]);
-		else if (IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, RECV))
-			vty_out(vty, "debug ospf6 message %s recv\n",
-				type_str[i]);
-		else if (IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, SEND_HDR)
-			 && IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, RECV_HDR))
-			vty_out(vty, "debug ospf6 message %s; header only\n",
-				type_str[i]);
-		else if (IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, RECV_HDR))
-			vty_out(vty, "debug ospf6 message %s recv-hdr\n",
 				type_str[i]);
 		else if (IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, SEND_HDR))
 			vty_out(vty, "debug ospf6 message %s send-hdr\n",
+				type_str[i]);
+
+		if (IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, RECV))
+			vty_out(vty, "debug ospf6 message %s recv\n",
+				type_str[i]);
+		else if (IS_OSPF6_DEBUG_MESSAGE_ENABLED(i, RECV_HDR))
+			vty_out(vty, "debug ospf6 message %s recv-hdr\n",
 				type_str[i]);
 	}
 

--- a/ospf6d/ospf6_message.h
+++ b/ospf6d/ospf6_message.h
@@ -42,14 +42,14 @@ extern unsigned char conf_debug_ospf6_message[];
 	(conf_debug_ospf6_message[type] &= ~(level))
 
 #define IS_OSPF6_DEBUG_MESSAGE(t, e)                                           \
-	((OSPF6_DEBUG_MESSAGE_##e) == OSPF6_DEBUG_MESSAGE_RECV_HDR)            \
+	(((OSPF6_DEBUG_MESSAGE_##e) == OSPF6_DEBUG_MESSAGE_RECV_HDR)           \
 		? (conf_debug_ospf6_message[t]                                 \
 		   & (OSPF6_DEBUG_MESSAGE_RECV_BOTH))                          \
 		: (((OSPF6_DEBUG_MESSAGE_##e) == OSPF6_DEBUG_MESSAGE_SEND_HDR) \
 			   ? (conf_debug_ospf6_message[t]                      \
 			      & (OSPF6_DEBUG_MESSAGE_SEND_BOTH))               \
 			   : (conf_debug_ospf6_message[t]                      \
-			      & (OSPF6_DEBUG_MESSAGE_##e)))
+			      & (OSPF6_DEBUG_MESSAGE_##e))))
 
 #define IS_OSPF6_DEBUG_MESSAGE_ENABLED(type, e)                                \
 	(conf_debug_ospf6_message[type] & (OSPF6_DEBUG_MESSAGE_##e))


### PR DESCRIPTION
```
ospf6d: fix invalid "no debug ospf6 message unknown"

The message is always shown in the config, because IS_OSPF6_DEBUG_MESSAGE
works incorrectly when negated because of missing outer brackets.
```
```
ospf6d: fix debug message config write

Fix the following issues:
- if "send" is combined with "recv-hdr", only "send" is shown
- if "recv" is combined with "send-hdr", only "recv" is shown
- if both "send-hdr" and "recv-hdr" are enabled, "; header only" is shown
```