### PR TITLE
bgpd: fix coverity warning

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -798,6 +798,9 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 
 	bgp_attr_default_set(&attr, BGP_ORIGIN_IGP);
 
+	/* make coverity happy */
+	assert(attr.aspath);
+
 	attr.local_pref = bgp->default_local_pref;
 
 	if ((afi == AFI_IP6) || peer_cap_enhe(peer, afi, safi)) {


### PR DESCRIPTION
CID 1506874.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>