### PR TITLE
Fix a bug that the RA packets send failed

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -494,7 +494,8 @@ static int rtadv_timer(struct thread *thread)
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			if (if_is_loopback_or_vrf(ifp)
-			    || !if_is_operative(ifp))
+			    || !if_is_operative(ifp)
+			    || ifp->vrf_id != zvrf->vrf->vrf_id)
 				continue;
 
 			zif = ifp->info;


### PR DESCRIPTION
The rtadv_timer() sends RA packets for all possible interfaces in the vrf, but the existing code sends RA packets for all interfaces in **all** VRFs (not only the zvrf), so when it uses the the zvrf's socket (zvrf->rtadv.sock) to send packets, it would be failed if the interface does not belong this this zvrf.

Issue reported: https://github.com/FRRouting/frr/issues/9821