### PR TITLE
zebra: free LSP workqueue later during shutdown

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -182,8 +182,6 @@ static void sigint(void)
 				SET_FLAG(zvrf->flags, ZEBRA_VRF_RETAIN);
 		}
 	}
-	if (zrouter.lsp_process_q)
-		work_queue_free_and_null(&zrouter.lsp_process_q);
 
 	vrf_terminate();
 

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -235,6 +235,9 @@ void zebra_router_terminate(void)
 	RB_FOREACH_SAFE (zrt, zebra_router_table_head, &zrouter.tables, tmp)
 		zebra_router_free_table(zrt);
 
+	if (zrouter.lsp_process_q)
+		work_queue_free_and_null(&zrouter.lsp_process_q);
+
 	work_queue_free_and_null(&zrouter.ribq);
 	meta_queue_free(zrouter.mq);
 


### PR DESCRIPTION
Free the LSP workqueue later during shutdown, so that zebra has enough time to clean up and uninstall any LSPs.
