### PR TITLE
topotests: to create pid file of topotest router

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -953,6 +953,32 @@ configuration files (per-daemon) using the following commands:
    end
    r1#
 
+You can also login to the node specified by nsenter using bash, etc.
+A pid file for each node will be created in the relevant test dir.
+You can run scripts inside the node, or use vtysh's <tab> or <?> feature.
+
+.. code:: shell
+
+  [unet shell]
+  # cd tests/topotests/srv6_locator
+  # ./test_srv6_locator.py --topology-only
+  unet> r1 sh segment-routing srv6 locator
+  Locator:
+  Name                 ID      Prefix                   Status
+  -------------------- ------- ------------------------ -------
+  loc1                       1 2001:db8:1:1::/64        Up
+  loc2                       2 2001:db8:2:2::/64        Up
+
+  [Another shell]
+  # nsenter -a -t $(cat /tmp/topotests/srv6_locator.test_srv6_locator/r1.pid) bash --norc
+  # vtysh
+  r1# r1 sh segment-routing srv6 locator
+  Locator:
+  Name                 ID      Prefix                   Status
+  -------------------- ------- ------------------------ -------
+  loc1                       1 2001:db8:1:1::/64        Up
+  loc2                       2 2001:db8:2:2::/64        Up
+
 Writing Tests
 """""""""""""
 

--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -962,7 +962,7 @@ You can run scripts inside the node, or use vtysh's <tab> or <?> feature.
   [unet shell]
   # cd tests/topotests/srv6_locator
   # ./test_srv6_locator.py --topology-only
-  unet> r1 sh segment-routing srv6 locator
+  unet> r1 show segment-routing srv6 locator
   Locator:
   Name                 ID      Prefix                   Status
   -------------------- ------- ------------------------ -------
@@ -972,7 +972,7 @@ You can run scripts inside the node, or use vtysh's <tab> or <?> feature.
   [Another shell]
   # nsenter -a -t $(cat /tmp/topotests/srv6_locator.test_srv6_locator/r1.pid) bash --norc
   # vtysh
-  r1# r1 sh segment-routing srv6 locator
+  r1# r1 show segment-routing srv6 locator
   Locator:
   Name                 ID      Prefix                   Status
   -------------------- ------- ------------------------ -------

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -773,7 +773,7 @@ class TopoRouter(TopoGear):
 
         # Ensure pid file
         with open(os.path.join(self.logdir, self.name + ".pid"), "w") as f:
-            f.write(str(tgen.net.hosts[self.name].pid))
+            f.write(str(self.net.pid) + "\n")
 
     def __str__(self):
         gear = super(TopoRouter, self).__str__()

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -771,6 +771,10 @@ class TopoRouter(TopoGear):
         # Mount gear log directory on a common path
         self.net.bind_mount(self.gearlogdir, "/tmp/gearlogdir")
 
+        # Ensure pid file
+        with open(os.path.join(self.logdir, self.name + ".pid"), "w") as f:
+            f.write(str(tgen.net.hosts[self.name].pid))
+
     def __str__(self):
         gear = super(TopoRouter, self).__str__()
         gear += " TopoRouter<>"


### PR DESCRIPTION
Create a pid file for the router created by topotest.
By executing nsenter directly against this pid, developers
can execute commands directly from outside the unet shell.
This allows the developer to use script, tab completion, etc.,
and improves efficiency.

Signed-off-by: Hiroki Shirokura <slank.dev@gmail.com>