### PR TITLE
zebra: Prevent null deref of zvrf->tbl_mgr on shutdown

### DIFF
--- a/zebra/table_manager.c
+++ b/zebra/table_manager.c
@@ -253,7 +253,7 @@ int release_daemon_table_chunks(struct zserv *client)
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 		zvrf = vrf->info;
 
-		if (!zvrf)
+		if (!zvrf || !zvrf->tbl_mgr)
 			continue;
 		if (!vrf_is_backend_netns() && vrf->vrf_id != VRF_DEFAULT)
 			continue;


### PR DESCRIPTION
I am seeing this zebra crash:

root@eva:/var/tmp/frr# more zebra.1060045/crashlog
ZEBRA: Received signal 11 at 1636047336 (si_addr 0x0, PC 0x556e5f92d309); aborting...
ZEBRA: zlog_signal+0x18c                  7f44aeead19a     7ffe8b88f010 /lib/libfrr.so.0 (mapped at 0x7f44aedfc000)
ZEBRA: core_handler+0xe3                  7f44aeeeb05e     7ffe8b88f130 /lib/libfrr.so.0 (mapped at 0x7f44aedfc000)
ZEBRA: funlockfile+0x50                   7f44aed8a140     7ffe8b88f280 /lib/x86_64-linux-gnu/libpthread.so.0 (mapped at 0x7f44aed760
00)
ZEBRA:     ---- signal ----
ZEBRA: release_daemon_table_chunks+0x82     556e5f92d309     7ffe8b88f810 /usr/lib/frr/zebra (mapped at 0x556e5f880000)
ZEBRA: hook_call_zserv_client_close+0x57     556e5f9b7ffa     7ffe8b88f870 /usr/lib/frr/zebra (mapped at 0x556e5f880000)
ZEBRA: zserv_client_free+0x23             556e5f9b8050     7ffe8b88f8b0 /usr/lib/frr/zebra (mapped at 0x556e5f880000)
ZEBRA: zserv_close_client+0x15d           556e5f9b8561     7ffe8b88f8f0 /usr/lib/frr/zebra (mapped at 0x556e5f880000)
ZEBRA: zserv_handle_client_fail+0x24      556e5f9b8588     7ffe8b88f930 /usr/lib/frr/zebra (mapped at 0x556e5f880000)
ZEBRA: thread_call+0xc2                   7f44aef01e32     7ffe8b88f960 /lib/libfrr.so.0 (mapped at 0x7f44aedfc000)
ZEBRA: frr_run+0x217                      7f44aeea27f3     7ffe8b88fa20 /lib/libfrr.so.0 (mapped at 0x7f44aedfc000)
ZEBRA: main+0x3e4                         556e5f9145b3     7ffe8b88fb30 /usr/lib/frr/zebra (mapped at 0x556e5f880000)
ZEBRA: __libc_start_main+0xea             7f44aebd5d0a     7ffe8b88fc00 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7f44aebaf000)
ZEBRA: _start+0x2a                        556e5f8fb46a     7ffe8b88fcd0 /usr/lib/frr/zebra (mapped at 0x556e5f880000)
ZEBRA: in thread zserv_handle_client_fail scheduled from zebra/zserv.c:973 zserv_event()

which translates to crashing on this line:

	for (ALL_LIST_ELEMENTS_RO(zvrf->tbl_mgr->lc_list, node, tmc)) {

Let's just ensure that we have some work to do before we try to release it.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>