### PR TITLE
fabricd: cleanup interface config output

### DIFF
--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -186,8 +186,6 @@ DECLARE_QOBJ_TYPE(isis_circuit);
 void isis_circuit_init(void);
 struct isis_circuit *isis_circuit_new(struct interface *ifp, const char *tag);
 void isis_circuit_del(struct isis_circuit *circuit);
-struct isis_circuit *circuit_lookup_by_ifp(struct interface *ifp,
-					   struct list *list);
 struct isis_circuit *circuit_scan_by_ifp(struct interface *ifp);
 void isis_circuit_configure(struct isis_circuit *circuit,
 			    struct isis_area *area);


### PR DESCRIPTION
We don't need to scan through all configured areas to find the circuit
associated with the interface. It is always stored in ifp->info.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>