### PR TITLE
staticd: Fix some string problems for Null0.

### DIFF
--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -143,8 +143,7 @@ static bool static_nexthop_create(struct nb_cb_create_args *args,
 	case NB_EV_VALIDATE:
 		ifname = yang_dnode_get_string(args->dnode, "./interface");
 		if (ifname != NULL) {
-			if (strcasecmp(ifname, "Null0") == 0
-			    || strcasecmp(ifname, "reject") == 0
+			if (strcasecmp(ifname, "reject") == 0
 			    || strcasecmp(ifname, "blackhole") == 0) {
 				snprintf(args->errmsg, args->errmsg_len,
 					"%s: Nexthop interface name can not be from reserved keywords(Null0, reject, blackhole)",

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -146,7 +146,7 @@ static bool static_nexthop_create(struct nb_cb_create_args *args,
 			if (strcmp(ifname, "reject") == 0
 			    || strcmp(ifname, "blackhole") == 0) {
 				snprintf(args->errmsg, args->errmsg_len,
-					"%s: Nexthop interface name can not be from reserved keywords(Null0, reject, blackhole)",
+					"%s: Nexthop interface name can not be from reserved keywords(reject, blackhole)",
 					ifname);
 				return NB_ERR_VALIDATION;
 			}

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -143,8 +143,8 @@ static bool static_nexthop_create(struct nb_cb_create_args *args,
 	case NB_EV_VALIDATE:
 		ifname = yang_dnode_get_string(args->dnode, "./interface");
 		if (ifname != NULL) {
-			if (strcasecmp(ifname, "reject") == 0
-			    || strcasecmp(ifname, "blackhole") == 0) {
+			if (strcmp(ifname, "reject") == 0
+			    || strcmp(ifname, "blackhole") == 0) {
 				snprintf(args->errmsg, args->errmsg_len,
 					"%s: Nexthop interface name can not be from reserved keywords(Null0, reject, blackhole)",
 					ifname);


### PR DESCRIPTION
### 3 commits for staticd:

- One condition check is unuseful, need removed.

- Comparing interface should be case sensitive.

- Adjust a confusing info 

As to this confusing info, give more details.
"Null0" is a normal interface name to be used.
debian10(config)# ip route 1.1.1.44/32 1.1.1.2 reject
% Configuration failed.

Error type: validation
Error description: reject: Nexthop interface name can not be from reserved keywords(Null0, reject, blackhole)
debian10(config)# ip route 1.1.1.44/32 1.1.1.2 Null0  <---- It is ok
debian10(config)# ip route 1.1.1.44/32 1.1.1.2 blackhole
% Configuration failed.

Error type: validation
Error description: blackhole: Nexthop interface name can not be from reserved keywords(Null0, reject, blackhole)