### PR TITLE
isisd, ospf6d, pimd: set vrf_id when creating bfd sessions

### DIFF
--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -132,6 +132,7 @@ static void bfd_handle_adj_up(struct isis_adjacency *adj)
 		bfd_sess_set_ipv6_addrs(adj->bfd_session, &src_ip.ipv6,
 					&dst_ip.ipv6);
 	bfd_sess_set_interface(adj->bfd_session, adj->circuit->interface->name);
+	bfd_sess_set_vrf(adj->bfd_session, adj->circuit->interface->vrf_id);
 	bfd_sess_set_profile(adj->bfd_session, circuit->bfd_config.profile);
 	bfd_sess_install(adj->bfd_session);
 	return;

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -143,6 +143,7 @@ void ospf6_bfd_info_nbr_create(struct ospf6_interface *oi,
 	bfd_sess_set_ipv6_addrs(on->bfd_session, on->ospf6_if->linklocal_addr,
 				&on->linklocal_addr);
 	bfd_sess_set_interface(on->bfd_session, oi->interface->name);
+	bfd_sess_set_vrf(on->bfd_session, oi->interface->vrf_id);
 	bfd_sess_set_profile(on->bfd_session, oi->bfd_config.profile);
 }
 

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -96,6 +96,7 @@ void pim_bfd_info_nbr_create(struct pim_interface *pim_ifp,
 		pim_ifp->bfd_config.min_rx, pim_ifp->bfd_config.min_tx);
 	bfd_sess_set_ipv4_addrs(neigh->bfd_session, NULL, &neigh->source_addr);
 	bfd_sess_set_interface(neigh->bfd_session, neigh->interface->name);
+	bfd_sess_set_vrf(neigh->bfd_session, neigh->interface->vrf_id);
 	bfd_sess_set_profile(neigh->bfd_session, pim_ifp->bfd_config.profile);
 	bfd_sess_install(neigh->bfd_session);
 }


### PR DESCRIPTION
Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>