### PR TITLE
*: cleanup interface node installation

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -59,15 +59,6 @@ static void babel_interface_free (babel_interface_nfo *bi);
 
 
 static vector babel_enable_if;                 /* enable interfaces (by cmd). */
-static int interface_config_write(struct vty *vty);
-static struct cmd_node babel_interface_node = {
-    .name = "interface",
-    .node = INTERFACE_NODE,
-    .parent_node = CONFIG_NODE,
-    .prompt = "%s(config-if)# ",
-    .config_write = interface_config_write,
-};
-
 
 int
 babel_interface_up (ZAPI_CALLBACK_ARGS)
@@ -1257,8 +1248,7 @@ babel_if_init(void)
     babel_enable_if = vector_init (1);
 
     /* install interface node and commands */
-    install_node(&babel_interface_node);
-    if_cmd_init();
+    if_cmd_init(interface_config_write);
 
     install_element(BABEL_NODE, &babel_network_cmd);
     install_element(BABEL_NODE, &no_babel_network_cmd);

--- a/eigrpd/eigrp_cli.c
+++ b/eigrpd/eigrp_cli.c
@@ -861,16 +861,6 @@ static int eigrp_config_write(struct vty *vty)
 	return written;
 }
 
-static int eigrp_write_interface(struct vty *vty);
-static struct cmd_node eigrp_interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = eigrp_write_interface,
-};
-
-
 static int eigrp_write_interface(struct vty *vty)
 {
 	struct lyd_node *dnode;
@@ -921,8 +911,7 @@ eigrp_cli_init(void)
 
 	vrf_cmd_init(NULL, &eigrpd_privs);
 
-	install_node(&eigrp_interface_node);
-	if_cmd_init();
+	if_cmd_init(eigrp_write_interface);
 
 	install_element(INTERFACE_NODE, &eigrp_if_delay_cmd);
 	install_element(INTERFACE_NODE, &no_eigrp_if_delay_cmd);

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1430,14 +1430,6 @@ ferr_r isis_circuit_passwd_hmac_md5_set(struct isis_circuit *circuit,
 				       passwd);
 }
 
-struct cmd_node interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = isis_interface_config_write,
-};
-
 void isis_circuit_circ_type_set(struct isis_circuit *circuit, int circ_type)
 {
 	if (circuit->circ_type == circ_type)
@@ -1537,8 +1529,7 @@ void isis_circuit_init(void)
 	hook_register_prio(if_del, 0, isis_if_delete_hook);
 
 	/* Install interface node */
-	install_node(&interface_node);
-	if_cmd_init();
+	if_cmd_init(isis_interface_config_write);
 	if_zapi_callbacks(isis_ifp_create, isis_ifp_up,
 			  isis_ifp_down, isis_ifp_destroy);
 }

--- a/lib/if.c
+++ b/lib/if.c
@@ -1349,9 +1349,19 @@ static const struct cmd_variable_handler if_var_handlers[] = {
 	{.tokenname = "INTERFACE", .completions = if_autocomplete},
 	{.completions = NULL}};
 
-void if_cmd_init(void)
+static struct cmd_node interface_node = {
+	.name = "interface",
+	.node = INTERFACE_NODE,
+	.parent_node = CONFIG_NODE,
+	.prompt = "%s(config-if)# ",
+};
+
+void if_cmd_init(int (*config_write)(struct vty *))
 {
 	cmd_variable_handler_register(if_var_handlers);
+
+	interface_node.config_write = config_write;
+	install_node(&interface_node);
 
 	install_element(CONFIG_NODE, &interface_cmd);
 	install_element(CONFIG_NODE, &no_interface_cmd);

--- a/lib/if.h
+++ b/lib/if.h
@@ -597,7 +597,8 @@ struct if_link_params *if_link_params_get(struct interface *);
 void if_link_params_free(struct interface *);
 
 /* Northbound. */
-extern void if_cmd_init(void);
+struct vty;
+extern void if_cmd_init(int (*config_write)(struct vty *));
 extern void if_zapi_callbacks(int (*create)(struct interface *ifp),
 			      int (*up)(struct interface *ifp),
 			      int (*down)(struct interface *ifp),

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -26,15 +26,6 @@ static struct cmd_node zebra_node = {
 	.config_write = nhrp_config_write,
 };
 
-static int interface_config_write(struct vty *vty);
-static struct cmd_node nhrp_interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = interface_config_write,
-};
-
 #define NHRP_DEBUG_FLAGS_CMD "<all|common|event|interface|kernel|route|vici>"
 
 #define NHRP_DEBUG_FLAGS_STR                                                   \
@@ -1263,9 +1254,7 @@ void nhrp_config_init(void)
 	vrf_cmd_init(NULL, &nhrpd_privs);
 
 	/* interface specific commands */
-	install_node(&nhrp_interface_node);
-
-	if_cmd_init();
+	if_cmd_init(interface_config_write);
 	install_element(INTERFACE_NODE, &tunnel_protection_cmd);
 	install_element(INTERFACE_NODE, &no_tunnel_protection_cmd);
 	install_element(INTERFACE_NODE, &tunnel_source_cmd);

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -2584,15 +2584,6 @@ static int config_write_interface(struct vty *vty)
 	return write;
 }
 
-static int config_write_ospf6_interface(struct vty *vty, struct vrf *vrf);
-static struct cmd_node interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = config_write_interface,
-};
-
 static int ospf6_ifp_create(struct interface *ifp)
 {
 	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
@@ -2650,8 +2641,7 @@ static int ospf6_ifp_destroy(struct interface *ifp)
 void ospf6_interface_init(void)
 {
 	/* Install interface node. */
-	install_node(&interface_node);
-	if_cmd_init();
+	if_cmd_init(config_write_interface);
 	if_zapi_callbacks(ospf6_ifp_create, ospf6_ifp_up,
 			  ospf6_ifp_down, ospf6_ifp_destroy);
 

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -12622,22 +12622,11 @@ void ospf_vty_show_init(void)
 	install_element(VIEW_NODE, &show_ip_ospf_external_aggregator_cmd);
 }
 
-static int config_write_interface(struct vty *vty);
-/* ospfd's interface node. */
-static struct cmd_node interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = config_write_interface,
-};
-
 /* Initialization of OSPF interface. */
 static void ospf_vty_if_init(void)
 {
 	/* Install interface node. */
-	install_node(&interface_node);
-	if_cmd_init();
+	if_cmd_init(config_write_interface);
 
 	/* "ip ospf authentication" commands. */
 	install_element(INTERFACE_NODE, &ip_ospf_authentication_args_addr_cmd);

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -1100,15 +1100,6 @@ DEFUN_NOSH(show_debugging_pbr,
 /* ------------------------------------------------------------------------- */
 
 
-static int pbr_interface_config_write(struct vty *vty);
-static struct cmd_node interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = pbr_interface_config_write,
-};
-
 static int pbr_interface_config_write(struct vty *vty)
 {
 	struct interface *ifp;
@@ -1240,8 +1231,7 @@ void pbr_vty_init(void)
 
 	vrf_cmd_init(NULL, &pbr_privs);
 
-	install_node(&interface_node);
-	if_cmd_init();
+	if_cmd_init(pbr_interface_config_write);
 
 	install_node(&pbr_map_node);
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -72,14 +72,6 @@
 #include "pimd/pim_cmd_clippy.c"
 #endif
 
-static struct cmd_node interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = pim_interface_config_write,
-};
-
 static struct cmd_node debug_node = {
 	.name = "debug",
 	.node = DEBUG_NODE,
@@ -11104,8 +11096,7 @@ DEFUN_HIDDEN (ip_pim_mlag,
 
 void pim_cmd_init(void)
 {
-	install_node(&interface_node); /* INTERFACE_NODE */
-	if_cmd_init();
+	if_cmd_init(pim_interface_config_write);
 
 	install_node(&debug_node);
 

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -1156,15 +1156,6 @@ int rip_show_network_config(struct vty *vty, struct rip *rip)
 	return 0;
 }
 
-static int rip_interface_config_write(struct vty *vty);
-static struct cmd_node interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = rip_interface_config_write,
-};
-
 void rip_interface_sync(struct interface *ifp)
 {
 	struct vrf *vrf;
@@ -1204,8 +1195,7 @@ void rip_if_init(void)
 	hook_register_prio(if_del, 0, rip_interface_delete_hook);
 
 	/* Install interface node. */
-	install_node(&interface_node);
-	if_cmd_init();
+	if_cmd_init(rip_interface_config_write);
 	if_zapi_callbacks(rip_ifp_create, rip_ifp_up,
 			  rip_ifp_down, rip_ifp_destroy);
 }

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -951,16 +951,6 @@ static int interface_config_write(struct vty *vty)
 	return write;
 }
 
-static int interface_config_write(struct vty *vty);
-/* ripngd's interface node. */
-static struct cmd_node interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = interface_config_write,
-};
-
 /* Initialization of interface. */
 void ripng_if_init(void)
 {
@@ -969,8 +959,7 @@ void ripng_if_init(void)
 	hook_register_prio(if_del, 0, ripng_if_delete_hook);
 
 	/* Install interface node. */
-	install_node(&interface_node);
-	if_cmd_init();
+	if_cmd_init(interface_config_write);
 	if_zapi_callbacks(ripng_ifp_create, ripng_ifp_up,
 			  ripng_ifp_down, ripng_ifp_destroy);
 }

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -744,14 +744,6 @@ static int vrrp_config_write_interface(struct vty *vty)
 	return write;
 }
 
-static struct cmd_node interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = vrrp_config_write_interface,
-};
-
 static struct cmd_node debug_node = {
 	.name = "debug",
 	.node = DEBUG_NODE,
@@ -769,10 +761,9 @@ static struct cmd_node vrrp_node = {
 void vrrp_vty_init(void)
 {
 	install_node(&debug_node);
-	install_node(&interface_node);
 	install_node(&vrrp_node);
 	vrf_cmd_init(NULL, &vrrp_privs);
-	if_cmd_init();
+	if_cmd_init(vrrp_config_write_interface);
 
 	install_element(VIEW_NODE, &vrrp_vrid_show_cmd);
 	install_element(VIEW_NODE, &vrrp_vrid_show_summary_cmd);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1786,15 +1786,6 @@ static void interface_update_stats(void)
 #endif /* HAVE_NET_RT_IFLIST */
 }
 
-static int if_config_write(struct vty *vty);
-struct cmd_node interface_node = {
-	.name = "interface",
-	.node = INTERFACE_NODE,
-	.parent_node = CONFIG_NODE,
-	.prompt = "%s(config-if)# ",
-	.config_write = if_config_write,
-};
-
 #ifndef VTYSH_EXTRACT_PL
 #include "zebra/interface_clippy.c"
 #endif
@@ -3703,9 +3694,8 @@ void zebra_if_init(void)
 	hook_register_prio(if_del, 0, if_zebra_delete_hook);
 
 	/* Install configuration write function. */
-	install_node(&interface_node);
+	if_cmd_init(if_config_write);
 	install_node(&link_params_node);
-	if_cmd_init();
 	/*
 	 * This is *intentionally* setting this to NULL, signaling
 	 * that interface creation for zebra acts differently


### PR DESCRIPTION
The only difference in daemons' interface node definition is the config
write function. No need to define the node in every daemon, just pass
the callback as an argument to a library function and define the node
there.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>