### PR TITLE
vtysh: Handle `en` better when in -u for vtysh

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -479,10 +479,21 @@ static int vtysh_execute_func(const char *line, int pager)
 		return CMD_SUCCESS;
 
 	if (user_mode) {
+		bool allow = true;
 		if (strncmp("en", vector_slot(vline, 0), 2) == 0) {
-			cmd_free_strvec(vline);
-			vty_out(vty, "%% Command not allowed: enable\n");
-			return CMD_WARNING;
+			if (strlen(line) >= 3) {
+				if (strncmp("ena", vector_slot(vline, 0), 3)
+				    == 0)
+					allow = false;
+			} else
+				allow = false;
+
+			if (!allow) {
+				cmd_free_strvec(vline);
+				vty_out(vty,
+					"%% Command not allowed: enable\n");
+				return CMD_WARNING;
+			}
 		}
 	}
 


### PR DESCRIPTION
vtysh was unable to distinguish between end and ena.  The
code can now do so:

sharpd@eva ~/frr5 (master)> sudo vtysh/vtysh -u sharpd

Hello, this is FRRouting (version 8.1-dev).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

eva> e
% Ambiguous command: e
eva> en
% Command not allowed: enable
eva> ena
% Command not allowed: enable
eva> enab
% Command not allowed: enable
eva> enabl
% Command not allowed: enable
eva> enable
% Command not allowed: enable
eva> enb
% Unknown command: enb
eva> enc
% Unknown command: enc
eva> end
% Unknown command: end
eva> ene
% Unknown command: ene
eva> quit

Fixes: #2296
Signed-off-by: Donald Sharp <sharpd@nvidia.com>