### PR TITLE
tests: Fix make check builds on some bsd variants

### DIFF
--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -310,7 +310,7 @@ static int setup_bgp_path_info_mpath_update(testcase_t *t)
 	str2prefix("42.1.1.0/24", &test_rn.p);
 	rt_node = bgp_dest_to_rnode(&test_rn);
 	memcpy((struct route_table *)&rt_node->table, &rt->route_table,
-	       sizeof(struct route_table *));
+	       sizeof(struct route_table));
 	setup_bgp_mp_list(t);
 	for (i = 0; i < test_mp_list_info_count; i++)
 		bgp_path_info_add(&test_rn, &test_mp_list_info[i]);


### PR DESCRIPTION
Compilation is warning that a memcpy is only copying
the first (sizeof pointer) into memory.  This is not
what we really want.  Although it does beg the question about
why this memcpy is needed( or what it is doing ).  I'm going
to just fix the memcpy and call it a day.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>