### PR TITLE
pimd: Remove default from enum based switch

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2446,8 +2446,6 @@ static const char *pim_reg_state2brief_str(enum pim_reg_state reg_state,
 	case PIM_REG_PRUNE:
 		strlcpy(state_str, "RegP", state_str_len);
 		break;
-	default:
-		strlcpy(state_str, "Unk", state_str_len);
 	}
 	return state_str;
 }

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1720,8 +1720,6 @@ const char *pim_reg_state2str(enum pim_reg_state reg_state, char *state_str,
 	case PIM_REG_PRUNE:
 		strlcpy(state_str, "RegPrune", state_str_len);
 		break;
-	default:
-		strlcpy(state_str, "RegUnknown", state_str_len);
 	}
 	return state_str;
 }
@@ -1785,7 +1783,7 @@ static int pim_upstream_register_stop_timer(struct thread *t)
 		}
 		pim_null_register_send(up);
 		break;
-	default:
+	case PIM_REG_NOINFO:
 		break;
 	}
 


### PR DESCRIPTION
enum based switches should never use default.  It makes
it very hard to fix and find issues when the enum is
changed.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>