### PR TITLE
snapcraft: add missing dependency

### DIFF
--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -322,6 +322,7 @@ parts:
            - bison
            - flex
            - python3-dev
+           - libprotobuf-c-dev
            - protobuf-c-compiler
            - python3-sphinx
         stage-packages:


### PR DESCRIPTION
Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>