### PR TITLE
zebra: Ensure stream is long enough

### DIFF
--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3920,8 +3920,18 @@ void zebra_evpn_proc_remote_nh(ZAPI_HANDLER_ARGS)
 	struct ipaddr nh;
 	struct ethaddr rmac;
 	struct prefix_evpn dummy_prefix;
+	size_t min_len = 4 + sizeof(nh);
 
 	s = msg;
+
+	/*
+	 * Ensure that the stream sent to us is long enough
+	 */
+	if (hdr->command == ZEBRA_EVPN_REMOTE_NH_ADD)
+		min_len += sizeof(rmac);
+	if (hdr->length < min_len)
+		return;
+
 	vrf_id = stream_getl(s);
 	stream_get(&nh, s, sizeof(nh));
 


### PR DESCRIPTION
In zebra_evpn_proc_remote_nh if we do not pass in a long
enough stream, the stream reads will fail.  Ensure that
we have enough data.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>