### PR TITLE
bgpd: Use strcmp comparing BGP alias with an actual entered alias

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10862,8 +10862,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 						const char *com2alias =
 							bgp_community2alias(
 								communities[i]);
-						if (strncmp(alias, com2alias,
-							    strlen(com2alias))
+						if (strcmp(alias, com2alias)
 						    == 0) {
 							found = true;
 							break;
@@ -10878,8 +10877,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 						const char *com2alias =
 							bgp_community2alias(
 								communities[i]);
-						if (strncmp(alias, com2alias,
-							    strlen(com2alias))
+						if (strcmp(alias, com2alias)
 						    == 0) {
 							found = true;
 							break;

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1195,7 +1195,7 @@ route_match_alias(void *rule, const struct prefix *prefix, void *object)
 		for (int i = 0; i < num; i++) {
 			const char *com2alias =
 				bgp_community2alias(communities[i]);
-			if (strncmp(alias, com2alias, strlen(com2alias)) == 0)
+			if (strcmp(alias, com2alias) == 0)
 				return RMAP_MATCH;
 		}
 	}
@@ -1206,7 +1206,7 @@ route_match_alias(void *rule, const struct prefix *prefix, void *object)
 		for (int i = 0; i < num; i++) {
 			const char *com2alias =
 				bgp_community2alias(communities[i]);
-			if (strncmp(alias, com2alias, strlen(com2alias)) == 0)
+			if (strcmp(alias, com2alias) == 0)
 				return RMAP_MATCH;
 		}
 	}


### PR DESCRIPTION
It might be a case when a partial match is hit and this needs to be fixed.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>