### PR TITLE
ospfd: Fix wrong parsing of TE subTLV

### DIFF
--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -2171,7 +2171,7 @@ static int ospf_te_parse_te(struct ls_ted *ted, struct ospf_lsa *lsa)
 	if ((len == 0) || (ntohs(tlvh->type) != TE_TLV_LINK))
 		return 0;
 
-	sum = 0;
+	sum = sizeof(struct tlv_header);
 	/* Browse sub-TLV and fulfill Link State Attributes */
 	for (tlvh = TLV_DATA(tlvh); sum < len; tlvh = TLV_HDR_NEXT(tlvh)) {
 		uint32_t val32, tab32[2];
@@ -2377,7 +2377,7 @@ static int ospf_te_delete_te(struct ls_ted *ted, struct ospf_lsa *lsa)
 	if (ntohs(tlvh->type) == TE_TLV_ROUTER_ADDR)
 		tlvh = TLV_HDR_NEXT(tlvh);
 	len = TLV_BODY_SIZE(tlvh);
-	sum = 0;
+	sum = sizeof(struct tlv_header);
 
 	/* Browse sub-TLV to find Link ID */
 	for (tlvh = TLV_DATA(tlvh); sum < len; tlvh = TLV_HDR_NEXT(tlvh)) {


### PR DESCRIPTION
Function ospf_te_parse_te() and ospf_te_delete_te() browse TE TLV but also
subTLV. The loop that parse the subTLV check that cummulative read data doesn't
exceed the total size of the TLV. However, the sum variable that counts the
number of read data was wrongly intialize to 0 instead to 4 (i.e. the initial
TLV Header size that is located at the TOP of subTLV).

This patch adjust accordingly the initial value of the counter.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>