### PR TITLE
bgpd: Add tracepoints for bgp_dest_lock_node/bgp_dest_unlock_node

### DIFF
--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -31,6 +31,7 @@
 #include "linklist.h"
 #include "bgpd.h"
 #include "bgp_advertise.h"
+#include "bgpd/bgp_trace.h"
 
 struct bgp_table {
 	/* table belongs to this instance */
@@ -175,6 +176,7 @@ static inline struct bgp_dest *bgp_dest_parent_nolock(struct bgp_dest *dest)
  */
 static inline void bgp_dest_unlock_node(struct bgp_dest *dest)
 {
+	frrtrace(1, frr_bgp, bgp_dest_unlock, dest);
 	bgp_delete_listnode(dest);
 	route_unlock_node(bgp_dest_to_rnode(dest));
 }
@@ -248,6 +250,7 @@ bgp_node_lookup(const struct bgp_table *const table, const struct prefix *p)
  */
 static inline struct bgp_dest *bgp_dest_lock_node(struct bgp_dest *dest)
 {
+	frrtrace(1, frr_bgp, bgp_dest_lock, dest);
 	struct route_node *rn = route_lock_node(bgp_dest_to_rnode(dest));
 
 	return bgp_dest_from_rnode(rn);


### PR DESCRIPTION
static inline functions cannot be probed, let's add USDT.

This will help catching memory leaks regarding lock/unlock in the future,
I believe.

```
global locks;

probe begin
{
	ansi_clear_screen();
	println("Starting...");
}

probe process("/usr/lib/frr/bgpd").mark("bgp_dest_lock")
{
	prefix = @cast($arg1, "bgp_node")->p->u->val;
	locks[prefix]++;
	printf("---> %s %d (lock count: %d)\n", probefunc(),
			prefix, @cast($arg1, "bgp_node")->lock);
}

probe process("/usr/lib/frr/bgpd").mark("bgp_dest_unlock")
{

	prefix = @cast($arg1, "bgp_node")->p->u->val;
	if (locks[prefix] > 0) {
		locks[prefix]--;
	}
	printf("<--- %s %d (lock count: %d)\n", probefunc(),
			prefix, @cast($arg1, "bgp_node")->lock);
}
```

Some outputs:

```
<--- adj_free 94283113939304 (lock count: 2)
<--- adj_free 94283114099240 (lock count: 3)
<--- adj_free 94283114099752 (lock count: 3)
---> bgp_clear_route_table 94283113936008 (lock count: 4)
---> bgp_clear_route_table 94283113932664 (lock count: 4)
---> bgp_clear_route_table 94283114099240 (lock count: 3)
---> bgp_clear_route_table 94283114099752 (lock count: 3)
<--- adj_free 94283113795608 (lock count: 2)
<--- adj_free 94283113797112 (lock count: 2)
<--- adj_free 94283113796456 (lock count: 2)
---> bgp_clear_route_table 94283113936008 (lock count: 5)
---> bgp_clear_route_table 94283113932664 (lock count: 5)
---> bgp_clear_route_table 94283114099240 (lock count: 4)
---> bgp_clear_route_table 94283114099752 (lock count: 4)
---> bgp_process 94283113936008 (lock count: 5)
<--- bgp_clear_node_queue_del 94283113936008 (lock count: 6)
---> bgp_process 94283113932664 (lock count: 5)
<--- bgp_clear_node_queue_del 94283113932664 (lock count: 6)
---> bgp_process 94283114099240 (lock count: 4)
<--- bgp_clear_node_queue_del 94283114099240 (lock count: 5)
---> bgp_process 94283114099752 (lock count: 4)
<--- bgp_clear_node_queue_del 94283114099752 (lock count: 5)
<--- bgp_clear_node_queue_del 94283113936008 (lock count: 5)
<--- bgp_clear_node_queue_del 94283113932664 (lock count: 5)
<--- bgp_clear_node_queue_del 94283114099240 (lock count: 4)
<--- bgp_clear_node_queue_del 94283114099752 (lock count: 4)
<--- bgp_path_info_reap 94283113936008 (lock count: 4)
<--- bgp_path_info_reap 94283113936008 (lock count: 3)
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>