### PR TITLE
*: Change thread->func to return void instead of int

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -49,11 +49,11 @@ THE SOFTWARE.
 DEFINE_MGROUP(BABELD, "babeld");
 DEFINE_MTYPE_STATIC(BABELD, BABEL, "Babel Structure");
 
-static int babel_init_routing_process(struct thread *thread);
+static void babel_init_routing_process(struct thread *thread);
 static void babel_get_myid(void);
 static void babel_initial_noise(void);
-static int babel_read_protocol (struct thread *thread);
-static int babel_main_loop(struct thread *thread);
+static void babel_read_protocol(struct thread *thread);
+static void babel_main_loop(struct thread *thread);
 static void babel_set_timer(struct timeval *timeout);
 static void babel_fill_with_next_timeout(struct timeval *tv);
 static void
@@ -175,8 +175,7 @@ fail:
 }
 
 /* thread reading entries form others babel daemons */
-static int
-babel_read_protocol (struct thread *thread)
+static void babel_read_protocol(struct thread *thread)
 {
     int rc;
     struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
@@ -207,14 +206,12 @@ babel_read_protocol (struct thread *thread)
 
     /* re-add thread */
     thread_add_read(master, &babel_read_protocol, NULL, protocol_socket, &babel_routing_process->t_read);
-    return 0;
 }
 
 /* Zebra will give some information, especially about interfaces. This function
  must be call with a litte timeout wich may give zebra the time to do his job,
  making these inits have sense. */
-static int
-babel_init_routing_process(struct thread *thread)
+static void babel_init_routing_process(struct thread *thread)
 {
     myseqno = (frr_weak_random() & 0xFFFF);
     babel_get_myid();
@@ -222,7 +219,6 @@ babel_init_routing_process(struct thread *thread)
     debugf(BABEL_DEBUG_COMMON, "My ID is : %s.", format_eui64(myid));
     babel_initial_noise();
     babel_main_loop(thread);/* this function self-add to the t_update thread */
-    return 0;
 }
 
 /* fill "myid" with an unique id (only if myid != {0}). */
@@ -327,8 +323,7 @@ babel_clean_routing_process(void)
 }
 
 /* Function used with timeout. */
-static int
-babel_main_loop(struct thread *thread)
+static void babel_main_loop(struct thread *thread)
 {
     struct timeval tv;
     struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
@@ -348,8 +343,8 @@ babel_main_loop(struct thread *thread)
             /* it happens often to have less than 1 ms, it's bad. */
             timeval_add_msec(&tv, &tv, 300);
             babel_set_timer(&tv);
-            return 0;
-        }
+	    return;
+	}
 
         gettime(&babel_now);
 
@@ -410,7 +405,6 @@ babel_main_loop(struct thread *thread)
     }
 
     assert(0); /* this line should never be reach */
-    return 0;
 }
 
 static void

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -609,27 +609,23 @@ struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *cp,
 	return bfd_key_lookup(key);
 }
 
-int bfd_xmt_cb(struct thread *t)
+void bfd_xmt_cb(struct thread *t)
 {
 	struct bfd_session *bs = THREAD_ARG(t);
 
 	ptm_bfd_xmt_TO(bs, 0);
-
-	return 0;
 }
 
-int bfd_echo_xmt_cb(struct thread *t)
+void bfd_echo_xmt_cb(struct thread *t)
 {
 	struct bfd_session *bs = THREAD_ARG(t);
 
 	if (bs->echo_xmt_TO > 0)
 		ptm_bfd_echo_xmt_TO(bs);
-
-	return 0;
 }
 
 /* Was ptm_bfd_detect_TO() */
-int bfd_recvtimer_cb(struct thread *t)
+void bfd_recvtimer_cb(struct thread *t)
 {
 	struct bfd_session *bs = THREAD_ARG(t);
 
@@ -639,12 +635,10 @@ int bfd_recvtimer_cb(struct thread *t)
 		ptm_bfd_sess_dn(bs, BD_CONTROL_EXPIRED);
 		break;
 	}
-
-	return 0;
 }
 
 /* Was ptm_bfd_echo_detect_TO() */
-int bfd_echo_recvtimer_cb(struct thread *t)
+void bfd_echo_recvtimer_cb(struct thread *t)
 {
 	struct bfd_session *bs = THREAD_ARG(t);
 
@@ -654,8 +648,6 @@ int bfd_echo_recvtimer_cb(struct thread *t)
 		ptm_bfd_sess_dn(bs, BD_ECHO_FAILED);
 		break;
 	}
-
-	return 0;
 }
 
 struct bfd_session *bfd_session_new(void)

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -426,7 +426,7 @@ int control_init(const char *path);
 void control_shutdown(void);
 int control_notify(struct bfd_session *bs, uint8_t notify_state);
 int control_notify_config(const char *op, struct bfd_session *bs);
-int control_accept(struct thread *t);
+void control_accept(struct thread *t);
 
 
 /*
@@ -556,7 +556,7 @@ int bp_echov6_socket(const struct vrf *vrf);
 void ptm_bfd_snd(struct bfd_session *bfd, int fbit);
 void ptm_bfd_echo_snd(struct bfd_session *bfd);
 
-int bfd_recv_cb(struct thread *t);
+void bfd_recv_cb(struct thread *t);
 
 
 /*
@@ -690,10 +690,10 @@ unsigned long bfd_get_session_count(void);
 /* Export callback functions for `event.c`. */
 extern struct thread_master *master;
 
-int bfd_recvtimer_cb(struct thread *t);
-int bfd_echo_recvtimer_cb(struct thread *t);
-int bfd_xmt_cb(struct thread *t);
-int bfd_echo_xmt_cb(struct thread *t);
+void bfd_recvtimer_cb(struct thread *t);
+void bfd_echo_recvtimer_cb(struct thread *t);
+void bfd_xmt_cb(struct thread *t);
+void bfd_echo_xmt_cb(struct thread *t);
 
 extern struct in6_addr zero_addr;
 

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -531,7 +531,7 @@ static void cp_debug(bool mhop, struct sockaddr_any *peer,
 		   mhop ? "yes" : "no", peerstr, localstr, portstr, vrfstr);
 }
 
-int bfd_recv_cb(struct thread *t)
+void bfd_recv_cb(struct thread *t)
 {
 	int sd = THREAD_FD(t);
 	struct bfd_session *bfd;
@@ -552,7 +552,7 @@ int bfd_recv_cb(struct thread *t)
 	/* Handle echo packets. */
 	if (sd == bvrf->bg_echo || sd == bvrf->bg_echov6) {
 		ptm_bfd_process_echo_pkt(bvrf, sd);
-		return 0;
+		return;
 	}
 
 	/* Sanitize input/output. */
@@ -590,14 +590,14 @@ int bfd_recv_cb(struct thread *t)
 	if (mlen < BFD_PKT_LEN) {
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "too small (%ld bytes)", mlen);
-		return 0;
+		return;
 	}
 
 	/* Validate single hop packet TTL. */
 	if ((!is_mhop) && (ttl != BFD_TTL_VAL)) {
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "invalid TTL: %d expected %d", ttl, BFD_TTL_VAL);
-		return 0;
+		return;
 	}
 
 	/*
@@ -611,24 +611,24 @@ int bfd_recv_cb(struct thread *t)
 	if (BFD_GETVER(cp->diag) != BFD_VERSION) {
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "bad version %d", BFD_GETVER(cp->diag));
-		return 0;
+		return;
 	}
 
 	if (cp->detect_mult == 0) {
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "detect multiplier set to zero");
-		return 0;
+		return;
 	}
 
 	if ((cp->len < BFD_PKT_LEN) || (cp->len > mlen)) {
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid, "too small");
-		return 0;
+		return;
 	}
 
 	if (cp->discrs.my_discr == 0) {
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "'my discriminator' is zero");
-		return 0;
+		return;
 	}
 
 	/* Find the session that this packet belongs. */
@@ -636,7 +636,7 @@ int bfd_recv_cb(struct thread *t)
 	if (bfd == NULL) {
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "no session found");
-		return 0;
+		return;
 	}
 
 	/*
@@ -648,7 +648,7 @@ int bfd_recv_cb(struct thread *t)
 			cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 				 "exceeded max hop count (expected %d, got %d)",
 				 bfd->mh_ttl, ttl);
-			return 0;
+			return;
 		}
 	} else if (bfd->local_address.sa_sin.sin_family == AF_UNSPEC) {
 		bfd->local_address = local;
@@ -733,8 +733,6 @@ int bfd_recv_cb(struct thread *t)
 		/* Send the control packet with the final bit immediately. */
 		ptm_bfd_snd(bfd, 1);
 	}
-
-	return 0;
 }
 
 /*

--- a/bgpd/bgp_conditional_adv.c
+++ b/bgpd/bgp_conditional_adv.c
@@ -165,7 +165,7 @@ static void bgp_conditional_adv_routes(struct peer *peer, afi_t afi,
 /* Handler of conditional advertisement timer event.
  * Each route in the condition-map is evaluated.
  */
-static int bgp_conditional_adv_timer(struct thread *t)
+static void bgp_conditional_adv_timer(struct thread *t)
 {
 	afi_t afi;
 	safi_t safi;
@@ -286,7 +286,6 @@ static int bgp_conditional_adv_timer(struct thread *t)
 		}
 		peer->advmap_table_change = false;
 	}
-	return 0;
 }
 
 void bgp_conditional_adv_enable(struct peer *peer, afi_t afi, safi_t safi)

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -113,7 +113,7 @@ int bgp_damp_decay(time_t tdiff, int penalty, struct bgp_damp_config *bdc)
 
 /* Handler of reuse timer event.  Each route in the current reuse-list
    is evaluated.  RFC2439 Section 4.8.7.  */
-static int bgp_reuse_timer(struct thread *t)
+static void bgp_reuse_timer(struct thread *t)
 {
 	struct bgp_damp_info *bdi;
 	struct bgp_damp_info *next;
@@ -178,8 +178,6 @@ static int bgp_reuse_timer(struct thread *t)
 			 * 4.8.6).  */
 			bgp_reuse_list_add(bdi, bdc);
 	}
-
-	return 0;
 }
 
 /* A route becomes unreachable (RFC2439 Section 4.8.2).  */

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -88,7 +88,7 @@ struct bgp_dump {
 };
 
 static int bgp_dump_unset(struct bgp_dump *bgp_dump);
-static int bgp_dump_interval_func(struct thread *);
+static void bgp_dump_interval_func(struct thread *);
 
 /* BGP packet dump output buffer. */
 struct stream *bgp_dump_obuf;
@@ -439,7 +439,7 @@ static unsigned int bgp_dump_routes_func(int afi, int first_run,
 	return seq;
 }
 
-static int bgp_dump_interval_func(struct thread *t)
+static void bgp_dump_interval_func(struct thread *t)
 {
 	struct bgp_dump *bgp_dump;
 	bgp_dump = THREAD_ARG(t);
@@ -462,8 +462,6 @@ static int bgp_dump_interval_func(struct thread *t)
 	/* if interval is set reschedule */
 	if (bgp_dump->interval > 0)
 		bgp_dump_interval_add(bgp_dump, bgp_dump->interval);
-
-	return 0;
 }
 
 /* Dump common information. */

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -76,7 +76,7 @@ static void bgp_evpn_mac_update_on_es_local_chg(struct bgp_evpn_es *es,
 						bool is_local);
 
 esi_t zero_esi_buf, *zero_esi = &zero_esi_buf;
-static int bgp_evpn_run_consistency_checks(struct thread *t);
+static void bgp_evpn_run_consistency_checks(struct thread *t);
 static void bgp_evpn_path_nh_info_free(struct bgp_path_evpn_nh_info *nh_info);
 static void bgp_evpn_path_nh_unlink(struct bgp_path_evpn_nh_info *nh_info);
 
@@ -4122,7 +4122,7 @@ static uint32_t bgp_evpn_es_run_consistency_checks(struct bgp_evpn_es *es)
 	return proc_cnt;
 }
 
-static int bgp_evpn_run_consistency_checks(struct thread *t)
+static void bgp_evpn_run_consistency_checks(struct thread *t)
 {
 	int proc_cnt = 0;
 	int es_cnt = 0;
@@ -4147,8 +4147,6 @@ static int bgp_evpn_run_consistency_checks(struct thread *t)
 	thread_add_timer(bm->master, bgp_evpn_run_consistency_checks, NULL,
 			BGP_EVPN_CONS_CHECK_INTERVAL,
 			&bgp_mh_info->t_cons_check);
-
-	return 0;
 }
 
 /*****************************************************************************

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -125,11 +125,11 @@
  * Update FSM for peer based on whether we have valid nexthops or not.
  */
 extern void bgp_fsm_nht_update(struct peer *peer, bool has_valid_nexthops);
-extern int bgp_event(struct thread *);
+extern void bgp_event(struct thread *);
 extern int bgp_event_update(struct peer *, enum bgp_fsm_events event);
 extern int bgp_stop(struct peer *peer);
 extern void bgp_timer_set(struct peer *);
-extern int bgp_routeadv_timer(struct thread *);
+extern void bgp_routeadv_timer(struct thread *);
 extern void bgp_fsm_change_status(struct peer *peer, int status);
 extern const char *const peer_down_str[];
 extern void bgp_update_delay_end(struct bgp *);

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -45,8 +45,8 @@
 /* forward declarations */
 static uint16_t bgp_write(struct peer *);
 static uint16_t bgp_read(struct peer *peer, int *code_p);
-static int bgp_process_writes(struct thread *);
-static int bgp_process_reads(struct thread *);
+static void bgp_process_writes(struct thread *);
+static void bgp_process_reads(struct thread *);
 static bool validate_header(struct peer *);
 
 /* generic i/o status codes */
@@ -121,7 +121,7 @@ void bgp_reads_off(struct peer *peer)
 /*
  * Called from I/O pthread when a file descriptor has become ready for writing.
  */
-static int bgp_process_writes(struct thread *thread)
+static void bgp_process_writes(struct thread *thread)
 {
 	static struct peer *peer;
 	peer = THREAD_ARG(thread);
@@ -130,7 +130,7 @@ static int bgp_process_writes(struct thread *thread)
 	bool fatal = false;
 
 	if (peer->fd < 0)
-		return -1;
+		return;
 
 	struct frr_pthread *fpt = bgp_pth_io;
 
@@ -161,8 +161,6 @@ static int bgp_process_writes(struct thread *thread)
 		BGP_UPDATE_GROUP_TIMER_ON(&peer->t_generate_updgrp_packets,
 					  bgp_generate_updgrp_packets);
 	}
-
-	return 0;
 }
 
 /*
@@ -172,7 +170,7 @@ static int bgp_process_writes(struct thread *thread)
  * We read as much data as possible, process as many packets as we can and
  * place them on peer->ibuf for secondary processing by the main thread.
  */
-static int bgp_process_reads(struct thread *thread)
+static void bgp_process_reads(struct thread *thread)
 {
 	/* clang-format off */
 	static struct peer *peer;	// peer to read from
@@ -186,7 +184,7 @@ static int bgp_process_reads(struct thread *thread)
 	peer = THREAD_ARG(thread);
 
 	if (peer->fd < 0 || bm->terminating)
-		return -1;
+		return;
 
 	struct frr_pthread *fpt = bgp_pth_io;
 
@@ -271,8 +269,6 @@ static int bgp_process_reads(struct thread *thread)
 			thread_add_event(bm->master, bgp_process_packet,
 					 peer, 0, &peer->t_process_packet);
 	}
-
-	return 0;
 }
 
 /*

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -342,7 +342,7 @@ static void bgp_socket_set_buffer_size(const int fd)
 }
 
 /* Accept bgp connection. */
-static int bgp_accept(struct thread *thread)
+static void bgp_accept(struct thread *thread)
 {
 	int bgp_sock;
 	int accept_sock;
@@ -363,7 +363,7 @@ static int bgp_accept(struct thread *thread)
 		flog_err_sys(EC_LIB_SOCKET,
 			     "[Error] BGP accept socket fd is negative: %d",
 			     accept_sock);
-		return -1;
+		return;
 	}
 
 	thread_add_read(bm->master, bgp_accept, listener, accept_sock,
@@ -402,7 +402,7 @@ static int bgp_accept(struct thread *thread)
 				"[Error] BGP socket accept failed (%s); retrying",
 				safe_strerror(save_errno));
 		}
-		return -1;
+		return;
 	}
 	set_nonblocking(bgp_sock);
 
@@ -418,7 +418,7 @@ static int bgp_accept(struct thread *thread)
 				"[Event] Could not get instance for incoming conn from %s",
 				inet_sutop(&su, buf));
 		close(bgp_sock);
-		return -1;
+		return;
 	}
 
 	bgp_socket_set_buffer_size(bgp_sock);
@@ -451,7 +451,7 @@ static int bgp_accept(struct thread *thread)
 						      TCP_connection_open);
 			}
 
-			return 0;
+			return;
 		}
 	}
 
@@ -463,7 +463,7 @@ static int bgp_accept(struct thread *thread)
 				VRF_LOGNAME(vrf_lookup_by_id(bgp->vrf_id)));
 		}
 		close(bgp_sock);
-		return -1;
+		return;
 	}
 
 	if (CHECK_FLAG(peer1->flags, PEER_FLAG_SHUTDOWN)
@@ -474,7 +474,7 @@ static int bgp_accept(struct thread *thread)
 				inet_sutop(&su, buf), bgp->name_pretty, bgp->as,
 				VRF_LOGNAME(vrf_lookup_by_id(bgp->vrf_id)));
 		close(bgp_sock);
-		return -1;
+		return;
 	}
 
 	/*
@@ -489,7 +489,7 @@ static int bgp_accept(struct thread *thread)
 				"[Event] Closing incoming conn for %s (%p) state %d",
 				peer1->host, peer1, peer1->status);
 		close(bgp_sock);
-		return -1;
+		return;
 	}
 
 	/* Check that at least one AF is activated for the peer. */
@@ -499,7 +499,7 @@ static int bgp_accept(struct thread *thread)
 				"%s - incoming conn rejected - no AF activated for peer",
 				peer1->host);
 		close(bgp_sock);
-		return -1;
+		return;
 	}
 
 	/* Do not try to reconnect if the peer reached maximum
@@ -512,7 +512,7 @@ static int bgp_accept(struct thread *thread)
 				"[Event] Incoming BGP connection rejected from %s due to maximum-prefix or shutdown",
 				peer1->host);
 		close(bgp_sock);
-		return -1;
+		return;
 	}
 
 	if (bgp_debug_neighbor_events(peer1))
@@ -600,8 +600,6 @@ static int bgp_accept(struct thread *thread)
 	 * massage the event system to make things happy
 	 */
 	bgp_nht_interface_events(peer);
-
-	return 0;
 }
 
 /* BGP socket bind. */

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -54,7 +54,7 @@ static void register_zebra_rnh(struct bgp_nexthop_cache *bnc,
 static void unregister_zebra_rnh(struct bgp_nexthop_cache *bnc,
 				 int is_bgp_static_route);
 static int make_prefix(int afi, struct bgp_path_info *pi, struct prefix *p);
-static int bgp_nht_ifp_initial(struct thread *thread);
+static void bgp_nht_ifp_initial(struct thread *thread);
 
 static int bgp_isvalid_nexthop(struct bgp_nexthop_cache *bnc)
 {
@@ -608,14 +608,14 @@ void bgp_nht_ifp_down(struct interface *ifp)
 	bgp_nht_ifp_handle(ifp, false);
 }
 
-static int bgp_nht_ifp_initial(struct thread *thread)
+static void bgp_nht_ifp_initial(struct thread *thread)
 {
 	ifindex_t ifindex = THREAD_VAL(thread);
 	struct bgp *bgp = THREAD_ARG(thread);
 	struct interface *ifp = if_lookup_by_index(ifindex, bgp->vrf_id);
 
 	if (!ifp)
-		return 0;
+		return;
 
 	if (BGP_DEBUG(nht, NHT))
 		zlog_debug(
@@ -626,8 +626,6 @@ static int bgp_nht_ifp_initial(struct thread *thread)
 		bgp_nht_ifp_up(ifp);
 	else
 		bgp_nht_ifp_down(ifp);
-
-	return 0;
 }
 
 /*

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -79,12 +79,12 @@ extern void bgp_check_update_delay(struct bgp *);
 extern int bgp_packet_set_marker(struct stream *s, uint8_t type);
 extern void bgp_packet_set_size(struct stream *s);
 
-extern int bgp_generate_updgrp_packets(struct thread *);
-extern int bgp_process_packet(struct thread *);
+extern void bgp_generate_updgrp_packets(struct thread *);
+extern void bgp_process_packet(struct thread *);
 
 extern void bgp_send_delayed_eor(struct bgp *bgp);
 
 /* Task callback to handle socket error encountered in the io pthread */
-int bgp_packet_process_error(struct thread *thread);
+void bgp_packet_process_error(struct thread *thread);
 
 #endif /* _QUAGGA_BGP_PACKET_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2402,7 +2402,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	return true;
 }
 
-static int bgp_route_select_timer_expire(struct thread *thread)
+static void bgp_route_select_timer_expire(struct thread *thread)
 {
 	struct afi_safi_info *info;
 	afi_t afi;
@@ -2423,7 +2423,7 @@ static int bgp_route_select_timer_expire(struct thread *thread)
 	XFREE(MTYPE_TMP, info);
 
 	/* Best path selection */
-	return bgp_best_path_select_defer(bgp, afi, safi);
+	bgp_best_path_select_defer(bgp, afi, safi);
 }
 
 void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
@@ -3354,7 +3354,7 @@ void bgp_add_eoiu_mark(struct bgp *bgp)
 	work_queue_add(bgp->process_queue, pqnode);
 }
 
-static int bgp_maximum_prefix_restart_timer(struct thread *thread)
+static void bgp_maximum_prefix_restart_timer(struct thread *thread)
 {
 	struct peer *peer;
 
@@ -3368,8 +3368,6 @@ static int bgp_maximum_prefix_restart_timer(struct thread *thread)
 
 	if ((peer_clear(peer, NULL) < 0) && bgp_debug_neighbor_events(peer))
 		zlog_debug("%s: %s peer_clear failed", __func__, peer->host);
-
-	return 0;
 }
 
 static uint32_t bgp_filtered_routes_count(struct peer *peer, afi_t afi,
@@ -4710,7 +4708,7 @@ void bgp_stop_announce_route_timer(struct peer_af *paf)
  * Callback that is invoked when the route announcement timer for a
  * peer_af expires.
  */
-static int bgp_announce_route_timer_expired(struct thread *t)
+static void bgp_announce_route_timer_expired(struct thread *t)
 {
 	struct peer_af *paf;
 	struct peer *peer;
@@ -4719,17 +4717,15 @@ static int bgp_announce_route_timer_expired(struct thread *t)
 	peer = paf->peer;
 
 	if (!peer_established(peer))
-		return 0;
+		return;
 
 	if (!peer->afc_nego[paf->afi][paf->safi])
-		return 0;
+		return;
 
 	peer_af_announce_route(paf, 1);
 
 	/* Notify BGP conditional advertisement scanner percess */
 	peer->advmap_config_change[paf->afi][paf->safi] = true;
-
-	return 0;
 }
 
 /*
@@ -4879,7 +4875,7 @@ static void bgp_soft_reconfig_table(struct peer *peer, afi_t afi, safi_t safi,
  * Without splitting the full job into several part,
  * vtysh waits for the job to finish before responding to a BGP command
  */
-static int bgp_soft_reconfig_table_task(struct thread *thread)
+static void bgp_soft_reconfig_table_task(struct thread *thread)
 {
 	uint32_t iter, max_iter;
 	int ret;
@@ -4933,7 +4929,7 @@ static int bgp_soft_reconfig_table_task(struct thread *thread)
 							&table->soft_reconfig_peers);
 						bgp_soft_reconfig_table_flag(
 							table, false);
-						return 0;
+						return;
 					}
 				}
 			}
@@ -4947,7 +4943,7 @@ static int bgp_soft_reconfig_table_task(struct thread *thread)
 		table->soft_reconfig_init = false;
 		thread_add_event(bm->master, bgp_soft_reconfig_table_task,
 				 table, 0, &table->soft_reconfig_thread);
-		return 0;
+		return;
 	}
 	/* we're done, clean up the background iteration context info and
 	schedule route annoucement
@@ -4958,8 +4954,6 @@ static int bgp_soft_reconfig_table_task(struct thread *thread)
 	}
 
 	list_delete(&table->soft_reconfig_peers);
-
-	return 0;
 }
 
 
@@ -12854,7 +12848,7 @@ static void bgp_table_stats_rn(struct bgp_dest *dest, struct bgp_dest *top,
 	}
 }
 
-static int bgp_table_stats_walker(struct thread *t)
+static void bgp_table_stats_walker(struct thread *t)
 {
 	struct bgp_dest *dest, *ndest;
 	struct bgp_dest *top;
@@ -12862,7 +12856,7 @@ static int bgp_table_stats_walker(struct thread *t)
 	unsigned int space = 0;
 
 	if (!(top = bgp_table_top(ts->table)))
-		return 0;
+		return;
 
 	switch (ts->table->afi) {
 	case AFI_IP:
@@ -12875,7 +12869,7 @@ static int bgp_table_stats_walker(struct thread *t)
 		space = EVPN_ROUTE_PREFIXLEN;
 		break;
 	default:
-		return 0;
+		return;
 	}
 
 	ts->counts[BGP_STATS_MAXBITLEN] = space;
@@ -12898,8 +12892,6 @@ static int bgp_table_stats_walker(struct thread *t)
 			bgp_table_stats_rn(dest, top, ts, space);
 		}
 	}
-
-	return 0;
 }
 
 static void bgp_table_stats_all(struct vty *vty, afi_t afi, safi_t safi,
@@ -13217,7 +13209,7 @@ static void bgp_peer_count_proc(struct bgp_dest *rn, struct peer_pcounts *pc)
 	}
 }
 
-static int bgp_peer_count_walker(struct thread *t)
+static void bgp_peer_count_walker(struct thread *t)
 {
 	struct bgp_dest *rn, *rm;
 	const struct bgp_table *table;
@@ -13237,8 +13229,6 @@ static int bgp_peer_count_walker(struct thread *t)
 	} else
 		for (rn = bgp_table_top(pc->table); rn; rn = bgp_route_next(rn))
 			bgp_peer_count_proc(rn, pc);
-
-	return 0;
 }
 
 static int bgp_peer_counts(struct vty *vty, struct peer *peer, afi_t afi,

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -4042,13 +4042,11 @@ static void bgp_route_map_process_update_cb(char *rmap_name)
 	vpn_policy_routemap_event(rmap_name);
 }
 
-int bgp_route_map_update_timer(struct thread *thread)
+void bgp_route_map_update_timer(struct thread *thread)
 {
 	bm->t_rmap_update = NULL;
 
 	route_map_walk_update_list(bgp_route_map_process_update_cb);
-
-	return 0;
 }
 
 static void bgp_route_map_mark_update(const char *rmap_name)

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1157,7 +1157,7 @@ bool update_subgroup_check_merge(struct update_subgroup *subgrp,
 /*
 * update_subgroup_merge_check_thread_cb
 */
-static int update_subgroup_merge_check_thread_cb(struct thread *thread)
+static void update_subgroup_merge_check_thread_cb(struct thread *thread)
 {
 	struct update_subgroup *subgrp;
 
@@ -1166,7 +1166,6 @@ static int update_subgroup_merge_check_thread_cb(struct thread *thread)
 	subgrp->t_merge_check = NULL;
 
 	update_subgroup_check_merge(subgrp, "triggered merge check");
-	return 0;
 }
 
 /*
@@ -1803,7 +1802,7 @@ update_group_default_originate_route_map_walkcb(struct update_group *updgrp,
 	return UPDWALK_CONTINUE;
 }
 
-int update_group_refresh_default_originate_route_map(struct thread *thread)
+void update_group_refresh_default_originate_route_map(struct thread *thread)
 {
 	struct bgp *bgp;
 	char reason[] = "refresh default-originate route-map";
@@ -1813,8 +1812,6 @@ int update_group_refresh_default_originate_route_map(struct thread *thread)
 			  reason);
 	thread_cancel(&bgp->t_rmap_def_originate_eval);
 	bgp_unlock(bgp);
-
-	return 0;
 }
 
 /*

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -375,7 +375,7 @@ extern void update_group_af_walk(struct bgp *bgp, afi_t afi, safi_t safi,
 				 updgrp_walkcb cb, void *ctx);
 extern void update_group_walk(struct bgp *bgp, updgrp_walkcb cb, void *ctx);
 extern void update_group_periodic_merge(struct bgp *bgp);
-extern int
+extern void
 update_group_refresh_default_originate_route_map(struct thread *thread);
 extern void update_group_start_advtimer(struct bgp *bgp);
 

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -316,7 +316,7 @@ static void updgrp_show_adj(struct bgp *bgp, afi_t afi, safi_t safi,
 	update_group_af_walk(bgp, afi, safi, updgrp_show_adj_walkcb, &ctx);
 }
 
-static int subgroup_coalesce_timer(struct thread *thread)
+static void subgroup_coalesce_timer(struct thread *thread)
 {
 	struct update_subgroup *subgrp;
 	struct bgp *bgp;
@@ -351,8 +351,6 @@ static int subgroup_coalesce_timer(struct thread *thread)
 			BGP_TIMER_ON(peer->t_routeadv, bgp_routeadv_timer, 0);
 		}
 	}
-
-	return 0;
 }
 
 static int update_group_announce_walkcb(struct update_group *updgrp, void *arg)

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1019,7 +1019,7 @@ static bool bgp_tm_chunk_obtained;
 static uint32_t bgp_tm_min, bgp_tm_max, bgp_tm_chunk_size;
 struct bgp *bgp_tm_bgp;
 
-static int bgp_zebra_tm_connect(struct thread *t)
+static void bgp_zebra_tm_connect(struct thread *t)
 {
 	struct zclient *zclient;
 	int delay = 10, ret = 0;
@@ -1050,7 +1050,6 @@ static int bgp_zebra_tm_connect(struct thread *t)
 	}
 	thread_add_timer(bm->master, bgp_zebra_tm_connect, zclient, delay,
 			 &bgp_tm_thread_connect);
-	return 0;
 }
 
 bool bgp_zebra_tm_chunk_obtained(void)

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3044,14 +3044,12 @@ int peer_group_bind(struct bgp *bgp, union sockunion *su, struct peer *peer,
 	return 0;
 }
 
-static int bgp_startup_timer_expire(struct thread *thread)
+static void bgp_startup_timer_expire(struct thread *thread)
 {
 	struct bgp *bgp;
 
 	bgp = THREAD_ARG(thread);
 	bgp->t_startup = NULL;
-
-	return 0;
 }
 
 /*

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2226,7 +2226,7 @@ extern int peer_ttl_security_hops_unset(struct peer *);
 extern void peer_tx_shutdown_message_set(struct peer *, const char *msg);
 extern void peer_tx_shutdown_message_unset(struct peer *);
 
-extern int bgp_route_map_update_timer(struct thread *thread);
+extern void bgp_route_map_update_timer(struct thread *thread);
 extern void bgp_route_map_terminate(void);
 
 extern int peer_cmp(struct peer *p1, struct peer *p2);

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -2372,7 +2372,7 @@ static void rfapiMonitorEncapDelete(struct bgp_path_info *vpn_bpi)
  * quagga lib/thread.h says this must return int even though
  * it doesn't do anything with the return value
  */
-static int rfapiWithdrawTimerVPN(struct thread *t)
+static void rfapiWithdrawTimerVPN(struct thread *t)
 {
 	struct rfapi_withdraw *wcb = t->arg;
 	struct bgp_path_info *bpi = wcb->info;
@@ -2385,13 +2385,13 @@ static int rfapiWithdrawTimerVPN(struct thread *t)
 		vnc_zlog_debug_verbose(
                    "%s: NULL BGP pointer, assume shutdown race condition!!!",
                    __func__);
-		return 0;
+		return;
 	}
 	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS)) {
 		vnc_zlog_debug_verbose(
 			"%s: BGP delete in progress, assume shutdown race condition!!!",
 			__func__);
-		return 0;
+		return;
 	}
 	assert(wcb->node);
 	assert(bpi);
@@ -2503,7 +2503,6 @@ done:
 	RFAPI_CHECK_REFCOUNT(wcb->node, SAFI_MPLS_VPN, 1 + wcb->lockoffset);
 	agg_unlock_node(wcb->node); /* decr ref count */
 	XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
-	return 0;
 }
 
 /*
@@ -2674,7 +2673,7 @@ rfapiWithdrawEncapUpdateCachedUn(struct rfapi_import_table *import_table,
 	return 0;
 }
 
-static int rfapiWithdrawTimerEncap(struct thread *t)
+static void rfapiWithdrawTimerEncap(struct thread *t)
 {
 	struct rfapi_withdraw *wcb = t->arg;
 	struct bgp_path_info *bpi = wcb->info;
@@ -2748,7 +2747,6 @@ done:
 	agg_unlock_node(wcb->node); /* decr ref count */
 	XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 	skiplist_free(vpn_node_sl);
-	return 0;
 }
 
 
@@ -2760,7 +2758,7 @@ static void
 rfapiBiStartWithdrawTimer(struct rfapi_import_table *import_table,
 			  struct agg_node *rn, struct bgp_path_info *bpi,
 			  afi_t afi, safi_t safi,
-			  int (*timer_service_func)(struct thread *))
+			  void (*timer_service_func)(struct thread *))
 {
 	uint32_t lifetime;
 	struct rfapi_withdraw *wcb;
@@ -4062,7 +4060,7 @@ static void rfapiProcessPeerDownRt(struct peer *peer,
 	struct agg_node *rn;
 	struct bgp_path_info *bpi;
 	struct agg_table *rt;
-	int (*timer_service_func)(struct thread *);
+	void (*timer_service_func)(struct thread *);
 
 	assert(afi == AFI_IP || afi == AFI_IP6);
 

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -126,8 +126,6 @@ extern void rfapiCheckRefcount(struct agg_node *rn, safi_t safi,
 
 extern int rfapiHasNonRemovedRoutes(struct agg_node *rn);
 
-extern int rfapiProcessDeferredClose(struct thread *t);
-
 extern int rfapiGetUnAddrOfVpnBi(struct bgp_path_info *bpi, struct prefix *p);
 
 extern void rfapiNexthop2Prefix(struct attr *attr, struct prefix *p);

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -731,7 +731,7 @@ void rfapiMonitorResponseRemovalOn(struct bgp *bgp)
 	bgp->rfapi_cfg->flags &= ~BGP_VNC_CONFIG_RESPONSE_REMOVAL_DISABLE;
 }
 
-static int rfapiMonitorTimerExpire(struct thread *t)
+static void rfapiMonitorTimerExpire(struct thread *t)
 {
 	struct rfapi_monitor_vpn *m = t->arg;
 
@@ -740,8 +740,6 @@ static int rfapiMonitorTimerExpire(struct thread *t)
 
 	/* delete the monitor */
 	rfapiMonitorDel(bgp_get_default(), m->rfd, &m->p);
-
-	return 0;
 }
 
 static void rfapiMonitorTimerRestart(struct rfapi_monitor_vpn *m)
@@ -1041,7 +1039,7 @@ void rfapiMonitorMovedUp(struct rfapi_import_table *import_table,
 	}
 }
 
-static int rfapiMonitorEthTimerExpire(struct thread *t)
+static void rfapiMonitorEthTimerExpire(struct thread *t)
 {
 	struct rfapi_monitor_eth *m = t->arg;
 
@@ -1052,7 +1050,6 @@ static int rfapiMonitorEthTimerExpire(struct thread *t)
 	rfapiMonitorEthDel(bgp_get_default(), m->rfd, &m->macaddr,
 			   m->logical_net_id);
 
-	return 0;
 }
 
 static void rfapiMonitorEthTimerRestart(struct rfapi_monitor_eth *m)

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -291,7 +291,7 @@ struct rfapi_rib_tcb {
 /*
  * remove route from rib
  */
-static int rfapiRibExpireTimer(struct thread *t)
+static void rfapiRibExpireTimer(struct thread *t)
 {
 	struct rfapi_rib_tcb *tcb = t->arg;
 
@@ -328,8 +328,6 @@ static int rfapiRibExpireTimer(struct thread *t)
 	XFREE(MTYPE_RFAPI_RECENT_DELETE, tcb);
 
 	RFAPI_RIB_CHECK_COUNTS(1, 0);
-
-	return 0;
 }
 
 static void rfapiRibStartTimer(struct rfapi_descriptor *rfd,

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -1728,7 +1728,7 @@ void vnc_direct_bgp_rh_add_route(struct bgp *bgp, afi_t afi,
 	bgp_attr_unintern(&iattr);
 }
 
-static int vncExportWithdrawTimer(struct thread *t)
+static void vncExportWithdrawTimer(struct thread *t)
 {
 	struct vnc_export_info *eti = t->arg;
 	const struct prefix *p = agg_node_get_prefix(eti->node);
@@ -1747,8 +1747,6 @@ static int vncExportWithdrawTimer(struct thread *t)
 	 * Free the eti
 	 */
 	vnc_eti_delete(eti);
-
-	return 0;
 }
 
 /*

--- a/eigrpd/eigrp_filter.c
+++ b/eigrpd/eigrp_filter.c
@@ -251,13 +251,13 @@ void eigrp_distribute_update_all_wrapper(struct access_list *notused)
  *
  * @param[in]   thread  current execution thread timer is associated with
  *
- * @return int  always returns 0
+ * @return void
  *
  * @par
  * Called when 10sec waiting time expire and
  * executes Graceful restart for whole process
  */
-int eigrp_distribute_timer_process(struct thread *thread)
+void eigrp_distribute_timer_process(struct thread *thread)
 {
 	struct eigrp *eigrp;
 
@@ -265,8 +265,6 @@ int eigrp_distribute_timer_process(struct thread *thread)
 
 	/* execute GR for whole process */
 	eigrp_update_send_process_GR(eigrp, EIGRP_GR_FILTER, NULL);
-
-	return 0;
 }
 
 /*
@@ -274,13 +272,13 @@ int eigrp_distribute_timer_process(struct thread *thread)
  *
  * @param[in]   thread  current execution thread timer is associated with
  *
- * @return int  always returns 0
+ * @return void
  *
  * @par
  * Called when 10sec waiting time expire and
  * executes Graceful restart for interface
  */
-int eigrp_distribute_timer_interface(struct thread *thread)
+void eigrp_distribute_timer_interface(struct thread *thread)
 {
 	struct eigrp_interface *ei;
 
@@ -289,6 +287,4 @@ int eigrp_distribute_timer_interface(struct thread *thread)
 
 	/* execute GR for interface */
 	eigrp_update_send_interface_GR(ei, EIGRP_GR_FILTER, NULL);
-
-	return 0;
 }

--- a/eigrpd/eigrp_filter.h
+++ b/eigrpd/eigrp_filter.h
@@ -38,7 +38,7 @@ extern void eigrp_distribute_update(struct distribute_ctx *ctx,
 extern void eigrp_distribute_update_interface(struct interface *ifp);
 extern void eigrp_distribute_update_all(struct prefix_list *plist);
 extern void eigrp_distribute_update_all_wrapper(struct access_list *alist);
-extern int eigrp_distribute_timer_process(struct thread *thread);
-extern int eigrp_distribute_timer_interface(struct thread *thread);
+extern void eigrp_distribute_timer_process(struct thread *thread);
+extern void eigrp_distribute_timer_interface(struct thread *thread);
 
 #endif /* EIGRPD_EIGRP_FILTER_H_ */

--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -74,14 +74,14 @@ static const struct message eigrp_general_tlv_type_str[] = {
  *
  * @param[in]   thread  current execution thread timer is associated with
  *
- * @return int  always returns 0
+ * @return void
  *
  * @par
  * Called once per "hello" time interval, default 5 seconds
  * Sends hello packet via multicast for all interfaces eigrp
  * is configured for
  */
-int eigrp_hello_timer(struct thread *thread)
+void eigrp_hello_timer(struct thread *thread)
 {
 	struct eigrp_interface *ei;
 
@@ -97,8 +97,6 @@ int eigrp_hello_timer(struct thread *thread)
 	/* Hello timer set. */
 	thread_add_timer(master, eigrp_hello_timer, ei, ei->params.v_hello,
 			 &ei->t_hello);
-
-	return 0;
 }
 
 /**

--- a/eigrpd/eigrp_neighbor.c
+++ b/eigrpd/eigrp_neighbor.c
@@ -189,7 +189,7 @@ void eigrp_nbr_delete(struct eigrp_neighbor *nbr)
 	XFREE(MTYPE_EIGRP_NEIGHBOR, nbr);
 }
 
-int holddown_timer_expired(struct thread *thread)
+void holddown_timer_expired(struct thread *thread)
 {
 	struct eigrp_neighbor *nbr = THREAD_ARG(thread);
 	struct eigrp *eigrp = nbr->ei->eigrp;
@@ -198,8 +198,6 @@ int holddown_timer_expired(struct thread *thread)
 		  ifindex2ifname(nbr->ei->ifp->ifindex, eigrp->vrf_id));
 	nbr->state = EIGRP_NEIGHBOR_DOWN;
 	eigrp_nbr_delete(nbr);
-
-	return 0;
 }
 
 uint8_t eigrp_nbr_state_get(struct eigrp_neighbor *nbr)

--- a/eigrpd/eigrp_neighbor.h
+++ b/eigrpd/eigrp_neighbor.h
@@ -39,7 +39,7 @@ extern struct eigrp_neighbor *eigrp_nbr_get(struct eigrp_interface *ei,
 extern struct eigrp_neighbor *eigrp_nbr_new(struct eigrp_interface *ei);
 extern void eigrp_nbr_delete(struct eigrp_neighbor *neigh);
 
-extern int holddown_timer_expired(struct thread *thread);
+extern void holddown_timer_expired(struct thread *thread);
 
 extern int eigrp_neighborship_check(struct eigrp_neighbor *neigh,
 				    struct TLV_Parameter_Type *tlv);

--- a/eigrpd/eigrp_network.h
+++ b/eigrpd/eigrp_network.h
@@ -35,7 +35,7 @@ extern int eigrp_if_ipmulticast(struct eigrp *, struct prefix *, unsigned int);
 extern int eigrp_network_set(struct eigrp *eigrp, struct prefix *p);
 extern int eigrp_network_unset(struct eigrp *eigrp, struct prefix *p);
 
-extern int eigrp_hello_timer(struct thread *);
+extern void eigrp_hello_timer(struct thread *thread);
 extern void eigrp_if_update(struct interface *);
 extern int eigrp_if_add_allspfrouters(struct eigrp *, struct prefix *,
 				      unsigned int);

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -320,7 +320,7 @@ int eigrp_check_sha256_digest(struct stream *s,
 	return 1;
 }
 
-int eigrp_write(struct thread *thread)
+void eigrp_write(struct thread *thread)
 {
 	struct eigrp *eigrp = THREAD_ARG(thread);
 	struct eigrp_header *eigrph;
@@ -471,12 +471,10 @@ out:
 		thread_add_write(master, eigrp_write, eigrp, eigrp->fd,
 				 &eigrp->t_write);
 	}
-
-	return 0;
 }
 
 /* Starting point of packet process function. */
-int eigrp_read(struct thread *thread)
+void eigrp_read(struct thread *thread)
 {
 	int ret;
 	struct stream *ibuf;
@@ -500,7 +498,7 @@ int eigrp_read(struct thread *thread)
 	if (!(ibuf = eigrp_recv_packet(eigrp, eigrp->fd, &ifp, eigrp->ibuf))) {
 		/* This raw packet is known to be at least as big as its IP
 		 * header. */
-		return -1;
+		return;
 	}
 
 	/* Note that there should not be alignment problems with this assignment
@@ -531,7 +529,7 @@ int eigrp_read(struct thread *thread)
 				      eigrp->vrf_id);
 
 		if (c == NULL)
-			return 0;
+			return;
 
 		ifp = c->ifp;
 	}
@@ -546,7 +544,7 @@ int eigrp_read(struct thread *thread)
 	   must remain very accurate in doing this.
 	*/
 	if (!ei)
-		return 0;
+		return;
 
 	/* Self-originated packet should be discarded silently. */
 	if (eigrp_if_lookup_by_local_addr(eigrp, NULL, iph->ip_src)
@@ -555,7 +553,7 @@ int eigrp_read(struct thread *thread)
 			zlog_debug(
 				"eigrp_read[%pI4]: Dropping self-originated packet",
 				&srcaddr);
-		return 0;
+		return;
 	}
 
 	/* Advance from IP header to EIGRP header (iph->ip_hl has been verified
@@ -574,7 +572,7 @@ int eigrp_read(struct thread *thread)
 				"ignoring packet from router %u sent to %pI4, wrong AS Number received: %u",
 				ntohs(eigrph->vrid), &iph->ip_dst,
 				ntohs(eigrph->ASNumber));
-		return 0;
+		return;
 	}
 
 	/* If incoming interface is passive one, ignore it. */
@@ -588,7 +586,7 @@ int eigrp_read(struct thread *thread)
 		if (iph->ip_dst.s_addr == htonl(EIGRP_MULTICAST_ADDRESS)) {
 			eigrp_if_set_multicast(ei);
 		}
-		return 0;
+		return;
 	}
 
 	/* else it must be a local eigrp interface, check it was received on
@@ -599,7 +597,7 @@ int eigrp_read(struct thread *thread)
 			zlog_warn(
 				"Packet from [%pI4] received on wrong link %s",
 				&iph->ip_src, ifp->name);
-		return 0;
+		return;
 	}
 
 	/* Verify more EIGRP header fields. */
@@ -609,7 +607,7 @@ int eigrp_read(struct thread *thread)
 			zlog_debug(
 				"eigrp_read[%pI4]: Header check failed, dropping.",
 				&iph->ip_src);
-		return ret;
+		return;
 	}
 
 	/* calcualte the eigrp packet length, and move the pounter to the
@@ -700,8 +698,6 @@ int eigrp_read(struct thread *thread)
 			IF_NAME(ei), opcode);
 		break;
 	}
-
-	return 0;
 }
 
 static struct stream *eigrp_recv_packet(struct eigrp *eigrp,
@@ -989,7 +985,7 @@ static int eigrp_check_network_mask(struct eigrp_interface *ei,
 	return 0;
 }
 
-int eigrp_unack_packet_retrans(struct thread *thread)
+void eigrp_unack_packet_retrans(struct thread *thread)
 {
 	struct eigrp_neighbor *nbr;
 	nbr = (struct eigrp_neighbor *)THREAD_ARG(thread);
@@ -1005,8 +1001,10 @@ int eigrp_unack_packet_retrans(struct thread *thread)
 		eigrp_fifo_push(nbr->ei->obuf, duplicate);
 
 		ep->retrans_counter++;
-		if (ep->retrans_counter == EIGRP_PACKET_RETRANS_MAX)
-			return eigrp_retrans_count_exceeded(ep, nbr);
+		if (ep->retrans_counter == EIGRP_PACKET_RETRANS_MAX) {
+			eigrp_retrans_count_exceeded(ep, nbr);
+			return;
+		}
 
 		/*Start retransmission timer*/
 		thread_add_timer(master, eigrp_unack_packet_retrans, nbr,
@@ -1021,11 +1019,9 @@ int eigrp_unack_packet_retrans(struct thread *thread)
 		thread_add_write(master, eigrp_write, nbr->ei->eigrp,
 				 nbr->ei->eigrp->fd, &nbr->ei->eigrp->t_write);
 	}
-
-	return 0;
 }
 
-int eigrp_unack_multicast_packet_retrans(struct thread *thread)
+void eigrp_unack_multicast_packet_retrans(struct thread *thread)
 {
 	struct eigrp_neighbor *nbr;
 	nbr = (struct eigrp_neighbor *)THREAD_ARG(thread);
@@ -1040,8 +1036,10 @@ int eigrp_unack_multicast_packet_retrans(struct thread *thread)
 		eigrp_fifo_push(nbr->ei->obuf, duplicate);
 
 		ep->retrans_counter++;
-		if (ep->retrans_counter == EIGRP_PACKET_RETRANS_MAX)
-			return eigrp_retrans_count_exceeded(ep, nbr);
+		if (ep->retrans_counter == EIGRP_PACKET_RETRANS_MAX) {
+			eigrp_retrans_count_exceeded(ep, nbr);
+			return;
+		}
 
 		/*Start retransmission timer*/
 		thread_add_timer(master, eigrp_unack_multicast_packet_retrans,
@@ -1056,8 +1054,6 @@ int eigrp_unack_multicast_packet_retrans(struct thread *thread)
 		thread_add_write(master, eigrp_write, nbr->ei->eigrp,
 				 nbr->ei->eigrp->fd, &nbr->ei->eigrp->t_write);
 	}
-
-	return 0;
 }
 
 /* Get packet from tail of fifo. */

--- a/eigrpd/eigrp_packet.h
+++ b/eigrpd/eigrp_packet.h
@@ -33,8 +33,8 @@
 #define _ZEBRA_EIGRP_PACKET_H
 
 /*Prototypes*/
-extern int eigrp_read(struct thread *);
-extern int eigrp_write(struct thread *);
+extern void eigrp_read(struct thread *thread);
+extern void eigrp_write(struct thread *thread);
 
 extern struct eigrp_packet *eigrp_packet_new(size_t size,
 					     struct eigrp_neighbor *nbr);
@@ -66,8 +66,8 @@ extern uint16_t eigrp_add_authTLV_MD5_to_stream(struct stream *s,
 extern uint16_t eigrp_add_authTLV_SHA256_to_stream(struct stream *s,
 						   struct eigrp_interface *ei);
 
-extern int eigrp_unack_packet_retrans(struct thread *thread);
-extern int eigrp_unack_multicast_packet_retrans(struct thread *thread);
+extern void eigrp_unack_packet_retrans(struct thread *thread);
+extern void eigrp_unack_multicast_packet_retrans(struct thread *thread);
 
 /*
  * untill there is reason to have their own header, these externs are found in
@@ -80,7 +80,7 @@ extern void eigrp_hello_send_ack(struct eigrp_neighbor *nbr);
 extern void eigrp_hello_receive(struct eigrp *eigrp, struct ip *iph,
 				struct eigrp_header *eigrph, struct stream *s,
 				struct eigrp_interface *ei, int size);
-extern int eigrp_hello_timer(struct thread *thread);
+extern void eigrp_hello_timer(struct thread *thread);
 
 /*
  * These externs are found in eigrp_update.c
@@ -96,7 +96,7 @@ extern void eigrp_update_send_all(struct eigrp *eigrp,
 				  struct eigrp_interface *exception);
 extern void eigrp_update_send_init(struct eigrp_neighbor *nbr);
 extern void eigrp_update_send_EOT(struct eigrp_neighbor *nbr);
-extern int eigrp_update_send_GR_thread(struct thread *thread);
+extern void eigrp_update_send_GR_thread(struct thread *thread);
 extern void eigrp_update_send_GR(struct eigrp_neighbor *nbr,
 				 enum GR_type gr_type, struct vty *vty);
 extern void eigrp_update_send_interface_GR(struct eigrp_interface *ei,

--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -910,7 +910,7 @@ static void eigrp_update_send_GR_part(struct eigrp_neighbor *nbr)
  *
  * Uses nbr_gr_packet_type and t_nbr_send_gr from neighbor.
  */
-int eigrp_update_send_GR_thread(struct thread *thread)
+void eigrp_update_send_GR_thread(struct thread *thread)
 {
 	struct eigrp_neighbor *nbr;
 
@@ -923,7 +923,7 @@ int eigrp_update_send_GR_thread(struct thread *thread)
 	if (nbr->retrans_queue->count > 0) {
 		thread_add_timer_msec(master, eigrp_update_send_GR_thread, nbr,
 				      10, &nbr->t_nbr_send_gr);
-		return 0;
+		return;
 	}
 
 	/* send GR EIGRP packet chunk */
@@ -933,8 +933,6 @@ int eigrp_update_send_GR_thread(struct thread *thread)
 	if (nbr->nbr_gr_packet_type != EIGRP_PACKET_PART_LAST) {
 		thread_execute(master, eigrp_update_send_GR_thread, nbr, 0);
 	}
-
-	return 0;
 }
 
 /**

--- a/isisd/fabricd.c
+++ b/isisd/fabricd.c
@@ -250,7 +250,7 @@ void fabricd_finish(struct fabricd *f)
 	hash_free(f->neighbors_neighbors);
 }
 
-static int fabricd_initial_sync_timeout(struct thread *thread)
+static void fabricd_initial_sync_timeout(struct thread *thread)
 {
 	struct fabricd *f = THREAD_ARG(thread);
 
@@ -258,7 +258,6 @@ static int fabricd_initial_sync_timeout(struct thread *thread)
 		  f->initial_sync_circuit->interface->name);
 	f->initial_sync_state = FABRICD_SYNC_PENDING;
 	f->initial_sync_circuit = NULL;
-	return 0;
 }
 
 void fabricd_initial_sync_hello(struct isis_circuit *circuit)
@@ -399,22 +398,21 @@ static uint8_t fabricd_calculate_fabric_tier(struct isis_area *area)
 	return tier;
 }
 
-static int fabricd_tier_set_timer(struct thread *thread)
+static void fabricd_tier_set_timer(struct thread *thread)
 {
 	struct fabricd *f = THREAD_ARG(thread);
 
 	fabricd_set_tier(f, f->tier_pending);
-	return 0;
 }
 
-static int fabricd_tier_calculation_cb(struct thread *thread)
+static void fabricd_tier_calculation_cb(struct thread *thread)
 {
 	struct fabricd *f = THREAD_ARG(thread);
 	uint8_t tier = ISIS_TIER_UNDEFINED;
 
 	tier = fabricd_calculate_fabric_tier(f->area);
 	if (tier == ISIS_TIER_UNDEFINED)
-		return 0;
+		return;
 
 	zlog_info("OpenFabric: Got tier %hhu from algorithm. Arming timer.",
 		  tier);
@@ -423,7 +421,6 @@ static int fabricd_tier_calculation_cb(struct thread *thread)
 			 f->area->lsp_gen_interval[ISIS_LEVEL2 - 1],
 			 &f->tier_set_timer);
 
-	return 0;
 }
 
 static void fabricd_bump_tier_calculation_timer(struct fabricd *f)

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -448,7 +448,7 @@ const char *isis_adj_yang_state(enum isis_adj_state state)
 	}
 }
 
-int isis_adj_expire(struct thread *thread)
+void isis_adj_expire(struct thread *thread)
 {
 	struct isis_adjacency *adj;
 
@@ -461,8 +461,6 @@ int isis_adj_expire(struct thread *thread)
 
 	/* trigger the adj expire event */
 	isis_adj_state_change(&adj, ISIS_ADJ_DOWN, "holding time expired");
-
-	return 0;
 }
 
 /*

--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -141,13 +141,13 @@ void isis_adj_state_change(struct isis_adjacency **adj,
 			   enum isis_adj_state state, const char *reason);
 void isis_adj_print(struct isis_adjacency *adj);
 const char *isis_adj_yang_state(enum isis_adj_state state);
-int isis_adj_expire(struct thread *thread);
+void isis_adj_expire(struct thread *thread);
 void isis_adj_print_vty(struct isis_adjacency *adj, struct vty *vty,
 			char detail);
 void isis_adj_build_neigh_list(struct list *adjdb, struct list *list);
 void isis_adj_build_up_list(struct list *adjdb, struct list *list);
 int isis_adj_usage2levels(enum isis_adj_usage usage);
-int isis_bfd_startup_timer(struct thread *thread);
+void isis_bfd_startup_timer(struct thread *thread);
 const char *isis_adj_name(const struct isis_adjacency *adj);
 
 #endif /* ISIS_ADJACENCY_H */

--- a/isisd/isis_dr.c
+++ b/isisd/isis_dr.c
@@ -61,7 +61,7 @@ const char *isis_disflag2string(int disflag)
 	return NULL; /* not reached */
 }
 
-int isis_run_dr(struct thread *thread)
+void isis_run_dr(struct thread *thread)
 {
 	struct isis_circuit_arg *arg = THREAD_ARG(thread);
 
@@ -76,7 +76,7 @@ int isis_run_dr(struct thread *thread)
 		zlog_warn("%s: scheduled for non broadcast circuit from %s:%d",
 			  __func__, thread->xref->xref.file,
 			  thread->xref->xref.line);
-		return ISIS_WARNING;
+		return;
 	}
 
 	if (circuit->u.bc.run_dr_elect[level - 1])
@@ -84,8 +84,6 @@ int isis_run_dr(struct thread *thread)
 
 	circuit->u.bc.t_run_dr[level - 1] = NULL;
 	circuit->u.bc.run_dr_elect[level - 1] = 1;
-
-	return ISIS_OK;
 }
 
 static int isis_check_dr_change(struct isis_adjacency *adj, int level)

--- a/isisd/isis_dr.h
+++ b/isisd/isis_dr.h
@@ -24,7 +24,7 @@
 #ifndef _ZEBRA_ISIS_DR_H
 #define _ZEBRA_ISIS_DR_H
 
-int isis_run_dr(struct thread *thread);
+void isis_run_dr(struct thread *thread);
 int isis_dr_elect(struct isis_circuit *circuit, int level);
 int isis_dr_resign(struct isis_circuit *circuit, int level);
 int isis_dr_commence(struct isis_circuit *circuit, int level);

--- a/isisd/isis_dynhn.c
+++ b/isisd/isis_dynhn.c
@@ -42,7 +42,7 @@
 
 DEFINE_MTYPE_STATIC(ISISD, ISIS_DYNHN, "ISIS dyn hostname");
 
-static int dyn_cache_cleanup(struct thread *);
+static void dyn_cache_cleanup(struct thread *);
 
 void dyn_cache_init(struct isis *isis)
 {
@@ -67,7 +67,7 @@ void dyn_cache_finish(struct isis *isis)
 	list_delete(&isis->dyn_cache);
 }
 
-static int dyn_cache_cleanup(struct thread *thread)
+static void dyn_cache_cleanup(struct thread *thread)
 {
 	struct listnode *node, *nnode;
 	struct isis_dynhn *dyn;
@@ -87,8 +87,6 @@ static int dyn_cache_cleanup(struct thread *thread)
 
 	thread_add_timer(master, dyn_cache_cleanup, isis, 120,
 			&isis->t_dync_clean);
-
-	return ISIS_OK;
 }
 
 struct isis_dynhn *dynhn_find_by_id(struct isis *isis, const uint8_t *id)

--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -209,7 +209,7 @@ void isis_circuit_is_type_set(struct isis_circuit *circuit, int newtype)
 
 /* events supporting code */
 
-int isis_event_dis_status_change(struct thread *thread)
+void isis_event_dis_status_change(struct thread *thread)
 {
 	struct isis_circuit *circuit;
 
@@ -217,15 +217,13 @@ int isis_event_dis_status_change(struct thread *thread)
 
 	/* invalid arguments */
 	if (!circuit || !circuit->area)
-		return 0;
+		return;
 	if (IS_DEBUG_EVENTS)
 		zlog_debug("ISIS-Evt (%s) DIS status change",
 			   circuit->area->area_tag);
 
 	/* LSP generation again */
 	lsp_regenerate_schedule(circuit->area, IS_LEVEL_1 | IS_LEVEL_2, 0);
-
-	return 0;
 }
 
 void isis_event_auth_failure(char *area_tag, const char *error_string,

--- a/isisd/isis_events.h
+++ b/isisd/isis_events.h
@@ -31,7 +31,7 @@ void isis_event_circuit_type_change(struct isis_circuit *circuit, int newtype);
 /*
  * Events related to adjacencies
  */
-int isis_event_dis_status_change(struct thread *thread);
+void isis_event_dis_status_change(struct thread *thread);
 
 /*
  * Error events

--- a/isisd/isis_ldp_sync.c
+++ b/isisd/isis_ldp_sync.c
@@ -344,7 +344,7 @@ void isis_ldp_sync_set_if_metric(struct isis_circuit *circuit, bool run_regen)
 /*
  * LDP-SYNC holddown timer routines
  */
-static int isis_ldp_sync_holddown_timer(struct thread *thread)
+static void isis_ldp_sync_holddown_timer(struct thread *thread)
 {
 	struct isis_circuit *circuit;
 	struct ldp_sync_info *ldp_sync_info;
@@ -355,7 +355,7 @@ static int isis_ldp_sync_holddown_timer(struct thread *thread)
 	 */
 	circuit = THREAD_ARG(thread);
 	if (circuit->ldp_sync_info == NULL)
-		return 0;
+		return;
 
 	ldp_sync_info = circuit->ldp_sync_info;
 
@@ -366,7 +366,6 @@ static int isis_ldp_sync_holddown_timer(struct thread *thread)
 		  circuit->interface->name);
 
 	isis_ldp_sync_set_if_metric(circuit, true);
-	return 0;
 }
 
 void isis_ldp_sync_holddown_timer_add(struct isis_circuit *circuit)

--- a/isisd/isis_lfa.c
+++ b/isisd/isis_lfa.c
@@ -1401,7 +1401,7 @@ static struct rlfa *rlfa_lookup(struct isis_spftree *spftree,
 	return rlfa_tree_find(&spftree->lfa.remote.rlfas, &s);
 }
 
-static int isis_area_verify_routes_cb(struct thread *thread)
+static void isis_area_verify_routes_cb(struct thread *thread)
 {
 	struct isis_area *area = THREAD_ARG(thread);
 
@@ -1409,8 +1409,6 @@ static int isis_area_verify_routes_cb(struct thread *thread)
 		zlog_debug("ISIS-LFA: updating RLFAs in the RIB");
 
 	isis_area_verify_routes(area);
-
-	return 0;
 }
 
 static mpls_label_t rlfa_nexthop_label(struct isis_spftree *spftree,

--- a/isisd/isis_lsp.h
+++ b/isisd/isis_lsp.h
@@ -65,7 +65,7 @@ DECLARE_RBTREE_UNIQ(lspdb, struct isis_lsp, dbe, lspdb_compare);
 
 void lsp_db_init(struct lspdb_head *head);
 void lsp_db_fini(struct lspdb_head *head);
-int lsp_tick(struct thread *thread);
+void lsp_tick(struct thread *thread);
 
 int lsp_generate(struct isis_area *area, int level);
 #define lsp_regenerate_schedule(area, level, all_pseudo) \

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -1793,11 +1793,10 @@ int isis_handle_pdu(struct isis_circuit *circuit, uint8_t *ssnpa)
 	return retval;
 }
 
-int isis_receive(struct thread *thread)
+void isis_receive(struct thread *thread)
 {
 	struct isis_circuit *circuit;
 	uint8_t ssnpa[ETH_ALEN];
-	int retval;
 
 	/*
 	 * Get the circuit
@@ -1809,20 +1808,22 @@ int isis_receive(struct thread *thread)
 
 	isis_circuit_stream(circuit, &circuit->rcv_stream);
 
+#if ISIS_METHOD != ISIS_METHOD_BPF
+	int retval;
+
 	retval = circuit->rx(circuit, ssnpa);
 
-#if ISIS_METHOD != ISIS_METHOD_BPF
 	if (retval == ISIS_OK)
-		retval = isis_handle_pdu(circuit, ssnpa);
-#endif //ISIS_METHOD != ISIS_METHOD_BPF
+		isis_handle_pdu(circuit, ssnpa);
+#else // ISIS_METHOD != ISIS_METHOD_BPF
+	circuit->rx(circuit, ssnpa);
+#endif
 
 	/*
 	 * prepare for next packet.
 	 */
 	if (!circuit->is_passive)
 		isis_circuit_prepare(circuit);
-
-	return retval;
 }
 
 /*
@@ -2015,7 +2016,7 @@ int send_hello(struct isis_circuit *circuit, int level)
 	return retval;
 }
 
-static int send_hello_cb(struct thread *thread)
+static void send_hello_cb(struct thread *thread)
 {
 	struct isis_circuit_arg *arg = THREAD_ARG(thread);
 	assert(arg);
@@ -2030,30 +2031,29 @@ static int send_hello_cb(struct thread *thread)
 		send_hello(circuit, 1);
 		send_hello_sched(circuit, ISIS_LEVEL1,
 				 1000 * circuit->hello_interval[1]);
-		return ISIS_OK;
+		return;
 	}
 
 	if (circuit->circ_type != CIRCUIT_T_BROADCAST) {
 		zlog_warn("ISIS-Hello (%s): Trying to send hello on unknown circuit type %d",
 			  circuit->area->area_tag, circuit->circ_type);
-		return ISIS_WARNING;
+		return;
 	}
 
 	circuit->u.bc.t_send_lan_hello[level - 1] = NULL;
 	if (!(circuit->is_type & level)) {
 		zlog_warn("ISIS-Hello (%s): Trying to send L%d IIH in L%d-only circuit",
 			  circuit->area->area_tag, level, 3 - level);
-		return ISIS_WARNING;
+		return;
 	}
 
 	if (circuit->u.bc.run_dr_elect[level - 1])
 		isis_dr_elect(circuit, level);
 
-	int rv = send_hello(circuit, level);
+	send_hello(circuit, level);
 
 	/* set next timer thread */
 	send_hello_sched(circuit, level, 1000 * circuit->hello_interval[level - 1]);
-	return rv;
 }
 
 static void _send_hello_sched(struct isis_circuit *circuit,
@@ -2247,7 +2247,7 @@ int send_csnp(struct isis_circuit *circuit, int level)
 	return ISIS_OK;
 }
 
-int send_l1_csnp(struct thread *thread)
+void send_l1_csnp(struct thread *thread)
 {
 	struct isis_circuit *circuit;
 
@@ -2265,11 +2265,9 @@ int send_l1_csnp(struct thread *thread)
 	thread_add_timer(master, send_l1_csnp, circuit,
 			 isis_jitter(circuit->csnp_interval[0], CSNP_JITTER),
 			 &circuit->t_send_csnp[0]);
-
-	return ISIS_OK;
 }
 
-int send_l2_csnp(struct thread *thread)
+void send_l2_csnp(struct thread *thread)
 {
 	struct isis_circuit *circuit;
 
@@ -2287,8 +2285,6 @@ int send_l2_csnp(struct thread *thread)
 	thread_add_timer(master, send_l2_csnp, circuit,
 			 isis_jitter(circuit->csnp_interval[1], CSNP_JITTER),
 			 &circuit->t_send_csnp[1]);
-
-	return ISIS_OK;
 }
 
 /*
@@ -2405,7 +2401,7 @@ static int send_psnp(int level, struct isis_circuit *circuit)
 	return ISIS_OK;
 }
 
-int send_l1_psnp(struct thread *thread)
+void send_l1_psnp(struct thread *thread)
 {
 
 	struct isis_circuit *circuit;
@@ -2420,15 +2416,13 @@ int send_l1_psnp(struct thread *thread)
 	thread_add_timer(master, send_l1_psnp, circuit,
 			 isis_jitter(circuit->psnp_interval[0], PSNP_JITTER),
 			 &circuit->t_send_psnp[0]);
-
-	return ISIS_OK;
 }
 
 /*
  *  7.3.15.4 action on expiration of partial SNP interval
  *  level 2
  */
-int send_l2_psnp(struct thread *thread)
+void send_l2_psnp(struct thread *thread)
 {
 	struct isis_circuit *circuit;
 
@@ -2443,8 +2437,6 @@ int send_l2_psnp(struct thread *thread)
 	thread_add_timer(master, send_l2_psnp, circuit,
 			 isis_jitter(circuit->psnp_interval[1], PSNP_JITTER),
 			 &circuit->t_send_psnp[1]);
-
-	return ISIS_OK;
 }
 
 /*

--- a/isisd/isis_pdu.h
+++ b/isisd/isis_pdu.h
@@ -195,7 +195,7 @@ struct isis_partial_seqnum_hdr {
 /*
  * Function for receiving IS-IS PDUs
  */
-int isis_receive(struct thread *thread);
+void isis_receive(struct thread *thread);
 
 /*
  * calling arguments for snp_process ()
@@ -210,10 +210,10 @@ int isis_receive(struct thread *thread);
  */
 void send_hello_sched(struct isis_circuit *circuit, int level, long delay);
 int send_csnp(struct isis_circuit *circuit, int level);
-int send_l1_csnp(struct thread *thread);
-int send_l2_csnp(struct thread *thread);
-int send_l1_psnp(struct thread *thread);
-int send_l2_psnp(struct thread *thread);
+void send_l1_csnp(struct thread *thread);
+void send_l2_csnp(struct thread *thread);
+void send_l1_psnp(struct thread *thread);
+void send_l2_psnp(struct thread *thread);
 void send_lsp(struct isis_circuit *circuit,
 	      struct isis_lsp *lsp, enum isis_tx_type tx_type);
 void fill_fixed_hdr(uint8_t pdu_type, struct stream *stream);

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1832,7 +1832,7 @@ void isis_spf_invalidate_routes(struct isis_spftree *tree)
 	tree->route_table_backup->cleanup = isis_route_node_cleanup;
 }
 
-static int isis_run_spf_cb(struct thread *thread)
+static void isis_run_spf_cb(struct thread *thread)
 {
 	struct isis_spf_run *run = THREAD_ARG(thread);
 	struct isis_area *area = run->area;
@@ -1845,7 +1845,7 @@ static int isis_run_spf_cb(struct thread *thread)
 		if (IS_DEBUG_SPF_EVENTS)
 			zlog_warn("ISIS-SPF (%s) area does not share level",
 				  area->area_tag);
-		return ISIS_WARNING;
+		return;
 	}
 
 	isis_area_delete_backup_adj_sids(area, level);
@@ -1883,8 +1883,6 @@ static int isis_run_spf_cb(struct thread *thread)
 		UNSET_FLAG(circuit->flags, ISIS_CIRCUIT_FLAPPED_AFTER_SPF);
 
 	fabricd_run_spf(area);
-
-	return 0;
 }
 
 static struct isis_spf_run *isis_run_spf_arg(struct isis_area *area, int level)

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -1090,7 +1090,7 @@ DEFUN(show_sr_node, show_sr_node_cmd,
  *
  * @return		1 on success
  */
-static int sr_start_label_manager(struct thread *start)
+static void sr_start_label_manager(struct thread *start)
 {
 	struct isis_area *area;
 
@@ -1098,8 +1098,6 @@ static int sr_start_label_manager(struct thread *start)
 
 	/* re-attempt to start SR & Label Manager connection */
 	isis_sr_start(area);
-
-	return 1;
 }
 
 /**

--- a/isisd/isis_tx_queue.c
+++ b/isisd/isis_tx_queue.c
@@ -114,7 +114,7 @@ static struct isis_tx_queue_entry *tx_queue_find(struct isis_tx_queue *queue,
 	return hash_lookup(queue->hash, &e);
 }
 
-static int tx_queue_send_event(struct thread *thread)
+static void tx_queue_send_event(struct thread *thread)
 {
 	struct isis_tx_queue_entry *e = THREAD_ARG(thread);
 	struct isis_tx_queue *queue = e->queue;
@@ -128,8 +128,6 @@ static int tx_queue_send_event(struct thread *thread)
 
 	queue->send_event(queue->circuit, e->lsp, e->type);
 	/* Don't access e here anymore, send_event might have destroyed it */
-
-	return 0;
 }
 
 void _isis_tx_queue_add(struct isis_tx_queue *queue,

--- a/ldpd/adjacency.c
+++ b/ldpd/adjacency.c
@@ -26,12 +26,12 @@
 #include "log.h"
 
 static __inline int adj_compare(const struct adj *, const struct adj *);
-static int	 adj_itimer(struct thread *);
+static void adj_itimer(struct thread *);
 static __inline int tnbr_compare(const struct tnbr *, const struct tnbr *);
 static void	 tnbr_del(struct ldpd_conf *, struct tnbr *);
 static void	 tnbr_start(struct tnbr *);
 static void	 tnbr_stop(struct tnbr *);
-static int	 tnbr_hello_timer(struct thread *);
+static void tnbr_hello_timer(struct thread *);
 static void	 tnbr_start_hello_timer(struct tnbr *);
 static void	 tnbr_stop_hello_timer(struct tnbr *);
 
@@ -172,8 +172,7 @@ adj_get_af(const struct adj *adj)
 /* adjacency timers */
 
 /* ARGSUSED */
-static int
-adj_itimer(struct thread *thread)
+static void adj_itimer(struct thread *thread)
 {
 	struct adj *adj = THREAD_ARG(thread);
 
@@ -187,13 +186,11 @@ adj_itimer(struct thread *thread)
 		    adj->source.target->rlfa_count == 0) {
 			/* remove dynamic targeted neighbor */
 			tnbr_del(leconf, adj->source.target);
-			return (0);
+			return;
 		}
 	}
 
 	adj_del(adj, S_HOLDTIME_EXP);
-
-	return (0);
 }
 
 void
@@ -345,16 +342,13 @@ tnbr_get_hello_interval(struct tnbr *tnbr)
 /* target neighbors timers */
 
 /* ARGSUSED */
-static int
-tnbr_hello_timer(struct thread *thread)
+static void tnbr_hello_timer(struct thread *thread)
 {
 	struct tnbr	*tnbr = THREAD_ARG(thread);
 
 	tnbr->hello_timer = NULL;
 	send_hello(HELLO_TARGETED, NULL, tnbr);
 	tnbr_start_hello_timer(tnbr);
-
-	return (0);
 }
 
 static void

--- a/ldpd/control.c
+++ b/ldpd/control.c
@@ -26,11 +26,11 @@
 
 #define	CONTROL_BACKLOG	5
 
-static int		 control_accept(struct thread *);
+static void control_accept(struct thread *);
 static struct ctl_conn	*control_connbyfd(int);
 static struct ctl_conn	*control_connbypid(pid_t);
 static void		 control_close(int);
-static int		 control_dispatch_imsg(struct thread *);
+static void control_dispatch_imsg(struct thread *);
 
 struct ctl_conns	 ctl_conns;
 
@@ -101,8 +101,7 @@ control_cleanup(char *path)
 }
 
 /* ARGSUSED */
-static int
-control_accept(struct thread *thread)
+static void control_accept(struct thread *thread)
 {
 	int			 connfd;
 	socklen_t		 len;
@@ -121,14 +120,14 @@ control_accept(struct thread *thread)
 		else if (errno != EWOULDBLOCK && errno != EINTR &&
 		    errno != ECONNABORTED)
 			log_warn("%s: accept", __func__);
-		return (0);
+		return;
 	}
 	sock_set_nonblock(connfd);
 
 	if ((c = calloc(1, sizeof(struct ctl_conn))) == NULL) {
 		log_warn(__func__);
 		close(connfd);
-		return (0);
+		return;
 	}
 
 	imsg_init(&c->iev.ibuf, connfd);
@@ -140,8 +139,6 @@ control_accept(struct thread *thread)
 	c->iev.ev_write = NULL;
 
 	TAILQ_INSERT_TAIL(&ctl_conns, c, entry);
-
-	return (0);
 }
 
 static struct ctl_conn *
@@ -191,8 +188,7 @@ control_close(int fd)
 }
 
 /* ARGSUSED */
-static int
-control_dispatch_imsg(struct thread *thread)
+static void control_dispatch_imsg(struct thread *thread)
 {
 	int		 fd = THREAD_FD(thread);
 	struct ctl_conn	*c;
@@ -202,7 +198,7 @@ control_dispatch_imsg(struct thread *thread)
 
 	if ((c = control_connbyfd(fd)) == NULL) {
 		log_warnx("%s: fd %d: not found", __func__, fd);
-		return (0);
+		return;
 	}
 
 	c->iev.ev_read = NULL;
@@ -210,13 +206,13 @@ control_dispatch_imsg(struct thread *thread)
 	if (((n = imsg_read(&c->iev.ibuf)) == -1 && errno != EAGAIN) ||
 	    n == 0) {
 		control_close(fd);
-		return (0);
+		return;
 	}
 
 	for (;;) {
 		if ((n = imsg_get(&c->iev.ibuf, &imsg)) == -1) {
 			control_close(fd);
-			return (0);
+			return;
 		}
 
 		if (n == 0)
@@ -278,8 +274,6 @@ control_dispatch_imsg(struct thread *thread)
 	}
 
 	imsg_event_add(&c->iev);
-
-	return (0);
 }
 
 int

--- a/ldpd/interface.c
+++ b/ldpd/interface.c
@@ -33,7 +33,7 @@ static struct if_addr	*if_addr_lookup(struct if_addr_head *, struct kaddr *);
 static int		 if_start(struct iface *, int);
 static int		 if_reset(struct iface *, int);
 static void		 if_update_af(struct iface_af *);
-static int		 if_hello_timer(struct thread *);
+static void if_hello_timer(struct thread *thread);
 static void		 if_start_hello_timer(struct iface_af *);
 static void		 if_stop_hello_timer(struct iface_af *);
 static int		 if_join_ipv4_group(struct iface *, struct in_addr *);
@@ -43,7 +43,7 @@ static int		 if_leave_ipv6_group(struct iface *, struct in6_addr *);
 
 static int ldp_sync_fsm_init(struct iface *iface, int state);
 static int ldp_sync_act_iface_start_sync(struct iface *iface);
-static int iface_wait_for_ldp_sync_timer(struct thread *thread);
+static void iface_wait_for_ldp_sync_timer(struct thread *thread);
 static void start_wait_for_ldp_sync_timer(struct iface *iface);
 static void stop_wait_for_ldp_sync_timer(struct iface *iface);
 static int ldp_sync_act_ldp_start_sync(struct iface *iface);
@@ -455,16 +455,13 @@ if_get_wait_for_sync_interval(void)
 
 /* timers */
 /* ARGSUSED */
-static int
-if_hello_timer(struct thread *thread)
+static void if_hello_timer(struct thread *thread)
 {
 	struct iface_af		*ia = THREAD_ARG(thread);
 
 	ia->hello_timer = NULL;
 	send_hello(HELLO_LINK, ia, NULL);
 	if_start_hello_timer(ia);
-
-	return (0);
 }
 
 static void
@@ -737,14 +734,11 @@ ldp_sync_act_iface_start_sync(struct iface *iface)
 	return (0);
 }
 
-static int
-iface_wait_for_ldp_sync_timer(struct thread *thread)
+static void iface_wait_for_ldp_sync_timer(struct thread *thread)
 {
 	struct iface *iface = THREAD_ARG(thread);
 
 	ldp_sync_fsm(iface, LDP_SYNC_EVT_LDP_SYNC_COMPLETE);
-
-	return (0);
 }
 
 static void start_wait_for_ldp_sync_timer(struct iface *iface)

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -41,8 +41,8 @@
 #include "libfrr.h"
 
 static void		 lde_shutdown(void);
-static int		 lde_dispatch_imsg(struct thread *);
-static int		 lde_dispatch_parent(struct thread *);
+static void lde_dispatch_imsg(struct thread *thread);
+static void lde_dispatch_parent(struct thread *thread);
 static __inline	int	 lde_nbr_compare(const struct lde_nbr *,
 			    const struct lde_nbr *);
 static struct lde_nbr	*lde_nbr_new(uint32_t, struct lde_nbr *);
@@ -243,8 +243,7 @@ lde_imsg_compose_ldpe(int type, uint32_t peerid, pid_t pid, void *data,
 }
 
 /* ARGSUSED */
-static int
-lde_dispatch_imsg(struct thread *thread)
+static void lde_dispatch_imsg(struct thread *thread)
 {
 	struct imsgev		*iev = THREAD_ARG(thread);
 	struct imsgbuf		*ibuf = &iev->ibuf;
@@ -422,13 +421,10 @@ lde_dispatch_imsg(struct thread *thread)
 		thread_cancel(&iev->ev_write);
 		lde_shutdown();
 	}
-
-	return (0);
 }
 
 /* ARGSUSED */
-static int
-lde_dispatch_parent(struct thread *thread)
+static void lde_dispatch_parent(struct thread *thread)
 {
 	static struct ldpd_conf	*nconf;
 	struct iface		*iface, *niface;
@@ -710,8 +706,6 @@ lde_dispatch_parent(struct thread *thread)
 		thread_cancel(&iev->ev_write);
 		lde_shutdown();
 	}
-
-	return (0);
 }
 
 int
@@ -2173,11 +2167,9 @@ lde_address_list_free(struct lde_nbr *ln)
 /*
  * Event callback used to retry the label-manager sync zapi session.
  */
-static int zclient_sync_retry(struct thread *thread)
+static void zclient_sync_retry(struct thread *thread)
 {
 	zclient_sync_init();
-
-	return 0;
 }
 
 /*

--- a/ldpd/lde.h
+++ b/ldpd/lde.h
@@ -227,7 +227,7 @@ void		 lde_check_withdraw(struct map *, struct lde_nbr *);
 void		 lde_check_withdraw_wcard(struct map *, struct lde_nbr *);
 int		 lde_wildcard_apply(struct map *, struct fec *,
 		    struct lde_map *);
-int		 lde_gc_timer(struct thread *);
+void lde_gc_timer(struct thread *thread);
 void		 lde_gc_start_timer(void);
 void		 lde_gc_stop_timer(void);
 

--- a/ldpd/lde_lib.c
+++ b/ldpd/lde_lib.c
@@ -1037,8 +1037,7 @@ lde_wildcard_apply(struct map *wcard, struct fec *fec, struct lde_map *me)
 /* gabage collector timer: timer to remove dead entries from the LIB */
 
 /* ARGSUSED */
-int
-lde_gc_timer(struct thread *thread)
+void lde_gc_timer(struct thread *thread)
 {
 	struct fec	*fec, *safe;
 	struct fec_node	*fn;
@@ -1064,8 +1063,6 @@ lde_gc_timer(struct thread *thread)
 		log_debug("%s: %u entries removed", __func__, count);
 
 	lde_gc_start_timer();
-
-	return (0);
 }
 
 void

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -46,8 +46,8 @@
 
 static void		 ldpd_shutdown(void);
 static pid_t		 start_child(enum ldpd_process, char *, int, int);
-static int		 main_dispatch_ldpe(struct thread *);
-static int		 main_dispatch_lde(struct thread *);
+static void main_dispatch_ldpe(struct thread *thread);
+static void main_dispatch_lde(struct thread *thread);
 static int		 main_imsg_send_ipc_sockets(struct imsgbuf *,
 			    struct imsgbuf *);
 static void		 main_imsg_send_net_sockets(int);
@@ -219,7 +219,7 @@ FRR_DAEMON_INFO(ldpd, LDP,
 	.n_yang_modules = array_size(ldpd_yang_modules),
 );
 
-static int ldp_config_fork_apply(struct thread *t)
+static void ldp_config_fork_apply(struct thread *t)
 {
 	/*
 	 * So the frr_config_fork() function schedules
@@ -231,8 +231,6 @@ static int ldp_config_fork_apply(struct thread *t)
 	 * after the read in of the config.
 	 */
 	ldp_config_apply(NULL, vty_conf);
-
-	return 0;
 }
 
 int
@@ -563,8 +561,7 @@ start_child(enum ldpd_process p, char *argv0, int fd_async, int fd_sync)
 
 /* imsg handling */
 /* ARGSUSED */
-static int
-main_dispatch_ldpe(struct thread *thread)
+static void main_dispatch_ldpe(struct thread *thread)
 {
 	struct imsgev		*iev = THREAD_ARG(thread);
 	struct imsgbuf		*ibuf = &iev->ibuf;
@@ -627,13 +624,10 @@ main_dispatch_ldpe(struct thread *thread)
 		else
 			kill(lde_pid, SIGTERM);
 	}
-
-	return (0);
 }
 
 /* ARGSUSED */
-static int
-main_dispatch_lde(struct thread *thread)
+static void main_dispatch_lde(struct thread *thread)
 {
 	struct imsgev	*iev = THREAD_ARG(thread);
 	struct imsgbuf	*ibuf = &iev->ibuf;
@@ -735,13 +729,10 @@ main_dispatch_lde(struct thread *thread)
 		else
 			kill(ldpe_pid, SIGTERM);
 	}
-
-	return (0);
 }
 
 /* ARGSUSED */
-int
-ldp_write_handler(struct thread *thread)
+void ldp_write_handler(struct thread *thread)
 {
 	struct imsgev	*iev = THREAD_ARG(thread);
 	struct imsgbuf	*ibuf = &iev->ibuf;
@@ -755,12 +746,10 @@ ldp_write_handler(struct thread *thread)
 		/* this pipe is dead, so remove the event handlers */
 		thread_cancel(&iev->ev_read);
 		thread_cancel(&iev->ev_write);
-		return (0);
+		return;
 	}
 
 	imsg_event_add(iev);
-
-	return (0);
 }
 
 void
@@ -828,9 +817,8 @@ evbuf_event_add(struct evbuf *eb)
 				 &eb->ev);
 }
 
-void
-evbuf_init(struct evbuf *eb, int fd, int (*handler)(struct thread *),
-    void *arg)
+void evbuf_init(struct evbuf *eb, int fd, void (*handler)(struct thread *),
+		void *arg)
 {
 	msgbuf_init(&eb->wbuf);
 	eb->wbuf.fd = fd;

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -63,15 +63,15 @@
 struct evbuf {
 	struct msgbuf		 wbuf;
 	struct thread		*ev;
-	int			 (*handler)(struct thread *);
+	void (*handler)(struct thread *);
 	void			*arg;
 };
 
 struct imsgev {
 	struct imsgbuf		 ibuf;
-	int			(*handler_write)(struct thread *);
+	void (*handler_write)(struct thread *);
 	struct thread		*ev_write;
-	int			(*handler_read)(struct thread *);
+	void (*handler_read)(struct thread *);
 	struct thread		*ev_read;
 };
 
@@ -792,7 +792,7 @@ void		 sa2addr(struct sockaddr *, int *, union ldpd_addr *,
 socklen_t	 sockaddr_len(struct sockaddr *);
 
 /* ldpd.c */
-int			 ldp_write_handler(struct thread *);
+void ldp_write_handler(struct thread *thread);
 void			 main_imsg_compose_ldpe(int, pid_t, void *, uint16_t);
 void			 main_imsg_compose_lde(int, pid_t, void *, uint16_t);
 int			 main_imsg_compose_both(enum imsg_type, void *,
@@ -802,8 +802,7 @@ int			 imsg_compose_event(struct imsgev *, uint16_t, uint32_t,
 			    pid_t, int, void *, uint16_t);
 void			 evbuf_enqueue(struct evbuf *, struct ibuf *);
 void			 evbuf_event_add(struct evbuf *);
-void			 evbuf_init(struct evbuf *, int,
-			    int (*)(struct thread *), void *);
+void evbuf_init(struct evbuf *, int, void (*)(struct thread *), void *);
 void			 evbuf_clear(struct evbuf *);
 int			 ldp_acl_request(struct imsgev *, char *, int,
 			    union ldpd_addr *, uint8_t);

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -36,10 +36,10 @@
 #include "libfrr.h"
 
 static void	 ldpe_shutdown(void);
-static int	 ldpe_dispatch_main(struct thread *);
-static int	 ldpe_dispatch_lde(struct thread *);
+static void ldpe_dispatch_main(struct thread *thread);
+static void ldpe_dispatch_lde(struct thread *thread);
 #ifdef __OpenBSD__
-static int	 ldpe_dispatch_pfkey(struct thread *);
+static void ldpe_dispatch_pfkey(struct thread *thread);
 #endif
 static void	 ldpe_setup_sockets(int, int, int, int);
 static void	 ldpe_close_sockets(int);
@@ -273,8 +273,7 @@ ldpe_imsg_compose_lde(int type, uint32_t peerid, pid_t pid, void *data,
 }
 
 /* ARGSUSED */
-static int
-ldpe_dispatch_main(struct thread *thread)
+static void ldpe_dispatch_main(struct thread *thread)
 {
 	static struct ldpd_conf	*nconf;
 	struct iface		*niface;
@@ -631,13 +630,10 @@ ldpe_dispatch_main(struct thread *thread)
 		thread_cancel(&iev->ev_write);
 		ldpe_shutdown();
 	}
-
-	return (0);
 }
 
 /* ARGSUSED */
-static int
-ldpe_dispatch_lde(struct thread *thread)
+static void ldpe_dispatch_lde(struct thread *thread)
 {
 	struct imsgev		*iev = THREAD_ARG(thread);
 	struct imsgbuf		*ibuf = &iev->ibuf;
@@ -770,14 +766,11 @@ ldpe_dispatch_lde(struct thread *thread)
 		thread_cancel(&iev->ev_write);
 		ldpe_shutdown();
 	}
-
-	return (0);
 }
 
 #ifdef __OpenBSD__
 /* ARGSUSED */
-static int
-ldpe_dispatch_pfkey(struct thread *thread)
+static void ldpe_dispatch_pfkey(struct thread *thread)
 {
 	int	 fd = THREAD_FD(thread);
 
@@ -786,8 +779,6 @@ ldpe_dispatch_pfkey(struct thread *thread)
 
 	if (pfkey_read(fd, NULL) == -1)
 		fatal("pfkey_read failed, exiting...");
-
-	return (0);
 }
 #endif /* __OpenBSD__ */
 

--- a/ldpd/ldpe.h
+++ b/ldpd/ldpe.h
@@ -148,7 +148,7 @@ extern struct nbr_pid_head	 nbrs_by_pid;
 
 /* accept.c */
 void	accept_init(void);
-int	accept_add(int, int (*)(struct thread *), void *);
+int accept_add(int, void (*)(struct thread *), void *);
 void	accept_del(int);
 void	accept_pause(void);
 void	accept_unpause(void);
@@ -292,8 +292,8 @@ int			 gen_ldp_hdr(struct ibuf *, uint16_t);
 int			 gen_msg_hdr(struct ibuf *, uint16_t, uint16_t);
 int			 send_packet(int, int, union ldpd_addr *,
 			    struct iface_af *, void *, size_t);
-int			 disc_recv_packet(struct thread *);
-int			 session_accept(struct thread *);
+void disc_recv_packet(struct thread *thread);
+void session_accept(struct thread *thread);
 void			 session_accept_nbr(struct nbr *, int);
 void			 session_shutdown(struct nbr *, uint32_t, uint32_t,
 			    uint32_t);

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -28,12 +28,12 @@
 
 static struct iface		*disc_find_iface(unsigned int, int,
 				    union ldpd_addr *);
-static int			 session_read(struct thread *);
-static int			 session_write(struct thread *);
+static void session_read(struct thread *thread);
+static void session_write(struct thread *thread);
 static ssize_t			 session_get_pdu(struct ibuf_read *, char **);
 static void			 tcp_close(struct tcp_conn *);
 static struct pending_conn	*pending_conn_new(int, int, union ldpd_addr *);
-static int			 pending_conn_timeout(struct thread *);
+static void pending_conn_timeout(struct thread *thread);
 
 int
 gen_ldp_hdr(struct ibuf *buf, uint16_t size)
@@ -106,8 +106,7 @@ send_packet(int fd, int af, union ldpd_addr *dst, struct iface_af *ia,
 }
 
 /* Discovery functions */
-int
-disc_recv_packet(struct thread *thread)
+void disc_recv_packet(struct thread *thread)
 {
 	int			 fd = THREAD_FD(thread);
 	struct thread		**threadp = THREAD_ARG(thread);
@@ -158,7 +157,7 @@ disc_recv_packet(struct thread *thread)
 		if (errno != EAGAIN && errno != EINTR)
 			log_debug("%s: read error: %s", __func__,
 			    strerror(errno));
-		return (0);
+		return;
 	}
 
 	sa2addr((struct sockaddr *)&from, &af, &src, NULL);
@@ -205,7 +204,7 @@ disc_recv_packet(struct thread *thread)
 	if (bad_addr(af, &src)) {
 		log_debug("%s: invalid source address: %s", __func__,
 		    log_addr(af, &src));
-		return (0);
+		return;
 	}
 	ifindex = getsockopt_ifindex(af, &m);
 
@@ -213,7 +212,7 @@ disc_recv_packet(struct thread *thread)
 	if (multicast) {
 		iface = disc_find_iface(ifindex, af, &src);
 		if (iface == NULL)
-			return (0);
+			return;
 	}
 
 	/* check packet size */
@@ -221,7 +220,7 @@ disc_recv_packet(struct thread *thread)
 	if (len < (LDP_HDR_SIZE + LDP_MSG_SIZE) || len > LDP_MAX_LEN) {
 		log_debug("%s: bad packet size, source %s", __func__,
 		    log_addr(af, &src));
-		return (0);
+		return;
 	}
 
 	/* LDP header sanity checks */
@@ -229,12 +228,12 @@ disc_recv_packet(struct thread *thread)
 	if (ntohs(ldp_hdr.version) != LDP_VERSION) {
 		log_debug("%s: invalid LDP version %d, source %s", __func__,
 		    ntohs(ldp_hdr.version), log_addr(af, &src));
-		return (0);
+		return;
 	}
 	if (ntohs(ldp_hdr.lspace_id) != 0) {
 		log_debug("%s: invalid label space %u, source %s", __func__,
 		    ntohs(ldp_hdr.lspace_id), log_addr(af, &src));
-		return (0);
+		return;
 	}
 	/* check "PDU Length" field */
 	pdu_len = ntohs(ldp_hdr.length);
@@ -242,7 +241,7 @@ disc_recv_packet(struct thread *thread)
 	    (pdu_len > (len - LDP_HDR_DEAD_LEN))) {
 		log_debug("%s: invalid LDP packet length %u, source %s",
 		    __func__, ntohs(ldp_hdr.length), log_addr(af, &src));
-		return (0);
+		return;
 	}
 	buf += LDP_HDR_SIZE;
 	len -= LDP_HDR_SIZE;
@@ -261,7 +260,7 @@ disc_recv_packet(struct thread *thread)
 	if (msg_len < LDP_MSG_LEN || ((msg_len + LDP_MSG_DEAD_LEN) > pdu_len)) {
 		log_debug("%s: invalid LDP message length %u, source %s",
 		    __func__, ntohs(msg.length), log_addr(af, &src));
-		return (0);
+		return;
 	}
 	buf += LDP_MSG_SIZE;
 	len -= LDP_MSG_SIZE;
@@ -275,8 +274,6 @@ disc_recv_packet(struct thread *thread)
 		log_debug("%s: unknown LDP packet type, source %s", __func__,
 		    log_addr(af, &src));
 	}
-
-	return (0);
 }
 
 static struct iface *
@@ -304,8 +301,7 @@ disc_find_iface(unsigned int ifindex, int af, union ldpd_addr *src)
 	return (iface);
 }
 
-int
-session_accept(struct thread *thread)
+void session_accept(struct thread *thread)
 {
 	int			 fd = THREAD_FD(thread);
 	struct sockaddr_storage	 src;
@@ -328,7 +324,7 @@ session_accept(struct thread *thread)
 		    errno != ECONNABORTED)
 			log_debug("%s: accept error: %s", __func__,
 			    strerror(errno));
-		return (0);
+		return;
 	}
 	sock_set_nonblock(newfd);
 
@@ -357,22 +353,20 @@ session_accept(struct thread *thread)
 			close(newfd);
 		else
 			pending_conn_new(newfd, af, &addr);
-		return (0);
+		return;
 	}
 	/* protection against buggy implementations */
 	if (nbr_session_active_role(nbr)) {
 		close(newfd);
-		return (0);
+		return;
 	}
 	if (nbr->state != NBR_STA_PRESENT) {
 		log_debug("%s: lsr-id %pI4: rejecting additional transport connection", __func__, &nbr->id);
 		close(newfd);
-		return (0);
+		return;
 	}
 
 	session_accept_nbr(nbr, newfd);
-
-	return (0);
 }
 
 void
@@ -411,8 +405,7 @@ session_accept_nbr(struct nbr *nbr, int fd)
 	nbr_fsm(nbr, NBR_EVT_MATCH_ADJ);
 }
 
-static int
-session_read(struct thread *thread)
+static void session_read(struct thread *thread)
 {
 	int		 fd = THREAD_FD(thread);
 	struct nbr	*nbr = THREAD_ARG(thread);
@@ -431,16 +424,16 @@ session_read(struct thread *thread)
 		if (errno != EINTR && errno != EAGAIN) {
 			log_warn("%s: read error", __func__);
 			nbr_fsm(nbr, NBR_EVT_CLOSE_SESSION);
-			return (0);
+			return;
 		}
 		/* retry read */
-		return (0);
+		return;
 	}
 	if (n == 0) {
 		/* connection closed */
 		log_debug("%s: connection closed by remote end", __func__);
 		nbr_fsm(nbr, NBR_EVT_CLOSE_SESSION);
-		return (0);
+		return;
 	}
 	tcp->rbuf->wpos += n;
 
@@ -450,7 +443,7 @@ session_read(struct thread *thread)
 		if (ntohs(ldp_hdr->version) != LDP_VERSION) {
 			session_shutdown(nbr, S_BAD_PROTO_VER, 0, 0);
 			free(buf);
-			return (0);
+			return;
 		}
 
 		pdu_len = ntohs(ldp_hdr->length);
@@ -467,14 +460,14 @@ session_read(struct thread *thread)
 		    pdu_len > max_pdu_len) {
 			session_shutdown(nbr, S_BAD_PDU_LEN, 0, 0);
 			free(buf);
-			return (0);
+			return;
 		}
 		pdu_len -= LDP_HDR_PDU_LEN;
 		if (ldp_hdr->lsr_id != nbr->id.s_addr ||
 		    ldp_hdr->lspace_id != 0) {
 			session_shutdown(nbr, S_BAD_LDP_ID, 0, 0);
 			free(buf);
-			return (0);
+			return;
 		}
 		pdu += LDP_HDR_SIZE;
 		len -= LDP_HDR_SIZE;
@@ -492,7 +485,7 @@ session_read(struct thread *thread)
 				session_shutdown(nbr, S_BAD_MSG_LEN, msg->id,
 				    msg->type);
 				free(buf);
-				return (0);
+				return;
 			}
 			msg_size = msg_len + LDP_MSG_DEAD_LEN;
 			pdu_len -= msg_size;
@@ -505,7 +498,7 @@ session_read(struct thread *thread)
 					session_shutdown(nbr, S_SHUTDOWN,
 					    msg->id, msg->type);
 					free(buf);
-					return (0);
+					return;
 				}
 				break;
 			case MSG_TYPE_KEEPALIVE:
@@ -514,7 +507,7 @@ session_read(struct thread *thread)
 					session_shutdown(nbr, S_SHUTDOWN,
 					    msg->id, msg->type);
 					free(buf);
-					return (0);
+					return;
 				}
 				break;
 			case MSG_TYPE_NOTIFICATION:
@@ -524,7 +517,7 @@ session_read(struct thread *thread)
 					session_shutdown(nbr, S_SHUTDOWN,
 					    msg->id, msg->type);
 					free(buf);
-					return (0);
+					return;
 				}
 				break;
 			}
@@ -571,7 +564,7 @@ session_read(struct thread *thread)
 			if (ret == -1) {
 				/* parser failed, giving up */
 				free(buf);
-				return (0);
+				return;
 			}
 
 			/* no errors - update per neighbor message counters */
@@ -618,7 +611,7 @@ session_read(struct thread *thread)
 		buf = NULL;
 		if (len != 0) {
 			session_shutdown(nbr, S_BAD_PDU_LEN, 0, 0);
-			return (0);
+			return;
 		}
 	}
 
@@ -626,11 +619,9 @@ session_read(struct thread *thread)
 	 * allocated - but let's get rid of the SA warning.
 	 */
 	free(buf);
-	return (0);
 }
 
-static int
-session_write(struct thread *thread)
+static void session_write(struct thread *thread)
 {
 	struct tcp_conn *tcp = THREAD_ARG(thread);
 	struct nbr	*nbr = tcp->nbr;
@@ -647,12 +638,10 @@ session_write(struct thread *thread)
 		 * close the socket.
 		 */
 		tcp_close(tcp);
-		return (0);
+		return;
 	}
 
 	evbuf_event_add(&tcp->wbuf);
-
-	return (0);
 }
 
 void
@@ -817,8 +806,7 @@ pending_conn_find(int af, union ldpd_addr *addr)
 	return (NULL);
 }
 
-static int
-pending_conn_timeout(struct thread *thread)
+static void pending_conn_timeout(struct thread *thread)
 {
 	struct pending_conn	*pconn = THREAD_ARG(thread);
 	struct tcp_conn		*tcp;
@@ -837,6 +825,4 @@ pending_conn_timeout(struct thread *thread)
 	msgbuf_write(&tcp->wbuf.wbuf);
 
 	pending_conn_del(pconn);
-
-	return (0);
 }

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -46,7 +46,7 @@ static struct list *events = NULL;
 
 static void agentx_events_update(void);
 
-static int agentx_timeout(struct thread *t)
+static void agentx_timeout(struct thread *t)
 {
 	timeout_thr = NULL;
 
@@ -54,10 +54,9 @@ static int agentx_timeout(struct thread *t)
 	run_alarms();
 	netsnmp_check_outstanding_agent_requests();
 	agentx_events_update();
-	return 0;
 }
 
-static int agentx_read(struct thread *t)
+static void agentx_read(struct thread *t)
 {
 	fd_set fds;
 	int flags, new_flags = 0;
@@ -72,7 +71,7 @@ static int agentx_read(struct thread *t)
 	if (-1 == flags) {
 		flog_err(EC_LIB_SYSTEM_CALL, "Failed to get FD settings fcntl: %s(%d)",
 			 strerror(errno), errno);
-		return -1;
+		return;
 	}
 
 	if (flags & O_NONBLOCK)
@@ -101,7 +100,6 @@ static int agentx_read(struct thread *t)
 
 	netsnmp_check_outstanding_agent_requests();
 	agentx_events_update();
-	return 0;
 }
 
 static void agentx_events_update(void)

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -461,14 +461,14 @@ static bool _bfd_sess_valid(const struct bfd_session_params *bsp)
 	return true;
 }
 
-static int _bfd_sess_send(struct thread *t)
+static void _bfd_sess_send(struct thread *t)
 {
 	struct bfd_session_params *bsp = THREAD_ARG(t);
 	int rv;
 
 	/* Validate configuration before trying to send bogus data. */
 	if (!_bfd_sess_valid(bsp))
-		return 0;
+		return;
 
 	if (bsp->lastev == BSE_INSTALL) {
 		bsp->args.command = bsp->installed ? ZEBRA_BFD_DEST_UPDATE
@@ -478,7 +478,7 @@ static int _bfd_sess_send(struct thread *t)
 
 	/* If not installed and asked for uninstall, do nothing. */
 	if (!bsp->installed && bsp->args.command == ZEBRA_BFD_DEST_DEREGISTER)
-		return 0;
+		return;
 
 	rv = zclient_bfd_command(bsglobal.zc, &bsp->args);
 	/* Command was sent successfully. */
@@ -504,8 +504,6 @@ static int _bfd_sess_send(struct thread *t)
 			bsp->lastev == BSE_INSTALL ? "installed"
 						   : "uninstalled");
 	}
-
-	return 0;
 }
 
 static void _bfd_sess_remove(struct bfd_session_params *bsp)

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -237,18 +237,16 @@ void frr_pthread_stop_all(void)
  */
 
 /* dummy task for sleeper pipe */
-static int fpt_dummy(struct thread *thread)
+static void fpt_dummy(struct thread *thread)
 {
-	return 0;
 }
 
 /* poison pill task to end event loop */
-static int fpt_finish(struct thread *thread)
+static void fpt_finish(struct thread *thread)
 {
 	struct frr_pthread *fpt = THREAD_ARG(thread);
 
 	atomic_store_explicit(&fpt->running, false, memory_order_relaxed);
-	return 0;
 }
 
 /* stop function, called from other threads to halt this one */

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -962,7 +962,7 @@ static void frr_daemonize(void)
  * to read the config in after thread execution starts, so that
  * we can match this behavior.
  */
-static int frr_config_read_in(struct thread *t)
+static void frr_config_read_in(struct thread *t)
 {
 	hook_call(frr_config_pre, master);
 
@@ -1000,8 +1000,6 @@ static int frr_config_read_in(struct thread *t)
 	}
 
 	hook_call(frr_config_post, master);
-
-	return 0;
 }
 
 void frr_config_fork(void)
@@ -1097,7 +1095,7 @@ static void frr_terminal_close(int isexit)
 
 static struct thread *daemon_ctl_thread = NULL;
 
-static int frr_daemon_ctl(struct thread *t)
+static void frr_daemon_ctl(struct thread *t)
 {
 	char buf[1];
 	ssize_t nr;
@@ -1106,7 +1104,7 @@ static int frr_daemon_ctl(struct thread *t)
 	if (nr < 0 && (errno == EINTR || errno == EAGAIN))
 		goto out;
 	if (nr <= 0)
-		return 0;
+		return;
 
 	switch (buf[0]) {
 	case 'S': /* SIGTSTP */
@@ -1131,7 +1129,6 @@ static int frr_daemon_ctl(struct thread *t)
 out:
 	thread_add_read(master, frr_daemon_ctl, NULL, daemon_ctl_sock,
 			&daemon_ctl_thread);
-	return 0;
 }
 
 void frr_detach(void)

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -347,7 +347,7 @@ int nb_cli_confirmed_commit_rollback(struct vty *vty)
 	return ret;
 }
 
-static int nb_cli_confirmed_commit_timeout(struct thread *thread)
+static void nb_cli_confirmed_commit_timeout(struct thread *thread)
 {
 	struct vty *vty = THREAD_ARG(thread);
 
@@ -357,8 +357,6 @@ static int nb_cli_confirmed_commit_timeout(struct thread *thread)
 
 	nb_cli_confirmed_commit_rollback(vty);
 	nb_cli_confirmed_commit_clean(vty);
-
-	return 0;
 }
 
 static int nb_cli_commit(struct vty *vty, bool force,

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -206,7 +206,7 @@ template <typename Q, typename S> class NewRpcState : RpcStateBase
 	}
 
 
-	static int c_callback(struct thread *thread)
+	static void c_callback(struct thread *thread)
 	{
 		auto _tag = static_cast<NewRpcState<Q, S> *>(thread->arg);
 		/*
@@ -225,7 +225,7 @@ template <typename Q, typename S> class NewRpcState : RpcStateBase
 
 		pthread_cond_signal(&_tag->cond);
 		pthread_mutex_unlock(&_tag->cmux);
-		return 0;
+		return;
 	}
 	NewRpcState<Q, S> *orig;
 
@@ -1368,7 +1368,7 @@ static int frr_grpc_finish(void)
  * fork. This is done by scheduling this init function as an event task, since
  * the event loop doesn't run until after fork.
  */
-static int frr_grpc_module_very_late_init(struct thread *thread)
+static void frr_grpc_module_very_late_init(struct thread *thread)
 {
 	const char *args = THIS_MODULE->load_args;
 	uint port = GRPC_DEFAULT_PORT;
@@ -1386,11 +1386,10 @@ static int frr_grpc_module_very_late_init(struct thread *thread)
 	if (frr_grpc_init(port) < 0)
 		goto error;
 
-	return 0;
+	return;
 
 error:
 	flog_err(EC_LIB_GRPC_INIT, "failed to initialize the gRPC module");
-	return -1;
 }
 
 static int frr_grpc_module_late_init(struct thread_master *tm)

--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -41,7 +41,7 @@ static sr_session_ctx_t *session;
 static sr_conn_ctx_t *connection;
 static struct nb_transaction *transaction;
 
-static int frr_sr_read_cb(struct thread *thread);
+static void frr_sr_read_cb(struct thread *thread);
 static int frr_sr_finish(void);
 
 /* Convert FRR YANG data value to sysrepo YANG data value. */
@@ -526,7 +526,7 @@ static int frr_sr_notification_send(const char *xpath, struct list *arguments)
 	return NB_OK;
 }
 
-static int frr_sr_read_cb(struct thread *thread)
+static void frr_sr_read_cb(struct thread *thread)
 {
 	struct yang_module *module = THREAD_ARG(thread);
 	int fd = THREAD_FD(thread);
@@ -536,12 +536,10 @@ static int frr_sr_read_cb(struct thread *thread)
 	if (ret != SR_ERR_OK) {
 		flog_err(EC_LIB_LIBSYSREPO, "%s: sr_fd_event_process(): %s",
 			 __func__, sr_strerror(ret));
-		return -1;
+		return;
 	}
 
 	thread_add_read(master, frr_sr_read_cb, module, fd, &module->sr_thread);
-
-	return 0;
 }
 
 static void frr_sr_subscribe_config(struct yang_module *module)

--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -104,17 +104,15 @@ static void resolver_fd_drop_maybe(struct resolver_fd *resfd)
 
 static void resolver_update_timeouts(struct resolver_state *r);
 
-static int resolver_cb_timeout(struct thread *t)
+static void resolver_cb_timeout(struct thread *t)
 {
 	struct resolver_state *r = THREAD_ARG(t);
 
 	ares_process(r->channel, NULL, NULL);
 	resolver_update_timeouts(r);
-
-	return 0;
 }
 
-static int resolver_cb_socket_readable(struct thread *t)
+static void resolver_cb_socket_readable(struct thread *t)
 {
 	struct resolver_fd *resfd = THREAD_ARG(t);
 	struct resolver_state *r = resfd->state;
@@ -127,11 +125,9 @@ static int resolver_cb_socket_readable(struct thread *t)
 	 */
 	ares_process_fd(r->channel, resfd->fd, ARES_SOCKET_BAD);
 	resolver_update_timeouts(r);
-
-	return 0;
 }
 
-static int resolver_cb_socket_writable(struct thread *t)
+static void resolver_cb_socket_writable(struct thread *t)
 {
 	struct resolver_fd *resfd = THREAD_ARG(t);
 	struct resolver_state *r = resfd->state;
@@ -144,8 +140,6 @@ static int resolver_cb_socket_writable(struct thread *t)
 	 */
 	ares_process_fd(r->channel, ARES_SOCKET_BAD, resfd->fd);
 	resolver_update_timeouts(r);
-
-	return 0;
 }
 
 static void resolver_update_timeouts(struct resolver_state *r)
@@ -232,7 +226,7 @@ static void ares_address_cb(void *arg, int status, int timeouts,
 	callback(query, NULL, i, &addr[0]);
 }
 
-static int resolver_cb_literal(struct thread *t)
+static void resolver_cb_literal(struct thread *t)
 {
 	struct resolver_query *query = THREAD_ARG(t);
 	void (*callback)(struct resolver_query *, const char *, int,
@@ -242,7 +236,6 @@ static int resolver_cb_literal(struct thread *t)
 	query->callback = NULL;
 
 	callback(query, ARES_SUCCESS, 1, &query->literal_addr);
-	return 0;
 }
 
 void resolver_resolve(struct resolver_query *query, int af, vrf_id_t vrf_id,

--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -143,7 +143,7 @@ int frr_sigevent_process(void)
 
 #ifdef SIGEVENT_SCHEDULE_THREAD
 /* timer thread to check signals. shouldn't be needed */
-int frr_signal_timer(struct thread *t)
+void frr_signal_timer(struct thread *t)
 {
 	struct frr_sigevent_master_t *sigm;
 
@@ -151,7 +151,7 @@ int frr_signal_timer(struct thread *t)
 	sigm->t = NULL;
 	thread_add_timer(sigm->t->master, frr_signal_timer, &sigmaster,
 			 FRR_SIGNAL_TIMER_INTERVAL, &sigm->t);
-	return frr_sigevent_process();
+	frr_sigevent_process();
 }
 #endif /* SIGEVENT_SCHEDULE_THREAD */
 

--- a/lib/spf_backoff.c
+++ b/lib/spf_backoff.c
@@ -117,17 +117,16 @@ void spf_backoff_free(struct spf_backoff *backoff)
 	XFREE(MTYPE_SPF_BACKOFF, backoff);
 }
 
-static int spf_backoff_timetolearn_elapsed(struct thread *thread)
+static void spf_backoff_timetolearn_elapsed(struct thread *thread)
 {
 	struct spf_backoff *backoff = THREAD_ARG(thread);
 
 	backoff->state = SPF_BACKOFF_LONG_WAIT;
 	backoff_debug("SPF Back-off(%s) TIMETOLEARN elapsed, move to state %s",
 		      backoff->name, spf_backoff_state2str(backoff->state));
-	return 0;
 }
 
-static int spf_backoff_holddown_elapsed(struct thread *thread)
+static void spf_backoff_holddown_elapsed(struct thread *thread)
 {
 	struct spf_backoff *backoff = THREAD_ARG(thread);
 
@@ -136,7 +135,6 @@ static int spf_backoff_holddown_elapsed(struct thread *thread)
 	backoff->state = SPF_BACKOFF_QUIET;
 	backoff_debug("SPF Back-off(%s) HOLDDOWN elapsed, move to state %s",
 		      backoff->name, spf_backoff_state2str(backoff->state));
-	return 0;
 }
 
 long spf_backoff_schedule(struct spf_backoff *backoff)

--- a/lib/systemd.c
+++ b/lib/systemd.c
@@ -80,14 +80,13 @@ void systemd_send_stopping(void)
 
 static struct thread_master *systemd_master = NULL;
 
-static int systemd_send_watchdog(struct thread *t)
+static void systemd_send_watchdog(struct thread *t)
 {
 	systemd_send_information("WATCHDOG=1");
 
 	assert(watchdog_msec > 0);
 	thread_add_timer_msec(systemd_master, systemd_send_watchdog, NULL,
 			      watchdog_msec, NULL);
-	return 1;
 }
 
 void systemd_send_started(struct thread_master *m)

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -773,7 +773,7 @@ char *thread_timer_to_hhmmss(char *buf, int buf_size,
 
 /* Get new thread.  */
 static struct thread *thread_get(struct thread_master *m, uint8_t type,
-				 int (*func)(struct thread *), void *arg,
+				 void (*func)(struct thread *), void *arg,
 				 const struct xref_threadsched *xref)
 {
 	struct thread *thread = thread_list_pop(&m->unuse);
@@ -930,7 +930,7 @@ done:
 /* Add new read thread. */
 void _thread_add_read_write(const struct xref_threadsched *xref,
 			    struct thread_master *m,
-			    int (*func)(struct thread *), void *arg, int fd,
+			    void (*func)(struct thread *), void *arg, int fd,
 			    struct thread **t_ptr)
 {
 	int dir = xref->thread_type;
@@ -1010,7 +1010,7 @@ void _thread_add_read_write(const struct xref_threadsched *xref,
 
 static void _thread_add_timer_timeval(const struct xref_threadsched *xref,
 				      struct thread_master *m,
-				      int (*func)(struct thread *), void *arg,
+				      void (*func)(struct thread *), void *arg,
 				      struct timeval *time_relative,
 				      struct thread **t_ptr)
 {
@@ -1057,7 +1057,7 @@ static void _thread_add_timer_timeval(const struct xref_threadsched *xref,
 
 /* Add timer event thread. */
 void _thread_add_timer(const struct xref_threadsched *xref,
-		       struct thread_master *m, int (*func)(struct thread *),
+		       struct thread_master *m, void (*func)(struct thread *),
 		       void *arg, long timer, struct thread **t_ptr)
 {
 	struct timeval trel;
@@ -1073,8 +1073,8 @@ void _thread_add_timer(const struct xref_threadsched *xref,
 /* Add timer event thread with "millisecond" resolution */
 void _thread_add_timer_msec(const struct xref_threadsched *xref,
 			    struct thread_master *m,
-			    int (*func)(struct thread *), void *arg, long timer,
-			    struct thread **t_ptr)
+			    void (*func)(struct thread *), void *arg,
+			    long timer, struct thread **t_ptr)
 {
 	struct timeval trel;
 
@@ -1088,15 +1088,16 @@ void _thread_add_timer_msec(const struct xref_threadsched *xref,
 
 /* Add timer event thread with "timeval" resolution */
 void _thread_add_timer_tv(const struct xref_threadsched *xref,
-			  struct thread_master *m, int (*func)(struct thread *),
-			  void *arg, struct timeval *tv, struct thread **t_ptr)
+			  struct thread_master *m,
+			  void (*func)(struct thread *), void *arg,
+			  struct timeval *tv, struct thread **t_ptr)
 {
 	_thread_add_timer_timeval(xref, m, func, arg, tv, t_ptr);
 }
 
 /* Add simple event thread. */
 void _thread_add_event(const struct xref_threadsched *xref,
-		       struct thread_master *m, int (*func)(struct thread *),
+		       struct thread_master *m, void (*func)(struct thread *),
 		       void *arg, int val, struct thread **t_ptr)
 {
 	struct thread *thread = NULL;
@@ -2008,7 +2009,7 @@ void thread_call(struct thread *thread)
 
 /* Execute thread */
 void _thread_execute(const struct xref_threadsched *xref,
-		     struct thread_master *m, int (*func)(struct thread *),
+		     struct thread_master *m, void (*func)(struct thread *),
 		     void *arg, int val)
 {
 	struct thread *thread;

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -114,7 +114,7 @@ struct thread {
 	struct thread_timer_list_item timeritem;
 	struct thread **ref;	  /* external reference (if given) */
 	struct thread_master *master; /* pointer to the struct thread_master */
-	int (*func)(struct thread *); /* event function */
+	void (*func)(struct thread *); /* event function */
 	void *arg;		      /* event argument */
 	union {
 		int val;	      /* second argument of the event. */
@@ -134,7 +134,7 @@ struct thread {
 #endif
 
 struct cpu_thread_history {
-	int (*func)(struct thread *);
+	void (*func)(struct thread *);
 	atomic_size_t total_cpu_warn;
 	atomic_size_t total_wall_warn;
 	atomic_size_t total_starv_warn;
@@ -227,32 +227,32 @@ extern void thread_master_free_unused(struct thread_master *);
 
 extern void _thread_add_read_write(const struct xref_threadsched *xref,
 				   struct thread_master *master,
-				   int (*fn)(struct thread *), void *arg,
+				   void (*fn)(struct thread *), void *arg,
 				   int fd, struct thread **tref);
 
 extern void _thread_add_timer(const struct xref_threadsched *xref,
 			      struct thread_master *master,
-			      int (*fn)(struct thread *), void *arg, long t,
+			      void (*fn)(struct thread *), void *arg, long t,
 			      struct thread **tref);
 
 extern void _thread_add_timer_msec(const struct xref_threadsched *xref,
 				   struct thread_master *master,
-				   int (*fn)(struct thread *), void *arg,
+				   void (*fn)(struct thread *), void *arg,
 				   long t, struct thread **tref);
 
 extern void _thread_add_timer_tv(const struct xref_threadsched *xref,
 				 struct thread_master *master,
-				 int (*fn)(struct thread *), void *arg,
+				 void (*fn)(struct thread *), void *arg,
 				 struct timeval *tv, struct thread **tref);
 
 extern void _thread_add_event(const struct xref_threadsched *xref,
 			      struct thread_master *master,
-			      int (*fn)(struct thread *), void *arg, int val,
+			      void (*fn)(struct thread *), void *arg, int val,
 			      struct thread **tref);
 
 extern void _thread_execute(const struct xref_threadsched *xref,
 			    struct thread_master *master,
-			    int (*fn)(struct thread *), void *arg, int val);
+			    void (*fn)(struct thread *), void *arg, int val);
 
 extern void thread_cancel(struct thread **event);
 extern void thread_cancel_async(struct thread_master *, struct thread **,

--- a/lib/wheel.c
+++ b/lib/wheel.c
@@ -29,9 +29,9 @@ DEFINE_MTYPE_STATIC(LIB, TIMER_WHEEL_LIST, "Timer Wheel Slot List");
 
 static int debug_timer_wheel = 0;
 
-static int wheel_timer_thread(struct thread *t);
+static void wheel_timer_thread(struct thread *t);
 
-static int wheel_timer_thread_helper(struct thread *t)
+static void wheel_timer_thread_helper(struct thread *t)
 {
 	struct listnode *node, *nextnode;
 	unsigned long long curr_slot;
@@ -63,19 +63,15 @@ static int wheel_timer_thread_helper(struct thread *t)
 	wheel->slots_to_skip = slots_to_skip;
 	thread_add_timer_msec(wheel->master, wheel_timer_thread, wheel,
 			      wheel->nexttime * slots_to_skip, &wheel->timer);
-
-	return 0;
 }
 
-static int wheel_timer_thread(struct thread *t)
+static void wheel_timer_thread(struct thread *t)
 {
 	struct timer_wheel *wheel;
 
 	wheel = THREAD_ARG(t);
 
 	thread_execute(wheel->master, wheel_timer_thread_helper, wheel, 0);
-
-	return 0;
 }
 
 struct timer_wheel *wheel_init(struct thread_master *master, int period,

--- a/lib/workqueue.c
+++ b/lib/workqueue.c
@@ -238,7 +238,7 @@ void work_queue_unplug(struct work_queue *wq)
  * will reschedule itself if required,
  * otherwise work_queue_item_add
  */
-int work_queue_run(struct thread *thread)
+void work_queue_run(struct thread *thread)
 {
 	struct work_queue *wq;
 	struct work_queue_item *item, *titem;
@@ -388,6 +388,4 @@ stats:
 
 	} else if (wq->spec.completion_func)
 		wq->spec.completion_func(wq);
-
-	return 0;
 }

--- a/lib/workqueue.h
+++ b/lib/workqueue.h
@@ -177,7 +177,7 @@ extern void work_queue_unplug(struct work_queue *wq);
 bool work_queue_is_scheduled(struct work_queue *);
 
 /* Helpers, exported for thread.c and command.c */
-extern int work_queue_run(struct thread *);
+extern void work_queue_run(struct thread *);
 
 extern void workqueue_cmd_init(void);
 

--- a/lib/zlog_5424.c
+++ b/lib/zlog_5424.c
@@ -799,7 +799,7 @@ static void zlog_5424_cycle(struct zlog_cfg_5424 *zcf, int fd)
 	rcu_free(MTYPE_LOG_5424, oldt, zt.rcu_head);
 }
 
-static int zlog_5424_reconnect(struct thread *t)
+static void zlog_5424_reconnect(struct thread *t)
 {
 	struct zlog_cfg_5424 *zcf = THREAD_ARG(t);
 	int fd = THREAD_FD(t);
@@ -812,7 +812,7 @@ static int zlog_5424_reconnect(struct thread *t)
 			/* logger is sending us something?!?! */
 			thread_add_read(t->master, zlog_5424_reconnect, zcf, fd,
 					&zcf->t_reconnect);
-			return 0;
+			return;
 		}
 
 		if (ret == 0)
@@ -832,7 +832,6 @@ static int zlog_5424_reconnect(struct thread *t)
 	frr_with_mutex (&zcf->cfg_mtx) {
 		zlog_5424_cycle(zcf, fd);
 	}
-	return 0;
 }
 
 static int zlog_5424_unix(struct sockaddr_un *suna, int sock_type)

--- a/nhrpd/netlink_arp.c
+++ b/nhrpd/netlink_arp.c
@@ -100,7 +100,7 @@ static void netlink_log_indication(struct nlmsghdr *msg, struct zbuf *zb)
 	nhrp_peer_send_indication(ifp, htons(pkthdr->hw_protocol), &pktpl);
 }
 
-static int netlink_log_recv(struct thread *t)
+static void netlink_log_recv(struct thread *t)
 {
 	uint8_t buf[ZNL_BUFFER_SIZE];
 	int fd = THREAD_FD(t);
@@ -124,8 +124,6 @@ static int netlink_log_recv(struct thread *t)
 
 	thread_add_read(master, netlink_log_recv, 0, netlink_log_fd,
 			&netlink_log_thread);
-
-	return 0;
 }
 
 void netlink_set_nflog_group(int nlgroup)

--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -197,16 +197,15 @@ struct nhrp_cache *nhrp_cache_get(struct interface *ifp,
 			create ? nhrp_cache_alloc : NULL);
 }
 
-static int nhrp_cache_do_free(struct thread *t)
+static void nhrp_cache_do_free(struct thread *t)
 {
 	struct nhrp_cache *c = THREAD_ARG(t);
 
 	c->t_timeout = NULL;
 	nhrp_cache_free(c);
-	return 0;
 }
 
-static int nhrp_cache_do_timeout(struct thread *t)
+static void nhrp_cache_do_timeout(struct thread *t)
 {
 	struct nhrp_cache *c = THREAD_ARG(t);
 
@@ -214,7 +213,6 @@ static int nhrp_cache_do_timeout(struct thread *t)
 	if (c->cur.type != NHRP_CACHE_INVALID)
 		nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL,
 					  NULL);
-	return 0;
 }
 
 static void nhrp_cache_update_route(struct nhrp_cache *c)
@@ -392,12 +390,11 @@ static void nhrp_cache_authorize_binding(struct nhrp_reqid *r, void *arg)
 	nhrp_cache_update_timers(c);
 }
 
-static int nhrp_cache_do_auth_timeout(struct thread *t)
+static void nhrp_cache_do_auth_timeout(struct thread *t)
 {
 	struct nhrp_cache *c = THREAD_ARG(t);
 	c->t_auth = NULL;
 	nhrp_cache_authorize_binding(&c->eventid, (void *)"timeout");
-	return 0;
 }
 
 static void nhrp_cache_newpeer_notifier(struct notifier_block *n,

--- a/nhrpd/nhrp_event.c
+++ b/nhrpd/nhrp_event.c
@@ -31,7 +31,7 @@ struct event_manager {
 	uint8_t ibuf_data[4 * 1024];
 };
 
-static int evmgr_reconnect(struct thread *t);
+static void evmgr_reconnect(struct thread *t);
 
 static void evmgr_connection_error(struct event_manager *evmgr)
 {
@@ -78,7 +78,7 @@ static void evmgr_recv_message(struct event_manager *evmgr, struct zbuf *zb)
 	}
 }
 
-static int evmgr_read(struct thread *t)
+static void evmgr_read(struct thread *t)
 {
 	struct event_manager *evmgr = THREAD_ARG(t);
 	struct zbuf *ibuf = &evmgr->ibuf;
@@ -86,7 +86,7 @@ static int evmgr_read(struct thread *t)
 
 	if (zbuf_read(ibuf, evmgr->fd, (size_t)-1) < 0) {
 		evmgr_connection_error(evmgr);
-		return 0;
+		return;
 	}
 
 	/* Process all messages in buffer */
@@ -94,10 +94,9 @@ static int evmgr_read(struct thread *t)
 		evmgr_recv_message(evmgr, &msg);
 
 	thread_add_read(master, evmgr_read, evmgr, evmgr->fd, &evmgr->t_read);
-	return 0;
 }
 
-static int evmgr_write(struct thread *t)
+static void evmgr_write(struct thread *t)
 {
 	struct event_manager *evmgr = THREAD_ARG(t);
 	int r;
@@ -109,8 +108,6 @@ static int evmgr_write(struct thread *t)
 	} else if (r < 0) {
 		evmgr_connection_error(evmgr);
 	}
-
-	return 0;
 }
 
 static void evmgr_hexdump(struct zbuf *zb, const uint8_t *val, size_t vallen)
@@ -186,13 +183,13 @@ static void evmgr_submit(struct event_manager *evmgr, struct zbuf *obuf)
 				 &evmgr->t_write);
 }
 
-static int evmgr_reconnect(struct thread *t)
+static void evmgr_reconnect(struct thread *t)
 {
 	struct event_manager *evmgr = THREAD_ARG(t);
 	int fd;
 
 	if (evmgr->fd >= 0 || !nhrp_event_socket_path)
-		return 0;
+		return;
 
 	fd = sock_open_unix(nhrp_event_socket_path);
 	if (fd < 0) {
@@ -201,14 +198,12 @@ static int evmgr_reconnect(struct thread *t)
 		zbufq_reset(&evmgr->obuf);
 		thread_add_timer(master, evmgr_reconnect, evmgr, 10,
 				 &evmgr->t_reconnect);
-		return 0;
+		return;
 	}
 
 	zlog_info("Connected to Event Manager");
 	evmgr->fd = fd;
 	thread_add_read(master, evmgr_read, evmgr, evmgr->fd, &evmgr->t_read);
-
-	return 0;
 }
 
 static struct event_manager evmgr_connection;

--- a/nhrpd/nhrp_multicast.c
+++ b/nhrpd/nhrp_multicast.c
@@ -142,7 +142,7 @@ static void netlink_mcast_log_handler(struct nlmsghdr *msg, struct zbuf *zb)
 	}
 }
 
-static int netlink_mcast_log_recv(struct thread *t)
+static void netlink_mcast_log_recv(struct thread *t)
 {
 	uint8_t buf[65535]; /* Max OSPF Packet size */
 	int fd = THREAD_FD(t);
@@ -166,8 +166,6 @@ static int netlink_mcast_log_recv(struct thread *t)
 
 	thread_add_read(master, netlink_mcast_log_recv, 0, netlink_mcast_log_fd,
 			&netlink_mcast_log_thread);
-
-	return 0;
 }
 
 static void netlink_mcast_log_register(int fd, int group)

--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -17,8 +17,8 @@
 DEFINE_MTYPE_STATIC(NHRPD, NHRP_NHS, "NHRP next hop server");
 DEFINE_MTYPE_STATIC(NHRPD, NHRP_REGISTRATION, "NHRP registration entries");
 
-static int nhrp_nhs_resolve(struct thread *t);
-static int nhrp_reg_send_req(struct thread *t);
+static void nhrp_nhs_resolve(struct thread *t);
+static void nhrp_reg_send_req(struct thread *t);
 
 static void nhrp_reg_reply(struct nhrp_reqid *reqid, void *arg)
 {
@@ -107,7 +107,7 @@ static void nhrp_reg_reply(struct nhrp_reqid *reqid, void *arg)
 					  &cie_nbma_nhs);
 }
 
-static int nhrp_reg_timeout(struct thread *t)
+static void nhrp_reg_timeout(struct thread *t)
 {
 	struct nhrp_registration *r = THREAD_ARG(t);
 	struct nhrp_cache *c;
@@ -138,8 +138,6 @@ static int nhrp_reg_timeout(struct thread *t)
 		r->timeout = 2;
 	}
 	thread_add_timer_msec(master, nhrp_reg_send_req, r, 10, &r->t_register);
-
-	return 0;
 }
 
 static void nhrp_reg_peer_notify(struct notifier_block *n, unsigned long cmd)
@@ -161,7 +159,7 @@ static void nhrp_reg_peer_notify(struct notifier_block *n, unsigned long cmd)
 	}
 }
 
-static int nhrp_reg_send_req(struct thread *t)
+static void nhrp_reg_send_req(struct thread *t)
 {
 	struct nhrp_registration *r = THREAD_ARG(t);
 	struct nhrp_nhs *nhs = r->nhs;
@@ -180,7 +178,7 @@ static int nhrp_reg_send_req(struct thread *t)
 		       &r->peer->vc->remote.nbma);
 		thread_add_timer(master, nhrp_reg_send_req, r, 120,
 				 &r->t_register);
-		return 0;
+		return;
 	}
 
 	thread_add_timer(master, nhrp_reg_timeout, r, r->timeout,
@@ -198,7 +196,7 @@ static int nhrp_reg_send_req(struct thread *t)
 
 	/* No protocol address configured for tunnel interface */
 	if (sockunion_family(&if_ad->addr) == AF_UNSPEC)
-		return 0;
+		return;
 
 	zb = zbuf_alloc(1400);
 	hdr = nhrp_packet_push(zb, NHRP_PACKET_REGISTRATION_REQUEST,
@@ -246,8 +244,6 @@ static int nhrp_reg_send_req(struct thread *t)
 	nhrp_packet_complete(zb, hdr);
 	nhrp_peer_send(r->peer, zb);
 	zbuf_free(zb);
-
-	return 0;
 }
 
 static void nhrp_reg_delete(struct nhrp_registration *r)
@@ -320,14 +316,12 @@ static void nhrp_nhs_resolve_cb(struct resolver_query *q, const char *errstr,
 			nhrp_reg_delete(reg);
 }
 
-static int nhrp_nhs_resolve(struct thread *t)
+static void nhrp_nhs_resolve(struct thread *t)
 {
 	struct nhrp_nhs *nhs = THREAD_ARG(t);
 
 	resolver_resolve(&nhs->dns_resolve, AF_INET, VRF_DEFAULT,
 			 nhs->nbma_fqdn, nhrp_nhs_resolve_cb);
-
-	return 0;
 }
 
 int nhrp_nhs_add(struct interface *ifp, afi_t afi, union sockunion *proto_addr,

--- a/nhrpd/nhrp_packet.c
+++ b/nhrpd/nhrp_packet.c
@@ -290,7 +290,7 @@ err:
 	return -1;
 }
 
-static int nhrp_packet_recvraw(struct thread *t)
+static void nhrp_packet_recvraw(struct thread *t)
 {
 	int fd = THREAD_FD(t), ifindex;
 	struct zbuf *zb;
@@ -304,7 +304,7 @@ static int nhrp_packet_recvraw(struct thread *t)
 
 	zb = zbuf_alloc(1500);
 	if (!zb)
-		return 0;
+		return;
 
 	len = zbuf_size(zb);
 	addrlen = sizeof(addr);
@@ -332,11 +332,10 @@ static int nhrp_packet_recvraw(struct thread *t)
 
 	nhrp_peer_recv(p, zb);
 	nhrp_peer_unref(p);
-	return 0;
+	return;
 
 err:
 	zbuf_free(zb);
-	return 0;
 }
 
 int nhrp_packet_init(void)

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -54,7 +54,7 @@ static void nhrp_peer_check_delete(struct nhrp_peer *p)
 	XFREE(MTYPE_NHRP_PEER, p);
 }
 
-static int nhrp_peer_notify_up(struct thread *t)
+static void nhrp_peer_notify_up(struct thread *t)
 {
 	struct nhrp_peer *p = THREAD_ARG(t);
 	struct nhrp_vc *vc = p->vc;
@@ -68,8 +68,6 @@ static int nhrp_peer_notify_up(struct thread *t)
 		notifier_call(&p->notifier_list, NOTIFY_PEER_UP);
 		nhrp_peer_unref(p);
 	}
-
-	return 0;
 }
 
 static void __nhrp_peer_check(struct nhrp_peer *p)
@@ -258,7 +256,7 @@ void nhrp_peer_unref(struct nhrp_peer *p)
 	}
 }
 
-static int nhrp_peer_request_timeout(struct thread *t)
+static void nhrp_peer_request_timeout(struct thread *t)
 {
 	struct nhrp_peer *p = THREAD_ARG(t);
 	struct nhrp_vc *vc = p->vc;
@@ -267,7 +265,7 @@ static int nhrp_peer_request_timeout(struct thread *t)
 
 
 	if (p->online)
-		return 0;
+		return;
 
 	if (nifp->ipsec_fallback_profile && !p->prio
 	    && !p->fallback_requested) {
@@ -279,11 +277,9 @@ static int nhrp_peer_request_timeout(struct thread *t)
 	} else {
 		p->requested = p->fallback_requested = 0;
 	}
-
-	return 0;
 }
 
-static int nhrp_peer_defer_vici_request(struct thread *t)
+static void nhrp_peer_defer_vici_request(struct thread *t)
 {
 	struct nhrp_peer *p = THREAD_ARG(t);
 	struct nhrp_vc *vc = p->vc;
@@ -304,7 +300,6 @@ static int nhrp_peer_defer_vici_request(struct thread *t)
 			(nifp->ipsec_fallback_profile && !p->prio) ? 15 : 30,
 			&p->t_fallback);
 	}
-	return 0;
 }
 
 int nhrp_peer_check(struct nhrp_peer *p, int establish)

--- a/nhrpd/nhrp_shortcut.c
+++ b/nhrpd/nhrp_shortcut.c
@@ -22,7 +22,7 @@ DEFINE_MTYPE_STATIC(NHRPD, NHRP_SHORTCUT, "NHRP shortcut");
 
 static struct route_table *shortcut_rib[AFI_MAX];
 
-static int nhrp_shortcut_do_purge(struct thread *t);
+static void nhrp_shortcut_do_purge(struct thread *t);
 static void nhrp_shortcut_delete(struct nhrp_shortcut *s);
 static void nhrp_shortcut_send_resolution_req(struct nhrp_shortcut *s);
 
@@ -35,7 +35,7 @@ static void nhrp_shortcut_check_use(struct nhrp_shortcut *s)
 	}
 }
 
-static int nhrp_shortcut_do_expire(struct thread *t)
+static void nhrp_shortcut_do_expire(struct thread *t)
 {
 	struct nhrp_shortcut *s = THREAD_ARG(t);
 
@@ -43,8 +43,6 @@ static int nhrp_shortcut_do_expire(struct thread *t)
 			 &s->t_timer);
 	s->expiring = 1;
 	nhrp_shortcut_check_use(s);
-
-	return 0;
 }
 
 static void nhrp_shortcut_cache_notify(struct notifier_block *n,
@@ -166,12 +164,11 @@ static void nhrp_shortcut_delete(struct nhrp_shortcut *s)
 	}
 }
 
-static int nhrp_shortcut_do_purge(struct thread *t)
+static void nhrp_shortcut_do_purge(struct thread *t)
 {
 	struct nhrp_shortcut *s = THREAD_ARG(t);
 	s->t_timer = NULL;
 	nhrp_shortcut_delete(s);
-	return 0;
 }
 
 static struct nhrp_shortcut *nhrp_shortcut_get(struct prefix *p)

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -197,7 +197,7 @@ struct ospf6_lsa *ospf6_as_external_lsa_originate(struct ospf6_route *route,
 	return lsa;
 }
 
-int ospf6_orig_as_external_lsa(struct thread *thread)
+void ospf6_orig_as_external_lsa(struct thread *thread)
 {
 	struct ospf6_interface *oi;
 	struct ospf6_lsa *lsa;
@@ -206,9 +206,9 @@ int ospf6_orig_as_external_lsa(struct thread *thread)
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
 
 	if (oi->state == OSPF6_INTERFACE_DOWN)
-		return 0;
+		return;
 	if (IS_AREA_NSSA(oi->area) || IS_AREA_STUB(oi->area))
-		return 0;
+		return;
 
 	type = htons(OSPF6_LSTYPE_AS_EXTERNAL);
 	adv_router = oi->area->ospf6->router_id;
@@ -222,8 +222,6 @@ int ospf6_orig_as_external_lsa(struct thread *thread)
 
 		ospf6_flood_interface(NULL, lsa, oi);
 	}
-
-	return 0;
 }
 
 static route_tag_t ospf6_as_external_lsa_get_tag(struct ospf6_lsa *lsa)
@@ -1084,7 +1082,7 @@ static void ospf6_asbr_routemap_unset(struct ospf6_redist *red)
 	ROUTEMAP(red) = NULL;
 }
 
-static int ospf6_asbr_routemap_update_timer(struct thread *thread)
+static void ospf6_asbr_routemap_update_timer(struct thread *thread)
 {
 	struct ospf6 *ospf6 = THREAD_ARG(thread);
 	struct ospf6_redist *red;
@@ -1116,8 +1114,6 @@ static int ospf6_asbr_routemap_update_timer(struct thread *thread)
 
 		UNSET_FLAG(red->flag, OSPF6_IS_RMAP_CHANGED);
 	}
-
-	return 0;
 }
 
 void ospf6_asbr_distribute_list_update(struct ospf6 *ospf6,
@@ -3331,7 +3327,7 @@ ospf6_handle_external_aggr_add(struct ospf6 *ospf6)
 	}
 }
 
-static int ospf6_asbr_summary_process(struct thread *thread)
+static void ospf6_asbr_summary_process(struct thread *thread)
 {
 	struct ospf6 *ospf6 = THREAD_ARG(thread);
 	int operation = 0;
@@ -3354,8 +3350,6 @@ static int ospf6_asbr_summary_process(struct thread *thread)
 	default:
 		break;
 	}
-
-	return OSPF6_SUCCESS;
 }
 
 static void

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -455,14 +455,12 @@ static bool ospf6_gr_check_adjs(struct ospf6 *ospf6)
 }
 
 /* Handling of grace period expiry. */
-static int ospf6_gr_grace_period_expired(struct thread *thread)
+static void ospf6_gr_grace_period_expired(struct thread *thread)
 {
 	struct ospf6 *ospf6 = THREAD_ARG(thread);
 
 	ospf6->gr_info.t_grace_period = NULL;
 	ospf6_gr_restart_exit(ospf6, "grace period has expired");
-
-	return 0;
 }
 
 /*

--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -208,12 +208,11 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
  * Returns:
  *    Nothing
  */
-static int ospf6_handle_grace_timer_expiry(struct thread *thread)
+static void ospf6_handle_grace_timer_expiry(struct thread *thread)
 {
 	struct ospf6_neighbor *nbr = THREAD_ARG(thread);
 
 	ospf6_gr_helper_exit(nbr, OSPF6_GR_HELPER_GRACE_TIMEOUT);
-	return OSPF6_SUCCESS;
 }
 
 /*

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -226,11 +226,11 @@ extern struct in6_addr *
 ospf6_interface_get_global_address(struct interface *ifp);
 
 /* interface event */
-extern int interface_up(struct thread *thread);
-extern int interface_down(struct thread *thread);
-extern int wait_timer(struct thread *thread);
-extern int backup_seen(struct thread *thread);
-extern int neighbor_change(struct thread *thread);
+extern void interface_up(struct thread *thread);
+extern void interface_down(struct thread *thread);
+extern void wait_timer(struct thread *thread);
+extern void backup_seen(struct thread *thread);
+extern void neighbor_change(struct thread *thread);
 
 extern void ospf6_interface_init(void);
 extern void ospf6_interface_clear(struct interface *ifp);

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -224,7 +224,7 @@ int ospf6_router_is_stub_router(struct ospf6_lsa *lsa)
 	return OSPF6_NOT_STUB_ROUTER;
 }
 
-int ospf6_router_lsa_originate(struct thread *thread)
+void ospf6_router_lsa_originate(struct thread *thread)
 {
 	struct ospf6_area *oa;
 
@@ -249,7 +249,7 @@ int ospf6_router_lsa_originate(struct thread *thread)
 		if (IS_DEBUG_OSPF6_GR)
 			zlog_debug(
 				"Graceful Restart in progress, don't originate LSA");
-		return 0;
+		return;
 	}
 
 	if (IS_OSPF6_DEBUG_ORIGINATE(ROUTER))
@@ -294,7 +294,7 @@ int ospf6_router_lsa_originate(struct thread *thread)
 				       + sizeof(struct ospf6_router_lsa)) {
 				zlog_warn(
 					"Size limit setting for Router-LSA too short");
-				return 0;
+				return;
 			}
 
 			/* Fill LSA Header */
@@ -433,8 +433,6 @@ int ospf6_router_lsa_originate(struct thread *thread)
 	if (count && !link_state_id)
 		ospf6_spf_schedule(oa->ospf6,
 				   OSPF6_SPF_FLAGS_ROUTER_LSA_ORIGINATED);
-
-	return 0;
 }
 
 /*******************************/
@@ -511,7 +509,7 @@ static int ospf6_network_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	return 0;
 }
 
-int ospf6_network_lsa_originate(struct thread *thread)
+void ospf6_network_lsa_originate(struct thread *thread)
 {
 	struct ospf6_interface *oi;
 
@@ -538,7 +536,7 @@ int ospf6_network_lsa_originate(struct thread *thread)
 		if (IS_DEBUG_OSPF6_GR)
 			zlog_debug(
 				"Graceful Restart in progress, don't originate LSA");
-		return 0;
+		return;
 	}
 
 	old = ospf6_lsdb_lookup(htons(OSPF6_LSTYPE_NETWORK),
@@ -558,7 +556,7 @@ int ospf6_network_lsa_originate(struct thread *thread)
 				oi->area->ospf6,
 				OSPF6_SPF_FLAGS_NETWORK_LSA_ORIGINATED);
 		}
-		return 0;
+		return;
 	}
 
 	if (IS_OSPF6_DEBUG_ORIGINATE(NETWORK))
@@ -577,7 +575,7 @@ int ospf6_network_lsa_originate(struct thread *thread)
 			zlog_debug("Interface stub, ignore");
 		if (old)
 			ospf6_lsa_purge(old);
-		return 0;
+		return;
 	}
 
 	/* prepare buffer */
@@ -635,8 +633,6 @@ int ospf6_network_lsa_originate(struct thread *thread)
 
 	/* Originate */
 	ospf6_lsa_originate_area(lsa, oi->area);
-
-	return 0;
 }
 
 
@@ -765,7 +761,7 @@ static int ospf6_link_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	return 0;
 }
 
-int ospf6_link_lsa_originate(struct thread *thread)
+void ospf6_link_lsa_originate(struct thread *thread)
 {
 	struct ospf6_interface *oi;
 
@@ -785,7 +781,7 @@ int ospf6_link_lsa_originate(struct thread *thread)
 		if (IS_DEBUG_OSPF6_GR)
 			zlog_debug(
 				"Graceful Restart in progress, don't originate LSA");
-		return 0;
+		return;
 	}
 
 
@@ -797,7 +793,7 @@ int ospf6_link_lsa_originate(struct thread *thread)
 	if (CHECK_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE)) {
 		if (old)
 			ospf6_lsa_purge(old);
-		return 0;
+		return;
 	}
 
 	if (IS_OSPF6_DEBUG_ORIGINATE(LINK))
@@ -812,7 +808,7 @@ int ospf6_link_lsa_originate(struct thread *thread)
 				oi->interface->name);
 		if (old)
 			ospf6_lsa_purge(old);
-		return 0;
+		return;
 	}
 
 	/* prepare buffer */
@@ -860,8 +856,6 @@ int ospf6_link_lsa_originate(struct thread *thread)
 
 	/* Originate */
 	ospf6_lsa_originate_interface(lsa, oi);
-
-	return 0;
 }
 
 
@@ -1003,7 +997,7 @@ static int ospf6_intra_prefix_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	return 0;
 }
 
-int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
+void ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 {
 	struct ospf6_area *oa;
 
@@ -1028,7 +1022,7 @@ int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 		if (IS_DEBUG_OSPF6_GR)
 			zlog_debug(
 				"Graceful Restart in progress, don't originate LSA");
-		return 0;
+		return;
 	}
 
 	/* find previous LSA */
@@ -1051,7 +1045,7 @@ int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 					oa->lsdb);
 			}
 		}
-		return 0;
+		return;
 	}
 
 	if (IS_OSPF6_DEBUG_ORIGINATE(INTRA_PREFIX))
@@ -1127,7 +1121,7 @@ int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 			}
 		}
 		ospf6_route_table_delete(route_advertise);
-		return 0;
+		return;
 	}
 
 	/* Neighbor change to FULL, if INTRA-AREA-PREFIX LSA
@@ -1212,7 +1206,7 @@ int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 		if (IS_OSPF6_DEBUG_ORIGINATE(INTRA_PREFIX))
 			zlog_debug(
 				"Quit to Advertise Intra-Prefix: no route to advertise");
-		return 0;
+		return;
 	}
 
 	intra_prefix_lsa->prefix_num = htons(prefix_num);
@@ -1235,12 +1229,10 @@ int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread)
 
 	/* Originate */
 	ospf6_lsa_originate_area(lsa, oa);
-
-	return 0;
 }
 
 
-int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
+void ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 {
 	struct ospf6_interface *oi;
 
@@ -1268,7 +1260,7 @@ int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 		if (IS_DEBUG_OSPF6_GR)
 			zlog_debug(
 				"Graceful Restart in progress, don't originate LSA");
-		return 0;
+		return;
 	}
 
 	/* find previous LSA */
@@ -1279,7 +1271,7 @@ int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 	if (CHECK_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE)) {
 		if (old)
 			ospf6_lsa_purge(old);
-		return 0;
+		return;
 	}
 
 	if (IS_OSPF6_DEBUG_ORIGINATE(INTRA_PREFIX))
@@ -1304,7 +1296,7 @@ int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 			zlog_debug("  Interface is not DR");
 		if (old)
 			ospf6_lsa_purge(old);
-		return 0;
+		return;
 	}
 
 	full_count = 0;
@@ -1317,7 +1309,7 @@ int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 			zlog_debug("  Interface is stub");
 		if (old)
 			ospf6_lsa_purge(old);
-		return 0;
+		return;
 	}
 
 	/* connected prefix to advertise */
@@ -1406,7 +1398,7 @@ int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 		if (IS_OSPF6_DEBUG_ORIGINATE(INTRA_PREFIX))
 			zlog_debug(
 				"Quit to Advertise Intra-Prefix: no route to advertise");
-		return 0;
+		return;
 	}
 
 	intra_prefix_lsa->prefix_num = htons(prefix_num);
@@ -1429,8 +1421,6 @@ int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread)
 
 	/* Originate */
 	ospf6_lsa_originate_area(lsa, oi->area);
-
-	return 0;
 }
 
 static void ospf6_intra_prefix_update_route_origin(struct ospf6_route *oa_route,

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -235,14 +235,14 @@ extern char *ospf6_network_lsdesc_lookup(uint32_t router_id,
 					 struct ospf6_lsa *lsa);
 
 extern int ospf6_router_is_stub_router(struct ospf6_lsa *lsa);
-extern int ospf6_router_lsa_originate(struct thread *thread);
-extern int ospf6_network_lsa_originate(struct thread *thread);
-extern int ospf6_link_lsa_originate(struct thread *thread);
-extern int ospf6_intra_prefix_lsa_originate_transit(struct thread *thread);
-extern int ospf6_intra_prefix_lsa_originate_stub(struct thread *thread);
+extern void ospf6_router_lsa_originate(struct thread *thread);
+extern void ospf6_network_lsa_originate(struct thread *thread);
+extern void ospf6_link_lsa_originate(struct thread *thread);
+extern void ospf6_intra_prefix_lsa_originate_transit(struct thread *thread);
+extern void ospf6_intra_prefix_lsa_originate_stub(struct thread *thread);
 extern void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa);
 extern void ospf6_intra_prefix_lsa_remove(struct ospf6_lsa *lsa);
-extern int ospf6_orig_as_external_lsa(struct thread *thread);
+extern void ospf6_orig_as_external_lsa(struct thread *thread);
 extern void ospf6_intra_route_calculation(struct ospf6_area *oa);
 extern void ospf6_intra_brouter_calculation(struct ospf6_area *oa);
 extern void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -829,7 +829,7 @@ struct ospf6_lsa *ospf6_lsa_unlock(struct ospf6_lsa *lsa)
 
 
 /* ospf6 lsa expiry */
-int ospf6_lsa_expire(struct thread *thread)
+void ospf6_lsa_expire(struct thread *thread)
 {
 	struct ospf6_lsa *lsa;
 	struct ospf6 *ospf6;
@@ -848,7 +848,7 @@ int ospf6_lsa_expire(struct thread *thread)
 	}
 
 	if (CHECK_FLAG(lsa->flag, OSPF6_LSA_HEADERONLY))
-		return 0; /* dbexchange will do something ... */
+		return; /* dbexchange will do something ... */
 	ospf6 = ospf6_get_by_lsdb(lsa);
 	assert(ospf6);
 
@@ -860,11 +860,9 @@ int ospf6_lsa_expire(struct thread *thread)
 
 	/* schedule maxage remover */
 	ospf6_maxage_remove(ospf6);
-
-	return 0;
 }
 
-int ospf6_lsa_refresh(struct thread *thread)
+void ospf6_lsa_refresh(struct thread *thread)
 {
 	struct ospf6_lsa *old, *self, *new;
 	struct ospf6_lsdb *lsdb_self;
@@ -882,7 +880,7 @@ int ospf6_lsa_refresh(struct thread *thread)
 			zlog_debug("Refresh: could not find self LSA, flush %s",
 				   old->name);
 		ospf6_lsa_premature_aging(old);
-		return 0;
+		return;
 	}
 
 	/* Reset age, increment LS sequence number. */
@@ -907,8 +905,6 @@ int ospf6_lsa_refresh(struct thread *thread)
 
 	ospf6_install_lsa(new);
 	ospf6_flood(NULL, new);
-
-	return 0;
 }
 
 void ospf6_flush_self_originated_lsas_now(struct ospf6 *ospf6)

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -256,8 +256,8 @@ extern struct ospf6_lsa *ospf6_lsa_copy(struct ospf6_lsa *lsa);
 extern struct ospf6_lsa *ospf6_lsa_lock(struct ospf6_lsa *lsa);
 extern struct ospf6_lsa *ospf6_lsa_unlock(struct ospf6_lsa *lsa);
 
-extern int ospf6_lsa_expire(struct thread *thread);
-extern int ospf6_lsa_refresh(struct thread *thread);
+extern void ospf6_lsa_expire(struct thread *thread);
+extern void ospf6_lsa_refresh(struct thread *thread);
 
 extern unsigned short ospf6_lsa_checksum(struct ospf6_lsa_header *lsah);
 extern int ospf6_lsa_checksum_valid(struct ospf6_lsa_header *lsah);

--- a/ospf6d/ospf6_message.h
+++ b/ospf6d/ospf6_message.h
@@ -173,16 +173,16 @@ extern void ospf6_fifo_free(struct ospf6_fifo *fifo);
 
 extern int ospf6_iobuf_size(unsigned int size);
 extern void ospf6_message_terminate(void);
-extern int ospf6_receive(struct thread *thread);
+extern void ospf6_receive(struct thread *thread);
 
-extern int ospf6_hello_send(struct thread *thread);
-extern int ospf6_dbdesc_send(struct thread *thread);
-extern int ospf6_dbdesc_send_newone(struct thread *thread);
-extern int ospf6_lsreq_send(struct thread *thread);
-extern int ospf6_lsupdate_send_interface(struct thread *thread);
-extern int ospf6_lsupdate_send_neighbor(struct thread *thread);
-extern int ospf6_lsack_send_interface(struct thread *thread);
-extern int ospf6_lsack_send_neighbor(struct thread *thread);
+extern void ospf6_hello_send(struct thread *thread);
+extern void ospf6_dbdesc_send(struct thread *thread);
+extern void ospf6_dbdesc_send_newone(struct thread *thread);
+extern void ospf6_lsreq_send(struct thread *thread);
+extern void ospf6_lsupdate_send_interface(struct thread *thread);
+extern void ospf6_lsupdate_send_neighbor(struct thread *thread);
+extern void ospf6_lsack_send_interface(struct thread *thread);
+extern void ospf6_lsack_send_neighbor(struct thread *thread);
 
 extern int config_write_ospf6_debug_message(struct vty *);
 extern void install_element_ospf6_debug_message(void);

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -272,7 +272,7 @@ static int need_adjacency(struct ospf6_neighbor *on)
 	return 0;
 }
 
-int hello_received(struct thread *thread)
+void hello_received(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
 
@@ -290,11 +290,9 @@ int hello_received(struct thread *thread)
 	if (on->state <= OSPF6_NEIGHBOR_DOWN)
 		ospf6_neighbor_state_change(OSPF6_NEIGHBOR_INIT, on,
 					    OSPF6_NEIGHBOR_EVENT_HELLO_RCVD);
-
-	return 0;
 }
 
-int twoway_received(struct thread *thread)
+void twoway_received(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
 
@@ -302,7 +300,7 @@ int twoway_received(struct thread *thread)
 	assert(on);
 
 	if (on->state > OSPF6_NEIGHBOR_INIT)
-		return 0;
+		return;
 
 	if (IS_OSPF6_DEBUG_NEIGHBOR(EVENT))
 		zlog_debug("Neighbor Event %s: *2Way-Received*", on->name);
@@ -312,7 +310,7 @@ int twoway_received(struct thread *thread)
 	if (!need_adjacency(on)) {
 		ospf6_neighbor_state_change(OSPF6_NEIGHBOR_TWOWAY, on,
 					    OSPF6_NEIGHBOR_EVENT_TWOWAY_RCVD);
-		return 0;
+		return;
 	}
 
 	ospf6_neighbor_state_change(OSPF6_NEIGHBOR_EXSTART, on,
@@ -324,11 +322,9 @@ int twoway_received(struct thread *thread)
 	THREAD_OFF(on->thread_send_dbdesc);
 	thread_add_event(master, ospf6_dbdesc_send, on, 0,
 			 &on->thread_send_dbdesc);
-
-	return 0;
 }
 
-int negotiation_done(struct thread *thread)
+void negotiation_done(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
 	struct ospf6_lsa *lsa, *lsanext;
@@ -337,7 +333,7 @@ int negotiation_done(struct thread *thread)
 	assert(on);
 
 	if (on->state != OSPF6_NEIGHBOR_EXSTART)
-		return 0;
+		return;
 
 	if (IS_OSPF6_DEBUG_NEIGHBOR(EVENT))
 		zlog_debug("Neighbor Event %s: *NegotiationDone*", on->name);
@@ -380,21 +376,17 @@ int negotiation_done(struct thread *thread)
 	UNSET_FLAG(on->dbdesc_bits, OSPF6_DBDESC_IBIT);
 	ospf6_neighbor_state_change(OSPF6_NEIGHBOR_EXCHANGE, on,
 				    OSPF6_NEIGHBOR_EVENT_NEGOTIATION_DONE);
-
-	return 0;
 }
 
-static int ospf6_neighbor_last_dbdesc_release(struct thread *thread)
+static void ospf6_neighbor_last_dbdesc_release(struct thread *thread)
 {
 	struct ospf6_neighbor *on = THREAD_ARG(thread);
 
 	assert(on);
 	memset(&on->dbdesc_last, 0, sizeof(struct ospf6_dbdesc));
-
-	return 0;
 }
 
-int exchange_done(struct thread *thread)
+void exchange_done(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
 
@@ -402,7 +394,7 @@ int exchange_done(struct thread *thread)
 	assert(on);
 
 	if (on->state != OSPF6_NEIGHBOR_EXCHANGE)
-		return 0;
+		return;
 
 	if (IS_OSPF6_DEBUG_NEIGHBOR(EVENT))
 		zlog_debug("Neighbor Event %s: *ExchangeDone*", on->name);
@@ -428,8 +420,6 @@ int exchange_done(struct thread *thread)
 		thread_add_event(master, ospf6_lsreq_send, on, 0,
 				 &on->thread_send_lsreq);
 	}
-
-	return 0;
 }
 
 /* Check loading state. */
@@ -453,7 +443,7 @@ void ospf6_check_nbr_loading(struct ospf6_neighbor *on)
 	}
 }
 
-int loading_done(struct thread *thread)
+void loading_done(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
 
@@ -461,7 +451,7 @@ int loading_done(struct thread *thread)
 	assert(on);
 
 	if (on->state != OSPF6_NEIGHBOR_LOADING)
-		return 0;
+		return;
 
 	if (IS_OSPF6_DEBUG_NEIGHBOR(EVENT))
 		zlog_debug("Neighbor Event %s: *LoadingDone*", on->name);
@@ -470,11 +460,9 @@ int loading_done(struct thread *thread)
 
 	ospf6_neighbor_state_change(OSPF6_NEIGHBOR_FULL, on,
 				    OSPF6_NEIGHBOR_EVENT_LOADING_DONE);
-
-	return 0;
 }
 
-int adj_ok(struct thread *thread)
+void adj_ok(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
 	struct ospf6_lsa *lsa, *lsanext;
@@ -507,11 +495,9 @@ int adj_ok(struct thread *thread)
 			ospf6_lsdb_remove(lsa, on->retrans_list);
 		}
 	}
-
-	return 0;
 }
 
-int seqnumber_mismatch(struct thread *thread)
+void seqnumber_mismatch(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
 	struct ospf6_lsa *lsa, *lsanext;
@@ -520,7 +506,7 @@ int seqnumber_mismatch(struct thread *thread)
 	assert(on);
 
 	if (on->state < OSPF6_NEIGHBOR_EXCHANGE)
-		return 0;
+		return;
 
 	if (IS_OSPF6_DEBUG_NEIGHBOR(EVENT))
 		zlog_debug("Neighbor Event %s: *SeqNumberMismatch*", on->name);
@@ -544,11 +530,9 @@ int seqnumber_mismatch(struct thread *thread)
 	on->thread_send_dbdesc = NULL;
 	thread_add_event(master, ospf6_dbdesc_send, on, 0,
 			 &on->thread_send_dbdesc);
-
-	return 0;
 }
 
-int bad_lsreq(struct thread *thread)
+void bad_lsreq(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
 	struct ospf6_lsa *lsa, *lsanext;
@@ -557,7 +541,7 @@ int bad_lsreq(struct thread *thread)
 	assert(on);
 
 	if (on->state < OSPF6_NEIGHBOR_EXCHANGE)
-		return 0;
+		return;
 
 	if (IS_OSPF6_DEBUG_NEIGHBOR(EVENT))
 		zlog_debug("Neighbor Event %s: *BadLSReq*", on->name);
@@ -582,10 +566,9 @@ int bad_lsreq(struct thread *thread)
 	thread_add_event(master, ospf6_dbdesc_send, on, 0,
 			 &on->thread_send_dbdesc);
 
-	return 0;
 }
 
-int oneway_received(struct thread *thread)
+void oneway_received(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
 	struct ospf6_lsa *lsa, *lsanext;
@@ -594,7 +577,7 @@ int oneway_received(struct thread *thread)
 	assert(on);
 
 	if (on->state < OSPF6_NEIGHBOR_TWOWAY)
-		return 0;
+		return;
 
 	if (IS_OSPF6_DEBUG_NEIGHBOR(EVENT))
 		zlog_debug("Neighbor Event %s: *1Way-Received*", on->name);
@@ -616,11 +599,9 @@ int oneway_received(struct thread *thread)
 	THREAD_OFF(on->thread_send_lsack);
 	THREAD_OFF(on->thread_exchange_done);
 	THREAD_OFF(on->thread_adj_ok);
-
-	return 0;
 }
 
-int inactivity_timer(struct thread *thread)
+void inactivity_timer(struct thread *thread)
 {
 	struct ospf6_neighbor *on;
 
@@ -656,8 +637,6 @@ int inactivity_timer(struct thread *thread)
 				 on->ospf6_if->dead_interval,
 				 &on->inactivity_timer);
 	}
-
-	return 0;
 }
 
 

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -205,16 +205,16 @@ struct ospf6_neighbor *ospf6_neighbor_create(uint32_t router_id,
 void ospf6_neighbor_delete(struct ospf6_neighbor *on);
 
 /* Neighbor event */
-extern int hello_received(struct thread *thread);
-extern int twoway_received(struct thread *thread);
-extern int negotiation_done(struct thread *thread);
-extern int exchange_done(struct thread *thread);
-extern int loading_done(struct thread *thread);
-extern int adj_ok(struct thread *thread);
-extern int seqnumber_mismatch(struct thread *thread);
-extern int bad_lsreq(struct thread *thread);
-extern int oneway_received(struct thread *thread);
-extern int inactivity_timer(struct thread *thread);
+extern void hello_received(struct thread *thread);
+extern void twoway_received(struct thread *thread);
+extern void negotiation_done(struct thread *thread);
+extern void exchange_done(struct thread *thread);
+extern void loading_done(struct thread *thread);
+extern void adj_ok(struct thread *thread);
+extern void seqnumber_mismatch(struct thread *thread);
+extern void bad_lsreq(struct thread *thread);
+extern void oneway_received(struct thread *thread);
+extern void inactivity_timer(struct thread *thread);
 extern void ospf6_check_nbr_loading(struct ospf6_neighbor *on);
 
 extern void ospf6_neighbor_init(void);

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -970,7 +970,7 @@ int ospf6_redistribute_check(struct ospf6 *ospf6, struct ospf6_route *route,
 }
 
 /* This function performs ABR related processing */
-static int ospf6_abr_task_timer(struct thread *thread)
+static void ospf6_abr_task_timer(struct thread *thread)
 {
 	struct ospf6 *ospf6 = THREAD_ARG(thread);
 
@@ -982,8 +982,6 @@ static int ospf6_abr_task_timer(struct thread *thread)
 	ospf6_abr_task(ospf6);
 	/* if nssa-abr, then scan Type-7 LSDB */
 	ospf6_abr_nssa_task(ospf6);
-
-	return 0;
 }
 
 void ospf6_schedule_abr_task(struct ospf6 *ospf6)

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -605,7 +605,7 @@ static void ospf6_spf_log_database(struct ospf6_area *oa)
 	zlog_debug("%s", buffer);
 }
 
-static int ospf6_spf_calculation_thread(struct thread *t)
+static void ospf6_spf_calculation_thread(struct thread *t)
 {
 	struct ospf6_area *oa;
 	struct ospf6 *ospf6;
@@ -681,7 +681,6 @@ static int ospf6_spf_calculation_thread(struct thread *t)
 
 	ospf6->last_spf_reason = ospf6->spf_reason;
 	ospf6_reset_spf_reason(ospf6);
-	return 0;
 }
 
 /* Add schedule for SPF calculation.  To avoid frequenst SPF calc, we
@@ -1245,7 +1244,7 @@ int ospf6_ase_calculate_route(struct ospf6 *ospf6, struct ospf6_lsa *lsa,
 	return 0;
 }
 
-static int ospf6_ase_calculate_timer(struct thread *t)
+static void ospf6_ase_calculate_timer(struct thread *t)
 {
 	struct ospf6 *ospf6;
 	struct ospf6_lsa *lsa;
@@ -1283,8 +1282,6 @@ static int ospf6_ase_calculate_timer(struct thread *t)
 		ospf6_zebra_gr_disable(ospf6);
 		ospf6->gr_info.finishing_restart = false;
 	}
-
-	return 0;
 }
 
 void ospf6_ase_calculate_timer_add(struct ospf6 *ospf6)

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -586,7 +586,7 @@ void ospf6_master_init(struct thread_master *master)
 	om6->master = master;
 }
 
-static int ospf6_maxage_remover(struct thread *thread)
+static void ospf6_maxage_remover(struct thread *thread)
 {
 	struct ospf6 *o = (struct ospf6 *)THREAD_ARG(thread);
 	struct ospf6_area *oa;
@@ -603,7 +603,7 @@ static int ospf6_maxage_remover(struct thread *thread)
 					continue;
 
 				ospf6_maxage_remove(o);
-				return 0;
+				return;
 			}
 		}
 	}
@@ -627,8 +627,6 @@ static int ospf6_maxage_remover(struct thread *thread)
 	if (reschedule) {
 		ospf6_maxage_remove(o);
 	}
-
-	return 0;
 }
 
 void ospf6_maxage_remove(struct ospf6 *o)

--- a/ospfclient/ospfclient.c
+++ b/ospfclient/ospfclient.c
@@ -82,7 +82,7 @@ struct my_opaque_lsa {
  * ---------------------------------------------------------
  */
 
-static int lsa_delete(struct thread *t)
+static void lsa_delete(struct thread *t)
 {
 	struct ospf_apiclient *oclient;
 	struct in_addr area_id;
@@ -93,7 +93,7 @@ static int lsa_delete(struct thread *t)
 	rc = inet_aton(args[6], &area_id);
 	if (rc <= 0) {
 		printf("Address Specified: %s is invalid\n", args[6]);
-		return rc;
+		return;
 	}
 
 	printf("Deleting LSA... ");
@@ -102,10 +102,9 @@ static int lsa_delete(struct thread *t)
 				       atoi(args[3]),  /* opaque type */
 				       atoi(args[4])); /* opaque ID */
 	printf("done, return code is = %d\n", rc);
-	return rc;
 }
 
-static int lsa_inject(struct thread *t)
+static void lsa_inject(struct thread *t)
 {
 	struct ospf_apiclient *cl;
 	struct in_addr ifaddr;
@@ -124,13 +123,13 @@ static int lsa_inject(struct thread *t)
 	rc = inet_aton(args[5], &ifaddr);
 	if (rc <= 0) {
 		printf("Ifaddr specified %s is invalid\n", args[5]);
-		return rc;
+		return;
 	}
 
 	rc = inet_aton(args[6], &area_id);
 	if (rc <= 0) {
 		printf("Area ID specified %s is invalid\n", args[6]);
-		return rc;
+		return;
 	}
 	lsa_type = atoi(args[2]);
 	opaque_type = atoi(args[3]);
@@ -146,14 +145,12 @@ static int lsa_inject(struct thread *t)
 	printf("done, return code is %d\n", rc);
 
 	counter++;
-
-	return 0;
 }
 
 
 /* This thread handles asynchronous messages coming in from the OSPF
    API server */
-static int lsa_read(struct thread *thread)
+static void lsa_read(struct thread *thread)
 {
 	struct ospf_apiclient *oclient;
 	int fd;
@@ -173,8 +170,6 @@ static int lsa_read(struct thread *thread)
 
 	/* Reschedule read thread */
 	thread_add_read(master, lsa_read, oclient, fd, NULL);
-
-	return 0;
 }
 
 /* ---------------------------------------------------------

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -1829,7 +1829,7 @@ void ospf_abr_task(struct ospf *ospf)
 		zlog_debug("ospf_abr_task(): Stop");
 }
 
-static int ospf_abr_task_timer(struct thread *thread)
+static void ospf_abr_task_timer(struct thread *thread)
 {
 	struct ospf *ospf = THREAD_ARG(thread);
 
@@ -1843,8 +1843,6 @@ static int ospf_abr_task_timer(struct thread *thread)
 
 	ospf_abr_task(ospf);
 	ospf_abr_nssa_task(ospf); /* if nssa-abr, then scan Type-7 LSDB */
-
-	return 0;
 }
 
 void ospf_schedule_abr_task(struct ospf *ospf)

--- a/ospfd/ospf_apiserver.h
+++ b/ospfd/ospf_apiserver.h
@@ -91,10 +91,10 @@ extern void ospf_apiserver_free(struct ospf_apiserver *apiserv);
 extern void ospf_apiserver_event(enum event event, int fd,
 				 struct ospf_apiserver *apiserv);
 extern int ospf_apiserver_serv_sock_family(unsigned short port, int family);
-extern int ospf_apiserver_accept(struct thread *thread);
-extern int ospf_apiserver_read(struct thread *thread);
-extern int ospf_apiserver_sync_write(struct thread *thread);
-extern int ospf_apiserver_async_write(struct thread *thread);
+extern void ospf_apiserver_accept(struct thread *thread);
+extern void ospf_apiserver_read(struct thread *thread);
+extern void ospf_apiserver_sync_write(struct thread *thread);
+extern void ospf_apiserver_async_write(struct thread *thread);
 extern int ospf_apiserver_send_reply(struct ospf_apiserver *apiserv,
 				     uint32_t seqnr, uint8_t rc);
 

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -279,7 +279,7 @@ void ospf_asbr_status_update(struct ospf *ospf, uint8_t status)
 /* If there's redistribution configured, we need to refresh external
  * LSAs in order to install Type-7 and flood to all NSSA Areas
  */
-static int ospf_asbr_nssa_redist_update_timer(struct thread *thread)
+static void ospf_asbr_nssa_redist_update_timer(struct thread *thread)
 {
 	struct ospf *ospf = THREAD_ARG(thread);
 	int type;
@@ -305,8 +305,6 @@ static int ospf_asbr_nssa_redist_update_timer(struct thread *thread)
 	}
 
 	ospf_external_lsa_refresh_default(ospf);
-
-	return 0;
 }
 
 void ospf_schedule_asbr_nssa_redist_update(struct ospf *ospf)
@@ -1064,7 +1062,7 @@ static void ospf_handle_external_aggr_update(struct ospf *ospf)
 	}
 }
 
-static int ospf_asbr_external_aggr_process(struct thread *thread)
+static void ospf_asbr_external_aggr_process(struct thread *thread)
 {
 	struct ospf *ospf = THREAD_ARG(thread);
 	int operation = 0;
@@ -1086,8 +1084,6 @@ static int ospf_asbr_external_aggr_process(struct thread *thread)
 	default:
 		break;
 	}
-
-	return OSPF_SUCCESS;
 }
 static void ospf_external_aggr_timer(struct ospf *ospf,
 				     struct ospf_external_aggr_rt *aggr,

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -564,7 +564,7 @@ static int ospf_ase_compare_tables(struct ospf *ospf,
 	return 0;
 }
 
-static int ospf_ase_calculate_timer(struct thread *t)
+static void ospf_ase_calculate_timer(struct thread *t)
 {
 	struct ospf *ospf;
 	struct ospf_lsa *lsa;
@@ -631,8 +631,6 @@ static int ospf_ase_calculate_timer(struct thread *t)
 		ospf_zebra_gr_disable(ospf);
 		ospf->gr_info.finishing_restart = false;
 	}
-
-	return 0;
 }
 
 void ospf_ase_calculate_schedule(struct ospf *ospf)

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -510,14 +510,12 @@ void ospf_gr_check_adjs(struct ospf *ospf)
 }
 
 /* Handling of grace period expiry. */
-static int ospf_gr_grace_period_expired(struct thread *thread)
+static void ospf_gr_grace_period_expired(struct thread *thread)
 {
 	struct ospf *ospf = THREAD_ARG(thread);
 
 	ospf->gr_info.t_grace_period = NULL;
 	ospf_gr_restart_exit(ospf, "grace period has expired");
-
-	return 0;
 }
 
 /*

--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -346,14 +346,13 @@ static int ospf_extract_grace_lsa_fields(struct ospf_lsa *lsa,
  * Returns:
  *    Nothing
  */
-static int ospf_handle_grace_timer_expiry(struct thread *thread)
+static void ospf_handle_grace_timer_expiry(struct thread *thread)
 {
 	struct ospf_neighbor *nbr = THREAD_ARG(thread);
 
 	nbr->gr_helper_info.t_grace_timer = NULL;
 
 	ospf_gr_helper_exit(nbr, OSPF_GR_HELPER_GRACE_TIMEOUT);
-	return OSPF_GR_SUCCESS;
 }
 
 /*

--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -248,7 +248,7 @@ int ospf_dr_election(struct ospf_interface *oi)
 }
 
 
-int ospf_hello_timer(struct thread *thread)
+void ospf_hello_timer(struct thread *thread)
 {
 	struct ospf_interface *oi;
 
@@ -263,11 +263,9 @@ int ospf_hello_timer(struct thread *thread)
 
 	/* Hello timer set. */
 	OSPF_HELLO_TIMER_ON(oi);
-
-	return 0;
 }
 
-static int ospf_wait_timer(struct thread *thread)
+static void ospf_wait_timer(struct thread *thread)
 {
 	struct ospf_interface *oi;
 
@@ -278,8 +276,6 @@ static int ospf_wait_timer(struct thread *thread)
 		zlog_debug("ISM[%s]: Timer (Wait timer expire)", IF_NAME(oi));
 
 	OSPF_ISM_EVENT_SCHEDULE(oi, ISM_WaitTimer);
-
-	return 0;
 }
 
 /* Hook function called after ospf ISM event is occurred. And vty's
@@ -575,7 +571,7 @@ static void ism_change_state(struct ospf_interface *oi, int state)
 }
 
 /* Execute ISM event process. */
-int ospf_ism_event(struct thread *thread)
+void ospf_ism_event(struct thread *thread)
 {
 	int event;
 	int next_state;
@@ -601,6 +597,4 @@ int ospf_ism_event(struct thread *thread)
 
 	/* Make sure timer is set. */
 	ism_timer_set(oi);
-
-	return 0;
 }

--- a/ospfd/ospf_ism.h
+++ b/ospfd/ospf_ism.h
@@ -90,9 +90,9 @@
 	thread_execute(master, ospf_ism_event, (I), (E))
 
 /* Prototypes. */
-extern int ospf_ism_event(struct thread *);
+extern void ospf_ism_event(struct thread *thread);
 extern void ism_change_status(struct ospf_interface *, int);
-extern int ospf_hello_timer(struct thread *thread);
+extern void ospf_hello_timer(struct thread *thread);
 extern int ospf_dr_election(struct ospf_interface *oi);
 
 DECLARE_HOOK(ospf_ism_change,

--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -353,7 +353,7 @@ static int ospf_ldp_sync_ism_change(struct ospf_interface *oi, int state,
 /*
  * LDP-SYNC holddown timer routines
  */
-static int ospf_ldp_sync_holddown_timer(struct thread *thread)
+static void ospf_ldp_sync_holddown_timer(struct thread *thread)
 {
 	struct interface *ifp;
 	struct ospf_if_params *params;
@@ -375,7 +375,6 @@ static int ospf_ldp_sync_holddown_timer(struct thread *thread)
 
 		ospf_if_recalculate_output_cost(ifp);
 	}
-	return 0;
 }
 
 void ospf_ldp_sync_holddown_timer_add(struct interface *ifp)

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -734,7 +734,7 @@ void ospf_router_lsa_body_set(struct stream **s, struct ospf_area *area)
 	stream_putw_at(*s, putp, cnt);
 }
 
-static int ospf_stub_router_timer(struct thread *t)
+static void ospf_stub_router_timer(struct thread *t)
 {
 	struct ospf_area *area = THREAD_ARG(t);
 
@@ -746,13 +746,11 @@ static int ospf_stub_router_timer(struct thread *t)
 	 * clobber an administratively set stub-router state though.
 	 */
 	if (CHECK_FLAG(area->stub_router_state, OSPF_AREA_ADMIN_STUB_ROUTED))
-		return 0;
+		return;
 
 	UNSET_FLAG(area->stub_router_state, OSPF_AREA_IS_STUB_ROUTED);
 
 	ospf_router_lsa_update_area(area);
-
-	return 0;
 }
 
 static void ospf_stub_router_check(struct ospf_area *area)
@@ -3025,7 +3023,7 @@ int ospf_check_nbr_status(struct ospf *ospf)
 }
 
 
-static int ospf_maxage_lsa_remover(struct thread *thread)
+static void ospf_maxage_lsa_remover(struct thread *thread)
 {
 	struct ospf *ospf = THREAD_ARG(thread);
 	struct ospf_lsa *lsa, *old;
@@ -3062,7 +3060,7 @@ static int ospf_maxage_lsa_remover(struct thread *thread)
 					      ospf_maxage_lsa_remover, 0);
 				route_unlock_node(
 					rn); /* route_top/route_next */
-				return 0;
+				return;
 			}
 
 			/* Remove LSA from the LSDB */
@@ -3118,8 +3116,6 @@ static int ospf_maxage_lsa_remover(struct thread *thread)
 	if (reschedule)
 		OSPF_TIMER_ON(ospf->t_maxage, ospf_maxage_lsa_remover,
 			      ospf->maxage_delay);
-
-	return 0;
 }
 
 /* This function checks whether an LSA with initial sequence number should be
@@ -3275,7 +3271,7 @@ static int ospf_lsa_maxage_walker_remover(struct ospf *ospf,
 }
 
 /* Periodical check of MaxAge LSA. */
-int ospf_lsa_maxage_walker(struct thread *thread)
+void ospf_lsa_maxage_walker(struct thread *thread)
 {
 	struct ospf *ospf = THREAD_ARG(thread);
 	struct route_node *rn;
@@ -3312,7 +3308,6 @@ int ospf_lsa_maxage_walker(struct thread *thread)
 
 	OSPF_TIMER_ON(ospf->t_maxage_walker, ospf_lsa_maxage_walker,
 		      OSPF_LSA_MAXAGE_CHECK_INTERVAL);
-	return 0;
 }
 
 struct ospf_lsa *ospf_lsa_lookup_by_prefix(struct ospf_lsdb *lsdb, uint8_t type,
@@ -3773,7 +3768,7 @@ struct lsa_action {
 	struct ospf_lsa *lsa;
 };
 
-static int ospf_lsa_action(struct thread *t)
+static void ospf_lsa_action(struct thread *t)
 {
 	struct lsa_action *data;
 
@@ -3794,7 +3789,6 @@ static int ospf_lsa_action(struct thread *t)
 
 	ospf_lsa_unlock(&data->lsa); /* Message */
 	XFREE(MTYPE_OSPF_MESSAGE, data);
-	return 0;
 }
 
 void ospf_schedule_lsa_flood_area(struct ospf_area *area, struct ospf_lsa *lsa)
@@ -3965,7 +3959,7 @@ void ospf_refresher_unregister_lsa(struct ospf *ospf, struct ospf_lsa *lsa)
 	}
 }
 
-int ospf_lsa_refresh_walker(struct thread *t)
+void ospf_lsa_refresh_walker(struct thread *t)
 {
 	struct list *refresh_list;
 	struct listnode *node, *nnode;
@@ -4044,8 +4038,6 @@ int ospf_lsa_refresh_walker(struct thread *t)
 
 	if (IS_DEBUG_OSPF(lsa, LSA_REFRESH))
 		zlog_debug("LSA[Refresh]: ospf_lsa_refresh_walker(): end");
-
-	return 0;
 }
 
 /* Flush the LSAs for the specific area */

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -308,7 +308,7 @@ extern struct ospf_lsa *ospf_lsa_lookup_by_prefix(struct ospf_lsdb *, uint8_t,
 extern void ospf_lsa_maxage(struct ospf *, struct ospf_lsa *);
 extern uint32_t get_metric(uint8_t *);
 
-extern int ospf_lsa_maxage_walker(struct thread *);
+extern void ospf_lsa_maxage_walker(struct thread *thread);
 extern struct ospf_lsa *ospf_lsa_refresh(struct ospf *, struct ospf_lsa *);
 
 extern void ospf_external_lsa_refresh_default(struct ospf *);
@@ -328,7 +328,7 @@ extern void ospf_schedule_lsa_flush_area(struct ospf_area *, struct ospf_lsa *);
 
 extern void ospf_refresher_register_lsa(struct ospf *, struct ospf_lsa *);
 extern void ospf_refresher_unregister_lsa(struct ospf *, struct ospf_lsa *);
-extern int ospf_lsa_refresh_walker(struct thread *);
+extern void ospf_lsa_refresh_walker(struct thread *thread);
 
 extern void ospf_lsa_maxage_delete(struct ospf *, struct ospf_lsa *);
 

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -59,7 +59,7 @@ DEFINE_HOOK(ospf_nsm_change,
 static void nsm_clear_adj(struct ospf_neighbor *);
 
 /* OSPF NSM Timer functions. */
-static int ospf_inactivity_timer(struct thread *thread)
+static void ospf_inactivity_timer(struct thread *thread)
 {
 	struct ospf_neighbor *nbr;
 
@@ -84,11 +84,9 @@ static int ospf_inactivity_timer(struct thread *thread)
 		OSPF_NSM_TIMER_ON(nbr->t_inactivity, ospf_inactivity_timer,
 				  nbr->v_inactivity);
 	}
-
-	return 0;
 }
 
-static int ospf_db_desc_timer(struct thread *thread)
+static void ospf_db_desc_timer(struct thread *thread)
 {
 	struct ospf_neighbor *nbr;
 
@@ -106,8 +104,6 @@ static int ospf_db_desc_timer(struct thread *thread)
 
 	/* DD Retransmit timer set. */
 	OSPF_NSM_TIMER_ON(nbr->t_db_desc, ospf_db_desc_timer, nbr->v_db_desc);
-
-	return 0;
 }
 
 /* Hook function called after ospf NSM event is occurred.
@@ -776,7 +772,7 @@ static void nsm_change_state(struct ospf_neighbor *nbr, int state)
 }
 
 /* Execute NSM event process. */
-int ospf_nsm_event(struct thread *thread)
+void ospf_nsm_event(struct thread *thread)
 {
 	int event;
 	int next_state;
@@ -846,8 +842,6 @@ int ospf_nsm_event(struct thread *thread)
 	 */
 	if (nbr->state == NSM_Deleted)
 		ospf_nbr_delete(nbr);
-
-	return 0;
 }
 
 /* Check loading state. */

--- a/ospfd/ospf_nsm.h
+++ b/ospfd/ospf_nsm.h
@@ -70,7 +70,7 @@
 	thread_execute(master, ospf_nsm_event, (N), (E))
 
 /* Prototypes. */
-extern int ospf_nsm_event(struct thread *);
+extern void ospf_nsm_event(struct thread *);
 extern void ospf_check_nbr_loading(struct ospf_neighbor *);
 extern int ospf_db_summary_isempty(struct ospf_neighbor *);
 extern int ospf_db_summary_count(struct ospf_neighbor *);

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1286,9 +1286,9 @@ out:
  * Followings are Opaque-LSA origination/refresh management functions.
  *------------------------------------------------------------------------*/
 
-static int ospf_opaque_type9_lsa_originate(struct thread *t);
-static int ospf_opaque_type10_lsa_originate(struct thread *t);
-static int ospf_opaque_type11_lsa_originate(struct thread *t);
+static void ospf_opaque_type9_lsa_originate(struct thread *t);
+static void ospf_opaque_type10_lsa_originate(struct thread *t);
+static void ospf_opaque_type11_lsa_originate(struct thread *t);
 static void ospf_opaque_lsa_reoriginate_resume(struct list *listtop, void *arg);
 
 void ospf_opaque_lsa_originate_schedule(struct ospf_interface *oi, int *delay0)
@@ -1460,10 +1460,9 @@ void ospf_opaque_lsa_originate_schedule(struct ospf_interface *oi, int *delay0)
 		*delay0 = delay;
 }
 
-static int ospf_opaque_type9_lsa_originate(struct thread *t)
+static void ospf_opaque_type9_lsa_originate(struct thread *t)
 {
 	struct ospf_interface *oi;
-	int rc;
 
 	oi = THREAD_ARG(t);
 	oi->t_opaque_lsa_self = NULL;
@@ -1472,15 +1471,12 @@ static int ospf_opaque_type9_lsa_originate(struct thread *t)
 		zlog_debug("Timer[Type9-LSA]: Originate Opaque-LSAs for OI %s",
 			   IF_NAME(oi));
 
-	rc = opaque_lsa_originate_callback(ospf_opaque_type9_funclist, oi);
-
-	return rc;
+	opaque_lsa_originate_callback(ospf_opaque_type9_funclist, oi);
 }
 
-static int ospf_opaque_type10_lsa_originate(struct thread *t)
+static void ospf_opaque_type10_lsa_originate(struct thread *t)
 {
 	struct ospf_area *area;
-	int rc;
 
 	area = THREAD_ARG(t);
 	area->t_opaque_lsa_self = NULL;
@@ -1490,15 +1486,12 @@ static int ospf_opaque_type10_lsa_originate(struct thread *t)
 			"Timer[Type10-LSA]: Originate Opaque-LSAs for Area %pI4",
 			&area->area_id);
 
-	rc = opaque_lsa_originate_callback(ospf_opaque_type10_funclist, area);
-
-	return rc;
+	opaque_lsa_originate_callback(ospf_opaque_type10_funclist, area);
 }
 
-static int ospf_opaque_type11_lsa_originate(struct thread *t)
+static void ospf_opaque_type11_lsa_originate(struct thread *t)
 {
 	struct ospf *top;
-	int rc;
 
 	top = THREAD_ARG(t);
 	top->t_opaque_lsa_self = NULL;
@@ -1507,9 +1500,7 @@ static int ospf_opaque_type11_lsa_originate(struct thread *t)
 		zlog_debug(
 			"Timer[Type11-LSA]: Originate AS-External Opaque-LSAs");
 
-	rc = opaque_lsa_originate_callback(ospf_opaque_type11_funclist, top);
-
-	return rc;
+	opaque_lsa_originate_callback(ospf_opaque_type11_funclist, top);
 }
 
 static void ospf_opaque_lsa_reoriginate_resume(struct list *listtop, void *arg)
@@ -1665,10 +1656,10 @@ struct ospf_lsa *ospf_opaque_lsa_refresh(struct ospf_lsa *lsa)
 static struct ospf_lsa *pseudo_lsa(struct ospf_interface *oi,
 				   struct ospf_area *area, uint8_t lsa_type,
 				   uint8_t opaque_type);
-static int ospf_opaque_type9_lsa_reoriginate_timer(struct thread *t);
-static int ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t);
-static int ospf_opaque_type11_lsa_reoriginate_timer(struct thread *t);
-static int ospf_opaque_lsa_refresh_timer(struct thread *t);
+static void ospf_opaque_type9_lsa_reoriginate_timer(struct thread *t);
+static void ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t);
+static void ospf_opaque_type11_lsa_reoriginate_timer(struct thread *t);
+static void ospf_opaque_lsa_refresh_timer(struct thread *t);
 
 void ospf_opaque_lsa_reoriginate_schedule(void *lsa_type_dependent,
 					  uint8_t lsa_type, uint8_t opaque_type)
@@ -1679,7 +1670,7 @@ void ospf_opaque_lsa_reoriginate_schedule(void *lsa_type_dependent,
 
 	struct ospf_lsa *lsa;
 	struct opaque_info_per_type *oipt;
-	int (*func)(struct thread * t) = NULL;
+	void (*func)(struct thread * t) = NULL;
 	int delay;
 
 	switch (lsa_type) {
@@ -1846,13 +1837,12 @@ static struct ospf_lsa *pseudo_lsa(struct ospf_interface *oi,
 	return &lsa;
 }
 
-static int ospf_opaque_type9_lsa_reoriginate_timer(struct thread *t)
+static void ospf_opaque_type9_lsa_reoriginate_timer(struct thread *t)
 {
 	struct opaque_info_per_type *oipt;
 	struct ospf_opaque_functab *functab;
 	struct ospf *top;
 	struct ospf_interface *oi;
-	int rc = -1;
 
 	oipt = THREAD_ARG(t);
 
@@ -1861,7 +1851,7 @@ static int ospf_opaque_type9_lsa_reoriginate_timer(struct thread *t)
 		flog_warn(
 			EC_OSPF_LSA,
 			"ospf_opaque_type9_lsa_reoriginate_timer: No associated function?");
-		goto out;
+		return;
 	}
 
 	oi = (struct ospf_interface *)oipt->owner;
@@ -1869,7 +1859,7 @@ static int ospf_opaque_type9_lsa_reoriginate_timer(struct thread *t)
 		flog_warn(
 			EC_OSPF_LSA,
 			"ospf_opaque_type9_lsa_reoriginate_timer: Something wrong?");
-		goto out;
+		return;
 	}
 
 	if (!CHECK_FLAG(top->config, OSPF_OPAQUE_CAPABLE)
@@ -1881,8 +1871,7 @@ static int ospf_opaque_type9_lsa_reoriginate_timer(struct thread *t)
 				oipt->opaque_type);
 
 		oipt->status = PROC_SUSPEND;
-		rc = 0;
-		goto out;
+		return;
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
@@ -1890,12 +1879,10 @@ static int ospf_opaque_type9_lsa_reoriginate_timer(struct thread *t)
 			"Timer[Type9-LSA]: Re-originate Opaque-LSAs (opaque-type=%u) for OI (%s)",
 			oipt->opaque_type, IF_NAME(oi));
 
-	rc = (*functab->lsa_originator)(oi);
-out:
-	return rc;
+	(*functab->lsa_originator)(oi);
 }
 
-static int ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t)
+static void ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t)
 {
 	struct opaque_info_per_type *oipt;
 	struct ospf_opaque_functab *functab;
@@ -1903,7 +1890,7 @@ static int ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t)
 	struct ospf *top;
 	struct ospf_area *area;
 	struct ospf_interface *oi;
-	int n, rc = -1;
+	int n;
 
 	oipt = THREAD_ARG(t);
 
@@ -1912,7 +1899,7 @@ static int ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t)
 		flog_warn(
 			EC_OSPF_LSA,
 			"ospf_opaque_type10_lsa_reoriginate_timer: No associated function?");
-		goto out;
+		return;
 	}
 
 	area = (struct ospf_area *)oipt->owner;
@@ -1920,7 +1907,7 @@ static int ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t)
 		flog_warn(
 			EC_OSPF_LSA,
 			"ospf_opaque_type10_lsa_reoriginate_timer: Something wrong?");
-		goto out;
+		return;
 	}
 
 	/* There must be at least one "opaque-capable, full-state" neighbor. */
@@ -1937,8 +1924,7 @@ static int ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t)
 				oipt->opaque_type);
 
 		oipt->status = PROC_SUSPEND;
-		rc = 0;
-		goto out;
+		return;
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
@@ -1946,17 +1932,14 @@ static int ospf_opaque_type10_lsa_reoriginate_timer(struct thread *t)
 			"Timer[Type10-LSA]: Re-originate Opaque-LSAs (opaque-type=%u) for Area %pI4",
 			oipt->opaque_type, &area->area_id);
 
-	rc = (*functab->lsa_originator)(area);
-out:
-	return rc;
+	(*functab->lsa_originator)(area);
 }
 
-static int ospf_opaque_type11_lsa_reoriginate_timer(struct thread *t)
+static void ospf_opaque_type11_lsa_reoriginate_timer(struct thread *t)
 {
 	struct opaque_info_per_type *oipt;
 	struct ospf_opaque_functab *functab;
 	struct ospf *top;
-	int rc = -1;
 
 	oipt = THREAD_ARG(t);
 
@@ -1965,14 +1948,14 @@ static int ospf_opaque_type11_lsa_reoriginate_timer(struct thread *t)
 		flog_warn(
 			EC_OSPF_LSA,
 			"ospf_opaque_type11_lsa_reoriginate_timer: No associated function?");
-		goto out;
+		return;
 	}
 
 	if ((top = (struct ospf *)oipt->owner) == NULL) {
 		flog_warn(
 			EC_OSPF_LSA,
 			"ospf_opaque_type11_lsa_reoriginate_timer: Something wrong?");
-		goto out;
+		return;
 	}
 
 	if (!CHECK_FLAG(top->config, OSPF_OPAQUE_CAPABLE)) {
@@ -1982,8 +1965,7 @@ static int ospf_opaque_type11_lsa_reoriginate_timer(struct thread *t)
 				oipt->opaque_type);
 
 		oipt->status = PROC_SUSPEND;
-		rc = 0;
-		goto out;
+		return;
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
@@ -1991,9 +1973,7 @@ static int ospf_opaque_type11_lsa_reoriginate_timer(struct thread *t)
 			"Timer[Type11-LSA]: Re-originate Opaque-LSAs (opaque-type=%u).",
 			oipt->opaque_type);
 
-	rc = (*functab->lsa_originator)(top);
-out:
-	return rc;
+	(*functab->lsa_originator)(top);
 }
 
 void ospf_opaque_lsa_refresh_schedule(struct ospf_lsa *lsa0)
@@ -2064,7 +2044,7 @@ out:
 	return;
 }
 
-static int ospf_opaque_lsa_refresh_timer(struct thread *t)
+static void ospf_opaque_lsa_refresh_timer(struct thread *t)
 {
 	struct opaque_info_per_id *oipi;
 	struct ospf_opaque_functab *functab;
@@ -2079,8 +2059,6 @@ static int ospf_opaque_lsa_refresh_timer(struct thread *t)
 		if ((functab = oipi->opqctl_type->functab) != NULL)
 			if (functab->lsa_refresher != NULL)
 				(*functab->lsa_refresher)(lsa);
-
-	return 0;
 }
 
 void ospf_opaque_lsa_flush_schedule(struct ospf_lsa *lsa0)

--- a/ospfd/ospf_packet.h
+++ b/ospfd/ospf_packet.h
@@ -139,7 +139,7 @@ extern struct ospf_packet *ospf_fifo_head(struct ospf_fifo *);
 extern void ospf_fifo_flush(struct ospf_fifo *);
 extern void ospf_fifo_free(struct ospf_fifo *);
 
-extern int ospf_read(struct thread *);
+extern void ospf_read(struct thread *thread);
 extern void ospf_hello_send(struct ospf_interface *);
 extern void ospf_db_desc_send(struct ospf_neighbor *);
 extern void ospf_db_desc_resend(struct ospf_neighbor *);
@@ -152,10 +152,10 @@ extern void ospf_ls_ack_send_delayed(struct ospf_interface *);
 extern void ospf_ls_retransmit(struct ospf_interface *, struct ospf_lsa *);
 extern void ospf_ls_req_event(struct ospf_neighbor *);
 
-extern int ospf_ls_upd_timer(struct thread *);
-extern int ospf_ls_ack_timer(struct thread *);
-extern int ospf_poll_timer(struct thread *);
-extern int ospf_hello_reply_timer(struct thread *);
+extern void ospf_ls_upd_timer(struct thread *thread);
+extern void ospf_ls_ack_timer(struct thread *thread);
+extern void ospf_poll_timer(struct thread *thread);
+extern void ospf_hello_reply_timer(struct thread *thread);
 
 extern const struct message ospf_packet_type_str[];
 extern const size_t ospf_packet_type_str_max;

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1809,7 +1809,7 @@ void ospf_spf_calculate_areas(struct ospf *ospf, struct route_table *new_table,
 }
 
 /* Worker for SPF calculation scheduler. */
-static int ospf_spf_calculate_schedule_worker(struct thread *thread)
+static void ospf_spf_calculate_schedule_worker(struct thread *thread)
 {
 	struct ospf *ospf = THREAD_ARG(thread);
 	struct route_table *new_table, *new_rtrs;
@@ -1929,8 +1929,6 @@ static int ospf_spf_calculate_schedule_worker(struct thread *thread)
 	}
 
 	ospf_clear_spf_reason_flags();
-
-	return 0;
 }
 
 /*

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -470,7 +470,7 @@ int ospf_sr_local_block_release_label(mpls_label_t label)
  *
  * @return		1 on success
  */
-static int sr_start_label_manager(struct thread *start)
+static void sr_start_label_manager(struct thread *start)
 {
 	struct ospf *ospf;
 
@@ -478,8 +478,6 @@ static int sr_start_label_manager(struct thread *start)
 
 	/* re-attempt to start SR & Label Manager connection */
 	ospf_sr_start(ospf);
-
-	return 1;
 }
 
 /* Segment Routing starter function */

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -524,7 +524,7 @@ bool ospf_external_default_routemap_apply_walk(struct ospf *ospf,
  * Function to originate or flush default after applying
  * route-map on all ei.
  */
-static int ospf_external_lsa_default_routemap_timer(struct thread *thread)
+static void ospf_external_lsa_default_routemap_timer(struct thread *thread)
 {
 	struct list *ext_list;
 	struct ospf *ospf = THREAD_ARG(thread);
@@ -545,7 +545,7 @@ static int ospf_external_lsa_default_routemap_timer(struct thread *thread)
 		/* Nothing to be done here. */
 		if (IS_DEBUG_OSPF_DEFAULT_INFO)
 			zlog_debug("Default originate info not present");
-		return 0;
+		return;
 	}
 
 	/* For all the ei apply route-map */
@@ -570,8 +570,6 @@ static int ospf_external_lsa_default_routemap_timer(struct thread *thread)
 		ospf_external_lsa_refresh(ospf, lsa, default_ei, true, false);
 	else if (!ret && lsa)
 		ospf_external_lsa_flush(ospf, DEFAULT_ROUTE, &default_ei->p, 0);
-
-	return 1;
 }
 
 
@@ -1522,7 +1520,7 @@ int ospf_distribute_list_out_unset(struct ospf *ospf, int type,
 }
 
 /* distribute-list update timer. */
-static int ospf_distribute_list_update_timer(struct thread *thread)
+static void ospf_distribute_list_update_timer(struct thread *thread)
 {
 	struct route_node *rn;
 	struct external_info *ei;
@@ -1532,7 +1530,7 @@ static int ospf_distribute_list_update_timer(struct thread *thread)
 	struct ospf *ospf = THREAD_ARG(thread);
 
 	if (ospf == NULL)
-		return 0;
+		return;
 
 	ospf->t_distribute_update = NULL;
 
@@ -1639,8 +1637,6 @@ static int ospf_distribute_list_update_timer(struct thread *thread)
 	}
 	if (default_refresh)
 		ospf_external_lsa_refresh_default(ospf);
-
-	return 0;
 }
 
 /* Update distribute-list and set timer to apply access-list. */

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -584,13 +584,11 @@ static void ospf_deferred_shutdown_finish(struct ospf *ospf)
 }
 
 /* Timer thread for G-R */
-static int ospf_deferred_shutdown_timer(struct thread *t)
+static void ospf_deferred_shutdown_timer(struct thread *t)
 {
 	struct ospf *ospf = THREAD_ARG(t);
 
 	ospf_deferred_shutdown_finish(ospf);
-
-	return 0;
 }
 
 /* Check whether deferred-shutdown must be scheduled, otherwise call

--- a/pathd/path_pcep_controller.h
+++ b/pathd/path_pcep_controller.h
@@ -90,7 +90,7 @@ struct pcep_ctrl_socket_data {
 	void *payload;
 };
 
-typedef int (*pcep_ctrl_thread_callback)(struct thread *);
+typedef void (*pcep_ctrl_thread_callback)(struct thread *);
 
 /* PCC connection information, populated in a thread-safe
  * manner with pcep_ctrl_get_pcc_info() */
@@ -174,7 +174,7 @@ int pcep_thread_socket_write(void *fpt, void **thread, int fd, void *payload,
 
 int pcep_thread_send_ctrl_event(void *fpt, void *payload,
 				pcep_ctrl_thread_callback cb);
-int pcep_thread_pcep_event(struct thread *thread);
+void pcep_thread_pcep_event(struct thread *thread);
 int pcep_thread_pcc_count(struct ctrl_state *ctrl_state);
 /* Called by the PCC to refine a path in the main thread */
 int pcep_thread_refine_path(struct ctrl_state *ctrl_state, int pcc_id,

--- a/pathd/path_pcep_lib.c
+++ b/pathd/path_pcep_lib.c
@@ -45,8 +45,8 @@ static int pcep_lib_pceplib_socket_read_cb(void *fpt, void **thread, int fd,
 					   void *payload);
 static int pcep_lib_pceplib_socket_write_cb(void *fpt, void **thread, int fd,
 					    void *payload);
-static int pcep_lib_socket_read_ready(struct thread *thread);
-static int pcep_lib_socket_write_ready(struct thread *thread);
+static void pcep_lib_socket_read_ready(struct thread *thread);
+static void pcep_lib_socket_write_ready(struct thread *thread);
 
 /* pceplib pcep_event callbacks */
 static void pcep_lib_pceplib_event_cb(void *fpt, pcep_event *event);
@@ -241,26 +241,22 @@ int pcep_lib_pceplib_socket_read_cb(void *fpt, void **thread, int fd,
 /* Callbacks called by path_pcep_controller when a socket is ready to read/write
  */
 
-int pcep_lib_socket_write_ready(struct thread *thread)
+void pcep_lib_socket_write_ready(struct thread *thread)
 {
 	struct pcep_ctrl_socket_data *data = THREAD_ARG(thread);
 	assert(data != NULL);
 
-	int retval = pceplib_external_socket_write(data->fd, data->payload);
+	pceplib_external_socket_write(data->fd, data->payload);
 	XFREE(MTYPE_PCEP, data);
-
-	return retval;
 }
 
-int pcep_lib_socket_read_ready(struct thread *thread)
+void pcep_lib_socket_read_ready(struct thread *thread)
 {
 	struct pcep_ctrl_socket_data *data = THREAD_ARG(thread);
 	assert(data != NULL);
 
-	int retval = pceplib_external_socket_read(data->fd, data->payload);
+	pceplib_external_socket_read(data->fd, data->payload);
 	XFREE(MTYPE_PCEP, data);
-
-	return retval;
 }
 
 /* Callback passed to pceplib when a pcep_event is ready */

--- a/pathd/path_ted.c
+++ b/pathd/path_ted.c
@@ -39,8 +39,8 @@ static void path_ted_unregister_vty(void);
 static uint32_t path_ted_start_importing_igp(const char *daemon_str);
 static uint32_t path_ted_stop_importing_igp(void);
 static enum zclient_send_status path_ted_link_state_sync(void);
-static int path_ted_timer_handler_sync(struct thread *thread);
-static int path_ted_timer_handler_refresh(struct thread *thread);
+static void path_ted_timer_handler_sync(struct thread *thread);
+static void path_ted_timer_handler_refresh(struct thread *thread);
 static int path_ted_cli_debug_config_write(struct vty *vty);
 static int path_ted_cli_debug_set_all(uint32_t flags, bool set);
 
@@ -602,14 +602,14 @@ enum zclient_send_status path_ted_link_state_sync(void)
  *
  * @return		status
  */
-int path_ted_timer_handler_sync(struct thread *thread)
+void path_ted_timer_handler_sync(struct thread *thread)
 {
 	/* data unpacking */
 	struct ted_state *data = THREAD_ARG(thread);
 
 	assert(data != NULL);
 	/* Retry the sync */
-	return path_ted_link_state_sync();
+	path_ted_link_state_sync();
 }
 
 /**
@@ -639,10 +639,10 @@ int path_ted_segment_list_refresh(void)
  *
  * @return		status
  */
-int path_ted_timer_handler_refresh(struct thread *thread)
+void path_ted_timer_handler_refresh(struct thread *thread)
 {
 	if (!path_ted_is_initialized())
-		return MPLS_LABEL_NONE;
+		return;
 
 	PATH_TED_DEBUG("%s: PATHD-TED: Refresh sid from current TED", __func__);
 	/* data unpacking */
@@ -651,7 +651,6 @@ int path_ted_timer_handler_refresh(struct thread *thread)
 	assert(data != NULL);
 
 	srte_policy_update_ted_sid();
-	return 0;
 }
 
 /**

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -45,9 +45,9 @@ DEFINE_HOOK(pathd_candidate_removed, (struct srte_candidate * candidate),
 	    (candidate));
 
 static void trigger_pathd_candidate_created(struct srte_candidate *candidate);
-static int trigger_pathd_candidate_created_timer(struct thread *thread);
+static void trigger_pathd_candidate_created_timer(struct thread *thread);
 static void trigger_pathd_candidate_updated(struct srte_candidate *candidate);
-static int trigger_pathd_candidate_updated_timer(struct thread *thread);
+static void trigger_pathd_candidate_updated_timer(struct thread *thread);
 static void trigger_pathd_candidate_removed(struct srte_candidate *candidate);
 static const char *
 srte_candidate_metric_name(enum srte_candidate_metric_type type);
@@ -1240,11 +1240,11 @@ void trigger_pathd_candidate_created(struct srte_candidate *candidate)
 			 (void *)candidate, HOOK_DELAY, &candidate->hook_timer);
 }
 
-int trigger_pathd_candidate_created_timer(struct thread *thread)
+void trigger_pathd_candidate_created_timer(struct thread *thread)
 {
 	struct srte_candidate *candidate = THREAD_ARG(thread);
 	candidate->hook_timer = NULL;
-	return hook_call(pathd_candidate_created, candidate);
+	hook_call(pathd_candidate_created, candidate);
 }
 
 void trigger_pathd_candidate_updated(struct srte_candidate *candidate)
@@ -1260,11 +1260,11 @@ void trigger_pathd_candidate_updated(struct srte_candidate *candidate)
 			 (void *)candidate, HOOK_DELAY, &candidate->hook_timer);
 }
 
-int trigger_pathd_candidate_updated_timer(struct thread *thread)
+void trigger_pathd_candidate_updated_timer(struct thread *thread)
 {
 	struct srte_candidate *candidate = THREAD_ARG(thread);
 	candidate->hook_timer = NULL;
-	return hook_call(pathd_candidate_updated, candidate);
+	hook_call(pathd_candidate_updated, candidate);
 }
 
 void trigger_pathd_candidate_removed(struct srte_candidate *candidate)

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -473,7 +473,7 @@ static int pim_assert_cancel(struct pim_ifchannel *ch)
 	return pim_assert_do(ch, metric);
 }
 
-static int on_assert_timer(struct thread *t)
+static void on_assert_timer(struct thread *t)
 {
 	struct pim_ifchannel *ch;
 	struct interface *ifp;
@@ -504,8 +504,6 @@ static int on_assert_timer(struct thread *t)
 				ifp->name);
 	}
 	}
-
-	return 0;
 }
 
 static void assert_timer_off(struct pim_ifchannel *ch)

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -157,7 +157,7 @@ static struct bsgrp_node *pim_bsm_new_bsgrp_node(struct route_table *rt,
 	return bsgrp;
 }
 
-static int pim_on_bs_timer(struct thread *t)
+static void pim_on_bs_timer(struct thread *t)
 {
 	struct route_node *rn;
 	struct bsm_scope *scope;
@@ -200,7 +200,6 @@ static int pim_on_bs_timer(struct thread *t)
 		pim_bsm_rpinfos_free(bsgrp_node->partial_bsrp_list);
 		bsgrp_node->pend_rp_cnt = 0;
 	}
-	return 0;
 }
 
 static void pim_bs_timer_stop(struct bsm_scope *scope)
@@ -276,7 +275,7 @@ static bool is_hold_time_elapsed(void *data)
 		return true;
 }
 
-static int pim_on_g2rp_timer(struct thread *t)
+static void pim_on_g2rp_timer(struct thread *t)
 {
 	struct bsm_rpinfo *bsrp;
 	struct bsm_rpinfo *bsrp_node;
@@ -312,14 +311,14 @@ static int pim_on_g2rp_timer(struct thread *t)
 
 	if (!rn) {
 		zlog_warn("%s: Route node doesn't exist", __func__);
-		return 0;
+		return;
 	}
 
 	rp_info = (struct rp_info *)rn->info;
 
 	if (!rp_info) {
 		route_unlock_node(rn);
-		return 0;
+		return;
 	}
 
 	if (rp_info->rp_src != RP_SRC_STATIC) {
@@ -342,8 +341,6 @@ static int pim_on_g2rp_timer(struct thread *t)
 				    &bsgrp_node->group);
 		pim_free_bsgrp_data(bsgrp_node);
 	}
-
-	return 0;
 }
 
 static void pim_g2rp_timer_start(struct bsm_rpinfo *bsrp, int hold_time)

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -644,7 +644,7 @@ static void ifjoin_to_noinfo(struct pim_ifchannel *ch)
 	delete_on_noinfo(ch);
 }
 
-static int on_ifjoin_expiry_timer(struct thread *t)
+static void on_ifjoin_expiry_timer(struct thread *t)
 {
 	struct pim_ifchannel *ch;
 
@@ -656,11 +656,9 @@ static int on_ifjoin_expiry_timer(struct thread *t)
 
 	ifjoin_to_noinfo(ch);
 	/* ch may have been deleted */
-
-	return 0;
 }
 
-static int on_ifjoin_prune_pending_timer(struct thread *t)
+static void on_ifjoin_prune_pending_timer(struct thread *t)
 {
 	struct pim_ifchannel *ch;
 	int send_prune_echo; /* boolean */
@@ -726,8 +724,6 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
 		}
 		/* from here ch may have been deleted */
 	}
-
-	return 0;
 }
 
 static void check_recv_upstream(int is_join, struct interface *recv_ifp,

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -40,7 +40,7 @@
 #include "pim_zebra.h"
 
 static void group_timer_off(struct gm_group *group);
-static int pim_igmp_general_query(struct thread *t);
+static void pim_igmp_general_query(struct thread *t);
 
 /* This socket is used for TXing IGMP packets only, IGMP RX happens
  * in pim_mroute_msg()
@@ -141,7 +141,7 @@ struct gm_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
 	return NULL;
 }
 
-static int pim_igmp_other_querier_expire(struct thread *t)
+static void pim_igmp_other_querier_expire(struct thread *t)
 {
 	struct gm_sock *igmp;
 
@@ -166,8 +166,6 @@ static int pim_igmp_other_querier_expire(struct thread *t)
 	  Query, Set Gen. Query. timer)
 	*/
 	pim_igmp_general_query(t);
-
-	return 0;
 }
 
 void pim_igmp_other_querier_timer_on(struct gm_sock *igmp)
@@ -705,7 +703,7 @@ void pim_igmp_general_query_off(struct gm_sock *igmp)
 }
 
 /* Issue IGMP general query */
-static int pim_igmp_general_query(struct thread *t)
+static void pim_igmp_general_query(struct thread *t)
 {
 	struct gm_sock *igmp;
 	struct in_addr dst_addr;
@@ -759,8 +757,6 @@ static int pim_igmp_general_query(struct thread *t)
 			igmp->querier_query_interval);
 
 	pim_igmp_general_query_on(igmp);
-
-	return 0;
 }
 
 static void sock_close(struct gm_sock *igmp)
@@ -1027,7 +1023,7 @@ static struct gm_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 
 static void igmp_read_on(struct gm_sock *igmp);
 
-static int pim_igmp_read(struct thread *t)
+static void pim_igmp_read(struct thread *t)
 {
 	uint8_t buf[10000];
 	struct gm_sock *igmp = (struct gm_sock *)THREAD_ARG(t);
@@ -1053,7 +1049,6 @@ static int pim_igmp_read(struct thread *t)
 
 done:
 	igmp_read_on(igmp);
-	return 0;
 }
 
 static void igmp_read_on(struct gm_sock *igmp)
@@ -1123,7 +1118,7 @@ struct gm_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
   source records.  Source records whose timers are zero (from the
   previous EXCLUDE mode) are deleted.
  */
-static int igmp_group_timer(struct thread *t)
+static void igmp_group_timer(struct thread *t)
 {
 	struct gm_group *group;
 
@@ -1157,8 +1152,6 @@ static int igmp_group_timer(struct thread *t)
 	if (listcount(group->group_source_list) < 1) {
 		igmp_group_delete_empty_include(group);
 	}
-
-	return 0;
 }
 
 static void group_timer_off(struct gm_group *group)

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -118,7 +118,7 @@ void igmp_group_reset_gmi(struct gm_group *group)
 	igmp_group_timer_on(group, group_membership_interval_msec, ifp->name);
 }
 
-static int igmp_source_timer(struct thread *t)
+static void igmp_source_timer(struct thread *t)
 {
 	struct gm_source *source;
 	struct gm_group *group;
@@ -179,8 +179,6 @@ static int igmp_source_timer(struct thread *t)
 			igmp_group_delete_empty_include(group);
 		}
 	}
-
-	return 0;
 }
 
 static void source_timer_off(struct gm_group *group, struct gm_source *source)
@@ -1212,7 +1210,7 @@ static int group_retransmit_sources(struct gm_group *group,
 	return num_retransmit_sources_left;
 }
 
-static int igmp_group_retransmit(struct thread *t)
+static void igmp_group_retransmit(struct thread *t)
 {
 	struct gm_group *group;
 	int num_retransmit_sources_left;
@@ -1262,8 +1260,6 @@ static int igmp_group_retransmit(struct thread *t)
 	    || (group->group_specific_query_retransmit_count > 0)) {
 		group_retransmit_timer_on(group);
 	}
-
-	return 0;
 }
 
 /*

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -930,12 +930,12 @@ int pim_zebra_mlag_process_down(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int pim_mlag_register_handler(struct thread *thread)
+static void pim_mlag_register_handler(struct thread *thread)
 {
 	uint32_t bit_mask = 0;
 
 	if (!zclient)
-		return -1;
+		return;
 
 	SET_FLAG(bit_mask, (1 << MLAG_STATUS_UPDATE));
 	SET_FLAG(bit_mask, (1 << MLAG_MROUTE_ADD));
@@ -952,7 +952,6 @@ static int pim_mlag_register_handler(struct thread *thread)
 			   __func__, bit_mask);
 
 	zclient_send_mlag_register(zclient, bit_mask);
-	return 0;
 }
 
 void pim_mlag_register(void)
@@ -966,17 +965,16 @@ void pim_mlag_register(void)
 			 NULL);
 }
 
-static int pim_mlag_deregister_handler(struct thread *thread)
+static void pim_mlag_deregister_handler(struct thread *thread)
 {
 	if (!zclient)
-		return -1;
+		return;
 
 	if (PIM_DEBUG_MLAG)
 		zlog_debug("%s: Posting Client De-Register to MLAG from PIM",
 			   __func__);
 	router->connected_to_mlag = false;
 	zclient_send_mlag_deregister(zclient);
-	return 0;
 }
 
 void pim_mlag_deregister(void)

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -677,12 +677,11 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 	return 0;
 }
 
-static int mroute_read(struct thread *t)
+static void mroute_read(struct thread *t)
 {
 	struct pim_instance *pim;
 	static long long count;
 	char buf[10000];
-	int result = 0;
 	int cont = 1;
 	int rd;
 	ifindex_t ifindex;
@@ -705,7 +704,7 @@ static int mroute_read(struct thread *t)
 			goto done;
 		}
 
-		result = pim_mroute_msg(pim, buf, rd, ifindex);
+		pim_mroute_msg(pim, buf, rd, ifindex);
 
 		count++;
 		if (count % router->packet_process == 0)
@@ -714,8 +713,6 @@ static int mroute_read(struct thread *t)
 /* Keep reading */
 done:
 	mroute_read_on(pim);
-
-	return result;
 }
 
 static void mroute_read_on(struct pim_instance *pim)

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -66,7 +66,7 @@ static void pim_msdp_sa_timer_expiry_log(struct pim_msdp_sa *sa,
 }
 
 /* RFC-3618:Sec-5.1 - global active source advertisement timer */
-static int pim_msdp_sa_adv_timer_cb(struct thread *t)
+static void pim_msdp_sa_adv_timer_cb(struct thread *t)
 {
 	struct pim_instance *pim = THREAD_ARG(t);
 
@@ -76,8 +76,8 @@ static int pim_msdp_sa_adv_timer_cb(struct thread *t)
 
 	pim_msdp_sa_adv_timer_setup(pim, true /* start */);
 	pim_msdp_pkt_sa_tx(pim);
-	return 0;
 }
+
 static void pim_msdp_sa_adv_timer_setup(struct pim_instance *pim, bool start)
 {
 	THREAD_OFF(pim->msdp.sa_adv_timer);
@@ -89,7 +89,7 @@ static void pim_msdp_sa_adv_timer_setup(struct pim_instance *pim, bool start)
 }
 
 /* RFC-3618:Sec-5.3 - SA cache state timer */
-static int pim_msdp_sa_state_timer_cb(struct thread *t)
+static void pim_msdp_sa_state_timer_cb(struct thread *t)
 {
 	struct pim_msdp_sa *sa;
 
@@ -100,8 +100,8 @@ static int pim_msdp_sa_state_timer_cb(struct thread *t)
 	}
 
 	pim_msdp_sa_deref(sa, PIM_MSDP_SAF_PEER);
-	return 0;
 }
+
 static void pim_msdp_sa_state_timer_setup(struct pim_msdp_sa *sa, bool start)
 {
 	THREAD_OFF(sa->sa_state_timer);
@@ -873,7 +873,7 @@ static void pim_msdp_peer_timer_expiry_log(struct pim_msdp_peer *mp,
 }
 
 /* RFC-3618:Sec-5.4 - peer hold timer */
-static int pim_msdp_peer_hold_timer_cb(struct thread *t)
+static void pim_msdp_peer_hold_timer_cb(struct thread *t)
 {
 	struct pim_msdp_peer *mp;
 
@@ -884,14 +884,13 @@ static int pim_msdp_peer_hold_timer_cb(struct thread *t)
 	}
 
 	if (mp->state != PIM_MSDP_ESTABLISHED) {
-		return 0;
+		return;
 	}
 
 	if (PIM_DEBUG_MSDP_EVENTS) {
 		pim_msdp_peer_state_chg_log(mp);
 	}
 	pim_msdp_peer_reset_tcp_conn(mp, "ht-expired");
-	return 0;
 }
 
 static void pim_msdp_peer_hold_timer_setup(struct pim_msdp_peer *mp, bool start)
@@ -906,7 +905,7 @@ static void pim_msdp_peer_hold_timer_setup(struct pim_msdp_peer *mp, bool start)
 
 
 /* RFC-3618:Sec-5.5 - peer keepalive timer */
-static int pim_msdp_peer_ka_timer_cb(struct thread *t)
+static void pim_msdp_peer_ka_timer_cb(struct thread *t)
 {
 	struct pim_msdp_peer *mp;
 
@@ -918,8 +917,8 @@ static int pim_msdp_peer_ka_timer_cb(struct thread *t)
 
 	pim_msdp_pkt_ka_tx(mp);
 	pim_msdp_peer_ka_timer_setup(mp, true /* start */);
-	return 0;
 }
+
 static void pim_msdp_peer_ka_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
 	THREAD_OFF(mp->ka_timer);
@@ -967,7 +966,7 @@ static void pim_msdp_peer_active_connect(struct pim_msdp_peer *mp)
 }
 
 /* RFC-3618:Sec-5.6 - connection retry on active peer */
-static int pim_msdp_peer_cr_timer_cb(struct thread *t)
+static void pim_msdp_peer_cr_timer_cb(struct thread *t)
 {
 	struct pim_msdp_peer *mp;
 
@@ -978,12 +977,12 @@ static int pim_msdp_peer_cr_timer_cb(struct thread *t)
 	}
 
 	if (mp->state != PIM_MSDP_CONNECTING || PIM_MSDP_PEER_IS_LISTENER(mp)) {
-		return 0;
+		return;
 	}
 
 	pim_msdp_peer_active_connect(mp);
-	return 0;
 }
+
 static void pim_msdp_peer_cr_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
 	THREAD_OFF(mp->cr_timer);

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -240,7 +240,7 @@ void pim_msdp_peer_established(struct pim_msdp_peer *mp);
 void pim_msdp_peer_pkt_rxed(struct pim_msdp_peer *mp);
 void pim_msdp_peer_stop_tcp_conn(struct pim_msdp_peer *mp, bool chg_state);
 void pim_msdp_peer_reset_tcp_conn(struct pim_msdp_peer *mp, const char *rc_str);
-int pim_msdp_write(struct thread *thread);
+void pim_msdp_write(struct thread *thread);
 int pim_msdp_config_write(struct pim_instance *pim, struct vty *vty,
 			  const char *spaces);
 bool pim_msdp_peer_config_write(struct vty *vty, struct pim_instance *pim,

--- a/pimd/pim_msdp_packet.c
+++ b/pimd/pim_msdp_packet.c
@@ -182,7 +182,7 @@ static void pim_msdp_write_proceed_actions(struct pim_msdp_peer *mp)
 	}
 }
 
-int pim_msdp_write(struct thread *thread)
+void pim_msdp_write(struct thread *thread)
 {
 	struct pim_msdp_peer *mp;
 	struct stream *s;
@@ -199,19 +199,19 @@ int pim_msdp_write(struct thread *thread)
 		zlog_debug("MSDP peer %s pim_msdp_write", mp->key_str);
 	}
 	if (mp->fd < 0) {
-		return -1;
+		return;
 	}
 
 	/* check if TCP connection is established */
 	if (mp->state != PIM_MSDP_ESTABLISHED) {
 		pim_msdp_connect_check(mp);
-		return 0;
+		return;
 	}
 
 	s = stream_fifo_head(mp->obuf);
 	if (!s) {
 		pim_msdp_write_proceed_actions(mp);
-		return 0;
+		return;
 	}
 
 	sockopt_cork(mp->fd, 1);
@@ -237,7 +237,7 @@ int pim_msdp_write(struct thread *thread)
 			}
 
 			pim_msdp_peer_reset_tcp_conn(mp, "pkt-tx-failed");
-			return 0;
+			return;
 		}
 
 		if (num != writenum) {
@@ -286,8 +286,6 @@ int pim_msdp_write(struct thread *thread)
 		zlog_debug("MSDP peer %s pim_msdp_write wrote %d packets",
 			   mp->key_str, work_cnt);
 	}
-
-	return 0;
 }
 
 static void pim_msdp_pkt_send(struct pim_msdp_peer *mp, struct stream *s)
@@ -674,7 +672,7 @@ static int pim_msdp_read_packet(struct pim_msdp_peer *mp)
 	return 0;
 }
 
-int pim_msdp_read(struct thread *thread)
+void pim_msdp_read(struct thread *thread)
 {
 	struct pim_msdp_peer *mp;
 	int rc;
@@ -688,13 +686,13 @@ int pim_msdp_read(struct thread *thread)
 	}
 
 	if (mp->fd < 0) {
-		return -1;
+		return;
 	}
 
 	/* check if TCP connection is established */
 	if (mp->state != PIM_MSDP_ESTABLISHED) {
 		pim_msdp_connect_check(mp);
-		return 0;
+		return;
 	}
 
 	PIM_MSDP_PEER_READ_ON(mp);
@@ -706,32 +704,27 @@ int pim_msdp_read(struct thread *thread)
 	if (stream_get_endp(mp->ibuf) < PIM_MSDP_HEADER_SIZE) {
 		/* start by reading the TLV header */
 		rc = pim_msdp_read_packet(mp);
-		if (rc < 0) {
-			goto pim_msdp_read_end;
-		}
+		if (rc < 0)
+			return;
 
 		/* Find TLV type and len  */
 		stream_getc(mp->ibuf);
 		len = stream_getw(mp->ibuf);
 		if (len < PIM_MSDP_HEADER_SIZE) {
 			pim_msdp_pkt_rxed_with_fatal_error(mp);
-			goto pim_msdp_read_end;
+			return;
 		}
 		/* read complete TLV */
 		mp->packet_size = len;
 	}
 
 	rc = pim_msdp_read_packet(mp);
-	if (rc < 0) {
-		goto pim_msdp_read_end;
-	}
+	if (rc < 0)
+		return;
 
 	pim_msdp_pkt_rx(mp);
 
 	/* reset input buffers and get ready for the next packet */
 	mp->packet_size = 0;
 	stream_reset(mp->ibuf);
-
-pim_msdp_read_end:
-	return 0;
 }

--- a/pimd/pim_msdp_packet.h
+++ b/pimd/pim_msdp_packet.h
@@ -64,7 +64,7 @@
 #define PIM_MSDP_PKT_TYPE_STRLEN 16
 
 void pim_msdp_pkt_ka_tx(struct pim_msdp_peer *mp);
-int pim_msdp_read(struct thread *thread);
+void pim_msdp_read(struct thread *thread);
 void pim_msdp_pkt_sa_tx(struct pim_instance *pim);
 void pim_msdp_pkt_sa_tx_one(struct pim_msdp_sa *sa);
 void pim_msdp_pkt_sa_tx_to_one_peer(struct pim_msdp_peer *mp);

--- a/pimd/pim_msdp_socket.c
+++ b/pimd/pim_msdp_socket.c
@@ -62,7 +62,7 @@ static void pim_msdp_update_sock_send_buffer_size(int fd)
 }
 
 /* passive peer socket accept */
-static int pim_msdp_sock_accept(struct thread *thread)
+static void pim_msdp_sock_accept(struct thread *thread)
 {
 	union sockunion su;
 	struct pim_instance *pim = THREAD_ARG(thread);
@@ -77,7 +77,7 @@ static int pim_msdp_sock_accept(struct thread *thread)
 	if (accept_sock < 0) {
 		flog_err(EC_LIB_DEVELOPMENT, "accept_sock is negative value %d",
 			 accept_sock);
-		return -1;
+		return;
 	}
 	pim->msdp.listener.thread = NULL;
 	thread_add_read(router->master, pim_msdp_sock_accept, pim, accept_sock,
@@ -88,7 +88,7 @@ static int pim_msdp_sock_accept(struct thread *thread)
 	if (msdp_sock < 0) {
 		flog_err_sys(EC_LIB_SOCKET, "pim_msdp_sock_accept failed (%s)",
 			     safe_strerror(errno));
-		return -1;
+		return;
 	}
 
 	/* see if have peer config for this */
@@ -100,7 +100,7 @@ static int pim_msdp_sock_accept(struct thread *thread)
 				 "msdp peer connection refused from %pSU", &su);
 		}
 		close(msdp_sock);
-		return -1;
+		return;
 	}
 
 	if (PIM_DEBUG_MSDP_INTERNAL) {
@@ -122,7 +122,6 @@ static int pim_msdp_sock_accept(struct thread *thread)
 	set_nonblocking(mp->fd);
 	pim_msdp_update_sock_send_buffer_size(mp->fd);
 	pim_msdp_peer_established(mp);
-	return 0;
 }
 
 /* global listener for the MSDP well know TCP port */

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -200,7 +200,7 @@ static void update_dr_priority(struct pim_neighbor *neigh,
 	}
 }
 
-static int on_neighbor_timer(struct thread *t)
+static void on_neighbor_timer(struct thread *t)
 {
 	struct pim_neighbor *neigh;
 	struct interface *ifp;
@@ -226,8 +226,6 @@ static int on_neighbor_timer(struct thread *t)
 	  router's own DR Priority changes.
 	*/
 	pim_if_dr_election(ifp); // neighbor times out
-
-	return 0;
 }
 
 void pim_neighbor_timer_reset(struct pim_neighbor *neigh, uint16_t holdtime)
@@ -252,7 +250,7 @@ void pim_neighbor_timer_reset(struct pim_neighbor *neigh, uint16_t holdtime)
 			 neigh->holdtime, &neigh->t_expire_timer);
 }
 
-static int on_neighbor_jp_timer(struct thread *t)
+static void on_neighbor_jp_timer(struct thread *t)
 {
 	struct pim_neighbor *neigh = THREAD_ARG(t);
 	struct pim_rpf rpf;
@@ -269,8 +267,6 @@ static int on_neighbor_jp_timer(struct thread *t)
 
 	thread_add_timer(router->master, on_neighbor_jp_timer, neigh,
 			 router->t_periodic, &neigh->jp_timer);
-
-	return 0;
 }
 
 static void pim_neighbor_start_jp_timer(struct pim_neighbor *neigh)

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -42,7 +42,7 @@
 #include "pim_errors.h"
 #include "pim_bsm.h"
 
-static int on_pim_hello_send(struct thread *t);
+static void on_pim_hello_send(struct thread *t);
 
 static const char *pim_pim_msgtype2str(enum pim_msg_type type)
 {
@@ -326,7 +326,7 @@ int pim_pim_packet(struct interface *ifp, uint8_t *buf, size_t len)
 
 static void pim_sock_read_on(struct interface *ifp);
 
-static int pim_sock_read(struct thread *t)
+static void pim_sock_read(struct thread *t)
 {
 	struct interface *ifp, *orig_ifp;
 	struct pim_interface *pim_ifp;
@@ -398,8 +398,6 @@ done:
 	if (result) {
 		++pim_ifp->pim_ifstat_hello_recvfail;
 	}
-
-	return result;
 }
 
 static void pim_sock_read_on(struct interface *ifp)
@@ -745,7 +743,7 @@ static void hello_resched(struct interface *ifp)
 /*
   Periodic hello timer
  */
-static int on_pim_hello_send(struct thread *t)
+static void on_pim_hello_send(struct thread *t)
 {
 	struct pim_interface *pim_ifp;
 	struct interface *ifp;
@@ -761,7 +759,7 @@ static int on_pim_hello_send(struct thread *t)
 	/*
 	 * Send hello
 	 */
-	return pim_hello_send(ifp, PIM_IF_DEFAULT_HOLDTIME(pim_ifp));
+	pim_hello_send(ifp, PIM_IF_DEFAULT_HOLDTIME(pim_ifp));
 }
 
 /*

--- a/pimd/pim_ssmpingd.c
+++ b/pimd/pim_ssmpingd.c
@@ -315,19 +315,16 @@ static int ssmpingd_read_msg(struct ssmpingd_sock *ss)
 	return 0;
 }
 
-static int ssmpingd_sock_read(struct thread *t)
+static void ssmpingd_sock_read(struct thread *t)
 {
 	struct ssmpingd_sock *ss;
-	int result;
 
 	ss = THREAD_ARG(t);
 
-	result = ssmpingd_read_msg(ss);
+	ssmpingd_read_msg(ss);
 
 	/* Keep reading */
 	ssmpingd_read_on(ss);
-
-	return result;
 }
 
 static void ssmpingd_read_on(struct ssmpingd_sock *ss)

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -302,7 +302,7 @@ void pim_upstream_send_join(struct pim_upstream *up)
 	pim_jp_agg_single_upstream_send(&up->rpf, up, 1 /* join */);
 }
 
-static int on_join_timer(struct thread *t)
+static void on_join_timer(struct thread *t)
 {
 	struct pim_upstream *up;
 
@@ -312,14 +312,14 @@ static int on_join_timer(struct thread *t)
 		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: up %s RPF is not present", __func__,
 				   up->sg_str);
-		return 0;
+		return;
 	}
 
 	/*
 	 * In the case of a HFR we will not ahve anyone to send this to.
 	 */
 	if (PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
-		return 0;
+		return;
 
 	/*
 	 * Don't send the join if the outgoing interface is a loopback
@@ -330,8 +330,6 @@ static int on_join_timer(struct thread *t)
 		pim_upstream_send_join(up);
 
 	join_timer_start(up);
-
-	return 0;
 }
 
 static void join_timer_stop(struct pim_upstream *up)
@@ -1482,7 +1480,7 @@ struct pim_upstream *pim_upstream_keep_alive_timer_proc(
 
 	return up;
 }
-static int pim_upstream_keep_alive_timer(struct thread *t)
+static void pim_upstream_keep_alive_timer(struct thread *t)
 {
 	struct pim_upstream *up;
 
@@ -1491,10 +1489,9 @@ static int pim_upstream_keep_alive_timer(struct thread *t)
 	/* pull the stats and re-check */
 	if (pim_upstream_sg_running_proc(up))
 		/* kat was restarted because of new activity */
-		return 0;
+		return;
 
 	pim_upstream_keep_alive_timer_proc(up);
-	return 0;
 }
 
 void pim_upstream_keep_alive_timer_start(struct pim_upstream *up, uint32_t time)
@@ -1516,15 +1513,15 @@ void pim_upstream_keep_alive_timer_start(struct pim_upstream *up, uint32_t time)
 }
 
 /* MSDP on RP needs to know if a source is registerable to this RP */
-static int pim_upstream_msdp_reg_timer(struct thread *t)
+static void pim_upstream_msdp_reg_timer(struct thread *t)
 {
 	struct pim_upstream *up = THREAD_ARG(t);
 	struct pim_instance *pim = up->channel_oil->pim;
 
 	/* source is no longer active - pull the SA from MSDP's cache */
 	pim_msdp_sa_local_del(pim, &up->sg);
-	return 1;
 }
+
 void pim_upstream_msdp_reg_timer_start(struct pim_upstream *up)
 {
 	THREAD_OFF(up->t_msdp_reg_timer);
@@ -1702,7 +1699,7 @@ const char *pim_reg_state2str(enum pim_reg_state reg_state, char *state_str,
 	return state_str;
 }
 
-static int pim_upstream_register_stop_timer(struct thread *t)
+static void pim_upstream_register_stop_timer(struct thread *t)
 {
 	struct pim_interface *pim_ifp;
 	struct pim_instance *pim;
@@ -1735,7 +1732,7 @@ static int pim_upstream_register_stop_timer(struct thread *t)
 				zlog_debug("%s: up %s RPF is not present",
 					   __func__, up->sg_str);
 			up->reg_state = PIM_REG_NOINFO;
-			return 0;
+			return;
 		}
 
 		pim_ifp = up->rpf.source_nexthop.interface->info;
@@ -1745,7 +1742,7 @@ static int pim_upstream_register_stop_timer(struct thread *t)
 					"%s: Interface: %s is not configured for pim",
 					__func__,
 					up->rpf.source_nexthop.interface->name);
-			return 0;
+			return;
 		}
 		up->reg_state = PIM_REG_JOIN_PENDING;
 		pim_upstream_start_register_stop_timer(up, 1);
@@ -1757,15 +1754,13 @@ static int pim_upstream_register_stop_timer(struct thread *t)
 				zlog_debug(
 					"%s: Stop sending the register, because I am the RP and we haven't seen a packet in a while",
 					__func__);
-			return 0;
+			return;
 		}
 		pim_null_register_send(up);
 		break;
 	case PIM_REG_NOINFO:
 		break;
 	}
-
-	return 0;
 }
 
 void pim_upstream_start_register_stop_timer(struct pim_upstream *up,

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -184,11 +184,10 @@ void pim_vxlan_update_sg_reg_state(struct pim_instance *pim,
 		pim_vxlan_del_work(vxlan_sg);
 }
 
-static int pim_vxlan_work_timer_cb(struct thread *t)
+static void pim_vxlan_work_timer_cb(struct thread *t)
 {
 	pim_vxlan_do_reg_work();
 	pim_vxlan_work_timer_setup(true /* start */);
-	return 0;
 }
 
 /* global 1second timer used for periodic processing */

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -382,7 +382,7 @@ void pim_scan_oil(struct pim_instance *pim)
 		pim_upstream_mroute_iif_update(c_oil, __func__);
 }
 
-static int on_rpf_cache_refresh(struct thread *t)
+static void on_rpf_cache_refresh(struct thread *t)
 {
 	struct pim_instance *pim = THREAD_ARG(t);
 
@@ -394,7 +394,6 @@ static int on_rpf_cache_refresh(struct thread *t)
 
 	// It is called as part of pim_neighbor_add
 	// pim_rp_setup ();
-	return 0;
 }
 
 void sched_rpf_cache_refresh(struct pim_instance *pim)

--- a/pimd/pim_zpthread.c
+++ b/pimd/pim_zpthread.c
@@ -140,7 +140,7 @@ static void pim_mlag_zebra_check_for_buffer_flush(uint32_t curr_msg_type,
  * Thsi thread reads the clients data from the Gloabl queue and encodes with
  * protobuf and pass on to the MLAG socket.
  */
-static int pim_mlag_zthread_handler(struct thread *event)
+static void pim_mlag_zthread_handler(struct thread *event)
 {
 	struct stream *read_s;
 	uint32_t wr_count = 0;
@@ -155,7 +155,7 @@ static int pim_mlag_zthread_handler(struct thread *event)
 			   __func__, wr_count);
 
 	if (wr_count == 0)
-		return 0;
+		return;
 
 	for (wr_count = 0; wr_count < PIM_MLAG_POST_LIMIT; wr_count++) {
 		/* FIFO is empty,wait for teh message to be add */
@@ -207,8 +207,6 @@ stream_failure:
 
 	if (wr_count >= PIM_MLAG_POST_LIMIT)
 		pim_mlag_signal_zpthread();
-
-	return 0;
 }
 
 

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -789,7 +789,7 @@ int rip_enable_if_delete(struct rip *rip, const char *ifname)
 }
 
 /* Join to multicast group and send request to the interface. */
-static int rip_interface_wakeup(struct thread *t)
+static void rip_interface_wakeup(struct thread *t)
 {
 	struct interface *ifp;
 	struct rip_interface *ri;
@@ -804,7 +804,7 @@ static int rip_interface_wakeup(struct thread *t)
 		flog_err_sys(EC_LIB_SOCKET,
 			     "multicast join failed, interface %s not running",
 			     ifp->name);
-		return 0;
+		return;
 	}
 
 	/* Set running flag. */
@@ -812,8 +812,6 @@ static int rip_interface_wakeup(struct thread *t)
 
 	/* Send RIP request to the interface. */
 	rip_request_interface(ifp);
-
-	return 0;
 }
 
 static void rip_connect_set(struct interface *ifp, int set)

--- a/ripd/rip_peer.c
+++ b/ripd/rip_peer.c
@@ -67,15 +67,13 @@ struct rip_peer *rip_peer_lookup_next(struct rip *rip, struct in_addr *addr)
 }
 
 /* RIP peer is timeout. */
-static int rip_peer_timeout(struct thread *t)
+static void rip_peer_timeout(struct thread *t)
 {
 	struct rip_peer *peer;
 
 	peer = THREAD_ARG(t);
 	listnode_delete(peer->rip->peer_list, peer);
 	rip_peer_free(peer);
-
-	return 0;
 }
 
 /* Get RIP peer.  At the same time update timeout thread. */

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -601,7 +601,7 @@ int ripng_enable_if_delete(struct ripng *ripng, const char *ifname)
 }
 
 /* Wake up interface. */
-static int ripng_interface_wakeup(struct thread *t)
+static void ripng_interface_wakeup(struct thread *t)
 {
 	struct interface *ifp;
 	struct ripng_interface *ri;
@@ -616,7 +616,7 @@ static int ripng_interface_wakeup(struct thread *t)
 		flog_err_sys(EC_LIB_SOCKET,
 			     "multicast join failed, interface %s not running",
 			     ifp->name);
-		return 0;
+		return;
 	}
 
 	/* Set running flag. */
@@ -624,8 +624,6 @@ static int ripng_interface_wakeup(struct thread *t)
 
 	/* Send RIP request to the interface. */
 	ripng_request(ifp);
-
-	return 0;
 }
 
 static void ripng_connect_set(struct interface *ifp, int set)

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -75,15 +75,13 @@ struct ripng_peer *ripng_peer_lookup_next(struct ripng *ripng,
 /* RIPng peer is timeout.
  * Garbage collector.
  **/
-static int ripng_peer_timeout(struct thread *t)
+static void ripng_peer_timeout(struct thread *t)
 {
 	struct ripng_peer *peer;
 
 	peer = THREAD_ARG(t);
 	listnode_delete(peer->ripng->peer_list, peer);
 	ripng_peer_free(peer);
-
-	return 0;
 }
 
 /* Get RIPng peer.  At the same time update timeout thread. */

--- a/sharpd/sharp_logpump.c
+++ b/sharpd/sharp_logpump.c
@@ -43,7 +43,7 @@ static struct vty *lp_vty;
 
 extern struct thread_master *master;
 
-static int logpump_done(struct thread *thread)
+static void logpump_done(struct thread *thread)
 {
 	double x;
 
@@ -67,7 +67,6 @@ static int logpump_done(struct thread *thread)
 	frr_pthread_stop(lpt, NULL);
 	frr_pthread_destroy(lpt);
 	lpt = NULL;
-	return 0;
 }
 
 static void *logpump_run(void *arg)

--- a/tests/helpers/c/main.c
+++ b/tests/helpers/c/main.c
@@ -47,13 +47,12 @@ DEFUN (daemon_exit,
 }
 
 static int timer_count;
-static int test_timer(struct thread *thread)
+static void test_timer(struct thread *thread)
 {
 	int *count = THREAD_ARG(thread);
 
 	printf("run %d of timer\n", (*count)++);
 	thread_add_timer(master, test_timer, count, 5, NULL);
-	return 0;
 }
 
 static void test_timer_init(void)

--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -79,7 +79,7 @@ static const struct frr_yang_module_info *const staticd_yang_modules[] = {
 	&frr_staticd_info,   &frr_vrf_info,
 };
 
-static int grpc_thread_stop(struct thread *thread);
+static void grpc_thread_stop(struct thread *thread);
 
 static void _err_print(const void *cookie, const char *errstr)
 {
@@ -499,7 +499,7 @@ void *grpc_client_test_start(void *arg)
 	return NULL;
 }
 
-static int grpc_thread_start(struct thread *thread)
+static void grpc_thread_start(struct thread *thread)
 {
 	struct frr_pthread_attr client = {
 		.start = grpc_client_test_start,
@@ -509,11 +509,9 @@ static int grpc_thread_start(struct thread *thread)
 	auto pth = frr_pthread_new(&client, "GRPC Client thread", "grpc");
 	frr_pthread_run(pth, NULL);
 	frr_pthread_wait_running(pth);
-
-	return 0;
 }
 
-static int grpc_thread_stop(struct thread *thread)
+static void grpc_thread_stop(struct thread *thread)
 {
 	std::cout << __func__ << ": frr_pthread_stop_all" << std::endl;
 	frr_pthread_stop_all();

--- a/tests/lib/test_heavy_thread.c
+++ b/tests/lib/test_heavy_thread.c
@@ -70,7 +70,7 @@ static void slow_func(struct vty *vty, const char *str, const int i)
 		printf("%s did %d, x = %g\n", str, i, x);
 }
 
-static int clear_something(struct thread *thread)
+static void clear_something(struct thread *thread)
 {
 	struct work_state *ws = THREAD_ARG(thread);
 
@@ -84,14 +84,13 @@ static int clear_something(struct thread *thread)
 		if (thread_should_yield(thread)) {
 			thread_add_timer_msec(master, clear_something, ws, 0,
 					      NULL);
-			return 0;
+			return;
 		}
 	}
 
 	/* All done! */
 	XFREE(MTYPE_TMP, ws->str);
 	XFREE(MTYPE_TMP, ws);
-	return 0;
 }
 
 DEFUN (clear_foo,

--- a/tests/lib/test_segv.c
+++ b/tests/lib/test_segv.c
@@ -62,10 +62,9 @@ void func3(void)
 	func2(6, buf);
 }
 
-static int threadfunc(struct thread *thread)
+static void threadfunc(struct thread *thread)
 {
 	func3();
-	return 0;
 }
 
 int main(void)

--- a/tests/lib/test_timer_correctness.c
+++ b/tests/lib/test_timer_correctness.c
@@ -76,7 +76,7 @@ static void terminate_test(void)
 	exit(exit_code);
 }
 
-static int timer_func(struct thread *thread)
+static void timer_func(struct thread *thread)
 {
 	int rv;
 
@@ -90,8 +90,6 @@ static int timer_func(struct thread *thread)
 	timers_pending--;
 	if (!timers_pending)
 		terminate_test();
-
-	return 0;
 }
 
 static int cmp_timeval(const void *a, const void *b)

--- a/tests/lib/test_timer_performance.c
+++ b/tests/lib/test_timer_performance.c
@@ -35,9 +35,8 @@
 
 struct thread_master *master;
 
-static int dummy_func(struct thread *thread)
+static void dummy_func(struct thread *thread)
 {
-	return 0;
 }
 
 int main(int argc, char **argv)

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -681,8 +681,8 @@ struct vrrp_vrouter *vrrp_lookup(const struct interface *ifp, uint8_t vrid)
 
 /* Forward decls */
 static void vrrp_change_state(struct vrrp_router *r, int to);
-static int vrrp_adver_timer_expire(struct thread *thread);
-static int vrrp_master_down_timer_expire(struct thread *thread);
+static void vrrp_adver_timer_expire(struct thread *thread);
+static void vrrp_master_down_timer_expire(struct thread *thread);
 
 /*
  * Finds the first connected address of the appropriate family on a VRRP
@@ -983,7 +983,7 @@ static int vrrp_recv_advertisement(struct vrrp_router *r, struct ipaddr *src,
 /*
  * Read and process next IPvX datagram.
  */
-static int vrrp_read(struct thread *thread)
+static void vrrp_read(struct thread *thread)
 {
 	struct vrrp_router *r = thread->arg;
 
@@ -1045,8 +1045,6 @@ done:
 
 	if (resched)
 		thread_add_read(master, vrrp_read, r, r->sock_rx, &r->t_read);
-
-	return 0;
 }
 
 /*
@@ -1480,7 +1478,7 @@ static void vrrp_change_state(struct vrrp_router *r, int to)
 /*
  * Called when Adver_Timer expires.
  */
-static int vrrp_adver_timer_expire(struct thread *thread)
+static void vrrp_adver_timer_expire(struct thread *thread)
 {
 	struct vrrp_router *r = thread->arg;
 
@@ -1503,14 +1501,12 @@ static int vrrp_adver_timer_expire(struct thread *thread)
 			 r->vr->vrid, family2str(r->family),
 			 vrrp_state_names[r->fsm.state]);
 	}
-
-	return 0;
 }
 
 /*
  * Called when Master_Down_Timer expires.
  */
-static int vrrp_master_down_timer_expire(struct thread *thread)
+static void vrrp_master_down_timer_expire(struct thread *thread)
 {
 	struct vrrp_router *r = thread->arg;
 
@@ -1522,8 +1518,6 @@ static int vrrp_master_down_timer_expire(struct thread *thread)
 			      r->vr->advertisement_interval * CS2MS,
 			      &r->t_adver_timer);
 	vrrp_change_state(r, VRRP_STATE_MASTER);
-
-	return 0;
 }
 
 /*

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -64,7 +64,7 @@ DEFINE_HOOK(zebra_if_config_wr, (struct vty * vty, struct interface *ifp),
 
 static void if_down_del_nbr_connected(struct interface *ifp);
 
-static int if_zebra_speed_update(struct thread *thread)
+static void if_zebra_speed_update(struct thread *thread)
 {
 	struct interface *ifp = THREAD_ARG(thread);
 	struct zebra_if *zif = ifp->info;
@@ -81,7 +81,7 @@ static int if_zebra_speed_update(struct thread *thread)
 	 * note that loopback & virtual interfaces can return 0 as speed
 	 */
 	if (error < 0)
-		return 1;
+		return;
 
 	if (new_speed != ifp->speed) {
 		zlog_info("%s: %s old speed: %u new speed: %u", __func__,
@@ -96,8 +96,6 @@ static int if_zebra_speed_update(struct thread *thread)
 				 &zif->speed_update);
 		thread_ignore_late_timer(zif->speed_update);
 	}
-
-	return 1;
 }
 
 static void zebra_if_node_destroy(route_table_delegate_t *delegate,

--- a/zebra/irdp.h
+++ b/zebra/irdp.h
@@ -144,10 +144,10 @@ struct Adv {
 extern void irdp_if_init(void);
 extern int irdp_sock_init(void);
 extern int irdp_config_write(struct vty *, struct interface *);
-extern int irdp_send_thread(struct thread *t_advert);
+extern void irdp_send_thread(struct thread *t_advert);
 extern void irdp_advert_off(struct interface *ifp);
 extern void process_solicit(struct interface *ifp);
-extern int irdp_read_raw(struct thread *r);
+extern void irdp_read_raw(struct thread *r);
 extern void send_packet(struct interface *ifp, struct stream *s, uint32_t dst,
 			struct prefix *p, uint32_t ttl);
 

--- a/zebra/irdp_main.c
+++ b/zebra/irdp_main.c
@@ -205,7 +205,7 @@ static void irdp_advertisement(struct interface *ifp, struct prefix *p)
 	stream_free(s);
 }
 
-int irdp_send_thread(struct thread *t_advert)
+void irdp_send_thread(struct thread *t_advert)
 {
 	uint32_t timer, tmp;
 	struct interface *ifp = THREAD_ARG(t_advert);
@@ -216,7 +216,7 @@ int irdp_send_thread(struct thread *t_advert)
 	struct connected *ifc;
 
 	if (!irdp)
-		return 0;
+		return;
 
 	irdp->flags &= ~IF_SOLICIT;
 
@@ -246,7 +246,6 @@ int irdp_send_thread(struct thread *t_advert)
 	irdp->t_advertise = NULL;
 	thread_add_timer(zrouter.master, irdp_send_thread, ifp, timer,
 			 &irdp->t_advertise);
-	return 0;
 }
 
 void irdp_advert_off(struct interface *ifp)

--- a/zebra/irdp_packet.c
+++ b/zebra/irdp_packet.c
@@ -224,7 +224,7 @@ static int irdp_recvmsg(int sock, uint8_t *buf, int size, int *ifindex)
 	return ret;
 }
 
-int irdp_read_raw(struct thread *r)
+void irdp_read_raw(struct thread *r)
 {
 	struct interface *ifp;
 	struct zebra_if *zi;
@@ -243,22 +243,22 @@ int irdp_read_raw(struct thread *r)
 
 	ifp = if_lookup_by_index(ifindex, VRF_DEFAULT);
 	if (!ifp)
-		return ret;
+		return;
 
 	zi = ifp->info;
 	if (!zi)
-		return ret;
+		return;
 
 	irdp = zi->irdp;
 	if (!irdp)
-		return ret;
+		return;
 
 	if (!(irdp->flags & IF_ACTIVE)) {
 
 		if (irdp->flags & IF_DEBUG_MISC)
 			zlog_debug("IRDP: RX ICMP for disabled interface %s",
 				   ifp->name);
-		return 0;
+		return;
 	}
 
 	if (irdp->flags & IF_DEBUG_PACKET) {
@@ -269,8 +269,6 @@ int irdp_read_raw(struct thread *r)
 	}
 
 	parse_irdp_packet(buf, ret, ifp);
-
-	return ret;
 }
 
 void send_packet(struct interface *ifp, struct stream *s, uint32_t dst,

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -418,7 +418,7 @@ static int dplane_netlink_information_fetch(struct nlmsghdr *h, ns_id_t ns_id,
 	return 0;
 }
 
-static int kernel_read(struct thread *thread)
+static void kernel_read(struct thread *thread)
 {
 	struct zebra_ns *zns = (struct zebra_ns *)THREAD_ARG(thread);
 	struct zebra_dplane_info dp_info;
@@ -431,8 +431,6 @@ static int kernel_read(struct thread *thread)
 
 	thread_add_read(zrouter.master, kernel_read, zns, zns->netlink.sock,
 			&zns->t_netlink);
-
-	return 0;
 }
 
 /*

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1292,7 +1292,7 @@ static void rtmsg_debug(struct rt_msghdr *rtm)
 #endif /* RTAX_MAX */
 
 /* Kernel routing table and interface updates via routing socket. */
-static int kernel_read(struct thread *thread)
+static void kernel_read(struct thread *thread)
 {
 	int sock;
 	int nbytes;
@@ -1356,11 +1356,11 @@ static int kernel_read(struct thread *thread)
 		if (errno != EAGAIN && errno != EWOULDBLOCK)
 			flog_err_sys(EC_LIB_SOCKET, "routing socket error: %s",
 				     safe_strerror(errno));
-		return 0;
+		return;
 	}
 
 	if (nbytes == 0)
-		return 0;
+		return;
 
 	thread_add_read(zrouter.master, kernel_read, NULL, sock, NULL);
 
@@ -1377,7 +1377,7 @@ static int kernel_read(struct thread *thread)
 		zlog_debug(
 			"kernel_read: rtm->rtm_msglen %d, nbytes %d, type %d",
 			rtm->rtm_msglen, nbytes, rtm->rtm_type);
-		return -1;
+		return;
 	}
 
 	switch (rtm->rtm_type) {
@@ -1403,7 +1403,6 @@ static int kernel_read(struct thread *thread)
 			zlog_debug("Unprocessed RTM_type: %d", rtm->rtm_type);
 		break;
 	}
-	return 0;
 }
 
 /* Make routing socket. */

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -213,7 +213,7 @@ static void sigint(void)
  * Final shutdown step for the zebra main thread. This is run after all
  * async update processing has completed.
  */
-int zebra_finalize(struct thread *dummy)
+void zebra_finalize(struct thread *dummy)
 {
 	zlog_info("Zebra final shutdown");
 

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -432,7 +432,7 @@ extern struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *p,
 extern void rib_update(enum rib_update_event event);
 extern void rib_update_table(struct route_table *table,
 			     enum rib_update_event event, int rtype);
-extern int rib_sweep_route(struct thread *t);
+extern void rib_sweep_route(struct thread *t);
 extern void rib_sweep_table(struct route_table *table);
 extern void rib_close_table(struct route_table *table);
 extern void rib_init(void);

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -471,7 +471,7 @@ no_more_opts:
 		zif->ra_sent++;
 }
 
-static int rtadv_timer(struct thread *thread)
+static void rtadv_timer(struct thread *thread)
 {
 	struct zebra_vrf *zvrf = THREAD_ARG(thread);
 	struct vrf *vrf;
@@ -534,8 +534,6 @@ static int rtadv_timer(struct thread *thread)
 				}
 			}
 		}
-
-	return 0;
 }
 
 static void rtadv_process_solicit(struct interface *ifp)
@@ -774,7 +772,7 @@ static void rtadv_process_packet(uint8_t *buf, unsigned int len,
 	return;
 }
 
-static int rtadv_read(struct thread *thread)
+static void rtadv_read(struct thread *thread)
 {
 	int sock;
 	int len;
@@ -797,12 +795,10 @@ static int rtadv_read(struct thread *thread)
 		flog_err_sys(EC_LIB_SOCKET,
 			     "RA/RS recv failed, socket %u error %s", sock,
 			     safe_strerror(errno));
-		return len;
+		return;
 	}
 
 	rtadv_process_packet(buf, (unsigned)len, ifindex, hoplimit, &from, zvrf);
-
-	return 0;
 }
 
 static int rtadv_make_socket(ns_id_t ns_id)

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -2131,7 +2131,7 @@ static void zebra_evpn_mh_advertise_svi_mac(void)
 	zebra_evpn_acc_vl_adv_svi_mac_all();
 }
 
-static int zebra_evpn_es_df_delay_exp_cb(struct thread *t)
+static void zebra_evpn_es_df_delay_exp_cb(struct thread *t)
 {
 	struct zebra_evpn_es *es;
 
@@ -2141,8 +2141,6 @@ static int zebra_evpn_es_df_delay_exp_cb(struct thread *t)
 		zlog_debug("es %s df-delay expired", es->esi_str);
 
 	zebra_evpn_es_run_df_election(es, __func__);
-
-	return 0;
 }
 
 /* currently there is no global config to turn on MH instead we use
@@ -3860,15 +3858,13 @@ void zebra_evpn_mh_uplink_oper_update(struct zebra_if *zif)
 				       new_protodown);
 }
 
-static int zebra_evpn_mh_startup_delay_exp_cb(struct thread *t)
+static void zebra_evpn_mh_startup_delay_exp_cb(struct thread *t)
 {
 	if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 		zlog_debug("startup-delay expired");
 
 	zebra_evpn_mh_update_protodown(ZEBRA_PROTODOWN_EVPN_STARTUP_DELAY,
 				       false /* set */);
-
-	return 0;
 }
 
 static void zebra_evpn_mh_startup_delay_timer_start(const char *rc)

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -284,8 +284,8 @@ static struct zfpm_glob *zfpm_g = &zfpm_glob_space;
 
 static int zfpm_trigger_update(struct route_node *rn, const char *reason);
 
-static int zfpm_read_cb(struct thread *thread);
-static int zfpm_write_cb(struct thread *thread);
+static void zfpm_read_cb(struct thread *thread);
+static void zfpm_write_cb(struct thread *thread);
 
 static void zfpm_set_state(enum zfpm_state state, const char *reason);
 static void zfpm_start_connect_timer(const char *reason);
@@ -518,7 +518,7 @@ static inline void zfpm_connect_off(void)
  * Callback for actions to be taken when the connection to the FPM
  * comes up.
  */
-static int zfpm_conn_up_thread_cb(struct thread *thread)
+static void zfpm_conn_up_thread_cb(struct thread *thread)
 {
 	struct route_node *rnode;
 	struct zfpm_rnodes_iter *iter;
@@ -559,14 +559,13 @@ static int zfpm_conn_up_thread_cb(struct thread *thread)
 		zfpm_rnodes_iter_pause(iter);
 		thread_add_timer_msec(zfpm_g->master, zfpm_conn_up_thread_cb,
 				      NULL, 0, &zfpm_g->t_conn_up);
-		return 0;
+		return;
 	}
 
 	zfpm_g->stats.t_conn_up_finishes++;
 
 done:
 	zfpm_rnodes_iter_cleanup(iter);
-	return 0;
 }
 
 /*
@@ -635,7 +634,7 @@ static void zfpm_connect_check(void)
  * Callback that is invoked to clean up state after the TCP connection
  * to the FPM goes down.
  */
-static int zfpm_conn_down_thread_cb(struct thread *thread)
+static void zfpm_conn_down_thread_cb(struct thread *thread)
 {
 	struct route_node *rnode;
 	struct zfpm_rnodes_iter *iter;
@@ -686,7 +685,7 @@ static int zfpm_conn_down_thread_cb(struct thread *thread)
 		zfpm_g->t_conn_down = NULL;
 		thread_add_timer_msec(zfpm_g->master, zfpm_conn_down_thread_cb,
 				      NULL, 0, &zfpm_g->t_conn_down);
-		return 0;
+		return;
 	}
 
 	zfpm_g->stats.t_conn_down_finishes++;
@@ -696,7 +695,6 @@ static int zfpm_conn_down_thread_cb(struct thread *thread)
 	 * Start the process of connecting to the FPM again.
 	 */
 	zfpm_start_connect_timer("cleanup complete");
-	return 0;
 }
 
 /*
@@ -740,7 +738,7 @@ static void zfpm_connection_down(const char *detail)
 /*
  * zfpm_read_cb
  */
-static int zfpm_read_cb(struct thread *thread)
+static void zfpm_read_cb(struct thread *thread)
 {
 	size_t already;
 	struct stream *ibuf;
@@ -754,7 +752,7 @@ static int zfpm_read_cb(struct thread *thread)
 	 */
 	if (zfpm_g->state == ZFPM_STATE_CONNECTING) {
 		zfpm_connect_check();
-		return 0;
+		return;
 	}
 
 	assert(zfpm_g->state == ZFPM_STATE_ESTABLISHED);
@@ -778,7 +776,7 @@ static int zfpm_read_cb(struct thread *thread)
 				zfpm_connection_down(buffer);
 			} else
 				zfpm_connection_down("closed socket in read");
-			return 0;
+			return;
 		}
 
 		if (nbyte != (ssize_t)(FPM_MSG_HDR_LEN - already))
@@ -793,7 +791,7 @@ static int zfpm_read_cb(struct thread *thread)
 
 	if (!fpm_msg_hdr_ok(hdr)) {
 		zfpm_connection_down("invalid message header");
-		return 0;
+		return;
 	}
 
 	msg_len = fpm_msg_len(hdr);
@@ -816,7 +814,7 @@ static int zfpm_read_cb(struct thread *thread)
 				zfpm_connection_down(buffer);
 			} else
 				zfpm_connection_down("failed to read message");
-			return 0;
+			return;
 		}
 
 		if (nbyte != (ssize_t)(msg_len - already))
@@ -830,7 +828,6 @@ static int zfpm_read_cb(struct thread *thread)
 
 done:
 	zfpm_read_on();
-	return 0;
 }
 
 static bool zfpm_updates_pending(void)
@@ -1171,7 +1168,7 @@ static void zfpm_build_updates(void)
 /*
  * zfpm_write_cb
  */
-static int zfpm_write_cb(struct thread *thread)
+static void zfpm_write_cb(struct thread *thread)
 {
 	struct stream *s;
 	int num_writes;
@@ -1183,7 +1180,7 @@ static int zfpm_write_cb(struct thread *thread)
 	 */
 	if (zfpm_g->state == ZFPM_STATE_CONNECTING) {
 		zfpm_connect_check();
-		return 0;
+		return;
 	}
 
 	assert(zfpm_g->state == ZFPM_STATE_ESTABLISHED);
@@ -1217,7 +1214,7 @@ static int zfpm_write_cb(struct thread *thread)
 				break;
 
 			zfpm_connection_down("failed to write to socket");
-			return 0;
+			return;
 		}
 
 		if (bytes_written != bytes_to_write) {
@@ -1248,14 +1245,12 @@ static int zfpm_write_cb(struct thread *thread)
 
 	if (zfpm_writes_pending())
 		zfpm_write_on();
-
-	return 0;
 }
 
 /*
  * zfpm_connect_cb
  */
-static int zfpm_connect_cb(struct thread *t)
+static void zfpm_connect_cb(struct thread *t)
 {
 	int sock, ret;
 	struct sockaddr_in serv;
@@ -1267,7 +1262,7 @@ static int zfpm_connect_cb(struct thread *t)
 		zlog_err("Failed to create socket for connect(): %s",
 			   strerror(errno));
 		zfpm_g->stats.connect_no_sock++;
-		return 0;
+		return;
 	}
 
 	set_nonblocking(sock);
@@ -1295,7 +1290,7 @@ static int zfpm_connect_cb(struct thread *t)
 	if (ret >= 0) {
 		zfpm_g->sock = sock;
 		zfpm_connection_up("connect succeeded");
-		return 1;
+		return;
 	}
 
 	if (errno == EINPROGRESS) {
@@ -1304,7 +1299,7 @@ static int zfpm_connect_cb(struct thread *t)
 		zfpm_write_on();
 		zfpm_set_state(ZFPM_STATE_CONNECTING,
 			       "async connect in progress");
-		return 0;
+		return;
 	}
 
 	zlog_info("can't connect to FPM %d: %s", sock, safe_strerror(errno));
@@ -1314,7 +1309,6 @@ static int zfpm_connect_cb(struct thread *t)
 	 * Restart timer for retrying connection.
 	 */
 	zfpm_start_connect_timer("connect() failed");
-	return 0;
 }
 
 /*
@@ -1663,7 +1657,7 @@ static void zfpm_iterate_rmac_table(struct hash_bucket *bucket, void *args)
 /*
  * struct zfpm_statsimer_cb
  */
-static int zfpm_stats_timer_cb(struct thread *t)
+static void zfpm_stats_timer_cb(struct thread *t)
 {
 	zfpm_g->t_stats = NULL;
 
@@ -1685,8 +1679,6 @@ static int zfpm_stats_timer_cb(struct thread *t)
 	zfpm_stats_reset(&zfpm_g->stats);
 
 	zfpm_start_stats_timer();
-
-	return 0;
 }
 
 /*

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -51,7 +51,7 @@
  * Forward declaration.
  */
 static struct zserv *zebra_gr_find_stale_client(struct zserv *client);
-static int32_t zebra_gr_route_stale_delete_timer_expiry(struct thread *thread);
+static void zebra_gr_route_stale_delete_timer_expiry(struct thread *thread);
 static int32_t zebra_gr_delete_stale_routes(struct client_gr_info *info);
 static void zebra_gr_process_client_stale_routes(struct zserv *client,
 						 vrf_id_t vrf_id);
@@ -444,7 +444,7 @@ void zread_client_capabilities(ZAPI_HANDLER_ARGS)
  * Delete all the stale routes that have not been refreshed
  * post restart.
  */
-static int32_t zebra_gr_route_stale_delete_timer_expiry(struct thread *thread)
+static void zebra_gr_route_stale_delete_timer_expiry(struct thread *thread)
 {
 	struct client_gr_info *info;
 	int32_t cnt = 0;
@@ -478,7 +478,6 @@ static int32_t zebra_gr_route_stale_delete_timer_expiry(struct thread *thread)
 		info->current_afi = 0;
 		zebra_gr_delete_stale_client(info);
 	}
-	return 0;
 }
 
 

--- a/zebra/zebra_mlag_private.c
+++ b/zebra/zebra_mlag_private.c
@@ -48,8 +48,8 @@
 static struct thread_master *zmlag_master;
 static int mlag_socket;
 
-static int zebra_mlag_connect(struct thread *thread);
-static int zebra_mlag_read(struct thread *thread);
+static void zebra_mlag_connect(struct thread *thread);
+static void zebra_mlag_read(struct thread *thread);
 
 /*
  * Write the data to MLAGD
@@ -72,7 +72,7 @@ static void zebra_mlag_sched_read(void)
 			&zrouter.mlag_info.t_read);
 }
 
-static int zebra_mlag_read(struct thread *thread)
+static void zebra_mlag_read(struct thread *thread)
 {
 	static uint32_t mlag_rd_buf_offset;
 	uint32_t *msglen;
@@ -98,13 +98,13 @@ static int zebra_mlag_read(struct thread *thread)
 					   mlag_socket);
 			close(mlag_socket);
 			zebra_mlag_handle_process_state(MLAG_DOWN);
-			return -1;
+			return;
 		}
 		mlag_rd_buf_offset += data_len;
 		if (data_len != (ssize_t)(ZEBRA_MLAG_LEN_SIZE - curr_len)) {
 			/* Try again later */
 			zebra_mlag_sched_read();
-			return 0;
+			return;
 		}
 		curr_len = ZEBRA_MLAG_LEN_SIZE;
 	}
@@ -136,13 +136,13 @@ static int zebra_mlag_read(struct thread *thread)
 					   mlag_socket);
 			close(mlag_socket);
 			zebra_mlag_handle_process_state(MLAG_DOWN);
-			return -1;
+			return;
 		}
 		mlag_rd_buf_offset += data_len;
 		if (data_len != (ssize_t)(tot_len - curr_len)) {
 			/* Try again later */
 			zebra_mlag_sched_read();
-			return 0;
+			return;
 		}
 	}
 
@@ -162,10 +162,9 @@ static int zebra_mlag_read(struct thread *thread)
 	zebra_mlag_reset_read_buffer();
 	mlag_rd_buf_offset = 0;
 	zebra_mlag_sched_read();
-	return 0;
 }
 
-static int zebra_mlag_connect(struct thread *thread)
+static void zebra_mlag_connect(struct thread *thread)
 {
 	struct sockaddr_un svr = {0};
 
@@ -178,7 +177,7 @@ static int zebra_mlag_connect(struct thread *thread)
 
 	mlag_socket = socket(svr.sun_family, SOCK_STREAM, 0);
 	if (mlag_socket < 0)
-		return -1;
+		return;
 
 	if (connect(mlag_socket, (struct sockaddr *)&svr, sizeof(svr)) == -1) {
 		if (IS_ZEBRA_DEBUG_MLAG)
@@ -189,7 +188,7 @@ static int zebra_mlag_connect(struct thread *thread)
 		zrouter.mlag_info.timer_running = true;
 		thread_add_timer(zmlag_master, zebra_mlag_connect, NULL, 10,
 				 &zrouter.mlag_info.t_read);
-		return 0;
+		return;
 	}
 
 	set_nonblocking(mlag_socket);
@@ -204,7 +203,6 @@ static int zebra_mlag_connect(struct thread *thread)
 	 * Connection is established with MLAGD, post to clients
 	 */
 	zebra_mlag_handle_process_state(MLAG_UP);
-	return 0;
 }
 
 /*

--- a/zebra/zebra_opaque.c
+++ b/zebra/zebra_opaque.c
@@ -106,7 +106,7 @@ static const char LOG_NAME[] = "Zebra Opaque";
 /* Prototypes */
 
 /* Main event loop, processing incoming message queue */
-static int process_messages(struct thread *event);
+static void process_messages(struct thread *event);
 static int handle_opq_registration(const struct zmsghdr *hdr,
 				   struct stream *msg);
 static int handle_opq_unregistration(const struct zmsghdr *hdr,
@@ -270,7 +270,7 @@ uint32_t zebra_opaque_enqueue_batch(struct stream_fifo *batch)
 /*
  * Pthread event loop, process the incoming message queue.
  */
-static int process_messages(struct thread *event)
+static void process_messages(struct thread *event)
 {
 	struct stream_fifo fifo;
 	struct stream *msg;
@@ -335,8 +335,6 @@ done:
 
 	/* This will also free any leftover messages, in the shutdown case */
 	stream_fifo_deinit(&fifo);
-
-	return 0;
 }
 
 /*

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -100,7 +100,7 @@ static ptm_lib_handle_t *ptm_hdl;
 struct zebra_ptm_cb ptm_cb;
 
 static int zebra_ptm_socket_init(void);
-int zebra_ptm_sock_read(struct thread *);
+void zebra_ptm_sock_read(struct thread *thread);
 static void zebra_ptm_install_commands(void);
 static int zebra_ptm_handle_msg_cb(void *arg, void *in_ctxt);
 void zebra_bfd_peer_replay_req(void);
@@ -168,12 +168,12 @@ void zebra_ptm_finish(void)
 		close(ptm_cb.ptm_sock);
 }
 
-static int zebra_ptm_flush_messages(struct thread *thread)
+static void zebra_ptm_flush_messages(struct thread *thread)
 {
 	ptm_cb.t_write = NULL;
 
 	if (ptm_cb.ptm_sock == -1)
-		return -1;
+		return;
 
 	errno = 0;
 
@@ -187,7 +187,7 @@ static int zebra_ptm_flush_messages(struct thread *thread)
 		ptm_cb.t_timer = NULL;
 		thread_add_timer(zrouter.master, zebra_ptm_connect, NULL,
 				 ptm_cb.reconnect_time, &ptm_cb.t_timer);
-		return -1;
+		return;
 	case BUFFER_PENDING:
 		ptm_cb.t_write = NULL;
 		thread_add_write(zrouter.master, zebra_ptm_flush_messages, NULL,
@@ -196,8 +196,6 @@ static int zebra_ptm_flush_messages(struct thread *thread)
 	case BUFFER_EMPTY:
 		break;
 	}
-
-	return 0;
 }
 
 static int zebra_ptm_send_message(char *data, int size)
@@ -226,7 +224,7 @@ static int zebra_ptm_send_message(char *data, int size)
 	return 0;
 }
 
-int zebra_ptm_connect(struct thread *t)
+void zebra_ptm_connect(struct thread *t)
 {
 	int init = 0;
 
@@ -255,8 +253,6 @@ int zebra_ptm_connect(struct thread *t)
 	} else if (ptm_cb.reconnect_time >= ZEBRA_PTM_RECONNECT_TIME_MAX) {
 		ptm_cb.reconnect_time = ZEBRA_PTM_RECONNECT_TIME_INITIAL;
 	}
-
-	return (errno);
 }
 
 DEFUN (zebra_ptm_enable,
@@ -649,7 +645,7 @@ static int zebra_ptm_handle_msg_cb(void *arg, void *in_ctxt)
 	}
 }
 
-int zebra_ptm_sock_read(struct thread *thread)
+void zebra_ptm_sock_read(struct thread *thread)
 {
 	int sock;
 	int rc;
@@ -658,7 +654,7 @@ int zebra_ptm_sock_read(struct thread *thread)
 	sock = THREAD_FD(thread);
 
 	if (sock == -1)
-		return -1;
+		return;
 
 	/* PTM communicates in CSV format */
 	do {
@@ -679,14 +675,12 @@ int zebra_ptm_sock_read(struct thread *thread)
 		thread_add_timer(zrouter.master, zebra_ptm_connect, NULL,
 				 ptm_cb.reconnect_time,
 				 &ptm_cb.t_timer);
-		return -1;
+		return;
 	}
 
 	ptm_cb.t_read = NULL;
 	thread_add_read(zrouter.master, zebra_ptm_sock_read, NULL,
 			ptm_cb.ptm_sock, &ptm_cb.t_read);
-
-	return 0;
 }
 
 /* BFD peer/dst register/update */

--- a/zebra/zebra_ptm.h
+++ b/zebra/zebra_ptm.h
@@ -74,7 +74,7 @@ struct zebra_ptm_cb {
 
 void zebra_ptm_init(void);
 void zebra_ptm_finish(void);
-int zebra_ptm_connect(struct thread *t);
+void zebra_ptm_connect(struct thread *t);
 void zebra_ptm_write(struct vty *vty);
 int zebra_ptm_get_enable_state(void);
 

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -47,7 +47,7 @@ DEFINE_HOOK(pw_uninstall, (struct zebra_pw * pw), (pw));
 static int zebra_pw_enabled(struct zebra_pw *);
 static void zebra_pw_install(struct zebra_pw *);
 static void zebra_pw_uninstall(struct zebra_pw *);
-static int zebra_pw_install_retry(struct thread *);
+static void zebra_pw_install_retry(struct thread *thread);
 static int zebra_pw_check_reachability(const struct zebra_pw *);
 static void zebra_pw_update_status(struct zebra_pw *, int);
 
@@ -226,14 +226,12 @@ void zebra_pw_install_failure(struct zebra_pw *pw, int pwstatus)
 	zebra_pw_update_status(pw, pwstatus);
 }
 
-static int zebra_pw_install_retry(struct thread *thread)
+static void zebra_pw_install_retry(struct thread *thread)
 {
 	struct zebra_pw *pw = THREAD_ARG(thread);
 
 	pw->install_retry_timer = NULL;
 	zebra_pw_install(pw);
-
-	return 0;
 }
 
 static void zebra_pw_update_status(struct zebra_pw *pw, int status)

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3948,7 +3948,7 @@ static void rib_update_ctx_fini(struct rib_update_ctx **ctx)
 	XFREE(MTYPE_RIB_UPDATE_CTX, *ctx);
 }
 
-static int rib_update_handler(struct thread *thread)
+static void rib_update_handler(struct thread *thread)
 {
 	struct rib_update_ctx *ctx;
 
@@ -3960,8 +3960,6 @@ static int rib_update_handler(struct thread *thread)
 		rib_update_handle_vrf(ctx->vrf_id, ctx->event, ZEBRA_ROUTE_ALL);
 
 	rib_update_ctx_fini(&ctx);
-
-	return 0;
 }
 
 /*
@@ -4055,7 +4053,7 @@ void rib_sweep_table(struct route_table *table)
 }
 
 /* Sweep all RIB tables.  */
-int rib_sweep_route(struct thread *t)
+void rib_sweep_route(struct thread *t)
 {
 	struct vrf *vrf;
 	struct zebra_vrf *zvrf;
@@ -4070,8 +4068,6 @@ int rib_sweep_route(struct thread *t)
 
 	zebra_router_sweep_route();
 	zebra_router_sweep_nhgs();
-
-	return 0;
 }
 
 /* Remove specific by protocol routes from 'table'. */
@@ -4181,7 +4177,7 @@ done:
  * Handle results from the dataplane system. Dequeue update context
  * structs, dispatch to appropriate internal handlers.
  */
-static int rib_process_dplane_results(struct thread *thread)
+static void rib_process_dplane_results(struct thread *thread)
 {
 	struct zebra_dplane_ctx *ctx;
 	struct dplane_ctx_q ctxlist;
@@ -4349,8 +4345,6 @@ static int rib_process_dplane_results(struct thread *thread)
 		}
 
 	} while (1);
-
-	return 0;
 }
 
 /*

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1638,7 +1638,7 @@ static void zebra_route_map_process_update_cb(char *rmap_name)
 	zebra_nht_rm_update(rmap_name);
 }
 
-static int zebra_route_map_update_timer(struct thread *thread)
+static void zebra_route_map_update_timer(struct thread *thread)
 {
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("Event driven route-map update triggered");
@@ -1655,7 +1655,6 @@ static int zebra_route_map_update_timer(struct thread *thread)
 	 * 1) VRF Aware <sigh>
 	 * 2) Route-map aware
 	 */
-	return 0;
 }
 
 static void zebra_route_map_set_delay_timer(uint32_t value)

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -379,7 +379,7 @@ void zserv_log_message(const char *errmsg, struct stream *msg,
 		       struct zmsghdr *hdr);
 
 /* TODO */
-__attribute__((__noreturn__)) int zebra_finalize(struct thread *event);
+__attribute__((__noreturn__)) void zebra_finalize(struct thread *event);
 
 /*
  * Graceful restart functions.


### PR DESCRIPTION
The int return value is never used.  Modify the code
base to just return a void instead.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>