### PR TITLE
ospfd: Memory Leak seen at show_ip_ospf_neighbor_all_common.

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4682,7 +4682,6 @@ static int show_ip_ospf_neighbor_all_common(struct vty *vty, struct ospf *ospf,
 			json_vrf = json_object_new_object();
 		else
 			json_vrf = json;
-		json_neighbor_sub = json_object_new_object();
 	}
 
 	ospf_show_vrf_name(ospf, vty, json_vrf, use_vrf);
@@ -4708,6 +4707,8 @@ static int show_ip_ospf_neighbor_all_common(struct vty *vty, struct ospf *ospf,
 			if (nbr_nbma->nbr == NULL
 			    || nbr_nbma->nbr->state == NSM_Down) {
 				if (use_json) {
+					json_neighbor_sub =
+						json_object_new_object();
 					json_object_int_add(json_neighbor_sub,
 							    "nbrNbmaPriority",
 							    nbr_nbma->priority);


### PR DESCRIPTION
**Problem Statement:**
Memory Leak seen at  show_ip_ospf_neighbor_all_common (ospf_vty.c:4635)

**RCA:**
In function show_ip_ospf_neighbor_all_common, one child json object is not
 added to the parent child object when there is no nbma neighbor. Hence
 the memory leak.

**Fix:**
Add the child object to the parent json object.

Fixes: #9548

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>