### PR TITLE
doc: fix typo in OSPFv3 NSSA

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -90,7 +90,7 @@ NSSA Support in OSPFv3
 =======================
 
 The configuration of NSSA areas in OSPFv3 is supported using the CLI command
-area A.B.C.D nssa  in ospf6 router configuration mode.
+``area A.B.C.D nssa`` in ospf6 router configuration mode.
 The following functionalities are implemented as per RFC 3101:
 
 1. Advertising Type-7 LSA into NSSA area when external route is redistributed
@@ -98,7 +98,7 @@ The following functionalities are implemented as per RFC 3101:
 2. Processing Type-7 LSA received from neighbor and installing route in the
    route table
 3. Support for NSSA ABR functionality which is generating Type-5 LSA when
-   backbone area is configured. Currently translation od TYpe-7 LSA to Type-5 LSA
+   backbone area is configured. Currently translation of Type-7 LSA to Type-5 LSA
    is enabled by default.
 4. Support for NSSA Translator functionality when there are multiple NSSA ABR
    in an area


### PR DESCRIPTION
Fix issue found late in code review from PR #8727 .

@pushpasis addressing your comments:

1. > Nit: 'od'/'of', 'TYpe'/'Type',

Fixed here.

2. > Should we not have the #defines outside the structure definition?

I don't recall a rule about this and I know a few examples:
 - https://github.com/FRRouting/frr/blob/master/lib/if.h#L236
 - https://github.com/FRRouting/frr/blob/master/bgpd/bgp_updgrp.h#L248
 - https://github.com/FRRouting/frr/blob/master/ospfd/ospf_interface.h#L194

3. > Is there a upper limit to the number of areas we support? If not this could become a performance issue.
    > Though in real-world deployments there won't be hundreds of areas on the same ABR :)

In this case I think we should wait it become a problem before trying to solve it, it might need a more specialized / complex solution.