### PR TITLE
bgpd: fix advertisedRoutes json key

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13821,7 +13821,11 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
 			       &output_count, &filtered_count);
 
 	if (use_json) {
-		json_object_object_add(json, "advertisedRoutes", json_ar);
+		if (type == bgp_show_adj_route_advertised)
+			json_object_object_add(json, "advertisedRoutes",
+					       json_ar);
+		else
+			json_object_object_add(json, "receivedRoutes", json_ar);
 		json_object_int_add(json, "totalPrefixCounter", output_count);
 		json_object_int_add(json, "filteredPrefixCounter",
 				    filtered_count);


### PR DESCRIPTION
'show bgp ... neighbor [routes|received-routes]' both incorrectly
used a json key of 'advertisedRoutes'.
This corrects the key to be 'receivedRoutes' for commands where
the displayed routes were received, not advertised.

before:
unet> r3 show ip bgp neigh 10.2.30.2 received-routes json | include Routes
  "advertisedRoutes":{

after:
ub18# show ip bgp neighbors enp1s0 received-routes json | include Routes
  "receivedRoutes":{
ub18# show ip bgp neighbors enp1s0 advertised-routes json | include Routes
  "advertisedRoutes":{

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>