### PR TITLE
doc: mention set as-path exclude in routemap.rst

### DIFF
--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -279,6 +279,10 @@ Route Map Set Command
 
    Set the BGP AS path to prepend.
 
+.. clicmd:: set as-path exclude AS-NUMBER...
+
+   Drop AS-NUMBER from the BGP AS path.
+
 .. clicmd:: set community COMMUNITY
 
    Set the BGP community attribute.


### PR DESCRIPTION
The set as-path exclude route map command appears to be
entirely undocumented. Mention it in routemap.rst.

Signed-off-by: Lars Seipel <ls@slrz.net>