### PR TITLE
zebra: Ignore NDA_LLADDR that is not 6 bytes

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3683,7 +3683,7 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	bool local_inactive;
 	uint32_t ext_flags = 0;
 	bool dp_static = false;
-	int l2_len = 0;
+	uint32_t l2_len = 0;
 	int cmd;
 
 	ndm = NLMSG_DATA(h);
@@ -3744,6 +3744,13 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	if (tb[NDA_LLADDR]) {
 		/* copy LLADDR information */
 		l2_len = RTA_PAYLOAD(tb[NDA_LLADDR]);
+		if (l2_len != sizeof(mac)) {
+			if (IS_ZEBRA_DEBUG_KERNEL)
+				zlog_debug(
+					"   Neighbor Entry received has a NDA_LLADDR of length %u but was expecting %lu, ignoring",
+					l2_len, sizeof(mac));
+			return 0;
+		}
 		memcpy(&mac, RTA_DATA(tb[NDA_LLADDR]), l2_len);
 	}
 	if (l2_len == IPV4_MAX_BYTELEN || l2_len == 0) {


### PR DESCRIPTION
It is possible to create a LL address in the kernel
that uses a v6 LL address, resulting in a 16 byte
NDA_LLADDR.  When we attempt to copy that into
the mac variable it will make life unhappy since
the mac is a mac address of 6 bytes.  If we
see a l2_len is not 6 bytes we will just ignore
the neighbor entry letting the world know that this
is what we are doing.

Fixes: #9671
Signed-off-by: Donald Sharp <sharpd@nvidia.com>