### PR TITLE
configure.ac: drop --enable-pcep option and HAVE_PATHD_PCEP 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -693,8 +693,6 @@ AC_ARG_ENABLE([pcreposix],
   AS_HELP_STRING([--enable-pcreposix], [enable using PCRE Posix libs for regex functions]))
 AC_ARG_ENABLE([fpm],
   AS_HELP_STRING([--enable-fpm], [enable Forwarding Plane Manager support]))
-AC_ARG_ENABLE([pcep],
-  AS_HELP_STRING([--enable-pcep], [enable PCEP support for pathd]))
 AC_ARG_ENABLE([werror],
   AS_HELP_STRING([--enable-werror], [enable -Werror (recommended for developers only)]))
 AC_ARG_ENABLE([cumulus],
@@ -1747,7 +1745,6 @@ fi
 
 AS_IF([test "$enable_pathd" != "no"], [
   AC_DEFINE([HAVE_PATHD], [1], [pathd])
-  AC_DEFINE([HAVE_PATHD_PCEP], [1], [pathd-pcep])
 ])
 
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1184,7 +1184,6 @@ static struct cmd_node srte_candidate_dyn_node = {
 	.prompt = "%s(config-sr-te-candidate)# ",
 };
 
-#if defined(HAVE_PATHD_PCEP)
 static struct cmd_node pcep_node = {
 	.name = "srte pcep",
 	.node = PCEP_NODE,
@@ -1212,7 +1211,6 @@ static struct cmd_node pcep_pce_config_node = {
 	.parent_node = PCEP_NODE,
 	.prompt = "%s(pcep-sr-te-pcep-pce-config)# ",
 };
-#endif /* HAVE_PATHD_PCEP */
 #endif /* HAVE_PATHD */
 
 static struct cmd_node vrf_node = {
@@ -2105,8 +2103,6 @@ DEFUNSH(VTYSH_PATHD, srte_policy_candidate_dyn_path,
 	return CMD_SUCCESS;
 }
 
-#if defined(HAVE_PATHD_PCEP)
-
 DEFUNSH(VTYSH_PATHD, pcep, pcep_cmd,
 	"pcep",
 	"Configure SR pcep\n")
@@ -2140,8 +2136,6 @@ DEFUNSH(VTYSH_PATHD, pcep_cli_pcep_pce_config, pcep_cli_pcep_pce_config_cmd,
 	vty->node = PCEP_PCE_CONFIG_NODE;
 	return CMD_SUCCESS;
 }
-
-#endif /* HAVE_PATHD_PCEP */
 
 #endif /* HAVE_PATHD */
 
@@ -4317,7 +4311,6 @@ void vtysh_init_vty(void)
 	install_element(SR_TRAFFIC_ENG_NODE, &srte_policy_cmd);
 	install_element(SR_POLICY_NODE, &srte_policy_candidate_dyn_path_cmd);
 
-#if defined(HAVE_PATHD_PCEP)
 	install_node(&pcep_node);
 	install_node(&pcep_pcc_node);
 	install_node(&pcep_pce_node);
@@ -4341,7 +4334,6 @@ void vtysh_init_vty(void)
 	install_element(PCEP_NODE, &pcep_cli_pcc_cmd);
 	install_element(PCEP_NODE, &pcep_cli_pcep_pce_config_cmd);
 	install_element(PCEP_NODE, &pcep_cli_pce_cmd);
-#endif /* HAVE_PATHD_PCEP */
 
 #endif /* HAVE_PATHD */
 


### PR DESCRIPTION
Drop `--enable-pcep` option and `HAVE_PATHD_PCEP` which does nothing since https://github.com/FRRouting/frr/commit/749714731ee9a59ae39be77e7db3915ce3ad0bd8

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>