### PR TITLE
pimd: fix igmp query packet

### DIFF
--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -53,7 +53,8 @@ void igmp_v2_send_query(struct gm_group *group, int fd, const char *ifname,
 
 	/* max_resp_code must be non-zero else this will look like an IGMP v1
 	 * query */
-	max_resp_code = igmp_msg_encode16to8(query_max_response_time_dsec);
+	/* RFC 2236: 2.2. , v2's is equal to it */
+	max_resp_code = query_max_response_time_dsec;
 	assert(max_resp_code > 0);
 
 	query_buf[0] = PIM_IGMP_MEMBERSHIP_QUERY;

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -616,7 +616,7 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 
 		connected_src = pim_if_connected_to_source(ifp, ip_hdr->ip_src);
 
-		if (!connected_src) {
+		if (!connected_src && PIM_INADDR_ISNOT_ANY(ip_hdr->ip_src)) {
 			if (PIM_DEBUG_IGMP_PACKETS) {
 				zlog_debug("Recv IGMP packet on interface: %s from a non-connected source: %pI4",
 					   ifp->name, &ip_hdr->ip_src);
@@ -625,7 +625,8 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 		}
 
 		pim_ifp = ifp->info;
-		ifaddr = connected_src->u.prefix4;
+		ifaddr = connected_src ? connected_src->u.prefix4
+				       : pim_ifp->primary_address;
 		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->gm_socket_list,
 						   ifaddr);
 
@@ -638,8 +639,9 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 		if (igmp)
 			pim_igmp_packet(igmp, (char *)buf, buf_size);
 		else if (PIM_DEBUG_IGMP_PACKETS) {
-			zlog_debug("No IGMP socket on interface: %s with connected source: %pFX",
-				   ifp->name, connected_src);
+			zlog_debug(
+				"No IGMP socket on interface: %s with connected source: %pI4",
+				ifp->name, &ifaddr);
 		}
 	} else if (ip_hdr->ip_p) {
 		if (PIM_DEBUG_MROUTE_DETAIL) {


### PR DESCRIPTION
'Max Resp Time' in v2 query needs no encode (RFC 2236: 2.2.).

Signed-off-by: ron <lyq140hf2006@163.com>