### PR TITLE
pimd: fix igmp user config

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -371,14 +371,6 @@ static void igmp_sock_query_interval_reconfig(struct igmp_sock *igmp)
 	struct pim_interface *pim_ifp;
 
 	assert(igmp);
-
-	/* other querier present? */
-
-	if (igmp->t_other_querier_timer)
-		return;
-
-	/* this is the querier */
-
 	assert(igmp->interface);
 	assert(igmp->interface->info);
 


### PR DESCRIPTION
user config should go ahead no matter it is a query router or not

Signed-off-by: ron lyq140hf2006@163.com