### PR TITLE
ospfd: fix crash on "ospf send-extra-data zebra"

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2223,6 +2223,9 @@ static void ospf_table_reinstall_routes(struct ospf *ospf,
 {
 	struct route_node *rn;
 
+	if (!rt)
+		return;
+
 	for (rn = route_top(rt); rn; rn = route_next(rn)) {
 		struct ospf_route *or;
 


### PR DESCRIPTION
`ospf->new_table` is NULL if the OSPF instance has no routes.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>