### PR TITLE
bgpd,lib,zebra: Encap remote l3vni for EVPN/VxLAN

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -962,6 +962,7 @@ char *ecommunity_ecom2str(struct ecommunity *ecom, int format, int filter)
 				uint16_t tunneltype;
 				memcpy(&tunneltype, pnt + 5, 2);
 				tunneltype = ntohs(tunneltype);
+				ecom->tunneltype = tunneltype;
 
 				snprintf(encbuf, sizeof(encbuf), "ET:%d",
 					 tunneltype);

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -124,6 +124,7 @@ struct ecommunity {
 
 	/* Human readable format string.  */
 	char *str;
+	uint16_t tunneltype;
 };
 
 struct ecommunity_as {

--- a/bgpd/bgp_label.h
+++ b/bgpd/bgp_label.h
@@ -106,6 +106,18 @@ static inline uint32_t label_pton(mpls_label_t *label)
 		| ((unsigned int)((t[2] & 0xF0) >> 4)));
 }
 
+/* vxlan vni Label stream to value */
+static inline uint32_t vxlan_label_pton(mpls_label_t *label)
+{
+	uint8_t *t = (uint8_t *)label;
+	unsigned int vni = 0;
+
+	vni = ((((unsigned int)t[0]) << 16) | (((unsigned int)t[1]) << 8)
+	       | ((unsigned int)(t[2])));
+
+	return vni;
+}
+
 /* Encode label values */
 static inline void label_ntop(uint32_t l, int bos, mpls_label_t *label)
 {

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1047,7 +1047,9 @@ int bgp_zebra_get_table_range(uint32_t chunk_size,
 
 static bool update_ipv4nh_for_route_install(int nh_othervrf, struct bgp *nh_bgp,
 					    struct in_addr *nexthop,
-					    struct attr *attr, bool is_evpn,
+					    struct attr *attr,
+					    struct bgp_path_info_extra *extra,
+					    bool is_evpn,
 					    struct zapi_nexthop *api_nh)
 {
 	api_nh->gate.ipv4 = *nexthop;
@@ -1070,6 +1072,13 @@ static bool update_ipv4nh_for_route_install(int nh_othervrf, struct bgp *nh_bgp,
 			api_nh->type = NEXTHOP_TYPE_IPV4_IFINDEX;
 			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
 			api_nh->ifindex = nh_bgp->l3vni_svi_ifindex;
+		}
+		if (attr->ecommunity->tunneltype == BGP_ENCAP_TYPE_VXLAN) {
+			if (extra) {
+				api_nh->tunneltype = BGP_ENCAP_TYPE_VXLAN;
+				api_nh->r_vni =
+					vxlan_label_pton(&extra->label[1]);
+			}
 		}
 	} else if (nh_othervrf &&
 		 api_nh->gate.ipv4.s_addr == INADDR_ANY) {
@@ -1360,11 +1369,10 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 
 		if (nh_family == AF_INET) {
 			nh_updated = update_ipv4nh_for_route_install(
-					nh_othervrf,
-					nh_othervrf ?
-					info->extra->bgp_orig : bgp,
-					&mpinfo_cp->attr->nexthop,
-					mpinfo_cp->attr, is_evpn, api_nh);
+				nh_othervrf,
+				nh_othervrf ? info->extra->bgp_orig : bgp,
+				&mpinfo_cp->attr->nexthop, mpinfo_cp->attr,
+				mpinfo_cp->extra, is_evpn, api_nh);
 		} else {
 			ifindex_t ifindex = IFINDEX_INTERNAL;
 			struct in6_addr *nexthop;
@@ -1378,7 +1386,8 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 					nh_othervrf ? info->extra->bgp_orig
 						    : bgp,
 					&mpinfo_cp->attr->nexthop,
-					mpinfo_cp->attr, is_evpn, api_nh);
+					mpinfo_cp->attr, mpinfo_cp->extra,
+					is_evpn, api_nh);
 			else
 				nh_updated = update_ipv6nh_for_route_install(
 					nh_othervrf,

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1031,10 +1031,12 @@ int zapi_nexthop_encode(struct stream *s, const struct zapi_nexthop *api_nh,
 	if (api_nh->weight)
 		stream_putl(s, api_nh->weight);
 
-	/* Router MAC for EVPN routes. */
-	if (CHECK_FLAG(api_flags, ZEBRA_FLAG_EVPN_ROUTE))
-		stream_put(s, &(api_nh->rmac),
-			   sizeof(struct ethaddr));
+	/* Router MAC and Remote-l3vni for EVPN routes. */
+	if (CHECK_FLAG(api_flags, ZEBRA_FLAG_EVPN_ROUTE)) {
+		stream_put(s, &(api_nh->rmac), sizeof(struct ethaddr));
+		stream_putw(s, api_nh->tunneltype);
+		stream_putl(s, api_nh->r_vni);
+	}
 
 	/* Color for Segment Routing TE. */
 	if (CHECK_FLAG(api_message, ZAPI_MESSAGE_SRTE))
@@ -1362,10 +1364,12 @@ int zapi_nexthop_decode(struct stream *s, struct zapi_nexthop *api_nh,
 	if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_WEIGHT))
 		STREAM_GETL(s, api_nh->weight);
 
-	/* Router MAC for EVPN routes. */
-	if (CHECK_FLAG(api_flags, ZEBRA_FLAG_EVPN_ROUTE))
-		STREAM_GET(&(api_nh->rmac), s,
-			   sizeof(struct ethaddr));
+	/* Router MAC and Remote-l3vni for EVPN routes. */
+	if (CHECK_FLAG(api_flags, ZEBRA_FLAG_EVPN_ROUTE)) {
+		STREAM_GET(&(api_nh->rmac), s, sizeof(struct ethaddr));
+		STREAM_GETW(s, api_nh->tunneltype);
+		STREAM_GETL(s, api_nh->r_vni);
+	}
 
 	/* Color for Segment Routing TE. */
 	if (CHECK_FLAG(api_message, ZAPI_MESSAGE_SRTE))

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -459,6 +459,9 @@ struct zapi_nexthop {
 	uint8_t label_num;
 	mpls_label_t labels[MPLS_MAX_LABELS];
 
+	uint16_t tunneltype;
+	vni_t r_vni;
+
 	struct ethaddr rmac;
 
 	uint32_t weight;

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1074,9 +1074,9 @@ static void fpm_enqueue_rmac_table(struct hash_bucket *bucket, void *arg)
 	dplane_ctx_reset(fra->ctx);
 	dplane_ctx_set_op(fra->ctx, DPLANE_OP_MAC_INSTALL);
 	dplane_mac_init(fra->ctx, fra->zl3vni->vxlan_if,
-			zif->brslave_info.br_if, vid,
-			&zrmac->macaddr, zrmac->fwd_info.r_vtep_ip, sticky,
-			0 /*nhg*/, 0 /*update_flags*/);
+			zif->brslave_info.br_if, vid, &zrmac->macaddr,
+			zrmac->fwd_info.remote.r_vtep_ip, sticky, 0 /*nhg*/,
+			0 /*update_flags*/, 0 /*r_vni*/);
 	if (fpm_nl_enqueue(fra->fnc, fra->ctx) == -1) {
 		thread_add_timer(zrouter.master, fpm_rmac_send,
 				 fra->fnc, 1, &fra->fnc->t_rmacwalk);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1569,8 +1569,9 @@ static struct nexthop *nexthop_from_zapi(const struct zapi_nexthop *api_nh,
 			vtep_ip.ipa_type = IPADDR_V4;
 			memcpy(&(vtep_ip.ipaddr_v4), &(api_nh->gate.ipv4),
 			       sizeof(struct in_addr));
-			zebra_vxlan_evpn_vrf_route_add(
-				api_nh->vrf_id, &api_nh->rmac, &vtep_ip, p);
+			zebra_vxlan_evpn_vrf_route_add(api_nh->vrf_id,
+						       &api_nh->rmac, &vtep_ip,
+						       p, api_nh->r_vni);
 		}
 		break;
 	case NEXTHOP_TYPE_IPV6:
@@ -1602,8 +1603,9 @@ static struct nexthop *nexthop_from_zapi(const struct zapi_nexthop *api_nh,
 			vtep_ip.ipa_type = IPADDR_V6;
 			memcpy(&vtep_ip.ipaddr_v6, &(api_nh->gate.ipv6),
 			       sizeof(struct in6_addr));
-			zebra_vxlan_evpn_vrf_route_add(
-				api_nh->vrf_id, &api_nh->rmac, &vtep_ip, p);
+			zebra_vxlan_evpn_vrf_route_add(api_nh->vrf_id,
+						       &api_nh->rmac, &vtep_ip,
+						       p, api_nh->r_vni);
 		}
 		break;
 	case NEXTHOP_TYPE_BLACKHOLE:

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -213,6 +213,7 @@ struct dplane_mac_info {
 	bool is_sticky;
 	uint32_t nhg_id;
 	uint32_t update_flags;
+	vni_t r_vni;
 };
 
 /*
@@ -227,6 +228,7 @@ struct dplane_neigh_info {
 	uint32_t flags;
 	uint16_t state;
 	uint32_t update_flags;
+	vni_t r_vni;
 };
 
 /*
@@ -521,12 +523,13 @@ static enum zebra_dplane_result mac_update_common(
 	const struct interface *br_ifp,
 	vlanid_t vid, const struct ethaddr *mac,
 	struct in_addr vtep_ip,	bool sticky, uint32_t nhg_id,
-	uint32_t update_flags);
+	uint32_t update_flags,
+	vni_t r_vni);
 static enum zebra_dplane_result
 neigh_update_internal(enum dplane_op_e op, const struct interface *ifp,
 		      const void *link, int link_family,
 		      const struct ipaddr *ip, uint32_t flags, uint16_t state,
-		      uint32_t update_flags, int protocol);
+		      uint32_t update_flags, int protocol, vni_t r_vni);
 
 /*
  * Public APIs
@@ -1728,6 +1731,12 @@ uint32_t dplane_ctx_mac_get_update_flags(const struct zebra_dplane_ctx *ctx)
 	return ctx->u.macinfo.update_flags;
 }
 
+uint32_t dplane_ctx_mac_get_rvni(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.macinfo.r_vni;
+}
+
 const struct ethaddr *dplane_ctx_mac_get_addr(
 	const struct zebra_dplane_ctx *ctx)
 {
@@ -1768,6 +1777,12 @@ const struct ethaddr *dplane_ctx_neigh_get_mac(
 {
 	DPLANE_CTX_VALID(ctx);
 	return &(ctx->u.neigh.link.mac);
+}
+
+vni_t dplane_ctx_neigh_get_r_vni(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.neigh.r_vni;
 }
 
 uint32_t dplane_ctx_neigh_get_flags(const struct zebra_dplane_ctx *ctx)
@@ -3508,7 +3523,8 @@ enum zebra_dplane_result dplane_rem_mac_add(const struct interface *ifp,
 					struct in_addr vtep_ip,
 					bool sticky,
 					uint32_t nhg_id,
-					bool was_static)
+					bool was_static,
+					vni_t r_vni)
 {
 	enum zebra_dplane_result result;
 	uint32_t update_flags = 0;
@@ -3519,7 +3535,7 @@ enum zebra_dplane_result dplane_rem_mac_add(const struct interface *ifp,
 
 	/* Use common helper api */
 	result = mac_update_common(DPLANE_OP_MAC_INSTALL, ifp, bridge_ifp,
-				   vid, mac, vtep_ip, sticky, nhg_id, update_flags);
+				   vid, mac, vtep_ip, sticky, nhg_id, update_flags, r_vni);
 	return result;
 }
 
@@ -3539,7 +3555,7 @@ enum zebra_dplane_result dplane_rem_mac_del(const struct interface *ifp,
 
 	/* Use common helper api */
 	result = mac_update_common(DPLANE_OP_MAC_DELETE, ifp, bridge_ifp,
-				   vid, mac, vtep_ip, false, 0, update_flags);
+				   vid, mac, vtep_ip, false, 0, update_flags, 0);
 	return result;
 }
 
@@ -3573,7 +3589,7 @@ enum zebra_dplane_result dplane_neigh_ip_update(enum dplane_op_e op,
 
 	result = neigh_update_internal(op, ifp, (const void *)link_ip,
 				       ipaddr_family(link_ip), ip, 0, state,
-				       update_flags, protocol);
+				       update_flags, protocol, 0);
 
 	return result;
 }
@@ -3604,7 +3620,7 @@ enum zebra_dplane_result dplane_local_mac_add(const struct interface *ifp,
 	/* Use common helper api */
 	result = mac_update_common(DPLANE_OP_MAC_INSTALL, ifp, bridge_ifp,
 				     vid, mac, vtep_ip, sticky, 0,
-				     update_flags);
+				     update_flags, 0);
 	return result;
 }
 
@@ -3623,7 +3639,7 @@ dplane_local_mac_del(const struct interface *ifp,
 
 	/* Use common helper api */
 	result = mac_update_common(DPLANE_OP_MAC_DELETE, ifp, bridge_ifp, vid,
-				   mac, vtep_ip, false, 0, 0);
+				   mac, vtep_ip, false, 0, 0, 0);
 	return result;
 }
 /*
@@ -3638,7 +3654,8 @@ void dplane_mac_init(struct zebra_dplane_ctx *ctx,
 		     struct in_addr vtep_ip,
 		     bool sticky,
 		     uint32_t nhg_id,
-		     uint32_t update_flags)
+		     uint32_t update_flags,
+		     vni_t r_vni)
 {
 	struct zebra_ns *zns;
 
@@ -3661,6 +3678,9 @@ void dplane_mac_init(struct zebra_dplane_ctx *ctx,
 	ctx->u.macinfo.is_sticky = sticky;
 	ctx->u.macinfo.nhg_id = nhg_id;
 	ctx->u.macinfo.update_flags = update_flags;
+	if (r_vni > 0) {
+		ctx->u.macinfo.r_vni = r_vni;
+	}
 }
 
 /*
@@ -3675,22 +3695,23 @@ mac_update_common(enum dplane_op_e op,
 		  struct in_addr vtep_ip,
 		  bool sticky,
 		  uint32_t nhg_id,
-		  uint32_t update_flags)
+		  uint32_t update_flags,
+		  vni_t r_vni)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
 	int ret;
 	struct zebra_dplane_ctx *ctx = NULL;
 
 	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
-		zlog_debug("init mac ctx %s: mac %pEA, ifp %s, vtep %pI4",
-			   dplane_op2str(op), mac, ifp->name, &vtep_ip);
+		zlog_debug("init mac ctx %s: mac %pEA, ifp %s, vtep %pI4, r_vni 0x%x",
+			   dplane_op2str(op), mac, ifp->name, &vtep_ip, r_vni);
 
 	ctx = dplane_ctx_alloc();
 	ctx->zd_op = op;
 
 	/* Common init for the ctx */
 	dplane_mac_init(ctx, ifp, br_ifp, vid, mac, vtep_ip, sticky,
-			nhg_id, update_flags);
+			nhg_id, update_flags, r_vni);
 
 	/* Enqueue for processing on the dplane pthread */
 	ret = dplane_update_enqueue(ctx);
@@ -3717,7 +3738,8 @@ mac_update_common(enum dplane_op_e op,
 enum zebra_dplane_result dplane_rem_neigh_add(const struct interface *ifp,
 					  const struct ipaddr *ip,
 					  const struct ethaddr *mac,
-					  uint32_t flags, bool was_static)
+					  uint32_t flags, bool was_static,
+					  vni_t r_vni)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
 	uint32_t update_flags = 0;
@@ -3729,7 +3751,7 @@ enum zebra_dplane_result dplane_rem_neigh_add(const struct interface *ifp,
 
 	result = neigh_update_internal(
 		DPLANE_OP_NEIGH_INSTALL, ifp, (const void *)mac, AF_ETHERNET,
-		ip, flags, DPLANE_NUD_NOARP, update_flags, 0);
+		ip, flags, DPLANE_NUD_NOARP, update_flags, 0, r_vni);
 
 	return result;
 }
@@ -3763,7 +3785,7 @@ enum zebra_dplane_result dplane_local_neigh_add(const struct interface *ifp,
 
 	result = neigh_update_internal(DPLANE_OP_NEIGH_INSTALL, ifp,
 				       (const void *)mac, AF_ETHERNET, ip, ntf,
-				       state, update_flags, 0);
+				       state, update_flags, 0, 0);
 
 	return result;
 }
@@ -3780,7 +3802,7 @@ enum zebra_dplane_result dplane_rem_neigh_delete(const struct interface *ifp,
 	update_flags |= DPLANE_NEIGH_REMOTE;
 
 	result = neigh_update_internal(DPLANE_OP_NEIGH_DELETE, ifp, NULL,
-				       AF_ETHERNET, ip, 0, 0, update_flags, 0);
+				       AF_ETHERNET, ip, 0, 0, update_flags, 0, 0);
 
 	return result;
 }
@@ -3804,7 +3826,7 @@ enum zebra_dplane_result dplane_vtep_add(const struct interface *ifp,
 	addr.ipaddr_v4 = *ip;
 
 	result = neigh_update_internal(DPLANE_OP_VTEP_ADD, ifp, &mac,
-				       AF_ETHERNET, &addr, 0, 0, 0, 0);
+				       AF_ETHERNET, &addr, 0, 0, 0, 0, 0);
 
 	return result;
 }
@@ -3830,7 +3852,7 @@ enum zebra_dplane_result dplane_vtep_delete(const struct interface *ifp,
 
 	result = neigh_update_internal(DPLANE_OP_VTEP_DELETE, ifp,
 				       (const void *)&mac, AF_ETHERNET, &addr,
-				       0, 0, 0, 0);
+				       0, 0, 0, 0, 0);
 
 	return result;
 }
@@ -3842,7 +3864,7 @@ enum zebra_dplane_result dplane_neigh_discover(const struct interface *ifp,
 
 	result = neigh_update_internal(DPLANE_OP_NEIGH_DISCOVER, ifp, NULL,
 				       AF_ETHERNET, ip, DPLANE_NTF_USE,
-				       DPLANE_NUD_INCOMPLETE, 0, 0);
+				       DPLANE_NUD_INCOMPLETE, 0, 0, 0);
 
 	return result;
 }
@@ -3910,7 +3932,7 @@ static enum zebra_dplane_result
 neigh_update_internal(enum dplane_op_e op, const struct interface *ifp,
 		      const void *link, const int link_family,
 		      const struct ipaddr *ip, uint32_t flags, uint16_t state,
-		      uint32_t update_flags, int protocol)
+		      uint32_t update_flags, int protocol, vni_t r_vni)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
 	int ret;
@@ -3932,10 +3954,10 @@ neigh_update_internal(enum dplane_op_e op, const struct interface *ifp,
 			prefix_mac2str(mac, buf1, sizeof(buf1));
 		else
 			ipaddr2str(link_ip, buf1, sizeof(buf1));
-		zlog_debug("init neigh ctx %s: ifp %s, %s %s, ip %pIA",
+		zlog_debug("init neigh ctx %s: ifp %s, %s %s, ip %pIA, r_vni 0x%x",
 			   dplane_op2str(op), ifp->name,
 			   link_family == AF_ETHERNET ? "mac " : "link ",
-			   buf1, ip);
+			   buf1, ip, r_vni);
 	}
 
 	ctx = dplane_ctx_alloc();
@@ -3960,6 +3982,7 @@ neigh_update_internal(enum dplane_op_e op, const struct interface *ifp,
 	else if (link_ip)
 		ctx->u.neigh.link.ip_addr = *link_ip;
 
+	ctx->u.neigh.r_vni = r_vni;
 	ctx->u.neigh.flags = flags;
 	ctx->u.neigh.state = state;
 	ctx->u.neigh.update_flags = update_flags;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -518,13 +518,12 @@ static enum zebra_dplane_result pw_update_internal(struct zebra_pw *pw,
 static enum zebra_dplane_result intf_addr_update_internal(
 	const struct interface *ifp, const struct connected *ifc,
 	enum dplane_op_e op);
-static enum zebra_dplane_result mac_update_common(
-	enum dplane_op_e op, const struct interface *ifp,
-	const struct interface *br_ifp,
-	vlanid_t vid, const struct ethaddr *mac,
-	struct in_addr vtep_ip,	bool sticky, uint32_t nhg_id,
-	uint32_t update_flags,
-	vni_t r_vni);
+static enum zebra_dplane_result
+mac_update_common(enum dplane_op_e op, const struct interface *ifp,
+		  const struct interface *br_ifp, vlanid_t vid,
+		  const struct ethaddr *mac, struct in_addr vtep_ip,
+		  bool sticky, uint32_t nhg_id, uint32_t update_flags,
+		  vni_t r_vni);
 static enum zebra_dplane_result
 neigh_update_internal(enum dplane_op_e op, const struct interface *ifp,
 		      const void *link, int link_family,
@@ -3516,15 +3515,11 @@ static enum zebra_dplane_result intf_addr_update_internal(
 /*
  * Enqueue vxlan/evpn mac add (or update).
  */
-enum zebra_dplane_result dplane_rem_mac_add(const struct interface *ifp,
-					const struct interface *bridge_ifp,
-					vlanid_t vid,
-					const struct ethaddr *mac,
-					struct in_addr vtep_ip,
-					bool sticky,
-					uint32_t nhg_id,
-					bool was_static,
-					vni_t r_vni)
+enum zebra_dplane_result
+dplane_rem_mac_add(const struct interface *ifp,
+		   const struct interface *bridge_ifp, vlanid_t vid,
+		   const struct ethaddr *mac, struct in_addr vtep_ip,
+		   bool sticky, uint32_t nhg_id, bool was_static, vni_t r_vni)
 {
 	enum zebra_dplane_result result;
 	uint32_t update_flags = 0;
@@ -3534,8 +3529,9 @@ enum zebra_dplane_result dplane_rem_mac_add(const struct interface *ifp,
 		update_flags |= DPLANE_MAC_WAS_STATIC;
 
 	/* Use common helper api */
-	result = mac_update_common(DPLANE_OP_MAC_INSTALL, ifp, bridge_ifp,
-				   vid, mac, vtep_ip, sticky, nhg_id, update_flags, r_vni);
+	result = mac_update_common(DPLANE_OP_MAC_INSTALL, ifp, bridge_ifp, vid,
+				   mac, vtep_ip, sticky, nhg_id, update_flags,
+				   r_vni);
 	return result;
 }
 
@@ -3554,8 +3550,8 @@ enum zebra_dplane_result dplane_rem_mac_del(const struct interface *ifp,
 	update_flags |= DPLANE_MAC_REMOTE;
 
 	/* Use common helper api */
-	result = mac_update_common(DPLANE_OP_MAC_DELETE, ifp, bridge_ifp,
-				   vid, mac, vtep_ip, false, 0, update_flags, 0);
+	result = mac_update_common(DPLANE_OP_MAC_DELETE, ifp, bridge_ifp, vid,
+				   mac, vtep_ip, false, 0, update_flags, 0);
 	return result;
 }
 
@@ -3618,9 +3614,8 @@ enum zebra_dplane_result dplane_local_mac_add(const struct interface *ifp,
 	vtep_ip.s_addr = 0;
 
 	/* Use common helper api */
-	result = mac_update_common(DPLANE_OP_MAC_INSTALL, ifp, bridge_ifp,
-				     vid, mac, vtep_ip, sticky, 0,
-				     update_flags, 0);
+	result = mac_update_common(DPLANE_OP_MAC_INSTALL, ifp, bridge_ifp, vid,
+				   mac, vtep_ip, sticky, 0, update_flags, 0);
 	return result;
 }
 
@@ -3646,15 +3641,10 @@ dplane_local_mac_del(const struct interface *ifp,
  * Public api to init an empty context - either newly-allocated or
  * reset/cleared - for a MAC update.
  */
-void dplane_mac_init(struct zebra_dplane_ctx *ctx,
-		     const struct interface *ifp,
-		     const struct interface *br_ifp,
-		     vlanid_t vid,
-		     const struct ethaddr *mac,
-		     struct in_addr vtep_ip,
-		     bool sticky,
-		     uint32_t nhg_id,
-		     uint32_t update_flags,
+void dplane_mac_init(struct zebra_dplane_ctx *ctx, const struct interface *ifp,
+		     const struct interface *br_ifp, vlanid_t vid,
+		     const struct ethaddr *mac, struct in_addr vtep_ip,
+		     bool sticky, uint32_t nhg_id, uint32_t update_flags,
 		     vni_t r_vni)
 {
 	struct zebra_ns *zns;
@@ -3687,15 +3677,10 @@ void dplane_mac_init(struct zebra_dplane_ctx *ctx,
  * Common helper api for MAC address/vxlan updates
  */
 static enum zebra_dplane_result
-mac_update_common(enum dplane_op_e op,
-		  const struct interface *ifp,
-		  const struct interface *br_ifp,
-		  vlanid_t vid,
-		  const struct ethaddr *mac,
-		  struct in_addr vtep_ip,
-		  bool sticky,
-		  uint32_t nhg_id,
-		  uint32_t update_flags,
+mac_update_common(enum dplane_op_e op, const struct interface *ifp,
+		  const struct interface *br_ifp, vlanid_t vid,
+		  const struct ethaddr *mac, struct in_addr vtep_ip,
+		  bool sticky, uint32_t nhg_id, uint32_t update_flags,
 		  vni_t r_vni)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
@@ -3703,15 +3688,16 @@ mac_update_common(enum dplane_op_e op,
 	struct zebra_dplane_ctx *ctx = NULL;
 
 	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
-		zlog_debug("init mac ctx %s: mac %pEA, ifp %s, vtep %pI4, r_vni 0x%x",
-			   dplane_op2str(op), mac, ifp->name, &vtep_ip, r_vni);
+		zlog_debug(
+			"init mac ctx %s: mac %pEA, ifp %s, vtep %pI4, r_vni 0x%x",
+			dplane_op2str(op), mac, ifp->name, &vtep_ip, r_vni);
 
 	ctx = dplane_ctx_alloc();
 	ctx->zd_op = op;
 
 	/* Common init for the ctx */
-	dplane_mac_init(ctx, ifp, br_ifp, vid, mac, vtep_ip, sticky,
-			nhg_id, update_flags, r_vni);
+	dplane_mac_init(ctx, ifp, br_ifp, vid, mac, vtep_ip, sticky, nhg_id,
+			update_flags, r_vni);
 
 	/* Enqueue for processing on the dplane pthread */
 	ret = dplane_update_enqueue(ctx);
@@ -3736,10 +3722,10 @@ mac_update_common(enum dplane_op_e op,
  * Enqueue evpn neighbor add for the dataplane.
  */
 enum zebra_dplane_result dplane_rem_neigh_add(const struct interface *ifp,
-					  const struct ipaddr *ip,
-					  const struct ethaddr *mac,
-					  uint32_t flags, bool was_static,
-					  vni_t r_vni)
+					      const struct ipaddr *ip,
+					      const struct ethaddr *mac,
+					      uint32_t flags, bool was_static,
+					      vni_t r_vni)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
 	uint32_t update_flags = 0;
@@ -3802,7 +3788,8 @@ enum zebra_dplane_result dplane_rem_neigh_delete(const struct interface *ifp,
 	update_flags |= DPLANE_NEIGH_REMOTE;
 
 	result = neigh_update_internal(DPLANE_OP_NEIGH_DELETE, ifp, NULL,
-				       AF_ETHERNET, ip, 0, 0, update_flags, 0, 0);
+				       AF_ETHERNET, ip, 0, 0, update_flags, 0,
+				       0);
 
 	return result;
 }
@@ -3954,10 +3941,11 @@ neigh_update_internal(enum dplane_op_e op, const struct interface *ifp,
 			prefix_mac2str(mac, buf1, sizeof(buf1));
 		else
 			ipaddr2str(link_ip, buf1, sizeof(buf1));
-		zlog_debug("init neigh ctx %s: ifp %s, %s %s, ip %pIA, r_vni 0x%x",
-			   dplane_op2str(op), ifp->name,
-			   link_family == AF_ETHERNET ? "mac " : "link ",
-			   buf1, ip, r_vni);
+		zlog_debug(
+			"init neigh ctx %s: ifp %s, %s %s, ip %pIA, r_vni 0x%x",
+			dplane_op2str(op), ifp->name,
+			link_family == AF_ETHERNET ? "mac " : "link ", buf1, ip,
+			r_vni);
 	}
 
 	ctx = dplane_ctx_alloc();

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -628,15 +628,11 @@ enum zebra_dplane_result dplane_neigh_ip_update(enum dplane_op_e op,
 /*
  * Enqueue evpn mac operations for the dataplane.
  */
-enum zebra_dplane_result dplane_rem_mac_add(const struct interface *ifp,
-					const struct interface *bridge_ifp,
-					vlanid_t vid,
-					const struct ethaddr *mac,
-					struct in_addr vtep_ip,
-					bool sticky,
-					uint32_t nhg_id,
-					bool was_static,
-					vni_t r_vni);
+enum zebra_dplane_result
+dplane_rem_mac_add(const struct interface *ifp,
+		   const struct interface *bridge_ifp, vlanid_t vid,
+		   const struct ethaddr *mac, struct in_addr vtep_ip,
+		   bool sticky, uint32_t nhg_id, bool was_static, vni_t r_vni);
 
 enum zebra_dplane_result dplane_local_mac_add(const struct interface *ifp,
 					const struct interface *bridge_ifp,
@@ -658,24 +654,20 @@ enum zebra_dplane_result dplane_rem_mac_del(const struct interface *ifp,
 					struct in_addr vtep_ip);
 
 /* Helper api to init an empty or new context for a MAC update */
-void dplane_mac_init(struct zebra_dplane_ctx *ctx,
-		     const struct interface *ifp,
-		     const struct interface *br_ifp,
-		     vlanid_t vid,
-		     const struct ethaddr *mac,
-		     struct in_addr vtep_ip,
-		     bool sticky,
-		     uint32_t nhg_id, uint32_t update_flags,
+void dplane_mac_init(struct zebra_dplane_ctx *ctx, const struct interface *ifp,
+		     const struct interface *br_ifp, vlanid_t vid,
+		     const struct ethaddr *mac, struct in_addr vtep_ip,
+		     bool sticky, uint32_t nhg_id, uint32_t update_flags,
 		     vni_t r_vni);
 
 /*
  * Enqueue evpn neighbor updates for the dataplane.
  */
 enum zebra_dplane_result dplane_rem_neigh_add(const struct interface *ifp,
-					  const struct ipaddr *ip,
-					  const struct ethaddr *mac,
-					  uint32_t flags, bool was_static,
-					  vni_t r_vni);
+					      const struct ipaddr *ip,
+					      const struct ethaddr *mac,
+					      uint32_t flags, bool was_static,
+					      vni_t r_vni);
 enum zebra_dplane_result dplane_local_neigh_add(const struct interface *ifp,
 					  const struct ipaddr *ip,
 					  const struct ethaddr *mac,

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -456,6 +456,7 @@ const char *dplane_ctx_get_intf_label(const struct zebra_dplane_ctx *ctx);
 vlanid_t dplane_ctx_mac_get_vlan(const struct zebra_dplane_ctx *ctx);
 bool dplane_ctx_mac_is_sticky(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_mac_get_update_flags(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_mac_get_rvni(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_mac_get_nhg_id(const struct zebra_dplane_ctx *ctx);
 const struct ethaddr *dplane_ctx_mac_get_addr(
 	const struct zebra_dplane_ctx *ctx);
@@ -470,6 +471,7 @@ const struct ethaddr *dplane_ctx_neigh_get_mac(
 	const struct zebra_dplane_ctx *ctx);
 const struct ipaddr *
 dplane_ctx_neigh_get_link_ip(const struct zebra_dplane_ctx *ctx);
+vni_t dplane_ctx_neigh_get_r_vni(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_neigh_get_flags(const struct zebra_dplane_ctx *ctx);
 uint16_t dplane_ctx_neigh_get_state(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_neigh_get_update_flags(const struct zebra_dplane_ctx *ctx);
@@ -633,7 +635,8 @@ enum zebra_dplane_result dplane_rem_mac_add(const struct interface *ifp,
 					struct in_addr vtep_ip,
 					bool sticky,
 					uint32_t nhg_id,
-					bool was_static);
+					bool was_static,
+					vni_t r_vni);
 
 enum zebra_dplane_result dplane_local_mac_add(const struct interface *ifp,
 					const struct interface *bridge_ifp,
@@ -662,7 +665,8 @@ void dplane_mac_init(struct zebra_dplane_ctx *ctx,
 		     const struct ethaddr *mac,
 		     struct in_addr vtep_ip,
 		     bool sticky,
-		     uint32_t nhg_id, uint32_t update_flags);
+		     uint32_t nhg_id, uint32_t update_flags,
+		     vni_t r_vni);
 
 /*
  * Enqueue evpn neighbor updates for the dataplane.
@@ -670,7 +674,8 @@ void dplane_mac_init(struct zebra_dplane_ctx *ctx,
 enum zebra_dplane_result dplane_rem_neigh_add(const struct interface *ifp,
 					  const struct ipaddr *ip,
 					  const struct ethaddr *mac,
-					  uint32_t flags, bool was_static);
+					  uint32_t flags, bool was_static,
+					  vni_t r_vni);
 enum zebra_dplane_result dplane_local_neigh_add(const struct interface *ifp,
 					  const struct ipaddr *ip,
 					  const struct ethaddr *mac,

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -100,7 +100,10 @@ struct zebra_mac_t_ {
 			vlanid_t vid;
 		} local;
 
-		struct in_addr r_vtep_ip;
+		struct {
+			vni_t r_vni;
+			struct in_addr r_vtep_ip;
+		} remote;
 	} fwd_info;
 
 	/* Local or remote ES */

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3901,8 +3901,8 @@ void zebra_evpn_proc_remote_nh(ZAPI_HANDLER_ARGS)
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 			zlog_debug("evpn remote nh %d %pIA rmac %pEA add",
 				   vrf_id, &nh, &rmac);
-		zebra_vxlan_evpn_vrf_route_add(vrf_id, &rmac, &nh,
-					       (struct prefix *)&dummy_prefix);
+		zebra_vxlan_evpn_vrf_route_add(
+			vrf_id, &rmac, &nh, (struct prefix *)&dummy_prefix, 0);
 	} else {
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 			zlog_debug("evpn remote nh %d %pIA del", vrf_id, &nh);

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -169,7 +169,7 @@ int zebra_evpn_rem_neigh_install(zebra_evpn_t *zevpn, zebra_neigh_t *n,
 		flags |= DPLANE_NTF_ROUTER;
 	ZEBRA_NEIGH_SET_ACTIVE(n);
 
-	dplane_rem_neigh_add(vlan_if, &n->ip, &n->emac, flags, was_static);
+	dplane_rem_neigh_add(vlan_if, &n->ip, &n->emac, flags, was_static, 0);
 
 	return ret;
 }
@@ -1631,7 +1631,7 @@ int zebra_evpn_remote_neigh_update(zebra_evpn_t *zevpn, struct interface *ifp,
 		UNSET_FLAG(n->flags, ZEBRA_NEIGH_ALL_LOCAL_FLAGS);
 		SET_FLAG(n->flags, ZEBRA_NEIGH_REMOTE);
 		ZEBRA_NEIGH_SET_ACTIVE(n);
-		n->r_vtep_ip = zmac->fwd_info.r_vtep_ip;
+		n->r_vtep_ip = zmac->fwd_info.remote.r_vtep_ip;
 	}
 
 	return 0;

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1603,7 +1603,7 @@ static int zfpm_trigger_rmac_update(zebra_mac_t *rmac, zebra_l3vni_t *zl3vni,
 			return 0;
 	}
 
-	fpm_mac->r_vtep_ip.s_addr = rmac->fwd_info.r_vtep_ip.s_addr;
+	fpm_mac->r_vtep_ip.s_addr = rmac->fwd_info.remote.r_vtep_ip.s_addr;
 	fpm_mac->zebra_flags = rmac->flags;
 	fpm_mac->vxlan_if = vxlan_if ? vxlan_if->ifindex : 0;
 	fpm_mac->svi_if = svi_if ? svi_if->ifindex : 0;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -83,7 +83,8 @@ static zebra_neigh_t *zl3vni_nh_add(zebra_l3vni_t *zl3vni,
 				    const struct ipaddr *vtep_ip,
 				    const struct ethaddr *rmac);
 static int zl3vni_nh_del(zebra_l3vni_t *zl3vni, zebra_neigh_t *n);
-static int zl3vni_nh_install(zebra_l3vni_t *zl3vni, zebra_neigh_t *n);
+static int zl3vni_nh_install(zebra_l3vni_t *zl3vni, zebra_neigh_t *n,
+			     vni_t r_vni);
 static int zl3vni_nh_uninstall(zebra_l3vni_t *zl3vni, zebra_neigh_t *n);
 
 /* l3-vni rmac related APIs */
@@ -350,7 +351,7 @@ static void zl3vni_print_rmac(zebra_mac_t *zrmac, struct vty *vty,
 		vty_out(vty, "MAC: %s\n",
 			prefix_mac2str(&zrmac->macaddr, buf1, sizeof(buf1)));
 		vty_out(vty, " Remote VTEP: %pI4\n",
-			&zrmac->fwd_info.r_vtep_ip);
+			&zrmac->fwd_info.remote.r_vtep_ip);
 		vty_out(vty, " Refcount: %d\n", rb_host_count(&zrmac->host_rb));
 		vty_out(vty, "  Prefixes:\n");
 		RB_FOREACH (hle, host_rb_tree_entry, &zrmac->host_rb)
@@ -360,10 +361,10 @@ static void zl3vni_print_rmac(zebra_mac_t *zrmac, struct vty *vty,
 		json_object_string_add(
 			json, "routerMac",
 			prefix_mac2str(&zrmac->macaddr, buf1, sizeof(buf1)));
-		json_object_string_add(json, "vtepIp",
-				       inet_ntop(AF_INET,
-						 &zrmac->fwd_info.r_vtep_ip,
-						 buf1, sizeof(buf1)));
+		json_object_string_add(
+			json, "vtepIp",
+			inet_ntop(AF_INET, &zrmac->fwd_info.remote.r_vtep_ip,
+				  buf1, sizeof(buf1)));
 		json_object_int_add(json, "refCount",
 				    rb_host_count(&zrmac->host_rb));
 		json_object_int_add(json, "localSequence", zrmac->loc_seq);
@@ -652,15 +653,15 @@ static void zl3vni_print_rmac_hash(struct hash_bucket *bucket, void *ctx)
 	if (!json) {
 		vty_out(vty, "%-17s %-21pI4\n",
 			prefix_mac2str(&zrmac->macaddr, buf, sizeof(buf)),
-			&zrmac->fwd_info.r_vtep_ip);
+			&zrmac->fwd_info.remote.r_vtep_ip);
 	} else {
 		json_object_string_add(
 			json_rmac, "routerMac",
 			prefix_mac2str(&zrmac->macaddr, buf, sizeof(buf)));
-		json_object_string_add(json_rmac, "vtepIp",
-				       inet_ntop(AF_INET,
-						 &zrmac->fwd_info.r_vtep_ip,
-						 buf, sizeof(buf)));
+		json_object_string_add(
+			json_rmac, "vtepIp",
+			inet_ntop(AF_INET, &zrmac->fwd_info.remote.r_vtep_ip,
+				  buf, sizeof(buf)));
 		json_object_object_add(
 			json, prefix_mac2str(&zrmac->macaddr, buf, sizeof(buf)),
 			json_rmac);
@@ -1217,9 +1218,10 @@ static int zl3vni_rmac_install(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 	else
 		vid = 0;
 
-	res = dplane_rem_mac_add(zl3vni->vxlan_if, br_ifp, vid,
-			     &zrmac->macaddr, zrmac->fwd_info.r_vtep_ip, 0, 0,
-				 false /*was_static*/);
+	res = dplane_rem_mac_add(zl3vni->vxlan_if, br_ifp, vid, &zrmac->macaddr,
+				 zrmac->fwd_info.remote.r_vtep_ip, 0, 0,
+				 false /*was_static*/,
+				 zrmac->fwd_info.remote.r_vni);
 	if (res != ZEBRA_DPLANE_REQUEST_FAILURE)
 		return 0;
 	else
@@ -1265,8 +1267,8 @@ static int zl3vni_rmac_uninstall(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 	else
 		vid = 0;
 
-	res = dplane_rem_mac_del(zl3vni->vxlan_if, br_ifp, vid,
-			     &zrmac->macaddr, zrmac->fwd_info.r_vtep_ip);
+	res = dplane_rem_mac_del(zl3vni->vxlan_if, br_ifp, vid, &zrmac->macaddr,
+				 zrmac->fwd_info.remote.r_vtep_ip);
 	if (res != ZEBRA_DPLANE_REQUEST_FAILURE)
 		return 0;
 	else
@@ -1277,7 +1279,7 @@ static int zl3vni_rmac_uninstall(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 static int zl3vni_remote_rmac_add(zebra_l3vni_t *zl3vni,
 				  const struct ethaddr *rmac,
 				  const struct ipaddr *vtep_ip,
-				  const struct prefix *host_prefix)
+				  const struct prefix *host_prefix, vni_t r_vni)
 {
 	zebra_mac_t *zrmac = NULL;
 
@@ -1288,12 +1290,13 @@ static int zl3vni_remote_rmac_add(zebra_l3vni_t *zl3vni,
 		zrmac = zl3vni_rmac_add(zl3vni, rmac);
 		if (!zrmac) {
 			zlog_debug(
-				"Failed to add RMAC %pEA L3VNI %u Remote VTEP %pIA, prefix %pFX",
-				rmac, zl3vni->vni, vtep_ip, host_prefix);
+				"Failed to add RMAC %pEA L3VNI %u Remote VTEP %pIA, prefix %pFX, r_vni = 0x%x",
+				rmac, zl3vni->vni, vtep_ip, host_prefix, r_vni);
 			return -1;
 		}
 		memset(&zrmac->fwd_info, 0, sizeof(zrmac->fwd_info));
-		zrmac->fwd_info.r_vtep_ip = vtep_ip->ipaddr_v4;
+		zrmac->fwd_info.remote.r_vtep_ip = vtep_ip->ipaddr_v4;
+		zrmac->fwd_info.remote.r_vni = r_vni;
 
 		/* Send RMAC for FPM processing */
 		hook_call(zebra_rmac_update, zrmac, zl3vni, false,
@@ -1301,16 +1304,16 @@ static int zl3vni_remote_rmac_add(zebra_l3vni_t *zl3vni,
 
 		/* install rmac in kernel */
 		zl3vni_rmac_install(zl3vni, zrmac);
-	} else if (!IPV4_ADDR_SAME(&zrmac->fwd_info.r_vtep_ip,
+	} else if (!IPV4_ADDR_SAME(&zrmac->fwd_info.remote.r_vtep_ip,
 				   &vtep_ip->ipaddr_v4)) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
 				"L3VNI %u Remote VTEP change(%pI4 -> %pIA) for RMAC %pEA, prefix %pFX",
-				zl3vni->vni, &zrmac->fwd_info.r_vtep_ip,
+				zl3vni->vni, &zrmac->fwd_info.remote.r_vtep_ip,
 				vtep_ip, rmac, host_prefix);
 
-		zrmac->fwd_info.r_vtep_ip = vtep_ip->ipaddr_v4;
-
+		zrmac->fwd_info.remote.r_vtep_ip = vtep_ip->ipaddr_v4;
+		zrmac->fwd_info.remote.r_vni = r_vni;
 		/* install rmac in kernel */
 		zl3vni_rmac_install(zl3vni, zrmac);
 	}
@@ -1419,7 +1422,8 @@ static int zl3vni_nh_del(zebra_l3vni_t *zl3vni, zebra_neigh_t *n)
 /*
  * Install remote nh as neigh into the kernel.
  */
-static int zl3vni_nh_install(zebra_l3vni_t *zl3vni, zebra_neigh_t *n)
+static int zl3vni_nh_install(zebra_l3vni_t *zl3vni, zebra_neigh_t *n,
+			     vni_t r_vni)
 {
 	uint8_t flags;
 	int ret = 0;
@@ -1436,7 +1440,7 @@ static int zl3vni_nh_install(zebra_l3vni_t *zl3vni, zebra_neigh_t *n)
 		flags |= DPLANE_NTF_ROUTER;
 
 	dplane_rem_neigh_add(zl3vni->svi_if, &n->ip, &n->emac, flags,
-			false /*was_static*/);
+			     false /*was_static*/, r_vni);
 
 	return ret;
 }
@@ -1462,7 +1466,7 @@ static int zl3vni_nh_uninstall(zebra_l3vni_t *zl3vni, zebra_neigh_t *n)
 static int zl3vni_remote_nh_add(zebra_l3vni_t *zl3vni,
 				const struct ipaddr *vtep_ip,
 				const struct ethaddr *rmac,
-				const struct prefix *host_prefix)
+				const struct prefix *host_prefix, vni_t r_vni)
 {
 	zebra_neigh_t *nh = NULL;
 
@@ -1478,7 +1482,7 @@ static int zl3vni_remote_nh_add(zebra_l3vni_t *zl3vni,
 		}
 
 		/* install the nh neigh in kernel */
-		zl3vni_nh_install(zl3vni, nh);
+		zl3vni_nh_install(zl3vni, nh, r_vni);
 	} else if (memcmp(&nh->emac, rmac, ETH_ALEN) != 0) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
@@ -1488,7 +1492,7 @@ static int zl3vni_remote_nh_add(zebra_l3vni_t *zl3vni,
 
 		memcpy(&nh->emac, rmac, ETH_ALEN);
 		/* install (update) the nh neigh in kernel */
-		zl3vni_nh_install(zl3vni, nh);
+		zl3vni_nh_install(zl3vni, nh, r_vni);
 	}
 
 	rb_find_or_add_host(&nh->host_rb, host_prefix);
@@ -1528,7 +1532,7 @@ static int zl3vni_local_nh_add_update(zebra_l3vni_t *zl3vni, struct ipaddr *ip,
 	 * If the kernel has aged this entry, re-install.
 	 */
 	if (state & NUD_STALE)
-		zl3vni_nh_install(zl3vni, n);
+		zl3vni_nh_install(zl3vni, n, 0);
 #endif
 	return 0;
 }
@@ -1546,7 +1550,7 @@ static int zl3vni_local_nh_del(zebra_l3vni_t *zl3vni, struct ipaddr *ip)
 	 * If we get an age out notification for these neigh entries, we have to
 	 * install it back
 	 */
-	zl3vni_nh_install(zl3vni, n);
+	zl3vni_nh_install(zl3vni, n, 0);
 
 	return 0;
 }
@@ -2171,7 +2175,8 @@ int is_l3vni_for_prefix_routes_only(vni_t vni)
 /* handle evpn route in vrf table */
 void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id, const struct ethaddr *rmac,
 				    const struct ipaddr *vtep_ip,
-				    const struct prefix *host_prefix)
+				    const struct prefix *host_prefix,
+				    vni_t r_vni)
 {
 	zebra_l3vni_t *zl3vni = NULL;
 	struct ipaddr ipv4_vtep;
@@ -2184,7 +2189,7 @@ void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id, const struct ethaddr *rmac,
 	 * add the next hop neighbor -
 	 * neigh to be installed is the ipv6 nexthop neigh
 	 */
-	zl3vni_remote_nh_add(zl3vni, vtep_ip, rmac, host_prefix);
+	zl3vni_remote_nh_add(zl3vni, vtep_ip, rmac, host_prefix, r_vni);
 
 	/*
 	 * if the remote vtep is a ipv4 mapped ipv6 address convert it to ipv4
@@ -2204,7 +2209,7 @@ void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id, const struct ethaddr *rmac,
 	 * add the rmac - remote rmac to be installed is against the ipv4
 	 * nexthop address
 	 */
-	zl3vni_remote_rmac_add(zl3vni, rmac, &ipv4_vtep, host_prefix);
+	zl3vni_remote_rmac_add(zl3vni, rmac, &ipv4_vtep, host_prefix, r_vni);
 }
 
 /* handle evpn vrf route delete */

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -195,7 +195,8 @@ extern void zebra_vxlan_disable(void);
 extern void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id,
 					   const struct ethaddr *rmac,
 					   const struct ipaddr *ip,
-					   const struct prefix *host_prefix);
+					   const struct prefix *host_prefix,
+					   vni_t r_vni);
 extern void zebra_vxlan_evpn_vrf_route_del(vrf_id_t vrf_id,
 					   struct ipaddr *vtep_ip,
 					   struct prefix *host_prefix);


### PR DESCRIPTION
Consider the topology as follow，VtepA and VtepB can communicate with each other using different l3vni in case of the same rts.

		 vxlan tunnel									 
    Vtep-A ----------------- Vtep-B								 
    l3vni 101                l3vni 102				 
    rt both 100:100          rt both 100:100	


Signed-off-by: gong.min <gong.min@huastart.com>