### PR TITLE
zebra: Do not allow redistribution for non-vrf tables

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -153,8 +153,14 @@ static bool zebra_redistribute_check(const struct route_entry *re,
 				     struct zserv *client,
 				     const struct prefix *p, int afi)
 {
+	struct zebra_vrf *zvrf;
+
 	/* Process only if there is valid re */
 	if (!re)
+		return false;
+
+	zvrf = vrf_info_lookup(re->vrf_id);
+	if (re->vrf_id == VRF_DEFAULT && zvrf->table_id != re->table)
 		return false;
 
 	/* If default route and redistributed */


### PR DESCRIPTION
Current code was allowing redistribution of kernel routes from
the non-default non vrf tables once FRR was already up and running.

In the case where we add `redistribute kernel` in an upper level
protocol we never consider the non-default vrf or non-vrf tables
so it is never accepted.

In the case where a kernel route is added after `redistribute kernel`
is already in place we were never looking at the fact that the
route was in a non-default non-vrf table.  This code fixes
that issue.

Fixes: #9073
Signed-off-by: Donald Sharp sharpd2nvidia.com>