### PR TITLE
bgpd, lib: fix inconsistency of match ip/ipv6 next-hop commands

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3065,7 +3065,7 @@ static void route_match_ipv6_next_hop_free(void *rule)
 }
 
 static const struct route_map_rule_cmd route_match_ipv6_next_hop_cmd = {
-	"ipv6 next-hop",
+	"ipv6 next-hop address",
 	route_match_ipv6_next_hop,
 	route_match_ipv6_next_hop_compile,
 	route_match_ipv6_next_hop_free
@@ -6047,10 +6047,11 @@ DEFUN_YANG (no_set_aggregator_as,
 
 DEFUN_YANG (match_ipv6_next_hop,
 	    match_ipv6_next_hop_cmd,
-	    "match ipv6 next-hop X:X::X:X",
+	    "match ipv6 next-hop address X:X::X:X",
 	    MATCH_STR
 	    IPV6_STR
 	    "Match IPv6 next-hop address of route\n"
+	    "IPv6 address\n"
 	    "IPv6 address of next hop\n")
 {
 	const char *xpath =
@@ -6061,18 +6062,19 @@ DEFUN_YANG (match_ipv6_next_hop,
 	snprintf(xpath_value, sizeof(xpath_value),
 		 "%s/rmap-match-condition/frr-bgp-route-map:ipv6-address",
 		 xpath);
-	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, argv[3]->arg);
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, argv[argc - 1]->arg);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
 
 DEFUN_YANG (no_match_ipv6_next_hop,
 	    no_match_ipv6_next_hop_cmd,
-	    "no match ipv6 next-hop X:X::X:X",
+	    "no match ipv6 next-hop address X:X::X:X",
 	    NO_STR
 	    MATCH_STR
 	    IPV6_STR
 	    "Match IPv6 next-hop address of route\n"
+	    "IPv6 address\n"
 	    "IPv6 address of next hop\n")
 {
 	const char *xpath =
@@ -6081,6 +6083,23 @@ DEFUN_YANG (no_match_ipv6_next_hop,
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 	return nb_cli_apply_changes(vty, NULL);
 }
+
+ALIAS_HIDDEN (match_ipv6_next_hop,
+	      match_ipv6_next_hop_old_cmd,
+	      "match ipv6 next-hop X:X::X:X",
+	      MATCH_STR
+	      IPV6_STR
+	      "Match IPv6 next-hop address of route\n"
+	      "IPv6 address of next hop\n")
+
+ALIAS_HIDDEN (no_match_ipv6_next_hop,
+	      no_match_ipv6_next_hop_old_cmd,
+	      "no match ipv6 next-hop X:X::X:X",
+	      NO_STR
+	      MATCH_STR
+	      IPV6_STR
+	      "Match IPv6 next-hop address of route\n"
+	      "IPv6 address of next hop\n")
 
 DEFPY_YANG (match_ipv4_next_hop,
        match_ipv4_next_hop_cmd,
@@ -6648,6 +6667,8 @@ void bgp_route_map_init(void)
 
 	install_element(RMAP_NODE, &match_ipv6_next_hop_cmd);
 	install_element(RMAP_NODE, &no_match_ipv6_next_hop_cmd);
+	install_element(RMAP_NODE, &match_ipv6_next_hop_old_cmd);
+	install_element(RMAP_NODE, &no_match_ipv6_next_hop_old_cmd);
 	install_element(RMAP_NODE, &match_ipv4_next_hop_cmd);
 	install_element(RMAP_NODE, &no_match_ipv4_next_hop_cmd);
 	install_element(RMAP_NODE, &set_ipv6_nexthop_global_cmd);

--- a/bgpd/bgp_routemap_nb_config.c
+++ b/bgpd/bgp_routemap_nb_config.c
@@ -1234,7 +1234,7 @@ lib_route_map_entry_match_condition_rmap_match_condition_ipv6_address_modify(
 
 		/* Set destroy information. */
 		rhc->rhc_mhook = bgp_route_match_delete;
-		rhc->rhc_rule = "ipv6 next-hop";
+		rhc->rhc_rule = "ipv6 next-hop address";
 		rhc->rhc_event = RMAP_EVENT_MATCH_DELETED;
 
 		ret = bgp_route_match_add(rhc->rhc_rmi, rhc->rhc_rule,

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -148,7 +148,7 @@ Route Map Match Command
 
    This is a BGP specific match command. Matches the specified `ipv4_addr`.
 
-.. clicmd:: match ipv6 next-hop IPV6_ADDR
+.. clicmd:: match ipv6 next-hop address IPV6_ADDR
 
    This is a BGP specific match command. Matches the specified `ipv6_addr`.
 

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -791,12 +791,12 @@ void route_map_condition_show(struct vty *vty, const struct lyd_node *dnode,
 
 		vty_out(vty, " match extcommunity %s\n", acl);
 	} else if (IS_MATCH_IPV4_NH(condition)) {
-		vty_out(vty, " match ip next-hop %s\n",
+		vty_out(vty, " match ip next-hop address %s\n",
 			yang_dnode_get_string(
 				dnode,
 				"./rmap-match-condition/frr-bgp-route-map:ipv4-address"));
 	} else if (IS_MATCH_IPV6_NH(condition)) {
-		vty_out(vty, " match ipv6 next-hop %s\n",
+		vty_out(vty, " match ipv6 next-hop address %s\n",
 			yang_dnode_get_string(
 				dnode,
 				"./rmap-match-condition/frr-bgp-route-map:ipv6-address"));


### PR DESCRIPTION
For IPv4 matching, we have "match ip next-hop address A.B.C.D".
For IPv6 matching, we have "match ipv6 next-hop X:X::X:X".

To have consistency, let's add "address" keyword to IPv6 commands.
Old commands are preserved as hidden for backward compatibility.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>