### PR TITLE
pimd: Fix Compilation issue in PIM

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8247,7 +8247,7 @@ DEFPY_HIDDEN (interface_ip_igmp_query_generate,
 	}
 
 	/* It takes the igmp version configured on the interface as default */
-	igmp_version = pim_ifp->version;
+	igmp_version = pim_ifp->igmp_version;
 
 	if (argc > 3)
 		igmp_version = atoi(argv[4]->arg);


### PR DESCRIPTION
A recent merge caused the below error in compilation, fixing it.

pimd/pim_cmd.c: In function ‘interface_ip_igmp_query_generate_magic’:
pimd/pim_cmd.c:8002:24: error: ‘struct pim_interface’ has no member named ‘version’
  igmp_version = pim_ifp->version;
                        ^~
Makefile:12435: recipe for target 'pimd/pimd_pimd-pim_cmd.o' failed
make[1]: *** [pimd/pimd_pimd-pim_cmd.o] Error 1
make[1]: Leaving directory '/root/mobash/FRR/frr'
Makefile:5659: recipe for target 'all' failed
make: *** [all] Error 2

Signed-off-by: Mobashshera Rasool <mrasool@gmail.com>