### PR TITLE
[8.0] bgpd: Unlock bgp_dest for bgp_distance_unset if distance does not match (backport #8976)

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13970,6 +13970,7 @@ static int bgp_distance_unset(struct vty *vty, const char *distance_str,
 
 	if (bdistance->distance != distance) {
 		vty_out(vty, "Distance does not match configured\n");
+		bgp_dest_unlock_node(dest);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>