### PR TITLE
tests: Set addresses before we use snmpd

### DIFF
--- a/tests/topotests/simple_snmp_test/test_simple_snmp.py
+++ b/tests/topotests/simple_snmp_test/test_simple_snmp.py
@@ -90,6 +90,16 @@ def setup_module(mod):
 
     r1 = tgen.gears["r1"]
 
+    r1.run("ip addr add 192.168.12.12/24 dev r1-eth0")
+    r1.run("ip -6 addr add 2000:1:1:12::12/64 dev r1-eth0")
+    r1.run("ip addr add 192.168.13.13/24 dev r1-eth1")
+    r1.run("ip -6 addr add 2000:1:1:13::13/64 dev r1-eth1")
+    r1.run("ip addr add 192.168.14.14/24 dev r1-eth2")
+    r1.run("ip -6 addr add 2000:1:1:14::14/64 dev r1-eth2")
+    r1.run("ip addr add 1.1.1.1/32 dev lo")
+    r1.run("ip -6 addr add 2000:1:1:1::1/128 dev lo")
+    r1.run("ip addr show")
+
     router_list = tgen.routers()
 
     # For all registred routers, load the zebra configuration file


### PR DESCRIPTION
The test_simple_snmp.py test starts bgp, zebra and snmpd at the
same time.  Then zebra configuration is read in and interface
addresses are applied.  If snmp start slower than zebra
the snmp process can properly get it's ip address to bind to
if it is faster than zebra, it will fail.  Ensure that the
test has addresses before we start daemons.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>