### PR TITLE
ospf6d: fix argument processing in the "area ... range" command

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -504,7 +504,7 @@ DEFUN (area_range,
 	struct ospf6_area *oa;
 	struct prefix prefix;
 	struct ospf6_route *range;
-	uint32_t cost = OSPF_AREA_RANGE_COST_UNSPEC;
+	uint32_t cost;
 
 	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
 
@@ -526,16 +526,15 @@ DEFUN (area_range,
 		range->path.cost = OSPF_AREA_RANGE_COST_UNSPEC;
 	}
 
+	/* default settings */
+	cost = OSPF_AREA_RANGE_COST_UNSPEC;
+	UNSET_FLAG(range->flag, OSPF6_ROUTE_DO_NOT_ADVERTISE);
+
 	if (argc > idx_type) {
-		if (strmatch(argv[idx_type]->text, "not-advertise")) {
+		if (strmatch(argv[idx_type]->text, "not-advertise"))
 			SET_FLAG(range->flag, OSPF6_ROUTE_DO_NOT_ADVERTISE);
-		} else if (strmatch(argv[idx_type]->text, "advertise")) {
-			UNSET_FLAG(range->flag, OSPF6_ROUTE_DO_NOT_ADVERTISE);
-			cost = range->path.u.cost_config;
-		} else {
+		else if (strmatch(argv[idx_type]->text, "cost"))
 			cost = strtoul(argv[5]->arg, NULL, 10);
-			UNSET_FLAG(range->flag, OSPF6_ROUTE_DO_NOT_ADVERTISE);
-		}
 	}
 
 	range->path.u.cost_config = cost;


### PR DESCRIPTION
* When the "cost" argument isn't present, the default cost should be
  used instead of preserving the previously configured one (if any);
* When the "not-advertise" argument isn't present, the "not-advertise"
  flag should be unset regardless if it was previously configured or
  not.

Configuration commands should be deterministic and work in the same
way regardless of the current state.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>