### PR TITLE
[RFC] lib: Batch config in vty_read_file()

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2268,8 +2268,12 @@ static void vty_read_file(struct nb_config *config, FILE *confp)
 		vty->candidate_config = nb_config_new(NULL);
 	}
 
+	cmd_execute(vty, "XFRR_start_configuration", NULL, 0);
+
 	/* Execute configuration file */
 	ret = config_from_file(vty, confp, &line_num);
+
+	cmd_execute(vty, "XFRR_end_configuration", NULL, 0);
 
 	/* Flush any previous errors before printing messages below */
 	buffer_flush_all(vty->obuf, vty->wfd);


### PR DESCRIPTION
Add start/end config commands to batch configs from file.
Follow the same way as `vtysh_read_file()`.

Tested with 3k static routes in staticd.conf. It takes more than 3 minutes to startup and load the config without batching. And only a few seconds after this change.