### PR TITLE
*: don't pass pointers to a local variables to thread_add_*

### DIFF
--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -243,7 +243,6 @@ main(int argc, char *argv[])
 	int			 pipe_parent2ldpe[2], pipe_parent2ldpe_sync[2];
 	int			 pipe_parent2lde[2], pipe_parent2lde_sync[2];
 	char			*ctl_sock_name;
-	struct thread           *thread = NULL;
 	bool                    ctl_sock_used = false;
 
 	snprintf(ctl_sock_path, sizeof(ctl_sock_path), LDPD_SOCKET,
@@ -393,7 +392,7 @@ main(int argc, char *argv[])
 	frr_config_fork();
 
 	/* apply configuration */
-	thread_add_event(master, ldp_config_fork_apply, NULL, 0, &thread);
+	thread_add_event(master, ldp_config_fork_apply, NULL, 0, NULL);
 
 	/* setup pipes to children */
 	if ((iev_ldpe = calloc(1, sizeof(struct imsgev))) == NULL ||

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -63,6 +63,8 @@ static int agentx_read(struct thread *t)
 	int flags, new_flags = 0;
 	int nonblock = false;
 	struct listnode *ln = THREAD_ARG(t);
+	struct thread **thr = listgetdata(ln);
+	XFREE(MTYPE_TMP, thr);
 	list_delete_node(events, ln);
 
 	/* fix for non blocking socket */
@@ -109,7 +111,7 @@ static void agentx_events_update(void)
 	struct timeval timeout = {.tv_sec = 0, .tv_usec = 0};
 	fd_set fds;
 	struct listnode *ln;
-	struct thread *thr;
+	struct thread **thr;
 	int fd, thr_fd;
 
 	thread_cancel(&timeout_thr);
@@ -125,7 +127,7 @@ static void agentx_events_update(void)
 
 	ln = listhead(events);
 	thr = ln ? listgetdata(ln) : NULL;
-	thr_fd = thr ? THREAD_FD(thr) : -1;
+	thr_fd = thr ? THREAD_FD(*thr) : -1;
 
 	/* "two-pointer" / two-list simultaneous iteration
 	 * ln/thr/thr_fd point to the next existing event listener to hit while
@@ -135,20 +137,21 @@ static void agentx_events_update(void)
 		if (thr_fd == fd) {
 			struct listnode *nextln = listnextnode(ln);
 			if (!FD_ISSET(fd, &fds)) {
-				thread_cancel(&thr);
+				thread_cancel(thr);
+				XFREE(MTYPE_TMP, thr);
 				list_delete_node(events, ln);
 			}
 			ln = nextln;
 			thr = ln ? listgetdata(ln) : NULL;
-			thr_fd = thr ? THREAD_FD(thr) : -1;
+			thr_fd = thr ? THREAD_FD(*thr) : -1;
 		}
 		/* need listener, but haven't hit one where it would be */
 		else if (FD_ISSET(fd, &fds)) {
 			struct listnode *newln;
-			thr = NULL;
-			thread_add_read(agentx_tm, agentx_read, NULL, fd, &thr);
+			thr = XCALLOC(MTYPE_TMP, sizeof(struct thread *));
+			thread_add_read(agentx_tm, agentx_read, NULL, fd, thr);
 			newln = listnode_add_before(events, ln, thr);
-			thr->arg = newln;
+			(*thr)->arg = newln;
 		}
 	}
 
@@ -157,7 +160,8 @@ static void agentx_events_update(void)
 	while (ln) {
 		struct listnode *nextln = listnextnode(ln);
 		thr = listgetdata(ln);
-		thread_cancel(&thr);
+		thread_cancel(thr);
+		XFREE(MTYPE_TMP, thr);
 		list_delete_node(events, ln);
 		ln = nextln;
 	}


### PR DESCRIPTION
We should never pass pointers to local variables to thread_add_* family.
When an event is executed, the library writes into this pointer, which
means it writes into some random memory on a stack.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>