### PR TITLE
bfdd: add ifname attribute to multihop sessions

### DIFF
--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -131,11 +131,6 @@ DEFPY_YANG_NOSH(
 				"%% local-address is required when using multihop\n");
 			return CMD_WARNING_CONFIG_FAILED;
 		}
-		if (ifname) {
-			vty_out(vty,
-				"%% interface is prohibited when using multihop\n");
-			return CMD_WARNING_CONFIG_FAILED;
-		}
 		snprintf(source_str, sizeof(source_str), "[source-addr='%s']",
 			 local_address_str);
 	} else
@@ -148,7 +143,7 @@ DEFPY_YANG_NOSH(
 	if (ifname)
 		slen += snprintf(xpath + slen, sizeof(xpath) - slen,
 				 "[interface='%s']", ifname);
-	else if (!multihop)
+	else
 		slen += snprintf(xpath + slen, sizeof(xpath) - slen,
 				 "[interface='*']");
 	if (vrf)
@@ -199,11 +194,6 @@ DEFPY_YANG(
 				"%% local-address is required when using multihop\n");
 			return CMD_WARNING_CONFIG_FAILED;
 		}
-		if (ifname) {
-			vty_out(vty,
-				"%% interface is prohibited when using multihop\n");
-			return CMD_WARNING_CONFIG_FAILED;
-		}
 		snprintf(source_str, sizeof(source_str), "[source-addr='%s']",
 			 local_address_str);
 	} else
@@ -216,7 +206,7 @@ DEFPY_YANG(
 	if (ifname)
 		slen += snprintf(xpath + slen, sizeof(xpath) - slen,
 				 "[interface='%s']", ifname);
-	else if (!multihop)
+	else
 		slen += snprintf(xpath + slen, sizeof(xpath) - slen,
 				 "[interface='*']");
 	if (vrf)
@@ -236,6 +226,8 @@ static void _bfd_cli_show_peer(struct vty *vty, const struct lyd_node *dnode,
 			       bool mhop)
 {
 	const char *vrf = yang_dnode_get_string(dnode, "./vrf");
+	const char *ifname =
+		yang_dnode_get_string(dnode, "./interface");
 
 	vty_out(vty, " peer %s",
 		yang_dnode_get_string(dnode, "./dest-addr"));
@@ -250,12 +242,8 @@ static void _bfd_cli_show_peer(struct vty *vty, const struct lyd_node *dnode,
 	if (strcmp(vrf, VRF_DEFAULT_NAME))
 		vty_out(vty, " vrf %s", vrf);
 
-	if (!mhop) {
-		const char *ifname =
-			yang_dnode_get_string(dnode, "./interface");
-		if (strcmp(ifname, "*"))
-			vty_out(vty, " interface %s", ifname);
-	}
+	if (strcmp(ifname, "*"))
+		vty_out(vty, " interface %s", ifname);
 
 	vty_out(vty, "\n");
 }

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -47,11 +47,9 @@ static void bfd_session_get_key(bool mhop, const struct lyd_node *dnode,
 
 	vrfname = yang_dnode_get_string(dnode, "./vrf");
 
-	if (!mhop) {
-		ifname = yang_dnode_get_string(dnode, "./interface");
-		if (strcmp(ifname, "*") == 0)
-			ifname = NULL;
-	}
+	ifname = yang_dnode_get_string(dnode, "./interface");
+	if (strcmp(ifname, "*") == 0)
+		ifname = NULL;
 
 	/* Generate the corresponding key. */
 	gen_bfd_key(bk, &psa, &lsa, mhop, ifname, vrfname);

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -435,7 +435,7 @@ module frr-bfdd {
         }
 
         list multi-hop {
-          key "source-addr dest-addr vrf";
+          key "source-addr dest-addr interface vrf";
           description "List of multi hop sessions";
 
           leaf source-addr {
@@ -446,6 +446,11 @@ module frr-bfdd {
           leaf dest-addr {
             type inet:ip-address;
             description "IP address of the peer";
+          }
+
+          leaf interface {
+            type frr-interface:interface-ref;
+            description "Interface to use to contact peer";
           }
 
           leaf vrf {


### PR DESCRIPTION
There has been discussions whether it was necessary to support
multihop sessions with interface parameter.
- IETF yang mode for BFD does not support ifname parameter
- BGP had problems when using update-source command. Support has
been removed from BGP, and the BFD configuration has been removed
with ifname parameter.

I propose to maintain this attribute, mainly because it was made
available on older frr branches (7.3 as example). Having it on
BFDD does not necessarily means that BGP has to use it. This can
be done in a separate commit. The same can be done when static
bfd feature is made available. There are some routes that would
benefit from multihop ifname attribute like that one:

ip route 2.2.2.2/32 10.125.0.2 eth2

Here too, this commit just unlocks the possibility to configure
bfd multihop sessions with ifname attribute.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>