### PR TITLE
pimd: Added new option "detail" in the "debug pim nht" CLI

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -609,6 +609,11 @@ the config was written out.
    This turns on debugging for PIM nexthop tracking. It will display
    information about RPF lookups and information about when a nexthop changes.
 
+.. clicmd:: debug pim nht detail
+
+   This turns on debugging for PIM nexthop in detail. This is not enabled
+   by default.
+
 .. clicmd:: debug pim packet-dump
 
    This turns on an extraordinary amount of data. Each pim packet sent and

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8639,6 +8639,31 @@ DEFUN (no_debug_pim_nht,
 	return CMD_SUCCESS;
 }
 
+DEFUN (debug_pim_nht_det,
+       debug_pim_nht_det_cmd,
+       "debug pim nht detail",
+       DEBUG_STR
+       DEBUG_PIM_STR
+       "Nexthop Tracking\n"
+       "Detailed Information\n")
+{
+	PIM_DO_DEBUG_PIM_NHT_DETAIL;
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_debug_pim_nht_det,
+       no_debug_pim_nht_det_cmd,
+       "no debug pim nht detail",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIM_STR
+       "Nexthop Tracking\n"
+       "Detailed Information\n")
+{
+	PIM_DONT_DEBUG_PIM_NHT_DETAIL;
+	return CMD_SUCCESS;
+}
+
 DEFUN (debug_pim_nht_rp,
        debug_pim_nht_rp_cmd,
        "debug pim nht rp",
@@ -10905,6 +10930,8 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &no_debug_pim_cmd);
 	install_element(ENABLE_NODE, &debug_pim_nht_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_nht_cmd);
+	install_element(ENABLE_NODE, &debug_pim_nht_det_cmd);
+	install_element(ENABLE_NODE, &no_debug_pim_nht_det_cmd);
 	install_element(ENABLE_NODE, &debug_pim_nht_rp_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_nht_rp_cmd);
 	install_element(ENABLE_NODE, &debug_pim_events_cmd);
@@ -10956,6 +10983,8 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_debug_pim_cmd);
 	install_element(CONFIG_NODE, &debug_pim_nht_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_nht_cmd);
+	install_element(CONFIG_NODE, &debug_pim_nht_det_cmd);
+	install_element(CONFIG_NODE, &no_debug_pim_nht_det_cmd);
 	install_element(CONFIG_NODE, &debug_pim_nht_rp_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_nht_rp_cmd);
 	install_element(CONFIG_NODE, &debug_pim_events_cmd);

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -121,7 +121,7 @@ static struct pim_nexthop_cache *pim_nht_get(struct pim_instance *pim,
 		pnc = pim_nexthop_cache_add(pim, &rpf);
 		pim_sendmsg_zebra_rnh(pim, zclient, pnc,
 				      ZEBRA_NEXTHOP_REGISTER);
-		if (PIM_DEBUG_PIM_NHT)
+		if (PIM_DEBUG_PIM_NHT_DETAIL)
 			zlog_debug(
 				"%s: NHT cache and zebra notification added for %pFX(%s)",
 				__func__, addr, pim->vrf->name);
@@ -899,7 +899,7 @@ int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
 	uint32_t num_nbrs = 0;
 	pim_addr src_addr = pim_addr_from_prefix(src);
 
-	if (PIM_DEBUG_PIM_NHT)
+	if (PIM_DEBUG_PIM_NHT_DETAIL)
 		zlog_debug("%s: Looking up: %pPA(%s), last lookup time: %lld",
 			   __func__, &src_addr, pim->vrf->name,
 			   nexthop->last_lookup_time);
@@ -1052,7 +1052,7 @@ int pim_ecmp_fib_lookup_if_vif_index(struct pim_instance *pim,
 	ifindex_t ifindex;
 	pim_addr src_addr;
 
-	if (PIM_DEBUG_PIM_NHT) {
+	if (PIM_DEBUG_PIM_NHT_DETAIL) {
 		src_addr = pim_addr_from_prefix(src);
 	}
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -166,6 +166,11 @@ int pim_debug_config_write(struct vty *vty)
 		++writes;
 	}
 
+	if (PIM_DEBUG_PIM_NHT_DETAIL) {
+		vty_out(vty, "debug pim nht detail\n");
+		++writes;
+	}
+
 	return writes;
 }
 

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -412,7 +412,7 @@ int zclient_lookup_nexthop(struct pim_instance *pim,
 		num_ifindex = zclient_lookup_nexthop_once(pim, nexthop_tab,
 							  tab_size, addr);
 		if (num_ifindex < 1) {
-			if (PIM_DEBUG_PIM_NHT)
+			if (PIM_DEBUG_PIM_NHT_DETAIL)
 				zlog_debug(
 					"%s: lookup=%d/%d: could not find nexthop ifindex for address %pPA(%s)",
 					__func__, lookup, max_lookup, &addr,

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -182,8 +182,7 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 #define PIM_DEBUG_MSDP_PACKETS (router->debugs & PIM_MASK_MSDP_PACKETS)
 #define PIM_DEBUG_MSDP_INTERNAL (router->debugs & PIM_MASK_MSDP_INTERNAL)
 #define PIM_DEBUG_PIM_NHT (router->debugs & PIM_MASK_PIM_NHT)
-#define PIM_DEBUG_PIM_NHT_DETAIL                                               \
-	(router->debugs & (PIM_MASK_PIM_NHT_DETAIL | PIM_MASK_PIM_NHT))
+#define PIM_DEBUG_PIM_NHT_DETAIL (router->debugs & PIM_MASK_PIM_NHT_DETAIL)
 #define PIM_DEBUG_PIM_NHT_RP (router->debugs & PIM_MASK_PIM_NHT_RP)
 #define PIM_DEBUG_MTRACE (router->debugs & PIM_MASK_MTRACE)
 #define PIM_DEBUG_VXLAN (router->debugs & PIM_MASK_VXLAN)
@@ -228,6 +227,7 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 #define PIM_DO_DEBUG_MSDP_PACKETS (router->debugs |= PIM_MASK_MSDP_PACKETS)
 #define PIM_DO_DEBUG_MSDP_INTERNAL (router->debugs |= PIM_MASK_MSDP_INTERNAL)
 #define PIM_DO_DEBUG_PIM_NHT (router->debugs |= PIM_MASK_PIM_NHT)
+#define PIM_DO_DEBUG_PIM_NHT_DETAIL (router->debugs |= PIM_MASK_PIM_NHT_DETAIL)
 #define PIM_DO_DEBUG_PIM_NHT_RP (router->debugs |= PIM_MASK_PIM_NHT_RP)
 #define PIM_DO_DEBUG_MTRACE (router->debugs |= PIM_MASK_MTRACE)
 #define PIM_DO_DEBUG_VXLAN (router->debugs |= PIM_MASK_VXLAN)
@@ -259,6 +259,8 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 #define PIM_DONT_DEBUG_MSDP_PACKETS (router->debugs &= ~PIM_MASK_MSDP_PACKETS)
 #define PIM_DONT_DEBUG_MSDP_INTERNAL (router->debugs &= ~PIM_MASK_MSDP_INTERNAL)
 #define PIM_DONT_DEBUG_PIM_NHT (router->debugs &= ~PIM_MASK_PIM_NHT)
+#define PIM_DONT_DEBUG_PIM_NHT_DETAIL                                          \
+	(router->debugs &= ~PIM_MASK_PIM_NHT_DETAIL)
 #define PIM_DONT_DEBUG_PIM_NHT_RP (router->debugs &= ~PIM_MASK_PIM_NHT_RP)
 #define PIM_DONT_DEBUG_MTRACE (router->debugs &= ~PIM_MASK_MTRACE)
 #define PIM_DONT_DEBUG_VXLAN (router->debugs &= ~PIM_MASK_VXLAN)


### PR DESCRIPTION
Problem Statement:
PIM Logs are coming at intervals of 1 minute although pim
is not enabled.

Fix:
Added a new option "detail" in the cli:
debug pim nht detail

Signed-off-by: Sai Gomathi <nsaigomathi@vmware.com>