### PR TITLE
zebra: Better handle replacing our route by a system route

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2702,7 +2702,7 @@ netlink_put_route_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx)
 			 */
 			if (RSYSTEM_ROUTE(dplane_ctx_get_type(ctx))
 			    && !RSYSTEM_ROUTE(dplane_ctx_get_old_type(ctx)))
-				netlink_batch_add_msg(
+				return netlink_batch_add_msg(
 					bth, ctx, netlink_delroute_msg_encoder,
 					true);
 		} else {


### PR DESCRIPTION
When a operator has a FRR based route installed into the
FIB and a better route comes in from the system.  There
is code in the data plane to schedule the batching
but not to save the context.  In this case if the
operations fails to work properly Zebra will never
know about this.  In this case tell the
Signed-off-by: Donald Sharp <sharpd@nvidia.com>