### PR TITLE
bgpd: [8.0] Don't forget bgp_dest_unlock_node for bgp_static_set()

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5867,6 +5867,7 @@ static int bgp_static_set(struct vty *vty, const char *negate,
 		    && (label_index != bgp_static->label_index)) {
 			vty_out(vty,
 				"%% label-index doesn't match static route\n");
+			bgp_dest_unlock_node(dest);
 			return CMD_WARNING_CONFIG_FAILED;
 		}
 
@@ -5874,6 +5875,7 @@ static int bgp_static_set(struct vty *vty, const char *negate,
 		    && strcmp(rmap, bgp_static->rmap.name)) {
 			vty_out(vty,
 				"%% route-map name doesn't match static route\n");
+			bgp_dest_unlock_node(dest);
 			return CMD_WARNING_CONFIG_FAILED;
 		}
 


### PR DESCRIPTION
Before returning an error, unlock bgp dest which is locked by
bgp_node_lookup().

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>