### PR TITLE
lib: set type for newly created interfaces

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1832,6 +1832,8 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			/* Update link. */
 			zebra_if_update_link(ifp, link_ifindex, ns_id);
 
+			ifp->ll_type =
+				netlink_to_zebra_link_type(ifi->ifi_type);
 			netlink_interface_update_hw_addr(tb, ifp);
 
 			/* Inform clients, install any configured addresses. */
@@ -1899,6 +1901,8 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			/* Update link. */
 			zebra_if_update_link(ifp, link_ifindex, ns_id);
 
+			ifp->ll_type =
+				netlink_to_zebra_link_type(ifi->ifi_type);
 			netlink_interface_update_hw_addr(tb, ifp);
 
 			if (if_is_no_ptm_operative(ifp)) {


### PR DESCRIPTION
Currently, the ll_type is set only in `netlink_interface` which is
executed only during startup. If the interface is created when the FRR
is already running, the type is not stored.

Fixes #1164.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>