### PR TITLE
pimd: fix segv when deleting pim interface

### DIFF
--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -688,6 +688,7 @@ void pim_neighbor_delete_all(struct interface *ifp, const char *delete_message)
 	for (ALL_LIST_ELEMENTS(pim_ifp->pim_neighbor_list, neigh_node,
 			       neigh_nextnode, neigh)) {
 		pim_neighbor_delete(ifp, neigh, delete_message);
+		list_delete_node(neigh_node);
 	}
 }
 


### PR DESCRIPTION
When deleting a pim interface with multiple neighbors on it:
1. The list of neighbors `pim_neighbor_list` is iterated through
2. `pim_neighbor_delete` is called with each neighbor struct, which calls
3. `list_delete(&neigh->jp_upstream_agg)`, which calls
4. `pim_jp_agg_group_list_free()` for each item, which calls
5. `list_delete(&jag->sources)`, which calls
6. `pim_jp_agg_src_free()` for each item, which calls
7. `join_timer_start(js->up)`, which calls
8. `pim_neighbor_find(up->rpf.source_nexthop.interface, ...)`, which
   iterates `pim_neighbor_list` from step 1

However in step 1 after calling `pim_neighbor_delete` for the pim
neighbor for that list item we don't delete the list item and so the
pointer to the now-freed neighbor remains in the list so when deleting
neighbors after the 0th one in the list, when we hit step 8 we access
stale pointers sometimes causing a segv.

Depending on various other conditions we may not get past step 6 making
this problem intermittent.

Fix this by deleting the list node when we have deleted the data
it points to.

Signed-off-by: Quentin Young <qlyoung@nvidia.com>