### PR TITLE
tests: refactor parallel reset/load config for non-json

### DIFF
--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -255,6 +255,7 @@ def pytest_configure(config):
             cli_level = config.getini("log_cli_level")
             if cli_level is not None:
                 config.option.log_cli_level = cli_level
+
     # ---------------------------------------
     # Record our options in global dictionary
     # ---------------------------------------
@@ -327,6 +328,12 @@ def setup_session_auto():
     if not is_worker:
         cleanup_current()
     logger.debug("After the run (is_worker: %s)", is_worker)
+
+
+def pytest_runtest_setup(item):
+    module = item.parent.module
+    script_dir = os.path.abspath(os.path.dirname(module.__file__))
+    os.environ["PYTEST_TOPOTEST_SCRIPTDIR"] = script_dir
 
 
 def pytest_runtest_makereport(item, call):

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -786,12 +786,15 @@ class TopoRouter(TopoGear):
         return self.net.checkCapability(daemonstr, param)
 
     def load_config(self, daemon, source=None, param=None):
-        """
-        Loads daemon configuration from the specified source
+        """Loads daemon configuration from the specified source
         Possible daemon values are: TopoRouter.RD_ZEBRA, TopoRouter.RD_RIP,
         TopoRouter.RD_RIPNG, TopoRouter.RD_OSPF, TopoRouter.RD_OSPF6,
         TopoRouter.RD_ISIS, TopoRouter.RD_BGP, TopoRouter.RD_LDP,
         TopoRouter.RD_PIM, TopoRouter.RD_PBR, TopoRouter.RD_SNMP.
+
+        Possible `source` values are `None` for an empty config file, a path name which is
+        used directly, or a file name with no path components which is first looked for
+        directly and then looked for under a sub-directory named after router.
 
         This API unfortunately allows for source to not exist for any and
         all routers.

--- a/tests/topotests/lib/topojson.py
+++ b/tests/topotests/lib/topojson.py
@@ -44,8 +44,6 @@ from lib.ospf import create_router_ospf, create_router_ospf6
 from lib.pim import create_igmp_config, create_pim_config
 from lib.topolog import logger
 
-ROUTER_LIST = []
-
 
 def build_topo_from_json(tgen, topo=None):
     """
@@ -58,26 +56,26 @@ def build_topo_from_json(tgen, topo=None):
     if topo is None:
         topo = tgen.json_topo
 
-    ROUTER_LIST = sorted(
+    router_list = sorted(
         topo["routers"].keys(), key=lambda x: int(re_search(r"\d+", x).group(0))
     )
 
-    SWITCH_LIST = []
+    switch_list = []
     if "switches" in topo:
-        SWITCH_LIST = sorted(
+        switch_list = sorted(
             topo["switches"].keys(), key=lambda x: int(re_search(r"\d+", x).group(0))
         )
 
-    listRouters = sorted(ROUTER_LIST[:])
-    listSwitches = sorted(SWITCH_LIST[:])
+    listRouters = sorted(router_list[:])
+    listSwitches = sorted(switch_list[:])
     listAllRouters = deepcopy(listRouters)
     dictSwitches = {}
 
-    for routerN in ROUTER_LIST:
+    for routerN in router_list:
         logger.info("Topo: Add router {}".format(routerN))
         tgen.add_router(routerN)
 
-    for switchN in SWITCH_LIST:
+    for switchN in switch_list:
         logger.info("Topo: Add switch {}".format(switchN))
         dictSwitches[switchN] = tgen.add_switch(switchN)
 


### PR DESCRIPTION
Refactor the bgp_auth test to create common_config code to allow
non-json based tests to reset routers and load configs in parallel.

Signed-off-by: Christian Hopps <chopps@labn.net>