### PR TITLE
lib/clippy: don't endian-convert twice

### DIFF
--- a/lib/elf_py.c
+++ b/lib/elf_py.c
@@ -1071,26 +1071,25 @@ static void elffile_add_dynreloc(struct elffile *w, Elf_Data *reldata,
 			 * always be a pointer...
 			 */
 			if (elffile_virt2file(w, rel->r_offset, &offs)) {
-				Elf_Data *ptr, *conv;
-				GElf_Addr tmp;
-				Elf_Data mem = {
-					.d_buf = (void *)&tmp,
-					.d_type = ELF_T_ADDR,
-					.d_version = EV_CURRENT,
-					.d_size = sizeof(tmp),
-					.d_off = 0,
-					.d_align = 0,
-				};
+				Elf_Data *ptr;
 
+				/* NB: this endian-converts! */
 				ptr = elf_getdata_rawchunk(w->elf, offs,
 							   w->elfclass / 8,
 							   ELF_T_ADDR);
 
-				conv = gelf_xlatetom(w->elf, &mem, ptr,
-						     w->mmap[EI_DATA]);
-				if (conv) {
-					memcpy(&rel_offs, conv->d_buf,
-					       conv->d_size);
+				if (ptr) {
+					char *dst = (char *)&rel_offs;
+
+					/* sigh.  it endian-converts.  but
+					 * doesn't size-convert.
+					 */
+					if (BYTE_ORDER == BIG_ENDIAN &&
+					    ptr->d_size < sizeof(rel_offs))
+						dst += sizeof(rel_offs) -
+						       ptr->d_size;
+
+					memcpy(dst, ptr->d_buf, ptr->d_size);
 
 					relw->relative = false;
 					relw->rela->r_addend = rel_offs;


### PR DESCRIPTION
elf_getdata_rawchunk() already endian-converts; doing it again is, uh,
counterproductive.

Fixes: #10051

[this will need to be backported]