### PR TITLE
bgpd: Force process networks on VRF creation

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6182,6 +6182,7 @@ void bgp_static_add(struct bgp *bgp)
 	struct bgp_table *table;
 	struct bgp_static *bgp_static;
 
+	SET_FLAG(bgp->flags, BGP_FLAG_FORCE_STATIC_PROCESS);
 	FOREACH_AFI_SAFI (afi, safi)
 		for (dest = bgp_table_top(bgp->route[afi][safi]); dest;
 		     dest = bgp_route_next(dest)) {
@@ -6208,6 +6209,7 @@ void bgp_static_add(struct bgp *bgp)
 					safi);
 			}
 		}
+	UNSET_FLAG(bgp->flags, BGP_FLAG_FORCE_STATIC_PROCESS);
 }
 
 /* Called from bgp_delete().  Delete all static routes from the BGP


### PR DESCRIPTION
**To Reproduce**

1. Config BGP instance and network of a non-existent VRF
    ```
    (config)# router bgp 65000 vrf vrf1
    (config-router)# network 1.1.1.1/32
    ```
2. Create the VRF and route
3. The path remains invalid
    ```
    # show ip bgp vrf vrf1 1.1.1.1/32
    BGP routing table entry for 1.1.1.1/32, version 0
    Paths: (1 available, no best path)
      Not advertised to any peer
      Local
        0.0.0.0 (inaccessible) from 0.0.0.0 (1.1.1.1)
          Origin IGP, metric 0, weight 32768, invalid, sourced, local
          Last update: Thu Jun 17 14:32:11 2021
    ```
4. The path will become valid after removing and reconfiguring the network.