### PR TITLE
bgpd: bgp_packet_process_error can access peer after deletion

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -111,6 +111,7 @@ void bgp_reads_off(struct peer *peer)
 
 	thread_cancel_async(fpt->master, &peer->t_read, NULL);
 	THREAD_OFF(peer->t_process_packet);
+	THREAD_OFF(peer->t_process_packet_error);
 
 	UNSET_FLAG(peer->thread_flags, PEER_THREAD_READS_ON);
 }
@@ -208,7 +209,7 @@ static int bgp_process_reads(struct thread *thread)
 		 * specific state change from 'bgp_read'.
 		 */
 		thread_add_event(bm->master, bgp_packet_process_error,
-				 peer, code, NULL);
+				 peer, code, &peer->t_process_packet_error);
 	}
 
 	while (more) {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1415,6 +1415,7 @@ struct peer {
 	struct thread *t_gr_stale;
 	struct thread *t_generate_updgrp_packets;
 	struct thread *t_process_packet;
+	struct thread *t_process_packet_error;
 	struct thread *t_refresh_stalepath;
 
 	/* Thread flags. */


### PR DESCRIPTION
in bgp_io.c upon packet read of some error we are storing
the peer pointer on a thread to call bgp_packet_process_error.
In this case an event is generated that is not guaranteed to be
run immediately.  It could come in *after* the peer data structure
is deleted and as such we now are writing into memory that we
no longer possibly own as a peer data structure.

Modify the code so that the peer can track the thread associated
with the read error and then it can wisely kill that thread
when deleting the peer data structure.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>