### PR TITLE
[8.1] tools: tweak clang format to match master

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,7 @@ AllowAllParametersOfDeclarationOnNextLine: false
 AlignAfterOpenBracket: true
 SpaceAfterCStyleCast: false
 MaxEmptyLinesToKeep: 2
-BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBinaryOperators: None
 BreakStringLiterals: false
 SortIncludes:    false
 IncludeCategories:


### PR DESCRIPTION
Port clang-format tweak to 8.1 branch: break after binary operators, rather than before.
