### PR TITLE
*: cleanup ifp->vrf_id

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -583,7 +583,7 @@ int bfd_recv_cb(struct thread *t)
 	if (ifindex) {
 		ifp = if_lookup_by_index(ifindex, vrfid);
 		if (ifp)
-			vrfid = ifp->vrf_id;
+			vrfid = ifp->vrf->vrf_id;
 	}
 
 	/* Implement RFC 5880 6.8.6 */

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -666,9 +666,7 @@ static void bfdd_sessions_enable_interface(struct interface *ifp)
 	struct bfd_session *bs;
 	struct vrf *vrf;
 
-	vrf = vrf_lookup_by_id(ifp->vrf_id);
-	if (!vrf)
-		return;
+	vrf = ifp->vrf;
 
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
 		bs = bso->bso_bs;
@@ -767,8 +765,8 @@ void bfdd_sessions_disable_vrf(struct vrf *vrf)
 static int bfd_ifp_destroy(struct interface *ifp)
 {
 	if (bglobal.debug_zebra)
-		zlog_debug("zclient: delete interface %s (VRF %u)", ifp->name,
-			   ifp->vrf_id);
+		zlog_debug("zclient: delete interface %s (VRF %s(%u))",
+			   ifp->name, ifp->vrf->name, ifp->vrf->vrf_id);
 
 	bfdd_sessions_disable_interface(ifp);
 
@@ -837,8 +835,8 @@ static int bfdd_interface_address_update(ZAPI_CALLBACK_ARGS)
 static int bfd_ifp_create(struct interface *ifp)
 {
 	if (bglobal.debug_zebra)
-		zlog_debug("zclient: add interface %s (VRF %u)", ifp->name,
-			   ifp->vrf_id);
+		zlog_debug("zclient: add interface %s (VRF %s(%u))", ifp->name,
+			   ifp->vrf->name, ifp->vrf->vrf_id);
 	bfdd_sessions_enable_interface(ifp);
 
 	return 0;

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -588,7 +588,7 @@ static void bgp_nht_ifp_handle(struct interface *ifp, bool up)
 {
 	struct bgp *bgp;
 
-	bgp = bgp_lookup_by_vrf_id(ifp->vrf_id);
+	bgp = ifp->vrf->info;
 	if (!bgp)
 		return;
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -206,10 +206,11 @@ static int bgp_ifp_destroy(struct interface *ifp)
 {
 	struct bgp *bgp;
 
-	bgp = bgp_lookup_by_vrf_id(ifp->vrf_id);
+	bgp = ifp->vrf->info;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Rx Intf del VRF %u IF %s", ifp->vrf_id, ifp->name);
+		zlog_debug("Rx Intf del VRF %u IF %s", ifp->vrf->vrf_id,
+			   ifp->name);
 
 	if (bgp) {
 		bgp_update_interface_nbrs(bgp, ifp, NULL);
@@ -228,12 +229,13 @@ static int bgp_ifp_up(struct interface *ifp)
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
 
-	bgp = bgp_lookup_by_vrf_id(ifp->vrf_id);
+	bgp = ifp->vrf->info;
 
 	bgp_mac_add_mac_entry(ifp);
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Rx Intf up VRF %u IF %s", ifp->vrf_id, ifp->name);
+		zlog_debug("Rx Intf up VRF %u IF %s", ifp->vrf->vrf_id,
+			   ifp->name);
 
 	if (!bgp)
 		return 0;
@@ -258,12 +260,13 @@ static int bgp_ifp_down(struct interface *ifp)
 	struct bgp *bgp;
 	struct peer *peer;
 
-	bgp = bgp_lookup_by_vrf_id(ifp->vrf_id);
+	bgp = ifp->vrf->info;
 
 	bgp_mac_del_mac_entry(ifp);
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Rx Intf down VRF %u IF %s", ifp->vrf_id, ifp->name);
+		zlog_debug("Rx Intf down VRF %u IF %s", ifp->vrf->vrf_id,
+			   ifp->name);
 
 	if (!bgp)
 		return 0;
@@ -3103,9 +3106,10 @@ static int bgp_ifp_create(struct interface *ifp)
 	struct bgp *bgp;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Rx Intf add VRF %u IF %s", ifp->vrf_id, ifp->name);
+		zlog_debug("Rx Intf add VRF %u IF %s", ifp->vrf->vrf_id,
+			   ifp->name);
 
-	bgp = bgp_lookup_by_vrf_id(ifp->vrf_id);
+	bgp = ifp->vrf->info;
 	if (!bgp)
 		return 0;
 

--- a/eigrpd/eigrp_filter.c
+++ b/eigrpd/eigrp_filter.c
@@ -215,7 +215,7 @@ void eigrp_distribute_update_interface(struct interface *ifp)
 	struct distribute *dist;
 	struct eigrp *eigrp;
 
-	eigrp = eigrp_lookup(ifp->vrf_id);
+	eigrp = eigrp_lookup(ifp->vrf->vrf_id);
 	if (!eigrp)
 		return;
 	dist = distribute_lookup(eigrp->distribute_ctx, ifp->name);

--- a/eigrpd/eigrp_network.c
+++ b/eigrpd/eigrp_network.c
@@ -288,7 +288,7 @@ void eigrp_if_update(struct interface *ifp)
 	 * we need to check eac one and add the interface as approperate
 	 */
 	for (ALL_LIST_ELEMENTS(eigrp_om->eigrp, node, nnode, eigrp)) {
-		if (ifp->vrf_id != eigrp->vrf_id)
+		if (ifp->vrf->vrf_id != eigrp->vrf_id)
 			continue;
 
 		/* EIGRP must be on and Router-ID must be configured. */

--- a/eigrpd/eigrp_northbound.c
+++ b/eigrpd/eigrp_northbound.c
@@ -1135,7 +1135,7 @@ static int lib_interface_eigrp_instance_create(struct nb_cb_create_args *args)
 		}
 
 		eigrp = eigrp_get(yang_dnode_get_uint16(args->dnode, "./asn"),
-				  ifp->vrf_id);
+				  ifp->vrf->vrf_id);
 		eif = eigrp_interface_lookup(eigrp, ifp->name);
 		if (eif == NULL)
 			return NB_ERR_INCONSISTENCY;
@@ -1147,7 +1147,7 @@ static int lib_interface_eigrp_instance_create(struct nb_cb_create_args *args)
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		eigrp = eigrp_get(yang_dnode_get_uint16(args->dnode, "./asn"),
-				  ifp->vrf_id);
+				  ifp->vrf->vrf_id);
 		eif = eigrp_interface_lookup(eigrp, ifp->name);
 		if (eif == NULL)
 			return NB_ERR_INCONSISTENCY;

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -132,7 +132,8 @@ static void bfd_handle_adj_up(struct isis_adjacency *adj)
 		bfd_sess_set_ipv6_addrs(adj->bfd_session, &src_ip.ipv6,
 					&dst_ip.ipv6);
 	bfd_sess_set_interface(adj->bfd_session, adj->circuit->interface->name);
-	bfd_sess_set_vrf(adj->bfd_session, adj->circuit->interface->vrf_id);
+	bfd_sess_set_vrf(adj->bfd_session,
+			 adj->circuit->interface->vrf->vrf_id);
 	bfd_sess_set_profile(adj->bfd_session, circuit->bfd_config.profile);
 	bfd_sess_install(adj->bfd_session);
 	return;

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -82,7 +82,7 @@ static void isis_circuit_enable(struct isis_circuit *circuit)
 	struct interface *ifp = circuit->interface;
 
 	if (!area) {
-		area = isis_area_lookup(circuit->tag, ifp->vrf_id);
+		area = isis_area_lookup(circuit->tag, ifp->vrf->vrf_id);
 		if (area)
 			isis_area_add_circuit(area, circuit);
 	}

--- a/isisd/isis_ldp_sync.c
+++ b/isisd/isis_ldp_sync.c
@@ -218,7 +218,7 @@ static int isis_ldp_sync_adj_state_change(struct isis_adjacency *adj)
 	struct isis_area *area = circuit->area;
 
 	if (!CHECK_FLAG(area->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE)
-	    || circuit->interface->vrf_id != VRF_DEFAULT
+	    || circuit->interface->vrf->vrf_id != VRF_DEFAULT
 	    || if_is_loopback(circuit->interface))
 		return 0;
 

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2479,7 +2479,7 @@ int lib_interface_isis_create(struct nb_cb_create_args *args)
 		actual_mtu =
 			if_is_broadcast(ifp) ? ifp->mtu - LLC_LEN : ifp->mtu;
 
-		area = isis_area_lookup(area_tag, ifp->vrf_id);
+		area = isis_area_lookup(area_tag, ifp->vrf->vrf_id);
 		if (area)
 			min_mtu = area->lsp_mtu;
 		else

--- a/isisd/isis_pfpacket.c
+++ b/isisd/isis_pfpacket.c
@@ -123,15 +123,10 @@ static int open_packet_socket(struct isis_circuit *circuit)
 	int fd, retval = ISIS_OK;
 	struct vrf *vrf = NULL;
 
-	vrf = vrf_lookup_by_id(circuit->interface->vrf_id);
+	vrf = circuit->interface->vrf;
 
-	if (vrf == NULL) {
-		zlog_warn("open_packet_socket(): failed to find vrf node");
-		return ISIS_WARNING;
-	}
-
-	fd = vrf_socket(PF_PACKET, SOCK_DGRAM, htons(ETH_P_ALL),
-			circuit->interface->vrf_id, vrf->name);
+	fd = vrf_socket(PF_PACKET, SOCK_DGRAM, htons(ETH_P_ALL), vrf->vrf_id,
+			vrf->name);
 
 	if (fd < 0) {
 		zlog_warn("open_packet_socket(): socket() failed %s",

--- a/lib/if.h
+++ b/lib/if.h
@@ -295,7 +295,6 @@ struct interface {
 	struct route_node *node;
 
 	struct vrf *vrf;
-	vrf_id_t vrf_id;
 
 	/*
 	 * Has the end users entered `interface XXXX` from the cli in some
@@ -312,56 +311,56 @@ RB_HEAD(if_index_head, interface);
 RB_PROTOTYPE(if_index_head, interface, index_entry, if_cmp_index_func)
 DECLARE_QOBJ_TYPE(interface);
 
-#define IFNAME_RB_INSERT(vrf, ifp)                                                    \
+#define IFNAME_RB_INSERT(v, ifp)                                                      \
 	({                                                                            \
 		struct interface *_iz =                                               \
-			RB_INSERT(if_name_head, &vrf->ifaces_by_name, (ifp));         \
+			RB_INSERT(if_name_head, &v->ifaces_by_name, (ifp));           \
 		if (_iz)                                                              \
 			flog_err(                                                     \
 				EC_LIB_INTERFACE,                                     \
 				"%s(%s): corruption detected -- interface with this " \
-				"name exists already in VRF %u!",                     \
-				__func__, (ifp)->name, (ifp)->vrf_id);                \
+				"name exists already in VRF %s!",                     \
+				__func__, (ifp)->name, (ifp)->vrf->name);             \
 		_iz;                                                                  \
 	})
 
-#define IFNAME_RB_REMOVE(vrf, ifp)                                                    \
+#define IFNAME_RB_REMOVE(v, ifp)                                                      \
 	({                                                                            \
 		struct interface *_iz =                                               \
-			RB_REMOVE(if_name_head, &vrf->ifaces_by_name, (ifp));         \
+			RB_REMOVE(if_name_head, &v->ifaces_by_name, (ifp));           \
 		if (_iz == NULL)                                                      \
 			flog_err(                                                     \
 				EC_LIB_INTERFACE,                                     \
 				"%s(%s): corruption detected -- interface with this " \
-				"name doesn't exist in VRF %u!",                      \
-				__func__, (ifp)->name, (ifp)->vrf_id);                \
+				"name doesn't exist in VRF %s!",                      \
+				__func__, (ifp)->name, (ifp)->vrf->name);             \
 		_iz;                                                                  \
 	})
 
 
-#define IFINDEX_RB_INSERT(vrf, ifp)                                                   \
+#define IFINDEX_RB_INSERT(v, ifp)                                                     \
 	({                                                                            \
-		struct interface *_iz = RB_INSERT(                                    \
-			if_index_head, &vrf->ifaces_by_index, (ifp));                 \
+		struct interface *_iz =                                               \
+			RB_INSERT(if_index_head, &v->ifaces_by_index, (ifp));         \
 		if (_iz)                                                              \
 			flog_err(                                                     \
 				EC_LIB_INTERFACE,                                     \
 				"%s(%u): corruption detected -- interface with this " \
-				"ifindex exists already in VRF %u!",                  \
-				__func__, (ifp)->ifindex, (ifp)->vrf_id);             \
+				"ifindex exists already in VRF %s!",                  \
+				__func__, (ifp)->ifindex, (ifp)->vrf->name);          \
 		_iz;                                                                  \
 	})
 
-#define IFINDEX_RB_REMOVE(vrf, ifp)                                                   \
+#define IFINDEX_RB_REMOVE(v, ifp)                                                     \
 	({                                                                            \
-		struct interface *_iz = RB_REMOVE(                                    \
-			if_index_head, &vrf->ifaces_by_index, (ifp));                 \
+		struct interface *_iz =                                               \
+			RB_REMOVE(if_index_head, &v->ifaces_by_index, (ifp));         \
 		if (_iz == NULL)                                                      \
 			flog_err(                                                     \
 				EC_LIB_INTERFACE,                                     \
 				"%s(%u): corruption detected -- interface with this " \
-				"ifindex doesn't exist in VRF %u!",                   \
-				__func__, (ifp)->ifindex, (ifp)->vrf_id);             \
+				"ifindex doesn't exist in VRF %s!",                   \
+				__func__, (ifp)->ifindex, (ifp)->vrf->name);          \
 		_iz;                                                                  \
 	})
 

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -354,13 +354,6 @@ const char *vrf_id_to_name(vrf_id_t vrf_id)
 	return VRF_LOGNAME(vrf);
 }
 
-/* Get the data pointer of the specified VRF. If not found, create one. */
-void *vrf_info_get(vrf_id_t vrf_id)
-{
-	struct vrf *vrf = vrf_get(vrf_id, NULL);
-	return vrf->info;
-}
-
 /* Look up the data pointer of the specified VRF. */
 void *vrf_info_lookup(vrf_id_t vrf_id)
 {

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -176,8 +176,6 @@ static inline uint32_t vrf_interface_count(struct vrf *vrf)
  * Utilities to obtain the user data
  */
 
-/* Get the data pointer of the specified VRF. If not found, create one. */
-extern void *vrf_info_get(vrf_id_t);
 /* Look up the data pointer of the specified VRF. */
 extern void *vrf_info_lookup(vrf_id_t);
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -4072,11 +4072,12 @@ enum zclient_send_status zclient_interface_set_master(struct zclient *client,
 	s = client->obuf;
 	stream_reset(s);
 
-	zclient_create_header(s, ZEBRA_INTERFACE_SET_MASTER, master->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_SET_MASTER,
+			      master->vrf->vrf_id);
 
-	stream_putl(s, master->vrf_id);
+	stream_putl(s, master->vrf->vrf_id);
 	stream_putl(s, master->ifindex);
-	stream_putl(s, slave->vrf_id);
+	stream_putl(s, slave->vrf->vrf_id);
 	stream_putl(s, slave->ifindex);
 
 	stream_putw_at(s, 0, stream_get_endp(s));
@@ -4163,7 +4164,7 @@ zclient_send_neigh_discovery_req(struct zclient *zclient,
 	s = zclient->obuf;
 	stream_reset(s);
 
-	zclient_create_header(s, ZEBRA_NEIGH_DISCOVER, ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_NEIGH_DISCOVER, ifp->vrf->vrf_id);
 	stream_putl(s, ifp->ifindex);
 
 	stream_putc(s, p->family);
@@ -4253,7 +4254,7 @@ int zclient_neigh_ip_encode(struct stream *s, uint16_t cmd, union sockunion *in,
 {
 	int ret = 0;
 
-	zclient_create_header(s, cmd, ifp->vrf_id);
+	zclient_create_header(s, cmd, ifp->vrf->vrf_id);
 	stream_putc(s, sockunion_family(in));
 	stream_write(s, sockunion_get_addr(in), sockunion_get_addrlen(in));
 	if (out && sockunion_family(out) != AF_UNSPEC) {
@@ -4297,9 +4298,7 @@ int zclient_send_zebra_gre_request(struct zclient *client,
 	}
 	s = client->obuf;
 	stream_reset(s);
-	zclient_create_header(s,
-			      ZEBRA_GRE_GET,
-			      ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_GRE_GET, ifp->vrf->vrf_id);
 	stream_putl(s, ifp->ifindex);
 	stream_putw_at(s, 0, stream_get_endp(s));
 	zclient_send_message(client);

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -143,13 +143,13 @@ static void nhrp_interface_update_source(struct interface *ifp)
 {
 	struct nhrp_interface *nifp = ifp->info;
 
-	if (!nifp->source || !nifp->nbmaifp ||
-	    ((ifindex_t)nifp->link_idx == nifp->nbmaifp->ifindex &&
-	     (nifp->link_vrf_id == nifp->nbmaifp->vrf_id)))
+	if (!nifp->source || !nifp->nbmaifp
+	    || ((ifindex_t)nifp->link_idx == nifp->nbmaifp->ifindex
+		&& (nifp->link_vrf_id == nifp->nbmaifp->vrf->vrf_id)))
 		return;
 
 	nifp->link_idx = nifp->nbmaifp->ifindex;
-	nifp->link_vrf_id = nifp->nbmaifp->vrf_id;
+	nifp->link_vrf_id = nifp->nbmaifp->vrf->vrf_id;
 	debugf(NHRP_DEBUG_IF, "%s: bound device index changed to %d, vr %u",
 	       ifp->name, nifp->link_idx, nifp->link_vrf_id);
 	nhrp_send_zebra_gre_source_set(ifp, nifp->link_idx, nifp->link_vrf_id);
@@ -414,7 +414,7 @@ static void interface_config_update_nhrp_map(struct nhrp_cache_config *cc,
 		return;
 
 	/* gre layer not ready */
-	if (ifp->vrf_id == VRF_UNKNOWN)
+	if (ifp->vrf->vrf_id == VRF_UNKNOWN)
 		return;
 
 	c = nhrp_cache_get(ifp, &cc->remote_addr, ctx->enabled ? 1 : 0);

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -408,9 +408,7 @@ void nhrp_send_zebra_configure_arp(struct interface *ifp, int family)
 	}
 	s = zclient->obuf;
 	stream_reset(s);
-	zclient_create_header(s,
-			      ZEBRA_CONFIGURE_ARP,
-			      ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_CONFIGURE_ARP, ifp->vrf->vrf_id);
 	stream_putc(s, family);
 	stream_putl(s, ifp->ifindex);
 	stream_putw_at(s, 0, stream_get_endp(s));
@@ -433,9 +431,7 @@ void nhrp_send_zebra_gre_source_set(struct interface *ifp,
 	}
 	s = zclient->obuf;
 	stream_reset(s);
-	zclient_create_header(s,
-			      ZEBRA_GRE_SOURCE_SET,
-			      ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_GRE_SOURCE_SET, ifp->vrf->vrf_id);
 	stream_putl(s, ifp->ifindex);
 	stream_putl(s, link_idx);
 	stream_putl(s, link_vrf_id);

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -143,7 +143,7 @@ void ospf6_bfd_info_nbr_create(struct ospf6_interface *oi,
 	bfd_sess_set_ipv6_addrs(on->bfd_session, on->ospf6_if->linklocal_addr,
 				&on->linklocal_addr);
 	bfd_sess_set_interface(on->bfd_session, oi->interface->name);
-	bfd_sess_set_vrf(on->bfd_session, oi->interface->vrf_id);
+	bfd_sess_set_vrf(on->bfd_session, oi->interface->vrf->vrf_id);
 	bfd_sess_set_profile(on->bfd_session, oi->bfd_config.profile);
 }
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -150,7 +150,7 @@ static uint32_t ospf6_interface_get_cost(struct ospf6_interface *oi)
 					      : OSPF6_INTERFACE_BANDWIDTH;
 	}
 
-	ospf6 = ospf6_lookup_by_vrf_id(oi->interface->vrf_id);
+	ospf6 = oi->interface->vrf->info;
 	refbw = ospf6 ? ospf6->ref_bandwidth : OSPF6_REFERENCE_BANDWIDTH;
 
 	/* A specifed ip ospf cost overrides a calculated one. */
@@ -1361,11 +1361,6 @@ static int ospf6_interface_show_traffic(struct vty *vty,
 	struct ospf6_interface *oi = NULL;
 	json_object *json_interface;
 
-	if (intf_ifp)
-		vrf = vrf_lookup_by_id(intf_ifp->vrf_id);
-	else
-		vrf = vrf_lookup_by_id(vrf_id);
-
 	if (!display_once && !use_json) {
 		vty_out(vty, "\n");
 		vty_out(vty, "%-12s%-17s%-17s%-17s%-17s%-17s\n", "Interface",
@@ -1379,6 +1374,7 @@ static int ospf6_interface_show_traffic(struct vty *vty,
 	}
 
 	if (intf_ifp == NULL) {
+		vrf = vrf_lookup_by_id(vrf_id);
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			if (ifp->info)
 				oi = (struct ospf6_interface *)ifp->info;
@@ -1685,7 +1681,7 @@ void ospf6_interface_start(struct ospf6_interface *oi)
 	if (oi->area)
 		return;
 
-	ospf6 = ospf6_lookup_by_vrf_id(oi->interface->vrf_id);
+	ospf6 = oi->interface->vrf->info;
 	if (!ospf6)
 		return;
 

--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -971,8 +971,7 @@ static uint8_t *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 			for (ALL_LIST_ELEMENTS_RO(ifslist, node, iif)) {
 				if (!iif->ifindex)
 					continue;
-				oi = ospf6_interface_lookup_by_ifindex(
-					iif->ifindex, iif->vrf_id);
+				oi = iif->info;
 				if (!oi)
 					continue;
 				if (iif->ifindex < ifindex)
@@ -1106,8 +1105,7 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 		for (ALL_LIST_ELEMENTS_RO(ifslist, i, iif)) {
 			if (!iif->ifindex)
 				continue;
-			oi = ospf6_interface_lookup_by_ifindex(iif->ifindex,
-							       iif->vrf_id);
+			oi = iif->info;
 			if (!oi)
 				continue;
 			if (iif->ifindex > ifindex
@@ -1272,8 +1270,7 @@ static uint8_t *ospfv3NbrEntry(struct variable *v, oid *name, size_t *length,
 		for (ALL_LIST_ELEMENTS_RO(ifslist, i, iif)) {
 			if (!iif->ifindex)
 				continue;
-			oi = ospf6_interface_lookup_by_ifindex(iif->ifindex,
-							       iif->vrf_id);
+			oi = iif->info;
 			if (!oi)
 				continue;
 			for (ALL_LIST_ELEMENTS_RO(oi->neighbor_list, j, on)) {

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -360,9 +360,8 @@ void ospf_if_free(struct ospf_interface *oi)
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: ospf interface %s vrf %s id %u deleted",
-			   __func__, oi->ifp->name,
-			   ospf_vrf_id_to_name(oi->ifp->vrf_id),
-			   oi->ifp->vrf_id);
+			   __func__, oi->ifp->name, oi->ifp->vrf->name,
+			   oi->ifp->vrf->vrf_id);
 
 	ospf_delete_from_if(oi->ifp, oi);
 
@@ -1331,10 +1330,9 @@ static int ospf_ifp_create(struct interface *ifp)
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
 		zlog_debug(
 			"Zebra: interface add %s vrf %s[%u] index %d flags %llx metric %d mtu %d speed %u",
-			ifp->name, ospf_vrf_id_to_name(ifp->vrf_id),
-			ifp->vrf_id, ifp->ifindex,
-			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu,
-			ifp->speed);
+			ifp->name, ifp->vrf->name, ifp->vrf->vrf_id,
+			ifp->ifindex, (unsigned long long)ifp->flags,
+			ifp->metric, ifp->mtu, ifp->speed);
 
 	assert(ifp->info);
 
@@ -1347,7 +1345,7 @@ static int ospf_ifp_create(struct interface *ifp)
 		IF_DEF_PARAMS(ifp)->type = ospf_default_iftype(ifp);
 	}
 
-	ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+	ospf = ifp->vrf->info;
 	if (!ospf)
 		return 0;
 
@@ -1431,13 +1429,13 @@ static int ospf_ifp_destroy(struct interface *ifp)
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
 		zlog_debug(
 			"Zebra: interface delete %s vrf %s[%u] index %d flags %llx metric %d mtu %d",
-			ifp->name, ospf_vrf_id_to_name(ifp->vrf_id),
-			ifp->vrf_id, ifp->ifindex,
-			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
+			ifp->name, ifp->vrf->name, ifp->vrf->vrf_id,
+			ifp->ifindex, (unsigned long long)ifp->flags,
+			ifp->metric, ifp->mtu);
 
 	hook_call(ospf_if_delete, ifp);
 
-	ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+	ospf = ifp->vrf->info;
 	if (ospf) {
 		if (ospf_if_count_area_params(ifp) > 0)
 			ospf_interface_area_unset(ospf, ifp);

--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -129,8 +129,9 @@ void ospf_ldp_sync_if_init(struct ospf_interface *oi)
 	 *  if LDP-IGP Sync is configured globally set state
 	 *  if ptop interface inform LDP LDP-SYNC is enabled
 	 */
-	if (if_is_loopback(ifp) || (ifp->vrf_id != VRF_DEFAULT) ||
-	    !(CHECK_FLAG(oi->ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE)))
+	if (if_is_loopback(ifp) || (ifp->vrf->vrf_id != VRF_DEFAULT)
+	    || !(CHECK_FLAG(oi->ospf->ldp_sync_cmd.flags,
+			    LDP_SYNC_FLAG_ENABLE)))
 		return;
 
 	ols_debug("ldp_sync: init if %s",ifp->name);
@@ -856,7 +857,7 @@ DEFPY (mpls_ldp_sync,
 		return CMD_ERR_NOTHING_TODO;
 	}
 
-	if (ifp->vrf_id != VRF_DEFAULT) {
+	if (ifp->vrf->vrf_id != VRF_DEFAULT) {
 		vty_out(vty, "ldp-sync only runs on DEFAULT VRF\n");
 		return CMD_ERR_NOTHING_TODO;
 	}
@@ -897,7 +898,7 @@ DEFPY (no_mpls_ldp_sync,
 		return CMD_ERR_NOTHING_TODO;
 	}
 
-	if (ifp->vrf_id != VRF_DEFAULT) {
+	if (ifp->vrf->vrf_id != VRF_DEFAULT) {
 		vty_out(vty, "ldp-sync only runs on DEFAULT VRF\n");
 		return CMD_ERR_NOTHING_TODO;
 	}
@@ -940,7 +941,7 @@ DEFPY (mpls_ldp_sync_holddown,
 		return CMD_ERR_NOTHING_TODO;
 	}
 
-	if (ifp->vrf_id != VRF_DEFAULT) {
+	if (ifp->vrf->vrf_id != VRF_DEFAULT) {
 		vty_out(vty, "ldp-sync only runs on DEFAULT VRF\n");
 		return CMD_ERR_NOTHING_TODO;
 	}
@@ -978,7 +979,7 @@ DEFPY (no_mpls_ldp_sync_holddown,
 		return CMD_ERR_NOTHING_TODO;
 	}
 
-	if (ifp->vrf_id != VRF_DEFAULT) {
+	if (ifp->vrf->vrf_id != VRF_DEFAULT) {
 		vty_out(vty, "ldp-sync only runs on DEFAULT VRF\n");
 		return CMD_ERR_NOTHING_TODO;
 	}

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -3012,7 +3012,7 @@ static enum ospf_read_return_enum ospf_read_helper(struct ospf *ospf)
 		}
 	}
 
-	if (ospf->vrf_id == VRF_DEFAULT && ospf->vrf_id != ifp->vrf_id) {
+	if (ospf->vrf_id == VRF_DEFAULT && ospf->vrf_id != ifp->vrf->vrf_id) {
 		/*
 		 * We may have a situation where l3mdev_accept == 1
 		 * let's just kindly drop the packet and move on.

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8074,7 +8074,7 @@ static int ospf_vty_dead_interval_set(struct vty *vty, const char *interval_str,
 	if (nbr_str) {
 		struct ospf *ospf = NULL;
 
-		ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+		ospf = ifp->vrf->info;
 		if (ospf) {
 			oi = ospf_if_lookup_by_local_addr(ospf, ifp, addr);
 			if (oi)
@@ -8192,7 +8192,7 @@ DEFUN (no_ip_ospf_dead_interval,
 	if (argc == 1) {
 		struct ospf *ospf = NULL;
 
-		ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+		ospf = ifp->vrf->info;
 		if (ospf) {
 			oi = ospf_if_lookup_by_local_addr(ospf, ifp, addr);
 			if (oi)
@@ -8844,7 +8844,7 @@ DEFUN (ip_ospf_area,
 	areaid = argv[idx + 1]->arg;
 
 	if (!instance)
-		ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+		ospf = ifp->vrf->info;
 	else
 		ospf = ospf_lookup_instance(instance);
 
@@ -8875,7 +8875,7 @@ DEFUN (ip_ospf_area,
 			}
 
 		if (count > 0) {
-			ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+			ospf = ifp->vrf->info;
 			if (ospf)
 				ospf_interface_area_unset(ospf, ifp);
 		}
@@ -8968,7 +8968,7 @@ DEFUN (no_ip_ospf_area,
 		instance = strtol(argv[idx]->arg, NULL, 10);
 
 	if (!instance)
-		ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+		ospf = ifp->vrf->info;
 	else
 		ospf = ospf_lookup_instance(instance);
 
@@ -11161,7 +11161,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 			continue;
 
 		vty_frame(vty, "!\n");
-		if (ifp->vrf_id == VRF_DEFAULT)
+		if (ifp->vrf->vrf_id == VRF_DEFAULT)
 			vty_frame(vty, "interface %s\n", ifp->name);
 		else
 			vty_frame(vty, "interface %s vrf %s\n", ifp->name,

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1443,8 +1443,8 @@ void ospf_if_update(struct ospf *ospf, struct interface *ifp)
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
-			"%s: interface %s ifp->vrf_id %u ospf vrf %s vrf_id %u router_id %pI4",
-			__func__, ifp->name, ifp->vrf_id,
+			"%s: interface %s vrf %s(%u) ospf vrf %s vrf_id %u router_id %pI4",
+			__func__, ifp->name, ifp->vrf->name, ifp->vrf->vrf_id,
 			ospf_vrf_id_to_name(ospf->vrf_id), ospf->vrf_id,
 			&ospf->router_id);
 

--- a/pbrd/pbr_vrf.c
+++ b/pbrd/pbr_vrf.c
@@ -92,17 +92,6 @@ static int pbr_vrf_delete(struct vrf *vrf)
 	return 0;
 }
 
-struct pbr_vrf *pbr_vrf_lookup_by_id(vrf_id_t vrf_id)
-{
-	struct vrf *vrf;
-
-	vrf = vrf_lookup_by_id(vrf_id);
-	if (vrf)
-		return ((struct pbr_vrf *)vrf->info);
-
-	return NULL;
-}
-
 struct pbr_vrf *pbr_vrf_lookup_by_name(const char *name)
 {
 	struct vrf *vrf;

--- a/pbrd/pbr_vrf.h
+++ b/pbrd/pbr_vrf.h
@@ -34,7 +34,6 @@ static inline vrf_id_t pbr_vrf_id(const struct pbr_vrf *pbr_vrf)
 	return pbr_vrf->vrf->vrf_id;
 }
 
-extern struct pbr_vrf *pbr_vrf_lookup_by_id(vrf_id_t vrf_id);
 extern struct pbr_vrf *pbr_vrf_lookup_by_name(const char *name);
 extern bool pbr_vrf_is_valid(const struct pbr_vrf *pbr_vrf);
 extern bool pbr_vrf_is_enabled(const struct pbr_vrf *pbr_vrf);

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -592,16 +592,12 @@ DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
 			vty_out(vty, "You must specify the nexthop-vrf\n");
 			return CMD_WARNING_CONFIG_FAILED;
 		}
-		if (ifp->vrf_id != vrf->vrf_id) {
-			struct vrf *actual;
-
-			actual = vrf_lookup_by_id(ifp->vrf_id);
+		if (ifp->vrf->vrf_id != vrf->vrf_id)
 			vty_out(vty,
 				"Specified Intf %s is not in vrf %s but is in vrf %s, using actual vrf\n",
-				ifp->name, vrf->name, VRF_LOGNAME(actual));
-		}
+				ifp->name, vrf->name, ifp->vrf->name);
 		nhop.ifindex = ifp->ifindex;
-		nhop.vrf_id = ifp->vrf_id;
+		nhop.vrf_id = ifp->vrf->vrf_id;
 	}
 
 	if (addr) {

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -513,7 +513,7 @@ pbr_encode_pbr_map_sequence_vrf(struct stream *s,
 	struct pbr_vrf *pbr_vrf;
 
 	if (pbrms->vrf_unchanged)
-		pbr_vrf = pbr_vrf_lookup_by_id(ifp->vrf_id);
+		pbr_vrf = ifp->vrf->info;
 	else
 		pbr_vrf = pbr_vrf_lookup_by_name(pbrms->vrf_name);
 

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -97,7 +97,7 @@ void pim_bfd_info_nbr_create(struct pim_interface *pim_ifp,
 		pim_ifp->bfd_config.min_rx, pim_ifp->bfd_config.min_tx);
 	bfd_sess_set_ipv4_addrs(neigh->bfd_session, NULL, &neigh->source_addr);
 	bfd_sess_set_interface(neigh->bfd_session, neigh->interface->name);
-	bfd_sess_set_vrf(neigh->bfd_session, neigh->interface->vrf_id);
+	bfd_sess_set_vrf(neigh->bfd_session, neigh->interface->vrf->vrf_id);
 	bfd_sess_set_profile(neigh->bfd_session, pim_ifp->bfd_config.profile);
 	bfd_sess_install(neigh->bfd_session);
 }

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -121,7 +121,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	pim_ifp = XCALLOC(MTYPE_PIM_INTERFACE, sizeof(*pim_ifp));
 
 	pim_ifp->options = 0;
-	pim_ifp->pim = pim_get_pim_instance(ifp->vrf_id);
+	pim_ifp->pim = ifp->vrf->info;
 	pim_ifp->mroute_vif_index = -1;
 
 	pim_ifp->igmp_version = IGMP_DEFAULT_VERSION;
@@ -785,12 +785,11 @@ void pim_if_addr_del_all(struct interface *ifp)
 	struct connected *ifc;
 	struct listnode *node;
 	struct listnode *nextnode;
-	struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
 	struct pim_instance *pim;
 
-	if (!vrf)
+	pim = ifp->vrf->info;
+	if (!pim)
 		return;
-	pim = vrf->info;
 
 	/* PIM/IGMP enabled ? */
 	if (!ifp->info)
@@ -857,10 +856,6 @@ struct in_addr pim_find_primary_addr(struct interface *ifp)
 	int v4_addrs = 0;
 	int v6_addrs = 0;
 	struct pim_interface *pim_ifp = ifp->info;
-	struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
-
-	if (!vrf)
-		return addr;
 
 	if (pim_ifp && PIM_INADDR_ISNOT_ANY(pim_ifp->update_source)) {
 		return pim_ifp->update_source;
@@ -899,10 +894,11 @@ struct in_addr pim_find_primary_addr(struct interface *ifp)
 		struct interface *lo_ifp;
 
 		// DBS - Come back and check here
-		if (ifp->vrf_id == VRF_DEFAULT)
-			lo_ifp = if_lookup_by_name("lo", vrf->vrf_id);
+		if (ifp->vrf->vrf_id == VRF_DEFAULT)
+			lo_ifp = if_lookup_by_name("lo", ifp->vrf->vrf_id);
 		else
-			lo_ifp = if_lookup_by_name(vrf->name, vrf->vrf_id);
+			lo_ifp = if_lookup_by_name(ifp->vrf->name,
+						   ifp->vrf->vrf_id);
 
 		if (lo_ifp && (lo_ifp != ifp))
 			return pim_find_primary_addr(lo_ifp);
@@ -1550,13 +1546,13 @@ int pim_ifp_create(struct interface *ifp)
 {
 	struct pim_instance *pim;
 
-	pim = pim_get_pim_instance(ifp->vrf_id);
+	pim = ifp->vrf->info;
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
-			__func__, ifp->name, ifp->ifindex, ifp->vrf_id,
-			(long)ifp->flags, ifp->metric, ifp->mtu,
-			if_is_operative(ifp));
+			"%s: %s index %d vrf %s(%u) flags %ld metric %d mtu %d operative %d",
+			__func__, ifp->name, ifp->ifindex, ifp->vrf->name,
+			ifp->vrf->vrf_id, (long)ifp->flags, ifp->metric,
+			ifp->mtu, if_is_operative(ifp));
 	}
 
 	if (if_is_operative(ifp)) {
@@ -1622,13 +1618,13 @@ int pim_ifp_up(struct interface *ifp)
 
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
-			__func__, ifp->name, ifp->ifindex, ifp->vrf_id,
-			(long)ifp->flags, ifp->metric, ifp->mtu,
-			if_is_operative(ifp));
+			"%s: %s index %d vrf %s(%u) flags %ld metric %d mtu %d operative %d",
+			__func__, ifp->name, ifp->ifindex, ifp->vrf->name,
+			ifp->vrf->vrf_id, (long)ifp->flags, ifp->metric,
+			ifp->mtu, if_is_operative(ifp));
 	}
 
-	pim = pim_get_pim_instance(ifp->vrf_id);
+	pim = ifp->vrf->info;
 
 	pim_ifp = ifp->info;
 	/*
@@ -1653,7 +1649,7 @@ int pim_ifp_up(struct interface *ifp)
 		struct vrf *vrf;
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 			if ((table_id == vrf->data.l.table_id)
-			    && (ifp->vrf_id != vrf->vrf_id)) {
+			    && (ifp->vrf->vrf_id != vrf->vrf_id)) {
 				struct interface *master = if_lookup_by_name(
 					vrf->name, vrf->vrf_id);
 
@@ -1674,10 +1670,10 @@ int pim_ifp_down(struct interface *ifp)
 {
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
-			__func__, ifp->name, ifp->ifindex, ifp->vrf_id,
-			(long)ifp->flags, ifp->metric, ifp->mtu,
-			if_is_operative(ifp));
+			"%s: %s index %d vrf %s(%u) flags %ld metric %d mtu %d operative %d",
+			__func__, ifp->name, ifp->ifindex, ifp->vrf->name,
+			ifp->vrf->vrf_id, (long)ifp->flags, ifp->metric,
+			ifp->mtu, if_is_operative(ifp));
 	}
 
 	if (!if_is_operative(ifp)) {
@@ -1710,16 +1706,16 @@ int pim_ifp_destroy(struct interface *ifp)
 
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
-			__func__, ifp->name, ifp->ifindex, ifp->vrf_id,
-			(long)ifp->flags, ifp->metric, ifp->mtu,
-			if_is_operative(ifp));
+			"%s: %s index %d vrf %s(%u) flags %ld metric %d mtu %d operative %d",
+			__func__, ifp->name, ifp->ifindex, ifp->vrf->name,
+			ifp->vrf->vrf_id, (long)ifp->flags, ifp->metric,
+			ifp->mtu, if_is_operative(ifp));
 	}
 
 	if (!if_is_operative(ifp))
 		pim_if_addr_del_all(ifp);
 
-	pim = pim_get_pim_instance(ifp->vrf_id);
+	pim = ifp->vrf->info;
 	if (pim && pim->vxlan.term_if == ifp)
 		pim_vxlan_del_term_dev(pim);
 

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -324,7 +324,7 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 		return 0;
 	}
 
-	if (if_address_is_local(&from, AF_INET, ifp->vrf_id)) {
+	if (if_address_is_local(&from, AF_INET, ifp->vrf->vrf_id)) {
 		if (PIM_DEBUG_IGMP_PACKETS)
 			zlog_debug("Recv IGMP query on interface: %s from ourself %s",
 				   ifp->name, from_str);

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -92,7 +92,7 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 		return -4;
 	}
 #endif
-	if (iif->vrf_id != oif->vrf_id) {
+	if (iif->vrf->vrf_id != oif->vrf->vrf_id) {
 		return -3;
 	}
 

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -201,14 +201,12 @@ static int ripng_if_down(struct interface *ifp)
 /* Inteface link up message processing. */
 static int ripng_ifp_up(struct interface *ifp)
 {
-	if (IS_RIPNG_DEBUG_ZEBRA) {
-		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
-
+	if (IS_RIPNG_DEBUG_ZEBRA)
 		zlog_debug(
 			"interface up %s vrf %s(%u) index %d flags %llx metric %d mtu %d",
-			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
-			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
-	}
+			ifp->name, ifp->vrf->name, ifp->vrf->vrf_id,
+			ifp->ifindex, (unsigned long long)ifp->flags,
+			ifp->metric, ifp->mtu6);
 
 	ripng_interface_sync(ifp);
 
@@ -230,14 +228,12 @@ static int ripng_ifp_down(struct interface *ifp)
 	ripng_interface_sync(ifp);
 	ripng_if_down(ifp);
 
-	if (IS_RIPNG_DEBUG_ZEBRA) {
-		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
-
+	if (IS_RIPNG_DEBUG_ZEBRA)
 		zlog_debug(
 			"interface down %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
-			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
-			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
-	}
+			ifp->name, ifp->vrf->name, ifp->vrf->vrf_id,
+			ifp->ifindex, (unsigned long long)ifp->flags,
+			ifp->metric, ifp->mtu6);
 
 	return 0;
 }
@@ -247,14 +243,12 @@ static int ripng_ifp_create(struct interface *ifp)
 {
 	ripng_interface_sync(ifp);
 
-	if (IS_RIPNG_DEBUG_ZEBRA) {
-		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
-
+	if (IS_RIPNG_DEBUG_ZEBRA)
 		zlog_debug(
 			"RIPng interface add %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
-			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
-			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
-	}
+			ifp->name, ifp->vrf->name, ifp->vrf->vrf_id,
+			ifp->ifindex, (unsigned long long)ifp->flags,
+			ifp->metric, ifp->mtu6);
 
 	/* Check is this interface is RIP enabled or not.*/
 	ripng_enable_apply(ifp);
@@ -270,8 +264,6 @@ static int ripng_ifp_create(struct interface *ifp)
 
 static int ripng_ifp_destroy(struct interface *ifp)
 {
-	struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
-
 	ripng_interface_sync(ifp);
 	if (if_is_up(ifp)) {
 		ripng_if_down(ifp);
@@ -280,8 +272,9 @@ static int ripng_ifp_destroy(struct interface *ifp)
 	if (IS_RIPNG_DEBUG_ZEBRA)
 		zlog_debug(
 			"interface delete %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
-			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
-			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
+			ifp->name, ifp->vrf->name, ifp->vrf->vrf_id,
+			ifp->ifindex, (unsigned long long)ifp->flags,
+			ifp->metric, ifp->mtu6);
 
 	return 0;
 }
@@ -298,12 +291,11 @@ int ripng_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 	if (IS_RIPNG_DEBUG_ZEBRA) {
-		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
 		struct vrf *nvrf = vrf_lookup_by_id(new_vrf_id);
 
 		zlog_debug("interface %s VRF change vrf %s(%u) new vrf %s(%u)",
-			   ifp->name, VRF_LOGNAME(vrf), vrf_id,
-			   VRF_LOGNAME(nvrf), new_vrf_id);
+			   ifp->name, ifp->vrf->name, vrf_id, VRF_LOGNAME(nvrf),
+			   new_vrf_id);
 	}
 
 	if_update_to_new_vrf(ifp, new_vrf_id);
@@ -896,16 +888,11 @@ static struct ripng_interface *ri_new(void)
 
 void ripng_interface_sync(struct interface *ifp)
 {
-	struct vrf *vrf;
+	struct ripng_interface *ri;
 
-	vrf = vrf_lookup_by_id(ifp->vrf_id);
-	if (vrf) {
-		struct ripng_interface *ri;
-
-		ri = ifp->info;
-		if (ri)
-			ri->ripng = vrf->info;
-	}
+	ri = ifp->info;
+	if (ri)
+		ri->ripng = ifp->vrf->info;
 }
 
 static int ripng_if_new_hook(struct interface *ifp)

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -432,13 +432,13 @@ static void static_ifindex_update_nh(struct interface *ifp, bool up,
 	if (up) {
 		if (strcmp(nh->ifname, ifp->name))
 			return;
-		if (nh->nh_vrf_id != ifp->vrf_id)
+		if (nh->nh_vrf_id != ifp->vrf->vrf_id)
 			return;
 		nh->ifindex = ifp->ifindex;
 	} else {
 		if (nh->ifindex != ifp->ifindex)
 			return;
-		if (nh->nh_vrf_id != ifp->vrf_id)
+		if (nh->nh_vrf_id != ifp->vrf->vrf_id)
 			return;
 		nh->ifindex = IFINDEX_INTERNAL;
 	}
@@ -723,7 +723,7 @@ static void static_fixup_intf_nh(struct route_table *stable,
 			continue;
 		frr_each(static_path_list, &si->path_list, pn) {
 			frr_each(static_nexthop_list, &pn->nexthop_list, nh) {
-				if (nh->nh_vrf_id != ifp->vrf_id)
+				if (nh->nh_vrf_id != ifp->vrf->vrf_id)
 					continue;
 
 				if (nh->ifindex != ifp->ifindex)
@@ -750,7 +750,7 @@ void static_install_intf_nh(struct interface *ifp)
 		struct static_vrf *svrf = vrf->info;
 
 		/* Not needed if same vrf since happens naturally */
-		if (vrf->vrf_id == ifp->vrf_id)
+		if (vrf->vrf_id == ifp->vrf->vrf_id)
 			continue;
 
 		/* Install any static routes configured for this interface. */

--- a/staticd/static_vrf.c
+++ b/staticd/static_vrf.c
@@ -123,17 +123,6 @@ struct route_table *static_vrf_static_table(afi_t afi, safi_t safi,
 	return svrf->stable[afi][safi];
 }
 
-struct static_vrf *static_vrf_lookup_by_id(vrf_id_t vrf_id)
-{
-	struct vrf *vrf;
-
-	vrf = vrf_lookup_by_id(vrf_id);
-	if (vrf)
-		return ((struct static_vrf *)vrf->info);
-
-	return NULL;
-}
-
 struct static_vrf *static_vrf_lookup_by_name(const char *name)
 {
 	struct vrf *vrf;

--- a/staticd/static_vrf.h
+++ b/staticd/static_vrf.h
@@ -39,7 +39,6 @@ struct stable_info {
 #define GET_STABLE_VRF_ID(info) info->svrf->vrf->vrf_id
 
 struct static_vrf *static_vrf_lookup_by_name(const char *vrf_name);
-struct static_vrf *static_vrf_lookup_by_id(vrf_id_t vrf_id);
 
 void static_vrf_init(void);
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -85,9 +85,10 @@ static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 static int static_ifp_up(struct interface *ifp)
 {
 	if (if_is_vrf(ifp)) {
-		struct static_vrf *svrf = static_vrf_lookup_by_id(ifp->vrf_id);
+		struct static_vrf *svrf = ifp->vrf->info;
 
-		static_fixup_vrf_ids(svrf);
+		if (svrf)
+			static_fixup_vrf_ids(svrf);
 	}
 
 	/* Install any static reliant on this interface coming up */

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -216,7 +216,7 @@ static struct vrrp_vrouter *vrrp_lookup_by_if_mvl(struct interface *mvl_ifp)
 		return NULL;
 	}
 
-	p = if_lookup_by_index(mvl_ifp->link_ifindex, mvl_ifp->vrf_id);
+	p = if_lookup_by_index(mvl_ifp->link_ifindex, mvl_ifp->vrf->vrf_id);
 
 	if (!p) {
 		DEBUGD(&vrrp_dbg_zebra,
@@ -544,7 +544,7 @@ static bool vrrp_attach_interface(struct vrrp_router *r)
 
 	size_t ifps_cnt =
 		if_lookup_by_hwaddr(r->vmac.octet, sizeof(r->vmac.octet), &ifps,
-				    r->vr->ifp->vrf_id);
+				    r->vr->ifp->vrf->vrf_id);
 
 	/*
 	 * Filter to only those macvlan interfaces whose parent is the base
@@ -1083,9 +1083,9 @@ static int vrrp_socket(struct vrrp_router *r)
 
 	frr_with_privs(&vrrp_privs) {
 		r->sock_rx = vrf_socket(r->family, SOCK_RAW, IPPROTO_VRRP,
-					r->vr->ifp->vrf_id, NULL);
+					r->vr->ifp->vrf->vrf_id, NULL);
 		r->sock_tx = vrf_socket(r->family, SOCK_RAW, IPPROTO_VRRP,
-					r->vr->ifp->vrf_id, NULL);
+					r->vr->ifp->vrf->vrf_id, NULL);
 	}
 
 	if (r->sock_rx < 0 || r->sock_tx < 0) {
@@ -1102,7 +1102,7 @@ static int vrrp_socket(struct vrrp_router *r)
 	 * Bind Tx socket to macvlan device - necessary for VRF support,
 	 * otherwise the kernel will select the vrf device
 	 */
-	if (r->vr->ifp->vrf_id != VRF_DEFAULT) {
+	if (r->vr->ifp->vrf->vrf_id != VRF_DEFAULT) {
 		frr_with_privs (&vrrp_privs) {
 			ret = setsockopt(r->sock_tx, SOL_SOCKET,
 					 SO_BINDTODEVICE, r->mvl_ifp->name,
@@ -1751,7 +1751,7 @@ vrrp_autoconfig_autocreate(struct interface *mvl_ifp)
 	struct interface *p;
 	struct vrrp_vrouter *vr;
 
-	p = if_lookup_by_index(mvl_ifp->link_ifindex, mvl_ifp->vrf_id);
+	p = if_lookup_by_index(mvl_ifp->link_ifindex, mvl_ifp->vrf->vrf_id);
 
 	if (!p)
 		return NULL;

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -152,7 +152,7 @@ static int if_get_hwaddr(struct interface *ifp)
 	ifreq.ifr_addr.sa_family = AF_INET;
 
 	/* Fetch Hardware address if available. */
-	ret = vrf_if_ioctl(SIOCGIFHWADDR, (caddr_t)&ifreq, ifp->vrf_id);
+	ret = vrf_if_ioctl(SIOCGIFHWADDR, (caddr_t)&ifreq, ifp->vrf->vrf_id);
 	if (ret < 0)
 		ifp->hw_addr_len = 0;
 	else {

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -140,7 +140,7 @@ void if_get_metric(struct interface *ifp)
 
 	ifreq_set_name(&ifreq, ifp);
 
-	if (vrf_if_ioctl(SIOCGIFMETRIC, (caddr_t)&ifreq, ifp->vrf_id) < 0)
+	if (vrf_if_ioctl(SIOCGIFMETRIC, (caddr_t)&ifreq, ifp->vrf->vrf_id) < 0)
 		return;
 	ifp->metric = ifreq.ifr_metric;
 	if (ifp->metric == 0)
@@ -158,7 +158,7 @@ void if_get_mtu(struct interface *ifp)
 	ifreq_set_name(&ifreq, ifp);
 
 #if defined(SIOCGIFMTU)
-	if (vrf_if_ioctl(SIOCGIFMTU, (caddr_t)&ifreq, ifp->vrf_id) < 0) {
+	if (vrf_if_ioctl(SIOCGIFMTU, (caddr_t)&ifreq, ifp->vrf->vrf_id) < 0) {
 		zlog_info("Can't lookup mtu by ioctl(SIOCGIFMTU)");
 		ifp->mtu6 = ifp->mtu = -1;
 		return;
@@ -414,7 +414,7 @@ void if_get_flags(struct interface *ifp)
 
 	ifreq_set_name(&ifreq, ifp);
 
-	ret = vrf_if_ioctl(SIOCGIFFLAGS, (caddr_t)&ifreq, ifp->vrf_id);
+	ret = vrf_if_ioctl(SIOCGIFFLAGS, (caddr_t)&ifreq, ifp->vrf->vrf_id);
 	if (ret < 0) {
 		flog_err_sys(EC_LIB_SYSTEM_CALL,
 			     "vrf_if_ioctl(SIOCGIFFLAGS %s) failed: %s",
@@ -443,13 +443,13 @@ void if_get_flags(struct interface *ifp)
 	struct if_data *ifdata = &ifdr.ifdr_data;
 
 	strlcpy(ifdr.ifdr_name, ifp->name, sizeof(ifdr.ifdr_name));
-	ret = vrf_if_ioctl(SIOCGIFDATA, (caddr_t)&ifdr, ifp->vrf_id);
+	ret = vrf_if_ioctl(SIOCGIFDATA, (caddr_t)&ifdr, ifp->vrf->vrf_id);
 #else
 	struct if_data ifd = {.ifi_link_state = 0};
 	struct if_data *ifdata = &ifd;
 
 	ifreq.ifr_data = (caddr_t)ifdata;
-	ret = vrf_if_ioctl(SIOCGIFDATA, (caddr_t)&ifreq, ifp->vrf_id);
+	ret = vrf_if_ioctl(SIOCGIFDATA, (caddr_t)&ifreq, ifp->vrf->vrf_id);
 #endif
 
 	if (ret == -1)
@@ -511,7 +511,7 @@ int if_set_flags(struct interface *ifp, uint64_t flags)
 	ifreq.ifr_flags = ifp->flags;
 	ifreq.ifr_flags |= flags;
 
-	ret = vrf_if_ioctl(SIOCSIFFLAGS, (caddr_t)&ifreq, ifp->vrf_id);
+	ret = vrf_if_ioctl(SIOCSIFFLAGS, (caddr_t)&ifreq, ifp->vrf->vrf_id);
 
 	if (ret < 0) {
 		zlog_info("can't set interface flags");
@@ -532,7 +532,7 @@ int if_unset_flags(struct interface *ifp, uint64_t flags)
 	ifreq.ifr_flags = ifp->flags;
 	ifreq.ifr_flags &= ~flags;
 
-	ret = vrf_if_ioctl(SIOCSIFFLAGS, (caddr_t)&ifreq, ifp->vrf_id);
+	ret = vrf_if_ioctl(SIOCSIFFLAGS, (caddr_t)&ifreq, ifp->vrf->vrf_id);
 
 	if (ret < 0) {
 		zlog_info("can't unset interface flags");

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -449,8 +449,8 @@ void zebra_interface_up_update(struct interface *ifp)
 	struct zserv *client;
 
 	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_UP %s(%u)",
-			   ifp->name, ifp->vrf_id);
+		zlog_debug("MESSAGE: ZEBRA_INTERFACE_UP %s vrf %s(%u)",
+			   ifp->name, ifp->vrf->name, ifp->vrf->vrf_id);
 
 	if (ifp->ptm_status || !ifp->ptm_enable) {
 		for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode,
@@ -475,8 +475,8 @@ void zebra_interface_down_update(struct interface *ifp)
 	struct zserv *client;
 
 	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_DOWN %s(%u)",
-			   ifp->name, ifp->vrf_id);
+		zlog_debug("MESSAGE: ZEBRA_INTERFACE_DOWN %s vrf %s(%u)",
+			   ifp->name, ifp->vrf->name, ifp->vrf->vrf_id);
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		/* Do not send unsolicited messages to synchronous clients. */
@@ -494,8 +494,8 @@ void zebra_interface_add_update(struct interface *ifp)
 	struct zserv *client;
 
 	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADD %s(%u)", ifp->name,
-			   ifp->vrf_id);
+		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADD %s vrf %s(%u)",
+			   ifp->name, ifp->vrf->name, ifp->vrf->vrf_id);
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		/* Do not send unsolicited messages to synchronous clients. */
@@ -514,8 +514,8 @@ void zebra_interface_delete_update(struct interface *ifp)
 	struct zserv *client;
 
 	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_DELETE %s(%u)",
-			   ifp->name, ifp->vrf_id);
+		zlog_debug("MESSAGE: ZEBRA_INTERFACE_DELETE %s vrf %s(%u)",
+			   ifp->name, ifp->vrf->name, ifp->vrf->vrf_id);
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		/* Do not send unsolicited messages to synchronous clients. */
@@ -538,8 +538,8 @@ void zebra_interface_address_add_update(struct interface *ifp,
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		p = ifc->address;
 		zlog_debug(
-			"MESSAGE: ZEBRA_INTERFACE_ADDRESS_ADD %pFX on %s(%u)",
-			p, ifp->name, ifp->vrf_id);
+			"MESSAGE: ZEBRA_INTERFACE_ADDRESS_ADD %pFX on %s vrf %s(%u)",
+			p, ifp->name, ifp->vrf->name, ifp->vrf->vrf_id);
 	}
 
 	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_REAL))
@@ -575,8 +575,8 @@ void zebra_interface_address_delete_update(struct interface *ifp,
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		p = ifc->address;
 		zlog_debug(
-			"MESSAGE: ZEBRA_INTERFACE_ADDRESS_DELETE %pFX on %s(%u)",
-			p, ifp->name, ifp->vrf_id);
+			"MESSAGE: ZEBRA_INTERFACE_ADDRESS_DELETE %pFX on %s vrf %s(%u)",
+			p, ifp->name, ifp->vrf->name, ifp->vrf->vrf_id);
 	}
 
 	zebra_vxlan_add_del_gw_macip(ifp, ifc->address, 0);
@@ -607,7 +607,7 @@ void zebra_interface_vrf_update_del(struct interface *ifp, vrf_id_t new_vrf_id)
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug(
 			"MESSAGE: ZEBRA_INTERFACE_VRF_UPDATE/DEL %s VRF Id %u -> %u",
-			ifp->name, ifp->vrf_id, new_vrf_id);
+			ifp->name, ifp->vrf->vrf_id, new_vrf_id);
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		/* Do not send unsolicited messages to synchronous clients. */
@@ -634,7 +634,7 @@ void zebra_interface_vrf_update_add(struct interface *ifp, vrf_id_t old_vrf_id)
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug(
 			"MESSAGE: ZEBRA_INTERFACE_VRF_UPDATE/ADD %s VRF Id %u -> %u",
-			ifp->name, old_vrf_id, ifp->vrf_id);
+			ifp->name, old_vrf_id, ifp->vrf->vrf_id);
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		/* Do not send unsolicited messages to synchronous clients. */
@@ -925,8 +925,8 @@ void zebra_interface_parameters_update(struct interface *ifp)
 	struct zserv *client;
 
 	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_LINK_PARAMS %s(%u)",
-			   ifp->name, ifp->vrf_id);
+		zlog_debug("MESSAGE: ZEBRA_INTERFACE_LINK_PARAMS %s vrf %s(%u)",
+			   ifp->name, ifp->vrf->name, ifp->vrf->vrf_id);
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		/* Do not send unsolicited messages to synchronous clients. */

--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -159,7 +159,7 @@ void router_id_add_address(struct connected *ifc)
 	struct prefix before;
 	struct prefix after;
 	struct zserv *client;
-	struct zebra_vrf *zvrf = vrf_info_get(ifc->ifp->vrf_id);
+	struct zebra_vrf *zvrf = ifc->ifp->vrf->info;
 	afi_t afi;
 	struct list *rid_lo;
 	struct list *rid_all;
@@ -206,7 +206,7 @@ void router_id_del_address(struct connected *ifc)
 	struct prefix before;
 	struct listnode *node;
 	struct zserv *client;
-	struct zebra_vrf *zvrf = vrf_info_get(ifc->ifp->vrf_id);
+	struct zebra_vrf *zvrf = ifc->ifp->vrf->info;
 	afi_t afi;
 	struct list *rid_lo;
 	struct list *rid_all;
@@ -521,7 +521,7 @@ DEFUN (show_ip_router_id,
 		vrf_name = argv[idx]->arg;
 	}
 
-	zvrf = vrf_info_get(vrf_id);
+	zvrf = vrf_info_lookup(vrf_id);
 
 	if (zvrf != NULL) {
 		if (is_ipv6) {

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -185,7 +185,7 @@ int zsend_interface_add(struct zserv *client, struct interface *ifp)
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, ZEBRA_INTERFACE_ADD, ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_ADD, ifp->vrf->vrf_id);
 	zserv_encode_interface(s, ifp);
 
 	client->ifadd_cnt++;
@@ -197,7 +197,7 @@ int zsend_interface_delete(struct zserv *client, struct interface *ifp)
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, ZEBRA_INTERFACE_DELETE, ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_DELETE, ifp->vrf->vrf_id);
 	zserv_encode_interface(s, ifp);
 
 	client->ifdel_cnt++;
@@ -237,7 +237,7 @@ int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
 		return 0;
 	}
 
-	zclient_create_header(s, ZEBRA_INTERFACE_LINK_PARAMS, ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_LINK_PARAMS, ifp->vrf->vrf_id);
 
 	/* Add Interface Index */
 	stream_putl(s, ifp->ifindex);
@@ -299,7 +299,7 @@ int zsend_interface_address(int cmd, struct zserv *client,
 	struct prefix *p;
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, cmd, ifp->vrf_id);
+	zclient_create_header(s, cmd, ifp->vrf->vrf_id);
 	stream_putl(s, ifp->ifindex);
 
 	/* Interface address flag. */
@@ -341,7 +341,7 @@ static int zsend_interface_nbr_address(int cmd, struct zserv *client,
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 	struct prefix *p;
 
-	zclient_create_header(s, cmd, ifp->vrf_id);
+	zclient_create_header(s, cmd, ifp->vrf->vrf_id);
 	stream_putl(s, ifp->ifindex);
 
 	/* Prefix information. */
@@ -459,7 +459,7 @@ int zsend_interface_vrf_update(struct zserv *client, struct interface *ifp,
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, ZEBRA_INTERFACE_VRF_UPDATE, ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_VRF_UPDATE, ifp->vrf->vrf_id);
 
 	/* Fill in the name of the interface and its new VRF (id) */
 	stream_put(s, ifp->name, INTERFACE_NAMSIZ);
@@ -534,7 +534,7 @@ int zsend_interface_update(int cmd, struct zserv *client, struct interface *ifp)
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, cmd, ifp->vrf_id);
+	zclient_create_header(s, cmd, ifp->vrf->vrf_id);
 	zserv_encode_interface(s, ifp);
 
 	if (cmd == ZEBRA_INTERFACE_UP)
@@ -985,7 +985,8 @@ void zsend_nhrp_neighbor_notify(int cmd, struct interface *ifp,
 	       family2addrsize(sockunion_family(&ip)));
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
-		if (!vrf_bitmap_check(client->nhrp_neighinfo[afi], ifp->vrf_id))
+		if (!vrf_bitmap_check(client->nhrp_neighinfo[afi],
+				      ifp->vrf->vrf_id))
 			continue;
 
 		s = stream_new(ZEBRA_MAX_PACKET_SIZ);
@@ -3421,7 +3422,7 @@ static inline void zebra_gre_get(ZAPI_HANDLER_ARGS)
 					zebra_ns_lookup(gre_info->link_nsid),
 					gre_info->ifindex_link);
 		if (ifp_link)
-			vrf_id_link = ifp_link->vrf_id;
+			vrf_id_link = ifp_link->vrf->vrf_id;
 		stream_putl(s, vrf_id_link);
 		stream_putl(s, gre_info->vtep_ip.s_addr);
 		stream_putl(s, gre_info->vtep_ip_remote.s_addr);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3569,9 +3569,9 @@ dplane_br_port_update(const struct interface *ifp, bool non_df,
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
-	ctx->zd_vrf_id = ifp->vrf_id;
+	ctx->zd_vrf_id = ifp->vrf->vrf_id;
 
-	zns = zebra_ns_lookup(ifp->vrf_id);
+	zns = zebra_ns_lookup(ifp->vrf->vrf_id);
 	dplane_ctx_ns_init(ctx, zns, false);
 
 	ctx->zd_ifindex = ifp->ifindex;
@@ -3646,16 +3646,16 @@ static enum zebra_dplane_result intf_addr_update_internal(
 
 	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
 		zlog_debug("init intf ctx %s: idx %d, addr %u:%pFX",
-			   dplane_op2str(op), ifp->ifindex, ifp->vrf_id,
+			   dplane_op2str(op), ifp->ifindex, ifp->vrf->vrf_id,
 			   ifc->address);
 
 	ctx = dplane_ctx_alloc();
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
-	ctx->zd_vrf_id = ifp->vrf_id;
+	ctx->zd_vrf_id = ifp->vrf->vrf_id;
 
-	zns = zebra_ns_lookup(ifp->vrf_id);
+	zns = zebra_ns_lookup(ifp->vrf->vrf_id);
 	dplane_ctx_ns_init(ctx, zns, false);
 
 	/* Init the interface-addr-specific area */
@@ -3853,9 +3853,9 @@ void dplane_mac_init(struct zebra_dplane_ctx *ctx,
 	struct zebra_ns *zns;
 
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
-	ctx->zd_vrf_id = ifp->vrf_id;
+	ctx->zd_vrf_id = ifp->vrf->vrf_id;
 
-	zns = zebra_ns_lookup(ifp->vrf_id);
+	zns = zebra_ns_lookup(ifp->vrf->vrf_id);
 	dplane_ctx_ns_init(ctx, zns, false);
 
 	strlcpy(ctx->zd_ifname, ifp->name, sizeof(ctx->zd_ifname));
@@ -4078,9 +4078,9 @@ enum zebra_dplane_result dplane_neigh_table_update(const struct interface *ifp,
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
-	ctx->zd_vrf_id = ifp->vrf_id;
+	ctx->zd_vrf_id = ifp->vrf->vrf_id;
 
-	zns = zebra_ns_lookup(ifp->vrf_id);
+	zns = zebra_ns_lookup(ifp->vrf->vrf_id);
 	dplane_ctx_ns_init(ctx, zns, false);
 
 	strlcpy(ctx->zd_ifname, ifp->name, sizeof(ctx->zd_ifname));
@@ -4152,10 +4152,10 @@ neigh_update_internal(enum dplane_op_e op, const struct interface *ifp,
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
-	ctx->zd_vrf_id = ifp->vrf_id;
+	ctx->zd_vrf_id = ifp->vrf->vrf_id;
 	dplane_ctx_set_type(ctx, protocol);
 
-	zns = zebra_ns_lookup(ifp->vrf_id);
+	zns = zebra_ns_lookup(ifp->vrf->vrf_id);
 	dplane_ctx_ns_init(ctx, zns, false);
 
 	strlcpy(ctx->zd_ifname, ifp->name, sizeof(ctx->zd_ifname));
@@ -4403,13 +4403,13 @@ dplane_gre_set(struct interface *ifp, struct interface *ifp_link,
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
-	zns = zebra_ns_lookup(ifp->vrf_id);
+	zns = zebra_ns_lookup(ifp->vrf->vrf_id);
 	if (!zns)
 		return result;
 	dplane_ctx_ns_init(ctx, zns, false);
 
 	dplane_ctx_set_ifname(ctx, ifp->name);
-	ctx->zd_vrf_id = ifp->vrf_id;
+	ctx->zd_vrf_id = ifp->vrf->vrf_id;
 	ctx->zd_ifindex = ifp->ifindex;
 	if (ifp_link)
 		ctx->u.gre.link_ifindex = ifp_link->ifindex;

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -417,10 +417,10 @@ int zebra_evpn_advertise_subnet(struct zebra_evpn *zevpn, struct interface *ifp,
 
 		apply_mask(&p);
 		if (advertise)
-			ip_prefix_send_to_client(ifp->vrf_id, &p,
+			ip_prefix_send_to_client(ifp->vrf->vrf_id, &p,
 						 ZEBRA_IP_PREFIX_ROUTE_ADD);
 		else
-			ip_prefix_send_to_client(ifp->vrf_id, &p,
+			ip_prefix_send_to_client(ifp->vrf->vrf_id, &p,
 						 ZEBRA_IP_PREFIX_ROUTE_DEL);
 	}
 	return 0;
@@ -481,7 +481,7 @@ int zebra_evpn_gw_macip_del(struct interface *ifp, struct zebra_evpn *zevpn,
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug(
 			"%u:SVI %s(%u) VNI %u, sending GW MAC %pEA IP %pIA del to BGP",
-			ifp->vrf_id, ifp->name, ifp->ifindex, zevpn->vni,
+			ifp->vrf->vrf_id, ifp->name, ifp->ifindex, zevpn->vni,
 			&n->emac, ip);
 
 	/* Remove neighbor from BGP. */
@@ -1531,7 +1531,7 @@ void zebra_evpn_rem_macip_del(vni_t vni, const struct ethaddr *macaddr,
 	if (!mac && !n)
 		return;
 
-	zvrf = vrf_info_lookup(zevpn->vxlan_if->vrf_id);
+	zvrf = zevpn->vxlan_if->vrf->info;
 
 	/* Ignore the delete if this mac is a gateway mac-ip */
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL)

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -1877,7 +1877,7 @@ static bool zebra_evpn_local_mac_update_fwd_info(struct zebra_mac *mac,
 	struct zebra_vrf *zvrf;
 	struct zebra_evpn_es *es;
 
-	zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	zvrf = ifp->vrf->info;
 	if (zvrf && zvrf->zns)
 		local_ns_id = zvrf->zns->ns_id;
 
@@ -2481,7 +2481,7 @@ int zebra_evpn_mac_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 	ns_id_t local_ns_id = NS_DEFAULT;
 	struct zebra_vrf *zvrf;
 
-	zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	zvrf = ifp->vrf->info;
 	if (zvrf && zvrf->zns)
 		local_ns_id = zvrf->zns->ns_id;
 

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -923,7 +923,7 @@ void zebra_evpn_process_neigh_on_local_mac_change(struct zebra_evpn *zevpn,
 	struct listnode *node = NULL;
 	struct zebra_vrf *zvrf = NULL;
 
-	zvrf = vrf_info_lookup(zevpn->vxlan_if->vrf_id);
+	zvrf = zevpn->vxlan_if->vrf->info;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug("Processing neighbors on local MAC %pEA %s, VNI %u",
@@ -1308,11 +1308,11 @@ int zebra_evpn_local_neigh_update(struct zebra_evpn *zevpn,
 		}
 	}
 
-	zvrf = vrf_info_lookup(zevpn->vxlan_if->vrf_id);
+	zvrf = zevpn->vxlan_if->vrf->info;
 	if (!zvrf) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug("        Unable to find vrf for: %d",
-				   zevpn->vxlan_if->vrf_id);
+				   zevpn->vxlan_if->vrf->vrf_id);
 		return -1;
 	}
 
@@ -2337,7 +2337,7 @@ int zebra_evpn_neigh_del_ip(struct zebra_evpn *zevpn, const struct ipaddr *ip)
 		return 0;
 	}
 
-	zvrf = vrf_info_lookup(zevpn->vxlan_if->vrf_id);
+	zvrf = zevpn->vxlan_if->vrf->info;
 	if (!zvrf) {
 		zlog_debug("%s: VNI %u vrf lookup failed.", __func__,
 			   zevpn->vni);

--- a/zebra/zebra_evpn_vxlan.h
+++ b/zebra/zebra_evpn_vxlan.h
@@ -28,7 +28,7 @@ zebra_get_vrr_intf_for_svi(struct interface *ifp)
 	struct interface *tmp_if = NULL;
 	struct zebra_if *zif = NULL;
 
-	zvrf = vrf_info_lookup(ifp->vrf_id);
+	zvrf = ifp->vrf->info;
 	assert(zvrf);
 
 	FOR_ALL_INTERFACES (zvrf->vrf, tmp_if) {

--- a/zebra/zebra_l2.c
+++ b/zebra/zebra_l2.c
@@ -58,7 +58,7 @@ static void map_slaves_to_bridge(struct interface *br_if, int link,
 	struct zebra_vrf *zvrf;
 	struct zebra_ns *zns;
 
-	zvrf = zebra_vrf_lookup_by_id(br_if->vrf_id);
+	zvrf = br_if->vrf->info;
 	assert(zvrf);
 	zns = zvrf->zns;
 	assert(zns);
@@ -425,7 +425,7 @@ void zebra_l2if_update_bridge_slave(struct interface *ifp,
 	zif = ifp->info;
 	assert(zif);
 
-	zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	zvrf = ifp->vrf->info;
 	if (!zvrf)
 		return;
 
@@ -505,7 +505,7 @@ void zebra_l2if_update_bond_slave(struct interface *ifp, ifindex_t bond_ifindex,
 
 	/* Set up or remove link with master */
 	if (bond_ifindex != IFINDEX_INTERNAL)
-		zebra_l2_map_slave_to_bond(zif, ifp->vrf_id);
+		zebra_l2_map_slave_to_bond(zif, ifp->vrf->vrf_id);
 	else if (old_bond_ifindex != IFINDEX_INTERNAL)
 		zebra_l2_unmap_slave_from_bond(zif);
 }

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -518,7 +518,7 @@ static int zebra_ptm_handle_bfd_msg(void *arg, void *in_ctxt,
 	}
 
 	if (!strcmp(ZEBRA_PTM_INVALID_VRF, vrf_str) && ifp) {
-		vrf_id = ifp->vrf_id;
+		vrf_id = ifp->vrf->vrf_id;
 	} else {
 		struct vrf *pVrf;
 


### PR DESCRIPTION
Since f60a1188 we store a pointer to the VRF in the interface structure.
There's no need anymore to store a separate vrf_id field.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>