### PR TITLE
ospfd: fix missing "aggregation timer" in running configuration

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -3383,8 +3383,8 @@ ospf6_start_asbr_summary_delay_timer(struct ospf6 *ospf6,
 	}
 
 	if (IS_OSPF6_DEBUG_AGGR)
-		zlog_debug("%s: Start Aggregator delay timer %d(in seconds).",
-			__func__, ospf6->aggr_delay_interval);
+		zlog_debug("%s: Start Aggregator delay timer %u(in seconds).",
+			   __func__, ospf6->aggr_delay_interval);
 
 	ospf6->aggr_action = operation;
 	thread_add_timer(master,
@@ -3421,8 +3421,7 @@ int ospf6_asbr_external_rt_advertise(struct ospf6 *ospf6,
 	return OSPF6_SUCCESS;
 }
 
-int ospf6_external_aggr_delay_timer_set(struct ospf6 *ospf6,
-			unsigned int interval)
+int ospf6_external_aggr_delay_timer_set(struct ospf6 *ospf6, uint16_t interval)
 {
 	ospf6->aggr_delay_interval = interval;
 

--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -163,8 +163,7 @@ extern void ospf6_asbr_status_update(struct ospf6 *ospf6, int status);
 
 int ospf6_asbr_external_rt_advertise(struct ospf6 *ospf6,
 				     struct prefix *p);
-int ospf6_external_aggr_delay_timer_set(struct ospf6 *ospf6,
-					unsigned int interval);
+int ospf6_external_aggr_delay_timer_set(struct ospf6 *ospf6, uint16_t interval);
 int ospf6_asbr_external_rt_no_advertise(struct ospf6 *ospf6,
 						struct prefix *p);
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -1997,8 +1997,8 @@ ospf6_show_summary_address(struct vty *vty, struct ospf6 *ospf6,
 
 	if (!uj) {
 		ospf6_show_vrf_name(vty, ospf6, json_vrf);
-		vty_out(vty, "aggregation delay interval :%d(in seconds)\n\n",
-				ospf6->aggr_delay_interval);
+		vty_out(vty, "aggregation delay interval :%u(in seconds)\n\n",
+			ospf6->aggr_delay_interval);
 		vty_out(vty, "%s\n", header);
 	} else {
 		json_vrf = json_object_new_object();

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -230,7 +230,7 @@ struct ospf6 {
 
 #define OSPF6_EXTL_AGGR_DEFAULT_DELAY 5
 	/* For ASBR summary delay timer */
-	int aggr_delay_interval;
+	uint16_t aggr_delay_interval;
 	/* Table of configured Aggregate addresses */
 	struct route_table *rt_aggr_tbl;
 

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -1108,7 +1108,7 @@ static void ospf_external_aggr_timer(struct ospf *ospf,
 	}
 
 	if (IS_DEBUG_OSPF(lsa, EXTNL_LSA_AGGR))
-		zlog_debug("%s: Start Aggregator delay timer %d(in seconds).",
+		zlog_debug("%s: Start Aggregator delay timer %u(in seconds).",
 			   __func__, ospf->aggr_delay_interval);
 
 	ospf->aggr_action = operation;
@@ -1232,7 +1232,7 @@ int ospf_asbr_external_rt_advertise(struct ospf *ospf, struct prefix_ipv4 *p)
 	return OSPF_SUCCESS;
 }
 
-int ospf_external_aggregator_timer_set(struct ospf *ospf, unsigned int interval)
+int ospf_external_aggregator_timer_set(struct ospf *ospf, uint16_t interval)
 {
 	ospf->aggr_delay_interval = interval;
 	return OSPF_SUCCESS;

--- a/ospfd/ospf_asbr.h
+++ b/ospfd/ospf_asbr.h
@@ -148,7 +148,7 @@ ospf_originate_summary_lsa(struct ospf *ospf,
 			   struct ospf_external_aggr_rt *aggr,
 			   struct external_info *ei);
 extern int ospf_external_aggregator_timer_set(struct ospf *ospf,
-					      unsigned int interval);
+					      uint16_t interval);
 extern void ospf_external_aggrigator_free(struct ospf_external_aggr_rt *aggr);
 
 extern struct ospf_external_aggr_rt *

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -12135,6 +12135,10 @@ static int config_write_ospf_external_aggregator(struct vty *vty,
 {
 	struct route_node *rn;
 
+	if (ospf->aggr_delay_interval != OSPF_EXTL_AGGR_DEFAULT_DELAY)
+		vty_out(vty, " aggregation timer %u\n",
+			ospf->aggr_delay_interval);
+
 	/* print 'summary-address A.B.C.D/M' */
 	for (rn = route_top(ospf->rt_aggr_tbl); rn; rn = route_next(rn))
 		if (rn->info) {

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9933,7 +9933,7 @@ DEFUN (ospf_external_route_aggregation,
        ospf_external_route_aggregation_cmd,
        "summary-address A.B.C.D/M [tag (1-4294967295)]",
        "External summary address\n"
-       "Summary address prefix (a.b.c.d/m) \n"
+       "Summary address prefix\n"
        "Router tag \n"
        "Router tag value\n")
 {
@@ -9974,7 +9974,7 @@ DEFUN (no_ospf_external_route_aggregation,
        "no summary-address A.B.C.D/M [tag (1-4294967295)]",
        NO_STR
        "External summary address\n"
-       "Summary address prefix (a.b.c.d/m)\n"
+       "Summary address prefix\n"
        "Router tag\n"
        "Router tag value\n")
 {
@@ -10264,7 +10264,7 @@ DEFUN (ospf_external_route_aggregation_no_adrvertise,
        ospf_external_route_aggregation_no_adrvertise_cmd,
        "summary-address A.B.C.D/M no-advertise",
        "External summary address\n"
-       "Summary address prefix (a.b.c.d/m) \n"
+       "Summary address prefix\n"
        "Don't advertise summary route \n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
@@ -10300,7 +10300,7 @@ DEFUN (no_ospf_external_route_aggregation_no_adrvertise,
        "no summary-address A.B.C.D/M no-advertise",
        NO_STR
        "External summary address\n"
-       "Summary address prefix (a.b.c.d/m)\n"
+       "Summary address prefix\n"
        "Advertise summary route to the AS \n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
@@ -12140,10 +12140,10 @@ static int config_write_ospf_external_aggregator(struct vty *vty,
 		if (rn->info) {
 			struct ospf_external_aggr_rt *aggr = rn->info;
 
-			vty_out(vty, " summary-address %pI4/%d ",
+			vty_out(vty, " summary-address %pI4/%d",
 				&aggr->p.prefix, aggr->p.prefixlen);
 			if (aggr->tag)
-				vty_out(vty, " tag %u ", aggr->tag);
+				vty_out(vty, " tag %u", aggr->tag);
 
 			if (CHECK_FLAG(aggr->flags,
 				       OSPF_EXTERNAL_AGGRT_NO_ADVERTISE))

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10339,7 +10339,7 @@ DEFUN (ospf_route_aggregation_timer,
        "Timer interval(in seconds)\n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
-	unsigned int interval = 0;
+	uint16_t interval = 0;
 
 	interval = strtoul(argv[2]->arg, NULL, 10);
 
@@ -11369,7 +11369,7 @@ static int ospf_show_summary_address(struct vty *vty, struct ospf *ospf,
 	ospf_show_vrf_name(ospf, vty, json_vrf, use_vrf);
 
 	if (!uj)
-		vty_out(vty, "aggregation delay interval :%d(in seconds)\n\n",
+		vty_out(vty, "aggregation delay interval :%u(in seconds)\n\n",
 			ospf->aggr_delay_interval);
 	else
 		json_object_int_add(json_vrf, "aggregation delay interval",

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -377,7 +377,7 @@ struct ospf {
 	struct thread *t_external_aggr;
 
 	/* delay interval in seconds */
-	unsigned int aggr_delay_interval;
+	uint16_t aggr_delay_interval;
 
 	/* Table of configured Aggregate addresses */
 	struct route_table *rt_aggr_tbl;


### PR DESCRIPTION
Four commits:
- ospfd: fix missing "aggregation timer" in running configuration
- ospfd:  small fixes on ospfd running configuration.
- ospf6d: adjust type of "aggr_delay_interval"
- ospfd: adjust type of "aggr_delay_interval"
Please check commit log.