### PR TITLE
bgpd: imported evpn rt5 routes copy igpmetric

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2385,6 +2385,7 @@ bgp_create_evpn_bgp_path_info(struct bgp_path_info *parent_pi,
 		memcpy(&pi->extra->label, &parent_pi->extra->label,
 		       sizeof(pi->extra->label));
 		pi->extra->num_labels = parent_pi->extra->num_labels;
+		pi->extra->igpmetric = parent_pi->extra->igpmetric;
 	}
 	bgp_path_info_add(dest, pi);
 


### PR DESCRIPTION
when doing BGP over an IGP platform, the expectation is that
the path calculation for a given prefix takes into account the
igpmetric given by IGP.
This is true with prefixes obtained in a given BGP instance where
peering occurs. For instance, ipv4 unicast entries or l2vpn evpn
entries work this way. The igpmetric is obtained through nexthop
tracking, like below:

south-vm# show bgp nexthop
Current BGP nexthop cache:
 1.1.1.1 valid [IGP metric 10], #paths 1, peer 1.1.1.1
 2.2.2.2 valid [IGP metric 20], #paths 1, peer 2.2.2.2

The igp metric is taken into account when doing best path
selection, and only the entry with lowest igp wins.

[..]
*>i[5]:[0]:[32]:[5.5.5.5]
                    1.1.1.1                  0    100      0 ?
                    RT:65400:268435556 ET:8 Rmac:2e:22:6c:67:bb:73
* i                 2.2.2.2                  0    100      0 ?
                    RT:65400:268435556 ET:8 Rmac:f2:d3:68:4e:f4:ed

however, for imported EVPN RT5 entries, the igpmetric was not
copied from the parent path info. Fix it. In this way, the
imported route entries use the igpmetric of the parent pi.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>