### PR TITLE
docs(bgp): refer to rfc9136 instead of draft

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2832,9 +2832,8 @@ at the same time.
 
 EVPN Overlay Index Gateway IP
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Draft https://tools.ietf.org/html/draft-ietf-bess-evpn-prefix-advertisement-11
-explains the use of overlay indexes for recursive route resolution for EVPN
-type-5 route.
+RFC https://datatracker.ietf.org/doc/html/rfc9136 explains the use of overlay
+indexes for recursive route resolution for EVPN type-5 route.
 
 We support gateway IP overlay index.
 A gateway IP, advertised with EVPN prefix route, is used to find an EVPN MAC/IP


### PR DESCRIPTION
Instead of referring to the draft of  IP Prefix Advertisement in Ethernet VPN let's point to the recently published RFC9136