### PR TITLE
isisd: use time_t for last update and last flap

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -480,8 +480,7 @@ void isis_adj_print_vty(struct isis_adjacency *adj, struct vty *vty,
 		vty_out(vty, "%-13s", adj_state2string(adj->adj_state));
 		now = time(NULL);
 		if (adj->last_upd) {
-			if (adj->last_upd + adj->hold_time
-			    < (unsigned long long)now)
+			if (adj->last_upd + adj->hold_time < now)
 				vty_out(vty, " Expiring");
 			else
 				vty_out(vty, " %-9llu",
@@ -508,8 +507,7 @@ void isis_adj_print_vty(struct isis_adjacency *adj, struct vty *vty,
 		vty_out(vty, ", State: %s", adj_state2string(adj->adj_state));
 		now = time(NULL);
 		if (adj->last_upd) {
-			if (adj->last_upd + adj->hold_time
-			    < (unsigned long long)now)
+			if (adj->last_upd + adj->hold_time < now)
 				vty_out(vty, " Expiring");
 			else
 				vty_out(vty, ", Expires in %s",

--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -96,8 +96,8 @@ struct isis_adjacency {
 	int level;			/* level (1 or 2) */
 	enum isis_system_type sys_type; /* neighbourSystemType */
 	uint16_t hold_time;		/* entryRemainingTime */
-	uint32_t last_upd;
-	uint32_t last_flap; /* last time the adj flapped */
+	time_t last_upd;
+	time_t last_flap; /* last time the adj flapped */
 	enum isis_threeway_state threeway_state;
 	uint32_t ext_circuit_id;
 	int flaps;		      /* number of adjacency flaps  */

--- a/isisd/isis_snmp.c
+++ b/isisd/isis_snmp.c
@@ -2571,7 +2571,7 @@ static uint8_t *isis_snmp_find_isadj(struct variable *v, oid *name,
 		 */
 		if (adj->last_upd != 0) {
 			val = time(NULL);
-			if (val < ((time_t)adj->last_upd + (time_t)adj->hold_time))
+			if (val < (adj->last_upd + adj->hold_time))
 				return SNMP_INTEGER(adj->last_upd
 						    + adj->hold_time - val);
 		}


### PR DESCRIPTION
These variables are only assigned with time() which returns time_t.
This should also fix occasional CI build failures because of comparisons
of signed and unsigned integers.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>