### PR TITLE
[8.0] ospfd: explicitly exit from the router node

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -12522,6 +12522,8 @@ static int ospf_config_write_one(struct vty *vty, struct ospf *ospf)
 	/* LDP-Sync print */
 	ospf_ldp_sync_write_config(vty, ospf);
 
+	vty_out(vty, " exit\n");
+
 	write++;
 	return write;
 }


### PR DESCRIPTION
There's a new "mpls ldp-sync" command added to the OSPF router node in
FRR 8.0. This change broke the following config:
```
router ospf
!
mpls ldp
 discovery hello interval 10
!
```
The config was broken because the "mpls ldp" line is now treated as an
"mpls ldp-sync" line inside the router node. We must explicitly print
"exit" at the end of OSPF router node to fix the issue.

Fixes #9206.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>