### PR TITLE
Bgp bfd type

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1648,6 +1648,8 @@ struct peer {
 		uint32_t min_tx;
 		/** Profile name. */
 		char profile[BFD_PROFILE_NAME_LEN];
+		/* bfd session ttl to send in bfd packets */
+		uint8_t bfd_ttl_configured;
 		/** Peer BFD session */
 		struct bfd_session_params *session;
 	} * bfd_config;

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -177,6 +177,11 @@ void bfd_sess_set_profile(struct bfd_session_params *bsp, const char *profile);
  */
 void bfd_sess_set_vrf(struct bfd_session_params *bsp, vrf_id_t vrf_id);
 
+/* For single-hop session, TTL value in forged packets has to be 1 */
+#define BFD_SINGLE_HOP_CONFIGURED_TTL 1
+/* For single-hop session, max TTL value in forged packets is 255 */
+#define BFD_MULTI_HOP_CONFIGURED_MAX_TTL 255
+
 /**
  * Configure the BFD session single/multi hop setting.
  *


### PR DESCRIPTION
This commit reenables bfd multihop|singlehop vty command.
This is still useful when one wants to hardset the bfd behaviour for a given BGP session.