### PR TITLE
zebra: use a separate dummy prefix for referencing v6 nexthops

### DIFF
--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3894,17 +3894,20 @@ void zebra_evpn_proc_remote_nh(ZAPI_HANDLER_ARGS)
 	dummy_prefix.family = AF_EVPN;
 	dummy_prefix.prefixlen = (sizeof(struct evpn_addr) * 8);
 	dummy_prefix.prefix.route_type = 1; /* XXX - fixup to type-1 def */
+	dummy_prefix.prefix.ead_addr.ip.ipa_type = nh.ipa_type;
 
 	if (hdr->command == ZEBRA_EVPN_REMOTE_NH_ADD) {
 		stream_get(&rmac, s, sizeof(rmac));
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
-			zlog_debug("evpn remote nh %d %pIA rmac %pEA add",
-				   vrf_id, &nh, &rmac);
+			zlog_debug(
+				"evpn remote nh %d %pIA rmac %pEA add pfx %pFX",
+				vrf_id, &nh, &rmac, &dummy_prefix);
 		zebra_rib_queue_evpn_route_add(vrf_id, &rmac, &nh,
 					       (struct prefix *)&dummy_prefix);
 	} else {
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
-			zlog_debug("evpn remote nh %d %pIA del", vrf_id, &nh);
+			zlog_debug("evpn remote nh %d %pIA del pfx %pFX",
+				   vrf_id, &nh, &dummy_prefix);
 		zebra_rib_queue_evpn_route_del(vrf_id, &nh,
 					       (struct prefix *)&dummy_prefix);
 	}

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -150,9 +150,28 @@ static int host_rb_entry_compare(const struct host_rb_entry *hle1,
 		return memcmp(&hle1->p.u.prefix6, &hle2->p.u.prefix6,
 			      IPV6_MAX_BYTELEN);
 	} else if (hle1->p.family == AF_EVPN) {
-		/* a single dummy prefix of route_type BGP_EVPN_AD_ROUTE is
-		 * used for all nexthops associated with a non-zero ESI
+		uint8_t family1;
+		uint8_t family2;
+
+		/* two (v4/v6) dummy prefixes of route_type BGP_EVPN_AD_ROUTE
+		 * are used for all nexthops associated with a non-zero ESI
 		 */
+		family1 = is_evpn_prefix_ipaddr_v4(
+				  (const struct prefix_evpn *)&hle1->p)
+				  ? AF_INET
+				  : AF_INET6;
+		family2 = is_evpn_prefix_ipaddr_v4(
+				  (const struct prefix_evpn *)&hle2->p)
+				  ? AF_INET
+				  : AF_INET6;
+
+
+		if (family1 < family2)
+			return -1;
+
+		if (family1 > family2)
+			return 1;
+
 		return 0;
 	} else {
 		zlog_debug("%s: Unexpected family type: %d", __func__,


### PR DESCRIPTION
v4 and v6 host/reference prefixes need to be setup separately for
[RMAC, VTEP] entries as the VTEP is always normalized to a v4 addr.

Signed-off-by: Anuradha Karuppiah <anuradhak@nvidia.com>