### PR TITLE
ospf6d: move error logs out from behind debug flags

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -974,11 +974,12 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 		/* if no database copy, should go above state (5) */
 		assert(old);
 
-		if (is_debug) {
-			zlog_debug(
-				"Received is not newer, on the neighbor's request-list");
-			zlog_debug("BadLSReq, discard the received LSA");
-		}
+		zlog_warn(
+			"Received is not newer, on the neighbor %s request-list",
+			from->name);
+		zlog_warn(
+			"BadLSReq, discard the received LSA lsa %s send badLSReq",
+			new->name);
 
 		/* BadLSReq */
 		thread_add_event(master, bad_lsreq, from, 0, NULL);

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -701,20 +701,17 @@ int interface_up(struct thread *thread)
 
 	/* check physical interface is up */
 	if (!if_is_operative(oi->interface)) {
-		if (IS_OSPF6_DEBUG_INTERFACE)
-			zlog_debug(
-				"Interface %s is down, can't execute [InterfaceUp]",
-				oi->interface->name);
+		zlog_warn("Interface %s is down, can't execute [InterfaceUp]",
+			  oi->interface->name);
 		return 0;
 	}
 
 	/* check interface has a link-local address */
 	if (!(ospf6_interface_get_linklocal_address(oi->interface)
 	      || if_is_loopback_or_vrf(oi->interface))) {
-		if (IS_OSPF6_DEBUG_INTERFACE)
-			zlog_debug(
-				"Interface %s has no link local address, can't execute [InterfaceUp]",
-				oi->interface->name);
+		zlog_warn(
+			"Interface %s has no link local address, can't execute [InterfaceUp]",
+			oi->interface->name);
 		return 0;
 	}
 
@@ -731,7 +728,7 @@ int interface_up(struct thread *thread)
 
 	/* If no area assigned, return */
 	if (oi->area == NULL) {
-		zlog_debug(
+		zlog_warn(
 			"%s: Not scheduleing Hello for %s as there is no area assigned yet",
 			__func__, oi->interface->name);
 		return 0;

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -289,9 +289,8 @@ int ospf6_router_lsa_originate(struct thread *thread)
 			if ((caddr_t)lsdesc
 			    == (caddr_t)router_lsa
 				       + sizeof(struct ospf6_router_lsa)) {
-				if (IS_OSPF6_DEBUG_ORIGINATE(ROUTER))
-					zlog_debug(
-						"Size limit setting for Router-LSA too short");
+				zlog_warn(
+					"Size limit setting for Router-LSA too short");
 				return 0;
 			}
 

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -284,9 +284,7 @@ static void ospf6_nexthop_calc(struct ospf6_vertex *w, struct ospf6_vertex *v,
 
 	oi = ospf6_interface_lookup_by_ifindex(ifindex, ospf6->vrf_id);
 	if (oi == NULL) {
-		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug("Can't find interface in SPF: ifindex %d",
-				   ifindex);
+		zlog_warn("Can't find interface in SPF: ifindex %d", ifindex);
 		return;
 	}
 
@@ -475,9 +473,7 @@ void ospf6_spf_calculation(uint32_t router_id,
 	/* construct root vertex */
 	lsa = ospf6_create_single_router_lsa(oa, oa->lsdb_self, router_id);
 	if (lsa == NULL) {
-		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug("%s: No router LSA for area %s", __func__,
-				   oa->name);
+		zlog_warn("%s: No router LSA for area %s", __func__, oa->name);
 		return;
 	}
 


### PR DESCRIPTION
The logging in ospf6 is very verbose.  If you turn on logging on a scaled
system you get too many logs.   The problem is that there are some errors
that occur that are hidden behind the debug flags, and to see these errors
we currently need to turn on the debug logging.  This change converts these
error logs to warnings and removes the debug flags.

Signed-off-by Lynne Morrison <lynne@voltanet.io>