### PR TITLE
zebra: use consistent route types to resolve nexthops

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -289,6 +289,13 @@ DECLARE_LIST(re_list, struct route_entry, next);
 
 #define RNODE_NEXT_RE(rn, re) RE_DEST_NEXT_ROUTE(rib_dest_from_rnode(rn), re)
 
+/* Identify the route/proto types that we consider valid for resolving
+ * nexthops (non-recursive).
+ */
+#define RIB_TYPE_RESOLVED(type) ((type) == ZEBRA_ROUTE_CONNECT || \
+				 (type) == ZEBRA_ROUTE_STATIC ||  \
+				 (type) == ZEBRA_ROUTE_KERNEL)
+
 #if defined(HAVE_RTADV)
 PREDECL_SORTLIST_UNIQ(adv_if_list);
 /* Structure which hold status of router advertisement. */

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2209,8 +2209,10 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 			continue;
 		}
 
-		if (match->type == ZEBRA_ROUTE_CONNECT) {
-			/* Directly point connected route. */
+		if (RIB_TYPE_RESOLVED(match->type)) {
+			/* Valid resolving route type for non-recursive
+			 * routes.
+			 */
 			newhop = match->nhe->nhg.nexthop;
 			if (newhop) {
 				if (nexthop->type == NEXTHOP_TYPE_IPV4

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -529,8 +529,7 @@ static bool rnh_check_re_nexthops(const struct route_entry *re,
 
 	/* Some special checks if registration asked for them. */
 	if (CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED)) {
-		if ((re->type == ZEBRA_ROUTE_CONNECT)
-		    || (re->type == ZEBRA_ROUTE_STATIC))
+		if (RIB_TYPE_RESOLVED(re->type))
 			ret = true;
 		if (re->type == ZEBRA_ROUTE_NHRP) {
 


### PR DESCRIPTION
Use a single consistent set of route types when resolving nexthops for NHT/reachability, and for routes' nexthops. The two paths were using different types when deciding whether a nexthop was resolved, and that doesn't make sense.

This is related to #10385 , see comments there for some more discussion about this area.
