### PR TITLE
ospfd: fix no-form of "graceful-restart" command

### DIFF
--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -770,7 +770,7 @@ DEFPY(graceful_restart, graceful_restart_cmd,
 }
 
 DEFPY(no_graceful_restart, no_graceful_restart_cmd,
-      "no graceful-restart [period (1-1800)]",
+      "no graceful-restart [grace-period (1-1800)]",
       NO_STR OSPF_GR_STR
       "Maximum length of the 'grace period'\n"
       "Maximum length of the 'grace period' in seconds\n")


### PR DESCRIPTION
The no-form should use the same arguments as the regular command, hence
replace "period" with "grace-period".

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>