### PR TITLE
tests: fix string comparison in lib/pim.py

### DIFF
--- a/tests/topotests/lib/pim.py
+++ b/tests/topotests/lib/pim.py
@@ -1020,10 +1020,10 @@ def verify_ip_mroutes(
     if not isinstance(group_addresses, list):
         group_addresses = [group_addresses]
 
-    if not isinstance(iif, list) and iif is not "none":
+    if not isinstance(iif, list) and iif != "none":
         iif = [iif]
 
-    if not isinstance(oil, list) and oil is not "none":
+    if not isinstance(oil, list) and oil != "none":
         oil = [oil]
 
     for grp_addr in group_addresses:


### PR DESCRIPTION
Use correct string comparison syntax in lib/pim.py.
