### PR TITLE
tests: add early interface config for topojson and fix test

### DIFF
--- a/tests/topotests/bgp_listen_on_multiple_addresses/test_bgp_listen_on_multiple_addresses.py
+++ b/tests/topotests/bgp_listen_on_multiple_addresses/test_bgp_listen_on_multiple_addresses.py
@@ -50,6 +50,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 from lib.topogen import Topogen, get_topogen
 from lib.topojson import build_topo_from_json, build_config_from_json
+from lib.topojson import linux_intf_config_from_json
 from lib.common_config import start_topology
 from lib.topotest import router_json_cmp, run_and_expect
 from mininet.topo import Topo
@@ -96,6 +97,9 @@ def setup_module(mod):
         )
 
     start_topology(tgen)
+
+    linux_intf_config_from_json(tgen, topo)
+
     build_config_from_json(tgen, topo)
 
 

--- a/tests/topotests/lib/topojson.py
+++ b/tests/topotests/lib/topojson.py
@@ -293,6 +293,24 @@ def build_topo_from_json(tgen, topo):
             )
 
 
+def linux_intf_config_from_json(tgen, topo):
+    """Configure interfaces from linux based on topo."""
+    routers = topo["routers"]
+    for rname in routers:
+        router = tgen.gears[rname]
+        links = routers[rname]["links"]
+        for rrname in links:
+            link = links[rrname]
+            if rrname == "lo":
+                lname = "lo"
+            else:
+                lname = link["interface"]
+            if "ipv4" in link:
+                router.run("ip addr add {} dev {}".format(link["ipv4"], lname))
+            if "ipv6" in link:
+                router.run("ip -6 addr add {} dev {}".format(link["ipv6"], lname))
+
+
 def build_config_from_json(tgen, topo, save_bkup=True):
     """
     Reads initial configuraiton from JSON for each router, builds


### PR DESCRIPTION
- A more general fix for the bgp listener test which requires interfaces be
configured in the kernel when the bgpd daemons are launched.

Signed-off-by: Christian Hopps <chopps@labn.net>