### PR TITLE
tests: test_ospf_lan.py is looking for a certain order enforce it

### DIFF
--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -413,6 +413,7 @@ def test_ospf_lan_tc1_p0(request):
 
     build_config_from_json(tgen, topo_modify_change_ip, save_bkup=False)
 
+    clear_ospf(tgen, "r0")
     step(
         "Verify that OSPF is in FULL state with other routers with "
         "newly configured IP."


### PR DESCRIPTION
OSPF when converging will choose a DR / Backup DR based upon
who has already come up.  Irrelevant of priority.  As such if
under system load OSPF comes up first and elects a DR that under
normal circumstances not be the elected one due to priority
OSPF does not go back through and re-elect to keep the system
stable in this case.  Tests are experiencing this:

unet> r0 show ip ospf neigh

Neighbor ID     Pri State           Up Time         Dead Time Address         Interface                        RXmtL RqstL DBsmL
100.1.1.1        99 Full/Backup     4m14s              3.780s 10.0.1.2        r0-s1-eth0:10.0.1.1                  0     0     0
100.1.1.2         0 Full/DROther    4m14s              3.848s 10.0.1.3        r0-s1-eth0:10.0.1.1                  0     0     0
100.1.1.3         0 Full/DROther    4m14s              3.912s 10.0.1.4        r0-s1-eth0:10.0.1.1                  0     0     0

unet> r1 show ip ospf neigh

Neighbor ID     Pri State           Up Time         Dead Time Address         Interface                        RXmtL RqstL DBsmL
100.1.1.0        98 Full/DR         4m15s              3.011s 10.0.1.1        r1-s1-eth1:10.0.1.2                  0     0     0
100.1.1.2         0 Full/DROther    4m19s              3.124s 10.0.1.3        r1-s1-eth1:10.0.1.2                  0     0     0
100.1.1.3         0 Full/DROther    4m19s              3.188s 10.0.1.4        r1-s1-eth1:10.0.1.2                  0     0     0

unet> r2 show ip ospf neigh

Neighbor ID     Pri State           Up Time         Dead Time Address         Interface                        RXmtL RqstL DBsmL
100.1.1.0        98 Full/DR         4m27s              3.483s 10.0.1.1        r2-s1-eth0:10.0.1.3                  0     0     0
100.1.1.1        99 Full/Backup     4m32s              3.527s 10.0.1.2        r2-s1-eth0:10.0.1.3                  0     0     0
100.1.1.3         0 2-Way/DROther   4m32s              3.660s 10.0.1.4        r2-s1-eth0:10.0.1.3                  0     0     0

unet> r3 show ip ospf neigh

Neighbor ID     Pri State           Up Time         Dead Time Address         Interface                        RXmtL RqstL DBsmL
100.1.1.0        98 Full/DR         4m55s              3.786s 10.0.1.1        r3-s1-eth1:10.0.1.4                  0     0     0
100.1.1.1        99 Full/Backup     4m55s              3.829s 10.0.1.2        r3-s1-eth1:10.0.1.4                  0     0     0
100.1.1.2         0 2-Way/DROther   4m54s              3.897s 10.0.1.3        r3-s1-eth1:10.0.1.4                  0     0     0

Modify the test to do a clear to enforce the order we are specifically looking for.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>