### PR TITLE
pimd: memory leak fix and issue fix

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1232,6 +1232,16 @@ int pim_ifchannel_local_membership_add(struct interface *ifp,
 					   __FILE__, __func__, child->sg_str,
 					   ifp->name, up->sg_str);
 
+			if (!child->rpf.source_nexthop.interface) {
+				/* when iif unknown, do not inherit */
+				if (PIM_DEBUG_EVENTS)
+					zlog_debug(
+						"Skipped (S,G)=%s(%s) from %s: no iif",
+						child->sg_str, ifp->name,
+						up->sg_str);
+				continue;
+			}
+
 			ch = pim_ifchannel_find(ifp, &child->sg);
 			if (pim_upstream_evaluate_join_desired_interface(
 				    child, ch, starch)) {

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -139,11 +139,12 @@ void pim_rp_init(struct pim_instance *pim)
 
 void pim_rp_free(struct pim_instance *pim)
 {
-	if (pim->rp_list)
-		list_delete(&pim->rp_list);
 	if (pim->rp_table)
 		route_table_finish(pim->rp_table);
 	pim->rp_table = NULL;
+
+	if (pim->rp_list)
+		list_delete(&pim->rp_list);
 }
 
 /*


### PR DESCRIPTION
2 issues are present as mentioned below:

Issue1:
======
pimd: pim_ifchannel_local_membership_add should not inherit if (S,G) rpf unresolved

Problem:
S,G entry has iif = oif in FHR is LHR case.

Setup:-

R11-----R2----R4

R11 :- FHR and LHR
R2 :- RP
R4 :- LHR

Issue :-

1) shut mapped interface in R11
2) wait for 5 min
3) do FRR restart
5) No shut of mapped interface

OIL is added for local interface also where OIL is same as IIF
and duplicate traffic observed on R4 receives in Ixia

RCA:
pim_ifchannel_local_membership_add adds inherited oif from starg when iif for
SG is unavailable.
When  rpf for that SG resolves to this inherited oif from starg, iif is also in oif.
This results in dup traffic.

Fix:
If iif is not available, do not inherit from starg.

Issue 2: Memleak
======
2020-05-05 22:09:29,451 ERROR: Memory leaks in router [r4] for daemon [pimd]
2020-05-05 22:09:29,451 ERROR: Memory leaks in router [r4] for daemon [zebra]
2020-05-05 22:09:29,637 ERROR: Found memory leak in module pimd
2020-05-05 22:09:29,638 ERROR: ==6178== 184 (56 direct, 128 indirect) bytes in 1 blocks are definitely lost in loss record 21 of 21
2020-05-05 22:09:29,638 ERROR: ==6178== at 0x4C2FFAC: calloc (vg_replace_malloc.c:762)
2020-05-05 22:09:29,638 ERROR: ==6178== by 0x4E855EE: qcalloc (memory.c:111)
2020-05-05 22:09:29,638 ERROR: ==6178== by 0x4EAA43C: route_table_init_with_delegate (table.c:52)
2020-05-05 22:09:29,638 ERROR: ==6178== by 0x1281A1: pim_rp_init (pim_rp.c:114)
2020-05-05 22:09:29,638 ERROR: ==6178== by 0x11D0F8: pim_instance_init (pim_instance.c:117)
2020-05-05 22:09:29,638 ERROR: ==6178== by 0x11D0F8: pim_vrf_new (pim_instance.c:150)
2020-05-05 22:09:29,638 ERROR: ==6178== by 0x4EB1BEC: vrf_get (vrf.c:209)
2020-05-05 22:09:29,638 ERROR: ==6178== by 0x4EB2B2F: vrf_init (vrf.c:493)
2020-05-05 22:09:29,638 ERROR: ==6178== by 0x11D227: pim_vrf_init (pim_instance.c:217)
2020-05-05 22:09:29,638 ERROR: ==6178== by 0x11BBAB: main (pim_main.c:121)
2020-05-05 22:09:29,638 ERROR: ==6178==

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>