### PR TITLE
bgpd: Add Long-lived Graceful Restart capability (restarter)

### DIFF
--- a/bgpd/bgp_open.h
+++ b/bgpd/bgp_open.h
@@ -50,6 +50,7 @@ struct graceful_restart_af {
 #define CAPABILITY_CODE_DYNAMIC        67 /* Dynamic Capability */
 #define CAPABILITY_CODE_ADDPATH        69 /* Addpath Capability */
 #define CAPABILITY_CODE_ENHANCED_RR    70 /* Enhanced Route Refresh capability */
+#define CAPABILITY_CODE_LLGR           71 /* Long-lived Graceful Restart */
 #define CAPABILITY_CODE_FQDN           73 /* Advertise hostname capability */
 #define CAPABILITY_CODE_ENHE            5 /* Extended Next Hop Encoding */
 #define CAPABILITY_CODE_REFRESH_OLD   128 /* Route Refresh Capability(cisco) */
@@ -66,6 +67,7 @@ struct graceful_restart_af {
 #define CAPABILITY_CODE_ENHE_LEN        6 /* NRLI AFI = 2, SAFI = 2, Nexthop AFI = 2 */
 #define CAPABILITY_CODE_MIN_FQDN_LEN    2
 #define CAPABILITY_CODE_ENHANCED_LEN    0
+#define CAPABILITY_CODE_LLGR_LEN        0
 #define CAPABILITY_CODE_ORF_LEN         5
 #define CAPABILITY_CODE_EXT_MESSAGE_LEN 0 /* Extended Message Support */
 
@@ -87,6 +89,9 @@ struct graceful_restart_af {
 /* Graceful Restart */
 #define RESTART_R_BIT              0x8000
 #define RESTART_F_BIT              0x80
+
+/* Long-lived Graceful Restart */
+#define LLGR_F_BIT 0x80
 
 extern int bgp_open_option_parse(struct peer *, uint8_t, int *);
 extern void bgp_open_capability(struct stream *, struct peer *);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3169,6 +3169,7 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	bgp_addpath_init_bgp_data(&bgp->tx_addpath);
 	bgp->fast_convergence = false;
 	bgp->as = *as;
+	bgp->llgr_stale_time = BGP_DEFAULT_LLGR_STALE_TIME;
 
 #ifdef ENABLE_BGP_VNC
 	if (inst_type != BGP_INSTANCE_TYPE_VRF) {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -613,6 +613,9 @@ struct bgp {
 	struct graceful_restart_info gr_info[AFI_MAX][SAFI_MAX];
 	uint32_t rib_stale_time;
 
+	/* BGP Long-lived Graceful Restart */
+	uint32_t llgr_stale_time;
+
 #define BGP_ROUTE_SELECT_DELAY 1
 #define BGP_MAX_BEST_ROUTE_SELECT 10000
 	/* Maximum-paths configuration */
@@ -1052,6 +1055,11 @@ enum bgp_fsm_status {
 
 #define PEER_HOSTNAME(peer) ((peer)->host ? (peer)->host : "(unknown peer)")
 
+struct llgr_info {
+	uint32_t stale_time;
+	uint8_t flags;
+};
+
 /* BGP neighbor structure. */
 struct peer {
 	/* BGP structure.  */
@@ -1182,6 +1190,8 @@ struct peer {
 #define PEER_CAP_ENHANCED_RR_RCV (1U << 18) /* enhanced rr received */
 #define PEER_CAP_EXTENDED_MESSAGE_ADV (1U << 19)
 #define PEER_CAP_EXTENDED_MESSAGE_RCV (1U << 20)
+#define PEER_CAP_LLGR_ADV (1U << 21)
+#define PEER_CAP_LLGR_RCV (1U << 22)
 
 	/* Capability flags (reset in bgp_stop) */
 	uint32_t af_cap[AFI_MAX][SAFI_MAX];
@@ -1200,6 +1210,8 @@ struct peer {
 #define PEER_CAP_ENHE_AF_ADV                (1U << 12) /* Extended nexthopi afi/safi advertised */
 #define PEER_CAP_ENHE_AF_RCV                (1U << 13) /* Extended nexthop afi/safi received */
 #define PEER_CAP_ENHE_AF_NEGO               (1U << 14) /* Extended nexthop afi/safi negotiated */
+#define PEER_CAP_LLGR_AF_ADV                (1U << 15)
+#define PEER_CAP_LLGR_AF_RCV                (1U << 16)
 
 	/* Global configuration flags. */
 	/*
@@ -1657,6 +1669,9 @@ struct peer {
 	/* set TCP max segment size */
 	uint32_t tcp_mss;
 
+	/* Long-lived Graceful Restart */
+	struct llgr_info llgr[AFI_MAX][SAFI_MAX];
+
 	QOBJ_FIELDS;
 };
 DECLARE_QOBJ_TYPE(peer);
@@ -1868,6 +1883,9 @@ struct bgp_nlri {
 #define BGP_DEFAULT_SELECT_DEFERRAL_TIME       360
 #define BGP_DEFAULT_RIB_STALE_TIME             500
 #define BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME  1
+
+/* BGP Long-lived Graceful Restart */
+#define BGP_DEFAULT_LLGR_STALE_TIME 360
 
 /* BGP uptime string length.  */
 #define BGP_UPTIME_LEN 25

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -989,6 +989,18 @@ BGP GR Peer Mode Commands
    at the peer level.
 
 
+Long-lived Graceful Restart
+---------------------------
+
+Currently, only restarter mode is supported. This capability is advertised only
+if graceful restart capability is negotiated.
+
+.. clicmd:: bgp long-lived-graceful-restart stale-time (0-4294967295)
+
+   Specifies the maximum time to wait before purging long-lived stale routes for
+   helper routers.
+
+
 .. _bgp-shutdown:
 
 Administrative Shutdown


### PR DESCRIPTION
Restart Router mode.

FRRouting (Restarter):
```
 bgp long-lived-graceful-restart stale-time 10
 bgp graceful-restart restart-time 1
```

Tested with GoBGP (Helper):
```
    long-lived-graceful-restart:	advertised and received
        Local:
	    ipv4-unicast, restart time 100000 sec
        Remote:
	    ipv4-unicast, restart time 10 sec, forward flag set
```

Logs:

```
{"Key":"192.168.10.123","Reason":"graceful-restart","State":"BGP_FSM_ESTABLISHED","Topic":"Peer","level":"info","msg":"Peer Down","time":"2021-10-25T17:48:36+03:00"}
{"Key":"192.168.10.123","State":"BGP_FSM_IDLE","Topic":"Peer","level":"warning","msg":"graceful restart timer expired","time":"2021-10-25T17:48:37+03:00"}
{"Family":65537,"Key":"192.168.10.123","Topic":"Peer","level":"info","msg":"start LLGR restart timer (10 sec) for ipv4-unicast","time":"2021-10-25T17:48:37+03:00"}
{"Family":65537,"Key":"192.168.10.123","Topic":"Peer","level":"info","msg":"LLGR restart timer (10 sec) for ipv4-unicast expired","time":"2021-10-25T17:48:47+03:00"}

% ./gobgp global rib
   Network              Next Hop             AS_PATH              Age        Attrs
S*>10.0.2.0/24          192.168.10.123       174                  00:12:08   [{Origin: ?} {Med: 0} {Communities: llgr-stale} {Extcomms: [174:1282304808]}]
```

Helper mode will be added with upcoming PRs.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>