### PR TITLE
bgpd: Don't lookup paf structure get straight to the point

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -337,11 +337,13 @@ static void bgp_write_proceed_actions(struct peer *peer)
 	struct peer_af *paf;
 	struct bpacket *next_pkt;
 	struct update_subgroup *subgrp;
+	enum bgp_af_index index;
 
-	FOREACH_AFI_SAFI (afi, safi) {
-		paf = peer_af_find(peer, afi, safi);
+	for (index = BGP_AF_START; index < BGP_AF_MAX; index++) {
+		paf = peer->peer_af_array[index];
 		if (!paf)
 			continue;
+
 		subgrp = paf->subgroup;
 		if (!subgrp)
 			continue;
@@ -363,6 +365,9 @@ static void bgp_write_proceed_actions(struct peer *peer)
 				     bgp_generate_updgrp_packets, 0);
 			return;
 		}
+
+		afi = paf->afi;
+		safi = paf->safi;
 
 		/* No packets to send, see if EOR is pending */
 		if (CHECK_FLAG(peer->cap, PEER_CAP_RESTART_RCV)) {
@@ -415,11 +420,16 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 		return 0;
 
 	do {
+		enum bgp_af_index index;
+
 		s = NULL;
-		FOREACH_AFI_SAFI (afi, safi) {
-			paf = peer_af_find(peer, afi, safi);
+		for (index = BGP_AF_START; index < BGP_AF_MAX; index++) {
+			paf = peer->peer_af_array[index];
 			if (!paf || !PAF_SUBGRP(paf))
 				continue;
+
+			afi = paf->afi;
+			safi = paf->safi;
 			next_pkt = paf->next_pkt_to_send;
 
 			/*

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -912,13 +912,19 @@ static int bgp_peer_clear(struct peer *peer, afi_t afi, safi_t safi,
 	if ((afi == AFI_UNSPEC) && (safi == SAFI_UNSPEC)) {
 		afi_t tmp_afi;
 		safi_t tmp_safi;
+		enum bgp_af_index index;
 
-		FOREACH_AFI_SAFI (tmp_afi, tmp_safi) {
-			paf = peer_af_find(peer, tmp_afi, tmp_safi);
+		for (index = BGP_AF_START; index < BGP_AF_MAX; index++) {
+			paf = peer->peer_af_array[index];
+			if (!paf)
+				continue;
+
 			if (paf && paf->subgroup)
 				SET_FLAG(paf->subgroup->sflags,
 					 SUBGRP_STATUS_FORCE_UPDATES);
 
+			tmp_afi = paf->afi;
+			tmp_safi = paf->safi;
 			if (!peer->afc[tmp_afi][tmp_safi])
 				continue;
 


### PR DESCRIPTION
The paf data structure is stored based upon an internal
bgp enum.  The code is looking over all AFI/SAFI's and
doing a paf_af_find which then calls afindex to find
the right paf structure.  Let's just loop over the
peer->peer_af_array[] and cut straight to the chase.
Under some loads the paf_af_find was taking up 6%
of the run time.  This removes it entirely.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>