### PR TITLE
doc: fix bgp user doc colons

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3539,7 +3539,7 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
    It helps to identify which prefixes were installed at some point.
 
    Here is an example of how to check what prefixes were installed starting
-   with an arbitrary version::
+   with an arbitrary version:
 
 .. code-block:: shell
 


### PR DESCRIPTION
Too many colons in a line in the bgp doc source file.

