### PR TITLE
ospf6: fix memory leak in ospf6_abr_examin_summary

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -1224,8 +1224,6 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 		if (table->hook_add)
 			(*table->hook_add)(old_route);
 
-		/* Delete new route */
-		ospf6_route_delete(route);
 		break;
 	}
 
@@ -1253,7 +1251,9 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 		listnode_add_sort(route->paths, path);
 		/* ospf6_ia_add_nw_route (table, &prefix, route); */
 		ospf6_route_add(route, table);
-	}
+	} else
+		/* if we did not add the route remove it */
+		ospf6_route_delete(route);
 }
 
 void ospf6_abr_examin_brouter(uint32_t router_id, struct ospf6_route *route,

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -39,6 +39,7 @@
 #include "ospf6_zebra.h"
 
 DEFINE_MTYPE_STATIC(OSPF6D, OSPF6_ROUTE,   "OSPF6 route");
+DEFINE_MTYPE_STATIC(OSPF6D, OSPF6_ROUTE_TABLE, "OSPF6 route table");
 DEFINE_MTYPE_STATIC(OSPF6D, OSPF6_NEXTHOP, "OSPF6 nexthop");
 DEFINE_MTYPE_STATIC(OSPF6D, OSPF6_PATH,    "OSPF6 Path");
 
@@ -1021,7 +1022,8 @@ void ospf6_route_remove_all(struct ospf6_route_table *table)
 struct ospf6_route_table *ospf6_route_table_create(int s, int t)
 {
 	struct ospf6_route_table *new;
-	new = XCALLOC(MTYPE_OSPF6_ROUTE, sizeof(struct ospf6_route_table));
+	new = XCALLOC(MTYPE_OSPF6_ROUTE_TABLE,
+		      sizeof(struct ospf6_route_table));
 	new->table = route_table_init();
 	new->scope_type = s;
 	new->table_type = t;
@@ -1033,7 +1035,7 @@ void ospf6_route_table_delete(struct ospf6_route_table *table)
 	ospf6_route_remove_all(table);
 	bf_free(table->idspace);
 	route_table_finish(table->table);
-	XFREE(MTYPE_OSPF6_ROUTE, table);
+	XFREE(MTYPE_OSPF6_ROUTE_TABLE, table);
 }
 
 


### PR DESCRIPTION
Ensure that if allocated route is not added to a table then it is
deleted to avoid leaking memory.
Add a new memory type for route table so that ospf6 routes can be
distinguished in the show memory output in isolation.

Signed-off-by: Pat Ruddy <pat@voltanet.io>