### PR TITLE
ospfd: Few modifications in "show ip ospf neighbor" o/p.

### DIFF
--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -127,7 +127,9 @@ const char *ospf_area_desc_string(struct ospf_area *area)
 	return buf;
 }
 
-#define OSPF_IF_STRING_MAXLEN  40
+#define OSPF_IF_STRING_MAXLEN 40
+
+/* Display both nbr and ism state of the ospf neighbor.*/
 const char *ospf_if_name_string(struct ospf_interface *oi)
 {
 	static char buf[OSPF_IF_STRING_MAXLEN] = "";
@@ -146,6 +148,13 @@ const char *ospf_if_name_string(struct ospf_interface *oi)
 	return buf;
 }
 
+/* Display only the nbr state.*/
+void ospf_nbr_state_message(struct ospf_neighbor *nbr, char *buf, size_t size)
+{
+	snprintf(buf, size, "%s",
+		 lookup_msg(ospf_nsm_state_msg, nbr->state, NULL));
+}
+
 int ospf_nbr_ism_state(struct ospf_neighbor *nbr)
 {
 	int state;
@@ -161,9 +170,23 @@ int ospf_nbr_ism_state(struct ospf_neighbor *nbr)
 	return state;
 }
 
-void ospf_nbr_state_message(struct ospf_neighbor *nbr, char *buf, size_t size)
+void ospf_nbr_ism_state_message(struct ospf_neighbor *nbr, char *buf,
+				size_t size)
 {
-	int state = ospf_nbr_ism_state(nbr);
+	int state;
+	struct ospf_interface *oi = nbr->oi;
+
+	if (!oi)
+		return;
+
+	/* network type is point-to-point */
+	if (oi->type == OSPF_IFTYPE_POINTOPOINT) {
+		snprintf(buf, size, "%s/-",
+			 lookup_msg(ospf_nsm_state_msg, nbr->state, NULL));
+		return;
+	}
+
+	state = ospf_nbr_ism_state(nbr);
 
 	snprintf(buf, size, "%s/%s",
 		 lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),

--- a/ospfd/ospf_dump.h
+++ b/ospfd/ospf_dump.h
@@ -151,7 +151,10 @@ extern const char *ospf_area_name_string(struct ospf_area *);
 extern const char *ospf_area_desc_string(struct ospf_area *);
 extern const char *ospf_if_name_string(struct ospf_interface *);
 extern int ospf_nbr_ism_state(struct ospf_neighbor *nbr);
-extern void ospf_nbr_state_message(struct ospf_neighbor *, char *, size_t);
+extern void ospf_nbr_state_message(struct ospf_neighbor *nbr, char *buf,
+				   size_t size);
+extern void ospf_nbr_ism_state_message(struct ospf_neighbor *nbr, char *buf,
+				       size_t size);
 extern const char *ospf_timer_dump(struct thread *, char *, size_t);
 extern const char *ospf_timeval_dump(struct timeval *, char *, size_t);
 extern void ospf_packet_dump(struct stream *);

--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -2432,7 +2432,7 @@ static void ospfTrapNbrStateChange(struct ospf_neighbor *on)
 	oid index[sizeof(oid) * (IN_ADDR_SIZE + 1)];
 	char msgbuf[16];
 
-	ospf_nbr_state_message(on, msgbuf, sizeof(msgbuf));
+	ospf_nbr_ism_state_message(on, msgbuf, sizeof(msgbuf));
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_info("%s: trap sent: %pI4 now %s", __func__,
 			  &on->address.u.prefix4, msgbuf);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4335,9 +4335,9 @@ DEFUN (show_ip_ospf_interface_traffic,
 
 static void show_ip_ospf_neighbour_header(struct vty *vty)
 {
-	vty_out(vty, "\n%-15s %3s %-15s %9s %-15s %-32s %5s %5s %5s\n",
-		"Neighbor ID", "Pri", "State", "Dead Time", "Address",
-		"Interface", "RXmtL", "RqstL", "DBsmL");
+	vty_out(vty, "\n%-15s %-3s %-15s %-15s %-9s %-15s %-32s %5s %5s %5s\n",
+		"Neighbor ID", "Pri", "State", "Up Time", "Dead Time",
+		"Address", "Interface", "RXmtL", "RqstL", "DBsmL");
 }
 
 static void show_ip_ospf_neighbor_sub(struct vty *vty,
@@ -4350,6 +4350,9 @@ static void show_ip_ospf_neighbor_sub(struct vty *vty,
 	char buf[PREFIX_STRLEN];
 	char timebuf[OSPF_TIME_DUMP_SIZE];
 	json_object *json_neighbor = NULL, *json_neigh_array = NULL;
+	struct timeval res;
+	long time_val = 0;
+	char uptime[OSPF_TIME_DUMP_SIZE];
 
 	for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
 		if ((nbr = rn->info)) {
@@ -4359,6 +4362,13 @@ static void show_ip_ospf_neighbor_sub(struct vty *vty,
 			/* Down state is not shown. */
 			if (nbr->state == NSM_Down)
 				continue;
+
+			if (nbr->ts_last_progress.tv_sec
+			    || nbr->ts_last_progress.tv_usec)
+				time_val = monotime_since(
+						   &nbr->ts_last_progress, &res)
+					   / 1000LL;
+
 			if (use_json) {
 				char neigh_str[INET_ADDRSTRLEN];
 
@@ -4416,8 +4426,22 @@ static void show_ip_ospf_neighbor_sub(struct vty *vty,
 							     NULL)
 						     / 1000LL;
 					json_object_int_add(json_neighbor,
+							    "upTimeInMsec",
+							    time_val);
+					json_object_int_add(json_neighbor,
 							    "deadTimeMsecs",
 							    time_store);
+					json_object_string_add(
+						json_neighbor, "upTime",
+						ospf_timeval_dump(
+							&res, uptime,
+							sizeof(uptime)));
+					json_object_string_add(
+						json_neighbor, "deadTime",
+						ospf_timer_dump(
+							nbr->t_inactivity,
+							timebuf,
+							sizeof(timebuf)));
 				} else {
 					json_object_string_add(json_neighbor,
 							       "deadTimeMsecs",
@@ -4451,8 +4475,12 @@ static void show_ip_ospf_neighbor_sub(struct vty *vty,
 						nbr->priority, msgbuf);
 				else
 					vty_out(vty, "%-15pI4 %3d %-15s ",
-						&nbr->router_id,
-						nbr->priority, msgbuf);
+						&nbr->router_id, nbr->priority,
+						msgbuf);
+
+				vty_out(vty, "%-15s ",
+					ospf_timeval_dump(&res, uptime,
+							  sizeof(uptime)));
 
 				vty_out(vty, "%9s ",
 					ospf_timer_dump(nbr->t_inactivity,

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4400,7 +4400,7 @@ static void show_ip_ospf_neighbor_sub(struct vty *vty,
 
 				json_neighbor = json_object_new_object();
 
-				ospf_nbr_state_message(nbr, msgbuf, 16);
+				ospf_nbr_ism_state_message(nbr, msgbuf, 16);
 
 				json_object_int_add(json_neighbor, "priority",
 						    nbr->priority);
@@ -4467,7 +4467,7 @@ static void show_ip_ospf_neighbor_sub(struct vty *vty,
 				json_object_array_add(json_neigh_array,
 						      json_neighbor);
 			} else {
-				ospf_nbr_state_message(nbr, msgbuf, 16);
+				ospf_nbr_ism_state_message(nbr, msgbuf, 16);
 
 				if (nbr->state == NSM_Attempt
 				    && nbr->router_id.s_addr == INADDR_ANY)


### PR DESCRIPTION

Description:

       change -1  :  Adding uptime to the 'show ip ospf neighbor' o/p.
	                     Adding uptime and deadtime in string format for json consumption.

        change-2  :  Changed the nbr state format to <nbrsate>/- (ex : FULL/-) to P2pnetworks.
	 

Signed-off-by: Rajesh Girada <rgirada@vmware.com>