### PR TITLE
vtysh command sorting fixes and improvements

### DIFF
--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -298,34 +298,12 @@ void vtysh_config_parse_line(void *arg, const char *line)
 					config_add_line_uniq(config->line,
 							     line);
 				}
-			} else if (strncmp(line, " link-params",
-					   strlen(" link-params"))
-				   == 0) {
-				config_add_line(config->line, line);
-				config->index = LINK_PARAMS_NODE;
-			} else if (strncmp(line, " ip multicast boundary",
-					   strlen(" ip multicast boundary"))
-				   == 0) {
-				config_add_line_uniq_end(config->line, line);
-			} else if (strncmp(line, " ip igmp query-interval",
-					   strlen(" ip igmp query-interval"))
-				   == 0) {
-				config_add_line_uniq_end(config->line, line);
-			} else if (config->index == LINK_PARAMS_NODE
-				   && strncmp(line, " exit-link-params",
-					      strlen(" exit"))
+			} else if (config->index == INTERFACE_NODE
+				   && strncmp(line, " description ",
+					      strlen(" description "))
 					      == 0) {
-				config_add_line(config->line, line);
-				config->index = INTERFACE_NODE;
-			} else if (!strncmp(line, " vrrp", strlen(" vrrp"))
-				   || !strncmp(line, " no vrrp",
-					       strlen(" no vrrp"))) {
-				config_add_line(config->line, line);
-			} else if (!strncmp(line, " ip mroute",
-					    strlen(" ip mroute"))) {
-				config_add_line_uniq_end(config->line, line);
+				config_add_line_uniq(config->line, line);
 			} else if (config->index == RMAP_NODE
-				   || config->index == INTERFACE_NODE
 				   || config->index == VTY_NODE
 				   || config->index == NH_GROUP_NODE)
 				config_add_line_uniq(config->line, line);


### PR DESCRIPTION
```
vtysh: simplify interface node command processing

Currently, we call `config_add_line_uniq` for commands in the interface
node to get rid of duplicates in the config. This function not only
filters duplicates, but also sorts the commands. At the same time, there
are some order dependent commands that we obviously don't want to sort.
Hence we maintain a list of such commands and add them without sorting.

Instead of this complicated logic we can simply never sort commands in
the interface node. The only command that needs to be checked for
duplicity is "description" - so let's check it and remove all other
daemon-dependent checks.
```
```
vtysh: remove sorting of vrf node commands

A simple strcmp-based sorting done by `config_add_line_uniq` breaks the
correct advanced sorting of static routes done by staticd. We don't
actually need to check vrf node commands for uniqueness as all commands
are daemon specific, so let's use simple `config_add_line` that doesn't
sort commands.
```