### PR TITLE
tests: Reduce bgp_conditional_advertisement converge time 10x

### DIFF
--- a/tests/topotests/bgp_conditional_advertisement/r1/bgpd.conf
+++ b/tests/topotests/bgp_conditional_advertisement/r1/bgpd.conf
@@ -17,6 +17,7 @@ route-map DEF permit 10
 !
 router bgp 1
  bgp log-neighbor-changes
+ bgp conditional-advertisement timer 5
  no bgp ebgp-requires-policy
  neighbor 10.10.10.2 remote-as 2
  !

--- a/tests/topotests/bgp_conditional_advertisement/r2/bgpd.conf
+++ b/tests/topotests/bgp_conditional_advertisement/r2/bgpd.conf
@@ -32,6 +32,7 @@ route-map RMAP-2 deny 10
 !
 router bgp 2
  bgp log-neighbor-changes
+ bgp conditional-advertisement timer 5
  no bgp ebgp-requires-policy
  neighbor 10.10.10.1 remote-as 1
  neighbor 10.10.20.3 remote-as 3

--- a/tests/topotests/bgp_conditional_advertisement/r3/bgpd.conf
+++ b/tests/topotests/bgp_conditional_advertisement/r3/bgpd.conf
@@ -1,6 +1,7 @@
 !
 router bgp 3
  bgp log-neighbor-changes
+ bgp conditional-advertisement timer 5
  no bgp ebgp-requires-policy
  neighbor 10.10.20.2 remote-as 2
  !


### PR DESCRIPTION
~15min vs. ~1min.

Before:
```
1 passed, 1 skipped in 908.61 seconds
```

After:
```
1 passed, 1 skipped in 82.94 seconds
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>