### PR TITLE
zebra: fix buffer overflow

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3744,7 +3744,6 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	if (tb[NDA_LLADDR]) {
 		/* copy LLADDR information */
 		l2_len = RTA_PAYLOAD(tb[NDA_LLADDR]);
-		memcpy(&mac, RTA_DATA(tb[NDA_LLADDR]), l2_len);
 	}
 	if (l2_len == IPV4_MAX_BYTELEN || l2_len == 0) {
 		union sockunion link_layer_ipv4;
@@ -3752,7 +3751,7 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 		if (l2_len) {
 			sockunion_family(&link_layer_ipv4) = AF_INET;
 			memcpy((void *)sockunion_get_addr(&link_layer_ipv4),
-			       &mac, l2_len);
+			       RTA_DATA(tb[NDA_LLADDR]), l2_len);
 		} else
 			sockunion_family(&link_layer_ipv4) = AF_UNSPEC;
 		zsend_nhrp_neighbor_notify(


### PR DESCRIPTION
mac is only 6 bytes long and we shouldn't blindly copy unknown number of
bytes into it.

Fixes #9671.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>