### PR TITLE
doc: fix code block in grpc docs

### DIFF
--- a/doc/developer/grpc.rst
+++ b/doc/developer/grpc.rst
@@ -42,6 +42,7 @@ Generating C++ FRR Bindings
 Generating FRR northbound bindings for C++ example:
 
 ::
+
    # Install gRPC (e.g., on Ubuntu 20.04)
    sudo apt-get install libgrpc++-dev libgrpc-dev
 


### PR DESCRIPTION
The code block after the :: is not displayed correctly without an empty
line in between.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>