### PR TITLE
zebra: netlink protodown event handling for vxlan device

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1939,7 +1939,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 						zlog_debug(
 							"Intf %s(%u) PTM up, notifying clients",
 							name, ifp->ifindex);
-					zebra_interface_up_update(ifp);
+					if_up(ifp);
 
 					/* Update EVPN VNI when SVI MAC change
 					 */

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1920,6 +1920,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			}
 
 			if (if_is_no_ptm_operative(ifp)) {
+				bool is_up = if_is_operative(ifp);
 				ifp->flags = ifi->ifi_flags & 0x0000fffff;
 				if (!if_is_no_ptm_operative(ifp) ||
 				    CHECK_FLAG(zif->flags,
@@ -1939,7 +1940,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 						zlog_debug(
 							"Intf %s(%u) PTM up, notifying clients",
 							name, ifp->ifindex);
-					if_up(ifp);
+					if_up(ifp, !is_up);
 
 					/* Update EVPN VNI when SVI MAC change
 					 */
@@ -1975,7 +1976,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 						zlog_debug(
 							"Intf %s(%u) has come UP",
 							name, ifp->ifindex);
-					if_up(ifp);
+					if_up(ifp, true);
 					if (IS_ZEBRA_IF_BRIDGE(ifp))
 						chgflags =
 							ZEBRA_BRIDGE_MASTER_UP;

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -517,7 +517,7 @@ void if_flags_update(struct interface *ifp, uint64_t newflags)
 		/* inoperative -> operative? */
 		ifp->flags = newflags;
 		if (if_is_operative(ifp))
-			if_up(ifp);
+			if_up(ifp, true);
 	}
 }
 
@@ -1045,7 +1045,7 @@ bool if_nhg_dependents_is_empty(const struct interface *ifp)
 }
 
 /* Interface is up. */
-void if_up(struct interface *ifp)
+void if_up(struct interface *ifp, bool install_connected)
 {
 	struct zebra_if *zif;
 	struct interface *link_if;
@@ -1077,7 +1077,8 @@ void if_up(struct interface *ifp)
 #endif
 
 	/* Install connected routes to the kernel. */
-	if_install_connected(ifp);
+	if (install_connected)
+		if_install_connected(ifp);
 
 	/* Handle interface up for specific types for EVPN. Non-VxLAN interfaces
 	 * are checked to see if (remote) neighbor entries need to be installed
@@ -2778,7 +2779,7 @@ int if_linkdetect(struct interface *ifp, bool detect)
 
 		/* Interface may come up after disabling link detection */
 		if (if_is_operative(ifp) && !if_was_operative)
-			if_up(ifp);
+			if_up(ifp, true);
 	}
 	/* FIXME: Will defer status change forwarding if interface
 	   does not come down! */

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -486,7 +486,7 @@ extern void if_nbr_ipv6ll_to_ipv4ll_neigh_update(struct interface *ifp,
 extern void if_nbr_ipv6ll_to_ipv4ll_neigh_del_all(struct interface *ifp);
 extern void if_delete_update(struct interface *ifp);
 extern void if_add_update(struct interface *ifp);
-extern void if_up(struct interface *);
+extern void if_up(struct interface *ifp, bool install_connected);
 extern void if_down(struct interface *);
 extern void if_refresh(struct interface *);
 extern void if_flags_update(struct interface *, uint64_t);

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -350,7 +350,7 @@ DEFUN (no_zebra_ptm_enable_if,
 			if (IS_ZEBRA_DEBUG_EVENT)
 				zlog_debug("%s: Bringing up interface %s",
 					   __func__, ifp->name);
-			if_up(ifp);
+			if_up(ifp, true);
 		}
 	}
 
@@ -553,7 +553,7 @@ static int zebra_ptm_handle_cbl_msg(void *arg, void *in_ctxt,
 		ifp->ptm_status = ZEBRA_PTM_STATUS_UP;
 		if (ifp->ptm_enable && if_is_no_ptm_operative(ifp)
 		    && send_linkup)
-			if_up(ifp);
+			if_up(ifp, true);
 	} else if (!strcmp(cbl_str, ZEBRA_PTM_FAIL_STR)
 		   && (ifp->ptm_status != ZEBRA_PTM_STATUS_DOWN)) {
 		ifp->ptm_status = ZEBRA_PTM_STATUS_DOWN;
@@ -1163,7 +1163,7 @@ void zebra_ptm_reset_status(int ptm_disable)
 						zlog_debug(
 							"%s: Bringing up interface %s",
 							__func__, ifp->name);
-					if_up(ifp);
+					if_up(ifp, true);
 				}
 			}
 		}


### PR DESCRIPTION
For  (vxlan but any) interface is configured and UP, in the event of protodown, handle the event to bring the interface down and trigger interface up event when protodown flag is removed.

The couple of fixes found in MLAG scenario where protodown event needs to bring down vni on the primary switch. In absence  evpn routes are advertised incorrectly. 

```
1. 
 zebra: handle protodown netlink for vxlan device
    Frr need to handle protocol down event for vxlan interface.
    In MLAG scenario, one of the pair switch can put vxlan port to protodown state, 
    followed by tunnel-ip change from anycast IP to individual IP.
    In absence of protodown handling, evpn end up advertising locally learn EVPN (MAC-IP) routes
    with individual IP as nexthop.  This leads an issue of overwriting locally learn  entries as remote on MLAG pair.

Testing:
    In EVPN deployment, restart one of the MLAG daemon, which puts vxlan interfaces in protodown state.
    FRR treats protodown as oper down for vxlan interfaces. 
    VNI down cleans up/withdraws locally learn routes. Followed by vxlan device UP event, re-advertise
    locally learn routes.

2.  zebra: handle protodown netlink for vxlan device
    
    Frr need to handle protocol down event for vxlan
    interface. In MLAG scenario, one of the pair switch can put
    vxlan port to protodown state, followed by tunnel-ip change from anycast IP to individual IP.
    
    In absence of protodown handling, evpn end up advertising locally learn EVPN (MAC-IP) routes
    with individual IP as nexthop.  This leads an issue of overwriting locally learn entries as remote on MLAG pair.
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>