### PR TITLE
isisd: Cancel thread associated with `struct isis` on deletion

### DIFF
--- a/isisd/isis_dynhn.c
+++ b/isisd/isis_dynhn.c
@@ -77,8 +77,6 @@ static int dyn_cache_cleanup(struct thread *thread)
 
 	isis = THREAD_ARG(thread);
 
-	isis->t_dync_clean = NULL;
-
 	for (ALL_LIST_ELEMENTS(dyn_cache, node, nnode, dyn)) {
 		if ((now - dyn->refresh) < MAX_LSP_LIFETIME)
 			continue;

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -229,6 +229,8 @@ void isis_finish(struct isis *isis)
 
 	isis_redist_free(isis);
 	list_delete(&isis->area_list);
+
+	thread_cancel(&isis->t_dync_clean);
 	XFREE(MTYPE_ISIS, isis);
 }
 


### PR DESCRIPTION
The isis->t_dync_clean thread is never canceled on cleanup of
a isis pointer.  This can lead to situations where the thread
is still around and has a pointer to the isis structure,
leading to fun.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>