### PR TITLE
lib: update the interface name when if context is available

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -624,12 +624,17 @@ struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id)
 	case VRF_BACKEND_VRF_LITE:
 		ifp = if_lookup_by_index_all_vrf(ifindex);
 		if (ifp) {
-			if (ifp->vrf_id == vrf_id)
+			if (ifp->vrf_id == vrf_id) {
+				if (name)
+					if_set_name(ifp, name, NULL);
 				return ifp;
+			}
 			/* If it came from the kernel or by way of zclient,
 			 * believe it and update the ifp accordingly.
 			 */
 			if_update_to_new_vrf(ifp, vrf_id);
+			if (name)
+				if_set_name(ifp, name, NULL);
 			return ifp;
 		}
 		return if_create_ifindex(ifindex, vrf_id);


### PR DESCRIPTION
it has been seen at startup that the parsing of a whole list of
interfaces leads to the following situation:
- function netlink_interface() retrieves an interface
- this interface somehow has already been allocated in the list
with the same index

When refreshing that new interface, if_get_by_ifindex() is called,
and because an interface with appopriate index is found, the name
will not be refreshed, with or without vrf change.

Try to fix this by updating if_get_by_ifindex() code appropriately
for the vrflite case.

The below trace shows what happens if the fix is not present, before
and after if_get_by_ifindex():

netlink_interface() (before) interface ethgrp1064 vrid 253 (index 254)
if_get_by_ifindex() get ifp idx 254 newvrf 253
netlink_interface() (afte) interface vrid 253 index 254

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>