### PR TITLE
pimd: Mroutes in prune state after removing and adding attached nw config

### DIFF
--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -263,10 +263,8 @@ void pim_zebra_upstream_rpf_changed(struct pim_instance *pim,
 		 * We have detected a case where we might need
 		 * to rescan the inherited o_list so do it.
 		 */
-		if (up->channel_oil->oil_inherited_rescan) {
-			pim_upstream_inherited_olist_decide(pim, up);
-			up->channel_oil->oil_inherited_rescan = 0;
-		}
+		pim_upstream_inherited_olist_decide(pim, up);
+		up->channel_oil->oil_inherited_rescan = 0;
 
 		if (up->join_state == PIM_UPSTREAM_JOINED) {
 			/*


### PR DESCRIPTION
Problem Statement:
==================
LHR has got the WHOLEPKT event, for (190.190.190.190 226.1.1.1),
(190.190.190.190 226.1.1.2) and (190.190.190.190 226.1.1.3)
It has created the upstream. But It has not send the join towards RP.
Also mroute out interface is not correct.

RCA:
====
While creating upstream and updating the rpf, for (190.190.190.190 226.1.1.1),
(190.190.190.190 226.1.1.2) and (190.190.190.190 226.1.1.3) with destination
190.190.190.190/32. It gets resolved to ens160, It was a management interface
and PIM was not enabled on this interface.
The wholepkt is a data packet it reaches early, path to 190.190.190.190 is
computed via BGP, so it takes some more time.
When pimd gets the update trigger for 190.190.190.190/32 it start processing
SG entries as mentioned above. But if fails to resolve mroute out interfaces
and eventually failed to calcluate join desired state.

Fix:
====
If RPF check returns changed, and previous interface was not there
in the upstream then recalculate the mroute oil

Signed-off-by: sarita patra <saritap@vmware.com>