### PR TITLE
pimd: IGMP groups are not getting timeout

### DIFF
--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -499,6 +499,21 @@ static void allow(struct igmp_sock *igmp, struct in_addr from,
 	struct igmp_group *group;
 	int i;
 
+	if (num_sources == 0) {
+		/*
+		  RFC 3376: 3.1. Socket-State
+		  If the requested filter mode is INCLUDE *and* the requested
+		  source list is empty, then the entry corresponding to the
+		  requested interface and multicast address is deleted if
+		  present. If no such entry is present, the request is ignored.
+		  So, deleting the group present.
+		*/
+		group = find_group_by_addr(igmp, group_addr);
+		if (group && (group->group_filtermode_isexcl == 0))
+			igmp_group_delete(group);
+		return;
+	}
+
 	/* non-existant group is created as INCLUDE {empty} */
 	group = igmp_add_group_by_addr(igmp, group_addr);
 	if (!group) {


### PR DESCRIPTION
Problem :
=======
IGMP Report is coming in include mode without any source address, 
When all the groups from Ixia are stopped,
groups still keep refreshing and not getting a timeout.

Fix :
===
If the requested filter mode is INCLUDE *and* the requested
source list is empty, then the entry corresponding to the
requested interface and multicast address is deleted if present.
If no such entry is present, the request is ignored.

When an interface receives the IGMP report without any source, then the group is deleted.

Signed-off-by: Sai Gomathi <nsaigomathi@vmware.com>