### PR TITLE
*: Add some missed make check generated files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ refix
 .emacs.desktop*
 
 /test-suite.log
+pceplib/test/*.log
+pceplib/test/*.trs


### PR DESCRIPTION
Some pcep log output from `make check` is showing up in
git status.  Make git know it's ok to ignore this stuff.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>