### PR TITLE
pimd: removing no caller functions

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -828,26 +828,6 @@ void pim_if_addr_del_all_igmp(struct interface *ifp)
 	}
 }
 
-void pim_if_addr_del_all_pim(struct interface *ifp)
-{
-	struct connected *ifc;
-	struct listnode *node;
-	struct listnode *nextnode;
-
-	/* PIM/IGMP enabled ? */
-	if (!ifp->info)
-		return;
-
-	for (ALL_LIST_ELEMENTS(ifp->connected, node, nextnode, ifc)) {
-		struct prefix *p = ifc->address;
-
-		if (p->family != AF_INET)
-			continue;
-
-		pim_if_addr_del_pim(ifc);
-	}
-}
-
 struct in_addr pim_find_primary_addr(struct interface *ifp)
 {
 	struct connected *ifc;

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -193,7 +193,6 @@ void pim_if_addr_del(struct connected *ifc, int force_prim_as_any);
 void pim_if_addr_add_all(struct interface *ifp);
 void pim_if_addr_del_all(struct interface *ifp);
 void pim_if_addr_del_all_igmp(struct interface *ifp);
-void pim_if_addr_del_all_pim(struct interface *ifp);
 
 int pim_if_add_vif(struct interface *ifp, bool ispimreg, bool is_vxlan_term);
 int pim_if_del_vif(struct interface *ifp);

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1567,10 +1567,3 @@ void pim_ifchannel_set_star_g_join_state(struct pim_ifchannel *ch, int eom,
 	if (send_upstream_starg)
 		pim_jp_agg_single_upstream_send(&starup->rpf, starup, true);
 }
-
-unsigned int pim_ifchannel_hash_key(const void *arg)
-{
-	const struct pim_ifchannel *ch = arg;
-
-	return jhash_2words(ch->sg.src.s_addr, ch->sg.grp.s_addr, 0);
-}

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -160,6 +160,5 @@ void pim_ifchannel_set_star_g_join_state(struct pim_ifchannel *ch, int eom,
 int pim_ifchannel_compare(const struct pim_ifchannel *ch1,
 			  const struct pim_ifchannel *ch2);
 
-unsigned int pim_ifchannel_hash_key(const void *arg);
 void delete_on_noinfo(struct pim_ifchannel *ch);
 #endif /* PIM_IFCHANNEL_H */

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -141,18 +141,6 @@ struct igmp_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
 	return NULL;
 }
 
-struct igmp_sock *igmp_sock_lookup_by_fd(struct list *igmp_sock_list, int fd)
-{
-	struct listnode *sock_node;
-	struct igmp_sock *igmp;
-
-	for (ALL_LIST_ELEMENTS_RO(igmp_sock_list, sock_node, igmp))
-		if (fd == igmp->fd)
-			return igmp;
-
-	return NULL;
-}
-
 static int pim_igmp_other_querier_expire(struct thread *t)
 {
 	struct igmp_sock *igmp;

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -110,7 +110,6 @@ void pim_igmp_if_fini(struct pim_interface *pim_ifp);
 
 struct igmp_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
 					      struct in_addr ifaddr);
-struct igmp_sock *igmp_sock_lookup_by_fd(struct list *igmp_sock_list, int fd);
 struct igmp_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
 				    struct in_addr ifaddr,
 				    struct interface *ifp,


### PR DESCRIPTION
Removing the no caller function declarations and definitions
in pimd directory.

Signed-off-by: Sai Gomathi <nsaigomathi@vmware.com>