### PR TITLE
[8.0] backport 8860 + 8920

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -829,6 +829,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 				struct bgp_path_info_extra tmp_pie;
 
 				tmp_attr = *pi->attr;
+				tmp_attr.aspath = attr.aspath;
 
 				prep_for_rmap_apply(&tmp_pi, &tmp_pie, dest, pi,
 						    pi->peer, &tmp_attr);
@@ -842,7 +843,6 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 					continue;
 				} else {
 					new_attr = bgp_attr_intern(&tmp_attr);
-					new_attr->aspath = attr.aspath;
 
 					subgroup_announce_reset_nhop(
 						(peer_cap_enhe(peer, afi, safi)

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -839,6 +839,8 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 					bgp_dest_get_prefix(dest), &tmp_pi);
 
 				if (ret == RMAP_DENYMATCH) {
+					/* The aspath belongs to 'attr' */
+					tmp_attr.aspath = NULL;
 					bgp_attr_flush(&tmp_attr);
 					continue;
 				} else {

--- a/tests/topotests/bgp_default_route_route_map_match_set/r1/bgpd.conf
+++ b/tests/topotests/bgp_default_route_route_map_match_set/r1/bgpd.conf
@@ -12,6 +12,7 @@ bgp community-list standard default seq 5 permit 65000:1
 route-map default permit 10
   match community default
   set metric 123
+  set as-path prepend 65000 65000 65000
 !
 route-map internal permit 10
   set community 65000:1

--- a/tests/topotests/bgp_default_route_route_map_match_set/test_bgp_default-originate_route-map_match_set.py
+++ b/tests/topotests/bgp_default_route_route_map_match_set/test_bgp_default-originate_route-map_match_set.py
@@ -94,7 +94,9 @@ def test_bgp_default_originate_route_map():
 
     def _bgp_default_route_has_metric(router):
         output = json.loads(router.vtysh_cmd("show ip bgp 0.0.0.0/0 json"))
-        expected = {"paths": [{"metric": 123}]}
+        expected = {
+            "paths": [{"aspath": {"string": "65000 65000 65000 65000"}, "metric": 123}]
+        }
         return topotest.json_cmp(output, expected)
 
     test_func = functools.partial(_bgp_converge, router)

--- a/tests/topotests/bgp_default_route_route_map_set/r1/bgpd.conf
+++ b/tests/topotests/bgp_default_route_route_map_set/r1/bgpd.conf
@@ -8,4 +8,5 @@ router bgp 65000
 !
 route-map default permit 10
   set metric 123
+  set as-path prepend 65000 65000 65000
 !

--- a/tests/topotests/bgp_default_route_route_map_set/test_bgp_default-originate_route-map_set.py
+++ b/tests/topotests/bgp_default_route_route_map_set/test_bgp_default-originate_route-map_set.py
@@ -93,7 +93,9 @@ def test_bgp_default_originate_route_map():
 
     def _bgp_default_route_has_metric(router):
         output = json.loads(router.vtysh_cmd("show ip bgp 0.0.0.0/0 json"))
-        expected = {"paths": [{"metric": 123}]}
+        expected = {
+            "paths": [{"aspath": {"string": "65000 65000 65000 65000"}, "metric": 123}]
+        }
         return topotest.json_cmp(output, expected)
 
     test_func = functools.partial(_bgp_converge, router)


### PR DESCRIPTION
This is a backport combination of #8860 and #8920.

The second one fixes an SA warning introduced by the first one, so they should be merged together, that's why I am not using Mergify.