### PR TITLE
lib, zebra: move vrf netns commands from lib to zebra

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -58,7 +58,6 @@ struct vrf_name_head vrfs_by_name = RB_INITIALIZER(&vrfs_by_name);
 
 static int vrf_backend;
 static int vrf_backend_configured;
-static struct zebra_privs_t *vrf_daemon_privs;
 static char vrf_default_name[VRF_NAMSIZ] = VRF_DEFAULT_NAME_INTERNAL;
 
 /*
@@ -856,62 +855,6 @@ static struct cmd_node vrf_node = {
 	.prompt = "%s(config-vrf)# ",
 };
 
-DEFUN_NOSH (vrf_netns,
-       vrf_netns_cmd,
-       "netns NAME",
-       "Attach VRF to a Namespace\n"
-       "The file name in " NS_RUN_DIR ", or a full pathname\n")
-{
-	int idx_name = 1, ret;
-	char *pathname = ns_netns_pathname(vty, argv[idx_name]->arg);
-
-	VTY_DECLVAR_CONTEXT(vrf, vrf);
-
-	if (!pathname)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	frr_with_privs(vrf_daemon_privs) {
-		ret = vrf_netns_handler_create(vty, vrf, pathname,
-					       NS_UNKNOWN,
-					       NS_UNKNOWN,
-					       NS_UNKNOWN);
-	}
-	return ret;
-}
-
-DEFUN_NOSH (no_vrf_netns,
-	no_vrf_netns_cmd,
-	"no netns [NAME]",
-	NO_STR
-	"Detach VRF from a Namespace\n"
-	"The file name in " NS_RUN_DIR ", or a full pathname\n")
-{
-	struct ns *ns = NULL;
-
-	VTY_DECLVAR_CONTEXT(vrf, vrf);
-
-	if (!vrf_is_backend_netns()) {
-		vty_out(vty, "VRF backend is not Netns. Aborting\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-	if (!vrf->ns_ctxt) {
-		vty_out(vty, "VRF %s(%u) is not configured with NetNS\n",
-			vrf->name, vrf->vrf_id);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	ns = (struct ns *)vrf->ns_ctxt;
-
-	ns->vrf_ctxt = NULL;
-	vrf_disable(vrf);
-	/* vrf ID from VRF is necessary for Zebra
-	 * so that propagate to other clients is done
-	 */
-	ns_delete(ns);
-	vrf->ns_ctxt = NULL;
-	return CMD_SUCCESS;
-}
-
 /*
  * Debug CLI for vrf's
  */
@@ -973,12 +916,6 @@ void vrf_cmd_init(int (*writefunc)(struct vty *vty),
 	install_node(&vrf_node);
 	install_default(VRF_NODE);
 	install_element(VRF_NODE, &vrf_exit_cmd);
-	if (vrf_is_backend_netns() && ns_have_netns()) {
-		/* Install NS commands. */
-		vrf_daemon_privs = daemon_privs;
-		install_element(VRF_NODE, &vrf_netns_cmd);
-		install_element(VRF_NODE, &no_vrf_netns_cmd);
-	}
 }
 
 void vrf_set_default_name(const char *default_name, bool force)

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -40,7 +40,6 @@
 #include "vtysh/vtysh.h"
 #include "vtysh/vtysh_daemons.h"
 #include "log.h"
-#include "ns.h"
 #include "vrf.h"
 #include "libfrr.h"
 #include "command_graph.h"
@@ -2744,17 +2743,6 @@ DEFUNSH(VTYSH_VRF, vtysh_vrf, vtysh_vrf_cmd, "vrf NAME",
 	return CMD_SUCCESS;
 }
 
-DEFSH(VTYSH_ZEBRA, vtysh_vrf_netns_cmd,
-      "netns NAME",
-      "Attach VRF to a Namespace\n"
-      "The file name in " NS_RUN_DIR ", or a full pathname\n")
-
-DEFSH(VTYSH_ZEBRA, vtysh_no_vrf_netns_cmd,
-      "no netns [NAME]",
-      NO_STR
-      "Detach VRF from a Namespace\n"
-      "The file name in " NS_RUN_DIR ", or a full pathname\n")
-
 DEFUNSH(VTYSH_VRF, vtysh_exit_vrf, vtysh_exit_vrf_cmd, "exit",
 	"Exit current mode and down to previous mode\n")
 {
@@ -4472,8 +4460,6 @@ void vtysh_init_vty(void)
 
 	install_node(&vrf_node);
 	install_element(CONFIG_NODE, &vtysh_vrf_cmd);
-	install_element(VRF_NODE, &vtysh_vrf_netns_cmd);
-	install_element(VRF_NODE, &vtysh_no_vrf_netns_cmd);
 	install_element(VRF_NODE, &exit_vrf_config_cmd);
 	install_element(VRF_NODE, &vtysh_end_all_cmd);
 	install_element(VRF_NODE, &vtysh_exit_vrf_cmd);

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -19,6 +19,7 @@ vtysh_scan += \
 	zebra/zebra_routemap.c \
 	zebra/zebra_vty.c \
 	zebra/zserv.c \
+	zebra/zebra_vrf.c \
 	# end
 
 # can be loaded as DSO - always include for vtysh
@@ -132,6 +133,7 @@ clippy_scan += \
 	zebra/zebra_routemap.c \
 	zebra/zebra_vty.c \
 	zebra/zebra_srv6_vty.c \
+	zebra/zebra_vrf.c \
 	# end
 
 noinst_HEADERS += \


### PR DESCRIPTION
"[no] netns NAME" commands are part of the lib, but they are actually
zebra-only:
- they are using vrf_netns_handler_create and its description clearly
  says that it "should be called from zebra only"
- vtysh sends these commands only to zebra
- only zebra outputs the netns related config
- zebra notifies other daemons about netns attachment

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>