### PR TITLE
tools: add warning logs for unsupported instances case.

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -133,6 +133,11 @@ daemon_prep() {
 	daemon="$1"
 	inst="$2"
 	[ "$daemon" = "watchfrr" ] && return 0
+	# Only daemon ospfd can create instances
+	[ "${daemon}" != "ospfd" ] && [ -n "$inst" ] && {
+		log_failure_msg "cannot start $daemon${inst:+ (instance $inst)}: daemon instances not supported"
+		return 1
+	}
 	[ -x "$D_PATH/$daemon" ] || {
 		log_failure_msg "cannot start $daemon${inst:+ (instance $inst)}: daemon binary not installed"
 		return 1


### PR DESCRIPTION
This instance number is used for multi-instances case.
At lease, two files need it: bgpd-<instance-id>.pid and bgpd-<instance-id>.vty,
Or else, bgpd can't start up for multi-instances case.

update:
Just throws warning for those unsupported multiple instance, otherwise uses will get confused.