### PR TITLE
bgpd: Allow v6 LL peers to work when connected to as well

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -46,6 +46,7 @@
 #include "bgpd/bgp_errors.h"
 #include "bgpd/bgp_network.h"
 #include "bgpd/bgp_zebra.h"
+#include "bgpd/bgp_nht.h"
 
 extern struct zebra_privs_t bgpd_privs;
 
@@ -602,6 +603,12 @@ static int bgp_accept(struct thread *thread)
 		else
 			BGP_EVENT_ADD(peer, TCP_connection_open);
 	}
+
+	/*
+	 * If we are doing nht for a peer that is v6 LL based
+	 * massage the event system to make things happy
+	 */
+	bgp_nht_interface_events(peer);
 
 	return 0;
 }


### PR DESCRIPTION
Initial commit: 8761cd6ddb5437767625f58c8e9cc3ccda7887ab

introduced the idea of v6 LL using interface up/down events
instead of nexthop resolution to know when a peering should
happen or not.  This above commit left a hole where if the remote
peer connected to this bgp, the bgp code would still believe
the peering is down.   Modify the code to double check and
ensure that we have proper v6 LL resolution flags set.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>