### PR TITLE
fix some SRv6 configuration isn't saved correctly 

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17152,6 +17152,7 @@ int bgp_config_write(struct vty *vty)
 			if (strlen(bgp->srv6_locator_name))
 				vty_out(vty, "  locator %s\n",
 					bgp->srv6_locator_name);
+			vty_endframe(vty, " exit\n");
 		}
 
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -15982,6 +15982,7 @@ static void bgp_vpn_policy_config_write_afi(struct vty *vty, struct bgp *bgp,
 					    afi_t afi)
 {
 	int indent = 2;
+	uint32_t tovpn_sid_index = 0;
 
 	if (bgp->vpn_policy[afi].rmap_name[BGP_VPN_POLICY_DIR_FROMVPN]) {
 		if (CHECK_FLAG(bgp->af_flags[afi][SAFI_UNICAST],
@@ -16011,6 +16012,16 @@ static void bgp_vpn_policy_config_write_afi(struct vty *vty, struct bgp *bgp,
 				bgp->vpn_policy[afi].tovpn_label);
 		}
 	}
+
+	tovpn_sid_index = bgp->vpn_policy[afi].tovpn_sid_index;
+	if (CHECK_FLAG(bgp->vpn_policy[afi].flags,
+		       BGP_VPN_POLICY_TOVPN_SID_AUTO)) {
+		vty_out(vty, "%*ssid vpn export %s\n", indent, "", "auto");
+	} else if (tovpn_sid_index != 0) {
+		vty_out(vty, "%*ssid vpn export %d\n", indent, "",
+			tovpn_sid_index);
+	}
+
 	if (CHECK_FLAG(bgp->vpn_policy[afi].flags,
 		       BGP_VPN_POLICY_TOVPN_RD_SET)) {
 		char buf[RD_ADDRSTRLEN];


### PR DESCRIPTION
I fixed two configuration issues.

1. `segment-routing srv6` block in `router bgp` block doesn't have `exit`. This causes an issue to load configuration at startup. 
2. `sid vpn export` setting is missing. This causes not to save configuration correctly.