### PR TITLE
bgpd: swap bgp error value with file descriptor value

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2718,7 +2718,7 @@ int bgp_packet_process_error(struct thread *thread)
 
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [Event] BGP error %d on fd %d",
-			   peer->host, peer->fd, code);
+			   peer->host, code, peer->fd);
 
 	/* Closed connection or error on the socket */
 	if (peer_established(peer)) {


### PR DESCRIPTION
the values were swapped by mistake. fix it.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>