### PR TITLE
ospfd,ospf6d: remove redundant parameters from "no" command

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -598,15 +598,13 @@ DEFUN (area_range,
 
 DEFUN (no_area_range,
        no_area_range_cmd,
-       "no area <A.B.C.D|(0-4294967295)> range X:X::X:X/M [<advertise|not-advertise|cost (0-16777215)>]",
+       "no area <A.B.C.D|(0-4294967295)> range X:X::X:X/M [cost (0-16777215)]",
        NO_STR
        "OSPF6 area parameters\n"
        "OSPF6 area ID in IP address format\n"
        "OSPF6 area ID as a decimal value\n"
        "Configured address range\n"
        "Specify IPv6 prefix\n"
-       "Advertise\n"
-       "Do not advertise\n"
        "User specified metric for this range\n"
        "Advertised metric for this range\n")
 {

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -1353,7 +1353,7 @@ DEFPY (area_nssa_range,
 
 DEFPY (no_area_nssa_range,
        no_area_nssa_range_cmd,
-       "no area <A.B.C.D|(0-4294967295)>$area nssa range X:X::X:X/M$prefix [<not-advertise|cost (0-16777215)>]",
+       "no area <A.B.C.D|(0-4294967295)>$area nssa range X:X::X:X/M$prefix [cost (0-16777215)]",
        NO_STR
        "OSPF6 area parameters\n"
        "OSPF6 area ID in IP address format\n"
@@ -1361,7 +1361,6 @@ DEFPY (no_area_nssa_range,
        "Configure OSPF6 area as nssa\n"
        "Configured address range\n"
        "Specify IPv6 prefix\n"
-       "Do not advertise\n"
        "User specified metric for this range\n"
        "Advertised metric for this range\n")
 {

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -713,7 +713,7 @@ DEFUN (ospf_area_range_not_advertise,
 
 DEFUN (no_ospf_area_range,
        no_ospf_area_range_cmd,
-       "no area <A.B.C.D|(0-4294967295)> range A.B.C.D/M [<cost (0-16777215)|advertise [cost (0-16777215)]|not-advertise>]",
+       "no area <A.B.C.D|(0-4294967295)> range A.B.C.D/M [cost (0-16777215)]",
        NO_STR
        "OSPF area parameters\n"
        "OSPF area ID in IP address format\n"
@@ -721,11 +721,7 @@ DEFUN (no_ospf_area_range,
        "Summarize routes matching address/mask (border routers only)\n"
        "Area range prefix\n"
        "User specified metric for this range\n"
-       "Advertised metric for this range\n"
-       "Advertise this range (default)\n"
-       "User specified metric for this range\n"
-       "Advertised metric for this range\n"
-       "DoNotAdvertise this range\n")
+       "Advertised metric for this range\n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 	int idx_ipv4_number = 2;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -733,7 +733,11 @@ DEFUN (no_ospf_area_range,
 	VTY_GET_OSPF_AREA_ID(area_id, format, argv[idx_ipv4_number]->arg);
 	str2prefix_ipv4(argv[idx_ipv4_prefixlen]->arg, &p);
 
-	ospf_area_range_unset(ospf, area_id, &p);
+	if (argc > 5)
+		ospf_area_range_cost_set(ospf, area_id, &p,
+					 OSPF_AREA_RANGE_COST_UNSPEC);
+	else
+		ospf_area_range_unset(ospf, area_id, &p);
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
3 commits:
cleanup ospfd/ospf6d redundant parameters and fix missing "cost" in "no" command.
Please check commit log.