### PR TITLE
lib: make checksum code take iovec for input 

### DIFF
--- a/lib/checksum.h
+++ b/lib/checksum.h
@@ -27,9 +27,41 @@ struct ipv6_ph {
 	uint8_t next_hdr;
 } __attribute__((packed));
 
-extern int in_cksum(void *data, int nbytes);
-extern int in_cksum_with_ph4(struct ipv4_ph *ph, void *data, int nbytes);
-extern int in_cksum_with_ph6(struct ipv6_ph *ph, void *data, int nbytes);
+
+extern uint16_t in_cksumv(const struct iovec *iov, size_t iov_len);
+
+static inline uint16_t in_cksum(const void *data, size_t nbytes)
+{
+	struct iovec iov[1];
+
+	iov[0].iov_base = (void *)data;
+	iov[0].iov_len = nbytes;
+	return in_cksumv(iov, array_size(iov));
+}
+
+static inline uint16_t in_cksum_with_ph4(const struct ipv4_ph *ph,
+					 const void *data, size_t nbytes)
+{
+	struct iovec iov[2];
+
+	iov[0].iov_base = (void *)ph;
+	iov[0].iov_len = sizeof(*ph);
+	iov[1].iov_base = (void *)data;
+	iov[1].iov_len = nbytes;
+	return in_cksumv(iov, array_size(iov));
+}
+
+static inline uint16_t in_cksum_with_ph6(const struct ipv6_ph *ph,
+					 const void *data, size_t nbytes)
+{
+	struct iovec iov[2];
+
+	iov[0].iov_base = (void *)ph;
+	iov[0].iov_len = sizeof(*ph);
+	iov[1].iov_base = (void *)data;
+	iov[1].iov_len = nbytes;
+	return in_cksumv(iov, array_size(iov));
+}
 
 #define FLETCHER_CHECKSUM_VALIDATE 0xffff
 extern uint16_t fletcher_checksum(uint8_t *, const size_t len,

--- a/lib/checksum.h
+++ b/lib/checksum.h
@@ -1,3 +1,6 @@
+#ifndef _FRR_CHECKSUM_H
+#define _FRR_CHECKSUM_H
+
 #include <stdint.h>
 #include <netinet/in.h>
 
@@ -35,3 +38,5 @@ extern uint16_t fletcher_checksum(uint8_t *, const size_t len,
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* _FRR_CHECKSUM_H */

--- a/tests/lib/subdir.am
+++ b/tests/lib/subdir.am
@@ -148,7 +148,7 @@ check_PROGRAMS += tests/lib/test_checksum
 tests_lib_test_checksum_CFLAGS = $(TESTS_CFLAGS)
 tests_lib_test_checksum_CPPFLAGS = $(TESTS_CPPFLAGS)
 tests_lib_test_checksum_LDADD = $(ALL_TESTS_LDADD)
-tests_lib_test_checksum_SOURCES = tests/lib/test_checksum.c
+tests_lib_test_checksum_SOURCES = tests/lib/test_checksum.c tests/helpers/c/prng.c
 
 
 check_PROGRAMS += tests/lib/test_graph


### PR DESCRIPTION
Feeding a `struct iovec` into the checksum code is useful to calculate a checksum before doing a `sendmsg()` with the same `iovec`. Otherwise we end up having to copy around the entire thing.  This also "assimilates" the IP pseudoheader bits to a degree, since they can just be put in a iovec.

Also `checksum.h` was missing an include guard, and the unit test is a bit odd.