### PR TITLE
zebra: add nhg id to show ip route json

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -965,6 +965,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 		json_object_int_add(json_route, "internalNextHopActiveNum",
 				    nexthop_group_active_nexthop_num(
 					    &(re->nhe->nhg)));
+		json_object_int_add(json_route, "nexthopGroupId", re->nhe_id);
 
 		json_object_string_add(json_route, "uptime", up_str);
 


### PR DESCRIPTION
Add json field nexthop group id to
'show ip route json'.

Testing Done:
```
{
  "27.0.0.14\/32":[
    {
      "prefix":"27.0.0.14\/32",
      "protocol":"bgp",
      "selected":true,
      "destSelected":true,
      "distance":20,
      "metric":0,
      "installed":true,
      "table":254,
      "internalStatus":16,
      "internalFlags":8,
      "internalNextHopNum":2,
      "internalNextHopActiveNum":2,
      "nexthopGroupId":103,     <---- New field
      "uptime":"00:04:37",
      "nexthops":[
        {
          "ip":"fe80::202:ff:fe00:11",
          "interfaceName":"uplink-1",
           ....
        },
        {
          "ip":"fe80::202:ff:fe00:1d",
          "interfaceName":"uplink-2",
          ...
        }
      ]
    }
  ]
}
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>