### PR TITLE
pimd: Adding pim_prefix_sg separate for pimd 

### DIFF
--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -141,9 +141,9 @@ static int dispatch_assert(struct interface *ifp, struct in_addr source_addr,
 			   struct pim_assert_metric recv_metric)
 {
 	struct pim_ifchannel *ch;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src = source_addr;
 	sg.grp = group_addr;
 	ch = pim_ifchannel_add(ifp, &sg, 0, 0);
@@ -215,7 +215,7 @@ static int dispatch_assert(struct interface *ifp, struct in_addr source_addr,
 int pim_assert_recv(struct interface *ifp, struct pim_neighbor *neigh,
 		    struct in_addr src_addr, uint8_t *buf, int buf_size)
 {
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	struct prefix msg_source_addr;
 	struct pim_assert_metric msg_metric;
 	int offset;
@@ -231,7 +231,7 @@ int pim_assert_recv(struct interface *ifp, struct pim_neighbor *neigh,
 	/*
 	  Parse assert group addr
 	 */
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	offset = pim_parse_addr_group(&sg, curr, curr_size);
 	if (offset < 1) {
 		char src_str[INET_ADDRSTRLEN];

--- a/pimd/pim_br.c
+++ b/pimd/pim_br.c
@@ -29,7 +29,7 @@
 #include "linklist.h"
 
 struct pim_br {
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	struct in_addr pmbr;
 };
 
@@ -37,7 +37,7 @@ struct in_addr pim_br_unknown = {.s_addr = 0};
 
 static struct list *pim_br_list = NULL;
 
-struct in_addr pim_br_get_pmbr(struct prefix_sg *sg)
+struct in_addr pim_br_get_pmbr(struct pim_prefix_sg *sg)
 {
 	struct listnode *node;
 	struct pim_br *pim_br;
@@ -51,7 +51,7 @@ struct in_addr pim_br_get_pmbr(struct prefix_sg *sg)
 	return pim_br_unknown;
 }
 
-void pim_br_set_pmbr(struct prefix_sg *sg, struct in_addr br)
+void pim_br_set_pmbr(struct pim_prefix_sg *sg, struct in_addr br)
 {
 	struct listnode *node, *next;
 	struct pim_br *pim_br;
@@ -75,7 +75,7 @@ void pim_br_set_pmbr(struct prefix_sg *sg, struct in_addr br)
 /*
  * Remove the (S,G) from the stored values
  */
-void pim_br_clear_pmbr(struct prefix_sg *sg)
+void pim_br_clear_pmbr(struct pim_prefix_sg *sg)
 {
 	struct listnode *node, *next;
 	struct pim_br *pim_br;

--- a/pimd/pim_br.h
+++ b/pimd/pim_br.h
@@ -20,10 +20,10 @@
 #ifndef PIM_BR_H
 #define PIM_BR_H
 
-struct in_addr pim_br_get_pmbr(struct prefix_sg *sg);
+struct in_addr pim_br_get_pmbr(struct pim_prefix_sg *sg);
 
-void pim_br_set_pmbr(struct prefix_sg *sg, struct in_addr value);
-void pim_br_clear_pmbr(struct prefix_sg *sg);
+void pim_br_set_pmbr(struct pim_prefix_sg *sg, struct in_addr value);
+void pim_br_clear_pmbr(struct pim_prefix_sg *sg);
 
 void pim_br_init(void);
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1741,7 +1741,7 @@ static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 }
 
 static void pim_show_join(struct pim_instance *pim, struct vty *vty,
-			  struct prefix_sg *sg, bool uj)
+			  struct pim_prefix_sg *sg, bool uj)
 {
 	struct pim_interface *pim_ifp;
 	struct pim_ifchannel *ch;
@@ -2439,7 +2439,7 @@ static const char *pim_reg_state2brief_str(enum pim_reg_state reg_state,
 }
 
 static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
-			      struct prefix_sg *sg, bool uj)
+			      struct pim_prefix_sg *sg, bool uj)
 {
 	struct pim_upstream *up;
 	time_t now;
@@ -4603,7 +4603,7 @@ DEFPY (show_ip_pim_join,
        "The Group\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	struct pim_prefix_sg sg = {0};
 	struct vrf *v;
 	bool uj = !!json;
 	struct pim_instance *pim;
@@ -4644,7 +4644,7 @@ DEFUN (show_ip_pim_join_vrf_all,
        "PIM interface join information\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	struct pim_prefix_sg sg = {0};
 	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
@@ -5223,7 +5223,7 @@ DEFPY (show_ip_pim_upstream,
        "The Group\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	struct pim_prefix_sg sg = {0};
 	struct vrf *v;
 	bool uj = !!json;
 	struct pim_instance *pim;
@@ -5263,7 +5263,7 @@ DEFUN (show_ip_pim_upstream_vrf_all,
        "PIM upstream information\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	struct pim_prefix_sg sg = {0};
 	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
@@ -5888,7 +5888,7 @@ DEFUN(show_ip_multicast_count_vrf_all,
 }
 
 static void show_mroute(struct pim_instance *pim, struct vty *vty,
-			struct prefix_sg *sg, bool fill, bool uj)
+			struct pim_prefix_sg *sg, bool fill, bool uj)
 {
 	struct listnode *node;
 	struct channel_oil *c_oil;
@@ -6273,7 +6273,7 @@ DEFPY (show_ip_mroute,
        "Fill in Assumed data\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	struct pim_prefix_sg sg = {0};
 	struct pim_instance *pim;
 	struct vrf *v;
 
@@ -6311,7 +6311,7 @@ DEFUN (show_ip_mroute_vrf_all,
        "Fill in Assumed data\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	struct pim_prefix_sg sg = {0};
 	bool uj = use_json(argc, argv);
 	int idx = 4;
 	struct vrf *vrf;
@@ -8219,7 +8219,7 @@ DEFPY_HIDDEN (pim_test_sg_keepalive,
 {
 	struct pim_upstream *up;
 	struct pim_instance *pim;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 
 	sg.src = source;
 	sg.grp = group;
@@ -10596,7 +10596,7 @@ static void pim_show_vxlan_sg_one(struct pim_instance *pim,
 				  bool uj)
 {
 	json_object *json = NULL;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	int result = 0;
 	struct pim_vxlan_sg *vxlan_sg;
 	const char *iif_name;
@@ -10616,8 +10616,6 @@ static void pim_show_vxlan_sg_one(struct pim_instance *pim,
 		return;
 	}
 
-	sg.family = AF_INET;
-	sg.prefixlen = IPV4_MAX_BITLEN;
 	if (uj)
 		json = json_object_new_object();
 

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -447,7 +447,7 @@ void reset_ifassert_state(struct pim_ifchannel *ch)
 }
 
 struct pim_ifchannel *pim_ifchannel_find(struct interface *ifp,
-					 struct prefix_sg *sg)
+					 struct pim_prefix_sg *sg)
 {
 	struct pim_interface *pim_ifp;
 	struct pim_ifchannel *ch;
@@ -524,7 +524,7 @@ void pim_ifchannel_delete_on_noinfo(struct interface *ifp)
  */
 static struct pim_ifchannel *pim_ifchannel_find_parent(struct pim_ifchannel *ch)
 {
-	struct prefix_sg parent_sg = ch->sg;
+	struct pim_prefix_sg parent_sg = ch->sg;
 	struct pim_ifchannel *parent = NULL;
 
 	// (S,G)
@@ -542,7 +542,7 @@ static struct pim_ifchannel *pim_ifchannel_find_parent(struct pim_ifchannel *ch)
 }
 
 struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp,
-					struct prefix_sg *sg,
+					struct pim_prefix_sg *sg,
 					uint8_t source_flags, int up_flags)
 {
 	struct pim_interface *pim_ifp;
@@ -752,7 +752,8 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
 }
 
 static void check_recv_upstream(int is_join, struct interface *recv_ifp,
-				struct in_addr upstream, struct prefix_sg *sg,
+				struct in_addr upstream,
+				struct pim_prefix_sg *sg,
 				uint8_t source_flags, int holdtime)
 {
 	struct pim_upstream *up;
@@ -817,7 +818,7 @@ static void check_recv_upstream(int is_join, struct interface *recv_ifp,
 }
 
 static int nonlocal_upstream(int is_join, struct interface *recv_ifp,
-			     struct in_addr upstream, struct prefix_sg *sg,
+			     struct in_addr upstream, struct pim_prefix_sg *sg,
 			     uint8_t source_flags, uint16_t holdtime)
 {
 	struct pim_interface *recv_pim_ifp;
@@ -871,7 +872,7 @@ static void pim_ifchannel_ifjoin_handler(struct pim_ifchannel *ch,
 
 
 void pim_ifchannel_join_add(struct interface *ifp, struct in_addr neigh_addr,
-			    struct in_addr upstream, struct prefix_sg *sg,
+			    struct in_addr upstream, struct pim_prefix_sg *sg,
 			    uint8_t source_flags, uint16_t holdtime)
 {
 	struct pim_interface *pim_ifp;
@@ -1036,7 +1037,7 @@ void pim_ifchannel_join_add(struct interface *ifp, struct in_addr neigh_addr,
 }
 
 void pim_ifchannel_prune(struct interface *ifp, struct in_addr upstream,
-			 struct prefix_sg *sg, uint8_t source_flags,
+			 struct pim_prefix_sg *sg, uint8_t source_flags,
 			 uint16_t holdtime)
 {
 	struct pim_ifchannel *ch;
@@ -1173,7 +1174,7 @@ void pim_ifchannel_prune(struct interface *ifp, struct in_addr upstream,
 }
 
 int pim_ifchannel_local_membership_add(struct interface *ifp,
-				       struct prefix_sg *sg, bool is_vxlan)
+				       struct pim_prefix_sg *sg, bool is_vxlan)
 {
 	struct pim_ifchannel *ch, *starch;
 	struct pim_interface *pim_ifp;
@@ -1279,7 +1280,7 @@ int pim_ifchannel_local_membership_add(struct interface *ifp,
 }
 
 void pim_ifchannel_local_membership_del(struct interface *ifp,
-					struct prefix_sg *sg)
+					struct pim_prefix_sg *sg)
 {
 	struct pim_ifchannel *starch, *ch, *orig;
 	struct pim_interface *pim_ifp;

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -25,6 +25,7 @@
 #include "if.h"
 #include "prefix.h"
 
+#include "pim_str.h"
 #include "pim_assert.h"
 
 struct pim_ifchannel;
@@ -89,7 +90,7 @@ struct pim_ifchannel {
 
 	struct pim_ifchannel *parent;
 	struct list *sources;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	char sg_str[PIM_SG_LEN];
 	struct interface *interface; /* backpointer to interface */
 	uint32_t flags;
@@ -124,20 +125,21 @@ void pim_ifchannel_delete_all(struct interface *ifp);
 void pim_ifchannel_membership_clear(struct interface *ifp);
 void pim_ifchannel_delete_on_noinfo(struct interface *ifp);
 struct pim_ifchannel *pim_ifchannel_find(struct interface *ifp,
-					 struct prefix_sg *sg);
+					 struct pim_prefix_sg *sg);
 struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp,
-					struct prefix_sg *sg, uint8_t ch_flags,
+					struct pim_prefix_sg *sg,
+					uint8_t ch_flags,
 					int up_flags);
 void pim_ifchannel_join_add(struct interface *ifp, struct in_addr neigh_addr,
-			    struct in_addr upstream, struct prefix_sg *sg,
+			    struct in_addr upstream, struct pim_prefix_sg *sg,
 			    uint8_t source_flags, uint16_t holdtime);
 void pim_ifchannel_prune(struct interface *ifp, struct in_addr upstream,
-			 struct prefix_sg *sg, uint8_t source_flags,
+			 struct pim_prefix_sg *sg, uint8_t source_flags,
 			 uint16_t holdtime);
 int pim_ifchannel_local_membership_add(struct interface *ifp,
-		struct prefix_sg *sg, bool is_vxlan);
+		struct pim_prefix_sg *sg, bool is_vxlan);
 void pim_ifchannel_local_membership_del(struct interface *ifp,
-					struct prefix_sg *sg);
+					struct pim_prefix_sg *sg);
 
 void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 				 enum pim_ifjoin_state new_state);

--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -106,13 +106,13 @@ static bool mtrace_fwd_info(struct pim_instance *pim,
 			    struct igmp_mtrace_rsp *rspp,
 			    struct interface **ifpp)
 {
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	struct pim_upstream *up;
 	struct interface *ifp_in;
 	struct in_addr nh_addr;
 	uint32_t total;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src = mtracep->src_addr;
 	sg.grp = mtracep->grp_addr;
 
@@ -426,14 +426,14 @@ static int mtrace_un_forward_packet(struct pim_instance *pim, struct ip *ip_hdr,
 
 static int mtrace_mc_forward_packet(struct pim_instance *pim, struct ip *ip_hdr)
 {
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	struct channel_oil *c_oil;
 	struct listnode *chnode;
 	struct listnode *chnextnode;
 	struct pim_ifchannel *ch = NULL;
 	int ret = -1;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.grp = ip_hdr->ip_dst;
 
 	c_oil = pim_find_channel_oil(pim, &sg);
@@ -477,14 +477,14 @@ static int mtrace_send_mc_response(struct pim_instance *pim,
 				   struct igmp_mtrace *mtracep,
 				   size_t mtrace_len)
 {
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	struct channel_oil *c_oil;
 	struct listnode *chnode;
 	struct listnode *chnextnode;
 	struct pim_ifchannel *ch = NULL;
 	int ret = -1;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.grp = mtracep->rsp_addr;
 
 	c_oil = pim_find_channel_oil(pim, &sg);

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -55,7 +55,7 @@ static void on_trace(const char *label, struct interface *ifp,
 
 static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		      uint16_t holdtime, struct in_addr upstream,
-		      struct prefix_sg *sg, uint8_t source_flags)
+		      struct pim_prefix_sg *sg, uint8_t source_flags)
 {
 	struct pim_interface *pim_ifp = NULL;
 
@@ -87,7 +87,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		struct pim_rpf *rp = RP(pim_ifp->pim, sg->grp);
 
 		if (!rp) {
-			zlog_warn("%s: Lookup of RP failed for %pSG4", __func__,
+			zlog_warn("%s: Lookup of RP failed for %pPSG", __func__,
 				  sg);
 			return;
 		}
@@ -125,7 +125,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 
 static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 		       uint16_t holdtime, struct in_addr upstream,
-		       struct prefix_sg *sg, uint8_t source_flags)
+		       struct pim_prefix_sg *sg, uint8_t source_flags)
 {
 	struct pim_interface *pim_ifp = NULL;
 
@@ -160,7 +160,7 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 
 			pim_inet4_dump("<received?>", sg->src, received_rp,
 				       sizeof(received_rp));
-			zlog_debug("%s: Prune received with RP(%s) for %pSG4",
+			zlog_debug("%s: Prune received with RP(%s) for %pPSG",
 				   __func__, received_rp, sg);
 		}
 
@@ -247,7 +247,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 
 	/* Scan groups */
 	for (group = 0; group < msg_num_groups; ++group) {
-		struct prefix_sg sg;
+		struct pim_prefix_sg sg;
 		uint8_t msg_source_flags;
 		uint16_t msg_num_joined_sources;
 		uint16_t msg_num_pruned_sources;
@@ -255,7 +255,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 		struct pim_ifchannel *starg_ch = NULL, *sg_ch = NULL;
 		bool filtered = false;
 
-		memset(&sg, 0, sizeof(struct prefix_sg));
+		memset(&sg, 0, sizeof(struct pim_prefix_sg));
 		addr_offset = pim_parse_addr_group(&sg, buf, pastend - buf);
 		if (addr_offset < 1) {
 			return -5;

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -253,11 +253,11 @@ static void pim_mlag_up_peer_add(struct mlag_mroute_add *msg)
 	struct pim_upstream *up;
 	struct pim_instance *pim;
 	int flags = 0;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	struct vrf *vrf;
 	char sg_str[PIM_SG_LEN];
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src.s_addr = htonl(msg->source_ip);
 	sg.grp.s_addr = htonl(msg->group_ip);
 	if (PIM_DEBUG_MLAG)
@@ -327,11 +327,11 @@ static void pim_mlag_up_peer_del(struct mlag_mroute_del *msg)
 {
 	struct pim_upstream *up;
 	struct pim_instance *pim;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	struct vrf *vrf;
 	char sg_str[PIM_SG_LEN];
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src.s_addr = htonl(msg->source_ip);
 	sg.grp.s_addr = htonl(msg->group_ip);
 	if (PIM_DEBUG_MLAG)
@@ -737,17 +737,17 @@ static void pim_mlag_process_vxlan_update(struct mlag_vxlan *msg)
 static void pim_mlag_process_mroute_add(struct mlag_mroute_add msg)
 {
 	if (PIM_DEBUG_MLAG) {
-		struct prefix_sg sg;
+		struct pim_prefix_sg sg;
 
 		sg.grp.s_addr = ntohl(msg.group_ip);
 		sg.src.s_addr = ntohl(msg.source_ip);
 
 		zlog_debug(
-			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x (%pSG4) cost: %u",
+			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x (%pPSG) cost: %u",
 			__func__, msg.vrf_name, msg.source_ip, msg.group_ip,
 			&sg, msg.cost_to_rp);
 		zlog_debug(
-			"(%pSG4)owner_id: %d, DR: %d, Dual active: %d, vrf_id: 0x%x intf_name: %s",
+			"(%pPSG)owner_id: %d, DR: %d, Dual active: %d, vrf_id: 0x%x intf_name: %s",
 			&sg, msg.owner_id, msg.am_i_dr, msg.am_i_dual_active,
 			msg.vrf_id, msg.intf_name);
 	}
@@ -767,15 +767,15 @@ static void pim_mlag_process_mroute_add(struct mlag_mroute_add msg)
 static void pim_mlag_process_mroute_del(struct mlag_mroute_del msg)
 {
 	if (PIM_DEBUG_MLAG) {
-		struct prefix_sg sg;
+		struct pim_prefix_sg sg;
 
 		sg.grp.s_addr = ntohl(msg.group_ip);
 		sg.src.s_addr = ntohl(msg.source_ip);
 		zlog_debug(
-			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x(%pSG4)",
+			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x(%pPSG)",
 			__func__, msg.vrf_name, msg.source_ip, msg.group_ip,
 			&sg);
-		zlog_debug("(%pSG4)owner_id: %d, vrf_id: 0x%x intf_name: %s",
+		zlog_debug("(%pPSG)owner_id: %d, vrf_id: 0x%x intf_name: %s",
 			   &sg, msg.owner_id, msg.vrf_id, msg.intf_name);
 	}
 

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -154,7 +154,7 @@ static int pim_mroute_msg_nocache(int fd, struct interface *ifp,
 	struct pim_interface *pim_ifp = ifp->info;
 	struct pim_upstream *up;
 	struct pim_rpf *rpg;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 
 	rpg = pim_ifp ? RP(pim_ifp->pim, msg->im_dst) : NULL;
 	/*
@@ -183,7 +183,7 @@ static int pim_mroute_msg_nocache(int fd, struct interface *ifp,
 		return 0;
 	}
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src = msg->im_src;
 	sg.grp = msg->im_dst;
 
@@ -242,7 +242,7 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 				   const char *buf)
 {
 	struct pim_interface *pim_ifp;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	struct pim_rpf *rpg;
 	const struct ip *ip_hdr;
 	struct pim_upstream *up;
@@ -251,13 +251,13 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 
 	ip_hdr = (const struct ip *)buf;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src = ip_hdr->ip_src;
 	sg.grp = ip_hdr->ip_dst;
 
 	up = pim_upstream_find(pim_ifp->pim, &sg);
 	if (!up) {
-		struct prefix_sg star = sg;
+		struct pim_prefix_sg star = sg;
 		star.src.s_addr = INADDR_ANY;
 
 		up = pim_upstream_find(pim_ifp->pim, &star);
@@ -342,9 +342,9 @@ static int pim_mroute_msg_wrongvif(int fd, struct interface *ifp,
 {
 	struct pim_ifchannel *ch;
 	struct pim_interface *pim_ifp;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src = msg->im_src;
 	sg.grp = msg->im_dst;
 
@@ -378,7 +378,7 @@ static int pim_mroute_msg_wrongvif(int fd, struct interface *ifp,
 
 	ch = pim_ifchannel_find(ifp, &sg);
 	if (!ch) {
-		struct prefix_sg star_g = sg;
+		struct pim_prefix_sg star_g = sg;
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
 				"%s: WRONGVIF (S,G)=%s could not find channel on interface %s",
@@ -448,12 +448,12 @@ static int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp,
 	struct pim_instance *pim;
 	struct pim_ifchannel *ch;
 	struct pim_upstream *up;
-	struct prefix_sg star_g;
-	struct prefix_sg sg;
+	struct pim_prefix_sg star_g;
+	struct pim_prefix_sg sg;
 
 	pim_ifp = ifp->info;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src = ip_hdr->ip_src;
 	sg.grp = ip_hdr->ip_dst;
 
@@ -1213,7 +1213,7 @@ void pim_mroute_update_counters(struct channel_oil *c_oil)
 	if (!c_oil->installed) {
 		c_oil->cc.lastused = 100 * pim->keep_alive_time;
 		if (PIM_DEBUG_MROUTE) {
-			struct prefix_sg sg;
+			struct pim_prefix_sg sg;
 
 			sg.src = c_oil->oil.mfcc_origin;
 			sg.grp = c_oil->oil.mfcc_mcastgrp;
@@ -1230,7 +1230,7 @@ void pim_mroute_update_counters(struct channel_oil *c_oil)
 
 	pim_zlookup_sg_statistics(c_oil);
 	if (ioctl(pim->mroute_socket, SIOCGETSGCNT, &sgreq)) {
-		struct prefix_sg sg;
+		struct pim_prefix_sg sg;
 
 		sg.src = c_oil->oil.mfcc_origin;
 		sg.grp = c_oil->oil.mfcc_mcastgrp;

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -152,7 +152,7 @@ static bool pim_msdp_sa_upstream_add_ok(struct pim_msdp_sa *sa,
 
 	/* check if we have a (*, G) with a non-empty immediate OIL */
 	if (!xg_up) {
-		struct prefix_sg sg;
+		struct pim_prefix_sg sg;
 
 		memset(&sg, 0, sizeof(sg));
 		sg.grp = sa->sg.grp;
@@ -237,7 +237,7 @@ static void pim_msdp_sa_free(struct pim_msdp_sa *sa)
 }
 
 static struct pim_msdp_sa *pim_msdp_sa_new(struct pim_instance *pim,
-					   struct prefix_sg *sg,
+					   struct pim_prefix_sg *sg,
 					   struct in_addr rp)
 {
 	struct pim_msdp_sa *sa;
@@ -262,7 +262,7 @@ static struct pim_msdp_sa *pim_msdp_sa_new(struct pim_instance *pim,
 }
 
 static struct pim_msdp_sa *pim_msdp_sa_find(struct pim_instance *pim,
-					    struct prefix_sg *sg)
+					    struct pim_prefix_sg *sg)
 {
 	struct pim_msdp_sa lookup;
 
@@ -271,7 +271,7 @@ static struct pim_msdp_sa *pim_msdp_sa_find(struct pim_instance *pim,
 }
 
 static struct pim_msdp_sa *pim_msdp_sa_add(struct pim_instance *pim,
-					   struct prefix_sg *sg,
+					   struct pim_prefix_sg *sg,
 					   struct in_addr rp)
 {
 	struct pim_msdp_sa *sa;
@@ -386,7 +386,7 @@ static void pim_msdp_sa_deref(struct pim_msdp_sa *sa,
 }
 
 void pim_msdp_sa_ref(struct pim_instance *pim, struct pim_msdp_peer *mp,
-		     struct prefix_sg *sg, struct in_addr rp)
+		     struct pim_prefix_sg *sg, struct in_addr rp)
 {
 	struct pim_msdp_sa *sa;
 
@@ -468,14 +468,14 @@ static bool pim_msdp_sa_local_add_ok(struct pim_upstream *up)
 }
 
 static void pim_msdp_sa_local_add(struct pim_instance *pim,
-				  struct prefix_sg *sg)
+				  struct pim_prefix_sg *sg)
 {
 	struct in_addr rp;
 	rp.s_addr = INADDR_ANY;
 	pim_msdp_sa_ref(pim, NULL /* mp */, sg, rp);
 }
 
-void pim_msdp_sa_local_del(struct pim_instance *pim, struct prefix_sg *sg)
+void pim_msdp_sa_local_del(struct pim_instance *pim, struct pim_prefix_sg *sg)
 {
 	struct pim_msdp_sa *sa;
 
@@ -488,7 +488,7 @@ void pim_msdp_sa_local_del(struct pim_instance *pim, struct prefix_sg *sg)
 /* we need to be very cautious with this API as SA del too can trigger an
  * upstream del and we will get stuck in a simple loop */
 static void pim_msdp_sa_local_del_on_up_del(struct pim_instance *pim,
-					    struct prefix_sg *sg)
+					    struct pim_prefix_sg *sg)
 {
 	struct pim_msdp_sa *sa;
 
@@ -643,7 +643,8 @@ void pim_msdp_up_join_state_changed(struct pim_instance *pim,
 	}
 }
 
-static void pim_msdp_up_xg_del(struct pim_instance *pim, struct prefix_sg *sg)
+static void pim_msdp_up_xg_del(struct pim_instance *pim,
+			       struct pim_prefix_sg *sg)
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;
@@ -667,7 +668,7 @@ static void pim_msdp_up_xg_del(struct pim_instance *pim, struct prefix_sg *sg)
 	}
 }
 
-void pim_msdp_up_del(struct pim_instance *pim, struct prefix_sg *sg)
+void pim_msdp_up_del(struct pim_instance *pim, struct pim_prefix_sg *sg)
 {
 	if (PIM_DEBUG_MSDP_INTERNAL) {
 		zlog_debug("MSDP up %s del", pim_str_sg_dump(sg));

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -78,7 +78,7 @@ enum pim_msdp_sa_flags {
 struct pim_msdp_sa {
 	struct pim_instance *pim;
 
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	char sg_str[PIM_SG_LEN];
 	struct in_addr rp;   /* Last RP address associated with this SA */
 	struct in_addr peer; /* last peer from who we heard this SA */
@@ -246,14 +246,14 @@ bool pim_msdp_peer_config_write(struct vty *vty, struct pim_instance *pim,
 				const char *spaces);
 void pim_msdp_peer_pkt_txed(struct pim_msdp_peer *mp);
 void pim_msdp_sa_ref(struct pim_instance *pim, struct pim_msdp_peer *mp,
-		     struct prefix_sg *sg, struct in_addr rp);
+		     struct pim_prefix_sg *sg, struct in_addr rp);
 void pim_msdp_sa_local_update(struct pim_upstream *up);
-void pim_msdp_sa_local_del(struct pim_instance *pim, struct prefix_sg *sg);
+void pim_msdp_sa_local_del(struct pim_instance *pim, struct pim_prefix_sg *sg);
 void pim_msdp_i_am_rp_changed(struct pim_instance *pim);
 bool pim_msdp_peer_rpf_check(struct pim_msdp_peer *mp, struct in_addr rp);
 void pim_msdp_up_join_state_changed(struct pim_instance *pim,
 				    struct pim_upstream *xg_up);
-void pim_msdp_up_del(struct pim_instance *pim, struct prefix_sg *sg);
+void pim_msdp_up_del(struct pim_instance *pim, struct pim_prefix_sg *sg);
 enum pim_msdp_err pim_msdp_mg_del(struct pim_instance *pim,
 				  const char *mesh_group_name);
 

--- a/pimd/pim_msdp_packet.c
+++ b/pimd/pim_msdp_packet.c
@@ -66,14 +66,14 @@ static char *pim_msdp_pkt_type_dump(enum pim_msdp_tlv type, char *buf,
 
 static void pim_msdp_pkt_sa_dump_one(struct stream *s)
 {
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 
 	/* just throw away the three reserved bytes */
 	stream_get3(s);
 	/* throw away the prefix length also */
 	stream_getc(s);
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.grp.s_addr = stream_get_ipv4(s);
 	sg.src.s_addr = stream_get_ipv4(s);
 
@@ -458,7 +458,8 @@ void pim_msdp_pkt_sa_tx_to_one_peer(struct pim_msdp_peer *mp)
 }
 
 void pim_msdp_pkt_sa_tx_one_to_one_peer(struct pim_msdp_peer *mp,
-					struct in_addr rp, struct prefix_sg sg)
+					struct in_addr rp,
+					struct pim_prefix_sg sg)
 {
 	struct pim_msdp_sa sa;
 
@@ -493,7 +494,7 @@ static void pim_msdp_pkt_ka_rx(struct pim_msdp_peer *mp, int len)
 static void pim_msdp_pkt_sa_rx_one(struct pim_msdp_peer *mp, struct in_addr rp)
 {
 	int prefix_len;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	struct listnode *peer_node;
 	struct pim_msdp_peer *peer;
 
@@ -501,7 +502,7 @@ static void pim_msdp_pkt_sa_rx_one(struct pim_msdp_peer *mp, struct in_addr rp)
 	stream_get3(mp->ibuf);
 	prefix_len = stream_getc(mp->ibuf);
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.grp.s_addr = stream_get_ipv4(mp->ibuf);
 	sg.src.s_addr = stream_get_ipv4(mp->ibuf);
 

--- a/pimd/pim_msdp_packet.h
+++ b/pimd/pim_msdp_packet.h
@@ -69,6 +69,7 @@ void pim_msdp_pkt_sa_tx(struct pim_instance *pim);
 void pim_msdp_pkt_sa_tx_one(struct pim_msdp_sa *sa);
 void pim_msdp_pkt_sa_tx_to_one_peer(struct pim_msdp_peer *mp);
 void pim_msdp_pkt_sa_tx_one_to_one_peer(struct pim_msdp_peer *mp,
-					struct in_addr rp, struct prefix_sg sg);
+					struct in_addr rp,
+					struct pim_prefix_sg sg);
 
 #endif

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -95,9 +95,9 @@ static void pim_if_membership_refresh(struct interface *ifp)
 					  src)) {
 
 			if (IGMP_SOURCE_TEST_FORWARDING(src->source_flags)) {
-				struct prefix_sg sg;
+				struct pim_prefix_sg sg;
 
-				memset(&sg, 0, sizeof(struct prefix_sg));
+				memset(&sg, 0, sizeof(struct pim_prefix_sg));
 				sg.src = src->source_addr;
 				sg.grp = grp->group_addr;
 				pim_ifchannel_local_membership_add(

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -39,7 +39,7 @@ char *pim_channel_oil_dump(struct channel_oil *c_oil, char *buf, size_t size)
 {
 	char *out;
 	struct interface *ifp;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	int i;
 
 	sg.src = c_oil->oil.mfcc_origin;
@@ -104,7 +104,7 @@ void pim_channel_oil_free(struct channel_oil *c_oil)
 }
 
 struct channel_oil *pim_find_channel_oil(struct pim_instance *pim,
-					 struct prefix_sg *sg)
+					 struct pim_prefix_sg *sg)
 {
 	struct channel_oil *c_oil = NULL;
 	struct channel_oil lookup;
@@ -118,7 +118,7 @@ struct channel_oil *pim_find_channel_oil(struct pim_instance *pim,
 }
 
 struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
-					struct prefix_sg *sg,
+					struct pim_prefix_sg *sg,
 					const char *name)
 {
 	struct channel_oil *c_oil;
@@ -145,7 +145,7 @@ struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
-				"%s(%s): Existing oil for %pSG4 Ref Count: %d (Post Increment)",
+				"%s(%s): Existing oil for %pPSG Ref Count: %d (Post Increment)",
 				__func__, name, sg, c_oil->oil_ref_count);
 		return c_oil;
 	}
@@ -174,11 +174,11 @@ struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
 					const char *name)
 {
 	if (PIM_DEBUG_MROUTE) {
-		struct prefix_sg sg = {.src = c_oil->oil.mfcc_mcastgrp,
+		struct pim_prefix_sg sg = {.src = c_oil->oil.mfcc_mcastgrp,
 				       .grp = c_oil->oil.mfcc_origin};
 
 		zlog_debug(
-			"%s(%s): Del oil for %pSG4, Ref Count: %d (Predecrement)",
+			"%s(%s): Del oil for %pPSG, Ref Count: %d (Predecrement)",
 			__func__, name, &sg, c_oil->oil_ref_count);
 	}
 	--c_oil->oil_ref_count;

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -123,9 +123,9 @@ void pim_oil_terminate(struct pim_instance *pim);
 
 void pim_channel_oil_free(struct channel_oil *c_oil);
 struct channel_oil *pim_find_channel_oil(struct pim_instance *pim,
-					 struct prefix_sg *sg);
+					 struct pim_prefix_sg *sg);
 struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
-					struct prefix_sg *sg,
+					struct pim_prefix_sg *sg,
 					const char *name);
 void pim_channel_oil_change_iif(struct pim_instance *pim,
 				struct channel_oil *c_oil, int input_vif_index,

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -64,7 +64,7 @@ void pim_register_join(struct pim_upstream *up)
 	pim_vxlan_update_sg_reg_state(pim, up, true /*reg_join*/);
 }
 
-void pim_register_stop_send(struct interface *ifp, struct prefix_sg *sg,
+void pim_register_stop_send(struct interface *ifp, struct pim_prefix_sg *sg,
 			    struct in_addr src, struct in_addr originator)
 {
 	struct pim_interface *pinfo;
@@ -119,12 +119,12 @@ int pim_register_stop_recv(struct interface *ifp, uint8_t *buf, int buf_size)
 	struct pim_instance *pim = pim_ifp->pim;
 	struct pim_upstream *upstream = NULL;
 	struct prefix source;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	int l;
 
 	++pim_ifp->pim_ifstat_reg_stop_recv;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	l = pim_parse_addr_group(&sg, buf, buf_size);
 	buf += l;
 	buf_size -= l;
@@ -318,7 +318,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 {
 	int sentRegisterStop = 0;
 	struct ip *ip_hdr;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	uint32_t *bits;
 	int i_am_rp = 0;
 	struct pim_interface *pim_ifp = ifp->info;
@@ -367,7 +367,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 	 * Line above.  So we need to add 4 bytes to get to the
 	 * start of the actual Encapsulated data.
 	 */
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src = ip_hdr->ip_src;
 	sg.grp = ip_hdr->ip_dst;
 
@@ -415,7 +415,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 					pim_inet4_dump("<src?>", src_addr,
 						       src_str,
 						       sizeof(src_str));
-					zlog_debug("%s: Sending register-stop to %s for %pSG4 due to prefix-list denial, dropping packet",
+					zlog_debug("%s: Sending register-stop to %s for %pPSG due to prefix-list denial, dropping packet",
 						   __func__, src_str, &sg);
 				}
 

--- a/pimd/pim_register.h
+++ b/pimd/pim_register.h
@@ -39,7 +39,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 void pim_register_send(const uint8_t *buf, int buf_size, struct in_addr src,
 		       struct pim_rpf *rpg, int null_register,
 		       struct pim_upstream *up);
-void pim_register_stop_send(struct interface *ifp, struct prefix_sg *sg,
+void pim_register_stop_send(struct interface *ifp, struct pim_prefix_sg *sg,
 			    struct in_addr src, struct in_addr originator);
 void pim_register_join(struct pim_upstream *up);
 void pim_null_register_send(struct pim_upstream *up);

--- a/pimd/pim_str.c
+++ b/pimd/pim_str.c
@@ -42,7 +42,7 @@ void pim_addr_dump(const char *onfail, struct prefix *p, char *buf,
 	errno = save_errno;
 }
 
-char *pim_str_sg_dump(const struct prefix_sg *sg)
+char *pim_str_sg_dump(const struct pim_prefix_sg *sg)
 {
 	static char sg_str[PIM_SG_LEN];
 

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -23,10 +23,36 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
-
 #include <prefix.h>
 
 typedef struct in_addr pim_addr;
+
+struct pim_prefix_sg {
+	struct in_addr src __attribute__((aligned(8)));
+	struct in_addr grp;
+};
+
+/*
+ * Longest possible length of a (S,G) string is 36 bytes
+ * 123.123.123.123 = 15 * 2
+ * (,) = 3
+ * NULL Character at end = 1
+ * (123.123.123.123,123.123.123.123)
+ */
+#define PREFIX_SG_STR_LEN 34
+
+static inline const char *pim_prefix_sg2str(const struct pim_prefix_sg *sg,
+					    char *sg_str)
+{
+	char src_str[INET_ADDRSTRLEN];
+	char grp_str[INET_ADDRSTRLEN];
+
+	prefix_mcast_inet4_dump("<src?>", sg->src, src_str, sizeof(src_str));
+	prefix_mcast_inet4_dump("<grp?>", sg->grp, grp_str, sizeof(grp_str));
+	snprintf(sg_str, PREFIX_SG_STR_LEN, "(%s,%s)", src_str, grp_str);
+
+	return sg_str;
+}
 
 /*
  * Longest possible length of a (S,G) string is 36 bytes
@@ -37,7 +63,34 @@ typedef struct in_addr pim_addr;
  */
 #define PIM_SG_LEN PREFIX_SG_STR_LEN
 #define pim_inet4_dump prefix_mcast_inet4_dump
-#define pim_str_sg_set prefix_sg2str
+#define pim_str_sg_set pim_prefix_sg2str
+
+printfrr_ext_autoreg_p("PSG", printfrr_psg)
+static ssize_t printfrr_psg(struct fbuf *buf, struct printfrr_eargs *ea,
+			    const void *ptr)
+{
+	const struct pim_prefix_sg *sg = ptr;
+	ssize_t ret = 0;
+
+	if (!sg)
+		return bputs(buf, "(null)");
+
+	if (sg->src.s_addr == INADDR_ANY)
+		ret += bputs(buf, "(*,");
+	else
+		ret += bprintfrr(buf, "(%pI4,", &sg->src);
+
+	if (sg->grp.s_addr == INADDR_ANY)
+		ret += bputs(buf, "*)");
+	else
+		ret += bprintfrr(buf, "%pI4)", &sg->grp);
+
+	return ret;
+}
+
+#ifdef _FRR_ATTRIBUTE_PRINTFRR
+#pragma FRR printfrr_ext "%pPSG" (struct pim_prefix_sg *)
+#endif
 
 static inline void pim_addr_copy(pim_addr *dest, pim_addr *source)
 {
@@ -58,6 +111,6 @@ void pim_addr_dump(const char *onfail, struct prefix *p, char *buf,
 		   int buf_size);
 void pim_inet4_dump(const char *onfail, struct in_addr addr, char *buf,
 		    int buf_size);
-char *pim_str_sg_dump(const struct prefix_sg *sg);
+char *pim_str_sg_dump(const struct pim_prefix_sg *sg);
 
 #endif

--- a/pimd/pim_tlv.c
+++ b/pimd/pim_tlv.c
@@ -510,7 +510,8 @@ int pim_parse_addr_ucast(struct prefix *p, const uint8_t *buf, int buf_size)
 	return addr - buf;
 }
 
-int pim_parse_addr_group(struct prefix_sg *sg, const uint8_t *buf, int buf_size)
+int pim_parse_addr_group(struct pim_prefix_sg *sg, const uint8_t *buf,
+			 int buf_size)
 {
 	const int grp_encoding_min_len =
 		4; /* 1 family + 1 type + 1 reserved + 1 addr */
@@ -569,7 +570,7 @@ int pim_parse_addr_group(struct prefix_sg *sg, const uint8_t *buf, int buf_size)
 	return addr - buf;
 }
 
-int pim_parse_addr_source(struct prefix_sg *sg, uint8_t *flags,
+int pim_parse_addr_source(struct pim_prefix_sg *sg, uint8_t *flags,
 			  const uint8_t *buf, int buf_size)
 {
 	const int src_encoding_min_len =

--- a/pimd/pim_tlv.h
+++ b/pimd/pim_tlv.h
@@ -111,9 +111,9 @@ int pim_encode_addr_group(uint8_t *buf, afi_t afi, int bidir, int scope,
 			  struct in_addr group);
 
 int pim_parse_addr_ucast(struct prefix *p, const uint8_t *buf, int buf_size);
-int pim_parse_addr_group(struct prefix_sg *sg, const uint8_t *buf,
+int pim_parse_addr_group(struct pim_prefix_sg *sg, const uint8_t *buf,
 			 int buf_size);
-int pim_parse_addr_source(struct prefix_sg *sg, uint8_t *flags,
+int pim_parse_addr_source(struct pim_prefix_sg *sg, uint8_t *flags,
 			  const uint8_t *buf, int buf_size);
 
 #endif /* PIM_TLV_H */

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -131,7 +131,7 @@ static void pim_upstream_find_new_children(struct pim_instance *pim,
 static struct pim_upstream *pim_upstream_find_parent(struct pim_instance *pim,
 						     struct pim_upstream *child)
 {
-	struct prefix_sg any = child->sg;
+	struct pim_prefix_sg any = child->sg;
 	struct pim_upstream *up = NULL;
 
 	// (S,G)
@@ -860,7 +860,7 @@ void pim_upstream_fill_static_iif(struct pim_upstream *up,
 }
 
 static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
-					     struct prefix_sg *sg,
+					     struct pim_prefix_sg *sg,
 					     struct interface *incoming,
 					     int flags,
 					     struct pim_ifchannel *ch)
@@ -1013,7 +1013,7 @@ uint32_t pim_up_mlag_peer_cost(struct pim_upstream *up)
 }
 
 struct pim_upstream *pim_upstream_find(struct pim_instance *pim,
-				       struct prefix_sg *sg)
+				       struct pim_prefix_sg *sg)
 {
 	struct pim_upstream lookup;
 	struct pim_upstream *up = NULL;
@@ -1023,7 +1023,7 @@ struct pim_upstream *pim_upstream_find(struct pim_instance *pim,
 	return up;
 }
 
-struct pim_upstream *pim_upstream_find_or_add(struct prefix_sg *sg,
+struct pim_upstream *pim_upstream_find_or_add(struct pim_prefix_sg *sg,
 		struct interface *incoming,
 		int flags, const char *name)
 {
@@ -1070,7 +1070,7 @@ void pim_upstream_ref(struct pim_upstream *up, int flags, const char *name)
 }
 
 struct pim_upstream *pim_upstream_add(struct pim_instance *pim,
-				      struct prefix_sg *sg,
+				      struct pim_prefix_sg *sg,
 				      struct interface *incoming, int flags,
 				      const char *name,
 				      struct pim_ifchannel *ch)
@@ -1584,7 +1584,7 @@ void pim_upstream_msdp_reg_timer_start(struct pim_upstream *up)
  *  received for the source and group.
  */
 int pim_upstream_switch_to_spt_desired_on_rp(struct pim_instance *pim,
-				       struct prefix_sg *sg)
+				       struct pim_prefix_sg *sg)
 {
 	if (I_am_RP(pim, sg->grp))
 		return 1;

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -231,7 +231,7 @@ struct pim_upstream {
 	struct pim_upstream *parent;
 	pim_addr upstream_addr;		  /* Who we are talking to */
 	pim_addr upstream_register;       /*Who we received a register from*/
-	struct prefix_sg sg;		  /* (S,G) group key */
+	struct pim_prefix_sg sg;		  /* (S,G) group key */
 	char sg_str[PIM_SG_LEN];
 	uint32_t flags;
 	struct channel_oil *channel_oil;
@@ -291,12 +291,12 @@ static inline bool pim_up_mlag_is_local(struct pim_upstream *up)
 }
 
 struct pim_upstream *pim_upstream_find(struct pim_instance *pim,
-				       struct prefix_sg *sg);
-struct pim_upstream *pim_upstream_find_or_add(struct prefix_sg *sg,
+				       struct pim_prefix_sg *sg);
+struct pim_upstream *pim_upstream_find_or_add(struct pim_prefix_sg *sg,
 					      struct interface *ifp, int flags,
 					      const char *name);
 struct pim_upstream *pim_upstream_add(struct pim_instance *pim,
-				      struct prefix_sg *sg,
+				      struct pim_prefix_sg *sg,
 				      struct interface *ifp, int flags,
 				      const char *name,
 				      struct pim_ifchannel *ch);
@@ -338,7 +338,7 @@ void pim_upstream_keep_alive_timer_start(struct pim_upstream *up,
 					 uint32_t time);
 
 int pim_upstream_switch_to_spt_desired_on_rp(struct pim_instance *pim,
-				       struct prefix_sg *sg);
+				       struct pim_prefix_sg *sg);
 #define SwitchToSptDesiredOnRp(pim, sg) pim_upstream_switch_to_spt_desired_on_rp (pim, sg)
 int pim_upstream_is_sg_rpt(struct pim_upstream *up);
 

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -734,7 +734,7 @@ static bool pim_vxlan_sg_hash_eq(const void *p1, const void *p2)
 }
 
 static struct pim_vxlan_sg *pim_vxlan_sg_new(struct pim_instance *pim,
-		struct prefix_sg *sg)
+		struct pim_prefix_sg *sg)
 {
 	struct pim_vxlan_sg *vxlan_sg;
 
@@ -761,7 +761,7 @@ static struct pim_vxlan_sg *pim_vxlan_sg_new(struct pim_instance *pim,
 }
 
 struct pim_vxlan_sg *pim_vxlan_sg_find(struct pim_instance *pim,
-		struct prefix_sg *sg)
+		struct pim_prefix_sg *sg)
 {
 	struct pim_vxlan_sg lookup;
 
@@ -770,7 +770,7 @@ struct pim_vxlan_sg *pim_vxlan_sg_find(struct pim_instance *pim,
 }
 
 struct pim_vxlan_sg *pim_vxlan_sg_add(struct pim_instance *pim,
-		struct prefix_sg *sg)
+		struct pim_prefix_sg *sg)
 {
 	struct pim_vxlan_sg *vxlan_sg;
 
@@ -805,7 +805,7 @@ static void pim_vxlan_sg_del_item(struct pim_vxlan_sg *vxlan_sg)
 	XFREE(MTYPE_PIM_VXLAN_SG, vxlan_sg);
 }
 
-void pim_vxlan_sg_del(struct pim_instance *pim, struct prefix_sg *sg)
+void pim_vxlan_sg_del(struct pim_instance *pim, struct pim_prefix_sg *sg)
 {
 	struct pim_vxlan_sg *vxlan_sg;
 

--- a/pimd/pim_vxlan.h
+++ b/pimd/pim_vxlan.h
@@ -41,7 +41,7 @@ struct pim_vxlan_sg {
 	struct pim_instance *pim;
 
 	/* key */
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	char sg_str[PIM_SG_LEN];
 
 	enum pim_vxlan_sg_flags flags;
@@ -127,10 +127,11 @@ static inline bool pim_vxlan_is_term_dev_cfg(struct pim_instance *pim,
 
 extern struct pim_vxlan *pim_vxlan_p;
 extern struct pim_vxlan_sg *pim_vxlan_sg_find(struct pim_instance *pim,
-					    struct prefix_sg *sg);
+					    struct pim_prefix_sg *sg);
 extern struct pim_vxlan_sg *pim_vxlan_sg_add(struct pim_instance *pim,
-					   struct prefix_sg *sg);
-extern void pim_vxlan_sg_del(struct pim_instance *pim, struct prefix_sg *sg);
+					   struct pim_prefix_sg *sg);
+extern void pim_vxlan_sg_del(struct pim_instance *pim,
+			     struct pim_prefix_sg *sg);
 extern void pim_vxlan_update_sg_reg_state(struct pim_instance *pim,
 		struct pim_upstream *up, bool reg_join);
 extern struct pim_interface *pim_vxlan_get_term_ifp(struct pim_instance *pim);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -327,7 +327,8 @@ static int pim_zebra_vxlan_sg_proc(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s;
 	struct pim_instance *pim;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
+	size_t prefixlen;
 
 	pim = pim_get_pim_instance(vrf_id);
 	if (!pim)
@@ -335,10 +336,9 @@ static int pim_zebra_vxlan_sg_proc(ZAPI_CALLBACK_ARGS)
 
 	s = zclient->ibuf;
 
-	sg.family = AF_INET;
-	sg.prefixlen = stream_getl(s);
-	stream_get(&sg.src.s_addr, s, sg.prefixlen);
-	stream_get(&sg.grp.s_addr, s, sg.prefixlen);
+	prefixlen = stream_getl(s);
+	stream_get(&sg.src.s_addr, s, prefixlen);
+	stream_get(&sg.grp.s_addr, s, prefixlen);
 
 	if (PIM_DEBUG_ZEBRA) {
 		char sg_str[PIM_SG_LEN];
@@ -502,7 +502,7 @@ void igmp_anysource_forward_stop(struct gm_group *group)
 static void igmp_source_forward_reevaluate_one(struct pim_instance *pim,
 					       struct gm_source *source)
 {
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	struct gm_group *group = source->source_group;
 	struct pim_ifchannel *ch;
 
@@ -510,7 +510,7 @@ static void igmp_source_forward_reevaluate_one(struct pim_instance *pim,
 	    || !IGMP_SOURCE_TEST_FORWARDING(source->source_flags))
 		return;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src = source->source_addr;
 	sg.grp = group->group_addr;
 
@@ -581,11 +581,11 @@ void igmp_source_forward_start(struct pim_instance *pim,
 {
 	struct pim_interface *pim_oif;
 	struct gm_group *group;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	int result;
 	int input_iface_vif_index = 0;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src = source->source_addr;
 	sg.grp = source->source_group->group_addr;
 
@@ -761,10 +761,10 @@ void igmp_source_forward_start(struct pim_instance *pim,
 void igmp_source_forward_stop(struct gm_source *source)
 {
 	struct gm_group *group;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	int result;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(struct pim_prefix_sg));
 	sg.src = source->source_addr;
 	sg.grp = source->source_group->group_addr;
 

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -524,14 +524,14 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 	struct stream *s = zlookup->obuf;
 	uint16_t command = 0;
 	unsigned long long lastused;
-	struct prefix_sg sg;
+	struct pim_prefix_sg sg;
 	int count = 0;
 	int ret;
 	struct interface *ifp =
 		pim_if_find_by_vif_index(c_oil->pim, c_oil->oil.mfcc_parent);
 
 	if (PIM_DEBUG_ZEBRA) {
-		struct prefix_sg more;
+		struct pim_prefix_sg more;
 
 		more.src = c_oil->oil.mfcc_origin;
 		more.grp = c_oil->oil.mfcc_mcastgrp;
@@ -587,7 +587,7 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 	if (sg.src.s_addr != c_oil->oil.mfcc_origin.s_addr
 	    || sg.grp.s_addr != c_oil->oil.mfcc_mcastgrp.s_addr) {
 		if (PIM_DEBUG_ZEBRA) {
-			struct prefix_sg more;
+			struct pim_prefix_sg more;
 
 			more.src = c_oil->oil.mfcc_origin;
 			more.grp = c_oil->oil.mfcc_mcastgrp;


### PR DESCRIPTION
Adding pim_prefix_sg separate for pimd

We will  do the below changes as part of #10194. This will take care for both IPV4 and IPV6
struct pim_prefix_sg {
        struct PIM_ADDR src __attribute__((aligned(8)));
        struct PIM_ADDR grp;
};
Reviewed-by: Mobashshera Rasool <mrasool@vmware.com>
Signed-off-by: sarita patra <saritap@vmware.com>