### PR TITLE
bfdd: removed local_address struct and migrated usage to key.local

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -914,7 +914,7 @@ struct bfd_session *bs_registrate(struct bfd_session *bfd)
 		bs_observer_add(bfd);
 
 	if (bglobal.debug_peer_event)
-		zlog_debug("session-new: %s", bs_to_string(bfd));
+		zlog_debug("session-new: [%s]", bs_to_string(bfd));
 
 	control_notify_config(BCM_NOTIFY_CONFIG_ADD, bfd);
 

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -290,7 +290,6 @@ struct bfd_session {
 	struct peer_label *pl;
 
 	struct bfd_dplane_ctx *bdc;
-	struct sockaddr_any local_address;
 	struct interface *ifp;
 	struct vrf *vrf;
 

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -486,21 +486,12 @@ static void _display_peer_brief(struct vty *vty, struct bfd_session *bs)
 {
 	char addr_buf[INET6_ADDRSTRLEN];
 
-	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)) {
-		vty_out(vty, "%-10u", bs->discrs.my_discr);
-		inet_ntop(bs->key.family, &bs->key.local, addr_buf, sizeof(addr_buf));
-		vty_out(vty, " %-40s", addr_buf);
-		inet_ntop(bs->key.family, &bs->key.peer, addr_buf, sizeof(addr_buf));
-		vty_out(vty, " %-40s", addr_buf);
-		vty_out(vty, "%-15s\n", state_list[bs->ses_state].str);
-	} else {
-		vty_out(vty, "%-10u", bs->discrs.my_discr);
-		vty_out(vty, " %-40s", satostr(&bs->local_address));
-		inet_ntop(bs->key.family, &bs->key.peer, addr_buf, sizeof(addr_buf));
-		vty_out(vty, " %-40s", addr_buf);
-
-		vty_out(vty, "%-15s\n", state_list[bs->ses_state].str);
-	}
+	vty_out(vty, "%-10u", bs->discrs.my_discr);
+	inet_ntop(bs->key.family, &bs->key.local, addr_buf, sizeof(addr_buf));
+	vty_out(vty, " %-40s", addr_buf);
+	inet_ntop(bs->key.family, &bs->key.peer, addr_buf, sizeof(addr_buf));
+	vty_out(vty, " %-40s", addr_buf);
+	vty_out(vty, "%-15s\n", state_list[bs->ses_state].str);
 }
 
 static void _display_peer_brief_iter(struct hash_bucket *hb, void *arg)


### PR DESCRIPTION
~~"show bfd peers brief" displayed unknown for local address.
There was a check to see if the bfd session was multihop and
the else statement called satostr with incomplete data in the
local_address struct. This displayed unknown without AF_INET info.
I don't know the significance of checking for multihop to display
local address, but the json output does not make this check so I
removed the check to match JSON functionality.~~

Changed code to remove the local_address struct completely.  Single hop sessions will now set key.local when BFD session is established and display correctly in show output.


Signed-off-by: ewlumpkin <ewlumpkin@gmail.com>