### PR TITLE
tests: Add aggressive timers to the new route server client test

### DIFF
--- a/tests/topotests/bgp_route_server_client/r1/bgpd.conf
+++ b/tests/topotests/bgp_route_server_client/r1/bgpd.conf
@@ -3,6 +3,7 @@ router bgp 65001
  bgp router-id 10.10.10.1
  no bgp ebgp-requires-policy
  neighbor 2001:db8:1::1 remote-as external
+ neighbor 2001:db8:1::1 timers 3 10
  address-family ipv6 unicast
   redistribute connected
   neighbor 2001:db8:1::1 activate

--- a/tests/topotests/bgp_route_server_client/r2/bgpd.conf
+++ b/tests/topotests/bgp_route_server_client/r2/bgpd.conf
@@ -2,7 +2,9 @@ router bgp 65000 view RS
  bgp router-id 10.10.10.2
  no bgp ebgp-requires-policy
  neighbor 2001:db8:1::2 remote-as external
+ neighbor 2001:db8:1::2 timers 3 10
  neighbor 2001:db8:3::2 remote-as external
+ neighbor 2001:db8:3::2 timers 3 10
  address-family ipv6 unicast
   redistribute connected
   neighbor 2001:db8:1::2 activate

--- a/tests/topotests/bgp_route_server_client/r3/bgpd.conf
+++ b/tests/topotests/bgp_route_server_client/r3/bgpd.conf
@@ -3,6 +3,7 @@ router bgp 65003
  bgp router-id 10.10.10.3
  no bgp ebgp-requires-policy
  neighbor 2001:db8:3::1 remote-as external
+ neighbor 2001:db8:3::1 timers 3 10
  address-family ipv6 unicast
   redistribute connected
   neighbor 2001:db8:3::1 activate


### PR DESCRIPTION
The new bgp_route_server_client test is not setting the
timers for peers to be fast enough to have the ability
to converge in under 60 seconds if a packet is dropped/missed
at startup.  Make the test have the ability to converge
under load

Signed-off-by: Donald Sharp <sharpd@nvidia.com>