### PR TITLE
vtysh: Really remove `address-family evpn`

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -4038,9 +4038,6 @@ void vtysh_init_vty(void)
 
 	install_node(&bgp_evpn_node);
 	install_element(BGP_NODE, &address_family_evpn_cmd);
-#if defined(HAVE_CUMULUS)
-	install_element(BGP_NODE, &address_family_evpn2_cmd);
-#endif
 	install_element(BGP_EVPN_NODE, &vtysh_quit_bgpd_cmd);
 	install_element(BGP_EVPN_NODE, &vtysh_exit_bgpd_cmd);
 	install_element(BGP_EVPN_NODE, &vtysh_end_all_cmd);


### PR DESCRIPTION
I don't know how my original compile didn't fail
or I didn't notice :(

Signed-off-by: Donald Sharp <sharpd@nvidia.com>