### PR TITLE
OSPF6d: Fixed assert at ospf6_originate_summary_lsa asbr.c:2849 and flushing of Type-7 LSAs

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1514,8 +1514,6 @@ static void ospf6_asbr_external_lsa_remove_by_id(struct ospf6 *ospf6,
 					 uint32_t id)
 {
 	struct ospf6_lsa *lsa;
-	struct ospf6_area *oa;
-	struct listnode *lnode;
 
 	lsa = ospf6_lsdb_lookup(htons(OSPF6_LSTYPE_AS_EXTERNAL),
 				htonl(id), ospf6->router_id, ospf6->lsdb);
@@ -1523,20 +1521,6 @@ static void ospf6_asbr_external_lsa_remove_by_id(struct ospf6 *ospf6,
 		return;
 
 	ospf6_external_lsa_purge(ospf6, lsa);
-
-	/* Delete the NSSA LSA */
-	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, lnode, oa)) {
-		lsa = ospf6_lsdb_lookup(htons(OSPF6_LSTYPE_TYPE_7),
-					htonl(id), ospf6->router_id,
-					oa->lsdb);
-		if (lsa) {
-			if (IS_OSPF6_DEBUG_ASBR)
-				zlog_debug("withdraw type 7 lsa, LS ID: %u",
-					   htonl(id));
-
-			ospf6_lsa_purge(lsa);
-		}
-	}
 
 }
 


### PR DESCRIPTION
1. Fixed an assert in ASBR summarisation test_ospfv3_type5_summary_tc46_p0 and handled a scenario where LSA was not flushed. 

test_ospfv3_type5_summary_tc46_p0 test case was failing due to the assert. 

2. Fixed removal of Type-7 LSA when Type-5 LSAs are removed.

Check individual comments for more details.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>