### PR TITLE
ospf6: fix del routing logging ospf6

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -2479,12 +2479,13 @@ DEFUN (debug_ospf6_brouter_router,
 
 DEFUN (no_debug_ospf6_brouter_router,
        no_debug_ospf6_brouter_router_cmd,
-       "no debug ospf6 border-routers router-id",
+       "no debug ospf6 border-routers router-id [A.B.C.D]",
        NO_STR
        DEBUG_STR
        OSPF6_STR
        "Debug border router\n"
        "Debug specific border router\n"
+       "Specify border-router's router-id\n"
       )
 {
 	OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER_OFF();
@@ -2510,12 +2511,13 @@ DEFUN (debug_ospf6_brouter_area,
 
 DEFUN (no_debug_ospf6_brouter_area,
        no_debug_ospf6_brouter_area_cmd,
-       "no debug ospf6 border-routers area-id",
+       "no debug ospf6 border-routers area-id [A.B.C.D]",
        NO_STR
        DEBUG_STR
        OSPF6_STR
        "Debug border router\n"
        "Debug border routers in specific Area\n"
+       "Specify Area-ID\n"
       )
 {
 	OSPF6_DEBUG_BROUTER_SPECIFIC_AREA_OFF();


### PR DESCRIPTION
The command 'del routing logging ospf6' is not working properly in yams
after applying logging ospf6 configuration.

Update the 'no debug ospf6 border-routers router-id' command in frr by
specifying the exact router-id that needs to be deleted.

Do the same for 'no debug ospf6 border-routers area-id' command.

Signed-off-by: Ahmad Caracalli <ahmad.caracalli@6wind.com>