### PR TITLE
tests: topotests/lib/lutil.py: optimize wait to not repeat command after expected result found

### DIFF
--- a/tests/topotests/lib/lutil.py
+++ b/tests/topotests/lib/lutil.py
@@ -189,11 +189,8 @@ Total %-4d                                                           %-4d %d\n\
             self.log("unable to read: " + tstFile)
             sys.exit(1)
 
-    def command(self, target, command, regexp, op, result, returnJson):
+    def command(self, target, command, regexp, op, result, returnJson, startt=None):
         global net
-        if op != "wait":
-            self.l_line += 1
-
         if op == "jsoncmp_pass" or op == "jsoncmp_fail":
             returnJson = True
 
@@ -294,7 +291,11 @@ Total %-4d                                                           %-4d %d\n\
                     % (group_nl_converted, ret),
                     9,
                 )
-        if op == "pass" or op == "fail":
+        if startt != None:
+            if js != None or ret is not False:
+                delta = time.time() - startt
+                self.result(target, success, "%s +%4.2f secs" % (result, delta))
+        elif op == "pass" or op == "fail":
             self.result(target, success, result)
         if js != None:
             return js
@@ -326,7 +327,7 @@ Total %-4d                                                           %-4d %d\n\
 
         while wait_count > 0:
             n += 1
-            found = self.command(target, command, regexp, op, result, returnJson)
+            found = self.command(target, command, regexp, op, result, returnJson, startt)
             if found is not False:
                 break
 
@@ -336,14 +337,6 @@ Total %-4d                                                           %-4d %d\n\
 
         delta = time.time() - startt
         self.log("Done after %d loops, time=%s, Found=%s" % (n, delta, found))
-        found = self.command(
-            target,
-            command,
-            regexp,
-            "pass",
-            "%s +%4.2f secs" % (result, delta),
-            returnJson,
-        )
         return found
 
 


### PR DESCRIPTION
Donald identified this as a source of an intermittent ci failure due to a code race condition (to be fixed under different PR) 

Signed-off-by: Lou Berger <lberger@labn.net>