### PR TITLE
ospfd: fix routemap update

### DIFF
--- a/ospfd/ospf_routemap.c
+++ b/ospfd/ospf_routemap.c
@@ -71,19 +71,14 @@ static void ospf_route_map_update(const char *name)
 					/* Keep old route-map. */
 					struct route_map *old = ROUTEMAP(red);
 
-					if (!old) {
-						/* Route-map creation */
-						/* Update route-map. */
-						ROUTEMAP(red) =
-							route_map_lookup_by_name(
-								ROUTEMAP_NAME(red));
+					ROUTEMAP(red) =
+						route_map_lookup_by_name(
+							ROUTEMAP_NAME(red));
 
-							route_map_counter_increment(
-								ROUTEMAP(red));
-					} else {
-						/* Route-map deletion */
-						ROUTEMAP(red) = NULL;
-					}
+					if (!old)
+						route_map_counter_increment(
+							ROUTEMAP(red));
+
 					/* No update for this distribute type.
 					 */
 					if (old == NULL


### PR DESCRIPTION
Currently, if the routemap already exists, we delete the pointer to it
when it is updated. We should delete the pointer only if the route-map
is actually deleted.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>