### PR TITLE
tests: Remove sleep(200) from bgp-evpn-overlay-index-gateway

### DIFF
--- a/tests/topotests/bgp-evpn-overlay-index-gateway/test_bgp_evpn_overlay_index_gateway.py
+++ b/tests/topotests/bgp-evpn-overlay-index-gateway/test_bgp_evpn_overlay_index_gateway.py
@@ -197,7 +197,6 @@ def setup_module(mod):
     tgen.start_router()
 
     logger.info("Running setup_module() done")
-    topotest.sleep(200)
 
 
 def teardown_module(mod):


### PR DESCRIPTION
Remove a 200 second sleep from bgp-evpn-overlay-index-gateway.
There does not seem to be any evidence that this is needed
and I cannot make the test fail without it.

Fixes: #9035
Signed-off-by: Donald Sharp <sharpd@nvidia.com>