### PR TITLE
pimd: When the igmp version changes from v2 to v3, the mroute for IGMPv3 group getting created and deleted.

### DIFF
--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -248,11 +248,11 @@ void igmp_send_query(int igmp_version, struct gm_group *group, char *query_buf,
 void igmp_group_delete(struct gm_group *group);
 
 void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver);
+void pim_if_igmp_version_change(struct interface *ifp);
 
 #else /* PIM_IPV != 4 */
 static inline void igmp_startup_mode_on(struct gm_sock *igmp)
 {
 }
 #endif /* PIM_IPV != 4 */
-
 #endif /* PIM_IGMP_H */

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -22,6 +22,7 @@
 #include "pimd.h"
 #include "pim_nb.h"
 #include "lib/northbound_cli.h"
+#include "pim_igmp.h"
 #include "pim_igmpv3.h"
 #include "pim_neighbor.h"
 #include "pim_pim.h"
@@ -2640,8 +2641,9 @@ int lib_interface_gmp_address_family_igmp_version_modify(
 		/* Current and new version is different refresh existing
 		 * membership. Going from 3 -> 2 or 2 -> 3.
 		 */
-		if (old_version != igmp_version)
+		if (old_version != igmp_version) {
 			pim_if_membership_refresh(ifp);
+		}
 
 		break;
 	}

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2666,6 +2666,11 @@ int lib_interface_gmp_address_family_igmp_version_destroy(
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
 		pim_ifp->igmp_version = IGMP_DEFAULT_VERSION;
+#if PIM_IPV == 4
+		int igmp_version = yang_dnode_get_uint8(args->dnode, NULL);
+		if (igmp_version == 2)
+			pim_if_igmp_version_change(ifp);
+#endif
 		break;
 	}
 

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -457,8 +457,9 @@ static int pim_sock_open(struct interface *ifp)
 	if (fd < 0)
 		return -1;
 
-	if (pim_socket_join(fd, qpim_all_pim_routers_addr,
-			    pim_ifp->primary_address, ifp->ifindex, pim_ifp)) {
+	if (pim_socket_join_or_leave(fd, qpim_all_pim_routers_addr,
+				     pim_ifp->primary_address, ifp->ifindex,
+				     pim_ifp, IP_ADD_MEMBERSHIP)) {
 		close(fd);
 		return -2;
 	}

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -451,15 +451,22 @@ static int pim_sock_open(struct interface *ifp)
 {
 	int fd;
 	struct pim_interface *pim_ifp = ifp->info;
+	int membership;
 
 	fd = pim_socket_mcast(IPPROTO_PIM, pim_ifp->primary_address, ifp,
 			      0 /* loop=false */);
 	if (fd < 0)
 		return -1;
 
+#if PIM_IPV == 4
+	membership = IP_ADD_MEMBERSHIP;
+#else
+	membership = IPV6_JOIN_GROUP;
+#endif
+
 	if (pim_socket_join_or_leave(fd, qpim_all_pim_routers_addr,
 				     pim_ifp->primary_address, ifp->ifindex,
-				     pim_ifp, IP_ADD_MEMBERSHIP)) {
+				     pim_ifp, membership)) {
 		close(fd);
 		return -2;
 	}

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -235,9 +235,9 @@ int pim_socket_mcast(int protocol, pim_addr ifaddr, struct interface *ifp,
 	return fd;
 }
 
-int pim_socket_join_or_leave(int fd, struct in_addr group,
-			     struct in_addr ifaddr, ifindex_t ifindex,
-			     struct pim_interface *pim_ifp, int membershipType)
+int pim_socket_join_or_leave(int fd, pim_addr group, pim_addr ifaddr,
+			     ifindex_t ifindex, struct pim_interface *pim_ifp,
+			     int membershipType)
 {
 	int ret;
 
@@ -249,7 +249,7 @@ int pim_socket_join_or_leave(int fd, struct in_addr group,
 
 	memcpy(&opt.ipv6mr_multiaddr, &group, 16);
 	opt.ipv6mr_interface = ifindex;
-	ret = setsockopt(fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, &opt, sizeof(opt));
+	ret = setsockopt(fd, IPPROTO_IPV6, membershipType, &opt, sizeof(opt));
 #endif
 
 	pim_ifp->igmp_ifstat_joins_sent++;

--- a/pimd/pim_sock.h
+++ b/pimd/pim_sock.h
@@ -42,8 +42,9 @@ void pim_socket_ip_hdr(int fd);
 int pim_socket_raw(int protocol);
 int pim_socket_mcast(int protocol, pim_addr ifaddr, struct interface *ifp,
 		     uint8_t loop);
-int pim_socket_join(int fd, pim_addr group, pim_addr ifaddr, ifindex_t ifindex,
-		    struct pim_interface *pim_ifp);
+int pim_socket_join_or_leave(int fd, struct in_addr group,
+			     struct in_addr ifaddr, ifindex_t ifindex,
+			     struct pim_interface *pim_ifp, int membershipType);
 int pim_socket_recvfromto(int fd, uint8_t *buf, size_t len,
 			  struct sockaddr_storage *from, socklen_t *fromlen,
 			  struct sockaddr_storage *to, socklen_t *tolen,

--- a/pimd/pim_sock.h
+++ b/pimd/pim_sock.h
@@ -42,9 +42,9 @@ void pim_socket_ip_hdr(int fd);
 int pim_socket_raw(int protocol);
 int pim_socket_mcast(int protocol, pim_addr ifaddr, struct interface *ifp,
 		     uint8_t loop);
-int pim_socket_join_or_leave(int fd, struct in_addr group,
-			     struct in_addr ifaddr, ifindex_t ifindex,
-			     struct pim_interface *pim_ifp, int membershipType);
+int pim_socket_join_or_leave(int fd, pim_addr group, pim_addr ifaddr,
+			     ifindex_t ifindex, struct pim_interface *pim_ifp,
+			     int membershipType);
 int pim_socket_recvfromto(int fd, uint8_t *buf, size_t len,
 			  struct sockaddr_storage *from, socklen_t *fromlen,
 			  struct sockaddr_storage *to, socklen_t *tolen,

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -57,7 +57,7 @@ CPP_NOTICE("Work needs to be done to make this work properly via the pim mroute 
 const char *const PIM_ALL_SYSTEMS = MCAST_ALL_SYSTEMS;
 const char *const PIM_ALL_ROUTERS = MCAST_ALL_ROUTERS;
 const char *const PIM_ALL_PIM_ROUTERS = MCAST_ALL_PIM_ROUTERS;
-const char *const PIM_ALL_IGMP_ROUTERS = MCAST_ALL_IGMP_ROUTERS;
+const char *const PIM_ALL_IGMP_ROUTERS = MCAST_ALL_IGMPV3_ROUTERS;
 #else
 const char *const PIM_ALL_SYSTEMS = "ff02::1";
 const char *const PIM_ALL_ROUTERS = "ff02::2";

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -77,7 +77,7 @@
 #define MCAST_ALL_SYSTEMS      "224.0.0.1"
 #define MCAST_ALL_ROUTERS      "224.0.0.2"
 #define MCAST_ALL_PIM_ROUTERS  "224.0.0.13"
-#define MCAST_ALL_IGMP_ROUTERS "224.0.0.22"
+#define MCAST_ALL_IGMPV3_ROUTERS "224.0.0.22"
 
 #define PIM_FORCE_BOOLEAN(expr) ((expr) != 0)
 


### PR DESCRIPTION
Router is in IGMPv2 mode, Host is in IGMPv3 mode.

Host sends Join for IGMPv3 Group, packet is accepted by router and mroute is created.
Then source timer for this group gets expired and then the mroute gets deleted.

If the router version is 2, router should not accept joins for IGMPv3 groups.
So remove multicast membership from the socket for IGMPv3 and 
When changing the igmp version from v2 to v3
router should accept the joins for multicast membership for IGMPv3
So add back the membership to the socket.

Signed-off-by: Sai Gomathi <nsaigomathi@vmware.com>