### PR TITLE
pbrd: pbr route maps get addr family of nhgs

### DIFF
--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -792,6 +792,12 @@ void pbr_map_check_nh_group_change(const char *nh_group)
 			if (found_name) {
 				bool original = pbrm->valid;
 
+				/* Set data we were waiting on */
+				if (pbrms->nhgrp_name)
+					pbr_nht_set_seq_nhg_data(
+						pbrms,
+						nhgc_find(pbrms->nhgrp_name));
+
 				pbr_map_check_valid_internal(pbrm);
 
 				if (pbrm->valid && (original != pbrm->valid))

--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -522,6 +522,49 @@ char *pbr_nht_nexthop_make_name(char *name, size_t l,
 	return buffer;
 }
 
+/* Set data derived from nhg in pbrms */
+void pbr_nht_set_seq_nhg_data(struct pbr_map_sequence *pbrms,
+			      const struct nexthop_group_cmd *nhgc)
+{
+	const struct nexthop_group *nhg;
+
+	if (!nhgc)
+		return;
+
+	nhg = &nhgc->nhg;
+	if (!nhg->nexthop)
+		return;
+
+	switch (nhg->nexthop->type) {
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		pbrms->family = AF_INET6;
+		break;
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		pbrms->family = AF_INET;
+	default:
+		break;
+	}
+}
+
+/* Configure a routemap sequence to use a given nexthop group */
+void pbr_nht_set_seq_nhg(struct pbr_map_sequence *pbrms, const char *name)
+{
+	struct nexthop_group_cmd *nhgc;
+
+	if (!name)
+		return;
+
+	pbrms->nhgrp_name = XSTRDUP(MTYPE_TMP, name);
+
+	nhgc = nhgc_find(name);
+	if (!nhgc)
+		return;
+
+	pbr_nht_set_seq_nhg_data(pbrms, nhgc);
+}
+
 void pbr_nht_add_individual_nexthop(struct pbr_map_sequence *pbrms,
 				    const struct nexthop *nhop)
 {

--- a/pbrd/pbr_nht.h
+++ b/pbrd/pbr_nht.h
@@ -109,6 +109,11 @@ extern struct pbr_nexthop_group_cache *pbr_nht_add_group(const char *name);
 extern void pbr_nht_change_group(const char *name);
 extern void pbr_nht_delete_group(const char *name);
 
+extern void pbr_nht_set_seq_nhg_data(struct pbr_map_sequence *pbrms,
+				     const struct nexthop_group_cmd *nhgc);
+extern void pbr_nht_set_seq_nhg(struct pbr_map_sequence *pbrms,
+				const char *name);
+
 extern void pbr_nht_add_individual_nexthop(struct pbr_map_sequence *pbrms,
 					   const struct nexthop *nhop);
 extern void pbr_nht_delete_individual_nexthop(struct pbr_map_sequence *pbrms);

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -506,7 +506,8 @@ DEFPY(pbr_map_nexthop_group, pbr_map_nexthop_group_cmd,
 	/* This is new/replacement config */
 	pbrms_clear_set_config(pbrms);
 
-	pbrms->nhgrp_name = XSTRDUP(MTYPE_TMP, name);
+	pbr_nht_set_seq_nhg(pbrms, name);
+
 	pbr_map_check(pbrms, true);
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
When adding a nhg to a route map, make sure to specify the `family`
of the rm by looking at the contents of the nhg. Installation in the
kernel (for DSCP rules in particular) relies on this being specified in
the netlink message.

Signed-off-by: Wesley Coakley <wcoakley@nvidia.com>
Signed-off-by: Stephen Worley <sworley@nvidia.com>