### PR TITLE
ospfd: Fix assert related to capability opaque

### DIFF
--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -382,9 +382,16 @@ void ospf_renegotiate_optional_capabilities(struct ospf *top)
 	struct route_table *nbrs;
 	struct route_node *rn;
 	struct ospf_neighbor *nbr;
+	uint8_t shutdown_save = top->inst_shutdown;
 
 	/* At first, flush self-originated LSAs from routing domain. */
 	ospf_flush_self_originated_lsas_now(top);
+
+	/* ospf_flush_self_originated_lsas_now is primarily intended for shut
+	 * down scenarios. Reset the inst_shutdown flag that it sets. We are
+	 * just changing configuration, and the flag can change the scheduling
+	 * of when maxage LSAs are sent. */
+	top->inst_shutdown = shutdown_save;
 
 	/* Revert all neighbor status to ExStart. */
 	for (ALL_LIST_ELEMENTS_RO(top->oiflist, node, oi)) {


### PR DESCRIPTION
The capability opaque command can trigger asserts through a rather
round-about mechanism. The command eventually calls
ospf_renegotiate_optional_capabilities, which will call
ospf_flush_self_originated_lsas_now, which has the side effect of
marking the OSPF instance as shutting down. This was causing the
flooding logic to call ospf_write immediately insted of waiting for the
select IO loop every time it was sending a maxage LSA.  This could cause
the list of OSPF interfaces needing to send packets to be drained while
there was a call to ospf_write pending from the IO loop. When the
pending call ran, it would see the empty list of interfaces and assert.

Signed-off-by: Yuan Yuan <yyuanam@amazon.com>