### PR TITLE
tests: add a topotest for ospf, mutli vrf, and route leaking

### DIFF
--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/frr.conf
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/frr.conf
@@ -1,0 +1,57 @@
+!
+hostname r1
+password zebra
+log file /tmp/r1-frr.log
+!
+interface r1-eth0
+ ip address 10.0.1.1/24
+!
+interface r1-eth1
+ ip address 10.0.20.1/24
+!
+interface r1-eth2 vrf neno
+ ip address 10.0.30.1/24
+!
+ip forwarding
+!
+router ospf
+  ospf router-id 10.0.255.1
+  redistribute bgp
+  network 10.0.1.0/24 area 0
+  network 10.0.20.0/24 area 0
+!
+router ospf vrf neno
+  ospf router-id 10.0.255.1
+  redistribute bgp
+  network 10.0.30.0/24 area 0
+!
+!
+router bgp 99
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf neno
+  !
+!
+router bgp 99 vrf neno
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf route-map rmap
+    import vrf default
+  !
+!
+!!!!!!!!!!!!!!!!!!!!!
+! VRFs neno and ray subnets
+ip prefix-list nets seq 5 permit 10.0.3.0/24
+ip prefix-list nets seq 10 permit 10.0.30.0/24
+ip prefix-list nets seq 15 permit 10.0.4.0/24
+ip prefix-list nets seq 20 permit 10.0.40.0/24
+ip prefix-list nets seq 25 deny any
+!
+route-map rmap permit 10
+  match ip address prefix-list nets
+  exit
+!

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/ospf-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/ospf-vrf-default.txt
@@ -1,0 +1,19 @@
+VRF Name: default
+============ OSPF network routing table ============
+N    10.0.1.0/24           [10] area: 0.0.0.0
+                           directly attached to r1-eth0
+N    10.0.2.0/24           [20] area: 0.0.0.0
+                           via 10.0.20.2, r1-eth1
+N    10.0.20.0/24          [10] area: 0.0.0.0
+                           directly attached to r1-eth1
+
+============ OSPF router routing table =============
+R    10.0.255.2            [10] area: 0.0.0.0, ASBR
+                           via 10.0.20.2, r1-eth1
+
+============ OSPF external routing table ===========
+N E2 10.0.4.0/24           [10/20] tag: 0
+                           via 10.0.20.2, r1-eth1
+N E2 10.0.40.0/24          [10/20] tag: 0
+                           via 10.0.20.2, r1-eth1
+

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/ospf-vrf-neno.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/ospf-vrf-neno.txt
@@ -1,0 +1,12 @@
+VRF Name: neno
+============ OSPF network routing table ============
+N    10.0.3.0/24           [20] area: 0.0.0.0
+                           via 10.0.30.3, r1-eth2
+N    10.0.30.0/24          [10] area: 0.0.0.0
+                           directly attached to r1-eth2
+
+============ OSPF router routing table =============
+R    10.0.255.3            [10] area: 0.0.0.0, ASBR
+                           via 10.0.30.3, r1-eth2
+
+============ OSPF external routing table ===========

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/zebra-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/zebra-vrf-default.txt
@@ -1,0 +1,9 @@
+O   10.0.1.0/24 [110/10] is directly connected, r1-eth0, weight 1, XX:XX:XX
+C>* 10.0.1.0/24 is directly connected, r1-eth0, XX:XX:XX
+O>* 10.0.2.0/24 [110/20] via 10.0.20.2, r1-eth1, weight 1, XX:XX:XX
+B>* 10.0.3.0/24 [20/20] via 10.0.30.3, r1-eth2 (vrf neno), weight 1, XX:XX:XX
+O>* 10.0.4.0/24 [110/20] via 10.0.20.2, r1-eth1, weight 1, XX:XX:XX
+O   10.0.20.0/24 [110/10] is directly connected, r1-eth1, weight 1, XX:XX:XX
+C>* 10.0.20.0/24 is directly connected, r1-eth1, XX:XX:XX
+B>* 10.0.30.0/24 [20/0] is directly connected, r1-eth2 (vrf neno), weight 1, XX:XX:XX
+O>* 10.0.40.0/24 [110/20] via 10.0.20.2, r1-eth1, weight 1, XX:XX:XX

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/zebra-vrf-neno.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/zebra-vrf-neno.txt
@@ -1,0 +1,6 @@
+VRF neno:
+O>* 10.0.3.0/24 [110/20] via 10.0.30.3, r1-eth2, weight 1, XX:XX:XX
+B>* 10.0.4.0/24 [20/20] via 10.0.20.2, r1-eth1 (vrf default), weight 1, XX:XX:XX
+O   10.0.30.0/24 [110/10] is directly connected, r1-eth2, weight 1, XX:XX:XX
+C>* 10.0.30.0/24 is directly connected, r1-eth2, XX:XX:XX
+B>* 10.0.40.0/24 [20/20] via 10.0.20.2, r1-eth1 (vrf default), weight 1, XX:XX:XX

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/frr.conf
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/frr.conf
@@ -1,0 +1,62 @@
+!
+hostname r2
+password zebra
+log file /tmp/r2-frr.log
+!
+interface r2-eth0
+ ip address 10.0.2.2/24
+!
+interface r2-eth1
+ ip address 10.0.20.2/24
+!
+ip route 0.0.0.0/0 10.0.20.1
+!
+interface r2-eth2 vrf ray
+ ip address 10.0.40.2/24
+!
+ip forwarding
+!
+vrf ray
+ ip protocol bgp route-map rmap
+ exit-vrf
+!
+router ospf
+  ospf router-id 10.0.255.2
+  redistribute bgp
+  network 10.0.2.0/24 area 0
+  network 10.0.20.0/24 area 0
+!
+router ospf vrf ray
+  ospf router-id 10.0.255.1
+  redistribute bgp
+  network 10.0.40.0/24 area 0
+!
+
+router bgp 99
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf ray
+  !
+!
+router bgp 99 vrf ray
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf default
+  !
+!
+!!!!!!!!!!!!!!!!!!!!!
+! VRFs neno and ray subnets
+ip prefix-list nets seq 5 permit 10.0.3.0/24
+ip prefix-list nets seq 10 permit 10.0.30.0/24
+ip prefix-list nets seq 15 permit 10.0.4.0/24
+ip prefix-list nets seq 20 permit 10.0.40.0/24
+ip prefix-list nets seq 25 deny any
+!
+route-map rmap permit 10
+  match ip address prefix-list nets
+  exit
+!

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/ospf-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/ospf-vrf-default.txt
@@ -1,0 +1,20 @@
+VRF Name: default
+============ OSPF network routing table ============
+N    10.0.1.0/24           [20] area: 0.0.0.0
+                           via 10.0.20.1, r2-eth1
+N    10.0.2.0/24           [10] area: 0.0.0.0
+                           directly attached to r2-eth0
+N    10.0.20.0/24          [10] area: 0.0.0.0
+                           directly attached to r2-eth1
+
+============ OSPF router routing table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.20.1, r2-eth1
+
+============ OSPF external routing table ===========
+N E2 10.0.3.0/24           [10/20] tag: 0
+                           via 10.0.20.1, r2-eth1
+N E2 10.0.30.0/24          [10/20] tag: 0
+                           via 10.0.20.1, r2-eth1
+
+

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/ospf-vrf-ray.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/ospf-vrf-ray.txt
@@ -1,0 +1,15 @@
+VRF Name: ray
+============ OSPF network routing table ============
+N    10.0.4.0/24           [20] area: 0.0.0.0
+                           via 10.0.40.4, r2-eth2
+N    10.0.40.0/24          [10] area: 0.0.0.0
+			   directly attached to r2-eth2
+
+============ OSPF router routing table =============
+R    10.0.255.4            [10] area: 0.0.0.0, ASBR
+                           via 10.0.40.4, r2-eth2
+
+============ OSPF external routing table ===========
+
+
+

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/zebra-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/zebra-vrf-default.txt
@@ -1,0 +1,10 @@
+S>* 0.0.0.0/0 [1/0] via 10.0.20.1, r2-eth1, weight 1, XX:XX:XX
+O>* 10.0.1.0/24 [110/20] via 10.0.20.1, r2-eth1, weight 1, XX:XX:XX
+O   10.0.2.0/24 [110/10] is directly connected, r2-eth0, weight 1, XX:XX:XX
+C>* 10.0.2.0/24 is directly connected, r2-eth0, XX:XX:XX
+O>* 10.0.3.0/24 [110/20] via 10.0.20.1, r2-eth1, weight 1, XX:XX:XX
+B>* 10.0.4.0/24 [20/20] via 10.0.40.4, r2-eth2 (vrf ray), weight 1, XX:XX:XX
+O   10.0.20.0/24 [110/10] is directly connected, r2-eth1, weight 1, XX:XX:XX
+C>* 10.0.20.0/24 is directly connected, r2-eth1, XX:XX:XX
+O>* 10.0.30.0/24 [110/20] via 10.0.20.1, r2-eth1, weight 1, XX:XX:XX
+B>* 10.0.40.0/24 [20/0] is directly connected, r2-eth2 (vrf ray), weight 1, XX:XX:XX

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/zebra-vrf-ray.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/zebra-vrf-ray.txt
@@ -1,0 +1,9 @@
+VRF ray:
+B   10.0.1.0/24 [20/20] via 10.0.20.1, r2-eth1 (vrf default) inactive, weight 1, XX:XX:XX
+B   10.0.2.0/24 [20/0] is directly connected, r2-eth0 (vrf default) inactive, weight 1, XX:XX:XX
+B>* 10.0.3.0/24 [20/20] via 10.0.20.1, r2-eth1 (vrf default), weight 1, XX:XX:XX
+O>* 10.0.4.0/24 [110/20] via 10.0.40.4, r2-eth2, weight 1, XX:XX:XX
+B   10.0.20.0/24 [20/0] is directly connected, r2-eth1 (vrf default) inactive, weight 1, XX:XX:XX
+B>* 10.0.30.0/24 [20/20] via 10.0.20.1, r2-eth1 (vrf default), weight 1, XX:XX:XX
+O   10.0.40.0/24 [110/10] is directly connected, r2-eth2, weight 1, XX:XX:XX
+C>* 10.0.40.0/24 is directly connected, r2-eth2, XX:XX:XX

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r3/frr.conf
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r3/frr.conf
@@ -1,0 +1,22 @@
+!
+hostname r3
+password zebra
+log file /tmp/r3-frr.log
+!
+interface r3-eth0
+ ip address 10.0.3.3/24
+!
+interface r3-eth1
+ ip address 10.0.30.3/24
+!
+ip forwarding
+!
+!
+router ospf
+  ospf router-id 10.0.255.3
+  redistribute kernel
+  redistribute connected
+  redistribute static
+  network 10.0.3.0/24 area 0
+  network 10.0.30.0/24 area 0
+!

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r3/ospf-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r3/ospf-vrf-default.txt
@@ -1,0 +1,17 @@
+VRF Name: default
+============ OSPF network routing table ============
+N    10.0.3.0/24           [10] area: 0.0.0.0
+                           directly attached to r3-eth0
+N    10.0.30.0/24          [10] area: 0.0.0.0
+                           directly attached to r3-eth1
+
+============ OSPF router routing table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.30.1, r3-eth1
+
+============ OSPF external routing table ===========
+N E2 10.0.4.0/24           [10/20] tag: 0
+                           via 10.0.30.1, r3-eth1
+N E2 10.0.40.0/24          [10/20] tag: 0
+                           via 10.0.30.1, r3-eth1
+

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r3/zebra-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r3/zebra-vrf-default.txt
@@ -1,0 +1,8 @@
+O   10.0.3.0/24 [110/10] is directly connected, r3-eth0, weight 1, XX:XX:XX
+C>* 10.0.3.0/24 is directly connected, r3-eth0, XX:XX:XX
+O>* 10.0.4.0/24 [110/20] via 10.0.30.1, r3-eth1, weight 1, XX:XX:XX
+O   10.0.30.0/24 [110/10] is directly connected, r3-eth1, weight 1, XX:XX:XX
+C>* 10.0.30.0/24 is directly connected, r3-eth1, XX:XX:XX
+O>* 10.0.40.0/24 [110/20] via 10.0.30.1, r3-eth1, weight 1, XX:XX:XX
+
+

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r4/frr.conf
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r4/frr.conf
@@ -1,0 +1,22 @@
+!
+hostname r4
+password zebra
+log file /tmp/r4-frr.log
+!
+interface r4-eth0
+ ip address 10.0.4.4/24
+!
+interface r4-eth1
+ ip address 10.0.40.4/24
+!
+ip forwarding
+!
+!
+router ospf
+  ospf router-id 10.0.255.4
+  redistribute kernel
+  redistribute connected
+  redistribute static
+  network 10.0.4.0/24 area 0
+  network 10.0.40.0/24 area 0
+!

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r4/ospf-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r4/ospf-vrf-default.txt
@@ -1,0 +1,17 @@
+VRF Name: default
+============ OSPF network routing table ============
+N    10.0.4.0/24           [10] area: 0.0.0.0
+                           directly attached to r4-eth0
+N    10.0.40.0/24          [10] area: 0.0.0.0
+                           directly attached to r4-eth1
+
+============ OSPF router routing table =============
+R    10.0.255.1            [10] area: 0.0.0.0, ASBR
+                           via 10.0.40.2, r4-eth1
+
+============ OSPF external routing table ===========
+N E2 10.0.3.0/24           [10/20] tag: 0
+                           via 10.0.40.2, r4-eth1
+N E2 10.0.30.0/24          [10/20] tag: 0
+                           via 10.0.40.2, r4-eth1
+

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r4/zebra-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r4/zebra-vrf-default.txt
@@ -1,0 +1,7 @@
+O>* 10.0.3.0/24 [110/20] via 10.0.40.2, r4-eth1, weight 1, XX:XX:XX
+O   10.0.4.0/24 [110/10] is directly connected, r4-eth0, weight 1, XX:XX:XX
+C>* 10.0.4.0/24 is directly connected, r4-eth0, XX:XX:XX
+O>* 10.0.30.0/24 [110/20] via 10.0.40.2, r4-eth1, weight 1, XX:XX:XX
+O   10.0.40.0/24 [110/10] is directly connected, r4-eth1, weight 1, XX:XX:XX
+C>* 10.0.40.0/24 is directly connected, r4-eth1, XX:XX:XX
+

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/test_ospf_multi_vrf_bgp_route_leak.py
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/test_ospf_multi_vrf_bgp_route_leak.py
@@ -71,7 +71,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.ospfd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/test_ospf_multi_vrf_bgp_route_leak.py
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/test_ospf_multi_vrf_bgp_route_leak.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python
+
+#
+# test_ospf_multi_vrf_bgp_route_leak.py
+#
+# Copyright (c) 2022 ATCorp
+# Jafar Al-Gharaibeh
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+import os
+import sys
+from functools import partial
+import pytest
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+
+"""
+test_ospf_multi_vrf_bgp_route_leak.py: Test OSPF with multi vrf setup and route leaking.
+"""
+
+TOPOLOGY = """
+   bgp route leaking (connected/ospf), vrfs:  neno <==> default <==> ray
+   routes leaking to vrfs are limited to neno and ray routes.
+
+                      10.0.1.1/24
+                            ^
+                            |vrf:default
+                        +---+---+
+      10.0.30.0/24    .1|       |.1
+      +-----------------+  R1   +
+      |        vrf:neno |       |
+      |                 +---+---+                ^
+      |.3                 .1|vrf:default         | 10.0.4.4/24
+  +---+---+                 |                +---+---+
+  |       |            10.0.20.0/24          |       |
+  |  R3   |                 |                |  R4   |
+  |       |                 |.2              |       |
+  +---+---+             +---+---+            +---+---+
+      |                 |       | vrf:ray        |.4
+      v                 |  R2   +----------------+
+10.0.3.3/24             |       |.2         10.0.40.0/24
+                        +---+---+
+                            |
+                            v
+                      10.0.2.2/24
+
+"""
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# Required to instantiate the topology builder class.
+
+pytestmark = [pytest.mark.ospfd]
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # Create 4 routers
+    for routern in range(1, 5):
+        tgen.add_router("r{}".format(routern))
+
+    # Create a empty network for router 1
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+
+    # Create a empty network for router 2
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"])
+
+    # Create a empty network for router 3
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r3"])
+
+    # Create a empty network for router 4
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["r4"])
+
+    # Interconect router 1, 2
+    switch = tgen.add_switch("s1-2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # Interconect router 1, 3
+    switch = tgen.add_switch("s1-3")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r3"])
+
+    # Interconect router 2, 4
+    switch = tgen.add_switch("s2-4")
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r4"])
+
+
+def setup_module(mod):
+    logger.info("OSPF Multi VRF Topology with BGP route leaking:\n {}".format(TOPOLOGY))
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    r1_vrf_setup_cmds = [
+        "ip link add name neno type vrf table 11",
+        "ip link set dev neno up",
+        "ip link set dev r1-eth2 vrf neno up",
+    ]
+    r2_vrf_setup_cmds = [
+        "ip link add name ray type vrf table 11",
+        "ip link set dev ray up",
+        "ip link set dev r2-eth2 vrf ray up",
+    ]
+
+    # Starting Routers
+    router_list = tgen.routers()
+
+    # Create VRFs on r1/r2 and bind to interfaces
+    for cmd in r1_vrf_setup_cmds:
+        tgen.net["r1"].cmd(cmd)
+    for cmd in r2_vrf_setup_cmds:
+        tgen.net["r2"].cmd(cmd)
+
+    logger.info("Testing OSPF VRF support")
+
+    for rname, router in router_list.items():
+        logger.info("Loading router %s" % rname)
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    # Initialize all routers.
+    tgen.start_router()
+    for router in router_list.values():
+        if router.has_version("<", "4.0"):
+            tgen.set_error("unsupported version")
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# Shared test function to validate expected output.
+def compare_show_ip_route_vrf(rname, expected, vrf_name):
+    """
+    Calls 'show ip route vrf [vrf_name] route' and compare the obtained
+    result with the expected output.
+    """
+    tgen = get_topogen()
+    current = topotest.ip4_route_zebra(tgen.gears[rname], vrf_name)
+    ret = topotest.difflines(
+        current, expected, title1="Current output", title2="Expected output"
+    )
+    return ret
+
+
+def test_ospf_convergence():
+    "Test OSPF daemon convergence"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    for rname, router in tgen.routers().items():
+        logger.info('Waiting for router "%s" convergence', rname)
+
+        for vrf in ["default", "neno", "ray"]:
+            # Load expected results from the command
+            reffile = os.path.join(CWD, "{}/ospf-vrf-{}.txt".format(rname, vrf))
+            if vrf == "default" or os.path.exists(reffile):
+                expected = open(reffile).read()
+
+                # Run test function until we get an result. Wait at most 80 seconds.
+                test_func = partial(
+                    topotest.router_output_cmp,
+                    router,
+                    "show ip ospf vrf {} route".format(vrf),
+                    expected,
+                )
+                result, diff = topotest.run_and_expect(
+                    test_func, "", count=80, wait=1
+                )
+                assertmsg = "OSPF did not converge on {}:\n{}".format(rname, diff)
+                assert result, assertmsg
+
+
+def test_ospf_kernel_route():
+    "Test OSPF kernel route installation"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    rlist = tgen.routers().values()
+    for router in rlist:
+        logger.info('Checking OSPF IPv4 kernel routes in "%s"', router.name)
+        for vrf in ["default", "neno", "ray"]:
+            reffile = os.path.join(CWD, "{}/zebra-vrf-{}.txt".format(router.name, vrf))
+            if vrf == "default" or os.path.exists(reffile):
+                expected = open(reffile).read()
+                # Run test function until we get an result. Wait at most 80 seconds.
+                test_func = partial(
+                    compare_show_ip_route_vrf, router.name, expected, vrf
+                )
+                result, diff = topotest.run_and_expect(
+                    test_func, "", count=80, wait=1
+                )
+                assertmsg = 'OSPF IPv4 route mismatch in router "{}": {}'.format(
+                    router.name, diff
+                )
+                assert result, assertmsg
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Test ospf running with 3 vrfs: default, neno, ray
Route leaking is setup via bgp between default and neno vrfs
Leaked routes include connected and ospf

Included test:
 1- OSPF convergnce
 2- zebra/kernel routes

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>