### PR TITLE
pimd: STAR inherited Flag not properly set in certain scenarios

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1865,6 +1865,8 @@ int pim_upstream_inherited_olist_decide(struct pim_instance *pim,
 					flag = PIM_OIF_FLAG_PROTO_IGMP;
 				if (PIM_IF_FLAG_TEST_PROTO_PIM(ch->flags))
 					flag |= PIM_OIF_FLAG_PROTO_PIM;
+				if (starch)
+					flag |= PIM_OIF_FLAG_PROTO_STAR;
 			}
 
 			pim_channel_add_oif(up->channel_oil, ifp, flag,


### PR DESCRIPTION
**Problem Statement:**
Mroutes are not recovered after shut/no shut of DUT to RP links

One interface is not added in OIL List in intermediate router,
hence traffic never received at LHR and mroutes not created for (S,G).

**Root Cause Analysis:**
```
(Receiver)
eth3
|
R3 ---0--> PIM join------eth0--- R1 ---eth1---------- R2(RP) ----------- R4 (SRC) (10.0.5.1) (226.1.1.1)
                                 |
                               eth2
                                 |
                          IGMP join (Receiver)
```
                                          

Problem is happening at nodes R3 and R1.
1. R1 has IGMP join and PIM join.
2. mroutes will be like this on R1
    (*,g) eth1    pimreg, eth0, eth2
    (s,g) eth1    eth0, eth2 
3. Now unicast route for SRC removed from R3 and R1 by interface shut.
4. At this point, mroutes will be removed from kernel.
5. KAT timer is still running.
6. Now make the routing up via interface no shut.
7. R3 sends the PIM join towards R1
8. R1 installs the routes in kernel for (S,G)
9. Now traffic has not reached yet R3 and KAT timer expired.
10. This sends the prune towards R1.
11. Now R1 will remove the interface eth0 from S,G
12. Traffic started again. 
13. Now traffic will hit S,G entry in the kernel, no trigger comes to R3 to generate PIM join.
14. Traffic will not reach R3.

Generally (*, G) PIM Join is received first and then (S,G) joins are received.
This issue occurs when (S,G) join comes first and then the (*,G) Join.
When (S,G) PIM Join is received, ifchannel is created and channel_oil
OIF flag is set to PIM_OIF_FLAG_PROTO_PIM. Now when (*,G) join is received
the flag PIM_OIF_FLAG_PROTO_STAR is not inherited due to wrong check present in
function pim_upstream_inherited_olist_decide.

**Fix:**
When (*,G) PIM Join is received, it should always add PIM_OIF_FLAG_PROTO_STAR
flag for all the (S,G) channel oils no matter what order the (*,G) or (S,G)
is received.

Fixes: #9918

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>