### PR TITLE
tests: Fix route replace test in all_protocol_startup

### DIFF
--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -1503,6 +1503,14 @@ def test_nexthop_group_replace():
         'vtysh -c "c t" -c "nexthop-group replace" -c "nexthop 1.1.1.1 r1-eth1 onlink" -c "nexthop 1.1.1.2 r1-eth2 onlink"'
     )
 
+    # At the moment there is absolutely no real easy way to query sharpd
+    # for the nexthop group actually installed.  If it is not installed
+    # sharpd will just transmit the nexthops down instead of the nexthop
+    # group id.  Leading to a situation where the replace is not actually
+    # being tested.  So let's just wait some time here because this
+    # is hard and this test fails all the time
+    sleep(5)
+
     # Create with sharpd using nexthop-group
     net["r1"].cmd('vtysh -c "sharp install routes 3.3.3.1 nexthop-group replace 1"')
 


### PR DESCRIPTION
The route replace test was doing this seq of events:

a) Create nhg
b) Install route w/ sharpd
c) Ensure it worked
d) Modify nhg
d) Ensure the update group replace worked

The problem is that the sharp code is doing this:

	/* Only send via ID if nhgroup has been successfully installed */
	if (nhgid && sharp_nhgroup_id_is_installed(nhgid)) {
		SET_FLAG(api.message, ZAPI_MESSAGE_NHG);
		api.nhgid = nhgid;
	} else {
		for (ALL_NEXTHOPS_PTR(nhg, nh)) {
			api_nh = &api.nexthops[i];

			zapi_nexthop_from_nexthop(api_nh, nh);

			i++;
		}
		api.nexthop_num = i;
	}

The created nhg has not been successfully installed( or at least
sharpd has not read the results yet) when it gets the command
to install the routes.  As such it passes down the individual
nexthops instead.  The route replace is never going to work.

Modify the code to add a bit of sleep to allow sharpd to
get notified when the system is under load.  At this point
there is no way to query sharpd for whether or not it
thinks it's nhg is installed properly or not.  This
test is failing all over the place for a bunch of people
let's get this fixed so people can get running

Signed-off-by: Donald Sharp <sharpd@nvidia.com>