### PR TITLE
ospfd: correctly cleanup spf data

### DIFF
--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1781,6 +1781,9 @@ void ospf_spf_calculate_area(struct ospf *ospf, struct ospf_area *area,
 				    ospf->ti_lfa_protection_type);
 
 	ospf_spf_cleanup(area->spf, area->spf_vertex_list);
+
+	area->spf = NULL;
+	area->spf_vertex_list = NULL;
 }
 
 void ospf_spf_calculate_areas(struct ospf *ospf, struct route_table *new_table,


### PR DESCRIPTION
ospf_spf_cleanup frees the data so we need to reset the stale pointers.

Fixes #9523.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>