### PR TITLE
*: fix interface config write in NB-converted daemons

### DIFF
--- a/eigrpd/eigrp_cli.c
+++ b/eigrpd/eigrp_cli.c
@@ -869,30 +869,6 @@ static int eigrp_config_write(struct vty *vty)
 	return written;
 }
 
-static int eigrp_write_interface(struct vty *vty)
-{
-	const struct lyd_node *dnode;
-	struct interface *ifp;
-	struct vrf *vrf;
-	int written = 0;
-
-	RB_FOREACH(vrf, vrf_name_head, &vrfs_by_name) {
-		FOR_ALL_INTERFACES(vrf, ifp) {
-			dnode = yang_dnode_getf(
-				running_config->dnode,
-				"/frr-interface:lib/interface[name='%s'][vrf='%s']",
-				ifp->name, vrf->name);
-			if (dnode == NULL)
-				continue;
-
-			written = 1;
-			nb_cli_show_dnode_cmds(vty, dnode, false);
-		}
-	}
-
-	return written;
-}
-
 void
 eigrp_cli_init(void)
 {
@@ -919,7 +895,7 @@ eigrp_cli_init(void)
 
 	vrf_cmd_init(NULL);
 
-	if_cmd_init(eigrp_write_interface);
+	if_cmd_init_default();
 
 	install_element(INTERFACE_NODE, &eigrp_if_delay_cmd);
 	install_element(INTERFACE_NODE, &no_eigrp_if_delay_cmd);

--- a/lib/if.c
+++ b/lib/if.c
@@ -1341,6 +1341,20 @@ static struct cmd_node interface_node = {
 	.prompt = "%s(config-if)# ",
 };
 
+static int if_config_write_single(const struct lyd_node *dnode, void *arg)
+{
+	nb_cli_show_dnode_cmds(arg, dnode, false);
+
+	return YANG_ITER_CONTINUE;
+}
+
+static int if_nb_config_write(struct vty *vty)
+{
+	yang_dnode_iterate(if_config_write_single, vty, running_config->dnode,
+			   "/frr-interface:lib/interface");
+	return 1;
+}
+
 void if_cmd_init(int (*config_write)(struct vty *))
 {
 	cmd_variable_handler_register(if_var_handlers);
@@ -1354,6 +1368,11 @@ void if_cmd_init(int (*config_write)(struct vty *))
 	install_default(INTERFACE_NODE);
 	install_element(INTERFACE_NODE, &interface_desc_cmd);
 	install_element(INTERFACE_NODE, &no_interface_desc_cmd);
+}
+
+void if_cmd_init_default(void)
+{
+	if_cmd_init(if_nb_config_write);
 }
 
 void if_zapi_callbacks(int (*create)(struct interface *ifp),

--- a/lib/if.h
+++ b/lib/if.h
@@ -594,6 +594,7 @@ void if_link_params_free(struct interface *);
 /* Northbound. */
 struct vty;
 extern void if_cmd_init(int (*config_write)(struct vty *));
+extern void if_cmd_init_default(void);
 extern void if_zapi_callbacks(int (*create)(struct interface *ifp),
 			      int (*up)(struct interface *ifp),
 			      int (*down)(struct interface *ifp),

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -1103,33 +1103,6 @@ void rip_passive_nondefault_clean(struct rip *rip)
 	rip_passive_interface_apply_all(rip);
 }
 
-/* Write rip configuration of each interface. */
-static int rip_interface_config_write(struct vty *vty)
-{
-	struct vrf *vrf;
-	int write = 0;
-
-	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-		struct interface *ifp;
-
-		FOR_ALL_INTERFACES (vrf, ifp) {
-			struct lyd_node *dnode;
-
-			dnode = yang_dnode_getf(
-				running_config->dnode,
-				"/frr-interface:lib/interface[name='%s'][vrf='%s']",
-				ifp->name, vrf->name);
-			if (dnode == NULL)
-				continue;
-
-			write = 1;
-			nb_cli_show_dnode_cmds(vty, dnode, false);
-		}
-	}
-
-	return write;
-}
-
 int rip_show_network_config(struct vty *vty, struct rip *rip)
 {
 	unsigned int i;
@@ -1194,7 +1167,7 @@ void rip_if_init(void)
 	hook_register_prio(if_del, 0, rip_interface_delete_hook);
 
 	/* Install interface node. */
-	if_cmd_init(rip_interface_config_write);
+	if_cmd_init_default();
 	if_zapi_callbacks(rip_ifp_create, rip_ifp_up,
 			  rip_ifp_down, rip_ifp_destroy);
 }

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -923,33 +923,6 @@ static int ripng_if_delete_hook(struct interface *ifp)
 	return 0;
 }
 
-/* Configuration write function for ripngd. */
-static int interface_config_write(struct vty *vty)
-{
-	struct vrf *vrf;
-	int write = 0;
-
-	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-		struct interface *ifp;
-
-		FOR_ALL_INTERFACES (vrf, ifp) {
-			struct lyd_node *dnode;
-
-			dnode = yang_dnode_getf(
-				running_config->dnode,
-				"/frr-interface:lib/interface[name='%s'][vrf='%s']",
-				ifp->name, vrf->name);
-			if (dnode == NULL)
-				continue;
-
-			write = 1;
-			nb_cli_show_dnode_cmds(vty, dnode, false);
-		}
-	}
-
-	return write;
-}
-
 /* Initialization of interface. */
 void ripng_if_init(void)
 {
@@ -958,7 +931,7 @@ void ripng_if_init(void)
 	hook_register_prio(if_del, 0, ripng_if_delete_hook);
 
 	/* Install interface node. */
-	if_cmd_init(interface_config_write);
+	if_cmd_init_default();
 	if_zapi_callbacks(ripng_ifp_create, ripng_ifp_up,
 			  ripng_ifp_down, ripng_ifp_destroy);
 }

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -715,35 +715,6 @@ DEFUN_NOSH (show_debugging_vrrp,
 
 /* clang-format on */
 
-/*
- * Write per interface VRRP config.
- */
-static int vrrp_config_write_interface(struct vty *vty)
-{
-	struct vrf *vrf;
-	int write = 0;
-
-	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-		struct interface *ifp;
-
-		FOR_ALL_INTERFACES (vrf, ifp) {
-			const struct lyd_node *dnode;
-
-			dnode = yang_dnode_getf(
-				running_config->dnode,
-				"/frr-interface:lib/interface[name='%s'][vrf='%s']",
-				ifp->name, vrf->name);
-			if (dnode == NULL)
-				continue;
-
-			write = 1;
-			nb_cli_show_dnode_cmds(vty, dnode, false);
-		}
-	}
-
-	return write;
-}
-
 static struct cmd_node debug_node = {
 	.name = "debug",
 	.node = DEBUG_NODE,
@@ -763,7 +734,7 @@ void vrrp_vty_init(void)
 	install_node(&debug_node);
 	install_node(&vrrp_node);
 	vrf_cmd_init(NULL);
-	if_cmd_init(vrrp_config_write_interface);
+	if_cmd_init_default();
 
 	install_element(VIEW_NODE, &vrrp_vrid_show_cmd);
 	install_element(VIEW_NODE, &vrrp_vrid_show_summary_cmd);


### PR DESCRIPTION
When writing the config from the NB-converted daemon, we must not rely
on the operational data. This commit changes the output of the interface
configuration to use only config data. As the code is the same for all
daemons, move it to the lib and remove all the duplicated code.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>