### PR TITLE
lib, zebra: Preserve user-configured VRF on netns deletion

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -287,6 +287,7 @@ void vrf_delete(struct vrf *vrf)
 			RB_REMOVE(vrf_id_head, &vrfs_by_id, vrf);
 			vrf->vrf_id = VRF_UNKNOWN;
 		}
+		vrf->ns_ctxt = NULL;
 		return;
 	}
 

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -149,8 +149,6 @@ static int zebra_ns_delete(char *name)
 			  "NS notify : no VRF found using NS %s", name);
 		return 0;
 	}
-	/* Clear configured flag and invoke delete. */
-	UNSET_FLAG(vrf->status, VRF_CONFIGURED);
 	ns = (struct ns *)vrf->ns_ctxt;
 	/* the deletion order is the same
 	 * as the one used when siging signal is received


### PR DESCRIPTION
Don't clear VRF's user-configured flag when netns is deleted.

Also avoid leaking wild pointer of VRF in northbound, which can be reproduced by:

1. Add a netns.
    ```
    # ip netns add test
   ```
2.  Create northbound VRF config node.
    ```
    (config)# vrf test
    ```
3. Delete the netns and add one with the same name.
    ```
    # ip netns delete test
    # ip netns add test
    ```
4. Configure something that accesses the config node entry of the VRF, and zebra crashes.
    ```
    (config)# vrf test
    (config-vrf)# vni 100
    ```