### PR TITLE
ospfd: fix distance not applied

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9478,8 +9478,13 @@ DEFUN (ospf_distance,
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 	int idx_number = 1;
+	uint8_t distance;
 
-	ospf->distance_all = atoi(argv[idx_number]->arg);
+	distance = atoi(argv[idx_number]->arg);
+	if (ospf->distance_all != distance) {
+		ospf->distance_all = distance;
+		ospf_restart_spf(ospf);
+	}
 
 	return CMD_SUCCESS;
 }
@@ -9493,7 +9498,10 @@ DEFUN (no_ospf_distance,
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 
-	ospf->distance_all = 0;
+	if (ospf->distance_all) {
+		ospf->distance_all = 0;
+		ospf_restart_spf(ospf);
+	}
 
 	return CMD_SUCCESS;
 }

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3272,6 +3272,10 @@ static int show_ip_ospf_common(struct vty *vty, struct ospf *ospf,
 		json_object_int_add(json_vrf, "refreshTimerMsecs",
 				    ospf->lsa_refresh_interval * 1000);
 
+		/* show max multipath */
+		json_object_int_add(json_vrf, "maximumPaths",
+				    ospf->max_multipath);
+
 		/* show administrative distance */
 		json_object_int_add(json_vrf, "preference",
 				    ospf->distance_all

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3271,6 +3271,12 @@ static int show_ip_ospf_common(struct vty *vty, struct ospf *ospf,
 		/* Show refresh parameters. */
 		json_object_int_add(json_vrf, "refreshTimerMsecs",
 				    ospf->lsa_refresh_interval * 1000);
+
+		/* show administrative distance */
+		json_object_int_add(json_vrf, "preference",
+				    ospf->distance_all
+					    ? ospf->distance_all
+					    : ZEBRA_OSPF_DISTANCE_DEFAULT);
 	} else {
 		vty_out(vty, " SPF timer %s%s\n",
 			(ospf->t_spf_calc ? "due in " : "is "),
@@ -3293,6 +3299,11 @@ static int show_ip_ospf_common(struct vty *vty, struct ospf *ospf,
 		/* show max multipath */
 		vty_out(vty, " Maximum multiple paths(ECMP) supported  %d\n",
 			ospf->max_multipath);
+
+		/* show administrative distance */
+		vty_out(vty, " Administrative distance %u\n",
+			ospf->distance_all ? ospf->distance_all
+					   : ZEBRA_OSPF_DISTANCE_DEFAULT);
 	}
 
 	/* Show ABR/ASBR flags. */

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3301,7 +3301,7 @@ static int show_ip_ospf_common(struct vty *vty, struct ospf *ospf,
 			ospf->lsa_refresh_interval);
 
 		/* show max multipath */
-		vty_out(vty, " Maximum multiple paths(ECMP) supported  %d\n",
+		vty_out(vty, " Maximum multiple paths(ECMP) supported %d\n",
 			ospf->max_multipath);
 
 		/* show administrative distance */


### PR DESCRIPTION
This is PR #10435 applied to OSPFv2. If r1 has a route received from a neighbor with the default administrative distance configured
```   
        r1# sh ip route
        Codes: K - kernel route, C - connected, S - static, R - RIP,
               O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
               T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
               f - OpenFabric,
               > - selected route, * - FIB route, q - queued, r - rejected, b - backup
               t - trapped, o - offload failure
    
        O>* 1.1.1.1/32 [110/20] via 10.0.12.2, r1-r2-eth0, weight 1, 00:00:41
```    
If we change the administrative distance
```    
        r1(config)# router ospf
        r1(config-router)# distance 50
```    
This is not applied as there are no changes in the routing table
```    
        r1# sh ip route
        Codes: K - kernel route, C - connected, S - static, R - RIP,
               O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
               T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
               f - OpenFabric,
               > - selected route, * - FIB route, q - queued, r - rejected, b - backup
               t - trapped, o - offload failure
    
        O>* 1.1.1.1/32 [110/20] via 10.0.12.2, r1-r2-eth0, weight 1, 00:00:13
```    
This commit will force the update of the routing table with the new configured distance
```    
        r1# sh ip route
        Codes: K - kernel route, C - connected, S - static, R - RIP,
               O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
               T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
               f - OpenFabric,
               > - selected route, * - FIB route, q - queued, r - rejected, b - backup
               t - trapped, o - offload failure
    
        O>* 1.1.1.1/32 [50/20] via 10.0.12.2, r1-r2-eth0, weight 1, 00:00:14
```    
Signed-off-by: ckishimo <carles.kishimoto@gmail.com>
