### PR TITLE
pimd: fix interface memleak

### DIFF
--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -178,8 +178,7 @@ int main(int argc, char **argv, char **envp)
 	/*
 	 * Initialize zclient "update" and "lookup" sockets
 	 */
-	if_zapi_callbacks(pim_ifp_create, pim_ifp_up,
-			  pim_ifp_down, pim_ifp_destroy);
+	pim_iface_init();
 
 	/* TODO PIM6: next line is temporary since pim_cmd_init is disabled */
 	if_cmd_init(NULL);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1710,6 +1710,9 @@ static int pim_if_new_hook(struct interface *ifp)
 
 static int pim_if_delete_hook(struct interface *ifp)
 {
+	if (ifp->info)
+		pim_if_delete(ifp);
+
 	return 0;
 }
 

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1521,7 +1521,7 @@ int pim_if_ifchannel_count(struct pim_interface *pim_ifp)
 	return count;
 }
 
-int pim_ifp_create(struct interface *ifp)
+static int pim_ifp_create(struct interface *ifp)
 {
 	struct pim_instance *pim;
 
@@ -1589,7 +1589,7 @@ int pim_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-int pim_ifp_up(struct interface *ifp)
+static int pim_ifp_up(struct interface *ifp)
 {
 	struct pim_interface *pim_ifp;
 	struct pim_instance *pim;
@@ -1645,7 +1645,7 @@ int pim_ifp_up(struct interface *ifp)
 	return 0;
 }
 
-int pim_ifp_down(struct interface *ifp)
+static int pim_ifp_down(struct interface *ifp)
 {
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
@@ -1681,7 +1681,7 @@ int pim_ifp_down(struct interface *ifp)
 	return 0;
 }
 
-int pim_ifp_destroy(struct interface *ifp)
+static int pim_ifp_destroy(struct interface *ifp)
 {
 	struct pim_instance *pim;
 
@@ -1701,4 +1701,23 @@ int pim_ifp_destroy(struct interface *ifp)
 		pim_vxlan_del_term_dev(pim);
 
 	return 0;
+}
+
+static int pim_if_new_hook(struct interface *ifp)
+{
+	return 0;
+}
+
+static int pim_if_delete_hook(struct interface *ifp)
+{
+	return 0;
+}
+
+void pim_iface_init(void)
+{
+	hook_register_prio(if_add, 0, pim_if_new_hook);
+	hook_register_prio(if_del, 0, pim_if_delete_hook);
+
+	if_zapi_callbacks(pim_ifp_create, pim_ifp_up, pim_ifp_down,
+			  pim_ifp_destroy);
 }

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -259,9 +259,6 @@ bool pim_if_is_vrf_device(struct interface *ifp);
 
 int pim_if_ifchannel_count(struct pim_interface *pim_ifp);
 
-extern int pim_ifp_create(struct interface *ifp);
-extern int pim_ifp_up(struct interface *ifp);
-extern int pim_ifp_down(struct interface *ifp);
-extern int pim_ifp_destroy(struct interface *ifp);
+void pim_iface_init(void);
 
 #endif /* PIM_IFACE_H */

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -136,8 +136,7 @@ int main(int argc, char **argv, char **envp)
 	/*
 	 * Initialize zclient "update" and "lookup" sockets
 	 */
-	if_zapi_callbacks(pim_ifp_create, pim_ifp_up,
-			  pim_ifp_down, pim_ifp_destroy);
+	pim_iface_init();
 	pim_zebra_init();
 	pim_bfd_init();
 	pim_mlag_init();


### PR DESCRIPTION
The first commit is cosmetic. The actual fix is in the second commit.