### PR TITLE
tools: fix wrong get_contexts() of Config class.

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -199,6 +199,9 @@ class Context(object):
         for ligne in lines:
             self.dlines[ligne] = True
 
+    def __str__(self):
+        return str(self.keys) + " : " + str(self.lines)
+
     def add_lines(self, lines):
         """
         Add lines to specified context
@@ -335,7 +338,7 @@ class Config(object):
         """
 
         for (_, ctx) in sorted(iteritems(self.contexts)):
-            print(str(ctx) + "\n")
+            print(str(ctx))
 
     def save_contexts(self, key, lines):
         """


### PR DESCRIPTION
Calling get_contexts() can't display as expected, it wrongly displays:
<__main__.Context object at 0x7fdee1d5ad50>

So make it display correct data by add __str__ in Context class.

Signed-off-by: anlan_cs <anlan_cs@tom.com>