### PR TITLE
zebra: remove ifp reference against the macs before deleting the ifp-…

### DIFF
--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -106,19 +106,6 @@ static void zebra_evpn_mac_ifp_new(struct zebra_if *zif)
 	listset_app_node_mem(zif->mac_list);
 }
 
-/* Free up the mac_list if any as a part of the interface del/cleanup */
-void zebra_evpn_mac_ifp_del(struct interface *ifp)
-{
-	struct zebra_if *zif = ifp->info;
-
-	if (zif->mac_list) {
-		if (IS_ZEBRA_DEBUG_EVPN_MH_MAC)
-			zlog_debug("MAC list deleted for ifp %s (%u)",
-				   zif->ifp->name, zif->ifp->ifindex);
-		list_delete(&zif->mac_list);
-	}
-}
-
 /* Unlink local mac from a destination access port */
 static void zebra_evpn_mac_ifp_unlink(struct zebra_mac *zmac)
 {
@@ -137,6 +124,25 @@ static void zebra_evpn_mac_ifp_unlink(struct zebra_mac *zmac)
 	zif = ifp->info;
 	list_delete_node(zif->mac_list, &zmac->ifp_listnode);
 	zmac->ifp = NULL;
+}
+
+/* Free up the mac_list if any as a part of the interface del/cleanup */
+void zebra_evpn_mac_ifp_del(struct interface *ifp)
+{
+	struct zebra_if *zif = ifp->info;
+	struct listnode *node;
+	struct zebra_mac *zmac;
+
+	if (zif->mac_list) {
+		if (IS_ZEBRA_DEBUG_EVPN_MH_MAC)
+			zlog_debug("MAC list deleted for ifp %s (%u)",
+				   zif->ifp->name, zif->ifp->ifindex);
+
+		for (ALL_LIST_ELEMENTS_RO(zif->mac_list, node, zmac)) {
+			zebra_evpn_mac_ifp_unlink(zmac);
+		}
+		list_delete(&zif->mac_list);
+	}
 }
 
 /* Link local mac to destination access port. This is done only if the


### PR DESCRIPTION
…>mac_list

Fix this crash seen in our topotests:

root@eva:/var/tmp/frr/zebra.928140# more crashlog
ZEBRA: Received signal 11 at 1636047065 (si_addr 0x0, PC 0x7fc01495a7a5); aborting...
ZEBRA: zlog_signal+0x18c                  7fc01496419a     7ffd595e1f50 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: core_handler+0xe3                  7fc0149a205e     7ffd595e2070 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: funlockfile+0x50                   7fc014841140     7ffd595e21c0 /lib/x86_64-linux-gnu/libpthread.so.0 (mapped at 0x7fc01482d000)
ZEBRA:     ---- signal ----
ZEBRA: list_delete_node+0x3c              7fc01495a7a5     7ffd595e2750 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: zebra_evpn_mac_ifp_unlink+0x9f     5600718b6518     7ffd595e2770 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: zebra_evpn_mac_clear_fwd_info+0x18     5600718b6654     7ffd595e27a0 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: zebra_evpn_mac_del+0x110           5600718b90b5     7ffd595e27c0 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: zebra_evpn_mac_del_hash_entry+0xef     5600718b93a7     7ffd595e28f0 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: hash_iterate+0x57                  7fc014949fa8     7ffd595e2920 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: zebra_evpn_mac_del_all+0x6d        5600718b9418     7ffd595e2970 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: zebra_evpn_cleanup_all+0x5a        5600718b5322     7ffd595e29e0 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: zebra_evpn_vxlan_cleanup_all+0x88     5600719106ff     7ffd595e2a10 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: hash_iterate+0x57                  7fc014949fa8     7ffd595e2a50 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: zebra_vxlan_cleanup_tables+0x3a     56007191a230     7ffd595e2aa0 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: zebra_vrf_disable+0x187            5600718fd656     7ffd595e2ad0 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: vrf_disable+0x8b                   7fc0149bc88f     7ffd595e2b40 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: vrf_delete+0x5b                    7fc0149bc65e     7ffd595e2b60 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: vrf_terminate_single+0x38          7fc0149bcd71     7ffd595e2b80 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: vrf_terminate+0xe5                 7fc0149bce59     7ffd595e2ba0 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: sigint+0x1de                       560071883117     7ffd595e2bc0 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: quagga_sigevent_process+0x73       7fc0149a1e6c     7ffd595e2c10 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: thread_fetch+0x4f                  7fc0149b8884     7ffd595e2c30 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: frr_run+0x230                      7fc01495980c     7ffd595e2cb0 /lib/libfrr.so.0 (mapped at 0x7fc0148b3000)
ZEBRA: main+0x3e4                         5600718835b3     7ffd595e2dc0 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: __libc_start_main+0xea             7fc01468cd0a     7ffd595e2e90 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7fc014666000)
ZEBRA: _start+0x2a                        56007186a46a     7ffd595e2f60 /usr/lib/frr/zebra (mapped at 0x5600717ef000)
ZEBRA: no thread information available
root@eva:/var/tmp/frr/zebra.928140#

Signed-off-by: Anuradha Karuppiah <anuradhak@nvidia.com>
Signed-off-by: Donald Sharp <sharpd@nvidia.com>