### PR TITLE
tests: Explicitly call out which version of python we need

### DIFF
--- a/tests/topotests/bgp_ecmp_topo1/peer1/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer1/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer10/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer10/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer11/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer11/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer12/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer12/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer13/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer13/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer14/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer14/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer15/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer15/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer16/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer16/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer17/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer17/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer18/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer18/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer19/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer19/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer2/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer2/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer20/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer20/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer3/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer3/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer4/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer4/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer5/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer5/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer6/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer6/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer7/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer7/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer8/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer8/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/peer9/exa-send.py
+++ b/tests/topotests/bgp_ecmp_topo1/peer9/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_ecmp_topo1/test_bgp_ecmp_topo1.py
+++ b/tests/topotests/bgp_ecmp_topo1/test_bgp_ecmp_topo1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #
 # test_bgp_ecmp_topo1.py

--- a/tests/topotests/bgp_multiview_topo1/peer1/exa-send.py
+++ b/tests/topotests/bgp_multiview_topo1/peer1/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_multiview_topo1/peer2/exa-send.py
+++ b/tests/topotests/bgp_multiview_topo1/peer2/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_multiview_topo1/peer3/exa-send.py
+++ b/tests/topotests/bgp_multiview_topo1/peer3/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_multiview_topo1/peer4/exa-send.py
+++ b/tests/topotests/bgp_multiview_topo1/peer4/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_multiview_topo1/peer5/exa-send.py
+++ b/tests/topotests/bgp_multiview_topo1/peer5/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_multiview_topo1/peer6/exa-send.py
+++ b/tests/topotests/bgp_multiview_topo1/peer6/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_multiview_topo1/peer7/exa-send.py
+++ b/tests/topotests/bgp_multiview_topo1/peer7/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_multiview_topo1/peer8/exa-send.py
+++ b/tests/topotests/bgp_multiview_topo1/peer8/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/bgp_peer_type_multipath_relax/peer1/exa_readpipe.py
+++ b/tests/topotests/bgp_peer_type_multipath_relax/peer1/exa_readpipe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 "Helper script to read api commands from a pipe and feed them to ExaBGP"
 
 import sys

--- a/tests/topotests/bgp_peer_type_multipath_relax/peer2/exa_readpipe.py
+++ b/tests/topotests/bgp_peer_type_multipath_relax/peer2/exa_readpipe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 "Helper script to read api commands from a pipe and feed them to ExaBGP"
 
 import sys

--- a/tests/topotests/bgp_peer_type_multipath_relax/peer3/exa_readpipe.py
+++ b/tests/topotests/bgp_peer_type_multipath_relax/peer3/exa_readpipe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 "Helper script to read api commands from a pipe and feed them to ExaBGP"
 
 import sys

--- a/tests/topotests/bgp_peer_type_multipath_relax/peer4/exa_readpipe.py
+++ b/tests/topotests/bgp_peer_type_multipath_relax/peer4/exa_readpipe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 "Helper script to read api commands from a pipe and feed them to ExaBGP"
 
 import sys

--- a/tests/topotests/bgp_vrf_netns/peer1/exa-send.py
+++ b/tests/topotests/bgp_vrf_netns/peer1/exa-send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 exa-send.py: Send a few testroutes with ExaBGP

--- a/tests/topotests/pim_basic/mcast-rx.py
+++ b/tests/topotests/pim_basic/mcast-rx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # mcast-rx.py
 #

--- a/tests/topotests/pim_basic/mcast-tx.py
+++ b/tests/topotests/pim_basic/mcast-tx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # mcast-tx.py
 #


### PR DESCRIPTION
Not all test systems have a specific python executable
they have python2 or python3.  Let's call out explicitly
which one we want here.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>