### PR TITLE
zebra: autorise nexthop interface labelled routes

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1751,7 +1751,6 @@ static bool zapi_read_nexthops(struct zserv *client, struct prefix *p,
 
 		/* MPLS labels for BGP-LU or Segment Routing */
 		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL)
-		    && api_nh->type != NEXTHOP_TYPE_IFINDEX
 		    && api_nh->type != NEXTHOP_TYPE_BLACKHOLE
 		    && api_nh->label_num > 0) {
 


### PR DESCRIPTION
When coming from staticd, some nexthop interface based routes
should be able to add a label. Following configuration can
help:

interface eth0
  ip address 10.125.0.1/32
!
ip route 10.125.0.0/24 eth0 label 55

Fixes: ("7fcb24bbaa91") zebra: reject routes without nexthops

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>