### PR TITLE
tests: uniq vrf names when using netns

### DIFF
--- a/tests/topotests/bfd_vrf_topo1/r1/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r1/bfdd.conf
@@ -4,7 +4,7 @@ debug bfd peer
 debug bfd zebra
 !
 bfd
- peer 192.168.0.2 vrf r1-cust1
+ peer 192.168.0.2 vrf r1-bfd-cust1
   echo-mode
   no shutdown
  !

--- a/tests/topotests/bfd_vrf_topo1/r1/bgpd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r1/bgpd.conf
@@ -1,4 +1,4 @@
-router bgp 101 vrf r1-cust1
+router bgp 101 vrf r1-bfd-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.0.2 remote-as 102

--- a/tests/topotests/bfd_vrf_topo1/r1/zebra.conf
+++ b/tests/topotests/bfd_vrf_topo1/r1/zebra.conf
@@ -1,3 +1,3 @@
-interface r1-eth0 vrf r1-cust1
+interface r1-eth0 vrf r1-bfd-cust1
  ip address 192.168.0.1/24
 !

--- a/tests/topotests/bfd_vrf_topo1/r2/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r2/bfdd.conf
@@ -4,13 +4,13 @@ debug bfd peer
 debug bfd zebra
 !
 bfd
- peer 192.168.0.1 vrf r2-cust1
+ peer 192.168.0.1 vrf r2-bfd-cust1
   receive-interval 1000
   transmit-interval 500
   echo-mode
   no shutdown
  !
- peer 192.168.1.1 vrf r2-cust1
+ peer 192.168.1.1 vrf r2-bfd-cust1
   echo-mode
   no shutdown
  !

--- a/tests/topotests/bfd_vrf_topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r2/bgpd.conf
@@ -1,4 +1,4 @@
-router bgp 102 vrf r2-cust1
+router bgp 102 vrf r2-bfd-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.0.1 remote-as 101

--- a/tests/topotests/bfd_vrf_topo1/r2/zebra.conf
+++ b/tests/topotests/bfd_vrf_topo1/r2/zebra.conf
@@ -1,9 +1,9 @@
-interface r2-eth0 vrf r2-cust1
+interface r2-eth0 vrf r2-bfd-cust1
  ip address 192.168.0.2/24
 !
-interface r2-eth1 vrf r2-cust1
+interface r2-eth1 vrf r2-bfd-cust1
  ip address 192.168.1.2/24
 !
-interface r2-eth2 vrf r2-cust1
+interface r2-eth2 vrf r2-bfd-cust1
  ip address 192.168.2.2/24
 !

--- a/tests/topotests/bfd_vrf_topo1/r3/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r3/bfdd.conf
@@ -4,7 +4,7 @@ debug bfd peer
 debug bfd zebra
 !
 bfd
- peer 192.168.1.2 vrf r3-cust1
+ peer 192.168.1.2 vrf r3-bfd-cust1
   echo-interval 100
   echo-mode
   no shutdown

--- a/tests/topotests/bfd_vrf_topo1/r3/bgpd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r3/bgpd.conf
@@ -1,4 +1,4 @@
-router bgp 103 vrf r3-cust1
+router bgp 103 vrf r3-bfd-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.1.2 remote-as 102

--- a/tests/topotests/bfd_vrf_topo1/r3/zebra.conf
+++ b/tests/topotests/bfd_vrf_topo1/r3/zebra.conf
@@ -1,3 +1,3 @@
-interface r3-eth0 vrf r3-cust1
+interface r3-eth0 vrf r3-bfd-cust1
  ip address 192.168.1.1/24
 !

--- a/tests/topotests/bfd_vrf_topo1/r4/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r4/bfdd.conf
@@ -4,7 +4,7 @@ debug bfd peer
 debug bfd zebra
 !
 bfd
- peer 192.168.2.2 vrf r4-cust1
+ peer 192.168.2.2 vrf r4-bfd-cust1
   transmit-interval 2000
   receive-interval 2000
   no shutdown

--- a/tests/topotests/bfd_vrf_topo1/r4/bgpd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r4/bgpd.conf
@@ -1,4 +1,4 @@
-router bgp 104 vrf r4-cust1
+router bgp 104 vrf r4-bfd-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.2.2 remote-as 102

--- a/tests/topotests/bfd_vrf_topo1/r4/zebra.conf
+++ b/tests/topotests/bfd_vrf_topo1/r4/zebra.conf
@@ -1,3 +1,3 @@
-interface r4-eth0 vrf r4-cust1
+interface r4-eth0 vrf r4-bfd-cust1
  ip address 192.168.2.1/24
 !

--- a/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
+++ b/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
@@ -178,14 +178,10 @@ NEXT_HOP_IP = {"ipv4": "Null0", "ipv6": "Null0"}
 LOOPBACK_1 = {
     "ipv4": "10.10.10.10/32",
     "ipv6": "10::10:10/128",
-    "ipv4_mask": "255.255.255.255",
-    "ipv6_mask": None,
 }
 LOOPBACK_2 = {
     "ipv4": "20.20.20.20/32",
     "ipv6": "20::20:20/128",
-    "ipv4_mask": "255.255.255.255",
-    "ipv6_mask": None,
 }
 
 
@@ -1911,7 +1907,6 @@ def test_static_routes_for_inter_vrf_route_leaking_p0(request):
             "loopback1",
             LOOPBACK_1[addr_type],
             "RED_A",
-            LOOPBACK_1["{}_mask".format(addr_type)],
         )
         create_interface_in_kernel(
             tgen,
@@ -1919,7 +1914,6 @@ def test_static_routes_for_inter_vrf_route_leaking_p0(request):
             "loopback2",
             LOOPBACK_2[addr_type],
             "RED_B",
-            LOOPBACK_2["{}_mask".format(addr_type)],
         )
 
     step(
@@ -2047,7 +2041,6 @@ def test_inter_vrf_and_intra_vrf_communication_iBGP_p0(request):
             "loopback1",
             LOOPBACK_1[addr_type],
             "RED_A",
-            LOOPBACK_1["{}_mask".format(addr_type)],
         )
 
         create_interface_in_kernel(
@@ -2056,7 +2049,6 @@ def test_inter_vrf_and_intra_vrf_communication_iBGP_p0(request):
             "loopback2",
             LOOPBACK_2[addr_type],
             "BLUE_A",
-            LOOPBACK_2["{}_mask".format(addr_type)],
         )
 
     step(
@@ -2216,7 +2208,6 @@ def test_inter_vrf_and_intra_vrf_communication_eBGP_p0(request):
             "loopback1",
             LOOPBACK_1[addr_type],
             "RED_A",
-            LOOPBACK_1["{}_mask".format(addr_type)],
         )
         create_interface_in_kernel(
             tgen,
@@ -2224,7 +2215,6 @@ def test_inter_vrf_and_intra_vrf_communication_eBGP_p0(request):
             "loopback2",
             LOOPBACK_2[addr_type],
             "BLUE_A",
-            LOOPBACK_2["{}_mask".format(addr_type)],
         )
 
     step(

--- a/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
+++ b/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
@@ -131,8 +131,6 @@ NEXT_HOP_IP = {"ipv4": "Null0", "ipv6": "Null0"}
 LOOPBACK_2 = {
     "ipv4": "20.20.20.20/32",
     "ipv6": "20::20:20/128",
-    "ipv4_mask": "255.255.255.255",
-    "ipv6_mask": None,
 }
 
 MAX_PATHS = 2
@@ -1928,7 +1926,6 @@ def test_vrf_route_leaking_next_hop_interface_flapping_p1(request):
             "loopback2",
             LOOPBACK_2[addr_type],
             "RED_B",
-            LOOPBACK_2["{}_mask".format(addr_type)],
         )
 
     intf_red1_r11 = topo["routers"]["red1"]["links"]["r1-link2"]["interface"]

--- a/tests/topotests/bgp_recursive_route_ebgp_multi_hop/test_bgp_recursive_route_ebgp_multi_hop.py
+++ b/tests/topotests/bgp_recursive_route_ebgp_multi_hop/test_bgp_recursive_route_ebgp_multi_hop.py
@@ -1103,7 +1103,7 @@ def test_next_hop_with_recursive_lookup_p1(request):
             tc_name, result
         )
 
-    step("Toggle the interface on R3(ifconfig 192.34).")
+    step("Toggle the interface on R3.")
 
     intf_r3_r4 = topo["routers"]["r3"]["links"]["r4"]["interface"]
     shutdown_bringup_interface(tgen, "r3", intf_r3_r4)
@@ -1161,7 +1161,7 @@ def test_next_hop_with_recursive_lookup_p1(request):
             tc_name, result
         )
 
-    step("Toggle the interface on R4(ifconfig 192.34).")
+    step("Toggle the interface on R4.")
 
     intf_r4_r3 = topo["routers"]["r4"]["links"]["r3"]["interface"]
     shutdown_bringup_interface(tgen, "r4", intf_r4_r3)

--- a/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo1.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo1.py
@@ -123,8 +123,6 @@ LOOPBACK_1 = {
 LOOPBACK_2 = {
     "ipv4": "10.0.0.16/24",
     "ipv6": "fd00:0:0:3::5/64",
-    "ipv4_mask": "255.255.255.0",
-    "ipv6_mask": None,
 }
 PREFERRED_NEXT_HOP = "global"
 
@@ -692,14 +690,13 @@ def test_dynamic_imported_routes_advertised_to_iBGP_peer_p0(request):
             "loopback2",
             LOOPBACK_2[addr_type],
             "ISR",
-            LOOPBACK_2["{}_mask".format(addr_type)],
         )
 
     for addr_type in ADDR_TYPES:
 
         step(
             "On router R1 Change the next-hop of static routes in vrf "
-            "ISR to LOOPBACK_1"
+            "ISR to LOOPBACK_2"
         )
 
         input_routes_r1 = {

--- a/tests/topotests/bgp_vrf_netns/r1/bgpd.conf
+++ b/tests/topotests/bgp_vrf_netns/r1/bgpd.conf
@@ -1,5 +1,5 @@
 !
-router bgp 100 vrf r1-cust1
+router bgp 100 vrf r1-bgp-cust1
  bgp router-id 10.0.1.1
  bgp bestpath as-path multipath-relax
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_vrf_netns/r1/summary.txt
+++ b/tests/topotests/bgp_vrf_netns/r1/summary.txt
@@ -2,7 +2,7 @@
 "ipv4Unicast":{
   "routerId":"10.0.1.1",
   "as":100,
-  "vrfName":"r1-cust1",
+  "vrfName":"r1-bgp-cust1",
   "peerCount":1,
   "peers":{
     "10.0.1.101":{

--- a/tests/topotests/bgp_vrf_netns/r1/summary20.txt
+++ b/tests/topotests/bgp_vrf_netns/r1/summary20.txt
@@ -1,7 +1,7 @@
 {
   "routerId":"10.0.1.1",
   "as":100,
-  "vrfName":"re1-cust1",
+  "vrfName":"re1-bgp-cust1",
   "peerCount":1,
   "peers":{
     "10.0.1.101":{

--- a/tests/topotests/bgp_vrf_netns/r1/zebra.conf
+++ b/tests/topotests/bgp_vrf_netns/r1/zebra.conf
@@ -1,5 +1,5 @@
 !
-interface r1-eth0 vrf r1-cust1
+interface r1-eth0 vrf r1-bgp-cust1
  ip address 10.0.1.1/24
 !
 line vty

--- a/tests/topotests/bgp_vrf_netns/test_bgp_vrf_netns_topo.py
+++ b/tests/topotests/bgp_vrf_netns/test_bgp_vrf_netns_topo.py
@@ -106,13 +106,12 @@ def setup_module(module):
     if CustomizeVrfWithNetns == True:
         logger.info("Testing with VRF Namespace support")
 
-    # create VRF r1-cust1
-    # move r1-eth0 to VRF r1-cust1
+    # create VRF r1-bgp-cust1
+    # move r1-eth0 to VRF r1-bgp-cust1
     cmds = [
-        "if [ -e /var/run/netns/{0}-cust1 ] ; then ip netns del {0}-cust1 ; fi",
-        "ip netns add {0}-cust1",
-        "ip link set dev {0}-eth0 netns {0}-cust1",
-        "ip netns exec {0}-cust1 ifconfig {0}-eth0 up",
+        "if [ -e /var/run/netns/{0}-bgp-cust1 ] ; then ip netns del {0}-bgp-cust1 ; fi",
+        "ip netns add {0}-bgp-cust1",
+        "ip link set {0}-eth0 netns {0}-bgp-cust1 up",
     ]
     for cmd in cmds:
         cmd = cmd.format("r1")
@@ -154,10 +153,10 @@ def setup_module(module):
 def teardown_module(module):
     tgen = get_topogen()
     # move back r1-eth0 to default VRF
-    # delete VRF r1-cust1
+    # delete VRF r1-bgp-cust1
     cmds = [
-        "ip netns exec {0}-cust1 ip link set {0}-eth0 netns 1",
-        "ip netns delete {0}-cust1",
+        "ip netns exec {0}-bgp-cust1 ip link set {0}-eth0 netns 1",
+        "ip netns delete {0}-bgp-cust1",
     ]
     for cmd in cmds:
         tgen.net["r1"].cmd(cmd.format("r1"))
@@ -203,7 +202,7 @@ def test_bgp_convergence():
     expected = json.loads(open(reffile).read())
 
     test_func = functools.partial(
-        topotest.router_json_cmp, router, "show bgp vrf r1-cust1 summary json", expected
+        topotest.router_json_cmp, router, "show bgp vrf r1-bgp-cust1 summary json", expected
     )
     _, res = topotest.run_and_expect(test_func, None, count=90, wait=0.5)
     assertmsg = "BGP router network did not converge"
@@ -231,11 +230,11 @@ def test_bgp_vrf_netns():
     test_func = functools.partial(
         topotest.router_json_cmp,
         tgen.gears["r1"],
-        "show ip bgp vrf r1-cust1 ipv4 json",
+        "show ip bgp vrf r1-bgp-cust1 ipv4 json",
         expect,
     )
     _, res = topotest.run_and_expect(test_func, None, count=12, wait=0.5)
-    assertmsg = 'expected routes in "show ip bgp vrf r1-cust1 ipv4" output'
+    assertmsg = 'expected routes in "show ip bgp vrf r1-bgp-cust1 ipv4" output'
     assert res is None, assertmsg
 
 

--- a/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
+++ b/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
@@ -1008,8 +1008,8 @@ def test_BSM_fragmentation_p1(request):
 
     # set mtu of fhr(f1) to i1 interface to 100 so that bsm fragments
     step("set mtu of fhr(f1) to i1 interface to 100 so that bsm fragments")
-    fhr_node.run("ifconfig f1-i1-eth2 mtu 100")
-    inter_node.run("ifconfig i1-f1-eth0 mtu 100")
+    fhr_node.run("ip link set f1-i1-eth2 mtu 100")
+    inter_node.run("ip link set i1-f1-eth0 mtu 100")
 
     # Use scapy to send pre-defined packet from senser to receiver
     result = scapy_send_bsr_raw_packet(tgen, topo, "b1", "f1", "packet2")

--- a/tests/topotests/ospf_basic_functionality/test_ospf_single_area.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_single_area.py
@@ -1011,7 +1011,7 @@ def test_ospf_tc4_mtu_ignore_p0(request):
     r0_r1_intf = topo["routers"]["r0"]["links"]["r1"]["interface"]
     r1_r0_intf = topo["routers"]["r1"]["links"]["r0"]["interface"]
 
-    rtr0.run("ifconfig {} mtu 1200".format(r0_r1_intf))
+    rtr0.run("ip link set {} mtu 1200".format(r0_r1_intf))
 
     clear_ospf(tgen, "r0")
 
@@ -1037,7 +1037,7 @@ def test_ospf_tc4_mtu_ignore_p0(request):
         "Modify the MTU to non default Value on R0 to R1 interface. "
         "Reset ospf neighbors on R0."
     )
-    rtr0.run("ifconfig {} mtu 1500".format(r0_r1_intf))
+    rtr0.run("ip link set {} mtu 1500".format(r0_r1_intf))
 
     clear_ospf(tgen, "r0")
 
@@ -1062,7 +1062,7 @@ def test_ospf_tc4_mtu_ignore_p0(request):
     result = config_ospf_interface(tgen, topo, r1_ospf_mtu)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    rtr0.run("ifconfig {} mtu 1200".format(r0_r1_intf))
+    rtr0.run("ip link set {} mtu 1200".format(r0_r1_intf))
 
     clear_ospf(tgen, "r0")
 
@@ -1094,7 +1094,7 @@ def test_ospf_tc4_mtu_ignore_p0(request):
 
     step("Modify the MTU to again default valaue on R0 to R1 interface.")
 
-    rtr0.run("ifconfig {} mtu 1500".format(r0_r1_intf))
+    rtr0.run("ip link set {} mtu 1500".format(r0_r1_intf))
 
     clear_ospf(tgen, "r0")
 
@@ -1106,8 +1106,8 @@ def test_ospf_tc4_mtu_ignore_p0(request):
         "Configure ospf interface with jumbo MTU (9216)." "Reset ospf neighbors on R0."
     )
 
-    rtr0.run("ifconfig {} mtu 9216".format(r0_r1_intf))
-    rtr1.run("ifconfig {} mtu 9216".format(r1_r0_intf))
+    rtr0.run("ip link set {} mtu 9216".format(r0_r1_intf))
+    rtr1.run("ip link set {} mtu 9216".format(r1_r0_intf))
 
     clear_ospf(tgen, "r0")
     clear_ospf(tgen, "r1")

--- a/tests/topotests/ospf_topo1_vrf/r1/ospfd.conf
+++ b/tests/topotests/ospf_topo1_vrf/r1/ospfd.conf
@@ -3,7 +3,7 @@ hostname r1
 password zebra
 log file /tmp/r1-ospfd.log
 !
-router ospf vrf r1-cust1
+router ospf vrf r1-ospf-cust1
   ospf router-id 10.0.255.1
   redistribute kernel
   redistribute connected

--- a/tests/topotests/ospf_topo1_vrf/r1/ospfroute.txt
+++ b/tests/topotests/ospf_topo1_vrf/r1/ospfroute.txt
@@ -1,4 +1,4 @@
-VRF Name: r1-cust1
+VRF Name: r1-ospf-cust1
 ============ OSPF network routing table ============
 N    10.0.1.0/24           [10] area: 0.0.0.0
                            directly attached to r1-eth0

--- a/tests/topotests/ospf_topo1_vrf/r1/ospfroute_down.txt
+++ b/tests/topotests/ospf_topo1_vrf/r1/ospfroute_down.txt
@@ -1,4 +1,4 @@
-VRF Name: r1-cust1
+VRF Name: r1-ospf-cust1
 ============ OSPF network routing table ============
 N    10.0.1.0/24           [10] area: 0.0.0.0
                            directly attached to r1-eth0

--- a/tests/topotests/ospf_topo1_vrf/r1/zebra.conf
+++ b/tests/topotests/ospf_topo1_vrf/r1/zebra.conf
@@ -7,10 +7,10 @@ hostname r1
 password zebra
 log file /tmp/r1-zebra.log
 !
-interface r1-eth0 vrf r1-cust1
+interface r1-eth0 vrf r1-ospf-cust1
  ip address 10.0.1.1/24
 !
-interface r1-eth1 vrf r1-cust1
+interface r1-eth1 vrf r1-ospf-cust1
  ip address 10.0.3.2/24
 !
 ip forwarding

--- a/tests/topotests/ospf_topo1_vrf/r1/zebraroute.txt
+++ b/tests/topotests/ospf_topo1_vrf/r1/zebraroute.txt
@@ -1,4 +1,4 @@
-VRF r1-cust1:
+VRF r1-ospf-cust1:
 O   10.0.1.0/24 [110/10] is directly connected, r1-eth0, weight 1, XX:XX:XX
 C>* 10.0.1.0/24 is directly connected, r1-eth0, XX:XX:XX
 O>* 10.0.2.0/24 [110/20] via 10.0.3.3, r1-eth1, weight 1, XX:XX:XX

--- a/tests/topotests/ospf_topo1_vrf/r1/zebraroutedown.txt
+++ b/tests/topotests/ospf_topo1_vrf/r1/zebraroutedown.txt
@@ -1,4 +1,4 @@
-VRF r1-cust1:
+VRF r1-ospf-cust1:
 O   10.0.1.0/24 [110/10] is directly connected, r1-eth0, weight 1, XX:XX:XX
 C>* 10.0.1.0/24 is directly connected, r1-eth0, XX:XX:XX
 O>* 10.0.2.0/24 [110/20] via 10.0.3.3, r1-eth1, weight 1, XX:XX:XX

--- a/tests/topotests/ospf_topo1_vrf/r2/ospfd.conf
+++ b/tests/topotests/ospf_topo1_vrf/r2/ospfd.conf
@@ -4,7 +4,7 @@ password zebra
 log file /tmp/r2-ospfd.log
 !
 !
-router ospf vrf r2-cust1
+router ospf vrf r2-ospf-cust1
   ospf router-id 10.0.255.2
   redistribute kernel
   redistribute connected

--- a/tests/topotests/ospf_topo1_vrf/r2/ospfroute.txt
+++ b/tests/topotests/ospf_topo1_vrf/r2/ospfroute.txt
@@ -1,4 +1,4 @@
-VRF Name: r2-cust1
+VRF Name: r2-ospf-cust1
 ============ OSPF network routing table ============
 N    10.0.1.0/24           [20] area: 0.0.0.0
                            via 10.0.3.2, r2-eth1

--- a/tests/topotests/ospf_topo1_vrf/r2/ospfroute_down.txt
+++ b/tests/topotests/ospf_topo1_vrf/r2/ospfroute_down.txt
@@ -1,4 +1,4 @@
-VRF Name: r2-cust1
+VRF Name: r2-ospf-cust1
 ============ OSPF network routing table ============
 N    10.0.1.0/24           [20] area: 0.0.0.0
                            via 10.0.3.2, r2-eth1

--- a/tests/topotests/ospf_topo1_vrf/r2/zebra.conf
+++ b/tests/topotests/ospf_topo1_vrf/r2/zebra.conf
@@ -3,10 +3,10 @@ hostname r2
 password zebra
 log file /tmp/r2-zebra.log
 !
-interface r2-eth0 vrf r2-cust1
+interface r2-eth0 vrf r2-ospf-cust1
  ip address 10.0.2.1/24
 !
-interface r2-eth1 vrf r2-cust1
+interface r2-eth1 vrf r2-ospf-cust1
  ip address 10.0.3.3/24
 !
 ip forwarding

--- a/tests/topotests/ospf_topo1_vrf/r2/zebraroute.txt
+++ b/tests/topotests/ospf_topo1_vrf/r2/zebraroute.txt
@@ -1,4 +1,4 @@
-VRF r2-cust1:
+VRF r2-ospf-cust1:
 O>* 10.0.1.0/24 [110/20] via 10.0.3.2, r2-eth1, weight 1, XX:XX:XX
 O   10.0.2.0/24 [110/10] is directly connected, r2-eth0, weight 1, XX:XX:XX
 C>* 10.0.2.0/24 is directly connected, r2-eth0, XX:XX:XX

--- a/tests/topotests/ospf_topo1_vrf/r2/zebraroutedown.txt
+++ b/tests/topotests/ospf_topo1_vrf/r2/zebraroutedown.txt
@@ -1,4 +1,4 @@
-VRF r2-cust1:
+VRF r2-ospf-cust1:
 O>* 10.0.1.0/24 [110/20] via 10.0.3.2, r2-eth1, weight 1, XX:XX:XX
 O   10.0.2.0/24 [110/10] is directly connected, r2-eth0, weight 1, XX:XX:XX
 C>* 10.0.2.0/24 is directly connected, r2-eth0, XX:XX:XX

--- a/tests/topotests/ospf_topo1_vrf/r3/ospfd.conf
+++ b/tests/topotests/ospf_topo1_vrf/r3/ospfd.conf
@@ -4,7 +4,7 @@ password zebra
 log file /tmp/r3-ospfd.log
 !
 !
-router ospf vrf r3-cust1
+router ospf vrf r3-ospf-cust1
   ospf router-id 10.0.255.3
   redistribute kernel
   redistribute connected

--- a/tests/topotests/ospf_topo1_vrf/r3/ospfroute.txt
+++ b/tests/topotests/ospf_topo1_vrf/r3/ospfroute.txt
@@ -1,4 +1,4 @@
-VRF Name: r3-cust1
+VRF Name: r3-ospf-cust1
 ============ OSPF network routing table ============
 N    10.0.1.0/24           [20] area: 0.0.0.0
                            via 10.0.3.2, r3-eth0

--- a/tests/topotests/ospf_topo1_vrf/r3/ospfroute_down.txt
+++ b/tests/topotests/ospf_topo1_vrf/r3/ospfroute_down.txt
@@ -1,4 +1,4 @@
-VRF Name: r3-cust1
+VRF Name: r3-ospf-cust1
 ============ OSPF network routing table ============
 N    10.0.10.0/24          [10] area: 0.0.0.0
                            directly attached to r3-eth1

--- a/tests/topotests/ospf_topo1_vrf/r3/zebra.conf
+++ b/tests/topotests/ospf_topo1_vrf/r3/zebra.conf
@@ -3,10 +3,10 @@ hostname r3
 password zebra
 log file /tmp/r3-zebra.log
 !
-interface r3-eth0 vrf r3-cust1
+interface r3-eth0 vrf r3-ospf-cust1
  ip address 10.0.3.1/24
 !
-interface r3-eth1 vrf r3-cust1
+interface r3-eth1 vrf r3-ospf-cust1
  ip address 10.0.10.1/24
 !
 ip forwarding

--- a/tests/topotests/ospf_topo1_vrf/r3/zebraroute.txt
+++ b/tests/topotests/ospf_topo1_vrf/r3/zebraroute.txt
@@ -1,4 +1,4 @@
-VRF r3-cust1:
+VRF r3-ospf-cust1:
 O>* 10.0.1.0/24 [110/20] via 10.0.3.2, r3-eth0, weight 1, XX:XX:XX
 O>* 10.0.2.0/24 [110/20] via 10.0.3.3, r3-eth0, weight 1, XX:XX:XX
 O   10.0.3.0/24 [110/10] is directly connected, r3-eth0, weight 1, XX:XX:XX

--- a/tests/topotests/ospf_topo1_vrf/r3/zebraroutedown.txt
+++ b/tests/topotests/ospf_topo1_vrf/r3/zebraroutedown.txt
@@ -1,4 +1,4 @@
-VRF r3-cust1:
+VRF r3-ospf-cust1:
 O   10.0.10.0/24 [110/10] is directly connected, r3-eth1, weight 1, XX:XX:XX
 C>* 10.0.10.0/24 is directly connected, r3-eth1, XX:XX:XX
 


### PR DESCRIPTION
- In order to run tests in parallel the netns-based vrfs need to
have unique names primarily bc they are all tracked/looked-up in
`/run/netns` which is not network namespace nesting friendly

- use ip(8) exclusively rather than a mix of `ip` and `ifconfig`
and `vconfig`, reducing required pkg count by a couple.

Signed-off-by: Christian Hopps <chopps@labn.net>