### PR TITLE
pimd: IGMPv3 conformance fixes for invalid TTL and invalid TOS

### DIFF
--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -494,6 +494,17 @@ bool pim_igmp_verify_header(struct ip *ip_hdr, size_t len, int igmp_msg_len,
 		}
 	}
 
+	if ((msg_type == PIM_IGMP_V3_MEMBERSHIP_REPORT)
+	    || ((msg_type == PIM_IGMP_MEMBERSHIP_QUERY)
+		&& (igmp_msg_len >= IGMP_V3_SOURCES_OFFSET))) {
+		/* All IGMPv3 messages must be received with TOS set to 0xC0*/
+		if (ip_hdr->ip_tos != IPTOS_PREC_INTERNETCONTROL) {
+			zlog_warn("Received IGMP Packet with invalid TOS %u",
+				  ip_hdr->ip_tos);
+			return -1;
+		}
+	}
+
 	return true;
 }
 

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -484,6 +484,16 @@ bool pim_igmp_verify_header(struct ip *ip_hdr, size_t len, int igmp_msg_len,
 		return false;
 	}
 
+	if ((msg_type != PIM_IGMP_MTRACE_RESPONSE)
+	    && (msg_type != PIM_IGMP_MTRACE_QUERY_REQUEST)) {
+		if (ip_hdr->ip_ttl != 1) {
+			zlog_warn(
+				"Recv IGMP packet with invalid ttl=%u, discarding the packet",
+				ip_hdr->ip_ttl);
+			return -1;
+		}
+	}
+
 	return true;
 }
 

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -116,7 +116,8 @@ void igmp_sock_delete(struct igmp_sock *igmp);
 void igmp_sock_free(struct igmp_sock *igmp);
 void igmp_sock_delete_all(struct interface *ifp);
 int pim_igmp_packet(struct igmp_sock *igmp, char *buf, size_t len);
-
+bool pim_igmp_verify_header(struct ip *ip_hdr, size_t len, int igmp_msg_len,
+			    int msg_type);
 void pim_igmp_general_query_on(struct igmp_sock *igmp);
 void pim_igmp_general_query_off(struct igmp_sock *igmp);
 void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp);


### PR DESCRIPTION
1. IGMPv3 packets with invalid TTL should be dropped.
Test Case ID: 4.10
TEST_DESCRIPTION
Every IGMP message described in this document is sent with an IP
Time-to-Live of 1 (Tests that IGMPv3 Membership Report Message
conforms to above statement)
TEST_REFERENCE
NEGATIVE: RFC 3376, IGMP Version 3, s4 p7 Message Formats
Issue: #9070

2. IGMPv3 packets with invalid TOS should be dropped.
Test Case ID: 4.10
TEST_DESCRIPTION
Every IGMP message described in this document is sent with
IP Precedence of Internetwork Control (e.g., Type of Service
0xc0)
(Tests that IGMPv3 Membership Query Message conforms to
above statement)
TEST_REFERENCE
NEGATIVE: RFC 3376, IGMP Version 3, s4 p7 Message Formats
Issue: #9071

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>