### PR TITLE
tests: Disable Redist test with call in route-map as it never worked

### DIFF
--- a/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
@@ -707,60 +707,70 @@ def test_ospf_routemaps_functionality_tc21_p0(request):
     result = create_route_maps(tgen, routemaps)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    step("Configure route map with call clause")
+    # Test with Call clause temporarly removed as it never worked
+    # need to fix code first
 
-    # Create ip prefix list
-    input_dict_2 = {
-        "r0": {
-            "prefix_lists": {
-                "ipv4": {
-                    "pf_list_1_ipv4": [
-                        {"seqid": 10, "network": "any", "action": "permit"}
-                    ]
-                }
-            }
-        }
-    }
-    result = create_prefix_lists(tgen, input_dict_2)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    # step("Configure route map with call clause")
 
-    # Create route map
-    input_dict_3 = {
-        "r0": {
-            "route_maps": {
-                "rmap_ipv4": [
-                    {
-                        "action": "permit",
-                        "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
-                        "set": {"med": 150},
-                        "call": "rmap_match_pf_2_ipv4",
-                        "seq_id": 10,
-                    }
-                ],
-                "rmap_match_pf_2_ipv4": [
-                    {
-                        "action": "permit",
-                        "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
-                        "set": {"med": 200},
-                        "seq_id": 10,
-                    }
-                ],
-            }
-        }
-    }
-    result = create_route_maps(tgen, input_dict_3)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    # # Create ip prefix list
+    # input_dict_2 = {
+    #     "r0": {
+    #         "prefix_lists": {
+    #             "ipv4": {
+    #                 "pf_list_1_ipv4": [
+    #                     {"seqid": 10, "network": "any", "action": "permit"}
+    #                 ]
+    #             }
+    #         }
+    #     }
+    # }
+    # result = create_prefix_lists(tgen, input_dict_2)
+    # assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    result = verify_ospf_rib(tgen, dut, input_dict)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    # # Create route map
+    # input_dict_3 = {
+    #     "r0": {
+    #         "route_maps": {
+    #             "rmap_ipv4": [
+    #                 {
+    #                     "action": "permit",
+    #                     "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
+    #                     "set": {"med": 150},
+    #                     "call": "rmap_match_pf_2_ipv4",
+    #                     "seq_id": 10,
+    #                 }
+    #             ],
+    #             "rmap_match_pf_2_ipv4": [
+    #                 {
+    #                     "action": "permit",
+    #                     "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
+    #                     "set": {"med": 200},
+    #                     "seq_id": 10,
+    #                 }
+    #             ],
+    #         }
+    #     }
+    # }
+    # result = create_route_maps(tgen, input_dict_3)
+    # assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    result = verify_rib(tgen, "ipv4", dut, input_dict, protocol=protocol)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    # result = verify_ospf_rib(tgen, dut, input_dict)
+    # assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    # Create route map
-    routemaps = {"r0": {"route_maps": {"rmap_ipv4": [{"delete": True}]}}}
-    result = create_route_maps(tgen, routemaps)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+    #######
+    # TODO: Fix Test: This verify_rib is too soon. The routes checked are on many platforms
+    #       still around from the previous test. We need a delay here, or do this test with
+    #       different routes or make sure the routes are withdrawn first before the new
+    #       route-map is tested
+    ########
+
+    # result = verify_rib(tgen, "ipv4", dut, input_dict, protocol=protocol)
+    # assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    # # Create route map
+    # routemaps = {"r0": {"route_maps": {"rmap_ipv4": [{"delete": True}]}}}
+    # result = create_route_maps(tgen, routemaps)
+    # assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     step("Configure route map with continue clause")
 


### PR DESCRIPTION
Disabling OSPF redistribution test with a route-map which uses call function.

The test never worked correctly. It used to pass as it ran too fast and didn't verify if the checked routes were withdrawn first (previous test used same test routes), but started to fail on CI on arm platform.

Test needs to be fixed after Issue #8872 is fixed, but done the correct way. See comment in commit

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>