### PR TITLE
ospfd,ospf6d: fix wrong comparison of routemap name

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1936,13 +1936,13 @@ DEFPY (ospf6_default_route_originate,
 	if (mtype_str == NULL)
 		mtype = -1;
 
-	/* To check ,if user is providing same route map */
-	if ((rtmap == ROUTEMAP_NAME(red))
-	    || (rtmap && ROUTEMAP_NAME(red)
-		&& (strcmp(rtmap, ROUTEMAP_NAME(red)) == 0)))
+	/* To check if user is providing same route map */
+	if ((!rtmap && !ROUTEMAP_NAME(red)) ||
+	    (rtmap && ROUTEMAP_NAME(red) &&
+	     (strcmp(rtmap, ROUTEMAP_NAME(red)) == 0)))
 		sameRtmap = true;
 
-	/* Don't allow if the same lsa is aleardy originated. */
+	/* Don't allow if the same lsa is already originated. */
 	if ((sameRtmap) && (red->dmetric.type == mtype)
 	    && (red->dmetric.value == mval)
 	    && (cur_originate == default_originate))

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9275,7 +9275,7 @@ DEFUN (ospf_default_information_originate,
 	struct ospf_redist *red;
 	int idx = 0;
 	int cur_originate = ospf->default_originate;
-	int sameRtmap = 0;
+	bool sameRtmap = false;
 	char *rtmap = NULL;
 
 	red = ospf_redist_add(ospf, DEFAULT_ROUTE, 0);
@@ -9300,13 +9300,13 @@ DEFUN (ospf_default_information_originate,
 	if (argv_find(argv, argc, "WORD", &idx))
 		rtmap = argv[idx]->arg;
 
-	/* To check ,if user is providing same route map */
-	if ((rtmap == ROUTEMAP_NAME(red)) ||
-	    (rtmap && ROUTEMAP_NAME(red)
-	    && (strcmp(rtmap, ROUTEMAP_NAME(red)) == 0)))
-		sameRtmap = 1;
+	/* To check if user is providing same route map */
+	if ((!rtmap && !ROUTEMAP_NAME(red)) ||
+	    (rtmap && ROUTEMAP_NAME(red) &&
+	     (strcmp(rtmap, ROUTEMAP_NAME(red)) == 0)))
+		sameRtmap = true;
 
-	/* Don't allow if the same lsa is aleardy originated. */
+	/* Don't allow if the same lsa is already originated. */
 	if ((sameRtmap)
 	    && (red->dmetric.type == type)
 	    && (red->dmetric.value == metric)


### PR DESCRIPTION
ospfd,ospf6d: fix wrong comparison of routemap name

Comparison of the two pointer is wrong, they have no relevance.
Additionly correct some comment words.

Signed-off-by: anlan_cs <anlan_cs@tom.com>