### PR TITLE
ospf6d: show if area is NSSA

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -511,11 +511,13 @@ void ospf6_area_show(struct vty *vty, struct ospf6_area *oa,
 		if (oa->ts_spf.tv_sec || oa->ts_spf.tv_usec) {
 			result = monotime_since(&oa->ts_spf, NULL);
 			if (result / TIMER_SECOND_MICRO > 0) {
-				vty_out(vty, "SPF last executed %ld.%lds ago\n",
+				vty_out(vty,
+					"     SPF last executed %ld.%lds ago\n",
 					result / TIMER_SECOND_MICRO,
 					result % TIMER_SECOND_MICRO);
 			} else {
-				vty_out(vty, "SPF last executed %ldus ago\n",
+				vty_out(vty,
+					"     SPF last executed %ldus ago\n",
 					result);
 			}
 		} else

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -446,7 +446,9 @@ void ospf6_area_show(struct vty *vty, struct ospf6_area *oa,
 		json_area = json_object_new_object();
 		json_object_boolean_add(json_area, "areaIsStub",
 					IS_AREA_STUB(oa));
-		if (IS_AREA_STUB(oa)) {
+		json_object_boolean_add(json_area, "areaIsNSSA",
+					IS_AREA_NSSA(oa));
+		if (IS_AREA_STUB(oa) || IS_AREA_NSSA(oa)) {
 			json_object_boolean_add(json_area, "areaNoSummary",
 						oa->no_summary);
 		}
@@ -490,14 +492,16 @@ void ospf6_area_show(struct vty *vty, struct ospf6_area *oa,
 
 	} else {
 
-		if (!IS_AREA_STUB(oa))
+		if (!IS_AREA_STUB(oa) && !IS_AREA_NSSA(oa))
 			vty_out(vty, " Area %s\n", oa->name);
 		else {
 			if (oa->no_summary) {
-				vty_out(vty, " Area %s[Stub, No Summary]\n",
-					oa->name);
+				vty_out(vty, " Area %s[%s, No Summary]\n",
+					oa->name,
+					IS_AREA_STUB(oa) ? "Stub" : "NSSA");
 			} else {
-				vty_out(vty, " Area %s[Stub]\n", oa->name);
+				vty_out(vty, " Area %s[%s]\n", oa->name,
+					IS_AREA_STUB(oa) ? "Stub" : "NSSA");
 			}
 		}
 		vty_out(vty, "     Number of Area scoped LSAs is %u\n",


### PR DESCRIPTION
This PR will include if the area is NSSA in the output of "show ipv6 ospf"
It also fixes the indentation of `SPF last executed...` string
```
        r2# show ipv6 ospf
         ...
         Area 0.0.0.0
             Number of Area scoped LSAs is 8
             Interface attached to this area: r2-eth1
             SPF last executed 20.46717s ago
         Area 0.0.0.1[Stub]
             Number of Area scoped LSAs is 9
             Interface attached to this area: r2-eth0
             SPF last executed 20.46911s ago
         Area 0.0.0.2[NSSA]                          <----- ***
             Number of Area scoped LSAs is 14
             Interface attached to this area: r2-eth2
             SPF last executed 20.46801s ago
```    
Signed-off-by: ckishimo <carles.kishimoto@gmail.com>
