### PR TITLE
pimd : IGMP join and pim join handling on same interface

### DIFF
--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -456,6 +456,12 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	/* Prevent single protocol from subscribing same interface to
 	   channel (S,G) multiple times */
 	if (channel_oil->oif_flags[pim_ifp->mroute_vif_index] & proto_mask) {
+
+		if (channel_oil->oif_flags[pim_ifp->mroute_vif_index]
+		    != proto_mask)
+			channel_oil->oif_flags[pim_ifp->mroute_vif_index] |=
+				proto_mask;
+
 		if (PIM_DEBUG_MROUTE) {
 			char group_str[INET_ADDRSTRLEN];
 			char source_str[INET_ADDRSTRLEN];


### PR DESCRIPTION
Problem Statement:
==================
When IGMP join and PIM join both exists on the same ifchannel.
Then mroutes were not getting programmed correctly.

Root Cause Analysis:
====================
In case DR/nonDR PIMd will have IGMP join and PIM join
on the same interface, in the topology when RP is reachable
via nonDR node. In this case nonDR will have PIM join.
Now nonDR becomes the DR, so DR node would have IGMP join also.
There is the problem when IGMP join removal comes first, then
mroute clean up is not happening correctly.

Signed-off-by: Abhishek N R <abnr@vmware.com>
Signed-off-by: Vishal Dhingra <rac.vishaldhingra@gmail.com>