### PR TITLE
Netlink modifications

### DIFF
--- a/zebra/debug_nl.c
+++ b/zebra/debug_nl.c
@@ -927,7 +927,7 @@ next_rta:
 	plen = RTA_PAYLOAD(rta);
 	zlog_debug("    rta [len=%d (payload=%zu) type=(%d) %s]", rta->rta_len,
 		   plen, rta->rta_type, neigh_rta2str(rta->rta_type));
-	switch (rta->rta_type) {
+	switch (rta->rta_type & ~ NLA_F_NESTED) {
 	case NDA_LLADDR:
 		datap = RTA_DATA(rta);
 		dbuf[0] = 0;

--- a/zebra/debug_nl.c
+++ b/zebra/debug_nl.c
@@ -1045,7 +1045,7 @@ next_rta:
 	plen = RTA_PAYLOAD(rta);
 	zlog_debug("    rta [len=%d (payload=%zu) type=(%d) %s]", rta->rta_len,
 		   plen, rta->rta_type, nhm_rta2str(rta->rta_type));
-	switch (rta->rta_type) {
+	switch (rta->rta_type & ~NLA_F_NESTED) {
 	case NHA_ID:
 		u32v = *(uint32_t *)RTA_DATA(rta);
 		zlog_debug("      %u", u32v);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2892,7 +2892,8 @@ int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return -1;
 	}
 
-	netlink_parse_rtattr(tb, NHA_MAX, RTM_NHA(nhm), len);
+	netlink_parse_rtattr_flags(tb, NHA_MAX, RTM_NHA(nhm), len,
+				   NLA_F_NESTED);
 
 
 	if (!tb[NHA_ID]) {


### PR DESCRIPTION
Couple of minor changes to allow us to work w/ nested netlink attributes

1) RTM_NEWNEXTHOP is starting to have to parse nested attributes.  FRR does not have the full ability to do this yet.  But this is a bug in parsing that should just be fixed.

2) RTM_NEWNEIGH with bridges have nested attributes.  Ensure that we can parse them in the debug dumps.