### PR TITLE
bgpd: fix typo in ensure_vrf_tovpn_sid

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -595,7 +595,7 @@ void ensure_vrf_tovpn_sid(struct bgp *bgp_vpn, struct bgp *bgp_vrf, afi_t afi)
 		return;
 
 	/* check invalid case both configured index and auto */
-	if (tovpn_sid_index != 0 && tovpn_sid_index) {
+	if (tovpn_sid_index != 0 && tovpn_sid_auto) {
 		zlog_err("%s: index-mode and auto-mode both selected. ignored.",
 			 __func__);
 		return;


### PR DESCRIPTION
In eusure_vrf_tovpn_sid, there is a check to ensure not to select both
SID index and SID auto mode. But, this current check is wrong and not
meaningful.