### PR TITLE
tests: Test if BGP session is up additionally for route_server_client setup

### DIFF
--- a/tests/topotests/bgp_route_server_client/r1/bgpd.conf
+++ b/tests/topotests/bgp_route_server_client/r1/bgpd.conf
@@ -4,6 +4,7 @@ router bgp 65001
  no bgp ebgp-requires-policy
  neighbor 2001:db8:1::1 remote-as external
  neighbor 2001:db8:1::1 timers 3 10
+ neighbor 2001:db8:1::1 timers connect 5
  address-family ipv6 unicast
   redistribute connected
   neighbor 2001:db8:1::1 activate

--- a/tests/topotests/bgp_route_server_client/r2/bgpd.conf
+++ b/tests/topotests/bgp_route_server_client/r2/bgpd.conf
@@ -3,8 +3,10 @@ router bgp 65000 view RS
  no bgp ebgp-requires-policy
  neighbor 2001:db8:1::2 remote-as external
  neighbor 2001:db8:1::2 timers 3 10
+ neighbor 2001:db8:1::2 timers connect 5
  neighbor 2001:db8:3::2 remote-as external
  neighbor 2001:db8:3::2 timers 3 10
+ neighbor 2001:db8:3::2 timers connect 5
  address-family ipv6 unicast
   redistribute connected
   neighbor 2001:db8:1::2 activate

--- a/tests/topotests/bgp_route_server_client/r3/bgpd.conf
+++ b/tests/topotests/bgp_route_server_client/r3/bgpd.conf
@@ -4,6 +4,7 @@ router bgp 65003
  no bgp ebgp-requires-policy
  neighbor 2001:db8:3::1 remote-as external
  neighbor 2001:db8:3::1 timers 3 10
+ neighbor 2001:db8:3::1 timers connect 5
  address-family ipv6 unicast
   redistribute connected
   neighbor 2001:db8:3::1 activate


### PR DESCRIPTION
Lower connect timer to 5 seconds as well.

```
FAILED test_bgp_route_server_client.py::test_bgp_route_server_client - AssertionError: Cannot see BGP GUA next hop from r3 in r1
```

```
2021-12-02 14:41:21,115 INFO: topolog.r1: vtysh command => "show bgp 2001:db8:f::3/128 json"
2021-12-02 14:41:21,115 DEBUG: topolog.r1: LinuxNamespace(r1): cmd_status("['/bin/bash', '-c', 'vtysh  -c "show bgp 2001:db8:f::3/128 json" 2>/dev/null']", kwargs: {'encoding': 'utf-8', 'stdout': -1, 'stderr': -2, 'shell': False, 'stdin': None})
2021-12-02 14:41:21,159 INFO: topolog.r1: vtysh result:
	{
	}
```

At least can't reproduce a failure locally (before managed to catch it).

Ran >2000 times, no failure.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>