### PR TITLE
tools: fix frr pathspace folder permissions

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -60,7 +60,7 @@ chownfrr() {
 	[ -n "$FRR_GROUP" ] && chgrp "$FRR_GROUP" "$1"
 	[ -n "$FRR_CONFIG_MODE" ] && chmod "$FRR_CONFIG_MODE" "$1"
 	if [ -d "$1" ]; then
-		chmod u+x "$1"
+		chmod gu+x "$1"
 	fi
 }
 


### PR DESCRIPTION
The pathspace folder in `/var/run` needs the `x` permission for the group too

Otherwise vtysh fails when running it with groups frrvty and frr:

    $ vtysh -N gateway
    % Can't open configuration file /etc/frr/gateway/vtysh.conf due to 'Permission denied'.
    vtysh_connect(/var/run/frr/gateway/zebra.vty): stat = Permission denied