### PR TITLE
Fix ISIS config batching

### DIFF
--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2383,14 +2383,14 @@ int isis_instance_segment_routing_prefix_sid_map_prefix_sid_n_flag_clear_modify(
 int isis_instance_mpls_ldp_sync_create(struct nb_cb_create_args *args)
 {
 	struct isis_area *area;
+	const char *vrfname;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		area = nb_running_get_entry(args->dnode, NULL, false);
-		if (area == NULL || area->isis == NULL)
-			return NB_ERR_VALIDATION;
+		vrfname = yang_dnode_get_string(
+			lyd_parent(lyd_parent(args->dnode)), "./vrf");
 
-		if (area->isis->vrf_id != VRF_DEFAULT) {
+		if (strcmp(vrfname, VRF_DEFAULT_NAME)) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "LDP-Sync only runs on Default VRF");
 			return NB_ERR_VALIDATION;
@@ -2427,14 +2427,15 @@ int isis_instance_mpls_ldp_sync_holddown_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
 	uint16_t holddown;
+	const char *vrfname;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		area = nb_running_get_entry(args->dnode, NULL, false);
-		if (area == NULL || area->isis == NULL)
-			return NB_ERR_VALIDATION;
+		vrfname = yang_dnode_get_string(
+			lyd_parent(lyd_parent(lyd_parent(args->dnode))),
+			"./vrf");
 
-		if (area->isis->vrf_id != VRF_DEFAULT) {
+		if (strcmp(vrfname, VRF_DEFAULT_NAME)) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "LDP-Sync only runs on Default VRF");
 			return NB_ERR_VALIDATION;

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -3204,26 +3204,14 @@ int lib_interface_isis_mpls_ldp_sync_modify(struct nb_cb_modify_args *args)
 	struct isis_circuit *circuit;
 	struct ldp_sync_info *ldp_sync_info;
 	bool ldp_sync_enable;
-	struct interface *ifp;
+	const char *vrfname;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		ifp = nb_running_get_entry(
-			lyd_parent(lyd_parent(lyd_parent(args->dnode))), NULL,
-			false);
-		if (ifp == NULL)
-			return NB_ERR_VALIDATION;
-		if (if_is_loopback(ifp)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "LDP-Sync does not run on loopback interface");
-			return NB_ERR_VALIDATION;
-		}
-
-		circuit = nb_running_get_entry(args->dnode, NULL, false);
-		if (circuit == NULL || circuit->area == NULL)
-			break;
-
-		if (circuit->isis->vrf_id != VRF_DEFAULT) {
+		vrfname = yang_dnode_get_string(
+			lyd_parent(lyd_parent(lyd_parent(args->dnode))),
+			"./vrf");
+		if (strcmp(vrfname, VRF_DEFAULT_NAME)) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "LDP-Sync only runs on Default VRF");
 			return NB_ERR_VALIDATION;
@@ -3260,27 +3248,14 @@ int lib_interface_isis_mpls_holddown_modify(struct nb_cb_modify_args *args)
 	struct isis_circuit *circuit;
 	struct ldp_sync_info *ldp_sync_info;
 	uint16_t holddown;
-	struct interface *ifp;
+	const char *vrfname;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-
-		ifp = nb_running_get_entry(
-			lyd_parent(lyd_parent(lyd_parent(args->dnode))), NULL,
-			false);
-		if (ifp == NULL)
-			return NB_ERR_VALIDATION;
-		if (if_is_loopback(ifp)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "LDP-Sync does not run on loopback interface");
-			return NB_ERR_VALIDATION;
-		}
-
-		circuit = nb_running_get_entry(args->dnode, NULL, false);
-		if (circuit == NULL || circuit->area == NULL)
-			break;
-
-		if (circuit->isis->vrf_id != VRF_DEFAULT) {
+		vrfname = yang_dnode_get_string(
+			lyd_parent(lyd_parent(lyd_parent(args->dnode))),
+			"./vrf");
+		if (strcmp(vrfname, VRF_DEFAULT_NAME)) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "LDP-Sync only runs on Default VRF");
 			return NB_ERR_VALIDATION;
@@ -3306,26 +3281,14 @@ int lib_interface_isis_mpls_holddown_destroy(struct nb_cb_destroy_args *args)
 {
 	struct isis_circuit *circuit;
 	struct ldp_sync_info *ldp_sync_info;
-	struct interface *ifp;
+	const char *vrfname;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		ifp = nb_running_get_entry(
-			lyd_parent(lyd_parent(lyd_parent(args->dnode))), NULL,
-			false);
-		if (ifp == NULL)
-			return NB_ERR_VALIDATION;
-		if (if_is_loopback(ifp)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "LDP-Sync does not run on loopback interface");
-			return NB_ERR_VALIDATION;
-		}
-
-		circuit = nb_running_get_entry(args->dnode, NULL, false);
-		if (circuit == NULL || circuit->area == NULL)
-			break;
-
-		if (circuit->isis->vrf_id != VRF_DEFAULT) {
+		vrfname = yang_dnode_get_string(
+			lyd_parent(lyd_parent(lyd_parent(args->dnode))),
+			"./vrf");
+		if (strcmp(vrfname, VRF_DEFAULT_NAME)) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "LDP-Sync only runs on Default VRF");
 			return NB_ERR_VALIDATION;


### PR DESCRIPTION
There are some places in the ISIS NB code that require operational data to be available on the validation stage.
This requirement can not be fulfilled when using config batching, which is the default mode for reading configuration.
Change these validations to use configurational data instead.

Fixes #8852.

P.S.
There are actually a lot of other usages of operational data in the ISIS NB code.
This is a fundamental issue but all these validations just silently pass when the operational data is not yet available, so they don't block reading the config and I am not fixing them in this PR.

Some examples:
1. When setting LSP MTU for an instance (`isis_instance_lsp_mtu_modify`) or adding an interface to an area (`lib_interface_isis_create`), we validate that the interface MTU is larger than the LSP MTU of an area. Okay, we checked that, but what happens if the MTU of the interface is changed later? We shouldn't do this check at all. The LSP processing code should just correctly process this case and not send an LSP when the interface MTU is lower than needed.
2. When setting a network type for an interface (`lib_interface_isis_network_type_modify`), we check that the network type is compatible with the interface type. This is not correct to do this check because the interface type may not be available yet when reading the config. The code should just ignore the config if the types are incompatible.
3. When configuring LDP sync on an interface (`lib_interface_isis_mpls_ldp_sync_modify`), we check that the interface is in the default VRF. The check was previously done using operational data and I fixed it to use configurational data in this PR. But there is still a question – what happens if the interface is moved to another VRF later? The config becomes invalid.

There are more issues in the NB code, these are just 3 examples. The examples show once again that validating the config against the operational data is completely pointless. The operational data can change any second and all the checks become invalid, but the config still stays. Why do all these checks in the first place then?