### PR TITLE
lib: add an MTYPE for bitfields

### DIFF
--- a/lib/bitfield.h
+++ b/lib/bitfield.h
@@ -60,6 +60,8 @@ typedef unsigned int word_t;
  */
 typedef struct {word_t *data; size_t n, m; } bitfield_t;
 
+DECLARE_MTYPE(BITFIELD);
+
 /**
  * Initialize the bits.
  * @v: an instance of bitfield_t struct.
@@ -70,7 +72,7 @@ typedef struct {word_t *data; size_t n, m; } bitfield_t;
 	do {                                                                   \
 		(v).n = 0;                                                     \
 		(v).m = ((N) / WORD_SIZE + 1);                                 \
-		(v).data = calloc(1, ((v).m * sizeof(word_t)));                \
+		(v).data = XCALLOC(MTYPE_BITFIELD, ((v).m * sizeof(word_t)));  \
 	} while (0)
 
 /**
@@ -193,7 +195,7 @@ static inline unsigned int bf_find_next_set_bit(bitfield_t v,
  */
 #define bf_free(v)                                                             \
 	do {                                                                   \
-		free((v).data);                                                \
+		XFREE(MTYPE_BITFIELD, (v).data);                               \
 		(v).data = NULL;                                               \
 	} while (0)
 

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -36,6 +36,7 @@ struct memgroup **mg_insert = &mg_first;
 
 DEFINE_MGROUP(LIB, "libfrr");
 DEFINE_MTYPE(LIB, TMP, "Temporary memory");
+DEFINE_MTYPE(LIB, BITFIELD, "Bitfield memory");
 
 static inline void mt_count_alloc(struct memtype *mt, size_t size, void *ptr)
 {


### PR DESCRIPTION
it is handy to be able to see allocated bitfields in the show
memory output.

Signed-off-by: Pat Ruddy <pat@voltanet.io>