### PR TITLE
zebra: Nexthop tracking, route resolution recursive lookup

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -4921,8 +4921,13 @@ def verify_ip_nht(tgen, input_dict):
 
         for nh in nh_list:
             if nh in show_ip_nht:
-                logger.info("Nexthop %s is resolved on %s", nh, router)
-                return True
+                nht = run_frr_cmd(rnode, f"show ip nht {nh}")
+                if "unresolved" in nht:
+                    errormsg = "Nexthop {} became unresolved on {}".format(nh, router)
+                    return errormsg
+                else:
+                    logger.info("Nexthop %s is resolved on %s", nh, router)
+                    return True
             else:
                 errormsg = "Nexthop {} is resolved on {}".format(nh, router)
                 return errormsg

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -1195,7 +1195,7 @@ def add_interfaces_to_vlan(tgen, input_dict):
 
                         # Assigning IP address
                         ifaddr = ipaddress.ip_interface(
-                            u"{}/{}".format(
+                            "{}/{}".format(
                                 frr_unicode(data["ip"]), frr_unicode(data["subnet"])
                             )
                         )
@@ -1626,7 +1626,7 @@ def create_interface_in_kernel(
         ifaddr = ipaddress.ip_interface(frr_unicode(ip_addr))
     else:
         ifaddr = ipaddress.ip_interface(
-            u"{}/{}".format(frr_unicode(ip_addr), frr_unicode(netmask))
+            "{}/{}".format(frr_unicode(ip_addr), frr_unicode(netmask))
         )
     cmd = "ip -{0} a flush {1} scope global && ip a add {2} dev {1} && ip l set {1} up".format(
         ifaddr.version, name, ifaddr

--- a/tests/topotests/zebra_nht_resolution/r1/zebra.conf
+++ b/tests/topotests/zebra_nht_resolution/r1/zebra.conf
@@ -1,0 +1,5 @@
+hostname r1
+!
+interface r1-eth0
+  ip address 192.168.120.1/24
+!

--- a/tests/topotests/zebra_nht_resolution/test_verify_nh_resolution.py
+++ b/tests/topotests/zebra_nht_resolution/test_verify_nh_resolution.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2022 by VMware, Inc. ("VMware")
+# Used Copyright (c) 2018 by Network Device Education Foundation,
+# Inc. ("NetDEF") in this file.
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND VMWARE DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL VMWARE BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+Test is indended for validating zebra NH resolution logic
+"""
+
+import os
+import sys
+import pytest
+
+from lib.common_config import (
+    start_topology,
+    verify_rib,
+    verify_ip_nht,
+    step,
+    create_static_routes,
+)
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.sharpd]
+
+#GLOBAL VARIABLES
+NH1 = "2.2.2.32"
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+
+    switch = tgen.add_switch("sw1")
+    switch.add_link(tgen.gears["r1"])
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+    router_list = tgen.routers()
+    for rname, router in tgen.routers().items():
+        router.load_config(TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname)))
+        router.load_config(
+            TopoRouter.RD_SHARP, os.path.join(CWD, "{}/sharpd.conf".format(rname))
+        )
+    tgen.start_router()
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_verify_zebra_nh_resolution(request):
+    tgen = get_topogen()
+    tc_name = request.node.name
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    logger.info("Starting Zebra NH resolution testcase")
+    r1 = tgen.gears["r1"]
+
+    step("Configure static route")
+    input_dict_1 = {
+            "r1": {
+                "static_routes": [
+                    {"network": "2.2.2.0/24", "next_hop": "r1-eth0"}
+                ]
+            }
+        }
+
+    result = create_static_routes(tgen, input_dict_1)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(
+        tc_name, result
+    )
+
+    step("Verify static routes in RIB of R1")
+    input_dict_2 = {
+            "r1": {
+                "static_routes": [
+                    {"network": "2.2.2.0/24"}
+                ]
+            }
+    }
+
+    dut = "r1"
+    result = verify_rib(tgen, "ipv4", dut, input_dict_2)
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(
+            tc_name, result)
+
+    step("Set the connected flag on the NH tracking entry")
+    r1.vtysh_cmd("sharp watch nexthop 2.2.2.32 connected")
+
+    step("Verify that NH 2.2.2.32 gets resolved over static route")
+    input_dict_nh = {
+        "r1": {
+            NH1: {
+                "Address": "2.2.2.0/24",
+                "resolvedVia": "static",
+                "nexthops": {"nexthop1": {"Interfcae": "r1-eth0"}},
+            }
+        }
+    }
+    result = verify_ip_nht(tgen, input_dict_nh)
+    assert result is True, "Testcase {} : Failed \n"
+    "Error: Nexthop is missing in RIB".format(
+        tc_name, result)
+
+    step("Add a .32/32 route with the NH as itself")
+    r1.vtysh_cmd("sharp install routes 2.2.2.32 nexthop 2.2.2.32 1")
+
+    step("Verify that the installation of .32/32 has no effect on the NHT")
+    input_dict_nh = {
+        "r1": {
+            NH1: {
+                "Address": "2.2.2.0/24",
+                "resolvedVia": "static",
+                "nexthops": {"nexthop1": {"Interface": "r1-eth0"}},
+            }
+        }
+    }
+    result = verify_ip_nht(tgen, input_dict_nh)
+    assert result is True, "Testcase {} : Failed \n"
+    "Error: Nexthop became unresolved".format(
+        tc_name, result)
+
+    step("Add a .31/32 route with the NH as 2.2.2.32"
+         "to verify the NH Resolution behaviour")
+    r1.vtysh_cmd("sharp install routes 2.2.2.31 nexthop 2.2.2.32 1")
+
+    step("Verify that NH 2.2.2.2/32 doesn't become unresolved")
+    input_dict_nh = {
+        "r1": {
+            NH1: {
+                "Address": "2.2.2.0/24",
+                "resolvedVia": "static",
+                "nexthops": {"nexthop1": {"Interface": "r1-eth0"}},
+            }
+        }
+    }
+    result = verify_ip_nht(tgen, input_dict_nh)
+    assert result is True, "Testcase {} : Failed \n"
+    "Error: Nexthop became unresolved".format(
+        tc_name, result)
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -637,15 +637,11 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 		if (re) {
 			*prn = rn;
 			return re;
-		}
-
-		if (!CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED))
+		} else {
+			/* Resolve the nexthop recursively by finding matching
+			 * route with lower prefix length
+			 */
 			rn = rn->parent;
-		else {
-			if (IS_ZEBRA_DEBUG_NHT_DETAILED)
-				zlog_debug(
-					"        Nexthop must be connected, cannot recurse up");
-			return NULL;
 		}
 	}
 


### PR DESCRIPTION
**Description:**
Change is intended for fixing the NHT resolution logic.
While recursively resolving nexthop, keep looking for a valid/useable route in the rib,
by not stopping at the first/most-specific route in the rib.

Consider the following set of events taking place on R1:

```
R1(config)# ip route 2.2.2.0/24 ens192
R1# sharp watch nexthop 2.2.2.32 connected
R1# show ip nht
2.2.2.32(Connected)
 resolved via static
 is directly connected, ens192
 Client list: sharp(fd 33)
```
- 2.2.2.32 NHT is resolved over the above valid static route.

```
R1# sharp install routes 2.2.2.32 nexthop 2.2.2.32 1
R1# 2.2.2.32(Connected)
 resolved via static
 is directly connected, ens192
 Client list: sharp(fd 33)
```
- .32/32 comes which is going to resolve through itself, but since this is an invalid route,
it will be marked as inactive and will not affect the NHT.

```
R1# sharp install routes 2.2.2.31 nexthop 2.2.2.32 1
R1# 2.2.2.32(Connected)
 unresolved(Connected)
 Client list: sharp(fd 50)
```
- Now a .31/32 comes which will resolve over .32 route, but as per the current logic,
this will trigger the NHT check, in turn making the NHT unresolved.
After configuring this, R1 routes start flapping.

- With fix, NHT should stay in resolved state as long as the valid static or connected route stays installed

**Fix:**
- While resolving nexthops, walk up the tree from the most-specific match,
   walk up the tree without any ZEBRA_NHT_CONNECTED check.

Co-authored-by: Vishal Dhingra <vdhingra@vmware.com>
Co-authored-by: Kantesh Mundaragi <kmundaragi@vmware.com>
Signed-off-by: Iqra Siddiqui <imujeebsiddi@vmware.com>