### PR TITLE
ospf6d: Prevent crash of show ipv6 ospf data adv-router 0.0.0.0 links…

### DIFF
--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -833,7 +833,6 @@ DEFUN(show_ipv6_ospf6_database_adv_router_linkstate_id,
 	bool all_vrf = false;
 	int idx_vrf = 0;
 
-
 	OSPF6_CMD_CHECK_RUNNING();
 	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
 	if (idx_vrf > 0) {
@@ -847,9 +846,8 @@ DEFUN(show_ipv6_ospf6_database_adv_router_linkstate_id,
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
 		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
-			ospf6_lsdb_type_show_wrapper(vty, level, NULL, &id,
-						     &adv_router, uj, ospf6);
-
+			ospf6_lsdb_show_wrapper(vty, level, NULL, &id,
+						&adv_router, uj, ospf6);
 			if (!all_vrf)
 				break;
 		}


### PR DESCRIPTION
…tate-id 0.0.0.0

With this sequence of events:
eva# conf
eva(config)# router ospf6
eva(config-ospf6)# end
eva# show ipv6 ospf data adv-router 0.0.0.0 linkstate-id 0.0.0.0
OSPF6: Received signal 11 at 1630442431 (si_addr 0x0, PC 0x559dcfa3a656); aborting...
OSPF6: zlog_signal+0x18c                  7fd2cc8229f7     7fff606775d0 /lib/libfrr.so.0 (mapped at 0x7fd2cc770000)
OSPF6: core_handler+0xe3                  7fd2cc8616ad     7fff606776f0 /lib/libfrr.so.0 (mapped at 0x7fd2cc770000)
OSPF6: funlockfile+0x50                   7fd2cc74f140     7fff60677840 /lib/x86_64-linux-gnu/libpthread.so.0 (mapped at 0x7fd2cc73b000)
OSPF6:     ---- signal ----
OSPF6: ospf6_lsdb_type_show_wrapper+0x5d     559dcfa3a656     7fff60677dd0 /usr/lib/frr/ospf6d (mapped at 0x559dcf9a5000)
OSPF6: show_ipv6_ospf6_database_adv_router_linkstate_id+0x1f9     559dcfa3c24a     7fff60677e50 /usr/lib/frr/ospf6d (mapped at 0x559dcf9a5000)

OSPF6 crashes.  Fix.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>