### PR TITLE
ospfd: GR Conformance fix in Hello packet DR election

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1081,6 +1081,25 @@ static void ospf_hello(struct ip *iph, struct ospf_header *ospfh,
 		return;
 	}
 
+	if (OSPF_GR_IS_ACTIVE_HELPER(nbr)) {
+		/* As per the GR Conformance Test Case 7.2. Section 3
+		 * "Also, if X was the Designated Router on network segment S
+		 * when the helping relationship began, Y maintains X as the
+		 * Designated Router until the helping relationship is
+		 * terminated."
+		 * When I am helper for this neighbor, I should not trigger the
+		 * ISM Events. Also Intentionally not setting the priority and
+		 * other fields so that when the neighbor exits the Grace
+		 * period, it can handle if there is any change before GR and
+		 * after GR. */
+		if (IS_DEBUG_OSPF_GR)
+			zlog_debug(
+				"%s, Neighbor is under GR Restart, hence ignoring the ISM Events",
+				__PRETTY_FUNCTION__);
+
+		return;
+	}
+
 	/* If neighbor itself declares DR and no BDR exists,
 	   cause event BackupSeen */
 	if (IPV4_ADDR_SAME(&nbr->address.u.prefix4, &hello->d_router))


### PR DESCRIPTION
**Problem Statement:**
DUT selecting itself as DR when Restarting Router goes for reload.
**Test Case 7.2**

DUT (GR Helper) receives the Hello packet from the OSPF GR RESTARTER
(ANVL here) with DR and BDR set to 0.0.0.0 and DUT in its hello
neighbor list. DUT triggers the DR and BDR election although it is
in the Helper mode for that neighbor.

**Root Cause Analysis:**
When hello packet is received with self router ID in the neighbor list,
there is no check in the code to handle this scenario. Hence the DR/BDR
election happens and it changes the DR although it is helper.

**Fix:**
As per RFC 3623 Section 3.  Operation of Helper Neighbor, below point,
we need to maintain the DR relationship.
Also, if X was the Designated Router on network segment S when the
helping relationship began, Y maintains X as the Designated Router
until the helping relationship is terminated.

Adding the check when DUT is under neighbor helper mode, we need to avoid
ISM state change when hello packet is received with DR/BDR set to 0.0.0.0.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>