### PR TITLE
ospf6d: fix lock leak of using ALL_LSDB in GR helper

### DIFF
--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -233,8 +233,13 @@ static bool ospf6_check_chg_in_rxmt_list(struct ospf6_neighbor *nbr)
 			ospf6_lsdb_lookup(lsa->header->type, lsa->header->id,
 					  lsa->header->adv_router, lsa->lsdb);
 
-		if (lsa_in_db && lsa_in_db->tobe_acknowledged)
+		if (lsa_in_db && lsa_in_db->tobe_acknowledged) {
+			ospf6_lsa_unlock(lsa);
+			if (lsanext)
+				ospf6_lsa_unlock(lsanext);
+
 			return OSPF6_TRUE;
+		}
 	}
 
 	return OSPF6_FALSE;

--- a/ospf6d/ospf6_lsdb.h
+++ b/ospf6d/ospf6_lsdb.h
@@ -68,7 +68,7 @@ extern struct ospf6_lsa *ospf6_lsdb_next(const struct route_node *iterend,
 
 /*
  * Since we are locking the lsa in ospf6_lsdb_head
- * and then unlocking it in lspf6_lsa_lock, when
+ * and then unlocking it in ospf6_lsa_unlock, when
  * we cache the next pointer we need to increment
  * the lock for the lsa so we don't accidently free
  * it really early.
@@ -76,7 +76,7 @@ extern struct ospf6_lsa *ospf6_lsdb_next(const struct route_node *iterend,
 #define ALL_LSDB(lsdb, lsa, lsanext)                                           \
 	const struct route_node *iterend =                                     \
 		ospf6_lsdb_head(lsdb, 0, 0, 0, &lsa);                          \
-	(lsa) != NULL &&ospf6_lsa_lock(lsa)                                    \
+	(lsa) != NULL && ospf6_lsa_lock(lsa)                                   \
 		&& ((lsanext) = ospf6_lsdb_next(iterend, (lsa)), 1);           \
 	ospf6_lsa_unlock(lsa), (lsa) = (lsanext)
 


### PR DESCRIPTION
Two fixes:

- The lsa and lsanext must be unlocked if break out of ALL_LSDB loop. So add it.

- Incidentally correct the comment of ALL_LSDB.

Signed-off-by: anlan_cs <anlan_cs@tom.com>