### PR TITLE
ospfd: Core in ospf_if_down during shutdown.

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -845,6 +845,8 @@ int ospf_if_down(struct ospf_interface *oi)
 	/* Shutdown packet reception and sending */
 	ospf_if_stream_unset(oi);
 
+	if (!ospf->new_table)
+		return 1;
 	for (rn = route_top(ospf->new_table); rn; rn = route_next(rn)) {
 		or = rn->info;
 


### PR DESCRIPTION
Skip marking routes as changed in ospf_if_down if there's now
new_table present, which might be the case when the instance is
being finished