### PR TITLE
tools: exit when reload fails to parse config file

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1842,7 +1842,7 @@ if __name__ == "__main__":
         lines_to_configure = []
 
         # We will not be able to do anything, go ahead and exit(1)
-        if not vtysh.is_config_available():
+        if not vtysh.is_config_available() or not reload_ok:
             sys.exit(1)
 
         log.debug("New Frr Config\n%s", newconf.get_lines())


### PR DESCRIPTION
frr-reload triggers restart of service in case
it fails to parse new config file and conjunction with
running config contains 'router bgp' (default bgp instnace).

When frr-reload fails to parse new config file, it fails
to build newconfig context (empty object).
Instead of bailing out it compares against the running config
context. If the running config contains default bgp instance
it thinks new config is removing default bgp instance so it
triggers frr restart.

Fix is to to bail out reload script when it fails to parse
config file.


Testing Done:

```
router bgp 102 vrf RED
bgp router-id 2.2.2.2
neighbor underlay peer-group
neighbor underlay remote-as <---- Partial config
```

**Before fix:**
```
2021-12-02 02:43:16,987 ERROR: vtysh failed to process new
configuration: vtysh (mark file) exited with status 4:
b'line 79: % Command incomplete: neighbor underlay remote-as\n\n'
2021-12-02 02:43:17,145  INFO: Loading Config object from vtysh show
running
2021-12-02 02:43:17,362  INFO: "frr version 7.5+cl5.0.0u0" cannot be
removed
2021-12-02 02:43:17,362  INFO: "frr defaults datacenter" cannot be
removed
2021-12-02 02:43:17,362  INFO: "service integrated-vtysh-config" cannot
be removed
2021-12-02 02:43:17,363  INFO: "line vty" cannot be removed
2021-12-02 02:43:17,522  INFO: EVPN is enabled and default instance del
needed
2021-12-02 02:43:17,522  INFO: Restarting FRR          <---- Restart frr
```

**After fix:**

Just throw Error and abort the script.
```
root@TORS1:mgmt:/home/cumulus# /usr/lib/frr/frr-reload.py --debug
--reload --stdout /etc/frr/frr.conf
2021-12-02 04:00:56,519  INFO: Called via "Namespace(bindir='/usr/bin',
confdir='/etc/frr', daemon='', debug=True, filename='/etc/frr/$
rr.conf', input=None, overwrite=False, pathspace=None, reload=True,
rundir='/var/run/frr', stdout=True, test=False, vty_socket=None)"
2021-12-02 04:00:56,520  INFO: Loading Config object from file
/etc/frr/frr.conf
2021-12-02 04:00:56,679   ERROR: vtysh failed to process new
configuration: vtysh (mark file) exited with status 4:
b'line 79: % Command incomplete: neighbor underlay remote-as\n\n'
root@TORS1:mgmt:/home/cumulus#
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>