### PR TITLE
Speedup support bundles, fix bugs, add CLI timestamp

### DIFF
--- a/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
+++ b/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
@@ -526,9 +526,14 @@ def test_multicast_data_traffic_static_RP_send_traffic_then_join_p0(request):
         {"dut": "r2", "src_address": source, "iif": "r2-f1-eth0", "oil": "r2-l1-eth2"},
         {"dut": "f1", "src_address": source, "iif": "f1-i2-eth1", "oil": "f1-r2-eth3"},
     ]
+    # On timeout change from default of 80 to 120: failures logs indicate times 90+
+    # seconds for success on the 2nd entry in the above table. Using 100s here restores
+    # previous 80 retries with 2s wait if we assume .5s per vtysh/show ip mroute runtime
+    # (41 * (2 + .5)) == 102.
     for data in input_dict:
         result = verify_ip_mroutes(
-            tgen, data["dut"], data["src_address"], IGMP_JOIN, data["iif"], data["oil"]
+            tgen, data["dut"], data["src_address"], IGMP_JOIN, data["iif"], data["oil"],
+            retry_timeout=102
         )
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 

--- a/tools/generate_support_bundle.py
+++ b/tools/generate_support_bundle.py
@@ -1,117 +1,89 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) 2021, LabN Consulting, L.L.C.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; see the file COPYING; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 ########################################################
 ### Python Script to generate the FRR support bundle ###
 ########################################################
+import argparse
+import logging
 import os
 import subprocess
-import datetime
+import tempfile
 
-ETC_DIR = "/etc/frr/"
-LOG_DIR = "/var/log/frr/"
-SUCCESS = 1
-FAIL = 0
+def open_with_backup(path):
+    if os.path.exists(path):
+        print("Making backup of " + path)
+        subprocess.check_call("mv {0} {0}.prev".format(path))
+    return open(path, "w")
 
-inputFile = ETC_DIR + "support_bundle_commands.conf"
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--config", default="/etc/frr/support_bundle_commands.conf", help="input config")
+    parser.add_argument("-l", "--log-dir", default="/var/log/frr", help="directory for logfiles")
+    args = parser.parse_args()
 
-# Create the output file name
-def createOutputFile(procName):
-    fileName = procName + "_support_bundle.log"
-    oldFile = LOG_DIR + fileName
-    cpFileCmd = "cp " + oldFile + " " + oldFile + ".prev"
-    rmFileCmd = "rm -rf " + oldFile
-    print("Making backup of " + oldFile)
-    os.system(cpFileCmd)
-    print("Removing " + oldFile)
-    os.system(rmFileCmd)
-    return fileName
+    collecting = False # file format has sentinels (seem superfluous)
+    proc_cmds = {}
+    proc = None
+    temp = None
 
-
-# Open the output file for this process
-def openOutputFile(fileName):
-    crt_file_cmd = LOG_DIR + fileName
-    print(crt_file_cmd)
+    # Collect all the commands for each daemon
     try:
-        outputFile = open(crt_file_cmd, "w")
-        return outputFile
-    except IOError:
-        return ()
+        for line in open(args.config):
+            line = line.rstrip()
+            if len(line) == 0 or line[0] == "#":
+                continue
 
-
-# Close the output file for this process
-def closeOutputFile(f):
-    try:
-        f.close()
-        return SUCCESS
-    except IOError:
-        return FAIL
-
-
-# Execute the command over vtysh and store in the
-# output file
-def executeCommand(cmd, outputFile):
-    cmd_exec_str = 'vtysh -c "' + cmd + '" '
-    try:
-        cmd_output = subprocess.check_output(cmd_exec_str, shell=True)
-        try:
-            dateTime = datetime.datetime.now()
-            outputFile.write(">>[" + str(dateTime) + "]" + cmd + "\n")
-            outputFile.write(str(cmd_output))
-            outputFile.write(
-                "########################################################\n"
-            )
-            outputFile.write("\n")
-        except Exception as e:
-            print("Writing to output file Failed: ", e)
-    except subprocess.CalledProcessError as e:
-        dateTime = datetime.datetime.now()
-        outputFile.write(">>[" + str(dateTime) + "]" + cmd + "\n")
-        outputFile.write(e.output)
-        outputFile.write("########################################################\n")
-        outputFile.write("\n")
-        print("Error:" + e.output)
-
-
-# Process the support bundle configuration file
-# and call appropriate functions
-def processConfFile():
-
-    lines = list()
-    outputFile = None
-
-    try:
-        with open(inputFile, "r") as supportBundleConfFile:
-            for l in supportBundleConfFile:
-                lines.append(l.rstrip())
-    except IOError:
-        print("conf file {} not present".format(inputFile))
+            cmd_line = line.split(":")
+            if cmd_line[0] == "PROC_NAME":
+                proc = cmd_line[1]
+                temp = tempfile.NamedTemporaryFile("w+")
+                collecting = False
+            elif cmd_line[0] == "CMD_LIST_START":
+                collecting = True
+            elif cmd_line[0] == "CMD_LIST_END":
+                collecting = False
+                temp.flush()
+                proc_cmds[proc] = open(temp.name)
+                temp.close()
+            elif collecting:
+                temp.write(line + "\n")
+            else:
+                print("Ignoring unexpected input " + line.rstrip())
+    except IOError as error:
+        logging.fatal("Cannot read config file: %s: %s", args.config, str(error))
         return
 
-    for line in lines:
-        if len(line) == 0 or line[0] == "#":
-            continue
+    # Spawn a vtysh to fetch each set of commands
+    procs = []
+    for proc in proc_cmds:
+        ofn = os.path.join(args.log_dir, proc + "_support_bundle.log")
+        p = subprocess.Popen(
+            ["/usr/bin/env", "vtysh", "-t"],
+            stdin=proc_cmds[proc],
+            stdout=open_with_backup(ofn),
+            stderr=subprocess.STDOUT,
+        )
+        procs.append(p)
 
-        cmd_line = line.split(":")
-        if cmd_line[0] == "PROC_NAME":
-            outputFileName = createOutputFile(cmd_line[1])
-            if outputFileName:
-                print(outputFileName, "created for", cmd_line[1])
-        elif cmd_line[0] == "CMD_LIST_START":
-            outputFile = openOutputFile(outputFileName)
-            if outputFile:
-                print(outputFileName, "opened")
-            else:
-                print(outputFileName, "open failed")
-                return FAIL
-        elif cmd_line[0] == "CMD_LIST_END":
-            if closeOutputFile(outputFile):
-                print(outputFileName, "closed")
-            else:
-                print(outputFileName, "close failed")
-        else:
-            print("Execute:", cmd_line[0])
-            executeCommand(cmd_line[0], outputFile)
+    for p in procs:
+        p.wait()
 
-
-# Main Function
-processConfFile()
+if __name__ == "__main__":
+    main()

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -56,6 +56,9 @@ struct vty *vty;
 /* VTY shell pager name. */
 char *vtysh_pager_name = NULL;
 
+/* VTY should add timestamp */
+bool vtysh_add_timestamp;
+
 /* VTY shell client structure */
 struct vtysh_client {
 	int fd;
@@ -481,6 +484,13 @@ static int vtysh_execute_func(const char *line, int pager)
 			vty_out(vty, "%% Command not allowed: enable\n");
 			return CMD_WARNING;
 		}
+	}
+
+	if (vtysh_add_timestamp && strncmp(line, "exit", 4)) {
+		char ts[48];
+
+		(void)quagga_timestamp(3, ts, sizeof(ts));
+		vty_out(vty, "%% %s\n\n", ts);
 	}
 
 	saved_ret = ret = cmd_execute(vty, line, &cmd, 1);

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -113,4 +113,6 @@ extern struct vty *vty;
 
 extern int user_mode;
 
+extern bool vtysh_add_timestamp;
+
 #endif /* VTYSH_H */

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -560,6 +560,7 @@ static int vtysh_read_file(FILE *confp, bool dry_run)
 int vtysh_read_config(const char *config_default_dir, bool dry_run)
 {
 	FILE *confp = NULL;
+	bool save;
 	int ret;
 
 	confp = fopen(config_default_dir, "r");
@@ -570,8 +571,13 @@ int vtysh_read_config(const char *config_default_dir, bool dry_run)
 		return CMD_ERR_NO_FILE;
 	}
 
+	save = vtysh_add_timestamp;
+	vtysh_add_timestamp = false;
+
 	ret = vtysh_read_file(confp, dry_run);
 	fclose(confp);
+
+	vtysh_add_timestamp = save;
 
 	return (ret);
 }

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -201,6 +201,7 @@ struct option longopts[] = {
 	{"writeconfig", no_argument, NULL, 'w'},
 	{"pathspace", required_argument, NULL, 'N'},
 	{"user", no_argument, NULL, 'u'},
+	{"timestamp", no_argument, NULL, 't'},
 	{0}};
 
 /* Read a string, and return a pointer to it.  Returns NULL on EOF. */
@@ -308,6 +309,7 @@ int main(int argc, char **argv, char **env)
 	int opt;
 	int dryrun = 0;
 	int boot_flag = 0;
+	bool ts_flag = false;
 	const char *daemon_name = NULL;
 	const char *inputfile = NULL;
 	struct cmd_rec {
@@ -346,7 +348,7 @@ int main(int argc, char **argv, char **env)
 
 	/* Option handling. */
 	while (1) {
-		opt = getopt_long(argc, argv, "be:c:d:nf:H:mEhCwN:u", longopts,
+		opt = getopt_long(argc, argv, "be:c:d:nf:H:mEhCwN:ut", longopts,
 				  0);
 
 		if (opt == EOF)
@@ -407,6 +409,9 @@ int main(int argc, char **argv, char **env)
 			break;
 		case 'u':
 			user_mode = 1;
+			break;
+		case 't':
+			ts_flag = true;
 			break;
 		case 'w':
 			writeconfig = 1;
@@ -624,6 +629,8 @@ int main(int argc, char **argv, char **env)
 		if (!user_mode)
 			vtysh_execute("enable");
 
+		vtysh_add_timestamp = ts_flag;
+
 		while (cmd != NULL) {
 			char *eol;
 
@@ -711,6 +718,8 @@ int main(int argc, char **argv, char **env)
 	/* Enter into enable node. */
 	if (!user_mode)
 		vtysh_execute("enable");
+
+	vtysh_add_timestamp = ts_flag;
 
 	/* Preparation for longjmp() in sigtstp(). */
 	sigsetjmp(jmpbuf, 1);


### PR DESCRIPTION
Speedup (large topo): OLD: ~6 minutes NEW: ~1 second.
- Collect from each node in parallel
- On each node collect each "proc" support in parallel
- For each "proc" only call vtysh once with all commands

Bug fixes:
- output was broken, a dump of python "repr" format of str.
- sub-directory test name was the same internal pytest function name
  for any test, and not the actual test name.

Needed timestamp to replace old gather bundle behavior so:

vtysh: add CLI timestamp '-t' flag

Example output:

    flk# show version
    % 2021/06/29 00:25:01.562

    FRRouting 8.1-dev-my-manual-build (flk).
    Copyright 1996-2005 Kunihiro Ishiguro, et al.

