### PR TITLE
zebra: Adding json support for nexthop information.

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1293,6 +1293,11 @@ zebra Terminal Mode Commands
    It dumps all the routes from RIB with detailed information including
    internal flags, status etc. This is defined as a hidden command.
 
+.. clicmd:: show <ip|ipv6> <nht|import-check> [<A.B.C.D|X:X::X:X>|vrf NAME [<A.B.C.D|X:X::X:X>]|vrf all] [json]
+
+   Display nexthops detailed information including the client details. This helps to
+   know the nexthops' resolution status.  
+
 
 Router-id
 =========

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -24,6 +24,7 @@
 
 #include "prefix.h"
 #include "vty.h"
+#include "lib/json.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,8 +47,8 @@ extern void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client);
 extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 			       const struct prefix *p, safi_t safi);
 extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, safi_t safi,
-				  struct vty *vty, const struct prefix *p);
-
+				  struct vty *vty, const struct prefix *p,
+				  json_object *json);
 extern int rnh_resolve_via_default(struct zebra_vrf *zvrf, int family);
 
 extern bool rnh_nexthop_valid(const struct route_entry *re,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1369,7 +1369,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
 
 DEFPY (show_ip_nht,
        show_ip_nht_cmd,
-       "show <ip$ipv4|ipv6$ipv6> <nht|import-check>$type [<A.B.C.D|X:X::X:X>$addr|vrf NAME$vrf_name [<A.B.C.D|X:X::X:X>$addr]|vrf all$vrf_all] [mrib$mrib]",
+       "show <ip$ipv4|ipv6$ipv6> <nht|import-check>$type [<A.B.C.D|X:X::X:X>$addr|vrf NAME$vrf_name [<A.B.C.D|X:X::X:X>$addr]|vrf all$vrf_all] [mrib$mrib] [json$json]",
        SHOW_STR
        IP_STR
        IP6_STR
@@ -1381,23 +1381,49 @@ DEFPY (show_ip_nht,
        "IPv4 Address\n"
        "IPv6 Address\n"
        VRF_ALL_CMD_HELP_STR
-       "Show Multicast (MRIB) NHT state\n")
+       "Show Multicast (MRIB) NHT state\n"
+       JSON_STR)
 {
 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
 	vrf_id_t vrf_id = VRF_DEFAULT;
 	struct prefix prefix, *p = NULL;
 	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;
+	json_object *jsonp = NULL;
+
+	if (json)
+		jsonp = json_object_new_object();
 
 	if (vrf_all) {
 		struct vrf *vrf;
 		struct zebra_vrf *zvrf;
+		json_object *json_vrf = NULL;
+		json_object *json_vrfs = NULL;
+
+		if (json)
+			json_vrfs = json_object_new_array();
 
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
 			if ((zvrf = vrf->info) != NULL) {
-				vty_out(vty, "\nVRF %s:\n", zvrf_name(zvrf));
+				if (!json)
+					vty_out(vty, "\nVRF %s:\n",
+						zvrf_name(zvrf));
+				else
+					json_vrf = json_object_new_object();
+
 				zebra_print_rnh_table(zvrf_id(zvrf), afi, safi,
-						      vty, NULL);
+						      vty, NULL, json_vrf);
+				if (json)
+					json_object_array_add(json_vrfs,
+							      json_vrf);
 			}
+
+		if (json) {
+			json_object_object_add(jsonp, "vrfs", json_vrfs);
+			vty_out(vty, "%s\n",
+				json_object_to_json_string_ext(
+					jsonp, JSON_C_TO_STRING_PRETTY));
+			json_object_free(jsonp);
+		}
 		return CMD_SUCCESS;
 	}
 	if (vrf_name)
@@ -1410,7 +1436,15 @@ DEFPY (show_ip_nht,
 			return CMD_WARNING;
 	}
 
-	zebra_print_rnh_table(vrf_id, afi, safi, vty, p);
+	zebra_print_rnh_table(vrf_id, afi, safi, vty, p, jsonp);
+
+	if (json) {
+		vty_out(vty, "%s\n",
+			json_object_to_json_string_ext(
+				jsonp, JSON_C_TO_STRING_PRETTY));
+		json_object_free(jsonp);
+	}
+
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
Description:
	Provided the json support for command "show ip/ipv6 nht json"
	which gives the detailed nexthop information.

Ex o/p:
--------
frr(config)# do show ip nht
10.1.1.35
 resolved via connected
 is directly connected, ens192
 Client list: static(fd 47)
10.1.1.109
 resolved via connected
 is directly connected, ens192
 Client list: static(fd 47)
25.5.5.5
 resolved via static
 via 10.1.1.109, ens192
 Client list: static(fd 47)
32.1.1.10
 unresolved
 Client list: static(fd 47)
frr(config)# 
frr(config)# 
frr(config)# do show ip nht json 
{
  "10.1.1.35":{
    "address":"10.1.1.35",
    "resolvedVia":"connected",
    "filtered":false,
    "clients":{
      "static":{
        "client":"static",
        "fd":47
      }
    }
  },
  "10.1.1.109":{
    "address":"10.1.1.109",
    "resolvedVia":"connected",
    "filtered":false,
    "clients":{
      "static":{
        "client":"static",
        "fd":47
      }
    }
  },
  "25.5.5.5":{
    "address":"25.5.5.5",
    "resolvedVia":"static",
    "filtered":false,
    "clients":{
      "static":{
        "client":"static",
        "fd":47
      }
    }
  },
  "32.1.1.10":{
    "address":"32.1.1.10",
    "unresolved":true,
    "connected":false,
    "filtered":false,
    "clients":{
      "static":{
        "client":"static",
        "fd":47
      }
    }
  }
}
frr(config)# 

Signed-off-by: Rajesh Girada <rgirada@vmware.com>