### PR TITLE
bgpd: fix import of evpn routes into vni/vrf/esi after nexthop update

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3307,7 +3307,9 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 		pi = bgp_create_evpn_bgp_path_info(parent_pi, dest, &attr);
 		new_pi = true;
 	} else {
-		if (!CHECK_FLAG(pi->flags, BGP_PATH_REMOVED) && attrhash_cmp(pi->attr, &attr)) {
+		if (!CHECK_FLAG(pi->flags, BGP_PATH_REMOVED) &&
+		    !CHECK_FLAG(parent_pi->flags, BGP_PATH_IGP_CHANGED) &&
+		    attrhash_cmp(pi->attr, &attr)) {
 			bgp_dest_unlock_node(dest);
 			bgp_attr_extra_discard(&attr);
 			return 0;

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1624,6 +1624,17 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
 						bgp_get_default(), bgp_path,
 						path);
 			}
+		} else if (safi == SAFI_EVPN && CHECK_FLAG(path->flags, BGP_PATH_IGP_CHANGED) &&
+			   bgp_evpn_is_prefix_nht_supported(bgp_dest_get_prefix(dest))) {
+			if (bnc_is_valid_nexthop)
+				/* import the EVPN routes if the IGP path
+				 * changed or update existing routes.
+				 */
+				bgp_evpn_import_route(bgp_path, afi, safi,
+						      bgp_dest_get_prefix(dest), path);
+			else
+				bgp_evpn_unimport_route(bgp_path, afi, safi,
+							bgp_dest_get_prefix(dest), path);
 		}
 
 		if (old_path_valid != bnc_is_valid_nexthop)

--- a/tests/topotests/bgp_path_selection/r1/bgpd.conf
+++ b/tests/topotests/bgp_path_selection/r1/bgpd.conf
@@ -15,6 +15,11 @@ router bgp 65001
   neighbor 192.0.2.2 activate
   neighbor 192.0.2.3 activate
  exit-address-family
+ address-family l2vpn evpn
+  neighbor 192.0.2.2 activate
+  neighbor 192.0.2.3 activate
+  advertise-all-vni
+ exit-address-family
 !
 router bgp 65001 vrf vrf1
  bgp router-id 192.0.2.1
@@ -24,5 +29,12 @@ router bgp 65001 vrf vrf1
   rt vpn both 52:100
   import vpn
   export vpn
+ exit-address-family
+!
+router bgp 65001 vrf vrf2
+ bgp router-id 192.0.2.1
+ address-family l2vpn evpn
+  autort rfc8365-compatible
+  rd 65001:100
  exit-address-family
 !

--- a/tests/topotests/bgp_path_selection/r1/zebra.conf
+++ b/tests/topotests/bgp_path_selection/r1/zebra.conf
@@ -1,4 +1,8 @@
 !
+vrf vrf2
+ vni 100
+ exit-vrf
+!
 interface lo
  ip address 192.0.2.1/32
  ip address 172.16.255.1/32

--- a/tests/topotests/bgp_path_selection/r2/bgpd.conf
+++ b/tests/topotests/bgp_path_selection/r2/bgpd.conf
@@ -10,6 +10,10 @@ router bgp 65002
  address-family ipv4 vpn
   neighbor 192.168.1.1 activate
  exit-address-family
+ address-family l2vpn evpn
+  neighbor 192.168.1.1 activate
+  advertise-all-vni
+ exit-address-family
 !
 router bgp 65002 vrf vrf1
  bgp router-id 192.0.2.2
@@ -21,5 +25,17 @@ router bgp 65002 vrf vrf1
   rt vpn both 52:100
   import vpn
   export vpn
+ exit-address-family
+!
+router bgp 65002 vrf vrf2
+ bgp router-id 192.0.2.2
+ no bgp ebgp-requires-policy
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+ address-family l2vpn evpn
+  autort rfc8365-compatible
+  advertise ipv4 unicast
+  rd 65002:100
  exit-address-family
 !

--- a/tests/topotests/bgp_path_selection/r2/zebra.conf
+++ b/tests/topotests/bgp_path_selection/r2/zebra.conf
@@ -1,4 +1,8 @@
 !
+vrf vrf2
+ vni 100
+ exit-vrf
+!
 int lo
  ip address 192.0.2.2/32
 !

--- a/tests/topotests/bgp_path_selection/r3/bgpd.conf
+++ b/tests/topotests/bgp_path_selection/r3/bgpd.conf
@@ -10,6 +10,10 @@ router bgp 65002
  address-family ipv4 vpn
   neighbor 192.168.2.1 activate
  exit-address-family
+ address-family l2vpn evpn
+  neighbor 192.168.2.1 activate
+  advertise-all-vni
+ exit-address-family
 !
 router bgp 65002 vrf vrf1
  bgp router-id 192.0.2.3
@@ -21,5 +25,17 @@ router bgp 65002 vrf vrf1
   rt vpn both 52:100
   import vpn
   export vpn
+ exit-address-family
+!
+router bgp 65002 vrf vrf2
+ bgp router-id 192.0.2.3
+ no bgp ebgp-requires-policy
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+ address-family l2vpn evpn
+  autort rfc8365-compatible
+  advertise ipv4 unicast
+  rd 65002:100
  exit-address-family
 !

--- a/tests/topotests/bgp_path_selection/r3/zebra.conf
+++ b/tests/topotests/bgp_path_selection/r3/zebra.conf
@@ -1,4 +1,8 @@
 !
+vrf vrf2
+ vni 100
+ exit-vrf
+!
 int lo
  ip address 192.0.2.3/32
 !

--- a/tests/topotests/bgp_path_selection/test_bgp_path_selection.py
+++ b/tests/topotests/bgp_path_selection/test_bgp_path_selection.py
@@ -54,8 +54,25 @@ def setup_module(mod):
                 routern, routern, routern, routern
             )
         )
+        tgen.gears["r{}".format(routern)].cmd("ip link add vrf2 type vrf table 20")
+        tgen.gears["r{}".format(routern)].cmd("ip link set vrf2 up")
+        tgen.gears["r{}".format(routern)].cmd(
+            "ip address add dev vrf2 192.0.2.{}/32".format(routern)
+        )
+        tgen.gears["r{}".format(routern)].cmd("ip link add br1 type bridge")
+        tgen.gears["r{}".format(routern)].cmd(
+            "ip link add vxl1 type vxlan id 100 dev lo local 192.0.2.{}".format(routern)
+        )
+        tgen.gears["r{}".format(routern)].cmd("ip link set dev vxl1 master br1")
+        tgen.gears["r{}".format(routern)].cmd("ip link set dev br1 master vrf2")
+        tgen.gears["r{}".format(routern)].cmd("ip link set dev br1 up")
+        tgen.gears["r{}".format(routern)].cmd("ip link set dev vxl1 up")
+
     tgen.gears["r2"].cmd("ip address add dev vrf1 192.0.2.8/32")
     tgen.gears["r3"].cmd("ip address add dev vrf1 192.0.2.8/32")
+
+    tgen.gears["r2"].cmd("ip address add dev vrf2 192.0.4.8/32")
+    tgen.gears["r3"].cmd("ip address add dev vrf2 192.0.4.8/32")
 
     for _, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
@@ -151,6 +168,58 @@ def test_bgp_path_selection_vpn_ecmp():
     assert result is None, "Failed to see BGP prefixes on R1"
 
 
+def test_bgp_path_selection_evpn_r5_ecmp():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _bgp_check_path_selection_evpn_r5_ecmp():
+        output = json.loads(
+            tgen.gears["r1"].vtysh_cmd("show ip route vrf vrf2 192.0.4.8/32 json")
+        )
+        expected = {
+            "192.0.4.8/32": [
+                {
+                    "prefix": "192.0.4.8/32",
+                    "protocol": "bgp",
+                    "vrfName": "vrf2",
+                    "selected": True,
+                    "installed": True,
+                    "internalNextHopNum": 2,
+                    "internalNextHopActiveNum": 2,
+                    "nexthops": [
+                        {
+                            "fib": True,
+                            "ip": "192.0.2.2",
+                            "afi": "ipv4",
+                            "interfaceName": "br1",
+                            "active": True,
+                            "onLink": True,
+                            "weight": 1,
+                        },
+                        {
+                            "fib": True,
+                            "ip": "192.0.2.3",
+                            "afi": "ipv4",
+                            "interfaceName": "br1",
+                            "active": True,
+                            "onLink": True,
+                            "weight": 1,
+                        },
+                    ],
+                }
+            ]
+        }
+
+        return topotest.json_cmp(output, expected)
+
+    step("Check if two ECMP paths are present")
+    test_func = functools.partial(_bgp_check_path_selection_evpn_r5_ecmp)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to see BGP prefixes on R1"
+
+
 def test_bgp_path_selection_metric():
     tgen = get_topogen()
 
@@ -220,6 +289,49 @@ def test_bgp_path_selection_vpn_metric():
 
     step("Check if IGP metric best path is selected")
     test_func = functools.partial(_bgp_check_path_selection_vpn_metric)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to see BGP prefixes on R1"
+
+
+def test_bgp_path_selection_evpn_r5_metric():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _bgp_check_path_selection_evpn_r5_metric():
+        output = json.loads(
+            tgen.gears["r1"].vtysh_cmd("show ip route vrf vrf2 192.0.4.8/32 json")
+        )
+        expected = {
+            "192.0.4.8/32": [
+                {
+                    "prefix": "192.0.4.8/32",
+                    "protocol": "bgp",
+                    "vrfName": "vrf2",
+                    "selected": True,
+                    "installed": True,
+                    "internalNextHopNum": 1,
+                    "internalNextHopActiveNum": 1,
+                    "nexthops": [
+                        {
+                            "fib": True,
+                            "ip": "192.0.2.2",
+                            "afi": "ipv4",
+                            "interfaceName": "br1",
+                            "active": True,
+                            "onLink": True,
+                            "weight": 1,
+                        }
+                    ],
+                }
+            ]
+        }
+
+        return topotest.json_cmp(output, expected)
+
+    step("Check if IGP metric best path is selected")
+    test_func = functools.partial(_bgp_check_path_selection_evpn_r5_metric)
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Failed to see BGP prefixes on R1"
 


### PR DESCRIPTION
Related to issue #10271

After an update of the BGP nexthop (e.g. update of the igp metric), the
EVPN routes are not updated in VNIs, VRFs and ESIs.

Fix the issue.

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>