### PR TITLE
tools: added timestamp to the output printed by frr_babeltrace

### DIFF
--- a/tools/frr_babeltrace.py
+++ b/tools/frr_babeltrace.py
@@ -30,6 +30,7 @@ import socket
 import sys
 
 import babeltrace
+import datetime
 
 ########################### common parsers - start ############################
 def print_ip_addr(field_val):
@@ -91,7 +92,9 @@ def parse_event(event, field_parsers):
             field_info[field] = field_parser(event.get(field))
         else:
             field_info[field] = event.get(field)
-    print(event.name, field_info)
+    dt = datetime.datetime.fromtimestamp(event.timestamp/1000000000)
+    dt_format = dt.strftime('%Y/%m/%d %H:%M:%S')
+    print(dt_format, event.name, field_info)
 ############################ common parsers - end #############################
 
 ############################ evpn parsers - start #############################


### PR DESCRIPTION
Sample output -
=============
2021/10/26 17:27:15 frr_bgp:evpn_mac_ip_zsend {'action': 'add', 'vni': 1004, 'mac': '00:02:00:00:00:0f', 'ip': '', 'vtep': '27.0.0.21', 'esi': '03:44:38:39:ff:ff:01:00:00:03'}

Signed-off-by: Anuradha Karuppiah <anuradhak@nvidia.com>