### PR TITLE
topotests: small fixes for two tests

### DIFF
--- a/tests/topotests/bfd_topo2/r2/ospf6d.conf
+++ b/tests/topotests/bfd_topo2/r2/ospf6d.conf
@@ -1,4 +1,5 @@
 interface r2-eth2
+ ipv6 ospf6 area 0.0.0.1
  ipv6 ospf6 bfd
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
@@ -7,5 +8,4 @@ router ospf6
  ospf6 router-id 10.254.254.2
  redistribute connected
  redistribute bgp
- interface r2-eth2 area 0.0.0.1
 !

--- a/tests/topotests/bfd_topo2/r4/ospf6d.conf
+++ b/tests/topotests/bfd_topo2/r4/ospf6d.conf
@@ -1,4 +1,5 @@
 interface r4-eth0
+ ipv6 ospf6 area 0.0.0.1
  ipv6 ospf6 bfd
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
@@ -6,5 +7,4 @@ interface r4-eth0
 router ospf6
  ospf6 router-id 10.254.254.4
  redistribute connected
- interface r4-eth0 area 0.0.0.1
 !

--- a/tests/topotests/bfd_topo2/test_bfd_topo2.py
+++ b/tests/topotests/bfd_topo2/test_bfd_topo2.py
@@ -130,7 +130,7 @@ def test_protocols_convergence():
         test_func = partial(
             topotest.router_json_cmp, router, "show ip route json", expected
         )
-        _, result = topotest.run_and_expect(test_func, None, count=160, wait=0.5)
+        _, result = topotest.run_and_expect(test_func, None, count=40, wait=2)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 
@@ -146,7 +146,7 @@ def test_protocols_convergence():
         test_func = partial(
             topotest.router_json_cmp, router, "show ipv6 route json", expected
         )
-        _, result = topotest.run_and_expect(test_func, None, count=160, wait=0.5)
+        _, result = topotest.run_and_expect(test_func, None, count=40, wait=2)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 

--- a/tests/topotests/bfd_topo2/test_bfd_topo2.py
+++ b/tests/topotests/bfd_topo2/test_bfd_topo2.py
@@ -80,21 +80,24 @@ def setup_module(mod):
 
     router_list = tgen.routers()
     for rname, router in router_list.items():
-        router.load_config(
-            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
-        )
-        router.load_config(
-            TopoRouter.RD_BFD, os.path.join(CWD, "{}/bfdd.conf".format(rname))
-        )
-        router.load_config(
-            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
-        )
-        router.load_config(
-            TopoRouter.RD_OSPF, os.path.join(CWD, "{}/ospfd.conf".format(rname))
-        )
-        router.load_config(
-            TopoRouter.RD_OSPF6, os.path.join(CWD, "{}/ospf6d.conf".format(rname))
-        )
+        daemon_file = "{}/{}/zebra.conf".format(CWD, rname)
+        router.load_config(TopoRouter.RD_ZEBRA, daemon_file)
+
+        daemon_file = "{}/{}/bfdd.conf".format(CWD, rname)
+        if os.path.isfile(daemon_file):
+            router.load_config(TopoRouter.RD_BFD, daemon_file)
+
+        daemon_file = "{}/{}/bgpd.conf".format(CWD, rname)
+        if os.path.isfile(daemon_file):
+            router.load_config(TopoRouter.RD_BGP, daemon_file)
+
+        daemon_file = "{}/{}/ospfd.conf".format(CWD, rname)
+        if os.path.isfile(daemon_file):
+            router.load_config(TopoRouter.RD_OSPF, daemon_file)
+
+        daemon_file = "{}/{}/ospf6d.conf".format(CWD, rname)
+        if os.path.isfile(daemon_file):
+            router.load_config(TopoRouter.RD_OSPF6, daemon_file)
 
     # Initialize all routers.
     tgen.start_router()

--- a/tests/topotests/bfd_topo2/test_bfd_topo2.py
+++ b/tests/topotests/bfd_topo2/test_bfd_topo2.py
@@ -99,14 +99,6 @@ def setup_module(mod):
     # Initialize all routers.
     tgen.start_router()
 
-    # Verify that we are using the proper version and that the BFD
-    # daemon exists.
-    for router in router_list.values():
-        # Check for Version
-        if router.has_version("<", "5.1"):
-            tgen.set_error("Unsupported FRR version")
-            break
-
 
 def teardown_module(_mod):
     "Teardown the pytest environment"

--- a/tests/topotests/msdp_topo1/test_msdp_topo1.py
+++ b/tests/topotests/msdp_topo1/test_msdp_topo1.py
@@ -128,7 +128,7 @@ class MSDPTopo1(Topo):
         switch.add_link(tgen.gears["r4"])
 
         switch = tgen.add_switch("s4")
-        switch.add_link(tgen.gears["r3"])
+        #switch.add_link(tgen.gears["r3"])
         switch.add_link(tgen.gears["r4"])
 
         switch = tgen.add_switch("s5")
@@ -434,11 +434,11 @@ def test_msdp():
             "local": "192.168.1.2",
             "state": "established"
         },
-        "192.168.3.2": {
-            "peer": "192.168.3.2",
-            "local": "192.168.3.1",
-            "state": "established"
-        }
+        #"192.169.3.2": {
+        #    "peer": "192.168.3.2",
+        #    "local": "192.168.3.1",
+        #    "state": "established"
+        #}
     }
     r4_expect = {
         "192.168.2.1": {
@@ -446,11 +446,11 @@ def test_msdp():
             "local": "192.168.2.2",
             "state": "established"
         },
-        "192.168.3.1": {
-            "peer": "192.168.3.1",
-            "local": "192.168.3.2",
-            "state": "established"
-        }
+        #"192.168.3.1": {
+        #    "peer": "192.168.3.1",
+        #    "local": "192.168.3.2",
+        #    "state": "established"
+        #}
     }
     r4_sa_expect = {
         "229.1.2.3": {


### PR DESCRIPTION
Summary
---

1. Fix a intermittent failure in MSDP topo1 due to undeterministic traffic route (the test is still testing the MSDP non meshed group peer feature).
2. Many small fixes for bfd_topo2