### PR TITLE
bgpd: don't return pointer to a local variable

### DIFF
--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -88,7 +88,7 @@ struct bgp_dest *bgp_dest_lock_node(struct bgp_dest *dest)
 const char *bgp_dest_get_prefix_str(struct bgp_dest *dest)
 {
 	const struct prefix *p = NULL;
-	char str[PREFIX_STRLEN] = {0};
+	static char str[PREFIX_STRLEN] = {0};
 
 	p = bgp_dest_get_prefix(dest);
 	if (p)


### PR DESCRIPTION
CID 1507651.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>