### PR TITLE
bgpd: Switch using RB tree for BGP dampening from SLIST

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -37,6 +37,37 @@
 #include "bgpd/bgp_advertise.h"
 #include "bgpd/bgp_vty.h"
 
+static int bgp_damp_info_compare(const struct reuselist_node *o1,
+				 const struct reuselist_node *o2)
+{
+	struct bgp_damp_info *bdi1 = o1->info;
+	struct bgp_damp_info *bdi2 = o2->info;
+
+	if (bdi1->index < bdi2->index)
+		return -1;
+
+	if (bdi1->index > bdi2->index)
+		return 1;
+
+	if (bdi1->flap < bdi2->flap)
+		return -1;
+
+	if (bdi1->flap > bdi2->flap)
+		return 1;
+
+	if (bdi1->penalty < bdi2->penalty)
+		return -1;
+
+	if (bdi1->penalty > bdi2->penalty)
+		return 1;
+
+	if (bdi1->dest == bdi2->dest && bdi1->path == bdi2->path)
+		return 0;
+
+	return -1;
+}
+RB_GENERATE(reuselist, reuselist_node, entry, bgp_damp_info_compare);
+
 static void bgp_reuselist_add(struct reuselist *list,
 			      struct bgp_damp_info *info)
 {
@@ -45,18 +76,14 @@ static void bgp_reuselist_add(struct reuselist *list,
 	assert(info);
 	new_node = XCALLOC(MTYPE_BGP_DAMP_REUSELIST, sizeof(*new_node));
 	new_node->info = info;
-	SLIST_INSERT_HEAD(list, new_node, entry);
+	RB_INSERT(reuselist, list, new_node);
 }
 
 static void bgp_reuselist_del(struct reuselist *list,
-			      struct reuselist_node **node)
+			      struct reuselist_node *node)
 {
-	if ((*node) == NULL)
-		return;
-	assert(list && node && *node);
-	SLIST_REMOVE(list, (*node), reuselist_node, entry);
-	XFREE(MTYPE_BGP_DAMP_REUSELIST, (*node));
-	*node = NULL;
+	RB_REMOVE(reuselist, list, node);
+	XFREE(MTYPE_BGP_DAMP_REUSELIST, node);
 }
 
 static void bgp_reuselist_switch(struct reuselist *source,
@@ -64,8 +91,8 @@ static void bgp_reuselist_switch(struct reuselist *source,
 				 struct reuselist *target)
 {
 	assert(source && target && node);
-	SLIST_REMOVE(source, node, reuselist_node, entry);
-	SLIST_INSERT_HEAD(target, node, entry);
+	RB_REMOVE(reuselist, source, node);
+	RB_INSERT(reuselist, target, node);
 }
 
 static void bgp_reuselist_free(struct reuselist *list)
@@ -73,18 +100,21 @@ static void bgp_reuselist_free(struct reuselist *list)
 	struct reuselist_node *rn;
 
 	assert(list);
-	while ((rn = SLIST_FIRST(list)) != NULL)
-		bgp_reuselist_del(list, &rn);
+
+	while (!RB_EMPTY(reuselist, list)) {
+		rn = RB_ROOT(reuselist, list);
+		bgp_reuselist_del(list, rn);
+	}
 }
 
 static struct reuselist_node *bgp_reuselist_find(struct reuselist *list,
 						 struct bgp_damp_info *info)
 {
-	struct reuselist_node *rn;
+	struct reuselist_node *rn, *rn_next;
 
 	assert(list && info);
-	SLIST_FOREACH (rn, list, entry) {
-		if (rn->info == info)
+	RB_FOREACH_SAFE (rn, reuselist, list, rn_next) {
+		if (rn->info && rn->info == info)
 			return rn;
 	}
 	return NULL;
@@ -98,13 +128,13 @@ static void bgp_damp_info_unclaim(struct bgp_damp_info *bdi)
 	if (bdi->index == BGP_DAMP_NO_REUSE_LIST_INDEX) {
 		node = bgp_reuselist_find(&bdi->config->no_reuse_list, bdi);
 		if (node)
-			bgp_reuselist_del(&bdi->config->no_reuse_list, &node);
+			bgp_reuselist_del(&bdi->config->no_reuse_list, node);
 	} else {
 		node = bgp_reuselist_find(&bdi->config->reuse_list[bdi->index],
 					  bdi);
 		if (node)
 			bgp_reuselist_del(&bdi->config->reuse_list[bdi->index],
-					  &node);
+					  node);
 	}
 	bdi->config = NULL;
 }
@@ -183,7 +213,9 @@ static void bgp_reuse_list_delete(struct bgp_damp_info *bdi,
 	list = &bdc->reuse_list[bdi->index];
 	rn = bgp_reuselist_find(list, bdi);
 	bgp_damp_info_unclaim(bdi);
-	bgp_reuselist_del(list, &rn);
+
+	if (rn)
+		bgp_reuselist_del(list, rn);
 }
 
 static void bgp_no_reuse_list_add(struct bgp_damp_info *bdi,
@@ -206,7 +238,9 @@ static void bgp_no_reuse_list_delete(struct bgp_damp_info *bdi,
 	}
 	bdi->config = NULL;
 	rn = bgp_reuselist_find(&bdc->no_reuse_list, bdi);
-	bgp_reuselist_del(&bdc->no_reuse_list, &rn);
+
+	if (rn)
+		bgp_reuselist_del(&bdc->no_reuse_list, rn);
 }
 
 /* Return decayed penalty value.  */
@@ -232,7 +266,7 @@ static int bgp_reuse_timer(struct thread *t)
 	struct bgp_damp_config *bdc = THREAD_ARG(t);
 	struct bgp_damp_info *bdi;
 	struct reuselist plist;
-	struct reuselist_node *node;
+	struct reuselist_node *node, *node_next;
 	struct bgp *bgp;
 	time_t t_now, t_diff;
 
@@ -245,7 +279,7 @@ static int bgp_reuse_timer(struct thread *t)
 	 * list head entry. */
 	assert(bdc->reuse_offset < bdc->reuse_list_size);
 	plist = bdc->reuse_list[bdc->reuse_offset];
-	SLIST_INIT(&bdc->reuse_list[bdc->reuse_offset]);
+	RB_INIT(reuselist, &bdc->reuse_list[bdc->reuse_offset]);
 
 	/* 2.  set offset = modulo reuse-list-size ( offset + 1 ), thereby
 	   rotating the circular queue of list-heads.  */
@@ -253,7 +287,7 @@ static int bgp_reuse_timer(struct thread *t)
 	assert(bdc->reuse_offset < bdc->reuse_list_size);
 
 	/* 3. if ( the saved list head pointer is non-empty ) */
-	while ((node = SLIST_FIRST(&plist)) != NULL) {
+	RB_FOREACH_SAFE (node, reuselist, &plist, node_next) {
 		bdi = node->info;
 		bgp = bdi->path->peer->bgp;
 
@@ -285,9 +319,9 @@ static int bgp_reuse_timer(struct thread *t)
 			}
 
 			if (bdi->penalty <= bdc->reuse_limit / 2.0) {
-				bgp_damp_info_free(&bdi, bdc, 1, bdi->afi,
+				bgp_damp_info_free(bdi, bdc, 1, bdi->afi,
 						   bdi->safi);
-				bgp_reuselist_del(&plist, &node);
+				bgp_reuselist_del(&plist, node);
 			} else {
 				node->info->index =
 					BGP_DAMP_NO_REUSE_LIST_INDEX;
@@ -303,7 +337,7 @@ static int bgp_reuse_timer(struct thread *t)
 		}
 	}
 
-	assert(SLIST_EMPTY(&plist));
+	assert(RB_EMPTY(reuselist, &plist));
 
 	return 0;
 }
@@ -431,27 +465,27 @@ int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
 		bdi->t_updated = t_now;
 	else {
 		bgp_damp_info_unclaim(bdi);
-		bgp_damp_info_free(&bdi, bdc, 0, afi, safi);
+		bgp_damp_info_free(bdi, bdc, 0, afi, safi);
 	}
 
 	return status;
 }
 
-void bgp_damp_info_free(struct bgp_damp_info **bdi, struct bgp_damp_config *bdc,
+void bgp_damp_info_free(struct bgp_damp_info *bdi, struct bgp_damp_config *bdc,
 			int withdraw, afi_t afi, safi_t safi)
 {
-	assert(bdc && bdi && *bdi);
+	assert(bdc && bdi);
 
-	if ((*bdi)->path == NULL) {
-		XFREE(MTYPE_BGP_DAMP_INFO, (*bdi));
+	if (bdi->path == NULL) {
+		XFREE(MTYPE_BGP_DAMP_INFO, bdi);
 		return;
 	}
 
-	(*bdi)->path->extra->damp_info = NULL;
-	bgp_path_info_unset_flag((*bdi)->dest, (*bdi)->path,
+	bdi->path->extra->damp_info = NULL;
+	bgp_path_info_unset_flag(bdi->dest, bdi->path,
 				 BGP_PATH_HISTORY | BGP_PATH_DAMPED);
-	if ((*bdi)->lastrecord == BGP_RECORD_WITHDRAW && withdraw)
-		bgp_path_info_delete((*bdi)->dest, (*bdi)->path);
+	if (bdi->lastrecord == BGP_RECORD_WITHDRAW && withdraw)
+		bgp_path_info_delete(bdi->dest, bdi->path);
 }
 
 static void bgp_damp_parameter_set(int hlife, int reuse, int sup, int maxsup,
@@ -548,14 +582,14 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 			 afi_t afi, safi_t safi)
 {
 	struct bgp_damp_info *bdi;
-	struct reuselist_node *rn;
+	struct reuselist_node *rn, *rn_next;
 	struct reuselist *list;
 	unsigned int i;
 
 	bdc->reuse_offset = 0;
 	for (i = 0; i < bdc->reuse_list_size; ++i) {
 		list = &bdc->reuse_list[i];
-		while ((rn = SLIST_FIRST(list)) != NULL) {
+		RB_FOREACH_SAFE (rn, reuselist, list, rn_next) {
 			bdi = rn->info;
 			if (bdi->lastrecord == BGP_RECORD_UPDATE) {
 				bgp_aggregate_increment(bgp, &bdi->dest->p,
@@ -564,15 +598,15 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 				bgp_process(bgp, bdi->dest, bdi->afi,
 					    bdi->safi);
 			}
-			bgp_reuselist_del(list, &rn);
-			bgp_damp_info_free(&bdi, bdc, 1, afi, safi);
+			bgp_reuselist_del(list, rn);
+			bgp_damp_info_free(bdi, bdc, 1, afi, safi);
 		}
 	}
 
-	while ((rn = SLIST_FIRST(&bdc->no_reuse_list)) != NULL) {
+	RB_FOREACH_SAFE (rn, reuselist, &bdc->no_reuse_list, rn_next) {
 		bdi = rn->info;
-		bgp_reuselist_del(&bdc->no_reuse_list, &rn);
-		bgp_damp_info_free(&bdi, bdc, 1, afi, safi);
+		bgp_reuselist_del(&bdc->no_reuse_list, rn);
+		bgp_damp_info_free(bdi, bdc, 1, afi, safi);
 	}
 
 	/* Free decay array */

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -22,6 +22,7 @@
 #define _QUAGGA_BGP_DAMP_H
 
 #include "bgpd/bgp_table.h"
+#include "lib/typesafe.h"
 
 /* Structure maintained on a per-route basis. */
 struct bgp_damp_info {
@@ -64,11 +65,12 @@ struct bgp_damp_info {
 };
 
 struct reuselist_node {
-	SLIST_ENTRY(reuselist_node) entry;
+	RB_ENTRY(reuselist_node) entry;
 	struct bgp_damp_info *info;
 };
 
-SLIST_HEAD(reuselist, reuselist_node);
+RB_HEAD(reuselist, reuselist_node);
+RB_PROTOTYPE(reuselist, reuselist_node, entry, bgp_damp_info_compare);
 
 /* Specified parameter set configuration. */
 struct bgp_damp_config {
@@ -148,7 +150,7 @@ extern int bgp_damp_withdraw(struct bgp_path_info *path, struct bgp_dest *dest,
 			     afi_t afi, safi_t safi, int attr_change);
 extern int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
 			   afi_t afi, safi_t saff);
-extern void bgp_damp_info_free(struct bgp_damp_info **path,
+extern void bgp_damp_info_free(struct bgp_damp_info *path,
 			       struct bgp_damp_config *bdc, int withdraw,
 			       afi_t afi, safi_t safi);
 extern void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14758,7 +14758,7 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 					if (pi->extra && pi->extra->damp_info) {
 						pi_temp = pi->next;
 						bgp_damp_info_free(
-							&pi->extra->damp_info,
+							pi->extra->damp_info,
 							&bgp->damp[afi][safi],
 							1, afi, safi);
 						pi = pi_temp;
@@ -14796,7 +14796,7 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 								    bdi->safi);
 						}
 						bgp_damp_info_free(
-							&pi->extra->damp_info,
+							pi->extra->damp_info,
 							&bgp->damp[afi][safi],
 							1, afi, safi);
 						pi = pi_temp;


### PR DESCRIPTION
Seems the main functionality isn't broken. Might be missed something ofc.

```
exit1-debian-9# sh ip bgp dampening dampened-paths
BGP table version is 7, local router ID is 192.168.0.1, vrf id 0
Default local pref 100, local AS 65001
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          From             Reuse    Path
*d 10.10.10.100/32  192.168.0.2      00:01:00 65000 ?
*d 10.10.10.200/32  192.168.0.2      00:01:00 65000 ?

Displayed  2 routes and 5 total paths

exit1-debian-9# show ip bgp
BGP table version is 7, local router ID is 192.168.0.1, vrf id 0
Default local pref 100, local AS 65001
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
*> 10.0.2.0/24      0.0.0.0                  0         32768 ?
*d 10.10.10.100/32  192.168.0.2              0             0 65000 ?
*d 10.10.10.200/32  192.168.0.2              0             0 65000 ?
*> 192.168.0.0/24   0.0.0.0                  0         32768 ?
*> 192.168.10.0/23  0.0.0.0                  0         32768 ?

exit1-debian-9# clear ip bgp dampening 10.10.10.100/32
exit1-debian-9# show ip bgp
BGP table version is 8, local router ID is 192.168.0.1, vrf id 0
Default local pref 100, local AS 65001
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
*> 10.0.2.0/24      0.0.0.0                  0         32768 ?
*> 10.10.10.100/32  192.168.0.2              0             0 65000 ?
*d 10.10.10.200/32  192.168.0.2              0             0 65000 ?
*> 192.168.0.0/24   0.0.0.0                  0         32768 ?
*> 192.168.10.0/23  0.0.0.0                  0         32768 ?

Displayed  5 routes and 5 total paths
exit1-debian-9# sh ip bgp dampening dampened-paths
BGP table version is 8, local router ID is 192.168.0.1, vrf id 0
Default local pref 100, local AS 65001
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          From             Reuse    Path
*d 10.10.10.200/32  192.168.0.2      00:01:00 65000 ?

Displayed  1 routes and 5 total paths
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>