### PR TITLE
pimv: Keeping list of address-family under gmp container

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7845,9 +7845,10 @@ DEFUN (interface_ip_igmp,
        IP_STR
        IFACE_IGMP_STR)
 {
-	nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY, "true");
+	nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp,
@@ -7876,11 +7877,12 @@ DEFUN (interface_no_ip_igmp,
 					      NULL);
 			nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 		} else
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "false");
 	}
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_igmp_join,
@@ -7908,7 +7910,7 @@ DEFUN (interface_ip_igmp_join,
 	} else
 		source_str = "0.0.0.0";
 
-	snprintf(xpath, sizeof(xpath), FRR_IGMP_JOIN_XPATH,
+	snprintf(xpath, sizeof(xpath), FRR_GMP_JOIN_XPATH,
 		 "frr-routing:ipv4", argv[idx_group]->arg, source_str);
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
@@ -7942,7 +7944,7 @@ DEFUN (interface_no_ip_igmp_join,
 	} else
 		source_str = "0.0.0.0";
 
-	snprintf(xpath, sizeof(xpath), FRR_IGMP_JOIN_XPATH,
+	snprintf(xpath, sizeof(xpath), FRR_GMP_JOIN_XPATH,
 		 "frr-routing:ipv4", argv[idx_group]->arg, source_str);
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
@@ -7969,14 +7971,15 @@ DEFUN (interface_ip_igmp_query_interval,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "true");
 	}
 
 	nb_cli_enqueue_change(vty, "./query-interval", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp_query_interval,
@@ -7990,7 +7993,8 @@ DEFUN (interface_no_ip_igmp_query_interval,
 {
 	nb_cli_enqueue_change(vty, "./query-interval", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_igmp_version,
@@ -8001,11 +8005,13 @@ DEFUN (interface_ip_igmp_version,
        "IGMP version\n"
        "IGMP version number\n")
 {
-	nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+	nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 			      "true");
-	nb_cli_enqueue_change(vty, "./version", NB_OP_MODIFY, argv[3]->arg);
+	nb_cli_enqueue_change(vty, "./igmp-version", NB_OP_MODIFY,
+			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp_version,
@@ -8017,9 +8023,10 @@ DEFUN (interface_no_ip_igmp_version,
        "IGMP version\n"
        "IGMP version number\n")
 {
-	nb_cli_enqueue_change(vty, "./version", NB_OP_DESTROY, NULL);
+	nb_cli_enqueue_change(vty, "./igmp-version", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_igmp_query_max_response_time,
@@ -8038,18 +8045,19 @@ DEFUN (interface_ip_igmp_query_max_response_time,
 				"frr-routing:ipv4");
 
 	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "true");
 	}
 
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp_query_max_response_time,
@@ -8063,7 +8071,8 @@ DEFUN (interface_no_ip_igmp_query_max_response_time,
 {
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_DESTROY,
 			      NULL);
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN_HIDDEN (interface_ip_igmp_query_max_response_time_dsec,
@@ -8081,18 +8090,19 @@ DEFUN_HIDDEN (interface_ip_igmp_query_max_response_time_dsec,
 				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
 				"frr-routing:ipv4");
 	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "true");
 	}
 
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN_HIDDEN (interface_no_ip_igmp_query_max_response_time_dsec,
@@ -8107,7 +8117,8 @@ DEFUN_HIDDEN (interface_no_ip_igmp_query_max_response_time_dsec,
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_DESTROY,
 			      NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_igmp_last_member_query_count,
@@ -8125,18 +8136,19 @@ DEFUN (interface_ip_igmp_last_member_query_count,
 				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
 				"frr-routing:ipv4");
 	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "true");
 	}
 
 	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp_last_member_query_count,
@@ -8151,7 +8163,8 @@ DEFUN (interface_no_ip_igmp_last_member_query_count,
 	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_DESTROY,
 			      NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_igmp_last_member_query_interval,
@@ -8169,18 +8182,19 @@ DEFUN (interface_ip_igmp_last_member_query_interval,
 				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
 				"frr-routing:ipv4");
 	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./igmp-enable", NB_OP_MODIFY,
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 				      "true");
 	} else {
 		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./igmp-enable",
+			nb_cli_enqueue_change(vty, "./enable",
 					      NB_OP_MODIFY, "true");
 	}
 
 	nb_cli_enqueue_change(vty, "./last-member-query-interval", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_no_ip_igmp_last_member_query_interval,
@@ -8195,7 +8209,8 @@ DEFUN (interface_no_ip_igmp_last_member_query_interval,
 	nb_cli_enqueue_change(vty, "./last-member-query-interval",
 			      NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./frr-igmp:igmp");
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    "frr-routing:ipv4");
 }
 
 DEFUN (interface_ip_pim_drprio,
@@ -8394,10 +8409,12 @@ DEFUN_HIDDEN (interface_no_ip_pim_ssm,
 	char igmp_if_xpath[XPATH_MAXLEN + 20];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
-		 "%s/frr-igmp:igmp", VTY_CURR_XPATH);
+		 "%s/frr-gmp:gmp/address-family[address-family='%s']",
+		 VTY_CURR_XPATH, "frr-routing:ipv4");
 	igmp_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
-					    "%s/igmp-enable", igmp_if_xpath);
-
+					    FRR_GMP_ENABLE_XPATH,
+					    VTY_CURR_XPATH,
+					    "frr-routing:ipv4");
 	if (!igmp_enable_dnode) {
 		nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY, NULL);
 		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
@@ -8427,9 +8444,12 @@ DEFUN_HIDDEN (interface_no_ip_pim_sm,
 	char igmp_if_xpath[XPATH_MAXLEN + 20];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
-		 "%s/frr-igmp:igmp", VTY_CURR_XPATH);
-	igmp_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
-					    "%s/igmp-enable", igmp_if_xpath);
+		 "%s/frr-gmp:gmp/address-family[address-family='%s']",
+		 VTY_CURR_XPATH, "frr-routing:ipv4");
+	igmp_enable_dnode =
+		yang_dnode_getf(vty->candidate_config->dnode,
+				FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 
 	if (!igmp_enable_dnode) {
 		nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY, NULL);
@@ -8460,9 +8480,12 @@ DEFUN (interface_no_ip_pim,
 	char igmp_if_xpath[XPATH_MAXLEN + 20];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
-		 "%s/frr-igmp:igmp", VTY_CURR_XPATH);
-	igmp_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
-					    "%s/igmp-enable", igmp_if_xpath);
+		 "%s/frr-gmp:gmp/address-family[address-family='%s']",
+		 VTY_CURR_XPATH, "frr-routing:ipv4");
+	igmp_enable_dnode =
+		yang_dnode_getf(vty->candidate_config->dnode,
+				FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 
 	if (!igmp_enable_dnode) {
 		nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY, NULL);
@@ -8587,7 +8610,8 @@ DEFUN (interface_ip_pim_hello,
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-igmp:igmp/igmp-enable", VTY_CURR_XPATH);
+				FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 	if (!igmp_enable_dnode) {
 		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
 				      "true");
@@ -9305,7 +9329,8 @@ DEFPY (ip_pim_bfd,
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-igmp:igmp/igmp-enable", VTY_CURR_XPATH);
+				FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 	if (!igmp_enable_dnode)
 		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
 				      "true");
@@ -9366,7 +9391,8 @@ DEFUN (ip_pim_bsm,
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-igmp:igmp/igmp-enable", VTY_CURR_XPATH);
+				FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 	if (!igmp_enable_dnode)
 		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
 				      "true");
@@ -9407,7 +9433,8 @@ DEFUN (ip_pim_ucast_bsm,
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-igmp:igmp/igmp-enable", VTY_CURR_XPATH);
+				FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 	if (!igmp_enable_dnode)
 		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
 				      "true");
@@ -9469,7 +9496,8 @@ DEFUN_HIDDEN (
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
-				"%s/frr-igmp:igmp/igmp-enable", VTY_CURR_XPATH);
+				FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
+				"frr-routing:ipv4");
 	if (!igmp_enable_dnode)
 		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
 				      "true");

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -81,7 +81,7 @@ static const struct frr_yang_module_info *const pimd_yang_modules[] = {
 	&frr_routing_info,
 	&frr_pim_info,
 	&frr_pim_rp_info,
-	&frr_igmp_info,
+	&frr_gmp_info,
 };
 
 FRR_DAEMON_INFO(pimd, PIM, .vty_port = PIMD_VTY_PORT,

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -366,65 +366,65 @@ const struct frr_yang_module_info frr_pim_rp_info = {
 };
 
 /* clang-format off */
-const struct frr_yang_module_info frr_igmp_info = {
-	.name = "frr-igmp",
+const struct frr_yang_module_info frr_gmp_info = {
+	.name = "frr-gmp",
 	.nodes = {
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp",
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family",
 			.cbs = {
-				.create = lib_interface_igmp_create,
-				.destroy = lib_interface_igmp_destroy,
+				.create = lib_interface_gmp_address_family_create,
+				.destroy = lib_interface_gmp_address_family_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/igmp-enable",
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/enable",
 			.cbs = {
-				.modify = lib_interface_igmp_igmp_enable_modify,
+				.modify = lib_interface_gmp_address_family_enable_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/version",
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/igmp-version",
 			.cbs = {
-				.modify = lib_interface_igmp_version_modify,
-				.destroy = lib_interface_igmp_version_destroy,
+				.modify = lib_interface_gmp_address_family_igmp_version_modify,
+				.destroy = lib_interface_gmp_address_family_igmp_version_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/query-interval",
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/mld-version",
 			.cbs = {
-				.modify = lib_interface_igmp_query_interval_modify,
+				.modify = lib_interface_gmp_address_family_mld_version_modify,
+				.destroy = lib_interface_gmp_address_family_mld_version_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/query-max-response-time",
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/query-interval",
 			.cbs = {
-				.modify = lib_interface_igmp_query_max_response_time_modify,
+				.modify = lib_interface_gmp_address_family_query_interval_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/last-member-query-interval",
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/query-max-response-time",
 			.cbs = {
-				.modify = lib_interface_igmp_last_member_query_interval_modify,
+				.modify = lib_interface_gmp_address_family_query_max_response_time_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/robustness-variable",
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/last-member-query-interval",
 			.cbs = {
-				.modify = lib_interface_igmp_robustness_variable_modify,
+				.modify = lib_interface_gmp_address_family_last_member_query_interval_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/address-family",
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/robustness-variable",
 			.cbs = {
-				.create = lib_interface_igmp_address_family_create,
-				.destroy = lib_interface_igmp_address_family_destroy,
+				.modify = lib_interface_gmp_address_family_robustness_variable_modify,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-igmp:igmp/address-family/static-group",
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/static-group",
 			.cbs = {
-				.create = lib_interface_igmp_address_family_static_group_create,
-				.destroy = lib_interface_igmp_address_family_static_group_destroy,
+				.create = lib_interface_gmp_address_family_static_group_create,
+				.destroy = lib_interface_gmp_address_family_static_group_destroy,
 			}
 		},
 		{
@@ -432,3 +432,4 @@ const struct frr_yang_module_info frr_igmp_info = {
 		},
 	}
 };
+

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -22,7 +22,7 @@
 
 extern const struct frr_yang_module_info frr_pim_info;
 extern const struct frr_yang_module_info frr_pim_rp_info;
-extern const struct frr_yang_module_info frr_igmp_info;
+extern const struct frr_yang_module_info frr_gmp_info;
 
 /* frr-pim prototypes*/
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ecmp_modify(
@@ -163,25 +163,33 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_static_rp_rp_list_prefix_list_destroy(
 	struct nb_cb_destroy_args *args);
 
-/* frr-igmp prototypes*/
-int lib_interface_igmp_create(struct nb_cb_create_args *args);
-int lib_interface_igmp_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_igmp_igmp_enable_modify(struct nb_cb_modify_args *args);
-int lib_interface_igmp_version_modify(struct nb_cb_modify_args *args);
-int lib_interface_igmp_version_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_igmp_query_interval_modify(struct nb_cb_modify_args *args);
-int lib_interface_igmp_query_max_response_time_modify(
-	struct nb_cb_modify_args *args);
-int lib_interface_igmp_last_member_query_interval_modify(
-	struct nb_cb_modify_args *args);
-int lib_interface_igmp_robustness_variable_modify(
-	struct nb_cb_modify_args *args);
-int lib_interface_igmp_address_family_create(struct nb_cb_create_args *args);
-int lib_interface_igmp_address_family_destroy(struct nb_cb_destroy_args *args);
-int lib_interface_igmp_address_family_static_group_create(
+/* frr-gmp prototypes*/
+int lib_interface_gmp_address_family_create(
 	struct nb_cb_create_args *args);
-int lib_interface_igmp_address_family_static_group_destroy(
+int lib_interface_gmp_address_family_destroy(
 	struct nb_cb_destroy_args *args);
+int lib_interface_gmp_address_family_enable_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_gmp_address_family_igmp_version_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_gmp_address_family_igmp_version_destroy(
+	struct nb_cb_destroy_args *args);
+int lib_interface_gmp_address_family_mld_version_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_gmp_address_family_mld_version_destroy(
+	struct nb_cb_destroy_args *args);
+int lib_interface_gmp_address_family_query_interval_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_gmp_address_family_query_max_response_time_modify(
+		struct nb_cb_modify_args *args);
+int lib_interface_gmp_address_family_last_member_query_interval_modify(
+		struct nb_cb_modify_args *args);
+int lib_interface_gmp_address_family_robustness_variable_modify(
+		struct nb_cb_modify_args *args);
+int lib_interface_gmp_address_family_static_group_create(
+		struct nb_cb_create_args *args);
+int lib_interface_gmp_address_family_static_group_destroy(
+		struct nb_cb_destroy_args *args);
 
 /*
  * Callback registered with routing_nb lib to validate only
@@ -208,8 +216,12 @@ int routing_control_plane_protocols_name_validate(
 	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"       \
 	"frr-pim:pim/address-family[address-family='%s']/"              \
 	"frr-pim-rp:rp/static-rp/rp-list[rp-address='%s']"
-#define FRR_IGMP_JOIN_XPATH                                             \
-	"./frr-igmp:igmp/address-family[address-family='%s']/"          \
+#define FRR_GMP_INTERFACE_XPATH                                         \
+	"./frr-gmp:gmp/address-family[address-family='%s']"
+#define FRR_GMP_ENABLE_XPATH                                            \
+	"%s/frr-gmp:gmp/address-family[address-family='%s']/enable"
+#define FRR_GMP_JOIN_XPATH                                              \
+	"./frr-gmp:gmp/address-family[address-family='%s']/"            \
 	"static-group[group-addr='%s'][source-addr='%s']"
 #define FRR_PIM_MSDP_XPATH FRR_PIM_VRF_XPATH "/msdp"
 

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -337,8 +337,9 @@ static bool is_pim_interface(const struct lyd_node *dnode)
 		yang_dnode_getf(dnode,
 				"%s/frr-pim:pim/address-family[address-family='%s']/pim-enable",
 				if_xpath, "frr-routing:ipv4");
-	igmp_enable_dnode = yang_dnode_getf(
-		dnode, "%s/frr-igmp:igmp/igmp-enable", if_xpath);
+	igmp_enable_dnode = yang_dnode_getf(dnode,
+			"%s/frr-gmp:gmp/address-family[address-family='%s']/enable",
+			if_xpath, "frr-routing:ipv4");
 
 	if (((pim_enable_dnode) &&
 	     (yang_dnode_get_bool(pim_enable_dnode, "."))) ||
@@ -2512,9 +2513,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family
  */
-int lib_interface_igmp_create(struct nb_cb_create_args *args)
+int lib_interface_gmp_address_family_create(struct nb_cb_create_args *args)
 {
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -2527,7 +2528,7 @@ int lib_interface_igmp_create(struct nb_cb_create_args *args)
 	return NB_OK;
 }
 
-int lib_interface_igmp_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_gmp_address_family_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -2558,9 +2559,10 @@ int lib_interface_igmp_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/igmp-enable
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/enable
  */
-int lib_interface_igmp_igmp_enable_modify(struct nb_cb_modify_args *args)
+int lib_interface_gmp_address_family_enable_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	bool igmp_enable;
@@ -2614,9 +2616,10 @@ int lib_interface_igmp_igmp_enable_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/version
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/igmp-version
  */
-int lib_interface_igmp_version_modify(struct nb_cb_modify_args *args)
+int lib_interface_gmp_address_family_igmp_version_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -2650,7 +2653,8 @@ int lib_interface_igmp_version_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-int lib_interface_igmp_version_destroy(struct nb_cb_destroy_args *args)
+int lib_interface_gmp_address_family_igmp_version_destroy(
+	struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
@@ -2671,9 +2675,41 @@ int lib_interface_igmp_version_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/query-interval
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/mld-version
  */
-int lib_interface_igmp_query_interval_modify(struct nb_cb_modify_args *args)
+int lib_interface_gmp_address_family_mld_version_modify(
+	struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_gmp_address_family_mld_version_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/query-interval
+ */
+int lib_interface_gmp_address_family_query_interval_modify(
+	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	int query_interval;
@@ -2693,9 +2729,9 @@ int lib_interface_igmp_query_interval_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/query-max-response-time
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/query-max-response-time
  */
-int lib_interface_igmp_query_max_response_time_modify(
+int lib_interface_gmp_address_family_query_max_response_time_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
@@ -2718,9 +2754,9 @@ int lib_interface_igmp_query_max_response_time_modify(
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/last-member-query-interval
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/last-member-query-interval
  */
-int lib_interface_igmp_last_member_query_interval_modify(
+int lib_interface_gmp_address_family_last_member_query_interval_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
@@ -2747,9 +2783,9 @@ int lib_interface_igmp_last_member_query_interval_modify(
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/robustness-variable
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/robustness-variable
  */
-int lib_interface_igmp_robustness_variable_modify(
+int lib_interface_gmp_address_family_robustness_variable_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
@@ -2775,38 +2811,9 @@ int lib_interface_igmp_robustness_variable_modify(
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/address-family
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/static-group
  */
-int lib_interface_igmp_address_family_create(struct nb_cb_create_args *args)
-{
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		break;
-	}
-
-	return NB_OK;
-}
-
-int lib_interface_igmp_address_family_destroy(struct nb_cb_destroy_args *args)
-{
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		break;
-	}
-
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-interface:lib/interface/frr-igmp:igmp/address-family/static-group
- */
-int lib_interface_igmp_address_family_static_group_create(
+int lib_interface_gmp_address_family_static_group_create(
 	struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
@@ -2847,7 +2854,7 @@ int lib_interface_igmp_address_family_static_group_create(
 	return NB_OK;
 }
 
-int lib_interface_igmp_address_family_static_group_destroy(
+int lib_interface_gmp_address_family_static_group_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -76,7 +76,7 @@ pimd_pimd_SOURCES = \
 nodist_pimd_pimd_SOURCES = \
 	yang/frr-pim.yang.c \
 	yang/frr-pim-rp.yang.c \
-	yang/frr-igmp.yang.c \
+	yang/frr-gmp.yang.c \
 	# end
 
 pimd_pim6d_SOURCES = \

--- a/yang/frr-gmp.yang
+++ b/yang/frr-gmp.yang
@@ -1,8 +1,8 @@
-module frr-igmp {
+module frr-gmp {
   yang-version "1.1";
-  namespace "http://frrouting.org/yang/igmp";
+  namespace "http://frrouting.org/yang/gmp";
 
-  prefix frr-igmp;
+  prefix frr-gmp;
 
   import frr-routing {
     prefix "frr-rt";
@@ -55,31 +55,49 @@ module frr-igmp {
      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
-  revision 2019-11-06 {
+  revision 2021-11-22 {
     description
       "Initial revision.";
     reference
       "RFC 2236: IGMP v2.
-       RFC 3376: IGMP v3.";
+       RFC 3376: IGMP v3.
+       RFC 2710: MLD.
+       RFC 3810: MLD v2.";
   }
 
   grouping interface-config-attributes {
     description
-      "Configuration attributes applied to the interface level.";
+      "Configuration IGMP/MLD attributes applied to the interface level.";
 
-    leaf igmp-enable {
+    leaf enable {
       type boolean;
       default "false";
       description
-        "Enable IGMP flag on the interface.";
+        "Enable IGMP/MLD flag on the interface.";
     }
 
-    leaf version {
+    leaf igmp-version {
+      when "../frr-gmp:address-family = 'frr-rt:ipv4'" {
+        description
+          "Only applicable to IPv4 address family.";
+      }
       type uint8 {
         range "2..3";
       }
       description
         "IGMP version.";
+    }
+
+    leaf mld-version {
+      when "../frr-gmp:address-family = 'frr-rt:ipv6'" {
+        description
+          "Only applicable to IPv6 address family.";
+      }
+      type uint8 {
+        range "1..2";
+      }
+      description
+        "MLD version.";
     }
 
     leaf query-interval {
@@ -126,11 +144,6 @@ module frr-igmp {
         "Querier's Robustness Variable allows tuning for the
          expected packet loss on a network.";
     }
-  }
-
-  grouping per-af-interface-config-attributes {
-    description
-      "Configuration attributes applied to the interface level per address family.";
 
     list static-group {
       key "group-addr source-addr";
@@ -149,25 +162,20 @@ module frr-igmp {
           "Multicast source address.";
       }
     }
-
-  } // per-af-interface-config-attributes
+  } // interface-config-attributes
 
   /*
    * Per-interface configuration data
    */
   augment "/frr-interface:lib/frr-interface:interface" {
-    container igmp {
-      presence
-        "Configure IGMP on an interface.";
-      uses interface-config-attributes;
+    container gmp {
       list address-family {
         key "address-family";
         description
           "Each list entry for one address family.";
         uses frr-rt:address-family;
-        uses per-af-interface-config-attributes;
-
-        } //address-family
+        uses interface-config-attributes;
+      } //address-family
     }
   }
 }

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -70,7 +70,7 @@ dist_yangmodels_DATA += yang/frr-zebra.yang
 endif
 
 if PIMD
-dist_yangmodels_DATA += yang/frr-igmp.yang
+dist_yangmodels_DATA += yang/frr-gmp.yang
 dist_yangmodels_DATA += yang/frr-pim.yang
 dist_yangmodels_DATA += yang/frr-pim-rp.yang
 endif


### PR DESCRIPTION
Renamed frr-igmp.yang to frr-gmp.yang, igmp to gmp container.
to support IGMP and MLD protocol.

frr-gmp.yang, created a list of address family under gmp
container. For PIMV4 the key is IPV4, where as for PIMV6
the key is IPV6. This is done for PIMV6 development.

This commit will have all the northbound changes to support
IPV4 address family.

Reviewed-by: Mobashshera Rasool <mrasool@vmware.com>
Signed-off-by: sarita patra <saritap@vmware.com>