### PR TITLE
lib: Return Null when we have an empty string for script name

### DIFF
--- a/lib/frrscript.c
+++ b/lib/frrscript.c
@@ -103,6 +103,10 @@ char *frrscript_names_get_script_name(const char *function_name)
 		frrscript_names_find(&frrscript_names_hash, &lookup);
 	if (!snhe)
 		return NULL;
+
+	if (snhe->script_name[0] == '\0')
+		return NULL;
+
 	return snhe->script_name;
 }
 


### PR DESCRIPTION
The script entries were being stored in a hash lookup with
the script name a pre-defined array of characters.  The hash
lookup is succeeding since it is auto-installed at script
start time irrelevant if there is a handler function.

Modify the code so that if the scriptname is an empty
string "\0" just return a NULL so that zebra does
not attempt to actually load up the script

Signed-off-by: Donald Sharp <sharpd@nvidia.com>