### PR TITLE
topotests: change ospf6 interface area configuration

### DIFF
--- a/tests/topotests/bfd_ospf_topo1/rt1/ospf6d.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt1/ospf6d.conf
@@ -10,16 +10,16 @@ interface eth-rt2
  ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
  ipv6 ospf6 bfd
+ ipv6 ospf6 area 0.0.0.0
 !
 interface eth-rt3
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
  ipv6 ospf6 bfd
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 1.1.1.1
- interface eth-rt2 area 0.0.0.0
- interface eth-rt3 area 0.0.0.0
  redistribute connected
 !

--- a/tests/topotests/bfd_ospf_topo1/rt2/ospf6d.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt2/ospf6d.conf
@@ -9,15 +9,15 @@ interface eth-rt1
  ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
  ipv6 ospf6 bfd
+ ipv6 ospf6 area 0.0.0.0
 !
 interface eth-rt5
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 2.2.2.2
- interface eth-rt1 area 0.0.0.0
- interface eth-rt5 area 0.0.0.0
  redistribute connected
 !

--- a/tests/topotests/bfd_ospf_topo1/rt3/ospf6d.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt3/ospf6d.conf
@@ -9,15 +9,15 @@ interface eth-rt1
  ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
  ipv6 ospf6 bfd
+ ipv6 ospf6 area 0.0.0.0
 !
 interface eth-rt4
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 3.3.3.3
- interface eth-rt1 area 0.0.0.0
- interface eth-rt4 area 0.0.0.0
  redistribute connected
 !

--- a/tests/topotests/bfd_ospf_topo1/rt4/ospf6d.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt4/ospf6d.conf
@@ -8,15 +8,15 @@ interface eth-rt3
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
+ ipv6 ospf6 area 0.0.0.0
 !
 interface eth-rt5
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 8
  ipv6 ospf6 network broadcast
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 4.4.4.4
- interface eth-rt3 area 0.0.0.0
- interface eth-rt5 area 0.0.0.0
  redistribute connected
 !

--- a/tests/topotests/bfd_ospf_topo1/rt5/ospf6d.conf
+++ b/tests/topotests/bfd_ospf_topo1/rt5/ospf6d.conf
@@ -8,15 +8,15 @@ interface eth-rt2
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 8
+ ipv6 ospf6 area 0.0.0.0
 !
 interface eth-rt4
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 8
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 5.5.5.5
- interface eth-rt2 area 0.0.0.0
- interface eth-rt4 area 0.0.0.0
  redistribute connected
 !

--- a/tests/topotests/bfd_profiles_topo1/r4/ospf6d.conf
+++ b/tests/topotests/bfd_profiles_topo1/r4/ospf6d.conf
@@ -2,9 +2,9 @@ interface r4-eth1
  ipv6 ospf6 bfd profile fast-tx
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 10.254.254.4
  redistribute connected
- interface r4-eth1 area 0.0.0.0
 !

--- a/tests/topotests/bfd_profiles_topo1/r5/ospf6d.conf
+++ b/tests/topotests/bfd_profiles_topo1/r5/ospf6d.conf
@@ -2,9 +2,9 @@ interface r5-eth0
  ipv6 ospf6 bfd
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 10.254.254.5
  redistribute connected
- interface r5-eth0 area 0.0.0.0
 !

--- a/tests/topotests/bgp_features/r1/ospf6d.conf
+++ b/tests/topotests/bgp_features/r1/ospf6d.conf
@@ -3,19 +3,19 @@ log file ospf6d.log
 ! debug ospf6 neighbor
 !
 interface r1-lo
+ ipv6 ospf6 area 0.0.0.0
 !
 interface r1-eth1
  ipv6 ospf6 priority 10
+ ipv6 ospf6 area 0.0.0.0
 !
 interface r1-eth2
  ipv6 ospf6 priority 10
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 192.168.0.1
  log-adjacency-changes
- interface r1-lo area 0.0.0.0
- interface r1-eth1 area 0.0.0.0
- interface r1-eth2 area 0.0.0.0
 !
 line vty
 !

--- a/tests/topotests/bgp_features/r2/ospf6d.conf
+++ b/tests/topotests/bgp_features/r2/ospf6d.conf
@@ -3,19 +3,19 @@ log file ospf6d.log
 ! debug ospf6 neighbor
 !
 interface r2-lo
+ ipv6 ospf6 area 0.0.0.0
 !
 interface r2-eth1
  ipv6 ospf6 priority 5
+ ipv6 ospf6 area 0.0.0.0
 !
 interface r2-eth2
  ipv6 ospf6 priority 10
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 192.168.0.2
  log-adjacency-changes
- interface r2-lo area 0.0.0.0
- interface r2-eth1 area 0.0.0.0
- interface r2-eth2 area 0.0.0.0
 !
 line vty
 !

--- a/tests/topotests/bgp_features/r3/ospf6d.conf
+++ b/tests/topotests/bgp_features/r3/ospf6d.conf
@@ -3,19 +3,19 @@ log file ospf6d.log
 ! debug ospf6 neighbor
 !
 interface r3-lo
+ ipv6 ospf6 area 0.0.0.0
 !
 interface r3-eth1
  ipv6 ospf6 priority 5
+ ipv6 ospf6 area 0.0.0.0
 !
 interface r3-eth2
  ipv6 ospf6 priority 5
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 192.168.0.3
  log-adjacency-changes
- interface r3-lo area 0.0.0.0
- interface r3-eth1 area 0.0.0.0
- interface r3-eth2 area 0.0.0.0
 !
 line vty
 !

--- a/tests/topotests/ospf6_topo1/README.md
+++ b/tests/topotests/ospf6_topo1/README.md
@@ -56,17 +56,17 @@ Simplified `R1` config (R1 is similar)
 	interface r1-stubnet
 	 ipv6 address fc00:1:1:1::1/64
 	 ipv6 ospf6 network broadcast
+	 ipv6 ospf6 area 0.0.0.0
 	!
 	interface r1-sw5
 	 ipv6 address fc00:a:a:a::1/64
 	 ipv6 ospf6 network broadcast
+	 ipv6 ospf6 area 0.0.0.0
 	!
 	router ospf6
 	 router-id 10.0.0.1
 	 log-adjacency-changes detail
 	 redistribute static
-	 interface r1-stubnet area 0.0.0.0
-	 interface r1-sw5 area 0.0.0.0
 	!
 	ipv6 route fc00:1111:1111:1111::/64 fc00:1:1:1::1234
 
@@ -77,22 +77,22 @@ Simplified `R3` config
 	interface r3-stubnet
 	 ipv6 address fc00:3:3:3::3/64
 	 ipv6 ospf6 network broadcast
+	 ipv6 ospf6 area 0.0.0.0
 	!
 	interface r3-sw5
 	 ipv6 address fc00:a:a:a::3/64
 	 ipv6 ospf6 network broadcast
+	 ipv6 ospf6 area 0.0.0.0
 	!
 	interface r3-sw6
 	 ipv6 address fc00:b:b:b::3/64
 	 ipv6 ospf6 network broadcast
+	 ipv6 ospf6 area 0.0.0.1
 	!
 	router ospf6
 	 router-id 10.0.0.3
 	 log-adjacency-changes detail
 	 redistribute static
-	 interface r3-stubnet area 0.0.0.0
-	 interface r3-sw5 area 0.0.0.0
-	 interface r3-sw6 area 0.0.0.1
 	!
 	ipv6 route fc00:3333:3333:3333::/64 fc00:3:3:3::1234
 

--- a/tests/topotests/ospf6_topo1/r1/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1/r1/ospf6d.conf
@@ -13,18 +13,18 @@ interface r1-stubnet
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 interface r1-sw5
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 10.0.0.1
  log-adjacency-changes detail
  redistribute static
- interface r1-stubnet area 0.0.0.0
- interface r1-sw5 area 0.0.0.0
 !
 line vty
  exec-timeout 0 0

--- a/tests/topotests/ospf6_topo1/r2/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1/r2/ospf6d.conf
@@ -13,18 +13,18 @@ interface r2-stubnet
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 interface r2-sw5
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 router ospf6
  ospf6 router-id 10.0.0.2
  log-adjacency-changes detail
  redistribute static
- interface r2-stubnet area 0.0.0.0
- interface r2-sw5 area 0.0.0.0
 !
 line vty
  exec-timeout 0 0

--- a/tests/topotests/ospf6_topo1/r3/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1/r3/ospf6d.conf
@@ -13,24 +13,24 @@ interface r3-stubnet
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 interface r3-sw5
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 interface r3-sw6
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.1
 !
 router ospf6
  ospf6 router-id 10.0.0.3
  log-adjacency-changes detail
  redistribute static
- interface r3-stubnet area 0.0.0.0
- interface r3-sw5 area 0.0.0.0
- interface r3-sw6 area 0.0.0.1
 !
 line vty
  exec-timeout 0 0

--- a/tests/topotests/ospf6_topo1/r4/ospf6d.conf
+++ b/tests/topotests/ospf6_topo1/r4/ospf6d.conf
@@ -13,18 +13,18 @@ interface r4-stubnet
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.1
 !
 interface r4-sw6
  ipv6 ospf6 network broadcast
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.1
 !
 router ospf6
  ospf6 router-id 10.0.0.4
  log-adjacency-changes detail
  redistribute static
- interface r4-stubnet area 0.0.0.1
- interface r4-sw6 area 0.0.0.1
 !
 line vty
  exec-timeout 0 0

--- a/tests/topotests/ospf_topo1/r1/ospf6d.conf
+++ b/tests/topotests/ospf_topo1/r1/ospf6d.conf
@@ -4,10 +4,12 @@ router ospf6
  redistribute kernel
  redistribute connected
  redistribute static
- interface r1-eth0 area 0.0.0.0
- interface r1-eth1 area 0.0.0.0
+!
+int r1-eth0
+ ipv6 ospf6 area 0.0.0.0
 !
 int r1-eth1
  ipv6 ospf6 dead-interval 10
  ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 area 0.0.0.0
 !

--- a/tests/topotests/ospf_topo1/r2/ospf6d.conf
+++ b/tests/topotests/ospf_topo1/r2/ospf6d.conf
@@ -4,14 +4,14 @@ router ospf6
  redistribute kernel
  redistribute connected
  redistribute static
- interface r2-eth0 area 0.0.0.0
- interface r2-eth1 area 0.0.0.0
 !
 int r2-eth0
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 int r2-eth1
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !

--- a/tests/topotests/ospf_topo1/r3/ospf6d.conf
+++ b/tests/topotests/ospf_topo1/r3/ospf6d.conf
@@ -4,19 +4,19 @@ router ospf6
  redistribute kernel
  redistribute connected
  redistribute static
- interface r3-eth0 area 0.0.0.0
- interface r3-eth1 area 0.0.0.0
- interface r3-eth2 area 0.0.0.1
 !
 int r3-eth0
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 int r3-eth1
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.0
 !
 int r3-eth2
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.1
 !

--- a/tests/topotests/ospf_topo1/r4/ospf6d.conf
+++ b/tests/topotests/ospf_topo1/r4/ospf6d.conf
@@ -4,14 +4,14 @@ router ospf6
  redistribute kernel
  redistribute connected
  redistribute static
- interface r4-eth0 area 0.0.0.1
- interface r4-eth1 area 0.0.0.1
 !
 int r4-eth0
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.1
 !
 int r4-eth1
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 area 0.0.0.1
 !


### PR DESCRIPTION
The command 'ipv6 ospf6 area X.X.X.X' command under interface node
is the model that will be kept. Remove old model configuration, that
was located under router ospf6.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>