### PR TITLE
bgpd: fix uninitialised segs6 buffer

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1543,6 +1543,7 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 
 			label_buf[0] = '\0';
 			eth_buf[0] = '\0';
+			segs_buf[0] = '\0';
 			if (has_valid_label
 			    && !CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE))
 				snprintf(label_buf, sizeof(label_buf),


### PR DESCRIPTION
Below dump may be observed when receiving bgp ipv6 updates.

2021/08/25 16:52:32 BGP: [V15FP-4CPVK] Tx route add VRF 0 4004::1/128 metric 0 tag 0 count 1 nhg 0
2021/08/25 16:52:32 BGP: [JQXM8-V0CKB]   nhop [1]: 2003::4 if 0 VRF 0 wt 0  P8�o�

Fix it.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>