### PR TITLE
ospf6d: Prevent use after free

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -562,6 +562,8 @@ static void ospf6_disable(struct ospf6 *o)
 		THREAD_OFF(o->t_ospf6_receive);
 		THREAD_OFF(o->t_external_aggr);
 		THREAD_OFF(o->gr_info.t_grace_period);
+		THREAD_OFF(o->t_write);
+		THREAD_OFF(o->t_abr_task);
 	}
 }
 
@@ -582,8 +584,6 @@ static int ospf6_maxage_remover(struct thread *thread)
 	struct ospf6_neighbor *on;
 	struct listnode *i, *j, *k;
 	int reschedule = 0;
-
-	o->maxage_remover = (struct thread *)NULL;
 
 	for (ALL_LIST_ELEMENTS_RO(o->area_list, i, oa)) {
 		for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi)) {


### PR DESCRIPTION
I encountered a crash where the ospf6_write thread
was already thought to be scheduled by ospf6d:

(gdb) bt
    t_ptr=0x5624ee6bd260) at lib/thread.c:972
(gdb)

When poking around it was noticed that the ospf6 pointer was crap:
(gdb) p (struct ospf6 *)$7
$8 = (struct ospf6 *) 0x5624ee6c6b20
(gdb) p *$8
$9 = {vrf_id = 3998487040, name = 0x5624ee420010 "\a", router_id = 65892, router_id_static = 65892, router_id_zebra = 0, starttime = {tv_sec = 1654674, tv_usec = 678673},
  area_list = 0x0, backbone = 0x5624ee6c6710, lsdb = 0x5624ee6c2370, lsdb_self = 0x5624ee6c5d80, route_table = 0x5624ee6c5c10, brouter_table = 0x5624ee6c4690,
  external_table = 0x5624ee6c4710, external_id_table = 0x5624ee6c4f10, external_id = 24, redist = {0x0 <repeats 32 times>}, nssa_default_import_check = {refcnt = 0,
    status = false}, flag = 1 '\001', redistribute = 0, config_flags = 0 '\000', default_originate = 0, lsa_minarrival = 1000, spf_delay = 0, spf_holdtime = 50,
  spf_max_holdtime = 5000, spf_hold_multiplier = 1, spf_reason = 554, ts_spf = {tv_sec = 1654712, tv_usec = 122041}, ts_spf_duration = {tv_sec = 0, tv_usec = 48},
  last_spf_reason = 11, fd = -1, t_spf_calc = 0x0, t_ase_calc = 0x0, maxage_remover = 0x0, t_distribute_update = 0x0, t_ospf6_receive = 0x0, t_external_aggr = 0x0,
  t_write = 0x5624ee6cc930, write_oi_count = 20, ref_bandwidth = 100000, distance_all = 0 '\000', distance_intra = 0 '\000', distance_inter = 0 '\000',
  distance_external = 0 '\000', distance_table = 0x5624ee6c4f50, inst_shutdown = 1 '\001', max_multipath = 128, gr_info = {restart_support = false, restart_in_progress = false,
    prepare_in_progress = false, finishing_restart = false, grace_period = 0, t_grace_period = 0x0}, ospf6_helper_cfg = {supported_grace_time = 1800, is_helper_supported = false,
    strict_lsa_check = true, only_planned_restart = false, enable_rtr_list = 0x0, active_restarter_cnt = 0, last_exit_reason = 0}, anyNSSA = 0 '\000', t_abr_task = 0x0,
  oi_write_q = 0x0, redist_count = 0, aggr_action = 1, aggr_delay_interval = 6, rt_aggr_tbl = 0x5624ee6c51b0, qobj_node = {nid = 6163304287853836241, nodehash = {hi = {next = 0x0,
        hashval = 1613461457}}, type = 0x5624ed65e4e0 <qobj_t_ospf6>}}

Upon code inspection there was no place where we disabled the t_write thread upon ospf6 deletion.
If the code were to issue a `no router ospf6` and then recreate it.  We could see this crash.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>