### PR TITLE
[8.0] Snap update to 18.04 base

### DIFF
--- a/snapcraft/README.snap_build.md
+++ b/snapcraft/README.snap_build.md
@@ -99,6 +99,7 @@ All the commands are prefixed with frr.
     frr.staticd-debug
     frr.bfdd-debug
     frr.fabricd-debug
+    frr.pathd-debug
 
 vtysh can be accessed as frr.vtysh (Make sure you have /snap/bin in your
 path). If access as `vtysh` instead of `frr.vtysh` is needed, you can enable it

--- a/snapcraft/README.snap_build.md
+++ b/snapcraft/README.snap_build.md
@@ -1,7 +1,6 @@
 Building your own FRRouting Snap
 ========================================
-(Tested on Ubuntu 16.04 with Snap Version 2, does not work on Ubuntu 15.x
-which uses earlier versions of snaps)
+(Tested on Ubuntu 18.04)
 
 1. Install snapcraft:
 

--- a/snapcraft/README.usage.md
+++ b/snapcraft/README.usage.md
@@ -18,7 +18,8 @@ ie for `ospf6d` (OSPFv3):
     systemctl enable snap.frr.ospf6d.service
 
 The daemons are: `ripd`, `ripngd`, `ospfd`, `ospf6d`, `isisd`, `bgpd`, 
-`pimd`, `ldpd`, `eigrpd`, `babeld`, `nhrpd`, `bfdd`, `zebra`
+`pimd`, `ldpd`, `eigrpd`, `babeld`, `nhrpd`, `bfdd`, `vrrpd`, `pbrd`,
+`pathd`, `fabricd`, `staticd`, `zebra`
 
 Commands defined by this snap
 -----------------------------

--- a/snapcraft/scripts/Makefile
+++ b/snapcraft/scripts/Makefile
@@ -19,6 +19,7 @@ install:
 	install -D -m 0755 bfdd-service $(DESTDIR)/bin/
 	install -D -m 0755 fabricd-service $(DESTDIR)/bin/
 	install -D -m 0755 vrrpd-service $(DESTDIR)/bin/
+	install -D -m 0755 pathd-service $(DESTDIR)/bin/
 	install -D -m 0755 set-options $(DESTDIR)/bin/
 	install -D -m 0755 show_version $(DESTDIR)/bin/
 

--- a/snapcraft/scripts/pathd-service
+++ b/snapcraft/scripts/pathd-service
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e -x
+
+if ! [ -e $SNAP_DATA/pathd.conf ]; then
+    cp $SNAP/etc/frr/pathd.conf.default $SNAP_DATA/pathd.conf
+fi
+exec $SNAP/sbin/pathd \
+    -f $SNAP_DATA/pathd.conf \
+    --pid_file $SNAP_DATA/pathd.pid \
+    --socket $SNAP_DATA/zsock \
+    --vty_socket $SNAP_DATA
+

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -322,6 +322,7 @@ parts:
            - bison
            - flex
            - python3-dev
+           - libprotobuf-c-dev
            - protobuf-c-compiler
            - python3-sphinx
         stage-packages:

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -9,6 +9,7 @@ description: BGP/OSPFv2/OSPFv3/ISIS/RIP/RIPng/PIM/LDP/EIGRP/BFD routing daemon
  FRRouting (frr) is a fork of Quagga.
 confinement: strict
 grade: devel
+base: core18
 
 apps:
     vtysh:
@@ -254,6 +255,7 @@ parts:
            - libssh-dev
         stage-packages:
            - libssh-4
+           - zlib1g
         prime:
            - lib/librtr.so*
            - usr/lib/x86_64-linux-gnu/libssh.so*
@@ -268,12 +270,12 @@ parts:
            - cmake
            - make
            - gcc
-           - libpcre3-dev
+           - libpcre2-dev
         stage-packages:
-           - libpcre3
+           - libpcre2-8-0
         source: https://github.com/CESNET/libyang.git
         source-type: git
-        source-tag: v1.0.184
+        source-tag: v2.0.7
         plugin: cmake
         configflags:
            - -DCMAKE_INSTALL_PREFIX:PATH=/usr
@@ -298,7 +300,6 @@ parts:
            - imagemagick
            - ghostscript
            - groff
-           - hardening-wrapper
            - libpcre3-dev
            - chrpath
            - pkg-config
@@ -315,12 +316,20 @@ parts:
            - logrotate
            - libcap2
            - libtinfo5
-           - libreadline6
-           - libjson-c2
+           - libreadline7
+           - libjson-c3
            - libc-ares2
            - libatm1
            - libprotobuf-c1
            - libdb5.3
+           - libacl1
+           - libattr1
+           - libaudit1
+           - libcap-ng0
+           - libpam0g
+           - libpcre3
+           - libselinux1
+           - libxtables12
         plugin: autotools
         source: ../frr-@PACKAGE_VERSION@.tar.gz
         configflags:
@@ -376,6 +385,8 @@ parts:
         stage-packages:
            - telnet
            - traceroute
+           - libgcc1
+           - libstdc++6
         plugin: make
         source: helpers
         prime:
@@ -389,9 +400,4 @@ parts:
             README.usage.md: doc/README.usage.md
             README.snap_build.md: doc/README.snap_build.md
             extra_version_info.txt: doc/extra_version_info.txt
-
-passthrough:
-    layout:
-         /usr/lib/x86_64-linux-gnu/libyang1:
-             bind: $SNAP/usr/lib/x86_64-linux-gnu/libyang1
 

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -4,8 +4,8 @@ summary: FRRouting BGP/OSPFv2/OSPFv3/ISIS/RIP/RIPng/PIM/LDP/EIGRP/BFD routing da
 description: BGP/OSPFv2/OSPFv3/ISIS/RIP/RIPng/PIM/LDP/EIGRP/BFD routing daemon
  FRRouting (FRR) is free software which manages TCP/IP based routing 
  protocols. It supports BGP4, BGP4+, OSPFv2, OSPFv3, IS-IS, RIPv1, RIPv2, 
- RIPng, PIM, LDP, Babel, EIGRP, PBR (Policy-based routing), BFD and OpenFabric
- as well as the IPv6 versions of these.
+ RIPng, PIM, LDP, Babel, EIGRP, PBR (Policy-based routing), PATHD (Segment
+ routing), BFD and OpenFabric as well as the IPv6 versions of these.
  FRRouting (frr) is a fork of Quagga.
 confinement: strict
 grade: devel
@@ -142,6 +142,13 @@ apps:
             - network
             - network-bind
             - network-control
+    pathd:
+        command: bin/pathd-service
+        daemon: simple
+        plugs:
+            - network
+            - network-bind
+            - network-control
     set:
         command: bin/set-options
     zebra-debug:
@@ -246,6 +253,13 @@ apps:
             - network
             - network-bind
             - network-control
+    pathd-debug:
+        command: sbin/pathd -f $SNAP_DATA/pathd.conf --pid_file $SNAP_DATA/pathd.pid --socket $SNAP_DATA/zsock --vty_socket $SNAP_DATA
+        plugs:
+            - network
+            - network-bind
+            - network-control
+
 parts:
     rtrlib:
         build-packages:
@@ -376,6 +390,7 @@ parts:
             bfdd.conf.default: etc/frr/bfdd.conf.default
             fabricd.conf.default: etc/frr/fabricd.conf.default
             vrrpd.conf.default: etc/frr/vrrpd.conf.default
+            pathd.conf.default: etc/frr/pathd.conf.default
             vtysh.conf.default: etc/frr/vtysh.conf.default
             staticd.conf.default: etc/frr/staticd.conf.default
     frr-scripts:


### PR DESCRIPTION
Old snap base (on Ubuntu 16.04) is no longer supported and snap package can't be built anymore because of it.
This updates the core for the snap to be based on 18.04 which is the current recommended version.

Additionally, adds the pathd to the daemons used by snap package