### PR TITLE
lib, vtysh: make node-processing code more generic 

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -852,96 +852,13 @@ char **cmd_complete_command(vector vline, struct vty *vty, int *status)
 /* MUST eventually converge on CONFIG_NODE */
 enum node_type node_parent(enum node_type node)
 {
-	enum node_type ret;
+	struct cmd_node *cnode;
 
 	assert(node > CONFIG_NODE);
 
-	switch (node) {
-	case BGP_VPNV4_NODE:
-	case BGP_VPNV6_NODE:
-	case BGP_FLOWSPECV4_NODE:
-	case BGP_FLOWSPECV6_NODE:
-	case BGP_VRF_POLICY_NODE:
-	case BGP_VNC_DEFAULTS_NODE:
-	case BGP_VNC_NVE_GROUP_NODE:
-	case BGP_VNC_L2_GROUP_NODE:
-	case BGP_IPV4_NODE:
-	case BGP_IPV4M_NODE:
-	case BGP_IPV4L_NODE:
-	case BGP_IPV6_NODE:
-	case BGP_IPV6M_NODE:
-	case BGP_EVPN_NODE:
-	case BGP_IPV6L_NODE:
-	case BMP_NODE:
-		ret = BGP_NODE;
-		break;
-	case BGP_EVPN_VNI_NODE:
-		ret = BGP_EVPN_NODE;
-		break;
-	case KEYCHAIN_KEY_NODE:
-		ret = KEYCHAIN_NODE;
-		break;
-	case LINK_PARAMS_NODE:
-		ret = INTERFACE_NODE;
-		break;
-	case LDP_IPV4_NODE:
-	case LDP_IPV6_NODE:
-		ret = LDP_NODE;
-		break;
-	case LDP_IPV4_IFACE_NODE:
-		ret = LDP_IPV4_NODE;
-		break;
-	case LDP_IPV6_IFACE_NODE:
-		ret = LDP_IPV6_NODE;
-		break;
-	case LDP_PSEUDOWIRE_NODE:
-		ret = LDP_L2VPN_NODE;
-		break;
-	case BFD_PEER_NODE:
-		ret = BFD_NODE;
-		break;
-	case BFD_PROFILE_NODE:
-		ret = BFD_NODE;
-		break;
-	case SR_TRAFFIC_ENG_NODE:
-		ret = SEGMENT_ROUTING_NODE;
-		break;
-	case SR_SEGMENT_LIST_NODE:
-		ret = SR_TRAFFIC_ENG_NODE;
-		break;
-	case SR_POLICY_NODE:
-		ret = SR_TRAFFIC_ENG_NODE;
-		break;
-	case SR_CANDIDATE_DYN_NODE:
-		ret = SR_POLICY_NODE;
-		break;
-	case PCEP_NODE:
-		ret = SR_TRAFFIC_ENG_NODE;
-		break;
-	case PCEP_PCE_CONFIG_NODE:
-		ret = PCEP_NODE;
-		break;
-	case PCEP_PCE_NODE:
-		ret = PCEP_NODE;
-		break;
-	case PCEP_PCC_NODE:
-		ret = PCEP_NODE;
-		break;
-	case SRV6_NODE:
-		ret = SEGMENT_ROUTING_NODE;
-		break;
-	case SRV6_LOCS_NODE:
-		ret = SRV6_NODE;
-		break;
-	case SRV6_LOC_NODE:
-		ret = SRV6_LOCS_NODE;
-		break;
-	default:
-		ret = CONFIG_NODE;
-		break;
-	}
+	cnode = vector_lookup(cmdvec, node);
 
-	return ret;
+	return cnode->parent_node;
 }
 
 /* Execute command by argument vline vector. */

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -509,51 +509,8 @@ static int vtysh_execute_func(const char *line, int pager)
 	 */
 	if (ret == CMD_SUCCESS || ret == CMD_SUCCESS_DAEMON
 	    || ret == CMD_WARNING) {
-		if ((saved_node == BGP_VPNV4_NODE
-		     || saved_node == BGP_VPNV6_NODE
-		     || saved_node == BGP_IPV4_NODE
-		     || saved_node == BGP_IPV6_NODE
-		     || saved_node == BGP_FLOWSPECV4_NODE
-		     || saved_node == BGP_FLOWSPECV6_NODE
-		     || saved_node == BGP_IPV4M_NODE
-		     || saved_node == BGP_IPV4L_NODE
-		     || saved_node == BGP_IPV6L_NODE
-		     || saved_node == BGP_IPV6M_NODE
-		     || saved_node == BGP_EVPN_NODE
-		     || saved_node == LDP_IPV4_NODE
-		     || saved_node == LDP_IPV6_NODE)
-		    && (tried == 1)) {
-			vtysh_execute("exit-address-family");
-		} else if ((saved_node == BGP_EVPN_VNI_NODE) && (tried == 1)) {
-			vtysh_execute("exit-vni");
-		} else if (saved_node == BGP_VRF_POLICY_NODE && (tried == 1)) {
-			vtysh_execute("exit-vrf-policy");
-		} else if ((saved_node == BGP_VNC_DEFAULTS_NODE
-			    || saved_node == BGP_VNC_NVE_GROUP_NODE
-			    || saved_node == BGP_VNC_L2_GROUP_NODE)
-			   && (tried == 1)) {
-			vtysh_execute("exit-vnc");
-		} else if (saved_node == VRF_NODE && (tried == 1)) {
-			vtysh_execute("exit-vrf");
-		} else if ((saved_node == KEYCHAIN_KEY_NODE
-			    || saved_node == LDP_PSEUDOWIRE_NODE
-			    || saved_node == LDP_IPV4_IFACE_NODE
-			    || saved_node == LDP_IPV6_IFACE_NODE)
-			   && (tried == 1)) {
+		while (tried-- > 0)
 			vtysh_execute("exit");
-		} else if ((saved_node == SR_SEGMENT_LIST_NODE
-			    || saved_node == SR_POLICY_NODE
-			    || saved_node == SR_CANDIDATE_DYN_NODE
-			    || saved_node == PCEP_NODE
-			    || saved_node == PCEP_PCE_CONFIG_NODE
-			    || saved_node == PCEP_PCE_NODE
-			    || saved_node == PCEP_PCC_NODE)
-			   && (tried > 0)) {
-			vtysh_execute("exit");
-		} else if (tried) {
-			vtysh_execute("end");
-			vtysh_execute("configure");
-		}
 	}
 	/*
 	 * If command didn't succeed in any node, continue with return value
@@ -701,7 +658,6 @@ int vtysh_mark_file(const char *filename)
 	int ret;
 	vector vline;
 	int tried = 0;
-	bool ending;
 	const struct cmd_element *cmd;
 	int saved_ret, prev_node;
 	int lineno = 0;
@@ -733,35 +689,6 @@ int vtysh_mark_file(const char *filename)
 		tried = 0;
 		strlcpy(vty_buf_copy, vty->buf, VTY_BUFSIZ);
 		vty_buf_trimmed = trim(vty_buf_copy);
-
-		switch (vty->node) {
-		case LDP_IPV4_IFACE_NODE:
-			if (strncmp(vty_buf_copy, "   ", 3)) {
-				vty_out(vty, " exit-ldp-if\n");
-				vty->node = LDP_IPV4_NODE;
-			}
-			break;
-		case LDP_IPV6_IFACE_NODE:
-			if (strncmp(vty_buf_copy, "   ", 3)) {
-				vty_out(vty, " exit-ldp-if\n");
-				vty->node = LDP_IPV6_NODE;
-			}
-			break;
-		case LDP_PSEUDOWIRE_NODE:
-			if (strncmp(vty_buf_copy, "  ", 2)) {
-				vty_out(vty, " exit\n");
-				vty->node = LDP_L2VPN_NODE;
-			}
-			break;
-		case SR_CANDIDATE_DYN_NODE:
-			if (strncmp(vty_buf_copy, "  ", 2)) {
-				vty_out(vty, " exit\n");
-				vty->node = SR_POLICY_NODE;
-			}
-			break;
-		default:
-			break;
-		}
 
 		if (vty_buf_trimmed[0] == '!' || vty_buf_trimmed[0] == '#') {
 			vty_out(vty, "%s", vty->buf);
@@ -810,57 +737,8 @@ int vtysh_mark_file(const char *filename)
 		 */
 		if (ret == CMD_SUCCESS || ret == CMD_SUCCESS_DAEMON
 		    || ret == CMD_WARNING) {
-			if ((prev_node == BGP_VPNV4_NODE
-			     || prev_node == BGP_VPNV6_NODE
-			     || prev_node == BGP_IPV4_NODE
-			     || prev_node == BGP_IPV6_NODE
-			     || prev_node == BGP_FLOWSPECV4_NODE
-			     || prev_node == BGP_FLOWSPECV6_NODE
-			     || prev_node == BGP_IPV4L_NODE
-			     || prev_node == BGP_IPV6L_NODE
-			     || prev_node == BGP_IPV4M_NODE
-			     || prev_node == BGP_IPV6M_NODE
-			     || prev_node == BGP_EVPN_NODE)
-			    && (tried == 1)) {
-				vty_out(vty, "exit-address-family\n");
-			} else if ((prev_node == BGP_EVPN_VNI_NODE)
-				   && (tried == 1)) {
-				vty_out(vty, "exit-vni\n");
-			} else if ((prev_node == KEYCHAIN_KEY_NODE)
-				   && (tried == 1)) {
+			while (tried-- > 0)
 				vty_out(vty, "exit\n");
-			} else if ((prev_node == BFD_PEER_NODE
-				    || prev_node == BFD_PROFILE_NODE)
-				   && (tried == 1)) {
-				vty_out(vty, "exit\n");
-			} else if (((prev_node == SEGMENT_ROUTING_NODE)
-				    || (prev_node == SR_TRAFFIC_ENG_NODE)
-				    || (prev_node == SR_SEGMENT_LIST_NODE)
-				    || (prev_node == SR_POLICY_NODE)
-				    || (prev_node == SR_CANDIDATE_DYN_NODE)
-				    || (prev_node == PCEP_NODE)
-				    || (prev_node == PCEP_PCE_CONFIG_NODE)
-				    || (prev_node == PCEP_PCE_NODE)
-				    || (prev_node == PCEP_PCC_NODE))
-				   && (tried > 0)) {
-				ending = (vty->node != SEGMENT_ROUTING_NODE)
-					 && (vty->node != SR_TRAFFIC_ENG_NODE)
-					 && (vty->node != SR_SEGMENT_LIST_NODE)
-					 && (vty->node != SR_POLICY_NODE)
-					 && (vty->node != SR_CANDIDATE_DYN_NODE)
-					 && (vty->node != PCEP_NODE)
-					 && (vty->node != PCEP_PCE_CONFIG_NODE)
-					 && (vty->node != PCEP_PCE_NODE)
-					 && (vty->node != PCEP_PCC_NODE);
-				if (ending)
-					tried--;
-				while (tried-- > 0)
-					vty_out(vty, "exit\n");
-				if (ending)
-					vty_out(vty, "end\n");
-			} else if (tried) {
-				vty_out(vty, "end\n");
-			}
 		}
 		/*
 		 * If command didn't succeed in any node, continue with return


### PR DESCRIPTION
Clean up a couple of places to use generic code instead of listing every node we have.