### PR TITLE
pimd: Change in PIM join and mroute

### DIFF
--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -39,6 +39,7 @@
 #include "pim_rp.h"
 #include "pim_jp_agg.h"
 #include "pim_util.h"
+#include "pim_ssm.h"
 
 static void on_trace(const char *label, struct interface *ifp,
 		     struct in_addr src)
@@ -55,6 +56,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		      struct prefix_sg *sg, uint8_t source_flags)
 {
 	struct pim_interface *pim_ifp = NULL;
+	char buf[PREFIX_STRLEN];
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		char up_str[INET_ADDRSTRLEN];
@@ -102,6 +104,14 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 			zlog_warn(
 				"%s: Specified RP(%s) in join is different than our configured RP(%s)",
 				__func__, received_rp, local_rp);
+			return;
+		}
+
+		if (pim_is_grp_ssm(pim_ifp->pim, sg->grp)) {
+			zlog_warn(
+				"%s: Specified Group(%s) in join is now in SSM, not allowed to create PIM state",
+				__func__,
+				inet_ntop(AF_INET, &sg->grp, buf, sizeof(buf)));
 			return;
 		}
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -542,6 +542,7 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 		struct pim_interface *pim_ifp = ifp->info;
 		struct listnode *grpnode;
 		struct igmp_group *grp;
+		struct pim_ifchannel *ch, *ch_temp;
 
 		if (!pim_ifp)
 			continue;
@@ -556,9 +557,17 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 			for (ALL_LIST_ELEMENTS_RO(grp->group_source_list,
 						  srcnode, src)) {
 				igmp_source_forward_reevaluate_one(pim, src);
-			}	  /* scan group sources */
-		}		  /* scan igmp groups */
-	}			  /* scan interfaces */
+			} /* scan group sources */
+		}	 /* scan igmp groups */
+
+		RB_FOREACH_SAFE (ch, pim_ifchannel_rb, &pim_ifp->ifchannel_rb,
+				 ch_temp) {
+			if (pim_is_grp_ssm(pim, ch->sg.grp)) {
+				if (ch->sg.src.s_addr == INADDR_ANY)
+					pim_ifchannel_delete(ch);
+			}
+		}
+	} /* scan interfaces */
 }
 
 void igmp_source_forward_start(struct pim_instance *pim,


### PR DESCRIPTION
Problem :
=======
(*,G) created on transit node where same groups are defined as SSM
At present FRR has SSM checks for IGMP report, but SSM check is missing for PIM join.

Fix :
===
1. When an interface receives the PIM (*,G)join with G as SSM group, then PIMd supposed to discard that join.
   There is no need to maintain PIM state for this group.
2. Whenever there is a modification in prefix list for SSM range, then we need to browse the ifchannels (PIM joins)
   and groups coming in SSM range with (and *,G) should be removed from ifchannel database and also withdraw those routes
   from upstream routers.

Signed-off-by: Sai Gomathi <nsaigomathi@vmware.com>