### PR TITLE
bgpd: fix update-source for ipv6

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -838,6 +838,12 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 			if (direct)
 				v6_ll_avail = if_get_ipv6_local(
 					ifp, &nexthop->v6_local);
+			/*
+			 * It's fine to not have a v6 LL when using
+			 * update-source loopback/vrf
+			 */
+			if (!v6_ll_avail && if_is_loopback_or_vrf(ifp))
+				v6_ll_avail = true;
 		} else
 		/* Link-local address. */
 		{


### PR DESCRIPTION
There's no IPv6 LL address on loopback/vrf interfaces. So if the user
configures update-source, the session is never going to be established.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>