### PR TITLE
bfdd: handle bfd echo packet emission and reply in a vrf

### DIFF
--- a/tests/topotests/bfd_vrf_topo1/r1/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r1/bfdd.conf
@@ -4,7 +4,7 @@
 ! debug bfd zebra
 !
 bfd
- peer 192.168.0.2 vrf r1-bfd-cust1
+ peer 192.168.0.2 vrf r1-cust1
   echo-mode
   no shutdown
  !

--- a/tests/topotests/bfd_vrf_topo1/r1/bgpd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r1/bgpd.conf
@@ -1,9 +1,8 @@
-router bgp 101 vrf r1-bfd-cust1
+router bgp 101 vrf r1-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.0.2 remote-as 102
  neighbor 192.168.0.2 timers 3 10
-! neighbor 192.168.0.2 ebgp-multihop 10
  neighbor 192.168.0.2 bfd
  address-family ipv4 unicast
   network 10.254.254.1/32

--- a/tests/topotests/bfd_vrf_topo1/r1/zebra.conf
+++ b/tests/topotests/bfd_vrf_topo1/r1/zebra.conf
@@ -1,3 +1,3 @@
-interface r1-eth0 vrf r1-bfd-cust1
+interface r1-eth0 vrf r1-cust1
  ip address 192.168.0.1/24
 !

--- a/tests/topotests/bfd_vrf_topo1/r2/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r2/bfdd.conf
@@ -4,13 +4,13 @@
 ! debug bfd zebra
 !
 bfd
- peer 192.168.0.1 vrf r2-bfd-cust1
+ peer 192.168.0.1 vrf r2-cust1
   receive-interval 1000
   transmit-interval 500
   echo-mode
   no shutdown
  !
- peer 192.168.1.1 vrf r2-bfd-cust1
+ peer 192.168.1.1 vrf r2-cust1
   echo-mode
   no shutdown
  !

--- a/tests/topotests/bfd_vrf_topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r2/bgpd.conf
@@ -1,4 +1,4 @@
-router bgp 102 vrf r2-bfd-cust1
+router bgp 102 vrf r2-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.0.1 remote-as 101

--- a/tests/topotests/bfd_vrf_topo1/r2/zebra.conf
+++ b/tests/topotests/bfd_vrf_topo1/r2/zebra.conf
@@ -1,9 +1,9 @@
-interface r2-eth0 vrf r2-bfd-cust1
+interface r2-eth0 vrf r2-cust1
  ip address 192.168.0.2/24
 !
-interface r2-eth1 vrf r2-bfd-cust1
+interface r2-eth1 vrf r2-cust1
  ip address 192.168.1.2/24
 !
-interface r2-eth2 vrf r2-bfd-cust1
+interface r2-eth2 vrf r2-cust1
  ip address 192.168.2.2/24
 !

--- a/tests/topotests/bfd_vrf_topo1/r3/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r3/bfdd.conf
@@ -4,7 +4,7 @@
 ! debug bfd zebra
 !
 bfd
- peer 192.168.1.2 vrf r3-bfd-cust1
+ peer 192.168.1.2 vrf r3-cust1
   echo-interval 100
   echo-mode
   no shutdown

--- a/tests/topotests/bfd_vrf_topo1/r3/bgpd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r3/bgpd.conf
@@ -1,4 +1,4 @@
-router bgp 103 vrf r3-bfd-cust1
+router bgp 103 vrf r3-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.1.2 remote-as 102

--- a/tests/topotests/bfd_vrf_topo1/r3/zebra.conf
+++ b/tests/topotests/bfd_vrf_topo1/r3/zebra.conf
@@ -1,3 +1,3 @@
-interface r3-eth0 vrf r3-bfd-cust1
+interface r3-eth0 vrf r3-cust1
  ip address 192.168.1.1/24
 !

--- a/tests/topotests/bfd_vrf_topo1/r4/bfdd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r4/bfdd.conf
@@ -4,7 +4,7 @@
 ! debug bfd zebra
 !
 bfd
- peer 192.168.2.2 vrf r4-bfd-cust1
+ peer 192.168.2.2 vrf r4-cust1
   transmit-interval 2000
   receive-interval 2000
   no shutdown

--- a/tests/topotests/bfd_vrf_topo1/r4/bgpd.conf
+++ b/tests/topotests/bfd_vrf_topo1/r4/bgpd.conf
@@ -1,4 +1,4 @@
-router bgp 104 vrf r4-bfd-cust1
+router bgp 104 vrf r4-cust1
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.2.2 remote-as 102

--- a/tests/topotests/bfd_vrf_topo1/r4/zebra.conf
+++ b/tests/topotests/bfd_vrf_topo1/r4/zebra.conf
@@ -1,3 +1,3 @@
-interface r4-eth0 vrf r4-bfd-cust1
+interface r4-eth0 vrf r4-cust1
  ip address 192.168.2.1/24
 !

--- a/tests/topotests/bfd_vrf_topo1/test_bfd_vrf_topo1.py
+++ b/tests/topotests/bfd_vrf_topo1/test_bfd_vrf_topo1.py
@@ -28,6 +28,7 @@ test_bfd_vrf_topo1.py: Test the FRR BFD daemon.
 """
 
 import os
+import platform
 import sys
 import json
 from functools import partial
@@ -43,64 +44,53 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-# Required to instantiate the topology builder class.
-
 pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd]
-
-
-def build_topo(tgen):
-    # Create 4 routers
-    for routern in range(1, 5):
-        tgen.add_router("r{}".format(routern))
-
-    switch = tgen.add_switch("s1")
-    switch.add_link(tgen.gears["r1"])
-    switch.add_link(tgen.gears["r2"])
-
-    switch = tgen.add_switch("s2")
-    switch.add_link(tgen.gears["r2"])
-    switch.add_link(tgen.gears["r3"])
-
-    switch = tgen.add_switch("s3")
-    switch.add_link(tgen.gears["r2"])
-    switch.add_link(tgen.gears["r4"])
 
 
 def setup_module(mod):
     "Sets up the pytest environment"
-    tgen = Topogen(build_topo, mod.__name__)
+    topodef = {
+        "s1": ("r1", "r2"),
+        "s2": ("r2", "r3"),
+        "s3": ("r2", "r4"),
+    }
+    tgen = Topogen(topodef, mod.__name__)
     tgen.start_topology()
 
     router_list = tgen.routers()
-
-    # check for zebra capability
-    for rname, router in router_list.items():
-        if router.check_capability(TopoRouter.RD_ZEBRA, "--vrfwnetns") == False:
-            return pytest.skip(
-                "Skipping BFD Topo1 VRF NETNS feature. VRF NETNS backend not available on FRR"
+    krel = platform.release()
+    if topotest.version_cmp(krel, "4.15") < 0:
+        logger.info(
+            "For BFD, kernel version should be minimum 4.15. Kernel present {}".format(
+                krel
             )
-
-    if os.system("ip netns list") != 0:
-        return pytest.skip(
-            "Skipping BFD Topo1 VRF NETNS Test. NETNS not available on System"
         )
+        return
+    l3mdev_accept = 0
+    if topotest.version_cmp(krel, '4.15') >= 0 and \
+       topotest.version_cmp(krel, '4.18') <= 0:
+        l3mdev_accept = 1
 
-    logger.info("Testing with VRF Namespace support")
+    if topotest.version_cmp(krel, '5.0') >= 0:
+        l3mdev_accept = 1
+        
+    cmds = ['sysctl -w net.ipv4.udp_l3mdev_accept={}'.format(l3mdev_accept),
+            'ip link add {0}-cust1 type vrf table 10',
+            'ip link set dev {0}-cust1 up',
+            'ip link set dev {0}-eth0 master {0}-cust1']
+    cmds2 = ['ip link set dev {0}-eth1 master {0}-cust1',
+             'ip link set dev {0}-eth2 master {0}-cust1']
 
     for rname, router in router_list.items():
-        # create VRF rx-bfd-cust1 and link rx-eth0 to rx-bfd-cust1
-        ns = "{}-bfd-cust1".format(rname)
-        router.net.add_netns(ns)
-        router.net.set_intf_netns(rname + "-eth0", ns, up=True)
+        for cmd in cmds:
+            output = tgen.net[rname].cmd(cmd.format(rname))
         if rname == "r2":
-            router.net.set_intf_netns(rname + "-eth1", ns, up=True)
-            router.net.set_intf_netns(rname + "-eth2", ns, up=True)
+            for cmd in cmds2:
+                output = tgen.net[rname].cmd(cmd.format(rname))
 
     for rname, router in router_list.items():
         router.load_config(
-            TopoRouter.RD_ZEBRA,
-            os.path.join(CWD, "{}/zebra.conf".format(rname)),
-            "--vrfwnetns",
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )
         router.load_config(
             TopoRouter.RD_BFD, os.path.join(CWD, "{}/bfdd.conf".format(rname))
@@ -112,19 +102,31 @@ def setup_module(mod):
     # Initialize all routers.
     tgen.start_router()
 
+    # Verify that we are using the proper version and that the BFD
+    # daemon exists.
+    for router in router_list.values():
+        # Check for Version
+        if router.has_version("<", "5.1"):
+            tgen.set_error("Unsupported FRR version")
+            break
+
 
 def teardown_module(_mod):
     "Teardown the pytest environment"
     tgen = get_topogen()
 
-    # Move interfaces out of vrf namespace and delete the namespace
+    cmds = ['ip link set dev {0}-eth0 nomaster',
+            'ip link delete {0}-cust1']
+    cmds2 = ['ip link set {0}-eth1 nomaster',
+             'ip link set {0}-eth2 nomaster']
+
     router_list = tgen.routers()
     for rname, router in router_list.items():
         if rname == "r2":
-            router.net.reset_intf_netns(rname + "-eth2")
-            router.net.reset_intf_netns(rname + "-eth1")
-        router.net.reset_intf_netns(rname + "-eth0")
-        router.net.delete_netns("{}-bfd-cust1".format(rname))
+            for cmd in cmds2:
+                tgen.net[rname].cmd(cmd.format(rname))
+        for cmd in cmds:
+            tgen.net[rname].cmd(cmd.format(rname))
     tgen.stop_topology()
 
 
@@ -135,6 +137,7 @@ def test_bfd_connection():
         pytest.skip(tgen.errors)
 
     logger.info("waiting for bfd peers to go up")
+
     for router in tgen.routers().values():
         json_file = "{}/{}/peers.json".format(CWD, router.name)
         expected = json.loads(open(json_file).read())
@@ -142,7 +145,7 @@ def test_bfd_connection():
         test_func = partial(
             topotest.router_json_cmp, router, "show bfd peers json", expected
         )
-        _, result = topotest.run_and_expect(test_func, None, count=16, wait=1)
+        _, result = topotest.run_and_expect(test_func, None, count=8, wait=0.5)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 
@@ -161,7 +164,7 @@ def test_bgp_convergence():
         test_func = partial(
             topotest.router_json_cmp,
             router,
-            "show ip bgp vrf {}-bfd-cust1 summary json".format(router.name),
+            "show ip bgp vrf {}-cust1 summary json".format(router.name),
             expected,
         )
         _, res = topotest.run_and_expect(test_func, None, count=125, wait=1.0)
@@ -183,10 +186,10 @@ def test_bgp_fast_convergence():
         test_func = partial(
             topotest.router_json_cmp,
             router,
-            "show ip bgp vrf {}-bfd-cust1 json".format(router.name),
+            "show ip bgp vrf {}-cust1 json".format(router.name),
             expected,
         )
-        _, res = topotest.run_and_expect(test_func, None, count=40, wait=1)
+        _, res = topotest.run_and_expect(test_func, None, count=40, wait=0.5)
         assertmsg = "{}: bgp did not converge".format(router.name)
         assert res is None, assertmsg
 
@@ -203,7 +206,7 @@ def test_bfd_fast_convergence():
     # Disable r2-eth0 link
     router2 = tgen.gears["r2"]
     topotest.interface_set_status(
-        router2, "r2-eth0", ifaceaction=False, vrf_name="r2-bfd-cust1"
+        router2, "r2-eth0", ifaceaction=False, vrf_name="r2-cust1"
     )
 
     # Wait the minimum time we can before checking that BGP/BFD
@@ -228,7 +231,7 @@ def test_bfd_fast_convergence():
         test_func = partial(
             topotest.router_json_cmp, router, "show bfd peers json", expected
         )
-        _, res = topotest.run_and_expect(test_func, None, count=40, wait=1)
+        _, res = topotest.run_and_expect(test_func, None, count=20, wait=0.5)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert res is None, assertmsg
 
@@ -258,10 +261,10 @@ def test_bgp_fast_reconvergence():
         test_func = partial(
             topotest.router_json_cmp,
             router,
-            "show ip bgp vrf {}-bfd-cust1 json".format(router.name),
+            "show ip bgp vrf {}-cust1 json".format(router.name),
             expected,
         )
-        _, res = topotest.run_and_expect(test_func, None, count=16, wait=1)
+        _, res = topotest.run_and_expect(test_func, None, count=3, wait=1)
         assertmsg = "{}: bgp did not converge".format(router.name)
         assert res is None, assertmsg
 


### PR DESCRIPTION
Bfd echo packets were not sent properly when a bfd session is
configured within a vrf. An error message:
  Loopback failure (network unreachable)
was displayed.

The reason is that outgoing echo packet is not sent in the
appropriate socket, as in vrflite, there is a single socket
for all vrf operations. To handle this situation, for each
outgoing echo packet, read the configured vrf of the bfd
session, and call vrf_bind() if there is non default vrf
configured.

A topotest is added to ensure that the functionality is not
broken.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>