### PR TITLE
tests: Remove debugs from topotests

### DIFF
--- a/tests/topotests/all_protocol_startup/r1/isisd.conf
+++ b/tests/topotests/all_protocol_startup/r1/isisd.conf
@@ -1,6 +1,6 @@
 log file isisd.log
 !
-debug isis events
+! debug isis events
 !
 !
 interface r1-eth5

--- a/tests/topotests/all_protocol_startup/r1/ldpd.conf
+++ b/tests/topotests/all_protocol_startup/r1/ldpd.conf
@@ -1,7 +1,7 @@
 log file ldpd.log
 !
-debug mpls ldp event
-debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp zebra
 !
 !
 mpls ldp

--- a/tests/topotests/all_protocol_startup/r1/ospf6d.conf
+++ b/tests/topotests/all_protocol_startup/r1/ospf6d.conf
@@ -1,9 +1,9 @@
 log file ospf6d.log
 !
-debug ospf6 lsa unknown
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
 !
 interface r1-eth4
 !

--- a/tests/topotests/all_protocol_startup/r1/ospfd.conf
+++ b/tests/topotests/all_protocol_startup/r1/ospfd.conf
@@ -1,7 +1,7 @@
 log file ospfd.log
 !
-debug ospf event
-debug ospf zebra
+! debug ospf event
+! debug ospf zebra
 !
 router ospf
  ospf router-id 192.168.0.1

--- a/tests/topotests/all_protocol_startup/r1/ripd.conf
+++ b/tests/topotests/all_protocol_startup/r1/ripd.conf
@@ -1,7 +1,7 @@
 log file ripd.log
 !
-debug rip events
-debug rip zebra
+! debug rip events
+! debug rip zebra
 !
 router rip
  version 2

--- a/tests/topotests/all_protocol_startup/r1/ripngd.conf
+++ b/tests/topotests/all_protocol_startup/r1/ripngd.conf
@@ -1,7 +1,7 @@
 log file ripngd.log
 !
-debug ripng events
-debug ripng zebra
+! debug ripng events
+! debug ripng zebra
 !
 router ripng
  network fc00:0:0:2::/64

--- a/tests/topotests/bfd_bgp_cbit_topo3/r1/bfdd.conf
+++ b/tests/topotests/bfd_bgp_cbit_topo3/r1/bfdd.conf
@@ -1,5 +1,5 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !

--- a/tests/topotests/bfd_bgp_cbit_topo3/r1/bgpd.conf
+++ b/tests/topotests/bfd_bgp_cbit_topo3/r1/bgpd.conf
@@ -1,4 +1,4 @@
-debug bgp neighbor-events
+! debug bgp neighbor-events
 router bgp 101
  bgp router-id 10.254.254.1
  no bgp ebgp-requires-policy

--- a/tests/topotests/bfd_bgp_cbit_topo3/r3/bfdd.conf
+++ b/tests/topotests/bfd_bgp_cbit_topo3/r3/bfdd.conf
@@ -1,5 +1,5 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !

--- a/tests/topotests/bfd_bgp_cbit_topo3/r3/bgpd.conf
+++ b/tests/topotests/bfd_bgp_cbit_topo3/r3/bgpd.conf
@@ -1,4 +1,4 @@
-debug bgp neighbor-events
+! debug bgp neighbor-events
 router bgp 102
  bgp router-id 10.254.254.3
  no bgp ebgp-requires-policy

--- a/tests/topotests/bfd_isis_topo1/rt1/bfdd.conf
+++ b/tests/topotests/bfd_isis_topo1/rt1/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 10.0.1.2 interface eth-rt2

--- a/tests/topotests/bfd_isis_topo1/rt1/isisd.conf
+++ b/tests/topotests/bfd_isis_topo1/rt1/isisd.conf
@@ -5,11 +5,11 @@ hostname rt1
 !
 password 1
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis adj-packets
-debug isis lsp-sched
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis adj-packets
+! debug isis lsp-sched
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/bfd_isis_topo1/rt1/zebra.conf
+++ b/tests/topotests/bfd_isis_topo1/rt1/zebra.conf
@@ -3,10 +3,10 @@ log timestamp precision 3
 !
 hostname rt1
 !
-debug zebra kernel
-debug zebra packet
-debug zebra events
-debug zebra rib
+! debug zebra kernel
+! debug zebra packet
+! debug zebra events
+! debug zebra rib
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/bfd_isis_topo1/rt2/bfdd.conf
+++ b/tests/topotests/bfd_isis_topo1/rt2/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 10.0.1.1 interface eth-rt1

--- a/tests/topotests/bfd_isis_topo1/rt2/isisd.conf
+++ b/tests/topotests/bfd_isis_topo1/rt2/isisd.conf
@@ -4,9 +4,9 @@ hostname rt2
 !
 password 1
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/bfd_isis_topo1/rt2/zebra.conf
+++ b/tests/topotests/bfd_isis_topo1/rt2/zebra.conf
@@ -2,8 +2,8 @@ log file zebra.log
 !
 hostname rt2
 !
-debug zebra kernel
-debug zebra packet
+! debug zebra kernel
+! debug zebra packet
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/bfd_isis_topo1/rt3/bfdd.conf
+++ b/tests/topotests/bfd_isis_topo1/rt3/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 10.0.2.1 interface eth-rt1

--- a/tests/topotests/bfd_isis_topo1/rt3/isisd.conf
+++ b/tests/topotests/bfd_isis_topo1/rt3/isisd.conf
@@ -4,9 +4,9 @@ hostname rt3
 !
 password 1
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/bfd_isis_topo1/rt3/zebra.conf
+++ b/tests/topotests/bfd_isis_topo1/rt3/zebra.conf
@@ -2,8 +2,8 @@ log file zebra.log
 !
 hostname rt3
 !
-debug zebra kernel
-debug zebra packet
+! debug zebra kernel
+! debug zebra packet
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/bfd_isis_topo1/rt4/bfdd.conf
+++ b/tests/topotests/bfd_isis_topo1/rt4/bfdd.conf
@@ -1,5 +1,5 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !

--- a/tests/topotests/bfd_isis_topo1/rt4/isisd.conf
+++ b/tests/topotests/bfd_isis_topo1/rt4/isisd.conf
@@ -4,9 +4,9 @@ hostname rt4
 !
 password 1
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/bfd_isis_topo1/rt4/zebra.conf
+++ b/tests/topotests/bfd_isis_topo1/rt4/zebra.conf
@@ -2,8 +2,8 @@ log file zebra.log
 !
 hostname rt4
 !
-debug zebra kernel
-debug zebra packet
+! debug zebra kernel
+! debug zebra packet
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/bfd_isis_topo1/rt5/bfdd.conf
+++ b/tests/topotests/bfd_isis_topo1/rt5/bfdd.conf
@@ -1,5 +1,5 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !

--- a/tests/topotests/bfd_isis_topo1/rt5/isisd.conf
+++ b/tests/topotests/bfd_isis_topo1/rt5/isisd.conf
@@ -4,9 +4,9 @@ hostname rt5
 !
 password 1
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/bfd_isis_topo1/rt5/zebra.conf
+++ b/tests/topotests/bfd_isis_topo1/rt5/zebra.conf
@@ -2,8 +2,8 @@ log file zebra.log
 !
 hostname rt5
 !
-debug zebra kernel
-debug zebra packet
+! debug zebra kernel
+! debug zebra packet
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/bfd_ospf_topo1/rt1/bfdd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt1/bfdd.conf
@@ -1,9 +1,9 @@
 log file bfdd.log
 log timestamp precision 3
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
 !

--- a/tests/topotests/bfd_ospf_topo1/rt1/ospfd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt1/ospfd.conf
@@ -5,8 +5,8 @@ hostname rt1
 !
 password 1
 !
-debug ospf event
-debug ospf zebra
+! debug ospf event
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/bfd_ospf_topo1/rt1/zebra.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt1/zebra.conf
@@ -3,10 +3,10 @@ log timestamp precision 3
 !
 hostname rt1
 !
-debug zebra kernel
-debug zebra packet
-debug zebra events
-debug zebra rib
+! debug zebra kernel
+! debug zebra packet
+! debug zebra events
+! debug zebra rib
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/bfd_ospf_topo1/rt2/bfdd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt2/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
 !

--- a/tests/topotests/bfd_ospf_topo1/rt2/ospfd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt2/ospfd.conf
@@ -4,8 +4,8 @@ hostname rt2
 !
 password 1
 !
-debug ospf event
-debug ospf zebra
+! debug ospf event
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/bfd_ospf_topo1/rt2/zebra.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt2/zebra.conf
@@ -2,8 +2,8 @@ log file zebra.log
 !
 hostname rt2
 !
-debug zebra kernel
-debug zebra packet
+! debug zebra kernel
+! debug zebra packet
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/bfd_ospf_topo1/rt3/bfdd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt3/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
 !

--- a/tests/topotests/bfd_ospf_topo1/rt3/ospfd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt3/ospfd.conf
@@ -4,8 +4,8 @@ hostname rt3
 !
 password 1
 !
-debug ospf event
-debug ospf zebra
+! debug ospf event
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/bfd_ospf_topo1/rt3/zebra.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt3/zebra.conf
@@ -2,8 +2,8 @@ log file zebra.log
 !
 hostname rt3
 !
-debug zebra kernel
-debug zebra packet
+! debug zebra kernel
+! debug zebra packet
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/bfd_ospf_topo1/rt4/bfdd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt4/bfdd.conf
@@ -1,5 +1,5 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !

--- a/tests/topotests/bfd_ospf_topo1/rt4/ospfd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt4/ospfd.conf
@@ -4,8 +4,8 @@ hostname rt4
 !
 password 1
 !
-debug ospf event
-debug ospf zebra
+! debug ospf event
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/bfd_ospf_topo1/rt4/zebra.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt4/zebra.conf
@@ -2,8 +2,8 @@ log file zebra.log
 !
 hostname rt4
 !
-debug zebra kernel
-debug zebra packet
+! debug zebra kernel
+! debug zebra packet
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/bfd_ospf_topo1/rt5/bfdd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt5/bfdd.conf
@@ -1,5 +1,5 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !

--- a/tests/topotests/bfd_ospf_topo1/rt5/ospfd.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt5/ospfd.conf
@@ -4,8 +4,8 @@ hostname rt5
 !
 password 1
 !
-debug ospf event
-debug ospf zebra
+! debug ospf event
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/bfd_ospf_topo1/rt5/zebra.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt5/zebra.conf
@@ -2,8 +2,8 @@ log file zebra.log
 !
 hostname rt5
 !
-debug zebra kernel
-debug zebra packet
+! debug zebra kernel
+! debug zebra packet
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/bfd_profiles_topo1/r1/bfdd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r1/bfdd.conf
@@ -1,6 +1,6 @@
-debug bfd peer
-debug bfd network
-debug bfd zebra
+! debug bfd peer
+! debug bfd network
+! debug bfd zebra
 !
 bfd
  profile slowtx

--- a/tests/topotests/bfd_profiles_topo1/r2/bfdd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r2/bfdd.conf
@@ -1,6 +1,6 @@
-debug bfd peer
-debug bfd network
-debug bfd zebra
+! debug bfd peer
+! debug bfd network
+! debug bfd zebra
 !
 bfd
  profile slowtx

--- a/tests/topotests/bfd_profiles_topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r2/bgpd.conf
@@ -1,4 +1,4 @@
-debug bgp neighbor-events
+! debug bgp neighbor-events
 !
 router bgp 100
  bgp router-id 10.254.254.2

--- a/tests/topotests/bfd_profiles_topo1/r3/bfdd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r3/bfdd.conf
@@ -1,6 +1,6 @@
-debug bfd peer
-debug bfd network
-debug bfd zebra
+! debug bfd peer
+! debug bfd network
+! debug bfd zebra
 !
 bfd
  profile fasttx

--- a/tests/topotests/bfd_profiles_topo1/r3/isisd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r3/isisd.conf
@@ -1,8 +1,8 @@
 hostname r3
 !
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 !
 interface r3-eth1
  ipv6 router isis lan

--- a/tests/topotests/bfd_profiles_topo1/r4/bfdd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r4/bfdd.conf
@@ -1,6 +1,6 @@
-debug bfd peer
-debug bfd network
-debug bfd zebra
+! debug bfd peer
+! debug bfd network
+! debug bfd zebra
 !
 bfd
  profile fast-tx

--- a/tests/topotests/bfd_profiles_topo1/r4/bgpd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r4/bgpd.conf
@@ -1,4 +1,4 @@
-debug bgp neighbor-events
+! debug bgp neighbor-events
 !
 router bgp 200
  bgp router-id 10.254.254.4

--- a/tests/topotests/bfd_profiles_topo1/r4/isisd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r4/isisd.conf
@@ -1,8 +1,8 @@
 hostname r4
 !
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 !
 interface r4-eth0
  ipv6 router isis lan

--- a/tests/topotests/bfd_profiles_topo1/r5/bfdd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r5/bfdd.conf
@@ -1,6 +1,6 @@
-debug bfd peer
-debug bfd network
-debug bfd zebra
+! debug bfd peer
+! debug bfd network
+! debug bfd zebra
 !
 bfd
  ! profile is commented out on purpose.

--- a/tests/topotests/bfd_profiles_topo1/r6/bfdd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r6/bfdd.conf
@@ -1,6 +1,6 @@
-debug bfd peer
-debug bfd network
-debug bfd zebra
+! debug bfd peer
+! debug bfd network
+! debug bfd zebra
 !
 bfd
  ! profile is commented out on purpose.

--- a/tests/topotests/bfd_topo1/r1/bfdd.conf
+++ b/tests/topotests/bfd_topo1/r1/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 192.168.0.2

--- a/tests/topotests/bfd_topo1/r2/bfdd.conf
+++ b/tests/topotests/bfd_topo1/r2/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 192.168.0.1

--- a/tests/topotests/bfd_topo1/r3/bfdd.conf
+++ b/tests/topotests/bfd_topo1/r3/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 192.168.1.2

--- a/tests/topotests/bfd_topo1/r4/bfdd.conf
+++ b/tests/topotests/bfd_topo1/r4/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 192.168.2.2

--- a/tests/topotests/bfd_topo2/r1/bfdd.conf
+++ b/tests/topotests/bfd_topo2/r1/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 2001:db8:4::1 multihop local-address 2001:db8:1::1

--- a/tests/topotests/bfd_topo2/r2/bfdd.conf
+++ b/tests/topotests/bfd_topo2/r2/bfdd.conf
@@ -1,5 +1,5 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !

--- a/tests/topotests/bfd_topo2/r3/bfdd.conf
+++ b/tests/topotests/bfd_topo2/r3/bfdd.conf
@@ -1,5 +1,5 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !

--- a/tests/topotests/bfd_topo2/r4/bfdd.conf
+++ b/tests/topotests/bfd_topo2/r4/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 2001:db8:1::1 multihop local-address 2001:db8:4::1

--- a/tests/topotests/bfd_topo3/r1/bfdd.conf
+++ b/tests/topotests/bfd_topo3/r1/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  profile fast-tx

--- a/tests/topotests/bfd_topo3/r2/bfdd.conf
+++ b/tests/topotests/bfd_topo3/r2/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  profile fast-tx

--- a/tests/topotests/bfd_topo3/r3/bfdd.conf
+++ b/tests/topotests/bfd_topo3/r3/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  profile slow-tx

--- a/tests/topotests/bfd_topo3/r4/bfdd.conf
+++ b/tests/topotests/bfd_topo3/r4/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  profile slow-tx

--- a/tests/topotests/bfd_vrf_topo1/r1/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r1/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 192.168.0.2 vrf r1-bfd-cust1

--- a/tests/topotests/bfd_vrf_topo1/r2/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r2/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 192.168.0.1 vrf r2-bfd-cust1

--- a/tests/topotests/bfd_vrf_topo1/r3/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r3/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 192.168.1.2 vrf r3-bfd-cust1

--- a/tests/topotests/bfd_vrf_topo1/r4/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r4/bfdd.conf
@@ -1,7 +1,7 @@
 !
-debug bfd network
-debug bfd peer
-debug bfd zebra
+! debug bfd network
+! debug bfd peer
+! debug bfd zebra
 !
 bfd
  peer 192.168.2.2 vrf r4-bfd-cust1

--- a/tests/topotests/bgp_aggregate_address_topo1/r1/bgpd.conf
+++ b/tests/topotests/bgp_aggregate_address_topo1/r1/bgpd.conf
@@ -1,4 +1,4 @@
-debug bgp updates
+! debug bgp updates
 !
 access-list acl-sup-one seq 5 permit 192.168.2.1/32
 access-list acl-sup-one seq 10 deny any

--- a/tests/topotests/bgp_auth/R1/bgpd_multi_vrf.conf
+++ b/tests/topotests/bgp_auth/R1/bgpd_multi_vrf.conf
@@ -1,4 +1,4 @@
-debug bgp neighbor-events
+! debug bgp neighbor-events
 
 router bgp 65001 vrf blue
  timers bgp 3 9

--- a/tests/topotests/bgp_auth/R1/bgpd_vrf.conf
+++ b/tests/topotests/bgp_auth/R1/bgpd_vrf.conf
@@ -1,4 +1,4 @@
-debug bgp neighbor-events
+! debug bgp neighbor-events
 
 router bgp 65001 vrf blue
  timers bgp 3 9

--- a/tests/topotests/bgp_community_change_update/c1/bgpd.conf
+++ b/tests/topotests/bgp_community_change_update/c1/bgpd.conf
@@ -1,5 +1,5 @@
 !
-debug bgp updates
+! debug bgp updates
 !
 router bgp 65001
   no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_community_change_update/x1/bgpd.conf
+++ b/tests/topotests/bgp_community_change_update/x1/bgpd.conf
@@ -1,5 +1,5 @@
 !
-debug bgp updates
+! debug bgp updates
 !
 router bgp 65002
   no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_evpn_mh/torm11/evpn.conf
+++ b/tests/topotests/bgp_evpn_mh/torm11/evpn.conf
@@ -1,9 +1,9 @@
 !
 frr defaults datacenter
 !
-debug bgp evpn mh es
-debug bgp evpn mh route
-debug bgp zebra
+! debug bgp evpn mh es
+! debug bgp evpn mh route
+! debug bgp zebra
 !
 !
 router bgp 65002

--- a/tests/topotests/bgp_evpn_mh/torm11/zebra.conf
+++ b/tests/topotests/bgp_evpn_mh/torm11/zebra.conf
@@ -1,8 +1,8 @@
-debug zebra evpn mh es
-debug zebra evpn mh mac
-debug zebra evpn mh neigh
-debug zebra evpn mh nh
-debug zebra vxlan
+! debug zebra evpn mh es
+! debug zebra evpn mh mac
+! debug zebra evpn mh neigh
+! debug zebra evpn mh nh
+! debug zebra vxlan
 !
 evpn mh startup-delay 1
 !

--- a/tests/topotests/bgp_evpn_mh/torm12/evpn.conf
+++ b/tests/topotests/bgp_evpn_mh/torm12/evpn.conf
@@ -1,9 +1,9 @@
 !
 frr defaults datacenter
 !
-debug bgp evpn mh es
-debug bgp evpn mh route
-debug bgp zebra
+! debug bgp evpn mh es
+! debug bgp evpn mh route
+! debug bgp zebra
 !
 !
 router bgp 65003

--- a/tests/topotests/bgp_evpn_mh/torm12/zebra.conf
+++ b/tests/topotests/bgp_evpn_mh/torm12/zebra.conf
@@ -1,8 +1,8 @@
-debug zebra evpn mh es
-debug zebra evpn mh mac
-debug zebra evpn mh neigh
-debug zebra evpn mh nh
-debug zebra vxlan
+! debug zebra evpn mh es
+! debug zebra evpn mh mac
+! debug zebra evpn mh neigh
+! debug zebra evpn mh nh
+! debug zebra vxlan
 !
 evpn mh startup-delay 1
 !

--- a/tests/topotests/bgp_evpn_mh/torm21/evpn.conf
+++ b/tests/topotests/bgp_evpn_mh/torm21/evpn.conf
@@ -1,9 +1,9 @@
 !
 frr defaults datacenter
 !
-debug bgp evpn mh es
-debug bgp evpn mh route
-debug bgp zebra
+! debug bgp evpn mh es
+! debug bgp evpn mh route
+! debug bgp zebra
 !
 !
 router bgp 65004

--- a/tests/topotests/bgp_evpn_mh/torm21/zebra.conf
+++ b/tests/topotests/bgp_evpn_mh/torm21/zebra.conf
@@ -1,8 +1,8 @@
-debug zebra evpn mh es
-debug zebra evpn mh mac
-debug zebra evpn mh neigh
-debug zebra evpn mh nh
-debug zebra vxlan
+! debug zebra evpn mh es
+! debug zebra evpn mh mac
+! debug zebra evpn mh neigh
+! debug zebra evpn mh nh
+! debug zebra vxlan
 !
 evpn mh startup-delay 1
 !

--- a/tests/topotests/bgp_evpn_mh/torm22/evpn.conf
+++ b/tests/topotests/bgp_evpn_mh/torm22/evpn.conf
@@ -1,9 +1,9 @@
 !
 frr defaults datacenter
 !
-debug bgp evpn mh es
-debug bgp evpn mh route
-debug bgp zebra
+! debug bgp evpn mh es
+! debug bgp evpn mh route
+! debug bgp zebra
 !
 router bgp 65005
   bgp router-id 192.168.100.18

--- a/tests/topotests/bgp_evpn_mh/torm22/zebra.conf
+++ b/tests/topotests/bgp_evpn_mh/torm22/zebra.conf
@@ -1,8 +1,8 @@
-debug zebra evpn mh es
-debug zebra evpn mh mac
-debug zebra evpn mh neigh
-debug zebra evpn mh nh
-debug zebra vxlan
+! debug zebra evpn mh es
+! debug zebra evpn mh mac
+! debug zebra evpn mh neigh
+! debug zebra evpn mh nh
+! debug zebra vxlan
 !
 evpn mh startup-delay 1
 !

--- a/tests/topotests/bgp_evpn_rt5/r1/bgpd.conf
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgpd.conf
@@ -1,6 +1,6 @@
-debug bgp neighbor-events
-debug bgp updates
-debug bgp zebra
+! debug bgp neighbor-events
+! debug bgp updates
+! debug bgp zebra
 router bgp 65000
  bgp router-id 192.168.100.21
  bgp log-neighbor-changes

--- a/tests/topotests/bgp_evpn_rt5/r1/zebra.conf
+++ b/tests/topotests/bgp_evpn_rt5/r1/zebra.conf
@@ -3,10 +3,10 @@ log stdout
 hostname r1
 password zebra
 
-debug zebra vxlan
-debug zebra kernel
-debug zebra dplane
-debug zebra rib
+! debug zebra vxlan
+! debug zebra kernel
+! debug zebra dplane
+! debug zebra rib
 log stdout
 vrf r1-vrf-101
  vni 101

--- a/tests/topotests/bgp_evpn_rt5/r2/bgpd.conf
+++ b/tests/topotests/bgp_evpn_rt5/r2/bgpd.conf
@@ -1,6 +1,6 @@
-debug bgp neighbor-events
-debug bgp updates
-debug bgp zebra
+! debug bgp neighbor-events
+! debug bgp updates
+! debug bgp zebra
 router bgp 65000
  bgp router-id 192.168.100.41
  bgp log-neighbor-changes

--- a/tests/topotests/bgp_evpn_rt5/r2/zebra.conf
+++ b/tests/topotests/bgp_evpn_rt5/r2/zebra.conf
@@ -3,7 +3,7 @@ log stdout
 hostname r2
 password zebra
 
-debug zebra vxlan
+! debug zebra vxlan
 
 vrf r2-vrf-101
  vni 101

--- a/tests/topotests/bgp_features/r1/ospf6d.conf
+++ b/tests/topotests/bgp_features/r1/ospf6d.conf
@@ -1,6 +1,6 @@
 log file ospf6d.log
 !
-debug ospf6 neighbor
+! debug ospf6 neighbor
 !
 interface r1-lo
 !

--- a/tests/topotests/bgp_features/r1/ospfd.conf
+++ b/tests/topotests/bgp_features/r1/ospfd.conf
@@ -1,7 +1,7 @@
 log file ospfd.log
 !
-debug ospf event
-debug ospf zebra
+! debug ospf event
+! debug ospf zebra
 !
 interface r1-eth1
  ip ospf hello-interval 2

--- a/tests/topotests/bgp_features/r2/ospf6d.conf
+++ b/tests/topotests/bgp_features/r2/ospf6d.conf
@@ -1,6 +1,6 @@
 log file ospf6d.log
 !
-debug ospf6 neighbor
+! debug ospf6 neighbor
 !
 interface r2-lo
 !

--- a/tests/topotests/bgp_features/r2/ospfd.conf
+++ b/tests/topotests/bgp_features/r2/ospfd.conf
@@ -1,7 +1,7 @@
 log file ospfd.log
 !
-debug ospf event
-debug ospf zebra
+! debug ospf event
+! debug ospf zebra
 !
 int r2-eth1
  ip ospf hello-interval 2

--- a/tests/topotests/bgp_features/r3/ospf6d.conf
+++ b/tests/topotests/bgp_features/r3/ospf6d.conf
@@ -1,6 +1,6 @@
 log file ospf6d.log
 !
-debug ospf6 neighbor
+! debug ospf6 neighbor
 !
 interface r3-lo
 !

--- a/tests/topotests/bgp_features/r3/ospfd.conf
+++ b/tests/topotests/bgp_features/r3/ospfd.conf
@@ -1,7 +1,7 @@
 log file ospfd.log
 !
-debug ospf event
-debug ospf zebra
+! debug ospf event
+! debug ospf zebra
 !
 int r3-eth1
  ip ospf hello-interval 2

--- a/tests/topotests/bgp_ipv6_rtadv/r1/zebra.conf
+++ b/tests/topotests/bgp_ipv6_rtadv/r1/zebra.conf
@@ -1,5 +1,5 @@
-debug zebra packet recv
-debug zebra packet send
+! debug zebra packet recv
+! debug zebra packet send
 log stdout
 interface lo
  ip address 10.254.254.1/32

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r1/ldpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r1/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r1
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 1.1.1.1

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r2/ldpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r2/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r2
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 2.2.2.2

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r3/ldpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r3/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r3
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/r4/ldpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/r4/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r4
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 4.4.4.4

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r1/ldpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r1/ldpd.conf
@@ -2,13 +2,13 @@ hostname r1
 log file ldpd.log
 password zebra
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 1.1.1.1

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r2/ldpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r2/ldpd.conf
@@ -2,13 +2,13 @@ hostname r2
 log file ldpd.log
 password zebra
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 2.2.2.2

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r3/ldpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r3/ldpd.conf
@@ -2,13 +2,13 @@ hostname r3
 password zebra
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/r4/ldpd.conf
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/r4/ldpd.conf
@@ -2,13 +2,13 @@ hostname r4
 password zebra
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 4.4.4.4

--- a/tests/topotests/bgp_link_bw_ip/r4/bgpd.conf
+++ b/tests/topotests/bgp_link_bw_ip/r4/bgpd.conf
@@ -1,9 +1,9 @@
 !
 log file bgpd.log
 !
-debug bgp updates
-debug bgp zebra
-debug bgp bestpath 198.10.1.1/32
+! debug bgp updates
+! debug bgp zebra
+! debug bgp bestpath 198.10.1.1/32
 !
 hostname r4
 !

--- a/tests/topotests/bgp_lu_topo1/R1/bgpd.conf
+++ b/tests/topotests/bgp_lu_topo1/R1/bgpd.conf
@@ -1,6 +1,6 @@
 !
-debug bgp labelpool
-debug bgp zebra
+! debug bgp labelpool
+! debug bgp zebra
 !
 router bgp 1
  bgp router-id 10.0.0.1

--- a/tests/topotests/bgp_lu_topo1/R1/zebra.conf
+++ b/tests/topotests/bgp_lu_topo1/R1/zebra.conf
@@ -1,6 +1,6 @@
-debug zebra events
-debug zebra dplane
-debug zebra mpls
+! debug zebra events
+! debug zebra dplane
+! debug zebra mpls
 !
 interface R1-eth0
  ip address 10.0.0.1/24

--- a/tests/topotests/bgp_lu_topo1/R2/bgpd.conf
+++ b/tests/topotests/bgp_lu_topo1/R2/bgpd.conf
@@ -1,5 +1,5 @@
-debug bgp labelpool
-debug bgp zebra
+! debug bgp labelpool
+! debug bgp zebra
 !
 router bgp 2
  bgp router-id 10.0.0.2

--- a/tests/topotests/bgp_lu_topo1/R2/zebra.conf
+++ b/tests/topotests/bgp_lu_topo1/R2/zebra.conf
@@ -1,7 +1,7 @@
 !
-debug zebra events
-debug zebra dplane
-debug zebra mpls
+! debug zebra events
+! debug zebra dplane
+! debug zebra mpls
 !
 interface R2-eth0
  ip address 10.0.0.2/24

--- a/tests/topotests/bgp_lu_topo1/R3/bgpd.conf
+++ b/tests/topotests/bgp_lu_topo1/R3/bgpd.conf
@@ -1,6 +1,6 @@
 log file /tmp/bgpd.log
 !
-debug bgp updates
+! debug bgp updates
 !
 router bgp 2
  bgp router-id 10.0.1.3

--- a/tests/topotests/bgp_lu_topo1/R3/zebra.conf
+++ b/tests/topotests/bgp_lu_topo1/R3/zebra.conf
@@ -1,8 +1,8 @@
 log file /tmp/zebra.log
 !
-debug zebra events
-debug zebra packet detail
-debug zebra mpls
+! debug zebra events
+! debug zebra packet detail
+! debug zebra mpls
 !
 interface R3-eth0
  ip address 10.0.1.3/24

--- a/tests/topotests/bgp_lu_topo2/R1/bgpd.conf
+++ b/tests/topotests/bgp_lu_topo2/R1/bgpd.conf
@@ -1,8 +1,8 @@
 !
 no log unique-id
 !
-debug bgp labelpool
-debug bgp zebra
+! debug bgp labelpool
+! debug bgp zebra
 !
 router bgp 1
  bgp router-id 10.0.0.1

--- a/tests/topotests/bgp_lu_topo2/R1/zebra.conf
+++ b/tests/topotests/bgp_lu_topo2/R1/zebra.conf
@@ -1,10 +1,10 @@
 !
 no log unique-id
 !
-debug zebra events
-debug zebra rib det
-debug zebra dplane
-debug zebra mpls
+! debug zebra events
+! debug zebra rib det
+! debug zebra dplane
+! debug zebra mpls
 !
 interface R1-eth0
  ip address 10.0.0.1/24

--- a/tests/topotests/bgp_lu_topo2/R2/bgpd.conf
+++ b/tests/topotests/bgp_lu_topo2/R2/bgpd.conf
@@ -1,8 +1,8 @@
 !
 no log unique-id
 !
-debug bgp labelpool
-debug bgp zebra
+! debug bgp labelpool
+! debug bgp zebra
 !
 router bgp 2
  bgp router-id 10.0.0.2

--- a/tests/topotests/bgp_lu_topo2/R2/zebra.conf
+++ b/tests/topotests/bgp_lu_topo2/R2/zebra.conf
@@ -1,10 +1,10 @@
 !
 no log unique-id
 !
-debug zebra events
-debug zebra dplane
-debug zebra mpls
-debug zebra rib det
+! debug zebra events
+! debug zebra dplane
+! debug zebra mpls
+! debug zebra rib det
 !
 interface R2-eth0
  ip address 10.0.0.2/24

--- a/tests/topotests/bgp_lu_topo2/R3/bgpd.conf
+++ b/tests/topotests/bgp_lu_topo2/R3/bgpd.conf
@@ -2,7 +2,7 @@ log file /tmp/bgpd.log
 no log unique-id
 !
 !
-debug bgp updates
+! debug bgp updates
 !
 router bgp 2
  bgp router-id 10.0.1.3

--- a/tests/topotests/bgp_lu_topo2/R3/zebra.conf
+++ b/tests/topotests/bgp_lu_topo2/R3/zebra.conf
@@ -2,9 +2,9 @@ log file /tmp/zebra.log
 no log unique-id
 !
 !
-debug zebra events
-debug zebra packet detail
-debug zebra mpls
+! debug zebra events
+! debug zebra packet detail
+! debug zebra mpls
 !
 interface R3-eth0
  ip address 10.0.1.3/24

--- a/tests/topotests/bgp_lu_topo2/R4/bgpd.conf
+++ b/tests/topotests/bgp_lu_topo2/R4/bgpd.conf
@@ -1,8 +1,8 @@
 !
 no log unique-id
 !
-debug bgp labelpool
-debug bgp zebra
+! debug bgp labelpool
+! debug bgp zebra
 !
 router bgp 4
  bgp router-id 10.0.4.4

--- a/tests/topotests/bgp_lu_topo2/R4/zebra.conf
+++ b/tests/topotests/bgp_lu_topo2/R4/zebra.conf
@@ -1,9 +1,9 @@
 no log unique-id
 !
-debug zebra events
-debug zebra dplane
-debug zebra mpls
-debug zebra rib det
+! debug zebra events
+! debug zebra dplane
+! debug zebra mpls
+! debug zebra rib det
 !
 interface R4-eth0
  ip address 10.0.4.4/24

--- a/tests/topotests/bgp_snmp_mplsl3vpn/ce1/zebra.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/ce1/zebra.conf
@@ -1,8 +1,8 @@
 log file /tmp/zebra.log
 log stdout
 !
-debug zebra events
-debug zebra dplane
+! debug zebra events
+! debug zebra dplane
 !
 !
 interface ce1-eth0

--- a/tests/topotests/bgp_snmp_mplsl3vpn/ce2/zebra.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/ce2/zebra.conf
@@ -1,8 +1,8 @@
 log file /tmp/zebra.log
 log stdout
 !
-debug zebra events
-debug zebra dplane
+! debug zebra events
+! debug zebra dplane
 !
 !
 interface ce2-eth0

--- a/tests/topotests/bgp_snmp_mplsl3vpn/ce3/zebra.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/ce3/zebra.conf
@@ -1,8 +1,8 @@
 log file /tmp/zebra.log
 log stdout
 !
-debug zebra events
-debug zebra dplane
+! debug zebra events
+! debug zebra dplane
 !
 !
 interface ce3-eth0

--- a/tests/topotests/bgp_snmp_mplsl3vpn/ce4/zebra.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/ce4/zebra.conf
@@ -1,8 +1,8 @@
 log file /tmp/zebra.log
 log stdout
 !
-debug zebra events
-debug zebra dplane
+! debug zebra events
+! debug zebra dplane
 !
 !
 interface ce4-eth0

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r1/isisd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r1/isisd.conf
@@ -1,7 +1,7 @@
 log stdout debugging
 !
-debug isis route-events
-debug isis events
+! debug isis route-events
+! debug isis events
 !
 interface r1-eth0
   ip router isis ISIS1

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r2/isisd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r2/isisd.conf
@@ -1,7 +1,7 @@
 log stdout debugging
 !
-debug isis route-events
-debug isis events
+! debug isis route-events
+! debug isis events
 !
 interface r2-eth0
   ip router isis ISIS1

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r2/zebra.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r2/zebra.conf
@@ -1,8 +1,8 @@
 log file /tmp/zebra.log
 log stdout
 !
-debug zebra events
-debug zebra dplane
+! debug zebra events
+! debug zebra dplane
 !
 !
 interface r2-eth0

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r3/isisd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r3/isisd.conf
@@ -1,7 +1,7 @@
 log stdout debugging
 !
-debug isis route-events
-debug isis events
+! debug isis route-events
+! debug isis events
 !
 interface r3-eth0
   ip router isis ISIS1

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r3/zebra.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r3/zebra.conf
@@ -1,8 +1,8 @@
 log file /tmp/zebra.log
 log stdout
 !
-debug zebra events
-debug zebra dplane
+! debug zebra events
+! debug zebra dplane
 !
 !
 interface r3-eth0

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r4/isisd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r4/isisd.conf
@@ -1,7 +1,7 @@
 log stdout debugging
 !
-debug isis route-events
-debug isis events
+! debug isis route-events
+! debug isis events
 !
 interface r4-eth0
   ip router isis ISIS1

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r4/zebra.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r4/zebra.conf
@@ -1,8 +1,8 @@
 log file /tmp/zebra.log
 log stdout
 !
-debug zebra events
-debug zebra dplane
+! debug zebra events
+! debug zebra dplane
 !
 !
 interface r4-eth0

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/r1/zebra.conf
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/r1/zebra.conf
@@ -7,9 +7,9 @@ log stdout notifications
 log monitor notifications
 log commands
 !
-debug zebra packet
-debug zebra dplane
-debug zebra kernel
+! debug zebra packet
+! debug zebra dplane
+! debug zebra kernel
 !
 interface eth0
  ipv6 address 2001::1/64

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/r2/zebra.conf
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/r2/zebra.conf
@@ -7,9 +7,9 @@ log stdout notifications
 log monitor notifications
 log commands
 !
-debug zebra packet
-debug zebra dplane
-debug zebra kernel
+! debug zebra packet
+! debug zebra dplane
+! debug zebra kernel
 !
 interface eth0
  ipv6 address 2001::2/64

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r1/zebra.conf
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/r1/zebra.conf
@@ -1,5 +1,5 @@
-debug zebra packet recv
-debug zebra packet send
+! debug zebra packet recv
+! debug zebra packet send
 log stdout
 interface loop1 vrf r1-cust1
  ip address 10.254.254.1/32

--- a/tests/topotests/bgp_vrf_netns/r1/zebra.conf
+++ b/tests/topotests/bgp_vrf_netns/r1/zebra.conf
@@ -4,4 +4,4 @@ interface r1-eth0 vrf r1-bgp-cust1
 !
 line vty
 !
-debug vrf
+! debug vrf

--- a/tests/topotests/eigrp_topo1/r1/zebra.conf
+++ b/tests/topotests/eigrp_topo1/r1/zebra.conf
@@ -1,5 +1,5 @@
 log file zebra.log
-debug zebra rib detail
+! debug zebra rib detail
 !
 hostname r1
 !

--- a/tests/topotests/evpn_pim_1/leaf1/pimd.conf
+++ b/tests/topotests/evpn_pim_1/leaf1/pimd.conf
@@ -1,6 +1,6 @@
-debug pim events
-debug pim nht
-debug pim zebra
+! debug pim events
+! debug pim nht
+! debug pim zebra
 ip pim rp 192.168.100.1
 ip pim join-prune-interval 5
 !

--- a/tests/topotests/isis_lfa_topo1/rt1/isisd.conf
+++ b/tests/topotests/isis_lfa_topo1/rt1/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt1
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ipv6 router isis 1

--- a/tests/topotests/isis_lfa_topo1/rt1/zebra.conf
+++ b/tests/topotests/isis_lfa_topo1/rt1/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt1
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/isis_lfa_topo1/rt2/isisd.conf
+++ b/tests/topotests/isis_lfa_topo1/rt2/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt2
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ipv6 router isis 1

--- a/tests/topotests/isis_lfa_topo1/rt2/zebra.conf
+++ b/tests/topotests/isis_lfa_topo1/rt2/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt2
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/isis_lfa_topo1/rt3/isisd.conf
+++ b/tests/topotests/isis_lfa_topo1/rt3/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt3
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ipv6 router isis 1

--- a/tests/topotests/isis_lfa_topo1/rt3/zebra.conf
+++ b/tests/topotests/isis_lfa_topo1/rt3/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt3
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/isis_lfa_topo1/rt4/isisd.conf
+++ b/tests/topotests/isis_lfa_topo1/rt4/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt4
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ipv6 router isis 1

--- a/tests/topotests/isis_lfa_topo1/rt4/zebra.conf
+++ b/tests/topotests/isis_lfa_topo1/rt4/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt4
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/isis_lfa_topo1/rt5/isisd.conf
+++ b/tests/topotests/isis_lfa_topo1/rt5/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt5
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ipv6 router isis 1

--- a/tests/topotests/isis_lfa_topo1/rt5/zebra.conf
+++ b/tests/topotests/isis_lfa_topo1/rt5/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt5
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/isis_lfa_topo1/rt6/isisd.conf
+++ b/tests/topotests/isis_lfa_topo1/rt6/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt6
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ipv6 router isis 1

--- a/tests/topotests/isis_lfa_topo1/rt6/zebra.conf
+++ b/tests/topotests/isis_lfa_topo1/rt6/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt6
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 6.6.6.6/32

--- a/tests/topotests/isis_lfa_topo1/rt7/isisd.conf
+++ b/tests/topotests/isis_lfa_topo1/rt7/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt6
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ipv6 router isis 1

--- a/tests/topotests/isis_lfa_topo1/rt7/zebra.conf
+++ b/tests/topotests/isis_lfa_topo1/rt7/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt7
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 7.7.7.7/32

--- a/tests/topotests/isis_lsp_bits_topo1/rt1/isisd.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt1/isisd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt1
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_lsp_bits_topo1/rt1/zebra.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt1/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt1
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/isis_lsp_bits_topo1/rt2/isisd.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt2/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt2
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_lsp_bits_topo1/rt2/zebra.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt2/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt2
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/isis_lsp_bits_topo1/rt3/isisd.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt3/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt3
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_lsp_bits_topo1/rt3/zebra.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt3/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt3
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/isis_lsp_bits_topo1/rt4/isisd.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt4/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt4
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 4

--- a/tests/topotests/isis_lsp_bits_topo1/rt4/zebra.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt4/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt4
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/isis_lsp_bits_topo1/rt5/isisd.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt5/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt5
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 2

--- a/tests/topotests/isis_lsp_bits_topo1/rt5/zebra.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt5/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt5
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/isis_lsp_bits_topo1/rt6/isisd.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt6/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt6
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 4

--- a/tests/topotests/isis_lsp_bits_topo1/rt6/zebra.conf
+++ b/tests/topotests/isis_lsp_bits_topo1/rt6/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt6
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 6.6.6.6/32

--- a/tests/topotests/isis_rlfa_topo1/rt1/isisd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt1/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt1
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_rlfa_topo1/rt1/ldpd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt1/ldpd.conf
@@ -2,9 +2,9 @@ log file ldpd.log
 !
 hostname rt1
 !
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp zebra
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp zebra
 !
 mpls ldp
  router-id 10.0.255.1

--- a/tests/topotests/isis_rlfa_topo1/rt1/zebra.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt1/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt1
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 10.0.255.1/32

--- a/tests/topotests/isis_rlfa_topo1/rt2/isisd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt2/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt2
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_rlfa_topo1/rt2/ldpd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt2/ldpd.conf
@@ -2,9 +2,9 @@ log file ldpd.log
 !
 hostname rt2
 !
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp zebra
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp zebra
 !
 mpls ldp
  router-id 10.0.255.2

--- a/tests/topotests/isis_rlfa_topo1/rt2/zebra.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt2/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt2
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 10.0.255.2/32

--- a/tests/topotests/isis_rlfa_topo1/rt3/isisd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt3/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt3
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_rlfa_topo1/rt3/ldpd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt3/ldpd.conf
@@ -2,9 +2,9 @@ log file ldpd.log
 !
 hostname rt3
 !
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp zebra
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp zebra
 !
 mpls ldp
  router-id 10.0.255.3

--- a/tests/topotests/isis_rlfa_topo1/rt3/zebra.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt3/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt3
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 10.0.255.3/32

--- a/tests/topotests/isis_rlfa_topo1/rt4/isisd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt4/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt4
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_rlfa_topo1/rt4/ldpd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt4/ldpd.conf
@@ -2,9 +2,9 @@ log file ldpd.log
 !
 hostname rt4
 !
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp zebra
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp zebra
 !
 mpls ldp
  router-id 10.0.255.4

--- a/tests/topotests/isis_rlfa_topo1/rt4/zebra.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt4/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt4
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 10.0.255.4/32

--- a/tests/topotests/isis_rlfa_topo1/rt5/isisd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt5/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt5
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_rlfa_topo1/rt5/ldpd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt5/ldpd.conf
@@ -2,9 +2,9 @@ log file ldpd.log
 !
 hostname rt5
 !
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp zebra
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp zebra
 !
 mpls ldp
  router-id 10.0.255.5

--- a/tests/topotests/isis_rlfa_topo1/rt5/zebra.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt5/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt5
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 10.0.255.5/32

--- a/tests/topotests/isis_rlfa_topo1/rt6/isisd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt6/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt6
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_rlfa_topo1/rt6/ldpd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt6/ldpd.conf
@@ -2,9 +2,9 @@ log file ldpd.log
 !
 hostname rt6
 !
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp zebra
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp zebra
 !
 mpls ldp
  router-id 10.0.255.6

--- a/tests/topotests/isis_rlfa_topo1/rt6/zebra.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt6/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt6
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 10.0.255.6/32

--- a/tests/topotests/isis_rlfa_topo1/rt7/isisd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt7/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt7
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_rlfa_topo1/rt7/ldpd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt7/ldpd.conf
@@ -2,9 +2,9 @@ log file ldpd.log
 !
 hostname rt7
 !
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp zebra
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp zebra
 !
 mpls ldp
  router-id 10.0.255.7

--- a/tests/topotests/isis_rlfa_topo1/rt7/zebra.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt7/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt7
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 10.0.255.7/32

--- a/tests/topotests/isis_rlfa_topo1/rt8/isisd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt8/isisd.conf
@@ -2,10 +2,10 @@ password 1
 hostname rt8
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_rlfa_topo1/rt8/ldpd.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt8/ldpd.conf
@@ -2,9 +2,9 @@ log file ldpd.log
 !
 hostname rt8
 !
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp zebra
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp zebra
 !
 mpls ldp
  router-id 10.0.255.8

--- a/tests/topotests/isis_rlfa_topo1/rt8/zebra.conf
+++ b/tests/topotests/isis_rlfa_topo1/rt8/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt8
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 10.0.255.8/32

--- a/tests/topotests/isis_snmp/r1/isisd.conf
+++ b/tests/topotests/isis_snmp/r1/isisd.conf
@@ -1,8 +1,8 @@
 hostname r1
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 agentx
 !
 router isis 1

--- a/tests/topotests/isis_snmp/r1/ldpd.conf
+++ b/tests/topotests/isis_snmp/r1/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r1
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 agentx
 !
 mpls ldp

--- a/tests/topotests/isis_snmp/r1/zebra.conf
+++ b/tests/topotests/isis_snmp/r1/zebra.conf
@@ -2,10 +2,10 @@ log file zebra.log
 !
 hostname r1
 !
-debug zebra kernel
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra nht
+! debug zebra kernel
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra nht
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/isis_snmp/r2/isisd.conf
+++ b/tests/topotests/isis_snmp/r2/isisd.conf
@@ -1,8 +1,8 @@
 hostname r2
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 agentx
 !
 router isis 1

--- a/tests/topotests/isis_snmp/r2/ldpd.conf
+++ b/tests/topotests/isis_snmp/r2/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r2
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 2.2.2.2

--- a/tests/topotests/isis_snmp/r2/zebra.conf
+++ b/tests/topotests/isis_snmp/r2/zebra.conf
@@ -2,10 +2,10 @@ log file zebra.log
 !
 hostname r2
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/isis_snmp/r3/isisd.conf
+++ b/tests/topotests/isis_snmp/r3/isisd.conf
@@ -1,8 +1,8 @@
 hostname r3
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 agentx
 !
 router isis 1

--- a/tests/topotests/isis_snmp/r3/ldpd.conf
+++ b/tests/topotests/isis_snmp/r3/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r3
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/isis_snmp/r3/zebra.conf
+++ b/tests/topotests/isis_snmp/r3/zebra.conf
@@ -2,10 +2,10 @@ log file zebra.log
 !
 hostname r3
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/isis_snmp/r4/isisd.conf
+++ b/tests/topotests/isis_snmp/r4/isisd.conf
@@ -1,8 +1,8 @@
 hostname r4
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 agentx
 !
 router isis 1

--- a/tests/topotests/isis_snmp/r4/ldpd.conf
+++ b/tests/topotests/isis_snmp/r4/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r4
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 4.4.4.4

--- a/tests/topotests/isis_snmp/r4/zebra.conf
+++ b/tests/topotests/isis_snmp/r4/zebra.conf
@@ -2,10 +2,10 @@ log file zebra.log
 !
 hostname r4
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/isis_snmp/r5/isisd.conf
+++ b/tests/topotests/isis_snmp/r5/isisd.conf
@@ -1,8 +1,8 @@
 hostname r5
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 agentx
 !
 router isis 1

--- a/tests/topotests/isis_snmp/r5/ldpd.conf
+++ b/tests/topotests/isis_snmp/r5/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r5
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 5.5.5.5

--- a/tests/topotests/isis_snmp/r5/zebra.conf
+++ b/tests/topotests/isis_snmp/r5/zebra.conf
@@ -2,10 +2,10 @@ log file zebra.log
 !
 hostname r5
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/isis_sr_te_topo1/dst/zebra.conf
+++ b/tests/topotests/isis_sr_te_topo1/dst/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname dst
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 9.9.9.2/32

--- a/tests/topotests/isis_sr_te_topo1/rt1/isisd.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt1/isisd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt1
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_te_topo1/rt1/zebra.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt1/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt1
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/isis_sr_te_topo1/rt2/isisd.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt2/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt2
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_te_topo1/rt2/zebra.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt2/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt2
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/isis_sr_te_topo1/rt3/isisd.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt3/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt3
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_te_topo1/rt3/zebra.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt3/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt3
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/isis_sr_te_topo1/rt4/isisd.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt4/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt4
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_te_topo1/rt4/zebra.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt4/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt4
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/isis_sr_te_topo1/rt5/isisd.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt5/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt5
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_te_topo1/rt5/zebra.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt5/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt5
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/isis_sr_te_topo1/rt6/isisd.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt6/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt6
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_te_topo1/rt6/zebra.conf
+++ b/tests/topotests/isis_sr_te_topo1/rt6/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt6
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 6.6.6.6/32

--- a/tests/topotests/isis_sr_topo1/rt1/isisd.conf
+++ b/tests/topotests/isis_sr_topo1/rt1/isisd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt1
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_topo1/rt1/zebra.conf
+++ b/tests/topotests/isis_sr_topo1/rt1/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt1
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/isis_sr_topo1/rt2/isisd.conf
+++ b/tests/topotests/isis_sr_topo1/rt2/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt2
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_topo1/rt2/zebra.conf
+++ b/tests/topotests/isis_sr_topo1/rt2/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt2
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/isis_sr_topo1/rt3/isisd.conf
+++ b/tests/topotests/isis_sr_topo1/rt3/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt3
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_topo1/rt3/zebra.conf
+++ b/tests/topotests/isis_sr_topo1/rt3/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt3
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/isis_sr_topo1/rt4/isisd.conf
+++ b/tests/topotests/isis_sr_topo1/rt4/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt4
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_topo1/rt4/zebra.conf
+++ b/tests/topotests/isis_sr_topo1/rt4/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt4
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/isis_sr_topo1/rt5/isisd.conf
+++ b/tests/topotests/isis_sr_topo1/rt5/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt5
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_topo1/rt5/zebra.conf
+++ b/tests/topotests/isis_sr_topo1/rt5/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt5
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/isis_sr_topo1/rt6/isisd.conf
+++ b/tests/topotests/isis_sr_topo1/rt6/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt6
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_sr_topo1/rt6/zebra.conf
+++ b/tests/topotests/isis_sr_topo1/rt6/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt6
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 6.6.6.6/32

--- a/tests/topotests/isis_tilfa_topo1/rt1/isisd.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt1/isisd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt1
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_tilfa_topo1/rt1/zebra.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt1/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt1
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/isis_tilfa_topo1/rt2/isisd.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt2/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt2
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_tilfa_topo1/rt2/zebra.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt2/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt2
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/isis_tilfa_topo1/rt3/isisd.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt3/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt3
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_tilfa_topo1/rt3/zebra.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt3/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt3
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/isis_tilfa_topo1/rt4/isisd.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt4/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt4
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_tilfa_topo1/rt4/zebra.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt4/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt4
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/isis_tilfa_topo1/rt5/isisd.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt5/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt5
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_tilfa_topo1/rt5/zebra.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt5/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt5
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/isis_tilfa_topo1/rt6/isisd.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt6/isisd.conf
@@ -1,11 +1,11 @@
 hostname rt6
 log file isisd.log
 !
-debug isis events
-debug isis route-events
-debug isis spf-events
-debug isis sr-events
-debug isis lsp-gen
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
 !
 interface lo
  ip router isis 1

--- a/tests/topotests/isis_tilfa_topo1/rt6/zebra.conf
+++ b/tests/topotests/isis_tilfa_topo1/rt6/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt6
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 6.6.6.6/32

--- a/tests/topotests/isis_topo1/r1/isisd.conf
+++ b/tests/topotests/isis_topo1/r1/isisd.conf
@@ -1,7 +1,7 @@
 hostname r1
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 interface r1-eth0
  ip router isis 1
  isis hello-interval 2

--- a/tests/topotests/isis_topo1/r2/isisd.conf
+++ b/tests/topotests/isis_topo1/r2/isisd.conf
@@ -1,7 +1,7 @@
 hostname r2
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 interface r2-eth0
  ip router isis 1
  isis hello-interval 2

--- a/tests/topotests/isis_topo1/r3/isisd.conf
+++ b/tests/topotests/isis_topo1/r3/isisd.conf
@@ -1,7 +1,7 @@
 hostname r3
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 interface r3-eth0
  ip router isis 1
  isis hello-interval 2

--- a/tests/topotests/isis_topo1/r4/isisd.conf
+++ b/tests/topotests/isis_topo1/r4/isisd.conf
@@ -1,7 +1,7 @@
 hostname r4
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 interface r4-eth0
  ip router isis 1
  isis hello-interval 2

--- a/tests/topotests/isis_topo1/r5/isisd.conf
+++ b/tests/topotests/isis_topo1/r5/isisd.conf
@@ -1,7 +1,7 @@
 hostname r5
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 interface r5-eth0
  ip router isis 1
  isis hello-interval 2

--- a/tests/topotests/isis_topo1_vrf/r1/isisd.conf
+++ b/tests/topotests/isis_topo1_vrf/r1/isisd.conf
@@ -1,7 +1,7 @@
 hostname r1
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 interface r1-eth0
  ip router isis 1 vrf r1-cust1
  ipv6 router isis 1 vrf r1-cust1

--- a/tests/topotests/isis_topo1_vrf/r2/isisd.conf
+++ b/tests/topotests/isis_topo1_vrf/r2/isisd.conf
@@ -1,7 +1,7 @@
 hostname r2
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 interface r2-eth0
  ip router isis 1 vrf r2-cust1
  ipv6 router isis 1 vrf r2-cust1

--- a/tests/topotests/isis_topo1_vrf/r3/isisd.conf
+++ b/tests/topotests/isis_topo1_vrf/r3/isisd.conf
@@ -1,7 +1,7 @@
 hostname r3
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 interface r3-eth0
  ip router isis 1 vrf r3-cust1
  ipv6 router isis 1 vrf r3-cust1

--- a/tests/topotests/isis_topo1_vrf/r4/isisd.conf
+++ b/tests/topotests/isis_topo1_vrf/r4/isisd.conf
@@ -1,9 +1,9 @@
 hostname r4
-debug isis adj-packets
-debug isis events
-debug isis update-packets
-debug isis lsp-gen
-debug isis lsp-sched
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
+! debug isis lsp-gen
+! debug isis lsp-sched
 
 interface r4-eth0
  ip router isis 1 vrf r4-cust1

--- a/tests/topotests/isis_topo1_vrf/r5/isisd.conf
+++ b/tests/topotests/isis_topo1_vrf/r5/isisd.conf
@@ -1,7 +1,7 @@
 hostname r5
-debug isis adj-packets
-debug isis events
-debug isis update-packets
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
 interface r5-eth0
  ip router isis 1 vrf r5-cust1
  ipv6 router isis 1 vrf r5-cust1

--- a/tests/topotests/ldp_oc_acl_topo1/r1/ldpd.conf
+++ b/tests/topotests/ldp_oc_acl_topo1/r1/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r1
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 1.1.1.1

--- a/tests/topotests/ldp_oc_acl_topo1/r2/ldpd.conf
+++ b/tests/topotests/ldp_oc_acl_topo1/r2/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r2
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 2.2.2.2

--- a/tests/topotests/ldp_oc_acl_topo1/r3/ldpd.conf
+++ b/tests/topotests/ldp_oc_acl_topo1/r3/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r3
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/ldp_oc_acl_topo1/r4/ldpd.conf
+++ b/tests/topotests/ldp_oc_acl_topo1/r4/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r4
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 4.4.4.4

--- a/tests/topotests/ldp_oc_topo1/r1/ldpd.conf
+++ b/tests/topotests/ldp_oc_topo1/r1/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r1
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 1.1.1.1

--- a/tests/topotests/ldp_oc_topo1/r2/ldpd.conf
+++ b/tests/topotests/ldp_oc_topo1/r2/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r2
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 2.2.2.2

--- a/tests/topotests/ldp_oc_topo1/r3/ldpd.conf
+++ b/tests/topotests/ldp_oc_topo1/r3/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r3
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/ldp_oc_topo1/r4/ldpd.conf
+++ b/tests/topotests/ldp_oc_topo1/r4/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r4
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 4.4.4.4

--- a/tests/topotests/ldp_snmp/r1/isisd.conf
+++ b/tests/topotests/ldp_snmp/r1/isisd.conf
@@ -1,9 +1,9 @@
 hostname r1
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
-debug isis ldp-sync
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
+! debug isis ldp-sync
 !
 router isis 1
  lsp-gen-interval 2

--- a/tests/topotests/ldp_snmp/r1/ldpd.conf
+++ b/tests/topotests/ldp_snmp/r1/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r1
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 1.1.1.1

--- a/tests/topotests/ldp_snmp/r1/zebra.conf
+++ b/tests/topotests/ldp_snmp/r1/zebra.conf
@@ -2,12 +2,12 @@ log file zebra.log
 !
 hostname r1
 !
-debug zebra kernel
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra nht
-debug zebra pseudowires
-debug zebra mpls
+! debug zebra kernel
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra nht
+! debug zebra pseudowires
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/ldp_snmp/r2/isisd.conf
+++ b/tests/topotests/ldp_snmp/r2/isisd.conf
@@ -1,9 +1,9 @@
 hostname r2
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
-debug isis ldp-sync
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
+! debug isis ldp-sync
 !
 router isis 1
  lsp-gen-interval 2

--- a/tests/topotests/ldp_snmp/r2/ldpd.conf
+++ b/tests/topotests/ldp_snmp/r2/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r2
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 2.2.2.2

--- a/tests/topotests/ldp_snmp/r2/ospfd.conf
+++ b/tests/topotests/ldp_snmp/r2/ospfd.conf
@@ -1,7 +1,7 @@
 hostname r2
 log file ospfd.log
-debug ospf zebra interface
-debug ospf ldp-sync
+! debug ospf zebra interface
+! debug ospf ldp-sync
 !
 router ospf
  router-id 2.2.2.2

--- a/tests/topotests/ldp_snmp/r2/zebra.conf
+++ b/tests/topotests/ldp_snmp/r2/zebra.conf
@@ -2,11 +2,11 @@ log file zebra.log
 !
 hostname r2
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
-debug zebra pseudowires
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
+! debug zebra pseudowires
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/ldp_snmp/r3/isisd.conf
+++ b/tests/topotests/ldp_snmp/r3/isisd.conf
@@ -1,9 +1,9 @@
 hostname r3
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
-debug isis ldp-sync
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
+! debug isis ldp-sync
 !
 router isis 1
  lsp-gen-interval 2

--- a/tests/topotests/ldp_snmp/r3/ldpd.conf
+++ b/tests/topotests/ldp_snmp/r3/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r3
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/ldp_snmp/r3/zebra.conf
+++ b/tests/topotests/ldp_snmp/r3/zebra.conf
@@ -2,11 +2,11 @@ log file zebra.log
 !
 hostname r3
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
-debug zebra pseudowires
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
+! debug zebra pseudowires
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/ldp_sync_isis_topo1/r1/isisd.conf
+++ b/tests/topotests/ldp_sync_isis_topo1/r1/isisd.conf
@@ -1,9 +1,9 @@
 hostname r1
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
-debug isis ldp-sync
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
+! debug isis ldp-sync
 !
 router isis 1
  lsp-gen-interval 2

--- a/tests/topotests/ldp_sync_isis_topo1/r1/ldpd.conf
+++ b/tests/topotests/ldp_sync_isis_topo1/r1/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r1
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 1.1.1.1

--- a/tests/topotests/ldp_sync_isis_topo1/r1/zebra.conf
+++ b/tests/topotests/ldp_sync_isis_topo1/r1/zebra.conf
@@ -2,12 +2,12 @@ log file zebra.log
 !
 hostname r1
 !
-debug zebra kernel
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra nht
-debug zebra pseudowires
-debug zebra mpls
+! debug zebra kernel
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra nht
+! debug zebra pseudowires
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/ldp_sync_isis_topo1/r2/isisd.conf
+++ b/tests/topotests/ldp_sync_isis_topo1/r2/isisd.conf
@@ -1,9 +1,9 @@
 hostname r2
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
-debug isis ldp-sync
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
+! debug isis ldp-sync
 !
 router isis 1
  lsp-gen-interval 2

--- a/tests/topotests/ldp_sync_isis_topo1/r2/ldpd.conf
+++ b/tests/topotests/ldp_sync_isis_topo1/r2/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r2
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 2.2.2.2

--- a/tests/topotests/ldp_sync_isis_topo1/r2/zebra.conf
+++ b/tests/topotests/ldp_sync_isis_topo1/r2/zebra.conf
@@ -2,11 +2,11 @@ log file zebra.log
 !
 hostname r2
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
-debug zebra pseudowires
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
+! debug zebra pseudowires
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/ldp_sync_isis_topo1/r3/isisd.conf
+++ b/tests/topotests/ldp_sync_isis_topo1/r3/isisd.conf
@@ -1,9 +1,9 @@
 hostname r3
 log file isisd.log
-debug isis adj-packets
-debug isis events
-debug isis update-packets
-debug isis ldp-sync
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
+! debug isis ldp-sync
 !
 router isis 1
  lsp-gen-interval 2

--- a/tests/topotests/ldp_sync_isis_topo1/r3/ldpd.conf
+++ b/tests/topotests/ldp_sync_isis_topo1/r3/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r3
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/ldp_sync_isis_topo1/r3/zebra.conf
+++ b/tests/topotests/ldp_sync_isis_topo1/r3/zebra.conf
@@ -2,11 +2,11 @@ log file zebra.log
 !
 hostname r3
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
-debug zebra pseudowires
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
+! debug zebra pseudowires
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/ldp_sync_ospf_topo1/r1/ldpd.conf
+++ b/tests/topotests/ldp_sync_ospf_topo1/r1/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r1
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 1.1.1.1

--- a/tests/topotests/ldp_sync_ospf_topo1/r1/ospfd.conf
+++ b/tests/topotests/ldp_sync_ospf_topo1/r1/ospfd.conf
@@ -1,7 +1,7 @@
 hostname r1
 log file ospfd.log
-debug ospf zebra interface
-debug ospf ldp-sync
+! debug ospf zebra interface
+! debug ospf ldp-sync
 !
 router ospf
  router-id 1.1.1.1

--- a/tests/topotests/ldp_sync_ospf_topo1/r1/zebra.conf
+++ b/tests/topotests/ldp_sync_ospf_topo1/r1/zebra.conf
@@ -2,12 +2,12 @@ log file zebra.log
 !
 hostname r1
 !
-debug zebra kernel
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra nht
-debug zebra pseudowires
-debug zebra mpls
+! debug zebra kernel
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra nht
+! debug zebra pseudowires
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/ldp_sync_ospf_topo1/r2/ldpd.conf
+++ b/tests/topotests/ldp_sync_ospf_topo1/r2/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r2
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 2.2.2.2

--- a/tests/topotests/ldp_sync_ospf_topo1/r2/ospfd.conf
+++ b/tests/topotests/ldp_sync_ospf_topo1/r2/ospfd.conf
@@ -1,7 +1,7 @@
 hostname r2
 log file ospfd.log
-debug ospf zebra interface
-debug ospf ldp-sync
+! debug ospf zebra interface
+! debug ospf ldp-sync
 !
 router ospf
  router-id 2.2.2.2

--- a/tests/topotests/ldp_sync_ospf_topo1/r2/zebra.conf
+++ b/tests/topotests/ldp_sync_ospf_topo1/r2/zebra.conf
@@ -2,11 +2,11 @@ log file zebra.log
 !
 hostname r2
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
-debug zebra pseudowires
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
+! debug zebra pseudowires
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/ldp_sync_ospf_topo1/r3/ldpd.conf
+++ b/tests/topotests/ldp_sync_ospf_topo1/r3/ldpd.conf
@@ -1,10 +1,10 @@
 hostname r3
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp sync
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/ldp_sync_ospf_topo1/r3/ospfd.conf
+++ b/tests/topotests/ldp_sync_ospf_topo1/r3/ospfd.conf
@@ -1,7 +1,7 @@
 hostname r3
 log file ospfd.log
-debug ospf zebra interface
-debug ospf ldp-sync
+! debug ospf zebra interface
+! debug ospf ldp-sync
 !
 router ospf
  router-id 3.3.3.3

--- a/tests/topotests/ldp_sync_ospf_topo1/r3/zebra.conf
+++ b/tests/topotests/ldp_sync_ospf_topo1/r3/zebra.conf
@@ -2,11 +2,11 @@ log file zebra.log
 !
 hostname r3
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
-debug zebra pseudowires
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
+! debug zebra pseudowires
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/ldp_topo1/r1/ldpd.conf
+++ b/tests/topotests/ldp_topo1/r1/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r1
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 1.1.1.1

--- a/tests/topotests/ldp_topo1/r2/ldpd.conf
+++ b/tests/topotests/ldp_topo1/r2/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r2
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 2.2.2.2

--- a/tests/topotests/ldp_topo1/r3/ldpd.conf
+++ b/tests/topotests/ldp_topo1/r3/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r3
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/ldp_topo1/r4/ldpd.conf
+++ b/tests/topotests/ldp_topo1/r4/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r4
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 4.4.4.4

--- a/tests/topotests/ldp_vpls_topo1/r1/ldpd.conf
+++ b/tests/topotests/ldp_vpls_topo1/r1/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r1
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 1.1.1.1

--- a/tests/topotests/ldp_vpls_topo1/r1/zebra.conf
+++ b/tests/topotests/ldp_vpls_topo1/r1/zebra.conf
@@ -2,12 +2,12 @@ log file zebra.log
 !
 hostname r1
 !
-debug zebra kernel
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra nht
-debug zebra pseudowires
-debug zebra mpls
+! debug zebra kernel
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra nht
+! debug zebra pseudowires
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/ldp_vpls_topo1/r2/ldpd.conf
+++ b/tests/topotests/ldp_vpls_topo1/r2/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r2
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 2.2.2.2

--- a/tests/topotests/ldp_vpls_topo1/r2/zebra.conf
+++ b/tests/topotests/ldp_vpls_topo1/r2/zebra.conf
@@ -2,11 +2,11 @@ log file zebra.log
 !
 hostname r2
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
-debug zebra pseudowires
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
+! debug zebra pseudowires
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/ldp_vpls_topo1/r3/ldpd.conf
+++ b/tests/topotests/ldp_vpls_topo1/r3/ldpd.conf
@@ -1,13 +1,13 @@
 hostname r3
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp messages recv
-debug mpls ldp messages sent
-debug mpls ldp discovery hello recv
-debug mpls ldp discovery hello sent
+! debug mpls ldp zebra
+! debug mpls ldp event
+! debug mpls ldp errors
+! debug mpls ldp messages recv
+! debug mpls ldp messages sent
+! debug mpls ldp discovery hello recv
+! debug mpls ldp discovery hello sent
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/ldp_vpls_topo1/r3/zebra.conf
+++ b/tests/topotests/ldp_vpls_topo1/r3/zebra.conf
@@ -2,11 +2,11 @@ log file zebra.log
 !
 hostname r3
 !
-debug zebra rib detailed
-debug zebra dplane detailed
-debug zebra kernel
-debug zebra nht
-debug zebra pseudowires
+! debug zebra rib detailed
+! debug zebra dplane detailed
+! debug zebra kernel
+! debug zebra nht
+! debug zebra pseudowires
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/msdp_topo1/r1/pimd.conf
+++ b/tests/topotests/msdp_topo1/r1/pimd.conf
@@ -1,5 +1,5 @@
-debug pim
-debug pim zebra
+! debug pim
+! debug pim zebra
 !
 interface lo
  ip pim

--- a/tests/topotests/msdp_topo1/r2/pimd.conf
+++ b/tests/topotests/msdp_topo1/r2/pimd.conf
@@ -1,5 +1,5 @@
-debug pim
-debug pim zebra
+! debug pim
+! debug pim zebra
 !
 interface lo
  ip pim

--- a/tests/topotests/msdp_topo1/r3/pimd.conf
+++ b/tests/topotests/msdp_topo1/r3/pimd.conf
@@ -1,5 +1,5 @@
-debug pim
-debug pim zebra
+! debug pim
+! debug pim zebra
 !
 interface lo
  ip pim

--- a/tests/topotests/msdp_topo1/r4/pimd.conf
+++ b/tests/topotests/msdp_topo1/r4/pimd.conf
@@ -1,5 +1,5 @@
-debug pim
-debug pim zebra
+! debug pim
+! debug pim zebra
 !
 interface lo
  ip pim

--- a/tests/topotests/nhrp_topo/r1/nhrpd.conf
+++ b/tests/topotests/nhrp_topo/r1/nhrpd.conf
@@ -1,5 +1,5 @@
 log stdout debugging
-debug nhrp all
+! debug nhrp all
 interface r1-gre0
  ip nhrp holdtime 500
  ip nhrp shortcut

--- a/tests/topotests/nhrp_topo/r2/nhrpd.conf
+++ b/tests/topotests/nhrp_topo/r2/nhrpd.conf
@@ -1,4 +1,4 @@
-debug nhrp all
+! debug nhrp all
 log stdout debugging
 nhrp nflog-group 1
 interface r2-gre0

--- a/tests/topotests/nhrp_topo/r3/zebra.conf
+++ b/tests/topotests/nhrp_topo/r3/zebra.conf
@@ -1,7 +1,7 @@
-debug zebra kernel
-debug zebra rib
-debug zebra events
-debug zebra packet
+! debug zebra kernel
+! debug zebra rib
+! debug zebra events
+! debug zebra packet
 ip forwarding
 interface r3-eth0
  ip address 10.1.1.3/24

--- a/tests/topotests/ospf6_gr_topo1/rt1/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt1/ospf6d.conf
@@ -3,14 +3,14 @@ hostname rt1
 log file ospf6d.log
 log commands
 !
-debug ospf6 lsa router originate
-debug ospf6 lsa router flooding
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 graceful-restart
-debug ospf6 spf process
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router flooding
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 graceful-restart
+! debug ospf6 spf process
 !
 interface lo
  ipv6 ospf area 1

--- a/tests/topotests/ospf6_gr_topo1/rt1/zebra.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt1/zebra.conf
@@ -3,10 +3,10 @@ hostname rt1
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/ospf6_gr_topo1/rt2/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt2/ospf6d.conf
@@ -3,14 +3,14 @@ hostname rt2
 log file ospf6d.log
 log commands
 !
-debug ospf6 lsa router originate
-debug ospf6 lsa router flooding
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 graceful-restart
-debug ospf6 spf process
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router flooding
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 graceful-restart
+! debug ospf6 spf process
 !
 interface lo
  ipv6 ospf area 0

--- a/tests/topotests/ospf6_gr_topo1/rt2/zebra.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt2/zebra.conf
@@ -3,10 +3,10 @@ hostname rt2
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/ospf6_gr_topo1/rt3/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt3/ospf6d.conf
@@ -3,14 +3,14 @@ hostname rt3
 log file ospf6d.log
 log commands
 !
-debug ospf6 lsa router originate
-debug ospf6 lsa router flooding
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 graceful-restart
-debug ospf6 spf process
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router flooding
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 graceful-restart
+! debug ospf6 spf process
 !
 interface lo
  ipv6 ospf area 0

--- a/tests/topotests/ospf6_gr_topo1/rt3/zebra.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt3/zebra.conf
@@ -3,10 +3,10 @@ hostname rt3
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/ospf6_gr_topo1/rt4/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt4/ospf6d.conf
@@ -3,14 +3,14 @@ hostname rt4
 log file ospf6d.log
 log commands
 !
-debug ospf6 lsa router originate
-debug ospf6 lsa router flooding
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 graceful-restart
-debug ospf6 spf process
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router flooding
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 graceful-restart
+! debug ospf6 spf process
 !
 interface lo
  ipv6 ospf area 0

--- a/tests/topotests/ospf6_gr_topo1/rt4/zebra.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt4/zebra.conf
@@ -3,10 +3,10 @@ hostname rt4
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/ospf6_gr_topo1/rt5/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt5/ospf6d.conf
@@ -3,14 +3,14 @@ hostname rt5
 log file ospf6d.log
 log commands
 !
-debug ospf6 lsa router originate
-debug ospf6 lsa router flooding
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 graceful-restart
-debug ospf6 spf process
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router flooding
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 graceful-restart
+! debug ospf6 spf process
 !
 interface lo
  ipv6 ospf area 2

--- a/tests/topotests/ospf6_gr_topo1/rt5/zebra.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt5/zebra.conf
@@ -3,10 +3,10 @@ hostname rt5
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/ospf6_gr_topo1/rt6/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt6/ospf6d.conf
@@ -3,14 +3,14 @@ hostname rt6
 log file ospf6d.log
 log commands
 !
-debug ospf6 lsa router originate
-debug ospf6 lsa router flooding
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 graceful-restart
-debug ospf6 spf process
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router flooding
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 graceful-restart
+! debug ospf6 spf process
 !
 interface lo
  ipv6 ospf area 0

--- a/tests/topotests/ospf6_gr_topo1/rt6/zebra.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt6/zebra.conf
@@ -3,10 +3,10 @@ hostname rt6
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 6.6.6.6/32

--- a/tests/topotests/ospf6_gr_topo1/rt7/ospf6d.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt7/ospf6d.conf
@@ -3,14 +3,14 @@ hostname rt7
 log file ospf6d.log
 log commands
 !
-debug ospf6 lsa router originate
-debug ospf6 lsa router flooding
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 graceful-restart
-debug ospf6 spf process
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router flooding
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 graceful-restart
+! debug ospf6 spf process
 !
 interface lo
  ipv6 ospf area 3

--- a/tests/topotests/ospf6_gr_topo1/rt7/zebra.conf
+++ b/tests/topotests/ospf6_gr_topo1/rt7/zebra.conf
@@ -3,10 +3,10 @@ hostname rt7
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 7.7.7.7/32

--- a/tests/topotests/ospf6_topo1/r1/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1/r1/ospf6d.conf
@@ -1,13 +1,13 @@
 hostname r1
 log file ospf6d.log
 !
-debug ospf6 message all
-debug ospf6 lsa unknown
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 route table
-debug ospf6 flooding
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
 !
 interface r1-stubnet
  ipv6 ospf6 network broadcast

--- a/tests/topotests/ospf6_topo1/r1/zebra.conf
+++ b/tests/topotests/ospf6_topo1/r1/zebra.conf
@@ -2,8 +2,8 @@
 hostname r1
 log file zebra.log
 !
-debug zebra events
-debug zebra rib
+! debug zebra events
+! debug zebra rib
 !
 interface r1-stubnet
  ipv6 address fc00:1:1:1::1/64

--- a/tests/topotests/ospf6_topo1/r2/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1/r2/ospf6d.conf
@@ -1,13 +1,13 @@
 hostname r2
 log file ospf6d.log
 !
-debug ospf6 message all
-debug ospf6 lsa unknown
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 route table
-debug ospf6 flooding
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
 !
 interface r2-stubnet
  ipv6 ospf6 network broadcast

--- a/tests/topotests/ospf6_topo1/r2/zebra.conf
+++ b/tests/topotests/ospf6_topo1/r2/zebra.conf
@@ -2,8 +2,8 @@
 hostname r2
 log file zebra.log
 !
-debug zebra events
-debug zebra rib
+! debug zebra events
+! debug zebra rib
 !
 interface r2-stubnet
  ipv6 address fc00:2:2:2::2/64

--- a/tests/topotests/ospf6_topo1/r3/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1/r3/ospf6d.conf
@@ -1,13 +1,13 @@
 hostname r3
 log file ospf6d.log
 !
-debug ospf6 message all
-debug ospf6 lsa unknown
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 route table
-debug ospf6 flooding
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
 !
 interface r3-stubnet
  ipv6 ospf6 network broadcast

--- a/tests/topotests/ospf6_topo1/r3/zebra.conf
+++ b/tests/topotests/ospf6_topo1/r3/zebra.conf
@@ -2,8 +2,8 @@
 hostname r3
 log file zebra.log
 !
-debug zebra events
-debug zebra rib
+! debug zebra events
+! debug zebra rib
 !
 interface r3-stubnet
  ipv6 address fc00:3:3:3::3/64

--- a/tests/topotests/ospf6_topo1/r4/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1/r4/ospf6d.conf
@@ -1,13 +1,13 @@
 hostname r4
 log file ospf6d.log
 !
-debug ospf6 message all
-debug ospf6 lsa unknown
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 route table
-debug ospf6 flooding
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
 !
 interface r4-stubnet
  ipv6 ospf6 network broadcast

--- a/tests/topotests/ospf6_topo1/r4/zebra.conf
+++ b/tests/topotests/ospf6_topo1/r4/zebra.conf
@@ -2,8 +2,8 @@
 hostname r4
 log file zebra.log
 !
-debug zebra events
-debug zebra rib
+! debug zebra events
+! debug zebra rib
 !
 interface r4-stubnet
  ipv6 address fc00:4:4:4::4/64

--- a/tests/topotests/ospf6_topo1_vrf/r1/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r1/ospf6d.conf
@@ -1,13 +1,13 @@
 hostname r1
 log file ospf6d.log
 !
-debug ospf6 message all
-debug ospf6 lsa unknown
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 route table
-debug ospf6 flooding
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
 !
 interface r1-stubnet
  ipv6 ospf6 area 0.0.0.0

--- a/tests/topotests/ospf6_topo1_vrf/r1/zebra.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r1/zebra.conf
@@ -2,8 +2,8 @@
 hostname r1
 log file zebra.log
 !
-debug zebra events
-debug zebra rib
+! debug zebra events
+! debug zebra rib
 !
 interface r1-stubnet vrf r1-cust1
  ipv6 address fc00:1:1:1::1/64

--- a/tests/topotests/ospf6_topo1_vrf/r2/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r2/ospf6d.conf
@@ -1,13 +1,13 @@
 hostname r2
 log file ospf6d.log
 !
-debug ospf6 message all
-debug ospf6 lsa unknown
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 route table
-debug ospf6 flooding
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
 !
 interface r2-stubnet
  ipv6 ospf6 area 0.0.0.0

--- a/tests/topotests/ospf6_topo1_vrf/r2/zebra.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r2/zebra.conf
@@ -2,8 +2,8 @@
 hostname r2
 log file zebra.log
 !
-debug zebra events
-debug zebra rib
+! debug zebra events
+! debug zebra rib
 !
 interface r2-stubnet vrf r2-cust1
  ipv6 address fc00:2:2:2::2/64

--- a/tests/topotests/ospf6_topo1_vrf/r3/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r3/ospf6d.conf
@@ -1,13 +1,13 @@
 hostname r3
 log file ospf6d.log
 !
-debug ospf6 message all
-debug ospf6 lsa unknown
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 route table
-debug ospf6 flooding
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
 !
 interface r3-stubnet
  ipv6 ospf6 area 0.0.0.0

--- a/tests/topotests/ospf6_topo1_vrf/r3/zebra.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r3/zebra.conf
@@ -2,8 +2,8 @@
 hostname r3
 log file zebra.log
 !
-debug zebra events
-debug zebra rib
+! debug zebra events
+! debug zebra rib
 !
 interface r3-stubnet vrf r3-cust1 
  ipv6 address fc00:3:3:3::3/64

--- a/tests/topotests/ospf6_topo1_vrf/r4/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r4/ospf6d.conf
@@ -1,13 +1,13 @@
 hostname r4
 log file ospf6d.log
 !
-debug ospf6 message all
-debug ospf6 lsa unknown
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 route table
-debug ospf6 flooding
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
 !
 interface r4-stubnet
  ipv6 ospf6 area 0.0.0.1

--- a/tests/topotests/ospf6_topo1_vrf/r4/zebra.conf
+++ b/tests/topotests/ospf6_topo1_vrf/r4/zebra.conf
@@ -2,8 +2,8 @@
 hostname r4
 log file zebra.log
 !
-debug zebra events
-debug zebra rib
+! debug zebra events
+! debug zebra rib
 !
 interface r4-stubnet vrf r4-cust1 
  ipv6 address fc00:4:4:4::4/64

--- a/tests/topotests/ospf6_topo2/r1/ospf6d.conf
+++ b/tests/topotests/ospf6_topo2/r1/ospf6d.conf
@@ -1,30 +1,30 @@
-debug ospf6 lsa router
-debug ospf6 lsa router originate
-debug ospf6 lsa router examine
-debug ospf6 lsa router flooding
-debug ospf6 lsa nssa
-debug ospf6 lsa nssa originate
-debug ospf6 lsa nssa examine
-debug ospf6 lsa nssa flooding
-debug ospf6 lsa as-external
-debug ospf6 lsa as-external originate
-debug ospf6 lsa as-external examine
-debug ospf6 lsa as-external flooding
-debug ospf6 lsa intra-prefix
-debug ospf6 lsa intra-prefix originate
-debug ospf6 lsa intra-prefix examine
-debug ospf6 lsa intra-prefix flooding
-debug ospf6 border-routers
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 spf process
-debug ospf6 route intra-area
-debug ospf6 route inter-area
-debug ospf6 abr
-debug ospf6 asbr
-debug ospf6 nssa
+! debug ospf6 lsa router
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router examine
+! debug ospf6 lsa router flooding
+! debug ospf6 lsa nssa
+! debug ospf6 lsa nssa originate
+! debug ospf6 lsa nssa examine
+! debug ospf6 lsa nssa flooding
+! debug ospf6 lsa as-external
+! debug ospf6 lsa as-external originate
+! debug ospf6 lsa as-external examine
+! debug ospf6 lsa as-external flooding
+! debug ospf6 lsa intra-prefix
+! debug ospf6 lsa intra-prefix originate
+! debug ospf6 lsa intra-prefix examine
+! debug ospf6 lsa intra-prefix flooding
+! debug ospf6 border-routers
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 spf process
+! debug ospf6 route intra-area
+! debug ospf6 route inter-area
+! debug ospf6 abr
+! debug ospf6 asbr
+! debug ospf6 nssa
 !
 interface r1-eth0
  ipv6 ospf6 area 0.0.0.1

--- a/tests/topotests/ospf6_topo2/r2/ospf6d.conf
+++ b/tests/topotests/ospf6_topo2/r2/ospf6d.conf
@@ -1,30 +1,30 @@
-debug ospf6 lsa router
-debug ospf6 lsa router originate
-debug ospf6 lsa router examine
-debug ospf6 lsa router flooding
-debug ospf6 lsa nssa
-debug ospf6 lsa nssa originate
-debug ospf6 lsa nssa examine
-debug ospf6 lsa nssa flooding
-debug ospf6 lsa as-external
-debug ospf6 lsa as-external originate
-debug ospf6 lsa as-external examine
-debug ospf6 lsa as-external flooding
-debug ospf6 lsa intra-prefix
-debug ospf6 lsa intra-prefix originate
-debug ospf6 lsa intra-prefix examine
-debug ospf6 lsa intra-prefix flooding
-debug ospf6 border-routers
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 spf process
-debug ospf6 route intra-area
-debug ospf6 route inter-area
-debug ospf6 abr
-debug ospf6 asbr
-debug ospf6 nssa
+! debug ospf6 lsa router
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router examine
+! debug ospf6 lsa router flooding
+! debug ospf6 lsa nssa
+! debug ospf6 lsa nssa originate
+! debug ospf6 lsa nssa examine
+! debug ospf6 lsa nssa flooding
+! debug ospf6 lsa as-external
+! debug ospf6 lsa as-external originate
+! debug ospf6 lsa as-external examine
+! debug ospf6 lsa as-external flooding
+! debug ospf6 lsa intra-prefix
+! debug ospf6 lsa intra-prefix originate
+! debug ospf6 lsa intra-prefix examine
+! debug ospf6 lsa intra-prefix flooding
+! debug ospf6 border-routers
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 spf process
+! debug ospf6 route intra-area
+! debug ospf6 route inter-area
+! debug ospf6 abr
+! debug ospf6 asbr
+! debug ospf6 nssa
 !
 interface r2-eth0
  ipv6 ospf6 area 0.0.0.1

--- a/tests/topotests/ospf6_topo2/r3/ospf6d.conf
+++ b/tests/topotests/ospf6_topo2/r3/ospf6d.conf
@@ -1,30 +1,30 @@
-debug ospf6 lsa router
-debug ospf6 lsa router originate
-debug ospf6 lsa router examine
-debug ospf6 lsa router flooding
-debug ospf6 lsa nssa
-debug ospf6 lsa nssa originate
-debug ospf6 lsa nssa examine
-debug ospf6 lsa nssa flooding
-debug ospf6 lsa as-external
-debug ospf6 lsa as-external originate
-debug ospf6 lsa as-external examine
-debug ospf6 lsa as-external flooding
-debug ospf6 lsa intra-prefix
-debug ospf6 lsa intra-prefix originate
-debug ospf6 lsa intra-prefix examine
-debug ospf6 lsa intra-prefix flooding
-debug ospf6 border-routers
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 spf process
-debug ospf6 route intra-area
-debug ospf6 route inter-area
-debug ospf6 abr
-debug ospf6 asbr
-debug ospf6 nssa
+! debug ospf6 lsa router
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router examine
+! debug ospf6 lsa router flooding
+! debug ospf6 lsa nssa
+! debug ospf6 lsa nssa originate
+! debug ospf6 lsa nssa examine
+! debug ospf6 lsa nssa flooding
+! debug ospf6 lsa as-external
+! debug ospf6 lsa as-external originate
+! debug ospf6 lsa as-external examine
+! debug ospf6 lsa as-external flooding
+! debug ospf6 lsa intra-prefix
+! debug ospf6 lsa intra-prefix originate
+! debug ospf6 lsa intra-prefix examine
+! debug ospf6 lsa intra-prefix flooding
+! debug ospf6 border-routers
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 spf process
+! debug ospf6 route intra-area
+! debug ospf6 route inter-area
+! debug ospf6 abr
+! debug ospf6 asbr
+! debug ospf6 nssa
 !
 interface r3-eth0
  ipv6 ospf6 area 0.0.0.0

--- a/tests/topotests/ospf6_topo2/r4/ospf6d.conf
+++ b/tests/topotests/ospf6_topo2/r4/ospf6d.conf
@@ -1,30 +1,30 @@
-debug ospf6 lsa router
-debug ospf6 lsa router originate
-debug ospf6 lsa router examine
-debug ospf6 lsa router flooding
-debug ospf6 lsa nssa
-debug ospf6 lsa nssa originate
-debug ospf6 lsa nssa examine
-debug ospf6 lsa nssa flooding
-debug ospf6 lsa as-external
-debug ospf6 lsa as-external originate
-debug ospf6 lsa as-external examine
-debug ospf6 lsa as-external flooding
-debug ospf6 lsa intra-prefix
-debug ospf6 lsa intra-prefix originate
-debug ospf6 lsa intra-prefix examine
-debug ospf6 lsa intra-prefix flooding
-debug ospf6 border-routers
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 spf process
-debug ospf6 route intra-area
-debug ospf6 route inter-area
-debug ospf6 abr
-debug ospf6 asbr
-debug ospf6 nssa
+! debug ospf6 lsa router
+! debug ospf6 lsa router originate
+! debug ospf6 lsa router examine
+! debug ospf6 lsa router flooding
+! debug ospf6 lsa nssa
+! debug ospf6 lsa nssa originate
+! debug ospf6 lsa nssa examine
+! debug ospf6 lsa nssa flooding
+! debug ospf6 lsa as-external
+! debug ospf6 lsa as-external originate
+! debug ospf6 lsa as-external examine
+! debug ospf6 lsa as-external flooding
+! debug ospf6 lsa intra-prefix
+! debug ospf6 lsa intra-prefix originate
+! debug ospf6 lsa intra-prefix examine
+! debug ospf6 lsa intra-prefix flooding
+! debug ospf6 border-routers
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 flooding
+! debug ospf6 spf process
+! debug ospf6 route intra-area
+! debug ospf6 route inter-area
+! debug ospf6 abr
+! debug ospf6 asbr
+! debug ospf6 nssa
 !
 interface r4-eth0
  ipv6 ospf6 area 0.0.0.2

--- a/tests/topotests/ospf_gr_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt1/ospfd.conf
@@ -3,16 +3,16 @@ hostname rt1
 log file ospfd.log
 log commands
 !
-debug ospf zebra
-debug ospf event
-debug ospf lsa
-debug ospf te
-debug ospf packet all
-debug ospf packet ls-update detail
-debug ospf ism
-debug ospf nsm
-debug ospf nssa
-debug ospf graceful-restart
+! debug ospf zebra
+! debug ospf event
+! debug ospf lsa
+! debug ospf te
+! debug ospf packet all
+! debug ospf packet ls-update detail
+! debug ospf ism
+! debug ospf nsm
+! debug ospf nssa
+! debug ospf graceful-restart
 !
 interface lo
  ip ospf area 1

--- a/tests/topotests/ospf_gr_topo1/rt1/zebra.conf
+++ b/tests/topotests/ospf_gr_topo1/rt1/zebra.conf
@@ -3,10 +3,10 @@ hostname rt1
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/ospf_gr_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt2/ospfd.conf
@@ -3,16 +3,16 @@ hostname rt2
 log file ospfd.log
 log commands
 !
-debug ospf zebra
-debug ospf event
-debug ospf lsa
-debug ospf te
-debug ospf packet all
-debug ospf packet ls-update detail
-debug ospf ism
-debug ospf nsm
-debug ospf nssa
-debug ospf graceful-restart
+! debug ospf zebra
+! debug ospf event
+! debug ospf lsa
+! debug ospf te
+! debug ospf packet all
+! debug ospf packet ls-update detail
+! debug ospf ism
+! debug ospf nsm
+! debug ospf nssa
+! debug ospf graceful-restart
 !
 interface lo
  ip ospf area 0

--- a/tests/topotests/ospf_gr_topo1/rt2/zebra.conf
+++ b/tests/topotests/ospf_gr_topo1/rt2/zebra.conf
@@ -3,10 +3,10 @@ hostname rt2
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/ospf_gr_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt3/ospfd.conf
@@ -3,16 +3,16 @@ hostname rt3
 log file ospfd.log
 log commands
 !
-debug ospf zebra
-debug ospf event
-debug ospf lsa
-debug ospf te
-debug ospf packet all
-debug ospf packet ls-update detail
-debug ospf ism
-debug ospf nsm
-debug ospf nssa
-debug ospf graceful-restart
+! debug ospf zebra
+! debug ospf event
+! debug ospf lsa
+! debug ospf te
+! debug ospf packet all
+! debug ospf packet ls-update detail
+! debug ospf ism
+! debug ospf nsm
+! debug ospf nssa
+! debug ospf graceful-restart
 !
 interface lo
  ip ospf area 0

--- a/tests/topotests/ospf_gr_topo1/rt3/zebra.conf
+++ b/tests/topotests/ospf_gr_topo1/rt3/zebra.conf
@@ -3,10 +3,10 @@ hostname rt3
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/ospf_gr_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt4/ospfd.conf
@@ -3,16 +3,16 @@ hostname rt4
 log file ospfd.log
 log commands
 !
-debug ospf zebra
-debug ospf event
-debug ospf lsa
-debug ospf te
-debug ospf packet all
-debug ospf packet ls-update detail
-debug ospf ism
-debug ospf nsm
-debug ospf nssa
-debug ospf graceful-restart
+! debug ospf zebra
+! debug ospf event
+! debug ospf lsa
+! debug ospf te
+! debug ospf packet all
+! debug ospf packet ls-update detail
+! debug ospf ism
+! debug ospf nsm
+! debug ospf nssa
+! debug ospf graceful-restart
 !
 interface lo
  ip ospf area 0

--- a/tests/topotests/ospf_gr_topo1/rt4/zebra.conf
+++ b/tests/topotests/ospf_gr_topo1/rt4/zebra.conf
@@ -3,10 +3,10 @@ hostname rt4
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/ospf_gr_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt5/ospfd.conf
@@ -3,16 +3,16 @@ hostname rt5
 log file ospfd.log
 log commands
 !
-debug ospf zebra
-debug ospf event
-debug ospf lsa
-debug ospf te
-debug ospf packet all
-debug ospf packet ls-update detail
-debug ospf ism
-debug ospf nsm
-debug ospf nssa
-debug ospf graceful-restart
+! debug ospf zebra
+! debug ospf event
+! debug ospf lsa
+! debug ospf te
+! debug ospf packet all
+! debug ospf packet ls-update detail
+! debug ospf ism
+! debug ospf nsm
+! debug ospf nssa
+! debug ospf graceful-restart
 !
 interface lo
  ip ospf area 2

--- a/tests/topotests/ospf_gr_topo1/rt5/zebra.conf
+++ b/tests/topotests/ospf_gr_topo1/rt5/zebra.conf
@@ -3,10 +3,10 @@ hostname rt5
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/ospf_gr_topo1/rt6/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt6/ospfd.conf
@@ -3,16 +3,16 @@ hostname rt6
 log file ospfd.log
 log commands
 !
-debug ospf zebra
-debug ospf event
-debug ospf lsa
-debug ospf te
-debug ospf packet all
-debug ospf packet ls-update detail
-debug ospf ism
-debug ospf nsm
-debug ospf nssa
-debug ospf graceful-restart
+! debug ospf zebra
+! debug ospf event
+! debug ospf lsa
+! debug ospf te
+! debug ospf packet all
+! debug ospf packet ls-update detail
+! debug ospf ism
+! debug ospf nsm
+! debug ospf nssa
+! debug ospf graceful-restart
 !
 interface lo
  ip ospf area 0

--- a/tests/topotests/ospf_gr_topo1/rt6/zebra.conf
+++ b/tests/topotests/ospf_gr_topo1/rt6/zebra.conf
@@ -3,10 +3,10 @@ hostname rt6
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 6.6.6.6/32

--- a/tests/topotests/ospf_gr_topo1/rt7/ospfd.conf
+++ b/tests/topotests/ospf_gr_topo1/rt7/ospfd.conf
@@ -3,16 +3,16 @@ hostname rt7
 log file ospfd.log
 log commands
 !
-debug ospf zebra
-debug ospf event
-debug ospf lsa
-debug ospf te
-debug ospf packet all
-debug ospf packet ls-update detail
-debug ospf ism
-debug ospf nsm
-debug ospf nssa
-debug ospf graceful-restart
+! debug ospf zebra
+! debug ospf event
+! debug ospf lsa
+! debug ospf te
+! debug ospf packet all
+! debug ospf packet ls-update detail
+! debug ospf ism
+! debug ospf nsm
+! debug ospf nssa
+! debug ospf graceful-restart
 !
 interface lo
  ip ospf area 3

--- a/tests/topotests/ospf_gr_topo1/rt7/zebra.conf
+++ b/tests/topotests/ospf_gr_topo1/rt7/zebra.conf
@@ -3,10 +3,10 @@ hostname rt7
 log file zebra.log
 log commands
 !
-debug zebra event
-debug zebra packet
-debug zebra rib
-debug zebra kernel
+! debug zebra event
+! debug zebra packet
+! debug zebra rib
+! debug zebra kernel
 !
 interface lo
  ip address 7.7.7.7/32

--- a/tests/topotests/ospf_sr_te_topo1/dst/zebra.conf
+++ b/tests/topotests/ospf_sr_te_topo1/dst/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname dst
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 9.9.9.2/32

--- a/tests/topotests/ospf_sr_te_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt1/ospfd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt1
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/ospf_sr_te_topo1/rt1/zebra.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt1/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt1
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/ospf_sr_te_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt2/ospfd.conf
@@ -1,11 +1,11 @@
 hostname rt2
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/ospf_sr_te_topo1/rt2/zebra.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt2/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt2
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/ospf_sr_te_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt3/ospfd.conf
@@ -1,11 +1,11 @@
 hostname rt3
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/ospf_sr_te_topo1/rt3/zebra.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt3/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt3
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/ospf_sr_te_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt4/ospfd.conf
@@ -1,11 +1,11 @@
 hostname rt4
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/ospf_sr_te_topo1/rt4/zebra.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt4/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt4
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/ospf_sr_te_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt5/ospfd.conf
@@ -1,11 +1,11 @@
 hostname rt5
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/ospf_sr_te_topo1/rt5/zebra.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt5/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt5
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/ospf_sr_te_topo1/rt6/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt6/ospfd.conf
@@ -1,11 +1,11 @@
 hostname rt6
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
  ip ospf area 0.0.0.0

--- a/tests/topotests/ospf_sr_te_topo1/rt6/zebra.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt6/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt6
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 6.6.6.6/32

--- a/tests/topotests/ospf_sr_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt1/ospfd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt1
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
 !

--- a/tests/topotests/ospf_sr_topo1/rt1/zebra.conf
+++ b/tests/topotests/ospf_sr_topo1/rt1/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt1
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/ospf_sr_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt2/ospfd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt2
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
 !

--- a/tests/topotests/ospf_sr_topo1/rt2/zebra.conf
+++ b/tests/topotests/ospf_sr_topo1/rt2/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt2
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/ospf_sr_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt3/ospfd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt3
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
 !

--- a/tests/topotests/ospf_sr_topo1/rt3/zebra.conf
+++ b/tests/topotests/ospf_sr_topo1/rt3/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt3
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 3.3.3.3/32

--- a/tests/topotests/ospf_sr_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt4/ospfd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt4
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
 !

--- a/tests/topotests/ospf_sr_topo1/rt4/zebra.conf
+++ b/tests/topotests/ospf_sr_topo1/rt4/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt4
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 4.4.4.4/32

--- a/tests/topotests/ospf_sr_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt5/ospfd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt5
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
 !

--- a/tests/topotests/ospf_sr_topo1/rt5/zebra.conf
+++ b/tests/topotests/ospf_sr_topo1/rt5/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt5
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 5.5.5.5/32

--- a/tests/topotests/ospf_sr_topo1/rt6/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt6/ospfd.conf
@@ -2,11 +2,11 @@ password 1
 hostname rt6
 log file ospfd.log
 !
-debug ospf sr
-debug ospf te
-debug ospf event
-debug ospf lsa
-debug ospf zebra
+! debug ospf sr
+! debug ospf te
+! debug ospf event
+! debug ospf lsa
+! debug ospf zebra
 !
 interface lo
 !

--- a/tests/topotests/ospf_sr_topo1/rt6/zebra.conf
+++ b/tests/topotests/ospf_sr_topo1/rt6/zebra.conf
@@ -2,9 +2,9 @@ log file zebra.log
 !
 hostname rt6
 !
-debug zebra kernel
-debug zebra packet
-debug zebra mpls
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
 !
 interface lo
  ip address 6.6.6.6/32

--- a/tests/topotests/ospf_tilfa_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt1/ospfd.conf
@@ -1,5 +1,5 @@
-debug ospf sr
-debug ospf ti-lfa
+! debug ospf sr
+! debug ospf ti-lfa
 !
 interface lo
 !

--- a/tests/topotests/ospf_tilfa_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt2/ospfd.conf
@@ -1,5 +1,5 @@
-debug ospf sr
-debug ospf ti-lfa
+! debug ospf sr
+! debug ospf ti-lfa
 !
 interface lo
 !

--- a/tests/topotests/ospf_tilfa_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt3/ospfd.conf
@@ -1,5 +1,5 @@
-debug ospf sr
-debug ospf ti-lfa
+! debug ospf sr
+! debug ospf ti-lfa
 !
 interface lo
 !

--- a/tests/topotests/ospf_tilfa_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt4/ospfd.conf
@@ -1,5 +1,5 @@
-debug ospf sr
-debug ospf ti-lfa
+! debug ospf sr
+! debug ospf ti-lfa
 !
 interface lo
 !

--- a/tests/topotests/ospf_tilfa_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt5/ospfd.conf
@@ -1,5 +1,5 @@
-debug ospf sr
-debug ospf ti-lfa
+! debug ospf sr
+! debug ospf ti-lfa
 !
 interface lo
 !

--- a/tests/topotests/ospf_topo1_vrf/r1/zebra.conf
+++ b/tests/topotests/ospf_topo1_vrf/r1/zebra.conf
@@ -1,7 +1,7 @@
-debug zebra kernel
-debug zebra dplane detail
-debug zebra rib
-debug zebra event
+! debug zebra kernel
+! debug zebra dplane detail
+! debug zebra rib
+! debug zebra event
 !
 hostname r1
 password zebra

--- a/tests/topotests/pbr_topo1/r1/pbrd.conf
+++ b/tests/topotests/pbr_topo1/r1/pbrd.conf
@@ -1,7 +1,7 @@
-debug pbr
-debug pbr events
-debug pbr nht
-debug pbr zebra
+! debug pbr
+! debug pbr events
+! debug pbr nht
+! debug pbr zebra
 # Valid table range
 pbr table range 10000 50000
 # Try to set invalid bounds

--- a/tests/topotests/pim_acl/r1/ospfd.conf
+++ b/tests/topotests/pim_acl/r1/ospfd.conf
@@ -1,6 +1,6 @@
 hostname r1
 !
-debug ospf event
+! debug ospf event
 !
 interface r1-eth1
  ip ospf hello-interval 2

--- a/tests/topotests/pim_acl/r1/pimd.conf
+++ b/tests/topotests/pim_acl/r1/pimd.conf
@@ -1,12 +1,12 @@
 hostname r1
 !
-debug igmp events
-debug igmp packets
-debug pim events
-debug pim packets
-debug pim trace
-debug pim zebra
-debug pim bsm
+! debug igmp events
+! debug igmp packets
+! debug pim events
+! debug pim packets
+! debug pim trace
+! debug pim zebra
+! debug pim bsm
 !
 ip pim rp 192.168.0.11 prefix-list rp-pl-1
 ip pim rp 192.168.0.12 prefix-list rp-pl-2

--- a/tests/topotests/pim_acl/r11/ospfd.conf
+++ b/tests/topotests/pim_acl/r11/ospfd.conf
@@ -1,6 +1,6 @@
 hostname r11
 !
-debug ospf event
+! debug ospf event
 !
 interface r11-eth0
  ip ospf hello-interval 2

--- a/tests/topotests/pim_acl/r11/pimd.conf
+++ b/tests/topotests/pim_acl/r11/pimd.conf
@@ -1,10 +1,10 @@
 hostname r11
 !
-debug pim events
-debug pim packets
-debug pim trace
-debug pim zebra
-debug pim bsm
+! debug pim events
+! debug pim packets
+! debug pim trace
+! debug pim zebra
+! debug pim bsm
 !
 ip pim rp 192.168.0.11 239.100.0.0/28
 ip pim join-prune-interval 5

--- a/tests/topotests/pim_acl/r12/ospfd.conf
+++ b/tests/topotests/pim_acl/r12/ospfd.conf
@@ -1,6 +1,6 @@
 hostname r12
 !
-debug ospf event
+! debug ospf event
 !
 interface r12-eth0
  ip ospf hello-interval 2

--- a/tests/topotests/pim_acl/r12/pimd.conf
+++ b/tests/topotests/pim_acl/r12/pimd.conf
@@ -1,10 +1,10 @@
 hostname r12
 !
-debug pim events
-debug pim packets
-debug pim trace
-debug pim zebra
-debug pim bsm
+! debug pim events
+! debug pim packets
+! debug pim trace
+! debug pim zebra
+! debug pim bsm
 !
 ip pim rp 192.168.0.12 239.100.0.17/32
 ip pim join-prune-interval 5

--- a/tests/topotests/pim_acl/r13/ospfd.conf
+++ b/tests/topotests/pim_acl/r13/ospfd.conf
@@ -1,6 +1,6 @@
 hostname r13
 !
-debug ospf event
+! debug ospf event
 !
 interface r13-eth0
  ip ospf hello-interval 2

--- a/tests/topotests/pim_acl/r13/pimd.conf
+++ b/tests/topotests/pim_acl/r13/pimd.conf
@@ -1,10 +1,10 @@
 hostname r13
 !
-debug pim events
-debug pim packets
-debug pim trace
-debug pim zebra
-debug pim bsm
+! debug pim events
+! debug pim packets
+! debug pim trace
+! debug pim zebra
+! debug pim bsm
 !
 ip pim rp 192.168.0.13 239.100.0.32/27
 ip pim join-prune-interval 5

--- a/tests/topotests/pim_acl/r14/ospfd.conf
+++ b/tests/topotests/pim_acl/r14/ospfd.conf
@@ -1,6 +1,6 @@
 hostname r14
 !
-debug ospf event
+! debug ospf event
 !
 interface r14-eth0
  ip ospf hello-interval 2

--- a/tests/topotests/pim_acl/r14/pimd.conf
+++ b/tests/topotests/pim_acl/r14/pimd.conf
@@ -1,10 +1,10 @@
 hostname r14
 !
-debug pim events
-debug pim packets
-debug pim trace
-debug pim zebra
-debug pim bsm
+! debug pim events
+! debug pim packets
+! debug pim trace
+! debug pim zebra
+! debug pim bsm
 !
 ip pim rp 192.168.0.14 239.100.0.96/28
 ip pim rp 192.168.0.14 239.100.0.128/25

--- a/tests/topotests/pim_acl/r15/ospfd.conf
+++ b/tests/topotests/pim_acl/r15/ospfd.conf
@@ -1,6 +1,6 @@
 hostname r15
 !
-debug ospf event
+! debug ospf event
 !
 interface r15-eth0
  ip ospf hello-interval 2

--- a/tests/topotests/pim_acl/r15/pimd.conf
+++ b/tests/topotests/pim_acl/r15/pimd.conf
@@ -1,10 +1,10 @@
 hostname r15
 !
-debug pim events
-debug pim packets
-debug pim trace
-debug pim zebra
-debug pim bsm
+! debug pim events
+! debug pim packets
+! debug pim trace
+! debug pim zebra
+! debug pim bsm
 !
 ip pim rp 192.168.0.15 239.100.0.64/28
 ip pim join-prune-interval 5

--- a/tests/topotests/pim_igmp_vrf/r1/ospfd.conf
+++ b/tests/topotests/pim_igmp_vrf/r1/ospfd.conf
@@ -1,6 +1,6 @@
 hostname r1
 !
-debug ospf event
+! debug ospf event
 !
 !
 interface r1-eth1

--- a/tests/topotests/pim_igmp_vrf/r1/pimd.conf
+++ b/tests/topotests/pim_igmp_vrf/r1/pimd.conf
@@ -1,12 +1,12 @@
 hostname r1
 !
-debug igmp events
-debug igmp packets
-debug pim events
-debug pim packets
-debug pim trace
-debug pim zebra
-debug pim bsm
+! debug igmp events
+! debug igmp packets
+! debug pim events
+! debug pim packets
+! debug pim trace
+! debug pim zebra
+! debug pim bsm
 !
 interface r1-eth0
  ip igmp

--- a/tests/topotests/pim_igmp_vrf/r11/ospfd.conf
+++ b/tests/topotests/pim_igmp_vrf/r11/ospfd.conf
@@ -1,6 +1,6 @@
 hostname r11
 !
-debug ospf event
+! debug ospf event
 !
 interface r11-eth0
  ip ospf hello-interval 2

--- a/tests/topotests/pim_igmp_vrf/r11/pimd.conf
+++ b/tests/topotests/pim_igmp_vrf/r11/pimd.conf
@@ -1,10 +1,10 @@
 hostname r11
 !
-debug pim events
-debug pim packets
-debug pim trace
-debug pim zebra
-debug pim bsm
+! debug pim events
+! debug pim packets
+! debug pim trace
+! debug pim zebra
+! debug pim bsm
 !
 ip pim rp 192.168.0.11 239.100.0.0/28
 ip pim join-prune-interval 5

--- a/tests/topotests/pim_igmp_vrf/r12/ospfd.conf
+++ b/tests/topotests/pim_igmp_vrf/r12/ospfd.conf
@@ -1,6 +1,6 @@
 hostname r12
 !
-debug ospf event
+! debug ospf event
 !
 interface r12-eth0
  ip ospf hello-interval 2

--- a/tests/topotests/pim_igmp_vrf/r12/pimd.conf
+++ b/tests/topotests/pim_igmp_vrf/r12/pimd.conf
@@ -1,10 +1,10 @@
 hostname r12
 !
-debug pim events
-debug pim packets
-debug pim trace
-debug pim zebra
-debug pim bsm
+! debug pim events
+! debug pim packets
+! debug pim trace
+! debug pim zebra
+! debug pim bsm
 !
 ip pim rp 192.168.0.12 239.100.0.0/28
 ip pim join-prune-interval 5

--- a/tests/topotests/ripng_topo1/r1/ripngd.conf
+++ b/tests/topotests/ripng_topo1/r1/ripngd.conf
@@ -1,8 +1,8 @@
 log file ripngd.log
 !
-debug ripng events
-debug ripng packet
-debug ripng zebra
+! debug ripng events
+! debug ripng packet
+! debug ripng zebra
 !
 router ripng
  timers basic 5 180 5

--- a/tests/topotests/ripng_topo1/r2/ripngd.conf
+++ b/tests/topotests/ripng_topo1/r2/ripngd.conf
@@ -1,8 +1,8 @@
 log file ripngd.log
 !
-debug ripng events
-debug ripng packet
-debug ripng zebra
+! debug ripng events
+! debug ripng packet
+! debug ripng zebra
 !
 router ripng
  timers basic 5 180 5

--- a/tests/topotests/ripng_topo1/r3/ripngd.conf
+++ b/tests/topotests/ripng_topo1/r3/ripngd.conf
@@ -1,8 +1,8 @@
 log file ripngd.log
 !
-debug ripng events
-debug ripng packet
-debug ripng zebra
+! debug ripng events
+! debug ripng packet
+! debug ripng zebra
 !
 router ripng
  timers basic 5 180 5

--- a/tests/topotests/simple_snmp_test/r1/isisd.conf
+++ b/tests/topotests/simple_snmp_test/r1/isisd.conf
@@ -1,7 +1,7 @@
 log stdout debugging
 !
-debug isis route-events
-debug isis events
+! debug isis route-events
+! debug isis events
 !
 interface r1-eth0
   ip router isis ISIS1

--- a/tests/topotests/srv6_locator/r1/zebra.conf
+++ b/tests/topotests/srv6_locator/r1/zebra.conf
@@ -1,7 +1,7 @@
 hostname r1
 !
-debug zebra events
-debug zebra rib detailed
+! debug zebra events
+! debug zebra rib detailed
 !
 log stdout notifications
 log monitor notifications

--- a/tests/topotests/zebra_seg6_route/r1/zebra.conf
+++ b/tests/topotests/zebra_seg6_route/r1/zebra.conf
@@ -4,9 +4,9 @@ log stdout notifications
 log monitor notifications
 log commands
 !
-debug zebra packet
-debug zebra dplane
-debug zebra kernel msgdump
+! debug zebra packet
+! debug zebra dplane
+! debug zebra kernel msgdump
 !
 interface dum0
  ipv6 address 2001::1/64

--- a/tests/topotests/zebra_seg6local_route/r1/zebra.conf
+++ b/tests/topotests/zebra_seg6local_route/r1/zebra.conf
@@ -4,6 +4,6 @@ log stdout notifications
 log monitor notifications
 log commands
 !
-debug zebra packet
-debug zebra dplane
-debug zebra kernel msgdump
+! debug zebra packet
+! debug zebra dplane
+! debug zebra kernel msgdump


### PR DESCRIPTION
Debugs take up a significant amount of cpu time as well as
increased disk space for storage of results.  Reduce test
over head by removing the debugs,  Hopefully this helps
alleviate some of the overloading that we are seeing in
our CI systems.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>