### PR TITLE
zebra: add installed nexthop-group id value

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -108,8 +108,11 @@ struct route_entry {
 	struct nexthop_group fib_ng;
 	struct nexthop_group fib_backup_ng;
 
-	/* Nexthop group hash entry ID */
+	/* Nexthop group hash entry IDs. The "installed" id is the id
+	 * used in linux/netlink, if available.
+	 */
 	uint32_t nhe_id;
+	uint32_t nhe_installed_id;
 
 	/* Tag */
 	route_tag_t tag;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2448,6 +2448,8 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 			ret = ENOENT;
 			goto done;
 		}
+
+		re->nhe_installed_id = nhe->id;
 	}
 #endif /* HAVE_NETLINK */
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -540,8 +540,14 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 
 		vty_out(vty, "  Last update %s ago\n", buf);
 
-		if (show_ng)
+		if (show_ng) {
 			vty_out(vty, "  Nexthop Group ID: %u\n", re->nhe_id);
+			if (re->nhe_installed_id != 0
+			    && re->nhe_id != re->nhe_installed_id)
+				vty_out(vty,
+					"  Installed Nexthop Group ID: %u\n",
+					re->nhe_installed_id);
+		}
 
 		for (ALL_NEXTHOPS(re->nhe->nhg, nexthop)) {
 			/* Use helper to format each nexthop */
@@ -976,6 +982,11 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 				    nexthop_group_active_nexthop_num(
 					    &(re->nhe->nhg)));
 		json_object_int_add(json_route, "nexthopGroupId", re->nhe_id);
+
+		if (re->nhe_installed_id != 0)
+			json_object_int_add(json_route,
+					    "installedNexthopGroupId",
+					    re->nhe_installed_id);
 
 		json_object_string_add(json_route, "uptime", up_str);
 


### PR DESCRIPTION
In some cases, zebra may install a nexthop-group id that is
different from the id of the nhe struct attached to a
route-entry. This happens for a singleton recursive nexthop,
for example, where the resolving nexthop's id is installed.

The installed value is the most useful value - that corresponds
to information in the kernel on linux/netlink platforms that
support nhgs. Add the installed value to the show route cli
output if it differs, and include both values in the json form.
