### PR TITLE
vtysh: fork() on boot

### DIFF
--- a/doc/manpages/vtysh.rst
+++ b/doc/manpages/vtysh.rst
@@ -67,6 +67,11 @@ OPTIONS available for the vtysh command:
 
    Display a usage message on standard output and exit.
 
+.. option:: --no-fork
+
+   When used in conjunction with ``-b``, prevents vtysh from forking children to handle configuring each target daemon.
+
+
 ENVIRONMENT VARIABLES
 =====================
 VTYSH_PAGER

--- a/doc/manpages/vtysh.rst
+++ b/doc/manpages/vtysh.rst
@@ -67,6 +67,10 @@ OPTIONS available for the vtysh command:
 
    Display a usage message on standard output and exit.
 
+.. option:: -t, --timestamp
+
+   Print a timestamp before going to shell or reading the configuration file.
+
 .. option:: --no-fork
 
    When used in conjunction with ``-b``, prevents vtysh from forking children to handle configuring each target daemon.

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3445,7 +3445,7 @@ DEFUN (vtysh_copy_to_running,
 	int ret;
 	const char *fname = argv[1]->arg;
 
-	ret = vtysh_read_config(fname, true);
+	ret = vtysh_apply_config(fname, true, false);
 
 	/* Return to enable mode - the 'read_config' api leaves us up a level */
 	vtysh_execute_no_pager("enable");

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -148,8 +148,6 @@ struct vtysh_client vtysh_client[] = {
 	{.name = "pim6d", .flag = VTYSH_PIM6D},
 };
 
-char my_client[64];
-
 /* Searches for client by name, returns index */
 static int vtysh_client_lookup(const char *name)
 {

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -63,18 +63,6 @@ char *vtysh_pager_name = NULL;
 /* VTY should add timestamp */
 bool vtysh_add_timestamp;
 
-/* VTY shell client structure */
-struct vtysh_client {
-	int fd;
-	const char *name;
-	int flag;
-	char path[MAXPATHLEN];
-	struct vtysh_client *next;
-
-	struct thread *log_reader;
-	int log_fd;
-};
-
 static bool stderr_tty;
 static bool stderr_stdout_same;
 
@@ -132,6 +120,10 @@ static void vtysh_pager_envdef(bool fallback)
 
 /* --- */
 
+/*
+ * When updating this array, remember to change the array size here and in
+ * vtysh.h
+ */
 struct vtysh_client vtysh_client[] = {
 	{.name = "zebra", .flag = VTYSH_ZEBRA},
 	{.name = "ripd", .flag = VTYSH_RIPD},
@@ -155,6 +147,8 @@ struct vtysh_client vtysh_client[] = {
 	{.name = "pathd", .flag = VTYSH_PATHD},
 	{.name = "pim6d", .flag = VTYSH_PIM6D},
 };
+
+char my_client[64];
 
 /* Searches for client by name, returns index */
 static int vtysh_client_lookup(const char *name)

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -100,7 +100,7 @@ void config_add_line(struct list *, const char *);
 
 int vtysh_mark_file(const char *filename);
 
-int vtysh_read_config(const char *filename, bool dry_run);
+int vtysh_apply_config(const char *config_file_path, bool dry_run, bool fork);
 int vtysh_write_config_integrated(void);
 
 void vtysh_config_parse_line(void *, const char *);

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -52,6 +52,22 @@ extern struct thread_master *master;
 
 #define VTYSH_WAS_ACTIVE (-2)
 
+
+/*
+ * When VTYSH is run in fork mode, where it forks one child per daemon to send
+ * configuration, we have to summarize the exit codes of the child processes
+ * into a single exit code returned by the VTYSH parent process. The following
+ * return codes are used in fork mode to summarize the state of child processes
+ * in the case where one or more do not exit successfully (nonzero exit).
+ */
+
+/* One or more children exited with an error */
+#define VTYSH_EXIT_MULTI_CHILD_ERROR 254
+
+/* One or more children were killed by a signal or crashed */
+#define VTYSH_EXIT_CHILD_ABNORMAL 255
+
+
 /* commands in REALLYALL are crucial to correct vtysh operation */
 #define VTYSH_REALLYALL	  ~0U
 /* watchfrr is not in ALL since library CLI functions should not be

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -133,6 +133,5 @@ struct vtysh_client {
 };
 
 extern struct vtysh_client vtysh_client[21];
-extern char my_client[64];
 
 #endif /* VTYSH_H */

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -121,4 +121,18 @@ extern int user_mode;
 
 extern bool vtysh_add_timestamp;
 
+struct vtysh_client {
+	int fd;
+	const char *name;
+	int flag;
+	char path[MAXPATHLEN];
+	struct vtysh_client *next;
+
+	struct thread *log_reader;
+	int log_fd;
+};
+
+extern struct vtysh_client vtysh_client[21];
+extern char my_client[64];
+
 #endif /* VTYSH_H */

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -19,6 +19,7 @@
  */
 
 #include <zebra.h>
+#include <sys/wait.h>
 
 #include "command.h"
 #include "linklist.h"
@@ -608,18 +609,20 @@ static int vtysh_read_file(FILE *confp, bool dry_run)
 	return (ret);
 }
 
-/* Read up configuration file from config_default_dir. */
-int vtysh_read_config(const char *config_default_dir, bool dry_run)
+/*
+ * Read configuration file and send it to all connected daemons
+ */
+static int vtysh_read_config(const char *config_file_path, bool dry_run)
 {
 	FILE *confp = NULL;
 	bool save;
 	int ret;
 
-	confp = fopen(config_default_dir, "r");
+	confp = fopen(config_file_path, "r");
 	if (confp == NULL) {
 		fprintf(stderr,
 			"%% Can't open configuration file %s due to '%s'.\n",
-			config_default_dir, safe_strerror(errno));
+			config_file_path, safe_strerror(errno));
 		return CMD_ERR_NO_FILE;
 	}
 
@@ -631,7 +634,93 @@ int vtysh_read_config(const char *config_default_dir, bool dry_run)
 
 	vtysh_add_timestamp = save;
 
-	return (ret);
+	return ret;
+}
+
+int vtysh_apply_config(const char *config_file_path, bool dry_run, bool do_fork)
+{
+	/*
+	 * We need to apply the whole config file to all daemons. Instead of
+	 * having one client talk to N daemons, we fork N times and let each
+	 * child handle one daemon.
+	 */
+	pid_t fork_pid = getpid();
+	int status = 0;
+	int ret;
+	int my_client_type;
+	char my_client[64];
+
+	if (do_fork) {
+		for (unsigned int i = 0; i < array_size(vtysh_client); i++) {
+			/* Store name of client this fork will handle */
+			strlcpy(my_client, vtysh_client[i].name,
+				sizeof(my_client));
+			my_client_type = vtysh_client[i].flag;
+			fork_pid = fork();
+
+			/* If child, break */
+			if (fork_pid == 0)
+				break;
+		}
+
+		/* parent, wait for children */
+		if (fork_pid != 0) {
+			fprintf(stdout,
+				"Waiting for children to finish applying config...\n");
+			while (wait(&status) > 0)
+				;
+			return 0;
+		}
+
+		/*
+		 * children, grow up to be cowboys
+		 */
+		for (unsigned int i = 0; i < array_size(vtysh_client); i++) {
+			if (my_client_type != vtysh_client[i].flag) {
+				struct vtysh_client *cl;
+
+				/*
+				 * If this is a client we aren't responsible
+				 * for, disconnect
+				 */
+				for (cl = &vtysh_client[i]; cl; cl = cl->next) {
+					if (cl->fd >= 0)
+						close(cl->fd);
+					cl->fd = -1;
+				}
+			} else if (vtysh_client[i].fd == -1 &&
+				   vtysh_client[i].next == NULL) {
+				/*
+				 * If this is the client we are responsible
+				 * for, but we aren't already connected to that
+				 * client, that means the client isn't up in
+				 * the first place and we can exit early
+				 */
+				exit(0);
+			}
+		}
+
+		fprintf(stdout, "[%d|%s] sending configuration\n", getpid(),
+			my_client);
+	}
+
+	ret = vtysh_read_config(config_file_path, dry_run);
+
+	if (ret) {
+		if (do_fork)
+			fprintf(stderr,
+				"[%d|%s] Configuration file[%s] processing failure: %d\n",
+				getpid(), my_client, frr_config, ret);
+		else
+			fprintf(stderr,
+				"Configuration file[%s] processing failure: %d\n",
+				frr_config, ret);
+	} else if (do_fork) {
+		fprintf(stderr, "[%d|%s] done\n", getpid(), my_client);
+		exit(0);
+	}
+
+	return ret;
 }
 
 /* We don't write vtysh specific into file from vtysh. vtysh.conf should

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -171,6 +171,7 @@ static void usage(int status)
 		       "-u  --user               Run as an unprivileged user\n"
 		       "-w, --writeconfig        Write integrated config (frr.conf) and exit\n"
 		       "-H, --histfile           Override history file\n"
+		       "-t, --timestamp          Print a timestamp before going to shell or reading the configuration\n"
 		       "    --no-fork            Don't fork clients to handle daemons (slower for large configs)\n"
 		       "-h, --help               Display this help and exit\n\n"
 		       "Note that multiple commands may be executed from the command\n"

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -22,7 +22,6 @@
 
 #include <sys/un.h>
 #include <setjmp.h>
-#include <sys/wait.h>
 #include <pwd.h>
 #include <sys/file.h>
 #include <unistd.h>
@@ -365,8 +364,6 @@ int main(int argc, char **argv, char **env)
 	const char *pathspace_arg = NULL;
 	char pathspace[MAXPATHLEN] = "";
 	const char *histfile = NULL;
-	char my_client[64];
-	int my_client_type;
 
 	/* SUID: drop down to calling user & go back up when needed */
 	elevuid = geteuid();
@@ -517,7 +514,7 @@ int main(int argc, char **argv, char **env)
 		/* Read vtysh configuration file before connecting to daemons.
 		 * (file may not be readable to calling user in SUID mode) */
 		suid_on();
-		vtysh_read_config(vtysh_config, dryrun);
+		vtysh_apply_config(vtysh_config, dryrun, false);
 		suid_off();
 	}
 	/* Error code library system */
@@ -536,9 +533,9 @@ int main(int argc, char **argv, char **env)
 	/* Start execution only if not in dry-run mode */
 	if (dryrun && !cmd) {
 		if (inputfile) {
-			ret = vtysh_read_config(inputfile, dryrun);
+			ret = vtysh_apply_config(inputfile, dryrun, false);
 		} else {
-			ret = vtysh_read_config(frr_config, dryrun);
+			ret = vtysh_apply_config(frr_config, dryrun, false);
 		}
 
 		exit(ret);
@@ -617,10 +614,17 @@ int main(int argc, char **argv, char **env)
 		return vtysh_write_config_integrated();
 	}
 
-	if (inputfile) {
+	if (boot_flag)
+		inputfile = frr_config;
+
+	if (inputfile || boot_flag) {
 		vtysh_flock_config(inputfile);
-		ret = vtysh_read_config(inputfile, dryrun);
+		ret = vtysh_apply_config(inputfile, dryrun, !no_fork);
 		vtysh_unflock_config();
+
+		if (no_error)
+			ret = 0;
+
 		exit(ret);
 	}
 
@@ -737,106 +741,6 @@ int main(int argc, char **argv, char **env)
 
 		history_truncate_file(history_file, 1000);
 		exit(0);
-	}
-
-	/* Boot startup configuration file. */
-	if (boot_flag) {
-		/*
-		 * flock config file before fork. After fork, each child will
-		 * hold the same lock. The lock can be released by any one of
-		 * them but they will exit without releasing the lock - the
-		 * parent (us) will release it when they are done
-		 */
-		vtysh_flock_config(frr_config);
-
-		/*
-		 * In boot mode, we need to apply the whole config file to all
-		 * daemons. Instead of having one client talk to N daemons, we
-		 * fork N times and let each child handle one daemon.
-		 */
-		pid_t fork_pid = getpid();
-		int status = 0;
-
-		if (!no_fork) {
-			for (unsigned int i = 0; i < array_size(vtysh_client);
-			     i++) {
-				/* Store name of client this fork will handle */
-				strlcpy(my_client, vtysh_client[i].name,
-					sizeof(my_client));
-				my_client_type = vtysh_client[i].flag;
-				fork_pid = fork();
-
-				/* If child, break */
-				if (fork_pid == 0)
-					break;
-			}
-
-			/* parent, wait for children */
-			if (fork_pid != 0) {
-				fprintf(stdout,
-					"Waiting for children to finish applying config...\n");
-				while (wait(&status) > 0)
-					;
-				ret = 0;
-				goto boot_done;
-			}
-
-			/*
-			 * children, grow up to be cowboys
-			 */
-			for (unsigned int i = 0; i < array_size(vtysh_client);
-			     i++) {
-				if (my_client_type != vtysh_client[i].flag) {
-					struct vtysh_client *cl;
-
-					/*
-					 * If this is a client we aren't
-					 * responsible for, disconnect
-					 */
-					for (cl = &vtysh_client[i]; cl;
-					     cl = cl->next) {
-						if (cl->fd >= 0)
-							close(cl->fd);
-						cl->fd = -1;
-					}
-				} else if (vtysh_client[i].fd == -1
-					   && vtysh_client[i].next == NULL) {
-					/*
-					 * If this is the client we are
-					 * responsible for, but we aren't
-					 * already connected to that client,
-					 * that means the client isn't up in the
-					 * first place and we can exit early
-					 */
-					ret = 0;
-					goto boot_done;
-				}
-			}
-
-			fprintf(stdout, "[%d|%s] sending configuration\n",
-				getpid(), my_client);
-		}
-
-		ret = vtysh_read_config(frr_config, dryrun);
-		if (ret) {
-			if (!no_fork)
-				fprintf(stderr,
-					"[%d|%s] Configuration file[%s] processing failure: %d\n",
-					getpid(), my_client, frr_config, ret);
-			else
-				fprintf(stderr,
-					"Configuration file[%s] processing failure: %d\n",
-					frr_config, ret);
-			if (no_error)
-				ret = 0;
-		} else if (!no_fork) {
-			fprintf(stderr, "[%d|%s] done\n", getpid(), my_client);
-		}
-
-	boot_done:
-		if (fork_pid != 0)
-			vtysh_unflock_config();
-		exit(ret);
 	}
 
 	vtysh_readline_init();

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -171,6 +171,7 @@ static void usage(int status)
 		       "-u  --user               Run as an unprivileged user\n"
 		       "-w, --writeconfig        Write integrated config (frr.conf) and exit\n"
 		       "-H, --histfile           Override history file\n"
+		       "    --no-fork            Don't fork clients to handle daemons (slower for large configs)\n"
 		       "-h, --help               Display this help and exit\n\n"
 		       "Note that multiple commands may be executed from the command\n"
 		       "line by passing multiple -c args, or by embedding linefeed\n"
@@ -184,6 +185,7 @@ static void usage(int status)
 /* VTY shell options, we use GNU getopt library. */
 #define OPTION_VTYSOCK 1000
 #define OPTION_CONFDIR 1001
+#define OPTION_NOFORK 1002
 struct option longopts[] = {
 	{"boot", no_argument, NULL, 'b'},
 	/* For compatibility with older zebra/quagga versions */
@@ -203,6 +205,7 @@ struct option longopts[] = {
 	{"pathspace", required_argument, NULL, 'N'},
 	{"user", no_argument, NULL, 'u'},
 	{"timestamp", no_argument, NULL, 't'},
+	{"no-fork", no_argument, NULL, OPTION_NOFORK},
 	{0}};
 
 bool vtysh_loop_exited;
@@ -342,6 +345,7 @@ int main(int argc, char **argv, char **env)
 	int dryrun = 0;
 	int boot_flag = 0;
 	bool ts_flag = false;
+	bool no_fork = false;
 	const char *daemon_name = NULL;
 	const char *inputfile = NULL;
 	struct cmd_rec {
@@ -412,6 +416,9 @@ int main(int argc, char **argv, char **env)
 			ditch_suid = 1; /* option disables SUID */
 			snprintf(sysconfdir, sizeof(sysconfdir), "%s/", optarg);
 			break;
+		case OPTION_NOFORK:
+			no_fork = true;
+			break;
 		case 'N':
 			if (strchr(optarg, '/') || strchr(optarg, '.')) {
 				fprintf(stderr,
@@ -459,6 +466,10 @@ int main(int argc, char **argv, char **env)
 			break;
 		}
 	}
+
+	/* No need for forks if we're talking to 1 daemon */
+	if (daemon_name)
+		no_fork = true;
 
 	if (ditch_suid) {
 		elevuid = realuid;
@@ -727,19 +738,95 @@ int main(int argc, char **argv, char **env)
 
 	/* Boot startup configuration file. */
 	if (boot_flag) {
+		/*
+		 * flock config file before fork. After fork, each child will
+		 * hold the same lock. The lock can be released by any one of
+		 * them but they will exit without releasing the lock - the
+		 * parent (us) will release it when they are done
+		 */
 		vtysh_flock_config(frr_config);
+
+		/*
+		 * In boot mode, we need to apply the whole config file to all
+		 * daemons. Instead of having one client talk to N daemons, we
+		 * fork N times and let each child handle one daemon.
+		 */
+		pid_t fork_pid = getpid();
+		int status = 0;
+
+		if (!no_fork) {
+			for (unsigned int i = 0; i < array_size(vtysh_client);
+			     i++) {
+				/* Store name of client this fork will handle */
+				strlcpy(my_client, vtysh_client[i].name,
+					sizeof(my_client));
+				fork_pid = fork();
+
+				/* If child, break */
+				if (fork_pid == 0)
+					break;
+			}
+
+			/* parent, wait for children */
+			if (fork_pid != 0) {
+				fprintf(stdout,
+					"Waiting for children to finish applying config...\n");
+				while (wait(&status) > 0)
+					;
+				ret = 0;
+				goto boot_done;
+			}
+
+			/*
+			 * children, grow up to be cowboys
+			 */
+			for (unsigned int i = 0; i < array_size(vtysh_client);
+			     i++) {
+				if (strcmp(my_client, vtysh_client[i].name)) {
+					/*
+					 * If this is a client we aren't
+					 * responsible for, disconnect
+					 */
+					if (vtysh_client[i].fd >= 0)
+						close(vtysh_client[i].fd);
+					vtysh_client[i].fd = -1;
+				} else if (vtysh_client[i].fd == -1) {
+					/*
+					 * If this is the client we are
+					 * responsible for, but we aren't
+					 * already connected to that client,
+					 * that means the client isn't up in the
+					 * first place and we can exit early
+					 */
+					ret = 0;
+					goto boot_done;
+				}
+			}
+
+			fprintf(stdout, "[%d|%s] sending configuration\n",
+				getpid(), my_client);
+		}
+
 		ret = vtysh_read_config(frr_config, dryrun);
-		vtysh_unflock_config();
 		if (ret) {
-			fprintf(stderr,
-				"Configuration file[%s] processing failure: %d\n",
-				frr_config, ret);
-			if (no_error)
-				exit(0);
+			if (!no_fork)
+				fprintf(stderr,
+					"[%d|%s] Configuration file[%s] processing failure: %d\n",
+					getpid(), my_client, frr_config, ret);
 			else
-				exit(ret);
-		} else
-			exit(0);
+				fprintf(stderr,
+					"Configuration file[%s] processing failure: %d\n",
+					frr_config, ret);
+			if (no_error)
+				ret = 0;
+		} else if (!no_fork) {
+			fprintf(stderr, "[%d|%s] done\n", getpid(), my_client);
+		}
+
+	boot_done:
+		if (fork_pid != 0)
+			vtysh_unflock_config();
+		exit(ret);
 	}
 
 	vtysh_readline_init();


### PR DESCRIPTION
When using -b flag to apply config to all running daemons, fork a copy of vtysh for each daemon we need to configure instead of doing them one at a time. This is about N times faster when you have N daemons.

Motivation for this work is that we noticed a particularly degenerate case with an...interesting configuration file that is 30,000 lines long. Applying this config with `vtysh -b` took about 10 seconds when just one daemon was running, but with several running it took close to 60 seconds. Currently vtysh is structured so that it reads each config line and sends it to each interested daemon one at a time, waiting for their response before moving to the next one, like so:

```
for line in config:
  for daemon in daemons:
    send(daemon, line)
    response = read(daemon)
```

In the boot case, our objective is to dump the entire config to all daemons as fast as possible and then exit. For this objective there's no reason that we can't just fork off a child to handle each daemon, ensuring that the daemons are never idle while their cohorts are behind fed config like so:

```
let my_daemon;

for daemon in daemons:
  my_daemon = daemon;
  if (fork() == child)
    break

if (parent)
  wait_for_all_children()
else
  apply_config(my_daemon)
```

Doing this results in a significant performance improvement, numbers follow.

---

Config
```
# wc -l /etc/frr/frr.conf
30730 /etc/frr/frr.conf
```

Daemons
```
root@archlinux /h/vagrant# ps -fu frr
UID          PID    PPID  C STIME TTY          TIME CMD
frr        40598       1 12 17:31 ?        00:01:11 /usr/lib/frr/zebra -d
frr        40610       1 11 17:31 ?        00:01:04 /usr/lib/frr/bgpd -d
frr        40627       1  0 17:31 ?        00:00:00 /usr/lib/frr/staticd -d
frr        40779       1  0 17:40 ?        00:00:00 /usr/lib/frr/ospfd -d
frr        40801       1  0 17:40 ?        00:00:00 /usr/lib/frr/ospf6d -d
```

### No fork

`-s/--single` is the new option to force the old behavior of not forking.

```
root@archlinux /h/vagrant# time vtysh -sb
________________________________________________________
Executed in   66.75 secs    fish           external
   usr time    2.28 secs  770.00 micros    2.28 secs
   sys time    2.56 secs  602.00 micros    2.56 secs
```

Process core saturation
![2021-09-15_17-44](https://user-images.githubusercontent.com/6827003/133514800-ec57e68f-cf8e-4054-b90b-4a614642e36e.png)

### Forking

Note the new output.

```
root@archlinux /h/vagrant# time vtysh -b
[40935|zebra] sending configuration
[40938|ospfd] sending configuration
[40939|ospf6d] sending configuration
[40941|bgpd] sending configuration
[40951|staticd] sending configuration
Waiting for children to finish applying config...
[40951|staticd] done
[40941|bgpd] done
[40939|ospf6d] done
[40938|ospfd] done
[40935|zebra] done

________________________________________________________
Executed in   18.97 secs    fish           external
   usr time    7.66 secs    0.00 millis    7.66 secs
   sys time    2.21 secs    1.54 millis    2.21 secs
```

Process saturation (`staticd` had already finished because the bulk of the config did not need to be sent to it)
![2021-09-15_17-56](https://user-images.githubusercontent.com/6827003/133515291-61a69fad-c7be-4b71-892f-ed1df234bdd5.png)

