### PR TITLE
pimd : packet processing optimization on rp change

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -35,6 +35,7 @@
 #include "pim_nht.h"
 #include "pim_bsm.h"
 #include "pim_time.h"
+#include "pim_zebra.h"
 
 /* Functions forward declaration */
 static void pim_bs_timer_start(struct bsm_scope *scope, int bs_timeout);
@@ -579,6 +580,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 	struct rp_info *rp_all;
 	struct pim_upstream *up;
 	struct rp_info *rp_info;
+	bool upstream_updated = false;
 
 	if (pim->global_scope.current_bsr.s_addr)
 		pim_nht_bsr_del(pim, pim->global_scope.current_bsr);
@@ -681,8 +683,12 @@ void pim_bsm_clear(struct pim_instance *pim)
 		} else {
 			/* RP found for the group grp */
 			pim_upstream_update(pim, up);
+			upstream_updated = true;
 		}
 	}
+
+	if (upstream_updated)
+		pim_zebra_update_all_interfaces(pim);
 }
 
 static bool pim_bsm_send_intf(uint8_t *buf, int len, struct interface *ifp,


### PR DESCRIPTION
**Problem Statement:**
on rp_change, PIM processes all the upstream in a loop and for selected
upstreams PIM has to send join/prune based on the RPF changed.
join and prune packets are not getting aggregated in a single packet.

**Root Cause Analysis:**
on pim_rp_change pim_upstream_update() gets called for selected upstreams.
This API calculates to whom it has to send join and to whom it has to
send prune via API pim_zebra_upstream_rpf_changed(). This API peprares
the upstream_switch_list list per interface and inserts the group and
sources.
Now PIM is still in the pim_upstream_update() API context, i.e PIM
is still processing the same upstream. In the last there is a
call to pim_zebra_update_all_interfaces() which processes the
upstream_switch_list list, sends the packets out and clears the list.

**Fix:**
Don't process the upstream_switch_list in the upstream context.
process all the upstreams prepare the upstream_switch_list and then
process in one go. This will club all the S,G entries.
It also saves list cleanup with respect to memory allocation and
deallocation multiple times.

Signed-off-by: Vishal Dhingra <rac.vishaldhingra@gmail.com>
Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>