### PR TITLE
pimd: move IGMP memberships from socket to iface, + some cleanups

### DIFF
--- a/pimd/pim_assert.h
+++ b/pimd/pim_assert.h
@@ -24,8 +24,22 @@
 
 #include "if.h"
 
-#include "pim_neighbor.h"
-#include "pim_ifchannel.h"
+struct pim_ifchannel;
+struct pim_neighbor;
+
+enum pim_ifassert_state {
+	PIM_IFASSERT_NOINFO,
+	PIM_IFASSERT_I_AM_WINNER,
+	PIM_IFASSERT_I_AM_LOSER
+};
+
+struct pim_assert_metric {
+	uint32_t rpt_bit_flag;
+	uint32_t metric_preference;
+	uint32_t route_metric;
+	struct in_addr ip_address; /* neighbor router that sourced the Assert
+				      message */
+};
 
 /*
   RFC 4601: 4.11.  Timer Values

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -28,6 +28,7 @@
 #include "zclient.h"
 
 #include "pim_instance.h"
+#include "pim_neighbor.h"
 #include "pim_cmd.h"
 #include "pim_vty.h"
 #include "pim_iface.h"

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -28,6 +28,7 @@
 #include "pimd.h"
 #include "pim_iface.h"
 #include "pim_instance.h"
+#include "pim_neighbor.h"
 #include "pim_rpf.h"
 #include "pim_hello.h"
 #include "pim_pim.h"

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3443,80 +3443,70 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list,
-					  grpnode, grp)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			char hhmmss[10];
 			char uptime[10];
 
-			pim_inet4_dump("<group?>", grp->group_addr,
-				       group_str, sizeof(group_str));
+			pim_inet4_dump("<group?>", grp->group_addr, group_str,
+				       sizeof(group_str));
 			pim_time_timer_to_hhmmss(hhmmss, sizeof(hhmmss),
 						 grp->t_group_timer);
 			pim_time_uptime(uptime, sizeof(uptime),
 					now - grp->group_creation);
 
 			if (uj) {
-				json_object_object_get_ex(
-					json, ifp->name, &json_iface);
+				json_object_object_get_ex(json, ifp->name,
+							  &json_iface);
 
 				if (!json_iface) {
-					json_iface =
-						json_object_new_object();
-					json_object_pim_ifp_add(
-						json_iface, ifp);
-					json_object_object_add(
-						json, ifp->name,
-						json_iface);
-					json_groups =
-						json_object_new_array();
-					json_object_object_add(
-						json_iface,
-						"groups",
-						json_groups);
+					json_iface = json_object_new_object();
+					json_object_pim_ifp_add(json_iface,
+								ifp);
+					json_object_object_add(json, ifp->name,
+							       json_iface);
+					json_groups = json_object_new_array();
+					json_object_object_add(json_iface,
+							       "groups",
+							       json_groups);
 				}
 
 				json_group = json_object_new_object();
-				json_object_string_add(json_group,
-						       "group",
+				json_object_string_add(json_group, "group",
 						       group_str);
 
 				if (grp->igmp_version == 3)
 					json_object_string_add(
 						json_group, "mode",
 						grp->group_filtermode_isexcl
-						? "EXCLUDE"
-						: "INCLUDE");
+							? "EXCLUDE"
+							: "INCLUDE");
 
-				json_object_string_add(json_group,
-						       "timer", hhmmss);
+				json_object_string_add(json_group, "timer",
+						       hhmmss);
 				json_object_int_add(
 					json_group, "sourcesCount",
-					grp->group_source_list
-					? listcount(
+					grp->group_source_list ? listcount(
 						grp->group_source_list)
-					: 0);
-				json_object_int_add(
-					json_group, "version",
-					grp->igmp_version);
-				json_object_string_add(
-					json_group, "uptime", uptime);
-				json_object_array_add(json_groups,
-						      json_group);
+							       : 0);
+				json_object_int_add(json_group, "version",
+						    grp->igmp_version);
+				json_object_string_add(json_group, "uptime",
+						       uptime);
+				json_object_array_add(json_groups, json_group);
 			} else {
-				vty_out(vty,
-					"%-16s %-15s %4s %8s %4d %d %8s\n",
+				vty_out(vty, "%-16s %-15s %4s %8s %4d %d %8s\n",
 					ifp->name, group_str,
 					grp->igmp_version == 3
-					? (grp->group_filtermode_isexcl
-					   ? "EXCL"
-					   : "INCL")
-					: "----",
+						? (grp->group_filtermode_isexcl
+							   ? "EXCL"
+							   : "INCL")
+						: "----",
 					hhmmss,
-					grp->group_source_list
-					? listcount(
+					grp->group_source_list ? listcount(
 						grp->group_source_list)
-					: 0,
+							       : 0,
 					grp->igmp_version, uptime);
 			}
 		} /* scan igmp groups */
@@ -3547,16 +3537,16 @@ static void igmp_show_group_retransmission(struct pim_instance *pim,
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list,
-					  grpnode, grp)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			char grp_retr_mmss[10];
 			struct listnode *src_node;
 			struct igmp_source *src;
 			int grp_retr_sources = 0;
 
-			pim_inet4_dump("<group?>", grp->group_addr,
-				       group_str, sizeof(group_str));
+			pim_inet4_dump("<group?>", grp->group_addr, group_str,
+				       sizeof(group_str));
 			pim_time_timer_to_mmss(
 				grp_retr_mmss, sizeof(grp_retr_mmss),
 				grp->t_group_query_retransmit_timer);
@@ -3564,17 +3554,15 @@ static void igmp_show_group_retransmission(struct pim_instance *pim,
 
 			/* count group sources with retransmission state
 			 */
-			for (ALL_LIST_ELEMENTS_RO(
-				     grp->group_source_list, src_node,
-				     src)) {
-				if (src->source_query_retransmit_count
-				    > 0) {
+			for (ALL_LIST_ELEMENTS_RO(grp->group_source_list,
+						  src_node, src)) {
+				if (src->source_query_retransmit_count > 0) {
 					++grp_retr_sources;
 				}
 			}
 
-			vty_out(vty, "%-16s %-15s %-8s %7d %7d\n",
-				ifp->name, group_str, grp_retr_mmss,
+			vty_out(vty, "%-16s %-15s %-8s %7d %7d\n", ifp->name,
+				group_str, grp_retr_mmss,
 				grp->group_specific_query_retransmit_count,
 				grp_retr_sources);
 
@@ -3602,46 +3590,41 @@ static void igmp_show_sources(struct pim_instance *pim, struct vty *vty)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list,
-					  grpnode, grp)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			struct listnode *srcnode;
 			struct igmp_source *src;
 
-			pim_inet4_dump("<group?>", grp->group_addr,
-				       group_str, sizeof(group_str));
+			pim_inet4_dump("<group?>", grp->group_addr, group_str,
+				       sizeof(group_str));
 
 			/* scan group sources */
-			for (ALL_LIST_ELEMENTS_RO(
-				     grp->group_source_list, srcnode,
-				     src)) {
+			for (ALL_LIST_ELEMENTS_RO(grp->group_source_list,
+						  srcnode, src)) {
 				char source_str[INET_ADDRSTRLEN];
 				char mmss[10];
 				char uptime[10];
 
-				pim_inet4_dump(
-					"<source?>", src->source_addr,
-					source_str, sizeof(source_str));
+				pim_inet4_dump("<source?>", src->source_addr,
+					       source_str, sizeof(source_str));
 
-				pim_time_timer_to_mmss(
-					mmss, sizeof(mmss),
-					src->t_source_timer);
+				pim_time_timer_to_mmss(mmss, sizeof(mmss),
+						       src->t_source_timer);
 
-				pim_time_uptime(
-					uptime, sizeof(uptime),
-					now - src->source_creation);
+				pim_time_uptime(uptime, sizeof(uptime),
+						now - src->source_creation);
 
-				vty_out(vty,
-					"%-16s %-15s %-15s %5s %3s %8s\n",
+				vty_out(vty, "%-16s %-15s %-15s %5s %3s %8s\n",
 					ifp->name, group_str, source_str, mmss,
 					IGMP_SOURCE_TEST_FORWARDING(
 						src->source_flags)
-					? "Y"
-					: "N",
+						? "Y"
+						: "N",
 					uptime);
 
 			} /* scan group sources */
-		}	 /* scan igmp groups */
+		}	  /* scan igmp groups */
 	}		  /* scan interfaces */
 }
 
@@ -3663,32 +3646,29 @@ static void igmp_show_source_retransmission(struct pim_instance *pim,
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list,
-					  grpnode, grp)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			struct listnode *srcnode;
 			struct igmp_source *src;
 
-			pim_inet4_dump("<group?>", grp->group_addr,
-				       group_str, sizeof(group_str));
+			pim_inet4_dump("<group?>", grp->group_addr, group_str,
+				       sizeof(group_str));
 
 			/* scan group sources */
-			for (ALL_LIST_ELEMENTS_RO(
-				     grp->group_source_list, srcnode,
-				     src)) {
+			for (ALL_LIST_ELEMENTS_RO(grp->group_source_list,
+						  srcnode, src)) {
 				char source_str[INET_ADDRSTRLEN];
 
-				pim_inet4_dump(
-					"<source?>", src->source_addr,
-					source_str, sizeof(source_str));
+				pim_inet4_dump("<source?>", src->source_addr,
+					       source_str, sizeof(source_str));
 
-				vty_out(vty,
-					"%-16s %-15s %-15s %7d\n",
+				vty_out(vty, "%-16s %-15s %-15s %7d\n",
 					ifp->name, group_str, source_str,
 					src->source_query_retransmit_count);
 
 			} /* scan group sources */
-		}	 /* scan igmp groups */
+		}	  /* scan igmp groups */
 	}		  /* scan interfaces */
 }
 
@@ -3959,8 +3939,7 @@ static void clear_mroute(struct pim_instance *pim)
 
 		if (pim_ifp->igmp_group_list) {
 			while (pim_ifp->igmp_group_list->count) {
-				grp = listnode_head(
-					pim_ifp->igmp_group_list);
+				grp = listnode_head(pim_ifp->igmp_group_list);
 				igmp_group_delete(grp);
 			}
 		}

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -156,14 +156,12 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	PIM_IF_DO_IGMP_LISTEN_ALLROUTERS(pim_ifp->options);
 
 	pim_ifp->igmp_join_list = NULL;
-	pim_ifp->igmp_socket_list = NULL;
 	pim_ifp->pim_neighbor_list = NULL;
 	pim_ifp->upstream_switch_list = NULL;
 	pim_ifp->pim_generation_id = 0;
 
 	/* list of struct igmp_sock */
-	pim_ifp->igmp_socket_list = list_new();
-	pim_ifp->igmp_socket_list->del = (void (*)(void *))igmp_sock_free;
+	pim_igmp_if_init(pim_ifp, ifp);
 
 	/* list of struct pim_neighbor */
 	pim_ifp->pim_neighbor_list = list_new();
@@ -214,7 +212,8 @@ void pim_if_delete(struct interface *ifp)
 	pim_if_del_vif(ifp);
 	pim_ifp->pim->mcast_if_count--;
 
-	list_delete(&pim_ifp->igmp_socket_list);
+	pim_igmp_if_fini(pim_ifp);
+
 	list_delete(&pim_ifp->pim_neighbor_list);
 	list_delete(&pim_ifp->upstream_switch_list);
 	list_delete(&pim_ifp->sec_addr_list);

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -30,6 +30,7 @@
 
 #include "pim_igmp.h"
 #include "pim_upstream.h"
+#include "pim_instance.h"
 #include "bfd.h"
 
 #define PIM_IF_MASK_PIM                             (1 << 0)

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -103,6 +103,8 @@ struct pim_interface {
 	int igmp_last_member_query_count; /* IGMP last member query count */
 	struct list *igmp_socket_list; /* list of struct igmp_sock */
 	struct list *igmp_join_list;   /* list of struct igmp_join */
+	struct list *igmp_group_list;  /* list of struct igmp_group */
+	struct hash *igmp_group_hash;
 
 	int pim_sock_fd;		/* PIM socket file descriptor */
 	struct thread *t_pim_sock_read; /* thread for reading PIM socket */

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -25,6 +25,8 @@
 #include "if.h"
 #include "prefix.h"
 
+#include "pim_assert.h"
+
 struct pim_ifchannel;
 #include "pim_upstream.h"
 
@@ -37,20 +39,6 @@ enum pim_ifjoin_state {
 	PIM_IFJOIN_PRUNE_PENDING,
 	PIM_IFJOIN_PRUNE_TMP,
 	PIM_IFJOIN_PRUNE_PENDING_TMP,
-};
-
-enum pim_ifassert_state {
-	PIM_IFASSERT_NOINFO,
-	PIM_IFASSERT_I_AM_WINNER,
-	PIM_IFASSERT_I_AM_LOSER
-};
-
-struct pim_assert_metric {
-	uint32_t rpt_bit_flag;
-	uint32_t metric_preference;
-	uint32_t route_metric;
-	struct in_addr ip_address; /* neighbor router that sourced the Assert
-				      message */
 };
 
 /*

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -938,11 +938,9 @@ void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp)
 	pim_ifp->igmp_group_list = list_new();
 	pim_ifp->igmp_group_list->del = (void (*)(void *))igmp_group_free;
 
-	snprintf(hash_name, sizeof(hash_name), "IGMP %s hash",
-		 ifp->name);
-	pim_ifp->igmp_group_hash = hash_create(igmp_group_hash_key,
-					       igmp_group_hash_equal,
-					       hash_name);
+	snprintf(hash_name, sizeof(hash_name), "IGMP %s hash", ifp->name);
+	pim_ifp->igmp_group_hash = hash_create(
+		igmp_group_hash_key, igmp_group_hash_equal, hash_name);
 }
 
 void pim_igmp_if_reset(struct pim_interface *pim_ifp)

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -810,13 +810,8 @@ static void igmp_group_free(struct igmp_group *group)
 	XFREE(MTYPE_PIM_IGMP_GROUP, group);
 }
 
-static void igmp_group_count_incr(struct igmp_sock *igmp)
+static void igmp_group_count_incr(struct pim_interface *pim_ifp)
 {
-	struct pim_interface *pim_ifp = igmp->interface->info;
-
-	if (!pim_ifp)
-		return;
-
 	++pim_ifp->pim->igmp_group_count;
 	if (pim_ifp->pim->igmp_group_count
 	    == pim_ifp->pim->igmp_watermark_limit) {
@@ -827,13 +822,8 @@ static void igmp_group_count_incr(struct igmp_sock *igmp)
 	}
 }
 
-static void igmp_group_count_decr(struct igmp_sock *igmp)
+static void igmp_group_count_decr(struct pim_interface *pim_ifp)
 {
-	struct pim_interface *pim_ifp = igmp->interface->info;
-
-	if (!pim_ifp)
-		return;
-
 	if (pim_ifp->pim->igmp_group_count == 0) {
 		zlog_warn("Cannot decrement igmp group count below 0(vrf: %s)",
 			  VRF_LOGNAME(pim_ifp->pim->vrf));
@@ -848,14 +838,14 @@ void igmp_group_delete(struct igmp_group *group)
 	struct listnode *src_node;
 	struct listnode *src_nextnode;
 	struct igmp_source *src;
+	struct pim_interface *pim_ifp = group->interface->info;
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
-		zlog_debug("Deleting IGMP group %s from socket %d interface %s",
-			   group_str, group->group_igmp_sock->fd,
-			   group->group_igmp_sock->interface->name);
+		zlog_debug("Deleting IGMP group %s from interface %s",
+			   group_str, group->interface->name);
 	}
 
 	for (ALL_LIST_ELEMENTS(group->group_source_list, src_node, src_nextnode,
@@ -866,9 +856,9 @@ void igmp_group_delete(struct igmp_group *group)
 	THREAD_OFF(group->t_group_query_retransmit_timer);
 
 	group_timer_off(group);
-	igmp_group_count_decr(group->group_igmp_sock);
-	listnode_delete(group->group_igmp_sock->igmp_group_list, group);
-	hash_release(group->group_igmp_sock->igmp_group_hash, group);
+	igmp_group_count_decr(pim_ifp);
+	listnode_delete(pim_ifp->igmp_group_list, group);
+	hash_release(pim_ifp->igmp_group_hash, group);
 
 	igmp_group_free(group);
 }
@@ -886,11 +876,6 @@ void igmp_sock_free(struct igmp_sock *igmp)
 	assert(!igmp->t_igmp_read);
 	assert(!igmp->t_igmp_query_timer);
 	assert(!igmp->t_other_querier_timer);
-	assert(igmp->igmp_group_list);
-	assert(!listcount(igmp->igmp_group_list));
-
-	list_delete(&igmp->igmp_group_list);
-	hash_free(igmp->igmp_group_hash);
 
 	XFREE(MTYPE_PIM_IGMP_SOCKET, igmp);
 }
@@ -898,14 +883,6 @@ void igmp_sock_free(struct igmp_sock *igmp)
 void igmp_sock_delete(struct igmp_sock *igmp)
 {
 	struct pim_interface *pim_ifp;
-	struct listnode *grp_node;
-	struct listnode *grp_nextnode;
-	struct igmp_group *grp;
-
-	for (ALL_LIST_ELEMENTS(igmp->igmp_group_list, grp_node, grp_nextnode,
-			       grp)) {
-		igmp_group_delete(grp);
-	}
 
 	sock_close(igmp);
 
@@ -914,6 +891,9 @@ void igmp_sock_delete(struct igmp_sock *igmp)
 	listnode_delete(pim_ifp->igmp_socket_list, igmp);
 
 	igmp_sock_free(igmp);
+
+	if (!listcount(pim_ifp->igmp_socket_list))
+		pim_igmp_if_reset(pim_ifp);
 }
 
 void igmp_sock_delete_all(struct interface *ifp)
@@ -948,12 +928,52 @@ static bool igmp_group_hash_equal(const void *arg1, const void *arg2)
 	return false;
 }
 
+void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp)
+{
+	char hash_name[64];
+
+	pim_ifp->igmp_socket_list = list_new();
+	pim_ifp->igmp_socket_list->del = (void (*)(void *))igmp_sock_free;
+
+	pim_ifp->igmp_group_list = list_new();
+	pim_ifp->igmp_group_list->del = (void (*)(void *))igmp_group_free;
+
+	snprintf(hash_name, sizeof(hash_name), "IGMP %s hash",
+		 ifp->name);
+	pim_ifp->igmp_group_hash = hash_create(igmp_group_hash_key,
+					       igmp_group_hash_equal,
+					       hash_name);
+}
+
+void pim_igmp_if_reset(struct pim_interface *pim_ifp)
+{
+	struct listnode *grp_node, *grp_nextnode;
+	struct igmp_group *grp;
+
+	for (ALL_LIST_ELEMENTS(pim_ifp->igmp_group_list, grp_node, grp_nextnode,
+			       grp)) {
+		igmp_group_delete(grp);
+	}
+}
+
+void pim_igmp_if_fini(struct pim_interface *pim_ifp)
+{
+	pim_igmp_if_reset(pim_ifp);
+
+	assert(pim_ifp->igmp_group_list);
+	assert(!listcount(pim_ifp->igmp_group_list));
+
+	list_delete(&pim_ifp->igmp_group_list);
+	hash_free(pim_ifp->igmp_group_hash);
+
+	list_delete(&pim_ifp->igmp_socket_list);
+}
+
 static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 				       struct interface *ifp, int mtrace_only)
 {
 	struct pim_interface *pim_ifp;
 	struct igmp_sock *igmp;
-	char hash_name[64];
 
 	pim_ifp = ifp->info;
 
@@ -964,13 +984,6 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	}
 
 	igmp = XCALLOC(MTYPE_PIM_IGMP_SOCKET, sizeof(*igmp));
-
-	igmp->igmp_group_list = list_new();
-	igmp->igmp_group_list->del = (void (*)(void *))igmp_group_free;
-
-	snprintf(hash_name, sizeof(hash_name), "IGMP %s hash", ifp->name);
-	igmp->igmp_group_hash = hash_create(igmp_group_hash_key,
-					    igmp_group_hash_equal, hash_name);
 
 	igmp->fd = fd;
 	igmp->interface = ifp;
@@ -1114,7 +1127,7 @@ static int igmp_group_timer(struct thread *t)
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
 		zlog_debug("%s: Timer for group %s on interface %s", __func__,
-			   group_str, group->group_igmp_sock->interface->name);
+			   group_str, group->interface->name);
 	}
 
 	assert(group->group_filtermode_isexcl);
@@ -1151,7 +1164,7 @@ static void group_timer_off(struct igmp_group *group)
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
 		zlog_debug("Cancelling TIMER event for group %s on %s",
-			   group_str, group->group_igmp_sock->interface->name);
+			   group_str, group->interface->name);
 	}
 	THREAD_OFF(group->t_group_timer);
 }
@@ -1188,16 +1201,18 @@ struct igmp_group *find_group_by_addr(struct igmp_sock *igmp,
 				      struct in_addr group_addr)
 {
 	struct igmp_group lookup;
+	struct pim_interface *pim_ifp = igmp->interface->info;
 
 	lookup.group_addr.s_addr = group_addr.s_addr;
 
-	return hash_lookup(igmp->igmp_group_hash, &lookup);
+	return hash_lookup(pim_ifp->igmp_group_hash, &lookup);
 }
 
 struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 					  struct in_addr group_addr)
 {
 	struct igmp_group *group;
+	struct pim_interface *pim_ifp = igmp->interface->info;
 
 	group = find_group_by_addr(igmp, group_addr);
 	if (group) {
@@ -1239,7 +1254,7 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 	group->t_group_query_retransmit_timer = NULL;
 	group->group_specific_query_retransmit_count = 0;
 	group->group_addr = group_addr;
-	group->group_igmp_sock = igmp;
+	group->interface = igmp->interface;
 	group->last_igmp_v1_report_dsec = -1;
 	group->last_igmp_v2_report_dsec = -1;
 	group->group_creation = pim_time_monotonic_sec();
@@ -1248,8 +1263,8 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 	/* initialize new group as INCLUDE {empty} */
 	group->group_filtermode_isexcl = 0; /* 0=INCLUDE, 1=EXCLUDE */
 
-	listnode_add(igmp->igmp_group_list, group);
-	group = hash_get(igmp->igmp_group_hash, group, hash_alloc_intern);
+	listnode_add(pim_ifp->igmp_group_list, group);
+	group = hash_get(pim_ifp->igmp_group_hash, group, hash_alloc_intern);
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
@@ -1260,7 +1275,7 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 			group_str, igmp->fd, igmp->interface->name);
 	}
 
-	igmp_group_count_incr(igmp);
+	igmp_group_count_incr(pim_ifp);
 
 	/*
 	  RFC 3376: 6.2.2. Definition of Group Timers

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -99,11 +99,14 @@ struct igmp_sock {
 
 	bool mtrace_only;
 
-	struct list *igmp_group_list; /* list of struct igmp_group */
-	struct hash *igmp_group_hash;
-
 	struct igmp_stats rx_stats;
 };
+
+struct pim_interface;
+
+void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp);
+void pim_igmp_if_reset(struct pim_interface *pim_ifp);
+void pim_igmp_if_fini(struct pim_interface *pim_ifp);
 
 struct igmp_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
 					      struct in_addr ifaddr);
@@ -178,7 +181,7 @@ struct igmp_group {
 	int group_filtermode_isexcl;    /* 0=INCLUDE, 1=EXCLUDE */
 	struct list *group_source_list; /* list of struct igmp_source */
 	time_t group_creation;
-	struct igmp_sock *group_igmp_sock; /* back pointer */
+	struct interface *interface;
 	int64_t last_igmp_v1_report_dsec;
 	int64_t last_igmp_v2_report_dsec;
 };

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -191,15 +191,16 @@ struct igmp_group *find_group_by_addr(struct igmp_sock *igmp,
 struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 					  struct in_addr group_addr);
 
+struct igmp_source *igmp_get_source_by_addr(struct igmp_group *group,
+					    struct in_addr src_addr,
+					    bool *created);
+
 void igmp_group_delete_empty_include(struct igmp_group *group);
 
 void igmp_startup_mode_on(struct igmp_sock *igmp);
 
 void igmp_group_timer_on(struct igmp_group *group, long interval_msec,
 			 const char *ifname);
-
-struct igmp_source *source_new(struct igmp_group *group,
-			       struct in_addr src_addr);
 
 void igmp_send_query(int igmp_version, struct igmp_group *group, int fd,
 		     const char *ifname, char *query_buf, int query_buf_size,

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -198,8 +198,7 @@ static void source_timer_off(struct igmp_group *group,
 			       sizeof(source_str));
 		zlog_debug(
 			"Cancelling TIMER event for group %s source %s on %s",
-			group_str, source_str,
-			group->interface->name);
+			group_str, source_str, group->interface->name);
 	}
 
 	THREAD_OFF(source->t_source_timer);
@@ -362,8 +361,7 @@ void igmp_source_delete(struct igmp_source *source)
 			       sizeof(source_str));
 		zlog_debug(
 			"Deleting IGMP source %s for group %s from interface %s c_oil ref_count %d",
-			source_str, group_str,
-			group->interface->name,
+			source_str, group_str, group->interface->name,
 			source->source_channel_oil
 				? source->source_channel_oil->oil_ref_count
 				: 0);
@@ -994,14 +992,13 @@ static void igmp_send_query_group(struct igmp_group *group, char *query_buf,
 	struct listnode *sock_node;
 
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
-		igmp_send_query(pim_ifp->igmp_version, group, igmp->fd,
-				ifp->name, query_buf, query_buf_size,
-				num_sources, group->group_addr,
-				group->group_addr,
-				pim_ifp->igmp_specific_query_max_response_time_dsec,
-				s_flag,
-				igmp->querier_robustness_variable,
-				igmp->querier_query_interval);
+		igmp_send_query(
+			pim_ifp->igmp_version, group, igmp->fd, ifp->name,
+			query_buf, query_buf_size, num_sources,
+			group->group_addr, group->group_addr,
+			pim_ifp->igmp_specific_query_max_response_time_dsec,
+			s_flag, igmp->querier_robustness_variable,
+			igmp->querier_query_interval);
 	}
 }
 
@@ -1177,10 +1174,9 @@ static int group_retransmit_sources(struct igmp_group *group,
 				  interest.
 				*/
 
-				igmp_send_query_group(group, query_buf1,
-						      sizeof(query_buf1),
-						      num_sources_tosend1,
-						      1 /* s_flag */);
+				igmp_send_query_group(
+					group, query_buf1, sizeof(query_buf1),
+					num_sources_tosend1, 1 /* s_flag */);
 			}
 
 		} /* send_with_sflag_set */
@@ -1214,10 +1210,9 @@ static int group_retransmit_sources(struct igmp_group *group,
 			  interest.
 			*/
 
-			igmp_send_query_group(group, query_buf2,
-					      sizeof(query_buf2),
-					      num_sources_tosend2,
-					      0 /* s_flag */);
+			igmp_send_query_group(
+				group, query_buf2, sizeof(query_buf2),
+				num_sources_tosend2, 0 /* s_flag */);
 		}
 	}
 

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -57,16 +57,28 @@ static void on_trace(const char *label, struct interface *ifp,
 	}
 }
 
+static inline long igmp_gmi_msec(struct igmp_group *group)
+{
+	struct pim_interface *pim_ifp = group->interface->info;
+	struct igmp_sock *igmp;
+	struct listnode *sock_node;
+
+	long qrv = 0, qqi = 0;
+
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+		qrv = MAX(qrv, igmp->querier_robustness_variable);
+		qqi = MAX(qqi, igmp->querier_query_interval);
+	}
+	return PIM_IGMP_GMI_MSEC(qrv, qqi,
+				 pim_ifp->igmp_query_max_response_time_dsec);
+}
+
 void igmp_group_reset_gmi(struct igmp_group *group)
 {
 	long group_membership_interval_msec;
-	struct pim_interface *pim_ifp;
-	struct igmp_sock *igmp;
 	struct interface *ifp;
 
-	igmp = group->group_igmp_sock;
-	ifp = igmp->interface;
-	pim_ifp = ifp->info;
+	ifp = group->interface;
 
 	/*
 	  RFC 3376: 8.4. Group Membership Interval
@@ -82,9 +94,7 @@ void igmp_group_reset_gmi(struct igmp_group *group)
 					   (1000 * querier_query_interval) +
 					   100 * query_response_interval_dsec;
 	*/
-	group_membership_interval_msec = PIM_IGMP_GMI_MSEC(
-		igmp->querier_robustness_variable, igmp->querier_query_interval,
-		pim_ifp->igmp_query_max_response_time_dsec);
+	group_membership_interval_msec = igmp_gmi_msec(group);
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
@@ -127,7 +137,7 @@ static int igmp_source_timer(struct thread *t)
 		zlog_debug(
 			"%s: Source timer expired for group %s source %s on %s",
 			__func__, group_str, source_str,
-			group->group_igmp_sock->interface->name);
+			group->interface->name);
 	}
 
 	/*
@@ -189,7 +199,7 @@ static void source_timer_off(struct igmp_group *group,
 		zlog_debug(
 			"Cancelling TIMER event for group %s source %s on %s",
 			group_str, source_str,
-			group->group_igmp_sock->interface->name);
+			group->interface->name);
 	}
 
 	THREAD_OFF(source->t_source_timer);
@@ -199,7 +209,7 @@ static void igmp_source_timer_on(struct igmp_group *group,
 				 struct igmp_source *source, long interval_msec)
 {
 	source_timer_off(group, source);
-	struct pim_interface *pim_ifp = group->group_igmp_sock->interface->info;
+	struct pim_interface *pim_ifp = group->interface->info;
 
 	if (PIM_DEBUG_IGMP_EVENTS) {
 		char group_str[INET_ADDRSTRLEN];
@@ -211,7 +221,7 @@ static void igmp_source_timer_on(struct igmp_group *group,
 		zlog_debug(
 			"Scheduling %ld.%03ld sec TIMER event for group %s source %s on %s",
 			interval_msec / 1000, interval_msec % 1000, group_str,
-			source_str, group->group_igmp_sock->interface->name);
+			source_str, group->interface->name);
 	}
 
 	thread_add_timer_msec(router->master, igmp_source_timer, source,
@@ -225,19 +235,14 @@ static void igmp_source_timer_on(struct igmp_group *group,
 	igmp_source_forward_start(pim_ifp->pim, source);
 }
 
-void igmp_source_reset_gmi(struct igmp_sock *igmp, struct igmp_group *group,
-			   struct igmp_source *source)
+void igmp_source_reset_gmi(struct igmp_group *group, struct igmp_source *source)
 {
 	long group_membership_interval_msec;
-	struct pim_interface *pim_ifp;
 	struct interface *ifp;
 
-	ifp = igmp->interface;
-	pim_ifp = ifp->info;
+	ifp = group->interface;
 
-	group_membership_interval_msec = PIM_IGMP_GMI_MSEC(
-		igmp->querier_robustness_variable, igmp->querier_query_interval,
-		pim_ifp->igmp_query_max_response_time_dsec);
+	group_membership_interval_msec = igmp_gmi_msec(group);
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
@@ -312,7 +317,7 @@ static void source_clear_send_flag(struct list *source_list)
 */
 static void group_exclude_fwd_anysrc_ifempty(struct igmp_group *group)
 {
-	struct pim_interface *pim_ifp = group->group_igmp_sock->interface->info;
+	struct pim_interface *pim_ifp = group->interface->info;
 
 	assert(group->group_filtermode_isexcl);
 
@@ -356,9 +361,9 @@ void igmp_source_delete(struct igmp_source *source)
 		pim_inet4_dump("<source?>", source->source_addr, source_str,
 			       sizeof(source_str));
 		zlog_debug(
-			"Deleting IGMP source %s for group %s from socket %d interface %s c_oil ref_count %d",
-			source_str, group_str, group->group_igmp_sock->fd,
-			group->group_igmp_sock->interface->name,
+			"Deleting IGMP source %s for group %s from interface %s c_oil ref_count %d",
+			source_str, group_str,
+			group->interface->name,
 			source->source_channel_oil
 				? source->source_channel_oil->oil_ref_count
 				: 0);
@@ -376,10 +381,9 @@ void igmp_source_delete(struct igmp_source *source)
 		pim_inet4_dump("<source?>", source->source_addr, source_str,
 			       sizeof(source_str));
 		zlog_warn(
-			"%s: forwarding=ON(!) IGMP source %s for group %s from socket %d interface %s",
+			"%s: forwarding=ON(!) IGMP source %s for group %s from interface %s",
 			__func__, source_str, group_str,
-			group->group_igmp_sock->fd,
-			group->group_igmp_sock->interface->name);
+			group->interface->name);
 		/* warning only */
 	}
 
@@ -452,9 +456,8 @@ struct igmp_source *source_new(struct igmp_group *group,
 		pim_inet4_dump("<source?>", src_addr, source_str,
 			       sizeof(source_str));
 		zlog_debug(
-			"Creating new IGMP source %s for group %s on socket %d interface %s",
-			source_str, group_str, group->group_igmp_sock->fd,
-			group->group_igmp_sock->interface->name);
+			"Creating new IGMP source %s for group %s on interface %s",
+			source_str, group_str, group->interface->name);
 	}
 
 	src = XCALLOC(MTYPE_PIM_IGMP_GROUP_SOURCE, sizeof(*src));
@@ -518,8 +521,7 @@ static void allow(struct igmp_sock *igmp, struct in_addr from,
 
 				source = igmp_find_source_by_addr(group, star);
 				if (source)
-					igmp_source_reset_gmi(igmp, group,
-							      source);
+					igmp_source_reset_gmi(group, source);
 			}
 		} else {
 			igmp_group_delete(group);
@@ -555,7 +557,7 @@ static void allow(struct igmp_sock *igmp, struct in_addr from,
 		  igmp_source_reset_gmi() below, resetting the source timers to
 		  GMI, accomplishes this.
 		*/
-		igmp_source_reset_gmi(igmp, group, source);
+		igmp_source_reset_gmi(group, source);
 
 	} /* scan received sources */
 }
@@ -598,8 +600,7 @@ static void isex_excl(struct igmp_group *group, int num_sources,
 			 * (A-X-Y) */
 			source = source_new(group, *src_addr);
 			assert(!source->t_source_timer); /* timer == 0 */
-			igmp_source_reset_gmi(group->group_igmp_sock, group,
-					      source);
+			igmp_source_reset_gmi(group, source);
 			assert(source->t_source_timer); /* (A-X-Y) timer > 0 */
 		}
 
@@ -615,8 +616,7 @@ static void isex_excl(struct igmp_group *group, int num_sources,
 		source = igmp_find_source_by_addr(group, star);
 		if (source) {
 			IGMP_SOURCE_DONT_DELETE(source->source_flags);
-			igmp_source_reset_gmi(group->group_igmp_sock, group,
-					      source);
+			igmp_source_reset_gmi(group, source);
 		}
 	}
 
@@ -706,7 +706,6 @@ void igmpv3_report_isex(struct igmp_sock *igmp, struct in_addr from,
 static void toin_incl(struct igmp_group *group, int num_sources,
 		      struct in_addr *sources)
 {
-	struct igmp_sock *igmp = group->group_igmp_sock;
 	int num_sources_tosend = listcount(group->group_source_list);
 	int i;
 
@@ -732,7 +731,7 @@ static void toin_incl(struct igmp_group *group, int num_sources,
 		}
 
 		/* (B)=GMI */
-		igmp_source_reset_gmi(igmp, group, source);
+		igmp_source_reset_gmi(group, source);
 	}
 
 	/* Send sources marked with SEND flag: Q(G,A-B) */
@@ -744,7 +743,6 @@ static void toin_incl(struct igmp_group *group, int num_sources,
 static void toin_excl(struct igmp_group *group, int num_sources,
 		      struct in_addr *sources)
 {
-	struct igmp_sock *igmp = group->group_igmp_sock;
 	int num_sources_tosend;
 	int i;
 
@@ -773,7 +771,7 @@ static void toin_excl(struct igmp_group *group, int num_sources,
 		}
 
 		/* (A)=GMI */
-		igmp_source_reset_gmi(igmp, group, source);
+		igmp_source_reset_gmi(group, source);
 	}
 
 	/* Send sources marked with SEND flag: Q(G,X-A) */
@@ -986,6 +984,27 @@ void igmpv3_report_allow(struct igmp_sock *igmp, struct in_addr from,
 	allow(igmp, from, group_addr, num_sources, sources);
 }
 
+static void igmp_send_query_group(struct igmp_group *group, char *query_buf,
+				  size_t query_buf_size, int num_sources,
+				  int s_flag)
+{
+	struct interface *ifp = group->interface;
+	struct pim_interface *pim_ifp = ifp->info;
+	struct igmp_sock *igmp;
+	struct listnode *sock_node;
+
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+		igmp_send_query(pim_ifp->igmp_version, group, igmp->fd,
+				ifp->name, query_buf, query_buf_size,
+				num_sources, group->group_addr,
+				group->group_addr,
+				pim_ifp->igmp_specific_query_max_response_time_dsec,
+				s_flag,
+				igmp->querier_robustness_variable,
+				igmp->querier_query_interval);
+	}
+}
+
 /*
   RFC3376: 6.6.3.1. Building and Sending Group Specific Queries
 
@@ -995,7 +1014,6 @@ void igmpv3_report_allow(struct igmp_sock *igmp, struct in_addr from,
 */
 static void group_retransmit_group(struct igmp_group *group)
 {
-	struct igmp_sock *igmp;
 	struct pim_interface *pim_ifp;
 	long lmqc;      /* Last Member Query Count */
 	long lmqi_msec; /* Last Member Query Interval */
@@ -1003,8 +1021,7 @@ static void group_retransmit_group(struct igmp_group *group)
 	int s_flag;
 	int query_buf_size;
 
-	igmp = group->group_igmp_sock;
-	pim_ifp = igmp->interface->info;
+	pim_ifp = group->interface->info;
 
 	if (pim_ifp->igmp_version == 3) {
 		query_buf_size = PIM_IGMP_BUFSIZE_WRITE;
@@ -1033,7 +1050,7 @@ static void group_retransmit_group(struct igmp_group *group)
 			       sizeof(group_str));
 		zlog_debug(
 			"retransmit_group_specific_query: group %s on %s: s_flag=%d count=%d",
-			group_str, igmp->interface->name, s_flag,
+			group_str, group->interface->name, s_flag,
 			group->group_specific_query_retransmit_count);
 	}
 
@@ -1045,14 +1062,7 @@ static void group_retransmit_group(struct igmp_group *group)
 	  interest.
 	*/
 
-	igmp_send_query(pim_ifp->igmp_version, group, igmp->fd,
-			igmp->interface->name, query_buf, sizeof(query_buf),
-			0 /* num_sources_tosend */,
-			group->group_addr /* dst_addr */,
-			group->group_addr /* group_addr */,
-			pim_ifp->igmp_specific_query_max_response_time_dsec,
-			s_flag, igmp->querier_robustness_variable,
-			igmp->querier_query_interval);
+	igmp_send_query_group(group, query_buf, sizeof(query_buf), 0, s_flag);
 }
 
 /*
@@ -1070,7 +1080,6 @@ static void group_retransmit_group(struct igmp_group *group)
 static int group_retransmit_sources(struct igmp_group *group,
 				    int send_with_sflag_set)
 {
-	struct igmp_sock *igmp;
 	struct pim_interface *pim_ifp;
 	long lmqc;      /* Last Member Query Count */
 	long lmqi_msec; /* Last Member Query Interval */
@@ -1090,8 +1099,7 @@ static int group_retransmit_sources(struct igmp_group *group,
 	source_addr1 = (struct in_addr *)(query_buf1 + IGMP_V3_SOURCES_OFFSET);
 	source_addr2 = (struct in_addr *)(query_buf2 + IGMP_V3_SOURCES_OFFSET);
 
-	igmp = group->group_igmp_sock;
-	pim_ifp = igmp->interface->info;
+	pim_ifp = group->interface->info;
 
 	lmqc = pim_ifp->igmp_last_member_query_count;
 	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
@@ -1131,7 +1139,7 @@ static int group_retransmit_sources(struct igmp_group *group,
 			       sizeof(group_str));
 		zlog_debug(
 			"retransmit_grp&src_specific_query: group %s on %s: srcs_with_sflag=%d srcs_wo_sflag=%d will_send_sflag=%d retransmit_src_left=%d",
-			group_str, igmp->interface->name, num_sources_tosend1,
+			group_str, group->interface->name, num_sources_tosend1,
 			num_sources_tosend2, send_with_sflag_set,
 			num_retransmit_sources_left);
 	}
@@ -1154,7 +1162,7 @@ static int group_retransmit_sources(struct igmp_group *group,
 				zlog_warn(
 					"%s: group %s on %s: s_flag=1 unable to fit %d sources into buf_size=%zu (max_sources=%d)",
 					__func__, group_str,
-					igmp->interface->name,
+					group->interface->name,
 					num_sources_tosend1, sizeof(query_buf1),
 					query_buf1_max_sources);
 			} else {
@@ -1169,15 +1177,10 @@ static int group_retransmit_sources(struct igmp_group *group,
 				  interest.
 				*/
 
-				igmp_send_query(
-					pim_ifp->igmp_version, group, igmp->fd,
-					igmp->interface->name, query_buf1,
-					sizeof(query_buf1), num_sources_tosend1,
-					group->group_addr, group->group_addr,
-					pim_ifp->igmp_specific_query_max_response_time_dsec,
-					1 /* s_flag */,
-					igmp->querier_robustness_variable,
-					igmp->querier_query_interval);
+				igmp_send_query_group(group, query_buf1,
+						      sizeof(query_buf1),
+						      num_sources_tosend1,
+						      1 /* s_flag */);
 			}
 
 		} /* send_with_sflag_set */
@@ -1197,7 +1200,7 @@ static int group_retransmit_sources(struct igmp_group *group,
 				       sizeof(group_str));
 			zlog_warn(
 				"%s: group %s on %s: s_flag=0 unable to fit %d sources into buf_size=%zu (max_sources=%d)",
-				__func__, group_str, igmp->interface->name,
+				__func__, group_str, group->interface->name,
 				num_sources_tosend2, sizeof(query_buf2),
 				query_buf2_max_sources);
 		} else {
@@ -1211,15 +1214,10 @@ static int group_retransmit_sources(struct igmp_group *group,
 			  interest.
 			*/
 
-			igmp_send_query(
-				pim_ifp->igmp_version, group, igmp->fd,
-				igmp->interface->name, query_buf2,
-				sizeof(query_buf2), num_sources_tosend2,
-				group->group_addr, group->group_addr,
-				pim_ifp->igmp_specific_query_max_response_time_dsec,
-				0 /* s_flag */,
-				igmp->querier_robustness_variable,
-				igmp->querier_query_interval);
+			igmp_send_query_group(group, query_buf2,
+					      sizeof(query_buf2),
+					      num_sources_tosend2,
+					      0 /* s_flag */);
 		}
 	}
 
@@ -1239,7 +1237,7 @@ static int igmp_group_retransmit(struct thread *t)
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
 		zlog_debug("group_retransmit_timer: group %s on %s", group_str,
-			   group->group_igmp_sock->interface->name);
+			   group->interface->name);
 	}
 
 	/* Retransmit group-specific queries? (RFC3376: 6.6.3.1) */
@@ -1287,7 +1285,6 @@ static int igmp_group_retransmit(struct thread *t)
 */
 static void group_retransmit_timer_on(struct igmp_group *group)
 {
-	struct igmp_sock *igmp;
 	struct pim_interface *pim_ifp;
 	long lmqi_msec; /* Last Member Query Interval */
 
@@ -1296,8 +1293,7 @@ static void group_retransmit_timer_on(struct igmp_group *group)
 		return;
 	}
 
-	igmp = group->group_igmp_sock;
-	pim_ifp = igmp->interface->info;
+	pim_ifp = group->interface->info;
 
 	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
 
@@ -1308,7 +1304,7 @@ static void group_retransmit_timer_on(struct igmp_group *group)
 		zlog_debug(
 			"Scheduling %ld.%03ld sec retransmit timer for group %s on %s",
 			lmqi_msec / 1000, lmqi_msec % 1000, group_str,
-			igmp->interface->name);
+			group->interface->name);
 	}
 
 	thread_add_timer_msec(router->master, igmp_group_retransmit, group,
@@ -1332,11 +1328,9 @@ static long igmp_source_timer_remain_msec(struct igmp_source *source)
 static void group_query_send(struct igmp_group *group)
 {
 	struct pim_interface *pim_ifp;
-	struct igmp_sock *igmp;
 	long lmqc; /* Last Member Query Count */
 
-	igmp = group->group_igmp_sock;
-	pim_ifp = igmp->interface->info;
+	pim_ifp = group->interface->info;
 	lmqc = pim_ifp->igmp_last_member_query_count;
 
 	/* lower group timer to lmqt */
@@ -1359,7 +1353,6 @@ static void group_query_send(struct igmp_group *group)
 static void source_query_send_by_flag(struct igmp_group *group,
 				      int num_sources_tosend)
 {
-	struct igmp_sock *igmp;
 	struct pim_interface *pim_ifp;
 	struct listnode *src_node;
 	struct igmp_source *src;
@@ -1369,8 +1362,7 @@ static void source_query_send_by_flag(struct igmp_group *group,
 
 	assert(num_sources_tosend > 0);
 
-	igmp = group->group_igmp_sock;
-	pim_ifp = igmp->interface->info;
+	pim_ifp = group->interface->info;
 
 	lmqc = pim_ifp->igmp_last_member_query_count;
 	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
@@ -1504,7 +1496,6 @@ void igmpv3_report_block(struct igmp_sock *igmp, struct in_addr from,
 
 void igmp_group_timer_lower_to_lmqt(struct igmp_group *group)
 {
-	struct igmp_sock *igmp;
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
 	char *ifname;
@@ -1523,8 +1514,7 @@ void igmp_group_timer_lower_to_lmqt(struct igmp_group *group)
 		return;
 	}
 
-	igmp = group->group_igmp_sock;
-	ifp = igmp->interface;
+	ifp = group->interface;
 	pim_ifp = ifp->info;
 	ifname = ifp->name;
 
@@ -1551,7 +1541,6 @@ void igmp_group_timer_lower_to_lmqt(struct igmp_group *group)
 void igmp_source_timer_lower_to_lmqt(struct igmp_source *source)
 {
 	struct igmp_group *group;
-	struct igmp_sock *igmp;
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
 	char *ifname;
@@ -1560,8 +1549,7 @@ void igmp_source_timer_lower_to_lmqt(struct igmp_source *source)
 	int lmqt_msec; /* Last Member Query Time */
 
 	group = source->source_group;
-	igmp = group->group_igmp_sock;
-	ifp = igmp->interface;
+	ifp = group->interface;
 	pim_ifp = ifp->info;
 	ifname = ifp->name;
 

--- a/pimd/pim_igmpv3.h
+++ b/pimd/pim_igmpv3.h
@@ -54,7 +54,7 @@
 #define PIM_IGMP_OHPI_DSEC(qrv,qqi,qri_dsec) ((qrv) * (10 * (qqi)) + (qri_dsec))
 
 void igmp_group_reset_gmi(struct igmp_group *group);
-void igmp_source_reset_gmi(struct igmp_sock *igmp, struct igmp_group *group,
+void igmp_source_reset_gmi(struct igmp_group *group,
 			   struct igmp_source *source);
 
 void igmp_source_free(struct igmp_source *source);

--- a/pimd/pim_igmpv3.h
+++ b/pimd/pim_igmpv3.h
@@ -23,6 +23,8 @@
 #include <zebra.h>
 #include "if.h"
 
+#include "pim_igmp.h"
+
 #define IGMP_V3_CHECKSUM_OFFSET            (2)
 #define IGMP_V3_REPORT_NUMGROUPS_OFFSET    (6)
 #define IGMP_V3_REPORT_GROUPPRECORD_OFFSET (8)

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -210,6 +210,8 @@ struct pim_instance {
 void pim_vrf_init(void);
 void pim_vrf_terminate(void);
 
+extern struct pim_router *router;
+
 struct pim_instance *pim_get_pim_instance(vrf_id_t vrf_id);
 
 #endif

--- a/pimd/pim_mroute.h
+++ b/pimd/pim_mroute.h
@@ -167,6 +167,8 @@ struct igmpmsg {
   Above: from <linux/mroute.h>
 */
 
+struct channel_oil;
+
 int pim_mroute_socket_enable(struct pim_instance *pim);
 int pim_mroute_socket_disable(struct pim_instance *pim);
 

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -23,6 +23,7 @@
 #include "pim_nb.h"
 #include "lib/northbound_cli.h"
 #include "pim_igmpv3.h"
+#include "pim_neighbor.h"
 #include "pim_pim.h"
 #include "pim_mlag.h"
 #include "pim_bfd.h"

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -105,7 +105,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 			}
 
 		} /* scan group sources */
-	}        /* scan igmp groups */
+	}	  /* scan igmp groups */
 
 	/*
 	 * Finally delete every PIM (S,G) entry lacking all state info
@@ -483,8 +483,8 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 			igmp_group_reset_gmi(grp);
 
 		/* scan group sources */
-		for (ALL_LIST_ELEMENTS_RO(grp->group_source_list,
-					src_node, src)) {
+		for (ALL_LIST_ELEMENTS_RO(grp->group_source_list, src_node,
+					  src)) {
 
 			/* reset source timers for sources with running
 			 * timers

--- a/pimd/pim_neighbor.h
+++ b/pimd/pim_neighbor.h
@@ -27,6 +27,7 @@
 #include "prefix.h"
 
 #include "pim_tlv.h"
+#include "pim_iface.h"
 
 struct pim_neighbor {
 	int64_t creation; /* timestamp of creation */

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -20,8 +20,9 @@
 #ifndef PIM_OIL_H
 #define PIM_OIL_H
 
+struct pim_interface;
+
 #include "pim_mroute.h"
-#include "pim_iface.h"
 
 /*
  * Where did we get this (S,G) from?

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -42,7 +42,7 @@
 #include "pim_rpf.h"
 #include "pim_sock.h"
 #include "pim_memory.h"
-#include "pim_iface.h"
+#include "pim_neighbor.h"
 #include "pim_msdp.h"
 #include "pim_nht.h"
 #include "pim_mroute.h"

--- a/pimd/pim_rp.h
+++ b/pimd/pim_rp.h
@@ -24,8 +24,9 @@
 #include "prefix.h"
 #include "vty.h"
 #include "plist.h"
-#include "pim_iface.h"
 #include "pim_rpf.h"
+
+struct pim_interface;
 
 enum rp_source {
 	RP_SRC_NONE = 0,

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -31,6 +31,7 @@
 #include "pim_pim.h"
 #include "pim_str.h"
 #include "pim_iface.h"
+#include "pim_neighbor.h"
 #include "pim_zlookup.h"
 #include "pim_ifchannel.h"
 #include "pim_time.h"

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -22,9 +22,6 @@
 
 #include <zebra.h>
 
-#include "pim_upstream.h"
-#include "pim_neighbor.h"
-
 /*
   RFC 4601:
 

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -24,7 +24,7 @@
 #include <prefix.h>
 #include "plist.h"
 
-#include <pimd/pim_rpf.h>
+#include "pim_rpf.h"
 #include "pim_str.h"
 #include "pim_ifchannel.h"
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -474,7 +474,7 @@ void igmp_anysource_forward_start(struct pim_instance *pim,
 	assert(group->group_filtermode_isexcl);
 	assert(listcount(group->group_source_list) < 1);
 
-	source = source_new(group, src_addr);
+	source = igmp_get_source_by_addr(group, src_addr, NULL);
 	if (!source) {
 		zlog_warn("%s: Failure to create * source", __func__);
 		return;

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -517,8 +517,8 @@ static void igmp_source_forward_reevaluate_one(struct pim_instance *pim,
 				zlog_debug(
 					"local membership del for %s as G is now SSM",
 					pim_str_sg_dump(&sg));
-			pim_ifchannel_local_membership_del(
-				group->interface, &sg);
+			pim_ifchannel_local_membership_del(group->interface,
+							   &sg);
 		}
 	} else {
 		/* If ASM group add local membership */
@@ -529,8 +529,7 @@ static void igmp_source_forward_reevaluate_one(struct pim_instance *pim,
 					"local membership add for %s as G is now ASM",
 					pim_str_sg_dump(&sg));
 			pim_ifchannel_local_membership_add(
-				group->interface, &sg,
-				false /*is_vxlan*/);
+				group->interface, &sg, false /*is_vxlan*/);
 		}
 	}
 }
@@ -557,8 +556,8 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 			for (ALL_LIST_ELEMENTS_RO(grp->group_source_list,
 						  srcnode, src)) {
 				igmp_source_forward_reevaluate_one(pim, src);
-			} /* scan group sources */
-		}	 /* scan igmp groups */
+			}	  /* scan group sources */
+		}		  /* scan igmp groups */
 	}			  /* scan interfaces */
 }
 
@@ -576,11 +575,10 @@ void igmp_source_forward_start(struct pim_instance *pim,
 	sg.grp = source->source_group->group_addr;
 
 	if (PIM_DEBUG_IGMP_TRACE) {
-		zlog_debug(
-			"%s: (S,G)=%s oif=%s fwd=%d", __func__,
-			pim_str_sg_dump(&sg),
-			source->source_group->interface->name,
-			IGMP_SOURCE_TEST_FORWARDING(source->source_flags));
+		zlog_debug("%s: (S,G)=%s oif=%s fwd=%d", __func__,
+			   pim_str_sg_dump(&sg),
+			   source->source_group->interface->name,
+			   IGMP_SOURCE_TEST_FORWARDING(source->source_flags));
 	}
 
 	/* Prevent IGMP interface from installing multicast route multiple
@@ -726,16 +724,15 @@ void igmp_source_forward_start(struct pim_instance *pim,
 	  Feed IGMPv3-gathered local membership information into PIM
 	  per-interface (S,G) state.
 	 */
-	if (!pim_ifchannel_local_membership_add(
-						group->interface, &sg,
+	if (!pim_ifchannel_local_membership_add(group->interface, &sg,
 						false /*is_vxlan*/)) {
 		if (PIM_DEBUG_MROUTE)
 			zlog_warn("%s: Failure to add local membership for %s",
 				  __func__, pim_str_sg_dump(&sg));
 
 		pim_channel_del_oif(source->source_channel_oil,
-				    group->interface,
-				    PIM_OIF_FLAG_PROTO_IGMP, __func__);
+				    group->interface, PIM_OIF_FLAG_PROTO_IGMP,
+				    __func__);
 		return;
 	}
 
@@ -757,11 +754,10 @@ void igmp_source_forward_stop(struct igmp_source *source)
 	sg.grp = source->source_group->group_addr;
 
 	if (PIM_DEBUG_IGMP_TRACE) {
-		zlog_debug(
-			"%s: (S,G)=%s oif=%s fwd=%d", __func__,
-			pim_str_sg_dump(&sg),
-			source->source_group->interface->name,
-			IGMP_SOURCE_TEST_FORWARDING(source->source_flags));
+		zlog_debug("%s: (S,G)=%s oif=%s fwd=%d", __func__,
+			   pim_str_sg_dump(&sg),
+			   source->source_group->interface->name,
+			   IGMP_SOURCE_TEST_FORWARDING(source->source_flags));
 	}
 
 	/* Prevent IGMP interface from removing multicast route multiple
@@ -784,9 +780,8 @@ void igmp_source_forward_stop(struct igmp_source *source)
 	 pim_forward_stop below.
 	*/
 	result = pim_channel_del_oif(source->source_channel_oil,
-				     group->interface,
-					 PIM_OIF_FLAG_PROTO_IGMP,
-					 __func__);
+				     group->interface, PIM_OIF_FLAG_PROTO_IGMP,
+				     __func__);
 	if (result) {
 		if (PIM_DEBUG_IGMP_TRACE)
 			zlog_debug(

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -31,6 +31,7 @@
 
 #include "pimd.h"
 #include "pim_iface.h"
+#include "pim_neighbor.h"
 #include "pim_pim.h"
 #include "pim_str.h"
 #include "pim_oil.h"

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -136,7 +136,6 @@ extern const char *const PIM_ALL_ROUTERS;
 extern const char *const PIM_ALL_PIM_ROUTERS;
 extern const char *const PIM_ALL_IGMP_ROUTERS;
 
-extern struct pim_router *router;
 extern struct zebra_privs_t pimd_privs;
 extern struct in_addr qpim_all_pim_routers_addr;
 extern uint8_t qpim_ecmp_enable;


### PR DESCRIPTION
Larger change:  IGMP group/source memberships moved from the IGMP socket (which is per-IPv4-addr on each interface) to the whole interface.  Keeping memberships on the querier is just plain wrong;  multicast happens on the entire link, not on each IPv4 subnet.  (Primarily relevant when you have multiple non-overlapping IPv4 subnets on 1 interface.  There's no way to associate the traffic to a specific subnet.)  Moving this also just cuts 1 unnecessary level of indirection from the picture, making the code a bit simpler.

Smaller changes:
* made the include files a bit less crossdependent (it's still bad, but not as bad as before.)
* refactored IGMP source creation/allocation to be simpler and more flexible (need to add ACLs and limit counts)

This PR is intended to only have functional impact in a very specific scenario:  when IPv4 addresses are added/deleted on an interface, IGMP group memberships would've been cleared before when the querier was deleted.  They now stick around as long as there is *any* IPv4 address.  (Deleting the last address still flushes all membership data.)