### PR TITLE
lib: fix address sanitizer crash on `find`

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1496,7 +1496,7 @@ static void permute(struct graph_node *start, struct vty *vty)
 static void print_cmd(struct vty *vty, const char *cmd)
 {
 	int i, j, len = strlen(cmd);
-	char buf[len];
+	char buf[len + 1];
 	bool skip = false;
 
 	j = 0;


### PR DESCRIPTION
Fix the following address sanitizer crash when running the command `find`:

```
  ERROR: AddressSanitizer: dynamic-stack-buffer-overflow
  WRITE of size 1 at 0x7fff4840fc1d thread T0
      0  in print_cmd ../lib/command.c:1541
      1  in cmd_find_cmds ../lib/command.c:2364
      2  in find ../vtysh/vtysh.c:3732
      3  in cmd_execute_command_real ../lib/command.c:995
      4  in cmd_execute_command ../lib/command.c:1055
      5  in cmd_execute ../lib/command.c:1219
      6  in vtysh_execute_func ../vtysh/vtysh.c:486
      7  in vtysh_execute ../vtysh/vtysh.c:671
      8  in main ../vtysh/vtysh_main.c:721
      9  in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
      10 in _start (/usr/bin/vtysh+0x21f64d)
```