### PR TITLE
zebra: We already store the last command as part of zserv_write

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1367,7 +1367,6 @@ int zebra_send_rnh_update(struct rnh *rnh, struct zserv *client,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	client->nh_last_upd_time = monotime(NULL);
-	client->last_write_cmd = cmd;
 	return zserv_send_message(client, s);
 
 failure:

--- a/zebra/zebra_srte.c
+++ b/zebra/zebra_srte.c
@@ -161,7 +161,6 @@ static int zebra_sr_policy_notify_update_client(struct zebra_sr_policy *policy,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	client->nh_last_upd_time = monotime(NULL);
-	client->last_write_cmd = ZEBRA_NEXTHOP_UPDATE;
 	return zserv_send_message(client, s);
 
 failure:


### PR DESCRIPTION
when sending nexthop information.  We do not need to reset the
last_write_cmd since that is taken care of in the send routine.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>