### PR TITLE
*: use compiler.h MIN/MAX macros instead of everyone having one

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -1002,8 +1002,6 @@ uint8_t *aspath_snmp_pathseg(struct aspath *as, size_t *varlen)
 	return stream_pnt(snmp_stream);
 }
 
-#define min(A,B) ((A) < (B) ? (A) : (B))
-
 static struct assegment *aspath_aggregate_as_set_add(struct aspath *aspath,
 						     struct assegment *asset,
 						     as_t as)
@@ -1060,7 +1058,7 @@ struct aspath *aspath_aggregate(struct aspath *as1, struct aspath *as2)
 			break;
 
 		/* Minimum segment length. */
-		minlen = min(seg1->length, seg2->length);
+		minlen = MIN(seg1->length, seg2->length);
 
 		for (match = 0; match < minlen; match++)
 			if (seg1->as[match] != seg2->as[match])

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1298,12 +1298,11 @@ static void bgp_l3nhg_zebra_init(void)
 }
 
 
-#define min(A, B) ((A) < (B) ? (A) : (B))
 void bgp_l3nhg_init(void)
 {
 	uint32_t id_max;
 
-	id_max = min(ZEBRA_NHG_PROTO_SPACING - 1, 16 * 1024);
+	id_max = MIN(ZEBRA_NHG_PROTO_SPACING - 1, 16 * 1024);
 	bf_init(bgp_nh_id_bitmap, id_max);
 	bf_assign_zero_index(bgp_nh_id_bitmap);
 

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -553,7 +553,7 @@ void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 
 	bgp_adv_fifo_add_tail(&subgrp->sync->update, adv);
 
-	subgrp->version = max(subgrp->version, dest->version);
+	subgrp->version = MAX(subgrp->version, dest->version);
 }
 
 /* The only time 'withdraw' will be false is if we are sending
@@ -609,7 +609,7 @@ void bgp_adj_out_unset_subgroup(struct bgp_dest *dest,
 		}
 	}
 
-	subgrp->version = max(subgrp->version, dest->version);
+	subgrp->version = MAX(subgrp->version, dest->version);
 }
 
 void bgp_adj_out_remove_subgroup(struct bgp_dest *dest, struct bgp_adj_out *adj,
@@ -721,7 +721,7 @@ void subgroup_announce_table(struct update_subgroup *subgrp,
 	 * covers the pathological case where all routes in the table have
 	 * now been deleted.
 	 */
-	subgrp->version = max(subgrp->version, table->version);
+	subgrp->version = MAX(subgrp->version, table->version);
 
 	/*
 	 * Start a task to merge the subgroup if necessary.

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -81,13 +81,6 @@ typedef uint32_t as_t;
 typedef uint16_t as16_t; /* we may still encounter 16 Bit asnums */
 typedef uint16_t bgp_size_t;
 
-#define max(a, b)                                                              \
-	({                                                                     \
-		__typeof__(a) _a = (a);                                        \
-		__typeof__(b) _b = (b);                                        \
-		_a > _b ? _a : _b;                                             \
-	})
-
 enum bgp_af_index {
 	BGP_AF_START,
 	BGP_AF_IPV4_UNICAST = BGP_AF_START,

--- a/ldpd/hello.c
+++ b/ldpd/hello.c
@@ -415,13 +415,13 @@ recv_hello(struct in_addr lsr_id, struct ldp_msg *msg, int af,
 		if (holdtime == 0)
 			holdtime = LINK_DFLT_HOLDTIME;
 
-		adj->holdtime = min(if_get_hello_holdtime(ia), holdtime);
+		adj->holdtime = MIN(if_get_hello_holdtime(ia), holdtime);
 		break;
 	case HELLO_TARGETED:
 		if (holdtime == 0)
 			holdtime = TARGETED_DFLT_HOLDTIME;
 
-		adj->holdtime = min(tnbr_get_hello_holdtime(tnbr), holdtime);
+		adj->holdtime = MIN(tnbr_get_hello_holdtime(tnbr), holdtime);
 	}
 	if (adj->holdtime != INFINITE_HOLDTIME)
 		adj_start_itimer(adj);

--- a/ldpd/init.c
+++ b/ldpd/init.c
@@ -197,7 +197,7 @@ recv_init(struct nbr *nbr, char *buf, uint16_t len)
 		len -= tlv_len;
 	}
 
-	nbr->keepalive = min(nbr_get_keepalive(nbr->af, nbr->id),
+	nbr->keepalive = MIN(nbr_get_keepalive(nbr->af, nbr->id),
 	    ntohs(sess.keepalive_time));
 
 	max_pdu_len = ntohs(sess.max_pdu_len);
@@ -208,7 +208,7 @@ recv_init(struct nbr *nbr, char *buf, uint16_t len)
 	 */
 	if (max_pdu_len <= 255)
 		max_pdu_len = LDP_MAX_LEN;
-	nbr->max_pdu_len = min(max_pdu_len, LDP_MAX_LEN);
+	nbr->max_pdu_len = MIN(max_pdu_len, LDP_MAX_LEN);
 
 	nbr_fsm(nbr, NBR_EVT_INIT_RCVD);
 

--- a/ldpd/ldpe.h
+++ b/ldpd/ldpe.h
@@ -30,9 +30,6 @@
 #include "ldpd.h"
 #include "lib/ldp_sync.h"
 
-#define min(x,y) ((x) <= (y) ? (x) : (y))
-#define max(x,y) ((x) > (y) ? (x) : (y))
-
 /* forward declarations */
 TAILQ_HEAD(mapping_head, mapping_entry);
 

--- a/lib/snmp.c
+++ b/lib/snmp.c
@@ -25,13 +25,11 @@
 
 #include "smux.h"
 
-#define min(A,B) ((A) < (B) ? (A) : (B))
-
 int oid_compare(const oid *o1, int o1_len, const oid *o2, int o2_len)
 {
 	int i;
 
-	for (i = 0; i < min(o1_len, o2_len); i++) {
+	for (i = 0; i < MIN(o1_len, o2_len); i++) {
 		if (o1[i] < o2[i])
 			return -1;
 		else if (o1[i] > o2[i])

--- a/pathd/path_pcep_controller.c
+++ b/pathd/path_pcep_controller.c
@@ -38,14 +38,6 @@
 
 #define MAX_RECONNECT_DELAY 120
 
-#define min(a, b)                                                              \
-	({                                                                     \
-		__typeof__(a) _a = (a);                                        \
-		__typeof__(b) _b = (b);                                        \
-		_a <= _b ? _a : _b;                                            \
-	})
-
-
 /* Event handling data structures */
 enum pcep_ctrl_event_type {
 	EV_UPDATE_PCC_OPTS = 1,
@@ -1078,7 +1070,7 @@ void remove_pcc_state(struct ctrl_state *ctrl_state,
 
 uint32_t backoff_delay(uint32_t max, uint32_t base, uint32_t retry_count)
 {
-	uint32_t a = min(max, base * (1 << retry_count));
+	uint32_t a = MIN(max, base * (1 << retry_count));
 	uint64_t r = frr_weak_random(), m = RAND_MAX;
 	uint32_t b = (a / 2) + (r * (a / 2)) / m;
 	return b;

--- a/pimd/pim_msdp_packet.h
+++ b/pimd/pim_msdp_packet.h
@@ -58,7 +58,8 @@
  * fragmentation */
 #define PIM_MSDP_SA_MAX_ENTRY_CNT 120
 
-#define PIM_MSDP_MAX_PACKET_SIZE max(PIM_MSDP_SA_TLV_MAX_SIZE, PIM_MSDP_KA_TLV_MAX_SIZE)
+#define PIM_MSDP_MAX_PACKET_SIZE                                               \
+	MAX(PIM_MSDP_SA_TLV_MAX_SIZE, PIM_MSDP_KA_TLV_MAX_SIZE)
 
 #define PIM_MSDP_PKT_TYPE_STRLEN 16
 

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -85,8 +85,6 @@
 #define PIM_INADDR_IS_ANY(addr) (addr).s_addr == PIM_NET_INADDR_ANY
 #define PIM_INADDR_ISNOT_ANY(addr) ((addr).s_addr != PIM_NET_INADDR_ANY) /* struct in_addr addr */
 
-#define max(x,y) ((x) > (y) ? (x) : (y))
-
 #define PIM_MASK_PIM_EVENTS          (1 << 0)
 #define PIM_MASK_PIM_EVENTS_DETAIL   (1 << 1)
 #define PIM_MASK_PIM_PACKETS         (1 << 2)

--- a/ripngd/ripng_nexthop.c
+++ b/ripngd/ripng_nexthop.c
@@ -43,8 +43,6 @@ DEFINE_MTYPE_STATIC(RIPNGD, RIPNG_RTE_DATA, "RIPng rte data");
 
 #define DEBUG 1
 
-#define min(a, b) ((a) < (b) ? (a) : (b))
-
 struct ripng_rte_data {
 	struct prefix_ipv6 *p;
 	struct ripng_info *rinfo;
@@ -151,7 +149,7 @@ void ripng_rte_send(struct list *ripng_rte_list, struct interface *ifp,
 	if (mtu < 0)
 		mtu = IFMINMTU;
 
-	rtemax = (min(mtu, RIPNG_MAX_PACKET_SIZE) - IPV6_HDRLEN
+	rtemax = (MIN(mtu, RIPNG_MAX_PACKET_SIZE) - IPV6_HDRLEN
 		  - sizeof(struct udphdr) - sizeof(struct ripng_packet)
 		  + sizeof(struct rte))
 		 / sizeof(struct rte);


### PR DESCRIPTION
We had various forms of min/max macros across multiple daemons
all of which duplicated what we have in compiler.h.  Convert
everyone to use the `correct` ones

Signed-off-by: Donald Sharp <sharpd@nvidia.com>