### PR TITLE
typedef cleanup to proper usage of `enum X` or `struct X`

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -874,7 +874,7 @@ struct fpm_lsp_arg {
 
 static int fpm_lsp_send_cb(struct hash_bucket *bucket, void *arg)
 {
-	zebra_lsp_t *lsp = bucket->data;
+	struct zebra_lsp *lsp = bucket->data;
 	struct fpm_lsp_arg *fla = arg;
 
 	/* Skip entries which have already been sent */
@@ -1138,7 +1138,7 @@ static int fpm_nhg_reset(struct thread *t)
  */
 static void fpm_lsp_reset_cb(struct hash_bucket *bucket, void *arg)
 {
-	zebra_lsp_t *lsp = bucket->data;
+	struct zebra_lsp *lsp = bucket->data;
 
 	UNSET_FLAG(lsp->flags, LSP_FLAG_FPM);
 }

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1055,7 +1055,7 @@ struct fpm_rmac_arg {
 static void fpm_enqueue_rmac_table(struct hash_bucket *bucket, void *arg)
 {
 	struct fpm_rmac_arg *fra = arg;
-	zebra_mac_t *zrmac = bucket->data;
+	struct zebra_mac *zrmac = bucket->data;
 	struct zebra_if *zif = fra->zl3vni->vxlan_if->info;
 	const struct zebra_l2info_vxlan *vxl = &zif->l2info.vxl;
 	struct zebra_if *br_zif;
@@ -1190,7 +1190,7 @@ static int fpm_rib_reset(struct thread *t)
  */
 static void fpm_unset_rmac_table(struct hash_bucket *bucket, void *arg)
 {
-	zebra_mac_t *zrmac = bucket->data;
+	struct zebra_mac *zrmac = bucket->data;
 
 	UNSET_FLAG(zrmac->flags, ZEBRA_MAC_FPM_SENT);
 }

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1048,7 +1048,7 @@ static int fpm_rib_send(struct thread *t)
 struct fpm_rmac_arg {
 	struct zebra_dplane_ctx *ctx;
 	struct fpm_nl_ctx *fnc;
-	zebra_l3vni_t *zl3vni;
+	struct zebra_l3vni *zl3vni;
 	bool complete;
 };
 
@@ -1087,7 +1087,7 @@ static void fpm_enqueue_rmac_table(struct hash_bucket *bucket, void *arg)
 static void fpm_enqueue_l3vni_table(struct hash_bucket *bucket, void *arg)
 {
 	struct fpm_rmac_arg *fra = arg;
-	zebra_l3vni_t *zl3vni = bucket->data;
+	struct zebra_l3vni *zl3vni = bucket->data;
 
 	fra->zl3vni = zl3vni;
 	hash_iterate(zl3vni->rmac_table, fpm_enqueue_rmac_table, zl3vni);
@@ -1197,7 +1197,7 @@ static void fpm_unset_rmac_table(struct hash_bucket *bucket, void *arg)
 
 static void fpm_unset_l3vni_table(struct hash_bucket *bucket, void *arg)
 {
-	zebra_l3vni_t *zl3vni = bucket->data;
+	struct zebra_l3vni *zl3vni = bucket->data;
 
 	hash_iterate(zl3vni->rmac_table, fpm_unset_rmac_table, zl3vni);
 }

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -250,7 +250,7 @@ static enum zebra_link_type netlink_to_zebra_link_type(unsigned int hwt)
 }
 
 static inline void zebra_if_set_ziftype(struct interface *ifp,
-					zebra_iftype_t zif_type,
+					enum zebra_iftype zif_type,
 					zebra_slave_iftype_t zif_slave_type)
 {
 	struct zebra_if *zif;
@@ -270,7 +270,7 @@ static inline void zebra_if_set_ziftype(struct interface *ifp,
 }
 
 static void netlink_determine_zebra_iftype(const char *kind,
-					   zebra_iftype_t *zif_type)
+					   enum zebra_iftype *zif_type)
 {
 	*zif_type = ZEBRA_IF_OTHER;
 
@@ -875,7 +875,7 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	char *slave_kind = NULL;
 	struct zebra_ns *zns = NULL;
 	vrf_id_t vrf_id = VRF_DEFAULT;
-	zebra_iftype_t zif_type = ZEBRA_IF_OTHER;
+	enum zebra_iftype zif_type = ZEBRA_IF_OTHER;
 	zebra_slave_iftype_t zif_slave_type = ZEBRA_IF_SLAVE_NONE;
 	ifindex_t bridge_ifindex = IFINDEX_INTERNAL;
 	ifindex_t link_ifindex = IFINDEX_INTERNAL;
@@ -1467,7 +1467,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	char *slave_kind = NULL;
 	struct zebra_ns *zns;
 	vrf_id_t vrf_id = VRF_DEFAULT;
-	zebra_iftype_t zif_type = ZEBRA_IF_OTHER;
+	enum zebra_iftype zif_type = ZEBRA_IF_OTHER;
 	zebra_slave_iftype_t zif_slave_type = ZEBRA_IF_SLAVE_NONE;
 	ifindex_t bridge_ifindex = IFINDEX_INTERNAL;
 	ifindex_t bond_ifindex = IFINDEX_INTERNAL;

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -251,7 +251,7 @@ static enum zebra_link_type netlink_to_zebra_link_type(unsigned int hwt)
 
 static inline void zebra_if_set_ziftype(struct interface *ifp,
 					enum zebra_iftype zif_type,
-					zebra_slave_iftype_t zif_slave_type)
+					enum zebra_slave_iftype zif_slave_type)
 {
 	struct zebra_if *zif;
 
@@ -876,7 +876,7 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	struct zebra_ns *zns = NULL;
 	vrf_id_t vrf_id = VRF_DEFAULT;
 	enum zebra_iftype zif_type = ZEBRA_IF_OTHER;
-	zebra_slave_iftype_t zif_slave_type = ZEBRA_IF_SLAVE_NONE;
+	enum zebra_slave_iftype zif_slave_type = ZEBRA_IF_SLAVE_NONE;
 	ifindex_t bridge_ifindex = IFINDEX_INTERNAL;
 	ifindex_t link_ifindex = IFINDEX_INTERNAL;
 	ifindex_t bond_ifindex = IFINDEX_INTERNAL;
@@ -1468,7 +1468,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	struct zebra_ns *zns;
 	vrf_id_t vrf_id = VRF_DEFAULT;
 	enum zebra_iftype zif_type = ZEBRA_IF_OTHER;
-	zebra_slave_iftype_t zif_slave_type = ZEBRA_IF_SLAVE_NONE;
+	enum zebra_slave_iftype zif_slave_type = ZEBRA_IF_SLAVE_NONE;
 	ifindex_t bridge_ifindex = IFINDEX_INTERNAL;
 	ifindex_t bond_ifindex = IFINDEX_INTERNAL;
 	ifindex_t link_ifindex = IFINDEX_INTERNAL;

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1295,7 +1295,7 @@ static const char *zebra_zifslavetype_2str(zebra_slave_iftype_t zif_slave_type)
 	return "None";
 }
 
-static const char *zebra_ziftype_2str(zebra_iftype_t zif_type)
+static const char *zebra_ziftype_2str(enum zebra_iftype zif_type)
 {
 	switch (zif_type) {
 	case ZEBRA_IF_OTHER:

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1278,7 +1278,8 @@ static void nbr_connected_dump_vty(struct vty *vty, json_object *json,
 		vty_out(vty, "  %s %pFX\n", prefix_family_str(p), p);
 }
 
-static const char *zebra_zifslavetype_2str(zebra_slave_iftype_t zif_slave_type)
+static const char *
+zebra_zifslavetype_2str(enum zebra_slave_iftype zif_slave_type)
 {
 	switch (zif_slave_type) {
 	case ZEBRA_IF_SLAVE_BRIDGE:

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -267,13 +267,13 @@ enum zebra_iftype {
 };
 
 /* Zebra "slave" interface type */
-typedef enum {
+enum zebra_slave_iftype {
 	ZEBRA_IF_SLAVE_NONE,   /* Not a slave */
 	ZEBRA_IF_SLAVE_VRF,    /* Member of a VRF */
 	ZEBRA_IF_SLAVE_BRIDGE, /* Member of a bridge */
 	ZEBRA_IF_SLAVE_BOND,   /* Bond member */
 	ZEBRA_IF_SLAVE_OTHER,  /* Something else - e.g., bond slave */
-} zebra_slave_iftype_t;
+};
 
 struct irdp_interface;
 
@@ -368,7 +368,7 @@ struct zebra_if {
 
 	/* Zebra interface and "slave" interface type */
 	enum zebra_iftype zif_type;
-	zebra_slave_iftype_t zif_slave_type;
+	enum zebra_slave_iftype zif_slave_type;
 
 	/* Additional L2 info, depends on zif_type */
 	union zebra_l2if_info l2info;

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -253,7 +253,7 @@ struct rtadv_dnssl {
 #endif /* HAVE_RTADV */
 
 /* Zebra interface type - ones of interest. */
-typedef enum {
+enum zebra_iftype {
 	ZEBRA_IF_OTHER = 0, /* Anything else */
 	ZEBRA_IF_VXLAN,     /* VxLAN interface */
 	ZEBRA_IF_VRF,       /* VRF device */
@@ -264,7 +264,7 @@ typedef enum {
 	ZEBRA_IF_BOND,	    /* Bond */
 	ZEBRA_IF_BOND_SLAVE,	    /* Bond */
 	ZEBRA_IF_GRE,      /* GRE interface */
-} zebra_iftype_t;
+};
 
 /* Zebra "slave" interface type */
 typedef enum {
@@ -367,7 +367,7 @@ struct zebra_if {
 	uint8_t ptm_enable;
 
 	/* Zebra interface and "slave" interface type */
-	zebra_iftype_t zif_type;
+	enum zebra_iftype zif_type;
 	zebra_slave_iftype_t zif_slave_type;
 
 	/* Additional L2 info, depends on zif_type */

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1731,12 +1731,11 @@ static bool _netlink_route_build_multipath(const struct prefix *p,
 	return true;
 }
 
-static inline bool _netlink_mpls_build_singlepath(const struct prefix *p,
-						  const char *routedesc,
-						  const zebra_nhlfe_t *nhlfe,
-						  struct nlmsghdr *nlmsg,
-						  struct rtmsg *rtmsg,
-						  size_t req_size, int cmd)
+static inline bool
+_netlink_mpls_build_singlepath(const struct prefix *p, const char *routedesc,
+			       const struct zebra_nhlfe *nhlfe,
+			       struct nlmsghdr *nlmsg, struct rtmsg *rtmsg,
+			       size_t req_size, int cmd)
 {
 	int bytelen;
 	uint8_t family;
@@ -1751,7 +1750,7 @@ static inline bool _netlink_mpls_build_singlepath(const struct prefix *p,
 
 static inline bool
 _netlink_mpls_build_multipath(const struct prefix *p, const char *routedesc,
-			      const zebra_nhlfe_t *nhlfe,
+			      const struct zebra_nhlfe *nhlfe,
 			      struct nlmsghdr *nlmsg, size_t req_size,
 			      struct rtmsg *rtmsg, const union g_addr **src)
 {
@@ -4252,7 +4251,7 @@ ssize_t netlink_mpls_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx,
 {
 	mpls_lse_t lse;
 	const struct nhlfe_list_head *head;
-	const zebra_nhlfe_t *nhlfe;
+	const struct zebra_nhlfe *nhlfe;
 	struct nexthop *nexthop = NULL;
 	unsigned int nexthop_num;
 	const char *routedesc;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -641,7 +641,7 @@ static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_LSP_DELETE:
 	case DPLANE_OP_LSP_NOTIFY:
 	{
-		zebra_nhlfe_t *nhlfe;
+		struct zebra_nhlfe *nhlfe;
 
 		/* Unlink and free allocated NHLFEs */
 		frr_each_safe(nhlfe_list, &ctx->u.lsp.nhlfe_list, nhlfe) {
@@ -1512,15 +1512,14 @@ const struct nhlfe_list_head *dplane_ctx_get_backup_nhlfe_list(
 	return &(ctx->u.lsp.backup_nhlfe_list);
 }
 
-zebra_nhlfe_t *dplane_ctx_add_nhlfe(struct zebra_dplane_ctx *ctx,
-				    enum lsp_types_t lsp_type,
-				    enum nexthop_types_t nh_type,
-				    const union g_addr *gate,
-				    ifindex_t ifindex,
-				    uint8_t num_labels,
-				    mpls_label_t *out_labels)
+struct zebra_nhlfe *dplane_ctx_add_nhlfe(struct zebra_dplane_ctx *ctx,
+					 enum lsp_types_t lsp_type,
+					 enum nexthop_types_t nh_type,
+					 const union g_addr *gate,
+					 ifindex_t ifindex, uint8_t num_labels,
+					 mpls_label_t *out_labels)
 {
-	zebra_nhlfe_t *nhlfe;
+	struct zebra_nhlfe *nhlfe;
 
 	DPLANE_CTX_VALID(ctx);
 
@@ -1531,15 +1530,12 @@ zebra_nhlfe_t *dplane_ctx_add_nhlfe(struct zebra_dplane_ctx *ctx,
 	return nhlfe;
 }
 
-zebra_nhlfe_t *dplane_ctx_add_backup_nhlfe(struct zebra_dplane_ctx *ctx,
-					   enum lsp_types_t lsp_type,
-					   enum nexthop_types_t nh_type,
-					   const union g_addr *gate,
-					   ifindex_t ifindex,
-					   uint8_t num_labels,
-					   mpls_label_t *out_labels)
+struct zebra_nhlfe *dplane_ctx_add_backup_nhlfe(
+	struct zebra_dplane_ctx *ctx, enum lsp_types_t lsp_type,
+	enum nexthop_types_t nh_type, const union g_addr *gate,
+	ifindex_t ifindex, uint8_t num_labels, mpls_label_t *out_labels)
 {
-	zebra_nhlfe_t *nhlfe;
+	struct zebra_nhlfe *nhlfe;
 
 	DPLANE_CTX_VALID(ctx);
 
@@ -1551,7 +1547,7 @@ zebra_nhlfe_t *dplane_ctx_add_backup_nhlfe(struct zebra_dplane_ctx *ctx,
 	return nhlfe;
 }
 
-const zebra_nhlfe_t *
+const struct zebra_nhlfe *
 dplane_ctx_get_best_nhlfe(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
@@ -1559,9 +1555,9 @@ dplane_ctx_get_best_nhlfe(const struct zebra_dplane_ctx *ctx)
 	return ctx->u.lsp.best_nhlfe;
 }
 
-const zebra_nhlfe_t *
+const struct zebra_nhlfe *
 dplane_ctx_set_best_nhlfe(struct zebra_dplane_ctx *ctx,
-			  zebra_nhlfe_t *nhlfe)
+			  struct zebra_nhlfe *nhlfe)
 {
 	DPLANE_CTX_VALID(ctx);
 
@@ -2407,7 +2403,7 @@ int dplane_ctx_lsp_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 			zebra_lsp_t *lsp)
 {
 	int ret = AOK;
-	zebra_nhlfe_t *nhlfe, *new_nhlfe;
+	struct zebra_nhlfe *nhlfe, *new_nhlfe;
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
@@ -3267,7 +3263,7 @@ dplane_lsp_notif_update(zebra_lsp_t *lsp,
 	int ret = EINVAL;
 	struct zebra_dplane_ctx *ctx = NULL;
 	struct nhlfe_list_head *head;
-	zebra_nhlfe_t *nhlfe, *new_nhlfe;
+	struct zebra_nhlfe *nhlfe, *new_nhlfe;
 
 	/* Obtain context block */
 	ctx = dplane_ctx_alloc();

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2202,7 +2202,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	struct zebra_ns *zns;
 	struct zebra_vrf *zvrf;
 	struct nexthop *nexthop;
-	zebra_l3vni_t *zl3vni;
+	struct zebra_l3vni *zl3vni;
 	const struct interface *ifp;
 	struct dplane_intf_extra *if_extra;
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -324,7 +324,7 @@ struct zebra_dplane_ctx {
 	/* Support info for different kinds of updates */
 	union {
 		struct dplane_route_info rinfo;
-		zebra_lsp_t lsp;
+		struct zebra_lsp lsp;
 		struct dplane_pw_info pw;
 		struct dplane_br_port_info br_port;
 		struct dplane_intf_info intf;
@@ -515,7 +515,7 @@ static struct zebra_dplane_globals {
 static int dplane_thread_loop(struct thread *event);
 static void dplane_info_from_zns(struct zebra_dplane_info *ns_info,
 				 struct zebra_ns *zns);
-static enum zebra_dplane_result lsp_update_internal(zebra_lsp_t *lsp,
+static enum zebra_dplane_result lsp_update_internal(struct zebra_lsp *lsp,
 						    enum dplane_op_e op);
 static enum zebra_dplane_result pw_update_internal(struct zebra_pw *pw,
 						   enum dplane_op_e op);
@@ -2400,7 +2400,7 @@ done:
  * Capture information for an LSP update in a dplane context.
  */
 int dplane_ctx_lsp_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
-			zebra_lsp_t *lsp)
+			struct zebra_lsp *lsp)
 {
 	int ret = AOK;
 	struct zebra_nhlfe *nhlfe, *new_nhlfe;
@@ -3223,7 +3223,7 @@ enum zebra_dplane_result dplane_nexthop_delete(struct nhg_hash_entry *nhe)
 /*
  * Enqueue LSP add for the dataplane.
  */
-enum zebra_dplane_result dplane_lsp_add(zebra_lsp_t *lsp)
+enum zebra_dplane_result dplane_lsp_add(struct zebra_lsp *lsp)
 {
 	enum zebra_dplane_result ret =
 		lsp_update_internal(lsp, DPLANE_OP_LSP_INSTALL);
@@ -3234,7 +3234,7 @@ enum zebra_dplane_result dplane_lsp_add(zebra_lsp_t *lsp)
 /*
  * Enqueue LSP update for the dataplane.
  */
-enum zebra_dplane_result dplane_lsp_update(zebra_lsp_t *lsp)
+enum zebra_dplane_result dplane_lsp_update(struct zebra_lsp *lsp)
 {
 	enum zebra_dplane_result ret =
 		lsp_update_internal(lsp, DPLANE_OP_LSP_UPDATE);
@@ -3245,7 +3245,7 @@ enum zebra_dplane_result dplane_lsp_update(zebra_lsp_t *lsp)
 /*
  * Enqueue LSP delete for the dataplane.
  */
-enum zebra_dplane_result dplane_lsp_delete(zebra_lsp_t *lsp)
+enum zebra_dplane_result dplane_lsp_delete(struct zebra_lsp *lsp)
 {
 	enum zebra_dplane_result ret =
 		lsp_update_internal(lsp, DPLANE_OP_LSP_DELETE);
@@ -3255,8 +3255,7 @@ enum zebra_dplane_result dplane_lsp_delete(zebra_lsp_t *lsp)
 
 /* Update or un-install resulting from an async notification */
 enum zebra_dplane_result
-dplane_lsp_notif_update(zebra_lsp_t *lsp,
-			enum dplane_op_e op,
+dplane_lsp_notif_update(struct zebra_lsp *lsp, enum dplane_op_e op,
 			struct zebra_dplane_ctx *notif_ctx)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
@@ -3335,7 +3334,7 @@ enum zebra_dplane_result dplane_pw_uninstall(struct zebra_pw *pw)
 /*
  * Common internal LSP update utility
  */
-static enum zebra_dplane_result lsp_update_internal(zebra_lsp_t *lsp,
+static enum zebra_dplane_result lsp_update_internal(struct zebra_lsp *lsp,
 						    enum dplane_op_e op)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -385,7 +385,7 @@ uint8_t dplane_ctx_get_nhe_nh_grp_count(const struct zebra_dplane_ctx *ctx);
  * context data area.
  */
 int dplane_ctx_lsp_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
-			zebra_lsp_t *lsp);
+			struct zebra_lsp *lsp);
 
 mpls_label_t dplane_ctx_get_in_label(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_in_label(struct zebra_dplane_ctx *ctx,
@@ -593,12 +593,12 @@ enum zebra_dplane_result dplane_nexthop_delete(struct nhg_hash_entry *nhe);
 /*
  * Enqueue LSP change operations for the dataplane.
  */
-enum zebra_dplane_result dplane_lsp_add(zebra_lsp_t *lsp);
-enum zebra_dplane_result dplane_lsp_update(zebra_lsp_t *lsp);
-enum zebra_dplane_result dplane_lsp_delete(zebra_lsp_t *lsp);
+enum zebra_dplane_result dplane_lsp_add(struct zebra_lsp *lsp);
+enum zebra_dplane_result dplane_lsp_update(struct zebra_lsp *lsp);
+enum zebra_dplane_result dplane_lsp_delete(struct zebra_lsp *lsp);
 
 /* Update or un-install resulting from an async notification */
-enum zebra_dplane_result dplane_lsp_notif_update(zebra_lsp_t *lsp,
+enum zebra_dplane_result dplane_lsp_notif_update(struct zebra_lsp *lsp,
 						 enum dplane_op_e op,
 						 struct zebra_dplane_ctx *ctx);
 

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -401,26 +401,23 @@ const struct nhlfe_list_head *dplane_ctx_get_nhlfe_list(
 const struct nhlfe_list_head *dplane_ctx_get_backup_nhlfe_list(
 	const struct zebra_dplane_ctx *ctx);
 
-zebra_nhlfe_t *dplane_ctx_add_nhlfe(struct zebra_dplane_ctx *ctx,
-				    enum lsp_types_t lsp_type,
-				    enum nexthop_types_t nh_type,
-				    const union g_addr *gate,
-				    ifindex_t ifindex,
-				    uint8_t num_labels,
-				    mpls_label_t *out_labels);
+struct zebra_nhlfe *dplane_ctx_add_nhlfe(struct zebra_dplane_ctx *ctx,
+					 enum lsp_types_t lsp_type,
+					 enum nexthop_types_t nh_type,
+					 const union g_addr *gate,
+					 ifindex_t ifindex, uint8_t num_labels,
+					 mpls_label_t *out_labels);
 
-zebra_nhlfe_t *dplane_ctx_add_backup_nhlfe(struct zebra_dplane_ctx *ctx,
-					   enum lsp_types_t lsp_type,
-					   enum nexthop_types_t nh_type,
-					   const union g_addr *gate,
-					   ifindex_t ifindex,
-					   uint8_t num_labels,
-					   mpls_label_t *out_labels);
+struct zebra_nhlfe *dplane_ctx_add_backup_nhlfe(
+	struct zebra_dplane_ctx *ctx, enum lsp_types_t lsp_type,
+	enum nexthop_types_t nh_type, const union g_addr *gate,
+	ifindex_t ifindex, uint8_t num_labels, mpls_label_t *out_labels);
 
-const zebra_nhlfe_t *dplane_ctx_get_best_nhlfe(
-	const struct zebra_dplane_ctx *ctx);
-const zebra_nhlfe_t *dplane_ctx_set_best_nhlfe(struct zebra_dplane_ctx *ctx,
-					       zebra_nhlfe_t *nhlfe);
+const struct zebra_nhlfe *
+dplane_ctx_get_best_nhlfe(const struct zebra_dplane_ctx *ctx);
+const struct zebra_nhlfe *
+dplane_ctx_set_best_nhlfe(struct zebra_dplane_ctx *ctx,
+			  struct zebra_nhlfe *nhlfe);
 uint32_t dplane_ctx_get_lsp_num_ecmp(const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for pseudowire information */

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -434,7 +434,7 @@ int zebra_evpn_advertise_subnet(struct zebra_evpn *zevpn, struct interface *ifp,
 int zebra_evpn_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 			    struct ethaddr *macaddr, struct ipaddr *ip)
 {
-	zebra_mac_t *mac = NULL;
+	struct zebra_mac *mac = NULL;
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan *vxl = NULL;
 
@@ -459,7 +459,7 @@ int zebra_evpn_gw_macip_del(struct interface *ifp, struct zebra_evpn *zevpn,
 			    struct ipaddr *ip)
 {
 	zebra_neigh_t *n = NULL;
-	zebra_mac_t *mac = NULL;
+	struct zebra_mac *mac = NULL;
 
 	/* If the neigh entry is not present nothing to do*/
 	n = zebra_evpn_neigh_lookup(zevpn, ip);
@@ -900,10 +900,10 @@ struct interface *zebra_evpn_map_to_macvlan(struct interface *br_if,
  */
 void zebra_evpn_install_mac_hash(struct hash_bucket *bucket, void *ctxt)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	struct mac_walk_ctx *wctx = ctxt;
 
-	mac = (zebra_mac_t *)bucket->data;
+	mac = (struct zebra_mac *)bucket->data;
 
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE))
 		zebra_evpn_rem_mac_install(wctx->zevpn, mac, false);
@@ -1394,7 +1394,7 @@ void zebra_evpn_rem_macip_add(vni_t vni, const struct ethaddr *macaddr,
 {
 	struct zebra_evpn *zevpn;
 	struct zebra_vtep *zvtep;
-	zebra_mac_t *mac = NULL;
+	struct zebra_mac *mac = NULL;
 	struct interface *ifp = NULL;
 	struct zebra_if *zif = NULL;
 	struct zebra_vrf *zvrf;
@@ -1470,7 +1470,7 @@ void zebra_evpn_rem_macip_del(vni_t vni, const struct ethaddr *macaddr,
 			      struct in_addr vtep_ip)
 {
 	struct zebra_evpn *zevpn;
-	zebra_mac_t *mac = NULL;
+	struct zebra_mac *mac = NULL;
 	zebra_neigh_t *n = NULL;
 	struct interface *ifp = NULL;
 	struct zebra_if *zif = NULL;

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -68,7 +68,7 @@ static const struct message zvtep_flood_str[] = {
 	{0}
 };
 
-int advertise_gw_macip_enabled(zebra_evpn_t *zevpn)
+int advertise_gw_macip_enabled(struct zebra_evpn *zevpn)
 {
 	struct zebra_vrf *zvrf;
 
@@ -82,7 +82,7 @@ int advertise_gw_macip_enabled(zebra_evpn_t *zevpn)
 	return 0;
 }
 
-int advertise_svi_macip_enabled(zebra_evpn_t *zevpn)
+int advertise_svi_macip_enabled(struct zebra_evpn *zevpn)
 {
 	struct zebra_vrf *zvrf;
 
@@ -99,7 +99,7 @@ int advertise_svi_macip_enabled(zebra_evpn_t *zevpn)
 /*
  * Print a specific EVPN entry.
  */
-void zebra_evpn_print(zebra_evpn_t *zevpn, void **ctxt)
+void zebra_evpn_print(struct zebra_evpn *zevpn, void **ctxt)
 {
 	struct vty *vty;
 	zebra_vtep_t *zvtep;
@@ -217,7 +217,7 @@ void zebra_evpn_print(zebra_evpn_t *zevpn, void **ctxt)
 void zebra_evpn_print_hash(struct hash_bucket *bucket, void *ctxt[])
 {
 	struct vty *vty;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_vtep_t *zvtep;
 	uint32_t num_vteps = 0;
 	uint32_t num_macs = 0;
@@ -231,7 +231,7 @@ void zebra_evpn_print_hash(struct hash_bucket *bucket, void *ctxt[])
 	vty = ctxt[0];
 	json = ctxt[1];
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 
 	zvtep = zevpn->vteps;
 	while (zvtep) {
@@ -283,7 +283,7 @@ void zebra_evpn_print_hash(struct hash_bucket *bucket, void *ctxt[])
 void zebra_evpn_print_hash_detail(struct hash_bucket *bucket, void *data)
 {
 	struct vty *vty;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	json_object *json_array = NULL;
 	bool use_json = false;
 	struct zebra_evpn_show *zes = data;
@@ -292,7 +292,7 @@ void zebra_evpn_print_hash_detail(struct hash_bucket *bucket, void *data)
 	json_array = zes->json;
 	use_json = zes->use_json;
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 
 	zebra_vxlan_print_vni(vty, zes->zvrf, zevpn->vni, use_json, json_array);
 
@@ -300,7 +300,8 @@ void zebra_evpn_print_hash_detail(struct hash_bucket *bucket, void *data)
 		vty_out(vty, "\n");
 }
 
-int zebra_evpn_del_macip_for_intf(struct interface *ifp, zebra_evpn_t *zevpn)
+int zebra_evpn_del_macip_for_intf(struct interface *ifp,
+				  struct zebra_evpn *zevpn)
 {
 	struct listnode *cnode = NULL, *cnnode = NULL;
 	struct connected *c = NULL;
@@ -333,7 +334,8 @@ int zebra_evpn_del_macip_for_intf(struct interface *ifp, zebra_evpn_t *zevpn)
 	return 0;
 }
 
-int zebra_evpn_add_macip_for_intf(struct interface *ifp, zebra_evpn_t *zevpn)
+int zebra_evpn_add_macip_for_intf(struct interface *ifp,
+				  struct zebra_evpn *zevpn)
 {
 	struct listnode *cnode = NULL, *cnnode = NULL;
 	struct connected *c = NULL;
@@ -397,7 +399,7 @@ static int ip_prefix_send_to_client(vrf_id_t vrf_id, struct prefix *p,
 	return zserv_send_message(client, s);
 }
 
-int zebra_evpn_advertise_subnet(zebra_evpn_t *zevpn, struct interface *ifp,
+int zebra_evpn_advertise_subnet(struct zebra_evpn *zevpn, struct interface *ifp,
 				int advertise)
 {
 	struct listnode *cnode = NULL, *cnnode = NULL;
@@ -429,7 +431,7 @@ int zebra_evpn_advertise_subnet(zebra_evpn_t *zevpn, struct interface *ifp,
 /*
  * zebra_evpn_gw_macip_add_to_client
  */
-int zebra_evpn_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
+int zebra_evpn_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 			    struct ethaddr *macaddr, struct ipaddr *ip)
 {
 	zebra_mac_t *mac = NULL;
@@ -453,7 +455,7 @@ int zebra_evpn_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
 /*
  * zebra_evpn_gw_macip_del_from_client
  */
-int zebra_evpn_gw_macip_del(struct interface *ifp, zebra_evpn_t *zevpn,
+int zebra_evpn_gw_macip_del(struct interface *ifp, struct zebra_evpn *zevpn,
 			    struct ipaddr *ip)
 {
 	zebra_neigh_t *n = NULL;
@@ -502,7 +504,7 @@ int zebra_evpn_gw_macip_del(struct interface *ifp, zebra_evpn_t *zevpn,
 void zebra_evpn_gw_macip_del_for_evpn_hash(struct hash_bucket *bucket,
 					   void *ctxt)
 {
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan zl2_info;
 	struct interface *vlan_if = NULL;
@@ -510,7 +512,7 @@ void zebra_evpn_gw_macip_del_for_evpn_hash(struct hash_bucket *bucket,
 	struct interface *ifp;
 
 	/* Add primary SVI MAC*/
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 
 	/* Global (Zvrf) advertise-default-gw is disabled,
 	 * but zevpn advertise-default-gw is enabled
@@ -552,14 +554,14 @@ void zebra_evpn_gw_macip_del_for_evpn_hash(struct hash_bucket *bucket,
 void zebra_evpn_gw_macip_add_for_evpn_hash(struct hash_bucket *bucket,
 					   void *ctxt)
 {
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan zl2_info;
 	struct interface *vlan_if = NULL;
 	struct interface *vrr_if = NULL;
 	struct interface *ifp = NULL;
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 
 	ifp = zevpn->vxlan_if;
 	if (!ifp)
@@ -594,14 +596,14 @@ void zebra_evpn_gw_macip_add_for_evpn_hash(struct hash_bucket *bucket,
 void zebra_evpn_svi_macip_del_for_evpn_hash(struct hash_bucket *bucket,
 					    void *ctxt)
 {
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan zl2_info;
 	struct interface *vlan_if = NULL;
 	struct interface *ifp;
 
 	/* Add primary SVI MAC*/
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 	if (!zevpn)
 		return;
 
@@ -644,8 +646,8 @@ static int zebra_evpn_map_vlan_ns(struct ns *ns,
 	struct zebra_ns *zns = ns->info;
 	struct route_node *rn;
 	struct interface *br_if;
-	zebra_evpn_t **p_zevpn = (zebra_evpn_t **)_p_zevpn;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn **p_zevpn = (struct zebra_evpn **)_p_zevpn;
+	struct zebra_evpn *zevpn;
 	struct interface *tmp_if = NULL;
 	struct zebra_if *zif;
 	struct zebra_l2info_vxlan *vxl = NULL;
@@ -695,13 +697,13 @@ static int zebra_evpn_map_vlan_ns(struct ns *ns,
  * Map port or (port, VLAN) to an EVPN. This is invoked upon getting MAC
  * notifications, to see if they are of interest.
  */
-zebra_evpn_t *zebra_evpn_map_vlan(struct interface *ifp,
-				  struct interface *br_if, vlanid_t vid)
+struct zebra_evpn *zebra_evpn_map_vlan(struct interface *ifp,
+				       struct interface *br_if, vlanid_t vid)
 {
 	struct zebra_if *zif;
 	struct zebra_l2info_bridge *br;
-	zebra_evpn_t **p_zevpn;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn **p_zevpn;
+	struct zebra_evpn *zevpn = NULL;
 	struct zebra_from_svi_param in_param;
 
 	/* Determine if bridge is VLAN-aware or not */
@@ -727,8 +729,8 @@ static int zebra_evpn_from_svi_ns(struct ns *ns,
 	struct zebra_ns *zns = ns->info;
 	struct route_node *rn;
 	struct interface *br_if;
-	zebra_evpn_t **p_zevpn = (zebra_evpn_t **)_p_zevpn;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn **p_zevpn = (struct zebra_evpn **)_p_zevpn;
+	struct zebra_evpn *zevpn;
 	struct interface *tmp_if = NULL;
 	struct zebra_if *zif;
 	struct zebra_l2info_vxlan *vxl = NULL;
@@ -777,12 +779,12 @@ static int zebra_evpn_from_svi_ns(struct ns *ns,
  * Map SVI and associated bridge to an EVPN. This is invoked upon getting
  * neighbor notifications, to see if they are of interest.
  */
-zebra_evpn_t *zebra_evpn_from_svi(struct interface *ifp,
-				  struct interface *br_if)
+struct zebra_evpn *zebra_evpn_from_svi(struct interface *ifp,
+				       struct interface *br_if)
 {
 	struct zebra_l2info_bridge *br;
-	zebra_evpn_t *zevpn = NULL;
-	zebra_evpn_t **p_zevpn;
+	struct zebra_evpn *zevpn = NULL;
+	struct zebra_evpn **p_zevpn;
 	struct zebra_if *zif;
 	struct zebra_from_svi_param in_param;
 
@@ -910,7 +912,7 @@ void zebra_evpn_install_mac_hash(struct hash_bucket *bucket, void *ctxt)
 /*
  * Read and populate local MACs and neighbors corresponding to this EVPN.
  */
-void zebra_evpn_read_mac_neigh(zebra_evpn_t *zevpn, struct interface *ifp)
+void zebra_evpn_read_mac_neigh(struct zebra_evpn *zevpn, struct interface *ifp)
 {
 	struct zebra_ns *zns;
 	struct zebra_vrf *zvrf;
@@ -959,7 +961,7 @@ void zebra_evpn_read_mac_neigh(zebra_evpn_t *zevpn, struct interface *ifp)
  */
 unsigned int zebra_evpn_hash_keymake(const void *p)
 {
-	const zebra_evpn_t *zevpn = p;
+	const struct zebra_evpn *zevpn = p;
 
 	return (jhash_1word(zevpn->vni, 0));
 }
@@ -969,16 +971,16 @@ unsigned int zebra_evpn_hash_keymake(const void *p)
  */
 bool zebra_evpn_hash_cmp(const void *p1, const void *p2)
 {
-	const zebra_evpn_t *zevpn1 = p1;
-	const zebra_evpn_t *zevpn2 = p2;
+	const struct zebra_evpn *zevpn1 = p1;
+	const struct zebra_evpn *zevpn2 = p2;
 
 	return (zevpn1->vni == zevpn2->vni);
 }
 
 int zebra_evpn_list_cmp(void *p1, void *p2)
 {
-	const zebra_evpn_t *zevpn1 = p1;
-	const zebra_evpn_t *zevpn2 = p2;
+	const struct zebra_evpn *zevpn1 = p1;
+	const struct zebra_evpn *zevpn2 = p2;
 
 	if (zevpn1->vni == zevpn2->vni)
 		return 0;
@@ -990,10 +992,10 @@ int zebra_evpn_list_cmp(void *p1, void *p2)
  */
 void *zebra_evpn_alloc(void *p)
 {
-	const zebra_evpn_t *tmp_vni = p;
-	zebra_evpn_t *zevpn;
+	const struct zebra_evpn *tmp_vni = p;
+	struct zebra_evpn *zevpn;
 
-	zevpn = XCALLOC(MTYPE_ZEVPN, sizeof(zebra_evpn_t));
+	zevpn = XCALLOC(MTYPE_ZEVPN, sizeof(struct zebra_evpn));
 	zevpn->vni = tmp_vni->vni;
 	return ((void *)zevpn);
 }
@@ -1001,15 +1003,15 @@ void *zebra_evpn_alloc(void *p)
 /*
  * Look up EVPN hash entry.
  */
-zebra_evpn_t *zebra_evpn_lookup(vni_t vni)
+struct zebra_evpn *zebra_evpn_lookup(vni_t vni)
 {
 	struct zebra_vrf *zvrf;
-	zebra_evpn_t tmp_vni;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn tmp_vni;
+	struct zebra_evpn *zevpn = NULL;
 
 	zvrf = zebra_vrf_get_evpn();
 	assert(zvrf);
-	memset(&tmp_vni, 0, sizeof(zebra_evpn_t));
+	memset(&tmp_vni, 0, sizeof(struct zebra_evpn));
 	tmp_vni.vni = vni;
 	zevpn = hash_lookup(zvrf->evpn_table, &tmp_vni);
 
@@ -1019,16 +1021,16 @@ zebra_evpn_t *zebra_evpn_lookup(vni_t vni)
 /*
  * Add EVPN hash entry.
  */
-zebra_evpn_t *zebra_evpn_add(vni_t vni)
+struct zebra_evpn *zebra_evpn_add(vni_t vni)
 {
 	char buffer[80];
 	struct zebra_vrf *zvrf;
-	zebra_evpn_t tmp_zevpn;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn tmp_zevpn;
+	struct zebra_evpn *zevpn = NULL;
 
 	zvrf = zebra_vrf_get_evpn();
 	assert(zvrf);
-	memset(&tmp_zevpn, 0, sizeof(zebra_evpn_t));
+	memset(&tmp_zevpn, 0, sizeof(struct zebra_evpn));
 	tmp_zevpn.vni = vni;
 	zevpn = hash_get(zvrf->evpn_table, &tmp_zevpn, zebra_evpn_alloc);
 	assert(zevpn);
@@ -1050,10 +1052,10 @@ zebra_evpn_t *zebra_evpn_add(vni_t vni)
 /*
  * Delete EVPN hash entry.
  */
-int zebra_evpn_del(zebra_evpn_t *zevpn)
+int zebra_evpn_del(struct zebra_evpn *zevpn)
 {
 	struct zebra_vrf *zvrf;
-	zebra_evpn_t *tmp_zevpn;
+	struct zebra_evpn *tmp_zevpn;
 
 	zvrf = zebra_vrf_get_evpn();
 	assert(zvrf);
@@ -1083,7 +1085,7 @@ int zebra_evpn_del(zebra_evpn_t *zevpn)
 /*
  * Inform BGP about local EVPN addition.
  */
-int zebra_evpn_send_add_to_client(zebra_evpn_t *zevpn)
+int zebra_evpn_send_add_to_client(struct zebra_evpn *zevpn)
 {
 	struct zserv *client;
 	struct stream *s;
@@ -1133,7 +1135,7 @@ int zebra_evpn_send_add_to_client(zebra_evpn_t *zevpn)
 /*
  * Inform BGP about local EVPN deletion.
  */
-int zebra_evpn_send_del_to_client(zebra_evpn_t *zevpn)
+int zebra_evpn_send_del_to_client(struct zebra_evpn *zevpn)
 {
 	struct zserv *client;
 	struct stream *s;
@@ -1177,7 +1179,8 @@ static int zebra_evpn_vtep_match(struct in_addr *vtep_ip, zebra_vtep_t *zvtep)
 /*
  * Locate remote VTEP in EVPN hash table.
  */
-zebra_vtep_t *zebra_evpn_vtep_find(zebra_evpn_t *zevpn, struct in_addr *vtep_ip)
+zebra_vtep_t *zebra_evpn_vtep_find(struct zebra_evpn *zevpn,
+				   struct in_addr *vtep_ip)
 {
 	zebra_vtep_t *zvtep;
 
@@ -1195,8 +1198,8 @@ zebra_vtep_t *zebra_evpn_vtep_find(zebra_evpn_t *zevpn, struct in_addr *vtep_ip)
 /*
  * Add remote VTEP to EVPN hash table.
  */
-zebra_vtep_t *zebra_evpn_vtep_add(zebra_evpn_t *zevpn, struct in_addr *vtep_ip,
-				  int flood_control)
+zebra_vtep_t *zebra_evpn_vtep_add(struct zebra_evpn *zevpn,
+				  struct in_addr *vtep_ip, int flood_control)
 
 {
 	zebra_vtep_t *zvtep;
@@ -1217,7 +1220,7 @@ zebra_vtep_t *zebra_evpn_vtep_add(zebra_evpn_t *zevpn, struct in_addr *vtep_ip,
 /*
  * Remove remote VTEP from EVPN hash table.
  */
-int zebra_evpn_vtep_del(zebra_evpn_t *zevpn, zebra_vtep_t *zvtep)
+int zebra_evpn_vtep_del(struct zebra_evpn *zevpn, zebra_vtep_t *zvtep)
 {
 	if (zvtep->next)
 		zvtep->next->prev = zvtep->prev;
@@ -1236,7 +1239,7 @@ int zebra_evpn_vtep_del(zebra_evpn_t *zevpn, zebra_vtep_t *zvtep)
  * Delete all remote VTEPs for this EVPN (upon VNI delete). Also
  * uninstall from kernel if asked to.
  */
-int zebra_evpn_vtep_del_all(zebra_evpn_t *zevpn, int uninstall)
+int zebra_evpn_vtep_del_all(struct zebra_evpn *zevpn, int uninstall)
 {
 	zebra_vtep_t *zvtep, *zvtep_next;
 
@@ -1257,7 +1260,7 @@ int zebra_evpn_vtep_del_all(zebra_evpn_t *zevpn, int uninstall)
  * Install remote VTEP into the kernel if the remote VTEP has asked
  * for head-end-replication.
  */
-int zebra_evpn_vtep_install(zebra_evpn_t *zevpn, zebra_vtep_t *zvtep)
+int zebra_evpn_vtep_install(struct zebra_evpn *zevpn, zebra_vtep_t *zvtep)
 {
 	if (is_vxlan_flooding_head_end() &&
 	    (zvtep->flood_control == VXLAN_FLOOD_HEAD_END_REPL)) {
@@ -1273,7 +1276,7 @@ int zebra_evpn_vtep_install(zebra_evpn_t *zevpn, zebra_vtep_t *zvtep)
 /*
  * Uninstall remote VTEP from the kernel.
  */
-int zebra_evpn_vtep_uninstall(zebra_evpn_t *zevpn, struct in_addr *vtep_ip)
+int zebra_evpn_vtep_uninstall(struct zebra_evpn *zevpn, struct in_addr *vtep_ip)
 {
 	if (!zevpn->vxlan_if) {
 		zlog_debug("VNI %u hash %p couldn't be uninstalled - no intf",
@@ -1295,10 +1298,10 @@ int zebra_evpn_vtep_uninstall(zebra_evpn_t *zevpn, struct in_addr *vtep_ip)
 void zebra_evpn_handle_flooding_remote_vteps(struct hash_bucket *bucket,
 					     void *zvrf)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_vtep_t *zvtep;
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 	if (!zevpn)
 		return;
 
@@ -1315,9 +1318,9 @@ void zebra_evpn_handle_flooding_remote_vteps(struct hash_bucket *bucket,
  */
 void zebra_evpn_cleanup_all(struct hash_bucket *bucket, void *arg)
 {
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 
 	/* Free up all neighbors and MACs, if any. */
 	zebra_evpn_neigh_del_all(zevpn, 1, 0, DEL_ALL_NEIGH);
@@ -1330,7 +1333,7 @@ void zebra_evpn_cleanup_all(struct hash_bucket *bucket, void *arg)
 	zebra_evpn_del(zevpn);
 }
 
-static void zebra_evpn_process_sync_macip_add(zebra_evpn_t *zevpn,
+static void zebra_evpn_process_sync_macip_add(struct zebra_evpn *zevpn,
 					      const struct ethaddr *macaddr,
 					      uint16_t ipa_len,
 					      const struct ipaddr *ipaddr,
@@ -1387,7 +1390,7 @@ void zebra_evpn_rem_macip_add(vni_t vni, const struct ethaddr *macaddr,
 			      uint8_t flags, uint32_t seq,
 			      struct in_addr vtep_ip, const esi_t *esi)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_vtep_t *zvtep;
 	zebra_mac_t *mac = NULL;
 	struct interface *ifp = NULL;
@@ -1464,7 +1467,7 @@ void zebra_evpn_rem_macip_del(vni_t vni, const struct ethaddr *macaddr,
 			      uint16_t ipa_len, const struct ipaddr *ipaddr,
 			      struct in_addr vtep_ip)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_mac_t *mac = NULL;
 	zebra_neigh_t *n = NULL;
 	struct interface *ifp = NULL;
@@ -1558,9 +1561,9 @@ void zebra_evpn_rem_macip_del(vni_t vni, const struct ethaddr *macaddr,
 /************************** EVPN BGP config management ************************/
 void zebra_evpn_cfg_cleanup(struct hash_bucket *bucket, void *ctxt)
 {
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 	zevpn->advertise_gw_macip = 0;
 	zevpn->advertise_svi_macip = 0;
 	zevpn->advertise_subnet = 0;

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -458,7 +458,7 @@ int zebra_evpn_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 int zebra_evpn_gw_macip_del(struct interface *ifp, struct zebra_evpn *zevpn,
 			    struct ipaddr *ip)
 {
-	zebra_neigh_t *n = NULL;
+	struct zebra_neigh *n = NULL;
 	struct zebra_mac *mac = NULL;
 
 	/* If the neigh entry is not present nothing to do*/
@@ -1346,7 +1346,7 @@ static void zebra_evpn_process_sync_macip_add(struct zebra_evpn *zevpn,
 	char ipbuf[INET6_ADDRSTRLEN];
 	bool sticky;
 	bool remote_gw;
-	zebra_neigh_t *n = NULL;
+	struct zebra_neigh *n = NULL;
 
 	sticky = !!CHECK_FLAG(flags, ZEBRA_MACIP_TYPE_STICKY);
 	remote_gw = !!CHECK_FLAG(flags, ZEBRA_MACIP_TYPE_GW);
@@ -1471,7 +1471,7 @@ void zebra_evpn_rem_macip_del(vni_t vni, const struct ethaddr *macaddr,
 {
 	struct zebra_evpn *zevpn;
 	struct zebra_mac *mac = NULL;
-	zebra_neigh_t *n = NULL;
+	struct zebra_neigh *n = NULL;
 	struct interface *ifp = NULL;
 	struct zebra_if *zif = NULL;
 	struct zebra_ns *zns;

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -102,7 +102,7 @@ int advertise_svi_macip_enabled(struct zebra_evpn *zevpn)
 void zebra_evpn_print(struct zebra_evpn *zevpn, void **ctxt)
 {
 	struct vty *vty;
-	zebra_vtep_t *zvtep;
+	struct zebra_vtep *zvtep;
 	uint32_t num_macs;
 	uint32_t num_neigh;
 	json_object *json = NULL;
@@ -218,7 +218,7 @@ void zebra_evpn_print_hash(struct hash_bucket *bucket, void *ctxt[])
 {
 	struct vty *vty;
 	struct zebra_evpn *zevpn;
-	zebra_vtep_t *zvtep;
+	struct zebra_vtep *zvtep;
 	uint32_t num_vteps = 0;
 	uint32_t num_macs = 0;
 	uint32_t num_neigh = 0;
@@ -1171,7 +1171,8 @@ int zebra_evpn_send_del_to_client(struct zebra_evpn *zevpn)
 /*
  * See if remote VTEP matches with prefix.
  */
-static int zebra_evpn_vtep_match(struct in_addr *vtep_ip, zebra_vtep_t *zvtep)
+static int zebra_evpn_vtep_match(struct in_addr *vtep_ip,
+				 struct zebra_vtep *zvtep)
 {
 	return (IPV4_ADDR_SAME(vtep_ip, &zvtep->vtep_ip));
 }
@@ -1179,10 +1180,10 @@ static int zebra_evpn_vtep_match(struct in_addr *vtep_ip, zebra_vtep_t *zvtep)
 /*
  * Locate remote VTEP in EVPN hash table.
  */
-zebra_vtep_t *zebra_evpn_vtep_find(struct zebra_evpn *zevpn,
-				   struct in_addr *vtep_ip)
+struct zebra_vtep *zebra_evpn_vtep_find(struct zebra_evpn *zevpn,
+					struct in_addr *vtep_ip)
 {
-	zebra_vtep_t *zvtep;
+	struct zebra_vtep *zvtep;
 
 	if (!zevpn)
 		return NULL;
@@ -1198,13 +1199,14 @@ zebra_vtep_t *zebra_evpn_vtep_find(struct zebra_evpn *zevpn,
 /*
  * Add remote VTEP to EVPN hash table.
  */
-zebra_vtep_t *zebra_evpn_vtep_add(struct zebra_evpn *zevpn,
-				  struct in_addr *vtep_ip, int flood_control)
+struct zebra_vtep *zebra_evpn_vtep_add(struct zebra_evpn *zevpn,
+				       struct in_addr *vtep_ip,
+				       int flood_control)
 
 {
-	zebra_vtep_t *zvtep;
+	struct zebra_vtep *zvtep;
 
-	zvtep = XCALLOC(MTYPE_ZEVPN_VTEP, sizeof(zebra_vtep_t));
+	zvtep = XCALLOC(MTYPE_ZEVPN_VTEP, sizeof(struct zebra_vtep));
 
 	zvtep->vtep_ip = *vtep_ip;
 	zvtep->flood_control = flood_control;
@@ -1220,7 +1222,7 @@ zebra_vtep_t *zebra_evpn_vtep_add(struct zebra_evpn *zevpn,
 /*
  * Remove remote VTEP from EVPN hash table.
  */
-int zebra_evpn_vtep_del(struct zebra_evpn *zevpn, zebra_vtep_t *zvtep)
+int zebra_evpn_vtep_del(struct zebra_evpn *zevpn, struct zebra_vtep *zvtep)
 {
 	if (zvtep->next)
 		zvtep->next->prev = zvtep->prev;
@@ -1241,7 +1243,7 @@ int zebra_evpn_vtep_del(struct zebra_evpn *zevpn, zebra_vtep_t *zvtep)
  */
 int zebra_evpn_vtep_del_all(struct zebra_evpn *zevpn, int uninstall)
 {
-	zebra_vtep_t *zvtep, *zvtep_next;
+	struct zebra_vtep *zvtep, *zvtep_next;
 
 	if (!zevpn)
 		return -1;
@@ -1260,7 +1262,7 @@ int zebra_evpn_vtep_del_all(struct zebra_evpn *zevpn, int uninstall)
  * Install remote VTEP into the kernel if the remote VTEP has asked
  * for head-end-replication.
  */
-int zebra_evpn_vtep_install(struct zebra_evpn *zevpn, zebra_vtep_t *zvtep)
+int zebra_evpn_vtep_install(struct zebra_evpn *zevpn, struct zebra_vtep *zvtep)
 {
 	if (is_vxlan_flooding_head_end() &&
 	    (zvtep->flood_control == VXLAN_FLOOD_HEAD_END_REPL)) {
@@ -1299,7 +1301,7 @@ void zebra_evpn_handle_flooding_remote_vteps(struct hash_bucket *bucket,
 					     void *zvrf)
 {
 	struct zebra_evpn *zevpn;
-	zebra_vtep_t *zvtep;
+	struct zebra_vtep *zvtep;
 
 	zevpn = (struct zebra_evpn *)bucket->data;
 	if (!zevpn)
@@ -1391,7 +1393,7 @@ void zebra_evpn_rem_macip_add(vni_t vni, const struct ethaddr *macaddr,
 			      struct in_addr vtep_ip, const esi_t *esi)
 {
 	struct zebra_evpn *zevpn;
-	zebra_vtep_t *zvtep;
+	struct zebra_vtep *zvtep;
 	zebra_mac_t *mac = NULL;
 	struct interface *ifp = NULL;
 	struct zebra_if *zif = NULL;

--- a/zebra/zebra_evpn.h
+++ b/zebra/zebra_evpn.h
@@ -38,7 +38,6 @@
 extern "C" {
 #endif
 
-typedef struct zebra_evpn_t_ zebra_evpn_t;
 typedef struct zebra_vtep_t_ zebra_vtep_t;
 
 RB_HEAD(zebra_es_evi_rb_head, zebra_evpn_es_evi);
@@ -78,7 +77,7 @@ struct zebra_vtep_t_ {
  * Contains information pertaining to a VNI:
  * - the list of remote VTEPs (with this VNI)
  */
-struct zebra_evpn_t_ {
+struct zebra_evpn {
 	/* VNI - key */
 	vni_t vni;
 
@@ -137,7 +136,7 @@ struct zebra_from_svi_param {
 
 struct interface *zvni_map_to_svi(vlanid_t vid, struct interface *br_if);
 
-static inline struct interface *zevpn_map_to_svi(zebra_evpn_t *zevpn)
+static inline struct interface *zevpn_map_to_svi(struct zebra_evpn *zevpn)
 {
 	struct interface *ifp;
 	struct zebra_if *zif = NULL;
@@ -157,18 +156,20 @@ static inline struct interface *zevpn_map_to_svi(zebra_evpn_t *zevpn)
 	return zvni_map_to_svi(zl2_info.access_vlan, zif->brslave_info.br_if);
 }
 
-int advertise_gw_macip_enabled(zebra_evpn_t *zevpn);
-int advertise_svi_macip_enabled(zebra_evpn_t *zevpn);
-void zebra_evpn_print(zebra_evpn_t *zevpn, void **ctxt);
+int advertise_gw_macip_enabled(struct zebra_evpn *zevpn);
+int advertise_svi_macip_enabled(struct zebra_evpn *zevpn);
+void zebra_evpn_print(struct zebra_evpn *zevpn, void **ctxt);
 void zebra_evpn_print_hash(struct hash_bucket *bucket, void *ctxt[]);
 void zebra_evpn_print_hash_detail(struct hash_bucket *bucket, void *data);
-int zebra_evpn_add_macip_for_intf(struct interface *ifp, zebra_evpn_t *zevpn);
-int zebra_evpn_del_macip_for_intf(struct interface *ifp, zebra_evpn_t *zevpn);
-int zebra_evpn_advertise_subnet(zebra_evpn_t *zevpn, struct interface *ifp,
+int zebra_evpn_add_macip_for_intf(struct interface *ifp,
+				  struct zebra_evpn *zevpn);
+int zebra_evpn_del_macip_for_intf(struct interface *ifp,
+				  struct zebra_evpn *zevpn);
+int zebra_evpn_advertise_subnet(struct zebra_evpn *zevpn, struct interface *ifp,
 				int advertise);
-int zebra_evpn_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
+int zebra_evpn_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 			    struct ethaddr *macaddr, struct ipaddr *ip);
-int zebra_evpn_gw_macip_del(struct interface *ifp, zebra_evpn_t *zevpn,
+int zebra_evpn_gw_macip_del(struct interface *ifp, struct zebra_evpn *zevpn,
 			    struct ipaddr *ip);
 void zebra_evpn_gw_macip_del_for_evpn_hash(struct hash_bucket *bucket,
 					   void *ctxt);
@@ -176,31 +177,32 @@ void zebra_evpn_gw_macip_add_for_evpn_hash(struct hash_bucket *bucket,
 					   void *ctxt);
 void zebra_evpn_svi_macip_del_for_evpn_hash(struct hash_bucket *bucket,
 					    void *ctxt);
-zebra_evpn_t *zebra_evpn_map_vlan(struct interface *ifp,
-				  struct interface *br_if, vlanid_t vid);
-zebra_evpn_t *zebra_evpn_from_svi(struct interface *ifp,
-				  struct interface *br_if);
+struct zebra_evpn *zebra_evpn_map_vlan(struct interface *ifp,
+				       struct interface *br_if, vlanid_t vid);
+struct zebra_evpn *zebra_evpn_from_svi(struct interface *ifp,
+				       struct interface *br_if);
 struct interface *zebra_evpn_map_to_macvlan(struct interface *br_if,
 					    struct interface *svi_if);
 void zebra_evpn_install_mac_hash(struct hash_bucket *bucket, void *ctxt);
-void zebra_evpn_read_mac_neigh(zebra_evpn_t *zevpn, struct interface *ifp);
+void zebra_evpn_read_mac_neigh(struct zebra_evpn *zevpn, struct interface *ifp);
 unsigned int zebra_evpn_hash_keymake(const void *p);
 bool zebra_evpn_hash_cmp(const void *p1, const void *p2);
 int zebra_evpn_list_cmp(void *p1, void *p2);
 void *zebra_evpn_alloc(void *p);
-zebra_evpn_t *zebra_evpn_lookup(vni_t vni);
-zebra_evpn_t *zebra_evpn_add(vni_t vni);
-int zebra_evpn_del(zebra_evpn_t *zevpn);
-int zebra_evpn_send_add_to_client(zebra_evpn_t *zevpn);
-int zebra_evpn_send_del_to_client(zebra_evpn_t *zevpn);
-zebra_vtep_t *zebra_evpn_vtep_find(zebra_evpn_t *zevpn,
+struct zebra_evpn *zebra_evpn_lookup(vni_t vni);
+struct zebra_evpn *zebra_evpn_add(vni_t vni);
+int zebra_evpn_del(struct zebra_evpn *zevpn);
+int zebra_evpn_send_add_to_client(struct zebra_evpn *zevpn);
+int zebra_evpn_send_del_to_client(struct zebra_evpn *zevpn);
+zebra_vtep_t *zebra_evpn_vtep_find(struct zebra_evpn *zevpn,
 				   struct in_addr *vtep_ip);
-zebra_vtep_t *zebra_evpn_vtep_add(zebra_evpn_t *zevpn, struct in_addr *vtep_ip,
-				  int flood_control);
-int zebra_evpn_vtep_del(zebra_evpn_t *zevpn, zebra_vtep_t *zvtep);
-int zebra_evpn_vtep_del_all(zebra_evpn_t *zevpn, int uninstall);
-int zebra_evpn_vtep_install(zebra_evpn_t *zevpn, zebra_vtep_t *zvtep);
-int zebra_evpn_vtep_uninstall(zebra_evpn_t *zevpn, struct in_addr *vtep_ip);
+zebra_vtep_t *zebra_evpn_vtep_add(struct zebra_evpn *zevpn,
+				  struct in_addr *vtep_ip, int flood_control);
+int zebra_evpn_vtep_del(struct zebra_evpn *zevpn, zebra_vtep_t *zvtep);
+int zebra_evpn_vtep_del_all(struct zebra_evpn *zevpn, int uninstall);
+int zebra_evpn_vtep_install(struct zebra_evpn *zevpn, zebra_vtep_t *zvtep);
+int zebra_evpn_vtep_uninstall(struct zebra_evpn *zevpn,
+			      struct in_addr *vtep_ip);
 void zebra_evpn_handle_flooding_remote_vteps(struct hash_bucket *bucket,
 					     void *zvrf);
 void zebra_evpn_cleanup_all(struct hash_bucket *bucket, void *arg);

--- a/zebra/zebra_evpn.h
+++ b/zebra/zebra_evpn.h
@@ -38,8 +38,6 @@
 extern "C" {
 #endif
 
-typedef struct zebra_vtep_t_ zebra_vtep_t;
-
 RB_HEAD(zebra_es_evi_rb_head, zebra_evpn_es_evi);
 RB_PROTOTYPE(zebra_es_evi_rb_head, zebra_evpn_es_evi, rb_node,
 	     zebra_es_evi_rb_cmp);
@@ -57,7 +55,7 @@ struct zebra_evpn_show {
  *
  * Right now, this just has each remote VTEP's IP address.
  */
-struct zebra_vtep_t_ {
+struct zebra_vtep {
 	/* Remote IP. */
 	/* NOTE: Can only be IPv4 right now. */
 	struct in_addr vtep_ip;
@@ -67,8 +65,8 @@ struct zebra_vtep_t_ {
 	int flood_control;
 
 	/* Links. */
-	struct zebra_vtep_t_ *next;
-	struct zebra_vtep_t_ *prev;
+	struct zebra_vtep *next;
+	struct zebra_vtep *prev;
 };
 
 /*
@@ -101,7 +99,7 @@ struct zebra_evpn {
 	struct interface *svi_if;
 
 	/* List of remote VTEPs */
-	zebra_vtep_t *vteps;
+	struct zebra_vtep *vteps;
 
 	/* Local IP */
 	struct in_addr local_vtep_ip;
@@ -194,13 +192,14 @@ struct zebra_evpn *zebra_evpn_add(vni_t vni);
 int zebra_evpn_del(struct zebra_evpn *zevpn);
 int zebra_evpn_send_add_to_client(struct zebra_evpn *zevpn);
 int zebra_evpn_send_del_to_client(struct zebra_evpn *zevpn);
-zebra_vtep_t *zebra_evpn_vtep_find(struct zebra_evpn *zevpn,
-				   struct in_addr *vtep_ip);
-zebra_vtep_t *zebra_evpn_vtep_add(struct zebra_evpn *zevpn,
-				  struct in_addr *vtep_ip, int flood_control);
-int zebra_evpn_vtep_del(struct zebra_evpn *zevpn, zebra_vtep_t *zvtep);
+struct zebra_vtep *zebra_evpn_vtep_find(struct zebra_evpn *zevpn,
+					struct in_addr *vtep_ip);
+struct zebra_vtep *zebra_evpn_vtep_add(struct zebra_evpn *zevpn,
+				       struct in_addr *vtep_ip,
+				       int flood_control);
+int zebra_evpn_vtep_del(struct zebra_evpn *zevpn, struct zebra_vtep *zvtep);
 int zebra_evpn_vtep_del_all(struct zebra_evpn *zevpn, int uninstall);
-int zebra_evpn_vtep_install(struct zebra_evpn *zevpn, zebra_vtep_t *zvtep);
+int zebra_evpn_vtep_install(struct zebra_evpn *zevpn, struct zebra_vtep *zvtep);
 int zebra_evpn_vtep_uninstall(struct zebra_evpn *zevpn,
 			      struct in_addr *vtep_ip);
 void zebra_evpn_handle_flooding_remote_vteps(struct hash_bucket *bucket,

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -47,7 +47,7 @@ DEFINE_MTYPE_STATIC(ZEBRA, MAC, "EVPN MAC");
  * Return number of valid MACs in an EVPN's MAC hash table - all
  * remote MACs and non-internal (auto) local MACs count.
  */
-uint32_t num_valid_macs(zebra_evpn_t *zevpn)
+uint32_t num_valid_macs(struct zebra_evpn *zevpn)
 {
 	unsigned int i;
 	uint32_t num_macs = 0;
@@ -71,7 +71,7 @@ uint32_t num_valid_macs(zebra_evpn_t *zevpn)
 	return num_macs;
 }
 
-uint32_t num_dup_detected_macs(zebra_evpn_t *zevpn)
+uint32_t num_dup_detected_macs(struct zebra_evpn *zevpn)
 {
 	unsigned int i;
 	uint32_t num_macs = 0;
@@ -187,7 +187,7 @@ void zebra_evpn_mac_clear_fwd_info(zebra_mac_t *zmac)
 /*
  * Install remote MAC into the forwarding plane.
  */
-int zebra_evpn_rem_mac_install(zebra_evpn_t *zevpn, zebra_mac_t *mac,
+int zebra_evpn_rem_mac_install(struct zebra_evpn *zevpn, zebra_mac_t *mac,
 			       bool was_static)
 {
 	const struct zebra_if *zif, *br_zif;
@@ -243,7 +243,7 @@ int zebra_evpn_rem_mac_install(zebra_evpn_t *zevpn, zebra_mac_t *mac,
 /*
  * Uninstall remote MAC from the forwarding plane.
  */
-int zebra_evpn_rem_mac_uninstall(zebra_evpn_t *zevpn, zebra_mac_t *mac,
+int zebra_evpn_rem_mac_uninstall(struct zebra_evpn *zevpn, zebra_mac_t *mac,
 				 bool force)
 {
 	const struct zebra_if *zif, *br_zif;
@@ -296,7 +296,7 @@ int zebra_evpn_rem_mac_uninstall(zebra_evpn_t *zevpn, zebra_mac_t *mac,
  * Decrement neighbor refcount of MAC; uninstall and free it if
  * appropriate.
  */
-void zebra_evpn_deref_ip2mac(zebra_evpn_t *zevpn, zebra_mac_t *mac)
+void zebra_evpn_deref_ip2mac(struct zebra_evpn *zevpn, zebra_mac_t *mac)
 {
 	if (!CHECK_FLAG(mac->flags, ZEBRA_MAC_AUTO))
 		return;
@@ -380,7 +380,7 @@ static int zebra_evpn_dad_mac_auto_recovery_exp(struct thread *t)
 {
 	struct zebra_vrf *zvrf = NULL;
 	zebra_mac_t *mac = NULL;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	struct listnode *node = NULL;
 	zebra_neigh_t *nbr = NULL;
 
@@ -1096,7 +1096,7 @@ static void *zebra_evpn_mac_alloc(void *p)
 /*
  * Add MAC entry.
  */
-zebra_mac_t *zebra_evpn_mac_add(zebra_evpn_t *zevpn,
+zebra_mac_t *zebra_evpn_mac_add(struct zebra_evpn *zevpn,
 				const struct ethaddr *macaddr)
 {
 	zebra_mac_t tmp_mac;
@@ -1128,7 +1128,7 @@ zebra_mac_t *zebra_evpn_mac_add(zebra_evpn_t *zevpn,
 /*
  * Delete MAC entry.
  */
-int zebra_evpn_mac_del(zebra_evpn_t *zevpn, zebra_mac_t *mac)
+int zebra_evpn_mac_del(struct zebra_evpn *zevpn, zebra_mac_t *mac)
 {
 	zebra_mac_t *tmp_mac;
 
@@ -1236,8 +1236,8 @@ static void zebra_evpn_mac_del_hash_entry(struct hash_bucket *bucket, void *arg)
 /*
  * Delete all MAC entries for this EVPN.
  */
-void zebra_evpn_mac_del_all(zebra_evpn_t *zevpn, int uninstall, int upd_client,
-			    uint32_t flags)
+void zebra_evpn_mac_del_all(struct zebra_evpn *zevpn, int uninstall,
+			    int upd_client, uint32_t flags)
 {
 	struct mac_walk_ctx wctx;
 
@@ -1256,7 +1256,7 @@ void zebra_evpn_mac_del_all(zebra_evpn_t *zevpn, int uninstall, int upd_client,
 /*
  * Look up MAC hash entry.
  */
-zebra_mac_t *zebra_evpn_mac_lookup(zebra_evpn_t *zevpn,
+zebra_mac_t *zebra_evpn_mac_lookup(struct zebra_evpn *zevpn,
 				   const struct ethaddr *mac)
 {
 	zebra_mac_t tmp;
@@ -1336,7 +1336,7 @@ int zebra_evpn_sync_mac_dp_install(zebra_mac_t *mac, bool set_inactive,
 	struct interface *ifp;
 	bool sticky;
 	bool set_static;
-	zebra_evpn_t *zevpn = mac->zevpn;
+	struct zebra_evpn *zevpn = mac->zevpn;
 	vlanid_t vid;
 	struct zebra_if *zif;
 	struct interface *br_ifp;
@@ -1563,7 +1563,7 @@ void zebra_evpn_sync_mac_del(zebra_mac_t *mac)
 					       __func__);
 }
 
-static inline bool zebra_evpn_mac_is_bgp_seq_ok(zebra_evpn_t *zevpn,
+static inline bool zebra_evpn_mac_is_bgp_seq_ok(struct zebra_evpn *zevpn,
 						zebra_mac_t *mac, uint32_t seq,
 						uint16_t ipa_len,
 						const struct ipaddr *ipaddr,
@@ -1631,9 +1631,9 @@ static inline bool zebra_evpn_mac_is_bgp_seq_ok(zebra_evpn_t *zevpn,
 }
 
 zebra_mac_t *zebra_evpn_proc_sync_mac_update(
-	zebra_evpn_t *zevpn, const struct ethaddr *macaddr, uint16_t ipa_len,
-	const struct ipaddr *ipaddr, uint8_t flags, uint32_t seq,
-	const esi_t *esi, struct sync_mac_ip_ctx *ctx)
+	struct zebra_evpn *zevpn, const struct ethaddr *macaddr,
+	uint16_t ipa_len, const struct ipaddr *ipaddr, uint8_t flags,
+	uint32_t seq, const esi_t *esi, struct sync_mac_ip_ctx *ctx)
 {
 	zebra_mac_t *mac;
 	bool inform_bgp = false;
@@ -1894,7 +1894,7 @@ static void zebra_evpn_send_mac_hash_entry_to_client(struct hash_bucket *bucket,
 }
 
 /* Iterator to Notify Local MACs of a EVPN */
-void zebra_evpn_send_mac_list_to_client(zebra_evpn_t *zevpn)
+void zebra_evpn_send_mac_list_to_client(struct zebra_evpn *zevpn)
 {
 	struct mac_walk_ctx wctx;
 
@@ -1908,7 +1908,7 @@ void zebra_evpn_send_mac_list_to_client(zebra_evpn_t *zevpn)
 		     &wctx);
 }
 
-void zebra_evpn_rem_mac_del(zebra_evpn_t *zevpn, zebra_mac_t *mac)
+void zebra_evpn_rem_mac_del(struct zebra_evpn *zevpn, zebra_mac_t *mac)
 {
 	zebra_evpn_process_neigh_on_remote_mac_del(zevpn, mac);
 	/* the remote sequence number in the auto mac entry
@@ -1960,13 +1960,11 @@ void zebra_evpn_print_dad_mac_hash_detail(struct hash_bucket *bucket,
 		zebra_evpn_print_mac_hash_detail(bucket, ctxt);
 }
 
-int zebra_evpn_mac_remote_macip_add(zebra_evpn_t *zevpn, struct zebra_vrf *zvrf,
-				    const struct ethaddr *macaddr,
-				    uint16_t ipa_len,
-				    const struct ipaddr *ipaddr,
-				    zebra_mac_t **macp, struct in_addr vtep_ip,
-				    uint8_t flags, uint32_t seq,
-				    const esi_t *esi)
+int zebra_evpn_mac_remote_macip_add(
+	struct zebra_evpn *zevpn, struct zebra_vrf *zvrf,
+	const struct ethaddr *macaddr, uint16_t ipa_len,
+	const struct ipaddr *ipaddr, zebra_mac_t **macp, struct in_addr vtep_ip,
+	uint8_t flags, uint32_t seq, const esi_t *esi)
 {
 	char buf1[INET6_ADDRSTRLEN];
 	bool sticky;
@@ -2129,7 +2127,8 @@ int zebra_evpn_mac_remote_macip_add(zebra_evpn_t *zevpn, struct zebra_vrf *zvrf,
 	return 0;
 }
 
-int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf, zebra_evpn_t *zevpn,
+int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf,
+				    struct zebra_evpn *zevpn,
 				    struct interface *ifp,
 				    const struct ethaddr *macaddr, vlanid_t vid,
 				    bool sticky, bool local_inactive,
@@ -2374,7 +2373,7 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf, zebra_evpn_t *zevpn,
 	return 0;
 }
 
-int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, zebra_mac_t *mac,
+int zebra_evpn_del_local_mac(struct zebra_evpn *zevpn, zebra_mac_t *mac,
 			     bool clear_static)
 {
 	bool old_bgp_ready;
@@ -2450,7 +2449,7 @@ int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, zebra_mac_t *mac,
 	return 0;
 }
 
-int zebra_evpn_mac_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
+int zebra_evpn_mac_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 				const struct ipaddr *ip, zebra_mac_t **macp,
 				const struct ethaddr *macaddr, vlanid_t vlan_id,
 				bool def_gw)
@@ -2489,7 +2488,7 @@ int zebra_evpn_mac_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
 	return 0;
 }
 
-void zebra_evpn_mac_svi_del(struct interface *ifp, zebra_evpn_t *zevpn)
+void zebra_evpn_mac_svi_del(struct interface *ifp, struct zebra_evpn *zevpn)
 {
 	zebra_mac_t *mac;
 	struct ethaddr macaddr;
@@ -2512,7 +2511,7 @@ void zebra_evpn_mac_svi_del(struct interface *ifp, zebra_evpn_t *zevpn)
 	}
 }
 
-void zebra_evpn_mac_svi_add(struct interface *ifp, zebra_evpn_t *zevpn)
+void zebra_evpn_mac_svi_add(struct interface *ifp, struct zebra_evpn *zevpn)
 {
 	zebra_mac_t *mac = NULL;
 	struct ethaddr macaddr;

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -53,14 +53,14 @@ uint32_t num_valid_macs(struct zebra_evpn *zevpn)
 	uint32_t num_macs = 0;
 	struct hash *hash;
 	struct hash_bucket *hb;
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 
 	hash = zevpn->mac_table;
 	if (!hash)
 		return num_macs;
 	for (i = 0; i < hash->size; i++) {
 		for (hb = hash->index[i]; hb; hb = hb->next) {
-			mac = (zebra_mac_t *)hb->data;
+			mac = (struct zebra_mac *)hb->data;
 			if (CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE)
 			    || CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL)
 			    || !CHECK_FLAG(mac->flags, ZEBRA_MAC_AUTO))
@@ -77,14 +77,14 @@ uint32_t num_dup_detected_macs(struct zebra_evpn *zevpn)
 	uint32_t num_macs = 0;
 	struct hash *hash;
 	struct hash_bucket *hb;
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 
 	hash = zevpn->mac_table;
 	if (!hash)
 		return num_macs;
 	for (i = 0; i < hash->size; i++) {
 		for (hb = hash->index[i]; hb; hb = hb->next) {
-			mac = (zebra_mac_t *)hb->data;
+			mac = (struct zebra_mac *)hb->data;
 			if (CHECK_FLAG(mac->flags, ZEBRA_MAC_DUPLICATE))
 				num_macs++;
 		}
@@ -120,7 +120,7 @@ void zebra_evpn_mac_ifp_del(struct interface *ifp)
 }
 
 /* Unlink local mac from a destination access port */
-static void zebra_evpn_mac_ifp_unlink(zebra_mac_t *zmac)
+static void zebra_evpn_mac_ifp_unlink(struct zebra_mac *zmac)
 {
 	struct zebra_if *zif;
 	struct interface *ifp = zmac->ifp;
@@ -143,7 +143,8 @@ static void zebra_evpn_mac_ifp_unlink(zebra_mac_t *zmac)
  * local mac is associated with a zero ESI i.e. single attach or lacp-bypass
  * bridge port member
  */
-static void zebra_evpn_mac_ifp_link(zebra_mac_t *zmac, struct interface *ifp)
+static void zebra_evpn_mac_ifp_link(struct zebra_mac *zmac,
+				    struct interface *ifp)
 {
 	struct zebra_if *zif;
 
@@ -178,7 +179,7 @@ static void zebra_evpn_mac_ifp_link(zebra_mac_t *zmac, struct interface *ifp)
 }
 
 /* If the mac is a local mac clear links to destination access port */
-void zebra_evpn_mac_clear_fwd_info(zebra_mac_t *zmac)
+void zebra_evpn_mac_clear_fwd_info(struct zebra_mac *zmac)
 {
 	zebra_evpn_mac_ifp_unlink(zmac);
 	memset(&zmac->fwd_info, 0, sizeof(zmac->fwd_info));
@@ -187,7 +188,7 @@ void zebra_evpn_mac_clear_fwd_info(zebra_mac_t *zmac)
 /*
  * Install remote MAC into the forwarding plane.
  */
-int zebra_evpn_rem_mac_install(struct zebra_evpn *zevpn, zebra_mac_t *mac,
+int zebra_evpn_rem_mac_install(struct zebra_evpn *zevpn, struct zebra_mac *mac,
 			       bool was_static)
 {
 	const struct zebra_if *zif, *br_zif;
@@ -243,8 +244,8 @@ int zebra_evpn_rem_mac_install(struct zebra_evpn *zevpn, zebra_mac_t *mac,
 /*
  * Uninstall remote MAC from the forwarding plane.
  */
-int zebra_evpn_rem_mac_uninstall(struct zebra_evpn *zevpn, zebra_mac_t *mac,
-				 bool force)
+int zebra_evpn_rem_mac_uninstall(struct zebra_evpn *zevpn,
+				 struct zebra_mac *mac, bool force)
 {
 	const struct zebra_if *zif, *br_zif;
 	const struct zebra_l2info_vxlan *vxl;
@@ -296,7 +297,7 @@ int zebra_evpn_rem_mac_uninstall(struct zebra_evpn *zevpn, zebra_mac_t *mac,
  * Decrement neighbor refcount of MAC; uninstall and free it if
  * appropriate.
  */
-void zebra_evpn_deref_ip2mac(struct zebra_evpn *zevpn, zebra_mac_t *mac)
+void zebra_evpn_deref_ip2mac(struct zebra_evpn *zevpn, struct zebra_mac *mac)
 {
 	if (!CHECK_FLAG(mac->flags, ZEBRA_MAC_AUTO))
 		return;
@@ -316,7 +317,7 @@ void zebra_evpn_deref_ip2mac(struct zebra_evpn *zevpn, zebra_mac_t *mac)
 		zebra_evpn_mac_del(zevpn, mac);
 }
 
-static void zebra_evpn_mac_get_access_info(zebra_mac_t *mac,
+static void zebra_evpn_mac_get_access_info(struct zebra_mac *mac,
 					   struct interface **ifpP,
 					   vlanid_t *vid)
 {
@@ -346,7 +347,7 @@ static void zebra_evpn_mac_get_access_info(zebra_mac_t *mac,
 }
 
 #define MAC_BUF_SIZE 256
-static char *zebra_evpn_zebra_mac_flag_dump(struct zebra_mac_t_ *mac, char *buf,
+static char *zebra_evpn_zebra_mac_flag_dump(struct zebra_mac *mac, char *buf,
 					    size_t len)
 {
 	if (mac->flags == 0) {
@@ -379,7 +380,7 @@ static char *zebra_evpn_zebra_mac_flag_dump(struct zebra_mac_t_ *mac, char *buf,
 static int zebra_evpn_dad_mac_auto_recovery_exp(struct thread *t)
 {
 	struct zebra_vrf *zvrf = NULL;
-	zebra_mac_t *mac = NULL;
+	struct zebra_mac *mac = NULL;
 	struct zebra_evpn *zevpn = NULL;
 	struct listnode *node = NULL;
 	zebra_neigh_t *nbr = NULL;
@@ -455,7 +456,7 @@ static int zebra_evpn_dad_mac_auto_recovery_exp(struct thread *t)
 }
 
 static void zebra_evpn_dup_addr_detect_for_mac(struct zebra_vrf *zvrf,
-					       zebra_mac_t *mac,
+					       struct zebra_mac *mac,
 					       struct in_addr vtep_ip,
 					       bool do_dad, bool *is_dup_detect,
 					       bool is_local)
@@ -605,7 +606,7 @@ static void zebra_evpn_dup_addr_detect_for_mac(struct zebra_vrf *zvrf,
 /*
  * Print a specific MAC entry.
  */
-void zebra_evpn_print_mac(zebra_mac_t *mac, void *ctxt, json_object *json)
+void zebra_evpn_print_mac(struct zebra_mac *mac, void *ctxt, json_object *json)
 {
 	struct vty *vty;
 	zebra_neigh_t *n = NULL;
@@ -827,7 +828,7 @@ void zebra_evpn_print_mac(zebra_mac_t *mac, void *ctxt, json_object *json)
 	}
 }
 
-static char *zebra_evpn_print_mac_flags(zebra_mac_t *mac, char *flags_buf,
+static char *zebra_evpn_print_mac_flags(struct zebra_mac *mac, char *flags_buf,
 					size_t flags_buf_sz)
 {
 	snprintf(flags_buf, flags_buf_sz, "%s%s%s%s",
@@ -846,7 +847,7 @@ void zebra_evpn_print_mac_hash(struct hash_bucket *bucket, void *ctxt)
 {
 	struct vty *vty;
 	json_object *json_mac_hdr = NULL, *json_mac = NULL;
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	char buf1[ETHER_ADDR_STRLEN];
 	char addr_buf[PREFIX_STRLEN];
 	struct mac_walk_ctx *wctx = ctxt;
@@ -854,7 +855,7 @@ void zebra_evpn_print_mac_hash(struct hash_bucket *bucket, void *ctxt)
 
 	vty = wctx->vty;
 	json_mac_hdr = wctx->json;
-	mac = (zebra_mac_t *)bucket->data;
+	mac = (struct zebra_mac *)bucket->data;
 
 	prefix_mac2str(&mac->macaddr, buf1, sizeof(buf1));
 
@@ -967,13 +968,13 @@ void zebra_evpn_print_mac_hash_detail(struct hash_bucket *bucket, void *ctxt)
 {
 	struct vty *vty;
 	json_object *json_mac_hdr = NULL;
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	struct mac_walk_ctx *wctx = ctxt;
 	char buf1[ETHER_ADDR_STRLEN];
 
 	vty = wctx->vty;
 	json_mac_hdr = wctx->json;
-	mac = (zebra_mac_t *)bucket->data;
+	mac = (struct zebra_mac *)bucket->data;
 	if (!mac)
 		return;
 
@@ -1055,7 +1056,7 @@ int zebra_evpn_macip_send_msg_to_client(vni_t vni,
 
 static unsigned int mac_hash_keymake(const void *p)
 {
-	const zebra_mac_t *pmac = p;
+	const struct zebra_mac *pmac = p;
 	const void *pnt = (void *)pmac->macaddr.octet;
 
 	return jhash(pnt, ETH_ALEN, 0xa5a5a55a);
@@ -1066,8 +1067,8 @@ static unsigned int mac_hash_keymake(const void *p)
  */
 static bool mac_cmp(const void *p1, const void *p2)
 {
-	const zebra_mac_t *pmac1 = p1;
-	const zebra_mac_t *pmac2 = p2;
+	const struct zebra_mac *pmac1 = p1;
+	const struct zebra_mac *pmac2 = p2;
 
 	if (pmac1 == NULL && pmac2 == NULL)
 		return true;
@@ -1084,10 +1085,10 @@ static bool mac_cmp(const void *p1, const void *p2)
  */
 static void *zebra_evpn_mac_alloc(void *p)
 {
-	const zebra_mac_t *tmp_mac = p;
-	zebra_mac_t *mac;
+	const struct zebra_mac *tmp_mac = p;
+	struct zebra_mac *mac;
 
-	mac = XCALLOC(MTYPE_MAC, sizeof(zebra_mac_t));
+	mac = XCALLOC(MTYPE_MAC, sizeof(struct zebra_mac));
 	*mac = *tmp_mac;
 
 	return ((void *)mac);
@@ -1096,13 +1097,13 @@ static void *zebra_evpn_mac_alloc(void *p)
 /*
  * Add MAC entry.
  */
-zebra_mac_t *zebra_evpn_mac_add(struct zebra_evpn *zevpn,
-				const struct ethaddr *macaddr)
+struct zebra_mac *zebra_evpn_mac_add(struct zebra_evpn *zevpn,
+				     const struct ethaddr *macaddr)
 {
-	zebra_mac_t tmp_mac;
-	zebra_mac_t *mac = NULL;
+	struct zebra_mac tmp_mac;
+	struct zebra_mac *mac = NULL;
 
-	memset(&tmp_mac, 0, sizeof(zebra_mac_t));
+	memset(&tmp_mac, 0, sizeof(struct zebra_mac));
 	memcpy(&tmp_mac.macaddr, macaddr, ETH_ALEN);
 	mac = hash_get(zevpn->mac_table, &tmp_mac, zebra_evpn_mac_alloc);
 	assert(mac);
@@ -1128,9 +1129,9 @@ zebra_mac_t *zebra_evpn_mac_add(struct zebra_evpn *zevpn,
 /*
  * Delete MAC entry.
  */
-int zebra_evpn_mac_del(struct zebra_evpn *zevpn, zebra_mac_t *mac)
+int zebra_evpn_mac_del(struct zebra_evpn *zevpn, struct zebra_mac *mac)
 {
-	zebra_mac_t *tmp_mac;
+	struct zebra_mac *tmp_mac;
 
 	if (IS_ZEBRA_DEBUG_VXLAN || IS_ZEBRA_DEBUG_EVPN_MH_MAC) {
 		char mac_buf[MAC_BUF_SIZE];
@@ -1171,7 +1172,7 @@ int zebra_evpn_mac_del(struct zebra_evpn *zevpn, zebra_mac_t *mac)
 }
 
 static bool zebra_evpn_check_mac_del_from_db(struct mac_walk_ctx *wctx,
-					     zebra_mac_t *mac)
+					     struct zebra_mac *mac)
 {
 	if ((wctx->flags & DEL_LOCAL_MAC) && (mac->flags & ZEBRA_MAC_LOCAL))
 		return true;
@@ -1207,7 +1208,7 @@ static bool zebra_evpn_check_mac_del_from_db(struct mac_walk_ctx *wctx,
 static void zebra_evpn_mac_del_hash_entry(struct hash_bucket *bucket, void *arg)
 {
 	struct mac_walk_ctx *wctx = arg;
-	zebra_mac_t *mac = bucket->data;
+	struct zebra_mac *mac = bucket->data;
 
 	if (zebra_evpn_check_mac_del_from_db(wctx, mac)) {
 		if (wctx->upd_client && (mac->flags & ZEBRA_MAC_LOCAL)) {
@@ -1256,11 +1257,11 @@ void zebra_evpn_mac_del_all(struct zebra_evpn *zevpn, int uninstall,
 /*
  * Look up MAC hash entry.
  */
-zebra_mac_t *zebra_evpn_mac_lookup(struct zebra_evpn *zevpn,
-				   const struct ethaddr *mac)
+struct zebra_mac *zebra_evpn_mac_lookup(struct zebra_evpn *zevpn,
+					const struct ethaddr *mac)
 {
-	zebra_mac_t tmp;
-	zebra_mac_t *pmac;
+	struct zebra_mac tmp;
+	struct zebra_mac *pmac;
 
 	memset(&tmp, 0, sizeof(tmp));
 	memcpy(&tmp.macaddr, mac, ETH_ALEN);
@@ -1330,7 +1331,7 @@ struct hash *zebra_mac_db_create(const char *desc)
 }
 
 /* program sync mac flags in the dataplane  */
-int zebra_evpn_sync_mac_dp_install(zebra_mac_t *mac, bool set_inactive,
+int zebra_evpn_sync_mac_dp_install(struct zebra_mac *mac, bool set_inactive,
 				   bool force_clear_static, const char *caller)
 {
 	struct interface *ifp;
@@ -1429,7 +1430,8 @@ int zebra_evpn_sync_mac_dp_install(zebra_mac_t *mac, bool set_inactive,
 	return 0;
 }
 
-void zebra_evpn_mac_send_add_del_to_client(zebra_mac_t *mac, bool old_bgp_ready,
+void zebra_evpn_mac_send_add_del_to_client(struct zebra_mac *mac,
+					   bool old_bgp_ready,
 					   bool new_bgp_ready)
 {
 	if (new_bgp_ready)
@@ -1450,7 +1452,7 @@ void zebra_evpn_mac_send_add_del_to_client(zebra_mac_t *mac, bool old_bgp_ready,
  */
 static int zebra_evpn_mac_hold_exp_cb(struct thread *t)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	bool old_bgp_ready;
 	bool new_bgp_ready;
 	bool old_static;
@@ -1496,7 +1498,7 @@ static int zebra_evpn_mac_hold_exp_cb(struct thread *t)
 	return 0;
 }
 
-static inline void zebra_evpn_mac_start_hold_timer(zebra_mac_t *mac)
+static inline void zebra_evpn_mac_start_hold_timer(struct zebra_mac *mac)
 {
 	if (mac->hold_timer)
 		return;
@@ -1515,7 +1517,7 @@ static inline void zebra_evpn_mac_start_hold_timer(zebra_mac_t *mac)
 			 zmh_info->mac_hold_time, &mac->hold_timer);
 }
 
-void zebra_evpn_mac_stop_hold_timer(zebra_mac_t *mac)
+void zebra_evpn_mac_stop_hold_timer(struct zebra_mac *mac)
 {
 	if (!mac->hold_timer)
 		return;
@@ -1534,7 +1536,7 @@ void zebra_evpn_mac_stop_hold_timer(zebra_mac_t *mac)
 	THREAD_OFF(mac->hold_timer);
 }
 
-void zebra_evpn_sync_mac_del(zebra_mac_t *mac)
+void zebra_evpn_sync_mac_del(struct zebra_mac *mac)
 {
 	bool old_static;
 	bool new_static;
@@ -1564,8 +1566,8 @@ void zebra_evpn_sync_mac_del(zebra_mac_t *mac)
 }
 
 static inline bool zebra_evpn_mac_is_bgp_seq_ok(struct zebra_evpn *zevpn,
-						zebra_mac_t *mac, uint32_t seq,
-						uint16_t ipa_len,
+						struct zebra_mac *mac,
+						uint32_t seq, uint16_t ipa_len,
 						const struct ipaddr *ipaddr,
 						bool sync)
 {
@@ -1630,12 +1632,12 @@ static inline bool zebra_evpn_mac_is_bgp_seq_ok(struct zebra_evpn *zevpn,
 	return true;
 }
 
-zebra_mac_t *zebra_evpn_proc_sync_mac_update(
+struct zebra_mac *zebra_evpn_proc_sync_mac_update(
 	struct zebra_evpn *zevpn, const struct ethaddr *macaddr,
 	uint16_t ipa_len, const struct ipaddr *ipaddr, uint8_t flags,
 	uint32_t seq, const esi_t *esi, struct sync_mac_ip_ctx *ctx)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	bool inform_bgp = false;
 	bool inform_dataplane = false;
 	bool seq_change = false;
@@ -1752,7 +1754,7 @@ zebra_mac_t *zebra_evpn_proc_sync_mac_update(
 
 		if (IS_ZEBRA_DEBUG_EVPN_MH_MAC && (old_flags != new_flags)) {
 			char mac_buf[MAC_BUF_SIZE], omac_buf[MAC_BUF_SIZE];
-			struct zebra_mac_t_ omac;
+			struct zebra_mac omac;
 
 			omac.flags = old_flags;
 			zlog_debug(
@@ -1845,7 +1847,7 @@ zebra_mac_t *zebra_evpn_proc_sync_mac_update(
 /* update local fowarding info. return true if a dest-ES change
  * is detected
  */
-static bool zebra_evpn_local_mac_update_fwd_info(zebra_mac_t *mac,
+static bool zebra_evpn_local_mac_update_fwd_info(struct zebra_mac *mac,
 						 struct interface *ifp,
 						 vlanid_t vid)
 {
@@ -1882,7 +1884,7 @@ static void zebra_evpn_send_mac_hash_entry_to_client(struct hash_bucket *bucket,
 						     void *arg)
 {
 	struct mac_walk_ctx *wctx = arg;
-	zebra_mac_t *zmac = bucket->data;
+	struct zebra_mac *zmac = bucket->data;
 
 	if (CHECK_FLAG(zmac->flags, ZEBRA_MAC_DEF_GW))
 		return;
@@ -1908,7 +1910,7 @@ void zebra_evpn_send_mac_list_to_client(struct zebra_evpn *zevpn)
 		     &wctx);
 }
 
-void zebra_evpn_rem_mac_del(struct zebra_evpn *zevpn, zebra_mac_t *mac)
+void zebra_evpn_rem_mac_del(struct zebra_evpn *zevpn, struct zebra_mac *mac)
 {
 	zebra_evpn_process_neigh_on_remote_mac_del(zevpn, mac);
 	/* the remote sequence number in the auto mac entry
@@ -1936,9 +1938,9 @@ void zebra_evpn_rem_mac_del(struct zebra_evpn *zevpn, zebra_mac_t *mac)
 /* Print Duplicate MAC */
 void zebra_evpn_print_dad_mac_hash(struct hash_bucket *bucket, void *ctxt)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 
-	mac = (zebra_mac_t *)bucket->data;
+	mac = (struct zebra_mac *)bucket->data;
 	if (!mac)
 		return;
 
@@ -1950,9 +1952,9 @@ void zebra_evpn_print_dad_mac_hash(struct hash_bucket *bucket, void *ctxt)
 void zebra_evpn_print_dad_mac_hash_detail(struct hash_bucket *bucket,
 					  void *ctxt)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 
-	mac = (zebra_mac_t *)bucket->data;
+	mac = (struct zebra_mac *)bucket->data;
 	if (!mac)
 		return;
 
@@ -1963,8 +1965,8 @@ void zebra_evpn_print_dad_mac_hash_detail(struct hash_bucket *bucket,
 int zebra_evpn_mac_remote_macip_add(
 	struct zebra_evpn *zevpn, struct zebra_vrf *zvrf,
 	const struct ethaddr *macaddr, uint16_t ipa_len,
-	const struct ipaddr *ipaddr, zebra_mac_t **macp, struct in_addr vtep_ip,
-	uint8_t flags, uint32_t seq, const esi_t *esi)
+	const struct ipaddr *ipaddr, struct zebra_mac **macp,
+	struct in_addr vtep_ip, uint8_t flags, uint32_t seq, const esi_t *esi)
 {
 	char buf1[INET6_ADDRSTRLEN];
 	bool sticky;
@@ -1974,7 +1976,7 @@ int zebra_evpn_mac_remote_macip_add(
 	bool is_dup_detect = false;
 	esi_t *old_esi;
 	bool old_static = false;
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	bool old_es_present;
 	bool new_es_present;
 
@@ -2132,7 +2134,7 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf,
 				    struct interface *ifp,
 				    const struct ethaddr *macaddr, vlanid_t vid,
 				    bool sticky, bool local_inactive,
-				    bool dp_static, zebra_mac_t *mac)
+				    bool dp_static, struct zebra_mac *mac)
 {
 	bool mac_sticky = false;
 	bool inform_client = false;
@@ -2373,7 +2375,7 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf,
 	return 0;
 }
 
-int zebra_evpn_del_local_mac(struct zebra_evpn *zevpn, zebra_mac_t *mac,
+int zebra_evpn_del_local_mac(struct zebra_evpn *zevpn, struct zebra_mac *mac,
 			     bool clear_static)
 {
 	bool old_bgp_ready;
@@ -2450,11 +2452,12 @@ int zebra_evpn_del_local_mac(struct zebra_evpn *zevpn, zebra_mac_t *mac,
 }
 
 int zebra_evpn_mac_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
-				const struct ipaddr *ip, zebra_mac_t **macp,
+				const struct ipaddr *ip,
+				struct zebra_mac **macp,
 				const struct ethaddr *macaddr, vlanid_t vlan_id,
 				bool def_gw)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	ns_id_t local_ns_id = NS_DEFAULT;
 	struct zebra_vrf *zvrf;
 
@@ -2490,7 +2493,7 @@ int zebra_evpn_mac_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 
 void zebra_evpn_mac_svi_del(struct interface *ifp, struct zebra_evpn *zevpn)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	struct ethaddr macaddr;
 	bool old_bgp_ready;
 
@@ -2513,7 +2516,7 @@ void zebra_evpn_mac_svi_del(struct interface *ifp, struct zebra_evpn *zevpn)
 
 void zebra_evpn_mac_svi_add(struct interface *ifp, struct zebra_evpn *zevpn)
 {
-	zebra_mac_t *mac = NULL;
+	struct zebra_mac *mac = NULL;
 	struct ethaddr macaddr;
 	struct zebra_if *zif = ifp->info;
 	bool old_bgp_ready;

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -383,7 +383,7 @@ static int zebra_evpn_dad_mac_auto_recovery_exp(struct thread *t)
 	struct zebra_mac *mac = NULL;
 	struct zebra_evpn *zevpn = NULL;
 	struct listnode *node = NULL;
-	zebra_neigh_t *nbr = NULL;
+	struct zebra_neigh *nbr = NULL;
 
 	mac = THREAD_ARG(t);
 
@@ -461,7 +461,7 @@ static void zebra_evpn_dup_addr_detect_for_mac(struct zebra_vrf *zvrf,
 					       bool do_dad, bool *is_dup_detect,
 					       bool is_local)
 {
-	zebra_neigh_t *nbr;
+	struct zebra_neigh *nbr;
 	struct listnode *node = NULL;
 	struct timeval elapsed = {0, 0};
 	bool reset_params = false;
@@ -609,7 +609,7 @@ static void zebra_evpn_dup_addr_detect_for_mac(struct zebra_vrf *zvrf,
 void zebra_evpn_print_mac(struct zebra_mac *mac, void *ctxt, json_object *json)
 {
 	struct vty *vty;
-	zebra_neigh_t *n = NULL;
+	struct zebra_neigh *n = NULL;
 	struct listnode *node = NULL;
 	char buf1[ETHER_ADDR_STRLEN];
 	char buf2[INET6_ADDRSTRLEN];

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -29,7 +29,6 @@
 extern "C" {
 #endif
 
-typedef struct zebra_mac_t_ zebra_mac_t;
 
 struct host_rb_entry {
 	RB_ENTRY(host_rb_entry) hl_entry;
@@ -52,7 +51,7 @@ RB_PROTOTYPE(host_rb_tree_entry, host_rb_entry, hl_entry,
  * information. The correct VNI will be obtained as zebra maintains
  * the mapping (of VLAN to VNI).
  */
-struct zebra_mac_t_ {
+struct zebra_mac {
 	/* MAC address. */
 	struct ethaddr macaddr;
 
@@ -185,7 +184,7 @@ struct sync_mac_ip_ctx {
 	bool mac_created;
 	bool mac_inactive;
 	bool mac_dp_update_deferred;
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 };
 
 /**************************** SYNC MAC handling *****************************/
@@ -194,7 +193,7 @@ struct sync_mac_ip_ctx {
  * peer we cannot let it age out i.e. we set the static bit
  * in the dataplane
  */
-static inline bool zebra_evpn_mac_is_static(zebra_mac_t *mac)
+static inline bool zebra_evpn_mac_is_static(struct zebra_mac *mac)
 {
 	return ((mac->flags & ZEBRA_MAC_ALL_PEER_FLAGS) || mac->sync_neigh_cnt);
 }
@@ -207,15 +206,15 @@ static inline bool zebra_evpn_mac_is_ready_for_bgp(uint32_t flags)
 		   || (flags & ZEBRA_MAC_ES_PEER_ACTIVE));
 }
 
-void zebra_evpn_mac_stop_hold_timer(zebra_mac_t *mac);
+void zebra_evpn_mac_stop_hold_timer(struct zebra_mac *mac);
 
-static inline void zebra_evpn_mac_clear_sync_info(zebra_mac_t *mac)
+static inline void zebra_evpn_mac_clear_sync_info(struct zebra_mac *mac)
 {
 	UNSET_FLAG(mac->flags, ZEBRA_MAC_ALL_PEER_FLAGS);
 	zebra_evpn_mac_stop_hold_timer(mac);
 }
 
-static inline bool zebra_evpn_mac_in_use(zebra_mac_t *mac)
+static inline bool zebra_evpn_mac_in_use(struct zebra_mac *mac)
 {
 	return !list_isempty(mac->neigh_list)
 	       || CHECK_FLAG(mac->flags, ZEBRA_MAC_SVI);
@@ -224,27 +223,28 @@ static inline bool zebra_evpn_mac_in_use(zebra_mac_t *mac)
 struct hash *zebra_mac_db_create(const char *desc);
 uint32_t num_valid_macs(struct zebra_evpn *zevi);
 uint32_t num_dup_detected_macs(struct zebra_evpn *zevi);
-int zebra_evpn_rem_mac_uninstall(struct zebra_evpn *zevi, zebra_mac_t *mac,
+int zebra_evpn_rem_mac_uninstall(struct zebra_evpn *zevi, struct zebra_mac *mac,
 				 bool force);
-int zebra_evpn_rem_mac_install(struct zebra_evpn *zevi, zebra_mac_t *mac,
+int zebra_evpn_rem_mac_install(struct zebra_evpn *zevi, struct zebra_mac *mac,
 			       bool was_static);
-void zebra_evpn_deref_ip2mac(struct zebra_evpn *zevi, zebra_mac_t *mac);
-zebra_mac_t *zebra_evpn_mac_lookup(struct zebra_evpn *zevi,
-				   const struct ethaddr *mac);
-zebra_mac_t *zebra_evpn_mac_add(struct zebra_evpn *zevi,
-				const struct ethaddr *macaddr);
-int zebra_evpn_mac_del(struct zebra_evpn *zevi, zebra_mac_t *mac);
+void zebra_evpn_deref_ip2mac(struct zebra_evpn *zevi, struct zebra_mac *mac);
+struct zebra_mac *zebra_evpn_mac_lookup(struct zebra_evpn *zevi,
+					const struct ethaddr *mac);
+struct zebra_mac *zebra_evpn_mac_add(struct zebra_evpn *zevi,
+				     const struct ethaddr *macaddr);
+int zebra_evpn_mac_del(struct zebra_evpn *zevi, struct zebra_mac *mac);
 int zebra_evpn_macip_send_msg_to_client(uint32_t id,
 					const struct ethaddr *macaddr,
 					const struct ipaddr *ip, uint8_t flags,
 					uint32_t seq, int state,
 					struct zebra_evpn_es *es, uint16_t cmd);
-void zebra_evpn_print_mac(zebra_mac_t *mac, void *ctxt, json_object *json);
+void zebra_evpn_print_mac(struct zebra_mac *mac, void *ctxt, json_object *json);
 void zebra_evpn_print_mac_hash(struct hash_bucket *bucket, void *ctxt);
 void zebra_evpn_print_mac_hash_detail(struct hash_bucket *bucket, void *ctxt);
-int zebra_evpn_sync_mac_dp_install(zebra_mac_t *mac, bool set_inactive,
+int zebra_evpn_sync_mac_dp_install(struct zebra_mac *mac, bool set_inactive,
 				   bool force_clear_static, const char *caller);
-void zebra_evpn_mac_send_add_del_to_client(zebra_mac_t *mac, bool old_bgp_ready,
+void zebra_evpn_mac_send_add_del_to_client(struct zebra_mac *mac,
+					   bool old_bgp_ready,
 					   bool new_bgp_ready);
 
 void zebra_evpn_mac_del_all(struct zebra_evpn *zevi, int uninstall,
@@ -255,37 +255,38 @@ int zebra_evpn_mac_send_add_to_client(vni_t vni, const struct ethaddr *macaddr,
 int zebra_evpn_mac_send_del_to_client(vni_t vni, const struct ethaddr *macaddr,
 				      uint32_t flags, bool force);
 void zebra_evpn_send_mac_list_to_client(struct zebra_evpn *zevi);
-zebra_mac_t *zebra_evpn_proc_sync_mac_update(
+struct zebra_mac *zebra_evpn_proc_sync_mac_update(
 	struct zebra_evpn *zevi, const struct ethaddr *macaddr,
 	uint16_t ipa_len, const struct ipaddr *ipaddr, uint8_t flags,
 	uint32_t seq, const esi_t *esi, struct sync_mac_ip_ctx *ctx);
-void zebra_evpn_sync_mac_del(zebra_mac_t *mac);
-void zebra_evpn_rem_mac_del(struct zebra_evpn *zevi, zebra_mac_t *mac);
+void zebra_evpn_sync_mac_del(struct zebra_mac *mac);
+void zebra_evpn_rem_mac_del(struct zebra_evpn *zevi, struct zebra_mac *mac);
 void zebra_evpn_print_dad_mac_hash(struct hash_bucket *bucket, void *ctxt);
 void zebra_evpn_print_dad_mac_hash_detail(struct hash_bucket *bucket,
 					  void *ctxt);
 int zebra_evpn_mac_remote_macip_add(
 	struct zebra_evpn *zevpn, struct zebra_vrf *zvrf,
 	const struct ethaddr *macaddr, uint16_t ipa_len,
-	const struct ipaddr *ipaddr, zebra_mac_t **macp, struct in_addr vtep_ip,
-	uint8_t flags, uint32_t seq, const esi_t *esi);
+	const struct ipaddr *ipaddr, struct zebra_mac **macp,
+	struct in_addr vtep_ip, uint8_t flags, uint32_t seq, const esi_t *esi);
 
 int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf,
 				    struct zebra_evpn *zevpn,
 				    struct interface *ifp,
 				    const struct ethaddr *macaddr, vlanid_t vid,
 				    bool sticky, bool local_inactive,
-				    bool dp_static, zebra_mac_t *mac);
-int zebra_evpn_del_local_mac(struct zebra_evpn *zevpn, zebra_mac_t *mac,
+				    bool dp_static, struct zebra_mac *mac);
+int zebra_evpn_del_local_mac(struct zebra_evpn *zevpn, struct zebra_mac *mac,
 			     bool clear_static);
 int zebra_evpn_mac_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
-				const struct ipaddr *ip, zebra_mac_t **macp,
+				const struct ipaddr *ip,
+				struct zebra_mac **macp,
 				const struct ethaddr *macaddr, vlanid_t vlan_id,
 				bool def_gw);
 void zebra_evpn_mac_svi_add(struct interface *ifp, struct zebra_evpn *zevpn);
 void zebra_evpn_mac_svi_del(struct interface *ifp, struct zebra_evpn *zevpn);
 void zebra_evpn_mac_ifp_del(struct interface *ifp);
-void zebra_evpn_mac_clear_fwd_info(zebra_mac_t *zmac);
+void zebra_evpn_mac_clear_fwd_info(struct zebra_mac *zmac);
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -88,7 +88,7 @@ struct zebra_mac_t_ {
 	(ZEBRA_MAC_ES_PEER_PROXY | ZEBRA_MAC_ES_PEER_ACTIVE)
 
 	/* back pointer to zevpn */
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 
 	/* Local or remote info.
 	 * Note: fwd_info is only relevant if mac->es is NULL.
@@ -152,7 +152,7 @@ struct zebra_mac_t_ {
  * Context for MAC hash walk - used by callbacks.
  */
 struct mac_walk_ctx {
-	zebra_evpn_t *zevpn;    /* EVPN hash */
+	struct zebra_evpn *zevpn; /* EVPN hash */
 	struct zebra_vrf *zvrf; /* VRF - for client notification. */
 	int uninstall;		/* uninstall from kernel? */
 	int upd_client;		/* uninstall from client? */
@@ -222,18 +222,18 @@ static inline bool zebra_evpn_mac_in_use(zebra_mac_t *mac)
 }
 
 struct hash *zebra_mac_db_create(const char *desc);
-uint32_t num_valid_macs(zebra_evpn_t *zevi);
-uint32_t num_dup_detected_macs(zebra_evpn_t *zevi);
-int zebra_evpn_rem_mac_uninstall(zebra_evpn_t *zevi, zebra_mac_t *mac,
+uint32_t num_valid_macs(struct zebra_evpn *zevi);
+uint32_t num_dup_detected_macs(struct zebra_evpn *zevi);
+int zebra_evpn_rem_mac_uninstall(struct zebra_evpn *zevi, zebra_mac_t *mac,
 				 bool force);
-int zebra_evpn_rem_mac_install(zebra_evpn_t *zevi, zebra_mac_t *mac,
+int zebra_evpn_rem_mac_install(struct zebra_evpn *zevi, zebra_mac_t *mac,
 			       bool was_static);
-void zebra_evpn_deref_ip2mac(zebra_evpn_t *zevi, zebra_mac_t *mac);
-zebra_mac_t *zebra_evpn_mac_lookup(zebra_evpn_t *zevi,
+void zebra_evpn_deref_ip2mac(struct zebra_evpn *zevi, zebra_mac_t *mac);
+zebra_mac_t *zebra_evpn_mac_lookup(struct zebra_evpn *zevi,
 				   const struct ethaddr *mac);
-zebra_mac_t *zebra_evpn_mac_add(zebra_evpn_t *zevi,
+zebra_mac_t *zebra_evpn_mac_add(struct zebra_evpn *zevi,
 				const struct ethaddr *macaddr);
-int zebra_evpn_mac_del(zebra_evpn_t *zevi, zebra_mac_t *mac);
+int zebra_evpn_mac_del(struct zebra_evpn *zevi, zebra_mac_t *mac);
 int zebra_evpn_macip_send_msg_to_client(uint32_t id,
 					const struct ethaddr *macaddr,
 					const struct ipaddr *ip, uint8_t flags,
@@ -247,44 +247,43 @@ int zebra_evpn_sync_mac_dp_install(zebra_mac_t *mac, bool set_inactive,
 void zebra_evpn_mac_send_add_del_to_client(zebra_mac_t *mac, bool old_bgp_ready,
 					   bool new_bgp_ready);
 
-void zebra_evpn_mac_del_all(zebra_evpn_t *zevi, int uninstall, int upd_client,
-			    uint32_t flags);
+void zebra_evpn_mac_del_all(struct zebra_evpn *zevi, int uninstall,
+			    int upd_client, uint32_t flags);
 int zebra_evpn_mac_send_add_to_client(vni_t vni, const struct ethaddr *macaddr,
 				      uint32_t mac_flags, uint32_t seq,
 				      struct zebra_evpn_es *es);
 int zebra_evpn_mac_send_del_to_client(vni_t vni, const struct ethaddr *macaddr,
 				      uint32_t flags, bool force);
-void zebra_evpn_send_mac_list_to_client(zebra_evpn_t *zevi);
+void zebra_evpn_send_mac_list_to_client(struct zebra_evpn *zevi);
 zebra_mac_t *zebra_evpn_proc_sync_mac_update(
-	zebra_evpn_t *zevi, const struct ethaddr *macaddr, uint16_t ipa_len,
-	const struct ipaddr *ipaddr, uint8_t flags, uint32_t seq,
-	const esi_t *esi, struct sync_mac_ip_ctx *ctx);
+	struct zebra_evpn *zevi, const struct ethaddr *macaddr,
+	uint16_t ipa_len, const struct ipaddr *ipaddr, uint8_t flags,
+	uint32_t seq, const esi_t *esi, struct sync_mac_ip_ctx *ctx);
 void zebra_evpn_sync_mac_del(zebra_mac_t *mac);
-void zebra_evpn_rem_mac_del(zebra_evpn_t *zevi, zebra_mac_t *mac);
+void zebra_evpn_rem_mac_del(struct zebra_evpn *zevi, zebra_mac_t *mac);
 void zebra_evpn_print_dad_mac_hash(struct hash_bucket *bucket, void *ctxt);
 void zebra_evpn_print_dad_mac_hash_detail(struct hash_bucket *bucket,
 					  void *ctxt);
-int zebra_evpn_mac_remote_macip_add(zebra_evpn_t *zevpn, struct zebra_vrf *zvrf,
-				    const struct ethaddr *macaddr,
-				    uint16_t ipa_len,
-				    const struct ipaddr *ipaddr,
-				    zebra_mac_t **macp, struct in_addr vtep_ip,
-				    uint8_t flags, uint32_t seq,
-				    const esi_t *esi);
+int zebra_evpn_mac_remote_macip_add(
+	struct zebra_evpn *zevpn, struct zebra_vrf *zvrf,
+	const struct ethaddr *macaddr, uint16_t ipa_len,
+	const struct ipaddr *ipaddr, zebra_mac_t **macp, struct in_addr vtep_ip,
+	uint8_t flags, uint32_t seq, const esi_t *esi);
 
-int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf, zebra_evpn_t *zevpn,
+int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf,
+				    struct zebra_evpn *zevpn,
 				    struct interface *ifp,
 				    const struct ethaddr *macaddr, vlanid_t vid,
 				    bool sticky, bool local_inactive,
 				    bool dp_static, zebra_mac_t *mac);
-int zebra_evpn_del_local_mac(zebra_evpn_t *zevpn, zebra_mac_t *mac,
+int zebra_evpn_del_local_mac(struct zebra_evpn *zevpn, zebra_mac_t *mac,
 			     bool clear_static);
-int zebra_evpn_mac_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
+int zebra_evpn_mac_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 				const struct ipaddr *ip, zebra_mac_t **macp,
 				const struct ethaddr *macaddr, vlanid_t vlan_id,
 				bool def_gw);
-void zebra_evpn_mac_svi_add(struct interface *ifp, zebra_evpn_t *zevpn);
-void zebra_evpn_mac_svi_del(struct interface *ifp, zebra_evpn_t *zevpn);
+void zebra_evpn_mac_svi_add(struct interface *ifp, struct zebra_evpn *zevpn);
+void zebra_evpn_mac_svi_del(struct interface *ifp, struct zebra_evpn *zevpn);
 void zebra_evpn_mac_ifp_del(struct interface *ifp);
 void zebra_evpn_mac_clear_fwd_info(zebra_mac_t *zmac);
 

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -1183,7 +1183,7 @@ bool zebra_evpn_nhg_is_local_es(uint32_t nhg_id,
 /* update remote macs associated with the ES */
 static void zebra_evpn_nhg_mac_update(struct zebra_evpn_es *es)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	struct listnode *node;
 	bool local_via_nw;
 
@@ -1995,7 +1995,8 @@ static void zebra_evpn_es_setup_evis(struct zebra_evpn_es *es)
 	}
 }
 
-static void zebra_evpn_flush_local_mac(zebra_mac_t *mac, struct interface *ifp)
+static void zebra_evpn_flush_local_mac(struct zebra_mac *mac,
+				       struct interface *ifp)
 {
 	struct zebra_if *zif;
 	struct interface *br_ifp;
@@ -2022,7 +2023,7 @@ static void zebra_evpn_flush_local_mac(zebra_mac_t *mac, struct interface *ifp)
 static void zebra_evpn_es_flush_local_macs(struct zebra_evpn_es *es,
 					   struct interface *ifp, bool add)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	struct listnode	*node;
 	struct listnode *nnode;
 
@@ -2508,7 +2509,7 @@ stream_failure:
 	return;
 }
 
-void zebra_evpn_es_mac_deref_entry(zebra_mac_t *mac)
+void zebra_evpn_es_mac_deref_entry(struct zebra_mac *mac)
 {
 	struct zebra_evpn_es *es = mac->es;
 
@@ -2524,7 +2525,8 @@ void zebra_evpn_es_mac_deref_entry(zebra_mac_t *mac)
 /* Associate a MAC entry with a local or remote ES. Returns false if there
  * was no ES change.
  */
-bool zebra_evpn_es_mac_ref_entry(zebra_mac_t *mac, struct zebra_evpn_es *es)
+bool zebra_evpn_es_mac_ref_entry(struct zebra_mac *mac,
+				 struct zebra_evpn_es *es)
 {
 	if (mac->es == es)
 		return false;
@@ -2542,7 +2544,7 @@ bool zebra_evpn_es_mac_ref_entry(zebra_mac_t *mac, struct zebra_evpn_es *es)
 	return true;
 }
 
-bool zebra_evpn_es_mac_ref(zebra_mac_t *mac, const esi_t *esi)
+bool zebra_evpn_es_mac_ref(struct zebra_mac *mac, const esi_t *esi)
 {
 	struct zebra_evpn_es *es;
 
@@ -2681,7 +2683,7 @@ static void zebra_evpn_es_df_pref_update(struct zebra_if *zif, uint16_t df_pref)
 static void zebra_evpn_es_bypass_update_macs(struct zebra_evpn_es *es,
 					     struct interface *ifp, bool bypass)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	struct listnode *node;
 	struct listnode *nnode;
 	struct zebra_if *zif;
@@ -2856,7 +2858,7 @@ void zebra_evpn_if_es_print(struct vty *vty, json_object *json,
 
 static void zebra_evpn_local_mac_oper_state_change(struct zebra_evpn_es *es)
 {
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 	struct listnode *node;
 
 	/* If fast-failover is supported by the dataplane via the use

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -60,7 +60,7 @@ DEFINE_MTYPE_STATIC(ZEBRA, L2_NH, "L2 nexthop");
 
 static void zebra_evpn_es_get_one_base_evpn(void);
 static int zebra_evpn_es_evi_send_to_client(struct zebra_evpn_es *es,
-		zebra_evpn_t *zevpn, bool add);
+					    struct zebra_evpn *zevpn, bool add);
 static void zebra_evpn_local_es_del(struct zebra_evpn_es **esp);
 static int zebra_evpn_local_es_update(struct zebra_if *zif, esi_t *esi);
 static bool zebra_evpn_es_br_port_dplane_update(struct zebra_evpn_es *es,
@@ -76,7 +76,7 @@ esi_t zero_esi_buf, *zero_esi = &zero_esi_buf;
 /*****************************************************************************/
 /* Ethernet Segment to EVI association -
  * 1. The ES-EVI entry is maintained as a RB tree per L2-VNI
- * (zebra_evpn_t.es_evi_rb_tree).
+ * (struct zebra_evpn.es_evi_rb_tree).
  * 2. Each local ES-EVI entry is sent to BGP which advertises it as an
  * EAD-EVI (Type-1 EVPN) route
  * 3. Local ES-EVI setup is re-evaluated on the following triggers -
@@ -103,7 +103,7 @@ RB_GENERATE(zebra_es_evi_rb_head, zebra_evpn_es_evi,
  * tables.
  */
 static struct zebra_evpn_es_evi *zebra_evpn_es_evi_new(struct zebra_evpn_es *es,
-		zebra_evpn_t *zevpn)
+						       struct zebra_evpn *zevpn)
 {
 	struct zebra_evpn_es_evi *es_evi;
 
@@ -169,7 +169,7 @@ static void zebra_evpn_es_evi_re_eval_send_to_client(
 static void zebra_evpn_es_evi_free(struct zebra_evpn_es_evi *es_evi)
 {
 	struct zebra_evpn_es *es = es_evi->es;
-	zebra_evpn_t *zevpn = es_evi->zevpn;
+	struct zebra_evpn *zevpn = es_evi->zevpn;
 
 	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 		zlog_debug("es %s evi %d free",
@@ -186,8 +186,8 @@ static void zebra_evpn_es_evi_free(struct zebra_evpn_es_evi *es_evi)
 }
 
 /* find the ES-EVI in the per-L2-VNI RB tree */
-static struct zebra_evpn_es_evi *zebra_evpn_es_evi_find(
-		struct zebra_evpn_es *es, zebra_evpn_t *zevpn)
+static struct zebra_evpn_es_evi *
+zebra_evpn_es_evi_find(struct zebra_evpn_es *es, struct zebra_evpn *zevpn)
 {
 	struct zebra_evpn_es_evi es_evi;
 
@@ -220,7 +220,7 @@ static void zebra_evpn_local_es_evi_do_del(struct zebra_evpn_es_evi *es_evi)
 	zebra_evpn_es_evi_free(es_evi);
 }
 static void zebra_evpn_local_es_evi_del(struct zebra_evpn_es *es,
-		zebra_evpn_t *zevpn)
+					struct zebra_evpn *zevpn)
 {
 	struct zebra_evpn_es_evi *es_evi;
 
@@ -231,7 +231,7 @@ static void zebra_evpn_local_es_evi_del(struct zebra_evpn_es *es,
 
 /* Create an ES-EVI if it doesn't already exist and tell BGP */
 static void zebra_evpn_local_es_evi_add(struct zebra_evpn_es *es,
-		zebra_evpn_t *zevpn)
+					struct zebra_evpn *zevpn)
 {
 	struct zebra_evpn_es_evi *es_evi;
 
@@ -334,7 +334,7 @@ zebra_evpn_es_evi_show_entry_detail(struct vty *vty,
 	}
 }
 
-static void zebra_evpn_es_evi_show_one_evpn(zebra_evpn_t *zevpn,
+static void zebra_evpn_es_evi_show_one_evpn(struct zebra_evpn *zevpn,
 					    struct vty *vty,
 					    json_object *json_array, int detail)
 {
@@ -358,7 +358,7 @@ struct evpn_mh_show_ctx {
 static void zebra_evpn_es_evi_show_one_evpn_hash_cb(struct hash_bucket *bucket,
 		void *ctxt)
 {
-	zebra_evpn_t *zevpn = (zebra_evpn_t *)bucket->data;
+	struct zebra_evpn *zevpn = (struct zebra_evpn *)bucket->data;
 	struct evpn_mh_show_ctx *wctx = (struct evpn_mh_show_ctx *)ctxt;
 
 	zebra_evpn_es_evi_show_one_evpn(zevpn, wctx->vty,
@@ -399,7 +399,7 @@ void zebra_evpn_es_evi_show(struct vty *vty, bool uj, int detail)
 void zebra_evpn_es_evi_show_vni(struct vty *vty, bool uj, vni_t vni, int detail)
 {
 	json_object *json_array = NULL;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 
 	zevpn = zebra_evpn_lookup(vni);
 	if (uj)
@@ -425,7 +425,7 @@ void zebra_evpn_es_evi_show_vni(struct vty *vty, bool uj, vni_t vni, int detail)
 }
 
 /* Initialize the ES tables maintained per-L2_VNI */
-void zebra_evpn_es_evi_init(zebra_evpn_t *zevpn)
+void zebra_evpn_es_evi_init(struct zebra_evpn *zevpn)
 {
 	/* Initialize the ES-EVI RB tree */
 	RB_INIT(zebra_es_evi_rb_head, &zevpn->es_evi_rb_tree);
@@ -438,7 +438,7 @@ void zebra_evpn_es_evi_init(zebra_evpn_t *zevpn)
 }
 
 /* Cleanup the ES info maintained per- EVPN */
-void zebra_evpn_es_evi_cleanup(zebra_evpn_t *zevpn)
+void zebra_evpn_es_evi_cleanup(struct zebra_evpn *zevpn)
 {
 	struct zebra_evpn_es_evi *es_evi;
 	struct zebra_evpn_es_evi *es_evi_next;
@@ -455,7 +455,7 @@ void zebra_evpn_es_evi_cleanup(zebra_evpn_t *zevpn)
 /* called when the oper state or bridge membership changes for the
  * vxlan device
  */
-void zebra_evpn_update_all_es(zebra_evpn_t *zevpn)
+void zebra_evpn_update_all_es(struct zebra_evpn *zevpn)
 {
 	struct zebra_evpn_es_evi *es_evi;
 	struct listnode *node;
@@ -664,7 +664,8 @@ void zebra_evpn_acc_bd_svi_mac_add(struct interface *vlan_if)
 
 /* called when a EVPN-L2VNI is set or cleared against a BD */
 static void zebra_evpn_acc_bd_evpn_set(struct zebra_evpn_access_bd *acc_bd,
-		zebra_evpn_t *zevpn, zebra_evpn_t *old_zevpn)
+				       struct zebra_evpn *zevpn,
+				       struct zebra_evpn *old_zevpn)
 {
 	struct zebra_if *zif;
 	struct listnode *node;
@@ -698,7 +699,7 @@ void zebra_evpn_vl_vxl_ref(uint16_t vid, struct zebra_if *vxlan_zif)
 {
 	struct zebra_evpn_access_bd *acc_bd;
 	struct zebra_if *old_vxlan_zif;
-	zebra_evpn_t *old_zevpn;
+	struct zebra_evpn *old_zevpn;
 
 	if (!vid)
 		return;
@@ -760,8 +761,8 @@ void zebra_evpn_vl_vxl_deref(uint16_t vid, struct zebra_if *vxlan_zif)
 }
 
 /* handle EVPN add/del */
-void zebra_evpn_vxl_evpn_set(struct zebra_if *zif, zebra_evpn_t *zevpn,
-		bool set)
+void zebra_evpn_vxl_evpn_set(struct zebra_if *zif, struct zebra_evpn *zevpn,
+			     bool set)
 {
 	struct zebra_l2info_vxlan *vxl;
 	struct zebra_evpn_access_bd *acc_bd;
@@ -783,7 +784,7 @@ void zebra_evpn_vxl_evpn_set(struct zebra_if *zif, zebra_evpn_t *zevpn,
 		}
 	} else {
 		if (acc_bd->zevpn) {
-			zebra_evpn_t *old_zevpn = acc_bd->zevpn;
+			struct zebra_evpn *old_zevpn = acc_bd->zevpn;
 			acc_bd->zevpn = NULL;
 			zebra_evpn_acc_bd_evpn_set(acc_bd, NULL, old_zevpn);
 		}
@@ -2561,7 +2562,7 @@ bool zebra_evpn_es_mac_ref(zebra_mac_t *mac, const esi_t *esi)
 
 /* Inform BGP about local ES-EVI add or del */
 static int zebra_evpn_es_evi_send_to_client(struct zebra_evpn_es *es,
-		zebra_evpn_t *zevpn, bool add)
+					    struct zebra_evpn *zevpn, bool add)
 {
 	struct zserv *client;
 	struct stream *s;
@@ -3511,7 +3512,7 @@ void zebra_evpn_mh_print(struct vty *vty)
  * necessary
  */
 /* called when a new vni is added or becomes oper up or becomes a bridge port */
-void zebra_evpn_es_set_base_evpn(zebra_evpn_t *zevpn)
+void zebra_evpn_es_set_base_evpn(struct zebra_evpn *zevpn)
 {
 	struct listnode *node;
 	struct zebra_evpn_es *es;
@@ -3560,7 +3561,7 @@ void zebra_evpn_es_set_base_evpn(zebra_evpn_t *zevpn)
 /* called when a vni is removed or becomes oper down or is removed from a
  * bridge
  */
-void zebra_evpn_es_clear_base_evpn(zebra_evpn_t *zevpn)
+void zebra_evpn_es_clear_base_evpn(struct zebra_evpn *zevpn)
 {
 	struct listnode *node;
 	struct zebra_evpn_es *es;
@@ -3589,7 +3590,7 @@ void zebra_evpn_es_clear_base_evpn(zebra_evpn_t *zevpn)
 /* Locate an "eligible" L2-VNI to follow */
 static int zebra_evpn_es_get_one_base_evpn_cb(struct hash_bucket *b, void *data)
 {
-	zebra_evpn_t *zevpn = b->data;
+	struct zebra_evpn *zevpn = b->data;
 
 	zebra_evpn_es_set_base_evpn(zevpn);
 

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -272,7 +272,7 @@ static inline bool zebra_evpn_send_to_client_ok(struct zebra_evpn *zevpn)
 	return !!(zevpn->flags & ZEVPN_READY_FOR_BGP);
 }
 
-static inline bool zebra_evpn_mac_is_es_local(zebra_mac_t *mac)
+static inline bool zebra_evpn_mac_is_es_local(struct zebra_mac *mac)
 {
 	return mac->es && (mac->es->flags & ZEBRA_EVPNES_LOCAL);
 }
@@ -336,10 +336,10 @@ int zebra_evpn_remote_es_del(const esi_t *esi, struct in_addr vtep_ip);
 extern void zebra_evpn_es_evi_show(struct vty *vty, bool uj, int detail);
 extern void zebra_evpn_es_evi_show_vni(struct vty *vty, bool uj,
 		vni_t vni, int detail);
-extern void zebra_evpn_es_mac_deref_entry(zebra_mac_t *mac);
-extern bool zebra_evpn_es_mac_ref_entry(zebra_mac_t *mac,
+extern void zebra_evpn_es_mac_deref_entry(struct zebra_mac *mac);
+extern bool zebra_evpn_es_mac_ref_entry(struct zebra_mac *mac,
 					struct zebra_evpn_es *es);
-extern bool zebra_evpn_es_mac_ref(zebra_mac_t *mac, const esi_t *esi);
+extern bool zebra_evpn_es_mac_ref(struct zebra_mac *mac, const esi_t *esi);
 extern struct zebra_evpn_es *zebra_evpn_es_find(const esi_t *esi);
 extern void zebra_evpn_interface_init(void);
 extern int zebra_evpn_mh_if_write(struct vty *vty, struct interface *ifp);

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -168,7 +168,7 @@ struct zebra_evpn_es_vtep {
 	uint8_t df_alg;
 	uint32_t df_pref;
 
-	/* XXX - maintain a backpointer to zebra_vtep_t */
+	/* XXX - maintain a backpointer to struct zebra_vtep */
 };
 
 /* Local/access-side broadcast domain - zebra_evpn_access_bd is added to -

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -113,7 +113,7 @@ RB_PROTOTYPE(zebra_es_rb_head, zebra_evpn_es, rb_node, zebra_es_rb_cmp);
  */
 struct zebra_evpn_es_evi {
 	struct zebra_evpn_es *es;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 
 	/* ES-EVI flags */
 	uint32_t flags;
@@ -183,7 +183,7 @@ struct zebra_evpn_access_bd {
 	/* list of members associated with the BD i.e. (potential) ESs */
 	struct list *mbr_zifs;
 	/* presence of zevpn activates the EVI on all the ESs in mbr_zifs */
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	/* SVI associated with the VLAN */
 	struct zebra_if *vlan_zif;
 };
@@ -224,7 +224,7 @@ struct zebra_evpn_mh_info {
 	 * XXX: once single vxlan device model becomes available this will
 	 * not be necessary
 	 */
-	zebra_evpn_t *es_base_evpn;
+	struct zebra_evpn *es_base_evpn;
 	struct in_addr es_originator_ip;
 
 	/* L2 NH and NHG ids -
@@ -267,7 +267,7 @@ struct zebra_evpn_mh_info {
 };
 
 /* returns TRUE if the EVPN is ready to be sent to BGP */
-static inline bool zebra_evpn_send_to_client_ok(zebra_evpn_t *zevpn)
+static inline bool zebra_evpn_send_to_client_ok(struct zebra_evpn *zevpn)
 {
 	return !!(zevpn->flags & ZEVPN_READY_FOR_BGP);
 }
@@ -313,12 +313,12 @@ extern void zebra_evpn_mh_terminate(void);
 extern bool zebra_evpn_is_if_es_capable(struct zebra_if *zif);
 extern void zebra_evpn_if_init(struct zebra_if *zif);
 extern void zebra_evpn_if_cleanup(struct zebra_if *zif);
-extern void zebra_evpn_es_evi_init(zebra_evpn_t *zevpn);
-extern void zebra_evpn_es_evi_cleanup(zebra_evpn_t *zevpn);
-extern void zebra_evpn_vxl_evpn_set(struct zebra_if *zif, zebra_evpn_t *zevpn,
-		bool set);
-extern void zebra_evpn_es_set_base_evpn(zebra_evpn_t *zevpn);
-extern void zebra_evpn_es_clear_base_evpn(zebra_evpn_t *zevpn);
+extern void zebra_evpn_es_evi_init(struct zebra_evpn *zevpn);
+extern void zebra_evpn_es_evi_cleanup(struct zebra_evpn *zevpn);
+extern void zebra_evpn_vxl_evpn_set(struct zebra_if *zif,
+				    struct zebra_evpn *zevpn, bool set);
+extern void zebra_evpn_es_set_base_evpn(struct zebra_evpn *zevpn);
+extern void zebra_evpn_es_clear_base_evpn(struct zebra_evpn *zevpn);
 extern void zebra_evpn_vl_vxl_ref(uint16_t vid, struct zebra_if *vxlan_zif);
 extern void zebra_evpn_vl_vxl_deref(uint16_t vid, struct zebra_if *vxlan_zif);
 extern void zebra_evpn_vl_mbr_ref(uint16_t vid, struct zebra_if *zif);
@@ -328,7 +328,7 @@ extern void zebra_evpn_es_if_oper_state_change(struct zebra_if *zif, bool up);
 extern void zebra_evpn_es_show(struct vty *vty, bool uj);
 extern void zebra_evpn_es_show_detail(struct vty *vty, bool uj);
 extern void zebra_evpn_es_show_esi(struct vty *vty, bool uj, esi_t *esi);
-extern void zebra_evpn_update_all_es(zebra_evpn_t *zevpn);
+extern void zebra_evpn_update_all_es(struct zebra_evpn *zevpn);
 extern void zebra_evpn_proc_remote_es(ZAPI_HANDLER_ARGS);
 int zebra_evpn_remote_es_add(const esi_t *esi, struct in_addr vtep_ip,
 			     bool esr_rxed, uint8_t df_alg, uint16_t df_pref);

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -88,7 +88,7 @@ struct hash *zebra_neigh_db_create(const char *desc)
 	return hash_create_size(8, neigh_hash_keymake, neigh_cmp, desc);
 }
 
-uint32_t num_dup_detected_neighs(zebra_evpn_t *zevpn)
+uint32_t num_dup_detected_neighs(struct zebra_evpn *zevpn)
 {
 	unsigned int i;
 	uint32_t num_neighs = 0;
@@ -150,7 +150,7 @@ int remote_neigh_count(zebra_mac_t *zmac)
 /*
  * Install remote neighbor into the kernel.
  */
-int zebra_evpn_rem_neigh_install(zebra_evpn_t *zevpn, zebra_neigh_t *n,
+int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 				 bool was_static)
 {
 	struct interface *vlan_if;
@@ -468,7 +468,7 @@ static void zebra_evpn_local_neigh_deref_mac(zebra_neigh_t *n,
 					     bool send_mac_update)
 {
 	zebra_mac_t *mac = n->mac;
-	zebra_evpn_t *zevpn = n->zevpn;
+	struct zebra_evpn *zevpn = n->zevpn;
 	bool old_static;
 	bool new_static;
 
@@ -496,7 +496,7 @@ static void zebra_evpn_local_neigh_deref_mac(zebra_neigh_t *n,
 	zebra_evpn_deref_ip2mac(zevpn, mac);
 }
 
-bool zebra_evpn_neigh_is_bgp_seq_ok(zebra_evpn_t *zevpn, zebra_neigh_t *n,
+bool zebra_evpn_neigh_is_bgp_seq_ok(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 				    const struct ethaddr *macaddr, uint32_t seq,
 				    bool sync)
 {
@@ -542,7 +542,7 @@ bool zebra_evpn_neigh_is_bgp_seq_ok(zebra_evpn_t *zevpn, zebra_neigh_t *n,
 /*
  * Add neighbor entry.
  */
-static zebra_neigh_t *zebra_evpn_neigh_add(zebra_evpn_t *zevpn,
+static zebra_neigh_t *zebra_evpn_neigh_add(struct zebra_evpn *zevpn,
 					   const struct ipaddr *ip,
 					   const struct ethaddr *mac,
 					   zebra_mac_t *zmac, uint32_t n_flags)
@@ -572,7 +572,7 @@ static zebra_neigh_t *zebra_evpn_neigh_add(zebra_evpn_t *zevpn,
 /*
  * Delete neighbor entry.
  */
-int zebra_evpn_neigh_del(zebra_evpn_t *zevpn, zebra_neigh_t *n)
+int zebra_evpn_neigh_del(struct zebra_evpn *zevpn, zebra_neigh_t *n)
 {
 	zebra_neigh_t *tmp_n;
 
@@ -614,7 +614,7 @@ void zebra_evpn_sync_neigh_del(zebra_neigh_t *n)
 }
 
 zebra_neigh_t *
-zebra_evpn_proc_sync_neigh_update(zebra_evpn_t *zevpn, zebra_neigh_t *n,
+zebra_evpn_proc_sync_neigh_update(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 				  uint16_t ipa_len, const struct ipaddr *ipaddr,
 				  uint8_t flags, uint32_t seq, const esi_t *esi,
 				  struct sync_mac_ip_ctx *ctx)
@@ -816,7 +816,8 @@ zebra_evpn_proc_sync_neigh_update(zebra_evpn_t *zevpn, zebra_neigh_t *n,
 /*
  * Uninstall remote neighbor from the kernel.
  */
-static int zebra_evpn_neigh_uninstall(zebra_evpn_t *zevpn, zebra_neigh_t *n)
+static int zebra_evpn_neigh_uninstall(struct zebra_evpn *zevpn,
+				      zebra_neigh_t *n)
 {
 	struct interface *vlan_if;
 
@@ -874,7 +875,7 @@ static void zebra_evpn_neigh_del_hash_entry(struct hash_bucket *bucket,
 /*
  * Delete all neighbor entries for this EVPN.
  */
-void zebra_evpn_neigh_del_all(zebra_evpn_t *zevpn, int uninstall,
+void zebra_evpn_neigh_del_all(struct zebra_evpn *zevpn, int uninstall,
 			      int upd_client, uint32_t flags)
 {
 	struct neigh_walk_ctx wctx;
@@ -895,7 +896,7 @@ void zebra_evpn_neigh_del_all(zebra_evpn_t *zevpn, int uninstall,
 /*
  * Look up neighbor hash entry.
  */
-zebra_neigh_t *zebra_evpn_neigh_lookup(zebra_evpn_t *zevpn,
+zebra_neigh_t *zebra_evpn_neigh_lookup(struct zebra_evpn *zevpn,
 				       const struct ipaddr *ip)
 {
 	zebra_neigh_t tmp;
@@ -912,7 +913,7 @@ zebra_neigh_t *zebra_evpn_neigh_lookup(zebra_evpn_t *zevpn,
  * Process all neighbors associated with a MAC upon the MAC being learnt
  * locally or undergoing any other change (such as sequence number).
  */
-void zebra_evpn_process_neigh_on_local_mac_change(zebra_evpn_t *zevpn,
+void zebra_evpn_process_neigh_on_local_mac_change(struct zebra_evpn *zevpn,
 						  zebra_mac_t *zmac,
 						  bool seq_change,
 						  bool es_change)
@@ -956,7 +957,7 @@ void zebra_evpn_process_neigh_on_local_mac_change(zebra_evpn_t *zevpn,
  * Process all neighbors associated with a local MAC upon the MAC being
  * deleted.
  */
-void zebra_evpn_process_neigh_on_local_mac_del(zebra_evpn_t *zevpn,
+void zebra_evpn_process_neigh_on_local_mac_del(struct zebra_evpn *zevpn,
 					       zebra_mac_t *zmac)
 {
 	zebra_neigh_t *n = NULL;
@@ -989,7 +990,7 @@ void zebra_evpn_process_neigh_on_local_mac_del(zebra_evpn_t *zevpn,
  * Process all neighbors associated with a MAC upon the MAC being remotely
  * learnt.
  */
-void zebra_evpn_process_neigh_on_remote_mac_add(zebra_evpn_t *zevpn,
+void zebra_evpn_process_neigh_on_remote_mac_add(struct zebra_evpn *zevpn,
 						zebra_mac_t *zmac)
 {
 	zebra_neigh_t *n = NULL;
@@ -1019,7 +1020,7 @@ void zebra_evpn_process_neigh_on_remote_mac_add(zebra_evpn_t *zevpn,
  * Process all neighbors associated with a remote MAC upon the MAC being
  * deleted.
  */
-void zebra_evpn_process_neigh_on_remote_mac_del(zebra_evpn_t *zevpn,
+void zebra_evpn_process_neigh_on_remote_mac_del(struct zebra_evpn *zevpn,
 						zebra_mac_t *zmac)
 {
 	/* NOTE: Currently a NO-OP. */
@@ -1094,7 +1095,7 @@ static int zebra_evpn_dad_ip_auto_recovery_exp(struct thread *t)
 {
 	struct zebra_vrf *zvrf = NULL;
 	zebra_neigh_t *nbr = NULL;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 
 	nbr = THREAD_ARG(t);
 
@@ -1254,7 +1255,8 @@ zebra_evpn_dup_addr_detect_for_neigh(struct zebra_vrf *zvrf, zebra_neigh_t *nbr,
 	}
 }
 
-int zebra_evpn_local_neigh_update(zebra_evpn_t *zevpn, struct interface *ifp,
+int zebra_evpn_local_neigh_update(struct zebra_evpn *zevpn,
+				  struct interface *ifp,
 				  const struct ipaddr *ip,
 				  const struct ethaddr *macaddr, bool is_router,
 				  bool local_inactive, bool dp_static)
@@ -1596,7 +1598,8 @@ int zebra_evpn_local_neigh_update(zebra_evpn_t *zevpn, struct interface *ifp,
 	return 0;
 }
 
-int zebra_evpn_remote_neigh_update(zebra_evpn_t *zevpn, struct interface *ifp,
+int zebra_evpn_remote_neigh_update(struct zebra_evpn *zevpn,
+				   struct interface *ifp,
 				   const struct ipaddr *ip,
 				   const struct ethaddr *macaddr,
 				   uint16_t state)
@@ -1664,7 +1667,7 @@ zebra_evpn_send_neigh_hash_entry_to_client(struct hash_bucket *bucket,
 }
 
 /* Iterator of a specific EVPN */
-void zebra_evpn_send_neigh_to_client(zebra_evpn_t *zevpn)
+void zebra_evpn_send_neigh_to_client(struct zebra_evpn *zevpn)
 {
 	struct neigh_walk_ctx wctx;
 
@@ -1679,7 +1682,7 @@ void zebra_evpn_clear_dup_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 {
 	struct neigh_walk_ctx *wctx = ctxt;
 	zebra_neigh_t *nbr;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	char buf[INET6_ADDRSTRLEN];
 
 	nbr = (zebra_neigh_t *)bucket->data;
@@ -2048,7 +2051,7 @@ void zebra_evpn_print_dad_neigh_hash_detail(struct hash_bucket *bucket,
 		zebra_evpn_print_neigh_hash_detail(bucket, ctxt);
 }
 
-void zebra_evpn_neigh_remote_macip_add(zebra_evpn_t *zevpn,
+void zebra_evpn_neigh_remote_macip_add(struct zebra_evpn *zevpn,
 				       struct zebra_vrf *zvrf,
 				       const struct ipaddr *ipaddr,
 				       zebra_mac_t *mac, struct in_addr vtep_ip,
@@ -2182,8 +2185,9 @@ void zebra_evpn_neigh_remote_macip_add(zebra_evpn_t *zevpn,
 	n->rem_seq = seq;
 }
 
-int zebra_evpn_neigh_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
-				  struct ipaddr *ip, zebra_mac_t *mac)
+int zebra_evpn_neigh_gw_macip_add(struct interface *ifp,
+				  struct zebra_evpn *zevpn, struct ipaddr *ip,
+				  zebra_mac_t *mac)
 {
 	zebra_neigh_t *n;
 
@@ -2241,7 +2245,7 @@ int zebra_evpn_neigh_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
 	return 0;
 }
 
-void zebra_evpn_neigh_remote_uninstall(zebra_evpn_t *zevpn,
+void zebra_evpn_neigh_remote_uninstall(struct zebra_evpn *zevpn,
 				       struct zebra_vrf *zvrf, zebra_neigh_t *n,
 				       zebra_mac_t *mac,
 				       const struct ipaddr *ipaddr)
@@ -2277,7 +2281,7 @@ void zebra_evpn_neigh_remote_uninstall(zebra_evpn_t *zevpn,
 	}
 }
 
-int zebra_evpn_neigh_del_ip(zebra_evpn_t *zevpn, const struct ipaddr *ip)
+int zebra_evpn_neigh_del_ip(struct zebra_evpn *zevpn, const struct ipaddr *ip)
 {
 	zebra_neigh_t *n;
 	zebra_mac_t *zmac;

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -133,7 +133,7 @@ void zebra_evpn_find_neigh_addr_width(struct hash_bucket *bucket, void *ctxt)
 /*
  * Count of remote neighbors referencing this MAC.
  */
-int remote_neigh_count(zebra_mac_t *zmac)
+int remote_neigh_count(struct zebra_mac *zmac)
 {
 	zebra_neigh_t *n = NULL;
 	struct listnode *node = NULL;
@@ -205,7 +205,7 @@ static void *zebra_evpn_neigh_alloc(void *p)
 
 static void zebra_evpn_local_neigh_ref_mac(zebra_neigh_t *n,
 					   const struct ethaddr *macaddr,
-					   zebra_mac_t *mac,
+					   struct zebra_mac *mac,
 					   bool send_mac_update)
 {
 	bool old_static;
@@ -286,8 +286,8 @@ static void zebra_evpn_sync_neigh_dp_install(zebra_neigh_t *n,
  */
 int zebra_evpn_neigh_send_add_to_client(vni_t vni, const struct ipaddr *ip,
 					const struct ethaddr *macaddr,
-					zebra_mac_t *zmac, uint32_t neigh_flags,
-					uint32_t seq)
+					struct zebra_mac *zmac,
+					uint32_t neigh_flags, uint32_t seq)
 {
 	uint8_t flags = 0;
 
@@ -359,7 +359,7 @@ void zebra_evpn_sync_neigh_static_chg(zebra_neigh_t *n, bool old_n_static,
 				      bool new_n_static, bool defer_n_dp,
 				      bool defer_mac_dp, const char *caller)
 {
-	zebra_mac_t *mac = n->mac;
+	struct zebra_mac *mac = n->mac;
 	bool old_mac_static;
 	bool new_mac_static;
 
@@ -467,7 +467,7 @@ static inline void zebra_evpn_neigh_start_hold_timer(zebra_neigh_t *n)
 static void zebra_evpn_local_neigh_deref_mac(zebra_neigh_t *n,
 					     bool send_mac_update)
 {
-	zebra_mac_t *mac = n->mac;
+	struct zebra_mac *mac = n->mac;
 	struct zebra_evpn *zevpn = n->zevpn;
 	bool old_static;
 	bool new_static;
@@ -545,7 +545,8 @@ bool zebra_evpn_neigh_is_bgp_seq_ok(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 static zebra_neigh_t *zebra_evpn_neigh_add(struct zebra_evpn *zevpn,
 					   const struct ipaddr *ip,
 					   const struct ethaddr *mac,
-					   zebra_mac_t *zmac, uint32_t n_flags)
+					   struct zebra_mac *zmac,
+					   uint32_t n_flags)
 {
 	zebra_neigh_t tmp_n;
 	zebra_neigh_t *n = NULL;
@@ -621,7 +622,7 @@ zebra_evpn_proc_sync_neigh_update(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 {
 	struct interface *ifp = NULL;
 	bool is_router;
-	zebra_mac_t *mac = ctx->mac;
+	struct zebra_mac *mac = ctx->mac;
 	uint32_t tmp_seq;
 	bool old_router = false;
 	bool old_bgp_ready = false;
@@ -914,7 +915,7 @@ zebra_neigh_t *zebra_evpn_neigh_lookup(struct zebra_evpn *zevpn,
  * locally or undergoing any other change (such as sequence number).
  */
 void zebra_evpn_process_neigh_on_local_mac_change(struct zebra_evpn *zevpn,
-						  zebra_mac_t *zmac,
+						  struct zebra_mac *zmac,
 						  bool seq_change,
 						  bool es_change)
 {
@@ -958,7 +959,7 @@ void zebra_evpn_process_neigh_on_local_mac_change(struct zebra_evpn *zevpn,
  * deleted.
  */
 void zebra_evpn_process_neigh_on_local_mac_del(struct zebra_evpn *zevpn,
-					       zebra_mac_t *zmac)
+					       struct zebra_mac *zmac)
 {
 	zebra_neigh_t *n = NULL;
 	struct listnode *node = NULL;
@@ -991,7 +992,7 @@ void zebra_evpn_process_neigh_on_local_mac_del(struct zebra_evpn *zevpn,
  * learnt.
  */
 void zebra_evpn_process_neigh_on_remote_mac_add(struct zebra_evpn *zevpn,
-						zebra_mac_t *zmac)
+						struct zebra_mac *zmac)
 {
 	zebra_neigh_t *n = NULL;
 	struct listnode *node = NULL;
@@ -1021,7 +1022,7 @@ void zebra_evpn_process_neigh_on_remote_mac_add(struct zebra_evpn *zevpn,
  * deleted.
  */
 void zebra_evpn_process_neigh_on_remote_mac_del(struct zebra_evpn *zevpn,
-						zebra_mac_t *zmac)
+						struct zebra_mac *zmac)
 {
 	/* NOTE: Currently a NO-OP. */
 }
@@ -1049,8 +1050,8 @@ static inline void zebra_evpn_local_neigh_update_log(
  * from MAC.
  */
 static int zebra_evpn_ip_inherit_dad_from_mac(struct zebra_vrf *zvrf,
-					      zebra_mac_t *old_zmac,
-					      zebra_mac_t *new_zmac,
+					      struct zebra_mac *old_zmac,
+					      struct zebra_mac *new_zmac,
 					      zebra_neigh_t *nbr)
 {
 	bool is_old_mac_dup = false;
@@ -1263,7 +1264,7 @@ int zebra_evpn_local_neigh_update(struct zebra_evpn *zevpn,
 {
 	struct zebra_vrf *zvrf;
 	zebra_neigh_t *n = NULL;
-	zebra_mac_t *zmac = NULL, *old_zmac = NULL;
+	struct zebra_mac *zmac = NULL, *old_zmac = NULL;
 	uint32_t old_mac_seq = 0, mac_new_seq = 0;
 	bool upd_mac_seq = false;
 	bool neigh_mac_change = false;
@@ -1605,7 +1606,7 @@ int zebra_evpn_remote_neigh_update(struct zebra_evpn *zevpn,
 				   uint16_t state)
 {
 	zebra_neigh_t *n = NULL;
-	zebra_mac_t *zmac = NULL;
+	struct zebra_mac *zmac = NULL;
 
 	/* If the neighbor is unknown, there is no further action. */
 	n = zebra_evpn_neigh_lookup(zevpn, ip);
@@ -1649,7 +1650,7 @@ zebra_evpn_send_neigh_hash_entry_to_client(struct hash_bucket *bucket,
 {
 	struct mac_walk_ctx *wctx = arg;
 	zebra_neigh_t *zn = bucket->data;
-	zebra_mac_t *zmac = NULL;
+	struct zebra_mac *zmac = NULL;
 
 	if (CHECK_FLAG(zn->flags, ZEBRA_NEIGH_DEF_GW))
 		return;
@@ -2054,12 +2055,13 @@ void zebra_evpn_print_dad_neigh_hash_detail(struct hash_bucket *bucket,
 void zebra_evpn_neigh_remote_macip_add(struct zebra_evpn *zevpn,
 				       struct zebra_vrf *zvrf,
 				       const struct ipaddr *ipaddr,
-				       zebra_mac_t *mac, struct in_addr vtep_ip,
-				       uint8_t flags, uint32_t seq)
+				       struct zebra_mac *mac,
+				       struct in_addr vtep_ip, uint8_t flags,
+				       uint32_t seq)
 {
 	zebra_neigh_t *n;
 	int update_neigh = 0;
-	zebra_mac_t *old_mac = NULL;
+	struct zebra_mac *old_mac = NULL;
 	bool old_static = false;
 	bool do_dad = false;
 	bool is_dup_detect = false;
@@ -2187,7 +2189,7 @@ void zebra_evpn_neigh_remote_macip_add(struct zebra_evpn *zevpn,
 
 int zebra_evpn_neigh_gw_macip_add(struct interface *ifp,
 				  struct zebra_evpn *zevpn, struct ipaddr *ip,
-				  zebra_mac_t *mac)
+				  struct zebra_mac *mac)
 {
 	zebra_neigh_t *n;
 
@@ -2247,7 +2249,7 @@ int zebra_evpn_neigh_gw_macip_add(struct interface *ifp,
 
 void zebra_evpn_neigh_remote_uninstall(struct zebra_evpn *zevpn,
 				       struct zebra_vrf *zvrf, zebra_neigh_t *n,
-				       zebra_mac_t *mac,
+				       struct zebra_mac *mac,
 				       const struct ipaddr *ipaddr)
 {
 	if (zvrf->dad_freeze && CHECK_FLAG(n->flags, ZEBRA_NEIGH_DUPLICATE)
@@ -2284,7 +2286,7 @@ void zebra_evpn_neigh_remote_uninstall(struct zebra_evpn *zevpn,
 int zebra_evpn_neigh_del_ip(struct zebra_evpn *zevpn, const struct ipaddr *ip)
 {
 	zebra_neigh_t *n;
-	zebra_mac_t *zmac;
+	struct zebra_mac *zmac;
 	bool old_bgp_ready;
 	bool new_bgp_ready;
 	struct zebra_vrf *zvrf;

--- a/zebra/zebra_evpn_neigh.h
+++ b/zebra/zebra_evpn_neigh.h
@@ -58,7 +58,7 @@ struct zebra_neigh_t_ {
 	struct ethaddr emac;
 
 	/* Back pointer to MAC. Only applicable to hosts in a L2-VNI. */
-	zebra_mac_t *mac;
+	struct zebra_mac *mac;
 
 	/* Underlying interface. */
 	ifindex_t ifindex;
@@ -207,20 +207,20 @@ static inline bool zebra_evpn_neigh_clear_sync_info(zebra_neigh_t *n)
 	return old_n_static != new_n_static;
 }
 
-int remote_neigh_count(zebra_mac_t *zmac);
+int remote_neigh_count(struct zebra_mac *zmac);
 
 int neigh_list_cmp(void *p1, void *p2);
 struct hash *zebra_neigh_db_create(const char *desc);
 uint32_t num_dup_detected_neighs(struct zebra_evpn *zevpn);
 void zebra_evpn_find_neigh_addr_width(struct hash_bucket *bucket, void *ctxt);
-int remote_neigh_count(zebra_mac_t *zmac);
+int remote_neigh_count(struct zebra_mac *zmac);
 int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 				 bool was_static);
 void zebra_evpn_install_neigh_hash(struct hash_bucket *bucket, void *ctxt);
 int zebra_evpn_neigh_send_add_to_client(vni_t vni, const struct ipaddr *ip,
 					const struct ethaddr *macaddr,
-					zebra_mac_t *zmac, uint32_t neigh_flags,
-					uint32_t seq);
+					struct zebra_mac *zmac,
+					uint32_t neigh_flags, uint32_t seq);
 int zebra_evpn_neigh_send_del_to_client(vni_t vni, struct ipaddr *ip,
 					struct ethaddr *macaddr, uint32_t flags,
 					int state, bool force);
@@ -242,15 +242,15 @@ zebra_neigh_t *zebra_evpn_neigh_lookup(struct zebra_evpn *zevpn,
 int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 				 bool was_static);
 void zebra_evpn_process_neigh_on_remote_mac_add(struct zebra_evpn *zevpn,
-						zebra_mac_t *zmac);
+						struct zebra_mac *zmac);
 void zebra_evpn_process_neigh_on_local_mac_del(struct zebra_evpn *zevpn,
-					       zebra_mac_t *zmac);
+					       struct zebra_mac *zmac);
 void zebra_evpn_process_neigh_on_local_mac_change(struct zebra_evpn *zevpn,
-						  zebra_mac_t *zmac,
+						  struct zebra_mac *zmac,
 						  bool seq_change,
 						  bool es_change);
 void zebra_evpn_process_neigh_on_remote_mac_del(struct zebra_evpn *zevpn,
-						zebra_mac_t *zmac);
+						struct zebra_mac *zmac);
 int zebra_evpn_local_neigh_update(struct zebra_evpn *zevpn,
 				  struct interface *ifp,
 				  const struct ipaddr *ip,
@@ -273,14 +273,15 @@ void zebra_evpn_print_dad_neigh_hash_detail(struct hash_bucket *bucket,
 void zebra_evpn_neigh_remote_macip_add(struct zebra_evpn *zevpn,
 				       struct zebra_vrf *zvrf,
 				       const struct ipaddr *ipaddr,
-				       zebra_mac_t *mac, struct in_addr vtep_ip,
-				       uint8_t flags, uint32_t seq);
+				       struct zebra_mac *mac,
+				       struct in_addr vtep_ip, uint8_t flags,
+				       uint32_t seq);
 int zebra_evpn_neigh_gw_macip_add(struct interface *ifp,
 				  struct zebra_evpn *zevpn, struct ipaddr *ip,
-				  zebra_mac_t *mac);
+				  struct zebra_mac *mac);
 void zebra_evpn_neigh_remote_uninstall(struct zebra_evpn *zevpn,
 				       struct zebra_vrf *zvrf, zebra_neigh_t *n,
-				       zebra_mac_t *mac,
+				       struct zebra_mac *mac,
 				       const struct ipaddr *ipaddr);
 int zebra_evpn_neigh_del_ip(struct zebra_evpn *zevpn, const struct ipaddr *ip);
 

--- a/zebra/zebra_evpn_neigh.h
+++ b/zebra/zebra_evpn_neigh.h
@@ -29,8 +29,6 @@
 extern "C" {
 #endif
 
-typedef struct zebra_neigh_t_ zebra_neigh_t;
-
 #define IS_ZEBRA_NEIGH_ACTIVE(n) (n->state == ZEBRA_NEIGH_ACTIVE)
 
 #define IS_ZEBRA_NEIGH_INACTIVE(n) (n->state == ZEBRA_NEIGH_INACTIVE)
@@ -50,7 +48,7 @@ typedef struct zebra_neigh_t_ zebra_neigh_t;
  * it is sufficient for zebra to maintain against the VNI. The correct
  * VNI will be obtained as zebra maintains the mapping (of VLAN to VNI).
  */
-struct zebra_neigh_t_ {
+struct zebra_neigh {
 	/* IP address. */
 	struct ipaddr ip;
 
@@ -144,12 +142,12 @@ struct neigh_walk_ctx {
 };
 
 /**************************** SYNC neigh handling **************************/
-static inline bool zebra_evpn_neigh_is_static(zebra_neigh_t *neigh)
+static inline bool zebra_evpn_neigh_is_static(struct zebra_neigh *neigh)
 {
 	return !!(neigh->flags & ZEBRA_NEIGH_ALL_PEER_FLAGS);
 }
 
-static inline bool zebra_evpn_neigh_is_ready_for_bgp(zebra_neigh_t *n)
+static inline bool zebra_evpn_neigh_is_ready_for_bgp(struct zebra_neigh *n)
 {
 	bool mac_ready;
 	bool neigh_ready;
@@ -165,7 +163,7 @@ static inline bool zebra_evpn_neigh_is_ready_for_bgp(zebra_neigh_t *n)
 	return mac_ready && neigh_ready;
 }
 
-static inline void zebra_evpn_neigh_stop_hold_timer(zebra_neigh_t *n)
+static inline void zebra_evpn_neigh_stop_hold_timer(struct zebra_neigh *n)
 {
 	if (!n->hold_timer)
 		return;
@@ -176,11 +174,11 @@ static inline void zebra_evpn_neigh_stop_hold_timer(zebra_neigh_t *n)
 	THREAD_OFF(n->hold_timer);
 }
 
-void zebra_evpn_sync_neigh_static_chg(zebra_neigh_t *n, bool old_n_static,
+void zebra_evpn_sync_neigh_static_chg(struct zebra_neigh *n, bool old_n_static,
 				      bool new_n_static, bool defer_n_dp,
 				      bool defer_mac_dp, const char *caller);
 
-static inline bool zebra_evpn_neigh_clear_sync_info(zebra_neigh_t *n)
+static inline bool zebra_evpn_neigh_clear_sync_info(struct zebra_neigh *n)
 {
 	bool old_n_static = false;
 	bool new_n_static = false;
@@ -214,8 +212,8 @@ struct hash *zebra_neigh_db_create(const char *desc);
 uint32_t num_dup_detected_neighs(struct zebra_evpn *zevpn);
 void zebra_evpn_find_neigh_addr_width(struct hash_bucket *bucket, void *ctxt);
 int remote_neigh_count(struct zebra_mac *zmac);
-int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn, zebra_neigh_t *n,
-				 bool was_static);
+int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn,
+				 struct zebra_neigh *n, bool was_static);
 void zebra_evpn_install_neigh_hash(struct hash_bucket *bucket, void *ctxt);
 int zebra_evpn_neigh_send_add_to_client(vni_t vni, const struct ipaddr *ip,
 					const struct ethaddr *macaddr,
@@ -224,23 +222,23 @@ int zebra_evpn_neigh_send_add_to_client(vni_t vni, const struct ipaddr *ip,
 int zebra_evpn_neigh_send_del_to_client(vni_t vni, struct ipaddr *ip,
 					struct ethaddr *macaddr, uint32_t flags,
 					int state, bool force);
-bool zebra_evpn_neigh_is_bgp_seq_ok(struct zebra_evpn *zevpn, zebra_neigh_t *n,
+bool zebra_evpn_neigh_is_bgp_seq_ok(struct zebra_evpn *zevpn,
+				    struct zebra_neigh *n,
 				    const struct ethaddr *macaddr, uint32_t seq,
 				    bool sync);
-int zebra_evpn_neigh_del(struct zebra_evpn *zevpn, zebra_neigh_t *n);
-void zebra_evpn_sync_neigh_del(zebra_neigh_t *n);
-zebra_neigh_t *
-zebra_evpn_proc_sync_neigh_update(struct zebra_evpn *zevpn, zebra_neigh_t *n,
-				  uint16_t ipa_len, const struct ipaddr *ipaddr,
-				  uint8_t flags, uint32_t seq, const esi_t *esi,
-				  struct sync_mac_ip_ctx *ctx);
+int zebra_evpn_neigh_del(struct zebra_evpn *zevpn, struct zebra_neigh *n);
+void zebra_evpn_sync_neigh_del(struct zebra_neigh *n);
+struct zebra_neigh *zebra_evpn_proc_sync_neigh_update(
+	struct zebra_evpn *zevpn, struct zebra_neigh *n, uint16_t ipa_len,
+	const struct ipaddr *ipaddr, uint8_t flags, uint32_t seq,
+	const esi_t *esi, struct sync_mac_ip_ctx *ctx);
 void zebra_evpn_neigh_del_all(struct zebra_evpn *zevpn, int uninstall,
 			      int upd_client, uint32_t flags);
-zebra_neigh_t *zebra_evpn_neigh_lookup(struct zebra_evpn *zevpn,
-				       const struct ipaddr *ip);
+struct zebra_neigh *zebra_evpn_neigh_lookup(struct zebra_evpn *zevpn,
+					    const struct ipaddr *ip);
 
-int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn, zebra_neigh_t *n,
-				 bool was_static);
+int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn,
+				 struct zebra_neigh *n, bool was_static);
 void zebra_evpn_process_neigh_on_remote_mac_add(struct zebra_evpn *zevpn,
 						struct zebra_mac *zmac);
 void zebra_evpn_process_neigh_on_local_mac_del(struct zebra_evpn *zevpn,
@@ -263,7 +261,8 @@ int zebra_evpn_remote_neigh_update(struct zebra_evpn *zevpn,
 				   uint16_t state);
 void zebra_evpn_send_neigh_to_client(struct zebra_evpn *zevpn);
 void zebra_evpn_clear_dup_neigh_hash(struct hash_bucket *bucket, void *ctxt);
-void zebra_evpn_print_neigh(zebra_neigh_t *n, void *ctxt, json_object *json);
+void zebra_evpn_print_neigh(struct zebra_neigh *n, void *ctxt,
+			    json_object *json);
 void zebra_evpn_print_neigh_hash(struct hash_bucket *bucket, void *ctxt);
 void zebra_evpn_print_neigh_hdr(struct vty *vty, struct neigh_walk_ctx *wctx);
 void zebra_evpn_print_neigh_hash_detail(struct hash_bucket *bucket, void *ctxt);
@@ -280,7 +279,8 @@ int zebra_evpn_neigh_gw_macip_add(struct interface *ifp,
 				  struct zebra_evpn *zevpn, struct ipaddr *ip,
 				  struct zebra_mac *mac);
 void zebra_evpn_neigh_remote_uninstall(struct zebra_evpn *zevpn,
-				       struct zebra_vrf *zvrf, zebra_neigh_t *n,
+				       struct zebra_vrf *zvrf,
+				       struct zebra_neigh *n,
 				       struct zebra_mac *mac,
 				       const struct ipaddr *ipaddr);
 int zebra_evpn_neigh_del_ip(struct zebra_evpn *zevpn, const struct ipaddr *ip);

--- a/zebra/zebra_evpn_neigh.h
+++ b/zebra/zebra_evpn_neigh.h
@@ -63,7 +63,7 @@ struct zebra_neigh_t_ {
 	/* Underlying interface. */
 	ifindex_t ifindex;
 
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 
 	uint32_t flags;
 #define ZEBRA_NEIGH_LOCAL 0x01
@@ -123,7 +123,7 @@ struct zebra_neigh_t_ {
  * Context for neighbor hash walk - used by callbacks.
  */
 struct neigh_walk_ctx {
-	zebra_evpn_t *zevpn;    /* VNI hash */
+	struct zebra_evpn *zevpn; /* VNI hash */
 	struct zebra_vrf *zvrf; /* VRF - for client notification. */
 	int uninstall;		/* uninstall from kernel? */
 	int upd_client;		/* uninstall from client? */
@@ -211,10 +211,10 @@ int remote_neigh_count(zebra_mac_t *zmac);
 
 int neigh_list_cmp(void *p1, void *p2);
 struct hash *zebra_neigh_db_create(const char *desc);
-uint32_t num_dup_detected_neighs(zebra_evpn_t *zevpn);
+uint32_t num_dup_detected_neighs(struct zebra_evpn *zevpn);
 void zebra_evpn_find_neigh_addr_width(struct hash_bucket *bucket, void *ctxt);
 int remote_neigh_count(zebra_mac_t *zmac);
-int zebra_evpn_rem_neigh_install(zebra_evpn_t *zevpn, zebra_neigh_t *n,
+int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 				 bool was_static);
 void zebra_evpn_install_neigh_hash(struct hash_bucket *bucket, void *ctxt);
 int zebra_evpn_neigh_send_add_to_client(vni_t vni, const struct ipaddr *ip,
@@ -224,42 +224,44 @@ int zebra_evpn_neigh_send_add_to_client(vni_t vni, const struct ipaddr *ip,
 int zebra_evpn_neigh_send_del_to_client(vni_t vni, struct ipaddr *ip,
 					struct ethaddr *macaddr, uint32_t flags,
 					int state, bool force);
-bool zebra_evpn_neigh_is_bgp_seq_ok(zebra_evpn_t *zevpn, zebra_neigh_t *n,
+bool zebra_evpn_neigh_is_bgp_seq_ok(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 				    const struct ethaddr *macaddr, uint32_t seq,
 				    bool sync);
-int zebra_evpn_neigh_del(zebra_evpn_t *zevpn, zebra_neigh_t *n);
+int zebra_evpn_neigh_del(struct zebra_evpn *zevpn, zebra_neigh_t *n);
 void zebra_evpn_sync_neigh_del(zebra_neigh_t *n);
 zebra_neigh_t *
-zebra_evpn_proc_sync_neigh_update(zebra_evpn_t *zevpn, zebra_neigh_t *n,
+zebra_evpn_proc_sync_neigh_update(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 				  uint16_t ipa_len, const struct ipaddr *ipaddr,
 				  uint8_t flags, uint32_t seq, const esi_t *esi,
 				  struct sync_mac_ip_ctx *ctx);
-void zebra_evpn_neigh_del_all(zebra_evpn_t *zevpn, int uninstall,
+void zebra_evpn_neigh_del_all(struct zebra_evpn *zevpn, int uninstall,
 			      int upd_client, uint32_t flags);
-zebra_neigh_t *zebra_evpn_neigh_lookup(zebra_evpn_t *zevpn,
+zebra_neigh_t *zebra_evpn_neigh_lookup(struct zebra_evpn *zevpn,
 				       const struct ipaddr *ip);
 
-int zebra_evpn_rem_neigh_install(zebra_evpn_t *zevpn, zebra_neigh_t *n,
+int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn, zebra_neigh_t *n,
 				 bool was_static);
-void zebra_evpn_process_neigh_on_remote_mac_add(zebra_evpn_t *zevpn,
+void zebra_evpn_process_neigh_on_remote_mac_add(struct zebra_evpn *zevpn,
 						zebra_mac_t *zmac);
-void zebra_evpn_process_neigh_on_local_mac_del(zebra_evpn_t *zevpn,
+void zebra_evpn_process_neigh_on_local_mac_del(struct zebra_evpn *zevpn,
 					       zebra_mac_t *zmac);
-void zebra_evpn_process_neigh_on_local_mac_change(zebra_evpn_t *zevpn,
+void zebra_evpn_process_neigh_on_local_mac_change(struct zebra_evpn *zevpn,
 						  zebra_mac_t *zmac,
 						  bool seq_change,
 						  bool es_change);
-void zebra_evpn_process_neigh_on_remote_mac_del(zebra_evpn_t *zevpn,
+void zebra_evpn_process_neigh_on_remote_mac_del(struct zebra_evpn *zevpn,
 						zebra_mac_t *zmac);
-int zebra_evpn_local_neigh_update(zebra_evpn_t *zevpn, struct interface *ifp,
+int zebra_evpn_local_neigh_update(struct zebra_evpn *zevpn,
+				  struct interface *ifp,
 				  const struct ipaddr *ip,
 				  const struct ethaddr *macaddr, bool is_router,
 				  bool local_inactive, bool dp_static);
-int zebra_evpn_remote_neigh_update(zebra_evpn_t *zevpn, struct interface *ifp,
+int zebra_evpn_remote_neigh_update(struct zebra_evpn *zevpn,
+				   struct interface *ifp,
 				   const struct ipaddr *ip,
 				   const struct ethaddr *macaddr,
 				   uint16_t state);
-void zebra_evpn_send_neigh_to_client(zebra_evpn_t *zevpn);
+void zebra_evpn_send_neigh_to_client(struct zebra_evpn *zevpn);
 void zebra_evpn_clear_dup_neigh_hash(struct hash_bucket *bucket, void *ctxt);
 void zebra_evpn_print_neigh(zebra_neigh_t *n, void *ctxt, json_object *json);
 void zebra_evpn_print_neigh_hash(struct hash_bucket *bucket, void *ctxt);
@@ -268,18 +270,19 @@ void zebra_evpn_print_neigh_hash_detail(struct hash_bucket *bucket, void *ctxt);
 void zebra_evpn_print_dad_neigh_hash(struct hash_bucket *bucket, void *ctxt);
 void zebra_evpn_print_dad_neigh_hash_detail(struct hash_bucket *bucket,
 					    void *ctxt);
-void zebra_evpn_neigh_remote_macip_add(zebra_evpn_t *zevpn,
+void zebra_evpn_neigh_remote_macip_add(struct zebra_evpn *zevpn,
 				       struct zebra_vrf *zvrf,
 				       const struct ipaddr *ipaddr,
 				       zebra_mac_t *mac, struct in_addr vtep_ip,
 				       uint8_t flags, uint32_t seq);
-int zebra_evpn_neigh_gw_macip_add(struct interface *ifp, zebra_evpn_t *zevpn,
-				  struct ipaddr *ip, zebra_mac_t *mac);
-void zebra_evpn_neigh_remote_uninstall(zebra_evpn_t *zevpn,
+int zebra_evpn_neigh_gw_macip_add(struct interface *ifp,
+				  struct zebra_evpn *zevpn, struct ipaddr *ip,
+				  zebra_mac_t *mac);
+void zebra_evpn_neigh_remote_uninstall(struct zebra_evpn *zevpn,
 				       struct zebra_vrf *zvrf, zebra_neigh_t *n,
 				       zebra_mac_t *mac,
 				       const struct ipaddr *ipaddr);
-int zebra_evpn_neigh_del_ip(zebra_evpn_t *zevpn, const struct ipaddr *ip);
+int zebra_evpn_neigh_del_ip(struct zebra_evpn *zevpn, const struct ipaddr *ip);
 
 
 #ifdef __cplusplus

--- a/zebra/zebra_evpn_vxlan.h
+++ b/zebra/zebra_evpn_vxlan.h
@@ -47,7 +47,7 @@ zebra_get_vrr_intf_for_svi(struct interface *ifp)
 }
 
 /* EVPN<=>vxlan_zif association */
-static inline void zevpn_vxlan_if_set(zebra_evpn_t *zevpn,
+static inline void zevpn_vxlan_if_set(struct zebra_evpn *zevpn,
 				      struct interface *ifp, bool set)
 {
 	struct zebra_if *zif;

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1553,8 +1553,9 @@ static void zfpm_mac_info_del(struct fpm_mac_info_t *fpm_mac)
  * This function checks if we already have enqueued an update for this RMAC,
  * If yes, update the same fpm_mac_info_t. Else, create and enqueue an update.
  */
-static int zfpm_trigger_rmac_update(zebra_mac_t *rmac, zebra_l3vni_t *zl3vni,
-					bool delete, const char *reason)
+static int zfpm_trigger_rmac_update(struct zebra_mac *rmac,
+				    zebra_l3vni_t *zl3vni, bool delete,
+				    const char *reason)
 {
 	struct fpm_mac_info_t *fpm_mac, key;
 	struct interface *vxlan_if, *svi_if;
@@ -1637,7 +1638,7 @@ static int zfpm_trigger_rmac_update(zebra_mac_t *rmac, zebra_l3vni_t *zl3vni,
 static void zfpm_trigger_rmac_update_wrapper(struct hash_bucket *bucket,
 					     void *args)
 {
-	zebra_mac_t *zrmac = (zebra_mac_t *)bucket->data;
+	struct zebra_mac *zrmac = (struct zebra_mac *)bucket->data;
 	zebra_l3vni_t *zl3vni = (zebra_l3vni_t *)args;
 
 	zfpm_trigger_rmac_update(zrmac, zl3vni, false, "RMAC added");

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1554,7 +1554,7 @@ static void zfpm_mac_info_del(struct fpm_mac_info_t *fpm_mac)
  * If yes, update the same fpm_mac_info_t. Else, create and enqueue an update.
  */
 static int zfpm_trigger_rmac_update(struct zebra_mac *rmac,
-				    zebra_l3vni_t *zl3vni, bool delete,
+				    struct zebra_l3vni *zl3vni, bool delete,
 				    const char *reason)
 {
 	struct fpm_mac_info_t *fpm_mac, key;
@@ -1639,7 +1639,7 @@ static void zfpm_trigger_rmac_update_wrapper(struct hash_bucket *bucket,
 					     void *args)
 {
 	struct zebra_mac *zrmac = (struct zebra_mac *)bucket->data;
-	zebra_l3vni_t *zl3vni = (zebra_l3vni_t *)args;
+	struct zebra_l3vni *zl3vni = (struct zebra_l3vni *)args;
 
 	zfpm_trigger_rmac_update(zrmac, zl3vni, false, "RMAC added");
 }
@@ -1651,7 +1651,7 @@ static void zfpm_trigger_rmac_update_wrapper(struct hash_bucket *bucket,
  */
 static void zfpm_iterate_rmac_table(struct hash_bucket *bucket, void *args)
 {
-	zebra_l3vni_t *zl3vni = (zebra_l3vni_t *)bucket->data;
+	struct zebra_l3vni *zl3vni = (struct zebra_l3vni *)bucket->data;
 
 	hash_iterate(zl3vni->rmac_table, zfpm_trigger_rmac_update_wrapper,
 		     (void *)zl3vni);

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -166,7 +166,7 @@ static int lsp_install(struct zebra_vrf *zvrf, mpls_label_t label,
 		       struct route_node *rn, struct route_entry *re)
 {
 	struct hash *lsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	zebra_lsp_t *lsp;
 	zebra_nhlfe_t *nhlfe;
 	struct nexthop *nexthop;
@@ -271,7 +271,7 @@ static int lsp_install(struct zebra_vrf *zvrf, mpls_label_t label,
 static int lsp_uninstall(struct zebra_vrf *zvrf, mpls_label_t label)
 {
 	struct hash *lsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	zebra_lsp_t *lsp;
 	zebra_nhlfe_t *nhlfe;
 	char buf[BUFSIZ];
@@ -576,7 +576,7 @@ static int fec_del(zebra_fec_t *fec)
  */
 static unsigned int label_hash(const void *p)
 {
-	const zebra_ile_t *ile = p;
+	const struct zebra_ile *ile = p;
 
 	return (jhash_1word(ile->in_label, 0));
 }
@@ -586,8 +586,8 @@ static unsigned int label_hash(const void *p)
  */
 static bool label_cmp(const void *p1, const void *p2)
 {
-	const zebra_ile_t *ile1 = p1;
-	const zebra_ile_t *ile2 = p2;
+	const struct zebra_ile *ile1 = p1;
+	const struct zebra_ile *ile2 = p2;
 
 	return (ile1->in_label == ile2->in_label);
 }
@@ -1099,7 +1099,7 @@ static int lsp_processq_add(zebra_lsp_t *lsp)
  */
 static void *lsp_alloc(void *p)
 {
-	const zebra_ile_t *ile = p;
+	const struct zebra_ile *ile = p;
 	zebra_lsp_t *lsp;
 
 	lsp = XCALLOC(MTYPE_LSP, sizeof(zebra_lsp_t));
@@ -1480,7 +1480,7 @@ static int mpls_static_lsp_uninstall_all(struct zebra_vrf *zvrf,
 					 mpls_label_t in_label)
 {
 	struct hash *lsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	zebra_lsp_t *lsp;
 
 	/* Lookup table. */
@@ -1760,7 +1760,7 @@ void zebra_mpls_lsp_dplane_result(struct zebra_dplane_ctx *ctx)
 {
 	struct zebra_vrf *zvrf;
 	mpls_label_t label;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	struct hash *lsp_table;
 	zebra_lsp_t *lsp;
 	zebra_nhlfe_t *nhlfe;
@@ -2038,7 +2038,7 @@ static int update_nhlfes_from_ctx(struct nhlfe_list_head *nhlfe_head,
 void zebra_mpls_process_dplane_notify(struct zebra_dplane_ctx *ctx)
 {
 	struct zebra_vrf *zvrf;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	struct hash *lsp_table;
 	zebra_lsp_t *lsp;
 	const struct nhlfe_list_head *ctx_list;
@@ -2900,7 +2900,7 @@ int mpls_zapi_labels_process(bool add_p, struct zebra_vrf *zvrf,
 	afi_t afi = AFI_IP;
 	const struct prefix *prefix = NULL;
 	struct hash *lsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	zebra_lsp_t *lsp = NULL;
 
 	/* Prep LSP for add case */
@@ -3180,7 +3180,7 @@ int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
 		     const union g_addr *gate, ifindex_t ifindex)
 {
 	struct hash *lsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	zebra_lsp_t *lsp;
 	zebra_nhlfe_t *nhlfe;
 
@@ -3273,7 +3273,7 @@ static int lsp_backup_znh_install(zebra_lsp_t *lsp, enum lsp_types_t type,
 zebra_lsp_t *mpls_lsp_find(struct zebra_vrf *zvrf, mpls_label_t in_label)
 {
 	struct hash *lsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 
 	/* Lookup table. */
 	lsp_table = zvrf->lsp_table;
@@ -3295,7 +3295,7 @@ int mpls_lsp_uninstall(struct zebra_vrf *zvrf, enum lsp_types_t type,
 		       bool backup_p)
 {
 	struct hash *lsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	zebra_lsp_t *lsp;
 	zebra_nhlfe_t *nhlfe;
 	char buf[NEXTHOP_STRLEN];
@@ -3354,7 +3354,7 @@ int mpls_lsp_uninstall_all_vrf(struct zebra_vrf *zvrf, enum lsp_types_t type,
 			       mpls_label_t in_label)
 {
 	struct hash *lsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	zebra_lsp_t *lsp;
 
 	/* Lookup table. */
@@ -3474,7 +3474,7 @@ int zebra_mpls_lsp_label_consistent(struct zebra_vrf *zvrf,
 				    union g_addr *gate, ifindex_t ifindex)
 {
 	struct hash *slsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	zebra_lsp_t *lsp;
 	zebra_nhlfe_t *nhlfe;
 	const struct nexthop *nh;
@@ -3542,7 +3542,7 @@ int zebra_mpls_static_lsp_add(struct zebra_vrf *zvrf, mpls_label_t in_label,
 			      ifindex_t ifindex)
 {
 	struct hash *slsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	zebra_lsp_t *lsp;
 	zebra_nhlfe_t *nhlfe;
 	char buf[BUFSIZ];
@@ -3621,7 +3621,7 @@ int zebra_mpls_static_lsp_del(struct zebra_vrf *zvrf, mpls_label_t in_label,
 			      ifindex_t ifindex)
 {
 	struct hash *slsp_table;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	zebra_lsp_t *lsp;
 	zebra_nhlfe_t *nhlfe;
 
@@ -3702,7 +3702,7 @@ void zebra_mpls_print_lsp(struct vty *vty, struct zebra_vrf *zvrf,
 {
 	struct hash *lsp_table;
 	zebra_lsp_t *lsp;
-	zebra_ile_t tmp_ile;
+	struct zebra_ile tmp_ile;
 	json_object *json = NULL;
 
 	/* Lookup table. */

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -49,7 +49,6 @@ extern "C" {
 
 /* Typedefs */
 
-typedef struct zebra_ile_t_ zebra_ile_t;
 typedef struct zebra_nhlfe_t_ zebra_nhlfe_t;
 typedef struct zebra_lsp_t_ zebra_lsp_t;
 typedef struct zebra_fec_t_ zebra_fec_t;
@@ -88,7 +87,7 @@ struct zebra_nhlfe_t_ {
 /*
  * Incoming label entry
  */
-struct zebra_ile_t_ {
+struct zebra_ile {
 	mpls_label_t in_label;
 };
 
@@ -97,7 +96,7 @@ struct zebra_ile_t_ {
  */
 struct zebra_lsp_t_ {
 	/* Incoming label */
-	zebra_ile_t ile;
+	struct zebra_ile ile;
 
 	/* List of NHLFEs, pointer to best, and num equal-cost. */
 	struct nhlfe_list_head nhlfe_list;

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -49,7 +49,6 @@ extern "C" {
 
 /* Typedefs */
 
-typedef struct zebra_lsp_t_ zebra_lsp_t;
 typedef struct zebra_fec_t_ zebra_fec_t;
 
 /* Declare LSP nexthop list types */
@@ -66,7 +65,7 @@ struct zebra_nhlfe {
 	struct nexthop *nexthop;
 
 	/* Backpointer to base entry. */
-	zebra_lsp_t *lsp;
+	struct zebra_lsp *lsp;
 
 	/* Runtime info - flags, pointers etc. */
 	uint32_t flags;
@@ -93,7 +92,7 @@ struct zebra_ile {
 /*
  * Label swap entry (ile -> list of nhlfes)
  */
-struct zebra_lsp_t_ {
+struct zebra_lsp {
 	/* Incoming label */
 	struct zebra_ile ile;
 
@@ -177,26 +176,26 @@ int zebra_mpls_lsp_uninstall(struct zebra_vrf *zvrf, struct route_node *rn,
 
 /* Add an NHLFE to an LSP, return the newly-added object */
 struct zebra_nhlfe *
-zebra_mpls_lsp_add_nhlfe(zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
+zebra_mpls_lsp_add_nhlfe(struct zebra_lsp *lsp, enum lsp_types_t lsp_type,
 			 enum nexthop_types_t gtype, const union g_addr *gate,
 			 ifindex_t ifindex, uint8_t num_labels,
 			 const mpls_label_t *out_labels);
 
 /* Add or update a backup NHLFE for an LSP; return the object */
 struct zebra_nhlfe *zebra_mpls_lsp_add_backup_nhlfe(
-	zebra_lsp_t *lsp, enum lsp_types_t lsp_type, enum nexthop_types_t gtype,
-	const union g_addr *gate, ifindex_t ifindex, uint8_t num_labels,
-	const mpls_label_t *out_labels);
+	struct zebra_lsp *lsp, enum lsp_types_t lsp_type,
+	enum nexthop_types_t gtype, const union g_addr *gate, ifindex_t ifindex,
+	uint8_t num_labels, const mpls_label_t *out_labels);
 
 /*
  * Add NHLFE or backup NHLFE to an LSP based on a nexthop. These just maintain
  * the LSP and NHLFE objects; nothing is scheduled for processing.
  * Return: the newly-added object
  */
-struct zebra_nhlfe *zebra_mpls_lsp_add_nh(zebra_lsp_t *lsp,
+struct zebra_nhlfe *zebra_mpls_lsp_add_nh(struct zebra_lsp *lsp,
 					  enum lsp_types_t lsp_type,
 					  const struct nexthop *nh);
-struct zebra_nhlfe *zebra_mpls_lsp_add_backup_nh(zebra_lsp_t *lsp,
+struct zebra_nhlfe *zebra_mpls_lsp_add_backup_nh(struct zebra_lsp *lsp,
 						 enum lsp_types_t lsp_type,
 						 const struct nexthop *nh);
 
@@ -289,7 +288,7 @@ int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
 /*
  * Lookup LSP by its input label.
  */
-zebra_lsp_t *mpls_lsp_find(struct zebra_vrf *zvrf, mpls_label_t in_label);
+struct zebra_lsp *mpls_lsp_find(struct zebra_vrf *zvrf, mpls_label_t in_label);
 
 /*
  * Uninstall a particular NHLFE in the forwarding table. If this is

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -47,10 +47,6 @@ extern "C" {
 		 ? AF_INET6                                                    \
 		 : AF_INET)
 
-/* Typedefs */
-
-typedef struct zebra_fec_t_ zebra_fec_t;
-
 /* Declare LSP nexthop list types */
 PREDECL_DLIST(nhlfe_list);
 
@@ -123,7 +119,7 @@ struct zebra_lsp {
 /*
  * FEC to label binding.
  */
-struct zebra_fec_t_ {
+struct zebra_fec {
 	/* FEC (prefix) */
 	struct route_node *rn;
 
@@ -221,8 +217,8 @@ int zebra_mpls_fec_unregister(struct zebra_vrf *zvrf, struct prefix *p,
  * TODO: Currently walks entire table, can optimize later with another
  * hash..
  */
-zebra_fec_t *zebra_mpls_fec_for_label(struct zebra_vrf *zvrf,
-				      mpls_label_t label);
+struct zebra_fec *zebra_mpls_fec_for_label(struct zebra_vrf *zvrf,
+					   mpls_label_t label);
 
 /*
  * Inform if specified label is currently bound to a FEC or not.

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -49,7 +49,6 @@ extern "C" {
 
 /* Typedefs */
 
-typedef struct zebra_nhlfe_t_ zebra_nhlfe_t;
 typedef struct zebra_lsp_t_ zebra_lsp_t;
 typedef struct zebra_fec_t_ zebra_fec_t;
 
@@ -59,7 +58,7 @@ PREDECL_DLIST(nhlfe_list);
 /*
  * (Outgoing) nexthop label forwarding entry
  */
-struct zebra_nhlfe_t_ {
+struct zebra_nhlfe {
 	/* Type of entry - static etc. */
 	enum lsp_types_t type;
 
@@ -101,7 +100,7 @@ struct zebra_lsp_t_ {
 	/* List of NHLFEs, pointer to best, and num equal-cost. */
 	struct nhlfe_list_head nhlfe_list;
 
-	zebra_nhlfe_t *best_nhlfe;
+	struct zebra_nhlfe *best_nhlfe;
 	uint32_t num_ecmp;
 
 	/* Backup nhlfes, if present. The nexthop in a primary/active nhlfe
@@ -144,7 +143,7 @@ struct zebra_fec_t_ {
 };
 
 /* Declare typesafe list apis/macros */
-DECLARE_DLIST(nhlfe_list, struct zebra_nhlfe_t_, list);
+DECLARE_DLIST(nhlfe_list, struct zebra_nhlfe, list);
 
 /* Function declarations. */
 
@@ -177,37 +176,32 @@ int zebra_mpls_lsp_uninstall(struct zebra_vrf *zvrf, struct route_node *rn,
 			     struct route_entry *re);
 
 /* Add an NHLFE to an LSP, return the newly-added object */
-zebra_nhlfe_t *zebra_mpls_lsp_add_nhlfe(zebra_lsp_t *lsp,
-					enum lsp_types_t lsp_type,
-					enum nexthop_types_t gtype,
-					const union g_addr *gate,
-					ifindex_t ifindex,
-					uint8_t num_labels,
-					const mpls_label_t *out_labels);
+struct zebra_nhlfe *
+zebra_mpls_lsp_add_nhlfe(zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
+			 enum nexthop_types_t gtype, const union g_addr *gate,
+			 ifindex_t ifindex, uint8_t num_labels,
+			 const mpls_label_t *out_labels);
 
 /* Add or update a backup NHLFE for an LSP; return the object */
-zebra_nhlfe_t *zebra_mpls_lsp_add_backup_nhlfe(zebra_lsp_t *lsp,
-					       enum lsp_types_t lsp_type,
-					       enum nexthop_types_t gtype,
-					       const union g_addr *gate,
-					       ifindex_t ifindex,
-					       uint8_t num_labels,
-					       const mpls_label_t *out_labels);
+struct zebra_nhlfe *zebra_mpls_lsp_add_backup_nhlfe(
+	zebra_lsp_t *lsp, enum lsp_types_t lsp_type, enum nexthop_types_t gtype,
+	const union g_addr *gate, ifindex_t ifindex, uint8_t num_labels,
+	const mpls_label_t *out_labels);
 
 /*
  * Add NHLFE or backup NHLFE to an LSP based on a nexthop. These just maintain
  * the LSP and NHLFE objects; nothing is scheduled for processing.
  * Return: the newly-added object
  */
-zebra_nhlfe_t *zebra_mpls_lsp_add_nh(zebra_lsp_t *lsp,
-				     enum lsp_types_t lsp_type,
-				     const struct nexthop *nh);
-zebra_nhlfe_t *zebra_mpls_lsp_add_backup_nh(zebra_lsp_t *lsp,
-					    enum lsp_types_t lsp_type,
-					    const struct nexthop *nh);
+struct zebra_nhlfe *zebra_mpls_lsp_add_nh(zebra_lsp_t *lsp,
+					  enum lsp_types_t lsp_type,
+					  const struct nexthop *nh);
+struct zebra_nhlfe *zebra_mpls_lsp_add_backup_nh(zebra_lsp_t *lsp,
+						 enum lsp_types_t lsp_type,
+						 const struct nexthop *nh);
 
 /* Free an allocated NHLFE */
-void zebra_mpls_nhlfe_free(zebra_nhlfe_t *nhlfe);
+void zebra_mpls_nhlfe_free(struct zebra_nhlfe *nhlfe);
 
 int zebra_mpls_fec_register(struct zebra_vrf *zvrf, struct prefix *p,
 			    uint32_t label, uint32_t label_index,

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -44,7 +44,7 @@ struct {
 } kr_state;
 
 static int kernel_send_rtmsg_v4(int action, mpls_label_t in_label,
-				const zebra_nhlfe_t *nhlfe)
+				const struct zebra_nhlfe *nhlfe)
 {
 	struct iovec iov[5];
 	struct rt_msghdr hdr;
@@ -136,7 +136,7 @@ static int kernel_send_rtmsg_v4(int action, mpls_label_t in_label,
 #endif
 
 static int kernel_send_rtmsg_v6(int action, mpls_label_t in_label,
-				const zebra_nhlfe_t *nhlfe)
+				const struct zebra_nhlfe *nhlfe)
 {
 	struct iovec iov[5];
 	struct rt_msghdr hdr;
@@ -240,7 +240,7 @@ static int kernel_send_rtmsg_v6(int action, mpls_label_t in_label,
 static int kernel_lsp_cmd(struct zebra_dplane_ctx *ctx)
 {
 	const struct nhlfe_list_head *head;
-	const zebra_nhlfe_t *nhlfe;
+	const struct zebra_nhlfe *nhlfe;
 	const struct nexthop *nexthop = NULL;
 	unsigned int nexthop_num = 0;
 	int action;

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1147,7 +1147,7 @@ int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)
 	struct vrf *vrf;
 	struct zebra_vrf *zvrf;
 	vni_t vni = 0;
-	zebra_l3vni_t *zl3vni = NULL;
+	struct zebra_l3vni *zl3vni = NULL;
 	struct zebra_vrf *zvrf_evpn = NULL;
 	char err[ERR_STR_SZ];
 	bool pfx_only = false;

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1965,7 +1965,7 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 	struct route_node *rn;
 	struct route_entry *match = NULL;
 	int resolved;
-	zebra_nhlfe_t *nhlfe;
+	struct zebra_nhlfe *nhlfe;
 	struct nexthop *newhop;
 	struct interface *ifp;
 	rib_dest_t *dest;

--- a/zebra/zebra_srte.c
+++ b/zebra/zebra_srte.c
@@ -99,7 +99,7 @@ struct zebra_sr_policy *zebra_sr_policy_find_by_name(char *name)
 static int zebra_sr_policy_notify_update_client(struct zebra_sr_policy *policy,
 						struct zserv *client)
 {
-	const zebra_nhlfe_t *nhlfe;
+	const struct zebra_nhlfe *nhlfe;
 	struct stream *s;
 	uint32_t message = 0;
 	unsigned long nump = 0;
@@ -293,7 +293,7 @@ int zebra_sr_policy_validate(struct zebra_sr_policy *policy,
 int zebra_sr_policy_bsid_install(struct zebra_sr_policy *policy)
 {
 	struct zapi_srte_tunnel *zt = &policy->segment_list;
-	zebra_nhlfe_t *nhlfe;
+	struct zebra_nhlfe *nhlfe;
 
 	if (zt->local_label == MPLS_LABEL_NONE)
 		return 0;

--- a/zebra/zebra_srte.c
+++ b/zebra/zebra_srte.c
@@ -211,7 +211,7 @@ static void zebra_sr_policy_notify_update(struct zebra_sr_policy *policy)
 }
 
 static void zebra_sr_policy_activate(struct zebra_sr_policy *policy,
-				     zebra_lsp_t *lsp)
+				     struct zebra_lsp *lsp)
 {
 	policy->status = ZEBRA_SR_POLICY_UP;
 	policy->lsp = lsp;
@@ -222,7 +222,7 @@ static void zebra_sr_policy_activate(struct zebra_sr_policy *policy,
 }
 
 static void zebra_sr_policy_update(struct zebra_sr_policy *policy,
-				   zebra_lsp_t *lsp,
+				   struct zebra_lsp *lsp,
 				   struct zapi_srte_tunnel *old_tunnel)
 {
 	bool bsid_changed;
@@ -267,7 +267,7 @@ int zebra_sr_policy_validate(struct zebra_sr_policy *policy,
 			     struct zapi_srte_tunnel *new_tunnel)
 {
 	struct zapi_srte_tunnel old_tunnel = policy->segment_list;
-	zebra_lsp_t *lsp;
+	struct zebra_lsp *lsp;
 
 	if (new_tunnel)
 		policy->segment_list = *new_tunnel;

--- a/zebra/zebra_srte.h
+++ b/zebra/zebra_srte.h
@@ -43,7 +43,7 @@ struct zebra_sr_policy {
 	char name[SRTE_POLICY_NAME_MAX_LENGTH];
 	enum zebra_sr_policy_status status;
 	struct zapi_srte_tunnel segment_list;
-	zebra_lsp_t *lsp;
+	struct zebra_lsp *lsp;
 	struct zebra_vrf *zvrf;
 };
 RB_HEAD(zebra_sr_policy_instance_head, zebra_sr_policy);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -200,7 +200,7 @@ static void zevpn_print_neigh_hash_all_evpn(struct hash_bucket *bucket,
 {
 	struct vty *vty;
 	json_object *json = NULL, *json_evpn = NULL;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	uint32_t num_neigh;
 	struct neigh_walk_ctx wctx;
 	char vni_str[VNI_STR_LEN];
@@ -210,7 +210,7 @@ static void zevpn_print_neigh_hash_all_evpn(struct hash_bucket *bucket,
 	json = (json_object *)args[1];
 	print_dup = (uint32_t)(uintptr_t)args[2];
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 
 	num_neigh = hashcount(zevpn->neigh_table);
 
@@ -267,7 +267,7 @@ static void zevpn_print_neigh_hash_all_evpn_detail(struct hash_bucket *bucket,
 {
 	struct vty *vty;
 	json_object *json = NULL, *json_evpn = NULL;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	uint32_t num_neigh;
 	struct neigh_walk_ctx wctx;
 	char vni_str[VNI_STR_LEN];
@@ -277,7 +277,7 @@ static void zevpn_print_neigh_hash_all_evpn_detail(struct hash_bucket *bucket,
 	json = (json_object *)args[1];
 	print_dup = (uint32_t)(uintptr_t)args[2];
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 	if (!zevpn) {
 		if (json)
 			vty_out(vty, "{}\n");
@@ -402,7 +402,7 @@ static void zevpn_print_mac_hash_all_evpn(struct hash_bucket *bucket, void *ctxt
 	struct vty *vty;
 	json_object *json = NULL, *json_evpn = NULL;
 	json_object *json_mac = NULL;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	uint32_t num_macs;
 	struct mac_walk_ctx *wctx = ctxt;
 	char vni_str[VNI_STR_LEN];
@@ -410,7 +410,7 @@ static void zevpn_print_mac_hash_all_evpn(struct hash_bucket *bucket, void *ctxt
 	vty = wctx->vty;
 	json = wctx->json;
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 	wctx->zevpn = zevpn;
 
 	/*We are iterating over a new VNI, set the count to 0*/
@@ -477,7 +477,7 @@ static void zevpn_print_mac_hash_all_evpn_detail(struct hash_bucket *bucket,
 	struct vty *vty;
 	json_object *json = NULL, *json_evpn = NULL;
 	json_object *json_mac = NULL;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	uint32_t num_macs;
 	struct mac_walk_ctx *wctx = ctxt;
 	char vni_str[VNI_STR_LEN];
@@ -485,7 +485,7 @@ static void zevpn_print_mac_hash_all_evpn_detail(struct hash_bucket *bucket,
 	vty = wctx->vty;
 	json = wctx->json;
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 	if (!zevpn) {
 		if (json)
 			vty_out(vty, "{}\n");
@@ -690,7 +690,7 @@ static void zl3vni_print(zebra_l3vni_t *zl3vni, void **ctx)
 	char buf[PREFIX_STRLEN];
 	struct vty *vty = NULL;
 	json_object *json = NULL;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	json_object *json_evpn_list = NULL;
 	struct listnode *node = NULL, *nnode = NULL;
 
@@ -887,7 +887,7 @@ struct interface *zvni_map_to_svi(vlanid_t vid, struct interface *br_if)
 	return tmp_if;
 }
 
-static int zebra_evpn_vxlan_del(zebra_evpn_t *zevpn)
+static int zebra_evpn_vxlan_del(struct zebra_evpn *zevpn)
 {
 	zevpn_vxlan_if_set(zevpn, zevpn->vxlan_if, false /* set */);
 
@@ -914,7 +914,7 @@ static int zevpn_build_hash_table_zns(struct ns *ns,
 	/* Walk VxLAN interfaces and create EVPN hash. */
 	for (rn = route_top(zns->if_table); rn; rn = route_next(rn)) {
 		vni_t vni;
-		zebra_evpn_t *zevpn = NULL;
+		struct zebra_evpn *zevpn = NULL;
 		zebra_l3vni_t *zl3vni = NULL;
 		struct zebra_if *zif;
 		struct zebra_l2info_vxlan *vxl;
@@ -1068,11 +1068,11 @@ static void zevpn_build_hash_table(void)
  */
 static void zebra_evpn_vxlan_cleanup_all(struct hash_bucket *bucket, void *arg)
 {
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 	struct zebra_vrf *zvrf = (struct zebra_vrf *)arg;
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 
 	/* remove from l3-vni list */
 	if (zvrf->l3vni)
@@ -1862,7 +1862,7 @@ static zebra_l3vni_t *zl3vni_from_svi(struct interface *ifp,
 vni_t vni_id_from_svi(struct interface *ifp, struct interface *br_if)
 {
 	vni_t vni = 0;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 
 	/* Check if an L3VNI belongs to this SVI interface.
@@ -2004,7 +2004,7 @@ static void zebra_vxlan_process_l3vni_oper_down(zebra_l3vni_t *zl3vni)
 
 static void zevpn_add_to_l3vni_list(struct hash_bucket *bucket, void *ctxt)
 {
-	zebra_evpn_t *zevpn = (zebra_evpn_t *)bucket->data;
+	struct zebra_evpn *zevpn = (struct zebra_evpn *)bucket->data;
 	zebra_l3vni_t *zl3vni = (zebra_l3vni_t *)ctxt;
 
 	if (zevpn->vrf_id == zl3vni_vrf_id(zl3vni))
@@ -2020,7 +2020,7 @@ static void zevpn_add_to_l3vni_list(struct hash_bucket *bucket, void *ctxt)
 static int zebra_vxlan_handle_vni_transition(struct zebra_vrf *zvrf, vni_t vni,
 					     int add)
 {
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 
 	/* There is a possibility that VNI notification was already received
 	 * from kernel and we programmed it as L2-VNI
@@ -2565,7 +2565,7 @@ void zebra_vxlan_print_vrf_vni(struct vty *vty, struct zebra_vrf *zvrf,
 void zebra_vxlan_print_neigh_vni(struct vty *vty, struct zebra_vrf *zvrf,
 				 vni_t vni, bool use_json)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	uint32_t num_neigh;
 	struct neigh_walk_ctx wctx;
 	json_object *json = NULL;
@@ -2683,7 +2683,7 @@ void zebra_vxlan_print_specific_neigh_vni(struct vty *vty,
 					  struct zebra_vrf *zvrf, vni_t vni,
 					  struct ipaddr *ip, bool use_json)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_neigh_t *n;
 	json_object *json = NULL;
 
@@ -2725,7 +2725,7 @@ void zebra_vxlan_print_neigh_vni_vtep(struct vty *vty, struct zebra_vrf *zvrf,
 				      vni_t vni, struct in_addr vtep_ip,
 				      bool use_json)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	uint32_t num_neigh;
 	struct neigh_walk_ctx wctx;
 	json_object *json = NULL;
@@ -2774,7 +2774,7 @@ void zebra_vxlan_print_neigh_vni_dad(struct vty *vty,
 				     vni_t vni,
 				     bool use_json)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	uint32_t num_neigh;
 	struct neigh_walk_ctx wctx;
 	json_object *json = NULL;
@@ -2837,7 +2837,7 @@ void zebra_vxlan_print_neigh_vni_dad(struct vty *vty,
 void zebra_vxlan_print_macs_vni(struct vty *vty, struct zebra_vrf *zvrf,
 				vni_t vni, bool use_json)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	uint32_t num_macs;
 	struct mac_walk_ctx wctx;
 	json_object *json = NULL;
@@ -2987,7 +2987,7 @@ void zebra_vxlan_print_specific_mac_vni(struct vty *vty, struct zebra_vrf *zvrf,
 					vni_t vni, struct ethaddr *macaddr,
 					bool use_json)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_mac_t *mac;
 	json_object *json = NULL;
 
@@ -3029,7 +3029,7 @@ void zebra_vxlan_print_macs_vni_dad(struct vty *vty,
 				    struct zebra_vrf *zvrf,
 				    vni_t vni, bool use_json)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	struct mac_walk_ctx wctx;
 	uint32_t num_macs;
 	json_object *json = NULL;
@@ -3086,7 +3086,7 @@ int zebra_vxlan_clear_dup_detect_vni_mac(struct zebra_vrf *zvrf, vni_t vni,
 					 struct ethaddr *macaddr, char *errmsg,
 					 size_t errmsg_len)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_mac_t *mac;
 	struct listnode *node = NULL;
 	zebra_neigh_t *nbr = NULL;
@@ -3174,7 +3174,7 @@ int zebra_vxlan_clear_dup_detect_vni_ip(struct zebra_vrf *zvrf, vni_t vni,
 					struct ipaddr *ip, char *errmsg,
 					size_t errmsg_len)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_neigh_t *nbr;
 	zebra_mac_t *mac;
 	char buf[INET6_ADDRSTRLEN];
@@ -3241,7 +3241,7 @@ static void zevpn_clear_dup_mac_hash(struct hash_bucket *bucket, void *ctxt)
 {
 	struct mac_walk_ctx *wctx = ctxt;
 	zebra_mac_t *mac;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	struct listnode *node = NULL;
 	zebra_neigh_t *nbr = NULL;
 
@@ -3296,12 +3296,12 @@ static void zevpn_clear_dup_mac_hash(struct hash_bucket *bucket, void *ctxt)
 static void zevpn_clear_dup_detect_hash_vni_all(struct hash_bucket *bucket,
 					    void **args)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	struct zebra_vrf *zvrf;
 	struct mac_walk_ctx m_wctx;
 	struct neigh_walk_ctx n_wctx;
 
-	zevpn = (zebra_evpn_t *)bucket->data;
+	zevpn = (struct zebra_evpn *)bucket->data;
 	if (!zevpn)
 		return;
 
@@ -3342,7 +3342,7 @@ int zebra_vxlan_clear_dup_detect_vni_all(struct zebra_vrf *zvrf)
 
 int zebra_vxlan_clear_dup_detect_vni(struct zebra_vrf *zvrf, vni_t vni)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	struct mac_walk_ctx m_wctx;
 	struct neigh_walk_ctx n_wctx;
 
@@ -3380,7 +3380,7 @@ void zebra_vxlan_print_macs_vni_vtep(struct vty *vty, struct zebra_vrf *zvrf,
 				     vni_t vni, struct in_addr vtep_ip,
 				     bool use_json)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	uint32_t num_macs;
 	struct mac_walk_ctx wctx;
 	json_object *json = NULL;
@@ -3438,7 +3438,7 @@ void zebra_vxlan_print_vni(struct vty *vty, struct zebra_vrf *zvrf, vni_t vni,
 	json_object *json = NULL;
 	void *args[2];
 	zebra_l3vni_t *zl3vni = NULL;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 
 	if (!is_evpn_enabled())
 		return;
@@ -3686,7 +3686,7 @@ int zebra_vxlan_handle_kernel_neigh_del(struct interface *ifp,
 					struct interface *link_if,
 					struct ipaddr *ip)
 {
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 
 	/* check if this is a remote neigh entry corresponding to remote
@@ -3737,7 +3737,7 @@ int zebra_vxlan_handle_kernel_neigh_update(struct interface *ifp,
 					   bool is_router,
 					   bool local_inactive, bool dp_static)
 {
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 
 	/* check if this is a remote neigh entry corresponding to remote
@@ -3937,7 +3937,7 @@ int zebra_vxlan_check_readd_vtep(struct interface *ifp,
 	struct zebra_vrf *zvrf = NULL;
 	struct zebra_l2info_vxlan *vxl;
 	vni_t vni;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_vtep_t *zvtep = NULL;
 
 	zif = ifp->info;
@@ -3986,7 +3986,7 @@ static int zebra_vxlan_check_del_local_mac(struct interface *ifp,
 	struct zebra_if *zif;
 	struct zebra_l2info_vxlan *vxl;
 	vni_t vni;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_mac_t *mac;
 
 	zif = ifp->info;
@@ -4082,7 +4082,7 @@ int zebra_vxlan_dp_network_mac_del(struct interface *ifp,
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan *vxl = NULL;
 	vni_t vni;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 	zebra_mac_t *mac = NULL;
 
@@ -4138,7 +4138,7 @@ int zebra_vxlan_dp_network_mac_del(struct interface *ifp,
 int zebra_vxlan_local_mac_del(struct interface *ifp, struct interface *br_if,
 			      struct ethaddr *macaddr, vlanid_t vid)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_mac_t *mac;
 
 	/* We are interested in MACs only on ports or (port, VLAN) that
@@ -4175,7 +4175,7 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 					 bool sticky, bool local_inactive,
 					 bool dp_static)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	struct zebra_vrf *zvrf;
 
 	assert(ifp);
@@ -4270,7 +4270,7 @@ stream_failure:
 void zebra_vxlan_remote_vtep_del(vrf_id_t vrf_id, vni_t vni,
 				 struct in_addr vtep_ip)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_vtep_t *zvtep;
 	struct interface *ifp;
 	struct zebra_if *zif;
@@ -4334,7 +4334,7 @@ void zebra_vxlan_remote_vtep_del(vrf_id_t vrf_id, vni_t vni,
 void zebra_vxlan_remote_vtep_add(vrf_id_t vrf_id, vni_t vni,
 				 struct in_addr vtep_ip, int flood_control)
 {
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	struct interface *ifp;
 	struct zebra_if *zif;
 	zebra_vtep_t *zvtep;
@@ -4468,7 +4468,7 @@ int zebra_vxlan_add_del_gw_macip(struct interface *ifp, const struct prefix *p,
 {
 	struct ipaddr ip;
 	struct ethaddr macaddr;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 
 	memset(&ip, 0, sizeof(struct ipaddr));
 	memset(&macaddr, 0, sizeof(struct ethaddr));
@@ -4603,7 +4603,7 @@ int zebra_vxlan_svi_down(struct interface *ifp, struct interface *link_if)
 		/* remove association with svi-if */
 		zl3vni->svi_if = NULL;
 	} else {
-		zebra_evpn_t *zevpn = NULL;
+		struct zebra_evpn *zevpn = NULL;
 
 		/* Unlink the SVI from the access VLAN */
 		zebra_evpn_acc_bd_svi_set(ifp->info, link_if->info, false);
@@ -4635,7 +4635,7 @@ int zebra_vxlan_svi_down(struct interface *ifp, struct interface *link_if)
  */
 int zebra_vxlan_svi_up(struct interface *ifp, struct interface *link_if)
 {
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 
 	zl3vni = zl3vni_from_svi(ifp, link_if);
@@ -4769,7 +4769,7 @@ int zebra_vxlan_if_down(struct interface *ifp)
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan *vxl = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 
 	/* Check if EVPN is enabled. */
 	if (!is_evpn_enabled())
@@ -4831,7 +4831,7 @@ int zebra_vxlan_if_up(struct interface *ifp)
 	vni_t vni;
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan *vxl = NULL;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 
 	/* Check if EVPN is enabled. */
@@ -4908,7 +4908,7 @@ int zebra_vxlan_if_del(struct interface *ifp)
 	vni_t vni;
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan *vxl = NULL;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 
 	/* Check if EVPN is enabled. */
@@ -4982,7 +4982,7 @@ int zebra_vxlan_if_update(struct interface *ifp, uint16_t chgflags)
 	vni_t vni;
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan *vxl = NULL;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 	struct interface *vlan_if = NULL;
 
@@ -5159,7 +5159,7 @@ int zebra_vxlan_if_add(struct interface *ifp)
 	vni_t vni;
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan *vxl = NULL;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
 
 	/* Check if EVPN is enabled. */
@@ -5235,24 +5235,15 @@ int zebra_vxlan_if_add(struct interface *ifp)
 				listnode_add_sort_nodup(zl3vni->l2vnis, zevpn);
 		}
 
-		if (IS_ZEBRA_DEBUG_VXLAN) {
-			char addr_buf1[INET_ADDRSTRLEN];
-			char addr_buf2[INET_ADDRSTRLEN];
-
-			inet_ntop(AF_INET, &vxl->vtep_ip,
-					addr_buf1, INET_ADDRSTRLEN);
-			inet_ntop(AF_INET, &vxl->mcast_grp,
-					addr_buf2, INET_ADDRSTRLEN);
-
+		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
-				"Add L2-VNI %u VRF %s intf %s(%u) VLAN %u local IP %s mcast_grp %s master %u",
+				"Add L2-VNI %u VRF %s intf %s(%u) VLAN %u local IP %pI4 mcast_grp %pI4 master %u",
 				vni,
 				vlan_if ? vrf_id_to_name(vlan_if->vrf_id)
 					: VRF_DEFAULT_NAME,
 				ifp->name, ifp->ifindex, vxl->access_vlan,
-				addr_buf1, addr_buf2,
+				&vxl->vtep_ip, &vxl->mcast_grp,
 				zif->brslave_info.bridge_ifindex);
-		}
 
 		/* If down or not mapped to a bridge, we're done. */
 		if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
@@ -5488,7 +5479,7 @@ void zebra_vxlan_advertise_svi_macip(ZAPI_HANDLER_ARGS)
 	struct stream *s;
 	int advertise;
 	vni_t vni = 0;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	struct interface *ifp = NULL;
 
 	if (!EVPN_ENABLED(zvrf)) {
@@ -5588,7 +5579,7 @@ void zebra_vxlan_advertise_subnet(ZAPI_HANDLER_ARGS)
 	struct stream *s;
 	int advertise;
 	vni_t vni = 0;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	struct interface *ifp = NULL;
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan zl2_info;
@@ -5654,7 +5645,7 @@ void zebra_vxlan_advertise_gw_macip(ZAPI_HANDLER_ARGS)
 	struct stream *s;
 	int advertise;
 	vni_t vni = 0;
-	zebra_evpn_t *zevpn = NULL;
+	struct zebra_evpn *zevpn = NULL;
 	struct interface *ifp = NULL;
 
 	if (!EVPN_ENABLED(zvrf)) {

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3938,7 +3938,7 @@ int zebra_vxlan_check_readd_vtep(struct interface *ifp,
 	struct zebra_l2info_vxlan *vxl;
 	vni_t vni;
 	struct zebra_evpn *zevpn = NULL;
-	zebra_vtep_t *zvtep = NULL;
+	struct zebra_vtep *zvtep = NULL;
 
 	zif = ifp->info;
 	assert(zif);
@@ -4271,7 +4271,7 @@ void zebra_vxlan_remote_vtep_del(vrf_id_t vrf_id, vni_t vni,
 				 struct in_addr vtep_ip)
 {
 	struct zebra_evpn *zevpn;
-	zebra_vtep_t *zvtep;
+	struct zebra_vtep *zvtep;
 	struct interface *ifp;
 	struct zebra_if *zif;
 	struct zebra_vrf *zvrf;
@@ -4337,7 +4337,7 @@ void zebra_vxlan_remote_vtep_add(vrf_id_t vrf_id, vni_t vni,
 	struct zebra_evpn *zevpn;
 	struct interface *ifp;
 	struct zebra_if *zif;
-	zebra_vtep_t *zvtep;
+	struct zebra_vtep *zvtep;
 	struct zebra_vrf *zvrf;
 
 	if (!is_evpn_enabled()) {

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -208,7 +208,7 @@ static inline void zl3vni_get_svi_rmac(zebra_l3vni_t *zl3vni,
 /* context for neigh hash walk - update l3vni and rmac */
 struct neigh_l3info_walk_ctx {
 
-	zebra_evpn_t *zevpn;
+	struct zebra_evpn *zevpn;
 	zebra_l3vni_t *zl3vni;
 	int add;
 };
@@ -256,7 +256,7 @@ typedef struct zebra_vxlan_sg_ {
 	uint32_t ref_cnt;
 } zebra_vxlan_sg_t;
 
-extern zebra_evpn_t *zevpn_lookup(vni_t vni);
+extern struct zebra_evpn *zevpn_lookup(vni_t vni);
 extern void zebra_vxlan_sync_mac_dp_install(zebra_mac_t *mac, bool set_inactive,
 		bool force_clear_static, const char *caller);
 extern bool zebra_evpn_do_dup_addr_detect(struct zebra_vrf *zvrf);

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -38,12 +38,8 @@ extern "C" {
 
 #define ERR_STR_SZ 256
 
-/* definitions */
-typedef struct zebra_l3vni_t_ zebra_l3vni_t;
-
-
 /* L3 VNI hash table */
-struct zebra_l3vni_t_ {
+struct zebra_l3vni {
 
 	/* VNI key */
 	vni_t vni;
@@ -76,25 +72,25 @@ struct zebra_l3vni_t_ {
 };
 
 /* get the vx-intf name for l3vni */
-static inline const char *zl3vni_vxlan_if_name(zebra_l3vni_t *zl3vni)
+static inline const char *zl3vni_vxlan_if_name(struct zebra_l3vni *zl3vni)
 {
 	return zl3vni->vxlan_if ? zl3vni->vxlan_if->name : "None";
 }
 
 /* get the svi intf name for l3vni */
-static inline const char *zl3vni_svi_if_name(zebra_l3vni_t *zl3vni)
+static inline const char *zl3vni_svi_if_name(struct zebra_l3vni *zl3vni)
 {
 	return zl3vni->svi_if ? zl3vni->svi_if->name : "None";
 }
 
 /* get the vrf name for l3vni */
-static inline const char *zl3vni_vrf_name(zebra_l3vni_t *zl3vni)
+static inline const char *zl3vni_vrf_name(struct zebra_l3vni *zl3vni)
 {
 	return vrf_id_to_name(zl3vni->vrf_id);
 }
 
 /* get the rmac string */
-static inline const char *zl3vni_rmac2str(zebra_l3vni_t *zl3vni, char *buf,
+static inline const char *zl3vni_rmac2str(struct zebra_l3vni *zl3vni, char *buf,
 					  int size)
 {
 	char *ptr;
@@ -131,8 +127,8 @@ static inline const char *zl3vni_rmac2str(zebra_l3vni_t *zl3vni, char *buf,
 }
 
 /* get the sys mac string */
-static inline const char *zl3vni_sysmac2str(zebra_l3vni_t *zl3vni, char *buf,
-					    int size)
+static inline const char *zl3vni_sysmac2str(struct zebra_l3vni *zl3vni,
+					    char *buf, int size)
 {
 	char *ptr;
 
@@ -166,14 +162,14 @@ static inline const char *zl3vni_sysmac2str(zebra_l3vni_t *zl3vni, char *buf,
  * 3. it is associated to an SVI
  * 4. associated SVI is oper up
  */
-static inline int is_l3vni_oper_up(zebra_l3vni_t *zl3vni)
+static inline int is_l3vni_oper_up(struct zebra_l3vni *zl3vni)
 {
 	return (is_evpn_enabled() && zl3vni && (zl3vni->vrf_id != VRF_UNKNOWN)
 		&& zl3vni->vxlan_if && if_is_operative(zl3vni->vxlan_if)
 		&& zl3vni->svi_if && if_is_operative(zl3vni->svi_if));
 }
 
-static inline const char *zl3vni_state2str(zebra_l3vni_t *zl3vni)
+static inline const char *zl3vni_state2str(struct zebra_l3vni *zl3vni)
 {
 	if (!zl3vni)
 		return NULL;
@@ -186,12 +182,12 @@ static inline const char *zl3vni_state2str(zebra_l3vni_t *zl3vni)
 	return NULL;
 }
 
-static inline vrf_id_t zl3vni_vrf_id(zebra_l3vni_t *zl3vni)
+static inline vrf_id_t zl3vni_vrf_id(struct zebra_l3vni *zl3vni)
 {
 	return zl3vni->vrf_id;
 }
 
-static inline void zl3vni_get_svi_rmac(zebra_l3vni_t *zl3vni,
+static inline void zl3vni_get_svi_rmac(struct zebra_l3vni *zl3vni,
 				       struct ethaddr *rmac)
 {
 	if (!zl3vni)
@@ -209,7 +205,7 @@ static inline void zl3vni_get_svi_rmac(zebra_l3vni_t *zl3vni,
 struct neigh_l3info_walk_ctx {
 
 	struct zebra_evpn *zevpn;
-	zebra_l3vni_t *zl3vni;
+	struct zebra_l3vni *zl3vni;
 	int add;
 };
 
@@ -219,15 +215,15 @@ struct nh_walk_ctx {
 	struct json_object *json;
 };
 
-extern zebra_l3vni_t *zl3vni_from_vrf(vrf_id_t vrf_id);
-extern struct interface *zl3vni_map_to_vxlan_if(zebra_l3vni_t *zl3vni);
-extern struct interface *zl3vni_map_to_svi_if(zebra_l3vni_t *zl3vni);
-extern struct interface *zl3vni_map_to_mac_vlan_if(zebra_l3vni_t *zl3vni);
-extern zebra_l3vni_t *zl3vni_lookup(vni_t vni);
+extern struct zebra_l3vni *zl3vni_from_vrf(vrf_id_t vrf_id);
+extern struct interface *zl3vni_map_to_vxlan_if(struct zebra_l3vni *zl3vni);
+extern struct interface *zl3vni_map_to_svi_if(struct zebra_l3vni *zl3vni);
+extern struct interface *zl3vni_map_to_mac_vlan_if(struct zebra_l3vni *zl3vni);
+extern struct zebra_l3vni *zl3vni_lookup(vni_t vni);
 extern vni_t vni_id_from_svi(struct interface *ifp, struct interface *br_if);
 
 DECLARE_HOOK(zebra_rmac_update,
-	     (struct zebra_mac * rmac, zebra_l3vni_t *zl3vni, bool delete,
+	     (struct zebra_mac * rmac, struct zebra_l3vni *zl3vni, bool delete,
 	      const char *reason),
 	     (rmac, zl3vni, delete, reason));
 

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -247,7 +247,7 @@ DECLARE_HOOK(zebra_rmac_update,
  * an aggregated table that pimd can consume without much
  * re-interpretation.
  */
-typedef struct zebra_vxlan_sg_ {
+struct zebra_vxlan_sg {
 	struct zebra_vrf *zvrf;
 
 	struct prefix_sg sg;
@@ -256,7 +256,7 @@ typedef struct zebra_vxlan_sg_ {
 	/* For SG - num of L2 VNIs using this entry for sending BUM traffic */
 	/* For XG - num of SG using this as parent */
 	uint32_t ref_cnt;
-} zebra_vxlan_sg_t;
+};
 
 extern struct zebra_evpn *zevpn_lookup(vni_t vni);
 extern void zebra_vxlan_sync_mac_dp_install(struct zebra_mac *mac,

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -226,8 +226,10 @@ extern struct interface *zl3vni_map_to_mac_vlan_if(zebra_l3vni_t *zl3vni);
 extern zebra_l3vni_t *zl3vni_lookup(vni_t vni);
 extern vni_t vni_id_from_svi(struct interface *ifp, struct interface *br_if);
 
-DECLARE_HOOK(zebra_rmac_update, (zebra_mac_t *rmac, zebra_l3vni_t *zl3vni,
-	     bool delete, const char *reason), (rmac, zl3vni, delete, reason));
+DECLARE_HOOK(zebra_rmac_update,
+	     (struct zebra_mac * rmac, zebra_l3vni_t *zl3vni, bool delete,
+	      const char *reason),
+	     (rmac, zl3vni, delete, reason));
 
 
 #ifdef __cplusplus
@@ -257,8 +259,10 @@ typedef struct zebra_vxlan_sg_ {
 } zebra_vxlan_sg_t;
 
 extern struct zebra_evpn *zevpn_lookup(vni_t vni);
-extern void zebra_vxlan_sync_mac_dp_install(zebra_mac_t *mac, bool set_inactive,
-		bool force_clear_static, const char *caller);
+extern void zebra_vxlan_sync_mac_dp_install(struct zebra_mac *mac,
+					    bool set_inactive,
+					    bool force_clear_static,
+					    const char *caller);
 extern bool zebra_evpn_do_dup_addr_detect(struct zebra_vrf *zvrf);
 
 #endif /* _ZEBRA_VXLAN_PRIVATE_H */


### PR DESCRIPTION
see individual commits.  Nothing fancy here