### PR TITLE
ospfd: ospfd crash while giving 'clear ip ospf neighbor'

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -11389,6 +11389,11 @@ DEFPY (clear_ip_ospf_neighbor,
 		if (!ospf->oi_running)
 			continue;
 
+		if (nbr_id_str && IPV4_ADDR_SAME(&ospf->router_id, &nbr_id)) {
+			vty_out(vty, "Self router-id is not allowed.\r\n ");
+			return CMD_SUCCESS;
+		}
+
 		ospf_neighbor_reset(ospf, nbr_id, nbr_id_str);
 	}
 


### PR DESCRIPTION
Description:
	Ospf process crashes upon giving 'clear ip ospf neighbor' with
        self routerId. It is asserting if it is a self neighbor in ospf
        neighbour kill event processing.
	Added a check to validate the provided router-id is self
        router-id.

Config:
--------
frr# 
frr# show ip ospf  neighbor 

Neighbor ID     Pri State           Dead Time Address         Interface                        RXmtL RqstL DBsmL
8.8.8.8           1 Full/DR           35.665s 10.1.1.110      ens192:10.1.1.220                    0     0     0

frr# 
frr# 
frr# do show ip ospf  
 OSPF Routing Process, Router ID: 10.112.156.220
 Supports only single TOS (TOS0) routes
 This implementation conforms to RFC2328
 RFC1583Compatibility flag is disabled
 OpaqueCapability flag is disabled
 Initial SPF scheduling delay 0 millisec(s)
 Minimum hold time between consecutive SPFs 50 millisec(s)
 Maximum hold time between consecutive SPFs 5000 millisec(s)
 Hold time multiplier is currently 1
 SPF algorithm last executed 1h05m22s ago
 Last SPF duration 29 usecs
 SPF timer is inactive
 LSA minimum interval 5000 msecs
 LSA minimum arrival 1000 msecs
 Write Multiplier set to 20 
 Refresh timer 10 secs
 Maximum multiple paths(ECMP) supported  8
 Number of external LSA 2. Checksum Sum 0x0000d69c
 Number of opaque AS LSA 0. Checksum Sum 0x00000000
 Number of areas attached to this router: 1
 Area ID: 0.0.0.1
   Shortcutting mode: Default, S-bit consensus: no
   Number of interfaces in this area: Total: 1, Active: 1
   Number of fully adjacent neighbors in this area: 1
   Area has no authentication
   Number of full virtual adjacencies going through this area: 0
   SPF algorithm executed 4 times
   Number of LSA 3
   Number of router LSA 2. Checksum Sum 0x0000c16c
   Number of network LSA 1. Checksum Sum 0x00004f4a
   Number of summary LSA 0. Checksum Sum 0x00000000
   Number of ASBR summary LSA 0. Checksum Sum 0x00000000
   Number of NSSA LSA 0. Checksum Sum 0x00000000
   Number of opaque link LSA 0. Checksum Sum 0x00000000
   Number of opaque area LSA 0. Checksum Sum 0x00000000
frr# 
frr# clear ip ospf  neighbor  10.112.156.220
vtysh: error reading from ospfd: Success (0)Warning: closing connection to ospfd because of an I/O error!
frr# 


[New LWP 16078]
[New LWP 16079]
warning: Unexpected size of section `.reg-xstate/16078' in core file.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/usr/lib/frr/ospfd -d -A 127.0.0.1'.
Program terminated with signal SIGABRT, Aborted.

warning: Unexpected size of section `.reg-xstate/16078' in core file.
#0  0x00007f8250b88428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
54      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
[Current thread is 1 (Thread 0x7f82518c0880 (LWP 16078))]
(gdb) bt
#0  0x00007f8250b88428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007f8250b8a02a in __GI_abort () at abort.c:89
#2  0x00007f8250b80bd7 in __assert_fail_base (fmt=<optimized out>, assertion=assertion@entry=0x55e12507e8e4 "nbr != nbr->oi->nbr_self", 
    file=file@entry=0x55e12507e8af "ospfd/ospf_nsm.c", line=line@entry=392, 
    function=function@entry=0x55e12507ec88 <__PRETTY_FUNCTION__.17419> "nsm_kill_nbr") at assert.c:92
#3  0x00007f8250b80c82 in __GI___assert_fail (assertion=assertion@entry=0x55e12507e8e4 "nbr != nbr->oi->nbr_self", 
    file=file@entry=0x55e12507e8af "ospfd/ospf_nsm.c", line=line@entry=392, 
    function=function@entry=0x55e12507ec88 <__PRETTY_FUNCTION__.17419> "nsm_kill_nbr") at assert.c:101
#4  0x000055e125029630 in nsm_kill_nbr (nbr=<optimized out>) at ospfd/ospf_nsm.c:392
#5  0x000055e125029829 in ospf_nsm_event (thread=<optimized out>) at ospfd/ospf_nsm.c:806
#6  0x00007f82515c1cd6 in thread_call (thread=0x55e1262d6460) at lib/thread.c:1557
#7  0x00007f82515c1ed6 in funcname_thread_execute (m=0x55e1260015e0, func=<optimized out>, arg=0x55e1262d4cc0, val=val@entry=11, 
    funcname=funcname@entry=0x55e1250784a7 "ospf_nsm_event", schedfrom=schedfrom@entry=0x55e125099bac "ospfd/ospfd.c", fromln=229) at lib/thread.c:1628
#8  0x000055e12506166c in ospf_neighbor_reset (ospf=<optimized out>, nbr_id=..., nbr_str=nbr_str@entry=0x55e1262da950 "100.1.1.1") at ospfd/ospfd.c:229
#9  0x000055e12504eda9 in clear_ip_ospf_neighbor_magic (self=<optimized out>, vty=0x55e1262dda20, argc=<optimized out>, argv=<optimized out>, 
    instance_str=<optimized out>, nbr_id_str=<optimized out>, nbr_id=..., instance=<optimized out>) at ospfd/ospf_vty.c:12641
#10 clear_ip_ospf_neighbor (self=<optimized out>, vty=0x55e1262dda20, argc=<optimized out>, argv=<optimized out>) at ./ospfd/ospf_vty_clippy.c:651
#11 0x00007f8251576b33 in cmd_execute_command_real (vline=vline@entry=0x55e1262d6420, vty=vty@entry=0x55e1262dda20, cmd=cmd@entry=0x0, 
    filter=FILTER_RELAXED) at lib/command.c:1063
#12 0x00007f8251578f5a in cmd_execute_command (vline=vline@entry=0x55e1262d7150, vty=vty@entry=0x55e1262dda20, cmd=0x0, vtysh=vtysh@entry=0)
    at lib/command.c:1113
#13 0x00007f8251579117 in cmd_execute (vty=vty@entry=0x55e1262dda20, cmd=cmd@entry=0x55e1262df0b0 "do clear ip ospf neighbor 100.1.1.1", 
    matched=matched@entry=0x0, vtysh=vtysh@entry=0) at lib/command.c:1278
#14 0x00007f82515c7095 in vty_command (vty=vty@entry=0x55e1262dda20, buf=0x55e1262df0b0 "do clear ip ospf neighbor 100.1.1.1") at lib/vty.c:514
#15 0x00007f82515c7270 in vty_execute (vty=0x55e1262dda20) at lib/vty.c:1281
#16 0x00007f82515c9be8 in vtysh_read (thread=<optimized out>) at lib/vty.c:2123
#17 0x00007f82515c1cd6 in thread_call (thread=thread@entry=0x7ffcfe51c370) at lib/thread.c:1557
#18 0x00007f82515937f8 in frr_run (master=0x55e1260015e0) at lib/libfrr.c:1026
#19 0x000055e1250179a4 in main (argc=4, argv=0x7ffcfe51c698) at ospfd/ospf_main.c:242
(gdb) quit()
        

Signed-off-by: Rajesh Girada <rgirada@vmware.com>