### PR TITLE
ospf6d: fix default ospf intance with default vrf name set to other value

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -1072,7 +1072,7 @@ DEFUN(show_ipv6_ospf6_spf_tree, show_ipv6_ospf6_spf_tree_cmd,
 	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ipv6_ospf6_spf_tree_common(vty, ospf6, uj);
 			if (!all_vrf)
 				break;
@@ -1138,7 +1138,7 @@ DEFUN(show_ipv6_ospf6_area_spf_tree, show_ipv6_ospf6_area_spf_tree_cmd,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			show_ospf6_area_spf_tree_common(vty, argv, ospf6,
 							area_id, idx_ipv4);
 			if (!all_vrf)
@@ -1225,7 +1225,7 @@ DEFUN(show_ipv6_ospf6_simulate_spf_tree_root,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			show_ospf6_simulate_spf_tree_commen(
 				vty, argv, ospf6, router_id, area_id, prefix,
 				idx_ipv4, idx_ipv4_2);

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -2537,10 +2537,7 @@ DEFUN(show_ipv6_ospf6_redistribute, show_ipv6_ospf6_redistribute_cmd,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf
-		    || ((ospf6->name == NULL && vrf_name == NULL)
-			|| (ospf6->name && vrf_name
-			    && strcmp(ospf6->name, vrf_name) == 0))) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_redistribute_show_config(
 				vty, ospf6, json_array_redistribute, json, uj);
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1337,7 +1337,7 @@ DEFUN(show_ipv6_ospf6_interface, show_ipv6_ospf6_interface_ifname_cmd,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			show_ospf6_interface_common(vty, ospf6->vrf_id, argc,
 						    argv, idx_ifname, intf_idx,
 						    json_idx);
@@ -1548,7 +1548,7 @@ DEFUN(show_ipv6_ospf6_interface_traffic, show_ipv6_ospf6_interface_traffic_cmd,
 	OSPF6_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_interface_show_traffic_common(vty, argc, argv,
 							    ospf6->vrf_id);
 
@@ -1594,7 +1594,7 @@ DEFUN(show_ipv6_ospf6_interface_ifname_prefix,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ifp = if_lookup_by_name(argv[idx_ifname]->arg,
 						ospf6->vrf_id);
 			if (ifp == NULL) {
@@ -1652,7 +1652,7 @@ DEFUN(show_ipv6_ospf6_interface_prefix, show_ipv6_ospf6_interface_prefix_cmd,
 		idx_prefix += 2;
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			vrf = vrf_lookup_by_id(ospf6->vrf_id);
 			FOR_ALL_INTERFACES (vrf, ifp) {
 				oi = (struct ospf6_interface *)ifp->info;

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -1101,7 +1101,7 @@ DEFUN(show_ipv6_ospf6_neighbor, show_ipv6_ospf6_neighbor_cmd,
 		drchoice = true;
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_neighbor_show_detail_common(vty, ospf6, uj,
 							  detail, drchoice);
 			if (!all_vrf)
@@ -1172,7 +1172,7 @@ DEFUN(show_ipv6_ospf6_neighbor_one, show_ipv6_ospf6_neighbor_one_cmd,
 		idx_ipv4 += 2;
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_neighbor_show_common(vty, argc, argv, ospf6,
 						   idx_ipv4);
 

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -419,7 +419,7 @@ DEFUN(show_ipv6_ospf6_database, show_ipv6_ospf6_database_cmd,
 
 	level = parse_show_level(idx_level, argc, argv);
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_show_wrapper(vty, level, NULL, NULL, NULL,
 						uj, ospf6);
 			if (!all_vrf)
@@ -469,7 +469,7 @@ DEFUN(show_ipv6_ospf6_database_type, show_ipv6_ospf6_database_type_cmd,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_type_show_wrapper(vty, level, &type, NULL,
 						     NULL, uj, ospf6);
 			if (!all_vrf)
@@ -510,7 +510,7 @@ DEFUN(show_ipv6_ospf6_database_id, show_ipv6_ospf6_database_id_cmd,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_show_wrapper(vty, level, NULL, &id, NULL, uj,
 						ospf6);
 			if (!all_vrf)
@@ -555,7 +555,7 @@ DEFUN(show_ipv6_ospf6_database_router, show_ipv6_ospf6_database_router_cmd,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_show_wrapper(vty, level, NULL, NULL,
 						&adv_router, uj, ospf6);
 			if (!all_vrf)
@@ -622,7 +622,7 @@ DEFUN_HIDDEN(
 	inet_pton(AF_INET, argv[idx_ipv4]->arg, &adv_router);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ipv6_ospf6_database_aggr_router_common(vty, adv_router,
 							       ospf6);
 
@@ -679,7 +679,7 @@ DEFUN(show_ipv6_ospf6_database_type_id, show_ipv6_ospf6_database_type_id_cmd,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_type_show_wrapper(vty, level, &type, &id,
 						     NULL, uj, ospf6);
 			if (!all_vrf)
@@ -737,7 +737,7 @@ DEFUN(show_ipv6_ospf6_database_type_router,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_type_show_wrapper(vty, level, &type, NULL,
 						     &adv_router, uj, ospf6);
 
@@ -787,7 +787,7 @@ DEFUN(show_ipv6_ospf6_database_id_router,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_show_wrapper(vty, level, NULL, &id,
 						&adv_router, uj, ospf6);
 			if (!all_vrf)
@@ -836,7 +836,7 @@ DEFUN(show_ipv6_ospf6_database_adv_router_linkstate_id,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_show_wrapper(vty, level, NULL, &id,
 						&adv_router, uj, ospf6);
 			if (!all_vrf)
@@ -896,7 +896,7 @@ DEFUN(show_ipv6_ospf6_database_type_id_router,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_type_show_wrapper(vty, level, &type, &id,
 						     &adv_router, uj, ospf6);
 
@@ -964,7 +964,7 @@ DEFUN (show_ipv6_ospf6_database_type_adv_router_linkstate_id,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_type_show_wrapper(vty, level, &type, &id,
 						     &adv_router, uj, ospf6);
 
@@ -1005,7 +1005,7 @@ DEFUN(show_ipv6_ospf6_database_self_originated,
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
 		adv_router = ospf6->router_id;
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			ospf6_lsdb_show_wrapper(vty, level, NULL, NULL,
 						&adv_router, uj, ospf6);
 
@@ -1061,7 +1061,7 @@ DEFUN(show_ipv6_ospf6_database_type_self_originated,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			adv_router = ospf6->router_id;
 			ospf6_lsdb_type_show_wrapper(vty, level, &type, NULL,
 						     &adv_router, uj, ospf6);
@@ -1123,7 +1123,7 @@ DEFUN(show_ipv6_ospf6_database_type_self_originated_linkstate_id,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			adv_router = ospf6->router_id;
 			ospf6_lsdb_type_show_wrapper(vty, level, &type, &id,
 						     &adv_router, uj, ospf6);
@@ -1183,7 +1183,7 @@ DEFUN(show_ipv6_ospf6_database_type_id_self_originated,
 	level = parse_show_level(idx_level, argc, argv);
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			adv_router = ospf6->router_id;
 			ospf6_lsdb_type_show_wrapper(vty, level, &type, &id,
 						     &adv_router, uj, ospf6);
@@ -1260,7 +1260,7 @@ DEFUN(show_ipv6_ospf6_border_routers, show_ipv6_ospf6_border_routers_cmd,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			show_ospf6_border_routers_common(vty, argc, argv, ospf6,
 							 idx_ipv4, idx_argc);
 
@@ -1297,7 +1297,7 @@ DEFUN(show_ipv6_ospf6_linkstate, show_ipv6_ospf6_linkstate_cmd,
 		idx_ipv4 += 2;
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, nnode, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
 				vty_out(vty,
 					"\n        SPF Result in Area %s\n\n",
@@ -1336,7 +1336,7 @@ DEFUN(show_ipv6_ospf6_linkstate_detail, show_ipv6_ospf6_linkstate_detail_cmd,
 		idx_detail += 2;
 
 	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6)) {
-		if (all_vrf || strcmp(ospf6->name, vrf_name) == 0) {
+		if (OSPF6_LOOKUP_VALID(ospf6, all_vrf, vrf_name)) {
 			for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
 				vty_out(vty,
 					"\n        SPF Result in Area %s\n\n",

--- a/ospf6d/ospf6d.h
+++ b/ospf6d/ospf6d.h
@@ -99,8 +99,12 @@ extern struct thread_master *master;
 		vrf_name = argv[idx_vrf + 1]->arg;                             \
 		all_vrf = strmatch(vrf_name, "all");                           \
 	} else {                                                               \
-		vrf_name = VRF_DEFAULT_NAME;                                   \
+		vrf_name = NULL;                                               \
 	}
+
+#define OSPF6_LOOKUP_VALID(O, A, V)                                            \
+	((A) || ((V) == NULL && (O)->name == NULL)                             \
+	 || ((V) && (O)->name && strcmp((O)->name, (V)) == 0))
 
 #define OSPF6_FALSE false
 #define OSPF6_TRUE true


### PR DESCRIPTION
This commit addresses following issue where the zebra is started with a
default vrf name set to a value different than default. For instance, the
following is launched:

zebra -o vrf0 &
ospf6d -f /tmp/ospf6d.conf

router ospf6
 ospf6 router-id 10.0.0.1
 log-adjacency-changes detail
 redistribute static
 interface r1-stubnet area 0.0.0.0
 interface r1-sw5 area 0.0.0.0
!

What happens is that the ospf6 instance is seen as a vrf instance with its
name set to 'default' keyword. The show running-config command confirms it:

router ospf6 vrf default
 [..]

Actually, the ospf6 engine works as below: at startup creation, the default
vrf name is picked up and an ospf6 instance is created. This startup creation
occurs before zebra is connected to ospf6d. The ospf6 instance is being
associated the "default" name as per VRF_DEFAULT_NAME macro. Then, when zebra
connects, there is an update of the default vrf, and the macro will then return
"vrf0". All further configuration attempts like below:

router ospf6
 ...

will create a second instance different than the first one, which is not
expected. Other than that, the initial configuration expects to work on a non
default vrf, and is not operational.

To handle those issues, when default vrf name reference is needed, ospf6 will
nullify the attribute name of ospf6. In that way, further zebra updates will
not impact the ospf6 configuration.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>