### PR TITLE
bgpd: We need to initialize the community alias hash

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7776,9 +7776,9 @@ void bgp_init(unsigned short instance)
 
 	/* BGP inits. */
 	bgp_attr_init();
+	bgp_community_alias_init();
 #ifndef FUZZING
 	bgp_debug_init();
-	bgp_community_alias_init();
 	bgp_dump_init();
 #endif
 	bgp_route_init();


### PR DESCRIPTION
When we are starting up under fuzzing we must have the community
alias hash inited on startup.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>