### PR TITLE
ospf6d: avoid writing dumb ospf6 info at startup

### DIFF
--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -461,6 +461,10 @@ void ospf6_spf_reason_string(uint32_t reason, char *buf, int size)
 	if (!buf)
 		return;
 
+	if (!reason) {
+		buf[0] = '\0';
+		return;
+	}
 	for (bit = 0; bit < array_size(ospf6_spf_reason_str); bit++) {
 		if ((reason & (1 << bit)) && (len < size)) {
 			len += snprintf((buf + len), (size - len), "%s%s",


### PR DESCRIPTION
in show: 'show ipv6 ospf6' handler command, the reason of SPF
executation is looked up and displayed. At startup, SPF has been
started, but shows no specific reason. Instead of dumping non
initialised string context, reset the string context.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>