### PR TITLE
pimd: fix coverity/dead-code issue

### DIFF
--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -509,8 +509,19 @@ static void allow(struct igmp_sock *igmp, struct in_addr from,
 		  So, deleting the group present.
 		*/
 		group = find_group_by_addr(igmp, group_addr);
-		if (group && (group->group_filtermode_isexcl == 0))
-			igmp_group_delete(group);
+		if (group) {
+			if (group->group_filtermode_isexcl) {
+				if (listcount(group->group_source_list) == 1) {
+					struct in_addr star = {.s_addr = INADDR_ANY};
+					source = igmp_find_source_by_addr(group, star);
+					if (source)
+						igmp_source_reset_gmi(igmp, group, source);
+				}
+			}
+			else
+				igmp_group_delete(group);
+		}
+
 		return;
 	}
 
@@ -544,15 +555,6 @@ static void allow(struct igmp_sock *igmp, struct in_addr from,
 		igmp_source_reset_gmi(igmp, group, source);
 
 	} /* scan received sources */
-
-	if ((num_sources == 0) && (group->group_filtermode_isexcl)
-	    && (listcount(group->group_source_list) == 1)) {
-		struct in_addr star = {.s_addr = INADDR_ANY};
-
-		source = igmp_find_source_by_addr(group, star);
-		if (source)
-			igmp_source_reset_gmi(igmp, group, source);
-	}
 }
 
 void igmpv3_report_isin(struct igmp_sock *igmp, struct in_addr from,


### PR DESCRIPTION
PR #9435 introduced an `if` statement that caused some code to be unreachable. 
Move the unreachable code and handle it in the same `if` at the top of the function. 

Note that the moved code followed a call to 
```
igmp_add_group_by_addr(igmp, group_addr)
```
whereas the new moved code follows a call to
```
find_group_by_addr(igmp, group_addr)
```
The result however should be the same since adding a new group with empty source
list will default to INCLUDE (`group_filtermode_isexcl == 0`). If the group already exists
and it is to exclude mode the moved code works as before.

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>