### PR TITLE
bgpd: Change the format of announcement for SRv6 L3VPN

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -856,16 +856,11 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 					new_attr->srv6_l3vpn->func_len;
 				extra->sid[0].arg_len =
 					new_attr->srv6_l3vpn->arg_len;
-
-				if (new_attr->srv6_l3vpn->transposition_len
-				    != 0)
-					transpose_sid(
-						&extra->sid[0].sid,
-						decode_label(label),
-						new_attr->srv6_l3vpn
-							->transposition_offset,
-						new_attr->srv6_l3vpn
-							->transposition_len);
+				extra->sid[0].transposition_len =
+					new_attr->srv6_l3vpn->transposition_len;
+				extra->sid[0].transposition_offset =
+					new_attr->srv6_l3vpn
+						->transposition_offset;
 			} else if (new_attr->srv6_vpn)
 				setsids(bpi, &new_attr->srv6_vpn->sid,
 					num_sids);
@@ -960,14 +955,10 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 				new_attr->srv6_l3vpn->loc_node_len;
 			extra->sid[0].func_len = new_attr->srv6_l3vpn->func_len;
 			extra->sid[0].arg_len = new_attr->srv6_l3vpn->arg_len;
-
-			if (new_attr->srv6_l3vpn->transposition_len != 0)
-				transpose_sid(&extra->sid[0].sid,
-					      decode_label(label),
-					      new_attr->srv6_l3vpn
-						      ->transposition_offset,
-					      new_attr->srv6_l3vpn
-						      ->transposition_len);
+			extra->sid[0].transposition_len =
+				new_attr->srv6_l3vpn->transposition_len;
+			extra->sid[0].transposition_offset =
+				new_attr->srv6_l3vpn->transposition_offset;
 		} else if (new_attr->srv6_vpn)
 			setsids(new, &new_attr->srv6_vpn->sid, num_sids);
 	} else

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1244,7 +1244,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 	static_attr.originator_id = bgp_vpn->router_id;
 
 	/* Set SID for SRv6 VPN */
-	if (bgp_vrf->vpn_policy[afi].tovpn_sid) {
+	if (bgp_vrf->vpn_policy[afi].tovpn_sid_locator) {
 		encode_label(bgp_vrf->vpn_policy[afi].tovpn_sid_transpose_label,
 			     &label);
 		static_attr.srv6_l3vpn = XCALLOC(MTYPE_BGP_SRV6_L3VPN,
@@ -1264,8 +1264,8 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 		static_attr.srv6_l3vpn->transposition_offset =
 			BGP_PREFIX_SID_SRV6_TRANSPOSITION_OFFSET;
 		memcpy(&static_attr.srv6_l3vpn->sid,
-		       bgp_vrf->vpn_policy[afi].tovpn_sid,
-		       sizeof(static_attr.srv6_l3vpn->sid));
+		       bgp_vrf->vpn_policy[afi].tovpn_sid_locator,
+		       sizeof(struct in6_addr));
 	}
 
 

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -21,6 +21,7 @@
 #ifndef _QUAGGA_BGP_MPLSVPN_H
 #define _QUAGGA_BGP_MPLSVPN_H
 
+#include "bgpd/bgp_attr.h"
 #include "bgpd/bgp_route.h"
 #include "bgpd/bgp_rd.h"
 #include "bgpd/bgp_zebra.h"

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4198,6 +4198,8 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 				extra->sid[0].loc_node_len = 0;
 				extra->sid[0].func_len = 0;
 				extra->sid[0].arg_len = 0;
+				extra->sid[0].transposition_len = 0;
+				extra->sid[0].transposition_offset = 0;
 
 				if (attr->srv6_l3vpn->loc_block_len != 0) {
 					extra->sid[0].loc_block_len =
@@ -4208,21 +4210,13 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 						attr->srv6_l3vpn->func_len;
 					extra->sid[0].arg_len =
 						attr->srv6_l3vpn->arg_len;
+					extra->sid[0].transposition_len =
+						attr->srv6_l3vpn
+							->transposition_len;
+					extra->sid[0].transposition_offset =
+						attr->srv6_l3vpn
+							->transposition_offset;
 				}
-
-				/*
-				 * draft-ietf-bess-srv6-services-07
-				 * The part of SRv6 SID may be encoded as MPLS
-				 * Label for the efficient packing.
-				 */
-				if (attr->srv6_l3vpn->transposition_len != 0)
-					transpose_sid(
-						&extra->sid[0].sid,
-						decode_label(label),
-						attr->srv6_l3vpn
-							->transposition_offset,
-						attr->srv6_l3vpn
-							->transposition_len);
 			}
 		} else if (attr->srv6_vpn) {
 			extra = bgp_path_info_extra_get(pi);
@@ -4419,17 +4413,10 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 				attr->srv6_l3vpn->loc_node_len;
 			extra->sid[0].func_len = attr->srv6_l3vpn->func_len;
 			extra->sid[0].arg_len = attr->srv6_l3vpn->arg_len;
-
-			/*
-			 * draft-ietf-bess-srv6-services-07
-			 * The part of SRv6 SID may be encoded as MPLS Label for
-			 * the efficient packing.
-			 */
-			if (attr->srv6_l3vpn->transposition_len != 0)
-				transpose_sid(
-					&extra->sid[0].sid, decode_label(label),
-					attr->srv6_l3vpn->transposition_offset,
-					attr->srv6_l3vpn->transposition_len);
+			extra->sid[0].transposition_len =
+				attr->srv6_l3vpn->transposition_len;
+			extra->sid[0].transposition_offset =
+				attr->srv6_l3vpn->transposition_offset;
 		} else if (attr->srv6_vpn) {
 			sid_copy(&extra->sid[0].sid, &attr->srv6_vpn->sid);
 			extra->num_sids = 1;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -154,6 +154,8 @@ struct bgp_sid_info {
 	uint8_t loc_node_len;
 	uint8_t func_len;
 	uint8_t arg_len;
+	uint8_t transposition_len;
+	uint8_t transposition_offset;
 };
 
 /* Ancillary information to struct bgp_path_info,

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -234,6 +234,7 @@ struct vpn_policy {
 	 */
 	uint32_t tovpn_sid_index; /* unset => set to 0 */
 	struct in6_addr *tovpn_sid;
+	struct in6_addr *tovpn_sid_locator;
 	uint32_t tovpn_sid_transpose_label;
 	struct in6_addr *tovpn_zebra_vrf_sid_last_sent;
 };


### PR DESCRIPTION
Currently, bgpd announces SRv6 L3VPN routes with transposed SID, but some implementations reject those routes. This patch changes to advertising routes with SRv6 Locator instead of transposed SID. This PR changes the following things:

- change alloc_new_sid to save not only transposed SID but also SRv6 Locator (in 1st patch)
- advertise SRv6 L3VPN routes with SRv6 Locator instead of transposed SID (2nd patch)
- change the treatment of SRv6 SID
    - before: transpose SID when bgp_sid_info is created and bgp_sid_info doesn't have transposition_len and transposition_offset
    - after: bgp_sid_info has transposition_len and transposition_offset and transpose SID only at bgp_announce_zebra