### PR TITLE
lib: Fix coverity warning of return value

### DIFF
--- a/lib/frrlua.c
+++ b/lib/frrlua.c
@@ -240,7 +240,7 @@ void lua_pushsockunion(lua_State *L, const union sockunion *su)
 void lua_decode_sockunion(lua_State *L, int idx, union sockunion *su)
 {
 	lua_getfield(L, idx, "string");
-	str2sockunion(lua_tostring(L, -1), su);
+	(void)str2sockunion(lua_tostring(L, -1), su);
 	lua_pop(L, 1);
 	/* pop the table */
 	lua_pop(L, 1);


### PR DESCRIPTION
Suppress coverity warning on unchecked str2sockunion's return value.

Signed-off-by: anlan_cs <anlan_cs@tom.com>