### PR TITLE
staticd: warn on attempted delete of non-existent route

### DIFF
--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -325,7 +325,8 @@ static int static_route_leak(struct vty *vty, const char *svrf,
 
 		dnode = yang_dnode_get(vty->candidate_config->dnode, ab_xpath);
 		if (!dnode) {
-			/* Silently return */
+			vty_out(vty,
+				"%% Refusing to remove a non-existent route\n");
 			return CMD_SUCCESS;
 		}
 


### PR DESCRIPTION
Warn when attempting to delete a non-existent static route instead of silently returning. This more closely aligns with what we already do for `no` with VRFs and other commands.

```
arch(config)# no ip route 1.1.1.1/32 blackhole
arch(config)# no vrf blah
% VRF blah does not exist
arch(config)# 
```