### PR TITLE
doc: Remove reference to non-existent command

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1425,15 +1425,6 @@ Configuring Peers
 
    Set description of the peer.
 
-.. clicmd:: neighbor PEER version VERSION
-
-   Set up the neighbor's BGP version. `version` can be `4`, `4+` or `4-`. BGP
-   version `4` is the default value used for BGP peering. BGP version `4+`
-   means that the neighbor supports Multiprotocol Extensions for BGP-4. BGP
-   version `4-` is similar but the neighbor speaks the old Internet-Draft
-   revision 00's Multiprotocol Extensions for BGP-4. Some routing software is
-   still using this version.
-
 .. clicmd:: neighbor PEER interface IFNAME
 
    When you connect to a BGP peer over an IPv6 link-local address, you have to


### PR DESCRIPTION
The `neighbor <peer> version <X>` command does not
exist.  I am unable to find it going back to version
2.0 of FRR.  So this command has been not in the system
for a very long time.

In any event bgp already supports version 4 of bgp and
it auto-negotiates this.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>