### PR TITLE
bgpd: fix BGP ORF Prefix-length matching

### DIFF
--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1480,9 +1480,9 @@ int prefix_bgp_orf_set(char *name, afi_t afi, struct orf_prefix *orfp,
 	struct prefix_list_entry *pentry;
 
 	/* ge and le value check */
-	if (orfp->ge && orfp->ge <= orfp->p.prefixlen)
+	if (orfp->ge && orfp->ge < orfp->p.prefixlen)
 		return CMD_WARNING_CONFIG_FAILED;
-	if (orfp->le && orfp->le <= orfp->p.prefixlen)
+	if (orfp->le && orfp->le < orfp->p.prefixlen)
 		return CMD_WARNING_CONFIG_FAILED;
 	if (orfp->le && orfp->ge > orfp->le)
 		return CMD_WARNING_CONFIG_FAILED;


### PR DESCRIPTION
BGP ORF Prefix list incorrectly rejected list with a GE or LE to match the actual
prefix.

A prefix list like 
```
ip prefix-list test-orf seq 20 deny 10.0.0.0/8 ge 8 le 24
```
was incorrectly rejected (`/8 ge 8` and `/24 le 24` should be allowed)

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>