### PR TITLE
isisd, ospfd: update interface_link_params callback to check for change

### DIFF
--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -145,10 +145,11 @@ static int isis_zebra_if_address_del(ZAPI_CALLBACK_ARGS)
 static int isis_zebra_link_params(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
+	bool changed = false;
 
-	ifp = zebra_interface_link_params_read(zclient->ibuf, vrf_id);
+	ifp = zebra_interface_link_params_read(zclient->ibuf, vrf_id, &changed);
 
-	if (ifp == NULL)
+	if (ifp == NULL || !changed)
 		return 0;
 
 	/* Update TE TLV */

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1043,7 +1043,8 @@ extern struct interface *zebra_interface_vrf_update_read(struct stream *s,
 extern int zebra_router_id_update_read(struct stream *s, struct prefix *rid);
 
 extern struct interface *zebra_interface_link_params_read(struct stream *s,
-							  vrf_id_t vrf_id);
+							  vrf_id_t vrf_id,
+							  bool *changed);
 extern size_t zebra_interface_link_params_write(struct stream *,
 						struct interface *);
 extern enum zclient_send_status

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -50,6 +50,7 @@
 #include "ospfd/ospf_dump.h"
 #include "ospfd/ospf_ldp_sync.h"
 #include "ospfd/ospf_route.h"
+#include "ospfd/ospf_te.h"
 
 DEFINE_QOBJ_TYPE(ospf_interface);
 DEFINE_HOOK(ospf_vl_add, (struct ospf_vl_data * vd), (vd));
@@ -1354,6 +1355,9 @@ static int ospf_ifp_create(struct interface *ifp)
 
 	ospf_if_update(ospf, ifp);
 
+	if (HAS_LINK_PARAMS(ifp))
+		ospf_mpls_te_update_if(ifp);
+
 	hook_call(ospf_if_update, ifp);
 
 	return 0;
@@ -1391,6 +1395,9 @@ static int ospf_ifp_up(struct interface *ifp)
 
 		ospf_if_up(oi);
 	}
+
+	if (HAS_LINK_PARAMS(ifp))
+		ospf_mpls_te_update_if(ifp);
 
 	return 0;
 }

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -163,10 +163,11 @@ static int ospf_interface_address_delete(ZAPI_CALLBACK_ARGS)
 static int ospf_interface_link_params(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
+	bool changed = false;
 
-	ifp = zebra_interface_link_params_read(zclient->ibuf, vrf_id);
+	ifp = zebra_interface_link_params_read(zclient->ibuf, vrf_id, &changed);
 
-	if (ifp == NULL)
+	if (ifp == NULL || !changed)
 		return 0;
 
 	/* Update TE TLV */


### PR DESCRIPTION
Adding defensive code to the interface_link_params zebra callback
to check if the link params changed before taking action.

Signed-off-by: Karen Schoener <karen@voltanet.io>