### PR TITLE
ripd: Fix packet send for non primary addresses

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1522,6 +1522,7 @@ static int rip_send_packet(uint8_t *buf, int size, struct sockaddr_in *to,
 	cmsgptr->cmsg_type = IP_PKTINFO;
 	pkt = (struct in_pktinfo *)CMSG_DATA(cmsgptr);
 	pkt->ipi_ifindex = ifc->ifp->ifindex;
+	pkt->ipi_spec_dst.s_addr = ifc->address->u.prefix4.s_addr;
 #endif /* GNU_LINUX */
 
 	ret = sendmsg(rip->sock, &msg, 0);


### PR DESCRIPTION
When rip is configured to work on secondary addresses
on an interface, rip was not properly sending out
the packets on secondary addresses because the source of the
packet was never properly being setup and rip would
send the packet out multiple times for the primary address
not once for each address on the interface that is setup to work.

tcpdump + rip debugs output with fix:

2022/02/15 19:59:50 RIP: [ZG173-BHW0K] turn on virbr0
2022/02/15 19:59:51 RIP: [PYB7S-80D89] multicast join at virbr0
2022/02/15 19:59:51 RIP: [GZR24-FCQGG] multicast request on virbr0
2022/02/15 19:59:51 RIP: [JTNCV-XD8S1] rip_send_packet 192.168.122.1 > 224.0.0.9 (virbr0)
2022/02/15 19:59:51 RIP: [VEJY5-67P5X] SEND to  224.0.0.9520
2022/02/15 19:59:51 RIP: [JTNCV-XD8S1] rip_send_packet 73.3.3.8 > 224.0.0.9 (virbr0)
2022/02/15 19:59:51 RIP: [VEJY5-67P5X] SEND to  224.0.0.9520
19:59:51.831128 IP 192.168.122.1.route > rip2-routers.mcast.net.route: RIPv2, Request, length: 24
19:59:51.831161 IP c-73-3-3-8.hsd1.mo.comcast.net.route > rip2-routers.mcast.net.route: RIPv2, Request, length: 24

Fixes: 10588
Signed-off-by: Donald Sharp <sharpd@nvidia.com>