### PR TITLE
pimd: replace inaddr_none with PIMADDR_ANY

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -433,8 +433,8 @@ static void pim_instate_pend_list(struct bsgrp_node *bsgrp_node)
 	 * install the rp from head(if exists) of partial list. List is
 	 * is sorted such that head is the elected RP for the group.
 	 */
-	if (!rn || (prefix_same(&rp_all->group, &bsgrp_node->group)
-		    && pim_rpf_addr_is_inaddr_none(&rp_all->rp))) {
+	if (!rn || (prefix_same(&rp_all->group, &bsgrp_node->group) &&
+		    pim_rpf_addr_is_inaddr_any(&rp_all->rp))) {
 		if (PIM_DEBUG_BSM)
 			zlog_debug("%s: Route node doesn't exist", __func__);
 		if (pend)
@@ -637,8 +637,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 		rp_all = pim_rp_find_match_group(pim, &g_all);
 
 		if (rp_all == rp_info) {
-			rp_all->rp.rpf_addr.family = AF_INET;
-			rp_all->rp.rpf_addr.u.prefix4.s_addr = INADDR_NONE;
+			pim_addr_to_prefix(&rp_all->rp.rpf_addr, PIMADDR_ANY);
 			rp_all->i_am_rp = 0;
 		} else {
 			/* Delete the rp_info from rp-list */
@@ -671,7 +670,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 		trp_info = pim_rp_find_match_group(pim, &grp);
 
 		/* RP not found for the group grp */
-		if (pim_rpf_addr_is_inaddr_none(&trp_info->rp)) {
+		if (pim_rpf_addr_is_inaddr_any(&trp_info->rp)) {
 			pim_upstream_rpf_clear(pim, up);
 			pim_rp_set_upstream_addr(pim, &up->upstream_addr,
 						 up->sg.src, up->sg.grp);

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -162,7 +162,7 @@ static int pim_mroute_msg_nocache(int fd, struct interface *ifp,
 	 * the Interface type is SSM we don't need to
 	 * do anything here
 	 */
-	if (!rpg || pim_rpf_addr_is_inaddr_none(rpg)) {
+	if (!rpg || pim_rpf_addr_is_inaddr_any(rpg)) {
 		if (PIM_DEBUG_MROUTE_DETAIL)
 			zlog_debug(
 				"%s: Interface is not configured correctly to handle incoming packet: Could be !pim_ifp, !SM, !RP",
@@ -299,8 +299,8 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 
 	rpg = pim_ifp ? RP(pim_ifp->pim, sg.grp) : NULL;
 
-	if ((pim_rpf_addr_is_inaddr_none(rpg)) || (!pim_ifp)
-	    || (!(PIM_I_am_DR(pim_ifp)))) {
+	if ((pim_rpf_addr_is_inaddr_any(rpg)) || (!pim_ifp) ||
+	    (!(PIM_I_am_DR(pim_ifp)))) {
 		if (PIM_DEBUG_MROUTE) {
 			zlog_debug("%s: Failed Check send packet", __func__);
 		}

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -426,7 +426,7 @@ static void pim_update_rp_nh(struct pim_instance *pim,
 
 	/*Traverse RP list and update each RP Nexthop info */
 	for (ALL_LIST_ELEMENTS_RO(pnc->rp_list, node, rp_info)) {
-		if (rp_info->rp.rpf_addr.u.prefix4.s_addr == INADDR_NONE)
+		if (pim_rpf_addr_is_inaddr_any(&rp_info->rp))
 			continue;
 
 		// Compute PIM RPF using cached nexthop

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -51,7 +51,7 @@ void pim_rpf_set_refresh_time(struct pim_instance *pim)
 }
 
 bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
-			struct in_addr addr, int neighbor_needed)
+			pim_addr addr, int neighbor_needed)
 {
 	struct pim_zlookup_nexthop nexthop_tab[MULTIPATH_NUM];
 	struct pim_neighbor *nbr = NULL;
@@ -66,7 +66,7 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 	 * 255.255.255.255 address, since
 	 * it will never work
 	 */
-	if (addr.s_addr == INADDR_NONE)
+	if (pim_addr_is_any(addr))
 		return false;
 
 	if ((nexthop->last_lookup.s_addr == addr.s_addr)
@@ -403,19 +403,6 @@ static struct in_addr pim_rpf_find_rpf_addr(struct pim_upstream *up)
 		rpf_addr.s_addr = PIM_NET_INADDR_ANY;
 
 	return rpf_addr;
-}
-
-int pim_rpf_addr_is_inaddr_none(struct pim_rpf *rpf)
-{
-	switch (rpf->rpf_addr.family) {
-	case AF_INET:
-		return rpf->rpf_addr.u.prefix4.s_addr == INADDR_NONE;
-	case AF_INET6:
-		zlog_warn("%s: v6 Unimplmeneted", __func__);
-		return 1;
-	default:
-		return 0;
-	}
 }
 
 int pim_rpf_addr_is_inaddr_any(struct pim_rpf *rpf)

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -64,7 +64,6 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 				   struct pim_rpf *old, const char *caller);
 void pim_upstream_rpf_clear(struct pim_instance *pim,
 			    struct pim_upstream *up);
-int pim_rpf_addr_is_inaddr_none(struct pim_rpf *rpf);
 int pim_rpf_addr_is_inaddr_any(struct pim_rpf *rpf);
 
 int pim_rpf_is_same(struct pim_rpf *rpf1, struct pim_rpf *rpf2);


### PR DESCRIPTION
We can use PIMADDR_ANY instead of INADDR_NONE to initalize rp->rpf_addr
when there is no rp configured for group_all.

This PR will bring below change in behaviour.
When user will configure rp as 255.255.255.255 pim will accept and create not reachable RP.
Earlier it was rejecting this config as bad address.

Signed-off-by: sarita patra <saritap@vmware.com>