### PR TITLE
bgpd: fix NULL pointer check is missing in bgp_generate_updgrp_packets

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -525,7 +525,9 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 			 * packet with appropriate attributes from peer
 			 * and advance peer */
 			s = bpacket_reformat_for_peer(next_pkt, paf);
-			bgp_packet_add(peer, s);
+			if (s != NULL)
+				bgp_packet_add(peer, s);
+
 			bpacket_queue_advance_peer(paf);
 		}
 	} while (s && (++generated < wpq));


### PR DESCRIPTION
bgp_generate_updgrp_packets calls bpacket_reformat_for_peer, which can return NULL, but NULL pointer check is missing. This causes FRR to crash.

Here is the log when FRR is crashed by this bug.

```
2021/08/05 03:42:36 BGP: [J85T9-K7RBY][EC 33554504] bpacket_reformat_for_peer: 2001:db8::2: invalid MP nexthop length (AFI IP6): 0
BGP: Received signal 11 at 1628134956 (si_addr 0x0, PC 0x7f2ca0fa0784); aborting...
BGP: zlog_signal+0xf9                   7f2ca0f6c1e9     7ffea8cabaf0 /usr/lib/frr/libfrr.so.0 (mapped at 0x7f2ca0ecc000)
BGP: core_handler+0xb5                  7f2ca0f968a5     7ffea8cabc30 /usr/lib/frr/libfrr.so.0 (mapped at 0x7f2ca0ecc000)
BGP: funlockfile+0x60                   7f2ca0c513c0     7ffea8cabd80 /lib/x86_64-linux-gnu/libpthread.so.0 (mapped at 0x7f2ca0c3c000)
BGP:     ---- signal ----
BGP: stream_fifo_push+0x14              7f2ca0fa0784     7ffea8caca78 /usr/lib/frr/libfrr.so.0 (mapped at 0x7f2ca0ecc000)
BGP: bgp_packet_add+0x31                5558cda80f31     7ffea8caca80 /usr/lib/frr/bgpd (mapped at 0x5558cd8ec000)
BGP: bgp_generate_updgrp_packets+0x108     5558cda82dd8     7ffea8cacab0 /usr/lib/frr/bgpd (mapped at 0x5558cd8ec000)
BGP: thread_call+0x81                   7f2ca0fa7b21     7ffea8cacb50 /usr/lib/frr/libfrr.so.0 (mapped at 0x7f2ca0ecc000)
BGP: frr_run+0xe8                       7f2ca0f64f98     7ffea8cacbf0 /usr/lib/frr/libfrr.so.0 (mapped at 0x7f2ca0ecc000)
BGP: main+0x3b8                         5558cda2d758     7ffea8cace10 /usr/lib/frr/bgpd (mapped at 0x5558cd8ec000)
BGP: __libc_start_main+0xf3             7f2ca0a710b3     7ffea8cace70 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7f2ca0a4a000)
BGP: _start+0x2e                        5558cda2fd4e     7ffea8cacf40 /usr/lib/frr/bgpd (mapped at 0x5558cd8ec000)
BGP: in thread (bgp_generate_updgrp_packets) scheduled from bgpd/bgp_fsm.c:842 bgp_adjust_routeadv()
```
