### PR TITLE
ospfd: NULL passed instead of ei pointer in external lsa origination

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2353,7 +2353,7 @@ void ospf_external_lsa_rid_change(struct ospf *ospf)
 						continue;
 
 					if (!ospf_external_lsa_originate(ospf,
-									 NULL))
+									 ei))
 						flog_warn(
 							EC_OSPF_LSA_INSTALL_FAILURE,
 							"LSA: AS-external-LSA was not originated.");


### PR DESCRIPTION
Description:
	NULL pointer wrongly passed instead of 'ei' pointer to
	ospf_external_lsa_originate() API in opaque capability enable/disable
	which always make it to fail in origination.
	Corrected it by passing actual ei pointer.

Ref corresponding old  PR : https://github.com/FRRouting/frr/pull/8557

Signed-off-by: Rajesh Girada <rgirada@vmware.com>