### PR TITLE
pbrd: add vty support for actions (packet mangling)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,10 @@
 /aclocal.m4
 /libtool
 /libtool.orig
-/test-driver
-/test-suite.log
+/changelog-auto
+/m4/ac
+/pathd/
+/pceplib/
 
 /Makefile
 /Makefile.in
@@ -111,7 +113,9 @@ refix
 .vscode
 .kitchen
 .emacs.desktop*
+*.xref
 
+/test-driver
 /test-suite.log
 pceplib/test/*.log
 pceplib/test/*.trs

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -5,9 +5,8 @@ PBR
 ***
 
 :abbr:`PBR` is Policy Based Routing.  This implementation supports a very simple
-interface to allow admins to influence routing on their router.  At this time
-you can only match on destination and source prefixes for an incoming interface.
-At this point in time, this implementation will only work on Linux.
+interface to allow admins to influence routing on their router. At this point 
+in time, this implementation will only work on Linux.
 
 .. _starting-pbr:
 
@@ -153,8 +152,7 @@ end destination.
    Match packets according to the specified explicit congestion notification
    (ECN) field in the IP header; if this value matches then forward the packet
    according to the nexthop(s) specified.
-
-
+   
 .. clicmd:: set queue-id (1-65535)
 
    Set the egress port queue identifier for matched packets. The Linux Kernel
@@ -178,16 +176,54 @@ end destination.
 
    Strip inner vlan tags from matched packets. The Linux Kernel provider does not currently support packet mangling, so this field will be ignored unless another provider is used. It is invalid to specify both a `strip` and `set
    vlan` action.
+.. clicmd:: set src-ip [A.B.C.D/M|X:X::X:X/M]
+
+   Change the source IP address of matched packets, possibly using a mask `M`.
+   Note that this action is not currently supported by the Linux kernel
+   provider, so will be ignored unless other providers are used.
+
+.. clicmd:: set dst-ip [A.B.C.D/M|X:X::X:X/M]
+
+   Change the destination IP address of matched packets, possibly using a mask
+   `M`. Note that this action is not currently supported by the Linux kernel
+   provider, so will be ignored unless other providers are used.
+
+.. clicmd:: set src-port (1-65535)
+
+   Change the source port of matched packets. Note that this action only makes
+   sense with layer 4 protocols that use ports, such as TCP, UDP, and SCTP.
+   This action is not currently supported by the Linux kernel provider, so will 
+   be ignored unless other providers are used.
+
+.. clicmd:: set dst-port (1-65535)
+
+   Change the destination port of matched packets. Note that this action only 
+   makes sense with layer 4 protocols that use ports, such as TCP, UDP, and 
+   SCTP. This action is not currently supported by the Linux kernel provider, 
+   so will be ignored unless other providers are used.
+
+.. clicmd:: set dscp DSCP
+
+   Set the differentiated services code point (DSCP) of matched packets. This
+   action is not currently supported by the Linux kernel provider, so will be
+   ignored unless other providers are used.
+
+.. clicmd:: set ecn (0-3)
+
+   Set the explicit congestion notification (ECN) of matched packets. This
+   action is not currently supported by the Linux kernel provider, so will be
+   ignored unless other providers are used.   
 
 .. clicmd:: set nexthop-group NAME
 
    Use the nexthop-group NAME as the place to forward packets when the match
    commands have matched a packet.
 
-.. clicmd:: set nexthop [A.B.C.D|X:X::X:XX] [interface] [nexthop-vrf NAME]
+.. clicmd:: set nexthop [A.B.C.D|X:X::X:XX|drop] [interface] [nexthop-vrf NAME]
 
    Use this individual nexthop as the place to forward packets when the match
-   commands have matched a packet.
+   commands have matched a packet. If `drop`, packets will be sent to a
+   blackhole route and dropped.
 
 .. clicmd:: set vrf unchanged|NAME
 

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -1001,6 +1001,7 @@ void nexthop_group_write_nexthop_simple(struct vty *vty,
 		vty_out(vty, "%pI6 %s", &nh->gate.ipv6, ifname);
 		break;
 	case NEXTHOP_TYPE_BLACKHOLE:
+		vty_out(vty, "%s", "drop");
 		break;
 	}
 }

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -1,5 +1,9 @@
 /* Policy Based Routing (PBR) main header
  * Copyright (C) 2018 6WIND
+ * Portions:
+ *     Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *     Approved for Public Release; Distribution Unlimited 21-1402
+ *
  *
  * FRR is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -59,7 +63,7 @@ struct pbr_filter {
 	struct prefix src_ip;
 	struct prefix dst_ip;
 
-	/* Source and Destination higher-layer (TCP/UDP) port numbers. */
+	/* Source and Destination layer 4 (tcp, udp, etc.) port numbers. */
 	uint16_t src_port;
 	uint16_t dst_port;
 
@@ -89,6 +93,17 @@ struct pbr_action {
 	uint16_t vlan_flags;
 
 	uint32_t queue_id;
+
+	/* Source and Destination IP address with masks. */
+	struct prefix src_ip;
+	struct prefix dst_ip;
+
+	/* Source and Destination layer 4 (tcp, udp, etc.) port numbers. */
+	uint32_t src_port;
+	uint32_t dst_port;
+
+	/* Differentiated Services field  */
+	uint8_t dsfield; /* DSCP (6 bits) & ECN (2 bits) */
 
 	uint32_t table;
 };

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -2,6 +2,10 @@
  * PBR-map Header
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
+ * Portions:
+ *     Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *     Approved for Public Release; Distribution Unlimited 21-1402
+ *
  *
  * FRR is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -120,6 +124,20 @@ struct pbr_map_sequence {
 	unsigned char family;
 
 	/*
+	 * Actions
+	 */
+	struct prefix *action_src;
+	struct prefix *action_dst;
+
+#define PBR_UNDEFINED_VALUE 0xffffffff
+#define PBR_UNDEFINED_QUEUE_ID 0xff
+
+	uint16_t action_src_port;
+	uint16_t action_dst_port;
+
+	uint8_t action_dsfield;
+
+	/*
 	 * Use interface's vrf.
 	 */
 	bool vrf_unchanged;
@@ -232,7 +250,17 @@ extern void pbr_map_policy_delete(struct pbr_map *pbrm,
 extern void pbr_map_check_vrf_nh_group_change(const char *nh_group,
 					      struct pbr_vrf *pbr_vrf,
 					      uint32_t old_vrf_id);
+
 extern void pbr_map_check_interface_nh_group_change(const char *nh_group,
 						    struct interface *ifp,
 						    ifindex_t oldifindex);
+
+extern void pbr_set_action_clause_for_dscp(struct pbr_map_sequence *pbrms,
+					   uint8_t dscp_value);
+extern void pbr_reset_action_clause_for_dscp(struct pbr_map_sequence *pbrms);
+
+extern void pbr_set_action_clause_for_ecn(struct pbr_map_sequence *pbrms,
+					  uint8_t ecn_value);
+extern void pbr_reset_action_clause_for_ecn(struct pbr_map_sequence *pbrms);
+
 #endif

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -2,6 +2,9 @@
  * PBR - vty code
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
+ * Portions:
+ *     Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *     Approved for Public Release; Distribution Unlimited 21-1402
  *
  * FRR is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -193,6 +196,60 @@ DEFPY(pbr_map_match_dst, pbr_map_match_dst_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(pbr_map_action_src, pbr_map_action_src_cmd,
+      "[no] set src-ip <A.B.C.D/M|X:X::X:X/M>$prefix",
+      NO_STR
+      "set the rest of the command\n"
+      "choose the src ip or ipv6 prefix to use\n"
+      "v4 Prefix\n"
+      "v6 Prefix\n")
+{
+	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
+
+	pbrms->family = prefix->family;
+
+	if (!no) {
+		if (pbrms->action_src) {
+			if (prefix_same(pbrms->action_src, prefix))
+				return CMD_SUCCESS;
+		} else
+			pbrms->action_src = prefix_new();
+
+		prefix_copy(pbrms->action_src, prefix);
+	} else
+		prefix_free(&pbrms->action_src);
+
+	pbr_map_check(pbrms, true);
+	return CMD_SUCCESS;
+}
+
+DEFPY(pbr_map_action_dst, pbr_map_action_dst_cmd,
+      "[no] set dst-ip <A.B.C.D/M|X:X::X:X/M>$prefix",
+      NO_STR
+      "setthe rest of the command\n"
+      "set the dst ip or ipv6 prefix to use\n"
+      "v4 Prefix\n"
+      "v6 Prefix\n")
+{
+	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
+
+	pbrms->family = prefix->family;
+
+	if (!no) {
+		if (pbrms->action_dst) {
+			if (prefix_same(pbrms->action_dst, prefix))
+				return CMD_SUCCESS;
+		} else
+			pbrms->action_dst = prefix_new();
+
+		prefix_copy(pbrms->action_dst, prefix);
+	} else
+		prefix_free(&pbrms->action_dst);
+
+	pbr_map_check(pbrms, true);
+	return CMD_SUCCESS;
+}
+
 DEFPY(pbr_map_match_ip_proto, pbr_map_match_ip_proto_cmd,
       "[no] match ip-protocol [tcp|udp]$ip_proto",
       NO_STR
@@ -263,11 +320,115 @@ DEFPY(pbr_map_match_dst_port, pbr_map_match_dst_port_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(pbr_map_action_src_port, pbr_map_action_src_port_cmd,
+      "[no] set src-port (1-65535)$port",
+      NO_STR
+      "Match the rest of the command\n"
+      "Choose the destination port to use\n"
+      "The Destination Port\n")
+{
+	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
+
+	if (!no) {
+		if (pbrms->action_src_port == port)
+			return CMD_SUCCESS;
+
+		pbrms->action_src_port = port;
+	} else
+		pbrms->action_src_port = 0;
+
+	pbr_map_check(pbrms, true);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(pbr_map_action_dst_port, pbr_map_action_dst_port_cmd,
+      "[no] set dst-port (1-65535)$port",
+      NO_STR
+      "Match the rest of the command\n"
+      "Choose the destination port to use\n"
+      "The Destination Port\n")
+{
+	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
+
+	if (!no) {
+		if (pbrms->action_dst_port == port)
+			return CMD_SUCCESS;
+
+		pbrms->action_dst_port = port;
+	} else
+		pbrms->action_dst_port = 0;
+
+	pbr_map_check(pbrms, true);
+
+	return CMD_SUCCESS;
+}
+
 DEFPY(pbr_map_match_dscp, pbr_map_match_dscp_cmd,
       "[no] match dscp DSCP$dscp",
       NO_STR
       "Match the rest of the command\n"
       "Match based on IP DSCP field\n"
+      "DSCP value (below 64) or standard codepoint name\n")
+{
+	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
+	char dscpname[100];
+	uint8_t rawDscp;
+
+	/* Discriminate dscp enums (cs0, cs1 etc.) and numbers */
+	bool isANumber = true;
+
+	for (int i = 0; i < (int)strlen(dscp); i++) {
+		/* Letters are not numbers */
+		if (!isdigit(dscp[i]))
+			isANumber = false;
+
+		/* Lowercase the dscp enum (if needed) */
+		if (isupper(dscp[i]))
+			dscpname[i] = tolower(dscp[i]);
+		else
+			dscpname[i] = dscp[i];
+	}
+	dscpname[strlen(dscp)] = '\0';
+
+	if (isANumber) {
+		/* dscp passed is a regular number */
+		long dscpAsNum = strtol(dscp, NULL, 0);
+
+		if (dscpAsNum > PBR_DSFIELD_DSCP >> 2) {
+			/* Refuse to install on overflow */
+			vty_out(vty, "dscp (%s) must be less than 64\n", dscp);
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+		rawDscp = dscpAsNum;
+	} else {
+		/* check dscp if it is an enum like cs0 */
+		rawDscp = pbr_map_decode_dscp_enum(dscpname);
+		if (rawDscp > PBR_DSFIELD_DSCP) {
+			vty_out(vty, "Invalid dscp value: %s\n", dscpname);
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	}
+
+	if (!no) {
+		if (((pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2) == rawDscp)
+			return CMD_SUCCESS;
+		/* Set the DSCP bits of the DSField */
+		pbrms->dsfield =
+			(pbrms->dsfield & ~PBR_DSFIELD_DSCP) | (rawDscp << 2);
+	} else {
+		pbrms->dsfield &= ~PBR_DSFIELD_DSCP;
+	}
+
+	pbr_map_check(pbrms, true);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(pbr_map_action_dscp, pbr_map_action_dscp_cmd, "[no] set dscp DSCP$dscp",
+      NO_STR
+      "set the rest of the command\n"
+      "set based on IP DSCP field\n"
       "DSCP value (below 64) or standard codepoint name\n")
 {
 	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
@@ -308,18 +469,10 @@ DEFPY(pbr_map_match_dscp, pbr_map_match_dscp_cmd,
 		}
 	}
 
-	if (!no) {
-		if (((pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2) == rawDscp)
-			return CMD_SUCCESS;
-
-		/* Set the DSCP bits of the DSField */
-		pbrms->dsfield =
-			(pbrms->dsfield & ~PBR_DSFIELD_DSCP) | (rawDscp << 2);
-	} else {
-		pbrms->dsfield &= ~PBR_DSFIELD_DSCP;
-	}
-
-	pbr_map_check(pbrms, true);
+	if (!no)
+		pbr_set_action_clause_for_dscp(pbrms, rawDscp);
+	else
+		pbr_reset_action_clause_for_dscp(pbrms);
 
 	return CMD_SUCCESS;
 }
@@ -344,6 +497,22 @@ DEFPY(pbr_map_match_ecn, pbr_map_match_ecn_cmd,
 	}
 
 	pbr_map_check(pbrms, true);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(pbr_map_action_ecn, pbr_map_action_ecn_cmd, "[no] set ecn (0-3)$ecn",
+      NO_STR
+      "set the rest of the command\n"
+      "set based on IP ECN field\n"
+      "explicit Congestion Notification\n")
+{
+	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
+
+	if (!no)
+		pbr_set_action_clause_for_ecn(pbrms, ecn);
+	else
+		pbr_reset_action_clause_for_ecn(pbrms);
 
 	return CMD_SUCCESS;
 }
@@ -529,9 +698,10 @@ DEFPY(no_pbr_map_nexthop_group, no_pbr_map_nexthop_group_cmd,
 DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
       "set nexthop\
         <\
-	  <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
-	  |INTERFACE$intf\
-	>\
+			<A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
+			|INTERFACE$intf\
+			|drop$drop\
+		>\
         [nexthop-vrf NAME$vrf_name]",
       "Set for the PBR-MAP\n"
       "Specify one of the nexthops in this map\n"
@@ -539,6 +709,7 @@ DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
       "v6 Address\n"
       "Interface to use\n"
       "Interface to use\n"
+      "drop action\n"
       "If the nexthop is in a different vrf tell us\n"
       "The nexthop-vrf Name\n")
 {
@@ -601,8 +772,12 @@ DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
 				nhop.type = NEXTHOP_TYPE_IPV6;
 			}
 		}
-	} else
+	} else {
 		nhop.type = NEXTHOP_TYPE_IFINDEX;
+	}
+
+	if (drop)
+		nhop.type = NEXTHOP_TYPE_BLACKHOLE;
 
 	if (pbrms->nhg)
 		nh = nexthop_exists(pbrms->nhg, &nhop);
@@ -633,10 +808,11 @@ done:
 
 DEFPY(no_pbr_map_nexthop, no_pbr_map_nexthop_cmd,
       "no set nexthop\
-        [<\
-	  <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
-	  |INTERFACE$intf\
-	>\
+		[<\
+			<A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
+			|INTERFACE$intf\
+			|drop$drop\
+		>\
         [nexthop-vrf NAME$vrf_name]]",
       NO_STR
       "Set for the PBR-MAP\n"
@@ -645,6 +821,7 @@ DEFPY(no_pbr_map_nexthop, no_pbr_map_nexthop_cmd,
       "v6 Address\n"
       "Interface to use\n"
       "Interface to use\n"
+      "drop action \n"
       "If the nexthop is in a different vrf tell us\n"
       "The nexthop-vrf Name\n")
 {
@@ -820,6 +997,8 @@ static void vty_show_pbrms(struct vty *vty,
 			pbrms->installed ? "yes" : "no",
 			pbrms->reason ? rbuf : "Valid");
 
+	/* match clauses first */
+
 	if (pbrms->ip_proto) {
 		struct protoent *p;
 
@@ -831,12 +1010,14 @@ static void vty_show_pbrms(struct vty *vty,
 		vty_out(vty, "        SRC Match: %pFX\n", pbrms->src);
 	if (pbrms->dst)
 		vty_out(vty, "        DST Match: %pFX\n", pbrms->dst);
+
 	if (pbrms->dsfield & PBR_DSFIELD_DSCP)
 		vty_out(vty, "        DSCP Match: %u\n",
 			(pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2);
 	if (pbrms->dsfield & PBR_DSFIELD_ECN)
 		vty_out(vty, "        ECN Match: %u\n",
 			pbrms->dsfield & PBR_DSFIELD_ECN);
+
 	if (pbrms->mark)
 		vty_out(vty, "        MARK Match: %u\n", pbrms->mark);
 
@@ -851,6 +1032,31 @@ static void vty_show_pbrms(struct vty *vty,
 	if (pbrms->action_pcp)
 		vty_out(vty, "        Set PCP %u\n", pbrms->action_pcp);
 
+	if (pbrms->src_prt)
+		vty_out(vty, "        Match Src port %u\n", pbrms->src_prt);
+	if (pbrms->dst_prt)
+		vty_out(vty, "        Match Dst port %u\n", pbrms->dst_prt);
+
+	/* set actions */
+
+	if (pbrms->action_dsfield & PBR_DSFIELD_ECN)
+		vty_out(vty, "        Set ECN %u\n",
+			pbrms->action_dsfield & PBR_DSFIELD_ECN);
+	if (pbrms->action_dsfield & PBR_DSFIELD_DSCP)
+		vty_out(vty, "        Set DSCP %u\n",
+			(pbrms->action_dsfield & PBR_DSFIELD_DSCP) >> 2);
+
+	if (pbrms->action_dst)
+		vty_out(vty, "        Set DST IP %pFX\n", pbrms->action_dst);
+	if (pbrms->action_src)
+		vty_out(vty, "        Set SRC IP %pFX\n", pbrms->action_src);
+
+	if (pbrms->action_dst_port)
+		vty_out(vty, "        Set Dst port %u\n",
+			pbrms->action_dst_port);
+	if (pbrms->action_src_port)
+		vty_out(vty, "        Set Src port %u\n",
+			pbrms->action_src_port);
 
 	if (pbrms->nhgrp_name) {
 		vty_out(vty, "        Nexthop-Group: %s\n", pbrms->nhgrp_name);
@@ -1229,6 +1435,8 @@ static int pbr_vty_map_config_write_sequence(struct vty *vty,
 {
 	vty_out(vty, "pbr-map %s seq %u\n", pbrm->name, pbrms->seqno);
 
+	/* match first */
+
 	if (pbrms->src)
 		vty_out(vty, " match src-ip %pFX\n", pbrms->src);
 
@@ -1270,6 +1478,25 @@ static int pbr_vty_map_config_write_sequence(struct vty *vty,
 
 	if (pbrms->action_vlan_flags == PBR_MAP_STRIP_INNER_ANY)
 		vty_out(vty, " strip vlan any\n");
+	/* set commands */
+	if (pbrms->action_src)
+		vty_out(vty, " set src-ip %pFX\n", pbrms->action_src);
+
+	if (pbrms->action_dst)
+		vty_out(vty, " set dst-ip %pFX\n", pbrms->dst);
+
+	if (pbrms->action_dsfield & PBR_DSFIELD_DSCP)
+		vty_out(vty, " set dscp %u\n",
+			(pbrms->action_dsfield & PBR_DSFIELD_DSCP) >> 2);
+
+	if (pbrms->action_dsfield & PBR_DSFIELD_ECN)
+		vty_out(vty, " set ecn %u\n",
+			pbrms->action_dsfield & PBR_DSFIELD_ECN);
+
+	if (pbrms->action_dst_port)
+		vty_out(vty, " set dst-port %d\n", pbrms->action_dst_port);
+	if (pbrms->action_src_port)
+		vty_out(vty, " set src-port %d\n", pbrms->action_src_port);
 
 	if (pbrms->vrf_unchanged)
 		vty_out(vty, " set vrf unchanged\n");
@@ -1362,6 +1589,12 @@ void pbr_vty_init(void)
 	install_element(PBRMAP_NODE, &pbr_map_action_strip_vlan_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_action_vlan_id_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_action_pcp_cmd);
+	install_element(PBRMAP_NODE, &pbr_map_action_src_cmd);
+	install_element(PBRMAP_NODE, &pbr_map_action_dst_cmd);
+	install_element(PBRMAP_NODE, &pbr_map_action_dscp_cmd);
+	install_element(PBRMAP_NODE, &pbr_map_action_ecn_cmd);
+	install_element(PBRMAP_NODE, &pbr_map_action_src_port_cmd);
+	install_element(PBRMAP_NODE, &pbr_map_action_dst_port_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_nexthop_group_cmd);
 	install_element(PBRMAP_NODE, &no_pbr_map_nexthop_group_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_nexthop_cmd);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -516,6 +516,10 @@ uint8_t dplane_ctx_rule_get_dsfield(const struct zebra_dplane_ctx *ctx);
 uint8_t dplane_ctx_rule_get_old_dsfield(const struct zebra_dplane_ctx *ctx);
 uint8_t dplane_ctx_rule_get_ipproto(const struct zebra_dplane_ctx *ctx);
 uint8_t dplane_ctx_rule_get_old_ipproto(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_rule_get_old_src_port(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_rule_get_src_port(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_rule_get_dst_port(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_rule_get_old_dst_port(const struct zebra_dplane_ctx *ctx);
 const struct prefix *
 dplane_ctx_rule_get_src_ip(const struct zebra_dplane_ctx *ctx);
 const struct prefix *

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -967,7 +967,7 @@ static void zebra_pbr_display_port(struct vty *vty, uint32_t filter_bm,
 			    uint16_t port_min, uint16_t port_max,
 			    uint8_t proto)
 {
-	if (!(filter_bm & PBR_FILTER_PROTO)) {
+	if (!(filter_bm & PBR_FILTER_IP_PROTOCOL)) {
 		if (port_max)
 			vty_out(vty, ":udp/tcp:%d-%d",
 				port_min, port_max);


### PR DESCRIPTION
This PR adds PBR VTY support for a few more action fields in addition to setting next hop: source/destination IP, source/destination port, DSCP, and ECN. To my knowledge the kernel does not currently provided this packet mangling functionality, but other providers, such as `netfilter` and Open vSwitch, may.

Signed-off-by: Eli Baum <ebaum@mitre.org>