### PR TITLE
tests: remove python format block from dir-locals

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -5,6 +5,4 @@
 ((c-mode . ((indent-tabs-mode . t)
             (show-trailing-whitespace . t)
             (c-basic-offset . 8)))
- (json-mode . ((js-indent-level 4)))
- (python-mode . ((python-formatter . black)
-                 (python-fill-column . 88))))
+ (json-mode . ((js-indent-level 4))))


### PR DESCRIPTION
Remove the python block from the local emacs settings file .dir-locals.el.
