### PR TITLE
ospfd, ospf6d: rename the "graceful-restart helper-only" command

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -276,7 +276,7 @@ Graceful Restart
    To perform a graceful shutdown, the "graceful-restart prepare ipv6 ospf"
    EXEC-level command needs to be issued before restarting the ospf6d daemon.
 
-.. clicmd:: graceful-restart helper-only [A.B.C.D]
+.. clicmd:: graceful-restart helper enable [A.B.C.D]
 
 
    Configure Graceful Restart (RFC 5187) helper support.

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -722,7 +722,7 @@ Graceful Restart
    To perform a graceful shutdown, the "graceful-restart prepare ip ospf"
    EXEC-level command needs to be issued before restarting the ospfd daemon.
 
-.. clicmd:: graceful-restart helper-only [A.B.C.D]
+.. clicmd:: graceful-restart helper enable [A.B.C.D]
 
 
    Configure Graceful Restart (RFC 3623) helper support.

--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -1019,10 +1019,11 @@ static void show_ospf6_gr_helper_details(struct vty *vty, struct ospf6 *ospf6,
 /* Graceful Restart HELPER  config Commands */
 DEFPY(ospf6_gr_helper_enable,
       ospf6_gr_helper_enable_cmd,
-      "graceful-restart helper-only [A.B.C.D$rtr_id]",
+      "graceful-restart helper enable [A.B.C.D$rtr_id]",
       "ospf6 graceful restart\n"
+      "ospf6 GR Helper\n"
       "Enable Helper support\n"
-      "Advertisement RouterId\n")
+      "Advertisement Router-ID\n")
 {
 	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
 
@@ -1041,11 +1042,12 @@ DEFPY(ospf6_gr_helper_enable,
 
 DEFPY(ospf6_gr_helper_disable,
       ospf6_gr_helper_disable_cmd,
-      "no graceful-restart helper-only [A.B.C.D$rtr_id]",
+      "no graceful-restart helper enable [A.B.C.D$rtr_id]",
       NO_STR
       "ospf6 graceful restart\n"
-      "Disable Helper support\n"
-      "Advertisement RouterId\n")
+      "ospf6 GR Helper\n"
+      "Enable Helper support\n"
+      "Advertisement Router-ID\n")
 {
 	VTY_DECLVAR_CONTEXT(ospf6, ospf6);
 
@@ -1354,14 +1356,14 @@ static int ospf6_cfg_write_helper_enable_rtr_walkcb(struct hash_bucket *backet,
 	struct advRtr *rtr = backet->data;
 	struct vty *vty = (struct vty *)arg;
 
-	vty_out(vty, " graceful-restart helper-only %pI4\n", &rtr->advRtrAddr);
+	vty_out(vty, " graceful-restart helper enable %pI4\n", &rtr->advRtrAddr);
 	return HASHWALK_CONTINUE;
 }
 
 int config_write_ospf6_gr_helper(struct vty *vty, struct ospf6 *ospf6)
 {
 	if (ospf6->ospf6_helper_cfg.is_helper_supported)
-		vty_out(vty, " graceful-restart helper-only\n");
+		vty_out(vty, " graceful-restart helper enable\n");
 
 	if (!ospf6->ospf6_helper_cfg.strict_lsa_check)
 		vty_out(vty, " graceful-restart helper lsa-check-disable\n");

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -329,14 +329,14 @@ def __create_ospf_global(tgen, input_dict, router, build, load_config, ospf):
                 cmd = "no {}".format(cmd)
             config_data.append(cmd)
 
-        if "helper-only" in gr_data and not gr_data["helper-only"]:
-            cmd = "graceful-restart helper-only"
+        if "helper enable" in gr_data and not gr_data["helper enable"]:
+            cmd = "graceful-restart helper enable"
             if gr_data.setdefault("delete", False):
                 cmd = "no {}".format(cmd)
             config_data.append(cmd)
-        elif "helper-only" in gr_data and type(gr_data["helper-only"]) is list:
-            for rtrs in gr_data["helper-only"]:
-                cmd = "graceful-restart helper-only {}".format(rtrs)
+        elif "helper enable" in gr_data and type(gr_data["helper enable"]) is list:
+            for rtrs in gr_data["helper enable"]:
+                cmd = "graceful-restart helper enable {}".format(rtrs)
                 if gr_data.setdefault("delete", False):
                     cmd = "no {}".format(cmd)
                 config_data.append(cmd)

--- a/tests/topotests/ospf6_gr_topo1/rt1/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt1/ospf6d.conf
@@ -26,5 +26,5 @@ router ospf6
  ospf6 router-id 1.1.1.1
  redistribute connected
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf6_gr_topo1/rt2/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt2/ospf6d.conf
@@ -31,5 +31,5 @@ interface eth-rt3
 router ospf6
  ospf6 router-id 2.2.2.2
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf6_gr_topo1/rt3/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt3/ospf6d.conf
@@ -37,5 +37,5 @@ interface eth-rt6
 router ospf6
  ospf6 router-id 3.3.3.3
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf6_gr_topo1/rt4/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt4/ospf6d.conf
@@ -31,5 +31,5 @@ interface eth-rt5
 router ospf6
  ospf6 router-id 4.4.4.4
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf6_gr_topo1/rt5/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt5/ospf6d.conf
@@ -25,5 +25,5 @@ interface eth-rt4
 router ospf6
  ospf6 router-id 5.5.5.5
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf6_gr_topo1/rt6/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt6/ospf6d.conf
@@ -31,5 +31,5 @@ interface eth-rt7
 router ospf6
  ospf6 router-id 6.6.6.6
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf6_gr_topo1/rt7/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt7/ospf6d.conf
@@ -26,5 +26,5 @@ router ospf6
  ospf6 router-id 7.7.7.7
  redistribute connected
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper.py
@@ -226,7 +226,7 @@ def test_ospf_gr_helper_tc1_p0(request):
 
     step("Configure graceful restart in the DUT")
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
@@ -243,7 +243,7 @@ def test_ospf_gr_helper_tc1_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
@@ -267,7 +267,7 @@ def test_ospf_gr_helper_tc1_p0(request):
     ospf_gr_r0 = {
         "r0": {
             "ospf": {
-                "graceful-restart": {"helper-only": [], "opaque": True, "delete": True}
+                "graceful-restart": {"helper enable": [], "opaque": True, "delete": True}
             }
         }
     }
@@ -282,7 +282,7 @@ def test_ospf_gr_helper_tc1_p0(request):
     step("Configure gr helper using the router id")
     ospf_gr_r0 = {
         "r0": {
-            "ospf": {"graceful-restart": {"helper-only": ["1.1.1.1"], "opaque": True}}
+            "ospf": {"graceful-restart": {"helper enable": ["1.1.1.1"], "opaque": True}}
         }
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
@@ -307,7 +307,7 @@ def test_ospf_gr_helper_tc1_p0(request):
         "r0": {
             "ospf": {
                 "graceful-restart": {
-                    "helper-only": ["1.1.1.1"],
+                    "helper enable": ["1.1.1.1"],
                     "opaque": True,
                     "delete": True,
                 }
@@ -356,13 +356,13 @@ def test_ospf_gr_helper_tc2_p0(request):
         ospf_covergence is True
     ), "OSPF is not after reset config \n Error:" " {}".format(ospf_covergence)
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
@@ -450,13 +450,13 @@ def test_ospf_gr_helper_tc3_p1(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
@@ -544,13 +544,13 @@ def test_ospf_gr_helper_tc4_p1(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
@@ -606,13 +606,13 @@ def test_ospf_gr_helper_tc7_p1(request):
         ospf_covergence is True
     ), "OSPF is not after reset config \n Error:" " {}".format(ospf_covergence)
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
@@ -666,13 +666,13 @@ def test_ospf_gr_helper_tc8_p1(request):
         ospf_covergence is True
     ), "OSPF is not after reset config \n Error:" " {}".format(ospf_covergence)
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper-only": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)

--- a/tests/topotests/ospf_gr_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt1/ospfd.conf
@@ -28,5 +28,5 @@ router ospf
  capability opaque
  redistribute connected
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt2/ospfd.conf
@@ -33,5 +33,5 @@ router ospf
  router-id 2.2.2.2
  capability opaque
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt3/ospfd.conf
@@ -39,5 +39,5 @@ router ospf
  router-id 3.3.3.3
  capability opaque
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt4/ospfd.conf
@@ -33,5 +33,5 @@ router ospf
  router-id 4.4.4.4
  capability opaque
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt5/ospfd.conf
@@ -27,5 +27,5 @@ router ospf
  router-id 5.5.5.5
  capability opaque
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_topo1/rt6/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt6/ospfd.conf
@@ -34,5 +34,5 @@ router ospf
  capability opaque
  area 3 nssa
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_topo1/rt7/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt7/ospfd.conf
@@ -29,5 +29,5 @@ router ospf
  redistribute connected
  area 3 nssa
  graceful-restart grace-period 120
- graceful-restart helper-only
+ graceful-restart helper enable
 !


### PR DESCRIPTION
Considering that both the GR helper mode and restarting mode can be enabled at the same time, the "graceful-restart helper-only" command can be a bit misleading since it implies that only the helper mode is enabled. Rename the command to "graceful-restart helper enable" to clarify what the command does.

In ospfd, start a deprecation cycle of one year before removing the original command. For ospf6d this isn't necessary since the GR helper code didn't see the light of a public release yet.