### PR TITLE
bgpd: XREALLOC handles NULL properly

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2915,11 +2915,8 @@ static bgp_attr_parse_ret_t bgp_attr_unknown(struct bgp_attr_parser_args *args)
 	if (!transit)
 		transit = XCALLOC(MTYPE_TRANSIT, sizeof(struct transit));
 
-	if (transit->val)
-		transit->val = XREALLOC(MTYPE_TRANSIT_VAL, transit->val,
-					transit->length + total);
-	else
-		transit->val = XMALLOC(MTYPE_TRANSIT_VAL, total);
+	transit->val = XREALLOC(MTYPE_TRANSIT_VAL, transit->val,
+				transit->length + total);
 
 	memcpy(transit->val + transit->length, startp, total);
 	transit->length += total;

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -60,11 +60,7 @@ void community_free(struct community **com)
 void community_add_val(struct community *com, uint32_t val)
 {
 	com->size++;
-	if (com->val)
-		com->val = XREALLOC(MTYPE_COMMUNITY_VAL, com->val,
-				    com_length(com));
-	else
-		com->val = XMALLOC(MTYPE_COMMUNITY_VAL, com_length(com));
+	com->val = XREALLOC(MTYPE_COMMUNITY_VAL, com->val, com_length(com));
 
 	val = htonl(val);
 	memcpy(com_lastval(com), &val, sizeof(uint32_t));
@@ -618,13 +614,8 @@ bool community_cmp(const struct community *com1, const struct community *com2)
 struct community *community_merge(struct community *com1,
 				  struct community *com2)
 {
-	if (com1->val)
-		com1->val =
-			XREALLOC(MTYPE_COMMUNITY_VAL, com1->val,
-				 (com1->size + com2->size) * COMMUNITY_SIZE);
-	else
-		com1->val = XMALLOC(MTYPE_COMMUNITY_VAL,
-				    (com1->size + com2->size) * COMMUNITY_SIZE);
+	com1->val = XREALLOC(MTYPE_COMMUNITY_VAL, com1->val,
+			     (com1->size + com2->size) * COMMUNITY_SIZE);
 
 	memcpy(com1->val + com1->size, com2->val, com2->size * COMMUNITY_SIZE);
 	com1->size += com2->size;

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -158,7 +158,6 @@ static bool ecommunity_add_val_internal(struct ecommunity *ecom,
 	ecom->val = XREALLOC(MTYPE_ECOMMUNITY_VAL, ecom->val,
 			 ecom_length_size(ecom, ecom_size));
 
-
 	memmove(ecom->val + ((ins_idx + 1) * ecom_size),
 		ecom->val + (ins_idx * ecom_size),
 		(ecom->size - 1 - ins_idx) * ecom_size);
@@ -287,14 +286,9 @@ char *ecommunity_str(struct ecommunity *ecom)
 struct ecommunity *ecommunity_merge(struct ecommunity *ecom1,
 				    struct ecommunity *ecom2)
 {
-	if (ecom1->val)
-		ecom1->val = XREALLOC(MTYPE_ECOMMUNITY_VAL, ecom1->val,
-				      (size_t)(ecom1->size + ecom2->size)
-					      * (size_t)ecom1->unit_size);
-	else
-		ecom1->val = XMALLOC(MTYPE_ECOMMUNITY_VAL,
-				     (size_t)(ecom1->size + ecom2->size)
-					     * (size_t)ecom1->unit_size);
+	ecom1->val = XREALLOC(MTYPE_ECOMMUNITY_VAL, ecom1->val,
+			      (size_t)(ecom1->size + ecom2->size)
+				      * (size_t)ecom1->unit_size);
 
 	memcpy(ecom1->val + (ecom1->size * ecom1->unit_size), ecom2->val,
 	       (size_t)ecom2->size * (size_t)ecom1->unit_size);

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -166,12 +166,8 @@ struct lcommunity *lcommunity_dup(struct lcommunity *lcom)
 struct lcommunity *lcommunity_merge(struct lcommunity *lcom1,
 				    struct lcommunity *lcom2)
 {
-	if (lcom1->val)
-		lcom1->val = XREALLOC(MTYPE_LCOMMUNITY_VAL, lcom1->val,
-				      lcom_length(lcom1) + lcom_length(lcom2));
-	else
-		lcom1->val = XMALLOC(MTYPE_LCOMMUNITY_VAL,
-				     lcom_length(lcom1) + lcom_length(lcom2));
+	lcom1->val = XREALLOC(MTYPE_LCOMMUNITY_VAL, lcom1->val,
+			      lcom_length(lcom1) + lcom_length(lcom2));
 
 	memcpy(lcom1->val + lcom_length(lcom1), lcom2->val, lcom_length(lcom2));
 	lcom1->size += lcom2->size;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -656,14 +656,9 @@ int bgp_confederation_peers_add(struct bgp *bgp, as_t as)
 	if (bgp_confederation_peers_check(bgp, as))
 		return -1;
 
-	if (bgp->confed_peers)
-		bgp->confed_peers =
-			XREALLOC(MTYPE_BGP_CONFED_LIST, bgp->confed_peers,
-				 (bgp->confed_peers_cnt + 1) * sizeof(as_t));
-	else
-		bgp->confed_peers =
-			XMALLOC(MTYPE_BGP_CONFED_LIST,
-				(bgp->confed_peers_cnt + 1) * sizeof(as_t));
+	bgp->confed_peers =
+		XREALLOC(MTYPE_BGP_CONFED_LIST, bgp->confed_peers,
+			 (bgp->confed_peers_cnt + 1) * sizeof(as_t));
 
 	bgp->confed_peers[bgp->confed_peers_cnt] = as;
 	bgp->confed_peers_cnt++;


### PR DESCRIPTION
the realloc man page:

If ptr is NULL, then the call is equivalent to malloc(size)

This should be sufficient for our needs to not have to have
XMALLOC and XREALLOC

Signed-off-by: Donald Sharp <sharpd@nvidia.com>