### PR TITLE
tests: fix bgp_community_change_update

### DIFF
--- a/tests/topotests/bgp_community_change_update/c1/bgpd.conf
+++ b/tests/topotests/bgp_community_change_update/c1/bgpd.conf
@@ -1,5 +1,5 @@
 !
-! debug bgp updates
+debug bgp updates
 !
 router bgp 65001
   no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_community_change_update/x1/bgpd.conf
+++ b/tests/topotests/bgp_community_change_update/x1/bgpd.conf
@@ -1,5 +1,5 @@
 !
-! debug bgp updates
+debug bgp updates
 !
 router bgp 65002
   no bgp ebgp-requires-policy


### PR DESCRIPTION
949aaea5 removed debugs from all topotests, but this test relies on the
debug logs so it constantly fails now.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>