### PR TITLE
pimd: Allow more permisive versions of some no commands

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8355,11 +8355,12 @@ DEFUN (interface_ip_igmp_last_member_query_count,
 
 DEFUN (interface_no_ip_igmp_last_member_query_count,
        interface_no_ip_igmp_last_member_query_count_cmd,
-       "no ip igmp last-member-query-count",
+       "no ip igmp last-member-query-count [(1-7)]",
        NO_STR
        IP_STR
        IFACE_IGMP_STR
-       IFACE_IGMP_LAST_MEMBER_QUERY_COUNT_STR)
+       IFACE_IGMP_LAST_MEMBER_QUERY_COUNT_STR
+       "Last member query count\n")
 {
 	char default_robustness[2];
 
@@ -8402,11 +8403,12 @@ DEFUN (interface_ip_igmp_last_member_query_interval,
 
 DEFUN (interface_no_ip_igmp_last_member_query_interval,
        interface_no_ip_igmp_last_member_query_interval_cmd,
-       "no ip igmp last-member-query-interval",
+       "no ip igmp last-member-query-interval [(1-255)]",
        NO_STR
        IP_STR
        IFACE_IGMP_STR
-       IFACE_IGMP_LAST_MEMBER_QUERY_INTERVAL_STR)
+       IFACE_IGMP_LAST_MEMBER_QUERY_INTERVAL_STR
+       "Last member query interval in deciseconds\n")
 {
 	char default_last_member_query_count[4];
 


### PR DESCRIPTION
Some no commands were not accepting values and left us in
a situation where a cut-n-paste of the non-no line would
not be properly accepted.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>