### PR TITLE
[8.2] doc: fix typo in zebra user doc

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -81,7 +81,7 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
 .. option:: -s <SIZE>, --nl-bufsize <SIZE>
 
    Allow zebra to modify the default receive buffer size to SIZE
-   in bytes.  Under *BSD only the -s option is available.
+   in bytes.  Under \*BSD only the -s option is available.
 
 .. _interface-commands:
 


### PR DESCRIPTION
Fix a typo in the zebra doc file that generates a warning.
This is the 8.2 backport of #10682 