### PR TITLE
bgpd: fix null pointer dereferences

### DIFF
--- a/bgpd/bgp_attr_evpn.c
+++ b/bgpd/bgp_attr_evpn.c
@@ -53,8 +53,10 @@ void bgp_add_routermac_ecom(struct attr *attr, struct ethaddr *routermac)
 	routermac_ecom.val[0] = ECOMMUNITY_ENCODE_EVPN;
 	routermac_ecom.val[1] = ECOMMUNITY_EVPN_SUBTYPE_ROUTERMAC;
 	memcpy(&routermac_ecom.val[2], routermac->octet, ETH_ALEN);
-	if (!ecomm)
+	if (!ecomm) {
 		bgp_attr_set_ecommunity(attr, ecommunity_new());
+		ecomm = bgp_attr_get_ecommunity(attr);
+	}
 	ecommunity_add_val(ecomm, &routermac_ecom, false, false);
 	ecommunity_str(ecomm);
 }

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -467,7 +467,7 @@ void rfapiPrintAttrPtrs(void *stream, struct attr *attr)
 	struct transit *transit;
 	struct cluster_list *cluster;
 	char buf[BUFSIZ];
-	struct ecommunity *ecomm = bgp_attr_get_ecommunity(attr);
+	struct ecommunity *ecomm;
 
 	if (rfapiStream2Vty(stream, &fp, &vty, &out, &vty_newline) == 0)
 		return;
@@ -485,6 +485,7 @@ void rfapiPrintAttrPtrs(void *stream, struct attr *attr)
 	fp(out, "  community=%p, refcnt=%d%s", attr->community,
 	   (attr->community ? attr->community->refcnt : 0), HVTYNL);
 
+	ecomm = bgp_attr_get_ecommunity(attr);
 	fp(out, "  ecommunity=%p, refcnt=%d%s", ecomm,
 	   (ecomm ? ecomm->refcnt : 0), HVTYNL);
 


### PR DESCRIPTION
They were introduced during recent ecommunity rework in b53e67a3.

CID 1511347 and 1511348.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>