### PR TITLE
ospfd: OSPF hello packets not sent with configured hello timer

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -1447,6 +1447,58 @@ static int ospf_ifp_destroy(struct interface *ifp)
 	return 0;
 }
 
+/* Resetting ospf hello timer */
+void ospf_reset_hello_timer(struct interface *ifp, struct in_addr addr,
+			    bool is_addr)
+{
+	struct route_node *rn;
+
+	if (is_addr) {
+		struct prefix p;
+		struct ospf_interface *oi = NULL;
+
+		p.u.prefix4 = addr;
+		p.family = AF_INET;
+
+		oi = ospf_if_table_lookup(ifp, &p);
+
+		if (oi) {
+			/* Send hello before restart the hello timer
+			 * to avoid session flaps in case of bigger
+			 * hello interval configurations.
+			 */
+			ospf_hello_send(oi);
+
+			/* Restart hello timer for this interface */
+			OSPF_ISM_TIMER_OFF(oi->t_hello);
+			OSPF_HELLO_TIMER_ON(oi);
+		}
+
+		return;
+	}
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+
+		/* If hello interval configured on this oi, don't restart. */
+		if (OSPF_IF_PARAM_CONFIGURED(oi->params, v_hello))
+			continue;
+
+		/* Send hello before restart the hello timer
+		 * to avoid session flaps in case of bigger
+		 * hello interval configurations.
+		 */
+		ospf_hello_send(oi);
+
+		/* Restart the hello timer. */
+		OSPF_ISM_TIMER_OFF(oi->t_hello);
+		OSPF_HELLO_TIMER_ON(oi);
+	}
+}
+
 void ospf_if_init(void)
 {
 	if_zapi_callbacks(ospf_ifp_create, ospf_ifp_up,

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -345,7 +345,8 @@ extern void ospf_if_set_multicast(struct ospf_interface *);
 extern void ospf_if_interface(struct interface *ifp);
 
 extern uint32_t ospf_if_count_area_params(struct interface *ifp);
-
+extern void ospf_reset_hello_timer(struct interface *ifp, struct in_addr addr,
+				   bool is_addr);
 DECLARE_HOOK(ospf_vl_add, (struct ospf_vl_data * vd), (vd));
 DECLARE_HOOK(ospf_vl_delete, (struct ospf_vl_data * vd), (vd));
 

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8305,10 +8305,12 @@ DEFUN (ip_ospf_hello_interval,
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	int idx = 0;
-	struct in_addr addr;
+	struct in_addr addr = {.s_addr = 0L};
 	struct ospf_if_params *params;
 	params = IF_DEF_PARAMS(ifp);
 	uint32_t seconds = 0;
+	bool is_addr = false;
+	uint32_t old_interval = 0;
 
 	argv_find(argv, argc, "(1-65535)", &idx);
 	seconds = strtol(argv[idx]->arg, NULL, 10);
@@ -8322,7 +8324,14 @@ DEFUN (ip_ospf_hello_interval,
 
 		params = ospf_get_if_params(ifp, addr);
 		ospf_if_update_params(ifp, addr);
+		is_addr = true;
 	}
+
+	old_interval = params->v_hello;
+
+	/* Return, if same interval is configured. */
+	if (old_interval == seconds)
+		return CMD_SUCCESS;
 
 	SET_IF_PARAM(params, v_hello);
 	params->v_hello = seconds;
@@ -8337,6 +8346,8 @@ DEFUN (ip_ospf_hello_interval,
 		 */
 		params->v_wait	= 4 * seconds;
 	}
+
+	ospf_reset_hello_timer(ifp, addr, is_addr);
 
 	return CMD_SUCCESS;
 }
@@ -8364,7 +8375,7 @@ DEFUN (no_ip_ospf_hello_interval,
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	int idx = 0;
-	struct in_addr addr;
+	struct in_addr addr = {.s_addr = 0L};
 	struct ospf_if_params *params;
 	struct route_node *rn;
 


### PR DESCRIPTION
Description :

	ospf hello timer is not getting refelcted upon changing the hello interval. Due to this ospf
       waits to send  ospf hello till the old timer got expired, 

scenario:
----------
frr(config-if)# do show ip ospf  interface 
ens192 is up
  ifindex 3, MTU 1500 bytes, BW 10000 Mbit <UP,BROADCAST,RUNNING,MULTICAST>
  Internet Address 10.1.1.220/24, Broadcast 10.1.1.255, Area 0.0.0.1
  MTU mismatch detection: enabled
  Router ID 10.112.156.220, Network Type BROADCAST, Cost: 10
  Transmit Delay is 1 sec, State Backup, Priority 1
  Designated Router (ID) 8.8.8.8 Interface Address 10.1.1.110/24
  Backup Designated Router (ID) 10.112.156.220, Interface Address 10.1.1.220
  Saved Network-LSA sequence number 0x80000005
  Multicast group memberships: OSPFAllRouters OSPFDesignatedRouters
  Timer intervals configured, Hello 10s, Dead 40s, Wait 40s, Retransmit 5
    Hello due in 6.772s
  Neighbor Count is 1, Adjacent neighbor count is 1

frr(config-if)# 
frr(config-if)# 
frr(config-if)# do show ip ospf  neighbor 

Neighbor ID     Pri State           Dead Time Address         Interface                        RXmtL RqstL DBsmL
8.8.8.8           1 Full/DR           38.714s 10.1.1.110      ens192:10.1.1.220                    1     0     0

frr(config-if)# 
frr(config-if)# 
frr(config-if)# 
frr(config-if)# 
frr(config-if)# ip ospf  hello-interval 1000
frr(config-if)# 
frr(config-if)# do show ip ospf  neighbor 

Neighbor ID     Pri State           Dead Time Address         Interface                        RXmtL RqstL DBsmL
8.8.8.8           1 Full/DR           32.494s 10.1.1.110      ens192:10.1.1.220                    0     0     0

frr(config-if)# 
frr(config-if)# 
frr(config-if)# do show ip ospf  interface 
ens192 is up
  ifindex 3, MTU 1500 bytes, BW 10000 Mbit <UP,BROADCAST,RUNNING,MULTICAST>
  Internet Address 10.1.1.220/24, Broadcast 10.1.1.255, Area 0.0.0.1
  MTU mismatch detection: enabled
  Router ID 10.112.156.220, Network Type BROADCAST, Cost: 10
  Transmit Delay is 1 sec, State Backup, Priority 1
  Designated Router (ID) 8.8.8.8 Interface Address 10.1.1.110/24
  Backup Designated Router (ID) 10.112.156.220, Interface Address 10.1.1.220
  Saved Network-LSA sequence number 0x80000005
  Multicast group memberships: OSPFAllRouters OSPFDesignatedRouters
  Timer intervals configured, Hello 1000s, Dead 4000s, Wait 4000s, Retransmit 5
    Hello due in 16m38s
  Neighbor Count is 1, Adjacent neighbor count is 1

frr(config-if)# 
frr(config-if)# 
frr(config-if)# ip ospf  hello-interval 10
frr(config-if)# 
frr(config-if)# 
frr(config-if)# do show ip ospf  interface 
ens192 is up
  ifindex 3, MTU 1500 bytes, BW 10000 Mbit <UP,BROADCAST,RUNNING,MULTICAST>
  Internet Address 10.1.1.220/24, Broadcast 10.1.1.255, Area 0.0.0.1
  MTU mismatch detection: enabled
  Router ID 10.112.156.220, Network Type BROADCAST, Cost: 10
  Transmit Delay is 1 sec, State Backup, Priority 1
  Designated Router (ID) 8.8.8.8 Interface Address 10.1.1.110/24
  Backup Designated Router (ID) 10.112.156.220, Interface Address 10.1.1.220
  Saved Network-LSA sequence number 0x80000005
  Multicast group memberships: OSPFAllRouters OSPFDesignatedRouters
  Timer intervals configured, Hello 10s, Dead 40s, Wait 40s, Retransmit 5
    Hello due in 16m28s <------------------------------------------------------ not getting reset
  Neighbor Count is 1, Adjacent neighbor count is 1

frr(config-if)# 
frr(config-if)# 
frr(config-if)# do show ip ospf  neighbor 

Neighbor ID     Pri State           Dead Time Address         Interface                        RXmtL RqstL DBsmL
8.8.8.8           1 Full/DR           36.046s 10.1.1.110      ens192:10.1.1.220                    0     0     0

frr(config-if)# do show ip ospf  neighbor 

Neighbor ID     Pri State           Dead Time Address         Interface                        RXmtL RqstL DBsmL
8.8.8.8           1 Full/DR           30.160s 10.1.1.110      ens192:10.1.1.220                    0     0     0

frr(config-if)# do show ip ospf  interface 
ens192 is up
  ifindex 3, MTU 1500 bytes, BW 10000 Mbit <UP,BROADCAST,RUNNING,MULTICAST>
  Internet Address 10.1.1.220/24, Broadcast 10.1.1.255, Area 0.0.0.1
  MTU mismatch detection: enabled
  Router ID 10.112.156.220, Network Type BROADCAST, Cost: 10
  Transmit Delay is 1 sec, State DR, Priority 1
  Designated Router (ID) 10.112.156.220 Interface Address 10.1.1.220/24
  No backup designated router on this network
  Saved Network-LSA sequence number 0x80000006
  Multicast group memberships: OSPFAllRouters OSPFDesignatedRouters
  Timer intervals configured, Hello 10s, Dead 40s, Wait 40s, Retransmit 5
    Hello due in 15m55s
  Neighbor Count is 1, Adjacent neighbor count is 0

frr(config-if)# do show ip ospf  neighbor 

Neighbor ID     Pri State           Dead Time Address         Interface                        RXmtL RqstL DBsmL
8.8.8.8           1 Init/DROther      32.044s 10.1.1.110      ens192:10.1.1.220                    0     0     0

frr(config-if)# 
-------------------

Signed-off-by: Rajesh Girada <rgirada@vmware.com>