### PR TITLE
enable to transition to `SEGMENT_ROUTING_NODE` when pathd is disabled

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -4280,6 +4280,7 @@ void vtysh_init_vty(void)
 #endif /* HAVE_BFDD */
 
 	install_node(&segment_routing_node);
+	install_element(CONFIG_NODE, &segment_routing_cmd);
 	install_element(SEGMENT_ROUTING_NODE, &vtysh_exit_sr_cmd);
 	install_element(SEGMENT_ROUTING_NODE, &vtysh_quit_sr_cmd);
 	install_element(SEGMENT_ROUTING_NODE, &vtysh_end_all_cmd);
@@ -4305,7 +4306,6 @@ void vtysh_init_vty(void)
 	install_element(SR_POLICY_NODE, &vtysh_end_all_cmd);
 	install_element(SR_CANDIDATE_DYN_NODE, &vtysh_end_all_cmd);
 
-	install_element(CONFIG_NODE, &segment_routing_cmd);
 	install_element(SEGMENT_ROUTING_NODE, &sr_traffic_eng_cmd);
 	install_element(SR_TRAFFIC_ENG_NODE, &srte_segment_list_cmd);
 	install_element(SR_TRAFFIC_ENG_NODE, &srte_policy_cmd);


### PR DESCRIPTION
Currently `segment_routing_cmd` is not installed but defined when FRR configured with `--disable-pathd`.
but `SEGMENT_ROUTING_NODE` is used Zebra SRv6 Manager too.
so this patch enables `SEGMENT_ROUTING_NODE` when FRR configured with `--disable-pathd`.

In Cisco's CLI, `SRV6_NODE` is directly installed on `CONFIG_NODE` .  
I'll contribute to make SRv6 Manager to follow Cisco's CLI as another PR after this PR will be merged.
reference: <https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/asr9k-r7-3/segment-routing/configuration/guide/b-segment-routing-cg-asr9000-73x/m-configure-srv6-usid.html?referring_site=RE&pos=1&page=https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/asr9k-r6-6/segment-routing/configuration/guide/b-segment-routing-cg-asr9000-66x/b-segment-routing-cg-asr9000-66x_chapter_011.html>

## AS-IS

if I configure FRR with `--disable-pathd`, srv6_locator topotest fails.

```
root:~/frr/tests/topotests/srv6_locator# git show HEAD
commit 2aa2e5932076a1f8dd641056a2f27cd7bd36f4af (HEAD -> master, upstream/master)
Merge: bf2209ec0 c1984955b
Author: David Lamparter <equinox@opensourcerouting.org>
Date:   Sat Jan 15 17:23:55 2022 +0100

    Merge pull request #10343 from taspelund/fix_receivedRoutes_string

root:~/frr.drumato/tests/topotests/srv6_locator# ./test_srv6_locator.py --topology-only
============================================================================== test session starts ===============================================================================
platform linux -- Python 3.8.0, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /root/frr.drumato/tests/topotests, configfile: pytest.ini
collected 1 item

test_srv6_locator.py
--- Micronet CLI Starting ---


unet> r1 sh daemons
 zebra bgpd sharpd staticd

unet> sh r1 vtysh -c "conf te" -c "segment-routing"
% Unknown command: segment-routing
```

## TO-BE

srv6_locator topotest will pass when FRR is configured with `--disable-pathd`.

```
root:~/frr/tests/topotests/srv6_locator# git show HEAD
commit a120c63f142ccd6e96b3ac7876030db29396b5a8 (HEAD -> fix-zebra-srv6-segment-routing-block)
Author: Yamato Sugawara <yamato.sugawara@linecorp.com>
Date:   Sun Jan 16 04:08:47 2022 +0000

    zebra: fix `segment-routing` command not found error with `--disable-pathd`

    Signed-off-by: Yamato Sugawara <yamato.sugawara@linecorp.com>

diff --git a/vtysh/vtysh.c b/vtysh/vtysh.c
index c56b72fcb..32088344d 100644
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -4284,6 +4284,7 @@ void vtysh_init_vty(void)
        install_element(SEGMENT_ROUTING_NODE, &vtysh_quit_sr_cmd);
        install_element(SEGMENT_ROUTING_NODE, &vtysh_end_all_cmd);

+       install_element(CONFIG_NODE, &segment_routing_cmd);
 #if defined(HAVE_PATHD)
        install_node(&sr_traffic_eng_node);
        install_node(&srte_segment_list_node);
@@ -4305,7 +4306,6 @@ void vtysh_init_vty(void)
        install_element(SR_POLICY_NODE, &vtysh_end_all_cmd);
        install_element(SR_CANDIDATE_DYN_NODE, &vtysh_end_all_cmd);

-       install_element(CONFIG_NODE, &segment_routing_cmd);
        install_element(SEGMENT_ROUTING_NODE, &sr_traffic_eng_cmd);
        install_element(SR_TRAFFIC_ENG_NODE, &srte_segment_list_cmd);
        install_element(SR_TRAFFIC_ENG_NODE, &srte_policy_cmd);
root:~/frr/tests/topotests/srv6_locator# ./test_srv6_locator.py --topology-only
============================================================================== test session starts ===============================================================================
platform linux -- Python 3.8.0, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /root/frr.drumato/tests/topotests, configfile: pytest.ini
collected 1 item

test_srv6_locator.py
--- Micronet CLI Starting ---


unet> r1 sh daemons
 zebra bgpd sharpd staticd

unet> sh r1 vtysh -c "conf t" -c "segment-routing"
```

Signed-off-by: Yamato Sugawara <yamato.sugawara@linecorp.com>