### PR TITLE
pim6d: Handle receive of pimv6 register packet

### DIFF
--- a/pimd/pim_br.c
+++ b/pimd/pim_br.c
@@ -33,8 +33,6 @@ struct pim_br {
 	pim_addr pmbr;
 };
 
-pim_addr pim_br_unknown = {.s_addr = 0};
-
 static struct list *pim_br_list = NULL;
 
 pim_addr pim_br_get_pmbr(pim_sgaddr *sg)
@@ -47,7 +45,7 @@ pim_addr pim_br_get_pmbr(pim_sgaddr *sg)
 			return pim_br->pmbr;
 	}
 
-	return pim_br_unknown;
+	return PIMADDR_ANY;
 }
 
 void pim_br_set_pmbr(pim_sgaddr *sg, pim_addr br)

--- a/pimd/pim_br.c
+++ b/pimd/pim_br.c
@@ -30,14 +30,14 @@
 
 struct pim_br {
 	pim_sgaddr sg;
-	struct in_addr pmbr;
+	pim_addr pmbr;
 };
 
-struct in_addr pim_br_unknown = {.s_addr = 0};
+pim_addr pim_br_unknown = {.s_addr = 0};
 
 static struct list *pim_br_list = NULL;
 
-struct in_addr pim_br_get_pmbr(pim_sgaddr *sg)
+pim_addr pim_br_get_pmbr(pim_sgaddr *sg)
 {
 	struct listnode *node;
 	struct pim_br *pim_br;
@@ -50,7 +50,7 @@ struct in_addr pim_br_get_pmbr(pim_sgaddr *sg)
 	return pim_br_unknown;
 }
 
-void pim_br_set_pmbr(pim_sgaddr *sg, struct in_addr br)
+void pim_br_set_pmbr(pim_sgaddr *sg, pim_addr br)
 {
 	struct listnode *node, *next;
 	struct pim_br *pim_br;

--- a/pimd/pim_br.h
+++ b/pimd/pim_br.h
@@ -20,13 +20,13 @@
 #ifndef PIM_BR_H
 #define PIM_BR_H
 
-struct in_addr pim_br_get_pmbr(pim_sgaddr *sg);
+pim_addr pim_br_get_pmbr(pim_sgaddr *sg);
 
-void pim_br_set_pmbr(pim_sgaddr *sg, struct in_addr value);
+void pim_br_set_pmbr(pim_sgaddr *sg, pim_addr value);
 void pim_br_clear_pmbr(pim_sgaddr *sg);
 
 void pim_br_init(void);
 
-extern struct in_addr pim_br_unknown;
+extern pim_addr pim_br_unknown;
 
 #endif

--- a/pimd/pim_br.h
+++ b/pimd/pim_br.h
@@ -27,6 +27,4 @@ void pim_br_clear_pmbr(pim_sgaddr *sg);
 
 void pim_br_init(void);
 
-extern pim_addr pim_br_unknown;
-
 #endif

--- a/pimd/pim_msg.h
+++ b/pimd/pim_msg.h
@@ -21,6 +21,9 @@
 #define PIM_MSG_H
 
 #include <netinet/in.h>
+#if PIM_IPV == 6
+#include <netinet/ip6.h>
+#endif
 
 #include "pim_jp_agg.h"
 
@@ -180,6 +183,30 @@ struct pim_jp {
 	uint16_t holdtime;
 	struct pim_jp_groups groups[1];
 } __attribute__((packed));
+
+#if PIM_IPV == 4
+static inline pim_sgaddr pim_sgaddr_from_iphdr(const void *iphdr)
+{
+	const struct ip *ipv4_hdr = iphdr;
+	pim_sgaddr sg;
+
+	sg.src = ipv4_hdr->ip_src;
+	sg.grp = ipv4_hdr->ip_dst;
+
+	return sg;
+}
+#else
+static inline pim_sgaddr pim_sgaddr_from_iphdr(const void *iphdr)
+{
+	const struct ip6_hdr *ipv6_hdr = iphdr;
+	pim_sgaddr sg;
+
+	sg.src = ipv6_hdr->ip6_src;
+	sg.grp = ipv6_hdr->ip6_dst;
+
+	return sg;
+}
+#endif
 
 void pim_msg_build_header(uint8_t *pim_msg, size_t pim_msg_size,
 			  uint8_t pim_msg_type, bool no_fwd);

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -408,15 +408,15 @@ int pim_register_recv(struct interface *ifp, pim_addr dest_addr,
 		}
 
 		if (*bits & PIM_REGISTER_BORDER_BIT) {
-			struct in_addr pimbr = pim_br_get_pmbr(&sg);
+			pim_addr pimbr = pim_br_get_pmbr(&sg);
 			if (PIM_DEBUG_PIM_PACKETS)
 				zlog_debug(
 					"%s: Received Register message with Border bit set",
 					__func__);
 
-			if (pimbr.s_addr == pim_br_unknown.s_addr)
+			if (!pim_addr_cmp(pimbr, pim_br_unknown))
 				pim_br_set_pmbr(&sg, src_addr);
-			else if (src_addr.s_addr != pimbr.s_addr) {
+			else if (pim_addr_cmp(src_addr, pimbr)) {
 				pim_register_stop_send(ifp, &sg, dest_addr,
 						       src_addr);
 				if (PIM_DEBUG_PIM_PACKETS)

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -414,7 +414,7 @@ int pim_register_recv(struct interface *ifp, pim_addr dest_addr,
 					"%s: Received Register message with Border bit set",
 					__func__);
 
-			if (!pim_addr_cmp(pimbr, pim_br_unknown))
+			if (pim_addr_is_any(pimbr))
 				pim_br_set_pmbr(&sg, src_addr);
 			else if (pim_addr_cmp(src_addr, pimbr)) {
 				pim_register_stop_send(ifp, &sg, dest_addr,

--- a/pimd/pim_register.h
+++ b/pimd/pim_register.h
@@ -32,9 +32,8 @@
 
 int pim_register_stop_recv(struct interface *ifp, uint8_t *buf, int buf_size);
 
-int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
-		      struct in_addr src_addr, uint8_t *tlv_buf,
-		      int tlv_buf_size);
+int pim_register_recv(struct interface *ifp, pim_addr dest_addr,
+		      pim_addr src_addr, uint8_t *tlv_buf, int tlv_buf_size);
 
 void pim_register_send(const uint8_t *buf, int buf_size, struct in_addr src,
 		       struct pim_rpf *rpg, int null_register,


### PR DESCRIPTION
Handle receive of pimv6 register packet

Once the send register flow is handled, will move the pim_register.c to pim_common in subdir.am

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>