### PR TITLE
lib/vtysh/ospf6d: assorted small bits

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17593,6 +17593,7 @@ static struct cmd_node bgp_ipv4_unicast_node = {
 	.node = BGP_IPV4_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_ipv4_multicast_node = {
@@ -17600,6 +17601,7 @@ static struct cmd_node bgp_ipv4_multicast_node = {
 	.node = BGP_IPV4M_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_ipv4_labeled_unicast_node = {
@@ -17607,6 +17609,7 @@ static struct cmd_node bgp_ipv4_labeled_unicast_node = {
 	.node = BGP_IPV4L_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_ipv6_unicast_node = {
@@ -17614,6 +17617,7 @@ static struct cmd_node bgp_ipv6_unicast_node = {
 	.node = BGP_IPV6_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_ipv6_multicast_node = {
@@ -17621,6 +17625,7 @@ static struct cmd_node bgp_ipv6_multicast_node = {
 	.node = BGP_IPV6M_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_ipv6_labeled_unicast_node = {
@@ -17628,6 +17633,7 @@ static struct cmd_node bgp_ipv6_labeled_unicast_node = {
 	.node = BGP_IPV6L_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_vpnv4_node = {
@@ -17635,6 +17641,7 @@ static struct cmd_node bgp_vpnv4_node = {
 	.node = BGP_VPNV4_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_vpnv6_node = {
@@ -17642,6 +17649,7 @@ static struct cmd_node bgp_vpnv6_node = {
 	.node = BGP_VPNV6_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af-vpnv6)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_evpn_node = {
@@ -17649,6 +17657,7 @@ static struct cmd_node bgp_evpn_node = {
 	.node = BGP_EVPN_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-evpn)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_evpn_vni_node = {
@@ -17663,6 +17672,7 @@ static struct cmd_node bgp_flowspecv4_node = {
 	.node = BGP_FLOWSPECV4_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_flowspecv6_node = {
@@ -17670,6 +17680,7 @@ static struct cmd_node bgp_flowspecv6_node = {
 	.node = BGP_FLOWSPECV6_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af-vpnv6)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_srv6_node = {

--- a/lib/command.h
+++ b/lib/command.h
@@ -213,6 +213,9 @@ struct cmd_node {
 
 	/* set as soon as any command is in cmdgraph */
 	bool graph_built;
+
+	/* don't decrement vty->xpath_index on leaving this node */
+	bool no_xpath;
 };
 
 /* Return value of the commands. */

--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -269,14 +269,14 @@ DEFUN_HIDDEN (no_config_log_monitor,
 	return CMD_SUCCESS;
 }
 
-DEFPY (debug_uid_backtrace,
-       debug_uid_backtrace_cmd,
-       "[no] debug unique-id UID backtrace",
-       NO_STR
-       DEBUG_STR
-       "Options per individual log message, by unique ID\n"
-       "Log message unique ID (XXXXX-XXXXX)\n"
-       "Add backtrace to log when message is printed\n")
+DEFPY_NOSH (debug_uid_backtrace,
+	    debug_uid_backtrace_cmd,
+	    "[no] debug unique-id UID backtrace",
+	    NO_STR
+	    DEBUG_STR
+	    "Options per individual log message, by unique ID\n"
+	    "Log message unique ID (XXXXX-XXXXX)\n"
+	    "Add backtrace to log when message is printed\n")
 {
 	struct xrefdata search, *xrd;
 	struct xrefdata_logmsg *xrdl;
@@ -285,10 +285,9 @@ DEFPY (debug_uid_backtrace,
 	strlcpy(search.uid, uid, sizeof(search.uid));
 	xrd = xrefdata_uid_find(&xrefdata_uid, &search);
 
-	if (!xrd) {
-		vty_out(vty, "%% no log message with ID \"%s\" found\n", uid);
-		return CMD_WARNING;
-	}
+	if (!xrd)
+		return CMD_ERR_NOTHING_TODO;
+
 	if (xrd->xref->type != XREFT_LOGMSG) {
 		vty_out(vty, "%% ID \"%s\" is not a log message\n", uid);
 		return CMD_WARNING;

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -173,8 +173,6 @@ struct ospf6_lsa_handler {
 #define OSPF6_LSA_IS_KNOWN(t)                                                  \
 	(ospf6_get_lsa_handler(t)->lh_type != OSPF6_LSTYPE_UNKNOWN ? 1 : 0)
 
-extern vector ospf6_lsa_handler_vector;
-
 /* Macro for LSA Origination */
 /* addr is (struct prefix *) */
 #define CONTINUE_IF_ADDRESS_LINKLOCAL(debug, addr)                             \
@@ -268,6 +266,7 @@ extern int ospf6_lsa_prohibited_duration(uint16_t type, uint32_t id,
 
 extern void ospf6_install_lsa_handler(struct ospf6_lsa_handler *handler);
 extern struct ospf6_lsa_handler *ospf6_get_lsa_handler(uint16_t type);
+extern void ospf6_lsa_debug_set_all(bool val);
 
 extern void ospf6_lsa_init(void);
 extern void ospf6_lsa_terminate(void);

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -1254,7 +1254,6 @@ DEFUN (no_debug_ospf6,
        OSPF6_STR)
 {
 	unsigned int i;
-	struct ospf6_lsa_handler *handler = NULL;
 
 	OSPF6_DEBUG_ABR_OFF();
 	OSPF6_DEBUG_ASBR_OFF();
@@ -1264,13 +1263,7 @@ DEFUN (no_debug_ospf6,
 	OSPF6_DEBUG_FLOODING_OFF();
 	OSPF6_DEBUG_INTERFACE_OFF();
 
-	for (i = 0; i < vector_active(ospf6_lsa_handler_vector); i++) {
-		handler = vector_slot(ospf6_lsa_handler_vector, i);
-
-		if (handler != NULL) {
-			UNSET_FLAG(handler->lh_debug, OSPF6_LSA_DEBUG);
-		}
-	}
+	ospf6_lsa_debug_set_all(false);
 
 	for (i = 0; i < 6; i++)
 		OSPF6_DEBUG_MESSAGE_OFF(i,

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1279,6 +1279,7 @@ static struct cmd_node bgp_vpnv4_node = {
 	.node = BGP_VPNV4_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_vpnv6_node = {
@@ -1286,6 +1287,7 @@ static struct cmd_node bgp_vpnv6_node = {
 	.node = BGP_VPNV6_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_flowspecv4_node = {
@@ -1293,6 +1295,7 @@ static struct cmd_node bgp_flowspecv4_node = {
 	.node = BGP_FLOWSPECV4_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_flowspecv6_node = {
@@ -1300,6 +1303,7 @@ static struct cmd_node bgp_flowspecv6_node = {
 	.node = BGP_FLOWSPECV6_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_ipv4_node = {
@@ -1307,6 +1311,7 @@ static struct cmd_node bgp_ipv4_node = {
 	.node = BGP_IPV4_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_ipv4m_node = {
@@ -1314,6 +1319,7 @@ static struct cmd_node bgp_ipv4m_node = {
 	.node = BGP_IPV4M_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_ipv4l_node = {
@@ -1321,6 +1327,7 @@ static struct cmd_node bgp_ipv4l_node = {
 	.node = BGP_IPV4L_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_ipv6_node = {
@@ -1328,6 +1335,7 @@ static struct cmd_node bgp_ipv6_node = {
 	.node = BGP_IPV6_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_ipv6m_node = {
@@ -1335,6 +1343,7 @@ static struct cmd_node bgp_ipv6m_node = {
 	.node = BGP_IPV6M_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_evpn_node = {
@@ -1342,6 +1351,7 @@ static struct cmd_node bgp_evpn_node = {
 	.node = BGP_EVPN_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 static struct cmd_node bgp_evpn_vni_node = {
@@ -1356,6 +1366,7 @@ static struct cmd_node bgp_ipv6l_node = {
 	.node = BGP_IPV6L_NODE,
 	.parent_node = BGP_NODE,
 	.prompt = "%s(config-router-af)# ",
+	.no_xpath = true,
 };
 
 #ifdef ENABLE_BGP_VNC
@@ -1516,6 +1527,7 @@ struct cmd_node link_params_node = {
 	.node = LINK_PARAMS_NODE,
 	.parent_node = INTERFACE_NODE,
 	.prompt = "%s(config-link-params)# ",
+	.no_xpath = true,
 };
 
 #ifdef HAVE_BGPD

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2905,6 +2905,7 @@ struct cmd_node link_params_node = {
 	.node = LINK_PARAMS_NODE,
 	.parent_node = INTERFACE_NODE,
 	.prompt = "%s(config-link-params)# ",
+	.no_xpath = true,
 };
 
 static void link_param_cmd_set_uint32(struct interface *ifp, uint32_t *field,


### PR DESCRIPTION
(refer to individual commits for details)

- removes a `vector` use from ospf6d for its LSA handlers (they're constant anyway)
- converts the route-map code from using a `vector` for its set/match items to a hash (which is what's appropriate for the use, i.e. lookup by name)
- replaces hardcoded CLI node numbers in `vty_check_node_for_xpath_decrement()` with a flag in `struct cli_node` for the particular node (so less changes in `lib/` that are really daemon changes)
- make vtysh actually able to configure the per-UID backtraces added in #10025

(25 uses of `vector_init()` remaining…)