### PR TITLE
tools: fix frr-reload context keywords

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -517,9 +517,11 @@ class Config(object):
                 "address-family ": {
                     "vni ": {},
                 },
-                "vnc ": {},
+                "vnc defaults": {},
+                "vnc nve-group ": {},
+                "vnc l2-group ": {},
                 "vrf-policy ": {},
-                "bmp ": {},
+                "bmp targets ": {},
                 "segment-routing srv6": {},
             },
             "router rip": {},


### PR DESCRIPTION
There are singline-line commands inside `router bgp` that start with
`vnc ` or `bmp `. Those commands are currently treated as node-entering
commands. We need to specify such commands more precisely.

Fixes #10548.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>