### PR TITLE
pimd: Interface delete operation doesn't clean up pim/igmp data

### DIFF
--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -257,4 +257,6 @@ int pim_if_ifchannel_count(struct pim_interface *pim_ifp);
 
 void pim_iface_init(void);
 
+void pim_pim_interface_delete(struct interface *ifp);
+void pim_gm_interface_delete(struct interface *ifp);
 #endif /* PIM_IFACE_H */


### PR DESCRIPTION
Problem:
interface delete operation doesn't delete igmp & pim datastructur properly.
In a particular case, igmp query timer is not cleaned up during interface delete.
When timer expires, interface doesn't exist causing stale pointer access.

Fix:
During interface delete, unconfigure pim and igmp from the interface which would
clean up all igmp and pim related data on the interface.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>