### PR TITLE
Bsd zebra graceful restart cleanup

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -29,6 +29,9 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
    Zebra, when started, will read in routes.  Those routes that Zebra
    identifies that it was the originator of will be swept in TIME seconds.
    If no time is specified then we will sweep those routes immediately.
+   Under the *BSD's, there is no way to properly store the originating
+   route and the route types in this case will show up as a static route
+   with an admin distance of 255.
 
 .. option:: -r, --retain
 

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1011,6 +1011,8 @@ void rtm_read(struct rt_msghdr *rtm)
 	ifindex_t ifindex = 0;
 	afi_t afi;
 	char fbuf[64];
+	int32_t proto = ZEBRA_ROUTE_KERNEL;
+	uint8_t distance = 0;
 
 	zebra_flags = 0;
 
@@ -1042,8 +1044,11 @@ void rtm_read(struct rt_msghdr *rtm)
 	if (!(flags & RTF_GATEWAY))
 		return;
 
-	if (flags & RTF_PROTO1)
+	if (flags & RTF_PROTO1) {
 		SET_FLAG(zebra_flags, ZEBRA_FLAG_SELFROUTE);
+		proto = ZEBRA_ROUTE_STATIC;
+		distance = 255;
+	}
 
 	memset(&nh, 0, sizeof(nh));
 
@@ -1111,13 +1116,13 @@ void rtm_read(struct rt_msghdr *rtm)
 			   0, true);
 	if (rtm->rtm_type == RTM_GET || rtm->rtm_type == RTM_ADD
 	    || rtm->rtm_type == RTM_CHANGE)
-		rib_add(afi, SAFI_UNICAST, VRF_DEFAULT, ZEBRA_ROUTE_KERNEL, 0,
-			zebra_flags, &p, NULL, &nh, 0, RT_TABLE_MAIN,
-			0, 0, 0, 0, false);
+		rib_add(afi, SAFI_UNICAST, VRF_DEFAULT, proto, 0, zebra_flags,
+			&p, NULL, &nh, 0, RT_TABLE_MAIN, 0, 0, distance, 0,
+			false);
 	else
-		rib_delete(afi, SAFI_UNICAST, VRF_DEFAULT, ZEBRA_ROUTE_KERNEL,
-			   0, zebra_flags, &p, NULL, &nh, 0, RT_TABLE_MAIN, 0,
-			   0, true);
+		rib_delete(afi, SAFI_UNICAST, VRF_DEFAULT, proto, 0,
+			   zebra_flags, &p, NULL, &nh, 0, RT_TABLE_MAIN, 0,
+			   distance, true);
 }
 
 /* Interface function for the kernel routing table updates.  Support

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -116,6 +116,7 @@ static const struct {
 	[ZEBRA_ROUTE_OPENFABRIC] = {ZEBRA_ROUTE_OPENFABRIC, 115, 5},
 	[ZEBRA_ROUTE_VRRP] = {ZEBRA_ROUTE_VRRP, 255, 7},
 	[ZEBRA_ROUTE_SRTE] = {ZEBRA_ROUTE_SRTE, 255, 7},
+	[ZEBRA_ROUTE_ALL] = {ZEBRA_ROUTE_ALL, 255, 7},
 	/* Any new route type added to zebra, should be mirrored here */
 
 	/* no entry/default: 150 */
@@ -4386,9 +4387,8 @@ static void check_route_info(void)
 	 * ZEBRA_ROUTE_ALL is also ignored.
 	 */
 	for (int i = 0; i < len; i++) {
-		if (i == ZEBRA_ROUTE_SYSTEM || i == ZEBRA_ROUTE_ALL)
-			continue;
-		assert(route_info[i].key);
+		assert(route_info[i].key >= ZEBRA_ROUTE_SYSTEM &&
+		       route_info[i].key < ZEBRA_ROUTE_MAX);
 		assert(route_info[i].meta_q_map < MQ_SIZE);
 	}
 }


### PR DESCRIPTION
See individual commits, but effectively let's get some level of graceful restart functioning in *BSD.  Currently a zebra restart with routes left in the table will cause the routes to stay in the kernel and zebra to not know about them at all after the graceful restart timer pops.  