### PR TITLE
tests: Allow interface statistics to be gathered with some delay

### DIFF
--- a/tests/topotests/lib/pim.py
+++ b/tests/topotests/lib/pim.py
@@ -21,8 +21,10 @@ import os
 import re
 import sys
 import traceback
+import functools
 from copy import deepcopy
 from time import sleep
+from lib import topotest
 
 
 # Import common_config to use commomnly used APIs
@@ -1481,24 +1483,34 @@ def verify_pim_interface_traffic(tgen, input_dict):
         rnode = tgen.routers()[dut]
 
         logger.info("[DUT: %s]: Verifying pim interface traffic", dut)
-        show_pim_intf_traffic_json = run_frr_cmd(
-            rnode, "show ip pim interface traffic json", isjson=True
+
+        def show_pim_intf_traffic(rnode, dut, input_dict, output_dict):
+            show_pim_intf_traffic_json = run_frr_cmd(
+                rnode, "show ip pim interface traffic json", isjson=True
+            )
+
+            output_dict[dut] = {}
+            for intf, data in input_dict[dut].items():
+                interface_json = show_pim_intf_traffic_json[intf]
+                for state in data:
+
+                    # Verify Tx/Rx
+                    if state in interface_json:
+                        output_dict[dut][state] = interface_json[state]
+                    else:
+                        errormsg = (
+                            "[DUT %s]: %s is not present"
+                            "for interface %s [FAILED]!! " % (dut, state, intf)
+                        )
+                        return errormsg
+            return None
+
+        test_func = functools.partial(
+            show_pim_intf_traffic, rnode, dut, input_dict, output_dict
         )
-
-        output_dict[dut] = {}
-        for intf, data in input_dict[dut].items():
-            interface_json = show_pim_intf_traffic_json[intf]
-            for state in data:
-
-                # Verify Tx/Rx
-                if state in interface_json:
-                    output_dict[dut][state] = interface_json[state]
-                else:
-                    errormsg = (
-                        "[DUT %s]: %s is not present"
-                        "for interface %s [FAILED]!! " % (dut, state, intf)
-                    )
-                    return errormsg
+        (result, out) = topotest.run_and_expect(test_func, None, count=20, wait=1)
+        if not result:
+            return out
 
     logger.debug("Exiting lib API: {}".format(sys._getframe().f_code.co_name))
     return output_dict


### PR DESCRIPTION
Currently under system load tests that use verify_pim_interface_traffic
immediately after a interface down/up event are not giving any time
for pim to receive and process the data from that event.  Give
the test some time to gather this data.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>