### PR TITLE
tools: Add another valgrind suppression for libyang

### DIFF
--- a/tools/valgrind.supp
+++ b/tools/valgrind.supp
@@ -78,3 +78,11 @@
    ...
    fun:yang_module_load
 }
+{
+   <libyang2 lys_compile_type_range>
+   Memcheck:Leak
+   ...
+   fun:lys_compile_type_range
+   ...
+   fun:yang_module_load
+}


### PR DESCRIPTION
More memory leaks from libyang that we can just ignore

Signed-off-by: Donald Sharp <sharpd@nvidia.com>