### PR TITLE
ospf6d: do not send Type-5 into stub area

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -207,7 +207,7 @@ int ospf6_orig_as_external_lsa(struct thread *thread)
 
 	if (oi->state == OSPF6_INTERFACE_DOWN)
 		return 0;
-	if (IS_AREA_NSSA(oi->area))
+	if (IS_AREA_NSSA(oi->area) || IS_AREA_STUB(oi->area))
 		return 0;
 
 	type = htons(OSPF6_LSTYPE_AS_EXTERNAL);


### PR DESCRIPTION
When running the `topotest ospf6_topo2`, we see the ABR r2 sending type 5 LSA into
the stub area `0.0.0.1` which are not acknowledged and the ABR keeps trying forever
```
    2022/01/07 15:51:57.953 LSUpdate to neighbor 10.254.254.1%r2-eth0
    2022/01/07 15:51:57.953 LSUpdate send on r2-eth0
    2022/01/07 15:51:57.953     src: fe80::5808:2aff:fe79:bb63
    2022/01/07 15:51:57.953     dst: fe80::785f:7aff:feee:82d6
    2022/01/07 15:51:57.953     OSPFv3 Type:4 Len:156 Router-ID:10.254.254.2
    2022/01/07 15:51:57.953     Area-ID:0.0.0.1 Cksum:0 Instance-ID:0
    2022/01/07 15:51:57.953     Number of LSA: 4
    2022/01/07 15:51:57.953     [AS-External Id:0.0.0.1 Adv:10.254.254.2]
    2022/01/07 15:51:57.953     Age:  198 SeqNum: 0x80000001 Cksum: 3959 Len: 28
    2022/01/07 15:51:57.953     [AS-External Id:0.0.0.2 Adv:10.254.254.2]
    2022/01/07 15:51:57.953     Age:  197 SeqNum: 0x80000001 Cksum: d5f2 Len: 36
    2022/01/07 15:51:57.953     [AS-External Id:0.0.0.3 Adv:10.254.254.2]
    2022/01/07 15:51:57.953     Age:  197 SeqNum: 0x80000001 Cksum: ebd9 Len: 36
    2022/01/07 15:51:57.953     [AS-External Id:0.0.0.4 Adv:10.254.254.2]
    2022/01/07 15:51:57.953     Age:  196 SeqNum: 0x80000001 Cksum: d1f3 Len: 36

    2022/01/07 15:52:02.953 LSUpdate to neighbor 10.254.254.1%r2-eth0
    2022/01/07 15:52:02.953 LSUpdate send on r2-eth0
    2022/01/07 15:52:02.953     src: fe80::5808:2aff:fe79:bb63
    2022/01/07 15:52:02.953     dst: fe80::785f:7aff:feee:82d6
    2022/01/07 15:52:02.953     OSPFv3 Type:4 Len:156 Router-ID:10.254.254.2
    2022/01/07 15:52:02.953     Area-ID:0.0.0.1 Cksum:0 Instance-ID:0
    2022/01/07 15:52:02.953     Number of LSA: 4
    2022/01/07 15:52:02.953     [AS-External Id:0.0.0.1 Adv:10.254.254.2]
    2022/01/07 15:52:02.953     Age:  203 SeqNum: 0x80000001 Cksum: 3959 Len: 28
    2022/01/07 15:52:02.954     [AS-External Id:0.0.0.2 Adv:10.254.254.2]
    2022/01/07 15:52:02.954     Age:  202 SeqNum: 0x80000001 Cksum: d5f2 Len: 36
    2022/01/07 15:52:02.954     [AS-External Id:0.0.0.3 Adv:10.254.254.2]
    2022/01/07 15:52:02.954     Age:  202 SeqNum: 0x80000001 Cksum: ebd9 Len: 36
    2022/01/07 15:52:02.954     [AS-External Id:0.0.0.4 Adv:10.254.254.2]
    2022/01/07 15:52:02.954     Age:  201 SeqNum: 0x80000001 Cksum: d1f3 Len: 36
```
This PR prevents the ABR of sending type 5 lsa into a stub area

Signed-off-by: ckishimo <carles.kishimoto@gmail.com>