### PR TITLE
lib: fix srv6 route hardcode with BGP

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -450,7 +450,7 @@ enum zclient_send_status zclient_send_localsid(struct zclient *zclient,
 	p.prefix = *sid;
 
 	api.vrf_id = VRF_DEFAULT;
-	api.type = ZEBRA_ROUTE_BGP;
+	api.type = zclient->redist_default;
 	api.instance = 0;
 	api.safi = SAFI_UNICAST;
 	memcpy(&api.prefix, &p, sizeof(p));


### PR DESCRIPTION
zclient_send_localsid is called by various routing protocol daemons. To set the
srv6 endpoint function. Fix a hard-coded error in the initial implementation.
Before this PR, the srv6 function will be registered to zebra as a BGP route
even if isisd executes zclient_send_localsid.

Signed-off-by: Hiroki Shirokura <hiroki.shirokura@linecorp.com>