### PR TITLE
ospf6: Drop LSA with bad seqnumber

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -811,6 +811,18 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 	ismore_recent = 1;
 	assert(from);
 
+	/* if we receive a LSA with invalid seqnum drop it */
+	if (ntohl(lsa_header->seqnum) - 1 == OSPF_MAX_SEQUENCE_NUMBER) {
+		if (IS_OSPF6_DEBUG_EXAMIN_TYPE(lsa_header->type)) {
+			zlog_debug(
+				"received lsa [%s Id:%pI4 Adv:%pI4] with invalid seqnum 0x%x, ignore",
+				ospf6_lstype_name(lsa_header->type),
+				&lsa_header->id, &lsa_header->adv_router,
+				ntohl(lsa_header->seqnum));
+		}
+		return;
+	}
+
 	/* make lsa structure for received lsa */
 	new = ospf6_lsa_create(lsa_header);
 


### PR DESCRIPTION
In RFC 2328, seqnumber 0x80000000 is reserved and not used.   If an LSA
is received with this seqnumber, the LSA is now dropped and a debug error
log is printed.

Signed-off-by: Lynne Morrison <lynne@voltanet.io>