### PR TITLE
bgpd: add knob to config cond-adv scanner period

### DIFF
--- a/bgpd/bgp_conditional_adv.c
+++ b/bgpd/bgp_conditional_adv.c
@@ -184,7 +184,7 @@ static int bgp_conditional_adv_timer(struct thread *t)
 	assert(bgp);
 
 	thread_add_timer(bm->master, bgp_conditional_adv_timer, bgp,
-			 CONDITIONAL_ROUTES_POLL_TIME, &bgp->t_condition_check);
+			 bgp->condition_check_period, &bgp->t_condition_check);
 
 	/* loop through each peer and advertise or withdraw routes if
 	 * advertise-map is configured and prefix(es) in condition-map
@@ -315,7 +315,7 @@ void bgp_conditional_adv_enable(struct peer *peer, afi_t afi, safi_t safi)
 
 	/* Register for conditional routes polling timer */
 	thread_add_timer(bm->master, bgp_conditional_adv_timer, bgp,
-			 CONDITIONAL_ROUTES_POLL_TIME, &bgp->t_condition_check);
+			 bgp->condition_check_period, &bgp->t_condition_check);
 }
 
 void bgp_conditional_adv_disable(struct peer *peer, afi_t afi, safi_t safi)

--- a/bgpd/bgp_conditional_adv.h
+++ b/bgpd/bgp_conditional_adv.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 /* Polling time for monitoring condition-map routes in route table */
-#define CONDITIONAL_ROUTES_POLL_TIME 60
+#define DEFAULT_CONDITIONAL_ROUTES_POLL_TIME 60
 
 extern void bgp_conditional_adv_enable(struct peer *peer, afi_t afi,
 				       safi_t safi);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3180,6 +3180,7 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	bgp->lb_ref_bw = BGP_LINK_BW_REF_BW;
 	bgp->lb_handling = BGP_LINK_BW_ECMP;
 	bgp->reject_as_sets = false;
+	bgp->condition_check_period = DEFAULT_CONDITIONAL_ROUTES_POLL_TIME;
 	bgp_addpath_init_bgp_data(&bgp->tx_addpath);
 
 	bgp->as = *as;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -748,6 +748,7 @@ struct bgp {
 	struct work_queue *process_queue;
 
 	/* BGP Conditional advertisement */
+	uint32_t condition_check_period;
 	uint32_t condition_filter_count;
 	struct thread *t_condition_check;
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3016,16 +3016,24 @@ The conditional BGP announcements are sent in addition to the normal
 announcements that a BGP router sends to its peer.
 
 The conditional advertisement process is triggered by the BGP scanner process,
-which runs every 60 seconds. This means that the maximum time for the conditional
-advertisement to take effect is 60 seconds. The conditional advertisement can take
-effect depending on when the tracked route is removed from the BGP table and
-when the next instance of the BGP scanner occurs.
+which runs every 60 by default. This means that the maximum time for the
+conditional advertisement to take effect is the value of the process timer.
+
+As an optimization, while the process always runs on each timer expiry, it
+determines whether or not the conditional advertisement policy or the routing
+table has changed; if neither have changed, no processing is necessary and the
+scanner exits early.
 
 .. clicmd:: neighbor A.B.C.D advertise-map NAME [exist-map|non-exist-map] NAME
 
    This command enables BGP scanner process to monitor routes specified by
    exist-map or non-exist-map command in BGP table and conditionally advertises
    the routes specified by advertise-map command.
+
+.. clicmd:: bgp conditional-advertisement timer (5-240)
+
+   Set the period to rerun the conditional advertisement scanner process. The
+   default is 60 seconds.
 
 Sample Configuration
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Adds a knob that sets the time between loc-rib scans for conditional
advertisement.

I chose the range (5-240) because 1 second seems dumb and too easy to
hurt yourself at even moderate scale, 5 seconds you can still hurt
yourself but I could see a use case for it, and 4 minutes should be
enough for anyone (tm)

Supersedes #8825 

Signed-off-by: Quentin Young <qlyoung@nvidia.com>