### PR TITLE
ospf6d: revert PR #8622

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -332,13 +332,3 @@ Larger example with policy and various options set:
     ipv6 access-class access6
     exec-timeout 0 0
    !
-
-
-Configuration Limits
-====================
-
-Ospf6d currently supports 100 interfaces addresses if MTU is set to
-default value, and 200 interface addresses if MTU is set to jumbo
-packet size or larger.
-
-  

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -385,7 +385,6 @@ void ospf6_interface_connected_route_update(struct interface *ifp)
 	struct connected *c;
 	struct listnode *node, *nnode;
 	struct in6_addr nh_addr;
-	int count = 0, max_addr_count;
 
 	oi = (struct ospf6_interface *)ifp->info;
 	if (oi == NULL)
@@ -404,21 +403,9 @@ void ospf6_interface_connected_route_update(struct interface *ifp)
 	/* update "route to advertise" interface route table */
 	ospf6_route_remove_all(oi->route_connected);
 
-	if (oi->ifmtu >= OSPF6_JUMBO_MTU)
-		max_addr_count = OSPF6_MAX_IF_ADDRS_JUMBO;
-	else
-		max_addr_count = OSPF6_MAX_IF_ADDRS;
-
 	for (ALL_LIST_ELEMENTS(oi->interface->connected, node, nnode, c)) {
 		if (c->address->family != AF_INET6)
 			continue;
-
-		/* number of interface addresses supported is based on MTU
-		 * size of OSPFv3 packet
-		 */
-		count++;
-		if (count >= max_addr_count)
-			break;
 
 		CONTINUE_IF_ADDRESS_LINKLOCAL(IS_OSPF6_DEBUG_INTERFACE,
 					      c->address);
@@ -1691,7 +1678,6 @@ DEFUN (ipv6_ospf6_area,
 	int idx_ipv4 = 3;
 	uint32_t area_id;
 	int format;
-	int ipv6_count = 0;
 
 	assert(ifp);
 
@@ -1704,23 +1690,6 @@ DEFUN (ipv6_ospf6_area,
 		vty_out(vty, "%s already attached to Area %s\n",
 			oi->interface->name, oi->area->name);
 		return CMD_SUCCESS;
-	}
-
-	/* if more than OSPF6_MAX_IF_ADDRS are configured on this interface
-	 * then don't allow ospfv3 to be configured
-	 */
-	ipv6_count = connected_count_by_family(ifp, AF_INET6);
-	if (oi->ifmtu == OSPF6_DEFAULT_MTU && ipv6_count > OSPF6_MAX_IF_ADDRS) {
-		vty_out(vty,
-			"can not configure OSPFv3 on if %s, must have less than %d interface addresses but has %d addresses\n",
-			ifp->name, OSPF6_MAX_IF_ADDRS, ipv6_count);
-		return CMD_WARNING_CONFIG_FAILED;
-	} else if (oi->ifmtu >= OSPF6_JUMBO_MTU
-		   && ipv6_count > OSPF6_MAX_IF_ADDRS_JUMBO) {
-		vty_out(vty,
-			"can not configure OSPFv3 on if %s, must have less than %d interface addresses but has %d addresses\n",
-			ifp->name, OSPF6_MAX_IF_ADDRS_JUMBO, ipv6_count);
-		return CMD_WARNING_CONFIG_FAILED;
 	}
 
 	if (str2area_id(argv[idx_ipv4]->arg, &area_id, &format)) {

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -201,7 +201,6 @@ extern void ospf6_interface_disable(struct ospf6_interface *);
 
 extern void ospf6_interface_state_update(struct interface *);
 extern void ospf6_interface_connected_route_update(struct interface *);
-extern void ospf6_interface_connected_route_add(struct connected *);
 extern struct in6_addr *
 ospf6_interface_get_global_address(struct interface *ifp);
 

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -767,7 +767,6 @@ int ospf6_link_lsa_originate(struct thread *thread)
 	struct ospf6_link_lsa *link_lsa;
 	struct ospf6_route *route;
 	struct ospf6_prefix *op;
-	int count, max_addr_count;
 
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
 	oi->thread_link_lsa = NULL;
@@ -811,20 +810,14 @@ int ospf6_link_lsa_originate(struct thread *thread)
 	memcpy(link_lsa->options, oi->area->options, 3);
 	memcpy(&link_lsa->linklocal_addr, oi->linklocal_addr,
 	       sizeof(struct in6_addr));
+	link_lsa->prefix_num = htonl(oi->route_connected->count);
 
 	op = (struct ospf6_prefix *)((caddr_t)link_lsa
 				     + sizeof(struct ospf6_link_lsa));
 
-	/* connected prefix to advertise, number of interface addresses
-	 * supported is based on MTU size of OSPFv3 packets
-	 */
-	if (oi->ifmtu >= OSPF6_JUMBO_MTU)
-		max_addr_count = OSPF6_MAX_IF_ADDRS_JUMBO;
-	else
-		max_addr_count = OSPF6_MAX_IF_ADDRS;
-	for (route = ospf6_route_head(oi->route_connected), count = 0;
-	     route && count < max_addr_count;
-	     route = ospf6_route_next(route), count++) {
+	/* connected prefix to advertise */
+	for (route = ospf6_route_head(oi->route_connected); route;
+	     route = ospf6_route_next(route)) {
 		op->prefix_length = route->prefix.prefixlen;
 		op->prefix_options = route->path.prefix_options;
 		op->prefix_metric = htons(0);
@@ -832,8 +825,6 @@ int ospf6_link_lsa_originate(struct thread *thread)
 		       OSPF6_PREFIX_SPACE(op->prefix_length));
 		op = OSPF6_PREFIX_NEXT(op);
 	}
-
-	link_lsa->prefix_num = htonl(count);
 
 	/* Fill LSA Header */
 	lsa_header->age = 0;
@@ -1014,7 +1005,6 @@ int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 	unsigned short prefix_num = 0;
 	struct ospf6_route_table *route_advertise;
 	int ls_id = 0;
-	int count, max_addr_count;
 
 	oa = (struct ospf6_area *)THREAD_ARG(thread);
 	oa->thread_intra_prefix_lsa = NULL;
@@ -1060,8 +1050,6 @@ int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 	intra_prefix_lsa->ref_adv_router = oa->ospf6->router_id;
 
 	route_advertise = ospf6_route_table_create(0, 0);
-	route_advertise->hook_add = NULL;
-	route_advertise->hook_remove = NULL;
 
 	for (ALL_LIST_ELEMENTS_RO(oa->if_list, i, oi)) {
 		if (oi->state == OSPF6_INTERFACE_DOWN) {
@@ -1090,14 +1078,8 @@ int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 			zlog_debug("  Interface %s:", oi->interface->name);
 
 		/* connected prefix to advertise */
-		if (oi->ifmtu >= OSPF6_JUMBO_MTU)
-			max_addr_count = OSPF6_MAX_IF_ADDRS_JUMBO;
-		else
-			max_addr_count = OSPF6_MAX_IF_ADDRS;
-
-		for (route = ospf6_route_head(oi->route_connected), count = 0;
-		     route && count < max_addr_count;
-		     route = ospf6_route_best_next(route), count++) {
+		for (route = ospf6_route_head(oi->route_connected); route;
+		     route = ospf6_route_best_next(route)) {
 			if (IS_OSPF6_DEBUG_ORIGINATE(INTRA_PREFIX))
 				zlog_debug("    include %pFX", &route->prefix);
 			ospf6_route_add(ospf6_route_copy(route),
@@ -1312,8 +1294,6 @@ int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 
 	/* connected prefix to advertise */
 	route_advertise = ospf6_route_table_create(0, 0);
-	route_advertise->hook_add = NULL;
-	route_advertise->hook_remove = NULL;
 
 	type = ntohs(OSPF6_LSTYPE_LINK);
 	for (ALL_LSDB_TYPED(oi->lsdb, type, lsa)) {

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -989,7 +989,6 @@ DEFUN_HIDDEN (ospf6_interface_area,
 	struct ospf6_interface *oi;
 	struct interface *ifp;
 	vrf_id_t vrf_id = VRF_DEFAULT;
-	int ipv6_count = 0;
 	uint32_t area_id;
 	int format;
 
@@ -1010,23 +1009,6 @@ DEFUN_HIDDEN (ospf6_interface_area,
 		vty_out(vty, "%s already attached to Area %s\n",
 			oi->interface->name, oi->area->name);
 		return CMD_SUCCESS;
-	}
-
-	/* if more than OSPF6_MAX_IF_ADDRS are configured on this interface
-	 * then don't allow ospfv3 to be configured
-	 */
-	ipv6_count = connected_count_by_family(ifp, AF_INET6);
-	if (oi->ifmtu == OSPF6_DEFAULT_MTU && ipv6_count > OSPF6_MAX_IF_ADDRS) {
-		vty_out(vty,
-			"can not configure OSPFv3 on if %s, must have less than %d interface addresses but has %d addresses\n",
-			ifp->name, OSPF6_MAX_IF_ADDRS, ipv6_count);
-		return CMD_WARNING_CONFIG_FAILED;
-	} else if (oi->ifmtu >= OSPF6_JUMBO_MTU
-		   && ipv6_count > OSPF6_MAX_IF_ADDRS_JUMBO) {
-		vty_out(vty,
-			"can not configure OSPFv3 on if %s, must have less than %d interface addresses but has %d addresses\n",
-			ifp->name, OSPF6_MAX_IF_ADDRS_JUMBO, ipv6_count);
-		return CMD_WARNING_CONFIG_FAILED;
 	}
 
 	if (str2area_id(argv[idx_ipv4]->arg, &area_id, &format)) {

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -162,10 +162,6 @@ DECLARE_QOBJ_TYPE(ospf6);
 
 #define OSPF6_DISABLED    0x01
 #define OSPF6_STUB_ROUTER 0x02
-#define OSPF6_MAX_IF_ADDRS 100
-#define OSPF6_MAX_IF_ADDRS_JUMBO 200
-#define OSPF6_DEFAULT_MTU 1500
-#define OSPF6_JUMBO_MTU 9000
 
 /* global pointer for OSPF top data structure */
 extern struct ospf6 *ospf6;

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -130,37 +130,16 @@ void ospf6_zebra_no_redistribute(int type, vrf_id_t vrf_id)
 static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
-	struct ospf6_interface *oi;
-	int ipv6_count = 0;
 
 	c = zebra_interface_address_read(ZEBRA_INTERFACE_ADDRESS_ADD,
 					 zclient->ibuf, vrf_id);
 	if (c == NULL)
 		return 0;
 
-	oi = (struct ospf6_interface *)c->ifp->info;
-	if (oi == NULL)
-		oi = ospf6_interface_create(c->ifp);
-	assert(oi);
-
 	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
 		zlog_debug("Zebra Interface address add: %s %5s %pFX",
 			   c->ifp->name, prefix_family_str(c->address),
 			   c->address);
-
-	ipv6_count = connected_count_by_family(c->ifp, AF_INET6);
-	if (oi->ifmtu == OSPF6_DEFAULT_MTU && ipv6_count > OSPF6_MAX_IF_ADDRS) {
-		zlog_warn(
-			"Zebra Interface : %s has too many interface addresses %d only support %d, increase MTU",
-			c->ifp->name, ipv6_count, OSPF6_MAX_IF_ADDRS);
-		return 0;
-	} else if (oi->ifmtu >= OSPF6_JUMBO_MTU
-		   && ipv6_count > OSPF6_MAX_IF_ADDRS_JUMBO) {
-		zlog_warn(
-			"Zebra Interface : %s has too many interface addresses %d only support %d",
-			c->ifp->name, ipv6_count, OSPF6_MAX_IF_ADDRS_JUMBO);
-		return 0;
-	}
 
 	if (c->address->family == AF_INET6) {
 		ospf6_interface_state_update(c->ifp);


### PR DESCRIPTION
Revert #8622; see comments there.

While the revert doesn't fix this, it backs out code that isn't part of the correct solution.  Also I'd rather crash one router than (possibly) break the network.