### PR TITLE
docker: build libyang2 along with FRR [8.0]

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -61,7 +61,7 @@ package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 
-	install -Dm644 "$builddir"/tools/etc/frr/daemons "$pkgdir"$_sysconfdir
+	install -Dm644 "$builddir"/tools/etc/frr/daemons "$pkgdir"$_sysconfdir/daemons
 	install -d "$pkgdir"/etc/init.d
 	ln -s ${_sbindir}/frr "$pkgdir"/etc/init.d/frr
 }

--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -13,7 +13,7 @@ makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
     expat fakeroot flex fortify-headers gdbm git gmp isl json-c-dev kmod
     lddtree libacl libatomic libattr libblkid libburn libbz2 libc-dev
     libcap-dev libcurl libedit libffi libgcc libgomp libisoburn libisofs
-    libltdl libressl libssh2 libstdc++ libtool libuuid libyang-dev
+    libltdl libressl libssh2 libstdc++ libtool libuuid
     linux-headers lzip lzo m4 make mkinitfs mpc1 mpfr4 mtools musl-dev
     ncurses-libs ncurses-terminfo ncurses-terminfo-base patch pax-utils pcre
     perl pkgconf python3 python3-dev readline readline-dev sqlite-libs

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,3 +1,26 @@
+# syntax=docker/dockerfile:1
+
+# Create a basic stage set up to build APKs
+FROM alpine:3.13 as alpine-builder
+RUN apk add \
+		--update-cache \
+		abuild \
+		alpine-conf \
+		alpine-sdk \
+	&& setup-apkcache /var/cache/apk \
+	&& mkdir -p /pkgs/apk \
+	&& echo 'builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN adduser -D -G abuild builder && su builder -c 'abuild-keygen -a -n'
+
+# This stage builds a libyang APK from source
+FROM alpine-builder as libyang-builder
+RUN mkdir -p /libyang && chown -R builder /pkgs /libyang
+COPY docker/alpine/libyang/ /libyang
+USER builder
+RUN cd /libyang \
+	&& abuild checksum \
+	&& abuild -r -P /pkgs/apk
+
 # This stage builds a dist tarball from the source
 FROM alpine:3.13 as source-builder
 
@@ -9,7 +32,14 @@ RUN source /src/alpine/APKBUILD.in \
 		--update-cache \
 		$makedepends \
 		gzip \
+		py-pip \
 	&& pip install pytest
+
+RUN mkdir -p /pkgs/apk
+COPY --from=libyang-builder /pkgs/apk/ /pkgs/apk/
+RUN apk add \
+		--no-cache \
+		--allow-untrusted /pkgs/apk/*/*.apk
 
 COPY . /src
 ARG PKGVER
@@ -20,25 +50,17 @@ RUN cd /src \
 		--with-pkg-extra-version="_git$PKGVER" \
 	&& make dist
 
-# This stage builds an apk from the dist tarball
-FROM alpine:3.13 as alpine-builder
-# Don't use nocache here so that abuild can use the cache
-RUN apk add \
-		--update-cache \
-		abuild \
-		alpine-conf \
-		alpine-sdk \
-		py-pip \
-	&& pip install pytest \
-	&& setup-apkcache /var/cache/apk \
-	&& mkdir -p /pkgs/apk \
-	&& echo 'builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
+# This stage builds an APK from the dist tarball
+FROM alpine-builder as frr-apk-builder
+COPY --from=libyang-builder /pkgs/apk/ /pkgs/apk/
 COPY --from=source-builder /src/frr-*.tar.gz /src/alpine/* /dist/
-RUN adduser -D -G abuild builder && chown -R builder /dist /pkgs
+RUN find /pkgs/apk -type f -name APKINDEX.tar.gz -delete
+RUN apk add \
+		--no-cache \
+		--allow-untrusted /pkgs/apk/*/*.apk
+RUN chown -R builder /dist /pkgs
 USER builder
 RUN cd /dist \
-	&& abuild-keygen -a -n \
 	&& abuild checksum \
 	&& git init \
 	&& abuild -r -P /pkgs/apk
@@ -46,7 +68,7 @@ RUN cd /dist \
 # This stage installs frr from the apk
 FROM alpine:3.13
 RUN mkdir -p /pkgs/apk
-COPY --from=alpine-builder /pkgs/apk/ /pkgs/apk/
+COPY --from=frr-apk-builder /pkgs/apk/ /pkgs/apk/
 RUN apk add \
 		--no-cache \
 		--update-cache \

--- a/docker/alpine/docker-start
+++ b/docker/alpine/docker-start
@@ -1,4 +1,18 @@
 #!/bin/ash
 
+if [ -r "/lib/lsb/init-functions" ]; then
+        . /lib/lsb/init-functions
+else
+        log_success_msg() {
+                echo "$@"
+        }
+        log_warning_msg() {
+                echo "$@" >&2
+        }
+        log_failure_msg() {
+                echo "$@" >&2
+        }
+fi
+
 source /usr/lib/frr/frrcommon.sh
 /usr/lib/frr/watchfrr $(daemon_list)

--- a/docker/alpine/libyang/10-remove-non-standard-headers.patch
+++ b/docker/alpine/libyang/10-remove-non-standard-headers.patch
@@ -1,0 +1,298 @@
+From 8f4907590afbe3eafabcf5b461c0ae51b65c3a37 Mon Sep 17 00:00:00 2001
+From: Michal Vasko <mvasko@cesnet.cz>
+Date: Thu, 10 Jun 2021 15:07:02 +0200
+Subject: [PATCH] libyang BUGFIX do not include non-standard headers
+
+Fixes #1614
+---
+ src/context.c                            | 1 -
+ src/diff.c                               | 1 -
+ src/log.c                                | 1 -
+ src/out.c                                | 1 -
+ src/plugins_types.c                      | 1 -
+ src/plugins_types/bits.c                 | 1 -
+ src/plugins_types/date_and_time.c        | 1 -
+ src/plugins_types/identityref.c          | 1 -
+ src/plugins_types/integer.c              | 1 -
+ src/plugins_types/ipv4_address.c         | 1 -
+ src/plugins_types/ipv4_address_no_zone.c | 1 -
+ src/plugins_types/ipv4_prefix.c          | 1 -
+ src/plugins_types/ipv6_address.c         | 1 -
+ src/plugins_types/ipv6_address_no_zone.c | 1 -
+ src/plugins_types/ipv6_prefix.c          | 1 -
+ src/plugins_types/union.c                | 1 -
+ src/schema_compile_node.c                | 1 -
+ src/tree_data_helpers.c                  | 1 -
+ src/tree_schema.c                        | 1 -
+ src/validation.c                         | 1 -
+ src/xpath.c                              | 1 -
+ tools/re/main.c                          | 1 -
+ 22 files changed, 22 deletions(-)
+
+diff --git a/src/context.c b/src/context.c
+index eb671255..ac62cac5 100644
+--- a/src/context.c
++++ b/src/context.c
+@@ -17,7 +17,6 @@
+ #define _XOPEN_SOURCE 1
+ #define _XOPEN_SOURCE_EXTENDED 1
+ #endif
+-#include <sys/cdefs.h>
+ 
+ #include "context.h"
+ 
+diff --git a/src/diff.c b/src/diff.c
+index b40dd73a..4971c6fe 100644
+--- a/src/diff.c
++++ b/src/diff.c
+@@ -12,7 +12,6 @@
+  *     https://opensource.org/licenses/BSD-3-Clause
+  */
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "diff.h"
+ 
+diff --git a/src/log.c b/src/log.c
+index 97c7b283..9cd5fd0d 100644
+--- a/src/log.c
++++ b/src/log.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "log.h"
+ 
+diff --git a/src/out.c b/src/out.c
+index 37beb696..898d663a 100644
+--- a/src/out.c
++++ b/src/out.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "out.h"
+ #include "out_internal.h"
+diff --git a/src/plugins_types.c b/src/plugins_types.c
+index 26bac210..a2cf0f38 100644
+--- a/src/plugins_types.c
++++ b/src/plugins_types.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/bits.c b/src/plugins_types/bits.c
+index 9d086ffb..ef87691b 100644
+--- a/src/plugins_types/bits.c
++++ b/src/plugins_types/bits.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/date_and_time.c b/src/plugins_types/date_and_time.c
+index 0d52dbb1..a23caaa9 100644
+--- a/src/plugins_types/date_and_time.c
++++ b/src/plugins_types/date_and_time.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/identityref.c b/src/plugins_types/identityref.c
+index 90546d69..91ddbde2 100644
+--- a/src/plugins_types/identityref.c
++++ b/src/plugins_types/identityref.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/integer.c b/src/plugins_types/integer.c
+index 44e87f99..bf2b7812 100644
+--- a/src/plugins_types/integer.c
++++ b/src/plugins_types/integer.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/ipv4_address.c b/src/plugins_types/ipv4_address.c
+index a95752ea..a7369d6b 100644
+--- a/src/plugins_types/ipv4_address.c
++++ b/src/plugins_types/ipv4_address.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/ipv4_address_no_zone.c b/src/plugins_types/ipv4_address_no_zone.c
+index a17a7efe..1fb34b06 100644
+--- a/src/plugins_types/ipv4_address_no_zone.c
++++ b/src/plugins_types/ipv4_address_no_zone.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/ipv4_prefix.c b/src/plugins_types/ipv4_prefix.c
+index 3108b2c5..6fb93390 100644
+--- a/src/plugins_types/ipv4_prefix.c
++++ b/src/plugins_types/ipv4_prefix.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/ipv6_address.c b/src/plugins_types/ipv6_address.c
+index c0d20fa4..d09425b3 100644
+--- a/src/plugins_types/ipv6_address.c
++++ b/src/plugins_types/ipv6_address.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/ipv6_address_no_zone.c b/src/plugins_types/ipv6_address_no_zone.c
+index c612b663..06bd1891 100644
+--- a/src/plugins_types/ipv6_address_no_zone.c
++++ b/src/plugins_types/ipv6_address_no_zone.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/ipv6_prefix.c b/src/plugins_types/ipv6_prefix.c
+index b3ad34b6..91431fef 100644
+--- a/src/plugins_types/ipv6_prefix.c
++++ b/src/plugins_types/ipv6_prefix.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/plugins_types/union.c b/src/plugins_types/union.c
+index a8ec43b3..89e81c7a 100644
+--- a/src/plugins_types/union.c
++++ b/src/plugins_types/union.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "plugins_types.h"
+ 
+diff --git a/src/schema_compile_node.c b/src/schema_compile_node.c
+index 424b7f8f..273023de 100644
+--- a/src/schema_compile_node.c
++++ b/src/schema_compile_node.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "schema_compile_node.h"
+ 
+diff --git a/src/tree_data_helpers.c b/src/tree_data_helpers.c
+index 488efbbb..2d9ba624 100644
+--- a/src/tree_data_helpers.c
++++ b/src/tree_data_helpers.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include <assert.h>
+ #include <ctype.h>
+diff --git a/src/tree_schema.c b/src/tree_schema.c
+index 93f29796..4a57cc47 100644
+--- a/src/tree_schema.c
++++ b/src/tree_schema.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "tree_schema.h"
+ 
+diff --git a/src/validation.c b/src/validation.c
+index b9eda810..e2062256 100644
+--- a/src/validation.c
++++ b/src/validation.c
+@@ -12,7 +12,6 @@
+  *     https://opensource.org/licenses/BSD-3-Clause
+  */
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "validation.h"
+ 
+diff --git a/src/xpath.c b/src/xpath.c
+index b68a76b8..ea1cdfc9 100644
+--- a/src/xpath.c
++++ b/src/xpath.c
+@@ -12,7 +12,6 @@
+  *     https://opensource.org/licenses/BSD-3-Clause
+  */
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include "xpath.h"
+ 
+diff --git a/tools/re/main.c b/tools/re/main.c
+index b512ad80..4d8aa99c 100644
+--- a/tools/re/main.c
++++ b/tools/re/main.c
+@@ -13,7 +13,6 @@
+  */
+ 
+ #define _GNU_SOURCE /* asprintf, strdup */
+-#include <sys/cdefs.h>
+ 
+ #include <errno.h>
+ #include <getopt.h>
+-- 
+2.31.1
+

--- a/docker/alpine/libyang/11-utest-dont-parse-dlerror.patch
+++ b/docker/alpine/libyang/11-utest-dont-parse-dlerror.patch
@@ -1,0 +1,40 @@
+From 2054431ea3024b177083f09c66c1bb4c3d08b048 Mon Sep 17 00:00:00 2001
+From: Wesley Coakley <w@wesleycoakley.com>
+Date: Wed, 16 Jun 2021 00:30:50 -0400
+Subject: [PATCH] don't attempt to parse dlerror() in utests
+
+---
+ tests/utests/basic/test_plugins.c | 17 -----------------
+ 1 file changed, 17 deletions(-)
+
+diff --git a/tests/utests/basic/test_plugins.c b/tests/utests/basic/test_plugins.c
+index fd9e6130..662fd9b4 100644
+--- a/tests/utests/basic/test_plugins.c
++++ b/tests/utests/basic/test_plugins.c
+@@ -36,23 +36,6 @@ static void
+ test_add_invalid(void **state)
+ {
+     assert_int_equal(LY_ESYS, lyplg_add(TESTS_BIN "/plugins/plugin_does_not_exist" LYPLG_SUFFIX));
+-
+-#ifdef __APPLE__
+-    CHECK_LOG("Loading \""TESTS_BIN "/plugins/plugin_does_not_exist" LYPLG_SUFFIX "\" as a plugin failed "
+-            "(dlopen("TESTS_BIN "/plugins/plugin_does_not_exist" LYPLG_SUFFIX ", 2): image not found).", NULL);
+-#else
+-    CHECK_LOG("Loading \""TESTS_BIN "/plugins/plugin_does_not_exist" LYPLG_SUFFIX "\" as a plugin failed "
+-            "("TESTS_BIN "/plugins/plugin_does_not_exist" LYPLG_SUFFIX ": cannot open shared object file: "
+-            "No such file or directory).", NULL);
+-#endif
+-
+-    assert_int_equal(LY_EINVAL, lyplg_add(TESTS_BIN "/plugins/plugin_invalid" LYPLG_SUFFIX));
+-#ifndef __APPLE__
+-    /* OS X prints address of the symbol being searched and cmocka doesn't support wildcards in string checking assert */
+-    CHECK_LOG("Processing user type plugin \""TESTS_BIN "/plugins/plugin_invalid"LYPLG_SUFFIX "\" failed, "
+-            "missing type plugins information ("TESTS_BIN "/plugins/plugin_invalid"LYPLG_SUFFIX ": "
+-            "undefined symbol: plugins_types__).", NULL);
+-#endif
+ }
+ 
+ static void
+-- 
+2.31.1
+

--- a/docker/alpine/libyang/APKBUILD
+++ b/docker/alpine/libyang/APKBUILD
@@ -1,0 +1,46 @@
+# Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
+# Maintainer: Christian Franke <nobody@nowhere.ws>
+pkgname=libyang
+pkgver=2.0.7
+pkgrel=0
+pkgdesc="YANG data modelling language parser and toolkit"
+url="https://github.com/CESNET/libyang"
+arch="all"
+license="BSD-3-Clause-Clear"
+makedepends="bison cmake cmocka-dev flex pcre2-dev"
+checkdepends="expect grep shunit2"
+subpackages="$pkgname-dev $pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/CESNET/libyang/archive/v$pkgver.tar.gz
+	10-remove-non-standard-headers.patch
+	11-utest-dont-parse-dlerror.patch"
+
+# secfixes:
+#   1.0.215-r1:
+#     - CVE-2021-28902
+#     - CVE-2021-28903
+#     - CVE-2021-28904
+#     - CVE-2021-28905
+#     - CVE-2021-28906
+
+build() {
+	if [ "$CBUILD" != "$CHOST" ]; then
+		CMAKE_CROSSOPTS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
+	fi
+	cmake -B build \
+		-DCMAKE_BUILD_TYPE=None \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_SHARED_LIBS=True \
+		-DCMAKE_C_FLAGS="$CFLAGS" \
+		-DENABLE_BUILD_TESTS=ON \
+		"$CMAKE_CROSSOPTS"
+	make -C build
+}
+
+package() {
+	make -C build DESTDIR="$pkgdir" install
+}
+
+sha512sums="edb1d8d372b25ed820fa312e0dc96d4af7c8cd5ddeb785964de73f64774062ea7a5586bb27e2039ad24189d4a2ba04268921ca86e82423fc48647d1d10a2a0a7  libyang-2.0.7.tar.gz
+385008c715e6b0dc9e8f33c9cb550b3af7ee16f056f35d09a4ba01b9e00ddb88940915f93fc608fedd30b4f9a6a1503df414ae0be64b1263681b0ee18e6f4db8  10-remove-non-standard-headers.patch
+b16881d301a6aec68fbe6bfb7ba53a8fcdb4b9eead3b03573e0e2a4a8c3c3d6962db623be14d29c023b5a7ad0f685da1f6033dd9985f7a2914ad2f4da07e60cb  11-utest-dont-parse-dlerror.patch"


### PR DESCRIPTION
Alpine images have been broken for some time because libyang2 is not
available in Alpine. This patch updates our Dockerfile to build a
libyang2 APK and install it into the image to satisfy FRR's libyang2
dependency.

Unfortunately, libyang2 erroneously includes an internal header from
libc which musl does not provide. FRR's official Docker
images are based on Alpine, which only offers musl libc. Until libyang2
fixes this problem, the libyang2 source that is installed in this image
is a patched version that is compatible with musl libc and not an
official version.

Signed-off-by: Quentin Young <qlyoung@nvidia.com>