### PR TITLE
zebra: Add support for json output in srv6 locator detail command

### DIFF
--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -171,6 +171,47 @@ json_object *srv6_locator_chunk_json(const struct srv6_locator_chunk *chunk)
 	return jo_root;
 }
 
+json_object *
+srv6_locator_chunk_detailed_json(const struct srv6_locator_chunk *chunk)
+{
+	json_object *jo_root = NULL;
+
+	jo_root = json_object_new_object();
+
+	/* set prefix */
+	json_object_string_addf(jo_root, "prefix", "%pFX", &chunk->prefix);
+
+	/* set block_bits_length */
+	json_object_int_add(jo_root, "blockBitsLength",
+			    chunk->block_bits_length);
+
+	/* set node_bits_length */
+	json_object_int_add(jo_root, "nodeBitsLength", chunk->node_bits_length);
+
+	/* set function_bits_length */
+	json_object_int_add(jo_root, "functionBitsLength",
+			    chunk->function_bits_length);
+
+	/* set argument_bits_length */
+	json_object_int_add(jo_root, "argumentBitsLength",
+			    chunk->argument_bits_length);
+
+	/* set keep */
+	json_object_int_add(jo_root, "keep", chunk->keep);
+
+	/* set proto */
+	json_object_string_add(jo_root, "proto",
+			       zebra_route_string(chunk->proto));
+
+	/* set instance */
+	json_object_int_add(jo_root, "instance", chunk->instance);
+
+	/* set session_id */
+	json_object_int_add(jo_root, "sessionId", chunk->session_id);
+
+	return jo_root;
+}
+
 json_object *srv6_locator_json(const struct srv6_locator *loc)
 {
 	struct listnode *node;
@@ -200,6 +241,53 @@ json_object *srv6_locator_json(const struct srv6_locator *loc)
 	json_object_object_add(jo_root, "chunks", jo_chunks);
 	for (ALL_LIST_ELEMENTS_RO((struct list *)loc->chunks, node, chunk)) {
 		jo_chunk = srv6_locator_chunk_json(chunk);
+		json_object_array_add(jo_chunks, jo_chunk);
+	}
+
+	return jo_root;
+}
+
+json_object *srv6_locator_detailed_json(const struct srv6_locator *loc)
+{
+	struct listnode *node;
+	struct srv6_locator_chunk *chunk;
+	json_object *jo_root = NULL;
+	json_object *jo_chunk = NULL;
+	json_object *jo_chunks = NULL;
+
+	jo_root = json_object_new_object();
+
+	/* set name */
+	json_object_string_add(jo_root, "name", loc->name);
+
+	/* set prefix */
+	json_object_string_addf(jo_root, "prefix", "%pFX", &loc->prefix);
+
+	/* set block_bits_length */
+	json_object_int_add(jo_root, "blockBitsLength", loc->block_bits_length);
+
+	/* set node_bits_length */
+	json_object_int_add(jo_root, "nodeBitsLength", loc->node_bits_length);
+
+	/* set function_bits_length */
+	json_object_int_add(jo_root, "functionBitsLength",
+			    loc->function_bits_length);
+
+	/* set argument_bits_length */
+	json_object_int_add(jo_root, "argumentBitsLength",
+			    loc->argument_bits_length);
+
+	/* set algonum */
+	json_object_int_add(jo_root, "algoNum", loc->algonum);
+
+	/* set status_up */
+	json_object_boolean_add(jo_root, "statusUp", loc->status_up);
+
+	/* set chunks */
+	jo_chunks = json_object_new_array();
+	json_object_object_add(jo_root, "chunks", jo_chunks);
+	for (ALL_LIST_ELEMENTS_RO((struct list *)loc->chunks, node, chunk)) {
+		jo_chunk = srv6_locator_chunk_detailed_json(chunk);
 		json_object_array_add(jo_chunks, jo_chunk);
 	}
 

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -189,6 +189,9 @@ extern void srv6_locator_free(struct srv6_locator *locator);
 extern void srv6_locator_chunk_free(struct srv6_locator_chunk *chunk);
 json_object *srv6_locator_chunk_json(const struct srv6_locator_chunk *chunk);
 json_object *srv6_locator_json(const struct srv6_locator *loc);
+json_object *srv6_locator_detailed_json(const struct srv6_locator *loc);
+json_object *
+srv6_locator_chunk_detailed_json(const struct srv6_locator_chunk *chunk);
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -147,10 +147,16 @@ DEFUN (show_srv6_locator_detail,
 	struct listnode *node;
 	char str[256];
 	const char *locator_name = argv[4]->arg;
+	json_object *json_locator = NULL;
 
 	if (uj) {
-		vty_out(vty, "JSON format isn't supported\n");
-		return CMD_WARNING;
+		locator = zebra_srv6_locator_lookup(locator_name);
+		if (!locator)
+			return CMD_WARNING;
+
+		json_locator = srv6_locator_detailed_json(locator);
+		vty_json(vty, json_locator);
+		return CMD_SUCCESS;
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(srv6->locators, node, locator)) {


### PR DESCRIPTION
Add the json output to `show-srv6-locator-detail` command.
At almost cases, these fields may be filled by zero but its not bad for future extensibility.

here's a sample output that's generated from `vtysh -c 'sh segment-routing srv6 locator loc1 detail json' | jq` in srv6_locator topotest.

```json
{
  "name": "loc1",
  "prefix": "2001:db8:1:1::/64",
  "blockBitsLength": 40,
  "nodeBitsLength": 24,
  "functionBitsLength": 0,
  "argumentBitsLength": 0,
  "algoNum": 0,
  "statusUp": true,
  "chunks": [
    {
      "prefix": "2001:db8:1:1::/64",
      "blockBitsLength": 0,
      "nodeBitsLength": 0,
      "functionBitsLength": 0,
      "argumentBitsLength": 0,
      "keep": 0,
      "proto": "system",
      "instance": 0,
      "sessionId": 0
    }
  ]
}
```

Signed-off-by: Drumato <drumato43@gmail.com>