### PR TITLE
lib: remove pure attribute from functions that modify memory

### DIFF
--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -123,15 +123,6 @@ extern "C" {
 #define assume(x)
 #endif
 
-/* pure = function does not modify memory & return value is the same if
- * memory hasn't changed (=> allows compiler to optimize)
- *
- * Mostly autodetected by the compiler if function body is available (i.e.
- * static inline functions in headers).  Since that implies it should only be
- * used in headers for non-inline functions, the "extern" is included here.
- */
-#define ext_pure	extern __attribute__((pure))
-
 /* for helper functions defined inside macros */
 #define macro_inline	static inline __attribute__((unused))
 #define macro_pure	static inline __attribute__((unused, pure))

--- a/lib/table.h
+++ b/lib/table.h
@@ -197,29 +197,25 @@ static inline void route_table_set_info(struct route_table *table, void *d)
 	table->info = d;
 }
 
-/* ext_pure => extern __attribute__((pure))
- *   does not modify memory (but depends on mem), allows compiler to optimize
- */
-
 extern void route_table_finish(struct route_table *table);
-ext_pure struct route_node *route_top(struct route_table *table);
-ext_pure struct route_node *route_next(struct route_node *node);
-ext_pure struct route_node *route_next_until(struct route_node *node,
-					     const struct route_node *limit);
+extern struct route_node *route_top(struct route_table *table);
+extern struct route_node *route_next(struct route_node *node);
+extern struct route_node *route_next_until(struct route_node *node,
+					   const struct route_node *limit);
 extern struct route_node *route_node_get(struct route_table *table,
 					 union prefixconstptr pu);
-ext_pure struct route_node *route_node_lookup(struct route_table *table,
-					      union prefixconstptr pu);
-ext_pure struct route_node *route_node_lookup_maynull(struct route_table *table,
-						      union prefixconstptr pu);
-ext_pure struct route_node *route_node_match(struct route_table *table,
-					     union prefixconstptr pu);
-ext_pure struct route_node *route_node_match_ipv4(struct route_table *table,
-						  const struct in_addr *addr);
-ext_pure struct route_node *route_node_match_ipv6(struct route_table *table,
-						  const struct in6_addr *addr);
+extern struct route_node *route_node_lookup(struct route_table *table,
+					    union prefixconstptr pu);
+extern struct route_node *route_node_lookup_maynull(struct route_table *table,
+						    union prefixconstptr pu);
+extern struct route_node *route_node_match(struct route_table *table,
+					   union prefixconstptr pu);
+extern struct route_node *route_node_match_ipv4(struct route_table *table,
+						const struct in_addr *addr);
+extern struct route_node *route_node_match_ipv6(struct route_table *table,
+						const struct in6_addr *addr);
 
-ext_pure unsigned long route_table_count(struct route_table *table);
+extern unsigned long route_table_count(struct route_table *table);
 
 extern struct route_node *route_node_create(route_table_delegate_t *delegate,
 					    struct route_table *table);
@@ -228,10 +224,10 @@ extern void route_node_destroy(route_table_delegate_t *delegate,
 			       struct route_table *table,
 			       struct route_node *node);
 
-ext_pure struct route_node *route_table_get_next(struct route_table *table,
-						 union prefixconstptr pu);
-ext_pure int route_table_prefix_iter_cmp(const struct prefix *p1,
-					 const struct prefix *p2);
+extern struct route_node *route_table_get_next(struct route_table *table,
+					       union prefixconstptr pu);
+extern int route_table_prefix_iter_cmp(const struct prefix *p1,
+				       const struct prefix *p2);
 
 /*
  * Iterator functions.


### PR DESCRIPTION
All these functions acquire a route_node lock. Marking them as pure
means that the compiler can optimize the code to not call them multiple
times when it already knows the return value. This is insane.

Fixes #8866
Fixes #8809
Fixes #8595
Fixes #6992

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>