### PR TITLE
ospf6d: suppress coverity warning of return value

### DIFF
--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -850,7 +850,7 @@ static void show_ospfv6_gr_helper_per_nbr(struct vty *vty, json_object *json,
 	}
 }
 
-static int show_ospf6_gr_helper_details(struct vty *vty, struct ospf6 *ospf6,
+static void show_ospf6_gr_helper_details(struct vty *vty, struct ospf6 *ospf6,
 					json_object *json, bool uj, bool detail)
 {
 	struct ospf6_interface *oi;
@@ -999,8 +999,6 @@ static int show_ospf6_gr_helper_details(struct vty *vty, struct ospf6 *ospf6,
 				}
 			}
 	}
-
-	return CMD_SUCCESS;
 }
 
 /* Graceful Restart HELPER  config Commands */


### PR DESCRIPTION
After i have checked the context of code, i think it needn't return any value.

Signed-off-by: anlan_cs <anlan_cs@tom.com>