### PR TITLE
bgpd: fix missing list add in dampening

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -342,7 +342,14 @@ int bgp_damp_withdraw(struct bgp_path_info *path, struct bgp_dest *dest,
 		(bgp_path_info_extra_get(path))->damp_info = bdi;
 		bgp_no_reuse_list_add(bdi, bdc);
 	} else {
-		bgp_damp_info_claim(bdi, bdc);
+		if (bdi->config != bdc) {
+			bgp_damp_info_claim(bdi, bdc);
+			if (bdi->index == BGP_DAMP_NO_REUSE_LIST_INDEX)
+				bgp_reuselist_add(&bdc->no_reuse_list, bdi);
+			else
+				bgp_reuselist_add(&bdc->reuse_list[bdi->index],
+						  bdi);
+		}
 		last_penalty = bdi->penalty;
 
 		/* 1. Set t-diff = t-now - t-updated.  */


### PR DESCRIPTION
One more crash in dampening code...

When bgp_damp_withdraw is called, if there's already a BDI structure,
bgp_damp_info_claim is called to re-assign the bdi->config in case it
was changed. The problem is that bgp_damp_info_claim actually removes
the BDI from the reuse list of the old config and never adds it to the
reuse list of the new config. We must do this to prevent the crash
because all the code assumes that BDI is always in some list.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>