### PR TITLE
zebra: copy nexthop_srv6 in nexthop_set_resolved

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1773,6 +1773,14 @@ static struct nexthop *nexthop_set_resolved(afi_t afi,
 		nexthop_add_labels(resolved_hop, label_type, num_labels,
 				   labels);
 
+	if (nexthop->nh_srv6) {
+		nexthop_add_srv6_seg6local(resolved_hop,
+					   nexthop->nh_srv6->seg6local_action,
+					   &nexthop->nh_srv6->seg6local_ctx);
+		nexthop_add_srv6_seg6(resolved_hop,
+				      &nexthop->nh_srv6->seg6_segs);
+	}
+
 	resolved_hop->rparent = nexthop;
 	_nexthop_add(&nexthop->resolved, resolved_hop);
 


### PR DESCRIPTION
Current implementation doesn't copy nexthop_srv6. This causes unexpected behavior when receiving SID information and nexthop isn't onlink.

For example:

Here is the example of unexpected behaviors. First nexthop of 172.31.2.0/24 has nexthop_srv6 correctly, but Second nexthop doesn't have. so SRv6 encap rule doesn't installed correctly when this route is installed into kernel.

```
r1# show ip route vrf vrf100
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

VRF vrf100:
C>* 172.31.1.0/24 is directly connected, ens2, 01:49:02
B>  172.31.2.0/24 [20/0] via fc00::2 (vrf default) (recursive), label 1024, seg6local unspec unknown(seg6local_context2str), seg6 2001:db8:2::, weight 1, 01:48:31
  *                        via 2001:db8::2, ens8 (vrf default), label 1024, weight 1, 01:48:31
```