### PR TITLE
pim6d: add skeleton & address structures

### DIFF
--- a/doc/developer/logging.rst
+++ b/doc/developer/logging.rst
@@ -153,11 +153,11 @@ Networking data types
    - :c:struct:`prefix_ls`
    - :c:struct:`prefix_rd`
    - :c:struct:`prefix_ptr`
-   - :c:struct:`prefix_sg` (use :frrfmt:`%pSG4`)
+   - :c:struct:`prefix_sg` (use :frrfmt:`%pPSG4`)
    - :c:union:`prefixptr` (dereference to get :c:struct:`prefix`)
    - :c:union:`prefixconstptr` (dereference to get :c:struct:`prefix`)
 
-.. frrfmt:: %pSG4 (struct prefix_sg *)
+.. frrfmt:: %pPSG4 (struct prefix_sg *)
 
    :frrfmtout:`(*,1.2.3.4)`
 

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1421,7 +1421,7 @@ static ssize_t printfrr_pfx(struct fbuf *buf, struct printfrr_eargs *ea,
 	return bputs(buf, cbuf);
 }
 
-printfrr_ext_autoreg_p("SG4", printfrr_psg)
+printfrr_ext_autoreg_p("PSG4", printfrr_psg)
 static ssize_t printfrr_psg(struct fbuf *buf, struct printfrr_eargs *ea,
 			    const void *ptr)
 {

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -602,7 +602,7 @@ static inline int is_default_host_route(const struct prefix *p)
 #pragma FRR printfrr_ext "%pFX"  (struct prefix_evpn *)
 #pragma FRR printfrr_ext "%pFX"  (struct prefix_fs *)
 
-#pragma FRR printfrr_ext "%pSG4" (struct prefix_sg *)
+#pragma FRR printfrr_ext "%pPSG4" (struct prefix_sg *)
 #endif
 
 #ifdef __cplusplus

--- a/pimd/.gitignore
+++ b/pimd/.gitignore
@@ -1,3 +1,4 @@
-pimd
-mtracebis
-test_igmpv3_join
+/pimd
+/pim6d
+/mtracebis
+/test_igmpv3_join

--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -1,0 +1,214 @@
+/*
+ * PIMv6 main()
+ * Copyright (C) 2021  David Lamparter for NetDEF, Inc.
+ * Copyright (C) 2008  Everton da Silva Marques (pim_main.c)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+
+#include "lib/vrf.h"
+#include "lib/filter.h"
+#include "lib/plist.h"
+#include "lib/routemap.h"
+#include "lib/routing_nb.h"
+
+#include "lib/privs.h"
+#include "lib/sigevent.h"
+#include "lib/libfrr.h"
+#include "lib/version.h"
+
+#include "pimd.h"
+#include "pim_instance.h"
+#include "pim_errors.h"
+#include "pim_iface.h"
+#include "pim_zebra.h"
+
+zebra_capabilities_t _caps_p[] = {
+	ZCAP_SYS_ADMIN,
+	ZCAP_NET_ADMIN,
+	ZCAP_NET_RAW,
+	ZCAP_BIND,
+};
+
+/* pimd privileges to run with */
+struct zebra_privs_t pimd_privs = {
+#if defined(FRR_USER) && defined(FRR_GROUP)
+	.user = FRR_USER,
+	.group = FRR_GROUP,
+#endif
+#ifdef VTY_GROUP
+	.vty_group = VTY_GROUP,
+#endif
+	.caps_p = _caps_p,
+	.cap_num_p = array_size(_caps_p),
+	.cap_num_i = 0,
+};
+
+static void pim6_terminate(void);
+
+static void pim6_sighup(void)
+{
+	zlog_info("SIGHUP received, ignoring");
+}
+
+static void pim6_sigint(void)
+{
+	zlog_notice("Terminating on signal SIGINT");
+	pim6_terminate();
+	exit(1);
+}
+
+static void pim6_sigterm(void)
+{
+	zlog_notice("Terminating on signal SIGTERM");
+	pim6_terminate();
+	exit(1);
+}
+
+static void pim6_sigusr1(void)
+{
+	zlog_rotate();
+}
+
+struct frr_signal_t pim6d_signals[] = {
+	{
+		.signal = SIGHUP,
+		.handler = &pim6_sighup,
+	},
+	{
+		.signal = SIGUSR1,
+		.handler = &pim6_sigusr1,
+	},
+	{
+		.signal = SIGINT,
+		.handler = &pim6_sigint,
+	},
+	{
+		.signal = SIGTERM,
+		.handler = &pim6_sigterm,
+	},
+};
+
+static const struct frr_yang_module_info *const pim6d_yang_modules[] = {
+	&frr_filter_info,
+	&frr_interface_info,
+	&frr_route_map_info,
+	&frr_vrf_info,
+	&frr_routing_info,
+};
+
+/* clang-format off */
+FRR_DAEMON_INFO(pim6d, PIM6,
+	.vty_port = 0,
+	.flags = FRR_NO_SPLIT_CONFIG,
+
+	.proghelp = "Protocol Independent Multicast (RFC7761) for IPv6",
+
+	.signals = pim6d_signals,
+	.n_signals = array_size(pim6d_signals),
+
+	.privs = &pimd_privs,
+
+	.yang_modules = pim6d_yang_modules,
+	.n_yang_modules = array_size(pim6d_yang_modules),
+);
+/* clang-format on */
+
+
+int main(int argc, char **argv, char **envp)
+{
+	static struct option longopts[] = {
+		{},
+	};
+
+	frr_preinit(&pim6d_di, argc, argv);
+	frr_opt_add("", longopts, "");
+
+	/* this while just reads the options */
+	while (1) {
+		int opt;
+
+		opt = frr_getopt(argc, argv, NULL);
+
+		if (opt == EOF)
+			break;
+
+		switch (opt) {
+		case 0:
+			break;
+		default:
+			frr_help_exit(1);
+		}
+	}
+
+	pim_router_init();
+	/* TODO PIM6: temporary enable all debugs, remove later in PIMv6 work */
+	router->debugs = ~0U;
+
+	access_list_init();
+	prefix_list_init();
+
+	/*
+	 * Initializations
+	 */
+	pim_error_init();
+	pim_vrf_init();
+#if 0
+	prefix_list_add_hook(pim_prefix_list_update);
+	prefix_list_delete_hook(pim_prefix_list_update);
+
+	pim_route_map_init();
+	pim_init();
+#endif
+
+	/*
+	 * Initialize zclient "update" and "lookup" sockets
+	 */
+	if_zapi_callbacks(pim_ifp_create, pim_ifp_up,
+			  pim_ifp_down, pim_ifp_destroy);
+
+	/* TODO PIM6: next line is temporary since pim_cmd_init is disabled */
+	if_cmd_init(NULL);
+
+#if 0
+	pim_zebra_init();
+	pim_bfd_init();
+	pim_mlag_init();
+
+	hook_register(routing_conf_event,
+		      routing_control_plane_protocols_name_validate);
+
+	routing_control_plane_protocols_register_vrf_dependency();
+#endif
+
+	frr_config_fork();
+	frr_run(router->master);
+
+	/* never reached */
+	return 0;
+}
+
+static void pim6_terminate(void)
+{
+	pim_vrf_terminate();
+	pim_router_terminate();
+
+	prefix_list_reset();
+	access_list_reset();
+
+	frr_fini();
+}

--- a/pimd/pim_addr.c
+++ b/pimd/pim_addr.c
@@ -1,0 +1,66 @@
+/*
+ * PIM address generalizations
+ * Copyright (C) 2022  David Lamparter for NetDEF, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+
+#include "pim_addr.h"
+#include "printfrr.h"
+#include "prefix.h"
+
+
+printfrr_ext_autoreg_p("PA", printfrr_pimaddr)
+static ssize_t printfrr_pimaddr(struct fbuf *buf, struct printfrr_eargs *ea,
+				const void *vptr)
+{
+	const pim_addr *addr = vptr;
+	bool use_star = false;
+
+	if (ea->fmt[0] == 's') {
+		use_star = true;
+		ea->fmt++;
+	}
+
+	if (!addr)
+		return bputs(buf, "(null)");
+
+	if (use_star) {
+		pim_addr zero = {};
+
+		if (memcmp(addr, &zero, sizeof(zero)) == 0)
+			return bputch(buf, '*');
+	}
+
+#if PIM_IPV == 4
+	return bprintfrr(buf, "%pI4", addr);
+#else
+	return bprintfrr(buf, "%pI6", addr);
+#endif
+}
+
+printfrr_ext_autoreg_p("SG", printfrr_sgaddr)
+static ssize_t printfrr_sgaddr(struct fbuf *buf, struct printfrr_eargs *ea,
+			       const void *vptr)
+{
+	const pim_sgaddr *sga = vptr;
+
+	if (!sga)
+		return bputs(buf, "(null)");
+
+	return bprintfrr(buf, "(%pPAs,%pPAs)", &sga->src, &sga->grp);
+}

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -1,0 +1,63 @@
+/*
+ * PIM address generalizations
+ * Copyright (C) 2022  David Lamparter for NetDEF, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _PIMD_PIM_ADDR_H
+#define _PIMD_PIM_ADDR_H
+
+#include "jhash.h"
+
+#if PIM_IPV == 4
+typedef struct in_addr pim_addr;
+#define PIM_ADDRSTRLEN INET_ADDRSTRLEN
+#else
+typedef struct in6_addr pim_addr;
+#define PIM_ADDRSTRLEN INET6_ADDRSTRLEN
+#endif
+
+/* don't use this struct directly, use the pim_sgaddr typedef */
+struct _pim_sgaddr {
+	pim_addr grp;
+	pim_addr src;
+};
+
+typedef struct _pim_sgaddr pim_sgaddr;
+
+static inline int pim_sgaddr_cmp(const pim_sgaddr a, const pim_sgaddr b)
+{
+	/* memcmp over the entire struct = memcmp(grp) + memcmp(src) */
+	return memcmp(&a, &b, sizeof(a));
+}
+
+static inline uint32_t pim_sgaddr_hash(const pim_sgaddr a, uint32_t initval)
+{
+	return jhash2((uint32_t *)&a, sizeof(a) / sizeof(uint32_t), initval);
+}
+
+#ifdef _FRR_ATTRIBUTE_PRINTFRR
+#pragma FRR printfrr_ext "%pPA" (pim_addr *)
+#pragma FRR printfrr_ext "%pSG" (pim_sgaddr *)
+#endif
+
+/*
+ * There is no pim_sgaddr2str().  This is intentional.  Instead, use:
+ *	snprintfrr(buf, sizeof(buf), "%pPA", sgaddr)
+ * (and note that snprintfrr is implicit for vty_out and zlog_*)
+ */
+
+#endif /* _PIMD_PIM_ADDR_H */

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -87,8 +87,8 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		struct pim_rpf *rp = RP(pim_ifp->pim, sg->grp);
 
 		if (!rp) {
-			zlog_warn("%s: Lookup of RP failed for %pSG4", __func__,
-				  sg);
+			zlog_warn("%s: Lookup of RP failed for %pPSG4",
+				  __func__, sg);
 			return;
 		}
 		/*
@@ -160,7 +160,7 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 
 			pim_inet4_dump("<received?>", sg->src, received_rp,
 				       sizeof(received_rp));
-			zlog_debug("%s: Prune received with RP(%s) for %pSG4",
+			zlog_debug("%s: Prune received with RP(%s) for %pPSG4",
 				   __func__, received_rp, sg);
 		}
 

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -743,11 +743,11 @@ static void pim_mlag_process_mroute_add(struct mlag_mroute_add msg)
 		sg.src.s_addr = ntohl(msg.source_ip);
 
 		zlog_debug(
-			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x (%pSG4) cost: %u",
+			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x (%pPSG4) cost: %u",
 			__func__, msg.vrf_name, msg.source_ip, msg.group_ip,
 			&sg, msg.cost_to_rp);
 		zlog_debug(
-			"(%pSG4)owner_id: %d, DR: %d, Dual active: %d, vrf_id: 0x%x intf_name: %s",
+			"(%pPSG4)owner_id: %d, DR: %d, Dual active: %d, vrf_id: 0x%x intf_name: %s",
 			&sg, msg.owner_id, msg.am_i_dr, msg.am_i_dual_active,
 			msg.vrf_id, msg.intf_name);
 	}
@@ -772,10 +772,10 @@ static void pim_mlag_process_mroute_del(struct mlag_mroute_del msg)
 		sg.grp.s_addr = ntohl(msg.group_ip);
 		sg.src.s_addr = ntohl(msg.source_ip);
 		zlog_debug(
-			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x(%pSG4)",
+			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x(%pPSG4)",
 			__func__, msg.vrf_name, msg.source_ip, msg.group_ip,
 			&sg);
-		zlog_debug("(%pSG4)owner_id: %d, vrf_id: 0x%x intf_name: %s",
+		zlog_debug("(%pPSG4)owner_id: %d, vrf_id: 0x%x intf_name: %s",
 			   &sg, msg.owner_id, msg.vrf_id, msg.intf_name);
 	}
 

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -145,7 +145,7 @@ struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
-				"%s(%s): Existing oil for %pSG4 Ref Count: %d (Post Increment)",
+				"%s(%s): Existing oil for %pPSG4 Ref Count: %d (Post Increment)",
 				__func__, name, sg, c_oil->oil_ref_count);
 		return c_oil;
 	}
@@ -178,7 +178,7 @@ struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
 				       .grp = c_oil->oil.mfcc_origin};
 
 		zlog_debug(
-			"%s(%s): Del oil for %pSG4, Ref Count: %d (Predecrement)",
+			"%s(%s): Del oil for %pPSG4, Ref Count: %d (Predecrement)",
 			__func__, name, &sg, c_oil->oil_ref_count);
 	}
 	--c_oil->oil_ref_count;

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -415,8 +415,9 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 					pim_inet4_dump("<src?>", src_addr,
 						       src_str,
 						       sizeof(src_str));
-					zlog_debug("%s: Sending register-stop to %s for %pSG4 due to prefix-list denial, dropping packet",
-						   __func__, src_str, &sg);
+					zlog_debug(
+						"%s: Sending register-stop to %s for %pPSG4 due to prefix-list denial, dropping packet",
+						__func__, src_str, &sg);
 				}
 
 				return 0;

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -26,7 +26,7 @@
 
 #include <prefix.h>
 
-typedef struct in_addr pim_addr;
+#include "pim_addr.h"
 
 /*
  * Longest possible length of a (S,G) string is 36 bytes

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -115,7 +115,6 @@ void pim_router_init(void)
 
 void pim_router_terminate(void)
 {
-	pim_mlag_terminate();
 	XFREE(MTYPE_ROUTER, router);
 }
 
@@ -155,6 +154,7 @@ void pim_terminate(void)
 	}
 
 	pim_free();
+	pim_mlag_terminate();
 	pim_router_terminate();
 
 	frr_fini();

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -27,6 +27,7 @@
 #include "vty.h"
 #include "plist.h"
 
+#include "pim_addr.h"
 #include "pim_instance.h"
 #include "pim_str.h"
 #include "pim_memory.h"

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -13,6 +13,7 @@ man8 += $(MANBUILD)/mtracebis.8
 endif
 
 pim_common = \
+	pimd/pim_addr.c \
 	pimd/pim_assert.c \
 	pimd/pim_bfd.c \
 	pimd/pim_br.c \
@@ -87,6 +88,7 @@ nodist_pimd_pim6d_SOURCES = \
 	# end
 
 noinst_HEADERS += \
+	pimd/pim_addr.h \
 	pimd/pim_assert.h \
 	pimd/pim_bfd.h \
 	pimd/pim_br.h \

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -12,7 +12,7 @@ man8 += $(MANBUILD)/frr-pimd.8
 man8 += $(MANBUILD)/mtracebis.8
 endif
 
-pimd_pimd_SOURCES = \
+pim_common = \
 	pimd/pim_assert.c \
 	pimd/pim_bfd.c \
 	pimd/pim_br.c \
@@ -32,7 +32,6 @@ pimd_pimd_SOURCES = \
 	pimd/pim_join.c \
 	pimd/pim_jp_agg.c \
 	pimd/pim_macro.c \
-	pimd/pim_main.c \
 	pimd/pim_memory.c \
 	pimd/pim_mlag.c \
 	pimd/pim_mroute.c \
@@ -50,7 +49,6 @@ pimd_pimd_SOURCES = \
 	pimd/pim_routemap.c \
 	pimd/pim_rp.c \
 	pimd/pim_rpf.c \
-	pimd/pim_signals.c \
 	pimd/pim_sock.c \
 	pimd/pim_ssm.c \
 	pimd/pim_ssmpingd.c \
@@ -68,10 +66,24 @@ pimd_pimd_SOURCES = \
 	pimd/pimd.c \
 	# end
 
+pimd_pimd_SOURCES = \
+	$(pim_common) \
+	pimd/pim_main.c \
+	pimd/pim_signals.c \
+	# end
+
 nodist_pimd_pimd_SOURCES = \
 	yang/frr-pim.yang.c \
 	yang/frr-pim-rp.yang.c \
 	yang/frr-igmp.yang.c \
+	# end
+
+pimd_pim6d_SOURCES = \
+	$(pim_common) \
+	pimd/pim6_main.c \
+	# end
+
+nodist_pimd_pim6d_SOURCES = \
 	# end
 
 noinst_HEADERS += \
@@ -134,12 +146,26 @@ clippy_scan += \
 	pimd/pim_cmd.c \
 	# end
 
+pimd_pimd_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=4
 pimd_pimd_LDADD = lib/libfrr.la $(LIBCAP)
+
+if PIMD
+if DEV_BUILD
+#
+# pim6d is only enabled for --enable-dev-build, and NOT installed currently
+# (change noinst_ to sbin_ below to install it.)
+#
+noinst_PROGRAMS += pimd/pim6d
+pimd_pim6d_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=6
+pimd_pim6d_LDADD = lib/libfrr.la $(LIBCAP)
+endif
+endif
 
 pimd_test_igmpv3_join_LDADD = lib/libfrr.la
 pimd_test_igmpv3_join_SOURCES = pimd/test_igmpv3_join.c
 
 pimd_mtracebis_LDADD =  lib/libfrr.la
+pimd_mtracebis_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=4
 pimd_mtracebis_SOURCES = pimd/mtracebis.c \
 			 pimd/mtracebis_netlink.c \
 			 pimd/mtracebis_routeget.c \

--- a/tests/lib/test_printfrr.c
+++ b/tests/lib/test_printfrr.c
@@ -206,16 +206,16 @@ int main(int argc, char **argv)
 	struct prefix_sg sg;
 	sg.src.s_addr = INADDR_ANY;
 	sg.grp.s_addr = INADDR_ANY;
-	printchk("(*,*)", "%pSG4", &sg);
+	printchk("(*,*)", "%pPSG4", &sg);
 
 	inet_aton("192.168.1.2", &sg.src);
-	printchk("(192.168.1.2,*)", "%pSG4", &sg);
+	printchk("(192.168.1.2,*)", "%pPSG4", &sg);
 
 	inet_aton("224.1.2.3", &sg.grp);
-	printchk("(192.168.1.2,224.1.2.3)", "%pSG4", &sg);
+	printchk("(192.168.1.2,224.1.2.3)", "%pPSG4", &sg);
 
 	sg.src.s_addr = INADDR_ANY;
-	printchk("(*,224.1.2.3)", "%pSG4", &sg);
+	printchk("(*,224.1.2.3)", "%pPSG4", &sg);
 
 	uint8_t randhex[] = { 0x12, 0x34, 0x00, 0xca, 0xfe, 0x00, 0xaa, 0x55 };
 


### PR DESCRIPTION
Start some mergeable progress towards `pim6d`

This replaces PR #10194 (unlike that PR, this one is not WIP, compiles, produces sensible output and can actually be merged)

This also partially replaces PRs #10278 / #10192 which I had previously commented/NAKd; at this point it seems a better allocation of my time to just do it rather than try to steer with reviews.