### PR TITLE
ospf6d: minor struct compare issues.

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -53,6 +53,17 @@
 
 unsigned char conf_debug_ospf6_abr;
 
+int ospf6_ls_origin_cmp(struct ospf6_path *o_path, struct ospf6_route *route)
+{
+	if (((o_path->origin.type == route->path.origin.type)
+				&& (o_path->origin.id == route->path.origin.id)
+				&& (o_path->origin.adv_router ==
+					route->path.origin.adv_router)))
+		return 1;
+	else
+		return 0;
+}
+
 bool ospf6_check_and_set_router_abr(struct ospf6 *o)
 {
 	struct listnode *node;
@@ -816,8 +827,7 @@ void ospf6_abr_old_path_update(struct ospf6_route *old_route,
 
 	for (ALL_LIST_ELEMENTS(old_route->paths, anode, anext, o_path)) {
 		if (o_path->area_id != route->path.area_id ||
-		    (memcmp(&(o_path)->origin, &(route)->path.origin,
-			    sizeof(struct ospf6_ls_origin)) != 0))
+		    (!ospf6_ls_origin_cmp(o_path, route)))
 			continue;
 
 		if ((o_path->cost == route->path.cost) &&
@@ -1233,8 +1243,7 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 		for (ALL_LIST_ELEMENTS_RO(old_route->paths, anode,
 						  o_path)) {
 			if (o_path->area_id == route->path.area_id &&
-			    (memcmp(&(o_path)->origin, &(route)->path.origin,
-				    sizeof(struct ospf6_ls_origin)) == 0))
+			    (ospf6_ls_origin_cmp(o_path, route)))
 				break;
 		}
 

--- a/ospf6d/ospf6_abr.h
+++ b/ospf6d/ospf6_abr.h
@@ -89,5 +89,7 @@ extern void ospf6_abr_init(void);
 extern void ospf6_abr_range_update(struct ospf6_route *range,
 				   struct ospf6 *ospf6);
 extern void ospf6_abr_remove_unapproved_summaries(struct ospf6 *ospf6);
+extern int ospf6_ls_origin_cmp(struct ospf6_path *o_path,
+		struct ospf6_route *route);
 
 #endif /*OSPF6_ABR_H*/

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -290,9 +290,7 @@ void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 			 * origin.
 			 */
 			if (o_path->area_id != route->path.area_id
-			    || (memcmp(&(o_path)->origin, &(route)->path.origin,
-				       sizeof(struct ospf6_ls_origin))
-				!= 0))
+			    || (!ospf6_ls_origin_cmp(o_path, route)))
 				continue;
 
 			/* Cost is not same then delete current path */
@@ -411,10 +409,7 @@ void ospf6_asbr_update_route_ecmp_path(struct ospf6_route *old,
 			for (ALL_LIST_ELEMENTS_RO(old_route->paths, anode,
 						  o_path)) {
 				if (o_path->area_id == route->path.area_id
-				    && (memcmp(&(o_path)->origin,
-					       &(route)->path.origin,
-					       sizeof(struct ospf6_ls_origin))
-					== 0))
+				    && (ospf6_ls_origin_cmp(o_path, route)))
 					break;
 			}
 			/* If path is not found in old_route paths's list,

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1525,8 +1525,7 @@ void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 			 * origin.
 			 */
 			if (o_path->area_id != route->path.area_id ||
-			    (memcmp(&(o_path)->origin, &(route)->path.origin,
-				   sizeof(struct ospf6_ls_origin)) != 0))
+			    (!ospf6_ls_origin_cmp(o_path, route)))
 				continue;
 
 			/* Cost is not same then delete current path */
@@ -1631,9 +1630,7 @@ void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 			for (ALL_LIST_ELEMENTS_RO(old_route->paths, anode,
 						  o_path)) {
 				if (o_path->area_id == route->path.area_id &&
-				    (memcmp(&(o_path)->origin,
-					&(route)->path.origin,
-					sizeof(struct ospf6_ls_origin)) == 0))
+				    (ospf6_ls_origin_cmp(o_path, route)))
 					break;
 			}
 			/* If path is not found in old_route paths's list,


### PR DESCRIPTION
Note: This pull request addresses comments given in the PR https://github.com/FRRouting/frr/pull/9691.

Problem Statement:
Multiple struct compare using memcmp, which might result in issue due to
structure padding/alignment.

Fix:
The code changes involve structure member by member comparison to
remove any issues related to padding/alignment.

Signed-off-by: Manoj Naragund <mnaragund@vmware.com>
(cherry picked from commit 67db821a1d6d68b19862d50b68ed19278c5f2422)