### PR TITLE
zebra: GRE_UPDATE message incomplete

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3434,6 +3434,7 @@ static inline void zebra_gre_get(ZAPI_HANDLER_ARGS)
 		stream_putl(s, IFINDEX_INTERNAL);
 		stream_putl(s, VRF_UNKNOWN);
 		stream_putl(s, 0);
+		stream_putl(s, 0);
 	}
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));


### PR DESCRIPTION
when gre information could not be retrieved because GRE interface has
been deleted, a GRE_UPDATE message may be sent to NHRP. In that case,
the gre values are reset. There was a missing tunnel destination value,
which has been omitted.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>