### PR TITLE
doc: Add doc stating new yang requirement for new CLI

### DIFF
--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -864,6 +864,9 @@ comments should be eschewed in favor of a suitable ``description`` statement.
 In short, a diff between your input file and the output of ``yanglint`` should
 either be empty or contain only comments.
 
+It is also a requirement that all new CLI introduced must use YANG if the
+daemon is already converted or partially converted to YANG.
+
 Specific Exceptions
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
It is now a requirement that all new CLI must use the
YANG model if a daemon the CLI is being added to is
already converted or partially converted.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>