### PR TITLE
ospf6d: Check the cost only when asbr_present for ECMP routes

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -811,7 +811,7 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 				/* Compare LSA cost with current
 				 * route info.
 				 */
-				if (!asbr_entry
+				if (asbr_entry
 				    && (o_path->cost != route_to_del->path.cost
 					|| o_path->u.cost_e2
 						   != route_to_del->path.u


### PR DESCRIPTION
For ECMP routes, the metric cost and metric type are compared
even when the asbr entry is not present. This stops the routes
from getting removed when max-age LSAs are received for the
ECMP routes.

For single path routes just after the ECMP case, this check is used
correctly. 

Signed-off-by: Yash Ranjan <ranjany@vmware.com>