### PR TITLE
tools: make frr-reload recognize `pbr table range` lines as single-line contexts

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -599,6 +599,7 @@ end
             "mpls label",
             "no ",
             "password ",
+            "pbr ",
             "ptm-enable",
             "router-id ",
             "service ",


### PR DESCRIPTION
One-line fix to make `frr-reload.py` treat `pbr table range ...` lines as being single-line contexts instead of creating a new context.

First create a config file with the following contents:

```
cumulus@cumulus:mgmt:~$ cat frr-1.conf 
nexthop-group GROUP1
 nexthop 21.1.1.2 swp2
pbr-map MAP1 seq 10
 set nexthop-group GROUP1
 match dscp 1
interface swp1
pbr-policy MAP1
```

Then copy this file and add `pbr table range ...` to the top:

```
cumulus@cumulus:mgmt:~$ cat frr-2.conf 
pbr table range 20000 4294966272
!
nexthop-group GROUP1
 nexthop 21.1.1.2 swp2
pbr-map MAP1 seq 10
 match dscp 1
 set nexthop-group GROUP1
interface swp1
 pbr-policy MAP1
```

```
./frr-reload.py --test --input frr-1.conf frr-2.conf
[...]
Lines To Delete
===============
no log syslog informational
no nexthop-group GROUP1

Lines To Add
============
pbr table range 20000 4294966272
pbr table range 20000 4294966272
 nexthop-group GROUP1
pbr table range 20000 4294966272
 nexthop 21.1.1.2 swp2
```

Clearly not a coherent delta. Attempting to apply this delta:

```
cumulus@cumulus:mgmt:~$ sudo ./frr-reload.py --reload --input frr-1.conf frr-2.conf 
line 7: % Unknown command[4]:  nexthop 21.1.1.2 swp2
line 5: % Unknown command[4]:  nexthop 21.1.1.2 swp2
line 18: % Unknown command[4]:  nexthop 21.1.1.2 swp2
```