### PR TITLE
ospf6d: fix possible NULL dereference

### DIFF
--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -1155,7 +1155,10 @@ DEFPY(show_ipv6_ospf6_gr_helper,
 	bool detail = false;
 
 	ospf6 = ospf6_lookup_by_vrf_name(VRF_DEFAULT_NAME);
-	OSPF6_CMD_CHECK_RUNNING();
+	if (ospf6 == NULL) {
+		vty_out(vty, "OSPFv3 is not configured\n");
+		return CMD_SUCCESS;
+	}
 
 	if (argv_find(argv, argc, "detail", &idx))
 		detail = true;


### PR DESCRIPTION
OSPF6_CMD_CHECK_RUNNING doesn't check that ospf6 is not NULL.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>