### PR TITLE
zebra: add netlink debugs for ip rules

### DIFF
--- a/zebra/debug_nl.c
+++ b/zebra/debug_nl.c
@@ -1338,8 +1338,7 @@ next_header:
 	case RTM_SETLINK:
 		ifi = NLMSG_DATA(nlmsg);
 		zlog_debug(
-			"  ifinfomsg [family=%d type=(%d) %s "
-			"index=%d flags=0x%04x {%s}]",
+			"  ifinfomsg [family=%d type=(%d) %s index=%d flags=0x%04x {%s}]",
 			ifi->ifi_family, ifi->ifi_type,
 			ifi_type2str(ifi->ifi_type), ifi->ifi_index,
 			ifi->ifi_flags,
@@ -1357,9 +1356,7 @@ next_header:
 	case RTM_GETROUTE:
 		rtm = NLMSG_DATA(nlmsg);
 		zlog_debug(
-			"  rtmsg [family=(%d) %s dstlen=%d srclen=%d tos=%d "
-			"table=%d protocol=(%d) %s scope=(%d) %s "
-			"type=(%d) %s flags=0x%04x {%s}]",
+			"  rtmsg [family=(%d) %s dstlen=%d srclen=%d tos=%d table=%d protocol=(%d) %s scope=(%d) %s type=(%d) %s flags=0x%04x {%s}]",
 			rtm->rtm_family, af_type2str(rtm->rtm_family),
 			rtm->rtm_dst_len, rtm->rtm_src_len, rtm->rtm_tos,
 			rtm->rtm_table, rtm->rtm_protocol,
@@ -1375,8 +1372,7 @@ next_header:
 	case RTM_DELNEIGH:
 		ndm = NLMSG_DATA(nlmsg);
 		zlog_debug(
-			"  ndm [family=%d (%s) ifindex=%d state=0x%04x {%s} "
-			"flags=0x%04x {%s} type=%d (%s)]",
+			"  ndm [family=%d (%s) ifindex=%d state=0x%04x {%s} flags=0x%04x {%s} type=%d (%s)]",
 			ndm->ndm_family, af_type2str(ndm->ndm_family),
 			ndm->ndm_ifindex, ndm->ndm_state,
 			neigh_state2str(ndm->ndm_state, ibuf, sizeof(ibuf)),
@@ -1391,8 +1387,7 @@ next_header:
 	case RTM_DELRULE:
 		frh = NLMSG_DATA(nlmsg);
 		zlog_debug(
-			"  frh [family=%d (%s) dst_len=%d src_len=%d tos=%d"
-			" table=%d res1=%d res2=%d action=%d (%s) flags=0x%x]",
+			"  frh [family=%d (%s) dst_len=%d src_len=%d tos=%d table=%d res1=%d res2=%d action=%d (%s) flags=0x%x]",
 			frh->family, af_type2str(frh->family), frh->dst_len,
 			frh->src_len, frh->tos, frh->table, frh->res1,
 			frh->res2, frh->action, frh_action2str(frh->action),
@@ -1405,8 +1400,7 @@ next_header:
 	case RTM_DELADDR:
 		ifa = NLMSG_DATA(nlmsg);
 		zlog_debug(
-			"  ifa [family=(%d) %s prefixlen=%d "
-			"flags=0x%04x {%s} scope=%d index=%u]",
+			"  ifa [family=(%d) %s prefixlen=%d flags=0x%04x {%s} scope=%d index=%u]",
 			ifa->ifa_family, af_type2str(ifa->ifa_family),
 			ifa->ifa_prefixlen, ifa->ifa_flags,
 			if_flags2str(ifa->ifa_flags, fbuf, sizeof(fbuf)),
@@ -1419,8 +1413,7 @@ next_header:
 	case RTM_GETNEXTHOP:
 		nhm = NLMSG_DATA(nlmsg);
 		zlog_debug(
-			"  nhm [family=(%d) %s scope=(%d) %s "
-			"protocol=(%d) %s flags=0x%08x {%s}]",
+			"  nhm [family=(%d) %s scope=(%d) %s protocol=(%d) %s flags=0x%08x {%s}]",
 			nhm->nh_family, af_type2str(nhm->nh_family),
 			nhm->nh_scope, rtm_scope2str(nhm->nh_scope),
 			nhm->nh_protocol, rtm_protocol2str(nhm->nh_protocol),

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -134,6 +134,8 @@ const char *rtm_rta2str(int type);
 const char *neigh_rta2str(int type);
 const char *ifa_rta2str(int type);
 const char *nhm_rta2str(int type);
+const char *frh_rta2str(int type);
+const char *frh_action2str(uint8_t action);
 const char *nlmsg_flags2str(uint16_t flags, char *buf, size_t buflen);
 const char *if_flags2str(uint32_t flags, char *buf, size_t buflen);
 const char *rtm_flags2str(uint32_t flags, char *buf, size_t buflen);


### PR DESCRIPTION
Adds functions to parse + decode netlink rules.
Adds RTM_NEWRULE + RTM_DELRULE to "debug zebra kernel".

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>

Example output:
```
2022/02/08 17:30:40 ZEBRA: [JAS4D-NCWGP] nlmsghdr [len=80 type=(32) NEWRULE flags=(0x0001) {REQUEST} seq=17 pid=3629048426]
2022/02/08 17:30:40 ZEBRA: [X216X-9DETH]   frh [family=2 (AF_INET) dst_len=32 src_len=32 tos=0 table=0 res1=0 res2=0 action=2 (GOTO) flags=0x0]
2022/02/08 17:30:40 ZEBRA: [KFBSR-XYJV1]     rta [len=5 (payload=1) type=(21) PROTO]
2022/02/08 17:30:40 ZEBRA: [Z4E9C-GD9EP]       11
2022/02/08 17:30:40 ZEBRA: [KFBSR-XYJV1]     rta [len=8 (payload=4) type=(6) PRIORITY]
2022/02/08 17:30:40 ZEBRA: [Z4E9C-GD9EP]       304
2022/02/08 17:30:40 ZEBRA: [KFBSR-XYJV1]     rta [len=11 (payload=7) type=(3) INBOUND INTERFACE NAME]
2022/02/08 17:30:40 ZEBRA: [QMZBY-7F37T]         enp6s0
2022/02/08 17:30:40 ZEBRA: [KFBSR-XYJV1]     rta [len=8 (payload=4) type=(2) SOURCE ADDRESS]
2022/02/08 17:30:40 ZEBRA: [M8QV4-KY9C0]       1.1.1.1                                 
2022/02/08 17:30:40 ZEBRA: [KFBSR-XYJV1]     rta [len=8 (payload=4) type=(1) DESTINATION ADDRESS]
2022/02/08 17:30:40 ZEBRA: [M8QV4-KY9C0]       2.2.2.2
2022/02/08 17:30:40 ZEBRA: [KFBSR-XYJV1]     rta [len=8 (payload=4) type=(4) GOTO]
2022/02/08 17:30:40 ZEBRA: [Z4E9C-GD9EP]       32766        
```