### PR TITLE
lib: fix prefix-list duplication check

### DIFF
--- a/lib/filter.h
+++ b/lib/filter.h
@@ -207,11 +207,10 @@ struct plist_dup_args {
 	/** Entry action. */
 	const char *pda_action;
 
-#define PDA_MAX_VALUES 4
-	/** Entry XPath for value. */
-	const char *pda_xpath[PDA_MAX_VALUES];
-	/** Entry value to match. */
-	const char *pda_value[PDA_MAX_VALUES];
+	bool any;
+	struct prefix prefix;
+	int ge;
+	int le;
 
 	/** Duplicated entry found in list? */
 	bool pda_found;


### PR DESCRIPTION
Currently, when we check the new prefix-list entry for duplication, we
only take filled in fields into account and ignore optional fields.
For example, if we already have `ip prefix-list A 0.0.0.0/0 le 32` and
we try to add `ip prefix-list A 0.0.0.0/0`, it is treated as duplicate.
We should always compare all prefix-list fields when doing the check.

Fixes #9355.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>