### PR TITLE
pimd: Add PIM_PREFIX to access prefix data struct for v4 and v6

### DIFF
--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -133,14 +133,14 @@ pim_jp_agg_get_interface_upstream_switch_list(struct pim_rpf *rpf)
 
 	for (ALL_LIST_ELEMENTS(pim_ifp->upstream_switch_list, node, nnode,
 			       pius)) {
-		if (pius->address.s_addr == rpf->rpf_addr.u.prefix4.s_addr)
+		if (pim_addr_cmp(pius->address, PIM_PREFIX(rpf->rpf_addr)))
 			break;
 	}
 
 	if (!pius) {
 		pius = XCALLOC(MTYPE_PIM_JP_AGG_GROUP,
 			       sizeof(struct pim_iface_upstream_switch));
-		pius->address.s_addr = rpf->rpf_addr.u.prefix4.s_addr;
+		pim_addr_copy(&pius->address, &PIM_PREFIX(rpf->rpf_addr));
 		pius->us = list_new();
 		listnode_add_sort(pim_ifp->upstream_switch_list, pius);
 	}

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -27,6 +27,7 @@
 #include <prefix.h>
 
 typedef struct in_addr pim_addr;
+#define PIM_PREFIX(p) ((p).u.prefix4)
 
 /*
  * Longest possible length of a (S,G) string is 36 bytes

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -240,7 +240,7 @@ void pim_zebra_update_all_interfaces(struct pim_instance *pim)
 			struct pim_rpf rpf;
 
 			rpf.source_nexthop.interface = ifp;
-			rpf.rpf_addr.u.prefix4 = us->address;
+			pim_addr_copy(&PIM_PREFIX(rpf.rpf_addr), &us->address);
 			pim_joinprune_send(&rpf, us->us);
 			pim_jp_agg_clear_group(us->us);
 		}


### PR DESCRIPTION
This PR is raised temporarily to access PREFIX struct.

Need to think if there is a better way to access it than this.

PIM_PREFIX can be used to access v4 or v6 data.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>