### PR TITLE
pim6d: get running with ipv6 types throughout

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1526,6 +1526,13 @@ AC_CHECK_HEADERS([linux/mroute.h], [], [],[
 	#include <linux/types.h>
 ])
 
+AC_CHECK_HEADERS([linux/mroute6.h], [], [],[
+	#include <sys/socket.h>
+	#include <netinet/in.h>
+	#define _LINUX_IN_H             /* For Linux <= 2.6.25 */
+	#include <linux/types.h>
+])
+
 m4_define([FRR_INCLUDES],
 FRR_INCLUDES
 [#ifdef HAVE_LINUX_MROUTE_H

--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -183,8 +183,8 @@ int main(int argc, char **argv, char **envp)
 	/* TODO PIM6: next line is temporary since pim_cmd_init is disabled */
 	if_cmd_init(NULL);
 
-#if 0
 	pim_zebra_init();
+#if 0
 	pim_bfd_init();
 	pim_mlag_init();
 

--- a/pimd/pim6_stubs.c
+++ b/pimd/pim6_stubs.c
@@ -1,0 +1,141 @@
+/*
+ * PIMv6 temporary stubs
+ * Copyright (C) 2022  David Lamparter for NetDEF, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+
+#include "pimd.h"
+#include "pim_nht.h"
+#include "pim_zlookup.h"
+#include "pim_pim.h"
+#include "pim_register.h"
+#include "pim_cmd.h"
+
+/*
+ * NH lookup / NHT
+ */
+void pim_sendmsg_zebra_rnh(struct pim_instance *pim, struct zclient *zclient,
+			   struct pim_nexthop_cache *pnc, int command)
+{
+}
+
+int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
+			    struct pim_nexthop *nexthop, struct prefix *src,
+			    struct prefix *grp, int neighbor_needed)
+{
+	return 0;
+}
+
+int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
+			      struct pim_upstream *up, struct rp_info *rp,
+			      struct pim_nexthop_cache *out_pnc)
+{
+	return 0;
+}
+
+void pim_delete_tracked_nexthop(struct pim_instance *pim, struct prefix *addr,
+				struct pim_upstream *up, struct rp_info *rp)
+{
+}
+
+struct pim_nexthop_cache *pim_nexthop_cache_find(struct pim_instance *pim,
+						 struct pim_rpf *rpf)
+{
+	return NULL;
+}
+
+void pim_rp_nexthop_del(struct rp_info *rp_info)
+{
+}
+
+void pim_nht_bsr_add(struct pim_instance *pim, struct in_addr addr)
+{
+}
+
+void pim_nht_bsr_del(struct pim_instance *pim, struct in_addr addr)
+{
+}
+
+int zclient_lookup_nexthop(struct pim_instance *pim,
+			   struct pim_zlookup_nexthop nexthop_tab[],
+			   const int tab_size, pim_addr addr,
+			   int max_lookup)
+{
+	return -1;
+}
+
+void zclient_lookup_new(void)
+{
+}
+
+void zclient_lookup_free(void)
+{
+}
+
+/*
+ * packet handling
+ */
+int pim_msg_send(int fd, pim_addr src, pim_addr dst, uint8_t *pim_msg,
+		 int pim_msg_size, const char *ifname)
+{
+	return 0;
+}
+
+int pim_hello_send(struct interface *ifp, uint16_t holdtime)
+{
+	return -1;
+}
+
+void pim_hello_restart_now(struct interface *ifp)
+{
+}
+
+void pim_hello_restart_triggered(struct interface *ifp)
+{
+}
+
+int pim_sock_add(struct interface *ifp)
+{
+	return -1;
+}
+
+void pim_sock_delete(struct interface *ifp, const char *delete_message)
+{
+}
+
+/*
+ * PIM register
+ */
+void pim_register_join(struct pim_upstream *up)
+{
+}
+
+void pim_null_register_send(struct pim_upstream *up)
+{
+}
+
+void pim_reg_del_on_couldreg_fail(struct interface *ifp)
+{
+}
+
+/*
+ * CLI
+ */
+void pim_cmd_init(void)
+{
+}

--- a/pimd/pim_addr.c
+++ b/pimd/pim_addr.c
@@ -44,9 +44,6 @@ static ssize_t printfrr_pimaddr(struct fbuf *buf, struct printfrr_eargs *ea,
 
 #if PIM_IPV == 4
 	return bprintfrr(buf, "%pI4", addr);
-#elif !defined(PIM_V6_TEMP_BREAK)
-	CPP_NOTICE("note IPv6 typing for pim_addr is temporarily disabled.");
-	return bprintfrr(buf, "%pI4", addr);
 #else
 	return bprintfrr(buf, "%pI6", addr);
 #endif

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -25,11 +25,7 @@
 
 /* clang-format off */
 
-/* temporarily disable IPv6 types to keep code compiling.
- * Defining PIM_V6_TEMP_BREAK will show a lot of compile errors - they are
- * very useful to see TODOs.
- */
-#if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
+#if PIM_IPV == 4
 typedef struct in_addr pim_addr;
 
 #define PIM_ADDRSTRLEN	INET_ADDRSTRLEN

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -94,7 +94,7 @@ void pim_bfd_info_nbr_create(struct pim_interface *pim_ifp,
 	bfd_sess_set_timers(
 		neigh->bfd_session, pim_ifp->bfd_config.detection_multiplier,
 		pim_ifp->bfd_config.min_rx, pim_ifp->bfd_config.min_tx);
-#if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
+#if PIM_IPV == 4
 	bfd_sess_set_ipv4_addrs(neigh->bfd_session, NULL, &neigh->source_addr);
 #else
 	bfd_sess_set_ipv6_addrs(neigh->bfd_session, NULL, &neigh->source_addr);

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -1374,7 +1374,12 @@ int pim_bsm_process(struct interface *ifp, struct ip *ip_hdr, uint8_t *buf,
 		}
 	}
 
-	if (ip_hdr->ip_dst.s_addr == qpim_all_pim_routers_addr.s_addr) {
+#if PIM_IPV == 4
+	if (ip_hdr->ip_dst.s_addr == qpim_all_pim_routers_addr.s_addr)
+#else
+	if (0)
+#endif
+	{
 		/* Multicast BSMs are only accepted if source interface & IP
 		 * match RPF towards the BSR's IP address, or they have
 		 * no-forward set

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3901,7 +3901,6 @@ static void clear_mroute(struct pim_instance *pim)
 	/* scan interfaces */
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp = ifp->info;
-		struct gm_group *grp;
 		struct pim_ifchannel *ch;
 
 		if (!pim_ifp)
@@ -3914,7 +3913,9 @@ static void clear_mroute(struct pim_instance *pim)
 			pim_ifchannel_delete(ch);
 		}
 
+#if PIM_IPV == 4
 		/* clean up all igmp groups */
+		struct gm_group *grp;
 
 		if (pim_ifp->gm_group_list) {
 			while (pim_ifp->gm_group_list->count) {
@@ -3922,6 +3923,7 @@ static void clear_mroute(struct pim_instance *pim)
 				igmp_group_delete(grp);
 			}
 		}
+#endif
 	}
 
 	/* clean up all upstreams*/
@@ -8236,6 +8238,7 @@ DEFPY_HIDDEN (interface_ip_igmp_query_generate,
 	      "IGMP version\n"
 	      "IGMP version number\n")
 {
+#if PIM_IPV == 4
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	int igmp_version = 2;
 
@@ -8249,7 +8252,7 @@ DEFPY_HIDDEN (interface_ip_igmp_query_generate,
 		igmp_version = atoi(argv[4]->arg);
 
 	igmp_send_query_on_intf(ifp, igmp_version);
-
+#endif
 	return CMD_SUCCESS;
 }
 

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -50,10 +50,12 @@
 #include "pim_igmp_join.h"
 #include "pim_vxlan.h"
 
+#if PIM_IPV == 4
 static void pim_if_igmp_join_del_all(struct interface *ifp);
 static int igmp_join_sock(const char *ifname, ifindex_t ifindex,
 			  struct in_addr group_addr,
 			  struct in_addr source_addr);
+#endif
 
 void pim_if_init(struct pim_instance *pim)
 {
@@ -1148,6 +1150,7 @@ long pim_if_t_suppressed_msec(struct interface *ifp)
 	return t_suppressed_msec;
 }
 
+#if PIM_IPV == 4
 static void igmp_join_free(struct gm_join *ij)
 {
 	XFREE(MTYPE_PIM_IGMP_JOIN, ij);
@@ -1358,6 +1361,19 @@ static void pim_if_igmp_join_del_all(struct interface *ifp)
 	for (ALL_LIST_ELEMENTS(pim_ifp->gm_join_list, node, nextnode, ij))
 		pim_if_igmp_join_del(ifp, ij->group_addr, ij->source_addr);
 }
+#else /* PIM_IPV != 4 */
+ferr_r pim_if_igmp_join_add(struct interface *ifp, struct in_addr group_addr,
+			    struct in_addr source_addr)
+{
+	return ferr_ok();
+}
+
+int pim_if_igmp_join_del(struct interface *ifp, struct in_addr group_addr,
+			 struct in_addr source_addr)
+{
+	return 0;
+}
+#endif /* PIM_IPV != 4 */
 
 /*
   RFC 4601

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -306,8 +306,8 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 					 * supplying the implied
 					 * if channel.  So remove it.
 					 */
-					if (c_oil->oil.mfcc_ttls
-						    [pim_ifp->mroute_vif_index])
+					if (oil_if_has(c_oil,
+						       pim_ifp->mroute_vif_index))
 						pim_channel_del_inherited_oif(
 							c_oil, ch->interface,
 							__func__);
@@ -1291,7 +1291,7 @@ void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg)
 			if (!pim_upstream_evaluate_join_desired_interface(
 				child, ch, starch) ||
 				(!chchannel &&
-				 c_oil->oil.mfcc_ttls[pim_ifp->mroute_vif_index])) {
+				 oil_if_has(c_oil, pim_ifp->mroute_vif_index))) {
 				pim_channel_del_inherited_oif(c_oil, ifp,
 						__func__);
 			}

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -105,6 +105,7 @@ struct gm_sock {
 
 struct pim_interface;
 
+#if PIM_IPV == 4
 void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp);
 void pim_igmp_if_reset(struct pim_interface *pim_ifp);
 void pim_igmp_if_fini(struct pim_interface *pim_ifp);
@@ -125,6 +126,24 @@ void pim_igmp_other_querier_timer_on(struct gm_sock *igmp);
 void pim_igmp_other_querier_timer_off(struct gm_sock *igmp);
 
 int igmp_validate_checksum(char *igmp_msg, int igmp_msg_len);
+
+#else /* PIM_IPV != 4 */
+static inline void pim_igmp_general_query_on(struct gm_sock *igmp)
+{
+}
+
+static inline void pim_igmp_general_query_off(struct gm_sock *igmp)
+{
+}
+
+static inline void pim_igmp_other_querier_timer_on(struct gm_sock *igmp)
+{
+}
+
+static inline void pim_igmp_other_querier_timer_off(struct gm_sock *igmp)
+{
+}
+#endif /* PIM_IPV == 4 */
 
 #define IGMP_SOURCE_MASK_FORWARDING        (1 << 0)
 #define IGMP_SOURCE_MASK_DELETE            (1 << 1)
@@ -184,6 +203,7 @@ struct gm_group {
 	int64_t last_igmp_v2_report_dsec;
 };
 
+#if PIM_IPV == 4
 struct gm_group *find_group_by_addr(struct gm_sock *igmp,
 				    struct in_addr group_addr);
 struct gm_group *igmp_add_group_by_addr(struct gm_sock *igmp,
@@ -210,4 +230,11 @@ void igmp_send_query(int igmp_version, struct gm_group *group, int fd,
 void igmp_group_delete(struct gm_group *group);
 
 void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver);
+
+#else /* PIM_IPV != 4 */
+static inline void igmp_startup_mode_on(struct gm_sock *igmp)
+{
+}
+#endif /* PIM_IPV != 4 */
+
 #endif /* PIM_IGMP_H */

--- a/pimd/pim_igmp_join.h
+++ b/pimd/pim_igmp_join.h
@@ -39,9 +39,9 @@ struct group_source_req {
 };
 #endif
 
-static int pim_igmp_join_source(int fd, ifindex_t ifindex,
-				struct in_addr group_addr,
-				struct in_addr source_addr)
+static inline int pim_igmp_join_source(int fd, ifindex_t ifindex,
+				       struct in_addr group_addr,
+				       struct in_addr source_addr)
 {
 	struct group_source_req req;
 	struct sockaddr_in group;

--- a/pimd/pim_igmp_stats.h
+++ b/pimd/pim_igmp_stats.h
@@ -35,7 +35,17 @@ struct igmp_stats {
 	uint32_t	unsupported;
 };
 
+#if PIM_IPV == 4
 void igmp_stats_init(struct igmp_stats *stats);
 void igmp_stats_add(struct igmp_stats *a, struct igmp_stats *b);
+#else
+static inline void igmp_stats_init(struct igmp_stats *stats)
+{
+}
+
+static inline void igmp_stats_add(struct igmp_stats *a, struct igmp_stats *b)
+{
+}
+#endif
 
 #endif /* PIM_IGMP_STATS_H */

--- a/pimd/pim_igmpv3.h
+++ b/pimd/pim_igmpv3.h
@@ -53,6 +53,7 @@
 /* OHPI: Older Host Present Interval */
 #define PIM_IGMP_OHPI_DSEC(qrv,qqi,qri_dsec) ((qrv) * (10 * (qqi)) + (qri_dsec))
 
+#if PIM_IPV == 4
 void igmp_group_reset_gmi(struct gm_group *group);
 void igmp_source_reset_gmi(struct gm_group *group, struct gm_source *source);
 
@@ -97,5 +98,17 @@ void igmp_v3_recv_query(struct gm_sock *igmp, const char *from_str,
 
 int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from,
 			const char *from_str, char *igmp_msg, int igmp_msg_len);
+
+#else /* PIM_IPV != 4 */
+static inline void igmp_group_reset_gmi(struct gm_group *group)
+{
+}
+
+
+static inline void igmp_source_reset_gmi(struct gm_group *group,
+					 struct gm_source *source)
+{
+}
+#endif
 
 #endif /* PIM_IGMPV3_H */

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -109,6 +109,7 @@ pim_jp_agg_get_interface_upstream_switch_list(struct pim_rpf *rpf)
 	struct pim_interface *pim_ifp;
 	struct pim_iface_upstream_switch *pius;
 	struct listnode *node, *nnode;
+	pim_addr rpf_addr;
 
 	if (!ifp)
 		return NULL;
@@ -119,16 +120,18 @@ pim_jp_agg_get_interface_upstream_switch_list(struct pim_rpf *rpf)
 	if (!pim_ifp)
 		return NULL;
 
+	rpf_addr = pim_addr_from_prefix(&rpf->rpf_addr);
+
 	for (ALL_LIST_ELEMENTS(pim_ifp->upstream_switch_list, node, nnode,
 			       pius)) {
-		if (pius->address.s_addr == rpf->rpf_addr.u.prefix4.s_addr)
+		if (!pim_addr_cmp(pius->address, rpf_addr))
 			break;
 	}
 
 	if (!pius) {
 		pius = XCALLOC(MTYPE_PIM_JP_AGG_GROUP,
 			       sizeof(struct pim_iface_upstream_switch));
-		pius->address.s_addr = rpf->rpf_addr.u.prefix4.s_addr;
+		pius->address = rpf_addr;
 		pius->us = list_new();
 		listnode_add_sort(pim_ifp->upstream_switch_list, pius);
 	}

--- a/pimd/pim_mlag.h
+++ b/pimd/pim_mlag.h
@@ -28,6 +28,7 @@
 #include "mlag.h"
 #include "pim_iface.h"
 
+#if PIM_IPV == 4
 extern void pim_mlag_init(void);
 extern void pim_mlag_terminate(void);
 extern void pim_instance_mlag_init(struct pim_instance *pim);
@@ -52,4 +53,49 @@ extern void pim_mlag_up_local_del(struct pim_instance *pim,
 extern bool pim_mlag_up_df_role_update(struct pim_instance *pim,
 				       struct pim_upstream *up, bool is_df,
 				       const char *reason);
+#else /* PIM_IPV == 4 */
+static inline void pim_mlag_terminate(void)
+{
+}
+
+static inline void pim_instance_mlag_init(struct pim_instance *pim)
+{
+}
+
+static inline void pim_instance_mlag_terminate(struct pim_instance *pim)
+{
+}
+
+static inline void pim_if_configure_mlag_dualactive(
+						struct pim_interface *pim_ifp)
+{
+}
+
+static inline void pim_if_unconfigure_mlag_dualactive(
+						struct pim_interface *pim_ifp)
+{
+}
+
+static inline void pim_mlag_register(void)
+{
+}
+
+static inline void pim_mlag_up_local_add(struct pim_instance *pim,
+					 struct pim_upstream *upstream)
+{
+}
+
+static inline void pim_mlag_up_local_del(struct pim_instance *pim,
+					 struct pim_upstream *upstream)
+{
+}
+
+static inline bool pim_mlag_up_df_role_update(struct pim_instance *pim,
+					      struct pim_upstream *up,
+					      bool is_df, const char *reason)
+{
+	return false;
+}
+#endif
+
 #endif

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -581,12 +581,8 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 			  int buf_size, ifindex_t ifindex)
 {
 	struct interface *ifp;
-	struct pim_interface *pim_ifp;
 	const struct ip *ip_hdr;
 	const struct igmpmsg *msg;
-	struct in_addr ifaddr;
-	struct gm_sock *igmp;
-	const struct prefix *connected_src;
 
 	if (buf_size < (int)sizeof(struct ip))
 		return 0;
@@ -594,6 +590,11 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 	ip_hdr = (const struct ip *)buf;
 
 	if (ip_hdr->ip_p == IPPROTO_IGMP) {
+#if PIM_IPV == 4
+		struct pim_interface *pim_ifp;
+		struct in_addr ifaddr;
+		struct gm_sock *igmp;
+		const struct prefix *connected_src;
 
 		/* We have the IP packet but we do not know which interface this
 		 * packet was
@@ -633,6 +634,7 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 			zlog_debug("No IGMP socket on interface: %s with connected source: %pFX",
 				   ifp->name, connected_src);
 		}
+#endif
 	} else if (ip_hdr->ip_p) {
 		if (PIM_DEBUG_MROUTE_DETAIL) {
 			zlog_debug(

--- a/pimd/pim_mroute.h
+++ b/pimd/pim_mroute.h
@@ -37,6 +37,7 @@
 
 #define PIM_MROUTE_MIN_TTL (1)
 
+#if PIM_IPV == 4
 #if defined(HAVE_LINUX_MROUTE_H)
 #include <linux/mroute.h>
 #else
@@ -157,6 +158,19 @@ struct igmpmsg {
 	struct in_addr im_src, im_dst;
 };
 #endif
+
+#endif /* HAVE_LINUX_MROUTE_H */
+
+typedef struct mfcctl pim_mfcctl;
+
+#else /* PIM_IPV != 4 */
+#if defined(HAVE_LINUX_MROUTE6_H)
+#include <linux/mroute6.h>
+#endif
+
+typedef struct mf6cctl pim_mfcctl;
+
+#define MAXVIFS IF_SETSIZE
 #endif
 
 #ifndef IGMPMSG_WRVIFWHOLE
@@ -172,7 +186,7 @@ struct channel_oil;
 int pim_mroute_socket_enable(struct pim_instance *pim);
 int pim_mroute_socket_disable(struct pim_instance *pim);
 
-int pim_mroute_add_vif(struct interface *ifp, struct in_addr ifaddr,
+int pim_mroute_add_vif(struct interface *ifp, pim_addr ifaddr,
 		       unsigned char flags);
 int pim_mroute_del_vif(struct interface *ifp);
 

--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -138,7 +138,7 @@ uint8_t *pim_msg_addr_encode_ipv6_group(uint8_t *buf, struct in6_addr addr)
 	return buf;
 }
 
-#if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
+#if PIM_IPV == 4
 #define pim_msg_addr_encode(what) pim_msg_addr_encode_ipv4_##what
 #else
 #define pim_msg_addr_encode(what) pim_msg_addr_encode_ipv6_##what

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -45,9 +45,13 @@ int funcname(struct argtype *args)                                             \
 }                                                                              \
 MACRO_REQUIRE_SEMICOLON()
 
+#define yang_dnode_get_pimaddr yang_dnode_get_ipv6
+
 #else /* PIM_IPV != 6 */
 #define pim6_msdp_err(funcname, argtype)                                       \
 MACRO_REQUIRE_SEMICOLON()
+
+#define yang_dnode_get_pimaddr yang_dnode_get_ipv4
 #endif /* PIM_IPV != 6 */
 
 static void pim_if_membership_clear(struct interface *ifp)
@@ -172,8 +176,7 @@ static int pim_cmd_interface_delete(struct interface *ifp)
 }
 
 static int interface_pim_use_src_cmd_worker(struct interface *ifp,
-		struct in_addr source_addr,
-		char *errmsg, size_t errmsg_len)
+		pim_addr source_addr, char *errmsg, size_t errmsg_len)
 {
 	int result;
 	int ret = NB_OK;
@@ -396,15 +399,10 @@ static void igmp_sock_query_interval_reconfig(struct gm_sock *igmp)
 	ifp = igmp->interface;
 	pim_ifp = ifp->info;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
-		char ifaddr_str[INET_ADDRSTRLEN];
-
-		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
-			       sizeof(ifaddr_str));
-		zlog_debug("%s: Querier %s on %s reconfig query_interval=%d",
-			   __func__, ifaddr_str, ifp->name,
+	if (PIM_DEBUG_IGMP_TRACE)
+		zlog_debug("%s: Querier %pPAs on %s reconfig query_interval=%d",
+			   __func__, &igmp->ifaddr, ifp->name,
 			   pim_ifp->gm_default_query_interval);
-	}
 
 	/*
 	 * igmp_startup_mode_on() will reset QQI:
@@ -2015,7 +2013,7 @@ int lib_interface_pim_address_family_use_source_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
-	struct ipaddr source_addr;
+	pim_addr source_addr;
 	int result;
 	const struct lyd_node *if_dnode;
 
@@ -2033,10 +2031,14 @@ int lib_interface_pim_address_family_use_source_modify(
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
-		yang_dnode_get_ip(&source_addr, args->dnode, NULL);
+#if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
+		yang_dnode_get_ipv4(&source_addr, args->dnode, NULL);
+#else
+		yang_dnode_get_ipv6(&source_addr, args->dnode, NULL);
+#endif
 
 		result = interface_pim_use_src_cmd_worker(
-				ifp, source_addr.ip._v4_addr,
+				ifp, source_addr,
 				args->errmsg, args->errmsg_len);
 
 		if (result != PIM_SUCCESS)
@@ -2052,7 +2054,6 @@ int lib_interface_pim_address_family_use_source_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
-	struct in_addr source_addr = {INADDR_ANY};
 	int result;
 	const struct lyd_node *if_dnode;
 
@@ -2071,7 +2072,7 @@ int lib_interface_pim_address_family_use_source_destroy(
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 
-		result = interface_pim_use_src_cmd_worker(ifp, source_addr,
+		result = interface_pim_use_src_cmd_worker(ifp, PIMADDR_ANY,
 				args->errmsg,
 				args->errmsg_len);
 

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2031,7 +2031,7 @@ int lib_interface_pim_address_family_use_source_modify(
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
-#if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
+#if PIM_IPV == 4
 		yang_dnode_get_ipv4(&source_addr, args->dnode, NULL);
 #else
 		yang_dnode_get_ipv6(&source_addr, args->dnode, NULL);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2180,8 +2180,8 @@ int lib_interface_pim_address_family_mroute_destroy(
 	struct interface *iif;
 	struct interface *oif;
 	const char *oifname;
-	struct ipaddr source_addr;
-	struct ipaddr group_addr;
+	pim_addr source_addr;
+	pim_addr group_addr;
 	const struct lyd_node *if_dnode;
 
 	switch (args->event) {
@@ -2211,11 +2211,10 @@ int lib_interface_pim_address_family_mroute_destroy(
 			return NB_ERR_INCONSISTENCY;
 		}
 
-		yang_dnode_get_ip(&source_addr, args->dnode, "./source-addr");
-		yang_dnode_get_ip(&group_addr, args->dnode, "./group-addr");
+		yang_dnode_get_pimaddr(&source_addr, args->dnode, "./source-addr");
+		yang_dnode_get_pimaddr(&group_addr, args->dnode, "./group-addr");
 
-		if (pim_static_del(pim, iif, oif, group_addr.ip._v4_addr,
-					source_addr.ip._v4_addr)) {
+		if (pim_static_del(pim, iif, oif, group_addr, source_addr)) {
 			snprintf(args->errmsg, args->errmsg_len,
 					"Failed to remove static mroute");
 			return NB_ERR_INCONSISTENCY;
@@ -2238,8 +2237,8 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 	struct interface *iif;
 	struct interface *oif;
 	const char *oifname;
-	struct ipaddr source_addr;
-	struct ipaddr group_addr;
+	pim_addr source_addr;
+	pim_addr group_addr;
 	const struct lyd_node *if_dnode;
 
 	switch (args->event) {
@@ -2288,11 +2287,10 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 			return NB_ERR_INCONSISTENCY;
 		}
 
-		yang_dnode_get_ip(&source_addr, args->dnode, "../source-addr");
-		yang_dnode_get_ip(&group_addr, args->dnode, "../group-addr");
+		yang_dnode_get_pimaddr(&source_addr, args->dnode, "../source-addr");
+		yang_dnode_get_pimaddr(&group_addr, args->dnode, "../group-addr");
 
-		if (pim_static_add(pim, iif, oif, group_addr.ip._v4_addr,
-				   source_addr.ip._v4_addr)) {
+		if (pim_static_add(pim, iif, oif, group_addr, source_addr)) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "Failed to add static mroute");
 			return NB_ERR_INCONSISTENCY;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -361,7 +361,7 @@ bool pim_nht_bsr_rpf_check(struct pim_instance *pim, struct in_addr bsr_addr,
 		pim_addr nhaddr;
 
 		switch (nh->type) {
-#if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
+#if PIM_IPV == 4
 		case NEXTHOP_TYPE_IPV4:
 			if (nh->ifindex == IFINDEX_INTERNAL)
 				continue;
@@ -605,7 +605,7 @@ static int pim_ecmp_nexthop_search(struct pim_instance *pim,
 		ifps[i] =
 			if_lookup_by_index(nh_node->ifindex, pim->vrf->vrf_id);
 		if (ifps[i]) {
-#if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
+#if PIM_IPV == 4
 			pim_addr nhaddr = nh_node->gate.ipv4;
 #else
 			pim_addr nhaddr = nh_node->gate.ipv6;
@@ -799,7 +799,7 @@ int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS)
 					nbr = pim_neighbor_find_if(ifp1);
 				/* Overwrite with Nbr address as NH addr */
 				if (nbr)
-#if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
+#if PIM_IPV == 4
 					nexthop->gate.ipv4 = nbr->source_addr;
 #else
 					nexthop->gate.ipv6 = nbr->source_addr;

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -42,15 +42,15 @@ char *pim_channel_oil_dump(struct channel_oil *c_oil, char *buf, size_t size)
 	pim_sgaddr sg;
 	int i;
 
-	sg.src = c_oil->oil.mfcc_origin;
-	sg.grp = c_oil->oil.mfcc_mcastgrp;
-	ifp = pim_if_find_by_vif_index(c_oil->pim, c_oil->oil.mfcc_parent);
+	sg.src = *oil_origin(c_oil);
+	sg.grp = *oil_mcastgrp(c_oil);
+	ifp = pim_if_find_by_vif_index(c_oil->pim, *oil_parent(c_oil));
 	snprintfrr(buf, size, "%pSG IIF: %s, OIFS: ", &sg,
 		   ifp ? ifp->name : "(?)");
 
 	out = buf + strlen(buf);
 	for (i = 0; i < MAXVIFS; i++) {
-		if (c_oil->oil.mfcc_ttls[i] != 0) {
+		if (oil_if_has(c_oil, i) != 0) {
 			ifp = pim_if_find_by_vif_index(c_oil->pim, i);
 			snprintf(out, buf + size - out, "%s ",
 				 ifp ? ifp->name : "(?)");
@@ -61,25 +61,19 @@ char *pim_channel_oil_dump(struct channel_oil *c_oil, char *buf, size_t size)
 	return buf;
 }
 
-int pim_channel_oil_compare(const struct channel_oil *c1,
-			    const struct channel_oil *c2)
+int pim_channel_oil_compare(const struct channel_oil *cc1,
+			    const struct channel_oil *cc2)
 {
-	if (ntohl(c1->oil.mfcc_mcastgrp.s_addr)
-	    < ntohl(c2->oil.mfcc_mcastgrp.s_addr))
-		return -1;
+	struct channel_oil *c1 = (struct channel_oil *)cc1;
+	struct channel_oil *c2 = (struct channel_oil *)cc2;
+	int rv;
 
-	if (ntohl(c1->oil.mfcc_mcastgrp.s_addr)
-	    > ntohl(c2->oil.mfcc_mcastgrp.s_addr))
-		return 1;
-
-	if (ntohl(c1->oil.mfcc_origin.s_addr)
-	    < ntohl(c2->oil.mfcc_origin.s_addr))
-		return -1;
-
-	if (ntohl(c1->oil.mfcc_origin.s_addr)
-	    > ntohl(c2->oil.mfcc_origin.s_addr))
-		return 1;
-
+	rv = pim_addr_cmp(*oil_mcastgrp(c1), *oil_mcastgrp(c2));
+	if (rv)
+		return rv;
+	rv = pim_addr_cmp(*oil_origin(c1), *oil_origin(c2));
+	if (rv)
+		return rv;
 	return 0;
 }
 
@@ -109,8 +103,8 @@ struct channel_oil *pim_find_channel_oil(struct pim_instance *pim,
 	struct channel_oil *c_oil = NULL;
 	struct channel_oil lookup;
 
-	lookup.oil.mfcc_mcastgrp = sg->grp;
-	lookup.oil.mfcc_origin = sg->src;
+	*oil_mcastgrp(&lookup) = sg->grp;
+	*oil_origin(&lookup) = sg->src;
 
 	c_oil = rb_pim_oil_find(&pim->channel_oil_head, &lookup);
 
@@ -151,10 +145,10 @@ struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 
 	c_oil = XCALLOC(MTYPE_PIM_CHANNEL_OIL, sizeof(*c_oil));
 
-	c_oil->oil.mfcc_mcastgrp = sg->grp;
-	c_oil->oil.mfcc_origin = sg->src;
+	*oil_mcastgrp(c_oil) = sg->grp;
+	*oil_origin(c_oil) = sg->src;
 
-	c_oil->oil.mfcc_parent = MAXVIFS;
+	*oil_parent(c_oil) = MAXVIFS;
 	c_oil->oil_ref_count = 1;
 	c_oil->installed = 0;
 	c_oil->up = pim_upstream_find(pim, sg);
@@ -172,8 +166,8 @@ struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
 					const char *name)
 {
 	if (PIM_DEBUG_MROUTE) {
-		pim_sgaddr sg = {.src = c_oil->oil.mfcc_mcastgrp,
-				 .grp = c_oil->oil.mfcc_origin};
+		pim_sgaddr sg = {.src = *oil_mcastgrp(c_oil),
+				 .grp = *oil_origin(c_oil)};
 
 		zlog_debug(
 			"%s(%s): Del oil for %pSG, Ref Count: %d (Predecrement)",
@@ -228,23 +222,15 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 	 */
 	if (!(channel_oil->oif_flags[pim_ifp->mroute_vif_index] & proto_mask)) {
 		if (PIM_DEBUG_MROUTE) {
-			char group_str[INET_ADDRSTRLEN];
-			char source_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<group?>",
-				       channel_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			pim_inet4_dump("<source?>",
-				       channel_oil->oil.mfcc_origin, source_str,
-				       sizeof(source_str));
 			zlog_debug(
-				"%s %s: no existing protocol mask %u(%u) for requested OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%s,%s)",
+				"%s %s: no existing protocol mask %u(%u) for requested OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%pPAs,%pPAs)",
 				__FILE__, __func__, proto_mask,
 				channel_oil
 					->oif_flags[pim_ifp->mroute_vif_index],
 				oif->name, pim_ifp->mroute_vif_index,
-				channel_oil->oil
-					.mfcc_ttls[pim_ifp->mroute_vif_index],
-				source_str, group_str);
+				oil_if_has(channel_oil, pim_ifp->mroute_vif_index),
+				oil_origin(channel_oil),
+				oil_mcastgrp(channel_oil));
 		}
 		return 0;
 	}
@@ -254,44 +240,29 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 	if (channel_oil->oif_flags[pim_ifp->mroute_vif_index] &
 			PIM_OIF_FLAG_PROTO_ANY) {
 		if (PIM_DEBUG_MROUTE) {
-			char group_str[INET_ADDRSTRLEN];
-			char source_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<group?>",
-				       channel_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			pim_inet4_dump("<source?>",
-				       channel_oil->oil.mfcc_origin, source_str,
-				       sizeof(source_str));
 			zlog_debug(
-				"%s %s: other protocol masks remain for requested OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%s,%s)",
+				"%s %s: other protocol masks remain for requested OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%pPAs,%pPAs)",
 				__FILE__, __func__, oif->name,
 				pim_ifp->mroute_vif_index,
-				channel_oil->oil
-					.mfcc_ttls[pim_ifp->mroute_vif_index],
-				source_str, group_str);
+				oil_if_has(channel_oil, pim_ifp->mroute_vif_index),
+				oil_origin(channel_oil),
+				oil_mcastgrp(channel_oil));
 		}
 		return 0;
 	}
 
-	channel_oil->oil.mfcc_ttls[pim_ifp->mroute_vif_index] = 0;
+	oil_if_set(channel_oil, pim_ifp->mroute_vif_index, false);
 	/* clear mute; will be re-evaluated when the OIF becomes valid again */
 	channel_oil->oif_flags[pim_ifp->mroute_vif_index] &= ~PIM_OIF_FLAG_MUTE;
 
 	if (pim_upstream_mroute_add(channel_oil, __func__)) {
 		if (PIM_DEBUG_MROUTE) {
-			char group_str[INET_ADDRSTRLEN];
-			char source_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<group?>",
-				       channel_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			pim_inet4_dump("<source?>",
-				       channel_oil->oil.mfcc_origin, source_str,
-				       sizeof(source_str));
 			zlog_debug(
-				"%s %s: could not remove output interface %s (vif_index=%d) for channel (S,G)=(%s,%s)",
+				"%s %s: could not remove output interface %s (vif_index=%d) for channel (S,G)=(%pPAs,%pPAs)",
 				__FILE__, __func__, oif->name,
-				pim_ifp->mroute_vif_index, source_str,
-				group_str);
+				pim_ifp->mroute_vif_index,
+				oil_origin(channel_oil),
+				oil_mcastgrp(channel_oil));
 		}
 		return -1;
 	}
@@ -299,16 +270,12 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 	--channel_oil->oil_size;
 
 	if (PIM_DEBUG_MROUTE) {
-		char group_str[INET_ADDRSTRLEN];
-		char source_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<group?>", channel_oil->oil.mfcc_mcastgrp,
-			       group_str, sizeof(group_str));
-		pim_inet4_dump("<source?>", channel_oil->oil.mfcc_origin,
-			       source_str, sizeof(source_str));
 		zlog_debug(
-			"%s(%s): (S,G)=(%s,%s): proto_mask=%u IIF:%d OIF=%s vif_index=%d",
-			__func__, caller, source_str, group_str, proto_mask,
-			channel_oil->oil.mfcc_parent, oif->name,
+			"%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u IIF:%d OIF=%s vif_index=%d",
+			__func__, caller, oil_origin(channel_oil),
+			oil_mcastgrp(channel_oil),
+			proto_mask,
+			*oil_parent(channel_oil), oif->name,
 			pim_ifp->mroute_vif_index);
 	}
 
@@ -397,7 +364,7 @@ void pim_channel_update_oif_mute(struct channel_oil *c_oil,
 	bool new_mute;
 
 	/* If pim_ifp is not a part of the OIL there is nothing to do */
-	if (!c_oil->oil.mfcc_ttls[pim_ifp->mroute_vif_index])
+	if (!oil_if_has(c_oil, pim_ifp->mroute_vif_index))
 		return;
 
 	old_mute = !!(c_oil->oif_flags[pim_ifp->mroute_vif_index] &
@@ -455,21 +422,13 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	   channel (S,G) multiple times */
 	if (channel_oil->oif_flags[pim_ifp->mroute_vif_index] & proto_mask) {
 		if (PIM_DEBUG_MROUTE) {
-			char group_str[INET_ADDRSTRLEN];
-			char source_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<group?>",
-				       channel_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			pim_inet4_dump("<source?>",
-				       channel_oil->oil.mfcc_origin, source_str,
-				       sizeof(source_str));
 			zlog_debug(
-				"%s %s: existing protocol mask %u requested OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%s,%s)",
+				"%s %s: existing protocol mask %u requested OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%pPAs,%pPAs)",
 				__FILE__, __func__, proto_mask, oif->name,
 				pim_ifp->mroute_vif_index,
-				channel_oil->oil
-					.mfcc_ttls[pim_ifp->mroute_vif_index],
-				source_str, group_str);
+				oil_if_has(channel_oil, pim_ifp->mroute_vif_index),
+				oil_origin(channel_oil),
+				oil_mcastgrp(channel_oil));
 		}
 		return -3;
 	}
@@ -487,36 +446,21 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 		channel_oil->oif_flags[pim_ifp->mroute_vif_index] |= proto_mask;
 		/* Check the OIF really exists before returning, and only log
 		   warning otherwise */
-		if (channel_oil->oil.mfcc_ttls[pim_ifp->mroute_vif_index] < 1) {
-			char group_str[INET_ADDRSTRLEN];
-			char source_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<group?>",
-				       channel_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			pim_inet4_dump("<source?>",
-				       channel_oil->oil.mfcc_origin, source_str,
-				       sizeof(source_str));
+		if (oil_if_has(channel_oil, pim_ifp->mroute_vif_index) < 1) {
 			zlog_warn(
-				"%s %s: new protocol mask %u requested nonexistent OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%s,%s)",
+				"%s %s: new protocol mask %u requested nonexistent OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%pPAs,%pPAs)",
 				__FILE__, __func__, proto_mask, oif->name,
 				pim_ifp->mroute_vif_index,
-				channel_oil->oil
-					.mfcc_ttls[pim_ifp->mroute_vif_index],
-				source_str, group_str);
+				oil_if_has(channel_oil, pim_ifp->mroute_vif_index),
+				oil_origin(channel_oil),
+				oil_mcastgrp(channel_oil));
 		}
 
 		if (PIM_DEBUG_MROUTE) {
-			char group_str[INET_ADDRSTRLEN];
-			char source_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<group?>",
-				       channel_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			pim_inet4_dump("<source?>",
-				       channel_oil->oil.mfcc_origin, source_str,
-				       sizeof(source_str));
 			zlog_debug(
-				"%s(%s): (S,G)=(%s,%s): proto_mask=%u OIF=%s vif_index=%d added to 0x%x",
-				__func__, caller, source_str, group_str,
+				"%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u OIF=%s vif_index=%d added to 0x%x",
+				__func__, caller, oil_origin(channel_oil),
+				oil_mcastgrp(channel_oil),
 				proto_mask, oif->name,
 				pim_ifp->mroute_vif_index,
 				channel_oil
@@ -525,29 +469,21 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 		return 0;
 	}
 
-	old_ttl = channel_oil->oil.mfcc_ttls[pim_ifp->mroute_vif_index];
+	old_ttl = oil_if_has(channel_oil, pim_ifp->mroute_vif_index);
 
 	if (old_ttl > 0) {
 		if (PIM_DEBUG_MROUTE) {
-			char group_str[INET_ADDRSTRLEN];
-			char source_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<group?>",
-				       channel_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			pim_inet4_dump("<source?>",
-				       channel_oil->oil.mfcc_origin, source_str,
-				       sizeof(source_str));
 			zlog_debug(
-				"%s %s: interface %s (vif_index=%d) is existing output for channel (S,G)=(%s,%s)",
+				"%s %s: interface %s (vif_index=%d) is existing output for channel (S,G)=(%pPAs,%pPAs)",
 				__FILE__, __func__, oif->name,
-				pim_ifp->mroute_vif_index, source_str,
-				group_str);
+				pim_ifp->mroute_vif_index,
+				oil_origin(channel_oil),
+				oil_mcastgrp(channel_oil));
 		}
 		return -4;
 	}
 
-	channel_oil->oil.mfcc_ttls[pim_ifp->mroute_vif_index] =
-		PIM_MROUTE_MIN_TTL;
+	oil_if_set(channel_oil, pim_ifp->mroute_vif_index, PIM_MROUTE_MIN_TTL);
 
 	/* Some OIFs are held in a muted state i.e. the PIM state machine
 	 * decided to include the OIF but additional status check such as
@@ -564,26 +500,19 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	/* channel_oil->oil.mfcc_parent != MAXVIFS indicate this entry is not
 	 * valid to get installed in kernel.
 	 */
-	if (channel_oil->oil.mfcc_parent != MAXVIFS) {
+	if (*oil_parent(channel_oil) != MAXVIFS) {
 		if (pim_upstream_mroute_add(channel_oil, __func__)) {
 			if (PIM_DEBUG_MROUTE) {
-				char group_str[INET_ADDRSTRLEN];
-				char source_str[INET_ADDRSTRLEN];
-				pim_inet4_dump("<group?>",
-				      channel_oil->oil.mfcc_mcastgrp,
-				      group_str, sizeof(group_str));
-				pim_inet4_dump("<source?>",
-				      channel_oil->oil.mfcc_origin, source_str,
-				      sizeof(source_str));
 				zlog_debug(
-					"%s %s: could not add output interface %s (vif_index=%d) for channel (S,G)=(%s,%s)",
+					"%s %s: could not add output interface %s (vif_index=%d) for channel (S,G)=(%pPAs,%pPAs)",
 					__FILE__, __func__, oif->name,
-					pim_ifp->mroute_vif_index, source_str,
-					group_str);
+					pim_ifp->mroute_vif_index,
+					oil_origin(channel_oil),
+					oil_mcastgrp(channel_oil));
 			}
 
-			channel_oil->oil.mfcc_ttls[pim_ifp->mroute_vif_index]
-				= old_ttl;
+			oil_if_set(channel_oil, pim_ifp->mroute_vif_index,
+				   old_ttl);
 			return -5;
 		}
 	}
@@ -594,15 +523,11 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	channel_oil->oif_flags[pim_ifp->mroute_vif_index] |= proto_mask;
 
 	if (PIM_DEBUG_MROUTE) {
-		char group_str[INET_ADDRSTRLEN];
-		char source_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<group?>", channel_oil->oil.mfcc_mcastgrp,
-			       group_str, sizeof(group_str));
-		pim_inet4_dump("<source?>", channel_oil->oil.mfcc_origin,
-			       source_str, sizeof(source_str));
 		zlog_debug(
-			"%s(%s): (S,G)=(%s,%s): proto_mask=%u OIF=%s vif_index=%d: DONE",
-			__func__, caller, source_str, group_str, proto_mask,
+			"%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u OIF=%s vif_index=%d: DONE",
+			__func__, caller, oil_origin(channel_oil),
+			oil_mcastgrp(channel_oil),
+			proto_mask,
 			oif->name, pim_ifp->mroute_vif_index);
 	}
 
@@ -611,8 +536,6 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 
 int pim_channel_oil_empty(struct channel_oil *c_oil)
 {
-	static struct mfcctl null_oil;
-
 	if (!c_oil)
 		return 1;
 
@@ -620,6 +543,13 @@ int pim_channel_oil_empty(struct channel_oil *c_oil)
 	 * non-NULL.
 	 * pimreg device (in all vrfs) uses a vifi of
 	 * 0 (PIM_OIF_PIM_REGISTER_VIF) so we simply mfcc_ttls[0] */
+#if PIM_IPV == 4
+	static pim_mfcctl null_oil;
+
 	return !memcmp(&c_oil->oil.mfcc_ttls[1], &null_oil.mfcc_ttls[1],
 		sizeof(null_oil.mfcc_ttls) - sizeof(null_oil.mfcc_ttls[0]));
+#else
+	CPP_NOTICE("FIXME STUB");
+	return false;
+#endif
 }

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -98,7 +98,7 @@ struct channel_oil {
 
 	struct rb_pim_oil_item oil_rb;
 
-	struct mfcctl oil;
+	pim_mfcctl oil;
 	int installed;
 	int oil_inherited_rescan;
 	int oil_size;
@@ -109,6 +109,61 @@ struct channel_oil {
 	struct pim_upstream *up;
 	time_t mroute_creation;
 };
+
+#if PIM_IPV == 4
+static inline pim_addr *oil_origin(struct channel_oil *c_oil)
+{
+	return &c_oil->oil.mfcc_origin;
+}
+
+static inline pim_addr *oil_mcastgrp(struct channel_oil *c_oil)
+{
+	return &c_oil->oil.mfcc_mcastgrp;
+}
+
+static inline vifi_t *oil_parent(struct channel_oil *c_oil)
+{
+	return &c_oil->oil.mfcc_parent;
+}
+
+static inline uint8_t oil_if_has(struct channel_oil *c_oil, vifi_t ifi)
+{
+	return c_oil->oil.mfcc_ttls[ifi];
+}
+
+static inline void oil_if_set(struct channel_oil *c_oil, vifi_t ifi, uint8_t set)
+{
+	c_oil->oil.mfcc_ttls[ifi] = set;
+}
+#else
+static inline pim_addr *oil_origin(struct channel_oil *c_oil)
+{
+	return &c_oil->oil.mf6cc_origin.sin6_addr;
+}
+
+static inline pim_addr *oil_mcastgrp(struct channel_oil *c_oil)
+{
+	return &c_oil->oil.mf6cc_mcastgrp.sin6_addr;
+}
+
+static inline mifi_t *oil_parent(struct channel_oil *c_oil)
+{
+	return &c_oil->oil.mf6cc_parent;
+}
+
+static inline bool oil_if_has(struct channel_oil *c_oil, mifi_t ifi)
+{
+	return !!IF_ISSET(ifi, &c_oil->oil.mf6cc_ifset);
+}
+
+static inline void oil_if_set(struct channel_oil *c_oil, mifi_t ifi, bool set)
+{
+	if (set)
+		IF_SET(ifi, &c_oil->oil.mf6cc_ifset);
+	else
+		IF_CLR(ifi, &c_oil->oil.mf6cc_ifset);
+}
+#endif
 
 extern int pim_channel_oil_compare(const struct channel_oil *c1,
 				   const struct channel_oil *c2);

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -1366,7 +1366,7 @@ void pim_resolve_rp_nh(struct pim_instance *pim, struct pim_neighbor *nbr)
 			if (nbr->interface != ifp1)
 				continue;
 
-#if PIM_IPV == 4 || !defined(PIM_V6_TEMP_BREAK)
+#if PIM_IPV == 4
 			nh_node->gate.ipv4 = nbr->source_addr;
 #else
 			nh_node->gate.ipv6 = nbr->source_addr;

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -58,7 +58,7 @@ unsigned int pim_rpf_hash_key(const void *arg);
 bool pim_rpf_equal(const void *arg1, const void *arg2);
 
 bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
-			struct in_addr addr, int neighbor_needed);
+			pim_addr addr, int neighbor_needed);
 enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 				   struct pim_upstream *up,
 				   struct pim_rpf *old, const char *caller);

--- a/pimd/pim_ssm.c
+++ b/pimd/pim_ssm.c
@@ -32,6 +32,7 @@
 
 static void pim_ssm_range_reevaluate(struct pim_instance *pim)
 {
+#if PIM_IPV == 4
 	/* 1. Setup register state for (S,G) entries if G has changed from SSM
 	 * to
 	 *    ASM.
@@ -50,6 +51,7 @@ static void pim_ssm_range_reevaluate(struct pim_instance *pim)
 	 */
 	pim_upstream_register_reevaluate(pim);
 	igmp_source_forward_reevaluate_all(pim);
+#endif
 }
 
 void pim_ssm_prefix_list_update(struct pim_instance *pim,

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -43,8 +43,8 @@ static struct static_route *static_route_alloc(void)
 }
 
 static struct static_route *static_route_new(ifindex_t iif, ifindex_t oif,
-					     struct in_addr group,
-					     struct in_addr source)
+					     pim_addr group,
+					     pim_addr source)
 {
 	struct static_route *s_route;
 	s_route = static_route_alloc();
@@ -54,10 +54,10 @@ static struct static_route *static_route_new(ifindex_t iif, ifindex_t oif,
 	s_route->iif = iif;
 	s_route->oif_ttls[oif] = 1;
 	s_route->c_oil.oil_ref_count = 1;
-	s_route->c_oil.oil.mfcc_origin = source;
-	s_route->c_oil.oil.mfcc_mcastgrp = group;
-	s_route->c_oil.oil.mfcc_parent = iif;
-	s_route->c_oil.oil.mfcc_ttls[oif] = 1;
+	*oil_origin(&s_route->c_oil) = source;
+	*oil_mcastgrp(&s_route->c_oil) = group;
+	*oil_parent(&s_route->c_oil) = iif;
+	oil_if_set(&s_route->c_oil, oif, 1);
 	s_route->c_oil.oif_creation[oif] = pim_time_monotonic_sec();
 
 	return s_route;
@@ -65,8 +65,7 @@ static struct static_route *static_route_new(ifindex_t iif, ifindex_t oif,
 
 
 int pim_static_add(struct pim_instance *pim, struct interface *iif,
-		   struct interface *oif, struct in_addr group,
-		   struct in_addr source)
+		   struct interface *oif, pim_addr group, pim_addr source)
 {
 	struct listnode *node = NULL;
 	struct static_route *s_route = NULL;
@@ -97,20 +96,14 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(pim->static_routes, node, s_route)) {
-		if (s_route->group.s_addr == group.s_addr
-		    && s_route->source.s_addr == source.s_addr) {
+		if (!pim_addr_cmp(s_route->group, group)
+		    && !pim_addr_cmp(s_route->source, source)) {
 			if (s_route->iif == iif_index
 			    && s_route->oif_ttls[oif_index]) {
-				char gifaddr_str[INET_ADDRSTRLEN];
-				char sifaddr_str[INET_ADDRSTRLEN];
-				pim_inet4_dump("<ifaddr?>", group, gifaddr_str,
-					       sizeof(gifaddr_str));
-				pim_inet4_dump("<ifaddr?>", source, sifaddr_str,
-					       sizeof(sifaddr_str));
 				zlog_warn(
-					"%s %s: Unable to add static route: Route already exists (iif=%d,oif=%d,group=%s,source=%s)",
+					"%s %s: Unable to add static route: Route already exists (iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
 					__FILE__, __func__, iif_index,
-					oif_index, gifaddr_str, sifaddr_str);
+					oif_index, &group, &source);
 				return -3;
 			}
 
@@ -130,7 +123,7 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 			 * adding a new output interface */
 			if (s_route->iif == iif_index) {
 				s_route->oif_ttls[oif_index] = 1;
-				s_route->c_oil.oil.mfcc_ttls[oif_index] = 1;
+				oil_if_set(&s_route->c_oil, oif_index, 1);
 				s_route->c_oil.oif_creation[oif_index] =
 					pim_time_monotonic_sec();
 				++s_route->c_oil.oil_ref_count;
@@ -147,8 +140,8 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 					s_route->oif_ttls[iif_index] = 0;
 					s_route->c_oil.oif_creation[iif_index] =
 						0;
-					s_route->c_oil.oil
-						.mfcc_ttls[iif_index] = 0;
+					oil_if_set(&s_route->c_oil, iif_index,
+						   0);
 					--s_route->c_oil.oil_ref_count;
 				}
 #endif
@@ -158,8 +151,8 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 					s_route->oif_ttls[oif_index] = 1;
 					s_route->c_oil.oif_creation[oif_index] =
 						pim_time_monotonic_sec();
-					s_route->c_oil.oil
-						.mfcc_ttls[oif_index] = 1;
+					oil_if_set(&s_route->c_oil, oif_index,
+						   1);
 					++s_route->c_oil.oil_ref_count;
 				}
 			}
@@ -178,16 +171,10 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 	s_route->c_oil.pim = pim;
 
 	if (pim_static_mroute_add(&s_route->c_oil, __func__)) {
-		char gifaddr_str[INET_ADDRSTRLEN];
-		char sifaddr_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<ifaddr?>", group, gifaddr_str,
-			       sizeof(gifaddr_str));
-		pim_inet4_dump("<ifaddr?>", source, sifaddr_str,
-			       sizeof(sifaddr_str));
 		zlog_warn(
-			"%s %s: Unable to add static route(iif=%d,oif=%d,group=%s,source=%s)",
-			__FILE__, __func__, iif_index, oif_index, gifaddr_str,
-			sifaddr_str);
+			"%s %s: Unable to add static route(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
+			__FILE__, __func__, iif_index, oif_index, &group,
+			&source);
 
 		/* Need to put s_route back to the way it was */
 		if (original_s_route) {
@@ -213,24 +200,17 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 	}
 
 	if (PIM_DEBUG_STATIC) {
-		char gifaddr_str[INET_ADDRSTRLEN];
-		char sifaddr_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<ifaddr?>", group, gifaddr_str,
-			       sizeof(gifaddr_str));
-		pim_inet4_dump("<ifaddr?>", source, sifaddr_str,
-			       sizeof(sifaddr_str));
 		zlog_debug(
-			"%s: Static route added(iif=%d,oif=%d,group=%s,source=%s)",
-			__func__, iif_index, oif_index, gifaddr_str,
-			sifaddr_str);
+			"%s: Static route added(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
+			__func__, iif_index, oif_index, &group,
+			&source);
 	}
 
 	return 0;
 }
 
 int pim_static_del(struct pim_instance *pim, struct interface *iif,
-		   struct interface *oif, struct in_addr group,
-		   struct in_addr source)
+		   struct interface *oif, pim_addr group, pim_addr source)
 {
 	struct listnode *node = NULL;
 	struct listnode *nextnode = NULL;
@@ -249,11 +229,11 @@ int pim_static_del(struct pim_instance *pim, struct interface *iif,
 
 	for (ALL_LIST_ELEMENTS(pim->static_routes, node, nextnode, s_route)) {
 		if (s_route->iif == iif_index
-		    && s_route->group.s_addr == group.s_addr
-		    && s_route->source.s_addr == source.s_addr
+		    && !pim_addr_cmp(s_route->group, group)
+		    && !pim_addr_cmp(s_route->source, source)
 		    && s_route->oif_ttls[oif_index]) {
 			s_route->oif_ttls[oif_index] = 0;
-			s_route->c_oil.oil.mfcc_ttls[oif_index] = 0;
+			oil_if_set(&s_route->c_oil, oif_index, 0);
 			--s_route->c_oil.oil_ref_count;
 
 			/* If there are no more outputs then delete the whole
@@ -263,19 +243,13 @@ int pim_static_del(struct pim_instance *pim, struct interface *iif,
 				    ? pim_mroute_del(&s_route->c_oil, __func__)
 				    : pim_static_mroute_add(&s_route->c_oil,
 							    __func__)) {
-				char gifaddr_str[INET_ADDRSTRLEN];
-				char sifaddr_str[INET_ADDRSTRLEN];
-				pim_inet4_dump("<ifaddr?>", group, gifaddr_str,
-					       sizeof(gifaddr_str));
-				pim_inet4_dump("<ifaddr?>", source, sifaddr_str,
-					       sizeof(sifaddr_str));
 				zlog_warn(
-					"%s %s: Unable to remove static route(iif=%d,oif=%d,group=%s,source=%s)",
+					"%s %s: Unable to remove static route(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
 					__FILE__, __func__, iif_index,
-					oif_index, gifaddr_str, sifaddr_str);
+					oif_index, &group, &source);
 
 				s_route->oif_ttls[oif_index] = 1;
-				s_route->c_oil.oil.mfcc_ttls[oif_index] = 1;
+				oil_if_set(&s_route->c_oil, oif_index, 1);
 				++s_route->c_oil.oil_ref_count;
 
 				return -1;
@@ -289,16 +263,10 @@ int pim_static_del(struct pim_instance *pim, struct interface *iif,
 			}
 
 			if (PIM_DEBUG_STATIC) {
-				char gifaddr_str[INET_ADDRSTRLEN];
-				char sifaddr_str[INET_ADDRSTRLEN];
-				pim_inet4_dump("<ifaddr?>", group, gifaddr_str,
-					       sizeof(gifaddr_str));
-				pim_inet4_dump("<ifaddr?>", source, sifaddr_str,
-					       sizeof(sifaddr_str));
 				zlog_debug(
-					"%s: Static route removed(iif=%d,oif=%d,group=%s,source=%s)",
+					"%s: Static route removed(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
 					__func__, iif_index, oif_index,
-					gifaddr_str, sifaddr_str);
+					&group, &source);
 			}
 
 			break;
@@ -306,16 +274,10 @@ int pim_static_del(struct pim_instance *pim, struct interface *iif,
 	}
 
 	if (!node) {
-		char gifaddr_str[INET_ADDRSTRLEN];
-		char sifaddr_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<ifaddr?>", group, gifaddr_str,
-			       sizeof(gifaddr_str));
-		pim_inet4_dump("<ifaddr?>", source, sifaddr_str,
-			       sizeof(sifaddr_str));
 		zlog_warn(
-			"%s %s: Unable to remove static route: Route does not exist(iif=%d,oif=%d,group=%s,source=%s)",
-			__FILE__, __func__, iif_index, oif_index, gifaddr_str,
-			sifaddr_str);
+			"%s %s: Unable to remove static route: Route does not exist(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
+			__FILE__, __func__, iif_index, oif_index, &group,
+			&source);
 		return -3;
 	}
 
@@ -329,15 +291,11 @@ int pim_static_write_mroute(struct pim_instance *pim, struct vty *vty,
 	struct listnode *node;
 	struct static_route *sroute;
 	int count = 0;
-	char sbuf[INET_ADDRSTRLEN];
-	char gbuf[INET_ADDRSTRLEN];
 
 	if (!pim_ifp)
 		return 0;
 
 	for (ALL_LIST_ELEMENTS_RO(pim->static_routes, node, sroute)) {
-		pim_inet4_dump("<ifaddr?>", sroute->group, gbuf, sizeof(gbuf));
-		pim_inet4_dump("<ifaddr?>", sroute->source, sbuf, sizeof(sbuf));
 		if (sroute->iif == pim_ifp->mroute_vif_index) {
 			int i;
 			for (i = 0; i < MAXVIFS; i++)
@@ -345,14 +303,15 @@ int pim_static_write_mroute(struct pim_instance *pim, struct vty *vty,
 					struct interface *oifp =
 						pim_if_find_by_vif_index(pim,
 									 i);
-					if (sroute->source.s_addr == INADDR_ANY)
+					if (pim_addr_is_any(sroute->source))
 						vty_out(vty,
-							" ip mroute %s %s\n",
-							oifp->name, gbuf);
+							" ip mroute %s %pPA\n",
+							oifp->name, &sroute->group);
 					else
 						vty_out(vty,
-							" ip mroute %s %s %s\n",
-							oifp->name, gbuf, sbuf);
+							" ip mroute %s %pPA %pPA\n",
+							oifp->name, &sroute->group,
+							&sroute->source);
 					count++;
 				}
 		}

--- a/pimd/pim_static.h
+++ b/pimd/pim_static.h
@@ -26,8 +26,8 @@
 
 struct static_route {
 	/* Each static route is unique by these pair of addresses */
-	struct in_addr group;
-	struct in_addr source;
+	pim_addr group;
+	pim_addr source;
 
 	struct channel_oil c_oil;
 	ifindex_t iif;
@@ -37,11 +37,9 @@ struct static_route {
 void pim_static_route_free(struct static_route *s_route);
 
 int pim_static_add(struct pim_instance *pim, struct interface *iif,
-		   struct interface *oif, struct in_addr group,
-		   struct in_addr source);
+		   struct interface *oif, pim_addr group, pim_addr source);
 int pim_static_del(struct pim_instance *pim, struct interface *iif,
-		   struct interface *oif, struct in_addr group,
-		   struct in_addr source);
+		   struct interface *oif, pim_addr group, pim_addr source);
 int pim_static_write_mroute(struct pim_instance *pim, struct vty *vty,
 			    struct interface *ifp);
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1997,7 +1997,7 @@ static bool pim_upstream_kat_start_ok(struct pim_upstream *up)
 		return false;
 
 	pim_ifp = ifp->info;
-	if (pim_ifp->mroute_vif_index != c_oil->oil.mfcc_parent)
+	if (pim_ifp->mroute_vif_index != *oil_parent(c_oil))
 		return false;
 
 	if (pim_if_connected_to_source(up->rpf.source_nexthop.interface,

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -326,7 +326,7 @@ void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,
 void pim_upstream_join_timer_restart(struct pim_upstream *up,
 				     struct pim_rpf *old);
 void pim_upstream_rpf_genid_changed(struct pim_instance *pim,
-				    struct in_addr neigh_addr);
+				    pim_addr neigh_addr);
 void pim_upstream_rpf_interface_changed(struct pim_upstream *up,
 					struct interface *old_rpf_ifp);
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -397,6 +397,7 @@ int pim_interface_config_write(struct vty *vty)
 					++writes;
 				}
 
+#if PIM_IPV == 4
 				/* IF ip igmp join */
 				if (pim_ifp->gm_join_list) {
 					struct listnode *node;
@@ -428,6 +429,7 @@ int pim_interface_config_write(struct vty *vty)
 						++writes;
 					}
 				}
+#endif /* PIM_IPV == 4 */
 
 				if (pim_ifp->activeactive)
 					vty_out(vty, " ip pim active-active\n");

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -242,7 +242,7 @@ void pim_zebra_update_all_interfaces(struct pim_instance *pim)
 			struct pim_rpf rpf;
 
 			rpf.source_nexthop.interface = ifp;
-			rpf.rpf_addr.u.prefix4 = us->address;
+			pim_addr_to_prefix(&rpf.rpf_addr, us->address);
 			pim_joinprune_send(&rpf, us->us);
 			pim_jp_agg_clear_group(us->us);
 		}

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -468,6 +468,7 @@ void pim_zebra_init(void)
 	zclient_lookup_new();
 }
 
+#if PIM_IPV == 4
 void igmp_anysource_forward_start(struct pim_instance *pim,
 				  struct gm_group *group)
 {
@@ -794,6 +795,7 @@ void igmp_source_forward_stop(struct gm_source *source)
 
 	IGMP_SOURCE_DONT_FORWARDING(source->source_flags);
 }
+#endif /* PIM_IPV == 4 */
 
 void pim_forward_start(struct pim_ifchannel *ch)
 {

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -397,7 +397,7 @@ int zclient_lookup_read_pipe(struct thread *thread)
 
 int zclient_lookup_nexthop(struct pim_instance *pim,
 			   struct pim_zlookup_nexthop nexthop_tab[],
-			   const int tab_size, struct in_addr addr,
+			   const int tab_size, pim_addr addr,
 			   int max_lookup)
 {
 	int lookup;

--- a/pimd/pim_zlookup.h
+++ b/pimd/pim_zlookup.h
@@ -39,7 +39,7 @@ void zclient_lookup_free(void);
 
 int zclient_lookup_nexthop(struct pim_instance *pim,
 			   struct pim_zlookup_nexthop nexthop_tab[],
-			   const int tab_size, struct in_addr addr,
+			   const int tab_size, pim_addr addr,
 			   int max_lookup);
 
 void pim_zlookup_show_ip_multicast(struct vty *vty);

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -29,7 +29,6 @@ pim_common = \
 	pimd/pim_jp_agg.c \
 	pimd/pim_macro.c \
 	pimd/pim_memory.c \
-	pimd/pim_mlag.c \
 	pimd/pim_mroute.c \
 	pimd/pim_msg.c \
 	pimd/pim_nb.c \
@@ -55,7 +54,6 @@ pim_common = \
 	pimd/pim_zebra.c \
 	pimd/pim_zlookup.c \
 	pimd/pim_vxlan.c \
-	pimd/pim_zpthread.c \
 	pimd/pimd.c \
 	# end
 
@@ -67,10 +65,12 @@ pimd_pimd_SOURCES = \
 	pimd/pim_igmpv2.c \
 	pimd/pim_igmpv3.c \
 	pimd/pim_main.c \
+	pimd/pim_mlag.c \
 	pimd/pim_msdp.c \
 	pimd/pim_msdp_packet.c \
 	pimd/pim_msdp_socket.c \
 	pimd/pim_signals.c \
+	pimd/pim_zpthread.c \
 	# end
 
 nodist_pimd_pimd_SOURCES = \

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -159,7 +159,7 @@ if DEV_BUILD
 # (change noinst_ to sbin_ below to install it.)
 #
 noinst_PROGRAMS += pimd/pim6d
-pimd_pim6d_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=6 $(and $(PIM_V6_TEMP_BREAK),-DPIM_V6_TEMP_BREAK)
+pimd_pim6d_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=6
 pimd_pim6d_LDADD = lib/libfrr.la $(LIBCAP)
 endif
 endif

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -18,7 +18,6 @@ pim_common = \
 	pimd/pim_bfd.c \
 	pimd/pim_br.c \
 	pimd/pim_bsm.c \
-	pimd/pim_cmd.c \
 	pimd/pim_errors.c \
 	pimd/pim_hello.c \
 	pimd/pim_iface.c \
@@ -34,10 +33,7 @@ pim_common = \
 	pimd/pim_nb.c \
 	pimd/pim_nb_config.c \
 	pimd/pim_neighbor.c \
-	pimd/pim_nht.c \
 	pimd/pim_oil.c \
-	pimd/pim_pim.c \
-	pimd/pim_register.c \
 	pimd/pim_routemap.c \
 	pimd/pim_rp.c \
 	pimd/pim_rpf.c \
@@ -52,13 +48,13 @@ pim_common = \
 	pimd/pim_util.c \
 	pimd/pim_vty.c \
 	pimd/pim_zebra.c \
-	pimd/pim_zlookup.c \
 	pimd/pim_vxlan.c \
 	pimd/pimd.c \
 	# end
 
 pimd_pimd_SOURCES = \
 	$(pim_common) \
+	pimd/pim_cmd.c \
 	pimd/pim_igmp.c \
 	pimd/pim_igmp_mtrace.c \
 	pimd/pim_igmp_stats.c \
@@ -69,7 +65,11 @@ pimd_pimd_SOURCES = \
 	pimd/pim_msdp.c \
 	pimd/pim_msdp_packet.c \
 	pimd/pim_msdp_socket.c \
+	pimd/pim_nht.c \
+	pimd/pim_pim.c \
+	pimd/pim_register.c \
 	pimd/pim_signals.c \
+	pimd/pim_zlookup.c \
 	pimd/pim_zpthread.c \
 	# end
 
@@ -82,6 +82,7 @@ nodist_pimd_pimd_SOURCES = \
 pimd_pim6d_SOURCES = \
 	$(pim_common) \
 	pimd/pim6_main.c \
+	pimd/pim6_stubs.c \
 	# end
 
 nodist_pimd_pim6d_SOURCES = \

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -23,11 +23,6 @@ pim_common = \
 	pimd/pim_hello.c \
 	pimd/pim_iface.c \
 	pimd/pim_ifchannel.c \
-	pimd/pim_igmp.c \
-	pimd/pim_igmp_mtrace.c \
-	pimd/pim_igmp_stats.c \
-	pimd/pim_igmpv2.c \
-	pimd/pim_igmpv3.c \
 	pimd/pim_instance.c \
 	pimd/pim_int.c \
 	pimd/pim_join.c \
@@ -66,6 +61,11 @@ pim_common = \
 
 pimd_pimd_SOURCES = \
 	$(pim_common) \
+	pimd/pim_igmp.c \
+	pimd/pim_igmp_mtrace.c \
+	pimd/pim_igmp_stats.c \
+	pimd/pim_igmpv2.c \
+	pimd/pim_igmpv3.c \
 	pimd/pim_main.c \
 	pimd/pim_msdp.c \
 	pimd/pim_msdp_packet.c \


### PR DESCRIPTION
This fixes up `pim6d` to at least compile without warnings, with IPv6 types used throughout. This by no means implies that IPv6 PIM would be working, just that everything got either mechanically adapted or stubbed out.

There are several whole blocks stubbed out:

- group → RP mapping
- NHT & RPF lookups
- low-level packet de-/encoding, including register tunneling
- processing notifications from the kernel
- the entire CLI (and YANG)

~Also I still have a few small items on my TODO to go back for, which means **I will be editing the history here, the commits are not finalized yet**.~