### PR TITLE
lib: optimize if_lookup_by_name_all_vrf

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -440,7 +440,7 @@ struct interface *if_lookup_by_name_all_vrf(const char *name)
 		return NULL;
 
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
-		ifp = if_lookup_by_name(name, vrf->vrf_id);
+		ifp = if_lookup_by_name_vrf(name, vrf);
 		if (ifp)
 			return ifp;
 	}


### PR DESCRIPTION
We already have a VRF pointer, no need to search for it again.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>