### PR TITLE
Adding support of running topotest on a physical router

### DIFF
--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -15,6 +15,7 @@ from lib.topolog import logger
 
 try:
     from _pytest._code.code import ExceptionInfo
+
     leak_check_ok = True
 except ImportError:
     leak_check_ok = False
@@ -74,11 +75,11 @@ def pytest_addoption(parser):
         help="Only set up this topology, don't run tests",
     )
     parser.addoption(
-        '--hw-router',
-        action='store',
-        dest='r_router',
+        "--hw-router",
+        action="store",
+        dest="r_router",
         default=None,
-        help='Topology router name to replace with HW router.'
+        help="Topology router name to replace with HW router.",
     )
 
     parser.addoption(
@@ -127,7 +128,7 @@ def check_for_memleaks():
             vfcontent = vf.read()
             match = re.search(r"ERROR SUMMARY: (\d+) errors", vfcontent)
             if match and match.group(1) != "0":
-                emsg = '{} in {}'.format(match.group(1), vfile)
+                emsg = "{} in {}".format(match.group(1), vfile)
                 leaks.append(emsg)
 
     if leaks:

--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -8,7 +8,7 @@ import pdb
 import re
 import pytest
 
-from lib.topogen import get_topogen, diagnose_env
+from lib.topogen import get_topogen, diagnose_env, set_remote_router
 from lib.topotest import json_cmp_result
 from lib.topotest import g_extra_config as topotest_extra_config
 from lib.topolog import logger
@@ -209,6 +209,9 @@ def pytest_configure(config):
     topotest_extra_config["pause_after"] = pause_after or shell or vtysh
 
     topotest_extra_config["topology_only"] = config.getoption("--topology-only")
+
+    if config.getoption("r_router"):
+        set_remote_router(config.getoption("r_router"))
 
 
 def pytest_runtest_makereport(item, call):

--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -73,6 +73,13 @@ def pytest_addoption(parser):
         default=False,
         help="Only set up this topology, don't run tests",
     )
+    parser.addoption(
+        '--hw-router',
+        action='store',
+        dest='r_router',
+        default=None,
+        help='Topology router name to replace with HW router.'
+    )
 
     parser.addoption(
         "--valgrind-extra",

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -144,8 +144,8 @@ class Topogen(object):
         else:
             # Otherwise check pytest.ini
             r_router = None
-            if self.config.has_option(self.CONFIG_SECTION, 'r_router'):
-                r_router = self.config.get(self.CONFIG_SECTION, 'r_router')
+            if self.config.has_option(self.CONFIG_SECTION, "r_router"):
+                r_router = self.config.get(self.CONFIG_SECTION, "r_router")
                 global_remote_router = r_router
             return r_router
 
@@ -205,10 +205,10 @@ class Topogen(object):
             raise KeyError("router already exists")
         if self.r_router and name == self.r_router:
             cls = topotest.RemoteLinuxRouter
-            params['server'] = self.config.get(self.CONFIG_SECTION, 'r_server')
-            params['user'] = self.config.get(self.CONFIG_SECTION, 'r_user')
-            params['keyFile'] = self.config.get(self.CONFIG_SECTION, 'r_keyFile')
-            params['sshPort'] = self.config.get(self.CONFIG_SECTION, 'r_sshPort')
+            params["server"] = self.config.get(self.CONFIG_SECTION, "r_server")
+            params["user"] = self.config.get(self.CONFIG_SECTION, "r_user")
+            params["keyFile"] = self.config.get(self.CONFIG_SECTION, "r_keyFile")
+            params["sshPort"] = self.config.get(self.CONFIG_SECTION, "r_sshPort")
         params["frrdir"] = self.config.get(self.CONFIG_SECTION, "frrdir")
         params["memleak_path"] = self.config.get(self.CONFIG_SECTION, "memleak_path")
         if "routertype" not in params:
@@ -291,17 +291,27 @@ class Topogen(object):
             else:
                 r_router = node2
                 neigh = node1
-            lport, rport = self.config.get(self.CONFIG_SECTION, 'r_link_{}'.format(r_router.linkn-1)).split(',')
+            lport, rport = self.config.get(
+                self.CONFIG_SECTION, "r_link_{}".format(r_router.linkn - 1)
+            ).split(",")
             r_router.register_link(rport, neigh, lport)
             neigh.register_link(lport, r_router, rport)
-            self.topo.addLink(neigh.name, r_router.name, cls=topotest.RemoteLink,
-                              cls1=topotest.HWIntf, cls2=topotest.HWIntf, intfName2=lport,
-                              hwport1=lport, hwport2=rport)
+            self.topo.addLink(
+                neigh.name,
+                r_router.name,
+                cls=topotest.RemoteLink,
+                cls1=topotest.HWIntf,
+                cls2=topotest.HWIntf,
+                intfName2=lport,
+                hwport1=lport,
+                hwport2=rport,
+            )
         else:
             node1.register_link(ifname1, node2, ifname2)
             node2.register_link(ifname2, node1, ifname1)
-            self.topo.addLink(node1.name, node2.name,
-                              intfName1=ifname1, intfName2=ifname2)
+            self.topo.addLink(
+                node1.name, node2.name, intfName1=ifname1, intfName2=ifname2
+            )
 
     def get_gears(self, geartype):
         """
@@ -733,17 +743,24 @@ class TopoRouter(TopoGear):
         self.logger.info("checking if daemons are running")
         return self.tgen.net[self.name].checkRouterRunning()
 
-    def link_name_update(self, daemon='zebra', file_name=None):
+    def link_name_update(self, daemon="zebra", file_name=None):
         """
         Update link names in config files if HW router is used
         """
         if not file_name:
-            file_name = '/etc/{rtype}/{daemon}.conf'.format(rtype=self.routertype, daemon=daemon)
+            file_name = "/etc/{rtype}/{daemon}.conf".format(
+                rtype=self.routertype, daemon=daemon
+            )
         for linkn in range(self.linkn):
-            default_ifname = '{}-eth{}'.format(self.name, linkn)  # See new_link()
-            hw_iface = self.tgen.config.get(Topogen.CONFIG_SECTION, 'r_link_{}'.format(linkn)).split(',')[-1]
-            self.run('sed -i "s/{iface}/{hwiface}/g" {file_name}'.format(
-                iface=default_ifname, hwiface=hw_iface, file_name=file_name))
+            default_ifname = "{}-eth{}".format(self.name, linkn)  # See new_link()
+            hw_iface = self.tgen.config.get(
+                Topogen.CONFIG_SECTION, "r_link_{}".format(linkn)
+            ).split(",")[-1]
+            self.run(
+                'sed -i "s/{iface}/{hwiface}/g" {file_name}'.format(
+                    iface=default_ifname, hwiface=hw_iface, file_name=file_name
+                )
+            )
 
     def start(self):
         """

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -126,6 +126,13 @@ class Topogen(object):
         self._init_topo(cls)
         logger.info("loading topology: {}".format(self.modname))
 
+    @property
+    def r_router(self):
+        r_router = None
+        if self.config.has_option(self.CONFIG_SECTION, 'r_router'):
+            r_router = self.config.get(self.CONFIG_SECTION, 'r_router')
+        return pytest.config.getoption('r_router') or r_router
+
     @staticmethod
     def _mininet_reset():
         "Reset the mininet environment"
@@ -180,7 +187,12 @@ class Topogen(object):
             name = "r{}".format(self.routern)
         if name in self.gears:
             raise KeyError("router already exists")
-
+        if self.r_router and name == self.r_router:
+            cls = topotest.RemoteLinuxRouter
+            params['server'] = self.config.get(self.CONFIG_SECTION, 'r_server')
+            params['user'] = self.config.get(self.CONFIG_SECTION, 'r_user')
+            params['keyFile'] = self.config.get(self.CONFIG_SECTION, 'r_keyFile')
+            params['sshPort'] = self.config.get(self.CONFIG_SECTION, 'r_sshPort')
         params["frrdir"] = self.config.get(self.CONFIG_SECTION, "frrdir")
         params["memleak_path"] = self.config.get(self.CONFIG_SECTION, "memleak_path")
         if "routertype" not in params:
@@ -256,9 +268,24 @@ class Topogen(object):
         if ifname2 is None:
             ifname2 = node2.new_link()
 
-        node1.register_link(ifname1, node2, ifname2)
-        node2.register_link(ifname2, node1, ifname1)
-        self.topo.addLink(node1.name, node2.name, intfName1=ifname1, intfName2=ifname2)
+        if self.r_router and self.r_router in [node1.name, node2.name]:
+            if node1.name == self.r_router:
+                r_router = node1
+                neigh = node2
+            else:
+                r_router = node2
+                neigh = node1
+            lport, rport = self.config.get(self.CONFIG_SECTION, 'r_link_{}'.format(r_router.linkn-1)).split(',')
+            r_router.register_link(rport, neigh, lport)
+            neigh.register_link(lport, r_router, rport)
+            self.topo.addLink(neigh.name, r_router.name, cls=topotest.RemoteLink,
+                              cls1=topotest.HWIntf, cls2=topotest.HWIntf, intfName2=lport,
+                              hwport1=lport, hwport2=rport)
+        else:
+            node1.register_link(ifname1, node2, ifname2)
+            node2.register_link(ifname2, node1, ifname1)
+            self.topo.addLink(node1.name, node2.name,
+                              intfName1=ifname1, intfName2=ifname2)
 
     def get_gears(self, geartype):
         """
@@ -690,6 +717,18 @@ class TopoRouter(TopoGear):
         self.logger.info("checking if daemons are running")
         return self.tgen.net[self.name].checkRouterRunning()
 
+    def link_name_update(self, daemon='zebra', file_name=None):
+        """
+        Update link names in config files if HW router is used
+        """
+        if not file_name:
+            file_name = '/etc/{rtype}/{daemon}.conf'.format(rtype=self.routertype, daemon=daemon)
+        for linkn in range(self.linkn):
+            default_ifname = '{}-eth{}'.format(self.name, linkn)  # See new_link()
+            hw_iface = self.tgen.config.get(Topogen.CONFIG_SECTION, 'r_link_{}'.format(linkn)).split(',')[-1]
+            self.run('sed -i "s/{iface}/{hwiface}/g" {file_name}'.format(
+                iface=default_ifname, hwiface=hw_iface, file_name=file_name))
+
     def start(self):
         """
         Start router:
@@ -699,6 +738,13 @@ class TopoRouter(TopoGear):
         * Start daemons (e.g. FRR)
         * Configure daemon logging files
         """
+
+        if self.tgen.r_router and self.name == self.tgen.r_router:
+            # Replace interface names in config files
+            for daemon, enabled in self.tgen.net[self.name].daemons.items():
+                if enabled == 1:
+                    self.link_name_update(daemon)
+
         self.logger.debug("starting")
         nrouter = self.tgen.net[self.name]
         result = nrouter.startRouter(self.tgen)
@@ -816,6 +862,8 @@ class TopoRouter(TopoGear):
         """
         # Prepare the temporary file that will hold the commands
         fname = topotest.get_file(commands)
+        if self.tgen.r_router and self.name == self.tgen.r_router:
+            self.tgen.net[self.name].scp(fname, fname)
 
         dparam = ""
         if daemon is not None:

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -70,6 +70,8 @@ CWD = os.path.dirname(os.path.realpath(__file__))
 # Global Topogen variable. This is being used to keep the Topogen available on
 # all test functions without declaring a test local variable.
 global_tgen = None
+# Global remote router name if any
+global_remote_router = None
 
 
 def get_topogen(topo=None):
@@ -87,6 +89,13 @@ def set_topogen(tgen):
     # pylint: disable=W0603
     global global_tgen
     global_tgen = tgen
+
+
+def set_remote_router(r_router):
+    "Helper function to set remote_router"
+    # pylint: disable=W0603
+    global global_remote_router
+    global_remote_router = r_router
 
 
 #
@@ -128,10 +137,17 @@ class Topogen(object):
 
     @property
     def r_router(self):
-        r_router = None
-        if self.config.has_option(self.CONFIG_SECTION, 'r_router'):
-            r_router = self.config.get(self.CONFIG_SECTION, 'r_router')
-        return pytest.config.getoption('r_router') or r_router
+        global global_remote_router
+        if global_remote_router is not None:
+            # Global remote_router is set by CLI option and has a precedence.
+            return global_remote_router
+        else:
+            # Otherwise check pytest.ini
+            r_router = None
+            if self.config.has_option(self.CONFIG_SECTION, 'r_router'):
+                r_router = self.config.get(self.CONFIG_SECTION, 'r_router')
+                global_remote_router = r_router
+            return r_router
 
     @staticmethod
     def _mininet_reset():

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -35,6 +35,9 @@ import platform
 import difflib
 import time
 import signal
+import pty
+import select
+from subprocess import PIPE, STDOUT
 
 from lib.topolog import logger
 from copy import deepcopy
@@ -49,8 +52,9 @@ from mininet.net import Mininet
 from mininet.node import Node, OVSSwitch, Host
 from mininet.log import setLogLevel, info
 from mininet.cli import CLI
-from mininet.link import Intf
+from mininet.link import Intf, Link
 from mininet.term import makeTerm
+from mininet.util import quietRun
 
 g_extra_config = {}
 
@@ -447,6 +451,17 @@ def int2dpid(dpid):
             "please either specify a dpid or use a "
             "canonical switch name such as s23."
         )
+
+
+def remote_pid_exists(pid, node):
+    "Stub for a check whether remote pid exists."
+
+    if pid <= 0:
+        return False
+    if node.cmd('kill -0 %s' % pid):
+        return False
+    else:
+        return True
 
 
 def pid_exists(pid):
@@ -1060,8 +1075,10 @@ def addRouter(topo, name):
         "/var/run/frr",
         "/var/log",
     ]
+    if opts.get('cls'):
+        return topo.addNode(name, cls=opts.pop('cls'), privateDirs=MyPrivateDirs, **opts)
     if sys.platform.startswith("linux"):
-        return topo.addNode(name, cls=LinuxRouter, privateDirs=MyPrivateDirs)
+        return topo.addNode(name, cls=LinuxRouter, privateDirs=MyPrivateDirs, **opts)
     elif sys.platform.startswith("freebsd"):
         return topo.addNode(name, cls=FreeBSDRouter, privateDirs=MyPrivateDirs)
 
@@ -1192,8 +1209,8 @@ class Router(Node):
         self.stopRouter()
 
         # Disable forwarding
-        set_sysctl(self, "net.ipv4.ip_forward", 0)
-        set_sysctl(self, "net.ipv6.conf.all.forwarding", 0)
+        set_sysctl(self, 'net.ipv4.ip_forward', 0)
+        set_sysctl(self, 'net.ipv6.conf.all.forwarding', 0)
         super(Router, self).terminate()
         os.system("chmod -R go+rw /tmp/topotests")
 
@@ -1219,12 +1236,16 @@ class Router(Node):
         errors = ""
         if re.search(r"No such file or directory", rundaemons):
             return errors
+        if isinstance(self, RemoteMixin):
+            pidExists = lambda p: remote_pid_exists(p, self)
+        else:
+            pidExists = pid_exists
         if rundaemons is not None:
             dmns = rundaemons.split("\n")
             # Exclude empty string at end of list
             for d in dmns[:-1]:
                 daemonpid = self.cmd("cat %s" % d.rstrip()).rstrip()
-                if daemonpid.isdigit() and pid_exists(int(daemonpid)):
+                if daemonpid.isdigit() and pidExists(int(daemonpid)):
                     daemonname = os.path.basename(d.rstrip().rsplit(".", 1)[0])
                     logger.info("{}: stopping {}".format(self.name, daemonname))
                     try:
@@ -1274,7 +1295,7 @@ class Router(Node):
                 # Exclude empty string at end of list
                 for d in dmns[:-1]:
                     daemonpid = self.cmd("cat %s" % d.rstrip()).rstrip()
-                    if daemonpid.isdigit() and pid_exists(int(daemonpid)):
+                    if daemonpid.isdigit() and pidExists(int(daemonpid)):
                         logger.info(
                             "{}: killing {}".format(
                                 self.name,
@@ -1367,6 +1388,8 @@ class Router(Node):
 
     def startRouter(self, tgen=None):
         # Disable integrated-vtysh-config
+        logger.info("# startRouter: %s" % str(self.cmd('hostname')))
+        logger.info(self.daemons)
         self.cmd(
             'echo "no service integrated-vtysh-config" >> /etc/%s/vtysh.conf'
             % self.routertype
@@ -1891,6 +1914,339 @@ class Router(Node):
             leakfile.close()
 
 
+class RemoteMixin(object):
+    """A mix-in class to turn local nodes into remote nodes"""
+
+    # ssh base command
+    # -q: don't print stupid diagnostic messages
+    # BatchMode yes: don't ask for password
+    # ForwardAgent yes: forward authentication credentials
+    sshbase = ['ssh', '-q', '-o', 'StrictHostKeyChecking=no',
+               '-o', 'BatchMode=yes',
+               '-o', 'ForwardAgent=yes', '-tt']
+
+    def __init__(self, name, server='localhost', user=None, serverIP=None,
+                 controlPath=False, splitInit=False, keyFile=None, sshPort=22, **kwargs):
+        """Instantiate a remote node
+           name: name of remote node
+           server: remote server (optional)
+           user: user on remote server (optional)
+           controlPath: specify shared ssh control path (optional)
+           splitInit: split initialization?
+           **kwargs: see Node()"""
+        # We connect to servers by IP address
+        self.server = server if server else 'localhost'
+        self.serverIP = (serverIP if serverIP
+                         else self.findServerIP(self.server))
+        self.user = user
+        # ClusterCleanup.add(server=server, user=user)
+        if controlPath is True:
+            # Set a default control path for shared SSH connections
+            controlPath = '/tmp/mn-%r@%h:%p'
+        self.controlPath = controlPath
+        self.keyFile = keyFile
+        self.sshPort = str(sshPort)
+        self.splitInit = splitInit
+        if self.user and self.server != 'localhost':
+            self.dest = '%s@%s' % (self.user, self.serverIP)
+            self.sshcmd = [] + self.sshbase + ['-p', self.sshPort]
+            if self.controlPath:
+                self.sshcmd += ['-o', 'ControlPath=' + self.controlPath,
+                                '-o', 'ControlMaster=auto',
+                                '-o', 'ControlPersist=' + '1']
+            if self.keyFile:
+                self.sshcmd += ['-i', self.keyFile, ]
+            self.sshcmd += [self.dest]
+            self.isRemote = True
+        else:
+            self.dest = None
+            self.sshcmd = []
+            self.isRemote = False
+        # Satisfy pylint
+        self.shell, self.pid = None, None
+        # info("super RemoteMixin\n")
+        super(RemoteMixin, self).__init__(name, **kwargs)
+
+    # Determine IP address of local host
+    _ipMatchRegex = re.compile(r'\d+\.\d+\.\d+\.\d+')
+
+    @classmethod
+    def findServerIP(cls, server):
+        """Return our server's IP address"""
+        # First, check for an IP address
+        ipmatch = cls._ipMatchRegex.findall( server )
+        if ipmatch:
+            return ipmatch[0]
+        # Otherwise, look up remote server
+        output = quietRun('getent ahostsv4 %s' % server)
+        ips = cls._ipMatchRegex.findall(output)
+        ip = ips[0] if ips else None
+        return ip
+
+    # Command support via shell process in namespace
+    def _startShell(self, mnopts=None):
+        """Start a shell process for running commands"""
+        if self.shell:
+            logger.error("%s: shell is already running\n" % self.name)
+            return
+        # bash -i: force interactive
+        # -s: pass $* to shell, and make process easy to find in ps
+        # prompt is set to sentinel chr( 127 )
+        cmd = ['env', 'PS1=' + chr(127), 'bash', '--norc', '--noediting', '-is']
+
+        # Spawn a shell subprocess in a pseudo-tty, to disable buffering
+        # in the subprocess and insulate it from signals (e.g. SIGINT)
+        # received by the parent
+        logger.debug(cmd)
+        self.master, self.slave = pty.openpty()
+        self.shell = self._popen(cmd, stdin=self.slave, stdout=self.slave,
+                                 stderr=self.slave, close_fds=False)
+        # XXX BL: This doesn't seem right, and we should also probably
+        # close our files when we exit...
+        self.stdin = os.fdopen(self.master, 'r')
+        self.stdout = self.stdin
+        self.pid = self.shell.pid
+        self.pollOut = select.poll()
+        self.pollOut.register(self.stdout)
+        # Maintain mapping between file descriptors and nodes
+        # This is useful for monitoring multiple nodes
+        # using select.poll()
+        self.outToNode[self.stdout.fileno()] = self
+        self.inToNode[self.stdin.fileno()] = self
+        self.execed = False
+        self.lastCmd = None
+        self.lastPid = None
+        self.readbuf = ''
+        # Wait for prompt
+        while True:
+            data = self.read(1024)
+            if data[-1] == chr(127):
+                break
+            self.pollOut.poll()
+        self.waiting = False
+        # +m: disable job control notification
+        self.cmd('unset HISTFILE; stty -echo; set +m')
+
+    # Command support via shell process in namespace
+    def startShell(self, *args, **kwargs):
+        """Start a shell process for running commands"""
+        info("RemoteMixin startShell\n")
+        if self.isRemote:
+            kwargs.update(mnopts='-c')
+        self._startShell(*args, **kwargs)
+        # Optional split initialization
+        self.sendCmd('echo $$')
+        if not self.splitInit:
+            self.finishInit()
+
+    def finishInit(self):
+        """Wait for split initialization to complete"""
+        self.pid = int(self.waitOutput())
+
+    def rpopen(self, *cmd, **opts):
+        """Return a Popen object on underlying server in root namespace"""
+        params = {'stdin': PIPE,
+                  'stdout': PIPE,
+                  'stderr': STDOUT,
+                  'sudo': True}
+        params.update(opts)
+        return self._popen(*cmd, **params)
+
+    def rcmd(self, *cmd, **opts):
+        """rcmd: run a command on underlying server
+           in root namespace
+           args: string or list of strings
+           returns: stdout and stderr"""
+        info("& " + self.name + ": " + " ".join(cmd))
+        popen = self.rpopen(*cmd, **opts)
+        # info( 'RCMD: POPEN:', popen, '\n' )
+        # These loops are tricky to get right.
+        # Once the process exits, we can read
+        # EOF twice if necessary.
+        result = b''
+        while True:
+            poll = popen.poll()
+            result += popen.stdout.read()
+            if poll is not None:
+                break
+        return result
+
+    @staticmethod
+    def _ignoreSignal():
+        """Detach from process group to ignore all signals"""
+        os.setpgrp()
+
+    def _popen( self, cmd, sudo=False, tt=True, local=False, **params):
+        """Spawn a process on a remote node
+            cmd: remote command to run (list)
+            **params: parameters to Popen()
+            returns: Popen() object"""
+        if type(cmd) is str:
+            cmd = cmd.split()
+        if self.isRemote and not local:
+            if sudo:
+                cmd = ['sudo', '-E'] + cmd
+            if tt:
+                cmd = self.sshcmd + cmd
+            else:
+                # Hack: remove -tt
+                sshcmd = list(self.sshcmd)
+                sshcmd.remove('-tt')
+                cmd = sshcmd + cmd
+        else:
+            if self.user and not sudo:
+                # Drop privileges
+                cmd = ['sudo', '-E', '-u', self.user] + cmd
+        params.update(preexec_fn=self._ignoreSignal)
+        logger.debug('_popen', cmd, '\n')
+        popen = super(RemoteMixin, self)._popen(cmd, **params)
+        return popen
+
+    def popen(self, *args, **kwargs):
+        """Override: disable -tt"""
+        return super(RemoteMixin, self).popen(*args, tt=False, **kwargs)
+
+    def addIntf(self, *args, **kwargs):
+        """Override: use RemoteLink.moveIntf"""
+        # kwargs.update( moveIntfFn=RemoteLink.moveIntf )
+        return super(RemoteMixin, self).addIntf(*args, **kwargs)
+
+    def scp(self, src, dest):
+        """Copy file to the remote router"""
+        scpcmd = 'scp -P {port} -o StrictHostKeyChecking=no -i {keyFile} {source} {user}@{host}:{dest}'.format(
+            port=self.sshPort, keyFile=self.keyFile, source=src, dest=dest, user=self.user, host=self.server)
+        logger.debug("scp[%s:%s]: %s" % (self.name, self.serverIP, scpcmd))
+        self.rcmd(scpcmd, local=True)
+
+    def loadConf(self, daemon, source=None, param=None):
+        """Load FRR daemons configuration files"""
+        if daemon in self.daemons.keys():
+            self.daemons[daemon] = 1
+            if param is not None:
+                self.daemons_options[daemon] = param
+            if source is None:
+                self.cmd('touch /etc/%s/%s.conf' % (self.routertype, daemon))
+            else:
+                self.scp(src=source, dest='/etc/{rtype}/{daemon}.conf'.format(rtype=self.routertype, daemon=daemon))
+            self.waitOutput()
+            self.cmd('chmod 640 /etc/%s/%s.conf' % (self.routertype, daemon))
+            self.waitOutput()
+            self.cmd('chown %s:%s /etc/%s/%s.conf' % (self.routertype, self.routertype, self.routertype, daemon))
+            self.waitOutput()
+            if (daemon == 'zebra') and (self.daemons['staticd'] == 0):
+                # Add staticd with zebra - if it exists
+                staticd_path = os.path.join(self.daemondir, 'staticd')
+                if os.path.isfile(staticd_path):
+                    self.daemons['staticd'] = 1
+                    self.daemons_options['staticd'] = ''
+                    # Auto-Started staticd has no config, so it will read from zebra config
+        else:
+            logger.info('No daemon {} known'.format(daemon))
+
+
+class HWIntf(Intf):
+    """Patch interface on an OVSSwitch"""
+
+    def delete(self):
+        """Delete interface"""
+        self.cmd('ip link set dev %s down' % self.name)
+        self.link = None
+
+
+class RemoteLink(Link):
+    """A RemoteLink is a link between nodes which may be on different servers"""
+
+    def __init__(self, node1, node2, **kwargs):
+        """Initialize a RemoteLink
+           see Link() for parameters"""
+        # Create links on remote node
+        self.node1 = node1
+        self.node2 = node2
+        self.hwintf = None
+        kwargs.setdefault( 'params1', {} )
+        kwargs.setdefault( 'params2', {} )
+        self.cmd = None  # satisfy pylint
+        self.extraopts = kwargs
+        if kwargs.get('hwport1'):
+             kwargs['intfName1'] = kwargs.pop('hwport1')
+        if kwargs.get('hwport2'):
+            kwargs['intfName2'] = kwargs.pop('hwport2')
+        Link.__init__( self, node1, node2, **kwargs )
+
+    def stop(self):
+        """Stop this link"""
+        if self.hwintf:
+            info("do nothing with HW ports.")
+        else:
+            Link.stop(self)
+        self.hwintf = None
+
+    def makeIntfPair(self, intfname1, intfname2, addr1=None, addr2=None,
+                     node1=None, node2=None, deleteIntfs=True):
+        """Create pair of interfaces
+            intfname1: name of interface 1
+            intfname2: name of interface 2
+            (override this method [and possibly delete()]
+            to change link type)"""
+        node1 = self.node1 if node1 is None else node1
+        node2 = self.node2 if node2 is None else node2
+        server1 = getattr(node1, 'server', 'localhost')
+        server2 = getattr(node2, 'server', 'localhost')
+        if server1 == server2:
+            # Link within same server
+            return Link.makeIntfPair(intfname1, intfname2, addr1, addr2,
+                                     node1, node2, deleteIntfs=deleteIntfs)
+        # Otherwise, use HW interface
+        self.hwintf = self.useHardLink(node1, node2, intfname1, intfname2,
+                                       addr1, addr2)
+        return self.hwintf
+
+    @staticmethod
+    def moveIntf(intf, node):
+        """Move remote interface from root ns to node
+            intf: string, interface
+            dstNode: destination Node
+            srcNode: source Node or None (default) for root ns"""
+        intf = str(intf)
+        cmd = 'ip link set %s netns %s' % (intf, node.pid)
+        result = node.rcmd(cmd)
+        if result:
+            raise Exception('error executing command %s' % cmd)
+        return True
+
+    def useHardLink(self, node1, node2, intf1, intf2, addr1=None, addr2=None):
+        """Make a veth pair connnecting new interfaces intf1 and intf2
+           intf1: name for interface 1
+           intf2: name for interface 2
+           addr1: MAC address for interface 1 (optional)
+           addr2: MAC address for interface 2 (optional)
+           node1: home node for interface 1 (optional)
+           node2: home node for interface 2 (optional)
+           deleteIntfs: delete intfs before creating them
+           runCmd: function to run shell commands (quietRun)
+           raises Exception on failure"""
+        # Create new pair
+        info("Make links: %s:%s - %s:%s (%s, %s)" % (node1, intf1, node2, intf2, addr1, addr2))
+        cmdOutput = ""
+        if cmdOutput:
+            raise Exception("Error creating interface pair (%s,%s): %s " %
+                            (intf1, intf2, cmdOutput))
+
+    def status(self):
+        """Detailed representation of link"""
+        if self.hwintf:
+            status = "OK"
+        else:
+            status = "OK"
+        result = "%s %s" % (Link.status(self), status)
+        return result
+
+
+class RemoteRouter(RemoteMixin, Node):
+    """A node on a remote server"""
+    pass
+
+
 class LinuxRouter(Router):
     "A Linux Router Node with IPv4/IPv6 forwarding enabled."
 
@@ -1918,6 +2274,45 @@ class LinuxRouter(Router):
         set_sysctl(self, "net.ipv4.ip_forward", 0)
         set_sysctl(self, "net.ipv6.conf.all.forwarding", 0)
         Router.terminate(self)
+
+
+class RemoteLinuxRouter(RemoteMixin, Router):
+    """A Linux Router Node with IPv4/IPv6 forwarding enabled."""
+
+    def __init__(self, name, **params):
+        super(RemoteLinuxRouter, self).__init__(name, **params)
+
+    def config(self, **params):
+        Router.config(self, **params)
+
+        info("#" * 79 + "\n")
+        info("# HOSTNAME = ")
+        self.cmd('hostname')
+        info("#" * 79 + "\n")
+
+        # Enable forwarding on the router
+        assert_sysctl(self, 'net.ipv4.ip_forward', 1)
+        assert_sysctl(self, 'net.ipv6.conf.all.forwarding', 1)
+        # Enable coredumps
+        assert_sysctl(self, 'kernel.core_uses_pid', 1)
+        assert_sysctl(self, 'fs.suid_dumpable', 1)
+        #this applies to the kernel not the namespace...
+        #original on ubuntu 17.x, but apport won't save as in namespace
+        # |/usr/share/apport/apport %p %s %c %d %P
+        corefile = '%e_core-sig_%s-pid_%p.dmp'
+        assert_sysctl(self, 'kernel.core_pattern', corefile)
+
+    def terminate(self):
+        """
+        Terminate generic LinuxRouter Mininet instance
+        """
+        set_sysctl(self, 'net.ipv4.ip_forward', 0)
+        set_sysctl(self, 'net.ipv6.conf.all.forwarding', 0)
+        Router.terminate(self)
+
+    def cmd(self, *args, **kwargs):
+        kwargs['verbose'] = kwargs.get('verbose', True)
+        return super(RemoteLinuxRouter, self).cmd(*args, **kwargs)
 
 
 class FreeBSDRouter(Router):


### PR DESCRIPTION
Because of the expensiveness of Network OS testing on physical devices, it is a good practice to run test scripts in an emulated environment first. 

Anyway, switching from emulation to testing on equipment is inevitable at some point. With the proposed patch engineer won’t need to make any changes in tests or the test framework in order to do this switch.

Moreover, we can have a fully virtual topology with multiple hosts and replace one of the mock devices with a real one.

The solution is ready-to-go for routing testing on DENT OS (or any other flavor of ONL). For SONiC, you will need to adapt it a bit.

To use it user have to add new properties to the topogen section in the pytest.ini.

```
; Default router name to replace with a real HW device
r_router = r1
; HW router IP address
r_server = 192.168.0.2
r_user = root 
r_keyFile = /root/.ssh/id_rsa 
r_sshPort = 22 
r_links_num = 4 
; Interface names on Test Host and HW router respectively
r_link_0 = enp2,eth1 
r_link_1 = enp3,eth2 
r_link_2 = enp4,eth3 
r_link_3 = enp5,eth4 
```
Run the test:
```
cd frr/tests/topotests/bgp_reject_as_sets 
sudo python test_bgp_reject_as_sets.py -k test_bgp_reject_as_sets --hw-router=r2
```

Since different tests may have various router names in the topology, default r_router can be re-defined using the CLI option `--hw-router=NAME`.
By placing a non-existent router name, the user can run a test on a virtual topology.

More on how the solution works and how to start using it can be found in the [blog post](https://plvision.eu/rd-lab/blog/opensource/mininet-testing-network-features-on-linux-switch).