### PR TITLE
zebra: fix ifp pointer for groups/recursives

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -453,8 +453,13 @@ static void *zebra_nhg_hash_alloc(void *arg)
 	/* Mark duplicate nexthops in a group at creation time. */
 	nexthop_group_mark_duplicates(&(nhe->nhg));
 
-	/* Add the ifp now if it's not a group or recursive and has ifindex */
-	if (nhe->nhg.nexthop && nhe->nhg.nexthop->ifindex) {
+	/*
+	 * Add the ifp now if it's not a group or recursive and has ifindex.
+	 *
+	 * A proto-owned ID is always a group.
+	 */
+	if (!PROTO_OWNED(nhe) && nhe->nhg.nexthop && !nhe->nhg.nexthop->next
+	    && !nhe->nhg.nexthop->resolved && nhe->nhg.nexthop->ifindex) {
 		struct interface *ifp = NULL;
 
 		ifp = if_lookup_by_index(nhe->nhg.nexthop->ifindex,


### PR DESCRIPTION
At some point we broke the ifp pointer for nhe->ifp such
that it was pointing to an interface even in groups/recurisve
instances.

Add checks here to make it again so that we only set the ifp
pointer if it is a fully resolved singleton NHE.

Signed-off-by: Stephen Worley <sworley@nvidia.com>