### PR TITLE
pimd: FRR drops IGMP packets for TOS value other than 0XC0

### DIFF
--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -526,17 +526,6 @@ bool pim_igmp_verify_header(struct ip *ip_hdr, size_t len, size_t *hlen)
 		}
 	}
 
-	if ((msg_type == PIM_IGMP_V3_MEMBERSHIP_REPORT)
-	    || ((msg_type == PIM_IGMP_MEMBERSHIP_QUERY)
-		&& (igmp_msg_len >= IGMP_V3_SOURCES_OFFSET))) {
-		/* All IGMPv3 messages must be received with TOS set to 0xC0*/
-		if (ip_hdr->ip_tos != IPTOS_PREC_INTERNETCONTROL) {
-			zlog_warn("Received IGMP Packet with invalid TOS %u",
-				  ip_hdr->ip_tos);
-			return false;
-		}
-	}
-
 	return true;
 }
 


### PR DESCRIPTION
Currently the code is expecting the TOS value for received
packet to be 0xC0 and hence it is discarding packets having
TOS value other than 0xc0.

We need to make sure that we are sending the packet with
TOS 0xC0 and while receiving we can allow any TOS value.
Let's follow Postel's law.
Checked Cisco behavior as well. It also accepts all TOS values.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>