### PR TITLE
ospf6d: consistent checksum JSON output

### DIFF
--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -659,7 +659,7 @@ void ospf6_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 				       adv_router);
 		json_object_int_add(json_obj, "lsSequenceNumber",
 				    (unsigned long)ntohl(lsa->header->seqnum));
-		json_object_int_add(json_obj, "checkSum",
+		json_object_int_add(json_obj, "checksum",
 				    ntohs(lsa->header->checksum));
 		json_object_int_add(json_obj, "length",
 				    ntohs(lsa->header->length));


### PR DESCRIPTION
Changed LSA checksum JSON output variable name from "checkSum" to
"checksum" to maintain consistency.

Signed-off-by: David Schweizer <dschweizer@opensourcerouting.org>