### PR TITLE
bgpd: Drop double-pointer for bgp_damp_info_free()

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -285,7 +285,7 @@ static int bgp_reuse_timer(struct thread *t)
 			}
 
 			if (bdi->penalty <= bdc->reuse_limit / 2.0) {
-				bgp_damp_info_free(&bdi, bdc, 1, bdi->afi,
+				bgp_damp_info_free(bdi, bdc, 1, bdi->afi,
 						   bdi->safi);
 				bgp_reuselist_del(&plist, &node);
 			} else {
@@ -431,27 +431,27 @@ int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
 		bdi->t_updated = t_now;
 	else {
 		bgp_damp_info_unclaim(bdi);
-		bgp_damp_info_free(&bdi, bdc, 0, afi, safi);
+		bgp_damp_info_free(bdi, bdc, 0, afi, safi);
 	}
 
 	return status;
 }
 
-void bgp_damp_info_free(struct bgp_damp_info **bdi, struct bgp_damp_config *bdc,
+void bgp_damp_info_free(struct bgp_damp_info *bdi, struct bgp_damp_config *bdc,
 			int withdraw, afi_t afi, safi_t safi)
 {
-	assert(bdc && bdi && *bdi);
+	assert(bdc && bdi);
 
-	if ((*bdi)->path == NULL) {
-		XFREE(MTYPE_BGP_DAMP_INFO, (*bdi));
+	if (bdi->path == NULL) {
+		XFREE(MTYPE_BGP_DAMP_INFO, bdi);
 		return;
 	}
 
-	(*bdi)->path->extra->damp_info = NULL;
-	bgp_path_info_unset_flag((*bdi)->dest, (*bdi)->path,
+	bdi->path->extra->damp_info = NULL;
+	bgp_path_info_unset_flag(bdi->dest, bdi->path,
 				 BGP_PATH_HISTORY | BGP_PATH_DAMPED);
-	if ((*bdi)->lastrecord == BGP_RECORD_WITHDRAW && withdraw)
-		bgp_path_info_delete((*bdi)->dest, (*bdi)->path);
+	if (bdi->lastrecord == BGP_RECORD_WITHDRAW && withdraw)
+		bgp_path_info_delete(bdi->dest, bdi->path);
 }
 
 static void bgp_damp_parameter_set(int hlife, int reuse, int sup, int maxsup,
@@ -565,14 +565,14 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 					    bdi->safi);
 			}
 			bgp_reuselist_del(list, &rn);
-			bgp_damp_info_free(&bdi, bdc, 1, afi, safi);
+			bgp_damp_info_free(bdi, bdc, 1, afi, safi);
 		}
 	}
 
 	while ((rn = SLIST_FIRST(&bdc->no_reuse_list)) != NULL) {
 		bdi = rn->info;
 		bgp_reuselist_del(&bdc->no_reuse_list, &rn);
-		bgp_damp_info_free(&bdi, bdc, 1, afi, safi);
+		bgp_damp_info_free(bdi, bdc, 1, afi, safi);
 	}
 
 	/* Free decay array */

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -148,7 +148,7 @@ extern int bgp_damp_withdraw(struct bgp_path_info *path, struct bgp_dest *dest,
 			     afi_t afi, safi_t safi, int attr_change);
 extern int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
 			   afi_t afi, safi_t saff);
-extern void bgp_damp_info_free(struct bgp_damp_info **path,
+extern void bgp_damp_info_free(struct bgp_damp_info *bdi,
 			       struct bgp_damp_config *bdc, int withdraw,
 			       afi_t afi, safi_t safi);
 extern void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14758,7 +14758,7 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 					if (pi->extra && pi->extra->damp_info) {
 						pi_temp = pi->next;
 						bgp_damp_info_free(
-							&pi->extra->damp_info,
+							pi->extra->damp_info,
 							&bgp->damp[afi][safi],
 							1, afi, safi);
 						pi = pi_temp;
@@ -14796,7 +14796,7 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 								    bdi->safi);
 						}
 						bgp_damp_info_free(
-							&pi->extra->damp_info,
+							pi->extra->damp_info,
 							&bgp->damp[afi][safi],
 							1, afi, safi);
 						pi = pi_temp;


### PR DESCRIPTION
This causes a crash using `clear ip bgp dampening <prefix>`.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>