### PR TITLE
zebra: fix SA warning in 'mpls lsp' cli

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -3637,7 +3637,7 @@ int zebra_mpls_static_lsp_del(struct zebra_vrf *zvrf, mpls_label_t in_label,
 		return 0;
 
 	/* Is it delete of entire LSP or a specific NHLFE? */
-	if (gtype == NEXTHOP_TYPE_BLACKHOLE) {
+	if (gate == NULL) {
 		if (IS_ZEBRA_DEBUG_MPLS)
 			zlog_debug("Del static LSP in-label %u", in_label);
 
@@ -3657,6 +3657,7 @@ int zebra_mpls_static_lsp_del(struct zebra_vrf *zvrf, mpls_label_t in_label,
 
 		if (IS_ZEBRA_DEBUG_MPLS) {
 			char buf[BUFSIZ];
+
 			nhlfe2str(nhlfe, buf, sizeof(buf));
 			zlog_debug("Del static LSP in-label %u nexthop %s",
 				   in_label, buf);

--- a/zebra/zebra_mpls_vty.c
+++ b/zebra/zebra_mpls_vty.c
@@ -67,11 +67,6 @@ static int zebra_mpls_transit_lsp(struct vty *vty, int add_cmd,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	if (gate_str == NULL) {
-		vty_out(vty, "%% No Nexthop Information\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
 	out_label = MPLS_LABEL_IMPLICIT_NULL; /* as initialization */
 	label = atoi(inlabel_str);
 	if (!IS_MPLS_UNRESERVED_LABEL(label)) {
@@ -80,12 +75,13 @@ static int zebra_mpls_transit_lsp(struct vty *vty, int add_cmd,
 	}
 
 	if (add_cmd) {
-		if (!gate_str) {
+		if (gate_str == NULL) {
 			vty_out(vty, "%% No Nexthop Information\n");
 			return CMD_WARNING_CONFIG_FAILED;
 		}
+
 		if (!outlabel_str) {
-			vty_out(vty, "%% No Outgoing label Information\n");
+			vty_out(vty, "%% No Outgoing label information\n");
 			return CMD_WARNING_CONFIG_FAILED;
 		}
 	}
@@ -93,16 +89,18 @@ static int zebra_mpls_transit_lsp(struct vty *vty, int add_cmd,
 	in_label = label;
 
 	/* Gateway is a IPv4 or IPv6 nexthop. */
-	ret = inet_pton(AF_INET6, gate_str, &gate.ipv6);
-	if (ret == 1)
-		gtype = NEXTHOP_TYPE_IPV6;
-	else {
-		ret = inet_pton(AF_INET, gate_str, &gate.ipv4);
+	if (gate_str) {
+		ret = inet_pton(AF_INET6, gate_str, &gate.ipv6);
 		if (ret == 1)
-			gtype = NEXTHOP_TYPE_IPV4;
+			gtype = NEXTHOP_TYPE_IPV6;
 		else {
-			vty_out(vty, "%% Invalid nexthop\n");
-			return CMD_WARNING_CONFIG_FAILED;
+			ret = inet_pton(AF_INET, gate_str, &gate.ipv4);
+			if (ret == 1)
+				gtype = NEXTHOP_TYPE_IPV4;
+			else {
+				vty_out(vty, "%% Invalid nexthop\n");
+				return CMD_WARNING_CONFIG_FAILED;
+			}
 		}
 	}
 
@@ -129,10 +127,14 @@ static int zebra_mpls_transit_lsp(struct vty *vty, int add_cmd,
 
 		ret = zebra_mpls_static_lsp_add(zvrf, in_label, out_label,
 						gtype, &gate, 0);
-	} else
-		ret = zebra_mpls_static_lsp_del(zvrf, in_label, gtype, &gate,
-						0);
-
+	} else {
+		if (gate_str)
+			ret = zebra_mpls_static_lsp_del(zvrf, in_label, gtype,
+							&gate, 0);
+		else
+			ret = zebra_mpls_static_lsp_del(zvrf, in_label, gtype,
+							NULL, 0);
+	}
 	if (ret != 0) {
 		vty_out(vty, "%% LSP cannot be %s\n",
 			add_cmd ? "added" : "deleted");


### PR DESCRIPTION
We're already checking for a nexthop string - don't check a second time, that annoys the SA checker.
