### PR TITLE
[8.0] ospf6d: don't create Adv-ID:0.0.0.0 LSAs at start

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -88,6 +88,16 @@ void ospf6_lsa_originate(struct ospf6_lsa *lsa)
 	struct ospf6_lsa *old;
 	struct ospf6_lsdb *lsdb_self;
 
+	if (lsa->header->adv_router == INADDR_ANY) {
+		if (IS_OSPF6_DEBUG_ORIGINATE_TYPE(lsa->header->type))
+			zlog_debug(
+				"Refusing to originate LSA (zero router ID): %s",
+				lsa->name);
+
+		ospf6_lsa_delete(lsa);
+		return;
+	}
+
 	/* find previous LSA */
 	old = ospf6_lsdb_lookup(lsa->header->type, lsa->header->id,
 				lsa->header->adv_router, lsa->lsdb);


### PR DESCRIPTION
When ospf6d comes up, it gets interface and address state before it
decides on its router ID.  This results in a bunch of LSAs with
advertising router ID 0.0.0.0 in the LSDB.  Not quite right.

There's a whole bunch of paths leading to this, so just drop the LSA in
ospf6_lsa_originate.  The router-ID change causes everything to be
readvertised anyway (... but the delete doesn't catch the 0.0.0.0 stuff
because the router-ID is now different.)

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>