### PR TITLE
pimd: re-rename fields in `struct pim_interface`

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -508,7 +508,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 		if (!pim_ifp)
 			continue;
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node,
 					  igmp)) {
 			char uptime[10];
 			char query_hhmmss[10];
@@ -525,7 +525,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 				json_object_string_add(json_row, "upTime",
 						       uptime);
 				json_object_int_add(json_row, "version",
-						    pim_ifp->version);
+						    pim_ifp->igmp_version);
 
 				if (igmp->t_igmp_query_timer) {
 					json_object_boolean_true_add(json_row,
@@ -555,7 +555,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 						: "down",
 					inet_ntop(AF_INET, &igmp->ifaddr, buf,
 						  sizeof(buf)),
-					pim_ifp->version,
+					pim_ifp->igmp_version,
 					igmp->t_igmp_query_timer ? "local"
 								 : "other",
 					&igmp->querier_addr, query_hhmmss,
@@ -610,7 +610,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 		if (strcmp(ifname, "detail") && strcmp(ifname, ifp->name))
 			continue;
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node,
 					  igmp)) {
 			found_ifname = 1;
 			pim_time_uptime(uptime, sizeof(uptime),
@@ -625,33 +625,35 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 			gmi_msec = PIM_IGMP_GMI_MSEC(
 				igmp->querier_robustness_variable,
 				igmp->querier_query_interval,
-				pim_ifp->query_max_response_time_dsec);
+				pim_ifp->igmp_query_max_response_time_dsec);
 
-			sqi = PIM_IGMP_SQI(pim_ifp->default_query_interval);
+			sqi = PIM_IGMP_SQI(
+				pim_ifp->igmp_default_query_interval);
 
 			oqpi_msec = PIM_IGMP_OQPI_MSEC(
 				igmp->querier_robustness_variable,
 				igmp->querier_query_interval,
-				pim_ifp->query_max_response_time_dsec);
+				pim_ifp->igmp_query_max_response_time_dsec);
 
 			lmqt_msec = PIM_IGMP_LMQT_MSEC(
-				pim_ifp->specific_query_max_response_time_dsec,
-				pim_ifp->last_member_query_count);
+				pim_ifp->igmp_specific_query_max_response_time_dsec,
+				pim_ifp->igmp_last_member_query_count);
 
 			ohpi_msec =
 				PIM_IGMP_OHPI_DSEC(
 					igmp->querier_robustness_variable,
 					igmp->querier_query_interval,
-					pim_ifp->query_max_response_time_dsec)
+					pim_ifp->igmp_query_max_response_time_dsec)
 				* 100;
 
-			qri_msec = pim_ifp->query_max_response_time_dsec * 100;
+			qri_msec = pim_ifp->igmp_query_max_response_time_dsec
+				* 100;
 			if (pim_ifp->pim_sock_fd >= 0)
 				mloop = pim_socket_mcastloop_get(
 					pim_ifp->pim_sock_fd);
 			else
 				mloop = 0;
-			lmqc = pim_ifp->last_member_query_count;
+			lmqc = pim_ifp->igmp_last_member_query_count;
 
 			if (uj) {
 				json_row = json_object_new_object();
@@ -674,7 +676,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 						       "queryOtherTimer",
 						       other_hhmmss);
 				json_object_int_add(json_row, "version",
-						    pim_ifp->version);
+						    pim_ifp->igmp_version);
 				json_object_int_add(
 					json_row,
 					"timerGroupMembershipIntervalMsec",
@@ -725,7 +727,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 					&pim_ifp->primary_address);
 				vty_out(vty, "Uptime    : %s\n", uptime);
 				vty_out(vty, "Version   : %d\n",
-					pim_ifp->version);
+					pim_ifp->igmp_version);
 				vty_out(vty, "\n");
 				vty_out(vty, "\n");
 
@@ -831,14 +833,15 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 		if (!pim_ifp)
 			continue;
 
-		if (!pim_ifp->join_list)
+		if (!pim_ifp->igmp_join_list)
 			continue;
 
 		pri_addr = pim_find_primary_addr(ifp);
 		pim_inet4_dump("<pri?>", pri_addr, pri_addr_str,
 			       sizeof(pri_addr_str));
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->join_list, join_node, ij)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_join_list, join_node,
+					  ij)) {
 			char group_str[INET_ADDRSTRLEN];
 			char source_str[INET_ADDRSTRLEN];
 			char uptime[10];
@@ -884,7 +887,7 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 					ifp->name, pri_addr_str, source_str,
 					group_str, ij->sock_fd, uptime);
 			}
-		} /* for (pim_ifp->join_list) */
+		} /* for (pim_ifp->igmp_join_list) */
 
 	} /* for (iflist) */
 
@@ -1337,7 +1340,7 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 		if (ifname && strcmp(ifname, ifp->name))
 			continue;
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node,
 					  igmp)) {
 			igmp_stats_add(&rx_stats, &igmp->rx_stats);
 		}
@@ -3426,7 +3429,8 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			char hhmmss[10];
 			char uptime[10];
@@ -3519,7 +3523,8 @@ static void igmp_show_group_retransmission(struct pim_instance *pim,
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			char grp_retr_mmss[10];
 			struct listnode *src_node;
@@ -3571,7 +3576,8 @@ static void igmp_show_sources(struct pim_instance *pim, struct vty *vty)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			struct listnode *srcnode;
 			struct igmp_source *src;
@@ -3604,7 +3610,7 @@ static void igmp_show_sources(struct pim_instance *pim, struct vty *vty)
 					uptime);
 
 			} /* scan group sources */
-		}	 /* scan igmp groups */
+		}	  /* scan igmp groups */
 	}		  /* scan interfaces */
 }
 
@@ -3626,7 +3632,8 @@ static void igmp_show_source_retransmission(struct pim_instance *pim,
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			struct listnode *srcnode;
 			struct igmp_source *src;
@@ -3647,7 +3654,7 @@ static void igmp_show_source_retransmission(struct pim_instance *pim,
 					src->source_query_retransmit_count);
 
 			} /* scan group sources */
-		}	 /* scan igmp groups */
+		}	  /* scan igmp groups */
 	}		  /* scan interfaces */
 }
 
@@ -3916,9 +3923,9 @@ static void clear_mroute(struct pim_instance *pim)
 
 		/* clean up all igmp groups */
 
-		if (pim_ifp->group_list) {
-			while (pim_ifp->group_list->count) {
-				grp = listnode_head(pim_ifp->group_list);
+		if (pim_ifp->igmp_group_list) {
+			while (pim_ifp->igmp_group_list->count) {
+				grp = listnode_head(pim_ifp->igmp_group_list);
 				igmp_group_delete(grp);
 			}
 		}

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -508,7 +508,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 		if (!pim_ifp)
 			continue;
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node,
 					  igmp)) {
 			char uptime[10];
 			char query_hhmmss[10];
@@ -610,7 +610,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 		if (strcmp(ifname, "detail") && strcmp(ifname, ifp->name))
 			continue;
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node,
 					  igmp)) {
 			found_ifname = 1;
 			pim_time_uptime(uptime, sizeof(uptime),
@@ -625,35 +625,34 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 			gmi_msec = PIM_IGMP_GMI_MSEC(
 				igmp->querier_robustness_variable,
 				igmp->querier_query_interval,
-				pim_ifp->igmp_query_max_response_time_dsec);
+				pim_ifp->gm_query_max_response_time_dsec);
 
-			sqi = PIM_IGMP_SQI(
-				pim_ifp->igmp_default_query_interval);
+			sqi = PIM_IGMP_SQI(pim_ifp->gm_default_query_interval);
 
 			oqpi_msec = PIM_IGMP_OQPI_MSEC(
 				igmp->querier_robustness_variable,
 				igmp->querier_query_interval,
-				pim_ifp->igmp_query_max_response_time_dsec);
+				pim_ifp->gm_query_max_response_time_dsec);
 
 			lmqt_msec = PIM_IGMP_LMQT_MSEC(
-				pim_ifp->igmp_specific_query_max_response_time_dsec,
-				pim_ifp->igmp_last_member_query_count);
+				pim_ifp->gm_specific_query_max_response_time_dsec,
+				pim_ifp->gm_last_member_query_count);
 
 			ohpi_msec =
 				PIM_IGMP_OHPI_DSEC(
 					igmp->querier_robustness_variable,
 					igmp->querier_query_interval,
-					pim_ifp->igmp_query_max_response_time_dsec)
+					pim_ifp->gm_query_max_response_time_dsec)
 				* 100;
 
-			qri_msec = pim_ifp->igmp_query_max_response_time_dsec
-				* 100;
+			qri_msec =
+				pim_ifp->gm_query_max_response_time_dsec * 100;
 			if (pim_ifp->pim_sock_fd >= 0)
 				mloop = pim_socket_mcastloop_get(
 					pim_ifp->pim_sock_fd);
 			else
 				mloop = 0;
-			lmqc = pim_ifp->igmp_last_member_query_count;
+			lmqc = pim_ifp->gm_last_member_query_count;
 
 			if (uj) {
 				json_row = json_object_new_object();
@@ -833,14 +832,14 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 		if (!pim_ifp)
 			continue;
 
-		if (!pim_ifp->igmp_join_list)
+		if (!pim_ifp->gm_join_list)
 			continue;
 
 		pri_addr = pim_find_primary_addr(ifp);
 		pim_inet4_dump("<pri?>", pri_addr, pri_addr_str,
 			       sizeof(pri_addr_str));
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_join_list, join_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_join_list, join_node,
 					  ij)) {
 			char group_str[INET_ADDRSTRLEN];
 			char source_str[INET_ADDRSTRLEN];
@@ -887,7 +886,7 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 					ifp->name, pri_addr_str, source_str,
 					group_str, ij->sock_fd, uptime);
 			}
-		} /* for (pim_ifp->igmp_join_list) */
+		} /* for (pim_ifp->gm_join_list) */
 
 	} /* for (iflist) */
 
@@ -1340,7 +1339,7 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 		if (ifname && strcmp(ifname, ifp->name))
 			continue;
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node,
 					  igmp)) {
 			igmp_stats_add(&rx_stats, &igmp->rx_stats);
 		}
@@ -3429,7 +3428,7 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			char hhmmss[10];
@@ -3523,7 +3522,7 @@ static void igmp_show_group_retransmission(struct pim_instance *pim,
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			char grp_retr_mmss[10];
@@ -3576,7 +3575,7 @@ static void igmp_show_sources(struct pim_instance *pim, struct vty *vty)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			struct listnode *srcnode;
@@ -3632,7 +3631,7 @@ static void igmp_show_source_retransmission(struct pim_instance *pim,
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			struct listnode *srcnode;
@@ -3923,9 +3922,9 @@ static void clear_mroute(struct pim_instance *pim)
 
 		/* clean up all igmp groups */
 
-		if (pim_ifp->igmp_group_list) {
-			while (pim_ifp->igmp_group_list->count) {
-				grp = listnode_head(pim_ifp->igmp_group_list);
+		if (pim_ifp->gm_group_list) {
+			while (pim_ifp->gm_group_list->count) {
+				grp = listnode_head(pim_ifp->gm_group_list);
 				igmp_group_delete(grp);
 			}
 		}

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -124,14 +124,16 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	pim_ifp->pim = ifp->vrf->info;
 	pim_ifp->mroute_vif_index = -1;
 
-	pim_ifp->version = IGMP_DEFAULT_VERSION;
-	pim_ifp->default_robustness_variable = IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
-	pim_ifp->default_query_interval = IGMP_GENERAL_QUERY_INTERVAL;
-	pim_ifp->query_max_response_time_dsec =
+	pim_ifp->igmp_version = IGMP_DEFAULT_VERSION;
+	pim_ifp->igmp_default_robustness_variable =
+		IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
+	pim_ifp->igmp_default_query_interval = IGMP_GENERAL_QUERY_INTERVAL;
+	pim_ifp->igmp_query_max_response_time_dsec =
 		IGMP_QUERY_MAX_RESPONSE_TIME_DSEC;
-	pim_ifp->specific_query_max_response_time_dsec =
+	pim_ifp->igmp_specific_query_max_response_time_dsec =
 		IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC;
-	pim_ifp->last_member_query_count = IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
+	pim_ifp->igmp_last_member_query_count =
+		IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
 
 	/* BSM config on interface: true by default */
 	pim_ifp->bsm_enable = true;
@@ -143,8 +145,8 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	  The number of seconds represented by the [Query Response Interval]
 	  must be less than the [Query Interval].
 	 */
-	assert(pim_ifp->query_max_response_time_dsec
-	       < pim_ifp->default_query_interval);
+	assert(pim_ifp->igmp_query_max_response_time_dsec
+	       < pim_ifp->igmp_default_query_interval);
 
 	if (pim)
 		PIM_IF_DO_PIM(pim_ifp->options);
@@ -153,7 +155,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 
 	PIM_IF_DO_IGMP_LISTEN_ALLROUTERS(pim_ifp->options);
 
-	pim_ifp->join_list = NULL;
+	pim_ifp->igmp_join_list = NULL;
 	pim_ifp->pim_neighbor_list = NULL;
 	pim_ifp->upstream_switch_list = NULL;
 	pim_ifp->pim_generation_id = 0;
@@ -198,7 +200,7 @@ void pim_if_delete(struct interface *ifp)
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
 
-	if (pim_ifp->join_list) {
+	if (pim_ifp->igmp_join_list) {
 		pim_if_igmp_join_del_all(ifp);
 	}
 
@@ -533,27 +535,27 @@ void pim_if_addr_add(struct connected *ifc)
 		struct igmp_sock *igmp;
 
 		/* lookup IGMP socket */
-		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->socket_list,
+		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list,
 						   ifaddr);
 		if (!igmp) {
 			/* if addr new, add IGMP socket */
 			if (ifc->address->family == AF_INET)
-				pim_igmp_sock_add(pim_ifp->socket_list, ifaddr,
-						  ifp, false);
+				pim_igmp_sock_add(pim_ifp->igmp_socket_list,
+						  ifaddr, ifp, false);
 		} else if (igmp->mtrace_only) {
 			igmp_sock_delete(igmp);
-			pim_igmp_sock_add(pim_ifp->socket_list, ifaddr, ifp,
-					  false);
+			pim_igmp_sock_add(pim_ifp->igmp_socket_list, ifaddr,
+					  ifp, false);
 		}
 
 		/* Replay Static IGMP groups */
-		if (pim_ifp->join_list) {
+		if (pim_ifp->igmp_join_list) {
 			struct listnode *node;
 			struct listnode *nextnode;
 			struct igmp_join *ij;
 			int join_fd;
 
-			for (ALL_LIST_ELEMENTS(pim_ifp->join_list, node,
+			for (ALL_LIST_ELEMENTS(pim_ifp->igmp_join_list, node,
 					       nextnode, ij)) {
 				/* Close socket and reopen with Source and Group
 				 */
@@ -584,14 +586,14 @@ void pim_if_addr_add(struct connected *ifc)
 		struct igmp_sock *igmp;
 
 		/* lookup IGMP socket */
-		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->socket_list,
+		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list,
 						   ifaddr);
 		if (ifc->address->family == AF_INET) {
 			if (igmp)
 				igmp_sock_delete(igmp);
 			/* if addr new, add IGMP socket */
-			pim_igmp_sock_add(pim_ifp->socket_list, ifaddr, ifp,
-					  true);
+			pim_igmp_sock_add(pim_ifp->igmp_socket_list, ifaddr,
+					  ifp, true);
 		}
 	} /* igmp mtrace only */
 
@@ -662,7 +664,7 @@ static void pim_if_addr_del_igmp(struct connected *ifc)
 	ifaddr = ifc->address->u.prefix4;
 
 	/* lookup IGMP socket */
-	igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->socket_list, ifaddr);
+	igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list, ifaddr);
 	if (igmp) {
 		/* if addr found, del IGMP socket */
 		igmp_sock_delete(igmp);
@@ -1243,7 +1245,7 @@ static struct igmp_join *igmp_join_new(struct interface *ifp,
 	ij->source_addr = source_addr;
 	ij->sock_creation = pim_time_monotonic_sec();
 
-	listnode_add(pim_ifp->join_list, ij);
+	listnode_add(pim_ifp->igmp_join_list, ij);
 
 	return ij;
 }
@@ -1260,12 +1262,12 @@ ferr_r pim_if_igmp_join_add(struct interface *ifp, struct in_addr group_addr,
 					ifp->name);
 	}
 
-	if (!pim_ifp->join_list) {
-		pim_ifp->join_list = list_new();
-		pim_ifp->join_list->del = (void (*)(void *))igmp_join_free;
+	if (!pim_ifp->igmp_join_list) {
+		pim_ifp->igmp_join_list = list_new();
+		pim_ifp->igmp_join_list->del = (void (*)(void *))igmp_join_free;
 	}
 
-	ij = igmp_join_find(pim_ifp->join_list, group_addr, source_addr);
+	ij = igmp_join_find(pim_ifp->igmp_join_list, group_addr, source_addr);
 
 	/* This interface has already been configured to join this IGMP group
 	 */
@@ -1304,13 +1306,13 @@ int pim_if_igmp_join_del(struct interface *ifp, struct in_addr group_addr,
 		return -1;
 	}
 
-	if (!pim_ifp->join_list) {
+	if (!pim_ifp->igmp_join_list) {
 		zlog_warn("%s: no IGMP join on interface %s", __func__,
 			  ifp->name);
 		return -2;
 	}
 
-	ij = igmp_join_find(pim_ifp->join_list, group_addr, source_addr);
+	ij = igmp_join_find(pim_ifp->igmp_join_list, group_addr, source_addr);
 	if (!ij) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
@@ -1337,11 +1339,11 @@ int pim_if_igmp_join_del(struct interface *ifp, struct in_addr group_addr,
 			errno, safe_strerror(errno));
 		/* warning only */
 	}
-	listnode_delete(pim_ifp->join_list, ij);
+	listnode_delete(pim_ifp->igmp_join_list, ij);
 	igmp_join_free(ij);
-	if (listcount(pim_ifp->join_list) < 1) {
-		list_delete(&pim_ifp->join_list);
-		pim_ifp->join_list = 0;
+	if (listcount(pim_ifp->igmp_join_list) < 1) {
+		list_delete(&pim_ifp->igmp_join_list);
+		pim_ifp->igmp_join_list = 0;
 	}
 
 	return 0;
@@ -1361,10 +1363,10 @@ static void pim_if_igmp_join_del_all(struct interface *ifp)
 		return;
 	}
 
-	if (!pim_ifp->join_list)
+	if (!pim_ifp->igmp_join_list)
 		return;
 
-	for (ALL_LIST_ELEMENTS(pim_ifp->join_list, node, nextnode, ij))
+	for (ALL_LIST_ELEMENTS(pim_ifp->igmp_join_list, node, nextnode, ij))
 		pim_if_igmp_join_del(ifp, ij->group_addr, ij->source_addr);
 }
 

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -125,15 +125,14 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	pim_ifp->mroute_vif_index = -1;
 
 	pim_ifp->igmp_version = IGMP_DEFAULT_VERSION;
-	pim_ifp->igmp_default_robustness_variable =
+	pim_ifp->gm_default_robustness_variable =
 		IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
-	pim_ifp->igmp_default_query_interval = IGMP_GENERAL_QUERY_INTERVAL;
-	pim_ifp->igmp_query_max_response_time_dsec =
+	pim_ifp->gm_default_query_interval = IGMP_GENERAL_QUERY_INTERVAL;
+	pim_ifp->gm_query_max_response_time_dsec =
 		IGMP_QUERY_MAX_RESPONSE_TIME_DSEC;
-	pim_ifp->igmp_specific_query_max_response_time_dsec =
+	pim_ifp->gm_specific_query_max_response_time_dsec =
 		IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC;
-	pim_ifp->igmp_last_member_query_count =
-		IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
+	pim_ifp->gm_last_member_query_count = IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
 
 	/* BSM config on interface: true by default */
 	pim_ifp->bsm_enable = true;
@@ -145,8 +144,8 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	  The number of seconds represented by the [Query Response Interval]
 	  must be less than the [Query Interval].
 	 */
-	assert(pim_ifp->igmp_query_max_response_time_dsec
-	       < pim_ifp->igmp_default_query_interval);
+	assert(pim_ifp->gm_query_max_response_time_dsec
+	       < pim_ifp->gm_default_query_interval);
 
 	if (pim)
 		PIM_IF_DO_PIM(pim_ifp->options);
@@ -155,7 +154,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 
 	PIM_IF_DO_IGMP_LISTEN_ALLROUTERS(pim_ifp->options);
 
-	pim_ifp->igmp_join_list = NULL;
+	pim_ifp->gm_join_list = NULL;
 	pim_ifp->pim_neighbor_list = NULL;
 	pim_ifp->upstream_switch_list = NULL;
 	pim_ifp->pim_generation_id = 0;
@@ -200,7 +199,7 @@ void pim_if_delete(struct interface *ifp)
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
 
-	if (pim_ifp->igmp_join_list) {
+	if (pim_ifp->gm_join_list) {
 		pim_if_igmp_join_del_all(ifp);
 	}
 
@@ -535,27 +534,27 @@ void pim_if_addr_add(struct connected *ifc)
 		struct igmp_sock *igmp;
 
 		/* lookup IGMP socket */
-		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list,
+		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->gm_socket_list,
 						   ifaddr);
 		if (!igmp) {
 			/* if addr new, add IGMP socket */
 			if (ifc->address->family == AF_INET)
-				pim_igmp_sock_add(pim_ifp->igmp_socket_list,
+				pim_igmp_sock_add(pim_ifp->gm_socket_list,
 						  ifaddr, ifp, false);
 		} else if (igmp->mtrace_only) {
 			igmp_sock_delete(igmp);
-			pim_igmp_sock_add(pim_ifp->igmp_socket_list, ifaddr,
-					  ifp, false);
+			pim_igmp_sock_add(pim_ifp->gm_socket_list, ifaddr, ifp,
+					  false);
 		}
 
 		/* Replay Static IGMP groups */
-		if (pim_ifp->igmp_join_list) {
+		if (pim_ifp->gm_join_list) {
 			struct listnode *node;
 			struct listnode *nextnode;
 			struct igmp_join *ij;
 			int join_fd;
 
-			for (ALL_LIST_ELEMENTS(pim_ifp->igmp_join_list, node,
+			for (ALL_LIST_ELEMENTS(pim_ifp->gm_join_list, node,
 					       nextnode, ij)) {
 				/* Close socket and reopen with Source and Group
 				 */
@@ -586,14 +585,14 @@ void pim_if_addr_add(struct connected *ifc)
 		struct igmp_sock *igmp;
 
 		/* lookup IGMP socket */
-		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list,
+		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->gm_socket_list,
 						   ifaddr);
 		if (ifc->address->family == AF_INET) {
 			if (igmp)
 				igmp_sock_delete(igmp);
 			/* if addr new, add IGMP socket */
-			pim_igmp_sock_add(pim_ifp->igmp_socket_list, ifaddr,
-					  ifp, true);
+			pim_igmp_sock_add(pim_ifp->gm_socket_list, ifaddr, ifp,
+					  true);
 		}
 	} /* igmp mtrace only */
 
@@ -664,7 +663,7 @@ static void pim_if_addr_del_igmp(struct connected *ifc)
 	ifaddr = ifc->address->u.prefix4;
 
 	/* lookup IGMP socket */
-	igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list, ifaddr);
+	igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->gm_socket_list, ifaddr);
 	if (igmp) {
 		/* if addr found, del IGMP socket */
 		igmp_sock_delete(igmp);
@@ -1245,7 +1244,7 @@ static struct igmp_join *igmp_join_new(struct interface *ifp,
 	ij->source_addr = source_addr;
 	ij->sock_creation = pim_time_monotonic_sec();
 
-	listnode_add(pim_ifp->igmp_join_list, ij);
+	listnode_add(pim_ifp->gm_join_list, ij);
 
 	return ij;
 }
@@ -1262,12 +1261,12 @@ ferr_r pim_if_igmp_join_add(struct interface *ifp, struct in_addr group_addr,
 					ifp->name);
 	}
 
-	if (!pim_ifp->igmp_join_list) {
-		pim_ifp->igmp_join_list = list_new();
-		pim_ifp->igmp_join_list->del = (void (*)(void *))igmp_join_free;
+	if (!pim_ifp->gm_join_list) {
+		pim_ifp->gm_join_list = list_new();
+		pim_ifp->gm_join_list->del = (void (*)(void *))igmp_join_free;
 	}
 
-	ij = igmp_join_find(pim_ifp->igmp_join_list, group_addr, source_addr);
+	ij = igmp_join_find(pim_ifp->gm_join_list, group_addr, source_addr);
 
 	/* This interface has already been configured to join this IGMP group
 	 */
@@ -1306,13 +1305,13 @@ int pim_if_igmp_join_del(struct interface *ifp, struct in_addr group_addr,
 		return -1;
 	}
 
-	if (!pim_ifp->igmp_join_list) {
+	if (!pim_ifp->gm_join_list) {
 		zlog_warn("%s: no IGMP join on interface %s", __func__,
 			  ifp->name);
 		return -2;
 	}
 
-	ij = igmp_join_find(pim_ifp->igmp_join_list, group_addr, source_addr);
+	ij = igmp_join_find(pim_ifp->gm_join_list, group_addr, source_addr);
 	if (!ij) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
@@ -1339,11 +1338,11 @@ int pim_if_igmp_join_del(struct interface *ifp, struct in_addr group_addr,
 			errno, safe_strerror(errno));
 		/* warning only */
 	}
-	listnode_delete(pim_ifp->igmp_join_list, ij);
+	listnode_delete(pim_ifp->gm_join_list, ij);
 	igmp_join_free(ij);
-	if (listcount(pim_ifp->igmp_join_list) < 1) {
-		list_delete(&pim_ifp->igmp_join_list);
-		pim_ifp->igmp_join_list = 0;
+	if (listcount(pim_ifp->gm_join_list) < 1) {
+		list_delete(&pim_ifp->gm_join_list);
+		pim_ifp->gm_join_list = 0;
 	}
 
 	return 0;
@@ -1363,10 +1362,10 @@ static void pim_if_igmp_join_del_all(struct interface *ifp)
 		return;
 	}
 
-	if (!pim_ifp->igmp_join_list)
+	if (!pim_ifp->gm_join_list)
 		return;
 
-	for (ALL_LIST_ELEMENTS(pim_ifp->igmp_join_list, node, nextnode, ij))
+	for (ALL_LIST_ELEMENTS(pim_ifp->gm_join_list, node, nextnode, ij))
 		pim_if_igmp_join_del(ifp, ij->group_addr, ij->source_addr);
 }
 

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -100,13 +100,13 @@ struct pim_interface {
 	struct in_addr update_source;   /* user can statically set the primary
 					 * address of the interface */
 
-	int version;			  /* IGMP or MLD version */
-	int default_robustness_variable;  /* IGMP or MLD QRV */
-	int default_query_interval;       /* IGMP or MLD secs between general
+	int igmp_version;		       /* IGMP version */
+	int igmp_default_robustness_variable;  /* IGMPv3 QRV */
+	int igmp_default_query_interval;       /* IGMPv3 secs between general
 						  queries */
-	int query_max_response_time_dsec; /* IGMP or MLD Max Response Time in
+	int igmp_query_max_response_time_dsec; /* IGMPv3 Max Response Time in
 						  dsecs for general queries */
-	int specific_query_max_response_time_dsec; /* IGMP or MLD Max Response
+	int igmp_specific_query_max_response_time_dsec; /* IGMPv3 Max Response
 							   Time in dsecs called
 							   as last member query
 							   interval, defines the
@@ -114,11 +114,11 @@ struct pim_interface {
 							   advertised in IGMP
 							   group-specific
 							   queries */
-	int last_member_query_count; /* IGMP or MLD last member query count */
-	struct list *socket_list;    /* list of struct IGMP or MLD sock */
-	struct list *join_list;      /* list of struct IGMP or MLD join */
-	struct list *group_list;     /* list of struct IGMP or MLD group */
-	struct hash *group_hash;
+	int igmp_last_member_query_count; /* IGMP last member query count */
+	struct list *igmp_socket_list; /* list of struct igmp_sock */
+	struct list *igmp_join_list;   /* list of struct igmp_join */
+	struct list *igmp_group_list;  /* list of struct igmp_group */
+	struct hash *igmp_group_hash;
 
 	int pim_sock_fd;		/* PIM socket file descriptor */
 	struct thread *t_pim_sock_read; /* thread for reading PIM socket */

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -101,24 +101,25 @@ struct pim_interface {
 					 * address of the interface */
 
 	int igmp_version;		       /* IGMP version */
-	int igmp_default_robustness_variable;  /* IGMPv3 QRV */
-	int igmp_default_query_interval;       /* IGMPv3 secs between general
+	int gm_default_robustness_variable;    /* IGMP or MLD QRV */
+	int gm_default_query_interval;	     /* IGMP or MLD secs between general
 						  queries */
-	int igmp_query_max_response_time_dsec; /* IGMPv3 Max Response Time in
+	int gm_query_max_response_time_dsec; /* IGMP or MLD Max Response Time in
 						  dsecs for general queries */
-	int igmp_specific_query_max_response_time_dsec; /* IGMPv3 Max Response
-							   Time in dsecs called
-							   as last member query
-							   interval, defines the
-							   maximum response time
-							   advertised in IGMP
+	int gm_specific_query_max_response_time_dsec; /* IGMP or MLD Max
+							 Response Time in dsecs
+							 called as last member
+							 query interval, defines
+							 the maximum response
+							 time advertised in IGMP
 							   group-specific
 							   queries */
-	int igmp_last_member_query_count; /* IGMP last member query count */
-	struct list *igmp_socket_list; /* list of struct igmp_sock */
-	struct list *igmp_join_list;   /* list of struct igmp_join */
-	struct list *igmp_group_list;  /* list of struct igmp_group */
-	struct hash *igmp_group_hash;
+	int gm_last_member_query_count; /* IGMP or MLD last member query count
+					 */
+	struct list *gm_socket_list;	/* list of struct IGMP or MLD sock */
+	struct list *gm_join_list;	/* list of struct IGMP or MLD join */
+	struct list *gm_group_list;	/* list of struct IGMP or MLD group */
+	struct hash *gm_group_hash;
 
 	int pim_sock_fd;		/* PIM socket file descriptor */
 	struct thread *t_pim_sock_read; /* thread for reading PIM socket */

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -226,7 +226,7 @@ void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp)
 	*/
 	other_querier_present_interval_msec = PIM_IGMP_OQPI_MSEC(
 		igmp->querier_robustness_variable, igmp->querier_query_interval,
-		pim_ifp->igmp_query_max_response_time_dsec);
+		pim_ifp->gm_query_max_response_time_dsec);
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
@@ -636,14 +636,14 @@ void pim_igmp_general_query_on(struct igmp_sock *igmp)
 		 * newly configured igmp interface send it out in 1 second
 		 * just to give the entire world a tiny bit of time to settle
 		 * else the query interval is:
-		 * query_interval = pim_ifp->igmp_default_query_interval >> 2;
+		 * query_interval = pim_ifp->gm_default_query_interval >> 2;
 		 */
 		if (igmp->startup_query_count
 		    == igmp->querier_robustness_variable)
 			query_interval = 1;
 		else
 			query_interval = PIM_IGMP_SQI(
-				pim_ifp->igmp_default_query_interval);
+				pim_ifp->gm_default_query_interval);
 
 		--igmp->startup_query_count;
 	} else {
@@ -729,7 +729,7 @@ static int pim_igmp_general_query(struct thread *t)
 	igmp_send_query(pim_ifp->igmp_version, 0 /* igmp_group */, igmp->fd,
 			igmp->interface->name, query_buf, sizeof(query_buf),
 			0 /* num_sources */, dst_addr, group_addr,
-			pim_ifp->igmp_query_max_response_time_dsec,
+			pim_ifp->gm_query_max_response_time_dsec,
 			1 /* s_flag: always set for general queries */,
 			igmp->querier_robustness_variable,
 			igmp->querier_query_interval);
@@ -787,7 +787,7 @@ void igmp_startup_mode_on(struct igmp_sock *igmp)
 	/*
 	  Since we're (re)starting, reset QQI to default Query Interval
 	*/
-	igmp->querier_query_interval = pim_ifp->igmp_default_query_interval;
+	igmp->querier_query_interval = pim_ifp->gm_default_query_interval;
 }
 
 static void igmp_group_free(struct igmp_group *group)
@@ -844,8 +844,8 @@ void igmp_group_delete(struct igmp_group *group)
 
 	group_timer_off(group);
 	igmp_group_count_decr(pim_ifp);
-	listnode_delete(pim_ifp->igmp_group_list, group);
-	hash_release(pim_ifp->igmp_group_hash, group);
+	listnode_delete(pim_ifp->gm_group_list, group);
+	hash_release(pim_ifp->gm_group_hash, group);
 
 	igmp_group_free(group);
 }
@@ -875,11 +875,11 @@ void igmp_sock_delete(struct igmp_sock *igmp)
 
 	pim_ifp = igmp->interface->info;
 
-	listnode_delete(pim_ifp->igmp_socket_list, igmp);
+	listnode_delete(pim_ifp->gm_socket_list, igmp);
 
 	igmp_sock_free(igmp);
 
-	if (!listcount(pim_ifp->igmp_socket_list))
+	if (!listcount(pim_ifp->gm_socket_list))
 		pim_igmp_if_reset(pim_ifp);
 }
 
@@ -891,7 +891,7 @@ void igmp_sock_delete_all(struct interface *ifp)
 
 	pim_ifp = ifp->info;
 
-	for (ALL_LIST_ELEMENTS(pim_ifp->igmp_socket_list, igmp_node,
+	for (ALL_LIST_ELEMENTS(pim_ifp->gm_socket_list, igmp_node,
 			       igmp_nextnode, igmp)) {
 		igmp_sock_delete(igmp);
 	}
@@ -919,15 +919,15 @@ void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp)
 {
 	char hash_name[64];
 
-	pim_ifp->igmp_socket_list = list_new();
-	pim_ifp->igmp_socket_list->del = (void (*)(void *))igmp_sock_free;
+	pim_ifp->gm_socket_list = list_new();
+	pim_ifp->gm_socket_list->del = (void (*)(void *))igmp_sock_free;
 
-	pim_ifp->igmp_group_list = list_new();
-	pim_ifp->igmp_group_list->del = (void (*)(void *))igmp_group_free;
+	pim_ifp->gm_group_list = list_new();
+	pim_ifp->gm_group_list->del = (void (*)(void *))igmp_group_free;
 
 	snprintf(hash_name, sizeof(hash_name), "IGMP %s hash", ifp->name);
-	pim_ifp->igmp_group_hash = hash_create(
-		igmp_group_hash_key, igmp_group_hash_equal, hash_name);
+	pim_ifp->gm_group_hash = hash_create(igmp_group_hash_key,
+					     igmp_group_hash_equal, hash_name);
 }
 
 void pim_igmp_if_reset(struct pim_interface *pim_ifp)
@@ -935,7 +935,7 @@ void pim_igmp_if_reset(struct pim_interface *pim_ifp)
 	struct listnode *grp_node, *grp_nextnode;
 	struct igmp_group *grp;
 
-	for (ALL_LIST_ELEMENTS(pim_ifp->igmp_group_list, grp_node, grp_nextnode,
+	for (ALL_LIST_ELEMENTS(pim_ifp->gm_group_list, grp_node, grp_nextnode,
 			       grp)) {
 		igmp_group_delete(grp);
 	}
@@ -945,13 +945,13 @@ void pim_igmp_if_fini(struct pim_interface *pim_ifp)
 {
 	pim_igmp_if_reset(pim_ifp);
 
-	assert(pim_ifp->igmp_group_list);
-	assert(!listcount(pim_ifp->igmp_group_list));
+	assert(pim_ifp->gm_group_list);
+	assert(!listcount(pim_ifp->gm_group_list));
 
-	list_delete(&pim_ifp->igmp_group_list);
-	hash_free(pim_ifp->igmp_group_hash);
+	list_delete(&pim_ifp->gm_group_list);
+	hash_free(pim_ifp->gm_group_hash);
 
-	list_delete(&pim_ifp->igmp_socket_list);
+	list_delete(&pim_ifp->gm_socket_list);
 }
 
 static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
@@ -978,7 +978,7 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	igmp->t_igmp_query_timer = NULL;
 	igmp->t_other_querier_timer = NULL; /* no other querier present */
 	igmp->querier_robustness_variable =
-		pim_ifp->igmp_default_robustness_variable;
+		pim_ifp->gm_default_robustness_variable;
 	igmp->sock_creation = pim_time_monotonic_sec();
 
 	igmp_stats_init(&igmp->rx_stats);
@@ -993,7 +993,7 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	/*
 	  igmp_startup_mode_on() will reset QQI:
 
-	  igmp->querier_query_interval = pim_ifp->igmp_default_query_interval;
+	  igmp->querier_query_interval = pim_ifp->gm_default_query_interval;
 	*/
 	igmp_startup_mode_on(igmp);
 	pim_igmp_general_query_on(igmp);
@@ -1189,7 +1189,7 @@ struct igmp_group *find_group_by_addr(struct igmp_sock *igmp,
 
 	lookup.group_addr.s_addr = group_addr.s_addr;
 
-	return hash_lookup(pim_ifp->igmp_group_hash, &lookup);
+	return hash_lookup(pim_ifp->gm_group_hash, &lookup);
 }
 
 struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
@@ -1247,8 +1247,8 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 	/* initialize new group as INCLUDE {empty} */
 	group->group_filtermode_isexcl = 0; /* 0=INCLUDE, 1=EXCLUDE */
 
-	listnode_add(pim_ifp->igmp_group_list, group);
-	group = hash_get(pim_ifp->igmp_group_hash, group, hash_alloc_intern);
+	listnode_add(pim_ifp->gm_group_list, group);
+	group = hash_get(pim_ifp->gm_group_hash, group, hash_alloc_intern);
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
@@ -1321,7 +1321,7 @@ void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver)
 		zlog_debug("Issuing general query on request on %s",
 				ifp->name);
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node, igmp)) {
 
 		char query_buf[query_buf_size];
 
@@ -1329,7 +1329,7 @@ void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver)
 				igmp->interface->name, query_buf,
 				sizeof(query_buf), 0 /* num_sources */,
 				dst_addr, group_addr,
-				pim_ifp->igmp_query_max_response_time_dsec,
+				pim_ifp->gm_query_max_response_time_dsec,
 				1 /* s_flag: always set for general queries */,
 				igmp->querier_robustness_variable,
 				igmp->querier_query_interval);

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -226,7 +226,7 @@ void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp)
 	*/
 	other_querier_present_interval_msec = PIM_IGMP_OQPI_MSEC(
 		igmp->querier_robustness_variable, igmp->querier_query_interval,
-		pim_ifp->query_max_response_time_dsec);
+		pim_ifp->igmp_query_max_response_time_dsec);
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
@@ -351,10 +351,11 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 	 * For now we will simplify things and inform the user that they need to
 	 * configure all PIM routers to use the same version of IGMP.
 	 */
-	if (query_version != pim_ifp->version) {
+	if (query_version != pim_ifp->igmp_version) {
 		zlog_warn(
 			"Recv IGMP query v%d from %s on %s but we are using v%d, please configure all PIM routers on this subnet to use the same IGMP version",
-			query_version, from_str, ifp->name, pim_ifp->version);
+			query_version, from_str, ifp->name,
+			pim_ifp->igmp_version);
 		return 0;
 	}
 
@@ -635,14 +636,14 @@ void pim_igmp_general_query_on(struct igmp_sock *igmp)
 		 * newly configured igmp interface send it out in 1 second
 		 * just to give the entire world a tiny bit of time to settle
 		 * else the query interval is:
-		 * query_interval = pim_ifp->default_query_interval >> 2;
+		 * query_interval = pim_ifp->igmp_default_query_interval >> 2;
 		 */
 		if (igmp->startup_query_count
 		    == igmp->querier_robustness_variable)
 			query_interval = 1;
 		else
-			query_interval =
-				PIM_IGMP_SQI(pim_ifp->default_query_interval);
+			query_interval = PIM_IGMP_SQI(
+				pim_ifp->igmp_default_query_interval);
 
 		--igmp->startup_query_count;
 	} else {
@@ -695,7 +696,7 @@ static int pim_igmp_general_query(struct thread *t)
 
 	pim_ifp = igmp->interface->info;
 
-	if (pim_ifp->version == 3) {
+	if (pim_ifp->igmp_version == 3) {
 		query_buf_size = PIM_IGMP_BUFSIZE_WRITE;
 	} else {
 		query_buf_size = IGMP_V12_MSG_SIZE;
@@ -725,10 +726,10 @@ static int pim_igmp_general_query(struct thread *t)
 			   querier_str, dst_str, igmp->interface->name);
 	}
 
-	igmp_send_query(pim_ifp->version, 0 /* igmp_group */, igmp->fd,
+	igmp_send_query(pim_ifp->igmp_version, 0 /* igmp_group */, igmp->fd,
 			igmp->interface->name, query_buf, sizeof(query_buf),
 			0 /* num_sources */, dst_addr, group_addr,
-			pim_ifp->query_max_response_time_dsec,
+			pim_ifp->igmp_query_max_response_time_dsec,
 			1 /* s_flag: always set for general queries */,
 			igmp->querier_robustness_variable,
 			igmp->querier_query_interval);
@@ -786,7 +787,7 @@ void igmp_startup_mode_on(struct igmp_sock *igmp)
 	/*
 	  Since we're (re)starting, reset QQI to default Query Interval
 	*/
-	igmp->querier_query_interval = pim_ifp->default_query_interval;
+	igmp->querier_query_interval = pim_ifp->igmp_default_query_interval;
 }
 
 static void igmp_group_free(struct igmp_group *group)
@@ -843,8 +844,8 @@ void igmp_group_delete(struct igmp_group *group)
 
 	group_timer_off(group);
 	igmp_group_count_decr(pim_ifp);
-	listnode_delete(pim_ifp->group_list, group);
-	hash_release(pim_ifp->group_hash, group);
+	listnode_delete(pim_ifp->igmp_group_list, group);
+	hash_release(pim_ifp->igmp_group_hash, group);
 
 	igmp_group_free(group);
 }
@@ -874,11 +875,11 @@ void igmp_sock_delete(struct igmp_sock *igmp)
 
 	pim_ifp = igmp->interface->info;
 
-	listnode_delete(pim_ifp->socket_list, igmp);
+	listnode_delete(pim_ifp->igmp_socket_list, igmp);
 
 	igmp_sock_free(igmp);
 
-	if (!listcount(pim_ifp->socket_list))
+	if (!listcount(pim_ifp->igmp_socket_list))
 		pim_igmp_if_reset(pim_ifp);
 }
 
@@ -890,8 +891,8 @@ void igmp_sock_delete_all(struct interface *ifp)
 
 	pim_ifp = ifp->info;
 
-	for (ALL_LIST_ELEMENTS(pim_ifp->socket_list, igmp_node, igmp_nextnode,
-			       igmp)) {
+	for (ALL_LIST_ELEMENTS(pim_ifp->igmp_socket_list, igmp_node,
+			       igmp_nextnode, igmp)) {
 		igmp_sock_delete(igmp);
 	}
 }
@@ -918,15 +919,15 @@ void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp)
 {
 	char hash_name[64];
 
-	pim_ifp->socket_list = list_new();
-	pim_ifp->socket_list->del = (void (*)(void *))igmp_sock_free;
+	pim_ifp->igmp_socket_list = list_new();
+	pim_ifp->igmp_socket_list->del = (void (*)(void *))igmp_sock_free;
 
-	pim_ifp->group_list = list_new();
-	pim_ifp->group_list->del = (void (*)(void *))igmp_group_free;
+	pim_ifp->igmp_group_list = list_new();
+	pim_ifp->igmp_group_list->del = (void (*)(void *))igmp_group_free;
 
 	snprintf(hash_name, sizeof(hash_name), "IGMP %s hash", ifp->name);
-	pim_ifp->group_hash = hash_create(igmp_group_hash_key,
-					  igmp_group_hash_equal, hash_name);
+	pim_ifp->igmp_group_hash = hash_create(
+		igmp_group_hash_key, igmp_group_hash_equal, hash_name);
 }
 
 void pim_igmp_if_reset(struct pim_interface *pim_ifp)
@@ -934,7 +935,7 @@ void pim_igmp_if_reset(struct pim_interface *pim_ifp)
 	struct listnode *grp_node, *grp_nextnode;
 	struct igmp_group *grp;
 
-	for (ALL_LIST_ELEMENTS(pim_ifp->group_list, grp_node, grp_nextnode,
+	for (ALL_LIST_ELEMENTS(pim_ifp->igmp_group_list, grp_node, grp_nextnode,
 			       grp)) {
 		igmp_group_delete(grp);
 	}
@@ -944,13 +945,13 @@ void pim_igmp_if_fini(struct pim_interface *pim_ifp)
 {
 	pim_igmp_if_reset(pim_ifp);
 
-	assert(pim_ifp->group_list);
-	assert(!listcount(pim_ifp->group_list));
+	assert(pim_ifp->igmp_group_list);
+	assert(!listcount(pim_ifp->igmp_group_list));
 
-	list_delete(&pim_ifp->group_list);
-	hash_free(pim_ifp->group_hash);
+	list_delete(&pim_ifp->igmp_group_list);
+	hash_free(pim_ifp->igmp_group_hash);
 
-	list_delete(&pim_ifp->socket_list);
+	list_delete(&pim_ifp->igmp_socket_list);
 }
 
 static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
@@ -977,7 +978,7 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	igmp->t_igmp_query_timer = NULL;
 	igmp->t_other_querier_timer = NULL; /* no other querier present */
 	igmp->querier_robustness_variable =
-		pim_ifp->default_robustness_variable;
+		pim_ifp->igmp_default_robustness_variable;
 	igmp->sock_creation = pim_time_monotonic_sec();
 
 	igmp_stats_init(&igmp->rx_stats);
@@ -992,7 +993,7 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	/*
 	  igmp_startup_mode_on() will reset QQI:
 
-	  igmp->querier_query_interval = pim_ifp->default_query_interval;
+	  igmp->querier_query_interval = pim_ifp->igmp_default_query_interval;
 	*/
 	igmp_startup_mode_on(igmp);
 	pim_igmp_general_query_on(igmp);
@@ -1188,7 +1189,7 @@ struct igmp_group *find_group_by_addr(struct igmp_sock *igmp,
 
 	lookup.group_addr.s_addr = group_addr.s_addr;
 
-	return hash_lookup(pim_ifp->group_hash, &lookup);
+	return hash_lookup(pim_ifp->igmp_group_hash, &lookup);
 }
 
 struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
@@ -1246,8 +1247,8 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 	/* initialize new group as INCLUDE {empty} */
 	group->group_filtermode_isexcl = 0; /* 0=INCLUDE, 1=EXCLUDE */
 
-	listnode_add(pim_ifp->group_list, group);
-	group = hash_get(pim_ifp->group_hash, group, hash_alloc_intern);
+	listnode_add(pim_ifp->igmp_group_list, group);
+	group = hash_get(pim_ifp->igmp_group_hash, group, hash_alloc_intern);
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
@@ -1320,7 +1321,7 @@ void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver)
 		zlog_debug("Issuing general query on request on %s",
 				ifp->name);
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
 
 		char query_buf[query_buf_size];
 
@@ -1328,7 +1329,7 @@ void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver)
 				igmp->interface->name, query_buf,
 				sizeof(query_buf), 0 /* num_sources */,
 				dst_addr, group_addr,
-				pim_ifp->query_max_response_time_dsec,
+				pim_ifp->igmp_query_max_response_time_dsec,
 				1 /* s_flag: always set for general queries */,
 				igmp->querier_robustness_variable,
 				igmp->querier_query_interval);

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -65,12 +65,12 @@ static inline long igmp_gmi_msec(struct igmp_group *group)
 
 	long qrv = 0, qqi = 0;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node, igmp)) {
 		qrv = MAX(qrv, igmp->querier_robustness_variable);
 		qqi = MAX(qqi, igmp->querier_query_interval);
 	}
 	return PIM_IGMP_GMI_MSEC(qrv, qqi,
-				 pim_ifp->igmp_query_max_response_time_dsec);
+				 pim_ifp->gm_query_max_response_time_dsec);
 }
 
 void igmp_group_reset_gmi(struct igmp_group *group)
@@ -985,12 +985,12 @@ static void igmp_send_query_group(struct igmp_group *group, char *query_buf,
 	struct igmp_sock *igmp;
 	struct listnode *sock_node;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node, igmp)) {
 		igmp_send_query(
 			pim_ifp->igmp_version, group, igmp->fd, ifp->name,
 			query_buf, query_buf_size, num_sources,
 			group->group_addr, group->group_addr,
-			pim_ifp->igmp_specific_query_max_response_time_dsec,
+			pim_ifp->gm_specific_query_max_response_time_dsec,
 			s_flag, igmp->querier_robustness_variable,
 			igmp->querier_query_interval);
 	}
@@ -1022,8 +1022,8 @@ static void group_retransmit_group(struct igmp_group *group)
 
 	char query_buf[query_buf_size];
 
-	lmqc = pim_ifp->igmp_last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->gm_last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/*
@@ -1092,8 +1092,8 @@ static int group_retransmit_sources(struct igmp_group *group,
 
 	pim_ifp = group->interface->info;
 
-	lmqc = pim_ifp->igmp_last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->gm_last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/* Scan all group sources */
@@ -1284,7 +1284,7 @@ static void group_retransmit_timer_on(struct igmp_group *group)
 
 	pim_ifp = group->interface->info;
 
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
@@ -1320,7 +1320,7 @@ static void group_query_send(struct igmp_group *group)
 	long lmqc; /* Last Member Query Count */
 
 	pim_ifp = group->interface->info;
-	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqc = pim_ifp->gm_last_member_query_count;
 
 	/* lower group timer to lmqt */
 	igmp_group_timer_lower_to_lmqt(group);
@@ -1353,8 +1353,8 @@ static void source_query_send_by_flag(struct igmp_group *group,
 
 	pim_ifp = group->interface->info;
 
-	lmqc = pim_ifp->igmp_last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->gm_last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/*
@@ -1510,8 +1510,8 @@ void igmp_group_timer_lower_to_lmqt(struct igmp_group *group)
 	pim_ifp = ifp->info;
 	ifname = ifp->name;
 
-	lmqi_dsec = pim_ifp->igmp_specific_query_max_response_time_dsec;
-	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqi_dsec = pim_ifp->gm_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->gm_last_member_query_count;
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
@@ -1545,8 +1545,8 @@ void igmp_source_timer_lower_to_lmqt(struct igmp_source *source)
 	pim_ifp = ifp->info;
 	ifname = ifp->name;
 
-	lmqi_dsec = pim_ifp->igmp_specific_query_max_response_time_dsec;
-	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqi_dsec = pim_ifp->gm_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->gm_last_member_query_count;
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
@@ -1718,7 +1718,7 @@ void igmp_v3_recv_query(struct igmp_sock *igmp, const char *from_str,
 	resv_s_qrv = igmp_msg[8];
 	qrv = 7 & resv_s_qrv;
 	igmp->querier_robustness_variable =
-		qrv ? qrv : pim_ifp->igmp_default_robustness_variable;
+		qrv ? qrv : pim_ifp->gm_default_robustness_variable;
 
 	/*
 	 * RFC 3376: 4.1.7. QQIC (Querier's Query Interval Code)
@@ -1735,7 +1735,7 @@ void igmp_v3_recv_query(struct igmp_sock *igmp, const char *from_str,
 		qqic = igmp_msg[9];
 		qqi = igmp_msg_decode8to16(qqic);
 		igmp->querier_query_interval =
-			qqi ? qqi : pim_ifp->igmp_default_query_interval;
+			qqi ? qqi : pim_ifp->gm_default_query_interval;
 
 		if (PIM_DEBUG_IGMP_TRACE) {
 			char ifaddr_str[INET_ADDRSTRLEN];

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -65,12 +65,12 @@ static inline long igmp_gmi_msec(struct igmp_group *group)
 
 	long qrv = 0, qqi = 0;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
 		qrv = MAX(qrv, igmp->querier_robustness_variable);
 		qqi = MAX(qqi, igmp->querier_query_interval);
 	}
 	return PIM_IGMP_GMI_MSEC(qrv, qqi,
-				 pim_ifp->query_max_response_time_dsec);
+				 pim_ifp->igmp_query_max_response_time_dsec);
 }
 
 void igmp_group_reset_gmi(struct igmp_group *group)
@@ -985,13 +985,14 @@ static void igmp_send_query_group(struct igmp_group *group, char *query_buf,
 	struct igmp_sock *igmp;
 	struct listnode *sock_node;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
-		igmp_send_query(pim_ifp->version, group, igmp->fd, ifp->name,
-				query_buf, query_buf_size, num_sources,
-				group->group_addr, group->group_addr,
-				pim_ifp->specific_query_max_response_time_dsec,
-				s_flag, igmp->querier_robustness_variable,
-				igmp->querier_query_interval);
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+		igmp_send_query(
+			pim_ifp->igmp_version, group, igmp->fd, ifp->name,
+			query_buf, query_buf_size, num_sources,
+			group->group_addr, group->group_addr,
+			pim_ifp->igmp_specific_query_max_response_time_dsec,
+			s_flag, igmp->querier_robustness_variable,
+			igmp->querier_query_interval);
 	}
 }
 
@@ -1013,7 +1014,7 @@ static void group_retransmit_group(struct igmp_group *group)
 
 	pim_ifp = group->interface->info;
 
-	if (pim_ifp->version == 3) {
+	if (pim_ifp->igmp_version == 3) {
 		query_buf_size = PIM_IGMP_BUFSIZE_WRITE;
 	} else {
 		query_buf_size = IGMP_V12_MSG_SIZE;
@@ -1021,8 +1022,8 @@ static void group_retransmit_group(struct igmp_group *group)
 
 	char query_buf[query_buf_size];
 
-	lmqc = pim_ifp->last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/*
@@ -1091,8 +1092,8 @@ static int group_retransmit_sources(struct igmp_group *group,
 
 	pim_ifp = group->interface->info;
 
-	lmqc = pim_ifp->last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/* Scan all group sources */
@@ -1283,7 +1284,7 @@ static void group_retransmit_timer_on(struct igmp_group *group)
 
 	pim_ifp = group->interface->info;
 
-	lmqi_msec = 100 * pim_ifp->specific_query_max_response_time_dsec;
+	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
@@ -1319,7 +1320,7 @@ static void group_query_send(struct igmp_group *group)
 	long lmqc; /* Last Member Query Count */
 
 	pim_ifp = group->interface->info;
-	lmqc = pim_ifp->last_member_query_count;
+	lmqc = pim_ifp->igmp_last_member_query_count;
 
 	/* lower group timer to lmqt */
 	igmp_group_timer_lower_to_lmqt(group);
@@ -1352,8 +1353,8 @@ static void source_query_send_by_flag(struct igmp_group *group,
 
 	pim_ifp = group->interface->info;
 
-	lmqc = pim_ifp->last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/*
@@ -1509,8 +1510,8 @@ void igmp_group_timer_lower_to_lmqt(struct igmp_group *group)
 	pim_ifp = ifp->info;
 	ifname = ifp->name;
 
-	lmqi_dsec = pim_ifp->specific_query_max_response_time_dsec;
-	lmqc = pim_ifp->last_member_query_count;
+	lmqi_dsec = pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->igmp_last_member_query_count;
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
@@ -1544,8 +1545,8 @@ void igmp_source_timer_lower_to_lmqt(struct igmp_source *source)
 	pim_ifp = ifp->info;
 	ifname = ifp->name;
 
-	lmqi_dsec = pim_ifp->specific_query_max_response_time_dsec;
-	lmqc = pim_ifp->last_member_query_count;
+	lmqi_dsec = pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->igmp_last_member_query_count;
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
@@ -1717,7 +1718,7 @@ void igmp_v3_recv_query(struct igmp_sock *igmp, const char *from_str,
 	resv_s_qrv = igmp_msg[8];
 	qrv = 7 & resv_s_qrv;
 	igmp->querier_robustness_variable =
-		qrv ? qrv : pim_ifp->default_robustness_variable;
+		qrv ? qrv : pim_ifp->igmp_default_robustness_variable;
 
 	/*
 	 * RFC 3376: 4.1.7. QQIC (Querier's Query Interval Code)
@@ -1734,7 +1735,7 @@ void igmp_v3_recv_query(struct igmp_sock *igmp, const char *from_str,
 		qqic = igmp_msg[9];
 		qqi = igmp_msg_decode8to16(qqic);
 		igmp->querier_query_interval =
-			qqi ? qqi : pim_ifp->default_query_interval;
+			qqi ? qqi : pim_ifp->igmp_default_query_interval;
 
 		if (PIM_DEBUG_IGMP_TRACE) {
 			char ifaddr_str[INET_ADDRSTRLEN];

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -626,7 +626,8 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 
 		pim_ifp = ifp->info;
 		ifaddr = connected_src->u.prefix4;
-		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list, ifaddr);
+		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->gm_socket_list,
+						   ifaddr);
 
 		if (PIM_DEBUG_IGMP_PACKETS) {
 			zlog_debug(

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -626,8 +626,7 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 
 		pim_ifp = ifp->info;
 		ifaddr = connected_src->u.prefix4;
-		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->socket_list,
-						   ifaddr);
+		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list, ifaddr);
 
 		if (PIM_DEBUG_IGMP_PACKETS) {
 			zlog_debug(

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -86,7 +86,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 	 */
 
 	/* scan igmp groups */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode, grp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode, grp)) {
 		struct listnode *srcnode;
 		struct igmp_source *src;
 
@@ -383,14 +383,14 @@ static void igmp_sock_query_interval_reconfig(struct igmp_sock *igmp)
 		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
 				sizeof(ifaddr_str));
 		zlog_debug("%s: Querier %s on %s reconfig query_interval=%d",
-				__func__, ifaddr_str, ifp->name,
-				pim_ifp->igmp_default_query_interval);
+			   __func__, ifaddr_str, ifp->name,
+			   pim_ifp->gm_default_query_interval);
 	}
 
 	/*
 	 * igmp_startup_mode_on() will reset QQI:
 
-	 * igmp->querier_query_interval = pim_ifp->igmp_default_query_interval;
+	 * igmp->querier_query_interval = pim_ifp->gm_default_query_interval;
 	 */
 	igmp_startup_mode_on(igmp);
 }
@@ -430,9 +430,9 @@ static void change_query_interval(struct pim_interface *pim_ifp,
 	struct listnode *sock_node;
 	struct igmp_sock *igmp;
 
-	pim_ifp->igmp_default_query_interval = query_interval;
+	pim_ifp->gm_default_query_interval = query_interval;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node, igmp)) {
 		igmp_sock_query_interval_reconfig(igmp);
 		igmp_sock_query_reschedule(igmp);
 	}
@@ -446,12 +446,11 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	struct listnode *grp_node;
 	struct igmp_group *grp;
 
-	if (pim_ifp->igmp_query_max_response_time_dsec
+	if (pim_ifp->gm_query_max_response_time_dsec
 	    == query_max_response_time_dsec)
 		return;
 
-	pim_ifp->igmp_query_max_response_time_dsec =
-		query_max_response_time_dsec;
+	pim_ifp->gm_query_max_response_time_dsec = query_max_response_time_dsec;
 
 	/*
 	 * Below we modify socket/group/source timers in order to quickly
@@ -460,13 +459,13 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	 */
 
 	/* scan all sockets */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node, igmp)) {
 		/* reschedule socket general query */
 		igmp_sock_query_reschedule(igmp);
 	}
 
 	/* scan socket groups */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grp_node, grp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grp_node, grp)) {
 		struct listnode *src_node;
 		struct igmp_source *src;
 
@@ -2690,7 +2689,7 @@ int lib_interface_igmp_last_member_query_interval_modify(
 		pim_ifp = ifp->info;
 		last_member_query_interval =
 			yang_dnode_get_uint16(args->dnode, NULL);
-		pim_ifp->igmp_specific_query_max_response_time_dsec =
+		pim_ifp->gm_specific_query_max_response_time_dsec =
 			last_member_query_interval;
 
 		break;
@@ -2719,7 +2718,7 @@ int lib_interface_igmp_robustness_variable_modify(
 		pim_ifp = ifp->info;
 		last_member_query_count = yang_dnode_get_uint8(args->dnode,
 				NULL);
-		pim_ifp->igmp_last_member_query_count = last_member_query_count;
+		pim_ifp->gm_last_member_query_count = last_member_query_count;
 
 		break;
 	}

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -86,7 +86,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 	 */
 
 	/* scan igmp groups */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode, grp)) {
 		struct listnode *srcnode;
 		struct igmp_source *src;
 
@@ -105,7 +105,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 			}
 
 		} /* scan group sources */
-	}	 /* scan igmp groups */
+	}	  /* scan igmp groups */
 
 	/*
 	 * Finally delete every PIM (S,G) entry lacking all state info
@@ -383,14 +383,14 @@ static void igmp_sock_query_interval_reconfig(struct igmp_sock *igmp)
 		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
 				sizeof(ifaddr_str));
 		zlog_debug("%s: Querier %s on %s reconfig query_interval=%d",
-			   __func__, ifaddr_str, ifp->name,
-			   pim_ifp->default_query_interval);
+				__func__, ifaddr_str, ifp->name,
+				pim_ifp->igmp_default_query_interval);
 	}
 
 	/*
 	 * igmp_startup_mode_on() will reset QQI:
 
-	 * igmp->querier_query_interval = pim_ifp->default_query_interval;
+	 * igmp->querier_query_interval = pim_ifp->igmp_default_query_interval;
 	 */
 	igmp_startup_mode_on(igmp);
 }
@@ -430,9 +430,9 @@ static void change_query_interval(struct pim_interface *pim_ifp,
 	struct listnode *sock_node;
 	struct igmp_sock *igmp;
 
-	pim_ifp->default_query_interval = query_interval;
+	pim_ifp->igmp_default_query_interval = query_interval;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
 		igmp_sock_query_interval_reconfig(igmp);
 		igmp_sock_query_reschedule(igmp);
 	}
@@ -446,11 +446,12 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	struct listnode *grp_node;
 	struct igmp_group *grp;
 
-	if (pim_ifp->query_max_response_time_dsec
+	if (pim_ifp->igmp_query_max_response_time_dsec
 	    == query_max_response_time_dsec)
 		return;
 
-	pim_ifp->query_max_response_time_dsec = query_max_response_time_dsec;
+	pim_ifp->igmp_query_max_response_time_dsec =
+		query_max_response_time_dsec;
 
 	/*
 	 * Below we modify socket/group/source timers in order to quickly
@@ -459,13 +460,13 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	 */
 
 	/* scan all sockets */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
 		/* reschedule socket general query */
 		igmp_sock_query_reschedule(igmp);
 	}
 
 	/* scan socket groups */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grp_node, grp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grp_node, grp)) {
 		struct listnode *src_node;
 		struct igmp_source *src;
 
@@ -2587,8 +2588,8 @@ int lib_interface_igmp_version_modify(struct nb_cb_modify_args *args)
 			return NB_ERR_INCONSISTENCY;
 
 		igmp_version = yang_dnode_get_uint8(args->dnode, NULL);
-		old_version = pim_ifp->version;
-		pim_ifp->version = igmp_version;
+		old_version = pim_ifp->igmp_version;
+		pim_ifp->igmp_version = igmp_version;
 
 		/* Current and new version is different refresh existing
 		 * membership. Going from 3 -> 2 or 2 -> 3.
@@ -2615,7 +2616,7 @@ int lib_interface_igmp_version_destroy(struct nb_cb_destroy_args *args)
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
-		pim_ifp->version = IGMP_DEFAULT_VERSION;
+		pim_ifp->igmp_version = IGMP_DEFAULT_VERSION;
 		break;
 	}
 
@@ -2689,7 +2690,7 @@ int lib_interface_igmp_last_member_query_interval_modify(
 		pim_ifp = ifp->info;
 		last_member_query_interval =
 			yang_dnode_get_uint16(args->dnode, NULL);
-		pim_ifp->specific_query_max_response_time_dsec =
+		pim_ifp->igmp_specific_query_max_response_time_dsec =
 			last_member_query_interval;
 
 		break;
@@ -2718,7 +2719,7 @@ int lib_interface_igmp_robustness_variable_modify(
 		pim_ifp = ifp->info;
 		last_member_query_count = yang_dnode_get_uint8(args->dnode,
 				NULL);
-		pim_ifp->last_member_query_count = last_member_query_count;
+		pim_ifp->igmp_last_member_query_count = last_member_query_count;
 
 		break;
 	}

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -366,47 +366,47 @@ int pim_interface_config_write(struct vty *vty)
 				}
 
 				/* IF ip igmp query-max-response-time */
-				if (pim_ifp->igmp_query_max_response_time_dsec
+				if (pim_ifp->gm_query_max_response_time_dsec
 				    != IGMP_QUERY_MAX_RESPONSE_TIME_DSEC) {
 					vty_out(vty,
 						" ip igmp query-max-response-time %d\n",
-						pim_ifp->igmp_query_max_response_time_dsec);
+						pim_ifp->gm_query_max_response_time_dsec);
 					++writes;
 				}
 
 				/* IF ip igmp query-interval */
-				if (pim_ifp->igmp_default_query_interval
+				if (pim_ifp->gm_default_query_interval
 				    != IGMP_GENERAL_QUERY_INTERVAL) {
 					vty_out(vty,
 						" ip igmp query-interval %d\n",
-						pim_ifp->igmp_default_query_interval);
+						pim_ifp->gm_default_query_interval);
 					++writes;
 				}
 
 				/* IF ip igmp last-member_query-count */
-				if (pim_ifp->igmp_last_member_query_count
+				if (pim_ifp->gm_last_member_query_count
 				    != IGMP_DEFAULT_ROBUSTNESS_VARIABLE) {
 					vty_out(vty,
 						" ip igmp last-member-query-count %d\n",
-						pim_ifp->igmp_last_member_query_count);
+						pim_ifp->gm_last_member_query_count);
 					++writes;
 				}
 
 				/* IF ip igmp last-member_query-interval */
-				if (pim_ifp->igmp_specific_query_max_response_time_dsec
+				if (pim_ifp->gm_specific_query_max_response_time_dsec
 				    != IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC) {
 					vty_out(vty,
 						" ip igmp last-member-query-interval %d\n",
-						pim_ifp->igmp_specific_query_max_response_time_dsec);
-					  ++writes;
+						pim_ifp->gm_specific_query_max_response_time_dsec);
+					++writes;
 				}
 
 				/* IF ip igmp join */
-				if (pim_ifp->igmp_join_list) {
+				if (pim_ifp->gm_join_list) {
 					struct listnode *node;
 					struct igmp_join *ij;
 					for (ALL_LIST_ELEMENTS_RO(
-						     pim_ifp->igmp_join_list,
+						     pim_ifp->gm_join_list,
 						     node, ij)) {
 						char group_str[INET_ADDRSTRLEN];
 						char source_str

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -358,55 +358,56 @@ int pim_interface_config_write(struct vty *vty)
 				}
 
 				/* ip igmp version */
-				if (pim_ifp->version != IGMP_DEFAULT_VERSION) {
+				if (pim_ifp->igmp_version
+				    != IGMP_DEFAULT_VERSION) {
 					vty_out(vty, " ip igmp version %d\n",
-						pim_ifp->version);
+						pim_ifp->igmp_version);
 					++writes;
 				}
 
 				/* IF ip igmp query-max-response-time */
-				if (pim_ifp->query_max_response_time_dsec
+				if (pim_ifp->igmp_query_max_response_time_dsec
 				    != IGMP_QUERY_MAX_RESPONSE_TIME_DSEC) {
 					vty_out(vty,
 						" ip igmp query-max-response-time %d\n",
-						pim_ifp->query_max_response_time_dsec);
+						pim_ifp->igmp_query_max_response_time_dsec);
 					++writes;
 				}
 
 				/* IF ip igmp query-interval */
-				if (pim_ifp->default_query_interval
+				if (pim_ifp->igmp_default_query_interval
 				    != IGMP_GENERAL_QUERY_INTERVAL) {
 					vty_out(vty,
 						" ip igmp query-interval %d\n",
-						pim_ifp->default_query_interval);
+						pim_ifp->igmp_default_query_interval);
 					++writes;
 				}
 
 				/* IF ip igmp last-member_query-count */
-				if (pim_ifp->last_member_query_count
+				if (pim_ifp->igmp_last_member_query_count
 				    != IGMP_DEFAULT_ROBUSTNESS_VARIABLE) {
 					vty_out(vty,
 						" ip igmp last-member-query-count %d\n",
-						pim_ifp->last_member_query_count);
+						pim_ifp->igmp_last_member_query_count);
 					++writes;
 				}
 
 				/* IF ip igmp last-member_query-interval */
-				if (pim_ifp->specific_query_max_response_time_dsec
+				if (pim_ifp->igmp_specific_query_max_response_time_dsec
 				    != IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC) {
 					vty_out(vty,
 						" ip igmp last-member-query-interval %d\n",
-						pim_ifp->specific_query_max_response_time_dsec);
-					++writes;
+						pim_ifp->igmp_specific_query_max_response_time_dsec);
+					  ++writes;
 				}
 
 				/* IF ip igmp join */
-				if (pim_ifp->join_list) {
+				if (pim_ifp->igmp_join_list) {
 					struct listnode *node;
 					struct igmp_join *ij;
 					for (ALL_LIST_ELEMENTS_RO(
-						     pim_ifp->join_list, node,
-						     ij)) {
+						     pim_ifp->igmp_join_list,
+						     node, ij)) {
 						char group_str[INET_ADDRSTRLEN];
 						char source_str
 							[INET_ADDRSTRLEN];

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -554,7 +554,7 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  grp)) {
 			struct listnode *srcnode;
 			struct igmp_source *src;
@@ -564,7 +564,7 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 						  srcnode, src)) {
 				igmp_source_forward_reevaluate_one(pim, src);
 			} /* scan group sources */
-		}	 /* scan igmp groups */
+		}	  /* scan igmp groups */
 
 		RB_FOREACH_SAFE (ch, pim_ifchannel_rb, &pim_ifp->ifchannel_rb,
 				 ch_temp) {

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -554,7 +554,8 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->group_list, grpnode, grp)) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+					  grp)) {
 			struct listnode *srcnode;
 			struct igmp_source *src;
 


### PR DESCRIPTION
This reverts commit ea7d74d702975def719a574f0b58d642abeef974 / PR #10164 .

Pretty much all of these struct field names are now misleading on whether they refer to IGMP, PIM, or maybe even MSDP.

- `join_list`, `group_list`, `group_hash` could all be PIM or IGMP
- `version` is extra confusing because version numbers between MLD and IGMP do not line up. …and it could also refer to PIM. 

~Please redo this, maybe with `gm_` as a prefix like the other PRs.~

Re-rename added below. Didn't have time for this on Saturday.