### PR TITLE
Improve pim timers

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -93,7 +93,7 @@ Certain signals have special meanings to *pimd*.
    down. This command is vrf aware, to configure for a vrf, enter the vrf
    submode.
 
-.. clicmd:: ip pim join-prune-interval (5-600)
+.. clicmd:: ip pim join-prune-interval (1-65535)
 
    Modify the join/prune interval that pim uses to the new value. Time is
    specified in seconds. This command is vrf aware, to configure for a vrf,
@@ -101,14 +101,14 @@ Certain signals have special meanings to *pimd*.
    a value smaller than 60 seconds be aware that this can and will affect
    convergence at scale.
 
-.. clicmd:: ip pim keep-alive-timer (31-60000)
+.. clicmd:: ip pim keep-alive-timer (1-65535)
 
-   Modify the time out value for a S,G flow from 31-60000 seconds. 31 seconds
-   is chosen for a lower bound because some hardware platforms cannot see data
+   Modify the time out value for a S,G flow from 1-60000 seconds. If choosing
+   a value below 31 seconds be aware that some hardware platforms cannot see data
    flowing in better than 30 second chunks. This command is vrf aware, to
    configure for a vrf, enter the vrf submode.
 
-.. clicmd:: ip pim packets (1-100)
+.. clicmd:: ip pim packets (1-255)
 
    When processing packets from a neighbor process the number of packets
    incoming at one time before moving on to the next task. The default value is
@@ -116,7 +116,7 @@ Certain signals have special meanings to *pimd*.
    a large number of pim control packets flowing. This command is vrf aware, to
    configure for a vrf, enter the vrf submode.
 
-.. clicmd:: ip pim register-suppress-time (5-60000)
+.. clicmd:: ip pim register-suppress-time (1-65535)
 
    Modify the time that pim will register suppress a FHR will send register
    notifications to the kernel. This command is vrf aware, to configure for a
@@ -162,7 +162,7 @@ Certain signals have special meanings to *pimd*.
    the existing IGMP general query timer.If no version is provided in the cli,
    it will be considered as default v2 query.This is a hidden command.
 
-.. clicmd:: ip igmp watermark-warn (10-60000)
+.. clicmd:: ip igmp watermark-warn (1-65535)
 
    Configure watermark warning generation for an igmp group limit. Generates
    warning once the configured group limit is reached while adding new groups.
@@ -201,7 +201,7 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    Set the DR Priority for the interface. This command is useful to allow the
    user to influence what node becomes the DR for a lan segment.
 
-.. clicmd:: ip pim hello (1-180) (1-630)
+.. clicmd:: ip pim hello (1-65535) (1-65535)
 
    Set the pim hello and hold interval for a interface.
 
@@ -227,11 +227,11 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
 
    Join multicast group or source-group on an interface.
 
-.. clicmd:: ip igmp query-interval (1-1800)
+.. clicmd:: ip igmp query-interval (1-65535)
 
    Set the IGMP query interval that PIM will use.
 
-.. clicmd:: ip igmp query-max-response-time (10-250)
+.. clicmd:: ip igmp query-max-response-time (1-65535)
 
    Set the IGMP query response timeout value. If an report is not returned in
    the specified time we will assume the S,G or \*,G has timed out.
@@ -246,12 +246,12 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    or IGMP report is received on this interface and the Group is denied by the
    prefix-list, PIM will ignore the join or report.
 
-.. clicmd:: ip igmp last-member-query-count (1-7)
+.. clicmd:: ip igmp last-member-query-count (1-255)
 
    Set the IGMP last member query count. The default value is 2. 'no' form of
    this command is used to to configure back to the default value.
 
-.. clicmd:: ip igmp last-member-query-interval (1-255)
+.. clicmd:: ip igmp last-member-query-interval (1-65535)
 
    Set the IGMP last member query interval in deciseconds. The default value is
    10 deciseconds. 'no' form of this command is used to to configure back to the
@@ -319,17 +319,17 @@ MSDP can be setup in different ways:
 
 Commands available for MSDP:
 
-.. clicmd:: ip msdp timers (2-600) (3-600) [(1-600)]
+.. clicmd:: ip msdp timers (1-65535) (1-65535) [(1-65535)]
 
    Configure global MSDP timers.
 
-   First value is the keep-alive interval and it must be less than the
-   second value which is hold-time. This configures the interval in
-   seconds between keep-alive messages. The default value is 60 seconds.
+   First value is the keep-alive interval. This configures the interval in
+   seconds between keep-alive messages. The default value is 60 seconds. It
+   should be less than the remote hold time.
 
-   Second value is the hold-time and it must be greater than the keep-alive
-   interval. This configures the interval in seconds before closing a non
-   responding connection. The default value is 75.
+   Second value is the hold-time. This configures the interval in seconds before
+   closing a non responding connection. The default value is 75. This value
+   should be greater than the remote keep alive time.
 
    Third value is the connection retry interval and it is optional. This
    configures the interval between connection attempts. The default value

--- a/lib/command.h
+++ b/lib/command.h
@@ -389,6 +389,7 @@ struct cmd_node {
 #define SRTE_STR "SR-TE information\n"
 #define SRTE_COLOR_STR "SR-TE Color information\n"
 #define NO_STR "Negate a command or set its defaults\n"
+#define IGNORED_IN_NO_STR "Ignored value in no form\n"
 #define REDIST_STR "Redistribute information from another routing protocol\n"
 #define CLEAR_STR "Reset functions\n"
 #define RIP_STR "RIP information\n"

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -96,9 +96,9 @@ struct pim_router {
 	int t_periodic;
 	struct pim_assert_metric infinite_assert_metric;
 	long rpf_cache_refresh_delay_msec;
-	int32_t register_suppress_time;
+	uint32_t register_suppress_time;
 	int packet_process;
-	int32_t register_probe_time;
+	uint32_t register_probe_time;
 
 	/*
 	 * What is the default vrf that we work in

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -956,21 +956,13 @@ int pim_msdp_hold_time_modify(struct nb_cb_modify_args *args)
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		if (yang_dnode_get_uint32(args->dnode, NULL)
-		    <= yang_dnode_get_uint32(args->dnode, "../keep-alive")) {
-			snprintf(
-				args->errmsg, args->errmsg_len,
-				"Hold time must be greater than keep alive interval");
-			return NB_ERR_VALIDATION;
-		}
-		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
 		vrf = nb_running_get_entry(args->dnode, NULL, true);
 		pim = vrf->info;
-		pim->msdp.hold_time = yang_dnode_get_uint32(args->dnode, NULL);
+		pim->msdp.hold_time = yang_dnode_get_uint16(args->dnode, NULL);
 		break;
 	}
 
@@ -988,21 +980,13 @@ int pim_msdp_keep_alive_modify(struct nb_cb_modify_args *args)
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		if (yang_dnode_get_uint32(args->dnode, NULL)
-		    >= yang_dnode_get_uint32(args->dnode, "../hold-time")) {
-			snprintf(
-				args->errmsg, args->errmsg_len,
-				"Keep alive must be less than hold time interval");
-			return NB_ERR_VALIDATION;
-		}
-		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
 		vrf = nb_running_get_entry(args->dnode, NULL, true);
 		pim = vrf->info;
-		pim->msdp.keep_alive = yang_dnode_get_uint32(args->dnode, NULL);
+		pim->msdp.keep_alive = yang_dnode_get_uint16(args->dnode, NULL);
 		break;
 	}
 
@@ -1027,7 +1011,7 @@ int pim_msdp_connection_retry_modify(struct nb_cb_modify_args *args)
 		vrf = nb_running_get_entry(args->dnode, NULL, true);
 		pim = vrf->info;
 		pim->msdp.connection_retry =
-			yang_dnode_get_uint32(args->dnode, NULL);
+			yang_dnode_get_uint16(args->dnode, NULL);
 		break;
 	}
 
@@ -2636,9 +2620,7 @@ int lib_interface_igmp_version_destroy(struct nb_cb_destroy_args *args)
 int lib_interface_igmp_query_interval_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
-	struct pim_interface *pim_ifp;
 	int query_interval;
-	int query_interval_dsec;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -2647,18 +2629,8 @@ int lib_interface_igmp_query_interval_modify(struct nb_cb_modify_args *args)
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
-		pim_ifp = ifp->info;
 		query_interval = yang_dnode_get_uint16(args->dnode, NULL);
-		query_interval_dsec = 10 * query_interval;
-		if (query_interval_dsec <=
-				pim_ifp->igmp_query_max_response_time_dsec) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "Can't set general query interval %d dsec <= query max response time %d dsec.",
-				 query_interval_dsec,
-				 pim_ifp->igmp_query_max_response_time_dsec);
-			return NB_ERR_INCONSISTENCY;
-		}
-		change_query_interval(pim_ifp, query_interval);
+		change_query_interval(ifp->info, query_interval);
 	}
 
 	return NB_OK;
@@ -2671,9 +2643,7 @@ int lib_interface_igmp_query_max_response_time_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
-	struct pim_interface *pim_ifp;
 	int query_max_response_time_dsec;
-	int default_query_interval_dsec;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -2682,22 +2652,9 @@ int lib_interface_igmp_query_max_response_time_modify(
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
-		pim_ifp = ifp->info;
 		query_max_response_time_dsec =
-			yang_dnode_get_uint8(args->dnode, NULL);
-		default_query_interval_dsec =
-			10 * pim_ifp->igmp_default_query_interval;
-
-		if (query_max_response_time_dsec
-			>= default_query_interval_dsec) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "Can't set query max response time %d sec >= general query interval %d sec",
-				 query_max_response_time_dsec,
-				 pim_ifp->igmp_default_query_interval);
-			return NB_ERR_INCONSISTENCY;
-		}
-
-		change_query_max_response_time(pim_ifp,
+			yang_dnode_get_uint16(args->dnode, NULL);
+		change_query_max_response_time(ifp->info,
 				query_max_response_time_dsec);
 	}
 
@@ -2722,8 +2679,8 @@ int lib_interface_igmp_last_member_query_interval_modify(
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
-		last_member_query_interval = yang_dnode_get_uint8(args->dnode,
-				NULL);
+		last_member_query_interval =
+			yang_dnode_get_uint16(args->dnode, NULL);
 		pim_ifp->igmp_specific_query_max_response_time_dsec =
 			last_member_query_interval;
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1800,12 +1800,16 @@ void pim_upstream_start_register_stop_timer(struct pim_upstream *up,
 	THREAD_OFF(up->t_rs_timer);
 
 	if (!null_register) {
-		uint32_t lower = (0.5 * PIM_REGISTER_SUPPRESSION_PERIOD);
-		uint32_t upper = (1.5 * PIM_REGISTER_SUPPRESSION_PERIOD);
-		time = lower + (frr_weak_random() % (upper - lower + 1))
-		       - PIM_REGISTER_PROBE_PERIOD;
+		uint32_t lower = (0.5 * router->register_suppress_time);
+		uint32_t upper = (1.5 * router->register_suppress_time);
+		time = lower + (frr_weak_random() % (upper - lower + 1));
+		/* Make sure we don't wrap around */
+		if (time >= router->register_probe_time)
+			time -= router->register_probe_time;
+		else
+			time = 0;
 	} else
-		time = PIM_REGISTER_PROBE_PERIOD;
+		time = router->register_probe_time;
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		zlog_debug(

--- a/tests/topotests/multicast_pim_sm_topo1/multicast_pim_sm_topo1.json
+++ b/tests/topotests/multicast_pim_sm_topo1/multicast_pim_sm_topo1.json
@@ -13,10 +13,12 @@
                 "r2": {"ipv4": "auto", "pim": "enable"},
                 "c1": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "igmp": {
                 "interfaces": {
                     "l1-i1-eth1" :{
                         "igmp":{
+                            "query": {"query-max-response-time": 40, "query-interval": 5},
                             "version":  "2"
                         }
                     }
@@ -38,6 +40,7 @@
                 "f1": {"ipv4": "auto", "pim": "enable"},
                 "i3": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["10.0.5.0/24", "10.0.6.0/24", "1.0.2.2/32", "10.0.1.0/24"],
                 "next_hop": "10.0.7.1"
@@ -55,6 +58,7 @@
                 "i2": {"ipv4": "auto", "pim": "enable"},
                 "i8": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["1.0.5.17/32", "10.0.8.0/24", "10.0.9.0/24", "10.0.10.0/24", "10.0.12.0/24", "10.0.11.0/24"],
                 "next_hop": "10.0.7.2"
@@ -71,6 +75,7 @@
                 "l1": {"ipv4": "auto", "pim": "enable"},
                 "i4": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["1.0.5.17/32", "10.0.6.0/24", "10.0.3.0/24", "10.0.8.0/24", "10.0.9.0/24", "10.0.12.0/24", "10.0.10.0/24", "10.0.11.0/24"],
                 "next_hop": "10.0.2.2"
@@ -87,6 +92,7 @@
                 "f1": {"ipv4": "auto", "pim": "enable"},
                 "i5": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["1.0.5.17/32", "10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24", "10.0.7.0/24", "10.0.10.0/24", "10.0.11.0/24"],
                 "next_hop": "10.0.3.2"

--- a/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
+++ b/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
@@ -78,6 +78,7 @@ from lib.common_config import (
     step,
     iperfSendIGMPJoin,
     addKernelRoute,
+    apply_raw_config,
     reset_config_on_routers,
     iperfSendTraffic,
     kill_iperf,
@@ -1553,8 +1554,10 @@ def test_modify_igmp_max_query_response_timer_p0(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     step("Delete the PIM and IGMP on FRR1")
-    input_dict_1 = {"l1": {"pim": {"disable": ["l1-i1-eth1"]}}}
-    result = create_pim_config(tgen, topo, input_dict_1)
+    raw_config = {
+        "l1": {"raw_config": ["interface l1-i1-eth1", "no ip pim"]}
+    }
+    result = apply_raw_config(tgen, raw_config)
     assert result is True, "Testcase {}: Failed Error: {}".format(tc_name, result)
 
     input_dict_2 = {

--- a/tests/topotests/multicast_pim_sm_topo2/multicast_pim_sm_topo2.json
+++ b/tests/topotests/multicast_pim_sm_topo2/multicast_pim_sm_topo2.json
@@ -13,10 +13,12 @@
                 "r2": {"ipv4": "auto", "pim": "enable"},
                 "c1": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "igmp": {
                 "interfaces": {
                     "l1-i1-eth1" :{
                         "igmp":{
+                            "query": {"query-max-response-time": 40, "query-interval": 5},
                             "version":  "2"
                         }
                     }
@@ -38,6 +40,7 @@
                 "f1": {"ipv4": "auto", "pim": "enable"},
                 "i3": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["10.0.5.0/24", "10.0.6.0/24", "1.0.2.2/32", "10.0.1.0/24"],
                 "next_hop": "10.0.7.1"
@@ -55,6 +58,7 @@
                 "i2": {"ipv4": "auto", "pim": "enable"},
                 "i8": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["1.0.5.17/32", "10.0.8.0/24", "10.0.9.0/24", "10.0.10.0/24", "10.0.12.0/24", "10.0.11.0/24"],
                 "next_hop": "10.0.7.2"
@@ -71,6 +75,7 @@
                 "l1": {"ipv4": "auto", "pim": "enable"},
                 "i4": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["1.0.5.17/32", "10.0.6.0/24", "10.0.3.0/24", "10.0.8.0/24", "10.0.9.0/24", "10.0.12.0/24", "10.0.10.0/24", "10.0.11.0/24"],
                 "next_hop": "10.0.2.2"
@@ -87,6 +92,7 @@
                 "f1": {"ipv4": "auto", "pim": "enable"},
                 "i5": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["1.0.5.17/32", "10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24", "10.0.7.0/24", "10.0.10.0/24", "10.0.11.0/24"],
                 "next_hop": "10.0.3.2"

--- a/tests/topotests/multicast_pim_sm_topo3/multicast_pim_sm_topo3.json
+++ b/tests/topotests/multicast_pim_sm_topo3/multicast_pim_sm_topo3.json
@@ -13,10 +13,12 @@
                 "r2": {"ipv4": "auto", "pim": "enable"},
                 "c1": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "igmp": {
                 "interfaces": {
                     "l1-i1-eth1" :{
                         "igmp":{
+                            "query": {"query-max-response-time": 40, "query-interval": 5},
                             "version":  "2"
                         }
                     }
@@ -38,6 +40,7 @@
                 "f1": {"ipv4": "auto", "pim": "enable"},
                 "i3": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["10.0.5.0/24", "10.0.6.0/24", "1.0.2.2/32", "10.0.1.0/24", "1.0.3.5/32"],
                 "next_hop": "10.0.7.1"
@@ -55,6 +58,7 @@
                 "i2": {"ipv4": "auto", "pim": "enable"},
                 "i8": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["1.0.5.17/32", "10.0.8.0/24", "10.0.9.0/24", "10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"],
                 "next_hop": "10.0.7.2"
@@ -71,6 +75,7 @@
                 "l1": {"ipv4": "auto", "pim": "enable"},
                 "i4": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["1.0.5.17/32", "10.0.6.0/24", "10.0.8.0/24", "10.0.9.0/24", "10.0.10.0/24", "10.0.11.0/24"],
                 "next_hop": "10.0.2.2"
@@ -87,6 +92,7 @@
                 "f1": {"ipv4": "auto", "pim": "enable"},
                 "i5": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["1.0.5.17/32", "10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24", "10.0.10.0/24", "10.0.11.0/24"],
                 "next_hop": "10.0.3.2"

--- a/tests/topotests/multicast_pim_sm_topo3/multicast_pim_sm_topo4.json
+++ b/tests/topotests/multicast_pim_sm_topo3/multicast_pim_sm_topo4.json
@@ -13,10 +13,12 @@
                 "r2": {"ipv4": "auto", "pim": "enable"},
                 "c1": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "igmp": {
                 "interfaces": {
                     "l1-i1-eth1" :{
                         "igmp":{
+                            "query": {"query-max-response-time": 40, "query-interval": 5},
                             "version":  "2"
                         }
                     }
@@ -40,6 +42,7 @@
                 "f1": {"ipv4": "auto", "pim": "enable"},
                 "i3": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["10.0.4.0/24","10.0.3.1/24"],
                 "next_hop": "10.0.7.1"
@@ -57,6 +60,7 @@
                 "i2": {"ipv4": "auto", "pim": "enable"},
                 "i8": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["10.0.4.0/24","10.0.3.1/24"],
                 "next_hop": "10.0.3.1"
@@ -73,6 +77,7 @@
                 "l1": {"ipv4": "auto", "pim": "enable"},
                 "i4": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [{
                 "network": ["1.0.4.11/32","10.0.4.2/24", "10.0.3.1/24"],
                 "next_hop": "10.0.2.2"
@@ -87,6 +92,7 @@
                 "f1": {"ipv4": "auto", "pim": "enable"},
                 "i5": {"ipv4": "auto", "pim": "enable"}
             },
+            "pim": { "join-prune-interval": "5", "keep-alive-timer": 15, "register-suppress-time": 12 },
             "static_routes": [
             {
                 "network": ["1.0.4.11/32", "10.0.2.1/24", "10.0.1.2/24"],

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
@@ -2231,8 +2231,10 @@ def test_verify_remove_add_pim_commands_when_igmp_configured_p1(request):
     step("Remove 'no ip pim' on receiver interface on FRR1")
 
     intf_l1_i1 = topo["routers"]["l1"]["links"]["i1"]["interface"]
-    input_dict_1 = {"l1": {"pim": {"disable": intf_l1_i1}}}
-    result = create_pim_config(tgen, topo, input_dict_1)
+    raw_config = {
+        "l1": {"raw_config": ["interface {}".format(intf_l1_i1), "no ip pim"]}
+    }
+    result = apply_raw_config(tgen, raw_config)
     assert result is True, "Testcase {}: Failed Error: {}".format(tc_name, result)
 
     step("Verify that no core is observed")

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
@@ -2014,7 +2014,7 @@ def test_verify_remove_add_igmp_commands_when_pim_configured_p0(request):
 
     intf_l1_i1 = topo["routers"]["l1"]["links"]["i1"]["interface"]
     input_dict_1 = {
-        "l1": {"igmp": {"interfaces": {intf_l1_i1: {"igmp": {"version": "2"}}}}}
+        "l1": {"igmp": {"interfaces": {intf_l1_i1: {"igmp": {"version": "2", "query": {"query-max-response-time": 40, "query-interval": 5}}}}}}
     }
 
     result = verify_igmp_config(tgen, input_dict_1)

--- a/tests/topotests/multicast_pim_static_rp_topo1/multicast_pim_static_rp.json
+++ b/tests/topotests/multicast_pim_static_rp_topo1/multicast_pim_static_rp.json
@@ -4,7 +4,11 @@
     "link_ip_start": {"ipv4": "10.0.0.0", "v4mask": 24},
     "lo_prefix": {"ipv4": "1.0.", "v4mask": 32},
     "routers": {
-        "r0": {"links": {"r1": {"ipv4": "auto"}}},
+        "r0": {
+            "links": {
+                "r1": {"ipv4": "auto"}
+            }
+        },
         "r1": {
             "links": {
                 "lo": {"ipv4": "auto", "type": "loopback", "pim": "enable"},
@@ -14,9 +18,20 @@
                 "r4": {"ipv4": "auto", "pim": "enable"}
             },
             "pim": {
-                "rp": [{"rp_addr": "1.0.2.17", "group_addr_range": ["224.0.0.0/4"]}]
+                "join-prune-interval": "5",
+                "keep-alive-timer": 15,
+                "register-suppress-time": 12
             },
-            "igmp": {"interfaces": {"r1-r0-eth0": {"igmp": {"version": "2"}}}},
+            "igmp": {
+                "interfaces": {
+                    "r1-r0-eth0": {
+                        "igmp": {
+                            "query": {"query-max-response-time": 40, "query-interval": 5},
+                            "version": "2"
+                        }
+                    }
+                }
+            },
             "static_routes": [
                 {"network": "10.0.4.0/24", "next_hop": "10.0.2.2"},
                 {"network": "10.0.5.0/24", "next_hop": "10.0.2.2"},
@@ -35,6 +50,9 @@
                 "r3": {"ipv4": "auto", "pim": "enable"}
             },
             "pim": {
+                "join-prune-interval": "5",
+                "keep-alive-timer": 15,
+                "register-suppress-time": 12,
                 "rp": [{"rp_addr": "1.0.2.17", "group_addr_range": ["224.0.0.0/4"]}]
             },
             "static_routes": [
@@ -57,7 +75,9 @@
                 "r5": {"ipv4": "auto", "pim": "enable"}
             },
             "pim": {
-                "rp": [{"rp_addr": "1.0.2.17", "group_addr_range": ["224.0.0.0/4"]}]
+                "join-prune-interval": "5",
+                "keep-alive-timer": 15,
+                "register-suppress-time": 12
             },
             "static_routes": [
                 {"network": "10.0.0.0/24", "next_hop": "10.0.2.1"},
@@ -75,7 +95,9 @@
                 "r3": {"ipv4": "auto", "pim": "enable"}
             },
             "pim": {
-                "rp": [{"rp_addr": "1.0.2.17", "group_addr_range": ["224.0.0.0/4"]}]
+                "join-prune-interval": "5",
+                "keep-alive-timer": 15,
+                "register-suppress-time": 12
             },
             "static_routes": [
                 {"network": "10.0.0.0/24", "next_hop": "10.0.3.1"},
@@ -88,6 +110,10 @@
                 {"network": "1.0.3.17/32", "next_hop": "10.0.5.1"}
             ]
         },
-        "r5": {"links": {"r3": {"ipv4": "auto"}}}
+        "r5": {
+            "links": {
+                "r3": {"ipv4": "auto"}
+            }
+        }
     }
 }

--- a/yang/frr-igmp.yang
+++ b/yang/frr-igmp.yang
@@ -84,9 +84,10 @@ module frr-igmp {
 
     leaf query-interval {
       type uint16 {
-        range "1..1800";
+        range "1..max";
       }
       units seconds;
+      must ". * 10 >= ../query-max-response-time";
       default "125";
       description
         "The Query Interval is the interval between General Queries
@@ -94,10 +95,11 @@ module frr-igmp {
     }
 
     leaf query-max-response-time {
-      type uint8 {
-        range "10..250";
+      type uint16 {
+        range "1..max";
       }
       units deciseconds;
+      must ". <= ../query-interval * 10";
       default "100";
       description
         "Query maximum response time specifies the maximum time
@@ -105,8 +107,8 @@ module frr-igmp {
     }
 
     leaf last-member-query-interval {
-      type uint8 {
-        range "1..255";
+      type uint16 {
+        range "1..max";
       }
       units deciseconds;
       default "10";
@@ -117,7 +119,7 @@ module frr-igmp {
 
     leaf robustness-variable {
       type uint8 {
-        range "1..7";
+        range "1..max";
       }
       default "2";
       description

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -97,7 +97,7 @@ module frr-pim {
 
     leaf keep-alive-timer {
       type uint16 {
-        range "31..60000";
+        range "1..max";
       }
       default "210";
       description
@@ -106,7 +106,7 @@ module frr-pim {
 
     leaf rp-keep-alive-timer {
       type uint16 {
-        range "31..60000";
+        range "1..max";
       }
       default "210";
       description
@@ -116,36 +116,34 @@ module frr-pim {
 
   grouping msdp-timers {
     leaf hold-time {
-      type uint32 {
-        range 3..600;
+      type uint16 {
+        range "1..max";
       }
       units seconds;
       default 75;
       description
         "Hold period is started at the MSDP peer connection establishment
          and is reset every new message. When the period expires the
-         connection is closed.
-
-         This value needs to be greater than `keep-alive-period`.";
+         connection is closed. This value should be greater than the
+         remote keep-alive time.";
     }
 
     leaf keep-alive {
-      type uint32 {
-        range 2..600;
+      type uint16 {
+        range "1..max";
       }
       units seconds;
       default 60;
       description
         "To maintain a connection established it is necessary to send
          keep alive messages in a certain frequency and this allows its
-         configuration.
-
-         This value needs to be lesser than `hold-time-period`.";
+         configuration. This value should be less than the remote
+         hold time.";
     }
 
     leaf connection-retry {
-      type uint32 {
-        range 1..600;
+      type uint16 {
+        range "1..max";
       }
       units seconds;
       default 30;
@@ -343,7 +341,7 @@ module frr-pim {
 
     leaf hello-interval {
       type uint8 {
-        range "1..180";
+        range "1..max";
       }
       default "30";
       description
@@ -352,7 +350,7 @@ module frr-pim {
 
     leaf hello-holdtime {
       type uint16 {
-        range "1..630";
+        range "1..max";
       }
       must ". > ./../hello-interval" {
       error-message "HoldTime must be greater than Hello";
@@ -367,7 +365,7 @@ module frr-pim {
 
       leaf min-rx-interval {
         type uint16 {
-          range "50..60000";
+          range "1..max";
         }
         default "300";
           description
@@ -376,7 +374,7 @@ module frr-pim {
 
       leaf min-tx-interval {
         type uint16 {
-          range "50..60000";
+          range "1..max";
         }
         default "300";
         description
@@ -422,7 +420,7 @@ module frr-pim {
 
     leaf dr-priority {
       type uint32 {
-        range "1..4294967295";
+        range "1..max";
       }
       default 1;
       description
@@ -521,7 +519,7 @@ module frr-pim {
       "PIM router parameters.";
     leaf packets {
       type uint8 {
-        range "1..100";
+        range "1..max";
       }
       default "3";
       description
@@ -529,7 +527,7 @@ module frr-pim {
     }
     leaf join-prune-interval {
       type uint16 {
-        range "5..600";
+        range "1..max";
       }
       default "60";
       description
@@ -537,7 +535,7 @@ module frr-pim {
     }
     leaf register-suppress-time {
       type uint16 {
-        range "5..60000";
+        range "1..max";
       }
       default "60";
       description


### PR DESCRIPTION
While defaults are good picks for "reasonable" guesses, min and max range values really aren't. Operators and experimenters often like to configure "unreasonable" values to stress test, tests boundary conditions and explore innovations.

With that in mind, change all ranges to 1..max (of type).
