### PR TITLE
bgpd: Switch using RB tree for BGP dampening from SLIST

### DIFF
--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -22,6 +22,7 @@
 #define _QUAGGA_BGP_DAMP_H
 
 #include "bgpd/bgp_table.h"
+#include "lib/typesafe.h"
 
 /* Structure maintained on a per-route basis. */
 struct bgp_damp_info {
@@ -64,11 +65,12 @@ struct bgp_damp_info {
 };
 
 struct reuselist_node {
-	SLIST_ENTRY(reuselist_node) entry;
+	RB_ENTRY(reuselist_node) entry;
 	struct bgp_damp_info *info;
 };
 
-SLIST_HEAD(reuselist, reuselist_node);
+RB_HEAD(reuselist, reuselist_node);
+RB_PROTOTYPE(reuselist, reuselist_node, entry, bgp_damp_info_compare);
 
 /* Specified parameter set configuration. */
 struct bgp_damp_config {
@@ -148,7 +150,7 @@ extern int bgp_damp_withdraw(struct bgp_path_info *path, struct bgp_dest *dest,
 			     afi_t afi, safi_t safi, int attr_change);
 extern int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
 			   afi_t afi, safi_t saff);
-extern void bgp_damp_info_free(struct bgp_damp_info **path,
+extern void bgp_damp_info_free(struct bgp_damp_info *path,
 			       struct bgp_damp_config *bdc, int withdraw,
 			       afi_t afi, safi_t safi);
 extern void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14758,7 +14758,7 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 					if (pi->extra && pi->extra->damp_info) {
 						pi_temp = pi->next;
 						bgp_damp_info_free(
-							&pi->extra->damp_info,
+							pi->extra->damp_info,
 							&bgp->damp[afi][safi],
 							1, afi, safi);
 						pi = pi_temp;
@@ -14796,7 +14796,7 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 								    bdi->safi);
 						}
 						bgp_damp_info_free(
-							&pi->extra->damp_info,
+							pi->extra->damp_info,
 							&bgp->damp[afi][safi],
 							1, afi, safi);
 						pi = pi_temp;


### PR DESCRIPTION
Seems the main functionality isn't broken. Might be missed something ofc.

```
exit1-debian-9# sh ip bgp dampening dampened-paths
BGP table version is 7, local router ID is 192.168.0.1, vrf id 0
Default local pref 100, local AS 65001
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          From             Reuse    Path
*d 10.10.10.100/32  192.168.0.2      00:01:00 65000 ?
*d 10.10.10.200/32  192.168.0.2      00:01:00 65000 ?

Displayed  2 routes and 5 total paths

exit1-debian-9# show ip bgp
BGP table version is 7, local router ID is 192.168.0.1, vrf id 0
Default local pref 100, local AS 65001
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
*> 10.0.2.0/24      0.0.0.0                  0         32768 ?
*d 10.10.10.100/32  192.168.0.2              0             0 65000 ?
*d 10.10.10.200/32  192.168.0.2              0             0 65000 ?
*> 192.168.0.0/24   0.0.0.0                  0         32768 ?
*> 192.168.10.0/23  0.0.0.0                  0         32768 ?

exit1-debian-9# clear ip bgp dampening 10.10.10.100/32
exit1-debian-9# show ip bgp
BGP table version is 8, local router ID is 192.168.0.1, vrf id 0
Default local pref 100, local AS 65001
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
*> 10.0.2.0/24      0.0.0.0                  0         32768 ?
*> 10.10.10.100/32  192.168.0.2              0             0 65000 ?
*d 10.10.10.200/32  192.168.0.2              0             0 65000 ?
*> 192.168.0.0/24   0.0.0.0                  0         32768 ?
*> 192.168.10.0/23  0.0.0.0                  0         32768 ?

Displayed  5 routes and 5 total paths
exit1-debian-9# sh ip bgp dampening dampened-paths
BGP table version is 8, local router ID is 192.168.0.1, vrf id 0
Default local pref 100, local AS 65001
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          From             Reuse    Path
*d 10.10.10.200/32  192.168.0.2      00:01:00 65000 ?

Displayed  1 routes and 5 total paths
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>