### PR TITLE
tests: Do not do a initial_timeout of 2 seconds for verify_bgp_rib

### DIFF
--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -2672,7 +2672,7 @@ def verify_best_path_as_per_admin_distance(
     return True
 
 
-@retry(retry_timeout=10, initial_wait=2)
+@retry(retry_timeout=30)
 def verify_bgp_rib(
     tgen,
     addr_type,


### PR DESCRIPTION
A bunch of tests have this pattern:

a) Install a new prefix into bgp
b) Run this loop:
foreach (router in topology) {
	verify_bgp_rib(router)
}

This is to ensure that the prefix is actually disseminated.
The problem with this, of course, is that a wait of 2 seconds
for every item in that loop makes no sense.  As that the initial
router verification of it's bgp rib will wait 2 seconds and
all the remaining bgp routers in the topology will have gotten
the data.  So we end up waiting a bunch of extra time.

Remove the initial_wait time for verify_bgp_rib.  Also
increase the failure wait time to 30 seconds.  This is
to give a bigger window for bgp to send it's data for
our test systems that could be under heavy load.  In the
normal case tests will never hit this.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>