### PR TITLE
pim6d: Adding new MLD Config CLI

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -625,6 +625,29 @@ DEFPY (interface_no_ipv6_mld_query_interval,
 				    "frr-routing:ipv6");
 }
 
+DEFPY (interface_ipv6_mld_query_max_response_time,
+       interface_ipv6_mld_query_max_response_time_cmd,
+       "ipv6 mld query-max-response-time (1-65535)$qmrt",
+       IPV6_STR
+       IFACE_MLD_STR
+       IFACE_MLD_QUERY_MAX_RESPONSE_TIME_STR
+       "Query response value in deci-seconds\n")
+{
+	return gm_process_query_max_response_time_cmd(vty, qmrt_str);
+}
+
+DEFPY (interface_no_ipv6_mld_query_max_response_time,
+       interface_no_ipv6_mld_query_max_response_time_cmd,
+       "no ipv6 mld query-max-response-time [(1-65535)]",
+       NO_STR
+       IPV6_STR
+       IFACE_MLD_STR
+       IFACE_MLD_QUERY_MAX_RESPONSE_TIME_STR
+       IGNORED_IN_NO_STR)
+{
+	return gm_process_no_query_max_response_time_cmd(vty);
+}
+
 DEFPY (show_ipv6_pim_rp,
        show_ipv6_pim_rp_cmd,
        "show ipv6 pim [vrf NAME] rp-info [X:X::X:X/M$group] [json$json]",
@@ -1501,6 +1524,11 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_ipv6_mld_query_interval_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ipv6_mld_query_interval_cmd);
+	install_element(INTERFACE_NODE,
+			&interface_ipv6_mld_query_max_response_time_cmd);
+	install_element(INTERFACE_NODE,
+			&interface_no_ipv6_mld_query_max_response_time_cmd);
+
 	install_element(VIEW_NODE, &show_ipv6_pim_rp_cmd);
 	install_element(VIEW_NODE, &show_ipv6_pim_rp_vrf_all_cmd);
 	install_element(VIEW_NODE, &show_ipv6_pim_rpf_cmd);

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -671,6 +671,29 @@ DEFPY (interface_no_ipv6_mld_last_member_query_count,
 	return gm_process_no_last_member_query_count_cmd(vty);
 }
 
+DEFPY (interface_ipv6_mld_last_member_query_interval,
+       interface_ipv6_mld_last_member_query_interval_cmd,
+       "ipv6 mld last-member-query-interval (1-65535)$lmqi",
+       IPV6_STR
+       IFACE_MLD_STR
+       IFACE_MLD_LAST_MEMBER_QUERY_INTERVAL_STR
+       "Last member query interval in deciseconds\n")
+{
+	return gm_process_last_member_query_interval_cmd(vty, lmqi_str);
+}
+
+DEFPY (interface_no_ipv6_mld_last_member_query_interval,
+       interface_no_ipv6_mld_last_member_query_interval_cmd,
+       "no ipv6 mld last-member-query-interval [(1-65535)]",
+       NO_STR
+       IPV6_STR
+       IFACE_MLD_STR
+       IFACE_MLD_LAST_MEMBER_QUERY_INTERVAL_STR
+       IGNORED_IN_NO_STR)
+{
+	return gm_process_no_last_member_query_interval_cmd(vty);
+}
+
 DEFPY (show_ipv6_pim_rp,
        show_ipv6_pim_rp_cmd,
        "show ipv6 pim [vrf NAME] rp-info [X:X::X:X/M$group] [json$json]",
@@ -1555,6 +1578,10 @@ void pim_cmd_init(void)
 			&interface_ipv6_mld_last_member_query_count_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ipv6_mld_last_member_query_count_cmd);
+	install_element(INTERFACE_NODE,
+			&interface_ipv6_mld_last_member_query_interval_cmd);
+	install_element(INTERFACE_NODE,
+			&interface_no_ipv6_mld_last_member_query_interval_cmd);
 
 	install_element(VIEW_NODE, &show_ipv6_pim_rp_cmd);
 	install_element(VIEW_NODE, &show_ipv6_pim_rp_vrf_all_cmd);

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -648,6 +648,29 @@ DEFPY (interface_no_ipv6_mld_query_max_response_time,
 	return gm_process_no_query_max_response_time_cmd(vty);
 }
 
+DEFPY (interface_ipv6_mld_last_member_query_count,
+       interface_ipv6_mld_last_member_query_count_cmd,
+       "ipv6 mld last-member-query-count (1-255)$lmqc",
+       IPV6_STR
+       IFACE_MLD_STR
+       IFACE_MLD_LAST_MEMBER_QUERY_COUNT_STR
+       "Last member query count\n")
+{
+	return gm_process_last_member_query_count_cmd(vty, lmqc_str);
+}
+
+DEFPY (interface_no_ipv6_mld_last_member_query_count,
+       interface_no_ipv6_mld_last_member_query_count_cmd,
+       "no ipv6 mld last-member-query-count [(1-255)]",
+       NO_STR
+       IPV6_STR
+       IFACE_MLD_STR
+       IFACE_MLD_LAST_MEMBER_QUERY_COUNT_STR
+       IGNORED_IN_NO_STR)
+{
+	return gm_process_no_last_member_query_count_cmd(vty);
+}
+
 DEFPY (show_ipv6_pim_rp,
        show_ipv6_pim_rp_cmd,
        "show ipv6 pim [vrf NAME] rp-info [X:X::X:X/M$group] [json$json]",
@@ -1528,6 +1551,10 @@ void pim_cmd_init(void)
 			&interface_ipv6_mld_query_max_response_time_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ipv6_mld_query_max_response_time_cmd);
+	install_element(INTERFACE_NODE,
+			&interface_ipv6_mld_last_member_query_count_cmd);
+	install_element(INTERFACE_NODE,
+			&interface_no_ipv6_mld_last_member_query_count_cmd);
 
 	install_element(VIEW_NODE, &show_ipv6_pim_rp_cmd);
 	install_element(VIEW_NODE, &show_ipv6_pim_rp_vrf_all_cmd);

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -625,6 +625,33 @@ DEFPY (interface_no_ipv6_mld_query_interval,
 				    "frr-routing:ipv6");
 }
 
+DEFPY (mld_group_watermark,
+       mld_group_watermark_cmd,
+       "ipv6 mld watermark-warn (1-65535)$limit",
+       IPV6_STR
+       MLD_STR
+       "Configure group limit for watermark warning\n"
+       "Group count to generate watermark warning\n")
+{
+	PIM_DECLVAR_CONTEXT(vrf, pim);
+	/* TBD Depends on MLD data structure changes */
+	return CMD_SUCCESS;
+}
+
+DEFPY (no_mld_group_watermark,
+       no_mld_group_watermark_cmd,
+       "no ipv6 mld watermark-warn [(1-65535)$limit]",
+       NO_STR
+       IPV6_STR
+       MLD_STR
+       "Unconfigure group limit for watermark warning\n"
+       IGNORED_IN_NO_STR)
+{
+	PIM_DECLVAR_CONTEXT(vrf, pim);
+	/* TBD Depends on MLD data structure changes */
+	return CMD_SUCCESS;
+}
+
 DEFPY (interface_ipv6_mld_query_max_response_time,
        interface_ipv6_mld_query_max_response_time_cmd,
        "ipv6 mld query-max-response-time (1-65535)$qmrt",
@@ -1570,6 +1597,10 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_ipv6_mld_query_interval_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ipv6_mld_query_interval_cmd);
+	install_element(CONFIG_NODE, &mld_group_watermark_cmd);
+	install_element(VRF_NODE, &mld_group_watermark_cmd);
+	install_element(CONFIG_NODE, &no_mld_group_watermark_cmd);
+	install_element(VRF_NODE, &no_mld_group_watermark_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_ipv6_mld_query_max_response_time_cmd);
 	install_element(INTERFACE_NODE,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5756,34 +5756,15 @@ DEFUN (interface_no_ip_igmp_last_member_query_count,
 	return gm_process_no_last_member_query_count_cmd(vty);
 }
 
-DEFUN (interface_ip_igmp_last_member_query_interval,
+DEFPY (interface_ip_igmp_last_member_query_interval,
        interface_ip_igmp_last_member_query_interval_cmd,
-       "ip igmp last-member-query-interval (1-65535)",
+       "ip igmp last-member-query-interval (1-65535)$lmqi",
        IP_STR
        IFACE_IGMP_STR
        IFACE_IGMP_LAST_MEMBER_QUERY_INTERVAL_STR
        "Last member query interval in deciseconds\n")
 {
-	const struct lyd_node *pim_enable_dnode;
-
-	pim_enable_dnode =
-		yang_dnode_getf(vty->candidate_config->dnode,
-				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
-				"frr-routing:ipv4");
-	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
-				      "true");
-	} else {
-		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./enable",
-					      NB_OP_MODIFY, "true");
-	}
-
-	nb_cli_enqueue_change(vty, "./last-member-query-interval", NB_OP_MODIFY,
-			      argv[3]->arg);
-
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	return gm_process_last_member_query_interval_cmd(vty, lmqi_str);
 }
 
 DEFUN (interface_no_ip_igmp_last_member_query_interval,
@@ -5795,11 +5776,7 @@ DEFUN (interface_no_ip_igmp_last_member_query_interval,
        IFACE_IGMP_LAST_MEMBER_QUERY_INTERVAL_STR
        IGNORED_IN_NO_STR)
 {
-	nb_cli_enqueue_change(vty, "./last-member-query-interval",
-			      NB_OP_DESTROY, NULL);
-
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	return gm_process_no_last_member_query_interval_cmd(vty);
 }
 
 DEFUN (interface_ip_pim_drprio,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5733,34 +5733,15 @@ DEFUN_HIDDEN (interface_no_ip_igmp_query_max_response_time_dsec,
 				    "frr-routing:ipv4");
 }
 
-DEFUN (interface_ip_igmp_last_member_query_count,
+DEFPY (interface_ip_igmp_last_member_query_count,
        interface_ip_igmp_last_member_query_count_cmd,
-       "ip igmp last-member-query-count (1-255)",
+       "ip igmp last-member-query-count (1-255)$lmqc",
        IP_STR
        IFACE_IGMP_STR
        IFACE_IGMP_LAST_MEMBER_QUERY_COUNT_STR
        "Last member query count\n")
 {
-	const struct lyd_node *pim_enable_dnode;
-
-	pim_enable_dnode =
-		yang_dnode_getf(vty->candidate_config->dnode,
-				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
-				"frr-routing:ipv4");
-	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
-				      "true");
-	} else {
-		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./enable",
-					      NB_OP_MODIFY, "true");
-	}
-
-	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_MODIFY,
-			      argv[3]->arg);
-
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	return gm_process_last_member_query_count_cmd(vty, lmqc_str);
 }
 
 DEFUN (interface_no_ip_igmp_last_member_query_count,
@@ -5772,11 +5753,7 @@ DEFUN (interface_no_ip_igmp_last_member_query_count,
        IFACE_IGMP_LAST_MEMBER_QUERY_COUNT_STR
        IGNORED_IN_NO_STR)
 {
-	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_DESTROY,
-			      NULL);
-
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	return gm_process_no_last_member_query_count_cmd(vty);
 }
 
 DEFUN (interface_ip_igmp_last_member_query_interval,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5664,35 +5664,15 @@ DEFUN (interface_no_ip_igmp_version,
 				    "frr-routing:ipv4");
 }
 
-DEFUN (interface_ip_igmp_query_max_response_time,
+DEFPY (interface_ip_igmp_query_max_response_time,
        interface_ip_igmp_query_max_response_time_cmd,
-       "ip igmp query-max-response-time (1-65535)",
+       "ip igmp query-max-response-time (1-65535)$qmrt",
        IP_STR
        IFACE_IGMP_STR
        IFACE_IGMP_QUERY_MAX_RESPONSE_TIME_STR
        "Query response value in deci-seconds\n")
 {
-	const struct lyd_node *pim_enable_dnode;
-
-	pim_enable_dnode =
-		yang_dnode_getf(vty->candidate_config->dnode,
-				FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
-				"frr-routing:ipv4");
-
-	if (!pim_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
-				      "true");
-	} else {
-		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./enable",
-					      NB_OP_MODIFY, "true");
-	}
-
-	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_MODIFY,
-			      argv[3]->arg);
-
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	return gm_process_query_max_response_time_cmd(vty, qmrt_str);
 }
 
 DEFUN (interface_no_ip_igmp_query_max_response_time,
@@ -5704,10 +5684,7 @@ DEFUN (interface_no_ip_igmp_query_max_response_time,
        IFACE_IGMP_QUERY_MAX_RESPONSE_TIME_STR
        IGNORED_IN_NO_STR)
 {
-	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_DESTROY,
-			      NULL);
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	return gm_process_no_query_max_response_time_cmd(vty);
 }
 
 DEFUN_HIDDEN (interface_ip_igmp_query_max_response_time_dsec,

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -2780,3 +2780,33 @@ int gm_process_no_query_max_response_time_cmd(struct vty *vty)
 	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
 				    FRR_PIM_AF_XPATH_VAL);
 }
+
+int gm_process_last_member_query_count_cmd(struct vty *vty,
+					   const char *lmqc_str)
+{
+	const struct lyd_node *pim_enable_dnode;
+
+	pim_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
+					   FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
+					   FRR_PIM_AF_XPATH_VAL);
+	if (!pim_enable_dnode) {
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY, "true");
+	} else {
+		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
+			nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
+					      "true");
+	}
+
+	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_MODIFY,
+			      lmqc_str);
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}
+
+int gm_process_no_last_member_query_count_cmd(struct vty *vty)
+{
+	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_DESTROY,
+			      NULL);
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -2810,3 +2810,33 @@ int gm_process_no_last_member_query_count_cmd(struct vty *vty)
 	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
 				    FRR_PIM_AF_XPATH_VAL);
 }
+
+int gm_process_last_member_query_interval_cmd(struct vty *vty,
+					      const char *lmqi_str)
+{
+	const struct lyd_node *pim_enable_dnode;
+
+	pim_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
+					   FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
+					   FRR_PIM_AF_XPATH_VAL);
+	if (!pim_enable_dnode) {
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY, "true");
+	} else {
+		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
+			nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
+					      "true");
+	}
+
+	nb_cli_enqueue_change(vty, "./last-member-query-interval", NB_OP_MODIFY,
+			      lmqi_str);
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}
+
+int gm_process_no_last_member_query_interval_cmd(struct vty *vty)
+{
+	nb_cli_enqueue_change(vty, "./last-member-query-interval",
+			      NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -2749,3 +2749,34 @@ void pim_show_neighbors(struct pim_instance *pim, struct vty *vty,
 		}
 	}
 }
+
+int gm_process_query_max_response_time_cmd(struct vty *vty,
+					   const char *qmrt_str)
+{
+	const struct lyd_node *pim_enable_dnode;
+
+	pim_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
+					   FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
+					   FRR_PIM_AF_XPATH_VAL);
+
+	if (!pim_enable_dnode) {
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY, "true");
+	} else {
+		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
+			nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
+					      "true");
+	}
+
+	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_MODIFY,
+			      qmrt_str);
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}
+
+int gm_process_no_query_max_response_time_cmd(struct vty *vty)
+{
+	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_DESTROY,
+			      NULL);
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -111,4 +111,12 @@ int gm_process_no_last_member_query_interval_cmd(struct vty *vty);
 		(vrf) ? vrf->info : pim_get_pim_instance(VRF_DEFAULT);         \
 	vrf = (vrf) ? vrf : pim->vrf
 
+/*
+ * Special Macro to allow us to get the correct pim_instance;
+ */
+#define PIM_DECLVAR_CONTEXT(A, B)                                              \
+	struct vrf *A = VTY_GET_CONTEXT(vrf);                                  \
+	struct pim_instance *B =                                               \
+		(vrf) ? vrf->info : pim_get_pim_instance(VRF_DEFAULT);         \
+	vrf = (vrf) ? vrf : pim->vrf
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -93,6 +93,9 @@ void pim_show_neighbors_single(struct pim_instance *pim, struct vty *vty,
 			       const char *neighbor, json_object *json);
 void pim_show_neighbors(struct pim_instance *pim, struct vty *vty,
 			json_object *json);
+int gm_process_query_max_response_time_cmd(struct vty *vty,
+					   const char *qmrt_str);
+int gm_process_no_query_max_response_time_cmd(struct vty *vty);
 /*
  * Special Macro to allow us to get the correct pim_instance
  */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -96,6 +96,9 @@ void pim_show_neighbors(struct pim_instance *pim, struct vty *vty,
 int gm_process_query_max_response_time_cmd(struct vty *vty,
 					   const char *qmrt_str);
 int gm_process_no_query_max_response_time_cmd(struct vty *vty);
+int gm_process_last_member_query_count_cmd(struct vty *vty,
+					   const char *lmqc_str);
+int gm_process_no_last_member_query_count_cmd(struct vty *vty);
 /*
  * Special Macro to allow us to get the correct pim_instance
  */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -99,6 +99,9 @@ int gm_process_no_query_max_response_time_cmd(struct vty *vty);
 int gm_process_last_member_query_count_cmd(struct vty *vty,
 					   const char *lmqc_str);
 int gm_process_no_last_member_query_count_cmd(struct vty *vty);
+int gm_process_last_member_query_interval_cmd(struct vty *vty,
+					      const char *lmqi_str);
+int gm_process_no_last_member_query_interval_cmd(struct vty *vty);
 /*
  * Special Macro to allow us to get the correct pim_instance
  */

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -409,7 +409,6 @@ static void igmp_sock_query_interval_reconfig(struct gm_sock *igmp)
 	 */
 	igmp_startup_mode_on(igmp);
 }
-#endif
 
 static void igmp_sock_query_reschedule(struct gm_sock *igmp)
 {
@@ -439,6 +438,7 @@ static void igmp_sock_query_reschedule(struct gm_sock *igmp)
 		assert(igmp->t_other_querier_timer);
 	}
 }
+#endif /* PIM_IPV == 4 */
 
 #if PIM_IPV == 4
 static void change_query_interval(struct pim_interface *pim_ifp,
@@ -456,6 +456,7 @@ static void change_query_interval(struct pim_interface *pim_ifp,
 }
 #endif
 
+#if PIM_IPV == 4
 static void change_query_max_response_time(struct pim_interface *pim_ifp,
 		int query_max_response_time_dsec)
 {
@@ -503,6 +504,7 @@ static void change_query_max_response_time(struct pim_interface *pim_ifp,
 		}
 	}
 }
+#endif
 
 int routing_control_plane_protocols_name_validate(
 	struct nb_cb_create_args *args)
@@ -2733,6 +2735,7 @@ int lib_interface_gmp_address_family_query_interval_modify(
 int lib_interface_gmp_address_family_query_max_response_time_modify(
 	struct nb_cb_modify_args *args)
 {
+#if PIM_IPV == 4
 	struct interface *ifp;
 	int query_max_response_time_dsec;
 
@@ -2748,6 +2751,10 @@ int lib_interface_gmp_address_family_query_max_response_time_modify(
 		change_query_max_response_time(ifp->info,
 				query_max_response_time_dsec);
 	}
+#else
+	/* TBD Depends on MLD data structure changes */
+#endif
+
 
 	return NB_OK;
 }

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2765,6 +2765,7 @@ int lib_interface_gmp_address_family_query_max_response_time_modify(
 int lib_interface_gmp_address_family_last_member_query_interval_modify(
 	struct nb_cb_modify_args *args)
 {
+#if PIM_IPV == 4
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
 	int last_member_query_interval;
@@ -2784,6 +2785,9 @@ int lib_interface_gmp_address_family_last_member_query_interval_modify(
 
 		break;
 	}
+#else
+	/* TBD Depends on MLD data structure changes */
+#endif
 
 	return NB_OK;
 }

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2794,6 +2794,7 @@ int lib_interface_gmp_address_family_last_member_query_interval_modify(
 int lib_interface_gmp_address_family_robustness_variable_modify(
 	struct nb_cb_modify_args *args)
 {
+#if PIM_IPV == 4
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
 	int last_member_query_count;
@@ -2812,6 +2813,9 @@ int lib_interface_gmp_address_family_robustness_variable_modify(
 
 		break;
 	}
+#else
+	/* TBD Depends on MLD data structure changes */
+#endif
 
 	return NB_OK;
 }


### PR DESCRIPTION
Adding the Interface level config CLI for IPV6 MLD

[no] ipv6 mld query-max-response-time,
[no] ipv6 mld last-member-query-interval,
[no] ipv6 mld last-member-query-count,
[no] ipv6 mld watermark-warn