### PR TITLE
ospf6d: ospf6d is crashing upon receiving duplicated Grace LSA.

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -1028,15 +1028,8 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 		if (old)
 			ospf6_flood_clear(old);
 
-		/* (b) immediately flood and (c) remove from all retrans-list */
-		/* Prevent self-originated LSA to be flooded. this is to make
-		reoriginated instance of the LSA not to be rejected by other
-		routers
-		due to MinLSArrival. */
 		self_originated = (new->header->adv_router
 				   == from->ospf6_if->area->ospf6->router_id);
-		if (!self_originated)
-			ospf6_flood(from, new);
 
 		/* Received non-self-originated Grace LSA. */
 		if (IS_GRACE_LSA(new) && !self_originated) {
@@ -1081,6 +1074,14 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 				}
 			}
 		}
+
+		/* (b) immediately flood and (c) remove from all retrans-list */
+		/* Prevent self-originated LSA to be flooded. this is to make
+		 * reoriginated instance of the LSA not to be rejected by other
+		 * routers due to MinLSArrival.
+		 */
+		if (!self_originated)
+			ospf6_flood(from, new);
 
 		/* (d), installing lsdb, which may cause routing
 			table calculation (replacing database copy) */


### PR DESCRIPTION
ospf6 deamon is crashing when duplicated graces sent from SCAPPY tool.

back trace:
----------
warning: Unexpected size of section `.reg-xstate/31332' in core file.
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
51      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x000073ffd42ba801 in __GI_abort () at abort.c:79
#2  0x000073ffd42aa39a in __assert_fail_base (fmt=0x73ffd44317d8 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", 
    assertion=assertion@entry=0x1ceef30e2a2c "orig->retrans_count >= 0", file=file@entry=0x1ceef30e29cb "ospf6d/ospf6_flood.c", line=line@entry=234, 
    function=function@entry=0x1ceef30e3800 <__PRETTY_FUNCTION__.17913> "ospf6_decrement_retrans_count") at assert.c:92
#3  0x000073ffd42aa412 in __GI___assert_fail (assertion=assertion@entry=0x1ceef30e2a2c "orig->retrans_count >= 0", 
    file=file@entry=0x1ceef30e29cb "ospf6d/ospf6_flood.c", line=line@entry=234, 
    function=function@entry=0x1ceef30e3800 <__PRETTY_FUNCTION__.17913> "ospf6_decrement_retrans_count") at assert.c:101
#4  0x00001ceef30a5cae in ospf6_decrement_retrans_count (lsa=0x1ceef60ec0b0) at ospf6d/ospf6_flood.c:234
#5  0x00001ceef30a75d6 in ospf6_receive_lsa (from=from@entry=0x1ceef60e3900, lsa_header=lsa_header@entry=0x1ceef60be364) at ospf6d/ospf6_flood.c:1112
#6  0x00001ceef30bb07d in ospf6_lsupdate_recv (src=0x799c2720fce0, dst=0x799c2720fcf0, oh=<optimized out>, oi=<optimized out>)
    at ospf6d/ospf6_message.c:1483
#7  ospf6_receive (thread=<optimized out>) at ospf6d/ospf6_message.c:1731
#8  0x000073ffd4d14abc in thread_call (thread=thread@entry=0x799c2720ff20) at lib/thread.c:1681
#9  0x000073ffd4ce50d8 in frr_run (master=0x1ceef5ea5320) at lib/libfrr.c:1059
#10 0x00001ceef309db56 in main (argc=4, argv=0x799c27210238, envp=<optimized out>) at ospf6d/ospf6_main.c:229
(gdb) quit


Description:
-----------
	When grace lsa received, DUT is adding
	the copy of the  lsas  to all nbrs retransmission  list as part of
	flooding procedure and subsequently incrementing the rmt counter in
	the original the LSA. This counter is supposed to be decremented
	when ack is received by nbr and the lsa  will be removed from retransmission list.

	But in our current scenario,
	Step-1:
		When GR helper is disabled, if DUT receives the grace lsa
		it adds the lsa copy to nbrs retransmission list but original
		LSA will be discarded since GR helper disabled.
	Step-2:
		GR helper enabled and DUT receives the grace lsa, as part
		of flooding process all nbrs have same copy of lsa in their
		corresponding rmt list which was added in step -1 due to this
		the corresponding rmt counter in the original lsa is not getting
		incremented.
	Step-3:
		If the same copy of the grace lsa received by DUT, It considers
		as implicit ack from nbr if the same copy of the lsa exits in its
		rmt list and subsequently  decrement the rmt counter.
	Since counter is zero (because of step-1 and 2) , it is asserting while decrement.


Fix:
It shouldn't flood the grace LSA to link level unless it is  added to link state database.
If the grace lsa is valid and eligible to add to linkstate database then it is allowed to flood it.
So moving the flooding logic after grace lsa processing.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>