### PR TITLE
pimd: IGMP messages may be longer than 8 octets

### DIFF
--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -173,10 +173,11 @@ int igmp_v2_recv_leave(struct gm_sock *igmp, struct ip *ip_hdr,
 		return 0;
 
 	if (igmp_msg_len != IGMP_V12_MSG_SIZE) {
-		zlog_warn(
-			"Recv IGMPv2 LEAVE from %s on %s: size=%d other than correct=%d",
-			from_str, ifp->name, igmp_msg_len, IGMP_V12_MSG_SIZE);
-		return -1;
+		if (PIM_DEBUG_IGMP_PACKETS)
+			zlog_debug(
+				"Recv IGMPv2 LEAVE from %s on %s: size=%d other than correct=%d",
+				from_str, ifp->name, igmp_msg_len,
+				IGMP_V12_MSG_SIZE);
 	}
 
 	if (igmp_validate_checksum(igmp_msg, igmp_msg_len) == -1) {

--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -115,10 +115,11 @@ int igmp_v2_recv_report(struct gm_sock *igmp, struct in_addr from,
 		return 0;
 
 	if (igmp_msg_len != IGMP_V12_MSG_SIZE) {
-		zlog_warn(
-			"Recv IGMPv2 REPORT from %s on %s: size=%d other than correct=%d",
-			from_str, ifp->name, igmp_msg_len, IGMP_V12_MSG_SIZE);
-		return -1;
+		if (PIM_DEBUG_IGMP_PACKETS)
+			zlog_debug(
+				"Recv IGMPv2 REPORT from %s on %s: size=%d other than correct=%d",
+				from_str, ifp->name, igmp_msg_len,
+				IGMP_V12_MSG_SIZE);
 	}
 
 	if (igmp_validate_checksum(igmp_msg, igmp_msg_len) == -1) {


### PR DESCRIPTION
Some of the older Cisco device is having IGMPv2 messages longer than 8 octets.
FRR drops these messages and hence forwarding gets impacted.
Also IGMP ANVL conformance test case 5.6 verifies this case.

Fixing the code as per RFC 2236 section 2.5:
        Note that IGMP messages may be longer than 8 octets, especially
        future backwards-compatible versions of IGMP.  As long as the Type is
        one that is recognized, an IGMPv2 implementation MUST ignore anything
        past the first 8 octets while processing the packet.  However, the
        IGMP checksum is always computed over the whole IP payload, not just
        over the first 8 octets.

Fixes: #10331 