### PR TITLE
bgp: Add a 6 hour warning to missing policy

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3239,6 +3239,10 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 
 	/*initilize global GR FSM */
 	bgp_global_gr_init(bgp);
+
+	memset(&bgp->ebgprequirespolicywarning, 0,
+	       sizeof(bgp->ebgprequirespolicywarning));
+
 	return bgp;
 }
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -759,6 +759,9 @@ struct bgp {
 	struct list *srv6_locator_chunks;
 	struct list *srv6_functions;
 
+	struct timeval ebgprequirespolicywarning;
+#define FIFTEENMINUTE2USEC (int64_t)15 * 60 * 1000000
+
 	QOBJ_FIELDS;
 };
 DECLARE_QOBJ_TYPE(bgp);


### PR DESCRIPTION
Add a 6 hour warning to the logging system when
bgp policy is not setup properly.  Operators keep asking
about the missing policy( on upgrade typically ).  Let's
try to give them a bit more of a hint when something is
going wrong as that they are clearly missing the other
various places FRR tells them about it.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>