### PR TITLE
zebra: remove checks for src address existence when using "set src"

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -908,10 +908,11 @@ IPv6 example for OSPFv3.
 
 .. note::
 
-   For both IPv4 and IPv6, the IP address has to exist at the point the
-   route-map is created.  Be wary of race conditions if the interface is
-   not created at startup.  On Debian, FRR might start before ifupdown
-   completes. Consider a reboot test.
+   For both IPv4 and IPv6, the IP address has to exist on some interface when
+   the route is getting installed into the system. Otherwise, kernel rejects
+   the route. To solve the problem of disappearing IPv6 addresses when the
+   interface goes down, use ``net.ipv6.conf.all.keep_addr_on_down``
+   :ref:`sysctl option <zebra-sysctl>`.
 
 .. clicmd:: zebra route-map delay-timer (0-600)
 
@@ -1231,6 +1232,8 @@ For protocols requiring an IPv6 router-id, the following commands are available:
 .. clicmd:: show ipv6 router-id [vrf NAME]
 
    Display the user configured IPv6 router-id.
+
+.. _zebra-sysctl:
 
 Expected sysctl settings
 ========================

--- a/zebra/zebra_routemap_nb_config.c
+++ b/zebra/zebra_routemap_nb_config.c
@@ -247,9 +247,7 @@ lib_route_map_entry_set_action_rmap_set_action_ipv4_src_address_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct routemap_hook_context *rhc;
-	struct interface *pif = NULL;
 	const char *source;
-	struct vrf *vrf;
 	struct prefix p;
 	int rv;
 
@@ -259,18 +257,6 @@ lib_route_map_entry_set_action_rmap_set_action_ipv4_src_address_modify(
 		yang_dnode_get_ipv4p(&p, args->dnode, NULL);
 		if (zebra_check_addr(&p) == 0) {
 			zlog_warn("%s: invalid IPv4 address: %s", __func__,
-				  yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
-
-		RB_FOREACH(vrf, vrf_id_head, &vrfs_by_id) {
-			pif = if_lookup_exact_address(&p.u.prefix4, AF_INET,
-						      vrf->vrf_id);
-			if (pif != NULL)
-				break;
-		}
-		if (pif == NULL) {
-			zlog_warn("%s: is not a local address: %s", __func__,
 				  yang_dnode_get_string(args->dnode, NULL));
 			return NB_ERR_VALIDATION;
 		}
@@ -325,9 +311,7 @@ lib_route_map_entry_set_action_rmap_set_action_ipv6_src_address_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct routemap_hook_context *rhc;
-	struct interface *pif = NULL;
 	const char *source;
-	struct vrf *vrf;
 	struct prefix p;
 	int rv;
 
@@ -337,18 +321,6 @@ lib_route_map_entry_set_action_rmap_set_action_ipv6_src_address_modify(
 		yang_dnode_get_ipv6p(&p, args->dnode, NULL);
 		if (zebra_check_addr(&p) == 0) {
 			zlog_warn("%s: invalid IPv6 address: %s", __func__,
-				  yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
-
-		RB_FOREACH(vrf, vrf_id_head, &vrfs_by_id) {
-			pif = if_lookup_exact_address(&p.u.prefix6, AF_INET6,
-						      vrf->vrf_id);
-			if (pif != NULL)
-				break;
-		}
-		if (pif == NULL) {
-			zlog_warn("%s: is not a local address: %s", __func__,
 				  yang_dnode_get_string(args->dnode, NULL));
 			return NB_ERR_VALIDATION;
 		}


### PR DESCRIPTION
1. This check is absolutely useless. Nothing keeps user from deleting
   the address right after this check.
2. This check prevents zebra from correctly reading the user config with
   "set src" because of a race with interface startup (see #4249).
3. NO OPERATIONAL DATA USAGE ON VALIDATION STAGE.

Fixes #7319.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>