### PR TITLE
zebra: use "assert" instead of unnecessary check

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -826,8 +826,7 @@ static int zvni_map_to_svi_ns(struct ns *ns,
 	struct interface **p_ifp = (struct interface **)_p_ifp;
 	struct zebra_if *zif;
 
-	if (!in_param)
-		return NS_WALK_STOP;
+	assert(in_param && p_ifp);
 
 	/* TODO: Optimize with a hash. */
 	for (rn = route_top(zns->if_table); rn; rn = route_next(rn)) {
@@ -842,8 +841,7 @@ static int zvni_map_to_svi_ns(struct ns *ns,
 		vl = (struct zebra_l2info_vlan *)&zif->l2info.vl;
 
 		if (vl->vid == in_param->vid) {
-			if (p_ifp)
-				*p_ifp = tmp_if;
+			*p_ifp = tmp_if;
 			return NS_WALK_STOP;
 		}
 	}


### PR DESCRIPTION
Since `zvni_map_to_svi_ns()` is used to find and return one specific interface
based on passed attributes of SVI, so the two parameters `in_param` and `p_ifp`
must not be NULL.
    
Passing NULL `p_ifp` makes no sense, so the check `if (p_ifp)` is
unnecessary.
    
So use `assert` to ensure the two parameters, and remove that unnecessary check.
