### PR TITLE
tests: Cleanup test_route_map_topo1.py from pylint

### DIFF
--- a/tests/topotests/bgp_route_map/test_route_map_topo1.py
+++ b/tests/topotests/bgp_route_map/test_route_map_topo1.py
@@ -444,9 +444,10 @@ def test_route_map_inbound_outbound_same_neighbor_p0(request):
         result = verify_rib(
             tgen, adt, dut, input_dict_2, protocol=protocol, expected=False
         )
-        assert result is not True, (
-            "Testcase {} : Failed \n"
-            "routes are not present in rib \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed \nroutes are not present in rib \n Error: {}".format(
+            tc_name, result
         )
         logger.info("Expected behaviour: {}".format(result))
 
@@ -466,9 +467,10 @@ def test_route_map_inbound_outbound_same_neighbor_p0(request):
         result = verify_rib(
             tgen, adt, dut, input_dict, protocol=protocol, expected=False
         )
-        assert result is not True, (
-            "Testcase {} : Failed \n "
-            "routes are not present in rib \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed \nroutes are not present in rib \n Error: {}".format(
+            tc_name, result
         )
         logger.info("Expected behaviour: {}".format(result))
 
@@ -664,9 +666,10 @@ def test_route_map_with_action_values_combination_of_prefix_action_p0(
             result = verify_rib(
                 tgen, adt, dut, input_dict_2, protocol=protocol, expected=False
             )
-            assert result is not True, (
-                "Testcase {} : Failed \n "
-                "Routes are still present \n Error: {}".format(tc_name, result)
+            assert (
+                result is not True
+            ), "Testcase {} : Failed \nRoutes are still present \n Error: {}".format(
+                tc_name, result
             )
             logger.info("Expected behaviour: {}".format(result))
         else:


### PR DESCRIPTION
noticed that pylint was complaining about some easily
fixable stuff in test_route_map_topo1.py so let's clean
it up some.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>