### PR TITLE
tools: Catch double pointer of struct thread towards thread_add_*

### DIFF
--- a/tools/coccinelle/struct_thread_double_pointer.cocci
+++ b/tools/coccinelle/struct_thread_double_pointer.cocci
@@ -1,0 +1,35 @@
+@r1@
+identifier fn, m, f, a, v, t;
+identifier func =~ "thread_add_";
+type T1, T2;
+position p;
+@@
+
+?static
+T1 fn(T2 *t)
+{
+...
+func(m,f,a,v,&t)@p
+...
+}
+
+@r2@
+identifier m, f, a, v, t;
+identifier func =~ "thread_add_";
+type T1;
+position p;
+@@
+
+T1 *t;
+...
+func(m,f,a,v,&t)@p
+
+@script:python@
+p << r1.p;
+@@
+coccilib.report.print_report(p[0],"Passed double 'struct thread' pointer")
+
+@script:python@
+p << r2.p;
+@@
+coccilib.report.print_report(p[0],"Passed double 'struct thread' pointer")


### PR DESCRIPTION
```
% spatch --sp-file tools/coccinelle/struct_thread_double_pointer.cocci --macro-file tools/cocci.h ./ 2>/dev/null
./lib/northbound_confd.c:429:65-66: Passed double 'struct thread' pointer
./lib/northbound_confd.c:1174:61-62: Passed double 'struct thread' pointer
./lib/northbound_sysrepo.c:543:69-70: Passed double 'struct thread' pointer
```

Related: https://github.com/FRRouting/frr/pull/9764

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>