### PR TITLE
zebra: Get link from the correct netns for vxlan

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2572,7 +2572,6 @@ static int zebra_vxlan_handle_vni_transition(struct zebra_vrf *zvrf, vni_t vni,
 		struct zebra_l2info_vxlan *vxl;
 		struct interface *vlan_if;
 		struct zebra_if *zif;
-		struct zebra_ns *zns;
 		struct vni_trans_ctx ctx = {};
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
@@ -2581,12 +2580,10 @@ static int zebra_vxlan_handle_vni_transition(struct zebra_vrf *zvrf, vni_t vni,
 
 		frrtrace(2, frr_zebra, zebra_vxlan_handle_vni_transition, vni, 2);
 
-		zns = zebra_ns_lookup(NS_DEFAULT);
-
 		ctx.vni = vni;
 
 		/* Find VxLAN interface for this VNI. */
-		zebra_ns_ifp_walk(zns, vni_trans_cb, &ctx);
+		zebra_ns_ifp_walk(zvrf->zns, vni_trans_cb, &ctx);
 
 		if (ctx.ret_ifp == NULL) {
 			if (IS_ZEBRA_DEBUG_VXLAN)
@@ -5142,8 +5139,7 @@ int zebra_vxlan_add_del_gw_macip(struct interface *ifp, const struct prefix *p,
 		/*
 		 * for a MACVLAN interface the link represents the svi_if
 		 */
-		svi_if = if_lookup_by_index_per_ns(zebra_ns_lookup(NS_DEFAULT),
-						   ifp_zif->link_ifindex);
+		svi_if = ifp_zif->link;
 		if (!svi_if) {
 			if (IS_ZEBRA_DEBUG_VXLAN)
 				zlog_debug("MACVLAN %s(%u) without link information", ifp->name,
@@ -5160,9 +5156,7 @@ int zebra_vxlan_add_del_gw_macip(struct interface *ifp, const struct prefix *p,
 
 			svi_if_zif = svi_if->info;
 			if (svi_if_zif) {
-				svi_if_link = if_lookup_by_index_per_ns(
-					zebra_ns_lookup(NS_DEFAULT),
-					svi_if_zif->link_ifindex);
+				svi_if_link = svi_if_zif->link;
 				zevpn = zebra_evpn_from_svi(svi_if,
 							    svi_if_link);
 			}
@@ -5181,9 +5175,7 @@ int zebra_vxlan_add_del_gw_macip(struct interface *ifp, const struct prefix *p,
 
 		svi_if_zif = ifp->info;
 		if (svi_if_zif) {
-			svi_if_link = if_lookup_by_index_per_ns(
-				zebra_ns_lookup(NS_DEFAULT),
-				svi_if_zif->link_ifindex);
+			svi_if_link = svi_if_zif->link;
 			if (svi_if_link)
 				zevpn = zebra_evpn_from_svi(ifp, svi_if_link);
 		}
@@ -5383,8 +5375,7 @@ void zebra_vxlan_macvlan_down(struct interface *ifp)
 	link_zif = link_ifp->info;
 	assert(link_zif);
 
-	link_if = if_lookup_by_index_per_ns(zebra_ns_lookup(NS_DEFAULT),
-					    link_zif->link_ifindex);
+	link_if = link_zif->link;
 
 	zl3vni = zl3vni_from_svi(link_ifp, link_if);
 	if (zl3vni) {
@@ -5427,8 +5418,7 @@ void zebra_vxlan_macvlan_up(struct interface *ifp)
 	link_zif = link_ifp->info;
 	assert(link_zif);
 
-	link_if = if_lookup_by_index_per_ns(zebra_ns_lookup(NS_DEFAULT),
-					    link_zif->link_ifindex);
+	link_if = link_zif->link;
 	zl3vni = zl3vni_from_svi(link_ifp, link_if);
 	if (zl3vni) {
 		/* associate with macvlan (VRR) interface */


### PR DESCRIPTION
If VRF backend is netns, bridges and SVIs are in the VRF's netns.
Get link information from there, rather than NS_DEFAULT.