### PR TITLE
ospf6d: Remove ospf6->external_id_table

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1410,7 +1410,6 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 	struct ospf6_route *route, *match;
 	struct ospf6_external_info *info;
 	struct prefix prefix_id;
-	struct route_node *node;
 	char ibuf[16];
 	struct ospf6_redist *red;
 
@@ -1496,13 +1495,6 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 			ospf6_route_add_nexthop(match, ifindex, nexthop);
 		else
 			ospf6_route_add_nexthop(match, ifindex, NULL);
-
-		/* create/update binding in external_id_table */
-		prefix_id.family = AF_INET;
-		prefix_id.prefixlen = IPV4_MAX_BITLEN;
-		prefix_id.u.prefix4.s_addr = htonl(info->id);
-		node = route_node_get(ospf6->external_id_table, &prefix_id);
-		node->info = match;
 
 		if (IS_OSPF6_DEBUG_ASBR) {
 			inet_ntop(AF_INET, &prefix_id.u.prefix4, ibuf,
@@ -2787,7 +2779,6 @@ static void ospf6_originate_new_aggr_lsa(struct ospf6 *ospf6,
 					 struct ospf6_external_aggr_rt *aggr)
 {
 	struct prefix prefix_id;
-	struct route_node *node;
 	struct ospf6_lsa *lsa = NULL;
 
 	if (IS_OSPF6_DEBUG_AGGR)
@@ -2795,13 +2786,6 @@ static void ospf6_originate_new_aggr_lsa(struct ospf6 *ospf6,
 			   &aggr->p);
 
 	aggr->id = ospf6->external_id++;
-
-	/* create/update binding in external_id_table */
-	prefix_id.family = AF_INET;
-	prefix_id.prefixlen = 32;
-	prefix_id.u.prefix4.s_addr = htonl(aggr->id);
-	node = route_node_get(ospf6->external_id_table, &prefix_id);
-	node->info = aggr;
 
 	if (IS_OSPF6_DEBUG_AGGR)
 		zlog_debug(
@@ -3014,8 +2998,6 @@ static void ospf6_aggr_handle_external_info(void *data)
 	struct ospf6_lsa *lsa = NULL;
 	struct ospf6_external_info *info;
 	struct ospf6 *ospf6 = NULL;
-	struct prefix prefix_id;
-	struct route_node *node;
 
 	rt->aggr_route = NULL;
 
@@ -3054,13 +3036,6 @@ static void ospf6_aggr_handle_external_info(void *data)
 
 	info->id  = ospf6->external_id++;
 	rt->path.origin.id = htonl(info->id);
-
-	/* create/update binding in external_id_table */
-	prefix_id.family = AF_INET;
-	prefix_id.prefixlen = 32;
-	prefix_id.u.prefix4.s_addr = htonl(info->id);
-	node = route_node_get(ospf6->external_id_table, &prefix_id);
-	node->info = rt;
 
 	(void)ospf6_originate_type5_type7_lsas(rt, ospf6);
 }
@@ -3642,7 +3617,6 @@ void ospf6_handle_external_lsa_origination(struct ospf6 *ospf6,
 	struct ospf6_external_aggr_rt *aggr;
 	struct ospf6_external_info *info;
 	struct prefix prefix_id;
-	struct route_node *node;
 
 	if (!is_default_prefix(p)) {
 		aggr = ospf6_external_aggr_match(ospf6,
@@ -3678,14 +3652,6 @@ void ospf6_handle_external_lsa_origination(struct ospf6 *ospf6,
 	 */
 	if (!info->id) {
 		info->id = ospf6->external_id++;
-
-		/* create/update binding in external_id_table */
-		prefix_id.family = AF_INET;
-		prefix_id.prefixlen = 32;
-		prefix_id.u.prefix4.s_addr = htonl(info->id);
-		node = route_node_get(ospf6->external_id_table, &prefix_id);
-		node->info = rt;
-
 	} else {
 		prefix_id.family = AF_INET;
 		prefix_id.prefixlen = 32;

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -151,24 +151,6 @@ void ospf6_lsa_originate_interface(struct ospf6_lsa *lsa,
 	ospf6_lsa_originate(oi->area->ospf6, lsa);
 }
 
-void ospf6_remove_id_from_external_id_table(struct ospf6 *ospf6,
-						uint32_t id)
-{
-	struct prefix prefix_id;
-	struct route_node *node;
-
-	/* remove binding in external_id_table */
-	prefix_id.family = AF_INET;
-	prefix_id.prefixlen = 32;
-	prefix_id.u.prefix4.s_addr = id;
-	node = route_node_lookup(ospf6->external_id_table, &prefix_id);
-	assert(node);
-	node->info = NULL;
-	route_unlock_node(node); /* to free the lookup lock */
-	route_unlock_node(node); /* to free the original lock */
-
-}
-
 void ospf6_external_lsa_purge(struct ospf6 *ospf6, struct ospf6_lsa *lsa)
 {
 	uint32_t id = lsa->header->id;
@@ -176,8 +158,6 @@ void ospf6_external_lsa_purge(struct ospf6 *ospf6, struct ospf6_lsa *lsa)
 	struct listnode *lnode;
 
 	ospf6_lsa_purge(lsa);
-
-	ospf6_remove_id_from_external_id_table(ospf6, id);
 
 	/* Delete the corresponding NSSA LSA */
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, lnode, oa)) {

--- a/ospf6d/ospf6_flood.h
+++ b/ospf6d/ospf6_flood.h
@@ -39,8 +39,6 @@ extern void ospf6_lsa_originate_area(struct ospf6_lsa *lsa,
 				     struct ospf6_area *oa);
 extern void ospf6_lsa_originate_interface(struct ospf6_lsa *lsa,
 					  struct ospf6_interface *oi);
-void ospf6_remove_id_from_external_id_table(struct ospf6 *ospf6,
-						uint32_t id);
 void ospf6_external_lsa_purge(struct ospf6 *ospf6, struct ospf6_lsa *lsa);
 extern void ospf6_lsa_purge(struct ospf6_lsa *lsa);
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -423,7 +423,6 @@ static struct ospf6 *ospf6_create(const char *name)
 	 * 1::1, this happened because of LS ID 0.
 	 */
 	o->external_id = OSPF6_EXT_INIT_LS_ID;
-	o->external_id_table = route_table_init();
 
 	o->write_oi_count = OSPF6_WRITE_INTERFACE_COUNT_DEFAULT;
 	o->ref_bandwidth = OSPF6_REFERENCE_BANDWIDTH;
@@ -515,7 +514,6 @@ void ospf6_delete(struct ospf6 *o)
 	ospf6_route_table_delete(o->brouter_table);
 
 	ospf6_route_table_delete(o->external_table);
-	route_table_finish(o->external_id_table);
 
 	ospf6_distance_reset(o);
 	route_table_finish(o->distance_table);

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -136,7 +136,6 @@ struct ospf6 {
 	struct ospf6_route_table *brouter_table;
 
 	struct ospf6_route_table *external_table;
-	struct route_table *external_id_table;
 #define OSPF6_EXT_INIT_LS_ID 1
 	uint32_t external_id;
 


### PR DESCRIPTION
The external_id_table was only ever used to store pointers to data
and was never used for lookup during the course of normal operations.
However it did lead to crashes because somewhere along the way
external routes stored in the external_table never had their
id associated into the external_id_table and we would assert
on the node lookup failing.

Since this code was never used for anything other than
storing data and it was never retrieved for anything useful
let's just remove it from ospf6d.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>