### PR TITLE
ospf6d: small batch of random fixes/improvements

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -477,11 +477,11 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		monotime(&summary->changed);
 	}
 
+	summary->prefix_options = route->prefix_options;
 	summary->path.router_bits = route->path.router_bits;
 	summary->path.options[0] = route->path.options[0];
 	summary->path.options[1] = route->path.options[1];
 	summary->path.options[2] = route->path.options[2];
-	summary->path.prefix_options = route->path.prefix_options;
 	summary->path.area_id = area->area_id;
 	summary->path.type = OSPF6_PATH_TYPE_INTER;
 	summary->path.subtype = route->path.subtype;
@@ -514,7 +514,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		/* Fill Inter-Area-Prefix-LSA */
 		OSPF6_ABR_SUMMARY_METRIC_SET(prefix_lsa, route->path.cost);
 		prefix_lsa->prefix.prefix_length = route->prefix.prefixlen;
-		prefix_lsa->prefix.prefix_options = route->path.prefix_options;
+		prefix_lsa->prefix.prefix_options = route->prefix_options;
 
 		/* set Prefix */
 		memcpy(p, &route->prefix.u.prefix6,
@@ -1167,6 +1167,7 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 
 	route->type = type;
 	route->prefix = prefix;
+	route->prefix_options = prefix_options;
 	route->path.origin.type = lsa->header->type;
 	route->path.origin.id = lsa->header->id;
 	route->path.origin.adv_router = lsa->header->adv_router;
@@ -1174,7 +1175,6 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 	route->path.options[0] = options[0];
 	route->path.options[1] = options[1];
 	route->path.options[2] = options[2];
-	route->path.prefix_options = prefix_options;
 	route->path.area_id = oa->area_id;
 	route->path.type = OSPF6_PATH_TYPE_INTER;
 	route->path.cost = abr_entry->path.cost + cost;

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -121,7 +121,7 @@ void ospf6_as_external_lsa_originate(struct ospf6_route *route,
 	as_external_lsa->prefix.prefix_length = route->prefix.prefixlen;
 
 	/* PrefixOptions */
-	as_external_lsa->prefix.prefix_options = route->path.prefix_options;
+	as_external_lsa->prefix.prefix_options = route->prefix_options;
 
 	/* don't use refer LS-type */
 	as_external_lsa->prefix.prefix_refer_lstype = htons(0);
@@ -589,12 +589,12 @@ void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa)
 	route->prefix.prefixlen = external->prefix.prefix_length;
 	ospf6_prefix_in6_addr(&route->prefix.u.prefix6, external,
 			      &external->prefix);
+	route->prefix_options = external->prefix.prefix_options;
 
 	route->path.area_id = asbr_entry->path.area_id;
 	route->path.origin.type = lsa->header->type;
 	route->path.origin.id = lsa->header->id;
 	route->path.origin.adv_router = lsa->header->adv_router;
-	route->path.prefix_options = external->prefix.prefix_options;
 	memcpy(&route->path.ls_prefix, &asbr_id, sizeof(struct prefix));
 
 	if (CHECK_FLAG(external->bits_metric, OSPF6_ASBR_BIT_E)) {

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -89,6 +89,16 @@ void ospf6_lsa_originate(struct ospf6_lsa *lsa)
 	struct ospf6_lsa *old;
 	struct ospf6_lsdb *lsdb_self;
 
+	if (lsa->header->adv_router == INADDR_ANY) {
+		if (IS_OSPF6_DEBUG_ORIGINATE_TYPE(lsa->header->type))
+			zlog_debug(
+				"Refusing to originate LSA (zero router ID): %s",
+				lsa->name);
+
+		ospf6_lsa_delete(lsa);
+		return;
+	}
+
 	/* find previous LSA */
 	old = ospf6_lsdb_lookup(lsa->header->type, lsa->header->id,
 				lsa->header->adv_router, lsa->lsdb);

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -821,7 +821,9 @@ int interface_up(struct thread *thread)
 	}
 
 	/* decide next interface state */
-	if (oi->type == OSPF_IFTYPE_POINTOPOINT) {
+	if (oi->type == OSPF_IFTYPE_LOOPBACK) {
+		ospf6_interface_state_change(OSPF6_INTERFACE_LOOPBACK, oi);
+	} else if (oi->type == OSPF_IFTYPE_POINTOPOINT) {
 		ospf6_interface_state_change(OSPF6_INTERFACE_POINTTOPOINT, oi);
 	} else if (oi->priority == 0)
 		ospf6_interface_state_change(OSPF6_INTERFACE_DROTHER, oi);

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -826,7 +826,7 @@ int ospf6_link_lsa_originate(struct thread *thread)
 	     route && count < max_addr_count;
 	     route = ospf6_route_next(route), count++) {
 		op->prefix_length = route->prefix.prefixlen;
-		op->prefix_options = route->path.prefix_options;
+		op->prefix_options = route->prefix_options;
 		op->prefix_metric = htons(0);
 		memcpy(OSPF6_PREFIX_BODY(op), &route->prefix.u.prefix6,
 		       OSPF6_PREFIX_SPACE(op->prefix_length));
@@ -1193,7 +1193,7 @@ int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 		}
 
 		op->prefix_length = route->prefix.prefixlen;
-		op->prefix_options = route->path.prefix_options;
+		op->prefix_options = route->prefix_options;
 		op->prefix_metric = htons(route->path.cost);
 		memcpy(OSPF6_PREFIX_BODY(op), &route->prefix.u.prefix6,
 		       OSPF6_PREFIX_SPACE(op->prefix_length));
@@ -1356,6 +1356,7 @@ int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 			       sizeof(struct in6_addr));
 			memcpy(&route->prefix.u.prefix6, OSPF6_PREFIX_BODY(op),
 			       OSPF6_PREFIX_SPACE(op->prefix_length));
+			route->prefix_options = op->prefix_options;
 
 			route->path.origin.type = lsa->header->type;
 			route->path.origin.id = lsa->header->id;
@@ -1363,7 +1364,6 @@ int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 			route->path.options[0] = link_lsa->options[0];
 			route->path.options[1] = link_lsa->options[1];
 			route->path.options[2] = link_lsa->options[2];
-			route->path.prefix_options = op->prefix_options;
 			route->path.area_id = oi->area->area_id;
 			route->path.type = OSPF6_PATH_TYPE_INTRA;
 
@@ -1384,7 +1384,7 @@ int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 	for (route = ospf6_route_head(route_advertise); route;
 	     route = ospf6_route_best_next(route)) {
 		op->prefix_length = route->prefix.prefixlen;
-		op->prefix_options = route->path.prefix_options;
+		op->prefix_options = route->prefix_options;
 		op->prefix_metric = htons(0);
 		memcpy(OSPF6_PREFIX_BODY(op), &route->prefix.u.prefix6,
 		       OSPF6_PREFIX_SPACE(op->prefix_length));
@@ -1817,12 +1817,12 @@ void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa)
 		route->prefix.prefixlen = op->prefix_length;
 		ospf6_prefix_in6_addr(&route->prefix.u.prefix6,
 				      intra_prefix_lsa, op);
+		route->prefix_options = op->prefix_options;
 
 		route->type = OSPF6_DEST_TYPE_NETWORK;
 		route->path.origin.type = lsa->header->type;
 		route->path.origin.id = lsa->header->id;
 		route->path.origin.adv_router = lsa->header->adv_router;
-		route->path.prefix_options = op->prefix_options;
 		route->path.area_id = oa->area_id;
 		route->path.type = OSPF6_PATH_TYPE_INTRA;
 		route->path.metric_type = 1;

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -1296,7 +1296,7 @@ void ospf6_nssa_lsa_originate(struct ospf6_route *route,
 	as_external_lsa->prefix.prefix_length = route->prefix.prefixlen;
 
 	/* PrefixOptions */
-	as_external_lsa->prefix.prefix_options = route->path.prefix_options;
+	as_external_lsa->prefix.prefix_options = route->prefix_options;
 
 	/* Set the P bit */
 	as_external_lsa->prefix.prefix_options |= OSPF6_PREFIX_OPTION_P;

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1138,6 +1138,7 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route,
 {
 	char destination[PREFIX2STR_BUFFER], nexthop[64];
 	char area_id[16], id[16], adv_router[16], capa[16], options[16];
+	char pfx_options[16];
 	struct timeval now, res;
 	char duration[64];
 	struct listnode *node;
@@ -1265,10 +1266,13 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route,
 		vty_out(vty, "Router Bits: %s\n", capa);
 
 	/* Prefix Options */
+	ospf6_prefix_options_printbuf(route->prefix_options, pfx_options,
+				      sizeof(pfx_options));
 	if (use_json)
-		json_object_string_add(json_route, "prefixOptions", "xxx");
+		json_object_string_add(json_route, "prefixOptions",
+				       pfx_options);
 	else
-		vty_out(vty, "Prefix Options: xxx\n");
+		vty_out(vty, "Prefix Options: %s\n", pfx_options);
 
 	/* Metrics */
 	if (use_json) {

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -436,6 +436,7 @@ struct ospf6_route *ospf6_route_copy(struct ospf6_route *route)
 	new = ospf6_route_create();
 	new->type = route->type;
 	memcpy(&new->prefix, &route->prefix, sizeof(struct prefix));
+	new->prefix_options = route->prefix_options;
 	new->installed = route->installed;
 	new->changed = route->changed;
 	new->flag = route->flag;

--- a/ospf6d/ospf6_route.h
+++ b/ospf6d/ospf6_route.h
@@ -79,9 +79,6 @@ struct ospf6_path {
 	/* Optional Capabilities */
 	uint8_t options[3];
 
-	/* Prefix Options */
-	uint8_t prefix_options;
-
 	/* Associated Area */
 	in_addr_t area_id;
 
@@ -146,6 +143,9 @@ struct ospf6_route {
 
 	/* flag */
 	uint8_t flag;
+
+	/* Prefix Options */
+	uint8_t prefix_options;
 
 	/* route option */
 	void *route_option;


### PR DESCRIPTION
Just the usual batch of small pieces you trip over while working on other things.  Mostly fixes.  Please refer to the individual commits/descriptions.

```
    ospf6d: use OSPF6_INTERFACE_LOOPBACK state
    
    The OSPF6_INTERFACE_LOOPBACK interface state wasn't entered anywhere,
    even if the interface was OSPF6_IFTYPE_LOOPBACK.  Fix.
```

``` 
    ospf6d: don't create Adv-ID:0.0.0.0 LSAs at start
    
    When ospf6d comes up, it gets interface and address state before it
    decides on its router ID.  This results in a bunch of LSAs with
    advertising router ID 0.0.0.0 in the LSDB.  Not quite right.
    
    There's a whole bunch of paths leading to this, so just drop the LSA in
    ospf6_lsa_originate.  The router-ID change causes everything to be
    readvertised anyway (... but the delete doesn't catch the 0.0.0.0 stuff
    because the router-ID is now different.)
```

```
    ospf6d: actually print prefix options
    
    Well at least I had a good laugh at the "xxx".
```

```
    ospf6d: move prefix_options from _path to _route
    
    Prefix options are per-prefix, not per-path.  As evident by the fact
    that the field is never used on ECMP paths.  Move it where it belongs.
```