### PR TITLE
zebra: name the route_entry opaque struct more specifically

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -87,7 +87,7 @@ struct rnh {
 
 PREDECL_LIST(re_list);
 
-struct opaque {
+struct re_opaque {
 	uint16_t length;
 	uint8_t data[];
 };
@@ -169,7 +169,7 @@ struct route_entry {
 	/* Distance. */
 	uint8_t distance;
 
-	struct opaque *opaque;
+	struct re_opaque *opaque;
 };
 
 #define RIB_SYSTEM_ROUTE(R) RSYSTEM_ROUTE((R)->type)

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -62,7 +62,7 @@
 #include "zebra/zebra_srte.h"
 #include "zebra/zebra_srv6.h"
 
-DEFINE_MTYPE_STATIC(ZEBRA, OPAQUE, "Opaque Data");
+DEFINE_MTYPE_STATIC(ZEBRA, RE_OPAQUE, "Route Opaque Data");
 
 static int zapi_nhg_decode(struct stream *s, int cmd, struct zapi_nhg *api_nhg);
 
@@ -2079,8 +2079,9 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 		re->mtu = api.mtu;
 
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_OPAQUE)) {
-		re->opaque = XMALLOC(MTYPE_OPAQUE,
-				     sizeof(struct opaque) + api.opaque.length);
+		re->opaque =
+			XMALLOC(MTYPE_RE_OPAQUE,
+				sizeof(struct re_opaque) + api.opaque.length);
 		re->opaque->length = api.opaque.length;
 		memcpy(re->opaque->data, api.opaque.data, re->opaque->length);
 	}
@@ -2092,7 +2093,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 			  __func__);
 		nexthop_group_delete(&ng);
 		zebra_nhg_backup_free(&bnhg);
-		XFREE(MTYPE_OPAQUE, re->opaque);
+		XFREE(MTYPE_RE_OPAQUE, re->opaque);
 		XFREE(MTYPE_RE, re);
 		return;
 	}
@@ -2105,7 +2106,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 			  __func__, api.safi);
 		nexthop_group_delete(&ng);
 		zebra_nhg_backup_free(&bnhg);
-		XFREE(MTYPE_OPAQUE, re->opaque);
+		XFREE(MTYPE_RE_OPAQUE, re->opaque);
 		XFREE(MTYPE_RE, re);
 		return;
 	}
@@ -2134,7 +2135,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	 */
 	if (ret == -1) {
 		client->error_cnt++;
-		XFREE(MTYPE_OPAQUE, re->opaque);
+		XFREE(MTYPE_RE_OPAQUE, re->opaque);
 		XFREE(MTYPE_RE, re);
 	}
 
@@ -2163,9 +2164,9 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	}
 }
 
-void zapi_opaque_free(struct opaque *opaque)
+void zapi_re_opaque_free(struct re_opaque *opaque)
 {
-	XFREE(MTYPE_OPAQUE, opaque);
+	XFREE(MTYPE_RE_OPAQUE, opaque);
 }
 
 static void zread_route_del(ZAPI_HANDLER_ARGS)

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -115,7 +115,7 @@ extern int zsend_client_close_notify(struct zserv *client,
 int zsend_nhg_notify(uint16_t type, uint16_t instance, uint32_t session_id,
 		     uint32_t id, enum zapi_nhg_notify_owner note);
 
-extern void zapi_opaque_free(struct opaque *opaque);
+extern void zapi_re_opaque_free(struct re_opaque *opaque);
 
 extern int zsend_zebra_srv6_locator_add(struct zserv *client,
 					struct srv6_locator *loc);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3105,7 +3105,7 @@ void rib_unlink(struct route_node *rn, struct route_entry *re)
 
 	nexthops_free(re->fib_ng.nexthop);
 
-	zapi_opaque_free(re->opaque);
+	zapi_re_opaque_free(re->opaque);
 
 	XFREE(MTYPE_RE, re);
 }

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -443,6 +443,7 @@ static void zebra_show_ip_route_opaque(struct vty *vty, struct route_entry *re,
 			vty_out(vty, "    Opaque Data: %s",
 				(char *)re->opaque->data);
 		break;
+
 	case ZEBRA_ROUTE_BGP:
 		memcpy(&bzo, re->opaque->data, re->opaque->length);
 


### PR DESCRIPTION
The name 'opaque' is a little general - call the route_entry struct 're_opaque' to make it more specific.
