### PR TITLE
zebra: Fix improper usage of hash_iterate that caused crashes

### DIFF
--- a/lib/hash.h
+++ b/lib/hash.h
@@ -235,9 +235,10 @@ extern void *hash_release(struct hash *hash, void *data);
 /*
  * Iterate over the elements in a hash table.
  *
- * It is safe to delete items passed to the iteration function from the hash
- * table during iteration. More than one item cannot be deleted during each
- * iteration. Please note that adding entries to the hash
+ * The passed in arg to the handler function is the only safe
+ * item to delete from the hash.
+ *
+ * Please note that adding entries to the hash
  * during the walk will cause undefined behavior in that some new entries
  * will be walked and some will not.  So do not do this.
  *
@@ -258,8 +259,10 @@ extern void hash_iterate(struct hash *hash,
 /*
  * Iterate over the elements in a hash table, stopping on condition.
  *
- * It is safe to delete items passed to the iteration function from the hash
- * table during iteration.  Please note that adding entries to the hash
+ * The passed in arg to the handler function is the only safe item
+ * to delete from the hash.
+ *
+ * Please note that adding entries to the hash
  * during the walk will cause undefined behavior in that some new entries
  * will be walked and some will not.  So do not do this.
  *


### PR DESCRIPTION
I'm seeing this crash in various forms:
Program terminated with signal SIGSEGV, Segmentation fault.
50	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
[Current thread is 1 (Thread 0x7f418efbc7c0 (LWP 3580253))]
(gdb) bt
(gdb) f 4
267				(*func)(hb, arg);
(gdb) p hb
$1 = (struct hash_bucket *) 0x558cdaafb250
(gdb) p *hb
$2 = {len = 0, next = 0x0, key = 0, data = 0x0}
(gdb)

I've also seen a crash where data is 0x03.

My suspicion is that hash_iterate is calling zebra_nhg_sweep_entry which
does delete the particular entry we are looking at as well as possibly other
entries when the ref count for those entries gets set to 0 as well.

Then we have this loop in hash_iterate.c:

       for (i = 0; i < hash->size; i++)
                for (hb = hash->index[i]; hb; hb = hbnext) {
                        /* get pointer to next hash bucket here, in case (*func)
                         * decides to delete hb by calling hash_release
                         */
                        hbnext = hb->next;
                        (*func)(hb, arg);
                }

Suppose in the previous loop hbnext is set to hb->next and we call
zebra_nhg_sweep_entry.  This deletes the previous entry and also
happens to cause the hbnext entry to be deleted as well, because of nhg
refcounts.  At this point in time the memory pointed to by hbnext is
not owned by the pthread anymore and we can end up on a state where
it's overwritten by another pthread in zebra with data for other incoming events.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>