### PR TITLE
[8.1] backport lib: fix elf_py TLS section handling

### DIFF
--- a/lib/elf_py.c
+++ b/lib/elf_py.c
@@ -636,6 +636,9 @@ static Elf_Scn *elf_find_addr(struct elffile *ef, uint64_t addr, size_t *idx)
 		Elf_Scn *scn = elf_getscn(ef->elf, i);
 		GElf_Shdr _shdr, *shdr = gelf_getshdr(scn, &_shdr);
 
+		/* virtual address is kinda meaningless for TLS sections */
+		if (shdr->sh_flags & SHF_TLS)
+			continue;
 		if (addr < shdr->sh_addr ||
 		    addr >= shdr->sh_addr + shdr->sh_size)
 			continue;


### PR DESCRIPTION
> ... need to ignore TLS sections, their address is effectively
> meaningless but can overlap other sections we actually need to access.
> 
> Signed-off-by: David Lamparter <equinox@opensourcerouting.org>
> (cherry picked from commit 3942ee1f7bc754dd0dd9ae79f89d0f2635be334f)

This might hopefully fix #10267 
(This is not a mergify backport since this commit came in a PR with a bunch of other commits, cf. #10025 )