### PR TITLE
ospfd: don't exit when socket is not created

### DIFF
--- a/ospfd/ospf_network.c
+++ b/ospfd/ospf_network.c
@@ -190,7 +190,7 @@ int ospf_sock_init(struct ospf *ospf)
 			flog_err(EC_LIB_SOCKET,
 				 "ospf_read_sock_init: socket: %s",
 				 safe_strerror(errno));
-			exit(1);
+			return -1;
 		}
 
 #ifdef IP_HDRINCL


### PR DESCRIPTION
Let's be less radical. There's no reason to stop the whole daemon when
there's a socket creation error in a single VRF. The user can always
restart this single VRF to retry to create a socket.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>