### PR TITLE
pimd: fix UAF/heap corruption in BSM code

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4140,9 +4140,8 @@ static void clear_pim_bsr_db(struct pim_instance *pim)
 			rpnode->info = NULL;
 			route_unlock_node(rpnode);
 			route_unlock_node(rpnode);
+			XFREE(MTYPE_PIM_RP, rp_info);
 		}
-
-		XFREE(MTYPE_PIM_RP, rp_info);
 
 		pim_free_bsgrp_node(bsgrp->scope->bsrp_table, &bsgrp->group);
 		pim_free_bsgrp_data(bsgrp);


### PR DESCRIPTION
This `XFREE()` call is in plainly in the wrong spot.  `rp_all` (the 224.0.0.0/4 entry) isn't supposed to be free'd ever, and the conditional above makes quite clear that it remains in use.

It may be possible to exploit this as a heap corruption bug, maybe even as RCE.  I haven't tried; I randomly noticed this while working on the BSM code.  Luckily this code is only run by the CLI for the clear command, so the surface is very small.