### PR TITLE
ospf6d: Addressing few coverity issues.

### DIFF
--- a/ospf6d/ospf6_gr.h
+++ b/ospf6d/ospf6_gr.h
@@ -93,7 +93,7 @@ struct tlv_header {
 
 #define TLV_BODY_SIZE(tlvh) (ROUNDUP(ntohs((tlvh)->length), sizeof(uint32_t)))
 
-#define TLV_SIZE(tlvh) (TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh))
+#define TLV_SIZE(tlvh) (uint32_t)(TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh))
 
 #define TLV_HDR_TOP(lsah)                                                      \
 	(struct tlv_header *)((char *)(lsah) + OSPF6_LSA_HEADER_SIZE)


### PR DESCRIPTION
Description:
	Addressed the following TAINTED_SCALAR issue which can possibly
	leads to memory currption.

	1. *** CID 1506514:  Insecure data handling  (TAINTED_SddddddCALAR)
	   /ospf6d/ospf6_gr_helper.c: 1222 in ospf6_grace_lsa_show_info()

	2. *** CID 1506513:  Insecure data handling  (TAINTED_SCALAR)
	   /ospf6d/ospf6_gr_helper.c: 160 in ospf6_extract_grace_lsa_fields()

Signed-off-by: Rajesh Girada <rgirada@vmware.com>