### PR TITLE
bgpd: Make sure withdraws are generated regardless of MRAI.

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -157,7 +157,7 @@ static int bgp_process_writes(struct thread *thread)
 	if (reschedule) {
 		thread_add_write(fpt->master, bgp_process_writes, peer,
 				 peer->fd, &peer->t_write);
-	} else if (!fatal) {
+	} else if (!fatal && !peer->t_routeadv) {
 		BGP_UPDATE_GROUP_TIMER_ON(&peer->t_generate_updgrp_packets,
 					  bgp_generate_updgrp_packets);
 	}

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -413,9 +413,6 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 	    || bgp_update_delay_active(peer->bgp))
 		return 0;
 
-	if (peer->t_routeadv)
-		return 0;
-
 	do {
 		enum bgp_af_index index;
 


### PR DESCRIPTION
Withdraws are delayed when the t_routeadv timer is set. It is unexpected because traffic should be drained from unusable paths as soon as possible.

This commit moves the `t_routeadv` presence check from `bgp_generate_updgrp_packets` to `bgp_process_writes`. It would only be checked when outQ is clear.