### PR TITLE
topotests: speed up MSDP convergence speed

### DIFF
--- a/tests/topotests/msdp_mesh_topo1/r1/pimd.conf
+++ b/tests/topotests/msdp_mesh_topo1/r1/pimd.conf
@@ -10,6 +10,7 @@ interface r1-eth1
  ip igmp
 !
 ip pim rp 10.254.254.1
+ip msdp timers 10 20 3
 ip msdp mesh-group mg-1 source 10.254.254.1
 ip msdp mesh-group mg-1 member 10.254.254.2
 ip msdp mesh-group mg-1 member 10.254.254.3

--- a/tests/topotests/msdp_mesh_topo1/r2/pimd.conf
+++ b/tests/topotests/msdp_mesh_topo1/r2/pimd.conf
@@ -9,6 +9,7 @@ interface r2-eth1
  ip pim
 !
 ip pim rp 10.254.254.2
+ip msdp timers 10 20 3
 ip msdp mesh-group mg-1 source 10.254.254.2
 ip msdp mesh-group mg-1 member 10.254.254.1
 ip msdp mesh-group mg-1 member 10.254.254.3

--- a/tests/topotests/msdp_mesh_topo1/r3/pimd.conf
+++ b/tests/topotests/msdp_mesh_topo1/r3/pimd.conf
@@ -10,6 +10,7 @@ interface r3-eth1
  ip igmp
 !
 ip pim rp 10.254.254.3
+ip msdp timers 10 20 3
 ip msdp mesh-group mg-1 source 10.254.254.3
 ip msdp mesh-group mg-1 member 10.254.254.1
 ip msdp mesh-group mg-1 member 10.254.254.2

--- a/tests/topotests/msdp_topo1/r1/pimd.conf
+++ b/tests/topotests/msdp_topo1/r1/pimd.conf
@@ -15,6 +15,7 @@ interface r1-eth2
  ip pim
  ip igmp
 !
+ip msdp timers 10 20 3
 ip msdp peer 192.168.0.2 source 192.168.0.1
 ip msdp peer 192.168.1.2 source 192.168.1.1
 ip pim rp 10.254.254.1

--- a/tests/topotests/msdp_topo1/r2/pimd.conf
+++ b/tests/topotests/msdp_topo1/r2/pimd.conf
@@ -11,6 +11,7 @@ interface r2-eth0
 interface r2-eth1
  ip pim
 !
+ip msdp timers 10 20 3
 ip msdp peer 192.168.0.1 source 192.168.0.2
 ip msdp peer 192.168.2.2 source 192.168.2.1
 ip pim rp 10.254.254.2

--- a/tests/topotests/msdp_topo1/r3/pimd.conf
+++ b/tests/topotests/msdp_topo1/r3/pimd.conf
@@ -11,6 +11,7 @@ interface r3-eth0
 interface r3-eth1
  ip pim
 !
+ip msdp timers 10 20 3
 ip msdp peer 192.168.1.1 source 192.168.1.2
 ip msdp peer 192.168.3.2 source 192.168.3.1
 ip pim rp 10.254.254.3

--- a/tests/topotests/msdp_topo1/r4/pimd.conf
+++ b/tests/topotests/msdp_topo1/r4/pimd.conf
@@ -15,6 +15,7 @@ interface r4-eth2
  ip pim
  ip igmp
 !
+ip msdp timers 10 20 3
 ip msdp peer 192.168.2.1 source 192.168.2.2
 ip msdp peer 192.168.3.1 source 192.168.3.2
 ip pim rp 10.254.254.4


### PR DESCRIPTION
Topotests tweaks to reduce MSDP tests converge time.

 - MSDP mesh topo1: made no difference in a few runs locally.
 - MSDP topo1: Some runs saved 60 seconds reducing the total run from 120 seconds to 60 seconds, depending on how fast the routers started.