### PR TITLE
pimd: make show ip mroute output consistent

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6323,7 +6323,7 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 
 		if (!uj && !found_oif) {
 			vty_out(vty,
-				"%-15s %-15s %-15s %-6s %-16s %-16s %-3d  %8s\n",
+				"%-15s %-15s %-8s %-6s %-16s %-16s %-3d  %8s\n",
 				src_str, grp_str, state_str, "none", in_ifname,
 				"none", 0, "--:--:--");
 		}
@@ -6430,10 +6430,9 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 						       json_ifp_out);
 			} else {
 				vty_out(vty,
-					"%-15s %-15s %-6s %-16s %-16s %-3d  %8s %s\n",
-					src_str, grp_str, proto, in_ifname,
-					out_ifname, ttl, oif_uptime,
-					pim->vrf->name);
+					"%-15s %-15s %-8s %-6s %-16s %-16s %-3d  %8s\n",
+					src_str, grp_str, "-", proto, in_ifname,
+					out_ifname, ttl, oif_uptime);
 				if (first && !fill) {
 					src_str[0] = '\0';
 					grp_str[0] = '\0';
@@ -6445,9 +6444,9 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 
 		if (!uj && !found_oif) {
 			vty_out(vty,
-				"%-15s %-15s %-6s %-16s %-16s %-3d  %8s %s\n",
-				src_str, grp_str, proto, in_ifname, "none", 0,
-				"--:--:--", pim->vrf->name);
+				"%-15s %-15s %-8s %-6s %-16s %-16s %-3d  %8s\n",
+				src_str, grp_str, "-", proto, in_ifname, "none",
+				0, "--:--:--");
 		}
 	}
 


### PR DESCRIPTION
We had 3 different string output formats in various places.
Make them all the same.

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>