### PR TITLE
doc: remove varnames from command descriptions

### DIFF
--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -124,7 +124,7 @@ BFDd Commands
 
     Show all configured BFD peers information and current status.
 
-.. clicmd:: show bfd [vrf NAME$vrf_name] peer <WORD$label|<A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname}]> [json]
+.. clicmd:: show bfd [vrf NAME] peer <WORD|<A.B.C.D|X:X::X:X> [{multihop|local-address <A.B.C.D|X:X::X:X>|interface IFNAME}]> [json]
 
     Show status for a specific BFD peer.
 

--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -108,14 +108,14 @@ keyword. At present, no sharp commands will be preserved in the config.
    Send opaque ZAPI messages with subtype ``type``. Sharpd will send
    a stream of messages if the count is greater than one.
 
-.. clicmd:: sharp send opaque unicast type (1-255) $proto_str [{instance (0-1000) | session (1-1000)}] (1-1000)
+.. clicmd:: sharp send opaque unicast type (1-255) PROTOCOL [{instance (0-1000) | session (1-1000)}] (1-1000)
 
    Send unicast opaque ZAPI messages with subtype ``type``. The
    protocol, instance, and session_id identify a single target zapi
    client. Sharpd will send a stream of messages if the count is
    greater than one.
 
-.. clicmd:: sharp send opaque <reg | unreg> $proto_str [{instance (0-1000) | session (1-1000)}] type (1-1000)
+.. clicmd:: sharp send opaque <reg | unreg> PROTOCOL [{instance (0-1000) | session (1-1000)}] type (1-1000)
 
    Send opaque ZAPI registration and unregistration messages for a
    single subtype. The messages must specify a protocol daemon by


### PR DESCRIPTION
Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>