### PR TITLE
lib: fix interface configuration after vrf change

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -266,20 +266,23 @@ void if_update_to_new_vrf(struct interface *ifp, vrf_id_t vrf_id)
 		char oldpath[XPATH_MAXLEN];
 		char newpath[XPATH_MAXLEN];
 
-		if_dnode = yang_dnode_getf(
-			running_config->dnode,
-			"/frr-interface:lib/interface[name='%s'][vrf='%s']/vrf",
-			ifp->name, old_vrf->name);
+		snprintf(oldpath, sizeof(oldpath),
+			 "/frr-interface:lib/interface[name='%s'][vrf='%s']",
+			 ifp->name, old_vrf->name);
+		snprintf(newpath, sizeof(newpath),
+			 "/frr-interface:lib/interface[name='%s'][vrf='%s']",
+			 ifp->name, vrf->name);
+
+		if_dnode = yang_dnode_getf(running_config->dnode, "%s/vrf",
+					   oldpath);
 
 		if (if_dnode) {
-			yang_dnode_get_path(lyd_parent(if_dnode), oldpath,
-					    sizeof(oldpath));
 			yang_dnode_change_leaf(if_dnode, vrf->name);
-			yang_dnode_get_path(lyd_parent(if_dnode), newpath,
-					    sizeof(newpath));
 			nb_running_move_tree(oldpath, newpath);
 			running_config->version++;
 		}
+
+		vty_update_xpath(oldpath, newpath);
 	}
 }
 

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -327,6 +327,7 @@ extern void vty_close(struct vty *);
 extern char *vty_get_cwd(void);
 extern void vty_log(const char *level, const char *proto, const char *msg,
 		    struct timestamp_control *);
+extern void vty_update_xpath(const char *oldpath, const char *newpath);
 extern int vty_config_enter(struct vty *vty, bool private_config,
 			    bool exclusive);
 extern void vty_config_exit(struct vty *);


### PR DESCRIPTION
This commit fixes the following problem:

- enter the interface node
- move the interface to another VRF
- try to continue configuring the interface

It is not possible to continue configuration because the XPath stored in
the vty doesn't correspond with the actual state of the system anymore.

For example:
```
nfware# conf
nfware(config)# interface enp2s0

<-- move the enp2s0 to a different VRF -->

nfware(config-if)# ip router isis 1
% Failed to get iface dnode in candidate DB
```

To fix the issue, go through all connected vty shells and update the
stored XPath.

Suggested-by: Renato Westphal <renato@opensourcerouting.org>
Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>

@rwestphal I added the "Suggested-by" tag mentioning you, as you suggested this idea in https://github.com/FRRouting/frr/pull/8845. If you don't want to be mentioned, please, comment and I'll remove the tag.