### PR TITLE
ospf6d: add support for NSSA Type-7 address ranges

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -204,6 +204,21 @@ OSPF6 area
    existence of a default route in the RIB that wasn't learned via the OSPF
    protocol.
 
+.. clicmd:: area A.B.C.D nssa range X:X::X:X/M [<not-advertise|cost (0-16777215)>]
+
+.. clicmd:: area (0-4294967295) nssa range X:X::X:X/M [<not-advertise|cost (0-16777215)>]
+
+    Summarize a group of external subnets into a single Type-7 LSA, which is
+    then translated to a Type-5 LSA and avertised to the backbone.
+    This command can only be used at the area boundary (NSSA ABR router).
+
+    By default, the metric of the summary route is calculated as the highest
+    metric among the summarized routes. The `cost` option, however, can be used
+    to set an explicit metric.
+
+    The `not-advertise` option, when present, prevents the summary route from
+    being advertised, effectively filtering the summarized routes.
+
 .. clicmd:: area A.B.C.D export-list NAME
 
 .. clicmd:: area (0-4294967295) export-list NAME

--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -176,7 +176,7 @@ OSPF6 area
     The `not-advertise` option, when present, prevents the summary route from
     being advertised, effectively filtering the summarized routes.
 
-.. clicmd:: area A.B.C.D nssa [no-summary]
+.. clicmd:: area A.B.C.D nssa [no-summary] [default-information-originate [metric-type (1-2)] [metric (0-16777214)]]
 
 .. clicmd:: area (0-4294967295) nssa [no-summary] [default-information-originate [metric-type (1-2)] [metric (0-16777214)]]
 

--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -96,8 +96,7 @@ static int ospf6_abr_nexthops_belong_to_area(struct ospf6_route *route,
 		return 0;
 }
 
-static void ospf6_abr_delete_route(struct ospf6_route *range,
-				   struct ospf6_route *summary,
+static void ospf6_abr_delete_route(struct ospf6_route *summary,
 				   struct ospf6_route_table *summary_table,
 				   struct ospf6_lsa *old)
 {
@@ -375,8 +374,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 					zlog_debug(
 						"The range is not active. withdraw");
 
-				ospf6_abr_delete_route(route, summary,
-						       summary_table, old);
+				ospf6_abr_delete_route(summary, summary_table,
+						       old);
 			}
 		} else if (old) {
 			ospf6_route_remove(summary, summary_table);
@@ -390,7 +389,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 			zlog_debug(
 				"Area has been stubbed, purge Inter-Router LSA");
 
-		ospf6_abr_delete_route(route, summary, summary_table, old);
+		ospf6_abr_delete_route(summary, summary_table, old);
 		return 0;
 	}
 
@@ -399,7 +398,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		if (is_debug)
 			zlog_debug("Area has been stubbed, purge prefix LSA");
 
-		ospf6_abr_delete_route(route, summary, summary_table, old);
+		ospf6_abr_delete_route(summary, summary_table, old);
 		return 0;
 	}
 
@@ -434,8 +433,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 			if (is_debug)
 				zlog_debug(
 					"This is the secondary path to the ASBR, ignore");
-			ospf6_abr_delete_route(route, summary, summary_table,
-					       old);
+			ospf6_abr_delete_route(summary, summary_table, old);
 			return 0;
 		}
 
@@ -465,8 +463,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 				zlog_debug(
 					"Suppressed by range %pFX of area %s",
 					&range->prefix, route_area->name);
-			ospf6_abr_delete_route(route, summary, summary_table,
-					       old);
+			ospf6_abr_delete_route(summary, summary_table, old);
 			return 0;
 		}
 	}
@@ -478,8 +475,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 			if (is_debug)
 				zlog_debug(
 					"This is the range with DoNotAdvertise set. ignore");
-			ospf6_abr_delete_route(route, summary, summary_table,
-					       old);
+			ospf6_abr_delete_route(summary, summary_table, old);
 			return 0;
 		}
 
@@ -487,8 +483,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		if (!CHECK_FLAG(route->flag, OSPF6_ROUTE_ACTIVE_SUMMARY)) {
 			if (is_debug)
 				zlog_debug("The range is not active. withdraw");
-			ospf6_abr_delete_route(route, summary, summary_table,
-					       old);
+			ospf6_abr_delete_route(summary, summary_table, old);
 			return 0;
 		}
 	}

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -306,6 +306,8 @@ struct ospf6_area *ospf6_area_create(uint32_t area_id, struct ospf6 *o, int df)
 
 	oa->range_table = OSPF6_ROUTE_TABLE_CREATE(AREA, PREFIX_RANGES);
 	oa->range_table->scope = oa;
+	oa->nssa_range_table = OSPF6_ROUTE_TABLE_CREATE(AREA, PREFIX_RANGES);
+	oa->nssa_range_table->scope = oa;
 	oa->summary_prefix = OSPF6_ROUTE_TABLE_CREATE(AREA, SUMMARY_PREFIXES);
 	oa->summary_prefix->scope = oa;
 	oa->summary_router = OSPF6_ROUTE_TABLE_CREATE(AREA, SUMMARY_ROUTERS);
@@ -360,6 +362,7 @@ void ospf6_area_delete(struct ospf6_area *oa)
 	ospf6_route_table_delete(oa->route_table);
 
 	ospf6_route_table_delete(oa->range_table);
+	ospf6_route_table_delete(oa->nssa_range_table);
 	ospf6_route_table_delete(oa->summary_prefix);
 	ospf6_route_table_delete(oa->summary_router);
 
@@ -689,6 +692,22 @@ void ospf6_area_config_write(struct vty *vty, struct ospf6 *ospf6)
 			}
 			if (oa->no_summary)
 				vty_out(vty, " no-summary");
+			vty_out(vty, "\n");
+		}
+		for (range = ospf6_route_head(oa->nssa_range_table); range;
+		     range = ospf6_route_next(range)) {
+			vty_out(vty, " area %s nssa range %pFX", oa->name,
+				&range->prefix);
+
+			if (CHECK_FLAG(range->flag,
+				       OSPF6_ROUTE_DO_NOT_ADVERTISE)) {
+				vty_out(vty, " not-advertise");
+			} else {
+				if (range->path.u.cost_config
+				    != OSPF_AREA_RANGE_COST_UNSPEC)
+					vty_out(vty, " cost %u",
+						range->path.u.cost_config);
+			}
 			vty_out(vty, "\n");
 		}
 		if (PREFIX_NAME_IN(oa))

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -306,7 +306,6 @@ struct ospf6_area *ospf6_area_create(uint32_t area_id, struct ospf6 *o, int df)
 
 	oa->range_table = OSPF6_ROUTE_TABLE_CREATE(AREA, PREFIX_RANGES);
 	oa->range_table->scope = oa;
-	bf_init(oa->range_table->idspace, 32);
 	oa->summary_prefix = OSPF6_ROUTE_TABLE_CREATE(AREA, SUMMARY_PREFIXES);
 	oa->summary_prefix->scope = oa;
 	oa->summary_router = OSPF6_ROUTE_TABLE_CREATE(AREA, SUMMARY_ROUTERS);

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -576,8 +576,6 @@ DEFUN (area_range,
 
 	range->path.u.cost_config = cost;
 
-	zlog_debug("%s: for prefix %s, flag = %x", __func__,
-		   argv[idx_ipv6_prefixlen]->arg, range->flag);
 	if (range->rnode == NULL) {
 		ospf6_route_add(range, oa->range_table);
 	}

--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -46,6 +46,7 @@ struct ospf6_area {
 	/* Summary routes to be originated (includes Configured Address Ranges)
 	 */
 	struct ospf6_route_table *range_table;
+	struct ospf6_route_table *nssa_range_table;
 	struct ospf6_route_table *summary_prefix;
 	struct ospf6_route_table *summary_router;
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1241,7 +1241,6 @@ struct in6_addr *ospf6_interface_get_global_address(struct interface *ifp)
 {
 	struct listnode *n;
 	struct connected *c;
-	struct in6_addr *l = (struct in6_addr *)NULL;
 
 	/* for each connected address */
 	for (ALL_LIST_ELEMENTS_RO(ifp->connected, n, c)) {
@@ -1250,9 +1249,10 @@ struct in6_addr *ospf6_interface_get_global_address(struct interface *ifp)
 			continue;
 
 		if (!IN6_IS_ADDR_LINKLOCAL(&c->address->u.prefix6))
-			l = &c->address->u.prefix6;
+			return &c->address->u.prefix6;
 	}
-	return l;
+
+	return NULL;
 }
 
 

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -1070,7 +1070,7 @@ DEFPY (debug_ospf6_lsa_aggregation,
 
 DEFUN (debug_ospf6_lsa_type,
        debug_ospf6_lsa_hex_cmd,
-       "debug ospf6 lsa <router|network|inter-prefix|inter-router|as-external|link|intra-prefix|unknown> [<originate|examine|flooding>]",
+       "debug ospf6 lsa <router|network|inter-prefix|inter-router|as-external|nssa|link|intra-prefix|unknown> [<originate|examine|flooding>]",
        DEBUG_STR
        OSPF6_STR
        "Debug Link State Advertisements (LSAs)\n"
@@ -1079,6 +1079,7 @@ DEFUN (debug_ospf6_lsa_type,
        "Display Inter-Area-Prefix LSAs\n"
        "Display Inter-Router LSAs\n"
        "Display As-External LSAs\n"
+       "Display NSSA LSAs\n"
        "Display Link LSAs\n"
        "Display Intra-Area-Prefix LSAs\n"
        "Display LSAs of unknown origin\n"
@@ -1122,7 +1123,7 @@ DEFUN (debug_ospf6_lsa_type,
 
 DEFUN (no_debug_ospf6_lsa_type,
        no_debug_ospf6_lsa_hex_cmd,
-       "no debug ospf6 lsa <router|network|inter-prefix|inter-router|as-external|link|intra-prefix|unknown> [<originate|examine|flooding>]",
+       "no debug ospf6 lsa <router|network|inter-prefix|inter-router|as-external|nssa|link|intra-prefix|unknown> [<originate|examine|flooding>]",
        NO_STR
        DEBUG_STR
        OSPF6_STR
@@ -1132,6 +1133,7 @@ DEFUN (no_debug_ospf6_lsa_type,
        "Display Inter-Area-Prefix LSAs\n"
        "Display Inter-Router LSAs\n"
        "Display As-External LSAs\n"
+       "Display NSSA LSAs\n"
        "Display Link LSAs\n"
        "Display Intra-Area-Prefix LSAs\n"
        "Display LSAs of unknown origin\n"

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -87,11 +87,6 @@
 #define OSPF6_SCOPE_AS         0x4000
 #define OSPF6_SCOPE_RESERVED   0x6000
 
-/* AS-external-LSA refresh method. */
-#define LSA_REFRESH_IF_CHANGED  0
-#define LSA_REFRESH_FORCE       1
-
-
 /* XXX U-bit handling should be treated here */
 #define OSPF6_LSA_SCOPE(type) (ntohs(type) & OSPF6_LSTYPE_SCOPE_MASK)
 

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -48,7 +48,7 @@
 #include "ospf6_gr.h"
 #include "lib/json.h"
 
-DEFINE_MTYPE(OSPF6D, OSPF6_NEIGHBOR, "OSPF6 neighbor");
+DEFINE_MTYPE_STATIC(OSPF6D, OSPF6_NEIGHBOR, "OSPF6 neighbor");
 
 DEFINE_HOOK(ospf6_neighbor_change,
 	    (struct ospf6_neighbor * on, int state, int next_state),

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -409,7 +409,6 @@ static struct ospf6_lsa *ospf6_lsa_translated_nssa_new(struct ospf6_area *area,
 	caddr_t old_ptr, new_ptr;
 	struct ospf6_as_external_lsa *nssa;
 	struct prefix prefix;
-	struct ospf6_route *match;
 	struct ospf6 *ospf6 = area->ospf6;
 	ptrdiff_t tag_offset = 0;
 	route_tag_t network_order;
@@ -447,15 +446,6 @@ static struct ospf6_lsa *ospf6_lsa_translated_nssa_new(struct ospf6_area *area,
 	prefix.family = AF_INET6;
 	prefix.prefixlen = nssa->prefix.prefix_length;
 	ospf6_prefix_in6_addr(&prefix.u.prefix6, nssa, &nssa->prefix);
-
-	/* Find the LSA from the external route */
-	match = ospf6_route_lookup(&prefix, area->route_table);
-	if (match == NULL) {
-		if (IS_OSPF6_DEBUG_NSSA)
-			zlog_debug("%s : no matching route %pFX", __func__,
-				   &prefix);
-		return NULL;
-	}
 
 	/* set Prefix */
 	memcpy(new_ptr, old_ptr, OSPF6_PREFIX_SPACE(ext->prefix.prefix_length));

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -402,7 +402,7 @@ static void ospf6_abr_unapprove_translates(struct ospf6 *ospf6)
 static struct ospf6_lsa *ospf6_lsa_translated_nssa_new(struct ospf6_area *area,
 						       struct ospf6_lsa *type7)
 {
-	char *buffer;
+	char buffer[OSPF6_MAX_LSASIZE];
 	struct ospf6_lsa *lsa;
 	struct ospf6_as_external_lsa *ext, *extnew;
 	struct ospf6_lsa_header *lsa_header;
@@ -424,7 +424,8 @@ static struct ospf6_lsa *ospf6_lsa_translated_nssa_new(struct ospf6_area *area,
 		return NULL;
 	}
 
-	buffer = XCALLOC(MTYPE_OSPF6_LSA, OSPF6_MAX_LSASIZE);
+	/* prepare buffer */
+	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
 	extnew = (struct ospf6_as_external_lsa
 			  *)((caddr_t)lsa_header

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -262,22 +262,20 @@ static void ospf6_abr_announce_aggregates(struct ospf6 *ospf6)
 {
 	struct ospf6_area *area;
 	struct ospf6_route *range;
-	struct listnode *node, *nnode;
+	struct listnode *node;
 
 	if (IS_OSPF6_DEBUG_ABR)
 		zlog_debug("ospf6_abr_announce_aggregates(): Start");
-
-	for (ALL_LIST_ELEMENTS(ospf6->area_list, node, nnode, area)) {
-		for (range = ospf6_route_head(area->range_table); range;
-		     range = ospf6_route_next(range))
-			ospf6_abr_range_update(range, ospf6);
-	}
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, area)) {
 		if (IS_OSPF6_DEBUG_ABR)
 			zlog_debug(
 				"ospf_abr_announce_aggregates(): looking at area %pI4",
 				&area->area_id);
+
+		for (range = ospf6_route_head(area->range_table); range;
+		     range = ospf6_route_next(range))
+			ospf6_abr_range_update(range, ospf6);
 	}
 
 	if (IS_OSPF6_DEBUG_ABR)

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -1249,10 +1249,14 @@ static struct in6_addr *ospf6_get_nssa_fwd_addr(struct ospf6_area *oa)
 	struct ospf6_interface *oi;
 
 	for (ALL_LIST_ELEMENTS(oa->if_list, node, nnode, oi)) {
-		if (if_is_operative(oi->interface))
-			if (oi->area && IS_AREA_NSSA(oi->area))
-				return ospf6_interface_get_global_address(
-					oi->interface);
+		struct in6_addr *addr;
+
+		if (!if_is_operative(oi->interface))
+			continue;
+
+		addr = ospf6_interface_get_global_address(oi->interface);
+		if (addr)
+			return addr;
 	}
 	return NULL;
 }

--- a/ospf6d/ospf6_nssa.h
+++ b/ospf6d/ospf6_nssa.h
@@ -55,8 +55,6 @@ extern void ospf6_nssa_lsa_flush(struct ospf6 *ospf6, struct prefix_ipv6 *p);
 extern struct ospf6_lsa *ospf6_translated_nssa_refresh(struct ospf6_area *oa,
 						       struct ospf6_lsa *type7,
 						       struct ospf6_lsa *type5);
-extern struct ospf6_lsa *
-ospf6_translated_nssa_originate(struct ospf6_area *oa, struct ospf6_lsa *type7);
 
 extern void ospf6_asbr_nssa_redist_task(struct ospf6 *ospf6);
 
@@ -69,8 +67,6 @@ extern void install_element_ospf6_debug_nssa(void);
 extern void ospf6_abr_nssa_type_7_defaults(struct ospf6 *osof6);
 int ospf6_redistribute_check(struct ospf6 *ospf6, struct ospf6_route *route,
 			     int type);
-extern int ospf6_abr_translate_nssa(struct ospf6_area *area,
-				    struct ospf6_lsa *lsa);
 extern void ospf6_abr_check_translate_nssa(struct ospf6_area *area,
 					   struct ospf6_lsa *lsa);
 extern void ospf6_abr_nssa_check_status(struct ospf6 *ospf6);

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1100,7 +1100,6 @@ struct ospf6_route_table *ospf6_route_table_create(int s, int t)
 void ospf6_route_table_delete(struct ospf6_route_table *table)
 {
 	ospf6_route_remove_all(table);
-	bf_free(table->idspace);
 	route_table_finish(table->table);
 	XFREE(MTYPE_OSPF6_ROUTE_TABLE, table);
 }

--- a/ospf6d/ospf6_route.h
+++ b/ospf6d/ospf6_route.h
@@ -241,8 +241,6 @@ struct ospf6_route_table {
 
 	uint32_t count;
 
-	bitfield_t idspace;
-
 	/* hooks */
 	void (*hook_add)(struct ospf6_route *);
 	void (*hook_change)(struct ospf6_route *);

--- a/ospf6d/ospf6_route.h
+++ b/ospf6d/ospf6_route.h
@@ -186,7 +186,7 @@ struct ospf6_route {
 	struct timeval changed;
 
 	/* flag */
-	uint8_t flag;
+	uint16_t flag;
 
 	/* Prefix Options */
 	uint8_t prefix_options;
@@ -221,14 +221,15 @@ struct ospf6_route {
 #define OSPF6_DEST_TYPE_RANGE      5
 #define OSPF6_DEST_TYPE_MAX        6
 
-#define OSPF6_ROUTE_CHANGE           0x01
-#define OSPF6_ROUTE_ADD              0x02
-#define OSPF6_ROUTE_REMOVE           0x04
-#define OSPF6_ROUTE_BEST             0x08
-#define OSPF6_ROUTE_ACTIVE_SUMMARY   0x10
-#define OSPF6_ROUTE_DO_NOT_ADVERTISE 0x20
-#define OSPF6_ROUTE_WAS_REMOVED      0x40
-#define OSPF6_ROUTE_BLACKHOLE_ADDED  0x80
+#define OSPF6_ROUTE_CHANGE           0x0001
+#define OSPF6_ROUTE_ADD              0x0002
+#define OSPF6_ROUTE_REMOVE           0x0004
+#define OSPF6_ROUTE_BEST             0x0008
+#define OSPF6_ROUTE_ACTIVE_SUMMARY   0x0010
+#define OSPF6_ROUTE_DO_NOT_ADVERTISE 0x0020
+#define OSPF6_ROUTE_WAS_REMOVED      0x0040
+#define OSPF6_ROUTE_BLACKHOLE_ADDED  0x0080
+#define OSPF6_ROUTE_NSSA_RANGE       0x0100
 struct ospf6;
 
 struct ospf6_route_table {

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -99,6 +99,7 @@ clippy_scan += \
 	ospf6d/ospf6_lsa.c \
 	ospf6d/ospf6_gr_helper.c \
 	ospf6d/ospf6_gr.c \
+	ospf6d/ospf6_nssa.c \
 	ospf6d/ospf6_route.c \
 	# end
 

--- a/tests/topotests/ospf6_topo2/r1/ospf6d.conf
+++ b/tests/topotests/ospf6_topo2/r1/ospf6d.conf
@@ -2,6 +2,10 @@ debug ospf6 lsa router
 debug ospf6 lsa router originate
 debug ospf6 lsa router examine
 debug ospf6 lsa router flooding
+debug ospf6 lsa nssa
+debug ospf6 lsa nssa originate
+debug ospf6 lsa nssa examine
+debug ospf6 lsa nssa flooding
 debug ospf6 lsa as-external
 debug ospf6 lsa as-external originate
 debug ospf6 lsa as-external examine
@@ -15,7 +19,6 @@ debug ospf6 zebra
 debug ospf6 interface
 debug ospf6 neighbor
 debug ospf6 flooding
-debug ospf6 gr helper
 debug ospf6 spf process
 debug ospf6 route intra-area
 debug ospf6 route inter-area
@@ -24,11 +27,11 @@ debug ospf6 asbr
 debug ospf6 nssa
 !
 interface r1-eth0
+ ipv6 ospf6 area 0.0.0.1
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
 router ospf6
  ospf6 router-id 10.254.254.1
  area 0.0.0.1 stub
- interface r1-eth0 area 0.0.0.1
 !

--- a/tests/topotests/ospf6_topo2/r2/ospf6d.conf
+++ b/tests/topotests/ospf6_topo2/r2/ospf6d.conf
@@ -2,6 +2,10 @@ debug ospf6 lsa router
 debug ospf6 lsa router originate
 debug ospf6 lsa router examine
 debug ospf6 lsa router flooding
+debug ospf6 lsa nssa
+debug ospf6 lsa nssa originate
+debug ospf6 lsa nssa examine
+debug ospf6 lsa nssa flooding
 debug ospf6 lsa as-external
 debug ospf6 lsa as-external originate
 debug ospf6 lsa as-external examine
@@ -15,7 +19,6 @@ debug ospf6 zebra
 debug ospf6 interface
 debug ospf6 neighbor
 debug ospf6 flooding
-debug ospf6 gr helper
 debug ospf6 spf process
 debug ospf6 route intra-area
 debug ospf6 route inter-area
@@ -24,14 +27,17 @@ debug ospf6 asbr
 debug ospf6 nssa
 !
 interface r2-eth0
+ ipv6 ospf6 area 0.0.0.1
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
 interface r2-eth1
+ ipv6 ospf6 area 0.0.0.0
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
 interface r2-eth2
+ ipv6 ospf6 area 0.0.0.2
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
@@ -42,7 +48,4 @@ router ospf6
  default-information originate always metric 123
  area 0.0.0.1 stub
  area 0.0.0.2 nssa
- interface r2-eth0 area 0.0.0.1
- interface r2-eth1 area 0.0.0.0
- interface r2-eth2 area 0.0.0.2
 !

--- a/tests/topotests/ospf6_topo2/r3/ospf6d.conf
+++ b/tests/topotests/ospf6_topo2/r3/ospf6d.conf
@@ -2,6 +2,10 @@ debug ospf6 lsa router
 debug ospf6 lsa router originate
 debug ospf6 lsa router examine
 debug ospf6 lsa router flooding
+debug ospf6 lsa nssa
+debug ospf6 lsa nssa originate
+debug ospf6 lsa nssa examine
+debug ospf6 lsa nssa flooding
 debug ospf6 lsa as-external
 debug ospf6 lsa as-external originate
 debug ospf6 lsa as-external examine
@@ -15,7 +19,6 @@ debug ospf6 zebra
 debug ospf6 interface
 debug ospf6 neighbor
 debug ospf6 flooding
-debug ospf6 gr helper
 debug ospf6 spf process
 debug ospf6 route intra-area
 debug ospf6 route inter-area
@@ -24,6 +27,7 @@ debug ospf6 asbr
 debug ospf6 nssa
 !
 interface r3-eth0
+ ipv6 ospf6 area 0.0.0.0
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
@@ -31,5 +35,4 @@ router ospf6
  ospf6 router-id 10.254.254.3
  redistribute connected
  redistribute static
- interface r3-eth0 area 0.0.0.0
 !

--- a/tests/topotests/ospf6_topo2/r4/ospf6d.conf
+++ b/tests/topotests/ospf6_topo2/r4/ospf6d.conf
@@ -2,6 +2,10 @@ debug ospf6 lsa router
 debug ospf6 lsa router originate
 debug ospf6 lsa router examine
 debug ospf6 lsa router flooding
+debug ospf6 lsa nssa
+debug ospf6 lsa nssa originate
+debug ospf6 lsa nssa examine
+debug ospf6 lsa nssa flooding
 debug ospf6 lsa as-external
 debug ospf6 lsa as-external originate
 debug ospf6 lsa as-external examine
@@ -15,7 +19,6 @@ debug ospf6 zebra
 debug ospf6 interface
 debug ospf6 neighbor
 debug ospf6 flooding
-debug ospf6 gr helper
 debug ospf6 spf process
 debug ospf6 route intra-area
 debug ospf6 route inter-area
@@ -24,11 +27,11 @@ debug ospf6 asbr
 debug ospf6 nssa
 !
 interface r4-eth0
+ ipv6 ospf6 area 0.0.0.2
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
 router ospf6
  ospf6 router-id 10.254.254.4
  area 0.0.0.2 nssa
- interface r4-eth0 area 0.0.0.2
 !

--- a/tests/topotests/ospf6_topo2/test_ospf6_topo2.py
+++ b/tests/topotests/ospf6_topo2/test_ospf6_topo2.py
@@ -131,6 +131,8 @@ def build_topo(tgen):
     switch.add_link(tgen.gears["r2"])
     switch.add_link(tgen.gears["r4"])
 
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["r4"], nodeif="r4-stubnet")
 
 def setup_module(mod):
     "Sets up the pytest environment"
@@ -484,7 +486,7 @@ def test_area_filters():
         pytest.skip(tgen.errors)
 
     #
-    # Configure import/export filters on r2 (ABR for area 1).
+    # Configure import/export filters on r2 (ABR for area 2).
     #
     config = """
     configure terminal
@@ -542,6 +544,102 @@ def test_area_filters():
     logger.info("Expecting ::/0 to be re-added on r1")
     routes = {"::/0": {}}
     expect_ospfv3_routes("r1", routes, wait=30, type="inter-area")
+
+
+def test_nssa_range():
+    """
+    Test NSSA ABR ranges.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Configure new addresses on r4 and enable redistribution of connected
+    # routes.
+    config = """
+    configure terminal
+    interface r4-stubnet
+    ipv6 address 2001:db8:1000::1/128
+    ipv6 address 2001:db8:1000::2/128
+    router ospf6
+    redistribute connected
+    """
+    tgen.gears["r4"].vtysh_cmd(config)
+    logger.info("Expecting NSSA-translated external routes to be added on r3")
+    routes = {"2001:db8:1000::1/128": {}, "2001:db8:1000::2/128": {}}
+    expect_ospfv3_routes("r3", routes, wait=30, type="external-2")
+
+    # Configure an NSSA range on r2 (ABR for area 2).
+    config = """
+    configure terminal
+    router ospf6
+    area 2 nssa range 2001:db8:1000::/64
+    """
+    tgen.gears["r2"].vtysh_cmd(config)
+    logger.info("Expecting summarized routes to be removed from r3")
+    for route in ["2001:db8:1000::1/128", "2001:db8:1000::2/128"]:
+        test_func = partial(dont_expect_route, "r3", route, type="external-2")
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assertmsg = "{}'s {} summarized route still exists".format("r3", route)
+        assert result is None, assertmsg
+    logger.info("Expecting NSSA range to be added on r3")
+    routes = {
+        "2001:db8:1000::/64": {
+            "metricType":2,
+            "metricCost":20,
+            "metricCostE2":10,
+        }}
+    expect_ospfv3_routes("r3", routes, wait=30, type="external-2", detail=True)
+
+    # Change the NSSA range cost.
+    config = """
+    configure terminal
+    router ospf6
+    area 2 nssa range 2001:db8:1000::/64 cost 1000
+    """
+    tgen.gears["r2"].vtysh_cmd(config)
+    logger.info("Expecting NSSA range to be updated with new cost")
+    routes = {
+        "2001:db8:1000::/64": {
+            "metricType":2,
+            "metricCost":20,
+            "metricCostE2":1000,
+        }}
+    expect_ospfv3_routes("r3", routes, wait=30, type="external-2", detail=True)
+
+    # Configure the NSSA range to not be advertised.
+    config = """
+    configure terminal
+    router ospf6
+    area 2 nssa range 2001:db8:1000::/64 not-advertise
+    """
+    tgen.gears["r2"].vtysh_cmd(config)
+    logger.info("Expecting NSSA summary route to be removed")
+    route = "2001:db8:1000::/64"
+    test_func = partial(dont_expect_route, "r3", route, type="external-2")
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = "{}'s {} NSSA summary route still exists".format("r3", route)
+    assert result is None, assertmsg
+
+    # Remove the NSSA range.
+    config = """
+    configure terminal
+    router ospf6
+    no area 2 nssa range 2001:db8:1000::/64
+    """
+    tgen.gears["r2"].vtysh_cmd(config)
+    logger.info("Expecting previously summarized routes to be re-added")
+    routes = {
+        "2001:db8:1000::1/128": {
+            "metricType":2,
+            "metricCost":20,
+        },
+        "2001:db8:1000::2/128": {
+            "metricType":2,
+            "metricCost":20,
+        },
+    }
+    expect_ospfv3_routes("r3", routes, wait=30, type="external-2", detail=True)
 
 
 def teardown_module(_mod):


### PR DESCRIPTION
Implement NSSA address ranges as specified by [RFC 3101](https://datatracker.ietf.org/doc/html/rfc3101#section-2.2):
```
   NSSA border routers may be configured with Type-7 address ranges.
   Each Type-7 address range is defined as an [address,mask] pair.  Many
   separate Type-7 networks may fall into a single Type-7 address range,
   just as a subnetted network is composed of many separate subnets.
   NSSA border routers may aggregate Type-7 routes by advertising a
   single Type-5 LSA for each Type-7 address range.  The Type-5 LSA
   resulting from a Type-7 address range match will be distributed to
   all Type-5 capable areas.
```

Syntax: `area A.B.C.D nssa range X:X::X:X/M [<not-advertise|cost (0-16777215)>]`.

Example:
```
router ospf6
 ospf6 router-id 1.1.1.1
 area 1 nssa
 area 1 nssa range 2001:db8:1000::/64
 area 1 nssa range 2001:db8:2000::/64
!
```

The majority of the commits are preparatory work containing code cleanup and assorted bug fixes.