### PR TITLE
pimd: During Joined -> NotJoined, upstream should send prune nomatter

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -803,9 +803,8 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 		if (pim_upstream_is_sg_rpt(up) && up->parent &&
 				!I_am_RP(pim, up->sg.grp))
 			send_xg_jp = true;
-		else
-			pim_jp_agg_single_upstream_send(&up->rpf, up,
-							0 /* prune */);
+
+		pim_jp_agg_single_upstream_send(&up->rpf, up, 0 /* prune */);
 
 		if (send_xg_jp) {
 			if (PIM_DEBUG_PIM_TRACE_DETAIL)


### PR DESCRIPTION
RCA: When upstream transition from Joined to NotJoined due to SGRpt
prune, then only SGRpt prune was sent and SG Prune is missed.

Fix: Send SG Prune towards source as well as SGRpt prune towards RP.

Signed-off-by: sarita patra <saritap@vmware.com>
Signed-off-by: Saravanan K <saravanank@vmware.com>