### PR TITLE
debian: add --enable-werror

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -62,6 +62,7 @@ override_dh_auto_configure:
 		--enable-vty-group=frrvty \
 		--enable-configfile-mask=0640 \
 		--enable-logfile-mask=0640 \
+		--enable-werror \
 		# end
 
 override_dh_auto_install:


### PR DESCRIPTION
We don't want to build a package when we have build warnings, right?

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>