### PR TITLE
bgpd: Set extended msg size only if we advertised and received capability

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1216,7 +1216,8 @@ int bgp_open_option_parse(struct peer *peer, uint8_t length, int *mp_capability)
 
 	/* Extended Message Support */
 	peer->max_packet_size =
-		CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_RCV)
+		(CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_RCV)
+		 && CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_ADV))
 			? BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE
 			: BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE;
 


### PR DESCRIPTION
If we don't advertise any capabilities (dont-capability-negotiate), we
shouldn't set msg size to 65k only if received this capability from another
peer.

Before:

```
~/frr# vtysh -c 'show ip bgp update-group' | grep 'Max packet size'
    Max packet size: 65535
```

After:

```
~/frr# vtysh -c 'show ip bgp update-group' | grep 'Max packet size'
    Max packet size: 4096
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>