### PR TITLE
ospf6d: fix LSAs remain in LSDB with an old router-id value

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -2483,20 +2483,22 @@ void ospf6_asbr_redistribute_disable(struct ospf6 *ospf6)
 	int type;
 	struct ospf6_redist *red;
 
-	for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
+	for (type = 0; type <= ZEBRA_ROUTE_MAX; type++) {
+		if (type == ZEBRA_ROUTE_OSPF6)
+			continue;
 		red = ospf6_redist_lookup(ospf6, type, 0);
 		if (!red)
 			continue;
-		if (type == ZEBRA_ROUTE_OSPF6)
+
+		if (type == DEFAULT_ROUTE) {
+			ospf6_asbr_routemap_unset(red);
+			ospf6_redist_del(ospf6, red, type);
+			ospf6_redistribute_default_set(ospf6,
+						       DEFAULT_ORIGINATE_NONE);
 			continue;
+		}
 		ospf6_asbr_redistribute_unset(ospf6, red, type);
 		ospf6_redist_del(ospf6, red, type);
-	}
-	red = ospf6_redist_lookup(ospf6, DEFAULT_ROUTE, 0);
-	if (red) {
-		ospf6_asbr_routemap_unset(red);
-		ospf6_redist_del(ospf6, red, type);
-		ospf6_redistribute_default_set(ospf6, DEFAULT_ORIGINATE_NONE);
 	}
 }
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -73,6 +73,8 @@ struct ospf6_master *om6;
 
 static void ospf6_disable(struct ospf6 *o);
 
+static void ospf6_process_reset(struct ospf6 *ospf6);
+
 static void ospf6_add(struct ospf6 *ospf6)
 {
 	listnode_add(om6->ospf6, ospf6);
@@ -628,6 +630,9 @@ void ospf6_router_id_update(struct ospf6 *ospf6, bool init, struct vty *vty)
 		}
 
 	ospf6->router_id = new_router_id;
+
+	if (!init)
+		ospf6_process_reset(ospf6);
 }
 
 /* start ospf6 */

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -175,7 +175,7 @@ extern void ospf6_master_init(struct thread_master *master);
 extern void install_element_ospf6_clear_process(void);
 extern void ospf6_top_init(void);
 extern void ospf6_delete(struct ospf6 *o);
-extern void ospf6_router_id_update(struct ospf6 *ospf6);
+extern void ospf6_router_id_update(struct ospf6 *ospf6, bool init);
 
 extern void ospf6_maxage_remove(struct ospf6 *o);
 extern struct ospf6 *ospf6_instance_create(const char *name);

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -175,7 +175,8 @@ extern void ospf6_master_init(struct thread_master *master);
 extern void install_element_ospf6_clear_process(void);
 extern void ospf6_top_init(void);
 extern void ospf6_delete(struct ospf6 *o);
-extern void ospf6_router_id_update(struct ospf6 *ospf6, bool init);
+extern void ospf6_router_id_update(struct ospf6 *ospf6, bool init,
+				   struct vty *vty);
 
 extern void ospf6_maxage_remove(struct ospf6 *o);
 extern struct ospf6 *ospf6_instance_create(const char *name);

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -101,7 +101,7 @@ static int ospf6_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 
 	o->router_id_zebra = router_id.u.prefix4.s_addr;
 
-	ospf6_router_id_update(o);
+	ospf6_router_id_update(o, false);
 
 	return 0;
 }

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -101,7 +101,7 @@ static int ospf6_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 
 	o->router_id_zebra = router_id.u.prefix4.s_addr;
 
-	ospf6_router_id_update(o, false);
+	ospf6_router_id_update(o, false, NULL);
 
 	return 0;
 }


### PR DESCRIPTION
In some situations the ospf6 router-id can change. Currently, LSAs that refers to the old router-id as advertising router remains in LS database.

These fixes reset the ospf area when the router-id modified and forbid zebra to change the router-id of ospf6 when one or more adjagency is Full.
