### PR TITLE
bgpd: fix size when comparing community alias fields

### DIFF
--- a/bgpd/bgp_community_alias.c
+++ b/bgpd/bgp_community_alias.c
@@ -41,8 +41,7 @@ static bool bgp_ca_community_hash_cmp(const void *p1, const void *p2)
 	const struct community_alias *ca2 = p2;
 
 	return (strncmp(ca1->community, ca2->community,
-			sizeof(struct community_alias))
-		== 0);
+			sizeof(ca1->community)) == 0);
 }
 
 static unsigned int bgp_ca_alias_hash_key(const void *p)
@@ -57,8 +56,7 @@ static bool bgp_ca_alias_hash_cmp(const void *p1, const void *p2)
 	const struct community_alias *ca1 = p1;
 	const struct community_alias *ca2 = p2;
 
-	return (strncmp(ca1->alias, ca2->alias, sizeof(struct community_alias))
-		== 0);
+	return (strncmp(ca1->alias, ca2->alias, sizeof(ca1->alias)) == 0);
 }
 
 static void *bgp_community_alias_alloc(void *p)


### PR DESCRIPTION
Fixes #10484.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>