### PR TITLE
tests: fix invalid multiline format

### DIFF
--- a/tests/topotests/bgp_basic_functionality_topo1/test_bgp_basic_functionality.py
+++ b/tests/topotests/bgp_basic_functionality_topo1/test_bgp_basic_functionality.py
@@ -1135,9 +1135,9 @@ def test_bgp_with_loopback_with_same_subnet_p1(request):
     protocol = "bgp"
     for addr_type in ADDR_TYPES:
         result = verify_fib_routes(tgen, addr_type, dut, input_dict_r1)
-        assert result is not True, "Testcase {} : Failed \n".format(tc_name)
+        assert result is not True, "Testcase {} : Failed \n"
         "Expected behavior: routes should not present in fib \n"
-        "Error: {}".format(result)
+        "Error: {}".format(tc_name, result)
 
     step("Verify Ipv4 and Ipv6 network installed in r3 RIB but not in FIB")
     input_dict_r3 = {
@@ -1152,9 +1152,9 @@ def test_bgp_with_loopback_with_same_subnet_p1(request):
     protocol = "bgp"
     for addr_type in ADDR_TYPES:
         result = verify_fib_routes(tgen, addr_type, dut, input_dict_r1)
-        assert result is not True, "Testcase {} : Failed \n".format(tc_name)
+        assert result is not True, "Testcase {} : Failed \n"
         "Expected behavior: routes should not present in fib \n"
-        "Error: {}".format(result)
+        "Error: {}".format(tc_name, result)
 
     write_test_footer(tc_name)
 


### PR DESCRIPTION
`format` can't be used per-line when we have a multiline string.

This was recently broken in 3881d05.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>