### PR TITLE
isisd: fix running-config for fast-reroute

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -1853,7 +1853,7 @@ void cli_show_isis_frr_lfa_load_sharing(struct vty *vty,
 					const struct lyd_node *dnode,
 					bool show_defaults)
 {
-	if (!yang_dnode_get_bool(dnode, NULL))
+	if (yang_dnode_get_bool(dnode, NULL))
 		vty_out(vty, " no");
 
 	vty_out(vty, " fast-reroute load-sharing disable %s\n",


### PR DESCRIPTION
YANG leaf means "enable" while CLI command is "disable".
So we should use "no" when the leaf is "true", not "false".

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>