### PR TITLE
ospfd: ASBR Summary LSA is not originated when process is reset

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -222,6 +222,9 @@ void ospf_process_refresh_data(struct ospf *ospf, bool reset)
 			ospf_lsdb_delete_all(ospf->lsdb);
 		}
 
+		/* Since the LSAs are deleted, need reset the aggr flag */
+		ospf_unset_all_aggr_flag(ospf);
+
 		/* Delete the LSDB */
 		for (ALL_LIST_ELEMENTS(ospf->areas, node, nnode, area))
 			ospf_area_lsdb_discard_delete(area);


### PR DESCRIPTION
**Problem Statement:**
Summary LSA is not originated when router-id is modified or process is reset

**Root Cause Analysis:**
When router-id is modified or process is cleared, all the external LSAs are
 flushed then LSA is re-originated using ospf_external_lsa_rid_change
When the LSAs are flushed, the aggregate flags are not reset.

**Fix:**
Reset the aggregation flag when the LSAs
 are flushed.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>