### PR TITLE
Flowspec dplane missing

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -893,7 +893,7 @@ void zsend_iptable_notify_owner(const struct zebra_dplane_ctx *ctx,
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, VRF_DEFAULT);
-	stream_put(s, &note, sizeof(note));
+	stream_putw(s, note);
 	stream_putl(s, ipt.unique);
 	stream_put(s, ipt.ipset_name, ZEBRA_IPSET_NAME_SIZE);
 	stream_putw_at(s, 0, stream_get_endp(s));
@@ -928,7 +928,7 @@ void zsend_ipset_notify_owner(const struct zebra_dplane_ctx *ctx,
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, VRF_DEFAULT);
-	stream_put(s, &note, sizeof(note));
+	stream_putw(s, note);
 	stream_putl(s, ipset.unique);
 	stream_put(s, ipset.ipset_name, ZEBRA_IPSET_NAME_SIZE);
 	stream_putw_at(s, 0, stream_get_endp(s));
@@ -966,7 +966,7 @@ void zsend_ipset_entry_notify_owner(const struct zebra_dplane_ctx *ctx,
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, VRF_DEFAULT);
-	stream_put(s, &note, sizeof(note));
+	stream_putw(s, note);
 	stream_putl(s, ipent.unique);
 	stream_put(s, ipset.ipset_name, ZEBRA_IPSET_NAME_SIZE);
 	stream_putw_at(s, 0, stream_get_endp(s));

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -341,7 +341,7 @@ struct zebra_dplane_ctx {
 		struct dplane_rule_info rule;
 		struct zebra_pbr_iptable iptable;
 		struct zebra_pbr_ipset ipset;
-		union {
+		struct {
 			struct zebra_pbr_ipset_entry entry;
 			struct zebra_pbr_ipset_info info;
 		} ipset_entry;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2166,6 +2166,7 @@ bool dplane_ctx_get_pbr_ipset(const struct zebra_dplane_ctx *ctx,
 	    ctx->zd_op == DPLANE_OP_IPSET_ENTRY_DELETE) {
 		memset(ipset, 0, sizeof(struct zebra_pbr_ipset));
 		ipset->type = ctx->u.ipset_entry.info.type;
+		ipset->family = ctx->u.ipset_entry.info.family;
 		memcpy(&ipset->ipset_name, &ctx->u.ipset_entry.info.ipset_name,
 		       ZEBRA_IPSET_NAME_SIZE);
 	} else
@@ -2943,6 +2944,7 @@ dplane_ctx_ipset_entry_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	       sizeof(struct zebra_pbr_ipset_entry));
 	ctx->u.ipset_entry.entry.backpointer = NULL;
 	ctx->u.ipset_entry.info.type = ipset->type;
+	ctx->u.ipset_entry.info.family = ipset->family;
 	memcpy(&ctx->u.ipset_entry.info.ipset_name, &ipset->ipset_name,
 	       ZEBRA_IPSET_NAME_SIZE);
 

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -70,6 +70,8 @@ struct zebra_pbr_ipset_info {
 	 */
 	uint32_t type;
 
+	uint8_t family;
+
 	char ipset_name[ZEBRA_IPSET_NAME_SIZE];
 };
 


### PR DESCRIPTION
Fixes related to flowspec information needed in zebra dataplane.
