### PR TITLE
zebra: use strlcpy in dplane_rule_init

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2688,7 +2688,7 @@ static int dplane_ctx_rule_init(struct zebra_dplane_ctx *ctx,
 	ctx->zd_is_update = (op == DPLANE_OP_RULE_UPDATE);
 
 	ctx->zd_vrf_id = new_rule->vrf_id;
-	memcpy(ctx->zd_ifname, new_rule->ifname, sizeof(new_rule->ifname));
+	strlcpy(ctx->zd_ifname, new_rule->ifname, sizeof(ctx->zd_ifname));
 
 	ctx->u.rule.sock = new_rule->sock;
 	ctx->u.rule.unique = new_rule->rule.unique;


### PR DESCRIPTION
Use strlcpy instead of memcpy for safety in dplane rule init api. This was the only place we weren't using strlcpy(); can't see any reason not to.
