### PR TITLE
ospf6d: fix distance not applied

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -971,8 +971,13 @@ DEFUN (ospf6_distance,
        "OSPF6 Administrative distance\n")
 {
 	VTY_DECLVAR_CONTEXT(ospf6, o);
+	uint8_t distance;
 
-	o->distance_all = atoi(argv[1]->arg);
+	distance = atoi(argv[1]->arg);
+	if (o->distance_all != distance) {
+		o->distance_all = distance;
+		ospf6_restart_spf(o);
+	}
 
 	return CMD_SUCCESS;
 }
@@ -986,8 +991,10 @@ DEFUN (no_ospf6_distance,
 {
 	VTY_DECLVAR_CONTEXT(ospf6, o);
 
-	o->distance_all = 0;
-
+	if (o->distance_all) {
+		o->distance_all = 0;
+		ospf6_restart_spf(o);
+	}
 	return CMD_SUCCESS;
 }
 
@@ -1237,7 +1244,7 @@ DEFUN (no_ospf6_stub_router_admin,
 }
 
 /* Restart OSPF SPF algorithm*/
-static void ospf6_restart_spf(struct ospf6 *ospf6)
+void ospf6_restart_spf(struct ospf6 *ospf6)
 {
 	ospf6_route_remove_all(ospf6->route_table);
 	ospf6_route_remove_all(ospf6->brouter_table);

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -1337,6 +1337,10 @@ static void ospf6_show(struct vty *vty, struct ospf6 *o, json_object *json,
 				    o->spf_hold_multiplier);
 
 		json_object_int_add(json, "maximumPaths", o->max_multipath);
+		json_object_int_add(json, "preference",
+				    o->distance_all
+					    ? o->distance_all
+					    : ZEBRA_OSPF6_DISTANCE_DEFAULT);
 
 		if (o->ts_spf.tv_sec || o->ts_spf.tv_usec) {
 			timersub(&now, &o->ts_spf, &result);
@@ -1420,6 +1424,9 @@ static void ospf6_show(struct vty *vty, struct ospf6 *o, json_object *json,
 			o->lsa_minarrival);
 
 		vty_out(vty, " Maximum-paths %u\n", o->max_multipath);
+		vty_out(vty, " Administrative distance %u\n",
+			o->distance_all ? o->distance_all
+					: ZEBRA_OSPF6_DISTANCE_DEFAULT);
 
 		/* Show SPF parameters */
 		vty_out(vty,

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -251,6 +251,7 @@ extern void install_element_ospf6_clear_process(void);
 extern void ospf6_top_init(void);
 extern void ospf6_delete(struct ospf6 *o);
 extern bool ospf6_router_id_update(struct ospf6 *ospf6, bool init);
+void ospf6_restart_spf(struct ospf6 *ospf6);
 
 extern void ospf6_maxage_remove(struct ospf6 *o);
 extern struct ospf6 *ospf6_instance_create(const char *name);


### PR DESCRIPTION
if `r1` has a route received from a neighbor and the same route configured as static, 
the administrative distance will determine  which route to use
```
    r1(config)# ipv6 route 1:1::1/128 Null0 70
   
    r1# sh ipv6 route
    Codes: K - kernel route, C - connected, S - static, R - RIPng,
           O - OSPFv3, I - IS-IS, B - BGP, N - NHRP, T - Table,
           v - VNC, V - VNC-Direct, A - Babel, F - PBR,
           f - OpenFabric,
           > - selected route, * - FIB route, q - queued, r - rejected, b - backup
           t - trapped, o - offload failure
    
    S>* 1:1::1/128 [70/0] unreachable (blackhole), weight 1, 00:00:12
    O   1:1::1/128 [110/20] via fe80::1833:c9ff:fe7b:3e43, r1-r2-eth0, weight 1, 00:00:49
```    
The static route is selected. If we now change the administrative distance in ospf6, the OSPF route should be selected
```    
    r1(config)# router ospf6
    r1(config-ospf6)# distance 50
    
    r1# sh ipv6 route
    Codes: K - kernel route, C - connected, S - static, R - RIPng,
           O - OSPFv3, I - IS-IS, B - BGP, N - NHRP, T - Table,
           v - VNC, V - VNC-Direct, A - Babel, F - PBR,
           f - OpenFabric,
           > - selected route, * - FIB route, q - queued, r - rejected, b - backup
           t - trapped, o - offload failure
    
    S>* 1:1::1/128 [70/0] unreachable (blackhole), weight 1, 00:00:39
    O   1:1::1/128 [110/20] via fe80::1833:c9ff:fe7b:3e43, r1-r2-eth0, weight 1, 00:01:16
```
However the distance is not applied as there are no changes in the routing table
This commit will force the update of the routing table with the new configured distance
Also we will print now the administrative distance in the output of `show ipv6 ospf`

```    
    r1# sh ipv6 route
    Codes: K - kernel route, C - connected, S - static, R - RIPng,
           O - OSPFv3, I - IS-IS, B - BGP, N - NHRP, T - Table,
           v - VNC, V - VNC-Direct, A - Babel, F - PBR,
           f - OpenFabric,
           > - selected route, * - FIB route, q - queued, r - rejected, b - backup
           t - trapped, o - offload failure
    
    O>* 1:1::1/128 [50/20] via fe80::8cb7:e6ff:fef5:2344, r1-r2-eth0, weight 1, 00:00:03
    S   1:1::1/128 [70/0] unreachable (blackhole), weight 1, 00:00:19
```    
Signed-off-by: ckishimo <carles.kishimoto@gmail.com>