### PR TITLE
zebra: fix disabling table manager

### DIFF
--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -184,8 +184,6 @@ static int zebra_vrf_disable(struct vrf *vrf)
 		zlog_debug("VRF %s id %u is now inactive", zvrf_name(zvrf),
 			   zvrf_id(zvrf));
 
-	table_manager_disable(zvrf);
-
 	/* Stop any VxLAN-EVPN processing. */
 	zebra_vxlan_vrf_disable(zvrf);
 
@@ -273,6 +271,8 @@ static int zebra_vrf_delete(struct vrf *vrf)
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("VRF %s id %u deleted", zvrf_name(zvrf),
 			   zvrf_id(zvrf));
+
+	table_manager_disable(zvrf);
 
 	/* clean-up work queues */
 	for (i = 0; i < MQ_SIZE; i++) {


### PR DESCRIPTION
42d4b30e introduced per-VRF table manager.

Table manager is allocated when the VRF is created, but it is freed when
the VRF is disabled. When this VRF is re-enabled, zebra ends up with
table manager being NULL pointer and it crashes on any dereference.

Table manager should be freed when the VRF is deleted, not when it's
disabled.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>