### PR TITLE
[8.0] bgpd: limit the length of opaque data sent to zebra

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1416,8 +1416,9 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 		struct aspath *aspath = info->attr->aspath;
 
 		SET_FLAG(api.message, ZAPI_MESSAGE_OPAQUE);
-		api.opaque.length = strlen(aspath->str) + 1;
-		memcpy(api.opaque.data, aspath->str, api.opaque.length);
+		strlcpy((char *)api.opaque.data, aspath->str,
+			sizeof(api.opaque.data));
+		api.opaque.length = strlen((char *)api.opaque.data) + 1;
 	}
 
 	if (allow_recursion)


### PR DESCRIPTION
Previously, when aspath->str was longer than sizeof(api.opaque.data), we
were overwriting the wrong memory.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>

This problem doesn't exist in master so this PR is targeting only stable/8.0.