### PR TITLE
docker: use tini as entrypoint unilaterally

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -55,5 +55,14 @@ RUN apk add \
 		--no-cache \
 		--allow-untrusted /pkgs/apk/*/*.apk \
 	&& rm -rf /pkgs
+
+# Own the config / PID files
+RUN mkdir -p /var/run/frr
+RUN chown -R frr:frr /etc/frr /var/run/frr
+
+# Simple init manager for reaping processes and forwarding signals
+ENTRYPOINT ["/sbin/tini", "--"]
+
+# Default CMD starts watchfrr
 COPY docker/alpine/docker-start /usr/lib/frr/docker-start
-CMD [ "/sbin/tini", "--", "/usr/lib/frr/docker-start" ]
+CMD ["/usr/lib/frr/docker-start"]

--- a/docker/alpine/docker-start
+++ b/docker/alpine/docker-start
@@ -1,12 +1,4 @@
-#!/bin/sh
+#!/bin/ash
 
-set -e
-
-##
-# For volume mounts...
-##
-chown -R frr:frr /etc/frr || true
-/usr/lib/frr/frrinit.sh start
-
-# Sleep forever
-exec tail -f /dev/null
+source /usr/lib/frr/frrcommon.sh
+/usr/lib/frr/watchfrr $(daemon_list)

--- a/docker/centos-7/Dockerfile
+++ b/docker/centos-7/Dockerfile
@@ -39,5 +39,19 @@ COPY --from=centos-7-builder /rpmbuild/RPMS/ /pkgs/rpm/
 
 RUN yum install -y /pkgs/rpm/*/*.rpm \
     && rm -rf /pkgs
+
+# Own the config / PID files
+RUN mkdir -p /var/run/frr
+RUN chown -R frr:frr /etc/frr /var/run/frr
+
+# Add tini because no CentOS7 package
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
+RUN chmod +x /sbin/tini
+
+# Simple init manager for reaping processes and forwarding signals
+ENTRYPOINT ["/sbin/tini", "--"]
+
+# Default CMD starts watchfrr
 COPY docker/centos-7/docker-start /usr/lib/frr/docker-start
-CMD [ "/usr/lib/frr/docker-start" ]
+CMD ["/usr/lib/frr/docker-start"]

--- a/docker/centos-7/docker-start
+++ b/docker/centos-7/docker-start
@@ -1,12 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
-
-##
-# Change owner for docker volume mount
-##
-chown -R frr:frr /etc/frr
-/usr/lib/frr/frrinit.sh start
-
-# Sleep forever
-exec tail -f /dev/null
+source /usr/lib/frr/frrcommon.sh
+/usr/lib/frr/watchfrr $(daemon_list)

--- a/docker/centos-8/Dockerfile
+++ b/docker/centos-8/Dockerfile
@@ -40,5 +40,19 @@ COPY --from=centos-8-builder /rpmbuild/RPMS/ /pkgs/rpm/
 
 RUN yum install -y /pkgs/rpm/*/*.rpm \
     && rm -rf /pkgs
+
+# Own the config / PID files
+RUN mkdir -p /var/run/frr
+RUN chown -R frr:frr /etc/frr /var/run/frr
+
+# Add tini because no CentOS8 package
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
+RUN chmod +x /sbin/tini
+
+# Simple init manager for reaping processes and forwarding signals
+ENTRYPOINT ["/sbin/tini", "--"]
+
+# Default CMD starts watchfrr
 COPY docker/centos-8/docker-start /usr/lib/frr/docker-start
-CMD [ "/usr/lib/frr/docker-start" ]
+CMD ["/usr/lib/frr/docker-start"]

--- a/docker/centos-8/docker-start
+++ b/docker/centos-8/docker-start
@@ -1,9 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
-
-chown -R frr:frr /etc/frr
-/usr/lib/frr/frrinit.sh start
-
-# Sleep forever
-exec tail -f /dev/null
+source /usr/lib/frr/frrcommon.sh
+/usr/lib/frr/watchfrr $(daemon_list)

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -6,8 +6,8 @@ ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 
 RUN apt-get update && \
     apt-get install -y libpcre3-dev apt-transport-https ca-certificates curl wget logrotate \
-    libc-ares2 libjson-c3 vim procps libreadline7 gnupg2 lsb-release apt-utils && \
-    rm -rf /var/lib/apt/lists/*
+    libc-ares2 libjson-c3 vim procps libreadline7 gnupg2 lsb-release apt-utils \
+    tini && rm -rf /var/lib/apt/lists/*
 
 RUN curl -s https://deb.frrouting.org/frr/keys.asc | apt-key add -
 RUN echo deb https://deb.frrouting.org/frr $(lsb_release -s -c) frr-stable | tee -a /etc/apt/sources.list.d/frr.list
@@ -16,5 +16,13 @@ RUN apt-get update && \
     apt-get install -y frr frr-pythontools && \
     rm -rf /var/lib/apt/lists/*
 
-ADD docker-start /usr/sbin/docker-start
-CMD ["/usr/sbin/docker-start"]
+# Own the config / PID files
+RUN mkdir -p /var/run/frr
+RUN chown -R frr:frr /etc/frr /var/run/frr
+
+# Simple init manager for reaping processes and forwarding signals
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+# Default CMD starts watchfrr
+COPY docker-start /usr/lib/frr/docker-start
+CMD ["/usr/lib/frr/docker-start"]

--- a/docker/debian/docker-start
+++ b/docker/debian/docker-start
@@ -1,12 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
-
-##
-# For volume mounts...
-##
-chown -R frr:frr /etc/frr
-/etc/init.d/frr start
-
-# Sleep forever
-exec tail -f /dev/null
+source /usr/lib/frr/frrcommon.sh
+/usr/lib/frr/watchfrr $(daemon_list)


### PR DESCRIPTION
Use `tini` to reap zombies and forward signals to the script. Also start `watchfrr.sh` directly instead of using `sleep 365d` in many of the Docker containers.

To build and test:

```
# centos-8
./docker/centos-8/build.sh
# centos-7
./docker/centos-7/build.sh
# debian
docker build ./docker/debian

# Run with no arguments starts watchfrr.sh as usual
w@kvm-gentoo .../code/frr $ docker run -it frr:centos-8-b7a223b691 
2021/06/16 02:14:56 WATCHFRR: [T83RR-8SM5G] watchfrr 8.1-dev_git788699264657 starting: vty@0
[...]

# PID1 is tini!
w@kvm-gentoo .../code/frr $ docker run -it frr:centos-8-b7a223b691 bash
[root@39cfa2832151 /]# ps 1
  PID TTY      STAT   TIME COMMAND
    1 pts/0    Ss     0:00 /sbin/tini -- bash

```

I wanted to fix the Alpine build with this PR as there is no LY2 in the Alpine repos but that's proving to be a more-than-trivial task :) it will take more work in the Alpine repository so not really much to do in FRR until that is in their package repo

Closes: #8788 