### PR TITLE
vtysh: add missing rpki node when showing config

### DIFF
--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -433,6 +433,8 @@ void vtysh_config_parse_line(void *arg, const char *line)
 			config = config_get(SEGMENT_ROUTING_NODE, line);
 		else if (strncmp(line, "bfd", strlen("bfd")) == 0)
 			config = config_get(BFD_NODE, line);
+		else if (strncmp(line, "rpki", strlen("rpki")) == 0)
+			config = config_get(RPKI_NODE, line);
 		else {
 			if (strncmp(line, "log", strlen("log")) == 0
 			    || strncmp(line, "hostname", strlen("hostname")) == 0


### PR DESCRIPTION
Before:
```
frr version 8.2-dev
frr defaults traditional
hostname frr
rpki
 rpki polling_period 20
 rpki cache 192.0.2.1 8080 preference 1
service integrated-vtysh-config
!
```

After:
```
frr version 8.2-dev
frr defaults traditional
hostname frr
service integrated-vtysh-config
!
rpki
 rpki polling_period 20
 rpki cache 192.0.2.1 8080 preference 1
exit
!
```

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>