### PR TITLE
pimd: Only remove bsr NHT if we actually have tracked something

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -171,7 +171,8 @@ static int pim_on_bs_timer(struct thread *t)
 		zlog_debug("%s: Bootstrap Timer expired for scope: %d",
 			   __func__, scope->sz_id);
 
-	pim_nht_bsr_del(scope->pim, scope->current_bsr);
+	if (scope->current_bsr.s_addr)
+		pim_nht_bsr_del(scope->pim, scope->current_bsr);
 
 	/* Reset scope zone data */
 	scope->accept_nofwd_bsm = false;

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -171,8 +171,7 @@ static int pim_on_bs_timer(struct thread *t)
 		zlog_debug("%s: Bootstrap Timer expired for scope: %d",
 			   __func__, scope->sz_id);
 
-	if (scope->current_bsr.s_addr)
-		pim_nht_bsr_del(scope->pim, scope->current_bsr);
+	pim_nht_bsr_del(scope->pim, scope->current_bsr);
 
 	/* Reset scope zone data */
 	scope->accept_nofwd_bsm = false;
@@ -558,8 +557,7 @@ static void pim_bsm_update(struct pim_instance *pim, struct in_addr bsr,
 			   uint32_t bsr_prio)
 {
 	if (bsr.s_addr != pim->global_scope.current_bsr.s_addr) {
-		if (pim->global_scope.current_bsr.s_addr)
-			pim_nht_bsr_del(pim, pim->global_scope.current_bsr);
+		pim_nht_bsr_del(pim, pim->global_scope.current_bsr);
 		pim_nht_bsr_add(pim, bsr);
 
 		pim->global_scope.current_bsr = bsr;
@@ -583,8 +581,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 	struct rp_info *rp_info;
 	bool upstream_updated = false;
 
-	if (pim->global_scope.current_bsr.s_addr)
-		pim_nht_bsr_del(pim, pim->global_scope.current_bsr);
+	pim_nht_bsr_del(pim, pim->global_scope.current_bsr);
 
 	/* Reset scope zone data */
 	pim->global_scope.accept_nofwd_bsm = false;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -259,6 +259,14 @@ void pim_nht_bsr_del(struct pim_instance *pim, struct in_addr addr)
 	struct pim_nexthop_cache *pnc = NULL;
 	struct pim_nexthop_cache lookup;
 
+	/*
+	 * Nothing to do here if the address to unregister
+	 * is 0.0.0.0 as that the BSR has not been registered
+	 * for tracking yet.
+	 */
+	if (addr.s_addr == INADDR_ANY)
+		return;
+
 	lookup.rpf.rpf_addr.family = AF_INET;
 	lookup.rpf.rpf_addr.prefixlen = IPV4_MAX_BITLEN;
 	lookup.rpf.rpf_addr.u.prefix4 = addr;


### PR DESCRIPTION
I'm now seeing in my log file:

2022/01/28 11:20:05 PIM: [Q0PZ7-QBBN3] attempting to delete nonexistent NHT BSR entry 0.0.0.0
2022/01/28 11:20:05 PIM: [Q0PZ7-QBBN3] attempting to delete nonexistent NHT BSR entry 0.0.0.0
2022/01/28 11:20:06 PIM: [Q0PZ7-QBBN3] attempting to delete nonexistent NHT BSR entry 0.0.0.0

When I run pimd.  Looking at the code there are 3 places where pim_bsm.c removes the
NHT BSR tracking.  In 2 of them the code ensures that the address is already setup
in 1 place it is not.  Fix.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>