### PR TITLE
bgpd: No need to test if a thread is running for BGP_TIMER_OFF

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -509,8 +509,7 @@ static int bgp_connect_timer(struct thread *thread)
 	peer = THREAD_ARG(thread);
 
 	/* stop the DelayOpenTimer if it is running */
-	if (peer->t_delayopen)
-		BGP_TIMER_OFF(peer->t_delayopen);
+	BGP_TIMER_OFF(peer->t_delayopen);
 
 	assert(!peer->t_write);
 	assert(!peer->t_read);
@@ -830,8 +829,7 @@ void bgp_adjust_routeadv(struct peer *peer)
 		 * different
 		 * duration and schedule write thread immediately.
 		 */
-		if (peer->t_routeadv)
-			BGP_TIMER_OFF(peer->t_routeadv);
+		BGP_TIMER_OFF(peer->t_routeadv);
 
 		peer->synctime = bgp_clock();
 		/* If suppress fib pending is enabled, route is advertised to

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7876,8 +7876,7 @@ void bgp_terminate(void)
 				bgp_notify_send(peer, BGP_NOTIFY_CEASE,
 						BGP_NOTIFY_CEASE_PEER_UNCONFIG);
 
-	if (bm->t_rmap_update)
-		BGP_TIMER_OFF(bm->t_rmap_update);
+	BGP_TIMER_OFF(bm->t_rmap_update);
 
 	bgp_mac_finish();
 }


### PR DESCRIPTION
Handles that inside the macro.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>