### PR TITLE
ospf6d: some cleaning

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -1176,7 +1176,7 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 		if (lsa->header->adv_router == router_lsa->router_id) {
 			if (is_debug)
 				zlog_debug(
-					"Ignorning Inter-Router LSA for an ABR (%s)",
+					"Ignoring Inter-Router LSA for an ABR (%s)",
 					buf);
 			if (old)
 				ospf6_route_remove(old, table);

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1409,8 +1409,6 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 	struct ospf6_external_info tinfo;
 	struct ospf6_route *route, *match;
 	struct ospf6_external_info *info;
-	struct prefix prefix_id;
-	char ibuf[16];
 	struct ospf6_redist *red;
 
 	red = ospf6_redist_lookup(ospf6, type, 0);
@@ -1495,14 +1493,6 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 			ospf6_route_add_nexthop(match, ifindex, nexthop);
 		else
 			ospf6_route_add_nexthop(match, ifindex, NULL);
-
-		if (IS_OSPF6_DEBUG_ASBR) {
-			inet_ntop(AF_INET, &prefix_id.u.prefix4, ibuf,
-				  sizeof(ibuf));
-			zlog_debug(
-				"Advertise as AS-External Id:%s prefix %pFX metric %u",
-				ibuf, prefix, match->path.metric_type);
-		}
 
 		match->path.origin.id = htonl(info->id);
 		ospf6_handle_external_lsa_origination(ospf6, match, prefix);

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -575,8 +575,9 @@ struct ospf6_lsa *ospf6_translated_nssa_refresh(struct ospf6_area *area,
 		match = ospf6_route_lookup(&prefix, ospf6->external_table);
 		if (match)
 			type5 = ospf6_lsdb_lookup(
-				OSPF6_LSTYPE_AS_EXTERNAL, match->path.origin.id,
-				ospf6->router_id, ospf6->lsdb);
+				htons(OSPF6_LSTYPE_AS_EXTERNAL),
+				match->path.origin.id, ospf6->router_id,
+				ospf6->lsdb);
 	}
 
 	if (type5) {

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -604,7 +604,6 @@ struct ospf6_lsa *ospf6_translated_nssa_refresh(struct ospf6_area *area,
 					__func__, &type7->header->id);
 			return NULL;
 		}
-		UNSET_FLAG(new->flag, OSPF6_LSA_UNAPPROVED);
 	}
 
 	if (IS_OSPF6_DEBUG_NSSA)

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -1021,10 +1021,10 @@ static void ospf6_nssa_flush_area(struct ospf6_area *area)
 
 		/* Flush the translated LSA */
 		if (ospf6_check_and_set_router_abr(ospf6)) {
-			type = htons(OSPF6_LSTYPE_AS_EXTERNAL);
 			type5 = ospf6_lsdb_lookup(
-				htons(type), lsa->external_lsa_id,
-				ospf6->router_id, ospf6->lsdb);
+				htons(OSPF6_LSTYPE_AS_EXTERNAL),
+				lsa->external_lsa_id, ospf6->router_id,
+				ospf6->lsdb);
 			if (type5
 			    && CHECK_FLAG(type5->flag, OSPF6_LSA_LOCAL_XLT)) {
 				type5->header->age = htons(OSPF_LSA_MAXAGE);

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -135,7 +135,7 @@ static void ospf6_flush_translated_lsa(struct ospf6_area *area)
 		zlog_debug("%s: finish area %s", __func__, area->name);
 }
 
-/* Check NSSA status for all nssa areas*/
+/* Check NSSA status for all nssa areas */
 void ospf6_abr_nssa_check_status(struct ospf6 *ospf6)
 {
 	struct ospf6_area *area;
@@ -404,7 +404,7 @@ static void ospf6_abr_unapprove_translates(struct ospf6 *ospf6)
 		zlog_debug("%s: Stop", __func__);
 }
 
-/* Generate the translated external lsa  from NSSA lsa */
+/* Generate the translated external lsa from NSSA lsa */
 static struct ospf6_lsa *ospf6_lsa_translated_nssa_new(struct ospf6_area *area,
 						       struct ospf6_lsa *type7)
 {
@@ -536,10 +536,10 @@ static void ospf6_ls_retransmit_delete_nbr_as(struct ospf6 *ospf6,
 		ospf6_flood_clear_area(lsa, area);
 
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug("%s : finish  lsa %s", __func__, lsa->name);
+		zlog_debug("%s : finish lsa %s", __func__, lsa->name);
 }
 
-/* Refresh translated  AS-external-LSA. */
+/* Refresh translated AS-external-LSA. */
 struct ospf6_lsa *ospf6_translated_nssa_refresh(struct ospf6_area *area,
 						struct ospf6_lsa *type7,
 						struct ospf6_lsa *type5)
@@ -614,7 +614,7 @@ struct ospf6_lsa *ospf6_translated_nssa_refresh(struct ospf6_area *area,
 
 static void ospf6_abr_translate_nssa(struct ospf6_area *area, struct ospf6_lsa *lsa)
 {
-	/* Incoming Type-7 or later aggregated Type-7
+	/* Incoming Type-7 or aggregated Type-7
 	 *
 	 * LSA is skipped if P-bit is off.
 	 *
@@ -706,7 +706,7 @@ static void ospf6_abr_translate_nssa(struct ospf6_area *area, struct ospf6_lsa *
 static void ospf6_abr_process_nssa_translates(struct ospf6 *ospf6)
 {
 	/* Scan through all NSSA_LSDB records for all areas;
-	 * If P-bit is on, translate all Type-7's to 5's and aggregate or\
+	 * If P-bit is on, translate all Type-7's to 5's and aggregate or
 	 * flood install as approved in Type-5 LSDB with XLATE Flag on
 	 * later, do same for all aggregates...  At end, DISCARD all
 	 * remaining UNAPPROVED Type-5's (Aggregate is for future ) */
@@ -738,7 +738,7 @@ static void ospf6_abr_process_nssa_translates(struct ospf6 *ospf6)
 		type = htons(OSPF6_LSTYPE_TYPE_7);
 		for (ALL_LSDB_TYPED(oa->lsdb, type, lsa)) {
 			zlog_debug("%s : lsa %s , id %pI4 , adv router %pI4",
-				   lsa->name, __func__, &lsa->header->id,
+				   __func__, lsa->name, &lsa->header->id,
 				   &lsa->header->adv_router);
 			ospf6_abr_translate_nssa(oa, lsa);
 		}
@@ -1374,7 +1374,7 @@ DEFPY (no_area_nssa_range,
 	range = ospf6_route_lookup((struct prefix *)prefix,
 				   oa->nssa_range_table);
 	if (range == NULL) {
-		vty_out(vty, "%% range %s does not exists.\n", prefix_str);
+		vty_out(vty, "%% range %s does not exist.\n", prefix_str);
 		return CMD_SUCCESS;
 	}
 

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -271,7 +271,7 @@ static void ospf6_abr_announce_aggregates(struct ospf6 *ospf6)
 	struct listnode *node;
 
 	if (IS_OSPF6_DEBUG_ABR)
-		zlog_debug("ospf6_abr_announce_aggregates(): Start");
+		zlog_debug("%s: Start", __func__);
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, area)) {
 		if (IS_OSPF6_DEBUG_ABR)
@@ -285,7 +285,7 @@ static void ospf6_abr_announce_aggregates(struct ospf6 *ospf6)
 	}
 
 	if (IS_OSPF6_DEBUG_ABR)
-		zlog_debug("ospf6_abr_announce_aggregates(): Stop");
+		zlog_debug("%s: Stop", __func__);
 }
 
 /* Flush the summary LSA's which are not approved.*/
@@ -387,7 +387,7 @@ static void ospf6_abr_unapprove_translates(struct ospf6 *ospf6)
 	uint16_t type;
 
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug("ospf6_abr_unapprove_translates(): Start");
+		zlog_debug("%s: Start", __func__);
 
 	type = htons(OSPF6_LSTYPE_AS_EXTERNAL);
 	for (ALL_LSDB_TYPED(ospf6->lsdb, type, lsa)) {
@@ -401,7 +401,7 @@ static void ospf6_abr_unapprove_translates(struct ospf6 *ospf6)
 	}
 
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug("ospf6_abr_unapprove_translates(): Stop");
+		zlog_debug("%s: Stop", __func__);
 }
 
 /* Generate the translated external lsa  from NSSA lsa */
@@ -782,7 +782,7 @@ static void ospf6_abr_remove_unapproved_translates(struct ospf6 *ospf6)
 	/* All AREA PROCESS should have APPROVED necessary LSAs */
 	/* Remove any left over and not APPROVED */
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug("ospf6_abr_remove_unapproved_translates(): Start");
+		zlog_debug("%s: Start", __func__);
 
 	type = htons(OSPF6_LSTYPE_AS_EXTERNAL);
 	for (ALL_LSDB_TYPED(ospf6->lsdb, type, lsa)) {
@@ -797,7 +797,7 @@ static void ospf6_abr_remove_unapproved_translates(struct ospf6 *ospf6)
 	}
 
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug("ospf_abr_remove_unapproved_translates(): Stop");
+		zlog_debug("%s: Stop", __func__);
 }
 
 static void ospf6_abr_nssa_type_7_default_create(struct ospf6 *ospf6,
@@ -896,17 +896,17 @@ static void ospf6_abr_nssa_task(struct ospf6 *ospf6)
 
 	/* Each area must confirm TranslatorRole */
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug("ospf6_abr_nssa_task(): Start");
+		zlog_debug("%s: Start", __func__);
 
 	/* For all Global Entries flagged "local-translate", unset APPROVED */
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug("ospf6_abr_nssa_task(): unapprove translates");
+		zlog_debug("%s: unapprove translates", __func__);
 
 	ospf6_abr_unapprove_translates(ospf6);
 
 	/* Originate Type-7 aggregates */
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug("ospf6_abr_nssa_task(): send NSSA aggregates");
+		zlog_debug("%s: send NSSA aggregates", __func__);
 	ospf6_abr_send_nssa_aggregates(ospf6);
 
 	/* For all NSSAs, Type-7s, translate to 5's, INSTALL/FLOOD, or
@@ -914,17 +914,16 @@ static void ospf6_abr_nssa_task(struct ospf6 *ospf6)
 	 * Install or Approve in Type-5 Global LSDB
 	 */
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug("ospf6_abr_nssa_task(): process translates");
+		zlog_debug("%s: process translates", __func__);
 	ospf6_abr_process_nssa_translates(ospf6);
 
 	/* Flush any unapproved previous translates from Global Data Base */
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug(
-			"ospf6_abr_nssa_task(): remove unapproved translates");
+		zlog_debug("%s: remove unapproved translates", __func__);
 	ospf6_abr_remove_unapproved_translates(ospf6);
 
 	if (IS_OSPF6_DEBUG_NSSA)
-		zlog_debug("ospf6_abr_nssa_task(): Stop");
+		zlog_debug("%s: Stop", __func__);
 }
 
 int ospf6_redistribute_check(struct ospf6 *ospf6, struct ospf6_route *route,


### PR DESCRIPTION
Some cleaning mostly in the NSSA part. See individual commits

* 2f2bf3a23 - ospf6d: fix typos
* 034156428 - ospf6d: use \__func__
* 8eaf7c4ec - ospf6d: remove duplicated code
* 0c7006848 - ospf6d: remove double htons
* b80cebb3b - ospf6d: remove duplicated log
