### PR TITLE
tests: remove unnecessary setting of l3mdev_accept

### DIFF
--- a/tests/topotests/bgp_evpn_overlay_index_gateway/test_bgp_evpn_overlay_index_gateway.py
+++ b/tests/topotests/bgp_evpn_overlay_index_gateway/test_bgp_evpn_overlay_index_gateway.py
@@ -128,12 +128,6 @@ def setup_module(mod):
         )
         return
 
-    if topotest.version_cmp(kernelv, "4.15") == 0:
-        l3mdev_accept = 1
-        logger.info("setting net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept))
-    else:
-        l3mdev_accept = 0
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start deamons and then start routers
     tgen.start_topology()
@@ -189,8 +183,6 @@ def setup_module(mod):
 
         pe.cmd_raises("sysctl -w net.ipv4.ip_forward=1")
         pe.cmd_raises("sysctl -w net.ipv6.conf.all.forwarding=1")
-        pe.cmd_raises("sysctl -w net.ipv4.udp_l3mdev_accept={}".format(l3mdev_accept))
-        pe.cmd_raises("sysctl -w net.ipv4.tcp_l3mdev_accept={}".format(l3mdev_accept))
 
     # For all registred routers, load the zebra configuration file
     for (name, router) in tgen.routers().items():


### PR DESCRIPTION
We don't needed since vrf_bind is correctly implemented.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>