### PR TITLE
lib: resolver per vrf support

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1833,6 +1833,7 @@ static int bmp_active_thread(struct thread *t)
 	socklen_t slen;
 	int status, ret;
 	char buf[SU_ADDRSTRLEN];
+	vrf_id_t vrf_id;
 
 	/* all 3 end up here, though only timer or read+write are active
 	 * at a time */
@@ -1843,7 +1844,12 @@ static int bmp_active_thread(struct thread *t)
 	ba->last_err = NULL;
 
 	if (ba->socket == -1) {
-		resolver_resolve(&ba->resq, AF_UNSPEC, ba->hostname,
+		/* get vrf_id */
+		if (!ba->targets || !ba->targets->bgp)
+			vrf_id = VRF_DEFAULT;
+		else
+			vrf_id = ba->targets->bgp->vrf_id;
+		resolver_resolve(&ba->resq, AF_UNSPEC, vrf_id, ba->hostname,
 				 bmp_active_resolved);
 		return 0;
 	}

--- a/lib/resolver.h
+++ b/lib/resolver.h
@@ -27,10 +27,10 @@ struct resolver_query {
 };
 
 void resolver_init(struct thread_master *tm);
-void resolver_resolve(struct resolver_query *query, int af,
-		      const char *hostname, void (*cb)(struct resolver_query *,
-						       const char *, int,
-						       union sockunion *));
+void resolver_resolve(struct resolver_query *query, int af, vrf_id_t vrf_id,
+		      const char *hostname,
+		      void (*cb)(struct resolver_query *, const char *, int,
+				 union sockunion *));
 
 #ifdef __cplusplus
 }

--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -324,8 +324,8 @@ static int nhrp_nhs_resolve(struct thread *t)
 {
 	struct nhrp_nhs *nhs = THREAD_ARG(t);
 
-	resolver_resolve(&nhs->dns_resolve, AF_INET, nhs->nbma_fqdn,
-			 nhrp_nhs_resolve_cb);
+	resolver_resolve(&nhs->dns_resolve, AF_INET, VRF_DEFAULT,
+			 nhs->nbma_fqdn, nhrp_nhs_resolve_cb);
 
 	return 0;
 }

--- a/tests/lib/test_resolver.c
+++ b/tests/lib/test_resolver.c
@@ -63,7 +63,7 @@ DEFUN (test_resolve,
        "DNS resolver\n"
        "Name to resolve\n")
 {
-	resolver_resolve(&query, AF_UNSPEC, argv[1]->arg, resolver_result);
+	resolver_resolve(&query, AF_UNSPEC, 0, argv[1]->arg, resolver_result);
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
add a parameter to resolver api that is the vrf identifier. this permits
to make resolution self to each vrf. in case vrf netns backend is used,
this is very practical, since resolution can happen on one netns, while
it is not the case in an other one.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
