### PR TITLE
bgpd: fix build error seen when lttng is enabled

### DIFF
--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -34,6 +34,7 @@
 #include <lttng/tracepoint.h>
 
 #include "bgpd/bgpd.h"
+#include "bgpd/bgp_attr.h"
 #include "lib/stream.h"
 
 /* clang-format off */


### PR DESCRIPTION
bgpd: fix build error seen when lttng is enabled

bgp_attr.h was needed to build with lttng enabled 
Signed-off-by: Anuradha Karuppiah <anuradhak@nvidia.com>