### PR TITLE
tests: fix strings with topologies

### DIFF
--- a/tests/topotests/bgp_community_change_update/test_bgp_community_change_update.py
+++ b/tests/topotests/bgp_community_change_update/test_bgp_community_change_update.py
@@ -18,7 +18,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 Reference: https://www.cmand.org/communityexploration
 
                      --y2--

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/customize.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/customize.py
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 customize.py: Simple FRR MPLS L3VPN test topology
 
                   |

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 customize.py: Simple FRR MPLS L3VPN test topology
 
                   |

--- a/tests/topotests/bgp_multiview_topo1/test_bgp_multiview_topo1.py
+++ b/tests/topotests/bgp_multiview_topo1/test_bgp_multiview_topo1.py
@@ -22,7 +22,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 test_bgp_multiview_topo1.py: Simple FRR Route-Server Test
 
 +----------+ +----------+ +----------+ +----------+ +----------+

--- a/tests/topotests/bgp_rfapi_basic_sanity/customize.py
+++ b/tests/topotests/bgp_rfapi_basic_sanity/customize.py
@@ -22,7 +22,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 customize.py: Simple FRR MPLS L3VPN test topology
 
              +---------+

--- a/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
+++ b/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 test_ldp_oc_acl_topo1.py: Simple FRR LDP Test
 
              +---------+

--- a/tests/topotests/ldp_oc_topo1/test_ldp_oc_topo1.py
+++ b/tests/topotests/ldp_oc_topo1/test_ldp_oc_topo1.py
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 test_ldp_oc_topo1.py: Simple FRR LDP Test
 
              +---------+

--- a/tests/topotests/ldp_topo1/test_ldp_topo1.py
+++ b/tests/topotests/ldp_topo1/test_ldp_topo1.py
@@ -22,7 +22,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 test_ldp_topo1.py: Simple FRR LDP Test
 
              +---------+

--- a/tests/topotests/ospf6_topo1/test_ospf6_topo1.py
+++ b/tests/topotests/ospf6_topo1/test_ospf6_topo1.py
@@ -22,7 +22,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 test_ospf6_topo1.py:
 
                                                   -----\

--- a/tests/topotests/ospf6_topo1_vrf/test_ospf6_topo1_vrf.py
+++ b/tests/topotests/ospf6_topo1_vrf/test_ospf6_topo1_vrf.py
@@ -23,7 +23,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 test_ospf6_topo1_vrf.py:
 
                                                   -----\


### PR DESCRIPTION
Add `r` prefix to treat backslashes as literals.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>