### PR TITLE
bgpd: Update route-type-1 legend to match output

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -358,7 +358,7 @@ static void bgp_evpn_show_route_header(struct vty *vty, struct bgp *bgp,
 		"Status codes: s suppressed, d damped, h history, * valid, > best, i - internal\n");
 	vty_out(vty, "Origin codes: i - IGP, e - EGP, ? - incomplete\n");
 	vty_out(vty,
-		"EVPN type-1 prefix: [1]:[ESI]:[EthTag]:[IPlen]:[VTEP-IP]\n");
+		"EVPN type-1 prefix: [1]:[EthTag]:[ESI]:[IPlen]:[VTEP-IP]\n");
 	vty_out(vty,
 		"EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]\n");
 	vty_out(vty, "EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]\n");

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2723,7 +2723,7 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 			/* RD header and legend - once overall. */
 			if (rd_header && !json) {
 				vty_out(vty,
-					"EVPN type-1 prefix: [1]:[ESI]:[EthTag]:[IPlen]:[VTEP-IP]\n");
+					"EVPN type-1 prefix: [1]:[EthTag]:[ESI]:[IPlen]:[VTEP-IP]\n");
 				vty_out(vty,
 					"EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]\n");
 				vty_out(vty,


### PR DESCRIPTION
Currently the route-type-1 output has the Ethernet Tag printed first and
not the ESI.

However the legend has the opposite format. Changing the output would be more disruptive, hence changing the legend. 

For eg:
Current legend:
EVPN type-1 prefix: [1]:[ESI]:[EthTag]:[IPlen]:[VTEP-IP]
*> [1]:[0]:[03:44:38:39:ff:ff:01:00:00:01]:[32]:[192.168.100.2]
                    192.168.100.2                          0 65002 i
                    RT:65002:100 ET:8
*> [1]:[0]:[03:44:38:39:ff:ff:01:00:00:01]:[32]:[192.168.100.3]
                    192.168.100.3                          0 65003 i
                    RT:65003:100 ET:8

Signed-off-by: Aaron Pereira <aaronpereira88@gmail.com>