### PR TITLE
bgpd: fix source-address for BFD sessions when using update-source IFNAME

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -163,7 +163,7 @@ void bgp_peer_bfd_update_source(struct peer *p)
 		return;
 
 	/* Figure out the correct source to use. */
-	if (CHECK_FLAG(p->flags, PEER_FLAG_UPDATE_SOURCE))
+	if (CHECK_FLAG(p->flags, PEER_FLAG_UPDATE_SOURCE) && p->update_source)
 		source = p->update_source;
 	else
 		source = p->su_local;


### PR DESCRIPTION
When "update-source IFNAME" is used for the neighbor, p->update_source
is set to NULL, so we can't use it as a source address and should use
the address from p->su_local.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>