### PR TITLE
zebra: Remove unnecessary check

### DIFF
--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -1311,14 +1311,7 @@ int zebra_evpn_local_neigh_update(struct zebra_evpn *zevpn,
 	if (!n) {
 		/* New neighbor - create */
 		n = zebra_evpn_neigh_add(zevpn, ip, macaddr, zmac, 0);
-		if (!n) {
-			flog_err(
-				EC_ZEBRA_MAC_ADD_FAILED,
-				"Failed to add neighbor %pIA MAC %pEA intf %s(%u) -> VNI %u",
-				ip, macaddr, ifp->name, ifp->ifindex,
-				zevpn->vni);
-			return -1;
-		}
+
 		/* Set "local" forwarding info. */
 		SET_FLAG(n->flags, ZEBRA_NEIGH_LOCAL);
 		n->ifindex = ifp->ifindex;
@@ -2070,14 +2063,6 @@ void zebra_evpn_neigh_remote_macip_add(struct zebra_evpn *zevpn,
 		if (!n) {
 			n = zebra_evpn_neigh_add(zevpn, ipaddr, &mac->macaddr,
 						 mac, 0);
-			if (!n) {
-				zlog_warn(
-					"Failed to add Neigh %pIA MAC %pEA VNI %u Remote VTEP %pI4",
-					ipaddr, &mac->macaddr, zevpn->vni,
-					&vtep_ip);
-				return;
-			}
-
 		} else {
 			/* When host moves but changes its (MAC,IP)
 			 * binding, BGP may install a MACIP entry that
@@ -2182,17 +2167,8 @@ int zebra_evpn_neigh_gw_macip_add(struct interface *ifp,
 	assert(mac);
 
 	n = zebra_evpn_neigh_lookup(zevpn, ip);
-	if (!n) {
+	if (!n)
 		n = zebra_evpn_neigh_add(zevpn, ip, &mac->macaddr, mac, 0);
-		if (!n) {
-			flog_err(
-				EC_ZEBRA_MAC_ADD_FAILED,
-				"Failed to add neighbor %pIA MAC %pEA intf %s(%u) -> VNI %u",
-				ip, &mac->macaddr,
-				ifp->name, ifp->ifindex, zevpn->vni);
-			return -1;
-		}
-	}
 
 	/* Set "local" forwarding info. */
 	SET_FLAG(n->flags, ZEBRA_NEIGH_LOCAL);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2124,13 +2124,6 @@ static int zebra_vxlan_handle_vni_transition(struct zebra_vrf *zvrf, vni_t vni,
 			return 0;
 
 		zevpn = zebra_evpn_add(vni);
-		if (!zevpn) {
-			flog_err(EC_ZEBRA_VNI_ADD_FAILED,
-				 "Adding L2-VNI - Failed to add VNI hash, VNI %u",
-				 vni);
-
-			return -1;
-		}
 
 		/* Find bridge interface for the VNI */
 		vlan_if = zvni_map_to_svi(vxl->access_vlan,
@@ -5171,16 +5164,8 @@ int zebra_vxlan_if_add(struct interface *ifp)
 
 		/* Create or update EVPN hash. */
 		zevpn = zebra_evpn_lookup(vni);
-		if (!zevpn) {
+		if (!zevpn)
 			zevpn = zebra_evpn_add(vni);
-			if (!zevpn) {
-				flog_err(
-					EC_ZEBRA_VNI_ADD_FAILED,
-					"Failed to add EVPN hash, IF %s(%u) VNI %u",
-					ifp->name, ifp->ifindex, vni);
-				return -1;
-			}
-		}
 
 		if (zevpn->local_vtep_ip.s_addr != vxl->vtep_ip.s_addr ||
 			zevpn->mcast_grp.s_addr != vxl->mcast_grp.s_addr) {


### PR DESCRIPTION
A little bit of cleanup.

Since `assert` is already done, just remove these unnecessary check.