### PR TITLE
bgpd: evpn route-map match ead type-1 route-type

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1045,6 +1045,8 @@ static void *route_match_evpn_route_type_compile(const char *arg)
 		*route_type = BGP_EVPN_MAC_IP_ROUTE;
 	else if (strncmp(arg, "mu", 2) == 0)
 		*route_type = BGP_EVPN_IMET_ROUTE;
+	else if (strncmp(arg, "es", 2) == 0)
+		*route_type = BGP_EVPN_ES_ROUTE;
 	else
 		*route_type = BGP_EVPN_IP_PREFIX_ROUTE;
 
@@ -4169,7 +4171,7 @@ static const char *parse_evpn_rt_type(const char *num_rt_type)
 
 DEFUN_YANG (match_evpn_route_type,
 	    match_evpn_route_type_cmd,
-	    "match evpn route-type <ead|1|macip|2|multicast|3|prefix|5>",
+	    "match evpn route-type <ead|1|macip|2|multicast|3|es|4|prefix|5>",
 	    MATCH_STR
 	    EVPN_HELP_STR
 	    EVPN_TYPE_HELP_STR
@@ -4179,6 +4181,8 @@ DEFUN_YANG (match_evpn_route_type,
 	    EVPN_TYPE_2_HELP_STR
 	    EVPN_TYPE_3_HELP_STR
 	    EVPN_TYPE_3_HELP_STR
+	    EVPN_TYPE_4_HELP_STR
+	    EVPN_TYPE_4_HELP_STR
 	    EVPN_TYPE_5_HELP_STR
 	    EVPN_TYPE_5_HELP_STR)
 {
@@ -4198,7 +4202,7 @@ DEFUN_YANG (match_evpn_route_type,
 
 DEFUN_YANG (no_match_evpn_route_type,
 	    no_match_evpn_route_type_cmd,
-	    "no match evpn route-type <ead|1|macip|2|multicast|3|prefix|5>",
+	    "no match evpn route-type <ead|1|macip|2|multicast|3|es|4|prefix|5>",
 	    NO_STR
 	    MATCH_STR
 	    EVPN_HELP_STR
@@ -4209,6 +4213,8 @@ DEFUN_YANG (no_match_evpn_route_type,
 	    EVPN_TYPE_2_HELP_STR
 	    EVPN_TYPE_3_HELP_STR
 	    EVPN_TYPE_3_HELP_STR
+	    EVPN_TYPE_4_HELP_STR
+	    EVPN_TYPE_4_HELP_STR
 	    EVPN_TYPE_5_HELP_STR
 	    EVPN_TYPE_5_HELP_STR)
 {

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1039,7 +1039,9 @@ static void *route_match_evpn_route_type_compile(const char *arg)
 
 	route_type = XMALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(uint8_t));
 
-	if (strncmp(arg, "ma", 2) == 0)
+	if (strncmp(arg, "ea", 2) == 0)
+		*route_type = BGP_EVPN_AD_ROUTE;
+	else if (strncmp(arg, "ma", 2) == 0)
 		*route_type = BGP_EVPN_MAC_IP_ROUTE;
 	else if (strncmp(arg, "mu", 2) == 0)
 		*route_type = BGP_EVPN_IMET_ROUTE;
@@ -4167,10 +4169,12 @@ static const char *parse_evpn_rt_type(const char *num_rt_type)
 
 DEFUN_YANG (match_evpn_route_type,
 	    match_evpn_route_type_cmd,
-	    "match evpn route-type <macip|2|multicast|3|prefix|5>",
+	    "match evpn route-type <ead|1|macip|2|multicast|3|prefix|5>",
 	    MATCH_STR
 	    EVPN_HELP_STR
 	    EVPN_TYPE_HELP_STR
+	    EVPN_TYPE_1_HELP_STR
+	    EVPN_TYPE_1_HELP_STR
 	    EVPN_TYPE_2_HELP_STR
 	    EVPN_TYPE_2_HELP_STR
 	    EVPN_TYPE_3_HELP_STR
@@ -4194,11 +4198,13 @@ DEFUN_YANG (match_evpn_route_type,
 
 DEFUN_YANG (no_match_evpn_route_type,
 	    no_match_evpn_route_type_cmd,
-	    "no match evpn route-type <macip|2|multicast|3|prefix|5>",
+	    "no match evpn route-type <ead|1|macip|2|multicast|3|prefix|5>",
 	    NO_STR
 	    MATCH_STR
 	    EVPN_HELP_STR
 	    EVPN_TYPE_HELP_STR
+	    EVPN_TYPE_1_HELP_STR
+	    EVPN_TYPE_1_HELP_STR
 	    EVPN_TYPE_2_HELP_STR
 	    EVPN_TYPE_2_HELP_STR
 	    EVPN_TYPE_3_HELP_STR

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -215,6 +215,18 @@ Route Map Match Command
   This is a ZEBRA specific match command.  The number is a range from (0-255).
   Matches the originating protocols instance specified.
 
+.. clicmd:: match evpn route-type ROUTE_TYPE_NAME
+
+  This is a BGP EVPN specific match command. It matches to EVPN route-type
+  from type-1 (EAD route-type) to type-5 (Prefix route-type).
+  User can provide in an integral form (1-5) or string form of route-type
+  (i.e ead, macip, multicast, es, prefix).
+
+.. clicmd:: match evpn vni NUMBER
+
+  This is a BGP EVPN specific match command which matches to EVPN VNI id.
+  The number is a range from (1-6777215).
+
 .. _route-map-set-command:
 
 Route Map Set Command

--- a/yang/frr-bgp-route-map.yang
+++ b/yang/frr-bgp-route-map.yang
@@ -537,6 +537,11 @@ module frr-bgp-route-map {
             description
               "Ethernet Auto-Discovery route";
           }
+          enum "es" {
+            value 4;
+            description
+              "Ethernet Segment route";
+          }
         }
       }
     }

--- a/yang/frr-bgp-route-map.yang
+++ b/yang/frr-bgp-route-map.yang
@@ -532,6 +532,11 @@ module frr-bgp-route-map {
             description
               "Prefix route";
           }
+          enum "ead" {
+            value 3;
+            description
+              "Ethernet Auto-Discovery route";
+          }
         }
       }
     }


### PR DESCRIPTION
Add evpn mh route type-1 (EAD) to match clause
of route-map.

Ticket: issue#10461
Reviewed By:
Testing Done:

With fix:
```
vtep1(config-route-map)# match evpn route-type
  1          EAD (Type-1) route
  2          MAC-IP (Type-2) route
  3          Multicast (Type-3) route
  4          Ethernet Segment (Type-4) route
  5          Prefix (Type-5) route
  ead        EAD (Type-1) route
  macip      MAC-IP (Type-2) route
  multicast  Multicast (Type-3) route
  prefix     Prefix (Type-5) route

vtep1# show running-config bgpd
....
route-map HOST_ALLOW_1 permit 1
 match evpn route-type ead

vtep1# show route-map HOST_ALLOW_1

BGP:
route-map: HOST_ALLOW_1 Invoked: 6 Optimization: disabled Processed Change: false
 permit, sequence 1 Invoked 6
  Match clauses:
    ip address prefix-list LOCAL_HOST_VRF1
    evpn route-type ead
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>