### PR TITLE
pimd: start tackling IPv6 address operations

### DIFF
--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -341,9 +341,6 @@ union prefixconstptr {
 	prefixtype(prefixconstptr, const struct prefix_rd,   rd)
 } TRANSPARENT_UNION;
 
-#undef prefixtype
-#undef TRANSPARENT_UNION
-
 #ifndef INET_ADDRSTRLEN
 #define INET_ADDRSTRLEN 16
 #endif /* INET_ADDRSTRLEN */

--- a/pimd/pim_addr.c
+++ b/pimd/pim_addr.c
@@ -39,12 +39,8 @@ static ssize_t printfrr_pimaddr(struct fbuf *buf, struct printfrr_eargs *ea,
 	if (!addr)
 		return bputs(buf, "(null)");
 
-	if (use_star) {
-		pim_addr zero = {};
-
-		if (memcmp(addr, &zero, sizeof(zero)) == 0)
-			return bputch(buf, '*');
-	}
+	if (use_star && pim_addr_is_any(*addr))
+		return bputch(buf, '*');
 
 #if PIM_IPV == 4
 	return bprintfrr(buf, "%pI4", addr);

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -34,6 +34,11 @@ typedef struct in6_addr pim_addr;
 #define PIM_ADDRSTRLEN INET6_ADDRSTRLEN
 #endif
 
+/* for assignment/initialization (C99 compound literal)
+ * named PIMADDR_ANY (not PIM_ADDR_ANY) to match INADDR_ANY
+ */
+#define PIMADDR_ANY (pim_addr){ }
+
 static inline bool pim_addr_is_any(pim_addr addr)
 {
 	pim_addr zero = {};

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -41,6 +41,11 @@ static inline bool pim_addr_is_any(pim_addr addr)
 	return memcmp(&addr, &zero, sizeof(zero)) == 0;
 }
 
+static inline int pim_addr_cmp(pim_addr a, pim_addr b)
+{
+	return memcmp(&a, &b, sizeof(a));
+}
+
 /* don't use this struct directly, use the pim_sgaddr typedef */
 struct _pim_sgaddr {
 	pim_addr grp;

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -21,6 +21,9 @@
 #define _PIMD_PIM_ADDR_H
 
 #include "jhash.h"
+#include "prefix.h"
+
+/* clang-format off */
 
 /* temporarily disable IPv6 types to keep code compiling.
  * Defining PIM_V6_TEMP_BREAK will show a lot of compile errors - they are
@@ -28,16 +31,47 @@
  */
 #if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
 typedef struct in_addr pim_addr;
-#define PIM_ADDRSTRLEN INET_ADDRSTRLEN
+
+#define PIM_ADDRSTRLEN	INET_ADDRSTRLEN
+#define PIM_AF		AF_INET
+#define PIM_AFI		AFI_IP
+#define PIM_MAX_BITLEN	IPV4_MAX_BITLEN
+
+union pimprefixptr {
+	prefixtype(pimprefixptr, struct prefix,      p)
+	prefixtype(pimprefixptr, struct prefix_ipv4, p4)
+} TRANSPARENT_UNION;
+
+union pimprefixconstptr {
+	prefixtype(pimprefixconstptr, const struct prefix,      p)
+	prefixtype(pimprefixconstptr, const struct prefix_ipv4, p4)
+} TRANSPARENT_UNION;
+
 #else
 typedef struct in6_addr pim_addr;
-#define PIM_ADDRSTRLEN INET6_ADDRSTRLEN
+
+#define PIM_ADDRSTRLEN	INET6_ADDRSTRLEN
+#define PIM_AF		AF_INET6
+#define PIM_AFI		AFI_IP6
+#define PIM_MAX_BITLEN	IPV6_MAX_BITLEN
+
+union pimprefixptr {
+	prefixtype(pimprefixptr, struct prefix,      p)
+	prefixtype(pimprefixptr, struct prefix_ipv6, p6)
+} TRANSPARENT_UNION;
+
+union pimprefixconstptr {
+	prefixtype(pimprefixconstptr, const struct prefix,      p)
+	prefixtype(pimprefixconstptr, const struct prefix_ipv6, p6)
+} TRANSPARENT_UNION;
 #endif
 
 /* for assignment/initialization (C99 compound literal)
  * named PIMADDR_ANY (not PIM_ADDR_ANY) to match INADDR_ANY
  */
 #define PIMADDR_ANY (pim_addr){ }
+
+/* clang-format on */
 
 static inline bool pim_addr_is_any(pim_addr addr)
 {
@@ -49,6 +83,24 @@ static inline bool pim_addr_is_any(pim_addr addr)
 static inline int pim_addr_cmp(pim_addr a, pim_addr b)
 {
 	return memcmp(&a, &b, sizeof(a));
+}
+
+static inline void pim_addr_to_prefix(union pimprefixptr out, pim_addr in)
+{
+	out.p->family = PIM_AF;
+	out.p->prefixlen = PIM_MAX_BITLEN;
+	memcpy(out.p->u.val, &in, sizeof(in));
+}
+
+static inline pim_addr pim_addr_from_prefix(union pimprefixconstptr in)
+{
+	pim_addr ret;
+
+	if (in.p->family != PIM_AF)
+		return PIMADDR_ANY;
+
+	memcpy(&ret, in.p->u.val, sizeof(ret));
+	return ret;
 }
 
 /* don't use this struct directly, use the pim_sgaddr typedef */

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -34,6 +34,13 @@ typedef struct in6_addr pim_addr;
 #define PIM_ADDRSTRLEN INET6_ADDRSTRLEN
 #endif
 
+static inline bool pim_addr_is_any(pim_addr addr)
+{
+	pim_addr zero = {};
+
+	return memcmp(&addr, &zero, sizeof(zero)) == 0;
+}
+
 /* don't use this struct directly, use the pim_sgaddr typedef */
 struct _pim_sgaddr {
 	pim_addr grp;

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -287,15 +287,13 @@ int pim_assert_recv(struct interface *ifp, struct pim_neighbor *neigh,
 	if (PIM_DEBUG_PIM_TRACE) {
 		char neigh_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
-		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<neigh?>", src_addr, neigh_str,
 			       sizeof(neigh_str));
 		pim_inet4_dump("<src?>", msg_source_addr.u.prefix4, source_str,
 			       sizeof(source_str));
-		pim_inet4_dump("<grp?>", sg.grp, group_str, sizeof(group_str));
 		zlog_debug(
-			"%s: from %s on %s: (S,G)=(%s,%s) pref=%u metric=%u rpt_bit=%u",
-			__func__, neigh_str, ifp->name, source_str, group_str,
+			"%s: from %s on %s: (S,G)=(%s,%pPAs) pref=%u metric=%u rpt_bit=%u",
+			__func__, neigh_str, ifp->name, source_str, &sg.grp,
 			msg_metric.metric_preference, msg_metric.route_metric,
 			PIM_FORCE_BOOLEAN(msg_metric.rpt_bit_flag));
 	}

--- a/pimd/pim_br.c
+++ b/pimd/pim_br.c
@@ -43,8 +43,7 @@ struct in_addr pim_br_get_pmbr(pim_sgaddr *sg)
 	struct pim_br *pim_br;
 
 	for (ALL_LIST_ELEMENTS_RO(pim_br_list, node, pim_br)) {
-		if (sg->src.s_addr == pim_br->sg.src.s_addr
-		    && sg->grp.s_addr == pim_br->sg.grp.s_addr)
+		if (!pim_sgaddr_cmp(*sg, pim_br->sg))
 			return pim_br->pmbr;
 	}
 
@@ -57,8 +56,7 @@ void pim_br_set_pmbr(pim_sgaddr *sg, struct in_addr br)
 	struct pim_br *pim_br;
 
 	for (ALL_LIST_ELEMENTS(pim_br_list, node, next, pim_br)) {
-		if (sg->src.s_addr == pim_br->sg.src.s_addr
-		    && sg->grp.s_addr == pim_br->sg.grp.s_addr)
+		if (!pim_sgaddr_cmp(*sg, pim_br->sg))
 			break;
 	}
 
@@ -81,8 +79,7 @@ void pim_br_clear_pmbr(pim_sgaddr *sg)
 	struct pim_br *pim_br;
 
 	for (ALL_LIST_ELEMENTS(pim_br_list, node, next, pim_br)) {
-		if (sg->src.s_addr == pim_br->sg.src.s_addr
-		    && sg->grp.s_addr == pim_br->sg.grp.s_addr)
+		if (!pim_sgaddr_cmp(*sg, pim_br->sg))
 			break;
 	}
 

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -663,7 +663,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 		/* Find the upstream (*, G) whose upstream address is same as
 		 * the RP
 		 */
-		if (up->sg.src.s_addr != INADDR_ANY)
+		if (!pim_addr_is_any(up->sg.src))
 			continue;
 
 		struct prefix grp;

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2536,8 +2536,8 @@ static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 			 * we are the FHR, else we just put
 			 * the RP as the rpfAddress
 			 */
-			if (up->flags & PIM_UPSTREAM_FLAG_MASK_FHR
-			    || up->sg.src.s_addr == INADDR_ANY) {
+			if (up->flags & PIM_UPSTREAM_FLAG_MASK_FHR ||
+			    pim_addr_is_any(up->sg.src)) {
 				char rpf[PREFIX_STRLEN];
 				struct pim_rpf *rpg;
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8246,13 +8246,12 @@ DEFPY_HIDDEN (pim_test_sg_keepalive,
 
 	up = pim_upstream_find(pim, &sg);
 	if (!up) {
-		vty_out(vty, "%% Unable to find %s specified\n",
-			pim_str_sg_dump(&sg));
+		vty_out(vty, "%% Unable to find %pSG specified\n", &sg);
 		return CMD_WARNING;
 	}
 
-	vty_out(vty, "Setting %s to current keep alive time: %d\n",
-		pim_str_sg_dump(&sg), pim->keep_alive_time);
+	vty_out(vty, "Setting %pSG to current keep alive time: %d\n", &sg,
+		pim->keep_alive_time);
 	pim_upstream_keep_alive_timer_start(up, pim->keep_alive_time);
 
 	return CMD_SUCCESS;

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5932,11 +5932,11 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 		if (!c_oil->installed)
 			continue;
 
-		if (sg->grp.s_addr != INADDR_ANY
-		    && sg->grp.s_addr != c_oil->oil.mfcc_mcastgrp.s_addr)
+		if (!pim_addr_is_any(sg->grp) &&
+		    pim_addr_cmp(sg->grp, c_oil->oil.mfcc_mcastgrp))
 			continue;
-		if (sg->src.s_addr != INADDR_ANY
-		    && sg->src.s_addr != c_oil->oil.mfcc_origin.s_addr)
+		if (!pim_addr_is_any(sg->src) &&
+		    pim_addr_cmp(sg->src, c_oil->oil.mfcc_origin))
 			continue;
 
 		pim_inet4_dump("<group?>", c_oil->oil.mfcc_mcastgrp, grp_str,
@@ -10493,8 +10493,8 @@ static void pim_show_vxlan_sg_entry(struct pim_vxlan_sg *vxlan_sg,
 	else
 		oif_name = vxlan_sg->term_oif?vxlan_sg->term_oif->name:"";
 
-	if (cwd->addr_match && (vxlan_sg->sg.src.s_addr != cwd->addr.s_addr) &&
-	    (vxlan_sg->sg.grp.s_addr != cwd->addr.s_addr)) {
+	if (cwd->addr_match && pim_addr_cmp(vxlan_sg->sg.src, cwd->addr) &&
+	    pim_addr_cmp(vxlan_sg->sg.grp, cwd->addr)) {
 		return;
 	}
 	pim_inet4_dump("<src?>", vxlan_sg->sg.src, src_str, sizeof(src_str));

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -108,8 +108,6 @@ static void pim_show_assert_helper(struct vty *vty,
 				   struct pim_interface *pim_ifp,
 				   struct pim_ifchannel *ch, time_t now)
 {
-	char ch_src_str[INET_ADDRSTRLEN];
-	char ch_grp_str[INET_ADDRSTRLEN];
 	char winner_str[INET_ADDRSTRLEN];
 	struct in_addr ifaddr;
 	char uptime[10];
@@ -118,18 +116,16 @@ static void pim_show_assert_helper(struct vty *vty,
 
 	ifaddr = pim_ifp->primary_address;
 
-	pim_inet4_dump("<ch_src?>", ch->sg.src, ch_src_str, sizeof(ch_src_str));
-	pim_inet4_dump("<ch_grp?>", ch->sg.grp, ch_grp_str, sizeof(ch_grp_str));
 	pim_inet4_dump("<assrt_win?>", ch->ifassert_winner, winner_str,
 		       sizeof(winner_str));
 
 	pim_time_uptime(uptime, sizeof(uptime), now - ch->ifassert_creation);
 	pim_time_timer_to_mmss(timer, sizeof(timer), ch->t_ifassert_timer);
 
-	vty_out(vty, "%-16s %-15s %-15s %-15s %-6s %-15s %-8s %-5s\n",
+	vty_out(vty, "%-16s %-15s %-15pPAs %-15pPAs %-6s %-15s %-8s %-5s\n",
 		ch->interface->name,
-		inet_ntop(AF_INET, &ifaddr, buf, sizeof(buf)), ch_src_str,
-		ch_grp_str, pim_ifchannel_ifassert_name(ch->ifassert_state),
+		inet_ntop(AF_INET, &ifaddr, buf, sizeof(buf)), &ch->sg.src,
+		&ch->sg.grp, pim_ifchannel_ifassert_name(ch->ifassert_state),
 		winner_str, uptime, timer);
 }
 
@@ -160,19 +156,15 @@ static void pim_show_assert_internal_helper(struct vty *vty,
 					    struct pim_interface *pim_ifp,
 					    struct pim_ifchannel *ch)
 {
-	char ch_src_str[INET_ADDRSTRLEN];
-	char ch_grp_str[INET_ADDRSTRLEN];
 	struct in_addr ifaddr;
 	char buf[PREFIX_STRLEN];
 
 	ifaddr = pim_ifp->primary_address;
 
-	pim_inet4_dump("<ch_src?>", ch->sg.src, ch_src_str, sizeof(ch_src_str));
-	pim_inet4_dump("<ch_grp?>", ch->sg.grp, ch_grp_str, sizeof(ch_grp_str));
-	vty_out(vty, "%-16s %-15s %-15s %-15s %-3s %-3s %-3s %-4s\n",
+	vty_out(vty, "%-16s %-15s %-15pPAs %-15pPAs %-3s %-3s %-3s %-4s\n",
 		ch->interface->name,
-		inet_ntop(AF_INET, &ifaddr, buf, sizeof(buf)),
-		ch_src_str, ch_grp_str,
+		inet_ntop(AF_INET, &ifaddr, buf, sizeof(buf)), &ch->sg.src,
+		&ch->sg.grp,
 		PIM_IF_FLAG_TEST_COULD_ASSERT(ch->flags) ? "yes" : "no",
 		pim_macro_ch_could_assert_eval(ch) ? "yes" : "no",
 		PIM_IF_FLAG_TEST_ASSERT_TRACKING_DESIRED(ch->flags) ? "yes"
@@ -209,8 +201,6 @@ static void pim_show_assert_metric_helper(struct vty *vty,
 					  struct pim_interface *pim_ifp,
 					  struct pim_ifchannel *ch)
 {
-	char ch_src_str[INET_ADDRSTRLEN];
-	char ch_grp_str[INET_ADDRSTRLEN];
 	char addr_str[INET_ADDRSTRLEN];
 	struct pim_assert_metric am;
 	struct in_addr ifaddr;
@@ -221,14 +211,12 @@ static void pim_show_assert_metric_helper(struct vty *vty,
 	am = pim_macro_spt_assert_metric(&ch->upstream->rpf,
 					 pim_ifp->primary_address);
 
-	pim_inet4_dump("<ch_src?>", ch->sg.src, ch_src_str, sizeof(ch_src_str));
-	pim_inet4_dump("<ch_grp?>", ch->sg.grp, ch_grp_str, sizeof(ch_grp_str));
 	pim_inet4_dump("<addr?>", am.ip_address, addr_str, sizeof(addr_str));
 
-	vty_out(vty, "%-16s %-15s %-15s %-15s %-3s %4u %6u %-15s\n",
+	vty_out(vty, "%-16s %-15s %-15pPAs %-15pPAs %-3s %4u %6u %-15s\n",
 		ch->interface->name,
-		inet_ntop(AF_INET, &ifaddr, buf, sizeof(buf)),
-		ch_src_str, ch_grp_str,	am.rpt_bit_flag ? "yes" : "no",
+		inet_ntop(AF_INET, &ifaddr, buf, sizeof(buf)), &ch->sg.src,
+		&ch->sg.grp, am.rpt_bit_flag ? "yes" : "no",
 		am.metric_preference, am.route_metric, addr_str);
 }
 
@@ -256,8 +244,6 @@ static void pim_show_assert_winner_metric_helper(struct vty *vty,
 						 struct pim_interface *pim_ifp,
 						 struct pim_ifchannel *ch)
 {
-	char ch_src_str[INET_ADDRSTRLEN];
-	char ch_grp_str[INET_ADDRSTRLEN];
 	char addr_str[INET_ADDRSTRLEN];
 	struct pim_assert_metric *am;
 	struct in_addr ifaddr;
@@ -269,8 +255,6 @@ static void pim_show_assert_winner_metric_helper(struct vty *vty,
 
 	am = &ch->ifassert_winner_metric;
 
-	pim_inet4_dump("<ch_src?>", ch->sg.src, ch_src_str, sizeof(ch_src_str));
-	pim_inet4_dump("<ch_grp?>", ch->sg.grp, ch_grp_str, sizeof(ch_grp_str));
 	pim_inet4_dump("<addr?>", am->ip_address, addr_str, sizeof(addr_str));
 
 	if (am->metric_preference == PIM_ASSERT_METRIC_PREFERENCE_MAX)
@@ -284,11 +268,11 @@ static void pim_show_assert_winner_metric_helper(struct vty *vty,
 	else
 		snprintf(metr_str, sizeof(metr_str), "%6u", am->route_metric);
 
-	vty_out(vty, "%-16s %-15s %-15s %-15s %-3s %-4s %-6s %-15s\n",
+	vty_out(vty, "%-16s %-15s %-15pPAs %-15pPAs %-3s %-4s %-6s %-15s\n",
 		ch->interface->name,
-		inet_ntop(AF_INET, &ifaddr, buf, sizeof(buf)), ch_src_str,
-		ch_grp_str, am->rpt_bit_flag ? "yes" : "no", pref_str, metr_str,
-		addr_str);
+		inet_ntop(AF_INET, &ifaddr, buf, sizeof(buf)), &ch->sg.src,
+		&ch->sg.grp, am->rpt_bit_flag ? "yes" : "no", pref_str,
+		metr_str, addr_str);
 }
 
 static void pim_show_assert_winner_metric(struct pim_instance *pim,
@@ -348,13 +332,9 @@ static void pim_show_membership_helper(struct vty *vty,
 				       struct pim_ifchannel *ch,
 				       struct json_object *json)
 {
-	char ch_src_str[INET_ADDRSTRLEN];
-	char ch_grp_str[INET_ADDRSTRLEN];
+	char ch_grp_str[PIM_ADDRSTRLEN];
 	json_object *json_iface = NULL;
 	json_object *json_row = NULL;
-
-	pim_inet4_dump("<ch_src?>", ch->sg.src, ch_src_str, sizeof(ch_src_str));
-	pim_inet4_dump("<ch_grp?>", ch->sg.grp, ch_grp_str, sizeof(ch_grp_str));
 
 	json_object_object_get_ex(json, ch->interface->name, &json_iface);
 	if (!json_iface) {
@@ -363,8 +343,10 @@ static void pim_show_membership_helper(struct vty *vty,
 		json_object_object_add(json, ch->interface->name, json_iface);
 	}
 
+	snprintfrr(ch_grp_str, sizeof(ch_grp_str), "%pPAs", &ch->sg.grp);
+
 	json_row = json_object_new_object();
-	json_object_string_add(json_row, "source", ch_src_str);
+	json_object_string_addf(json_row, "source", "%pPAs", &ch->sg.src);
 	json_object_string_add(json_row, "group", ch_grp_str);
 	json_object_string_add(json_row, "localMembership",
 			       ch->local_ifmembership == PIM_IFMEMBERSHIP_NOINFO
@@ -372,6 +354,7 @@ static void pim_show_membership_helper(struct vty *vty,
 			       : "INCLUDE");
 	json_object_object_add(json_iface, ch_grp_str, json_row);
 }
+
 static void pim_show_membership(struct pim_instance *pim, struct vty *vty,
 				bool uj)
 {
@@ -1063,10 +1046,10 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 					json_fhr_sources =
 						json_object_new_object();
 
-				pim_inet4_dump("<src?>", up->sg.src, src_str,
-					       sizeof(src_str));
-				pim_inet4_dump("<grp?>", up->sg.grp, grp_str,
-					       sizeof(grp_str));
+				snprintfrr(grp_str, sizeof(grp_str), "%pPAs",
+					   &up->sg.grp);
+				snprintfrr(src_str, sizeof(src_str), "%pPAs",
+					   &up->sg.src);
 				pim_time_uptime(uptime, sizeof(uptime),
 						now - up->state_transition);
 
@@ -1240,15 +1223,11 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 					print_header = 0;
 				}
 
-				pim_inet4_dump("<src?>", up->sg.src, src_str,
-					       sizeof(src_str));
-				pim_inet4_dump("<grp?>", up->sg.grp, grp_str,
-					       sizeof(grp_str));
 				pim_time_uptime(uptime, sizeof(uptime),
 						now - up->state_transition);
 				vty_out(vty,
-					"%s : %s is a source, uptime is %s\n",
-					grp_str, src_str, uptime);
+					"%pPAs : %pPAs is a source, uptime is %s\n",
+					&up->sg.grp, &up->sg.src, uptime);
 			}
 
 			if (!print_header) {
@@ -1681,8 +1660,6 @@ static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 				 struct pim_ifchannel *ch, json_object *json,
 				 time_t now, bool uj)
 {
-	char ch_src_str[INET_ADDRSTRLEN];
-	char ch_grp_str[INET_ADDRSTRLEN];
 	json_object *json_iface = NULL;
 	json_object *json_row = NULL;
 	json_object *json_grp = NULL;
@@ -1694,9 +1671,6 @@ static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 
 	ifaddr = pim_ifp->primary_address;
 
-	pim_inet4_dump("<ch_src?>", ch->sg.src, ch_src_str, sizeof(ch_src_str));
-	pim_inet4_dump("<ch_grp?>", ch->sg.grp, ch_grp_str, sizeof(ch_grp_str));
-
 	pim_time_uptime_begin(uptime, sizeof(uptime), now, ch->ifjoin_creation);
 	pim_time_timer_to_mmss(expire, sizeof(expire),
 			       ch->t_ifjoin_expiry_timer);
@@ -1704,6 +1678,14 @@ static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 			       ch->t_ifjoin_prune_pending_timer);
 
 	if (uj) {
+		char ch_grp_str[PIM_ADDRSTRLEN];
+		char ch_src_str[PIM_ADDRSTRLEN];
+
+		snprintfrr(ch_grp_str, sizeof(ch_grp_str), "%pPAs",
+			   &ch->sg.grp);
+		snprintfrr(ch_src_str, sizeof(ch_src_str), "%pPAs",
+			   &ch->sg.src);
+
 		json_object_object_get_ex(json, ch->interface->name,
 					  &json_iface);
 
@@ -1738,10 +1720,10 @@ static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 		} else
 			json_object_object_add(json_grp, ch_src_str, json_row);
 	} else {
-		vty_out(vty, "%-16s %-15s %-15s %-15s %-10s %8s %-6s %5s\n",
+		vty_out(vty, "%-16s %-15s %-15pPAs %-15pPAs %-10s %8s %-6s %5s\n",
 			ch->interface->name,
 			inet_ntop(AF_INET, &ifaddr, buf, sizeof(buf)),
-			ch_src_str, ch_grp_str,
+			&ch->sg.src, &ch->sg.grp,
 			pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->flags),
 			uptime, expire, prune);
 	}
@@ -2459,8 +2441,6 @@ static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 			"Iif             Source          Group           State       Uptime   JoinTimer RSTimer   KATimer   RefCnt\n");
 
 	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
-		char src_str[INET_ADDRSTRLEN];
-		char grp_str[INET_ADDRSTRLEN];
 		char uptime[10];
 		char join_timer[10];
 		char rs_timer[10];
@@ -2471,8 +2451,6 @@ static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 		if (!pim_sgaddr_match(up->sg, *sg))
 			continue;
 
-		pim_inet4_dump("<src?>", up->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", up->sg.grp, grp_str, sizeof(grp_str));
 		pim_time_uptime(uptime, sizeof(uptime),
 				now - up->state_transition);
 		pim_time_timer_to_hhmmss(join_timer, sizeof(join_timer),
@@ -2513,6 +2491,14 @@ static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 		}
 
 		if (uj) {
+			char grp_str[PIM_ADDRSTRLEN];
+			char src_str[PIM_ADDRSTRLEN];
+
+			snprintfrr(grp_str, sizeof(grp_str), "%pPAs",
+				   &up->sg.grp);
+			snprintfrr(src_str, sizeof(src_str), "%pPAs",
+				   &up->sg.src);
+
 			json_object_object_get_ex(json, grp_str, &json_group);
 
 			if (!json_group) {
@@ -2576,12 +2562,12 @@ static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 			json_object_object_add(json_group, src_str, json_row);
 		} else {
 			vty_out(vty,
-				"%-16s%-15s %-15s %-11s %-8s %-9s %-9s %-9s %6d\n",
+				"%-16s%-15pPAs %-15pPAs %-11s %-8s %-9s %-9s %-9s %6d\n",
 				up->rpf.source_nexthop.interface
 				? up->rpf.source_nexthop.interface->name
 				: "Unknown",
-				src_str, grp_str, state_str, uptime, join_timer,
-				rs_timer, ka_timer, up->ref_count);
+				&up->sg.src, &up->sg.grp, state_str, uptime,
+				join_timer, rs_timer, ka_timer, up->ref_count);
 		}
 	}
 
@@ -2600,14 +2586,15 @@ static void pim_show_channel_helper(struct pim_instance *pim,
 {
 	struct pim_upstream *up = ch->upstream;
 	json_object *json_group = NULL;
-	char src_str[INET_ADDRSTRLEN];
-	char grp_str[INET_ADDRSTRLEN];
 	json_object *json_row = NULL;
 
-	pim_inet4_dump("<src?>", up->sg.src, src_str, sizeof(src_str));
-	pim_inet4_dump("<grp?>", up->sg.grp, grp_str, sizeof(grp_str));
-
 	if (uj) {
+		char grp_str[PIM_ADDRSTRLEN];
+		char src_str[PIM_ADDRSTRLEN];
+
+		snprintfrr(grp_str, sizeof(grp_str), "%pPAs", &up->sg.grp);
+		snprintfrr(src_str, sizeof(src_str), "%pPAs", &up->sg.src);
+
 		json_object_object_get_ex(json, grp_str, &json_group);
 
 		if (!json_group) {
@@ -2638,8 +2625,8 @@ static void pim_show_channel_helper(struct pim_instance *pim,
 		json_object_object_add(json_group, src_str, json_row);
 
 	} else {
-		vty_out(vty, "%-16s %-15s %-15s %-10s %-5s %-10s %-11s %-6s\n",
-			ch->interface->name, src_str, grp_str,
+		vty_out(vty, "%-16s %-15pPAs %-15pPAs %-10s %-5s %-10s %-11s %-6s\n",
+			ch->interface->name, &up->sg.src, &up->sg.grp,
 			pim_macro_ch_lost_assert(ch) ? "yes" : "no",
 			pim_macro_chisin_joins(ch) ? "yes" : "no",
 			pim_macro_chisin_pim_include(ch) ? "yes" : "no",
@@ -2693,14 +2680,15 @@ static void pim_show_join_desired_helper(struct pim_instance *pim,
 					 json_object *json, bool uj)
 {
 	json_object *json_group = NULL;
-	char src_str[INET_ADDRSTRLEN];
-	char grp_str[INET_ADDRSTRLEN];
 	json_object *json_row = NULL;
 
-	pim_inet4_dump("<src?>", up->sg.src, src_str, sizeof(src_str));
-	pim_inet4_dump("<grp?>", up->sg.grp, grp_str, sizeof(grp_str));
-
 	if (uj) {
+		char grp_str[PIM_ADDRSTRLEN];
+		char src_str[PIM_ADDRSTRLEN];
+
+		snprintfrr(grp_str, sizeof(grp_str), "%pPAs", &up->sg.grp);
+		snprintfrr(src_str, sizeof(src_str), "%pPAs", &up->sg.src);
+
 		json_object_object_get_ex(json, grp_str, &json_group);
 
 		if (!json_group) {
@@ -2720,8 +2708,8 @@ static void pim_show_join_desired_helper(struct pim_instance *pim,
 		json_object_object_add(json_group, src_str, json_row);
 
 	} else {
-		vty_out(vty, "%-15s %-15s %-6s\n",
-			src_str, grp_str,
+		vty_out(vty, "%-15pPAs %-15pPAs %-6s\n",
+			&up->sg.src, &up->sg.grp,
 			pim_upstream_evaluate_join_desired(pim, up) ? "yes"
 			: "no");
 	}
@@ -2768,8 +2756,6 @@ static void pim_show_upstream_rpf(struct pim_instance *pim, struct vty *vty,
 			"Source          Group           RpfIface         RibNextHop      RpfAddress     \n");
 
 	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
-		char src_str[INET_ADDRSTRLEN];
-		char grp_str[INET_ADDRSTRLEN];
 		char rpf_nexthop_str[PREFIX_STRLEN];
 		char rpf_addr_str[PREFIX_STRLEN];
 		struct pim_rpf *rpf;
@@ -2777,8 +2763,6 @@ static void pim_show_upstream_rpf(struct pim_instance *pim, struct vty *vty,
 
 		rpf = &up->rpf;
 
-		pim_inet4_dump("<src?>", up->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", up->sg.grp, grp_str, sizeof(grp_str));
 		pim_addr_dump("<nexthop?>",
 			      &rpf->source_nexthop.mrib_nexthop_addr,
 			      rpf_nexthop_str, sizeof(rpf_nexthop_str));
@@ -2788,6 +2772,14 @@ static void pim_show_upstream_rpf(struct pim_instance *pim, struct vty *vty,
 		rpf_ifname = rpf->source_nexthop.interface ? rpf->source_nexthop.interface->name : "<ifname?>";
 
 		if (uj) {
+			char grp_str[PIM_ADDRSTRLEN];
+			char src_str[PIM_ADDRSTRLEN];
+
+			snprintfrr(grp_str, sizeof(grp_str), "%pPAs",
+				   &up->sg.grp);
+			snprintfrr(src_str, sizeof(src_str), "%pPAs",
+				   &up->sg.src);
+
 			json_object_object_get_ex(json, grp_str, &json_group);
 
 			if (!json_group) {
@@ -2808,9 +2800,9 @@ static void pim_show_upstream_rpf(struct pim_instance *pim, struct vty *vty,
 					       rpf_addr_str);
 			json_object_object_add(json_group, src_str, json_row);
 		} else {
-			vty_out(vty, "%-15s %-15s %-16s %-15s %-15s\n", src_str,
-				grp_str, rpf_ifname, rpf_nexthop_str,
-				rpf_addr_str);
+			vty_out(vty, "%-15pPAs %-15pPAs %-16s %-15s %-15s\n",
+				&up->sg.src, &up->sg.grp, rpf_ifname,
+				rpf_nexthop_str, rpf_addr_str);
 		}
 	}
 
@@ -2905,15 +2897,11 @@ static void pim_show_rpf(struct pim_instance *pim, struct vty *vty, bool uj)
 	}
 
 	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
-		char src_str[INET_ADDRSTRLEN];
-		char grp_str[INET_ADDRSTRLEN];
 		char rpf_addr_str[PREFIX_STRLEN];
 		char rib_nexthop_str[PREFIX_STRLEN];
 		const char *rpf_ifname;
 		struct pim_rpf *rpf = &up->rpf;
 
-		pim_inet4_dump("<src?>", up->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", up->sg.grp, grp_str, sizeof(grp_str));
 		pim_addr_dump("<rpf?>", &rpf->rpf_addr, rpf_addr_str,
 			      sizeof(rpf_addr_str));
 		pim_addr_dump("<nexthop?>",
@@ -2923,6 +2911,14 @@ static void pim_show_rpf(struct pim_instance *pim, struct vty *vty, bool uj)
 		rpf_ifname = rpf->source_nexthop.interface ? rpf->source_nexthop.interface->name : "<ifname?>";
 
 		if (uj) {
+			char grp_str[PIM_ADDRSTRLEN];
+			char src_str[PIM_ADDRSTRLEN];
+
+			snprintfrr(grp_str, sizeof(grp_str), "%pPAs",
+				   &up->sg.grp);
+			snprintfrr(src_str, sizeof(src_str), "%pPAs",
+				   &up->sg.src);
+
 			json_object_object_get_ex(json, grp_str, &json_group);
 
 			if (!json_group) {
@@ -2949,9 +2945,9 @@ static void pim_show_rpf(struct pim_instance *pim, struct vty *vty, bool uj)
 			json_object_object_add(json_group, src_str, json_row);
 
 		} else {
-			vty_out(vty, "%-15s %-15s %-16s %-15s %-15s %6d %4d\n",
-				src_str, grp_str, rpf_ifname, rpf_addr_str,
-				rib_nexthop_str,
+			vty_out(vty, "%-15pPAs %-15pPAs %-16s %-15s %-15s %6d %4d\n",
+				&up->sg.src, &up->sg.grp, rpf_ifname,
+				rpf_addr_str, rib_nexthop_str,
 				rpf->source_nexthop.mrib_route_metric,
 				rpf->source_nexthop.mrib_metric_preference);
 		}
@@ -4674,18 +4670,13 @@ static void pim_show_jp_agg_helper(struct vty *vty,
 				   struct pim_upstream *up,
 				   int is_join)
 {
-	char src_str[INET_ADDRSTRLEN];
-	char grp_str[INET_ADDRSTRLEN];
 	char rpf_str[INET_ADDRSTRLEN];
 
-	pim_inet4_dump("<src?>", up->sg.src, src_str, sizeof(src_str));
-	pim_inet4_dump("<grp?>", up->sg.grp, grp_str, sizeof(grp_str));
 	/* pius->address.s_addr */
 	pim_inet4_dump("<rpf?>", neigh->source_addr, rpf_str, sizeof(rpf_str));
 
-	vty_out(vty, "%-16s %-15s %-15s %-15s %5s\n",
-		ifp->name, rpf_str, src_str,
-		grp_str, is_join?"J":"P");
+	vty_out(vty, "%-16s %-15s %-15pPAs %-15pPAs %5s\n", ifp->name, rpf_str,
+		&up->sg.src, &up->sg.grp, is_join ? "J" : "P");
 }
 
 static void pim_show_jp_agg_list(struct pim_instance *pim, struct vty *vty)
@@ -4843,8 +4834,8 @@ static void pim_show_mlag_up_detail(struct vrf *vrf,
 				    struct vty *vty, const char *src_or_group,
 				    const char *group, bool uj)
 {
-	char src_str[INET_ADDRSTRLEN];
-	char grp_str[INET_ADDRSTRLEN];
+	char src_str[PIM_ADDRSTRLEN];
+	char grp_str[PIM_ADDRSTRLEN];
 	struct pim_upstream *up;
 	struct pim_instance *pim = vrf->info;
 	json_object *json = NULL;
@@ -4861,8 +4852,9 @@ static void pim_show_mlag_up_detail(struct vrf *vrf,
 		    && !pim_up_mlag_is_local(up))
 			continue;
 
-		pim_inet4_dump("<src?>", up->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", up->sg.grp, grp_str, sizeof(grp_str));
+		snprintfrr(grp_str, sizeof(grp_str), "%pPAs", &up->sg.grp);
+		snprintfrr(src_str, sizeof(src_str), "%pPAs", &up->sg.src);
+
 		/* XXX: strcmps are clearly inefficient. we should do uint comps
 		 * here instead.
 		 */
@@ -4891,8 +4883,6 @@ static void pim_show_mlag_up_vrf(struct vrf *vrf, struct vty *vty, bool uj)
 	json_object *json = NULL;
 	json_object *json_row;
 	struct pim_upstream *up;
-	char src_str[INET_ADDRSTRLEN];
-	char grp_str[INET_ADDRSTRLEN];
 	struct pim_instance *pim = vrf->info;
 	json_object *json_group = NULL;
 
@@ -4908,10 +4898,15 @@ static void pim_show_mlag_up_vrf(struct vrf *vrf, struct vty *vty, bool uj)
 		    && !(up->flags & PIM_UPSTREAM_FLAG_MASK_MLAG_INTERFACE)
 		    && !pim_up_mlag_is_local(up))
 			continue;
-		pim_inet4_dump("<src?>", up->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", up->sg.grp, grp_str, sizeof(grp_str));
 		if (uj) {
+			char src_str[PIM_ADDRSTRLEN];
+			char grp_str[PIM_ADDRSTRLEN];
 			json_object *own_list = NULL;
+
+			snprintfrr(grp_str, sizeof(grp_str), "%pPAs",
+				   &up->sg.grp);
+			snprintfrr(src_str, sizeof(src_str), "%pPAs",
+				   &up->sg.src);
 
 			json_object_object_get_ex(json, grp_str, &json_group);
 			if (!json_group) {
@@ -4959,8 +4954,8 @@ static void pim_show_mlag_up_vrf(struct vrf *vrf, struct vty *vty, bool uj)
 			if (up->flags & (PIM_UPSTREAM_FLAG_MASK_MLAG_INTERFACE))
 				strlcat(own_str, "I", sizeof(own_str));
 			vty_out(vty,
-				"%-15s %-15s %-6s %-11u %-10u %2s\n",
-				src_str, grp_str, own_str,
+				"%-15pPAs %-15pPAs %-6s %-11u %-10u %2s\n",
+				&up->sg.src, &up->sg.grp, own_str,
 				pim_up_mlag_local_cost(up),
 				pim_up_mlag_peer_cost(up),
 				PIM_UPSTREAM_FLAG_TEST_MLAG_NON_DF(up->flags)
@@ -10106,8 +10101,6 @@ static void ip_msdp_show_sa(struct pim_instance *pim, struct vty *vty, bool uj)
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;
-	char src_str[INET_ADDRSTRLEN];
-	char grp_str[INET_ADDRSTRLEN];
 	char rp_str[INET_ADDRSTRLEN];
 	char timebuf[PIM_MSDP_UPTIME_STRLEN];
 	char spt_str[8];
@@ -10127,8 +10120,6 @@ static void ip_msdp_show_sa(struct pim_instance *pim, struct vty *vty, bool uj)
 	for (ALL_LIST_ELEMENTS_RO(pim->msdp.sa_list, sanode, sa)) {
 		now = pim_time_monotonic_sec();
 		pim_time_uptime(timebuf, sizeof(timebuf), now - sa->uptime);
-		pim_inet4_dump("<src?>", sa->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", sa->sg.grp, grp_str, sizeof(grp_str));
 		if (sa->flags & PIM_MSDP_SAF_PEER) {
 			pim_inet4_dump("<rp?>", sa->rp, rp_str, sizeof(rp_str));
 			if (sa->up) {
@@ -10146,6 +10137,14 @@ static void ip_msdp_show_sa(struct pim_instance *pim, struct vty *vty, bool uj)
 			strlcpy(local_str, "no", sizeof(local_str));
 		}
 		if (uj) {
+			char src_str[PIM_ADDRSTRLEN];
+			char grp_str[PIM_ADDRSTRLEN];
+
+			snprintfrr(grp_str, sizeof(grp_str), "%pPAs",
+				   &sa->sg.grp);
+			snprintfrr(src_str, sizeof(src_str), "%pPAs",
+				   &sa->sg.src);
+
 			json_object_object_get_ex(json, grp_str, &json_group);
 
 			if (!json_group) {
@@ -10163,8 +10162,8 @@ static void ip_msdp_show_sa(struct pim_instance *pim, struct vty *vty, bool uj)
 			json_object_string_add(json_row, "upTime", timebuf);
 			json_object_object_add(json_group, src_str, json_row);
 		} else {
-			vty_out(vty, "%-15s  %15s  %15s  %5c  %3c  %8s\n",
-				src_str, grp_str, rp_str, local_str[0],
+			vty_out(vty, "%-15pPAs  %15pPAs  %15s  %5c  %3c  %8s\n",
+				&sa->sg.src, &sa->sg.grp, rp_str, local_str[0],
 				spt_str[0], timebuf);
 		}
 	}
@@ -10247,8 +10246,6 @@ static void ip_msdp_show_sa_detail(struct pim_instance *pim, struct vty *vty,
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;
-	char src_str[INET_ADDRSTRLEN];
-	char grp_str[INET_ADDRSTRLEN];
 	json_object *json = NULL;
 
 	if (uj) {
@@ -10256,8 +10253,12 @@ static void ip_msdp_show_sa_detail(struct pim_instance *pim, struct vty *vty,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(pim->msdp.sa_list, sanode, sa)) {
-		pim_inet4_dump("<src?>", sa->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", sa->sg.grp, grp_str, sizeof(grp_str));
+		char src_str[PIM_ADDRSTRLEN];
+		char grp_str[PIM_ADDRSTRLEN];
+
+		snprintfrr(grp_str, sizeof(grp_str), "%pPAs", &sa->sg.grp);
+		snprintfrr(src_str, sizeof(src_str), "%pPAs", &sa->sg.src);
+
 		ip_msdp_show_sa_entry_detail(sa, src_str, grp_str, vty, uj,
 					     json);
 	}
@@ -10330,8 +10331,6 @@ static void ip_msdp_show_sa_addr(struct pim_instance *pim, struct vty *vty,
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;
-	char src_str[INET_ADDRSTRLEN];
-	char grp_str[INET_ADDRSTRLEN];
 	json_object *json = NULL;
 
 	if (uj) {
@@ -10339,8 +10338,12 @@ static void ip_msdp_show_sa_addr(struct pim_instance *pim, struct vty *vty,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(pim->msdp.sa_list, sanode, sa)) {
-		pim_inet4_dump("<src?>", sa->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", sa->sg.grp, grp_str, sizeof(grp_str));
+		char src_str[PIM_ADDRSTRLEN];
+		char grp_str[PIM_ADDRSTRLEN];
+
+		snprintfrr(grp_str, sizeof(grp_str), "%pPAs", &sa->sg.grp);
+		snprintfrr(src_str, sizeof(src_str), "%pPAs", &sa->sg.src);
+
 		if (!strcmp(addr, src_str) || !strcmp(addr, grp_str)) {
 			ip_msdp_show_sa_entry_detail(sa, src_str, grp_str, vty,
 						     uj, json);
@@ -10359,8 +10362,6 @@ static void ip_msdp_show_sa_sg(struct pim_instance *pim, struct vty *vty,
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;
-	char src_str[INET_ADDRSTRLEN];
-	char grp_str[INET_ADDRSTRLEN];
 	json_object *json = NULL;
 
 	if (uj) {
@@ -10368,8 +10369,12 @@ static void ip_msdp_show_sa_sg(struct pim_instance *pim, struct vty *vty,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(pim->msdp.sa_list, sanode, sa)) {
-		pim_inet4_dump("<src?>", sa->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", sa->sg.grp, grp_str, sizeof(grp_str));
+		char src_str[PIM_ADDRSTRLEN];
+		char grp_str[PIM_ADDRSTRLEN];
+
+		snprintfrr(grp_str, sizeof(grp_str), "%pPAs", &sa->sg.grp);
+		snprintfrr(src_str, sizeof(src_str), "%pPAs", &sa->sg.src);
+
 		if (!strcmp(src, src_str) && !strcmp(grp, grp_str)) {
 			ip_msdp_show_sa_entry_detail(sa, src_str, grp_str, vty,
 						     uj, json);
@@ -10481,8 +10486,6 @@ static void pim_show_vxlan_sg_entry(struct pim_vxlan_sg *vxlan_sg,
 {
 	struct vty *vty = cwd->vty;
 	json_object *json = cwd->json;
-	char src_str[INET_ADDRSTRLEN];
-	char grp_str[INET_ADDRSTRLEN];
 	json_object *json_row;
 	bool installed = (vxlan_sg->up) ? true : false;
 	const char *iif_name = vxlan_sg->iif?vxlan_sg->iif->name:"-";
@@ -10497,9 +10500,15 @@ static void pim_show_vxlan_sg_entry(struct pim_vxlan_sg *vxlan_sg,
 	    pim_addr_cmp(vxlan_sg->sg.grp, cwd->addr)) {
 		return;
 	}
-	pim_inet4_dump("<src?>", vxlan_sg->sg.src, src_str, sizeof(src_str));
-	pim_inet4_dump("<grp?>", vxlan_sg->sg.grp, grp_str, sizeof(grp_str));
 	if (json) {
+		char src_str[PIM_ADDRSTRLEN];
+		char grp_str[PIM_ADDRSTRLEN];
+
+		snprintfrr(grp_str, sizeof(grp_str), "%pPAs",
+			   &vxlan_sg->sg.grp);
+		snprintfrr(src_str, sizeof(src_str), "%pPAs",
+			   &vxlan_sg->sg.src);
+
 		json_object_object_get_ex(json, grp_str, &cwd->json_group);
 
 		if (!cwd->json_group) {
@@ -10519,9 +10528,9 @@ static void pim_show_vxlan_sg_entry(struct pim_vxlan_sg *vxlan_sg,
 			json_object_boolean_false_add(json_row, "installed");
 		json_object_object_add(cwd->json_group, src_str, json_row);
 	} else {
-		vty_out(vty, "%-15s %-15s %-15s %-15s %-5s\n",
-			src_str, grp_str, iif_name, oif_name,
-			installed?"I":"");
+		vty_out(vty, "%-15pPAs %-15pPAs %-15s %-15s %-5s\n",
+			&vxlan_sg->sg.src, &vxlan_sg->sg.grp, iif_name,
+			oif_name, installed ? "I" : "");
 	}
 }
 

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -403,7 +403,7 @@ static int pim_sec_addr_update(struct interface *ifp)
 	for (ALL_LIST_ELEMENTS_RO(ifp->connected, node, ifc)) {
 		struct prefix *p = ifc->address;
 
-		if (PIM_INADDR_IS_ANY(p->u.prefix4)) {
+		if (p->u.prefix4.s_addr == INADDR_ANY) {
 			continue;
 		}
 
@@ -598,7 +598,7 @@ void pim_if_addr_add(struct connected *ifc)
 
 	if (PIM_IF_TEST_PIM(pim_ifp->options)) {
 
-		if (PIM_INADDR_ISNOT_ANY(pim_ifp->primary_address)) {
+		if (!pim_addr_is_any(pim_ifp->primary_address)) {
 
 			/* Interface has a valid socket ? */
 			if (pim_ifp->pim_sock_fd < 0) {
@@ -684,7 +684,7 @@ static void pim_if_addr_del_pim(struct connected *ifc)
 		return;
 	}
 
-	if (PIM_INADDR_ISNOT_ANY(pim_ifp->primary_address)) {
+	if (!pim_addr_is_any(pim_ifp->primary_address)) {
 		/* Interface keeps a valid primary address */
 		return;
 	}
@@ -752,7 +752,7 @@ void pim_if_addr_add_all(struct interface *ifp)
 		if (PIM_IF_TEST_PIM(pim_ifp->options)) {
 
 			/* Interface has a valid primary address ? */
-			if (PIM_INADDR_ISNOT_ANY(pim_ifp->primary_address)) {
+			if (!pim_addr_is_any(pim_ifp->primary_address)) {
 
 				/* Interface has a valid socket ? */
 				if (pim_ifp->pim_sock_fd < 0) {
@@ -836,7 +836,7 @@ struct in_addr pim_find_primary_addr(struct interface *ifp)
 	int v6_addrs = 0;
 	struct pim_interface *pim_ifp = ifp->info;
 
-	if (pim_ifp && PIM_INADDR_ISNOT_ANY(pim_ifp->update_source)) {
+	if (pim_ifp && !pim_addr_is_any(pim_ifp->update_source)) {
 		return pim_ifp->update_source;
 	}
 
@@ -848,7 +848,7 @@ struct in_addr pim_find_primary_addr(struct interface *ifp)
 			continue;
 		}
 
-		if (PIM_INADDR_IS_ANY(p->u.prefix4)) {
+		if (p->u.prefix4.s_addr == INADDR_ANY) {
 			zlog_warn(
 				"%s: null IPv4 address connected to interface %s",
 				__func__, ifp->name);
@@ -916,7 +916,7 @@ static int pim_iface_next_vif_index(struct interface *ifp)
 int pim_if_add_vif(struct interface *ifp, bool ispimreg, bool is_vxlan_term)
 {
 	struct pim_interface *pim_ifp = ifp->info;
-	struct in_addr ifaddr;
+	pim_addr ifaddr;
 	unsigned char flags = 0;
 
 	assert(pim_ifp);
@@ -935,7 +935,7 @@ int pim_if_add_vif(struct interface *ifp, bool ispimreg, bool is_vxlan_term)
 	}
 
 	ifaddr = pim_ifp->primary_address;
-	if (!ispimreg && !is_vxlan_term && PIM_INADDR_IS_ANY(ifaddr)) {
+	if (!ispimreg && !is_vxlan_term && pim_addr_is_any(ifaddr)) {
 		zlog_warn(
 			"%s: could not get address for interface %s ifindex=%d",
 			__func__, ifp->name, ifp->ifindex);

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -115,8 +115,7 @@ static void pim_ifchannel_find_new_children(struct pim_ifchannel *ch)
 
 	RB_FOREACH (child, pim_ifchannel_rb, &pim_ifp->ifchannel_rb) {
 		if (!pim_addr_is_any(ch->sg.grp) &&
-		    (child->sg.grp.s_addr == ch->sg.grp.s_addr) &&
-		    (child != ch)) {
+		    !pim_addr_cmp(child->sg.grp, ch->sg.grp) && (child != ch)) {
 			child->parent = ch;
 			listnode_add_sort(ch->sources, child);
 		}

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -62,19 +62,7 @@ int pim_ifchannel_compare(const struct pim_ifchannel *ch1,
 	if (pim_ifp1->mroute_vif_index > pim_ifp2->mroute_vif_index)
 		return 1;
 
-	if (ntohl(ch1->sg.grp.s_addr) < ntohl(ch2->sg.grp.s_addr))
-		return -1;
-
-	if (ntohl(ch1->sg.grp.s_addr) > ntohl(ch2->sg.grp.s_addr))
-		return 1;
-
-	if (ntohl(ch1->sg.src.s_addr) < ntohl(ch2->sg.src.s_addr))
-		return -1;
-
-	if (ntohl(ch1->sg.src.s_addr) > ntohl(ch2->sg.src.s_addr))
-		return 1;
-
-	return 0;
+	return pim_sgaddr_cmp(ch1->sg, ch2->sg);
 }
 
 /*

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -455,8 +455,8 @@ struct pim_ifchannel *pim_ifchannel_find(struct interface *ifp, pim_sgaddr *sg)
 	pim_ifp = ifp->info;
 
 	if (!pim_ifp) {
-		zlog_warn("%s: (S,G)=%s: multicast not enabled on interface %s",
-			  __func__, pim_str_sg_dump(sg), ifp->name);
+		zlog_warn("%s: (S,G)=%pSG: multicast not enabled on interface %s",
+			  __func__, sg, ifp->name);
 		return NULL;
 	}
 
@@ -558,8 +558,7 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 		if (ch->upstream)
 			ch->upstream->flags |= up_flags;
 		else if (PIM_DEBUG_EVENTS)
-			zlog_debug("%s:%s No Upstream found", __func__,
-				   pim_str_sg_dump(sg));
+			zlog_debug("%s:%pSG No Upstream found", __func__, sg);
 
 		return ch;
 	}
@@ -688,10 +687,9 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
 	ch = THREAD_ARG(t);
 
 	if (PIM_DEBUG_PIM_TRACE)
-		zlog_debug(
-			"%s: IFCHANNEL%s %s Prune Pending Timer Popped",
-			__func__, pim_str_sg_dump(&ch->sg),
-			pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->flags));
+		zlog_debug("%s: IFCHANNEL%pSG %s Prune Pending Timer Popped",
+			   __func__, &ch->sg,
+			   pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->flags));
 
 	if (ch->ifjoin_state == PIM_IFJOIN_PRUNE_PENDING) {
 		ifp = ch->interface;
@@ -832,9 +830,9 @@ static int nonlocal_upstream(int is_join, struct interface *recv_ifp,
 	if (PIM_DEBUG_PIM_TRACE_DETAIL) {
 		char up_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<upstream?>", upstream, up_str, sizeof(up_str));
-		zlog_warn("%s: recv %s (S,G)=%s to non-local upstream=%s on %s",
+		zlog_warn("%s: recv %s (S,G)=%pSG to non-local upstream=%s on %s",
 			  __func__, is_join ? "join" : "prune",
-			  pim_str_sg_dump(sg), up_str, recv_ifp->name);
+			  sg, up_str, recv_ifp->name);
 	}
 
 	/*
@@ -1049,10 +1047,9 @@ void pim_ifchannel_prune(struct interface *ifp, struct in_addr upstream,
 	ch = pim_ifchannel_find(ifp, sg);
 	if (!ch && !(source_flags & PIM_ENCODE_RPT_BIT)) {
 		if (PIM_DEBUG_PIM_TRACE)
-			zlog_debug(
-				"%s: Received prune with no relevant ifchannel %s%s state: %d",
-				__func__, ifp->name, pim_str_sg_dump(sg),
-				source_flags);
+			zlog_debug("%s: Received prune with no relevant ifchannel %s%pSG state: %d",
+				   __func__, ifp->name, sg,
+				   source_flags);
 		return;
 	}
 
@@ -1182,16 +1179,15 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 	pim_ifp = ifp->info;
 	if (!pim_ifp) {
 		if (PIM_DEBUG_EVENTS)
-			zlog_debug("%s:%s Expected pim interface setup for %s",
-				   __func__, pim_str_sg_dump(sg), ifp->name);
+			zlog_debug("%s:%pSG Expected pim interface setup for %s",
+				   __func__, sg, ifp->name);
 		return 0;
 	}
 
 	if (!PIM_IF_TEST_PIM(pim_ifp->options)) {
 		if (PIM_DEBUG_EVENTS)
-			zlog_debug(
-				"%s:%s PIM is not configured on this interface %s",
-				__func__, pim_str_sg_dump(sg), ifp->name);
+			zlog_debug("%s:%pSG PIM is not configured on this interface %s",
+				   __func__, sg, ifp->name);
 		return 0;
 	}
 
@@ -1201,9 +1197,8 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 	if (sg->src.s_addr == INADDR_ANY) {
 		if (pim_is_grp_ssm(pim, sg->grp)) {
 			if (PIM_DEBUG_PIM_EVENTS)
-				zlog_debug(
-					"%s: local membership (S,G)=%s ignored as group is SSM",
-					__func__, pim_str_sg_dump(sg));
+				zlog_debug("%s: local membership (S,G)=%pSG ignored as group is SSM",
+					   __func__, sg);
 			return 1;
 		}
 	}

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -575,7 +575,7 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 
 	ch->interface = ifp;
 	ch->sg = *sg;
-	pim_str_sg_set(sg, ch->sg_str);
+	snprintfrr(ch->sg_str, sizeof(ch->sg_str), "%pSG", sg);
 	ch->parent = pim_ifchannel_find_parent(ch);
 	if (ch->sg.src.s_addr == INADDR_ANY) {
 		ch->sources = list_new();

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -107,18 +107,16 @@ static void pim_ifchannel_find_new_children(struct pim_ifchannel *ch)
 	struct pim_ifchannel *child;
 
 	// Basic Sanity that we are not being silly
-	if ((ch->sg.src.s_addr != INADDR_ANY)
-	    && (ch->sg.grp.s_addr != INADDR_ANY))
+	if (!pim_addr_is_any(ch->sg.src) && !pim_addr_is_any(ch->sg.grp))
 		return;
 
-	if ((ch->sg.src.s_addr == INADDR_ANY)
-	    && (ch->sg.grp.s_addr == INADDR_ANY))
+	if (pim_addr_is_any(ch->sg.src) && pim_addr_is_any(ch->sg.grp))
 		return;
 
 	RB_FOREACH (child, pim_ifchannel_rb, &pim_ifp->ifchannel_rb) {
-		if ((ch->sg.grp.s_addr != INADDR_ANY)
-		    && (child->sg.grp.s_addr == ch->sg.grp.s_addr)
-		    && (child != ch)) {
+		if (!pim_addr_is_any(ch->sg.grp) &&
+		    (child->sg.grp.s_addr == ch->sg.grp.s_addr) &&
+		    (child != ch)) {
 			child->parent = ch;
 			listnode_add_sort(ch->sources, child);
 		}
@@ -162,9 +160,9 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 		 * being inherited.  So let's figure out what
 		 * needs to be done here
 		 */
-		if ((ch->sg.src.s_addr != INADDR_ANY) &&
-				pim_upstream_evaluate_join_desired_interface(
-					ch->upstream, ch, ch->parent))
+		if (!pim_addr_is_any(ch->sg.src) &&
+		    pim_upstream_evaluate_join_desired_interface(
+			    ch->upstream, ch, ch->parent))
 			pim_channel_add_oif(ch->upstream->channel_oil,
 					ch->interface,
 					PIM_OIF_FLAG_PROTO_STAR,
@@ -293,7 +291,7 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 
 	ch->ifjoin_state = new_state;
 
-	if (ch->sg.src.s_addr == INADDR_ANY) {
+	if (pim_addr_is_any(ch->sg.src)) {
 		struct pim_upstream *up = ch->upstream;
 		struct pim_upstream *child;
 		struct listnode *up_node;
@@ -527,8 +525,8 @@ static struct pim_ifchannel *pim_ifchannel_find_parent(struct pim_ifchannel *ch)
 	struct pim_ifchannel *parent = NULL;
 
 	// (S,G)
-	if ((parent_sg.src.s_addr != INADDR_ANY)
-	    && (parent_sg.grp.s_addr != INADDR_ANY)) {
+	if (!pim_addr_is_any(parent_sg.src) &&
+	    !pim_addr_is_any(parent_sg.grp)) {
 		parent_sg.src.s_addr = INADDR_ANY;
 		parent = pim_ifchannel_find(ch->interface, &parent_sg);
 
@@ -576,7 +574,7 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 	ch->sg = *sg;
 	snprintfrr(ch->sg_str, sizeof(ch->sg_str), "%pSG", sg);
 	ch->parent = pim_ifchannel_find_parent(ch);
-	if (ch->sg.src.s_addr == INADDR_ANY) {
+	if (pim_addr_is_any(ch->sg.src)) {
 		ch->sources = list_new();
 		ch->sources->cmp =
 			(int (*)(void *, void *))pim_ifchannel_compare;
@@ -992,8 +990,8 @@ void pim_ifchannel_join_add(struct interface *ifp, struct in_addr neigh_addr,
 		THREAD_OFF(ch->t_ifjoin_prune_pending_timer);
 
 		/* Check if SGRpt join Received */
-		if ((source_flags & PIM_ENCODE_RPT_BIT)
-		    && (sg->src.s_addr != INADDR_ANY)) {
+		if ((source_flags & PIM_ENCODE_RPT_BIT) &&
+		    !pim_addr_is_any(sg->src)) {
 			/*
 			 * Transitions from Prune-Pending State (Rcv SGRpt Join)
 			 * RFC 7761 Sec 4.5.3:
@@ -1194,7 +1192,7 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 	pim = pim_ifp->pim;
 
 	/* skip (*,G) ch creation if G is of type SSM */
-	if (sg->src.s_addr == INADDR_ANY) {
+	if (pim_addr_is_any(sg->src)) {
 		if (pim_is_grp_ssm(pim, sg->grp)) {
 			if (PIM_DEBUG_PIM_EVENTS)
 				zlog_debug("%s: local membership (S,G)=%pSG ignored as group is SSM",
@@ -1212,7 +1210,7 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 
 	ifmembership_set(ch, PIM_IFMEMBERSHIP_INCLUDE);
 
-	if (sg->src.s_addr == INADDR_ANY) {
+	if (pim_addr_is_any(sg->src)) {
 		struct pim_upstream *up = pim_upstream_find(pim, sg);
 		struct pim_upstream *child;
 		struct listnode *up_node;
@@ -1288,7 +1286,7 @@ void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg)
 		return;
 	ifmembership_set(ch, PIM_IFMEMBERSHIP_NOINFO);
 
-	if (sg->src.s_addr == INADDR_ANY) {
+	if (pim_addr_is_any(sg->src)) {
 		struct pim_upstream *up = pim_upstream_find(pim_ifp->pim, sg);
 		struct pim_upstream *child;
 		struct listnode *up_node, *up_nnode;

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -514,7 +514,7 @@ static struct pim_ifchannel *pim_ifchannel_find_parent(struct pim_ifchannel *ch)
 	// (S,G)
 	if (!pim_addr_is_any(parent_sg.src) &&
 	    !pim_addr_is_any(parent_sg.grp)) {
-		parent_sg.src.s_addr = INADDR_ANY;
+		parent_sg.src = PIMADDR_ANY;
 		parent = pim_ifchannel_find(ch->interface, &parent_sg);
 
 		if (parent)

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1331,15 +1331,11 @@ void pim_ifchannel_update_could_assert(struct pim_ifchannel *ch)
 	if (new_couldassert == old_couldassert)
 		return;
 
-	if (PIM_DEBUG_PIM_EVENTS) {
-		char src_str[INET_ADDRSTRLEN];
-		char grp_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", ch->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", ch->sg.grp, grp_str, sizeof(grp_str));
-		zlog_debug("%s: CouldAssert(%s,%s,%s) changed from %d to %d",
-			   __func__, src_str, grp_str, ch->interface->name,
-			   old_couldassert, new_couldassert);
-	}
+	if (PIM_DEBUG_PIM_EVENTS)
+		zlog_debug("%s: CouldAssert(%pPAs,%pPAs,%s) changed from %d to %d",
+			   __func__, &ch->sg.src, &ch->sg.grp,
+			   ch->interface->name, old_couldassert,
+			   new_couldassert);
 
 	if (new_couldassert) {
 		/* CouldAssert(S,G,I) switched from false to true */
@@ -1373,19 +1369,15 @@ void pim_ifchannel_update_my_assert_metric(struct pim_ifchannel *ch)
 		return;
 
 	if (PIM_DEBUG_PIM_EVENTS) {
-		char src_str[INET_ADDRSTRLEN];
-		char grp_str[INET_ADDRSTRLEN];
 		char old_addr_str[INET_ADDRSTRLEN];
 		char new_addr_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", ch->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", ch->sg.grp, grp_str, sizeof(grp_str));
 		pim_inet4_dump("<old_addr?>", ch->ifassert_my_metric.ip_address,
 			       old_addr_str, sizeof(old_addr_str));
 		pim_inet4_dump("<new_addr?>", my_metric_new.ip_address,
 			       new_addr_str, sizeof(new_addr_str));
 		zlog_debug(
-			"%s: my_assert_metric(%s,%s,%s) changed from %u,%u,%u,%s to %u,%u,%u,%s",
-			__func__, src_str, grp_str, ch->interface->name,
+			"%s: my_assert_metric(%pPAs,%pPAs,%s) changed from %u,%u,%u,%s to %u,%u,%u,%s",
+			__func__, &ch->sg.src, &ch->sg.grp, ch->interface->name,
 			ch->ifassert_my_metric.rpt_bit_flag,
 			ch->ifassert_my_metric.metric_preference,
 			ch->ifassert_my_metric.route_metric, old_addr_str,
@@ -1412,16 +1404,11 @@ void pim_ifchannel_update_assert_tracking_desired(struct pim_ifchannel *ch)
 	if (new_atd == old_atd)
 		return;
 
-	if (PIM_DEBUG_PIM_EVENTS) {
-		char src_str[INET_ADDRSTRLEN];
-		char grp_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", ch->sg.src, src_str, sizeof(src_str));
-		pim_inet4_dump("<grp?>", ch->sg.grp, grp_str, sizeof(grp_str));
+	if (PIM_DEBUG_PIM_EVENTS)
 		zlog_debug(
-			"%s: AssertTrackingDesired(%s,%s,%s) changed from %d to %d",
-			__func__, src_str, grp_str, ch->interface->name,
+			"%s: AssertTrackingDesired(%pPAs,%pPAs,%s) changed from %d to %d",
+			__func__, &ch->sg.src, &ch->sg.grp, ch->interface->name,
 			old_atd, new_atd);
-	}
 
 	if (new_atd) {
 		/* AssertTrackingDesired(S,G,I) switched from false to true */

--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -154,7 +154,7 @@ static bool mtrace_fwd_info(struct pim_instance *pim,
 	rspp->rtg_proto = MTRACE_RTG_PROTO_PIM;
 
 	/* 6.2.2. 4. Fill in ... S, and Src Mask */
-	if (sg.src.s_addr != INADDR_ANY) {
+	if (!pim_addr_is_any(sg.src)) {
 		rspp->s = 1;
 		rspp->src_mask = MTRACE_SRC_MASK_SOURCE;
 	} else {

--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -119,7 +119,7 @@ static bool mtrace_fwd_info(struct pim_instance *pim,
 	up = pim_upstream_find(pim, &sg);
 
 	if (!up) {
-		sg.src.s_addr = INADDR_ANY;
+		sg.src = PIMADDR_ANY;
 		up = pim_upstream_find(pim, &sg);
 	}
 

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1675,7 +1675,7 @@ void igmp_v3_send_query(struct gm_group *group, int fd, const char *ifname,
 	*/
 	if (!s_flag) {
 		/* general query? */
-		if (PIM_INADDR_IS_ANY(group_addr)) {
+		if (group_addr.s_addr == INADDR_ANY) {
 			char dst_str[INET_ADDRSTRLEN];
 			char group_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<dst?>", dst_addr, dst_str,
@@ -1762,7 +1762,7 @@ void igmp_v3_recv_query(struct gm_sock *igmp, const char *from_str,
 	if (!s_flag) {
 		/* s_flag is clear */
 
-		if (PIM_INADDR_IS_ANY(group_addr)) {
+		if (group_addr.s_addr == INADDR_ANY) {
 			/* this is a general query */
 			/* log that general query should have the s_flag set */
 			zlog_warn(

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -65,12 +65,11 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		pim_inet4_dump("<upstream?>", upstream, up_str, sizeof(up_str));
 		pim_inet4_dump("<neigh?>", neigh->source_addr, neigh_str,
 			       sizeof(neigh_str));
-		zlog_debug(
-			"%s: join (S,G)=%s rpt=%d wc=%d upstream=%s holdtime=%d from %s on %s",
-			__func__, pim_str_sg_dump(sg),
-			!!(source_flags & PIM_RPT_BIT_MASK),
-			!!(source_flags & PIM_WILDCARD_BIT_MASK), up_str,
-			holdtime, neigh_str, ifp->name);
+		zlog_debug("%s: join (S,G)=%pSG rpt=%d wc=%d upstream=%s holdtime=%d from %s on %s",
+			   __func__, sg,
+			   !!(source_flags & PIM_RPT_BIT_MASK),
+			   !!(source_flags & PIM_WILDCARD_BIT_MASK), up_str,
+			   holdtime, neigh_str, ifp->name);
 	}
 
 	pim_ifp = ifp->info;
@@ -135,12 +134,12 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 		pim_inet4_dump("<upstream?>", upstream, up_str, sizeof(up_str));
 		pim_inet4_dump("<neigh?>", neigh->source_addr, neigh_str,
 			       sizeof(neigh_str));
-		zlog_debug(
-			"%s: prune (S,G)=%s rpt=%d wc=%d upstream=%s holdtime=%d from %s on %s",
-			__func__, pim_str_sg_dump(sg),
-			source_flags & PIM_RPT_BIT_MASK,
-			source_flags & PIM_WILDCARD_BIT_MASK, up_str, holdtime,
-			neigh_str, ifp->name);
+		zlog_debug("%s: prune (S,G)=%pSG rpt=%d wc=%d upstream=%s holdtime=%d from %s on %s",
+			   __func__, sg,
+			   source_flags & PIM_RPT_BIT_MASK,
+			   source_flags & PIM_WILDCARD_BIT_MASK, up_str,
+			   holdtime,
+			   neigh_str, ifp->name);
 	}
 
 	pim_ifp = ifp->info;

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -477,7 +477,7 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 		return -1;
 	}
 
-	if (PIM_INADDR_IS_ANY(rpf->rpf_addr.u.prefix4)) {
+	if (rpf->rpf_addr.u.prefix4.s_addr == INADDR_ANY) {
 		if (PIM_DEBUG_PIM_J_P) {
 			char dst_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<dst?>", rpf->rpf_addr.u.prefix4,

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -95,15 +95,12 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		 * our RP for the group, drop the message
 		 */
 		if (sg->src.s_addr != rp->rpf_addr.u.prefix4.s_addr) {
-			char received_rp[INET_ADDRSTRLEN];
 			char local_rp[INET_ADDRSTRLEN];
-			pim_inet4_dump("<received?>", sg->src, received_rp,
-				       sizeof(received_rp));
 			pim_inet4_dump("<local?>", rp->rpf_addr.u.prefix4,
 				       local_rp, sizeof(local_rp));
 			zlog_warn(
-				"%s: Specified RP(%s) in join is different than our configured RP(%s)",
-				__func__, received_rp, local_rp);
+				"%s: Specified RP(%pPAs) in join is different than our configured RP(%s)",
+				__func__, &sg->src, local_rp);
 			return;
 		}
 
@@ -154,14 +151,9 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 		 * Received Prune(*,G) messages are processed even if the
 		 * RP in the message does not match RP(G).
 		 */
-		if (PIM_DEBUG_PIM_TRACE) {
-			char received_rp[INET_ADDRSTRLEN];
-
-			pim_inet4_dump("<received?>", sg->src, received_rp,
-				       sizeof(received_rp));
-			zlog_debug("%s: Prune received with RP(%s) for %pSG",
-				   __func__, received_rp, sg);
-		}
+		if (PIM_DEBUG_PIM_TRACE)
+			zlog_debug("%s: Prune received with RP(%pPAs) for %pSG",
+				   __func__, &sg->src, sg);
 
 		sg->src = PIMADDR_ANY;
 	}
@@ -280,16 +272,13 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 		if (PIM_DEBUG_PIM_J_P) {
 			char src_str[INET_ADDRSTRLEN];
 			char upstream_str[INET_ADDRSTRLEN];
-			char group_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<src?>", src_addr, src_str,
 				       sizeof(src_str));
 			pim_inet4_dump("<addr?>", msg_upstream_addr.u.prefix4,
 				       upstream_str, sizeof(upstream_str));
-			pim_inet4_dump("<grp?>", sg.grp, group_str,
-				       sizeof(group_str));
 			zlog_debug(
-				"%s: join/prune upstream=%s group=%s/32 join_src=%d prune_src=%d from %s on %s",
-				__func__, upstream_str, group_str,
+				"%s: join/prune upstream=%s group=%pPA/32 join_src=%d prune_src=%d from %s on %s",
+				__func__, upstream_str, &sg.grp,
 				msg_num_joined_sources, msg_num_pruned_sources,
 				src_str, ifp->name);
 		}

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -114,7 +114,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 			return;
 		}
 
-		sg->src.s_addr = INADDR_ANY;
+		sg->src = PIMADDR_ANY;
 	}
 
 	/* Restart join expiry timer */
@@ -163,7 +163,7 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 				   __func__, received_rp, sg);
 		}
 
-		sg->src.s_addr = INADDR_ANY;
+		sg->src = PIMADDR_ANY;
 	}
 
 	pim_ifchannel_prune(ifp, upstream, sg, source_flags, holdtime);

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -315,7 +315,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 				  msg_upstream_addr.u.prefix4, &sg,
 				  msg_source_flags);
 
-			if (sg.src.s_addr == INADDR_ANY) {
+			if (pim_addr_is_any(sg.src)) {
 				starg_ch = pim_ifchannel_find(ifp, &sg);
 				if (starg_ch)
 					pim_ifchannel_set_star_g_join_state(

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -106,7 +106,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 
 		if (pim_is_grp_ssm(pim_ifp->pim, sg->grp)) {
 			zlog_warn(
-				"%s: Specified Group(%pI4) in join is now in SSM, not allowed to create PIM state",
+				"%s: Specified Group(%pPA) in join is now in SSM, not allowed to create PIM state",
 				__func__, &sg->grp);
 			return;
 		}

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -80,13 +80,7 @@ static int pim_jp_agg_src_cmp(void *arg1, void *arg2)
 	if (!js1->is_join && js2->is_join)
 		return 1;
 
-	if ((uint32_t)js1->up->sg.src.s_addr < (uint32_t)js2->up->sg.src.s_addr)
-		return -1;
-
-	if ((uint32_t)js1->up->sg.src.s_addr > (uint32_t)js2->up->sg.src.s_addr)
-		return 1;
-
-	return 0;
+	return pim_addr_cmp(js1->up->sg.src, js2->up->sg.src);
 }
 
 /*
@@ -156,7 +150,7 @@ void pim_jp_agg_remove_group(struct list *group, struct pim_upstream *up,
 	struct pim_jp_sources *js = NULL;
 
 	for (ALL_LIST_ELEMENTS(group, node, nnode, jag)) {
-		if (jag->group.s_addr == up->sg.grp.s_addr)
+		if (!pim_addr_cmp(jag->group, up->sg.grp))
 			break;
 	}
 
@@ -202,7 +196,7 @@ int pim_jp_agg_is_in_list(struct list *group, struct pim_upstream *up)
 	struct pim_jp_sources *js = NULL;
 
 	for (ALL_LIST_ELEMENTS(group, node, nnode, jag)) {
-		if (jag->group.s_addr == up->sg.grp.s_addr)
+		if (!pim_addr_cmp(jag->group, up->sg.grp))
 			break;
 	}
 
@@ -276,7 +270,7 @@ void pim_jp_agg_add_group(struct list *group, struct pim_upstream *up,
 	struct pim_jp_sources *js = NULL;
 
 	for (ALL_LIST_ELEMENTS(group, node, nnode, jag)) {
-		if (jag->group.s_addr == up->sg.grp.s_addr)
+		if (!pim_addr_cmp(jag->group, up->sg.grp))
 			break;
 	}
 

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -277,7 +277,7 @@ void pim_jp_agg_add_group(struct list *group, struct pim_upstream *up,
 	if (!jag) {
 		jag = XCALLOC(MTYPE_PIM_JP_AGG_GROUP,
 			      sizeof(struct pim_jp_agg_group));
-		jag->group.s_addr = up->sg.grp.s_addr;
+		jag->group = up->sg.grp;
 		jag->sources = list_new();
 		jag->sources->cmp = pim_jp_agg_src_cmp;
 		jag->sources->del = (void (*)(void *))pim_jp_agg_src_free;
@@ -372,7 +372,7 @@ void pim_jp_agg_single_upstream_send(struct pim_rpf *rpf,
 	listnode_add(&groups, &jag);
 	listnode_add(jag.sources, &js);
 
-	jag.group.s_addr = up->sg.grp.s_addr;
+	jag.group = up->sg.grp;
 	js.up = up;
 	js.is_join = is_join;
 

--- a/pimd/pim_macro.c
+++ b/pimd/pim_macro.c
@@ -128,7 +128,7 @@ int pim_macro_ch_lost_assert(const struct pim_ifchannel *ch)
 		return 0; /* false */
 	}
 
-	if (PIM_INADDR_IS_ANY(ch->ifassert_winner))
+	if (pim_addr_is_any(ch->ifassert_winner))
 		return 0; /* false */
 
 	/* AssertWinner(S,G,I) == me ? */

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -255,17 +255,14 @@ static void pim_mlag_up_peer_add(struct mlag_mroute_add *msg)
 	int flags = 0;
 	pim_sgaddr sg;
 	struct vrf *vrf;
-	char sg_str[PIM_SG_LEN];
 
 	memset(&sg, 0, sizeof(sg));
 	sg.src.s_addr = htonl(msg->source_ip);
 	sg.grp.s_addr = htonl(msg->group_ip);
-	if (PIM_DEBUG_MLAG)
-		pim_str_sg_set(&sg, sg_str);
 
 	if (PIM_DEBUG_MLAG)
-		zlog_debug("peer MLAG mroute add %s:%s cost %d",
-			msg->vrf_name, sg_str, msg->cost_to_rp);
+		zlog_debug("peer MLAG mroute add %s:%pSG cost %d",
+			   msg->vrf_name, &sg, msg->cost_to_rp);
 
 	/* XXX - this is not correct. we MUST cache updates to avoid losing
 	 * an entry because of race conditions with the peer switch.
@@ -273,8 +270,9 @@ static void pim_mlag_up_peer_add(struct mlag_mroute_add *msg)
 	vrf = vrf_lookup_by_name(msg->vrf_name);
 	if  (!vrf) {
 		if (PIM_DEBUG_MLAG)
-			zlog_debug("peer MLAG mroute add failed %s:%s; no vrf",
-					msg->vrf_name, sg_str);
+			zlog_debug(
+				"peer MLAG mroute add failed %s:%pSG; no vrf",
+				msg->vrf_name, &sg);
 		return;
 	}
 	pim = vrf->info;
@@ -294,8 +292,9 @@ static void pim_mlag_up_peer_add(struct mlag_mroute_add *msg)
 
 		if (!up) {
 			if (PIM_DEBUG_MLAG)
-				zlog_debug("peer MLAG mroute add failed %s:%s",
-						vrf->name, sg_str);
+				zlog_debug(
+					"peer MLAG mroute add failed %s:%pSG",
+					vrf->name, &sg);
 			return;
 		}
 	}
@@ -329,23 +328,20 @@ static void pim_mlag_up_peer_del(struct mlag_mroute_del *msg)
 	struct pim_instance *pim;
 	pim_sgaddr sg;
 	struct vrf *vrf;
-	char sg_str[PIM_SG_LEN];
 
 	memset(&sg, 0, sizeof(sg));
 	sg.src.s_addr = htonl(msg->source_ip);
 	sg.grp.s_addr = htonl(msg->group_ip);
-	if (PIM_DEBUG_MLAG)
-		pim_str_sg_set(&sg, sg_str);
 
 	if (PIM_DEBUG_MLAG)
-		zlog_debug("peer MLAG mroute del %s:%s", msg->vrf_name,
-				sg_str);
+		zlog_debug("peer MLAG mroute del %s:%pSG", msg->vrf_name, &sg);
 
 	vrf = vrf_lookup_by_name(msg->vrf_name);
 	if  (!vrf) {
 		if (PIM_DEBUG_MLAG)
-			zlog_debug("peer MLAG mroute del skipped %s:%s; no vrf",
-					msg->vrf_name, sg_str);
+			zlog_debug(
+				"peer MLAG mroute del skipped %s:%pSG; no vrf",
+				msg->vrf_name, &sg);
 		return;
 	}
 	pim = vrf->info;
@@ -353,8 +349,9 @@ static void pim_mlag_up_peer_del(struct mlag_mroute_del *msg)
 	up = pim_upstream_find(pim, &sg);
 	if  (!up) {
 		if (PIM_DEBUG_MLAG)
-			zlog_debug("peer MLAG mroute del skipped %s:%s; no up",
-					vrf->name, sg_str);
+			zlog_debug(
+				"peer MLAG mroute del skipped %s:%pSG; no up",
+				vrf->name, &sg);
 		return;
 	}
 

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -174,8 +174,8 @@ bool pim_mlag_up_df_role_update(struct pim_instance *pim,
 	/* If DF role changed on a (*,G) termination mroute update the
 	 * associated DF role on the inherited (S,G) entries
 	 */
-	if ((up->sg.src.s_addr == INADDR_ANY) &&
-			PIM_UPSTREAM_FLAG_TEST_MLAG_VXLAN(up->flags))
+	if (pim_addr_is_any(up->sg.src) &&
+	    PIM_UPSTREAM_FLAG_TEST_MLAG_VXLAN(up->flags))
 		pim_vxlan_inherit_mlag_flags(pim, up, true /* inherit */);
 
 	return true;

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -257,7 +257,7 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 	up = pim_upstream_find(pim_ifp->pim, &sg);
 	if (!up) {
 		pim_sgaddr star = sg;
-		star.src.s_addr = INADDR_ANY;
+		star.src = PIMADDR_ANY;
 
 		up = pim_upstream_find(pim_ifp->pim, &star);
 
@@ -377,7 +377,7 @@ static int pim_mroute_msg_wrongvif(int fd, struct interface *ifp,
 			zlog_debug("%s: WRONGVIF (S,G)=%pSG could not find channel on interface %s",
 				   __func__, &sg, ifp->name);
 
-		star_g.src.s_addr = INADDR_ANY;
+		star_g.src = PIMADDR_ANY;
 		ch = pim_ifchannel_find(ifp, &star_g);
 		if (!ch) {
 			if (PIM_DEBUG_MROUTE)
@@ -459,7 +459,7 @@ static int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp,
 	}
 
 	star_g = sg;
-	star_g.src.s_addr = INADDR_ANY;
+	star_g.src = PIMADDR_ANY;
 
 	pim = pim_ifp->pim;
 	/*

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -189,9 +189,8 @@ static int pim_mroute_msg_nocache(int fd, struct interface *ifp,
 
 	if (!(PIM_I_am_DR(pim_ifp))) {
 		if (PIM_DEBUG_MROUTE_DETAIL)
-			zlog_debug(
-				"%s: Interface is not the DR blackholing incoming traffic for %s",
-				__func__, pim_str_sg_dump(&sg));
+			zlog_debug("%s: Interface is not the DR blackholing incoming traffic for %pSG",
+				   __func__, &sg);
 
 		/*
 		 * We are not the DR, but we are still receiving packets
@@ -268,9 +267,8 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 					      __func__, NULL);
 			if (!up) {
 				if (PIM_DEBUG_MROUTE)
-					zlog_debug(
-						"%s: Unable to create upstream information for %s",
-						__func__, pim_str_sg_dump(&sg));
+					zlog_debug("%s: Unable to create upstream information for %pSG",
+						   __func__, &sg);
 				return 0;
 			}
 			pim_upstream_keep_alive_timer_start(
@@ -284,9 +282,8 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 			return 0;
 		}
 		if (PIM_DEBUG_MROUTE_DETAIL) {
-			zlog_debug(
-				"%s: Unable to find upstream channel WHOLEPKT%s",
-				__func__, pim_str_sg_dump(&sg));
+			zlog_debug("%s: Unable to find upstream channel WHOLEPKT%pSG",
+				   __func__, &sg);
 		}
 		return 0;
 	}
@@ -316,9 +313,8 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 	if (!up->t_rs_timer) {
 		if (pim_is_grp_ssm(pim_ifp->pim, sg.grp)) {
 			if (PIM_DEBUG_PIM_REG)
-				zlog_debug(
-					"%s register forward skipped as group is SSM",
-					pim_str_sg_dump(&sg));
+				zlog_debug("%pSG register forward skipped as group is SSM",
+					   &sg);
 			return 0;
 		}
 
@@ -361,18 +357,16 @@ static int pim_mroute_msg_wrongvif(int fd, struct interface *ifp,
 
 	if (!ifp) {
 		if (PIM_DEBUG_MROUTE)
-			zlog_debug(
-				"%s: WRONGVIF (S,G)=%s could not find input interface for input_vif_index=%d",
-				__func__, pim_str_sg_dump(&sg), msg->im_vif);
+			zlog_debug("%s: WRONGVIF (S,G)=%pSG could not find input interface for input_vif_index=%d",
+				   __func__, &sg, msg->im_vif);
 		return -1;
 	}
 
 	pim_ifp = ifp->info;
 	if (!pim_ifp) {
 		if (PIM_DEBUG_MROUTE)
-			zlog_debug(
-				"%s: WRONGVIF (S,G)=%s multicast not enabled on interface %s",
-				__func__, pim_str_sg_dump(&sg), ifp->name);
+			zlog_debug("%s: WRONGVIF (S,G)=%pSG multicast not enabled on interface %s",
+				   __func__, &sg, ifp->name);
 		return -2;
 	}
 
@@ -380,18 +374,16 @@ static int pim_mroute_msg_wrongvif(int fd, struct interface *ifp,
 	if (!ch) {
 		pim_sgaddr star_g = sg;
 		if (PIM_DEBUG_MROUTE)
-			zlog_debug(
-				"%s: WRONGVIF (S,G)=%s could not find channel on interface %s",
-				__func__, pim_str_sg_dump(&sg), ifp->name);
+			zlog_debug("%s: WRONGVIF (S,G)=%pSG could not find channel on interface %s",
+				   __func__, &sg, ifp->name);
 
 		star_g.src.s_addr = INADDR_ANY;
 		ch = pim_ifchannel_find(ifp, &star_g);
 		if (!ch) {
 			if (PIM_DEBUG_MROUTE)
-				zlog_debug(
-					"%s: WRONGVIF (*,G)=%s could not find channel on interface %s",
-					__func__, pim_str_sg_dump(&star_g),
-					ifp->name);
+				zlog_debug("%s: WRONGVIF (*,G)=%pSG could not find channel on interface %s",
+					   __func__, &star_g,
+					   ifp->name);
 			return -3;
 		}
 	}
@@ -558,9 +550,8 @@ static int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp,
 				      NULL);
 		if (!up) {
 			if (PIM_DEBUG_MROUTE)
-				zlog_debug(
-					"%s: WRONGVIF%s unable to create upstream on interface",
-					pim_str_sg_dump(&sg), ifp->name);
+				zlog_debug("%pSG: WRONGVIF%s unable to create upstream on interface",
+					   &sg, ifp->name);
 			return -2;
 		}
 		PIM_UPSTREAM_FLAG_SET_SRC_STREAM(up->flags);
@@ -1218,9 +1209,8 @@ void pim_mroute_update_counters(struct channel_oil *c_oil)
 
 			sg.src = c_oil->oil.mfcc_origin;
 			sg.grp = c_oil->oil.mfcc_mcastgrp;
-			zlog_debug(
-				"Channel%s is not installed no need to collect data from kernel",
-				pim_str_sg_dump(&sg));
+			zlog_debug("Channel%pSG is not installed no need to collect data from kernel",
+				   &sg);
 		}
 		return;
 	}
@@ -1236,8 +1226,8 @@ void pim_mroute_update_counters(struct channel_oil *c_oil)
 		sg.src = c_oil->oil.mfcc_origin;
 		sg.grp = c_oil->oil.mfcc_mcastgrp;
 
-		zlog_warn("ioctl(SIOCGETSGCNT=%lu) failure for (S,G)=%s: errno=%d: %s",
-			  (unsigned long)SIOCGETSGCNT, pim_str_sg_dump(&sg),
+		zlog_warn("ioctl(SIOCGETSGCNT=%lu) failure for (S,G)=%pSG: errno=%d: %s",
+			  (unsigned long)SIOCGETSGCNT, &sg,
 			  errno, safe_strerror(errno));
 		return;
 	}

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -680,7 +680,7 @@ static unsigned int pim_msdp_sa_hash_key_make(const void *p)
 {
 	const struct pim_msdp_sa *sa = p;
 
-	return (jhash_2words(sa->sg.src.s_addr, sa->sg.grp.s_addr, 0));
+	return pim_sgaddr_hash(sa->sg, 0);
 }
 
 static bool pim_msdp_sa_hash_eq(const void *p1, const void *p2)
@@ -688,8 +688,7 @@ static bool pim_msdp_sa_hash_eq(const void *p1, const void *p2)
 	const struct pim_msdp_sa *sa1 = p1;
 	const struct pim_msdp_sa *sa2 = p2;
 
-	return ((sa1->sg.src.s_addr == sa2->sg.src.s_addr)
-		&& (sa1->sg.grp.s_addr == sa2->sg.grp.s_addr));
+	return !pim_sgaddr_cmp(sa1->sg, sa2->sg);
 }
 
 static int pim_msdp_sa_comp(const void *p1, const void *p2)
@@ -697,19 +696,7 @@ static int pim_msdp_sa_comp(const void *p1, const void *p2)
 	const struct pim_msdp_sa *sa1 = p1;
 	const struct pim_msdp_sa *sa2 = p2;
 
-	if (ntohl(sa1->sg.grp.s_addr) < ntohl(sa2->sg.grp.s_addr))
-		return -1;
-
-	if (ntohl(sa1->sg.grp.s_addr) > ntohl(sa2->sg.grp.s_addr))
-		return 1;
-
-	if (ntohl(sa1->sg.src.s_addr) < ntohl(sa2->sg.src.s_addr))
-		return -1;
-
-	if (ntohl(sa1->sg.src.s_addr) > ntohl(sa2->sg.src.s_addr))
-		return 1;
-
-	return 0;
+	return pim_sgaddr_cmp(sa1->sg, sa2->sg);
 }
 
 /* RFC-3618:Sec-10.1.3 - Peer-RPF forwarding */

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -315,7 +315,7 @@ static void pim_msdp_sa_peer_ip_set(struct pim_msdp_sa *sa,
 	}
 
 	/* any time the peer ip changes also update the rp address */
-	if (PIM_INADDR_ISNOT_ANY(sa->peer)) {
+	if (sa->peer.s_addr != INADDR_ANY) {
 		old_mp = pim_msdp_peer_find(sa->pim, sa->peer);
 		if (old_mp && old_mp->sa_cnt) {
 			--old_mp->sa_cnt;

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -625,8 +625,7 @@ void pim_msdp_up_join_state_changed(struct pim_instance *pim,
 	}
 
 	/* If this is not really an XG entry just move on */
-	if ((xg_up->sg.src.s_addr != INADDR_ANY)
-	    || (xg_up->sg.grp.s_addr == INADDR_ANY)) {
+	if (!pim_addr_is_any(xg_up->sg.src) || pim_addr_is_any(xg_up->sg.grp)) {
 		return;
 	}
 
@@ -650,7 +649,7 @@ static void pim_msdp_up_xg_del(struct pim_instance *pim, pim_sgaddr *sg)
 	}
 
 	/* If this is not really an XG entry just move on */
-	if ((sg->src.s_addr != INADDR_ANY) || (sg->grp.s_addr == INADDR_ANY)) {
+	if (!pim_addr_is_any(sg->src) || pim_addr_is_any(sg->grp)) {
 		return;
 	}
 
@@ -669,7 +668,7 @@ void pim_msdp_up_del(struct pim_instance *pim, pim_sgaddr *sg)
 	if (PIM_DEBUG_MSDP_INTERNAL) {
 		zlog_debug("MSDP up %pSG del", sg);
 	}
-	if (sg->src.s_addr == INADDR_ANY) {
+	if (pim_addr_is_any(sg->src)) {
 		pim_msdp_up_xg_del(pim, sg);
 	} else {
 		pim_msdp_sa_local_del_on_up_del(pim, sg);

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -632,7 +632,7 @@ void pim_msdp_up_join_state_changed(struct pim_instance *pim,
 	/* XXX: Need to maintain SAs per-group to avoid all this unnecessary
 	 * walking */
 	for (ALL_LIST_ELEMENTS_RO(pim->msdp.sa_list, sanode, sa)) {
-		if (sa->sg.grp.s_addr != xg_up->sg.grp.s_addr) {
+		if (pim_addr_cmp(sa->sg.grp, xg_up->sg.grp)) {
 			continue;
 		}
 		pim_msdp_sa_upstream_update(sa, xg_up, "up-jp-change");
@@ -656,7 +656,7 @@ static void pim_msdp_up_xg_del(struct pim_instance *pim, pim_sgaddr *sg)
 	/* XXX: Need to maintain SAs per-group to avoid all this unnecessary
 	 * walking */
 	for (ALL_LIST_ELEMENTS_RO(pim->msdp.sa_list, sanode, sa)) {
-		if (sa->sg.grp.s_addr != sg->grp.s_addr) {
+		if (pim_addr_cmp(sa->sg.grp, sg->grp)) {
 			continue;
 		}
 		pim_msdp_sa_upstream_update(sa, NULL /* xg */, "up-jp-change");

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -245,7 +245,7 @@ static struct pim_msdp_sa *pim_msdp_sa_new(struct pim_instance *pim,
 
 	sa->pim = pim;
 	sa->sg = *sg;
-	pim_str_sg_set(sg, sa->sg_str);
+	snprintfrr(sa->sg_str, sizeof(sa->sg_str), "%pSG", sg);
 	sa->rp = rp;
 	sa->uptime = pim_time_monotonic_sec();
 

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -646,7 +646,7 @@ static void pim_msdp_up_xg_del(struct pim_instance *pim, pim_sgaddr *sg)
 	struct pim_msdp_sa *sa;
 
 	if (PIM_DEBUG_MSDP_INTERNAL) {
-		zlog_debug("MSDP %s del", pim_str_sg_dump(sg));
+		zlog_debug("MSDP %pSG del", sg);
 	}
 
 	/* If this is not really an XG entry just move on */
@@ -667,7 +667,7 @@ static void pim_msdp_up_xg_del(struct pim_instance *pim, pim_sgaddr *sg)
 void pim_msdp_up_del(struct pim_instance *pim, pim_sgaddr *sg)
 {
 	if (PIM_DEBUG_MSDP_INTERNAL) {
-		zlog_debug("MSDP up %s del", pim_str_sg_dump(sg));
+		zlog_debug("MSDP up %pSG del", sg);
 	}
 	if (sg->src.s_addr == INADDR_ANY) {
 		pim_msdp_up_xg_del(pim, sg);

--- a/pimd/pim_msdp_packet.c
+++ b/pimd/pim_msdp_packet.c
@@ -77,7 +77,7 @@ static void pim_msdp_pkt_sa_dump_one(struct stream *s)
 	sg.grp.s_addr = stream_get_ipv4(s);
 	sg.src.s_addr = stream_get_ipv4(s);
 
-	zlog_debug("  sg %s", pim_str_sg_dump(&sg));
+	zlog_debug("  sg %pSG", &sg);
 }
 
 static void pim_msdp_pkt_sa_dump(struct stream *s)
@@ -513,7 +513,7 @@ static void pim_msdp_pkt_sa_rx_one(struct pim_msdp_peer *mp, struct in_addr rp)
 		return;
 	}
 	if (PIM_DEBUG_MSDP_PACKETS) {
-		zlog_debug("  sg %s", pim_str_sg_dump(&sg));
+		zlog_debug("  sg %pSG", &sg);
 	}
 	pim_msdp_sa_ref(mp->pim, mp, &sg, rp);
 

--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -115,7 +115,7 @@ size_t pim_msg_get_jp_group_size(struct list *sources)
 	size += sizeof(struct pim_encoded_source_ipv4) * sources->count;
 
 	js = listgetdata(listhead(sources));
-	if (js && js->up->sg.src.s_addr == INADDR_ANY && js->is_join) {
+	if (js && pim_addr_is_any(js->up->sg.src) && js->is_join) {
 		struct pim_upstream *child, *up;
 		struct listnode *up_node;
 
@@ -193,7 +193,7 @@ size_t pim_msg_build_jp_groups(struct pim_jp_groups *grp,
 		else
 			grp->prunes++;
 
-		if (source->up->sg.src.s_addr == INADDR_ANY) {
+		if (pim_addr_is_any(source->up->sg.src)) {
 			struct pim_instance *pim = source->up->channel_oil->pim;
 			struct pim_rpf *rpf = pim_rp_g(pim, source->up->sg.grp);
 			bits = PIM_ENCODE_SPARSE_BIT | PIM_ENCODE_WC_BIT

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -234,7 +234,7 @@ void pim_delete_tracked_nexthop(struct pim_instance *pim, struct prefix *addr,
 			struct prefix grp;
 			struct rp_info *trp_info;
 
-			if (upstream->sg.src.s_addr != INADDR_ANY)
+			if (!pim_addr_is_any(upstream->sg.src))
 				continue;
 
 			grp.family = AF_INET;

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -326,8 +326,8 @@ void pim_channel_del_inherited_oif(struct channel_oil *c_oil,
 	/* if an inherited OIF is being removed join-desired can change
 	 * if the inherited OIL is now empty and KAT is running
 	 */
-	if (up && up->sg.src.s_addr != INADDR_ANY &&
-			pim_upstream_empty_inherited_olist(up))
+	if (up && !pim_addr_is_any(up->sg.src) &&
+	    pim_upstream_empty_inherited_olist(up))
 		pim_upstream_update_join_desired(up->pim, up);
 }
 

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -45,8 +45,8 @@ char *pim_channel_oil_dump(struct channel_oil *c_oil, char *buf, size_t size)
 	sg.src = c_oil->oil.mfcc_origin;
 	sg.grp = c_oil->oil.mfcc_mcastgrp;
 	ifp = pim_if_find_by_vif_index(c_oil->pim, c_oil->oil.mfcc_parent);
-	snprintf(buf, size, "%s IIF: %s, OIFS: ", pim_str_sg_dump(&sg),
-		 ifp ? ifp->name : "(?)");
+	snprintfrr(buf, size, "%pSG IIF: %s, OIFS: ", &sg,
+		   ifp ? ifp->name : "(?)");
 
 	out = buf + strlen(buf);
 	for (i = 0; i < MAXVIFS; i++) {
@@ -163,8 +163,7 @@ struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 	rb_pim_oil_add(&pim->channel_oil_head, c_oil);
 
 	if (PIM_DEBUG_MROUTE)
-		zlog_debug("%s(%s): c_oil %s add",
-				__func__, name, pim_str_sg_dump(sg));
+		zlog_debug("%s(%s): c_oil %pSG add", __func__, name, sg);
 
 	return c_oil;
 }

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -383,7 +383,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 	if (pim_is_grp_ssm(pim_ifp->pim, sg.grp)) {
 		if (pim_addr_is_any(sg.src)) {
 			zlog_warn(
-				"%s: Received Register message for Group(%pI4) is now in SSM, dropping the packet",
+				"%s: Received Register message for Group(%pPA) is now in SSM, dropping the packet",
 				__func__, &sg.grp);
 			/* Drop Packet Silently */
 			return 0;

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -75,9 +75,8 @@ void pim_register_stop_send(struct interface *ifp, pim_sgaddr *sg,
 	struct prefix p;
 
 	if (PIM_DEBUG_PIM_REG) {
-		zlog_debug("Sending Register stop for %s to %pI4 on %s",
-			   pim_str_sg_dump(sg), &originator,
-			   ifp->name);
+		zlog_debug("Sending Register stop for %pSG to %pI4 on %s", sg,
+			   &originator, ifp->name);
 	}
 
 	memset(buffer, 0, 10000);
@@ -377,8 +376,8 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 		char src_str[INET_ADDRSTRLEN];
 
 		pim_inet4_dump("<src?>", src_addr, src_str, sizeof(src_str));
-		zlog_debug("Received Register message%s from %s on %s, rp: %d",
-			   pim_str_sg_dump(&sg), src_str, ifp->name, i_am_rp);
+		zlog_debug("Received Register message%pSG from %s on %s, rp: %d",
+			   &sg, src_str, ifp->name, i_am_rp);
 	}
 
 	if (pim_is_grp_ssm(pim_ifp->pim, sg.grp)) {
@@ -515,13 +514,11 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 	} else {
 		if (PIM_DEBUG_PIM_REG) {
 			if (!i_am_rp)
-				zlog_debug(
-					"Received Register packet for %s, Rejecting packet because I am not the RP configured for group",
-					pim_str_sg_dump(&sg));
+				zlog_debug("Received Register packet for %pSG, Rejecting packet because I am not the RP configured for group",
+					   &sg);
 			else
-				zlog_debug(
-					"Received Register packet for %s, Rejecting packet because the dst ip address is not the actual RP",
-					pim_str_sg_dump(&sg));
+				zlog_debug("Received Register packet for %pSG, Rejecting packet because the dst ip address is not the actual RP",
+					   &sg);
 		}
 		pim_register_stop_send(ifp, &sg, dest_addr, src_addr);
 	}

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -381,7 +381,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 	}
 
 	if (pim_is_grp_ssm(pim_ifp->pim, sg.grp)) {
-		if (sg.src.s_addr == INADDR_ANY) {
+		if (pim_addr_is_any(sg.src)) {
 			zlog_warn(
 				"%s: Received Register message for Group(%pI4) is now in SSM, dropping the packet",
 				__func__, &sg.grp);

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -536,8 +536,8 @@ int pim_rp_new(struct pim_instance *pim, struct in_addr rp_addr,
 				/* Find (*, G) upstream whose RP is not
 				 * configured yet
 				 */
-				if ((up->upstream_addr.s_addr == INADDR_ANY)
-				    && (up->sg.src.s_addr == INADDR_ANY)) {
+				if ((up->upstream_addr.s_addr == INADDR_ANY) &&
+				    pim_addr_is_any(up->sg.src)) {
 					struct prefix grp;
 					struct rp_info *trp_info;
 
@@ -628,7 +628,7 @@ int pim_rp_new(struct pim_instance *pim, struct in_addr rp_addr,
 			   route_node_get_lock_count(rn));
 
 	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
-		if (up->sg.src.s_addr == INADDR_ANY) {
+		if (pim_addr_is_any(up->sg.src)) {
 			struct prefix grp;
 			struct rp_info *trp_info;
 
@@ -778,9 +778,9 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 			/* Find the upstream (*, G) whose upstream address is
 			 * same as the deleted RP
 			 */
-			if ((up->upstream_addr.s_addr
-			     == rp_info->rp.rpf_addr.u.prefix4.s_addr)
-			    && (up->sg.src.s_addr == INADDR_ANY)) {
+			if ((up->upstream_addr.s_addr ==
+			     rp_info->rp.rpf_addr.u.prefix4.s_addr) &&
+			    pim_addr_is_any(up->sg.src)) {
 				struct prefix grp;
 				grp.family = AF_INET;
 				grp.prefixlen = IPV4_MAX_BITLEN;
@@ -826,9 +826,9 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 		/* Find the upstream (*, G) whose upstream address is same as
 		 * the deleted RP
 		 */
-		if ((up->upstream_addr.s_addr
-		     == rp_info->rp.rpf_addr.u.prefix4.s_addr)
-		    && (up->sg.src.s_addr == INADDR_ANY)) {
+		if ((up->upstream_addr.s_addr ==
+		     rp_info->rp.rpf_addr.u.prefix4.s_addr) &&
+		    pim_addr_is_any(up->sg.src)) {
 			struct prefix grp;
 
 			grp.family = AF_INET;
@@ -914,7 +914,7 @@ int pim_rp_change(struct pim_instance *pim, struct in_addr new_rp_addr,
 	listnode_add_sort(pim->rp_list, rp_info);
 
 	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
-		if (up->sg.src.s_addr == INADDR_ANY) {
+		if (pim_addr_is_any(up->sg.src)) {
 			struct prefix grp;
 			struct rp_info *trp_info;
 

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -259,7 +259,7 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 	grp.prefixlen = IPV4_MAX_BITLEN;
 	grp.u.prefix4 = up->sg.grp;
 
-	if ((up->sg.src.s_addr == INADDR_ANY && I_am_RP(pim, up->sg.grp)) ||
+	if ((pim_addr_is_any(up->sg.src) && I_am_RP(pim, up->sg.grp)) ||
 	    PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
 		neigh_needed = false;
 	pim_find_or_track_nexthop(pim, &nht_p, up, NULL, NULL);

--- a/pimd/pim_str.c
+++ b/pimd/pim_str.c
@@ -46,7 +46,7 @@ char *pim_str_sg_dump(const pim_sgaddr *sg)
 {
 	static char sg_str[PIM_SG_LEN];
 
-	pim_str_sg_set(sg, sg_str);
+	snprintfrr(sg_str, sizeof(sg_str), "%pSG", sg);
 
 	return sg_str;
 }

--- a/pimd/pim_str.c
+++ b/pimd/pim_str.c
@@ -41,13 +41,3 @@ void pim_addr_dump(const char *onfail, struct prefix *p, char *buf,
 
 	errno = save_errno;
 }
-
-char *pim_str_sg_dump(const pim_sgaddr *sg)
-{
-	static char sg_str[PIM_SG_LEN];
-
-	snprintfrr(sg_str, sizeof(sg_str), "%pSG", sg);
-
-	return sg_str;
-}
-

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -39,12 +39,6 @@
 #define PIM_SG_LEN PREFIX_SG_STR_LEN
 #define pim_inet4_dump prefix_mcast_inet4_dump
 
-static inline const char *pim_str_sg_set(const pim_sgaddr *sg, char *str)
-{
-	snprintfrr(str, PREFIX_SG_STR_LEN, "%pSG", sg);
-	return str;
-}
-
 static inline void pim_addr_copy(pim_addr *dest, pim_addr *source)
 {
 	dest->s_addr = source->s_addr;

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -44,11 +44,6 @@ static inline void pim_addr_copy(pim_addr *dest, pim_addr *source)
 	dest->s_addr = source->s_addr;
 }
 
-static inline int pim_addr_cmp(pim_addr addr1, pim_addr addr2)
-{
-	return IPV4_ADDR_CMP(&addr1, &addr2);
-}
-
 void pim_addr_dump(const char *onfail, struct prefix *p, char *buf,
 		   int buf_size);
 void pim_inet4_dump(const char *onfail, struct in_addr addr, char *buf,

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -44,11 +44,6 @@ static inline void pim_addr_copy(pim_addr *dest, pim_addr *source)
 	dest->s_addr = source->s_addr;
 }
 
-static inline int pim_is_addr_any(pim_addr addr)
-{
-	return (addr.s_addr == INADDR_ANY);
-}
-
 static inline int pim_addr_cmp(pim_addr addr1, pim_addr addr2)
 {
 	return IPV4_ADDR_CMP(&addr1, &addr2);

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -39,11 +39,6 @@
 #define PIM_SG_LEN PREFIX_SG_STR_LEN
 #define pim_inet4_dump prefix_mcast_inet4_dump
 
-static inline void pim_addr_copy(pim_addr *dest, pim_addr *source)
-{
-	dest->s_addr = source->s_addr;
-}
-
 void pim_addr_dump(const char *onfail, struct prefix *p, char *buf,
 		   int buf_size);
 void pim_inet4_dump(const char *onfail, struct in_addr addr, char *buf,

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -58,6 +58,5 @@ void pim_addr_dump(const char *onfail, struct prefix *p, char *buf,
 		   int buf_size);
 void pim_inet4_dump(const char *onfail, struct in_addr addr, char *buf,
 		    int buf_size);
-char *pim_str_sg_dump(const pim_sgaddr *sg);
 
 #endif

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -824,19 +824,7 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 int pim_upstream_compare(const struct pim_upstream *up1,
 			 const struct pim_upstream *up2)
 {
-	if (ntohl(up1->sg.grp.s_addr) < ntohl(up2->sg.grp.s_addr))
-		return -1;
-
-	if (ntohl(up1->sg.grp.s_addr) > ntohl(up2->sg.grp.s_addr))
-		return 1;
-
-	if (ntohl(up1->sg.src.s_addr) < ntohl(up2->sg.src.s_addr))
-		return -1;
-
-	if (ntohl(up1->sg.src.s_addr) > ntohl(up2->sg.src.s_addr))
-		return 1;
-
-	return 0;
+	return pim_sgaddr_cmp(up1->sg, up2->sg);
 }
 
 void pim_upstream_fill_static_iif(struct pim_upstream *up,
@@ -1958,7 +1946,7 @@ unsigned int pim_upstream_hash_key(const void *arg)
 {
 	const struct pim_upstream *up = arg;
 
-	return jhash_2words(up->sg.src.s_addr, up->sg.grp.s_addr, 0);
+	return pim_sgaddr_hash(up->sg, 0);
 }
 
 void pim_upstream_terminate(struct pim_instance *pim)
@@ -1981,11 +1969,7 @@ bool pim_upstream_equal(const void *arg1, const void *arg2)
 	const struct pim_upstream *up1 = (const struct pim_upstream *)arg1;
 	const struct pim_upstream *up2 = (const struct pim_upstream *)arg2;
 
-	if ((up1->sg.grp.s_addr == up2->sg.grp.s_addr)
-	    && (up1->sg.src.s_addr == up2->sg.src.s_addr))
-		return true;
-
-	return false;
+	return !pim_sgaddr_cmp(up1->sg, up2->sg);
 }
 
 /* rfc4601:section-4.2:"Data Packet Forwarding Rules" defines

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1092,8 +1092,8 @@ struct pim_upstream *pim_upstream_add(struct pim_instance *pim, pim_sgaddr *sg,
                    up->rpf.source_nexthop.interface->name : "Unknown" ,
 		   found, up->ref_count);
 		else
-			zlog_debug("%s(%s): (%s) failure to create", __func__,
-				   name, pim_str_sg_dump(sg));
+			zlog_debug("%s(%s): (%pSG) failure to create", __func__,
+				   name, sg);
 	}
 
 	return up;

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -873,7 +873,7 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 
 	up->pim = pim;
 	up->sg = *sg;
-	pim_str_sg_set(sg, up->sg_str);
+	snprintfrr(up->sg_str, sizeof(up->sg_str), "%pSG", sg);
 	if (ch)
 		ch->upstream = up;
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -109,8 +109,7 @@ static void pim_upstream_find_new_children(struct pim_instance *pim,
 
 	frr_each (rb_pim_upstream, &pim->upstream_head, child) {
 		if (!pim_addr_is_any(up->sg.grp) &&
-		    (child->sg.grp.s_addr == up->sg.grp.s_addr) &&
-		    (child != up)) {
+		    !pim_addr_cmp(child->sg.grp, up->sg.grp) && (child != up)) {
 			child->parent = up;
 			listnode_add_sort(up->sources, child);
 			if (PIM_UPSTREAM_FLAG_TEST_USE_RPT(child->flags))

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -134,7 +134,7 @@ static struct pim_upstream *pim_upstream_find_parent(struct pim_instance *pim,
 	// (S,G)
 	if (!pim_addr_is_any(child->sg.src) &&
 	    !pim_addr_is_any(child->sg.grp)) {
-		any.src.s_addr = INADDR_ANY;
+		any.src = PIMADDR_ANY;
 		up = pim_upstream_find(pim, &any);
 
 		if (up)

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -339,8 +339,7 @@ int pim_interface_config_write(struct vty *vty)
 				}
 
 				/* update source */
-				if (PIM_INADDR_ISNOT_ANY(
-					    pim_ifp->update_source)) {
+				if (!pim_addr_is_any(pim_ifp->update_source)) {
 					char src_str[INET_ADDRSTRLEN];
 					pim_inet4_dump("<src?>",
 						       pim_ifp->update_source,

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -720,8 +720,7 @@ static unsigned int pim_vxlan_sg_hash_key_make(const void *p)
 {
 	const struct pim_vxlan_sg *vxlan_sg = p;
 
-	return (jhash_2words(vxlan_sg->sg.src.s_addr,
-				vxlan_sg->sg.grp.s_addr, 0));
+	return pim_sgaddr_hash(vxlan_sg->sg, 0);
 }
 
 static bool pim_vxlan_sg_hash_eq(const void *p1, const void *p2)
@@ -729,8 +728,7 @@ static bool pim_vxlan_sg_hash_eq(const void *p1, const void *p2)
 	const struct pim_vxlan_sg *sg1 = p1;
 	const struct pim_vxlan_sg *sg2 = p2;
 
-	return ((sg1->sg.src.s_addr == sg2->sg.src.s_addr)
-			&& (sg1->sg.grp.s_addr == sg2->sg.grp.s_addr));
+	return !pim_sgaddr_cmp(sg1->sg, sg2->sg);
 }
 
 static struct pim_vxlan_sg *pim_vxlan_sg_new(struct pim_instance *pim,

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -742,7 +742,7 @@ static struct pim_vxlan_sg *pim_vxlan_sg_new(struct pim_instance *pim,
 
 	vxlan_sg->pim = pim;
 	vxlan_sg->sg = *sg;
-	pim_str_sg_set(sg, vxlan_sg->sg_str);
+	snprintfrr(vxlan_sg->sg_str, sizeof(vxlan_sg->sg_str), "%pSG", sg);
 
 	if (PIM_DEBUG_VXLAN)
 		zlog_debug("vxlan SG %s alloc", vxlan_sg->sg_str);

--- a/pimd/pim_vxlan.h
+++ b/pimd/pim_vxlan.h
@@ -109,14 +109,14 @@ struct pim_vxlan {
  */
 static inline bool pim_vxlan_is_orig_mroute(struct pim_vxlan_sg *vxlan_sg)
 {
-	return (vxlan_sg->sg.src.s_addr != INADDR_ANY);
+	return !pim_addr_is_any(vxlan_sg->sg.src);
 }
 
 static inline bool pim_vxlan_is_local_sip(struct pim_upstream *up)
 {
-	return (up->sg.src.s_addr != INADDR_ANY) &&
-		up->rpf.source_nexthop.interface &&
-		if_is_loopback(up->rpf.source_nexthop.interface);
+	return !pim_addr_is_any(up->sg.src) &&
+	       up->rpf.source_nexthop.interface &&
+	       if_is_loopback(up->rpf.source_nexthop.interface);
 }
 
 static inline bool pim_vxlan_is_term_dev_cfg(struct pim_instance *pim,

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -515,9 +515,8 @@ static void igmp_source_forward_reevaluate_one(struct pim_instance *pim,
 		if (ch
 		    && (ch->local_ifmembership == PIM_IFMEMBERSHIP_INCLUDE)) {
 			if (PIM_DEBUG_PIM_EVENTS)
-				zlog_debug(
-					"local membership del for %s as G is now SSM",
-					pim_str_sg_dump(&sg));
+				zlog_debug("local membership del for %pSG as G is now SSM",
+					   &sg);
 			pim_ifchannel_local_membership_del(group->interface,
 							   &sg);
 		}
@@ -526,9 +525,8 @@ static void igmp_source_forward_reevaluate_one(struct pim_instance *pim,
 		if (!ch
 		    || (ch->local_ifmembership == PIM_IFMEMBERSHIP_NOINFO)) {
 			if (PIM_DEBUG_PIM_EVENTS)
-				zlog_debug(
-					"local membership add for %s as G is now ASM",
-					pim_str_sg_dump(&sg));
+				zlog_debug("local membership add for %pSG as G is now ASM",
+					   &sg);
 			pim_ifchannel_local_membership_add(
 				group->interface, &sg, false /*is_vxlan*/);
 		}
@@ -585,8 +583,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
 	sg.grp = source->source_group->group_addr;
 
 	if (PIM_DEBUG_IGMP_TRACE) {
-		zlog_debug("%s: (S,G)=%s oif=%s fwd=%d", __func__,
-			   pim_str_sg_dump(&sg),
+		zlog_debug("%s: (S,G)=%pSG oif=%s fwd=%d", __func__, &sg,
 			   source->source_group->interface->name,
 			   IGMP_SOURCE_TEST_FORWARDING(source->source_flags));
 	}
@@ -650,10 +647,9 @@ void igmp_source_forward_start(struct pim_instance *pim,
 
 				pim_inet4_dump("<source?>", vif_source, buf2,
 					       sizeof(buf2));
-				zlog_debug(
-					"%s: NHT %s vif_source %s vif_index:%d ",
-					__func__, pim_str_sg_dump(&sg), buf2,
-					input_iface_vif_index);
+				zlog_debug("%s: NHT %pSG vif_source %s vif_index:%d ",
+					   __func__, &sg, buf2,
+					   input_iface_vif_index);
 			}
 
 			if (input_iface_vif_index < 1) {
@@ -684,13 +680,12 @@ void igmp_source_forward_start(struct pim_instance *pim,
 					/* ignore request for looped MFC entry
 					 */
 					if (PIM_DEBUG_IGMP_TRACE) {
-						zlog_debug(
-							"%s: ignoring request for looped MFC entry (S,G)=%s: oif=%s vif_index=%d",
-							__func__,
-							pim_str_sg_dump(&sg),
-							source->source_group
-								->interface->name,
-							input_iface_vif_index);
+						zlog_debug("%s: ignoring request for looped MFC entry (S,G)=%pSG: oif=%s vif_index=%d",
+							   __func__,
+							   &sg,
+							   source->source_group
+							   ->interface->name,
+							   input_iface_vif_index);
 					}
 					return;
 				}
@@ -699,10 +694,9 @@ void igmp_source_forward_start(struct pim_instance *pim,
 					pim_channel_oil_add(pim, &sg, __func__);
 				if (!source->source_channel_oil) {
 					if (PIM_DEBUG_IGMP_TRACE) {
-						zlog_debug(
-							"%s %s: could not create OIL for channel (S,G)=%s",
-							__FILE__, __func__,
-							pim_str_sg_dump(&sg));
+						zlog_debug("%s %s: could not create OIL for channel (S,G)=%pSG",
+							   __FILE__, __func__,
+							   &sg);
 					}
 					return;
 				}
@@ -723,10 +717,9 @@ void igmp_source_forward_start(struct pim_instance *pim,
 		}
 	} else {
 		if (PIM_DEBUG_IGMP_TRACE)
-			zlog_debug(
-				"%s: %s was received on %s interface but we are not DR for that interface",
-				__func__, pim_str_sg_dump(&sg),
-				group->interface->name);
+			zlog_debug("%s: %pSG was received on %s interface but we are not DR for that interface",
+				   __func__, &sg,
+				   group->interface->name);
 
 		return;
 	}
@@ -737,8 +730,8 @@ void igmp_source_forward_start(struct pim_instance *pim,
 	if (!pim_ifchannel_local_membership_add(group->interface, &sg,
 						false /*is_vxlan*/)) {
 		if (PIM_DEBUG_MROUTE)
-			zlog_warn("%s: Failure to add local membership for %s",
-				  __func__, pim_str_sg_dump(&sg));
+			zlog_warn("%s: Failure to add local membership for %pSG",
+				  __func__, &sg);
 
 		pim_channel_del_oif(source->source_channel_oil,
 				    group->interface, PIM_OIF_FLAG_PROTO_IGMP,
@@ -764,8 +757,7 @@ void igmp_source_forward_stop(struct gm_source *source)
 	sg.grp = source->source_group->group_addr;
 
 	if (PIM_DEBUG_IGMP_TRACE) {
-		zlog_debug("%s: (S,G)=%s oif=%s fwd=%d", __func__,
-			   pim_str_sg_dump(&sg),
+		zlog_debug("%s: (S,G)=%pSG oif=%s fwd=%d", __func__, &sg,
 			   source->source_group->interface->name,
 			   IGMP_SOURCE_TEST_FORWARDING(source->source_flags));
 	}

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -562,7 +562,7 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 		RB_FOREACH_SAFE (ch, pim_ifchannel_rb, &pim_ifp->ifchannel_rb,
 				 ch_temp) {
 			if (pim_is_grp_ssm(pim, ch->sg.grp)) {
-				if (ch->sg.src.s_addr == INADDR_ANY)
+				if (pim_addr_is_any(ch->sg.src))
 					pim_ifchannel_delete(ch);
 			}
 		}

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -340,14 +340,9 @@ static int pim_zebra_vxlan_sg_proc(ZAPI_CALLBACK_ARGS)
 	stream_get(&sg.src.s_addr, s, prefixlen);
 	stream_get(&sg.grp.s_addr, s, prefixlen);
 
-	if (PIM_DEBUG_ZEBRA) {
-		char sg_str[PIM_SG_LEN];
-
-		pim_str_sg_set(&sg, sg_str);
-		zlog_debug("%u:recv SG %s %s", vrf_id,
-			(cmd == ZEBRA_VXLAN_SG_ADD)?"add":"del",
-			sg_str);
-	}
+	if (PIM_DEBUG_ZEBRA)
+		zlog_debug("%u:recv SG %s %pSG", vrf_id,
+			   (cmd == ZEBRA_VXLAN_SG_ADD) ? "add" : "del", &sg);
 
 	if (cmd == ZEBRA_VXLAN_SG_ADD)
 		pim_vxlan_sg_add(pim, &sg);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -806,21 +806,9 @@ void pim_forward_start(struct pim_ifchannel *ch)
 	struct pim_upstream *up = ch->upstream;
 	uint32_t mask = 0;
 
-	if (PIM_DEBUG_PIM_TRACE) {
-		char source_str[INET_ADDRSTRLEN];
-		char group_str[INET_ADDRSTRLEN];
-		char upstream_str[INET_ADDRSTRLEN];
-
-		pim_inet4_dump("<source?>", ch->sg.src, source_str,
-			       sizeof(source_str));
-		pim_inet4_dump("<group?>", ch->sg.grp, group_str,
-			       sizeof(group_str));
-		pim_inet4_dump("<upstream?>", up->upstream_addr, upstream_str,
-			       sizeof(upstream_str));
-		zlog_debug("%s: (S,G)=(%s,%s) oif=%s (%pI4)", __func__,
-			   source_str, group_str, ch->interface->name,
-			   &up->upstream_addr);
-	}
+	if (PIM_DEBUG_PIM_TRACE)
+		zlog_debug("%s: (S,G)=%pSG oif=%s (%pI4)", __func__, &ch->sg,
+			   ch->interface->name, &up->upstream_addr);
 
 	if (PIM_IF_FLAG_TEST_PROTO_IGMP(ch->flags))
 		mask = PIM_OIF_FLAG_PROTO_IGMP;

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -535,10 +535,9 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 
 		more.src = c_oil->oil.mfcc_origin;
 		more.grp = c_oil->oil.mfcc_mcastgrp;
-		zlog_debug(
-			"Sending Request for New Channel Oil Information%s VIIF %d(%s)",
-			pim_str_sg_dump(&more), c_oil->oil.mfcc_parent,
-			c_oil->pim->vrf->name);
+		zlog_debug("Sending Request for New Channel Oil Information%pSG VIIF %d(%s)",
+			   &more, c_oil->oil.mfcc_parent,
+			   c_oil->pim->vrf->name);
 	}
 
 	if (!ifp)
@@ -593,9 +592,8 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 			more.grp = c_oil->oil.mfcc_mcastgrp;
 			flog_err(
 				EC_LIB_ZAPI_MISSMATCH,
-				"%s: Received wrong %s(%s) information requested",
-				__func__, pim_str_sg_dump(&more),
-				c_oil->pim->vrf->name);
+				"%s: Received wrong %pSG(%s) information requested",
+				__func__, &more, c_oil->pim->vrf->name);
 		}
 		zclient_lookup_failed(zlookup);
 		return -3;

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -83,8 +83,6 @@
 #define PIM_FORCE_BOOLEAN(expr) ((expr) != 0)
 
 #define PIM_NET_INADDR_ANY (htonl(INADDR_ANY))
-#define PIM_INADDR_IS_ANY(addr) (addr).s_addr == PIM_NET_INADDR_ANY
-#define PIM_INADDR_ISNOT_ANY(addr) ((addr).s_addr != PIM_NET_INADDR_ANY) /* struct in_addr addr */
 
 #define PIM_MASK_PIM_EVENTS          (1 << 0)
 #define PIM_MASK_PIM_EVENTS_DETAIL   (1 << 1)


### PR DESCRIPTION
A bunch of things get abstracted into helpers:

- pim_addr_cmp replaces `x.s_addr < == !=  y.s_addr`
- pim_addr_is_zero replaces `x.s_addr == INADDR_ANY`
- PIMADDR_ANY replaces `x.s_addr = INADDR_ANY`
- pim_sgaddr_{cmp,hash,match} analogous (match is for CLI filters with zero as wildcard)
- `pim_str_sg_set` and `pim_str_sg_dump` replaced with printfrr