### PR TITLE
bgpd: Fix SA warning about freeing an aspath

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -839,6 +839,8 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 					bgp_dest_get_prefix(dest), &tmp_pi);
 
 				if (ret == RMAP_DENYMATCH) {
+					/* The aspath belongs to 'attr' */
+					tmp_attr.aspath = NULL;
 					bgp_attr_flush(&tmp_attr);
 					continue;
 				} else {


### PR DESCRIPTION
Fix coverity warning CID 1505589: a temp bgp attr is freed while pointing at another attr's aspath.
