### PR TITLE
bfdd: correct one spelling error of comment

### DIFF
--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -1380,7 +1380,7 @@ static int _zebra_ptm_bfd_client_deregister(struct zserv *zs)
 	}
 
 	/*
-	 * The message type will be BFD_DEST_REPLY so we can use only
+	 * The message type will be ZEBRA_BFD_DEST_REPLAY so we can use only
 	 * one callback at the `bfdd` side, however the real command
 	 * number will be included right after the zebra header.
 	 */


### PR DESCRIPTION
bfdd: correct one spelling error of comment

Signed-off-by: anlan_cs <anlan_cs@tom.com>