### PR TITLE
Keeping PIM  under address-family to accomodate IPv6 in future

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3815,7 +3815,7 @@ static void pim_cli_legacy_mesh_group_behavior(struct vty *vty,
 
 	/* Get mesh group base XPath. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_AF_XPATH "/msdp-mesh-groups[name='%s']",
+		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
 	/* Group must exists, otherwise just quit. */
 	if (!yang_dnode_exists(vty->candidate_config->dnode, xpath_value))
@@ -6791,13 +6791,13 @@ DEFUN (ip_pim_spt_switchover_infinity,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
 		 "frr-routing:ipv4");
 	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
 		sizeof(spt_plist_xpath));
 
 	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
 		 "frr-routing:ipv4");
 	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
 		sizeof(spt_action_xpath));
@@ -6830,13 +6830,13 @@ DEFUN (ip_pim_spt_switchover_infinity_plist,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
 		 "frr-routing:ipv4");
 	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
 		sizeof(spt_plist_xpath));
 
 	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
 		 "frr-routing:ipv4");
 	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
 		sizeof(spt_action_xpath));
@@ -6867,13 +6867,13 @@ DEFUN (no_ip_pim_spt_switchover_infinity,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
 		 "frr-routing:ipv4");
 	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
 		sizeof(spt_plist_xpath));
 
 	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
 		 "frr-routing:ipv4");
 	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
 		sizeof(spt_action_xpath));
@@ -6905,13 +6905,13 @@ DEFUN (no_ip_pim_spt_switchover_infinity_plist,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
 		 "frr-routing:ipv4");
 	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
 		sizeof(spt_plist_xpath));
 
 	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
 		 "frr-routing:ipv4");
 	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
 		sizeof(spt_action_xpath));
@@ -6940,7 +6940,7 @@ DEFPY (pim_register_accept_list,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(reg_alist_xpath, sizeof(reg_alist_xpath),
-		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
 		 "frr-routing:ipv4");
 	strlcat(reg_alist_xpath, "/register-accept-list",
 		sizeof(reg_alist_xpath));
@@ -6963,8 +6963,13 @@ DEFUN (ip_pim_joinprune_time,
        "Join Prune Send Interval\n"
        "Seconds\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/join-prune-interval",
-			      NB_OP_MODIFY, argv[3]->arg);
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 "frr-routing:ipv4");
+	strlcat(xpath, "/join-prune-interval", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, argv[3]->arg);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -6978,8 +6983,13 @@ DEFUN (no_ip_pim_joinprune_time,
        "Join Prune Send Interval\n"
        IGNORED_IN_NO_STR)
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/join-prune-interval",
-			      NB_OP_DESTROY, NULL);
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 "frr-routing:ipv4");
+	strlcat(xpath, "/join-prune-interval", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -6992,8 +7002,13 @@ DEFUN (ip_pim_register_suppress,
        "Register Suppress Timer\n"
        "Seconds\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/register-suppress-time",
-			      NB_OP_MODIFY, argv[3]->arg);
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 "frr-routing:ipv4");
+	strlcat(xpath, "/register-suppress-time", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, argv[3]->arg);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -7007,8 +7022,13 @@ DEFUN (no_ip_pim_register_suppress,
        "Register Suppress Timer\n"
        IGNORED_IN_NO_STR)
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/register-suppress-time",
-			      NB_OP_DESTROY, NULL);
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 "frr-routing:ipv4");
+	strlcat(xpath, "/register-suppress-time", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -7030,7 +7050,8 @@ DEFUN (ip_pim_rp_keep_alive,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(rp_ka_timer_xpath, sizeof(rp_ka_timer_xpath),
-		 FRR_PIM_XPATH, "frr-pim:pimd", "pim", vrfname);
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 "frr-routing:ipv4");
 	strlcat(rp_ka_timer_xpath, "/rp-keep-alive-timer",
 		sizeof(rp_ka_timer_xpath));
 
@@ -7054,10 +7075,16 @@ DEFUN (no_ip_pim_rp_keep_alive,
 	char rp_ka_timer[6];
 	char rp_ka_timer_xpath[XPATH_MAXLEN];
 	uint v;
+	char rs_timer_xpath[XPATH_MAXLEN];
+
+	snprintf(rs_timer_xpath, sizeof(rs_timer_xpath),
+		 FRR_PIM_ROUTER_XPATH, "frr-routing:ipv4");
+	strlcat(rs_timer_xpath, "/register-suppress-time",
+		sizeof(rs_timer_xpath));
 
 	/* RFC4601 */
 	v = yang_dnode_get_uint16(vty->candidate_config->dnode,
-				  "/frr-pim:pim/register-suppress-time");
+				  rs_timer_xpath);
 	v = 3 * v + PIM_REGISTER_PROBE_TIME_DEFAULT;
 	if (v > UINT16_MAX)
 		v = UINT16_MAX;
@@ -7068,7 +7095,8 @@ DEFUN (no_ip_pim_rp_keep_alive,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(rp_ka_timer_xpath, sizeof(rp_ka_timer_xpath),
-		 FRR_PIM_XPATH, "frr-pim:pimd", "pim", vrfname);
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 "frr-routing:ipv4");
 	strlcat(rp_ka_timer_xpath, "/rp-keep-alive-timer",
 		sizeof(rp_ka_timer_xpath));
 
@@ -7093,8 +7121,8 @@ DEFUN (ip_pim_keep_alive,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_VRF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ka_timer_xpath, "/keep-alive-timer", sizeof(ka_timer_xpath));
 
 	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_MODIFY,
@@ -7119,8 +7147,8 @@ DEFUN (no_ip_pim_keep_alive,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_VRF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ka_timer_xpath, "/keep-alive-timer", sizeof(ka_timer_xpath));
 
 	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_DESTROY, NULL);
@@ -7136,8 +7164,13 @@ DEFUN (ip_pim_packets,
        "packets to process at one time per fd\n"
        "Number of packets\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/packets", NB_OP_MODIFY,
-			      argv[3]->arg);
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 "frr-routing:ipv4");
+	strlcat(xpath, "/packets", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, argv[3]->arg);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -7151,7 +7184,13 @@ DEFUN (no_ip_pim_packets,
        "packets to process at one time per fd\n"
        IGNORED_IN_NO_STR)
 {
-	nb_cli_enqueue_change(vty, "/frr-pim:pim/packets", NB_OP_DESTROY, NULL);
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 "frr-routing:ipv4");
+	strlcat(xpath, "/packets", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -7200,7 +7239,7 @@ DEFUN (ip_pim_v6_secondary,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(send_v6_secondary_xpath, sizeof(send_v6_secondary_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(send_v6_secondary_xpath, "/send-v6-secondary",
 		sizeof(send_v6_secondary_xpath));
@@ -7227,7 +7266,7 @@ DEFUN (no_ip_pim_v6_secondary,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(send_v6_secondary_xpath, sizeof(send_v6_secondary_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(send_v6_secondary_xpath, "/send-v6-secondary",
 		sizeof(send_v6_secondary_xpath));
@@ -7441,7 +7480,7 @@ DEFUN (ip_pim_ssm_prefix_list,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath), FRR_PIM_AF_XPATH,
+	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath), FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ssm_plist_xpath, "/ssm-prefix-list", sizeof(ssm_plist_xpath));
 
@@ -7467,7 +7506,7 @@ DEFUN (no_ip_pim_ssm_prefix_list,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ssm_plist_xpath, "/ssm-prefix-list", sizeof(ssm_plist_xpath));
 
@@ -7496,7 +7535,7 @@ DEFUN (no_ip_pim_ssm_prefix_list_name,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ssm_plist_xpath, "/ssm-prefix-list", sizeof(ssm_plist_xpath));
 	ssm_plist_dnode = yang_dnode_get(vty->candidate_config->dnode,
@@ -7655,7 +7694,7 @@ DEFUN (ip_ssmpingd,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(ssmpingd_ip_xpath, sizeof(ssmpingd_ip_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ssmpingd_ip_xpath, "/ssm-pingd-source-ip",
 		sizeof(ssmpingd_ip_xpath));
@@ -7684,7 +7723,7 @@ DEFUN (no_ip_ssmpingd,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(ssmpingd_ip_xpath, sizeof(ssmpingd_ip_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ssmpingd_ip_xpath, "/ssm-pingd-source-ip",
 		sizeof(ssmpingd_ip_xpath));
@@ -7709,8 +7748,8 @@ DEFUN (ip_pim_ecmp,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_VRF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ecmp_xpath, "/ecmp", sizeof(ecmp_xpath));
 
 	nb_cli_enqueue_change(vty, ecmp_xpath, NB_OP_MODIFY, "true");
@@ -7732,8 +7771,8 @@ DEFUN (no_ip_pim_ecmp,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_VRF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ecmp_xpath, "/ecmp", sizeof(ecmp_xpath));
 
 	nb_cli_enqueue_change(vty, ecmp_xpath, NB_OP_MODIFY, "false");
@@ -7757,12 +7796,12 @@ DEFUN (ip_pim_ecmp_rebalance,
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_VRF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ecmp_xpath, "/ecmp", sizeof(ecmp_xpath));
 	snprintf(ecmp_rebalance_xpath, sizeof(ecmp_rebalance_xpath),
-		 FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+		 FRR_PIM_VRF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ecmp_rebalance_xpath, "/ecmp-rebalance",
 		sizeof(ecmp_rebalance_xpath));
 
@@ -7789,8 +7828,8 @@ DEFUN (no_ip_pim_ecmp_rebalance,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(ecmp_rebalance_xpath, sizeof(ecmp_rebalance_xpath),
-		 FRR_PIM_XPATH,
-		 "frr-pim:pimd", "pim", vrfname);
+		 FRR_PIM_VRF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	strlcat(ecmp_rebalance_xpath, "/ecmp-rebalance",
 		sizeof(ecmp_rebalance_xpath));
 
@@ -7821,10 +7860,12 @@ DEFUN (interface_no_ip_igmp,
 	char pim_if_xpath[XPATH_MAXLEN + 20];
 
 	snprintf(pim_if_xpath, sizeof(pim_if_xpath),
-		 "%s/frr-pim:pim", VTY_CURR_XPATH);
+		 "%s/frr-pim:pim/address-family[address-family='%s']",
+		 VTY_CURR_XPATH, "frr-routing:ipv4");
 
 	pim_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
-					   "%s/pim-enable", pim_if_xpath);
+					   FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
+					   "frr-routing:ipv4");
 	if (!pim_enable_dnode) {
 		nb_cli_enqueue_change(vty, pim_if_xpath, NB_OP_DESTROY, NULL);
 		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
@@ -7920,9 +7961,10 @@ DEFUN (interface_ip_igmp_query_interval,
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-pim:pim/pim-enable", VTY_CURR_XPATH);
+				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
@@ -7991,7 +8033,8 @@ DEFUN (interface_ip_igmp_query_max_response_time,
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-pim:pim/pim-enable", VTY_CURR_XPATH);
+				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 
 	if (!pim_enable_dnode) {
 		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
@@ -8034,7 +8077,8 @@ DEFUN_HIDDEN (interface_ip_igmp_query_max_response_time_dsec,
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-pim:pim/pim-enable", VTY_CURR_XPATH);
+				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 	if (!pim_enable_dnode) {
 		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
 				      "true");
@@ -8077,7 +8121,8 @@ DEFUN (interface_ip_igmp_last_member_query_count,
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-pim:pim/pim-enable", VTY_CURR_XPATH);
+				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 	if (!pim_enable_dnode) {
 		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
 				      "true");
@@ -8120,7 +8165,8 @@ DEFUN (interface_ip_igmp_last_member_query_interval,
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-pim:pim/pim-enable", VTY_CURR_XPATH);
+				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 	if (!pim_enable_dnode) {
 		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
 				      "true");
@@ -8164,7 +8210,8 @@ DEFUN (interface_ip_pim_drprio,
 	nb_cli_enqueue_change(vty, "./dr-priority", NB_OP_MODIFY,
 			      argv[idx_number]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_pim_drprio,
@@ -8178,7 +8225,8 @@ DEFUN (interface_no_ip_pim_drprio,
 {
 	nb_cli_enqueue_change(vty, "./dr-priority", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				   "frr-routing:ipv4");
 }
 
 DEFPY_HIDDEN (interface_ip_igmp_query_generate,
@@ -8276,7 +8324,9 @@ DEFPY (interface_ip_pim_activeactive,
 				      "true");
 	}
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH,
+			"frr-routing:ipv4");
 }
 
 DEFUN_HIDDEN (interface_ip_pim_ssm,
@@ -8290,7 +8340,9 @@ DEFUN_HIDDEN (interface_ip_pim_ssm,
 
 	nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY, "true");
 
-	ret = nb_cli_apply_changes(vty, "./frr-pim:pim");
+	ret = nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH,
+			"frr-routing:ipv4");
 
 	if (ret != NB_OK)
 		return ret;
@@ -8310,7 +8362,9 @@ DEFUN_HIDDEN (interface_ip_pim_sm,
 {
 	nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH,
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_pim,
@@ -8321,7 +8375,10 @@ DEFUN (interface_ip_pim,
 {
 	nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH,
+			"frr-routing:ipv4");
+
 }
 
 DEFUN_HIDDEN (interface_no_ip_pim_ssm,
@@ -8353,7 +8410,8 @@ DEFUN_HIDDEN (interface_no_ip_pim_ssm,
 					      "false");
 	}
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN_HIDDEN (interface_no_ip_pim_sm,
@@ -8385,7 +8443,9 @@ DEFUN_HIDDEN (interface_no_ip_pim_sm,
 					      "false");
 	}
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH,
+			"frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_pim,
@@ -8416,7 +8476,9 @@ DEFUN (interface_no_ip_pim,
 					      "false");
 	}
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+				    FRR_PIM_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 /* boundaries */
@@ -8433,7 +8495,7 @@ DEFUN(interface_ip_pim_boundary_oil,
 			      argv[4]->arg);
 
 	return nb_cli_apply_changes(vty,
-				    "./frr-pim:pim/address-family[address-family='%s']",
+				    FRR_PIM_INTERFACE_XPATH,
 				    "frr-routing:ipv4");
 
 }
@@ -8452,7 +8514,7 @@ DEFUN(interface_no_ip_pim_boundary_oil,
 			      NULL);
 
 	return nb_cli_apply_changes(vty,
-				    "./frr-pim:pim/address-family[address-family='%s']",
+				    FRR_PIM_INTERFACE_XPATH,
 				    "frr-routing:ipv4");
 }
 
@@ -8478,7 +8540,7 @@ DEFUN (interface_ip_mroute,
 			      argv[idx_interface]->arg);
 
 	return nb_cli_apply_changes(vty,
-				    "./frr-pim:pim/address-family[address-family='%s']/mroute[source-addr='%s'][group-addr='%s']",
+				    FRR_PIM_MROUTE_XPATH,
 				    "frr-routing:ipv4", source_str,
 				    argv[idx_ipv4]->arg);
 }
@@ -8504,7 +8566,7 @@ DEFUN (interface_no_ip_mroute,
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty,
-				    "./frr-pim:pim/address-family[address-family='%s']/mroute[source-addr='%s'][group-addr='%s']",
+				    FRR_PIM_MROUTE_XPATH,
 				    "frr-routing:ipv4", source_str,
 				    argv[idx_ipv4]->arg);
 }
@@ -8541,7 +8603,9 @@ DEFUN (interface_ip_pim_hello,
 		nb_cli_enqueue_change(vty, "./hello-holdtime", NB_OP_MODIFY,
 				      argv[idx_hold]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+				    FRR_PIM_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_pim_hello,
@@ -8557,7 +8621,9 @@ DEFUN (interface_no_ip_pim_hello,
 	nb_cli_enqueue_change(vty, "./hello-interval", NB_OP_DESTROY, NULL);
 	nb_cli_enqueue_change(vty, "./hello-holdtime", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+				    FRR_PIM_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (debug_igmp,
@@ -9205,7 +9271,7 @@ DEFUN (interface_pim_use_source,
 	nb_cli_enqueue_change(vty, "./use-source", NB_OP_MODIFY, argv[3]->arg);
 
 	return nb_cli_apply_changes(vty,
-				    "./frr-pim:pim/address-family[address-family='%s']",
+				    FRR_PIM_INTERFACE_XPATH,
 				    "frr-routing:ipv4");
 }
 
@@ -9221,7 +9287,7 @@ DEFUN (interface_no_pim_use_source,
 	nb_cli_enqueue_change(vty, "./use-source", NB_OP_MODIFY, "0.0.0.0");
 
 	return nb_cli_apply_changes(vty,
-				    "./frr-pim:pim/address-family[address-family='%s']",
+				    FRR_PIM_INTERFACE_XPATH,
 				    "frr-routing:ipv4");
 }
 
@@ -9252,7 +9318,9 @@ DEFPY (ip_pim_bfd,
 	if (prof)
 		nb_cli_enqueue_change(vty, "./bfd/profile", NB_OP_MODIFY, prof);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+				    FRR_PIM_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFPY(no_ip_pim_bfd_profile, no_ip_pim_bfd_profile_cmd,
@@ -9266,7 +9334,9 @@ DEFPY(no_ip_pim_bfd_profile, no_ip_pim_bfd_profile_cmd,
 {
 	nb_cli_enqueue_change(vty, "./bfd/profile", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH,
+			"frr-routing:ipv4");
 }
 
 DEFUN (no_ip_pim_bfd,
@@ -9279,7 +9349,9 @@ DEFUN (no_ip_pim_bfd,
 {
 	nb_cli_enqueue_change(vty, "./bfd", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH,
+			"frr-routing:ipv4");
 }
 
 DEFUN (ip_pim_bsm,
@@ -9305,7 +9377,8 @@ DEFUN (ip_pim_bsm,
 
 	nb_cli_enqueue_change(vty, "./bsm", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH, "frr-routing:ipv4");
 }
 
 DEFUN (no_ip_pim_bsm,
@@ -9318,7 +9391,8 @@ DEFUN (no_ip_pim_bsm,
 {
 	nb_cli_enqueue_change(vty, "./bsm", NB_OP_MODIFY, "false");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH, "frr-routing:ipv4");
 }
 
 DEFUN (ip_pim_ucast_bsm,
@@ -9344,7 +9418,9 @@ DEFUN (ip_pim_ucast_bsm,
 
 	nb_cli_enqueue_change(vty, "./unicast-bsm", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH, "frr-routing:ipv4");
+
 }
 
 DEFUN (no_ip_pim_ucast_bsm,
@@ -9357,7 +9433,8 @@ DEFUN (no_ip_pim_ucast_bsm,
 {
 	nb_cli_enqueue_change(vty, "./unicast-bsm", NB_OP_MODIFY, "false");
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH, "frr-routing:ipv4");
 }
 
 #if HAVE_BFDD > 0
@@ -9409,7 +9486,8 @@ DEFUN_HIDDEN (
 	nb_cli_enqueue_change(vty, "./bfd/detect_mult", NB_OP_MODIFY,
 			      argv[idx_number]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-pim:pim");
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH, "frr-routing:ipv4");
 }
 
 #if HAVE_BFDD == 0
@@ -9442,7 +9520,7 @@ DEFPY(ip_msdp_peer, ip_msdp_peer_cmd,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(msdp_peer_source_xpath, sizeof(msdp_peer_source_xpath),
-		 FRR_PIM_AF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
 		 "frr-routing:ipv4");
 	snprintf(temp_xpath, sizeof(temp_xpath),
 		 "/msdp-peer[peer-ip='%s']/source-ip", peer_str);
@@ -9452,7 +9530,8 @@ DEFPY(ip_msdp_peer, ip_msdp_peer_cmd,
 	nb_cli_enqueue_change(vty, msdp_peer_source_xpath, NB_OP_MODIFY,
 			      source_str);
 
-	return nb_cli_apply_changes(vty, NULL);
+	return nb_cli_apply_changes(vty,
+			FRR_PIM_INTERFACE_XPATH, "frr-routing:ipv4");
 }
 
 DEFPY(ip_msdp_timers, ip_msdp_timers_cmd,
@@ -9534,7 +9613,7 @@ DEFUN (no_ip_msdp_peer,
 		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(msdp_peer_xpath, sizeof(msdp_peer_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
 	snprintf(temp_xpath, sizeof(temp_xpath),
 		 "/msdp-peer[peer-ip='%s']",
@@ -9566,7 +9645,7 @@ DEFPY(ip_msdp_mesh_group_member,
 
 	/* Create mesh group. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_AF_XPATH "/msdp-mesh-groups[name='%s']",
+		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
 
@@ -9600,7 +9679,7 @@ DEFPY(no_ip_msdp_mesh_group_member,
 
 	/* Get mesh group base XPath. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_AF_XPATH "/msdp-mesh-groups[name='%s']",
+		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
 
 	if (!yang_dnode_exists(vty->candidate_config->dnode, xpath_value)) {
@@ -9650,7 +9729,7 @@ DEFPY(ip_msdp_mesh_group_source,
 
 	/* Create mesh group. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_AF_XPATH "/msdp-mesh-groups[name='%s']",
+		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
 
@@ -9681,7 +9760,7 @@ DEFPY(no_ip_msdp_mesh_group_source,
 
 	/* Get mesh group base XPath. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_AF_XPATH "/msdp-mesh-groups[name='%s']",
+		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
 
@@ -9716,7 +9795,7 @@ DEFPY(no_ip_msdp_mesh_group,
 
 	/* Get mesh group base XPath. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_AF_XPATH "/msdp-mesh-groups[name='%s']",
+		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
 		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
 	if (!yang_dnode_exists(vty->candidate_config->dnode, xpath_value))
 		return CMD_SUCCESS;
@@ -10756,7 +10835,7 @@ DEFUN_HIDDEN (no_ip_pim_mlag,
 {
 	char mlag_xpath[XPATH_MAXLEN];
 
-	snprintf(mlag_xpath, sizeof(mlag_xpath), FRR_PIM_AF_XPATH,
+	snprintf(mlag_xpath, sizeof(mlag_xpath), FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", "default", "frr-routing:ipv4");
 	strlcat(mlag_xpath, "/mlag", sizeof(mlag_xpath));
 
@@ -10789,7 +10868,7 @@ DEFUN_HIDDEN (ip_pim_mlag,
 	char mlag_reg_address_xpath[XPATH_MAXLEN];
 
 	snprintf(mlag_peerlink_rif_xpath, sizeof(mlag_peerlink_rif_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", "default", "frr-routing:ipv4");
 	strlcat(mlag_peerlink_rif_xpath, "/mlag/peerlink-rif",
 		sizeof(mlag_peerlink_rif_xpath));
@@ -10799,7 +10878,7 @@ DEFUN_HIDDEN (ip_pim_mlag,
 			      argv[idx]->arg);
 
 	snprintf(mlag_my_role_xpath, sizeof(mlag_my_role_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", "default", "frr-routing:ipv4");
 	strlcat(mlag_my_role_xpath, "/mlag/my-role",
 		sizeof(mlag_my_role_xpath));
@@ -10819,7 +10898,7 @@ DEFUN_HIDDEN (ip_pim_mlag,
 	}
 
 	snprintf(mlag_peer_state_xpath, sizeof(mlag_peer_state_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", "default", "frr-routing:ipv4");
 	strlcat(mlag_peer_state_xpath, "/mlag/peer-state",
 		sizeof(mlag_peer_state_xpath));
@@ -10839,7 +10918,7 @@ DEFUN_HIDDEN (ip_pim_mlag,
 	}
 
 	snprintf(mlag_reg_address_xpath, sizeof(mlag_reg_address_xpath),
-		 FRR_PIM_AF_XPATH,
+		 FRR_PIM_VRF_XPATH,
 		 "frr-pim:pimd", "pim", "default", "frr-routing:ipv4");
 	strlcat(mlag_reg_address_xpath, "/mlag/reg-address",
 		sizeof(mlag_reg_address_xpath));

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -29,52 +29,59 @@ const struct frr_yang_module_info frr_pim_info = {
 	.name = "frr-pim",
 	.nodes = {
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/ecmp",
-			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_pim_ecmp_modify,
-			}
-		},
-		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/ecmp-rebalance",
-			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_pim_ecmp_rebalance_modify,
-			}
-		},
-		{
-			.xpath = "/frr-pim:pim/join-prune-interval",
-			.cbs = {
-				.modify = pim_join_prune_interval_modify,
-			}
-		},
-		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/keep-alive-timer",
-			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_pim_keep_alive_timer_modify,
-			}
-		},
-		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/rp-keep-alive-timer",
-			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_pim_rp_keep_alive_timer_modify,
-			}
-		},
-		{
-			.xpath = "/frr-pim:pim/packets",
-			.cbs = {
-				.modify = pim_packets_modify,
-			}
-		},
-		{
-			.xpath = "/frr-pim:pim/register-suppress-time",
-			.cbs = {
-				.modify = pim_register_suppress_time_modify,
-			}
-		},
-		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family",
 			.cbs = {
 				.create = routing_control_plane_protocols_control_plane_protocol_pim_address_family_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_pim_address_family_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/ecmp",
+			.cbs = {
+				.modify = routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_modify,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/ecmp-rebalance",
+			.cbs = {
+				.modify = routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_rebalance_modify,
+			}
+		},
+		{
+			.xpath = "/frr-pim:pim/address-family/join-prune-interval",
+			.cbs = {
+				.modify = pim_address_family_join_prune_interval_modify,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/keep-alive-timer",
+			.cbs = {
+				.modify = routing_control_plane_protocols_control_plane_protocol_pim_address_family_keep_alive_timer_modify,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/rp-keep-alive-timer",
+			.cbs = {
+				.modify = routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_keep_alive_timer_modify,
+			}
+		},
+		{
+			.xpath = "/frr-pim:pim/address-family",
+			.cbs = {
+				.create = pim_address_family_create,
+				.destroy = pim_address_family_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-pim:pim/address-family/packets",
+			.cbs = {
+				.modify = pim_address_family_packets_modify,
+			}
+		},
+		{
+			.xpath = "/frr-pim:pim/address-family/register-suppress-time",
+			.cbs = {
+				.modify = pim_address_family_register_suppress_time_modify,
 			}
 		},
 		{
@@ -211,93 +218,86 @@ const struct frr_yang_module_info frr_pim_info = {
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim",
-			.cbs = {
-				.create = lib_interface_pim_create,
-				.destroy = lib_interface_pim_destroy,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/pim-enable",
-			.cbs = {
-				.modify = lib_interface_pim_pim_enable_modify,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/dr-priority",
-			.cbs = {
-				.modify = lib_interface_pim_dr_priority_modify,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/hello-interval",
-			.cbs = {
-				.modify = lib_interface_pim_hello_interval_modify,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/hello-holdtime",
-			.cbs = {
-				.modify = lib_interface_pim_hello_holdtime_modify,
-				.destroy = lib_interface_pim_hello_holdtime_destroy,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bfd",
-			.cbs = {
-				.create = lib_interface_pim_bfd_create,
-				.destroy = lib_interface_pim_bfd_destroy,
-				.apply_finish = lib_interface_pim_bfd_apply_finish,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bfd/min-rx-interval",
-			.cbs = {
-				.modify = lib_interface_pim_bfd_min_rx_interval_modify,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bfd/min-tx-interval",
-			.cbs = {
-				.modify = lib_interface_pim_bfd_min_tx_interval_modify,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bfd/detect_mult",
-			.cbs = {
-				.modify = lib_interface_pim_bfd_detect_mult_modify,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bfd/profile",
-			.cbs = {
-				.modify = lib_interface_pim_bfd_profile_modify,
-				.destroy = lib_interface_pim_bfd_profile_destroy,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/bsm",
-			.cbs = {
-				.modify = lib_interface_pim_bsm_modify,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/unicast-bsm",
-			.cbs = {
-				.modify = lib_interface_pim_unicast_bsm_modify,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-pim:pim/active-active",
-			.cbs = {
-				.modify = lib_interface_pim_active_active_modify,
-			}
-		},
-		{
 			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family",
 			.cbs = {
 				.create = lib_interface_pim_address_family_create,
 				.destroy = lib_interface_pim_address_family_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/pim-enable",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_pim_enable_modify,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/dr-priority",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_dr_priority_modify,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/hello-interval",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_hello_interval_modify,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/hello-holdtime",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_hello_holdtime_modify,
+				.destroy = lib_interface_pim_address_family_hello_holdtime_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd",
+			.cbs = {
+				.create = lib_interface_pim_address_family_bfd_create,
+				.destroy = lib_interface_pim_address_family_bfd_destroy,
+				.apply_finish = lib_interface_pim_address_family_bfd_apply_finish,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd/min-rx-interval",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_bfd_min_rx_interval_modify,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd/min-tx-interval",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_bfd_min_tx_interval_modify,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd/detect_mult",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_bfd_detect_mult_modify,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd/profile",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_bfd_profile_modify,
+				.destroy = lib_interface_pim_address_family_bfd_profile_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bsm",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_bsm_modify,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/unicast-bsm",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_unicast_bsm_modify,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/active-active",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_active_active_modify,
 			}
 		},
 		{

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -25,17 +25,20 @@ extern const struct frr_yang_module_info frr_pim_rp_info;
 extern const struct frr_yang_module_info frr_igmp_info;
 
 /* frr-pim prototypes*/
-int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_modify(
 	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_rebalance_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_rebalance_modify(
 	struct nb_cb_modify_args *args);
-int pim_join_prune_interval_modify(struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_pim_keep_alive_timer_modify(
+int pim_address_family_join_prune_interval_modify(struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_keep_alive_timer_modify(
 	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_pim_rp_keep_alive_timer_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_keep_alive_timer_modify(
 	struct nb_cb_modify_args *args);
-int pim_packets_modify(struct nb_cb_modify_args *args);
-int pim_register_suppress_time_modify(struct nb_cb_modify_args *args);
+int pim_address_family_create(struct nb_cb_create_args *args);
+int pim_address_family_destroy(struct nb_cb_destroy_args *args);
+int pim_address_family_packets_modify(struct nb_cb_modify_args *args);
+int pim_address_family_register_suppress_time_modify(
+	struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_create(
 	struct nb_cb_create_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_destroy(
@@ -97,28 +100,38 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_re
 	struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_register_accept_list_destroy(
 	struct nb_cb_destroy_args *args);
-int lib_interface_pim_dr_priority_modify(
+int lib_interface_pim_address_family_dr_priority_modify(
 	struct nb_cb_modify_args *args);
-int lib_interface_pim_create(struct nb_cb_create_args *args);
-int lib_interface_pim_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_pim_pim_enable_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_hello_interval_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_hello_holdtime_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_hello_holdtime_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_pim_bfd_create(struct nb_cb_create_args *args);
-int lib_interface_pim_bfd_destroy(struct nb_cb_destroy_args *args);
-void lib_interface_pim_bfd_apply_finish(struct nb_cb_apply_finish_args *args);
-int lib_interface_pim_bfd_min_rx_interval_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_bfd_min_tx_interval_modify(
-	struct nb_cb_modify_args *args);
-int lib_interface_pim_bfd_detect_mult_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_bfd_profile_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_bfd_profile_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_pim_bsm_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_unicast_bsm_modify(struct nb_cb_modify_args *args);
-int lib_interface_pim_active_active_modify(struct nb_cb_modify_args *args);
 int lib_interface_pim_address_family_create(struct nb_cb_create_args *args);
 int lib_interface_pim_address_family_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_pim_address_family_pim_enable_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_hello_interval_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_hello_holdtime_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_hello_holdtime_destroy(
+	struct nb_cb_destroy_args *args);
+int lib_interface_pim_address_family_bfd_create(struct nb_cb_create_args *args);
+int lib_interface_pim_address_family_bfd_destroy(
+	struct nb_cb_destroy_args *args);
+void lib_interface_pim_address_family_bfd_apply_finish(
+	struct nb_cb_apply_finish_args *args);
+int lib_interface_pim_address_family_bfd_min_rx_interval_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_bfd_min_tx_interval_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_bfd_detect_mult_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_bfd_profile_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_bfd_profile_destroy(
+	struct nb_cb_destroy_args *args);
+int lib_interface_pim_address_family_bsm_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_unicast_bsm_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_active_active_modify(
+	struct nb_cb_modify_args *args);
 int lib_interface_pim_address_family_use_source_modify(
 	struct nb_cb_modify_args *args);
 int lib_interface_pim_address_family_use_source_destroy(
@@ -177,14 +190,19 @@ int lib_interface_igmp_address_family_static_group_destroy(
 int routing_control_plane_protocols_name_validate(
 	struct nb_cb_create_args *args);
 
-#define FRR_PIM_XPATH                                                   \
-	"/frr-routing:routing/control-plane-protocols/"                 \
-	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"       \
-	"frr-pim:pim"
-#define FRR_PIM_AF_XPATH                                                \
+#define FRR_PIM_VRF_XPATH                                               \
 	"/frr-routing:routing/control-plane-protocols/"                 \
 	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"       \
 	"frr-pim:pim/address-family[address-family='%s']"
+#define FRR_PIM_INTERFACE_XPATH                                         \
+	"./frr-pim:pim/address-family[address-family='%s']"
+#define FRR_PIM_ENABLE_XPATH                                            \
+	"%s/frr-pim:pim/address-family[address-family='%s']/pim-enable"
+#define FRR_PIM_ROUTER_XPATH                                            \
+	"/frr-pim:pim/address-family[address-family='%s']"
+#define FRR_PIM_MROUTE_XPATH                                            \
+	"./frr-pim:pim/address-family[address-family='%s']/"            \
+	"mroute[source-addr='%s'][group-addr='%s']"
 #define FRR_PIM_STATIC_RP_XPATH                                         \
 	"/frr-routing:routing/control-plane-protocols/"                 \
 	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"       \
@@ -193,6 +211,6 @@ int routing_control_plane_protocols_name_validate(
 #define FRR_IGMP_JOIN_XPATH                                             \
 	"./frr-igmp:igmp/address-family[address-family='%s']/"          \
 	"static-group[group-addr='%s'][source-addr='%s']"
-#define FRR_PIM_MSDP_XPATH FRR_PIM_AF_XPATH "/msdp"
+#define FRR_PIM_MSDP_XPATH FRR_PIM_VRF_XPATH "/msdp"
 
 #endif /* _FRR_PIM_NB_H_ */

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -318,7 +318,9 @@ static bool is_pim_interface(const struct lyd_node *dnode)
 
 	yang_dnode_get_path(dnode, if_xpath, sizeof(if_xpath));
 	pim_enable_dnode =
-		yang_dnode_getf(dnode, "%s/frr-pim:pim/pim-enable", if_xpath);
+		yang_dnode_getf(dnode,
+				"%s/frr-pim:pim/address-family[address-family='%s']/pim-enable",
+				if_xpath, "frr-routing:ipv4");
 	igmp_enable_dnode = yang_dnode_getf(
 		dnode, "%s/frr-igmp:igmp/igmp-enable", if_xpath);
 
@@ -502,9 +504,38 @@ int routing_control_plane_protocols_name_validate(
 }
 
 /*
- * XPath: /frr-pim:pim/packets
+ * XPath: /frr-pim:pim/address-family
  */
-int pim_packets_modify(struct nb_cb_modify_args *args)
+int pim_address_family_create(struct nb_cb_create_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		break;
+	}
+
+	return NB_OK;
+}
+
+int pim_address_family_destroy(struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-pim:pim/address-family/packets
+ */
+int pim_address_family_packets_modify(struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -521,9 +552,10 @@ int pim_packets_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-pim:pim/join-prune-interval
+ * XPath: /frr-pim:pim/address-family/join-prune-interval
  */
-int pim_join_prune_interval_modify(struct nb_cb_modify_args *args)
+int pim_address_family_join_prune_interval_modify(
+	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -539,9 +571,10 @@ int pim_join_prune_interval_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-pim:pim/register-suppress-time
+ * XPath: /frr-pim:pim/address-family/register-suppress-time
  */
-int pim_register_suppress_time_modify(struct nb_cb_modify_args *args)
+int pim_address_family_register_suppress_time_modify(
+	struct nb_cb_modify_args *args)
 {
 	uint16_t value;
 	switch (args->event) {
@@ -577,9 +610,9 @@ int pim_register_suppress_time_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/ecmp
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/ecmp
  */
-int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
@@ -600,9 +633,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_modify(
 }
 
 /*
- * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/ecmp-rebalance
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/ecmp-rebalance
  */
-int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_rebalance_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_rebalance_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
@@ -624,9 +657,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_ecmp_rebalance_mo
 }
 
 /*
- * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/keep-alive-timer
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/keep-alive-timer
  */
-int routing_control_plane_protocols_control_plane_protocol_pim_keep_alive_timer_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_keep_alive_timer_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
@@ -648,9 +681,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_keep_alive_timer_
 }
 
 /*
- * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/rp-keep-alive-timer
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/rp-keep-alive-timer
  */
-int routing_control_plane_protocols_control_plane_protocol_pim_rp_keep_alive_timer_modify(
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_keep_alive_timer_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
@@ -697,7 +730,6 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_de
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 	case NB_EV_APPLY:
-		/* TODO: implement me. */
 		break;
 	}
 
@@ -1468,9 +1500,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_re
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family
  */
-int lib_interface_pim_create(struct nb_cb_create_args *args)
+int lib_interface_pim_address_family_create(struct nb_cb_create_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -1483,7 +1515,7 @@ int lib_interface_pim_create(struct nb_cb_create_args *args)
 	return NB_OK;
 }
 
-int lib_interface_pim_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_pim_address_family_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1511,9 +1543,9 @@ int lib_interface_pim_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/pim-enable
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/pim-enable
  */
-int lib_interface_pim_pim_enable_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_pim_enable_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1565,9 +1597,10 @@ int lib_interface_pim_pim_enable_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/hello-interval
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/hello-interval
  */
-int lib_interface_pim_hello_interval_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_hello_interval_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1590,9 +1623,10 @@ int lib_interface_pim_hello_interval_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/hello-holdtime
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/hello-holdtime
  */
-int lib_interface_pim_hello_holdtime_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_hello_holdtime_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1614,7 +1648,8 @@ int lib_interface_pim_hello_holdtime_modify(struct nb_cb_modify_args *args)
 
 }
 
-int lib_interface_pim_hello_holdtime_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_pim_address_family_hello_holdtime_destroy(
+	struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1634,9 +1669,9 @@ int lib_interface_pim_hello_holdtime_destroy(struct nb_cb_destroy_args *args)
 	return NB_OK;
 }
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd
  */
-int lib_interface_pim_bfd_create(struct nb_cb_create_args *args)
+int lib_interface_pim_address_family_bfd_create(struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1657,7 +1692,8 @@ int lib_interface_pim_bfd_create(struct nb_cb_create_args *args)
 	return NB_OK;
 }
 
-int lib_interface_pim_bfd_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_pim_address_family_bfd_destroy(
+	struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1687,9 +1723,10 @@ int lib_interface_pim_bfd_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd
  */
-void lib_interface_pim_bfd_apply_finish(struct nb_cb_apply_finish_args *args)
+void lib_interface_pim_address_family_bfd_apply_finish(
+	struct nb_cb_apply_finish_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1713,9 +1750,10 @@ void lib_interface_pim_bfd_apply_finish(struct nb_cb_apply_finish_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd/min-rx-interval
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd/min-rx-interval
  */
-int lib_interface_pim_bfd_min_rx_interval_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_bfd_min_rx_interval_modify(
+	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -1729,9 +1767,10 @@ int lib_interface_pim_bfd_min_rx_interval_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd/min-tx-interval
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd/min-tx-interval
  */
-int lib_interface_pim_bfd_min_tx_interval_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_bfd_min_tx_interval_modify(
+	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -1745,9 +1784,10 @@ int lib_interface_pim_bfd_min_tx_interval_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd/detect_mult
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd/detect_mult
  */
-int lib_interface_pim_bfd_detect_mult_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_bfd_detect_mult_modify(
+	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -1761,9 +1801,10 @@ int lib_interface_pim_bfd_detect_mult_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bfd/profile
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd/profile
  */
-int lib_interface_pim_bfd_profile_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_bfd_profile_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1786,7 +1827,8 @@ int lib_interface_pim_bfd_profile_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-int lib_interface_pim_bfd_profile_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_pim_address_family_bfd_profile_destroy(
+	struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1808,9 +1850,9 @@ int lib_interface_pim_bfd_profile_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/bsm
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bsm
  */
-int lib_interface_pim_bsm_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_bsm_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1832,9 +1874,10 @@ int lib_interface_pim_bsm_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/unicast-bsm
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/unicast-bsm
  */
-int lib_interface_pim_unicast_bsm_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_unicast_bsm_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1857,9 +1900,10 @@ int lib_interface_pim_unicast_bsm_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/active-active
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/active-active
  */
-int lib_interface_pim_active_active_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_active_active_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1894,9 +1938,10 @@ int lib_interface_pim_active_active_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/dr-priority
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/dr-priority
  */
-int lib_interface_pim_dr_priority_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_dr_priority_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -1908,7 +1953,7 @@ int lib_interface_pim_dr_priority_modify(struct nb_cb_modify_args *args)
 		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
 		if (!is_pim_interface(if_dnode)) {
 			snprintf(args->errmsg, args->errmsg_len,
-					"Pim not enabled on this interface");
+				 "Pim not enabled on this interface");
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -1933,38 +1978,10 @@ int lib_interface_pim_dr_priority_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family
- */
-int lib_interface_pim_address_family_create(struct nb_cb_create_args *args)
-{
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		break;
-	}
-
-	return NB_OK;
-}
-
-int lib_interface_pim_address_family_destroy(struct nb_cb_destroy_args *args)
-{
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		break;
-	}
-
-	return NB_OK;
-}
-
-/*
  * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/use-source
  */
-int lib_interface_pim_address_family_use_source_modify(struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_use_source_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct ipaddr source_addr;
@@ -2013,7 +2030,7 @@ int lib_interface_pim_address_family_use_source_destroy(
 		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
 		if (!is_pim_interface(if_dnode)) {
 			snprintf(args->errmsg, args->errmsg_len,
-					"Pim not enabled on this interface");
+				 "Pim not enabled on this interface");
 			return NB_ERR_VALIDATION;
 		}
 		break;

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -56,7 +56,7 @@ module frr-pim {
      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
-  revision 2017-03-09 {
+  revision 2021-11-22 {
     description
       "Initial revision.";
     reference
@@ -76,43 +76,6 @@ module frr-pim {
   /*
    * Groupings
    */
-
-  grouping global-pim-config-attributes {
-    description
-      "A grouping defining pim global attributes.";
-
-    leaf ecmp {
-      type boolean;
-      default "false";
-      description
-        "Enable PIM ECMP.";
-    }
-
-    leaf ecmp-rebalance {
-      type boolean;
-      default "false";
-      description
-        "Enable PIM ECMP Rebalance.";
-    }
-
-    leaf keep-alive-timer {
-      type uint16 {
-        range "1..max";
-      }
-      default "210";
-      description
-        "Keep alive Timer in seconds.";
-    }
-
-    leaf rp-keep-alive-timer {
-      type uint16 {
-        range "1..max";
-      }
-      default "210";
-      description
-        "RP keep alive Timer in seconds.";
-    }
-  }
 
   grouping msdp-timers {
     leaf hold-time {
@@ -154,9 +117,41 @@ module frr-pim {
     }
   }
 
-  grouping per-af-global-pim-config-attributes {
+  grouping global-pim-config-attributes {
     description
       "A grouping defining per address family pim global attributes";
+
+    leaf ecmp {
+      type boolean;
+      default "false";
+      description
+        "Enable PIM ECMP.";
+    }
+    
+    leaf ecmp-rebalance {
+      type boolean;
+      default "false";
+      description
+        "Enable PIM ECMP Rebalance.";
+    }
+    
+    leaf keep-alive-timer {
+      type uint16 {
+        range "1..max";
+      }
+      default "210";
+      description
+        "Keep alive Timer in seconds.";
+    }
+    
+    leaf rp-keep-alive-timer {
+      type uint16 {
+        range "1..max";
+      }
+      default "210";
+      description
+        "RP keep alive Timer in seconds.";
+    }
 
     leaf send-v6-secondary {
       when "../frr-pim:address-family = 'frr-rt:ipv4'" {
@@ -326,11 +321,11 @@ module frr-pim {
         description
           "Only accept registers from a specific source prefix list.";
     }
-  } // per-af-global-pim-config-attributes
+  } // global-pim-config-attributes
 
   grouping interface-pim-config-attributes {
     description
-      "A grouping defining pim interface attributes.";
+      "A grouping defining pim interface attributes per address family.";
 
     leaf pim-enable {
       type boolean;
@@ -426,11 +421,6 @@ module frr-pim {
       description
         "DR (Designated Router) priority";
     }
-  } // interface-pim-config-attributes
-
-  grouping per-af-interface-pim-config-attributes {
-    description
-      "A grouping defining pim interface attributes per address family.";
 
     leaf use-source {
       type inet:ip-address;
@@ -467,56 +457,11 @@ module frr-pim {
           "Multicast group address.";
       }
     }
-  } // per-af-interface-pim-config-attributes
+  } // interface-pim-config-attributes
 
-  /*
-   * Global Configuration data nodes
-   */
-  augment "/frr-rt:routing/frr-rt:control-plane-protocols/"
-        + "frr-rt:control-plane-protocol" {
-    container pim {
-      when "../frr-rt:type = 'frr-pim:pimd'" {
-        description
-          "This container is only valid for the 'pim' routing
-           protocol.";
-      }
-      description
-        "PIM configuration data.";
-
-      uses global-pim-config-attributes;
-
-      list address-family {
-        key "address-family";
-        description
-          "Each list entry for one address family.";
-        uses frr-rt:address-family;
-        uses per-af-global-pim-config-attributes;
-
-      } //address-family
-    } // pim
-  } // augment
-
-  /*
-   * Per-interface configuration data
-   */
-  augment "/frr-interface:lib/frr-interface:interface" {
-    container pim {
-      presence
-        "Configure PIM on an interface.";
-      uses interface-pim-config-attributes;
-      list address-family {
-        key "address-family";
-        description
-          "Each list entry for one address family.";
-        uses frr-rt:address-family;
-        uses per-af-interface-pim-config-attributes;
-      }
-    }
-  }
-
-  container pim {
+  grouping router-pim-config-attributes {
     description
-      "PIM router parameters.";
+      "A grouping defining pim router attributes per address family.";
     leaf packets {
       type uint8 {
         range "1..max";
@@ -540,6 +485,60 @@ module frr-pim {
       default "60";
       description
         "Register Suppress Timer.";
+    }
+  }
+
+  /*
+   * Global Configuration data nodes
+   */
+  augment "/frr-rt:routing/frr-rt:control-plane-protocols/"
+        + "frr-rt:control-plane-protocol" {
+    container pim {
+      when "../frr-rt:type = 'frr-pim:pimd'" {
+        description
+          "This container is only valid for the 'pim' routing
+           protocol.";
+      }
+      description
+        "PIM configuration data.";
+      list address-family {
+        key "address-family";
+        description
+          "Each list entry for one address family.";
+        uses frr-rt:address-family;
+        uses global-pim-config-attributes;
+
+      } //address-family
+    } // pim
+  } // augment
+
+  /*
+   * Per-interface configuration data
+   */
+  augment "/frr-interface:lib/frr-interface:interface" {
+    container pim {
+      list address-family {
+        key "address-family";
+        description
+          "Each list entry for one address family.";
+        uses frr-rt:address-family;
+        uses interface-pim-config-attributes;
+      }
+    }
+  }
+
+  /*
+   * Router configuration data
+   */
+  container pim {
+    description
+      "PIM router parameters.";
+    list address-family {
+      key "address-family";
+      description
+        "Each list entry for one address family.";
+      uses frr-rt:address-family;
+      uses router-pim-config-attributes;
     }
   }
 }


### PR DESCRIPTION
frr-pim.yang, created a list of address family under pim
container. For PIMV4 the key is IPV4, where as for PIMV6
the key is IPV6. This is done for PIMV6 development.

This commit will have all the northbound changes to support
IPV4 address family.

Reviewed-by: Mobashshera Rasool mrasool@vmware.com
Signed-off-by: sarita patra <saritap@vmware.com>