### PR TITLE
ospf6d: Ensure expire thread is properly stopped

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -288,7 +288,6 @@ void ospf6_install_lsa(struct ospf6_lsa *lsa)
 
 	monotime(&now);
 	if (!OSPF6_LSA_IS_MAXAGE(lsa)) {
-		lsa->expire = NULL;
 		thread_add_timer(master, ospf6_lsa_expire, lsa,
 				 OSPF_LSA_MAXAGE + lsa->birth.tv_sec
 					 - now.tv_sec,

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -304,24 +304,16 @@ void ospf6_abr_remove_unapproved_summaries(struct ospf6 *ospf6)
 		type = htons(OSPF6_LSTYPE_INTER_ROUTER);
 		for (ALL_LSDB_TYPED_ADVRTR(area->lsdb, type, ospf6->router_id,
 					   lsa)) {
-			if (CHECK_FLAG(lsa->flag, OSPF6_LSA_UNAPPROVED)) {
-				lsa->header->age = htons(OSPF_LSA_MAXAGE);
-				THREAD_OFF(lsa->refresh);
-				thread_execute(master, ospf6_lsa_expire, lsa,
-					       0);
-			}
+			if (CHECK_FLAG(lsa->flag, OSPF6_LSA_UNAPPROVED))
+				ospf6_lsa_premature_aging(lsa);
 		}
 
 		/* Inter area prefix LSA */
 		type = htons(OSPF6_LSTYPE_INTER_PREFIX);
 		for (ALL_LSDB_TYPED_ADVRTR(area->lsdb, type, ospf6->router_id,
 					   lsa)) {
-			if (CHECK_FLAG(lsa->flag, OSPF6_LSA_UNAPPROVED)) {
-				lsa->header->age = htons(OSPF_LSA_MAXAGE);
-				THREAD_OFF(lsa->refresh);
-				thread_execute(master, ospf6_lsa_expire, lsa,
-					       0);
-			}
+			if (CHECK_FLAG(lsa->flag, OSPF6_LSA_UNAPPROVED))
+				ospf6_lsa_premature_aging(lsa);
 		}
 	}
 


### PR DESCRIPTION
The lsa->expire thread is for keeping track of when we
are expecting to expire(remove/delete) a lsa.  There
are situations where we just decide to straight up
delete the lsa, but we are not ensuring that the
lsa is not already setup for expiration.
In that case just stop the expiry thread and
do the deletion.

Additionally there was a case where ospf6d was
just dropping the fact that a thread was already
scheduled for expiration.  In that case we
should just setup the timer again and it will
reset it appropriately.

Fixes: #9721
Signed-off-by: Donald Sharp <sharpd@nvidia.com>