### PR TITLE
snapcraft: Add missing libelf-dev build package

### DIFF
--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -306,6 +306,7 @@ parts:
            - make
            - gawk
            - libreadline-dev
+           - libelf-dev
            - texinfo
            - libncurses5-dev
            - texlive-latex-base


### PR DESCRIPTION
Fix missing `libelf-dev` package in the snap build configuration

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>