### PR TITLE
bgpd: fix "no router bgp X vrf default"

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1387,8 +1387,12 @@ DEFUN (no_router_bgp,
 	} else {
 		as = strtoul(argv[idx_asn]->arg, NULL, 10);
 
-		if (argc > 4)
+		if (argc > 4) {
 			name = argv[idx_vrf]->arg;
+			if (strmatch(argv[idx_vrf - 1]->text, "vrf")
+			    && strmatch(name, VRF_DEFAULT_NAME))
+				name = NULL;
+		}
 
 		/* Lookup bgp structure. */
 		bgp = bgp_lookup(as, name);


### PR DESCRIPTION
Currently, "vrf default" modifier is not processed correctly and we get
the `% Can't find BGP instance` error.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>