### PR TITLE
pimd: To print querierIP address on the querier and nonQuerier IGMP e…

### DIFF
--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -167,6 +167,8 @@ static int pim_igmp_other_querier_expire(struct thread *t)
 			       sizeof(ifaddr_str));
 		zlog_debug("%s: Querier %s resuming", __func__, ifaddr_str);
 	}
+	/* Mark the interface address as querier address */
+	igmp->querier_addr = igmp->ifaddr;
 
 	/*
 	  We are the current querier, then
@@ -397,6 +399,8 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 				ntohl(igmp->ifaddr.s_addr), from_str,
 				ntohl(from.s_addr));
 		}
+		if (ntohl(from.s_addr) < ntohl(igmp->querier_addr.s_addr))
+			igmp->querier_addr.s_addr = from.s_addr;
 
 		pim_igmp_other_querier_timer_on(igmp);
 	}
@@ -935,6 +939,7 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	igmp->fd = fd;
 	igmp->interface = ifp;
 	igmp->ifaddr = ifaddr;
+	igmp->querier_addr = ifaddr;
 	igmp->t_igmp_read = NULL;
 	igmp->t_igmp_query_timer = NULL;
 	igmp->t_other_querier_timer = NULL; /* no other querier present */

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -92,8 +92,8 @@ struct igmp_sock {
 	struct thread
 		*t_igmp_query_timer; /* timer: issue IGMP general queries */
 	struct thread *t_other_querier_timer; /* timer: other querier present */
-
-	int querier_query_interval;      /* QQI */
+	struct in_addr querier_addr;	  /* IP address of the querier */
+	int querier_query_interval;	   /* QQI */
 	int querier_robustness_variable; /* QRV */
 	int startup_query_count;
 


### PR DESCRIPTION
pimd: To print querierIP address on the querier and nonQuerier IGMP enabled intf

1. Add the querierIP object to igmp_sock datastruct to save the IP address of the querier.
   Management of the querierIP object is added.
2. To show the querier IP address in the CLI "show ip igmp interface".
3. To add the json object querierIP for querier IP address in the json CLI "show ip igmp interface json".

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>