### PR TITLE
ospf6d: always generate default route for stubs

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -710,22 +710,9 @@ void ospf6_abr_defaults_to_stub(struct ospf6 *o)
 	struct listnode *node, *nnode;
 	struct ospf6_area *oa;
 	struct ospf6_route *def, *route;
-	struct ospf6_redist *red;
 	int type = DEFAULT_ROUTE;
-	struct prefix_ipv6 p = {};
 
 	if (!o->backbone)
-		return;
-
-	red = ospf6_redist_lookup(o, type, 0);
-	if (!red)
-		return;
-
-	p.family = AF_INET6;
-	p.prefixlen = 0;
-
-	route = ospf6_route_lookup((struct prefix *)&p, o->external_table);
-	if (!route)
 		return;
 
 	def = ospf6_route_create();


### PR DESCRIPTION
In RFC 2328 OSPF Version 2, Section 12.4.3.1 "Originating summary-LSAs
into stub areas" mentions that the stub areas should not import external
routes and instead should generate a 'default summary-LSA' set to
default destination.

> In a stub area, instead of importing external routes
> each area border router originates a "default summary-
> LSA" into the area. The Link State ID for the default
> summary-LSA is set to DefaultDestination, and the metric
> set to the (per-area) configurable parameter
> StubDefaultCost.  Note that StubDefaultCost need not be
> configured identically in all of the stub area's area
> border routers.

**note** OSPFv3 RFC 5340 Section 2.10 "Stub/NSSA Area Support" only mentions that the functionality is mostly the same.