### PR TITLE
bgpd: fix segfault when re-adding "match evpn default-route" rule

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1431,7 +1431,7 @@ enum rmap_compile_rets route_map_add_match(struct route_map_index *index,
 			 * the same as the existing configuration then,
 			 * ignore the duplicate configuration.
 			 */
-			if (strcmp(match_arg, rule->rule_str) == 0) {
+			if (rulecmp(match_arg, rule->rule_str) == 0) {
 				if (cmd->func_free)
 					(*cmd->func_free)(compile);
 


### PR DESCRIPTION
When using "match evpn default-route" rule, match_arg is NULL and strcmp
is not happy with that. There's already a special function named rulecmp
that handles such situations.

Fixes #9384.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>