### PR TITLE
ospf6d: Fix memory leak for `show ipv6 ospf6 zebra json`

### DIFF
--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -352,9 +352,7 @@ DEFUN(show_zebra,
 		json_object_object_add(json_zebra, "redistribute", json_array);
 		json_object_object_add(json, "zebraInformation", json_zebra);
 
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
+		vty_json(vty, json);
 	} else {
 		vty_out(vty, "Zebra Infomation\n");
 		vty_out(vty, "  fail: %d\n", zclient->fail);


### PR DESCRIPTION
$ for x in $(seq 1 10000); do vtysh -c 'show ipv6 ospf6 zebra json' >/dev/null; done

Before:
```
$ vtysh -c 'show memory ospf6d' | grep 'Total heap allocated'
  Total heap allocated:  26 MiB
```

After:
```
$ vtysh -c 'show memory ospf6d' | grep 'Total heap allocated'
  Total heap allocated:  2256 KiB
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>