### PR TITLE
lib: northbound cli show/cmd functions must not modify data nodes

### DIFF
--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -92,14 +92,15 @@ DEFUN_YANG(
 }
 
 void bfd_cli_show_header(struct vty *vty,
-			 struct lyd_node *dnode __attribute__((__unused__)),
+			 const struct lyd_node *dnode
+			 __attribute__((__unused__)),
 			 bool show_defaults __attribute__((__unused__)))
 {
 	vty_out(vty, "!\nbfd\n");
 }
 
-void bfd_cli_show_header_end(struct vty *vty,
-			     struct lyd_node *dnode __attribute__((__unused__)))
+void bfd_cli_show_header_end(struct vty *vty, const struct lyd_node *dnode
+			     __attribute__((__unused__)))
 {
 	vty_out(vty, "exit\n");
 	vty_out(vty, "!\n");
@@ -230,7 +231,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-static void _bfd_cli_show_peer(struct vty *vty, struct lyd_node *dnode,
+static void _bfd_cli_show_peer(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults __attribute__((__unused__)),
 			       bool mhop)
 {
@@ -259,22 +260,20 @@ static void _bfd_cli_show_peer(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void bfd_cli_show_single_hop_peer(struct vty *vty,
-				  struct lyd_node *dnode,
+void bfd_cli_show_single_hop_peer(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults)
 {
 	_bfd_cli_show_peer(vty, dnode, show_defaults, false);
 }
 
-void bfd_cli_show_multi_hop_peer(struct vty *vty,
-				  struct lyd_node *dnode,
-				  bool show_defaults)
+void bfd_cli_show_multi_hop_peer(struct vty *vty, const struct lyd_node *dnode,
+				 bool show_defaults)
 {
 	_bfd_cli_show_peer(vty, dnode, show_defaults, true);
 }
 
-void bfd_cli_show_peer_end(struct vty *vty,
-			   struct lyd_node *dnode __attribute__((__unused__)))
+void bfd_cli_show_peer_end(struct vty *vty, const struct lyd_node *dnode
+			   __attribute__((__unused__)))
 {
 	vty_out(vty, " exit\n");
 	vty_out(vty, " !\n");
@@ -291,7 +290,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void bfd_cli_show_shutdown(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_shutdown(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	vty_out(vty, "  %sshutdown\n",
@@ -309,7 +308,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void bfd_cli_show_passive(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_passive(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults)
 {
 	vty_out(vty, "  %spassive-mode\n",
@@ -347,7 +346,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void bfd_cli_show_minimum_ttl(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_minimum_ttl(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	vty_out(vty, "  minimum-ttl %s\n", yang_dnode_get_string(dnode, NULL));
@@ -364,7 +363,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void bfd_cli_show_mult(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_mult(struct vty *vty, const struct lyd_node *dnode,
 		       bool show_defaults)
 {
 	vty_out(vty, "  detect-multiplier %s\n",
@@ -386,7 +385,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void bfd_cli_show_rx(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_rx(struct vty *vty, const struct lyd_node *dnode,
 		     bool show_defaults)
 {
 	uint32_t value = yang_dnode_get_uint32(dnode, NULL);
@@ -409,7 +408,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void bfd_cli_show_tx(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_tx(struct vty *vty, const struct lyd_node *dnode,
 		     bool show_defaults)
 {
 	uint32_t value = yang_dnode_get_uint32(dnode, NULL);
@@ -437,8 +436,8 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void bfd_cli_show_echo(struct vty *vty, struct lyd_node *dnode,
-			   bool show_defaults)
+void bfd_cli_show_echo(struct vty *vty, const struct lyd_node *dnode,
+		       bool show_defaults)
 {
 	vty_out(vty, "  %secho-mode\n",
 		yang_dnode_get_bool(dnode, NULL) ? "" : "no ");
@@ -487,8 +486,8 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void bfd_cli_show_desired_echo_transmission_interval(struct vty *vty,
-	struct lyd_node *dnode, bool show_defaults)
+void bfd_cli_show_desired_echo_transmission_interval(
+	struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
 {
 	uint32_t value = yang_dnode_get_uint32(dnode, NULL);
 
@@ -522,7 +521,8 @@ DEFPY_YANG(
 }
 
 void bfd_cli_show_required_echo_receive_interval(struct vty *vty,
-	struct lyd_node *dnode, bool show_defaults)
+						 const struct lyd_node *dnode,
+						 bool show_defaults)
 {
 	uint32_t value = yang_dnode_get_uint32(dnode, NULL);
 
@@ -573,7 +573,7 @@ DEFPY_YANG(no_bfd_profile, no_bfd_profile_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void bfd_cli_show_profile(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_profile(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults)
 {
 	vty_out(vty, " profile %s\n", yang_dnode_get_string(dnode, "./name"));
@@ -654,7 +654,7 @@ DEFPY_YANG(bfd_peer_profile, bfd_peer_profile_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void bfd_cli_peer_profile_show(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_peer_profile_show(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults)
 {
 	vty_out(vty, "  profile %s\n", yang_dnode_get_string(dnode, NULL));

--- a/bfdd/bfdd_nb.h
+++ b/bfdd/bfdd_nb.h
@@ -195,35 +195,36 @@ bfdd_bfd_sessions_multi_hop_stats_echo_packet_output_count_get_elem(
 	struct nb_cb_get_elem_args *args);
 
 /* Optional 'cli_show' callbacks. */
-void bfd_cli_show_header(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_header(struct vty *vty, const struct lyd_node *dnode,
 			 bool show_defaults);
-void bfd_cli_show_header_end(struct vty *vty, struct lyd_node *dnode);
-void bfd_cli_show_single_hop_peer(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_header_end(struct vty *vty, const struct lyd_node *dnode);
+void bfd_cli_show_single_hop_peer(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
-void bfd_cli_show_multi_hop_peer(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_multi_hop_peer(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
-void bfd_cli_show_peer_end(struct vty *vty, struct lyd_node *dnode);
-void bfd_cli_show_mult(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_peer_end(struct vty *vty, const struct lyd_node *dnode);
+void bfd_cli_show_mult(struct vty *vty, const struct lyd_node *dnode,
 		       bool show_defaults);
-void bfd_cli_show_tx(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_tx(struct vty *vty, const struct lyd_node *dnode,
 		     bool show_defaults);
-void bfd_cli_show_rx(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_rx(struct vty *vty, const struct lyd_node *dnode,
 		     bool show_defaults);
-void bfd_cli_show_shutdown(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_shutdown(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
-void bfd_cli_show_echo(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_echo(struct vty *vty, const struct lyd_node *dnode,
 		       bool show_defaults);
 void bfd_cli_show_desired_echo_transmission_interval(
-	struct vty *vty, struct lyd_node *dnode, bool show_defaults);
-void bfd_cli_show_required_echo_receive_interval(
-	struct vty *vty, struct lyd_node *dnode, bool show_defaults);
-void bfd_cli_show_profile(struct vty *vty, struct lyd_node *dnode,
+	struct vty *vty, const struct lyd_node *dnode, bool show_defaults);
+void bfd_cli_show_required_echo_receive_interval(struct vty *vty,
+						 const struct lyd_node *dnode,
+						 bool show_defaults);
+void bfd_cli_show_profile(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults);
-void bfd_cli_peer_profile_show(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_peer_profile_show(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults);
-void bfd_cli_show_passive(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_passive(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults);
-void bfd_cli_show_minimum_ttl(struct vty *vty, struct lyd_node *dnode,
+void bfd_cli_show_minimum_ttl(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults);
 
 #endif /* _FRR_BFDD_NB_H_ */

--- a/eigrpd/eigrp_cli.c
+++ b/eigrpd/eigrp_cli.c
@@ -82,7 +82,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes_clear_pending(vty, NULL);
 }
 
-void eigrp_cli_show_header(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_header(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	const char *asn = yang_dnode_get_string(dnode, "./asn");
@@ -94,7 +94,7 @@ void eigrp_cli_show_header(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void eigrp_cli_show_end_header(struct vty *vty, struct lyd_node *dnode)
+void eigrp_cli_show_end_header(struct vty *vty, const struct lyd_node *dnode)
 {
 	vty_out(vty, "exit\n");
 	vty_out(vty, "!\n");
@@ -128,7 +128,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_router_id(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_router_id(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	const char *router_id = yang_dnode_get_string(dnode, NULL);
@@ -157,7 +157,8 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_passive_interface(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_passive_interface(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults)
 {
 	const char *ifname = yang_dnode_get_string(dnode, NULL);
@@ -200,7 +201,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_active_time(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_active_time(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	const char *timer = yang_dnode_get_string(dnode, NULL);
@@ -234,7 +235,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_variance(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_variance(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults)
 {
 	const char *variance = yang_dnode_get_string(dnode, NULL);
@@ -269,7 +270,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_maximum_paths(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_maximum_paths(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults)
 {
 	const char *maximum_paths = yang_dnode_get_string(dnode, NULL);
@@ -333,7 +334,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_metrics(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_metrics(struct vty *vty, const struct lyd_node *dnode,
 			    bool show_defaults)
 {
 	const char *k1, *k2, *k3, *k4, *k5, *k6;
@@ -379,7 +380,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_network(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_network(struct vty *vty, const struct lyd_node *dnode,
 			    bool show_defaults)
 {
 	const char *prefix = yang_dnode_get_string(dnode, NULL);
@@ -408,8 +409,8 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_neighbor(struct vty *vty, struct lyd_node *dnode,
-			    bool show_defaults)
+void eigrp_cli_show_neighbor(struct vty *vty, const struct lyd_node *dnode,
+			     bool show_defaults)
 {
 	const char *prefix = yang_dnode_get_string(dnode, NULL);
 
@@ -468,7 +469,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_redistribute(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_redistribute(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults)
 {
 	const char *proto = yang_dnode_get_string(dnode, "./protocol");
@@ -520,7 +521,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_delay(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_delay(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults)
 {
 	const char *delay = yang_dnode_get_string(dnode, NULL);
@@ -558,7 +559,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_bandwidth(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_bandwidth(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	const char *bandwidth = yang_dnode_get_string(dnode, NULL);
@@ -599,7 +600,8 @@ DEFPY_YANG(
 }
 
 
-void eigrp_cli_show_hello_interval(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_hello_interval(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
 	const char *hello = yang_dnode_get_string(dnode, NULL);
@@ -639,7 +641,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_hold_time(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_hold_time(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	const char *holdtime = yang_dnode_get_string(dnode, NULL);
@@ -701,10 +703,12 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_summarize_address(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_summarize_address(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults)
 {
-	const struct lyd_node *instance = yang_dnode_get_parent(dnode, "instance");
+	const struct lyd_node *instance =
+		yang_dnode_get_parent(dnode, "instance");
 	uint16_t asn = yang_dnode_get_uint16(instance, "./asn");
 	const char *summarize_address = yang_dnode_get_string(dnode, NULL);
 
@@ -765,10 +769,12 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_authentication(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_authentication(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
-	const struct lyd_node *instance = yang_dnode_get_parent(dnode, "instance");
+	const struct lyd_node *instance =
+		yang_dnode_get_parent(dnode, "instance");
 	uint16_t asn = yang_dnode_get_uint16(instance, "./asn");
 	const char *crypt = yang_dnode_get_string(dnode, NULL);
 
@@ -824,10 +830,11 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void eigrp_cli_show_keychain(struct vty *vty, struct lyd_node *dnode,
+void eigrp_cli_show_keychain(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults)
 {
-	const struct lyd_node *instance = yang_dnode_get_parent(dnode, "instance");
+	const struct lyd_node *instance =
+		yang_dnode_get_parent(dnode, "instance");
 	uint16_t asn = yang_dnode_get_uint16(instance, "./asn");
 	const char *keychain = yang_dnode_get_string(dnode, NULL);
 
@@ -850,7 +857,7 @@ static struct cmd_node eigrp_node = {
 
 static int eigrp_config_write(struct vty *vty)
 {
-	struct lyd_node *dnode;
+	const struct lyd_node *dnode;
 	int written = 0;
 
 	dnode = yang_dnode_get(running_config->dnode, "/frr-eigrpd:eigrpd");
@@ -864,7 +871,7 @@ static int eigrp_config_write(struct vty *vty)
 
 static int eigrp_write_interface(struct vty *vty)
 {
-	struct lyd_node *dnode;
+	const struct lyd_node *dnode;
 	struct interface *ifp;
 	struct vrf *vrf;
 	int written = 0;

--- a/eigrpd/eigrp_cli.h
+++ b/eigrpd/eigrp_cli.h
@@ -25,45 +25,56 @@
 #define _EIGRP_CLI_H_
 
 /*Prototypes*/
-extern void eigrp_cli_show_header(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_header(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
-extern void eigrp_cli_show_end_header(struct vty *vty, struct lyd_node *dnode);
-extern void eigrp_cli_show_router_id(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_end_header(struct vty *vty,
+				      const struct lyd_node *dnode);
+extern void eigrp_cli_show_router_id(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
 extern void eigrp_cli_show_passive_interface(struct vty *vty,
-					     struct lyd_node *dnode,
+					     const struct lyd_node *dnode,
 					     bool show_defaults);
-extern void eigrp_cli_show_active_time(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_active_time(struct vty *vty,
+				       const struct lyd_node *dnode,
 				       bool show_defaults);
-extern void eigrp_cli_show_variance(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_variance(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
 extern void eigrp_cli_show_maximum_paths(struct vty *vty,
-					 struct lyd_node *dnode,
+					 const struct lyd_node *dnode,
 					 bool show_defaults);
-extern void eigrp_cli_show_metrics(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_metrics(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-extern void eigrp_cli_show_network(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_network(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-extern void eigrp_cli_show_neighbor(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_neighbor(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-extern void eigrp_cli_show_redistribute(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_redistribute(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults);
-extern void eigrp_cli_show_delay(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_delay(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
-extern void eigrp_cli_show_bandwidth(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_bandwidth(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
 extern void eigrp_cli_show_hello_interval(struct vty *vty,
-					  struct lyd_node *dnode,
+					  const struct lyd_node *dnode,
 					  bool show_defaults);
-extern void eigrp_cli_show_hold_time(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_hold_time(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
 extern void eigrp_cli_show_summarize_address(struct vty *vty,
-					     struct lyd_node *dnode,
+					     const struct lyd_node *dnode,
 					     bool show_defaults);
 extern void eigrp_cli_show_authentication(struct vty *vty,
-					  struct lyd_node *dnode,
+					  const struct lyd_node *dnode,
 					  bool show_defaults);
-extern void eigrp_cli_show_keychain(struct vty *vty, struct lyd_node *dnode,
+extern void eigrp_cli_show_keychain(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
 extern void eigrp_cli_init(void);
 

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -131,7 +131,7 @@ DEFPY_YANG(no_router_isis, no_router_isis_cmd,
 		vrf_name);
 }
 
-void cli_show_router_isis(struct vty *vty, struct lyd_node *dnode,
+void cli_show_router_isis(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults)
 {
 	const char *vrf = NULL;
@@ -146,7 +146,7 @@ void cli_show_router_isis(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void cli_show_router_isis_end(struct vty *vty, struct lyd_node *dnode)
+void cli_show_router_isis_end(struct vty *vty, const struct lyd_node *dnode)
 {
 	vty_out(vty, "exit\n");
 }
@@ -165,7 +165,7 @@ DEFPY_YANG(ip_router_isis, ip_router_isis_cmd,
 	   "Routing process tag\n")
 {
 	char inst_xpath[XPATH_MAXLEN];
-	struct lyd_node *if_dnode, *inst_dnode;
+	const struct lyd_node *if_dnode, *inst_dnode;
 	const char *circ_type = NULL;
 	const char *vrf_name;
 	struct interface *ifp;
@@ -222,7 +222,7 @@ DEFPY_YANG(ip6_router_isis, ip6_router_isis_cmd,
 	   "Routing process tag\n")
 {
 	char inst_xpath[XPATH_MAXLEN];
-	struct lyd_node *if_dnode, *inst_dnode;
+	const struct lyd_node *if_dnode, *inst_dnode;
 	const char *circ_type = NULL;
 	const char *vrf_name;
 	struct interface *ifp;
@@ -321,7 +321,7 @@ ALIAS_HIDDEN(no_ip_router_isis, no_ip_router_isis_vrf_cmd,
 	     "Routing process tag\n"
 	     VRF_CMD_HELP_STR)
 
-void cli_show_ip_isis_ipv4(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_ipv4(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -330,7 +330,7 @@ void cli_show_ip_isis_ipv4(struct vty *vty, struct lyd_node *dnode,
 		yang_dnode_get_string(dnode, "../area-tag"));
 }
 
-void cli_show_ip_isis_ipv6(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_ipv6(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -395,7 +395,8 @@ DEFPY_YANG(isis_bfd_profile,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_bfd_monitoring(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_bfd_monitoring(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, "./enabled")) {
@@ -424,7 +425,7 @@ DEFPY_YANG(net, net_cmd, "[no] net WORD",
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_area_address(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_area_address(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	vty_out(vty, " net %s\n", yang_dnode_get_string(dnode, NULL));
@@ -459,7 +460,7 @@ DEFPY_YANG(no_is_type, no_is_type_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_is_type(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_is_type(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	int is_type = yang_dnode_get_enum(dnode, NULL);
@@ -491,7 +492,8 @@ DEFPY_YANG(dynamic_hostname, dynamic_hostname_cmd, "[no] hostname dynamic",
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_dynamic_hostname(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_dynamic_hostname(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -513,7 +515,7 @@ DEFPY_YANG(set_overload_bit, set_overload_bit_cmd, "[no] set-overload-bit",
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_overload(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_overload(struct vty *vty, const struct lyd_node *dnode,
 			    bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -552,7 +554,7 @@ DEFPY_YANG(attached_bit_send, attached_bit_send_cmd, "[no] attached-bit send",
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_attached_send(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_attached_send(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -577,7 +579,8 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_attached_receive(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_attached_receive(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -613,7 +616,7 @@ DEFPY_YANG(no_metric_style, no_metric_style_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_metric_style(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_metric_style(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	int metric = yang_dnode_get_enum(dnode, NULL);
@@ -656,7 +659,7 @@ DEFPY_YANG(area_passwd, area_passwd_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_area_pwd(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_area_pwd(struct vty *vty, const struct lyd_node *dnode,
 			    bool show_defaults)
 {
 	const char *snp;
@@ -706,7 +709,7 @@ DEFPY_YANG(no_area_passwd, no_area_passwd_cmd,
 	return nb_cli_apply_changes(vty, "./%s", cmd);
 }
 
-void cli_show_isis_domain_pwd(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_domain_pwd(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	const char *snp;
@@ -931,7 +934,7 @@ DEFPY_YANG(no_lsp_timers, no_lsp_timers_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_lsp_timers(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_lsp_timers(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	const char *l1_refresh =
@@ -983,7 +986,7 @@ DEFPY_YANG(no_area_lsp_mtu, no_area_lsp_mtu_cmd, "no lsp-mtu [(128-4352)]",
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_lsp_mtu(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_lsp_mtu(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	vty_out(vty, " lsp-mtu %s\n", yang_dnode_get_string(dnode, NULL));
@@ -1027,7 +1030,8 @@ DEFPY_YANG(no_spf_interval, no_spf_interval_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_spf_min_interval(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_spf_min_interval(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
 	const char *l1 = yang_dnode_get_string(dnode, "./level-1");
@@ -1095,7 +1099,8 @@ DEFPY_YANG(no_spf_delay_ietf, no_spf_delay_ietf_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_spf_ietf_backoff(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_spf_ietf_backoff(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
 	vty_out(vty,
@@ -1147,7 +1152,8 @@ DEFPY_YANG(no_spf_prefix_priority, no_spf_prefix_priority_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_spf_prefix_priority(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_spf_prefix_priority(struct vty *vty,
+				       const struct lyd_node *dnode,
 				       bool show_defaults)
 {
 	vty_out(vty, " spf prefix-priority %s %s\n",
@@ -1167,7 +1173,7 @@ DEFPY_YANG(area_purge_originator, area_purge_originator_cmd, "[no] purge-origina
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_purge_origin(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_purge_origin(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -1198,7 +1204,7 @@ DEFPY_YANG(no_isis_mpls_te_on, no_isis_mpls_te_on_cmd, "no mpls-te [on]",
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_mpls_te(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mpls_te(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	vty_out(vty, " mpls-te on\n");
@@ -1231,7 +1237,8 @@ DEFPY_YANG(no_isis_mpls_te_router_addr, no_isis_mpls_te_router_addr_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_mpls_te_router_addr(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mpls_te_router_addr(struct vty *vty,
+				       const struct lyd_node *dnode,
 				       bool show_defaults)
 {
 	vty_out(vty, " mpls-te router-address %s\n",
@@ -1292,7 +1299,7 @@ DEFPY_YANG(isis_default_originate, isis_default_originate_cmd,
 		level);
 }
 
-static void vty_print_def_origin(struct vty *vty, struct lyd_node *dnode,
+static void vty_print_def_origin(struct vty *vty, const struct lyd_node *dnode,
 				 const char *family, const char *level,
 				 bool show_defaults)
 {
@@ -1310,7 +1317,8 @@ static void vty_print_def_origin(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void cli_show_isis_def_origin_ipv4(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_def_origin_ipv4(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
 	const char *level = yang_dnode_get_string(dnode, "./level");
@@ -1318,7 +1326,8 @@ void cli_show_isis_def_origin_ipv4(struct vty *vty, struct lyd_node *dnode,
 	vty_print_def_origin(vty, dnode, "ipv4", level, show_defaults);
 }
 
-void cli_show_isis_def_origin_ipv6(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_def_origin_ipv6(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
 	const char *level = yang_dnode_get_string(dnode, "./level");
@@ -1361,7 +1370,8 @@ DEFPY_YANG(isis_redistribute, isis_redistribute_cmd,
 		level);
 }
 
-static void vty_print_redistribute(struct vty *vty, struct lyd_node *dnode,
+static void vty_print_redistribute(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults, const char *family)
 {
 	const char *level = yang_dnode_get_string(dnode, "./level");
@@ -1377,12 +1387,14 @@ static void vty_print_redistribute(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void cli_show_isis_redistribute_ipv4(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_redistribute_ipv4(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults)
 {
 	vty_print_redistribute(vty, dnode, show_defaults, "ipv4");
 }
-void cli_show_isis_redistribute_ipv6(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_redistribute_ipv6(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults)
 {
 	vty_print_redistribute(vty, dnode, show_defaults, "ipv6");
@@ -1435,7 +1447,8 @@ DEFPY_YANG(isis_topology, isis_topology_cmd,
 	return nb_cli_apply_changes(vty, base_xpath);
 }
 
-void cli_show_isis_mt_ipv4_multicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv4_multicast(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults)
 {
 	vty_out(vty, " topology ipv4-multicast");
@@ -1444,7 +1457,7 @@ void cli_show_isis_mt_ipv4_multicast(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void cli_show_isis_mt_ipv4_mgmt(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv4_mgmt(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	vty_out(vty, " topology ipv4-mgmt");
@@ -1453,7 +1466,8 @@ void cli_show_isis_mt_ipv4_mgmt(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void cli_show_isis_mt_ipv6_unicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv6_unicast(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
 	vty_out(vty, " topology ipv6-unicast");
@@ -1462,7 +1476,8 @@ void cli_show_isis_mt_ipv6_unicast(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void cli_show_isis_mt_ipv6_multicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv6_multicast(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults)
 {
 	vty_out(vty, " topology ipv6-multicast");
@@ -1471,7 +1486,7 @@ void cli_show_isis_mt_ipv6_multicast(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void cli_show_isis_mt_ipv6_mgmt(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv6_mgmt(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	vty_out(vty, " topology ipv6-mgmt");
@@ -1480,7 +1495,7 @@ void cli_show_isis_mt_ipv6_mgmt(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void cli_show_isis_mt_ipv6_dstsrc(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv6_dstsrc(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults)
 {
 	vty_out(vty, " topology ipv6-dstsrc");
@@ -1517,7 +1532,7 @@ DEFPY_YANG (no_isis_sr_enable,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_sr_enabled(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_sr_enabled(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -1585,7 +1600,7 @@ DEFPY_YANG(no_isis_sr_global_block_label_range,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_label_blocks(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_label_blocks(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	vty_out(vty, " segment-routing global-block %s %s",
@@ -1671,7 +1686,7 @@ DEFPY_YANG (no_isis_sr_node_msd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_node_msd(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_node_msd(struct vty *vty, const struct lyd_node *dnode,
 			    bool show_defaults)
 {
 	vty_out(vty, " segment-routing node-msd %s\n",
@@ -1748,7 +1763,7 @@ DEFPY_YANG (no_isis_sr_prefix_sid,
 		prefix_str);
 }
 
-void cli_show_isis_prefix_sid(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_prefix_sid(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	const char *prefix;
@@ -1825,7 +1840,7 @@ DEFPY_YANG (isis_frr_lfa_priority_limit,
 }
 
 void cli_show_isis_frr_lfa_priority_limit(struct vty *vty,
-					  struct lyd_node *dnode,
+					  const struct lyd_node *dnode,
 					  bool show_defaults)
 {
 	vty_out(vty, " fast-reroute priority-limit %s %s\n",
@@ -1890,7 +1905,8 @@ DEFPY_YANG (isis_frr_lfa_tiebreaker,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_frr_lfa_tiebreaker(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_frr_lfa_tiebreaker(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults)
 {
 	vty_out(vty, " fast-reroute lfa tiebreaker %s index %s %s\n",
@@ -1938,7 +1954,8 @@ DEFPY_YANG (isis_frr_lfa_load_sharing,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_frr_lfa_load_sharing(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_frr_lfa_load_sharing(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -1996,7 +2013,8 @@ DEFPY_YANG (no_isis_frr_remote_lfa_plist,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_frr_remote_lfa_plist(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_frr_remote_lfa_plist(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults)
 {
 	vty_out(vty, " fast-reroute remote-lfa prefix-list %s %s\n",
@@ -2018,7 +2036,7 @@ DEFPY_YANG(isis_passive, isis_passive_cmd, "[no] isis passive",
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_passive(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_passive(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -2061,7 +2079,7 @@ DEFPY_YANG(no_isis_passwd, no_isis_passwd_cmd, "no isis password [<md5|clear> WO
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_password(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_password(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults)
 {
 	vty_out(vty, " isis password %s %s\n",
@@ -2109,7 +2127,7 @@ DEFPY_YANG(no_isis_metric, no_isis_metric_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_metric(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_metric(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults)
 {
 	const char *l1 = yang_dnode_get_string(dnode, "./level-1");
@@ -2167,7 +2185,8 @@ DEFPY_YANG(no_isis_hello_interval, no_isis_hello_interval_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_hello_interval(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_hello_interval(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults)
 {
 	const char *l1 = yang_dnode_get_string(dnode, "./level-1");
@@ -2225,7 +2244,7 @@ DEFPY_YANG(no_isis_hello_multiplier, no_isis_hello_multiplier_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_hello_multi(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_hello_multi(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults)
 {
 	const char *l1 = yang_dnode_get_string(dnode, "./level-1");
@@ -2255,7 +2274,8 @@ DEFPY_YANG(isis_threeway_adj, isis_threeway_adj_cmd, "[no] isis three-way-handsh
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_threeway_shake(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_threeway_shake(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults)
 {
 	if (yang_dnode_get_bool(dnode, NULL))
@@ -2278,7 +2298,8 @@ DEFPY_YANG(isis_hello_padding, isis_hello_padding_cmd, "[no] isis hello padding"
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_hello_padding(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_hello_padding(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -2331,7 +2352,8 @@ DEFPY_YANG(no_csnp_interval, no_csnp_interval_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_csnp_interval(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_csnp_interval(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
 	const char *l1 = yang_dnode_get_string(dnode, "./level-1");
@@ -2389,7 +2411,8 @@ DEFPY_YANG(no_psnp_interval, no_psnp_interval_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_psnp_interval(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_psnp_interval(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
 	const char *l1 = yang_dnode_get_string(dnode, "./level-1");
@@ -2432,7 +2455,8 @@ DEFPY_YANG(circuit_topology, circuit_topology_cmd,
 			vty, "./frr-isisd:isis/multi-topology/%s", topology);
 }
 
-void cli_show_ip_isis_mt_ipv4_unicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv4_unicast(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -2440,7 +2464,8 @@ void cli_show_ip_isis_mt_ipv4_unicast(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, " isis topology ipv4-unicast\n");
 }
 
-void cli_show_ip_isis_mt_ipv4_multicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv4_multicast(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -2448,7 +2473,8 @@ void cli_show_ip_isis_mt_ipv4_multicast(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, " isis topology ipv4-multicast\n");
 }
 
-void cli_show_ip_isis_mt_ipv4_mgmt(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv4_mgmt(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -2456,7 +2482,8 @@ void cli_show_ip_isis_mt_ipv4_mgmt(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, " isis topology ipv4-mgmt\n");
 }
 
-void cli_show_ip_isis_mt_ipv6_unicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv6_unicast(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -2464,7 +2491,8 @@ void cli_show_ip_isis_mt_ipv6_unicast(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, " isis topology ipv6-unicast\n");
 }
 
-void cli_show_ip_isis_mt_ipv6_multicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv6_multicast(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -2472,7 +2500,8 @@ void cli_show_ip_isis_mt_ipv6_multicast(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, " isis topology ipv6-multicast\n");
 }
 
-void cli_show_ip_isis_mt_ipv6_mgmt(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv6_mgmt(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -2480,7 +2509,8 @@ void cli_show_ip_isis_mt_ipv6_mgmt(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, " isis topology ipv6-mgmt\n");
 }
 
-void cli_show_ip_isis_mt_ipv6_dstsrc(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv6_dstsrc(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -2516,7 +2546,7 @@ DEFPY_YANG(no_isis_circuit_type, no_isis_circuit_type_cmd,
       "Level-2 only adjacencies are formed\n")
 {
 	char inst_xpath[XPATH_MAXLEN];
-	struct lyd_node *if_dnode, *inst_dnode;
+	const struct lyd_node *if_dnode, *inst_dnode;
 	const char *vrf_name;
 	const char *tag;
 	const char *circ_type = NULL;
@@ -2554,7 +2584,7 @@ DEFPY_YANG(no_isis_circuit_type, no_isis_circuit_type_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_circ_type(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_circ_type(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	int level = yang_dnode_get_enum(dnode, NULL);
@@ -2588,7 +2618,8 @@ DEFPY_YANG(isis_network, isis_network_cmd, "[no] isis network point-to-point",
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_network_type(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_network_type(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
 	if (yang_dnode_get_enum(dnode, NULL) != CIRCUIT_T_P2P)
@@ -2637,7 +2668,7 @@ DEFPY_YANG(no_isis_priority, no_isis_priority_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ip_isis_priority(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_priority(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults)
 {
 	const char *l1 = yang_dnode_get_string(dnode, "./level-1");
@@ -2654,7 +2685,7 @@ void cli_show_ip_isis_priority(struct vty *vty, struct lyd_node *dnode,
 /*
  * XPath: /frr-interface:lib/interface/frr-isisd:isis/fast-reroute
  */
-void cli_show_ip_isis_frr(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_frr(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults)
 {
 	bool l1_enabled, l2_enabled;
@@ -2832,7 +2863,8 @@ DEFPY(isis_lfa_exclude_interface, isis_lfa_exclude_interface_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_frr_lfa_exclude_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_frr_lfa_exclude_interface(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults)
 {
 	vty_out(vty, " isis fast-reroute lfa %s exclude interface %s\n",
@@ -2930,7 +2962,8 @@ DEFPY(isis_remote_lfa_max_metric, isis_remote_lfa_max_metric_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_frr_remote_lfa_max_metric(struct vty *vty, struct lyd_node *dnode,
+void cli_show_frr_remote_lfa_max_metric(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults)
 {
 	vty_out(vty, " isis fast-reroute remote-lfa maximum-metric %s %s\n",
@@ -3028,7 +3061,7 @@ DEFPY_YANG(log_adj_changes, log_adj_changes_cmd, "[no] log-adjacency-changes",
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_log_adjacency(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_log_adjacency(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -3055,7 +3088,7 @@ DEFPY(no_isis_mpls_ldp_sync, no_isis_mpls_ldp_sync_cmd, "no mpls ldp-sync",
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_isis_mpls_ldp_sync(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mpls_ldp_sync(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults)
 {
 	vty_out(vty, " mpls ldp-sync\n");
@@ -3084,7 +3117,7 @@ DEFPY(no_isis_mpls_ldp_sync_holddown, no_isis_mpls_ldp_sync_holddown_cmd,
 }
 
 void cli_show_isis_mpls_ldp_sync_holddown(struct vty *vty,
-					  struct lyd_node *dnode,
+					  const struct lyd_node *dnode,
 					  bool show_defaults)
 {
 	vty_out(vty, " mpls ldp-sync holddown %s\n",
@@ -3114,7 +3147,8 @@ DEFPY(isis_mpls_if_ldp_sync, isis_mpls_if_ldp_sync_cmd,
 }
 
 
-void cli_show_isis_mpls_if_ldp_sync(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mpls_if_ldp_sync(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -3165,7 +3199,7 @@ DEFPY(no_isis_mpls_if_ldp_sync_holddown, no_isis_mpls_if_ldp_sync_holddown_cmd,
 }
 
 void cli_show_isis_mpls_if_ldp_sync_holddown(struct vty *vty,
-					     struct lyd_node *dnode,
+					     const struct lyd_node *dnode,
 					     bool show_defaults)
 {
 	vty_out(vty, " isis mpls ldp-sync holddown %s\n",

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -413,141 +413,174 @@ void isis_instance_segment_routing_prefix_sid_map_prefix_sid_apply_finish(
 	struct nb_cb_apply_finish_args *args);
 
 /* Optional 'cli_show' callbacks. */
-void cli_show_router_isis(struct vty *vty, struct lyd_node *dnode,
+void cli_show_router_isis(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults);
-void cli_show_router_isis_end(struct vty *vty, struct lyd_node *dnode);
-void cli_show_ip_isis_ipv4(struct vty *vty, struct lyd_node *dnode,
+void cli_show_router_isis_end(struct vty *vty, const struct lyd_node *dnode);
+void cli_show_ip_isis_ipv4(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
-void cli_show_ip_isis_ipv6(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_ipv6(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
-void cli_show_ip_isis_bfd_monitoring(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_bfd_monitoring(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-void cli_show_isis_area_address(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_area_address(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
-void cli_show_isis_is_type(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_is_type(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
-void cli_show_isis_dynamic_hostname(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_dynamic_hostname(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-void cli_show_isis_attached_send(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_attached_send(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
-void cli_show_isis_attached_receive(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_attached_receive(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-void cli_show_isis_overload(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_overload(struct vty *vty, const struct lyd_node *dnode,
 			    bool show_defaults);
-void cli_show_isis_metric_style(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_metric_style(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
-void cli_show_isis_area_pwd(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_area_pwd(struct vty *vty, const struct lyd_node *dnode,
 			    bool show_defaults);
-void cli_show_isis_domain_pwd(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_domain_pwd(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults);
-void cli_show_isis_lsp_timers(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_lsp_timers(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults);
-void cli_show_isis_lsp_mtu(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_lsp_mtu(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
-void cli_show_isis_spf_min_interval(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_spf_min_interval(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-void cli_show_isis_spf_ietf_backoff(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_spf_ietf_backoff(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-void cli_show_isis_spf_prefix_priority(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_spf_prefix_priority(struct vty *vty,
+				       const struct lyd_node *dnode,
 				       bool show_defaults);
-void cli_show_isis_purge_origin(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_purge_origin(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
-void cli_show_isis_mpls_te(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mpls_te(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
-void cli_show_isis_mpls_te_router_addr(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mpls_te_router_addr(struct vty *vty,
+				       const struct lyd_node *dnode,
 				       bool show_defaults);
-void cli_show_isis_def_origin_ipv4(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_def_origin_ipv4(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-void cli_show_isis_def_origin_ipv6(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_def_origin_ipv6(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-void cli_show_isis_redistribute_ipv4(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_redistribute_ipv4(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-void cli_show_isis_redistribute_ipv6(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_redistribute_ipv6(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-void cli_show_isis_mt_ipv4_multicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv4_multicast(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-void cli_show_isis_mt_ipv4_mgmt(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv4_mgmt(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
-void cli_show_isis_mt_ipv6_unicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv6_unicast(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-void cli_show_isis_mt_ipv6_multicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv6_multicast(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-void cli_show_isis_mt_ipv6_mgmt(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv6_mgmt(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
-void cli_show_isis_mt_ipv6_dstsrc(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mt_ipv6_dstsrc(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
-void cli_show_isis_sr_enabled(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_sr_enabled(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults);
-void cli_show_isis_label_blocks(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_label_blocks(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
-void cli_show_isis_node_msd(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_node_msd(struct vty *vty, const struct lyd_node *dnode,
 			    bool show_defaults);
-void cli_show_isis_prefix_sid(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_prefix_sid(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults);
 void cli_show_isis_frr_lfa_priority_limit(struct vty *vty,
-					  struct lyd_node *dnode,
+					  const struct lyd_node *dnode,
 					  bool show_defaults);
-void cli_show_isis_frr_lfa_tiebreaker(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_frr_lfa_tiebreaker(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults);
-void cli_show_isis_frr_lfa_load_sharing(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_frr_lfa_load_sharing(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults);
-void cli_show_isis_frr_remote_lfa_plist(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_frr_remote_lfa_plist(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults);
-void cli_show_ip_isis_passive(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_passive(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults);
-void cli_show_ip_isis_password(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_password(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults);
-void cli_show_ip_isis_metric(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_metric(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults);
-void cli_show_ip_isis_hello_interval(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_hello_interval(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-void cli_show_ip_isis_hello_multi(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_hello_multi(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
-void cli_show_ip_isis_threeway_shake(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_threeway_shake(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-void cli_show_ip_isis_hello_padding(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_hello_padding(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-void cli_show_ip_isis_csnp_interval(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_csnp_interval(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-void cli_show_ip_isis_psnp_interval(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_psnp_interval(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-void cli_show_ip_isis_mt_ipv4_unicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv4_unicast(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults);
-void cli_show_ip_isis_mt_ipv4_multicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv4_multicast(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults);
-void cli_show_ip_isis_mt_ipv4_mgmt(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv4_mgmt(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-void cli_show_ip_isis_mt_ipv6_unicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv6_unicast(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults);
-void cli_show_ip_isis_mt_ipv6_multicast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv6_multicast(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults);
-void cli_show_ip_isis_mt_ipv6_mgmt(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv6_mgmt(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-void cli_show_ip_isis_mt_ipv6_dstsrc(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_mt_ipv6_dstsrc(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-void cli_show_ip_isis_frr(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_frr(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults);
-void cli_show_frr_lfa_exclude_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_frr_lfa_exclude_interface(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults);
-void cli_show_frr_remote_lfa_max_metric(struct vty *vty, struct lyd_node *dnode,
+void cli_show_frr_remote_lfa_max_metric(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults);
-void cli_show_ip_isis_circ_type(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_circ_type(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
-void cli_show_ip_isis_network_type(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_network_type(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-void cli_show_ip_isis_priority(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_isis_priority(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults);
-void cli_show_isis_log_adjacency(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_log_adjacency(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
-void cli_show_isis_mpls_ldp_sync(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mpls_ldp_sync(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
 void cli_show_isis_mpls_ldp_sync_holddown(struct vty *vty,
-					  struct lyd_node *dnode,
+					  const struct lyd_node *dnode,
 					  bool show_defaults);
-void cli_show_isis_mpls_if_ldp_sync(struct vty *vty, struct lyd_node *dnode,
+void cli_show_isis_mpls_if_ldp_sync(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
 void cli_show_isis_mpls_if_ldp_sync_holddown(struct vty *vty,
-					     struct lyd_node *dnode,
+					     const struct lyd_node *dnode,
 					     bool show_defaults);
 
 /* Notifications. */

--- a/lib/filter.h
+++ b/lib/filter.h
@@ -234,15 +234,19 @@ bool plist_is_dup(const struct lyd_node *dnode, struct plist_dup_args *pda);
 struct lyd_node;
 struct vty;
 
-extern int access_list_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2);
-extern void access_list_show(struct vty *vty, struct lyd_node *dnode,
+extern int access_list_cmp(const struct lyd_node *dnode1,
+			   const struct lyd_node *dnode2);
+extern void access_list_show(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults);
-extern void access_list_remark_show(struct vty *vty, struct lyd_node *dnode,
+extern void access_list_remark_show(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-extern int prefix_list_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2);
-extern void prefix_list_show(struct vty *vty, struct lyd_node *dnode,
+extern int prefix_list_cmp(const struct lyd_node *dnode1,
+			   const struct lyd_node *dnode2);
+extern void prefix_list_show(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults);
-extern void prefix_list_remark_show(struct vty *vty, struct lyd_node *dnode,
+extern void prefix_list_remark_show(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
 
 void filter_cli_init(void);

--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -1015,7 +1015,8 @@ ALIAS(
 	ACCESS_LIST_REMARK_STR
 	ACCESS_LIST_REMARK_LINE_STR)
 
-int access_list_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
+int access_list_cmp(const struct lyd_node *dnode1,
+		    const struct lyd_node *dnode2)
 {
 	uint32_t seq1 = yang_dnode_get_uint32(dnode1, "./sequence");
 	uint32_t seq2 = yang_dnode_get_uint32(dnode2, "./sequence");
@@ -1023,7 +1024,7 @@ int access_list_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
 	return seq1 - seq2;
 }
 
-void access_list_show(struct vty *vty, struct lyd_node *dnode,
+void access_list_show(struct vty *vty, const struct lyd_node *dnode,
 		      bool show_defaults)
 {
 	int type = yang_dnode_get_enum(dnode, "../type");
@@ -1137,7 +1138,7 @@ void access_list_show(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void access_list_remark_show(struct vty *vty, struct lyd_node *dnode,
+void access_list_remark_show(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults)
 {
 	int type = yang_dnode_get_enum(dnode, "../type");
@@ -1658,7 +1659,8 @@ ALIAS(
 	ACCESS_LIST_REMARK_STR
 	ACCESS_LIST_REMARK_LINE_STR)
 
-int prefix_list_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
+int prefix_list_cmp(const struct lyd_node *dnode1,
+		    const struct lyd_node *dnode2)
 {
 	uint32_t seq1 = yang_dnode_get_uint32(dnode1, "./sequence");
 	uint32_t seq2 = yang_dnode_get_uint32(dnode2, "./sequence");
@@ -1666,7 +1668,7 @@ int prefix_list_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
 	return seq1 - seq2;
 }
 
-void prefix_list_show(struct vty *vty, struct lyd_node *dnode,
+void prefix_list_show(struct vty *vty, const struct lyd_node *dnode,
 		      bool show_defaults)
 {
 	int type = yang_dnode_get_enum(dnode, "../type");
@@ -1725,7 +1727,7 @@ void prefix_list_show(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-void prefix_list_remark_show(struct vty *vty, struct lyd_node *dnode,
+void prefix_list_remark_show(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults)
 {
 	int type = yang_dnode_get_enum(dnode, "../type");

--- a/lib/if.c
+++ b/lib/if.c
@@ -1277,8 +1277,8 @@ DEFPY_YANG (no_interface,
 		ifname, vrf_name);
 }
 
-static void cli_show_interface(struct vty *vty, struct lyd_node *dnode,
-			bool show_defaults)
+static void cli_show_interface(struct vty *vty, const struct lyd_node *dnode,
+			       bool show_defaults)
 {
 	const char *vrf;
 
@@ -1291,7 +1291,8 @@ static void cli_show_interface(struct vty *vty, struct lyd_node *dnode,
 	vty_out(vty, "\n");
 }
 
-static void cli_show_interface_end(struct vty *vty, struct lyd_node *dnode)
+static void cli_show_interface_end(struct vty *vty,
+				   const struct lyd_node *dnode)
 {
 	vty_out(vty, "exit\n");
 }
@@ -1327,8 +1328,9 @@ DEFPY_YANG  (no_interface_desc,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-static void cli_show_interface_desc(struct vty *vty, struct lyd_node *dnode,
-			     bool show_defaults)
+static void cli_show_interface_desc(struct vty *vty,
+				    const struct lyd_node *dnode,
+				    bool show_defaults)
 {
 	vty_out(vty, " description %s\n", yang_dnode_get_string(dnode, NULL));
 }

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -488,7 +488,8 @@ struct nb_callbacks {
 	 *    >0 when the CLI command for the dnode2 should be printed first
 	 *     0 when there is no difference
 	 */
-	int (*cli_cmp)(struct lyd_node *dnode1, struct lyd_node *dnode2);
+	int (*cli_cmp)(const struct lyd_node *dnode1,
+		       const struct lyd_node *dnode2);
 
 	/*
 	 * Optional callback to show the CLI command associated to the given
@@ -510,7 +511,7 @@ struct nb_callbacks {
 	 *    nodes, in which case it might be desirable to hide one or more
 	 *    parts of the command when this parameter is set to false.
 	 */
-	void (*cli_show)(struct vty *vty, struct lyd_node *dnode,
+	void (*cli_show)(struct vty *vty, const struct lyd_node *dnode,
 			 bool show_defaults);
 
 	/*
@@ -523,7 +524,7 @@ struct nb_callbacks {
 	 *    libyang data node that should be shown in the form of a CLI
 	 *    command.
 	 */
-	void (*cli_show_end)(struct vty *vty, struct lyd_node *dnode);
+	void (*cli_show_end)(struct vty *vty, const struct lyd_node *dnode);
 };
 
 struct nb_dependency_callbacks {

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -550,14 +550,16 @@ void nb_cli_show_config_prepare(struct nb_config *config, bool with_defaults)
 				       LYD_VALIDATE_NO_STATE, NULL);
 }
 
-static int lyd_node_cmp(struct lyd_node **dnode1, struct lyd_node **dnode2)
+static int lyd_node_cmp(const struct lyd_node **dnode1,
+			const struct lyd_node **dnode2)
 {
 	struct nb_node *nb_node = (*dnode1)->schema->priv;
 
 	return nb_node->cbs.cli_cmp(*dnode1, *dnode2);
 }
 
-static void show_dnode_children_cmds(struct vty *vty, struct lyd_node *root,
+static void show_dnode_children_cmds(struct vty *vty,
+				     const struct lyd_node *root,
 				     bool with_defaults)
 {
 	struct nb_node *nb_node, *sort_node = NULL;
@@ -616,7 +618,7 @@ static void show_dnode_children_cmds(struct vty *vty, struct lyd_node *root,
 	}
 }
 
-void nb_cli_show_dnode_cmds(struct vty *vty, struct lyd_node *root,
+void nb_cli_show_dnode_cmds(struct vty *vty, const struct lyd_node *root,
 			    bool with_defaults)
 {
 	struct nb_node *nb_node;

--- a/lib/northbound_cli.h
+++ b/lib/northbound_cli.h
@@ -127,7 +127,8 @@ extern int nb_cli_rpc(struct vty *vty, const char *xpath, struct list *input,
  * show_defaults
  *    Specify whether to display default configuration values or not.
  */
-extern void nb_cli_show_dnode_cmds(struct vty *vty, struct lyd_node *dnode,
+extern void nb_cli_show_dnode_cmds(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
 
 /*

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -908,25 +908,28 @@ void routemap_hook_context_free(struct routemap_hook_context *rhc);
 extern const struct frr_yang_module_info frr_route_map_info;
 
 /* routemap_cli.c */
-extern int route_map_instance_cmp(struct lyd_node *dnode1,
-				  struct lyd_node *dnode2);
-extern void route_map_instance_show(struct vty *vty, struct lyd_node *dnode,
+extern int route_map_instance_cmp(const struct lyd_node *dnode1,
+				  const struct lyd_node *dnode2);
+extern void route_map_instance_show(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
 extern void route_map_instance_show_end(struct vty *vty,
-					struct lyd_node *dnode);
-extern void route_map_condition_show(struct vty *vty, struct lyd_node *dnode,
+					const struct lyd_node *dnode);
+extern void route_map_condition_show(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-extern void route_map_action_show(struct vty *vty, struct lyd_node *dnode,
+extern void route_map_action_show(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
-extern void route_map_exit_policy_show(struct vty *vty, struct lyd_node *dnode,
+extern void route_map_exit_policy_show(struct vty *vty,
+				       const struct lyd_node *dnode,
 				       bool show_defaults);
-extern void route_map_call_show(struct vty *vty, struct lyd_node *dnode,
+extern void route_map_call_show(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
 extern void route_map_description_show(struct vty *vty,
-				       struct lyd_node *dnode,
+				       const struct lyd_node *dnode,
 				       bool show_defaults);
 extern void route_map_optimization_disabled_show(struct vty *vty,
-						 struct lyd_node *dnode,
+						 const struct lyd_node *dnode,
 						 bool show_defaults);
 extern void route_map_cli_init(void);
 

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -103,7 +103,8 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-int route_map_instance_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
+int route_map_instance_cmp(const struct lyd_node *dnode1,
+			   const struct lyd_node *dnode2)
 {
 	uint16_t seq1 = yang_dnode_get_uint16(dnode1, "./sequence");
 	uint16_t seq2 = yang_dnode_get_uint16(dnode2, "./sequence");
@@ -111,7 +112,7 @@ int route_map_instance_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
 	return seq1 - seq2;
 }
 
-void route_map_instance_show(struct vty *vty, struct lyd_node *dnode,
+void route_map_instance_show(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults)
 {
 	const char *name = yang_dnode_get_string(dnode, "../name");
@@ -122,7 +123,7 @@ void route_map_instance_show(struct vty *vty, struct lyd_node *dnode,
 
 }
 
-void route_map_instance_show_end(struct vty *vty, struct lyd_node *dnode)
+void route_map_instance_show_end(struct vty *vty, const struct lyd_node *dnode)
 {
 	vty_out(vty, "exit\n");
 	vty_out(vty, "!\n");
@@ -546,11 +547,11 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void route_map_condition_show(struct vty *vty, struct lyd_node *dnode,
+void route_map_condition_show(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	const char *condition = yang_dnode_get_string(dnode, "./condition");
-	struct lyd_node *ln;
+	const struct lyd_node *ln;
 	const char *acl;
 
 	if (IS_MATCH_INTERFACE(condition)) {
@@ -1021,11 +1022,11 @@ DEFUN_YANG (no_set_srte_color,
 }
 
 
-void route_map_action_show(struct vty *vty, struct lyd_node *dnode,
+void route_map_action_show(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	const char *action = yang_dnode_get_string(dnode, "./action");
-	struct lyd_node *ln;
+	const struct lyd_node *ln;
 	const char *acl;
 
 	if (IS_SET_IPv4_NH(action)) {
@@ -1363,7 +1364,7 @@ ALIAS_YANG(
 	"Continue on a different entry within the route-map\n"
 	"Route-map entry sequence number\n")
 
-void route_map_exit_policy_show(struct vty *vty, struct lyd_node *dnode,
+void route_map_exit_policy_show(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	int exit_policy = yang_dnode_get_enum(dnode, NULL);
@@ -1405,7 +1406,7 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void route_map_call_show(struct vty *vty, struct lyd_node *dnode,
+void route_map_call_show(struct vty *vty, const struct lyd_node *dnode,
 			 bool show_defaults)
 {
 	vty_out(vty, " call %s\n", yang_dnode_get_string(dnode, NULL));
@@ -1439,7 +1440,7 @@ DEFUN_YANG (no_rmap_description,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void route_map_description_show(struct vty *vty, struct lyd_node *dnode,
+void route_map_description_show(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	vty_out(vty, " description %s\n", yang_dnode_get_string(dnode, NULL));
@@ -1468,7 +1469,7 @@ DEFPY_YANG(
 }
 
 void route_map_optimization_disabled_show(struct vty *vty,
-					  struct lyd_node *dnode,
+					  const struct lyd_node *dnode,
 					  bool show_defaults)
 {
 	const char *name = yang_dnode_get_string(dnode, "../name");
@@ -1515,7 +1516,7 @@ DEFPY_HIDDEN(
 
 static int route_map_config_write(struct vty *vty)
 {
-	struct lyd_node *dnode;
+	const struct lyd_node *dnode;
 	int written = 0;
 
 	dnode = yang_dnode_get(running_config->dnode,

--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -298,14 +298,15 @@ DEFPY(srte_no_segment_list,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_srte_segment_list(struct vty *vty, struct lyd_node *dnode,
+void cli_show_srte_segment_list(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	vty_out(vty, "  segment-list %s\n",
 		yang_dnode_get_string(dnode, "./name"));
 }
 
-void cli_show_srte_segment_list_end(struct vty *vty, struct lyd_node *dnode)
+void cli_show_srte_segment_list_end(struct vty *vty,
+				    const struct lyd_node *dnode)
 {
 	vty_out(vty, "  exit\n");
 }
@@ -557,7 +558,7 @@ DEFPY(srte_segment_list_no_segment,
 }
 
 void cli_show_srte_segment_list_segment(struct vty *vty,
-					struct lyd_node *dnode,
+					const struct lyd_node *dnode,
 					bool show_defaults)
 {
 	vty_out(vty, "   index %s", yang_dnode_get_string(dnode, "./index"));
@@ -668,7 +669,7 @@ DEFPY(srte_no_policy,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_srte_policy(struct vty *vty, struct lyd_node *dnode,
+void cli_show_srte_policy(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults)
 {
 	vty_out(vty, "  policy color %s endpoint %s\n",
@@ -676,7 +677,7 @@ void cli_show_srte_policy(struct vty *vty, struct lyd_node *dnode,
 		yang_dnode_get_string(dnode, "./endpoint"));
 }
 
-void cli_show_srte_policy_end(struct vty *vty, struct lyd_node *dnode)
+void cli_show_srte_policy_end(struct vty *vty, const struct lyd_node *dnode)
 {
 	vty_out(vty, "  exit\n");
 }
@@ -708,8 +709,8 @@ DEFPY(srte_policy_no_name,
 }
 
 
-void cli_show_srte_policy_name(struct vty *vty, struct lyd_node *dnode,
-				     bool show_defaults)
+void cli_show_srte_policy_name(struct vty *vty, const struct lyd_node *dnode,
+			       bool show_defaults)
 {
 	vty_out(vty, "   name %s\n", yang_dnode_get_string(dnode, NULL));
 }
@@ -741,7 +742,7 @@ DEFPY(srte_policy_no_binding_sid,
 }
 
 void cli_show_srte_policy_binding_sid(struct vty *vty,
-				      struct lyd_node *dnode,
+				      const struct lyd_node *dnode,
 				      bool show_defaults)
 {
 	vty_out(vty, "   binding-sid %s\n", yang_dnode_get_string(dnode, NULL));
@@ -1187,7 +1188,7 @@ static int config_write_metric_cb(const struct lyd_node *dnode, void *arg)
 }
 
 void cli_show_srte_policy_candidate_path(struct vty *vty,
-					 struct lyd_node *dnode,
+					 const struct lyd_node *dnode,
 					 bool show_defaults)
 {
 	float bandwidth;
@@ -1253,7 +1254,7 @@ void cli_show_srte_policy_candidate_path(struct vty *vty,
 }
 
 void cli_show_srte_policy_candidate_path_end(struct vty *vty,
-					     struct lyd_node *dnode)
+					     const struct lyd_node *dnode)
 {
 	const char *type = yang_dnode_get_string(dnode, "./type");
 
@@ -1265,7 +1266,7 @@ static int config_write_dnode(const struct lyd_node *dnode, void *arg)
 {
 	struct vty *vty = arg;
 
-	nb_cli_show_dnode_cmds(vty, (struct lyd_node *)dnode, false);
+	nb_cli_show_dnode_cmds(vty, dnode, false);
 
 	return YANG_ITER_CONTINUE;
 }

--- a/pathd/path_nb.h
+++ b/pathd/path_nb.h
@@ -110,23 +110,26 @@ int pathd_srte_policy_candidate_path_segment_list_name_destroy(
 void pathd_apply_finish(struct nb_cb_apply_finish_args *args);
 
 /* Optional 'cli_show' callbacks. */
-void cli_show_srte_segment_list(struct vty *vty, struct lyd_node *dnode,
+void cli_show_srte_segment_list(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
-void cli_show_srte_segment_list_end(struct vty *vty, struct lyd_node *dnode);
-void cli_show_srte_segment_list_segment(struct vty *vty, struct lyd_node *dnode,
+void cli_show_srte_segment_list_end(struct vty *vty,
+				    const struct lyd_node *dnode);
+void cli_show_srte_segment_list_segment(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults);
-void cli_show_srte_policy(struct vty *vty, struct lyd_node *dnode,
+void cli_show_srte_policy(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults);
-void cli_show_srte_policy_end(struct vty *vty, struct lyd_node *dnode);
-void cli_show_srte_policy_name(struct vty *vty, struct lyd_node *dnode,
+void cli_show_srte_policy_end(struct vty *vty, const struct lyd_node *dnode);
+void cli_show_srte_policy_name(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults);
-void cli_show_srte_policy_binding_sid(struct vty *vty, struct lyd_node *dnode,
+void cli_show_srte_policy_binding_sid(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults);
 void cli_show_srte_policy_candidate_path(struct vty *vty,
-					 struct lyd_node *dnode,
+					 const struct lyd_node *dnode,
 					 bool show_defaults);
 void cli_show_srte_policy_candidate_path_end(struct vty *vty,
-					     struct lyd_node *dnode);
+					     const struct lyd_node *dnode);
 
 /* Utility functions */
 typedef void (*of_pref_cp_t)(enum objfun_type type, void *arg);

--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -83,7 +83,7 @@ DEFPY_YANG (no_router_rip,
 	return nb_cli_apply_changes_clear_pending(vty, NULL);
 }
 
-void cli_show_router_rip(struct vty *vty, struct lyd_node *dnode,
+void cli_show_router_rip(struct vty *vty, const struct lyd_node *dnode,
 			 bool show_defaults)
 {
 	const char *vrf_name;
@@ -112,7 +112,7 @@ DEFPY_YANG (rip_allow_ecmp,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_rip_allow_ecmp(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_allow_ecmp(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -138,7 +138,7 @@ DEFPY_YANG (rip_default_information_originate,
 }
 
 void cli_show_rip_default_information_originate(struct vty *vty,
-						struct lyd_node *dnode,
+						const struct lyd_node *dnode,
 						bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -174,7 +174,7 @@ DEFPY_YANG (no_rip_default_metric,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_rip_default_metric(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_default_metric(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults)
 {
 	vty_out(vty, " default-metric %s\n",
@@ -208,7 +208,7 @@ DEFPY_YANG (no_rip_distance,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_rip_distance(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_distance(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	if (yang_dnode_is_default(dnode, NULL))
@@ -243,7 +243,7 @@ DEFPY_YANG (rip_distance_source,
 				    prefix_str);
 }
 
-void cli_show_rip_distance_source(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_distance_source(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults)
 {
 	vty_out(vty, " distance %s %s",
@@ -271,7 +271,7 @@ DEFPY_YANG (rip_neighbor,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_rip_neighbor(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_neighbor(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	vty_out(vty, " neighbor %s\n", yang_dnode_get_string(dnode, NULL));
@@ -293,7 +293,7 @@ DEFPY_YANG (rip_network_prefix,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_rip_network_prefix(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_network_prefix(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults)
 {
 	vty_out(vty, " network %s\n", yang_dnode_get_string(dnode, NULL));
@@ -315,7 +315,8 @@ DEFPY_YANG (rip_network_if,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_rip_network_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_network_interface(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
 	vty_out(vty, " network %s\n", yang_dnode_get_string(dnode, NULL));
@@ -348,7 +349,7 @@ DEFPY_YANG (rip_offset_list,
 		ifname ? ifname : "*", direction);
 }
 
-void cli_show_rip_offset_list(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_offset_list(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults)
 {
 	const char *interface;
@@ -380,7 +381,7 @@ DEFPY_YANG (rip_passive_default,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_rip_passive_default(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_passive_default(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -417,14 +418,16 @@ DEFPY_YANG (rip_passive_interface,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_rip_passive_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_passive_interface(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
 	vty_out(vty, " passive-interface %s\n",
 		yang_dnode_get_string(dnode, NULL));
 }
 
-void cli_show_rip_non_passive_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_non_passive_interface(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults)
 {
 	vty_out(vty, " no passive-interface %s\n",
@@ -460,7 +463,7 @@ DEFPY_YANG (rip_redistribute,
 				    protocol);
 }
 
-void cli_show_rip_redistribute(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_redistribute(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults)
 {
 	vty_out(vty, " redistribute %s",
@@ -490,7 +493,7 @@ DEFPY_YANG (rip_route,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_rip_route(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_route(struct vty *vty, const struct lyd_node *dnode,
 			bool show_defaults)
 {
 	vty_out(vty, " route %s\n", yang_dnode_get_string(dnode, NULL));
@@ -535,7 +538,7 @@ DEFPY_YANG (no_rip_timers,
 	return nb_cli_apply_changes(vty, "./timers");
 }
 
-void cli_show_rip_timers(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_timers(struct vty *vty, const struct lyd_node *dnode,
 			 bool show_defaults)
 {
 	vty_out(vty, " timers basic %s %s %s\n",
@@ -573,7 +576,7 @@ DEFPY_YANG (no_rip_version,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_rip_version(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_version(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults)
 {
 	/*
@@ -619,7 +622,8 @@ DEFPY_YANG (ip_rip_split_horizon,
 	return nb_cli_apply_changes(vty, "./frr-ripd:rip");
 }
 
-void cli_show_ip_rip_split_horizon(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_rip_split_horizon(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
 	int value;
@@ -655,7 +659,7 @@ DEFPY_YANG (ip_rip_v2_broadcast,
 	return nb_cli_apply_changes(vty, "./frr-ripd:rip");
 }
 
-void cli_show_ip_rip_v2_broadcast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_rip_v2_broadcast(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -711,7 +715,8 @@ DEFPY_YANG (no_ip_rip_receive_version,
 	return nb_cli_apply_changes(vty, "./frr-ripd:rip");
 }
 
-void cli_show_ip_rip_receive_version(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_rip_receive_version(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults)
 {
 	switch (yang_dnode_get_enum(dnode, NULL)) {
@@ -780,7 +785,7 @@ DEFPY_YANG (no_ip_rip_send_version,
 	return nb_cli_apply_changes(vty, "./frr-ripd:rip");
 }
 
-void cli_show_ip_rip_send_version(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_rip_send_version(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults)
 {
 	switch (yang_dnode_get_enum(dnode, NULL)) {
@@ -860,7 +865,7 @@ DEFPY_YANG (no_ip_rip_authentication_mode,
 }
 
 void cli_show_ip_rip_authentication_scheme(struct vty *vty,
-					   struct lyd_node *dnode,
+					   const struct lyd_node *dnode,
 					   bool show_defaults)
 {
 	switch (yang_dnode_get_enum(dnode, "./mode")) {
@@ -933,7 +938,7 @@ DEFPY_YANG (no_ip_rip_authentication_string,
 }
 
 void cli_show_ip_rip_authentication_string(struct vty *vty,
-					   struct lyd_node *dnode,
+					   const struct lyd_node *dnode,
 					   bool show_defaults)
 {
 	vty_out(vty, " ip rip authentication string %s\n",
@@ -982,7 +987,7 @@ DEFPY_YANG (no_ip_rip_authentication_key_chain,
 }
 
 void cli_show_ip_rip_authentication_key_chain(struct vty *vty,
-					      struct lyd_node *dnode,
+					      const struct lyd_node *dnode,
 					      bool show_defaults)
 {
 	vty_out(vty, " ip rip authentication key-chain %s\n",

--- a/ripd/rip_nb.h
+++ b/ripd/rip_nb.h
@@ -128,57 +128,62 @@ void ripd_instance_redistribute_apply_finish(
 void ripd_instance_timers_apply_finish(struct nb_cb_apply_finish_args *args);
 
 /* Optional 'cli_show' callbacks. */
-void cli_show_router_rip(struct vty *vty, struct lyd_node *dnode,
+void cli_show_router_rip(struct vty *vty, const struct lyd_node *dnode,
 			 bool show_defaults);
-void cli_show_rip_allow_ecmp(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_allow_ecmp(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults);
 void cli_show_rip_default_information_originate(struct vty *vty,
-						struct lyd_node *dnode,
+						const struct lyd_node *dnode,
 						bool show_defaults);
-void cli_show_rip_default_metric(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_default_metric(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
-void cli_show_rip_distance(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_distance(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
-void cli_show_rip_distance_source(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_distance_source(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
-void cli_show_rip_neighbor(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_neighbor(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
-void cli_show_rip_network_prefix(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_network_prefix(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
-void cli_show_rip_network_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_network_interface(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-void cli_show_rip_offset_list(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_offset_list(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults);
-void cli_show_rip_passive_default(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_passive_default(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
-void cli_show_rip_passive_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_passive_interface(struct vty *vty,
+				    const struct lyd_node *dnode,
 				    bool show_defaults);
-void cli_show_rip_non_passive_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_non_passive_interface(struct vty *vty,
+					const struct lyd_node *dnode,
 					bool show_defaults);
-void cli_show_rip_redistribute(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_redistribute(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults);
-void cli_show_rip_route(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_route(struct vty *vty, const struct lyd_node *dnode,
 			bool show_defaults);
-void cli_show_rip_timers(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_timers(struct vty *vty, const struct lyd_node *dnode,
 			 bool show_defaults);
-void cli_show_rip_version(struct vty *vty, struct lyd_node *dnode,
+void cli_show_rip_version(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults);
-void cli_show_ip_rip_split_horizon(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_rip_split_horizon(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-void cli_show_ip_rip_v2_broadcast(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_rip_v2_broadcast(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
-void cli_show_ip_rip_receive_version(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_rip_receive_version(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-void cli_show_ip_rip_send_version(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip_rip_send_version(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
 void cli_show_ip_rip_authentication_scheme(struct vty *vty,
-					   struct lyd_node *dnode,
+					   const struct lyd_node *dnode,
 					   bool show_defaults);
 void cli_show_ip_rip_authentication_string(struct vty *vty,
-					   struct lyd_node *dnode,
+					   const struct lyd_node *dnode,
 					   bool show_defaults);
 void cli_show_ip_rip_authentication_key_chain(struct vty *vty,
-					      struct lyd_node *dnode,
+					      const struct lyd_node *dnode,
 					      bool show_defaults);
 
 /* Notifications. */

--- a/ripngd/ripng_cli.c
+++ b/ripngd/ripng_cli.c
@@ -83,8 +83,8 @@ DEFPY_YANG (no_router_ripng,
 	return nb_cli_apply_changes_clear_pending(vty, NULL);
 }
 
-void cli_show_router_ripng(struct vty *vty, struct lyd_node *dnode,
-			 bool show_defaults)
+void cli_show_router_ripng(struct vty *vty, const struct lyd_node *dnode,
+			   bool show_defaults)
 {
 	const char *vrf_name;
 
@@ -112,7 +112,7 @@ DEFPY_YANG (ripng_allow_ecmp,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ripng_allow_ecmp(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_allow_ecmp(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -138,7 +138,7 @@ DEFPY_YANG (ripng_default_information_originate,
 }
 
 void cli_show_ripng_default_information_originate(struct vty *vty,
-						  struct lyd_node *dnode,
+						  const struct lyd_node *dnode,
 						  bool show_defaults)
 {
 	if (!yang_dnode_get_bool(dnode, NULL))
@@ -174,7 +174,8 @@ DEFPY_YANG (no_ripng_default_metric,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ripng_default_metric(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_default_metric(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
 	vty_out(vty, " default-metric %s\n",
@@ -197,7 +198,8 @@ DEFPY_YANG (ripng_network_prefix,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ripng_network_prefix(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_network_prefix(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults)
 {
 	vty_out(vty, " network %s\n", yang_dnode_get_string(dnode, NULL));
@@ -219,7 +221,8 @@ DEFPY_YANG (ripng_network_if,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ripng_network_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_network_interface(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults)
 {
 	vty_out(vty, " network %s\n", yang_dnode_get_string(dnode, NULL));
@@ -252,7 +255,7 @@ DEFPY_YANG (ripng_offset_list,
 		ifname ? ifname : "*", direction);
 }
 
-void cli_show_ripng_offset_list(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_offset_list(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults)
 {
 	const char *interface;
@@ -284,7 +287,8 @@ DEFPY_YANG (ripng_passive_interface,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ripng_passive_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_passive_interface(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults)
 {
 	vty_out(vty, " passive-interface %s\n",
@@ -320,7 +324,7 @@ DEFPY_YANG (ripng_redistribute,
 				    protocol);
 }
 
-void cli_show_ripng_redistribute(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_redistribute(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults)
 {
 	vty_out(vty, " redistribute %s",
@@ -350,7 +354,7 @@ DEFPY_YANG (ripng_route,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ripng_route(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_route(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults)
 {
 	vty_out(vty, " route %s\n", yang_dnode_get_string(dnode, NULL));
@@ -373,7 +377,8 @@ DEFPY_YANG (ripng_aggregate_address,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-void cli_show_ripng_aggregate_address(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_aggregate_address(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults)
 {
 	vty_out(vty, " aggregate-address %s\n",
@@ -419,7 +424,7 @@ DEFPY_YANG (no_ripng_timers,
 	return nb_cli_apply_changes(vty, "./timers");
 }
 
-void cli_show_ripng_timers(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_timers(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults)
 {
 	vty_out(vty, " timers basic %s %s %s\n",
@@ -454,7 +459,8 @@ DEFPY_YANG (ipv6_ripng_split_horizon,
 	return nb_cli_apply_changes(vty, "./frr-ripngd:ripng");
 }
 
-void cli_show_ipv6_ripng_split_horizon(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ipv6_ripng_split_horizon(struct vty *vty,
+				       const struct lyd_node *dnode,
 				       bool show_defaults)
 {
 	int value;

--- a/ripngd/ripng_nb.h
+++ b/ripngd/ripng_nb.h
@@ -101,32 +101,38 @@ void ripngd_instance_redistribute_apply_finish(
 void ripngd_instance_timers_apply_finish(struct nb_cb_apply_finish_args *args);
 
 /* Optional 'cli_show' callbacks. */
-void cli_show_router_ripng(struct vty *vty, struct lyd_node *dnode,
+void cli_show_router_ripng(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
-void cli_show_ripng_allow_ecmp(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_allow_ecmp(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults);
 void cli_show_ripng_default_information_originate(struct vty *vty,
-						  struct lyd_node *dnode,
+						  const struct lyd_node *dnode,
 						  bool show_defaults);
-void cli_show_ripng_default_metric(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_default_metric(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-void cli_show_ripng_network_prefix(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_network_prefix(struct vty *vty,
+				   const struct lyd_node *dnode,
 				   bool show_defaults);
-void cli_show_ripng_network_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_network_interface(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults);
-void cli_show_ripng_offset_list(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_offset_list(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
-void cli_show_ripng_passive_interface(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_passive_interface(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults);
-void cli_show_ripng_redistribute(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_redistribute(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
-void cli_show_ripng_route(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_route(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults);
-void cli_show_ripng_aggregate_address(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_aggregate_address(struct vty *vty,
+				      const struct lyd_node *dnode,
 				      bool show_defaults);
-void cli_show_ripng_timers(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ripng_timers(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
-void cli_show_ipv6_ripng_split_horizon(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ipv6_ripng_split_horizon(struct vty *vty,
+				       const struct lyd_node *dnode,
 				       bool show_defaults);
 
 #endif /* _FRR_RIPNG_NB_H_ */

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -1002,7 +1002,7 @@ DEFPY_YANG(ipv6_route_vrf,
 				 table_str, false, color_str);
 }
 
-void static_cli_show(struct vty *vty, struct lyd_node *dnode,
+void static_cli_show(struct vty *vty, const struct lyd_node *dnode,
 		     bool show_defaults)
 {
 	const char *vrf;
@@ -1012,7 +1012,7 @@ void static_cli_show(struct vty *vty, struct lyd_node *dnode,
 		vty_out(vty, "vrf %s\n", vrf);
 }
 
-void static_cli_show_end(struct vty *vty, struct lyd_node *dnode)
+void static_cli_show_end(struct vty *vty, const struct lyd_node *dnode)
 {
 	const char *vrf;
 
@@ -1154,7 +1154,7 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 	vty_out(vty, "\n");
 }
 
-void static_nexthop_cli_show(struct vty *vty, struct lyd_node *dnode,
+void static_nexthop_cli_show(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults)
 {
 	const struct lyd_node *path = yang_dnode_get_parent(dnode, "path-list");
@@ -1164,7 +1164,7 @@ void static_nexthop_cli_show(struct vty *vty, struct lyd_node *dnode,
 	nexthop_cli_show(vty, route, NULL, path, dnode, show_defaults);
 }
 
-void static_src_nexthop_cli_show(struct vty *vty, struct lyd_node *dnode,
+void static_src_nexthop_cli_show(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults)
 {
 	const struct lyd_node *path = yang_dnode_get_parent(dnode, "path-list");
@@ -1174,7 +1174,8 @@ void static_src_nexthop_cli_show(struct vty *vty, struct lyd_node *dnode,
 	nexthop_cli_show(vty, route, src, path, dnode, show_defaults);
 }
 
-int static_nexthop_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
+int static_nexthop_cli_cmp(const struct lyd_node *dnode1,
+			   const struct lyd_node *dnode2)
 {
 	enum static_nh_type nh_type1, nh_type2;
 	struct prefix prefix1, prefix2;
@@ -1221,7 +1222,8 @@ int static_nexthop_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
 				yang_dnode_get_string(dnode2, "./vrf"));
 }
 
-int static_route_list_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
+int static_route_list_cli_cmp(const struct lyd_node *dnode1,
+			      const struct lyd_node *dnode2)
 {
 	const char *afi_safi1, *afi_safi2;
 	afi_t afi1, afi2;
@@ -1246,7 +1248,8 @@ int static_route_list_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
 	return prefix_cmp(&prefix1, &prefix2);
 }
 
-int static_src_list_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
+int static_src_list_cli_cmp(const struct lyd_node *dnode1,
+			    const struct lyd_node *dnode2)
 {
 	struct prefix prefix1, prefix2;
 
@@ -1256,7 +1259,8 @@ int static_src_list_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
 	return prefix_cmp(&prefix1, &prefix2);
 }
 
-int static_path_list_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2)
+int static_path_list_cli_cmp(const struct lyd_node *dnode1,
+			     const struct lyd_node *dnode2)
 {
 	uint32_t table_id1, table_id2;
 	uint8_t distance1, distance2;

--- a/staticd/static_vty.h
+++ b/staticd/static_vty.h
@@ -23,17 +23,21 @@
 extern "C" {
 #endif
 
-void static_cli_show(struct vty *vty, struct lyd_node *dnode,
+void static_cli_show(struct vty *vty, const struct lyd_node *dnode,
 		     bool show_defaults);
-void static_cli_show_end(struct vty *vty, struct lyd_node *dnode);
-void static_nexthop_cli_show(struct vty *vty, struct lyd_node *dnode,
+void static_cli_show_end(struct vty *vty, const struct lyd_node *dnode);
+void static_nexthop_cli_show(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults);
-void static_src_nexthop_cli_show(struct vty *vty, struct lyd_node *dnode,
+void static_src_nexthop_cli_show(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
-int static_nexthop_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2);
-int static_route_list_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2);
-int static_src_list_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2);
-int static_path_list_cli_cmp(struct lyd_node *dnode1, struct lyd_node *dnode2);
+int static_nexthop_cli_cmp(const struct lyd_node *dnode1,
+			   const struct lyd_node *dnode2);
+int static_route_list_cli_cmp(const struct lyd_node *dnode1,
+			      const struct lyd_node *dnode2);
+int static_src_list_cli_cmp(const struct lyd_node *dnode1,
+			    const struct lyd_node *dnode2);
+int static_path_list_cli_cmp(const struct lyd_node *dnode1,
+			     const struct lyd_node *dnode2);
 
 void static_vty_init(void);
 

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -75,7 +75,7 @@ DEFPY_YANG(vrrp_vrid,
 	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
 }
 
-void cli_show_vrrp(struct vty *vty, struct lyd_node *dnode, bool show_defaults)
+void cli_show_vrrp(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
 {
 	const char *vrid = yang_dnode_get_string(dnode, "./virtual-router-id");
 	const char *ver = yang_dnode_get_string(dnode, "./version");
@@ -103,7 +103,7 @@ DEFPY_YANG(vrrp_shutdown,
 	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
 }
 
-void cli_show_shutdown(struct vty *vty, struct lyd_node *dnode,
+void cli_show_shutdown(struct vty *vty, const struct lyd_node *dnode,
 		       bool show_defaults)
 {
 	const char *vrid = yang_dnode_get_string(dnode, "../virtual-router-id");
@@ -145,7 +145,7 @@ DEFPY_YANG(no_vrrp_priority,
 	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
 }
 
-void cli_show_priority(struct vty *vty, struct lyd_node *dnode,
+void cli_show_priority(struct vty *vty, const struct lyd_node *dnode,
 		       bool show_defaults)
 {
 	const char *vrid = yang_dnode_get_string(dnode, "../virtual-router-id");
@@ -191,7 +191,7 @@ DEFPY_YANG(no_vrrp_advertisement_interval,
 	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
 }
 
-void cli_show_advertisement_interval(struct vty *vty, struct lyd_node *dnode,
+void cli_show_advertisement_interval(struct vty *vty, const struct lyd_node *dnode,
 				     bool show_defaults)
 {
 	const char *vrid = yang_dnode_get_string(dnode, "../virtual-router-id");
@@ -220,7 +220,7 @@ DEFPY_YANG(vrrp_ip,
 	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
 }
 
-void cli_show_ip(struct vty *vty, struct lyd_node *dnode, bool show_defaults)
+void cli_show_ip(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
 {
 	const char *vrid =
 		yang_dnode_get_string(dnode, "../../virtual-router-id");
@@ -248,7 +248,7 @@ DEFPY_YANG(vrrp_ip6,
 	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
 }
 
-void cli_show_ipv6(struct vty *vty, struct lyd_node *dnode, bool show_defaults)
+void cli_show_ipv6(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
 {
 	const char *vrid =
 		yang_dnode_get_string(dnode, "../../virtual-router-id");
@@ -274,7 +274,7 @@ DEFPY_YANG(vrrp_preempt,
 	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
 }
 
-void cli_show_preempt(struct vty *vty, struct lyd_node *dnode,
+void cli_show_preempt(struct vty *vty, const struct lyd_node *dnode,
 		      bool show_defaults)
 {
 	const char *vrid = yang_dnode_get_string(dnode, "../virtual-router-id");
@@ -727,7 +727,7 @@ static int vrrp_config_write_interface(struct vty *vty)
 		struct interface *ifp;
 
 		FOR_ALL_INTERFACES (vrf, ifp) {
-			struct lyd_node *dnode;
+			const struct lyd_node *dnode;
 
 			dnode = yang_dnode_getf(
 				running_config->dnode,

--- a/vrrpd/vrrp_vty.h
+++ b/vrrpd/vrrp_vty.h
@@ -25,16 +25,20 @@
 void vrrp_vty_init(void);
 
 /* Northbound callbacks */
-void cli_show_vrrp(struct vty *vty, struct lyd_node *dnode, bool show_defaults);
-void cli_show_shutdown(struct vty *vty, struct lyd_node *dnode,
+void cli_show_vrrp(struct vty *vty, const struct lyd_node *dnode,
+		   bool show_defaults);
+void cli_show_shutdown(struct vty *vty, const struct lyd_node *dnode,
 		       bool show_defaults);
-void cli_show_priority(struct vty *vty, struct lyd_node *dnode,
+void cli_show_priority(struct vty *vty, const struct lyd_node *dnode,
 		       bool show_defaults);
-void cli_show_advertisement_interval(struct vty *vty, struct lyd_node *dnode,
+void cli_show_advertisement_interval(struct vty *vty,
+				     const struct lyd_node *dnode,
 				     bool show_defaults);
-void cli_show_ip(struct vty *vty, struct lyd_node *dnode, bool show_defaults);
-void cli_show_ipv6(struct vty *vty, struct lyd_node *dnode, bool show_defaults);
-void cli_show_preempt(struct vty *vty, struct lyd_node *dnode,
+void cli_show_ip(struct vty *vty, const struct lyd_node *dnode,
+		 bool show_defaults);
+void cli_show_ipv6(struct vty *vty, const struct lyd_node *dnode,
+		   bool show_defaults);
+void cli_show_preempt(struct vty *vty, const struct lyd_node *dnode,
 		      bool show_defaults);
 
 #endif /* __VRRP_VTY_H__ */


### PR DESCRIPTION
To ensure this, add a const modifier to functions' arguments. Would be
great do this initially and avoid this large code change, but better
late than never.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>