### PR TITLE
Do not return true/false in dplane_ctx_get_XXX functions

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -940,8 +940,7 @@ void zsend_ipset_entry_notify_owner(const struct zebra_dplane_ctx *ctx,
 	struct zebra_pbr_ipset ipset;
 	uint16_t cmd = ZEBRA_IPSET_ENTRY_NOTIFY_OWNER;
 
-	if (!dplane_ctx_get_pbr_ipset_entry(ctx, &ipent))
-		return;
+	dplane_ctx_get_pbr_ipset_entry(ctx, &ipent);
 	dplane_ctx_get_pbr_ipset(ctx, &ipset);
 
 	if (IS_ZEBRA_DEBUG_PACKET)

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -871,8 +871,7 @@ void zsend_iptable_notify_owner(const struct zebra_dplane_ctx *ctx,
 	struct zebra_pbr_iptable ipt;
 	uint16_t cmd = ZEBRA_IPTABLE_NOTIFY_OWNER;
 
-	if (!dplane_ctx_get_pbr_iptable(ctx, &ipt))
-		return;
+	dplane_ctx_get_pbr_iptable(ctx, &ipt);
 
 	if (IS_ZEBRA_DEBUG_PACKET)
 		zlog_debug("%s: Notifying %s id %u note %u", __func__,

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -906,8 +906,7 @@ void zsend_ipset_notify_owner(const struct zebra_dplane_ctx *ctx,
 	struct zebra_pbr_ipset ipset;
 	uint16_t cmd = ZEBRA_IPSET_NOTIFY_OWNER;
 
-	if (!dplane_ctx_get_pbr_ipset(ctx, &ipset))
-		return;
+	dplane_ctx_get_pbr_ipset(ctx, &ipset);
 
 	if (IS_ZEBRA_DEBUG_PACKET)
 		zlog_debug("%s: Notifying %s id %u note %u", __func__,
@@ -944,8 +943,7 @@ void zsend_ipset_entry_notify_owner(const struct zebra_dplane_ctx *ctx,
 
 	if (!dplane_ctx_get_pbr_ipset_entry(ctx, &ipent))
 		return;
-	if (!dplane_ctx_get_pbr_ipset(ctx, &ipset))
-		return;
+	dplane_ctx_get_pbr_ipset(ctx, &ipset);
 
 	if (IS_ZEBRA_DEBUG_PACKET)
 		zlog_debug("%s: Notifying %s id %u note %u", __func__,

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2155,13 +2155,13 @@ dplane_ctx_get_pbr_iptable(const struct zebra_dplane_ctx *ctx,
 	return true;
 }
 
-bool dplane_ctx_get_pbr_ipset(const struct zebra_dplane_ctx *ctx,
+void dplane_ctx_get_pbr_ipset(const struct zebra_dplane_ctx *ctx,
 			      struct zebra_pbr_ipset *ipset)
 {
 	DPLANE_CTX_VALID(ctx);
 
-	if (!ipset)
-		return false;
+	assert(ipset);
+
 	if (ctx->zd_op == DPLANE_OP_IPSET_ENTRY_ADD ||
 	    ctx->zd_op == DPLANE_OP_IPSET_ENTRY_DELETE) {
 		memset(ipset, 0, sizeof(struct zebra_pbr_ipset));
@@ -2171,7 +2171,6 @@ bool dplane_ctx_get_pbr_ipset(const struct zebra_dplane_ctx *ctx,
 		       ZEBRA_IPSET_NAME_SIZE);
 	} else
 		memcpy(ipset, &ctx->u.ipset, sizeof(struct zebra_pbr_ipset));
-	return true;
 }
 
 bool dplane_ctx_get_pbr_ipset_entry(const struct zebra_dplane_ctx *ctx,
@@ -5068,10 +5067,10 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_IPSET_DELETE: {
 		struct zebra_pbr_ipset ipset;
 
-		if (dplane_ctx_get_pbr_ipset(ctx, &ipset))
-			zlog_debug("Dplane ipset update op %s, unique(%u), ctx %p",
-				   dplane_op2str(dplane_ctx_get_op(ctx)),
-				   ipset.unique, ctx);
+		dplane_ctx_get_pbr_ipset(ctx, &ipset);
+		zlog_debug("Dplane ipset update op %s, unique(%u), ctx %p",
+			   dplane_op2str(dplane_ctx_get_op(ctx)), ipset.unique,
+			   ctx);
 	} break;
 	case DPLANE_OP_IPSET_ENTRY_ADD:
 	case DPLANE_OP_IPSET_ENTRY_DELETE: {

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2145,14 +2145,12 @@ dplane_ctx_get_br_port_backup_nhg_id(const struct zebra_dplane_ctx *ctx)
 }
 
 /* Accessors for PBR iptable information */
-bool
-dplane_ctx_get_pbr_iptable(const struct zebra_dplane_ctx *ctx,
-			   struct zebra_pbr_iptable *table)
+void dplane_ctx_get_pbr_iptable(const struct zebra_dplane_ctx *ctx,
+				struct zebra_pbr_iptable *table)
 {
 	DPLANE_CTX_VALID(ctx);
 
 	memcpy(table, &ctx->u.iptable, sizeof(struct zebra_pbr_iptable));
-	return true;
 }
 
 void dplane_ctx_get_pbr_ipset(const struct zebra_dplane_ctx *ctx,
@@ -5059,9 +5057,10 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_IPTABLE_DELETE: {
 		struct zebra_pbr_iptable ipt;
 
-		if (dplane_ctx_get_pbr_iptable(ctx, &ipt))
-			zlog_debug("Dplane iptable update op %s, unique(%u), ctx %p",
-				   dplane_op2str(dplane_ctx_get_op(ctx)), ipt.unique, ctx);
+		dplane_ctx_get_pbr_iptable(ctx, &ipt);
+		zlog_debug("Dplane iptable update op %s, unique(%u), ctx %p",
+			   dplane_op2str(dplane_ctx_get_op(ctx)), ipt.unique,
+			   ctx);
 	} break;
 	case DPLANE_OP_IPSET_ADD:
 	case DPLANE_OP_IPSET_DELETE: {

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2171,15 +2171,14 @@ void dplane_ctx_get_pbr_ipset(const struct zebra_dplane_ctx *ctx,
 		memcpy(ipset, &ctx->u.ipset, sizeof(struct zebra_pbr_ipset));
 }
 
-bool dplane_ctx_get_pbr_ipset_entry(const struct zebra_dplane_ctx *ctx,
+void dplane_ctx_get_pbr_ipset_entry(const struct zebra_dplane_ctx *ctx,
 				    struct zebra_pbr_ipset_entry *entry)
 {
 	DPLANE_CTX_VALID(ctx);
 
-	if (!entry)
-		return false;
+	assert(entry);
+
 	memcpy(entry, &ctx->u.ipset_entry.entry, sizeof(struct zebra_pbr_ipset_entry));
-	return true;
 }
 
 /*
@@ -5075,12 +5074,12 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_IPSET_ENTRY_DELETE: {
 		struct zebra_pbr_ipset_entry ipent;
 
-		if (dplane_ctx_get_pbr_ipset_entry(ctx, &ipent))
-			zlog_debug("Dplane ipset entry update op %s, unique(%u), ctx %p",
-				   dplane_op2str(dplane_ctx_get_op(ctx)),
-				   ipent.unique, ctx);
+		dplane_ctx_get_pbr_ipset_entry(ctx, &ipent);
+		zlog_debug(
+			"Dplane ipset entry update op %s, unique(%u), ctx %p",
+			dplane_op2str(dplane_ctx_get_op(ctx)), ipent.unique,
+			ctx);
 	} break;
-
 	case DPLANE_OP_NEIGH_TABLE_UPDATE:
 		zlog_debug("Dplane neigh table op %s, ifp %s, family %s",
 			   dplane_op2str(dplane_ctx_get_op(ctx)),

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -532,9 +532,8 @@ struct zebra_pbr_ipset;
 void dplane_ctx_get_pbr_ipset(const struct zebra_dplane_ctx *ctx,
 			      struct zebra_pbr_ipset *ipset);
 struct zebra_pbr_ipset_entry;
-bool
-dplane_ctx_get_pbr_ipset_entry(const struct zebra_dplane_ctx *ctx,
-			       struct zebra_pbr_ipset_entry *entry);
+void dplane_ctx_get_pbr_ipset_entry(const struct zebra_dplane_ctx *ctx,
+				    struct zebra_pbr_ipset_entry *entry);
 /* Accessors for bridge port information */
 uint32_t dplane_ctx_get_br_port_flags(const struct zebra_dplane_ctx *ctx);
 uint32_t

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -526,9 +526,8 @@ const struct prefix *
 dplane_ctx_rule_get_old_dst_ip(const struct zebra_dplane_ctx *ctx);
 /* Accessors for policy based routing iptable information */
 struct zebra_pbr_iptable;
-bool
-dplane_ctx_get_pbr_iptable(const struct zebra_dplane_ctx *ctx,
-			   struct zebra_pbr_iptable *table);
+void dplane_ctx_get_pbr_iptable(const struct zebra_dplane_ctx *ctx,
+				struct zebra_pbr_iptable *table);
 struct zebra_pbr_ipset;
 void dplane_ctx_get_pbr_ipset(const struct zebra_dplane_ctx *ctx,
 			      struct zebra_pbr_ipset *ipset);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -530,9 +530,8 @@ bool
 dplane_ctx_get_pbr_iptable(const struct zebra_dplane_ctx *ctx,
 			   struct zebra_pbr_iptable *table);
 struct zebra_pbr_ipset;
-bool
-dplane_ctx_get_pbr_ipset(const struct zebra_dplane_ctx *ctx,
-			 struct zebra_pbr_ipset *ipset);
+void dplane_ctx_get_pbr_ipset(const struct zebra_dplane_ctx *ctx,
+			      struct zebra_pbr_ipset *ipset);
 struct zebra_pbr_ipset_entry;
 bool
 dplane_ctx_get_pbr_ipset_entry(const struct zebra_dplane_ctx *ctx,

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -571,13 +571,13 @@ void zebra_pbr_process_ipset(struct zebra_dplane_ctx *ctx)
 		mode = 1;
 	else
 		mode = 0;
-	if (dplane_ctx_get_pbr_ipset(ctx, &ipset)) {
-		ret = hook_call(zebra_pbr_ipset_update, mode, &ipset);
-		if (ret)
-			dplane_ctx_set_status(ctx,
-					      ZEBRA_DPLANE_REQUEST_SUCCESS);
-	}
-	if (!ret)
+
+	dplane_ctx_get_pbr_ipset(ctx, &ipset);
+
+	ret = hook_call(zebra_pbr_ipset_update, mode, &ipset);
+	if (ret)
+		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_SUCCESS);
+	else
 		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_FAILURE);
 }
 
@@ -594,8 +594,8 @@ void zebra_pbr_process_ipset_entry(struct zebra_dplane_ctx *ctx)
 
 	if (!dplane_ctx_get_pbr_ipset_entry(ctx, &ipset_entry))
 		return;
-	if (!dplane_ctx_get_pbr_ipset(ctx, &ipset))
-		return;
+	dplane_ctx_get_pbr_ipset(ctx, &ipset);
+
 	ipset_entry.backpointer = &ipset;
 
 	ret = hook_call(zebra_pbr_ipset_entry_update, mode, &ipset_entry);

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -552,13 +552,12 @@ void zebra_pbr_process_iptable(struct zebra_dplane_ctx *ctx)
 	else
 		mode = 0;
 
-	if (dplane_ctx_get_pbr_iptable(ctx, &ipt)) {
-		ret = hook_call(zebra_pbr_iptable_update, mode, &ipt);
-		if (ret)
-			dplane_ctx_set_status(ctx,
-					      ZEBRA_DPLANE_REQUEST_SUCCESS);
-	}
-	if (!ret)
+	dplane_ctx_get_pbr_iptable(ctx, &ipt);
+
+	ret = hook_call(zebra_pbr_iptable_update, mode, &ipt);
+	if (ret)
+		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_SUCCESS);
+	else
 		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_FAILURE);
 }
 

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -591,8 +591,7 @@ void zebra_pbr_process_ipset_entry(struct zebra_dplane_ctx *ctx)
 	else
 		mode = 0;
 
-	if (!dplane_ctx_get_pbr_ipset_entry(ctx, &ipset_entry))
-		return;
+	dplane_ctx_get_pbr_ipset_entry(ctx, &ipset_entry);
 	dplane_ctx_get_pbr_ipset(ctx, &ipset);
 
 	ipset_entry.backpointer = &ipset;


### PR DESCRIPTION
There are 3 dplane_ctx_get_XXX functions for pbr that return true/false.  False is only ever returned because the developer would pass in a null pointer.  Which is useless.  change to an assert to signify the api that we want and don't return true false.