### PR TITLE
bgpd: [7.3] withdraw default route when route-map has no match

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -760,6 +760,9 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 		 */
 		for (rn = bgp_table_top(bgp->rib[afi][safi]); rn;
 		     rn = bgp_route_next(rn)) {
+			if (!bgp_node_has_bgp_path_info_data(rn))
+				continue;
+
 			ret = route_map_apply(peer->default_rmap[afi][safi].map,
 					      &rn->p, RMAP_BGP, &bpi_rmap);
 


### PR DESCRIPTION
If you advertise a default route (via default-originate) only if some
prefix is present in the BGP RIB (route-map specified) and this prefix
becomes unavailable, the default route keeps being advertised.

With this change, when we iterate over the BGP RIB to check if we can
advertise the default route, skip unavailable prefixes.

Signed-off-by: Alexander Chernavin <achernavin@netgate.com>
Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

Closes https://github.com/FRRouting/frr/issues/8877