### PR TITLE
ospfd: show ip ospf route json does not shown metric and tag

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10913,6 +10913,8 @@ static void show_ip_ospf_route_external(struct vty *vty, struct ospf *ospf,
 						       "N E1");
 				json_object_int_add(json_route, "cost",
 						    er->cost);
+				json_object_int_add(json_route, "tag",
+						    er->u.ext.tag);
 			} else {
 				vty_out(vty,
 					"N E1 %-18s    [%d] tag: %" ROUTE_TAG_PRI
@@ -10926,6 +10928,10 @@ static void show_ip_ospf_route_external(struct vty *vty, struct ospf *ospf,
 						       "N E2");
 				json_object_int_add(json_route, "cost",
 						    er->cost);
+				json_object_int_add(json_route, "type2cost",
+						    er->u.ext.type2_cost);
+				json_object_int_add(json_route, "tag",
+						    er->u.ext.tag);
 			} else {
 				vty_out(vty,
 					"N E2 %-18s    [%d/%d] tag: %" ROUTE_TAG_PRI


### PR DESCRIPTION
ospfd: show ip ospf route json does not shown metric and tag

**Problem Statement:**
[FRR OSPF] show ip ospf route json does not shown metric and tag.

**Root Cause Analysis:**
In function show_ip_ospf_route_external, type 2 cost is not added in json.
Hence it is not displayed.

**Fix:**
1. Add type2cost in the json display
2. Tag was also missing, added that as well

Issue: #8729

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>