### PR TITLE
zebra: add optional NHG ID output to `show ip ro`

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -76,7 +76,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
 			    const struct prefix *longer_prefix_p,
 			    bool supernets_only, int type,
 			    unsigned short ospf_instance_id, uint32_t tableid,
-			    struct route_show_ctx *ctx);
+			    bool show_ng, struct route_show_ctx *ctx);
 static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 				     int mcast, bool use_fib, bool show_ng);
 static void vty_show_ip_route_summary(struct vty *vty,
@@ -158,7 +158,8 @@ DEFUN (show_ip_rpf,
 	};
 
 	return do_show_ip_route(vty, VRF_DEFAULT_NAME, AFI_IP, SAFI_MULTICAST,
-				false, uj, 0, NULL, false, 0, 0, 0, &ctx);
+				false, uj, 0, NULL, false, 0, 0, 0, false,
+				&ctx);
 }
 
 DEFUN (show_ip_rpf_addr,
@@ -889,7 +890,7 @@ static void show_nexthop_json_helper(json_object *json_nexthop,
 
 static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 			      struct route_entry *re, json_object *json,
-			      bool is_fib)
+			      bool is_fib, bool show_ng)
 {
 	const struct nexthop *nexthop;
 	int len = 0;
@@ -1050,6 +1051,9 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 		len += vty_out(vty, " [%u/%u]", re->distance,
 			       re->metric);
 
+	if (show_ng)
+		len += vty_out(vty, " (%u)", re->nhe_id);
+
 	/* Nexthop information. */
 	for (ALL_NEXTHOPS_PTR(nhg, nexthop)) {
 		if (first_p) {
@@ -1122,7 +1126,7 @@ static void vty_show_ip_route_detail_json(struct vty *vty,
 		 */
 		if (use_fib && re != dest->selected_fib)
 			continue;
-		vty_show_ip_route(vty, rn, re, json_prefix, use_fib);
+		vty_show_ip_route(vty, rn, re, json_prefix, use_fib, false);
 	}
 
 	prefix2str(&rn->p, buf, sizeof(buf));
@@ -1136,7 +1140,8 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 				 const struct prefix *longer_prefix_p,
 				 bool supernets_only, int type,
 				 unsigned short ospf_instance_id, bool use_json,
-				 uint32_t tableid, struct route_show_ctx *ctx)
+				 uint32_t tableid, bool show_ng,
+				 struct route_show_ctx *ctx)
 {
 	struct route_node *rn;
 	struct route_entry *re;
@@ -1227,7 +1232,8 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 				first = 0;
 			}
 
-			vty_show_ip_route(vty, rn, re, json_prefix, use_fib);
+			vty_show_ip_route(vty, rn, re, json_prefix, use_fib,
+					  show_ng);
 		}
 
 		if (json_prefix) {
@@ -1246,7 +1252,7 @@ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf,
 				 route_tag_t tag,
 				 const struct prefix *longer_prefix_p,
 				 bool supernets_only, int type,
-				 unsigned short ospf_instance_id,
+				 unsigned short ospf_instance_id, bool show_ng,
 				 struct route_show_ctx *ctx)
 {
 	struct zebra_router_table *zrt;
@@ -1265,7 +1271,7 @@ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf,
 		do_show_ip_route(vty, zvrf_name(zvrf), afi, SAFI_UNICAST,
 				 use_fib, use_json, tag, longer_prefix_p,
 				 supernets_only, type, ospf_instance_id,
-				 zrt->tableid, ctx);
+				 zrt->tableid, show_ng, ctx);
 	}
 }
 
@@ -1275,7 +1281,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
 			    const struct prefix *longer_prefix_p,
 			    bool supernets_only, int type,
 			    unsigned short ospf_instance_id, uint32_t tableid,
-			    struct route_show_ctx *ctx)
+			    bool show_ng, struct route_show_ctx *ctx)
 {
 	struct route_table *table;
 	struct zebra_vrf *zvrf = NULL;
@@ -1308,7 +1314,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
 
 	do_show_route_helper(vty, zvrf, table, afi, use_fib, tag,
 			     longer_prefix_p, supernets_only, type,
-			     ospf_instance_id, use_json, tableid, ctx);
+			     ospf_instance_id, use_json, tableid, show_ng, ctx);
 
 	return CMD_SUCCESS;
 }
@@ -1792,7 +1798,7 @@ DEFPY (show_route,
 	   }]\
 	   [" FRR_IP6_REDIST_STR_ZEBRA "$type_str]\
 	 >\
-        [json$json]",
+        [<json$json|nexthop-group$ng>]",
        SHOW_STR
        IP_STR
        "IP forwarding table\n"
@@ -1821,7 +1827,8 @@ DEFPY (show_route,
        "IPv6 prefix\n"
        "Show route matching the specified Network/Mask pair only\n"
        FRR_IP6_REDIST_HELP_STR_ZEBRA
-       JSON_STR)
+       JSON_STR
+       "Nexthop Group Information\n")
 {
 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
 	struct vrf *vrf;
@@ -1857,18 +1864,18 @@ DEFPY (show_route,
 				continue;
 
 			if (table_all)
-				do_show_ip_route_all(vty, zvrf, afi, !!fib,
-						     !!json, tag,
-						     prefix_str ? prefix : NULL,
-						     !!supernets_only, type,
-						     ospf_instance_id, &ctx);
+				do_show_ip_route_all(
+					vty, zvrf, afi, !!fib, !!json, tag,
+					prefix_str ? prefix : NULL,
+					!!supernets_only, type,
+					ospf_instance_id, !!ng, &ctx);
 			else
-				do_show_ip_route(vty, zvrf_name(zvrf), afi,
-						 SAFI_UNICAST, !!fib, !!json,
-						 tag,
-						 prefix_str ? prefix : NULL,
-						 !!supernets_only, type,
-						 ospf_instance_id, table, &ctx);
+				do_show_ip_route(
+					vty, zvrf_name(zvrf), afi, SAFI_UNICAST,
+					!!fib, !!json, tag,
+					prefix_str ? prefix : NULL,
+					!!supernets_only, type,
+					ospf_instance_id, table, !!ng, &ctx);
 		}
 	} else {
 		vrf_id_t vrf_id = VRF_DEFAULT;
@@ -1887,13 +1894,13 @@ DEFPY (show_route,
 			do_show_ip_route_all(vty, zvrf, afi, !!fib, !!json, tag,
 					     prefix_str ? prefix : NULL,
 					     !!supernets_only, type,
-					     ospf_instance_id, &ctx);
+					     ospf_instance_id, !!ng, &ctx);
 		else
 			do_show_ip_route(vty, vrf->name, afi, SAFI_UNICAST,
 					 !!fib, !!json, tag,
 					 prefix_str ? prefix : NULL,
 					 !!supernets_only, type,
-					 ospf_instance_id, table, &ctx);
+					 ospf_instance_id, table, !!ng, &ctx);
 	}
 
 	return CMD_SUCCESS;
@@ -2659,7 +2666,7 @@ DEFUN (show_ipv6_mroute,
 				vty_out(vty, SHOW_ROUTE_V6_HEADER);
 				first = 0;
 			}
-			vty_show_ip_route(vty, rn, re, NULL, false);
+			vty_show_ip_route(vty, rn, re, NULL, false, false);
 		}
 	return CMD_SUCCESS;
 }
@@ -2691,7 +2698,8 @@ DEFUN (show_ipv6_mroute_vrf_all,
 					vty_out(vty, SHOW_ROUTE_V6_HEADER);
 					first = 0;
 				}
-				vty_show_ip_route(vty, rn, re, NULL, false);
+				vty_show_ip_route(vty, rn, re, NULL, false,
+						  false);
 			}
 	}
 	return CMD_SUCCESS;


### PR DESCRIPTION
Add optional NHG ID output to `show ip route` dumps. We have
this in json output already as nexthopGroupID but nice
to have the option in a normal dump as well. Not including in main
output for now to avoid breaking screen scrapers.

Signed-off-by: Stephen Worley <sworley@nvidia.com>


```
alfred# show ip route vrf all nexthop-group                                                                                                                                                                                                   
Codes: K - kernel route, C - connected, S - static, R - RIP,                                                                                                                                                                                  
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,                                                                                                                                                                                     
       T - Table, A - Babel, D - SHARP, F - PBR, f - OpenFabric,                                                                                                                                                                              
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup                                                                                                                                                                
       t - trapped, o - offload failure                                                                                                                                                                                                       
                                                                                                                                                                                                                                              
VRF default:                                                                                                                                                                                                                                  
K * 0.0.0.0/0 [0/600] (41) via 10.42.0.1, wlp2s0, 00:01:51                                                                                                                                                                                    
K>* 0.0.0.0/0 [0/0] (38) is directly connected, tun0, 00:01:51                                                                                                                                                                                
D>* 3.3.3.1/32 [150/0] (47) via 10.42.0.1, wlp2s0, weight 1, 00:01:02           
  *                         via 10.42.0.2, wlp2s0, weight 1, 00:01:02           
K>* 3.33.209.43/32 [0/0] (42) via 10.42.0.1, wlp2s0, src 10.42.0.160, 00:01:51  
K>* 10.2.80.0/20 [0/0] (38) is directly connected, tun0, 00:01:51                
C>* 10.2.81.216/32 (38) is directly connected, tun0, 00:01:51                    
C>* 10.42.0.0/24 (36) is directly connected, wlp2s0, 00:01:51                    
K>* 13.107.64.0/18 [0/0] (42) via 10.42.0.1, wlp2s0, src 10.42.0.160, 00:01:51
```