### PR TITLE
lib, zebra: make startup less noisy

### DIFF
--- a/lib/yang.c
+++ b/lib/yang.c
@@ -49,6 +49,11 @@ static LY_ERR yang_module_imp_clb(const char *mod_name, const char *mod_rev,
 {
 	struct yang_module_embed *e;
 
+	if (!strcmp(mod_name, "ietf-inet-types") ||
+	    !strcmp(mod_name, "ietf-yang-types"))
+		/* libyang has these built in, don't try finding them here */
+		return LY_ENOTFOUND;
+
 	for (e = embeds; e; e = e->next) {
 		if (e->sub_mod_name && submod_name) {
 			if (strcmp(e->sub_mod_name, submod_name))

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -271,9 +271,6 @@ static int netlink_recvbuf(struct nlsock *nl, uint32_t newsize)
 			     safe_strerror(errno));
 		return -1;
 	}
-
-	zlog_info("Setting netlink socket receive buffer size: %u -> %u",
-		  oldsize, newsize);
 	return 0;
 }
 


### PR DESCRIPTION
Removes 2-pack of noisy log messages printed at startup: (both are printed multiple times)

```
2022/01/17 09:47:55 ZEBRA: [HG1WF-2N96F] YANG model "ietf-inet-types@*" "*@*"not embedded, trying external file
2022/01/17 09:47:55 ZEBRA: [VMBPM-Q87BB] Setting netlink socket receive buffer size: 212992 -> 8388608
```

Neither of these is something that should trigger user attention.