### PR TITLE
pathd: fix render candidate-path bandwidth

### DIFF
--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -1195,9 +1195,10 @@ void cli_show_srte_policy_candidate_path(struct vty *vty,
 				dnode, "./constraints/bandwidth/value");
 			required = yang_dnode_get_bool(
 				dnode, "./constraints/bandwidth/required");
-			vty_out(vty, "    %sbandwidth",
-				required ? "required " : "");
+			vty_out(vty, "    bandwidth");
 			config_write_float(vty, bandwidth);
+			if (required)
+				vty_out(vty, " required");
 			vty_out(vty, "\n");
 		}
 		if (yang_dnode_exists(dnode,


### PR DESCRIPTION
the config for dynamic candidate paths with bandwidth preferences was using a different order of keywords (`required bandwidth X`) than the corresponding command (`bandwidth X required`). This confuses frr-reload, and possibly users too. Make both use the same order.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>