### PR TITLE
[8.0] backport bgp view fixes

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -612,8 +612,6 @@ static int bgp_accept(struct thread *thread)
 /* BGP socket bind. */
 static char *bgp_get_bound_name(struct peer *peer)
 {
-	char *name = NULL;
-
 	if (!peer)
 		return NULL;
 
@@ -629,14 +627,16 @@ static char *bgp_get_bound_name(struct peer *peer)
 	 * takes precedence over VRF. For IPv4 peering, explicit interface or
 	 * VRF are the situations to bind.
 	 */
-	if (peer->su.sa.sa_family == AF_INET6)
-		name = (peer->conf_if ? peer->conf_if
-				      : (peer->ifname ? peer->ifname
-						      : peer->bgp->name));
-	else
-		name = peer->ifname ? peer->ifname : peer->bgp->name;
+	if (peer->su.sa.sa_family == AF_INET6 && peer->conf_if)
+		return peer->conf_if;
 
-	return name;
+	if (peer->ifname)
+		return peer->ifname;
+
+	if (peer->bgp->inst_type == BGP_INSTANCE_TYPE_VIEW)
+		return NULL;
+
+	return peer->bgp->name;
 }
 
 static int bgp_update_address(struct interface *ifp, const union sockunion *dst,

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3397,8 +3397,21 @@ int bgp_get(struct bgp **bgp_val, as_t *as, const char *name,
 		return ret;
 
 	bgp = bgp_create(as, name, inst_type);
-	if (bgp_option_check(BGP_OPT_NO_ZEBRA) && name)
-		bgp->vrf_id = vrf_generate_id();
+
+	/*
+	 * view instances will never work inside of a vrf
+	 * as such they must always be in the VRF_DEFAULT
+	 * Also we must set this to something useful because
+	 * of the vrf socket code needing an actual useful
+	 * default value to send to the underlying OS.
+	 *
+	 * This code is currently ignoring vrf based
+	 * code using the -Z option( and that is probably
+	 * best addressed elsewhere in the code )
+	 */
+	if (inst_type == BGP_INSTANCE_TYPE_VIEW)
+		bgp->vrf_id = VRF_DEFAULT;
+
 	bgp_router_id_set(bgp, &bgp->router_id_zebra, true);
 	bgp_address_init(bgp);
 	bgp_tip_hash_init(bgp);

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post4.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post4.1.ref
@@ -1,4 +1,4 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post6.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post6.1.ref
@@ -1,4 +1,4 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
 Default local pref 100, local AS 100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post4.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post4.1.ref
@@ -1,4 +1,4 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post6.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post6.1.ref
@@ -1,4 +1,4 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
 Default local pref 100, local AS 100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post4.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post4.1.ref
@@ -1,4 +1,4 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post6.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post6.1.ref
@@ -1,4 +1,4 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
 Default local pref 100, local AS 100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed


### PR DESCRIPTION
It was necessary to update the topotest to reflect that VRF ID is now always 0 for views.
The third commit is not in master because the topotest was updated to use JSON instead of simple vty output.