### PR TITLE
BGP opaque data improvements

### DIFF
--- a/lib/route_opaque.h
+++ b/lib/route_opaque.h
@@ -26,7 +26,7 @@
 #include "bgpd/bgp_lcommunity.h"
 
 struct bgp_zebra_opaque {
-	char aspath[ASPATH_STR_DEFAULT_LEN];
+	char aspath[256];
 
 	/* Show at least 10 communities AA:BB */
 	char community[COMMUNITY_SIZE * 20];

--- a/lib/route_opaque.h
+++ b/lib/route_opaque.h
@@ -21,6 +21,9 @@
 #ifndef FRR_ROUTE_OPAQUE_H
 #define FRR_ROUTE_OPAQUE_H
 
+#include "assert.h"
+#include "zclient.h"
+
 #include "bgpd/bgp_aspath.h"
 #include "bgpd/bgp_community.h"
 #include "bgpd/bgp_lcommunity.h"
@@ -34,5 +37,8 @@ struct bgp_zebra_opaque {
 	/* Show at least 10 large-communities AA:BB:CC */
 	char lcommunity[LCOMMUNITY_SIZE * 30];
 };
+
+static_assert(sizeof(struct bgp_zebra_opaque) <= ZAPI_MESSAGE_OPAQUE_LENGTH,
+              "BGP opaque data shouldn't be larger than zebra's buffer");
 
 #endif /* FRR_ROUTE_OPAQUE_H */


### PR DESCRIPTION
```
bgpd: use longer aspath string in opaque data

32 bytes are not enough to carry relatively long AS paths so let's make
the buffer larger.
```
```
bgpd: add protection against too large opaque data structure

BGP opaque data shouldn't be larger than zebra's buffer.
```