### PR TITLE
*: rework renaming the default VRF

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -774,7 +774,6 @@ void bfdd_zclient_unregister(vrf_id_t vrf_id);
 void bfdd_zclient_register(vrf_id_t vrf_id);
 void bfdd_sessions_enable_vrf(struct vrf *vrf);
 void bfdd_sessions_disable_vrf(struct vrf *vrf);
-void bfd_session_update_vrf_name(struct bfd_session *bs, struct vrf *vrf);
 
 int ptm_bfd_notify(struct bfd_session *bs, uint8_t notify_state);
 

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -721,11 +721,6 @@ void bfdd_sessions_enable_vrf(struct vrf *vrf)
 	/* it may affect configs without interfaces */
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
 		bs = bso->bso_bs;
-		/* update name */
-		if (bs->vrf && bs->vrf == vrf) {
-			if (!strmatch(bs->key.vrfname, vrf->name))
-				bfd_session_update_vrf_name(bs, vrf);
-		}
 		if (bs->vrf)
 			continue;
 		if (bs->key.vrfname[0] &&

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -294,19 +294,6 @@ static int bgp_vrf_enable(struct vrf *vrf)
 
 	bgp = bgp_lookup_by_name(vrf->name);
 	if (bgp && bgp->vrf_id != vrf->vrf_id) {
-		if (bgp->name && strmatch(vrf->name, VRF_DEFAULT_NAME)) {
-			XFREE(MTYPE_BGP, bgp->name);
-			XFREE(MTYPE_BGP, bgp->name_pretty);
-			bgp->name_pretty = XSTRDUP(MTYPE_BGP, "VRF default");
-			bgp->inst_type = BGP_INSTANCE_TYPE_DEFAULT;
-#ifdef ENABLE_BGP_VNC
-			if (!bgp->rfapi) {
-				bgp->rfapi = bgp_rfapi_new(bgp);
-				assert(bgp->rfapi);
-				assert(bgp->rfapi_cfg);
-			}
-#endif /* ENABLE_BGP_VNC */
-		}
 		old_vrf_id = bgp->vrf_id;
 		/* We have instance configured, link to VRF and make it "up". */
 		bgp_vrf_link(bgp, vrf);
@@ -367,8 +354,7 @@ static int bgp_vrf_disable(struct vrf *vrf)
 
 static void bgp_vrf_init(void)
 {
-	vrf_init(bgp_vrf_new, bgp_vrf_enable, bgp_vrf_disable,
-		 bgp_vrf_delete, bgp_vrf_enable);
+	vrf_init(bgp_vrf_new, bgp_vrf_enable, bgp_vrf_disable, bgp_vrf_delete);
 }
 
 static void bgp_vrf_terminate(void)

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -712,6 +712,14 @@ These options apply to all |PACKAGE_NAME| daemons.
    be added to all files that use the statedir.  If you have "/var/run/frr"
    as the default statedir then it will become "/var/run/frr/<namespace>".
 
+.. option:: -o, --vrfdefaultname <name>
+
+   Set the name used for the *Default VRF* in CLI commands and YANG models.
+   This option must be the same for all running daemons. By default, the name
+   is "default".
+
+   .. seealso:: :ref:`zebra-vrf`
+
 .. option:: -v, --version
 
    Print program version.

--- a/doc/user/setup.rst
+++ b/doc/user/setup.rst
@@ -22,6 +22,8 @@ of these buffers, pipe their contents through ``tr '\0' '\n'``.  A blank line
 marks the end of valid unwritten data (it will generally be followed by
 garbled, older log messages since the buffer is not cleared.)
 
+.. _daemons-configuration-file:
+
 Daemons Configuration File
 --------------------------
 After a fresh install, starting FRR will do nothing. This is because daemons

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -51,13 +51,6 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
 
    .. seealso:: :ref:`zebra-vrf`
 
-.. option:: -o, --vrfdefaultname
-
-   When *Zebra* starts with this option, the default VRF name is changed to the
-   parameter.
-
-   .. seealso:: :ref:`zebra-vrf`
-
 .. option:: -z <path_to_socket>, --socket <path_to_socket>
 
    If this option is supplied on the cli, the path to the zebra
@@ -363,7 +356,13 @@ separate for each set of VRF, and routing daemons can have their own context
 for each VRF.
 
 This conceptual view introduces the *Default VRF* case. If the user does not
-configure any specific VRF, then by default, FRR uses the *Default VRF*.
+configure any specific VRF, then by default, FRR uses the *Default VRF*. The
+name "default" is used to refer to this VRF in various CLI commands and YANG
+models. It is possible to change that name by passing the ``-o`` option to all
+daemons, for example, one can use ``-o vrf0`` to change the name to "vrf0".
+The easiest way to pass the same option to all daemons is to use the
+``frr_global_options`` variable in the
+:ref:`Daemons Configuration File <daemons-configuration-file>`.
 
 Configuring VRF networking contexts can be done in various ways on FRR. The VRF
 interfaces can be configured by entering in interface configuration mode
@@ -439,39 +438,6 @@ commands in relationship to VRF. Here is an extract of some of those commands:
    combination.  If neither VRF or TABLENO is specified FRR defaults to
    the default vrf and default table.  If prefix is specified dump the
    number of prefix routes.
-
-By using the :option:`-n` option, the *Linux network namespace* will be mapped
-over the *Zebra* VRF. One nice feature that is possible by handling *Linux
-network namespace* is the ability to name default VRF. At startup, *Zebra*
-discovers the available *Linux network namespace* by parsing folder
-``/var/run/netns``. Each file stands for a *Linux network namespace*, but not all
-*Linux network namespaces* are available under that folder. This is the case for
-default VRF. It is possible to name the default VRF, by creating a file, by
-executing following commands.
-
-.. code-block:: shell
-
-   touch /var/run/netns/vrf0
-   mount --bind /proc/self/ns/net /var/run/netns/vrf0
-
-Above command illustrates what happens when the default VRF is visible under
-``/var/run/netns``. Here, the default VRF file is ``vrf0``.
-At startup, FRR detects the presence of that file. It detects that the file
-statistics information matches the same file statistics information as
-``/proc/self/ns/net`` ( through stat() function). As statistics information
-matches, then ``vrf0`` stands for the new default namespace name.
-Consequently, the VRF naming ``Default`` will be overridden by the new discovered
-namespace name ``vrf0``.
-
-For those who don't use VRF backend with *Linux network namespace*, it is
-possible to statically configure and recompile FRR. It is possible to choose an
-alternate name for default VRF. Then, the default VRF naming will automatically
-be updated with the new name. To illustrate, if you want to recompile with
-``global`` value, use the following command:
-
-.. code-block:: shell
-
-   ./configure --with-defaultvrfname=global
 
 .. _zebra-table-allocation:
 

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -189,7 +189,7 @@ int main(int argc, char **argv, char **envp)
 
 	eigrp_error_init();
 	eigrp_vrf_init();
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL);
 
 	/*EIGRPd init*/
 	eigrp_if_init();

--- a/eigrpd/eigrp_vrf.c
+++ b/eigrpd/eigrp_vrf.c
@@ -45,6 +45,6 @@ static int eigrp_vrf_delete(struct vrf *vrf)
 
 void eigrp_vrf_init(void)
 {
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
+	vrf_init(eigrp_vrf_new, eigrp_vrf_enable, eigrp_vrf_disable,
+		 eigrp_vrf_delete);
 }

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -646,51 +646,6 @@ static int isis_vrf_enable(struct vrf *vrf)
 			   vrf->vrf_id);
 
 	isis = isis_lookup_by_vrfname(vrf->name);
-	if (!isis) {
-		char *old_vrf_name = NULL;
-
-		isis = (struct isis *)vrf->info;
-		if (!isis)
-			return 0;
-		/* update vrf name */
-		if (isis->name)
-			old_vrf_name = isis->name;
-		isis->name = XSTRDUP(MTYPE_ISIS_NAME, vrf->name);
-		/*
-		 * HACK: Change the ISIS VRF in the running configuration
-		 * directly, bypassing the northbound layer. This is necessary
-		 * to avoid deleting the ISIS and readding it in the new VRF,
-		 * which would have several implications.
-		 */
-		if (yang_module_find("frr-isisd") && old_vrf_name) {
-			struct lyd_node *isis_dnode;
-			struct isis_area *area;
-			char oldpath[XPATH_MAXLEN];
-			char newpath[XPATH_MAXLEN];
-			struct listnode *node, *nnode;
-
-			for (ALL_LIST_ELEMENTS(isis->area_list, node, nnode,
-					       area)) {
-				isis_dnode = yang_dnode_getf(
-					running_config->dnode,
-					"/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']/vrf",
-					area->area_tag, old_vrf_name);
-				if (isis_dnode) {
-					yang_dnode_get_path(
-						lyd_parent(isis_dnode), oldpath,
-						sizeof(oldpath));
-					yang_dnode_change_leaf(isis_dnode,
-							       vrf->name);
-					yang_dnode_get_path(
-						lyd_parent(isis_dnode), newpath,
-						sizeof(newpath));
-					nb_running_move_tree(oldpath, newpath);
-					running_config->version++;
-				}
-			}
-		}
-		XFREE(MTYPE_ISIS_NAME, old_vrf_name);
-	}
 	if (isis && isis->vrf_id != vrf->vrf_id) {
 		old_vrf_id = isis->vrf_id;
 		/* We have instance configured, link to VRF and make it "up". */
@@ -742,7 +697,7 @@ static int isis_vrf_disable(struct vrf *vrf)
 void isis_vrf_init(void)
 {
 	vrf_init(isis_vrf_new, isis_vrf_enable, isis_vrf_disable,
-		 isis_vrf_delete, isis_vrf_enable);
+		 isis_vrf_delete);
 
 	vrf_cmd_init(NULL);
 }

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -373,7 +373,7 @@ main(int argc, char *argv[])
 
 	master = frr_init();
 
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL);
 	access_list_init();
 	ldp_vty_init();
 	ldp_zebra_init(master);

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -116,6 +116,7 @@ static const struct option lo_always[] = {
 	{"module", no_argument, NULL, 'M'},
 	{"profile", required_argument, NULL, 'F'},
 	{"pathspace", required_argument, NULL, 'N'},
+	{"vrfdefaultname", required_argument, NULL, 'o'},
 	{"vty_socket", required_argument, NULL, OPTION_VTYSOCK},
 	{"moduledir", required_argument, NULL, OPTION_MODULEDIR},
 	{"scriptdir", required_argument, NULL, OPTION_SCRIPTDIR},
@@ -126,13 +127,14 @@ static const struct option lo_always[] = {
 	{"limit-fds", required_argument, NULL, OPTION_LIMIT_FDS},
 	{NULL}};
 static const struct optspec os_always = {
-	"hvdM:F:N:",
+	"hvdM:F:N:o:",
 	"  -h, --help         Display this help and exit\n"
 	"  -v, --version      Print program version\n"
 	"  -d, --daemon       Runs in daemon mode\n"
 	"  -M, --module       Load specified module\n"
 	"  -F, --profile      Use specified configuration profile\n"
 	"  -N, --pathspace    Insert prefix into config & socket paths\n"
+	"  -o, --vrfdefaultname     Set default VRF name.\n"
 	"      --vty_socket   Override vty socket path\n"
 	"      --moduledir    Override modules directory\n"
 	"      --scriptdir    Override scripts directory\n"
@@ -494,6 +496,9 @@ static int frr_opt(int opt)
 			 di->pathspace);
 		snprintf(pidfile_default, sizeof(pidfile_default), "%s/%s.pid",
 			 frr_vtydir, di->name);
+		break;
+	case 'o':
+		vrf_set_default_name(optarg);
 		break;
 #ifdef HAVE_SQLITE3
 	case OPTION_DB_FILE:

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -69,7 +69,6 @@ static struct vrf_master {
 	int (*vrf_delete_hook)(struct vrf *);
 	int (*vrf_enable_hook)(struct vrf *);
 	int (*vrf_disable_hook)(struct vrf *);
-	int (*vrf_update_name_hook)(struct vrf *vrf);
 } vrf_master = {
 	0,
 };
@@ -176,8 +175,6 @@ struct vrf *vrf_get(vrf_id_t vrf_id, const char *name)
 			name, NS_NAMSIZ);
 		strlcpy(vrf->name, name, sizeof(vrf->name));
 		RB_INSERT(vrf_name_head, &vrfs_by_name, vrf);
-		if (vrf->vrf_id == VRF_DEFAULT)
-			vrf_set_default_name(vrf->name, false);
 	} else if (name && vrf->name[0] == '\0') {
 		strlcpy(vrf->name, name, sizeof(vrf->name));
 		RB_INSERT(vrf_name_head, &vrfs_by_name, vrf);
@@ -487,8 +484,7 @@ static const struct cmd_variable_handler vrf_var_handlers[] = {
 
 /* Initialize VRF module. */
 void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
-	      int (*disable)(struct vrf *), int (*destroy)(struct vrf *),
-	      int ((*update)(struct vrf *)))
+	      int (*disable)(struct vrf *), int (*destroy)(struct vrf *))
 {
 	struct vrf *default_vrf;
 
@@ -501,7 +497,6 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 	vrf_master.vrf_enable_hook = enable;
 	vrf_master.vrf_disable_hook = disable;
 	vrf_master.vrf_delete_hook = destroy;
-	vrf_master.vrf_update_name_hook = update;
 
 	/* The default VRF always exists. */
 	default_vrf = vrf_get(VRF_DEFAULT, VRF_DEFAULT_NAME);
@@ -773,33 +768,9 @@ void vrf_cmd_init(int (*writefunc)(struct vty *vty))
 	install_element(VRF_NODE, &vrf_exit_cmd);
 }
 
-void vrf_set_default_name(const char *default_name, bool force)
+void vrf_set_default_name(const char *default_name)
 {
-	struct vrf *def_vrf;
-	static bool def_vrf_forced;
-
-	def_vrf = vrf_lookup_by_id(VRF_DEFAULT);
-	assert(default_name);
-	if (def_vrf && !force && def_vrf_forced) {
-		zlog_debug("VRF: %s, avoid changing name to %s, previously forced (%u)",
-			   def_vrf->name, default_name,
-			   def_vrf->vrf_id);
-		return;
-	}
-	if (strmatch(vrf_default_name, default_name))
-		return;
 	snprintf(vrf_default_name, VRF_NAMSIZ, "%s", default_name);
-	if (def_vrf) {
-		if (force)
-			def_vrf_forced = true;
-		RB_REMOVE(vrf_name_head, &vrfs_by_name, def_vrf);
-		strlcpy(def_vrf->data.l.netns_name,
-			vrf_default_name, NS_NAMSIZ);
-		strlcpy(def_vrf->name, vrf_default_name, sizeof(def_vrf->name));
-		RB_INSERT(vrf_name_head, &vrfs_by_name, def_vrf);
-		if (vrf_master.vrf_update_name_hook)
-			(*vrf_master.vrf_update_name_hook)(def_vrf);
-	}
 }
 
 const char *vrf_get_default_name(void)

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -212,9 +212,10 @@ extern int vrf_bitmap_check(vrf_bitmap_t, vrf_id_t);
  * delete -> Called back when a vrf is being deleted from
  *           the system ( 2 and 3 ) above.
  */
-extern void vrf_init(int (*create)(struct vrf *vrf), int (*enable)(struct vrf *vrf),
-		     int (*disable)(struct vrf *vrf), int (*destroy)(struct vrf *vrf),
-		     int (*update)(struct vrf *vrf));
+extern void vrf_init(int (*create)(struct vrf *vrf),
+		     int (*enable)(struct vrf *vrf),
+		     int (*disable)(struct vrf *vrf),
+		     int (*destroy)(struct vrf *vrf));
 
 /*
  * Call vrf_terminate when the protocol is being shutdown
@@ -267,7 +268,9 @@ extern int vrf_ioctl(vrf_id_t vrf_id, int d, unsigned long request, char *args);
 /* The default VRF ID */
 #define VRF_DEFAULT 0
 
-extern void vrf_set_default_name(const char *default_name, bool force);
+/* Must be called only during startup, before config is read */
+extern void vrf_set_default_name(const char *default_name);
+
 extern const char *vrf_get_default_name(void);
 #define VRF_DEFAULT_NAME    vrf_get_default_name()
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2135,9 +2135,6 @@ static int zclient_vrf_add(ZAPI_CALLBACK_ARGS)
 
 	vrf->data.l.table_id = data.l.table_id;
 	memcpy(vrf->data.l.netns_name, data.l.netns_name, NS_NAMSIZ);
-	/* overwrite default vrf */
-	if (vrf_id == VRF_DEFAULT)
-		vrf_set_default_name(vrfname_tmp, false);
 	vrf_enable(vrf);
 
 	return 0;

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
 	/* Library inits. */
 	master = frr_init();
 	nhrp_error_init();
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL);
 	nhrp_interface_init();
 	resolver_init(master);
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -236,7 +236,7 @@ static int ospf6_vrf_enable(struct vrf *vrf)
 void ospf6_vrf_init(void)
 {
 	vrf_init(ospf6_vrf_new, ospf6_vrf_enable, ospf6_vrf_disable,
-		 ospf6_vrf_delete, ospf6_vrf_enable);
+		 ospf6_vrf_delete);
 
 	vrf_cmd_init(NULL);
 }

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -157,7 +157,7 @@ static int ospf_router_cmd_parse(struct vty *vty, struct cmd_token *argv[],
 		*instance = strtoul(argv[idx_inst]->arg, NULL, 10);
 	}
 
-	*vrf_name = NULL;
+	*vrf_name = VRF_DEFAULT_NAME;
 	if (argv_find(argv, argc, "vrf", &idx_vrf)) {
 		if (ospf_instance != 0) {
 			vty_out(vty,
@@ -166,8 +166,6 @@ static int ospf_router_cmd_parse(struct vty *vty, struct cmd_token *argv[],
 		}
 
 		*vrf_name = argv[idx_vrf + 1]->arg;
-		if (*vrf_name && strmatch(*vrf_name, VRF_DEFAULT_NAME))
-			*vrf_name = NULL;
 	}
 
 	return CMD_SUCCESS;
@@ -11704,12 +11702,12 @@ static int ospf_config_write_one(struct vty *vty, struct ospf *ospf)
 	int write = 0;
 
 	/* `router ospf' print. */
-	if (ospf->instance && ospf->name) {
+	if (ospf->instance && strcmp(ospf->name, VRF_DEFAULT_NAME)) {
 		vty_out(vty, "router ospf %d vrf %s\n", ospf->instance,
 			ospf->name);
 	} else if (ospf->instance) {
 		vty_out(vty, "router ospf %d\n", ospf->instance);
-	} else if (ospf->name) {
+	} else if (strcmp(ospf->name, VRF_DEFAULT_NAME)) {
 		vty_out(vty, "router ospf vrf %s\n", ospf->name);
 	} else
 		vty_out(vty, "router ospf\n");

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -314,22 +314,19 @@ struct ospf *ospf_new_alloc(unsigned short instance, const char *name)
 	new->instance = instance;
 	new->router_id.s_addr = htonl(0);
 	new->router_id_static.s_addr = htonl(0);
-	if (name) {
-		vrf = vrf_lookup_by_name(name);
-		if (vrf)
-			new->vrf_id = vrf->vrf_id;
-		else
-			new->vrf_id = VRF_UNKNOWN;
-		/* Freed in ospf_finish_final */
-		new->name = XSTRDUP(MTYPE_OSPF_TOP, name);
-		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"%s: Create new ospf instance with vrf_name %s vrf_id %u",
-				__func__, name, new->vrf_id);
-	} else {
-		new->vrf_id = VRF_DEFAULT;
-		vrf = vrf_lookup_by_id(VRF_DEFAULT);
-	}
+
+	vrf = vrf_lookup_by_name(name);
+	if (vrf)
+		new->vrf_id = vrf->vrf_id;
+	else
+		new->vrf_id = VRF_UNKNOWN;
+
+	/* Freed in ospf_finish_final */
+	new->name = XSTRDUP(MTYPE_OSPF_TOP, name);
+	if (IS_DEBUG_OSPF_EVENT)
+		zlog_debug(
+			"%s: Create new ospf instance with vrf_name %s vrf_id %u",
+			__func__, name, new->vrf_id);
 
 	if (vrf)
 		ospf_vrf_link(new, vrf);
@@ -478,9 +475,6 @@ struct ospf *ospf_lookup_by_inst_name(unsigned short instance, const char *name)
 {
 	struct ospf *ospf = NULL;
 	struct listnode *node, *nnode;
-
-	if (name == NULL || strmatch(name, VRF_DEFAULT_NAME))
-		return ospf_lookup_by_vrf_id(VRF_DEFAULT);
 
 	for (ALL_LIST_ELEMENTS(om->ospf, node, nnode, ospf)) {
 		if ((ospf->instance == instance)
@@ -911,8 +905,7 @@ static void ospf_finish_final(struct ospf *ospf)
 	if (vrf)
 		ospf_vrf_unlink(ospf, vrf);
 
-	if (ospf->name)
-		XFREE(MTYPE_OSPF_TOP, ospf->name);
+	XFREE(MTYPE_OSPF_TOP, ospf->name);
 	XFREE(MTYPE_OSPF_TOP, ospf);
 }
 
@@ -2211,10 +2204,6 @@ static int ospf_vrf_enable(struct vrf *vrf)
 
 	ospf = ospf_lookup_by_name(vrf->name);
 	if (ospf) {
-		if (ospf->name && strmatch(vrf->name, VRF_DEFAULT_NAME)) {
-			XFREE(MTYPE_OSPF_TOP, ospf->name);
-			ospf->name = NULL;
-		}
 		old_vrf_id = ospf->vrf_id;
 		/* We have instance configured, link to VRF and make it "up". */
 		ospf_vrf_link(ospf, vrf);
@@ -2283,7 +2272,7 @@ static int ospf_vrf_disable(struct vrf *vrf)
 void ospf_vrf_init(void)
 {
 	vrf_init(ospf_vrf_new, ospf_vrf_enable, ospf_vrf_disable,
-		 ospf_vrf_delete, ospf_vrf_enable);
+		 ospf_vrf_delete);
 }
 
 void ospf_vrf_terminate(void)

--- a/pbrd/pbr_vrf.c
+++ b/pbrd/pbr_vrf.c
@@ -124,8 +124,7 @@ bool pbr_vrf_is_valid(const struct pbr_vrf *pbr_vrf)
 
 void pbr_vrf_init(void)
 {
-	vrf_init(pbr_vrf_new, pbr_vrf_enable, pbr_vrf_disable, pbr_vrf_delete,
-		 NULL);
+	vrf_init(pbr_vrf_new, pbr_vrf_enable, pbr_vrf_disable, pbr_vrf_delete);
 }
 
 void pbr_vrf_terminate(void)

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -228,8 +228,7 @@ static int pim_vrf_config_write(struct vty *vty)
 
 void pim_vrf_init(void)
 {
-	vrf_init(pim_vrf_new, pim_vrf_enable, pim_vrf_disable,
-		 pim_vrf_delete, NULL);
+	vrf_init(pim_vrf_new, pim_vrf_enable, pim_vrf_disable, pim_vrf_delete);
 
 	vrf_cmd_init(pim_vrf_config_write);
 }

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2604,45 +2604,7 @@ static int ripng_vrf_enable(struct vrf *vrf)
 	int socket;
 
 	ripng = ripng_lookup_by_vrf_name(vrf->name);
-	if (!ripng) {
-		char *old_vrf_name = NULL;
-
-		ripng = (struct ripng *)vrf->info;
-		if (!ripng)
-			return 0;
-		/* update vrf name */
-		if (ripng->vrf_name)
-			old_vrf_name = ripng->vrf_name;
-		ripng->vrf_name = XSTRDUP(MTYPE_RIPNG_VRF_NAME, vrf->name);
-		/*
-		 * HACK: Change the RIPng VRF in the running configuration directly,
-		 * bypassing the northbound layer. This is necessary to avoid deleting
-		 * the RIPng and readding it in the new VRF, which would have
-		 * several implications.
-		 */
-		if (yang_module_find("frr-ripngd") && old_vrf_name) {
-			struct lyd_node *ripng_dnode;
-			char oldpath[XPATH_MAXLEN];
-			char newpath[XPATH_MAXLEN];
-
-			ripng_dnode = yang_dnode_getf(
-				running_config->dnode,
-				"/frr-ripngd:ripngd/instance[vrf='%s']/vrf",
-				old_vrf_name);
-			if (ripng_dnode) {
-				yang_dnode_get_path(lyd_parent(ripng_dnode),
-						    oldpath, sizeof(oldpath));
-				yang_dnode_change_leaf(ripng_dnode, vrf->name);
-				yang_dnode_get_path(lyd_parent(ripng_dnode),
-						    newpath, sizeof(newpath));
-				nb_running_move_tree(oldpath, newpath);
-				running_config->version++;
-			}
-		}
-		XFREE(MTYPE_RIPNG_VRF_NAME, old_vrf_name);
-	}
-
-	if (ripng->enabled)
+	if (!ripng || ripng->enabled)
 		return 0;
 
 	if (IS_RIPNG_DEBUG_EVENT)
@@ -2681,7 +2643,7 @@ static int ripng_vrf_disable(struct vrf *vrf)
 void ripng_vrf_init(void)
 {
 	vrf_init(ripng_vrf_new, ripng_vrf_enable, ripng_vrf_disable,
-		 ripng_vrf_delete, ripng_vrf_enable);
+		 ripng_vrf_delete);
 
 	vrf_cmd_init(NULL);
 }

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -181,7 +181,7 @@ int main(int argc, char **argv, char **envp)
 	sharp_global_init();
 
 	sharp_nhgroup_init();
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL);
 
 	sharp_zebra_init();
 

--- a/staticd/static_vrf.c
+++ b/staticd/static_vrf.c
@@ -153,8 +153,8 @@ static int static_vrf_config_write(struct vty *vty)
 
 void static_vrf_init(void)
 {
-	vrf_init(static_vrf_new, static_vrf_enable,
-		 static_vrf_disable, static_vrf_delete, NULL);
+	vrf_init(static_vrf_new, static_vrf_enable, static_vrf_disable,
+		 static_vrf_delete);
 
 	vrf_cmd_init(static_vrf_config_write);
 }

--- a/tests/bgpd/test_capability.c
+++ b/tests/bgpd/test_capability.c
@@ -913,7 +913,7 @@ int main(void)
 	qobj_init();
 	master = thread_master_create(NULL);
 	bgp_master_init(master, BGP_SOCKET_SNDBUF_SIZE, list_new());
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 
 	frr_pthread_init();

--- a/tests/bgpd/test_mp_attr.c
+++ b/tests/bgpd/test_mp_attr.c
@@ -1087,7 +1087,7 @@ int main(void)
 	bgp_vty_init();
 	master = thread_master_create("test mp attr");
 	bgp_master_init(master, BGP_SOCKET_SNDBUF_SIZE, list_new());
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 	bgp_attr_init();
 

--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -394,7 +394,7 @@ static int global_test_init(void)
 	master = thread_master_create(NULL);
 	zclient = zclient_new(master, &zclient_options_default, NULL, 0);
 	bgp_master_init(master, BGP_SOCKET_SNDBUF_SIZE, list_new());
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 
 	if (fileno(stdout) >= 0)

--- a/tests/bgpd/test_packet.c
+++ b/tests/bgpd/test_packet.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
 	bgp_attr_init();
 	master = thread_master_create(NULL);
 	bgp_master_init(master, BGP_SOCKET_SNDBUF_SIZE, list_new());
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 
 	if (bgp_get(&bgp, &asn, NULL, BGP_INSTANCE_TYPE_DEFAULT) < 0)

--- a/tests/bgpd/test_peer_attr.c
+++ b/tests/bgpd/test_peer_attr.c
@@ -1389,7 +1389,7 @@ static void bgp_startup(void)
 	nb_init(master, NULL, 0, false);
 	bgp_master_init(master, BGP_SOCKET_SNDBUF_SIZE, list_new());
 	bgp_option_set(BGP_OPT_NO_LISTEN);
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL);
 	frr_pthread_init();
 	bgp_init(0);
 	bgp_pthreads_run();

--- a/tests/ospfd/test_ospf_spf.c
+++ b/tests/ospfd/test_ospf_spf.c
@@ -34,7 +34,7 @@ static struct ospf *test_init(struct ospf_test_node *root)
 	struct in_addr area_id;
 	struct in_addr router_id;
 
-	ospf = ospf_new_alloc(0, NULL);
+	ospf = ospf_new_alloc(0, VRF_DEFAULT_NAME);
 
 	area_id.s_addr = OSPF_AREA_BACKBONE;
 	area = ospf_area_new(ospf, area_id);

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -2398,7 +2398,7 @@ void vrrp_init(void)
 	vrrp_autoconfig_version = 3;
 	vrrp_vrouters_hash = hash_create(&vrrp_hash_key, vrrp_hash_cmp,
 					 "VRRP virtual router hash");
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL);
 }
 
 void vrrp_fini(void)

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -93,7 +93,6 @@ const struct option longopts[] = {
 	{"socket", required_argument, NULL, 'z'},
 	{"ecmp", required_argument, NULL, 'e'},
 	{"retain", no_argument, NULL, 'r'},
-	{"vrfdefaultname", required_argument, NULL, 'o'},
 	{"graceful_restart", required_argument, NULL, 'K'},
 	{"asic-offload", optional_argument, NULL, OPTION_ASIC_OFFLOAD},
 #ifdef HAVE_NETLINK
@@ -284,7 +283,6 @@ int main(int argc, char **argv)
 {
 	// int batch_mode = 0;
 	char *zserv_path = NULL;
-	char *vrf_default_name_configured = NULL;
 	struct sockaddr_storage dummy;
 	socklen_t dummylen;
 	bool asic_offload = false;
@@ -296,7 +294,7 @@ int main(int argc, char **argv)
 	frr_preinit(&zebra_di, argc, argv);
 
 	frr_opt_add(
-		"baz:e:o:rK:"
+		"baz:e:rK:"
 #ifdef HAVE_NETLINK
 		"s:n"
 #endif
@@ -307,7 +305,6 @@ int main(int argc, char **argv)
 		"  -z, --socket             Set path of zebra socket\n"
 		"  -e, --ecmp               Specify ECMP to use.\n"
 		"  -r, --retain             When program terminates, retain added route by zebra.\n"
-		"  -o, --vrfdefaultname     Set default VRF name.\n"
 		"  -K, --graceful_restart   Graceful restart at the kernel level, timer in seconds for expiration\n"
 		"  -A, --asic-offload       FRR is interacting with an asic underneath the linux kernel\n"
 #ifdef HAVE_NETLINK
@@ -347,9 +344,6 @@ int main(int argc, char **argv)
 			zrouter.multipath_num = parsed_multipath;
 			break;
 		}
-		case 'o':
-			vrf_default_name_configured = optarg;
-			break;
 		case 'z':
 			zserv_path = optarg;
 			if (!frr_zclient_addr(&dummy, &dummylen, optarg)) {
@@ -400,7 +394,7 @@ int main(int argc, char **argv)
 	/*
 	 * Initialize NS( and implicitly the VRF module), and make kernel
 	 * routing socket. */
-	zebra_ns_init((const char *)vrf_default_name_configured);
+	zebra_ns_init();
 	router_id_cmd_init();
 	zebra_vty_init();
 	access_list_init();

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -266,8 +266,8 @@ static int zebra_ns_ready_read(struct thread *t)
 	}
 	if (zebra_ns_notify_is_default_netns(basename(netnspath))) {
 		zlog_warn(
-			  "NS notify : NS %s is default VRF. Updating VRF Name", basename(netnspath));
-		vrf_set_default_name(basename(netnspath), false);
+			"NS notify : NS %s is default VRF. Ignore VRF creation",
+			basename(netnspath));
 		return zebra_ns_continue_read(zns_info, 1);
 	}
 
@@ -367,8 +367,8 @@ void zebra_ns_notify_parse(void)
 		}
 		if (zebra_ns_notify_is_default_netns(dent->d_name)) {
 			zlog_warn(
-				  "NS notify : NS %s is default VRF. Updating VRF Name", dent->d_name);
-			vrf_set_default_name(dent->d_name, false);
+				"NS notify : NS %s is default VRF. Ignore VRF creation",
+				dent->d_name);
 			continue;
 		}
 		zebra_ns_notify_create_context_from_entry_name(dent->d_name);

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -180,7 +180,7 @@ int zebra_ns_final_shutdown(struct ns *ns,
 	return NS_WALK_CONTINUE;
 }
 
-int zebra_ns_init(const char *optional_default_name)
+int zebra_ns_init(void)
 {
 	struct ns *default_ns;
 	ns_id_t ns_id;
@@ -212,10 +212,6 @@ int zebra_ns_init(const char *optional_default_name)
 
 	/* Default NS is activated */
 	zebra_ns_enable(ns_id_external, (void **)&dzns);
-
-	if (optional_default_name)
-		vrf_set_default_name(optional_default_name,
-				     true);
 
 	if (vrf_is_backend_netns()) {
 		ns_add_hook(NS_NEW_HOOK, zebra_ns_new);

--- a/zebra/zebra_ns.h
+++ b/zebra/zebra_ns.h
@@ -69,7 +69,7 @@ struct zebra_ns {
 
 struct zebra_ns *zebra_ns_lookup(ns_id_t ns_id);
 
-int zebra_ns_init(const char *optional_default_name);
+int zebra_ns_init(void);
 int zebra_ns_enable(ns_id_t ns_id, void **info);
 int zebra_ns_disabled(struct ns *ns);
 int zebra_ns_early_shutdown(struct ns *ns,

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -337,18 +337,6 @@ static int zebra_vrf_delete(struct vrf *vrf)
 	return 0;
 }
 
-static int zebra_vrf_update(struct vrf *vrf)
-{
-	struct zebra_vrf *zvrf = vrf->info;
-
-	assert(zvrf);
-	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("VRF %s id %u, name updated", vrf->name,
-			   zvrf_id(zvrf));
-	zebra_vrf_add_update(zvrf);
-	return 0;
-}
-
 /* Lookup the routing table in a VRF based on both VRF-Id and table-id.
  * NOTE: Table-id is relevant on two modes:
  * - case VRF backend is default : on default VRF only
@@ -703,7 +691,7 @@ int zebra_vrf_netns_handler_create(struct vty *vty, struct vrf *vrf,
 void zebra_vrf_init(void)
 {
 	vrf_init(zebra_vrf_new, zebra_vrf_enable, zebra_vrf_disable,
-		 zebra_vrf_delete, zebra_vrf_update);
+		 zebra_vrf_delete);
 
 	hook_register(zserv_client_close, release_daemon_table_chunks);
 


### PR DESCRIPTION
Currently, it is possible to rename the default VRF either by passing
`-o` option to zebra or by creating a file in `/var/run/netns` and
binding it to `/proc/self/ns/net`.

In both cases, only zebra knows about the rename and other daemons learn
about it only after they connect to zebra. This is a problem, because
daemons may read their config before they connect to zebra. To handle
this rename after the config is read, we have some special code in every
single daemon, which is not very bad but not desirable in my opinion.
But things are getting worse when we need to handle this in northbound
layer as we have to manually rewrite the config nodes. This approach is
already hacky, but still works as every daemon handles its own NB
structures. But it is completely incompatible with the central
management daemon architecture we are aiming for, as mgmtd doesn't even
have a connection with zebra to learn from it. And it shouldn't have it,
because operational state changes should never affect configuration.

To solve the problem and simplify the code, I propose to expand the `-o`
option to all daemons. By using the startup option, we let daemons know
about the rename before they read their configs so we don't need any
special code to deal with it. There's an easy way to pass the option to
all daemons by using `frr_global_options` variable.

Unfortunately, the second way of renaming by creating a file in
`/var/run/netns` is incompatible with the new mgmtd architecture.
Theoretically, we could force daemons to read their configs only after
they connect to zebra, but it means adding even more code to handle a
very specific use-case. And anyway this won't work for mgmtd as it
doesn't have a connection with zebra. So I had to remove this option.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>