### PR TITLE
zebra: Fix IPv4 routes with IPv6 link local next hops install in FPM

### DIFF
--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -292,6 +292,9 @@ static void zfpm_start_connect_timer(const char *reason);
 static void zfpm_start_stats_timer(void);
 static void zfpm_mac_info_del(struct fpm_mac_info_t *fpm_mac);
 
+static const char ipv4_ll_buf[16] = "169.254.0.1";
+union g_addr ipv4ll_gateway;
+
 /*
  * zfpm_thread_should_yield
  */
@@ -1992,6 +1995,9 @@ static int zfpm_init(struct thread_master *master)
 	zfpm_stats_init(&zfpm_g->stats);
 	zfpm_stats_init(&zfpm_g->last_ivl_stats);
 	zfpm_stats_init(&zfpm_g->cumulative_stats);
+
+	memset(&ipv4ll_gateway, 0, sizeof(ipv4ll_gateway));
+	inet_pton(AF_INET, ipv4_ll_buf, &ipv4ll_gateway.ipv4);
 
 	install_node(&zebra_node);
 	install_element(ENABLE_NODE, &show_zebra_fpm_stats_cmd);

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -189,7 +189,12 @@ static int netlink_route_info_add_nh(struct netlink_route_info *ri,
 
 	if (nexthop->type == NEXTHOP_TYPE_IPV6
 	    || nexthop->type == NEXTHOP_TYPE_IPV6_IFINDEX) {
-		nhi.gateway = &nexthop->gate;
+		/* Special handling for IPv4 route with IPv6 Link Local next hop
+		 */
+		if (ri->af == AF_INET)
+			nhi.gateway = &ipv4ll_gateway;
+		else
+			nhi.gateway = &nexthop->gate;
 	}
 
 	if (nexthop->type == NEXTHOP_TYPE_IFINDEX) {

--- a/zebra/zebra_fpm_private.h
+++ b/zebra/zebra_fpm_private.h
@@ -97,6 +97,8 @@ extern int zfpm_netlink_encode_mac(struct fpm_mac_info_t *mac, char *in_buf,
 
 extern struct route_entry *zfpm_route_for_update(rib_dest_t *dest);
 
+extern union g_addr ipv4ll_gateway;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION

Description: Currently IPv4 routes with IPv6 link local next hops are
not properly installed in FPM.
Reason is the netlink decoding truncates the ipv6 LL address to 4 byte
ipv4 address.

Ex : fe80:: is directly converted to ipv4 and it results in 254.128.0.0
as next hop for below routes

show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
F - PBR, f - OpenFabric,
> - selected route, * - FIB route, q - queued, r - rejected, b - backup

B>* 2.1.0.0/16 [200/0] via fe80::268a:7ff:fed0:d40, Ethernet0, weight 1,
02:22:26
B>* 5.1.0.0/16 [200/0] via fe80::268a:7ff:fed0:d40, Ethernet0, weight 1,
02:22:26
B>* 10.1.0.2/32 [200/0] via fe80::268a:7ff:fed0:d40, Ethernet0, weight
1, 02:22:26

Hence this fix converts the ipv6-LL address to ipv4-LL (169.254.0.1)
address before sending it to FPM. This is inline with how these types of
routes are currently programmed into kernel.

Signed-off-by: Nikhil Kelapure nikhil.kelapure@broadcom.com
