### PR TITLE
Putting PIM and IGMP under address family

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6963,7 +6963,12 @@ DEFUN (ip_pim_joinprune_time,
        "Join Prune Send Interval\n"
        "Seconds\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/join-prune-interval",
+	char jp_timer_xpath[XPATH_MAXLEN];
+
+	snprintf(jp_timer_xpath, sizeof(jp_timer_xpath),
+		 "/frr-pim:pim/address-family[address-family='%s']/join-prune-interval",
+		 "frr-routing:ipv4");
+	nb_cli_enqueue_change(vty, jp_timer_xpath,
 			      NB_OP_MODIFY, argv[3]->arg);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -6978,7 +6983,12 @@ DEFUN (no_ip_pim_joinprune_time,
        "Join Prune Send Interval\n"
        IGNORED_IN_NO_STR)
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/join-prune-interval",
+	char jp_timer_xpath[XPATH_MAXLEN];
+
+	snprintf(jp_timer_xpath, sizeof(jp_timer_xpath),
+                 "/frr-pim:pim/address-family[address-family='%s']/join-prune-interval",
+                 "frr-routing:ipv4");
+	nb_cli_enqueue_change(vty, jp_timer_xpath,
 			      NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -6992,7 +7002,12 @@ DEFUN (ip_pim_register_suppress,
        "Register Suppress Timer\n"
        "Seconds\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/register-suppress-time",
+	char rs_timer_xpath[XPATH_MAXLEN];
+
+	snprintf(rs_timer_xpath, sizeof(rs_timer_xpath),
+		 "/frr-pim:pim/address-family[address-family='%s']/register-suppress-time",
+		 "frr-routing:ipv4");
+	nb_cli_enqueue_change(vty, rs_timer_xpath,
 			      NB_OP_MODIFY, argv[3]->arg);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -7007,7 +7022,12 @@ DEFUN (no_ip_pim_register_suppress,
        "Register Suppress Timer\n"
        IGNORED_IN_NO_STR)
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/register-suppress-time",
+	char rs_timer_xpath[XPATH_MAXLEN];
+
+	snprintf(rs_timer_xpath, sizeof(rs_timer_xpath),
+		 "/frr-pim:pim/address-family[address-family='%s']/register-suppress-time",
+		 "frr-routing:ipv4");
+	nb_cli_enqueue_change(vty, rs_timer_xpath,
 			      NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -7030,7 +7050,8 @@ DEFUN (ip_pim_rp_keep_alive,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(rp_ka_timer_xpath, sizeof(rp_ka_timer_xpath),
-		 FRR_PIM_XPATH, "frr-pim:pimd", "pim", vrfname);
+		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 "frr-routing:ipv4");
 	strlcat(rp_ka_timer_xpath, "/rp-keep-alive-timer",
 		sizeof(rp_ka_timer_xpath));
 
@@ -7054,10 +7075,15 @@ DEFUN (no_ip_pim_rp_keep_alive,
 	char rp_ka_timer[6];
 	char rp_ka_timer_xpath[XPATH_MAXLEN];
 	uint v;
+	char rs_timer_xpath[XPATH_MAXLEN];
+
+	snprintf(rs_timer_xpath, sizeof(rs_timer_xpath),
+		 "/frr-pim:pim/address-family[address-family='%s']/register-suppress-time",
+		 "frr-routing:ipv4");
 
 	/* RFC4601 */
 	v = yang_dnode_get_uint16(vty->candidate_config->dnode,
-				  "/frr-pim:pim/register-suppress-time");
+				  rs_timer_xpath);
 	v = 3 * v + PIM_REGISTER_PROBE_TIME_DEFAULT;
 	if (v > UINT16_MAX)
 		v = UINT16_MAX;
@@ -7068,7 +7094,8 @@ DEFUN (no_ip_pim_rp_keep_alive,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(rp_ka_timer_xpath, sizeof(rp_ka_timer_xpath),
-		 FRR_PIM_XPATH, "frr-pim:pimd", "pim", vrfname);
+		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 "frr-routing:ipv4");
 	strlcat(rp_ka_timer_xpath, "/rp-keep-alive-timer",
 		sizeof(rp_ka_timer_xpath));
 
@@ -7093,8 +7120,8 @@ DEFUN (ip_pim_keep_alive,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_AF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ka_timer_xpath, "/keep-alive-timer", sizeof(ka_timer_xpath));
 
 	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_MODIFY,
@@ -7119,8 +7146,8 @@ DEFUN (no_ip_pim_keep_alive,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_AF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ka_timer_xpath, "/keep-alive-timer", sizeof(ka_timer_xpath));
 
 	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_DESTROY, NULL);
@@ -7136,7 +7163,12 @@ DEFUN (ip_pim_packets,
        "packets to process at one time per fd\n"
        "Number of packets\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/packets", NB_OP_MODIFY,
+	char packet_xpath[XPATH_MAXLEN];
+
+	snprintf(packet_xpath, sizeof(packet_xpath),
+		 "/frr-pim:pim/address-family[address-family='%s']/packets",
+		 "frr-routing:ipv4");
+	nb_cli_enqueue_change(vty, packet_xpath, NB_OP_MODIFY,
 			      argv[3]->arg);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -7151,7 +7183,12 @@ DEFUN (no_ip_pim_packets,
        "packets to process at one time per fd\n"
        IGNORED_IN_NO_STR)
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/packets", NB_OP_DESTROY, NULL);
+	char packet_xpath[XPATH_MAXLEN];
+
+	snprintf(packet_xpath, sizeof(packet_xpath),
+		 "/frr-pim:pim/address-family[address-family='%s']/packets",
+		 "frr-routing:ipv4");
+	nb_cli_enqueue_change(vty, packet_xpath, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -7709,8 +7746,8 @@ DEFUN (ip_pim_ecmp,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_AF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ecmp_xpath, "/ecmp", sizeof(ecmp_xpath));
 
 	nb_cli_enqueue_change(vty, ecmp_xpath, NB_OP_MODIFY, "true");
@@ -7732,8 +7769,8 @@ DEFUN (no_ip_pim_ecmp,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_AF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ecmp_xpath, "/ecmp", sizeof(ecmp_xpath));
 
 	nb_cli_enqueue_change(vty, ecmp_xpath, NB_OP_MODIFY, "false");
@@ -7757,12 +7794,12 @@ DEFUN (ip_pim_ecmp_rebalance,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_AF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ecmp_xpath, "/ecmp", sizeof(ecmp_xpath));
 	snprintf(ecmp_rebalance_xpath, sizeof(ecmp_rebalance_xpath),
-		 FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+		 FRR_PIM_AF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ecmp_rebalance_xpath, "/ecmp-rebalance",
 		sizeof(ecmp_rebalance_xpath));
 
@@ -7789,8 +7826,8 @@ DEFUN (no_ip_pim_ecmp_rebalance,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(ecmp_rebalance_xpath, sizeof(ecmp_rebalance_xpath),
-		 FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+		 FRR_PIM_AF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ecmp_rebalance_xpath, "/ecmp-rebalance",
 		sizeof(ecmp_rebalance_xpath));
 
@@ -7805,9 +7842,11 @@ DEFUN (interface_ip_igmp,
        IP_STR
        IFACE_IGMP_STR)
 {
-	nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY, "true");
+	nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+		"./frr-mgmd:mgmd/address-family[address-family='%s']",
+		"frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp,
@@ -7821,7 +7860,8 @@ DEFUN (interface_no_ip_igmp,
 	char pim_if_xpath[XPATH_MAXLEN + 20];
 
 	snprintf(pim_if_xpath, sizeof(pim_if_xpath),
-		 "%s/frr-pim:pim", VTY_CURR_XPATH);
+		 "%s/frr-pim:pim/address-family[address-family='%s']",
+		 VTY_CURR_XPATH, "frr-routing:ipv4");
 
 	pim_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
 					   "%s/pim-enable", pim_if_xpath);
@@ -7834,11 +7874,13 @@ DEFUN (interface_no_ip_igmp,
 					      NULL);
 			nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 		} else
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "false");
 	}
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_igmp_join,
@@ -7866,7 +7908,7 @@ DEFUN (interface_ip_igmp_join,
 	} else
 		source_str = "0.0.0.0";
 
-	snprintf(xpath, sizeof(xpath), FRR_IGMP_JOIN_XPATH,
+	snprintf(xpath, sizeof(xpath), FRR_MGMD_JOIN_XPATH,
 		 "frr-routing:ipv4", argv[idx_group]->arg, source_str);
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
@@ -7900,7 +7942,7 @@ DEFUN (interface_no_ip_igmp_join,
 	} else
 		source_str = "0.0.0.0";
 
-	snprintf(xpath, sizeof(xpath), FRR_IGMP_JOIN_XPATH,
+	snprintf(xpath, sizeof(xpath), FRR_MGMD_JOIN_XPATH,
 		 "frr-routing:ipv4", argv[idx_group]->arg, source_str);
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
@@ -7920,20 +7962,23 @@ DEFUN (interface_ip_igmp_query_interval,
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-pim:pim/pim-enable", VTY_CURR_XPATH);
+				"%s/frr-pim:pim/address-family[address-family='%s']/pim-enable",
+				VTY_CURR_XPATH, "frr-routing:ipv4");
 	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "true");
 	}
 
 	nb_cli_enqueue_change(vty, "./query-interval", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp_query_interval,
@@ -7947,7 +7992,9 @@ DEFUN (interface_no_ip_igmp_query_interval,
 {
 	nb_cli_enqueue_change(vty, "./query-interval", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_igmp_version,
@@ -7958,11 +8005,13 @@ DEFUN (interface_ip_igmp_version,
        "IGMP version\n"
        "IGMP version number\n")
 {
-	nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+	nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 			      "true");
 	nb_cli_enqueue_change(vty, "./version", NB_OP_MODIFY, argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp_version,
@@ -7976,7 +8025,9 @@ DEFUN (interface_no_ip_igmp_version,
 {
 	nb_cli_enqueue_change(vty, "./version", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_igmp_query_max_response_time,
@@ -7991,21 +8042,24 @@ DEFUN (interface_ip_igmp_query_max_response_time,
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-pim:pim/pim-enable", VTY_CURR_XPATH);
+				"%s/frr-pim:pim/address-family[address-family='%s']/pim-enable",
+				VTY_CURR_XPATH, "frr-routing:ipv4");
 
 	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "true");
 	}
 
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp_query_max_response_time,
@@ -8019,7 +8073,9 @@ DEFUN (interface_no_ip_igmp_query_max_response_time,
 {
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_DESTROY,
 			      NULL);
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN_HIDDEN (interface_ip_igmp_query_max_response_time_dsec,
@@ -8034,20 +8090,23 @@ DEFUN_HIDDEN (interface_ip_igmp_query_max_response_time_dsec,
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-pim:pim/pim-enable", VTY_CURR_XPATH);
+				"%s/frr-pim:pim/address-family[address-family='%s']/pim-enable",
+				VTY_CURR_XPATH, "frr-routing:ipv4");
 	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "true");
 	}
 
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN_HIDDEN (interface_no_ip_igmp_query_max_response_time_dsec,
@@ -8062,7 +8121,9 @@ DEFUN_HIDDEN (interface_no_ip_igmp_query_max_response_time_dsec,
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_DESTROY,
 			      NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_igmp_last_member_query_count,
@@ -8077,20 +8138,23 @@ DEFUN (interface_ip_igmp_last_member_query_count,
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-pim:pim/pim-enable", VTY_CURR_XPATH);
+				"%s/frr-pim:pim/address-family[address-family='%s']/pim-enable",
+				VTY_CURR_XPATH, "frr-routing:ipv4");
 	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "true");
 	}
 
 	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp_last_member_query_count,
@@ -8105,7 +8169,9 @@ DEFUN (interface_no_ip_igmp_last_member_query_count,
 	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_DESTROY,
 			      NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_igmp_last_member_query_interval,
@@ -8120,20 +8186,23 @@ DEFUN (interface_ip_igmp_last_member_query_interval,
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-pim:pim/pim-enable", VTY_CURR_XPATH);
+				"%s/frr-pim:pim/address-family[address-family='%s']/pim-enable",
+				VTY_CURR_XPATH, "frr-routing:ipv4");
 	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "true");
 	}
 
 	nb_cli_enqueue_change(vty, "./last-member-query-interval", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp_last_member_query_interval,
@@ -8148,7 +8217,9 @@ DEFUN (interface_no_ip_igmp_last_member_query_interval,
 	nb_cli_enqueue_change(vty, "./last-member-query-interval",
 			      NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty,
+			"./frr-mgmd:mgmd/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_pim_drprio,
@@ -8164,7 +8235,8 @@ DEFUN (interface_ip_pim_drprio,
 	nb_cli_enqueue_change(vty, "./dr-priority", NB_OP_MODIFY,
 			      argv[idx_number]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty, "./frr-pim:pim/address-family[address-family='%s']",
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_pim_drprio,
@@ -8178,7 +8250,8 @@ DEFUN (interface_no_ip_pim_drprio,
 {
 	nb_cli_enqueue_change(vty, "./dr-priority", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty, "./frr-pim:pim/address-family[address-family='%s']",
+				   "frr-routing:ipv4");
 }
 
 DEFPY_HIDDEN (interface_ip_igmp_query_generate,
@@ -8276,7 +8349,9 @@ DEFPY (interface_ip_pim_activeactive,
 				      "true");
 	}
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN_HIDDEN (interface_ip_pim_ssm,
@@ -8290,7 +8365,9 @@ DEFUN_HIDDEN (interface_ip_pim_ssm,
 
 	nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY, "true");
 
-	ret = nb_cli_apply_changes(vty, "./frr-pim:pim");
+	ret = nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 
 	if (ret != NB_OK)
 		return ret;
@@ -8310,7 +8387,9 @@ DEFUN_HIDDEN (interface_ip_pim_sm,
 {
 	nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_pim,
@@ -8321,7 +8400,10 @@ DEFUN (interface_ip_pim,
 {
 	nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
+
 }
 
 DEFUN_HIDDEN (interface_no_ip_pim_ssm,
@@ -8336,9 +8418,10 @@ DEFUN_HIDDEN (interface_no_ip_pim_ssm,
 	char igmp_if_xpath[XPATH_MAXLEN + 20];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
-		 "%s/frr-igmp:igmp", VTY_CURR_XPATH);
+		 "%s/frr-mgmd:mgmd/address-family[address-family='%s']",
+		 VTY_CURR_XPATH, "frr-routing:ipv4");
 	igmp_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
-					    "%s/igmp-enable", igmp_if_xpath);
+					    "%s/enable", igmp_if_xpath);
 
 	if (!igmp_enable_dnode) {
 		nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY, NULL);
@@ -8353,7 +8436,8 @@ DEFUN_HIDDEN (interface_no_ip_pim_ssm,
 					      "false");
 	}
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty, "./frr-pim:pim/address-family[address-family='%s']",
+				    "frr-routing:ipv4");
 }
 
 DEFUN_HIDDEN (interface_no_ip_pim_sm,
@@ -8368,9 +8452,10 @@ DEFUN_HIDDEN (interface_no_ip_pim_sm,
 	char igmp_if_xpath[XPATH_MAXLEN + 20];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
-		 "%s/frr-igmp:igmp", VTY_CURR_XPATH);
+		 "%s/frr-mgmd:mgmd/address-family[address-family='%s']",
+		 VTY_CURR_XPATH, "frr-routing:ipv4");
 	igmp_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
-					    "%s/igmp-enable", igmp_if_xpath);
+					    "%s/enable", igmp_if_xpath);
 
 	if (!igmp_enable_dnode) {
 		nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY, NULL);
@@ -8385,7 +8470,9 @@ DEFUN_HIDDEN (interface_no_ip_pim_sm,
 					      "false");
 	}
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_pim,
@@ -8399,9 +8486,10 @@ DEFUN (interface_no_ip_pim,
 	char igmp_if_xpath[XPATH_MAXLEN + 20];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
-		 "%s/frr-igmp:igmp", VTY_CURR_XPATH);
+		 "%s/frr-mgmd:mgmd/address-family[address-family='%s']",
+		 VTY_CURR_XPATH, "frr-routing:ipv4");
 	igmp_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
-					    "%s/igmp-enable", igmp_if_xpath);
+					    "%s/enable", igmp_if_xpath);
 
 	if (!igmp_enable_dnode) {
 		nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY, NULL);
@@ -8416,7 +8504,9 @@ DEFUN (interface_no_ip_pim,
 					      "false");
 	}
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+				    "./frr-pim:pim/address-family[address-family='%s']",
+				    "frr-routing:ipv4");
 }
 
 /* boundaries */
@@ -8524,7 +8614,8 @@ DEFUN (interface_ip_pim_hello,
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-igmp:igmp/igmp-enable", VTY_CURR_XPATH);
+				"%s/frr-mgmd:mgmd/address-family[address-family='%s']/enable",
+				VTY_CURR_XPATH, "frr-routing:ipv4");
 	if (!igmp_enable_dnode) {
 		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
 				      "true");
@@ -8541,7 +8632,9 @@ DEFUN (interface_ip_pim_hello,
 		nb_cli_enqueue_change(vty, "./hello-holdtime", NB_OP_MODIFY,
 				      argv[idx_hold]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+				    "./frr-pim:pim/address-family[address-family='%s']",
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_pim_hello,
@@ -8557,7 +8650,9 @@ DEFUN (interface_no_ip_pim_hello,
 	nb_cli_enqueue_change(vty, "./hello-interval", NB_OP_DESTROY, NULL);
 	nb_cli_enqueue_change(vty, "./hello-holdtime", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+				    "./frr-pim:pim/address-family[address-family='%s']",
+				    "frr-routing:ipv4");
 }
 
 DEFUN (debug_igmp,
@@ -9238,7 +9333,8 @@ DEFPY (ip_pim_bfd,
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-igmp:igmp/igmp-enable", VTY_CURR_XPATH);
+				"%s/frr-mgmd:mgmd/address-family[address-family='%s']/enable",
+				VTY_CURR_XPATH, "frr-routing:ipv4");
 	if (!igmp_enable_dnode)
 		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
 				      "true");
@@ -9252,7 +9348,9 @@ DEFPY (ip_pim_bfd,
 	if (prof)
 		nb_cli_enqueue_change(vty, "./bfd/profile", NB_OP_MODIFY, prof);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+				    "./frr-pim:pim/address-family[address-family='%s']",
+				    "frr-routing:ipv4");
 }
 
 DEFPY(no_ip_pim_bfd_profile, no_ip_pim_bfd_profile_cmd,
@@ -9266,7 +9364,9 @@ DEFPY(no_ip_pim_bfd_profile, no_ip_pim_bfd_profile_cmd,
 {
 	nb_cli_enqueue_change(vty, "./bfd/profile", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (no_ip_pim_bfd,
@@ -9279,7 +9379,9 @@ DEFUN (no_ip_pim_bfd,
 {
 	nb_cli_enqueue_change(vty, "./bfd", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (ip_pim_bsm,
@@ -9293,7 +9395,8 @@ DEFUN (ip_pim_bsm,
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-igmp:igmp/igmp-enable", VTY_CURR_XPATH);
+				"%s/frr-mgmd:mgmd/address-family[address-family='%s']/enable",
+				VTY_CURR_XPATH, "frr-routing:ipv4");
 	if (!igmp_enable_dnode)
 		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
 				      "true");
@@ -9305,7 +9408,9 @@ DEFUN (ip_pim_bsm,
 
 	nb_cli_enqueue_change(vty, "./bsm", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (no_ip_pim_bsm,
@@ -9318,7 +9423,9 @@ DEFUN (no_ip_pim_bsm,
 {
 	nb_cli_enqueue_change(vty, "./bsm", NB_OP_MODIFY, "false");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFUN (ip_pim_ucast_bsm,
@@ -9332,7 +9439,8 @@ DEFUN (ip_pim_ucast_bsm,
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-igmp:igmp/igmp-enable", VTY_CURR_XPATH);
+				"%s/frr-mgmd:mgmd/address-family[address-family='%s']/enable",
+				VTY_CURR_XPATH, "frr-routing:ipv4");
 	if (!igmp_enable_dnode)
 		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
 				      "true");
@@ -9344,7 +9452,10 @@ DEFUN (ip_pim_ucast_bsm,
 
 	nb_cli_enqueue_change(vty, "./unicast-bsm", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
+
 }
 
 DEFUN (no_ip_pim_ucast_bsm,
@@ -9357,7 +9468,9 @@ DEFUN (no_ip_pim_ucast_bsm,
 {
 	nb_cli_enqueue_change(vty, "./unicast-bsm", NB_OP_MODIFY, "false");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 #if HAVE_BFDD > 0
@@ -9391,7 +9504,8 @@ DEFUN_HIDDEN (
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-igmp:igmp/igmp-enable", VTY_CURR_XPATH);
+				"%s/frr-mgmd:mgmd/address-family[address-family='%s']/enable",
+				VTY_CURR_XPATH, "frr-routing:ipv4");
 	if (!igmp_enable_dnode)
 		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
 				      "true");
@@ -9409,7 +9523,9 @@ DEFUN_HIDDEN (
 	nb_cli_enqueue_change(vty, "./bfd/detect_mult", NB_OP_MODIFY,
 			      argv[idx_number]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 #if HAVE_BFDD == 0
@@ -9452,7 +9568,9 @@ DEFPY(ip_msdp_peer, ip_msdp_peer_cmd,
 	nb_cli_enqueue_change(vty, msdp_peer_source_xpath, NB_OP_MODIFY,
 			      source_str);
 
-	return nb_cli_apply_changes(vty, NULL);
+	return nb_cli_apply_changes(vty,
+			"./frr-pim:pim/address-family[address-family='%s']",
+			"frr-routing:ipv4");
 }
 
 DEFPY(ip_msdp_timers, ip_msdp_timers_cmd,
@@ -11179,4 +11297,11 @@ void pim_cmd_init(void)
 #if HAVE_BFDD == 0
 	install_element(INTERFACE_NODE, &no_ip_pim_bfd_param_cmd);
 #endif /* !HAVE_BFDD */
+}
+
+void pim6_cmd_init(void)
+{
+        if_cmd_init(pim_interface_config_write);
+
+        install_node(&debug_node);
 }

--- a/pimd/pim_cmd.h
+++ b/pimd/pim_cmd.h
@@ -72,7 +72,7 @@
 
 
 void pim_cmd_init(void);
-
+void pim6_cmd_init(void);
 /*
  * Special Macro to allow us to get the correct pim_instance;
  */

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -81,7 +81,7 @@ static const struct frr_yang_module_info *const pimd_yang_modules[] = {
 	&frr_routing_info,
 	&frr_pim_info,
 	&frr_pim_rp_info,
-	&frr_igmp_info,
+	&frr_mgmd_info,
 };
 
 FRR_DAEMON_INFO(pimd, PIM, .vty_port = PIMD_VTY_PORT,

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -28,53 +28,60 @@
 const struct frr_yang_module_info frr_pim_info = {
 	.name = "frr-pim",
 	.nodes = {
+                {
+                        .xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family",
+                        .cbs = {
+                                .create = routing_control_plane_protocols_control_plane_protocol_pim_address_family_create,
+                                .destroy = routing_control_plane_protocols_control_plane_protocol_pim_address_family_destroy,
+                        }
+                },
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/ecmp",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/ecmp",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_pim_ecmp_modify,
+				.modify = routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_modify,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/ecmp-rebalance",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/ecmp-rebalance",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_pim_ecmp_rebalance_modify,
+				.modify = routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_rebalance_modify,
 			}
 		},
 		{
-			.xpath = "/frr-pim:pim/join-prune-interval",
+			.xpath = "/frr-pim:pim/address-family/join-prune-interval",
 			.cbs = {
-				.modify = pim_join_prune_interval_modify,
+				.modify = pim_address_family_join_prune_interval_modify,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/keep-alive-timer",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/keep-alive-timer",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_pim_keep_alive_timer_modify,
+				.modify = routing_control_plane_protocols_control_plane_protocol_pim_address_family_keep_alive_timer_modify,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/rp-keep-alive-timer",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/rp-keep-alive-timer",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_pim_rp_keep_alive_timer_modify,
+				.modify = routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_keep_alive_timer_modify,
 			}
 		},
 		{
-			.xpath = "/frr-pim:pim/packets",
+			.xpath = "/frr-pim:pim/address-family",
 			.cbs = {
-				.modify = pim_packets_modify,
+				.create = pim_address_family_create,
+				.destroy = pim_address_family_destroy, 
 			}
 		},
 		{
-			.xpath = "/frr-pim:pim/register-suppress-time",
+			.xpath = "/frr-pim:pim/address-family/packets",
 			.cbs = {
-				.modify = pim_register_suppress_time_modify,
+				.modify = pim_address_family_packets_modify,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family",
+			.xpath = "/frr-pim:pim/address-family/register-suppress-time",
 			.cbs = {
-				.create = routing_control_plane_protocols_control_plane_protocol_pim_address_family_create,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_pim_address_family_destroy,
+				.modify = pim_address_family_register_suppress_time_modify,
 			}
 		},
 		{
@@ -210,94 +217,87 @@ const struct frr_yang_module_info frr_pim_info = {
 				.destroy = routing_control_plane_protocols_control_plane_protocol_pim_address_family_register_accept_list_destroy,
 			}
 		},
+                {
+                        .xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family",
+                        .cbs = {
+                                .create = lib_interface_pim_address_family_create,
+                                .destroy = lib_interface_pim_address_family_destroy,
+                        }
+                },
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/pim-enable",
 			.cbs = {
-				.create = lib_interface_pim_create,
-				.destroy = lib_interface_pim_destroy,
+				.modify = lib_interface_pim_address_family_pim_enable_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/pim-enable",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/dr-priority",
 			.cbs = {
-				.modify = lib_interface_pim_pim_enable_modify,
+				.modify = lib_interface_pim_address_family_dr_priority_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/dr-priority",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/hello-interval",
 			.cbs = {
-				.modify = lib_interface_pim_dr_priority_modify,
+				.modify = lib_interface_pim_address_family_hello_interval_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/hello-interval",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/hello-holdtime",
 			.cbs = {
-				.modify = lib_interface_pim_hello_interval_modify,
+				.modify = lib_interface_pim_address_family_hello_holdtime_modify,
+				.destroy = lib_interface_pim_address_family_hello_holdtime_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/hello-holdtime",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd",
 			.cbs = {
-				.modify = lib_interface_pim_hello_holdtime_modify,
-				.destroy = lib_interface_pim_hello_holdtime_destroy,
+				.create = lib_interface_pim_address_family_bfd_create,
+				.destroy = lib_interface_pim_address_family_bfd_destroy,
+				.apply_finish = lib_interface_pim_address_family_bfd_apply_finish,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bfd",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd/min-rx-interval",
 			.cbs = {
-				.create = lib_interface_pim_bfd_create,
-				.destroy = lib_interface_pim_bfd_destroy,
-				.apply_finish = lib_interface_pim_bfd_apply_finish,
+				.modify = lib_interface_pim_address_family_bfd_min_rx_interval_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bfd/min-rx-interval",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd/min-tx-interval",
 			.cbs = {
-				.modify = lib_interface_pim_bfd_min_rx_interval_modify,
+				.modify = lib_interface_pim_address_family_bfd_min_tx_interval_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bfd/min-tx-interval",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd/detect_mult",
 			.cbs = {
-				.modify = lib_interface_pim_bfd_min_tx_interval_modify,
+				.modify = lib_interface_pim_address_family_bfd_detect_mult_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bfd/detect_mult",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd/profile",
 			.cbs = {
-				.modify = lib_interface_pim_bfd_detect_mult_modify,
+				.modify = lib_interface_pim_address_family_bfd_profile_modify,
+				.destroy = lib_interface_pim_address_family_bfd_profile_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bfd/profile",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bsm",
 			.cbs = {
-				.modify = lib_interface_pim_bfd_profile_modify,
-				.destroy = lib_interface_pim_bfd_profile_destroy,
+				.modify = lib_interface_pim_address_family_bsm_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bsm",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/unicast-bsm",
 			.cbs = {
-				.modify = lib_interface_pim_bsm_modify,
+				.modify = lib_interface_pim_address_family_unicast_bsm_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/unicast-bsm",
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/active-active",
 			.cbs = {
-				.modify = lib_interface_pim_unicast_bsm_modify,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/active-active",
-			.cbs = {
-				.modify = lib_interface_pim_active_active_modify,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family",
-			.cbs = {
-				.create = lib_interface_pim_address_family_create,
-				.destroy = lib_interface_pim_address_family_destroy,
+				.modify = lib_interface_pim_address_family_active_active_modify,
 			}
 		},
 		{
@@ -366,65 +366,58 @@ const struct frr_yang_module_info frr_pim_rp_info = {
 };
 
 /* clang-format off */
-const struct frr_yang_module_info frr_igmp_info = {
-	.name = "frr-igmp",
+const struct frr_yang_module_info frr_mgmd_info = {
+	.name = "frr-mgmd",
 	.nodes = {
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp",
+			.xpath = "/frr-interface:lib/interface/frr-mgmd:mgmd/address-family",
 			.cbs = {
-				.create = lib_interface_igmp_create,
-				.destroy = lib_interface_igmp_destroy,
+				.create = lib_interface_mgmd_address_family_create,
+				.destroy = lib_interface_mgmd_address_family_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/igmp-enable",
+			.xpath = "/frr-interface:lib/interface/frr-mgmd:mgmd/address-family/enable",
 			.cbs = {
-				.modify = lib_interface_igmp_igmp_enable_modify,
+				.modify = lib_interface_mgmd_address_family_enable_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/version",
+			.xpath = "/frr-interface:lib/interface/frr-mgmd:mgmd/address-family/version",
 			.cbs = {
-				.modify = lib_interface_igmp_version_modify,
-				.destroy = lib_interface_igmp_version_destroy,
+				.modify = lib_interface_mgmd_address_family_version_modify,
+				.destroy = lib_interface_mgmd_address_family_version_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/query-interval",
+			.xpath = "/frr-interface:lib/interface/frr-mgmd:mgmd/address-family/query-interval",
 			.cbs = {
-				.modify = lib_interface_igmp_query_interval_modify,
+				.modify = lib_interface_mgmd_address_family_query_interval_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/query-max-response-time",
+			.xpath = "/frr-interface:lib/interface/frr-mgmd:mgmd/address-family/query-max-response-time",
 			.cbs = {
-				.modify = lib_interface_igmp_query_max_response_time_modify,
+				.modify = lib_interface_mgmd_address_family_query_max_response_time_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/last-member-query-interval",
+			.xpath = "/frr-interface:lib/interface/frr-mgmd:mgmd/address-family/last-member-query-interval",
 			.cbs = {
-				.modify = lib_interface_igmp_last_member_query_interval_modify,
+				.modify = lib_interface_mgmd_address_family_last_member_query_interval_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/robustness-variable",
+			.xpath = "/frr-interface:lib/interface/frr-mgmd:mgmd/address-family/robustness-variable",
 			.cbs = {
-				.modify = lib_interface_igmp_robustness_variable_modify,
+				.modify = lib_interface_mgmd_address_family_robustness_variable_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/address-family",
+			.xpath = "/frr-interface:lib/interface/frr-mgmd:mgmd/address-family/static-group",
 			.cbs = {
-				.create = lib_interface_igmp_address_family_create,
-				.destroy = lib_interface_igmp_address_family_destroy,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/address-family/static-group",
-			.cbs = {
-				.create = lib_interface_igmp_address_family_static_group_create,
-				.destroy = lib_interface_igmp_address_family_static_group_destroy,
+				.create = lib_interface_mgmd_address_family_static_group_create,
+				.destroy = lib_interface_mgmd_address_family_static_group_destroy,
 			}
 		},
 		{

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -22,20 +22,22 @@
 
 extern const struct frr_yang_module_info frr_pim_info;
 extern const struct frr_yang_module_info frr_pim_rp_info;
-extern const struct frr_yang_module_info frr_igmp_info;
+extern const struct frr_yang_module_info frr_mgmd_info;
 
 /* frr-pim prototypes*/
-int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_modify(
 	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_rebalance_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_rebalance_modify(
 	struct nb_cb_modify_args *args);
-int pim_join_prune_interval_modify(struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_pim_keep_alive_timer_modify(
+int pim_address_family_join_prune_interval_modify(struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_keep_alive_timer_modify(
 	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_pim_rp_keep_alive_timer_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_keep_alive_timer_modify(
 	struct nb_cb_modify_args *args);
-int pim_packets_modify(struct nb_cb_modify_args *args);
-int pim_register_suppress_time_modify(struct nb_cb_modify_args *args);
+int pim_address_family_create(struct nb_cb_create_args *args);
+int pim_address_family_destroy(struct nb_cb_destroy_args *args);
+int pim_address_family_packets_modify(struct nb_cb_modify_args *args);
+int pim_address_family_register_suppress_time_modify(struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_create(
 	struct nb_cb_create_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_destroy(
@@ -97,28 +99,26 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_re
 	struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_register_accept_list_destroy(
 	struct nb_cb_destroy_args *args);
-int lib_interface_pim_dr_priority_modify(
+int lib_interface_pim_address_family_dr_priority_modify(
 	struct nb_cb_modify_args *args);
-int lib_interface_pim_create(struct nb_cb_create_args *args);
-int lib_interface_pim_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_pim_pim_enable_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_hello_interval_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_hello_holdtime_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_hello_holdtime_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_pim_bfd_create(struct nb_cb_create_args *args);
-int lib_interface_pim_bfd_destroy(struct nb_cb_destroy_args *args);
-void lib_interface_pim_bfd_apply_finish(struct nb_cb_apply_finish_args *args);
-int lib_interface_pim_bfd_min_rx_interval_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_bfd_min_tx_interval_modify(
-	struct nb_cb_modify_args *args);
-int lib_interface_pim_bfd_detect_mult_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_bfd_profile_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_bfd_profile_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_pim_bsm_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_unicast_bsm_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_active_active_modify(struct nb_cb_modify_args *args);
 int lib_interface_pim_address_family_create(struct nb_cb_create_args *args);
 int lib_interface_pim_address_family_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_pim_address_family_pim_enable_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_hello_interval_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_hello_holdtime_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_hello_holdtime_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_pim_address_family_bfd_create(struct nb_cb_create_args *args);
+int lib_interface_pim_address_family_bfd_destroy(struct nb_cb_destroy_args *args);
+void lib_interface_pim_address_family_bfd_apply_finish(struct nb_cb_apply_finish_args *args);
+int lib_interface_pim_address_family_bfd_min_rx_interval_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_bfd_min_tx_interval_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_bfd_detect_mult_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_bfd_profile_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_bfd_profile_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_pim_address_family_bsm_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_unicast_bsm_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_active_active_modify(struct nb_cb_modify_args *args);
 int lib_interface_pim_address_family_use_source_modify(
 	struct nb_cb_modify_args *args);
 int lib_interface_pim_address_family_use_source_destroy(
@@ -150,24 +150,22 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_static_rp_rp_list_prefix_list_destroy(
 	struct nb_cb_destroy_args *args);
 
-/* frr-igmp prototypes*/
-int lib_interface_igmp_create(struct nb_cb_create_args *args);
-int lib_interface_igmp_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_igmp_igmp_enable_modify(struct nb_cb_modify_args *args);
-int lib_interface_igmp_version_modify(struct nb_cb_modify_args *args);
-int lib_interface_igmp_version_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_igmp_query_interval_modify(struct nb_cb_modify_args *args);
-int lib_interface_igmp_query_max_response_time_modify(
+/* frr-mgmd prototypes*/
+int lib_interface_mgmd_address_family_create(struct nb_cb_create_args *args);
+int lib_interface_mgmd_address_family_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_mgmd_address_family_enable_modify(struct nb_cb_modify_args *args);
+int lib_interface_mgmd_address_family_version_modify(struct nb_cb_modify_args *args);
+int lib_interface_mgmd_address_family_version_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_mgmd_address_family_query_interval_modify(struct nb_cb_modify_args *args);
+int lib_interface_mgmd_address_family_query_max_response_time_modify(
 	struct nb_cb_modify_args *args);
-int lib_interface_igmp_last_member_query_interval_modify(
+int lib_interface_mgmd_address_family_last_member_query_interval_modify(
 	struct nb_cb_modify_args *args);
-int lib_interface_igmp_robustness_variable_modify(
+int lib_interface_mgmd_address_family_robustness_variable_modify(
 	struct nb_cb_modify_args *args);
-int lib_interface_igmp_address_family_create(struct nb_cb_create_args *args);
-int lib_interface_igmp_address_family_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_igmp_address_family_static_group_create(
+int lib_interface_mgmd_address_family_static_group_create(
 	struct nb_cb_create_args *args);
-int lib_interface_igmp_address_family_static_group_destroy(
+int lib_interface_mgmd_address_family_static_group_destroy(
 	struct nb_cb_destroy_args *args);
 
 /*
@@ -177,10 +175,6 @@ int lib_interface_igmp_address_family_static_group_destroy(
 int routing_control_plane_protocols_name_validate(
 	struct nb_cb_create_args *args);
 
-#define FRR_PIM_XPATH                                                   \
-	"/frr-routing:routing/control-plane-protocols/"                 \
-	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"       \
-	"frr-pim:pim"
 #define FRR_PIM_AF_XPATH                                                \
 	"/frr-routing:routing/control-plane-protocols/"                 \
 	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"       \
@@ -190,8 +184,8 @@ int routing_control_plane_protocols_name_validate(
 	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"       \
 	"frr-pim:pim/address-family[address-family='%s']/"              \
 	"frr-pim-rp:rp/static-rp/rp-list[rp-address='%s']"
-#define FRR_IGMP_JOIN_XPATH                                             \
-	"./frr-igmp:igmp/address-family[address-family='%s']/"          \
+#define FRR_MGMD_JOIN_XPATH                                             \
+	"./frr-mgmd:mgmd/address-family[address-family='%s']/"          \
 	"static-group[group-addr='%s'][source-addr='%s']"
 #define FRR_PIM_MSDP_XPATH FRR_PIM_AF_XPATH "/msdp"
 

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -318,9 +318,12 @@ static bool is_pim_interface(const struct lyd_node *dnode)
 
 	yang_dnode_get_path(dnode, if_xpath, sizeof(if_xpath));
 	pim_enable_dnode =
-		yang_dnode_getf(dnode, "%s/frr-pim:pim/pim-enable", if_xpath);
-	igmp_enable_dnode = yang_dnode_getf(
-		dnode, "%s/frr-igmp:igmp/igmp-enable", if_xpath);
+		yang_dnode_getf(dnode,
+				"%s/frr-pim:pim/address-family[address-family='%s']/pim-enable",
+				if_xpath, "frr-routing:ipv4");
+	igmp_enable_dnode = yang_dnode_getf(dnode,
+			"%s/frr-mgmd:mgmd/address-family[address-family='%s']/enable",
+			if_xpath, "frr-routing:ipv4");
 
 	if (((pim_enable_dnode) &&
 	     (yang_dnode_get_bool(pim_enable_dnode, "."))) ||
@@ -510,9 +513,38 @@ int routing_control_plane_protocols_name_validate(
 }
 
 /*
- * XPath: /frr-pim:pim/packets
+ * XPath: /frr-pim:pim/address-family
  */
-int pim_packets_modify(struct nb_cb_modify_args *args)
+int pim_address_family_create(struct nb_cb_create_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		break;
+	}
+
+	return NB_OK;
+}
+
+int pim_address_family_destroy(struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-pim:pim/address-family/packets
+ */
+int pim_address_family_packets_modify(struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -520,6 +552,7 @@ int pim_packets_modify(struct nb_cb_modify_args *args)
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
+		
 		router->packet_process = yang_dnode_get_uint8(args->dnode,
 				NULL);
 		break;
@@ -529,9 +562,9 @@ int pim_packets_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-pim:pim/join-prune-interval
+ * XPath: /frr-pim:pim/address-family/join-prune-interval
  */
-int pim_join_prune_interval_modify(struct nb_cb_modify_args *args)
+int pim_address_family_join_prune_interval_modify(struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -547,9 +580,9 @@ int pim_join_prune_interval_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-pim:pim/register-suppress-time
+ * XPath: /frr-pim:pim/address-family/register-suppress-time
  */
-int pim_register_suppress_time_modify(struct nb_cb_modify_args *args)
+int pim_address_family_register_suppress_time_modify(struct nb_cb_modify_args *args)
 {
 	uint16_t value;
 	switch (args->event) {
@@ -585,9 +618,9 @@ int pim_register_suppress_time_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/ecmp
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/ecmp
  */
-int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
@@ -608,9 +641,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_modify(
 }
 
 /*
- * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/ecmp-rebalance
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/ecmp-rebalance
  */
-int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_rebalance_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_rebalance_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
@@ -632,9 +665,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_rebalance_mo
 }
 
 /*
- * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/keep-alive-timer
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/keep-alive-timer
  */
-int routing_control_plane_protocols_control_plane_protocol_pim_keep_alive_timer_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_keep_alive_timer_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
@@ -656,9 +689,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_keep_alive_timer_
 }
 
 /*
- * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/rp-keep-alive-timer
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/rp-keep-alive-timer
  */
-int routing_control_plane_protocols_control_plane_protocol_pim_rp_keep_alive_timer_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_keep_alive_timer_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
@@ -1476,9 +1509,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_re
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family
  */
-int lib_interface_pim_create(struct nb_cb_create_args *args)
+int lib_interface_pim_address_family_create(struct nb_cb_create_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -1491,7 +1524,7 @@ int lib_interface_pim_create(struct nb_cb_create_args *args)
 	return NB_OK;
 }
 
-int lib_interface_pim_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_pim_address_family_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1519,9 +1552,9 @@ int lib_interface_pim_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/pim-enable
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/pim-enable
  */
-int lib_interface_pim_pim_enable_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_pim_enable_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1573,9 +1606,9 @@ int lib_interface_pim_pim_enable_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/hello-interval
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/hello-interval
  */
-int lib_interface_pim_hello_interval_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_hello_interval_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1598,9 +1631,9 @@ int lib_interface_pim_hello_interval_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/hello-holdtime
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/hello-holdtime
  */
-int lib_interface_pim_hello_holdtime_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_hello_holdtime_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1622,7 +1655,7 @@ int lib_interface_pim_hello_holdtime_modify(struct nb_cb_modify_args *args)
 
 }
 
-int lib_interface_pim_hello_holdtime_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_pim_address_family_hello_holdtime_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1642,9 +1675,9 @@ int lib_interface_pim_hello_holdtime_destroy(struct nb_cb_destroy_args *args)
 	return NB_OK;
 }
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd
  */
-int lib_interface_pim_bfd_create(struct nb_cb_create_args *args)
+int lib_interface_pim_address_family_bfd_create(struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1665,7 +1698,7 @@ int lib_interface_pim_bfd_create(struct nb_cb_create_args *args)
 	return NB_OK;
 }
 
-int lib_interface_pim_bfd_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_pim_address_family_bfd_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1695,9 +1728,9 @@ int lib_interface_pim_bfd_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd
  */
-void lib_interface_pim_bfd_apply_finish(struct nb_cb_apply_finish_args *args)
+void lib_interface_pim_address_family_bfd_apply_finish(struct nb_cb_apply_finish_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1721,9 +1754,9 @@ void lib_interface_pim_bfd_apply_finish(struct nb_cb_apply_finish_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd/min-rx-interval
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd/min-rx-interval
  */
-int lib_interface_pim_bfd_min_rx_interval_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_bfd_min_rx_interval_modify(struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -1737,9 +1770,9 @@ int lib_interface_pim_bfd_min_rx_interval_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd/min-tx-interval
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd/min-tx-interval
  */
-int lib_interface_pim_bfd_min_tx_interval_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_bfd_min_tx_interval_modify(struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -1753,9 +1786,9 @@ int lib_interface_pim_bfd_min_tx_interval_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd/detect_mult
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd/detect_mult
  */
-int lib_interface_pim_bfd_detect_mult_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_bfd_detect_mult_modify(struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -1769,9 +1802,9 @@ int lib_interface_pim_bfd_detect_mult_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd/profile
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd/profile
  */
-int lib_interface_pim_bfd_profile_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_bfd_profile_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1794,7 +1827,7 @@ int lib_interface_pim_bfd_profile_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-int lib_interface_pim_bfd_profile_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_pim_address_family_bfd_profile_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1816,9 +1849,9 @@ int lib_interface_pim_bfd_profile_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bsm
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bsm
  */
-int lib_interface_pim_bsm_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_bsm_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1840,9 +1873,9 @@ int lib_interface_pim_bsm_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/unicast-bsm
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/unicast-bsm
  */
-int lib_interface_pim_unicast_bsm_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_unicast_bsm_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1865,9 +1898,9 @@ int lib_interface_pim_unicast_bsm_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/active-active
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/active-active
  */
-int lib_interface_pim_active_active_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_active_active_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1902,9 +1935,9 @@ int lib_interface_pim_active_active_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/dr-priority
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/dr-priority
  */
-int lib_interface_pim_dr_priority_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_dr_priority_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1916,7 +1949,7 @@ int lib_interface_pim_dr_priority_modify(struct nb_cb_modify_args *args)
 		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
 		if (!is_pim_interface(if_dnode)) {
 			snprintf(args->errmsg, args->errmsg_len,
-					"Pim not enabled on this interface");
+				 "Pim not enabled on this interface");
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -1934,35 +1967,6 @@ int lib_interface_pim_dr_priority_modify(struct nb_cb_modify_args *args)
 			pim_if_dr_election(ifp);
 			pim_hello_restart_now(ifp);
 		}
-		break;
-	}
-
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family
- */
-int lib_interface_pim_address_family_create(struct nb_cb_create_args *args)
-{
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		break;
-	}
-
-	return NB_OK;
-}
-
-int lib_interface_pim_address_family_destroy(struct nb_cb_destroy_args *args)
-{
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
 		break;
 	}
 
@@ -2021,7 +2025,7 @@ int lib_interface_pim_address_family_use_source_destroy(
 		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
 		if (!is_pim_interface(if_dnode)) {
 			snprintf(args->errmsg, args->errmsg_len,
-					"Pim not enabled on this interface");
+				 "Pim not enabled on this interface");
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -2473,9 +2477,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp
+ * XPath: /frr-interface:lib/interface/frr-mgmd:mgmd/address-family
  */
-int lib_interface_igmp_create(struct nb_cb_create_args *args)
+int lib_interface_mgmd_address_family_create(struct nb_cb_create_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -2488,7 +2492,7 @@ int lib_interface_igmp_create(struct nb_cb_create_args *args)
 	return NB_OK;
 }
 
-int lib_interface_igmp_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_mgmd_address_family_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -2519,9 +2523,9 @@ int lib_interface_igmp_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/igmp-enable
+ * XPath: /frr-interface:lib/interface/frr-mgmd:mgmd/address-family/enable
  */
-int lib_interface_igmp_igmp_enable_modify(struct nb_cb_modify_args *args)
+int lib_interface_mgmd_address_family_enable_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	bool igmp_enable;
@@ -2575,9 +2579,9 @@ int lib_interface_igmp_igmp_enable_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/version
+ * XPath: /frr-interface:lib/interface/frr-mgmd:mgmd/address-family/version
  */
-int lib_interface_igmp_version_modify(struct nb_cb_modify_args *args)
+int lib_interface_mgmd_address_family_version_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -2611,7 +2615,7 @@ int lib_interface_igmp_version_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-int lib_interface_igmp_version_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_mgmd_address_family_version_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -2632,9 +2636,9 @@ int lib_interface_igmp_version_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/query-interval
+ * XPath: /frr-interface:lib/interface/frr-mgmd:mgmd/address-family/query-interval
  */
-int lib_interface_igmp_query_interval_modify(struct nb_cb_modify_args *args)
+int lib_interface_mgmd_address_family_query_interval_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	int query_interval;
@@ -2646,6 +2650,7 @@ int lib_interface_igmp_query_interval_modify(struct nb_cb_modify_args *args)
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
+
 		query_interval = yang_dnode_get_uint16(args->dnode, NULL);
 		change_query_interval(ifp->info, query_interval);
 	}
@@ -2654,9 +2659,9 @@ int lib_interface_igmp_query_interval_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/query-max-response-time
+ * XPath: /frr-interface:lib/interface/frr-mgmd:mgmd/address-family/query-max-response-time
  */
-int lib_interface_igmp_query_max_response_time_modify(
+int lib_interface_mgmd_address_family_query_max_response_time_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
@@ -2669,6 +2674,7 @@ int lib_interface_igmp_query_max_response_time_modify(
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
+
 		query_max_response_time_dsec =
 			yang_dnode_get_uint16(args->dnode, NULL);
 		change_query_max_response_time(ifp->info,
@@ -2679,9 +2685,9 @@ int lib_interface_igmp_query_max_response_time_modify(
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/last-member-query-interval
+ * XPath: /frr-interface:lib/interface/frr-mgmd:mgmd/address-family/last-member-query-interval
  */
-int lib_interface_igmp_last_member_query_interval_modify(
+int lib_interface_mgmd_address_family_last_member_query_interval_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
@@ -2695,6 +2701,7 @@ int lib_interface_igmp_last_member_query_interval_modify(
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
+
 		pim_ifp = ifp->info;
 		last_member_query_interval =
 			yang_dnode_get_uint16(args->dnode, NULL);
@@ -2708,9 +2715,9 @@ int lib_interface_igmp_last_member_query_interval_modify(
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/robustness-variable
+ * XPath: /frr-interface:lib/interface/frr-mgmd:mgmd/address-family/robustness-variable
  */
-int lib_interface_igmp_robustness_variable_modify(
+int lib_interface_mgmd_address_family_robustness_variable_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
@@ -2724,6 +2731,7 @@ int lib_interface_igmp_robustness_variable_modify(
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
+
 		pim_ifp = ifp->info;
 		last_member_query_count = yang_dnode_get_uint8(args->dnode,
 				NULL);
@@ -2736,38 +2744,9 @@ int lib_interface_igmp_robustness_variable_modify(
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/address-family
+ * XPath: /frr-interface:lib/interface/frr-mgmd:mgmd/address-family/static-group
  */
-int lib_interface_igmp_address_family_create(struct nb_cb_create_args *args)
-{
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		break;
-	}
-
-	return NB_OK;
-}
-
-int lib_interface_igmp_address_family_destroy(struct nb_cb_destroy_args *args)
-{
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		break;
-	}
-
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/address-family/static-group
- */
-int lib_interface_igmp_address_family_static_group_create(
+int lib_interface_mgmd_address_family_static_group_create(
 	struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
@@ -2793,6 +2772,7 @@ int lib_interface_igmp_address_family_static_group_create(
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
+
 		yang_dnode_get_ip(&source_addr, args->dnode, "./source-addr");
 		yang_dnode_get_ip(&group_addr, args->dnode, "./group-addr");
 
@@ -2808,7 +2788,7 @@ int lib_interface_igmp_address_family_static_group_create(
 	return NB_OK;
 }
 
-int lib_interface_igmp_address_family_static_group_destroy(
+int lib_interface_mgmd_address_family_static_group_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
@@ -2823,6 +2803,7 @@ int lib_interface_igmp_address_family_static_group_destroy(
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
+
 		yang_dnode_get_ip(&source_addr, args->dnode, "./source-addr");
 		yang_dnode_get_ip(&group_addr, args->dnode, "./group-addr");
 

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -71,7 +71,7 @@ pimd_pimd_SOURCES = \
 nodist_pimd_pimd_SOURCES = \
 	yang/frr-pim.yang.c \
 	yang/frr-pim-rp.yang.c \
-	yang/frr-igmp.yang.c \
+	yang/frr-mgmd.yang.c \
 	# end
 
 noinst_HEADERS += \

--- a/yang/frr-mgmd.yang
+++ b/yang/frr-mgmd.yang
@@ -1,8 +1,8 @@
-module frr-igmp {
+module frr-mgmd {
   yang-version "1.1";
-  namespace "http://frrouting.org/yang/igmp";
+  namespace "http://frrouting.org/yang/mgmd";
 
-  prefix frr-igmp;
+  prefix frr-mgmd;
 
   import frr-routing {
     prefix "frr-rt";
@@ -55,23 +55,24 @@ module frr-igmp {
      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
-  revision 2019-11-06 {
+  revision 2021-11-22 {
     description
       "Initial revision.";
     reference
       "RFC 2236: IGMP v2.
-       RFC 3376: IGMP v3.";
+       RFC 3376: IGMP v3.
+       RFC 2710: MLD.";
   }
 
   grouping interface-config-attributes {
     description
-      "Configuration attributes applied to the interface level.";
+      "Configuration IGMP/MLD attributes applied to the interface level.";
 
-    leaf igmp-enable {
+    leaf enable {
       type boolean;
       default "false";
       description
-        "Enable IGMP flag on the interface.";
+        "Enable IGMP/MLD flag on the interface.";
     }
 
     leaf version {
@@ -79,7 +80,7 @@ module frr-igmp {
         range "2..3";
       }
       description
-        "IGMP version.";
+        "version.";
     }
 
     leaf query-interval {
@@ -126,11 +127,6 @@ module frr-igmp {
         "Querier's Robustness Variable allows tuning for the
          expected packet loss on a network.";
     }
-  }
-
-  grouping per-af-interface-config-attributes {
-    description
-      "Configuration attributes applied to the interface level per address family.";
 
     list static-group {
       key "group-addr source-addr";
@@ -149,25 +145,22 @@ module frr-igmp {
           "Multicast source address.";
       }
     }
-
-  } // per-af-interface-config-attributes
+  } // interface-config-attributes
 
   /*
    * Per-interface configuration data
    */
   augment "/frr-interface:lib/frr-interface:interface" {
-    container igmp {
-      presence
-        "Configure IGMP on an interface.";
-      uses interface-config-attributes;
+    container mgmd {
+//      presence
+//        "Configure Multicast Group Membership Discovery protocol.";
       list address-family {
         key "address-family";
         description
           "Each list entry for one address family.";
         uses frr-rt:address-family;
-        uses per-af-interface-config-attributes;
-
-        } //address-family
+        uses interface-config-attributes;
+      } //address-family
     }
   }
 }

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -56,11 +56,11 @@ module frr-pim {
      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
-  revision 2017-03-09 {
+  revision 2021-11-22 {
     description
       "Initial revision.";
     reference
-      "RFC XXXX: A YANG Data Model for PIM";
+      "RFC 7761: A YANG Data Model for PIM";
   }
 
   identity pimd {
@@ -76,43 +76,6 @@ module frr-pim {
   /*
    * Groupings
    */
-
-  grouping global-pim-config-attributes {
-    description
-      "A grouping defining pim global attributes.";
-
-    leaf ecmp {
-      type boolean;
-      default "false";
-      description
-        "Enable PIM ECMP.";
-    }
-
-    leaf ecmp-rebalance {
-      type boolean;
-      default "false";
-      description
-        "Enable PIM ECMP Rebalance.";
-    }
-
-    leaf keep-alive-timer {
-      type uint16 {
-        range "1..max";
-      }
-      default "210";
-      description
-        "Keep alive Timer in seconds.";
-    }
-
-    leaf rp-keep-alive-timer {
-      type uint16 {
-        range "1..max";
-      }
-      default "210";
-      description
-        "RP keep alive Timer in seconds.";
-    }
-  }
 
   grouping msdp-timers {
     leaf hold-time {
@@ -154,9 +117,41 @@ module frr-pim {
     }
   }
 
-  grouping per-af-global-pim-config-attributes {
+  grouping global-pim-config-attributes {
     description
       "A grouping defining per address family pim global attributes";
+
+    leaf ecmp {
+      type boolean;
+      default "false";
+      description
+        "Enable PIM ECMP.";
+    }
+    
+    leaf ecmp-rebalance {
+      type boolean;
+      default "false";
+      description
+        "Enable PIM ECMP Rebalance.";
+    }
+    
+    leaf keep-alive-timer {
+      type uint16 {
+        range "1..max";
+      }
+      default "210";
+      description
+        "Keep alive Timer in seconds.";
+    }
+    
+    leaf rp-keep-alive-timer {
+      type uint16 {
+        range "1..max";
+      }
+      default "210";
+      description
+        "RP keep alive Timer in seconds.";
+    }
 
     leaf send-v6-secondary {
       when "../frr-pim:address-family = 'frr-rt:ipv4'" {
@@ -326,11 +321,11 @@ module frr-pim {
         description
           "Only accept registers from a specific source prefix list.";
     }
-  } // per-af-global-pim-config-attributes
+  } // global-pim-config-attributes
 
   grouping interface-pim-config-attributes {
     description
-      "A grouping defining pim interface attributes.";
+      "A grouping defining pim interface attributes per address family.";
 
     leaf pim-enable {
       type boolean;
@@ -426,11 +421,6 @@ module frr-pim {
       description
         "DR (Designated Router) priority";
     }
-  } // interface-pim-config-attributes
-
-  grouping per-af-interface-pim-config-attributes {
-    description
-      "A grouping defining pim interface attributes per address family.";
 
     leaf use-source {
       type inet:ip-address;
@@ -467,56 +457,11 @@ module frr-pim {
           "Multicast group address.";
       }
     }
-  } // per-af-interface-pim-config-attributes
+  } // interface-pim-config-attributes
 
-  /*
-   * Global Configuration data nodes
-   */
-  augment "/frr-rt:routing/frr-rt:control-plane-protocols/"
-        + "frr-rt:control-plane-protocol" {
-    container pim {
-      when "../frr-rt:type = 'frr-pim:pimd'" {
-        description
-          "This container is only valid for the 'pim' routing
-           protocol.";
-      }
-      description
-        "PIM configuration data.";
-
-      uses global-pim-config-attributes;
-
-      list address-family {
-        key "address-family";
-        description
-          "Each list entry for one address family.";
-        uses frr-rt:address-family;
-        uses per-af-global-pim-config-attributes;
-
-      } //address-family
-    } // pim
-  } // augment
-
-  /*
-   * Per-interface configuration data
-   */
-  augment "/frr-interface:lib/frr-interface:interface" {
-    container pim {
-      presence
-        "Configure PIM on an interface.";
-      uses interface-pim-config-attributes;
-      list address-family {
-        key "address-family";
-        description
-          "Each list entry for one address family.";
-        uses frr-rt:address-family;
-        uses per-af-interface-pim-config-attributes;
-      }
-    }
-  }
-
-  container pim {
+  grouping router-pim-config-attributes {
     description
-      "PIM router parameters.";
+      "A grouping defining pim router attributes per address family.";
     leaf packets {
       type uint8 {
         range "1..max";
@@ -540,6 +485,62 @@ module frr-pim {
       default "60";
       description
         "Register Suppress Timer.";
+    }
+  }
+
+  /*
+   * Global Configuration data nodes
+   */
+  augment "/frr-rt:routing/frr-rt:control-plane-protocols/"
+        + "frr-rt:control-plane-protocol" {
+    container pim {
+      when "../frr-rt:type = 'frr-pim:pimd'" {
+        description
+          "This container is only valid for the 'pim' routing
+           protocol.";
+      }
+      description
+        "PIM configuration data.";
+      list address-family {
+        key "address-family";
+        description
+          "Each list entry for one address family.";
+        uses frr-rt:address-family;
+        uses global-pim-config-attributes;
+
+      } //address-family
+    } // pim
+  } // augment
+
+  /*
+   * Per-interface configuration data
+   */
+  augment "/frr-interface:lib/frr-interface:interface" {
+    container pim {
+//      presence
+//        "Configure PIM on an interface.";
+      list address-family {
+        key "address-family";
+        description
+          "Each list entry for one address family.";
+        uses frr-rt:address-family;
+        uses interface-pim-config-attributes;
+      }
+    }
+  }
+
+  /*
+   * Router configuration data
+   */
+  container pim {
+    description
+      "PIM router parameters.";
+    list address-family {
+      key "address-family";
+      description
+        "Each list entry for one address family.";
+      uses frr-rt:address-family;
+      uses router-pim-config-attributes;
     }
   }
 }

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -70,7 +70,7 @@ dist_yangmodels_DATA += yang/frr-zebra.yang
 endif
 
 if PIMD
-dist_yangmodels_DATA += yang/frr-igmp.yang
+dist_yangmodels_DATA += yang/frr-mgmd.yang
 dist_yangmodels_DATA += yang/frr-pim.yang
 dist_yangmodels_DATA += yang/frr-pim-rp.yang
 endif


### PR DESCRIPTION
pimd: Keeping PIM and IGMP under address-family to accomodate IPv6 in future

Co-authored-by: Mobashshera Rasool mrasool@vmware.com
Issue: # #10023