### PR TITLE
vtysh, pathd: fix pcep node-entering commands

### DIFF
--- a/pathd/path_pcep_cli.c
+++ b/pathd/path_pcep_cli.c
@@ -1755,13 +1755,20 @@ DEFPY_NOSH(
 DEFPY_NOSH(
       pcep_cli_pcep_pce_config,
       pcep_cli_pcep_pce_config_cmd,
-      "[no] pce-config WORD$name",
+      "pce-config WORD$name",
+      "Shared configuration\n"
+      "Shared configuration name\n")
+{
+	return path_pcep_cli_pcep_pce_config(vty, name);
+}
+
+DEFPY(pcep_cli_pcep_no_pce_config,
+      pcep_cli_pcep_no_pce_config_cmd,
+      "no pce-config WORD$name",
       NO_STR
       "Shared configuration\n"
       "Shared configuration name\n")
 {
-	if (no == NULL)
-		return path_pcep_cli_pcep_pce_config(vty, name);
 	return path_pcep_cli_pcep_pce_config_delete(vty, name);
 }
 
@@ -1781,13 +1788,20 @@ DEFPY(pcep_cli_show_srte_pcep_pce_config,
 DEFPY_NOSH(
       pcep_cli_pce,
       pcep_cli_pce_cmd,
-      "[no] pce WORD$name",
+      "pce WORD$name",
+      "PCE configuration, address sub-config is mandatory\n"
+      "PCE name\n")
+{
+	return path_pcep_cli_pce(vty, name);
+}
+
+DEFPY(pcep_cli_no_pce,
+      pcep_cli_no_pce_cmd,
+      "no pce WORD$name",
       NO_STR
       "PCE configuration, address sub-config is mandatory\n"
       "PCE name\n")
 {
-	if (no == NULL)
-		return path_pcep_cli_pce(vty, name);
 	return path_pcep_cli_pce_delete(vty, name);
 }
 
@@ -1906,15 +1920,19 @@ DEFPY(pcep_cli_peer_timers,
 DEFPY_NOSH(
       pcep_cli_pcc,
       pcep_cli_pcc_cmd,
-      "[no] pcc",
+      "pcc",
+      "PCC configuration\n")
+{
+	return path_pcep_cli_pcc(vty);
+}
+
+DEFPY(pcep_cli_no_pcc,
+      pcep_cli_no_pcc_cmd,
+      "no pcc",
       NO_STR
       "PCC configuration\n")
 {
-	if (no != NULL) {
-		return path_pcep_cli_pcc_delete(vty);
-	} else {
-		return path_pcep_cli_pcc(vty);
-	}
+	return path_pcep_cli_pcc_delete(vty);
 }
 
 DEFPY(pcep_cli_pcc_pcc_msd,
@@ -2001,6 +2019,7 @@ void pcep_cli_init(void)
 
 	/* PCEP configuration group related configuration commands */
 	install_element(PCEP_NODE, &pcep_cli_pcep_pce_config_cmd);
+	install_element(PCEP_NODE, &pcep_cli_pcep_no_pce_config_cmd);
 	install_element(PCEP_PCE_CONFIG_NODE,
 			&pcep_cli_peer_source_address_cmd);
 	install_element(PCEP_PCE_CONFIG_NODE, &pcep_cli_peer_timers_cmd);
@@ -2010,6 +2029,7 @@ void pcep_cli_init(void)
 
 	/* PCE peer related configuration commands */
 	install_element(PCEP_NODE, &pcep_cli_pce_cmd);
+	install_element(PCEP_NODE, &pcep_cli_no_pce_cmd);
 	install_element(PCEP_PCE_NODE, &pcep_cli_peer_address_cmd);
 	install_element(PCEP_PCE_NODE, &pcep_cli_peer_source_address_cmd);
 	install_element(PCEP_PCE_NODE, &pcep_cli_peer_pcep_pce_config_ref_cmd);
@@ -2021,6 +2041,7 @@ void pcep_cli_init(void)
 	/* PCC related configuration commands */
 	install_element(ENABLE_NODE, &pcep_cli_show_srte_pcc_cmd);
 	install_element(PCEP_NODE, &pcep_cli_pcc_cmd);
+	install_element(PCEP_NODE, &pcep_cli_no_pcc_cmd);
 	install_element(PCEP_PCC_NODE, &pcep_cli_pcc_pcc_peer_cmd);
 	install_element(PCEP_PCC_NODE, &pcep_cli_pcc_pcc_msd_cmd);
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2237,8 +2237,7 @@ DEFUNSH(VTYSH_PATHD, pcep, pcep_cmd,
 }
 
 DEFUNSH(VTYSH_PATHD, pcep_cli_pcc, pcep_cli_pcc_cmd,
-	"[no] pcc",
-	NO_STR
+	"pcc",
 	"PCC configuration\n")
 {
 	vty->node = PCEP_PCC_NODE;
@@ -2246,8 +2245,7 @@ DEFUNSH(VTYSH_PATHD, pcep_cli_pcc, pcep_cli_pcc_cmd,
 }
 
 DEFUNSH(VTYSH_PATHD, pcep_cli_pce, pcep_cli_pce_cmd,
-	"[no] pce WORD",
-	NO_STR
+	"pce WORD",
 	"PCE configuration\n"
 	"Peer name\n")
 {
@@ -2256,8 +2254,7 @@ DEFUNSH(VTYSH_PATHD, pcep_cli_pce, pcep_cli_pce_cmd,
 }
 
 DEFUNSH(VTYSH_PATHD, pcep_cli_pcep_pce_config, pcep_cli_pcep_pce_config_cmd,
-	"[no] pce-config WORD",
-	NO_STR
+	"pce-config WORD",
 	"PCEP peer Configuration Group\n"
 	"PCEP peer Configuration Group name\n")
 {


### PR DESCRIPTION
pce-config, pce and pcc node-entering commands in vtysh include no-form,
which is incorrect. Currently, when user passes a no-form command like
`no pcc`, vtysh enters the node while pathd deletes the node and this
leads to a desynchronization.

Regular and no-form commands should be defined separately to fix this.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>