### PR TITLE
ospf6d: add PtMP interface mode & related bits

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -299,9 +299,134 @@ OSPF6 interface
 
    Sets interface's Inf-Trans-Delay. Default value is 1.
 
-.. clicmd:: ipv6 ospf6 network (broadcast|point-to-point)
+.. clicmd:: ipv6 ospf6 network (broadcast|point-to-point|point-to-multipoint)
 
    Set explicitly network type for specified interface.
+
+   The only functional difference between ``point-to-point`` (PtP) and
+   ``point-to-multipoint`` (PtMP) mode is the packet addressing for database
+   flooding and updates.  PtP will use multicast packets while PtMP will
+   unicast them.  Apart from this,
+   :clicmd:`ipv6 ospf6 p2p-p2mp connected-prefixes <include|exclude>` has a
+   different default for PtP and PtMP.  There are no other differences, in
+   particular FRR does not impose a limit of one neighbor in PtP mode.
+
+   FRR does not support NBMA mode for IPv6 and likely never will, as NBMA is
+   considered deprecated for IPv6.  Refer to `this IETF OSPF working group
+   discussion
+   <https://mailarchive.ietf.org/arch/msg/ospf/8GAbr4qSMMt5J7SvAcZQ1H7ARhk/>`_
+   for context.
+
+OSPF6 point-to-point and point-to-multipoint operation
+======================================================
+
+OSPFv3, by default, operates in broadcast mode where it elects a DR and BDR
+for each network segment.  This can be changed to point-to-point (PtP) /
+point-to-multipoint (PtMP) mode by configuration.  The actual physical
+interface characteristics do not matter for this setting, all interfaces can
+be configured for all modes.  However, routers must be configured for the same
+mode to form adjacencies.
+
+The main advantages of PtP/PtMP mode are:
+
+- no DR/BDR election
+- adjacencies can be suppressed in a pairwise manner for any two routers, e.g.
+  to represent the underlying topology if it isn't a true full mesh
+- distinct costs can be set for each pair of routers and direction
+
+The main downside is less efficient flooding on networks with a large number
+of OSPFv3 routers.
+
+.. warning::
+
+   All options in this section should be considered "advanced" configuration
+   options.  Inconsistent or nonsensical combinations can easily result in a
+   non-functional setup.
+
+.. clicmd:: ipv6 ospf6 p2p-p2mp disable-multicast-hello
+
+   Disables sending normal multicast hellos when in PtP/PtMP mode.  Some
+   vendors do this automatically for PtMP mode while others have a separate
+   ``no-broadcast`` option matching this.
+
+   If this setting is used, you must issue
+   :clicmd:`ipv6 ospf6 neighbor X:X::X:X poll-interval (1-65535)` for each
+   neighbor to send unicast hello packets.
+
+.. clicmd:: ipv6 ospf6 p2p-p2mp config-neighbors-only
+
+   Only form adjacencies with neighbors that are explicitly configured with
+   the :clicmd:`ipv6 ospf6 neighbor X:X::X:X` command.  Hellos from other
+   routers are ignored.
+
+   .. warning::
+
+      This setting is not intended to provide any security benefit.  Do not
+      run OSPFv3 over untrusted links without additional security measures
+      (e.g. IPsec.)
+
+.. clicmd:: ipv6 ospf6 p2p-p2mp connected-prefixes <include|exclude>
+
+   For global/ULA prefixes configured on this interfaces, do (not) advertise
+   the full prefix to the area.  Regardless of this setting, the router's own
+   address, as a /128 host route with the "LA" (Local Address) bit set, will
+   always be advertised.
+
+   The default is to include connected prefixes for PtP mode and exclude them
+   for PtMP mode.  Since these prefixes will cover other router's addresses,
+   these addresses can become unreachable if the link is partitioned if the
+   other router does not advertise the address as a /128.  However, conversely,
+   if all routers have this flag set, the overall prefix will not be advertised
+   anywhere.  End hosts on this link will therefore be unreachable (and
+   blackholing best-practices for non-existing prefixes apply.)  It may be
+   preferable to have only one router announce the connected prefix.
+
+   The Link LSA (which is not propagated into the area) always includes all
+   prefixes on the interface.  This setting only affects the Router LSA that
+   is visible to all routers in the area.
+
+   .. note::
+
+      Before interacting with this setting, consider either not configuring
+      any global/ULA IPv6 address on the interface, or directly configuring a
+      /128 if needed.  OSPFv3 relies exclusively on link-local addresses to do
+      its signaling and there is absolutely no reason to configure global/ULA
+      addresses as far as OSPFv3 is concerned.
+
+.. clicmd:: ipv6 ospf6 neighbor X:X::X:X
+
+   Explicitly configure a neighbor by its link-local address on this interface.
+   This statement has no effect other than allowing an adjacency when
+   :clicmd:`ipv6 ospf6 p2p-p2mp config-neighbors-only` is set.  This command
+   does **not** cause unicast hellos to be sent.
+
+   Only link-local addresses can be used to establish explicit neighbors.
+   When using this command, you should probably assign static IPv6 link-local
+   addresses to all routers on this link.  It would technically be possible to
+   use the neighbor's Router ID (IPv4 address) here to ease working with
+   changing link-local addresses but this is not planned as a feature at the
+   time of writing.  Global/ULA IPv6 addresses cannot be supported here due to
+   the way OSPFv3 works.
+
+.. clicmd:: ipv6 ospf6 neighbor X:X::X:X poll-interval (1-65535)
+
+   Send unicast hellos to this neighbor at the specified interval (in seconds.)
+   The interval is only used while there is no adjacency with this neighbor.
+   As soon as an adjacency is formed, the interface's
+   :clicmd:`ipv6 ospf6 hello-interval HELLOINTERVAL` value is used.
+   (``hello-interval`` must be the same on all routers on this link.)
+
+   :rfc:`2328` recommends a "much larger" value than ``hello-interval`` for
+   this setting, but this is a legacy of ATM and X.25 networks and nowadays you
+   should probably just use the same value as for ``hello-interval``.
+
+.. clicmd:: ipv6 ospf6 neighbor X:X::X:X cost (1-65535)
+
+   Use a distinct cost for paths traversing this neighbor.  The default is
+   to use the interface's cost value (which may be automatically calculated
+   based on link bandwidth.)  Note that costs are directional in OSPF and the
+   reverse direction must be set on the other router.
+
 
 OSPF6 route-map
 ===============

--- a/lib/if.h
+++ b/lib/if.h
@@ -576,7 +576,6 @@ extern ifindex_t ifname2ifindex(const char *ifname, vrf_id_t vrf_id);
 /* Connected address functions. */
 extern struct connected *connected_new(void);
 extern void connected_free(struct connected **connected);
-extern void connected_add(struct interface *, struct connected *);
 extern struct connected *
 connected_add_by_prefix(struct interface *, struct prefix *, struct prefix *);
 extern struct connected *connected_delete_by_prefix(struct interface *,

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -2623,6 +2623,33 @@ DEFPY (ipv6_ospf6_p2xp_only_cfg_neigh,
 	return CMD_SUCCESS;
 }
 
+DEFPY (ipv6_ospf6_p2xp_no_multicast_hello,
+       ipv6_ospf6_p2xp_no_multicast_hello_cmd,
+       "[no] ipv6 ospf6 p2p-p2mp disable-multicast-hello",
+       NO_STR
+       IP6_STR
+       OSPF6_STR
+       "Point-to-point and Point-to-Multipoint parameters\n"
+       "Do not send multicast hellos\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf6_interface *oi = ifp->info;
+
+	if (no) {
+		if (!oi)
+			return CMD_SUCCESS;
+
+		oi->p2xp_no_multicast_hello = false;
+		return CMD_SUCCESS;
+	}
+
+	if (!oi)
+		oi = ospf6_interface_create(ifp);
+
+	oi->p2xp_no_multicast_hello = true;
+	return CMD_SUCCESS;
+}
+
 
 static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf)
 {
@@ -2691,6 +2718,10 @@ static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf)
 		if (oi->p2xp_only_cfg_neigh)
 			vty_out(vty,
 				" ipv6 ospf6 p2p-p2mp config-neighbors-only\n");
+
+		if (oi->p2xp_no_multicast_hello)
+			vty_out(vty,
+				" ipv6 ospf6 p2p-p2mp disable-multicast-hello\n");
 
 		ospf6_bfd_write_config(vty, oi);
 
@@ -2815,6 +2846,8 @@ void ospf6_interface_init(void)
 	install_element(INTERFACE_NODE, &no_ipv6_ospf6_network_cmd);
 
 	install_element(INTERFACE_NODE, &ipv6_ospf6_p2xp_only_cfg_neigh_cmd);
+	install_element(INTERFACE_NODE,
+			&ipv6_ospf6_p2xp_no_multicast_hello_cmd);
 
 	/* reference bandwidth commands */
 	install_element(OSPF6_NODE, &auto_cost_reference_bandwidth_cmd);

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -63,8 +63,8 @@ DEFINE_HOOK(ospf6_interface_change,
 unsigned char conf_debug_ospf6_interface = 0;
 
 const char *const ospf6_interface_state_str[] = {
-	"None",    "Down", "Loopback", "Waiting", "PointToPoint",
-	"DROther", "BDR",  "DR",       NULL};
+	"None",		"Down",	   "Loopback", "Waiting", "PointToPoint",
+	"PtMultipoint", "DROther", "BDR",      "DR",	  NULL};
 
 int ospf6_interface_neighbor_count(struct ospf6_interface *oi)
 {
@@ -461,6 +461,7 @@ void ospf6_interface_connected_route_update(struct interface *ifp)
 		}
 
 		if (oi->state == OSPF6_INTERFACE_LOOPBACK
+		    || oi->state == OSPF6_INTERFACE_POINTTOMULTIPOINT
 		    || oi->state == OSPF6_INTERFACE_POINTTOPOINT) {
 			struct ospf6_route *la_route;
 
@@ -554,7 +555,8 @@ static int ospf6_interface_state_change(uint8_t next_state,
 		OSPF6_INTRA_PREFIX_LSA_SCHEDULE_STUB(oi->area);
 	}
 
-	if (next_state == OSPF6_INTERFACE_POINTTOPOINT)
+	if (next_state == OSPF6_INTERFACE_POINTTOPOINT
+	    || next_state == OSPF6_INTERFACE_POINTTOMULTIPOINT)
 		ospf6_if_p2xp_up(oi);
 
 	hook_call(ospf6_interface_change, oi, next_state, prev_state);
@@ -861,6 +863,9 @@ void interface_up(struct thread *thread)
 		ospf6_interface_state_change(OSPF6_INTERFACE_LOOPBACK, oi);
 	} else if (oi->type == OSPF_IFTYPE_POINTOPOINT) {
 		ospf6_interface_state_change(OSPF6_INTERFACE_POINTTOPOINT, oi);
+	} else if (oi->type == OSPF_IFTYPE_POINTOMULTIPOINT) {
+		ospf6_interface_state_change(OSPF6_INTERFACE_POINTTOMULTIPOINT,
+					     oi);
 	} else if (oi->priority == 0)
 		ospf6_interface_state_change(OSPF6_INTERFACE_DROTHER, oi);
 	else {
@@ -989,6 +994,8 @@ static const char *ospf6_iftype_str(uint8_t iftype)
 		return "BROADCAST";
 	case OSPF_IFTYPE_POINTOPOINT:
 		return "POINTOPOINT";
+	case OSPF_IFTYPE_POINTOMULTIPOINT:
+		return "POINTOMULTIPOINT";
 	}
 	return "UNKNOWN";
 }
@@ -2523,12 +2530,13 @@ DEFUN (no_ipv6_ospf6_advertise_prefix_list,
 
 DEFUN (ipv6_ospf6_network,
        ipv6_ospf6_network_cmd,
-       "ipv6 ospf6 network <broadcast|point-to-point>",
+       "ipv6 ospf6 network <broadcast|point-to-point|point-to-multipoint>",
        IP6_STR
        OSPF6_STR
        "Network type\n"
        "Specify OSPF6 broadcast network\n"
        "Specify OSPF6 point-to-point network\n"
+       "Specify OSPF6 point-to-multipoint network\n"
        )
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
@@ -2554,6 +2562,11 @@ DEFUN (ipv6_ospf6_network,
 			return CMD_SUCCESS;
 		}
 		oi->type = OSPF_IFTYPE_POINTOPOINT;
+	} else if (strncmp(argv[idx_network]->arg, "point-to-m", 10) == 0) {
+		if (oi->type == OSPF_IFTYPE_POINTOMULTIPOINT) {
+			return CMD_SUCCESS;
+		}
+		oi->type = OSPF_IFTYPE_POINTOMULTIPOINT;
 	}
 
 	/* Reset the interface */
@@ -2713,7 +2726,10 @@ static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf)
 		if (oi->mtu_ignore)
 			vty_out(vty, " ipv6 ospf6 mtu-ignore\n");
 
-		if (oi->type_cfg && oi->type == OSPF_IFTYPE_POINTOPOINT)
+		if (oi->type_cfg && oi->type == OSPF_IFTYPE_POINTOMULTIPOINT)
+			vty_out(vty,
+				" ipv6 ospf6 network point-to-multipoint\n");
+		else if (oi->type_cfg && oi->type == OSPF_IFTYPE_POINTOPOINT)
 			vty_out(vty, " ipv6 ospf6 network point-to-point\n");
 		else if (oi->type_cfg && oi->type == OSPF_IFTYPE_BROADCAST)
 			vty_out(vty, " ipv6 ospf6 network broadcast\n");

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -554,6 +554,9 @@ static int ospf6_interface_state_change(uint8_t next_state,
 		OSPF6_INTRA_PREFIX_LSA_SCHEDULE_STUB(oi->area);
 	}
 
+	if (next_state == OSPF6_INTERFACE_POINTTOPOINT)
+		ospf6_if_p2xp_up(oi);
+
 	hook_call(ospf6_interface_change, oi, next_state, prev_state);
 
 	return 0;
@@ -2723,6 +2726,7 @@ static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf)
 			vty_out(vty,
 				" ipv6 ospf6 p2p-p2mp disable-multicast-hello\n");
 
+		config_write_ospf6_p2xp_neighbor(vty, oi);
 		ospf6_bfd_write_config(vty, oi);
 
 		ospf6_auth_write_config(vty, &oi->at_data);

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -2596,6 +2596,34 @@ DEFUN (no_ipv6_ospf6_network,
 	return CMD_SUCCESS;
 }
 
+DEFPY (ipv6_ospf6_p2xp_only_cfg_neigh,
+       ipv6_ospf6_p2xp_only_cfg_neigh_cmd,
+       "[no] ipv6 ospf6 p2p-p2mp config-neighbors-only",
+       NO_STR
+       IP6_STR
+       OSPF6_STR
+       "Point-to-point and Point-to-Multipoint parameters\n"
+       "Only form adjacencies with explicitly configured neighbors\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf6_interface *oi = ifp->info;
+
+	if (no) {
+		if (!oi)
+			return CMD_SUCCESS;
+
+		oi->p2xp_only_cfg_neigh = false;
+		return CMD_SUCCESS;
+	}
+
+	if (!oi)
+		oi = ospf6_interface_create(ifp);
+
+	oi->p2xp_only_cfg_neigh = true;
+	return CMD_SUCCESS;
+}
+
+
 static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf)
 {
 	struct ospf6_interface *oi;
@@ -2659,6 +2687,10 @@ static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf)
 			vty_out(vty, " ipv6 ospf6 network point-to-point\n");
 		else if (oi->type_cfg && oi->type == OSPF_IFTYPE_BROADCAST)
 			vty_out(vty, " ipv6 ospf6 network broadcast\n");
+
+		if (oi->p2xp_only_cfg_neigh)
+			vty_out(vty,
+				" ipv6 ospf6 p2p-p2mp config-neighbors-only\n");
 
 		ospf6_bfd_write_config(vty, oi);
 
@@ -2781,6 +2813,8 @@ void ospf6_interface_init(void)
 
 	install_element(INTERFACE_NODE, &ipv6_ospf6_network_cmd);
 	install_element(INTERFACE_NODE, &no_ipv6_ospf6_network_cmd);
+
+	install_element(INTERFACE_NODE, &ipv6_ospf6_p2xp_only_cfg_neigh_cmd);
 
 	/* reference bandwidth commands */
 	install_element(OSPF6_NODE, &auto_cost_reference_bandwidth_cmd);

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -85,6 +85,9 @@ struct ospf6_interface {
 
 	/* P2P/P2MP behavior: */
 
+	/* only allow explicitly configured neighbors? */
+	bool p2xp_only_cfg_neigh;
+
 	struct ospf6_if_p2xp_neighcfgs_head p2xp_neighs;
 
 	/* Router Priority */

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -188,15 +188,16 @@ struct ospf6_interface {
 DECLARE_QOBJ_TYPE(ospf6_interface);
 
 /* interface state */
-#define OSPF6_INTERFACE_NONE             0
-#define OSPF6_INTERFACE_DOWN             1
-#define OSPF6_INTERFACE_LOOPBACK         2
-#define OSPF6_INTERFACE_WAITING          3
-#define OSPF6_INTERFACE_POINTTOPOINT     4
-#define OSPF6_INTERFACE_DROTHER          5
-#define OSPF6_INTERFACE_BDR              6
-#define OSPF6_INTERFACE_DR               7
-#define OSPF6_INTERFACE_MAX              8
+#define OSPF6_INTERFACE_NONE               0
+#define OSPF6_INTERFACE_DOWN               1
+#define OSPF6_INTERFACE_LOOPBACK           2
+#define OSPF6_INTERFACE_WAITING            3
+#define OSPF6_INTERFACE_POINTTOPOINT       4
+#define OSPF6_INTERFACE_POINTTOMULTIPOINT  5
+#define OSPF6_INTERFACE_DROTHER            6
+#define OSPF6_INTERFACE_BDR                7
+#define OSPF6_INTERFACE_DR                 8
+#define OSPF6_INTERFACE_MAX                9
 
 extern const char *const ospf6_interface_state_str[];
 

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -28,6 +28,8 @@
 
 DECLARE_MTYPE(OSPF6_AUTH_MANUAL_KEY);
 
+#include "ospf6_neighbor.h"
+
 /* Debug option */
 extern unsigned char conf_debug_ospf6_interface;
 #define OSPF6_DEBUG_INTERFACE_ON() (conf_debug_ospf6_interface = 1)
@@ -80,6 +82,10 @@ struct ospf6_interface {
 	/* Network Type */
 	uint8_t type;
 	bool type_cfg;
+
+	/* P2P/P2MP behavior: */
+
+	struct ospf6_if_p2xp_neighcfgs_head p2xp_neighs;
 
 	/* Router Priority */
 	uint8_t priority;

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -89,6 +89,11 @@ struct ospf6_interface {
 	bool p2xp_no_multicast_hello;
 	/* only allow explicitly configured neighbors? */
 	bool p2xp_only_cfg_neigh;
+	/* override mode default for advertising connected prefixes.
+	 * both false by default (= do include for PtP, exclude for PtMP)
+	 */
+	bool p2xp_connected_pfx_include;
+	bool p2xp_connected_pfx_exclude;
 
 	struct ospf6_if_p2xp_neighcfgs_head p2xp_neighs;
 

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -85,6 +85,8 @@ struct ospf6_interface {
 
 	/* P2P/P2MP behavior: */
 
+	/* disable hellos on standard multicast? */
+	bool p2xp_no_multicast_hello;
 	/* only allow explicitly configured neighbors? */
 	bool p2xp_only_cfg_neigh;
 

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -342,7 +342,7 @@ void ospf6_router_lsa_originate(struct thread *thread)
 					continue;
 
 				lsdesc->type = OSPF6_ROUTER_LSDESC_POINTTOPOINT;
-				lsdesc->metric = htons(oi->cost);
+				lsdesc->metric = htons(ospf6_neighbor_cost(on));
 				lsdesc->interface_id =
 					htonl(oi->interface->ifindex);
 				lsdesc->neighbor_interface_id =

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -336,7 +336,8 @@ void ospf6_router_lsa_originate(struct thread *thread)
 		}
 
 		/* Point-to-Point interfaces */
-		if (oi->type == OSPF_IFTYPE_POINTOPOINT) {
+		if (oi->type == OSPF_IFTYPE_POINTOPOINT
+		    || oi->type == OSPF_IFTYPE_POINTOMULTIPOINT) {
 			for (ALL_LIST_ELEMENTS_RO(oi->neighbor_list, j, on)) {
 				if (on->state != OSPF6_NEIGHBOR_FULL)
 					continue;
@@ -1083,6 +1084,7 @@ void ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 
 		if (oi->state != OSPF6_INTERFACE_LOOPBACK
 		    && oi->state != OSPF6_INTERFACE_POINTTOPOINT
+		    && oi->state != OSPF6_INTERFACE_POINTTOMULTIPOINT
 		    && full_count != 0) {
 			if (IS_OSPF6_DEBUG_ORIGINATE(INTRA_PREFIX))
 				zlog_debug("  Interface %s is not stub, ignore",

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -434,7 +434,8 @@ static void ospf6_hello_recv(struct in6_addr *src, struct in6_addr *dst,
 	hello = (struct ospf6_hello *)((caddr_t)oh
 				       + sizeof(struct ospf6_header));
 
-	if (oi->state == OSPF6_INTERFACE_POINTTOPOINT
+	if ((oi->state == OSPF6_INTERFACE_POINTTOPOINT
+	     || oi->state == OSPF6_INTERFACE_POINTTOMULTIPOINT)
 	    && oi->p2xp_only_cfg_neigh) {
 		/* NEVER, never, ever, do this on broadcast (or NBMA)!
 		 * DR/BDR election requires everyone to talk to everyone else
@@ -2315,8 +2316,9 @@ void ospf6_hello_send_addr(struct ospf6_interface *oi,
 	/* Set packet length. */
 	op->length = length;
 
-	if (!addr && oi->state == OSPF6_INTERFACE_POINTTOPOINT
-	    && oi->p2xp_no_multicast_hello) {
+	if ((oi->state == OSPF6_INTERFACE_POINTTOPOINT
+	     || oi->state == OSPF6_INTERFACE_POINTTOMULTIPOINT)
+	    && !addr && oi->p2xp_no_multicast_hello) {
 		struct listnode *node;
 		struct ospf6_neighbor *on;
 		struct ospf6_packet *opdup;

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -491,7 +491,7 @@ static void ospf6_hello_recv(struct in6_addr *src, struct in6_addr *dst,
 	on->hello_in++;
 
 	/* Always override neighbor's source address */
-	memcpy(&on->linklocal_addr, src, sizeof(struct in6_addr));
+	ospf6_neighbor_lladdr_set(on, src);
 
 	/* Neighbor ifindex check */
 	if (on->ifindex != (ifindex_t)ntohl(hello->interface_id)) {

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -2273,6 +2273,13 @@ void ospf6_hello_send(struct thread *thread)
 		return;
 	}
 
+	thread_add_timer(master, ospf6_hello_send, oi, oi->hello_interval,
+			 &oi->thread_send_hello);
+
+	if (oi->state == OSPF6_INTERFACE_POINTTOPOINT
+	    && oi->p2xp_no_multicast_hello)
+		return 0;
+
 	op = ospf6_packet_new(oi->ifmtu);
 
 	ospf6_make_header(OSPF6_MESSAGE_TYPE_HELLO, oi, op->s);
@@ -2299,10 +2306,6 @@ void ospf6_hello_send(struct thread *thread)
 	 * can't get delayed by things like long queues of LS Update packets
 	 */
 	ospf6_packet_add_top(oi, op);
-
-	/* set next thread */
-	thread_add_timer(master, ospf6_hello_send, oi, oi->hello_interval,
-			 &oi->thread_send_hello);
 
 	OSPF6_MESSAGE_WRITE_ON(oi);
 }

--- a/ospf6d/ospf6_message.h
+++ b/ospf6d/ospf6_message.h
@@ -65,6 +65,8 @@ extern unsigned char conf_debug_ospf6_message[];
 #define OSPF6_MESSAGE_TYPE_ALL      0x6  /* For debug option */
 #define OSPF6_MESSAGE_TYPE_MAX 0x6       /* same as OSPF6_MESSAGE_TYPE_ALL */
 
+struct ospf6_interface;
+
 struct ospf6_packet {
 	struct ospf6_packet *next;
 
@@ -183,6 +185,9 @@ extern void ospf6_lsupdate_send_interface(struct thread *thread);
 extern void ospf6_lsupdate_send_neighbor(struct thread *thread);
 extern void ospf6_lsack_send_interface(struct thread *thread);
 extern void ospf6_lsack_send_neighbor(struct thread *thread);
+
+extern void ospf6_hello_send_addr(struct ospf6_interface *oi,
+				  const struct in6_addr *addr);
 
 extern int config_write_ospf6_debug_message(struct vty *);
 extern void install_element_ospf6_debug_message(void);

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -216,7 +216,8 @@ void ospf6_neighbor_lladdr_set(struct ospf6_neighbor *on,
 
 	memcpy(&on->linklocal_addr, addr, sizeof(struct in6_addr));
 
-	if (on->ospf6_if->type == OSPF_IFTYPE_POINTOPOINT) {
+	if (on->ospf6_if->type == OSPF_IFTYPE_POINTOPOINT
+	    || on->ospf6_if->type == OSPF_IFTYPE_POINTOMULTIPOINT) {
 		uint32_t prev_cost = ospf6_neighbor_cost(on);
 
 		p2xp_neigh_refresh(on, prev_cost);
@@ -299,6 +300,7 @@ static void ospf6_neighbor_state_change(uint8_t next_state,
 static int need_adjacency(struct ospf6_neighbor *on)
 {
 	if (on->ospf6_if->state == OSPF6_INTERFACE_POINTTOPOINT
+	    || on->ospf6_if->state == OSPF6_INTERFACE_POINTTOMULTIPOINT
 	    || on->ospf6_if->state == OSPF6_INTERFACE_DR
 	    || on->ospf6_if->state == OSPF6_INTERFACE_BDR)
 		return 1;
@@ -808,7 +810,8 @@ static void p2xp_unicast_hello_send(struct thread *thread);
 static void p2xp_unicast_hello_sched(struct ospf6_if_p2xp_neighcfg *p2xp_cfg)
 {
 	if (!p2xp_cfg->poll_interval
-	    || p2xp_cfg->ospf6_if->state != OSPF6_INTERFACE_POINTTOPOINT)
+	    || (p2xp_cfg->ospf6_if->state != OSPF6_INTERFACE_POINTTOMULTIPOINT
+		&& p2xp_cfg->ospf6_if->state != OSPF6_INTERFACE_POINTTOPOINT))
 		/* state check covers DOWN state too */
 		THREAD_OFF(p2xp_cfg->t_unicast_hello);
 	else
@@ -830,7 +833,8 @@ static void p2xp_unicast_hello_send(struct thread *thread)
 	struct ospf6_if_p2xp_neighcfg *p2xp_cfg = THREAD_ARG(thread);
 	struct ospf6_interface *oi = p2xp_cfg->ospf6_if;
 
-	if (oi->state != OSPF6_INTERFACE_POINTTOPOINT)
+	if (oi->state != OSPF6_INTERFACE_POINTTOPOINT
+	    && oi->state != OSPF6_INTERFACE_POINTTOMULTIPOINT)
 		return;
 
 	p2xp_unicast_hello_sched(p2xp_cfg);
@@ -905,6 +909,8 @@ static void ospf6_neighbor_show(struct vty *vty, struct ospf6_neighbor *on,
 	/* Neighbor State */
 	if (on->ospf6_if->type == OSPF_IFTYPE_POINTOPOINT)
 		snprintf(nstate, sizeof(nstate), "PointToPoint");
+	else if (on->ospf6_if->type == OSPF_IFTYPE_POINTOMULTIPOINT)
+		snprintf(nstate, sizeof(nstate), "PtMultipoint");
 	else {
 		if (on->router_id == on->drouter)
 			snprintf(nstate, sizeof(nstate), "DR");

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -195,6 +195,15 @@ void ospf6_neighbor_delete(struct ospf6_neighbor *on)
 	XFREE(MTYPE_OSPF6_NEIGHBOR, on);
 }
 
+void ospf6_neighbor_lladdr_set(struct ospf6_neighbor *on,
+			       const struct in6_addr *addr)
+{
+	if (IPV6_ADDR_SAME(addr, &on->linklocal_addr))
+		return;
+
+	memcpy(&on->linklocal_addr, addr, sizeof(struct in6_addr));
+}
+
 static void ospf6_neighbor_state_change(uint8_t next_state,
 					struct ospf6_neighbor *on, int event)
 {

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -54,8 +54,6 @@ DEFINE_MTYPE_STATIC(OSPF6D, OSPF6_NEIGHBOR_P2XP_CFG,
 
 static int ospf6_if_p2xp_neighcfg_cmp(const struct ospf6_if_p2xp_neighcfg *a,
 				      const struct ospf6_if_p2xp_neighcfg *b);
-static struct ospf6_if_p2xp_neighcfg *
-ospf6_if_p2xp_find(struct ospf6_interface *oi, const struct in6_addr *addr);
 
 DECLARE_RBTREE_UNIQ(ospf6_if_p2xp_neighcfgs, struct ospf6_if_p2xp_neighcfg,
 		    item, ospf6_if_p2xp_neighcfg_cmp);
@@ -661,8 +659,8 @@ static int ospf6_if_p2xp_neighcfg_cmp(const struct ospf6_if_p2xp_neighcfg *a,
 	return IPV6_ADDR_CMP(&a->addr, &b->addr);
 }
 
-static struct ospf6_if_p2xp_neighcfg *
-ospf6_if_p2xp_find(struct ospf6_interface *oi, const struct in6_addr *addr)
+struct ospf6_if_p2xp_neighcfg *ospf6_if_p2xp_find(struct ospf6_interface *oi,
+						  const struct in6_addr *addr)
 {
 	struct ospf6_if_p2xp_neighcfg ref;
 

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -204,6 +204,9 @@ struct ospf6_neighbor *ospf6_neighbor_create(uint32_t router_id,
 					     struct ospf6_interface *oi);
 void ospf6_neighbor_delete(struct ospf6_neighbor *on);
 
+void ospf6_neighbor_lladdr_set(struct ospf6_neighbor *on,
+			       const struct in6_addr *addr);
+
 /* Neighbor event */
 extern void hello_received(struct thread *thread);
 extern void twoway_received(struct thread *thread);

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -175,9 +175,12 @@ struct ospf6_if_p2xp_neighcfg {
 	bool cfg_cost : 1;
 
 	uint32_t cost;
+	uint16_t poll_interval;
 
 	/* NULL if down */
 	struct ospf6_neighbor *active;
+
+	struct thread *t_unicast_hello;
 };
 
 /* Neighbor state */
@@ -234,6 +237,7 @@ void ospf6_neighbor_lladdr_set(struct ospf6_neighbor *on,
 			       const struct in6_addr *addr);
 struct ospf6_if_p2xp_neighcfg *ospf6_if_p2xp_find(struct ospf6_interface *oi,
 						  const struct in6_addr *addr);
+void ospf6_if_p2xp_up(struct ospf6_interface *oi);
 
 uint32_t ospf6_neighbor_cost(struct ospf6_neighbor *on);
 

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -21,7 +21,10 @@
 #ifndef OSPF6_NEIGHBOR_H
 #define OSPF6_NEIGHBOR_H
 
+#include "typesafe.h"
 #include "hook.h"
+
+#include "ospf6_message.h"
 
 /* Forward declaration(s). */
 struct ospf6_area;
@@ -67,6 +70,8 @@ struct ospf6_helper_info {
 	uint32_t rejected_reason;
 };
 
+struct ospf6_if_p2xp_neighcfg;
+
 /* Neighbor structure */
 struct ospf6_neighbor {
 	/* Neighbor Router ID String */
@@ -74,6 +79,11 @@ struct ospf6_neighbor {
 
 	/* OSPFv3 Interface this neighbor belongs to */
 	struct ospf6_interface *ospf6_if;
+
+	/* P2P/P2MP config for this neighbor.
+	 * can be NULL if not explicitly configured!
+	 */
+	struct ospf6_if_p2xp_neighcfg *p2xp_cfg;
 
 	/* Neighbor state */
 	uint8_t state;
@@ -154,6 +164,22 @@ struct ospf6_neighbor {
 	bool lls_present;
 };
 
+PREDECL_RBTREE_UNIQ(ospf6_if_p2xp_neighcfgs);
+
+struct ospf6_if_p2xp_neighcfg {
+	struct ospf6_if_p2xp_neighcfgs_item item;
+
+	struct ospf6_interface *ospf6_if;
+	struct in6_addr addr;
+
+	bool cfg_cost : 1;
+
+	uint32_t cost;
+
+	/* NULL if down */
+	struct ospf6_neighbor *active;
+};
+
 /* Neighbor state */
 #define OSPF6_NEIGHBOR_DOWN     1
 #define OSPF6_NEIGHBOR_ATTEMPT  2
@@ -207,6 +233,8 @@ void ospf6_neighbor_delete(struct ospf6_neighbor *on);
 void ospf6_neighbor_lladdr_set(struct ospf6_neighbor *on,
 			       const struct in6_addr *addr);
 
+uint32_t ospf6_neighbor_cost(struct ospf6_neighbor *on);
+
 /* Neighbor event */
 extern void hello_received(struct thread *thread);
 extern void twoway_received(struct thread *thread);
@@ -222,6 +250,8 @@ extern void ospf6_check_nbr_loading(struct ospf6_neighbor *on);
 
 extern void ospf6_neighbor_init(void);
 extern int config_write_ospf6_debug_neighbor(struct vty *vty);
+extern int config_write_ospf6_p2xp_neighbor(struct vty *vty,
+					    struct ospf6_interface *oi);
 extern void install_element_ospf6_debug_neighbor(void);
 
 DECLARE_HOOK(ospf6_neighbor_change,

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -232,6 +232,8 @@ void ospf6_neighbor_delete(struct ospf6_neighbor *on);
 
 void ospf6_neighbor_lladdr_set(struct ospf6_neighbor *on,
 			       const struct in6_addr *addr);
+struct ospf6_if_p2xp_neighcfg *ospf6_if_p2xp_find(struct ospf6_interface *oi,
+						  const struct in6_addr *addr);
 
 uint32_t ospf6_neighbor_cost(struct ospf6_neighbor *on);
 

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -554,6 +554,10 @@ int ospf6_route_cmp(struct ospf6_route *ra, struct ospf6_route *rb)
 	if (ra->path.area_id != rb->path.area_id)
 		return (ntohl(ra->path.area_id) - ntohl(rb->path.area_id));
 
+	if ((ra->prefix_options & OSPF6_PREFIX_OPTION_LA)
+	    != (rb->prefix_options & OSPF6_PREFIX_OPTION_LA))
+		return ra->prefix_options & OSPF6_PREFIX_OPTION_LA ? -1 : 1;
+
 	return 0;
 }
 

--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -1141,6 +1141,8 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 			return SNMP_INTEGER(1);
 		else if (oi->type == OSPF_IFTYPE_POINTOPOINT)
 			return SNMP_INTEGER(3);
+		else if (oi->type == OSPF_IFTYPE_POINTOMULTIPOINT)
+			return SNMP_INTEGER(5);
 		else
 			break; /* Unknown, don't put anything */
 	case OSPFv3IFADMINSTATUS:
@@ -1382,6 +1384,7 @@ static int ospf6TrapIfStateChange(struct ospf6_interface *oi, int next_state,
 
 	/* Terminal state or regression */
 	if ((next_state != OSPF6_INTERFACE_POINTTOPOINT)
+	    && (next_state != OSPF6_INTERFACE_POINTTOMULTIPOINT)
 	    && (next_state != OSPF6_INTERFACE_DROTHER)
 	    && (next_state != OSPF6_INTERFACE_BDR)
 	    && (next_state != OSPF6_INTERFACE_DR) && (next_state >= prev_state))

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -81,6 +81,7 @@ clippy_scan += \
 	ospf6d/ospf6_lsa.c \
 	ospf6d/ospf6_gr_helper.c \
 	ospf6d/ospf6_gr.c \
+	ospf6d/ospf6_interface.c \
 	ospf6d/ospf6_nssa.c \
 	ospf6d/ospf6_route.c \
 	ospf6d/ospf6_neighbor.c \

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -83,6 +83,7 @@ clippy_scan += \
 	ospf6d/ospf6_gr.c \
 	ospf6d/ospf6_nssa.c \
 	ospf6d/ospf6_route.c \
+	ospf6d/ospf6_neighbor.c \
 	# end
 
 nodist_ospf6d_ospf6d_SOURCES = \


### PR DESCRIPTION
This implements:

- announcing the router's own addresses as /128 prefix in the Router LSA with the `LA` bit set (this is a prerequisite for implementing virtual link support too, since this is how the IPv6 address for the other router is found)
- adds a `ipv6 ospf6 neighbor X:X::X:X` list under each interface, with `cost` and `poll-interval` settings each
- `ipv6 ospf6 p2p-p2mp disable-multicast-hello` knob does what the label says
- `ipv6 ospf6 p2p-p2mp config-neighbors-only` refuses becoming neighbor/adjacent with routers that aren't in the `ipv6 ospf6 neighbor` list
- `ipv6 ospf6 p2p-p2mp connected-prefixes <include|exclude>` the semantically trickiest one (though code-wise extremely simple) controls whether addresses on the ptp/ptmp interface are announced as /128 or as /128 + (/64 or other prefix len)
- `ipv6 ospf6 network point-to-multipoint`, finally, just changes from multicast to unicast for LSDB flooding & updates

User doc should explain everything.

Not fully tested yet, hence draft PR.  Tests coming up soon™.