### PR TITLE
ospf6d: JSON output for database dump show command

### DIFF
--- a/lib/frrstr.c
+++ b/lib/frrstr.c
@@ -217,3 +217,11 @@ int all_digit(const char *str)
 			return 0;
 	return 1;
 }
+
+
+char *frrstr_hex(char *buff, const char *str, size_t num)
+{
+	for (size_t i = 0; i < num; ++i)
+		snprintf(&buff[2 * i], 3, "%02x", (unsigned char)str[i]);
+	return buff;
+}

--- a/lib/frrstr.h
+++ b/lib/frrstr.h
@@ -154,6 +154,23 @@ bool frrstr_endswith(const char *str, const char *suffix);
  */
 int all_digit(const char *str);
 
+/*
+ * Copy the hexadecimal representation of the string to a buffer.
+ *
+ * buff
+ *    Buffer to copy result into with size of at least (2 * num) + 1.
+ *
+ * str
+ *    String to represent as hexadecimal.
+ *
+ * num
+ *    Number of characters to copy.
+ *
+ * Returns:
+ *    Pointer to buffer containing resulting hexadecimal representation.
+ */
+char *frrstr_hex(char *buff, const char *str, size_t num);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added missing output to "show ipv6 ospf6 databse dump json" VTY shell
command.

Signed-off-by: David Schweizer <dschweizer@opensourcerouting.org>