### PR TITLE
bgpd: flowspec redirect vrf uses vrf table instead of allocated table id

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3316,6 +3316,13 @@ void bgp_zebra_announce_default(struct bgp *bgp, struct nexthop *nh,
 		    && nh->type != NEXTHOP_TYPE_IPV6)
 	    || nh->vrf_id == VRF_UNKNOWN)
 		return;
+
+	/* in vrf-lite, no default route has to be announced
+	 * the table id of vrf is directly used to divert traffic
+	 */
+	if (!vrf_is_backend_netns() && bgp->vrf_id != nh->vrf_id)
+		return;
+
 	memset(&p, 0, sizeof(struct prefix));
 	if (afi != AFI_IP && afi != AFI_IP6)
 		return;


### PR DESCRIPTION
Until now, when bgp flowspec entry action was to redirect to a vrf, a
default route was installed in a specific table. that route was a vrf
route leak one. The process can be simplified, as vrf-lite already
has a table identifier. Actually, because policy routing is used to
redirect traffic to a defined table (with ip rule command), use
the table identifier of the VRF.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>