### PR TITLE
bgpd: Mark the node as the correct type for bgp ipv6 unicast

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -18290,7 +18290,7 @@ static struct cmd_node bgp_ipv4_labeled_unicast_node = {
 };
 
 static struct cmd_node bgp_ipv6_unicast_node = {
-	.name = "bgp ipv6",
+	.name = "bgp ipv6 unicast",
 	.node = BGP_IPV6_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",


### PR DESCRIPTION
The bgp ipv6 unicast node should be called `bgp ipv6 unicast`
to make it consistent with other nodes where we list the afi/safi

Signed-off-by: Donald Sharp <sharpd@nvidia.com>