### PR TITLE
ospf6d: Fix ECMP inter-area route nexthop update

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -1276,7 +1276,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 			continue;
 		}
 
-		ospf6_route_merge_nexthops(old_route, route);
+		list_delete_all_node(old_route->nh_list);
+		ospf6_route_copy_nexthops(old_route, route);
 		old_entry_updated = true;
 
 		for (ALL_LIST_ELEMENTS_RO(old_route->paths, anode,


### PR DESCRIPTION
Fixes #9720. When updating an ECMP inter-area route, we compute
a new route and check whether that already exists. If so, we keep the old
route and only update its nexthops. Previously, we merged the new route's
nexthops into the old one's, but this way, it's impossible to remove
nexthops from the old route, resulting in stale nexthops.

This commit fixes this by first removing all nexthops from the old route and
then copying all nexthops from the new route into it. If the new route has
fewer nexthops, the old one will have as well afterwards.

Signed-off-by: Martin Buck <mb-tmp-tvguho.pbz@gromit.dyndns.org>