### PR TITLE
Refactor decoder for Lua hook system

### DIFF
--- a/doc/developer/scripting.rst
+++ b/doc/developer/scripting.rst
@@ -488,12 +488,6 @@ match *exactly*.
 In the above example, we defined encoders/decoders for a value of
 ``struct prefix *``, but not ``struct prefix`` or ``const struct prefix *``.
 
-``const`` values are a special case. We want to use them in our Lua scripts
-but not modify them, so creating a decoder for them would be meaningless.
-But we still need a decoder for the type of value so that the compiler will be
-satisfied.
-For that, use ``lua_decode_noop``:
-
 .. code-block:: diff
 
      #define DECODE_ARGS_WITH_STATE(L, value) \

--- a/lib/frrlua.c
+++ b/lib/frrlua.c
@@ -274,7 +274,7 @@ void lua_decode_integerp(lua_State *L, int idx, int *num)
 
 void *lua_tointegerp(lua_State *L, int idx)
 {
-	int *num = XCALLOC(MTYPE_TMP, sizeof(int));
+	int *num = XCALLOC(MTYPE_SCRIPT_RES, sizeof(int));
 
 	lua_decode_integerp(L, idx, num);
 	return num;
@@ -348,7 +348,7 @@ void lua_decode_longlongp(lua_State *L, int idx, long long *num)
 
 void *lua_tolonglongp(lua_State *L, int idx)
 {
-	long long *num = XCALLOC(MTYPE_TMP, sizeof(long long));
+	long long *num = XCALLOC(MTYPE_SCRIPT_RES, sizeof(long long));
 
 	lua_decode_longlongp(L, idx, num);
 	return num;

--- a/lib/frrlua.c
+++ b/lib/frrlua.c
@@ -346,21 +346,6 @@ void *lua_tostringp(lua_State *L, int idx)
 }
 
 /*
- * Decoder for const values, since we cannot modify them.
- */
-void lua_decode_noop(lua_State *L, int idx, const void *ptr)
-{
-}
-
-
-/*
- * Noop decoder for int.
- */
-void lua_decode_integer_noop(lua_State *L, int idx, int i)
-{
-}
-
-/*
  * Logging.
  *
  * Lua-compatible wrappers for FRR logging functions.

--- a/lib/frrlua.c
+++ b/lib/frrlua.c
@@ -259,12 +259,12 @@ void *lua_tosockunion(lua_State *L, int idx)
 	return su;
 }
 
-void lua_pushintegerp(lua_State *L, const long long *num)
+void lua_pushintegerp(lua_State *L, const int *num)
 {
 	lua_pushinteger(L, *num);
 }
 
-void lua_decode_integerp(lua_State *L, int idx, long long *num)
+void lua_decode_integerp(lua_State *L, int idx, int *num)
 {
 	int isnum;
 	*num = lua_tonumberx(L, idx, &isnum);
@@ -274,7 +274,7 @@ void lua_decode_integerp(lua_State *L, int idx, long long *num)
 
 void *lua_tointegerp(lua_State *L, int idx)
 {
-	long long *num = XCALLOC(MTYPE_SCRIPT_RES, sizeof(long long));
+	int *num = XCALLOC(MTYPE_TMP, sizeof(int));
 
 	lua_decode_integerp(L, idx, num);
 	return num;
@@ -330,6 +330,28 @@ void lua_pushnexthop_group(lua_State *L, const struct nexthop_group *ng)
 		lua_seti(L, -2, i);
 		i++;
 	}
+}
+
+void lua_pushlonglongp(lua_State *L, const long long *num)
+{
+	/* lua library function; this can take a long long */
+	lua_pushinteger(L, *num);
+}
+
+void lua_decode_longlongp(lua_State *L, int idx, long long *num)
+{
+	int isnum;
+	*num = lua_tonumberx(L, idx, &isnum);
+	lua_pop(L, 1);
+	assert(isnum);
+}
+
+void *lua_tolonglongp(lua_State *L, int idx)
+{
+	long long *num = XCALLOC(MTYPE_TMP, sizeof(long long));
+
+	lua_decode_longlongp(L, idx, num);
+	return num;
 }
 
 void lua_decode_stringp(lua_State *L, int idx, char *str)

--- a/lib/frrlua.h
+++ b/lib/frrlua.h
@@ -121,9 +121,9 @@ void lua_pushnexthop(lua_State *L, const struct nexthop *nexthop);
 /*
  * Converts an int to a Lua value and pushes it on the stack.
  */
-void lua_pushintegerp(lua_State *L, const long long *num);
+void lua_pushintegerp(lua_State *L, const int *num);
 
-void lua_decode_integerp(lua_State *L, int idx, long long *num);
+void lua_decode_integerp(lua_State *L, int idx, int *num);
 
 /*
  * Converts the Lua value at idx to an int.
@@ -132,6 +132,21 @@ void lua_decode_integerp(lua_State *L, int idx, long long *num);
  *    int allocated with MTYPE_TMP.
  */
 void *lua_tointegerp(lua_State *L, int idx);
+
+/*
+ * Converts a long long to a Lua value and pushes it on the stack.
+ */
+void lua_pushlonglongp(lua_State *L, const long long *num);
+
+void lua_decode_longlongp(lua_State *L, int idx, long long *num);
+
+/*
+ * Converts the Lua value at idx to a long long.
+ *
+ * Returns:
+ *    long long allocated with MTYPE_TMP.
+ */
+void *lua_tolonglongp(lua_State *L, int idx);
 
 void lua_decode_stringp(lua_State *L, int idx, char *str);
 

--- a/lib/frrlua.h
+++ b/lib/frrlua.h
@@ -144,13 +144,6 @@ void lua_decode_stringp(lua_State *L, int idx, char *str);
 void *lua_tostringp(lua_State *L, int idx);
 
 /*
- * No-op decoders
- */
-void lua_decode_noop(lua_State *L, int idx, const void *ptr);
-
-void lua_decode_integer_noop(lua_State *L, int idx, int i);
-
-/*
  * Retrieve an integer from table on the top of the stack.
  *
  * key

--- a/lib/frrscript.c
+++ b/lib/frrscript.c
@@ -25,6 +25,8 @@ DEFINE_MTYPE_STATIC(LIB, SCRIPT, "Scripting");
 
 struct frrscript_names_head frrscript_names_hash;
 
+void _lua_decode_noop(lua_State *L, ...) {}
+
 /*
  * Wrapper for frrscript_names_add
  * Use this to register hook calls when a daemon starts up

--- a/lib/frrscript.h
+++ b/lib/frrscript.h
@@ -197,8 +197,9 @@ void _lua_decode_noop(lua_State *, ...);
 #define ENCODE_ARGS_WITH_STATE(L, value)                                       \
 	_Generic((value), \
 int : lua_pushinteger,                                          \
+int * : lua_pushintegerp,                                       \
 long long : lua_pushinteger,                                    \
-long long * : lua_pushintegerp,                                 \
+long long * : lua_pushlonglongp,                                \
 struct prefix * : lua_pushprefix,                               \
 struct interface * : lua_pushinterface,                         \
 struct in_addr * : lua_pushinaddr,                              \
@@ -217,8 +218,8 @@ struct zebra_dplane_ctx * : lua_pushzebra_dplane_ctx            \
 
 #define DECODE_ARGS_WITH_STATE(L, value)                                       \
 	_Generic((value), \
-int : lua_decode_integer_noop,                                  \
-long long * : lua_decode_integerp,                              \
+int * : lua_decode_integerp,                                    \
+long long * : lua_decode_longlongp,                             \
 struct prefix * : lua_decode_prefix,                            \
 struct interface * : lua_decode_interface,                      \
 struct in_addr * : lua_decode_inaddr,                           \

--- a/lib/frrscript.h
+++ b/lib/frrscript.h
@@ -197,6 +197,7 @@ void _lua_decode_noop(lua_State *, ...);
 #define ENCODE_ARGS_WITH_STATE(L, value)                                       \
 	_Generic((value), \
 int : lua_pushinteger,                                          \
+long long : lua_pushinteger,                                    \
 long long * : lua_pushintegerp,                                 \
 struct prefix * : lua_pushprefix,                               \
 struct interface * : lua_pushinterface,                         \

--- a/lib/frrscript.h
+++ b/lib/frrscript.h
@@ -181,6 +181,11 @@ void frrscript_fini(void);
 	} while (0)
 
 /*
+ * Noop function. Used below where we need a noop decoder for any type.
+ */
+void _lua_decode_noop(lua_State *, ...);
+
+/*
  * Maps the type of value to its encoder/decoder.
  * Add new mappings here.
  *
@@ -220,13 +225,7 @@ struct in6_addr * : lua_decode_in6addr,                         \
 union sockunion * : lua_decode_sockunion,                       \
 char * : lua_decode_stringp,                                    \
 struct attr * : lua_decode_attr,                                \
-struct peer * : lua_decode_noop,                                \
-const struct prefix * : lua_decode_noop,                        \
-const struct ipaddr * : lua_decode_noop,                        \
-const struct ethaddr * : lua_decode_noop,                       \
-const struct nexthop_group * : lua_decode_noop,                 \
-const struct nexthop * : lua_decode_noop,                       \
-struct zebra_dplane_ctx * : lua_decode_noop                     \
+default : _lua_decode_noop                                      \
 )((L), -1, (value))
 
 /*

--- a/tests/lib/test_frrlua.c
+++ b/tests/lib/test_frrlua.c
@@ -13,12 +13,20 @@ static void test_encode_decode(void)
 {
 	lua_State *L = luaL_newstate();
 
-	long long a = 123;
-	long long b = a;
+	int a = 123;
+	int b = a;
 
 	lua_pushintegerp(L, &a);
 	lua_decode_integerp(L, -1, &a);
 	assert(a == b);
+	assert(lua_gettop(L) == 0);
+
+	long long ll_a = 123L;
+	long long ll_b = a;
+
+	lua_pushlonglongp(L, &ll_a);
+	lua_decode_longlongp(L, -1, &ll_a);
+	assert(ll_a == ll_b);
 	assert(lua_gettop(L) == 0);
 
 	time_t time_a = 100;

--- a/tests/lib/test_frrscript.c
+++ b/tests/lib/test_frrscript.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
 	assert(result == 0);
 	result = frrscript_call(fs, "bar", ("a", &a), ("b", &b));
 	assert(result == 0);
-	long long *cptr = frrscript_get_result(fs, "bar", "c", lua_tointegerp);
+	long long *cptr = frrscript_get_result(fs, "bar", "c", lua_tolonglongp);
 
 	/* a should not occur in the returned table in script */
 	assert(a == 100);
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
 	result = frrscript_call(fs, "fact", ("n", &n));
 	assert(result == 0);
 	long long *ansptr =
-		frrscript_get_result(fs, "fact", "ans", lua_tointegerp);
+		frrscript_get_result(fs, "fact", "ans", lua_tolonglongp);
 	assert(*ansptr == 120);
 
 	/* check consecutive call + get_result without re-loading */


### PR DESCRIPTION
 - Add noop decoder, this replaces my `const void*` noop decoder
 - Rename and create decoders for int, int*, long long, long long *
 - Fix bgp_routemap.c cast (it was casting from int* to long long*, changed it to int*)

---

So we have encoders and decoders. Encoders encode types from C -> Lua, decoders the other way. But decoders doesn't work for all types.

Breaking it down, we have three types:
 1. non cost qualified pointer types (e.g. int*)
 2. const qualified pointer types (e.g. const int *)
 3. everything else, lets call these value types (e.g. int)

We want to be able to encode all three types, but we can really only decode non const qualified pointer types. The other two types, we want them to noop. e.g. I have integer values I encode into frrscript, but I don't want to/can decode these back to C space.

Currently: frrscript_call knows which decoder to call by [dispatching](https://github.com/FRRouting/frr/blob/master/lib/frrscript.h#L149) its type with _Generic, then calling whatever that is replaced by with (L, -1, value)
```
#define DECODE_ARGS_WITH_STATE(L, value)
	_Generic((value),
long long * : lua_decode_integerp, 
...                  
)(L, -1, value)
```
e.g. for `long long *`: `_Generic(...) (L, -1, value)` is replaced by `lua_decode_integerp (L, -1, value)`.

Possible solution:
For const qualified pointer types, I had [lua_decode_noop](https://github.com/FRRouting/frr/blob/master/lib/frrlua.h#L167), which takes a `const void *` as its third argument, making it "polymorphic" over const pointers. However, this doesn't work for value types (can't make a function that takes `void`).

Possible solution for value types: keep manually adding on noop decoders
```
#define DECODE_ARGS_WITH_STATE(L, value)
	_Generic((value),
long long : lua_decode_longlong_noop, 
...                  
)(L, -1, value)

// implementation:
void lua_decode_longlong_noop(... long long ll) {};
```

However, this isn't really nice either. So what I really want is a noop function that can take any type (as one of its arguments).
Looking at C [lambdas with ](https://stackoverflow.com/questions/59990270/how-does-the-lambda-macro-create-a-lambda)macros, I created a similar [macro](https://github.com/FRRouting/frr/pull/9012/commits/9c14b03b7ca1c3fa5b75b2923afd8f0c775ae684#) to accept any type as its third argument. This replaces my previous noop decoder for const qualified pointer types.

I can refactor out the lambda to compiler.h if we can see this lambda macro being useful.
