### PR TITLE
bgpd: Graceful Restart restart-time can be 0

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2704,7 +2704,7 @@ DEFUN (bgp_graceful_restart_stalepath_time,
 
 DEFUN (bgp_graceful_restart_restart_time,
 	bgp_graceful_restart_restart_time_cmd,
-	"bgp graceful-restart restart-time (1-4095)",
+	"bgp graceful-restart restart-time (0-4095)",
 	BGP_STR
 	"Graceful restart capability parameters\n"
 	"Set the time to wait to delete stale routes before a BGP open message is received\n"
@@ -2758,7 +2758,7 @@ DEFUN (no_bgp_graceful_restart_stalepath_time,
 
 DEFUN (no_bgp_graceful_restart_restart_time,
 	no_bgp_graceful_restart_restart_time_cmd,
-	"no bgp graceful-restart restart-time [(1-4095)]",
+	"no bgp graceful-restart restart-time [(0-4095)]",
 	NO_STR
 	BGP_STR
 	"Graceful restart capability parameters\n"

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -924,6 +924,17 @@ However, it MUST defer route selection for an address family until it either.
 
    This is command, will set the time for which stale routes are kept in RIB.
 
+.. clicmd:: bgp graceful-restart restart-time (0-4095)
+
+   Set the time to wait to delete stale routes before a BGP open message
+   is received.
+
+   Using with Long-lived Graceful Restart capability, this is recommended
+   setting this timer to 0 and control stale routes with
+   ``bgp long-lived-graceful-restart stale-time``.
+
+   Default value is 120.
+
 .. clicmd:: bgp graceful-restart stalepath-time (1-4095)
 
    This is command, will set the max time (in seconds) to hold onto

--- a/tests/topotests/bgp_llgr/r0/bgpd.conf
+++ b/tests/topotests/bgp_llgr/r0/bgpd.conf
@@ -1,7 +1,7 @@
 router bgp 65000
  no bgp ebgp-requires-policy
  bgp graceful-restart
- bgp graceful-restart restart-time 1
+ bgp graceful-restart restart-time 0
  bgp long-lived-graceful-restart stale-time 20
  neighbor 192.168.0.2 remote-as external
  address-family ipv4 unicast

--- a/tests/topotests/bgp_llgr/r1/bgpd.conf
+++ b/tests/topotests/bgp_llgr/r1/bgpd.conf
@@ -1,7 +1,7 @@
 router bgp 65001
  no bgp ebgp-requires-policy
  bgp graceful-restart
- bgp graceful-restart restart-time 1
+ bgp graceful-restart restart-time 0
  bgp long-lived-graceful-restart stale-time 20
  neighbor 192.168.1.2 remote-as external
  address-family ipv4 unicast


### PR DESCRIPTION
Using with LLGR, this should be allowed setting GR restart-time timer to 0,
to immediately start LLGR timers.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>