### PR TITLE
zebra: Fix the RA packets can not sent out

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -493,8 +493,8 @@ static int rtadv_timer(struct thread *thread)
 
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
 		FOR_ALL_INTERFACES (vrf, ifp) {
-			if (if_is_loopback_or_vrf(ifp)
-			    || !if_is_operative(ifp))
+			if (if_is_loopback_or_vrf(ifp) || !if_is_operative(ifp)
+			    || ifp->vrf_id != zvrf->vrf->vrf_id)
 				continue;
 
 			zif = ifp->info;

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -494,7 +494,7 @@ static int rtadv_timer(struct thread *thread)
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			if (if_is_loopback_or_vrf(ifp) || !if_is_operative(ifp)
-			    || ifp->vrf_id != zvrf->vrf->vrf_id)
+				|| if_lookup_by_index(ifp->ifindex, zvrf->vrf->vrf_id) == NULL)
 				continue;
 
 			zif = ifp->info;

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -494,7 +494,7 @@ static int rtadv_timer(struct thread *thread)
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			if (if_is_loopback_or_vrf(ifp) || !if_is_operative(ifp)
-				|| if_lookup_by_index(ifp->ifindex, zvrf->vrf->vrf_id) == NULL)
+				|| (vrf_is_backend_netns() && ifp->vrf_id != zvrf->vrf->vrf_id))
 				continue;
 
 			zif = ifp->info;


### PR DESCRIPTION
The rtadv_timer() sends RA packets for all interfaces in all VRFs no matter whether the interface belong or not belong to the current thread's vrf, and when it uses the zvrf's socket (zvrf->rtadv.sock) to send packets for the interface that not belong to the vrf, it would be failed because the socket does not in the same netns as the interface, so the `error 19 (No such device)` would happen.

Issue reported: #9821

Solution:
Skip the interfaces that are no in the same vrf as the current thread's zvrf.