### PR TITLE
zebra: [7.5] handle "show evpn es-evi" a non-existent VNI

### DIFF
--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -355,11 +355,11 @@ void zebra_evpn_es_evi_show_vni(struct vty *vty, bool uj, vni_t vni, int detail)
 			vty_out(vty, "Type: L local, R remote\n");
 			vty_out(vty, "%-8s %-30s %-4s\n", "VNI", "ESI", "Type");
 		}
+		zebra_evpn_es_evi_show_one_evpn(zevpn, vty, json, detail);
 	} else {
 		if (!uj)
 			vty_out(vty, "VNI %d doesn't exist\n", vni);
 	}
-	zebra_evpn_es_evi_show_one_evpn(zevpn, vty, json, detail);
 }
 
 /* Initialize the ES tables maintained per-L2_VNI */


### PR DESCRIPTION
zebra was crashing when the command was run on a non-existent VNI.

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
root@torm-12:mgmt:~# net show evpn es-evi vni 16777215
VNI 16777215 doesn't exist
root@torm-12:mgmt:~# net show evpn es-evi vni 16777215 detail
VNI 16777215 doesn't exist
root@torm-12:mgmt:~# net show evpn es-evi vni 16777215 json
[
]
root@torm-12:mgmt:~# net show evpn es-evi vni 16777215 detail json
[
]
root@torm-12:mgmt:~#
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

Ticket: CM-30232

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>

Closes https://github.com/FRRouting/frr/issues/9008