### PR TITLE
bgpd: Adjust symbolic names for cease notifications according to rfc4486

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -160,14 +160,14 @@ static const struct message bgp_notify_update_msg[] = {
 static const struct message bgp_notify_cease_msg[] = {
 	{BGP_NOTIFY_SUBCODE_UNSPECIFIC, "/Unspecific"},
 	{BGP_NOTIFY_CEASE_MAX_PREFIX, "/Maximum Number of Prefixes Reached"},
-	{BGP_NOTIFY_CEASE_ADMIN_SHUTDOWN, "/Administratively Shutdown"},
-	{BGP_NOTIFY_CEASE_PEER_UNCONFIG, "/Peer Unconfigured"},
-	{BGP_NOTIFY_CEASE_ADMIN_RESET, "/Administratively Reset"},
+	{BGP_NOTIFY_CEASE_ADMIN_SHUTDOWN, "/Administrative Shutdown"},
+	{BGP_NOTIFY_CEASE_PEER_UNCONFIG, "/Peer De-configured"},
+	{BGP_NOTIFY_CEASE_ADMIN_RESET, "/Administrative Reset"},
 	{BGP_NOTIFY_CEASE_CONNECT_REJECT, "/Connection Rejected"},
 	{BGP_NOTIFY_CEASE_CONFIG_CHANGE, "/Other Configuration Change"},
 	{BGP_NOTIFY_CEASE_COLLISION_RESOLUTION,
-	 "/Connection collision resolution"},
-	{BGP_NOTIFY_CEASE_OUT_OF_RESOURCE, "/Out of Resource"},
+	 "/Connection Collision Resolution"},
+	{BGP_NOTIFY_CEASE_OUT_OF_RESOURCE, "/Out of Resources"},
 	{0}};
 
 static const struct message bgp_notify_route_refresh_msg[] = {

--- a/doc/user/snmptrap.rst
+++ b/doc/user/snmptrap.rst
@@ -155,13 +155,13 @@ a siren, have your display flash, etc., be creative ;).
    error="Cease"
    case "$suberrorcode" in
    01) suberror="Maximum Number of Prefixes Reached" ;;
-   02) suberror="Administratively Shutdown" ;;
-   03) suberror="Peer Unconfigured" ;;
-   04) suberror="Administratively Reset" ;;
+   02) suberror="Administrative Shutdown" ;;
+   03) suberror="Peer De-configured" ;;
+   04) suberror="Administrative Reset" ;;
    05) suberror="Connection Rejected" ;;
    06) suberror="Other Configuration Change" ;;
-   07) suberror="Connection collision resolution" ;;
-   08) suberror="Out of Resource" ;;
+   07) suberror="Connection Collision Resolution" ;;
+   08) suberror="Out of Resources" ;;
    09) suberror="MAX" ;;
    *) suberror="Unknown" ;;
    esac

--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -235,7 +235,7 @@ def test_bgp_shutdown_message():
         logger.info("Checking BGP shutdown received on router r{}".format(rtrNum))
 
         shut_message = tgen.net["r{}".format(rtrNum)].cmd(
-            'tail bgpd.log | grep "NOTIFICATION.*Cease/Administratively Shutdown"'
+            'tail bgpd.log | grep "NOTIFICATION.*Cease/Administrative Shutdown"'
         )
         assertmsg = "BGP shutdown message not received on router R{}".format(rtrNum)
         assert shut_message != "", assertmsg


### PR DESCRIPTION
The following subcodes are defined for the Cease NOTIFICATION
   message:

      Subcode     Symbolic Name

         1        Maximum Number of Prefixes Reached
         2        Administrative Shutdown
         3        Peer De-configured
         4        Administrative Reset
         5        Connection Rejected
         6        Other Configuration Change
         7        Connection Collision Resolution
         8        Out of Resources

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>