### PR TITLE
bgpd: Store distance received from a redistribute statement

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -789,9 +789,9 @@ static void attr_show_all_iterator(struct hash_bucket *bucket, struct vty *vty)
 		inet_ntop(AF_INET6, &attr->srv6_vpn->sid, sid_str, BUFSIZ);
 
 	vty_out(vty,
-		"\tflags: %" PRIu64" med: %u local_pref: %u origin: %u weight: %u label: %u sid: %s\n",
-		attr->flag, attr->med, attr->local_pref, attr->origin,
-		attr->weight, attr->label, sid_str);
+		"\tflags: %" PRIu64" distance: %u med: %u local_pref: %u origin: %u weight: %u label: %u sid: %s\n",
+		attr->flag, attr->distance, attr->med, attr->local_pref,
+		attr->origin, attr->weight, attr->label, sid_str);
 }
 
 void attr_show_all(struct vty *vty)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8211,9 +8211,9 @@ void cli_show_bgp_global_afi_safi_unicast_aggregate_route(
 /* Redistribute route treatment. */
 void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 			  const union g_addr *nexthop, ifindex_t ifindex,
-			  enum nexthop_types_t nhtype, uint32_t metric,
-			  uint8_t type, unsigned short instance,
-			  route_tag_t tag)
+			  enum nexthop_types_t nhtype, uint8_t distance,
+			  uint32_t metric, uint8_t type,
+			  unsigned short instance, route_tag_t tag)
 {
 	struct bgp_path_info *new;
 	struct bgp_path_info *bpi;
@@ -8260,6 +8260,7 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 	attr.nh_ifindex = ifindex;
 
 	attr.med = metric;
+	attr.distance = distance;
 	attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC);
 	attr.tag = tag;
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -641,9 +641,9 @@ extern bool bgp_maximum_prefix_overflow(struct peer *, afi_t, safi_t, int);
 
 extern void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 				 const union g_addr *nexthop, ifindex_t ifindex,
-				 enum nexthop_types_t nhtype, uint32_t metric,
-				 uint8_t type, unsigned short instance,
-				 route_tag_t tag);
+				 enum nexthop_types_t nhtype, uint8_t distance,
+				 uint32_t metric, uint8_t type,
+				 unsigned short instance, route_tag_t tag);
 extern void bgp_redistribute_delete(struct bgp *, struct prefix *, uint8_t,
 				    unsigned short);
 extern void bgp_redistribute_withdraw(struct bgp *, afi_t, int, unsigned short);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -517,8 +517,8 @@ static int zebra_read_route(ZAPI_CALLBACK_ARGS)
 
 		/* Now perform the add/update. */
 		bgp_redistribute_add(bgp, &api.prefix, &nexthop, ifindex,
-				     nhtype, api.metric, api.type, api.instance,
-				     api.tag);
+				     nhtype, api.distance, api.metric, api.type,
+				     api.instance, api.tag);
 	} else {
 		bgp_redistribute_delete(bgp, &api.prefix, api.type,
 					api.instance);


### PR DESCRIPTION
When bgp receives the admin distance from a redistribution statement
let's store that distance for later usage.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>