### PR TITLE
tests: Fix wrong setting of mpls being turned on

### DIFF
--- a/tests/topotests/bgp_snmp_mplsl3vpn/test_bgp_snmp_mplsvpn.py
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/test_bgp_snmp_mplsvpn.py
@@ -161,13 +161,6 @@ def setup_module(mod):
     r1.run("sysctl -w net.mpls.conf.r1-eth0.input=1")
     r1.run("sysctl -w net.mpls.conf.r1-eth1.input=1")
     r1.run("sysctl -w net.mpls.conf.r1-eth2.input=1")
-    r2.run("sysctl -w net.mpls.conf.r1-eth0.input=1")
-    r2.run("sysctl -w net.mpls.conf.r1-eth1.input=1")
-    r3.run("sysctl -w net.mpls.conf.r1-eth0.input=1")
-    r3.run("sysctl -w net.mpls.conf.r1-eth1.input=1")
-    r3.run("sysctl -w net.mpls.conf.r1-eth2.input=1")
-    r4.run("sysctl -w net.mpls.conf.r1-eth0.input=1")
-    r4.run("sysctl -w net.mpls.conf.r1-eth1.input=1")
 
     router_list = tgen.routers()
 


### PR DESCRIPTION
There were some tests where we were turning on mpls on
interface names that don't exist for certain `machines`
in the topology.  Fix.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>