### PR TITLE
zebra: fix chdir judgment to avoid starting failed in a non-existent directory

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2998,7 +2998,7 @@ static void vty_save_cwd(void)
 		 * the whole world is coming down around us
 		 * Hence not worrying about it too much.
 		 */
-		if (!chdir(SYSCONFDIR)) {
+		if (chdir(SYSCONFDIR)) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,
 				     "Failure to chdir to %s, errno: %d",
 				     SYSCONFDIR, errno);


### PR DESCRIPTION
Getcwd failed and then chdir(SYSCONFDIR) returns 0. In this condition, It should continue vty_init function instead of entering the if and exist. This will cause zebra failing to start in a non-existent path.

Signed-off-by: Solyn <admin@iloft.xyz>