### PR TITLE
docker: update alpine build enable set own version

### DIFF
--- a/docker/alpine/build.sh
+++ b/docker/alpine/build.sh
@@ -6,7 +6,15 @@ set -x
 ##
 # Package version needs to be decimal
 ##
-GITREV="$(git rev-parse --short=10 HEAD)"
+
+##
+# Set GITREV=0 or similar in ENV if you want the tag to just be updated to -0
+# everytime for automation usage/scripts/etc locally.
+#
+# Ex) GITREV=0 ./build.sh
+##
+
+GITREV="${GITREV:=$(git rev-parse --short=10 HEAD)}"
 PKGVER="$(printf '%u\n' 0x$GITREV)"
 
 docker build \

--- a/docker/alpine/docker-start
+++ b/docker/alpine/docker-start
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 
 if [ -r "/lib/lsb/init-functions" ]; then
         . /lib/lsb/init-functions


### PR DESCRIPTION
Add ability to set your own env for the version of the docker
container alpine image. This is useful for applications like GNS3
who pin a specific version to look for when they boot up. When you build
locally to test your code you can just set the version to 0 so you don't
have to update configs/scripts looking for a specific image version.

Also fix a shebang in docker start for alpine.

Signed-off-by: Stephen Worley <sworley@nvidia.com>