### PR TITLE
lib: Do not use sizeof() on `size_t errmsg_len`.

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -830,8 +830,7 @@ int nb_candidate_validate(struct nb_context *context,
 	struct nb_config_cbs changes;
 	int ret;
 
-	if (nb_candidate_validate_yang(candidate, errmsg, sizeof(errmsg_len))
-	    != NB_OK)
+	if (nb_candidate_validate_yang(candidate, errmsg, errmsg_len) != NB_OK)
 		return NB_ERR_VALIDATION;
 
 	RB_INIT(nb_config_cbs, &changes);


### PR DESCRIPTION
This prevents caller from getting complete validation message.