### PR TITLE
pimd: rename IGMP members in pim_interface for MLD use

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -508,7 +508,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 		if (!pim_ifp)
 			continue;
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node,
 					  igmp)) {
 			char uptime[10];
 			char query_hhmmss[10];
@@ -610,7 +610,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 		if (strcmp(ifname, "detail") && strcmp(ifname, ifp->name))
 			continue;
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node,
 					  igmp)) {
 			found_ifname = 1;
 			pim_time_uptime(uptime, sizeof(uptime),
@@ -625,35 +625,34 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 			gmi_msec = PIM_IGMP_GMI_MSEC(
 				igmp->querier_robustness_variable,
 				igmp->querier_query_interval,
-				pim_ifp->igmp_query_max_response_time_dsec);
+				pim_ifp->gm_query_max_response_time_dsec);
 
-			sqi = PIM_IGMP_SQI(
-				pim_ifp->igmp_default_query_interval);
+			sqi = PIM_IGMP_SQI(pim_ifp->gm_default_query_interval);
 
 			oqpi_msec = PIM_IGMP_OQPI_MSEC(
 				igmp->querier_robustness_variable,
 				igmp->querier_query_interval,
-				pim_ifp->igmp_query_max_response_time_dsec);
+				pim_ifp->gm_query_max_response_time_dsec);
 
 			lmqt_msec = PIM_IGMP_LMQT_MSEC(
-				pim_ifp->igmp_specific_query_max_response_time_dsec,
-				pim_ifp->igmp_last_member_query_count);
+				pim_ifp->gm_specific_query_max_response_time_dsec,
+				pim_ifp->gm_last_member_query_count);
 
 			ohpi_msec =
 				PIM_IGMP_OHPI_DSEC(
 					igmp->querier_robustness_variable,
 					igmp->querier_query_interval,
-					pim_ifp->igmp_query_max_response_time_dsec)
-				* 100;
+					pim_ifp->gm_query_max_response_time_dsec) *
+				100;
 
-			qri_msec = pim_ifp->igmp_query_max_response_time_dsec
-				* 100;
+			qri_msec =
+				pim_ifp->gm_query_max_response_time_dsec * 100;
 			if (pim_ifp->pim_sock_fd >= 0)
 				mloop = pim_socket_mcastloop_get(
 					pim_ifp->pim_sock_fd);
 			else
 				mloop = 0;
-			lmqc = pim_ifp->igmp_last_member_query_count;
+			lmqc = pim_ifp->gm_last_member_query_count;
 
 			if (uj) {
 				json_row = json_object_new_object();
@@ -833,14 +832,14 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 		if (!pim_ifp)
 			continue;
 
-		if (!pim_ifp->igmp_join_list)
+		if (!pim_ifp->gm_join_list)
 			continue;
 
 		pri_addr = pim_find_primary_addr(ifp);
 		pim_inet4_dump("<pri?>", pri_addr, pri_addr_str,
 			       sizeof(pri_addr_str));
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_join_list, join_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_join_list, join_node,
 					  ij)) {
 			char group_str[INET_ADDRSTRLEN];
 			char source_str[INET_ADDRSTRLEN];
@@ -887,7 +886,7 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 					ifp->name, pri_addr_str, source_str,
 					group_str, ij->sock_fd, uptime);
 			}
-		} /* for (pim_ifp->igmp_join_list) */
+		} /* for (pim_ifp->gm_join_list) */
 
 	} /* for (iflist) */
 
@@ -1340,7 +1339,7 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 		if (ifname && strcmp(ifname, ifp->name))
 			continue;
 
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node,
 					  igmp)) {
 			igmp_stats_add(&rx_stats, &igmp->rx_stats);
 		}
@@ -3429,7 +3428,7 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			char hhmmss[10];
@@ -3523,7 +3522,7 @@ static void igmp_show_group_retransmission(struct pim_instance *pim,
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			char grp_retr_mmss[10];
@@ -3576,7 +3575,7 @@ static void igmp_show_sources(struct pim_instance *pim, struct vty *vty)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			struct listnode *srcnode;
@@ -3610,7 +3609,7 @@ static void igmp_show_sources(struct pim_instance *pim, struct vty *vty)
 					uptime);
 
 			} /* scan group sources */
-		}	  /* scan igmp groups */
+		}	 /* scan igmp groups */
 	}		  /* scan interfaces */
 }
 
@@ -3632,7 +3631,7 @@ static void igmp_show_source_retransmission(struct pim_instance *pim,
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  grp)) {
 			char group_str[INET_ADDRSTRLEN];
 			struct listnode *srcnode;
@@ -3654,7 +3653,7 @@ static void igmp_show_source_retransmission(struct pim_instance *pim,
 					src->source_query_retransmit_count);
 
 			} /* scan group sources */
-		}	  /* scan igmp groups */
+		}	 /* scan igmp groups */
 	}		  /* scan interfaces */
 }
 
@@ -3923,9 +3922,9 @@ static void clear_mroute(struct pim_instance *pim)
 
 		/* clean up all igmp groups */
 
-		if (pim_ifp->igmp_group_list) {
-			while (pim_ifp->igmp_group_list->count) {
-				grp = listnode_head(pim_ifp->igmp_group_list);
+		if (pim_ifp->gm_group_list) {
+			while (pim_ifp->gm_group_list->count) {
+				grp = listnode_head(pim_ifp->gm_group_list);
 				igmp_group_delete(grp);
 			}
 		}

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -125,15 +125,14 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	pim_ifp->mroute_vif_index = -1;
 
 	pim_ifp->igmp_version = IGMP_DEFAULT_VERSION;
-	pim_ifp->igmp_default_robustness_variable =
+	pim_ifp->gm_default_robustness_variable =
 		IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
-	pim_ifp->igmp_default_query_interval = IGMP_GENERAL_QUERY_INTERVAL;
-	pim_ifp->igmp_query_max_response_time_dsec =
+	pim_ifp->gm_default_query_interval = IGMP_GENERAL_QUERY_INTERVAL;
+	pim_ifp->gm_query_max_response_time_dsec =
 		IGMP_QUERY_MAX_RESPONSE_TIME_DSEC;
-	pim_ifp->igmp_specific_query_max_response_time_dsec =
+	pim_ifp->gm_specific_query_max_response_time_dsec =
 		IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC;
-	pim_ifp->igmp_last_member_query_count =
-		IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
+	pim_ifp->gm_last_member_query_count = IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
 
 	/* BSM config on interface: true by default */
 	pim_ifp->bsm_enable = true;
@@ -145,8 +144,8 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	  The number of seconds represented by the [Query Response Interval]
 	  must be less than the [Query Interval].
 	 */
-	assert(pim_ifp->igmp_query_max_response_time_dsec
-	       < pim_ifp->igmp_default_query_interval);
+	assert(pim_ifp->gm_query_max_response_time_dsec <
+	       pim_ifp->gm_default_query_interval);
 
 	if (pim)
 		PIM_IF_DO_PIM(pim_ifp->options);
@@ -155,7 +154,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 
 	PIM_IF_DO_IGMP_LISTEN_ALLROUTERS(pim_ifp->options);
 
-	pim_ifp->igmp_join_list = NULL;
+	pim_ifp->gm_join_list = NULL;
 	pim_ifp->pim_neighbor_list = NULL;
 	pim_ifp->upstream_switch_list = NULL;
 	pim_ifp->pim_generation_id = 0;
@@ -200,7 +199,7 @@ void pim_if_delete(struct interface *ifp)
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
 
-	if (pim_ifp->igmp_join_list) {
+	if (pim_ifp->gm_join_list) {
 		pim_if_igmp_join_del_all(ifp);
 	}
 
@@ -535,27 +534,27 @@ void pim_if_addr_add(struct connected *ifc)
 		struct gm_sock *igmp;
 
 		/* lookup IGMP socket */
-		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list,
+		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->gm_socket_list,
 						   ifaddr);
 		if (!igmp) {
 			/* if addr new, add IGMP socket */
 			if (ifc->address->family == AF_INET)
-				pim_igmp_sock_add(pim_ifp->igmp_socket_list,
+				pim_igmp_sock_add(pim_ifp->gm_socket_list,
 						  ifaddr, ifp, false);
 		} else if (igmp->mtrace_only) {
 			igmp_sock_delete(igmp);
-			pim_igmp_sock_add(pim_ifp->igmp_socket_list, ifaddr,
-					  ifp, false);
+			pim_igmp_sock_add(pim_ifp->gm_socket_list, ifaddr, ifp,
+					  false);
 		}
 
 		/* Replay Static IGMP groups */
-		if (pim_ifp->igmp_join_list) {
+		if (pim_ifp->gm_join_list) {
 			struct listnode *node;
 			struct listnode *nextnode;
 			struct gm_join *ij;
 			int join_fd;
 
-			for (ALL_LIST_ELEMENTS(pim_ifp->igmp_join_list, node,
+			for (ALL_LIST_ELEMENTS(pim_ifp->gm_join_list, node,
 					       nextnode, ij)) {
 				/* Close socket and reopen with Source and Group
 				 */
@@ -586,14 +585,14 @@ void pim_if_addr_add(struct connected *ifc)
 		struct gm_sock *igmp;
 
 		/* lookup IGMP socket */
-		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list,
+		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->gm_socket_list,
 						   ifaddr);
 		if (ifc->address->family == AF_INET) {
 			if (igmp)
 				igmp_sock_delete(igmp);
 			/* if addr new, add IGMP socket */
-			pim_igmp_sock_add(pim_ifp->igmp_socket_list, ifaddr,
-					  ifp, true);
+			pim_igmp_sock_add(pim_ifp->gm_socket_list, ifaddr, ifp,
+					  true);
 		}
 	} /* igmp mtrace only */
 
@@ -664,7 +663,7 @@ static void pim_if_addr_del_igmp(struct connected *ifc)
 	ifaddr = ifc->address->u.prefix4;
 
 	/* lookup IGMP socket */
-	igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list, ifaddr);
+	igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->gm_socket_list, ifaddr);
 	if (igmp) {
 		/* if addr found, del IGMP socket */
 		igmp_sock_delete(igmp);
@@ -1245,7 +1244,7 @@ static struct gm_join *igmp_join_new(struct interface *ifp,
 	ij->source_addr = source_addr;
 	ij->sock_creation = pim_time_monotonic_sec();
 
-	listnode_add(pim_ifp->igmp_join_list, ij);
+	listnode_add(pim_ifp->gm_join_list, ij);
 
 	return ij;
 }
@@ -1262,12 +1261,12 @@ ferr_r pim_if_igmp_join_add(struct interface *ifp, struct in_addr group_addr,
 					ifp->name);
 	}
 
-	if (!pim_ifp->igmp_join_list) {
-		pim_ifp->igmp_join_list = list_new();
-		pim_ifp->igmp_join_list->del = (void (*)(void *))igmp_join_free;
+	if (!pim_ifp->gm_join_list) {
+		pim_ifp->gm_join_list = list_new();
+		pim_ifp->gm_join_list->del = (void (*)(void *))igmp_join_free;
 	}
 
-	ij = igmp_join_find(pim_ifp->igmp_join_list, group_addr, source_addr);
+	ij = igmp_join_find(pim_ifp->gm_join_list, group_addr, source_addr);
 
 	/* This interface has already been configured to join this IGMP group
 	 */
@@ -1306,13 +1305,13 @@ int pim_if_igmp_join_del(struct interface *ifp, struct in_addr group_addr,
 		return -1;
 	}
 
-	if (!pim_ifp->igmp_join_list) {
+	if (!pim_ifp->gm_join_list) {
 		zlog_warn("%s: no IGMP join on interface %s", __func__,
 			  ifp->name);
 		return -2;
 	}
 
-	ij = igmp_join_find(pim_ifp->igmp_join_list, group_addr, source_addr);
+	ij = igmp_join_find(pim_ifp->gm_join_list, group_addr, source_addr);
 	if (!ij) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
@@ -1339,11 +1338,11 @@ int pim_if_igmp_join_del(struct interface *ifp, struct in_addr group_addr,
 			errno, safe_strerror(errno));
 		/* warning only */
 	}
-	listnode_delete(pim_ifp->igmp_join_list, ij);
+	listnode_delete(pim_ifp->gm_join_list, ij);
 	igmp_join_free(ij);
-	if (listcount(pim_ifp->igmp_join_list) < 1) {
-		list_delete(&pim_ifp->igmp_join_list);
-		pim_ifp->igmp_join_list = 0;
+	if (listcount(pim_ifp->gm_join_list) < 1) {
+		list_delete(&pim_ifp->gm_join_list);
+		pim_ifp->gm_join_list = 0;
 	}
 
 	return 0;
@@ -1363,10 +1362,10 @@ static void pim_if_igmp_join_del_all(struct interface *ifp)
 		return;
 	}
 
-	if (!pim_ifp->igmp_join_list)
+	if (!pim_ifp->gm_join_list)
 		return;
 
-	for (ALL_LIST_ELEMENTS(pim_ifp->igmp_join_list, node, nextnode, ij))
+	for (ALL_LIST_ELEMENTS(pim_ifp->gm_join_list, node, nextnode, ij))
 		pim_if_igmp_join_del(ifp, ij->group_addr, ij->source_addr);
 }
 

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -99,25 +99,28 @@ struct pim_interface {
 	struct list *sec_addr_list;     /* list of struct pim_secondary_addr */
 	pim_addr update_source;		/* user can statically set the primary
 					 * address of the interface */
-	int igmp_version;		/* IGMP or MLD version */
-	int igmp_default_robustness_variable; /* IGMP or MLD QRV */
-	int igmp_default_query_interval; /* IGMP or MLD secs between general
-					    queries */
-	int igmp_query_max_response_time_dsec; /* IGMPv3 Max Response Time in
+
+	int igmp_version;		     /* IGMP version */
+	int gm_default_robustness_variable;  /* IGMP or MLD QRV */
+	int gm_default_query_interval;       /* IGMP or MLD secs between general
+						  queries */
+	int gm_query_max_response_time_dsec; /* IGMP or MLD Max Response Time in
 						  dsecs for general queries */
-	int igmp_specific_query_max_response_time_dsec; /* IGMPv3 Max Response
-							   Time in dsecs called
-							   as last member query
-							   interval, defines the
-							   maximum response time
-							   advertised in IGMP
-							   group-specific
-							   queries */
-	int igmp_last_member_query_count; /* IGMP last member query count */
-	struct list *igmp_socket_list; /* list of struct igmp_sock */
-	struct list *igmp_join_list;   /* list of struct igmp_join */
-	struct list *igmp_group_list;  /* list of struct igmp_group */
-	struct hash *igmp_group_hash;
+	int gm_specific_query_max_response_time_dsec; /* IGMP or MLD Max
+							 Response Time in dsecs
+							 called as last member
+							 query interval, defines
+							 the maximum response
+							 time advertised in IGMP
+							 group-specific
+							 queries */
+	int gm_last_member_query_count;		      /* IGMP or MLD last member
+							 query count
+						       */
+	struct list *gm_socket_list; /* list of struct IGMP or MLD sock */
+	struct list *gm_join_list;   /* list of struct IGMP or MLD join */
+	struct list *gm_group_list;  /* list of struct IGMP or MLD group */
+	struct hash *gm_group_hash;
 
 	int pim_sock_fd;		/* PIM socket file descriptor */
 	struct thread *t_pim_sock_read; /* thread for reading PIM socket */
@@ -188,8 +191,8 @@ struct pim_interface {
 };
 
 /*
-  if default_holdtime is set (>= 0), use it;
-  otherwise default_holdtime is 3.5 * hello_period
+ * if default_holdtime is set (>= 0), use it;
+ * otherwise default_holdtime is 3.5 * hello_period
  */
 #define PIM_IF_DEFAULT_HOLDTIME(pim_ifp)                                       \
 	(((pim_ifp)->pim_default_holdtime < 0)                                 \

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -65,12 +65,12 @@ static inline long igmp_gmi_msec(struct gm_group *group)
 
 	long qrv = 0, qqi = 0;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node, igmp)) {
 		qrv = MAX(qrv, igmp->querier_robustness_variable);
 		qqi = MAX(qqi, igmp->querier_query_interval);
 	}
 	return PIM_IGMP_GMI_MSEC(qrv, qqi,
-				 pim_ifp->igmp_query_max_response_time_dsec);
+				 pim_ifp->gm_query_max_response_time_dsec);
 }
 
 void igmp_group_reset_gmi(struct gm_group *group)
@@ -984,12 +984,12 @@ static void igmp_send_query_group(struct gm_group *group, char *query_buf,
 	struct gm_sock *igmp;
 	struct listnode *sock_node;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node, igmp)) {
 		igmp_send_query(
 			pim_ifp->igmp_version, group, igmp->fd, ifp->name,
 			query_buf, query_buf_size, num_sources,
 			group->group_addr, group->group_addr,
-			pim_ifp->igmp_specific_query_max_response_time_dsec,
+			pim_ifp->gm_specific_query_max_response_time_dsec,
 			s_flag, igmp->querier_robustness_variable,
 			igmp->querier_query_interval);
 	}
@@ -1021,8 +1021,8 @@ static void group_retransmit_group(struct gm_group *group)
 
 	char query_buf[query_buf_size];
 
-	lmqc = pim_ifp->igmp_last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->gm_last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/*
@@ -1091,8 +1091,8 @@ static int group_retransmit_sources(struct gm_group *group,
 
 	pim_ifp = group->interface->info;
 
-	lmqc = pim_ifp->igmp_last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->gm_last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/* Scan all group sources */
@@ -1283,7 +1283,7 @@ static void group_retransmit_timer_on(struct gm_group *group)
 
 	pim_ifp = group->interface->info;
 
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
@@ -1319,7 +1319,7 @@ static void group_query_send(struct gm_group *group)
 	long lmqc; /* Last Member Query Count */
 
 	pim_ifp = group->interface->info;
-	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqc = pim_ifp->gm_last_member_query_count;
 
 	/* lower group timer to lmqt */
 	igmp_group_timer_lower_to_lmqt(group);
@@ -1352,8 +1352,8 @@ static void source_query_send_by_flag(struct gm_group *group,
 
 	pim_ifp = group->interface->info;
 
-	lmqc = pim_ifp->igmp_last_member_query_count;
-	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->gm_last_member_query_count;
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/*
@@ -1509,8 +1509,8 @@ void igmp_group_timer_lower_to_lmqt(struct gm_group *group)
 	pim_ifp = ifp->info;
 	ifname = ifp->name;
 
-	lmqi_dsec = pim_ifp->igmp_specific_query_max_response_time_dsec;
-	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqi_dsec = pim_ifp->gm_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->gm_last_member_query_count;
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
@@ -1544,8 +1544,8 @@ void igmp_source_timer_lower_to_lmqt(struct gm_source *source)
 	pim_ifp = ifp->info;
 	ifname = ifp->name;
 
-	lmqi_dsec = pim_ifp->igmp_specific_query_max_response_time_dsec;
-	lmqc = pim_ifp->igmp_last_member_query_count;
+	lmqi_dsec = pim_ifp->gm_specific_query_max_response_time_dsec;
+	lmqc = pim_ifp->gm_last_member_query_count;
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
@@ -1717,7 +1717,7 @@ void igmp_v3_recv_query(struct gm_sock *igmp, const char *from_str,
 	resv_s_qrv = igmp_msg[8];
 	qrv = 7 & resv_s_qrv;
 	igmp->querier_robustness_variable =
-		qrv ? qrv : pim_ifp->igmp_default_robustness_variable;
+		qrv ? qrv : pim_ifp->gm_default_robustness_variable;
 
 	/*
 	 * RFC 3376: 4.1.7. QQIC (Querier's Query Interval Code)
@@ -1734,7 +1734,7 @@ void igmp_v3_recv_query(struct gm_sock *igmp, const char *from_str,
 		qqic = igmp_msg[9];
 		qqi = igmp_msg_decode8to16(qqic);
 		igmp->querier_query_interval =
-			qqi ? qqi : pim_ifp->igmp_default_query_interval;
+			qqi ? qqi : pim_ifp->gm_default_query_interval;
 
 		if (PIM_DEBUG_IGMP_TRACE) {
 			char ifaddr_str[INET_ADDRSTRLEN];

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -626,7 +626,8 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 
 		pim_ifp = ifp->info;
 		ifaddr = connected_src->u.prefix4;
-		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->igmp_socket_list, ifaddr);
+		igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->gm_socket_list,
+						   ifaddr);
 
 		if (PIM_DEBUG_IGMP_PACKETS) {
 			zlog_debug(

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -86,7 +86,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 	 */
 
 	/* scan igmp groups */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode, grp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode, grp)) {
 		struct listnode *srcnode;
 		struct gm_source *src;
 
@@ -105,7 +105,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 			}
 
 		} /* scan group sources */
-	}	  /* scan igmp groups */
+	}	 /* scan igmp groups */
 
 	/*
 	 * Finally delete every PIM (S,G) entry lacking all state info
@@ -381,16 +381,16 @@ static void igmp_sock_query_interval_reconfig(struct gm_sock *igmp)
 		char ifaddr_str[INET_ADDRSTRLEN];
 
 		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
-				sizeof(ifaddr_str));
+			       sizeof(ifaddr_str));
 		zlog_debug("%s: Querier %s on %s reconfig query_interval=%d",
-				__func__, ifaddr_str, ifp->name,
-				pim_ifp->igmp_default_query_interval);
+			   __func__, ifaddr_str, ifp->name,
+			   pim_ifp->gm_default_query_interval);
 	}
 
 	/*
 	 * igmp_startup_mode_on() will reset QQI:
 
-	 * igmp->querier_query_interval = pim_ifp->igmp_default_query_interval;
+	 * igmp->querier_query_interval = pim_ifp->gm_default_query_interval;
 	 */
 	igmp_startup_mode_on(igmp);
 }
@@ -430,9 +430,9 @@ static void change_query_interval(struct pim_interface *pim_ifp,
 	struct listnode *sock_node;
 	struct gm_sock *igmp;
 
-	pim_ifp->igmp_default_query_interval = query_interval;
+	pim_ifp->gm_default_query_interval = query_interval;
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node, igmp)) {
 		igmp_sock_query_interval_reconfig(igmp);
 		igmp_sock_query_reschedule(igmp);
 	}
@@ -446,12 +446,11 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	struct listnode *grp_node;
 	struct gm_group *grp;
 
-	if (pim_ifp->igmp_query_max_response_time_dsec
-	    == query_max_response_time_dsec)
+	if (pim_ifp->gm_query_max_response_time_dsec ==
+	    query_max_response_time_dsec)
 		return;
 
-	pim_ifp->igmp_query_max_response_time_dsec =
-		query_max_response_time_dsec;
+	pim_ifp->gm_query_max_response_time_dsec = query_max_response_time_dsec;
 
 	/*
 	 * Below we modify socket/group/source timers in order to quickly
@@ -460,13 +459,13 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 	 */
 
 	/* scan all sockets */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node, igmp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node, igmp)) {
 		/* reschedule socket general query */
 		igmp_sock_query_reschedule(igmp);
 	}
 
 	/* scan socket groups */
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grp_node, grp)) {
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grp_node, grp)) {
 		struct listnode *src_node;
 		struct gm_source *src;
 
@@ -2690,7 +2689,7 @@ int lib_interface_igmp_last_member_query_interval_modify(
 		pim_ifp = ifp->info;
 		last_member_query_interval =
 			yang_dnode_get_uint16(args->dnode, NULL);
-		pim_ifp->igmp_specific_query_max_response_time_dsec =
+		pim_ifp->gm_specific_query_max_response_time_dsec =
 			last_member_query_interval;
 
 		break;
@@ -2717,9 +2716,9 @@ int lib_interface_igmp_robustness_variable_modify(
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
-		last_member_query_count = yang_dnode_get_uint8(args->dnode,
-				NULL);
-		pim_ifp->igmp_last_member_query_count = last_member_query_count;
+		last_member_query_count =
+			yang_dnode_get_uint8(args->dnode, NULL);
+		pim_ifp->gm_last_member_query_count = last_member_query_count;
 
 		break;
 	}

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -366,47 +366,47 @@ int pim_interface_config_write(struct vty *vty)
 				}
 
 				/* IF ip igmp query-max-response-time */
-				if (pim_ifp->igmp_query_max_response_time_dsec
-				    != IGMP_QUERY_MAX_RESPONSE_TIME_DSEC) {
+				if (pim_ifp->gm_query_max_response_time_dsec !=
+				    IGMP_QUERY_MAX_RESPONSE_TIME_DSEC) {
 					vty_out(vty,
 						" ip igmp query-max-response-time %d\n",
-						pim_ifp->igmp_query_max_response_time_dsec);
+						pim_ifp->gm_query_max_response_time_dsec);
 					++writes;
 				}
 
 				/* IF ip igmp query-interval */
-				if (pim_ifp->igmp_default_query_interval
-				    != IGMP_GENERAL_QUERY_INTERVAL) {
+				if (pim_ifp->gm_default_query_interval !=
+				    IGMP_GENERAL_QUERY_INTERVAL) {
 					vty_out(vty,
 						" ip igmp query-interval %d\n",
-						pim_ifp->igmp_default_query_interval);
+						pim_ifp->gm_default_query_interval);
 					++writes;
 				}
 
 				/* IF ip igmp last-member_query-count */
-				if (pim_ifp->igmp_last_member_query_count
-				    != IGMP_DEFAULT_ROBUSTNESS_VARIABLE) {
+				if (pim_ifp->gm_last_member_query_count !=
+				    IGMP_DEFAULT_ROBUSTNESS_VARIABLE) {
 					vty_out(vty,
 						" ip igmp last-member-query-count %d\n",
-						pim_ifp->igmp_last_member_query_count);
+						pim_ifp->gm_last_member_query_count);
 					++writes;
 				}
 
 				/* IF ip igmp last-member_query-interval */
-				if (pim_ifp->igmp_specific_query_max_response_time_dsec
-				    != IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC) {
+				if (pim_ifp->gm_specific_query_max_response_time_dsec !=
+				    IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC) {
 					vty_out(vty,
 						" ip igmp last-member-query-interval %d\n",
-						pim_ifp->igmp_specific_query_max_response_time_dsec);
-					  ++writes;
+						pim_ifp->gm_specific_query_max_response_time_dsec);
+					++writes;
 				}
 
 				/* IF ip igmp join */
-				if (pim_ifp->igmp_join_list) {
+				if (pim_ifp->gm_join_list) {
 					struct listnode *node;
 					struct gm_join *ij;
 					for (ALL_LIST_ELEMENTS_RO(
-						     pim_ifp->igmp_join_list,
+						     pim_ifp->gm_join_list,
 						     node, ij)) {
 						char group_str[INET_ADDRSTRLEN];
 						char source_str

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -554,7 +554,7 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_group_list, grpnode,
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  grp)) {
 			struct listnode *srcnode;
 			struct gm_source *src;


### PR DESCRIPTION
Modifying the members of pim_interface which are to be used
for both IPv4 and IPv6 to common names(for both MLD and IGMP).

Issues: #10023

Co-authored-by: Mobashshera Rasool <mrasool@vmware.com>
Co-authored-by: Sarita Patra <saritap@vmware.com>
Signed-off-by: Sai Gomathi <nsaigomathi@vmware.com>