### PR TITLE
ospf6d: do not originate Type-4 lsa when NSSA

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -447,6 +447,18 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 			return 0;
 		}
 
+		/* Do not generate if area is NSSA */
+		route_area =
+			ospf6_area_lookup(route->path.area_id, area->ospf6);
+		if (IS_AREA_NSSA(route_area)) {
+			if (is_debug)
+				zlog_debug(
+					"%s: The route comes from NSSA area, skip",
+					__func__);
+			ospf6_abr_delete_route(summary, summary_table, old);
+			return 0;
+		}
+
 		/* Do not generate if the area is stub */
 		/* XXX */
 	}

--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -394,7 +394,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		return 0;
 	}
 
-	if ((route->type == OSPF6_DEST_TYPE_ROUTER) && IS_AREA_STUB(area)) {
+	if ((route->type == OSPF6_DEST_TYPE_ROUTER)
+	    && (IS_AREA_STUB(area) || IS_AREA_NSSA(area))) {
 		if (is_debug)
 			zlog_debug(
 				"Area has been stubbed, purge Inter-Router LSA");


### PR DESCRIPTION
In a topology like:
```
     r1 ---- 0.0.0.0 ---- r2(ABR) ---- 1.1.1.1 -----r3(ASBR)
```
where r3 is redistributing statics and area 1.1.1.1 is NSSA, the ABR r2 should
not originate type-4 LSA, according to RFC 3101, section 1.3:

"also an NSSA's border routers never originate Type-4 summary-LSAs for the
NSSA's AS boundary routers, since Type-7 AS-external-LSAs are never flooded
beyond the NSSA's border"
``` 
r1# sh ipv6 os database inter-router

        Area Scoped Link State Database (Area 0.0.0.0)

Type LSId           AdvRouter       Age   SeqNum                        Payload
IAR  3.3.3.3        2.2.2.2          49 80000001                        3.3.3.3
```
This PR prevents the above LSA of being originated by the ABR r2

Likewise, if r1 is redistributing statics, r2 should not inject a type-4 LSA into the NSSA area. 
From RFC 3101: "NSSA border routers should not originate Type-4 summary-LSAs into their NSSAs."

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>