### PR TITLE
bgpd: Fix json object memory leaks and double-free

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13426,16 +13426,6 @@ show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table *table,
 
 	bgp = peer->bgp;
 
-	if (!bgp) {
-		if (use_json) {
-			json_object_string_add(json, "alert", "no BGP");
-			vty_out(vty, "%s\n", json_object_to_json_string(json));
-			json_object_free(json);
-		} else
-			vty_out(vty, "%% No bgp\n");
-		return;
-	}
-
 	subgrp = peer_subgroup(peer, afi, safi);
 
 	if (type == bgp_show_adj_route_advertised && subgrp


### PR DESCRIPTION
Fix for double-free of json structure and some memory leaks.
This fixes a potential bgpd crash during a "show bgp ipv4 neighbors x.x.x.x filtered-routes json"

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>