### PR TITLE
pimd: Modify `show ip pim assert` to only show interesting bits

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -452,6 +452,7 @@ cause great confusion.
 .. clicmd:: show ip pim assert
 
    Display information about asserts in the PIM system for S,G mroutes.
+   This command does not show S,G Channel states that in a NOINFO state.
 
 .. clicmd:: show ip pim assert-internal
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -143,6 +143,9 @@ static void pim_show_assert(struct pim_instance *pim, struct vty *vty)
 			continue;
 
 		RB_FOREACH (ch, pim_ifchannel_rb, &pim_ifp->ifchannel_rb) {
+			if (ch->ifassert_state == PIM_IFASSERT_NOINFO)
+				continue;
+
 			pim_show_assert_helper(vty, pim_ifp, ch, now);
 		} /* scan interface channels */
 	}


### PR DESCRIPTION
`show ip pim assert` shows S,G ifchannel information even when
there is no information available about the assert process.

Fix the code to not dump non-interesting cases.

Fixes: #10462
Signed-off-by: Donald Sharp <sharpd@nvidia.com>