### PR TITLE
lib: fix `struct thread **` misuse in c-ares resolver bindings

### DIFF
--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -14,7 +14,8 @@
 #include <ares.h>
 #include <ares_version.h>
 
-#include "vector.h"
+#include "typesafe.h"
+#include "jhash.h"
 #include "thread.h"
 #include "lib_errors.h"
 #include "resolver.h"
@@ -27,13 +28,78 @@ struct resolver_state {
 	ares_channel channel;
 	struct thread_master *master;
 	struct thread *timeout;
-	vector read_threads, write_threads;
 };
 
 static struct resolver_state state;
 static bool resolver_debug;
 
-#define THREAD_RUNNING ((struct thread *)-1)
+/* a FD doesn't necessarily map 1:1 to a request;  we could be talking to
+ * multiple caches simultaneously, to see which responds fastest.
+ * Theoretically we could also be using the same fd for multiple lookups,
+ * but the c-ares API guarantees an n:1 mapping for fd => channel.
+ *
+ * Either way c-ares makes that decision and we just need to deal with
+ * whatever FDs it gives us.
+ */
+
+DEFINE_MTYPE_STATIC(LIB, ARES_FD, "c-ares (DNS) file descriptor information");
+PREDECL_HASH(resolver_fds);
+
+struct resolver_fd {
+	struct resolver_fds_item itm;
+
+	int fd;
+	struct resolver_state *state;
+	struct thread *t_read, *t_write;
+};
+
+static int resolver_fd_cmp(const struct resolver_fd *a,
+			   const struct resolver_fd *b)
+{
+	return numcmp(a->fd, b->fd);
+}
+
+static uint32_t resolver_fd_hash(const struct resolver_fd *item)
+{
+	return jhash_1word(item->fd, 0xacd04c9e);
+}
+
+DECLARE_HASH(resolver_fds, struct resolver_fd, itm, resolver_fd_cmp,
+	     resolver_fd_hash);
+
+static struct resolver_fds_head resfds[1] = {INIT_HASH(resfds[0])};
+
+static struct resolver_fd *resolver_fd_get(int fd,
+					   struct resolver_state *newstate)
+{
+	struct resolver_fd ref = {.fd = fd}, *res;
+
+	res = resolver_fds_find(resfds, &ref);
+	if (!res && newstate) {
+		res = XCALLOC(MTYPE_ARES_FD, sizeof(*res));
+		res->fd = fd;
+		res->state = newstate;
+		resolver_fds_add(resfds, res);
+
+		if (resolver_debug)
+			zlog_debug("c-ares registered FD %d", fd);
+	}
+	return res;
+}
+
+static void resolver_fd_drop_maybe(struct resolver_fd *resfd)
+{
+	if (resfd->t_read || resfd->t_write)
+		return;
+
+	if (resolver_debug)
+		zlog_debug("c-ares unregistered FD %d", resfd->fd);
+
+	resolver_fds_del(resfds, resfd);
+	XFREE(MTYPE_ARES_FD, resfd);
+}
+
+/* end of FD housekeeping */
 
 static void resolver_update_timeouts(struct resolver_state *r);
 
@@ -41,9 +107,7 @@ static int resolver_cb_timeout(struct thread *t)
 {
 	struct resolver_state *r = THREAD_ARG(t);
 
-	r->timeout = THREAD_RUNNING;
 	ares_process(r->channel, NULL, NULL);
-	r->timeout = NULL;
 	resolver_update_timeouts(r);
 
 	return 0;
@@ -51,17 +115,16 @@ static int resolver_cb_timeout(struct thread *t)
 
 static int resolver_cb_socket_readable(struct thread *t)
 {
-	struct resolver_state *r = THREAD_ARG(t);
-	int fd = THREAD_FD(t);
-	struct thread **t_ptr;
+	struct resolver_fd *resfd = THREAD_ARG(t);
+	struct resolver_state *r = resfd->state;
 
-	vector_set_index(r->read_threads, fd, THREAD_RUNNING);
-	ares_process_fd(r->channel, fd, ARES_SOCKET_BAD);
-	if (vector_lookup(r->read_threads, fd) == THREAD_RUNNING) {
-		t_ptr = (struct thread **)vector_get_index(r->read_threads, fd);
-		thread_add_read(r->master, resolver_cb_socket_readable, r, fd,
-				t_ptr);
-	}
+	thread_add_read(r->master, resolver_cb_socket_readable, resfd,
+			resfd->fd, &resfd->t_read);
+	/* ^ ordering important:
+	 * ares_process_fd may transitively call THREAD_OFF(resfd->t_read)
+	 * combined with resolver_fd_drop_maybe, so resfd may be free'd after!
+	 */
+	ares_process_fd(r->channel, resfd->fd, ARES_SOCKET_BAD);
 	resolver_update_timeouts(r);
 
 	return 0;
@@ -69,17 +132,16 @@ static int resolver_cb_socket_readable(struct thread *t)
 
 static int resolver_cb_socket_writable(struct thread *t)
 {
-	struct resolver_state *r = THREAD_ARG(t);
-	int fd = THREAD_FD(t);
-	struct thread **t_ptr;
+	struct resolver_fd *resfd = THREAD_ARG(t);
+	struct resolver_state *r = resfd->state;
 
-	vector_set_index(r->write_threads, fd, THREAD_RUNNING);
-	ares_process_fd(r->channel, ARES_SOCKET_BAD, fd);
-	if (vector_lookup(r->write_threads, fd) == THREAD_RUNNING) {
-		t_ptr = (struct thread **)vector_get_index(r->write_threads, fd);
-		thread_add_write(r->master, resolver_cb_socket_writable, r, fd,
-				 t_ptr);
-	}
+	thread_add_write(r->master, resolver_cb_socket_writable, resfd,
+			 resfd->fd, &resfd->t_write);
+	/* ^ ordering important:
+	 * ares_process_fd may transitively call THREAD_OFF(resfd->t_write)
+	 * combined with resolver_fd_drop_maybe, so resfd may be free'd after!
+	 */
+	ares_process_fd(r->channel, ARES_SOCKET_BAD, resfd->fd);
 	resolver_update_timeouts(r);
 
 	return 0;
@@ -89,13 +151,11 @@ static void resolver_update_timeouts(struct resolver_state *r)
 {
 	struct timeval *tv, tvbuf;
 
-	if (r->timeout == THREAD_RUNNING)
-		return;
-
 	THREAD_OFF(r->timeout);
 	tv = ares_timeout(r->channel, NULL, &tvbuf);
 	if (tv) {
 		unsigned int timeoutms = tv->tv_sec * 1000 + tv->tv_usec / 1000;
+
 		thread_add_timer_msec(r->master, resolver_cb_timeout, r,
 				      timeoutms, &r->timeout);
 	}
@@ -105,43 +165,27 @@ static void ares_socket_cb(void *data, ares_socket_t fd, int readable,
 			   int writable)
 {
 	struct resolver_state *r = (struct resolver_state *)data;
-	struct thread *t, **t_ptr;
+	struct resolver_fd *resfd;
 
-	if (readable) {
-		t = vector_lookup(r->read_threads, fd);
-		if (!t) {
-			t_ptr = (struct thread **)vector_get_index(
-				r->read_threads, fd);
-			thread_add_read(r->master, resolver_cb_socket_readable,
-					r, fd, t_ptr);
-		}
-	} else {
-		t = vector_lookup(r->read_threads, fd);
-		if (t) {
-			if (t != THREAD_RUNNING) {
-				THREAD_OFF(t);
-			}
-			vector_unset(r->read_threads, fd);
-		}
-	}
+	resfd = resolver_fd_get(fd, (readable || writable) ? r : NULL);
+	if (!resfd)
+		return;
 
-	if (writable) {
-		t = vector_lookup(r->write_threads, fd);
-		if (!t) {
-			t_ptr = (struct thread **)vector_get_index(
-				r->write_threads, fd);
-			thread_add_read(r->master, resolver_cb_socket_writable,
-					r, fd, t_ptr);
-		}
-	} else {
-		t = vector_lookup(r->write_threads, fd);
-		if (t) {
-			if (t != THREAD_RUNNING) {
-				THREAD_OFF(t);
-			}
-			vector_unset(r->write_threads, fd);
-		}
-	}
+	assert(resfd->state == r);
+
+	if (!readable)
+		THREAD_OFF(resfd->t_read);
+	else if (!resfd->t_read)
+		thread_add_read(r->master, resolver_cb_socket_readable, resfd,
+				fd, &resfd->t_read);
+
+	if (!writable)
+		THREAD_OFF(resfd->t_write);
+	else if (!resfd->t_write)
+		thread_add_write(r->master, resolver_cb_socket_writable, resfd,
+				 fd, &resfd->t_write);
+
+	resolver_fd_drop_maybe(resfd);
 }
 
 
@@ -271,8 +315,6 @@ void resolver_init(struct thread_master *tm)
 	struct ares_options ares_opts;
 
 	state.master = tm;
-	state.read_threads = vector_init(1);
-	state.write_threads = vector_init(1);
 
 	ares_opts = (struct ares_options){
 		.sock_state_cb = &ares_socket_cb,

--- a/lib/vector.c
+++ b/lib/vector.c
@@ -136,17 +136,6 @@ int vector_set_index(vector v, unsigned int i, void *val)
 	return i;
 }
 
-/* Make a specified index slot active and return its address. */
-void **vector_get_index(vector v, unsigned int i)
-{
-	vector_ensure(v, i);
-
-	if (v->active <= i)
-		v->active = i + 1;
-
-	return &v->index[i];
-}
-
 /* Look up vector.  */
 void *vector_lookup(vector v, unsigned int i)
 {

--- a/lib/vector.h
+++ b/lib/vector.h
@@ -55,7 +55,6 @@ extern void vector_ensure(vector v, unsigned int num);
 extern int vector_empty_slot(vector v);
 extern int vector_set(vector v, void *val);
 extern int vector_set_index(vector v, unsigned int i, void *val);
-extern void **vector_get_index(vector v, unsigned int i);
 extern void vector_unset(vector v, unsigned int i);
 extern void vector_unset_value(vector v, void *val);
 extern void vector_remove(vector v, unsigned int ix);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -41,6 +41,7 @@
 /lib/test_prefix2str
 /lib/test_printfrr
 /lib/test_privs
+/lib/test_resolver
 /lib/test_ringbuf
 /lib/test_segv
 /lib/test_seqlock

--- a/tests/lib/cli/common_cli.c
+++ b/tests/lib/cli/common_cli.c
@@ -60,6 +60,7 @@ static void vty_do_exit(int isexit)
 }
 
 const struct frr_yang_module_info *const *test_yang_modules = NULL;
+int test_log_prio = ZLOG_DISABLED;
 
 /* main routine. */
 int main(int argc, char **argv)
@@ -73,7 +74,7 @@ int main(int argc, char **argv)
 	/* master init. */
 	master = thread_master_create(NULL);
 
-	zlog_aux_init("NONE: ", ZLOG_DISABLED);
+	zlog_aux_init("NONE: ", test_log_prio);
 
 	/* Library inits. */
 	cmd_init(1);

--- a/tests/lib/cli/common_cli.h
+++ b/tests/lib/cli/common_cli.h
@@ -37,6 +37,8 @@ extern void test_init(int argc, char **argv);
  */
 extern struct thread_master *master;
 
+extern int test_log_prio;
+
 extern int dump_args(struct vty *vty, const char *descr, int argc,
 		     struct cmd_token *argv[]);
 

--- a/tests/lib/test_resolver.c
+++ b/tests/lib/test_resolver.c
@@ -1,0 +1,81 @@
+/*
+ * FRR c-ares integration test
+ * Copyright (C) 2021  David Lamparter for NetDEF, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/* this test is not run automatically since tests MUST NOT rely on any outside
+ * state.  DNS is most definitely "outside state".  A testbed may not have any
+ * internet connectivity at all.  It may not have working DNS.  Or worst of
+ * all, whatever name we use to test may have a temporary failure entirely
+ * beyond our control.
+ *
+ * The only way this test could be run in a testbed is with an all-local DNS
+ * setup, which considering the resolver code is rarely touched is not worth
+ * the time at all.  Instead, after touching the resolver code, manually run
+ * this test and throw some names at it.
+ */
+
+#include <zebra.h>
+
+#include "vty.h"
+#include "command.h"
+#include "resolver.h"
+#include "log.h"
+#include "sockunion.h"
+
+#include "tests/lib/cli/common_cli.h"
+
+extern struct thread_master *master;
+
+static void resolver_result(struct resolver_query *resq, const char *errstr,
+			    int numaddrs, union sockunion *addr)
+{
+	int i;
+
+	if (numaddrs <= 0) {
+		zlog_warn("hostname resolution failed: %s", errstr);
+		return;
+	}
+
+	for (i = 0; i < numaddrs; i++)
+		zlog_info("resolver result: %pSU", &addr[i]);
+}
+
+struct resolver_query query;
+
+DEFUN (test_resolve,
+       test_resolve_cmd,
+       "resolve WORD",
+       "DNS resolver\n"
+       "Name to resolve\n")
+{
+	resolver_resolve(&query, AF_UNSPEC, argv[1]->arg, resolver_result);
+	return CMD_SUCCESS;
+}
+
+__attribute__((_CONSTRUCTOR(2000)))
+static void test_setup(void)
+{
+	test_log_prio = LOG_DEBUG;
+}
+
+void test_init(int argc, char **argv)
+{
+	resolver_init(master);
+
+	install_element(VIEW_NODE, &test_resolve_cmd);
+}

--- a/tests/subdir.am
+++ b/tests/subdir.am
@@ -132,6 +132,12 @@ check_PROGRAMS += \
 	# end
 endif
 
+if CARES
+check_PROGRAMS += \
+	tests/lib/test_resolver \
+	# end
+endif
+
 tests/lib/cli/test_commands_defun.c: vtysh/vtysh_cmd.c
 	mkdir -p tests/lib/cli
 	sed \
@@ -351,6 +357,10 @@ tests_lib_test_privs_CFLAGS = $(TESTS_CFLAGS)
 tests_lib_test_privs_CPPFLAGS = $(TESTS_CPPFLAGS)
 tests_lib_test_privs_LDADD = $(ALL_TESTS_LDADD)
 tests_lib_test_privs_SOURCES = tests/lib/test_privs.c
+tests_lib_test_resolver_CFLAGS = $(TESTS_CFLAGS)
+tests_lib_test_resolver_CPPFLAGS = $(TESTS_CPPFLAGS)
+tests_lib_test_resolver_LDADD = $(ALL_TESTS_LDADD) lib/libfrrcares.la
+tests_lib_test_resolver_SOURCES = tests/lib/test_resolver.c tests/lib/cli/common_cli.c
 tests_lib_test_ringbuf_CFLAGS = $(TESTS_CFLAGS)
 tests_lib_test_ringbuf_CPPFLAGS = $(TESTS_CPPFLAGS)
 tests_lib_test_ringbuf_LDADD = $(ALL_TESTS_LDADD)


### PR DESCRIPTION
(commit message:)

The `struct thread **ref` that the thread code takes is written to and needs to stay valid over the lifetime of a thread.  This does not hold up if thread pointers are directly put in a `vector` since adding items to a `vector` may reallocate the entire array.  The thread code would then write to a now-invalid `ref`, potentially corrupting entirely unrelated data.

This should be extremely rare to trigger in practice since we only use one c-ares channel, which will likely only ever use one fd, so the vector is never resized.  That said, c-ares using only one fd is just plain fragile luck.

Either way, fix this by creating a resolver_fd tracking struct, and clean up the code while we're at it.

(this should be backported to 8.1 & 8.0 at least)

---

Randomly bumped into this while looking at the various uses the `vector` code has.  Turns out this one is plain wrong/buggy…

Added an "exercise" tool to run the resolver code while at it.  Refer to comment in `test_resolver.c` on why this isn't executed by `make check` or CI.