### PR TITLE
tools: add a script to generate a draft release changelog

### DIFF
--- a/doc/developer/frr-release-procedure.rst
+++ b/doc/developer/frr-release-procedure.rst
@@ -9,6 +9,10 @@ FRR Release Procedure
 Stage 1 - Preparation
 ---------------------
 
+#. Prepare changelog for the new release
+
+   Note: use ``tools/release_notes.py`` to help draft release notes changelog
+
 #. Checkout the existing ``dev/<version>`` branch.
 
    .. code-block:: console

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+#
+# 2021 Jafar Al-Gharaibeh, ATCorp
+#
+# Generate a draft FRR release notes
+#
+
+import sys
+import os
+import getopt
+import subprocess
+
+def run(cmd):
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    rv = proc.communicate("")[0].decode("UTF-8")
+    proc.wait()
+    return rv
+
+
+def usage(n):
+    print(os.path.basename(__file__), " [-b <branch>] [-t <tag> ]")
+    print("    Generate one line logs for non merge commits")
+    print("   -branch: branch name to use, default to HEAD")
+    print("   -tag   : generate logs up to this tag, default to latest tag")
+    sys.exit(n)
+
+
+def main(argv):
+    branch = tag = None
+    try:
+        opts, args = getopt.getopt(argv, "hb:t:", ["branch=", "tag="])
+    except getopt.GetoptError:
+        usage(2)
+    for opt, arg in opts:
+        if opt == "-h":
+            usage(0)
+        elif opt in ("-b", "--branch"):
+            branch = arg
+        elif opt in ("-t", "--tag"):
+            tag = arg
+
+    if branch is None:
+        branch = "HEAD"
+    if tag is None:
+        tag = run(["git", "describe", "--abbrev=0"]).strip("\n")
+
+    chnglog = run(
+        ["git", "log", "--no-merges", "--pretty=format:'%s%d'", tag + ".." + branch]
+    )
+    chnglog = chnglog.split("\n")
+
+    chnglist = []
+    daemons = [
+        "babel",
+        "bgp",
+        "eigrp",
+        "nhrp",
+        "ospf",
+        "ospf6",
+        "pbr",
+        "pim",
+        "rip",
+        "ripng",
+        "sharp",
+        "vrrp",
+        "zebra",
+    ]
+
+    for line in chnglog:
+        line = line.strip("'")
+        colon = line.partition(":")
+        label = colon[0].strip().lower()
+        if label in daemons:
+            label = label + "d"
+        comment = colon[2].strip().capitalize()
+        chnglist.append(label + ":" + comment)
+
+    chnglist.sort()
+    lastlabel = ""
+    for line in chnglist:
+        colon = line.partition(":")
+        label = colon[0]
+        comment = colon[2]
+        if label != lastlabel:
+            print("")
+            print(label)
+            lastlabel = label
+
+        print("   ", comment)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
This utility script helps in generating formatted and consistent
change log including:
       1- group logs per daemon
       2- standarize daemon names (lowercase, end with d)
       3- capitalize all log lines
       4- no merge commits

caveat: comments are assumed to be in the form. However all commit message are required to be in that format to begin with to be merged.

   daemon-name : message

Sample Output:

```
sharpd
    Follow the practice on cli design for json output
    Install route supports nexthop-seg6 (step3)
    Install_routes_helper support zapi_route flags (step1)

snapcraft
    Add missing dependency
    Add pathd to frr snap daemons
    Change base to ubuntu 18.04 and libyang 2.0.7

staticd
    Convert typedef to enum
    Fix distance processing
    Fix late initialization of blackhole type
    Output config using nb callbacks instead of operational data
```

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>