### PR TITLE
vtysh: add "exit" for bfd's profile node

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -830,7 +830,8 @@ int vtysh_mark_file(const char *filename)
 			} else if ((prev_node == KEYCHAIN_KEY_NODE)
 				   && (tried == 1)) {
 				vty_out(vty, "exit\n");
-			} else if ((prev_node == BFD_PEER_NODE)
+			} else if ((prev_node == BFD_PEER_NODE
+				    || prev_node == BFD_PROFILE_NODE)
 				   && (tried == 1)) {
 				vty_out(vty, "exit\n");
 			} else if (((prev_node == SEGMENT_ROUTING_NODE)


### PR DESCRIPTION
Just like `bfd peer`,  we should add "exit" for `bfd profile`

Since no "exit-bfd-profile",  add "exit" for profile during mark process.

Signed-off-by: anlan_cs <anlan_cs@tom.com>