### PR TITLE
tests: Ensure ospf has reconverged before continuing

### DIFF
--- a/tests/topotests/ldp_vpls_topo1/r1/show_ip_route_after_link_down.ref
+++ b/tests/topotests/ldp_vpls_topo1/r1/show_ip_route_after_link_down.ref
@@ -1,0 +1,20 @@
+{
+  "2.2.2.2/32":[
+    {
+      "prefix":"2.2.2.2/32",
+      "protocol":"ospf",
+      "selected":true,
+      "distance":110,
+      "metric":20,
+      "nexthops":[
+        {
+          "fib":true,
+          "ip":"10.0.2.3",
+          "afi":"ipv4",
+          "interfaceName":"r1-eth2",
+          "active":true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/ldp_vpls_topo1/test_ldp_vpls_topo1.py
+++ b/tests/topotests/ldp_vpls_topo1/test_ldp_vpls_topo1.py
@@ -272,9 +272,15 @@ def test_ldp_pseudowires_after_link_down():
 
     # Shut down r1-r2 link */
     tgen = get_topogen()
-    tgen.gears["r1"].peer_link_enable("r1-eth1", False)
-    topotest.sleep(5, "Waiting for the network to reconverge")
-
+    rname = "r1"
+    tgen.gears[rname].peer_link_enable("r1-eth1", False)
+    router_compare_json_output(
+        rname,
+        "show ip route json",
+        "show_ip_route_after_link_down.ref",
+        count=160,
+        wait=1,
+    )
     # check if the pseudowire is still up (using an alternate path
     # for nexthop resolution). Give some extra wait time.
     for rname in ["r1", "r2", "r3"]:


### PR DESCRIPTION
The test_ldp_pseudowires_after_link_down test
shuts a link down and was blindly waiting 5 seconds
before just assuming the test system was in a sane
state.  Remove the sleep(5) and actually look for
the changed state for the route 2.2.2.2 that the
psueudowire actually depends on.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>