### PR TITLE
pimd: IGMPv2 query timer gets delayed in a scenario

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -459,6 +459,10 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	struct listnode *sock_node;
 	struct igmp_sock *igmp;
 
+	if (pim_ifp->igmp_query_max_response_time_dsec
+	    == query_max_response_time_dsec)
+		return;
+
 	pim_ifp->igmp_query_max_response_time_dsec =
 		query_max_response_time_dsec;
 


### PR DESCRIPTION
**Problem Statement:**
IGMP query is sent at irregular intervals
(more than 30 seconds) when "ip igmp query-max-response-time 100"
command is executed multiple times.

**RCA:**
When "ip igmp query-max-response-time 100" is executed, the timers
are reset resulting in the delay of sending the query.

**Fix:**
When there is no change in the config value, we should not reset
the timers.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>