### PR TITLE
isisd: add fuzzers for isisd and fabricd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -398,6 +398,8 @@ if test "$enable_libfuzzer" = "yes"; then
     OSPFD_SAN_FLAGS="-fsanitize=fuzzer"
     VRRPD_SAN_FLAGS="-fsanitize=fuzzer"
     PIMD_SAN_FLAGS="-fsanitize=fuzzer"
+    ISISD_SAN_FLAGS="-fsanitize=fuzzer"
+    FABRICD_SAN_FLAGS="-fsanitize=fuzzer"
     AC_DEFINE([FUZZING_LIBFUZZER], [1], [Compiling and linking with libFuzzer])
   ])
 fi
@@ -407,6 +409,8 @@ AC_SUBST([ZEBRA_SAN_FLAGS])
 AC_SUBST([OSPFD_SAN_FLAGS])
 AC_SUBST([VRRPD_SAN_FLAGS])
 AC_SUBST([PIMD_SAN_FLAGS])
+AC_SUBST([ISISD_SAN_FLAGS])
+AC_SUBST([FABRICD_SAN_FLAGS])
 
 dnl frr-format.so
 if test "$with_frr_format" != "no" -a "$with_frr_format" != "yes" -a -n "$with_frr_format"; then

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -115,6 +115,22 @@ struct isis_circuit *isis_circuit_new(struct interface *ifp, const char *tag)
 	/*
 	 * Default values
 	 */
+#ifdef FUZZING
+	circuit->is_type = IS_LEVEL_1_AND_2;
+	circuit->flags = 0;
+	circuit->pad_hellos = 1;
+	for (i = 0; i < 2; i++) {
+		circuit->hello_interval[i] = DEFAULT_HELLO_INTERVAL;
+		circuit->hello_multiplier[i] = DEFAULT_HELLO_MULTIPLIER;
+		circuit->csnp_interval[i] = DEFAULT_CSNP_INTERVAL;
+		circuit->psnp_interval[i] = DEFAULT_PSNP_INTERVAL;
+		circuit->priority[i] = DEFAULT_PRIORITY;
+		circuit->metric[i] = DEFAULT_CIRCUIT_METRIC;
+		circuit->te_metric[i] = DEFAULT_CIRCUIT_METRIC;
+		circuit->level_arg[i].level = i + 1;
+		circuit->level_arg[i].circuit = circuit;
+	}
+#else
 #ifndef FABRICD
 	circuit->is_type = yang_get_default_enum(
 		"/frr-interface:lib/interface/frr-isisd:isis/circuit-type");
@@ -171,6 +187,7 @@ struct isis_circuit *isis_circuit_new(struct interface *ifp, const char *tag)
 		circuit->level_arg[i].circuit = circuit;
 	}
 #endif /* ifndef FABRICD */
+#endif /* ifdef FUZZING */
 
 	circuit_mt_init(circuit);
 	isis_lfa_excluded_ifaces_init(circuit, ISIS_LEVEL1);

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -322,6 +322,7 @@ void lsp_inc_seqno(struct isis_lsp *lsp, uint32_t seqno)
 	else
 		newseq = seqno + 1;
 
+#ifndef FUZZING
 #ifndef FABRICD
 	/* check for overflow */
 	if (newseq < lsp->hdr.seqno) {
@@ -330,6 +331,7 @@ void lsp_inc_seqno(struct isis_lsp *lsp, uint32_t seqno)
 		isis_notif_lsp_exceed_max(lsp->area, lsp->hdr.lsp_id);
 	}
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 
 	lsp->hdr.seqno = newseq;
 
@@ -1341,11 +1343,13 @@ int lsp_generate(struct isis_area *area, int level)
 		"ISIS (%s): Built L%d LSP. Set triggered regenerate to non-pending.",
 		area->area_tag, level);
 
+#ifndef FUZZING
 #ifndef FABRICD
 	/* send northbound notification */
 	isis_notif_lsp_gen(area, newlsp->hdr.lsp_id, newlsp->hdr.seqno,
 			   newlsp->last_generated);
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 
 	return ISIS_OK;
 }

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -595,22 +595,26 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 		if (circuit->circ_type != CIRCUIT_T_P2P) {
 			zlog_warn("p2p hello on non p2p circuit");
 			update_rej_adj_count(circuit);
+#ifndef FUZZING
 #ifndef FABRICD
 			isis_notif_reject_adjacency(
 				circuit, "p2p hello on non p2p circuit",
 				raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 			return ISIS_WARNING;
 		}
 	} else {
 		if (circuit->circ_type != CIRCUIT_T_BROADCAST) {
 			zlog_warn("lan hello on non broadcast circuit");
 			update_rej_adj_count(circuit);
+#ifndef FUZZING
 #ifndef FABRICD
 			isis_notif_reject_adjacency(
 				circuit, "lan hello on non broadcast circuit",
 				raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING*/
 			return ISIS_WARNING;
 		}
 
@@ -619,12 +623,14 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 				"level %d LAN Hello received over circuit with externalDomain = true",
 				level);
 			update_rej_adj_count(circuit);
+#ifndef FUZZING
 #ifndef FABRICD
 			isis_notif_reject_adjacency(
 				circuit,
 				"LAN Hello received over circuit with externalDomain = true",
 				raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING*/
 			return ISIS_WARNING;
 		}
 
@@ -636,11 +642,13 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 					circuit->interface->name);
 			}
 			update_rej_adj_count(circuit);
+#ifndef FUZZING
 #ifndef FABRICD
 			isis_notif_reject_adjacency(circuit,
 						    "Interface level mismatch",
 						    raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING*/
 			return ISIS_WARNING;
 		}
 	}
@@ -667,10 +675,12 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 			circuit->area->area_tag, pdu_name,
 			circuit->interface->name, iih.pdu_len);
 		update_rej_adj_count(circuit);
+#ifndef FUZZING
 #ifndef FABRICD
 		isis_notif_reject_adjacency(circuit, "Invalid PDU length",
 					    raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		return ISIS_WARNING;
 	}
 
@@ -679,11 +689,13 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 			 "Level %d LAN Hello with Circuit Type %d", level,
 			 iih.circ_type);
 		update_rej_adj_count(circuit);
+#ifndef FUZZING
 #ifndef FABRICD
 		isis_notif_reject_adjacency(circuit,
 					    "LAN Hello with wrong IS-level",
 					    raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		return ISIS_ERROR;
 	}
 
@@ -694,30 +706,36 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 			     circuit->rcv_stream, &iih.tlvs, &error_log)) {
 		zlog_warn("isis_unpack_tlvs() failed: %s", error_log);
 		update_rej_adj_count(circuit);
+#ifndef FUZZING
 #ifndef FABRICD
 		isis_notif_reject_adjacency(circuit, "Failed to unpack TLVs",
 					    raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		goto out;
 	}
 
 	if (!iih.tlvs->area_addresses.count) {
 		zlog_warn("No Area addresses TLV in %s", pdu_name);
+#ifndef FUZZING
 #ifndef FABRICD
 		/* send northbound notification */
 		isis_notif_area_mismatch(circuit, raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		goto out;
 	}
 
 	if (!iih.tlvs->protocols_supported.count) {
 		zlog_warn("No supported protocols TLV in %s", pdu_name);
 		update_rej_adj_count(circuit);
+#ifndef FUZZING
 #ifndef FABRICD
 		isis_notif_reject_adjacency(circuit,
 					    "No supported protocols TLV",
 					    raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		goto out;
 	}
 
@@ -727,6 +745,7 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 		isis_event_auth_failure(circuit->area->area_tag,
 					"IIH authentication failure",
 					iih.sys_id);
+#ifndef FUZZING
 #ifndef FABRICD
 		/* send northbound notification */
 		stream_get_from(raw_pdu, circuit->rcv_stream, pdu_start,
@@ -741,6 +760,7 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 							       sizeof(raw_pdu));
 		}
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		goto out;
 	}
 
@@ -749,11 +769,13 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 			"ISIS-Adj (%s): Received IIH with own sysid on %s - discard",
 			circuit->area->area_tag, circuit->interface->name);
 		update_rej_adj_count(circuit);
+#ifndef FUZZING
 #ifndef FABRICD
 		isis_notif_reject_adjacency(circuit,
 					    "Received IIH with our own sysid",
 					    raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		goto out;
 	}
 
@@ -768,10 +790,12 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 				circuit->area->area_tag, level,
 				circuit->interface->name);
 		}
+#ifndef FUZZING
 #ifndef FABRICD
 		/* send northbound notification */
 		isis_notif_area_mismatch(circuit, raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		goto out;
 	}
 
@@ -788,11 +812,13 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 				circuit->area->area_tag);
 		}
 		update_rej_adj_count(circuit);
+#ifndef FUZZING
 #ifndef FABRICD
 		isis_notif_reject_adjacency(
 			circuit, "Neither IPv4 not IPv6 considered usable",
 			raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		goto out;
 	}
 
@@ -873,11 +899,13 @@ static int process_lsp(uint8_t pdu_type, struct isis_circuit *circuit,
 	hdr.checksum = stream_getw(circuit->rcv_stream);
 	hdr.lsp_bits = stream_getc(circuit->rcv_stream);
 
+#ifndef FUZZING
 #ifndef FABRICD
 	/* send northbound notification */
 	isis_notif_lsp_received(circuit, hdr.lsp_id, hdr.seqno, time(NULL),
 				sysid_print(hdr.lsp_id));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 
 	if (pdu_len_validate(hdr.pdu_len, circuit)) {
 		zlog_debug("ISIS-Upd (%s): LSP %s invalid LSP length %hu",
@@ -941,6 +969,7 @@ static int process_lsp(uint8_t pdu_type, struct isis_circuit *circuit,
 			     circuit->rcv_stream, &tlvs, &error_log)) {
 		zlog_warn("Something went wrong unpacking the LSP: %s",
 			  error_log);
+#ifndef FUZZING
 #ifndef FABRICD
 		/* send northbound notification. Note that the tlv-type and
 		 * offset cannot correctly be set here as they are not returned
@@ -962,6 +991,7 @@ static int process_lsp(uint8_t pdu_type, struct isis_circuit *circuit,
 		isis_notif_lsp_error(circuit, hdr.lsp_id, raw_pdu,
 				     sizeof(raw_pdu), 0, 0);
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		goto out;
 	}
 
@@ -980,6 +1010,7 @@ static int process_lsp(uint8_t pdu_type, struct isis_circuit *circuit,
 		isis_event_auth_failure(circuit->area->area_tag,
 					"LSP authentication failure",
 					hdr.lsp_id);
+#ifndef FUZZING
 #ifndef FABRICD
 		/* send northbound notification */
 		if (auth_code == ISIS_AUTH_FAILURE) {
@@ -1008,6 +1039,7 @@ static int process_lsp(uint8_t pdu_type, struct isis_circuit *circuit,
 							       sizeof(raw_pdu));
 		}
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		goto out;
 	}
 
@@ -1146,6 +1178,7 @@ dontcheckadj:
 			} else if (lsp->hdr.rem_lifetime != 0) {
 				/* our own LSP -> 7.3.16.4 c) */
 				if (comp == LSP_NEWER) {
+#ifndef FUZZING
 #ifndef FABRICD
 					if (lsp->hdr.seqno < hdr.seqno) {
 						/* send northbound
@@ -1156,6 +1189,7 @@ dontcheckadj:
 							circuit, hdr.lsp_id);
 					}
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 					lsp_inc_seqno(lsp, hdr.seqno);
 					lsp_flood_or_update(lsp, NULL,
 							    circuit_scoped);
@@ -1172,10 +1206,12 @@ dontcheckadj:
 						lsp->hdr.seqno);
 			} else {
 				/* our own LSP with 0 remaining life time */
+#ifndef FUZZING
 #ifndef FABRICD
 				/* send northbound notification */
 				isis_notif_own_lsp_purge(circuit, hdr.lsp_id);
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 			}
 		}
 		goto out;
@@ -1200,11 +1236,13 @@ dontcheckadj:
 		if (comp == LSP_NEWER) {
 			/* 7.3.16.1  */
 			lsp_inc_seqno(lsp, hdr.seqno);
+#ifndef FUZZING
 #ifndef FABRICD
 			/* send northbound notification */
 			circuit->area->lsp_seqno_skipped_counter++;
 			isis_notif_seqno_skipped(circuit, hdr.lsp_id);
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 			if (IS_DEBUG_UPDATE_PACKETS) {
 				zlog_debug(
 					"ISIS-Upd (%s): (2) re-originating LSP %s new seq 0x%08x",
@@ -1427,6 +1465,7 @@ static int process_snp(uint8_t pdu_type, struct isis_circuit *circuit,
 						"SNP authentication failure",
 						rem_sys_id);
 #ifndef FABRICD
+#ifndef FUZZING
 			/* send northbound notification */
 			stream_get_from(raw_pdu, circuit->rcv_stream, pdu_start,
 					pdu_end - pdu_start);
@@ -1456,6 +1495,7 @@ static int process_snp(uint8_t pdu_type, struct isis_circuit *circuit,
 					circuit, raw_pdu, sizeof(raw_pdu));
 			}
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 			goto out;
 		}
 	}
@@ -1678,11 +1718,13 @@ int isis_handle_pdu(struct isis_circuit *circuit, uint8_t *ssnpa)
 
 	if (version1 != 1) {
 		zlog_warn("Unsupported ISIS version %hhu", version1);
+#ifndef FUZZING
 #ifndef FABRICD
 		/* send northbound notification */
 		isis_notif_version_skew(circuit, version1, raw_pdu,
 					sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		return ISIS_WARNING;
 	}
 
@@ -1701,11 +1743,13 @@ int isis_handle_pdu(struct isis_circuit *circuit, uint8_t *ssnpa)
 			circuit->area->id_len_mismatches[1]++;
 		}
 
+#ifndef FUZZING
 #ifndef FABRICD
 		/* send northbound notification */
 		isis_notif_id_len_mismatch(circuit, id_len, raw_pdu,
 					   sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* FUZZING */
 		return ISIS_ERROR;
 	}
 
@@ -1731,11 +1775,13 @@ int isis_handle_pdu(struct isis_circuit *circuit, uint8_t *ssnpa)
 
 	if (version2 != 1) {
 		zlog_warn("Unsupported ISIS PDU version %hhu", version2);
+#ifndef FUZZING
 #ifndef FABRICD
 		/* send northbound notification */
 		isis_notif_version_skew(circuit, version2, raw_pdu,
 					sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		return ISIS_WARNING;
 	}
 
@@ -1755,11 +1801,13 @@ int isis_handle_pdu(struct isis_circuit *circuit, uint8_t *ssnpa)
 			"maximumAreaAddressesMismatch: maximumAreaAdresses in a received PDU %hhu while the parameter for this IS is %u",
 			max_area_addrs, circuit->isis->max_area_addrs);
 		circuit->max_area_addr_mismatches++;
+#ifndef FUZZING
 #ifndef FABRICD
 		/* send northbound notification */
 		isis_notif_max_area_addr_mismatch(circuit, max_area_addrs,
 						  raw_pdu, sizeof(raw_pdu));
 #endif /* ifndef FABRICD */
+#endif /* FUZZING */
 		return ISIS_ERROR;
 	}
 
@@ -2478,11 +2526,13 @@ void send_lsp(struct isis_circuit *circuit, struct isis_lsp *lsp,
 			lsp->hdr.checksum, lsp->hdr.rem_lifetime,
 			circuit->interface->name, stream_get_endp(lsp->pdu),
 			stream_get_size(circuit->snd_stream));
+#ifndef FUZZING
 #ifndef FABRICD
 		/* send a northbound notification */
 		isis_notif_lsp_too_large(circuit, stream_get_endp(lsp->pdu),
 					 lsp->hdr.lsp_id);
 #endif /* ifndef FABRICD */
+#endif /* ifndef FUZZING */
 		if (IS_DEBUG_PACKET_DUMP)
 			zlog_dump_data(STREAM_DATA(lsp->pdu),
 				       stream_get_endp(lsp->pdu));

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -1209,8 +1209,15 @@ void isis_sr_area_init(struct isis_area *area)
 	memset(srdb, 0, sizeof(*srdb));
 	srdb->adj_sids = list_new();
 
-	/* Pull defaults from the YANG module. */
+#ifdef FUZZING
+	srdb->config.enabled = false;
+	srdb->config.srgb_lower_bound = SRGB_LOWER_BOUND;
+	srdb->config.srgb_upper_bound = SRGB_UPPER_BOUND;
+	srdb->config.srlb_lower_bound = SRLB_LOWER_BOUND;
+	srdb->config.srlb_upper_bound = SRLB_UPPER_BOUND;
+#else
 #ifndef FABRICD
+	/* Pull defaults from the YANG module. */
 	srdb->config.enabled = yang_get_default_bool("%s/enabled", ISIS_SR);
 	srdb->config.srgb_lower_bound = yang_get_default_uint32(
 		"%s/label-blocks/srgb/lower-bound", ISIS_SR);
@@ -1227,6 +1234,7 @@ void isis_sr_area_init(struct isis_area *area)
 	srdb->config.srlb_lower_bound = SRLB_LOWER_BOUND;
 	srdb->config.srlb_upper_bound = SRLB_UPPER_BOUND;
 #endif
+#endif /* FUZZING */
 	srdb->config.msd = 0;
 	srdb_prefix_cfg_init(&srdb->config.prefix_sids);
 }

--- a/isisd/subdir.am
+++ b/isisd/subdir.am
@@ -137,6 +137,8 @@ nodist_isisd_isisd_SOURCES = \
 	yang/frr-isisd.yang.c \
 	# end
 
+isisd_isisd_LDFLAGS = $(AM_LDFLAGS) $(ISISD_SAN_FLAGS)
+
 isisd_isisd_snmp_la_SOURCES = isisd/isis_snmp.c
 isisd_isisd_snmp_la_CFLAGS = $(AM_CFLAGS) $(SNMP_CFLAGS) -std=gnu11
 isisd_isisd_snmp_la_LDFLAGS = $(MODULE_LDFLAGS)
@@ -152,5 +154,6 @@ isisd_libfabric_a_SOURCES = \
 	#end
 isisd_libfabric_a_CPPFLAGS = $(FABRICD_CPPFLAGS)
 isisd_fabricd_LDADD = isisd/libfabric.a $(ISIS_LDADD_COMMON)
+isisd_fabricd_LDFLAGS = $(AM_LDFLAGS) $(FABRICD_SAN_FLAGS)
 isisd_fabricd_SOURCES = $(ISIS_SOURCES)
 isisd_fabricd_CPPFLAGS = $(FABRICD_CPPFLAGS)


### PR DESCRIPTION
Hello,

this PR adds fuzz harnesses for isisd and fabricd.

The harnesses send the input received from the fuzzer to `isis_handle_pdu()`.  There is some coverage overlap with `test_fuzz_isis_tlv` which calls TLV functions but I think this harness should achieve wider coverage. It has already found some issues that I haven't managed to easily reproduce with `test_fuzz_isis_tlv`.

I've let the isisd fuzzer run for around a month so far with ASAN and UBSAN. It initially discovered a few dozen issues in router capability TLV parsing and in `unpack_item_ext_subtlvs()`. After that there have been no new crashes but the fuzzer continuously found new paths, so I assume it is working fine. The fixes for those issues are available in PRs #9850 and #9851

I formatted the changes with `clang-format` and ran `checkpatch.sh` on the patch.

`checkpatch.sh` reports the following:
```
Report for isis_main.c | 2 issues
===============================================
< WARNING: char * array declaration might be better as static const
< #205: FILE: /tmp/f1-5919/isis_main.c:205:
```

Looking at the other fuzzers, `char *` seems to be used for the other name variables, so I haven't changed it to static const.

I've tested that the fuzzer builds work with AFL compilers and with `./configure --enable-libufzzer`.

If there are any comments or changes that should be made, please let me know.