### PR TITLE
zebra:  svi down remove evpn l2vni from l3vni list

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4645,6 +4645,11 @@ int zebra_vxlan_svi_down(struct interface *ifp, struct interface *link_if)
 		zevpn = zebra_evpn_from_svi(ifp, link_if);
 
 		if (zevpn) {
+                       /* remove from l3-vni list */
+                       zl3vni = zl3vni_from_vrf(zevpn->vrf_id);
+                       if (zl3vni)
+                               listnode_delete(zl3vni->l2vnis, zevpn);
+
 			zevpn->svi_if = NULL;
 			zevpn->vrf_id = VRF_DEFAULT;
 
@@ -4703,6 +4708,10 @@ int zebra_vxlan_svi_up(struct interface *ifp, struct interface *link_if)
 		/* update the vrf information for l2-vni and inform bgp */
 		zevpn->svi_if = ifp;
 		zevpn->vrf_id = ifp->vrf_id;
+
+               zl3vni = zl3vni_from_vrf(zevpn->vrf_id);
+               if (zl3vni)
+                       listnode_add_sort_nodup(zl3vni->l2vnis, zevpn);
 
 		if (if_is_operative(zevpn->vxlan_if))
 			zebra_evpn_send_add_to_client(zevpn);


### PR DESCRIPTION
Problem:
L2-VNI SVI down followed by L2-VNI's vxlan device
deletion leads to stale entry into L3VNI's
L2-VNI list.

Solution:
When L2-VNI associated SVI is down, default vrf
is the new tenant vrf.
Remove L2-VNI from L3VNI's l2vni list as
L3VNI/VRF is no longer valid in absence of associated
SVI.

When SVI is up re-add L2-VNI into associated VRF's
L3VNI.

The above remove/add from the L3VNI's L2VNI list is
already done when vxlan or L2-VNI is flaped, just need
to handle when SVI is flapped.


Testing Done:

After deleting SVI following by L2-VNI deletion,
L3VNI's L2-VNI list delets the L2-VNI. (no stale entry).

After adding back SVI/L2-VNI, L3VNI list adds back the
L2-VNI and it is associated right tenant VRF.

Signed-off-by: Chirag Shah <chirag@nvidia.com>