### PR TITLE
zebra: rework RA handling for vrf-lite

### DIFF
--- a/doc/user/ipv6.rst
+++ b/doc/user/ipv6.rst
@@ -17,6 +17,11 @@ no longer possible.
 Router Advertisement
 ====================
 
+.. clicmd:: show ipv6 nd ra-interfaces [vrf <VRFNAME|all>]
+
+   Show configured route advertisement interfaces. VRF subcommand only
+   applicable for netns-based vrfs.
+
 .. clicmd:: ipv6 nd suppress-ra
 
    Don't send router advertisement messages. The ``no`` form of this command

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -186,7 +186,6 @@ static void sigint(void)
 		work_queue_free_and_null(&zrouter.lsp_process_q);
 
 	vrf_terminate();
-	rtadv_terminate();
 
 	ns_walk_func(zebra_ns_early_shutdown, NULL, NULL);
 	zebra_ns_notify_close();

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -288,16 +288,30 @@ DECLARE_LIST(re_list, struct route_entry, next);
 #define RNODE_NEXT_RE(rn, re) RE_DEST_NEXT_ROUTE(rib_dest_from_rnode(rn), re)
 
 #if defined(HAVE_RTADV)
+PREDECL_SORTLIST_UNIQ(adv_if_list);
 /* Structure which hold status of router advertisement. */
 struct rtadv {
 	int sock;
 
-	int adv_if_count;
-	int adv_msec_if_count;
+	struct adv_if_list_head adv_if;
+	struct adv_if_list_head adv_msec_if;
 
 	struct thread *ra_read;
 	struct thread *ra_timer;
 };
+
+/* adv list node */
+struct adv_if {
+	char name[INTERFACE_NAMSIZ];
+	struct adv_if_list_item list_item;
+};
+
+static int adv_if_cmp(const struct adv_if *a, const struct adv_if *b)
+{
+	return if_cmp_name_func(a->name, b->name);
+}
+
+DECLARE_SORTLIST_UNIQ(adv_if_list, struct adv_if, list_item, adv_if_cmp);
 #endif /* HAVE_RTADV */
 
 /*

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -953,7 +953,7 @@ static struct adv_if *adv_if_add(struct zebra_vrf *zvrf, const char *name)
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		struct vrf *vrf = zvrf->vrf;
 
-		zlog_debug("%s: %s:%u IF %s count: %lu", __func__,
+		zlog_debug("%s: %s:%u IF %s count: %zu", __func__,
 			   VRF_LOGNAME(vrf), zvrf_id(zvrf), name,
 			   adv_if_list_count(&zvrf->rtadv.adv_if));
 	}
@@ -977,7 +977,7 @@ static struct adv_if *adv_if_del(struct zebra_vrf *zvrf, const char *name)
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		struct vrf *vrf = zvrf->vrf;
 
-		zlog_debug("%s: %s:%u IF %s count: %lu", __func__,
+		zlog_debug("%s: %s:%u IF %s count: %zu", __func__,
 			   VRF_LOGNAME(vrf), zvrf_id(zvrf), name,
 			   adv_if_list_count(&zvrf->rtadv.adv_if));
 	}
@@ -1001,7 +1001,7 @@ static struct adv_if *adv_msec_if_add(struct zebra_vrf *zvrf, const char *name)
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		struct vrf *vrf = zvrf->vrf;
 
-		zlog_debug("%s: %s:%u IF %s count: %lu", __func__,
+		zlog_debug("%s: %s:%u IF %s count: %zu", __func__,
 			   VRF_LOGNAME(vrf), zvrf_id(zvrf), name,
 			   adv_if_list_count(&zvrf->rtadv.adv_msec_if));
 	}
@@ -1025,7 +1025,7 @@ static struct adv_if *adv_msec_if_del(struct zebra_vrf *zvrf, const char *name)
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		struct vrf *vrf = zvrf->vrf;
 
-		zlog_debug("%s: %s:%u IF %s count: %lu", __func__,
+		zlog_debug("%s: %s:%u IF %s count: %zu", __func__,
 			   VRF_LOGNAME(vrf), zvrf_id(zvrf), name,
 			   adv_if_list_count(&zvrf->rtadv.adv_msec_if));
 	}
@@ -1039,7 +1039,7 @@ static void adv_if_clean(struct zebra_vrf *zvrf)
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		struct vrf *vrf = zvrf->vrf;
 
-		zlog_debug("%s: %s:%u count: %lu -> 0", __func__,
+		zlog_debug("%s: %s:%u count: %zu -> 0", __func__,
 			   VRF_LOGNAME(vrf), zvrf_id(zvrf),
 			   adv_if_list_count(&zvrf->rtadv.adv_if));
 	}
@@ -1053,7 +1053,7 @@ static void adv_msec_if_clean(struct zebra_vrf *zvrf)
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		struct vrf *vrf = zvrf->vrf;
 
-		zlog_debug("%s: %s:%u count: %lu -> 0", __func__,
+		zlog_debug("%s: %s:%u count: %zu -> 0", __func__,
 			   VRF_LOGNAME(vrf), zvrf_id(zvrf),
 			   adv_if_list_count(&zvrf->rtadv.adv_msec_if));
 	}

--- a/zebra/rtadv.h
+++ b/zebra/rtadv.h
@@ -152,9 +152,8 @@ enum ipv6_nd_suppress_ra_status {
 	RA_SUPPRESS,
 };
 
-extern void rtadv_init(struct zebra_vrf *zvrf);
+extern void rtadv_vrf_init(struct zebra_vrf *zvrf);
 extern void rtadv_vrf_terminate(struct zebra_vrf *zvrf);
-extern void rtadv_terminate(void);
 extern void rtadv_stop_ra(struct interface *ifp);
 extern void rtadv_stop_ra_all(void);
 extern void rtadv_cmd_init(void);

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -268,8 +268,6 @@ void zebra_router_init(bool asic_offload, bool notify_on_ack)
 
 	zrouter.packets_to_process = ZEBRA_ZAPI_PACKETS_TO_PROCESS;
 
-	zrouter.rtadv_sock = -1;
-
 	zebra_vxlan_init();
 	zebra_mlag_init();
 

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -162,9 +162,6 @@ struct zebra_router {
 
 	struct hash *iptable_hash;
 
-	/* used if vrf backend is not network namespace */
-	int rtadv_sock;
-
 	/* A sequence number used for tracking routes */
 	_Atomic uint32_t sequence_num;
 

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -131,7 +131,7 @@ static int zebra_vrf_enable(struct vrf *vrf)
 	else
 		zvrf->zns = zebra_ns_lookup(NS_DEFAULT);
 #if defined(HAVE_RTADV)
-	rtadv_init(zvrf);
+	rtadv_vrf_init(zvrf);
 #endif
 
 	/* Inform clients that the VRF is now active. This is an


### PR DESCRIPTION
Rework RA handling for vrf-lite scenarios.

Before we were using a single FD descriptor for polling
across multiple zvrf's. This would cause us to hit this
assert() in some bgp unnumbered and vrrp configs:

```
/*
 * What happens if we have a thread already
 * created for this event?
 */
if (thread_array[fd])
	assert(!"Thread already scheduled for file descriptor");
```

We were scheduling a thread_read on the same FD for every zvrf.

With vrf-lite, RAs and ARPs are not vrf-bound, so we can just use one
rtadv instance to manage them for all VRFs. We will choose the default
VRF for this.

This patch removes the rtadv_sock altogether for zrouter and moves the
functionality this represented to the default VRF. All RAs will be
handled in the default VRF under vrf-lite configs with only one poll
thread started for it.

This patch also extends how we track subscribed interfaces (s or msec)
to use an actual sorted list by interface names rather than just a
counter. With multiple daemons turning interfaces/on/off these counters
can get very wrong during ifup/down events. Making them a sorted list
prevents this from happening by preventing duplicates.

With netns-vrf's nothing should change other than the interface list.

Signed-off-by: Stephen Worley <sworley@nvidia.com>