### PR TITLE
ospfd: fix memory leaks in summarization

### DIFF
--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -508,7 +508,6 @@ static void ospf_external_aggr_delete(struct ospf *ospf, struct route_node *rn)
 
 	rn->info = NULL;
 	route_unlock_node(rn);
-	route_unlock_node(rn);
 }
 
 struct ospf_external_aggr_rt *
@@ -1160,6 +1159,7 @@ int ospf_asbr_external_aggregator_unset(struct ospf *ospf,
 	rn = route_node_lookup(ospf->rt_aggr_tbl, (struct prefix *)p);
 	if (!rn)
 		return OSPF_INVALID;
+	route_unlock_node(rn);
 
 	aggr = rn->info;
 
@@ -1217,6 +1217,7 @@ int ospf_asbr_external_rt_advertise(struct ospf *ospf, struct prefix_ipv4 *p)
 	rn = route_node_lookup(ospf->rt_aggr_tbl, (struct prefix *)p);
 	if (!rn)
 		return OSPF_INVALID;
+	route_unlock_node(rn);
 
 	aggr = rn->info;
 


### PR DESCRIPTION
To reproduce the issue:
1. Create summary-address: `summary-address 1.1.1.0/24`.
2. Try to delete it with the wrong tag: `no summary-address 1.1.1.0/24 tag 1`.
   Each time this command is executed, route_node_lookup is called which
   locks route node one more time. As the tag is wrong, the function
   return immediately without unlock.
3. Finally delete the summary-address: `no summary-address 1.1.1.0/24`.

The route node won't be deleted.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>