### PR TITLE
zebra: bugfix of error quit of zebra, due to no nexthop ACTIVE

### DIFF
--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1002,7 +1002,6 @@ static int zfpm_build_route_updates(void)
 			data_len = zfpm_encode_route(dest, re, (char *)data,
 						     buf_end - data, &msg_type);
 
-			assert(data_len);
 			if (data_len) {
 				hdr->msg_type = msg_type;
 				msg_len = fpm_data_len_to_msg_len(data_len);
@@ -1013,6 +1012,9 @@ static int zfpm_build_route_updates(void)
 					zfpm_g->stats.route_adds++;
 				else
 					zfpm_g->stats.route_dels++;
+			} else {
+				zlog_err("%s: Encoding Prefix: %pRN No valid nexthops",
+					 __func__, dest->rnode);
 			}
 		}
 


### PR DESCRIPTION
There exists some rare situations where fpm will attempt
to send a route update with no valid nexthops.  In that
case an assert would be hit.  This is not good for
trying to keep your routing daemons up and running
when we can safely just recover the situation.

Fixes #7588
Signed-off-by: batmancn <batmanustc@gmail.com>
<fixed commit message, and used zlog_err>
Signed-off-by: Donald Sharp <sharpd@nvidia.com>