### PR TITLE
zebra: authorize table manager configuration at startup

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4312,7 +4312,7 @@ DEFUN(ip_table_range, ip_table_range_cmd,
 	if (!zvrf)
 		return CMD_WARNING;
 
-	if (zvrf_id(zvrf) != VRF_DEFAULT && !vrf_is_backend_netns()) {
+	if (!vrf_is_backend_netns()) {
 		vty_out(vty,
 			"VRF subcommand does not make any sense in l3mdev based vrf's\n");
 		return CMD_WARNING;


### PR DESCRIPTION
At startup, a non initialised vrf may be present, and may permit
to configure table range, even if the vrf is not yet present on
the underlying operating system.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>