### PR TITLE
Fixing typo in ospf_vty.c

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -6416,7 +6416,7 @@ static int show_network_lsa_detail(struct vty *vty, struct ospf_lsa *lsa,
 	}
 
 	if (json)
-		json_object_object_add(json, "attchedRouters",
+		json_object_object_add(json, "attachedRouters",
 				       json_attached_rt);
 
 	return 0;


### PR DESCRIPTION
opfd: The typo in output of command `show ip ospf database network json`

`Attached Routers` displays as `attchedRouters` (with missing `a`), but should look like `attachedRouters`.
Fixing this in ospfd/ospf_vty.c, line 6419