### PR TITLE
vtysh: enter wrong node when execute command on parent node

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -601,8 +601,7 @@ vector completions_to_vec(struct list *completions)
  * @param status pointer to matcher status code
  * @return vector of struct cmd_token * with possible completions
  */
-static vector cmd_complete_command_real(vector vline, struct vty *vty,
-					int *status)
+vector cmd_complete_command_real(vector vline, struct vty *vty, int *status)
 {
 	struct list *completions;
 	struct graph *cmdgraph = cmd_node_graph(cmdvec, vty->node);

--- a/lib/command.h
+++ b/lib/command.h
@@ -555,6 +555,7 @@ extern int argv_find(struct cmd_token **argv, int argc, const char *text,
 extern vector cmd_make_strvec(const char *);
 extern void cmd_free_strvec(vector);
 extern vector cmd_describe_command(vector, struct vty *, int *status);
+vector cmd_complete_command_real(vector vline, struct vty *vty, int *status);
 extern char **cmd_complete_command(vector, struct vty *, int *status);
 extern const char *cmd_prompt(enum node_type);
 extern int command_config_read_one_line(struct vty *vty,


### PR DESCRIPTION
when vtysh, execute command and can't find the command on current node, it try to execute that on the parent node. If the command change vty node(like interface command), vtysh goes to config node wrongly. this is so bad in apply batch configurations (that commonly used by many of users) that cause miss configuration.

to clarify this bug assume vtysh is in `interface eth0` node and user run `interface eth1` command we expect vty->node change to `interface eth1` node but:

```
(config)# interface eth0
(config-if)# ip address 192.168.1.1/24
(config-if)# interface eth1
(config)# ip address 192.168.2.1/24
% Unknown command: ip address 192.168.2.1/24
(config)#
```

this PR fix this issue by executing command after evaluate that command exist on parent node or no.