### PR TITLE
staticd: Prevent Crash on shutdown

### DIFF
--- a/staticd/static_vrf.c
+++ b/staticd/static_vrf.c
@@ -100,6 +100,9 @@ static int static_vrf_delete(struct vrf *vrf)
 	for (afi = AFI_IP; afi <= AFI_IP6; afi++) {
 		for (safi = SAFI_UNICAST; safi <= SAFI_MULTICAST; safi++) {
 			table = svrf->stable[afi][safi];
+			if (!table)
+				continue;
+
 			info = route_table_get_info(table);
 			route_table_finish(table);
 			XFREE(MTYPE_STATIC_RTABLE_INFO, info);


### PR DESCRIPTION
I have a crash decode that decodes to this:

(gdb) l *(route_table_get_info+0xc)
0x165a3 is in route_table_get_info (./lib/table.h:192).
187
188     extern route_table_delegate_t *route_table_get_default_delegate(void);
189
190     static inline void *route_table_get_info(struct route_table *table)
191     {
192             return table->info;
193     }
194
195     static inline void route_table_set_info(struct route_table *table, void *d)
196     {
(gdb) l *(static_vrf_delete+0x56)
0xa2f3 is in static_vrf_delete (staticd/static_vrf.c:103).
98
99              svrf = vrf->info;
100             for (afi = AFI_IP; afi <= AFI_IP6; afi++) {
101                     for (safi = SAFI_UNICAST; safi <= SAFI_MULTICAST; safi++) {
102                             table = svrf->stable[afi][safi];
103                             info = route_table_get_info(table);
104                             route_table_finish(table);
105                             XFREE(MTYPE_STATIC_RTABLE_INFO, info);
106                             svrf->stable[afi][safi] = NULL;
107                     }
(gdb) quit

Effectively table is null when we pass it into route_table_get_info causing
a crash.  Let's just check and ensure that we have table before we start
doing unspeakable things to it.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>