### PR TITLE
zebra: fix memleak on shutdown

### DIFF
--- a/zebra/table_manager.c
+++ b/zebra/table_manager.c
@@ -72,7 +72,8 @@ void table_manager_enable(struct zebra_vrf *zvrf)
 
 	if (zvrf->tbl_mgr)
 		return;
-	if (!vrf_is_backend_netns() && zvrf_id(zvrf) != VRF_DEFAULT) {
+	if (!vrf_is_backend_netns()
+	    && strcmp(zvrf_name(zvrf), VRF_DEFAULT_NAME)) {
 		struct zebra_vrf *def = zebra_vrf_lookup_by_id(VRF_DEFAULT);
 
 		if (def)
@@ -284,7 +285,8 @@ void table_manager_disable(struct zebra_vrf *zvrf)
 {
 	if (!zvrf->tbl_mgr)
 		return;
-	if (!vrf_is_backend_netns() && zvrf_id(zvrf) != VRF_DEFAULT) {
+	if (!vrf_is_backend_netns()
+	    && strcmp(zvrf_name(zvrf), VRF_DEFAULT_NAME)) {
 		zvrf->tbl_mgr = NULL;
 		return;
 	}


### PR DESCRIPTION
During shutdown, when table_manager_disable is called for the default
VRF, its vrf_id is already set to VRF_UNKNOWN, so the expression is true
and the table manager memory is not freed. Change the expression to
compare the VRF name instead of the id. The check in table_manager_enable
is changed for consistency.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>