### PR TITLE
bgpd: fix crash when using "show bgp vrf all"

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7883,8 +7883,7 @@ struct peer *peer_lookup_in_view(struct vty *vty, struct bgp *bgp,
 					json_no, JSON_C_TO_STRING_PRETTY));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "No such neighbor in %s\n",
-				bgp->name_pretty);
+			vty_out(vty, "No such neighbor in this view/vrf\n");
 		return NULL;
 	}
 

--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -966,7 +966,7 @@ def test_bgp_summary():
                         r"(192.168.7.(1|2)0|fc00:0:0:8::2000).+Active.+", "", expected
                     )
                 elif "10.0.0.1" in arguments:
-                    expected = "No such neighbor in VRF default"
+                    expected = "No such neighbor in this view/vrf"
 
                 if "terse" in arguments:
                     expected = re.sub(r"BGP table version .+", "", expected)


### PR DESCRIPTION
Any command that uses `peer_lookup_in_view` crashes when "vrf all" is
used, because bgp is NULL in this case.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>