### PR TITLE
ospf6d: use per-vrf router id instead of one global

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -602,7 +602,7 @@ void ospf6_router_id_update(struct ospf6 *ospf6)
 	if (ospf6->router_id_static != 0)
 		ospf6->router_id = ospf6->router_id_static;
 	else
-		ospf6->router_id = om6->zebra_router_id;
+		ospf6->router_id = ospf6->router_id_zebra;
 }
 
 /* start ospf6 */
@@ -786,8 +786,8 @@ DEFUN(no_ospf6_router_id,
 		}
 	}
 	o->router_id = 0;
-	if (o->router_id_zebra.s_addr)
-		o->router_id = (uint32_t)o->router_id_zebra.s_addr;
+	if (o->router_id_zebra)
+		o->router_id = o->router_id_zebra;
 
 	return CMD_SUCCESS;
 }

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -29,7 +29,6 @@ struct ospf6_master {
 	struct list *ospf6;
 	/* OSPFv3 thread master. */
 	struct thread_master *master;
-	in_addr_t zebra_router_id;
 };
 
 /* ospf6->config_flags */
@@ -71,7 +70,7 @@ struct ospf6 {
 	/* static router id */
 	in_addr_t router_id_static;
 
-	struct in_addr router_id_zebra;
+	in_addr_t router_id_zebra;
 
 	/* start time */
 	struct timeval starttime;

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -90,15 +90,16 @@ static int ospf6_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 
 	zebra_router_id_update_read(zclient->ibuf, &router_id);
 
-	om6->zebra_router_id = router_id.u.prefix4.s_addr;
+	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
+		zlog_debug("Zebra router-id update %pI4 vrf %s id %u",
+			   &router_id.u.prefix4, ospf6_vrf_id_to_name(vrf_id),
+			   vrf_id);
+
 	o = ospf6_lookup_by_vrf_id(vrf_id);
 	if (o == NULL)
 		return 0;
 
-	o->router_id_zebra = router_id.u.prefix4;
-	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
-		zlog_debug("%s: zebra router-id %pI4 update", __func__,
-			   &router_id.u.prefix4);
+	o->router_id_zebra = router_id.u.prefix4.s_addr;
 
 	ospf6_router_id_update(o);
 


### PR DESCRIPTION
This code was not fully completed when adding support for VRFs.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>