### PR TITLE
ospf6d: remove extra debug message

### DIFF
--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1977,7 +1977,6 @@ static int ospf6_write(struct thread *thread)
 					  __func__, latency);
 			oi->last_hello = timestamp;
 			oi->hello_out++;
-			ospf6_hello_print(oh, OSPF6_ACTION_SEND);
 			break;
 		case OSPF6_MESSAGE_TYPE_DBDESC:
 			oi->db_desc_out++;


### PR DESCRIPTION
Somehow the hello message debugging code slipped outside the debug guard. Lets just remove it.

Acidentally introduced by this commit: https://github.com/FRRouting/frr/commit/3d9680313e663a6f906db9cf87b568cb25b62b9b

**NOTE** this is not present in FRR 8.0.


Sample
---

This PR removes the following unguarded debug messages:

```
2021/07/14 17:52:55 OSPF6: [GNVTE-A64WG]     OSPFv3 Type:1 Len:40 Router-ID:10.254.254.1
2021/07/14 17:52:55 OSPF6: [RA6WJ-XZB2C]     Area-ID:0.0.0.0 Cksum:0 Instance-ID:0
2021/07/14 17:52:55 OSPF6: [K6N0H-3Q3W7]     I/F-Id:3 Priority:1 Option:--|R|-|--|E|V6
2021/07/14 17:52:55 OSPF6: [MFC3G-8KW9N]     HelloInterval:2 DeadInterval:8
2021/07/14 17:52:55 OSPF6: [SMPBA-YB7BT]     DR:10.254.254.1 BDR:0.0.0.0
```