### PR TITLE
bfdd: fix the possibly wrong counter of control packets

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -639,8 +639,6 @@ int bfd_recv_cb(struct thread *t)
 		return 0;
 	}
 
-	bfd->stats.rx_ctrl_pkt++;
-
 	/*
 	 * Multi hop: validate packet TTL.
 	 * Single hop: set local address that received the packet.
@@ -655,6 +653,8 @@ int bfd_recv_cb(struct thread *t)
 	} else if (bfd->local_address.sa_sin.sin_family == AF_UNSPEC) {
 		bfd->local_address = local;
 	}
+
+	bfd->stats.rx_ctrl_pkt++;
 
 	/*
 	 * If no interface was detected, save the interface where the


### PR DESCRIPTION
Just correct one small statistics problem of bfd control packets.
Please refer to commit.