### PR TITLE
tests: Fixing common pylint error for topojson

### DIFF
--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -990,7 +990,7 @@ def modify_bgp_config_when_bgpd_down(tgen, topo, input_dict):
 # Verification APIs
 #############################################
 @retry(attempts=4, wait=2, return_is_str=True)
-def verify_router_id(tgen, topo, input_dict):
+def verify_router_id(tgen, topo, input_dict, expected=True):
     """
     Running command "show ip bgp json" for DUT and reading router-id
     from input_dict and verifying with command output.
@@ -1006,6 +1006,8 @@ def verify_router_id(tgen, topo, input_dict):
     * `topo`: input json file data
     * `input_dict`: input dictionary, have details of Device Under Test, for
                     which user wants to test the data
+    * `expected` : expected results from API, by-default True
+
     Usage
     -----
     # Verify if router-id for r1 is 12.12.12.12
@@ -1060,7 +1062,7 @@ def verify_router_id(tgen, topo, input_dict):
 
 
 @retry(attempts=50, wait=3, return_is_str=True)
-def verify_bgp_convergence(tgen, topo, dut=None):
+def verify_bgp_convergence(tgen, topo, dut=None, expected=True):
     """
     API will verify if BGP is converged with in the given time frame.
     Running "show bgp summary json" command and verify bgp neighbor
@@ -1070,6 +1072,8 @@ def verify_bgp_convergence(tgen, topo, dut=None):
     * `tgen`: topogen object
     * `topo`: input json file data
     * `dut`: device under test
+    * `expected` : expected results from API, by-default True
+
     Usage
     -----
     # To veriry is BGP is converged for all the routers used in
@@ -1264,7 +1268,7 @@ def verify_bgp_convergence(tgen, topo, dut=None):
 
 @retry(attempts=4, wait=4, return_is_str=True)
 def verify_bgp_community(
-    tgen, addr_type, router, network, input_dict=None, vrf=None, bestpath=False
+    tgen, addr_type, router, network, input_dict=None, vrf=None, bestpath=False, expected=True
 ):
     """
     API to veiryf BGP large community is attached in route for any given
@@ -1280,6 +1284,7 @@ def verify_bgp_community(
             values needs to be verified
     * `vrf`: VRF name
     * `bestpath`: To check best path cli
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -1423,7 +1428,7 @@ def modify_as_number(tgen, topo, input_dict):
 
 
 @retry(attempts=4, wait=2, return_is_str=True)
-def verify_as_numbers(tgen, topo, input_dict):
+def verify_as_numbers(tgen, topo, input_dict, expected=True):
     """
     This API is to verify AS numbers for given DUT by running
     "show ip bgp neighbor json" command. Local AS and Remote AS
@@ -1435,6 +1440,7 @@ def verify_as_numbers(tgen, topo, input_dict):
     * `topo`: input json file data
     * `addr_type` : ip type, ipv4/ipv6
     * `input_dict`: defines - for which router, AS numbers needs to be verified
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -1522,7 +1528,7 @@ def verify_as_numbers(tgen, topo, input_dict):
 
 
 @retry(attempts=50, wait=3, return_is_str=True)
-def verify_bgp_convergence_from_running_config(tgen, dut=None):
+def verify_bgp_convergence_from_running_config(tgen, dut=None, expected=True):
     """
     API to verify BGP convergence b/w loopback and physical interface.
     This API would be used when routers have BGP neighborship is loopback
@@ -1532,6 +1538,7 @@ def verify_bgp_convergence_from_running_config(tgen, dut=None):
     ----------
     * `tgen`: topogen object
     * `dut`: device under test
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -2086,6 +2093,7 @@ def verify_bgp_attributes(
     input_dict=None,
     seq_id=None,
     nexthop=None,
+    expected=True
 ):
     """
     API will verify BGP attributes set by Route-map for given prefix and
@@ -2101,6 +2109,7 @@ def verify_bgp_attributes(
     * `rmap_name`: route map name for which set criteria needs to be verified
     * `input_dict`: defines for which router, AS numbers needs
     * `seq_id`: sequence number of rmap, default is None
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -2216,7 +2225,7 @@ def verify_bgp_attributes(
 
 @retry(attempts=4, wait=2, return_is_str=True)
 def verify_best_path_as_per_bgp_attribute(
-    tgen, addr_type, router, input_dict, attribute
+    tgen, addr_type, router, input_dict, attribute, expected=True
 ):
     """
     API is to verify best path according to BGP attributes for given routes.
@@ -2231,6 +2240,8 @@ def verify_best_path_as_per_bgp_attribute(
     * `attribute` : calculate best path using this attribute
     * `input_dict`: defines different routes to calculate for which route
                     best path is selected
+    * `expected` : expected results from API, by-default True
+
     Usage
     -----
     # To verify best path for routes 200.50.2.0/32 and 200.60.2.0/32 from
@@ -2420,7 +2431,7 @@ def verify_best_path_as_per_bgp_attribute(
 
 @retry(attempts=5, wait=2, return_is_str=True)
 def verify_best_path_as_per_admin_distance(
-    tgen, addr_type, router, input_dict, attribute
+    tgen, addr_type, router, input_dict, attribute, expected=True
 ):
     """
     API is to verify best path according to admin distance for given
@@ -2435,6 +2446,8 @@ def verify_best_path_as_per_admin_distance(
     * `attribute` : calculate best path using admin distance
     * `input_dict`: defines different routes with different admin distance
                     to calculate for which route best path is selected
+    * `expected` : expected results from API, by-default True
+
     Usage
     -----
     # To verify best path for route 200.50.2.0/32 from  router r2 to
@@ -2532,7 +2545,7 @@ def verify_best_path_as_per_admin_distance(
 
 @retry(attempts=5, wait=2, return_is_str=True, initial_wait=2)
 def verify_bgp_rib(
-    tgen, addr_type, dut, input_dict, next_hop=None, aspath=None, multi_nh=None
+    tgen, addr_type, dut, input_dict, next_hop=None, aspath=None, multi_nh=None, expected=True
 ):
     """
     This API is to verify whether bgp rib has any
@@ -2547,6 +2560,7 @@ def verify_bgp_rib(
     * `next_hop`[optional]: next_hop which needs to be verified,
        default = static
     * 'aspath'[optional]: aspath which needs to be verified
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -2833,7 +2847,7 @@ def verify_bgp_rib(
 
 
 @retry(attempts=5, wait=2, return_is_str=True)
-def verify_graceful_restart(tgen, topo, addr_type, input_dict, dut, peer):
+def verify_graceful_restart(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
     """
     This API is to verify verify_graceful_restart configuration of DUT and
     cross verify the same from the peer bgp routerrouter.
@@ -2847,6 +2861,7 @@ def verify_graceful_restart(tgen, topo, addr_type, input_dict, dut, peer):
                     which user wants to test the data
     * `dut`: input dut router name
     * `peer`: input peer router name
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -3082,7 +3097,7 @@ def verify_graceful_restart(tgen, topo, addr_type, input_dict, dut, peer):
 
 
 @retry(attempts=5, wait=2, return_is_str=True)
-def verify_r_bit(tgen, topo, addr_type, input_dict, dut, peer):
+def verify_r_bit(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
     """
     This API is to verify r_bit in the BGP gr capability advertised
     by the neighbor router
@@ -3096,6 +3111,8 @@ def verify_r_bit(tgen, topo, addr_type, input_dict, dut, peer):
                     which user wants to test the data
     * `dut`: input dut router name
     * `peer`: peer name
+    * `expected` : expected results from API, by-default True
+
     Usage
     -----
     input_dict = {
@@ -3200,7 +3217,7 @@ def verify_r_bit(tgen, topo, addr_type, input_dict, dut, peer):
 
 
 @retry(attempts=5, wait=2, return_is_str=True)
-def verify_eor(tgen, topo, addr_type, input_dict, dut, peer):
+def verify_eor(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
     """
     This API is to verify EOR
 
@@ -3363,7 +3380,7 @@ def verify_eor(tgen, topo, addr_type, input_dict, dut, peer):
 
 
 @retry(attempts=4, wait=2, return_is_str=True)
-def verify_f_bit(tgen, topo, addr_type, input_dict, dut, peer):
+def verify_f_bit(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
     """
     This API is to verify f_bit in the BGP gr capability advertised
     by the neighbor router
@@ -3377,6 +3394,7 @@ def verify_f_bit(tgen, topo, addr_type, input_dict, dut, peer):
                     which user wants to test the data
     * `dut`: input dut router name
     * `peer`: peer name
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -3516,6 +3534,8 @@ def verify_graceful_restart_timers(tgen, topo, addr_type, input_dict, dut, peer)
                     for which user wants to test the data
     * `dut`: input dut router name
     * `peer`: peer name
+    * `expected` : expected results from API, by-default True
+
     Usage
     -----
     # Configure graceful-restart
@@ -3629,7 +3649,7 @@ def verify_graceful_restart_timers(tgen, topo, addr_type, input_dict, dut, peer)
 
 
 @retry(attempts=4, wait=2, return_is_str=True)
-def verify_gr_address_family(tgen, topo, addr_type, addr_family, dut):
+def verify_gr_address_family(tgen, topo, addr_type, addr_family, dut, expected=True):
     """
     This API is to verify gr_address_family in the BGP gr capability advertised
     by the neighbor router
@@ -3641,6 +3661,7 @@ def verify_gr_address_family(tgen, topo, addr_type, addr_family, dut):
     * `addr_type` : ip type ipv4/ipv6
     * `addr_type` : ip type IPV4 Unicast/IPV6 Unicast
     * `dut`: input dut router name
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -3730,6 +3751,7 @@ def verify_attributes_for_evpn_routes(
     ipLen=None,
     rd_peer=None,
     rt_peer=None,
+    expected=True
 ):
     """
     API to verify rd and rt value using "sh bgp l2vpn evpn 10.1.1.1"
@@ -3747,6 +3769,8 @@ def verify_attributes_for_evpn_routes(
     * `ipLen` : IP prefix length
     * `rd_peer` : Peer name from which RD will be auto-generated
     * `rt_peer` : Peer name from which RT will be auto-generated
+    * `expected` : expected results from API, by-default True
+
     Usage
     -----
         input_dict_1 = {
@@ -4117,7 +4141,7 @@ def verify_attributes_for_evpn_routes(
 
 @retry(attempts=5, wait=2, return_is_str=True)
 def verify_evpn_routes(
-    tgen, topo, dut, input_dict, routeType=5, EthTag=0, next_hop=None
+    tgen, topo, dut, input_dict, routeType=5, EthTag=0, next_hop=None, expected=True
 ):
     """
     API to verify evpn routes using "sh bgp l2vpn evpn"
@@ -4132,6 +4156,8 @@ def verify_evpn_routes(
     * `route_type` : Route type 5 is supported as of now
     * `EthTag` : Ethernet tag, by-default is 0
     * `next_hop` : Prefered nexthop for the evpn routes
+    * `expected` : expected results from API, by-default True
+
     Usage
     -----
         input_dict_1 = {

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -490,7 +490,7 @@ def redistribute_ospf(tgen, topo, dut, route_type, **kwargs):
 # Verification procs
 ################################
 @retry(attempts=40, wait=2, return_is_str=True)
-def verify_ospf_neighbor(tgen, topo, dut=None, input_dict=None, lan=False):
+def verify_ospf_neighbor(tgen, topo, dut=None, input_dict=None, lan=False, expected=True):
     """
     This API is to verify ospf neighborship by running
     show ip ospf neighbour command,
@@ -502,6 +502,7 @@ def verify_ospf_neighbor(tgen, topo, dut=None, input_dict=None, lan=False):
     * `dut`: device under test
     * `input_dict` : Input dict data, required when configuring from testcase
     * `lan` : verify neighbors in lan topology
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -684,7 +685,7 @@ def verify_ospf_neighbor(tgen, topo, dut=None, input_dict=None, lan=False):
 # Verification procs
 ################################
 @retry(attempts=40, wait=2, return_is_str=True)
-def verify_ospf6_neighbor(tgen, topo):
+def verify_ospf6_neighbor(tgen, topo, expected=True):
     """
     This API is to verify ospf neighborship by running
     show ip ospf neighbour command,
@@ -693,6 +694,7 @@ def verify_ospf6_neighbor(tgen, topo):
     ----------
     * `tgen` : Topogen object
     * `topo` : json file data
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -746,7 +748,7 @@ def verify_ospf6_neighbor(tgen, topo):
 
 @retry(attempts=21, wait=2, return_is_str=True)
 def verify_ospf_rib(
-    tgen, dut, input_dict, next_hop=None, tag=None, metric=None, fib=None
+    tgen, dut, input_dict, next_hop=None, tag=None, metric=None, fib=None, expected=True
 ):
     """
     This API is to verify ospf routes by running
@@ -761,6 +763,7 @@ def verify_ospf_rib(
     * `tag` : tag to be verified
     * `metric` : metric to be verified
     * `fib` : True if the route is installed in FIB.
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -1021,7 +1024,7 @@ def verify_ospf_rib(
 
 
 @retry(attempts=10, wait=2, return_is_str=True)
-def verify_ospf_interface(tgen, topo, dut=None, lan=False, input_dict=None):
+def verify_ospf_interface(tgen, topo, dut=None, lan=False, input_dict=None, expected=True):
     """
     This API is to verify ospf routes by running
     show ip ospf interface command.
@@ -1033,6 +1036,7 @@ def verify_ospf_interface(tgen, topo, dut=None, lan=False, input_dict=None):
     * `dut`: device under test
     * `lan`: if set to true this interface belongs to LAN.
     * `input_dict` : Input dict data, required when configuring from testcase
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -1110,7 +1114,7 @@ def verify_ospf_interface(tgen, topo, dut=None, lan=False, input_dict=None):
 
 
 @retry(attempts=11, wait=2, return_is_str=True)
-def verify_ospf_database(tgen, topo, dut, input_dict):
+def verify_ospf_database(tgen, topo, dut, input_dict, expected=True):
     """
     This API is to verify ospf lsa's by running
     show ip ospf database command.
@@ -1121,6 +1125,7 @@ def verify_ospf_database(tgen, topo, dut, input_dict):
     * `dut`: device under test
     * `input_dict` : Input dict data, required when configuring from testcase
     * `topo` : next to be verified
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -1273,7 +1278,7 @@ def verify_ospf_database(tgen, topo, dut, input_dict):
 
 
 @retry(attempts=10, wait=2, return_is_str=True)
-def verify_ospf_summary(tgen, topo, dut, input_dict):
+def verify_ospf_summary(tgen, topo, dut, input_dict, expected=True):
     """
     This API is to verify ospf routes by running
     show ip ospf interface command.
@@ -1284,6 +1289,7 @@ def verify_ospf_summary(tgen, topo, dut, input_dict):
     * `topo` : topology descriptions
     * `dut`: device under test
     * `input_dict` : Input dict data, required when configuring from testcase
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----

--- a/tests/topotests/lib/pim.py
+++ b/tests/topotests/lib/pim.py
@@ -496,7 +496,7 @@ def configure_pim_force_expire(tgen, topo, input_dict, build=False):
 # Verification APIs
 #############################################
 @retry(attempts=6, wait=2, return_is_str=True)
-def verify_pim_neighbors(tgen, topo, dut=None, iface=None, nbr_ip=None):
+def verify_pim_neighbors(tgen, topo, dut=None, iface=None, nbr_ip=None, expected=True):
     """
     Verify all PIM neighbors are up and running, config is verified
     using "show ip pim neighbor" cli
@@ -508,6 +508,7 @@ def verify_pim_neighbors(tgen, topo, dut=None, iface=None, nbr_ip=None):
     * `dut` : dut info
     * `iface` : link for which PIM nbr need to check
     * `nbr_ip` : neighbor ip of interface
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -619,7 +620,7 @@ def verify_pim_neighbors(tgen, topo, dut=None, iface=None, nbr_ip=None):
 
 
 @retry(attempts=21, wait=2, return_is_str=True)
-def verify_igmp_groups(tgen, dut, interface, group_addresses):
+def verify_igmp_groups(tgen, dut, interface, group_addresses, expected=True):
     """
     Verify IGMP groups are received from an intended interface
     by running "show ip igmp groups" command
@@ -630,6 +631,7 @@ def verify_igmp_groups(tgen, dut, interface, group_addresses):
     * `dut`: device under test
     * `interface`: interface, from which IGMP groups would be received
     * `group_addresses`: IGMP group address
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -693,7 +695,7 @@ def verify_igmp_groups(tgen, dut, interface, group_addresses):
 
 @retry(attempts=31, wait=2, return_is_str=True)
 def verify_upstream_iif(
-    tgen, dut, iif, src_address, group_addresses, joinState=None, refCount=1
+    tgen, dut, iif, src_address, group_addresses, joinState=None, refCount=1, expected=True
 ):
     """
     Verify upstream inbound interface  is updated correctly
@@ -708,6 +710,7 @@ def verify_upstream_iif(
     * `group_addresses`: IGMP group address
     * `joinState`: upstream join state
     * `refCount`: refCount value
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -845,7 +848,7 @@ def verify_upstream_iif(
 
 
 @retry(attempts=6, wait=2, return_is_str=True)
-def verify_join_state_and_timer(tgen, dut, iif, src_address, group_addresses):
+def verify_join_state_and_timer(tgen, dut, iif, src_address, group_addresses, expected=True):
     """
     Verify  join state is updated correctly and join timer is
     running with the help of "show ip pim upstream" cli
@@ -857,6 +860,7 @@ def verify_join_state_and_timer(tgen, dut, iif, src_address, group_addresses):
     * `iif`: inbound interface
     * `src_address`: source address
     * `group_addresses`: IGMP group address
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -964,7 +968,7 @@ def verify_join_state_and_timer(tgen, dut, iif, src_address, group_addresses):
 
 @retry(attempts=41, wait=2, return_is_dict=True)
 def verify_ip_mroutes(
-    tgen, dut, src_address, group_addresses, iif, oil, return_uptime=False, mwait=0
+    tgen, dut, src_address, group_addresses, iif, oil, return_uptime=False, mwait=0, expected=True
 ):
     """
     Verify ip mroutes and make sure (*, G)/(S, G) is present in mroutes
@@ -980,7 +984,7 @@ def verify_ip_mroutes(
     * `oil`: Outgoing interface
     * `return_uptime`: If True, return uptime dict, default is False
     * `mwait`: Wait time, default is 0
-
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -1161,7 +1165,7 @@ def verify_ip_mroutes(
 
 @retry(attempts=31, wait=2, return_is_str=True)
 def verify_pim_rp_info(
-    tgen, topo, dut, group_addresses, oif=None, rp=None, source=None, iamrp=None
+    tgen, topo, dut, group_addresses, oif=None, rp=None, source=None, iamrp=None, expected=True
 ):
     """
     Verify pim rp info by running "show ip pim rp-info" cli
@@ -1176,6 +1180,7 @@ def verify_pim_rp_info(
     * `rp`: RP address
     * `source`: Source of RP
     * `iamrp`: User defined RP
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -1317,7 +1322,7 @@ def verify_pim_rp_info(
 
 @retry(attempts=31, wait=2, return_is_str=True)
 def verify_pim_state(
-    tgen, dut, iif, oil, group_addresses, src_address=None, installed_fl=None
+    tgen, dut, iif, oil, group_addresses, src_address=None, installed_fl=None, expected=True
 ):
     """
     Verify pim state by running "show ip pim state" cli
@@ -1331,6 +1336,7 @@ def verify_pim_state(
     * `group_addresses`: IGMP group address
     * `src_address`: source address, default = None
     * installed_fl` : Installed flag
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -1485,7 +1491,7 @@ def verify_pim_interface_traffic(tgen, input_dict):
 
 
 @retry(attempts=21, wait=2, return_is_str=True)
-def verify_pim_interface(tgen, topo, dut, interface=None, interface_ip=None):
+def verify_pim_interface(tgen, topo, dut, interface=None, interface_ip=None, expected=True):
     """
     Verify all PIM interface are up and running, config is verified
     using "show ip pim interface" cli
@@ -1497,6 +1503,7 @@ def verify_pim_interface(tgen, topo, dut, interface=None, interface_ip=None):
     * `dut` : device under test
     * `interface` : interface name
     * `interface_ip` : interface ip address
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -1791,7 +1798,7 @@ def clear_ip_igmp_interfaces(tgen, dut):
 
 
 @retry(attempts=10, wait=2, return_is_str=True)
-def clear_ip_mroute_verify(tgen, dut):
+def clear_ip_mroute_verify(tgen, dut, expected=True):
     """
     Clear ip mroute by running "clear ip mroute" cli and verify
     mroutes are up again after mroute clear
@@ -1800,6 +1807,8 @@ def clear_ip_mroute_verify(tgen, dut):
     ----------
     * `tgen`: topogen object
     * `dut`: Device Under Test
+    * `expected` : expected results from API, by-default True
+
     Usage
     -----
 
@@ -2165,7 +2174,7 @@ def find_rp_from_bsrp_info(tgen, dut, bsr, grp=None):
 
 
 @retry(attempts=6, wait=2, return_is_str=True)
-def verify_pim_grp_rp_source(tgen, topo, dut, grp_addr, rp_source, rpadd=None):
+def verify_pim_grp_rp_source(tgen, topo, dut, grp_addr, rp_source, rpadd=None, expected=True):
     """
     Verify pim rp info by running "show ip pim rp-info" cli
 
@@ -2177,6 +2186,7 @@ def verify_pim_grp_rp_source(tgen, topo, dut, grp_addr, rp_source, rpadd=None):
     * `grp_addr`: IGMP group address
     * 'rp_source': source from which rp installed
     * 'rpadd': rp address
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -2267,7 +2277,7 @@ def verify_pim_grp_rp_source(tgen, topo, dut, grp_addr, rp_source, rpadd=None):
 
 
 @retry(attempts=31, wait=2, return_is_str=True)
-def verify_pim_bsr(tgen, topo, dut, bsr_ip):
+def verify_pim_bsr(tgen, topo, dut, bsr_ip, expected=True):
     """
     Verify all PIM interface are up and running, config is verified
     using "show ip pim interface" cli
@@ -2278,6 +2288,7 @@ def verify_pim_bsr(tgen, topo, dut, bsr_ip):
     * `topo` : json file data
     * `dut` : device under test
     * 'bsr' : bsr ip to be verified
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -2322,7 +2333,7 @@ def verify_pim_bsr(tgen, topo, dut, bsr_ip):
 
 
 @retry(attempts=31, wait=2, return_is_str=True)
-def verify_ip_pim_upstream_rpf(tgen, topo, dut, interface, group_addresses, rp=None):
+def verify_ip_pim_upstream_rpf(tgen, topo, dut, interface, group_addresses, rp=None, expected=True):
     """
     Verify IP PIM upstream rpf, config is verified
     using "show ip pim neighbor" cli
@@ -2336,6 +2347,7 @@ def verify_ip_pim_upstream_rpf(tgen, topo, dut, interface, group_addresses, rp=N
     * `group_addresses` : list of group address for which upstream info
                           needs to be checked
     * `rp` : RP address
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -2519,7 +2531,7 @@ def enable_disable_pim_bsm(tgen, router, intf, enable=True):
 
 
 @retry(attempts=31, wait=2, return_is_str=True)
-def verify_ip_pim_join(tgen, topo, dut, interface, group_addresses, src_address=None):
+def verify_ip_pim_join(tgen, topo, dut, interface, group_addresses, src_address=None, expected=True):
     """
     Verify ip pim join by running "show ip pim join" cli
 
@@ -2531,6 +2543,7 @@ def verify_ip_pim_join(tgen, topo, dut, interface, group_addresses, src_address=
     * `interface`: interface name, from which PIM join would come
     * `group_addresses`: IGMP group address
     * `src_address`: Source address
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -2609,7 +2622,7 @@ def verify_ip_pim_join(tgen, topo, dut, interface, group_addresses, src_address=
 
 
 @retry(attempts=31, wait=2, return_is_dict=True)
-def verify_igmp_config(tgen, input_dict, stats_return=False):
+def verify_igmp_config(tgen, input_dict, stats_return=False, expected=True):
     """
     Verify igmp interface details, verifying following configs:
     timerQueryInterval
@@ -2623,6 +2636,7 @@ def verify_igmp_config(tgen, input_dict, stats_return=False):
     * `input_dict` : Input dict data, required to verify
                      timer
     * `stats_return`: If user wants API to return statistics
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -2898,7 +2912,7 @@ def verify_igmp_config(tgen, input_dict, stats_return=False):
 
 
 @retry(attempts=31, wait=2, return_is_str=True)
-def verify_pim_config(tgen, input_dict):
+def verify_pim_config(tgen, input_dict, expected=True):
     """
     Verify pim interface details, verifying following configs:
     drPriority
@@ -2912,6 +2926,7 @@ def verify_pim_config(tgen, input_dict):
     * `tgen`: topogen object
     * `input_dict` : Input dict data, required to verify
                      timer
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -3023,7 +3038,7 @@ def verify_pim_config(tgen, input_dict):
 
 
 @retry(attempts=21, wait=2, return_is_dict=True)
-def verify_multicast_traffic(tgen, input_dict, return_traffic=False):
+def verify_multicast_traffic(tgen, input_dict, return_traffic=False, expected=True):
     """
     Verify multicast traffic by running
     "show multicast traffic count json" cli
@@ -3034,6 +3049,8 @@ def verify_multicast_traffic(tgen, input_dict, return_traffic=False):
     * `input_dict(dict)`: defines DUT, what and for which interfaces
                           traffic needs to be verified
     * `return_traffic`: returns traffic stats
+    * `expected` : expected results from API, by-default True
+
     Usage
     -----
     input_dict = {
@@ -3264,7 +3281,7 @@ def get_refCount_for_mroute(tgen, dut, iif, src_address, group_addresses):
 
 
 @retry(attempts=21, wait=2, return_is_str=True)
-def verify_multicast_flag_state(tgen, dut, src_address, group_addresses, flag):
+def verify_multicast_flag_state(tgen, dut, src_address, group_addresses, flag, expected=True):
     """
     Verify flag state for mroutes and make sure (*, G)/(S, G) are having
     coorect flags by running "show ip mroute" cli
@@ -3276,6 +3293,7 @@ def verify_multicast_flag_state(tgen, dut, src_address, group_addresses, flag):
     * `src_address`: source address
     * `group_addresses`: IGMP group address
     * `flag`: flag state, needs to be verified
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----
@@ -3358,7 +3376,7 @@ def verify_multicast_flag_state(tgen, dut, src_address, group_addresses, flag):
 
 
 @retry(attempts=21, wait=2, return_is_str=True)
-def verify_igmp_interface(tgen, topo, dut, igmp_iface, interface_ip):
+def verify_igmp_interface(tgen, topo, dut, igmp_iface, interface_ip, expected=True):
     """
     Verify all IGMP interface are up and running, config is verified
     using "show ip igmp interface" cli
@@ -3370,6 +3388,7 @@ def verify_igmp_interface(tgen, topo, dut, igmp_iface, interface_ip):
     * `dut` : device under test
     * `igmp_iface` : interface name
     * `interface_ip` : interface ip address
+    * `expected` : expected results from API, by-default True
 
     Usage
     -----


### PR DESCRIPTION
Issue: There was an error reported by Pylint regarding "expected" keyword:
           Unexpected keyword argument 'expected' in function call (unexpected-keyword-arg)
Fix: We have defined expected keyword in all topojson APIs.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>