### PR TITLE
bgpd: remove es_path VNI display from type-2 routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8977,8 +8977,6 @@ void route_vty_out(struct vty *vty, const struct prefix *p,
 		vty_out(vty, "\n");
 
 		if (safi == SAFI_EVPN) {
-			struct bgp_path_es_info *path_es_info = NULL;
-
 			if (bgp_evpn_is_esi_valid(&attr->esi)) {
 				/* XXX - add these params to the json out */
 				vty_out(vty, "%*s", 20, " ");
@@ -8986,13 +8984,6 @@ void route_vty_out(struct vty *vty, const struct prefix *p,
 					esi_to_str(&attr->esi, esi_buf,
 						   sizeof(esi_buf)));
 
-				if (path->extra && path->extra->mh_info)
-					path_es_info =
-						path->extra->mh_info->es_info;
-
-				if (path_es_info && path_es_info->es)
-					vty_out(vty, " VNI: %u",
-						path_es_info->vni);
 				vty_out(vty, "\n");
 			}
 			if (attr->flag &


### PR DESCRIPTION
EVPN paths are maintained in per-ES list for efficient updates
(es→macip_global_path_list, es→macip_evi_path_list). VNI is also maintained
in path_extra for efficient lookups. This (path_extra) VNI (which is always 0 for
global paths) was being displayed against the path and was mis-interpreted
as the BD.

To avoid that confusion I have removed the display.

Ticket: #2732605

Signed-off-by: Anuradha Karuppiah <anuradhak@nvidia.com>