### PR TITLE
nhrpd: align nhrp privs with definition from others

### DIFF
--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -55,7 +55,9 @@ struct zebra_privs_t nhrpd_privs = {
 #endif
 	.caps_p = _caps_p,
 	.cap_num_p = array_size(_caps_p),
+	.cap_num_i = 0
 };
+
 
 static void parse_arguments(int argc, char **argv)
 {


### PR DESCRIPTION
nhrp_privs global context is aligned with other daemon contexts

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>