### PR TITLE
tests: BFD timing tests under system load need more leeway

### DIFF
--- a/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
+++ b/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
@@ -198,7 +198,7 @@ def test_bfd_ospf_interface_failure_rt2_step3():
     topotest.sleep(2, 'Wait for BFD down notification')
 
     router_compare_json_output(
-        "rt1", "show ip route ospf json", "step3/show_ip_route_rt2_down.ref", 1, 0
+        "rt1", "show ip route ospf json", "step3/show_ip_route_rt2_down.ref", 10, 2
     )
     router_compare_json_output(
         "rt1", "show ipv6 route ospf json", "step3/show_ipv6_route_rt2_down.ref", 1, 0
@@ -236,7 +236,7 @@ def test_bfd_ospf_interface_failure_rt3_step3():
     # initial 2 seconds to let the CI not suffer.
     topotest.sleep(2, 'Wait for BFD down notification')
     router_compare_json_output(
-        "rt1", "show ip route ospf json", "step3/show_ip_route_rt3_down.ref", 1, 0
+        "rt1", "show ip route ospf json", "step3/show_ip_route_rt3_down.ref", 10, 2
     )
     router_compare_json_output(
         "rt1", "show ipv6 route ospf json", "step3/show_ipv6_route_rt3_down.ref", 1, 0


### PR DESCRIPTION
We have this pattern in this test:

    # Let's kill the interface on rt2 and see what happens with the RIB and BFD on rt1
    tgen.gears["rt2"].link_enable("eth-rt1", enabled=False)

    # By default BFD provides a recovery time of 900ms plus jitter, so let's wait
    # initial 2 seconds to let the CI not suffer.
    topotest.sleep(2, 'Wait for BFD down notification')

    router_compare_json_output(
        "rt1", "show ip route ospf json", "step3/show_ip_route_rt2_down.ref", 1, 0
    )

Under a heavy CI load, interface down events and then reacting to them may not actually
happen within 2 seconds.  Allow some more grace time in the test to ensure that we
react to it in an appropriate manner.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>