### PR TITLE
pimd: remove redundant header inclusion

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -38,7 +38,6 @@
 #include "pim_str.h"
 #include "pim_iface.h"
 #include "pim_rp.h"
-#include "pim_str.h"
 #include "pim_rpf.h"
 #include "pim_sock.h"
 #include "pim_memory.h"


### PR DESCRIPTION
Just found while code inspection, pim_str.h is included twice.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>