### PR TITLE
bgpd: cleanup special checks for views

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -358,8 +358,7 @@ void bgp_timer_set(struct peer *peer)
 		   status start timer is on unless peer is shutdown or peer is
 		   inactive.  All other timer must be turned off */
 		if (BGP_PEER_START_SUPPRESSED(peer) || !peer_active(peer)
-		    || (peer->bgp->inst_type != BGP_INSTANCE_TYPE_VIEW &&
-			peer->bgp->vrf_id == VRF_UNKNOWN)) {
+		    || peer->bgp->vrf_id == VRF_UNKNOWN) {
 			BGP_TIMER_OFF(peer->t_start);
 		} else {
 			BGP_TIMER_ON(peer->t_start, bgp_start_timer,
@@ -1694,8 +1693,7 @@ int bgp_start(struct peer *peer)
 		return 0;
 	}
 
-	if (peer->bgp->inst_type != BGP_INSTANCE_TYPE_VIEW &&
-	    peer->bgp->vrf_id == VRF_UNKNOWN) {
+	if (peer->bgp->vrf_id == VRF_UNKNOWN) {
 		if (bgp_debug_neighbor_events(peer))
 			flog_err(
 				EC_BGP_FSM,

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -173,9 +173,7 @@ static int bgp_md5_set_password(struct peer *peer, const char *password)
 				 * must be the default vrf or a view instance
 				 */
 				if (!listener->bgp) {
-					if (peer->bgp->vrf_id != VRF_DEFAULT
-					    && peer->bgp->inst_type
-						       != BGP_INSTANCE_TYPE_VIEW)
+					if (peer->bgp->vrf_id != VRF_DEFAULT)
 						continue;
 				} else if (listener->bgp != peer->bgp)
 					continue;
@@ -853,8 +851,7 @@ static int bgp_listener(int sock, struct sockaddr *sa, socklen_t salen,
 	listener->name = XSTRDUP(MTYPE_BGP_LISTENER, bgp->name);
 
 	/* this socket is in a vrf record bgp back pointer */
-	if (bgp->vrf_id != VRF_DEFAULT
-	    && bgp->inst_type != BGP_INSTANCE_TYPE_VIEW)
+	if (bgp->vrf_id != VRF_DEFAULT)
 		listener->bgp = bgp;
 
 	memcpy(&listener->su, sa, salen);
@@ -906,9 +903,7 @@ int bgp_socket(struct bgp *bgp, unsigned short port, const char *address)
 			sock = vrf_socket(ainfo->ai_family,
 					  ainfo->ai_socktype,
 					  ainfo->ai_protocol,
-					  (bgp->inst_type
-					   != BGP_INSTANCE_TYPE_VIEW
-					   ? bgp->vrf_id : VRF_DEFAULT),
+					  bgp->vrf_id,
 					  (bgp->inst_type
 					   == BGP_INSTANCE_TYPE_VRF
 					   ? bgp->name : NULL));


### PR DESCRIPTION
bgp->vrf_id is always VRF_DEFAULT for views. All these special checks
are not necessary.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>