### PR TITLE
Ospf test cleanup

### DIFF
--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -265,35 +265,6 @@ def __create_ospf_global(tgen, input_dict, router, build, load_config, ospf):
                 cmd = "no {}".format(cmd)
             config_data.append(cmd)
 
-    # area interface information for ospf6d only
-    if ospf == "ospf6":
-        area_iface = ospf_data.setdefault("neighbors", {})
-        if area_iface:
-            for neighbor in area_iface:
-                if "area" in area_iface[neighbor]:
-                    iface = input_dict[router]["links"][neighbor]["interface"]
-                    cmd = "interface {} area {}".format(
-                        iface, area_iface[neighbor]["area"]
-                    )
-                    if area_iface[neighbor].setdefault("delete", False):
-                        cmd = "no {}".format(cmd)
-                    config_data.append(cmd)
-
-                try:
-                    if "area" in input_dict[router]["links"][neighbor]["ospf6"]:
-                        iface = input_dict[router]["links"][neighbor]["interface"]
-                        cmd = "interface {} area {}".format(
-                            iface,
-                            input_dict[router]["links"][neighbor]["ospf6"]["area"],
-                        )
-                        if input_dict[router]["links"][neighbor].setdefault(
-                            "delete", False
-                        ):
-                            cmd = "no {}".format(cmd)
-                        config_data.append(cmd)
-                except KeyError:
-                    pass
-
     # summary information
     summary_data = ospf_data.setdefault("summary-address", {})
     if summary_data:

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -334,69 +334,6 @@ def __create_ospf_global(tgen, input_dict, router, build, load_config, ospf):
     return config_data
 
 
-def create_router_ospf6(
-    tgen, topo=None, input_dict=None, build=False, load_config=True
-):
-    """
-    API to configure ospf on router
-
-    Parameters
-    ----------
-    * `tgen` : Topogen object
-    * `topo` : json file data
-    * `input_dict` : Input dict data, required when configuring from testcase
-    * `build` : Only for initial setup phase this is set as True.
-
-    Usage
-    -----
-    input_dict = {
-        "r1": {
-            "ospf6": {
-                "router_id": "22.22.22.22",
-        }
-    }
-
-    Returns
-    -------
-    True or False
-    """
-    logger.debug("Entering lib API: create_router_ospf6()")
-    result = False
-
-    if topo is None:
-        topo = tgen.json_topo
-
-    if not input_dict:
-        input_dict = deepcopy(topo)
-    else:
-        topo = topo["routers"]
-        input_dict = deepcopy(input_dict)
-
-    config_data_dict = {}
-
-    for router in input_dict.keys():
-        if "ospf6" not in input_dict[router]:
-            logger.debug("Router %s: 'ospf6' not present in input_dict", router)
-            continue
-
-        config_data = __create_ospf_global(
-            tgen, input_dict, router, build, load_config, "ospf6"
-        )
-        if config_data:
-            config_data_dict[router] = config_data
-
-    try:
-        result = create_common_configurations(
-            tgen, config_data_dict, "ospf6", build, load_config
-        )
-    except InvalidCLIError:
-        logger.error("create_router_ospf6", exc_info=True)
-        result = False
-
-    logger.debug("Exiting lib API: create_router_ospf6()")
-    return result
-
-
 def config_ospf_interface(
     tgen, topo=None, input_dict=None, build=False, load_config=True
 ):

--- a/tests/topotests/lib/topojson.py
+++ b/tests/topotests/lib/topojson.py
@@ -352,6 +352,18 @@ def build_config_from_json(tgen, topo=None, save_bkup=True):
         logger.info("build_config_from_json: failed to configure topology")
         pytest.exit(1)
 
+    logger.info("Built config now clearing ospf neighbors as that router-id might not be what is used")
+    for ospf in ["ospf", "ospf6"]:
+        for router in data:
+            if ospf not in data[router]:
+                continue
+
+            r = tgen.gears[router]
+            if ospf == "ospf":
+                r.vtysh_cmd("clear ip ospf process")
+            else:
+                r.vtysh_cmd("clear ipv6 ospf6 process")
+
 
 def create_tgen_from_json(testfile, json_file=None):
     """Create a topogen object given a testfile.

--- a/tests/topotests/lib/topojson.py
+++ b/tests/topotests/lib/topojson.py
@@ -40,7 +40,7 @@ from lib.common_config import (
     topo_daemons,
     number_to_column,
 )
-from lib.ospf import create_router_ospf, create_router_ospf6
+from lib.ospf import create_router_ospf
 from lib.pim import create_igmp_config, create_pim_config
 from lib.topolog import logger
 
@@ -334,7 +334,6 @@ def build_config_from_json(tgen, topo=None, save_bkup=True):
             ("igmp", create_igmp_config),
             ("bgp", create_router_bgp),
             ("ospf", create_router_ospf),
-            ("ospf6", create_router_ospf6),
         ]
     )
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -408,7 +408,7 @@ def test_ospf_lan_tc1_p0(request):
     topo_modify_change_ip = deepcopy(topo)
     intf_ip = topo_modify_change_ip["routers"]["r0"]["links"]["s1"]["ipv4"]
     topo_modify_change_ip["routers"]["r0"]["links"]["s1"]["ipv4"] = str(
-        IPv4Address(frr_unicode(intf_ip.split("/")[0])) + 3
+        IPv4Address(frr_unicode(intf_ip.split("/")[0])) + 4
     ) + "/{}".format(intf_ip.split("/")[1])
 
     build_config_from_json(tgen, topo_modify_change_ip, save_bkup=False)

--- a/tests/topotests/ospf_dual_stack/test_ospf_dual_stack.json
+++ b/tests/topotests/ospf_dual_stack/test_ospf_dual_stack.json
@@ -23,7 +23,8 @@
                     },
                      "ospf6": {
                         "hello_interval": 1,
-                        "dead_interval": 4
+                        "dead_interval": 4,
+                        "area": "1.1.1.1"
                     }
                }
             },
@@ -36,9 +37,7 @@
             "ospf6": {
                 "router_id": "1.1.1.1",
                 "neighbors": {
-                    "r3": {
-                        "area": "1.1.1.1"
-                    }
+                    "r3": {}
                 }
             }
         },
@@ -56,7 +55,8 @@
                     "ospf6": {
                         "hello_interval": 1,
                         "dead_interval": 4,
-                        "network": "point-to-point"
+                        "network": "point-to-point",
+                        "area": "1.1.1.1"
                     }
                 },
                 "r4": {
@@ -71,7 +71,8 @@
                     "ospf6": {
                         "hello_interval": 1,
                         "dead_interval": 4,
-                        "network": "point-to-point"
+                        "network": "point-to-point",
+                        "area": "0.0.0.0"
                     }
                 }
             },
@@ -85,8 +86,8 @@
             "ospf6": {
                 "router_id": "2.2.2.2",
                 "neighbors": {
-                    "r3": { "area": "1.1.1.1" },
-                    "r4": { "area": "0.0.0.0" }
+                    "r3": {},
+                    "r4": {}
                 }
             }
         },
@@ -104,7 +105,8 @@
                     "ospf6": {
                         "hello_interval": 1,
                         "dead_interval": 4,
-                        "network": "point-to-point"
+                        "network": "point-to-point",
+                        "area": "1.1.1.1"
                     }
                 },
                 "r2": {
@@ -119,7 +121,8 @@
                     "ospf6": {
                         "hello_interval": 1,
                         "dead_interval": 4,
-                        "network": "point-to-point"
+                        "network": "point-to-point",
+                        "area": "1.1.1.1"
                     }
                 },
                 "r4": {
@@ -134,7 +137,8 @@
                     "ospf6": {
                         "hello_interval": 1,
                         "dead_interval": 4,
-                        "network": "point-to-point"
+                        "network": "point-to-point",
+                        "area": "0.0.0.0"
                     }
                 }
             },
@@ -149,9 +153,9 @@
             "ospf6": {
                 "router_id": "3.3.3.3",
                 "neighbors": {
-                    "r1": { "area": "1.1.1.1" },
-                    "r2": { "area": "1.1.1.1" },
-                    "r4": { "area": "0.0.0.0" }
+                    "r1": {},
+                    "r2": {},
+                    "r4": {}
                 }
             }
         },
@@ -169,7 +173,8 @@
                     "ospf6": {
                         "hello_interval": 1,
                         "dead_interval": 4,
-                        "network": "point-to-point"
+                        "network": "point-to-point",
+                        "area": "0.0.0.0"
                     }
                 },
                 "r3": {
@@ -184,7 +189,8 @@
                     "ospf6": {
                         "hello_interval": 1,
                         "dead_interval": 4,
-                        "network": "point-to-point"
+                        "network": "point-to-point",
+                        "area": "0.0.0.0"
                     }
                 },
                 "r5": {
@@ -199,7 +205,8 @@
                     "ospf6": {
                         "hello_interval": 1,
                         "dead_interval": 4,
-                        "network": "point-to-point"
+                        "network": "point-to-point",
+                        "area": "2.2.2.2"
                     }
                 }
             },
@@ -214,9 +221,9 @@
             "ospf6": {
                 "router_id": "4.4.4.4",
                 "neighbors": {
-                    "r2": { "area": "0.0.0.0" },
-                    "r3": { "area": "0.0.0.0" },
-                    "r5": { "area": "2.2.2.2" }
+                    "r2": {},
+                    "r3": {},
+                    "r5": {}
                 }
             }
         },
@@ -234,7 +241,8 @@
                     "ospf6": {
                         "hello_interval": 1,
                         "dead_interval": 4,
-                        "network": "point-to-point"
+                        "network": "point-to-point",
+                        "area": "2.2.2.2"
                     }
                 }
             },
@@ -247,7 +255,7 @@
             "ospf6": {
                 "router_id": "5.5.5.5",
                 "neighbors": {
-                    "r4": { "area": "2.2.2.2" }
+                    "r4": {}
                 }
             }
         }


### PR DESCRIPTION
See individual commits, but the gist of all this started when I had ospf tests failing because the router-id that was being looked for had already been decided by the time the test issued a `router <ospf|ospf6>\nrouter-id A.B.C.D`.  Operationally ospf was not reseting the router id and tests were failing.  

So when we create router config, let's automatically reset the peering so that we don't have to worry about this anymore