### PR TITLE
staticd: simplify the northbound code

### DIFF
--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -77,32 +77,41 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 	return NB_OK;
 }
 
-static void static_path_list_destroy(struct nb_cb_destroy_args *args,
-				     const struct lyd_node *rn_dnode,
-				     struct stable_info *info)
+static int static_path_list_destroy(struct nb_cb_destroy_args *args)
 {
-	struct route_node *rn;
 	struct static_path *pn;
 
-	pn = nb_running_unset_entry(args->dnode);
-	rn = nb_running_get_entry(rn_dnode, NULL, true);
-	static_del_path(rn, pn, info->safi, info->svrf);
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		pn = nb_running_unset_entry(args->dnode);
+		static_del_path(pn);
+		break;
+	}
+
+	return NB_OK;
 }
 
-static void static_path_list_tag_modify(struct nb_cb_modify_args *args,
-					const struct lyd_node *rn_dnode,
-					struct stable_info *info)
+static int static_path_list_tag_modify(struct nb_cb_modify_args *args)
 {
 	struct static_path *pn;
-	struct route_node *rn;
-	route_tag_t tag;
 
-	tag = yang_dnode_get_uint32(args->dnode, NULL);
-	pn = nb_running_get_entry(args->dnode, NULL, true);
-	pn->tag = tag;
-	rn = nb_running_get_entry(rn_dnode, NULL, true);
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_ABORT:
+	case NB_EV_PREPARE:
+		break;
+	case NB_EV_APPLY:
+		pn = nb_running_get_entry(args->dnode, NULL, true);
+		pn->tag = yang_dnode_get_uint32(args->dnode, NULL);
+		static_install_path(pn);
+		break;
+	}
 
-	static_install_path(rn, pn, info->safi, info->svrf);
+	return NB_OK;
 }
 
 struct nexthop_iter {
@@ -125,13 +134,10 @@ static int nexthop_iter_cb(const struct lyd_node *dnode, void *arg)
 	return YANG_ITER_CONTINUE;
 }
 
-static bool static_nexthop_create(struct nb_cb_create_args *args,
-				  const struct lyd_node *rn_dnode,
-				  struct stable_info *info)
+static bool static_nexthop_create(struct nb_cb_create_args *args)
 {
 	const struct lyd_node *pn_dnode;
 	struct nexthop_iter iter;
-	struct route_node *rn;
 	struct static_path *pn;
 	struct ipaddr ipaddr;
 	struct static_nexthop *nh;
@@ -176,7 +182,6 @@ static bool static_nexthop_create(struct nb_cb_create_args *args,
 		ifname = yang_dnode_get_string(args->dnode, "./interface");
 		nh_vrf = yang_dnode_get_string(args->dnode, "./vrf");
 		pn = nb_running_get_entry(args->dnode, NULL, true);
-		rn = nb_running_get_entry(rn_dnode, NULL, true);
 
 		if (!static_add_nexthop_validate(nh_vrf, nh_type, &ipaddr))
 			flog_warn(
@@ -184,8 +189,8 @@ static bool static_nexthop_create(struct nb_cb_create_args *args,
 				"Warning!! Local connected address is configured as Gateway IP((%s))",
 				yang_dnode_get_string(args->dnode,
 						      "./gateway"));
-		nh = static_add_nexthop(rn, pn, info->safi, info->svrf, nh_type,
-					&ipaddr, ifname, nh_vrf, 0);
+		nh = static_add_nexthop(pn, nh_type, &ipaddr, ifname, nh_vrf,
+					0);
 		nb_running_set_entry(args->dnode, nh);
 		break;
 	}
@@ -193,33 +198,19 @@ static bool static_nexthop_create(struct nb_cb_create_args *args,
 	return NB_OK;
 }
 
-static bool static_nexthop_destroy(struct nb_cb_destroy_args *args,
-				   const struct lyd_node *rn_dnode,
-				   struct stable_info *info)
+static bool static_nexthop_destroy(struct nb_cb_destroy_args *args)
 {
-	struct route_node *rn;
-	struct static_path *pn;
-	const struct lyd_node *pn_dnode;
 	struct static_nexthop *nh;
-	int ret;
 
-	nh = nb_running_unset_entry(args->dnode);
-	pn_dnode = yang_dnode_get_parent(args->dnode, "path-list");
-	pn = nb_running_get_entry(pn_dnode, NULL, true);
-	rn = nb_running_get_entry(rn_dnode, NULL, true);
-
-	ret = static_delete_nexthop(rn, pn, info->safi, info->svrf, nh);
-	if (!ret) {
-		char buf[SRCDEST2STR_BUFFER];
-
-		flog_warn(EC_LIB_NB_CB_CONFIG_APPLY,
-			  "%s : nh [%d:%s:%s:%s] nexthop destroy failed",
-			  srcdest_rnode2str(rn, buf, sizeof(buf)),
-			  yang_dnode_get_enum(args->dnode, "./nh-type"),
-			  yang_dnode_get_string(args->dnode, "./interface"),
-			  yang_dnode_get_string(args->dnode, "./gateway"),
-			  yang_dnode_get_string(args->dnode, "./vrf"));
-		return NB_ERR;
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		nh = nb_running_unset_entry(args->dnode);
+		static_delete_nexthop(nh);
+		break;
 	}
 
 	return NB_OK;
@@ -384,72 +375,26 @@ static int static_nexthop_bh_type_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-
 void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_apply_finish(
 	struct nb_cb_apply_finish_args *args)
 {
 	struct static_nexthop *nh;
-	struct static_path *pn;
-	struct route_node *rn;
-	const struct lyd_node *pn_dnode;
-	const struct lyd_node *rn_dnode;
-	const char *ifname;
-	const char *nh_vrf;
-	struct stable_info *info;
-	int nh_type;
-
-	nh_type = yang_dnode_get_enum(args->dnode, "./nh-type");
-	ifname = yang_dnode_get_string(args->dnode, "./interface");
-	nh_vrf = yang_dnode_get_string(args->dnode, "./vrf");
 
 	nh = nb_running_get_entry(args->dnode, NULL, true);
 
-	pn_dnode = yang_dnode_get_parent(args->dnode, "path-list");
-	pn = nb_running_get_entry(pn_dnode, NULL, true);
-
-	rn_dnode = yang_dnode_get_parent(pn_dnode, "route-list");
-	rn = nb_running_get_entry(rn_dnode, NULL, true);
-	info = route_table_get_info(rn->table);
-
-	static_install_nexthop(rn, pn, nh, info->safi, info->svrf, ifname,
-			       nh_type, nh_vrf);
+	static_install_nexthop(nh);
 }
-
 
 void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_apply_finish(
 	struct nb_cb_apply_finish_args *args)
 {
 	struct static_nexthop *nh;
-	struct static_path *pn;
-	struct route_node *rn;
-	struct route_node *src_rn;
-	const struct lyd_node *pn_dnode;
-	const struct lyd_node *rn_dnode;
-	const struct lyd_node *src_dnode;
-	const char *ifname;
-	const char *nh_vrf;
-	struct stable_info *info;
-	int nh_type;
-
-	nh_type = yang_dnode_get_enum(args->dnode, "./nh-type");
-	ifname = yang_dnode_get_string(args->dnode, "./interface");
-	nh_vrf = yang_dnode_get_string(args->dnode, "./vrf");
 
 	nh = nb_running_get_entry(args->dnode, NULL, true);
 
-	pn_dnode = yang_dnode_get_parent(args->dnode, "path-list");
-	pn = nb_running_get_entry(pn_dnode, NULL, true);
-
-	src_dnode = yang_dnode_get_parent(pn_dnode, "src-list");
-	src_rn = nb_running_get_entry(src_dnode, NULL, true);
-
-	rn_dnode = yang_dnode_get_parent(src_dnode, "route-list");
-	rn = nb_running_get_entry(rn_dnode, NULL, true);
-	info = route_table_get_info(rn->table);
-
-	static_install_nexthop(src_rn, pn, nh, info->safi, info->svrf, ifname,
-			       nh_type, nh_vrf);
+	static_install_nexthop(nh);
 }
+
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate(
 	struct nb_cb_pre_validate_args *args)
 {
@@ -548,7 +493,6 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_de
 	struct nb_cb_destroy_args *args)
 {
 	struct route_node *rn;
-	struct stable_info *info;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -557,8 +501,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_de
 		break;
 	case NB_EV_APPLY:
 		rn = nb_running_unset_entry(args->dnode);
-		info = route_table_get_info(rn->table);
-		static_del_route(rn, info->safi, info->svrf);
+		static_del_route(rn);
 		break;
 	}
 	return NB_OK;
@@ -577,23 +520,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_destroy(
 	struct nb_cb_destroy_args *args)
 {
-	const struct lyd_node *rn_dnode;
-	struct route_node *rn;
-	struct stable_info *info;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-		break;
-	case NB_EV_APPLY:
-		rn_dnode = yang_dnode_get_parent(args->dnode, "route-list");
-		rn = nb_running_get_entry(rn_dnode, NULL, true);
-		info = route_table_get_info(rn->table);
-		static_path_list_destroy(args, rn_dnode, info);
-		break;
-	}
-	return NB_OK;
+	return static_path_list_destroy(args);
 }
 
 /*
@@ -603,24 +530,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_tag_modify(
 	struct nb_cb_modify_args *args)
 {
-	struct stable_info *info;
-	struct route_node *rn;
-	const struct lyd_node *rn_dnode;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_ABORT:
-	case NB_EV_PREPARE:
-		break;
-	case NB_EV_APPLY:
-		rn_dnode = yang_dnode_get_parent(args->dnode, "route-list");
-		rn = nb_running_get_entry(rn_dnode, NULL, true);
-		info = route_table_get_info(rn->table);
-		static_path_list_tag_modify(args, rn_dnode, info);
-		break;
-	}
-
-	return NB_OK;
+	return static_path_list_tag_modify(args);
 }
 
 /*
@@ -630,53 +540,13 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_create(
 	struct nb_cb_create_args *args)
 {
-	struct route_node *rn;
-	const struct lyd_node *rn_dnode;
-	struct stable_info *info;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-		rn_dnode = yang_dnode_get_parent(args->dnode, "route-list");
-		if (static_nexthop_create(args, rn_dnode, NULL) != NB_OK)
-			return NB_ERR_VALIDATION;
-		break;
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-		break;
-	case NB_EV_APPLY:
-		rn_dnode = yang_dnode_get_parent(args->dnode, "route-list");
-		rn = nb_running_get_entry(rn_dnode, NULL, true);
-		info = route_table_get_info(rn->table);
-
-		if (static_nexthop_create(args, rn_dnode, info) != NB_OK)
-			return NB_ERR_INCONSISTENCY;
-		break;
-	}
-	return NB_OK;
+	return static_nexthop_create(args);
 }
 
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_destroy(
 	struct nb_cb_destroy_args *args)
 {
-	struct route_node *rn;
-	const struct lyd_node *rn_dnode;
-	struct stable_info *info;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-		break;
-	case NB_EV_APPLY:
-		rn_dnode = yang_dnode_get_parent(args->dnode, "route-list");
-		rn = nb_running_get_entry(rn_dnode, NULL, true);
-		info = route_table_get_info(rn->table);
-
-		if (static_nexthop_destroy(args, rn_dnode, info) != NB_OK)
-			return NB_ERR;
-		break;
-	}
-	return NB_OK;
+	return static_nexthop_destroy(args);
 }
 
 /*
@@ -899,9 +769,6 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	struct nb_cb_destroy_args *args)
 {
 	struct route_node *src_rn;
-	struct route_node *rn;
-	struct stable_info *info;
-	const struct lyd_node *rn_dnode;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -910,10 +777,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 		break;
 	case NB_EV_APPLY:
 		src_rn = nb_running_unset_entry(args->dnode);
-		rn_dnode = yang_dnode_get_parent(args->dnode, "route-list");
-		rn = nb_running_get_entry(rn_dnode, NULL, true);
-		info = route_table_get_info(rn->table);
-		static_del_route(src_rn, info->safi, info->svrf);
+		static_del_route(src_rn);
 		break;
 	}
 
@@ -933,25 +797,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_destroy(
 	struct nb_cb_destroy_args *args)
 {
-	struct route_node *rn;
-	const struct lyd_node *rn_dnode;
-	const struct lyd_node *srn_dnode;
-	struct stable_info *info;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-		break;
-	case NB_EV_APPLY:
-		srn_dnode = yang_dnode_get_parent(args->dnode, "src-list");
-		rn_dnode = yang_dnode_get_parent(srn_dnode, "route-list");
-		rn = nb_running_get_entry(rn_dnode, NULL, true);
-		info = route_table_get_info(rn->table);
-		static_path_list_destroy(args, srn_dnode, info);
-		break;
-	}
-	return NB_OK;
+	return static_path_list_destroy(args);
 }
 
 /*
@@ -961,25 +807,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_tag_modify(
 	struct nb_cb_modify_args *args)
 {
-	struct stable_info *info;
-	struct route_node *rn;
-	const struct lyd_node *srn_dnode;
-	const struct lyd_node *rn_dnode;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_ABORT:
-	case NB_EV_PREPARE:
-		break;
-	case NB_EV_APPLY:
-		srn_dnode = yang_dnode_get_parent(args->dnode, "src-list");
-		rn_dnode = yang_dnode_get_parent(srn_dnode, "route-list");
-		rn = nb_running_get_entry(rn_dnode, NULL, true);
-		info = route_table_get_info(rn->table);
-		static_path_list_tag_modify(args, srn_dnode, info);
-		break;
-	}
-	return NB_OK;
+	return static_path_list_tag_modify(args);
 }
 
 /*
@@ -989,58 +817,13 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_create(
 	struct nb_cb_create_args *args)
 {
-	struct route_node *rn;
-	const struct lyd_node *rn_dnode;
-	const struct lyd_node *src_dnode;
-	struct stable_info *info;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-		rn_dnode = yang_dnode_get_parent(args->dnode, "route-list");
-		if (static_nexthop_create(args, rn_dnode, NULL) != NB_OK)
-			return NB_ERR_VALIDATION;
-		break;
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-		break;
-	case NB_EV_APPLY:
-		src_dnode = yang_dnode_get_parent(args->dnode, "src-list");
-		rn_dnode = yang_dnode_get_parent(src_dnode, "route-list");
-		rn = nb_running_get_entry(rn_dnode, NULL, true);
-		info = route_table_get_info(rn->table);
-
-		if (static_nexthop_create(args, src_dnode, info) != NB_OK)
-			return NB_ERR_VALIDATION;
-
-		break;
-	}
-	return NB_OK;
+	return static_nexthop_create(args);
 }
 
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_destroy(
 	struct nb_cb_destroy_args *args)
 {
-	struct route_node *rn;
-	const struct lyd_node *rn_dnode;
-	const struct lyd_node *src_dnode;
-	struct stable_info *info;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-		break;
-	case NB_EV_APPLY:
-		src_dnode = yang_dnode_get_parent(args->dnode, "src-list");
-		rn_dnode = yang_dnode_get_parent(src_dnode, "route-list");
-		rn = nb_running_get_entry(rn_dnode, NULL, true);
-		info = route_table_get_info(rn->table);
-
-		if (static_nexthop_destroy(args, rn_dnode, info) != NB_OK)
-			return NB_ERR;
-		break;
-	}
-	return NB_OK;
+	return static_nexthop_destroy(args);
 }
 
 /*

--- a/staticd/static_nht.c
+++ b/staticd/static_nht.c
@@ -30,10 +30,9 @@
 #include "static_zebra.h"
 #include "static_nht.h"
 
-static void static_nht_update_path(struct route_node *rn,
-				   struct static_path *pn, struct prefix *nhp,
+static void static_nht_update_path(struct static_path *pn, struct prefix *nhp,
 				   uint32_t nh_num, vrf_id_t nh_vrf_id,
-				   struct vrf *vrf, safi_t safi)
+				   struct vrf *vrf)
 {
 	struct static_nexthop *nh;
 
@@ -57,7 +56,7 @@ static void static_nht_update_path(struct route_node *rn,
 			nh->nh_valid = !!nh_num;
 
 		if (nh->state == STATIC_START)
-			static_zebra_route_add(rn, pn, safi, true);
+			static_zebra_route_add(pn, true);
 	}
 }
 
@@ -84,8 +83,8 @@ static void static_nht_update_safi(struct prefix *sp, struct prefix *nhp,
 		if (rn && rn->info) {
 			si = static_route_info_from_rnode(rn);
 			frr_each(static_path_list, &si->path_list, pn) {
-				static_nht_update_path(rn, pn, nhp, nh_num,
-						       nh_vrf_id, vrf, safi);
+				static_nht_update_path(pn, nhp, nh_num,
+						       nh_vrf_id, vrf);
 			}
 			route_unlock_node(rn);
 		}
@@ -97,8 +96,7 @@ static void static_nht_update_safi(struct prefix *sp, struct prefix *nhp,
 		if (!si)
 			continue;
 		frr_each(static_path_list, &si->path_list, pn) {
-			static_nht_update_path(rn, pn, nhp, nh_num, nh_vrf_id,
-					       vrf, safi);
+			static_nht_update_path(pn, nhp, nh_num, nh_vrf_id, vrf);
 		}
 	}
 }

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -98,26 +98,24 @@ void zebra_stable_node_cleanup(struct route_table *table,
 }
 
 /* Install static path into rib. */
-void static_install_path(struct route_node *rn, struct static_path *pn,
-			 safi_t safi, struct static_vrf *svrf)
+void static_install_path(struct static_path *pn)
 {
 	struct static_nexthop *nh;
 
 	frr_each(static_nexthop_list, &pn->nexthop_list, nh)
-		static_zebra_nht_register(rn, nh, true);
+		static_zebra_nht_register(nh, true);
 
-	if (static_nexthop_list_count(&pn->nexthop_list) && svrf && svrf->vrf)
-		static_zebra_route_add(rn, pn, safi, true);
+	if (static_nexthop_list_count(&pn->nexthop_list))
+		static_zebra_route_add(pn, true);
 }
 
 /* Uninstall static path from RIB. */
-static void static_uninstall_path(struct route_node *rn, struct static_path *pn,
-				  safi_t safi, struct static_vrf *svrf)
+static void static_uninstall_path(struct static_path *pn)
 {
 	if (static_nexthop_list_count(&pn->nexthop_list))
-		static_zebra_route_add(rn, pn, safi, true);
+		static_zebra_route_add(pn, true);
 	else
-		static_zebra_route_add(rn, pn, safi, false);
+		static_zebra_route_add(pn, false);
 }
 
 struct route_node *static_add_route(afi_t afi, safi_t safi, struct prefix *p,
@@ -135,7 +133,10 @@ struct route_node *static_add_route(afi_t afi, safi_t safi, struct prefix *p,
 	rn = srcdest_rnode_get(stable, p, src_p);
 
 	si = XCALLOC(MTYPE_STATIC_ROUTE, sizeof(struct static_route_info));
-	static_route_info_init(si);
+
+	si->svrf = svrf;
+	si->safi = safi;
+	static_path_list_init(&(si->path_list));
 
 	rn->info = si;
 
@@ -143,8 +144,7 @@ struct route_node *static_add_route(afi_t afi, safi_t safi, struct prefix *p,
 }
 
 /* To delete the srcnodes */
-static void static_del_src_route(struct route_node *rn, safi_t safi,
-				 struct static_vrf *svrf)
+static void static_del_src_route(struct route_node *rn)
 {
 	struct static_path *pn;
 	struct static_route_info *si;
@@ -152,15 +152,14 @@ static void static_del_src_route(struct route_node *rn, safi_t safi,
 	si = rn->info;
 
 	frr_each_safe(static_path_list, &si->path_list, pn) {
-		static_del_path(rn, pn, safi, svrf);
+		static_del_path(pn);
 	}
 
 	XFREE(MTYPE_STATIC_ROUTE, rn->info);
 	route_unlock_node(rn);
 }
 
-void static_del_route(struct route_node *rn, safi_t safi,
-		      struct static_vrf *svrf)
+void static_del_route(struct route_node *rn)
 {
 	struct static_path *pn;
 	struct static_route_info *si;
@@ -170,7 +169,7 @@ void static_del_route(struct route_node *rn, safi_t safi,
 	si = rn->info;
 
 	frr_each_safe(static_path_list, &si->path_list, pn) {
-		static_del_path(rn, pn, safi, svrf);
+		static_del_path(pn);
 	}
 
 	/* clean up for dst table */
@@ -181,7 +180,7 @@ void static_del_route(struct route_node *rn, safi_t safi,
 		 */
 		for (src_node = route_top(src_table); src_node;
 		     src_node = route_next(src_node)) {
-			static_del_src_route(src_node, safi, svrf);
+			static_del_src_route(src_node);
 		}
 	}
 	XFREE(MTYPE_STATIC_ROUTE, rn->info);
@@ -228,6 +227,7 @@ struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
 	/* Make new static route structure. */
 	pn = XCALLOC(MTYPE_STATIC_PATH, sizeof(struct static_path));
 
+	pn->rn = rn;
 	pn->distance = distance;
 	pn->table_id = table_id;
 	static_nexthop_list_init(&(pn->nexthop_list));
@@ -238,9 +238,9 @@ struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
 	return pn;
 }
 
-void static_del_path(struct route_node *rn, struct static_path *pn, safi_t safi,
-		     struct static_vrf *svrf)
+void static_del_path(struct static_path *pn)
 {
+	struct route_node *rn = pn->rn;
 	struct static_route_info *si;
 	struct static_nexthop *nh;
 
@@ -249,7 +249,7 @@ void static_del_path(struct route_node *rn, struct static_path *pn, safi_t safi,
 	static_path_list_del(&si->path_list, pn);
 
 	frr_each_safe(static_nexthop_list, &pn->nexthop_list, nh) {
-		static_delete_nexthop(rn, pn, safi, svrf, nh);
+		static_delete_nexthop(nh);
 	}
 
 	route_unlock_node(rn);
@@ -257,12 +257,13 @@ void static_del_path(struct route_node *rn, struct static_path *pn, safi_t safi,
 	XFREE(MTYPE_STATIC_PATH, pn);
 }
 
-struct static_nexthop *
-static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
-		   struct static_vrf *svrf, static_types type,
-		   struct ipaddr *ipaddr, const char *ifname,
-		   const char *nh_vrf, uint32_t color)
+struct static_nexthop *static_add_nexthop(struct static_path *pn,
+					  static_types type,
+					  struct ipaddr *ipaddr,
+					  const char *ifname,
+					  const char *nh_vrf, uint32_t color)
 {
+	struct route_node *rn = pn->rn;
 	struct static_nexthop *nh;
 	struct static_vrf *nh_svrf;
 	struct interface *ifp;
@@ -274,6 +275,8 @@ static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
 
 	/* Make new static route structure. */
 	nh = XCALLOC(MTYPE_STATIC_NEXTHOP, sizeof(struct static_nexthop));
+
+	nh->pn = pn;
 
 	nh->type = type;
 	nh->color = color;
@@ -354,11 +357,10 @@ static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
 	return nh;
 }
 
-void static_install_nexthop(struct route_node *rn, struct static_path *pn,
-			    struct static_nexthop *nh, safi_t safi,
-			    struct static_vrf *svrf, const char *ifname,
-			    static_types type, const char *nh_vrf)
+void static_install_nexthop(struct static_nexthop *nh)
 {
+	struct static_path *pn = nh->pn;
+	struct route_node *rn = pn->rn;
 	struct interface *ifp;
 
 	if (nh->nh_vrf_id == VRF_UNKNOWN) {
@@ -375,48 +377,47 @@ void static_install_nexthop(struct route_node *rn, struct static_path *pn,
 	switch (nh->type) {
 	case STATIC_IPV4_GATEWAY:
 	case STATIC_IPV6_GATEWAY:
-		if (!static_zebra_nh_update(rn, nh))
-			static_zebra_nht_register(rn, nh, true);
+		if (!static_zebra_nh_update(nh))
+			static_zebra_nht_register(nh, true);
 		break;
 	case STATIC_IPV4_GATEWAY_IFNAME:
 	case STATIC_IPV6_GATEWAY_IFNAME:
-		if (!static_zebra_nh_update(rn, nh))
-			static_zebra_nht_register(rn, nh, true);
+		if (!static_zebra_nh_update(nh))
+			static_zebra_nht_register(nh, true);
 		break;
 	case STATIC_BLACKHOLE:
-		static_install_path(rn, pn, safi, svrf);
+		static_install_path(pn);
 		break;
 	case STATIC_IFNAME:
-		ifp = if_lookup_by_name(ifname, nh->nh_vrf_id);
+		ifp = if_lookup_by_name(nh->ifname, nh->nh_vrf_id);
 		if (ifp && ifp->ifindex != IFINDEX_INTERNAL)
-			static_install_path(rn, pn, safi, svrf);
+			static_install_path(pn);
 
 		break;
 	}
 }
 
-int static_delete_nexthop(struct route_node *rn, struct static_path *pn,
-			  safi_t safi, struct static_vrf *svrf,
-			  struct static_nexthop *nh)
+void static_delete_nexthop(struct static_nexthop *nh)
 {
+	struct static_path *pn = nh->pn;
+	struct route_node *rn = pn->rn;
+
 	static_nexthop_list_del(&(pn->nexthop_list), nh);
 
 	if (nh->nh_vrf_id == VRF_UNKNOWN)
 		goto EXIT;
 
-	static_zebra_nht_register(rn, nh, false);
+	static_zebra_nht_register(nh, false);
 	/*
 	 * If we have other si nodes then route replace
 	 * else delete the route
 	 */
-	static_uninstall_path(rn, pn, safi, svrf);
+	static_uninstall_path(pn);
 
 EXIT:
 	route_unlock_node(rn);
 	/* Free static route configuration. */
 	XFREE(MTYPE_STATIC_NEXTHOP, nh);
-
-	return 1;
 }
 
 static void static_ifindex_update_nh(struct interface *ifp, bool up,
@@ -441,7 +442,7 @@ static void static_ifindex_update_nh(struct interface *ifp, bool up,
 		nh->ifindex = IFINDEX_INTERNAL;
 	}
 
-	static_install_path(rn, pn, safi, svrf);
+	static_install_path(pn);
 }
 
 static void static_ifindex_update_af(struct interface *ifp, bool up, afi_t afi,
@@ -520,7 +521,7 @@ static void static_fixup_vrf(struct static_vrf *svrf,
 						continue;
 				}
 
-				static_install_path(rn, pn, safi, svrf);
+				static_install_path(pn);
 			}
 		}
 	}
@@ -561,7 +562,7 @@ static void static_enable_vrf(struct static_vrf *svrf,
 				}
 				if (nh->nh_vrf_id == VRF_UNKNOWN)
 					continue;
-				static_install_path(rn, pn, safi, svrf);
+				static_install_path(pn);
 			}
 		}
 	}
@@ -628,7 +629,7 @@ static void static_cleanup_vrf(struct static_vrf *svrf,
 				    != 0)
 					continue;
 
-				static_uninstall_path(rn, pn, safi, svrf);
+				static_uninstall_path(pn);
 			}
 		}
 	}
@@ -648,10 +649,7 @@ static void static_disable_vrf(struct route_table *stable,
 	struct route_node *rn;
 	struct static_nexthop *nh;
 	struct static_path *pn;
-	struct stable_info *info;
 	struct static_route_info *si;
-
-	info = route_table_get_info(stable);
 
 	for (rn = route_top(stable); rn; rn = route_next(rn)) {
 		si = static_route_info_from_rnode(rn);
@@ -659,7 +657,7 @@ static void static_disable_vrf(struct route_table *stable,
 			continue;
 		frr_each(static_path_list, &si->path_list, pn) {
 			frr_each(static_nexthop_list, &pn->nexthop_list, nh) {
-				static_uninstall_path(rn, pn, safi, info->svrf);
+				static_uninstall_path(pn);
 			}
 		}
 	}
@@ -714,12 +712,9 @@ static void static_fixup_intf_nh(struct route_table *stable,
 				 afi_t afi, safi_t safi)
 {
 	struct route_node *rn;
-	struct stable_info *info;
 	struct static_nexthop *nh;
 	struct static_path *pn;
 	struct static_route_info *si;
-
-	info = route_table_get_info(stable);
 
 	for (rn = route_top(stable); rn; rn = route_next(rn)) {
 		si = static_route_info_from_rnode(rn);
@@ -733,7 +728,7 @@ static void static_fixup_intf_nh(struct route_table *stable,
 				if (nh->ifindex != ifp->ifindex)
 					continue;
 
-				static_install_path(rn, pn, safi, info->svrf);
+				static_install_path(pn);
 			}
 		}
 	}
@@ -808,12 +803,6 @@ struct stable_info *static_get_stable_info(struct route_node *rn)
 	table = srcdest_rnode_table(rn);
 	return table->info;
 }
-
-void static_route_info_init(struct static_route_info *si)
-{
-	static_path_list_init(&(si->path_list));
-}
-
 
 void static_get_nh_str(struct static_nexthop *nh, char *nexthop, size_t size)
 {

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -81,12 +81,16 @@ PREDECL_DLIST(static_nexthop_list);
 
 /* Static route information */
 struct static_route_info {
+	struct static_vrf *svrf;
+	safi_t safi;
 	/* path list */
 	struct static_path_list_head path_list;
 };
 
 /* Static path information */
 struct static_path {
+	/* Route node back pointer. */
+	struct route_node *rn;
 	/* Linkage for static path lists */
 	struct static_path_list_item list;
 	/* Administrative distance. */
@@ -103,6 +107,8 @@ DECLARE_DLIST(static_path_list, struct static_path, list);
 
 /* Static route information. */
 struct static_nexthop {
+	/* Path back pointer. */
+	struct static_path *pn;
 	/* For linked list. */
 	struct static_nexthop_list_item list;
 
@@ -163,19 +169,12 @@ extern struct zebra_privs_t static_privs;
 void static_fixup_vrf_ids(struct static_vrf *svrf);
 
 extern struct static_nexthop *
-static_add_nexthop(struct route_node *rn, struct static_path *pn, safi_t safi,
-		   struct static_vrf *svrf, static_types type,
+static_add_nexthop(struct static_path *pn, static_types type,
 		   struct ipaddr *ipaddr, const char *ifname,
 		   const char *nh_vrf, uint32_t color);
-extern void static_install_nexthop(struct route_node *rn,
-				   struct static_path *pn,
-				   struct static_nexthop *nh, safi_t safi,
-				   struct static_vrf *svrf, const char *ifname,
-				   static_types type, const char *nh_vrf);
+extern void static_install_nexthop(struct static_nexthop *nh);
 
-extern int static_delete_nexthop(struct route_node *rn, struct static_path *pn,
-				 safi_t safi, struct static_vrf *svrf,
-				 struct static_nexthop *nh);
+extern void static_delete_nexthop(struct static_nexthop *nh);
 
 extern void static_cleanup_vrf_ids(struct static_vrf *disable_svrf);
 
@@ -183,27 +182,23 @@ extern void static_install_intf_nh(struct interface *ifp);
 
 extern void static_ifindex_update(struct interface *ifp, bool up);
 
-extern void static_install_path(struct route_node *rn, struct static_path *pn,
-				safi_t safi, struct static_vrf *svrf);
+extern void static_install_path(struct static_path *pn);
 
 extern struct route_node *static_add_route(afi_t afi, safi_t safi,
 					   struct prefix *p,
 					   struct prefix_ipv6 *src_p,
 					   struct static_vrf *svrf);
-extern void static_del_route(struct route_node *rn, safi_t safi,
-			     struct static_vrf *svrf);
+extern void static_del_route(struct route_node *rn);
 
 extern struct static_path *static_add_path(struct route_node *rn,
 					   uint32_t table_id, uint8_t distance);
-extern void static_del_path(struct route_node *rn, struct static_path *pn,
-			    safi_t safi, struct static_vrf *svrf);
+extern void static_del_path(struct static_path *pn);
 
 extern void static_get_nh_type(static_types stype, char *type, size_t size);
 extern bool static_add_nexthop_validate(const char *nh_vrf_name,
 					static_types type,
 					struct ipaddr *ipaddr);
 extern struct stable_info *static_get_stable_info(struct route_node *rn);
-extern void static_route_info_init(struct static_route_info *si);
 
 extern void zebra_stable_node_cleanup(struct route_table *table,
 				      struct route_node *node);

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -261,9 +261,10 @@ static void static_nht_hash_free(void *data)
 	XFREE(MTYPE_TMP, nhtd);
 }
 
-void static_zebra_nht_register(struct route_node *rn, struct static_nexthop *nh,
-			       bool reg)
+void static_zebra_nht_register(struct static_nexthop *nh, bool reg)
 {
+	struct static_path *pn = nh->pn;
+	struct route_node *rn = pn->rn;
 	struct static_nht_data *nhtd, lookup;
 	uint32_t cmd;
 	struct prefix p;
@@ -339,8 +340,10 @@ void static_zebra_nht_register(struct route_node *rn, struct static_nexthop *nh,
  * When nexthop gets updated via configuration then use the
  * already registered NH and resend the route to zebra
  */
-int static_zebra_nh_update(struct route_node *rn, struct static_nexthop *nh)
+int static_zebra_nh_update(struct static_nexthop *nh)
 {
+	struct static_path *pn = nh->pn;
+	struct route_node *rn = pn->rn;
 	struct static_nht_data *nhtd, lookup = {};
 	struct prefix p = {};
 	afi_t afi = AFI_IP;
@@ -381,25 +384,23 @@ int static_zebra_nh_update(struct route_node *rn, struct static_nexthop *nh)
 	return 0;
 }
 
-extern void static_zebra_route_add(struct route_node *rn,
-				   struct static_path *pn, safi_t safi,
-				   bool install)
+extern void static_zebra_route_add(struct static_path *pn, bool install)
 {
+	struct route_node *rn = pn->rn;
+	struct static_route_info *si = rn->info;
 	struct static_nexthop *nh;
 	const struct prefix *p, *src_pp;
 	struct zapi_nexthop *api_nh;
 	struct zapi_route api;
 	uint32_t nh_num = 0;
-	struct stable_info *info;
 
 	p = src_pp = NULL;
 	srcdest_rnode_prefixes(rn, &p, &src_pp);
 
 	memset(&api, 0, sizeof(api));
-	info = static_get_stable_info(rn);
-	api.vrf_id = GET_STABLE_VRF_ID(info);
+	api.vrf_id = si->svrf->vrf->vrf_id;
 	api.type = ZEBRA_ROUTE_STATIC;
-	api.safi = safi;
+	api.safi = si->safi;
 	memcpy(&api.prefix, p, sizeof(api.prefix));
 
 	if (src_pp) {

--- a/staticd/static_zebra.h
+++ b/staticd/static_zebra.h
@@ -25,19 +25,15 @@ extern "C" {
 
 extern struct thread_master *master;
 
-extern void static_zebra_nht_register(struct route_node *rn,
-				      struct static_nexthop *nh, bool reg);
+extern void static_zebra_nht_register(struct static_nexthop *nh, bool reg);
 
-extern void static_zebra_route_add(struct route_node *rn,
-				   struct static_path *pn, safi_t safi,
-				   bool install);
+extern void static_zebra_route_add(struct static_path *pn, bool install);
 extern void static_zebra_init(void);
 /* static_zebra_stop used by tests/lib/test_grpc.cpp */
 extern void static_zebra_stop(void);
 extern void static_zebra_vrf_register(struct vrf *vrf);
 extern void static_zebra_vrf_unregister(struct vrf *vrf);
-extern int static_zebra_nh_update(struct route_node *rn,
-				  struct static_nexthop *nh);
+extern int static_zebra_nh_update(struct static_nexthop *nh);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add a couple of back pointers to static route/path/nexthop structures to
simplify the NB code and save ~200 lines.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>