### PR TITLE
ospf6d: check N-bit in Hello packet

### DIFF
--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -431,6 +431,14 @@ static void ospf6_hello_recv(struct in6_addr *src, struct in6_addr *dst,
 		return;
 	}
 
+	/* N-bit check */
+	if (OSPF6_OPT_ISSET(hello->options, OSPF6_OPT_N)
+	    != OSPF6_OPT_ISSET(oi->area->options, OSPF6_OPT_N)) {
+		zlog_warn("VRF %s: IF %s N-bit mismatch",
+			  oi->interface->vrf->name, oi->interface->name);
+		return;
+	}
+
 	/* Find neighbor, create if not exist */
 	on = ospf6_neighbor_lookup(oh->router_id, oi);
 	if (on == NULL) {

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -782,6 +782,16 @@ def verify_ospf6_neighbor(tgen, topo=None, dut=None, input_dict=None, lan=False)
     }
     result = verify_ospf6_neighbor(tgen, topo, dut, input_dict, lan=True)
 
+    3. To check there are no neighbors.
+    input_dict = {
+        "r0": {
+            "ospf6": {
+                "neighbors": []
+            }
+        }
+    }
+    result = verify_ospf6_neighbor(tgen, topo, dut, input_dict)
+
     Returns
     -------
     True or False (Error Message)
@@ -811,6 +821,19 @@ def verify_ospf6_neighbor(tgen, topo=None, dut=None, input_dict=None, lan=False)
 
             ospf_data_list = input_dict[router]["ospf6"]
             ospf_nbr_list = ospf_data_list["neighbors"]
+
+            # Check if looking for no neighbors
+            if ospf_nbr_list == []:
+                if show_ospf_json["neighbors"] == []:
+                    logger.info("[DUT: {}] OSPF6 no neighbors found".format(router))
+                    return True
+                else:
+                    errormsg = (
+                        "[DUT: {}] OSPF6 active neighbors found, expected None".format(
+                            router
+                        )
+                    )
+                    return errormsg
 
             for ospf_nbr, nbr_data in ospf_nbr_list.items():
 

--- a/tests/topotests/ospfv3_basic_functionality/ospfv3_nssa.json
+++ b/tests/topotests/ospfv3_basic_functionality/ospfv3_nssa.json
@@ -1,0 +1,86 @@
+{
+    "address_types": [
+        "ipv6"
+    ],
+    "lo_prefix": {
+        "ipv6": "2001::",
+        "v6mask": 128
+    },
+    "routers": {
+        "r1": {
+            "links": {
+                "lo": {
+                    "ipv6": "auto",
+                    "type": "loopback"
+                },
+                "r2": {
+                    "ipv6": "12::1/64",
+                    "ospf6": {
+                        "area": "0.0.0.0",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                }
+            },
+            "ospf6": {
+                "router_id": "1.1.1.1",
+                "neighbors": {
+                    "r2": {}
+                }
+            }
+        },
+        "r2": {
+            "links": {
+                "lo": {
+                    "ipv6": "auto",
+                    "type": "loopback"
+                },
+                "r1": {
+                    "ipv6": "12::2/64",
+                    "ospf6": {
+                        "area": "0.0.0.0",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                },
+                "r3": {
+                    "ipv6": "23::2/64",
+                    "ospf6": {
+                        "area": "1.1.1.1",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                }
+            },
+            "ospf6": {
+                "router_id": "2.2.2.2",
+                "neighbors": {
+                    "r1": {},
+                    "r3": {}
+                }
+            }
+        },
+        "r3": {
+            "links": {
+                "lo": {
+                    "ipv6": "auto",
+                    "type": "loopback"
+                },
+                "r2": {
+                    "ipv6": "23::3/64",
+                    "ospf6": {
+                        "area": "1.1.1.1",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                }
+            },
+            "ospf6": {
+                "router_id": "3.3.3.3",
+                "neighbors": {
+                    "r2": {}
+                }
+            }
+        }
+    }
+}

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa.py
@@ -1,0 +1,162 @@
+#!/usr/bin/python
+
+from lib.topogen import Topogen, get_topogen
+from lib.common_config import (
+    start_topology,
+    write_test_header,
+    write_test_footer,
+    reset_config_on_routers,
+    step,
+    topo_daemons,
+)
+from lib.topolog import logger
+from lib.topojson import build_config_from_json
+from lib.ospf import create_router_ospf, verify_ospf6_neighbor
+import os
+import sys
+import time
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+sys.path.append(os.path.join(CWD, "../lib/"))
+
+# pylint: disable=C0413
+
+pytestmark = [pytest.mark.ospfd]
+
+
+# Global variables
+topo = None
+
+"""
+TOPOOLOGY
+
+      +---+   0.0.0.0  +---+   1.1.1.1  +---+
+      +R1 +------------+R2 |------------+R3 |
+      +-+-+            +--++            +--++
+
+TESTCASES =
+1. OSPF Verify E-bit mismatch between R2 and R3
+2. OSPF Verify N-bit mismatch between R2 and R3
+"""
+
+
+def setup_module(mod):
+    """
+    Sets up the pytest environment
+
+    * `mod`: module name
+    """
+    testsuite_run_time = time.asctime(time.localtime(time.time()))
+    logger.info("Testsuite start time: {}".format(testsuite_run_time))
+    logger.info("=" * 40)
+
+    logger.info("Running setup_module to create topology")
+
+    # This function initiates the topology build with Topogen...
+    json_file = "{}/ospfv3_nssa.json".format(CWD)
+    tgen = Topogen(json_file, mod.__name__)
+    global topo
+    topo = tgen.json_topo
+    # ... and here it calls Mininet initialization functions.
+
+    # get list of daemons needs to be started for this suite.
+    daemons = topo_daemons(tgen, topo)
+
+    # Starting topology, create tmp files which are loaded to routers
+    #  to start deamons and then start routers
+    start_topology(tgen, daemons)
+
+    # Creating configuration from JSON
+    build_config_from_json(tgen, topo)
+
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    result = verify_ospf6_neighbor(tgen, topo)
+    assert result is True, "setup_module: Failed \n Error:" " {}".format(result)
+
+    logger.info("Running setup_module() done")
+
+
+def teardown_module(mod):
+    """
+    Teardown the pytest environment.
+
+    * `mod`: module name
+    """
+
+    logger.info("Running teardown_module to delete topology")
+
+    tgen = get_topogen()
+
+    # Stop toplogy and Remove tmp files
+    tgen.stop_topology()
+
+    logger.info(
+        "Testsuite end time: {}".format(time.asctime(time.localtime(time.time())))
+    )
+    logger.info("=" * 40)
+
+
+# ##################################
+# Test cases start here.
+# ##################################
+
+
+def test_ospfv3_bit_mismatch(request):
+    """OSPF verify E-bit and N-bit mismatch."""
+
+    tc_name = request.node.name
+    write_test_header(tc_name)
+    tgen = get_topogen()
+
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    global topo
+    step("Bring up the base config as per the topology")
+    reset_config_on_routers(tgen)
+
+    input_dict = {"r3": {"ospf6": {"neighbors": []}}}
+
+    step("Configure r3 as stub router")
+    stub = {"r3": {"ospf6": {"area": [{"id": "1.1.1.1", "type": "stub"}]}}}
+    result = create_router_ospf(tgen, topo, stub)
+    assert result is True, "Testcase {}: Failed \n Error: {}".format(tc_name, result)
+    # Verify r3 lost its adjacency with r2 due to E-bit mismatch
+    result = verify_ospf6_neighbor(tgen, topo, dut="r3", input_dict=input_dict)
+    assert result is True, "Testcase {}: Failed \n Error: {}".format(tc_name, result)
+
+    step("Configure r2 as stub router")
+    stub = {"r2": {"ospf6": {"area": [{"id": "1.1.1.1", "type": "stub"}]}}}
+    result = create_router_ospf(tgen, topo, stub)
+    assert result is True, "Testcase {}: Failed \n Error: {}".format(tc_name, result)
+    # Verify r3 has an adjacency up with r2 again
+    result = verify_ospf6_neighbor(tgen, topo, dut="r3")
+    assert result is True, "Testcase {}: Failed \n Error: {}".format(tc_name, result)
+
+    step("Configure r3 as NSSA router")
+    nssa = {"r3": {"ospf6": {"area": [{"id": "1.1.1.1", "type": "nssa"}]}}}
+    result = create_router_ospf(tgen, topo, nssa)
+    # Verify r3 lost its adjacency with r2 due to N-bit mismatch
+    result = verify_ospf6_neighbor(tgen, topo, dut="r3", input_dict=input_dict)
+    assert result is True, "Testcase {}: Failed \n Error: {}".format(tc_name, result)
+
+    step("Configure r2 as NSSA router")
+    nssa = {"r2": {"ospf6": {"area": [{"id": "1.1.1.1", "type": "nssa"}]}}}
+    result = create_router_ospf(tgen, topo, nssa)
+    # Verify r3 has an adjacency up with r2 again
+    result = verify_ospf6_neighbor(tgen, topo, dut="r3")
+    assert result is True, "Testcase {}: Failed \n Error: {}".format(tc_name, result)
+
+    write_test_footer(tc_name)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
RFC 3101 states both E-bit and N-bit need to be checked when receiving a Hello packet.

```
To support the NSSA option an additional check must be made in the function
that handles the receiving of the Hello packet to verify that both the N-bit
and the E-bit found in the Hello packet's option field match the area type and
ExternalRoutingCapability of the area of the receiving interface.
```

This PR adds the check for the N-bit

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>