### PR TITLE
pimd : IGMP join and pim join handling on same interface

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1283,11 +1283,15 @@ void pim_ifchannel_local_membership_del(struct interface *ifp,
 {
 	struct pim_ifchannel *starch, *ch, *orig;
 	struct pim_interface *pim_ifp;
+	struct pim_instance *pim;
 
 	/* PIM enabled on interface? */
 	pim_ifp = ifp->info;
 	if (!pim_ifp)
 		return;
+
+	pim = pim_ifp->pim;
+
 	if (!PIM_IF_TEST_PIM(pim_ifp->options))
 		return;
 
@@ -1295,6 +1299,10 @@ void pim_ifchannel_local_membership_del(struct interface *ifp,
 	if (!ch)
 		return;
 	ifmembership_set(ch, PIM_IFMEMBERSHIP_NOINFO);
+
+	if (orig->upstream)
+		pim_channel_del_oif(orig->upstream->channel_oil, ch->interface,
+				    PIM_OIF_FLAG_PROTO_IGMP, __func__);
 
 	if (sg->src.s_addr == INADDR_ANY) {
 		struct pim_upstream *up = pim_upstream_find(pim_ifp->pim, sg);
@@ -1333,6 +1341,8 @@ void pim_ifchannel_local_membership_del(struct interface *ifp,
 			/* Child node removal/ref count-- will happen as part of
 			 * parent' delete_no_info */
 		}
+		pim_channel_del_oif(up->channel_oil, pim->regiface,
+				    PIM_OIF_FLAG_PROTO_IGMP, __func__);
 	}
 
 	/* Resettng the IGMP flags here */

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -456,6 +456,10 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	/* Prevent single protocol from subscribing same interface to
 	   channel (S,G) multiple times */
 	if (channel_oil->oif_flags[pim_ifp->mroute_vif_index] & proto_mask) {
+
+		channel_oil->oif_flags[pim_ifp->mroute_vif_index] |=
+			proto_mask;
+
 		if (PIM_DEBUG_MROUTE) {
 			char group_str[INET_ADDRSTRLEN];
 			char source_str[INET_ADDRSTRLEN];


### PR DESCRIPTION
Problem Statement:
==================
When IGMP join and PIM join both exists on the same ifchannel.
Then mroutes were not getting programmed correctly.

Root Cause Analysis:
====================
In case DR/nonDR PIMd will have IGMP join and PIM join
on the same interface, in the topology when RP is reachable
via nonDR node. In this case nonDR will have PIM join.
Now nonDR becomes the DR, so DR node would have IGMP join also.
There is the problem when IGMP join removal comes first, then
mroute clean up is not happening correctly.

Signed-off-by: Sarita Patra <saritap@vmware.com>