### PR TITLE
pim6d: reenable NHT code

### DIFF
--- a/pimd/pim6_stubs.c
+++ b/pimd/pim6_stubs.c
@@ -29,40 +29,6 @@
 /*
  * NH lookup / NHT
  */
-void pim_sendmsg_zebra_rnh(struct pim_instance *pim, struct zclient *zclient,
-			   struct pim_nexthop_cache *pnc, int command)
-{
-}
-
-int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
-			    struct pim_nexthop *nexthop, struct prefix *src,
-			    struct prefix *grp, int neighbor_needed)
-{
-	return 0;
-}
-
-int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
-			      struct pim_upstream *up, struct rp_info *rp,
-			      struct pim_nexthop_cache *out_pnc)
-{
-	return 0;
-}
-
-void pim_delete_tracked_nexthop(struct pim_instance *pim, struct prefix *addr,
-				struct pim_upstream *up, struct rp_info *rp)
-{
-}
-
-struct pim_nexthop_cache *pim_nexthop_cache_find(struct pim_instance *pim,
-						 struct pim_rpf *rpf)
-{
-	return NULL;
-}
-
-void pim_rp_nexthop_del(struct rp_info *rp_info)
-{
-}
-
 void pim_nht_bsr_add(struct pim_instance *pim, struct in_addr addr)
 {
 }

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -162,6 +162,7 @@ int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
 	return 0;
 }
 
+#if PIM_IPV == 4
 void pim_nht_bsr_add(struct pim_instance *pim, struct in_addr addr)
 {
 	struct pim_nexthop_cache *pnc;
@@ -175,6 +176,7 @@ void pim_nht_bsr_add(struct pim_instance *pim, struct in_addr addr)
 
 	pnc->bsr_count++;
 }
+#endif /* PIM_IPV == 4 */
 
 static void pim_nht_drop_maybe(struct pim_instance *pim,
 			       struct pim_nexthop_cache *pnc)
@@ -244,6 +246,7 @@ void pim_delete_tracked_nexthop(struct pim_instance *pim, struct prefix *addr,
 	pim_nht_drop_maybe(pim, pnc);
 }
 
+#if PIM_IPV == 4
 void pim_nht_bsr_del(struct pim_instance *pim, struct in_addr addr)
 {
 	struct pim_nexthop_cache *pnc = NULL;
@@ -398,6 +401,7 @@ bool pim_nht_bsr_rpf_check(struct pim_instance *pim, struct in_addr bsr_addr,
 	}
 	return false;
 }
+#endif /* PIM_IPV == 4 */
 
 void pim_rp_nexthop_del(struct rp_info *rp_info)
 {

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -454,10 +454,11 @@ static void pim_zebra_capabilities(struct zclient_capabilities *cap)
 static zclient_handler *const pim_handlers[] = {
 	[ZEBRA_INTERFACE_ADDRESS_ADD] = pim_zebra_if_address_add,
 	[ZEBRA_INTERFACE_ADDRESS_DELETE] = pim_zebra_if_address_del,
+
+	[ZEBRA_NEXTHOP_UPDATE] = pim_parse_nexthop_update,
 #if PIM_IPV == 4
 	[ZEBRA_ROUTER_ID_UPDATE] = pim_router_id_update_zebra,
 	[ZEBRA_INTERFACE_VRF_UPDATE] = pim_zebra_interface_vrf_update,
-	[ZEBRA_NEXTHOP_UPDATE] = pim_parse_nexthop_update,
 
 	[ZEBRA_VXLAN_SG_ADD] = pim_zebra_vxlan_sg_proc,
 	[ZEBRA_VXLAN_SG_DEL] = pim_zebra_vxlan_sg_proc,

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -38,6 +38,7 @@ pim_common = \
 	pimd/pim_nb.c \
 	pimd/pim_nb_config.c \
 	pimd/pim_neighbor.c \
+	pimd/pim_nht.c \
 	pimd/pim_oil.c \
 	pimd/pim_routemap.c \
 	pimd/pim_rp.c \
@@ -70,7 +71,6 @@ pimd_pimd_SOURCES = \
 	pimd/pim_msdp.c \
 	pimd/pim_msdp_packet.c \
 	pimd/pim_msdp_socket.c \
-	pimd/pim_nht.c \
 	pimd/pim_pim.c \
 	pimd/pim_register.c \
 	pimd/pim_signals.c \


### PR DESCRIPTION
include NHT code back into compilation for IPv6

not tested at this point, just compiles (and doesn't immediately crash)