### PR TITLE
zebra: don't register same hook multiple times

### DIFF
--- a/zebra/table_manager.c
+++ b/zebra/table_manager.c
@@ -82,7 +82,6 @@ void table_manager_enable(struct zebra_vrf *zvrf)
 	zvrf->tbl_mgr = XCALLOC(MTYPE_TM_TABLE, sizeof(struct table_manager));
 	zvrf->tbl_mgr->lc_list = list_new();
 	zvrf->tbl_mgr->lc_list->del = delete_table_chunk;
-	hook_register(zserv_client_close, release_daemon_table_chunks);
 }
 
 /**

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -705,6 +705,8 @@ void zebra_vrf_init(void)
 	vrf_init(zebra_vrf_new, zebra_vrf_enable, zebra_vrf_disable,
 		 zebra_vrf_delete, zebra_vrf_update);
 
+	hook_register(zserv_client_close, release_daemon_table_chunks);
+
 	vrf_cmd_init(vrf_config_write);
 
 	if (vrf_is_backend_netns() && ns_have_netns()) {


### PR DESCRIPTION
Before 42d4b30e, table_manager_enable was called only once and the hook
was also registered once. After the change, the hook is registered per
each VRF that is created in the system. This is wrong.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>