### PR TITLE
pimd: bump pim cli XPath buffers size

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7859,7 +7859,7 @@ DEFUN (interface_no_ip_igmp,
        IFACE_IGMP_STR)
 {
 	const struct lyd_node *pim_enable_dnode;
-	char pim_if_xpath[XPATH_MAXLEN + 20];
+	char pim_if_xpath[XPATH_MAXLEN + 128];
 
 	snprintf(pim_if_xpath, sizeof(pim_if_xpath),
 		 "%s/frr-pim:pim/address-family[address-family='%s']",
@@ -8406,7 +8406,7 @@ DEFUN_HIDDEN (interface_no_ip_pim_ssm,
 	      IFACE_PIM_STR)
 {
 	const struct lyd_node *igmp_enable_dnode;
-	char igmp_if_xpath[XPATH_MAXLEN + 20];
+	char igmp_if_xpath[XPATH_MAXLEN + 128];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
 		 "%s/frr-gmp:gmp/address-family[address-family='%s']",
@@ -8441,7 +8441,7 @@ DEFUN_HIDDEN (interface_no_ip_pim_sm,
 	      IFACE_PIM_SM_STR)
 {
 	const struct lyd_node *igmp_enable_dnode;
-	char igmp_if_xpath[XPATH_MAXLEN + 20];
+	char igmp_if_xpath[XPATH_MAXLEN + 128];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
 		 "%s/frr-gmp:gmp/address-family[address-family='%s']",
@@ -8477,7 +8477,7 @@ DEFUN (interface_no_ip_pim,
        PIM_STR)
 {
 	const struct lyd_node *igmp_enable_dnode;
-	char igmp_if_xpath[XPATH_MAXLEN + 20];
+	char igmp_if_xpath[XPATH_MAXLEN + 128];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
 		 "%s/frr-gmp:gmp/address-family[address-family='%s']",


### PR DESCRIPTION
Bump the size of the buffers so the new compilers don't complain about
possible truncation:

Trying to fix the below truncation issues.

pimd/pim_cmd.c: In function ‘interface_no_ip_igmp’:
pimd/pim_cmd.c:7865:7: error: ‘/frr-pim:pim/address-family[...’ directive output may be truncated writing 44 bytes into a region of size between 21 and 1044 [-Werror=format-truncation=]
 7865 |    "%s/frr-pim:pim/address-family[address-family='%s']",
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pimd/pim_cmd.c:7864:2: note: ‘snprintf’ output between 63 and 1086 bytes into a destination of size 1044
 7864 |  snprintf(pim_if_xpath, sizeof(pim_if_xpath),
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 7865 |    "%s/frr-pim:pim/address-family[address-family='%s']",
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 7866 |    VTY_CURR_XPATH, "frr-routing:ipv4");
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pimd/pim_cmd.c: In function ‘interface_no_ip_pim_ssm’:
pimd/pim_cmd.c:8412:7: error: ‘/frr-gmp:gmp/address-family[...’ directive output may be truncated writing 44 bytes into a region of size between 21 and 1044 [-Werror=format-truncation=]
 8412 |    "%s/frr-gmp:gmp/address-family[address-family='%s']",
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pimd/pim_cmd.c:8411:2: note: ‘snprintf’ output between 63 and 1086 bytes into a destination of size 1044
 8411 |  snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 8412 |    "%s/frr-gmp:gmp/address-family[address-family='%s']",
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 8413 |    VTY_CURR_XPATH, "frr-routing:ipv4");
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pimd/pim_cmd.c: In function ‘interface_no_ip_pim_sm’:
pimd/pim_cmd.c:8447:7: error: ‘/frr-gmp:gmp/address-family[...’ directive output may be truncated writing 44 bytes into a region of size between 21 and 1044 [-Werror=format-truncation=]
 8447 |    "%s/frr-gmp:gmp/address-family[address-family='%s']",
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pimd/pim_cmd.c:8446:2: note: ‘snprintf’ output between 63 and 1086 bytes into a destination of size 1044
 8446 |  snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 8447 |    "%s/frr-gmp:gmp/address-family[address-family='%s']",
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 8448 |    VTY_CURR_XPATH, "frr-routing:ipv4");
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pimd/pim_cmd.c: In function ‘interface_no_ip_pim’:
pimd/pim_cmd.c:8483:7: error: ‘/frr-gmp:gmp/address-family[...’ directive output may be truncated writing 44 bytes into a region of size between 21 and 1044 [-Werror=format-truncation=]
 8483 |    "%s/frr-gmp:gmp/address-family[address-family='%s']",
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pimd/pim_cmd.c:8482:2: note: ‘snprintf’ output between 63 and 1086 bytes into a destination of size 1044
 8482 |  snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 8483 |    "%s/frr-gmp:gmp/address-family[address-family='%s']",
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 8484 |    VTY_CURR_XPATH, "frr-routing:ipv4");
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

cc1: all warnings being treated as errors

Signed-off-by: sarita patra <saritap@vmware.com>