### PR TITLE
bgpd: add carriage return when dumping tags from all evpn rds

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9314,7 +9314,8 @@ void route_vty_out_tag(struct vty *vty, const struct prefix *p,
 			vty_out(vty, "notag/%d", label);
 			vty_out(vty, "\n");
 		}
-	}
+	} else if (!json)
+		vty_out(vty, "\n");
 }
 
 void route_vty_out_overlay(struct vty *vty, const struct prefix *p,


### PR DESCRIPTION
following command: show bgp l2vpn evpn rd all tags
does not append rd contexts one after the other

before:
dut-vm# show bgp l2vpn evpn rd all tags
   Network          Next Hop      In tag/Out tag
Route Distinguisher: 65000:999
*> [5]:[0]:[24]:[10.40.1.0]
                    10.209.36.1     Route Distinguisher: 65000:1000
*> [5]:[0]:[24]:[10.40.1.0]
                    10.209.36.1
Displayed 2 out of 2 total prefixes

after:
dut-vm# show bgp l2vpn evpn rd all tags
   Network          Next Hop      In tag/Out tag
Route Distinguisher: 65000:999
*> [5]:[0]:[24]:[10.40.1.0]
                    10.209.36.1
Route Distinguisher: 65000:1000
*> [5]:[0]:[24]:[10.40.1.0]
                    10.209.36.1

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>