### PR TITLE
[WIP] tools: fix frr-reload removing isis iface config

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1438,6 +1438,11 @@ def compare_context_objects(newconf, running):
                 0
             ].startswith("vrf"):
                 for line in running_ctx.lines:
+                    # we are removing the entire interface block. ISIS config is removed
+                    # when we disable both ipv4 and ipv6 on it, so the other commands
+                    # should not be sent (else they will fail)
+                    if line.startswith("isis") or line.startswith("no isis"):
+                        continue
                     lines_to_del.append((running_ctx_keys, line))
 
             # If this is an address-family under 'router bgp' and we are already deleting the


### PR DESCRIPTION
When we remove isis config from an interface we disable it for ipv4 and/or ipv6, which will destroy the entire yang config
for that interface in isisd. However frr-reload will also send negative commands for any other isisd option on that interface;
these commands will fail as there is no config anymore. Avoid sending those.

Note that this fix is insufficient for the non-integrated config flavor: if the interface still exists in the new config but we remove
all of the isis configuration, the issue persists. For other daemons we would check if we are already sending the negative
command that disables the entire "context" and suppress the superfluous commands, but here this is tricky, as we do not know if only ipv4 or ipv6 (or both) were originally enabled for that interface.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>