### PR TITLE
bgpd: fix memory leaks when using route-maps

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10806,6 +10806,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				path.attr = &dummy_attr;
 
 				ret = route_map_apply(rmap, dest_p, &path);
+				bgp_attr_flush(&dummy_attr);
 				if (ret == RMAP_DENYMATCH)
 					continue;
 			}


### PR DESCRIPTION
There are places where we use route-maps using duplicated attributes and
neither intern nor flush them after the usage. If a route-map has set
rules for aspath/communities, they will be allocated and never freed.
We should always flush unneeded duplicated attributes.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>