### PR TITLE
configure.ac: fix help text to --enable-undefined-sanitizer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -703,7 +703,7 @@ AC_ARG_ENABLE([thread-sanitizer],
 AC_ARG_ENABLE([memory-sanitizer],
   AS_HELP_STRING([--enable-memory-sanitizer], [enable MemorySanitizer support for detecting uninitialized memory reads]))
 AC_ARG_ENABLE([undefined-sanitizer],
-  AS_HELP_STRING([--undefined-sanitizer], [enable UndefinedBehaviorSanitizer support for detecting undefined behavior]))
+  AS_HELP_STRING([--enable-undefined-sanitizer], [enable UndefinedBehaviorSanitizer support for detecting undefined behavior]))
 AC_ARG_WITH([crypto],
   AS_HELP_STRING([--with-crypto=<internal|openssl>], [choose between different implementations of cryptographic functions(default value is --with-crypto=internal)]))
 AC_ARG_WITH([frr-format],


### PR DESCRIPTION
Change option text from `--undefined-sanitizer` to `--enable-undefined-sanitizer`, or else the option is not recognized.