### PR TITLE
zebra: Fix for route node having no tracking NHT

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -490,7 +490,8 @@ extern struct route_table *rib_tables_iter_next(rib_tables_iter_t *iter);
 
 extern uint8_t route_distance(int type);
 
-extern void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq);
+extern void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq,
+					   bool rt_delete);
 
 /*
  * Inline functions.


### PR DESCRIPTION
Topology:
IXIA-----(ens192)FRR(ens224)------iXIA

Configuration:
1. Create 8 sub-interfaces on ens192 under Default VRF and configure 8
EBGP session between FRR and IXIA.
2. Create 1000 sub-interfaces on ens224 under Default VRF and configure
1000 EBGP session between FRR and IXIA.
3. 2M prefixes distributed from Left side Ixia each with 8 ECMP path.
4. So in total, there are 2M prefixes * 8 ECMP = 16M prefixes entries
in RIB and FIB.

Issue:
Shut ens192 and ens224, this is taking 1hr 15 mins to clean up the routes.

Root Cause:
In the case of route deletion, if the particular route node is having
nht count = 0, we are going to the parent and doing nht evaluation,
which is not needed.

Fix:
If the deleted the route node is having nht count > 0, then do a nht
evaluation on the parent node.
Shut ens192 and ens224, it is taking 1 min to clean up the routes
with the fix.

Signed-off-by: Sarita Patra <saritap@vmware.com>