### PR TITLE
lib: allow to create interfaces in non-existing VRFs

### DIFF
--- a/lib/if.h
+++ b/lib/if.h
@@ -293,6 +293,8 @@ struct interface {
 #endif /* HAVE_NET_RT_IFLIST */
 
 	struct route_node *node;
+
+	struct vrf *vrf;
 	vrf_id_t vrf_id;
 
 	/*
@@ -510,11 +512,6 @@ extern int if_cmp_name_func(const char *p1, const char *p2);
  */
 extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
 
-/* Create new interface, adds to name list only */
-extern struct interface *if_create_name(const char *name, vrf_id_t vrf_id);
-
-/* Create new interface, adds to index list only */
-extern struct interface *if_create_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
 extern struct interface *if_vrf_lookup_by_index_next(ifindex_t ifindex,
 						     vrf_id_t vrf_id);
@@ -532,13 +529,11 @@ struct vrf;
 extern struct interface *if_lookup_by_name_all_vrf(const char *ifname);
 extern struct interface *if_lookup_by_name_vrf(const char *name, struct vrf *vrf);
 extern struct interface *if_lookup_by_name(const char *ifname, vrf_id_t vrf_id);
-extern struct interface *if_get_by_name(const char *ifname, vrf_id_t vrf_id);
-extern struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);
+extern struct interface *if_get_by_name(const char *ifname, vrf_id_t vrf_id,
+					const char *vrf_name);
 
 /* Sets the index and adds to index list */
 extern int if_set_index(struct interface *ifp, ifindex_t ifindex);
-/* Sets the name and adds to name list */
-extern void if_set_name(struct interface *ifp, const char *name);
 
 /* Delete the interface, but do not free the structure, and leave it in the
    interface list.  It is often advisable to leave the pseudo interface

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2164,19 +2164,21 @@ static int zclient_interface_add(struct zclient *zclient, vrf_id_t vrf_id)
 	struct interface *ifp;
 	char ifname_tmp[INTERFACE_NAMSIZ + 1] = {};
 	struct stream *s = zclient->ibuf;
+	struct vrf *vrf;
 
 	/* Read interface name. */
 	STREAM_GET(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* Lookup/create interface by name. */
-	if (!vrf_get(vrf_id, NULL)) {
+	vrf = vrf_lookup_by_id(vrf_id);
+	if (!vrf) {
 		zlog_debug(
 			"Rx'd interface add from Zebra, but VRF %u does not exist",
 			vrf_id);
 		return -1;
 	}
 
-	ifp = if_get_by_name(ifname_tmp, vrf_id);
+	ifp = if_get_by_name(ifname_tmp, vrf_id, vrf->name);
 
 	zebra_interface_if_set_value(s, ifp);
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -1032,7 +1032,6 @@ DEFUN_HIDDEN (ospf6_interface_area,
 	struct ospf6_area *oa;
 	struct ospf6_interface *oi;
 	struct interface *ifp;
-	vrf_id_t vrf_id = VRF_DEFAULT;
 	uint32_t area_id;
 	int format;
 
@@ -1041,11 +1040,8 @@ DEFUN_HIDDEN (ospf6_interface_area,
 	vty_out(vty,
 		"Please, use \"ipv6 ospf6 area\" on an interface instead.\n");
 
-	if (ospf6->vrf_id != VRF_UNKNOWN)
-		vrf_id = ospf6->vrf_id;
-
 	/* find/create ospf6 interface */
-	ifp = if_get_by_name(argv[idx_ifname]->arg, vrf_id);
+	ifp = if_get_by_name(argv[idx_ifname]->arg, ospf6->vrf_id, ospf6->name);
 	oi = (struct ospf6_interface *)ifp->info;
 	if (oi == NULL)
 		oi = ospf6_interface_create(ifp);
@@ -1107,18 +1103,14 @@ DEFUN_HIDDEN (no_ospf6_interface_area,
 	struct ospf6_area *oa;
 	struct interface *ifp;
 	uint32_t area_id;
-	vrf_id_t vrf_id = VRF_DEFAULT;
 
 	vty_out(vty,
 		"This command is deprecated, because it is not VRF-aware.\n");
 	vty_out(vty,
 		"Please, use \"no ipv6 ospf6 area\" on an interface instead.\n");
 
-	if (ospf6->vrf_id != VRF_UNKNOWN)
-		vrf_id = ospf6->vrf_id;
-
 	/* find/create ospf6 interface */
-	ifp = if_get_by_name(argv[idx_ifname]->arg, vrf_id);
+	ifp = if_get_by_name(argv[idx_ifname]->arg, ospf6->vrf_id, ospf6->name);
 
 	if (ifp == NULL) {
 		vty_out(vty, "No such interface %s\n", argv[idx_ifname]->arg);

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -915,9 +915,9 @@ struct ospf_interface *ospf_vl_new(struct ospf *ospf,
 			ospf->vrf_id);
 
 	snprintf(ifname, sizeof(ifname), "VLINK%u", vlink_count);
-	vi = if_create_name(ifname, ospf->vrf_id);
+	vi = if_get_by_name(ifname, ospf->vrf_id, ospf->name);
 	/*
-	 * if_create_name sets ZEBRA_INTERFACE_LINKDETECTION
+	 * if_get_by_name sets ZEBRA_INTERFACE_LINKDETECTION
 	 * virtual links don't need this.
 	 */
 	UNSET_FLAG(vi->status, ZEBRA_INTERFACE_LINKDETECTION);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -445,7 +445,7 @@ DEFUN_HIDDEN (ospf_passive_interface_addr,
 		"Please, use \"ip ospf passive\" on an interface instead.\n");
 
 	if (ospf->vrf_id != VRF_UNKNOWN)
-		ifp = if_get_by_name(argv[1]->arg, ospf->vrf_id);
+		ifp = if_get_by_name(argv[1]->arg, ospf->vrf_id, ospf->name);
 
 	if (ifp == NULL) {
 		vty_out(vty, "interface %s not found.\n", (char *)argv[1]->arg);
@@ -506,7 +506,7 @@ DEFUN_HIDDEN (no_ospf_passive_interface,
 		"Please, use \"no ip ospf passive\" on an interface instead.\n");
 
 	if (ospf->vrf_id != VRF_UNKNOWN)
-		ifp = if_get_by_name(argv[2]->arg, ospf->vrf_id);
+		ifp = if_get_by_name(argv[2]->arg, ospf->vrf_id, ospf->name);
 
 	if (ifp == NULL) {
 		vty_out(vty, "interface %s not found.\n", (char *)argv[2]->arg);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1482,7 +1482,8 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 			snprintf(pimreg_name, sizeof(pimreg_name), "pimreg%u",
 				 pim->vrf->data.l.table_id);
 
-		pim->regiface = if_create_name(pimreg_name, pim->vrf->vrf_id);
+		pim->regiface = if_get_by_name(pimreg_name, pim->vrf->vrf_id,
+					       pim->vrf->name);
 		pim->regiface->ifindex = PIM_OIF_PIM_REGISTER_VIF;
 
 		pim_if_new(pim->regiface, false, false, true,

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -109,7 +109,8 @@ static int interface_list_ioctl(void)
 		unsigned int size;
 
 		ifreq = (struct ifreq *)((caddr_t)ifconf.ifc_req + n);
-		ifp = if_get_by_name(ifreq->ifr_name, VRF_DEFAULT);
+		ifp = if_get_by_name(ifreq->ifr_name, VRF_DEFAULT,
+				     VRF_DEFAULT_NAME);
 		if_add_update(ifp);
 		size = ifreq->ifr_addr.sa_len;
 		if (size < sizeof(ifreq->ifr_addr))
@@ -119,7 +120,8 @@ static int interface_list_ioctl(void)
 	}
 #else
 	for (n = 0; n < ifconf.ifc_len; n += sizeof(struct ifreq)) {
-		ifp = if_get_by_name(ifreq->ifr_name, VRF_DEFAULT);
+		ifp = if_get_by_name(ifreq->ifr_name, VRF_DEFAULT,
+				     VRF_DEFAULT_NAME);
 		if_add_update(ifp);
 		ifreq++;
 	}

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -972,16 +972,8 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		link_nsid = ns_id_get_absolute(ns_id, link_nsid);
 	}
 
-	/* Add interface.
-	 * We add by index first because in some cases such as the master
-	 * interface, we have the index before we have the name. Fixing
-	 * back references on the slave interfaces is painful if not done
-	 * this way, i.e. by creating by ifindex.
-	 */
-	ifp = if_get_by_ifindex(ifi->ifi_index, vrf_id);
+	ifp = if_get_by_name(name, vrf_id, NULL);
 	set_ifindex(ifp, ifi->ifi_index, zns); /* add it to ns struct */
-
-	if_set_name(ifp, name);
 
 	ifp->flags = ifi->ifi_flags & 0x0000fffff;
 	ifp->mtu6 = ifp->mtu = *(uint32_t *)RTA_DATA(tb[IFLA_MTU]);
@@ -1814,7 +1806,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 			if (ifp == NULL) {
 				/* unknown interface */
-				ifp = if_get_by_name(name, vrf_id);
+				ifp = if_get_by_name(name, vrf_id, NULL);
 			} else {
 				/* pre-configured interface, learnt now */
 				if (ifp->vrf_id != vrf_id)

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1616,7 +1616,6 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 	struct listnode *node;
 	struct route_node *rn;
 	struct zebra_if *zebra_if;
-	struct vrf *vrf;
 	char pd_buf[ZEBRA_PROTODOWN_RC_STR_LEN];
 
 	zebra_if = ifp->info;
@@ -1644,8 +1643,7 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 
 	zebra_ptm_show_status(vty, NULL, ifp);
 
-	vrf = vrf_lookup_by_id(ifp->vrf_id);
-	vty_out(vty, "  vrf: %s\n", vrf->name);
+	vty_out(vty, "  vrf: %s\n", ifp->vrf->name);
 
 	if (ifp->desc)
 		vty_out(vty, "  Description: %s\n", ifp->desc);
@@ -1941,7 +1939,6 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 	struct listnode *node;
 	struct route_node *rn;
 	struct zebra_if *zebra_if;
-	struct vrf *vrf;
 	char pd_buf[ZEBRA_PROTODOWN_RC_STR_LEN];
 	char buf[BUFSIZ];
 	json_object *json_if;
@@ -1979,8 +1976,7 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 
 	zebra_ptm_show_status(vty, json, ifp);
 
-	vrf = vrf_lookup_by_id(ifp->vrf_id);
-	json_object_string_add(json_if, "vrfName", vrf->name);
+	json_object_string_add(json_if, "vrfName", ifp->vrf->name);
 
 	if (ifp->desc)
 		json_object_string_add(json_if, "description", ifp->desc);
@@ -4206,21 +4202,19 @@ static int link_params_config_write(struct vty *vty, struct interface *ifp)
 
 static int if_config_write(struct vty *vty)
 {
-	struct vrf *vrf0;
+	struct vrf *vrf;
 	struct interface *ifp;
 
 	zebra_ptm_write(vty);
 
-	RB_FOREACH (vrf0, vrf_name_head, &vrfs_by_name)
-		FOR_ALL_INTERFACES (vrf0, ifp) {
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
+		FOR_ALL_INTERFACES (vrf, ifp) {
 			struct zebra_if *if_data;
 			struct listnode *addrnode;
 			struct connected *ifc;
 			struct prefix *p;
-			struct vrf *vrf;
 
 			if_data = ifp->info;
-			vrf = vrf_lookup_by_id(ifp->vrf_id);
 
 			if (ifp->vrf_id == VRF_DEFAULT)
 				vty_frame(vty, "interface %s\n", ifp->name);

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -443,7 +443,8 @@ static int ifan_read(struct if_announcemsghdr *ifan)
 				__func__, ifan->ifan_index, ifan->ifan_name);
 
 		/* Create Interface */
-		ifp = if_get_by_name(ifan->ifan_name, VRF_DEFAULT);
+		ifp = if_get_by_name(ifan->ifan_name, VRF_DEFAULT,
+				     VRF_DEFAULT_NAME);
 		if_set_index(ifp, ifan->ifan_index);
 
 		if_get_metric(ifp);
@@ -624,7 +625,8 @@ int ifm_read(struct if_msghdr *ifm)
 		if (ifp == NULL) {
 			/* Interface that zebra was not previously aware of, so
 			 * create. */
-			ifp = if_create_name(ifname, VRF_DEFAULT);
+			ifp = if_get_by_name(ifname, VRF_DEFAULT,
+					     VRF_DEFAULT_NAME);
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug("%s: creating ifp for ifindex %d",
 					   __func__, ifm->ifm_index);


### PR DESCRIPTION
It allows FRR to read the interface config even when the necessary VRFs
are not yet created and interfaces are in "wrong" VRFs. Currently, such
config is rejected.

For VRF-lite backend, we don't care at all about the VRF of the inactive
interface. When the interface is created in the OS and becomes active,
we always use its actual VRF instead of the configured one. So there's
no need to reject the config.

For netns backend, we may have multiple interfaces with the same name in
different VRFs. So we care about the VRF of inactive interfaces. And we
must allow to preconfigure the interface in a VRF even before it is
moved to the corresponding netns. From now on, we allow to create
multiple configs for the same interface name in different VRFs and
the necessary config is applied once the OS interface is moved to the
corresponding netns.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>