### PR TITLE
ospf6d: add prompt for commands with non-exist vrf

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -1075,6 +1075,8 @@ DEFUN(show_ipv6_ospf6_spf_tree, show_ipv6_ospf6_spf_tree_cmd,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -1141,6 +1143,8 @@ DEFUN(show_ipv6_ospf6_area_spf_tree, show_ipv6_ospf6_area_spf_tree_cmd,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(false, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -1229,6 +1233,8 @@ DEFUN(show_ipv6_ospf6_simulate_spf_tree_root,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(false, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -2553,6 +2553,8 @@ DEFUN(show_ipv6_ospf6_redistribute, show_ipv6_ospf6_redistribute_cmd,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1260,14 +1260,13 @@ struct in6_addr *ospf6_interface_get_global_address(struct interface *ifp)
 static int show_ospf6_interface_common(struct vty *vty, vrf_id_t vrf_id,
 				       int argc, struct cmd_token **argv,
 				       int idx_ifname, int intf_idx,
-				       int json_idx)
+				       int json_idx, bool uj)
 {
 
 	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 	struct interface *ifp;
 	json_object *json;
 	json_object *json_int;
-	bool uj = use_json(argc, argv);
 
 	if (uj) {
 		json = json_object_new_object();
@@ -1323,6 +1322,7 @@ DEFUN(show_ipv6_ospf6_interface, show_ipv6_ospf6_interface_ifname_cmd,
 	const char *vrf_name = NULL;
 	bool all_vrf = false;
 	int idx_vrf = 0;
+	bool uj = use_json(argc, argv);
 
 	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
 	if (idx_vrf > 0) {
@@ -1335,12 +1335,14 @@ DEFUN(show_ipv6_ospf6_interface, show_ipv6_ospf6_interface_ifname_cmd,
 		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
 			show_ospf6_interface_common(vty, ospf6->vrf_id, argc,
 						    argv, idx_ifname, intf_idx,
-						    json_idx);
+						    json_idx, uj);
 
 			if (!all_vrf)
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -1457,14 +1459,13 @@ static int ospf6_interface_show_traffic(struct vty *vty,
 
 static int ospf6_interface_show_traffic_common(struct vty *vty, int argc,
 					       struct cmd_token **argv,
-					       vrf_id_t vrf_id)
+					       vrf_id_t vrf_id, bool uj)
 {
 	int idx_ifname = 0;
 	int display_once = 0;
 	char *intf_name = NULL;
 	struct interface *ifp = NULL;
 	json_object *json = NULL;
-	bool uj = use_json(argc, argv);
 
 	if (uj)
 		json = json_object_new_object();
@@ -1525,18 +1526,21 @@ DEFUN(show_ipv6_ospf6_interface_traffic, show_ipv6_ospf6_interface_traffic_cmd,
 	const char *vrf_name = NULL;
 	bool all_vrf = false;
 	int idx_vrf = 0;
+	bool uj = use_json(argc, argv);
 
 	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
 		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
 			ospf6_interface_show_traffic_common(vty, argc, argv,
-							    ospf6->vrf_id);
+							    ospf6->vrf_id, uj);
 
 			if (!all_vrf)
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -1601,6 +1605,8 @@ DEFUN(show_ipv6_ospf6_interface_ifname_prefix,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -1650,6 +1656,8 @@ DEFUN(show_ipv6_ospf6_interface_prefix, show_ipv6_ospf6_interface_prefix_cmd,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -1111,12 +1111,15 @@ DEFUN(show_ipv6_ospf6_neighbor, show_ipv6_ospf6_neighbor_cmd,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
 static int ospf6_neighbor_show_common(struct vty *vty, int argc,
 				      struct cmd_token **argv,
-				      struct ospf6 *ospf6, int idx_ipv4)
+				      struct ospf6 *ospf6, int idx_ipv4,
+				      bool uj)
 {
 	struct ospf6_neighbor *on;
 	struct ospf6_interface *oi;
@@ -1126,7 +1129,6 @@ static int ospf6_neighbor_show_common(struct vty *vty, int argc,
 			 json_object *json, bool use_json);
 	uint32_t router_id;
 	json_object *json = NULL;
-	bool uj = use_json(argc, argv);
 
 	showfunc = ospf6_neighbor_show_detail;
 	if (uj)
@@ -1164,6 +1166,7 @@ DEFUN(show_ipv6_ospf6_neighbor_one, show_ipv6_ospf6_neighbor_one_cmd,
 	const char *vrf_name = NULL;
 	bool all_vrf = false;
 	int idx_vrf = 0;
+	bool uj = use_json(argc, argv);
 
 	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
 	if (idx_vrf > 0)
@@ -1172,12 +1175,14 @@ DEFUN(show_ipv6_ospf6_neighbor_one, show_ipv6_ospf6_neighbor_one_cmd,
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
 		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
 			ospf6_neighbor_show_common(vty, argc, argv, ospf6,
-						   idx_ipv4);
+						   idx_ipv4, uj);
 
 			if (!all_vrf)
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -1536,6 +1536,8 @@ DEFUN(show_ipv6_ospf6, show_ipv6_ospf6_cmd,
 	if (uj)
 		json_object_free(json);
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -1574,6 +1576,8 @@ DEFUN(show_ipv6_ospf6_route, show_ipv6_ospf6_route_cmd,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -1606,6 +1610,8 @@ DEFUN(show_ipv6_ospf6_route_match, show_ipv6_ospf6_route_match_cmd,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -1641,6 +1647,8 @@ DEFUN(show_ipv6_ospf6_route_match_detail,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -1675,6 +1683,8 @@ DEFUN(show_ipv6_ospf6_route_type_detail, show_ipv6_ospf6_route_type_detail_cmd,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -2090,6 +2100,8 @@ DEFPY (show_ipv6_ospf6_external_aggregator,
 	if (uj) {
 		vty_json(vty, json);
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -421,6 +421,8 @@ DEFUN(show_ipv6_ospf6_database, show_ipv6_ospf6_database_cmd,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -471,6 +473,8 @@ DEFUN(show_ipv6_ospf6_database_type, show_ipv6_ospf6_database_type_cmd,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -511,6 +515,8 @@ DEFUN(show_ipv6_ospf6_database_id, show_ipv6_ospf6_database_id_cmd,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -556,6 +562,8 @@ DEFUN(show_ipv6_ospf6_database_router, show_ipv6_ospf6_database_router_cmd,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -625,6 +633,8 @@ DEFUN_HIDDEN(
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(false, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -680,6 +690,8 @@ DEFUN(show_ipv6_ospf6_database_type_id, show_ipv6_ospf6_database_type_id_cmd,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -740,6 +752,8 @@ DEFUN(show_ipv6_ospf6_database_type_router,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -789,6 +803,8 @@ DEFUN(show_ipv6_ospf6_database_id_router,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -837,6 +853,8 @@ DEFUN(show_ipv6_ospf6_database_adv_router_linkstate_id,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -898,6 +916,8 @@ DEFUN(show_ipv6_ospf6_database_type_id_router,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -967,6 +987,8 @@ DEFUN (show_ipv6_ospf6_database_type_adv_router_linkstate_id,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -1007,6 +1029,8 @@ DEFUN(show_ipv6_ospf6_database_self_originated,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -1064,6 +1088,8 @@ DEFUN(show_ipv6_ospf6_database_type_self_originated,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -1127,6 +1153,8 @@ DEFUN(show_ipv6_ospf6_database_type_self_originated_linkstate_id,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -1186,6 +1214,8 @@ DEFUN(show_ipv6_ospf6_database_type_id_self_originated,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }
@@ -1263,6 +1293,8 @@ DEFUN(show_ipv6_ospf6_border_routers, show_ipv6_ospf6_border_routers_cmd,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(false, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -1306,6 +1338,8 @@ DEFUN(show_ipv6_ospf6_linkstate, show_ipv6_ospf6_linkstate_cmd,
 		}
 	}
 
+	OSPF6_CMD_CHECK_VRF(false, all_vrf, ospf6);
+
 	return CMD_SUCCESS;
 }
 
@@ -1345,6 +1379,8 @@ DEFUN(show_ipv6_ospf6_linkstate_detail, show_ipv6_ospf6_linkstate_detail_cmd,
 				break;
 		}
 	}
+
+	OSPF6_CMD_CHECK_VRF(false, all_vrf, ospf6);
 
 	return CMD_SUCCESS;
 }

--- a/ospf6d/ospf6d.h
+++ b/ospf6d/ospf6d.h
@@ -93,14 +93,24 @@ extern struct thread_master *master;
 #define OSPF6_ROUTER_ID_STR "Specify Router-ID\n"
 #define OSPF6_LS_ID_STR     "Specify Link State ID\n"
 
+#define OSPF6_CMD_CHECK_VRF(uj, all_vrf, ospf6)                                \
+	do {                                                                   \
+		if (uj == false && all_vrf == false && ospf6 == NULL) {        \
+			vty_out(vty, "%% OSPFv3 instance not found\n");        \
+			return CMD_SUCCESS;                                    \
+		}                                                              \
+	} while (0)
+
 #define IS_OSPF6_ASBR(O) ((O)->flag & OSPF6_FLAG_ASBR)
 #define OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf)            \
-	if (argv_find(argv, argc, "vrf", &idx_vrf)) {                          \
-		vrf_name = argv[idx_vrf + 1]->arg;                             \
-		all_vrf = strmatch(vrf_name, "all");                           \
-	} else {                                                               \
-		vrf_name = VRF_DEFAULT_NAME;                                   \
-	}
+	do {                                                                   \
+		if (argv_find(argv, argc, "vrf", &idx_vrf)) {                  \
+			vrf_name = argv[idx_vrf + 1]->arg;                     \
+			all_vrf = strmatch(vrf_name, "all");                   \
+		} else {                                                       \
+			vrf_name = VRF_DEFAULT_NAME;                           \
+		}                                                              \
+	} while (0)
 
 #define OSPF6_FALSE false
 #define OSPF6_TRUE true


### PR DESCRIPTION

ospf ipv4 will give error information, but ospf ipv6 doesn't.

```
# show ip ospf  vrf non-exist-vrf route 
% OSPF instance not found
#show ipv6 ospf6  vrf non-exist-vrf route
#
```

Just like ospf ipv4, i have checked all files on ospf6d directory.
So this PR make ospf ipv6 also give error information in the case of non-exist vrfs.