### PR TITLE
doc,lib,ospfd,ospf6d: trivial improvements

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -85,6 +85,61 @@ OSPF6 router
    change to take effect, user can use this cli instead of restarting the
    ospf6d daemon.
 
+.. _ospf6-debugging:
+
+OSPFv3 Debugging
+================
+
+The following debug commands are supported:
+
+.. clicmd:: debug ospf6 abr
+
+   Toggle OSPFv3 ABR debugging messages.
+
+.. clicmd:: debug ospf6 asbr
+
+   Toggle OSPFv3 ASBR debugging messages.
+
+.. clicmd:: debug ospf6 border-routers
+
+   Toggle OSPFv3 border router debugging messages.
+
+.. clicmd:: debug ospf6 flooding
+
+   Toggle OSPFv3 flooding debugging messages.
+
+.. clicmd:: debug ospf6 interface
+
+   Toggle OSPFv3 interface related debugging messages.
+
+.. clicmd:: debug ospf6 lsa
+
+   Toggle OSPFv3 Link State Advertisements debugging messages.
+
+.. clicmd:: debug ospf6 message
+
+   Toggle OSPFv3 message exchange debugging messages.
+
+.. clicmd:: debug ospf6 neighbor
+
+   Toggle OSPFv3 neighbor interaction debugging messages.
+
+.. clicmd:: debug ospf6 nssa
+
+   Toggle OSPFv3 Not So Stubby Area (NSSA) debugging messages.
+
+.. clicmd:: debug ospf6 route
+
+   Toggle OSPFv3 routes debugging messages.
+
+.. clicmd:: debug ospf6 spf
+
+   Toggle OSPFv3 Shortest Path calculation debugging messages.
+
+.. clicmd:: debug ospf6 zebra
+
+   Toggle OSPFv3 zebra interaction debugging messages.
+
 .. _ospf6-area:
 
 OSPF6 area

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -537,20 +537,32 @@ static inline int ipv4_martian(struct in_addr *addr)
 	return 0;
 }
 
-static inline int is_default_prefix(const struct prefix *p)
+static inline bool is_default_prefix4(const struct prefix_ipv4 *p)
 {
-	if (!p)
-		return 0;
+	return p && p->family == AF_INET && p->prefixlen == 0
+	       && p->prefix.s_addr == INADDR_ANY;
+}
 
-	if ((p->family == AF_INET) && (p->u.prefix4.s_addr == INADDR_ANY)
-	    && (p->prefixlen == 0))
-		return 1;
+static inline bool is_default_prefix6(const struct prefix_ipv6 *p)
+{
+	return p && p->family == AF_INET6 && p->prefixlen == 0
+	       && memcmp(&p->prefix, &in6addr_any, sizeof(struct in6_addr))
+			  == 0;
+}
 
-	if ((p->family == AF_INET6) && (p->prefixlen == 0)
-	    && (!memcmp(&p->u.prefix6, &in6addr_any, sizeof(struct in6_addr))))
-		return 1;
+static inline bool is_default_prefix(const struct prefix *p)
+{
+	if (p == NULL)
+		return false;
 
-	return 0;
+	switch (p->family) {
+	case AF_INET:
+		return is_default_prefix4((const struct prefix_ipv4 *)p);
+	case AF_INET6:
+		return is_default_prefix6((const struct prefix_ipv6 *)p);
+	}
+
+	return false;
 }
 
 static inline int is_host_route(const struct prefix *p)

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -194,16 +194,6 @@ static int ospf6_zebra_if_address_update_delete(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int is_prefix_default(struct prefix_ipv6 *p)
-{
-	struct prefix_ipv6 q = {};
-
-	q.family = AF_INET6;
-	q.prefixlen = 0;
-
-	return prefix_same((struct prefix *)p, (struct prefix *)&q);
-}
-
 static int ospf6_zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	struct zapi_route api;
@@ -239,7 +229,7 @@ static int ospf6_zebra_read_route(ZAPI_CALLBACK_ARGS)
 			ifindex, api.tag);
 
 	memcpy(&p, &api.prefix, sizeof(p));
-	if (is_prefix_default(&p))
+	if (is_default_prefix6(&p))
 		api.type = DEFAULT_ROUTE;
 
 	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -334,7 +334,7 @@ void ospf_redistribute_withdraw(struct ospf *ospf, uint8_t type,
 
 		struct ospf_external_aggr_rt *aggr;
 
-		if (is_prefix_default(&ei->p)
+		if (is_default_prefix4(&ei->p)
 		    && ospf->default_originate != DEFAULT_ORIGINATE_NONE)
 			continue;
 
@@ -862,7 +862,7 @@ static void ospf_handle_external_aggr_add(struct ospf *ospf)
 					continue;
 
 				ei = rn->info;
-				if (is_prefix_default(&ei->p))
+				if (is_default_prefix4(&ei->p))
 					continue;
 
 				/* Check the AS-external-LSA

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -98,14 +98,14 @@ struct external_info *ospf_external_info_check(struct ospf *ospf,
 		int redist_on = 0;
 
 		redist_on =
-			is_prefix_default(&p)
+			is_default_prefix4(&p)
 				? vrf_bitmap_check(
-					  zclient->default_information[AFI_IP],
-					  ospf->vrf_id)
+					zclient->default_information[AFI_IP],
+					ospf->vrf_id)
 				: (zclient->mi_redist[AFI_IP][type].enabled
 				   || vrf_bitmap_check(
-					      zclient->redist[AFI_IP][type],
-					      ospf->vrf_id));
+					   zclient->redist[AFI_IP][type],
+					   ospf->vrf_id));
 		// Pending: check for MI above.
 		if (redist_on) {
 			ext_list = ospf->external[type];
@@ -128,7 +128,7 @@ struct external_info *ospf_external_info_check(struct ospf *ospf,
 		}
 	}
 
-	if (is_prefix_default(&p) && ospf->external[DEFAULT_ROUTE]) {
+	if (is_default_prefix4(&p) && ospf->external[DEFAULT_ROUTE]) {
 		ext_list = ospf->external[DEFAULT_ROUTE];
 
 		for (ALL_LIST_ELEMENTS_RO(ext_list, node, ext)) {

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -1551,8 +1551,8 @@ static void ospf_external_lsa_body_set(struct stream *s,
 	stream_put_ipv4(s, mask.s_addr);
 
 	/* If prefix is default, specify DEFAULT_ROUTE. */
-	type = is_prefix_default(&ei->p) ? DEFAULT_ROUTE : ei->type;
-	instance = is_prefix_default(&ei->p) ? 0 : ei->instance;
+	type = is_default_prefix4(&ei->p) ? DEFAULT_ROUTE : ei->type;
+	instance = is_default_prefix4(&ei->p) ? 0 : ei->instance;
 
 	mtype = (ROUTEMAP_METRIC_TYPE(ei) != -1)
 			? ROUTEMAP_METRIC_TYPE(ei)
@@ -1947,17 +1947,6 @@ struct ospf_lsa *ospf_translated_nssa_refresh(struct ospf *ospf,
 	return new;
 }
 
-int is_prefix_default(struct prefix_ipv4 *p)
-{
-	struct prefix_ipv4 q;
-
-	q.family = AF_INET;
-	q.prefix.s_addr = INADDR_ANY;
-	q.prefixlen = 0;
-
-	return prefix_same((struct prefix *)p, (struct prefix *)&q);
-}
-
 /* Originate an AS-external-LSA, install and flood. */
 struct ospf_lsa *ospf_external_lsa_originate(struct ospf *ospf,
 					     struct external_info *ei)
@@ -2113,8 +2102,7 @@ void ospf_external_lsa_rid_change(struct ospf *ospf)
 				if (!ei)
 					continue;
 
-				if (is_prefix_default(
-					    (struct prefix_ipv4 *)&ei->p))
+				if (is_default_prefix4(&ei->p))
 					continue;
 
 				lsa = ospf_external_info_find_lsa(ospf, &ei->p);
@@ -2284,7 +2272,7 @@ void ospf_external_lsa_refresh_type(struct ospf *ospf, uint8_t type,
 		     rn = route_next(rn)) {
 			ei = rn->info;
 			if (ei) {
-				if (!is_prefix_default(&ei->p)) {
+				if (!is_default_prefix4(&ei->p)) {
 					struct ospf_lsa *lsa;
 					struct ospf_external_aggr_rt *aggr;
 

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -331,7 +331,6 @@ extern void ospf_lsa_maxage_delete(struct ospf *, struct ospf_lsa *);
 
 extern void ospf_discard_from_db(struct ospf *, struct ospf_lsdb *,
 				 struct ospf_lsa *);
-extern int is_prefix_default(struct prefix_ipv4 *);
 
 extern int metric_type(struct ospf *, uint8_t, unsigned short);
 extern int metric_value(struct ospf *, uint8_t, unsigned short);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10027,7 +10027,7 @@ DEFUN (ospf_external_route_aggregation,
 
 	str2prefix_ipv4(argv[idx]->arg, &p);
 
-	if (is_prefix_default(&p)) {
+	if (is_default_prefix4(&p)) {
 		vty_out(vty,
 			"Default address shouldn't be configured as summary address.\n");
 		return CMD_SUCCESS;
@@ -10068,7 +10068,7 @@ DEFUN (no_ospf_external_route_aggregation,
 
 	str2prefix_ipv4(argv[idx]->arg, &p);
 
-	if (is_prefix_default(&p)) {
+	if (is_default_prefix4(&p)) {
 		vty_out(vty,
 			"Default address shouldn't be configured as summary address.\n");
 		return CMD_SUCCESS;
@@ -10361,7 +10361,7 @@ DEFUN (ospf_external_route_aggregation_no_adrvertise,
 
 	str2prefix_ipv4(argv[idx]->arg, &p);
 
-	if (is_prefix_default(&p)) {
+	if (is_default_prefix4(&p)) {
 		vty_out(vty,
 			"Default address shouldn't be configured as summary address.\n");
 		return CMD_SUCCESS;
@@ -10397,7 +10397,7 @@ DEFUN (no_ospf_external_route_aggregation_no_adrvertise,
 
 	str2prefix_ipv4(argv[idx]->arg, &p);
 
-	if (is_prefix_default(&p)) {
+	if (is_default_prefix4(&p)) {
 		vty_out(vty,
 			"Default address shouldn't be configured as summary address.\n");
 		return CMD_SUCCESS;

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -933,7 +933,7 @@ static int ospf_external_lsa_originate_check(struct ospf *ospf,
 	}
 
 	/* Take care of default-originate. */
-	if (is_prefix_default(&ei->p))
+	if (is_default_prefix4(&ei->p))
 		if (ospf->default_originate == DEFAULT_ORIGINATE_NONE) {
 			zlog_info(
 				"LSA[Type5:0.0.0.0]: Not originate AS-external-LSA for default");
@@ -1089,8 +1089,8 @@ int ospf_redistribute_check(struct ospf *ospf, struct external_info *ei,
 	struct route_map_set_values save_values;
 	struct prefix_ipv4 *p = &ei->p;
 	struct ospf_redist *red;
-	uint8_t type = is_prefix_default(&ei->p) ? DEFAULT_ROUTE : ei->type;
-	unsigned short instance = is_prefix_default(&ei->p) ? 0 : ei->instance;
+	uint8_t type = is_default_prefix4(&ei->p) ? DEFAULT_ROUTE : ei->type;
+	unsigned short instance = is_default_prefix4(&ei->p) ? 0 : ei->instance;
 	route_tag_t saved_tag = 0;
 
 	/* Default is handled differently. */
@@ -1213,7 +1213,7 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 	 * originate)ZEBRA_ROUTE_MAX is used to delete the ex-info.
 	 * Resolved this inconsistency by maintaining same route type.
 	 */
-	if (is_prefix_default(&p))
+	if (is_default_prefix4(&p))
 		rt_type = DEFAULT_ROUTE;
 
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_REDISTRIBUTE))
@@ -1252,7 +1252,7 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 			return 0;
 		}
 		if (ospf->router_id.s_addr != INADDR_ANY) {
-			if (is_prefix_default(&p))
+			if (is_default_prefix4(&p))
 				ospf_external_lsa_refresh_default(ospf);
 			else {
 				struct ospf_external_aggr_rt *aggr;
@@ -1374,7 +1374,7 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 			ospf_external_info_delete(ospf, rt_type, api.instance,
 						  p);
 
-			if (is_prefix_default(&p))
+			if (is_default_prefix4(&p))
 				ospf_external_lsa_refresh_default(ospf);
 			else
 				ospf_external_lsa_flush(ospf, rt_type, &p,
@@ -1471,7 +1471,7 @@ static int ospf_distribute_list_update_timer(struct thread *thread)
 				if (!ei)
 					continue;
 
-				if (is_prefix_default(&ei->p))
+				if (is_default_prefix4(&ei->p))
 					default_refresh = 1;
 				else {
 					struct ospf_external_aggr_rt *aggr;


### PR DESCRIPTION
Summary
---

Changes
 - Remove some code by removing duplicated functionality: use `is_default_prefix` instead of implementing it again
 - Document OSPFv3 debug commands
 - Rework default-information configuration show code

I found these while working on OSPFv3 so I want to try to get these merged before my next PR.


Note
----

I tried to use the `transparent union` feature for `is_default_prefix` to accept all kinds of `struct prefix *` but the CI failed on all its variants. You can see all my attempts here:
 - https://github.com/opensourcerouting/frr/commit/dc40fc1fd5a5abcbcb7b06ecebf59136d4058dc9
 - https://github.com/opensourcerouting/frr/commit/36d4f18514bfc0db94d8d6e6835f052649ae90e0
 - https://github.com/opensourcerouting/frr/commit/75b79cc05e0f03dda1eacaad941102c78e320ef0

The analyzer always assumes that someone with a `struct prefix_ipv4 *` will inevitably call `is_default_prefix` with `family = AF_INET6` and so it always marks it as warning causing the CI to fail.

Warning message:

```
  In function ‘is_default_prefix’,
      inlined from ‘ospf_zebra_read_route’ at ospfd/ospf_zebra.c:1377:8:
  ./lib/prefix.h:552:11: error: ‘__builtin_memcmp_eq’ reading 16 bytes from a region of size 8 [-Werror=stringop-overflow=]
    552 |      && (!memcmp(&p->u.prefix6, &in6addr_any, sizeof(struct in6_addr))))
        |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```