### PR TITLE
pimd: Modifying name of structures to accommodate IPv6 changes.

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3523,7 +3523,7 @@ static void igmp_show_group_retransmission(struct pim_instance *pim,
 			char group_str[INET_ADDRSTRLEN];
 			char grp_retr_mmss[10];
 			struct listnode *src_node;
-			struct igmp_source *src;
+			struct gm_source *src;
 			int grp_retr_sources = 0;
 
 			pim_inet4_dump("<group?>", grp->group_addr, group_str,
@@ -3574,7 +3574,7 @@ static void igmp_show_sources(struct pim_instance *pim, struct vty *vty)
 		for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			struct listnode *srcnode;
-			struct igmp_source *src;
+			struct gm_source *src;
 
 			pim_inet4_dump("<group?>", grp->group_addr, group_str,
 				       sizeof(group_str));
@@ -3629,7 +3629,7 @@ static void igmp_show_source_retransmission(struct pim_instance *pim,
 		for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			struct listnode *srcnode;
-			struct igmp_source *src;
+			struct gm_source *src;
 
 			pim_inet4_dump("<group?>", grp->group_addr, group_str,
 				       sizeof(group_str));

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3420,7 +3420,7 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp = ifp->info;
 		struct listnode *grpnode;
-		struct igmp_group *grp;
+		struct gm_group *grp;
 
 		if (!pim_ifp)
 			continue;
@@ -3513,7 +3513,7 @@ static void igmp_show_group_retransmission(struct pim_instance *pim,
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp = ifp->info;
 		struct listnode *grpnode;
-		struct igmp_group *grp;
+		struct gm_group *grp;
 
 		if (!pim_ifp)
 			continue;
@@ -3565,7 +3565,7 @@ static void igmp_show_sources(struct pim_instance *pim, struct vty *vty)
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp = ifp->info;
 		struct listnode *grpnode;
-		struct igmp_group *grp;
+		struct gm_group *grp;
 
 		if (!pim_ifp)
 			continue;
@@ -3620,7 +3620,7 @@ static void igmp_show_source_retransmission(struct pim_instance *pim,
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp = ifp->info;
 		struct listnode *grpnode;
-		struct igmp_group *grp;
+		struct gm_group *grp;
 
 		if (!pim_ifp)
 			continue;
@@ -3901,7 +3901,7 @@ static void clear_mroute(struct pim_instance *pim)
 	/* scan interfaces */
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp = ifp->info;
-		struct igmp_group *grp;
+		struct gm_group *grp;
 		struct pim_ifchannel *ch;
 
 		if (!pim_ifp)

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -501,7 +501,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp;
 		struct listnode *sock_node;
-		struct igmp_sock *igmp;
+		struct gm_sock *igmp;
 
 		pim_ifp = ifp->info;
 
@@ -575,7 +575,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 					struct vty *vty, const char *ifname,
 					bool uj)
 {
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 	struct interface *ifp;
 	struct listnode *sock_node;
 	struct pim_interface *pim_ifp;
@@ -1327,7 +1327,7 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp;
 		struct listnode *sock_node;
-		struct igmp_sock *igmp;
+		struct gm_sock *igmp;
 
 		pim_ifp = ifp->info;
 

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -158,7 +158,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	pim_ifp->upstream_switch_list = NULL;
 	pim_ifp->pim_generation_id = 0;
 
-	/* list of struct igmp_sock */
+	/* list of struct gm_sock */
 	pim_igmp_if_init(pim_ifp, ifp);
 
 	/* list of struct pim_neighbor */
@@ -530,7 +530,7 @@ void pim_if_addr_add(struct connected *ifc)
 	//  return;
 
 	if (PIM_IF_TEST_IGMP(pim_ifp->options)) {
-		struct igmp_sock *igmp;
+		struct gm_sock *igmp;
 
 		/* lookup IGMP socket */
 		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->socket_list,
@@ -581,7 +581,7 @@ void pim_if_addr_add(struct connected *ifc)
 		}
 	} /* igmp */
 	else {
-		struct igmp_sock *igmp;
+		struct gm_sock *igmp;
 
 		/* lookup IGMP socket */
 		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->socket_list,
@@ -646,7 +646,7 @@ void pim_if_addr_add(struct connected *ifc)
 static void pim_if_addr_del_igmp(struct connected *ifc)
 {
 	struct pim_interface *pim_ifp = ifc->ifp->info;
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 	struct in_addr ifaddr;
 
 	if (ifc->address->family != AF_INET) {

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -115,7 +115,7 @@ static void igmp_sock_dump(array_t *igmp_sock_array)
 	int size = array_size(igmp_sock_array);
 	for (int i = 0; i < size; ++i) {
 
-		struct igmp_sock *igmp = array_get(igmp_sock_array, i);
+		struct gm_sock *igmp = array_get(igmp_sock_array, i);
 
 		zlog_debug("%s %s: [%d/%d] igmp_addr=%pI4 fd=%d", __FILE__,
 			   __func__, i, size, &igmp->ifaddr,
@@ -124,11 +124,11 @@ static void igmp_sock_dump(array_t *igmp_sock_array)
 }
 #endif
 
-struct igmp_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
-					      struct in_addr ifaddr)
+struct gm_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
+					    struct in_addr ifaddr)
 {
 	struct listnode *sock_node;
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 
 #ifdef IGMP_SOCK_DUMP
 	igmp_sock_dump(igmp_sock_list);
@@ -143,7 +143,7 @@ struct igmp_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
 
 static int pim_igmp_other_querier_expire(struct thread *t)
 {
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 
 	igmp = THREAD_ARG(t);
 
@@ -170,7 +170,7 @@ static int pim_igmp_other_querier_expire(struct thread *t)
 	return 0;
 }
 
-void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp)
+void pim_igmp_other_querier_timer_on(struct gm_sock *igmp)
 {
 	long other_querier_present_interval_msec;
 	struct pim_interface *pim_ifp;
@@ -243,7 +243,7 @@ void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp)
 			      &igmp->t_other_querier_timer);
 }
 
-void pim_igmp_other_querier_timer_off(struct igmp_sock *igmp)
+void pim_igmp_other_querier_timer_off(struct gm_sock *igmp)
 {
 	assert(igmp);
 
@@ -281,7 +281,7 @@ int igmp_validate_checksum(char *igmp_msg, int igmp_msg_len)
 	return 0;
 }
 
-static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
+static int igmp_recv_query(struct gm_sock *igmp, int query_version,
 			   int max_resp_code, struct in_addr from,
 			   const char *from_str, char *igmp_msg,
 			   int igmp_msg_len)
@@ -410,7 +410,7 @@ static void on_trace(const char *label, struct interface *ifp,
 	}
 }
 
-static int igmp_v1_recv_report(struct igmp_sock *igmp, struct in_addr from,
+static int igmp_v1_recv_report(struct gm_sock *igmp, struct in_addr from,
 			       const char *from_str, char *igmp_msg,
 			       int igmp_msg_len)
 {
@@ -517,7 +517,7 @@ bool pim_igmp_verify_header(struct ip *ip_hdr, size_t len, size_t *hlen)
 	return true;
 }
 
-int pim_igmp_packet(struct igmp_sock *igmp, char *buf, size_t len)
+int pim_igmp_packet(struct gm_sock *igmp, char *buf, size_t len)
 {
 	struct ip *ip_hdr = (struct ip *)buf;
 	size_t ip_hlen; /* ip header length in bytes */
@@ -606,7 +606,7 @@ int pim_igmp_packet(struct igmp_sock *igmp, char *buf, size_t len)
 	return -1;
 }
 
-void pim_igmp_general_query_on(struct igmp_sock *igmp)
+void pim_igmp_general_query_on(struct gm_sock *igmp)
 {
 	struct pim_interface *pim_ifp;
 	int startup_mode;
@@ -662,7 +662,7 @@ void pim_igmp_general_query_on(struct igmp_sock *igmp)
 			 query_interval, &igmp->t_igmp_query_timer);
 }
 
-void pim_igmp_general_query_off(struct igmp_sock *igmp)
+void pim_igmp_general_query_off(struct gm_sock *igmp)
 {
 	assert(igmp);
 
@@ -682,7 +682,7 @@ void pim_igmp_general_query_off(struct igmp_sock *igmp)
 /* Issue IGMP general query */
 static int pim_igmp_general_query(struct thread *t)
 {
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 	struct in_addr dst_addr;
 	struct in_addr group_addr;
 	struct pim_interface *pim_ifp;
@@ -738,7 +738,7 @@ static int pim_igmp_general_query(struct thread *t)
 	return 0;
 }
 
-static void sock_close(struct igmp_sock *igmp)
+static void sock_close(struct gm_sock *igmp)
 {
 	pim_igmp_other_querier_timer_off(igmp);
 	pim_igmp_general_query_off(igmp);
@@ -768,7 +768,7 @@ static void sock_close(struct igmp_sock *igmp)
 	}
 }
 
-void igmp_startup_mode_on(struct igmp_sock *igmp)
+void igmp_startup_mode_on(struct gm_sock *igmp)
 {
 	struct pim_interface *pim_ifp;
 
@@ -857,7 +857,7 @@ void igmp_group_delete_empty_include(struct gm_group *group)
 	igmp_group_delete(group);
 }
 
-void igmp_sock_free(struct igmp_sock *igmp)
+void igmp_sock_free(struct gm_sock *igmp)
 {
 	assert(!igmp->t_igmp_read);
 	assert(!igmp->t_igmp_query_timer);
@@ -866,7 +866,7 @@ void igmp_sock_free(struct igmp_sock *igmp)
 	XFREE(MTYPE_PIM_IGMP_SOCKET, igmp);
 }
 
-void igmp_sock_delete(struct igmp_sock *igmp)
+void igmp_sock_delete(struct gm_sock *igmp)
 {
 	struct pim_interface *pim_ifp;
 
@@ -886,7 +886,7 @@ void igmp_sock_delete_all(struct interface *ifp)
 {
 	struct pim_interface *pim_ifp;
 	struct listnode *igmp_node, *igmp_nextnode;
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 
 	pim_ifp = ifp->info;
 
@@ -953,11 +953,11 @@ void pim_igmp_if_fini(struct pim_interface *pim_ifp)
 	list_delete(&pim_ifp->socket_list);
 }
 
-static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
-				       struct interface *ifp, int mtrace_only)
+static struct gm_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
+				     struct interface *ifp, int mtrace_only)
 {
 	struct pim_interface *pim_ifp;
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 
 	pim_ifp = ifp->info;
 
@@ -1000,12 +1000,12 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	return igmp;
 }
 
-static void igmp_read_on(struct igmp_sock *igmp);
+static void igmp_read_on(struct gm_sock *igmp);
 
 static int pim_igmp_read(struct thread *t)
 {
 	uint8_t buf[10000];
-	struct igmp_sock *igmp = (struct igmp_sock *)THREAD_ARG(t);
+	struct gm_sock *igmp = (struct gm_sock *)THREAD_ARG(t);
 	struct sockaddr_in from;
 	struct sockaddr_in to;
 	socklen_t fromlen = sizeof(from);
@@ -1031,7 +1031,7 @@ done:
 	return 0;
 }
 
-static void igmp_read_on(struct igmp_sock *igmp)
+static void igmp_read_on(struct gm_sock *igmp)
 {
 
 	if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
@@ -1042,13 +1042,12 @@ static void igmp_read_on(struct igmp_sock *igmp)
 			&igmp->t_igmp_read);
 }
 
-struct igmp_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
-				    struct in_addr ifaddr,
-				    struct interface *ifp,
-				    bool mtrace_only)
+struct gm_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
+				  struct in_addr ifaddr, struct interface *ifp,
+				  bool mtrace_only)
 {
 	struct pim_interface *pim_ifp;
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 	struct sockaddr_in sin;
 	int fd;
 
@@ -1180,7 +1179,7 @@ void igmp_group_timer_on(struct gm_group *group, long interval_msec,
 			      interval_msec, &group->t_group_timer);
 }
 
-struct gm_group *find_group_by_addr(struct igmp_sock *igmp,
+struct gm_group *find_group_by_addr(struct gm_sock *igmp,
 				    struct in_addr group_addr)
 {
 	struct gm_group lookup;
@@ -1191,7 +1190,7 @@ struct gm_group *find_group_by_addr(struct igmp_sock *igmp,
 	return hash_lookup(pim_ifp->group_hash, &lookup);
 }
 
-struct gm_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
+struct gm_group *igmp_add_group_by_addr(struct gm_sock *igmp,
 					struct in_addr group_addr)
 {
 	struct gm_group *group;
@@ -1300,7 +1299,7 @@ void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver)
 {
 	struct pim_interface *pim_ifp = ifp->info;
 	struct listnode *sock_node = NULL;
-	struct igmp_sock *igmp = NULL;
+	struct gm_sock *igmp = NULL;
 	struct in_addr dst_addr;
 	struct in_addr group_addr;
 	int query_buf_size;

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -823,7 +823,7 @@ void igmp_group_delete(struct igmp_group *group)
 {
 	struct listnode *src_node;
 	struct listnode *src_nextnode;
-	struct igmp_source *src;
+	struct gm_source *src;
 	struct pim_interface *pim_ifp = group->interface->info;
 
 	if (PIM_DEBUG_IGMP_TRACE) {

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -39,7 +39,7 @@
 #include "pim_time.h"
 #include "pim_zebra.h"
 
-static void group_timer_off(struct igmp_group *group);
+static void group_timer_off(struct gm_group *group);
 static int pim_igmp_general_query(struct thread *t);
 
 /* This socket is used for TXing IGMP packets only, IGMP RX happens
@@ -415,7 +415,7 @@ static int igmp_v1_recv_report(struct igmp_sock *igmp, struct in_addr from,
 			       int igmp_msg_len)
 {
 	struct interface *ifp = igmp->interface;
-	struct igmp_group *group;
+	struct gm_group *group;
 	struct in_addr group_addr;
 
 	on_trace(__func__, igmp->interface, from);
@@ -789,7 +789,7 @@ void igmp_startup_mode_on(struct igmp_sock *igmp)
 	igmp->querier_query_interval = pim_ifp->default_query_interval;
 }
 
-static void igmp_group_free(struct igmp_group *group)
+static void igmp_group_free(struct gm_group *group)
 {
 	list_delete(&group->group_source_list);
 
@@ -819,7 +819,7 @@ static void igmp_group_count_decr(struct pim_interface *pim_ifp)
 	--pim_ifp->pim->igmp_group_count;
 }
 
-void igmp_group_delete(struct igmp_group *group)
+void igmp_group_delete(struct gm_group *group)
 {
 	struct listnode *src_node;
 	struct listnode *src_nextnode;
@@ -849,7 +849,7 @@ void igmp_group_delete(struct igmp_group *group)
 	igmp_group_free(group);
 }
 
-void igmp_group_delete_empty_include(struct igmp_group *group)
+void igmp_group_delete_empty_include(struct gm_group *group)
 {
 	assert(!group->group_filtermode_isexcl);
 	assert(!listcount(group->group_source_list));
@@ -898,15 +898,15 @@ void igmp_sock_delete_all(struct interface *ifp)
 
 static unsigned int igmp_group_hash_key(const void *arg)
 {
-	const struct igmp_group *group = arg;
+	const struct gm_group *group = arg;
 
 	return jhash_1word(group->group_addr.s_addr, 0);
 }
 
 static bool igmp_group_hash_equal(const void *arg1, const void *arg2)
 {
-	const struct igmp_group *g1 = (const struct igmp_group *)arg1;
-	const struct igmp_group *g2 = (const struct igmp_group *)arg2;
+	const struct gm_group *g1 = (const struct gm_group *)arg1;
+	const struct gm_group *g2 = (const struct gm_group *)arg2;
 
 	if (g1->group_addr.s_addr == g2->group_addr.s_addr)
 		return true;
@@ -932,7 +932,7 @@ void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp)
 void pim_igmp_if_reset(struct pim_interface *pim_ifp)
 {
 	struct listnode *grp_node, *grp_nextnode;
-	struct igmp_group *grp;
+	struct gm_group *grp;
 
 	for (ALL_LIST_ELEMENTS(pim_ifp->group_list, grp_node, grp_nextnode,
 			       grp)) {
@@ -1101,7 +1101,7 @@ struct igmp_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
  */
 static int igmp_group_timer(struct thread *t)
 {
-	struct igmp_group *group;
+	struct gm_group *group;
 
 	group = THREAD_ARG(t);
 
@@ -1137,7 +1137,7 @@ static int igmp_group_timer(struct thread *t)
 	return 0;
 }
 
-static void group_timer_off(struct igmp_group *group)
+static void group_timer_off(struct gm_group *group)
 {
 	if (!group->t_group_timer)
 		return;
@@ -1152,7 +1152,7 @@ static void group_timer_off(struct igmp_group *group)
 	THREAD_OFF(group->t_group_timer);
 }
 
-void igmp_group_timer_on(struct igmp_group *group, long interval_msec,
+void igmp_group_timer_on(struct gm_group *group, long interval_msec,
 			 const char *ifname)
 {
 	group_timer_off(group);
@@ -1180,10 +1180,10 @@ void igmp_group_timer_on(struct igmp_group *group, long interval_msec,
 			      interval_msec, &group->t_group_timer);
 }
 
-struct igmp_group *find_group_by_addr(struct igmp_sock *igmp,
-				      struct in_addr group_addr)
+struct gm_group *find_group_by_addr(struct igmp_sock *igmp,
+				    struct in_addr group_addr)
 {
-	struct igmp_group lookup;
+	struct gm_group lookup;
 	struct pim_interface *pim_ifp = igmp->interface->info;
 
 	lookup.group_addr.s_addr = group_addr.s_addr;
@@ -1191,10 +1191,10 @@ struct igmp_group *find_group_by_addr(struct igmp_sock *igmp,
 	return hash_lookup(pim_ifp->group_hash, &lookup);
 }
 
-struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
-					  struct in_addr group_addr)
+struct gm_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
+					struct in_addr group_addr)
 {
-	struct igmp_group *group;
+	struct gm_group *group;
 	struct pim_interface *pim_ifp = igmp->interface->info;
 
 	group = find_group_by_addr(igmp, group_addr);
@@ -1276,7 +1276,7 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 	return group;
 }
 
-void igmp_send_query(int igmp_version, struct igmp_group *group, int fd,
+void igmp_send_query(int igmp_version, struct gm_group *group, int fd,
 		     const char *ifname, char *query_buf, int query_buf_size,
 		     int num_sources, struct in_addr dst_addr,
 		     struct in_addr group_addr,

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -139,7 +139,7 @@ int igmp_validate_checksum(char *igmp_msg, int igmp_msg_len);
 #define IGMP_SOURCE_DONT_DELETE(flags)     ((flags) &= ~IGMP_SOURCE_MASK_DELETE)
 #define IGMP_SOURCE_DONT_SEND(flags)       ((flags) &= ~IGMP_SOURCE_MASK_SEND)
 
-struct igmp_source {
+struct gm_source {
 	struct in_addr source_addr;
 	struct thread *t_source_timer;
 	struct igmp_group *source_group; /* back pointer */
@@ -178,7 +178,7 @@ struct igmp_group {
 
 	struct in_addr group_addr;
 	int group_filtermode_isexcl;    /* 0=INCLUDE, 1=EXCLUDE */
-	struct list *group_source_list; /* list of struct igmp_source */
+	struct list *group_source_list; /* list of struct gm_source */
 	time_t group_creation;
 	struct interface *interface;
 	int64_t last_igmp_v1_report_dsec;
@@ -190,7 +190,7 @@ struct igmp_group *find_group_by_addr(struct igmp_sock *igmp,
 struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 					  struct in_addr group_addr);
 
-struct igmp_source *igmp_get_source_by_addr(struct igmp_group *group,
+struct gm_source *igmp_get_source_by_addr(struct igmp_group *group,
 					    struct in_addr src_addr,
 					    bool *created);
 

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -142,7 +142,7 @@ int igmp_validate_checksum(char *igmp_msg, int igmp_msg_len);
 struct gm_source {
 	struct in_addr source_addr;
 	struct thread *t_source_timer;
-	struct igmp_group *source_group; /* back pointer */
+	struct gm_group *source_group; /* back pointer */
 	time_t source_creation;
 	uint32_t source_flags;
 	struct channel_oil *source_channel_oil;
@@ -154,7 +154,7 @@ struct gm_source {
 	int source_query_retransmit_count;
 };
 
-struct igmp_group {
+struct gm_group {
 	/*
 	  RFC 3376: 6.2.2. Definition of Group Timers
 
@@ -185,30 +185,30 @@ struct igmp_group {
 	int64_t last_igmp_v2_report_dsec;
 };
 
-struct igmp_group *find_group_by_addr(struct igmp_sock *igmp,
-				      struct in_addr group_addr);
-struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
-					  struct in_addr group_addr);
+struct gm_group *find_group_by_addr(struct igmp_sock *igmp,
+				    struct in_addr group_addr);
+struct gm_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
+					struct in_addr group_addr);
 
-struct gm_source *igmp_get_source_by_addr(struct igmp_group *group,
-					    struct in_addr src_addr,
-					    bool *created);
+struct gm_source *igmp_get_source_by_addr(struct gm_group *group,
+					  struct in_addr src_addr,
+					  bool *created);
 
-void igmp_group_delete_empty_include(struct igmp_group *group);
+void igmp_group_delete_empty_include(struct gm_group *group);
 
 void igmp_startup_mode_on(struct igmp_sock *igmp);
 
-void igmp_group_timer_on(struct igmp_group *group, long interval_msec,
+void igmp_group_timer_on(struct gm_group *group, long interval_msec,
 			 const char *ifname);
 
-void igmp_send_query(int igmp_version, struct igmp_group *group, int fd,
+void igmp_send_query(int igmp_version, struct gm_group *group, int fd,
 		     const char *ifname, char *query_buf, int query_buf_size,
 		     int num_sources, struct in_addr dst_addr,
 		     struct in_addr group_addr,
 		     int query_max_response_time_dsec, uint8_t s_flag,
 		     uint8_t querier_robustness_variable,
 		     uint16_t querier_query_interval);
-void igmp_group_delete(struct igmp_group *group);
+void igmp_group_delete(struct gm_group *group);
 
 void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver);
 #endif /* PIM_IGMP_H */

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -82,7 +82,7 @@ struct igmp_join {
 	time_t sock_creation;
 };
 
-struct igmp_sock {
+struct gm_sock {
 	int fd;
 	struct interface *interface;
 	struct in_addr ifaddr;
@@ -108,21 +108,20 @@ void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp);
 void pim_igmp_if_reset(struct pim_interface *pim_ifp);
 void pim_igmp_if_fini(struct pim_interface *pim_ifp);
 
-struct igmp_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
-					      struct in_addr ifaddr);
-struct igmp_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
-				    struct in_addr ifaddr,
-				    struct interface *ifp,
-				    bool mtrace_only);
-void igmp_sock_delete(struct igmp_sock *igmp);
-void igmp_sock_free(struct igmp_sock *igmp);
+struct gm_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
+					    struct in_addr ifaddr);
+struct gm_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
+				  struct in_addr ifaddr, struct interface *ifp,
+				  bool mtrace_only);
+void igmp_sock_delete(struct gm_sock *igmp);
+void igmp_sock_free(struct gm_sock *igmp);
 void igmp_sock_delete_all(struct interface *ifp);
-int pim_igmp_packet(struct igmp_sock *igmp, char *buf, size_t len);
+int pim_igmp_packet(struct gm_sock *igmp, char *buf, size_t len);
 bool pim_igmp_verify_header(struct ip *ip_hdr, size_t len, size_t *ip_hlen);
-void pim_igmp_general_query_on(struct igmp_sock *igmp);
-void pim_igmp_general_query_off(struct igmp_sock *igmp);
-void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp);
-void pim_igmp_other_querier_timer_off(struct igmp_sock *igmp);
+void pim_igmp_general_query_on(struct gm_sock *igmp);
+void pim_igmp_general_query_off(struct gm_sock *igmp);
+void pim_igmp_other_querier_timer_on(struct gm_sock *igmp);
+void pim_igmp_other_querier_timer_off(struct gm_sock *igmp);
 
 int igmp_validate_checksum(char *igmp_msg, int igmp_msg_len);
 
@@ -185,9 +184,9 @@ struct gm_group {
 	int64_t last_igmp_v2_report_dsec;
 };
 
-struct gm_group *find_group_by_addr(struct igmp_sock *igmp,
+struct gm_group *find_group_by_addr(struct gm_sock *igmp,
 				    struct in_addr group_addr);
-struct gm_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
+struct gm_group *igmp_add_group_by_addr(struct gm_sock *igmp,
 					struct in_addr group_addr);
 
 struct gm_source *igmp_get_source_by_addr(struct gm_group *group,
@@ -196,7 +195,7 @@ struct gm_source *igmp_get_source_by_addr(struct gm_group *group,
 
 void igmp_group_delete_empty_include(struct gm_group *group);
 
-void igmp_startup_mode_on(struct igmp_sock *igmp);
+void igmp_startup_mode_on(struct gm_sock *igmp);
 
 void igmp_group_timer_on(struct gm_group *group, long interval_msec,
 			 const char *ifname);

--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -564,7 +564,7 @@ static int mtrace_send_response(struct pim_instance *pim,
 				  mtracep->rsp_addr, mtracep->grp_addr);
 }
 
-int igmp_mtrace_recv_qry_req(struct igmp_sock *igmp, struct ip *ip_hdr,
+int igmp_mtrace_recv_qry_req(struct gm_sock *igmp, struct ip *ip_hdr,
 			     struct in_addr from, const char *from_str,
 			     char *igmp_msg, int igmp_msg_len)
 {
@@ -799,7 +799,7 @@ int igmp_mtrace_recv_qry_req(struct igmp_sock *igmp, struct ip *ip_hdr,
 }
 
 /* 6.3. Traceroute responses */
-int igmp_mtrace_recv_response(struct igmp_sock *igmp, struct ip *ip_hdr,
+int igmp_mtrace_recv_response(struct gm_sock *igmp, struct ip *ip_hdr,
 			      struct in_addr from, const char *from_str,
 			      char *igmp_msg, int igmp_msg_len)
 {

--- a/pimd/pim_igmp_mtrace.h
+++ b/pimd/pim_igmp_mtrace.h
@@ -94,11 +94,11 @@ struct igmp_mtrace {
 #define MTRACE_HDR_SIZE (sizeof(struct igmp_mtrace))
 #define MTRACE_RSP_SIZE (sizeof(struct igmp_mtrace_rsp))
 
-int igmp_mtrace_recv_qry_req(struct igmp_sock *igmp, struct ip *ip_hdr,
+int igmp_mtrace_recv_qry_req(struct gm_sock *igmp, struct ip *ip_hdr,
 			     struct in_addr from, const char *from_str,
 			     char *igmp_msg, int igmp_msg_len);
 
-int igmp_mtrace_recv_response(struct igmp_sock *igmp, struct ip *ip_hdr,
+int igmp_mtrace_recv_response(struct gm_sock *igmp, struct ip *ip_hdr,
 			      struct in_addr from, const char *from_str,
 			      char *igmp_msg, int igmp_msg_len);
 

--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -102,7 +102,7 @@ void igmp_v2_send_query(struct gm_group *group, int fd, const char *ifname,
 	}
 }
 
-int igmp_v2_recv_report(struct igmp_sock *igmp, struct in_addr from,
+int igmp_v2_recv_report(struct gm_sock *igmp, struct in_addr from,
 			const char *from_str, char *igmp_msg, int igmp_msg_len)
 {
 	struct interface *ifp = igmp->interface;
@@ -158,7 +158,7 @@ int igmp_v2_recv_report(struct igmp_sock *igmp, struct in_addr from,
 	return 0;
 }
 
-int igmp_v2_recv_leave(struct igmp_sock *igmp, struct ip *ip_hdr,
+int igmp_v2_recv_leave(struct gm_sock *igmp, struct ip *ip_hdr,
 		       const char *from_str, char *igmp_msg, int igmp_msg_len)
 {
 	struct interface *ifp = igmp->interface;

--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -39,7 +39,7 @@ static void on_trace(const char *label, struct interface *ifp,
 	}
 }
 
-void igmp_v2_send_query(struct igmp_group *group, int fd, const char *ifname,
+void igmp_v2_send_query(struct gm_group *group, int fd, const char *ifname,
 			char *query_buf, struct in_addr dst_addr,
 			struct in_addr group_addr,
 			int query_max_response_time_dsec)

--- a/pimd/pim_igmpv2.h
+++ b/pimd/pim_igmpv2.h
@@ -26,10 +26,10 @@ void igmp_v2_send_query(struct gm_group *group, int fd, const char *ifname,
 			struct in_addr group_addr,
 			int query_max_response_time_dsec);
 
-int igmp_v2_recv_report(struct igmp_sock *igmp, struct in_addr from,
+int igmp_v2_recv_report(struct gm_sock *igmp, struct in_addr from,
 			const char *from_str, char *igmp_msg, int igmp_msg_len);
 
-int igmp_v2_recv_leave(struct igmp_sock *igmp, struct ip *ip_hdr,
+int igmp_v2_recv_leave(struct gm_sock *igmp, struct ip *ip_hdr,
 		       const char *from_str, char *igmp_msg, int igmp_msg_len);
 
 #endif /* PIM_IGMPV2_H */

--- a/pimd/pim_igmpv2.h
+++ b/pimd/pim_igmpv2.h
@@ -21,7 +21,7 @@
 #ifndef PIM_IGMPV2_H
 #define PIM_IGMPV2_H
 
-void igmp_v2_send_query(struct igmp_group *group, int fd, const char *ifname,
+void igmp_v2_send_query(struct gm_group *group, int fd, const char *ifname,
 			char *query_buf, struct in_addr dst_addr,
 			struct in_addr group_addr,
 			int query_max_response_time_dsec);

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -60,7 +60,7 @@ static void on_trace(const char *label, struct interface *ifp,
 static inline long igmp_gmi_msec(struct gm_group *group)
 {
 	struct pim_interface *pim_ifp = group->interface->info;
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 	struct listnode *sock_node;
 
 	long qrv = 0, qqi = 0;
@@ -481,7 +481,7 @@ struct gm_source *igmp_get_source_by_addr(struct gm_group *group,
 	return src;
 }
 
-static void allow(struct igmp_sock *igmp, struct in_addr from,
+static void allow(struct gm_sock *igmp, struct in_addr from,
 		  struct in_addr group_addr, int num_sources,
 		  struct in_addr *sources)
 {
@@ -548,7 +548,7 @@ static void allow(struct igmp_sock *igmp, struct in_addr from,
 	} /* scan received sources */
 }
 
-void igmpv3_report_isin(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_isin(struct gm_sock *igmp, struct in_addr from,
 			struct in_addr group_addr, int num_sources,
 			struct in_addr *sources)
 {
@@ -658,7 +658,7 @@ static void isex_incl(struct gm_group *group, int num_sources,
 	group_exclude_fwd_anysrc_ifempty(group);
 }
 
-void igmpv3_report_isex(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_isex(struct gm_sock *igmp, struct in_addr from,
 			struct in_addr group_addr, int num_sources,
 			struct in_addr *sources, int from_igmp_v2_report)
 {
@@ -775,7 +775,7 @@ static void toin_excl(struct gm_group *group, int num_sources,
 	group_query_send(group);
 }
 
-void igmpv3_report_toin(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_toin(struct gm_sock *igmp, struct in_addr from,
 			struct in_addr group_addr, int num_sources,
 			struct in_addr *sources)
 {
@@ -936,7 +936,7 @@ static void toex_excl(struct gm_group *group, int num_sources,
 	}
 }
 
-void igmpv3_report_toex(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_toex(struct gm_sock *igmp, struct in_addr from,
 			struct in_addr group_addr, int num_sources,
 			struct in_addr *sources)
 {
@@ -965,7 +965,7 @@ void igmpv3_report_toex(struct igmp_sock *igmp, struct in_addr from,
 	igmp_group_reset_gmi(group);
 }
 
-void igmpv3_report_allow(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_allow(struct gm_sock *igmp, struct in_addr from,
 			 struct in_addr group_addr, int num_sources,
 			 struct in_addr *sources)
 {
@@ -981,7 +981,7 @@ static void igmp_send_query_group(struct gm_group *group, char *query_buf,
 {
 	struct interface *ifp = group->interface;
 	struct pim_interface *pim_ifp = ifp->info;
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 	struct listnode *sock_node;
 
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
@@ -1460,7 +1460,7 @@ static void block_incl(struct gm_group *group, int num_sources,
 	}
 }
 
-void igmpv3_report_block(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_block(struct gm_sock *igmp, struct in_addr from,
 			 struct in_addr group_addr, int num_sources,
 			 struct in_addr *sources)
 {
@@ -1689,7 +1689,7 @@ void igmp_v3_send_query(struct gm_group *group, int fd, const char *ifname,
 	}
 }
 
-void igmp_v3_recv_query(struct igmp_sock *igmp, const char *from_str,
+void igmp_v3_recv_query(struct gm_sock *igmp, const char *from_str,
 			char *igmp_msg)
 {
 	struct interface *ifp;
@@ -1825,7 +1825,7 @@ void igmp_v3_recv_query(struct igmp_sock *igmp, const char *from_str,
 	} /* s_flag is clear: timer updates */
 }
 
-int igmp_v3_recv_report(struct igmp_sock *igmp, struct in_addr from,
+int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from,
 			const char *from_str, char *igmp_msg, int igmp_msg_len)
 {
 	int num_groups;

--- a/pimd/pim_igmpv3.h
+++ b/pimd/pim_igmpv3.h
@@ -53,9 +53,8 @@
 /* OHPI: Older Host Present Interval */
 #define PIM_IGMP_OHPI_DSEC(qrv,qqi,qri_dsec) ((qrv) * (10 * (qqi)) + (qri_dsec))
 
-void igmp_group_reset_gmi(struct igmp_group *group);
-void igmp_source_reset_gmi(struct igmp_group *group,
-			   struct gm_source *source);
+void igmp_group_reset_gmi(struct gm_group *group);
+void igmp_source_reset_gmi(struct gm_group *group, struct gm_source *source);
 
 void igmp_source_free(struct gm_source *source);
 void igmp_source_delete(struct gm_source *source);
@@ -80,13 +79,13 @@ void igmpv3_report_block(struct igmp_sock *igmp, struct in_addr from,
 			 struct in_addr group_addr, int num_sources,
 			 struct in_addr *sources);
 
-void igmp_group_timer_lower_to_lmqt(struct igmp_group *group);
+void igmp_group_timer_lower_to_lmqt(struct gm_group *group);
 void igmp_source_timer_lower_to_lmqt(struct gm_source *source);
 
-struct gm_source *igmp_find_source_by_addr(struct igmp_group *group,
-					     struct in_addr src_addr);
+struct gm_source *igmp_find_source_by_addr(struct gm_group *group,
+					   struct in_addr src_addr);
 
-void igmp_v3_send_query(struct igmp_group *group, int fd, const char *ifname,
+void igmp_v3_send_query(struct gm_group *group, int fd, const char *ifname,
 			char *query_buf, int query_buf_size, int num_sources,
 			struct in_addr dst_addr, struct in_addr group_addr,
 			int query_max_response_time_dsec, uint8_t s_flag,

--- a/pimd/pim_igmpv3.h
+++ b/pimd/pim_igmpv3.h
@@ -60,22 +60,22 @@ void igmp_source_free(struct gm_source *source);
 void igmp_source_delete(struct gm_source *source);
 void igmp_source_delete_expired(struct list *source_list);
 
-void igmpv3_report_isin(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_isin(struct gm_sock *igmp, struct in_addr from,
 			struct in_addr group_addr, int num_sources,
 			struct in_addr *sources);
-void igmpv3_report_isex(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_isex(struct gm_sock *igmp, struct in_addr from,
 			struct in_addr group_addr, int num_sources,
 			struct in_addr *sources, int from_igmp_v2_report);
-void igmpv3_report_toin(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_toin(struct gm_sock *igmp, struct in_addr from,
 			struct in_addr group_addr, int num_sources,
 			struct in_addr *sources);
-void igmpv3_report_toex(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_toex(struct gm_sock *igmp, struct in_addr from,
 			struct in_addr group_addr, int num_sources,
 			struct in_addr *sources);
-void igmpv3_report_allow(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_allow(struct gm_sock *igmp, struct in_addr from,
 			 struct in_addr group_addr, int num_sources,
 			 struct in_addr *sources);
-void igmpv3_report_block(struct igmp_sock *igmp, struct in_addr from,
+void igmpv3_report_block(struct gm_sock *igmp, struct in_addr from,
 			 struct in_addr group_addr, int num_sources,
 			 struct in_addr *sources);
 
@@ -92,10 +92,10 @@ void igmp_v3_send_query(struct gm_group *group, int fd, const char *ifname,
 			uint8_t querier_robustness_variable,
 			uint16_t querier_query_interval);
 
-void igmp_v3_recv_query(struct igmp_sock *igmp, const char *from_str,
+void igmp_v3_recv_query(struct gm_sock *igmp, const char *from_str,
 			char *igmp_msg);
 
-int igmp_v3_recv_report(struct igmp_sock *igmp, struct in_addr from,
+int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from,
 			const char *from_str, char *igmp_msg, int igmp_msg_len);
 
 #endif /* PIM_IGMPV3_H */

--- a/pimd/pim_igmpv3.h
+++ b/pimd/pim_igmpv3.h
@@ -55,10 +55,10 @@
 
 void igmp_group_reset_gmi(struct igmp_group *group);
 void igmp_source_reset_gmi(struct igmp_group *group,
-			   struct igmp_source *source);
+			   struct gm_source *source);
 
-void igmp_source_free(struct igmp_source *source);
-void igmp_source_delete(struct igmp_source *source);
+void igmp_source_free(struct gm_source *source);
+void igmp_source_delete(struct gm_source *source);
 void igmp_source_delete_expired(struct list *source_list);
 
 void igmpv3_report_isin(struct igmp_sock *igmp, struct in_addr from,
@@ -81,9 +81,9 @@ void igmpv3_report_block(struct igmp_sock *igmp, struct in_addr from,
 			 struct in_addr *sources);
 
 void igmp_group_timer_lower_to_lmqt(struct igmp_group *group);
-void igmp_source_timer_lower_to_lmqt(struct igmp_source *source);
+void igmp_source_timer_lower_to_lmqt(struct gm_source *source);
 
-struct igmp_source *igmp_find_source_by_addr(struct igmp_group *group,
+struct gm_source *igmp_find_source_by_addr(struct igmp_group *group,
 					     struct in_addr src_addr);
 
 void igmp_v3_send_query(struct igmp_group *group, int fd, const char *ifname,

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -593,7 +593,7 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 	const struct ip *ip_hdr;
 	const struct igmpmsg *msg;
 	struct in_addr ifaddr;
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 	const struct prefix *connected_src;
 
 	if (buf_size < (int)sizeof(struct ip))

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -88,7 +88,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 	/* scan igmp groups */
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
 		struct listnode *srcnode;
-		struct igmp_source *src;
+		struct gm_source *src;
 
 		/* scan group sources */
 		for (ALL_LIST_ELEMENTS_RO(grp->group_source_list, srcnode,
@@ -467,7 +467,7 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	/* scan socket groups */
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grp_node, grp)) {
 		struct listnode *src_node;
-		struct igmp_source *src;
+		struct gm_source *src;
 
 		/* reset group timers for groups in EXCLUDE mode */
 		if (grp->group_filtermode_isexcl)

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -62,7 +62,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 {
 	struct pim_interface *pim_ifp;
 	struct listnode *grpnode;
-	struct igmp_group *grp;
+	struct gm_group *grp;
 
 
 	pim_ifp = ifp->info;
@@ -444,7 +444,7 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	struct listnode *sock_node;
 	struct igmp_sock *igmp;
 	struct listnode *grp_node;
-	struct igmp_group *grp;
+	struct gm_group *grp;
 
 	if (pim_ifp->query_max_response_time_dsec
 	    == query_max_response_time_dsec)

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -365,7 +365,7 @@ static int pim_cmd_igmp_start(struct interface *ifp)
  * This function propagates the reconfiguration to every active socket
  * for that interface.
  */
-static void igmp_sock_query_interval_reconfig(struct igmp_sock *igmp)
+static void igmp_sock_query_interval_reconfig(struct gm_sock *igmp)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -395,7 +395,7 @@ static void igmp_sock_query_interval_reconfig(struct igmp_sock *igmp)
 	igmp_startup_mode_on(igmp);
 }
 
-static void igmp_sock_query_reschedule(struct igmp_sock *igmp)
+static void igmp_sock_query_reschedule(struct gm_sock *igmp)
 {
 	if (igmp->mtrace_only)
 		return;
@@ -428,7 +428,7 @@ static void change_query_interval(struct pim_interface *pim_ifp,
 		int query_interval)
 {
 	struct listnode *sock_node;
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 
 	pim_ifp->default_query_interval = query_interval;
 
@@ -442,7 +442,7 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 		int query_max_response_time_dsec)
 {
 	struct listnode *sock_node;
-	struct igmp_sock *igmp;
+	struct gm_sock *igmp;
 	struct listnode *grp_node;
 	struct gm_group *grp;
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -472,7 +472,7 @@ void pim_zebra_init(void)
 }
 
 void igmp_anysource_forward_start(struct pim_instance *pim,
-				  struct igmp_group *group)
+				  struct gm_group *group)
 {
 	struct gm_source *source;
 	struct in_addr src_addr = {.s_addr = 0};
@@ -489,7 +489,7 @@ void igmp_anysource_forward_start(struct pim_instance *pim,
 	igmp_source_forward_start(pim, source);
 }
 
-void igmp_anysource_forward_stop(struct igmp_group *group)
+void igmp_anysource_forward_stop(struct gm_group *group)
 {
 	struct gm_source *source;
 	struct in_addr star = {.s_addr = 0};
@@ -503,7 +503,7 @@ static void igmp_source_forward_reevaluate_one(struct pim_instance *pim,
 					       struct gm_source *source)
 {
 	struct prefix_sg sg;
-	struct igmp_group *group = source->source_group;
+	struct gm_group *group = source->source_group;
 	struct pim_ifchannel *ch;
 
 	if ((source->source_addr.s_addr != INADDR_ANY)
@@ -547,7 +547,7 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp = ifp->info;
 		struct listnode *grpnode;
-		struct igmp_group *grp;
+		struct gm_group *grp;
 		struct pim_ifchannel *ch, *ch_temp;
 
 		if (!pim_ifp)
@@ -579,7 +579,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
 			       struct gm_source *source)
 {
 	struct pim_interface *pim_oif;
-	struct igmp_group *group;
+	struct gm_group *group;
 	struct prefix_sg sg;
 	int result;
 	int input_iface_vif_index = 0;
@@ -759,7 +759,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
  */
 void igmp_source_forward_stop(struct gm_source *source)
 {
-	struct igmp_group *group;
+	struct gm_group *group;
 	struct prefix_sg sg;
 	int result;
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -474,7 +474,7 @@ void pim_zebra_init(void)
 void igmp_anysource_forward_start(struct pim_instance *pim,
 				  struct igmp_group *group)
 {
-	struct igmp_source *source;
+	struct gm_source *source;
 	struct in_addr src_addr = {.s_addr = 0};
 	/* Any source (*,G) is forwarded only if mode is EXCLUDE {empty} */
 	assert(group->group_filtermode_isexcl);
@@ -491,7 +491,7 @@ void igmp_anysource_forward_start(struct pim_instance *pim,
 
 void igmp_anysource_forward_stop(struct igmp_group *group)
 {
-	struct igmp_source *source;
+	struct gm_source *source;
 	struct in_addr star = {.s_addr = 0};
 
 	source = igmp_find_source_by_addr(group, star);
@@ -500,7 +500,7 @@ void igmp_anysource_forward_stop(struct igmp_group *group)
 }
 
 static void igmp_source_forward_reevaluate_one(struct pim_instance *pim,
-					       struct igmp_source *source)
+					       struct gm_source *source)
 {
 	struct prefix_sg sg;
 	struct igmp_group *group = source->source_group;
@@ -556,7 +556,7 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 		/* scan igmp groups */
 		for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
 			struct listnode *srcnode;
-			struct igmp_source *src;
+			struct gm_source *src;
 
 			/* scan group sources */
 			for (ALL_LIST_ELEMENTS_RO(grp->group_source_list,
@@ -576,7 +576,7 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 }
 
 void igmp_source_forward_start(struct pim_instance *pim,
-			       struct igmp_source *source)
+			       struct gm_source *source)
 {
 	struct pim_interface *pim_oif;
 	struct igmp_group *group;
@@ -757,7 +757,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
   igmp_source_forward_stop: stop fowarding, but keep the source
   igmp_source_delete:       stop fowarding, and delete the source
  */
-void igmp_source_forward_stop(struct igmp_source *source)
+void igmp_source_forward_stop(struct gm_source *source)
 {
 	struct igmp_group *group;
 	struct prefix_sg sg;

--- a/pimd/pim_zebra.h
+++ b/pimd/pim_zebra.h
@@ -37,8 +37,8 @@ void igmp_anysource_forward_start(struct pim_instance *pim,
 void igmp_anysource_forward_stop(struct igmp_group *group);
 
 void igmp_source_forward_start(struct pim_instance *pim,
-			       struct igmp_source *source);
-void igmp_source_forward_stop(struct igmp_source *source);
+			       struct gm_source *source);
+void igmp_source_forward_stop(struct gm_source *source);
 void igmp_source_forward_reevaluate_all(struct pim_instance *pim);
 
 void pim_forward_start(struct pim_ifchannel *ch);

--- a/pimd/pim_zebra.h
+++ b/pimd/pim_zebra.h
@@ -33,8 +33,8 @@ void pim_scan_individual_oil(struct channel_oil *c_oil, int in_vif_index);
 void pim_scan_oil(struct pim_instance *pim_matcher);
 
 void igmp_anysource_forward_start(struct pim_instance *pim,
-				  struct igmp_group *group);
-void igmp_anysource_forward_stop(struct igmp_group *group);
+				  struct gm_group *group);
+void igmp_anysource_forward_stop(struct gm_group *group);
 
 void igmp_source_forward_start(struct pim_instance *pim,
 			       struct gm_source *source);


### PR DESCRIPTION
Modifying the name of structures igmp_source and igmp_group to gm_source and gm_group respectively, which are to be used by both IPv4 and IPv6(for both MLD and IGMP).

Issues:  #10023

Co-authored-by: Mobashshera Rasool <mrasool@vmware.com>
Co-authored-by: Sarita Patra <saritap@vmware.com>
Signed-off-by: Sai Gomathi <nsaigomathi@vmware.com>