### PR TITLE
zebra: Send path del to bgp for local-inactive path

### DIFF
--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -2113,12 +2113,12 @@ void zebra_evpn_neigh_remote_macip_add(struct zebra_evpn *zevpn,
 						"sync->remote neigh vni %u ip %pIA mac %pEA seq %d f0x%x",
 						n->zevpn->vni, &n->ip, &n->emac,
 						seq, n->flags);
-				zebra_evpn_neigh_clear_sync_info(n);
 				if (IS_ZEBRA_NEIGH_ACTIVE(n))
 					zebra_evpn_neigh_send_del_to_client(
 						zevpn->vni, &n->ip, &n->emac,
 						n->flags, n->state,
 						false /*force*/);
+				zebra_evpn_neigh_clear_sync_info(n);
 			}
 			if (memcmp(&n->emac, &mac->macaddr,
 				   sizeof(struct ethaddr))


### PR DESCRIPTION
Problem:
When IP1:M1 (local) moves to IP1:M2 (remote-VTEP) bgpd continues to
advertise IP1:M1. This problem is seen in an EVPN-MH setup.

Fix:
Local path del is sent to bgp if the neigh was {local-active||peer-active}.
So path del needs to be called before the sync flags (including peer-active)
are cleared.

Ticket: #2706744

Signed-off-by: Anuradha Karuppiah <anuradhak@nvidia.com>