### PR TITLE
Revert "zebra: free LSP workqueue later during shutdown"

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -182,6 +182,8 @@ static void sigint(void)
 				SET_FLAG(zvrf->flags, ZEBRA_VRF_RETAIN);
 		}
 	}
+	if (zrouter.lsp_process_q)
+		work_queue_free_and_null(&zrouter.lsp_process_q);
 
 	vrf_terminate();
 

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -235,9 +235,6 @@ void zebra_router_terminate(void)
 	RB_FOREACH_SAFE (zrt, zebra_router_table_head, &zrouter.tables, tmp)
 		zebra_router_free_table(zrt);
 
-	if (zrouter.lsp_process_q)
-		work_queue_free_and_null(&zrouter.lsp_process_q);
-
 	work_queue_free_and_null(&zrouter.ribq);
 	meta_queue_free(zrouter.mq);
 


### PR DESCRIPTION
This reverts commit dd9538c5f36f9d6110f1465b8708d0d7529f2cc7.

Work queue must be stopped and freed before `vrf_terminate`, because it relies on the existence of the default VRF.