### PR TITLE
zebra: install port filter

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -339,6 +339,12 @@ Files: tests/helpers/python/frrsix.py
 License: MIT
 Copyright: Copyright (c) 2010-2017 Benjamin Peterson
 
+Files: pbrd/pbr_map.c pbrd/pbr_vty.c zebra/rule_netlink.c zebra/zebra_dplane.*
+License: MIT
+Copyright:
+   Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+   Approved for Public Release; Distribution Unlimited 21-1402
+
 License: GPL-2+
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -2,6 +2,9 @@
  * PBR-map Code
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
+ * Portions:
+ *     Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *		Approved for Public Release; Distribution Unlimited 21-1402
  *
  * FRR is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -545,6 +548,9 @@ struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
 		pbrms->action_pcp = 0;
 
 		pbrms->action_queue_id = PBR_MAP_UNDEFINED_QUEUE_ID;
+
+		pbrms->src_prt = 0;
+		pbrms->dst_prt = 0;
 
 		pbrms->reason =
 			PBR_MAP_INVALID_EMPTY |

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -2,6 +2,9 @@
  * PBR - vty code
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
+ * Portions:
+ *     Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *      Approved for Public Release; Distribution Unlimited 21-1402
  *
  * FRR is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -851,6 +854,10 @@ static void vty_show_pbrms(struct vty *vty,
 	if (pbrms->action_pcp)
 		vty_out(vty, "        Set PCP %u\n", pbrms->action_pcp);
 
+	if (pbrms->src_prt)
+		vty_out(vty, "        Match Src port %u\n", pbrms->src_prt);
+	if (pbrms->dst_prt)
+		vty_out(vty, "        Match Dst port %u\n", pbrms->dst_prt);
 
 	if (pbrms->nhgrp_name) {
 		vty_out(vty, "        Nexthop-Group: %s\n", pbrms->nhgrp_name);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -1,6 +1,9 @@
 /*
  * Zebra dataplane layer.
  * Copyright (c) 2018 Volta Networks, Inc.
+ * Portions:
+ *     Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *      Approved for Public Release; Distribution Unlimited 21-1402
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -267,6 +270,9 @@ struct dplane_ctx_rule {
 	uint16_t action_vlan_flags;
 
 	uint32_t action_queue_id;
+
+	uint32_t filter_src_port;
+	uint32_t filter_dst_port;
 
 	char ifname[INTERFACE_NAMSIZ + 1];
 };
@@ -2053,6 +2059,34 @@ uint32_t dplane_ctx_rule_get_old_fwmark(const struct zebra_dplane_ctx *ctx)
 	return ctx->u.rule.old.fwmark;
 }
 
+uint16_t dplane_ctx_rule_get_src_port(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.rule.new.filter_src_port;
+}
+
+uint16_t dplane_ctx_rule_get_old_src_port(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.rule.old.filter_src_port;
+}
+
+uint16_t dplane_ctx_rule_get_dst_port(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.rule.new.filter_dst_port;
+}
+
+uint16_t dplane_ctx_rule_get_old_dst_port(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.rule.old.filter_dst_port;
+}
+
 uint8_t dplane_ctx_rule_get_ipproto(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
@@ -2777,12 +2811,12 @@ static void dplane_ctx_rule_init_single(struct dplane_ctx_rule *dplane_rule,
 	dplane_rule->ip_proto = rule->rule.filter.ip_proto;
 	prefix_copy(&(dplane_rule->dst_ip), &rule->rule.filter.dst_ip);
 	prefix_copy(&(dplane_rule->src_ip), &rule->rule.filter.src_ip);
-
 	dplane_rule->action_pcp = rule->rule.action.pcp;
 	dplane_rule->action_vlan_flags = rule->rule.action.vlan_flags;
 	dplane_rule->action_vlan_id = rule->rule.action.vlan_id;
 	dplane_rule->action_queue_id = rule->rule.action.queue_id;
-
+	dplane_rule->filter_src_port = rule->rule.filter.src_port;
+	dplane_rule->filter_dst_port = rule->rule.filter.dst_port;
 	strlcpy(dplane_rule->ifname, rule->ifname, INTERFACE_NAMSIZ);
 }
 

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -1,6 +1,9 @@
 /*
  * Zebra dataplane layer api interfaces.
  * Copyright (c) 2018 Volta Networks, Inc.
+ * Portions:
+ *     Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *		Approved for Public Release; Distribution Unlimited 21-1402
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -516,6 +519,10 @@ uint8_t dplane_ctx_rule_get_dsfield(const struct zebra_dplane_ctx *ctx);
 uint8_t dplane_ctx_rule_get_old_dsfield(const struct zebra_dplane_ctx *ctx);
 uint8_t dplane_ctx_rule_get_ipproto(const struct zebra_dplane_ctx *ctx);
 uint8_t dplane_ctx_rule_get_old_ipproto(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_rule_get_old_src_port(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_rule_get_src_port(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_rule_get_dst_port(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_rule_get_old_dst_port(const struct zebra_dplane_ctx *ctx);
 const struct prefix *
 dplane_ctx_rule_get_src_ip(const struct zebra_dplane_ctx *ctx);
 const struct prefix *


### PR DESCRIPTION
Source and destination ports were previously being added to the zebra dplane context, but were not being sent to netlink.

Signed-off-by: Eli Baum <ebaum@mitre.org>