### PR TITLE
vtysh: another take at "enable" in vtysh user mode

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -478,25 +478,6 @@ static int vtysh_execute_func(const char *line, int pager)
 	if (vline == NULL)
 		return CMD_SUCCESS;
 
-	if (user_mode) {
-		bool allow = true;
-		if (strncmp("en", vector_slot(vline, 0), 2) == 0) {
-			if (strlen(line) >= 3) {
-				if (strncmp("ena", vector_slot(vline, 0), 3)
-				    == 0)
-					allow = false;
-			} else
-				allow = false;
-
-			if (!allow) {
-				cmd_free_strvec(vline);
-				vty_out(vty,
-					"%% Command not allowed: enable\n");
-				return CMD_WARNING;
-			}
-		}
-	}
-
 	if (vtysh_add_timestamp && strncmp(line, "exit", 4)) {
 		char ts[48];
 
@@ -4523,7 +4504,8 @@ void vtysh_init_vty(void)
 
 	/* vtysh */
 
-	install_element(VIEW_NODE, &vtysh_enable_cmd);
+	if (!user_mode)
+		install_element(VIEW_NODE, &vtysh_enable_cmd);
 	install_element(ENABLE_NODE, &vtysh_config_terminal_cmd);
 	install_element(ENABLE_NODE, &vtysh_disable_cmd);
 


### PR DESCRIPTION
Recent change in d1b287e only fixed the problem for 3-letter words.

We were still displaying error for longer words starting with "ena":
```
nfware> enac
% Command not allowed: enable
nfware> enad
% Command not allowed: enable
nfware> enaena
% Command not allowed: enable
```

If we don't allow "enable" command in user mode, why add it at all?

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>