### PR TITLE
ospfd: Summarised External LSA is not flushed in one scenario

### DIFF
--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -267,6 +267,8 @@ static void ospf_process_self_originated_lsa(struct ospf *ospf,
 
 				ospf_external_lsa_refresh(ospf, new, &ei_aggr,
 						  LSA_REFRESH_FORCE, true);
+				SET_FLAG(aggr->flags,
+					 OSPF_EXTERNAL_AGGRT_ORIGINATED);
 			} else
 				ospf_lsa_flush_as(ospf, new);
 		}

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3631,6 +3631,8 @@ struct ospf_lsa *ospf_lsa_refresh(struct ospf *ospf, struct ospf_lsa *lsa)
 
 				ospf_external_lsa_refresh(ospf, lsa, &ei_aggr,
 						  LSA_REFRESH_FORCE, true);
+				SET_FLAG(aggr->flags,
+					 OSPF_EXTERNAL_AGGRT_ORIGINATED);
 			} else
 				ospf_lsa_flush_as(ospf, lsa);
 		}


### PR DESCRIPTION
Fix CI Failure test_ospf_type5_summary_tc45_p0

**Problem Statement:**
Summarised LSA is not flushed in OSPFv2 in below scenario:
1. Configure summary-address in ospfv2
2. redistribute static and connected.
3. Check the LSAs are received on neighbor.
4. Now remove all OSPFv2 configs, so neighbor will still have the summarised LSA.
5. Configure router ospf with redistribute static and connected.
6. Check the DB, summarised LSA is present although the configuration is not present.
7. Now configure the summary-address and remove the configuration after sometime.
8. The summarised LSA will be still present.

**RCA:**
When self originated LSA is received from the neighbor and that
LSA is summarised one, the LSA is refreshed but a flag is not set
due to which it was not able to remove it later.

**Fix:**
Set the originated flag when refreshing summarised LSA.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>