### PR TITLE
topotests: isis vrf config changed

### DIFF
--- a/tests/topotests/isis_topo1_vrf/r1/isisd.conf
+++ b/tests/topotests/isis_topo1_vrf/r1/isisd.conf
@@ -2,9 +2,9 @@ hostname r1
 ! debug isis adj-packets
 ! debug isis events
 ! debug isis update-packets
-interface r1-eth0
- ip router isis 1 vrf r1-cust1
- ipv6 router isis 1 vrf r1-cust1
+interface r1-eth0 vrf r1-cust1
+ ip router isis 1
+ ipv6 router isis 1
  isis circuit-type level-2-only
 !
 router isis 1 vrf r1-cust1 

--- a/tests/topotests/isis_topo1_vrf/r2/isisd.conf
+++ b/tests/topotests/isis_topo1_vrf/r2/isisd.conf
@@ -2,9 +2,9 @@ hostname r2
 ! debug isis adj-packets
 ! debug isis events
 ! debug isis update-packets
-interface r2-eth0
- ip router isis 1 vrf r2-cust1
- ipv6 router isis 1 vrf r2-cust1
+interface r2-eth0 vrf r2-cust1
+ ip router isis 1
+ ipv6 router isis 1
  isis circuit-type level-2-only
 !
 router isis 1 vrf r2-cust1

--- a/tests/topotests/isis_topo1_vrf/r3/isisd.conf
+++ b/tests/topotests/isis_topo1_vrf/r3/isisd.conf
@@ -2,14 +2,14 @@ hostname r3
 ! debug isis adj-packets
 ! debug isis events
 ! debug isis update-packets
-interface r3-eth0
- ip router isis 1 vrf r3-cust1
- ipv6 router isis 1 vrf r3-cust1
+interface r3-eth0 vrf r3-cust1
+ ip router isis 1
+ ipv6 router isis 1
  isis circuit-type level-2-only
 !
-interface r3-eth1
- ip router isis 1 vrf r3-cust1
- ipv6 router isis 1 vrf r3-cust1
+interface r3-eth1 vrf r3-cust1
+ ip router isis 1
+ ipv6 router isis 1
  isis circuit-type level-1
 !
 router isis 1 vrf r3-cust1

--- a/tests/topotests/isis_topo1_vrf/r4/isisd.conf
+++ b/tests/topotests/isis_topo1_vrf/r4/isisd.conf
@@ -5,14 +5,14 @@ hostname r4
 ! debug isis lsp-gen
 ! debug isis lsp-sched
 
-interface r4-eth0
- ip router isis 1 vrf r4-cust1
- ipv6 router isis 1 vrf r4-cust1
+interface r4-eth0 vrf r4-cust1
+ ip router isis 1
+ ipv6 router isis 1
  isis circuit-type level-2-only
 !
-interface r4-eth1
- ip router isis 1 vrf r4-cust1
- ipv6 router isis 1 vrf r4-cust1
+interface r4-eth1 vrf r4-cust1
+ ip router isis 1
+ ipv6 router isis 1
  isis circuit-type level-1
 !
 router isis 1 vrf r4-cust1

--- a/tests/topotests/isis_topo1_vrf/r5/isisd.conf
+++ b/tests/topotests/isis_topo1_vrf/r5/isisd.conf
@@ -2,14 +2,14 @@ hostname r5
 ! debug isis adj-packets
 ! debug isis events
 ! debug isis update-packets
-interface r5-eth0
- ip router isis 1 vrf r5-cust1
- ipv6 router isis 1 vrf r5-cust1
+interface r5-eth0 vrf r5-cust1
+ ip router isis 1
+ ipv6 router isis 1
  isis circuit-type level-1
 !
-interface r5-eth1
- ip router isis 1 vrf r5-cust1
- ipv6 router isis 1 vrf r5-cust1
+interface r5-eth1 vrf r5-cust1
+ ip router isis 1
+ ipv6 router isis 1
  isis circuit-type level-1
 !
 router isis 1 vrf r5-cust1


### PR DESCRIPTION
Use vrf keyword for interface, and directly configure isis under
that interface.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>