### PR TITLE
tests: use std polling for results in zebra_rib test

### DIFF
--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -104,13 +104,19 @@ def test_zebra_kernel_admin_distance():
     r1 = tgen.gears["r1"]
 
     # Route with 255/8192 metric
-    r1.run("ip route add 4.5.1.0/24 via 192.168.210.2 dev r1-eth0 metric 4278198272")
+
+    distance = 255
+    metric = 8192
+    def makekmetric(dist, metric):
+        return (dist << 24) + metric
+
+    r1.run("ip route add 4.5.1.0/24 via 192.168.210.2 dev r1-eth0 metric " + str(makekmetric(255, 8192)))
     # Route with 1/1 metric
-    r1.run("ip route add 4.5.2.0/24 via 192.168.211.2 dev r1-eth1 metric 16777217")
+    r1.run("ip route add 4.5.2.0/24 via 192.168.211.2 dev r1-eth1 metric " + str(makekmetric(1, 1)))
     # Route with 10/1 metric
-    r1.run("ip route add 4.5.3.0/24 via 192.168.212.2 dev r1-eth2 metric 167772161")
+    r1.run("ip route add 4.5.3.0/24 via 192.168.212.2 dev r1-eth2 metric " + str(makekmetric(10, 1)))
     # Same route with a 160/1 metric
-    r1.run("ip route add 4.5.3.0/24 via 192.168.213.2 dev r1-eth3 metric 2684354561")
+    r1.run("ip route add 4.5.3.0/24 via 192.168.213.2 dev r1-eth3 metric " + str(makekmetric(160, 1)))
 
     # Currently I believe we have a bug here with the same route and different
     # metric.  That needs to be properly resolved.  Making a note for
@@ -194,93 +200,69 @@ def test_route_map_usage():
     static_rmapfile = "%s/r1/static_rmap.ref" % (thisDir)
     expected = open(static_rmapfile).read().rstrip()
     expected = ("\n".join(expected.splitlines()) + "\n").rstrip()
-    actual = r1.vtysh_cmd("show route-map static")
-    actual = ("\n".join(actual.splitlines()) + "\n").rstrip()
     logger.info(
         "Does the show route-map static command run the correct number of times"
     )
-
-    diff = topotest.get_textdiff(
-        actual,
-        expected,
-        title1="Actual Route-map output",
-        title2="Expected Route-map output",
-    )
-    if diff:
-        logger.info("Actual:")
-        logger.info(actual)
-        logger.info("Expected:")
-        logger.info(expected)
-        srun = r1.vtysh_cmd("show run")
-        srun = ("\n".join(srun.splitlines()) + "\n").rstrip()
-        logger.info("Show run")
-        logger.info(srun)
-        assert 0, "r1 static route processing:\n"
+    def check_static_map_correct_runs():
+        actual = r1.vtysh_cmd("show route-map static")
+        actual = ("\n".join(actual.splitlines()) + "\n").rstrip()
+        return topotest.get_textdiff(
+            actual,
+            expected,
+            title1="Actual Route-map output",
+            title2="Expected Route-map output",
+        )
+    ok, result = topotest.run_and_expect(check_static_map_correct_runs, "", count=5, wait=1)
+    assert ok, result
 
     sharp_rmapfile = "%s/r1/sharp_rmap.ref" % (thisDir)
     expected = open(sharp_rmapfile).read().rstrip()
     expected = ("\n".join(expected.splitlines()) + "\n").rstrip()
-    actual = r1.vtysh_cmd("show route-map sharp")
-    actual = ("\n".join(actual.splitlines()) + "\n").rstrip()
     logger.info("Does the show route-map sharp command run the correct number of times")
-
-    diff = topotest.get_textdiff(
-        actual,
-        expected,
-        title1="Actual Route-map output",
-        title2="Expected Route-map output",
-    )
-    if diff:
-        logger.info("Actual:")
-        logger.info(actual)
-        logger.info("Expected:")
-        logger.info(expected)
-        srun = r1.vtysh_cmd("show run")
-        srun = ("\n".join(srun.splitlines()) + "\n").rstrip()
-        logger.info("Show run:")
-        logger.info(srun)
-        assert 0, "r1 sharp route-map processing:\n"
+    def check_sharp_map_correct_runs():
+        actual = r1.vtysh_cmd("show route-map sharp")
+        actual = ("\n".join(actual.splitlines()) + "\n").rstrip()
+        return topotest.get_textdiff(
+            actual,
+            expected,
+            title1="Actual Route-map output",
+            title2="Expected Route-map output",
+        )
+    ok, result = topotest.run_and_expect(check_sharp_map_correct_runs, "", count=5, wait=1)
+    assert ok, result
 
     logger.info(
         "Add a extension to the static route-map to see the static route go away"
+        " and test that the routes installed are correct"
     )
+
     r1.vtysh_cmd("conf\nroute-map sharp deny 5\nmatch ip address 5")
-    sleep(2)
     # we are only checking the kernel here as that this will give us the implied
     # testing of both the route-map and staticd withdrawing the route
     # let's spot check that the routes were installed correctly
     # in the kernel
-    logger.info("Test that the routes installed are correct")
     sharp_ipfile = "%s/r1/iproute.ref" % (thisDir)
     expected = open(sharp_ipfile).read().rstrip()
     expected = ("\n".join(expected.splitlines()) + "\n").rstrip()
-    actual = r1.run("ip route show")
-    actual = ("\n".join(actual.splitlines()) + "\n").rstrip()
-    actual = re.sub(r" nhid [0-9][0-9]", "", actual)
-    actual = re.sub(r" proto sharp", " proto XXXX", actual)
-    actual = re.sub(r" proto static", " proto XXXX", actual)
-    actual = re.sub(r" proto 194", " proto XXXX", actual)
-    actual = re.sub(r" proto 196", " proto XXXX", actual)
-    actual = re.sub(r" proto kernel", " proto XXXX", actual)
-    actual = re.sub(r" proto 2", " proto XXXX", actual)
-    # Some platforms have double spaces?  Why??????
-    actual = re.sub(r"  proto XXXX  ", " proto XXXX ", actual)
-    actual = re.sub(r"  metric", " metric", actual)
-    actual = re.sub(r" link  ", " link ", actual)
-    diff = topotest.get_textdiff(
-        actual, expected, title1="Actual ip route show", title2="Expected ip route show"
-    )
-
-    if diff:
-        logger.info("Actual:")
-        logger.info(actual)
-        logger.info("Expected:")
-        logger.info(expected)
-        srun = r1.vtysh_cmd("show run")
-        srun = ("\n".join(srun.splitlines()) + "\n").rstrip()
-        logger.info("Show run:")
-        logger.info(srun)
-        assert 0, "r1 ip route show is not correct:"
+    def check_routes_installed():
+        actual = r1.run("ip route show")
+        actual = ("\n".join(actual.splitlines()) + "\n").rstrip()
+        actual = re.sub(r" nhid [0-9][0-9]", "", actual)
+        actual = re.sub(r" proto sharp", " proto XXXX", actual)
+        actual = re.sub(r" proto static", " proto XXXX", actual)
+        actual = re.sub(r" proto 194", " proto XXXX", actual)
+        actual = re.sub(r" proto 196", " proto XXXX", actual)
+        actual = re.sub(r" proto kernel", " proto XXXX", actual)
+        actual = re.sub(r" proto 2", " proto XXXX", actual)
+        # Some platforms have double spaces?  Why??????
+        actual = re.sub(r"  proto XXXX  ", " proto XXXX ", actual)
+        actual = re.sub(r"  metric", " metric", actual)
+        actual = re.sub(r" link  ", " link ", actual)
+        return topotest.get_textdiff(
+            actual, expected, title1="Actual ip route show", title2="Expected ip route show"
+        )
+    ok, result = topotest.run_and_expect(check_routes_installed, "", count=5, wait=1)
+    assert ok, result
 
 
 def test_memory_leak():


### PR DESCRIPTION
In particular, the fixed 2 second sleep here was not long enough.
Switch to standard run_and_expect polling to make test more robust.

Signed-off-by: Christian Hopps <chopps@labn.net>