### PR TITLE
bgpd: clearer safi handling for BGP-LU route updates

### DIFF
--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -444,8 +444,8 @@ int bgp_nlri_parse_label(struct peer *peer, struct attr *attr,
 
 		if (attr) {
 			bgp_update(peer, &p, addpath_id, attr, packet->afi,
-				   SAFI_UNICAST, ZEBRA_ROUTE_BGP,
-				   BGP_ROUTE_NORMAL, NULL, &label, 1, 0, NULL);
+				   safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
+				   NULL, &label, 1, 0, NULL);
 		} else {
 			bgp_withdraw(peer, &p, addpath_id, attr, packet->afi,
 				     SAFI_UNICAST, ZEBRA_ROUTE_BGP,


### PR DESCRIPTION
Don't hide the LABELED_UNICAST safi when processing route updates; map it where necessary (to use the UNICAST table for instance). Without this, an 'in' direction route-map configured for the LABELED_UNICAST safi would not be run, because the real safi was being lost.
