### PR TITLE
workflow: add guidelines for config knobs

### DIFF
--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -898,8 +898,15 @@ preference, these are:
 
    This is the preferred way for all FRR knobs.  Not all daemons and features
    are fully YANGified yet, so in some cases new features cannot rely on a
-   YANG interface.  However, if a new feature/PR *can* implement a YANG
-   interface, it probably *should*.
+   YANG interface.  If a daemon already implements a YANG interface (even
+   partial), new CLI options must be implemented through a YANG model.
+
+   .. warning::
+
+      Unlike everything else in this section being guidelines with some slack,
+      implementing and using a YANG interface for new CLI options in (even
+      partially!) YANGified daemons is a hard requirement.
+
 
 -  at configuration/runtime, through the CLI.
 


### PR DESCRIPTION
This is essentially just a write-up of the conclusions I've been working by.  I think it's valuable to just get this down into our workflow doc to make people aware that usability is an important concern.  Telling users to rebuild FRR to change a `./configure` option is horrible UX.  Restarting FRR to change a command line option is annoying at best and a service interruption at worst.

As said in the `.. note::` at the top of this block, I'm not trying to make these rules, just trying to point out that UX is a factor that should be considered.  It's tempting to take the "easy way out" and make things command line options or build options — less cases to cover, no reconfiguration, etc.  Sometimes it's the only feasible option.  But please at least try reasonably hard :smiley: