### PR TITLE
ospfd: Fixing one static analyser issue in ospf

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -1457,8 +1457,10 @@ void ospf_reset_hello_timer(struct interface *ifp, struct in_addr addr,
 		struct prefix p;
 		struct ospf_interface *oi = NULL;
 
+		memset(&p, 0, sizeof(struct prefix));
 		p.u.prefix4 = addr;
 		p.family = AF_INET;
+		p.prefixlen = IPV4_MAX_BITLEN;
 
 		oi = ospf_if_table_lookup(ifp, &p);
 


### PR DESCRIPTION
Description:
	Prefix p structure is not initialised in ospf_reset_hello_timer()
	before using it. There is a possibility that garbage values might be
	assigned and used whenever these uninitialized parameters are being used.
	SA throws the following error. Addressed this issue by memsetting
	this structure before using it.

	SA issue :
	*** CID 1506193:  Uninitialized variables  (UNINIT)
	/ospfd/ospf_interface.c: 1463 in ospf_reset_hello_timer()
	1457                    struct prefix p;
	1458                    struct ospf_interface *oi = NULL;
	1459
	1460                    p.u.prefix4 = addr;
	1461                    p.family = AF_INET;
	1462
	>>>     CID 1506193:  Uninitialized variables  (UNINIT)
	>>>     Using uninitialized value "p". Field "p.prefixlen" is uninitialized when calling "ospf_if_table_lookup".
	1463                    oi = ospf_if_table_lookup(ifp, &p);

Signed-off-by: Rajesh Girada <rgirada@vmware.com>