### PR TITLE
ospf6d: rework filtering commands to be in line with ospfd

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -198,6 +198,47 @@ OSPF6 area
    advertisement of summaries into the area. In that case, a single Type-3 LSA
    containing a default route is originated into the NSSA.
 
+.. clicmd:: area A.B.C.D export-list NAME
+
+.. clicmd:: area (0-4294967295) export-list NAME
+
+   Filter Type-3 summary-LSAs announced to other areas originated from intra-
+   area paths from specified area.
+
+   .. code-block:: frr
+
+      router ospf6
+       area 0.0.0.10 export-list foo
+      !
+      ipv6 access-list foo permit 2001:db8:1000::/64
+      ipv6 access-list foo deny any
+
+   With example above any intra-area paths from area 0.0.0.10 and from range
+   2001:db8::/32 (for example 2001:db8:1::/64 and 2001:db8:2::/64) are announced
+   into other areas as Type-3 summary-LSA's, but any others (for example
+   2001:200::/48) aren't.
+
+   This command is only relevant if the router is an ABR for the specified
+   area.
+
+.. clicmd:: area A.B.C.D import-list NAME
+
+.. clicmd:: area (0-4294967295) import-list NAME
+
+   Same as export-list, but it applies to paths announced into specified area
+   as Type-3 summary-LSAs.
+
+.. clicmd:: area A.B.C.D filter-list prefix NAME in
+
+.. clicmd:: area A.B.C.D filter-list prefix NAME out
+
+.. clicmd:: area (0-4294967295) filter-list prefix NAME in
+
+.. clicmd:: area (0-4294967295) filter-list prefix NAME out
+
+   Filtering Type-3 summary-LSAs to/from area using prefix lists. This command
+   makes sense in ABR only.
+
 .. _ospf6-interface:
 
 OSPF6 interface

--- a/ospf6d/ospf6_abr.h
+++ b/ospf6d/ospf6_abr.h
@@ -73,8 +73,6 @@ extern void ospf6_abr_defaults_to_stub(struct ospf6 *ospf6);
 extern void ospf6_abr_examin_brouter(uint32_t router_id,
 				     struct ospf6_route *route,
 				     struct ospf6 *ospf6);
-extern void ospf6_abr_reimport(struct ospf6_area *oa);
-extern void ospf6_abr_reexport(struct ospf6_area *oa);
 extern void ospf6_abr_range_reset_cost(struct ospf6 *ospf6);
 extern void ospf6_abr_prefix_resummarize(struct ospf6 *ospf6);
 
@@ -88,7 +86,6 @@ extern void ospf6_abr_old_path_update(struct ospf6_route *old_route,
 				      struct ospf6_route *route,
 				      struct ospf6_route_table *table);
 extern void ospf6_abr_init(void);
-extern void ospf6_abr_reexport(struct ospf6_area *oa);
 extern void ospf6_abr_range_update(struct ospf6_route *range,
 				   struct ospf6 *ospf6);
 extern void ospf6_abr_remove_unapproved_summaries(struct ospf6 *ospf6);

--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -163,7 +163,7 @@ extern void ospf6_area_disable(struct ospf6_area *oa);
 extern void ospf6_area_show(struct vty *vty, struct ospf6_area *oa,
 			    json_object *json_areas, bool use_json);
 
-extern void ospf6_area_plist_update(struct prefix_list *plist, int add);
+extern void ospf6_plist_update(struct prefix_list *plist);
 extern void ospf6_filter_update(struct access_list *access);
 extern void ospf6_area_config_write(struct vty *vty, struct ospf6 *ospf6);
 extern void ospf6_area_init(void);

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -1355,20 +1355,6 @@ DEFUN(show_ipv6_ospf6_linkstate_detail, show_ipv6_ospf6_linkstate_detail_cmd,
 	return CMD_SUCCESS;
 }
 
-static void ospf6_plist_add(struct prefix_list *plist)
-{
-	if (prefix_list_afi(plist) != AFI_IP6)
-		return;
-	ospf6_area_plist_update(plist, 1);
-}
-
-static void ospf6_plist_del(struct prefix_list *plist)
-{
-	if (prefix_list_afi(plist) != AFI_IP6)
-		return;
-	ospf6_area_plist_update(plist, 0);
-}
-
 /* Install ospf related commands. */
 void ospf6_init(struct thread_master *master)
 {
@@ -1387,8 +1373,8 @@ void ospf6_init(struct thread_master *master)
 	ospf6_gr_helper_config_init();
 
 	/* initialize hooks for modifying filter rules */
-	prefix_list_add_hook(ospf6_plist_add);
-	prefix_list_delete_hook(ospf6_plist_del);
+	prefix_list_add_hook(ospf6_plist_update);
+	prefix_list_delete_hook(ospf6_plist_update);
 	access_list_add_hook(ospf6_filter_update);
 	access_list_delete_hook(ospf6_filter_update);
 


### PR DESCRIPTION
Issue #9535 describes how the export-list/import-list commands work differently on ospfd and ospf6d.

In short:
* On ospfd, "area A.B.C.D export-list" filters which internal routes an ABR exports to other areas. On ospf6d, instead, that command filters which inter-area routes an ABR exports to the configured area (which is quite counter-intuitive). In other words, both commands do the same but in opposite directions.
* On ospfd, "area A.B.C.D import-list" filters which inter-area routes an ABR imports into the configured area. On ospf6d, that command filters which inter-area routes an interior router accepts.
* On both daemons, "area A.B.C.D filter-list prefix NAME <in|out>" works exactly the same as import/export lists, but using prefix-lists instead of ACLs.

The inconsistency on how those commands work is undesirable. This PR proposes to adapt the ospf6d commands to behave like they do in ospfd.

These changes are obviously backward incompatible and this PR doesn't propose any mitigation strategy other than warning users about the changes in the next release notes. Since these ospf6d commands are undocumented and work in such a peculiar way, it's unlikely many users will be affected (if any at all). New documentation and topology tests were added for the updated commands.

Closes #9535.