### PR TITLE
*: fix usage of if_lookup_by_index_all_vrf

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -607,10 +607,10 @@ static struct bfd_session *bfd_find_disc(struct sockaddr_any *sa,
 struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *cp,
 				      struct sockaddr_any *peer,
 				      struct sockaddr_any *local,
-				      ifindex_t ifindex, vrf_id_t vrfid,
+				      struct interface *ifp,
+				      vrf_id_t vrfid,
 				      bool is_mhop)
 {
-	struct interface *ifp;
 	struct vrf *vrf;
 	struct bfd_key key;
 
@@ -618,21 +618,8 @@ struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *cp,
 	if (cp->discrs.remote_discr)
 		return bfd_find_disc(peer, ntohl(cp->discrs.remote_discr));
 
-	/*
-	 * Search for session without using discriminator.
-	 *
-	 * XXX: we can't trust `vrfid` because the VRF handling is not
-	 * properly implemented. Meanwhile we should use the interface
-	 * VRF to find out which one it belongs.
-	 */
-	ifp = if_lookup_by_index_all_vrf(ifindex);
-	if (ifp == NULL) {
-		if (vrfid != VRF_DEFAULT)
-			vrf = vrf_lookup_by_id(vrfid);
-		else
-			vrf = NULL;
-	} else
-		vrf = vrf_lookup_by_id(ifp->vrf_id);
+	/* Search for session without using discriminator. */
+	vrf = vrf_lookup_by_id(vrfid);
 
 	gen_bfd_key(&key, peer, local, is_mhop, ifp ? ifp->name : NULL,
 		    vrf ? vrf->name : VRF_DEFAULT_NAME);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -600,7 +600,8 @@ void ptm_bfd_start_xmt_timer(struct bfd_session *bfd, bool is_echo);
 struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *cp,
 				      struct sockaddr_any *peer,
 				      struct sockaddr_any *local,
-				      ifindex_t ifindex, vrf_id_t vrfid,
+				      struct interface *ifp,
+				      vrf_id_t vrfid,
 				      bool is_mhop);
 
 struct bfd_session *bs_peer_find(struct bfd_peer_cfg *bpc);

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -611,7 +611,8 @@ void bgp_nht_ifp_down(struct interface *ifp)
 static int bgp_nht_ifp_initial(struct thread *thread)
 {
 	ifindex_t ifindex = THREAD_VAL(thread);
-	struct interface *ifp = if_lookup_by_index_all_vrf(ifindex);
+	struct bgp *bgp = THREAD_ARG(thread);
+	struct interface *ifp = if_lookup_by_index(ifindex, bgp->vrf_id);
 
 	if (!ifp)
 		return 0;
@@ -657,7 +658,7 @@ void bgp_nht_interface_events(struct peer *peer)
 		return;
 
 	if (bnc->ifindex)
-		thread_add_event(bm->master, bgp_nht_ifp_initial, NULL,
+		thread_add_event(bm->master, bgp_nht_ifp_initial, bnc->bgp,
 				 bnc->ifindex, NULL);
 }
 

--- a/lib/if.c
+++ b/lib/if.c
@@ -47,6 +47,7 @@ DEFINE_MTYPE_STATIC(LIB, IF_LINK_PARAMS, "Informational Link Parameters");
 
 static struct interface *if_lookup_by_ifindex(ifindex_t ifindex,
 					      vrf_id_t vrf_id);
+static struct interface *if_lookup_by_index_all_vrf(ifindex_t ifindex);
 static int if_cmp_func(const struct interface *, const struct interface *);
 static int if_cmp_index_func(const struct interface *ifp1,
 			     const struct interface *ifp2);
@@ -448,7 +449,7 @@ struct interface *if_lookup_by_name_all_vrf(const char *name)
 	return NULL;
 }
 
-struct interface *if_lookup_by_index_all_vrf(ifindex_t ifindex)
+static struct interface *if_lookup_by_index_all_vrf(ifindex_t ifindex)
 {
 	struct vrf *vrf;
 	struct interface *ifp;

--- a/lib/if.h
+++ b/lib/if.h
@@ -518,7 +518,6 @@ extern struct interface *if_create_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
 extern struct interface *if_vrf_lookup_by_index_next(ifindex_t ifindex,
 						     vrf_id_t vrf_id);
-extern struct interface *if_lookup_by_index_all_vrf(ifindex_t);
 extern struct interface *if_lookup_exact_address(const void *matchaddr,
 						 int family, vrf_id_t vrf_id);
 extern struct connected *if_lookup_address(const void *matchaddr, int family,

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -953,12 +953,6 @@ DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
 			nhg_hooks.add_nexthop(nhgc, nh);
 	}
 
-	if (intf) {
-		struct interface *ifp = if_lookup_by_name_all_vrf(intf);
-
-		if (ifp)
-			ifp->configured = true;
-	}
 	return CMD_SUCCESS;
 }
 
@@ -1265,7 +1259,6 @@ void nexthop_group_interface_state_change(struct interface *ifp,
 				if (ifp->ifindex != nhop.ifindex)
 					continue;
 
-				ifp->configured = true;
 				nh = nexthop_new();
 
 				memcpy(nh, &nhop, sizeof(nhop));

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1117,6 +1117,7 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route,
 	json_object *json_route = NULL;
 	json_object *json_array_next_hops = NULL;
 	json_object *json_next_hop;
+	vrf_id_t vrf_id = route->ospf6->vrf_id;
 
 	monotime(&now);
 	timersub(&now, &route->changed, &res);
@@ -1150,16 +1151,15 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route,
 	else
 		i = 0;
 	for (ALL_LIST_ELEMENTS_RO(route->nh_list, node, nh)) {
-		struct interface *ifp;
 		/* nexthop */
 		inet_ntop(AF_INET6, &nh->address, nexthop, sizeof(nexthop));
-		ifp = if_lookup_by_index_all_vrf(nh->ifindex);
 		if (use_json) {
 			json_next_hop = json_object_new_object();
 			json_object_string_add(json_next_hop, "nextHop",
 					       nexthop);
-			json_object_string_add(json_next_hop, "interfaceName",
-					       ifp->name);
+			json_object_string_add(
+				json_next_hop, "interfaceName",
+				ifindex2ifname(nh->ifindex, vrf_id));
 			json_object_array_add(json_array_next_hops,
 					      json_next_hop);
 		} else {
@@ -1171,12 +1171,14 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route,
 					OSPF6_PATH_TYPE_SUBSTR(
 						route->path.type),
 					destination, nexthop, IFNAMSIZ,
-					ifp->name, duration);
+					ifindex2ifname(nh->ifindex, vrf_id),
+					duration);
 				i++;
 			} else
 				vty_out(vty, "%c%1s %2s %-30s %-25s %6.*s %s\n",
 					' ', "", "", "", nexthop, IFNAMSIZ,
-					ifp->name, "");
+					ifindex2ifname(nh->ifindex, vrf_id),
+					"");
 		}
 	}
 	if (use_json) {
@@ -1200,6 +1202,7 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route,
 	json_object *json_route = NULL;
 	json_object *json_array_next_hops = NULL;
 	json_object *json_next_hop;
+	vrf_id_t vrf_id = route->ospf6->vrf_id;
 
 	monotime(&now);
 
@@ -1350,8 +1353,6 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route,
 		vty_out(vty, "Nexthop:\n");
 
 	for (ALL_LIST_ELEMENTS_RO(route->nh_list, node, nh)) {
-		struct interface *ifp;
-		ifp = if_lookup_by_index_all_vrf(nh->ifindex);
 		/* nexthop */
 		if (use_json) {
 			inet_ntop(AF_INET6, &nh->address, nexthop,
@@ -1359,13 +1360,14 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route,
 			json_next_hop = json_object_new_object();
 			json_object_string_add(json_next_hop, "nextHop",
 					       nexthop);
-			json_object_string_add(json_next_hop, "interfaceName",
-					       ifp->name);
+			json_object_string_add(
+				json_next_hop, "interfaceName",
+				ifindex2ifname(nh->ifindex, vrf_id));
 			json_object_array_add(json_array_next_hops,
 					      json_next_hop);
 		} else
 			vty_out(vty, "  %pI6 %.*s\n", &nh->address, IFNAMSIZ,
-				ifp->name);
+				ifindex2ifname(nh->ifindex, vrf_id));
 	}
 	if (use_json) {
 		json_object_object_add(json_route, "nextHops",

--- a/zebra/zebra_l2.c
+++ b/zebra/zebra_l2.c
@@ -162,7 +162,7 @@ void zebra_l2_map_slave_to_bond(struct zebra_if *zif, vrf_id_t vrf_id)
 	struct zebra_if *bond_zif;
 	struct zebra_l2info_bondslave *bond_slave = &zif->bondslave_info;
 
-	bond_if = if_lookup_by_index_all_vrf(bond_slave->bond_ifindex);
+	bond_if = if_lookup_by_index(bond_slave->bond_ifindex, vrf_id);
 	if (bond_if == bond_slave->bond_if)
 		return;
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4736,13 +4736,11 @@ void zebra_vxlan_macvlan_down(struct interface *ifp)
 	assert(zif);
 	link_ifp = zif->link;
 	if (!link_ifp) {
-		if (IS_ZEBRA_DEBUG_VXLAN) {
-			struct interface *ifp;
-
-			ifp = if_lookup_by_index_all_vrf(zif->link_ifindex);
-			zlog_debug("macvlan parent link is not found. Parent index %d ifp %s",
-				zif->link_ifindex, ifp ? ifp->name : " ");
-		}
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug(
+				"macvlan parent link is not found. Parent index %d ifp %s",
+				zif->link_ifindex,
+				ifindex2ifname(zif->link_ifindex, ifp->vrf_id));
 		return;
 	}
 	link_zif = link_ifp->info;


### PR DESCRIPTION
This function doesn't work correctly with netns VRF backend as the same
index may be used in multiple netns simultaneously.

This PR fixes all the incorrect usages and makes the function internal
to prevent future bugs.

Please, check individual commits for the details.