### PR TITLE
lib: remove VRF from interface NB list key

### DIFF
--- a/eigrpd/eigrp_cli.c
+++ b/eigrpd/eigrp_cli.c
@@ -873,6 +873,7 @@ static struct cmd_node eigrp_interface_node = {
 
 static int eigrp_write_interface(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
 	struct lyd_node *dnode;
 	struct interface *ifp;
 	struct vrf *vrf;
@@ -880,10 +881,8 @@ static int eigrp_write_interface(struct vty *vty)
 
 	RB_FOREACH(vrf, vrf_name_head, &vrfs_by_name) {
 		FOR_ALL_INTERFACES(vrf, ifp) {
-			dnode = yang_dnode_getf(
-				running_config->dnode,
-				"/frr-interface:lib/interface[name='%s'][vrf='%s']",
-				ifp->name, vrf->name);
+			interface_xpath(xpath, ifp->name, vrf->name);
+			dnode = yang_dnode_get(running_config->dnode, xpath);
 			if (dnode == NULL)
 				continue;
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1298,6 +1298,7 @@ static int isis_interface_config_write(struct vty *vty)
 #else
 static int isis_interface_config_write(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
 	struct vrf *vrf = NULL;
 	int write = 0;
 
@@ -1306,10 +1307,8 @@ static int isis_interface_config_write(struct vty *vty)
 
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			struct lyd_node *dnode;
-			dnode = yang_dnode_getf(
-				running_config->dnode,
-				"/frr-interface:lib/interface[name='%s'][vrf='%s']",
-				ifp->name, vrf->name);
+			interface_xpath(xpath, ifp->name, vrf->name);
+			dnode = yang_dnode_get(running_config->dnode, xpath);
 			if (dnode == NULL)
 				continue;
 

--- a/lib/if.h
+++ b/lib/if.h
@@ -597,6 +597,8 @@ struct if_link_params *if_link_params_get(struct interface *);
 void if_link_params_free(struct interface *);
 
 /* Northbound. */
+void interface_xpath(char *xpath, const char *ifname, const char *vrfname);
+
 extern void if_cmd_init(void);
 extern void if_zapi_callbacks(int (*create)(struct interface *ifp),
 			      int (*up)(struct interface *ifp),

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -1258,6 +1258,9 @@ struct yang_data *nb_callback_get_elem(const struct nb_node *nb_node,
 	       "northbound callback (get_elem): xpath [%s] list_entry [%p]",
 	       xpath, list_entry);
 
+	if (!nb_node->cbs.get_elem)
+		return NULL;
+
 	args.xpath = xpath;
 	args.list_entry = list_entry;
 	return nb_node->cbs.get_elem(&args);
@@ -1626,9 +1629,6 @@ static int nb_oper_data_iter_leaf(const struct nb_node *nb_node,
 				  uint32_t flags, nb_oper_data_cb cb, void *arg)
 {
 	struct yang_data *data;
-
-	if (CHECK_FLAG(nb_node->snode->flags, LYS_CONFIG_W))
-		return NB_OK;
 
 	/* Ignore list keys. */
 	if (lysc_is_key(nb_node->snode))

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -1107,6 +1107,7 @@ void rip_passive_nondefault_clean(struct rip *rip)
 /* Write rip configuration of each interface. */
 static int rip_interface_config_write(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
 	struct vrf *vrf;
 	int write = 0;
 
@@ -1116,10 +1117,8 @@ static int rip_interface_config_write(struct vty *vty)
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			struct lyd_node *dnode;
 
-			dnode = yang_dnode_getf(
-				running_config->dnode,
-				"/frr-interface:lib/interface[name='%s'][vrf='%s']",
-				ifp->name, vrf->name);
+			interface_xpath(xpath, ifp->name, vrf->name);
+			dnode = yang_dnode_get(running_config->dnode, xpath);
 			if (dnode == NULL)
 				continue;
 

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -927,6 +927,7 @@ static int ripng_if_delete_hook(struct interface *ifp)
 /* Configuration write function for ripngd. */
 static int interface_config_write(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
 	struct vrf *vrf;
 	int write = 0;
 
@@ -936,10 +937,8 @@ static int interface_config_write(struct vty *vty)
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			struct lyd_node *dnode;
 
-			dnode = yang_dnode_getf(
-				running_config->dnode,
-				"/frr-interface:lib/interface[name='%s'][vrf='%s']",
-				ifp->name, vrf->name);
+			interface_xpath(xpath, ifp->name, vrf->name);
+			dnode = yang_dnode_get(running_config->dnode, xpath);
 			if (dnode == NULL)
 				continue;
 

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -720,6 +720,7 @@ DEFUN_NOSH (show_debugging_vrrp,
  */
 static int vrrp_config_write_interface(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
 	struct vrf *vrf;
 	int write = 0;
 
@@ -729,10 +730,8 @@ static int vrrp_config_write_interface(struct vty *vty)
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			struct lyd_node *dnode;
 
-			dnode = yang_dnode_getf(
-				running_config->dnode,
-				"/frr-interface:lib/interface[name='%s'][vrf='%s']",
-				ifp->name, vrf->name);
+			interface_xpath(xpath, ifp->name, vrf->name);
+			dnode = yang_dnode_get(running_config->dnode, xpath);
 			if (dnode == NULL)
 				continue;
 

--- a/yang/frr-interface.yang
+++ b/yang/frr-interface.yang
@@ -288,7 +288,7 @@ module frr-interface {
 
   container lib {
     list interface {
-      key "name vrf";
+      key "name";
       description
         "Interface.";
       leaf name {
@@ -303,6 +303,7 @@ module frr-interface {
         type frr-vrf:vrf-ref;
         description
           "VRF this interface is associated with.";
+        mandatory true;
       }
 
       leaf description {

--- a/yang/ietf/frr-ietf-translator.json
+++ b/yang/ietf/frr-ietf-translator.json
@@ -3,20 +3,6 @@
     "family": "ietf",
     "module": [
       {
-        "name": "ietf-interfaces@2018-01-09",
-        "deviations": "frr-deviations-ietf-interfaces",
-        "mappings": [
-          {
-            "custom": "/ietf-interfaces:interfaces/interface[name='KEY1']",
-            "native": "/frr-interface:lib/interface[name='KEY1'][vrf='default']"
-          },
-          {
-            "custom": "/ietf-interfaces:interfaces/interface[name='KEY1']/description",
-            "native": "/frr-interface:lib/interface[name='KEY1'][vrf='default']/description"
-          }
-        ]
-      },
-      {
         "name": "ietf-routing@2018-01-25",
         "deviations": "frr-deviations-ietf-routing",
         "mappings": [
@@ -60,7 +46,7 @@
           },
           {
             "custom": "/ietf-routing:routing/control-plane-protocols/control-plane-protocol[type='ietf-rip:ripv2'][name='main']/ietf-rip:rip/interfaces/interface[interface='KEY1']/split-horizon",
-            "native": "/frr-interface:lib/interface[name='KEY1'][vrf='default']/frr-ripd:rip/split-horizon"
+            "native": "/frr-interface:lib/interface[name='KEY1']/frr-ripd:rip/split-horizon"
           },
           {
             "custom": "/ietf-routing:routing/control-plane-protocols/control-plane-protocol[type='ietf-rip:ripv2'][name='main']/ietf-rip:rip/ipv4/neighbors/neighbor[ipv4-address='KEY1']",


### PR DESCRIPTION
Currently, the interface NB list key includes a VRF name. Because of
this we have the following problem with the interface configuration:

- enter the interface node
- move the interface to another VRF
- try to continue configuring the interface

It is not possible to continue configuration because the XPath stored in
the vty doesn't correspond with the actual state of the system anymore.
For example:

```
nfware# conf
nfware(config)# interface enp2s0

<-- move the enp2s0 to a different VRF -->

nfware(config-if)# ip router isis 1
% Failed to get iface dnode in candidate DB
```

Removing the VRF from the key eliminates the issue. However, when the
netns backend is used, it is possible to have multiple interfaces with
the same name in different VRFs. To support that, let's prepend the VRF
name to the interface name in the NB config.

This change also makes it possible to configure the VRF of the interface
from the FRR's CLI in the future. It would be impossible if the VRF was
part of the key.