### PR TITLE
bgpd: Show Long-lived Graceful Restart seconds remaining per prefix

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10725,6 +10725,19 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 				str, label2vni(&attr->label));
 	}
 
+	if (path->peer->t_llgr_stale[afi][safi] && attr->community &&
+	    community_include(attr->community, COMMUNITY_LLGR_STALE)) {
+		unsigned long llgr_remaining = thread_timer_remain_second(
+			path->peer->t_llgr_stale[afi][safi]);
+		if (json_paths) {
+			json_object_int_add(json_path, "llgrSecondsRemaining",
+					    llgr_remaining);
+		} else
+			vty_out(vty,
+				"      Time until Long-lived stale route deleted: %lu\n",
+				llgr_remaining);
+	}
+
 	/* Output some debug about internal state of the dest flags */
 	if (json_paths) {
 		if (CHECK_FLAG(bn->flags, BGP_NODE_PROCESS_SCHEDULED))

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10741,12 +10741,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 			json_object_boolean_true_add(json_path, "fibInstalled");
 		if (CHECK_FLAG(bn->flags, BGP_NODE_FIB_INSTALL_PENDING))
 			json_object_boolean_true_add(json_path, "fibPending");
-	}
 
-	/* We've constructed the json object for this path, add it to the json
-	 * array of paths
-	 */
-	if (json_paths) {
 		if (json_nexthop_global || json_nexthop_ll) {
 			json_nexthops = json_object_new_array();
 


### PR DESCRIPTION
```
exit1-debian-11# sh ip bgp 100.100.100.100/32
BGP routing table entry for 100.100.100.100/32, version 7
Paths: (2 available, best #2, table default)
  Advertised to non peer-group peers:
  home-spine1.donatas.net(192.168.0.2)
  65002, (stale)
    192.168.10.17 from donatas-pc(192.168.10.17) (0.0.0.0)
      Origin incomplete, valid, external
      Community: llgr-stale
      Last update: Thu Jan 13 08:58:08 2022
      Time until Long-lived stale route deleted: 18 <<<<<<<<<<<
  65001
    192.168.0.2 from home-spine1.donatas.net(192.168.0.2) (2.2.2.2)
      Origin incomplete, metric 0, valid, external, best (First path received)
      Last update: Thu Jan 13 08:57:56 2022
```

```
~# vtysh -c 'show ip bgp 100.100.100.100/32 json' | jq '."paths"[] | ."llgrSecondsRemaining"'
17
```