### PR TITLE
configure.ac: fix enable_bmp typo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1806,7 +1806,7 @@ if test "$enable_bgp_vnc" != "no";then
 fi
 
 bgpd_bmp=false
-case "${enable_bmp}" in
+case "${enable_bgp_bmp}" in
   no)
     ;;
   yes)


### PR DESCRIPTION
`enable_bmp` doesn't exist, use `enable_bgp_bmp`

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>