### PR TITLE
tests: bfd_ospf_topo1 expects unreasonable convergence times under load

### DIFF
--- a/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
+++ b/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
@@ -195,16 +195,16 @@ def test_bfd_ospf_interface_failure_rt2_step3():
 
     # By default BFD provides a recovery time of 900ms plus jitter, so let's wait
     # initial 2 seconds to let the CI not suffer.
-    topotest.sleep(2, 'Wait for BFD down notification')
+    topotest.sleep(2, "Wait for BFD down notification")
 
     router_compare_json_output(
         "rt1", "show ip route ospf json", "step3/show_ip_route_rt2_down.ref", 10, 2
     )
     router_compare_json_output(
-        "rt1", "show ipv6 route ospf json", "step3/show_ipv6_route_rt2_down.ref", 1, 0
+        "rt1", "show ipv6 route ospf json", "step3/show_ipv6_route_rt2_down.ref", 10, 2
     )
     router_compare_json_output(
-        "rt1", "show bfd peers json", "step3/show_bfd_peers_rt2_down.ref", 1, 0
+        "rt1", "show bfd peers json", "step3/show_bfd_peers_rt2_down.ref", 10, 2
     )
 
     # Check recovery, this can take some time
@@ -234,15 +234,15 @@ def test_bfd_ospf_interface_failure_rt3_step3():
 
     # By default BFD provides a recovery time of 900ms plus jitter, so let's wait
     # initial 2 seconds to let the CI not suffer.
-    topotest.sleep(2, 'Wait for BFD down notification')
+    topotest.sleep(2, "Wait for BFD down notification")
     router_compare_json_output(
         "rt1", "show ip route ospf json", "step3/show_ip_route_rt3_down.ref", 10, 2
     )
     router_compare_json_output(
-        "rt1", "show ipv6 route ospf json", "step3/show_ipv6_route_rt3_down.ref", 1, 0
+        "rt1", "show ipv6 route ospf json", "step3/show_ipv6_route_rt3_down.ref", 10, 2
     )
     router_compare_json_output(
-        "rt1", "show bfd peers json", "step3/show_bfd_peers_rt3_down.ref", 1, 0
+        "rt1", "show bfd peers json", "step3/show_bfd_peers_rt3_down.ref", 10, 2
     )
 
     # Check recovery, this can take some time


### PR DESCRIPTION
When our CI test system is under high load, expecting bfd to
converge in under 2 seconds is not going to happen.  Modify the test
suites to just ensure that things reconvderge.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>