### PR TITLE
ospfd: Provide header info to ospf route command

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -11197,6 +11197,10 @@ DEFUN (show_ip_ospf_route,
 
 	OSPF_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
 
+	/* Display header information */
+	if (!uj)
+		vty_out(vty, "%s", SHOW_OSPF_ROUTE_HEADER);
+
 	/* vrf input is provided could be all or specific vrf*/
 	if (vrf_name) {
 		bool ospf_output = false;

--- a/ospfd/ospf_vty.h
+++ b/ospfd/ospf_vty.h
@@ -48,6 +48,13 @@
 		}                                                              \
 	}
 
+#define SHOW_OSPF_ROUTE_HEADER                                                 \
+	"Codes: R - Router, N - Network, D - Discard,\n"                       \
+	"       IA - Inter Area, E1 - Type1 external, E2 - Type2 external,\n"  \
+	"       N1 - Type1 NSSA external, N2 - Type2 NSSA external,\n"         \
+	"       ABR - Area Border Router, ASBR - Autonomous System Border"     \
+	" Router\n"
+
 /* Prototypes. */
 extern void ospf_vty_init(void);
 extern void ospf_vty_show_init(void);


### PR DESCRIPTION
Description:
	Adding header information to "show ip ospf route" command
	which displays all codes description to the user.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>