### PR TITLE
lib: remove the dependency on bgpd code

### DIFF
--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -151,12 +151,6 @@ struct ecommunity_val_ipv6 {
 	char val[IPV6_ECOMMUNITY_SIZE];
 };
 
-enum ecommunity_lb_type {
-	EXPLICIT_BANDWIDTH,
-	CUMULATIVE_BANDWIDTH,
-	COMPUTED_BANDWIDTH
-};
-
 #define ecom_length_size(X, Y)    ((X)->size * (Y))
 
 /*

--- a/bgpd/bgp_routemap_nb_config.c
+++ b/bgpd/bgp_routemap_nb_config.c
@@ -25,7 +25,6 @@
 #include "lib/routemap.h"
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_routemap_nb.h"
-#include "bgpd/bgp_ecommunity.h"
 
 /* Add bgp route map rule. */
 static int bgp_route_match_add(struct route_map_index *index,

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -379,6 +379,12 @@ DECLARE_QOBJ_TYPE(route_map);
 #define IS_SET_BGP_EVPN_GATEWAY_IP_IPV6(A)                                     \
 	(strmatch(A, "frr-bgp-route-map:set-evpn-gateway-ip-ipv6"))
 
+enum ecommunity_lb_type {
+	EXPLICIT_BANDWIDTH,
+	CUMULATIVE_BANDWIDTH,
+	COMPUTED_BANDWIDTH
+};
+
 /* Prototypes. */
 extern void route_map_init(void);
 

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -25,7 +25,6 @@
 #include "lib/command.h"
 #include "lib/northbound_cli.h"
 #include "lib/routemap.h"
-#include "bgpd/bgp_ecommunity.h"
 
 #ifndef VTYSH_EXTRACT_PL
 #include "lib/routemap_cli_clippy.c"


### PR DESCRIPTION
The library code should not depend on a specific daemon's code.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>