### PR TITLE
tools: clang-format break after operators

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,7 @@ AllowAllParametersOfDeclarationOnNextLine: false
 AlignAfterOpenBracket: true
 SpaceAfterCStyleCast: false
 MaxEmptyLinesToKeep: 2
-BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBinaryOperators: None
 BreakStringLiterals: false
 SortIncludes:    false
 IncludeCategories:


### PR DESCRIPTION
Break after binary operators, rather than before. the current setting seems to trip a lot of us up, so ... let's talk about changing the setting?