### PR TITLE
vtysh: make hostname and domainname persistent

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -2522,10 +2522,6 @@ void cmd_init(int terminal)
 		hash_cmd_init();
 	}
 
-	install_element(CONFIG_NODE, &hostname_cmd);
-	install_element(CONFIG_NODE, &no_hostname_cmd);
-	install_element(CONFIG_NODE, &domainname_cmd);
-	install_element(CONFIG_NODE, &no_domainname_cmd);
 
 	if (terminal > 0) {
 		full_cli = true;
@@ -2536,6 +2532,11 @@ void cmd_init(int terminal)
 		install_element(CONFIG_NODE, &no_password_cmd);
 		install_element(CONFIG_NODE, &enable_password_cmd);
 		install_element(CONFIG_NODE, &no_enable_password_cmd);
+
+		install_element(CONFIG_NODE, &hostname_cmd);
+		install_element(CONFIG_NODE, &no_hostname_cmd);
+		install_element(CONFIG_NODE, &domainname_cmd);
+		install_element(CONFIG_NODE, &no_domainname_cmd);
 
 		install_element(CONFIG_NODE, &service_password_encrypt_cmd);
 		install_element(CONFIG_NODE, &no_service_password_encrypt_cmd);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -682,7 +682,7 @@ static int vtysh_execute_func(const char *line, int pager)
 			 * Need make it better
 			 */
 			if (!strcmp(cmd->string, "hostname WORD")
-			    || !strcmp(cmd->string, "doaminname WORD"))
+			    || !strcmp(cmd->string, "domainname WORD"))
 				(*cmd->func)(cmd, vty, 1, (struct cmd_token **)line);
 			else
 				(*cmd->func)(cmd, vty, 0, NULL);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -459,6 +459,31 @@ static void vtysh_client_config(struct vtysh_client *head_client, char *line)
 	vty->of = vty->of_saved;
 }
 
+/* Command execution to some special commands */
+int vtysh_client_run_special_commands()
+{
+	char line[] = "do write terminal\n";
+	struct vtysh_client *head_client;
+	unsigned int i;
+
+	for (i = 0; i < array_size(vtysh_client); i++) {
+		head_client = &vtysh_client[i];
+
+		/* One daemon is enough */
+		if (head_client->flag != VTYSH_ZEBRA)
+			continue;
+
+		/* suppress output to user */
+		vty->of_saved = vty->of;
+		vty->of = NULL;
+		vtysh_client_run_all(head_client, line, 1, vtysh_config_parse_name_line,
+				     NULL);
+		vty->of = vty->of_saved;
+    }
+
+    return 1;
+}
+
 /* Command execution over the vty interface. */
 static int vtysh_execute_func(const char *line, int pager)
 {
@@ -652,8 +677,16 @@ static int vtysh_execute_func(const char *line, int pager)
 		if (cmd_stat != CMD_SUCCESS)
 			break;
 
-		if (cmd->func)
-			(*cmd->func)(cmd, vty, 0, NULL);
+		if (cmd->func) {
+			/* XX
+			 * Need make it better
+			 */
+			if (!strcmp(cmd->string, "hostname WORD")
+			    || !strcmp(cmd->string, "doaminname WORD"))
+				(*cmd->func)(cmd, vty, 1, (struct cmd_token **)line);
+			else
+				(*cmd->func)(cmd, vty, 0, NULL);
+		}
 	}
 	}
 	if (vty->is_paged)
@@ -3171,6 +3204,50 @@ DEFUNSH(VTYSH_ALL, no_vtysh_config_enable_password,
 	return CMD_SUCCESS;
 }
 
+/* Hostname configuration */
+DEFUNSH(VTYSH_ALL, vtysh_config_hostname,
+       vtysh_hostname_cmd,
+       "hostname WORD",
+       "Set system's network name\n"
+       "This system's network name\n")
+{
+	/* Skip all checks, which are already checked in other daemons */
+        char * m = strrchr((char*)argv, ' ');
+        return cmd_hostname_set(m + 1);
+}
+
+DEFUNSH(VTYSH_ALL, vtysh_config_no_hostname,
+       vtysh_no_hostname_cmd,
+       "no hostname [HOSTNAME]",
+       NO_STR
+       "Reset system's network name\n"
+       "Host name of this router\n")
+{
+	return cmd_hostname_set(NULL);
+}
+
+/* Domainname configuration */
+DEFUNSH(VTYSH_ALL, vtysh_config_domainname,
+      vtysh_domainname_cmd,
+      "domainname WORD",
+      "Set system's domain name\n"
+      "This system's domain name\n")
+{
+	/* Skip all checks, which are already checked in other daemons */
+        char *m = strrchr((char*)argv, ' ');
+        return cmd_domainname_set(m + 1);
+}
+
+DEFUNSH(VTYSH_ALL, vysh_config_no_domainname,
+      vtysh_no_domainname_cmd,
+      "no domainname [DOMAINNAME]",
+      NO_STR
+      "Reset system's domain name\n"
+      "domain name of this router\n")
+{
+	return cmd_domainname_set(NULL);
+}
+
 DEFUN (vtysh_write_terminal,
        vtysh_write_terminal_cmd,
        "write terminal ["DAEMONS_LIST"] [no-header]",
@@ -4568,4 +4645,9 @@ void vtysh_init_vty(void)
 	install_element(CONFIG_NODE, &no_vtysh_password_cmd);
 	install_element(CONFIG_NODE, &vtysh_enable_password_cmd);
 	install_element(CONFIG_NODE, &no_vtysh_enable_password_cmd);
+
+	install_element(CONFIG_NODE, &vtysh_hostname_cmd);
+	install_element(CONFIG_NODE, &vtysh_no_hostname_cmd);
+	install_element(CONFIG_NODE, &vtysh_domainname_cmd);
+	install_element(CONFIG_NODE, &vtysh_no_domainname_cmd);
 }

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -96,8 +96,10 @@ int vtysh_mark_file(const char *filename);
 
 int vtysh_read_config(const char *filename, bool dry_run);
 int vtysh_write_config_integrated(void);
+int vtysh_client_run_special_commands(void);
 
 void vtysh_config_parse_line(void *, const char *);
+void vtysh_config_parse_name_line(void *, const char *);
 
 void vtysh_config_dump(void);
 

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -236,6 +236,27 @@ static void config_add_line_uniq_end(struct list *config, const char *line)
 		listnode_move_to_tail(config, node);
 }
 
+void vtysh_config_parse_name_line(void *arg, const char *line)
+{
+	char c;
+
+	if (!line)
+		return;
+
+	c = line[0];
+
+	if (c == '\0')
+		return;
+
+	if (strncmp(line, "hostname", strlen("hostname")) == 0
+	    || strncmp(line, "domainname", strlen("domainname")) == 0) {
+		vtysh_execute("configure terminal");
+		vtysh_execute(line);
+		vtysh_execute("end");
+	}
+	return;
+}
+
 void vtysh_config_parse_line(void *arg, const char *line)
 {
 	char c;
@@ -582,18 +603,6 @@ int vtysh_read_config(const char *config_default_dir, bool dry_run)
  */
 void vtysh_config_write(void)
 {
-	char line[512];
-
-	if (cmd_hostname_get()) {
-		snprintf(line, sizeof(line), "hostname %s", cmd_hostname_get());
-		vtysh_config_parse_line(NULL, line);
-	}
-
-	if (cmd_domainname_get()) {
-		snprintf(line, sizeof(line), "domainname %s",
-			 cmd_domainname_get());
-		vtysh_config_parse_line(NULL, line);
-	}
 	if (vtysh_write_integrated == WRITE_INTEGRATED_NO)
 		vtysh_config_parse_line(NULL,
 					"no service integrated-vtysh-config");

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -565,6 +565,16 @@ int main(int argc, char **argv, char **env)
 		}
 		vtysh_execute("enable");
 		return vtysh_write_config_integrated();
+	} else {
+		/*
+		 * Exec some special commands from other daemon at booting
+		 * Because these commands of vtysh itself maybe not exact
+		 *
+		 * Here, maybe better way?
+		 */
+		vtysh_execute("enable");
+		vtysh_client_run_special_commands();
+		vtysh_execute("disable");
 	}
 
 	if (inputfile) {


### PR DESCRIPTION
Two difficults to make persistent:

1) In integrated mode, watchfrr uses `vtysh -w` to save into configure file, but the new
`vtysh` can't get these names from current using vtysh.

2) When usesrs run `vtysh`, it will never reading /etf/frr/frr.conf, so
`vtysh` can't get the exact names.

To fixes this issue, need put these names saved into all daemons besides
current vtysh.

Signed-off-by: anlancs <anlan_cs@tom.com>