### PR TITLE
bgpd: Implement LLGR helper mode

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -606,8 +606,15 @@ static int bgp_capability_llgr(struct peer *peer,
 					peer->host, iana_afi2str(pkt_afi),
 					iana_safi2str(pkt_safi));
 		} else {
+			if (bgp_debug_neighbor_events(peer))
+				zlog_debug(
+					"%s Addr-family %s/%s(afi/safi) Long-lived Graceful Restart capability stale time %u sec",
+					peer->host, iana_afi2str(pkt_afi),
+					iana_safi2str(pkt_safi), stale_time);
+
 			peer->llgr[afi][safi].flags = flags;
-			peer->llgr[afi][safi].stale_time = stale_time;
+			peer->llgr[afi][safi].stale_time =
+				MIN(stale_time, peer->bgp->llgr_stale_time);
 			SET_FLAG(peer->af_cap[afi][safi], PEER_CAP_LLGR_AF_RCV);
 		}
 	}

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1869,11 +1869,11 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			if (peer->nsf[afi][safi])
 				bgp_clear_stale_route(peer, afi, safi);
 
-                        zlog_info(
-                            "%s: rcvd End-of-RIB for %s from %s in vrf %s",
-                            __func__, get_afi_safi_str(afi, safi, false),
-                            peer->host, vrf ? vrf->name : VRF_DEFAULT_NAME);
-                }
+			zlog_info(
+				"%s: rcvd End-of-RIB for %s from %s in vrf %s",
+				__func__, get_afi_safi_str(afi, safi, false),
+				peer->host, vrf ? vrf->name : VRF_DEFAULT_NAME);
+		}
 	}
 
 	/* Everything is done.  We unintern temporary structures which

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -802,6 +802,7 @@ extern int bgp_path_info_cmp_compatible(struct bgp *bgp,
 					struct bgp_path_info *exist,
 					char *pfx_buf, afi_t afi, safi_t safi,
 					enum bgp_path_selection_reason *reason);
+extern void bgp_attr_add_llgr_community(struct attr *attr);
 extern void bgp_attr_add_gshut_community(struct attr *attr);
 
 extern void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3163,7 +3163,8 @@ DEFUN (no_bgp_graceful_restart_rib_stale_time,
 }
 
 DEFUN(bgp_llgr_stalepath_time, bgp_llgr_stalepath_time_cmd,
-      "bgp long-lived-graceful-restart stale-time (0-4294967295)", BGP_STR
+      "bgp long-lived-graceful-restart stale-time (1-4294967295)",
+      BGP_STR
       "Enable Long-lived Graceful Restart\n"
       "Specifies maximum time to wait before purging long-lived stale routes\n"
       "Stale time value (seconds)\n")
@@ -3179,7 +3180,7 @@ DEFUN(bgp_llgr_stalepath_time, bgp_llgr_stalepath_time_cmd,
 }
 
 DEFUN(no_bgp_llgr_stalepath_time, no_bgp_llgr_stalepath_time_cmd,
-      "no bgp long-lived-graceful-restart stale-time [(0-4294967295)]",
+      "no bgp long-lived-graceful-restart stale-time [(1-4294967295)]",
       NO_STR BGP_STR
       "Enable Long-lived Graceful Restart\n"
       "Specifies maximum time to wait before purging long-lived stale routes\n"

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1656,8 +1656,7 @@ void bgp_peer_conf_if_to_su_update(struct peer *peer)
 	hash_get(peer->bgp->peerhash, peer, hash_alloc_intern);
 }
 
-static void bgp_recalculate_afi_safi_bestpaths(struct bgp *bgp, afi_t afi,
-					       safi_t safi)
+void bgp_recalculate_afi_safi_bestpaths(struct bgp *bgp, afi_t afi, safi_t safi)
 {
 	struct bgp_dest *dest, *ndest;
 	struct bgp_table *table;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1885,7 +1885,7 @@ struct bgp_nlri {
 #define BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME  1
 
 /* BGP Long-lived Graceful Restart */
-#define BGP_DEFAULT_LLGR_STALE_TIME 360
+#define BGP_DEFAULT_LLGR_STALE_TIME 0
 
 /* BGP uptime string length.  */
 #define BGP_UPTIME_LEN 25

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1402,6 +1402,8 @@ struct peer {
 #define PEER_STATUS_BORR_RECEIVED (1U << 8) /* BoRR received from peer */
 #define PEER_STATUS_EORR_SEND (1U << 9) /* EoRR send to peer */
 #define PEER_STATUS_EORR_RECEIVED (1U << 10) /* EoRR received from peer */
+/* LLGR aware peer */
+#define PEER_STATUS_LLGR_WAIT (1U << 11)
 
 	/* Configured timer values. */
 	_Atomic uint32_t holdtime;
@@ -1433,6 +1435,7 @@ struct peer {
 	struct thread *t_pmax_restart;
 	struct thread *t_gr_restart;
 	struct thread *t_gr_stale;
+	struct thread *t_llgr_stale[AFI_MAX][SAFI_MAX];
 	struct thread *t_generate_updgrp_packets;
 	struct thread *t_process_packet;
 	struct thread *t_process_packet_error;
@@ -2473,4 +2476,7 @@ void peer_nsf_stop(struct peer *peer);
 
 void peer_tcp_mss_set(struct peer *peer, uint32_t tcp_mss);
 void peer_tcp_mss_unset(struct peer *peer);
+
+extern void bgp_recalculate_afi_safi_bestpaths(struct bgp *bgp, afi_t afi,
+					       safi_t safi);
 #endif /* _QUAGGA_BGPD_H */

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -995,11 +995,13 @@ Long-lived Graceful Restart
 Currently, only restarter mode is supported. This capability is advertised only
 if graceful restart capability is negotiated.
 
-.. clicmd:: bgp long-lived-graceful-restart stale-time (0-4294967295)
+.. clicmd:: bgp long-lived-graceful-restart stale-time (1-4294967295)
 
    Specifies the maximum time to wait before purging long-lived stale routes for
    helper routers.
 
+   Default is 0, which means the feature is off by default. Only graceful
+   restart takes into account.
 
 .. _bgp-shutdown:
 

--- a/tests/topotests/bgp_llgr/r0/bgpd.conf
+++ b/tests/topotests/bgp_llgr/r0/bgpd.conf
@@ -1,0 +1,10 @@
+router bgp 65000
+ no bgp ebgp-requires-policy
+ bgp graceful-restart
+ bgp graceful-restart restart-time 1
+ bgp long-lived-graceful-restart stale-time 20
+ neighbor 192.168.0.2 remote-as external
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/bgp_llgr/r0/zebra.conf
+++ b/tests/topotests/bgp_llgr/r0/zebra.conf
@@ -1,0 +1,7 @@
+!
+int lo
+ ip address 172.16.1.1/32
+!
+int r0-eth0
+ ip address 192.168.0.1/24
+!

--- a/tests/topotests/bgp_llgr/r1/bgpd.conf
+++ b/tests/topotests/bgp_llgr/r1/bgpd.conf
@@ -1,0 +1,10 @@
+router bgp 65001
+ no bgp ebgp-requires-policy
+ bgp graceful-restart
+ bgp graceful-restart restart-time 1
+ bgp long-lived-graceful-restart stale-time 20
+ neighbor 192.168.1.2 remote-as external
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/bgp_llgr/r1/zebra.conf
+++ b/tests/topotests/bgp_llgr/r1/zebra.conf
@@ -1,0 +1,7 @@
+!
+int lo
+ ip address 172.16.1.1/32
+!
+int r1-eth0
+ ip address 192.168.1.1/24
+!

--- a/tests/topotests/bgp_llgr/r2/bgpd.conf
+++ b/tests/topotests/bgp_llgr/r2/bgpd.conf
@@ -1,0 +1,9 @@
+router bgp 65002
+ no bgp ebgp-requires-policy
+ bgp graceful-restart
+ bgp long-lived-graceful-restart stale-time 20
+ neighbor 192.168.0.1 remote-as external
+ neighbor 192.168.1.1 remote-as external
+ neighbor 192.168.2.1 remote-as external
+ address-family ipv4 unicast
+   neighbor 192.168.1.1 weight 100

--- a/tests/topotests/bgp_llgr/r2/zebra.conf
+++ b/tests/topotests/bgp_llgr/r2/zebra.conf
@@ -1,0 +1,10 @@
+!
+int r2-eth0
+ ip address 192.168.0.2/24
+!
+int r2-eth1
+ ip address 192.168.1.2/24
+!
+int r2-eth2
+ ip address 192.168.2.2/24
+!

--- a/tests/topotests/bgp_llgr/r3/bgpd.conf
+++ b/tests/topotests/bgp_llgr/r3/bgpd.conf
@@ -1,0 +1,6 @@
+router bgp 65003
+ bgp router-id 192.168.2.1
+ no bgp ebgp-requires-policy
+ bgp graceful-restart
+ bgp long-lived-graceful-restart stale-time 20
+ neighbor 192.168.2.2 remote-as external

--- a/tests/topotests/bgp_llgr/r3/zebra.conf
+++ b/tests/topotests/bgp_llgr/r3/zebra.conf
@@ -1,0 +1,4 @@
+!
+int r3-eth0
+ ip address 192.168.2.1/24
+!

--- a/tests/topotests/bgp_llgr/test_bgp_llgr.py
+++ b/tests/topotests/bgp_llgr/test_bgp_llgr.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2021 by
+# Donatas Abraitis <donatas.abraitis@gmail.com>
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+Test if BGP Long-lived Graceful Restart capability works:
+    Check if we can see 172.16.1.1/32 after initial converge in R3.
+    Check if we can see 172.16.1.1/32 as best selected due to higher weigth in R2.
+    Kill bgpd in R1.
+    Check if we can see 172.16.1.1/32 as stale in R2.
+    Check if we can see 172.16.1.1/32 depreferenced due to LLGR_STALE in R2.
+    Check if we can see 172.16.1.1/32 after R1 was killed in R3.
+"""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+pytestmark = [pytest.mark.bgpd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+from lib.common_config import (
+    kill_router_daemons,
+    start_router_daemons,
+    step,
+)
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    for routern in range(0, 5):
+        tgen.add_router("r{}".format(routern))
+
+    switch = tgen.add_switch("s0")
+    switch.add_link(tgen.gears["r0"])
+    switch.add_link(tgen.gears["r2"])
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_llgr():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+    r3 = tgen.gears["r3"]
+
+    def _bgp_converge(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp json"))
+        expected = {
+            "routes": {
+                "172.16.1.1/32": [{"nexthops": [{"ip": "192.168.2.2", "used": True}]}]
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    step("Check if we can see 172.16.1.1/32 after initial converge in R3")
+    test_func = functools.partial(_bgp_converge, r3)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Cannot see 172.16.1.1/32 in r3"
+
+    def _bgp_weight_prefered_route(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp 172.16.1.1/32 json"))
+        expected = {
+            "paths": [
+                {
+                    "bestpath": {"selectionReason": "Weight"},
+                    "nexthops": [
+                        {
+                            "ip": "192.168.1.1",
+                        }
+                    ],
+                }
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    step(
+        "Check if we can see 172.16.1.1/32 as best selected due to higher weigth in R2"
+    )
+    test_func = functools.partial(_bgp_weight_prefered_route, r2)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert (
+        result is None
+    ), "Prefix 172.16.1.1/32 is not selected as bests path due to weight"
+
+    step("Kill bgpd in R1")
+    kill_router_daemons(tgen, "r1", ["bgpd"])
+
+    def _bgp_stale_route(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp 172.16.1.1/32 json"))
+        expected = {"paths": [{"community": {"string": "llgr-stale"}, "stale": True}]}
+        return topotest.json_cmp(output, expected)
+
+    step("Check if we can see 172.16.1.1/32 as stale in R2")
+    test_func = functools.partial(_bgp_stale_route, r2)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Prefix 172.16.1.1/32 is not stale"
+
+    def _bgp_llgr_depreference_route(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp 172.16.1.1/32 json"))
+        expected = {
+            "paths": [
+                {
+                    "bestpath": {"selectionReason": "First path received"},
+                    "nexthops": [
+                        {
+                            "ip": "192.168.0.1",
+                        }
+                    ],
+                }
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    step("Check if we can see 172.16.1.1/32 depreferenced due to LLGR_STALE in R2")
+    test_func = functools.partial(_bgp_llgr_depreference_route, r2)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Prefix 172.16.1.1/32 is not depreferenced due to LLGR_STALE"
+
+    step("Check if we can see 172.16.1.1/32 after R1 was killed in R3")
+    test_func = functools.partial(_bgp_converge, r3)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Cannot see 172.16.1.1/32 in r3"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Tested between GoBGP and FRR (this commit).

```
┌───────────┐             ┌────────────┐
│           │             │            │
│ GoBGPD    │             │ FRRouting  │
│ (restart) │             │            │
│           │             │            │
└──────┬────┘             └───────┬────┘
       │                          │
       │                          │
       │                          │
       │     ┌───────────┐        │
       │     │           │        │
       │     │           │        │
       └─────┤ FRRouting ├────────┘
             │ (helper)  │
             │           │
             └───────────┘

// GoBGPD
% cat /etc/gobgp/config.toml
[global.config]
    as = 65002
    router-id = "2.2.2.2"
    port = 179

[[neighbors]]
    [neighbors.config]
        peer-as = 65001
        neighbor-address = "2a02:abc::123"
    [neighbors.graceful-restart.config]
        enabled = true
        restart-time = 3
        long-lived-enabled = true
    [[neighbors.afi-safis]]
        [neighbors.afi-safis.config]
            afi-safi-name = "ipv6-unicast"
        [neighbors.afi-safis.mp-graceful-restart.config]
            enabled = true
        [neighbors.afi-safis.long-lived-graceful-restart.config]
            enabled = true
            restart-time = 10
    [[neighbors.afi-safis]]
        [neighbors.afi-safis.config]
            afi-safi-name = "ipv4-unicast"
        [neighbors.afi-safis.mp-graceful-restart.config]
            enabled = true
        [neighbors.afi-safis.long-lived-graceful-restart.config]
            enabled = true
            restart-time = 20

% ./gobgp global rib add -a ipv6 2001:db8:4::/64
% ./gobgp global rib add -a ipv6 2001:db8:5::/64 community 65535:7
% ./gobgp global rib add -a ipv4 100.100.100.100/32
% ./gobgp global rib add -a ipv4 100.100.100.200/32 community 65535:7
```

1. When killing GoBGPD, graceful restart timer starts in FRR helper router;
2. When GR timer expires in helper router:
   a) LLGR_STALE community is attached to routes to be retained;
   b) Clear stale routes that have NO_LLGR community attached;
   c) Start LLGR timer per AFI/SAFI;
   d) Recompute bestpath and reannounce routes to peers;
   d) When LLGR timer expires, clear all routes on particular AFI/SAFI.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

Fixes https://github.com/FRRouting/frr/issues/3571