### PR TITLE
tests: Fix `Invalid escape sequence` warnings in test runs

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_mpls.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_mpls.py
@@ -4,7 +4,7 @@ from lib import topotest
 ret = luCommand(
     "r2",
     "ip -M route show",
-    "\d*(?= via inet 10.0.2.4 dev r2-eth1)",
+    r"\d*(?= via inet 10.0.2.4 dev r2-eth1)",
     "wait",
     "See mpls route to r4",
 )
@@ -16,7 +16,7 @@ if ret != False and found != None:
     ret = luCommand(
         "r2",
         "ip -M route show",
-        "\d*(?= via inet 10.0.1.1 dev r2-eth0)",
+        r"\d*(?= via inet 10.0.1.1 dev r2-eth0)",
         "wait",
         "See mpls route to r1",
     )

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/scale_up.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/scale_up.py
@@ -21,7 +21,7 @@ for rtr in rtrs:
     ret = luCommand(
         rtr,
         'vtysh -c "show memory"',
-        "zebra: System allocator statistics:   Total heap allocated: *(\d*) ([A-Za-z]*) .*bgpd: System allocator statistics:   Total heap allocated: *(\d*) ([A-Za-z]*)",
+        r"zebra: System allocator statistics:   Total heap allocated: *(\d*) ([A-Za-z]*) .*bgpd: System allocator statistics:   Total heap allocated: *(\d*) ([A-Za-z]*)",
         "none",
         "collect bgpd memory stats",
     )
@@ -188,7 +188,7 @@ else:
         ret = luCommand(
             rtr,
             'vtysh -c "show memory"',
-            "zebra: System allocator statistics:   Total heap allocated: *(\d*) ([A-Za-z]*) .*bgpd: System allocator statistics:   Total heap allocated: *(\d*) ([A-Za-z]*)",
+            r"zebra: System allocator statistics:   Total heap allocated: *(\d*) ([A-Za-z]*) .*bgpd: System allocator statistics:   Total heap allocated: *(\d*) ([A-Za-z]*)",
             "none",
             "collect bgpd memory stats",
         )

--- a/tests/topotests/lib/ltemplate.py
+++ b/tests/topotests/lib/ltemplate.py
@@ -291,7 +291,7 @@ def ltemplateVersionCheck(
             # collect/log info on iproute2
             cc = ltemplateRtrCmd()
             found = cc.doCmd(
-                tgen, rname, "apt-cache policy iproute2", "Installed: ([\d\.]*)"
+                tgen, rname, "apt-cache policy iproute2", r"Installed: ([\d\.]*)"
             )
             if found != None:
                 iproute2Ver = found.group(1)


### PR DESCRIPTION
Test runs are creating these warnings:
bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py::test_check_linux_mpls
  <string>:7: DeprecationWarning: invalid escape sequence \d

bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py::test_check_linux_mpls
  <string>:19: DeprecationWarning: invalid escape sequence \d

bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py::test_check_scale_up
  <string>:24: DeprecationWarning: invalid escape sequence \d

bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py::test_check_scale_up
  <string>:191: DeprecationWarning: invalid escape sequence \d

-- Docs: https://docs.pytest.org/en/stable/warnings.html

Find and destroy these warnings

Signed-off-by: Donald Sharp <sharpd@nvidia.com>