### PR TITLE
*: If building clippy we must have python3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -797,6 +797,7 @@ fi
 #
 
 AS_IF([test "$host" = "$build"], [
+  AM_PATH_PYTHON([3])
   AC_CHECK_HEADER([gelf.h], [], [
     AC_MSG_ERROR([libelf headers are required for building clippy.  (Host only when cross-compiling.)])
   ])


### PR DESCRIPTION
When building clippy we must have python 3.  Let's
ensure that we test for it and stop the auto-make
if it is not installed on the system.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>