### PR TITLE
patch reload script logic to stop daemons no longer enabled in /etc/frr/daemons

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -124,6 +124,41 @@ daemon_list() {
 	[ -n "$dvar" ] && eval $dvar="\"$disabled\""
 }
 
+all_daemon_list() {
+	# note $1 specifies the name of a global variable to be set
+	local enabled evar daemon inst oldifs i
+	enabled=""
+	evar="$1"
+
+	for daemon in $DAEMONS; do
+		eval inst=\$${daemon}_instances
+		if [ -n "$inst" ]; then
+			oldifs="${IFS}"
+			IFS="${IFS},"
+			for i in $inst; do
+				enabled="$enabled $daemon-$i"
+			done
+			IFS="${oldifs}"
+		else
+		    enabled="$enabled $daemon"
+		fi
+	done
+
+	enabled="${enabled# }"
+	[ -z "$evar" ] && echo "$enabled"
+	[ -n "$evar" ] && eval $evar="\"$enabled\""
+}
+
+in_list() {
+	local item i
+	item="$1"
+	shift 1
+	for i in "$@"; do
+		[ "$item" = "$i" ] && return 0
+	done
+	return 1
+}
+
 #
 # individual daemon management
 #

--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -90,7 +90,7 @@ reload)
 		# Traverse command line args in reverse order, bailing out when we hit
 		# an argument that is not a daemon. Otherwise, if it's not in the
 		# new daemon list, stop it.
-		for i in `tr '\0' '\n' < /proc/$watchfrr_pid/cmdline | tac`; do
+		for i in `awk -v RS='\0' '{s[++i] = $0} END {while (i > 0) print s[i--]}' /proc/$watchfrr_pid/cmdline`; do
 			in_list $i $all_daemons || break
 			in_list $i $daemons || daemon_stop $i
 		done

--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -74,6 +74,8 @@ reload)
 		exit 1
 	fi
 
+	daemon_list daemons
+
 	# systemd doesn't set WATCHDOG_USEC for reload commands.
 	watchfrr_pidfile="$V_PATH/watchfrr.pid"
 	watchfrr_pid="`cat \"$watchfrr_pidfile\"`"
@@ -82,11 +84,20 @@ reload)
 		wdt="${wdt#WATCHDOG_USEC=}"
 		[ -n "$wdt" ] && : ${WATCHDOG_USEC:=$wdt}
 		[ -n "$WATCHDOG_USEC" ] && export WATCHDOG_USEC
+
+		all_daemon_list all_daemons
+		# Kill any currently monitored daemons that are no longer enabled.
+		# Traverse command line args in reverse order, bailing out when we hit
+		# an argument that is not a daemon. Otherwise, if it's not in the
+		# new daemon list, stop it.
+		for i in `tr '\0' '\n' < /proc/$watchfrr_pid/cmdline | tac`; do
+			in_list $i $all_daemons || break
+			in_list $i $daemons || daemon_stop $i
+		done
 	fi
 
 	# restart watchfrr to pick up added daemons.
 	# NB: This will NOT cause the other daemons to be restarted.
-	daemon_list daemons
 	watchfrr_options="$watchfrr_options $daemons"
 	daemon_stop watchfrr && \
 		daemon_start watchfrr


### PR DESCRIPTION
 tools/frrcommon.sh.in (all_daemon_list): add new function to list all valid daemons.
       (in_list): new function to test list membership.

 tools/frrinit.sh.in (reload): stop any daemons currently monitored by watchfrr
       that are not in the new config.
