### PR TITLE
bgpd: VRF-Lite fix nexthop type

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -691,6 +691,8 @@ unsigned int attrhash_key_make(const void *p)
 	key = jhash(attr->mp_nexthop_local.s6_addr, IPV6_MAX_BYTELEN, key);
 	MIX3(attr->nh_ifindex, attr->nh_lla_ifindex, attr->distance);
 	MIX(attr->rmap_table_id);
+	MIX(attr->nh_type);
+	MIX(attr->bh_type);
 
 	return key;
 }
@@ -747,7 +749,9 @@ bool attrhash_cmp(const void *p1, const void *p2)
 		    && attr1->distance == attr2->distance
 		    && srv6_l3vpn_same(attr1->srv6_l3vpn, attr2->srv6_l3vpn)
 		    && srv6_vpn_same(attr1->srv6_vpn, attr2->srv6_vpn)
-		    && attr1->srte_color == attr2->srte_color)
+		    && attr1->srte_color == attr2->srte_color
+		    && attr1->nh_type == attr2->nh_type
+		    && attr1->bh_type == attr2->bh_type)
 			return true;
 	}
 

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -307,6 +307,12 @@ struct attr {
 	/* EVPN DF preference and algorithm for DF election on local ESs */
 	uint16_t df_pref;
 	uint8_t df_alg;
+
+	/* Nexthop type */
+	enum nexthop_types_t nh_type;
+
+	/* If NEXTHOP_TYPE_BLACKHOLE, then blackhole type */
+	enum blackhole_type bh_type;
 };
 
 /* rmap_change_flags definition */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8066,8 +8066,9 @@ DEFPY(aggregate_addressv6, aggregate_addressv6_cmd,
 void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 			  const union g_addr *nexthop, ifindex_t ifindex,
 			  enum nexthop_types_t nhtype, uint8_t distance,
-			  uint32_t metric, uint8_t type,
-			  unsigned short instance, route_tag_t tag)
+			  enum blackhole_type bhtype, uint32_t metric,
+			  uint8_t type, unsigned short instance,
+			  route_tag_t tag)
 {
 	struct bgp_path_info *new;
 	struct bgp_path_info *bpi;
@@ -8109,8 +8110,10 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 			attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
 			break;
 		}
+		attr.bh_type = bhtype;
 		break;
 	}
+	attr.nh_type = nhtype;
 	attr.nh_ifindex = ifindex;
 
 	attr.med = metric;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -642,8 +642,9 @@ extern bool bgp_maximum_prefix_overflow(struct peer *, afi_t, safi_t, int);
 extern void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 				 const union g_addr *nexthop, ifindex_t ifindex,
 				 enum nexthop_types_t nhtype, uint8_t distance,
-				 uint32_t metric, uint8_t type,
-				 unsigned short instance, route_tag_t tag);
+				 enum blackhole_type bhtype, uint32_t metric,
+				 uint8_t type, unsigned short instance,
+				 route_tag_t tag);
 extern void bgp_redistribute_delete(struct bgp *, struct prefix *, uint8_t,
 				    unsigned short);
 extern void bgp_redistribute_withdraw(struct bgp *, afi_t, int, unsigned short);

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -519,12 +519,13 @@ struct nexthop *nexthop_from_ipv6_ifindex(const struct in6_addr *ipv6,
 	return nexthop;
 }
 
-struct nexthop *nexthop_from_blackhole(enum blackhole_type bh_type)
+struct nexthop *nexthop_from_blackhole(enum blackhole_type bh_type,
+				       vrf_id_t nh_vrf_id)
 {
 	struct nexthop *nexthop;
 
 	nexthop = nexthop_new();
-	nexthop->vrf_id = VRF_DEFAULT;
+	nexthop->vrf_id = nh_vrf_id;
 	nexthop->type = NEXTHOP_TYPE_BLACKHOLE;
 	nexthop->bh_type = bh_type;
 

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -182,7 +182,8 @@ struct nexthop *nexthop_from_ipv6(const struct in6_addr *ipv6,
 				  vrf_id_t vrf_id);
 struct nexthop *nexthop_from_ipv6_ifindex(const struct in6_addr *ipv6,
 					  ifindex_t ifindex, vrf_id_t vrf_id);
-struct nexthop *nexthop_from_blackhole(enum blackhole_type bh_type);
+struct nexthop *nexthop_from_blackhole(enum blackhole_type bh_type,
+				       vrf_id_t nh_vrf_id);
 
 /*
  * Hash a nexthop. Suitable for use with hash tables.

--- a/tests/lib/test_nexthop.c
+++ b/tests/lib/test_nexthop.c
@@ -112,15 +112,15 @@ static void test_run_first(void)
 	nexthop_free(nh2);
 
 	/* Blackhole */
-	nh1 = nexthop_from_blackhole(BLACKHOLE_REJECT);
-	nh2 = nexthop_from_blackhole(BLACKHOLE_REJECT);
+	nh1 = nexthop_from_blackhole(BLACKHOLE_REJECT, 0);
+	nh2 = nexthop_from_blackhole(BLACKHOLE_REJECT, 0);
 
 	ret = nexthop_cmp_basic(nh1, nh2);
 	assert(ret == 0);
 
 	nexthop_free(nh2);
 
-	nh2 = nexthop_from_blackhole(BLACKHOLE_NULL);
+	nh2 = nexthop_from_blackhole(BLACKHOLE_NULL, 0);
 
 	ret = nexthop_cmp_basic(nh1, nh2);
 	assert(ret != 0);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1611,7 +1611,8 @@ static struct nexthop *nexthop_from_zapi(const struct zapi_nexthop *api_nh,
 			zlog_debug("%s: nh blackhole %d",
 				   __func__, api_nh->bh_type);
 
-		nexthop = nexthop_from_blackhole(api_nh->bh_type);
+		nexthop =
+			nexthop_from_blackhole(api_nh->bh_type, api_nh->vrf_id);
 		break;
 	}
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -357,9 +357,11 @@ static void show_nexthop_detail_helper(struct vty *vty,
 		break;
 	}
 
-	if ((re->vrf_id != nexthop->vrf_id)
-	    && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE))
-		vty_out(vty, "(vrf %s)", vrf_id_to_name(nexthop->vrf_id));
+	if (re->vrf_id != nexthop->vrf_id) {
+		struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
+
+		vty_out(vty, "(vrf %s)", VRF_LOGNAME(vrf));
+	}
 
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
 		vty_out(vty, " (duplicate nexthop removed)");
@@ -607,8 +609,7 @@ static void show_route_nexthop_helper(struct vty *vty,
 		break;
 	}
 
-	if ((re == NULL || (nexthop->vrf_id != re->vrf_id))
-	    && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE))
+	if ((re == NULL || (nexthop->vrf_id != re->vrf_id)))
 		vty_out(vty, " (vrf %s)", vrf_id_to_name(nexthop->vrf_id));
 
 	if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
@@ -780,8 +781,7 @@ static void show_nexthop_json_helper(json_object *json_nexthop,
 		break;
 	}
 
-	if ((nexthop->vrf_id != re->vrf_id)
-	    && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE))
+	if (nexthop->vrf_id != re->vrf_id)
 		json_object_string_add(json_nexthop, "vrf",
 				       vrf_id_to_name(nexthop->vrf_id));
 


### PR DESCRIPTION
Description:
Change is intended for fixing the following issues related to vrf route leaking:

Routes with special nexthops i.e. blackhole/sink routes when imported, 
are not programmed into the FIB and corresponding nexthop is set as 'inactive', 
nexthop interface as 'unknown'.

While importing/leaking routes between VRFs, in case of special nexthop(ipv4/ipv6)
once bgp announces route(s) to zebra, nexthop type is incorrectly set as
NEXTHOP_TYPE_IPV6_IFINDEX/NEXTHOP_TYPE_IFINDEX
i.e. directly connected even though we are not able to resolve through an interface.
This leads to nexthop_active_check marking nexthop !NEXTHOP_FLAG_ACTIVE.
Unable to find the active nexthop(s), route is not programmed into the FIB.

Whenever BGP leaks routes, set the correct nexthop type, so that route gets resolved
and correctly programmed into the FIB, in the imported vrf.

Co-authored-by: Kantesh Mundaragi <kmundaragi@vmware.com>
Signed-off-by: Iqra Siddiqui <imujeebsiddi@vmware.com>