### PR TITLE
pim6d:  Adding PIMv6 Config CLIs for top level

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -116,6 +116,29 @@ DEFPY (no_ipv6_pim_spt_switchover_infinity_plist,
 	return pim_process_no_spt_switchover_cmd(vty);
 }
 
+DEFPY (ipv6_pim_packets,
+       ipv6_pim_packets_cmd,
+       "ipv6 pim packets (1-255)",
+       IPV6_STR
+       PIM_STR
+       "packets to process at one time per fd\n"
+       "Number of packets\n")
+{
+	return pim_process_pim_packet_cmd(vty, packets_str);
+}
+
+DEFPY (no_ipv6_pim_packets,
+       no_ipv6_pim_packets_cmd,
+       "no ipv6 pim packets [(1-255)]",
+       NO_STR
+       IPV6_STR
+       PIM_STR
+       "packets to process at one time per fd\n"
+       IGNORED_IN_NO_STR)
+{
+	return pim_process_no_pim_packet_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -126,4 +149,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &ipv6_pim_spt_switchover_infinity_plist_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_spt_switchover_infinity_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_spt_switchover_infinity_plist_cmd);
+	install_element(CONFIG_NODE, &ipv6_pim_packets_cmd);
+	install_element(CONFIG_NODE, &no_ipv6_pim_packets_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -66,10 +66,64 @@ DEFPY (no_ipv6_pim_joinprune_time,
 	return pim_process_no_join_prune_cmd(vty);
 }
 
+DEFPY (ipv6_pim_spt_switchover_infinity,
+       ipv6_pim_spt_switchover_infinity_cmd,
+       "ipv6 pim spt-switchover infinity-and-beyond",
+       IPV6_STR
+       PIM_STR
+       "SPT-Switchover\n"
+       "Never switch to SPT Tree\n")
+{
+	return pim_process_spt_switchover_infinity_cmd(vty);
+}
+
+DEFPY (ipv6_pim_spt_switchover_infinity_plist,
+       ipv6_pim_spt_switchover_infinity_plist_cmd,
+       "ipv6 pim spt-switchover infinity-and-beyond prefix-list WORD$plist",
+       IPV6_STR
+       PIM_STR
+       "SPT-Switchover\n"
+       "Never switch to SPT Tree\n"
+       "Prefix-List to control which groups to switch\n"
+       "Prefix-List name\n")
+{
+	return pim_process_spt_switchover_prefixlist_cmd(vty, plist);
+}
+
+DEFPY (no_ipv6_pim_spt_switchover_infinity,
+       no_ipv6_pim_spt_switchover_infinity_cmd,
+       "no ipv6 pim spt-switchover infinity-and-beyond",
+       NO_STR
+       IPV6_STR
+       PIM_STR
+       "SPT_Switchover\n"
+       "Never switch to SPT Tree\n")
+{
+	return pim_process_no_spt_switchover_cmd(vty);
+}
+
+DEFPY (no_ipv6_pim_spt_switchover_infinity_plist,
+       no_ipv6_pim_spt_switchover_infinity_plist_cmd,
+       "no ipv6 pim spt-switchover infinity-and-beyond prefix-list WORD",
+       NO_STR
+       IPV6_STR
+       PIM_STR
+       "SPT_Switchover\n"
+       "Never switch to SPT Tree\n"
+       "Prefix-List to control which groups to switch\n"
+       "Prefix-List name\n")
+{
+	return pim_process_no_spt_switchover_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
 
 	install_element(CONFIG_NODE, &ipv6_pim_joinprune_time_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_joinprune_time_cmd);
+	install_element(CONFIG_NODE, &ipv6_pim_spt_switchover_infinity_cmd);
+	install_element(CONFIG_NODE, &ipv6_pim_spt_switchover_infinity_plist_cmd);
+	install_element(CONFIG_NODE, &no_ipv6_pim_spt_switchover_infinity_cmd);
+	install_element(CONFIG_NODE, &no_ipv6_pim_spt_switchover_infinity_plist_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -162,6 +162,31 @@ DEFPY (no_ipv6_pim_keep_alive,
 	return pim_process_no_keepalivetimer_cmd(vty);
 }
 
+DEFPY (ipv6_pim_rp_keep_alive,
+       ipv6_pim_rp_keep_alive_cmd,
+       "ipv6 pim rp keep-alive-timer (1-65535)$kat",
+       IPV6_STR
+       PIM_STR
+       "Rendevous Point\n"
+       "Keep alive Timer\n"
+       "Seconds\n")
+{
+	return pim_process_rp_kat_cmd(vty, kat_str);
+}
+
+DEFPY (no_ipv6_pim_rp_keep_alive,
+       no_ipv6_pim_rp_keep_alive_cmd,
+       "no ipv6 pim rp keep-alive-timer [(1-65535)]",
+       NO_STR
+       IPV6_STR
+       PIM_STR
+       "Rendevous Point\n"
+       "Keep alive Timer\n"
+       IGNORED_IN_NO_STR)
+{
+	return pim_process_no_rp_kat_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -176,4 +201,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_ipv6_pim_packets_cmd);
 	install_element(CONFIG_NODE, &ipv6_pim_keep_alive_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_keep_alive_cmd);
+	install_element(CONFIG_NODE, &ipv6_pim_rp_keep_alive_cmd);
+	install_element(CONFIG_NODE, &no_ipv6_pim_rp_keep_alive_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -43,7 +43,33 @@
 #include "pimd/pim6_cmd_clippy.c"
 #endif
 
+DEFPY (ipv6_pim_joinprune_time,
+       ipv6_pim_joinprune_time_cmd,
+       "ipv6 pim join-prune-interval (1-65535)$jpi",
+       IPV6_STR
+       PIM_STR
+       "Join Prune Send Interval\n"
+       "Seconds\n")
+{
+	return pim_process_join_prune_cmd(vty, jpi_str);
+}
+
+DEFPY (no_ipv6_pim_joinprune_time,
+       no_ipv6_pim_joinprune_time_cmd,
+       "no ipv6 pim join-prune-interval [(1-65535)]",
+       NO_STR
+       IPV6_STR
+       PIM_STR
+       "Join Prune Send Interval\n"
+       IGNORED_IN_NO_STR)
+{
+	return pim_process_no_join_prune_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
+
+	install_element(CONFIG_NODE, &ipv6_pim_joinprune_time_cmd);
+	install_element(CONFIG_NODE, &no_ipv6_pim_joinprune_time_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -187,6 +187,29 @@ DEFPY (no_ipv6_pim_rp_keep_alive,
 	return pim_process_no_rp_kat_cmd(vty);
 }
 
+DEFPY (ipv6_pim_register_suppress,
+       ipv6_pim_register_suppress_cmd,
+       "ipv6 pim register-suppress-time (1-65535)$rst",
+       IPV6_STR
+       PIM_STR
+       "Register Suppress Timer\n"
+       "Seconds\n")
+{
+	return pim_process_register_suppress_cmd(vty, rst_str);
+}
+
+DEFPY (no_ipv6_pim_register_suppress,
+       no_ipv6_pim_register_suppress_cmd,
+       "no ipv6 pim register-suppress-time [(1-65535)]",
+       NO_STR
+       IPV6_STR
+       PIM_STR
+       "Register Suppress Timer\n"
+       IGNORED_IN_NO_STR)
+{
+	return pim_process_no_register_suppress_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -203,4 +226,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_ipv6_pim_keep_alive_cmd);
 	install_element(CONFIG_NODE, &ipv6_pim_rp_keep_alive_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_rp_keep_alive_cmd);
+	install_element(CONFIG_NODE, &ipv6_pim_register_suppress_cmd);
+	install_element(CONFIG_NODE, &no_ipv6_pim_register_suppress_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1,0 +1,48 @@
+/*
+ * PIM for IPv6 FRR
+ * Copyright (C) 2022  Vmware, Inc.
+ *		       Mobashshera Rasool <mrasool@vmware.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+
+#include "lib/json.h"
+#include "command.h"
+#include "if.h"
+#include "prefix.h"
+#include "zclient.h"
+#include "plist.h"
+#include "hash.h"
+#include "nexthop.h"
+#include "vrf.h"
+#include "ferr.h"
+
+#include "pimd.h"
+#include "pim6_cmd.h"
+#include "pim_vty.h"
+#include "lib/northbound_cli.h"
+#include "pim_errors.h"
+#include "pim_nb.h"
+
+#ifndef VTYSH_EXTRACT_PL
+#include "pimd/pim6_cmd_clippy.c"
+#endif
+
+void pim_cmd_init(void)
+{
+	if_cmd_init(pim_interface_config_write);
+}

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -139,6 +139,29 @@ DEFPY (no_ipv6_pim_packets,
 	return pim_process_no_pim_packet_cmd(vty);
 }
 
+DEFPY (ipv6_pim_keep_alive,
+       ipv6_pim_keep_alive_cmd,
+       "ipv6 pim keep-alive-timer (1-65535)$kat",
+       IPV6_STR
+       PIM_STR
+       "Keep alive Timer\n"
+       "Seconds\n")
+{
+	return pim_process_keepalivetimer_cmd(vty, kat_str);
+}
+
+DEFPY (no_ipv6_pim_keep_alive,
+       no_ipv6_pim_keep_alive_cmd,
+       "no ipv6 pim keep-alive-timer [(1-65535)]",
+       NO_STR
+       IPV6_STR
+       PIM_STR
+       "Keep alive Timer\n"
+       IGNORED_IN_NO_STR)
+{
+	return pim_process_no_keepalivetimer_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -151,4 +174,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_ipv6_pim_spt_switchover_infinity_plist_cmd);
 	install_element(CONFIG_NODE, &ipv6_pim_packets_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_packets_cmd);
+	install_element(CONFIG_NODE, &ipv6_pim_keep_alive_cmd);
+	install_element(CONFIG_NODE, &no_ipv6_pim_keep_alive_cmd);
 }

--- a/pimd/pim6_cmd.h
+++ b/pimd/pim6_cmd.h
@@ -1,0 +1,44 @@
+/*
+ * PIM for IPv6 FRR
+ * Copyright (C) 2022  Vmware, Inc.
+ *		       Mobashshera Rasool <mrasool@vmware.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef PIM6_CMD_H
+#define PIM6_CMD_H
+
+#define PIM_STR "PIM information\n"
+#define MLD_STR "MLD information\n"
+#define MLD_GROUP_STR "MLD groups information\n"
+#define MLD_SOURCE_STR "MLD sources information\n"
+#define IFACE_MLD_STR  "Enable MLD operation\n"
+#define IFACE_MLD_QUERY_INTERVAL_STR "MLD host query interval\n"
+#define IFACE_MLD_QUERY_MAX_RESPONSE_TIME_STR \
+	"MLD max query response value (seconds)\n"
+#define IFACE_MLD_QUERY_MAX_RESPONSE_TIME_DSEC_STR \
+	"MLD max query response value (deciseconds)\n"
+#define IFACE_MLD_LAST_MEMBER_QUERY_INTERVAL_STR \
+	"MLD last member query interval\n"
+#define IFACE_MLD_LAST_MEMBER_QUERY_COUNT_STR "MLD last member query count\n"
+#define MROUTE_STR "IP multicast routing table\n"
+#define DEBUG_MLD_STR "MLD protocol activity\n"
+#define DEBUG_MLD_EVENTS_STR "MLD protocol events\n"
+#define DEBUG_MLD_PACKETS_STR "MLD protocol packets\n"
+#define DEBUG_MLD_TRACE_STR "MLD internal daemon activity\n"
+
+void pim_cmd_init(void);
+
+#endif /* PIM6_CMD_H */

--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -37,6 +37,7 @@
 #include "pim_iface.h"
 #include "pim_zebra.h"
 #include "pim_nb.h"
+#include "pim6_cmd.h"
 
 zebra_capabilities_t _caps_p[] = {
 	ZCAP_SYS_ADMIN,
@@ -176,9 +177,9 @@ int main(int argc, char **argv, char **envp)
 	prefix_list_delete_hook(pim_prefix_list_update);
 
 	pim_route_map_init();
-	pim_init();
 #endif
-
+	/* pim_init(); */
+	pim_cmd_init();
 	/*
 	 * Initialize zclient "update" and "lookup" sockets
 	 */

--- a/pimd/pim6_stubs.c
+++ b/pimd/pim6_stubs.c
@@ -133,9 +133,3 @@ void pim_reg_del_on_couldreg_fail(struct interface *ifp)
 {
 }
 
-/*
- * CLI
- */
-void pim_cmd_init(void)
-{
-}

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -32,6 +32,7 @@ typedef struct in_addr pim_addr;
 #define PIM_AF		AF_INET
 #define PIM_AFI		AFI_IP
 #define PIM_MAX_BITLEN	IPV4_MAX_BITLEN
+#define PIM_AF_NAME     "ip"
 
 union pimprefixptr {
 	prefixtype(pimprefixptr, struct prefix,      p)
@@ -50,6 +51,7 @@ typedef struct in6_addr pim_addr;
 #define PIM_AF		AF_INET6
 #define PIM_AFI		AFI_IP6
 #define PIM_MAX_BITLEN	IPV6_MAX_BITLEN
+#define PIM_AF_NAME     "ipv6"
 
 union pimprefixptr {
 	prefixtype(pimprefixptr, struct prefix,      p)

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -33,6 +33,7 @@ typedef struct in_addr pim_addr;
 #define PIM_AFI		AFI_IP
 #define PIM_MAX_BITLEN	IPV4_MAX_BITLEN
 #define PIM_AF_NAME     "ip"
+#define	FRR_PIM_AF_XPATH_VAL "frr-routing:ipv4"
 
 union pimprefixptr {
 	prefixtype(pimprefixptr, struct prefix,      p)
@@ -52,6 +53,7 @@ typedef struct in6_addr pim_addr;
 #define PIM_AFI		AFI_IP6
 #define PIM_MAX_BITLEN	IPV6_MAX_BITLEN
 #define PIM_AF_NAME     "ipv6"
+#define	FRR_PIM_AF_XPATH_VAL "frr-routing:ipv6"
 
 union pimprefixptr {
 	prefixtype(pimprefixptr, struct prefix,      p)

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -50,15 +50,15 @@ void pim_bfd_write_config(struct vty *vty, struct interface *ifp)
 	if (pim_ifp->bfd_config.detection_multiplier != BFD_DEF_DETECT_MULT
 	    || pim_ifp->bfd_config.min_rx != BFD_DEF_MIN_RX
 	    || pim_ifp->bfd_config.min_tx != BFD_DEF_MIN_TX)
-		vty_out(vty, " ip pim bfd %d %d %d\n",
+		vty_out(vty, " " PIM_AF_NAME " pim bfd %d %d %d\n",
 			pim_ifp->bfd_config.detection_multiplier,
 			pim_ifp->bfd_config.min_rx, pim_ifp->bfd_config.min_tx);
 	else
 #endif /* ! HAVE_BFDD */
-		vty_out(vty, " ip pim bfd\n");
+		vty_out(vty, " " PIM_AF_NAME " pim bfd\n");
 
 	if (pim_ifp->bfd_config.profile)
-		vty_out(vty, " ip pim bfd profile %s\n",
+		vty_out(vty, " " PIM_AF_NAME " pim bfd profile %s\n",
 			pim_ifp->bfd_config.profile);
 }
 

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -59,9 +59,9 @@ void pim_bsm_write_config(struct vty *vty, struct interface *ifp)
 
 	if (pim_ifp) {
 		if (!pim_ifp->bsm_enable)
-			vty_out(vty, " no ip pim bsm\n");
+			vty_out(vty, " no " PIM_AF_NAME " pim bsm\n");
 		if (!pim_ifp->ucast_bsm_accept)
-			vty_out(vty, " no ip pim unicast-bsm\n");
+			vty_out(vty, " no " PIM_AF_NAME " pim unicast-bsm\n");
 	}
 }
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -67,6 +67,7 @@
 #include "lib/northbound_cli.h"
 #include "pim_errors.h"
 #include "pim_nb.h"
+#include "pim_cmd_common.h"
 
 #ifndef VTYSH_EXTRACT_PL
 #include "pimd/pim_cmd_clippy.c"

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6821,23 +6821,15 @@ DEFUN (no_ip_pim_joinprune_time,
 	return pim_process_no_join_prune_cmd(vty);
 }
 
-DEFUN (ip_pim_register_suppress,
+DEFPY (ip_pim_register_suppress,
        ip_pim_register_suppress_cmd,
-       "ip pim register-suppress-time (1-65535)",
+       "ip pim register-suppress-time (1-65535)$rst",
        IP_STR
        "pim multicast routing\n"
        "Register Suppress Timer\n"
        "Seconds\n")
 {
-	char xpath[XPATH_MAXLEN];
-
-	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
-		 "frr-routing:ipv4");
-	strlcat(xpath, "/register-suppress-time", sizeof(xpath));
-
-	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, argv[3]->arg);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_register_suppress_cmd(vty, rst_str);
 }
 
 DEFUN (no_ip_pim_register_suppress,
@@ -6849,15 +6841,7 @@ DEFUN (no_ip_pim_register_suppress,
        "Register Suppress Timer\n"
        IGNORED_IN_NO_STR)
 {
-	char xpath[XPATH_MAXLEN];
-
-	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
-		 "frr-routing:ipv4");
-	strlcat(xpath, "/register-suppress-time", sizeof(xpath));
-
-	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_no_register_suppress_cmd(vty);
 }
 
 DEFPY (ip_pim_rp_keep_alive,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3785,7 +3785,6 @@ static const char *pim_cli_get_vrf_name(struct vty *vty)
 	return yang_dnode_get_string(vrf_node, "./name");
 }
 
-#if PIM_IPV != 6
 /**
  * Compatibility function to keep the legacy mesh group CLI behavior:
  * Delete group when there are no more configurations in it.
@@ -3833,7 +3832,6 @@ static void pim_cli_legacy_mesh_group_behavior(struct vty *vty,
 	/* No configurations found: delete it. */
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_DESTROY, NULL);
 }
-#endif /* PIM_IPV != 6 */
 
 DEFUN (clear_ip_interfaces,
        clear_ip_interfaces_cmd,
@@ -9543,7 +9541,6 @@ ALIAS(no_ip_pim_bfd, no_ip_pim_bfd_param_cmd,
       "Desired min transmit interval\n")
 #endif /* !HAVE_BFDD */
 
-#if PIM_IPV != 6
 DEFPY(ip_msdp_peer, ip_msdp_peer_cmd,
       "ip msdp peer A.B.C.D$peer source A.B.C.D$source",
       IP_STR
@@ -10571,7 +10568,6 @@ DEFUN (show_ip_msdp_sa_sg_vrf_all,
 
 	return CMD_SUCCESS;
 }
-#endif /* PIM_IPV != 6 */
 
 struct pim_sg_cache_walk_data {
 	struct vty *vty;
@@ -11005,12 +11001,10 @@ void pim_cmd_init(void)
 	install_element(VRF_NODE, &ip_ssmpingd_cmd);
 	install_element(CONFIG_NODE, &no_ip_ssmpingd_cmd);
 	install_element(VRF_NODE, &no_ip_ssmpingd_cmd);
-#if PIM_IPV != 6
 	install_element(CONFIG_NODE, &ip_msdp_peer_cmd);
 	install_element(VRF_NODE, &ip_msdp_peer_cmd);
 	install_element(CONFIG_NODE, &no_ip_msdp_peer_cmd);
 	install_element(VRF_NODE, &no_ip_msdp_peer_cmd);
-#endif /* PIM_IPV != 6 */
 	install_element(CONFIG_NODE, &ip_pim_ecmp_cmd);
 	install_element(VRF_NODE, &ip_pim_ecmp_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_ecmp_cmd);
@@ -11179,14 +11173,12 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &no_debug_pim_mlag_cmd);
 	install_element(ENABLE_NODE, &debug_pim_vxlan_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_vxlan_cmd);
-#if PIM_IPV != 6
 	install_element(ENABLE_NODE, &debug_msdp_cmd);
 	install_element(ENABLE_NODE, &no_debug_msdp_cmd);
 	install_element(ENABLE_NODE, &debug_msdp_events_cmd);
 	install_element(ENABLE_NODE, &no_debug_msdp_events_cmd);
 	install_element(ENABLE_NODE, &debug_msdp_packets_cmd);
 	install_element(ENABLE_NODE, &no_debug_msdp_packets_cmd);
-#endif /* PIM_IPV != 6 */
 	install_element(ENABLE_NODE, &debug_mtrace_cmd);
 	install_element(ENABLE_NODE, &no_debug_mtrace_cmd);
 	install_element(ENABLE_NODE, &debug_bsm_cmd);
@@ -11232,20 +11224,17 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_debug_pim_mlag_cmd);
 	install_element(CONFIG_NODE, &debug_pim_vxlan_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_vxlan_cmd);
-#if PIM_IPV != 6
 	install_element(CONFIG_NODE, &debug_msdp_cmd);
 	install_element(CONFIG_NODE, &no_debug_msdp_cmd);
 	install_element(CONFIG_NODE, &debug_msdp_events_cmd);
 	install_element(CONFIG_NODE, &no_debug_msdp_events_cmd);
 	install_element(CONFIG_NODE, &debug_msdp_packets_cmd);
 	install_element(CONFIG_NODE, &no_debug_msdp_packets_cmd);
-#endif /* PIM_IPV != 6 */
 	install_element(CONFIG_NODE, &debug_mtrace_cmd);
 	install_element(CONFIG_NODE, &no_debug_mtrace_cmd);
 	install_element(CONFIG_NODE, &debug_bsm_cmd);
 	install_element(CONFIG_NODE, &no_debug_bsm_cmd);
 
-#if PIM_IPV != 6
 	install_element(CONFIG_NODE, &ip_msdp_timers_cmd);
 	install_element(VRF_NODE, &ip_msdp_timers_cmd);
 	install_element(CONFIG_NODE, &no_ip_msdp_timers_cmd);
@@ -11268,7 +11257,6 @@ void pim_cmd_init(void)
 	install_element(VIEW_NODE, &show_ip_msdp_sa_sg_vrf_all_cmd);
 	install_element(VIEW_NODE, &show_ip_msdp_mesh_group_cmd);
 	install_element(VIEW_NODE, &show_ip_msdp_mesh_group_vrf_all_cmd);
-#endif /* PIM_IPV != 6 */
 	install_element(VIEW_NODE, &show_ip_pim_ssm_range_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_group_type_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_vxlan_sg_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6983,7 +6983,7 @@ DEFUN (no_ip_pim_keep_alive,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-DEFUN (ip_pim_packets,
+DEFPY (ip_pim_packets,
        ip_pim_packets_cmd,
        "ip pim packets (1-255)",
        IP_STR
@@ -6991,15 +6991,7 @@ DEFUN (ip_pim_packets,
        "packets to process at one time per fd\n"
        "Number of packets\n")
 {
-	char xpath[XPATH_MAXLEN];
-
-	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
-		 "frr-routing:ipv4");
-	strlcat(xpath, "/packets", sizeof(xpath));
-
-	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, argv[3]->arg);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_pim_packet_cmd(vty, packets_str);
 }
 
 DEFUN (no_ip_pim_packets,
@@ -7011,15 +7003,7 @@ DEFUN (no_ip_pim_packets,
        "packets to process at one time per fd\n"
        IGNORED_IN_NO_STR)
 {
-	char xpath[XPATH_MAXLEN];
-
-	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
-		 "frr-routing:ipv4");
-	strlcat(xpath, "/packets", sizeof(xpath));
-
-	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_no_pim_packet_cmd(vty);
 }
 
 DEFPY (igmp_group_watermark,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3762,31 +3762,6 @@ static void clear_interfaces(struct pim_instance *pim)
 	}
 
 /**
- * Get current node VRF name.
- *
- * NOTE:
- * In case of failure it will print error message to user.
- *
- * \returns name or NULL if failed to get VRF.
- */
-static const char *pim_cli_get_vrf_name(struct vty *vty)
-{
-	const struct lyd_node *vrf_node;
-
-	/* Not inside any VRF context. */
-	if (vty->xpath_index == 0)
-		return VRF_DEFAULT_NAME;
-
-	vrf_node = yang_dnode_get(vty->candidate_config->dnode, VTY_CURR_XPATH);
-	if (vrf_node == NULL) {
-		vty_out(vty, "%% Failed to get vrf dnode in configuration\n");
-		return NULL;
-	}
-
-	return yang_dnode_get_string(vrf_node, "./name");
-}
-
-/**
  * Compatibility function to keep the legacy mesh group CLI behavior:
  * Delete group when there are no more configurations in it.
  *

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6897,23 +6897,15 @@ DEFPY (pim_register_accept_list,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-DEFUN (ip_pim_joinprune_time,
+DEFPY (ip_pim_joinprune_time,
        ip_pim_joinprune_time_cmd,
-       "ip pim join-prune-interval (1-65535)",
+       "ip pim join-prune-interval (1-65535)$jpi",
        IP_STR
        "pim multicast routing\n"
        "Join Prune Send Interval\n"
        "Seconds\n")
 {
-	char xpath[XPATH_MAXLEN];
-
-	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
-		 "frr-routing:ipv4");
-	strlcat(xpath, "/join-prune-interval", sizeof(xpath));
-
-	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, argv[3]->arg);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_join_prune_cmd(vty, jpi_str);
 }
 
 DEFUN (no_ip_pim_joinprune_time,
@@ -6925,15 +6917,7 @@ DEFUN (no_ip_pim_joinprune_time,
        "Join Prune Send Interval\n"
        IGNORED_IN_NO_STR)
 {
-	char xpath[XPATH_MAXLEN];
-
-	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
-		 "frr-routing:ipv4");
-	strlcat(xpath, "/join-prune-interval", sizeof(xpath));
-
-	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_no_join_prune_cmd(vty);
 }
 
 DEFUN (ip_pim_register_suppress,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6860,32 +6860,16 @@ DEFUN (no_ip_pim_register_suppress,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-DEFUN (ip_pim_rp_keep_alive,
+DEFPY (ip_pim_rp_keep_alive,
        ip_pim_rp_keep_alive_cmd,
-       "ip pim rp keep-alive-timer (1-65535)",
+       "ip pim rp keep-alive-timer (1-65535)$kat",
        IP_STR
        "pim multicast routing\n"
        "Rendevous Point\n"
        "Keep alive Timer\n"
        "Seconds\n")
 {
-	const char *vrfname;
-	char rp_ka_timer_xpath[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(rp_ka_timer_xpath, sizeof(rp_ka_timer_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(rp_ka_timer_xpath, "/rp-keep-alive-timer",
-		sizeof(rp_ka_timer_xpath));
-
-	nb_cli_enqueue_change(vty, rp_ka_timer_xpath, NB_OP_MODIFY,
-			      argv[4]->arg);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_rp_kat_cmd(vty, kat_str);
 }
 
 DEFUN (no_ip_pim_rp_keep_alive,
@@ -6898,39 +6882,7 @@ DEFUN (no_ip_pim_rp_keep_alive,
        "Keep alive Timer\n"
        IGNORED_IN_NO_STR)
 {
-	const char *vrfname;
-	char rp_ka_timer[6];
-	char rp_ka_timer_xpath[XPATH_MAXLEN];
-	uint v;
-	char rs_timer_xpath[XPATH_MAXLEN];
-
-	snprintf(rs_timer_xpath, sizeof(rs_timer_xpath),
-		 FRR_PIM_ROUTER_XPATH, "frr-routing:ipv4");
-	strlcat(rs_timer_xpath, "/register-suppress-time",
-		sizeof(rs_timer_xpath));
-
-	/* RFC4601 */
-	v = yang_dnode_get_uint16(vty->candidate_config->dnode,
-				  rs_timer_xpath);
-	v = 3 * v + PIM_REGISTER_PROBE_TIME_DEFAULT;
-	if (v > UINT16_MAX)
-		v = UINT16_MAX;
-	snprintf(rp_ka_timer, sizeof(rp_ka_timer), "%u", v);
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(rp_ka_timer_xpath, sizeof(rp_ka_timer_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(rp_ka_timer_xpath, "/rp-keep-alive-timer",
-		sizeof(rp_ka_timer_xpath));
-
-	nb_cli_enqueue_change(vty, rp_ka_timer_xpath, NB_OP_MODIFY,
-			      rp_ka_timer);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_no_rp_kat_cmd(vty);
 }
 
 DEFPY (ip_pim_keep_alive,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6724,38 +6724,12 @@ DEFUN (ip_pim_spt_switchover_infinity,
        "SPT-Switchover\n"
        "Never switch to SPT Tree\n")
 {
-	const char *vrfname;
-	char spt_plist_xpath[XPATH_MAXLEN];
-	char spt_action_xpath[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
-		sizeof(spt_plist_xpath));
-
-	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
-		sizeof(spt_action_xpath));
-
-	if (yang_dnode_exists(vty->candidate_config->dnode, spt_plist_xpath))
-		nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_DESTROY,
-				      NULL);
-	nb_cli_enqueue_change(vty, spt_action_xpath, NB_OP_MODIFY,
-			      "PIM_SPT_INFINITY");
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_spt_switchover_infinity_cmd(vty);
 }
 
-DEFUN (ip_pim_spt_switchover_infinity_plist,
+DEFPY (ip_pim_spt_switchover_infinity_plist,
        ip_pim_spt_switchover_infinity_plist_cmd,
-       "ip pim spt-switchover infinity-and-beyond prefix-list WORD",
+       "ip pim spt-switchover infinity-and-beyond prefix-list WORD$plist",
        IP_STR
        PIM_STR
        "SPT-Switchover\n"
@@ -6763,32 +6737,7 @@ DEFUN (ip_pim_spt_switchover_infinity_plist,
        "Prefix-List to control which groups to switch\n"
        "Prefix-List name\n")
 {
-	const char *vrfname;
-	char spt_plist_xpath[XPATH_MAXLEN];
-	char spt_action_xpath[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
-		sizeof(spt_plist_xpath));
-
-	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
-		sizeof(spt_action_xpath));
-
-	nb_cli_enqueue_change(vty, spt_action_xpath, NB_OP_MODIFY,
-			      "PIM_SPT_INFINITY");
-	nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_MODIFY,
-			      argv[5]->arg);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_spt_switchover_prefixlist_cmd(vty, plist);
 }
 
 DEFUN (no_ip_pim_spt_switchover_infinity,
@@ -6800,31 +6749,7 @@ DEFUN (no_ip_pim_spt_switchover_infinity,
        "SPT_Switchover\n"
        "Never switch to SPT Tree\n")
 {
-	const char *vrfname;
-	char spt_plist_xpath[XPATH_MAXLEN];
-	char spt_action_xpath[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
-		sizeof(spt_plist_xpath));
-
-	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
-		sizeof(spt_action_xpath));
-
-	nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_DESTROY, NULL);
-	nb_cli_enqueue_change(vty, spt_action_xpath, NB_OP_MODIFY,
-			      "PIM_SPT_IMMEDIATE");
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_no_spt_switchover_cmd(vty);
 }
 
 DEFUN (no_ip_pim_spt_switchover_infinity_plist,
@@ -6838,31 +6763,7 @@ DEFUN (no_ip_pim_spt_switchover_infinity_plist,
        "Prefix-List to control which groups to switch\n"
        "Prefix-List name\n")
 {
-	const char *vrfname;
-	char spt_plist_xpath[XPATH_MAXLEN];
-	char spt_action_xpath[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
-		sizeof(spt_plist_xpath));
-
-	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
-		sizeof(spt_action_xpath));
-
-	nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_DESTROY, NULL);
-	nb_cli_enqueue_change(vty, spt_action_xpath, NB_OP_MODIFY,
-			      "PIM_SPT_IMMEDIATE");
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_no_spt_switchover_cmd(vty);
 }
 
 DEFPY (pim_register_accept_list,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6933,29 +6933,15 @@ DEFUN (no_ip_pim_rp_keep_alive,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-DEFUN (ip_pim_keep_alive,
+DEFPY (ip_pim_keep_alive,
        ip_pim_keep_alive_cmd,
-       "ip pim keep-alive-timer (1-65535)",
+       "ip pim keep-alive-timer (1-65535)$kat",
        IP_STR
        "pim multicast routing\n"
        "Keep alive Timer\n"
        "Seconds\n")
 {
-	const char *vrfname;
-	char ka_timer_xpath[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(ka_timer_xpath, "/keep-alive-timer", sizeof(ka_timer_xpath));
-
-	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_MODIFY,
-			      argv[3]->arg);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_keepalivetimer_cmd(vty, kat_str);
 }
 
 DEFUN (no_ip_pim_keep_alive,
@@ -6967,20 +6953,7 @@ DEFUN (no_ip_pim_keep_alive,
        "Keep alive Timer\n"
        IGNORED_IN_NO_STR)
 {
-	const char *vrfname;
-	char ka_timer_xpath[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(ka_timer_xpath, "/keep-alive-timer", sizeof(ka_timer_xpath));
-
-	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_DESTROY, NULL);
-
-	return nb_cli_apply_changes(vty, NULL);
+	return pim_process_no_keepalivetimer_cmd(vty);
 }
 
 DEFPY (ip_pim_packets,

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -36,6 +36,7 @@
 #include "lib/northbound_cli.h"
 #include "pim_errors.h"
 #include "pim_nb.h"
+#include "pim_cmd_common.h"
 
 /**
  * Get current node VRF name.
@@ -62,3 +63,28 @@ const char *pim_cli_get_vrf_name(struct vty *vty)
 	return yang_dnode_get_string(vrf_node, "./name");
 }
 
+int pim_process_join_prune_cmd(struct vty *vty, const char *jpi_str)
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(xpath, "/join-prune-interval", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, jpi_str);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+int pim_process_no_join_prune_cmd(struct vty *vty)
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(xpath, "/join-prune-interval", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -242,3 +242,61 @@ int pim_process_no_keepalivetimer_cmd(struct vty *vty)
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+
+int pim_process_rp_kat_cmd(struct vty *vty, const char *rpkat)
+{
+	const char *vrfname;
+	char rp_ka_timer_xpath[XPATH_MAXLEN];
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname == NULL)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	snprintf(rp_ka_timer_xpath, sizeof(rp_ka_timer_xpath),
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(rp_ka_timer_xpath, "/rp-keep-alive-timer",
+		sizeof(rp_ka_timer_xpath));
+
+	nb_cli_enqueue_change(vty, rp_ka_timer_xpath, NB_OP_MODIFY,
+			      rpkat);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+int pim_process_no_rp_kat_cmd(struct vty *vty)
+{
+	const char *vrfname;
+	char rp_ka_timer[6];
+	char rp_ka_timer_xpath[XPATH_MAXLEN];
+	uint v;
+	char rs_timer_xpath[XPATH_MAXLEN];
+
+	snprintf(rs_timer_xpath, sizeof(rs_timer_xpath),
+		 FRR_PIM_ROUTER_XPATH, FRR_PIM_AF_XPATH_VAL);
+	strlcat(rs_timer_xpath, "/register-suppress-time",
+		sizeof(rs_timer_xpath));
+
+	/* RFC4601 */
+	v = yang_dnode_get_uint16(vty->candidate_config->dnode,
+				  rs_timer_xpath);
+	v = 3 * v + PIM_REGISTER_PROBE_TIME_DEFAULT;
+	if (v > UINT16_MAX)
+		v = UINT16_MAX;
+	snprintf(rp_ka_timer, sizeof(rp_ka_timer), "%u", v);
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname == NULL)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	snprintf(rp_ka_timer_xpath, sizeof(rp_ka_timer_xpath),
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(rp_ka_timer_xpath, "/rp-keep-alive-timer",
+		sizeof(rp_ka_timer_xpath));
+
+	nb_cli_enqueue_change(vty, rp_ka_timer_xpath, NB_OP_MODIFY,
+			      rp_ka_timer);
+
+	return nb_cli_apply_changes(vty, NULL);
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -88,3 +88,94 @@ int pim_process_no_join_prune_cmd(struct vty *vty)
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+
+int pim_process_spt_switchover_infinity_cmd(struct vty *vty)
+{
+	const char *vrfname;
+	char spt_plist_xpath[XPATH_MAXLEN];
+	char spt_action_xpath[XPATH_MAXLEN];
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname == NULL)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
+		sizeof(spt_plist_xpath));
+
+	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
+		sizeof(spt_action_xpath));
+
+	if (yang_dnode_exists(vty->candidate_config->dnode, spt_plist_xpath))
+		nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_DESTROY,
+				      NULL);
+	nb_cli_enqueue_change(vty, spt_action_xpath, NB_OP_MODIFY,
+			      "PIM_SPT_INFINITY");
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+int pim_process_spt_switchover_prefixlist_cmd(struct vty *vty,
+					      const char *plist)
+{
+	const char *vrfname;
+	char spt_plist_xpath[XPATH_MAXLEN];
+	char spt_action_xpath[XPATH_MAXLEN];
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname == NULL)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
+		sizeof(spt_plist_xpath));
+
+	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
+		sizeof(spt_action_xpath));
+
+	nb_cli_enqueue_change(vty, spt_action_xpath, NB_OP_MODIFY,
+			      "PIM_SPT_INFINITY");
+	nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_MODIFY,
+			      plist);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+int pim_process_no_spt_switchover_cmd(struct vty *vty)
+{
+	const char *vrfname;
+	char spt_plist_xpath[XPATH_MAXLEN];
+	char spt_action_xpath[XPATH_MAXLEN];
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname == NULL)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
+		sizeof(spt_plist_xpath));
+
+	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
+		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
+		sizeof(spt_action_xpath));
+
+	nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_DESTROY, NULL);
+	nb_cli_enqueue_change(vty, spt_action_xpath, NB_OP_MODIFY,
+			      "PIM_SPT_IMMEDIATE");
+
+	return nb_cli_apply_changes(vty, NULL);
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -179,3 +179,29 @@ int pim_process_no_spt_switchover_cmd(struct vty *vty)
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+
+int pim_process_pim_packet_cmd(struct vty *vty, const char *packet)
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(xpath, "/packets", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, packet);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+int pim_process_no_pim_packet_cmd(struct vty *vty)
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(xpath, "/packets", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -37,4 +37,28 @@
 #include "pim_errors.h"
 #include "pim_nb.h"
 
+/**
+ * Get current node VRF name.
+ *
+ * NOTE:
+ * In case of failure it will print error message to user.
+ *
+ * \returns name or NULL if failed to get VRF.
+ */
+const char *pim_cli_get_vrf_name(struct vty *vty)
+{
+	const struct lyd_node *vrf_node;
+
+	/* Not inside any VRF context. */
+	if (vty->xpath_index == 0)
+		return VRF_DEFAULT_NAME;
+
+	vrf_node = yang_dnode_get(vty->candidate_config->dnode, VTY_CURR_XPATH);
+	if (vrf_node == NULL) {
+		vty_out(vty, "%% Failed to get vrf dnode in configuration\n");
+		return NULL;
+	}
+
+	return yang_dnode_get_string(vrf_node, "./name");
+}
 

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -300,3 +300,29 @@ int pim_process_no_rp_kat_cmd(struct vty *vty)
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+
+int pim_process_register_suppress_cmd(struct vty *vty, const char *rst)
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(xpath, "/register-suppress-time", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, rst);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+int pim_process_no_register_suppress_cmd(struct vty *vty)
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_ROUTER_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	strlcat(xpath, "/register-suppress-time", sizeof(xpath));
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -32,18 +32,9 @@
 #include "ferr.h"
 
 #include "pimd.h"
-#include "pim6_cmd.h"
 #include "pim_vty.h"
 #include "lib/northbound_cli.h"
 #include "pim_errors.h"
 #include "pim_nb.h"
-#include "pim_cmd_common.h"
 
-#ifndef VTYSH_EXTRACT_PL
-#include "pimd/pim6_cmd_clippy.c"
-#endif
 
-void pim_cmd_init(void)
-{
-	if_cmd_init(pim_interface_config_write);
-}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -205,3 +205,40 @@ int pim_process_no_pim_packet_cmd(struct vty *vty)
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+
+int pim_process_keepalivetimer_cmd(struct vty *vty, const char *kat)
+{
+	const char *vrfname;
+	char ka_timer_xpath[XPATH_MAXLEN];
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname == NULL)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_VRF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+	strlcat(ka_timer_xpath, "/keep-alive-timer", sizeof(ka_timer_xpath));
+
+	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_MODIFY,
+			      kat);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+int pim_process_no_keepalivetimer_cmd(struct vty *vty)
+{
+	const char *vrfname;
+	char ka_timer_xpath[XPATH_MAXLEN];
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname == NULL)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_VRF_XPATH,
+		 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+	strlcat(ka_timer_xpath, "/keep-alive-timer", sizeof(ka_timer_xpath));
+
+	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -29,5 +29,7 @@ int pim_process_spt_switchover_prefixlist_cmd(struct vty *vty,
 int pim_process_no_spt_switchover_cmd(struct vty *vty);
 int pim_process_pim_packet_cmd(struct vty *vty, const char *packet);
 int pim_process_no_pim_packet_cmd(struct vty *vty);
+int pim_process_keepalivetimer_cmd(struct vty *vty, const char *kat);
+int pim_process_no_keepalivetimer_cmd(struct vty *vty);
 
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -31,5 +31,7 @@ int pim_process_pim_packet_cmd(struct vty *vty, const char *packet);
 int pim_process_no_pim_packet_cmd(struct vty *vty);
 int pim_process_keepalivetimer_cmd(struct vty *vty, const char *kat);
 int pim_process_no_keepalivetimer_cmd(struct vty *vty);
+int pim_process_rp_kat_cmd(struct vty *vty, const char *rpkat);
+int pim_process_no_rp_kat_cmd(struct vty *vty);
 
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -23,5 +23,9 @@
 const char *pim_cli_get_vrf_name(struct vty *vty);
 int pim_process_join_prune_cmd(struct vty *vty, const char *jpi_str);
 int pim_process_no_join_prune_cmd(struct vty *vty);
+int pim_process_spt_switchover_infinity_cmd(struct vty *vty);
+int pim_process_spt_switchover_prefixlist_cmd(struct vty *vty,
+					      const char *plist);
+int pim_process_no_spt_switchover_cmd(struct vty *vty);
 
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -27,5 +27,7 @@ int pim_process_spt_switchover_infinity_cmd(struct vty *vty);
 int pim_process_spt_switchover_prefixlist_cmd(struct vty *vty,
 					      const char *plist);
 int pim_process_no_spt_switchover_cmd(struct vty *vty);
+int pim_process_pim_packet_cmd(struct vty *vty, const char *packet);
+int pim_process_no_pim_packet_cmd(struct vty *vty);
 
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -19,4 +19,6 @@
  */
 #ifndef PIM_CMD_COMMON_H
 #define PIM_CMD_COMMON_H
+
+const char *pim_cli_get_vrf_name(struct vty *vty);
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -17,33 +17,6 @@
  * with this program; see the file COPYING; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-
-#include <zebra.h>
-
-#include "lib/json.h"
-#include "command.h"
-#include "if.h"
-#include "prefix.h"
-#include "zclient.h"
-#include "plist.h"
-#include "hash.h"
-#include "nexthop.h"
-#include "vrf.h"
-#include "ferr.h"
-
-#include "pimd.h"
-#include "pim6_cmd.h"
-#include "pim_vty.h"
-#include "lib/northbound_cli.h"
-#include "pim_errors.h"
-#include "pim_nb.h"
-#include "pim_cmd_common.h"
-
-#ifndef VTYSH_EXTRACT_PL
-#include "pimd/pim6_cmd_clippy.c"
-#endif
-
-void pim_cmd_init(void)
-{
-	if_cmd_init(pim_interface_config_write);
-}
+#ifndef PIM_CMD_COMMON_H
+#define PIM_CMD_COMMON_H
+#endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -21,4 +21,7 @@
 #define PIM_CMD_COMMON_H
 
 const char *pim_cli_get_vrf_name(struct vty *vty);
+int pim_process_join_prune_cmd(struct vty *vty, const char *jpi_str);
+int pim_process_no_join_prune_cmd(struct vty *vty);
+
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -33,5 +33,7 @@ int pim_process_keepalivetimer_cmd(struct vty *vty, const char *kat);
 int pim_process_no_keepalivetimer_cmd(struct vty *vty);
 int pim_process_rp_kat_cmd(struct vty *vty, const char *rpkat);
 int pim_process_no_rp_kat_cmd(struct vty *vty);
+int pim_process_register_suppress_cmd(struct vty *vty, const char *rst);
+int pim_process_no_register_suppress_cmd(struct vty *vty);
 
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -305,11 +305,11 @@ int pim_static_write_mroute(struct pim_instance *pim, struct vty *vty,
 									 i);
 					if (pim_addr_is_any(sroute->source))
 						vty_out(vty,
-							" ip mroute %s %pPA\n",
+							" " PIM_AF_NAME " mroute %s %pPA\n",
 							oifp->name, &sroute->group);
 					else
 						vty_out(vty,
-							" ip mroute %s %pPA %pPA\n",
+							" " PIM_AF_NAME " mroute %s %pPA %pPA\n",
 							oifp->name, &sroute->group,
 							&sroute->source);
 					count++;

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -353,48 +353,49 @@ static int pim_igmp_config_write(struct vty *vty, int writes,
 }
 #endif
 
-#if PIM_IPV == 4
 int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
 		     struct pim_instance *pim)
 {
 	struct pim_interface *pim_ifp = ifp->info;
 
 	if (PIM_IF_TEST_PIM(pim_ifp->options)) {
-		vty_out(vty, " ip pim\n");
+		vty_out(vty, " " PIM_AF_NAME " pim\n");
 		++writes;
 	}
 
 	/* IF ip pim drpriority */
 	if (pim_ifp->pim_dr_priority != PIM_DEFAULT_DR_PRIORITY) {
-		vty_out(vty, " ip pim drpriority %u\n",
+		vty_out(vty, " " PIM_AF_NAME " pim drpriority %u\n",
 			pim_ifp->pim_dr_priority);
 		++writes;
 	}
 
 	/* IF ip pim hello */
 	if (pim_ifp->pim_hello_period != PIM_DEFAULT_HELLO_PERIOD) {
-		vty_out(vty, " ip pim hello %d", pim_ifp->pim_hello_period);
+		vty_out(vty, " " PIM_AF_NAME " pim hello %d", pim_ifp->pim_hello_period);
 		if (pim_ifp->pim_default_holdtime != -1)
 			vty_out(vty, " %d", pim_ifp->pim_default_holdtime);
 		vty_out(vty, "\n");
 		++writes;
 	}
 
+#if PIM_IPV == 4
 	writes += pim_igmp_config_write(vty, writes, pim_ifp);
+#endif
 
 	/* update source */
 	if (!pim_addr_is_any(pim_ifp->update_source)) {
-		vty_out(vty, " ip pim use-source %pPA\n",
+		vty_out(vty, " " PIM_AF_NAME " pim use-source %pPA\n",
 			&pim_ifp->update_source);
 		++writes;
 	}
 
 	if (pim_ifp->activeactive)
-		vty_out(vty, " ip pim active-active\n");
+		vty_out(vty, " " PIM_AF_NAME " pim active-active\n");
 
 	/* boundary */
 	if (pim_ifp->boundary_oil_plist) {
-		vty_out(vty, " ip multicast boundary oil %s\n",
+		vty_out(vty, " " PIM_AF_NAME " multicast boundary oil %s\n",
 			pim_ifp->boundary_oil_plist);
 		++writes;
 	}
@@ -407,7 +408,6 @@ int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
 
 	return writes;
 }
-#endif
 
 int pim_interface_config_write(struct vty *vty)
 {
@@ -438,11 +438,12 @@ int pim_interface_config_write(struct vty *vty)
 				vty_out(vty, " description %s\n", ifp->desc);
 				++writes;
 			}
-#if PIM_IPV == 4
-			if (ifp->info)
+
+			if (ifp->info) {
 				pim_config_write(vty, writes, ifp, pim);
-#endif
+			}
 			if_vty_config_end(vty);
+
 			++writes;
 		}
 	}

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -193,30 +193,30 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 	if (pim->vrf->vrf_id == VRF_DEFAULT) {
 		if (router->register_suppress_time
 		    != PIM_REGISTER_SUPPRESSION_TIME_DEFAULT) {
-			vty_out(vty, "%sip pim register-suppress-time %d\n",
-					spaces, router->register_suppress_time);
+			vty_out(vty, "%s" PIM_AF_NAME " pim register-suppress-time %d\n",
+				spaces, router->register_suppress_time);
 			++writes;
 		}
 		if (router->t_periodic != PIM_DEFAULT_T_PERIODIC) {
-			vty_out(vty, "%sip pim join-prune-interval %d\n",
+			vty_out(vty, "%s" PIM_AF_NAME " pim join-prune-interval %d\n",
 				spaces, router->t_periodic);
 			++writes;
 		}
 
 		if (router->packet_process != PIM_DEFAULT_PACKET_PROCESS) {
-			vty_out(vty, "%sip pim packets %d\n", spaces,
+			vty_out(vty, "%s" PIM_AF_NAME " pim packets %d\n", spaces,
 				router->packet_process);
 			++writes;
 		}
 	}
 	if (pim->keep_alive_time != PIM_KEEPALIVE_PERIOD) {
-		vty_out(vty, "%sip pim keep-alive-timer %d\n", spaces,
-			pim->keep_alive_time);
+		vty_out(vty, "%s" PIM_AF_NAME " pim keep-alive-timer %d\n",
+			spaces, pim->keep_alive_time);
 		++writes;
 	}
 	if (pim->rp_keep_alive_time != (unsigned int)PIM_RP_KEEPALIVE_PERIOD) {
-		vty_out(vty, "%sip pim rp keep-alive-timer %d\n", spaces,
-			pim->rp_keep_alive_time);
+		vty_out(vty, "%s" PIM_AF_NAME " pim rp keep-alive-timer %d\n",
+			spaces, pim->rp_keep_alive_time);
 		++writes;
 	}
 	if (ssm->plist_name) {
@@ -232,11 +232,11 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 	if (pim->spt.switchover == PIM_SPT_INFINITY) {
 		if (pim->spt.plist)
 			vty_out(vty,
-				"%sip pim spt-switchover infinity-and-beyond prefix-list %s\n",
+				"%s" PIM_AF_NAME " pim spt-switchover infinity-and-beyond prefix-list %s\n",
 				spaces, pim->spt.plist);
 		else
 			vty_out(vty,
-				"%sip pim spt-switchover infinity-and-beyond\n",
+				"%s" PIM_AF_NAME " pim spt-switchover infinity-and-beyond\n",
 				spaces);
 		++writes;
 	}

--- a/pimd/pim_vty.h
+++ b/pimd/pim_vty.h
@@ -25,5 +25,8 @@
 int pim_debug_config_write(struct vty *vty);
 int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty);
 int pim_interface_config_write(struct vty *vty);
-
+#if PIM_IPV == 4
+int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
+		     struct pim_instance *pim);
+#endif
 #endif /* PIM_VTY_H */

--- a/pimd/pim_vty.h
+++ b/pimd/pim_vty.h
@@ -25,8 +25,6 @@
 int pim_debug_config_write(struct vty *vty);
 int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty);
 int pim_interface_config_write(struct vty *vty);
-#if PIM_IPV == 4
 int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
 		     struct pim_instance *pim);
-#endif
 #endif /* PIM_VTY_H */

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -32,7 +32,11 @@
 #include "bfd.h"
 
 #include "pimd.h"
+#if PIM_IPV == 4
 #include "pim_cmd.h"
+#else
+#include "pim6_cmd.h"
+#endif
 #include "pim_str.h"
 #include "pim_oil.h"
 #include "pim_pim.h"

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -6,10 +6,10 @@ if PIMD
 sbin_PROGRAMS += pimd/pimd
 bin_PROGRAMS += pimd/mtracebis
 noinst_PROGRAMS += pimd/test_igmpv3_join
-vtysh_scan += pimd/pim_cmd.c
-
-# Add pim6_cmd.c under vtysh_scan, once the file is merged
-
+vtysh_scan += \
+	pimd/pim_cmd.c \
+	pimd/pim6_cmd.c \
+	#end
 vtysh_daemons += pimd
 vtysh_daemons += pim6d
 man8 += $(MANBUILD)/frr-pimd.8
@@ -87,6 +87,7 @@ pimd_pim6d_SOURCES = \
 	$(pim_common) \
 	pimd/pim6_main.c \
 	pimd/pim6_stubs.c \
+	pimd/pim6_cmd.c \
 	# end
 
 nodist_pimd_pim6d_SOURCES = \
@@ -150,10 +151,12 @@ noinst_HEADERS += \
 	pimd/pimd.h \
 	pimd/mtracebis_netlink.h \
 	pimd/mtracebis_routeget.h \
+	pimd/pim6_cmd.h \
 	# end
 
 clippy_scan += \
 	pimd/pim_cmd.c \
+	pimd/pim6_cmd.c \
 	# end
 
 pimd_pimd_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=4

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -22,6 +22,7 @@ pim_common = \
 	pimd/pim_bfd.c \
 	pimd/pim_br.c \
 	pimd/pim_bsm.c \
+	pimd/pim_cmd_common.c \
 	pimd/pim_errors.c \
 	pimd/pim_hello.c \
 	pimd/pim_iface.c \
@@ -103,6 +104,7 @@ noinst_HEADERS += \
 	pimd/pim_br.h \
 	pimd/pim_bsm.h \
 	pimd/pim_cmd.h \
+	pimd/pim_cmd_common.h \
 	pimd/pim_errors.h \
 	pimd/pim_hello.h \
 	pimd/pim_iface.h \


### PR DESCRIPTION
This PR adds the below top level CLIs for PIMv6.

Adding the below CLIs for PIMv6 Daemon:

[no] ipv6 pim register-suppress-time (1-65535)

[no] ipv6 pim rp keep-alive-timer [(1-65535)]

[no] ipv6 pim keep-alive-timer (1-65535)

[no] ipv6 pim packet (1-255)

[no] ipv6 pim spt-switchover infinity-and-beyond

[no] ipv6 pim spt-switchover infinity-and-beyond prefix-list WORD

[no] ipv6 pim join-prune interval (1-65535)

Note: The first 4 commits are common in #10393
#10365
#10366 
since we are using the same file. This has been done to ease development.

Signed-off-by: Mobashshera Rasool mrasool@vmware.com