### PR TITLE
pimd: Updating rpf when pim disabled and enabled on an interface

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -24,6 +24,7 @@
 #include "lib/northbound_cli.h"
 #include "pim_igmpv3.h"
 #include "pim_neighbor.h"
+#include "pim_nht.h"
 #include "pim_pim.h"
 #include "pim_mlag.h"
 #include "pim_bfd.h"
@@ -146,6 +147,7 @@ static int pim_cmd_interface_add(struct interface *ifp)
 		pim_ifp->pim_enable = true;
 
 	pim_if_addr_add_all(ifp);
+	pim_upstream_nh_if_update(pim_ifp->pim, ifp);
 	pim_if_membership_refresh(ifp);
 
 	pim_if_create_pimreg(pim_ifp->pim);
@@ -171,6 +173,7 @@ static int pim_cmd_interface_delete(struct interface *ifp)
 
 	if (!pim_ifp->gm_enable) {
 		pim_if_addr_del_all(ifp);
+		pim_upstream_nh_if_update(pim_ifp->pim, ifp);
 		pim_if_delete(ifp);
 	}
 

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -53,6 +53,11 @@ struct pim_nexthop_cache {
 	uint32_t bsr_count;
 };
 
+struct pnc_hash_walk_data {
+	struct pim_instance *pim;
+	struct interface *ifp;
+};
+
 int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS);
 int pim_find_or_track_nexthop(struct pim_instance *pim, pim_addr addr,
 			      struct pim_upstream *up, struct rp_info *rp,
@@ -78,4 +83,5 @@ void pim_nht_bsr_del(struct pim_instance *pim, pim_addr bsr_addr);
 bool pim_nht_bsr_rpf_check(struct pim_instance *pim, pim_addr bsr_addr,
 			   struct interface *src_ifp, pim_addr src_ip);
 
+void pim_upstream_nh_if_update(struct pim_instance *pim, struct interface *ifp);
 #endif

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -61,6 +61,7 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 	ifindex_t first_ifindex = 0;
 	int found = 0;
 	int i = 0;
+	struct pim_interface *pim_ifp;
 
 #if PIM_IPV == 4
 	/*
@@ -117,15 +118,25 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 			continue;
 		}
 
-		if (!ifp->info) {
+		pim_ifp = ifp->info;
+		if (!pim_ifp) {
 			if (PIM_DEBUG_ZEBRA)
 				zlog_debug(
 					"%s: multicast not enabled on input interface %s (ifindex=%d, RPF for source %pPAs)",
 					__func__, ifp->name, first_ifindex,
 					&addr);
 			i++;
-		} else if (neighbor_needed
-			   && !pim_if_connected_to_source(ifp, addr)) {
+
+		} else if (!pim_ifp->pim_enable) {
+			if (PIM_DEBUG_ZEBRA)
+				zlog_debug(
+					"%s: pim not enabled on input interface %s (ifindex=%d, RPF for source %pI4)",
+					__func__, ifp->name, first_ifindex,
+					&addr);
+			i++;
+
+		} else if (neighbor_needed &&
+			   !pim_if_connected_to_source(ifp, addr)) {
 			nbr = pim_neighbor_find(ifp,
 						nexthop_tab[i].nexthop_addr);
 			if (PIM_DEBUG_PIM_TRACE_DETAIL)


### PR DESCRIPTION
RPF is not updated when PIM disabled and enabled on an interface.

Topology :- 

----ens192--------+---------+
R11 -------------R2--------R3
---ens256-------+---------+

R11: receiver
R2: RP
R3: source .
There are 2 links connected between each routers .

******R11: Initially (*,G) joins are sent over ens192 interface ******
R11(config)# do show ip pim upstream 225.0.7.208
Iif             Source          Group           State       Uptime   JoinTimer RSTimer   KATimer   RefCnt
ens192          *               225.0.7.208     J           00:00:4 00:00:30  --:--:--  --:--:--       1

****** Remove PIM from interface ens192 still (*,G) iif not changed ******

R11(config)# interface ens192
R11(config-if)# no ip pim
R11(config-if)# exit
R11(config)# do show ip pim upstream 225.0.7.208
Iif             Source          Group           State       Uptime   JoinTimer RSTimer   KATimer   RefCnt
ens192          *               225.0.7.208     J           00:00:12 00:00:51  --:--:--  --:--:--       1

Signed-off-by: sarita patra <saritap@vmware.com>