### PR TITLE
zebra: Fix usage to enum in notify functions

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -867,7 +867,7 @@ void zsend_rule_notify_owner(const struct zebra_dplane_ctx *ctx,
 }
 
 void zsend_iptable_notify_owner(const struct zebra_dplane_ctx *ctx,
-				uint16_t note)
+				enum zapi_iptable_notify_owner note)
 {
 	struct listnode *node;
 	struct zserv *client;
@@ -901,7 +901,8 @@ void zsend_iptable_notify_owner(const struct zebra_dplane_ctx *ctx,
 	zserv_send_message(client, s);
 }
 
-void zsend_ipset_notify_owner(const struct zebra_dplane_ctx *ctx, uint16_t note)
+void zsend_ipset_notify_owner(const struct zebra_dplane_ctx *ctx,
+			      enum zapi_ipset_notify_owner note)
 {
 	struct listnode *node;
 	struct zserv *client;
@@ -936,7 +937,7 @@ void zsend_ipset_notify_owner(const struct zebra_dplane_ctx *ctx, uint16_t note)
 }
 
 void zsend_ipset_entry_notify_owner(const struct zebra_dplane_ctx *ctx,
-				    uint16_t note)
+				    enum zapi_ipset_entry_notify_owner note)
 {
 	struct listnode *node;
 	struct zserv *client;

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -87,11 +87,12 @@ extern void zsend_rule_notify_owner(const struct zebra_dplane_ctx *ctx,
 				    enum zapi_rule_notify_owner note);
 
 extern void zsend_iptable_notify_owner(const struct zebra_dplane_ctx *ctx,
-				       uint16_t note);
+				       enum zapi_iptable_notify_owner note);
 extern void zsend_ipset_notify_owner(const struct zebra_dplane_ctx *ctx,
-				     uint16_t note);
-extern void zsend_ipset_entry_notify_owner(const struct zebra_dplane_ctx *ctx,
-					   uint16_t note);
+				     enum zapi_ipset_notify_owner note);
+extern void
+zsend_ipset_entry_notify_owner(const struct zebra_dplane_ctx *ctx,
+			       enum zapi_ipset_entry_notify_owner note);
 extern bool zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 				   const unsigned int nexthop_num);
 


### PR DESCRIPTION
For some reason commit #ef524230a6baa decided
to remove enums and switch to uint16_t.  Which
is not the right thing to do.  Put it back

Signed-off-by: Donald Sharp <sharpd@nvidia.com>