### PR TITLE
*: add route-map match ipv6 next-hop prefix-list/access-list

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -683,18 +683,20 @@ static const struct route_map_rule_cmd
 /* `match ip next-hop prefix-list PREFIX_LIST' */
 
 static enum route_map_cmd_result_t
-route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
-				    void *object)
+route_match_next_hop_prefix_list(void *rule, const struct prefix *prefix,
+				 void *object, afi_t afi)
 {
 	struct prefix_list *plist;
-	struct bgp_path_info *path;
-	struct prefix_ipv4 p;
+	struct bgp_path_info *path = object;
+	struct prefix p;
 
-	if (prefix->family == AF_INET) {
-		path = object;
+	if (path->attr->nexthop.s_addr) {
+		if (afi != AFI_IP)
+			return RMAP_NOMATCH;
+
 		p.family = AF_INET;
-		p.prefix = path->attr->nexthop;
 		p.prefixlen = IPV4_MAX_BITLEN;
+		p.u.prefix4 = path->attr->nexthop;
 
 		plist = prefix_list_lookup(AFI_IP, (char *)rule);
 		if (plist == NULL)
@@ -704,15 +706,50 @@ route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
 				? RMAP_NOMATCH
 				: RMAP_MATCH);
 	}
+
+	if (afi != AFI_IP6)
+		return RMAP_NOMATCH;
+
+	plist = prefix_list_lookup(AFI_IP6, (char *)rule);
+	if (plist == NULL)
+		return RMAP_NOMATCH;
+
+	p.family = AF_INET6;
+	p.prefixlen = IPV6_MAX_BITLEN;
+
+	p.u.prefix6 = path->attr->mp_nexthop_global;
+	if (prefix_list_apply(plist, &p) == PREFIX_PERMIT)
+		return RMAP_MATCH;
+
+	if (path->attr->mp_nexthop_len == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL) {
+		p.u.prefix6 = path->attr->mp_nexthop_local;
+		if (prefix_list_apply(plist, &p) == PREFIX_PERMIT)
+			return RMAP_MATCH;
+	}
+
 	return RMAP_NOMATCH;
 }
 
-static void *route_match_ip_next_hop_prefix_list_compile(const char *arg)
+static enum route_map_cmd_result_t
+route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
+				    void *object)
+{
+	return route_match_next_hop_prefix_list(rule, prefix, object, AFI_IP);
+}
+
+static enum route_map_cmd_result_t
+route_match_ipv6_next_hop_prefix_list(void *rule, const struct prefix *prefix,
+				      void *object)
+{
+	return route_match_next_hop_prefix_list(rule, prefix, object, AFI_IP6);
+}
+
+static void *route_match_next_hop_prefix_list_compile(const char *arg)
 {
 	return XSTRDUP(MTYPE_ROUTE_MAP_COMPILED, arg);
 }
 
-static void route_match_ip_next_hop_prefix_list_free(void *rule)
+static void route_match_next_hop_prefix_list_free(void *rule)
 {
 	XFREE(MTYPE_ROUTE_MAP_COMPILED, rule);
 }
@@ -721,8 +758,16 @@ static const struct route_map_rule_cmd
 		route_match_ip_next_hop_prefix_list_cmd = {
 	"ip next-hop prefix-list",
 	route_match_ip_next_hop_prefix_list,
-	route_match_ip_next_hop_prefix_list_compile,
-	route_match_ip_next_hop_prefix_list_free
+	route_match_next_hop_prefix_list_compile,
+	route_match_next_hop_prefix_list_free
+};
+
+static const struct route_map_rule_cmd
+		route_match_ipv6_next_hop_prefix_list_cmd = {
+	"ipv6 next-hop prefix-list",
+	route_match_ipv6_next_hop_prefix_list,
+	route_match_next_hop_prefix_list_compile,
+	route_match_next_hop_prefix_list_free
 };
 
 /* `match ip next-hop type <blackhole>' */
@@ -6374,6 +6419,9 @@ void bgp_route_map_init(void)
 	route_map_match_ipv6_address_prefix_list_hook(generic_match_add);
 	route_map_no_match_ipv6_address_prefix_list_hook(generic_match_delete);
 
+	route_map_match_ipv6_next_hop_prefix_list_hook(generic_match_add);
+	route_map_no_match_ipv6_next_hop_prefix_list_hook(generic_match_delete);
+
 	route_map_match_ipv6_next_hop_type_hook(generic_match_add);
 	route_map_no_match_ipv6_next_hop_type_hook(generic_match_delete);
 
@@ -6409,6 +6457,7 @@ void bgp_route_map_init(void)
 	route_map_install_match(&route_match_ip_route_source_cmd);
 	route_map_install_match(&route_match_ip_address_prefix_list_cmd);
 	route_map_install_match(&route_match_ip_next_hop_prefix_list_cmd);
+	route_map_install_match(&route_match_ipv6_next_hop_prefix_list_cmd);
 	route_map_install_match(&route_match_ip_next_hop_type_cmd);
 	route_map_install_match(&route_match_ip_route_source_prefix_list_cmd);
 	route_map_install_match(&route_match_aspath_cmd);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -503,17 +503,20 @@ static const struct route_map_rule_cmd route_match_ip_address_cmd = {
 
 /* Match function return 1 if match is success else return zero. */
 static enum route_map_cmd_result_t
-route_match_ip_next_hop(void *rule, const struct prefix *prefix, void *object)
+route_match_next_hop(void *rule, const struct prefix *prefix, void *object,
+		     afi_t afi)
 {
 	struct access_list *alist;
-	struct bgp_path_info *path;
-	struct prefix_ipv4 p;
+	struct bgp_path_info *path = object;
+	struct prefix p;
 
-	if (prefix->family == AF_INET) {
-		path = object;
+	if (path->attr->nexthop.s_addr) {
+		if (afi != AFI_IP)
+			return RMAP_NOMATCH;
+
 		p.family = AF_INET;
-		p.prefix = path->attr->nexthop;
 		p.prefixlen = IPV4_MAX_BITLEN;
+		p.u.prefix4 = path->attr->nexthop;
 
 		alist = access_list_lookup(AFI_IP, (char *)rule);
 		if (alist == NULL)
@@ -523,18 +526,51 @@ route_match_ip_next_hop(void *rule, const struct prefix *prefix, void *object)
 				? RMAP_NOMATCH
 				: RMAP_MATCH);
 	}
+
+	if (afi != AFI_IP6)
+		return RMAP_NOMATCH;
+
+	alist = access_list_lookup(AFI_IP6, (char *)rule);
+	if (alist == NULL)
+		return RMAP_NOMATCH;
+
+	p.family = AF_INET6;
+	p.prefixlen = IPV6_MAX_BITLEN;
+
+	p.u.prefix6 = path->attr->mp_nexthop_global;
+	if (access_list_apply(alist, &p) == FILTER_PERMIT)
+		return RMAP_MATCH;
+
+	if (path->attr->mp_nexthop_len == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL) {
+		p.u.prefix6 = path->attr->mp_nexthop_local;
+		if (access_list_apply(alist, &p) == FILTER_PERMIT)
+			return RMAP_MATCH;
+	}
 	return RMAP_NOMATCH;
+}
+
+static enum route_map_cmd_result_t
+route_match_ip_next_hop(void *rule, const struct prefix *prefix, void *object)
+{
+	return route_match_next_hop(rule, prefix, object, AFI_IP);
+}
+
+static enum route_map_cmd_result_t
+route_match_ipv6_next_hop_access_list(void *rule, const struct prefix *prefix,
+				      void *object)
+{
+	return route_match_next_hop(rule, prefix, object, AFI_IP6);
 }
 
 /* Route map `ip next-hop' match statement. `arg' is
    access-list name. */
-static void *route_match_ip_next_hop_compile(const char *arg)
+static void *route_match_next_hop_compile(const char *arg)
 {
 	return XSTRDUP(MTYPE_ROUTE_MAP_COMPILED, arg);
 }
 
 /* Free route map's compiled `ip address' value. */
-static void route_match_ip_next_hop_free(void *rule)
+static void route_match_next_hop_free(void *rule)
 {
 	XFREE(MTYPE_ROUTE_MAP_COMPILED, rule);
 }
@@ -543,8 +579,15 @@ static void route_match_ip_next_hop_free(void *rule)
 static const struct route_map_rule_cmd route_match_ip_next_hop_cmd = {
 	"ip next-hop",
 	route_match_ip_next_hop,
-	route_match_ip_next_hop_compile,
-	route_match_ip_next_hop_free
+	route_match_next_hop_compile,
+	route_match_next_hop_free
+};
+
+static const struct route_map_rule_cmd route_match_ipv6_next_hop_list_cmd = {
+	"ipv6 next-hop access-list",
+	route_match_ipv6_next_hop_access_list,
+	route_match_next_hop_compile,
+	route_match_next_hop_free
 };
 
 /* `match ip route-source ACCESS-LIST' */
@@ -6419,6 +6462,9 @@ void bgp_route_map_init(void)
 	route_map_match_ipv6_address_prefix_list_hook(generic_match_add);
 	route_map_no_match_ipv6_address_prefix_list_hook(generic_match_delete);
 
+	route_map_match_ipv6_next_hop_hook(generic_match_add);
+	route_map_no_match_ipv6_next_hop_hook(generic_match_delete);
+
 	route_map_match_ipv6_next_hop_prefix_list_hook(generic_match_add);
 	route_map_no_match_ipv6_next_hop_prefix_list_hook(generic_match_delete);
 
@@ -6454,6 +6500,7 @@ void bgp_route_map_init(void)
 #endif
 	route_map_install_match(&route_match_ip_address_cmd);
 	route_map_install_match(&route_match_ip_next_hop_cmd);
+	route_map_install_match(&route_match_ipv6_next_hop_list_cmd);
 	route_map_install_match(&route_match_ip_route_source_cmd);
 	route_map_install_match(&route_match_ip_address_prefix_list_cmd);
 	route_map_install_match(&route_match_ip_next_hop_prefix_list_cmd);

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -159,6 +159,24 @@ void route_map_no_match_ip_next_hop_hook(int (*func)(
 	rmap_match_set_hook.no_match_ip_next_hop = func;
 }
 
+/* match ipv6 next-hop */
+void route_map_match_ipv6_next_hop_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len))
+{
+	rmap_match_set_hook.match_ipv6_next_hop = func;
+}
+
+/* no match ipv6 next-hop */
+void route_map_no_match_ipv6_next_hop_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len))
+{
+	rmap_match_set_hook.no_match_ipv6_next_hop = func;
+}
+
 /* match ip next hop prefix list */
 void route_map_match_ip_next_hop_prefix_list_hook(int (*func)(
 	struct route_map_index *index, const char *command,

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -232,6 +232,24 @@ void route_map_no_match_ipv6_address_prefix_list_hook(int (*func)(
 	rmap_match_set_hook.no_match_ipv6_address_prefix_list = func;
 }
 
+/* match ipv6 next-hop prefix-list */
+void route_map_match_ipv6_next_hop_prefix_list_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len))
+{
+	rmap_match_set_hook.match_ipv6_next_hop_prefix_list = func;
+}
+
+/* no match ipv6 next-hop prefix-list */
+void route_map_no_match_ipv6_next_hop_prefix_list_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len))
+{
+	rmap_match_set_hook.no_match_ipv6_next_hop_prefix_list = func;
+}
+
 /* match ipv6 next-hop type */
 void route_map_match_ipv6_next_hop_type_hook(int (*func)(
 	struct route_map_index *index, const char *command,

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -243,6 +243,8 @@ DECLARE_QOBJ_TYPE(route_map);
 	(strmatch(C, "frr-route-map:ipv6-address-list"))
 #define IS_MATCH_IPv4_NEXTHOP_LIST(C)                                          \
 	(strmatch(C, "frr-route-map:ipv4-next-hop-list"))
+#define IS_MATCH_IPv6_NEXTHOP_LIST(C)                                          \
+	(strmatch(C, "frr-route-map:ipv6-next-hop-list"))
 #define IS_MATCH_IPv4_PREFIX_LIST(C)                                           \
 	(strmatch(C, "frr-route-map:ipv4-prefix-list"))
 #define IS_MATCH_IPv6_PREFIX_LIST(C)                                           \
@@ -565,6 +567,16 @@ extern void route_map_no_match_ipv6_address_prefix_list_hook(int (*func)(
 	struct route_map_index *index, const char *command,
 	const char *arg, route_map_event_t type,
 	char *errmsg, size_t errmsg_len));
+/* match ipv6 next hop */
+extern void route_map_match_ipv6_next_hop_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len));
+/* no match ipv6 next hop */
+extern void route_map_no_match_ipv6_next_hop_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len));
 /* match ipv6 next hop prefix list */
 extern void route_map_match_ipv6_next_hop_prefix_list_hook(int (*func)(
 	struct route_map_index *index, const char *command,
@@ -778,6 +790,18 @@ struct route_map_match_set_hooks {
 						 route_map_event_t type,
 						 char *errmsg,
 						 size_t errmsg_len);
+
+	/* match ipv6 next-hop */
+	int (*match_ipv6_next_hop)(struct route_map_index *index,
+				   const char *command, const char *arg,
+				   route_map_event_t type, char *errmsg,
+				   size_t errmsg_len);
+
+	/* no match ipv6 next-hop */
+	int (*no_match_ipv6_next_hop)(struct route_map_index *index,
+				      const char *command, const char *arg,
+				      route_map_event_t type, char *errmsg,
+				      size_t errmsg_len);
 
 	/* match ipv6 next-hop prefix-list */
 	int (*match_ipv6_next_hop_prefix_list)(struct route_map_index *index,

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -249,6 +249,8 @@ DECLARE_QOBJ_TYPE(route_map);
 	(strmatch(C, "frr-route-map:ipv6-prefix-list"))
 #define IS_MATCH_IPv4_NEXTHOP_PREFIX_LIST(C)                                   \
 	(strmatch(C, "frr-route-map:ipv4-next-hop-prefix-list"))
+#define IS_MATCH_IPv6_NEXTHOP_PREFIX_LIST(C)                                   \
+	(strmatch(C, "frr-route-map:ipv6-next-hop-prefix-list"))
 #define IS_MATCH_IPv4_NEXTHOP_TYPE(C)                                          \
 	(strmatch(C, "frr-route-map:ipv4-next-hop-type"))
 #define IS_MATCH_IPv6_NEXTHOP_TYPE(C)                                          \
@@ -563,6 +565,16 @@ extern void route_map_no_match_ipv6_address_prefix_list_hook(int (*func)(
 	struct route_map_index *index, const char *command,
 	const char *arg, route_map_event_t type,
 	char *errmsg, size_t errmsg_len));
+/* match ipv6 next hop prefix list */
+extern void route_map_match_ipv6_next_hop_prefix_list_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len));
+/* no match ipv6 next hop prefix list */
+extern void route_map_no_match_ipv6_next_hop_prefix_list_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len));
 /* match ipv6 next-hop type */
 extern void route_map_match_ipv6_next_hop_type_hook(int (*func)(
 	struct route_map_index *index, const char *command,
@@ -766,6 +778,21 @@ struct route_map_match_set_hooks {
 						 route_map_event_t type,
 						 char *errmsg,
 						 size_t errmsg_len);
+
+	/* match ipv6 next-hop prefix-list */
+	int (*match_ipv6_next_hop_prefix_list)(struct route_map_index *index,
+					       const char *command,
+					       const char *arg,
+					       route_map_event_t type,
+					       char *errmsg, size_t errmsg_len);
+
+	/* no match ipv6 next-hop prefix-list */
+	int (*no_match_ipv6_next_hop_prefix_list)(struct route_map_index *index,
+						  const char *command,
+						  const char *arg,
+						  route_map_event_t type,
+						  char *errmsg,
+						  size_t errmsg_len);
 
 	/* match ipv6 next-hop type */
 	int (*match_ipv6_next_hop_type)(struct route_map_index *index,

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -326,6 +326,47 @@ DEFPY_YANG(
 }
 
 DEFPY_YANG(
+	match_ipv6_next_hop_prefix_list,
+	match_ipv6_next_hop_prefix_list_cmd,
+	"match ipv6 next-hop prefix-list WORD$name",
+	MATCH_STR
+	IPV6_STR
+	"Match next-hop address of route\n"
+	"Match entries of prefix-lists\n"
+	"IP prefix-list name\n")
+{
+	const char *xpath =
+		"./match-condition[condition='frr-route-map:ipv6-next-hop-prefix-list']";
+	char xpath_value[XPATH_MAXLEN];
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+	snprintf(xpath_value, sizeof(xpath_value),
+		 "%s/rmap-match-condition/list-name", xpath);
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, name);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG(
+	no_match_ipv6_next_hop_prefix_list,
+	no_match_ipv6_next_hop_prefix_list_cmd,
+	"no match ipv6 next-hop prefix-list [WORD]",
+	NO_STR
+	MATCH_STR
+	IPV6_STR
+	"Match next-hop address of route\n"
+	"Match entries of prefix-lists\n"
+	"IP prefix-list name\n")
+{
+	const char *xpath =
+		"./match-condition[condition='frr-route-map:ipv6-next-hop-prefix-list']";
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG(
 	match_ip_next_hop_type, match_ip_next_hop_type_cmd,
 	"match ip next-hop type <blackhole>$type",
 	MATCH_STR
@@ -584,6 +625,10 @@ void route_map_condition_show(struct vty *vty, struct lyd_node *dnode,
 				dnode, "./rmap-match-condition/list-name"));
 	} else if (IS_MATCH_IPv6_PREFIX_LIST(condition)) {
 		vty_out(vty, " match ipv6 address prefix-list %s\n",
+			yang_dnode_get_string(
+				dnode, "./rmap-match-condition/list-name"));
+	} else if (IS_MATCH_IPv6_NEXTHOP_PREFIX_LIST(condition)) {
+		vty_out(vty, " match ipv6 next-hop prefix-list %s\n",
 			yang_dnode_get_string(
 				dnode, "./rmap-match-condition/list-name"));
 	} else if (IS_MATCH_IPv4_NEXTHOP_TYPE(condition)) {
@@ -1600,6 +1645,9 @@ void route_map_cli_init(void)
 
 	install_element(RMAP_NODE, &match_ipv6_address_prefix_list_cmd);
 	install_element(RMAP_NODE, &no_match_ipv6_address_prefix_list_cmd);
+
+	install_element(RMAP_NODE, &match_ipv6_next_hop_prefix_list_cmd);
+	install_element(RMAP_NODE, &no_match_ipv6_next_hop_prefix_list_cmd);
 
 	install_element(RMAP_NODE, &match_ipv6_next_hop_type_cmd);
 	install_element(RMAP_NODE, &no_match_ipv6_next_hop_type_cmd);

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -285,6 +285,47 @@ DEFPY_YANG(
 }
 
 DEFPY_YANG(
+	match_ipv6_next_hop_list,
+	match_ipv6_next_hop_list_cmd,
+	"match ipv6 next-hop access-list WORD$name",
+	MATCH_STR
+	IPV6_STR
+	"Match next-hop address of route\n"
+	"Match entries of an access-list\n"
+	"IPv6 access-list name\n")
+{
+	const char *xpath =
+		"./match-condition[condition='frr-route-map:ipv6-next-hop-list']";
+	char xpath_value[XPATH_MAXLEN + 32];
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+	snprintf(xpath_value, sizeof(xpath_value),
+		 "%s/rmap-match-condition/list-name", xpath);
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, name);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG(
+	no_match_ipv6_next_hop_list,
+	no_match_ipv6_next_hop_list_cmd,
+	"no match ipv6 next-hop access-list [WORD]",
+	NO_STR
+	MATCH_STR
+	IPV6_STR
+	"Match address of route\n"
+	"Match entries of an access-list\n"
+	"IPv6 access-list name\n")
+{
+	const char *xpath =
+		"./match-condition[condition='frr-route-map:ipv6-next-hop-list']";
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG(
 	match_ip_next_hop_prefix_list,
 	match_ip_next_hop_prefix_list_cmd,
 	"match ip next-hop prefix-list WORD$name",
@@ -625,6 +666,10 @@ void route_map_condition_show(struct vty *vty, struct lyd_node *dnode,
 				dnode, "./rmap-match-condition/list-name"));
 	} else if (IS_MATCH_IPv6_PREFIX_LIST(condition)) {
 		vty_out(vty, " match ipv6 address prefix-list %s\n",
+			yang_dnode_get_string(
+				dnode, "./rmap-match-condition/list-name"));
+	} else if (IS_MATCH_IPv6_NEXTHOP_LIST(condition)) {
+		vty_out(vty, " match ipv6 next-hop access-list %s\n",
 			yang_dnode_get_string(
 				dnode, "./rmap-match-condition/list-name"));
 	} else if (IS_MATCH_IPv6_NEXTHOP_PREFIX_LIST(condition)) {
@@ -1645,6 +1690,9 @@ void route_map_cli_init(void)
 
 	install_element(RMAP_NODE, &match_ipv6_address_prefix_list_cmd);
 	install_element(RMAP_NODE, &no_match_ipv6_address_prefix_list_cmd);
+
+	install_element(RMAP_NODE, &match_ipv6_next_hop_list_cmd);
+	install_element(RMAP_NODE, &no_match_ipv6_next_hop_list_cmd);
 
 	install_element(RMAP_NODE, &match_ipv6_next_hop_prefix_list_cmd);
 	install_element(RMAP_NODE, &no_match_ipv6_next_hop_prefix_list_cmd);

--- a/lib/routemap_northbound.c
+++ b/lib/routemap_northbound.c
@@ -612,6 +612,17 @@ static int lib_route_map_entry_match_condition_list_name_modify(
 			rhc->rhc_rmi, "ip next-hop prefix-list", acl,
 			RMAP_EVENT_PLIST_ADDED,
 			args->errmsg, args->errmsg_len);
+	} else if (IS_MATCH_IPv6_NEXTHOP_LIST(condition)) {
+		if (rmap_match_set_hook.match_ipv6_next_hop == NULL)
+			return NB_OK;
+		rhc->rhc_mhook =
+			rmap_match_set_hook.no_match_ipv6_next_hop;
+		rhc->rhc_rule = "ipv6 next-hop";
+		rhc->rhc_event = RMAP_EVENT_PLIST_DELETED;
+		rv = rmap_match_set_hook.match_ipv6_next_hop(
+			rhc->rhc_rmi, "ipv6 next-hop", acl,
+			RMAP_EVENT_PLIST_ADDED,
+			args->errmsg, args->errmsg_len);
 	} else if (IS_MATCH_IPv6_NEXTHOP_PREFIX_LIST(condition)) {
 		if (rmap_match_set_hook.match_ipv6_next_hop_prefix_list == NULL)
 			return NB_OK;

--- a/lib/routemap_northbound.c
+++ b/lib/routemap_northbound.c
@@ -612,6 +612,17 @@ static int lib_route_map_entry_match_condition_list_name_modify(
 			rhc->rhc_rmi, "ip next-hop prefix-list", acl,
 			RMAP_EVENT_PLIST_ADDED,
 			args->errmsg, args->errmsg_len);
+	} else if (IS_MATCH_IPv6_NEXTHOP_PREFIX_LIST(condition)) {
+		if (rmap_match_set_hook.match_ipv6_next_hop_prefix_list == NULL)
+			return NB_OK;
+		rhc->rhc_mhook =
+			rmap_match_set_hook.no_match_ipv6_next_hop_prefix_list;
+		rhc->rhc_rule = "ipv6 next-hop prefix-list";
+		rhc->rhc_event = RMAP_EVENT_PLIST_DELETED;
+		rv = rmap_match_set_hook.match_ipv6_next_hop_prefix_list(
+			rhc->rhc_rmi, "ipv6 next-hop prefix-list", acl,
+			RMAP_EVENT_PLIST_ADDED,
+			args->errmsg, args->errmsg_len);
 	} else if (IS_MATCH_IPv6_ADDRESS_LIST(condition)) {
 		if (rmap_match_set_hook.match_ipv6_address == NULL)
 			return NB_OK;

--- a/yang/frr-route-map.yang
+++ b/yang/frr-route-map.yang
@@ -106,6 +106,12 @@ module frr-route-map {
       "Match an IPv6 prefix-list";
   }
 
+  identity ipv6-next-hop-list {
+    base rmap-match-type;
+    description
+      "Match an IPv6 next-hop";
+  }
+
   identity ipv6-next-hop-prefix-list {
     base rmap-match-type;
     description
@@ -207,6 +213,7 @@ module frr-route-map {
              + "derived-from-or-self(../condition, 'ipv4-next-hop-prefix-list') or "
              + "derived-from-or-self(../condition, 'ipv6-address-list') or "
              + "derived-from-or-self(../condition, 'ipv6-prefix-list') or "
+             + "derived-from-or-self(../condition, 'ipv6-next-hop-list') or "
              + "derived-from-or-self(../condition, 'ipv6-next-hop-prefix-list')";
           leaf list-name {
             type filter:access-list-name;

--- a/yang/frr-route-map.yang
+++ b/yang/frr-route-map.yang
@@ -106,6 +106,12 @@ module frr-route-map {
       "Match an IPv6 prefix-list";
   }
 
+  identity ipv6-next-hop-prefix-list {
+    base rmap-match-type;
+    description
+      "Match an IPv6 next-hop prefix list";
+  }
+
   identity ipv6-next-hop-type {
     base rmap-match-type;
     description
@@ -200,7 +206,8 @@ module frr-route-map {
              + "derived-from-or-self(../condition, 'ipv4-next-hop-list') or "
              + "derived-from-or-self(../condition, 'ipv4-next-hop-prefix-list') or "
              + "derived-from-or-self(../condition, 'ipv6-address-list') or "
-             + "derived-from-or-self(../condition, 'ipv6-prefix-list')";
+             + "derived-from-or-self(../condition, 'ipv6-prefix-list') or "
+             + "derived-from-or-self(../condition, 'ipv6-next-hop-prefix-list')";
           leaf list-name {
             type filter:access-list-name;
           }


### PR DESCRIPTION
The changes add access- and prefix-lists as a next-hop match criteria to ipv6 route-maps.

Original Author: David Lamparter <equinox@opensourcerouting.org>
Signed-off-by: David Schweizer <dschweizer@opensourcerouting.org>