### PR TITLE
bgpd: fix various memory leaks in dampening

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -228,8 +228,7 @@ static int bgp_reuse_timer(struct thread *t)
 
 			if (bdi->penalty <= bdc->reuse_limit / 2.0) {
 				bgp_reuselist_del(&plist, bdi);
-				bgp_damp_info_free(bdi, bdc, 1, bdi->afi,
-						   bdi->safi);
+				bgp_damp_info_free(bdi, 1);
 			} else {
 				bdi->index = BGP_DAMP_NO_REUSE_LIST_INDEX;
 				bgp_reuselist_switch(&plist, bdi,
@@ -379,16 +378,15 @@ int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
 		bdi->t_updated = t_now;
 	else {
 		bgp_damp_info_unclaim(bdi);
-		bgp_damp_info_free(bdi, bdc, 0, afi, safi);
+		bgp_damp_info_free(bdi, 0);
 	}
 
 	return status;
 }
 
-void bgp_damp_info_free(struct bgp_damp_info *bdi, struct bgp_damp_config *bdc,
-			int withdraw, afi_t afi, safi_t safi)
+void bgp_damp_info_free(struct bgp_damp_info *bdi, int withdraw)
 {
-	assert(bdc && bdi);
+	assert(bdi);
 
 	bdi->path->extra->damp_info = NULL;
 	bgp_path_info_unset_flag(bdi->dest, bdi->path,
@@ -508,13 +506,13 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 					    bdi->safi);
 			}
 			bgp_reuselist_del(list, bdi);
-			bgp_damp_info_free(bdi, bdc, 1, afi, safi);
+			bgp_damp_info_free(bdi, 1);
 		}
 	}
 
 	while ((bdi = SLIST_FIRST(&bdc->no_reuse_list)) != NULL) {
 		bgp_reuselist_del(&bdc->no_reuse_list, bdi);
-		bgp_damp_info_free(bdi, bdc, 1, afi, safi);
+		bgp_damp_info_free(bdi, 1);
 	}
 
 	/* Free decay array */

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -390,16 +390,13 @@ void bgp_damp_info_free(struct bgp_damp_info *bdi, struct bgp_damp_config *bdc,
 {
 	assert(bdc && bdi);
 
-	if (bdi->path == NULL) {
-		XFREE(MTYPE_BGP_DAMP_INFO, bdi);
-		return;
-	}
-
 	bdi->path->extra->damp_info = NULL;
 	bgp_path_info_unset_flag(bdi->dest, bdi->path,
 				 BGP_PATH_HISTORY | BGP_PATH_DAMPED);
 	if (bdi->lastrecord == BGP_RECORD_WITHDRAW && withdraw)
 		bgp_path_info_delete(bdi->dest, bdi->path);
+
+	XFREE(MTYPE_BGP_DAMP_INFO, bdi);
 }
 
 static void bgp_damp_parameter_set(int hlife, int reuse, int sup, int maxsup,

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -40,72 +40,33 @@
 static void bgp_reuselist_add(struct reuselist *list,
 			      struct bgp_damp_info *info)
 {
-	struct reuselist_node *new_node;
-
 	assert(info);
-	new_node = XCALLOC(MTYPE_BGP_DAMP_REUSELIST, sizeof(*new_node));
-	new_node->info = info;
-	SLIST_INSERT_HEAD(list, new_node, entry);
+	SLIST_INSERT_HEAD(list, info, entry);
 }
 
 static void bgp_reuselist_del(struct reuselist *list,
-			      struct reuselist_node **node)
+			      struct bgp_damp_info *info)
 {
-	if ((*node) == NULL)
-		return;
-	assert(list && node && *node);
-	SLIST_REMOVE(list, (*node), reuselist_node, entry);
-	XFREE(MTYPE_BGP_DAMP_REUSELIST, (*node));
-	*node = NULL;
+	assert(info);
+	SLIST_REMOVE(list, info, bgp_damp_info, entry);
 }
 
 static void bgp_reuselist_switch(struct reuselist *source,
-				 struct reuselist_node *node,
+				 struct bgp_damp_info *info,
 				 struct reuselist *target)
 {
-	assert(source && target && node);
-	SLIST_REMOVE(source, node, reuselist_node, entry);
-	SLIST_INSERT_HEAD(target, node, entry);
-}
-
-static void bgp_reuselist_free(struct reuselist *list)
-{
-	struct reuselist_node *rn;
-
-	assert(list);
-	while ((rn = SLIST_FIRST(list)) != NULL)
-		bgp_reuselist_del(list, &rn);
-}
-
-static struct reuselist_node *bgp_reuselist_find(struct reuselist *list,
-						 struct bgp_damp_info *info)
-{
-	struct reuselist_node *rn;
-
-	assert(list && info);
-	SLIST_FOREACH (rn, list, entry) {
-		if (rn->info == info)
-			return rn;
-	}
-	return NULL;
+	assert(source && target && info);
+	SLIST_REMOVE(source, info, bgp_damp_info, entry);
+	SLIST_INSERT_HEAD(target, info, entry);
 }
 
 static void bgp_damp_info_unclaim(struct bgp_damp_info *bdi)
 {
-	struct reuselist_node *node;
-
 	assert(bdi && bdi->config);
-	if (bdi->index == BGP_DAMP_NO_REUSE_LIST_INDEX) {
-		node = bgp_reuselist_find(&bdi->config->no_reuse_list, bdi);
-		if (node)
-			bgp_reuselist_del(&bdi->config->no_reuse_list, &node);
-	} else {
-		node = bgp_reuselist_find(&bdi->config->reuse_list[bdi->index],
-					  bdi);
-		if (node)
-			bgp_reuselist_del(&bdi->config->reuse_list[bdi->index],
-					  &node);
-	}
+	if (bdi->index == BGP_DAMP_NO_REUSE_LIST_INDEX)
+		bgp_reuselist_del(&bdi->config->no_reuse_list, bdi);
+	else
+		bgp_reuselist_del(&bdi->config->reuse_list[bdi->index], bdi);
 	bdi->config = NULL;
 }
 
@@ -187,19 +148,9 @@ static void bgp_no_reuse_list_add(struct bgp_damp_info *bdi,
 	bgp_reuselist_add(&bdc->no_reuse_list, bdi);
 }
 
-static void bgp_no_reuse_list_delete(struct bgp_damp_info *bdi,
-				     struct bgp_damp_config *bdc)
+static void bgp_no_reuse_list_delete(struct bgp_damp_info *bdi)
 {
-	struct reuselist_node *rn;
-
-	assert(bdc && bdi);
-	if (bdi->config == NULL) {
-		bgp_damp_info_unclaim(bdi);
-		return;
-	}
-	bdi->config = NULL;
-	rn = bgp_reuselist_find(&bdc->no_reuse_list, bdi);
-	bgp_reuselist_del(&bdc->no_reuse_list, &rn);
+	bgp_damp_info_unclaim(bdi);
 }
 
 /* Return decayed penalty value.  */
@@ -225,7 +176,6 @@ static int bgp_reuse_timer(struct thread *t)
 	struct bgp_damp_config *bdc = THREAD_ARG(t);
 	struct bgp_damp_info *bdi;
 	struct reuselist plist;
-	struct reuselist_node *node;
 	struct bgp *bgp;
 	time_t t_now, t_diff;
 
@@ -246,8 +196,7 @@ static int bgp_reuse_timer(struct thread *t)
 	assert(bdc->reuse_offset < bdc->reuse_list_size);
 
 	/* 3. if ( the saved list head pointer is non-empty ) */
-	while ((node = SLIST_FIRST(&plist)) != NULL) {
-		bdi = node->info;
+	while ((bdi = SLIST_FIRST(&plist)) != NULL) {
 		bgp = bdi->path->peer->bgp;
 
 		/* Set t-diff = t-now - t-updated.  */
@@ -278,20 +227,19 @@ static int bgp_reuse_timer(struct thread *t)
 			}
 
 			if (bdi->penalty <= bdc->reuse_limit / 2.0) {
+				bgp_reuselist_del(&plist, bdi);
 				bgp_damp_info_free(bdi, bdc, 1, bdi->afi,
 						   bdi->safi);
-				bgp_reuselist_del(&plist, &node);
 			} else {
-				node->info->index =
-					BGP_DAMP_NO_REUSE_LIST_INDEX;
-				bgp_reuselist_switch(&plist, node,
+				bdi->index = BGP_DAMP_NO_REUSE_LIST_INDEX;
+				bgp_reuselist_switch(&plist, bdi,
 						     &bdc->no_reuse_list);
 			}
 		} else {
 			/* Re-insert into another list (See RFC2439 Section
 			 * 4.8.6).  */
 			bdi->index = bgp_reuse_index(bdi->penalty, bdc);
-			bgp_reuselist_switch(&plist, node,
+			bgp_reuselist_switch(&plist, bdi,
 					     &bdc->reuse_list[bdi->index]);
 		}
 	}
@@ -387,7 +335,7 @@ int bgp_damp_withdraw(struct bgp_path_info *path, struct bgp_dest *dest,
 	if (bdi->penalty >= bdc->suppress_value) {
 		bgp_path_info_set_flag(dest, path, BGP_PATH_DAMPED);
 		bdi->suppress_time = t_now;
-		bgp_no_reuse_list_delete(bdi, bdc);
+		bgp_no_reuse_list_delete(bdi);
 		bgp_reuse_list_add(bdi, bdc);
 	}
 	return BGP_DAMP_USED;
@@ -548,15 +496,13 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 			 afi_t afi, safi_t safi)
 {
 	struct bgp_damp_info *bdi;
-	struct reuselist_node *rn;
 	struct reuselist *list;
 	unsigned int i;
 
 	bdc->reuse_offset = 0;
 	for (i = 0; i < bdc->reuse_list_size; ++i) {
 		list = &bdc->reuse_list[i];
-		while ((rn = SLIST_FIRST(list)) != NULL) {
-			bdi = rn->info;
+		while ((bdi = SLIST_FIRST(list)) != NULL) {
 			if (bdi->lastrecord == BGP_RECORD_UPDATE) {
 				bgp_aggregate_increment(bgp, &bdi->dest->p,
 							bdi->path, bdi->afi,
@@ -564,14 +510,13 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 				bgp_process(bgp, bdi->dest, bdi->afi,
 					    bdi->safi);
 			}
-			bgp_reuselist_del(list, &rn);
+			bgp_reuselist_del(list, bdi);
 			bgp_damp_info_free(bdi, bdc, 1, afi, safi);
 		}
 	}
 
-	while ((rn = SLIST_FIRST(&bdc->no_reuse_list)) != NULL) {
-		bdi = rn->info;
-		bgp_reuselist_del(&bdc->no_reuse_list, &rn);
+	while ((bdi = SLIST_FIRST(&bdc->no_reuse_list)) != NULL) {
+		bgp_reuselist_del(&bdc->no_reuse_list, bdi);
 		bgp_damp_info_free(bdi, bdc, 1, afi, safi);
 	}
 
@@ -582,10 +527,6 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 	/* Free reuse index array */
 	XFREE(MTYPE_BGP_DAMP_ARRAY, bdc->reuse_index);
 	bdc->reuse_index_size = 0;
-
-	/* Free reuse list array. */
-	for (i = 0; i < bdc->reuse_list_size; ++i)
-		bgp_reuselist_free(&bdc->reuse_list[i]);
 
 	XFREE(MTYPE_BGP_DAMP_ARRAY, bdc->reuse_list);
 	bdc->reuse_list_size = 0;

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -41,14 +41,14 @@ static void bgp_reuselist_add(struct reuselist *list,
 			      struct bgp_damp_info *info)
 {
 	assert(info);
-	SLIST_INSERT_HEAD(list, info, entry);
+	LIST_INSERT_HEAD(list, info, entry);
 }
 
 static void bgp_reuselist_del(struct reuselist *list,
 			      struct bgp_damp_info *info)
 {
 	assert(info);
-	SLIST_REMOVE(list, info, bgp_damp_info, entry);
+	LIST_REMOVE(info, entry);
 }
 
 static void bgp_reuselist_switch(struct reuselist *source,
@@ -56,8 +56,8 @@ static void bgp_reuselist_switch(struct reuselist *source,
 				 struct reuselist *target)
 {
 	assert(source && target && info);
-	SLIST_REMOVE(source, info, bgp_damp_info, entry);
-	SLIST_INSERT_HEAD(target, info, entry);
+	LIST_REMOVE(info, entry);
+	LIST_INSERT_HEAD(target, info, entry);
 }
 
 static void bgp_damp_info_unclaim(struct bgp_damp_info *bdi)
@@ -188,7 +188,7 @@ static int bgp_reuse_timer(struct thread *t)
 	 * list head entry. */
 	assert(bdc->reuse_offset < bdc->reuse_list_size);
 	plist = bdc->reuse_list[bdc->reuse_offset];
-	SLIST_INIT(&bdc->reuse_list[bdc->reuse_offset]);
+	LIST_INIT(&bdc->reuse_list[bdc->reuse_offset]);
 
 	/* 2.  set offset = modulo reuse-list-size ( offset + 1 ), thereby
 	   rotating the circular queue of list-heads.  */
@@ -196,7 +196,7 @@ static int bgp_reuse_timer(struct thread *t)
 	assert(bdc->reuse_offset < bdc->reuse_list_size);
 
 	/* 3. if ( the saved list head pointer is non-empty ) */
-	while ((bdi = SLIST_FIRST(&plist)) != NULL) {
+	while ((bdi = LIST_FIRST(&plist)) != NULL) {
 		bgp = bdi->path->peer->bgp;
 
 		/* Set t-diff = t-now - t-updated.  */
@@ -242,7 +242,7 @@ static int bgp_reuse_timer(struct thread *t)
 		}
 	}
 
-	assert(SLIST_EMPTY(&plist));
+	assert(LIST_EMPTY(&plist));
 
 	return 0;
 }
@@ -496,7 +496,7 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 	bdc->reuse_offset = 0;
 	for (i = 0; i < bdc->reuse_list_size; ++i) {
 		list = &bdc->reuse_list[i];
-		while ((bdi = SLIST_FIRST(list)) != NULL) {
+		while ((bdi = LIST_FIRST(list)) != NULL) {
 			if (bdi->lastrecord == BGP_RECORD_UPDATE) {
 				bgp_aggregate_increment(bgp, &bdi->dest->p,
 							bdi->path, bdi->afi,
@@ -508,7 +508,7 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 		}
 	}
 
-	while ((bdi = SLIST_FIRST(&bdc->no_reuse_list)) != NULL)
+	while ((bdi = LIST_FIRST(&bdc->no_reuse_list)) != NULL)
 		bgp_damp_info_free(bdi, 1);
 
 	/* Free decay array */

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -62,10 +62,10 @@ struct bgp_damp_info {
 	afi_t afi;
 	safi_t safi;
 
-	SLIST_ENTRY(bgp_damp_info) entry;
+	LIST_ENTRY(bgp_damp_info) entry;
 };
 
-SLIST_HEAD(reuselist, bgp_damp_info);
+LIST_HEAD(reuselist, bgp_damp_info);
 
 /* Specified parameter set configuration. */
 struct bgp_damp_config {

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -61,14 +61,11 @@ struct bgp_damp_info {
 
 	afi_t afi;
 	safi_t safi;
+
+	SLIST_ENTRY(bgp_damp_info) entry;
 };
 
-struct reuselist_node {
-	SLIST_ENTRY(reuselist_node) entry;
-	struct bgp_damp_info *info;
-};
-
-SLIST_HEAD(reuselist, reuselist_node);
+SLIST_HEAD(reuselist, bgp_damp_info);
 
 /* Specified parameter set configuration. */
 struct bgp_damp_config {

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -145,9 +145,7 @@ extern int bgp_damp_withdraw(struct bgp_path_info *path, struct bgp_dest *dest,
 			     afi_t afi, safi_t safi, int attr_change);
 extern int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
 			   afi_t afi, safi_t saff);
-extern void bgp_damp_info_free(struct bgp_damp_info *bdi,
-			       struct bgp_damp_config *bdc, int withdraw,
-			       afi_t afi, safi_t safi);
+extern void bgp_damp_info_free(struct bgp_damp_info *bdi, int withdraw);
 extern void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 				afi_t afi, safi_t safi);
 extern void bgp_damp_config_clean(struct bgp_damp_config *bdc);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14759,8 +14759,7 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 						pi_temp = pi->next;
 						bgp_damp_info_free(
 							pi->extra->damp_info,
-							&bgp->damp[afi][safi],
-							1, afi, safi);
+							1);
 						pi = pi_temp;
 					} else
 						pi = pi->next;
@@ -14797,8 +14796,7 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 						}
 						bgp_damp_info_free(
 							pi->extra->damp_info,
-							&bgp->damp[afi][safi],
-							1, afi, safi);
+							1);
 						pi = pi_temp;
 					} else
 						pi = pi->next;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -222,7 +222,10 @@ void bgp_path_info_extra_free(struct bgp_path_info_extra **extra)
 
 	e = *extra;
 
+	if (e->damp_info)
+		bgp_damp_info_free(e->damp_info, 0);
 	e->damp_info = NULL;
+
 	if (e->parent) {
 		struct bgp_path_info *bpi = (struct bgp_path_info *)e->parent;
 


### PR DESCRIPTION
Overall this PR aims to fix multiple memory leaks in the dampening code. All the leaks are regressions in 8.0 and I want this code to be backported even though there are a couple of cleanup-only commits. It is difficult to fix the leaks without doing the cleanup.

Please, check individual commits for descriptions.

The last commit changes the SLIST to a LIST. The dampening code was always using a double-linked list before the rework in 8.0 that introduced all those crashes and memory leaks. As there are frequent removals from the list, using a single-linked list is actually a real performance regression so changing it back to double-linked list should be considered as a fix.