### PR TITLE
*: cleanup interface loopback/vrf check

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -477,7 +477,7 @@ struct ospf_interface *ospf_if_lookup_recv_if(struct ospf *ospf,
 		if (oi->type == OSPF_IFTYPE_VIRTUALLINK)
 			continue;
 
-		if (if_is_loopback(oi->ifp) || if_is_vrf(oi->ifp))
+		if (if_is_loopback_or_vrf(oi->ifp))
 			continue;
 
 		if (CHECK_FLAG(oi->connected->flags, ZEBRA_IFA_UNNUMBERED))
@@ -719,7 +719,7 @@ static int ospf_if_delete_hook(struct interface *ifp)
 
 int ospf_if_is_enable(struct ospf_interface *oi)
 {
-	if (!(if_is_loopback(oi->ifp) || if_is_vrf(oi->ifp)))
+	if (!(if_is_loopback_or_vrf(oi->ifp)))
 		if (if_is_up(oi->ifp))
 			return 1;
 
@@ -1291,7 +1291,7 @@ uint8_t ospf_default_iftype(struct interface *ifp)
 {
 	if (if_is_pointopoint(ifp))
 		return OSPF_IFTYPE_POINTOPOINT;
-	else if (if_is_loopback(ifp) || if_is_vrf(ifp))
+	else if (if_is_loopback_or_vrf(ifp))
 		return OSPF_IFTYPE_LOOPBACK;
 	else
 		return OSPF_IFTYPE_BROADCAST;

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -73,8 +73,7 @@ static void connected_announce(struct interface *ifp, struct connected *ifc)
 	if (!ifc)
 		return;
 
-	if (!if_is_loopback(ifp) && ifc->address->family == AF_INET &&
-	    !IS_ZEBRA_IF_VRF(ifp)) {
+	if (!if_is_loopback_or_vrf(ifp) && ifc->address->family == AF_INET) {
 		if (ifc->address->prefixlen == IPV4_MAX_BITLEN)
 			SET_FLAG(ifc->flags, ZEBRA_IFA_UNNUMBERED);
 		else

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -493,9 +493,7 @@ static int rtadv_timer(struct thread *thread)
 
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
 		FOR_ALL_INTERFACES (vrf, ifp) {
-			if (if_is_loopback(ifp)
-			    || CHECK_FLAG(ifp->status,
-					  ZEBRA_INTERFACE_VRF_LOOPBACK)
+			if (if_is_loopback_or_vrf(ifp)
 			    || !if_is_operative(ifp))
 				continue;
 
@@ -728,8 +726,7 @@ static void rtadv_process_packet(uint8_t *buf, unsigned int len,
 			   VRF_LOGNAME(vrf), ifp->ifindex, len, addr_str);
 	}
 
-	if (if_is_loopback(ifp)
-	    || CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK))
+	if (if_is_loopback_or_vrf(ifp))
 		return;
 
 	/* Check interface configuration. */
@@ -1465,8 +1462,7 @@ DEFUN (ipv6_nd_ra_fast_retrans,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct zebra_if *zif = ifp->info;
 
-	if (if_is_loopback(ifp)
-	    || CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK)) {
+	if (if_is_loopback_or_vrf(ifp)) {
 		vty_out(vty,
 			"Cannot configure IPv6 Router Advertisements on this  interface\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -1488,8 +1484,7 @@ DEFUN (no_ipv6_nd_ra_fast_retrans,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct zebra_if *zif = ifp->info;
 
-	if (if_is_loopback(ifp)
-	    || CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK)) {
+	if (if_is_loopback_or_vrf(ifp)) {
 		vty_out(vty,
 			"Cannot configure IPv6 Router Advertisements on this  interface\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -1511,8 +1506,7 @@ DEFPY (ipv6_nd_ra_hop_limit,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct zebra_if *zif = ifp->info;
 
-	if (if_is_loopback(ifp)
-	    || CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK)) {
+	if (if_is_loopback_or_vrf(ifp)) {
 		vty_out(vty,
 			"Cannot configure IPv6 Router Advertisements on this interface\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -1535,8 +1529,7 @@ DEFPY (no_ipv6_nd_ra_hop_limit,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct zebra_if *zif = ifp->info;
 
-	if (if_is_loopback(ifp)
-	    || CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK)) {
+	if (if_is_loopback_or_vrf(ifp)) {
 		vty_out(vty,
 			"Cannot configure IPv6 Router Advertisements on this interface\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -1558,8 +1551,7 @@ DEFPY (ipv6_nd_ra_retrans_interval,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct zebra_if *zif = ifp->info;
 
-	if (if_is_loopback(ifp)
-	    || CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK)) {
+	if (if_is_loopback_or_vrf(ifp)) {
 		vty_out(vty,
 			"Cannot configure IPv6 Router Advertisements on loopback interface\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -1582,8 +1574,7 @@ DEFPY (no_ipv6_nd_ra_retrans_interval,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct zebra_if *zif = ifp->info;
 
-	if (if_is_loopback(ifp)
-	    || CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK)) {
+	if (if_is_loopback_or_vrf(ifp)) {
 		vty_out(vty,
 			"Cannot remove IPv6 Router Advertisements on loopback interface\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -1604,8 +1595,7 @@ DEFUN (ipv6_nd_suppress_ra,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct zebra_if *zif = ifp->info;
 
-	if (if_is_loopback(ifp)
-	    || CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK)) {
+	if (if_is_loopback_or_vrf(ifp)) {
 		vty_out(vty,
 			"Cannot configure IPv6 Router Advertisements on this  interface\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -1629,8 +1619,7 @@ DEFUN (no_ipv6_nd_suppress_ra,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct zebra_if *zif = ifp->info;
 
-	if (if_is_loopback(ifp)
-	    || CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK)) {
+	if (if_is_loopback_or_vrf(ifp)) {
 		vty_out(vty,
 			"Cannot configure IPv6 Router Advertisements on this interface\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -2619,8 +2608,7 @@ static int rtadv_config_write(struct vty *vty, struct interface *ifp)
 
 	zif = ifp->info;
 
-	if (!(if_is_loopback(ifp)
-	      || CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK))) {
+	if (!if_is_loopback_or_vrf(ifp)) {
 		if (zif->rtadv.AdvSendAdvertisements
 		    && CHECK_FLAG(zif->rtadv.ra_configured, VTY_RA_CONFIGURED))
 			vty_out(vty, " no ipv6 nd suppress-ra\n");


### PR DESCRIPTION
There's a helper function to check whether the interface is loopback or
VRF - if_is_loopback_or_vrf. Let's use it whenever we need to check that.

There's no functional change in this commit.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>