### PR TITLE
lib: fix coverity unused result warning

### DIFF
--- a/lib/systemd.c
+++ b/lib/systemd.c
@@ -66,8 +66,8 @@ static void systemd_send_information(const char *info)
 		sun.sun_path[0] = '\0';
 
 	/* nothing we can do if this errors out... */
-	sendto(sock, info, strlen(info), 0, (struct sockaddr *)&sun,
-	       sizeof(sun));
+	(void)sendto(sock, info, strlen(info), 0, (struct sockaddr *)&sun,
+		     sizeof(sun));
 
 	close(sock);
 }


### PR DESCRIPTION
There's nothing that can be done here with an error.  Try to make
Coverity understand that this is intentional.

(I don't know if the `(void)` will actually fix the coverity warning,
but I don't really have a better way to figure it out beyond just
getting this merged and waiting for a result...)