### PR TITLE
ospfv3 is showing enabled on loopback interface although it is not

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -943,6 +943,10 @@ static const char *ospf6_iftype_str(uint8_t iftype)
 	return "UNKNOWN";
 }
 
+#if CONFDATE > 20220709
+CPP_NOTICE("Time to remove ospf6Enabled from JSON output")
+#endif
+
 /* show specified interface structure */
 static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 				json_object *json_obj, bool use_json)


### PR DESCRIPTION
ospfv3 is showing enabled on loopback interface although
it is not configured in "show ipv6 ospf6 interface json"

Fix: Make the json output similar to the CLI output.

Fixes: #9286

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>