### PR TITLE
pimd: debug pim fixes

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -11115,6 +11115,10 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_debug_pim_events_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packets_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_packets_cmd);
+	install_element(CONFIG_NODE, &debug_pim_packetdump_send_cmd);
+	install_element(CONFIG_NODE, &no_debug_pim_packetdump_send_cmd);
+	install_element(CONFIG_NODE, &debug_pim_packetdump_recv_cmd);
+	install_element(CONFIG_NODE, &no_debug_pim_packetdump_recv_cmd);
 	install_element(CONFIG_NODE, &debug_pim_trace_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_trace_cmd);
 	install_element(CONFIG_NODE, &debug_pim_trace_detail_cmd);

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -162,6 +162,11 @@ int pim_debug_config_write(struct vty *vty)
 		++writes;
 	}
 
+	if (PIM_DEBUG_PIM_NHT_RP) {
+		vty_out(vty, "debug pim nht rp\n");
+		++writes;
+	}
+
 	return writes;
 }
 


### PR DESCRIPTION
Enable debug commands "debug pim packetdump send" and
"debug pim packetdump receive" in config mode.

Display "debug pim nht rp" in show running config.

Signed-off-by: sarita patra <saritap@vmware.com>