### PR TITLE
pimd: Modifying struct igmp_join to struct gm_join to accomodate IPv6

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -822,7 +822,7 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp;
 		struct listnode *join_node;
-		struct igmp_join *ij;
+		struct gm_join *ij;
 		struct in_addr pri_addr;
 		char pri_addr_str[INET_ADDRSTRLEN];
 

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -550,7 +550,7 @@ void pim_if_addr_add(struct connected *ifc)
 		if (pim_ifp->join_list) {
 			struct listnode *node;
 			struct listnode *nextnode;
-			struct igmp_join *ij;
+			struct gm_join *ij;
 			int join_fd;
 
 			for (ALL_LIST_ELEMENTS(pim_ifp->join_list, node,
@@ -1157,17 +1157,17 @@ long pim_if_t_suppressed_msec(struct interface *ifp)
 	return t_suppressed_msec;
 }
 
-static void igmp_join_free(struct igmp_join *ij)
+static void igmp_join_free(struct gm_join *ij)
 {
 	XFREE(MTYPE_PIM_IGMP_JOIN, ij);
 }
 
-static struct igmp_join *igmp_join_find(struct list *join_list,
-					struct in_addr group_addr,
-					struct in_addr source_addr)
+static struct gm_join *igmp_join_find(struct list *join_list,
+				      struct in_addr group_addr,
+				      struct in_addr source_addr)
 {
 	struct listnode *node;
-	struct igmp_join *ij;
+	struct gm_join *ij;
 
 	assert(join_list);
 
@@ -1209,12 +1209,12 @@ static int igmp_join_sock(const char *ifname, ifindex_t ifindex,
 	return join_fd;
 }
 
-static struct igmp_join *igmp_join_new(struct interface *ifp,
-				       struct in_addr group_addr,
-				       struct in_addr source_addr)
+static struct gm_join *igmp_join_new(struct interface *ifp,
+				     struct in_addr group_addr,
+				     struct in_addr source_addr)
 {
 	struct pim_interface *pim_ifp;
-	struct igmp_join *ij;
+	struct gm_join *ij;
 	int join_fd;
 
 	pim_ifp = ifp->info;
@@ -1252,7 +1252,7 @@ ferr_r pim_if_igmp_join_add(struct interface *ifp, struct in_addr group_addr,
 			    struct in_addr source_addr)
 {
 	struct pim_interface *pim_ifp;
-	struct igmp_join *ij;
+	struct gm_join *ij;
 
 	pim_ifp = ifp->info;
 	if (!pim_ifp) {
@@ -1295,7 +1295,7 @@ int pim_if_igmp_join_del(struct interface *ifp, struct in_addr group_addr,
 			 struct in_addr source_addr)
 {
 	struct pim_interface *pim_ifp;
-	struct igmp_join *ij;
+	struct gm_join *ij;
 
 	pim_ifp = ifp->info;
 	if (!pim_ifp) {
@@ -1352,7 +1352,7 @@ static void pim_if_igmp_join_del_all(struct interface *ifp)
 	struct pim_interface *pim_ifp;
 	struct listnode *node;
 	struct listnode *nextnode;
-	struct igmp_join *ij;
+	struct gm_join *ij;
 
 	pim_ifp = ifp->info;
 	if (!pim_ifp) {

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -75,7 +75,7 @@
 		output |= *((ptr) + 1);                                        \
 	} while (0)
 
-struct igmp_join {
+struct gm_join {
 	struct in_addr group_addr;
 	struct in_addr source_addr;
 	int sock_fd;

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -403,7 +403,7 @@ int pim_interface_config_write(struct vty *vty)
 				/* IF ip igmp join */
 				if (pim_ifp->join_list) {
 					struct listnode *node;
-					struct igmp_join *ij;
+					struct gm_join *ij;
 					for (ALL_LIST_ELEMENTS_RO(
 						     pim_ifp->join_list, node,
 						     ij)) {


### PR DESCRIPTION
pimd: Modifying struct igmp_join to struct gm_join to accomodate IPv6 changes

Fix:
Modifying name of struct igmp_join to struct gm_join, which is to be used
by both IPv4 and IPv6(for both MLD and IGMP).
Here gm denotes group membership.

Issue:  # #10023 

Co-authored-by: Abhishek N R abnr@vmware.com
Co-authored-by: Sarita Patra saritap@vmware.com
Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>