### PR TITLE
tests: test_ospf_topo1.py ensure rib has time to converge

### DIFF
--- a/tests/topotests/ospf_topo1/test_ospf_topo1.py
+++ b/tests/topotests/ospf_topo1/test_ospf_topo1.py
@@ -30,6 +30,7 @@ import os
 import re
 import sys
 from functools import partial
+from time import sleep
 import pytest
 
 # Save the Current Working Directory to find configuration files.
@@ -475,7 +476,18 @@ def test_ospf_link_down_kernel_route():
         assertmsg = 'OSPF IPv4 route mismatch in router "{}" after link down'.format(
             router.name
         )
-        assert topotest.json_cmp(routes, expected) is None, assertmsg
+        count = 0
+        not_found = True
+        while not_found and count < 10:
+            not_found = topotest.json_cmp(routes, expected)
+            if not_found:
+                sleep(1)
+                routes = topotest.ip4_route(router)
+                count += 1
+            else:
+                not_found = False
+                break
+        assert not_found is False, assertmsg
 
 
 def test_ospf6_link_down():
@@ -547,7 +559,19 @@ def test_ospf6_link_down_kernel_route():
         assertmsg = 'OSPF IPv6 route mismatch in router "{}" after link down'.format(
             router.name
         )
-        assert topotest.json_cmp(routes, expected) is None, assertmsg
+        count = 0
+        not_found = True
+        while not_found and count < 10:
+            not_found = topotest.json_cmp(routes, expected)
+            if not_found:
+                sleep(1)
+                routes = topotest.ip6_route(router)
+                count += 1
+            else:
+                not_found = False
+                break
+
+        assert not_found is False, assertmsg
 
 
 def test_memory_leak():


### PR DESCRIPTION
The test does this:

a) shut link down
b) test for ospf convergence
c) ensure the route is installed

When under a heavily loaded system c) is not guaranteed
to happen quickly.  Give the system 10 extra seconds
to ensure it happens.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>