### PR TITLE
tests: Fix frequent failure of ospf_gr_topo1 on slower systems

### DIFF
--- a/tests/topotests/ospf_gr_topo1/test_ospf_gr_topo1.py
+++ b/tests/topotests/ospf_gr_topo1/test_ospf_gr_topo1.py
@@ -231,7 +231,7 @@ def check_routers(initial_convergence=False, exiting=None, restarting=None):
             tries = 240
         else:
             if restarting != None:
-                tries = 40
+                tries = 60
             else:
                 tries = 1
         router_compare_json_output(


### PR DESCRIPTION
Test doesn't wait long enough when it checks the routers after
restart. On slower systems, it frequently failed as it ran out
of time

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>