### PR TITLE
tests: fix typo in zebra.conf

### DIFF
--- a/tests/topotests/bgp_evpn_overlay_index_gateway/host2/zebra.conf
+++ b/tests/topotests/bgp_evpn_overlay_index_gateway/host2/zebra.conf
@@ -1,4 +1,4 @@
 !
-int host1-eth0
+int host2-eth0
  ip address 50.0.1.21/24
  ipv6 address 50:0:1::21/48


### PR DESCRIPTION
Fixed typo in zebra.conf in host2 of bgp_evpn_overlay_index_gateway in topotests.
Signed-off-by: Enigamict mochienper@gmail.com