### PR TITLE
zebra: add mpls configuration knob per interface

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -168,6 +168,12 @@ Standard Commands
    configuration.
 
 
+.. clicmd:: mpls
+
+
+   Enable or disables incoming mpls traffic for the interface.
+
+
 .. clicmd:: link-detect
 
 

--- a/lib/mpls.c
+++ b/lib/mpls.c
@@ -98,3 +98,35 @@ char *mpls_label2str(uint8_t num_labels, const mpls_label_t *labels, char *buf,
 
 	return buf;
 }
+
+int mpls_interface_set(const char *name, bool val)
+{
+	char buf[MAXPATHLEN];
+	FILE *fp;
+	int ret = 0, mplsinput = 0;
+
+	snprintf(buf, sizeof(buf), "/proc/sys/net/mpls/conf/%s/input", name);
+	fp = fopen(buf, "w");
+	if (fp == NULL)
+		return -1;
+	fprintf(fp, "%d\n", !!val);
+	fclose(fp);
+
+	fp = fopen(buf, "r");
+	if (fp == NULL)
+		return -1;
+
+	/* Read mpls/input value
+	 * 1 => mpls input is enabled.
+	 * 0 => mpls input is disabled.
+	 */
+	if (!fgets(buf, 2, fp))
+		return -1;
+	ret = sscanf(buf, "%d\n", &mplsinput);
+
+	fclose(fp);
+
+	if (ret != 1)
+		return -1;
+	return mplsinput;
+}

--- a/lib/mpls.h
+++ b/lib/mpls.h
@@ -219,6 +219,9 @@ int mpls_str2label(const char *label_str, uint8_t *num_labels,
 char *mpls_label2str(uint8_t num_labels, const mpls_label_t *labels, char *buf,
 		     int len, int pretty);
 
+/* this function is used to disable or enable mpls per interface */
+extern int mpls_interface_set(const char *name, bool val);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -33,6 +33,7 @@
 #include "log.h"
 #include "zclient.h"
 #include "vrf.h"
+#include "mpls.h"
 
 #include "zebra/rtadv.h"
 #include "zebra_ns.h"
@@ -61,8 +62,10 @@ DEFINE_HOOK(zebra_if_extra_info, (struct vty * vty, struct interface *ifp),
 DEFINE_HOOK(zebra_if_config_wr, (struct vty * vty, struct interface *ifp),
 	    (vty, ifp));
 
+extern struct zebra_privs_t zserv_privs;
 
 static void if_down_del_nbr_connected(struct interface *ifp);
+static void mpls_enable_if_set(struct interface *ifp);
 
 static int if_zebra_speed_update(struct thread *thread)
 {
@@ -131,6 +134,7 @@ static int if_zebra_new_hook(struct interface *ifp)
 
 	zebra_if->multicast = IF_ZEBRA_MULTICAST_UNSPEC;
 	zebra_if->shutdown = IF_ZEBRA_SHUTDOWN_OFF;
+	zebra_if->mpls = IF_ZEBRA_MPLS_UNSPEC;
 
 	zebra_if_nhg_dependents_init(zebra_if);
 
@@ -603,6 +607,9 @@ void if_add_update(struct interface *ifp)
 	zebra_ptm_if_set_ptm_state(ifp, if_data);
 
 	zebra_interface_add_update(ifp);
+
+	if (if_data->mpls != IF_ZEBRA_MPLS_UNSPEC)
+		mpls_enable_if_set(ifp);
 
 	if (!CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
 		SET_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE);
@@ -3758,6 +3765,54 @@ DEFUN (no_ip_address,
 				    NULL, NULL);
 }
 
+static void mpls_enable_if_set(struct interface *ifp)
+{
+	struct zebra_if *if_data;
+
+	if_data = ifp->info;
+	if (if_data->mpls == IF_ZEBRA_MPLS_UNSPEC)
+		return;
+	frr_with_privs (&zserv_privs) {
+		vrf_switch_to_netns(ifp->vrf_id);
+		if (if_data->mpls == IF_ZEBRA_MPLS_ON)
+			mpls_interface_set(ifp->name, true);
+		else
+			mpls_interface_set(ifp->name, false);
+		vrf_switchback_to_initial();
+	}
+}
+
+static int mpls_enable_interface(struct interface *ifp, uint8_t flag)
+{
+	struct zebra_if *if_data;
+
+	if_data = ifp->info;
+
+	if (if_data->mpls == flag)
+		return CMD_SUCCESS;
+	if_data->mpls = flag;
+
+	if (CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE))
+		mpls_enable_if_set(ifp);
+
+	return CMD_SUCCESS;
+}
+
+DEFUN(mpls_enable_if, mpls_enable_if_cmd, "[no] mpls",
+      NO_STR "Enable MPLS traffic reception on this interface\n")
+{
+	int idx = 0;
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	uint8_t flag;
+
+	if (argv_find(argv, argc, "no", &idx))
+		flag = IF_ZEBRA_MPLS_OFF;
+	else
+		flag = IF_ZEBRA_MPLS_ON;
+	mpls_enable_interface(ifp, flag);
+	return CMD_SUCCESS;
+}
+
 DEFUN(ip_address_peer,
       ip_address_peer_cmd,
       "ip address A.B.C.D peer A.B.C.D/M",
@@ -3797,6 +3852,7 @@ DEFUN (ip_address_label,
 {
 	int idx_ipv4_prefixlen = 2;
 	int idx_line = 4;
+
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	return ip_address_install(vty, ifp, argv[idx_ipv4_prefixlen]->arg, NULL,
 				  argv[idx_line]->arg);
@@ -3814,6 +3870,7 @@ DEFUN (no_ip_address_label,
 {
 	int idx_ipv4_prefixlen = 3;
 	int idx_line = 5;
+
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	return ip_address_uninstall(vty, ifp, argv[idx_ipv4_prefixlen]->arg,
 				    NULL, argv[idx_line]->arg);
@@ -4182,6 +4239,11 @@ static int if_config_write(struct vty *vty)
 								== IF_ZEBRA_MULTICAST_ON
 							? ""
 							: "no ");
+				if (if_data->mpls != IF_ZEBRA_MPLS_UNSPEC)
+					vty_out(vty, " %smpls\n",
+						if_data->mpls == IF_ZEBRA_MPLS_ON
+							? ""
+							: "no ");
 			}
 
 			hook_call(zebra_if_config_wr, vty, ifp);
@@ -4234,6 +4296,7 @@ void zebra_if_init(void)
 	install_element(INTERFACE_NODE, &ip_address_label_cmd);
 	install_element(INTERFACE_NODE, &no_ip_address_label_cmd);
 #endif /* HAVE_NETLINK */
+	install_element(INTERFACE_NODE, &mpls_enable_if_cmd);
 	install_element(INTERFACE_NODE, &link_params_cmd);
 	install_default(LINK_PARAMS_NODE);
 	install_element(LINK_PARAMS_NODE, &link_params_enable_cmd);

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -44,6 +44,11 @@ extern "C" {
 #define IF_ZEBRA_SHUTDOWN_OFF    0
 #define IF_ZEBRA_SHUTDOWN_ON     1
 
+/* For interface MPLS input configuration */
+#define IF_ZEBRA_MPLS_UNSPEC 0
+#define IF_ZEBRA_MPLS_ON 1
+#define IF_ZEBRA_MPLS_OFF 2
+
 #define IF_VLAN_BITMAP_MAX 4096
 
 #if defined(HAVE_RTADV)
@@ -325,6 +330,9 @@ struct zebra_if {
 
 	/* Router advertise configuration. */
 	uint8_t rtadv_enable;
+
+	/* Mpls configuration. */
+	uint8_t mpls;
 
 	/* Installed addresses chains tree. */
 	struct route_table *ipv4_subnets;


### PR DESCRIPTION
This configuration knob permits to set value of :
proc/sys/net/mpls/conf/<iface>/input.
Even if underlying interface is not available at the moment of the call.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>