### PR TITLE
ospfd: When 50k routes are present, OSPFd spiked to 100% and crashed

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10608,11 +10608,8 @@ static void show_ip_ospf_route_network(struct vty *vty, struct ospf *ospf,
 		prefix2str(&rn->p, buf1, sizeof(buf1));
 
 		json_route = json_object_new_object();
-		if (json) {
+		if (json)
 			json_object_object_add(json, buf1, json_route);
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_NOSLASHESCAPE);
-		}
 
 		switch (or->path_type) {
 		case OSPF_PATH_INTER_AREA:
@@ -10909,11 +10906,8 @@ static void show_ip_ospf_route_external(struct vty *vty, struct ospf *ospf,
 
 		snprintfrr(buf1, sizeof(buf1), "%pFX", &rn->p);
 		json_route = json_object_new_object();
-		if (json) {
+		if (json)
 			json_object_object_add(json, buf1, json_route);
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_NOSLASHESCAPE);
-		}
 
 		switch (er->path_type) {
 		case OSPF_PATH_TYPE1_EXTERNAL:


### PR DESCRIPTION
**Problem Statement:**
ospfd is taking too long time and crashes when 20K type-3, 30k type-5 routes are present

**RCA:**
The function json_object_to_json_string_ext took a lot of time
due to which OSPF daemon took more time and watchfrr restarted it
assuming OSPFd is not responding.

**Fix:**
json_object_to_json_string_ext(json, JSON_C_TO_STRING_NOSLASHESCAPE);
The above statement is used to remove the forward slashes which appears
in the output when displaying the prefix as x.x.x.x\/y but the
the removal of forward slash is not working in the current lib, hence
it is of no use. Removing this API as it is of no use as of now.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>