### PR TITLE
bgpd: Fix misleading comments for some parts

### DIFF
--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -544,7 +544,7 @@ struct community *community_dup(struct community *com)
 	return new;
 }
 
-/* Retrun string representation of communities attribute. */
+/* Return string representation of communities attribute. */
 char *community_str(struct community *com, bool make_json)
 {
 	if (!com)
@@ -594,8 +594,6 @@ bool community_match(const struct community *com1, const struct community *com2)
 		return false;
 }
 
-/* If two aspath have same value then return 1 else return 0. This
-   function is used by hash package. */
 bool community_cmp(const struct community *com1, const struct community *com2)
 {
 	if (com1 == NULL && com2 == NULL)

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -273,7 +273,7 @@ struct ecommunity *ecommunity_dup(struct ecommunity *ecom)
 	return new;
 }
 
-/* Retrun string representation of communities attribute. */
+/* Return string representation of ecommunities attribute. */
 char *ecommunity_str(struct ecommunity *ecom)
 {
 	if (!ecom->str)

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -287,7 +287,7 @@ void lcommunity_unintern(struct lcommunity **lcom)
 	}
 }
 
-/* Retrun string representation of communities attribute. */
+/* Return string representation of lcommunities attribute. */
 char *lcommunity_str(struct lcommunity *lcom, bool make_json)
 {
 	if (!lcom)

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -326,7 +326,7 @@ static uint8_t *bgpVersion(struct variable *v, oid name[], size_t *length,
 	    == MATCH_FAILED)
 		return NULL;
 
-	/* Retrun BGP version.  Zebra bgpd only support version 4. */
+	/* Return BGP version.  Zebra bgpd only support version 4. */
 	version = (0x80 >> (BGP_VERSION_4 - 1));
 
 	/* Return octet string length 1. */

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -882,7 +882,7 @@ static void __attribute__((unused)) prefix_list_print(struct prefix_list *plist)
 	}
 }
 
-/* Retrun 1 when plist already include pentry policy. */
+/* Return 1 when plist already include pentry policy. */
 static struct prefix_list_entry *
 prefix_entry_dup_check(struct prefix_list *plist, struct prefix_list_entry *new)
 {

--- a/ripd/rip_snmp.c
+++ b/ripd/rip_snmp.c
@@ -166,7 +166,7 @@ static uint8_t *rip2Globals(struct variable *v, oid name[], size_t *length,
 	if (!rip)
 		return NULL;
 
-	/* Retrun global counter. */
+	/* Return global counter. */
 	switch (v->magic) {
 	case RIP2GLOBALROUTECHANGES:
 		return SNMP_INTEGER(rip->counters.route_changes);


### PR DESCRIPTION
Mostly just retrun => return and misleading comments at all.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>