### PR TITLE
bgpd: Drop afi/safi duplicate string notation for AddPath capability

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -13016,11 +13016,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 									    [safi],
 								    PEER_CAP_ADDPATH_AF_TX_ADV))
 								vty_out(vty,
-									"advertised %s",
-									get_afi_safi_str(
-										afi,
-										safi,
-										false));
+									"advertised");
 
 							if (CHECK_FLAG(
 								    p->af_cap
@@ -13061,11 +13057,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 									    [safi],
 								    PEER_CAP_ADDPATH_AF_RX_ADV))
 								vty_out(vty,
-									"advertised %s",
-									get_afi_safi_str(
-										afi,
-										safi,
-										false));
+									"advertised");
 
 							if (CHECK_FLAG(
 								    p->af_cap


### PR DESCRIPTION
Before:

```
    AddPath:
      IPv4 Unicast: TX advertised IPv4 Unicast and received
      IPv4 Unicast: RX advertised IPv4 Unicast and received
      IPv6 Unicast: TX advertised IPv6 Unicast
      IPv6 Unicast: RX advertised IPv6 Unicast
```

After:

```
    AddPath:
      IPv4 Unicast: TX advertised and received
      IPv4 Unicast: RX advertised and received
      IPv6 Unicast: TX advertised
      IPv6 Unicast: RX advertised
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>