### PR TITLE
yang: replace an empty pattern with a zero-length restriction

### DIFF
--- a/yang/frr-nexthop.yang
+++ b/yang/frr-nexthop.yang
@@ -61,7 +61,7 @@ module frr-nexthop {
     type union {
       type inet:ip-address;
       type string {
-        pattern "";
+        length "0";
       }
     }
   }


### PR DESCRIPTION
No functional difference, but `length "0"` is more comprehensible.

Suggested-by: Christian Hopps <chopps@labn.net>
Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>