### PR TITLE
bgpd: do not set the 'BGP_NEXTHOP_REGISTERED/BGP_NEXTHOP_UNREGISTERD'…

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -895,10 +895,11 @@ static void sendmsg_zebra_rnh(struct bgp_nexthop_cache *bnc, int command)
 
 	ret = zclient_send_rnh(zclient, command, &bnc->prefix, exact_match,
 			       resolve_via_default, bnc->bgp->vrf_id);
-	/* TBD: handle the failure */
-	if (ret == ZCLIENT_SEND_FAILURE)
+	if (ret == ZCLIENT_SEND_FAILURE) {
 		flog_warn(EC_BGP_ZEBRA_SEND,
 			  "sendmsg_nexthop: zclient_send_message() failed");
+		return;
+	}
 
 	if (command == ZEBRA_NEXTHOP_REGISTER)
 		SET_FLAG(bnc->flags, BGP_NEXTHOP_REGISTERED);


### PR DESCRIPTION
When failed in sending msg to zclient, the flag of BGP_NEXTHOP_REGISTERED/BGP_NEXTHOP_UNREGISTERD should not be set.
For example, if the zclient connection is not ready, the zclient send operation fails, we need to register nexthops again when the connection is ready. In this case, the BGP_NEXTHOP_REGISTERED should not be set.

Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>