### PR TITLE
pimd: hello sent stats counter change and new flag addition to decide hello send

### DIFF
--- a/pimd/pim_hello.c
+++ b/pimd/pim_hello.c
@@ -545,7 +545,7 @@ void pim_hello_require(struct interface *ifp)
 
 	assert(pim_ifp);
 
-	if (pim_ifp->pim_ifstat_hello_sent)
+	if (PIM_IF_FLAG_TEST_HELLO_SENT(pim_ifp->flags))
 		return;
 
 	pim_hello_restart_now(ifp); /* Send hello and restart timer */

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -289,7 +289,6 @@ static void pim_addr_change(struct interface *ifp)
 	  HoldTime should be sent immediately.
 	  -- FIXME See TODO T31
 	 */
-	pim_ifp->pim_ifstat_hello_sent = 0; /* reset hello counter */
 	PIM_IF_FLAG_UNSET_HELLO_SENT(pim_ifp->flags);
 	if (pim_ifp->pim_sock_fd < 0)
 		return;

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -290,6 +290,7 @@ static void pim_addr_change(struct interface *ifp)
 	  -- FIXME See TODO T31
 	 */
 	pim_ifp->pim_ifstat_hello_sent = 0; /* reset hello counter */
+	PIM_IF_FLAG_UNSET_HELLO_SENT(pim_ifp->flags);
 	if (pim_ifp->pim_sock_fd < 0)
 		return;
 	pim_hello_restart_now(ifp); /* send hello and restart timer */
@@ -1697,8 +1698,10 @@ int pim_ifp_down(struct interface *ifp)
 		}
 	}
 
-	if (ifp->info)
+	if (ifp->info) {
 		pim_if_del_vif(ifp);
+		pim_ifstat_reset(ifp);
+	}
 
 	return 0;
 }

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -61,6 +61,20 @@
 #define PIM_I_am_DR(pim_ifp) (pim_ifp)->pim_dr_addr.s_addr == (pim_ifp)->primary_address.s_addr
 #define PIM_I_am_DualActive(pim_ifp) (pim_ifp)->activeactive == true
 
+/* Macros for interface flags */
+
+/*
+ * PIM needs to know if hello is required to send before other PIM messages
+ * like Join, prune, assert would go out
+ */
+#define PIM_IF_FLAG_HELLO_SENT (1 << 0)
+
+#define PIM_IF_FLAG_TEST_HELLO_SENT(flags) ((flags)&PIM_IF_FLAG_HELLO_SENT)
+
+#define PIM_IF_FLAG_SET_HELLO_SENT(flags) ((flags) |= PIM_IF_FLAG_HELLO_SENT)
+
+#define PIM_IF_FLAG_UNSET_HELLO_SENT(flags) ((flags) &= ~PIM_IF_FLAG_HELLO_SENT)
+
 struct pim_iface_upstream_switch {
 	struct in_addr address;
 	struct list *us;
@@ -161,6 +175,7 @@ struct pim_interface {
 	uint32_t pim_ifstat_bsm_cfg_miss;
 	uint32_t pim_ifstat_ucast_bsm_cfg_miss;
 	uint32_t pim_ifstat_bsm_invalid_sz;
+	uint8_t flags;
 	bool bsm_enable; /* bsm processing enable */
 	bool ucast_bsm_accept; /* ucast bsm processing */
 

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -341,7 +341,7 @@ pim_neighbor_new(struct interface *ifp, struct in_addr source_addr,
 	 * reset the value so that we can know to hurry up and
 	 * hello
 	 */
-	pim_ifp->pim_ifstat_hello_sent = 0;
+	PIM_IF_FLAG_UNSET_HELLO_SENT(pim_ifp->flags);
 
 	pim_inet4_dump("<src?>", source_addr, src_str, sizeof(src_str));
 

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -455,6 +455,21 @@ void pim_ifstat_reset(struct interface *ifp)
 	pim_ifp->pim_ifstat_hello_sendfail = 0;
 	pim_ifp->pim_ifstat_hello_recv = 0;
 	pim_ifp->pim_ifstat_hello_recvfail = 0;
+	pim_ifp->pim_ifstat_bsm_rx = 0;
+	pim_ifp->pim_ifstat_bsm_tx = 0;
+	pim_ifp->pim_ifstat_join_recv = 0;
+	pim_ifp->pim_ifstat_join_send = 0;
+	pim_ifp->pim_ifstat_prune_recv = 0;
+	pim_ifp->pim_ifstat_prune_send = 0;
+	pim_ifp->pim_ifstat_reg_recv = 0;
+	pim_ifp->pim_ifstat_reg_send = 0;
+	pim_ifp->pim_ifstat_reg_stop_recv = 0;
+	pim_ifp->pim_ifstat_reg_stop_send = 0;
+	pim_ifp->pim_ifstat_assert_recv = 0;
+	pim_ifp->pim_ifstat_assert_send = 0;
+	pim_ifp->pim_ifstat_bsm_cfg_miss = 0;
+	pim_ifp->pim_ifstat_ucast_bsm_cfg_miss = 0;
+	pim_ifp->pim_ifstat_bsm_invalid_sz = 0;
 }
 
 void pim_sock_reset(struct interface *ifp)
@@ -707,6 +722,7 @@ int pim_hello_send(struct interface *ifp, uint16_t holdtime)
 	}
 
 	++pim_ifp->pim_ifstat_hello_sent;
+	PIM_IF_FLAG_SET_HELLO_SENT(pim_ifp->flags);
 
 	return 0;
 }

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo4.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo4.py
@@ -954,11 +954,13 @@ def test_PIM_hello_tx_rx_p1(request):
         tc_name, result
     )
 
-    step("verify stats not increamented on c1")
+    step("verify stats incremented on c1")
     result = verify_state_incremented(c1_state_before, c1_state_after)
     assert (
-        result is not True
-    ), "Testcase{} : Failed Error: {}" "stats incremented".format(tc_name, result)
+        result is True
+    ), "Testcase{} : Failed Error: {}" "stats is not incremented".format(
+        tc_name, result
+    )
 
     step("verify before stats on l1")
     l1_state_dict = {
@@ -991,7 +993,7 @@ def test_PIM_hello_tx_rx_p1(request):
         tc_name, result
     )
 
-    step("verify stats not increamented on l1")
+    step("verify stats not incremented on l1")
     result = verify_state_incremented(l1_state_before, l1_state_after)
     assert (
         result is not True
@@ -1041,10 +1043,10 @@ def test_PIM_hello_tx_rx_p1(request):
         tc_name, result
     )
 
-    step("verify stats not increamented on c1")
+    step("verify stats incremented on c1")
     result = verify_state_incremented(c1_state_before, c1_state_after)
     assert (
-        result is not True
+        result is True
     ), "Testcase{} : Failed Error: {}" "stats incremented".format(tc_name, result)
 
     write_test_footer(tc_name)


### PR DESCRIPTION
**Problem Statement:**
pim maintains two counters hello tx and hello rx at interface level.
At present pim needs to send the hello message prior to other pim
message as per RFC. This logic is getting derived from the tx hello
counters. Ideally we should not set the tx counters to zero
on the new neighbor addition.

**Fix:**
Let the counters not reset to zero, on neighbor addition since it is statistics for hello.
Use a flag to note down, PIM has to send the hello message.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>