### PR TITLE
staticd: Fix `make check` failures

### DIFF
--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -43,7 +43,6 @@
 char backup_config_file[256];
 
 bool mpls_enabled;
-uint32_t zebra_ecmp_count = MULTIPATH_NUM;
 
 zebra_capabilities_t _caps_p[] = {
 };

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -47,6 +47,7 @@
 /* Zebra structure to hold current status. */
 struct zclient *zclient;
 static struct hash *static_nht_hash;
+uint32_t zebra_ecmp_count = MULTIPATH_NUM;
 
 /* Inteface addition message from zebra. */
 static int static_ifp_create(struct interface *ifp)


### PR DESCRIPTION
Recent commit:
abc246e19345cbd2bc74c7dc50dac0b9cf2addf8

Has broken `make check` with recently new compilers:

/usr/bin/ld: staticd/libstatic.a(static_nb_config.o): warning: relocation against `zebra_ecmp_count' in read-only section `.text'
  CCLD     tests/bgpd/test_peer_attr
  CCLD     tests/bgpd/test_packet
/usr/bin/ld: staticd/libstatic.a(static_zebra.o): in function `static_zebra_capabilities':
/home/sharpd/frr5/staticd/static_zebra.c:208: undefined reference to `zebra_ecmp_count'
/usr/bin/ld: staticd/libstatic.a(static_zebra.o): in function `static_zebra_route_add':
/home/sharpd/frr5/staticd/static_zebra.c:418: undefined reference to `zebra_ecmp_count'
/usr/bin/ld: staticd/libstatic.a(static_nb_config.o): in function `static_nexthop_create':
/home/sharpd/frr5/staticd/static_nb_config.c:174: undefined reference to `zebra_ecmp_count'
/usr/bin/ld: /home/sharpd/frr5/staticd/static_nb_config.c:175: undefined reference to `zebra_ecmp_count'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
collect2: error: ld returned 1 exit status
make: *** [Makefile:8679: tests/lib/test_grpc] Error 1
make: *** Waiting for unfinished jobs....

Essentially the newly introduced variable zebra_ecmp_count is not available in the
libstatic.a compiled and make check has code that compiles against it.

The fix is to just move the variable to the library.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>