### PR TITLE
pimd: Modifying members of pim_interface to accommodate IPv6 changes

### DIFF
--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -100,13 +100,13 @@ struct pim_interface {
 	struct in_addr update_source;   /* user can statically set the primary
 					 * address of the interface */
 
-	int igmp_version;		       /* IGMP version */
-	int igmp_default_robustness_variable;  /* IGMPv3 QRV */
-	int igmp_default_query_interval;       /* IGMPv3 secs between general
+	int version;			  /* IGMP or MLD version */
+	int default_robustness_variable;  /* IGMP or MLD QRV */
+	int default_query_interval;       /* IGMP or MLD secs between general
 						  queries */
-	int igmp_query_max_response_time_dsec; /* IGMPv3 Max Response Time in
+	int query_max_response_time_dsec; /* IGMP or MLD Max Response Time in
 						  dsecs for general queries */
-	int igmp_specific_query_max_response_time_dsec; /* IGMPv3 Max Response
+	int specific_query_max_response_time_dsec; /* IGMP or MLD Max Response
 							   Time in dsecs called
 							   as last member query
 							   interval, defines the
@@ -114,11 +114,11 @@ struct pim_interface {
 							   advertised in IGMP
 							   group-specific
 							   queries */
-	int igmp_last_member_query_count; /* IGMP last member query count */
-	struct list *igmp_socket_list; /* list of struct igmp_sock */
-	struct list *igmp_join_list;   /* list of struct igmp_join */
-	struct list *igmp_group_list;  /* list of struct igmp_group */
-	struct hash *igmp_group_hash;
+	int last_member_query_count; /* IGMP or MLD last member query count */
+	struct list *socket_list;    /* list of struct IGMP or MLD sock */
+	struct list *join_list;      /* list of struct IGMP or MLD join */
+	struct list *group_list;     /* list of struct IGMP or MLD group */
+	struct hash *group_hash;
 
 	int pim_sock_fd;		/* PIM socket file descriptor */
 	struct thread *t_pim_sock_read; /* thread for reading PIM socket */

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -226,7 +226,7 @@ void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp)
 	*/
 	other_querier_present_interval_msec = PIM_IGMP_OQPI_MSEC(
 		igmp->querier_robustness_variable, igmp->querier_query_interval,
-		pim_ifp->igmp_query_max_response_time_dsec);
+		pim_ifp->query_max_response_time_dsec);
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
@@ -351,11 +351,10 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 	 * For now we will simplify things and inform the user that they need to
 	 * configure all PIM routers to use the same version of IGMP.
 	 */
-	if (query_version != pim_ifp->igmp_version) {
+	if (query_version != pim_ifp->version) {
 		zlog_warn(
 			"Recv IGMP query v%d from %s on %s but we are using v%d, please configure all PIM routers on this subnet to use the same IGMP version",
-			query_version, from_str, ifp->name,
-			pim_ifp->igmp_version);
+			query_version, from_str, ifp->name, pim_ifp->version);
 		return 0;
 	}
 
@@ -636,14 +635,14 @@ void pim_igmp_general_query_on(struct igmp_sock *igmp)
 		 * newly configured igmp interface send it out in 1 second
 		 * just to give the entire world a tiny bit of time to settle
 		 * else the query interval is:
-		 * query_interval = pim_ifp->igmp_default_query_interval >> 2;
+		 * query_interval = pim_ifp->default_query_interval >> 2;
 		 */
 		if (igmp->startup_query_count
 		    == igmp->querier_robustness_variable)
 			query_interval = 1;
 		else
-			query_interval = PIM_IGMP_SQI(
-				pim_ifp->igmp_default_query_interval);
+			query_interval =
+				PIM_IGMP_SQI(pim_ifp->default_query_interval);
 
 		--igmp->startup_query_count;
 	} else {
@@ -696,7 +695,7 @@ static int pim_igmp_general_query(struct thread *t)
 
 	pim_ifp = igmp->interface->info;
 
-	if (pim_ifp->igmp_version == 3) {
+	if (pim_ifp->version == 3) {
 		query_buf_size = PIM_IGMP_BUFSIZE_WRITE;
 	} else {
 		query_buf_size = IGMP_V12_MSG_SIZE;
@@ -726,10 +725,10 @@ static int pim_igmp_general_query(struct thread *t)
 			   querier_str, dst_str, igmp->interface->name);
 	}
 
-	igmp_send_query(pim_ifp->igmp_version, 0 /* igmp_group */, igmp->fd,
+	igmp_send_query(pim_ifp->version, 0 /* igmp_group */, igmp->fd,
 			igmp->interface->name, query_buf, sizeof(query_buf),
 			0 /* num_sources */, dst_addr, group_addr,
-			pim_ifp->igmp_query_max_response_time_dsec,
+			pim_ifp->query_max_response_time_dsec,
 			1 /* s_flag: always set for general queries */,
 			igmp->querier_robustness_variable,
 			igmp->querier_query_interval);
@@ -787,7 +786,7 @@ void igmp_startup_mode_on(struct igmp_sock *igmp)
 	/*
 	  Since we're (re)starting, reset QQI to default Query Interval
 	*/
-	igmp->querier_query_interval = pim_ifp->igmp_default_query_interval;
+	igmp->querier_query_interval = pim_ifp->default_query_interval;
 }
 
 static void igmp_group_free(struct igmp_group *group)
@@ -844,8 +843,8 @@ void igmp_group_delete(struct igmp_group *group)
 
 	group_timer_off(group);
 	igmp_group_count_decr(pim_ifp);
-	listnode_delete(pim_ifp->igmp_group_list, group);
-	hash_release(pim_ifp->igmp_group_hash, group);
+	listnode_delete(pim_ifp->group_list, group);
+	hash_release(pim_ifp->group_hash, group);
 
 	igmp_group_free(group);
 }
@@ -875,11 +874,11 @@ void igmp_sock_delete(struct igmp_sock *igmp)
 
 	pim_ifp = igmp->interface->info;
 
-	listnode_delete(pim_ifp->igmp_socket_list, igmp);
+	listnode_delete(pim_ifp->socket_list, igmp);
 
 	igmp_sock_free(igmp);
 
-	if (!listcount(pim_ifp->igmp_socket_list))
+	if (!listcount(pim_ifp->socket_list))
 		pim_igmp_if_reset(pim_ifp);
 }
 
@@ -891,8 +890,8 @@ void igmp_sock_delete_all(struct interface *ifp)
 
 	pim_ifp = ifp->info;
 
-	for (ALL_LIST_ELEMENTS(pim_ifp->igmp_socket_list, igmp_node,
-			       igmp_nextnode, igmp)) {
+	for (ALL_LIST_ELEMENTS(pim_ifp->socket_list, igmp_node, igmp_nextnode,
+			       igmp)) {
 		igmp_sock_delete(igmp);
 	}
 }
@@ -919,15 +918,15 @@ void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp)
 {
 	char hash_name[64];
 
-	pim_ifp->igmp_socket_list = list_new();
-	pim_ifp->igmp_socket_list->del = (void (*)(void *))igmp_sock_free;
+	pim_ifp->socket_list = list_new();
+	pim_ifp->socket_list->del = (void (*)(void *))igmp_sock_free;
 
-	pim_ifp->igmp_group_list = list_new();
-	pim_ifp->igmp_group_list->del = (void (*)(void *))igmp_group_free;
+	pim_ifp->group_list = list_new();
+	pim_ifp->group_list->del = (void (*)(void *))igmp_group_free;
 
 	snprintf(hash_name, sizeof(hash_name), "IGMP %s hash", ifp->name);
-	pim_ifp->igmp_group_hash = hash_create(
-		igmp_group_hash_key, igmp_group_hash_equal, hash_name);
+	pim_ifp->group_hash = hash_create(igmp_group_hash_key,
+					  igmp_group_hash_equal, hash_name);
 }
 
 void pim_igmp_if_reset(struct pim_interface *pim_ifp)
@@ -935,7 +934,7 @@ void pim_igmp_if_reset(struct pim_interface *pim_ifp)
 	struct listnode *grp_node, *grp_nextnode;
 	struct igmp_group *grp;
 
-	for (ALL_LIST_ELEMENTS(pim_ifp->igmp_group_list, grp_node, grp_nextnode,
+	for (ALL_LIST_ELEMENTS(pim_ifp->group_list, grp_node, grp_nextnode,
 			       grp)) {
 		igmp_group_delete(grp);
 	}
@@ -945,13 +944,13 @@ void pim_igmp_if_fini(struct pim_interface *pim_ifp)
 {
 	pim_igmp_if_reset(pim_ifp);
 
-	assert(pim_ifp->igmp_group_list);
-	assert(!listcount(pim_ifp->igmp_group_list));
+	assert(pim_ifp->group_list);
+	assert(!listcount(pim_ifp->group_list));
 
-	list_delete(&pim_ifp->igmp_group_list);
-	hash_free(pim_ifp->igmp_group_hash);
+	list_delete(&pim_ifp->group_list);
+	hash_free(pim_ifp->group_hash);
 
-	list_delete(&pim_ifp->igmp_socket_list);
+	list_delete(&pim_ifp->socket_list);
 }
 
 static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
@@ -978,7 +977,7 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	igmp->t_igmp_query_timer = NULL;
 	igmp->t_other_querier_timer = NULL; /* no other querier present */
 	igmp->querier_robustness_variable =
-		pim_ifp->igmp_default_robustness_variable;
+		pim_ifp->default_robustness_variable;
 	igmp->sock_creation = pim_time_monotonic_sec();
 
 	igmp_stats_init(&igmp->rx_stats);
@@ -993,7 +992,7 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	/*
 	  igmp_startup_mode_on() will reset QQI:
 
-	  igmp->querier_query_interval = pim_ifp->igmp_default_query_interval;
+	  igmp->querier_query_interval = pim_ifp->default_query_interval;
 	*/
 	igmp_startup_mode_on(igmp);
 	pim_igmp_general_query_on(igmp);
@@ -1189,7 +1188,7 @@ struct igmp_group *find_group_by_addr(struct igmp_sock *igmp,
 
 	lookup.group_addr.s_addr = group_addr.s_addr;
 
-	return hash_lookup(pim_ifp->igmp_group_hash, &lookup);
+	return hash_lookup(pim_ifp->group_hash, &lookup);
 }
 
 struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
@@ -1247,8 +1246,8 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 	/* initialize new group as INCLUDE {empty} */
 	group->group_filtermode_isexcl = 0; /* 0=INCLUDE, 1=EXCLUDE */
 
-	listnode_add(pim_ifp->igmp_group_list, group);
-	group = hash_get(pim_ifp->igmp_group_hash, group, hash_alloc_intern);
+	listnode_add(pim_ifp->group_list, group);
+	group = hash_get(pim_ifp->group_hash, group, hash_alloc_intern);
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
@@ -1321,7 +1320,7 @@ void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver)
 		zlog_debug("Issuing general query on request on %s",
 				ifp->name);
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
 
 		char query_buf[query_buf_size];
 
@@ -1329,7 +1328,7 @@ void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver)
 				igmp->interface->name, query_buf,
 				sizeof(query_buf), 0 /* num_sources */,
 				dst_addr, group_addr,
-				pim_ifp->igmp_query_max_response_time_dsec,
+				pim_ifp->query_max_response_time_dsec,
 				1 /* s_flag: always set for general queries */,
 				igmp->querier_robustness_variable,
 				igmp->querier_query_interval);

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -65,12 +65,12 @@ static inline long igmp_gmi_msec(struct igmp_group *group)
 
 	long qrv = 0, qqi = 0;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
 		qrv = MAX(qrv, igmp->querier_robustness_variable);
 		qqi = MAX(qqi, igmp->querier_query_interval);
 	}
 	return PIM_IGMP_GMI_MSEC(qrv, qqi,
-				 pim_ifp->igmp_query_max_response_time_dsec);
+				 pim_ifp->query_max_response_time_dsec);
 }
 
 void igmp_group_reset_gmi(struct igmp_group *group)
@@ -985,14 +985,13 @@ static void igmp_send_query_group(struct igmp_group *group, char *query_buf,
 	struct igmp_sock *igmp;
 	struct listnode *sock_node;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
-		igmp_send_query(
-			pim_ifp->igmp_version, group, igmp->fd, ifp->name,
-			query_buf, query_buf_size, num_sources,
-			group->group_addr, group->group_addr,
-			pim_ifp->igmp_specific_query_max_response_time_dsec,
-			s_flag, igmp->querier_robustness_variable,
-			igmp->querier_query_interval);
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
+		igmp_send_query(pim_ifp->version, group, igmp->fd, ifp->name,
+				query_buf, query_buf_size, num_sources,
+				group->group_addr, group->group_addr,
+				pim_ifp->specific_query_max_response_time_dsec,
+				s_flag, igmp->querier_robustness_variable,
+				igmp->querier_query_interval);
 	}
 }
 
@@ -1014,7 +1013,7 @@ static void group_retransmit_group(struct igmp_group *group)
 
 	pim_ifp = group->interface->info;
 
-	if (pim_ifp->igmp_version == 3) {
+	if (pim_ifp->version == 3) {
 		query_buf_size = PIM_IGMP_BUFSIZE_WRITE;
 	} else {
 		query_buf_size = IGMP_V12_MSG_SIZE;
@@ -1022,8 +1021,8 @@ static void group_retransmit_group(struct igmp_group *group)
 
 	char query_buf[query_buf_size];
 
-	lmqc = pim_ifp->igmp_last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/*
@@ -1092,8 +1091,8 @@ static int group_retransmit_sources(struct igmp_group *group,
 
 	pim_ifp = group->interface->info;
 
-	lmqc = pim_ifp->igmp_last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/* Scan all group sources */
@@ -1284,7 +1283,7 @@ static void group_retransmit_timer_on(struct igmp_group *group)
 
 	pim_ifp = group->interface->info;
 
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqi_msec = 100 * pim_ifp->specific_query_max_response_time_dsec;
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
@@ -1320,7 +1319,7 @@ static void group_query_send(struct igmp_group *group)
 	long lmqc; /* Last Member Query Count */
 
 	pim_ifp = group->interface->info;
-	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqc = pim_ifp->last_member_query_count;
 
 	/* lower group timer to lmqt */
 	igmp_group_timer_lower_to_lmqt(group);
@@ -1353,8 +1352,8 @@ static void source_query_send_by_flag(struct igmp_group *group,
 
 	pim_ifp = group->interface->info;
 
-	lmqc = pim_ifp->igmp_last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/*
@@ -1510,8 +1509,8 @@ void igmp_group_timer_lower_to_lmqt(struct igmp_group *group)
 	pim_ifp = ifp->info;
 	ifname = ifp->name;
 
-	lmqi_dsec = pim_ifp->igmp_specific_query_max_response_time_dsec;
-	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqi_dsec = pim_ifp->specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->last_member_query_count;
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
@@ -1545,8 +1544,8 @@ void igmp_source_timer_lower_to_lmqt(struct igmp_source *source)
 	pim_ifp = ifp->info;
 	ifname = ifp->name;
 
-	lmqi_dsec = pim_ifp->igmp_specific_query_max_response_time_dsec;
-	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqi_dsec = pim_ifp->specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->last_member_query_count;
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
@@ -1718,7 +1717,7 @@ void igmp_v3_recv_query(struct igmp_sock *igmp, const char *from_str,
 	resv_s_qrv = igmp_msg[8];
 	qrv = 7 & resv_s_qrv;
 	igmp->querier_robustness_variable =
-		qrv ? qrv : pim_ifp->igmp_default_robustness_variable;
+		qrv ? qrv : pim_ifp->default_robustness_variable;
 
 	/*
 	 * RFC 3376: 4.1.7. QQIC (Querier's Query Interval Code)
@@ -1735,7 +1734,7 @@ void igmp_v3_recv_query(struct igmp_sock *igmp, const char *from_str,
 		qqic = igmp_msg[9];
 		qqi = igmp_msg_decode8to16(qqic);
 		igmp->querier_query_interval =
-			qqi ? qqi : pim_ifp->igmp_default_query_interval;
+			qqi ? qqi : pim_ifp->default_query_interval;
 
 		if (PIM_DEBUG_IGMP_TRACE) {
 			char ifaddr_str[INET_ADDRSTRLEN];

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -626,7 +626,8 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 
 		pim_ifp = ifp->info;
 		ifaddr = connected_src->u.prefix4;
-		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list, ifaddr);
+		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->socket_list,
+						   ifaddr);
 
 		if (PIM_DEBUG_IGMP_PACKETS) {
 			zlog_debug(

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -86,7 +86,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 	 */
 
 	/* scan igmp groups */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode, grp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
 		struct listnode *srcnode;
 		struct igmp_source *src;
 
@@ -105,7 +105,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 			}
 
 		} /* scan group sources */
-	}	  /* scan igmp groups */
+	}	 /* scan igmp groups */
 
 	/*
 	 * Finally delete every PIM (S,G) entry lacking all state info
@@ -383,14 +383,14 @@ static void igmp_sock_query_interval_reconfig(struct igmp_sock *igmp)
 		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
 				sizeof(ifaddr_str));
 		zlog_debug("%s: Querier %s on %s reconfig query_interval=%d",
-				__func__, ifaddr_str, ifp->name,
-				pim_ifp->igmp_default_query_interval);
+			   __func__, ifaddr_str, ifp->name,
+			   pim_ifp->default_query_interval);
 	}
 
 	/*
 	 * igmp_startup_mode_on() will reset QQI:
 
-	 * igmp->querier_query_interval = pim_ifp->igmp_default_query_interval;
+	 * igmp->querier_query_interval = pim_ifp->default_query_interval;
 	 */
 	igmp_startup_mode_on(igmp);
 }
@@ -430,9 +430,9 @@ static void change_query_interval(struct pim_interface *pim_ifp,
 	struct listnode *sock_node;
 	struct igmp_sock *igmp;
 
-	pim_ifp->igmp_default_query_interval = query_interval;
+	pim_ifp->default_query_interval = query_interval;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
 		igmp_sock_query_interval_reconfig(igmp);
 		igmp_sock_query_reschedule(igmp);
 	}
@@ -446,12 +446,11 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	struct listnode *grp_node;
 	struct igmp_group *grp;
 
-	if (pim_ifp->igmp_query_max_response_time_dsec
+	if (pim_ifp->query_max_response_time_dsec
 	    == query_max_response_time_dsec)
 		return;
 
-	pim_ifp->igmp_query_max_response_time_dsec =
-		query_max_response_time_dsec;
+	pim_ifp->query_max_response_time_dsec = query_max_response_time_dsec;
 
 	/*
 	 * Below we modify socket/group/source timers in order to quickly
@@ -460,13 +459,13 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	 */
 
 	/* scan all sockets */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
 		/* reschedule socket general query */
 		igmp_sock_query_reschedule(igmp);
 	}
 
 	/* scan socket groups */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grp_node, grp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grp_node, grp)) {
 		struct listnode *src_node;
 		struct igmp_source *src;
 
@@ -2588,8 +2587,8 @@ int lib_interface_igmp_version_modify(struct nb_cb_modify_args *args)
 			return NB_ERR_INCONSISTENCY;
 
 		igmp_version = yang_dnode_get_uint8(args->dnode, NULL);
-		old_version = pim_ifp->igmp_version;
-		pim_ifp->igmp_version = igmp_version;
+		old_version = pim_ifp->version;
+		pim_ifp->version = igmp_version;
 
 		/* Current and new version is different refresh existing
 		 * membership. Going from 3 -> 2 or 2 -> 3.
@@ -2616,7 +2615,7 @@ int lib_interface_igmp_version_destroy(struct nb_cb_destroy_args *args)
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
-		pim_ifp->igmp_version = IGMP_DEFAULT_VERSION;
+		pim_ifp->version = IGMP_DEFAULT_VERSION;
 		break;
 	}
 
@@ -2690,7 +2689,7 @@ int lib_interface_igmp_last_member_query_interval_modify(
 		pim_ifp = ifp->info;
 		last_member_query_interval =
 			yang_dnode_get_uint16(args->dnode, NULL);
-		pim_ifp->igmp_specific_query_max_response_time_dsec =
+		pim_ifp->specific_query_max_response_time_dsec =
 			last_member_query_interval;
 
 		break;
@@ -2719,7 +2718,7 @@ int lib_interface_igmp_robustness_variable_modify(
 		pim_ifp = ifp->info;
 		last_member_query_count = yang_dnode_get_uint8(args->dnode,
 				NULL);
-		pim_ifp->igmp_last_member_query_count = last_member_query_count;
+		pim_ifp->last_member_query_count = last_member_query_count;
 
 		break;
 	}

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -358,56 +358,55 @@ int pim_interface_config_write(struct vty *vty)
 				}
 
 				/* ip igmp version */
-				if (pim_ifp->igmp_version
-				    != IGMP_DEFAULT_VERSION) {
+				if (pim_ifp->version != IGMP_DEFAULT_VERSION) {
 					vty_out(vty, " ip igmp version %d\n",
-						pim_ifp->igmp_version);
+						pim_ifp->version);
 					++writes;
 				}
 
 				/* IF ip igmp query-max-response-time */
-				if (pim_ifp->igmp_query_max_response_time_dsec
+				if (pim_ifp->query_max_response_time_dsec
 				    != IGMP_QUERY_MAX_RESPONSE_TIME_DSEC) {
 					vty_out(vty,
 						" ip igmp query-max-response-time %d\n",
-						pim_ifp->igmp_query_max_response_time_dsec);
+						pim_ifp->query_max_response_time_dsec);
 					++writes;
 				}
 
 				/* IF ip igmp query-interval */
-				if (pim_ifp->igmp_default_query_interval
+				if (pim_ifp->default_query_interval
 				    != IGMP_GENERAL_QUERY_INTERVAL) {
 					vty_out(vty,
 						" ip igmp query-interval %d\n",
-						pim_ifp->igmp_default_query_interval);
+						pim_ifp->default_query_interval);
 					++writes;
 				}
 
 				/* IF ip igmp last-member_query-count */
-				if (pim_ifp->igmp_last_member_query_count
+				if (pim_ifp->last_member_query_count
 				    != IGMP_DEFAULT_ROBUSTNESS_VARIABLE) {
 					vty_out(vty,
 						" ip igmp last-member-query-count %d\n",
-						pim_ifp->igmp_last_member_query_count);
+						pim_ifp->last_member_query_count);
 					++writes;
 				}
 
 				/* IF ip igmp last-member_query-interval */
-				if (pim_ifp->igmp_specific_query_max_response_time_dsec
+				if (pim_ifp->specific_query_max_response_time_dsec
 				    != IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC) {
 					vty_out(vty,
 						" ip igmp last-member-query-interval %d\n",
-						pim_ifp->igmp_specific_query_max_response_time_dsec);
-					  ++writes;
+						pim_ifp->specific_query_max_response_time_dsec);
+					++writes;
 				}
 
 				/* IF ip igmp join */
-				if (pim_ifp->igmp_join_list) {
+				if (pim_ifp->join_list) {
 					struct listnode *node;
 					struct igmp_join *ij;
 					for (ALL_LIST_ELEMENTS_RO(
-						     pim_ifp->igmp_join_list,
-						     node, ij)) {
+						     pim_ifp->join_list, node,
+						     ij)) {
 						char group_str[INET_ADDRSTRLEN];
 						char source_str
 							[INET_ADDRSTRLEN];

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -554,8 +554,7 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
-					  grp)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
 			struct listnode *srcnode;
 			struct igmp_source *src;
 


### PR DESCRIPTION
Modifying the members of pim_interface which are to be used
for both IPv4 and IPv6 to common names(for both MLD and IGMP).

Issue: #10023

Co-authored-by: Mobashshera Rasool <mrasool@vmware.com>
Co-authored-by: Sarita Patra <saritap@vmware.com>
Signed-off-by: Sai Gomathi <nsaigomathi@vmware.com>