### PR TITLE
tests: fix xterm windows for topotests, better errors

### DIFF
--- a/tests/topotests/lib/micronet.py
+++ b/tests/topotests/lib/micronet.py
@@ -369,13 +369,13 @@ class Commander(object):  # pylint: disable=R0205
             cmd = [self.get_exec_path("xterm")]
             if "SUDO_USER" in os.environ:
                 cmd = [self.get_exec_path("sudo"), "-u", os.environ["SUDO_USER"]] + cmd
-            # if title:
-            #    cmd.append("-T")
-            #    cmd.append(title)
+            if title:
+                cmd.append("-T")
+                cmd.append(title)
             cmd.append("-e")
             cmd.append(sudo_path)
             cmd.extend(self.pre_cmd)
-            cmd.append(user_cmd)
+            cmd.extend(["bash", "-c", user_cmd])
             # if channel:
             #    return self.cmd_raises(cmd, skip_pre_cmd=True)
             # else:
@@ -384,13 +384,11 @@ class Commander(object):  # pylint: disable=R0205
                 skip_pre_cmd=True,
                 stdin=None,
                 shell=False,
-                # stdout=open("/dev/null", "w"),
-                # stderr=open("/dev/null", "w"),
             )
             time_mod.sleep(2)
             if p.poll() is not None:
                 self.logger.error("%s: Failed to launch xterm: %s", self, comm_error(p))
-            return ""
+            return p
         else:
             self.logger.error(
                 "DISPLAY, STY, and TMUX not in environment, can't open window"

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1603,10 +1603,6 @@ class Router(Node):
         if "all" in shell_routers or self.name in shell_routers:
             self.run_in_window(os.getenv("SHELL", "bash"))
 
-        vtysh_routers = g_extra_config["vtysh"]
-        if "all" in vtysh_routers or self.name in vtysh_routers:
-            self.run_in_window("vtysh")
-
         if self.daemons["eigrpd"] == 1:
             eigrpd_path = os.path.join(self.daemondir, "eigrpd")
             if not os.path.isfile(eigrpd_path):
@@ -1619,7 +1615,13 @@ class Router(Node):
                 logger.info("BFD Test, but no bfdd compiled or installed")
                 return "BFD Test, but no bfdd compiled or installed"
 
-        return self.startRouterDaemons(tgen=tgen)
+        status = self.startRouterDaemons(tgen=tgen)
+
+        vtysh_routers = g_extra_config["vtysh"]
+        if "all" in vtysh_routers or self.name in vtysh_routers:
+            self.run_in_window("vtysh")
+
+        return status
 
     def getStdErr(self, daemon):
         return self.getLog("err", daemon)


### PR DESCRIPTION
- Fix xterm support to work, previously it mostly didn't, not it should
in all cases (i.e., single or dist mode).

- Catch when the user tries to use various window requiring topotests
features (e.g., --cli-on-error) but isn't running under supported
system (e.g., byobu/tmux/xterm), and fail the run with an explanation.

Signed-off-by: Christian Hopps <chopps@labn.net>