### PR TITLE
ospfd: ospf routing table update upon Changing area from normal to nssa

### DIFF
--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -280,6 +280,19 @@ int ospf_ase_calculate_route(struct ospf *ospf, struct ospf_lsa *lsa)
 		return 0;
 	}
 
+	/* Type-5 shouldn't be calculated if it is originated from NSSA ASBR.
+	 * As per RFC 3101, expectation is to receive type-7 lsas from
+	 * NSSA ASBR. Ignore calculation, if the current LSA is type-5 and
+	 * originated ASBR's area is NSSA.
+	 */
+	if ((lsa->data->type == OSPF_AS_EXTERNAL_LSA)
+	    && (asbr_route->u.std.external_routing != OSPF_AREA_DEFAULT)) {
+		if (IS_DEBUG_OSPF(lsa, LSA))
+			zlog_debug(
+				"Route[External]: Ignore, If type-5 LSA from NSSA area.");
+		return 0;
+	}
+
 	/*     Else, this LSA describes an AS external path to destination
 	       N.  Examine the forwarding address specified in the AS-
 	       external-LSA.  This indicates the IP address to which


### PR DESCRIPTION
Description:
	When changing the area from normal to NSSA, previous area's
	ASBR router's type-5 also calculated and added to routing table along
	with Type-7 lsas.
	Made a change in route calculation such that it will not consider Type-5
	lsas in calculation if it is originated from NSSA ASBR router.
	These lsas will be age out at MAX age.

  log:
  frr(config-router)# do show ip route
	Codes: K - kernel route, C - connected, S - static, R - RIP,
         O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
         T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
         f - OpenFabric,
         > - selected route, * - FIB route, q - queued, r - rejected, b - backup
         t - trapped, o - offload failure

	K>* 0.0.0.0/0 [0/0] via 10.112.157.253, ens160, 00:32:47
	C>* 10.112.156.0/23 is directly connected, ens160, 00:32:47
	S>* 22.22.22.2/32 [1/0] is directly connected, ens192, weight 1, 00:20:03
	O>* 33.33.33.0/24 [110/20] via 100.1.1.220, ens192, weight 1, 00:08:55
				   via 100.1.1.220, ens192, weight 1, 00:08:55
	O   100.1.1.0/24 [110/10] is directly connected, ens192, weight 1, 00:21:32
	C>* 100.1.1.0/24 is directly connected, ens192, 00:23:11
  frr(config-router)# do show ip ospf  route
	============ OSPF network routing table ============
	N    100.1.1.0/24          [10] area: 0.0.0.1
                           directly attached to ens192

	============ OSPF router routing table =============
	R    2.2.2.2               [10] area: 0.0.0.1, ASBR
                           via 100.1.1.220, ens192

	============ OSPF external routing table ===========
	N E2 33.33.33.0/24         [10/20] tag: 0
                           via 100.1.1.220, ens192
                           via 100.1.1.220, ens192

Signed-off-by: Rajesh Girada <rgirada@vmware.com>