### PR TITLE
SRv6 routes aren't inserted into data plane correctly with soft-reconfiguration

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -834,10 +834,6 @@ static void *bgp_attr_hash_alloc(void *p)
 	if (vnc_subtlvs)
 		bgp_attr_set_vnc_subtlvs(val, NULL);
 #endif
-	if (val->srv6_l3vpn)
-		val->srv6_l3vpn = NULL;
-	if (val->srv6_vpn)
-		val->srv6_vpn = NULL;
 
 	attr->refcnt = 0;
 	return attr;


### PR DESCRIPTION
### Summary

If soft-reconfiguration is enabled, bgp_adj_in_set will be called from bgp_update and bgp_adj_in_set will call bgp_attr_intern to intern attr pointer. If given attr isn't found in attrhash, hash_get will call bgp_attr_hash_alloc to allocate new attr structure. In bgp_attr_hash_alloc, NULL will be assigned to srv6_vpn field and srv6_l3vpn field in origin attr pointer. attr->srv6_vpn and attr->srv6_l3vpn are interned in bgp_attr_intern, so NULL assignment isn't needed.

And, these fields are used later in bgp_update to set SRv6 information to bgp_path_info. If bgp_attr_hash_alloc assigns NULL to these fields, SRv6 information will be lost and incorrect routes are inserted into the data plane.

### Components

bgpd

### Related Issue

**Before applying this PR**

Before applying this PR, we can check incorrect output for 10.0.2.0/24 (R2 advertises 10.0.2.0/24 with Prefix-SID Type-5, so it's not expected that sid_structure isn't shown up).

<img width="672" alt="Screen Shot 2021-12-17 at 1 06 55" src="https://user-images.githubusercontent.com/18246032/146408547-12fe57b9-c069-4e62-952e-9614e7965862.png">

After soft-configuring, we can check the correct output for 10.0.2.0/24.

<img width="673" alt="Screen Shot 2021-12-17 at 1 07 22" src="https://user-images.githubusercontent.com/18246032/146408557-1b33b492-edc0-47f6-a3a5-a2ecd66868ab.png">

**After applying this PR**

we can check the correct output for 10.0.2.0/24.

<img width="674" alt="Screen Shot 2021-12-17 at 0 04 39" src="https://user-images.githubusercontent.com/18246032/146408574-c586a73f-467a-4fb4-803d-4e9e4b094198.png">

#### Configuration

**R1**

```
frr defaults traditional
!
hostname r1.virtual
!
service integrated-vtysh-config
!
interface lo
 ipv6 address 2002:ac:1::/128
exit
!
interface eth0
 ipv6 address 2001:db8:1::2/64
exit
!
interface eth1 vrf vrf10
 ip address 10.0.1.254/24
exit
!
segment-routing
 srv6
  locators
   locator SRv6_Loc
    prefix 2002:ac:1::/64
   exit
   !
  exit
  !
 exit
 !
exit
!
ip forwarding
ipv6 forwarding
!
router bgp 7675
 bgp router-id 192.168.50.11
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 neighbor FABRIC peer-group
 neighbor FABRIC remote-as external
 neighbor FABRIC capability extended-nexthop
 neighbor FABRIC timers 3 9
 neighbor 2001:db8:1::3 peer-group FABRIC
 !
 segment-routing srv6
   locator SRv6_Loc
 exit
 !
 address-family ipv4 vpn
  neighbor FABRIC activate
  neighbor FABRIC soft-reconfiguration inbound
 exit-address-family
 !
 address-family ipv6 vpn
  neighbor FABRIC activate
 exit-address-family
 !
 address-family ipv6 unicast
  network 2002:ac:1::/64
  neighbor FABRIC activate
  redistribute connected
 exit-address-family
!
!
router bgp 7675 vrf vrf10
 address-family ipv4 unicast
  redistribute connected
  redistribute static
  sid vpn export auto
  nexthop vpn export 2002:ac:1::
  rd vpn export 1:10
  rt vpn both 99:99
  import vpn
  export vpn
 exit-address-family
!
ip route 10.0.3.0/24 blackhole vrf vrf10
ip route 10.0.5.0/24 blackhole vrf vrf10
```

**R2**

```
frr defaults traditional
!
hostname r2.virtual
!
service integrated-vtysh-config
!
interface lo
 ipv6 address 2002:ac:2::/128
exit
!
interface eth0
 ipv6 address 2001:db8:1::3/64
exit
!
interface eth1 vrf vrf10
 ip address 10.0.2.254/24
exit
!
segment-routing
 srv6
  locators
   locator SRv6_Loc
    prefix 2002:ac:2::/64
   exit
   !
  exit
  !
 exit
 !
exit
!
ip forwarding
ipv6 forwarding
!
router bgp 7676
 bgp router-id 192.168.50.12
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 neighbor FABRIC peer-group
 neighbor FABRIC remote-as external
 neighbor FABRIC capability extended-nexthop
 neighbor FABRIC timers 3 9
 neighbor 2001:db8:1::2  peer-group FABRIC
!
 segment-routing srv6
   locator SRv6_Loc
 exit
 !
 address-family ipv4 vpn
  neighbor FABRIC activate
 exit-address-family
!
 address-family ipv6 vpn
  neighbor FABRIC activate
 exit-address-family
!
 address-family ipv6 unicast
  network 2002:ac:2::/64
  neighbor FABRIC activate
  redistribute connected
 exit-address-family
!
!
router bgp 7676 vrf vrf10
 address-family ipv4 unicast
  redistribute connected
  redistribute static
  sid vpn export auto
  nexthop vpn export 2002:ac:2::
  rd vpn export 2:10
  rt vpn both 99:99
  import vpn
  export vpn
 exit-address-family
!
ip route 10.0.4.0/24 blackhole vrf vrf10
ip route 10.0.6.0/24 blackhole vrf vrf10
```
