### PR TITLE
pimd: Fix modern compiler issues with long strings

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7851,6 +7851,15 @@ DEFUN (interface_ip_igmp,
 				    "frr-routing:ipv4");
 }
 
+/*
+ * what is this?  VTY_CURR_XPATH is 1024 bytes( XPATH_MAXLEN )
+ * and the code in the following functions has a pattern where
+ * it is copying into a buffer of XPATH_MAXLEN with some additional
+ * extra string data.  Let's just make it obscenely big enough
+ * to cover and our compilers will let us be happy
+ */
+#define PIM_XPATH_EXTRA 2 * XPATH_MAXLEN
+
 DEFUN (interface_no_ip_igmp,
        interface_no_ip_igmp_cmd,
        "no ip igmp",
@@ -7859,7 +7868,7 @@ DEFUN (interface_no_ip_igmp,
        IFACE_IGMP_STR)
 {
 	const struct lyd_node *pim_enable_dnode;
-	char pim_if_xpath[XPATH_MAXLEN + 20];
+	char pim_if_xpath[PIM_XPATH_EXTRA];
 
 	snprintf(pim_if_xpath, sizeof(pim_if_xpath),
 		 "%s/frr-pim:pim/address-family[address-family='%s']",
@@ -8406,7 +8415,7 @@ DEFUN_HIDDEN (interface_no_ip_pim_ssm,
 	      IFACE_PIM_STR)
 {
 	const struct lyd_node *igmp_enable_dnode;
-	char igmp_if_xpath[XPATH_MAXLEN + 20];
+	char igmp_if_xpath[PIM_XPATH_EXTRA];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
 		 "%s/frr-gmp:gmp/address-family[address-family='%s']",
@@ -8441,7 +8450,7 @@ DEFUN_HIDDEN (interface_no_ip_pim_sm,
 	      IFACE_PIM_SM_STR)
 {
 	const struct lyd_node *igmp_enable_dnode;
-	char igmp_if_xpath[XPATH_MAXLEN + 20];
+	char igmp_if_xpath[PIM_XPATH_EXTRA];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
 		 "%s/frr-gmp:gmp/address-family[address-family='%s']",
@@ -8477,7 +8486,7 @@ DEFUN (interface_no_ip_pim,
        PIM_STR)
 {
 	const struct lyd_node *igmp_enable_dnode;
-	char igmp_if_xpath[XPATH_MAXLEN + 20];
+	char igmp_if_xpath[PIM_XPATH_EXTRA];
 
 	snprintf(igmp_if_xpath, sizeof(igmp_if_xpath),
 		 "%s/frr-gmp:gmp/address-family[address-family='%s']",


### PR DESCRIPTION
Lot's of these errors:

pimd/pim_cmd.c: In function ‘interface_no_ip_igmp’:
pimd/pim_cmd.c:7865:7: error: ‘/frr-pim:pim/address-family[...’ directive output may be truncated writing 44 bytes into a region of size between 21 and 1044 [-Werror=format-truncation=]
 7865 |    "%s/frr-pim:pim/address-family[address-family='%s']",
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pimd/pim_cmd.c:7864:2: note: ‘snprintf’ output between 63 and 1086 bytes into a destination of size 1044
 7864 |  snprintf(pim_if_xpath, sizeof(pim_if_xpath),
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 7865 |    "%s/frr-pim:pim/address-family[address-family='%s']",
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 7866 |    VTY_CURR_XPATH, "frr-routing:ipv4");
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

fix them

Signed-off-by: Donald Sharp <sharpd@nvidia.com>