### PR TITLE
bgpd: Inconsistency in Local BGP GR state.

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -258,10 +258,6 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	peer->last_reset = from_peer->last_reset;
 	peer->max_packet_size = from_peer->max_packet_size;
 
-	peer->peer_gr_present_state = from_peer->peer_gr_present_state;
-	peer->peer_gr_new_status_flag = from_peer->peer_gr_new_status_flag;
-	bgp_peer_gr_flags_update(peer);
-
 	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(peer->bgp,
 							  peer->bgp->peer);
 


### PR DESCRIPTION
Problem: Sometimes the configured Local GR state is not reflected in
show command and peer node. This is causing failures in few of the
BGP-GR topotests.

RCA: This problem is seen when the configuration of local GR state
happens when the BGP session is in OpenSent state and  moves to
Established after the configuration is complete.
When the session gets established, we move the GR state value from stub peer
to the config peer. This will result in overriding the GR state to
previous value.

Fix: The local GR state is modified only through CLI configuration and
does not change during BGP FSM transition. In this case it is not necessary
to transfer the GR state value from stub peer to config peer. This way we
can ensure that always the most recent config value is present in peer
datastructure.

Signed-off-by: Prerana-GB <prerana@vmware.com>