### PR TITLE
bgpd: fix crash during configuration removal

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -326,7 +326,9 @@ static void bgp_peer_remove_bfd(struct peer *p)
 		return;
 	}
 
-	bfd_sess_free(&p->bfd_config->session);
+	if (p->bfd_config)
+		bfd_sess_free(&p->bfd_config->session);
+
 	XFREE(MTYPE_BFD_CONFIG, p->bfd_config);
 }
 


### PR DESCRIPTION
Test the BFD config pointer before trying to free the session as it might not exist.

To Reproduce
---

```sh
vtysh -c 'conf t' -c 'router bgp 65000' \
  -c 'neighbor 10.10.10.10 remote-as internal' \
  -c 'neighbor 10.10.10.10 bfd' \
  -c 'no neighbor 10.10.10.10 bfd' \
  -c 'no neighbor 10.10.10.10 bfd'
```