### PR TITLE
lib: Fix comparison function in link_state.c

### DIFF
--- a/lib/link_state.h
+++ b/lib/link_state.h
@@ -94,6 +94,16 @@ struct ls_node_id {
 	} id __attribute__((aligned(8)));
 };
 
+/**
+ * Check if two Link State Node IDs are equal. Note that this routine has the
+ * same return value sense as '==' (which is different from a comparison).
+ *
+ * @param i1	First Link State Node Identifier
+ * @param i2	Second Link State Node Identifier
+ * @return	1 if equal, 0 otherwise
+ */
+extern int ls_node_id_same(struct ls_node_id i1, struct ls_node_id i2);
+
 /* Link State flags to indicate which Node parameters are valid */
 #define LS_NODE_UNSET		0x0000
 #define LS_NODE_NAME		0x0001


### PR DESCRIPTION
ls_node_same, ls_attributes_same and ls_prefix_same are not producing expected
result due to a wrong usage of memcmp. In addition, if respective structures
are not initialized with 0, there is a risk that the comparison failed.

This patch correct usage of memcmp and expand comparison to each invidual
parameters of the respective structure for safer result.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>