### PR TITLE
ospf6d: Link state ID in LSA database JSON output

### DIFF
--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -654,6 +654,7 @@ void ospf6_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 				    ospf6_lsa_age_current(lsa));
 		json_object_string_add(json_obj, "type",
 				       ospf6_lstype_name(lsa->header->type));
+		json_object_string_add(json_obj, "linkStateId", id);
 		json_object_string_add(json_obj, "advertisingRouter",
 				       adv_router);
 		json_object_int_add(json_obj, "lsSequenceNumber",


### PR DESCRIPTION
Added link state ID to JSON output of LSA database CLI show command.

Signed-off-by: David Schweizer <dschweizer@opensourcerouting.org>