### PR TITLE
vrf_name_to_id(): remove and change callers to use vrf_lookup_by_name()

### DIFF
--- a/eigrpd/eigrp_northbound.c
+++ b/eigrpd/eigrp_northbound.c
@@ -79,6 +79,7 @@ static int eigrpd_instance_create(struct nb_cb_create_args *args)
 {
 	struct eigrp *eigrp;
 	const char *vrf;
+	struct vrf *pVrf;
 	vrf_id_t vrfid;
 
 	switch (args->event) {
@@ -87,7 +88,12 @@ static int eigrpd_instance_create(struct nb_cb_create_args *args)
 		break;
 	case NB_EV_PREPARE:
 		vrf = yang_dnode_get_string(args->dnode, "./vrf");
-		vrfid = vrf_name_to_id(vrf);
+
+		pVrf = vrf_lookup_by_name(vrf);
+		if (pVrf)
+			vrfid = pVrf->vrf_id;
+		else
+			vrfid = VRF_DEFAULT;
 
 		eigrp = eigrp_get(yang_dnode_get_uint16(args->dnode, "./asn"),
 				  vrfid);
@@ -719,12 +725,19 @@ static int eigrpd_instance_redistribute_create(struct nb_cb_create_args *args)
 	struct eigrp *eigrp;
 	uint32_t proto;
 	vrf_id_t vrfid;
+	struct vrf *pVrf;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		proto = yang_dnode_get_enum(args->dnode, "./protocol");
 		vrfname = yang_dnode_get_string(args->dnode, "../vrf");
-		vrfid = vrf_name_to_id(vrfname);
+
+		pVrf = vrf_lookup_by_name(vrfname);
+		if (pVrf)
+			vrfid = pVrf->vrf_id;
+		else
+			vrfid = VRF_DEFAULT;
+
 		if (vrf_bitmap_check(zclient->redist[AFI_IP][proto], vrfid))
 			return NB_ERR_INCONSISTENCY;
 		break;

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -384,21 +384,6 @@ const char *vrf_id_to_name(vrf_id_t vrf_id)
 	return VRF_LOGNAME(vrf);
 }
 
-vrf_id_t vrf_name_to_id(const char *name)
-{
-	struct vrf *vrf;
-	vrf_id_t vrf_id = VRF_DEFAULT; // Pending: need a way to return invalid
-				       // id/ routine not used.
-
-	if (!name)
-		return vrf_id;
-	vrf = vrf_lookup_by_name(name);
-	if (vrf)
-		vrf_id = vrf->vrf_id;
-
-	return vrf_id;
-}
-
 /* Get the data pointer of the specified VRF. If not found, create one. */
 void *vrf_info_get(vrf_id_t vrf_id)
 {

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -119,7 +119,6 @@ extern struct vrf *vrf_lookup_by_name(const char *);
 extern struct vrf *vrf_get(vrf_id_t, const char *);
 extern struct vrf *vrf_update(vrf_id_t new_vrf_id, const char *name);
 extern const char *vrf_id_to_name(vrf_id_t vrf_id);
-extern vrf_id_t vrf_name_to_id(const char *);
 
 #define VRF_LOGNAME(V) V ? V->name : "Unknown"
 

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -520,7 +520,13 @@ static int zebra_ptm_handle_bfd_msg(void *arg, void *in_ctxt,
 	if (!strcmp(ZEBRA_PTM_INVALID_VRF, vrf_str) && ifp) {
 		vrf_id = ifp->vrf_id;
 	} else {
-		vrf_id = vrf_name_to_id(vrf_str);
+		struct vrf *pVrf;
+
+		pVrf = vrf_lookup_by_name(vrf_str);
+		if (pVrf)
+			vrf_id = pVrf->vrf_id;
+		else
+			vrf_id = VRF_DEFAULT;
 	}
 
 	if (!strcmp(bfdst_str, ZEBRA_PTM_BFDSTATUS_DOWN_STR)) {


### PR DESCRIPTION
lib/vrf.c vrf_name_to_id(char *name) returned VRF_DEFAULT on lookup failures, which hid failures from the caller.

This change removes vrf_name_to_id(). It also modifies the few callers to have identical behavior (i.e., lookup failure yields VRF_DEFAULT) in case caller code depends on that behavior.