### PR TITLE
pimd: Data structure changes to accommodate address family for IPv4 and IPv6

### DIFF
--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -43,12 +43,11 @@ static void assert_action_a6(struct pim_ifchannel *ch,
 			     struct pim_assert_metric winner_metric);
 
 void pim_ifassert_winner_set(struct pim_ifchannel *ch,
-			     enum pim_ifassert_state new_state,
-			     struct in_addr winner,
+			     enum pim_ifassert_state new_state, pim_addr winner,
 			     struct pim_assert_metric winner_metric)
 {
 	struct pim_interface *pim_ifp = ch->interface->info;
-	int winner_changed = (ch->ifassert_winner.s_addr != winner.s_addr);
+	int winner_changed = !!pim_addr_cmp(ch->ifassert_winner, winner);
 	int metric_changed = !pim_assert_metric_match(
 		&ch->ifassert_winner_metric, &winner_metric);
 
@@ -66,9 +65,9 @@ void pim_ifassert_winner_set(struct pim_ifchannel *ch,
 			char was_str[INET_ADDRSTRLEN];
 			char winner_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<was?>", ch->ifassert_winner, was_str,
-				       sizeof(was_str));
+				      sizeof(was_str));
 			pim_inet4_dump("<winner?>", winner, winner_str,
-				       sizeof(winner_str));
+				      sizeof(winner_str));
 			zlog_debug(
 				"%s: (S,G)=%s assert winner changed from %s to %s on interface %s",
 				__func__, ch->sg_str, was_str, winner_str,
@@ -179,8 +178,8 @@ static int dispatch_assert(struct interface *ifp, struct in_addr source_addr,
 		}
 		break;
 	case PIM_IFASSERT_I_AM_LOSER:
-		if (recv_metric.ip_address.s_addr
-		    == ch->ifassert_winner.s_addr) {
+		if (!pim_addr_cmp(recv_metric.ip_address,
+				  ch->ifassert_winner)) {
 			/* Assert from current winner */
 
 			if (cancel_assert(&recv_metric)) {

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -65,9 +65,9 @@ void pim_ifassert_winner_set(struct pim_ifchannel *ch,
 			char was_str[INET_ADDRSTRLEN];
 			char winner_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<was?>", ch->ifassert_winner, was_str,
-				      sizeof(was_str));
+				       sizeof(was_str));
 			pim_inet4_dump("<winner?>", winner, winner_str,
-				      sizeof(winner_str));
+				       sizeof(winner_str));
 			zlog_debug(
 				"%s: (S,G)=%s assert winner changed from %s to %s on interface %s",
 				__func__, ch->sg_str, was_str, winner_str,
@@ -339,7 +339,7 @@ int pim_assert_metric_better(const struct pim_assert_metric *m1,
 	if (m1->route_metric > m2->route_metric)
 		return 0;
 
-	return ntohl(m1->ip_address.s_addr) > ntohl(m2->ip_address.s_addr);
+	return pim_addr_cmp(m1->ip_address, m2->ip_address) > 0;
 }
 
 int pim_assert_metric_match(const struct pim_assert_metric *m1,
@@ -352,7 +352,7 @@ int pim_assert_metric_match(const struct pim_assert_metric *m1,
 	if (m1->route_metric != m2->route_metric)
 		return 0;
 
-	return m1->ip_address.s_addr == m2->ip_address.s_addr;
+	return !pim_addr_cmp(m1->ip_address, m2->ip_address);
 }
 
 int pim_assert_build_msg(uint8_t *pim_msg, int buf_size, struct interface *ifp,

--- a/pimd/pim_assert.h
+++ b/pimd/pim_assert.h
@@ -37,7 +37,7 @@ struct pim_assert_metric {
 	uint32_t rpt_bit_flag;
 	uint32_t metric_preference;
 	uint32_t route_metric;
-	struct in_addr ip_address; /* neighbor router that sourced the Assert
+	pim_addr ip_address; /* neighbor router that sourced the Assert
 				      message */
 };
 

--- a/pimd/pim_assert.h
+++ b/pimd/pim_assert.h
@@ -55,8 +55,7 @@ struct pim_assert_metric {
 #define PIM_ASSERT_ROUTE_METRIC_MAX      (0xFFFFFFFF)
 
 void pim_ifassert_winner_set(struct pim_ifchannel *ch,
-			     enum pim_ifassert_state new_state,
-			     struct in_addr winner,
+			     enum pim_ifassert_state new_state, pim_addr winner,
 			     struct pim_assert_metric winner_metric);
 
 int pim_assert_recv(struct interface *ifp, struct pim_neighbor *neigh,

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -94,16 +94,14 @@ struct pim_interface {
 	uint32_t options; /* bit vector */
 	ifindex_t mroute_vif_index;
 	struct pim_instance *pim;
-
-	struct in_addr primary_address; /* remember addr to detect change */
+	pim_addr primary_address;       /* remember addr to detect change */
 	struct list *sec_addr_list;     /* list of struct pim_secondary_addr */
-	struct in_addr update_source;   /* user can statically set the primary
+	pim_addr update_source;		/* user can statically set the primary
 					 * address of the interface */
-
-	int igmp_version;		       /* IGMP version */
-	int igmp_default_robustness_variable;  /* IGMPv3 QRV */
-	int igmp_default_query_interval;       /* IGMPv3 secs between general
-						  queries */
+	int igmp_version;		/* IGMP or MLD version */
+	int igmp_default_robustness_variable; /* IGMP or MLD QRV */
+	int igmp_default_query_interval; /* IGMP or MLD secs between general
+					    queries */
 	int igmp_query_max_response_time_dsec; /* IGMPv3 Max Response Time in
 						  dsecs for general queries */
 	int igmp_specific_query_max_response_time_dsec; /* IGMPv3 Max Response
@@ -144,7 +142,7 @@ struct pim_interface {
 	int64_t pim_dr_election_last; /* timestamp */
 	int pim_dr_election_count;
 	int pim_dr_election_changes;
-	struct in_addr pim_dr_addr;
+	pim_addr pim_dr_addr;
 	uint32_t pim_dr_priority;	  /* config */
 	int pim_dr_num_nondrpri_neighbors; /* neighbors without dr_pri */
 

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -32,6 +32,7 @@
 #include "pim_upstream.h"
 #include "pim_instance.h"
 #include "bfd.h"
+#include "pim_str.h"
 
 #define PIM_IF_MASK_PIM                             (1 << 0)
 #define PIM_IF_MASK_IGMP                            (1 << 1)
@@ -76,7 +77,7 @@
 #define PIM_IF_FLAG_UNSET_HELLO_SENT(flags) ((flags) &= ~PIM_IF_FLAG_HELLO_SENT)
 
 struct pim_iface_upstream_switch {
-	struct in_addr address;
+	pim_addr address;
 	struct list *us;
 };
 

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -106,7 +106,7 @@ struct pim_ifchannel {
 	/* Per-interface (S,G) Assert State (Section 4.6.1 of RFC4601) */
 	enum pim_ifassert_state ifassert_state;
 	struct thread *t_ifassert_timer;
-	struct in_addr ifassert_winner;
+	pim_addr ifassert_winner;
 	struct pim_assert_metric ifassert_winner_metric;
 	int64_t ifassert_creation; /* Record uptime of ifassert state */
 	struct pim_assert_metric ifassert_my_metric;

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -26,6 +26,7 @@
 #include "vty.h"
 #include "linklist.h"
 #include "pim_igmp_stats.h"
+#include "pim_str.h"
 
 /*
   The following sizes are likely to support
@@ -76,8 +77,8 @@
 	} while (0)
 
 struct gm_join {
-	struct in_addr group_addr;
-	struct in_addr source_addr;
+	pim_addr group_addr;
+	pim_addr source_addr;
 	int sock_fd;
 	time_t sock_creation;
 };

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -86,14 +86,14 @@ struct gm_join {
 struct gm_sock {
 	int fd;
 	struct interface *interface;
-	struct in_addr ifaddr;
+	pim_addr ifaddr;
 	time_t sock_creation;
 
 	struct thread *t_igmp_read; /* read: IGMP sockets */
 	struct thread
 		*t_igmp_query_timer; /* timer: issue IGMP general queries */
 	struct thread *t_other_querier_timer; /* timer: other querier present */
-	pim_addr querier_addr;	 /* IP address of the querier */
+	pim_addr querier_addr;		      /* IP address of the querier */
 	int querier_query_interval;	   /* QQI */
 	int querier_robustness_variable; /* QRV */
 	int startup_query_count;

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -140,7 +140,7 @@ int igmp_validate_checksum(char *igmp_msg, int igmp_msg_len);
 #define IGMP_SOURCE_DONT_SEND(flags)       ((flags) &= ~IGMP_SOURCE_MASK_SEND)
 
 struct gm_source {
-	struct in_addr source_addr;
+	pim_addr source_addr;
 	struct thread *t_source_timer;
 	struct gm_group *source_group; /* back pointer */
 	time_t source_creation;

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -175,8 +175,7 @@ struct gm_group {
 
 	/* compatibility mode - igmp v1, v2 or v3 */
 	int igmp_version;
-
-	struct in_addr group_addr;
+	pim_addr group_addr;
 	int group_filtermode_isexcl;    /* 0=INCLUDE, 1=EXCLUDE */
 	struct list *group_source_list; /* list of struct gm_source */
 	time_t group_creation;

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -93,7 +93,7 @@ struct gm_sock {
 	struct thread
 		*t_igmp_query_timer; /* timer: issue IGMP general queries */
 	struct thread *t_other_querier_timer; /* timer: other querier present */
-	struct in_addr querier_addr;	  /* IP address of the querier */
+	pim_addr querier_addr;	 /* IP address of the querier */
 	int querier_query_interval;	   /* QQI */
 	int querier_robustness_variable; /* QRV */
 	int startup_query_count;

--- a/pimd/pim_jp_agg.h
+++ b/pimd/pim_jp_agg.h
@@ -26,7 +26,7 @@ struct pim_jp_sources {
 };
 
 struct pim_jp_agg_group {
-	struct in_addr group;
+	pim_addr group;
 	struct list *sources;
 };
 

--- a/pimd/pim_macro.c
+++ b/pimd/pim_macro.c
@@ -261,7 +261,7 @@ int pim_macro_ch_could_assert_eval(const struct pim_ifchannel *ch)
     }
 */
 struct pim_assert_metric pim_macro_spt_assert_metric(const struct pim_rpf *rpf,
-						     struct in_addr ifaddr)
+						     pim_addr ifaddr)
 {
 	struct pim_assert_metric metric;
 

--- a/pimd/pim_macro.h
+++ b/pimd/pim_macro.h
@@ -33,7 +33,7 @@ int pim_macro_chisin_pim_include(const struct pim_ifchannel *ch);
 int pim_macro_chisin_joins_or_include(const struct pim_ifchannel *ch);
 int pim_macro_ch_could_assert_eval(const struct pim_ifchannel *ch);
 struct pim_assert_metric pim_macro_spt_assert_metric(const struct pim_rpf *rpf,
-						     struct in_addr ifaddr);
+						     pim_addr ifaddr);
 struct pim_assert_metric
 pim_macro_ch_my_assert_metric_eval(const struct pim_ifchannel *ch);
 int pim_macro_chisin_oiflist(const struct pim_ifchannel *ch);

--- a/pimd/pim_neighbor.h
+++ b/pimd/pim_neighbor.h
@@ -28,10 +28,11 @@
 
 #include "pim_tlv.h"
 #include "pim_iface.h"
+#include "pim_str.h"
 
 struct pim_neighbor {
 	int64_t creation; /* timestamp of creation */
-	struct in_addr source_addr;
+	pim_addr source_addr;
 	pim_hello_options hello_options;
 	uint16_t holdtime;
 	uint16_t propagation_delay_msec;

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -570,8 +570,8 @@ static int pim_msg_send_frame(int fd, char *buf, size_t len,
 	return 0;
 }
 
-int pim_msg_send(int fd, struct in_addr src, struct in_addr dst,
-		 uint8_t *pim_msg, int pim_msg_size, const char *ifname)
+int pim_msg_send(int fd, pim_addr src, struct in_addr dst, uint8_t *pim_msg,
+		 int pim_msg_size, const char *ifname)
 {
 	struct sockaddr_in to;
 	socklen_t tolen;

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -21,6 +21,7 @@
 #define PIM_RPF_H
 
 #include <zebra.h>
+#include "pim_str.h"
 
 /*
   RFC 4601:
@@ -35,7 +36,7 @@
     units applicable to the unicast routing protocol used.
 */
 struct pim_nexthop {
-	struct in_addr last_lookup;
+	pim_addr last_lookup;
 	long long last_lookup_time;
 	struct interface *interface;     /* RPF_interface(S) */
 	struct prefix mrib_nexthop_addr; /* MRIB.next_hop(S) */

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -39,6 +39,21 @@ typedef struct in_addr pim_addr;
 #define pim_inet4_dump prefix_mcast_inet4_dump
 #define pim_str_sg_set prefix_sg2str
 
+static inline void pim_addr_copy(pim_addr *dest, pim_addr *source)
+{
+	dest->s_addr = source->s_addr;
+}
+
+static inline int pim_is_addr_any(pim_addr addr)
+{
+	return (addr.s_addr == INADDR_ANY);
+}
+
+static inline int pim_addr_cmp(pim_addr addr1, pim_addr addr2)
+{
+	return IPV4_ADDR_CMP(&addr1, &addr2);
+}
+
 void pim_addr_dump(const char *onfail, struct prefix *p, char *buf,
 		   int buf_size);
 void pim_inet4_dump(const char *onfail, struct in_addr addr, char *buf,

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -26,6 +26,8 @@
 
 #include <prefix.h>
 
+typedef struct in_addr pim_addr;
+
 /*
  * Longest possible length of a (S,G) string is 36 bytes
  * 123.123.123.123 = 16 * 2

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -229,8 +229,8 @@ struct pim_upstream {
 	struct pim_instance *pim;
 	struct rb_pim_upstream_item upstream_rb;
 	struct pim_upstream *parent;
-	struct in_addr upstream_addr;     /* Who we are talking to */
-	struct in_addr upstream_register; /*Who we received a register from*/
+	pim_addr upstream_addr;		  /* Who we are talking to */
+	pim_addr upstream_register;       /*Who we received a register from*/
 	struct prefix_sg sg;		  /* (S,G) group key */
 	char sg_str[PIM_SG_LEN];
 	uint32_t flags;


### PR DESCRIPTION
PIM_ADDR will be controlled at compile time for IPv4 and IPv6.
in_addr and in6_addr will be compiled for the respective daemons.
Added few macros to access some common addresses.

Please refer https://github.com/FRRouting/frr/pull/10194 for the pimv6
compilation stuff.
pim_str.h will be included only for pimv4 compilation.

Issue: #10023 
Co-authored-by: Sarita Patra <saritap@vmware.com>
Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>