### PR TITLE
ospf6d: Fix route map "set tag" command

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -2009,6 +2009,9 @@ static void ospf6_routemap_init(void)
 	route_map_set_metric_hook(generic_set_add);
 	route_map_no_set_metric_hook(generic_set_delete);
 
+	route_map_set_tag_hook(generic_set_add);
+	route_map_no_set_tag_hook(generic_set_delete);
+
 	route_map_match_tag_hook(generic_match_add);
 	route_map_no_match_tag_hook(generic_match_delete);
 


### PR DESCRIPTION
So far, "set tag" was 99% implemented in ospf6d, but registration of the
hook functions was missing, causing "set tag" actions in route maps to be
ignored in ospf6d.

This commit adds the missing hook registration.


Without this bugfix (zebra & ospf6d running):
```
root@d30049169956:~# vtysh 
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.

Hello, this is FRRouting (version 8.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

d30049169956# conf t       
d30049169956(config)# route-map FOO permit 10
d30049169956(config-route-map)# set metric 123
d30049169956(config-route-map)# set tag 123
d30049169956(config-route-map)# end
d30049169956# show route-map FOO 
ZEBRA:
route-map: FOO Invoked: 0 Optimization: enabled Processed Change: false
 permit, sequence 10 Invoked 0
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
OSPF6:
route-map: FOO Invoked: 0 Optimization: enabled Processed Change: false
 permit, sequence 10 Invoked 0
  Match clauses:
  Set clauses:
    metric 123
  Call clause:
  Action:
    Exit routemap
d30049169956# 
```

Note that for ospf6d, only one set clause is printed.

With this bugfix:
```
77d12f5fd12f# show route-map FOO
ZEBRA:
route-map: FOO Invoked: 0 Optimization: enabled Processed Change: false
 permit, sequence 10 Invoked 0
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
OSPF6:
route-map: FOO Invoked: 0 Optimization: enabled Processed Change: false
 permit, sequence 10 Invoked 0
  Match clauses:
  Set clauses:
    metric 123
    tag 123
  Call clause:
  Action:
    Exit routemap
```

Note the additional *tag 123" in the route-map for OSPF6.

As soon as *tag 123" can be configured, route tagging starts to work and redistributed routes get tagged accordingly.
