### PR TITLE
ospfd: fix code being guarded by debug check

### DIFF
--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -76,10 +76,11 @@ static int ospf_inactivity_timer(struct thread *thread)
 	 */
 	if (!OSPF_GR_IS_ACTIVE_HELPER(nbr))
 		OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_InactivityTimer);
-	else if (IS_DEBUG_OSPF_GR) {
-		zlog_debug(
-			"%s, Acting as HELPER for this neighbour, So restart the dead timer",
-			__func__);
+	else {
+		if (IS_DEBUG_OSPF_GR)
+			zlog_debug(
+				"%s, Acting as HELPER for this neighbour, So restart the dead timer",
+				__func__);
 		OSPF_NSM_TIMER_ON(nbr->t_inactivity, ospf_inactivity_timer,
 				  nbr->v_inactivity);
 	}


### PR DESCRIPTION
OSPF_NSM_TIMER_ON must be called regardless of debug configuration.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>