### PR TITLE
tools: add mac access-list context to frr-reload.py

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -595,6 +595,7 @@ end
             "ip ",
             "ipv6 ",
             "log ",
+            "mac access-list ",
             "mpls lsp",
             "mpls label",
             "no ",


### PR DESCRIPTION
Problem reported that frr-reload.py didn't handle the mac access-list
command correctly, causing reloads to fail.  This fix adds the
support for the command as a single line context.

Signed-off-by: Don Slice <dslice@nvidia.com>