### PR TITLE
ospf6d: clean coverity warning of possible null pointer

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -451,6 +451,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		/* Do not generate if area is NSSA */
 		route_area =
 			ospf6_area_lookup(route->path.area_id, area->ospf6);
+		assert(route_area);
+
 		if (IS_AREA_NSSA(route_area)) {
 			if (is_debug)
 				zlog_debug(


### PR DESCRIPTION
ospf6d: clean coverity warning of possible null pointer

Add assert to protect it.

Signed-off-by: anlan_cs <anlan_cs@tom.com>