### PR TITLE
ospf6d: fix duplicated packet read

### DIFF
--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1709,6 +1709,13 @@ static int ospf6_read_helper(int sockfd, struct ospf6 *ospf6)
 		return OSPF6_READ_CONTINUE;
 	}
 
+	/*
+	 * Drop packet destined to another VRF.
+	 * This happens when raw_l3mdev_accept is set to 1.
+	 */
+	if (ospf6->vrf_id != oi->interface->vrf_id)
+		return OSPF6_READ_CONTINUE;
+
 	oh = (struct ospf6_header *)recvbuf;
 	if (ospf6_rxpacket_examin(oi, oh, len) != MSG_OK)
 		return OSPF6_READ_CONTINUE;


### PR DESCRIPTION
When OSPFv3 router is configured in both default and non-default VRFs,
every packet destined to a non-default VRF is read twice. This makes it
impossible to establish neighborship because every DbDesc packet is
treated as duplicated and we end up infinitely exchanging DbDescs.

We should drop packets received in the default VRF if an interface we
received it on is bound to another VRF.

Same thing was done for OSPFv2 in 555691e.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>