### PR TITLE
ospfd: Convert output to host order from network order for route_tag

### DIFF
--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -389,7 +389,7 @@ static void ospf_as_external_lsa_dump(struct stream *s, uint16_t length)
 			   asr->tos & 0x7f, GET_METRIC(asr->metric));
 		zlog_debug("    Forwarding address %pI4", &asr->fwd_addr);
 		zlog_debug("    External Route Tag %" ROUTE_TAG_PRI,
-			   asr->route_tag);
+			   ntohl(asr->route_tag));
 	}
 }
 


### PR DESCRIPTION
FRR stores the route_tag in network byte order.  Bug filed indicates
that the `show ip ospf route` command shows the correct value.
Every place route_tag is dumped in ospf_vty.c the ntohl function
is used first.

Fixes: #10450
Signed-off-by: Donald Sharp <sharpd@nvidia.com>