### PR TITLE
Don't overwrite existing frr.conf

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -566,8 +566,9 @@ zebra_spec_add_service fabricd	2618/tcp "Fabricd vty"
 # Create dummy config file if they don't exist so basic functions can be used.
 if [ ! -e %{configdir}/zebra.conf ]; then
     # per daemon configs exist
-    test ! -e %{configdir}/frr.conf && \
+    if [ ! -e %{configdir}/frr.conf ]; then
         mv %{configdir}/frr.conf.template %{configdir}/frr.conf
+    fi
 %if 0%{?frr_user:1}
     chown %{frr_user}:%{frr_user} %{configdir}/frr.conf
 %endif
@@ -917,7 +918,7 @@ sed -i 's/ -M rpki//' %{_sysconfdir}/frr/daemons
 -    Add ability to show BGP routes from a particular table version
 -    Add support for for RFC 8050 (MRT add-path)
 -    Add SNMP support for MPLS VPN
--    Add `show bgp summary wide` command to show more detailed output 
+-    Add `show bgp summary wide` command to show more detailed output
      on wide terminals
 -    Add ability for peer-groups to have `ttl-security hops` configured
 -    Add support for conditional Advertisement

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -566,7 +566,8 @@ zebra_spec_add_service fabricd	2618/tcp "Fabricd vty"
 # Create dummy config file if they don't exist so basic functions can be used.
 if [ ! -e %{configdir}/zebra.conf ]; then
     # per daemon configs exist
-    mv %{configdir}/frr.conf.template %{configdir}/frr.conf
+    test ! -e %{configdir}/frr.conf && \
+        mv %{configdir}/frr.conf.template %{configdir}/frr.conf
 %if 0%{?frr_user:1}
     chown %{frr_user}:%{frr_user} %{configdir}/frr.conf
 %endif


### PR DESCRIPTION
If an frr.conf already exists, don't overwrite it during package installation. This can break already running FRR instances.