### PR TITLE
lib: Allow ZAPI_MESSAGE_OPAQUE_LENGTH length of data

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1537,7 +1537,7 @@ int zapi_route_decode(struct stream *s, struct zapi_route *api)
 
 	if (CHECK_FLAG(api->message, ZAPI_MESSAGE_OPAQUE)) {
 		STREAM_GETW(s, api->opaque.length);
-		assert(api->opaque.length < ZAPI_MESSAGE_OPAQUE_LENGTH);
+		assert(api->opaque.length <= ZAPI_MESSAGE_OPAQUE_LENGTH);
 
 		STREAM_GET(api->opaque.data, s, api->opaque.length);
 	}


### PR DESCRIPTION
We are sending up to ZAPI_MESSAGE_OPAQUE_LENGTH but checking
for one less.  We know the data will fit in it to that size.
Also we have asserts on the write to ensure we don't go over
it

Fixes: #8995
Signed-off-by: Donald Sharp <sharpd@nvidia.com>