### PR TITLE
ospf6d: LSA statistics

### DIFF
--- a/lib/json.h
+++ b/lib/json.h
@@ -42,6 +42,15 @@ extern "C" {
 	     json_object_iter_equal(&(joi), &(join)) == 0;                     \
 	     json_object_iter_next(&(joi)))
 
+#define JSON_OBJECT_NEW_ARRAY(json_func, fields, n)                            \
+	({                                                                     \
+		struct json_object *_json_array = json_object_new_array();     \
+		for (int _i = 0; _i < (n); _i++)                               \
+			json_object_array_add(_json_array,                     \
+					      (json_func)((fields)[_i]));      \
+		(_json_array);                                                 \
+	})
+
 extern bool use_json(const int argc, struct cmd_token *argv[]);
 extern void json_object_string_add(struct json_object *obj, const char *key,
 				   const char *s);

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -453,6 +453,11 @@ void ospf6_area_show(struct vty *vty, struct ospf6_area *oa,
 
 		json_object_int_add(json_area, "numberOfAreaScopedLsa",
 				    oa->lsdb->count);
+		json_object_object_add(
+			json_area, "lsaStatistics",
+			JSON_OBJECT_NEW_ARRAY(json_object_new_int,
+					      oa->lsdb->stats,
+					      OSPF6_LSTYPE_SIZE));
 
 		/* Interfaces Attached */
 		array_interfaces = json_object_new_array();

--- a/ospf6d/ospf6_lsdb.h
+++ b/ospf6d/ospf6_lsdb.h
@@ -29,6 +29,7 @@ struct ospf6_lsdb {
 	void *data; /* data structure that holds this lsdb */
 	struct route_table *table;
 	uint32_t count;
+	uint32_t stats[OSPF6_LSTYPE_SIZE];
 	void (*hook_add)(struct ospf6_lsa *);
 	void (*hook_remove)(struct ospf6_lsa *);
 };


### PR DESCRIPTION
The changes implement LSA type counters in the LSA database and add functionality to display those statistics in JSON output of `show area` commands.

Isolated feature of closed WIP PR #8547