### PR TITLE
pimd: fix stale forwarding entries left around after join goes away

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -651,9 +651,9 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp,
 	return ch;
 }
 
-static void ifjoin_to_noinfo(struct pim_ifchannel *ch, bool ch_del)
+static void ifjoin_to_noinfo(struct pim_ifchannel *ch)
 {
-	pim_forward_stop(ch, !ch_del);
+	pim_forward_stop(ch);
 	pim_ifchannel_ifjoin_switch(__func__, ch, PIM_IFJOIN_NOINFO);
 
 	if (ch->upstream)
@@ -661,8 +661,7 @@ static void ifjoin_to_noinfo(struct pim_ifchannel *ch, bool ch_del)
 
 	PIM_IF_FLAG_UNSET_PROTO_PIM(ch->flags);
 
-	if (ch_del)
-		delete_on_noinfo(ch);
+	delete_on_noinfo(ch);
 }
 
 static int on_ifjoin_expiry_timer(struct thread *t)
@@ -675,7 +674,7 @@ static int on_ifjoin_expiry_timer(struct thread *t)
 		zlog_debug("%s: ifchannel %s expiry timer", __func__,
 			   ch->sg_str);
 
-	ifjoin_to_noinfo(ch, true);
+	ifjoin_to_noinfo(ch);
 	/* ch may have been deleted */
 
 	return 0;
@@ -714,7 +713,7 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
 					&rpf, ch->upstream, 0);
 			}
 
-			ifjoin_to_noinfo(ch, true);
+			ifjoin_to_noinfo(ch);
 		} else {
 			/* If SGRpt flag is set on ifchannel, Trigger SGRpt
 			 *  message on RP path upon prune timer expiry.

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -653,8 +653,8 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp,
 
 static void ifjoin_to_noinfo(struct pim_ifchannel *ch)
 {
-	pim_forward_stop(ch);
 	pim_ifchannel_ifjoin_switch(__func__, ch, PIM_IFJOIN_NOINFO);
+	pim_forward_stop(ch);
 
 	if (ch->upstream)
 		PIM_UPSTREAM_FLAG_UNSET_SRC_PIM(ch->upstream->flags);

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -561,7 +561,7 @@ static void forward_off(struct pim_upstream *up)
 	/* scan per-interface (S,G) state */
 	for (ALL_LIST_ELEMENTS(up->ifchannels, chnode, chnextnode, ch)) {
 
-		pim_forward_stop(ch, false);
+		pim_forward_stop(ch);
 
 	} /* scan iface channel list */
 }

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -845,14 +845,14 @@ void pim_forward_start(struct pim_ifchannel *ch)
 			mask, __func__);
 }
 
-void pim_forward_stop(struct pim_ifchannel *ch, bool install_it)
+void pim_forward_stop(struct pim_ifchannel *ch)
 {
 	struct pim_upstream *up = ch->upstream;
 
 	if (PIM_DEBUG_PIM_TRACE) {
-		zlog_debug("%s: (S,G)=%s oif=%s install_it: %d installed: %d",
+		zlog_debug("%s: (S,G)=%s oif=%s installed: %d",
 			   __func__, ch->sg_str, ch->interface->name,
-			   install_it, up->channel_oil->installed);
+			   up->channel_oil->installed);
 	}
 
 	/*
@@ -865,9 +865,6 @@ void pim_forward_stop(struct pim_ifchannel *ch, bool install_it)
 	else
 		pim_channel_del_oif(up->channel_oil, ch->interface,
 				    PIM_OIF_FLAG_PROTO_PIM, __func__);
-
-	if (install_it && !up->channel_oil->installed)
-		pim_upstream_mroute_add(up->channel_oil, __func__);
 }
 
 void pim_zebra_zclient_update(struct vty *vty)

--- a/pimd/pim_zebra.h
+++ b/pimd/pim_zebra.h
@@ -42,7 +42,7 @@ void igmp_source_forward_stop(struct igmp_source *source);
 void igmp_source_forward_reevaluate_all(struct pim_instance *pim);
 
 void pim_forward_start(struct pim_ifchannel *ch);
-void pim_forward_stop(struct pim_ifchannel *ch, bool install_it);
+void pim_forward_stop(struct pim_ifchannel *ch);
 
 void sched_rpf_cache_refresh(struct pim_instance *pim);
 struct zclient *pim_zebra_zclient_get(void);


### PR DESCRIPTION
The ordering of actions is just wrong here, causing us to not remove MFC entries until something else bumps it.

(Free bonus cleanup included.)