### PR TITLE
pimv6 Interface cli implementation 

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -340,6 +340,32 @@ DEFPY_HIDDEN (interface_no_ipv6_pim_sm,
 	return pim_process_no_ip_pim_cmd(vty);
 }
 
+/* boundaries */
+DEFPY (interface_ipv6_pim_boundary_oil,
+      interface_ipv6_pim_boundary_oil_cmd,
+      "ipv6 multicast boundary oil WORD",
+      IPV6_STR
+      "Generic multicast configuration options\n"
+      "Define multicast boundary\n"
+      "Filter OIL by group using prefix list\n"
+      "Prefix list to filter OIL with\n")
+{
+	return pim_process_ip_pim_boundary_oil_cmd(vty, oil);
+}
+
+DEFPY (interface_no_ipv6_pim_boundary_oil,
+      interface_no_ipv6_pim_boundary_oil_cmd,
+      "no ipv6 multicast boundary oil [WORD]",
+      NO_STR
+      IPV6_STR
+      "Generic multicast configuration options\n"
+      "Define multicast boundary\n"
+      "Filter OIL by group using prefix list\n"
+      "Prefix list to filter OIL with\n")
+{
+	return pim_process_no_ip_pim_boundary_oil_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -369,4 +395,8 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_ssm_cmd);
 	install_element(INTERFACE_NODE, &interface_ipv6_pim_sm_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_sm_cmd);
+	install_element(INTERFACE_NODE,
+			&interface_ipv6_pim_boundary_oil_cmd);
+	install_element(INTERFACE_NODE,
+			&interface_no_ipv6_pim_boundary_oil_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -319,6 +319,27 @@ DEFPY_HIDDEN (interface_no_ipv6_pim_ssm,
 	return pim_process_no_ip_pim_cmd(vty);
 }
 
+DEFPY_HIDDEN (interface_ipv6_pim_sm,
+	      interface_ipv6_pim_sm_cmd,
+	      "ipv6 pim sm",
+	      IPV6_STR
+	      PIM_STR
+	      IFACE_PIM_SM_STR)
+{
+	return pim_process_ip_pim_cmd(vty);
+}
+
+DEFPY_HIDDEN (interface_no_ipv6_pim_sm,
+	      interface_no_ipv6_pim_sm_cmd,
+	      "no ipv6 pim sm",
+	      NO_STR
+	      IPV6_STR
+	      PIM_STR
+	      IFACE_PIM_SM_STR)
+{
+	return pim_process_no_ip_pim_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -346,4 +367,6 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_ipv6_pim_activeactive_cmd);
 	install_element(INTERFACE_NODE, &interface_ipv6_pim_ssm_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_ssm_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_sm_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_sm_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -210,6 +210,25 @@ DEFPY (no_ipv6_pim_register_suppress,
 	return pim_process_no_register_suppress_cmd(vty);
 }
 
+DEFPY (interface_ipv6_pim,
+       interface_ipv6_pim_cmd,
+       "ipv6 pim",
+       IPV6_STR
+       PIM_STR)
+{
+	return pim_process_ip_pim_cmd(vty);
+}
+
+DEFPY (interface_no_ipv6_pim,
+       interface_no_ipv6_pim_cmd,
+       "no ipv6 pim",
+       NO_STR
+       IPV6_STR
+       PIM_STR)
+{
+	return pim_process_no_ip_pim_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -228,4 +247,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_ipv6_pim_rp_keep_alive_cmd);
 	install_element(CONFIG_NODE, &ipv6_pim_register_suppress_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_register_suppress_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -366,6 +366,32 @@ DEFPY (interface_no_ipv6_pim_boundary_oil,
 	return pim_process_no_ip_pim_boundary_oil_cmd(vty);
 }
 
+DEFPY (interface_ipv6_mroute,
+       interface_ipv6_mroute_cmd,
+       "ipv6 mroute INTERFACE X:X::X:X$group [X:X::X:X]$source",
+       IPV6_STR
+       "Add multicast route\n"
+       "Outgoing interface name\n"
+       "Group address\n"
+       "Source address\n")
+{
+	return pim_process_ip_mroute_cmd(vty, interface, group_str, source_str);
+}
+
+DEFPY (interface_no_ipv6_mroute,
+       interface_no_ipv6_mroute_cmd,
+       "no ipv6 mroute INTERFACE X:X::X:X$group [X:X::X:X]$source",
+       NO_STR
+       IPV6_STR
+       "Add multicast route\n"
+       "Outgoing interface name\n"
+       "Group Address\n"
+       "Source Address\n")
+{
+	return pim_process_no_ip_mroute_cmd(vty, interface, group_str,
+					    source_str);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -399,4 +425,6 @@ void pim_cmd_init(void)
 			&interface_ipv6_pim_boundary_oil_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ipv6_pim_boundary_oil_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_mroute_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_mroute_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -277,6 +277,17 @@ DEFPY (interface_no_ipv6_pim_hello,
 	return pim_process_no_ip_pim_hello_cmd(vty);
 }
 
+DEFPY (interface_ipv6_pim_activeactive,
+       interface_ipv6_pim_activeactive_cmd,
+       "[no] ipv6 pim active-active",
+       NO_STR
+       IPV6_STR
+       PIM_STR
+       "Mark interface as Active-Active for MLAG operations\n")
+{
+	return pim_process_ip_pim_activeactive_cmd(vty, no);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -301,4 +312,5 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_drprio_cmd);
 	install_element(INTERFACE_NODE, &interface_ipv6_pim_hello_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_hello_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_activeactive_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -252,6 +252,31 @@ DEFPY (interface_no_ipv6_pim_drprio,
 	return pim_process_no_ip_pim_drprio_cmd(vty);
 }
 
+DEFPY (interface_ipv6_pim_hello,
+       interface_ipv6_pim_hello_cmd,
+       "ipv6 pim hello (1-65535) [(1-65535)]$hold",
+       IPV6_STR
+       PIM_STR
+       IFACE_PIM_HELLO_STR
+       IFACE_PIM_HELLO_TIME_STR
+       IFACE_PIM_HELLO_HOLD_STR)
+{
+	return pim_process_ip_pim_hello_cmd(vty, hello_str, hold_str);
+}
+
+DEFPY (interface_no_ipv6_pim_hello,
+       interface_no_ipv6_pim_hello_cmd,
+       "no ipv6 pim hello [(1-65535) [(1-65535)]]",
+       NO_STR
+       IPV6_STR
+       PIM_STR
+       IFACE_PIM_HELLO_STR
+       IGNORED_IN_NO_STR
+       IGNORED_IN_NO_STR)
+{
+	return pim_process_no_ip_pim_hello_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -274,4 +299,6 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_cmd);
 	install_element(INTERFACE_NODE, &interface_ipv6_pim_drprio_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_drprio_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_hello_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_hello_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -229,6 +229,29 @@ DEFPY (interface_no_ipv6_pim,
 	return pim_process_no_ip_pim_cmd(vty);
 }
 
+DEFPY (interface_ipv6_pim_drprio,
+       interface_ipv6_pim_drprio_cmd,
+       "ipv6 pim drpriority (1-4294967295)",
+       IPV6_STR
+       PIM_STR
+       "Set the Designated Router Election Priority\n"
+       "Value of the new DR Priority\n")
+{
+	return pim_process_ip_pim_drprio_cmd(vty, drpriority_str);
+}
+
+DEFPY (interface_no_ipv6_pim_drprio,
+       interface_no_ipv6_pim_drprio_cmd,
+       "no ip pim drpriority [(1-4294967295)]",
+       NO_STR
+       IPV6_STR
+       PIM_STR
+       "Revert the Designated Router Priority to default\n"
+       "Old Value of the Priority\n")
+{
+	return pim_process_no_ip_pim_drprio_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -249,4 +272,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_ipv6_pim_register_suppress_cmd);
 	install_element(INTERFACE_NODE, &interface_ipv6_pim_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_drprio_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_drprio_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -288,6 +288,37 @@ DEFPY (interface_ipv6_pim_activeactive,
 	return pim_process_ip_pim_activeactive_cmd(vty, no);
 }
 
+DEFPY_HIDDEN (interface_ipv6_pim_ssm,
+              interface_ipv6_pim_ssm_cmd,
+              "ipv6 pim ssm",
+              IPV6_STR
+              PIM_STR
+              IFACE_PIM_STR)
+{
+	int ret;
+
+	ret = pim_process_ip_pim_cmd(vty);
+
+	if (ret != NB_OK)
+		return ret;
+
+	vty_out(vty,
+		"Enabled PIM SM on interface; configure PIM SSM range if needed\n");
+
+	return NB_OK;
+}
+
+DEFPY_HIDDEN (interface_no_ipv6_pim_ssm,
+              interface_no_ipv6_pim_ssm_cmd,
+              "no ipv6 pim ssm",
+              NO_STR
+              IPV6_STR
+              PIM_STR
+              IFACE_PIM_STR)
+{
+	return pim_process_no_ip_pim_cmd(vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -313,4 +344,6 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_ipv6_pim_hello_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_hello_cmd);
 	install_element(INTERFACE_NODE, &interface_ipv6_pim_activeactive_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_ssm_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_ssm_cmd);
 }

--- a/pimd/pim6_cmd.h
+++ b/pimd/pim6_cmd.h
@@ -33,6 +33,9 @@
 #define IFACE_MLD_LAST_MEMBER_QUERY_INTERVAL_STR \
 	"MLD last member query interval\n"
 #define IFACE_MLD_LAST_MEMBER_QUERY_COUNT_STR "MLD last member query count\n"
+#define IFACE_PIM_HELLO_STR "Hello Interval\n"
+#define IFACE_PIM_HELLO_TIME_STR "Time in seconds for Hello Interval\n"
+#define IFACE_PIM_HELLO_HOLD_STR "Time in seconds for Hold Interval\n"
 #define MROUTE_STR "IP multicast routing table\n"
 #define DEBUG_MLD_STR "MLD protocol activity\n"
 #define DEBUG_MLD_EVENTS_STR "MLD protocol events\n"

--- a/pimd/pim6_cmd.h
+++ b/pimd/pim6_cmd.h
@@ -34,6 +34,7 @@
 	"MLD last member query interval\n"
 #define IFACE_MLD_LAST_MEMBER_QUERY_COUNT_STR "MLD last member query count\n"
 #define IFACE_PIM_STR "Enable PIM SSM operation\n"
+#define IFACE_PIM_SM_STR "Enable PIM SM operation\n"
 #define IFACE_PIM_HELLO_STR "Hello Interval\n"
 #define IFACE_PIM_HELLO_TIME_STR "Time in seconds for Hello Interval\n"
 #define IFACE_PIM_HELLO_HOLD_STR "Time in seconds for Hold Interval\n"

--- a/pimd/pim6_cmd.h
+++ b/pimd/pim6_cmd.h
@@ -33,6 +33,7 @@
 #define IFACE_MLD_LAST_MEMBER_QUERY_INTERVAL_STR \
 	"MLD last member query interval\n"
 #define IFACE_MLD_LAST_MEMBER_QUERY_COUNT_STR "MLD last member query count\n"
+#define IFACE_PIM_STR "Enable PIM SSM operation\n"
 #define IFACE_PIM_HELLO_STR "Hello Interval\n"
 #define IFACE_PIM_HELLO_TIME_STR "Time in seconds for Hello Interval\n"
 #define IFACE_PIM_HELLO_HOLD_STR "Time in seconds for Hold Interval\n"

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -33,7 +33,6 @@ typedef struct in_addr pim_addr;
 #define PIM_AFI		AFI_IP
 #define PIM_MAX_BITLEN	IPV4_MAX_BITLEN
 #define PIM_AF_NAME     "ip"
-#define	FRR_PIM_AF_XPATH_VAL "frr-routing:ipv4"
 
 union pimprefixptr {
 	prefixtype(pimprefixptr, struct prefix,      p)
@@ -53,7 +52,6 @@ typedef struct in6_addr pim_addr;
 #define PIM_AFI		AFI_IP6
 #define PIM_MAX_BITLEN	IPV6_MAX_BITLEN
 #define PIM_AF_NAME     "ipv6"
-#define	FRR_PIM_AF_XPATH_VAL "frr-routing:ipv6"
 
 union pimprefixptr {
 	prefixtype(pimprefixptr, struct prefix,      p)

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8180,13 +8180,8 @@ DEFUN (interface_ip_mroute,
 	else
 		source_str = argv[idx_ipv4 + 1]->arg;
 
-	nb_cli_enqueue_change(vty, "./oif", NB_OP_MODIFY,
-			      argv[idx_interface]->arg);
-
-	return nb_cli_apply_changes(vty,
-				    FRR_PIM_MROUTE_XPATH,
-				    "frr-routing:ipv4", source_str,
-				    argv[idx_ipv4]->arg);
+	return pim_process_ip_mroute_cmd(vty, argv[idx_interface]->arg,
+					 argv[idx_ipv4]->arg, source_str);
 }
 
 DEFUN (interface_no_ip_mroute,
@@ -8199,6 +8194,7 @@ DEFUN (interface_no_ip_mroute,
        "Group Address\n"
        "Source Address\n")
 {
+	int idx_interface = 3;
 	int idx_ipv4 = 4;
 	const char *source_str;
 
@@ -8207,12 +8203,8 @@ DEFUN (interface_no_ip_mroute,
 	else
 		source_str = argv[idx_ipv4 + 1]->arg;
 
-	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
-
-	return nb_cli_apply_changes(vty,
-				    FRR_PIM_MROUTE_XPATH,
-				    "frr-routing:ipv4", source_str,
-				    argv[idx_ipv4]->arg);
+	return pim_process_no_ip_mroute_cmd(vty, argv[idx_interface]->arg,
+					    argv[idx_ipv4]->arg, source_str);
 }
 
 DEFUN (interface_ip_pim_hello,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7959,11 +7959,7 @@ DEFUN (interface_ip_pim_drprio,
 {
 	int idx_number = 3;
 
-	nb_cli_enqueue_change(vty, "./dr-priority", NB_OP_MODIFY,
-			      argv[idx_number]->arg);
-
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	return pim_process_ip_pim_drprio_cmd(vty, argv[idx_number]->arg);
 }
 
 DEFUN (interface_no_ip_pim_drprio,
@@ -7975,10 +7971,7 @@ DEFUN (interface_no_ip_pim_drprio,
        "Revert the Designated Router Priority to default\n"
        "Old Value of the Priority\n")
 {
-	nb_cli_enqueue_change(vty, "./dr-priority", NB_OP_DESTROY, NULL);
-
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				   "frr-routing:ipv4");
+	return pim_process_no_ip_pim_drprio_cmd(vty);
 }
 
 DEFPY_HIDDEN (interface_ip_igmp_query_generate,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8074,11 +8074,7 @@ DEFUN_HIDDEN (interface_ip_pim_ssm,
 {
 	int ret;
 
-	nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY, "true");
-
-	ret = nb_cli_apply_changes(vty,
-			FRR_PIM_INTERFACE_XPATH,
-			"frr-routing:ipv4");
+	ret = pim_process_ip_pim_cmd(vty);
 
 	if (ret != NB_OK)
 		return ret;
@@ -8120,39 +8116,7 @@ DEFUN_HIDDEN (interface_no_ip_pim_ssm,
 	      PIM_STR
 	      IFACE_PIM_STR)
 {
-	const struct lyd_node *igmp_enable_dnode;
-	char igmp_if_xpath[XPATH_MAXLEN];
-
-	int printed =
-		snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
-			 "%s/frr-gmp:gmp/address-family[address-family='%s']",
-			 VTY_CURR_XPATH, "frr-routing:ipv4");
-
-	if (printed >= (int)(sizeof(igmp_if_xpath))) {
-		vty_out(vty, "Xpath too long (%d > %u)", printed + 1,
-			XPATH_MAXLEN);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	igmp_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
-					    FRR_GMP_ENABLE_XPATH,
-					    VTY_CURR_XPATH,
-					    "frr-routing:ipv4");
-	if (!igmp_enable_dnode) {
-		nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY, NULL);
-		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
-	} else {
-		if (!yang_dnode_get_bool(igmp_enable_dnode, ".")) {
-			nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY,
-					      NULL);
-			nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
-		} else
-			nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
-					      "false");
-	}
-
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	return pim_process_no_ip_pim_cmd(vty);
 }
 
 DEFUN_HIDDEN (interface_no_ip_pim_sm,
@@ -8207,7 +8171,7 @@ DEFUN (interface_no_ip_pim,
        IP_STR
        PIM_STR)
 {
-	pim_process_no_ip_pim_cmd(vty);
+	return pim_process_no_ip_pim_cmd(vty);
 }
 
 /* boundaries */

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8324,31 +8324,14 @@ DEFUN (interface_ip_pim_hello,
 {
 	int idx_time = 3;
 	int idx_hold = 4;
-	const struct lyd_node *igmp_enable_dnode;
-
-	igmp_enable_dnode =
-		yang_dnode_getf(vty->candidate_config->dnode,
-				FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
-				"frr-routing:ipv4");
-	if (!igmp_enable_dnode) {
-		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
-				      "true");
-	} else {
-		if (!yang_dnode_get_bool(igmp_enable_dnode, "."))
-			nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
-					      "true");
-	}
-
-	nb_cli_enqueue_change(vty, "./hello-interval", NB_OP_MODIFY,
-			      argv[idx_time]->arg);
 
 	if (argc == idx_hold + 1)
-		nb_cli_enqueue_change(vty, "./hello-holdtime", NB_OP_MODIFY,
-				      argv[idx_hold]->arg);
+		return pim_process_ip_pim_hello_cmd(vty, argv[idx_time]->arg,
+						    argv[idx_hold]->arg);
 
-	return nb_cli_apply_changes(vty,
-				    FRR_PIM_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	else
+		return pim_process_ip_pim_hello_cmd(vty, argv[idx_time]->arg,
+						    NULL);
 }
 
 DEFUN (interface_no_ip_pim_hello,
@@ -8361,12 +8344,7 @@ DEFUN (interface_no_ip_pim_hello,
        IGNORED_IN_NO_STR
        IGNORED_IN_NO_STR)
 {
-	nb_cli_enqueue_change(vty, "./hello-interval", NB_OP_DESTROY, NULL);
-	nb_cli_enqueue_change(vty, "./hello-holdtime", NB_OP_DESTROY, NULL);
-
-	return nb_cli_apply_changes(vty,
-				    FRR_PIM_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	return pim_process_no_ip_pim_hello_cmd(vty);
 }
 
 DEFUN (debug_igmp,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8092,11 +8092,7 @@ DEFUN_HIDDEN (interface_ip_pim_sm,
 	      PIM_STR
 	      IFACE_PIM_SM_STR)
 {
-	nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY, "true");
-
-	return nb_cli_apply_changes(vty,
-			FRR_PIM_INTERFACE_XPATH,
-			"frr-routing:ipv4");
+	return pim_process_ip_pim_cmd(vty);
 }
 
 DEFUN (interface_ip_pim,
@@ -8127,41 +8123,7 @@ DEFUN_HIDDEN (interface_no_ip_pim_sm,
 	      PIM_STR
 	      IFACE_PIM_SM_STR)
 {
-	const struct lyd_node *igmp_enable_dnode;
-	char igmp_if_xpath[XPATH_MAXLEN];
-
-	int printed =
-		snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
-			 "%s/frr-gmp:gmp/address-family[address-family='%s']",
-			 VTY_CURR_XPATH, "frr-routing:ipv4");
-
-	if (printed >= (int)(sizeof(igmp_if_xpath))) {
-		vty_out(vty, "Xpath too long (%d > %u)", printed + 1,
-			XPATH_MAXLEN);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	igmp_enable_dnode =
-		yang_dnode_getf(vty->candidate_config->dnode,
-				FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
-				"frr-routing:ipv4");
-
-	if (!igmp_enable_dnode) {
-		nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY, NULL);
-		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
-	} else {
-		if (!yang_dnode_get_bool(igmp_enable_dnode, ".")) {
-			nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY,
-					      NULL);
-			nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
-		} else
-			nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
-					      "false");
-	}
-
-	return nb_cli_apply_changes(vty,
-			FRR_PIM_INTERFACE_XPATH,
-			"frr-routing:ipv4");
+	return pim_process_no_ip_pim_cmd(vty);
 }
 
 DEFUN (interface_no_ip_pim,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8129,12 +8129,7 @@ DEFUN (interface_ip_pim,
        IP_STR
        PIM_STR)
 {
-	nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY, "true");
-
-	return nb_cli_apply_changes(vty,
-			FRR_PIM_INTERFACE_XPATH,
-			"frr-routing:ipv4");
-
+	return pim_process_ip_pim_cmd(vty);
 }
 
 DEFUN_HIDDEN (interface_no_ip_pim_ssm,
@@ -8232,41 +8227,7 @@ DEFUN (interface_no_ip_pim,
        IP_STR
        PIM_STR)
 {
-	const struct lyd_node *igmp_enable_dnode;
-	char igmp_if_xpath[XPATH_MAXLEN];
-
-	int printed =
-		snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
-			 "%s/frr-gmp:gmp/address-family[address-family='%s']",
-			 VTY_CURR_XPATH, "frr-routing:ipv4");
-
-	if (printed >= (int)(sizeof(igmp_if_xpath))) {
-		vty_out(vty, "Xpath too long (%d > %u)", printed + 1,
-			XPATH_MAXLEN);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	igmp_enable_dnode =
-		yang_dnode_getf(vty->candidate_config->dnode,
-				FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
-				"frr-routing:ipv4");
-
-	if (!igmp_enable_dnode) {
-		nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY, NULL);
-		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
-	} else {
-		if (!yang_dnode_get_bool(igmp_enable_dnode, ".")) {
-			nb_cli_enqueue_change(vty, igmp_if_xpath, NB_OP_DESTROY,
-					      NULL);
-			nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
-		} else
-			nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
-					      "false");
-	}
-
-	return nb_cli_apply_changes(vty,
-				    FRR_PIM_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	pim_process_no_ip_pim_cmd(vty);
 }
 
 /* boundaries */

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8062,20 +8062,7 @@ DEFPY (interface_ip_pim_activeactive,
        PIM_STR
        "Mark interface as Active-Active for MLAG operations, Hidden because not finished yet\n")
 {
-	if (no)
-		nb_cli_enqueue_change(vty, "./active-active", NB_OP_MODIFY,
-				      "false");
-	else {
-		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
-				      "true");
-
-		nb_cli_enqueue_change(vty, "./active-active", NB_OP_MODIFY,
-				      "true");
-	}
-
-	return nb_cli_apply_changes(vty,
-			FRR_PIM_INTERFACE_XPATH,
-			"frr-routing:ipv4");
+	return pim_process_ip_pim_activeactive_cmd(vty, no);
 }
 
 DEFUN_HIDDEN (interface_ip_pim_ssm,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8146,13 +8146,7 @@ DEFUN(interface_ip_pim_boundary_oil,
       "Filter OIL by group using prefix list\n"
       "Prefix list to filter OIL with\n")
 {
-	nb_cli_enqueue_change(vty, "./multicast-boundary-oil", NB_OP_MODIFY,
-			      argv[4]->arg);
-
-	return nb_cli_apply_changes(vty,
-				    FRR_PIM_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
-
+	return pim_process_ip_pim_boundary_oil_cmd(vty, argv[4]->arg);
 }
 
 DEFUN(interface_no_ip_pim_boundary_oil,
@@ -8165,12 +8159,7 @@ DEFUN(interface_no_ip_pim_boundary_oil,
       "Filter OIL by group using prefix list\n"
       "Prefix list to filter OIL with\n")
 {
-	nb_cli_enqueue_change(vty, "./multicast-boundary-oil", NB_OP_DESTROY,
-			      NULL);
-
-	return nb_cli_apply_changes(vty,
-				    FRR_PIM_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	return pim_process_no_ip_pim_boundary_oil_cmd(vty);
 }
 
 DEFUN (interface_ip_mroute,

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -425,3 +425,20 @@ int pim_process_no_ip_pim_hello_cmd(struct vty *vty)
 	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
 				    FRR_PIM_AF_XPATH_VAL);
 }
+
+int pim_process_ip_pim_activeactive_cmd(struct vty *vty, const char *no)
+{
+	if (no)
+		nb_cli_enqueue_change(vty, "./active-active", NB_OP_MODIFY,
+				      "false");
+	else {
+		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
+				      "true");
+
+		nb_cli_enqueue_change(vty, "./active-active", NB_OP_MODIFY,
+				      "true");
+	}
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -30,6 +30,7 @@
 #include "nexthop.h"
 #include "vrf.h"
 #include "ferr.h"
+#include "lib/srcdest_table.h"
 
 #include "pimd.h"
 #include "pim_vty.h"
@@ -459,4 +460,42 @@ int pim_process_no_ip_pim_boundary_oil_cmd(struct vty *vty)
 
 	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
 				    FRR_PIM_AF_XPATH_VAL);
+}
+
+int pim_process_ip_mroute_cmd(struct vty *vty, const char *interface,
+			      const char *group_str, const char *source_str)
+{
+	nb_cli_enqueue_change(vty, "./oif", NB_OP_MODIFY, interface);
+
+	if (!source_str) {
+		char buf[SRCDEST2STR_BUFFER];
+
+		inet_ntop(AF_INET6, &in6addr_any, buf, sizeof(buf));
+		return nb_cli_apply_changes(vty, FRR_PIM_MROUTE_XPATH,
+					    FRR_PIM_AF_XPATH_VAL, buf,
+					    group_str);
+	}
+
+	return nb_cli_apply_changes(vty, FRR_PIM_MROUTE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL, source_str,
+				    group_str);
+}
+
+int pim_process_no_ip_mroute_cmd(struct vty *vty, const char *interface,
+				 const char *group_str, const char *source_str)
+{
+	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
+
+	if (!source_str) {
+		char buf[SRCDEST2STR_BUFFER];
+
+		inet_ntop(AF_INET6, &in6addr_any, buf, sizeof(buf));
+		return nb_cli_apply_changes(vty, FRR_PIM_MROUTE_XPATH,
+					    FRR_PIM_AF_XPATH_VAL, buf,
+					    group_str);
+	}
+
+	return nb_cli_apply_changes(vty, FRR_PIM_MROUTE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL, source_str,
+				    group_str);
 }

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -371,3 +371,20 @@ int pim_process_no_ip_pim_cmd(struct vty *vty)
 	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
 				    FRR_PIM_AF_XPATH_VAL);
 }
+
+int pim_process_ip_pim_drprio_cmd(struct vty *vty, const char *drpriority_str)
+{
+	nb_cli_enqueue_change(vty, "./dr-priority", NB_OP_MODIFY,
+			      drpriority_str);
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}
+
+int pim_process_no_ip_pim_drprio_cmd(struct vty *vty)
+{
+	nb_cli_enqueue_change(vty, "./dr-priority", NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -442,3 +442,21 @@ int pim_process_ip_pim_activeactive_cmd(struct vty *vty, const char *no)
 	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
 				    FRR_PIM_AF_XPATH_VAL);
 }
+
+int pim_process_ip_pim_boundary_oil_cmd(struct vty *vty, const char *oil)
+{
+	nb_cli_enqueue_change(vty, "./multicast-boundary-oil", NB_OP_MODIFY,
+			      oil);
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}
+
+int pim_process_no_ip_pim_boundary_oil_cmd(struct vty *vty)
+{
+	nb_cli_enqueue_change(vty, "./multicast-boundary-oil", NB_OP_DESTROY,
+			      NULL);
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -388,3 +388,40 @@ int pim_process_no_ip_pim_drprio_cmd(struct vty *vty)
 	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
 				    FRR_PIM_AF_XPATH_VAL);
 }
+
+int pim_process_ip_pim_hello_cmd(struct vty *vty, const char *hello_str,
+				 const char *hold_str)
+{
+	const struct lyd_node *mld_enable_dnode;
+
+	mld_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
+					   FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
+					   FRR_PIM_AF_XPATH_VAL);
+
+	if (!mld_enable_dnode) {
+		nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
+				      "true");
+	} else {
+		if (!yang_dnode_get_bool(mld_enable_dnode, "."))
+			nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY,
+					      "true");
+	}
+
+	nb_cli_enqueue_change(vty, "./hello-interval", NB_OP_MODIFY, hello_str);
+
+	if (hold_str)
+		nb_cli_enqueue_change(vty, "./hello-holdtime", NB_OP_MODIFY,
+				      hold_str);
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}
+
+int pim_process_no_ip_pim_hello_cmd(struct vty *vty)
+{
+	nb_cli_enqueue_change(vty, "./hello-interval", NB_OP_DESTROY, NULL);
+	nb_cli_enqueue_change(vty, "./hello-holdtime", NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -40,5 +40,8 @@ int pim_process_ip_pim_cmd(struct vty *vty);
 int pim_process_no_ip_pim_cmd(struct vty *vty);
 int pim_process_ip_pim_drprio_cmd(struct vty *vty, const char *drpriority_str);
 int pim_process_no_ip_pim_drprio_cmd(struct vty *vty);
+int pim_process_ip_pim_hello_cmd(struct vty *vty, const char *hello_str,
+				 const char *hold_str);
+int pim_process_no_ip_pim_hello_cmd(struct vty *vty);
 
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -46,5 +46,9 @@ int pim_process_no_ip_pim_hello_cmd(struct vty *vty);
 int pim_process_ip_pim_activeactive_cmd(struct vty *vty, const char *no);
 int pim_process_ip_pim_boundary_oil_cmd(struct vty *vty, const char *oil);
 int pim_process_no_ip_pim_boundary_oil_cmd(struct vty *vty);
+int pim_process_ip_mroute_cmd(struct vty *vty, const char *interface,
+			      const char *group_str, const char *source_str);
+int pim_process_no_ip_mroute_cmd(struct vty *vty, const char *interface,
+				 const char *group_str, const char *src_str);
 
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -44,5 +44,7 @@ int pim_process_ip_pim_hello_cmd(struct vty *vty, const char *hello_str,
 				 const char *hold_str);
 int pim_process_no_ip_pim_hello_cmd(struct vty *vty);
 int pim_process_ip_pim_activeactive_cmd(struct vty *vty, const char *no);
+int pim_process_ip_pim_boundary_oil_cmd(struct vty *vty, const char *oil);
+int pim_process_no_ip_pim_boundary_oil_cmd(struct vty *vty);
 
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -43,5 +43,6 @@ int pim_process_no_ip_pim_drprio_cmd(struct vty *vty);
 int pim_process_ip_pim_hello_cmd(struct vty *vty, const char *hello_str,
 				 const char *hold_str);
 int pim_process_no_ip_pim_hello_cmd(struct vty *vty);
+int pim_process_ip_pim_activeactive_cmd(struct vty *vty, const char *no);
 
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -38,5 +38,7 @@ int pim_process_no_register_suppress_cmd(struct vty *vty);
 
 int pim_process_ip_pim_cmd(struct vty *vty);
 int pim_process_no_ip_pim_cmd(struct vty *vty);
+int pim_process_ip_pim_drprio_cmd(struct vty *vty, const char *drpriority_str);
+int pim_process_no_ip_pim_drprio_cmd(struct vty *vty);
 
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -36,4 +36,7 @@ int pim_process_no_rp_kat_cmd(struct vty *vty);
 int pim_process_register_suppress_cmd(struct vty *vty, const char *rst);
 int pim_process_no_register_suppress_cmd(struct vty *vty);
 
+int pim_process_ip_pim_cmd(struct vty *vty);
+int pim_process_no_ip_pim_cmd(struct vty *vty);
+
 #endif /* PIM_CMD_COMMON_H */

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -198,6 +198,12 @@ int lib_interface_gmp_address_family_static_group_destroy(
 int routing_control_plane_protocols_name_validate(
 	struct nb_cb_create_args *args);
 
+#if PIM_IPV == 4
+#define FRR_PIM_AF_XPATH_VAL "frr-routing:ipv4"
+#else
+#define FRR_PIM_AF_XPATH_VAL "frr-routing:ipv6"
+#endif
+
 #define FRR_PIM_VRF_XPATH                                               \
 	"/frr-routing:routing/control-plane-protocols/"                 \
 	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"       \


### PR DESCRIPTION
This PR adds the below interface level CLIs for PIMv6.

Adding the below CLIs for PIMv6 Daemon:

[no] ipv6 pim
[no] ipv6 pim drpriority (1-4294967295)
[no] ipv6 pim hello (1-65535) [(1-65535)]
[no] ipv6 pim active-active
[no] ipv6 pim ssm
[no] ipv6 pim sm
[no] ipv6 multicast boundary oil WORD
[no] ipv6 mroute INTERFACE X:X::X:X [X:X::X:X]
