### PR TITLE
[8.2] bgpd: Fixing memcmp to avoid coverity issue

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -404,9 +404,8 @@ static bool overlay_index_same(const struct attr *a1, const struct attr *a2)
 	if (!a1 && !a2)
 		return true;
 
-	return !memcmp(bgp_attr_get_evpn_overlay(a1),
-		       bgp_attr_get_evpn_overlay(a2),
-		       sizeof(struct bgp_route_evpn));
+	return bgp_route_evpn_same(bgp_attr_get_evpn_overlay(a1),
+				   bgp_attr_get_evpn_overlay(a2));
 }
 
 /* Unknown transit attribute. */

--- a/bgpd/bgp_attr_evpn.c
+++ b/bgpd/bgp_attr_evpn.c
@@ -36,6 +36,14 @@
 #include "bgpd/bgp_evpn.h"
 #include "bgpd/bgp_evpn_private.h"
 
+bool bgp_route_evpn_same(const struct bgp_route_evpn *e1,
+			 const struct bgp_route_evpn *e2)
+{
+	return (e1->type == e2->type &&
+		!memcmp(&(e1->eth_s_id), &(e2->eth_s_id), sizeof(esi_t)) &&
+		!ipaddr_cmp(&(e1->gw_ip), &(e2->gw_ip)));
+}
+
 void bgp_add_routermac_ecom(struct attr *attr, struct ethaddr *routermac)
 {
 	struct ecommunity_val routermac_ecom;

--- a/bgpd/bgp_attr_evpn.h
+++ b/bgpd/bgp_attr_evpn.h
@@ -59,4 +59,7 @@ extern void bgp_attr_evpn_na_flag(struct attr *attr, uint8_t *router_flag,
 		bool *proxy);
 extern uint16_t bgp_attr_df_pref_from_ec(struct attr *attr, uint8_t *alg);
 
+
+extern bool bgp_route_evpn_same(const struct bgp_route_evpn *e1,
+				const struct bgp_route_evpn *e2);
 #endif /* _QUAGGA_BGP_ATTR_EVPN_H */

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -6146,7 +6146,7 @@ static bool bgp_evpn_remote_ip_hash_cmp(const void *p1, const void *p2)
 	const struct evpn_remote_ip *ip1 = p1;
 	const struct evpn_remote_ip *ip2 = p2;
 
-	return (memcmp(&ip1->addr, &ip2->addr, sizeof(struct ipaddr)) == 0);
+	return !ipaddr_cmp(&ip1->addr, &ip2->addr);
 }
 
 static void bgp_evpn_remote_ip_hash_init(struct bgpevpn *vpn)


### PR DESCRIPTION
Description:
Replacing memcmp at certain places,
to avoid the coverity issues caused by it.

Co-authored-by: Kantesh Mundargi <kmundaragi@vmware.com>
Signed-off-by: Iqra Siddiqui <imujeebsiddi@vmware.com>