### PR TITLE
bfdd: remove unnecessary receive timer restart

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -639,14 +639,6 @@ int bfd_recvtimer_cb(struct thread *t)
 	case PTM_BFD_INIT:
 	case PTM_BFD_UP:
 		ptm_bfd_sess_dn(bs, BD_CONTROL_EXPIRED);
-		bfd_recvtimer_update(bs);
-		break;
-
-	default:
-		/* Second detect time expiration, zero remote discr (section
-		 * 6.5.1)
-		 */
-		bs->discrs.remote_discr = 0;
 		break;
 	}
 


### PR DESCRIPTION
When the detection time expires, we put the session down and restart the
timer. As the comment in the code says, it's needed to zero the remote
discriminator after the second expiration.

But the RFC clearly says that this must be done on the first expiration:

```
   bfd.RemoteDiscr

      The remote discriminator for this BFD session.  This is the
      discriminator chosen by the remote system, and is totally opaque
      to the local system.  This MUST be initialized to zero.  If a
      period of a Detection Time passes without the receipt of a valid,
      authenticated BFD packet from the remote system, this variable
      MUST be set to zero.
```

And we actually already do it in `ptm_bfd_sess_dn`, so there's no need
to reset the timer and wait for it twice.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>