### PR TITLE
[bgpd] set PATH ATTRIBUTE CHANGE flag when macip route is updated to EVPN ES

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1533,6 +1533,9 @@ void bgp_evpn_path_es_link(struct bgp_path_info *pi, vni_t vni, esi_t *esi)
 	if (es_info->es == es)
 		return;
 
+	/* Set change flag for ES value is updated */
+	SET_FLAG(pi->flags, BGP_PATH_ATTR_CHANGED);
+
 	/* unlink old ES if any */
 	bgp_evpn_path_es_unlink(es_info);
 


### PR DESCRIPTION
[bgpd] set PATH ATTRIBUTE CHANGE flag when macip route is updated to EVPN ES

When handling the macip route updated events, e.g. es1 --> es2, or normal port --> es,
if the new dest is an ES, it was only updated the route info and not update the new
dest to zebra, and cause the kerenl fdb still use older dest value.

Add to set the PATH ATTRIBUTE CHANGE flag to trigger the zebra to update the kernel
fdb while there is ES update operation in the bgpd.

Signed-off-by: Gord Chen <gord_chen@edge-core.com>