### PR TITLE
topotests: improve bfd_ospf_topo1 test

### DIFF
--- a/tests/topotests/bfd_ospf_topo1/rt1/ospf6d.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt1/ospf6d.conf
@@ -6,10 +6,14 @@ hostname rt1
 password 1
 !
 interface eth-rt2
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
  ipv6 ospf6 bfd
 !
 interface eth-rt3
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
  ipv6 ospf6 bfd
 !

--- a/tests/topotests/bfd_ospf_topo1/rt1/ospfd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt1/ospfd.conf
@@ -10,13 +10,19 @@ debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 interface eth-rt2
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
  ip ospf bfd
 !
 interface eth-rt3
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
  ip ospf bfd
 !
 router ospf

--- a/tests/topotests/bfd_ospf_topo1/rt2/ospf6d.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt2/ospf6d.conf
@@ -5,10 +5,14 @@ hostname rt2
 password 1
 !
 interface eth-rt1
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
  ipv6 ospf6 bfd
 !
 interface eth-rt5
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
 !
 router ospf6

--- a/tests/topotests/bfd_ospf_topo1/rt2/ospfd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt2/ospfd.conf
@@ -9,13 +9,19 @@ debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 interface eth-rt1
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
  ip ospf bfd
 !
 interface eth-rt5
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 router ospf
  ospf router-id 2.2.2.2

--- a/tests/topotests/bfd_ospf_topo1/rt3/ospf6d.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt3/ospf6d.conf
@@ -5,10 +5,14 @@ hostname rt3
 password 1
 !
 interface eth-rt1
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
  ipv6 ospf6 bfd
 !
 interface eth-rt4
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
 !
 router ospf6

--- a/tests/topotests/bfd_ospf_topo1/rt3/ospfd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt3/ospfd.conf
@@ -9,13 +9,19 @@ debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 interface eth-rt1
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
  ip ospf bfd
 !
 interface eth-rt4
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 router ospf
  ospf router-id 3.3.3.3

--- a/tests/topotests/bfd_ospf_topo1/rt4/ospf6d.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt4/ospf6d.conf
@@ -5,9 +5,13 @@ hostname rt4
 password 1
 !
 interface eth-rt3
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
 !
 interface eth-rt5
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
 !
 router ospf6

--- a/tests/topotests/bfd_ospf_topo1/rt4/ospfd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt4/ospfd.conf
@@ -9,12 +9,18 @@ debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 interface eth-rt3
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 interface eth-rt5
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 router ospf
  ospf router-id 4.4.4.4

--- a/tests/topotests/bfd_ospf_topo1/rt5/ospf6d.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt5/ospf6d.conf
@@ -6,9 +6,13 @@ password 1
 !
 interface eth-rt2
  ipv6 ospf6 network broadcast
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
 !
 interface eth-rt4
  ipv6 ospf6 network broadcast
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
 !
 router ospf6
  ospf6 router-id 5.5.5.5

--- a/tests/topotests/bfd_ospf_topo1/rt5/ospfd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt5/ospfd.conf
@@ -9,12 +9,18 @@ debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 interface eth-rt2
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 interface eth-rt4
  ip ospf area 0.0.0.0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
 !
 router ospf
  ospf router-id 5.5.5.5

--- a/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
+++ b/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
@@ -195,8 +195,8 @@ def test_bfd_ospf_interface_failure_rt2_step3():
 
     # By default BFD provides a recovery time of 900ms plus jitter, so let's wait
     # initial 2 seconds to let the CI not suffer.
-    # TODO: add check for array size
-    sleep(2)
+    topotest.sleep(2, 'Wait for BFD down notification')
+
     router_compare_json_output(
         "rt1", "show ip route ospf json", "step3/show_ip_route_rt2_down.ref", 1, 0
     )
@@ -234,8 +234,7 @@ def test_bfd_ospf_interface_failure_rt3_step3():
 
     # By default BFD provides a recovery time of 900ms plus jitter, so let's wait
     # initial 2 seconds to let the CI not suffer.
-    # TODO: add check for array size
-    sleep(2)
+    topotest.sleep(2, 'Wait for BFD down notification')
     router_compare_json_output(
         "rt1", "show ip route ospf json", "step3/show_ip_route_rt3_down.ref", 1, 0
     )

--- a/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
+++ b/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
@@ -132,7 +132,7 @@ def print_cmd_result(rname, command):
     print(get_topogen().gears[rname].vtysh_cmd(command, isjson=False))
 
 
-def router_compare_json_output(rname, command, reference, count=120, wait=0.5):
+def router_compare_json_output(rname, command, reference, count=40, wait=2):
     "Compare router JSON output"
 
     logger.info('Comparing router "%s" "%s" output', rname, command)
@@ -141,7 +141,7 @@ def router_compare_json_output(rname, command, reference, count=120, wait=0.5):
     filename = "{}/{}/{}".format(CWD, rname, reference)
     expected = json.loads(open(filename).read())
 
-    # Run test function until we get an result. Wait at most 60 seconds.
+    # Run test function until we get an result. Wait at most 80 seconds.
     test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
     _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
     assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)


### PR DESCRIPTION
Some improvements to reduce pressure and run time.

**Previous run time**
```
5 passed in 112.46 seconds
```

**New run time**
```
5 passed in 69.24 seconds
```
