### PR TITLE
pimd: fix missing list remove when deleting mesh group

### DIFF
--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1217,6 +1217,7 @@ void pim_msdp_mg_free(struct pim_instance *pim, struct pim_msdp_mg **mgp)
 	if ((*mgp)->mbr_list)
 		list_delete(&(*mgp)->mbr_list);
 
+	SLIST_REMOVE(&pim->msdp.mglist, (*mgp), pim_msdp_mg, mg_entry);
 	XFREE(MTYPE_PIM_MSDP_MG, (*mgp));
 }
 


### PR DESCRIPTION
This leads to a crash when you use "show run" after deleting the group.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>