### PR TITLE
pimd: fix crash on "no ip pim"

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1987,9 +1987,6 @@ static bool pim_upstream_kat_start_ok(struct pim_upstream *up)
 	 * So we will do an approximate check here to avoid starting KAT
 	 * because of (S,G,rpt) forwarding on a non-LHR.
 	 */
-	if (!ifp)
-		return false;
-
 	pim_ifp = ifp->info;
 	if (pim_ifp->mroute_vif_index != *oil_parent(c_oil))
 		return false;
@@ -2011,8 +2008,13 @@ static bool pim_upstream_sg_running_proc(struct pim_upstream *up)
 {
 	bool rv = false;
 	struct pim_instance *pim = up->pim;
+	struct interface *ifp;
 
 	if (!up->channel_oil->installed)
+		return rv;
+
+	ifp = up->rpf.source_nexthop.interface;
+	if (!ifp || !ifp->info)
 		return rv;
 
 	pim_mroute_update_counters(up->channel_oil);


### PR DESCRIPTION
pimd: fix crash on "no ip pim"                                                      
                                                                                    
`up->rpf.source_nexthop.interface` is the upstream source interface. When           
"no ip pim" on it,  its `ifp->info` is set to NULL. But KAT on this interface       
is still running, it wrongly dereferences NULL `ifp->info`.                         
                                                                                    
KAT on this upstream source interface will be expired after next cycle              
( interval is `keep-alive-timer` value, 210 seconds by default ) with               
disabled PIM interface.                                                             
                                                                                    
KAT cycle is triggered by `wheel timer` ( interval is 30 seconds ). Let             
`wheel timer` go through and skip invalid interfaces, KAT can be expired in         
the next cycle.                                                                     
                                                                                    
During go through, these invalid interfaces have not been correctly checked,        
this lead to crash.                                                                 
                                                                                    
So add NULL check for `wheel timer`'s `pim_upstream_sg_running_proc` to skip        
invalid upstream source interfaces ( `ifp` is NULL or `ifp->info` is NULL ).        
Additionly, move the check to the earliest possible location.