### PR TITLE
[8.0] lib: fix handling of rmap prefix-tree default node

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1982,7 +1982,15 @@ static void route_map_add_plist_entries(afi_t afi,
 		return;
 	}
 
-	route_map_pfx_table_del_default(afi, index);
+	/* Default entry should be deleted only if the first entry of the
+	 * prefix-list is created.
+	 */
+	if (entry) {
+		if (plist->count == 1)
+			route_map_pfx_table_del_default(afi, index);
+	} else {
+		route_map_pfx_table_del_default(afi, index);
+	}
 
 	if (entry) {
 		if (afi == AFI_IP) {


### PR DESCRIPTION
Backport of #8718 to 8.0