### PR TITLE
isisd: Fix sending of LSP with null seqno

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -641,7 +641,7 @@ void lsp_insert(struct lspdb_head *head, struct isis_lsp *lsp)
 }
 
 /*
- * Build a list of LSPs with non-zero ht bounded by start and stop ids
+ * Build a list of LSPs with non-zero ht and seqno bounded by start and stop ids
  */
 void lsp_build_list_nonzero_ht(struct lspdb_head *head, const uint8_t *start_id,
 			       const uint8_t *stop_id, struct list *list)
@@ -657,7 +657,7 @@ void lsp_build_list_nonzero_ht(struct lspdb_head *head, const uint8_t *start_id,
 			   ISIS_SYS_ID_LEN + 2) > 0)
 			break;
 
-		if (lsp->hdr.rem_lifetime)
+		if (lsp->hdr.rem_lifetime && lsp->hdr.seqno)
 			listnode_add(list, lsp);
 	}
 }

--- a/tests/isisd/test_isis_lspdb.c
+++ b/tests/isisd/test_isis_lspdb.c
@@ -23,15 +23,15 @@ static void test_lsp_build_list_nonzero_ht(void)
 	struct lspdb_head _lspdb, *lspdb = &_lspdb;
 	lsp_db_init(&_lspdb);
 
-	struct isis_lsp *lsp1 = lsp_new(area, lsp_id1, 6000, 0, 0, 0, NULL,
-					ISIS_LEVEL2);
+	struct isis_lsp *lsp1 =
+		lsp_new(area, lsp_id1, 6000, 1, 0, 0, NULL, ISIS_LEVEL2);
 
-	lsp_insert(lspdb, lsp1);
+	lspdb_add(lspdb, lsp1);
 
-	struct isis_lsp *lsp2 = lsp_new(area, lsp_id2, 6000, 0, 0, 0, NULL,
-					ISIS_LEVEL2);
+	struct isis_lsp *lsp2 =
+		lsp_new(area, lsp_id2, 6000, 1, 0, 0, NULL, ISIS_LEVEL2);
 
-	lsp_insert(lspdb, lsp2);
+	lspdb_add(lspdb, lsp2);
 
 	struct list *list = list_new();
 


### PR DESCRIPTION
This is used to fix #8755 

It checks sequence number is not null when building LSP missing in received CSNP.