### PR TITLE
tests: Re-add the ability to generate core files with topotests

### DIFF
--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import time
+import resource
 
 import pytest
 import lib.fixtures
@@ -221,6 +222,9 @@ def pytest_configure(config):
         is_xdist = True
         is_worker = True
 
+    resource.setrlimit(
+        resource.RLIMIT_CORE, (resource.RLIM_INFINITY, resource.RLIM_INFINITY)
+    )
     # -----------------------------------------------------
     # Set some defaults for the pytest.ini [pytest] section
     # ---------------------------------------------------
@@ -505,5 +509,6 @@ def pytest_runtest_makereport(item, call):
 #
 # Add common fixtures available to all tests as parameters
 #
+
 tgen = pytest.fixture(lib.fixtures.tgen)
 topo = pytest.fixture(lib.fixtures.topo)

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1386,7 +1386,6 @@ class Router(Node):
             if params.get("routertype") is not None:
                 self.routertype = params.get("routertype")
 
-        self.cmd("ulimit -c unlimited")
         # Set ownership of config files
         self.cmd("chown {0}:{0}vty /etc/{0}".format(self.routertype))
 


### PR DESCRIPTION
Somewhere along the line core-files stopped being generated
with the running of the topotests.  With this change we now
see this:

sharpd@eva /t/topotests> find . -name '*.dmp' -print
./ospfv3_basic_functionality.test_ospfv3_asbr_summary_topo1/r0/ospf6d_core-sig_6-pid_430478.dmp
sharpd@eva /t/topotests> sudo gdb /usr/lib/frr/ospf6d ./ospfv3_basic_functionality.test_ospfv3_asbr_summary_topo1/r0/ospf6d_core-sig_6-pid_430478.dmp
GNU gdb (Debian 10.1-1.7) 10.1.90.20210103-git
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/lib/frr/ospf6d...
[New LWP 430478]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/usr/lib/frr/ospf6d --log file:ospf6d.log --log-level debug -d'.
Program terminated with signal SIGABRT, Aborted.
50	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
(gdb)

Signed-off-by: Donald Sharp <sharpd@nvidia.com>