### PR TITLE
zebra: stop asking for AF_BRIDGE interface info twice

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1102,16 +1102,6 @@ int interface_lookup_netlink(struct zebra_ns *zns)
 	if (ret < 0)
 		return ret;
 
-	/* Get interface information - for bridge interfaces. */
-	ret = netlink_request_intf_addr(netlink_cmd, AF_BRIDGE, RTM_GETLINK,
-					RTEXT_FILTER_BRVLAN);
-	if (ret < 0)
-		return ret;
-	ret = netlink_parse_info(netlink_interface, netlink_cmd, &dp_info, 0,
-				 0);
-	if (ret < 0)
-		return ret;
-
 	/* fixup linkages */
 	zebra_if_update_all_links(zns);
 	return 0;


### PR DESCRIPTION
There were two identical blocks of code run at init time that requested info about AF_BRIDGE - don't see any reason to do that twice, so remove one block.
