### PR TITLE
Add Support for Setting Protodown Reason Code

### DIFF
--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -296,3 +296,7 @@ keyword. At present, no sharp commands will be preserved in the config.
 
    router# show sharp segment-routing srv6
    (nothing)
+
+.. clicmd:: sharp interface IFNAME protodown
+
+   Set an interface protodown.

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -255,6 +255,17 @@ Link Parameters Commands
    for InterASv2 link in OSPF (RFC5392).  Note that this option is not yet
    supported for ISIS (RFC5316).
 
+Global Commands
+------------------------
+
+.. clicmd:: zebra protodown reason-bit (0-31)
+
+   This command is only supported for linux and a kernel > 5.1.
+   Change reason-bit frr uses for setting protodown. We default to 7, but
+   if another userspace app ever conflicts with this, you can change it here.
+   The descriptor for this bit should exist in :file:`/etc/iproute2/protodown_reasons.d/`
+   to display with :clicmd:`ip -d link show`.
+
 Nexthop Tracking
 ================
 

--- a/include/linux/if_link.h
+++ b/include/linux/if_link.h
@@ -167,11 +167,24 @@ enum {
 	IFLA_NEW_IFINDEX,
 	IFLA_MIN_MTU,
 	IFLA_MAX_MTU,
+	IFLA_PROP_LIST,
+	IFLA_ALT_IFNAME, /* Alternative ifname */
+	IFLA_PERM_ADDRESS,
+	IFLA_PROTO_DOWN_REASON,
 	__IFLA_MAX
 };
 
 
 #define IFLA_MAX (__IFLA_MAX - 1)
+
+enum {
+	IFLA_PROTO_DOWN_REASON_UNSPEC,
+	IFLA_PROTO_DOWN_REASON_MASK,	/* u32, mask for reason bits */
+	IFLA_PROTO_DOWN_REASON_VALUE,   /* u32, reason bit value */
+
+	__IFLA_PROTO_DOWN_REASON_CNT,
+	IFLA_PROTO_DOWN_REASON_MAX = __IFLA_PROTO_DOWN_REASON_CNT - 1
+};
 
 /* backwards compatibility for userspace */
 #ifndef __KERNEL__

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -968,6 +968,18 @@ static int sharp_zebra_process_srv6_locator_chunk(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
+int sharp_zebra_send_interface_protodown(struct interface *ifp, bool down)
+{
+	zlog_debug("Sending zebra to set %s protodown %s", ifp->name,
+		   down ? "on" : "off");
+
+	if (zclient_send_interface_protodown(zclient, ifp->vrf->vrf_id, ifp,
+					     down) == ZCLIENT_SEND_FAILURE)
+		return -1;
+
+	return 0;
+}
+
 static zclient_handler *const sharp_handlers[] = {
 	[ZEBRA_INTERFACE_ADDRESS_ADD] = interface_address_add,
 	[ZEBRA_INTERFACE_ADDRESS_DELETE] = interface_address_delete,

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -73,4 +73,6 @@ extern void sharp_install_seg6local_route_helper(struct prefix *p,
 						 enum seg6local_action_t act,
 						 struct seg6local_context *ctx);
 
+extern int sharp_zebra_send_interface_protodown(struct interface *ifp,
+						bool down);
 #endif

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -812,6 +812,9 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_INTF_ADDR_ADD:
 	case DPLANE_OP_INTF_ADDR_DEL:
 	case DPLANE_OP_INTF_NETCONFIG:
+	case DPLANE_OP_INTF_INSTALL:
+	case DPLANE_OP_INTF_UPDATE:
+	case DPLANE_OP_INTF_DELETE:
 	case DPLANE_OP_NONE:
 		break;
 

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -2214,4 +2214,34 @@ void interface_list(struct zebra_ns *zns)
 	interface_addr_lookup_netlink(zns);
 }
 
+void if_netlink_set_frr_protodown_r_bit(uint8_t bit)
+{
+	if (IS_ZEBRA_DEBUG_KERNEL)
+		zlog_debug("FRR protodown reason bit change %u -> %u",
+			   frr_protodown_r_bit, bit);
+
+	frr_protodown_r_bit = bit;
+}
+
+void if_netlink_unset_frr_protodown_r_bit(void)
+{
+	if (IS_ZEBRA_DEBUG_KERNEL)
+		zlog_debug("FRR protodown reason bit change %u -> %u",
+			   frr_protodown_r_bit,
+			   FRR_PROTODOWN_REASON_DEFAULT_BIT);
+
+	frr_protodown_r_bit = FRR_PROTODOWN_REASON_DEFAULT_BIT;
+}
+
+
+bool if_netlink_frr_protodown_r_bit_is_set(void)
+{
+	return (frr_protodown_r_bit != FRR_PROTODOWN_REASON_DEFAULT_BIT);
+}
+
+uint8_t if_netlink_get_frr_protodown_r_bit(void)
+{
+	return frr_protodown_r_bit;
+}
+
 #endif /* GNU_LINUX */

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -872,6 +872,13 @@ static void netlink_proc_dplane_if_protodown(struct zebra_if *zif,
 		zif->flags &= ~ZIF_FLAG_PROTODOWN;
 
 	if (zebra_evpn_is_es_bond_member(zif->ifp)) {
+		/* Check it's not already being sent to the dplane first */
+		if (protodown && (zif->flags & ZIF_FLAG_SET_PROTODOWN))
+			return;
+
+		if (!protodown && (zif->flags & ZIF_FLAG_UNSET_PROTODOWN))
+			return;
+
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES || IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
 				"bond mbr %s re-instate protdown %s in the dplane",

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -815,39 +815,73 @@ static int netlink_bridge_interface(struct nlmsghdr *h, int len, ns_id_t ns_id,
 	return 0;
 }
 
-/* If the interface is an es bond member then it must follow EVPN's
- * protodown setting
+static bool is_if_protodown_r_only_frr(uint32_t rc_bitfield)
+{
+	/* This shouldn't be possible */
+	assert(frr_protodown_r_bit < 32);
+	return (rc_bitfield == (((uint32_t)1) << frr_protodown_r_bit));
+}
+
+/*
+ * Process interface protodown dplane update.
+ *
+ * If the interface is an es bond member then it must follow EVPN's
+ * protodown setting.
  */
 static void netlink_proc_dplane_if_protodown(struct zebra_if *zif,
-					     bool protodown)
+					     struct rtattr **tb)
 {
-	bool zif_protodown;
+	bool protodown;
+	bool old_protodown;
+	uint32_t rc_bitfield = 0;
+	struct rtattr *pd_reason_info[IFLA_MAX + 1];
 
-	/* Set our reason code to note it wasn't us */
-	if (protodown)
+	protodown = !!*(uint8_t *)RTA_DATA(tb[IFLA_PROTO_DOWN]);
+
+	if (tb[IFLA_PROTO_DOWN_REASON]) {
+		netlink_parse_rtattr_nested(pd_reason_info, IFLA_INFO_MAX,
+					    tb[IFLA_PROTO_DOWN_REASON]);
+
+		if (pd_reason_info[IFLA_PROTO_DOWN_REASON_VALUE])
+			rc_bitfield = *(uint32_t *)RTA_DATA(
+				pd_reason_info[IFLA_PROTO_DOWN_REASON_VALUE]);
+	}
+
+	/*
+	 * Set our reason code to note it wasn't us.
+	 * If the reason we got from the kernel is ONLY frr though, don't
+	 * set it.
+	 */
+	if (protodown && is_if_protodown_r_only_frr(rc_bitfield) == false)
 		zif->protodown_rc |= ZEBRA_PROTODOWN_EXTERNAL;
 	else
 		zif->protodown_rc &= ~ZEBRA_PROTODOWN_EXTERNAL;
 
-	zif_protodown = !!(zif->flags & ZIF_FLAG_PROTODOWN);
-	if (protodown == zif_protodown)
+	old_protodown = !!(zif->flags & ZIF_FLAG_PROTODOWN);
+	if (protodown == old_protodown)
 		return;
 
 	if (IS_ZEBRA_DEBUG_EVPN_MH_ES || IS_ZEBRA_DEBUG_KERNEL)
 		zlog_debug("interface %s dplane change, protdown %s",
 			   zif->ifp->name, protodown ? "on" : "off");
 
+	if (protodown)
+		zif->flags |= ZIF_FLAG_PROTODOWN;
+	else
+		zif->flags &= ~ZIF_FLAG_PROTODOWN;
+
 	if (zebra_evpn_is_es_bond_member(zif->ifp)) {
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES || IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
 				"bond mbr %s re-instate protdown %s in the dplane",
-				zif->ifp->name, zif_protodown ? "on" : "off");
-		netlink_protodown(zif->ifp, zif_protodown, zif->protodown_rc);
-	} else {
-		if (protodown)
-			zif->flags |= ZIF_FLAG_PROTODOWN;
+				zif->ifp->name, old_protodown ? "on" : "off");
+
+		if (old_protodown)
+			zif->flags |= ZIF_FLAG_SET_PROTODOWN;
 		else
-			zif->flags &= ~ZIF_FLAG_PROTODOWN;
+			zif->flags |= ZIF_FLAG_UNSET_PROTODOWN;
+
+		dplane_intf_update(zif->ifp);
 	}
 }
 
@@ -863,6 +897,28 @@ static uint8_t netlink_parse_lacp_bypass(struct rtattr **linkinfo)
 			mbrinfo[IFLA_BOND_SLAVE_AD_RX_BYPASS]);
 
 	return bypass;
+}
+
+/*
+ * Only called at startup to cleanup leftover protodown we may have not cleanup
+ */
+static void if_sweep_protodown(struct zebra_if *zif)
+{
+	bool protodown;
+
+	protodown = !!(zif->flags & ZIF_FLAG_PROTODOWN);
+
+	if (!protodown)
+		return;
+
+	if (IS_ZEBRA_DEBUG_KERNEL)
+		zlog_debug("interface %s sweeping protdown %s", zif->ifp->name,
+			   protodown ? "on" : "off");
+
+	/* Only clear our reason codes, leave external if it was set */
+	zif->protodown_rc |= ~ZEBRA_PROTODOWN_ALL;
+	zif->flags |= ZIF_FLAG_UNSET_PROTODOWN;
+	dplane_intf_update(zif->ifp);
 }
 
 /*
@@ -912,7 +968,8 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 	/* Looking up interface name. */
 	memset(linkinfo, 0, sizeof(linkinfo));
-	netlink_parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), len);
+	netlink_parse_rtattr_flags(tb, IFLA_MAX, IFLA_RTA(ifi), len,
+				   NLA_F_NESTED);
 
 	/* check for wireless messages to ignore */
 	if ((tb[IFLA_WIRELESS] != NULL) && (ifi->ifi_change == 0)) {
@@ -1027,10 +1084,8 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		zebra_l2if_update_bond_slave(ifp, bond_ifindex, !!bypass);
 
 	if (tb[IFLA_PROTO_DOWN]) {
-		uint8_t protodown;
-
-		protodown = *(uint8_t *)RTA_DATA(tb[IFLA_PROTO_DOWN]);
-		netlink_proc_dplane_if_protodown(zif, !!protodown);
+		netlink_proc_dplane_if_protodown(zif, tb);
+		if_sweep_protodown(zif);
 	}
 
 	return 0;
@@ -1758,7 +1813,8 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 	/* Looking up interface name. */
 	memset(linkinfo, 0, sizeof(linkinfo));
-	netlink_parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), len);
+	netlink_parse_rtattr_flags(tb, IFLA_MAX, IFLA_RTA(ifi), len,
+				   NLA_F_NESTED);
 
 	/* check for wireless messages to ignore */
 	if ((tb[IFLA_WIRELESS] != NULL) && (ifi->ifi_change == 0)) {
@@ -1898,14 +1954,9 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 				zebra_l2if_update_bond_slave(ifp, bond_ifindex,
 							     !!bypass);
 
-			if (tb[IFLA_PROTO_DOWN]) {
-				uint8_t protodown;
+			if (tb[IFLA_PROTO_DOWN])
+				netlink_proc_dplane_if_protodown(ifp->info, tb);
 
-				protodown = *(uint8_t *)RTA_DATA(
-					tb[IFLA_PROTO_DOWN]);
-				netlink_proc_dplane_if_protodown(ifp->info,
-								 !!protodown);
-			}
 		} else if (ifp->vrf->vrf_id != vrf_id) {
 			/* VRF change for an interface. */
 			if (IS_ZEBRA_DEBUG_KERNEL)
@@ -1952,14 +2003,8 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 				netlink_to_zebra_link_type(ifi->ifi_type);
 			netlink_interface_update_hw_addr(tb, ifp);
 
-			if (tb[IFLA_PROTO_DOWN]) {
-				uint8_t protodown;
-
-				protodown = *(uint8_t *)RTA_DATA(
-					tb[IFLA_PROTO_DOWN]);
-				netlink_proc_dplane_if_protodown(zif,
-								 !!protodown);
-			}
+			if (tb[IFLA_PROTO_DOWN])
+				netlink_proc_dplane_if_protodown(ifp->info, tb);
 
 			if (if_is_no_ptm_operative(ifp)) {
 				bool is_up = if_is_operative(ifp);
@@ -2112,7 +2157,6 @@ ssize_t netlink_intf_msg_encode(uint16_t cmd,
 
 	struct rtattr *nest_protodown_reason;
 	ifindex_t ifindex = dplane_ctx_get_ifindex(ctx);
-	uint32_t r_bitfield = dplane_ctx_get_intf_r_bitfield(ctx);
 	bool down = dplane_ctx_intf_is_protodown(ctx);
 	struct nlsock *nl =
 		kernel_netlink_nlsock_lookup(dplane_ctx_get_ns_sock(ctx));
@@ -2137,20 +2181,19 @@ ssize_t netlink_intf_msg_encode(uint16_t cmd,
 	nl_attr_put8(&req->n, buflen, IFLA_PROTO_DOWN, down);
 	nl_attr_put32(&req->n, buflen, IFLA_LINK, ifindex);
 
-	if (r_bitfield) {
-		nest_protodown_reason =
-			nl_attr_nest(&req->n, buflen, IFLA_PROTO_DOWN_REASON);
+	/* Reason info nest */
+	nest_protodown_reason =
+		nl_attr_nest(&req->n, buflen, IFLA_PROTO_DOWN_REASON);
 
-		if (!nest_protodown_reason)
-			return -1;
+	if (!nest_protodown_reason)
+		return -1;
 
-		nl_attr_put32(&req->n, buflen, IFLA_PROTO_DOWN_REASON_MASK,
-			      (1 << frr_protodown_r_bit));
-		nl_attr_put32(&req->n, buflen, IFLA_PROTO_DOWN_REASON_VALUE,
-			      ((int)down) << frr_protodown_r_bit);
+	nl_attr_put32(&req->n, buflen, IFLA_PROTO_DOWN_REASON_MASK,
+		      (1 << frr_protodown_r_bit));
+	nl_attr_put32(&req->n, buflen, IFLA_PROTO_DOWN_REASON_VALUE,
+		      ((int)down) << frr_protodown_r_bit);
 
-		nl_attr_nest_end(&req->n, nest_protodown_reason);
-	}
+	nl_attr_nest_end(&req->n, nest_protodown_reason);
 
 	if (IS_ZEBRA_DEBUG_KERNEL)
 		zlog_debug("%s: %s, protodown=%d ifindex=%u", __func__,

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -857,7 +857,7 @@ static void netlink_proc_dplane_if_protodown(struct zebra_if *zif,
 	else
 		zif->protodown_rc &= ~ZEBRA_PROTODOWN_EXTERNAL;
 
-	old_protodown = !!(zif->flags & ZIF_FLAG_PROTODOWN);
+	old_protodown = !!ZEBRA_IF_IS_PROTODOWN(zif);
 	if (protodown == old_protodown)
 		return;
 
@@ -906,7 +906,7 @@ static void if_sweep_protodown(struct zebra_if *zif)
 {
 	bool protodown;
 
-	protodown = !!(zif->flags & ZIF_FLAG_PROTODOWN);
+	protodown = !!ZEBRA_IF_IS_PROTODOWN(zif);
 
 	if (!protodown)
 		return;

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -77,6 +77,7 @@
 #include "zebra/netconf_netlink.h"
 
 extern struct zebra_privs_t zserv_privs;
+uint8_t frr_protodown_r_bit = FRR_PROTODOWN_REASON_DEFAULT_BIT;
 
 /* Note: on netlink systems, there should be a 1-to-1 mapping between interface
    names and ifindex values. */
@@ -822,6 +823,12 @@ static void netlink_proc_dplane_if_protodown(struct zebra_if *zif,
 {
 	bool zif_protodown;
 
+	/* Set our reason code to note it wasn't us */
+	if (protodown)
+		zif->protodown_rc |= ZEBRA_PROTODOWN_EXTERNAL;
+	else
+		zif->protodown_rc &= ~ZEBRA_PROTODOWN_EXTERNAL;
+
 	zif_protodown = !!(zif->flags & ZIF_FLAG_PROTODOWN);
 	if (protodown == zif_protodown)
 		return;
@@ -835,7 +842,7 @@ static void netlink_proc_dplane_if_protodown(struct zebra_if *zif,
 			zlog_debug(
 				"bond mbr %s re-instate protdown %s in the dplane",
 				zif->ifp->name, zif_protodown ? "on" : "off");
-		netlink_protodown(zif->ifp, zif_protodown);
+		netlink_protodown(zif->ifp, zif_protodown, zif->protodown_rc);
 	} else {
 		if (protodown)
 			zif->flags |= ZIF_FLAG_PROTODOWN;
@@ -1242,6 +1249,41 @@ netlink_put_address_update_msg(struct nl_batch *bth,
 {
 	return netlink_batch_add_msg(bth, ctx, netlink_address_msg_encoder,
 				     false);
+}
+
+static ssize_t netlink_intf_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
+					size_t buflen)
+{
+	enum dplane_op_e op;
+	int cmd = 0;
+
+	op = dplane_ctx_get_op(ctx);
+
+	switch (op) {
+	case DPLANE_OP_INTF_UPDATE:
+		cmd = RTM_SETLINK;
+		break;
+	case DPLANE_OP_INTF_INSTALL:
+		cmd = RTM_NEWLINK;
+		break;
+	case DPLANE_OP_INTF_DELETE:
+		cmd = RTM_DELLINK;
+		break;
+	default:
+		flog_err(
+			EC_ZEBRA_NHG_FIB_UPDATE,
+			"Context received for kernel interface update with incorrect OP code (%u)",
+			op);
+		return -1;
+	}
+
+	return netlink_intf_msg_encode(cmd, ctx, buf, buflen);
+}
+
+enum netlink_msg_status
+netlink_put_intf_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx)
+{
+	return netlink_batch_add_msg(bth, ctx, netlink_intf_msg_encoder, false);
 }
 
 int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
@@ -2049,9 +2091,78 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	return 0;
 }
 
-int netlink_protodown(struct interface *ifp, bool down)
+/**
+ * Interface encoding helper function.
+ *
+ * \param[in] cmd netlink command.
+ * \param[in] ctx dataplane context (information snapshot).
+ * \param[out] buf buffer to hold the packet.
+ * \param[in] buflen amount of buffer bytes.
+ */
+
+ssize_t netlink_intf_msg_encode(uint16_t cmd,
+				const struct zebra_dplane_ctx *ctx, void *buf,
+				size_t buflen)
+{
+	struct {
+		struct nlmsghdr n;
+		struct ifinfomsg ifa;
+		char buf[];
+	} *req = buf;
+
+	struct rtattr *nest_protodown_reason;
+	ifindex_t ifindex = dplane_ctx_get_ifindex(ctx);
+	uint32_t r_bitfield = dplane_ctx_get_intf_r_bitfield(ctx);
+	bool down = dplane_ctx_intf_is_protodown(ctx);
+	struct nlsock *nl =
+		kernel_netlink_nlsock_lookup(dplane_ctx_get_ns_sock(ctx));
+
+	if (buflen < sizeof(*req))
+		return 0;
+
+	memset(req, 0, sizeof(*req));
+
+	if (cmd != RTM_SETLINK)
+		flog_err(
+			EC_ZEBRA_INTF_UPDATE_FAILURE,
+			"Only RTM_SETLINK message type currently supported in dplane pthread");
+
+	req->n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg));
+	req->n.nlmsg_flags = NLM_F_REQUEST;
+	req->n.nlmsg_type = cmd;
+	req->n.nlmsg_pid = nl->snl.nl_pid;
+
+	req->ifa.ifi_index = ifindex;
+
+	nl_attr_put8(&req->n, buflen, IFLA_PROTO_DOWN, down);
+	nl_attr_put32(&req->n, buflen, IFLA_LINK, ifindex);
+
+	if (r_bitfield) {
+		nest_protodown_reason =
+			nl_attr_nest(&req->n, buflen, IFLA_PROTO_DOWN_REASON);
+
+		if (!nest_protodown_reason)
+			return -1;
+
+		nl_attr_put32(&req->n, buflen, IFLA_PROTO_DOWN_REASON_MASK,
+			      (1 << frr_protodown_r_bit));
+		nl_attr_put32(&req->n, buflen, IFLA_PROTO_DOWN_REASON_VALUE,
+			      ((int)down) << frr_protodown_r_bit);
+
+		nl_attr_nest_end(&req->n, nest_protodown_reason);
+	}
+
+	if (IS_ZEBRA_DEBUG_KERNEL)
+		zlog_debug("%s: %s, protodown=%d ifindex=%u", __func__,
+			   nl_msg_type_to_str(cmd), down, ifindex);
+
+	return NLMSG_ALIGN(req->n.nlmsg_len);
+}
+
+int netlink_protodown(struct interface *ifp, bool down, uint32_t r_bitfield)
 {
 	struct zebra_ns *zns = zebra_ns_lookup(NS_DEFAULT);
+	struct rtattr *nest_protodown_reason;
 
 	struct {
 		struct nlmsghdr n;
@@ -2068,8 +2179,23 @@ int netlink_protodown(struct interface *ifp, bool down)
 
 	req.ifa.ifi_index = ifp->ifindex;
 
-	nl_attr_put(&req.n, sizeof(req), IFLA_PROTO_DOWN, &down, sizeof(down));
+	nl_attr_put8(&req.n, sizeof(req), IFLA_PROTO_DOWN, down);
 	nl_attr_put32(&req.n, sizeof(req), IFLA_LINK, ifp->ifindex);
+
+	if (r_bitfield) {
+		nest_protodown_reason = nl_attr_nest(&req.n, sizeof(req),
+						     IFLA_PROTO_DOWN_REASON);
+
+		if (!nest_protodown_reason)
+			return -1;
+
+		nl_attr_put32(&req.n, sizeof(req), IFLA_PROTO_DOWN_REASON_MASK,
+			      (1 << frr_protodown_r_bit));
+		nl_attr_put32(&req.n, sizeof(req), IFLA_PROTO_DOWN_REASON_VALUE,
+			      ((int)down) << frr_protodown_r_bit);
+
+		nl_attr_nest_end(&req.n, nest_protodown_reason);
+	}
 
 	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns,
 			    false);

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -815,7 +815,7 @@ static int netlink_bridge_interface(struct nlmsghdr *h, int len, ns_id_t ns_id,
 	return 0;
 }
 
-static bool is_if_protodown_r_only_frr(uint32_t rc_bitfield)
+static bool is_if_protodown_reason_only_frr(uint32_t rc_bitfield)
 {
 	/* This shouldn't be possible */
 	assert(frr_protodown_r_bit < 32);
@@ -853,7 +853,7 @@ static void netlink_proc_dplane_if_protodown(struct zebra_if *zif,
 	 * set it.
 	 */
 	if (protodown && rc_bitfield &&
-	    is_if_protodown_r_only_frr(rc_bitfield) == false)
+	    is_if_protodown_reason_only_frr(rc_bitfield) == false)
 		zif->protodown_rc |= ZEBRA_PROTODOWN_EXTERNAL;
 	else
 		zif->protodown_rc &= ~ZEBRA_PROTODOWN_EXTERNAL;

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -870,16 +870,27 @@ static void netlink_proc_dplane_if_protodown(struct zebra_if *zif,
 
 	if (zebra_evpn_is_es_bond_member(zif->ifp)) {
 		/* Check it's not already being sent to the dplane first */
-		if (protodown && CHECK_FLAG(zif->flags, ZIF_FLAG_SET_PROTODOWN))
+		if (protodown &&
+		    CHECK_FLAG(zif->flags, ZIF_FLAG_SET_PROTODOWN)) {
+			if (IS_ZEBRA_DEBUG_EVPN_MH_ES || IS_ZEBRA_DEBUG_KERNEL)
+				zlog_debug(
+					"bond mbr %s protodown on recv'd but already sent protodown on to the dplane",
+					zif->ifp->name);
 			return;
+		}
 
-		if (!protodown
-		    && CHECK_FLAG(zif->flags, ZIF_FLAG_UNSET_PROTODOWN))
+		if (!protodown &&
+		    CHECK_FLAG(zif->flags, ZIF_FLAG_UNSET_PROTODOWN)) {
+			if (IS_ZEBRA_DEBUG_EVPN_MH_ES || IS_ZEBRA_DEBUG_KERNEL)
+				zlog_debug(
+					"bond mbr %s protodown off recv'd but already sent protodown off to the dplane",
+					zif->ifp->name);
 			return;
+		}
 
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES || IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
-				"bond mbr %s re-instate protdown %s in the dplane",
+				"bond mbr %s reinstate protodown %s in the dplane",
 				zif->ifp->name, old_protodown ? "on" : "off");
 
 		if (old_protodown)
@@ -2227,8 +2238,9 @@ void interface_list(struct zebra_ns *zns)
 void if_netlink_set_frr_protodown_r_bit(uint8_t bit)
 {
 	if (IS_ZEBRA_DEBUG_KERNEL)
-		zlog_debug("FRR protodown reason bit change %u -> %u",
-			   frr_protodown_r_bit, bit);
+		zlog_debug(
+			"Protodown reason bit index changed: bit-index %u -> bit-index %u",
+			frr_protodown_r_bit, bit);
 
 	frr_protodown_r_bit = bit;
 }
@@ -2236,9 +2248,9 @@ void if_netlink_set_frr_protodown_r_bit(uint8_t bit)
 void if_netlink_unset_frr_protodown_r_bit(void)
 {
 	if (IS_ZEBRA_DEBUG_KERNEL)
-		zlog_debug("FRR protodown reason bit change %u -> %u",
-			   frr_protodown_r_bit,
-			   FRR_PROTODOWN_REASON_DEFAULT_BIT);
+		zlog_debug(
+			"Protodown reason bit index changed: bit-index %u -> bit-index %u",
+			frr_protodown_r_bit, FRR_PROTODOWN_REASON_DEFAULT_BIT);
 
 	frr_protodown_r_bit = FRR_PROTODOWN_REASON_DEFAULT_BIT;
 }

--- a/zebra/if_netlink.h
+++ b/zebra/if_netlink.h
@@ -40,6 +40,9 @@ int netlink_interface_addr_dplane(struct nlmsghdr *h, ns_id_t ns_id,
 extern int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup);
 extern int interface_lookup_netlink(struct zebra_ns *zns);
 
+extern ssize_t netlink_intf_msg_encode(uint16_t cmd,
+				       const struct zebra_dplane_ctx *ctx,
+				       void *buf, size_t buflen);
 extern enum netlink_msg_status
 netlink_put_gre_set_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx);
 
@@ -47,6 +50,11 @@ extern enum netlink_msg_status
 netlink_put_address_update_msg(struct nl_batch *bth,
 			       struct zebra_dplane_ctx *ctx);
 
+extern enum netlink_msg_status
+netlink_put_intf_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx);
+
+#define FRR_PROTODOWN_REASON_DEFAULT_BIT 7
+#define PROTODOWN_REASON_NUM_BITS 32
 /*
  * Set protodown status of interface.
  *
@@ -56,10 +64,13 @@ netlink_put_address_update_msg(struct nl_batch *bth,
  * down
  *    If true, set protodown on. If false, set protodown off.
  *
+ * reason
+ *    bitfield representing reason codes
+ *
  * Returns:
  *    0
  */
-int netlink_protodown(struct interface *ifp, bool down);
+int netlink_protodown(struct interface *ifp, bool down, uint32_t r_bitfield);
 
 #ifdef __cplusplus
 }

--- a/zebra/if_netlink.h
+++ b/zebra/if_netlink.h
@@ -54,24 +54,6 @@ extern enum netlink_msg_status
 netlink_put_intf_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx);
 
 #define FRR_PROTODOWN_REASON_DEFAULT_BIT 7
-#define PROTODOWN_REASON_NUM_BITS 32
-/*
- * Set protodown status of interface.
- *
- * ifp
- *    Interface to set protodown on.
- *
- * down
- *    If true, set protodown on. If false, set protodown off.
- *
- * reason
- *    bitfield representing reason codes
- *
- * Returns:
- *    0
- */
-int netlink_protodown(struct interface *ifp, bool down, uint32_t r_bitfield);
-
 /* Protodown bit setter/getter
  *
  * Allow users to change the bit if it conflicts with another

--- a/zebra/if_netlink.h
+++ b/zebra/if_netlink.h
@@ -72,6 +72,16 @@ netlink_put_intf_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx);
  */
 int netlink_protodown(struct interface *ifp, bool down, uint32_t r_bitfield);
 
+/* Protodown bit setter/getter
+ *
+ * Allow users to change the bit if it conflicts with another
+ * on their system.
+ */
+extern void if_netlink_set_frr_protodown_r_bit(uint8_t bit);
+extern void if_netlink_unset_frr_protodown_r_bit(void);
+extern bool if_netlink_frr_protodown_r_bit_is_set(void);
+extern uint8_t if_netlink_get_frr_protodown_r_bit(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/if_socket.c
+++ b/zebra/if_socket.c
@@ -1,0 +1,41 @@
+/*
+ * Zebra Interface interaction with the kernel using socket.
+ * Copyright (C) 2022  NVIDIA CORPORATION & AFFILIATES
+ *                     Stephen Worley
+ *
+ * This file is part of FRR.
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with FRR; see the file COPYING.  If not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+
+#include <zebra.h>
+
+#ifndef HAVE_NETLINK
+
+#include "lib_errors.h"
+
+#include "zebra/rt.h"
+#include "zebra/zebra_dplane.h"
+#include "zebra/zebra_errors.h"
+
+enum zebra_dplane_result kernel_intf_update(struct zebra_dplane_ctx *ctx)
+{
+	flog_err(EC_LIB_UNAVAILABLE, "%s not Implemented for this platform",
+		 __func__);
+	return ZEBRA_DPLANE_REQUEST_FAILURE;
+}
+
+#endif

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1244,7 +1244,7 @@ static bool if_ignore_set_protodown(const struct interface *ifp, bool new_down,
 	zif = ifp->info;
 
 	/* Current state as we know it */
-	old_down = !!(zif->flags & ZIF_FLAG_PROTODOWN);
+	old_down = !!(ZEBRA_IF_IS_PROTODOWN(zif));
 	old_set_down = !!(zif->flags & ZIF_FLAG_SET_PROTODOWN);
 	old_unset_down = !!(zif->flags & ZIF_FLAG_UNSET_PROTODOWN);
 
@@ -2091,7 +2091,7 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 
 	zebra_evpn_if_es_print(vty, NULL, zebra_if);
 	vty_out(vty, "  protodown: %s %s\n",
-		(zebra_if->flags & ZIF_FLAG_PROTODOWN) ? "on" : "off",
+		(ZEBRA_IF_IS_PROTODOWN(zebra_if)) ? "on" : "off",
 		if_is_protodown_applicable(ifp) ? "" : "(n/a)");
 	if (zebra_if->protodown_rc)
 		vty_out(vty, "  protodown reasons: %s\n",
@@ -2442,7 +2442,7 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 	if (if_is_protodown_applicable(ifp)) {
 		json_object_string_add(
 			json_if, "protodown",
-			(zebra_if->flags & ZIF_FLAG_PROTODOWN) ? "on" : "off");
+			(ZEBRA_IF_IS_PROTODOWN(zebra_if)) ? "on" : "off");
 		if (zebra_if->protodown_rc)
 			json_object_string_add(
 				json_if, "protodownReason",

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -63,8 +63,6 @@ DEFINE_HOOK(zebra_if_config_wr, (struct vty * vty, struct interface *ifp),
 
 
 static void if_down_del_nbr_connected(struct interface *ifp);
-static int zebra_if_update_protodown(struct interface *ifp, bool new_down,
-				     uint32_t new_protodown_rc);
 
 static void if_zebra_speed_update(struct thread *thread)
 {
@@ -266,9 +264,9 @@ static int if_zebra_delete_hook(struct interface *ifp)
 		/* If we set protodown, clear our reason now from the kernel */
 		if (ZEBRA_IF_IS_PROTODOWN(zebra_if) && zebra_if->protodown_rc &&
 		    !ZEBRA_IF_IS_PROTODOWN_ONLY_EXTERNAL(zebra_if))
-			zebra_if_update_protodown(ifp, true,
-						  (zebra_if->protodown_rc &
-						   ~ZEBRA_PROTODOWN_ALL));
+			zebra_if_update_protodown_rc(ifp, true,
+						     (zebra_if->protodown_rc &
+						      ~ZEBRA_PROTODOWN_ALL));
 
 		/* Free installed address chains tree. */
 		if (zebra_if->ipv4_subnets)
@@ -1294,8 +1292,8 @@ static bool if_ignore_set_protodown(const struct interface *ifp, bool new_down,
 	return false;
 }
 
-static int zebra_if_update_protodown(struct interface *ifp, bool new_down,
-				     uint32_t new_protodown_rc)
+int zebra_if_update_protodown_rc(struct interface *ifp, bool new_down,
+				 uint32_t new_protodown_rc)
 {
 	struct zebra_if *zif;
 
@@ -1338,7 +1336,7 @@ int zebra_if_set_protodown(struct interface *ifp, bool new_down,
 	else
 		new_protodown_rc = zif->protodown_rc & ~new_reason;
 
-	return zebra_if_update_protodown(ifp, new_down, new_protodown_rc);
+	return zebra_if_update_protodown_rc(ifp, new_down, new_protodown_rc);
 }
 
 /*

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1446,17 +1446,19 @@ static void zebra_if_update_ctx(struct zebra_dplane_ctx *ctx,
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug("%s: if %s(%u) dplane update failed",
 				   __func__, ifp->name, ifp->ifindex);
-		return;
+		goto done;
 	}
 
 	/* Update our info */
-	if (down) {
+	if (down)
 		zif->flags |= ZIF_FLAG_PROTODOWN;
-		zif->flags &= ~ZIF_FLAG_SET_PROTODOWN;
-	} else {
+	else
 		zif->flags &= ~ZIF_FLAG_PROTODOWN;
-		zif->flags &= ~ZIF_FLAG_UNSET_PROTODOWN;
-	}
+
+done:
+	/* Clear our dplane flags */
+	zif->flags &= ~ZIF_FLAG_SET_PROTODOWN;
+	zif->flags &= ~ZIF_FLAG_UNSET_PROTODOWN;
 }
 
 /*

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1254,9 +1254,9 @@ static bool if_ignore_set_protodown(const struct interface *ifp, bool new_down,
 		if (new_down == old_down) {
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug(
-					"Ignoring %s (%u): protodown %s already set reason: old 0x%x new 0x%x",
-					ifp->name, ifp->ifindex,
-					new_down ? "on" : "off",
+					"Ignoring request to set protodown %s for interface %s (%u): protodown %s is already set (reason bitfield: old 0x%x new 0x%x)",
+					new_down ? "on" : "off", ifp->name,
+					ifp->ifindex, new_down ? "on" : "off",
 					zif->protodown_rc, new_protodown_rc);
 
 			return true;
@@ -1267,9 +1267,9 @@ static bool if_ignore_set_protodown(const struct interface *ifp, bool new_down,
 		if (new_down && old_set_down) {
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug(
-					"Ignoring %s (%u): protodown %s queued to dplane already reason: old 0x%x new 0x%x",
-					ifp->name, ifp->ifindex,
-					new_down ? "on" : "off",
+					"Ignoring request to set protodown %s for interface %s (%u): protodown %s is already queued to dplane (reason bitfield: old 0x%x new 0x%x)",
+					new_down ? "on" : "off", ifp->name,
+					ifp->ifindex, new_down ? "on" : "off",
 					zif->protodown_rc, new_protodown_rc);
 
 			return true;
@@ -1280,9 +1280,9 @@ static bool if_ignore_set_protodown(const struct interface *ifp, bool new_down,
 		if (!new_down && old_unset_down) {
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug(
-					"Ignoring %s (%u): protodown %s queued to dplane already reason: old 0x%x new 0x%x",
-					ifp->name, ifp->ifindex,
-					new_down ? "on" : "off",
+					"Ignoring request to set protodown %s for interface %s (%u): protodown %s is already queued to dplane (reason bitfield: old 0x%x new 0x%x)",
+					new_down ? "on" : "off", ifp->name,
+					ifp->ifindex, new_down ? "on" : "off",
 					zif->protodown_rc, new_protodown_rc);
 
 			return true;
@@ -1304,8 +1304,8 @@ int zebra_if_update_protodown_rc(struct interface *ifp, bool new_down,
 		return 1;
 
 	zlog_info(
-		"Setting interface %s (%u): protodown %s reason: old 0x%x new 0x%x",
-		ifp->name, ifp->ifindex, new_down ? "on" : "off",
+		"Setting protodown %s - interface %s (%u): reason bitfield change from 0x%x --> 0x%x",
+		new_down ? "on" : "off", ifp->name, ifp->ifindex,
 		zif->protodown_rc, new_protodown_rc);
 
 	zif->protodown_rc = new_protodown_rc;

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1852,49 +1852,31 @@ static void ifs_dump_brief_vty_json(json_object *json, struct vrf *vrf)
 const char *zebra_protodown_rc_str(uint32_t protodown_rc, char *pd_buf,
 				   uint32_t pd_buf_len)
 {
-	bool first = true;
-
 	pd_buf[0] = '\0';
+	size_t len;
 
 	strlcat(pd_buf, "(", pd_buf_len);
 
-	if (protodown_rc & ZEBRA_PROTODOWN_EXTERNAL) {
-		if (first)
-			first = false;
-		else
-			strlcat(pd_buf, ",", pd_buf_len);
-		strlcat(pd_buf, "external", pd_buf_len);
-	}
+	if (protodown_rc & ZEBRA_PROTODOWN_EXTERNAL)
+		strlcat(pd_buf, "external,", pd_buf_len);
 
-	if (protodown_rc & ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY) {
-		if (first)
-			first = false;
-		else
-			strlcat(pd_buf, ",", pd_buf_len);
-		strlcat(pd_buf, "startup-delay", pd_buf_len);
-	}
+	if (protodown_rc & ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY)
+		strlcat(pd_buf, "startup-delay,", pd_buf_len);
 
-	if (protodown_rc & ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN) {
-		if (first)
-			first = false;
-		else
-			strlcat(pd_buf, ",", pd_buf_len);
-		strlcat(pd_buf, "uplinks-down", pd_buf_len);
-	}
+	if (protodown_rc & ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN)
+		strlcat(pd_buf, "uplinks-down,", pd_buf_len);
 
-	if (protodown_rc & ZEBRA_PROTODOWN_VRRP) {
-		if (first)
-			first = false;
-		else
-			strlcat(pd_buf, ",", pd_buf_len);
-		strlcat(pd_buf, "vrrp", pd_buf_len);
-	}
+	if (protodown_rc & ZEBRA_PROTODOWN_VRRP)
+		strlcat(pd_buf, "vrrp,", pd_buf_len);
 
-	if (protodown_rc & ZEBRA_PROTODOWN_SHARP) {
-		if (!first)
-			strlcat(pd_buf, ",", pd_buf_len);
-		strlcat(pd_buf, "sharp", pd_buf_len);
-	}
+	if (protodown_rc & ZEBRA_PROTODOWN_SHARP)
+		strlcat(pd_buf, "sharp,", pd_buf_len);
+
+	len = strnlen(pd_buf, pd_buf_len);
+
+	/* Remove trailing comma */
+	if (pd_buf[len - 1] == ',')
+		pd_buf[len - 1] = '\0';
 
 	strlcat(pd_buf, ")", pd_buf_len);
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1246,8 +1246,8 @@ static bool if_ignore_set_protodown(const struct interface *ifp, bool new_down,
 
 	/* Current state as we know it */
 	old_down = !!(ZEBRA_IF_IS_PROTODOWN(zif));
-	old_set_down = !!(zif->flags & ZIF_FLAG_SET_PROTODOWN);
-	old_unset_down = !!(zif->flags & ZIF_FLAG_UNSET_PROTODOWN);
+	old_set_down = !!CHECK_FLAG(zif->flags, ZIF_FLAG_SET_PROTODOWN);
+	old_unset_down = !!CHECK_FLAG(zif->flags, ZIF_FLAG_UNSET_PROTODOWN);
 
 	if (new_protodown_rc == zif->protodown_rc) {
 		/* Early return if already down & reason bitfield matches */
@@ -1311,9 +1311,9 @@ int zebra_if_update_protodown_rc(struct interface *ifp, bool new_down,
 	zif->protodown_rc = new_protodown_rc;
 
 	if (new_down)
-		zif->flags |= ZIF_FLAG_SET_PROTODOWN;
+		SET_FLAG(zif->flags, ZIF_FLAG_SET_PROTODOWN);
 	else
-		zif->flags |= ZIF_FLAG_UNSET_PROTODOWN;
+		SET_FLAG(zif->flags, ZIF_FLAG_UNSET_PROTODOWN);
 
 #ifdef HAVE_NETLINK
 	dplane_intf_update(ifp);
@@ -1450,15 +1450,12 @@ static void zebra_if_update_ctx(struct zebra_dplane_ctx *ctx,
 	}
 
 	/* Update our info */
-	if (down)
-		zif->flags |= ZIF_FLAG_PROTODOWN;
-	else
-		zif->flags &= ~ZIF_FLAG_PROTODOWN;
+	COND_FLAG(zif->flags, ZIF_FLAG_PROTODOWN, down);
 
 done:
 	/* Clear our dplane flags */
-	zif->flags &= ~ZIF_FLAG_SET_PROTODOWN;
-	zif->flags &= ~ZIF_FLAG_UNSET_PROTODOWN;
+	UNSET_FLAG(zif->flags, ZIF_FLAG_SET_PROTODOWN);
+	UNSET_FLAG(zif->flags, ZIF_FLAG_UNSET_PROTODOWN);
 }
 
 /*
@@ -1859,19 +1856,19 @@ const char *zebra_protodown_rc_str(uint32_t protodown_rc, char *pd_buf,
 
 	strlcat(pd_buf, "(", pd_buf_len);
 
-	if (protodown_rc & ZEBRA_PROTODOWN_EXTERNAL)
+	if (CHECK_FLAG(protodown_rc, ZEBRA_PROTODOWN_EXTERNAL))
 		strlcat(pd_buf, "external,", pd_buf_len);
 
-	if (protodown_rc & ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY)
+	if (CHECK_FLAG(protodown_rc, ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY))
 		strlcat(pd_buf, "startup-delay,", pd_buf_len);
 
-	if (protodown_rc & ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN)
+	if (CHECK_FLAG(protodown_rc, ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN))
 		strlcat(pd_buf, "uplinks-down,", pd_buf_len);
 
-	if (protodown_rc & ZEBRA_PROTODOWN_VRRP)
+	if (CHECK_FLAG(protodown_rc, ZEBRA_PROTODOWN_VRRP))
 		strlcat(pd_buf, "vrrp,", pd_buf_len);
 
-	if (protodown_rc & ZEBRA_PROTODOWN_SHARP)
+	if (CHECK_FLAG(protodown_rc, ZEBRA_PROTODOWN_SHARP))
 		strlcat(pd_buf, "sharp,", pd_buf_len);
 
 	len = strnlen(pd_buf, pd_buf_len);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1321,8 +1321,6 @@ int zebra_if_set_protodown(struct interface *ifp, bool new_down,
 		zif->flags |= ZIF_FLAG_UNSET_PROTODOWN;
 
 #ifdef HAVE_NETLINK
-	// TODO: remove this as separate commit
-	// netlink_protodown(ifp, new_down, zif->protodown_rc);
 	dplane_intf_update(ifp);
 #else
 	zlog_warn("Protodown is not supported on this platform");

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -261,6 +261,12 @@ static int if_zebra_delete_hook(struct interface *ifp)
 	if (ifp->info) {
 		zebra_if = ifp->info;
 
+		/* If we set protodown, clear it now from the kernel */
+		if (ZEBRA_IF_IS_PROTODOWN(zebra_if) &&
+		    !ZEBRA_IF_IS_PROTODOWN_ONLY_EXTERNAL(zebra_if))
+			zebra_if_set_protodown(ifp, false, ZEBRA_PROTODOWN_ALL);
+
+
 		/* Free installed address chains tree. */
 		if (zebra_if->ipv4_subnets)
 			route_table_finish(zebra_if->ipv4_subnets);

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -403,7 +403,7 @@ struct zebra_if {
 	 * in the dataplane. This results in a carrier/L1 down on the
 	 * physical device.
 	 */
-	enum protodown_reasons protodown_rc;
+	uint32_t protodown_rc;
 
 	/* list of zebra_mac entries using this interface as destination */
 	struct list *mac_list;
@@ -497,7 +497,8 @@ extern void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id);
 extern void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex,
 				 ns_id_t ns_id);
 extern void zebra_if_update_all_links(struct zebra_ns *zns);
-extern void zebra_if_set_protodown(struct interface *ifp, bool down);
+extern int zebra_if_set_protodown(struct interface *ifp, bool down,
+				  enum protodown_reasons new_reason);
 extern int if_ip_address_install(struct interface *ifp, struct prefix *prefix,
 				 const char *label, struct prefix *pp);
 extern int if_ipv6_address_install(struct interface *ifp, struct prefix *prefix,
@@ -521,10 +522,9 @@ extern bool if_nhg_dependents_is_empty(const struct interface *ifp);
 extern void vrf_add_update(struct vrf *vrfp);
 extern void zebra_l2_map_slave_to_bond(struct zebra_if *zif, vrf_id_t vrf);
 extern void zebra_l2_unmap_slave_from_bond(struct zebra_if *zif);
-extern const char *zebra_protodown_rc_str(enum protodown_reasons protodown_rc,
-					  char *pd_buf, uint32_t pd_buf_len);
-void zebra_if_addr_update_ctx(struct zebra_dplane_ctx *ctx);
-int zebra_if_netconf_update_ctx(struct zebra_dplane_ctx *ctx);
+extern const char *zebra_protodown_rc_str(uint32_t protodown_rc, char *pd_buf,
+					  uint32_t pd_buf_len);
+void zebra_if_dplane_result(struct zebra_dplane_ctx *ctx);
 
 #ifdef HAVE_PROC_NET_DEV
 extern void ifstat_update_proc(void);

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -505,6 +505,14 @@ extern void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id);
 extern void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex,
 				 ns_id_t ns_id);
 extern void zebra_if_update_all_links(struct zebra_ns *zns);
+/**
+ * Directly update entire protodown & reason code bitfield.
+ */
+extern int zebra_if_update_protodown_rc(struct interface *ifp, bool new_down,
+					uint32_t new_protodown_rc);
+/**
+ * Set protodown with single reason.
+ */
 extern int zebra_if_set_protodown(struct interface *ifp, bool down,
 				  enum protodown_reasons new_reason);
 extern int if_ip_address_install(struct interface *ifp, struct prefix *prefix,

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -320,9 +320,9 @@ enum zebra_if_flags {
 	ZIF_FLAG_LACP_BYPASS = (1 << 5)
 };
 
-#define ZEBRA_IF_IS_PROTODOWN(zif) (zif->flags & ZIF_FLAG_PROTODOWN)
+#define ZEBRA_IF_IS_PROTODOWN(zif) ((zif)->flags & ZIF_FLAG_PROTODOWN)
 #define ZEBRA_IF_IS_PROTODOWN_ONLY_EXTERNAL(zif)                               \
-	(zif->protodown_rc == ZEBRA_PROTODOWN_EXTERNAL)
+	((zif)->protodown_rc == ZEBRA_PROTODOWN_EXTERNAL)
 
 /* `zebra' daemon local interface structure. */
 struct zebra_if {

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -320,6 +320,10 @@ enum zebra_if_flags {
 	ZIF_FLAG_LACP_BYPASS = (1 << 5)
 };
 
+#define ZEBRA_IF_IS_PROTODOWN(zif) (zif->flags & ZIF_FLAG_PROTODOWN)
+#define ZEBRA_IF_IS_PROTODOWN_ONLY_EXTERNAL(zif)                               \
+	(zif->protodown_rc == ZEBRA_PROTODOWN_EXTERNAL)
+
 /* `zebra' daemon local interface structure. */
 struct zebra_if {
 	/* back pointer to the interface */

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -308,12 +308,16 @@ enum zebra_if_flags {
 
 	/* Dataplane protodown-on */
 	ZIF_FLAG_PROTODOWN = (1 << 2),
+	/* Dataplane protodown-on Queued to the dplane */
+	ZIF_FLAG_SET_PROTODOWN = (1 << 3),
+	/* Dataplane protodown-off Queued to the dplane */
+	ZIF_FLAG_UNSET_PROTODOWN = (1 << 4),
 
 	/* LACP bypass state is set by the dataplane on a bond member
 	 * and inherited by the bond (if one or more bond members are in
 	 * a bypass state the bond is placed in a bypass state)
 	 */
-	ZIF_FLAG_LACP_BYPASS = (1 << 3)
+	ZIF_FLAG_LACP_BYPASS = (1 << 5)
 };
 
 /* `zebra' daemon local interface structure. */

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -94,6 +94,7 @@ static const struct message nlmsg_str[] = {{RTM_NEWROUTE, "RTM_NEWROUTE"},
 					   {RTM_DELROUTE, "RTM_DELROUTE"},
 					   {RTM_GETROUTE, "RTM_GETROUTE"},
 					   {RTM_NEWLINK, "RTM_NEWLINK"},
+					   {RTM_SETLINK, "RTM_SETLINK"},
 					   {RTM_DELLINK, "RTM_DELLINK"},
 					   {RTM_GETLINK, "RTM_GETLINK"},
 					   {RTM_NEWADDR, "RTM_NEWADDR"},
@@ -1491,6 +1492,11 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
 	case DPLANE_OP_INTF_NETCONFIG:
 	case DPLANE_OP_NONE:
 		return FRR_NETLINK_ERROR;
+
+	case DPLANE_OP_INTF_INSTALL:
+	case DPLANE_OP_INTF_UPDATE:
+	case DPLANE_OP_INTF_DELETE:
+		return netlink_put_intf_update_msg(bth, ctx);
 	}
 
 	return FRR_NETLINK_ERROR;

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -210,6 +210,10 @@ int netlink_config_write_helper(struct vty *vty)
 		vty_out(vty, "zebra kernel netlink batch-tx-buf %u %u\n", size,
 			threshold);
 
+	if (if_netlink_frr_protodown_r_bit_is_set())
+		vty_out(vty, "zebra protodown reason-bit %u\n",
+			if_netlink_get_frr_protodown_r_bit());
+
 	return 0;
 }
 

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1577,6 +1577,12 @@ void kernel_update_multi(struct dplane_ctx_q *ctx_list)
 			res = kernel_pbr_rule_update(ctx);
 			break;
 
+		case DPLANE_OP_INTF_INSTALL:
+		case DPLANE_OP_INTF_UPDATE:
+		case DPLANE_OP_INTF_DELETE:
+			res = kernel_intf_update(ctx);
+			break;
+
 		/* Ignore 'notifications' - no-op */
 		case DPLANE_OP_SYS_ROUTE_ADD:
 		case DPLANE_OP_SYS_ROUTE_DELETE:

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -66,6 +66,9 @@ enum zebra_dplane_result kernel_neigh_update_ctx(struct zebra_dplane_ctx *ctx);
 extern enum zebra_dplane_result
 kernel_pbr_rule_update(struct zebra_dplane_ctx *ctx);
 
+extern enum zebra_dplane_result
+kernel_intf_update(struct zebra_dplane_ctx *ctx);
+
 #endif /* !HAVE_NETLINK */
 
 extern int kernel_neigh_update(int cmd, int ifindex, void *addr, char *lla,

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -128,6 +128,8 @@ const char *af_type2str(int type);
 const char *ifi_type2str(int type);
 const char *rta_type2str(int type);
 const char *rtm_type2str(int type);
+const char *ifla_pdr_type2str(int type);
+const char *ifla_info_type2str(int type);
 const char *rtm_protocol2str(int type);
 const char *rtm_scope2str(int type);
 const char *rtm_rta2str(int type);

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -60,6 +60,7 @@ zebra_zebra_SOURCES = \
 	zebra/debug.c \
 	zebra/if_ioctl.c \
 	zebra/if_netlink.c \
+	zebra/if_socket.c \
 	zebra/if_sysctl.c \
 	zebra/interface.c \
 	zebra/ioctl.c \

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2690,8 +2690,8 @@ done:
 int dplane_ctx_intf_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 			 const struct interface *ifp)
 {
-	struct zebra_ns *zns = NULL;
-	struct zebra_if *zif = NULL;
+	struct zebra_ns *zns;
+	struct zebra_if *zif;
 	int ret = EINVAL;
 	bool set_pdown, unset_pdown;
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2732,8 +2732,7 @@ int dplane_ctx_intf_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		else if (unset_pdown)
 			ctx->u.intf.protodown = false;
 		else
-			ctx->u.intf.protodown =
-				!!(zif->flags & ZIF_FLAG_PROTODOWN);
+			ctx->u.intf.protodown = !!ZEBRA_IF_IS_PROTODOWN(zif);
 	}
 
 	dplane_ctx_ns_init(ctx, zns, (op == DPLANE_OP_INTF_UPDATE));

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -192,9 +192,9 @@ struct dplane_intf_info {
 
 	uint32_t metric;
 	uint32_t flags;
-	uint32_t r_bitfield;
 
 	bool protodown;
+	bool pd_reason_val;
 
 #define DPLANE_INTF_CONNECTED   (1 << 0) /* Connected peer, p2p */
 #define DPLANE_INTF_SECONDARY   (1 << 1)
@@ -1790,19 +1790,18 @@ void dplane_ctx_set_intf_metric(struct zebra_dplane_ctx *ctx, uint32_t metric)
 	ctx->u.intf.metric = metric;
 }
 
-uint32_t dplane_ctx_get_intf_r_bitfield(const struct zebra_dplane_ctx *ctx)
+uint32_t dplane_ctx_get_intf_pd_reason_val(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
 
-	return ctx->u.intf.r_bitfield;
+	return ctx->u.intf.pd_reason_val;
 }
 
-void dplane_ctx_set_intf_r_bitfield(struct zebra_dplane_ctx *ctx,
-				    uint32_t r_bitfield)
+void dplane_ctx_set_intf_pd_reason_val(struct zebra_dplane_ctx *ctx, bool val)
 {
 	DPLANE_CTX_VALID(ctx);
 
-	ctx->u.intf.r_bitfield = r_bitfield;
+	ctx->u.intf.pd_reason_val = val;
 }
 
 bool dplane_ctx_intf_is_protodown(const struct zebra_dplane_ctx *ctx)
@@ -2721,7 +2720,9 @@ int dplane_ctx_intf_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		set_pdown = !!(zif->flags & ZIF_FLAG_SET_PROTODOWN);
 		unset_pdown = !!(zif->flags & ZIF_FLAG_UNSET_PROTODOWN);
 
-		ctx->u.intf.r_bitfield = zif->protodown_rc;
+		if (zif->protodown_rc &&
+		    ZEBRA_IF_IS_PROTODOWN_ONLY_EXTERNAL(zif) == false)
+			ctx->u.intf.pd_reason_val = true;
 
 		/*
 		 * See if we have new protodown state to set, otherwise keep

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -188,6 +188,11 @@ enum dplane_op_e {
 
 	/* Incoming interface config events */
 	DPLANE_OP_INTF_NETCONFIG,
+
+	/* Interface update */
+	DPLANE_OP_INTF_INSTALL,
+	DPLANE_OP_INTF_UPDATE,
+	DPLANE_OP_INTF_DELETE,
 };
 
 /*
@@ -480,6 +485,10 @@ dplane_ctx_get_pw_backup_nhg(const struct zebra_dplane_ctx *ctx);
 /* Accessors for interface information */
 uint32_t dplane_ctx_get_intf_metric(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_intf_metric(struct zebra_dplane_ctx *ctx, uint32_t metric);
+uint32_t dplane_ctx_get_intf_r_bitfield(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_intf_r_bitfield(struct zebra_dplane_ctx *ctx,
+				    uint32_t r_bitfield);
+bool dplane_ctx_intf_is_protodown(const struct zebra_dplane_ctx *ctx);
 /* Is interface addr p2p? */
 bool dplane_ctx_intf_is_connected(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_intf_set_connected(struct zebra_dplane_ctx *ctx);
@@ -677,6 +686,13 @@ enum zebra_dplane_result dplane_intf_addr_unset(const struct interface *ifp,
 						const struct connected *ifc);
 
 /*
+ * Enqueue interface link changes for the dataplane.
+ */
+enum zebra_dplane_result dplane_intf_add(const struct interface *ifp);
+enum zebra_dplane_result dplane_intf_update(const struct interface *ifp);
+enum zebra_dplane_result dplane_intf_delete(const struct interface *ifp);
+
+/*
  * Link layer operations for the dataplane.
  */
 enum zebra_dplane_result dplane_neigh_ip_update(enum dplane_op_e op,
@@ -813,6 +829,10 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 /* Encode next hop information into data plane context. */
 int dplane_ctx_nexthop_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 			    struct nhg_hash_entry *nhe);
+
+/* Encode interface information into data plane context. */
+int dplane_ctx_intf_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
+			 const struct interface *ifp);
 
 /* Retrieve the limit on the number of pending, unprocessed updates. */
 uint32_t dplane_get_in_queue_limit(void);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -485,9 +485,8 @@ dplane_ctx_get_pw_backup_nhg(const struct zebra_dplane_ctx *ctx);
 /* Accessors for interface information */
 uint32_t dplane_ctx_get_intf_metric(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_intf_metric(struct zebra_dplane_ctx *ctx, uint32_t metric);
-uint32_t dplane_ctx_get_intf_r_bitfield(const struct zebra_dplane_ctx *ctx);
-void dplane_ctx_set_intf_r_bitfield(struct zebra_dplane_ctx *ctx,
-				    uint32_t r_bitfield);
+uint32_t dplane_ctx_get_intf_pd_reason_val(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_intf_pd_reason_val(struct zebra_dplane_ctx *ctx, bool val);
 bool dplane_ctx_intf_is_protodown(const struct zebra_dplane_ctx *ctx);
 /* Is interface addr p2p? */
 bool dplane_ctx_intf_is_connected(const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_errors.c
+++ b/zebra/zebra_errors.c
@@ -792,6 +792,15 @@ static struct log_ref ferr_zebra_err[] = {
 		.suggestion = "Ignore this error.",
 	},
 	{
+		.code = EC_ZEBRA_INTF_UPDATE_FAILURE,
+		.title =
+			"Zebra failed to update interface in the kernel",
+		.description =
+			"Zebra made an attempt to update an interfce in the kernel, but it was not successful.",
+		.suggestion =
+			"Wait for Zebra to reattempt update.",
+	},
+	{
 		.code = END_FERR,
 	}
 };

--- a/zebra/zebra_errors.h
+++ b/zebra/zebra_errors.h
@@ -136,6 +136,7 @@ enum zebra_log_refs {
 	EC_ZEBRA_ES_CREATE,
 	EC_ZEBRA_GRE_SET_UPDATE,
 	EC_ZEBRA_SRV6M_UNRELEASED_LOCATOR_CHUNK,
+	EC_ZEBRA_INTF_UPDATE_FAILURE,
 };
 
 void zebra_error_init(void);

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3646,8 +3646,8 @@ void zebra_evpn_mh_update_protodown_bond_mbr(struct zebra_if *zif, bool clear,
 			caller, zif->ifp->name, old_protodown_rc,
 			new_protodown_rc);
 
-	if (zebra_if_set_protodown(zif->ifp, new_protodown, new_protodown_rc) ==
-	    0) {
+	if (zebra_if_update_protodown_rc(zif->ifp, new_protodown,
+					 new_protodown_rc) == 0) {
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 			zlog_debug("%s protodown %s", zif->ifp->name,
 				   new_protodown ? "on" : "off");

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3623,10 +3623,10 @@ bool zebra_evpn_is_es_bond_member(struct interface *ifp)
 void zebra_evpn_mh_update_protodown_bond_mbr(struct zebra_if *zif, bool clear,
 					     const char *caller)
 {
-	bool old_protodown;
 	bool new_protodown;
-	enum protodown_reasons old_protodown_rc = 0;
-	enum protodown_reasons protodown_rc = 0;
+	uint32_t old_protodown_rc = 0;
+	uint32_t new_protodown_rc = 0;
+	uint32_t protodown_rc = 0;
 
 	if (!clear) {
 		struct zebra_if *bond_zif;
@@ -3635,32 +3635,23 @@ void zebra_evpn_mh_update_protodown_bond_mbr(struct zebra_if *zif, bool clear,
 		protodown_rc = bond_zif->protodown_rc;
 	}
 
-	old_protodown = !!(zif->flags & ZIF_FLAG_PROTODOWN);
 	old_protodown_rc = zif->protodown_rc;
-	zif->protodown_rc &= ~ZEBRA_PROTODOWN_EVPN_ALL;
-	zif->protodown_rc |= (protodown_rc & ZEBRA_PROTODOWN_EVPN_ALL);
-	new_protodown = !!zif->protodown_rc;
+	new_protodown_rc &= ~ZEBRA_PROTODOWN_EVPN_ALL;
+	new_protodown_rc |= (protodown_rc & ZEBRA_PROTODOWN_EVPN_ALL);
+	new_protodown = !!new_protodown_rc;
 
-	if (IS_ZEBRA_DEBUG_EVPN_MH_ES
-	    && (zif->protodown_rc != old_protodown_rc))
+	if (IS_ZEBRA_DEBUG_EVPN_MH_ES && (new_protodown_rc != old_protodown_rc))
 		zlog_debug(
 			"%s bond mbr %s protodown_rc changed; old 0x%x new 0x%x",
 			caller, zif->ifp->name, old_protodown_rc,
-			zif->protodown_rc);
+			new_protodown_rc);
 
-	if (old_protodown == new_protodown)
-		return;
-
-	if (new_protodown)
-		zif->flags |= ZIF_FLAG_PROTODOWN;
-	else
-		zif->flags &= ~ZIF_FLAG_PROTODOWN;
-
-	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
-		zlog_debug("%s protodown %s", zif->ifp->name,
-			   new_protodown ? "on" : "off");
-
-	zebra_if_set_protodown(zif->ifp, new_protodown);
+	if (zebra_if_set_protodown(zif->ifp, new_protodown, new_protodown_rc) ==
+	    0) {
+		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
+			zlog_debug("%s protodown %s", zif->ifp->name,
+				   new_protodown ? "on" : "off");
+	}
 }
 
 /* The bond members inherit the protodown reason code from the bond */
@@ -3683,7 +3674,7 @@ static void zebra_evpn_mh_update_protodown_es(struct zebra_evpn_es *es,
 					      bool resync_dplane)
 {
 	struct zebra_if *zif;
-	enum protodown_reasons old_protodown_rc;
+	uint32_t old_protodown_rc;
 
 	zif = es->zif;
 	/* if the reason code is the same bail unless it is a new
@@ -3714,7 +3705,7 @@ static void zebra_evpn_mh_update_protodown_es(struct zebra_evpn_es *es,
 static void zebra_evpn_mh_clear_protodown_es(struct zebra_evpn_es *es)
 {
 	struct zebra_if *zif;
-	enum protodown_reasons old_protodown_rc;
+	uint32_t old_protodown_rc;
 
 	zif = es->zif;
 	if (!(zif->protodown_rc & ZEBRA_PROTODOWN_EVPN_ALL))
@@ -3742,10 +3733,9 @@ static void zebra_evpn_mh_update_protodown_es_all(void)
 		zebra_evpn_mh_update_protodown_es(es, false /*resync_dplane*/);
 }
 
-static void zebra_evpn_mh_update_protodown(enum protodown_reasons protodown_rc,
-					   bool set)
+static void zebra_evpn_mh_update_protodown(uint32_t protodown_rc, bool set)
 {
-	enum protodown_reasons old_protodown_rc = zmh_info->protodown_rc;
+	uint32_t old_protodown_rc = zmh_info->protodown_rc;
 
 	if (set) {
 		if ((protodown_rc & zmh_info->protodown_rc) == protodown_rc)

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3463,13 +3463,14 @@ void zebra_evpn_mh_json(json_object *json)
 
 	if (zmh_info->protodown_rc) {
 		json_array = json_object_new_array();
-		if (zmh_info->protodown_rc & ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY)
+		if (CHECK_FLAG(zmh_info->protodown_rc,
+			       ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY))
 			json_object_array_add(
 				json_array,
 				json_object_new_string("startupDelay"));
-		if (zmh_info->protodown_rc & ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN)
-			json_object_array_add(
-				json_array,
+		if (CHECK_FLAG(zmh_info->protodown_rc,
+			       ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN))
+			json_object_array_add(json_array,
 				json_object_new_string("uplinkDown"));
 		json_object_object_add(json, "protodownReasons", json_array);
 	}

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3470,7 +3470,8 @@ void zebra_evpn_mh_json(json_object *json)
 				json_object_new_string("startupDelay"));
 		if (CHECK_FLAG(zmh_info->protodown_rc,
 			       ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN))
-			json_object_array_add(json_array,
+			json_object_array_add(
+				json_array,
 				json_object_new_string("uplinkDown"));
 		json_object_object_add(json, "protodownReasons", json_array);
 	}

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3636,7 +3636,7 @@ void zebra_evpn_mh_update_protodown_bond_mbr(struct zebra_if *zif, bool clear,
 	}
 
 	old_protodown_rc = zif->protodown_rc;
-	new_protodown_rc &= ~ZEBRA_PROTODOWN_EVPN_ALL;
+	new_protodown_rc = (old_protodown_rc & ~ZEBRA_PROTODOWN_EVPN_ALL);
 	new_protodown_rc |= (protodown_rc & ZEBRA_PROTODOWN_EVPN_ALL);
 	new_protodown = !!new_protodown_rc;
 

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -263,7 +263,7 @@ struct zebra_evpn_mh_info {
 	uint32_t uplink_oper_up_cnt;
 
 	/* These protodown bits are inherited by all ES bonds */
-	enum protodown_reasons protodown_rc;
+	uint32_t protodown_rc;
 };
 
 /* returns TRUE if the EVPN is ready to be sent to BGP */

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2993,6 +2993,9 @@ void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_INTF_ADDR_ADD:
 	case DPLANE_OP_INTF_ADDR_DEL:
 	case DPLANE_OP_INTF_NETCONFIG:
+	case DPLANE_OP_INTF_INSTALL:
+	case DPLANE_OP_INTF_UPDATE:
+	case DPLANE_OP_INTF_DELETE:
 		break;
 	}
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4318,11 +4318,11 @@ static void rib_process_dplane_results(struct thread *thread)
 
 			case DPLANE_OP_INTF_ADDR_ADD:
 			case DPLANE_OP_INTF_ADDR_DEL:
-				zebra_if_addr_update_ctx(ctx);
-				break;
-
+			case DPLANE_OP_INTF_INSTALL:
+			case DPLANE_OP_INTF_UPDATE:
+			case DPLANE_OP_INTF_DELETE:
 			case DPLANE_OP_INTF_NETCONFIG:
-				zebra_if_netconf_update_ctx(ctx);
+				zebra_if_dplane_result(ctx);
 				break;
 
 			/* Some op codes not handled here */

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -68,19 +68,24 @@ enum multicast_mode {
  * physical device.
  */
 enum protodown_reasons {
+	/* A process outside of FRR's control protodowned the interface */
+	ZEBRA_PROTODOWN_EXTERNAL = (1 << 0),
 	/* On startup local ESs are held down for some time to
 	 * allow the underlay to converge and EVPN routes to
 	 * get learnt
 	 */
-	ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY = (1 << 0),
+	ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY = (1 << 1),
 	/* If all the uplinks are down the switch has lost access
 	 * to the VxLAN overlay and must shut down the access
 	 * ports to allow servers to re-direct their traffic to
 	 * other switches on the Ethernet Segment
 	 */
-	ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN = (1 << 1),
-	ZEBRA_PROTODOWN_EVPN_ALL = (ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN
-				    | ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY)
+	ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN = (1 << 2),
+	ZEBRA_PROTODOWN_EVPN_ALL = (ZEBRA_PROTODOWN_EVPN_UPLINK_DOWN |
+				    ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY),
+	ZEBRA_PROTODOWN_VRRP = (1 << 3),
+	/* This reason used exclusively for testing */
+	ZEBRA_PROTODOWN_SHARP = (1 << 4)
 };
 #define ZEBRA_PROTODOWN_RC_STR_LEN 80
 

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -85,7 +85,10 @@ enum protodown_reasons {
 				    ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY),
 	ZEBRA_PROTODOWN_VRRP = (1 << 3),
 	/* This reason used exclusively for testing */
-	ZEBRA_PROTODOWN_SHARP = (1 << 4)
+	ZEBRA_PROTODOWN_SHARP = (1 << 4),
+	/* Just used to clear our fields on shutdown, externel not included */
+	ZEBRA_PROTODOWN_ALL = (ZEBRA_PROTODOWN_EVPN_ALL | ZEBRA_PROTODOWN_VRRP |
+			       ZEBRA_PROTODOWN_SHARP)
 };
 #define ZEBRA_PROTODOWN_RC_STR_LEN 80
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -60,6 +60,7 @@
 #include "northbound_cli.h"
 #include "zebra/zebra_nb.h"
 #include "zebra/kernel_netlink.h"
+#include "zebra/if_netlink.h"
 #include "zebra/table_manager.h"
 #include "zebra/zebra_script.h"
 #include "zebra/rtadv.h"
@@ -4356,6 +4357,31 @@ DEFUN_HIDDEN(no_zebra_kernel_netlink_batch_tx_buf,
 	return CMD_SUCCESS;
 }
 
+DEFPY (zebra_protodown_bit,
+       zebra_protodown_bit_cmd,
+       "zebra protodown reason-bit (0-31)$bit",
+       ZEBRA_STR
+       "Protodown Configuration\n"
+       "Reason Bit used in the kernel for application\n"
+       "Reason Bit range\n")
+{
+	if_netlink_set_frr_protodown_r_bit(bit);
+	return CMD_SUCCESS;
+}
+
+DEFPY (no_zebra_protodown_bit,
+       no_zebra_protodown_bit_cmd,
+       "no zebra protodown reason-bit [(0-31)$bit]",
+       NO_STR
+       ZEBRA_STR
+       "Protodown Configuration\n"
+       "Reason Bit used in the kernel for setting protodown\n"
+       "Reason Bit Range\n")
+{
+	if_netlink_unset_frr_protodown_r_bit();
+	return CMD_SUCCESS;
+}
+
 #endif /* HAVE_NETLINK */
 
 DEFUN(ip_table_range, ip_table_range_cmd,
@@ -4561,6 +4587,8 @@ void zebra_vty_init(void)
 #ifdef HAVE_NETLINK
 	install_element(CONFIG_NODE, &zebra_kernel_netlink_batch_tx_buf_cmd);
 	install_element(CONFIG_NODE, &no_zebra_kernel_netlink_batch_tx_buf_cmd);
+	install_element(CONFIG_NODE, &zebra_protodown_bit_cmd);
+	install_element(CONFIG_NODE, &no_zebra_protodown_bit_cmd);
 #endif /* HAVE_NETLINK */
 
 #ifdef HAVE_SCRIPTING


### PR DESCRIPTION
    Add support for setting the protodown reason code.
    
    https://github.com/torvalds/linux/commit/829eb208e80d6db95c0201cb8fa00c2f9ad87faf
    
    These patches handle all our netlink code for setting the reason.
    
    For protodown reason we only set `frr` as the reason externally
    but internally we have more descriptive reasoning available via
    `show interface IFNAME`. The kernel only provides a bitwidth of 32
    that all userspace programs have to share so this makes the most sense.
    
    Since this is new functionality, it needs to be added to the dplane
    pthread instead. So these patches, also move the protodown setting we
    were doing before into the dplane pthread. For this, we abstract it a
    bit more to make it a general interface LINK update dplane API. This
    API can be expanded to support gernal link creation/updating when/if
    someone ever adds that code.
    
    We also move a more common entrypoint for evpn-mh and from zapi clients
    like vrrpd. They both call common code now to set our internal flags
    for protodown and protodown reason.
    
    Also add debugging code for dumping netlink packets with
    protodown/protodown_reason.
    
    Add functionality to clear any reason code set on shutdown
    of zebra when we are freeing the interface, in case a bad
    client didn't tell us to clear it when the shutdown.
    
    Also, in case of a crash or failure to do the above, clear reason
    on startup if it is set.

    Add command to adjust set protodown bit via frr.conf in
    the case our default conflicts with another application
    they are using.



Support is also added to sharpd for testing this feature.

Docs have been added for both sharpd/zebra reason bit.

new commands are:

```
sharp interface IFNAME protodown
```

```
zebra protodown reason-bit (0-31)
```


Example output:

```
alfred# sharp interface mv1 protodown 
alfred# show interface mv1
Interface mv1 is up, line protocol is down
  Link ups:       0    last: (never)
  Link downs:     1    last: 2022/01/26 01:46:51.24
  vrf: default
  index 8 metric 0 mtu 1500 speed 0 
  flags: <UP,BROADCAST,MULTICAST>
  Type: Ethernet
  HWaddr: 9e:1d:18:d5:16:54
  inet6 fe80::9c1d:18ff:fed5:1654/64
  Interface Type macvlan
  Interface Slave Type None
  protodown: on 
  protodown reasons: (sharp)
  Parent interface: dummy1

```

```
root@alfred /h/s/D/c/e/frr-2 (Protodown-Reason-Upstream)# ip -d link show mv1
8: mv1@dummy1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state LOWERLAYERDOWN mode DEFAULT group default qlen 1000
    link/ether 9e:1d:18:d5:16:54 brd ff:ff:ff:ff:ff:ff protodown on protodown_reason <frr> promiscuity 0 minmtu 68 maxmtu 0 
    macvlan mode bridge addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535
```


Note the `protodown_reason` in both of the above.

This value is enumerated by `iproute2` in `/etc/iproute2/protodown_reasons.d/` when dumping link info.