### PR TITLE
bfdd,bgpd: fix some integration bugs

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -150,6 +150,7 @@ void bgp_peer_config_apply(struct peer *p, struct peer_group *pg)
 void bgp_peer_bfd_update_source(struct peer *p)
 {
 	struct bfd_session_params *session = p->bfd_config->session;
+	const union sockunion *source;
 	bool changed = false;
 	int family;
 	union {
@@ -161,44 +162,45 @@ void bgp_peer_bfd_update_source(struct peer *p)
 	if (CHECK_FLAG(p->sflags, PEER_STATUS_GROUP))
 		return;
 
+	/* Figure out the correct source to use. */
+	if (CHECK_FLAG(p->flags, PEER_FLAG_UPDATE_SOURCE))
+		source = p->update_source;
+	else
+		source = p->su_local;
+
 	/* Update peer's source/destination addresses. */
 	bfd_sess_addresses(session, &family, &src.v6, &dst.v6);
 	if (family == AF_INET) {
-		if ((p->su_local
-		     && p->su_local->sin.sin_addr.s_addr != src.v4.s_addr)
+		if ((source && source->sin.sin_addr.s_addr != src.v4.s_addr)
 		    || p->su.sin.sin_addr.s_addr != dst.v4.s_addr) {
 			if (BGP_DEBUG(bfd, BFD_LIB))
 				zlog_debug(
 					"%s: address [%pI4->%pI4] to [%pI4->%pI4]",
 					__func__, &src.v4, &dst.v4,
-					p->su_local ? &p->su_local->sin.sin_addr
-						    : &src.v4,
+					source ? &source->sin.sin_addr
+					       : &src.v4,
 					&p->su.sin.sin_addr);
 
 			bfd_sess_set_ipv4_addrs(
-				session,
-				p->su_local ? &p->su_local->sin.sin_addr : NULL,
+				session, source ? &source->sin.sin_addr : NULL,
 				&p->su.sin.sin_addr);
 			changed = true;
 		}
 	} else {
-		if ((p->su_local
-		     && memcmp(&p->su_local->sin6, &src.v6, sizeof(src.v6)))
+		if ((source && memcmp(&source->sin6, &src.v6, sizeof(src.v6)))
 		    || memcmp(&p->su.sin6, &dst.v6, sizeof(dst.v6))) {
 			if (BGP_DEBUG(bfd, BFD_LIB))
 				zlog_debug(
 					"%s: address [%pI6->%pI6] to [%pI6->%pI6]",
 					__func__, &src.v6, &dst.v6,
-					p->su_local
-						? &p->su_local->sin6.sin6_addr
-						: &src.v6,
+					source ? &source->sin6.sin6_addr
+					       : &src.v6,
 					&p->su.sin6.sin6_addr);
 
-			bfd_sess_set_ipv6_addrs(
-				session,
-				p->su_local ? &p->su_local->sin6.sin6_addr
-					    : NULL,
-				&p->su.sin6.sin6_addr);
+			bfd_sess_set_ipv6_addrs(session,
+						source ? &source->sin6.sin6_addr
+						       : NULL,
+						&p->su.sin6.sin6_addr);
 			changed = true;
 		}
 	}

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4752,6 +4752,10 @@ int peer_ebgp_multihop_set(struct peer *peer, int ttl)
 						BGP_NOTIFY_CEASE_CONFIG_CHANGE);
 			else
 				bgp_session_reset(peer);
+
+			/* Reconfigure BFD peer with new TTL. */
+			if (peer->bfd_config)
+				bgp_peer_bfd_update_source(peer);
 		}
 	} else {
 		group = peer->group;
@@ -4766,6 +4770,10 @@ int peer_ebgp_multihop_set(struct peer *peer, int ttl)
 						BGP_NOTIFY_CEASE_CONFIG_CHANGE);
 			else
 				bgp_session_reset(peer);
+
+			/* Reconfigure BFD peer with new TTL. */
+			if (peer->bfd_config)
+				bgp_peer_bfd_update_source(peer);
 		}
 	}
 	return 0;
@@ -4799,6 +4807,10 @@ int peer_ebgp_multihop_unset(struct peer *peer)
 					BGP_NOTIFY_CEASE_CONFIG_CHANGE);
 		else
 			bgp_session_reset(peer);
+
+		/* Reconfigure BFD peer with new TTL. */
+		if (peer->bfd_config)
+			bgp_peer_bfd_update_source(peer);
 	} else {
 		group = peer->group;
 		for (ALL_LIST_ELEMENTS(group->peer, node, nnode, peer)) {
@@ -4815,6 +4827,10 @@ int peer_ebgp_multihop_unset(struct peer *peer)
 				else
 					bgp_session_reset(peer);
 			}
+
+			/* Reconfigure BFD peer with new TTL. */
+			if (peer->bfd_config)
+				bgp_peer_bfd_update_source(peer);
 		}
 	}
 	return 0;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4876,6 +4876,10 @@ int peer_update_source_if_set(struct peer *peer, const char *ifname)
 		} else
 			bgp_session_reset(peer);
 
+		/* Apply new source configuration to BFD session. */
+		if (peer->bfd_config)
+			bgp_peer_bfd_update_source(peer);
+
 		/* Skip peer-group mechanics for regular peers. */
 		return 0;
 	}
@@ -4909,6 +4913,10 @@ int peer_update_source_if_set(struct peer *peer, const char *ifname)
 					BGP_NOTIFY_CEASE_CONFIG_CHANGE);
 		} else
 			bgp_session_reset(member);
+
+		/* Apply new source configuration to BFD session. */
+		if (member->bfd_config)
+			bgp_peer_bfd_update_source(member);
 	}
 
 	return 0;
@@ -4938,6 +4946,10 @@ int peer_update_source_addr_set(struct peer *peer, const union sockunion *su)
 					BGP_NOTIFY_CEASE_CONFIG_CHANGE);
 		} else
 			bgp_session_reset(peer);
+
+		/* Apply new source configuration to BFD session. */
+		if (peer->bfd_config)
+			bgp_peer_bfd_update_source(peer);
 
 		/* Skip peer-group mechanics for regular peers. */
 		return 0;
@@ -4971,6 +4983,10 @@ int peer_update_source_addr_set(struct peer *peer, const union sockunion *su)
 					BGP_NOTIFY_CEASE_CONFIG_CHANGE);
 		} else
 			bgp_session_reset(member);
+
+		/* Apply new source configuration to BFD session. */
+		if (member->bfd_config)
+			bgp_peer_bfd_update_source(member);
 	}
 
 	return 0;
@@ -5008,6 +5024,10 @@ int peer_update_source_unset(struct peer *peer)
 		} else
 			bgp_session_reset(peer);
 
+		/* Apply new source configuration to BFD session. */
+		if (peer->bfd_config)
+			bgp_peer_bfd_update_source(peer);
+
 		/* Skip peer-group mechanics for regular peers. */
 		return 0;
 	}
@@ -5039,6 +5059,10 @@ int peer_update_source_unset(struct peer *peer)
 					BGP_NOTIFY_CEASE_CONFIG_CHANGE);
 		} else
 			bgp_session_reset(member);
+
+		/* Apply new source configuration to BFD session. */
+		if (member->bfd_config)
+			bgp_peer_bfd_update_source(member);
 	}
 
 	return 0;

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -552,7 +552,8 @@ static bool bfd_sess_address_changed(const struct bfd_session_params *bsp,
 }
 
 void bfd_sess_set_ipv4_addrs(struct bfd_session_params *bsp,
-			     struct in_addr *src, struct in_addr *dst)
+			     const struct in_addr *src,
+			     const struct in_addr *dst)
 {
 	if (!bfd_sess_address_changed(bsp, AF_INET, (struct in6_addr *)src,
 				      (struct in6_addr *)dst))
@@ -576,7 +577,8 @@ void bfd_sess_set_ipv4_addrs(struct bfd_session_params *bsp,
 }
 
 void bfd_sess_set_ipv6_addrs(struct bfd_session_params *bsp,
-			     struct in6_addr *src, struct in6_addr *dst)
+			     const struct in6_addr *src,
+			     const struct in6_addr *dst)
 {
 	if (!bfd_sess_address_changed(bsp, AF_INET6, src, dst))
 		return;

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -578,8 +578,7 @@ void bfd_sess_set_ipv4_addrs(struct bfd_session_params *bsp,
 void bfd_sess_set_ipv6_addrs(struct bfd_session_params *bsp,
 			     struct in6_addr *src, struct in6_addr *dst)
 {
-	if (!bfd_sess_address_changed(bsp, AF_INET, (struct in6_addr *)src,
-				      (struct in6_addr *)dst))
+	if (!bfd_sess_address_changed(bsp, AF_INET6, src, dst))
 		return;
 
 	/* If already installed, remove the old setting. */

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -124,7 +124,8 @@ void bfd_sess_free(struct bfd_session_params **bsp);
  * \param dst remote address (mandatory).
  */
 void bfd_sess_set_ipv4_addrs(struct bfd_session_params *bsp,
-			     struct in_addr *src, struct in_addr *dst);
+			     const struct in_addr *src,
+			     const struct in_addr *dst);
 
 /**
  * Set the local and peer address of the BFD session.
@@ -138,7 +139,8 @@ void bfd_sess_set_ipv4_addrs(struct bfd_session_params *bsp,
  * \param dst remote address (mandatory).
  */
 void bfd_sess_set_ipv6_addrs(struct bfd_session_params *bsp,
-			     struct in6_addr *src, struct in6_addr *dst);
+			     const struct in6_addr *src,
+			     const struct in6_addr *dst);
 
 /**
  * Configure the BFD session interface.


### PR DESCRIPTION
Summary
---

This PR fixes a few BFD BGP integration bugs:
- On some configurations IPv6 address changes didn't correctly propagate
- Follow `ebgp-multihop` for BFD session TTL

   How to reproduce:
   1. Configure remote eBGP peer
   2. Shutdown remote interface to avoid local BGP to connect to it
   3. Configure local eBGP peer with `ebgp-multihop N`
   4. Start remote interface (`no shutdown`)

   The local BGP will create a BFD session with single hop because the TTL configuration never got updated.

- Use `update-source` address for BFD session as well

   Same issue as with `ebgp-multihop` but worse: if the BGP peers never connected then the session would not be configured at all. Also this PR makes it explicit that we'll use the `update-source` address for BFD session.