### PR TITLE
bgpd: Increase maximum supress threshold for dampening to 50,000

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14607,7 +14607,7 @@ DEFUN (no_ipv6_bgp_distance_source_access_list,
 
 DEFUN (bgp_damp_set,
        bgp_damp_set_cmd,
-       "bgp dampening [(1-45) [(1-20000) (1-20000) (1-255)]]",
+       "bgp dampening [(1-45) [(1-20000) (1-50000) (1-255)]]",
        "BGP Specific commands\n"
        "Enable route-flap dampening\n"
        "Half-life time for the penalty\n"
@@ -14653,7 +14653,7 @@ DEFUN (bgp_damp_set,
 
 DEFUN (bgp_damp_unset,
        bgp_damp_unset_cmd,
-       "no bgp dampening [(1-45) [(1-20000) (1-20000) (1-255)]]",
+       "no bgp dampening [(1-45) [(1-20000) (1-50000) (1-255)]]",
        NO_STR
        "BGP Specific commands\n"
        "Enable route-flap dampening\n"

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -515,7 +515,7 @@ Disable checking if nexthop is connected on EBGP sessions
 Route Flap Dampening
 --------------------
 
-.. clicmd:: bgp dampening (1-45) (1-20000) (1-20000) (1-255)
+.. clicmd:: bgp dampening (1-45) (1-20000) (1-50000) (1-255)
 
    This command enables BGP route-flap dampening and specifies dampening parameters.
 

--- a/doc/user/overview.rst
+++ b/doc/user/overview.rst
@@ -349,6 +349,8 @@ BGP
   :t:`The Resource Public Key Infrastructure (RPKI) to Router Protocol. R. Bush, R. Austein. January 2013.`
 - :rfc:`6811`
   :t:`BGP Prefix Origin Validation. P. Mohapatra, J. Scudder, D. Ward, R. Bush, R. Austein. January 2013.`
+- :rfc:`7196`
+  :t:`Making Route Flap Damping Usable. C. Pelsser, R. Bush, K. Patel, P. Mohapatra, O. Maennel. May 2014.`
 - :rfc:`7313`
   :t:`Enhanced Route Refresh Capability for BGP-4. K. Patel, E. Chen, B. Venkatachalapathy. July 2014.`
 - :rfc:`7606`


### PR DESCRIPTION
rfc7196 recommends:

In addition, BGP implementations have an internal constant, which we
   will call the 'maximum penalty', and the current computed penalty may
   not exceed it.

Router Maximum Penalty:  The internal constant for the maximum
      penalty value MUST be raised to at least 50,000.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>