### PR TITLE
pimd: `prefix_sg` => `pim_sgaddr`

### DIFF
--- a/doc/developer/logging.rst
+++ b/doc/developer/logging.rst
@@ -153,11 +153,11 @@ Networking data types
    - :c:struct:`prefix_ls`
    - :c:struct:`prefix_rd`
    - :c:struct:`prefix_ptr`
-   - :c:struct:`prefix_sg` (use :frrfmt:`%pSG4`)
+   - :c:struct:`prefix_sg` (use :frrfmt:`%pPSG4`)
    - :c:union:`prefixptr` (dereference to get :c:struct:`prefix`)
    - :c:union:`prefixconstptr` (dereference to get :c:struct:`prefix`)
 
-.. frrfmt:: %pSG4 (struct prefix_sg *)
+.. frrfmt:: %pPSG4 (struct prefix_sg *)
 
    :frrfmtout:`(*,1.2.3.4)`
 

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1421,7 +1421,7 @@ static ssize_t printfrr_pfx(struct fbuf *buf, struct printfrr_eargs *ea,
 	return bputs(buf, cbuf);
 }
 
-printfrr_ext_autoreg_p("SG4", printfrr_psg)
+printfrr_ext_autoreg_p("PSG4", printfrr_psg)
 static ssize_t printfrr_psg(struct fbuf *buf, struct printfrr_eargs *ea,
 			    const void *ptr)
 {

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -602,7 +602,7 @@ static inline int is_default_host_route(const struct prefix *p)
 #pragma FRR printfrr_ext "%pFX"  (struct prefix_evpn *)
 #pragma FRR printfrr_ext "%pFX"  (struct prefix_fs *)
 
-#pragma FRR printfrr_ext "%pSG4" (struct prefix_sg *)
+#pragma FRR printfrr_ext "%pPSG4" (struct prefix_sg *)
 #endif
 
 #ifdef __cplusplus

--- a/pimd/.gitignore
+++ b/pimd/.gitignore
@@ -1,3 +1,4 @@
-pimd
-mtracebis
-test_igmpv3_join
+/pimd
+/pim6d
+/mtracebis
+/test_igmpv3_join

--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -1,0 +1,214 @@
+/*
+ * PIMv6 main()
+ * Copyright (C) 2021  David Lamparter for NetDEF, Inc.
+ * Copyright (C) 2008  Everton da Silva Marques (pim_main.c)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+
+#include "lib/vrf.h"
+#include "lib/filter.h"
+#include "lib/plist.h"
+#include "lib/routemap.h"
+#include "lib/routing_nb.h"
+
+#include "lib/privs.h"
+#include "lib/sigevent.h"
+#include "lib/libfrr.h"
+#include "lib/version.h"
+
+#include "pimd.h"
+#include "pim_instance.h"
+#include "pim_errors.h"
+#include "pim_iface.h"
+#include "pim_zebra.h"
+
+zebra_capabilities_t _caps_p[] = {
+	ZCAP_SYS_ADMIN,
+	ZCAP_NET_ADMIN,
+	ZCAP_NET_RAW,
+	ZCAP_BIND,
+};
+
+/* pimd privileges to run with */
+struct zebra_privs_t pimd_privs = {
+#if defined(FRR_USER) && defined(FRR_GROUP)
+	.user = FRR_USER,
+	.group = FRR_GROUP,
+#endif
+#ifdef VTY_GROUP
+	.vty_group = VTY_GROUP,
+#endif
+	.caps_p = _caps_p,
+	.cap_num_p = array_size(_caps_p),
+	.cap_num_i = 0,
+};
+
+static void pim6_terminate(void);
+
+static void pim6_sighup(void)
+{
+	zlog_info("SIGHUP received, ignoring");
+}
+
+static void pim6_sigint(void)
+{
+	zlog_notice("Terminating on signal SIGINT");
+	pim6_terminate();
+	exit(1);
+}
+
+static void pim6_sigterm(void)
+{
+	zlog_notice("Terminating on signal SIGTERM");
+	pim6_terminate();
+	exit(1);
+}
+
+static void pim6_sigusr1(void)
+{
+	zlog_rotate();
+}
+
+struct frr_signal_t pim6d_signals[] = {
+	{
+		.signal = SIGHUP,
+		.handler = &pim6_sighup,
+	},
+	{
+		.signal = SIGUSR1,
+		.handler = &pim6_sigusr1,
+	},
+	{
+		.signal = SIGINT,
+		.handler = &pim6_sigint,
+	},
+	{
+		.signal = SIGTERM,
+		.handler = &pim6_sigterm,
+	},
+};
+
+static const struct frr_yang_module_info *const pim6d_yang_modules[] = {
+	&frr_filter_info,
+	&frr_interface_info,
+	&frr_route_map_info,
+	&frr_vrf_info,
+	&frr_routing_info,
+};
+
+/* clang-format off */
+FRR_DAEMON_INFO(pim6d, PIM6,
+	.vty_port = 0,
+	.flags = FRR_NO_SPLIT_CONFIG,
+
+	.proghelp = "Protocol Independent Multicast (RFC7761) for IPv6",
+
+	.signals = pim6d_signals,
+	.n_signals = array_size(pim6d_signals),
+
+	.privs = &pimd_privs,
+
+	.yang_modules = pim6d_yang_modules,
+	.n_yang_modules = array_size(pim6d_yang_modules),
+);
+/* clang-format on */
+
+
+int main(int argc, char **argv, char **envp)
+{
+	static struct option longopts[] = {
+		{},
+	};
+
+	frr_preinit(&pim6d_di, argc, argv);
+	frr_opt_add("", longopts, "");
+
+	/* this while just reads the options */
+	while (1) {
+		int opt;
+
+		opt = frr_getopt(argc, argv, NULL);
+
+		if (opt == EOF)
+			break;
+
+		switch (opt) {
+		case 0:
+			break;
+		default:
+			frr_help_exit(1);
+		}
+	}
+
+	pim_router_init();
+	/* TODO PIM6: temporary enable all debugs, remove later in PIMv6 work */
+	router->debugs = ~0U;
+
+	access_list_init();
+	prefix_list_init();
+
+	/*
+	 * Initializations
+	 */
+	pim_error_init();
+	pim_vrf_init();
+#if 0
+	prefix_list_add_hook(pim_prefix_list_update);
+	prefix_list_delete_hook(pim_prefix_list_update);
+
+	pim_route_map_init();
+	pim_init();
+#endif
+
+	/*
+	 * Initialize zclient "update" and "lookup" sockets
+	 */
+	if_zapi_callbacks(pim_ifp_create, pim_ifp_up,
+			  pim_ifp_down, pim_ifp_destroy);
+
+	/* TODO PIM6: next line is temporary since pim_cmd_init is disabled */
+	if_cmd_init(NULL);
+
+#if 0
+	pim_zebra_init();
+	pim_bfd_init();
+	pim_mlag_init();
+
+	hook_register(routing_conf_event,
+		      routing_control_plane_protocols_name_validate);
+
+	routing_control_plane_protocols_register_vrf_dependency();
+#endif
+
+	frr_config_fork();
+	frr_run(router->master);
+
+	/* never reached */
+	return 0;
+}
+
+static void pim6_terminate(void)
+{
+	pim_vrf_terminate();
+	pim_router_terminate();
+
+	prefix_list_reset();
+	access_list_reset();
+
+	frr_fini();
+}

--- a/pimd/pim_addr.c
+++ b/pimd/pim_addr.c
@@ -48,6 +48,9 @@ static ssize_t printfrr_pimaddr(struct fbuf *buf, struct printfrr_eargs *ea,
 
 #if PIM_IPV == 4
 	return bprintfrr(buf, "%pI4", addr);
+#elif !defined(PIM_V6_TEMP_BREAK)
+	CPP_NOTICE("note IPv6 typing for pim_addr is temporarily disabled.");
+	return bprintfrr(buf, "%pI4", addr);
 #else
 	return bprintfrr(buf, "%pI6", addr);
 #endif

--- a/pimd/pim_addr.c
+++ b/pimd/pim_addr.c
@@ -1,0 +1,66 @@
+/*
+ * PIM address generalizations
+ * Copyright (C) 2022  David Lamparter for NetDEF, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+
+#include "pim_addr.h"
+#include "printfrr.h"
+#include "prefix.h"
+
+
+printfrr_ext_autoreg_p("PA", printfrr_pimaddr)
+static ssize_t printfrr_pimaddr(struct fbuf *buf, struct printfrr_eargs *ea,
+				const void *vptr)
+{
+	const pim_addr *addr = vptr;
+	bool use_star = false;
+
+	if (ea->fmt[0] == 's') {
+		use_star = true;
+		ea->fmt++;
+	}
+
+	if (!addr)
+		return bputs(buf, "(null)");
+
+	if (use_star) {
+		pim_addr zero = {};
+
+		if (memcmp(addr, &zero, sizeof(zero)) == 0)
+			return bputch(buf, '*');
+	}
+
+#if PIM_IPV == 4
+	return bprintfrr(buf, "%pI4", addr);
+#else
+	return bprintfrr(buf, "%pI6", addr);
+#endif
+}
+
+printfrr_ext_autoreg_p("SG", printfrr_sgaddr)
+static ssize_t printfrr_sgaddr(struct fbuf *buf, struct printfrr_eargs *ea,
+			       const void *vptr)
+{
+	const pim_sgaddr *sga = vptr;
+
+	if (!sga)
+		return bputs(buf, "(null)");
+
+	return bprintfrr(buf, "(%pPAs,%pPAs)", &sga->src, &sga->grp);
+}

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -22,7 +22,11 @@
 
 #include "jhash.h"
 
-#if PIM_IPV == 4
+/* temporarily disable IPv6 types to keep code compiling.
+ * Defining PIM_V6_TEMP_BREAK will show a lot of compile errors - they are
+ * very useful to see TODOs.
+ */
+#if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
 typedef struct in_addr pim_addr;
 #define PIM_ADDRSTRLEN INET_ADDRSTRLEN
 #else

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -1,0 +1,63 @@
+/*
+ * PIM address generalizations
+ * Copyright (C) 2022  David Lamparter for NetDEF, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _PIMD_PIM_ADDR_H
+#define _PIMD_PIM_ADDR_H
+
+#include "jhash.h"
+
+#if PIM_IPV == 4
+typedef struct in_addr pim_addr;
+#define PIM_ADDRSTRLEN INET_ADDRSTRLEN
+#else
+typedef struct in6_addr pim_addr;
+#define PIM_ADDRSTRLEN INET6_ADDRSTRLEN
+#endif
+
+/* don't use this struct directly, use the pim_sgaddr typedef */
+struct _pim_sgaddr {
+	pim_addr grp;
+	pim_addr src;
+};
+
+typedef struct _pim_sgaddr pim_sgaddr;
+
+static inline int pim_sgaddr_cmp(const pim_sgaddr a, const pim_sgaddr b)
+{
+	/* memcmp over the entire struct = memcmp(grp) + memcmp(src) */
+	return memcmp(&a, &b, sizeof(a));
+}
+
+static inline uint32_t pim_sgaddr_hash(const pim_sgaddr a, uint32_t initval)
+{
+	return jhash2((uint32_t *)&a, sizeof(a) / sizeof(uint32_t), initval);
+}
+
+#ifdef _FRR_ATTRIBUTE_PRINTFRR
+#pragma FRR printfrr_ext "%pPA" (pim_addr *)
+#pragma FRR printfrr_ext "%pSG" (pim_sgaddr *)
+#endif
+
+/*
+ * There is no pim_sgaddr2str().  This is intentional.  Instead, use:
+ *	snprintfrr(buf, sizeof(buf), "%pPA", sgaddr)
+ * (and note that snprintfrr is implicit for vty_out and zlog_*)
+ */
+
+#endif /* _PIMD_PIM_ADDR_H */

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -141,9 +141,9 @@ static int dispatch_assert(struct interface *ifp, struct in_addr source_addr,
 			   struct pim_assert_metric recv_metric)
 {
 	struct pim_ifchannel *ch;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src = source_addr;
 	sg.grp = group_addr;
 	ch = pim_ifchannel_add(ifp, &sg, 0, 0);
@@ -215,7 +215,7 @@ static int dispatch_assert(struct interface *ifp, struct in_addr source_addr,
 int pim_assert_recv(struct interface *ifp, struct pim_neighbor *neigh,
 		    struct in_addr src_addr, uint8_t *buf, int buf_size)
 {
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	struct prefix msg_source_addr;
 	struct pim_assert_metric msg_metric;
 	int offset;
@@ -231,7 +231,7 @@ int pim_assert_recv(struct interface *ifp, struct pim_neighbor *neigh,
 	/*
 	  Parse assert group addr
 	 */
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	offset = pim_parse_addr_group(&sg, curr, curr_size);
 	if (offset < 1) {
 		char src_str[INET_ADDRSTRLEN];

--- a/pimd/pim_br.c
+++ b/pimd/pim_br.c
@@ -29,7 +29,7 @@
 #include "linklist.h"
 
 struct pim_br {
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	struct in_addr pmbr;
 };
 
@@ -37,7 +37,7 @@ struct in_addr pim_br_unknown = {.s_addr = 0};
 
 static struct list *pim_br_list = NULL;
 
-struct in_addr pim_br_get_pmbr(struct prefix_sg *sg)
+struct in_addr pim_br_get_pmbr(pim_sgaddr *sg)
 {
 	struct listnode *node;
 	struct pim_br *pim_br;
@@ -51,7 +51,7 @@ struct in_addr pim_br_get_pmbr(struct prefix_sg *sg)
 	return pim_br_unknown;
 }
 
-void pim_br_set_pmbr(struct prefix_sg *sg, struct in_addr br)
+void pim_br_set_pmbr(pim_sgaddr *sg, struct in_addr br)
 {
 	struct listnode *node, *next;
 	struct pim_br *pim_br;
@@ -75,7 +75,7 @@ void pim_br_set_pmbr(struct prefix_sg *sg, struct in_addr br)
 /*
  * Remove the (S,G) from the stored values
  */
-void pim_br_clear_pmbr(struct prefix_sg *sg)
+void pim_br_clear_pmbr(pim_sgaddr *sg)
 {
 	struct listnode *node, *next;
 	struct pim_br *pim_br;

--- a/pimd/pim_br.h
+++ b/pimd/pim_br.h
@@ -20,10 +20,10 @@
 #ifndef PIM_BR_H
 #define PIM_BR_H
 
-struct in_addr pim_br_get_pmbr(struct prefix_sg *sg);
+struct in_addr pim_br_get_pmbr(pim_sgaddr *sg);
 
-void pim_br_set_pmbr(struct prefix_sg *sg, struct in_addr value);
-void pim_br_clear_pmbr(struct prefix_sg *sg);
+void pim_br_set_pmbr(pim_sgaddr *sg, struct in_addr value);
+void pim_br_clear_pmbr(pim_sgaddr *sg);
 
 void pim_br_init(void);
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1741,7 +1741,7 @@ static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 }
 
 static void pim_show_join(struct pim_instance *pim, struct vty *vty,
-			  struct prefix_sg *sg, bool uj)
+			  pim_sgaddr *sg, bool uj)
 {
 	struct pim_interface *pim_ifp;
 	struct pim_ifchannel *ch;
@@ -2439,7 +2439,7 @@ static const char *pim_reg_state2brief_str(enum pim_reg_state reg_state,
 }
 
 static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
-			      struct prefix_sg *sg, bool uj)
+			      pim_sgaddr *sg, bool uj)
 {
 	struct pim_upstream *up;
 	time_t now;
@@ -4603,7 +4603,7 @@ DEFPY (show_ip_pim_join,
        "The Group\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	pim_sgaddr sg = {0};
 	struct vrf *v;
 	bool uj = !!json;
 	struct pim_instance *pim;
@@ -4644,7 +4644,7 @@ DEFUN (show_ip_pim_join_vrf_all,
        "PIM interface join information\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	pim_sgaddr sg = {0};
 	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
@@ -5223,7 +5223,7 @@ DEFPY (show_ip_pim_upstream,
        "The Group\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	pim_sgaddr sg = {0};
 	struct vrf *v;
 	bool uj = !!json;
 	struct pim_instance *pim;
@@ -5263,7 +5263,7 @@ DEFUN (show_ip_pim_upstream_vrf_all,
        "PIM upstream information\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	pim_sgaddr sg = {0};
 	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
@@ -5888,7 +5888,7 @@ DEFUN(show_ip_multicast_count_vrf_all,
 }
 
 static void show_mroute(struct pim_instance *pim, struct vty *vty,
-			struct prefix_sg *sg, bool fill, bool uj)
+			pim_sgaddr *sg, bool fill, bool uj)
 {
 	struct listnode *node;
 	struct channel_oil *c_oil;
@@ -6273,7 +6273,7 @@ DEFPY (show_ip_mroute,
        "Fill in Assumed data\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	pim_sgaddr sg = {0};
 	struct pim_instance *pim;
 	struct vrf *v;
 
@@ -6311,7 +6311,7 @@ DEFUN (show_ip_mroute_vrf_all,
        "Fill in Assumed data\n"
        JSON_STR)
 {
-	struct prefix_sg sg = {0};
+	pim_sgaddr sg = {0};
 	bool uj = use_json(argc, argv);
 	int idx = 4;
 	struct vrf *vrf;
@@ -8219,7 +8219,7 @@ DEFPY_HIDDEN (pim_test_sg_keepalive,
 {
 	struct pim_upstream *up;
 	struct pim_instance *pim;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 
 	sg.src = source;
 	sg.grp = group;
@@ -10596,7 +10596,7 @@ static void pim_show_vxlan_sg_one(struct pim_instance *pim,
 				  bool uj)
 {
 	json_object *json = NULL;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	int result = 0;
 	struct pim_vxlan_sg *vxlan_sg;
 	const char *iif_name;
@@ -10616,8 +10616,6 @@ static void pim_show_vxlan_sg_one(struct pim_instance *pim,
 		return;
 	}
 
-	sg.family = AF_INET;
-	sg.prefixlen = IPV4_MAX_BITLEN;
 	if (uj)
 		json = json_object_new_object();
 

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -446,8 +446,7 @@ void reset_ifassert_state(struct pim_ifchannel *ch)
 				router->infinite_assert_metric);
 }
 
-struct pim_ifchannel *pim_ifchannel_find(struct interface *ifp,
-					 struct prefix_sg *sg)
+struct pim_ifchannel *pim_ifchannel_find(struct interface *ifp, pim_sgaddr *sg)
 {
 	struct pim_interface *pim_ifp;
 	struct pim_ifchannel *ch;
@@ -524,7 +523,7 @@ void pim_ifchannel_delete_on_noinfo(struct interface *ifp)
  */
 static struct pim_ifchannel *pim_ifchannel_find_parent(struct pim_ifchannel *ch)
 {
-	struct prefix_sg parent_sg = ch->sg;
+	pim_sgaddr parent_sg = ch->sg;
 	struct pim_ifchannel *parent = NULL;
 
 	// (S,G)
@@ -541,8 +540,7 @@ static struct pim_ifchannel *pim_ifchannel_find_parent(struct pim_ifchannel *ch)
 	return NULL;
 }
 
-struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp,
-					struct prefix_sg *sg,
+struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 					uint8_t source_flags, int up_flags)
 {
 	struct pim_interface *pim_ifp;
@@ -752,7 +750,7 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
 }
 
 static void check_recv_upstream(int is_join, struct interface *recv_ifp,
-				struct in_addr upstream, struct prefix_sg *sg,
+				struct in_addr upstream, pim_sgaddr *sg,
 				uint8_t source_flags, int holdtime)
 {
 	struct pim_upstream *up;
@@ -817,7 +815,7 @@ static void check_recv_upstream(int is_join, struct interface *recv_ifp,
 }
 
 static int nonlocal_upstream(int is_join, struct interface *recv_ifp,
-			     struct in_addr upstream, struct prefix_sg *sg,
+			     struct in_addr upstream, pim_sgaddr *sg,
 			     uint8_t source_flags, uint16_t holdtime)
 {
 	struct pim_interface *recv_pim_ifp;
@@ -871,7 +869,7 @@ static void pim_ifchannel_ifjoin_handler(struct pim_ifchannel *ch,
 
 
 void pim_ifchannel_join_add(struct interface *ifp, struct in_addr neigh_addr,
-			    struct in_addr upstream, struct prefix_sg *sg,
+			    struct in_addr upstream, pim_sgaddr *sg,
 			    uint8_t source_flags, uint16_t holdtime)
 {
 	struct pim_interface *pim_ifp;
@@ -1036,7 +1034,7 @@ void pim_ifchannel_join_add(struct interface *ifp, struct in_addr neigh_addr,
 }
 
 void pim_ifchannel_prune(struct interface *ifp, struct in_addr upstream,
-			 struct prefix_sg *sg, uint8_t source_flags,
+			 pim_sgaddr *sg, uint8_t source_flags,
 			 uint16_t holdtime)
 {
 	struct pim_ifchannel *ch;
@@ -1172,8 +1170,8 @@ void pim_ifchannel_prune(struct interface *ifp, struct in_addr upstream,
 	}
 }
 
-int pim_ifchannel_local_membership_add(struct interface *ifp,
-				       struct prefix_sg *sg, bool is_vxlan)
+int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
+				       bool is_vxlan)
 {
 	struct pim_ifchannel *ch, *starch;
 	struct pim_interface *pim_ifp;
@@ -1278,8 +1276,7 @@ int pim_ifchannel_local_membership_add(struct interface *ifp,
 	return 1;
 }
 
-void pim_ifchannel_local_membership_del(struct interface *ifp,
-					struct prefix_sg *sg)
+void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg)
 {
 	struct pim_ifchannel *starch, *ch, *orig;
 	struct pim_interface *pim_ifp;

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -89,7 +89,7 @@ struct pim_ifchannel {
 
 	struct pim_ifchannel *parent;
 	struct list *sources;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	char sg_str[PIM_SG_LEN];
 	struct interface *interface; /* backpointer to interface */
 	uint32_t flags;
@@ -123,21 +123,18 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch);
 void pim_ifchannel_delete_all(struct interface *ifp);
 void pim_ifchannel_membership_clear(struct interface *ifp);
 void pim_ifchannel_delete_on_noinfo(struct interface *ifp);
-struct pim_ifchannel *pim_ifchannel_find(struct interface *ifp,
-					 struct prefix_sg *sg);
-struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp,
-					struct prefix_sg *sg, uint8_t ch_flags,
-					int up_flags);
+struct pim_ifchannel *pim_ifchannel_find(struct interface *ifp, pim_sgaddr *sg);
+struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
+					uint8_t ch_flags, int up_flags);
 void pim_ifchannel_join_add(struct interface *ifp, struct in_addr neigh_addr,
-			    struct in_addr upstream, struct prefix_sg *sg,
+			    struct in_addr upstream, pim_sgaddr *sg,
 			    uint8_t source_flags, uint16_t holdtime);
 void pim_ifchannel_prune(struct interface *ifp, struct in_addr upstream,
-			 struct prefix_sg *sg, uint8_t source_flags,
+			 pim_sgaddr *sg, uint8_t source_flags,
 			 uint16_t holdtime);
-int pim_ifchannel_local_membership_add(struct interface *ifp,
-		struct prefix_sg *sg, bool is_vxlan);
-void pim_ifchannel_local_membership_del(struct interface *ifp,
-					struct prefix_sg *sg);
+int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
+				       bool is_vxlan);
+void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg);
 
 void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 				 enum pim_ifjoin_state new_state);

--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -106,13 +106,13 @@ static bool mtrace_fwd_info(struct pim_instance *pim,
 			    struct igmp_mtrace_rsp *rspp,
 			    struct interface **ifpp)
 {
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	struct pim_upstream *up;
 	struct interface *ifp_in;
 	struct in_addr nh_addr;
 	uint32_t total;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src = mtracep->src_addr;
 	sg.grp = mtracep->grp_addr;
 
@@ -426,14 +426,14 @@ static int mtrace_un_forward_packet(struct pim_instance *pim, struct ip *ip_hdr,
 
 static int mtrace_mc_forward_packet(struct pim_instance *pim, struct ip *ip_hdr)
 {
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	struct channel_oil *c_oil;
 	struct listnode *chnode;
 	struct listnode *chnextnode;
 	struct pim_ifchannel *ch = NULL;
 	int ret = -1;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.grp = ip_hdr->ip_dst;
 
 	c_oil = pim_find_channel_oil(pim, &sg);
@@ -477,14 +477,14 @@ static int mtrace_send_mc_response(struct pim_instance *pim,
 				   struct igmp_mtrace *mtracep,
 				   size_t mtrace_len)
 {
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	struct channel_oil *c_oil;
 	struct listnode *chnode;
 	struct listnode *chnextnode;
 	struct pim_ifchannel *ch = NULL;
 	int ret = -1;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.grp = mtracep->rsp_addr;
 
 	c_oil = pim_find_channel_oil(pim, &sg);

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -87,8 +87,8 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		struct pim_rpf *rp = RP(pim_ifp->pim, sg->grp);
 
 		if (!rp) {
-			zlog_warn("%s: Lookup of RP failed for %pSG4", __func__,
-				  sg);
+			zlog_warn("%s: Lookup of RP failed for %pPSG4",
+				  __func__, sg);
 			return;
 		}
 		/*
@@ -160,7 +160,7 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 
 			pim_inet4_dump("<received?>", sg->src, received_rp,
 				       sizeof(received_rp));
-			zlog_debug("%s: Prune received with RP(%s) for %pSG4",
+			zlog_debug("%s: Prune received with RP(%s) for %pPSG4",
 				   __func__, received_rp, sg);
 		}
 

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -55,7 +55,7 @@ static void on_trace(const char *label, struct interface *ifp,
 
 static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		      uint16_t holdtime, struct in_addr upstream,
-		      struct prefix_sg *sg, uint8_t source_flags)
+		      pim_sgaddr *sg, uint8_t source_flags)
 {
 	struct pim_interface *pim_ifp = NULL;
 
@@ -87,8 +87,8 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		struct pim_rpf *rp = RP(pim_ifp->pim, sg->grp);
 
 		if (!rp) {
-			zlog_warn("%s: Lookup of RP failed for %pPSG4",
-				  __func__, sg);
+			zlog_warn("%s: Lookup of RP failed for %pSG", __func__,
+				  sg);
 			return;
 		}
 		/*
@@ -125,7 +125,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 
 static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 		       uint16_t holdtime, struct in_addr upstream,
-		       struct prefix_sg *sg, uint8_t source_flags)
+		       pim_sgaddr *sg, uint8_t source_flags)
 {
 	struct pim_interface *pim_ifp = NULL;
 
@@ -160,7 +160,7 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 
 			pim_inet4_dump("<received?>", sg->src, received_rp,
 				       sizeof(received_rp));
-			zlog_debug("%s: Prune received with RP(%s) for %pPSG4",
+			zlog_debug("%s: Prune received with RP(%s) for %pSG",
 				   __func__, received_rp, sg);
 		}
 
@@ -247,7 +247,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 
 	/* Scan groups */
 	for (group = 0; group < msg_num_groups; ++group) {
-		struct prefix_sg sg;
+		pim_sgaddr sg;
 		uint8_t msg_source_flags;
 		uint16_t msg_num_joined_sources;
 		uint16_t msg_num_pruned_sources;
@@ -255,7 +255,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 		struct pim_ifchannel *starg_ch = NULL, *sg_ch = NULL;
 		bool filtered = false;
 
-		memset(&sg, 0, sizeof(struct prefix_sg));
+		memset(&sg, 0, sizeof(sg));
 		addr_offset = pim_parse_addr_group(&sg, buf, pastend - buf);
 		if (addr_offset < 1) {
 			return -5;

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -743,11 +743,11 @@ static void pim_mlag_process_mroute_add(struct mlag_mroute_add msg)
 		sg.src.s_addr = ntohl(msg.source_ip);
 
 		zlog_debug(
-			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x (%pSG4) cost: %u",
+			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x (%pPSG4) cost: %u",
 			__func__, msg.vrf_name, msg.source_ip, msg.group_ip,
 			&sg, msg.cost_to_rp);
 		zlog_debug(
-			"(%pSG4)owner_id: %d, DR: %d, Dual active: %d, vrf_id: 0x%x intf_name: %s",
+			"(%pPSG4)owner_id: %d, DR: %d, Dual active: %d, vrf_id: 0x%x intf_name: %s",
 			&sg, msg.owner_id, msg.am_i_dr, msg.am_i_dual_active,
 			msg.vrf_id, msg.intf_name);
 	}
@@ -772,10 +772,10 @@ static void pim_mlag_process_mroute_del(struct mlag_mroute_del msg)
 		sg.grp.s_addr = ntohl(msg.group_ip);
 		sg.src.s_addr = ntohl(msg.source_ip);
 		zlog_debug(
-			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x(%pSG4)",
+			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x(%pPSG4)",
 			__func__, msg.vrf_name, msg.source_ip, msg.group_ip,
 			&sg);
-		zlog_debug("(%pSG4)owner_id: %d, vrf_id: 0x%x intf_name: %s",
+		zlog_debug("(%pPSG4)owner_id: %d, vrf_id: 0x%x intf_name: %s",
 			   &sg, msg.owner_id, msg.vrf_id, msg.intf_name);
 	}
 

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -253,11 +253,11 @@ static void pim_mlag_up_peer_add(struct mlag_mroute_add *msg)
 	struct pim_upstream *up;
 	struct pim_instance *pim;
 	int flags = 0;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	struct vrf *vrf;
 	char sg_str[PIM_SG_LEN];
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src.s_addr = htonl(msg->source_ip);
 	sg.grp.s_addr = htonl(msg->group_ip);
 	if (PIM_DEBUG_MLAG)
@@ -327,11 +327,11 @@ static void pim_mlag_up_peer_del(struct mlag_mroute_del *msg)
 {
 	struct pim_upstream *up;
 	struct pim_instance *pim;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	struct vrf *vrf;
 	char sg_str[PIM_SG_LEN];
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src.s_addr = htonl(msg->source_ip);
 	sg.grp.s_addr = htonl(msg->group_ip);
 	if (PIM_DEBUG_MLAG)
@@ -737,17 +737,17 @@ static void pim_mlag_process_vxlan_update(struct mlag_vxlan *msg)
 static void pim_mlag_process_mroute_add(struct mlag_mroute_add msg)
 {
 	if (PIM_DEBUG_MLAG) {
-		struct prefix_sg sg;
+		pim_sgaddr sg;
 
 		sg.grp.s_addr = ntohl(msg.group_ip);
 		sg.src.s_addr = ntohl(msg.source_ip);
 
 		zlog_debug(
-			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x (%pPSG4) cost: %u",
+			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x (%pSG) cost: %u",
 			__func__, msg.vrf_name, msg.source_ip, msg.group_ip,
 			&sg, msg.cost_to_rp);
 		zlog_debug(
-			"(%pPSG4)owner_id: %d, DR: %d, Dual active: %d, vrf_id: 0x%x intf_name: %s",
+			"(%pSG)owner_id: %d, DR: %d, Dual active: %d, vrf_id: 0x%x intf_name: %s",
 			&sg, msg.owner_id, msg.am_i_dr, msg.am_i_dual_active,
 			msg.vrf_id, msg.intf_name);
 	}
@@ -767,15 +767,15 @@ static void pim_mlag_process_mroute_add(struct mlag_mroute_add msg)
 static void pim_mlag_process_mroute_del(struct mlag_mroute_del msg)
 {
 	if (PIM_DEBUG_MLAG) {
-		struct prefix_sg sg;
+		pim_sgaddr sg;
 
 		sg.grp.s_addr = ntohl(msg.group_ip);
 		sg.src.s_addr = ntohl(msg.source_ip);
 		zlog_debug(
-			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x(%pPSG4)",
+			"%s: msg dump: vrf_name: %s, s.ip: 0x%x, g.ip: 0x%x(%pSG)",
 			__func__, msg.vrf_name, msg.source_ip, msg.group_ip,
 			&sg);
-		zlog_debug("(%pPSG4)owner_id: %d, vrf_id: 0x%x intf_name: %s",
+		zlog_debug("(%pSG)owner_id: %d, vrf_id: 0x%x intf_name: %s",
 			   &sg, msg.owner_id, msg.vrf_id, msg.intf_name);
 	}
 

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -154,7 +154,7 @@ static int pim_mroute_msg_nocache(int fd, struct interface *ifp,
 	struct pim_interface *pim_ifp = ifp->info;
 	struct pim_upstream *up;
 	struct pim_rpf *rpg;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 
 	rpg = pim_ifp ? RP(pim_ifp->pim, msg->im_dst) : NULL;
 	/*
@@ -183,7 +183,7 @@ static int pim_mroute_msg_nocache(int fd, struct interface *ifp,
 		return 0;
 	}
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src = msg->im_src;
 	sg.grp = msg->im_dst;
 
@@ -242,7 +242,7 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 				   const char *buf)
 {
 	struct pim_interface *pim_ifp;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	struct pim_rpf *rpg;
 	const struct ip *ip_hdr;
 	struct pim_upstream *up;
@@ -251,13 +251,13 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 
 	ip_hdr = (const struct ip *)buf;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src = ip_hdr->ip_src;
 	sg.grp = ip_hdr->ip_dst;
 
 	up = pim_upstream_find(pim_ifp->pim, &sg);
 	if (!up) {
-		struct prefix_sg star = sg;
+		pim_sgaddr star = sg;
 		star.src.s_addr = INADDR_ANY;
 
 		up = pim_upstream_find(pim_ifp->pim, &star);
@@ -342,9 +342,9 @@ static int pim_mroute_msg_wrongvif(int fd, struct interface *ifp,
 {
 	struct pim_ifchannel *ch;
 	struct pim_interface *pim_ifp;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src = msg->im_src;
 	sg.grp = msg->im_dst;
 
@@ -378,7 +378,7 @@ static int pim_mroute_msg_wrongvif(int fd, struct interface *ifp,
 
 	ch = pim_ifchannel_find(ifp, &sg);
 	if (!ch) {
-		struct prefix_sg star_g = sg;
+		pim_sgaddr star_g = sg;
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
 				"%s: WRONGVIF (S,G)=%s could not find channel on interface %s",
@@ -448,12 +448,12 @@ static int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp,
 	struct pim_instance *pim;
 	struct pim_ifchannel *ch;
 	struct pim_upstream *up;
-	struct prefix_sg star_g;
-	struct prefix_sg sg;
+	pim_sgaddr star_g;
+	pim_sgaddr sg;
 
 	pim_ifp = ifp->info;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src = ip_hdr->ip_src;
 	sg.grp = ip_hdr->ip_dst;
 
@@ -1213,7 +1213,7 @@ void pim_mroute_update_counters(struct channel_oil *c_oil)
 	if (!c_oil->installed) {
 		c_oil->cc.lastused = 100 * pim->keep_alive_time;
 		if (PIM_DEBUG_MROUTE) {
-			struct prefix_sg sg;
+			pim_sgaddr sg;
 
 			sg.src = c_oil->oil.mfcc_origin;
 			sg.grp = c_oil->oil.mfcc_mcastgrp;
@@ -1230,7 +1230,7 @@ void pim_mroute_update_counters(struct channel_oil *c_oil)
 
 	pim_zlookup_sg_statistics(c_oil);
 	if (ioctl(pim->mroute_socket, SIOCGETSGCNT, &sgreq)) {
-		struct prefix_sg sg;
+		pim_sgaddr sg;
 
 		sg.src = c_oil->oil.mfcc_origin;
 		sg.grp = c_oil->oil.mfcc_mcastgrp;

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -152,7 +152,7 @@ static bool pim_msdp_sa_upstream_add_ok(struct pim_msdp_sa *sa,
 
 	/* check if we have a (*, G) with a non-empty immediate OIL */
 	if (!xg_up) {
-		struct prefix_sg sg;
+		pim_sgaddr sg;
 
 		memset(&sg, 0, sizeof(sg));
 		sg.grp = sa->sg.grp;
@@ -237,8 +237,7 @@ static void pim_msdp_sa_free(struct pim_msdp_sa *sa)
 }
 
 static struct pim_msdp_sa *pim_msdp_sa_new(struct pim_instance *pim,
-					   struct prefix_sg *sg,
-					   struct in_addr rp)
+					   pim_sgaddr *sg, struct in_addr rp)
 {
 	struct pim_msdp_sa *sa;
 
@@ -262,7 +261,7 @@ static struct pim_msdp_sa *pim_msdp_sa_new(struct pim_instance *pim,
 }
 
 static struct pim_msdp_sa *pim_msdp_sa_find(struct pim_instance *pim,
-					    struct prefix_sg *sg)
+					    pim_sgaddr *sg)
 {
 	struct pim_msdp_sa lookup;
 
@@ -271,8 +270,7 @@ static struct pim_msdp_sa *pim_msdp_sa_find(struct pim_instance *pim,
 }
 
 static struct pim_msdp_sa *pim_msdp_sa_add(struct pim_instance *pim,
-					   struct prefix_sg *sg,
-					   struct in_addr rp)
+					   pim_sgaddr *sg, struct in_addr rp)
 {
 	struct pim_msdp_sa *sa;
 
@@ -386,7 +384,7 @@ static void pim_msdp_sa_deref(struct pim_msdp_sa *sa,
 }
 
 void pim_msdp_sa_ref(struct pim_instance *pim, struct pim_msdp_peer *mp,
-		     struct prefix_sg *sg, struct in_addr rp)
+		     pim_sgaddr *sg, struct in_addr rp)
 {
 	struct pim_msdp_sa *sa;
 
@@ -467,15 +465,14 @@ static bool pim_msdp_sa_local_add_ok(struct pim_upstream *up)
 	return false;
 }
 
-static void pim_msdp_sa_local_add(struct pim_instance *pim,
-				  struct prefix_sg *sg)
+static void pim_msdp_sa_local_add(struct pim_instance *pim, pim_sgaddr *sg)
 {
 	struct in_addr rp;
 	rp.s_addr = INADDR_ANY;
 	pim_msdp_sa_ref(pim, NULL /* mp */, sg, rp);
 }
 
-void pim_msdp_sa_local_del(struct pim_instance *pim, struct prefix_sg *sg)
+void pim_msdp_sa_local_del(struct pim_instance *pim, pim_sgaddr *sg)
 {
 	struct pim_msdp_sa *sa;
 
@@ -488,7 +485,7 @@ void pim_msdp_sa_local_del(struct pim_instance *pim, struct prefix_sg *sg)
 /* we need to be very cautious with this API as SA del too can trigger an
  * upstream del and we will get stuck in a simple loop */
 static void pim_msdp_sa_local_del_on_up_del(struct pim_instance *pim,
-					    struct prefix_sg *sg)
+					    pim_sgaddr *sg)
 {
 	struct pim_msdp_sa *sa;
 
@@ -643,7 +640,7 @@ void pim_msdp_up_join_state_changed(struct pim_instance *pim,
 	}
 }
 
-static void pim_msdp_up_xg_del(struct pim_instance *pim, struct prefix_sg *sg)
+static void pim_msdp_up_xg_del(struct pim_instance *pim, pim_sgaddr *sg)
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;
@@ -667,7 +664,7 @@ static void pim_msdp_up_xg_del(struct pim_instance *pim, struct prefix_sg *sg)
 	}
 }
 
-void pim_msdp_up_del(struct pim_instance *pim, struct prefix_sg *sg)
+void pim_msdp_up_del(struct pim_instance *pim, pim_sgaddr *sg)
 {
 	if (PIM_DEBUG_MSDP_INTERNAL) {
 		zlog_debug("MSDP up %s del", pim_str_sg_dump(sg));

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -78,7 +78,7 @@ enum pim_msdp_sa_flags {
 struct pim_msdp_sa {
 	struct pim_instance *pim;
 
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	char sg_str[PIM_SG_LEN];
 	struct in_addr rp;   /* Last RP address associated with this SA */
 	struct in_addr peer; /* last peer from who we heard this SA */
@@ -246,14 +246,14 @@ bool pim_msdp_peer_config_write(struct vty *vty, struct pim_instance *pim,
 				const char *spaces);
 void pim_msdp_peer_pkt_txed(struct pim_msdp_peer *mp);
 void pim_msdp_sa_ref(struct pim_instance *pim, struct pim_msdp_peer *mp,
-		     struct prefix_sg *sg, struct in_addr rp);
+		     pim_sgaddr *sg, struct in_addr rp);
 void pim_msdp_sa_local_update(struct pim_upstream *up);
-void pim_msdp_sa_local_del(struct pim_instance *pim, struct prefix_sg *sg);
+void pim_msdp_sa_local_del(struct pim_instance *pim, pim_sgaddr *sg);
 void pim_msdp_i_am_rp_changed(struct pim_instance *pim);
 bool pim_msdp_peer_rpf_check(struct pim_msdp_peer *mp, struct in_addr rp);
 void pim_msdp_up_join_state_changed(struct pim_instance *pim,
 				    struct pim_upstream *xg_up);
-void pim_msdp_up_del(struct pim_instance *pim, struct prefix_sg *sg);
+void pim_msdp_up_del(struct pim_instance *pim, pim_sgaddr *sg);
 enum pim_msdp_err pim_msdp_mg_del(struct pim_instance *pim,
 				  const char *mesh_group_name);
 

--- a/pimd/pim_msdp_packet.c
+++ b/pimd/pim_msdp_packet.c
@@ -66,14 +66,14 @@ static char *pim_msdp_pkt_type_dump(enum pim_msdp_tlv type, char *buf,
 
 static void pim_msdp_pkt_sa_dump_one(struct stream *s)
 {
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 
 	/* just throw away the three reserved bytes */
 	stream_get3(s);
 	/* throw away the prefix length also */
 	stream_getc(s);
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.grp.s_addr = stream_get_ipv4(s);
 	sg.src.s_addr = stream_get_ipv4(s);
 
@@ -458,7 +458,7 @@ void pim_msdp_pkt_sa_tx_to_one_peer(struct pim_msdp_peer *mp)
 }
 
 void pim_msdp_pkt_sa_tx_one_to_one_peer(struct pim_msdp_peer *mp,
-					struct in_addr rp, struct prefix_sg sg)
+					struct in_addr rp, pim_sgaddr sg)
 {
 	struct pim_msdp_sa sa;
 
@@ -493,7 +493,7 @@ static void pim_msdp_pkt_ka_rx(struct pim_msdp_peer *mp, int len)
 static void pim_msdp_pkt_sa_rx_one(struct pim_msdp_peer *mp, struct in_addr rp)
 {
 	int prefix_len;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	struct listnode *peer_node;
 	struct pim_msdp_peer *peer;
 
@@ -501,7 +501,7 @@ static void pim_msdp_pkt_sa_rx_one(struct pim_msdp_peer *mp, struct in_addr rp)
 	stream_get3(mp->ibuf);
 	prefix_len = stream_getc(mp->ibuf);
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.grp.s_addr = stream_get_ipv4(mp->ibuf);
 	sg.src.s_addr = stream_get_ipv4(mp->ibuf);
 

--- a/pimd/pim_msdp_packet.h
+++ b/pimd/pim_msdp_packet.h
@@ -69,6 +69,6 @@ void pim_msdp_pkt_sa_tx(struct pim_instance *pim);
 void pim_msdp_pkt_sa_tx_one(struct pim_msdp_sa *sa);
 void pim_msdp_pkt_sa_tx_to_one_peer(struct pim_msdp_peer *mp);
 void pim_msdp_pkt_sa_tx_one_to_one_peer(struct pim_msdp_peer *mp,
-					struct in_addr rp, struct prefix_sg sg);
+					struct in_addr rp, pim_sgaddr sg);
 
 #endif

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -95,9 +95,9 @@ static void pim_if_membership_refresh(struct interface *ifp)
 					  src)) {
 
 			if (IGMP_SOURCE_TEST_FORWARDING(src->source_flags)) {
-				struct prefix_sg sg;
+				pim_sgaddr sg;
 
-				memset(&sg, 0, sizeof(struct prefix_sg));
+				memset(&sg, 0, sizeof(sg));
 				sg.src = src->source_addr;
 				sg.grp = grp->group_addr;
 				pim_ifchannel_local_membership_add(

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -145,7 +145,7 @@ struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
-				"%s(%s): Existing oil for %pSG4 Ref Count: %d (Post Increment)",
+				"%s(%s): Existing oil for %pPSG4 Ref Count: %d (Post Increment)",
 				__func__, name, sg, c_oil->oil_ref_count);
 		return c_oil;
 	}
@@ -178,7 +178,7 @@ struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
 				       .grp = c_oil->oil.mfcc_origin};
 
 		zlog_debug(
-			"%s(%s): Del oil for %pSG4, Ref Count: %d (Predecrement)",
+			"%s(%s): Del oil for %pPSG4, Ref Count: %d (Predecrement)",
 			__func__, name, &sg, c_oil->oil_ref_count);
 	}
 	--c_oil->oil_ref_count;

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -39,7 +39,7 @@ char *pim_channel_oil_dump(struct channel_oil *c_oil, char *buf, size_t size)
 {
 	char *out;
 	struct interface *ifp;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	int i;
 
 	sg.src = c_oil->oil.mfcc_origin;
@@ -104,7 +104,7 @@ void pim_channel_oil_free(struct channel_oil *c_oil)
 }
 
 struct channel_oil *pim_find_channel_oil(struct pim_instance *pim,
-					 struct prefix_sg *sg)
+					 pim_sgaddr *sg)
 {
 	struct channel_oil *c_oil = NULL;
 	struct channel_oil lookup;
@@ -118,8 +118,7 @@ struct channel_oil *pim_find_channel_oil(struct pim_instance *pim,
 }
 
 struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
-					struct prefix_sg *sg,
-					const char *name)
+					pim_sgaddr *sg, const char *name)
 {
 	struct channel_oil *c_oil;
 
@@ -145,7 +144,7 @@ struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
-				"%s(%s): Existing oil for %pPSG4 Ref Count: %d (Post Increment)",
+				"%s(%s): Existing oil for %pSG Ref Count: %d (Post Increment)",
 				__func__, name, sg, c_oil->oil_ref_count);
 		return c_oil;
 	}
@@ -174,11 +173,11 @@ struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
 					const char *name)
 {
 	if (PIM_DEBUG_MROUTE) {
-		struct prefix_sg sg = {.src = c_oil->oil.mfcc_mcastgrp,
-				       .grp = c_oil->oil.mfcc_origin};
+		pim_sgaddr sg = {.src = c_oil->oil.mfcc_mcastgrp,
+				 .grp = c_oil->oil.mfcc_origin};
 
 		zlog_debug(
-			"%s(%s): Del oil for %pPSG4, Ref Count: %d (Predecrement)",
+			"%s(%s): Del oil for %pSG, Ref Count: %d (Predecrement)",
 			__func__, name, &sg, c_oil->oil_ref_count);
 	}
 	--c_oil->oil_ref_count;

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -123,10 +123,9 @@ void pim_oil_terminate(struct pim_instance *pim);
 
 void pim_channel_oil_free(struct channel_oil *c_oil);
 struct channel_oil *pim_find_channel_oil(struct pim_instance *pim,
-					 struct prefix_sg *sg);
+					 pim_sgaddr *sg);
 struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
-					struct prefix_sg *sg,
-					const char *name);
+					pim_sgaddr *sg, const char *name);
 void pim_channel_oil_change_iif(struct pim_instance *pim,
 				struct channel_oil *c_oil, int input_vif_index,
 				const char *name);

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -64,7 +64,7 @@ void pim_register_join(struct pim_upstream *up)
 	pim_vxlan_update_sg_reg_state(pim, up, true /*reg_join*/);
 }
 
-void pim_register_stop_send(struct interface *ifp, struct prefix_sg *sg,
+void pim_register_stop_send(struct interface *ifp, pim_sgaddr *sg,
 			    struct in_addr src, struct in_addr originator)
 {
 	struct pim_interface *pinfo;
@@ -119,12 +119,12 @@ int pim_register_stop_recv(struct interface *ifp, uint8_t *buf, int buf_size)
 	struct pim_instance *pim = pim_ifp->pim;
 	struct pim_upstream *upstream = NULL;
 	struct prefix source;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	int l;
 
 	++pim_ifp->pim_ifstat_reg_stop_recv;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	l = pim_parse_addr_group(&sg, buf, buf_size);
 	buf += l;
 	buf_size -= l;
@@ -318,7 +318,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 {
 	int sentRegisterStop = 0;
 	struct ip *ip_hdr;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	uint32_t *bits;
 	int i_am_rp = 0;
 	struct pim_interface *pim_ifp = ifp->info;
@@ -367,7 +367,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 	 * Line above.  So we need to add 4 bytes to get to the
 	 * start of the actual Encapsulated data.
 	 */
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src = ip_hdr->ip_src;
 	sg.grp = ip_hdr->ip_dst;
 
@@ -416,7 +416,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 						       src_str,
 						       sizeof(src_str));
 					zlog_debug(
-						"%s: Sending register-stop to %s for %pPSG4 due to prefix-list denial, dropping packet",
+						"%s: Sending register-stop to %s for %pSG due to prefix-list denial, dropping packet",
 						__func__, src_str, &sg);
 				}
 

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -415,8 +415,9 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 					pim_inet4_dump("<src?>", src_addr,
 						       src_str,
 						       sizeof(src_str));
-					zlog_debug("%s: Sending register-stop to %s for %pSG4 due to prefix-list denial, dropping packet",
-						   __func__, src_str, &sg);
+					zlog_debug(
+						"%s: Sending register-stop to %s for %pPSG4 due to prefix-list denial, dropping packet",
+						__func__, src_str, &sg);
 				}
 
 				return 0;

--- a/pimd/pim_register.h
+++ b/pimd/pim_register.h
@@ -39,7 +39,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 void pim_register_send(const uint8_t *buf, int buf_size, struct in_addr src,
 		       struct pim_rpf *rpg, int null_register,
 		       struct pim_upstream *up);
-void pim_register_stop_send(struct interface *ifp, struct prefix_sg *sg,
+void pim_register_stop_send(struct interface *ifp, pim_sgaddr *sg,
 			    struct in_addr src, struct in_addr originator);
 void pim_register_join(struct pim_upstream *up);
 void pim_null_register_send(struct pim_upstream *up);

--- a/pimd/pim_str.c
+++ b/pimd/pim_str.c
@@ -42,7 +42,7 @@ void pim_addr_dump(const char *onfail, struct prefix *p, char *buf,
 	errno = save_errno;
 }
 
-char *pim_str_sg_dump(const struct prefix_sg *sg)
+char *pim_str_sg_dump(const pim_sgaddr *sg)
 {
 	static char sg_str[PIM_SG_LEN];
 

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -26,7 +26,7 @@
 
 #include <prefix.h>
 
-typedef struct in_addr pim_addr;
+#include "pim_addr.h"
 
 /*
  * Longest possible length of a (S,G) string is 36 bytes

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -24,7 +24,8 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 
-#include <prefix.h>
+#include "prefix.h"
+#include "pim_addr.h"
 
 #include "pim_addr.h"
 
@@ -37,7 +38,12 @@
  */
 #define PIM_SG_LEN PREFIX_SG_STR_LEN
 #define pim_inet4_dump prefix_mcast_inet4_dump
-#define pim_str_sg_set prefix_sg2str
+
+static inline const char *pim_str_sg_set(const pim_sgaddr *sg, char *str)
+{
+	snprintfrr(str, PREFIX_SG_STR_LEN, "%pSG", sg);
+	return str;
+}
 
 static inline void pim_addr_copy(pim_addr *dest, pim_addr *source)
 {
@@ -58,6 +64,6 @@ void pim_addr_dump(const char *onfail, struct prefix *p, char *buf,
 		   int buf_size);
 void pim_inet4_dump(const char *onfail, struct in_addr addr, char *buf,
 		    int buf_size);
-char *pim_str_sg_dump(const struct prefix_sg *sg);
+char *pim_str_sg_dump(const pim_sgaddr *sg);
 
 #endif

--- a/pimd/pim_tlv.c
+++ b/pimd/pim_tlv.c
@@ -510,7 +510,7 @@ int pim_parse_addr_ucast(struct prefix *p, const uint8_t *buf, int buf_size)
 	return addr - buf;
 }
 
-int pim_parse_addr_group(struct prefix_sg *sg, const uint8_t *buf, int buf_size)
+int pim_parse_addr_group(pim_sgaddr *sg, const uint8_t *buf, int buf_size)
 {
 	const int grp_encoding_min_len =
 		4; /* 1 family + 1 type + 1 reserved + 1 addr */
@@ -569,8 +569,8 @@ int pim_parse_addr_group(struct prefix_sg *sg, const uint8_t *buf, int buf_size)
 	return addr - buf;
 }
 
-int pim_parse_addr_source(struct prefix_sg *sg, uint8_t *flags,
-			  const uint8_t *buf, int buf_size)
+int pim_parse_addr_source(pim_sgaddr *sg, uint8_t *flags, const uint8_t *buf,
+			  int buf_size)
 {
 	const int src_encoding_min_len =
 		4; /* 1 family + 1 type + 1 reserved + 1 addr */

--- a/pimd/pim_tlv.h
+++ b/pimd/pim_tlv.h
@@ -111,9 +111,8 @@ int pim_encode_addr_group(uint8_t *buf, afi_t afi, int bidir, int scope,
 			  struct in_addr group);
 
 int pim_parse_addr_ucast(struct prefix *p, const uint8_t *buf, int buf_size);
-int pim_parse_addr_group(struct prefix_sg *sg, const uint8_t *buf,
-			 int buf_size);
-int pim_parse_addr_source(struct prefix_sg *sg, uint8_t *flags,
-			  const uint8_t *buf, int buf_size);
+int pim_parse_addr_group(pim_sgaddr *sg, const uint8_t *buf, int buf_size);
+int pim_parse_addr_source(pim_sgaddr *sg, uint8_t *flags, const uint8_t *buf,
+			  int buf_size);
 
 #endif /* PIM_TLV_H */

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -131,7 +131,7 @@ static void pim_upstream_find_new_children(struct pim_instance *pim,
 static struct pim_upstream *pim_upstream_find_parent(struct pim_instance *pim,
 						     struct pim_upstream *child)
 {
-	struct prefix_sg any = child->sg;
+	pim_sgaddr any = child->sg;
 	struct pim_upstream *up = NULL;
 
 	// (S,G)
@@ -860,7 +860,7 @@ void pim_upstream_fill_static_iif(struct pim_upstream *up,
 }
 
 static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
-					     struct prefix_sg *sg,
+					     pim_sgaddr *sg,
 					     struct interface *incoming,
 					     int flags,
 					     struct pim_ifchannel *ch)
@@ -1012,8 +1012,7 @@ uint32_t pim_up_mlag_peer_cost(struct pim_upstream *up)
 	return up->mlag.peer_mrib_metric;
 }
 
-struct pim_upstream *pim_upstream_find(struct pim_instance *pim,
-				       struct prefix_sg *sg)
+struct pim_upstream *pim_upstream_find(struct pim_instance *pim, pim_sgaddr *sg)
 {
 	struct pim_upstream lookup;
 	struct pim_upstream *up = NULL;
@@ -1023,9 +1022,9 @@ struct pim_upstream *pim_upstream_find(struct pim_instance *pim,
 	return up;
 }
 
-struct pim_upstream *pim_upstream_find_or_add(struct prefix_sg *sg,
-		struct interface *incoming,
-		int flags, const char *name)
+struct pim_upstream *pim_upstream_find_or_add(pim_sgaddr *sg,
+					      struct interface *incoming,
+					      int flags, const char *name)
 {
 	struct pim_interface *pim_ifp = incoming->info;
 
@@ -1069,8 +1068,7 @@ void pim_upstream_ref(struct pim_upstream *up, int flags, const char *name)
 			   __func__, name, up->sg_str, up->ref_count);
 }
 
-struct pim_upstream *pim_upstream_add(struct pim_instance *pim,
-				      struct prefix_sg *sg,
+struct pim_upstream *pim_upstream_add(struct pim_instance *pim, pim_sgaddr *sg,
 				      struct interface *incoming, int flags,
 				      const char *name,
 				      struct pim_ifchannel *ch)
@@ -1584,7 +1582,7 @@ void pim_upstream_msdp_reg_timer_start(struct pim_upstream *up)
  *  received for the source and group.
  */
 int pim_upstream_switch_to_spt_desired_on_rp(struct pim_instance *pim,
-				       struct prefix_sg *sg)
+					     pim_sgaddr *sg)
 {
 	if (I_am_RP(pim, sg->grp))
 		return 1;

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -231,7 +231,7 @@ struct pim_upstream {
 	struct pim_upstream *parent;
 	pim_addr upstream_addr;		  /* Who we are talking to */
 	pim_addr upstream_register;       /*Who we received a register from*/
-	struct prefix_sg sg;		  /* (S,G) group key */
+	pim_sgaddr sg;			  /* (S,G) group key */
 	char sg_str[PIM_SG_LEN];
 	uint32_t flags;
 	struct channel_oil *channel_oil;
@@ -291,12 +291,11 @@ static inline bool pim_up_mlag_is_local(struct pim_upstream *up)
 }
 
 struct pim_upstream *pim_upstream_find(struct pim_instance *pim,
-				       struct prefix_sg *sg);
-struct pim_upstream *pim_upstream_find_or_add(struct prefix_sg *sg,
+				       pim_sgaddr *sg);
+struct pim_upstream *pim_upstream_find_or_add(pim_sgaddr *sg,
 					      struct interface *ifp, int flags,
 					      const char *name);
-struct pim_upstream *pim_upstream_add(struct pim_instance *pim,
-				      struct prefix_sg *sg,
+struct pim_upstream *pim_upstream_add(struct pim_instance *pim, pim_sgaddr *sg,
 				      struct interface *ifp, int flags,
 				      const char *name,
 				      struct pim_ifchannel *ch);
@@ -338,7 +337,7 @@ void pim_upstream_keep_alive_timer_start(struct pim_upstream *up,
 					 uint32_t time);
 
 int pim_upstream_switch_to_spt_desired_on_rp(struct pim_instance *pim,
-				       struct prefix_sg *sg);
+					     pim_sgaddr *sg);
 #define SwitchToSptDesiredOnRp(pim, sg) pim_upstream_switch_to_spt_desired_on_rp (pim, sg)
 int pim_upstream_is_sg_rpt(struct pim_upstream *up);
 

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -734,7 +734,7 @@ static bool pim_vxlan_sg_hash_eq(const void *p1, const void *p2)
 }
 
 static struct pim_vxlan_sg *pim_vxlan_sg_new(struct pim_instance *pim,
-		struct prefix_sg *sg)
+					     pim_sgaddr *sg)
 {
 	struct pim_vxlan_sg *vxlan_sg;
 
@@ -760,8 +760,7 @@ static struct pim_vxlan_sg *pim_vxlan_sg_new(struct pim_instance *pim,
 	return vxlan_sg;
 }
 
-struct pim_vxlan_sg *pim_vxlan_sg_find(struct pim_instance *pim,
-		struct prefix_sg *sg)
+struct pim_vxlan_sg *pim_vxlan_sg_find(struct pim_instance *pim, pim_sgaddr *sg)
 {
 	struct pim_vxlan_sg lookup;
 
@@ -769,8 +768,7 @@ struct pim_vxlan_sg *pim_vxlan_sg_find(struct pim_instance *pim,
 	return hash_lookup(pim->vxlan.sg_hash, &lookup);
 }
 
-struct pim_vxlan_sg *pim_vxlan_sg_add(struct pim_instance *pim,
-		struct prefix_sg *sg)
+struct pim_vxlan_sg *pim_vxlan_sg_add(struct pim_instance *pim, pim_sgaddr *sg)
 {
 	struct pim_vxlan_sg *vxlan_sg;
 
@@ -805,7 +803,7 @@ static void pim_vxlan_sg_del_item(struct pim_vxlan_sg *vxlan_sg)
 	XFREE(MTYPE_PIM_VXLAN_SG, vxlan_sg);
 }
 
-void pim_vxlan_sg_del(struct pim_instance *pim, struct prefix_sg *sg)
+void pim_vxlan_sg_del(struct pim_instance *pim, pim_sgaddr *sg)
 {
 	struct pim_vxlan_sg *vxlan_sg;
 

--- a/pimd/pim_vxlan.h
+++ b/pimd/pim_vxlan.h
@@ -41,7 +41,7 @@ struct pim_vxlan_sg {
 	struct pim_instance *pim;
 
 	/* key */
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	char sg_str[PIM_SG_LEN];
 
 	enum pim_vxlan_sg_flags flags;
@@ -127,10 +127,10 @@ static inline bool pim_vxlan_is_term_dev_cfg(struct pim_instance *pim,
 
 extern struct pim_vxlan *pim_vxlan_p;
 extern struct pim_vxlan_sg *pim_vxlan_sg_find(struct pim_instance *pim,
-					    struct prefix_sg *sg);
+					      pim_sgaddr *sg);
 extern struct pim_vxlan_sg *pim_vxlan_sg_add(struct pim_instance *pim,
-					   struct prefix_sg *sg);
-extern void pim_vxlan_sg_del(struct pim_instance *pim, struct prefix_sg *sg);
+					     pim_sgaddr *sg);
+extern void pim_vxlan_sg_del(struct pim_instance *pim, pim_sgaddr *sg);
 extern void pim_vxlan_update_sg_reg_state(struct pim_instance *pim,
 		struct pim_upstream *up, bool reg_join);
 extern struct pim_interface *pim_vxlan_get_term_ifp(struct pim_instance *pim);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -327,7 +327,8 @@ static int pim_zebra_vxlan_sg_proc(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s;
 	struct pim_instance *pim;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
+	size_t prefixlen;
 
 	pim = pim_get_pim_instance(vrf_id);
 	if (!pim)
@@ -335,10 +336,9 @@ static int pim_zebra_vxlan_sg_proc(ZAPI_CALLBACK_ARGS)
 
 	s = zclient->ibuf;
 
-	sg.family = AF_INET;
-	sg.prefixlen = stream_getl(s);
-	stream_get(&sg.src.s_addr, s, sg.prefixlen);
-	stream_get(&sg.grp.s_addr, s, sg.prefixlen);
+	prefixlen = stream_getl(s);
+	stream_get(&sg.src.s_addr, s, prefixlen);
+	stream_get(&sg.grp.s_addr, s, prefixlen);
 
 	if (PIM_DEBUG_ZEBRA) {
 		char sg_str[PIM_SG_LEN];
@@ -502,7 +502,7 @@ void igmp_anysource_forward_stop(struct gm_group *group)
 static void igmp_source_forward_reevaluate_one(struct pim_instance *pim,
 					       struct gm_source *source)
 {
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	struct gm_group *group = source->source_group;
 	struct pim_ifchannel *ch;
 
@@ -510,7 +510,7 @@ static void igmp_source_forward_reevaluate_one(struct pim_instance *pim,
 	    || !IGMP_SOURCE_TEST_FORWARDING(source->source_flags))
 		return;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src = source->source_addr;
 	sg.grp = group->group_addr;
 
@@ -581,11 +581,11 @@ void igmp_source_forward_start(struct pim_instance *pim,
 {
 	struct pim_interface *pim_oif;
 	struct gm_group *group;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	int result;
 	int input_iface_vif_index = 0;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src = source->source_addr;
 	sg.grp = source->source_group->group_addr;
 
@@ -761,10 +761,10 @@ void igmp_source_forward_start(struct pim_instance *pim,
 void igmp_source_forward_stop(struct gm_source *source)
 {
 	struct gm_group *group;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	int result;
 
-	memset(&sg, 0, sizeof(struct prefix_sg));
+	memset(&sg, 0, sizeof(sg));
 	sg.src = source->source_addr;
 	sg.grp = source->source_group->group_addr;
 

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -524,14 +524,14 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 	struct stream *s = zlookup->obuf;
 	uint16_t command = 0;
 	unsigned long long lastused;
-	struct prefix_sg sg;
+	pim_sgaddr sg;
 	int count = 0;
 	int ret;
 	struct interface *ifp =
 		pim_if_find_by_vif_index(c_oil->pim, c_oil->oil.mfcc_parent);
 
 	if (PIM_DEBUG_ZEBRA) {
-		struct prefix_sg more;
+		pim_sgaddr more;
 
 		more.src = c_oil->oil.mfcc_origin;
 		more.grp = c_oil->oil.mfcc_mcastgrp;
@@ -587,7 +587,7 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 	if (sg.src.s_addr != c_oil->oil.mfcc_origin.s_addr
 	    || sg.grp.s_addr != c_oil->oil.mfcc_mcastgrp.s_addr) {
 		if (PIM_DEBUG_ZEBRA) {
-			struct prefix_sg more;
+			pim_sgaddr more;
 
 			more.src = c_oil->oil.mfcc_origin;
 			more.grp = c_oil->oil.mfcc_mcastgrp;

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -115,7 +115,6 @@ void pim_router_init(void)
 
 void pim_router_terminate(void)
 {
-	pim_mlag_terminate();
 	XFREE(MTYPE_ROUTER, router);
 }
 
@@ -155,6 +154,7 @@ void pim_terminate(void)
 	}
 
 	pim_free();
+	pim_mlag_terminate();
 	pim_router_terminate();
 
 	frr_fini();

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -27,6 +27,7 @@
 #include "vty.h"
 #include "plist.h"
 
+#include "pim_addr.h"
 #include "pim_instance.h"
 #include "pim_str.h"
 #include "pim_memory.h"

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -13,6 +13,7 @@ man8 += $(MANBUILD)/mtracebis.8
 endif
 
 pim_common = \
+	pimd/pim_addr.c \
 	pimd/pim_assert.c \
 	pimd/pim_bfd.c \
 	pimd/pim_br.c \
@@ -87,6 +88,7 @@ nodist_pimd_pim6d_SOURCES = \
 	# end
 
 noinst_HEADERS += \
+	pimd/pim_addr.h \
 	pimd/pim_assert.h \
 	pimd/pim_bfd.h \
 	pimd/pim_br.h \

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -158,7 +158,7 @@ if DEV_BUILD
 # (change noinst_ to sbin_ below to install it.)
 #
 noinst_PROGRAMS += pimd/pim6d
-pimd_pim6d_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=6
+pimd_pim6d_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=6 $(and $(PIM_V6_TEMP_BREAK),-DPIM_V6_TEMP_BREAK)
 pimd_pim6d_LDADD = lib/libfrr.la $(LIBCAP)
 endif
 endif

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -12,7 +12,7 @@ man8 += $(MANBUILD)/frr-pimd.8
 man8 += $(MANBUILD)/mtracebis.8
 endif
 
-pimd_pimd_SOURCES = \
+pim_common = \
 	pimd/pim_assert.c \
 	pimd/pim_bfd.c \
 	pimd/pim_br.c \
@@ -32,7 +32,6 @@ pimd_pimd_SOURCES = \
 	pimd/pim_join.c \
 	pimd/pim_jp_agg.c \
 	pimd/pim_macro.c \
-	pimd/pim_main.c \
 	pimd/pim_memory.c \
 	pimd/pim_mlag.c \
 	pimd/pim_mroute.c \
@@ -50,7 +49,6 @@ pimd_pimd_SOURCES = \
 	pimd/pim_routemap.c \
 	pimd/pim_rp.c \
 	pimd/pim_rpf.c \
-	pimd/pim_signals.c \
 	pimd/pim_sock.c \
 	pimd/pim_ssm.c \
 	pimd/pim_ssmpingd.c \
@@ -68,10 +66,24 @@ pimd_pimd_SOURCES = \
 	pimd/pimd.c \
 	# end
 
+pimd_pimd_SOURCES = \
+	$(pim_common) \
+	pimd/pim_main.c \
+	pimd/pim_signals.c \
+	# end
+
 nodist_pimd_pimd_SOURCES = \
 	yang/frr-pim.yang.c \
 	yang/frr-pim-rp.yang.c \
 	yang/frr-igmp.yang.c \
+	# end
+
+pimd_pim6d_SOURCES = \
+	$(pim_common) \
+	pimd/pim6_main.c \
+	# end
+
+nodist_pimd_pim6d_SOURCES = \
 	# end
 
 noinst_HEADERS += \
@@ -134,12 +146,26 @@ clippy_scan += \
 	pimd/pim_cmd.c \
 	# end
 
+pimd_pimd_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=4
 pimd_pimd_LDADD = lib/libfrr.la $(LIBCAP)
+
+if PIMD
+if DEV_BUILD
+#
+# pim6d is only enabled for --enable-dev-build, and NOT installed currently
+# (change noinst_ to sbin_ below to install it.)
+#
+noinst_PROGRAMS += pimd/pim6d
+pimd_pim6d_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=6
+pimd_pim6d_LDADD = lib/libfrr.la $(LIBCAP)
+endif
+endif
 
 pimd_test_igmpv3_join_LDADD = lib/libfrr.la
 pimd_test_igmpv3_join_SOURCES = pimd/test_igmpv3_join.c
 
 pimd_mtracebis_LDADD =  lib/libfrr.la
+pimd_mtracebis_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=4
 pimd_mtracebis_SOURCES = pimd/mtracebis.c \
 			 pimd/mtracebis_netlink.c \
 			 pimd/mtracebis_routeget.c \

--- a/tests/lib/test_printfrr.c
+++ b/tests/lib/test_printfrr.c
@@ -206,16 +206,16 @@ int main(int argc, char **argv)
 	struct prefix_sg sg;
 	sg.src.s_addr = INADDR_ANY;
 	sg.grp.s_addr = INADDR_ANY;
-	printchk("(*,*)", "%pSG4", &sg);
+	printchk("(*,*)", "%pPSG4", &sg);
 
 	inet_aton("192.168.1.2", &sg.src);
-	printchk("(192.168.1.2,*)", "%pSG4", &sg);
+	printchk("(192.168.1.2,*)", "%pPSG4", &sg);
 
 	inet_aton("224.1.2.3", &sg.grp);
-	printchk("(192.168.1.2,224.1.2.3)", "%pSG4", &sg);
+	printchk("(192.168.1.2,224.1.2.3)", "%pPSG4", &sg);
 
 	sg.src.s_addr = INADDR_ANY;
-	printchk("(*,224.1.2.3)", "%pSG4", &sg);
+	printchk("(*,224.1.2.3)", "%pPSG4", &sg);
 
 	uint8_t randhex[] = { 0x12, 0x34, 0x00, 0xca, 0xfe, 0x00, 0xaa, 0x55 };
 


### PR DESCRIPTION
This is the bulk editing part of #10281, split off here to reduce the surface area for merge conflicts.

NB: this temporarily compiles `pim6d` using the v4 address structures, because that's really a significant separate step and I'd rather keep `pim6d` compiling cleanly for now.