### PR TITLE
bgpd: associate correct nexthop when using peer link-local

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -750,6 +750,9 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 								? peer->conf_if
 								: peer->ifname,
 							peer->bgp->vrf_id);
+			else if (peer->update_if)
+				ifp = if_lookup_by_name(peer->update_if,
+							peer->bgp->vrf_id);
 		} else if (peer->update_if)
 			ifp = if_lookup_by_name(peer->update_if,
 						peer->bgp->vrf_id);


### PR DESCRIPTION
When setting bgp configuration using peers referencing link local
ipv6 addresses, the bgp should be able to handle incoming bgp
connections, and find out the appropriate interface where the
connection comes from.

ipv6 link local sessions work by using bgp unnumbered interfaces
 config, but it does not work if we have a shared media with
 multiple potential link local ipv6 addresses on the network.

The fix consists in finding out the appropriate interface, when
the local configuration references a link local ipv6 addresses.

note: this change does not solve the ability for such config to
create an outgoing connection to remote peer (as the link local
 ipv6 address config does not indicate which interface to use).

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>