### PR TITLE
ospf6d: add a knob to generate Type-7 default routes

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -178,7 +178,7 @@ OSPF6 area
 
 .. clicmd:: area A.B.C.D nssa [no-summary]
 
-.. clicmd:: area (0-4294967295) nssa [no-summary]
+.. clicmd:: area (0-4294967295) nssa [no-summary] [default-information-originate [metric-type (1-2)] [metric (0-16777214)]]
 
    Configure the area to be a NSSA (Not-So-Stubby Area).
 
@@ -197,6 +197,12 @@ OSPF6 area
    An NSSA ABR can be configured with the `no-summary` option to prevent the
    advertisement of summaries into the area. In that case, a single Type-3 LSA
    containing a default route is originated into the NSSA.
+
+   NSSA ABRs and ASBRs can be configured with `default-information-originate`
+   option to originate a Type-7 default route into the NSSA area. In the case
+   of NSSA ASBRs, the origination of the default route is conditioned to the
+   existence of a default route in the RIB that wasn't learned via the OSPF
+   protocol.
 
 .. clicmd:: area A.B.C.D export-list NAME
 

--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -52,6 +52,13 @@ struct ospf6_area {
 	/* Area type */
 	int no_summary;
 
+	/* NSSA default-information-originate */
+	struct {
+		bool enabled;
+		int metric_type;
+		int metric_value;
+	} nssa_default_originate;
+
 	/* Brouter traversal protection */
 	bool intra_brouter_calc;
 

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -49,6 +49,7 @@
 #include "ospf6_abr.h"
 #include "ospf6_intra.h"
 #include "ospf6_flood.h"
+#include "ospf6_nssa.h"
 #include "ospf6d.h"
 #include "ospf6_spf.h"
 #include "ospf6_nssa.h"
@@ -85,7 +86,7 @@ static struct ospf6_lsa *ospf6_originate_type5_type7_lsas(
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, lnode, oa)) {
 		if (IS_AREA_NSSA(oa))
-			ospf6_nssa_lsa_originate(route, oa);
+			ospf6_nssa_lsa_originate(route, oa, true);
 	}
 
 	return lsa;

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1433,7 +1433,10 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 	memset(&tinfo, 0, sizeof(tinfo));
 
 	if (IS_OSPF6_DEBUG_ASBR)
-		zlog_debug("Redistribute %pFX (%s)", prefix, ZROUTE_NAME(type));
+		zlog_debug("Redistribute %pFX (%s)", prefix,
+			   type == DEFAULT_ROUTE
+				   ? "default-information-originate"
+				   : ZROUTE_NAME(type));
 
 	/* if route-map was specified but not found, do not advertise */
 	if (ROUTEMAP_NAME(red)) {

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1787,7 +1787,7 @@ int ospf6_redistribute_config_write(struct vty *vty, struct ospf6 *ospf6)
 		vty_out(vty, " redistribute %s", ZROUTE_NAME(type));
 		if (red->dmetric.value >= 0)
 			vty_out(vty, " metric %d", red->dmetric.value);
-		if (red->dmetric.type != DEFAULT_METRIC_TYPE)
+		if (red->dmetric.type == 1)
 			vty_out(vty, " metric-type 1");
 		if (ROUTEMAP_NAME(red))
 			vty_out(vty, " route-map %s", ROUTEMAP_NAME(red));

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -1169,10 +1169,11 @@ static void ospf6_check_and_originate_type7_lsa(struct ospf6_area *area)
 	for (route = ospf6_route_head(
 		     area->ospf6->external_table);
 	     route; route = ospf6_route_next(route)) {
-		/* This means the Type-5 LSA was originated for this route */
-		if (route->path.origin.id != 0)
-			ospf6_nssa_lsa_originate(route, area);
+		struct ospf6_external_info *info = route->route_option;
 
+		/* This means the Type-5 LSA was originated for this route */
+		if (route->path.origin.id != 0 && info->type != DEFAULT_ROUTE)
+			ospf6_nssa_lsa_originate(route, area);
 	}
 
 	/* Loop through the aggregation table to originate type-7 LSAs

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -1311,7 +1311,7 @@ void ospf6_nssa_lsa_originate(struct ospf6_route *route,
 
 	/* Fill AS-External-LSA */
 	/* Metric type */
-	if (route->path.metric_type == OSPF6_PATH_TYPE_EXTERNAL2)
+	if (route->path.metric_type == 2)
 		SET_FLAG(as_external_lsa->bits_metric, OSPF6_ASBR_BIT_E);
 	else
 		UNSET_FLAG(as_external_lsa->bits_metric, OSPF6_ASBR_BIT_E);

--- a/ospf6d/ospf6_nssa.h
+++ b/ospf6d/ospf6_nssa.h
@@ -64,8 +64,9 @@ extern void ospf6_schedule_abr_task(struct ospf6 *ospf6);
 extern void ospf6_area_nssa_update(struct ospf6_area *area);
 void ospf6_asbr_prefix_readvertise(struct ospf6 *ospf6);
 extern void ospf6_nssa_lsa_originate(struct ospf6_route *route,
-				     struct ospf6_area *area);
+				     struct ospf6_area *area, bool p_bit);
 extern void install_element_ospf6_debug_nssa(void);
+extern void ospf6_abr_nssa_type_7_defaults(struct ospf6 *osof6);
 int ospf6_redistribute_check(struct ospf6 *ospf6, struct ospf6_route *route,
 			     int type);
 extern int ospf6_abr_translate_nssa(struct ospf6_area *area,

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -646,8 +646,10 @@ static int ospf6_spf_calculation_thread(struct thread *t)
 	/* External LSA calculation */
 	ospf6_ase_calculate_timer_add(ospf6);
 
-	if (ospf6_check_and_set_router_abr(ospf6))
+	if (ospf6_check_and_set_router_abr(ospf6)) {
 		ospf6_abr_defaults_to_stub(ospf6);
+		ospf6_abr_nssa_type_7_defaults(ospf6);
+	}
 
 	monotime(&end);
 	timersub(&end, &start, &runtime);

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -143,6 +143,18 @@ struct ospf6 {
 	/* OSPF6 redistribute configuration */
 	struct list *redist[ZEBRA_ROUTE_MAX + 1];
 
+	/* NSSA default-information-originate */
+	struct {
+		/* # of NSSA areas requesting default information */
+		uint16_t refcnt;
+
+		/*
+		 * Whether a default route known through non-OSPF protocol is
+		 * present in the RIB.
+		 */
+		bool status;
+	} nssa_default_import_check;
+
 	uint8_t flag;
 #define OSPF6_FLAG_ABR          0x04
 #define OSPF6_FLAG_ASBR         0x08

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -55,6 +55,7 @@ extern void ospf6_zebra_no_redistribute(int, vrf_id_t vrf_id);
 #define ospf6_zebra_is_redistribute(type, vrf_id)                              \
 	vrf_bitmap_check(zclient->redist[AFI_IP6][type], vrf_id)
 extern void ospf6_zebra_init(struct thread_master *tm);
+extern void ospf6_zebra_import_default_route(struct ospf6 *ospf6, bool unreg);
 extern void ospf6_zebra_add_discard(struct ospf6_route *request,
 				    struct ospf6 *ospf6);
 extern void ospf6_zebra_delete_discard(struct ospf6_route *request,

--- a/tests/topotests/ospf6_topo2/test_ospf6_topo2.py
+++ b/tests/topotests/ospf6_topo2/test_ospf6_topo2.py
@@ -217,8 +217,8 @@ def test_ospfv3_expected_route_types():
         {
             "numberOfIntraAreaRoutes": 1,
             "numberOfInterAreaRoutes": 2,
-            "numberOfExternal1Routes": 4,
-            "numberOfExternal2Routes": 0,
+            "numberOfExternal1Routes": 0,
+            "numberOfExternal2Routes": 4,
         },
     )
 
@@ -330,7 +330,7 @@ def test_nssa_lsa_type7():
     ]
     route = {
         "2001:db8:100::/64": {
-            "pathType": "E1",
+            "pathType": "E2",
             "nextHops": [{"nextHop": "::", "interfaceName": "r4-eth0"}],
         }
     }

--- a/tests/topotests/ospf6_topo2/test_ospf6_topo2.py
+++ b/tests/topotests/ospf6_topo2/test_ospf6_topo2.py
@@ -218,7 +218,7 @@ def test_ospfv3_expected_route_types():
             "numberOfIntraAreaRoutes": 1,
             "numberOfInterAreaRoutes": 2,
             "numberOfExternal1Routes": 0,
-            "numberOfExternal2Routes": 4,
+            "numberOfExternal2Routes": 3,
         },
     )
 


### PR DESCRIPTION
Add a knob to generate Type-7 default routes on NSSA ABRs/ASBRs.

Syntax: `area A.B.C.D nssa default-information-originate [{metric (0-16777214)|metric-type (1-2)}]`.

Example:
```
router ospf6
 area 1 nssa default-information-originate
!
```

This PR also includes a few assorted fixes. Please refer to the individual commits for details.