### PR TITLE
ospfd: delay ospf GR notice

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9728,7 +9728,7 @@ DEFUN (no_ospf_proactive_arp,
 	return CMD_SUCCESS;
 }
 
-#if CONFDATE > 20211209
+#if CONFDATE > 20220209
 CPP_NOTICE("Time to remove broken OSPF GR helper")
 #endif
 


### PR DESCRIPTION
The ospf GR issue may not get fixed during the holidays; extend the date on the build-time notice for a couple of months so it doesn't bug us all.
