### PR TITLE
pimd: fixing command "no ip msdp mesh-group member"

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3842,7 +3842,7 @@ static void pim_cli_legacy_mesh_group_behavior(struct vty *vty,
 			      xpath_member_value)) {
 		member_dnode = yang_dnode_get(vty->candidate_config->dnode,
 					      xpath_member_value);
-		if (!yang_is_last_list_dnode(member_dnode))
+		if (!member_dnode || !yang_is_last_list_dnode(member_dnode))
 			return;
 	}
 
@@ -9762,7 +9762,7 @@ DEFPY(no_ip_msdp_mesh_group_member,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	nb_cli_enqueue_change(vty, xpath_value, NB_OP_DESTROY, NULL);
+	nb_cli_enqueue_change(vty, xpath_member_value, NB_OP_DESTROY, NULL);
 
 	/*
 	 * If this is the last member, then we must remove the group altogether
@@ -9796,7 +9796,7 @@ DEFPY(ip_msdp_mesh_group_source,
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
 
-	/* Create mesh group member. */
+	/* Create mesh group source. */
 	strlcat(xpath_value, "/source", sizeof(xpath_value));
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, saddr_str);
 
@@ -9827,7 +9827,7 @@ DEFPY(no_ip_msdp_mesh_group_source,
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
 
-	/* Create mesh group member. */
+	/* Create mesh group source. */
 	strlcat(xpath_value, "/source", sizeof(xpath_value));
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_DESTROY, NULL);
 

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1168,6 +1168,7 @@ int pim_msdp_mesh_group_members_destroy(struct nb_cb_destroy_args *args)
 {
 	struct pim_msdp_mg_mbr *mbr;
 	struct pim_msdp_mg *mg;
+	const struct lyd_node *mg_dnode;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -1176,9 +1177,11 @@ int pim_msdp_mesh_group_members_destroy(struct nb_cb_destroy_args *args)
 		break;
 	case NB_EV_APPLY:
 		mbr = nb_running_get_entry(args->dnode, NULL, true);
-		mg = nb_running_get_entry(args->dnode, "../", true);
-
+		mg_dnode =
+			yang_dnode_get_parent(args->dnode, "msdp-mesh-groups");
+		mg = nb_running_get_entry(mg_dnode, NULL, true);
 		pim_msdp_mg_mbr_del(mg, mbr);
+		nb_running_unset_entry(args->dnode);
 		break;
 	}
 


### PR DESCRIPTION
Deleting a mesh-group member no longer deletes the mesh-group.

Complete bug description at:
https://github.com/FRRouting/frr/issues/9664

Signed-off-by: Adriano Marto Reis <adrianomarto@gmail.com>