### PR TITLE
bgpd: fix aggregate route unsuppression bug

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7561,15 +7561,14 @@ void bgp_aggregate_delete(struct bgp *bgp, const struct prefix *p, afi_t afi,
 			if (pi->sub_type == BGP_ROUTE_AGGREGATE)
 				continue;
 
-			if (aggregate->summary_only && pi->extra
-			    && AGGREGATE_MED_VALID(aggregate)) {
-				if (aggr_unsuppress_path(aggregate, pi))
-					match++;
-			}
-
-			if (aggregate->suppress_map_name
-			    && AGGREGATE_MED_VALID(aggregate)
-			    && aggr_suppress_map_test(bgp, aggregate, pi)) {
+			/*
+			 * This route is suppressed: attempt to unsuppress it.
+			 *
+			 * `aggr_unsuppress_path` will fail if this particular
+			 * aggregate route was not the suppressor.
+			 */
+			if (pi->extra && pi->extra->aggr_suppressors &&
+			    listcount(pi->extra->aggr_suppressors)) {
 				if (aggr_unsuppress_path(aggregate, pi))
 					match++;
 			}


### PR DESCRIPTION
Issue
---

There is a race when an `aggregate-address` with `suppress-map` configured is removed right after a `route-map` removal: the suppressed route never comes back again. This happens because the route-map update timer is scheduled for after the actual aggregation removal.

When the CLI calls the aggregate route removal function the suppressed route will never meet the condition to remove the suppression:

```
void bgp_aggregate_delete(struct bgp *bgp, const struct prefix *p, afi_t afi,
			  safi_t safi, struct bgp_aggregate *aggregate)
{
//...
			if (aggregate->suppress_map_name
			    && AGGREGATE_MED_VALID(aggregate)
			    && aggr_suppress_map_test(bgp, aggregate, pi)) {
				if (aggr_unsuppress_path(aggregate, pi))
					match++;
			}
//...
}
```

Because the route-map configuration is no longer there.

My proposed solution is to simplify the unsuppression by just checking if the route was suppressed by the current aggregation route. The double check is unnecessary:

```
			if (aggregate->summary_only && pi->extra
			    && AGGREGATE_MED_VALID(aggregate)) {}
			if (aggregate->suppress_map_name
			    && AGGREGATE_MED_VALID(aggregate)
			    && aggr_suppress_map_test(bgp, aggregate, pi)) {}
```

Since `summary-only` and `suppress-map` are mutually exclusive.

This bug was found using `frr-reload` to remove both simultaneously.


Steps to Reproduce
---

1. Configure prefix list to select an address:

   ```
   ip prefix-list pl-sup-100 permit 192.168.100.0/24
   ```

2. Configure route-map to match and permit the above prefix list:

   ```
   route-map rm-sup-100 permit 10
    match ip address prefix-list pl-sup-100
   !
   ```

3. Configure a static route and the matching aggregate route:

   ```
   router bgp
    address-family ipv4 unicast
     network 192.168.100.0/24
     aggregate-address 192.168.0.0/16 suppress-map rm-sup-100
    exit-address-family
   !
   ```

4. Wait for RIB convergence:

   ```
   frr(config)# do show bgp ipv4
   BGP table version is X, local router ID is Y, vrf id Z
   Default local pref B, local AS A
   Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                  i internal, r RIB-failure, S Stale, R Removed
   Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
   Origin codes:  i - IGP, e - EGP, ? - incomplete
   RPKI validation codes: V valid, I invalid, N Not found
   
      Network          Next Hop            Metric LocPrf Weight Path
   *> 192.168.0.0/16   0.0.0.0                  0         32768 i
   s> 192.168.100.0/24 0.0.0.0                  0         32768 i
   ```

5. Remove route-map and aggregate route in a single command batch:

   ```
   no route-map rm-sup-100 permit 10
   router bgp
    no aggregate-address 192.168.0.0/16
   ```

6. RIB will never converge correctly:

   ```
   frr(config)# do show bgp ipv4
   BGP table version is X, local router ID is Y, vrf id Z
   Default local pref B, local AS A
   Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                  i internal, r RIB-failure, S Stale, R Removed
   Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
   Origin codes:  i - IGP, e - EGP, ? - incomplete
   RPKI validation codes: V valid, I invalid, N Not found
   
      Network          Next Hop            Metric LocPrf Weight Path
   s> 192.168.100.0/24 0.0.0.0                  0         32768 i
   ```