### PR TITLE
Zebra trace

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -75,6 +75,7 @@
 #include "zebra/zebra_evpn_mh.h"
 #include "zebra/zebra_l2.h"
 #include "zebra/netconf_netlink.h"
+#include "zebra/zebra_trace.h"
 
 extern struct zebra_privs_t zserv_privs;
 uint8_t frr_protodown_r_bit = FRR_PROTODOWN_REASON_DEFAULT_BIT;
@@ -964,6 +965,8 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	struct zebra_if *zif;
 	ns_id_t link_nsid = ns_id;
 	uint8_t bypass = 0;
+
+	frrtrace(3, frr_zebra, netlink_interface, h, ns_id, startup);
 
 	zns = zebra_ns_lookup(ns_id);
 	ifi = NLMSG_DATA(h);

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1379,6 +1379,8 @@ int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	uint32_t metric = METRIC_MAX;
 	uint32_t kernel_flags = 0;
 
+	frrtrace(3, frr_zebra, netlink_interface_addr, h, ns_id, startup);
+
 	zns = zebra_ns_lookup(ns_id);
 	ifa = NLMSG_DATA(h);
 

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1122,6 +1122,9 @@ static int netlink_request_intf_addr(struct nlsock *netlink_cmd, int family,
 		char buf[256];
 	} req;
 
+	frrtrace(4, frr_zebra, netlink_request_intf_addr, netlink_cmd, family,
+		 type, filter_mask);
+
 	/* Form the request, specifying filter (rtattr) if needed. */
 	memset(&req, 0, sizeof(req));
 	req.n.nlmsg_type = type;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -701,6 +701,9 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 	void *src = NULL;     /* IPv6 srcdest   source prefix */
 	enum blackhole_type bh_type = BLACKHOLE_UNSPEC;
 
+	frrtrace(3, frr_zebra, netlink_route_change_read_unicast, h, ns_id,
+		 startup);
+
 	rtm = NLMSG_DATA(h);
 
 	if (startup && h->nlmsg_type != RTM_NEWROUTE)

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -79,6 +79,7 @@
 #include "zebra/zebra_vxlan.h"
 #include "zebra/zebra_errors.h"
 #include "zebra/zebra_evpn_mh.h"
+#include "zebra/zebra_trace.h"
 
 #ifndef AF_MPLS
 #define AF_MPLS 28
@@ -2905,6 +2906,8 @@ int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	/* Count of nexthops in group array */
 	uint8_t grp_count = 0;
 	struct rtattr *tb[NHA_MAX + 1] = {};
+
+	frrtrace(3, frr_zebra, netlink_nexthop_change, h, ns_id, startup);
 
 	nhm = NLMSG_DATA(h);
 

--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -42,6 +42,7 @@
 #include "zebra/zebra_pbr.h"
 #include "zebra/zebra_errors.h"
 #include "zebra/zebra_dplane.h"
+#include "zebra/zebra_trace.h"
 
 /* definitions */
 
@@ -242,6 +243,8 @@ int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	struct zebra_pbr_rule rule = {};
 	uint8_t proto = 0;
 	uint8_t ip_proto = 0;
+
+	frrtrace(3, frr_zebra, netlink_rule_change, h, ns_id, startup);
 
 	/* Basic validation followed by extracting attributes. */
 	if (h->nlmsg_type != RTM_NEWRULE && h->nlmsg_type != RTM_DELRULE)

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -50,7 +50,7 @@ man8 += $(MANBUILD)/frr-zebra.8
 ## endif ZEBRA
 endif
 
-zebra_zebra_LDADD = lib/libfrr.la $(LIBCAP)
+zebra_zebra_LDADD = lib/libfrr.la $(LIBCAP) $(UST_LIBS)
 if HAVE_PROTOBUF3
 zebra_zebra_LDADD += mlag/libmlag_pb.la $(PROTOBUF_C_LIBS)
 zebra/zebra_mlag.$(OBJEXT): mlag/mlag.pb-c.h
@@ -120,6 +120,7 @@ zebra_zebra_SOURCES = \
 	zebra/zebra_routemap_nb_config.c \
 	zebra/zebra_script.c \
 	zebra/zebra_srte.c \
+	zebra/zebra_trace.c \
 	zebra/zebra_vrf.c \
 	zebra/zebra_vty.c \
 	zebra/zebra_vxlan.c \
@@ -191,6 +192,7 @@ noinst_HEADERS += \
 	zebra/zebra_router.h \
 	zebra/zebra_script.h \
 	zebra/zebra_srte.h \
+	zebra/zebra_trace.h \
 	zebra/zebra_vrf.h \
 	zebra/zebra_vxlan.h \
 	zebra/zebra_vxlan_private.h \

--- a/zebra/zebra_trace.c
+++ b/zebra/zebra_trace.c
@@ -1,0 +1,6 @@
+#define TRACEPOINT_CREATE_PROBES
+#define TRACEPOINT_DEFINE
+
+#include <zebra.h>
+
+#include "zebra_trace.h"

--- a/zebra/zebra_trace.h
+++ b/zebra/zebra_trace.h
@@ -67,6 +67,20 @@ TRACEPOINT_EVENT(
 		)
 	)
 
+TRACEPOINT_EVENT(
+	frr_zebra,
+	netlink_nexthop_change,
+	TP_ARGS(
+		struct nlmsghdr *, h,
+		ns_id_t, ns_id,
+		int, startup),
+	TP_FIELDS(
+		ctf_integer_hex(intptr_t, h, h)
+		ctf_integer(uint32_t, ns_id, ns_id)
+		ctf_integer(uint32_t, startup, startup)
+		)
+	)
+
 #include <lttng/tracepoint-event.h>
 
 #endif /* HAVE_LTTNG */

--- a/zebra/zebra_trace.h
+++ b/zebra/zebra_trace.h
@@ -95,6 +95,19 @@ TRACEPOINT_EVENT(
 		)
 	)
 
+TRACEPOINT_EVENT(
+	frr_zebra,
+	netlink_route_change_read_unicast,
+	TP_ARGS(
+		struct nlmsghdr *, h,
+		ns_id_t, ns_id,
+		int, startup),
+	TP_FIELDS(
+		ctf_integer_hex(intptr_t, h, h)
+		ctf_integer(uint32_t, ns_id, ns_id)
+		ctf_integer(uint32_t, startup, startup)
+		)
+	)
 #include <lttng/tracepoint-event.h>
 
 #endif /* HAVE_LTTNG */

--- a/zebra/zebra_trace.h
+++ b/zebra/zebra_trace.h
@@ -57,11 +57,11 @@ TRACEPOINT_EVENT(
 	frr_zebra,
 	netlink_interface,
 	TP_ARGS(
-		struct nlmsghdr *, h,
+		struct nlmsghdr *, header,
 		ns_id_t, ns_id,
 		int, startup),
 	TP_FIELDS(
-		ctf_integer_hex(intptr_t, h, h)
+		ctf_integer_hex(intptr_t, header, header)
 		ctf_integer(uint32_t, ns_id, ns_id)
 		ctf_integer(uint32_t, startup, startup)
 		)
@@ -71,11 +71,11 @@ TRACEPOINT_EVENT(
 	frr_zebra,
 	netlink_nexthop_change,
 	TP_ARGS(
-		struct nlmsghdr *, h,
+		struct nlmsghdr *, header,
 		ns_id_t, ns_id,
 		int, startup),
 	TP_FIELDS(
-		ctf_integer_hex(intptr_t, h, h)
+		ctf_integer_hex(intptr_t, header, header)
 		ctf_integer(uint32_t, ns_id, ns_id)
 		ctf_integer(uint32_t, startup, startup)
 		)
@@ -85,11 +85,11 @@ TRACEPOINT_EVENT(
 	frr_zebra,
 	netlink_interface_addr,
 	TP_ARGS(
-		struct nlmsghdr *, h,
+		struct nlmsghdr *, header,
 		ns_id_t, ns_id,
 		int, startup),
 	TP_FIELDS(
-		ctf_integer_hex(intptr_t, h, h)
+		ctf_integer_hex(intptr_t, header, header)
 		ctf_integer(uint32_t, ns_id, ns_id)
 		ctf_integer(uint32_t, startup, startup)
 		)
@@ -99,11 +99,11 @@ TRACEPOINT_EVENT(
 	frr_zebra,
 	netlink_route_change_read_unicast,
 	TP_ARGS(
-		struct nlmsghdr *, h,
+		struct nlmsghdr *, header,
 		ns_id_t, ns_id,
 		int, startup),
 	TP_FIELDS(
-		ctf_integer_hex(intptr_t, h, h)
+		ctf_integer_hex(intptr_t, header, header)
 		ctf_integer(uint32_t, ns_id, ns_id)
 		ctf_integer(uint32_t, startup, startup)
 		)
@@ -113,11 +113,11 @@ TRACEPOINT_EVENT(
 	frr_zebra,
 	netlink_rule_change,
 	TP_ARGS(
-		struct nlmsghdr *, h,
+		struct nlmsghdr *, header,
 		ns_id_t, ns_id,
 		int, startup),
 	TP_FIELDS(
-		ctf_integer_hex(intptr_t, h, h)
+		ctf_integer_hex(intptr_t, header, header)
 		ctf_integer(uint32_t, ns_id, ns_id)
 		ctf_integer(uint32_t, startup, startup)
 		)

--- a/zebra/zebra_trace.h
+++ b/zebra/zebra_trace.h
@@ -36,6 +36,23 @@
 #include <lib/ns.h>
 #include <lib/table.h>
 
+#include <zebra/zebra_ns.h>
+
+TRACEPOINT_EVENT(
+	frr_zebra,
+	netlink_request_intf_addr,
+	TP_ARGS(struct nlsock *, netlink_cmd,
+		int, family,
+		int, type,
+		uint32_t, filter_mask),
+	TP_FIELDS(
+		ctf_integer_hex(intptr_t, netlink_cmd, netlink_cmd)
+		ctf_integer(int, family, family)
+		ctf_integer(int, type, type)
+		ctf_integer(uint32_t, filter_mask, filter_mask)
+		)
+	)
+
 TRACEPOINT_EVENT(
 	frr_zebra,
 	netlink_interface,

--- a/zebra/zebra_trace.h
+++ b/zebra/zebra_trace.h
@@ -108,6 +108,21 @@ TRACEPOINT_EVENT(
 		ctf_integer(uint32_t, startup, startup)
 		)
 	)
+
+TRACEPOINT_EVENT(
+	frr_zebra,
+	netlink_rule_change,
+	TP_ARGS(
+		struct nlmsghdr *, h,
+		ns_id_t, ns_id,
+		int, startup),
+	TP_FIELDS(
+		ctf_integer_hex(intptr_t, h, h)
+		ctf_integer(uint32_t, ns_id, ns_id)
+		ctf_integer(uint32_t, startup, startup)
+		)
+	)
+
 #include <lttng/tracepoint-event.h>
 
 #endif /* HAVE_LTTNG */

--- a/zebra/zebra_trace.h
+++ b/zebra/zebra_trace.h
@@ -1,0 +1,57 @@
+/* Tracing for zebra
+ *
+ * Copyright (C) 2020  NVIDIA Corporation
+ * Donald Sharp
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#if !defined(__ZEBRA_TRACE_H__) || defined(TRACEPOINT_HEADER_MULTI_READ)
+#define __ZEBRA_TRACE_H__
+
+#include "lib/trace.h"
+
+#ifdef HAVE_LTTNG
+
+#undef TRACEPOINT_PROVIDER
+#define TRACEPOINT_PROVIDER frr_zebra
+
+#undef TRACEPOINT_INCLUDE
+#define TRACEPOINT_INCLUDE "zebra/zebra_trace.h"
+
+#include <lttng/tracepoint.h>
+
+#include <lib/ns.h>
+#include <lib/table.h>
+
+TRACEPOINT_EVENT(
+	frr_zebra,
+	netlink_interface,
+	TP_ARGS(
+		struct nlmsghdr *, h,
+		ns_id_t, ns_id,
+		int, startup),
+	TP_FIELDS(
+		ctf_integer_hex(intptr_t, h, h)
+		ctf_integer(uint32_t, ns_id, ns_id)
+		ctf_integer(uint32_t, startup, startup)
+		)
+	)
+
+#include <lttng/tracepoint-event.h>
+
+#endif /* HAVE_LTTNG */
+
+#endif /* __ZEBRA_TRACE_H__ */

--- a/zebra/zebra_trace.h
+++ b/zebra/zebra_trace.h
@@ -81,6 +81,20 @@ TRACEPOINT_EVENT(
 		)
 	)
 
+TRACEPOINT_EVENT(
+	frr_zebra,
+	netlink_interface_addr,
+	TP_ARGS(
+		struct nlmsghdr *, h,
+		ns_id_t, ns_id,
+		int, startup),
+	TP_FIELDS(
+		ctf_integer_hex(intptr_t, h, h)
+		ctf_integer(uint32_t, ns_id, ns_id)
+		ctf_integer(uint32_t, startup, startup)
+		)
+	)
+
 #include <lttng/tracepoint-event.h>
 
 #endif /* HAVE_LTTNG */


### PR DESCRIPTION
Add a series of tracepoints for zebra so that we can gather data about netlink read events from the kernel.  At this point I've instrumented the basic startup netlink functionality so we can see how long it is taking zebra to get up and running with various startup conditions.