### PR TITLE
staticd: reject route config with too many nexthops

### DIFF
--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -43,7 +43,7 @@
 char backup_config_file[256];
 
 bool mpls_enabled;
-
+uint32_t zebra_ecmp_count = MULTIPATH_NUM;
 
 zebra_capabilities_t _caps_p[] = {
 };

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -115,7 +115,7 @@ static int static_path_list_tag_modify(struct nb_cb_modify_args *args)
 }
 
 struct nexthop_iter {
-	int count;
+	uint32_t count;
 	bool blackhole;
 };
 
@@ -170,6 +170,11 @@ static bool static_nexthop_create(struct nb_cb_create_args *args)
 			snprintf(
 				args->errmsg, args->errmsg_len,
 				"Route cannot have blackhole and non-blackhole nexthops simultaneously");
+			return NB_ERR_VALIDATION;
+		} else if (iter.count > zebra_ecmp_count) {
+			snprintf(args->errmsg, args->errmsg_len,
+				"Route cannot have more than %d ECMP nexthops",
+				 zebra_ecmp_count);
 			return NB_ERR_VALIDATION;
 		}
 		break;

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -169,7 +169,7 @@ static bool static_nexthop_create(struct nb_cb_create_args *args)
 		if (iter.blackhole && iter.count > 1) {
 			snprintf(
 				args->errmsg, args->errmsg_len,
-				"Route can not have blackhole and non-blackhole nexthops simultaneously");
+				"Route cannot have blackhole and non-blackhole nexthops simultaneously");
 			return NB_ERR_VALIDATION;
 		}
 		break;

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -163,6 +163,7 @@ static_route_info_from_rnode(struct route_node *rn)
 }
 
 extern bool mpls_enabled;
+extern uint32_t zebra_ecmp_count;
 
 extern struct zebra_privs_t static_privs;
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -205,6 +205,7 @@ static int static_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
 static void static_zebra_capabilities(struct zclient_capabilities *cap)
 {
 	mpls_enabled = cap->mpls_enabled;
+	zebra_ecmp_count = cap->ecmp;
 }
 
 static unsigned int static_nht_hash_key(const void *data)

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -414,6 +414,10 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 		api.tableid = pn->table_id;
 	}
 	frr_each(static_nexthop_list, &pn->nexthop_list, nh) {
+		/* Don't overrun the nexthop array */
+		if (nh_num == zebra_ecmp_count)
+			break;
+
 		api_nh = &api.nexthops[nh_num];
 		if (nh->nh_vrf_id == VRF_UNKNOWN)
 			continue;


### PR DESCRIPTION
Restrict the number of nexthops for a route to the compiled-in limit. Be careful with the zapi route struct's array of nexthops too.

Fixes #10601 
