### PR TITLE
bgpd: Extend EVPN next hop tracking to type-1 and type-4 routes

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -6048,10 +6048,12 @@ bool bgp_evpn_is_prefix_nht_supported(const struct prefix *pfx)
 	 * type-5 routes. It may be tweaked later on for other routes, or
 	 * even removed completely when all routes are handled.
 	 */
-	if (pfx && pfx->family == AF_EVPN &&
-	    (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE ||
-	     evp->prefix.route_type == BGP_EVPN_IMET_ROUTE ||
-	     evp->prefix.route_type == BGP_EVPN_IP_PREFIX_ROUTE))
+	if (pfx && pfx->family == AF_EVPN
+	    && (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE
+		|| evp->prefix.route_type == BGP_EVPN_AD_ROUTE
+		|| evp->prefix.route_type == BGP_EVPN_ES_ROUTE
+		|| evp->prefix.route_type == BGP_EVPN_IMET_ROUTE
+		|| evp->prefix.route_type == BGP_EVPN_IP_PREFIX_ROUTE))
 		return true;
 
 	return false;


### PR DESCRIPTION
NH tracking is already in use for type-1, type-3 and type-5 routes.
This change extends that tracking to EAD and ESR to eliminate the 9s
delay (BGP holdtimer) with ES/L2-NHG update seen when all the uplinks
are shutdown on a remote EVPN PE.

Ticket: #2682896

Signed-off-by: Anuradha Karuppiah <anuradhak@nvidia.com>