### PR TITLE
vtysh: fix reading bfd profiles configuration

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -542,6 +542,9 @@ static int vtysh_execute_func(const char *line, int pager)
 			    || saved_node == LDP_IPV6_IFACE_NODE)
 			   && (tried == 1)) {
 			vtysh_execute("exit");
+		} else if ((saved_node == BFD_PROFILE_NODE)
+			   && (tried == 1)) {
+			vtysh_execute("exit");
 		} else if ((saved_node == SR_SEGMENT_LIST_NODE
 			    || saved_node == SR_POLICY_NODE
 			    || saved_node == SR_CANDIDATE_DYN_NODE


### PR DESCRIPTION
Currently, when we have multiple BFD profiles in the configuration file,
vtysh fails to read any profile other than the first one. It happens
because vtysh doesn't exit the profile node when it sees the next
profile.

Fixes #9333.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>