### PR TITLE
pimd: handle vxlan sg add/del for upstream entries that are in a reg-join state

### DIFF
--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -406,7 +406,9 @@ static void pim_vxlan_orig_mr_up_add(struct pim_vxlan_sg *vxlan_sg)
 		pim_vxlan_update_sg_reg_state(pim, up, true);
 		break;
 
-	default:;
+	case PIM_REG_JOIN_PENDING:
+	case PIM_REG_PRUNE:
+		break;
 	}
 
 	/* update the inherited OIL */

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -390,9 +390,23 @@ static void pim_vxlan_orig_mr_up_add(struct pim_vxlan_sg *vxlan_sg)
 	pim_upstream_keep_alive_timer_start(up, vxlan_sg->pim->keep_alive_time);
 
 	/* register the source with the RP */
-	if (up->reg_state == PIM_REG_NOINFO) {
+	switch (up->reg_state) {
+
+	case PIM_REG_NOINFO:
 		pim_register_join(up);
 		pim_null_register_send(up);
+		break;
+
+	case PIM_REG_JOIN:
+		/* if the pim upstream entry is already in reg-join state
+		 * send null_register right away and add to the register
+		 * worklist
+		 */
+		pim_null_register_send(up);
+		pim_vxlan_update_sg_reg_state(pim, up, true);
+		break;
+
+	default:;
 	}
 
 	/* update the inherited OIL */


### PR DESCRIPTION
pim-vxlan uses periodic null registers to bootstrap a new (VTEP, mcast-grp).
These null registers were not being sent if the (S, G) was already present
and in a register-join state.

Ticket: #2848079

Signed-off-by: Anuradha Karuppiah <anuradhak@nvidia.com>