### PR TITLE
doc: add a note for ospfd instances

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -80,10 +80,12 @@ Routers
 
 To start OSPF process you have to specify the OSPF router.
 
-.. clicmd:: router ospf [(1-65535)] vrf NAME
+.. clicmd:: router ospf [{(1-65535)|vrf NAME}]
 
 
    Enable or disable the OSPF process.
+
+   Multiple instances don't support `vrf NAME`.
 
 .. clicmd:: ospf router-id A.B.C.D
 


### PR DESCRIPTION
Multiple instances support multiple vrfs is our favorite. But in recent master, it doesn't work, so i do some investigation.
Users including me will be amazed by it.

Multiple instances of ospfd don't support vrf henceforth.

Signed-off-by: anlancs <anlan_cs@tom.com>