### PR TITLE
vtysh: Add error code if daemon is not running

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -229,6 +229,7 @@ struct cmd_node {
 #define CMD_WARNING_CONFIG_FAILED 13
 #define CMD_NOT_MY_INSTANCE	14
 #define CMD_NO_LEVEL_UP 15
+#define CMD_ERR_NO_DAEMON 16
 
 /* Argc max counts. */
 #define CMD_ARGC_MAX   256

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -602,7 +602,8 @@ static int vtysh_execute_func(const char *line, int pager)
 						fprintf(stderr,
 							"%s is not running\n",
 							vtysh_client[i].name);
-						continue;
+						cmd_stat = CMD_ERR_NO_DAEMON;
+						break;
 					}
 				}
 				cmd_stat = vtysh_client_execute(
@@ -611,7 +612,7 @@ static int vtysh_execute_func(const char *line, int pager)
 					break;
 			}
 		}
-		if (cmd_stat != CMD_SUCCESS)
+		if (cmd_stat != CMD_SUCCESS && cmd_stat != CMD_ERR_NO_DAEMON)
 			break;
 
 		if (cmd->func)


### PR DESCRIPTION
After `<daemon_name> is not running` message vtysh does not return error. For example if you disable ospf in `/etc/frr/daemons` and run `vtysh -c configure -c "router ospf"` it prints the message to stderr, but returns 0.

Since it is not possible to do anything daemon related with daemon not running (except some utility commands like `list`, `find`, etc.) I see no reason why it should return 0 and allow you to enter views of daemons that are down. Vtysh can't even properly validate the commands inside those views (let alone save them to config).

I am just not sure which status to use. I chose `CMD_WARNING_CONFIG_FAILED` because I saw it being commonly used in daemons when command fails.

Also the continue was unnecessary because we already checked in line `635` that the `cmd->daemon` corresponds to exactly one `vtysh_client` (daemon), so there is no need to loop over others.