### PR TITLE
bgpd: support redirect import more than one route-target ipv6

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -934,7 +934,7 @@ char *ecommunity_ecom2str(struct ecommunity *ecom, int format, int filter)
 			strlcat(str_buf, " ", str_size);
 
 		/* Retrieve value field */
-		pnt = ecom->val + (i * 8);
+		pnt = ecom->val + (i * ecom->unit_size);
 
 		/* High-order octet is the type */
 		type = *pnt++;


### PR DESCRIPTION
the fix consists in parsing the ext community list ipv6 by taking
account the size of the ecommunity val size.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>