### PR TITLE
vrrpd: use ipaddr_is_zero when needed

### DIFF
--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -137,15 +137,6 @@ static inline void ipv4_mapped_ipv6_to_ipv4(const struct in6_addr *in6,
 }
 
 /*
- * Check if a struct ipaddr has nonzero value
- */
-static inline bool ipaddr_isset(struct ipaddr *ip)
-{
-	static struct ipaddr a = {};
-	return (0 != memcmp(&a, ip, sizeof(struct ipaddr)));
-}
-
-/*
  * generic ordering comparison between IP addresses
  */
 static inline int ipaddr_cmp(const struct ipaddr *a, const struct ipaddr *b)

--- a/vrrpd/vrrp_northbound.c
+++ b/vrrpd/vrrp_northbound.c
@@ -246,11 +246,8 @@ lib_interface_vrrp_vrrp_group_v4_source_address_get_elem(
 {
 	const struct vrrp_vrouter *vr = args->list_entry;
 	struct yang_data *val = NULL;
-	struct ipaddr ip;
 
-	memset(&ip, 0x00, sizeof(ip));
-
-	if (memcmp(&vr->v4->src.ipaddr_v4, &ip.ipaddr_v4, sizeof(ip.ipaddr_v4)))
+	if (!ipaddr_is_zero(&vr->v4->src))
 		val = yang_data_new_ip(args->xpath, &vr->v4->src);
 
 	return val;
@@ -410,7 +407,7 @@ lib_interface_vrrp_vrrp_group_v6_source_address_get_elem(
 	const struct vrrp_vrouter *vr = args->list_entry;
 	struct yang_data *val = NULL;
 
-	if (ipaddr_isset(&vr->v6->src))
+	if (!ipaddr_is_zero(&vr->v6->src))
 		val = yang_data_new_ip(args->xpath, &vr->v6->src);
 
 	return val;


### PR DESCRIPTION
Replace custom implementation or call to ipaddr_isset with a call to
ipaddr_is_zero.

ipaddr_isset is not fully correct, because it's fine to have some
non-zero bytes at the end of the struct in case of IPv4 and the function
doesn't allow that.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>