### PR TITLE
tools, vtysh: Remove final vestige of `address-family evpn`

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -488,17 +488,6 @@ class Config(object):
          exit-address-family
         !
         end
-         address-family evpn
-          neighbor LEAF activate
-          advertise-all-vni
-          vni 10100
-           rd 65000:10100
-           route-target import 10.1.1.1:10100
-           route-target export 10.1.1.1:10100
-          exit-vni
-         exit-address-family
-        !
-        end
         router ospf
          ospf router-id 10.0.0.1
          log-adjacency-changes detail

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1799,22 +1799,6 @@ DEFUNSH(VTYSH_BGPD, address_family_evpn, address_family_evpn_cmd,
 	return CMD_SUCCESS;
 }
 
-#if defined(HAVE_CUMULUS)
-#if CONFDATE > 20211115
-CPP_NOTICE("Use of `address-family evpn` is deprecated please remove don't forget frr-reload.py")
-#endif
-DEFUNSH_HIDDEN(VTYSH_BGPD, address_family_evpn2, address_family_evpn2_cmd,
-	       "address-family evpn",
-	       "Enter Address Family command mode\n"
-	       "EVPN Address family\n")
-{
-	vty_out(vty,
-		"This command is deprecated please convert to `address-family l2vpn evpn`\n");
-	vty->node = BGP_EVPN_NODE;
-	return CMD_SUCCESS;
-}
-#endif
-
 DEFUNSH(VTYSH_BGPD, bgp_evpn_vni, bgp_evpn_vni_cmd, "vni " CMD_VNI_RANGE,
 	"VXLAN Network Identifier\n"
 	"VNI number\n")


### PR DESCRIPTION
This was deprecated over a year ago now.  Let's finally
remove it from the system.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>