### PR TITLE
tests: pim_basic needs to wait for event to happen under load

### DIFF
--- a/tests/topotests/pim_basic/test_pim.py
+++ b/tests/topotests/pim_basic/test_pim.py
@@ -172,7 +172,11 @@ def test_pim_send_mcast_stream():
         }
     }
 
-    assert topotest.json_cmp(out, expected) is None, "failed to converge pim"
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip pim upstream json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "failed to converge pim"
     # tgen.mininet_cli()
 
 


### PR DESCRIPTION
The test system under load looks for upstream state only
1 time immediately after sending 2 streams of S,G data
flowing.  Give the system some time to process this
and ensure that it actually shows up in a small
amount of time.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>