### PR TITLE
ospf6d: add support for NSSA totally stub areas

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -176,9 +176,9 @@ OSPF6 area
     The `not-advertise` option, when present, prevents the summary route from
     being advertised, effectively filtering the summarized routes.
 
-.. clicmd:: area A.B.C.D nssa
+.. clicmd:: area A.B.C.D nssa [no-summary]
 
-.. clicmd:: area (0-4294967295) nssa
+.. clicmd:: area (0-4294967295) nssa [no-summary]
 
    Configure the area to be a NSSA (Not-So-Stubby Area).
 
@@ -193,6 +193,10 @@ OSPF6 area
       Type-5 LSA is enabled by default.
    4. Support for NSSA Translator functionality when there are multiple NSSA
       ABR in an area.
+
+   An NSSA ABR can be configured with the `no-summary` option to prevent the
+   advertisement of summaries into the area. In that case, a single Type-3 LSA
+   containing a default route is originated into the NSSA.
 
 .. _ospf6-interface:
 

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -92,6 +92,7 @@ ospf6d_ospf6d_snmp_la_LIBADD = lib/libfrrsnmp.la
 
 clippy_scan += \
 	ospf6d/ospf6_top.c \
+	ospf6d/ospf6_area.c \
 	ospf6d/ospf6_asbr.c \
 	ospf6d/ospf6_lsa.c \
 	ospf6d/ospf6_gr_helper.c \


### PR DESCRIPTION
Add a knob to turn an NSSA area into a totally stub area. In this configuration, a Type-3 default summary route is generated by default.

Syntax: `area A.B.C.D nssa no-summary`.

Example:
```
router ospf6
 area A.B.C.D nssa no-summary
!
```

Note: different from stub areas, NSSA areas can have Type-7 external routes redistributed in from another routing domain. And among those external routes there might be a default route, which can conflict with the ABR default route if one exists. For this reason, the NSSA RFC specifies that an NSSA ABR should advertise a Type-3 default route **only** when summary routes aren't imported into the NSSA (i.e. totally stub NSSA). _ospfd_ violates that part of the spec since an NSSA ABR announces a Type-3 default route regardless if the "no-summary" option is configured or not. That gives operators little leeway to manipulate default routes according to business needs. In this PR I decided to make ospf6d comply to the NSSA specification instead of mirroring ospfd's behavior, which probably needs to be fixed at some point.