### PR TITLE
ospfd: fix coverity warning

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -1459,6 +1459,7 @@ void ospf_reset_hello_timer(struct interface *ifp, struct in_addr addr,
 
 		p.u.prefix4 = addr;
 		p.family = AF_INET;
+		p.prefixlen = IPV4_MAX_BITLEN;
 
 		oi = ospf_if_table_lookup(ifp, &p);
 


### PR DESCRIPTION
Initialize prefixlen field, and use struct prefix_ipv4
to replace struct prefix.

Signed-off-by: anlan_cs <anlan_cs@tom.com>