### PR TITLE
vtysh: remove sorting of vrf node commands

### DIFF
--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -286,7 +286,6 @@ void vtysh_config_parse_line(void *arg, const char *line)
 			} else if (config->index == RMAP_NODE
 				   || config->index == INTERFACE_NODE
 				   || config->index == VTY_NODE
-				   || config->index == VRF_NODE
 				   || config->index == NH_GROUP_NODE)
 				config_add_line_uniq(config->line, line);
 			else


### PR DESCRIPTION
A simple strcmp-based sorting done by `config_add_line_uniq` breaks the
correct advanced sorting of static routes done by staticd. We don't
actually need to check vrf node commands for uniqueness as all commands
are daemon specific, so let's use simple `config_add_line` that doesn't
sort commands.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>