### PR TITLE
bgpd: Do not check for NULL values for vni_hash_cmp()

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -111,11 +111,7 @@ static bool vni_hash_cmp(const void *p1, const void *p2)
 	const struct bgpevpn *vpn1 = p1;
 	const struct bgpevpn *vpn2 = p2;
 
-	if (!vpn1 && !vpn2)
-		return true;
-	if (!vpn1 || !vpn2)
-		return false;
-	return (vpn1->vni == vpn2->vni);
+	return vpn1->vni == vpn2->vni;
 }
 
 int vni_list_cmp(void *p1, void *p2)

--- a/tools/coccinelle/hash_compare_null_values_check.cocci
+++ b/tools/coccinelle/hash_compare_null_values_check.cocci
@@ -1,0 +1,20 @@
+// There is no need to test for null values in the hash compare
+// function as that we are guaranteed to send in data in
+// the hash compare functions.
+@@
+identifier fn =~ "_hash_cmp";
+type T;
+identifier p1;
+identifier p2;
+@@
+
+?static
+T fn(...)
+{
+...
+- if (p1 == NULL && p2 == NULL)
+-	return ...;
+- if (p1 == NULL || p2 == NULL)
+-	return ...;
+...
+}


### PR DESCRIPTION
Related: https://github.com/FRRouting/frr/pull/9036