### PR TITLE
zebra: Give extra space and stop processing if we run out of space

### DIFF
--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -111,7 +111,7 @@ void zebra_mlag_process_mlag_data(uint8_t *data, uint32_t len)
 	struct stream *s = NULL;
 	int msg_type = 0;
 
-	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	s = stream_new(ZEBRA_MLAG_BUF_LIMIT);
 	/*
 	 * Place holder we need the message type first
 	 */
@@ -1081,7 +1081,7 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 		case ZEBRA_MLAG__HEADER__MESSAGE_TYPE__ZEBRA_MLAG_MROUTE_ADD_BULK: {
 			ZebraMlagMrouteAddBulk *Bulk_msg = NULL;
 			ZebraMlagMrouteAdd *msg = NULL;
-			size_t i;
+			size_t i, length_spot;
 
 			Bulk_msg = zebra_mlag_mroute_add_bulk__unpack(
 				NULL, hdr->data.len, hdr->data.data);
@@ -1093,10 +1093,17 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 			stream_putw(s, (Bulk_msg->n_mroute_add
 					* sizeof(struct mlag_mroute_add)));
 			/* No. of msgs in Batch */
-			stream_putw(s, Bulk_msg->n_mroute_add);
+			length_spot = stream_putw(s, Bulk_msg->n_mroute_add);
 
 			/* Actual Data */
 			for (i = 0; i < Bulk_msg->n_mroute_add; i++) {
+				if (STREAM_SIZE(s)
+				    < VRF_NAMSIZ + 22 + INTERFACE_NAMSIZ) {
+					zlog_warn(
+						"We have received more messages than we can parse at this point in time: %zu",
+						Bulk_msg->n_mroute_add);
+					break;
+				}
 
 				msg = Bulk_msg->mroute_add[i];
 
@@ -1116,13 +1123,16 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 				else
 					stream_put(s, NULL, INTERFACE_NAMSIZ);
 			}
+
+			stream_putw_at(s, length_spot, i + 1);
+
 			zebra_mlag_mroute_add_bulk__free_unpacked(Bulk_msg,
 								  NULL);
 		} break;
 		case ZEBRA_MLAG__HEADER__MESSAGE_TYPE__ZEBRA_MLAG_MROUTE_DEL_BULK: {
 			ZebraMlagMrouteDelBulk *Bulk_msg = NULL;
 			ZebraMlagMrouteDel *msg = NULL;
-			size_t i;
+			size_t i, length_spot;
 
 			Bulk_msg = zebra_mlag_mroute_del_bulk__unpack(
 				NULL, hdr->data.len, hdr->data.data);
@@ -1134,10 +1144,16 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 			stream_putw(s, (Bulk_msg->n_mroute_del
 					* sizeof(struct mlag_mroute_del)));
 			/* No. of msgs in Batch */
-			stream_putw(s, Bulk_msg->n_mroute_del);
+			length_spot = stream_putw(s, Bulk_msg->n_mroute_del);
 
 			/* Actual Data */
 			for (i = 0; i < Bulk_msg->n_mroute_del; i++) {
+				if (STREAM_SIZE(s)
+				    < VRF_NAMSIZ + 16 + INTERFACE_NAMSIZ) {
+					zlog_warn(
+						"We have received more messages than we can parse at this time");
+					break;
+				}
 
 				msg = Bulk_msg->mroute_del[i];
 
@@ -1154,6 +1170,9 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 				else
 					stream_put(s, NULL, INTERFACE_NAMSIZ);
 			}
+
+			stream_putw_at(s, length_spot, i + 1);
+
 			zebra_mlag_mroute_del_bulk__free_unpacked(Bulk_msg,
 								  NULL);
 		} break;


### PR DESCRIPTION
When processing bulk messages we need more space to handle more
mroutes.  In this case we are doubling the stream size from
16k -> 32k, which should roughly double the number of mroutes
we can handle in one go.

Additionally.   If we cannot parse the passed message into
the stream to pass up to pimd then gracefully stop processing

Signed-off-by: Donald Sharp <sharpd@nvidia.com>