### PR TITLE
zebra: Send up ifindex for redistribution when appropriate

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -604,8 +604,6 @@ int zsend_redistribute_route(int cmd, struct zserv *client,
 			api_nh->bh_type = nexthop->bh_type;
 			break;
 		case NEXTHOP_TYPE_IPV4:
-			api_nh->gate.ipv4 = nexthop->gate.ipv4;
-			break;
 		case NEXTHOP_TYPE_IPV4_IFINDEX:
 			api_nh->gate.ipv4 = nexthop->gate.ipv4;
 			api_nh->ifindex = nexthop->ifindex;
@@ -614,8 +612,6 @@ int zsend_redistribute_route(int cmd, struct zserv *client,
 			api_nh->ifindex = nexthop->ifindex;
 			break;
 		case NEXTHOP_TYPE_IPV6:
-			api_nh->gate.ipv6 = nexthop->gate.ipv6;
-			break;
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
 			api_nh->gate.ipv6 = nexthop->gate.ipv6;
 			api_nh->ifindex = nexthop->ifindex;


### PR DESCRIPTION
Currently the NEXTHOP_TYPE_IPV4 and NEXTHOP_TYPE_IPV6 are
not sending up the resolved ifindex for the route.  This
is causing upper level protocols that have something like
this:

route-map FOO permit 10
  match interface swp13
!

router ospf
   redistribute static
!

ip route 4.5.6.7/32 10.10.10.10

where 10.10.10.10 resolves to interface swp13.  The route-map
will never match in this case.

Since FRR has the resolved nexthop interface, FRR might as
well send it up to be selected on by the upper level protocol
as needed.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>