### PR TITLE
pimd: Modifying structure members to accommodate IPv6 changes

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1322,7 +1322,7 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 				 const char *ifname, bool uj)
 {
 	struct interface *ifp;
-	struct igmp_stats rx_stats;
+	struct gm_stats rx_stats;
 
 	igmp_stats_init(&rx_stats);
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3407,14 +3407,14 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 
 	if (uj) {
 		json = json_object_new_object();
-		json_object_int_add(json, "totalGroups", pim->igmp_group_count);
+		json_object_int_add(json, "totalGroups", pim->gm_group_count);
 		json_object_int_add(json, "watermarkLimit",
-				    pim->igmp_watermark_limit);
+				    pim->gm_watermark_limit);
 	} else {
-		vty_out(vty, "Total IGMP groups: %u\n", pim->igmp_group_count);
+		vty_out(vty, "Total IGMP groups: %u\n", pim->gm_group_count);
 		vty_out(vty, "Watermark warn limit(%s): %u\n",
-			pim->igmp_watermark_limit ? "Set" : "Not Set",
-			pim->igmp_watermark_limit);
+			pim->gm_watermark_limit ? "Set" : "Not Set",
+			pim->gm_watermark_limit);
 		vty_out(vty,
 			"Interface        Group           Mode Timer    Srcs V Uptime  \n");
 	}
@@ -7165,7 +7165,7 @@ DEFPY (igmp_group_watermark,
        "Group count to generate watermark warning\n")
 {
 	PIM_DECLVAR_CONTEXT(vrf, pim);
-	pim->igmp_watermark_limit = limit;
+	pim->gm_watermark_limit = limit;
 
 	return CMD_SUCCESS;
 }
@@ -7180,7 +7180,7 @@ DEFPY (no_igmp_group_watermark,
        IGNORED_IN_NO_STR)
 {
 	PIM_DECLVAR_CONTEXT(vrf, pim);
-	pim->igmp_watermark_limit = 0;
+	pim->gm_watermark_limit = 0;
 
 	return CMD_SUCCESS;
 }

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -517,7 +517,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 					now - igmp->sock_creation);
 			pim_time_timer_to_hhmmss(query_hhmmss,
 						 sizeof(query_hhmmss),
-						 igmp->t_igmp_query_timer);
+						 igmp->t_query_timer);
 
 			if (uj) {
 				json_row = json_object_new_object();
@@ -527,7 +527,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 				json_object_int_add(json_row, "version",
 						    pim_ifp->igmp_version);
 
-				if (igmp->t_igmp_query_timer) {
+				if (igmp->t_query_timer) {
 					json_object_boolean_true_add(json_row,
 								     "querier");
 					json_object_string_add(json_row,
@@ -556,8 +556,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 					inet_ntop(AF_INET, &igmp->ifaddr, buf,
 						  sizeof(buf)),
 					pim_ifp->igmp_version,
-					igmp->t_igmp_query_timer ? "local"
-								 : "other",
+					igmp->t_query_timer ? "local" : "other",
 					&igmp->querier_addr, query_hhmmss,
 					uptime);
 			}
@@ -617,7 +616,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 					now - igmp->sock_creation);
 			pim_time_timer_to_hhmmss(query_hhmmss,
 						 sizeof(query_hhmmss),
-						 igmp->t_igmp_query_timer);
+						 igmp->t_query_timer);
 			pim_time_timer_to_hhmmss(other_hhmmss,
 						 sizeof(other_hhmmss),
 						 igmp->t_other_querier_timer);
@@ -661,9 +660,9 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 				json_object_string_add(json_row, "upTime",
 						       uptime);
 				json_object_string_add(json_row, "querier",
-						       igmp->t_igmp_query_timer
-						       ? "local"
-						       : "other");
+						       igmp->t_query_timer
+							       ? "local"
+							       : "other");
 				json_object_string_addf(json_row, "querierIp",
 							"%pI4",
 							&igmp->querier_addr);
@@ -734,8 +733,8 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 				vty_out(vty, "Querier\n");
 				vty_out(vty, "-------\n");
 				vty_out(vty, "Querier     : %s\n",
-					igmp->t_igmp_query_timer ? "local"
-					: "other");
+					igmp->t_query_timer ? "local"
+							    : "other");
 				vty_out(vty, "QuerierIp   : %pI4",
 					&igmp->querier_addr);
 				if (pim_ifp->primary_address.s_addr
@@ -3490,9 +3489,10 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 							   : "INCL")
 						: "----",
 					hhmmss,
-					grp->group_source_list ? listcount(
-						grp->group_source_list)
-							       : 0,
+					grp->group_source_list
+						? listcount(
+							  grp->group_source_list)
+						: 0,
 					grp->igmp_version, uptime);
 			}
 		} /* scan igmp groups */

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -799,25 +799,24 @@ static void igmp_group_free(struct gm_group *group)
 
 static void igmp_group_count_incr(struct pim_interface *pim_ifp)
 {
-	++pim_ifp->pim->igmp_group_count;
-	if (pim_ifp->pim->igmp_group_count
-	    == pim_ifp->pim->igmp_watermark_limit) {
+	++pim_ifp->pim->gm_group_count;
+	if (pim_ifp->pim->gm_group_count == pim_ifp->pim->gm_watermark_limit) {
 		zlog_warn(
 			"IGMP group count reached watermark limit: %u(vrf: %s)",
-			pim_ifp->pim->igmp_group_count,
+			pim_ifp->pim->gm_group_count,
 			VRF_LOGNAME(pim_ifp->pim->vrf));
 	}
 }
 
 static void igmp_group_count_decr(struct pim_interface *pim_ifp)
 {
-	if (pim_ifp->pim->igmp_group_count == 0) {
+	if (pim_ifp->pim->gm_group_count == 0) {
 		zlog_warn("Cannot decrement igmp group count below 0(vrf: %s)",
 			  VRF_LOGNAME(pim_ifp->pim->vrf));
 		return;
 	}
 
-	--pim_ifp->pim->igmp_group_count;
+	--pim_ifp->pim->gm_group_count;
 }
 
 void igmp_group_delete(struct gm_group *group)

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -88,9 +88,9 @@ struct gm_sock {
 	struct in_addr ifaddr;
 	time_t sock_creation;
 
-	struct thread *t_igmp_read; /* read: IGMP sockets */
+	struct thread *t_gm_read; /* read: IGMP or MLD sockets */
 	struct thread
-		*t_igmp_query_timer; /* timer: issue IGMP general queries */
+		*t_query_timer; /* timer: issue IGMP or MLD general queries */
 	struct thread *t_other_querier_timer; /* timer: other querier present */
 	struct in_addr querier_addr;	  /* IP address of the querier */
 	int querier_query_interval;	   /* QQI */

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -99,7 +99,7 @@ struct gm_sock {
 
 	bool mtrace_only;
 
-	struct igmp_stats rx_stats;
+	struct gm_stats rx_stats;
 };
 
 struct pim_interface;

--- a/pimd/pim_igmp_stats.c
+++ b/pimd/pim_igmp_stats.c
@@ -23,12 +23,12 @@
 
 #include "pim_igmp_stats.h"
 
-void igmp_stats_init(struct igmp_stats *stats)
+void igmp_stats_init(struct gm_stats *stats)
 {
-	memset(stats, 0, sizeof(struct igmp_stats));
+	memset(stats, 0, sizeof(struct gm_stats));
 }
 
-void igmp_stats_add(struct igmp_stats *a, struct igmp_stats *b)
+void igmp_stats_add(struct gm_stats *a, struct gm_stats *b)
 {
 	if (!a || !b)
 		return;

--- a/pimd/pim_igmp_stats.h
+++ b/pimd/pim_igmp_stats.h
@@ -22,20 +22,20 @@
 
 #include <zebra.h>
 
-struct igmp_stats {
-	uint32_t	query_v1;
-	uint32_t	query_v2;
-	uint32_t	query_v3;
+struct gm_stats {
+	uint32_t query_v1;
+	uint32_t query_v2;
+	uint32_t query_v3;
 	uint32_t	report_v1;
 	uint32_t	report_v2;
 	uint32_t	report_v3;
 	uint32_t	leave_v2;
 	uint32_t	mtrace_rsp;
 	uint32_t	mtrace_req;
-	uint32_t	unsupported;
+	uint32_t unsupported;
 };
 
-void igmp_stats_init(struct igmp_stats *stats);
-void igmp_stats_add(struct igmp_stats *a, struct igmp_stats *b);
+void igmp_stats_init(struct gm_stats *stats);
+void igmp_stats_add(struct gm_stats *a, struct gm_stats *b);
 
 #endif /* PIM_IGMP_STATS_H */

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -178,8 +178,9 @@ struct pim_instance {
 	struct list *ssmpingd_list;
 	struct in_addr ssmpingd_group_addr;
 
-	unsigned int igmp_group_count;
-	unsigned int igmp_watermark_limit;
+	/*IGMP or MLD Group count*/
+	unsigned int gm_group_count;
+	unsigned int gm_watermark_limit;
 	unsigned int keep_alive_time;
 	unsigned int rp_keep_alive_time;
 

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -400,26 +400,26 @@ static void igmp_sock_query_reschedule(struct gm_sock *igmp)
 	if (igmp->mtrace_only)
 		return;
 
-	if (igmp->t_igmp_query_timer) {
+	if (igmp->t_query_timer) {
 		/* other querier present */
-		assert(igmp->t_igmp_query_timer);
+		assert(igmp->t_query_timer);
 		assert(!igmp->t_other_querier_timer);
 
 		pim_igmp_general_query_off(igmp);
 		pim_igmp_general_query_on(igmp);
 
-		assert(igmp->t_igmp_query_timer);
+		assert(igmp->t_query_timer);
 		assert(!igmp->t_other_querier_timer);
 	} else {
 		/* this is the querier */
 
-		assert(!igmp->t_igmp_query_timer);
+		assert(!igmp->t_query_timer);
 		assert(igmp->t_other_querier_timer);
 
 		pim_igmp_other_querier_timer_off(igmp);
 		pim_igmp_other_querier_timer_on(igmp);
 
-		assert(!igmp->t_igmp_query_timer);
+		assert(!igmp->t_query_timer);
 		assert(igmp->t_other_querier_timer);
 	}
 }

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -244,9 +244,9 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 		++writes;
 	}
 
-	if (pim->igmp_watermark_limit != 0) {
+	if (pim->gm_watermark_limit != 0) {
 		vty_out(vty, "%sip igmp watermark-warn %u\n", spaces,
-			pim->igmp_watermark_limit);
+			pim->gm_watermark_limit);
 		++writes;
 	}
 


### PR DESCRIPTION
Modifying the members of pim_instance, igmp_sock and igmp_group which are to be used for both IPv4 and IPv6 to common names(for both MLD and IGMP).

Issue: #10023

Co-authored-by: Mobashshera Rasool <mrasool@vmware.com>
Co-authored-by:  Sarita Patra <saritap@vmware.com>
Signed-off-by: Abhishek N R <abnr@vmware.com>