### PR TITLE
doc: Drop misleading explanation about `neighbor X interface IFNAME`

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1444,9 +1444,6 @@ Configuring Peers
    IPv4 session addresses, see the ``neighbor PEER update-source`` command
    below.
 
-   This command is deprecated and may be removed in a future release. Its use
-   should be avoided.
-
 .. clicmd:: neighbor PEER interface remote-as <internal|external|ASN>
 
    Configure an unnumbered BGP peer. ``PEER`` should be an interface name. The


### PR DESCRIPTION
This command is not deprecated.