### PR TITLE
zebra: fix wrong check of mpls command

### DIFF
--- a/zebra/zebra_mpls_vty.c
+++ b/zebra/zebra_mpls_vty.c
@@ -67,11 +67,6 @@ static int zebra_mpls_transit_lsp(struct vty *vty, int add_cmd,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	if (gate_str == NULL) {
-		vty_out(vty, "%% No Nexthop Information\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
 	out_label = MPLS_LABEL_IMPLICIT_NULL; /* as initialization */
 	label = atoi(inlabel_str);
 	if (!IS_MPLS_UNRESERVED_LABEL(label)) {
@@ -91,18 +86,21 @@ static int zebra_mpls_transit_lsp(struct vty *vty, int add_cmd,
 	}
 
 	in_label = label;
+	gtype = NEXTHOP_TYPE_BLACKHOLE; /* as initialization */
 
-	/* Gateway is a IPv4 or IPv6 nexthop. */
-	ret = inet_pton(AF_INET6, gate_str, &gate.ipv6);
-	if (ret == 1)
-		gtype = NEXTHOP_TYPE_IPV6;
-	else {
-		ret = inet_pton(AF_INET, gate_str, &gate.ipv4);
+	if (gate_str) {
+		/* Gateway is a IPv4 or IPv6 nexthop. */
+		ret = inet_pton(AF_INET6, gate_str, &gate.ipv6);
 		if (ret == 1)
-			gtype = NEXTHOP_TYPE_IPV4;
+			gtype = NEXTHOP_TYPE_IPV6;
 		else {
-			vty_out(vty, "%% Invalid nexthop\n");
-			return CMD_WARNING_CONFIG_FAILED;
+			ret = inet_pton(AF_INET, gate_str, &gate.ipv4);
+			if (ret == 1)
+				gtype = NEXTHOP_TYPE_IPV4;
+			else {
+				vty_out(vty, "%% Invalid nexthop\n");
+				return CMD_WARNING_CONFIG_FAILED;
+			}
 		}
 	}
 


### PR DESCRIPTION
Maybe with empty nexthop to call zebra_mpls_transit_lsp():
"no mpls lsp (16-1048575)".

So just delete this "gate_str" check.

The check is only for "add" commands, which is already exist.

Signed-off-by: anlan_cs <anlan_cs@tom.com>