### PR TITLE
write bgp view to custom table 

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3065,7 +3065,8 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 				     new_select);
 
 	/* FIB update. */
-	if (bgp_fibupd_safi(safi) && (bgp->inst_type != BGP_INSTANCE_TYPE_VIEW)
+	int is_custom_table = (new_select && new_select->attr->rmap_table_id) || (old_select && old_select->attr->rmap_table_id);
+	if (bgp_fibupd_safi(safi) && (bgp->inst_type != BGP_INSTANCE_TYPE_VIEW || is_custom_table)
 	    && !bgp_option_check(BGP_OPT_NO_FIB)) {
 
 		if (new_select && new_select->type == ZEBRA_ROUTE_BGP

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -779,6 +779,7 @@ struct afi_safi_info {
 
 #define IS_BGP_INST_KNOWN_TO_ZEBRA(bgp)                                        \
 	(bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT                           \
+	 || bgp->inst_type == BGP_INSTANCE_TYPE_VIEW                           \
 	 || (bgp->inst_type == BGP_INSTANCE_TYPE_VRF                           \
 	     && bgp->vrf_id != VRF_UNKNOWN))
 


### PR DESCRIPTION
When peer in bgp view has route-map and bound with custom table, it is better is write to that table.