### PR TITLE
tests: Allow ripng_topo1 to converge a bit faster

### DIFF
--- a/tests/topotests/ripng_topo1/r1/ripng_status.ref
+++ b/tests/topotests/ripng_topo1/r1/ripng_status.ref
@@ -1,5 +1,5 @@
 Routing Protocol is "RIPng"
-  Sending updates every 5 seconds with +/-50%, next due in XX seconds
+  Sending updates every 1 seconds with +/-50%, next due in XX seconds
   Timeout after 180 seconds, garbage collect after 5 seconds
   Outgoing update filter list for all interface is not set
   Incoming update filter list for all interface is not set

--- a/tests/topotests/ripng_topo1/r1/ripngd.conf
+++ b/tests/topotests/ripng_topo1/r1/ripngd.conf
@@ -5,7 +5,7 @@ log file ripngd.log
 ! debug ripng zebra
 !
 router ripng
- timers basic 5 180 5
+ timers basic 1 180 5
  network fc00:5::/64
  network r1-eth2
  network r1-eth3

--- a/tests/topotests/ripng_topo1/r2/ripng_status.ref
+++ b/tests/topotests/ripng_topo1/r2/ripng_status.ref
@@ -1,5 +1,5 @@
 Routing Protocol is "RIPng"
-  Sending updates every 5 seconds with +/-50%, next due in XX seconds
+  Sending updates every 1 seconds with +/-50%, next due in XX seconds
   Timeout after 180 seconds, garbage collect after 5 seconds
   Outgoing update filter list for all interface is not set
   Incoming update filter list for all interface is not set

--- a/tests/topotests/ripng_topo1/r2/ripngd.conf
+++ b/tests/topotests/ripng_topo1/r2/ripngd.conf
@@ -5,7 +5,7 @@ log file ripngd.log
 ! debug ripng zebra
 !
 router ripng
- timers basic 5 180 5
+ timers basic 1 180 5
  network fc00:5::/64
  network fc00:6::/62
 !

--- a/tests/topotests/ripng_topo1/r3/ripng_status.ref
+++ b/tests/topotests/ripng_topo1/r3/ripng_status.ref
@@ -1,5 +1,5 @@
 Routing Protocol is "RIPng"
-  Sending updates every 5 seconds with +/-50%, next due in XX seconds
+  Sending updates every 1 seconds with +/-50%, next due in XX seconds
   Timeout after 180 seconds, garbage collect after 5 seconds
   Outgoing update filter list for all interface is not set
   Incoming update filter list for all interface is not set

--- a/tests/topotests/ripng_topo1/r3/ripngd.conf
+++ b/tests/topotests/ripng_topo1/r3/ripngd.conf
@@ -5,7 +5,7 @@ log file ripngd.log
 ! debug ripng zebra
 !
 router ripng
- timers basic 5 180 5
+ timers basic 1 180 5
  network fc00:6::/62
  redistribute connected
  redistribute static


### PR DESCRIPTION
Modify the timers uses to send updates/hello's every
1 seconds instead of 5.  Allowing this test to converge
faster under heavy system load.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>