### PR TITLE
ospfd: GR helper functionality change in helper exit

### DIFF
--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -723,14 +723,10 @@ void ospf_gr_helper_exit(struct ospf_neighbor *nbr,
 
 	/* check exit triggered due to successful completion
 	 * of graceful restart.
-	 * If no, bring down the neighbour.
 	 */
 	if (reason != OSPF_GR_HELPER_COMPLETED) {
 		if (IS_DEBUG_OSPF_GR)
-			zlog_debug(
-				"%s, Failed GR exit, so bringing down the neighbour",
-				__func__);
-		OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_KillNbr);
+			zlog_debug("%s, Unsuccessful GR exit", __func__);
 	}
 
 	/*Recalculate the DR for the network segment */

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -76,10 +76,13 @@ static int ospf_inactivity_timer(struct thread *thread)
 	 */
 	if (!OSPF_GR_IS_ACTIVE_HELPER(nbr))
 		OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_InactivityTimer);
-	else if (IS_DEBUG_OSPF_GR)
+	else if (IS_DEBUG_OSPF_GR) {
 		zlog_debug(
-			"%s, Acting as HELPER for this neighbour, So inactivitytimer event will not be fired.",
+			"%s, Acting as HELPER for this neighbour, So restart the dead timer",
 			__func__);
+		OSPF_NSM_TIMER_ON(nbr->t_inactivity, ospf_inactivity_timer,
+				  nbr->v_inactivity);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Description:
	As per the RFC 3623 section 3.2,
	OSPF nbr shouldn't be deleted even in unsuccessful helper exit.

	1. Made the changes to keep neighbour even after exit.
	2. Restart the dead timer after expiry in helper. Otherwise, Restarter
	   will be in FULL state in helper forever until it receives the 'hello'.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>