### PR TITLE
lib: Add ability for timer wheel to know it should modify it's timer

### DIFF
--- a/lib/wheel.h
+++ b/lib/wheel.h
@@ -33,6 +33,15 @@ struct timer_wheel {
 	unsigned int nexttime;
 	unsigned int slots_to_skip;
 
+	/*
+	 * When inserting a new item into the timer wheel and
+	 * the new slot that we are going to move the wheel
+	 * to would have already popped, due to passed time.
+	 * So save the time_passed to subtract from the next cycle
+	 * of the wheel
+	 */
+	uint32_t time_reduction;
+
 	struct list **wheel_slot_lists;
 	struct thread *timer;
 	/*


### PR DESCRIPTION
Upon insertion of a new item into the timer wheel, figure out
if the current timer needs to be modified.  There are several
situations after insertion:

a) The new slot to pop off in is the same as the old.  This
can mean a couple of things:
     1) The new item was inserted in the slot that was
        already scheduled to pop
     2) The new item was inserted after the slot that
        is scheduled to pop
In both these cases there is nothing to do, just move on

b) The new slot to pop off is inbetween the current slot
and the scheduled slot to pop, but the timer has already
spent more time sleeping than where the new slot to pop
is.  In this case, let's immediately pop the timer and
do processing.  In this case save the amount of time
passed since the last timer scheduling so that the
next scheduling of the timer wheel can account for
the time spent sleeping.

c) The new slot to pop off is inbetween the current slot and
the scheduled slot to pop, and the timer has not spent
the required amount of time waiting yet.  In this case
just figure out the new time to sleep based upon the
inclusion of how much time has passed.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>