### PR TITLE
zebra: Prevent thread usage of data after it being freed

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -443,8 +443,8 @@ int main(int argc, char **argv)
 	* we have to have route_read() called before.
 	*/
 	zrouter.startup_time = monotime(NULL);
-	thread_add_timer(zrouter.master, rib_sweep_route,
-			 NULL, graceful_restart, NULL);
+	thread_add_timer(zrouter.master, rib_sweep_route, NULL,
+			 graceful_restart, &zrouter.sweeper);
 
 	/* Needed for BSD routing socket. */
 	pid = getpid();

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -232,6 +232,8 @@ void zebra_router_terminate(void)
 {
 	struct zebra_router_table *zrt, *tmp;
 
+	THREAD_OFF(zrouter.sweeper);
+
 	RB_FOREACH_SAFE (zrt, zebra_router_table_head, &zrouter.tables, tmp)
 		zebra_router_free_table(zrt);
 

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -196,6 +196,7 @@ struct zebra_router {
 	 * Time for when we sweep the rib from old routes
 	 */
 	time_t startup_time;
+	struct thread *sweeper;
 
 	/*
 	 * The hash of nexthop groups associated with this router


### PR DESCRIPTION
On startup we create a thread timer event to do a rib sweep
of the system.  On shutdown we never stopped this timer and
as such we have a situation where a thread event could be run
on shutdown after the data for it has been freed.  Here is the
crash I am seeing:

(gdb) bt
(gdb)

Save the thread data in zebra_router and stop the thread so we don't
accidently do work on shutdown we don't mean to.  In this case
it happened in our topotests with some severe system load.
Essentially we happened to kill the zebra daemon just as the
graceful_restart timer popped here.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>