### PR TITLE
lib: lua: consecutive script calls

### DIFF
--- a/doc/developer/scripting.rst
+++ b/doc/developer/scripting.rst
@@ -117,6 +117,7 @@ Load
 The function to be called must first be loaded. Use ``frrscript_load()``
 which takes a ``frrscript`` object, the name of the Lua function
 and a callback function.
+The script file will be read to load and compile the function.
 
 For example, to load the Lua function ``on_foo``
 in ``/etc/frr/scripts/bingus.lua``:
@@ -138,7 +139,7 @@ should not be able to write the scripts directory anyway.
 Call
 ^^^^
 
-After loading, Lua functions may be called.
+After loading, a Lua function can be called any number of times.
 
 Input
 """""
@@ -230,6 +231,18 @@ Returns the pointer to the decoded value, or NULL if it was not found.
 In the example, ``d`` is a "new" value in C space,
 so memory allocation might take place. Hence the caller is
 responsible for memory deallocation.
+
+``frrscript_call()`` may be called multiple times without re-loading with
+``frrscript_load()``. Results are not preserved between consecutive calls.
+
+.. code-block:: c
+
+   frrscript_load(fs, "on_foo");
+
+   frrscript_call(fs, "on_foo");
+   frrscript_get_result(fs, "on_foo", ...);
+   frrscript_call(fs, "on_foo");
+   frrscript_get_result(fs, "on_foo", ...);
 
 
 Delete

--- a/doc/developer/scripting.rst
+++ b/doc/developer/scripting.rst
@@ -398,7 +398,7 @@ Again, for ``struct prefix *``:
    {
         lua_getfield(L, idx, "network");
         (void)str2prefix(lua_tostring(L, -1), prefix);
-        /* pop the netork string */
+        /* pop the network string */
         lua_pop(L, 1);
         /* pop the prefix table */
         lua_pop(L, 1);

--- a/lib/frrscript.c
+++ b/lib/frrscript.c
@@ -288,13 +288,16 @@ int frrscript_load(struct frrscript *fs, const char *function_name,
 		goto fail;
 	}
 
-	/* Push the Lua function we want */
+	/* To check the Lua function, we get it from the global table */
 	lua_getglobal(L, function_name);
 	if (lua_isfunction(L, lua_gettop(L)) == 0) {
 		zlog_err("frrscript: loaded script '%s.lua' but %s not found",
 			 script_name, function_name);
 		goto fail;
 	}
+	/* Then pop the function (frrscript_call will push it when it needs it)
+	 */
+	lua_pop(L, 1);
 
 	if (load_cb && (*load_cb)(fs) != 0) {
 		zlog_err(

--- a/tests/lib/test_frrscript.c
+++ b/tests/lib/test_frrscript.c
@@ -62,6 +62,14 @@ int main(int argc, char **argv)
 	long long *ansptr =
 		frrscript_get_result(fs, "fact", "ans", lua_tointegerp);
 	assert(*ansptr == 120);
+
+	/* check consecutive call + get_result without re-loading */
+	n = 4;
+	result = frrscript_call(fs, "fact", ("n", &n));
+	assert(result == 0);
+	ansptr = frrscript_get_result(fs, "fact", "ans", lua_tointegerp);
+	assert(*ansptr == 24);
+
 	XFREE(MTYPE_SCRIPT_RES, ansptr);
 
 	/* Negative testing */


### PR DESCRIPTION
Previous:
 - frrscript_load: push Lua function onto stack
 - frrscript_call: calls Lua function

This means frrscript_call only works once since it doesn't push the lua function back onto the stack.

Now:
 - frrscript_load: checks Lua function
    - this works by pushing the function name from the global table, checking if it is a function, then popping it
 - frrscript_call: pushes and calls Lua function (first clear the stack)

Now multiple calls can happen. Consecutive frrscript_calls should still be quite fast, since we aren't reading from the script or compiling the Lua function, its just getting the function from the global table.

See https://github.com/FRRouting/frr/pull/9348/commits/80bfe93670461bfc868c6252e2f15bd44586cd4e for example of consecutive frrscript_call
