### PR TITLE
vtysh: Expose SR node for non pathd use cases

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1263,7 +1263,6 @@ static struct cmd_node pw_node = {
 	.prompt = "%s(config-pw)# ",
 };
 
-#if defined(HAVE_PATHD)
 static struct cmd_node segment_routing_node = {
 	.name = "segment-routing",
 	.node = SEGMENT_ROUTING_NODE,
@@ -1271,6 +1270,7 @@ static struct cmd_node segment_routing_node = {
 	.prompt = "%s(config-sr)# ",
 };
 
+#if defined(HAVE_PATHD)
 static struct cmd_node sr_traffic_eng_node = {
 	.name = "sr traffic-eng",
 	.node = SR_TRAFFIC_ENG_NODE,
@@ -2171,7 +2171,6 @@ DEFUNSH(VTYSH_FABRICD, router_openfabric, router_openfabric_cmd, "router openfab
 }
 #endif /* HAVE_FABRICD */
 
-#if defined(HAVE_PATHD)
 DEFUNSH(VTYSH_SR, segment_routing, segment_routing_cmd,
 	"segment-routing",
 	"Configure segment routing\n")
@@ -2180,6 +2179,7 @@ DEFUNSH(VTYSH_SR, segment_routing, segment_routing_cmd,
 	return CMD_SUCCESS;
 }
 
+#if defined (HAVE_PATHD)
 DEFUNSH(VTYSH_PATHD, sr_traffic_eng, sr_traffic_eng_cmd,
 	"traffic-eng",
 	"Configure SR traffic engineering\n")
@@ -2662,6 +2662,18 @@ DEFUNSH(VTYSH_KEYS, vtysh_quit_keys, vtysh_quit_keys_cmd, "quit",
 	"Exit current mode and down to previous mode\n")
 {
 	return vtysh_exit_keys(self, vty, argc, argv);
+}
+
+DEFUNSH(VTYSH_SR, vtysh_exit_sr, vtysh_exit_sr_cmd, "exit",
+	"Exit current mode and down to previous mode\n")
+{
+	return vtysh_exit(vty);
+}
+
+DEFUNSH(VTYSH_SR, vtysh_quit_sr, vtysh_quit_sr_cmd, "quit",
+	"Exit current mode and down to previous mode\n")
+{
+	return vtysh_exit(vty);
 }
 
 #if defined(HAVE_PATHD)
@@ -4329,15 +4341,17 @@ void vtysh_init_vty(void)
 	install_element(BFD_PROFILE_NODE, &vtysh_end_all_cmd);
 #endif /* HAVE_BFDD */
 
-#if defined(HAVE_PATHD)
 	install_node(&segment_routing_node);
+	install_element(SEGMENT_ROUTING_NODE, &vtysh_exit_sr_cmd);
+	install_element(SEGMENT_ROUTING_NODE, &vtysh_quit_sr_cmd);
+	install_element(SEGMENT_ROUTING_NODE, &vtysh_end_all_cmd);
+
+#if defined(HAVE_PATHD)
 	install_node(&sr_traffic_eng_node);
 	install_node(&srte_segment_list_node);
 	install_node(&srte_policy_node);
 	install_node(&srte_candidate_dyn_node);
 
-	install_element(SEGMENT_ROUTING_NODE, &vtysh_exit_pathd_cmd);
-	install_element(SEGMENT_ROUTING_NODE, &vtysh_quit_pathd_cmd);
 	install_element(SR_TRAFFIC_ENG_NODE, &vtysh_exit_pathd_cmd);
 	install_element(SR_TRAFFIC_ENG_NODE, &vtysh_quit_pathd_cmd);
 	install_element(SR_SEGMENT_LIST_NODE, &vtysh_exit_pathd_cmd);
@@ -4347,7 +4361,7 @@ void vtysh_init_vty(void)
 	install_element(SR_CANDIDATE_DYN_NODE, &vtysh_exit_pathd_cmd);
 	install_element(SR_CANDIDATE_DYN_NODE, &vtysh_quit_pathd_cmd);
 
-	install_element(SEGMENT_ROUTING_NODE, &vtysh_end_all_cmd);
+
 	install_element(SR_TRAFFIC_ENG_NODE, &vtysh_end_all_cmd);
 	install_element(SR_SEGMENT_LIST_NODE, &vtysh_end_all_cmd);
 	install_element(SR_POLICY_NODE, &vtysh_end_all_cmd);


### PR DESCRIPTION
The SR node is hidden by a `--enable-pathd` configuration option.
But the recent commit of SRv6 uses this node as well.  Let's expose
this node and let things work.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>