### PR TITLE
zebra: handle renamed interfaces in same namespace - alternative to PR 8310

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -232,6 +232,43 @@ struct interface *if_create_ifindex(ifindex_t ifindex, vrf_id_t vrf_id)
 }
 
 /* Create new interface structure. */
+extern void if_update_to_new_name(struct interface *ifp, const char *name)
+{
+	struct vrf *vrf = vrf_get(ifp->vrf_id, NULL);
+
+	assert(vrf);
+	if_set_name(ifp, name);
+
+	/*
+	 * HACK: Change the interface name in the running configuration
+	 * directly bypassing the northbound layer. This is necessary to
+	 * avoid deleting the interface and readding it with new name, which
+	 * would have several implications.
+	 */
+	if (yang_module_find("frr-interface")) {
+		struct lyd_node *if_dnode;
+		char oldpath[XPATH_MAXLEN];
+		char newpath[XPATH_MAXLEN];
+
+		snprintf(oldpath, sizeof(oldpath),
+			 "/frr-interface:lib/interface[name='%s'][vrf='%s']",
+			 ifp->name, vrf->name);
+		snprintf(newpath, sizeof(newpath),
+			 "/frr-interface:lib/interface[name='%s'][vrf='%s']",
+			 name, vrf->name);
+		if_dnode = yang_dnode_getf(running_config->dnode, "%s/vrf",
+					   oldpath);
+
+		if (if_dnode) {
+			yang_dnode_change_leaf(if_dnode, vrf->name);
+			nb_running_move_tree(oldpath, newpath);
+			running_config->version++;
+		}
+		vty_update_xpath(oldpath, newpath);
+	}
+}
+
+/* Create new interface structure. */
 void if_update_to_new_vrf(struct interface *ifp, vrf_id_t vrf_id)
 {
 	struct vrf *old_vrf, *vrf;

--- a/lib/if.h
+++ b/lib/if.h
@@ -509,6 +509,7 @@ extern int if_cmp_name_func(const char *p1, const char *p2);
  * else think before you use VRF_UNKNOWN
  */
 extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
+extern void if_update_to_new_name(struct interface *ifp, const char *name);
 
 /* Create new interface, adds to name list only */
 extern struct interface *if_create_name(const char *name, vrf_id_t vrf_id);


### PR DESCRIPTION
when an interface is renamed in a given namespace, the yang
operational context is not refreshed with the new interface
name. For instance, following config can show the problem:

-step 0 : setup
zebra &
ip link add dum1 type dummy
ip link set dev dum1 up
vtysh
configure terminal
interface dum1
ip address 4.4.4.4/24
exit
exit

-step 1 : rename
ip link set dev dum1 down
ip link set dev dum1 name dum2
ip link set dev dum2 up

This scenario, from netlink perspective is processed as NETLINK_ADD
event. For each new interface, a new interface context is created.
Two consequences:
- the interface attributes of the 1st interface may be lost. this
is the case for ipv6 link local addresses.
- the yang operational context does not track the interface context
and sticks to the 1st interface configuration.

The proposal consists in reusing the previous interface, and renaming
the interface name. Also, update the yang operational context by
using the new interface name.

For operational contexts of daemons other than zebra, two events are
seen: delete old interface, and create new interface. so operational
contexts from all daemons are synced.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>