### PR TITLE
lib: backtraces for specific log messages

### DIFF
--- a/doc/developer/building-frr-for-archlinux.rst
+++ b/doc/developer/building-frr-for-archlinux.rst
@@ -11,7 +11,9 @@ Installing Dependencies
       git autoconf automake libtool make cmake pcre readline texinfo \
       pkg-config pam json-c bison flex python-pytest \
       c-ares python python2-ipaddress python-sphinx \
-      net-snmp perl libcap libelf
+      net-snmp perl libcap libelf libunwind
+
+.. include:: building-libunwind-note.rst
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-centos7.rst
+++ b/doc/developer/building-frr-for-centos7.rst
@@ -22,7 +22,9 @@ Add packages:
       readline-devel texinfo net-snmp-devel groff pkgconfig \
       json-c-devel pam-devel bison flex pytest c-ares-devel \
       python-devel python-sphinx libcap-devel \
-      elfutils-libelf-devel
+      elfutils-libelf-devel libunwind-devel
+
+.. include:: building-libunwind-note.rst
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-centos8.rst
+++ b/doc/developer/building-frr-for-centos8.rst
@@ -15,7 +15,9 @@ Add packages:
       automake libtool make readline-devel texinfo net-snmp-devel pkgconfig \
       groff pkgconfig json-c-devel pam-devel bison flex python2-pytest \
       c-ares-devel python2-devel libcap-devel \
-      elfutils-libelf-devel
+      elfutils-libelf-devel libunwind-devel
+
+.. include:: building-libunwind-note.rst
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-debian9.rst
+++ b/doc/developer/building-frr-for-debian9.rst
@@ -11,7 +11,9 @@ Add packages:
    sudo apt-get install git autoconf automake libtool make \
      libreadline-dev texinfo libjson-c-dev pkg-config bison flex \
      libc-ares-dev python3-dev python3-pytest python3-sphinx build-essential \
-     libsnmp-dev libcap-dev libelf-dev
+     libsnmp-dev libcap-dev libelf-dev libunwind-dev
+
+.. include:: building-libunwind-note.rst
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-fedora.rst
+++ b/doc/developer/building-frr-for-fedora.rst
@@ -15,7 +15,9 @@ Installing Dependencies
      readline-devel texinfo net-snmp-devel groff pkgconfig json-c-devel \
      pam-devel python3-pytest bison flex c-ares-devel python3-devel \
      python3-sphinx perl-core patch libcap-devel \
-     elfutils-libelf-devel
+     elfutils-libelf-devel libunwind-devel
+
+.. include:: building-libunwind-note.rst
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-freebsd10.rst
+++ b/doc/developer/building-frr-for-freebsd10.rst
@@ -17,7 +17,9 @@ is first package install and asked)
 ::
 
     pkg install git autoconf automake libtool gmake json-c pkgconf \
-        bison flex py36-pytest c-ares python3.6 py36-sphinx
+        bison flex py36-pytest c-ares python3.6 py36-sphinx libunwind
+
+.. include:: building-libunwind-note.rst
 
 Make sure there is no /usr/bin/flex preinstalled (and use the newly
 installed in /usr/local/bin): (FreeBSD frequently provides a older flex

--- a/doc/developer/building-frr-for-freebsd11.rst
+++ b/doc/developer/building-frr-for-freebsd11.rst
@@ -17,7 +17,9 @@ is first package install and asked)
 .. code-block:: shell
 
    pkg install git autoconf automake libtool gmake json-c pkgconf \
-      bison flex py36-pytest c-ares python3.6 py36-sphinx texinfo
+      bison flex py36-pytest c-ares python3.6 py36-sphinx texinfo libunwind
+
+.. include:: building-libunwind-note.rst
 
 Make sure there is no /usr/bin/flex preinstalled (and use the newly
 installed in /usr/local/bin): (FreeBSD frequently provides a older flex

--- a/doc/developer/building-frr-for-opensuse.rst
+++ b/doc/developer/building-frr-for-opensuse.rst
@@ -14,7 +14,9 @@ Installing Dependencies
      readline-devel texinfo net-snmp-devel groff pkgconfig libjson-c-devel\
      pam-devel python3-pytest bison flex c-ares-devel python3-devel\
      python3-Sphinx perl patch libcap-devel libyang-devel \
-     libelf-devel
+     libelf-devel libunwind-devel
+
+.. include:: building-libunwind-note.rst
 
 Building & Installing FRR
 -------------------------

--- a/doc/developer/building-frr-for-ubuntu1804.rst
+++ b/doc/developer/building-frr-for-ubuntu1804.rst
@@ -15,7 +15,9 @@ Installing Dependencies
       pkg-config libpam0g-dev libjson-c-dev bison flex \
       libc-ares-dev python3-dev python3-sphinx \
       install-info build-essential libsnmp-dev perl libcap-dev \
-      libelf-dev
+      libelf-dev libunwind-dev
+
+.. include:: building-libunwind-note.rst
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-ubuntu2004.rst
+++ b/doc/developer/building-frr-for-ubuntu2004.rst
@@ -15,7 +15,9 @@ Installing Dependencies
       pkg-config libpam0g-dev libjson-c-dev bison flex \
       libc-ares-dev python3-dev python3-sphinx \
       install-info build-essential libsnmp-dev perl \
-      libcap-dev python2 libelf-dev
+      libcap-dev python2 libelf-dev libunwind-dev
+
+.. include:: building-libunwind-note.rst
 
 Note that Ubuntu 20 no longer installs python 2.x, so it must be
 installed explicitly. Ensure that your system has a symlink named

--- a/doc/developer/building-libunwind-note.rst
+++ b/doc/developer/building-libunwind-note.rst
@@ -1,0 +1,6 @@
+.. note::
+
+   The ``libunwind`` library is optional but highly recommended, as it improves
+   backtraces printed for crashes and debugging.  However, if it is not
+   available for some reason, it can simply be left out without any loss of
+   functionality.

--- a/doc/developer/conf.py
+++ b/doc/developer/conf.py
@@ -136,6 +136,7 @@ language = None
 # directories to ignore when looking for source files.
 exclude_patterns = [
     "_build",
+    "building-libunwind-note.rst",
     "building-libyang.rst",
     "topotests-snippets.rst",
     "topotests-markers.rst",

--- a/doc/developer/subdir.am
+++ b/doc/developer/subdir.am
@@ -23,6 +23,7 @@ dev_RSTFILES = \
 	doc/developer/building-frr-for-ubuntu1604.rst \
 	doc/developer/building-frr-for-ubuntu1804.rst \
 	doc/developer/building-frr-for-ubuntu2004.rst \
+	doc/developer/building-libunwind-note.rst \
 	doc/developer/building-libyang.rst \
 	doc/developer/building.rst \
 	doc/developer/cli.rst \

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -244,6 +244,42 @@ Basic Config Commands
    Use unbuffered output for log and debug messages; normally there is
    some internal buffering.
 
+.. clicmd:: log unique-id
+
+   Include ``[XXXXX-XXXXX]`` log message unique identifier in the textual part
+   of log messages.  This is enabled by default, but can be disabled with
+   ``no log unique-id``.  Please make sure the IDs are enabled when including
+   logs for FRR bug reports.
+
+   The unique identifiers are automatically generated based on source code
+   file name, format string (before filling out) and severity.  They do not
+   change "randomly", but some cleanup work may cause large chunks of ID
+   changes between releases.  The IDs always start with a letter, consist of
+   letters and numbers (and a dash for readability), are case insensitive, and
+   ``I``, ``L``, ``O`` & ``U`` are excluded.
+
+   This option will not affect future logging targets which allow putting the
+   unique identifier in auxiliary metadata outside the log message text
+   content.  (No such logging target exists currently, but RFC5424 syslog and
+   systemd's journald both support it.)
+
+.. clicmd:: debug unique-id XXXXX-XXXXX backtrace
+
+   Print backtraces (call stack) for specific log messages, identified by
+   their unique ID (see above.)  Includes source code location and current
+   event handler being executed.  On some systems you may need to install a
+   `debug symbols` package to get proper function names rather than raw code
+   pointers.
+
+   This command can be issued inside and outside configuration mode, and is
+   saved to configuration only if it was given in configuration mode.
+
+   .. warning::
+
+      Printing backtraces can significantly slow down logging calls and cause
+      log files to quickly balloon in size.  Remember to disable backtraces
+      when they're no longer needed.
+
 .. clicmd:: service password-encryption
 
    Encrypt password.

--- a/lib/atomlist.c
+++ b/lib/atomlist.c
@@ -18,6 +18,8 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
+
 #include "atomlist.h"
 
 void atomlist_add_head(struct atomlist_head *h, struct atomlist_item *item)

--- a/lib/elf_py.c
+++ b/lib/elf_py.c
@@ -636,6 +636,9 @@ static Elf_Scn *elf_find_addr(struct elffile *ef, uint64_t addr, size_t *idx)
 		Elf_Scn *scn = elf_getscn(ef->elf, i);
 		GElf_Shdr _shdr, *shdr = gelf_getshdr(scn, &_shdr);
 
+		/* virtual address is kinda meaningless for TLS sections */
+		if (shdr->sh_flags & SHF_TLS)
+			continue;
 		if (addr < shdr->sh_addr ||
 		    addr >= shdr->sh_addr + shdr->sh_size)
 			continue;

--- a/lib/frrcu.h
+++ b/lib/frrcu.h
@@ -17,6 +17,8 @@
 #ifndef _FRRCU_H
 #define _FRRCU_H
 
+#include <assert.h>
+
 #include "memory.h"
 #include "atomlist.h"
 

--- a/lib/typerb.h
+++ b/lib/typerb.h
@@ -20,6 +20,7 @@
 #ifndef _FRR_TYPERB_H
 #define _FRR_TYPERB_H
 
+#include <string.h>
 #include "typesafe.h"
 
 #ifdef __cplusplus

--- a/lib/typesafe.c
+++ b/lib/typesafe.c
@@ -20,6 +20,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #include "typesafe.h"
 #include "memory.h"

--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <assert.h>
 #include "compiler.h"
 
 #ifdef __cplusplus

--- a/lib/xref.c
+++ b/lib/xref.c
@@ -35,6 +35,8 @@
 struct xref_block *xref_blocks;
 static struct xref_block **xref_block_last = &xref_blocks;
 
+struct xrefdata_uid_head xrefdata_uid = INIT_RBTREE_UNIQ(xrefdata_uid);
+
 static void base32(uint8_t **inpos, int *bitpos,
 		   char *out, size_t n_chars)
 {
@@ -109,6 +111,8 @@ static void xref_add_one(const struct xref *xref)
 	base32(&h, &bitpos, &xrefdata->uid[0], 5);
 	xrefdata->uid[5] = '-';
 	base32(&h, &bitpos, &xrefdata->uid[6], 5);
+
+	xrefdata_uid_add(&xrefdata_uid, xrefdata);
 }
 
 void xref_gcc_workaround(const struct xref *xref)

--- a/lib/xref.h
+++ b/lib/xref.h
@@ -22,6 +22,7 @@
 #include <limits.h>
 #include <errno.h>
 #include "compiler.h"
+#include "typesafe.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,6 +64,8 @@ struct xref {
 	/* type-specific bits appended by embedding this struct */
 };
 
+PREDECL_RBTREE_UNIQ(xrefdata_uid);
+
 struct xrefdata {
 	/* pointer back to the const part;  this will be initialized at
 	 * program startup by xref_block_add().  (Creating structs with
@@ -88,7 +91,17 @@ struct xrefdata {
 	uint32_t hashu32[2];
 
 	/* -- 32 bytes (on 64bit) -- */
+	struct xrefdata_uid_item xui;
 };
+
+static inline int xrefdata_uid_cmp(const struct xrefdata *a,
+				   const struct xrefdata *b)
+{
+	return strcmp(a->uid, b->uid);
+}
+
+DECLARE_RBTREE_UNIQ(xrefdata_uid, struct xrefdata, xui, xrefdata_uid_cmp);
+extern struct xrefdata_uid_head xrefdata_uid;
 
 /* linker "magic" is used to create an array of pointers to struct xref.
  * the result is a contiguous block of pointers, each pointing to an xref

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -47,12 +47,19 @@
 #include <mach/mach_traps.h>
 #endif
 
+#ifdef HAVE_LIBUNWIND
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+#include <dlfcn.h>
+#endif
+
 #include "memory.h"
 #include "atomlist.h"
 #include "printfrr.h"
 #include "frrcu.h"
 #include "zlog.h"
 #include "libfrr_trace.h"
+#include "thread.h"
 
 DEFINE_MTYPE_STATIC(LIB, LOG_MESSAGE,  "log message");
 DEFINE_MTYPE_STATIC(LIB, LOG_TLSBUF,   "log thread-local buffer");
@@ -508,6 +515,87 @@ static void vzlog_tls(struct zlog_tls *zlog_tls, const struct xref_logmsg *xref,
 		XFREE(MTYPE_LOG_MESSAGE, msg->text);
 }
 
+static void zlog_backtrace_msg(const struct xref_logmsg *xref, int prio)
+{
+	struct thread *tc = pthread_getspecific(thread_current);
+	const char *uid = xref->xref.xrefdata->uid;
+	bool found_thread = false;
+
+	zlog(prio, "| (%s) message in thread %jd, at %s(), %s:%d", uid,
+	     zlog_gettid(), xref->xref.func, xref->xref.file, xref->xref.line);
+
+#ifdef HAVE_LIBUNWIND
+	const char *threadfunc = tc ? tc->xref->funcname : NULL;
+	bool found_caller = false;
+	unw_cursor_t cursor;
+	unw_context_t uc;
+	unw_word_t ip, off, sp;
+	Dl_info dlinfo;
+
+	unw_getcontext(&uc);
+
+	unw_init_local(&cursor, &uc);
+	while (unw_step(&cursor) > 0) {
+		char buf[96], name[128] = "?";
+		bool is_thread = false;
+
+		unw_get_reg(&cursor, UNW_REG_IP, &ip);
+		unw_get_reg(&cursor, UNW_REG_SP, &sp);
+
+		if (unw_is_signal_frame(&cursor))
+			zlog(prio, "| (%s)    ---- signal ----", uid);
+
+		if (!unw_get_proc_name(&cursor, buf, sizeof(buf), &off)) {
+			if (!strcmp(buf, xref->xref.func))
+				found_caller = true;
+			if (threadfunc && !strcmp(buf, threadfunc))
+				found_thread = is_thread = true;
+
+			snprintf(name, sizeof(name), "%s+%#lx", buf, (long)off);
+		}
+
+		if (!found_caller)
+			continue;
+
+		if (dladdr((void *)ip, &dlinfo))
+			zlog(prio, "| (%s) %-36s %16lx+%08lx %16lx %s", uid,
+			     name, (long)dlinfo.dli_fbase,
+			     (long)ip - (long)dlinfo.dli_fbase, (long)sp,
+			     dlinfo.dli_fname);
+		else
+			zlog(prio, "| (%s) %-36s %16lx %16lx", uid, name,
+			     (long)ip, (long)sp);
+
+		if (is_thread)
+			zlog(prio, "| (%s) ^- scheduled from %s(), %s:%u", uid,
+			     tc->xref->xref.func, tc->xref->xref.file,
+			     tc->xref->xref.line);
+	}
+#elif defined(HAVE_GLIBC_BACKTRACE)
+	void *frames[64];
+	char **names = NULL;
+	int n_frames, i;
+
+	n_frames = backtrace(frames, array_size(frames));
+	if (n_frames < 0)
+		n_frames = 0;
+	if (n_frames)
+		names = backtrace_symbols(frames, n_frames);
+
+	for (i = 0; i < n_frames; i++) {
+		void *retaddr = frames[i];
+		char *loc = names[i];
+
+		zlog(prio, "| (%s) %16lx %-36s", uid, (long)retaddr, loc);
+	}
+	free(names);
+#endif
+	if (!found_thread && tc)
+		zlog(prio, "| (%s) scheduled from %s(), %s:%u", uid,
+		     tc->xref->xref.func, tc->xref->xref.file,
+		     tc->xref->xref.line);
+}
+
 void vzlogx(const struct xref_logmsg *xref, int prio,
 	    const char *fmt, va_list ap)
 {
@@ -545,6 +633,15 @@ void vzlogx(const struct xref_logmsg *xref, int prio,
 		vzlog_tls(zlog_tls, xref, prio, fmt, ap);
 	else
 		vzlog_notls(xref, prio, fmt, ap);
+
+	if (xref) {
+		struct xrefdata_logmsg *xrdl;
+
+		xrdl = container_of(xref->xref.xrefdata, struct xrefdata_logmsg,
+				    xrefdata);
+		if (xrdl->fl_print_bt)
+			zlog_backtrace_msg(xref, prio);
+	}
 }
 
 void zlog_sigsafe(const char *text, size_t len)

--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -54,10 +54,14 @@ struct xref_logmsg {
 	const char *args;
 };
 
+/* whether flag was added in config mode or enable mode */
+#define LOGMSG_FLAG_EPHEMERAL	(1 << 0)
+#define LOGMSG_FLAG_PERSISTENT	(1 << 1)
+
 struct xrefdata_logmsg {
 	struct xrefdata xrefdata;
 
-	/* nothing more here right now */
+	uint8_t fl_print_bt;
 };
 
 /* These functions are set up to write to stdout/stderr without explicit
@@ -94,15 +98,19 @@ static inline void zlog_ref(const struct xref_logmsg *xref,
 
 #define _zlog_ecref(ec_, prio, msg, ...)                                       \
 	do {                                                                   \
-		static struct xrefdata _xrefdata = {                           \
-			.xref = NULL,                                          \
-			.uid = {},                                             \
-			.hashstr = (msg),                                      \
-			.hashu32 = {(prio), (ec_)},                            \
+		static struct xrefdata_logmsg _xrefdata = {                    \
+			.xrefdata =                                            \
+				{                                              \
+					.xref = NULL,                          \
+					.uid = {},                             \
+					.hashstr = (msg),                      \
+					.hashu32 = {(prio), (ec_)},            \
+				},                                             \
 		};                                                             \
 		static const struct xref_logmsg _xref __attribute__(           \
 			(used)) = {                                            \
-			.xref = XREF_INIT(XREFT_LOGMSG, &_xrefdata, __func__), \
+			.xref = XREF_INIT(XREFT_LOGMSG, &_xrefdata.xrefdata,   \
+					  __func__),                           \
 			.fmtstring = (msg),                                    \
 			.priority = (prio),                                    \
 			.ec = (ec_),                                           \


### PR DESCRIPTION
This adds `debug unique-id XXXXX-XXXXX backtrace`, which prints a backtrace whenever the specified log message is printed. It looks like this:

```
areia# debug unique-id ZWE6K-GRWAN backtrace
[…]
2021/11/10 11:09:57.718033 debugging: ZEBRA: [ZWE6K-GRWAN] Not Notifying Owner: kernel about prefix 0.0.0.1/32(254) 3 vrf: 0
2021/11/10 11:09:57.718036 debugging: ZEBRA: | (ZWE6K-GRWAN) message in thread 115524, at route_notify_internal(), zebra/zapi_msg.c:758
2021/11/10 11:09:57.718888 debugging: ZEBRA: | (ZWE6K-GRWAN) route_notify_internal+0xa3               5595a8b73000+000ae37a     7ffcc8d4c920 /home/equinox/c/frr-xref-bt/zebra/.libs/zebra
2021/11/10 11:09:57.719080 debugging: ZEBRA: | (ZWE6K-GRWAN) zsend_route_notify_owner_ctx+0x9c        5595a8b73000+000ae5e6     7ffcc8d4c990 /home/equinox/c/frr-xref-bt/zebra/.libs/zebra
2021/11/10 11:09:57.719282 debugging: ZEBRA: | (ZWE6K-GRWAN) rib_process_result+0x827                 5595a8b73000+000f8e91     7ffcc8d4c9f0 /home/equinox/c/frr-xref-bt/zebra/.libs/zebra
2021/11/10 11:09:57.719480 debugging: ZEBRA: | (ZWE6K-GRWAN) rib_process_dplane_results+0x12a         5595a8b73000+000fdb41     7ffcc8d4cab0 /home/equinox/c/frr-xref-bt/zebra/.libs/zebra
2021/11/10 11:09:57.719482 debugging: ZEBRA: | (ZWE6K-GRWAN) ^- scheduled from rib_dplane_results(), zebra/zebra_rib.c:4287
2021/11/10 11:09:57.719779 debugging: ZEBRA: | (ZWE6K-GRWAN) thread_call+0x126                        7f6e8cbb5000+000ff918     7ffcc8d4cb10 /home/equinox/c/frr-xref-bt/lib/.libs/libfrr.so.0
2021/11/10 11:09:57.720045 debugging: ZEBRA: | (ZWE6K-GRWAN) frr_run+0x217                            7f6e8cbb5000+000a04b3     7ffcc8d4cbd0 /home/equinox/c/frr-xref-bt/lib/.libs/libfrr.so.0
2021/11/10 11:09:57.720234 debugging: ZEBRA: | (ZWE6K-GRWAN) main+0x3e4                               5595a8b73000+00093443     7ffcc8d4cce0 /home/equinox/c/frr-xref-bt/zebra/.libs/zebra
2021/11/10 11:09:57.720428 debugging: ZEBRA: | (ZWE6K-GRWAN) __libc_start_main+0xea                   7f6e8c956000+00027e4a     7ffcc8d4cdb0 /lib/x86_64-linux-gnu/libc.so.6
2021/11/10 11:09:57.720620 debugging: ZEBRA: | (ZWE6K-GRWAN) _start+0x2a                              5595a8b73000+0007a2fa     7ffcc8d4ce80 /home/equinox/c/frr-xref-bt/zebra/.libs/zebra
```

… except if you don't have `libunwind` it's not quite as pretty:

```
2021/11/10 11:07:36.725201 debugging: ZEBRA: [ZWE6K-GRWAN] Not Notifying Owner: kernel about prefix 0.0.0.1/32(254) 2 vrf: 0
2021/11/10 11:07:36.725203 debugging: ZEBRA: | (ZWE6K-GRWAN) message in thread 99691, at route_notify_internal(), zebra/zapi_msg.c:758
2021/11/10 11:07:36.725831 debugging: ZEBRA: | (ZWE6K-GRWAN)     7f76958a1242 /home/equinox/c/frr-xref-bt/lib/.libs/libfrr.so.0(+0x120242) [0x7f76958a1242]
2021/11/10 11:07:36.725834 debugging: ZEBRA: | (ZWE6K-GRWAN)     7f76958a13de /home/equinox/c/frr-xref-bt/lib/.libs/libfrr.so.0(vzlogx+0x95) [0x7f76958a13de]
2021/11/10 11:07:36.725835 debugging: ZEBRA: | (ZWE6K-GRWAN)     55649fca459a /home/equinox/c/frr-xref-bt/zebra/.libs/zebra(+0xac59a) [0x55649fca459a]
2021/11/10 11:07:36.725836 debugging: ZEBRA: | (ZWE6K-GRWAN)     55649fca637a /home/equinox/c/frr-xref-bt/zebra/.libs/zebra(+0xae37a) [0x55649fca637a]
2021/11/10 11:07:36.725836 debugging: ZEBRA: | (ZWE6K-GRWAN)     55649fca65e6 /home/equinox/c/frr-xref-bt/zebra/.libs/zebra(zsend_route_notify_owner_ctx+0x9c) [0x55649fca65e6]
2021/11/10 11:07:36.725837 debugging: ZEBRA: | (ZWE6K-GRWAN)     55649fcf0ced /home/equinox/c/frr-xref-bt/zebra/.libs/zebra(+0xf8ced) [0x55649fcf0ced]
2021/11/10 11:07:36.725838 debugging: ZEBRA: | (ZWE6K-GRWAN)     55649fcf5b41 /home/equinox/c/frr-xref-bt/zebra/.libs/zebra(+0xfdb41) [0x55649fcf5b41]
2021/11/10 11:07:36.725838 debugging: ZEBRA: | (ZWE6K-GRWAN)     7f7695880637 /home/equinox/c/frr-xref-bt/lib/.libs/libfrr.so.0(thread_call+0x126) [0x7f7695880637]
2021/11/10 11:07:36.725839 debugging: ZEBRA: | (ZWE6K-GRWAN)     7f7695821463 /home/equinox/c/frr-xref-bt/lib/.libs/libfrr.so.0(frr_run+0x217) [0x7f7695821463]
2021/11/10 11:07:36.725840 debugging: ZEBRA: | (ZWE6K-GRWAN)     55649fc8b443 /home/equinox/c/frr-xref-bt/zebra/.libs/zebra(main+0x3e4) [0x55649fc8b443]
2021/11/10 11:07:36.725840 debugging: ZEBRA: | (ZWE6K-GRWAN)     7f7695549e4a /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xea) [0x7f7695549e4a]
2021/11/10 11:07:36.725841 debugging: ZEBRA: | (ZWE6K-GRWAN)     55649fc722fa /home/equinox/c/frr-xref-bt/zebra/.libs/zebra(_start+0x2a) [0x55649fc722fa]
2021/11/10 11:07:36.725842 debugging: ZEBRA: | (ZWE6K-GRWAN) scheduled from rib_dplane_results(), zebra/zebra_rib.c:4287
```

I've added `libunwind` to the build docs; it's **purely optional but recommended**.  `./configure` autodetects it and uses `libunwind` when available. This has actually been in there for a long time, some of the BSDs use libunwind by default, and there are also some cases on ARM and PowerPC systems where `backtrace()` just doesn't work but `libunwind` does. (This is related to architecture specific frame pointer shenanigans; libunwind understands DWARF debug info to handle that, `backtrace()` doesn't.)