### PR TITLE
ospfd: NSSA area should not exchange Type-4 LSAs in DD

### DIFF
--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -298,8 +298,6 @@ static int nsm_negotiation_done(struct ospf_neighbor *nbr)
 		ospf_db_summary_add(nbr, lsa);
 	LSDB_LOOP (SUMMARY_LSDB(area), rn, lsa)
 		ospf_db_summary_add(nbr, lsa);
-	LSDB_LOOP (ASBR_SUMMARY_LSDB(area), rn, lsa)
-		ospf_db_summary_add(nbr, lsa);
 
 	/* Process only if the neighbor is opaque capable. */
 	if (CHECK_FLAG(nbr->options, OSPF_OPTION_O)) {
@@ -314,10 +312,14 @@ static int nsm_negotiation_done(struct ospf_neighbor *nbr)
 			ospf_db_summary_add(nbr, lsa);
 	}
 
+	/* For Stub/NSSA area, we should not send Type-4 and Type-5 LSAs */
 	if (nbr->oi->type != OSPF_IFTYPE_VIRTUALLINK
-	    && area->external_routing == OSPF_AREA_DEFAULT)
+	    && area->external_routing == OSPF_AREA_DEFAULT) {
+		LSDB_LOOP (ASBR_SUMMARY_LSDB(area), rn, lsa)
+			ospf_db_summary_add(nbr, lsa);
 		LSDB_LOOP (EXTERNAL_LSDB(nbr->oi->ospf), rn, lsa)
 			ospf_db_summary_add(nbr, lsa);
+	}
 
 	if (CHECK_FLAG(nbr->options, OSPF_OPTION_O)
 	    && (nbr->oi->type != OSPF_IFTYPE_VIRTUALLINK


### PR DESCRIPTION
**Problem Statement:**
OSPF Peer gets stuck in EXSTART with ARISTA Device.

**Root Cause:**
First peer is form with Arista device in normal area and then
the area type is changed to NSSA. Due to this Type-4 and Type-5
LSAs advertised by Arista router is still present in
the OSPF DB. While DD exchange the Type-5 LSAs are omitted but
the Type-4 LSAs are not omitted due to which Arista device gets
stuck in EXSTART and it keeps moving between EXCHANGE And EXSTART.

**Fix:**
When the area is NSSA, we should not send Type-4 LSAs in DD
exchange packet.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>