### PR TITLE
pimd: remove usage of inet_ntop

### DIFF
--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -1,3 +1,5 @@
+
+
 /*
  * PIM for Quagga
  * Copyright (C) 2008  Everton da Silva Marques
@@ -56,7 +58,6 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		      struct prefix_sg *sg, uint8_t source_flags)
 {
 	struct pim_interface *pim_ifp = NULL;
-	char buf[PREFIX_STRLEN];
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		char up_str[INET_ADDRSTRLEN];
@@ -109,9 +110,8 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 
 		if (pim_is_grp_ssm(pim_ifp->pim, sg->grp)) {
 			zlog_warn(
-				"%s: Specified Group(%s) in join is now in SSM, not allowed to create PIM state",
-				__func__,
-				inet_ntop(AF_INET, &sg->grp, buf, sizeof(buf)));
+				"%s: Specified Group(%pI4) in join is now in SSM, not allowed to create PIM state",
+				__func__, &sg->grp);
 			return;
 		}
 

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -323,7 +323,6 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 	int i_am_rp = 0;
 	struct pim_interface *pim_ifp = ifp->info;
 	struct pim_instance *pim = pim_ifp->pim;
-	char buf[PREFIX_STRLEN];
 
 #define PIM_MSG_REGISTER_BIT_RESERVED_LEN 4
 	ip_hdr = (struct ip *)(tlv_buf + PIM_MSG_REGISTER_BIT_RESERVED_LEN);
@@ -385,9 +384,8 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 	if (pim_is_grp_ssm(pim_ifp->pim, sg.grp)) {
 		if (sg.src.s_addr == INADDR_ANY) {
 			zlog_warn(
-				"%s: Received Register message for Group(%s) is now in SSM, dropping the packet",
-				__func__,
-				inet_ntop(AF_INET, &sg.grp, buf, sizeof(buf)));
+				"%s: Received Register message for Group(%pI4) is now in SSM, dropping the packet",
+				__func__, &sg.grp);
 			/* Drop Packet Silently */
 			return 0;
 		}


### PR DESCRIPTION
We should not be using inet_ntop. and should be using
the appropriate %pI4 instead.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>