### PR TITLE
lib, yang: remove vrf from the interface list key

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -690,15 +690,10 @@ DEFUN_YANG (no_vrf,
 
 	if (vrf_get_backend() == VRF_BACKEND_VRF_LITE) {
 		/*
-		 * Remove the VRF interface config. Currently, we allow to
-		 * remove only inactive VRFs, so we use VRF_DEFAULT_NAME here,
-		 * because when the VRF is removed from kernel, the interface
-		 * is moved to the default VRF. If we ever allow removing
-		 * active VRFs, this code have to be updated accordingly.
+		 * Remove the VRF interface config when removing the VRF.
 		 */
 		snprintf(xpath_list, sizeof(xpath_list),
-			 "/frr-interface:lib/interface[name='%s'][vrf='%s']",
-			 vrfname, VRF_DEFAULT_NAME);
+			 "/frr-interface:lib/interface[name='%s']", vrfname);
 		nb_cli_enqueue_change(vty, xpath_list, NB_OP_DESTROY, NULL);
 	}
 

--- a/yang/frr-interface.yang
+++ b/yang/frr-interface.yang
@@ -288,13 +288,11 @@ module frr-interface {
 
   container lib {
     list interface {
-      key "name vrf";
+      key "name";
       description
         "Interface.";
       leaf name {
-        type string {
-          length "1..16";
-        }
+        type string;
         description
           "Interface name.";
       }
@@ -303,6 +301,7 @@ module frr-interface {
         type frr-vrf:vrf-ref;
         description
           "VRF this interface is associated with.";
+        config false;
       }
 
       leaf description {

--- a/yang/ietf/frr-ietf-translator.json
+++ b/yang/ietf/frr-ietf-translator.json
@@ -3,20 +3,6 @@
     "family": "ietf",
     "module": [
       {
-        "name": "ietf-interfaces@2018-01-09",
-        "deviations": "frr-deviations-ietf-interfaces",
-        "mappings": [
-          {
-            "custom": "/ietf-interfaces:interfaces/interface[name='KEY1']",
-            "native": "/frr-interface:lib/interface[name='KEY1'][vrf='default']"
-          },
-          {
-            "custom": "/ietf-interfaces:interfaces/interface[name='KEY1']/description",
-            "native": "/frr-interface:lib/interface[name='KEY1'][vrf='default']/description"
-          }
-        ]
-      },
-      {
         "name": "ietf-routing@2018-01-25",
         "deviations": "frr-deviations-ietf-routing",
         "mappings": [
@@ -60,7 +46,7 @@
           },
           {
             "custom": "/ietf-routing:routing/control-plane-protocols/control-plane-protocol[type='ietf-rip:ripv2'][name='main']/ietf-rip:rip/interfaces/interface[interface='KEY1']/split-horizon",
-            "native": "/frr-interface:lib/interface[name='KEY1'][vrf='default']/frr-ripd:rip/split-horizon"
+            "native": "/frr-interface:lib/interface[name='KEY1']/frr-ripd:rip/split-horizon"
           },
           {
             "custom": "/ietf-routing:routing/control-plane-protocols/control-plane-protocol[type='ietf-rip:ripv2'][name='main']/ietf-rip:rip/ipv4/neighbors/neighbor[ipv4-address='KEY1']",


### PR DESCRIPTION
This is needed for the following two reasons:

1. To be able to remove the northbound HACK in if_update_to_new_vrf. It
   is totally wrong to rewrite the configuration datastore when some
   operational state changes. It is a hard blocker for storing a
   configuration data in a management daemon which knows nothing about
   the operational state.
2. To allow changing the VRF of the interface using FRR CLI or any other
   frontend in the future. If the VRF is a part of the key, it can't be
   changed. If the VRF is a simple leaf, it becomes possible to change
   it and thus move the interface between VRFs. For now I mark the leaf
   as a "config false" as it's not yet possible to control it from FRR.

But we can't simply remove the VRF from the key, because it is needed to
distinguish interfaces when using netns based VRFs, as it is possible to
have multiple interfaces with the same name in different namespaces. To
handle this, I came up with an idea to store both VRF and an interface
name in the "name" leaf using the pattern "vrfname:ifname". For example,
if there's an interface "eth0" in VRF "red" then its "name" leaf will be
"red:eth0".


Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>