### PR TITLE
a couple of isis fixes

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -78,12 +78,14 @@ DEFINE_HOOK(isis_circuit_del_hook, (struct isis_circuit *circuit), (circuit));
 
 static void isis_circuit_enable(struct isis_circuit *circuit)
 {
-	struct isis_area *area;
+	struct isis_area *area = circuit->area;
 	struct interface *ifp = circuit->interface;
 
-	area = isis_area_lookup(circuit->tag, ifp->vrf_id);
-	if (area)
-		isis_area_add_circuit(area, circuit);
+	if (!area) {
+		area = isis_area_lookup(circuit->tag, ifp->vrf_id);
+		if (area)
+			isis_area_add_circuit(area, circuit);
+	}
 
 	if (if_is_operative(ifp))
 		isis_csm_state_change(IF_UP_FROM_Z, circuit, ifp);

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -402,7 +402,7 @@ struct isis_area *isis_area_create(const char *area_tag, const char *vrf_name)
 				continue;
 
 			circuit = ifp->info;
-			if (circuit)
+			if (circuit && strmatch(circuit->tag, area->area_tag))
 				isis_area_add_circuit(area, circuit);
 		}
 	}


### PR DESCRIPTION
```
isisd: fix adding a circuit to the wrong area

When creating a new area, we're adding all circuits in the same VRF to
this area. We should only add circuits configured with the same tag.
```
```
isis: fix double-adding a circuit to the area

isis_circuit_enable can be called for an already enabled circuit. In this
case we would add the circuit to the area multiple times.
```