### PR TITLE
lib: remove confusing bfd TTL API

### DIFF
--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -646,32 +646,16 @@ void bfd_sess_set_vrf(struct bfd_session_params *bsp, vrf_id_t vrf_id)
 	bsp->args.vrf_id = vrf_id;
 }
 
-void bfd_sess_set_mininum_ttl(struct bfd_session_params *bsp, uint8_t min_ttl)
+void bfd_sess_set_hop_count(struct bfd_session_params *bsp, uint8_t hops)
 {
-	assert(min_ttl != 0);
-
-	if (bsp->args.ttl == ((BFD_SINGLE_HOP_TTL + 1) - min_ttl))
+	if (bsp->args.ttl == hops)
 		return;
 
 	/* If already installed, remove the old setting. */
 	_bfd_sess_remove(bsp);
 
-	/* Invert TTL value: protocol expects number of hops. */
-	min_ttl = (BFD_SINGLE_HOP_TTL + 1) - min_ttl;
-	bsp->args.ttl = min_ttl;
-	bsp->args.mhop = (min_ttl > 1);
-}
-
-void bfd_sess_set_hop_count(struct bfd_session_params *bsp, uint8_t min_ttl)
-{
-	if (bsp->args.ttl == min_ttl)
-		return;
-
-	/* If already installed, remove the old setting. */
-	_bfd_sess_remove(bsp);
-
-	bsp->args.ttl = min_ttl;
-	bsp->args.mhop = (min_ttl > 1);
+	bsp->args.ttl = hops;
+	bsp->args.mhop = (hops > 1);
 }
 
 
@@ -704,11 +688,6 @@ void bfd_sess_uninstall(struct bfd_session_params *bsp)
 enum bfd_session_state bfd_sess_status(const struct bfd_session_params *bsp)
 {
 	return bsp->bss.state;
-}
-
-uint8_t bfd_sess_minimum_ttl(const struct bfd_session_params *bsp)
-{
-	return ((BFD_SINGLE_HOP_TTL + 1) - bsp->args.ttl);
 }
 
 uint8_t bfd_sess_hop_count(const struct bfd_session_params *bsp)

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -181,39 +181,14 @@ void bfd_sess_set_vrf(struct bfd_session_params *bsp, vrf_id_t vrf_id);
  * Configure the BFD session single/multi hop setting.
  *
  * NOTE:
- * If the TTL changed the session is removed and must be installed again
- * with `bfd_sess_install`.
+ * If the number of hops is changed the session is removed and must be
+ * installed again with `bfd_sess_install`.
  *
  * \param bsp BFD session parameters.
- * \param min_ttl minimum TTL value expected (255 for single hop, 254 for
- *                multi hop with single hop, 253 for multi hop with two hops
- *                and so on). See `BFD_SINGLE_HOP_TTL` and
- *                `BFD_MULTI_HOP_MIN_TTL` for defaults.
- *
- * To simplify things if your protocol only knows the amount of hops it is
- * better to use `bfd_sess_set_hops` instead.
+ * \param hops maximum amount of hops expected (1 for single hop, 2 or
+ *             more for multi hop).
  */
-void bfd_sess_set_mininum_ttl(struct bfd_session_params *bsp, uint8_t min_ttl);
-
-/** To use single hop the minimum TTL must be set to this. */
-#define BFD_SINGLE_HOP_TTL 255
-/** To use multi hop the minimum TTL must be set to this or less. */
-#define BFD_MULTI_HOP_MIN_TTL 254
-
-/**
- * This function is the inverted version of `bfd_sess_set_minimum_ttl`.
- * Instead of receiving the minimum expected TTL, it receives the amount of
- * hops the protocol will jump.
- *
- * NOTE:
- * If the TTL changed the session is removed and must be installed again
- * with `bfd_sess_install`.
- *
- * \param bsp BFD session parameters.
- * \param min_ttl minimum amount of hops expected (1 for single hop, 2 or
- *                more for multi hop).
- */
-void bfd_sess_set_hop_count(struct bfd_session_params *bsp, uint8_t min_ttl);
+void bfd_sess_set_hop_count(struct bfd_session_params *bsp, uint8_t hops);
 
 /**
  * Configure the BFD session to set the Control Plane Independent bit.
@@ -278,17 +253,7 @@ void bfd_sess_uninstall(struct bfd_session_params *bsp);
 enum bfd_session_state bfd_sess_status(const struct bfd_session_params *bsp);
 
 /**
- * Get BFD session minimum TTL configured value.
- *
- * \param bsp session parameters.
- *
- * \returns configured minimum TTL.
- */
-uint8_t bfd_sess_minimum_ttl(const struct bfd_session_params *bsp);
-
-/**
- * Inverted version of `bfd_sess_minimum_ttl`. Gets the amount of hops in the
- * way to the peer.
+ * Get BFD session amount of hops configured value.
  *
  * \param bsp session parameters.
  *


### PR DESCRIPTION
There are two APIs to control the expected number of hops for a BFD
session – `bfd_sess_set_mininum_ttl` and `bfd_sess_set_hop_count`.
The former is very confusing, as it takes an expected TTL in the
BFD packet which is actually a protocol internal value. The latter is
simple and straightforward – it takes an expected number of hops, which
is always 1 for single-hop and >1 for multi-hop.

As the former API is not used anywhere, just remove it to avoid any
confusion.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>