### PR TITLE
Static route issues

### DIFF
--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -113,7 +113,7 @@ struct nexthop_iter {
 static int nexthop_iter_cb(const struct lyd_node *dnode, void *arg)
 {
 	struct nexthop_iter *iter = arg;
-	int nh_type;
+	enum static_types nh_type;
 
 	nh_type = yang_dnode_get_enum(dnode, "./nh-type");
 
@@ -135,7 +135,7 @@ static bool static_nexthop_create(struct nb_cb_create_args *args,
 	struct static_path *pn;
 	struct ipaddr ipaddr;
 	struct static_nexthop *nh;
-	int nh_type;
+	enum static_types nh_type;
 	const char *ifname;
 	const char *nh_vrf;
 
@@ -313,7 +313,7 @@ static int static_nexthop_mpls_label_modify(struct nb_cb_modify_args *args)
 static int static_nexthop_onlink_modify(struct nb_cb_modify_args *args)
 {
 	struct static_nexthop *nh;
-	static_types nh_type;
+	enum static_types nh_type;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -361,7 +361,7 @@ static int static_nexthop_color_destroy(struct nb_cb_destroy_args *args)
 static int static_nexthop_bh_type_modify(struct nb_cb_modify_args *args)
 {
 	struct static_nexthop *nh;
-	static_types nh_type;
+	enum static_types nh_type;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -396,7 +396,7 @@ void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_p
 	const char *ifname;
 	const char *nh_vrf;
 	struct stable_info *info;
-	int nh_type;
+	enum static_types nh_type;
 
 	nh_type = yang_dnode_get_enum(args->dnode, "./nh-type");
 	ifname = yang_dnode_get_string(args->dnode, "./interface");
@@ -429,7 +429,7 @@ void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_s
 	const char *ifname;
 	const char *nh_vrf;
 	struct stable_info *info;
-	int nh_type;
+	enum static_types nh_type;
 
 	nh_type = yang_dnode_get_enum(args->dnode, "./nh-type");
 	ifname = yang_dnode_get_string(args->dnode, "./interface");

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -152,6 +152,14 @@ static bool static_nexthop_create(struct nb_cb_create_args *args,
 				return NB_ERR_VALIDATION;
 			}
 		}
+		nh_type = yang_dnode_get_enum(args->dnode, "./nh-type");
+		nh_vrf = yang_dnode_get_string(args->dnode, "./vrf");
+		if (nh_type == STATIC_BLACKHOLE && nh_vrf) {
+			snprintf(
+				args->errmsg, args->errmsg_len,
+				"Nexthop cannot be a blackhole with a nexthop-vrf");
+			return NB_ERR_VALIDATION;
+		}
 
 		iter.count = 0;
 		iter.blackhole = false;

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -188,8 +188,8 @@ void static_del_route(struct route_node *rn, safi_t safi,
 	route_unlock_node(rn);
 }
 
-bool static_add_nexthop_validate(const char *nh_vrf_name, static_types type,
-				 struct ipaddr *ipaddr)
+bool static_add_nexthop_validate(const char *nh_vrf_name,
+				 enum static_types type, struct ipaddr *ipaddr)
 {
 	struct vrf *vrf;
 
@@ -259,7 +259,7 @@ void static_del_path(struct route_node *rn, struct static_path *pn, safi_t safi,
 
 struct static_nexthop *
 static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
-		   struct static_vrf *svrf, static_types type,
+		   struct static_vrf *svrf, enum static_types type,
 		   struct ipaddr *ipaddr, const char *ifname,
 		   const char *nh_vrf, uint32_t color)
 {
@@ -357,7 +357,7 @@ static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
 void static_install_nexthop(struct route_node *rn, struct static_path *pn,
 			    struct static_nexthop *nh, safi_t safi,
 			    struct static_vrf *svrf, const char *ifname,
-			    static_types type, const char *nh_vrf)
+			    enum static_types type, const char *nh_vrf)
 {
 	struct interface *ifp;
 
@@ -777,7 +777,7 @@ void static_ifindex_update(struct interface *ifp, bool up)
 	static_ifindex_update_af(ifp, up, AFI_IP6, SAFI_MULTICAST);
 }
 
-void static_get_nh_type(static_types stype, char *type, size_t size)
+void static_get_nh_type(enum static_types stype, char *type, size_t size)
 {
 	switch (stype) {
 	case STATIC_IFNAME:

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -45,16 +45,16 @@ enum static_blackhole_type {
 
 /*
  * The order for below macros should be in sync with
- * yang model typedef nexthop-type
+ * yang model enum nexthop-type
  */
-typedef enum {
+enum static_types {
 	STATIC_IFNAME = 1,
 	STATIC_IPV4_GATEWAY,
 	STATIC_IPV4_GATEWAY_IFNAME,
 	STATIC_IPV6_GATEWAY,
 	STATIC_IPV6_GATEWAY_IFNAME,
 	STATIC_BLACKHOLE,
-} static_types;
+};
 
 /*
  * Route Creation gives us:
@@ -117,7 +117,7 @@ struct static_nexthop {
 	enum static_install_states state;
 
 	/* Flag for this static route's type. */
-	static_types type;
+	enum static_types type;
 
 	/*
 	 * Nexthop value.
@@ -164,14 +164,14 @@ void static_fixup_vrf_ids(struct static_vrf *svrf);
 
 extern struct static_nexthop *
 static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
-		   struct static_vrf *svrf, static_types type,
+		   struct static_vrf *svrf, enum static_types type,
 		   struct ipaddr *ipaddr, const char *ifname,
 		   const char *nh_vrf, uint32_t color);
 extern void static_install_nexthop(struct route_node *rn,
 				   struct static_path *pn,
 				   struct static_nexthop *nh, safi_t safi,
 				   struct static_vrf *svrf, const char *ifname,
-				   static_types type, const char *nh_vrf);
+				   enum static_types type, const char *nh_vrf);
 
 extern int static_delete_nexthop(struct route_node *rn, struct static_path *pn,
 				 safi_t safi, struct static_vrf *svrf,
@@ -198,9 +198,10 @@ extern struct static_path *static_add_path(struct route_node *rn,
 extern void static_del_path(struct route_node *rn, struct static_path *pn,
 			    safi_t safi, struct static_vrf *svrf);
 
-extern void static_get_nh_type(static_types stype, char *type, size_t size);
+extern void static_get_nh_type(enum static_types stype, char *type,
+			       size_t size);
 extern bool static_add_nexthop_validate(const char *nh_vrf_name,
-					static_types type,
+					enum static_types type,
 					struct ipaddr *ipaddr);
 extern struct stable_info *static_get_stable_info(struct route_node *rn);
 extern void static_route_info_init(struct static_route_info *si);


### PR DESCRIPTION
1) We don't use typedefs
2) Dissallow the `ip route 4.5.6.7/32 blackhole nexthop-vrf X` command
3) handle the situation better where blackhole and reject are parsed as interfaces.