### PR TITLE
lib: Send c-bit when not using bfdd as daemon of choice

### DIFF
--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -366,6 +366,9 @@ int zclient_bfd_command(struct zclient *zc, struct bfd_session_arg *args)
 		if (args->ifnamelen)
 			stream_put(s, args->ifname, args->ifnamelen);
 	}
+
+	/* Send the C bit indicator. */
+	stream_putc(s, args->cbit);
 #endif /* HAVE_BFDD */
 
 	/* Finish the message by writing the size. */


### PR DESCRIPTION
Commit: 4b983eef2cb5c7306a8303f002d0e053ebeabdca

Modified the zapi send receive of the c-bit to only
be under the HAVE_BFDD.  If you are using ptm-bfd
then the decoder function still expects this to be
sent down.  This commit puts this behavior back

Signed-off-by: Donald Sharp <sharpd@nvidia.com>