### PR TITLE
ospf6d: route-map config changed, not getting applied on all types of…

### DIFF
--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -105,7 +105,8 @@ extern void install_element_ospf6_debug_asbr(void);
 extern void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 					      struct ospf6_route *route,
 					      struct ospf6 *ospf6);
-extern void ospf6_asbr_distribute_list_update(int type, struct ospf6 *ospf6);
+extern void ospf6_asbr_distribute_list_update(struct ospf6 *ospf6,
+					      struct ospf6_redist *red);
 struct ospf6_redist *ospf6_redist_lookup(struct ospf6 *ospf6, int type,
 					 unsigned short instance);
 extern void ospf6_asbr_routemap_update(const char *mapname);

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -38,9 +38,12 @@ enum {
 	OSPF6_LOG_ADJACENCY_DETAIL =	(1 << 1),
 };
 
+/* For processing route-map change update in the callback */
+#define OSPF6_IS_RMAP_CHANGED 0x01
 struct ospf6_redist {
 	uint8_t instance;
 
+	uint8_t flag;
 	/* Redistribute metric info. */
 	struct {
 		int type;  /* External metric type (E1 or E2).  */


### PR DESCRIPTION
… routes

Problem Statement:
==================
when route-map config is changed from permit to deny, it is not getting
applied to both connected and static and vice versa

RCA:
==================
When route-map changes from permit to deny or vice versa, a notification is
sent to ospf6 daemon via ospf6_asbr_routemap_update. In this function, a thread
is scheduled after 5 seconds to apply the route-map changes. In this thread
(ospf6_asbr_routemap_update_timer), only the first type is passed as argument
and only the first type i.e "connected" is passed and hence in callback only
on this type of route route-map gets applied.

Fix:
====
Need to loop through all the route-types in the call back and process
the route-map changes. Added a flag to mark which all route-types needs
to be processed.

Test Executed:
===============
1. Change route-map from permit to deny.
2. Change route-map from deny to permit.
3. Add new route and checked.
4. Verified summarised routes.

Risk:
============
Low

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>