### PR TITLE
zebra: Fix IPv4 routes with IPv6 link local next hops installation in FPM

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -105,7 +105,7 @@ struct gw_family_t {
 };
 
 static const char ipv4_ll_buf[16] = "169.254.0.1";
-static struct in_addr ipv4_ll;
+struct in_addr ipv4_ll;
 
 /* Is this a ipv4 over ipv6 route? */
 static bool is_route_v4_over_v6(unsigned char rtm_family,

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -169,6 +169,7 @@ static int netlink_route_info_add_nh(struct netlink_route_info *ri,
 	struct interface *ifp = NULL, *link_if = NULL;
 	struct zebra_if *zif = NULL;
 	vni_t vni = 0;
+	extern struct in_addr ipv4_ll;
 
 	memset(&nhi, 0, sizeof(nhi));
 	src = NULL;
@@ -189,7 +190,11 @@ static int netlink_route_info_add_nh(struct netlink_route_info *ri,
 
 	if (nexthop->type == NEXTHOP_TYPE_IPV6
 	    || nexthop->type == NEXTHOP_TYPE_IPV6_IFINDEX) {
-		nhi.gateway = &nexthop->gate;
+		/* Special handling for IPv4 route with IPv6 Link Local next hop */
+		if (ri->af == AF_INET)
+			nhi.gateway = &ipv4_ll;
+		else
+			nhi.gateway = &nexthop->gate;
 	}
 
 	if (nexthop->type == NEXTHOP_TYPE_IFINDEX) {

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -190,7 +190,8 @@ static int netlink_route_info_add_nh(struct netlink_route_info *ri,
 
 	if (nexthop->type == NEXTHOP_TYPE_IPV6
 	    || nexthop->type == NEXTHOP_TYPE_IPV6_IFINDEX) {
-		/* Special handling for IPv4 route with IPv6 Link Local next hop */
+		/* Special handling for IPv4 route with IPv6 Link Local next hop
+		 */
 		if (ri->af == AF_INET)
 			nhi.gateway = &ipv4_ll;
 		else


### PR DESCRIPTION

Description: 
Currently IPv4 routes with IPv6 link local next hops are
not properly installed in FPM.
Reason is the netlink decoding truncates the ipv6 LL address to 4 byte
ipv4 address.

Ex : fe80:: is directly converted to ipv4 and it results in 254.128.0.0
as next hop for below routes

show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
F - PBR, f - OpenFabric,
> - selected route, * - FIB route, q - queued, r - rejected, b - backup

B>* 2.1.0.0/16 [200/0] via fe80::268a:7ff:fed0:d40, Ethernet0, weight 1,
02:22:26
B>* 5.1.0.0/16 [200/0] via fe80::268a:7ff:fed0:d40, Ethernet0, weight 1,
02:22:26
B>* 10.1.0.2/32 [200/0] via fe80::268a:7ff:fed0:d40, Ethernet0, weight
1, 02:22:26

Hence this fix converts the ipv6-LL address to ipv4-LL (169.254.0.1)
address before sending it to FPM. This is inline with how these types of
routes are currently programmed into kernel.

Signed-off-by: Nikhil Kelapure nikhil.kelapure@broadcom.com
