### PR TITLE
bgpd: Allow for auto-completion of community alias's created

### DIFF
--- a/bgpd/bgp_community_alias.c
+++ b/bgpd/bgp_community_alias.c
@@ -152,3 +152,32 @@ const char *bgp_community2alias(char *community)
 
 	return community;
 }
+
+static int bgp_community_alias_vector_walker(struct hash_bucket *bucket,
+					     void *data)
+{
+	vector *comps = data;
+	struct community_alias *alias = bucket->data;
+
+	vector_set(*comps, XSTRDUP(MTYPE_COMPLETION, alias->alias));
+
+	return 1;
+}
+
+static void bgp_community_alias_cmd_completion(vector comps,
+					       struct cmd_token *token)
+{
+	hash_walk(bgp_ca_alias_hash, bgp_community_alias_vector_walker, &comps);
+}
+
+static const struct cmd_variable_handler community_alias_handlers[] = {
+	{.varname = "alias_name",
+	 .completions = bgp_community_alias_cmd_completion},
+	{.tokenname = "ALIAS_NAME",
+	 .completions = bgp_community_alias_cmd_completion},
+	{.completions = NULL}};
+
+void bgp_community_alias_command_completion_setup(void)
+{
+	cmd_variable_handler_register(community_alias_handlers);
+}

--- a/bgpd/bgp_community_alias.h
+++ b/bgpd/bgp_community_alias.h
@@ -42,5 +42,6 @@ extern void bgp_ca_community_delete(struct community_alias *ca);
 extern void bgp_ca_alias_delete(struct community_alias *ca);
 extern int bgp_community_alias_write(struct vty *vty);
 extern const char *bgp_community2alias(char *community);
+extern void bgp_community_alias_command_completion_setup(void);
 
 #endif /* FRR_BGP_COMMUNITY_ALIAS_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12196,7 +12196,7 @@ DEFPY(show_ip_bgp_json, show_ip_bgp_json_cmd,
                      |route-filter-translated-v4] [exact-match]\
           |rpki <invalid|valid|notfound>\
           |version (1-4294967295)\
-          |alias WORD\
+          |alias ALIAS_NAME\
           ] [json$uj [detail$detail] | wide$wide]",
       SHOW_STR IP_STR BGP_STR BGP_INSTANCE_HELP_STR BGP_AFI_HELP_STR
 	      BGP_SAFI_WITH_LABEL_HELP_STR

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1565,7 +1565,7 @@ void cli_show_router_bgp_router_id(struct vty *vty, struct lyd_node *dnode,
 }
 
 DEFPY(bgp_community_alias, bgp_community_alias_cmd,
-      "[no$no] bgp community alias WORD$community WORD$alias",
+      "[no$no] bgp community alias WORD$community ALIAS_NAME$alias_name",
       NO_STR BGP_STR
       "Add community specific parameters\n"
       "Create an alias for a community\n"
@@ -1585,7 +1585,7 @@ DEFPY(bgp_community_alias, bgp_community_alias_cmd,
 	memset(&ca1, 0, sizeof(ca1));
 	memset(&ca2, 0, sizeof(ca2));
 	strlcpy(ca1.community, community, sizeof(ca1.community));
-	strlcpy(ca1.alias, alias, sizeof(ca1.alias));
+	strlcpy(ca1.alias, alias_name, sizeof(ca1.alias));
 
 	lookup_community = bgp_ca_community_lookup(&ca1);
 	lookup_alias = bgp_ca_alias_lookup(&ca1);
@@ -20970,4 +20970,6 @@ void community_alias_vty(void)
 
 	/* Community-list.  */
 	install_element(CONFIG_NODE, &bgp_community_alias_cmd);
+
+	bgp_community_alias_command_completion_setup();
 }


### PR DESCRIPTION
Add a bit of code to allow for auto-completion of the community
alias command when attempting to use it for show commands.

example:
eva(config)# bgp community alias 11:22 FOO
eva(config)# end
eva# show bgp ipv4 uni alias
  ALIAS_NAME  BGP community alias
     FOO

Signed-off-by: Donald Sharp <sharpd@nvidia.com>