### PR TITLE
bgpd: make show bgp labeled-unicast work

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11121,6 +11121,10 @@ static int bgp_show(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 		return CMD_WARNING;
 	}
 
+	/* Labeled-unicast routes live in the unicast table. */
+	if (safi == SAFI_LABELED_UNICAST)
+		safi = SAFI_UNICAST;
+
 	table = bgp->rib[afi][safi];
 	/* use MPLS and ENCAP specific shows until they are merged */
 	if (safi == SAFI_MPLS_VPN) {
@@ -11133,9 +11137,6 @@ static int bgp_show(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 					       output_arg, use_json,
 					       1, NULL, NULL);
 	}
-	/* labeled-unicast routes live in the unicast table */
-	else if (safi == SAFI_LABELED_UNICAST)
-		safi = SAFI_UNICAST;
 
 	return bgp_show_table(vty, bgp, safi, table, type, output_arg, NULL, 1,
 			      NULL, NULL, &json_header_depth, show_flags,


### PR DESCRIPTION
Yet-another path where the safi needs to be changed to locate the unicast table where LU routes live. There are lots of places where this needs to be done -  this one makes 'show bgp ipv4 labeled-unicast' work.