### PR TITLE
isisd: per-instance dynamic hostname cache

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -270,7 +270,7 @@ const char *isis_adj_name(const struct isis_adjacency *adj)
 
 	struct isis_dynhn *dyn;
 
-	dyn = dynhn_find_by_id(adj->sysid);
+	dyn = dynhn_find_by_id(adj->circuit->isis, adj->sysid);
 	if (dyn)
 		return dyn->hostname;
 	else
@@ -401,7 +401,7 @@ void isis_adj_print(struct isis_adjacency *adj)
 
 	if (!adj)
 		return;
-	dyn = dynhn_find_by_id(adj->sysid);
+	dyn = dynhn_find_by_id(adj->circuit->isis, adj->sysid);
 	if (dyn)
 		zlog_debug("%s", dyn->hostname);
 
@@ -537,7 +537,7 @@ void isis_adj_print_vty(struct isis_adjacency *adj, struct vty *vty,
 		vty_out(vty, "    SNPA: %s", snpa_print(adj->snpa));
 		if (adj->circuit
 		    && (adj->circuit->circ_type == CIRCUIT_T_BROADCAST)) {
-			dyn = dynhn_find_by_id(adj->lanid);
+			dyn = dynhn_find_by_id(adj->circuit->isis, adj->lanid);
 			if (dyn)
 				vty_out(vty, ", LAN id: %s.%02x", dyn->hostname,
 					adj->lanid[ISIS_SYS_ID_LEN]);

--- a/isisd/isis_dynhn.h
+++ b/isisd/isis_dynhn.h
@@ -31,14 +31,16 @@ struct isis_dynhn {
 };
 
 void dyn_cache_init(struct isis *isis);
-void dyn_cache_cleanup_all(void);
-void isis_dynhn_insert(const uint8_t *id, const char *hostname, int level);
-void isis_dynhn_remove(const uint8_t *id);
-struct isis_dynhn *dynhn_find_by_id(const uint8_t *id);
-struct isis_dynhn *dynhn_find_by_name(const char *hostname);
+void dyn_cache_finish(struct isis *isis);
+void isis_dynhn_insert(struct isis *isis, const uint8_t *id,
+		       const char *hostname, int level);
+void isis_dynhn_remove(struct isis *isis, const uint8_t *id);
+struct isis_dynhn *dynhn_find_by_id(struct isis *isis, const uint8_t *id);
+struct isis_dynhn *dynhn_find_by_name(struct isis *isis, const char *hostname);
 void dynhn_print_all(struct vty *vty, struct isis *isis);
 
 /* Snmp support */
-struct isis_dynhn *dynhn_snmp_next(const uint8_t *id, int level);
+struct isis_dynhn *dynhn_snmp_next(struct isis *isis, const uint8_t *id,
+				   int level);
 
 #endif /* _ZEBRA_ISIS_DYNHN_H */

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -533,11 +533,11 @@ static void lsp_update_data(struct isis_lsp *lsp, struct isis_lsp_hdr *hdr,
 
 	if (area->dynhostname && lsp->tlvs->hostname
 	    && lsp->hdr.rem_lifetime) {
-		isis_dynhn_insert(lsp->hdr.lsp_id, lsp->tlvs->hostname,
-				  (lsp->hdr.lsp_bits & LSPBIT_IST)
-						  == IS_LEVEL_1_AND_2
-					  ? IS_LEVEL_2
-					  : IS_LEVEL_1);
+		isis_dynhn_insert(
+			area->isis, lsp->hdr.lsp_id, lsp->tlvs->hostname,
+			(lsp->hdr.lsp_bits & LSPBIT_IST) == IS_LEVEL_1_AND_2
+				? IS_LEVEL_2
+				: IS_LEVEL_1);
 	}
 
 	return;
@@ -700,7 +700,7 @@ void lspid_print(uint8_t *lsp_id, char *dest, size_t dest_len, char dynhost,
 	char id[SYSID_STRLEN];
 
 	if (dynhost)
-		dyn = dynhn_find_by_id(lsp_id);
+		dyn = dynhn_find_by_id(isis, lsp_id);
 	else
 		dyn = NULL;
 

--- a/isisd/isis_misc.c
+++ b/isisd/isis_misc.c
@@ -458,6 +458,7 @@ const char *print_sys_hostname(const uint8_t *sysid)
 {
 	struct isis_dynhn *dyn;
 	struct isis *isis = NULL;
+	struct listnode *node;
 
 	if (!sysid)
 		return "nullsysid";
@@ -467,9 +468,11 @@ const char *print_sys_hostname(const uint8_t *sysid)
 	if (isis && !CHECK_FLAG(im->options, F_ISIS_UNIT_TEST))
 		return cmd_hostname_get();
 
-	dyn = dynhn_find_by_id(sysid);
-	if (dyn)
-		return dyn->hostname;
+	for (ALL_LIST_ELEMENTS_RO(im->isis, node, isis)) {
+		dyn = dynhn_find_by_id(isis, sysid);
+		if (dyn)
+			return dyn->hostname;
+	}
 
 	return sysid_print(sysid);
 }

--- a/isisd/isis_nb_notifications.c
+++ b/isisd/isis_nb_notifications.c
@@ -315,7 +315,7 @@ void isis_notif_adj_state_change(const struct isis_adjacency *adj,
 	struct yang_data *data;
 	struct isis_circuit *circuit = adj->circuit;
 	struct isis_area *area = circuit->area;
-	struct isis_dynhn *dyn = dynhn_find_by_id(adj->sysid);
+	struct isis_dynhn *dyn = dynhn_find_by_id(circuit->isis, adj->sysid);
 
 	notif_prep_instance_hdr(xpath, area, "default", arguments);
 	notif_prepr_iface_hdr(xpath, circuit, arguments);

--- a/isisd/isis_snmp.c
+++ b/isisd/isis_snmp.c
@@ -1654,6 +1654,10 @@ static uint8_t *isis_snmp_find_router(struct variable *v, oid *name,
 	oid *oid_idx;
 	size_t oid_idx_len;
 	size_t off = 0;
+	struct isis *isis = isis_lookup_by_vrfid(VRF_DEFAULT);
+
+	if (isis == NULL)
+		return NULL;
 
 	*write_method = NULL;
 
@@ -1687,7 +1691,7 @@ static uint8_t *isis_snmp_find_router(struct variable *v, oid *name,
 
 		cmp_level = (int)oid_idx[ISIS_SYS_ID_LEN + 1];
 
-		dyn = dynhn_find_by_id(cmp_buf);
+		dyn = dynhn_find_by_id(isis, cmp_buf);
 
 		if (dyn == NULL || dyn->level != cmp_level)
 			return NULL;
@@ -1739,7 +1743,7 @@ static uint8_t *isis_snmp_find_router(struct variable *v, oid *name,
 		 */
 		cmp_level = (int)(IS_LEVEL_2 + 1);
 
-	dyn = dynhn_snmp_next(cmp_buf, cmp_level);
+	dyn = dynhn_snmp_next(isis, cmp_buf, cmp_level);
 
 	if (dyn == NULL)
 		return NULL;

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -229,6 +229,7 @@ void isis_finish(struct isis *isis)
 
 	isis_redist_free(isis);
 	list_delete(&isis->area_list);
+	dyn_cache_finish(isis);
 	XFREE(MTYPE_ISIS, isis);
 }
 
@@ -1076,6 +1077,23 @@ DEFUN(show_isis_interface_arg,
 					  vrf_name, all_vrf);
 }
 
+static int id_to_sysid(struct isis *isis, const char *id, uint8_t *sysid)
+{
+	struct isis_dynhn *dynhn;
+
+	memset(sysid, 0, ISIS_SYS_ID_LEN);
+	if (id) {
+		if (sysid2buff(sysid, id) == 0) {
+			dynhn = dynhn_find_by_name(isis, id);
+			if (dynhn == NULL)
+				return -1;
+			memcpy(sysid, dynhn->id, ISIS_SYS_ID_LEN);
+		}
+	}
+
+	return 0;
+}
+
 static void isis_neighbor_common(struct vty *vty, const char *id, char detail,
 				 struct isis *isis, uint8_t *sysid)
 {
@@ -1131,7 +1149,6 @@ int show_isis_neighbor_common(struct vty *vty, const char *id, char detail,
 			      const char *vrf_name, bool all_vrf)
 {
 	struct listnode *node;
-	struct isis_dynhn *dynhn;
 	uint8_t sysid[ISIS_SYS_ID_LEN];
 	struct isis *isis;
 
@@ -1140,29 +1157,27 @@ int show_isis_neighbor_common(struct vty *vty, const char *id, char detail,
 		return CMD_SUCCESS;
 	}
 
-	memset(sysid, 0, ISIS_SYS_ID_LEN);
-	if (id) {
-		if (sysid2buff(sysid, id) == 0) {
-			dynhn = dynhn_find_by_name(id);
-			if (dynhn == NULL) {
-				vty_out(vty, "Invalid system id %s\n", id);
-				return CMD_SUCCESS;
-			}
-			memcpy(sysid, dynhn->id, ISIS_SYS_ID_LEN);
-		}
-	}
-
 	if (vrf_name) {
 		if (all_vrf) {
 			for (ALL_LIST_ELEMENTS_RO(im->isis, node, isis)) {
+				if (id_to_sysid(isis, id, sysid)) {
+					vty_out(vty, "Invalid system id %s\n",
+						id);
+					return CMD_SUCCESS;
+				}
 				isis_neighbor_common(vty, id, detail, isis,
 						     sysid);
 			}
 			return CMD_SUCCESS;
 		}
 		isis = isis_lookup_by_vrfname(vrf_name);
-		if (isis != NULL)
+		if (isis != NULL) {
+			if (id_to_sysid(isis, id, sysid)) {
+				vty_out(vty, "Invalid system id %s\n", id);
+				return CMD_SUCCESS;
+			}
 			isis_neighbor_common(vty, id, detail, isis, sysid);
+		}
 	}
 
 	return CMD_SUCCESS;
@@ -1218,7 +1233,6 @@ int clear_isis_neighbor_common(struct vty *vty, const char *id, const char *vrf_
 			       bool all_vrf)
 {
 	struct listnode *node;
-	struct isis_dynhn *dynhn;
 	uint8_t sysid[ISIS_SYS_ID_LEN];
 	struct isis *isis;
 
@@ -1227,27 +1241,27 @@ int clear_isis_neighbor_common(struct vty *vty, const char *id, const char *vrf_
 		return CMD_SUCCESS;
 	}
 
-	memset(sysid, 0, ISIS_SYS_ID_LEN);
-	if (id) {
-		if (sysid2buff(sysid, id) == 0) {
-			dynhn = dynhn_find_by_name(id);
-			if (dynhn == NULL) {
-				vty_out(vty, "Invalid system id %s\n", id);
-				return CMD_SUCCESS;
-			}
-			memcpy(sysid, dynhn->id, ISIS_SYS_ID_LEN);
-		}
-	}
 	if (vrf_name) {
 		if (all_vrf) {
-			for (ALL_LIST_ELEMENTS_RO(im->isis, node, isis))
+			for (ALL_LIST_ELEMENTS_RO(im->isis, node, isis)) {
+				if (id_to_sysid(isis, id, sysid)) {
+					vty_out(vty, "Invalid system id %s\n",
+						id);
+					return CMD_SUCCESS;
+				}
 				isis_neighbor_common_clear(vty, id, sysid,
 							   isis);
+			}
 			return CMD_SUCCESS;
 		}
 		isis = isis_lookup_by_vrfname(vrf_name);
-		if (isis != NULL)
+		if (isis != NULL) {
+			if (id_to_sysid(isis, id, sysid)) {
+				vty_out(vty, "Invalid system id %s\n", id);
+				return CMD_SUCCESS;
+			}
 			isis_neighbor_common_clear(vty, id, sysid, isis);
+		}
 	}
 
 	return CMD_SUCCESS;
@@ -2204,7 +2218,7 @@ struct isis_lsp *lsp_for_arg(struct lspdb_head *head, const char *argv,
 	 */
 	if (sysid2buff(lspid, sysid)) {
 		lsp = lsp_search(head, lspid);
-	} else if ((dynhn = dynhn_find_by_name(sysid))) {
+	} else if ((dynhn = dynhn_find_by_name(isis, sysid))) {
 		memcpy(lspid, dynhn->id, ISIS_SYS_ID_LEN);
 		lsp = lsp_search(head, lspid);
 	} else if (strncmp(cmd_hostname_get(), sysid, 15) == 0) {

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -95,6 +95,7 @@ struct isis {
 	struct thread *t_dync_clean;      /* dynamic hostname cache cleanup thread */
 	uint32_t circuit_ids_used[8];     /* 256 bits to track circuit ids 1 through 255 */
 	int snmp_notifications;
+	struct list *dyn_cache;
 
 	struct route_table *ext_info[REDIST_PROTOCOL_COUNT];
 };

--- a/tests/isisd/test_common.c
+++ b/tests/isisd/test_common.c
@@ -309,7 +309,8 @@ static int topology_load_node(const struct isis_topology *topology,
 {
 	int ret;
 
-	isis_dynhn_insert(tnode->sysid, tnode->hostname, tnode->level);
+	isis_dynhn_insert(area->isis, tnode->sysid, tnode->hostname,
+			  tnode->level);
 
 	for (int level = IS_LEVEL_1; level <= IS_LEVEL_2; level++) {
 		if ((tnode->level & level) == 0)

--- a/tests/isisd/test_isis_spf.c
+++ b/tests/isisd/test_isis_spf.c
@@ -269,7 +269,7 @@ static int test_run(struct vty *vty, const struct isis_topology *topology,
 		if (sysid2buff(fail_id, fail_sysid_str) == 0) {
 			struct isis_dynhn *dynhn;
 
-			dynhn = dynhn_find_by_name(fail_sysid_str);
+			dynhn = dynhn_find_by_name(area->isis, fail_sysid_str);
 			if (dynhn == NULL) {
 				vty_out(vty, "Invalid system id %s\n",
 					fail_sysid_str);
@@ -338,9 +338,6 @@ static int test_run(struct vty *vty, const struct isis_topology *topology,
 
 	/* Cleanup IS-IS area. */
 	isis_area_destroy(area);
-
-	/* Cleanup hostnames. */
-	dyn_cache_cleanup_all();
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
Currently, the dynamic hostname cache is global. It is incorrect because
neighbors in different VRFs may have the same system ID and different
hostnames.

This also fixes a memory leak - when the instance is deleted, the cache
must be cleaned up and the cleanup thread must be cancelled.

Fixes #8832.

As discussed with @donaldsharp, this PR should replace https://github.com/FRRouting/frr/pull/8834.