### PR TITLE
zebra: fix handling return value of recvmsg function

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -813,7 +813,7 @@ static int netlink_recv_msg(const struct nlsock *nl, struct msghdr msg,
 
 	if (status == 0) {
 		flog_err_sys(EC_LIB_SOCKET, "%s EOF", nl->name);
-		return -1;
+		return 0;
 	}
 
 	if (msg.msg_namelen != sizeof(struct sockaddr_nl)) {


### PR DESCRIPTION
Just like other places calling recvmsg function:
If it returns 0(meaning EOF), we should no longer try.

Signed-off-by: anlancs <anlan_cs@tom.com>