### PR TITLE
ospf6d: Use bool instead of an int

### DIFF
--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -53,7 +53,7 @@ struct ospf6_area {
 	int no_summary;
 
 	/* Brouter traversal protection */
-	int intra_brouter_calc;
+	bool intra_brouter_calc;
 
 	/* OSPF interface list */
 	struct list *if_list;

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -2353,7 +2353,7 @@ void ospf6_intra_brouter_calculation(struct ospf6_area *oa)
 			 * the table. For an example, ospf6_abr_examin_summary,
 			 * removes brouters which are marked for remove.
 			 */
-			oa->intra_brouter_calc = 1;
+			oa->intra_brouter_calc = true;
 			ospf6_route_remove(brouter, oa->ospf6->brouter_table);
 			brouter = NULL;
 		} else if (CHECK_FLAG(brouter->flag, OSPF6_ROUTE_ADD)
@@ -2386,7 +2386,7 @@ void ospf6_intra_brouter_calculation(struct ospf6_area *oa)
 			UNSET_FLAG(brouter->flag, OSPF6_ROUTE_CHANGE);
 		}
 		/* Reset for nbrouter */
-		oa->intra_brouter_calc = 0;
+		oa->intra_brouter_calc = false;
 	}
 
 	if (IS_OSPF6_DEBUG_BROUTER_SPECIFIC_AREA_ID(oa->area_id) ||


### PR DESCRIPTION
intra_brouter_calc is a int that is being used a bool,
convert to a bool.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>