### PR TITLE
pimd: When passing lookup information back pass the fully resolved

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -598,8 +598,7 @@ static const int RNH_INVALID_NH_FLAGS = (NEXTHOP_FLAG_RECURSIVE |
 					 NEXTHOP_FLAG_DUPLICATE |
 					 NEXTHOP_FLAG_RNH_FILTERED);
 
-static bool rnh_nexthop_valid(const struct route_entry *re,
-			      const struct nexthop *nh)
+bool rnh_nexthop_valid(const struct route_entry *re, const struct nexthop *nh)
 {
 	return (CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED)
 		&& CHECK_FLAG(nh->flags, NEXTHOP_FLAG_ACTIVE)

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -64,6 +64,9 @@ extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
 
 extern int rnh_resolve_via_default(struct zebra_vrf *zvrf, int family);
 
+extern bool rnh_nexthop_valid(const struct route_entry *re,
+			      const struct nexthop *nh);
+
 /* UI control to avoid notifications if backup nexthop status changes */
 void rnh_set_hide_backups(bool hide_p);
 bool rnh_get_hide_backups(void);


### PR DESCRIPTION
In the reachability code we auto pass back the fully resolved
nexthops.  Modify the ZEBRA_IPV4_NEXTHOP_LOOKUP_MRIB code
to do the exact same thing so that the zclient_lookup_nexthop
code does not need to recursively look for the data that
zebra already has.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>