### PR TITLE
*: convert zclient callbacks to table

### DIFF
--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -234,16 +234,20 @@ babel_zebra_connected (struct zclient *zclient)
   zclient_send_reg_requests (zclient, VRF_DEFAULT);
 }
 
+static zclient_handler *const babel_handlers[] = {
+    [ZEBRA_INTERFACE_ADDRESS_ADD] = babel_interface_address_add,
+    [ZEBRA_INTERFACE_ADDRESS_DELETE] = babel_interface_address_delete,
+    [ZEBRA_REDISTRIBUTE_ROUTE_ADD] = babel_zebra_read_route,
+    [ZEBRA_REDISTRIBUTE_ROUTE_DEL] = babel_zebra_read_route,
+};
+
 void babelz_zebra_init(void)
 {
-    zclient = zclient_new(master, &zclient_options_default);
+    zclient = zclient_new(master, &zclient_options_default, babel_handlers,
+			  array_size(babel_handlers));
     zclient_init(zclient, ZEBRA_ROUTE_BABEL, 0, &babeld_privs);
 
     zclient->zebra_connected = babel_zebra_connected;
-    zclient->interface_address_add = babel_interface_address_add;
-    zclient->interface_address_delete = babel_interface_address_delete;
-    zclient->redistribute_route_add = babel_zebra_read_route;
-    zclient->redistribute_route_del = babel_zebra_read_route;
 
     install_element(BABEL_NODE, &babel_redistribute_type_cmd);
     install_element(ENABLE_NODE, &debug_babel_cmd);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -136,8 +136,7 @@ static void bgp_update_interface_nbrs(struct bgp *bgp, struct interface *ifp,
 	}
 }
 
-static int bgp_read_fec_update(int command, struct zclient *zclient,
-			       zebra_size_t length)
+static int bgp_read_fec_update(ZAPI_CALLBACK_ARGS)
 {
 	bgp_parse_fec_update();
 	return 0;
@@ -3005,7 +3004,7 @@ static int bgp_zebra_process_local_macip(ZAPI_CALLBACK_ARGS)
 	}
 }
 
-static void bgp_zebra_process_local_ip_prefix(ZAPI_CALLBACK_ARGS)
+static int bgp_zebra_process_local_ip_prefix(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s = NULL;
 	struct bgp *bgp_vrf = NULL;
@@ -3017,7 +3016,7 @@ static void bgp_zebra_process_local_ip_prefix(ZAPI_CALLBACK_ARGS)
 
 	bgp_vrf = bgp_lookup_by_vrf_id(vrf_id);
 	if (!bgp_vrf)
-		return;
+		return 0;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("Recv prefix %pFX %s on vrf %s", &p,
@@ -3041,9 +3040,10 @@ static void bgp_zebra_process_local_ip_prefix(ZAPI_CALLBACK_ARGS)
 			bgp_evpn_withdraw_type5_route(bgp_vrf, &p, AFI_IP6,
 						      SAFI_UNICAST);
 	}
+	return 0;
 }
 
-static void bgp_zebra_process_label_chunk(ZAPI_CALLBACK_ARGS)
+static int bgp_zebra_process_label_chunk(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s = NULL;
 	uint8_t response_keep;
@@ -3062,12 +3062,12 @@ static void bgp_zebra_process_label_chunk(ZAPI_CALLBACK_ARGS)
 	if (zclient->redist_default != proto) {
 		flog_err(EC_BGP_LM_ERROR, "Got LM msg with wrong proto %u",
 			 proto);
-		return;
+		return 0;
 	}
 	if (zclient->instance != instance) {
 		flog_err(EC_BGP_LM_ERROR, "Got LM msg with wrong instance %u",
 			 proto);
-		return;
+		return 0;
 	}
 
 	if (first > last ||
@@ -3076,7 +3076,7 @@ static void bgp_zebra_process_label_chunk(ZAPI_CALLBACK_ARGS)
 
 		flog_err(EC_BGP_LM_ERROR, "%s: Invalid Label chunk: %u - %u",
 			 __func__, first, last);
-		return;
+		return 0;
 	}
 	if (BGP_DEBUG(zebra, ZEBRA)) {
 		zlog_debug("Label Chunk assign: %u - %u (%u) ",
@@ -3085,8 +3085,10 @@ static void bgp_zebra_process_label_chunk(ZAPI_CALLBACK_ARGS)
 
 	bgp_lp_event_chunk(response_keep, first, last);
 
+	return 0;
+
 stream_failure:		/* for STREAM_GETX */
-	return;
+	return -1;
 }
 
 extern struct zebra_privs_t bgpd_privs;
@@ -3109,7 +3111,7 @@ static int bgp_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-static void bgp_zebra_process_srv6_locator_chunk(ZAPI_CALLBACK_ARGS)
+static int bgp_zebra_process_srv6_locator_chunk(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s = NULL;
 	struct bgp *bgp = bgp_get_default();
@@ -3124,18 +3126,19 @@ static void bgp_zebra_process_srv6_locator_chunk(ZAPI_CALLBACK_ARGS)
 	if (strcmp(bgp->srv6_locator_name, s6c.locator_name) != 0) {
 		zlog_err("%s: Locator name unmatch %s:%s", __func__,
 			 bgp->srv6_locator_name, s6c.locator_name);
-		return;
+		return 0;
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(bgp->srv6_locator_chunks, node, c)) {
 		if (!prefix_cmp(c, &s6c.prefix))
-			return;
+			return 0;
 	}
 
 	chunk = prefix_ipv6_new();
 	*chunk = s6c.prefix;
 	listnode_add(bgp->srv6_locator_chunks, chunk);
 	vpn_leak_postchange_all();
+	return 0;
 }
 
 static int bgp_zebra_process_srv6_locator_add(ZAPI_CALLBACK_ARGS)
@@ -3220,6 +3223,41 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
+static zclient_handler *const bgp_handlers[] = {
+	[ZEBRA_ROUTER_ID_UPDATE] = bgp_router_id_update,
+	[ZEBRA_INTERFACE_ADDRESS_ADD] = bgp_interface_address_add,
+	[ZEBRA_INTERFACE_ADDRESS_DELETE] = bgp_interface_address_delete,
+	[ZEBRA_INTERFACE_NBR_ADDRESS_ADD] = bgp_interface_nbr_address_add,
+	[ZEBRA_INTERFACE_NBR_ADDRESS_DELETE] = bgp_interface_nbr_address_delete,
+	[ZEBRA_INTERFACE_VRF_UPDATE] = bgp_interface_vrf_update,
+	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = zebra_read_route,
+	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = zebra_read_route,
+	[ZEBRA_NEXTHOP_UPDATE] = bgp_read_nexthop_update,
+	[ZEBRA_FEC_UPDATE] = bgp_read_fec_update,
+	[ZEBRA_LOCAL_ES_ADD] = bgp_zebra_process_local_es_add,
+	[ZEBRA_LOCAL_ES_DEL] = bgp_zebra_process_local_es_del,
+	[ZEBRA_VNI_ADD] = bgp_zebra_process_local_vni,
+	[ZEBRA_LOCAL_ES_EVI_ADD] = bgp_zebra_process_local_es_evi,
+	[ZEBRA_LOCAL_ES_EVI_DEL] = bgp_zebra_process_local_es_evi,
+	[ZEBRA_VNI_DEL] = bgp_zebra_process_local_vni,
+	[ZEBRA_MACIP_ADD] = bgp_zebra_process_local_macip,
+	[ZEBRA_MACIP_DEL] = bgp_zebra_process_local_macip,
+	[ZEBRA_L3VNI_ADD] = bgp_zebra_process_local_l3vni,
+	[ZEBRA_L3VNI_DEL] = bgp_zebra_process_local_l3vni,
+	[ZEBRA_IP_PREFIX_ROUTE_ADD] = bgp_zebra_process_local_ip_prefix,
+	[ZEBRA_IP_PREFIX_ROUTE_DEL] = bgp_zebra_process_local_ip_prefix,
+	[ZEBRA_GET_LABEL_CHUNK] = bgp_zebra_process_label_chunk,
+	[ZEBRA_RULE_NOTIFY_OWNER] = rule_notify_owner,
+	[ZEBRA_IPSET_NOTIFY_OWNER] = ipset_notify_owner,
+	[ZEBRA_IPSET_ENTRY_NOTIFY_OWNER] = ipset_entry_notify_owner,
+	[ZEBRA_IPTABLE_NOTIFY_OWNER] = iptable_notify_owner,
+	[ZEBRA_ROUTE_NOTIFY_OWNER] = bgp_zebra_route_notify_owner,
+	[ZEBRA_SRV6_LOCATOR_ADD] = bgp_zebra_process_srv6_locator_add,
+	[ZEBRA_SRV6_LOCATOR_DELETE] = bgp_zebra_process_srv6_locator_delete,
+	[ZEBRA_SRV6_MANAGER_GET_LOCATOR_CHUNK] =
+		bgp_zebra_process_srv6_locator_chunk,
+};
+
 void bgp_zebra_init(struct thread_master *master, unsigned short instance)
 {
 	zclient_num_connects = 0;
@@ -3228,43 +3266,11 @@ void bgp_zebra_init(struct thread_master *master, unsigned short instance)
 			  bgp_ifp_down, bgp_ifp_destroy);
 
 	/* Set default values. */
-	zclient = zclient_new(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default, bgp_handlers,
+			      array_size(bgp_handlers));
 	zclient_init(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
 	zclient->zebra_connected = bgp_zebra_connected;
-	zclient->router_id_update = bgp_router_id_update;
-	zclient->interface_address_add = bgp_interface_address_add;
-	zclient->interface_address_delete = bgp_interface_address_delete;
-	zclient->interface_nbr_address_add = bgp_interface_nbr_address_add;
-	zclient->interface_nbr_address_delete =
-		bgp_interface_nbr_address_delete;
-	zclient->interface_vrf_update = bgp_interface_vrf_update;
-	zclient->redistribute_route_add = zebra_read_route;
-	zclient->redistribute_route_del = zebra_read_route;
-	zclient->nexthop_update = bgp_read_nexthop_update;
-	zclient->fec_update = bgp_read_fec_update;
-	zclient->local_es_add = bgp_zebra_process_local_es_add;
-	zclient->local_es_del = bgp_zebra_process_local_es_del;
-	zclient->local_vni_add = bgp_zebra_process_local_vni;
-	zclient->local_es_evi_add = bgp_zebra_process_local_es_evi;
-	zclient->local_es_evi_del = bgp_zebra_process_local_es_evi;
-	zclient->local_vni_del = bgp_zebra_process_local_vni;
-	zclient->local_macip_add = bgp_zebra_process_local_macip;
-	zclient->local_macip_del = bgp_zebra_process_local_macip;
-	zclient->local_l3vni_add = bgp_zebra_process_local_l3vni;
-	zclient->local_l3vni_del = bgp_zebra_process_local_l3vni;
-	zclient->local_ip_prefix_add = bgp_zebra_process_local_ip_prefix;
-	zclient->local_ip_prefix_del = bgp_zebra_process_local_ip_prefix;
-	zclient->label_chunk = bgp_zebra_process_label_chunk;
-	zclient->rule_notify_owner = rule_notify_owner;
-	zclient->ipset_notify_owner = ipset_notify_owner;
-	zclient->ipset_entry_notify_owner = ipset_entry_notify_owner;
-	zclient->iptable_notify_owner = iptable_notify_owner;
-	zclient->route_notify_owner = bgp_zebra_route_notify_owner;
 	zclient->instance = instance;
-	zclient->srv6_locator_add = bgp_zebra_process_srv6_locator_add;
-	zclient->srv6_locator_delete = bgp_zebra_process_srv6_locator_delete;
-	zclient->process_srv6_locator_chunk =
-		bgp_zebra_process_srv6_locator_chunk;
 }
 
 void bgp_zebra_destroy(void)

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -895,6 +895,11 @@ int vnc_redistribute_unset(struct bgp *bgp, afi_t afi, int type)
 
 extern struct zebra_privs_t bgpd_privs;
 
+static zclient_handler *const vnc_handlers[] = {
+	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = vnc_zebra_read_route,
+	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = vnc_zebra_read_route,
+};
+
 /*
  * Modeled after bgp_zebra.c'bgp_zebra_init()
  * Charriere asks, "Is it possible to carry two?"
@@ -902,11 +907,9 @@ extern struct zebra_privs_t bgpd_privs;
 void vnc_zebra_init(struct thread_master *master)
 {
 	/* Set default values. */
-	zclient_vnc = zclient_new(master, &zclient_options_default);
+	zclient_vnc = zclient_new(master, &zclient_options_default,
+				  vnc_handlers, array_size(vnc_handlers));
 	zclient_init(zclient_vnc, ZEBRA_ROUTE_VNC, 0, &bgpd_privs);
-
-	zclient_vnc->redistribute_route_add = vnc_zebra_read_route;
-	zclient_vnc->redistribute_route_del = vnc_zebra_read_route;
 }
 
 void vnc_zebra_destroy(void)

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -102,20 +102,24 @@ static void eigrp_zebra_connected(struct zclient *zclient)
 	zclient_send_reg_requests(zclient, VRF_DEFAULT);
 }
 
+static zclient_handler *const eigrp_handlers[] = {
+	[ZEBRA_ROUTER_ID_UPDATE] = eigrp_router_id_update_zebra,
+	[ZEBRA_INTERFACE_ADDRESS_ADD] = eigrp_interface_address_add,
+	[ZEBRA_INTERFACE_ADDRESS_DELETE] = eigrp_interface_address_delete,
+	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = eigrp_zebra_read_route,
+	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = eigrp_zebra_read_route,
+	[ZEBRA_ROUTE_NOTIFY_OWNER] = eigrp_zebra_route_notify_owner,
+};
+
 void eigrp_zebra_init(void)
 {
 	struct zclient_options opt = {.receive_notify = false};
 
-	zclient = zclient_new(master, &opt);
+	zclient = zclient_new(master, &opt, eigrp_handlers,
+			      array_size(eigrp_handlers));
 
 	zclient_init(zclient, ZEBRA_ROUTE_EIGRP, 0, &eigrpd_privs);
 	zclient->zebra_connected = eigrp_zebra_connected;
-	zclient->router_id_update = eigrp_router_id_update_zebra;
-	zclient->interface_address_add = eigrp_interface_address_add;
-	zclient->interface_address_delete = eigrp_interface_address_delete;
-	zclient->redistribute_route_add = eigrp_zebra_read_route;
-	zclient->redistribute_route_del = eigrp_zebra_read_route;
-	zclient->route_notify_owner = eigrp_zebra_route_notify_owner;
 }
 
 

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -2192,7 +2192,7 @@ static void zclient_sync_init(void)
 	options.synchronous = true;
 
 	/* Initialize special zclient for synchronous message exchanges. */
-	zclient_sync = zclient_new(master, &options);
+	zclient_sync = zclient_new(master, &options, NULL, 0);
 	zclient_sync->sock = -1;
 	zclient_sync->redist_default = ZEBRA_ROUTE_LDP;
 	zclient_sync->session_id = 1; /* Distinguish from main session */

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -694,6 +694,16 @@ ldp_zebra_filter_update(struct access_list *access)
 
 extern struct zebra_privs_t ldpd_privs;
 
+static zclient_handler *const ldp_handlers[] = {
+	[ZEBRA_ROUTER_ID_UPDATE] = ldp_router_id_update,
+	[ZEBRA_INTERFACE_ADDRESS_ADD] = ldp_interface_address_add,
+	[ZEBRA_INTERFACE_ADDRESS_DELETE] = ldp_interface_address_delete,
+	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = ldp_zebra_read_route,
+	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = ldp_zebra_read_route,
+	[ZEBRA_PW_STATUS_UPDATE] = ldp_zebra_read_pw_status_update,
+	[ZEBRA_OPAQUE_MESSAGE] = ldp_zebra_opaque_msg_handler,
+};
+
 void
 ldp_zebra_init(struct thread_master *master)
 {
@@ -701,18 +711,12 @@ ldp_zebra_init(struct thread_master *master)
 			  ldp_ifp_down, ldp_ifp_destroy);
 
 	/* Set default values. */
-	zclient = zclient_new(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default, ldp_handlers,
+			      array_size(ldp_handlers));
 	zclient_init(zclient, ZEBRA_ROUTE_LDP, 0, &ldpd_privs);
 
 	/* set callbacks */
 	zclient->zebra_connected = ldp_zebra_connected;
-	zclient->router_id_update = ldp_router_id_update;
-	zclient->interface_address_add = ldp_interface_address_add;
-	zclient->interface_address_delete = ldp_interface_address_delete;
-	zclient->redistribute_route_add = ldp_zebra_read_route;
-	zclient->redistribute_route_del = ldp_zebra_read_route;
-	zclient->pw_status_update = ldp_zebra_read_pw_status_update;
-	zclient->opaque_msg_handler = ldp_zebra_opaque_msg_handler;
 
 	/* Access list initialize. */
 	access_list_add_hook(ldp_zebra_filter_update);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -21,6 +21,8 @@
 #ifndef _ZEBRA_ZCLIENT_H
 #define _ZEBRA_ZCLIENT_H
 
+struct zclient;
+
 /* For struct zapi_route. */
 #include "prefix.h"
 #include "ipaddr.h"
@@ -284,6 +286,14 @@ struct zapi_cap {
 	vrf_id_t vrf_id;
 };
 
+/* clang-format off */
+#define ZAPI_CALLBACK_ARGS                                                     \
+	int cmd, struct zclient *zclient, uint16_t length, vrf_id_t vrf_id
+
+/* function-type typedef (pointer not included) */
+typedef int (zclient_handler)(ZAPI_CALLBACK_ARGS);
+/* clang-format on */
+
 /* Structure for the zebra client. */
 struct zclient {
 	/* The thread master we schedule ourselves on */
@@ -297,6 +307,9 @@ struct zclient {
 
 	/* Is this a synchronous client? */
 	bool synchronous;
+
+	/* BFD enabled with bfd_protocol_integration_init() */
+	bool bfd_integration;
 
 	/* Session id (optional) to support clients with multiple sessions */
 	uint32_t session_id;
@@ -332,12 +345,11 @@ struct zclient {
 	/* Redistribute defauilt. */
 	vrf_bitmap_t default_information[AFI_MAX];
 
-#define ZAPI_CALLBACK_ARGS                                                     \
-	int cmd, struct zclient *zclient, uint16_t length, vrf_id_t vrf_id
-
 	/* Pointer to the callback functions. */
 	void (*zebra_connected)(struct zclient *);
 	void (*zebra_capabilities)(struct zclient_capabilities *cap);
+
+	int (*handle_error)(enum zebra_error_types error);
 
 	/*
 	 * When the zclient attempts to write the stream data to
@@ -350,60 +362,14 @@ struct zclient {
 	 * more data.
 	 */
 	void (*zebra_buffer_write_ready)(void);
-	int (*router_id_update)(ZAPI_CALLBACK_ARGS);
-	int (*interface_address_add)(ZAPI_CALLBACK_ARGS);
-	int (*interface_address_delete)(ZAPI_CALLBACK_ARGS);
-	int (*interface_link_params)(ZAPI_CALLBACK_ARGS);
-	int (*interface_bfd_dest_update)(ZAPI_CALLBACK_ARGS);
-	int (*interface_nbr_address_add)(ZAPI_CALLBACK_ARGS);
-	int (*interface_nbr_address_delete)(ZAPI_CALLBACK_ARGS);
-	int (*interface_vrf_update)(ZAPI_CALLBACK_ARGS);
-	int (*nexthop_update)(ZAPI_CALLBACK_ARGS);
-	int (*bfd_dest_replay)(ZAPI_CALLBACK_ARGS);
-	int (*redistribute_route_add)(ZAPI_CALLBACK_ARGS);
-	int (*redistribute_route_del)(ZAPI_CALLBACK_ARGS);
-	int (*fec_update)(int, struct zclient *, uint16_t);
-	int (*local_es_add)(ZAPI_CALLBACK_ARGS);
-	int (*local_es_del)(ZAPI_CALLBACK_ARGS);
-	int (*local_es_evi_add)(ZAPI_CALLBACK_ARGS);
-	int (*local_es_evi_del)(ZAPI_CALLBACK_ARGS);
-	int (*local_vni_add)(ZAPI_CALLBACK_ARGS);
-	int (*local_vni_del)(ZAPI_CALLBACK_ARGS);
-	int (*local_l3vni_add)(ZAPI_CALLBACK_ARGS);
-	int (*local_l3vni_del)(ZAPI_CALLBACK_ARGS);
-	void (*local_ip_prefix_add)(ZAPI_CALLBACK_ARGS);
-	void (*local_ip_prefix_del)(ZAPI_CALLBACK_ARGS);
-	int (*local_macip_add)(ZAPI_CALLBACK_ARGS);
-	int (*local_macip_del)(ZAPI_CALLBACK_ARGS);
-	int (*pw_status_update)(ZAPI_CALLBACK_ARGS);
-	int (*route_notify_owner)(ZAPI_CALLBACK_ARGS);
-	int (*rule_notify_owner)(ZAPI_CALLBACK_ARGS);
-	void (*label_chunk)(ZAPI_CALLBACK_ARGS);
-	int (*ipset_notify_owner)(ZAPI_CALLBACK_ARGS);
-	int (*ipset_entry_notify_owner)(ZAPI_CALLBACK_ARGS);
-	int (*iptable_notify_owner)(ZAPI_CALLBACK_ARGS);
-	int (*vxlan_sg_add)(ZAPI_CALLBACK_ARGS);
-	int (*vxlan_sg_del)(ZAPI_CALLBACK_ARGS);
-	int (*mlag_process_up)(void);
-	int (*mlag_process_down)(void);
-	int (*mlag_handle_msg)(struct stream *msg, int len);
-	int (*nhg_notify_owner)(ZAPI_CALLBACK_ARGS);
-	int (*srv6_locator_add)(ZAPI_CALLBACK_ARGS);
-	int (*srv6_locator_delete)(ZAPI_CALLBACK_ARGS);
-	int (*srv6_function_add)(ZAPI_CALLBACK_ARGS);
-	int (*srv6_function_delete)(ZAPI_CALLBACK_ARGS);
-	void (*process_srv6_locator_chunk)(ZAPI_CALLBACK_ARGS);
-	int (*handle_error)(enum zebra_error_types error);
-	int (*opaque_msg_handler)(ZAPI_CALLBACK_ARGS);
-	int (*opaque_register_handler)(ZAPI_CALLBACK_ARGS);
-	int (*opaque_unregister_handler)(ZAPI_CALLBACK_ARGS);
-	int (*sr_policy_notify_status)(ZAPI_CALLBACK_ARGS);
-	int (*zebra_client_close_notify)(ZAPI_CALLBACK_ARGS);
-	void (*neighbor_added)(ZAPI_CALLBACK_ARGS);
-	void (*neighbor_removed)(ZAPI_CALLBACK_ARGS);
-	void (*neighbor_get)(ZAPI_CALLBACK_ARGS);
-	void (*gre_update)(ZAPI_CALLBACK_ARGS);
+
+	zclient_handler *const *handlers;
+	size_t n_handlers;
 };
+
+/* lib handlers added in bfd.c */
+extern int zclient_bfd_session_reply(ZAPI_CALLBACK_ARGS);
+extern int zclient_bfd_session_update(ZAPI_CALLBACK_ARGS);
 
 /* Zebra API message flag. */
 #define ZAPI_MESSAGE_NEXTHOP  0x01
@@ -893,7 +859,9 @@ int zclient_neigh_ip_encode(struct stream *s, uint16_t cmd, union sockunion *in,
 extern uint32_t zclient_get_nhg_start(uint32_t proto);
 
 extern struct zclient *zclient_new(struct thread_master *m,
-				   struct zclient_options *opt);
+				   struct zclient_options *opt,
+				   zclient_handler *const *handlers,
+				   size_t n_handlers);
 
 extern void zclient_init(struct zclient *, int, unsigned short,
 			 struct zebra_privs_t *privs);

--- a/nhrpd/netlink_arp.c
+++ b/nhrpd/netlink_arp.c
@@ -147,7 +147,7 @@ void netlink_set_nflog_group(int nlgroup)
 	}
 }
 
-void nhrp_neighbor_operation(ZAPI_CALLBACK_ARGS)
+int nhrp_neighbor_operation(ZAPI_CALLBACK_ARGS)
 {
 	union sockunion addr = {}, lladdr = {};
 	struct interface *ifp;
@@ -157,7 +157,7 @@ void nhrp_neighbor_operation(ZAPI_CALLBACK_ARGS)
 
 	zclient_neigh_ip_decode(zclient->ibuf, &api);
 	if (api.ip_in.ipa_type == AF_UNSPEC)
-		return;
+		return 0;
 	sockunion_family(&addr) = api.ip_in.ipa_type;
 	memcpy((uint8_t *)sockunion_get_addr(&addr), &api.ip_in.ip.addr,
 	       family2addrsize(api.ip_in.ipa_type));
@@ -172,10 +172,10 @@ void nhrp_neighbor_operation(ZAPI_CALLBACK_ARGS)
 	ndm_state = api.ndm_state;
 
 	if (!ifp)
-		return;
+		return 0;
 	c = nhrp_cache_get(ifp, &addr, 0);
 	if (!c)
-		return;
+		return 0;
 	debugf(NHRP_DEBUG_KERNEL,
 	       "Netlink: %s %pSU dev %s lladdr %pSU nud 0x%x cache used %u type %u",
 	       (cmd == ZEBRA_NHRP_NEIGH_GET)
@@ -200,4 +200,5 @@ void nhrp_neighbor_operation(ZAPI_CALLBACK_ARGS)
 			: ZEBRA_NEIGH_STATE_FAILED;
 		nhrp_cache_set_used(c, state == ZEBRA_NEIGH_STATE_REACHABLE);
 	}
+	return 0;
 }

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -363,8 +363,8 @@ int nhrp_interface_up(ZAPI_CALLBACK_ARGS);
 int nhrp_interface_down(ZAPI_CALLBACK_ARGS);
 int nhrp_interface_address_add(ZAPI_CALLBACK_ARGS);
 int nhrp_interface_address_delete(ZAPI_CALLBACK_ARGS);
-void nhrp_neighbor_operation(ZAPI_CALLBACK_ARGS);
-void nhrp_gre_update(ZAPI_CALLBACK_ARGS);
+int nhrp_neighbor_operation(ZAPI_CALLBACK_ARGS);
+int nhrp_gre_update(ZAPI_CALLBACK_ARGS);
 
 void nhrp_interface_notify_add(struct interface *ifp, struct notifier_block *n,
 			       notifier_fn_t fn);

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -709,19 +709,22 @@ static void ospf6_zebra_connected(struct zclient *zclient)
 	zclient_send_reg_requests(zclient, VRF_DEFAULT);
 }
 
+static zclient_handler *const ospf6_handlers[] = {
+	[ZEBRA_ROUTER_ID_UPDATE] = ospf6_router_id_update_zebra,
+	[ZEBRA_INTERFACE_ADDRESS_ADD] = ospf6_zebra_if_address_update_add,
+	[ZEBRA_INTERFACE_ADDRESS_DELETE] = ospf6_zebra_if_address_update_delete,
+	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = ospf6_zebra_read_route,
+	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = ospf6_zebra_read_route,
+	[ZEBRA_NEXTHOP_UPDATE] = ospf6_zebra_import_check_update,
+};
+
 void ospf6_zebra_init(struct thread_master *master)
 {
 	/* Allocate zebra structure. */
-	zclient = zclient_new(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default, ospf6_handlers,
+			      array_size(ospf6_handlers));
 	zclient_init(zclient, ZEBRA_ROUTE_OSPF6, 0, &ospf6d_privs);
 	zclient->zebra_connected = ospf6_zebra_connected;
-	zclient->router_id_update = ospf6_router_id_update_zebra;
-	zclient->interface_address_add = ospf6_zebra_if_address_update_add;
-	zclient->interface_address_delete =
-		ospf6_zebra_if_address_update_delete;
-	zclient->redistribute_route_add = ospf6_zebra_read_route;
-	zclient->redistribute_route_del = ospf6_zebra_read_route;
-	zclient->nexthop_update = ospf6_zebra_import_check_update;
 
 	/* Install command element for zebra node. */
 	install_element(VIEW_NODE, &show_ospf6_zebra_cmd);

--- a/pathd/path_zebra.c
+++ b/pathd/path_zebra.c
@@ -320,6 +320,12 @@ static int path_zebra_opaque_msg_handler(ZAPI_CALLBACK_ARGS)
 	return ret;
 }
 
+static zclient_handler *const path_handlers[] = {
+	[ZEBRA_SR_POLICY_NOTIFY_STATUS] = path_zebra_sr_policy_notify_status,
+	[ZEBRA_ROUTER_ID_UPDATE] = path_zebra_router_id_update,
+	[ZEBRA_OPAQUE_MESSAGE] = path_zebra_opaque_msg_handler,
+};
+
 /**
  * Initializes Zebra asynchronous connection.
  *
@@ -331,15 +337,13 @@ void path_zebra_init(struct thread_master *master)
 	options.synchronous = true;
 
 	/* Initialize asynchronous zclient. */
-	zclient = zclient_new(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default, path_handlers,
+			      array_size(path_handlers));
 	zclient_init(zclient, ZEBRA_ROUTE_SRTE, 0, &pathd_privs);
 	zclient->zebra_connected = path_zebra_connected;
-	zclient->sr_policy_notify_status = path_zebra_sr_policy_notify_status;
-	zclient->router_id_update = path_zebra_router_id_update;
-	zclient->opaque_msg_handler = path_zebra_opaque_msg_handler;
 
 	/* Initialize special zclient for synchronous message exchanges. */
-	zclient_sync = zclient_new(master, &options);
+	zclient_sync = zclient_new(master, &options, NULL, 0);
 	zclient_sync->sock = -1;
 	zclient_sync->redist_default = ZEBRA_ROUTE_SRTE;
 	zclient_sync->instance = 1;

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -429,20 +429,24 @@ static int pbr_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
 
 extern struct zebra_privs_t pbr_privs;
 
+static zclient_handler *const pbr_handlers[] = {
+	[ZEBRA_INTERFACE_ADDRESS_ADD] = interface_address_add,
+	[ZEBRA_INTERFACE_ADDRESS_DELETE] = interface_address_delete,
+	[ZEBRA_INTERFACE_VRF_UPDATE] = interface_vrf_update,
+	[ZEBRA_ROUTE_NOTIFY_OWNER] = route_notify_owner,
+	[ZEBRA_RULE_NOTIFY_OWNER] = rule_notify_owner,
+	[ZEBRA_NEXTHOP_UPDATE] = pbr_zebra_nexthop_update,
+};
+
 void pbr_zebra_init(void)
 {
 	struct zclient_options opt = { .receive_notify = true };
 
-	zclient = zclient_new(master, &opt);
+	zclient = zclient_new(master, &opt, pbr_handlers,
+			      array_size(pbr_handlers));
 
 	zclient_init(zclient, ZEBRA_ROUTE_PBR, 0, &pbr_privs);
 	zclient->zebra_connected = zebra_connected;
-	zclient->interface_address_add = interface_address_add;
-	zclient->interface_address_delete = interface_address_delete;
-	zclient->interface_vrf_update = interface_vrf_update;
-	zclient->route_notify_owner = route_notify_owner;
-	zclient->rule_notify_owner = rule_notify_owner;
-	zclient->nexthop_update = pbr_zebra_nexthop_update;
 }
 
 void pbr_send_rnh(struct nexthop *nhop, bool reg)

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -791,8 +791,10 @@ static void pim_mlag_process_mroute_del(struct mlag_mroute_del msg)
 	pim_mlag_up_peer_del(&msg);
 }
 
-int pim_zebra_mlag_handle_msg(struct stream *s, int len)
+int pim_zebra_mlag_handle_msg(int cmd, struct zclient *zclient,
+			      uint16_t zapi_length, vrf_id_t vrf_id)
 {
+	struct stream *s = zclient->ibuf;
 	struct mlag_msg mlag_msg;
 	char buf[80];
 	int rc = 0;
@@ -880,7 +882,7 @@ int pim_zebra_mlag_handle_msg(struct stream *s, int len)
 
 /****************End of PIM Mesasge processing handler********************/
 
-int pim_zebra_mlag_process_up(void)
+int pim_zebra_mlag_process_up(ZAPI_CALLBACK_ARGS)
 {
 	if (PIM_DEBUG_MLAG)
 		zlog_debug("%s: Received Process-Up from Mlag", __func__);
@@ -908,7 +910,7 @@ static void pim_mlag_param_reset(void)
 	router->peerlink_rif[0] = '\0';
 }
 
-int pim_zebra_mlag_process_down(void)
+int pim_zebra_mlag_process_down(ZAPI_CALLBACK_ARGS)
 {
 	if (PIM_DEBUG_MLAG)
 		zlog_debug("%s: Received Process-Down from Mlag", __func__);

--- a/pimd/pim_mlag.h
+++ b/pimd/pim_mlag.h
@@ -24,6 +24,7 @@
 #ifndef __PIM_MLAG_H__
 #define __PIM_MLAG_H__
 
+#include "zclient.h"
 #include "mlag.h"
 #include "pim_iface.h"
 
@@ -33,9 +34,9 @@ extern void pim_instance_mlag_init(struct pim_instance *pim);
 extern void pim_instance_mlag_terminate(struct pim_instance *pim);
 extern void pim_if_configure_mlag_dualactive(struct pim_interface *pim_ifp);
 extern void pim_if_unconfigure_mlag_dualactive(struct pim_interface *pim_ifp);
-extern int pim_zebra_mlag_process_up(void);
-extern int pim_zebra_mlag_process_down(void);
-extern int pim_zebra_mlag_handle_msg(struct stream *msg, int len);
+extern int pim_zebra_mlag_process_up(ZAPI_CALLBACK_ARGS);
+extern int pim_zebra_mlag_process_down(ZAPI_CALLBACK_ARGS);
+extern int pim_zebra_mlag_handle_msg(ZAPI_CALLBACK_ARGS);
 
 /* pm_zpthread.c */
 extern int pim_mlag_signal_zpthread(void);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -439,23 +439,29 @@ static void pim_zebra_capabilities(struct zclient_capabilities *cap)
 	router->mlag_role = cap->role;
 }
 
+static zclient_handler *const pim_handlers[] = {
+	[ZEBRA_ROUTER_ID_UPDATE] = pim_router_id_update_zebra,
+	[ZEBRA_INTERFACE_ADDRESS_ADD] = pim_zebra_if_address_add,
+	[ZEBRA_INTERFACE_ADDRESS_DELETE] = pim_zebra_if_address_del,
+	[ZEBRA_INTERFACE_VRF_UPDATE] = pim_zebra_interface_vrf_update,
+	[ZEBRA_NEXTHOP_UPDATE] = pim_parse_nexthop_update,
+
+	[ZEBRA_VXLAN_SG_ADD] = pim_zebra_vxlan_sg_proc,
+	[ZEBRA_VXLAN_SG_DEL] = pim_zebra_vxlan_sg_proc,
+
+	[ZEBRA_MLAG_PROCESS_UP] = pim_zebra_mlag_process_up,
+	[ZEBRA_MLAG_PROCESS_DOWN] = pim_zebra_mlag_process_down,
+	[ZEBRA_MLAG_FORWARD_MSG] = pim_zebra_mlag_handle_msg,
+};
+
 void pim_zebra_init(void)
 {
 	/* Socket for receiving updates from Zebra daemon */
-	zclient = zclient_new(router->master, &zclient_options_default);
+	zclient = zclient_new(router->master, &zclient_options_default,
+			      pim_handlers, array_size(pim_handlers));
 
 	zclient->zebra_capabilities = pim_zebra_capabilities;
 	zclient->zebra_connected = pim_zebra_connected;
-	zclient->router_id_update = pim_router_id_update_zebra;
-	zclient->interface_address_add = pim_zebra_if_address_add;
-	zclient->interface_address_delete = pim_zebra_if_address_del;
-	zclient->interface_vrf_update = pim_zebra_interface_vrf_update;
-	zclient->nexthop_update = pim_parse_nexthop_update;
-	zclient->vxlan_sg_add = pim_zebra_vxlan_sg_proc;
-	zclient->vxlan_sg_del = pim_zebra_vxlan_sg_proc;
-	zclient->mlag_process_up = pim_zebra_mlag_process_up;
-	zclient->mlag_process_down = pim_zebra_mlag_process_down;
-	zclient->mlag_handle_msg = pim_zebra_mlag_handle_msg;
 
 	zclient_init(zclient, ZEBRA_ROUTE_PIM, 0, &pimd_privs);
 	if (PIM_DEBUG_PIM_TRACE) {

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -137,7 +137,7 @@ void zclient_lookup_new(void)
 	struct zclient_options options = zclient_options_default;
 	options.synchronous = true;
 
-	zlookup = zclient_new(router->master, &options);
+	zlookup = zclient_new(router->master, &options, NULL, 0);
 	if (!zlookup) {
 		flog_err(EC_LIB_ZAPI_SOCKET, "%s: zclient_new() failure",
 			 __func__);

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -230,17 +230,21 @@ static void rip_zebra_connected(struct zclient *zclient)
 	zclient_send_reg_requests(zclient, VRF_DEFAULT);
 }
 
+zclient_handler *const rip_handlers[] = {
+	[ZEBRA_INTERFACE_ADDRESS_ADD] = rip_interface_address_add,
+	[ZEBRA_INTERFACE_ADDRESS_DELETE] = rip_interface_address_delete,
+	[ZEBRA_INTERFACE_VRF_UPDATE] = rip_interface_vrf_update,
+	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = rip_zebra_read_route,
+	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = rip_zebra_read_route,
+};
+
 void rip_zclient_init(struct thread_master *master)
 {
 	/* Set default value to the zebra client structure. */
-	zclient = zclient_new(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default, rip_handlers,
+			      array_size(rip_handlers));
 	zclient_init(zclient, ZEBRA_ROUTE_RIP, 0, &ripd_privs);
 	zclient->zebra_connected = rip_zebra_connected;
-	zclient->interface_address_add = rip_interface_address_add;
-	zclient->interface_address_delete = rip_interface_address_delete;
-	zclient->interface_vrf_update = rip_interface_vrf_update;
-	zclient->redistribute_route_add = rip_zebra_read_route;
-	zclient->redistribute_route_del = rip_zebra_read_route;
 }
 
 void rip_zclient_stop(void)

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -234,19 +234,23 @@ static void ripng_zebra_connected(struct zclient *zclient)
 	zclient_send_reg_requests(zclient, VRF_DEFAULT);
 }
 
+static zclient_handler *const ripng_handlers[] = {
+	[ZEBRA_INTERFACE_ADDRESS_ADD] = ripng_interface_address_add,
+	[ZEBRA_INTERFACE_ADDRESS_DELETE] = ripng_interface_address_delete,
+	[ZEBRA_INTERFACE_VRF_UPDATE] = ripng_interface_vrf_update,
+	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = ripng_zebra_read_route,
+	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = ripng_zebra_read_route,
+};
+
 /* Initialize zebra structure and it's commands. */
 void zebra_init(struct thread_master *master)
 {
 	/* Allocate zebra structure. */
-	zclient = zclient_new(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default, ripng_handlers,
+			      array_size(ripng_handlers));
 	zclient_init(zclient, ZEBRA_ROUTE_RIPNG, 0, &ripngd_privs);
 
 	zclient->zebra_connected = ripng_zebra_connected;
-	zclient->interface_address_add = ripng_interface_address_add;
-	zclient->interface_address_delete = ripng_interface_address_delete;
-	zclient->interface_vrf_update = ripng_interface_vrf_update;
-	zclient->redistribute_route_add = ripng_zebra_read_route;
-	zclient->redistribute_route_del = ripng_zebra_read_route;
 }
 
 void ripng_zebra_stop(void)

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -720,6 +720,10 @@ void sharp_redistribute_vrf(struct vrf *vrf, int type)
 				0, vrf->vrf_id);
 }
 
+static zclient_handler *const sharp_opaque_handlers[] = {
+	[ZEBRA_OPAQUE_MESSAGE] = sharp_opaque_handler,
+};
+
 /* Add a zclient with a specified session id, for testing. */
 int sharp_zclient_create(uint32_t session_id)
 {
@@ -732,14 +736,13 @@ int sharp_zclient_create(uint32_t session_id)
 			return -1;
 	}
 
-	client = zclient_new(master, &zclient_options_default);
+	client = zclient_new(master, &zclient_options_default,
+			     sharp_opaque_handlers,
+			     array_size(sharp_opaque_handlers));
 	client->sock = -1;
 	client->session_id = session_id;
 
 	zclient_init(client, ZEBRA_ROUTE_SHARP, 0, &sharp_privs);
-
-	/* Register handlers for messages we expect this session to see */
-	client->opaque_msg_handler = sharp_opaque_handler;
 
 	/* Enqueue on the list of test clients */
 	add_zclient(client);
@@ -928,7 +931,7 @@ int sharp_zebra_srv6_manager_release_locator_chunk(const char *locator_name)
 	return srv6_manager_release_locator_chunk(zclient, locator_name);
 }
 
-static void sharp_zebra_process_srv6_locator_chunk(ZAPI_CALLBACK_ARGS)
+static int sharp_zebra_process_srv6_locator_chunk(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s = NULL;
 	struct srv6_locator_chunk s6c = {};
@@ -951,16 +954,30 @@ static void sharp_zebra_process_srv6_locator_chunk(ZAPI_CALLBACK_ARGS)
 
 		for (ALL_LIST_ELEMENTS_RO(loc->chunks, chunk_node, c))
 			if (!prefix_cmp(c, &s6c.prefix))
-				return;
+				return 0;
 
 		chunk = prefix_ipv6_new();
 		*chunk = s6c.prefix;
 		listnode_add(loc->chunks, chunk);
-		return;
+		return 0;
 	}
 
 	zlog_err("%s: can't get locator_chunk!!", __func__);
+	return 0;
 }
+
+static zclient_handler *const sharp_handlers[] = {
+	[ZEBRA_INTERFACE_ADDRESS_ADD] = interface_address_add,
+	[ZEBRA_INTERFACE_ADDRESS_DELETE] = interface_address_delete,
+	[ZEBRA_ROUTE_NOTIFY_OWNER] = route_notify_owner,
+	[ZEBRA_NEXTHOP_UPDATE] = sharp_nexthop_update,
+	[ZEBRA_NHG_NOTIFY_OWNER] = nhg_notify_owner,
+	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = sharp_redistribute_route,
+	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = sharp_redistribute_route,
+	[ZEBRA_OPAQUE_MESSAGE] = sharp_opaque_handler,
+	[ZEBRA_SRV6_MANAGER_GET_LOCATOR_CHUNK] =
+		sharp_zebra_process_srv6_locator_chunk,
+};
 
 void sharp_zebra_init(void)
 {
@@ -969,19 +986,10 @@ void sharp_zebra_init(void)
 	if_zapi_callbacks(sharp_ifp_create, sharp_ifp_up,
 			  sharp_ifp_down, sharp_ifp_destroy);
 
-	zclient = zclient_new(master, &opt);
+	zclient = zclient_new(master, &opt, sharp_handlers,
+			      array_size(sharp_handlers));
 
 	zclient_init(zclient, ZEBRA_ROUTE_SHARP, 0, &sharp_privs);
 	zclient->zebra_connected = zebra_connected;
-	zclient->interface_address_add = interface_address_add;
-	zclient->interface_address_delete = interface_address_delete;
-	zclient->route_notify_owner = route_notify_owner;
-	zclient->nexthop_update = sharp_nexthop_update;
-	zclient->nhg_notify_owner = nhg_notify_owner;
 	zclient->zebra_buffer_write_ready = sharp_zclient_buffer_ready;
-	zclient->redistribute_route_add = sharp_redistribute_route;
-	zclient->redistribute_route_del = sharp_redistribute_route;
-	zclient->opaque_msg_handler = sharp_opaque_handler;
-	zclient->process_srv6_locator_chunk =
-		sharp_zebra_process_srv6_locator_chunk;
 }

--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -392,7 +392,7 @@ static int global_test_init(void)
 {
 	qobj_init();
 	master = thread_master_create(NULL);
-	zclient = zclient_new(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default, NULL, 0);
 	bgp_master_init(master, BGP_SOCKET_SNDBUF_SIZE, list_new());
 	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);


### PR DESCRIPTION
This removes a giant `switch { }` block from lib/zclient.c and
harmonizes all zclient callback function types to be the same (some had
a subset of the args, some had a void return, now they all have
ZAPI_CALLBACK_ARGS and int return.)

Apart from getting rid of the giant switch, this is a minor security
benefit since the function pointers are now in a `const` array, so they
can't be overwritten by e.g. heap overflows for code execution anymore.