### PR TITLE
bgpd: Revert a couple of BGP dampening related commits

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -388,13 +388,16 @@ void bgp_damp_info_free(struct bgp_damp_info *bdi, int withdraw)
 {
 	assert(bdi);
 
+	if (bdi->path == NULL) {
+		XFREE(MTYPE_BGP_DAMP_INFO, bdi);
+		return;
+	}
+
 	bdi->path->extra->damp_info = NULL;
 	bgp_path_info_unset_flag(bdi->dest, bdi->path,
 				 BGP_PATH_HISTORY | BGP_PATH_DAMPED);
 	if (bdi->lastrecord == BGP_RECORD_WITHDRAW && withdraw)
 		bgp_path_info_delete(bdi->dest, bdi->path);
-
-	XFREE(MTYPE_BGP_DAMP_INFO, bdi);
 }
 
 static void bgp_damp_parameter_set(int hlife, int reuse, int sup, int maxsup,

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -62,10 +62,10 @@ struct bgp_damp_info {
 	afi_t afi;
 	safi_t safi;
 
-	LIST_ENTRY(bgp_damp_info) entry;
+	SLIST_ENTRY(bgp_damp_info) entry;
 };
 
-LIST_HEAD(reuselist, bgp_damp_info);
+SLIST_HEAD(reuselist, bgp_damp_info);
 
 /* Specified parameter set configuration. */
 struct bgp_damp_config {


### PR DESCRIPTION
The main reasons:
* bgpd stops responding after 90 seconds when more than 200 entries in reuselist; (SLIST => LIST conversion)
* new crash reported with full feed with bgp_damp_info_free().