### PR TITLE
ospfd, doc, tests: enable the opaque capability by default

### DIFF
--- a/doc/developer/ospf-sr.rst
+++ b/doc/developer/ospf-sr.rst
@@ -300,15 +300,13 @@ OSPFd
 ^^^^^
 
 Here it is a simple example of configuration to enable Segment Routing. Note
-that `opaque capability` and `router information` must be set to activate
-Opaque LSA prior to Segment
+that `router information` must be set to activate Opaque LSA prior to Segment
 Routing.
 
 ::
 
    router ospf
     ospf router-id 192.168.1.11
-    capability opaque
     segment-routing on
     segment-routing global-block 10000 19999 local-block 5000 5999
     segment-routing node-msd 8

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -853,14 +853,14 @@ Opaque LSA
 .. clicmd:: capability opaque
 
 
+   *ospfd* supports Opaque LSA (:rfc:`2370`), which is a pre-requisite for
+   Graceful Restart, Segment Routing, MPLS Traffic Engineering, and others.
 
-   *ospfd* supports Opaque LSA (:rfc:`2370`) as partial support for
-   MPLS Traffic Engineering LSAs. The opaque-lsa capability must be
-   enabled in the configuration. An alternate command could be
-   "mpls-te on" (:ref:`ospf-traffic-engineering`). Note that FRR
-   offers only partial support for some of the routing protocol
-   extensions that are used with MPLS-TE; it does not support a
-   complete RSVP-TE solution.
+   The opaque-lsa capability is enabled by default.
+
+   Note that FRR offers only partial support for some of the routing
+   protocol extensions that are used with MPLS-TE; it does not support
+   a complete RSVP-TE solution.
 
 .. clicmd:: show ip ospf [vrf <NAME|all>] database (opaque-link|opaque-area|opaque-external)
 

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1089,8 +1089,8 @@ void ospf_opaque_config_write_router(struct vty *vty, struct ospf *ospf)
 {
 	struct list *funclist;
 
-	if (CHECK_FLAG(ospf->config, OSPF_OPAQUE_CAPABLE))
-		vty_out(vty, " capability opaque\n");
+	if (!CHECK_FLAG(ospf->config, OSPF_OPAQUE_CAPABLE))
+		vty_out(vty, " no capability opaque\n");
 
 	funclist = ospf_opaque_wildcard_funclist;
 	opaque_lsa_config_write_router_callback(funclist, vty);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -414,6 +414,7 @@ struct ospf *ospf_new_alloc(unsigned short instance, const char *name)
 
 	ospf_asbr_external_aggregator_init(new);
 
+	SET_FLAG(new->config, OSPF_OPAQUE_CAPABLE);
 	ospf_opaque_type11_lsa_init(new);
 
 	QOBJ_REG(new, ospf);

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
@@ -211,7 +211,7 @@ def test_ospf_gr_helper_tc1_p0(request):
 
     step("Configure graceful restart in the DUT")
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
@@ -228,7 +228,7 @@ def test_ospf_gr_helper_tc1_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
@@ -254,7 +254,6 @@ def test_ospf_gr_helper_tc1_p0(request):
             "ospf": {
                 "graceful-restart": {
                     "helper enable": [],
-                    "opaque": True,
                     "delete": True,
                 }
             }
@@ -271,7 +270,7 @@ def test_ospf_gr_helper_tc1_p0(request):
     step("Configure gr helper using the router id")
     ospf_gr_r0 = {
         "r0": {
-            "ospf": {"graceful-restart": {"helper enable": ["1.1.1.1"], "opaque": True}}
+            "ospf": {"graceful-restart": {"helper enable": ["1.1.1.1"]}}
         }
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
@@ -297,7 +296,6 @@ def test_ospf_gr_helper_tc1_p0(request):
             "ospf": {
                 "graceful-restart": {
                     "helper enable": ["1.1.1.1"],
-                    "opaque": True,
                     "delete": True,
                 }
             }
@@ -345,13 +343,13 @@ def test_ospf_gr_helper_tc2_p0(request):
         ospf_covergence is True
     ), "OSPF is not after reset config \n Error:" " {}".format(ospf_covergence)
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper2.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper2.py
@@ -228,13 +228,13 @@ def test_ospf_gr_helper_tc3_p1(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
@@ -322,13 +322,13 @@ def test_ospf_gr_helper_tc4_p1(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper3.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper3.py
@@ -195,13 +195,13 @@ def test_ospf_gr_helper_tc7_p1(request):
         ospf_covergence is True
     ), "OSPF is not after reset config \n Error:" " {}".format(ospf_covergence)
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
@@ -255,13 +255,13 @@ def test_ospf_gr_helper_tc8_p1(request):
         ospf_covergence is True
     ), "OSPF is not after reset config \n Error:" " {}".format(ospf_covergence)
     ospf_gr_r0 = {
-        "r0": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r0": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r0)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     ospf_gr_r1 = {
-        "r1": {"ospf": {"graceful-restart": {"helper enable": [], "opaque": True}}}
+        "r1": {"ospf": {"graceful-restart": {"helper enable": []}}}
     }
     result = create_router_ospf(tgen, topo, ospf_gr_r1)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)

--- a/tests/topotests/ospf_gr_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt1/ospfd.conf
@@ -25,7 +25,6 @@ interface eth-rt2
 !
 router ospf
  router-id 1.1.1.1
- capability opaque
  redistribute connected
  graceful-restart grace-period 120
  graceful-restart helper enable

--- a/tests/topotests/ospf_gr_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt2/ospfd.conf
@@ -31,7 +31,6 @@ interface eth-rt3
 !
 router ospf
  router-id 2.2.2.2
- capability opaque
  graceful-restart grace-period 120
  graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt3/ospfd.conf
@@ -37,7 +37,6 @@ interface eth-rt6
 !
 router ospf
  router-id 3.3.3.3
- capability opaque
  graceful-restart grace-period 120
  graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt4/ospfd.conf
@@ -31,7 +31,6 @@ interface eth-rt5
 !
 router ospf
  router-id 4.4.4.4
- capability opaque
  graceful-restart grace-period 120
  graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt5/ospfd.conf
@@ -25,7 +25,6 @@ interface eth-rt4
 !
 router ospf
  router-id 5.5.5.5
- capability opaque
  graceful-restart grace-period 120
  graceful-restart helper enable
 !

--- a/tests/topotests/ospf_gr_topo1/rt6/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt6/ospfd.conf
@@ -31,7 +31,6 @@ interface eth-rt7
 !
 router ospf
  router-id 6.6.6.6
- capability opaque
  area 3 nssa
  graceful-restart grace-period 120
  graceful-restart helper enable

--- a/tests/topotests/ospf_gr_topo1/rt7/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt7/ospfd.conf
@@ -25,7 +25,6 @@ interface eth-rt6
 !
 router ospf
  router-id 7.7.7.7
- capability opaque
  redistribute connected
  area 3 nssa
  graceful-restart grace-period 120

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/ospf-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/ospf-vrf-default.txt
@@ -11,6 +11,10 @@ N    10.0.20.0/24          [10] area: 0.0.0.0
 R    10.0.255.2            [10] area: 0.0.0.0, ASBR
                            via 10.0.20.2, r1-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.2            [10] area: 0.0.0.0, ASBR
+                           via 10.0.20.2, r1-eth1
+
 ============ OSPF external routing table ===========
 N E2 10.0.4.0/24           [10/20] tag: 0
                            via 10.0.20.2, r1-eth1

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/ospf-vrf-neno.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/ospf-vrf-neno.txt
@@ -9,4 +9,8 @@ N    10.0.30.0/24          [10] area: 0.0.0.0
 R    10.0.255.3            [10] area: 0.0.0.0, ASBR
                            via 10.0.30.3, r1-eth2
 
+============ OSPF reachable routers table =============
+R    10.0.255.3            [10] area: 0.0.0.0, ASBR
+                           via 10.0.30.3, r1-eth2
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/ospf-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/ospf-vrf-default.txt
@@ -11,6 +11,10 @@ N    10.0.20.0/24          [10] area: 0.0.0.0
 R    10.0.255.1            [10] area: 0.0.0.0, ASBR
                            via 10.0.20.1, r2-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.20.1, r2-eth1
+
 ============ OSPF external routing table ===========
 N E2 10.0.3.0/24           [10/20] tag: 0
                            via 10.0.20.1, r2-eth1

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/ospf-vrf-ray.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/ospf-vrf-ray.txt
@@ -3,9 +3,13 @@ VRF Name: ray
 N    10.0.4.0/24           [20] area: 0.0.0.0
                            via 10.0.40.4, r2-eth2
 N    10.0.40.0/24          [10] area: 0.0.0.0
-			   directly attached to r2-eth2
+                           directly attached to r2-eth2
 
 ============ OSPF router routing table =============
+R    10.0.255.4            [10] area: 0.0.0.0, ASBR
+                           via 10.0.40.4, r2-eth2
+
+============ OSPF reachable routers table =============
 R    10.0.255.4            [10] area: 0.0.0.0, ASBR
                            via 10.0.40.4, r2-eth2
 

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r3/ospf-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r3/ospf-vrf-default.txt
@@ -9,6 +9,10 @@ N    10.0.30.0/24          [10] area: 0.0.0.0
 R    10.0.255.1            [10] area: 0.0.0.0, ASBR
                            via 10.0.30.1, r3-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.30.1, r3-eth1
+
 ============ OSPF external routing table ===========
 N E2 10.0.4.0/24           [10/20] tag: 0
                            via 10.0.30.1, r3-eth1

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r4/ospf-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r4/ospf-vrf-default.txt
@@ -9,6 +9,10 @@ N    10.0.40.0/24          [10] area: 0.0.0.0
 R    10.0.255.1            [10] area: 0.0.0.0, ASBR
                            via 10.0.40.2, r4-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.40.2, r4-eth1
+
 ============ OSPF external routing table ===========
 N E2 10.0.3.0/24           [10/20] tag: 0
                            via 10.0.40.2, r4-eth1

--- a/tests/topotests/ospf_netns_vrf/r1/ospfroute.txt
+++ b/tests/topotests/ospf_netns_vrf/r1/ospfroute.txt
@@ -15,4 +15,10 @@ R    10.0.255.2            [10] area: 0.0.0.0, ASBR
 R    10.0.255.3            [10] area: 0.0.0.0, ASBR
                            via 10.0.3.1, r1-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.2            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.3, r1-eth1
+R    10.0.255.3            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.1, r1-eth1
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_netns_vrf/r1/ospfroute_down.txt
+++ b/tests/topotests/ospf_netns_vrf/r1/ospfroute_down.txt
@@ -11,4 +11,8 @@ N    10.0.3.0/24           [10] area: 0.0.0.0
 R    10.0.255.2            [10] area: 0.0.0.0, ASBR
                            via 10.0.3.3, r1-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.2            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.3, r1-eth1
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_netns_vrf/r2/ospfroute.txt
+++ b/tests/topotests/ospf_netns_vrf/r2/ospfroute.txt
@@ -15,4 +15,10 @@ R    10.0.255.1            [10] area: 0.0.0.0, ASBR
 R    10.0.255.3            [10] area: 0.0.0.0, ASBR
                            via 10.0.3.1, r2-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.2, r2-eth1
+R    10.0.255.3            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.1, r2-eth1
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_netns_vrf/r2/ospfroute_down.txt
+++ b/tests/topotests/ospf_netns_vrf/r2/ospfroute_down.txt
@@ -11,4 +11,8 @@ N    10.0.3.0/24           [10] area: 0.0.0.0
 R    10.0.255.1            [10] area: 0.0.0.0, ASBR
                            via 10.0.3.2, r2-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.2, r2-eth1
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_netns_vrf/r3/ospfroute.txt
+++ b/tests/topotests/ospf_netns_vrf/r3/ospfroute.txt
@@ -15,4 +15,10 @@ R    10.0.255.1            [10] area: 0.0.0.0, ASBR
 R    10.0.255.2            [10] area: 0.0.0.0, ASBR
                            via 10.0.3.3, r3-eth0
 
+============ OSPF reachable routers table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.2, r3-eth0
+R    10.0.255.2            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.3, r3-eth0
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_netns_vrf/r3/ospfroute_down.txt
+++ b/tests/topotests/ospf_netns_vrf/r3/ospfroute_down.txt
@@ -5,4 +5,6 @@ N    10.0.10.0/24          [10] area: 0.0.0.0
 
 ============ OSPF router routing table =============
 
+============ OSPF reachable routers table =============
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_sr_te_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt1/ospfd.conf
@@ -21,7 +21,6 @@ router ospf
  ospf router-id 1.1.1.1
  network 1.1.1.1/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
  !ospf opaque-lsa
  mpls-te on
  mpls-te export

--- a/tests/topotests/ospf_sr_te_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt2/ospfd.conf
@@ -32,7 +32,6 @@ router ospf
  ospf router-id 2.2.2.2
  network 2.2.2.2/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
  !ospf opaque-lsa
  mpls-te on
  !mpls-te export

--- a/tests/topotests/ospf_sr_te_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt3/ospfd.conf
@@ -32,7 +32,6 @@ router ospf
  ospf router-id 3.3.3.3
  network 3.3.3.3/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
  !ospf opaque-lsa
  mpls-te on
  !mpls-te export

--- a/tests/topotests/ospf_sr_te_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt4/ospfd.conf
@@ -38,7 +38,6 @@ router ospf
  ospf router-id 4.4.4.4
  network 4.4.4.4/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
  !ospf opaque-lsa
  mpls-te on
  !mpls-te export

--- a/tests/topotests/ospf_sr_te_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt5/ospfd.conf
@@ -38,7 +38,6 @@ router ospf
  ospf router-id 5.5.5.5
  network 5.5.5.5/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
 ! ospf opaque-lsa
  mpls-te on
 ! mpls-te export

--- a/tests/topotests/ospf_sr_te_topo1/rt6/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt6/ospfd.conf
@@ -26,7 +26,6 @@ router ospf
  ospf router-id 6.6.6.6
  network 6.6.6.6/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
 ! ospf opaque-lsa
  mpls-te on
  mpls-te export

--- a/tests/topotests/ospf_sr_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt1/ospfd.conf
@@ -19,7 +19,6 @@ router ospf
  ospf router-id 1.1.1.1
  network 1.1.1.1/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
  mpls-te on
  mpls-te router-address 1.1.1.1
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_sr_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt2/ospfd.conf
@@ -29,7 +29,6 @@ router ospf
  ospf router-id 2.2.2.2
  network 2.2.2.2/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
  mpls-te on
  mpls-te router-address 2.2.2.2
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_sr_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt3/ospfd.conf
@@ -29,7 +29,6 @@ router ospf
  ospf router-id 3.3.3.3
  network 3.3.3.3/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
  mpls-te on
  mpls-te router-address 3.3.3.3
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_sr_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt4/ospfd.conf
@@ -34,7 +34,6 @@ router ospf
  ospf router-id 4.4.4.4
  network 4.4.4.4/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
  mpls-te on
  mpls-te router-address 4.4.4.4
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_sr_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt5/ospfd.conf
@@ -34,7 +34,6 @@ router ospf
  ospf router-id 5.5.5.5
  network 5.5.5.5/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
  mpls-te on
  mpls-te router-address 5.5.5.5
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_sr_topo1/rt6/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt6/ospfd.conf
@@ -24,7 +24,6 @@ router ospf
  ospf router-id 6.6.6.6
  network 6.6.6.6/32 area 0.0.0.0
  network 10.0.0.0/16 area 0.0.0.0
- capability opaque
  mpls-te on
  mpls-te router-address 6.6.6.6
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_te_topo1/r1/ospfd.conf
+++ b/tests/topotests/ospf_te_topo1/r1/ospfd.conf
@@ -16,7 +16,6 @@ interface r1-eth1
 !
 router ospf
   ospf router-id 10.0.255.1
-  capability opaque
   mpls-te on
   mpls-te router-address 10.0.255.1
 !

--- a/tests/topotests/ospf_te_topo1/r2/ospfd.conf
+++ b/tests/topotests/ospf_te_topo1/r2/ospfd.conf
@@ -28,7 +28,6 @@ interface r2-eth3
 !
 router ospf
   ospf router-id 10.0.255.2
-  capability opaque
   mpls-te on
   mpls-te router-address 10.0.255.2
 !

--- a/tests/topotests/ospf_te_topo1/r3/ospfd.conf
+++ b/tests/topotests/ospf_te_topo1/r3/ospfd.conf
@@ -17,7 +17,6 @@ interface r3-eth1
 !
 router ospf
   ospf router-id 10.0.255.3
-  capability opaque
   mpls-te on
   mpls-te router-address 10.0.255.3
   mpls-te inter-as as

--- a/tests/topotests/ospf_te_topo1/r4/ospfd.conf
+++ b/tests/topotests/ospf_te_topo1/r4/ospfd.conf
@@ -11,7 +11,6 @@ interface r4-eth0
 !
 router ospf
   ospf router-id 10.0.255.4
-  capability opaque
   mpls-te on
   mpls-te router-address 10.0.255.4
   segment-routing on

--- a/tests/topotests/ospf_tilfa_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt1/ospfd.conf
@@ -15,7 +15,6 @@ router ospf
  network 10.0.0.0/16 area 0.0.0.0
  area 0.0.0.0 range 10.0.0.0/16
  area 0.0.0.0 range 1.1.1.0/24
- capability opaque
  mpls-te on
  mpls-te router-address 1.1.1.1
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_tilfa_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt2/ospfd.conf
@@ -15,7 +15,6 @@ router ospf
  network 10.0.0.0/16 area 0.0.0.0
  area 0.0.0.0 range 10.0.0.0/16
  area 0.0.0.0 range 1.1.1.0/24
- capability opaque
  mpls-te on
  mpls-te router-address 1.1.1.2
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_tilfa_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt3/ospfd.conf
@@ -15,7 +15,6 @@ router ospf
  network 10.0.0.0/16 area 0.0.0.0
  area 0.0.0.0 range 10.0.0.0/16
  area 0.0.0.0 range 1.1.1.0/24
- capability opaque
  mpls-te on
  mpls-te router-address 1.1.1.3
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_tilfa_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt4/ospfd.conf
@@ -15,7 +15,6 @@ router ospf
  network 10.0.0.0/16 area 0.0.0.0
  area 0.0.0.0 range 10.0.0.0/16
  area 0.0.0.0 range 1.1.1.0/24
- capability opaque
  mpls-te on
  mpls-te router-address 1.1.1.4
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_tilfa_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt5/ospfd.conf
@@ -15,7 +15,6 @@ router ospf
  network 10.0.0.0/16 area 0.0.0.0
  area 0.0.0.0 range 10.0.0.0/16
  area 0.0.0.0 range 1.1.1.0/24
- capability opaque
  mpls-te on
  mpls-te router-address 1.1.1.5
  router-info area 0.0.0.0

--- a/tests/topotests/ospf_topo1/r1/ospfroute.txt
+++ b/tests/topotests/ospf_topo1/r1/ospfroute.txt
@@ -20,4 +20,10 @@ R    10.0.255.3            [10] area: 0.0.0.0, ABR, ASBR
 R    10.0.255.4         IA [20] area: 0.0.0.0, ASBR
                            via 10.0.3.1, r1-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.2            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.3, r1-eth1
+R    10.0.255.3            [10] area: 0.0.0.0, ABR, ASBR
+                           via 10.0.3.1, r1-eth1
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_topo1/r1/ospfroute_down.txt
+++ b/tests/topotests/ospf_topo1/r1/ospfroute_down.txt
@@ -10,4 +10,8 @@ N    10.0.3.0/24           [10] area: 0.0.0.0
 R    10.0.255.2            [10] area: 0.0.0.0, ASBR
                            via 10.0.3.3, r1-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.2            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.3, r1-eth1
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_topo1/r2/ospfroute.txt
+++ b/tests/topotests/ospf_topo1/r2/ospfroute.txt
@@ -20,4 +20,10 @@ R    10.0.255.3            [10] area: 0.0.0.0, ABR, ASBR
 R    10.0.255.4         IA [20] area: 0.0.0.0, ASBR
                            via 10.0.3.1, r2-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.2, r2-eth1
+R    10.0.255.3            [10] area: 0.0.0.0, ABR, ASBR
+                           via 10.0.3.1, r2-eth1
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_topo1/r2/ospfroute_down.txt
+++ b/tests/topotests/ospf_topo1/r2/ospfroute_down.txt
@@ -10,4 +10,8 @@ N    10.0.3.0/24           [10] area: 0.0.0.0
 R    10.0.255.1            [10] area: 0.0.0.0, ASBR
                            via 10.0.3.2, r2-eth1
 
+============ OSPF reachable routers table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.2, r2-eth1
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_topo1/r3/ospfroute.txt
+++ b/tests/topotests/ospf_topo1/r3/ospfroute.txt
@@ -20,4 +20,12 @@ R    10.0.255.2            [10] area: 0.0.0.0, ASBR
 R    10.0.255.4            [10] area: 0.0.0.1, ASBR
                            via 172.16.0.1, r3-eth2
 
+============ OSPF reachable routers table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.2, r3-eth0
+R    10.0.255.2            [10] area: 0.0.0.0, ASBR
+                           via 10.0.3.3, r3-eth0
+R    10.0.255.4            [10] area: 0.0.0.1, ASBR
+                           via 172.16.0.1, r3-eth2
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_topo1/r3/ospfroute_down.txt
+++ b/tests/topotests/ospf_topo1/r3/ospfroute_down.txt
@@ -10,4 +10,8 @@ N    172.16.1.0/24         [20] area: 0.0.0.1
 R    10.0.255.4            [10] area: 0.0.0.1, ASBR
                            via 172.16.0.1, r3-eth2
 
+============ OSPF reachable routers table =============
+R    10.0.255.4            [10] area: 0.0.0.1, ASBR
+                           via 172.16.0.1, r3-eth2
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_topo1/r4/ospfroute.txt
+++ b/tests/topotests/ospf_topo1/r4/ospfroute.txt
@@ -20,4 +20,8 @@ R    10.0.255.2         IA [20] area: 0.0.0.1, ASBR
 R    10.0.255.3            [10] area: 0.0.0.1, ABR, ASBR
                            via 172.16.0.2, r4-eth0
 
+============ OSPF reachable routers table =============
+R    10.0.255.3            [10] area: 0.0.0.1, ABR, ASBR
+                           via 172.16.0.2, r4-eth0
+
 ============ OSPF external routing table ===========

--- a/tests/topotests/ospf_topo1/r4/ospfroute_down.txt
+++ b/tests/topotests/ospf_topo1/r4/ospfroute_down.txt
@@ -10,4 +10,8 @@ N    172.16.1.0/24         [10] area: 0.0.0.1
 R    10.0.255.3            [10] area: 0.0.0.1, ABR, ASBR
                            via 172.16.0.2, r4-eth0
 
+============ OSPF reachable routers table =============
+R    10.0.255.3            [10] area: 0.0.0.1, ABR, ASBR
+                           via 172.16.0.2, r4-eth0
+
 ============ OSPF external routing table ===========


### PR DESCRIPTION
Enable the opaque capability [1] by default since that's what users
will want most of the time.

Nowadays many important OSPF extensions depend on Opaque-LSAs,
so by enabling Opaque LSAs by default we make it easier for users
to deploy those extensions (e.g. GR, SR, MPLS-TE, etc).

This change shouldn't cause any disruption in existing networks as
an opaque capability mismatch won't prevent adjacencies from forming,
it will only prevent Opaque-LSAs from being exchanged.

Disabling the opaque capability should still be possible with the "no
capability opaque" command. That might be necessary in cases where
the router has severe memory limitations (which is rare nowadays).

[1] https://datatracker.ietf.org/doc/html/rfc5250

Suggested-by: Martin Winter <mwinter@opensourcerouting.org>
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>