### PR TITLE
ospfd: Core on router id update.

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2210,7 +2210,7 @@ struct ospf_lsa *ospf_external_lsa_originate(struct ospf *ospf,
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
 				"LSA[Type5:%pI4]: deferring AS-external-LSA origination, router ID is zero",
-				&ei->p.prefix);
+				ei ? &ei->p.prefix : NULL);
 		return NULL;
 	}
 
@@ -2219,7 +2219,7 @@ struct ospf_lsa *ospf_external_lsa_originate(struct ospf *ospf,
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
 				"LSA[Type5:%pI4]: Could not originate AS-external-LSA",
-				&ei->p.prefix);
+				ei ? &ei->p.prefix : NULL);
 		return NULL;
 	}
 


### PR DESCRIPTION
A router id change triggered a core:

core_handler (signo=11, siginfo=0x7fffffffbaf0, context=<optimized out>) at lib/sigevent.c:257
<signal handler called>
....
zlog_ref (xref=xref@entry=0x555555691c20 <_xref.22591>, fmt=fmt@entry=0x555555646878 \
  "LSA[Type5:%pI4]: Could not originate AS-external-LSA") at ./lib/zlog.h:91
ospf_external_lsa_originate (ei=0x0, ospf=0x55555599a790) at ospfd/ospf_lsa.c:2049
ospf_external_lsa_originate (ospf=0x55555599a790, ei=0x0) at ospfd/ospf_lsa.c:1990
ospf_external_lsa_rid_change (ospf=ospf@entry=0x55555599a790) at ospfd/ospf_lsa.c:2187
ospf_process_refresh_data (ospf=0x55555599a790, reset=reset@entry=false) at ospfd/ospfd.c:243
ospf_router_id_update (ospf=<optimized out>) at ospfd/ospfd.c:251
...
vty_command (vty=vty@entry=0x5555559ae340, buf=0x5555559b4a70 " ospf router-id 2.0.0.23") at lib/vty.c:523
...

If ospf_external_lsa_new failed during router change, the logging of the
error could access members of a null pointer.

Signed-off-by: Tomi Salminen <tsalminen@forcepoint.com>