### PR TITLE
ospf6d: Show neighbor displays twice for every neighbor.

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1632,6 +1632,9 @@ void ospf6_interface_start(struct ospf6_interface *oi)
 	if (oi->area_id_format == OSPF6_AREA_FMT_UNSET)
 		return;
 
+	if (oi->area)
+		return;
+
 	ospf6 = ospf6_lookup_by_vrf_id(oi->interface->vrf_id);
 	if (!ospf6)
 		return;


### PR DESCRIPTION
Problem Statement:
=================
When show ipv6 ospf6 neighbor is executed each neighbor gets
displayed twice.

frr# show ipv6 ospf6 neighbor
Neighbor ID     Pri    DeadTime    State/IfState         Duration I/F[State]
1.1.1.1           1    00:00:39     Full/DR              00:00:10 ens192[BDR]
1.1.1.1           1    00:00:39     Full/DR              00:00:10 ens192[BDR]

RCA:
====
Since ospf6_interface gets added twice to if_list we see multiple
display output.

Fix:
====
add ospf6_interface to if_list only when newly area gets attached
to the interface. If its already added no need to add it again.

Risk:
=====
Low

Tests Executed:
===============
Have tested the defect scenario.

frr# show ipv6 ospf6 neighbor
Neighbor ID     Pri    DeadTime    State/IfState         Duration I/F[State]
1.1.1.1           1    00:00:35     Full/DR              00:36:04 ens192[BDR]
frr#

Signed-off-by: Abhinay Ramesh <rabhinay@vmware.com>