### PR TITLE
tests: All_protocol_startup sporadic failure

### DIFF
--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -568,14 +568,17 @@ def test_nexthop_groups():
     net["r1"].cmd(
         'vtysh -c "sharp install routes 6.6.6.4 nexthop-group infinite-recursive 1"'
     )
+    sleep(5)
 
     net["r1"].cmd(
         'vtysh -c "sharp install routes 6.6.6.3 nexthop-group infinite-recursive 1"'
     )
+    sleep(5)
 
     net["r1"].cmd(
         'vtysh -c "sharp install routes 6.6.6.2 nexthop-group infinite-recursive 1"'
     )
+    sleep(5)
 
     net["r1"].cmd(
         'vtysh -c "sharp install routes 6.6.6.1 nexthop-group infinite-recursive 1"'


### PR DESCRIPTION
the test_nexthop_groups function is failing occassionally
because the test executes 4 in succession sharp install
routes commands.  When I dumped the rib on a failed test
run there were only 2 of the 4 routes in the rib and
the two that were in were the last 2 installed.
The sharp daemon setups a event process where it
installs routes `automatically`.  If the previous
run is not finished entering a new command to install
the routes will mess up the last one from ever happening.
It is assumed that the user doesn't do stupid stuff here.
In this case I am just adding a small sleep between each
installation to just let the test proceed.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>