### PR TITLE
bgpd: uninitialized compiler warning

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -526,7 +526,7 @@ static uint32_t alloc_new_sid(struct bgp *bgp, uint32_t index,
 	struct prefix_ipv6 *chunk;
 	struct in6_addr sid_buf;
 	bool alloced = false;
-	int label;
+	int label = 0;
 
 	if (!bgp || !sid)
 		return false;


### PR DESCRIPTION
Build warning: 'label' may be used uninitialized in this function bgpd/bgp_mplsvpn.c alloc_new_sid