### PR TITLE
pim6d: drop off MSDP code

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3793,6 +3793,7 @@ static const char *pim_cli_get_vrf_name(struct vty *vty)
 	return yang_dnode_get_string(vrf_node, "./name");
 }
 
+#if PIM_IPV != 6
 /**
  * Compatibility function to keep the legacy mesh group CLI behavior:
  * Delete group when there are no more configurations in it.
@@ -3840,6 +3841,7 @@ static void pim_cli_legacy_mesh_group_behavior(struct vty *vty,
 	/* No configurations found: delete it. */
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_DESTROY, NULL);
 }
+#endif /* PIM_IPV != 6 */
 
 DEFUN (clear_ip_interfaces,
        clear_ip_interfaces_cmd,
@@ -9423,6 +9425,7 @@ ALIAS(no_ip_pim_bfd, no_ip_pim_bfd_param_cmd,
       "Desired min transmit interval\n")
 #endif /* !HAVE_BFDD */
 
+#if PIM_IPV != 6
 DEFPY(ip_msdp_peer, ip_msdp_peer_cmd,
       "ip msdp peer A.B.C.D$peer source A.B.C.D$source",
       IP_STR
@@ -10464,6 +10467,7 @@ DEFUN (show_ip_msdp_sa_sg_vrf_all,
 
 	return CMD_SUCCESS;
 }
+#endif /* PIM_IPV != 6 */
 
 struct pim_sg_cache_walk_data {
 	struct vty *vty;
@@ -10905,10 +10909,12 @@ void pim_cmd_init(void)
 	install_element(VRF_NODE, &ip_ssmpingd_cmd);
 	install_element(CONFIG_NODE, &no_ip_ssmpingd_cmd);
 	install_element(VRF_NODE, &no_ip_ssmpingd_cmd);
+#if PIM_IPV != 6
 	install_element(CONFIG_NODE, &ip_msdp_peer_cmd);
 	install_element(VRF_NODE, &ip_msdp_peer_cmd);
 	install_element(CONFIG_NODE, &no_ip_msdp_peer_cmd);
 	install_element(VRF_NODE, &no_ip_msdp_peer_cmd);
+#endif /* PIM_IPV != 6 */
 	install_element(CONFIG_NODE, &ip_pim_ecmp_cmd);
 	install_element(VRF_NODE, &ip_pim_ecmp_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_ecmp_cmd);
@@ -11077,12 +11083,14 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &no_debug_pim_mlag_cmd);
 	install_element(ENABLE_NODE, &debug_pim_vxlan_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_vxlan_cmd);
+#if PIM_IPV != 6
 	install_element(ENABLE_NODE, &debug_msdp_cmd);
 	install_element(ENABLE_NODE, &no_debug_msdp_cmd);
 	install_element(ENABLE_NODE, &debug_msdp_events_cmd);
 	install_element(ENABLE_NODE, &no_debug_msdp_events_cmd);
 	install_element(ENABLE_NODE, &debug_msdp_packets_cmd);
 	install_element(ENABLE_NODE, &no_debug_msdp_packets_cmd);
+#endif /* PIM_IPV != 6 */
 	install_element(ENABLE_NODE, &debug_mtrace_cmd);
 	install_element(ENABLE_NODE, &no_debug_mtrace_cmd);
 	install_element(ENABLE_NODE, &debug_bsm_cmd);
@@ -11124,17 +11132,20 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_debug_pim_mlag_cmd);
 	install_element(CONFIG_NODE, &debug_pim_vxlan_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_vxlan_cmd);
+#if PIM_IPV != 6
 	install_element(CONFIG_NODE, &debug_msdp_cmd);
 	install_element(CONFIG_NODE, &no_debug_msdp_cmd);
 	install_element(CONFIG_NODE, &debug_msdp_events_cmd);
 	install_element(CONFIG_NODE, &no_debug_msdp_events_cmd);
 	install_element(CONFIG_NODE, &debug_msdp_packets_cmd);
 	install_element(CONFIG_NODE, &no_debug_msdp_packets_cmd);
+#endif /* PIM_IPV != 6 */
 	install_element(CONFIG_NODE, &debug_mtrace_cmd);
 	install_element(CONFIG_NODE, &no_debug_mtrace_cmd);
 	install_element(CONFIG_NODE, &debug_bsm_cmd);
 	install_element(CONFIG_NODE, &no_debug_bsm_cmd);
 
+#if PIM_IPV != 6
 	install_element(CONFIG_NODE, &ip_msdp_timers_cmd);
 	install_element(VRF_NODE, &ip_msdp_timers_cmd);
 	install_element(CONFIG_NODE, &no_ip_msdp_timers_cmd);
@@ -11157,6 +11168,7 @@ void pim_cmd_init(void)
 	install_element(VIEW_NODE, &show_ip_msdp_sa_sg_vrf_all_cmd);
 	install_element(VIEW_NODE, &show_ip_msdp_mesh_group_cmd);
 	install_element(VIEW_NODE, &show_ip_msdp_mesh_group_vrf_all_cmd);
+#endif /* PIM_IPV != 6 */
 	install_element(VIEW_NODE, &show_ip_pim_ssm_range_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_group_type_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_vxlan_sg_cmd);

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -227,6 +227,7 @@ struct pim_msdp {
 #define PIM_MSDP_PEER_READ_OFF(mp) thread_cancel(&mp->t_read)
 #define PIM_MSDP_PEER_WRITE_OFF(mp) thread_cancel(&mp->t_write)
 
+#if PIM_IPV != 6
 // struct pim_msdp *msdp;
 struct pim_instance;
 void pim_msdp_init(struct pim_instance *pim, struct thread_master *master);
@@ -317,5 +318,51 @@ void pim_msdp_peer_del(struct pim_msdp_peer **mp);
  */
 void pim_msdp_peer_change_source(struct pim_msdp_peer *mp,
 				 const struct in_addr *addr);
+
+#else /* PIM_IPV == 6 */
+static inline void pim_msdp_init(struct pim_instance *pim,
+				 struct thread_master *master)
+{
+}
+
+static inline void pim_msdp_exit(struct pim_instance *pim)
+{
+}
+
+static inline void pim_msdp_i_am_rp_changed(struct pim_instance *pim)
+{
+}
+
+static inline void pim_msdp_up_join_state_changed(struct pim_instance *pim,
+						  struct pim_upstream *xg_up)
+{
+}
+
+static inline void pim_msdp_up_del(struct pim_instance *pim, pim_sgaddr *sg)
+{
+}
+
+static inline void pim_msdp_sa_local_update(struct pim_upstream *up)
+{
+}
+
+static inline void pim_msdp_sa_local_del(struct pim_instance *pim,
+					 pim_sgaddr *sg)
+{
+}
+
+static inline int pim_msdp_config_write(struct pim_instance *pim,
+					struct vty *vty, const char *spaces)
+{
+	return 0;
+}
+
+static inline bool pim_msdp_peer_config_write(struct vty *vty,
+					      struct pim_instance *pim,
+					      const char *spaces)
+{
+	return false;
+}
+#endif /* PIM_IPV == 6 */
 
 #endif

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -34,6 +34,22 @@
 #include "log.h"
 #include "lib_errors.h"
 
+#if PIM_IPV == 6
+#define pim6_msdp_err(funcname, argtype)                                       \
+int funcname(struct argtype *args)                                             \
+{                                                                              \
+	snprintf(args->errmsg, args->errmsg_len,                               \
+		 "Trying to configure MSDP in pim6d.  "                        \
+		 "MSDP does not exist for IPv6.");                             \
+	return NB_ERR_VALIDATION;                                              \
+}                                                                              \
+MACRO_REQUIRE_SEMICOLON()
+
+#else /* PIM_IPV != 6 */
+#define pim6_msdp_err(funcname, argtype)                                       \
+MACRO_REQUIRE_SEMICOLON()
+#endif /* PIM_IPV != 6 */
+
 static void pim_if_membership_clear(struct interface *ifp)
 {
 	struct pim_interface *pim_ifp;
@@ -1023,6 +1039,20 @@ int pim_msdp_connection_retry_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
+pim6_msdp_err(pim_msdp_mesh_group_destroy, nb_cb_destroy_args);
+pim6_msdp_err(pim_msdp_mesh_group_create, nb_cb_create_args);
+pim6_msdp_err(pim_msdp_mesh_group_source_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_mesh_group_source_destroy, nb_cb_destroy_args);
+pim6_msdp_err(pim_msdp_mesh_group_members_create, nb_cb_create_args);
+pim6_msdp_err(pim_msdp_mesh_group_members_destroy, nb_cb_destroy_args);
+pim6_msdp_err(routing_control_plane_protocols_control_plane_protocol_pim_address_family_msdp_peer_source_ip_modify,
+	      nb_cb_modify_args);
+pim6_msdp_err(routing_control_plane_protocols_control_plane_protocol_pim_address_family_msdp_peer_destroy,
+	      nb_cb_destroy_args);
+pim6_msdp_err(routing_control_plane_protocols_control_plane_protocol_pim_address_family_msdp_peer_create,
+	      nb_cb_create_args);
+
+#if PIM_IPV != 6
 /*
  * XPath:
  * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp-mesh-groups
@@ -1252,6 +1282,7 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ms
 
 	return NB_OK;
 }
+#endif /* PIM_IPV != 6 */
 
 /*
  * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/mlag

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -36,9 +36,6 @@ pim_common = \
 	pimd/pim_memory.c \
 	pimd/pim_mlag.c \
 	pimd/pim_mroute.c \
-	pimd/pim_msdp.c \
-	pimd/pim_msdp_packet.c \
-	pimd/pim_msdp_socket.c \
 	pimd/pim_msg.c \
 	pimd/pim_nb.c \
 	pimd/pim_nb_config.c \
@@ -70,6 +67,9 @@ pim_common = \
 pimd_pimd_SOURCES = \
 	$(pim_common) \
 	pimd/pim_main.c \
+	pimd/pim_msdp.c \
+	pimd/pim_msdp_packet.c \
+	pimd/pim_msdp_socket.c \
 	pimd/pim_signals.c \
 	# end
 


### PR DESCRIPTION
There is no MSDP for IPv6, so drop this code out of pim6d.