### PR TITLE
bfdd: fix detection timeout update

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1226,27 +1226,6 @@ void bs_final_handler(struct bfd_session *bs)
 	/* Apply new transmission timer immediately. */
 	ptm_bfd_start_xmt_timer(bs, false);
 
-	/*
-	 * Detection timeout calculation:
-	 * The minimum detection timeout is the remote detection
-	 * multipler (number of packets to be missed) times the agreed
-	 * transmission interval.
-	 *
-	 * RFC 5880, Section 6.8.4.
-	 *
-	 * TODO: support sending/counting more packets inside detection
-	 * timeout.
-	 */
-	if (bs->timers.required_min_rx > bs->remote_timers.desired_min_tx)
-		bs->detect_TO = bs->remote_detect_mult
-				* bs->timers.required_min_rx;
-	else
-		bs->detect_TO = bs->remote_detect_mult
-				* bs->remote_timers.desired_min_tx;
-
-	/* Apply new receive timer immediately. */
-	bfd_recvtimer_update(bs);
-
 	/* Notify watchers about changed timers. */
 	control_notify_config(BCM_NOTIFY_CONFIG_UPDATE, bs);
 }


### PR DESCRIPTION
Per RFC 5880 section 6.8.12, the use of a Poll Sequence is not necessary
when the Detect Multiplier is changed. Currently, we update the Detection
Timeout only when a Poll Sequence is terminated, therefore we ignore the
Detect Multiplier change if it's not accompanied with RX/TX timer change.
To fix the problem, we should update the Detection Timeout on every
received packet.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>