### PR TITLE
lib: do not delete vrf upon interface deletion

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -302,9 +302,6 @@ void if_delete(struct interface **ifp)
 	if (ptr->ifindex != IFINDEX_INTERNAL)
 		IFINDEX_RB_REMOVE(vrf, ptr);
 
-	if (!vrf_is_enabled(vrf))
-		vrf_delete(vrf);
-
 	if_delete_retain(ptr);
 
 	list_delete(&ptr->connected);

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -539,13 +539,10 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 
 static void vrf_terminate_single(struct vrf *vrf)
 {
-	int enabled = vrf_is_enabled(vrf);
-
 	/* Clear configured flag and invoke delete. */
 	UNSET_FLAG(vrf->status, VRF_CONFIGURED);
 	if_terminate(vrf);
-	if (enabled)
-		vrf_delete(vrf);
+	vrf_delete(vrf);
 }
 
 /* Terminate VRF module. */


### PR DESCRIPTION
Backout deletion of vrf once an interface is removed. Actually, the
interface deletion code is not properly handled in daemons. Keep the
VRF present, upon interface deletion, even if the VRF has been created
upon interface config creation.

Link: https://github.com/FRRouting/frr/pull/9943/commits/d2dbaf3b5e57051b56efd1a38d69f552a5d56c41
Link: https://github.com/FRRouting/frr/commit/f60a11883cb426f574dbe5abeff8254148e7c371#diff-95442bb13ff5d3902cbf87ddc7593245aa101fb25c07a03916035817f7156dbeR305-R307

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>