### PR TITLE
zebra: Lookup linked interface in link netns

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1834,7 +1834,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 					 ZEBRA_INTERFACE_VRF_LOOPBACK);
 
 			/* Update link. */
-			zebra_if_update_link(ifp, link_ifindex, ns_id);
+			zebra_if_update_link(ifp, link_ifindex, link_nsid);
 
 			ifp->ll_type =
 				netlink_to_zebra_link_type(ifi->ifi_type);
@@ -1903,7 +1903,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			memcpy(old_hw_addr, ifp->hw_addr, INTERFACE_HWADDR_MAX);
 
 			/* Update link. */
-			zebra_if_update_link(ifp, link_ifindex, ns_id);
+			zebra_if_update_link(ifp, link_ifindex, link_nsid);
 
 			ifp->ll_type =
 				netlink_to_zebra_link_type(ifi->ifi_type);


### PR DESCRIPTION
Look up linked interface in the correct netns, otherwise, either a wrong
interface or NULL would be used.

**To Reproduce**

```
# ip netns add ns1
# ip link add link eth0 link1 type macvlan
# ip link set link1 netns ns1 up
```

zebra will crash in `zebra_vxlan_macvlan_up` because `zif->link` is `NULL`.