### PR TITLE
redhat: logrotate file has typo for staticd

### DIFF
--- a/redhat/frr.logrotate
+++ b/redhat/frr.logrotate
@@ -138,7 +138,7 @@
     notifempty
     missingok
     postrotate
-        /bin/kill -USR1 `cat /var/run/frr/static.pid 2> /dev/null` 2> /dev/null || true
+        /bin/kill -USR1 `cat /var/run/frr/staticd.pid 2> /dev/null` 2> /dev/null || true
     endscript
 }
 


### PR DESCRIPTION
s/static/staticd

fixes #10418 

Signed-off-by: Quentin Young <qlyoung@nvidia.com>