### PR TITLE
staticd: return meaningful status in cli error path

### DIFF
--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -294,9 +294,8 @@ static int static_route_leak(struct vty *vty, const char *svrf,
 
 		dnode = yang_dnode_get(vty->candidate_config->dnode, ab_xpath);
 		if (!dnode) {
-			vty_out(vty,
-				"%% Refusing to remove a non-existent route\n");
-			return ret;
+			/* Silently return */
+			return CMD_SUCCESS;
 		}
 
 		dnode = yang_get_subtree_with_no_sibling(dnode);


### PR DESCRIPTION
Return a meaningful vtysh value in an error path, if user tries to delete a route that doesn't exist - staticd has always returned SUCCESS in this case.
