### PR TITLE
bgpd: memory leak about bmp_peer and bmp_open

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -69,6 +69,7 @@ unsigned long conf_bgp_debug_pbr;
 unsigned long conf_bgp_debug_graceful_restart;
 unsigned long conf_bgp_debug_evpn_mh;
 unsigned long conf_bgp_debug_bfd;
+unsigned long conf_bgp_debug_bmp;
 
 unsigned long term_bgp_debug_as4;
 unsigned long term_bgp_debug_neighbor_events;
@@ -89,6 +90,7 @@ unsigned long term_bgp_debug_pbr;
 unsigned long term_bgp_debug_graceful_restart;
 unsigned long term_bgp_debug_evpn_mh;
 unsigned long term_bgp_debug_bfd;
+unsigned long term_bgp_debug_bmp;
 
 struct list *bgp_debug_neighbor_events_peers = NULL;
 struct list *bgp_debug_keepalive_peers = NULL;
@@ -2124,6 +2126,25 @@ DEFPY(debug_bgp_bfd, debug_bgp_bfd_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(debug_bgp_bmp, debug_bgp_bmp_cmd, "[no] debug bgp bmp",
+      NO_STR DEBUG_STR BGP_STR "BGP Monitoring Protocol\n")
+{
+	if (vty->node == CONFIG_NODE) {
+		if (no)
+			DEBUG_OFF(bmp, BMP);
+		else
+			DEBUG_ON(bmp, BMP);
+	} else {
+		if (no)
+			TERM_DEBUG_OFF(bmp, BMP);
+		else
+			TERM_DEBUG_ON(bmp, BMP);
+		vty_out(vty, "%s debug bgp bmp\n", no ? "disabled" : "enabled");
+	}
+
+	return CMD_SUCCESS;
+}
+
 DEFUN (no_debug_bgp,
        no_debug_bgp_cmd,
        "no debug bgp",
@@ -2168,6 +2189,7 @@ DEFUN (no_debug_bgp,
 	TERM_DEBUG_OFF(evpn_mh, EVPN_MH_ES);
 	TERM_DEBUG_OFF(evpn_mh, EVPN_MH_RT);
 	TERM_DEBUG_OFF(bfd, BFD_LIB);
+	TERM_DEBUG_OFF(bmp, BMP);
 
 	vty_out(vty, "All possible debugging has been turned off\n");
 
@@ -2259,6 +2281,9 @@ DEFUN_NOSH (show_debugging_bgp,
 
 	if (BGP_DEBUG(bfd, BFD_LIB))
 		vty_out(vty, "  BGP BFD library debugging is on\n");
+
+	if (BGP_DEBUG(bmp, BMP))
+		vty_out(vty, "  BGP BMP debugging is on\n");
 
 	vty_out(vty, "\n");
 	return CMD_SUCCESS;
@@ -2387,6 +2412,11 @@ static int bgp_config_write_debug(struct vty *vty)
 
 	if (CONF_BGP_DEBUG(bfd, BFD_LIB)) {
 		vty_out(vty, "debug bgp bfd\n");
+		write++;
+	}
+
+	if (CONF_BGP_DEBUG(bmp, BMP)) {
+		vty_out(vty, "debug bgp bmp\n");
 		write++;
 	}
 
@@ -2522,6 +2552,10 @@ void bgp_debug_init(void)
 	/* debug bgp bfd */
 	install_element(ENABLE_NODE, &debug_bgp_bfd_cmd);
 	install_element(CONFIG_NODE, &debug_bgp_bfd_cmd);
+
+	/* debug bgp bmp */
+	install_element(ENABLE_NODE, &debug_bgp_bmp_cmd);
+	install_element(CONFIG_NODE, &debug_bgp_bmp_cmd);
 }
 
 /* Return true if this prefix is on the per_prefix_list of prefixes to debug

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -80,6 +80,7 @@ extern unsigned long conf_bgp_debug_pbr;
 extern unsigned long conf_bgp_debug_graceful_restart;
 extern unsigned long conf_bgp_debug_evpn_mh;
 extern unsigned long conf_bgp_debug_bfd;
+extern unsigned long conf_bgp_debug_bmp;
 
 extern unsigned long term_bgp_debug_as4;
 extern unsigned long term_bgp_debug_neighbor_events;
@@ -98,6 +99,7 @@ extern unsigned long term_bgp_debug_pbr;
 extern unsigned long term_bgp_debug_graceful_restart;
 extern unsigned long term_bgp_debug_evpn_mh;
 extern unsigned long term_bgp_debug_bfd;
+extern unsigned long term_bgp_debug_bmp;
 
 extern struct list *bgp_debug_neighbor_events_peers;
 extern struct list *bgp_debug_keepalive_peers;
@@ -143,6 +145,7 @@ struct bgp_debug_filter {
 #define BGP_DEBUG_GRACEFUL_RESTART     0x01
 
 #define BGP_DEBUG_BFD_LIB             0x01
+#define BGP_DEBUG_BMP 0x01
 
 #define CONF_DEBUG_ON(a, b)	(conf_bgp_debug_ ## a |= (BGP_DEBUG_ ## b))
 #define CONF_DEBUG_OFF(a, b)	(conf_bgp_debug_ ## a &= ~(BGP_DEBUG_ ## b))


### PR DESCRIPTION
Fixes #9933


Test log
```
Nov  2 17:23:26.633985 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 [FSM] ConnectRetry_timer_expired (Active->Connect), fd -1
Nov  2 17:23:26.634051 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 [Event] Connect start to 7.0.0.2 fd 26
Nov  2 17:23:26.634109 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 [FSM] Non blocking connect waiting result, fd 26
Nov  2 17:23:26.634131 TestDev DEBUG bgp#bgpd[1429]: bgp_fsm_change_status : vrf default(0), Status: Connect established_peers 0
Nov  2 17:23:26.634141 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 went from Active to Connect
Nov  2 17:23:26.634323 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 [Event] Connect failed 111(Connection refused)
Nov  2 17:23:26.634361 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 [FSM] TCP_connection_open_failed (Connect->Active), fd 26
Nov  2 17:23:26.634504 TestDev DEBUG bgp#bgpd[1429]: bgp_fsm_change_status : vrf default(0), Status: Active established_peers 0
Nov  2 17:23:26.634517 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 went from Connect to Active
Nov  2 17:23:26.933843 TestDev DEBUG bgp#bgpd[1429]: 8.0.0.2 [FSM] ConnectRetry_timer_expired (Active->Connect), fd -1
Nov  2 17:23:26.933899 TestDev DEBUG bgp#bgpd[1429]: 8.0.0.2 [Event] Connect start to 8.0.0.2 fd 26
Nov  2 17:23:26.934021 TestDev DEBUG bgp#bgpd[1429]: 8.0.0.2 [FSM] Non blocking connect waiting result, fd 26
Nov  2 17:23:26.934036 TestDev DEBUG bgp#bgpd[1429]: bgp_fsm_change_status : vrf default(0), Status: Connect established_peers 0
Nov  2 17:23:26.934045 TestDev DEBUG bgp#bgpd[1429]: 8.0.0.2 went from Active to Connect
Nov  2 17:23:26.934238 TestDev DEBUG bgp#bgpd[1429]: 8.0.0.2 [Event] Connect failed 111(Connection refused)
Nov  2 17:23:26.934271 TestDev DEBUG bgp#bgpd[1429]: 8.0.0.2 [FSM] TCP_connection_open_failed (Connect->Active), fd 26
Nov  2 17:23:26.934393 TestDev DEBUG bgp#bgpd[1429]: bgp_fsm_change_status : vrf default(0), Status: Active established_peers 0
Nov  2 17:23:26.934413 TestDev DEBUG bgp#bgpd[1429]: 8.0.0.2 went from Connect to Active
Nov  2 17:23:27.956150 TestDev DEBUG bgp#bgpd[1429]: [Event] BGP connection from host 7.0.0.2 fd 26
Nov  2 17:23:27.956208 TestDev DEBUG bgp#bgpd[1429]: peer_create(0x55d3269d6c90) host:7.0.0.2 id:709518115, doppelganger(0x0) id:0
Nov  2 17:23:27.956225 TestDev DEBUG bgp#bgpd[1429]: bgp_fsm_change_status : vrf default(0), Status: Active established_peers 0
Nov  2 17:23:27.956237 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 went from Idle to Active
Nov  2 17:23:27.956261 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 [FSM] TCP_connection_open (Active->OpenSent), fd 26
Nov  2 17:23:27.956287 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 passive open
Nov  2 17:23:27.956306 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 Sending hostname cap with hn = TestDev.43, dn = (null)
Nov  2 17:23:27.956319 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 sending OPEN, version 4, my as 8342, holdtime 30, id 10.189.89.43
Nov  2 17:23:27.956331 TestDev DEBUG bgp#bgpd[1429]: bmp_bgp_peer_get(0x55d3269d6c90) host:7.0.0.2 id:709518115, doppelganger(0x55d32696d500) id:818515352
Nov  2 17:23:27.956346 TestDev DEBUG bgp#bgpd[1429]: bgp_fsm_change_status : vrf default(0), Status: OpenSent established_peers 0
Nov  2 17:23:27.956361 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 went from Active to OpenSent
Nov  2 17:23:27.956418 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 rcv OPEN, version 4, remote-as (in open) 65100, holdtime 90, id 192.0.0.1
Nov  2 17:23:27.956480 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 rcv OPEN w/ OPTION parameter len: 8
Nov  2 17:23:27.956490 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 rcvd OPEN w/ optional parameter type 2 (Capability) len 6
Nov  2 17:23:27.956497 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 OPEN has MultiProtocol Extensions capability (1), length 4
Nov  2 17:23:27.956548 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 OPEN has MP_EXT CAP for afi/safi: IPv4/unicast
Nov  2 17:23:27.956569 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 [FSM] Receive_OPEN_message (OpenSent->OpenConfirm), fd 26
Nov  2 17:23:27.956590 TestDev DEBUG bgp#bgpd[1429]: bgp_fsm_change_status : vrf default(0), Status: OpenConfirm established_peers 0
Nov  2 17:23:27.956601 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 went from OpenSent to OpenConfirm
Nov  2 17:23:27.956647 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 [FSM] Receive_KEEPALIVE_message (OpenConfirm->Established), fd 26
Nov  2 17:23:27.956657 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2: peer transfer 0x55d3269d6c90 fd 26 -> 0x55d32696d500 fd -1)
Nov  2 17:23:27.956794 TestDev DEBUG bgp#bgpd[1429]: bgp_fsm_change_status : vrf default(0), Status: Established established_peers 1
Nov  2 17:23:27.956805 TestDev INFO bgp#bgpd[1429]: Begin maxmed onpeerstartup mode - timer 200 seconds
Nov  2 17:23:27.956830 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 went from OpenConfirm to Established
Nov  2 17:23:27.956840 TestDev INFO bgp#bgpd[1429]: %ADJCHANGE: neighbor 7.0.0.2(Unknown) in vrf default Up
Nov  2 17:23:27.956860 TestDev DEBUG bgp#bgpd[1429]: create update group 13198
Nov  2 17:23:27.956875 TestDev DEBUG bgp#bgpd[1429]: create subgroup u13198:s13199
Nov  2 17:23:27.956884 TestDev DEBUG bgp#bgpd[1429]: update_subgroup_add_peer, peer 647419136 7.0.0.2 added to subgroup s13199
Nov  2 17:23:27.956893 TestDev DEBUG bgp#bgpd[1429]: u13198:s13199 add peer 7.0.0.2
Nov  2 17:23:27.956905 TestDev DEBUG bgp#bgpd[1429]: [Event] Deleting stub connection for peer 7.0.0.2
Nov  2 17:23:27.956915 TestDev DEBUG bgp#bgpd[1429]: peer_delete(0x55d3269d6c90) host:7.0.0.2 id:709518115, doppelganger(0x55d32696d500) id:818515352
Nov  2 17:23:27.957019 TestDev DEBUG bgp#bgpd[1429]: bgp_fsm_change_status : vrf default(0), Status: Deleted established_peers 1
Nov  2 17:23:27.957040 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 went from Active to Deleted
Nov  2 17:23:27.957051 TestDev DEBUG bgp#bgpd[1429]: bmp_peer_deleted(0x55d3269d6c90) host:7.0.0.2 id:709518115, doppelganger(0x0)
Nov  2 17:23:27.957070 TestDev DEBUG bgp#bgpd[1429]: peer_free(0x55d3269d6c90) host:7.0.0.2 id:709518115, doppelganger(0x0) id:0
Nov  2 17:23:27.957158 TestDev DEBUG bgp#bgpd[1429]: 7.0.0.2 [FSM] Timer (routeadv timer expire)
```


Signed-off-by: tangxiaojun36@qq.com