### PR TITLE
bfdd: fix bfd key structure

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -173,15 +173,26 @@ enum bfd_session_flags {
 	BFD_SESS_FLAG_PASSIVE = 1 << 10, /* Passive mode */
 };
 
-/* BFD session hash keys */
+/*
+ * BFD session hash key.
+ *
+ * This structure must not have any padding bytes because their value is
+ * unspecified after the struct assignment. Even when all fields of two keys
+ * are the same, if the padding bytes are different, then the calculated hash
+ * value is different, and the hash lookup will fail.
+ *
+ * Currently, the structure fields are correctly aligned, and the "packed"
+ * attribute is added as a precaution. "family" and "mhop" fields are two-bytes
+ * to eliminate unaligned memory access to "peer" and "local".
+ */
 struct bfd_key {
 	uint16_t family;
-	uint8_t mhop;
+	uint16_t mhop;
 	struct in6_addr peer;
 	struct in6_addr local;
 	char ifname[MAXNAMELEN];
 	char vrfname[MAXNAMELEN];
-};
+} __attribute__((packed));
 
 struct bfd_session_stats {
 	uint64_t rx_ctrl_pkt;


### PR DESCRIPTION
There's a padding byte between "mhop" and "peer" fields in this structure.
This structure is sometimes passed by value to functions and used in
assignments. The standard doesn't guarantee that the padding bytes are
copied on assignments. As this structure is used as a hash key, having
this padding byte with unspecified value can lead to unwanted behavior.

Fix the possible issue by making the struct packed.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>