### PR TITLE
[8.1] ospfd: fix crash when creating vlink in unknown vrf

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -909,6 +909,13 @@ struct ospf_interface *ospf_vl_new(struct ospf *ospf,
 		return NULL;
 	}
 
+	if (ospf->vrf_id == VRF_UNKNOWN) {
+		if (IS_DEBUG_OSPF_EVENT)
+			zlog_debug(
+				"ospf_vl_new(): Alarm: cannot create pseudo interface in unknown VRF");
+		return NULL;
+	}
+
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
 			"ospf_vl_new(): creating pseudo zebra interface vrf id %u",

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -892,6 +892,12 @@ ospf_find_vl_data(struct ospf *ospf, struct ospf_vl_config_data *vl_config)
 		vl_data = ospf_vl_data_new(area, vl_config->vl_peer);
 		if (vl_data->vl_oi == NULL) {
 			vl_data->vl_oi = ospf_vl_new(ospf, vl_data);
+			if (!vl_data->vl_oi) {
+				ospf_vl_data_free(vl_data);
+				vty_out(vty,
+					"Can't create VL, check logs for more information\n");
+				return NULL;
+			}
 			ospf_vl_add(ospf, vl_data);
 			ospf_spf_calculate_schedule(ospf,
 						    SPF_FLAG_CONFIG_CHANGE);


### PR DESCRIPTION
if_create_name crashes when vrf_id is VRF_UNKNOWN:
```
nfware# conf t
nfware(config)# router ospf vrf doesnt-exist
nfware(config-router)# area 1.1.1.1 virtual-link 2.2.2.2
vtysh: error reading from ospfd: Success (0)Warning: closing connection to ospfd because of an I/O error!
```

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>

This PR is opened against the dev branch, because the issue is addressed in https://github.com/FRRouting/frr/pull/9818 for master.