### PR TITLE
pimd : correct prefix-list ssm range update for exclude mode

### DIFF
--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -548,23 +548,38 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 		struct pim_interface *pim_ifp = ifp->info;
 		struct listnode *grpnode;
 		struct gm_group *grp;
+		struct listnode *grp_nextnode;
 		struct pim_ifchannel *ch, *ch_temp;
 
 		if (!pim_ifp)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
-					  grp)) {
+		for (ALL_LIST_ELEMENTS(pim_ifp->igmp_group_list, grpnode,
+				       grp_nextnode, grp)) {
 			struct listnode *srcnode;
 			struct gm_source *src;
-
-			/* scan group sources */
-			for (ALL_LIST_ELEMENTS_RO(grp->group_source_list,
-						  srcnode, src)) {
-				igmp_source_forward_reevaluate_one(pim, src);
-			} /* scan group sources */
-		}	 /* scan igmp groups */
+			/*
+			 * RFC 4604
+			 * section 2.2.1
+			 * EXCLUDE mode does not apply to SSM addresses,
+			 * and an SSM-aware router will ignore
+			 * MODE_IS_EXCLUDE and CHANGE_TO_EXCLUDE_MODE
+			 * requests in the SSM range.
+			 */
+			if (pim_is_grp_ssm(pim, grp->group_addr)
+			    && grp->group_filtermode_isexcl) {
+				igmp_group_delete(grp);
+			} else {
+				/* scan group sources */
+				for (ALL_LIST_ELEMENTS_RO(
+					     grp->group_source_list, srcnode,
+					     src)) {
+					igmp_source_forward_reevaluate_one(pim,
+									   src);
+				} /* scan group sources */
+			}
+		} /* scan igmp groups */
 
 		RB_FOREACH_SAFE (ch, pim_ifchannel_rb, &pim_ifp->ifchannel_rb,
 				 ch_temp) {


### PR DESCRIPTION
Fixing 2 issues here.

1. As per RFC 4604 section 2.2.1
 EXCLUDE mode does not apply to SSM addresses, and an SSM-aware router
 will ignore MODE_IS_EXCLUDE and CHANGE_TO_EXCLUDE_MODE requests in
 the SSM range.
If the group is in ssm range and exclude mode,
delete the group from the IGMP table.

2. When an (S,G) IGMP join is received on a router where the group
    is configured as ASM, PIM state and mroute is created for this (S,G)
    which is wrong.
    
    Fix: Do not allow PIM State to be created for such misconfiguration.
    
    Fixes: #10128

Co-authored-by: Vishal Dhingra <rac.vishaldhingra@gmail.com>
Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>