### PR TITLE
lib, ospfd: Enum fixup

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -65,7 +65,7 @@ DEFINE_MTYPE_STATIC(LIB, VTY_HIST, "VTY history");
 DECLARE_DLIST(vtys, struct vty, itm);
 
 /* Vty events */
-enum event {
+enum vty_event {
 	VTY_SERV,
 	VTY_READ,
 	VTY_WRITE,
@@ -90,8 +90,8 @@ struct vty_serv {
 
 DECLARE_DLIST(vtyservs, struct vty_serv, itm);
 
-static void vty_event_serv(enum event event, struct vty_serv *);
-static void vty_event(enum event, struct vty *);
+static void vty_event_serv(enum vty_event event, struct vty_serv *);
+static void vty_event(enum vty_event, struct vty *);
 
 /* Extern host structure from command.c */
 extern struct host host;
@@ -2683,7 +2683,7 @@ int vty_config_node_exit(struct vty *vty)
 /* Master of the threads. */
 static struct thread_master *vty_master;
 
-static void vty_event_serv(enum event event, struct vty_serv *vty_serv)
+static void vty_event_serv(enum vty_event event, struct vty_serv *vty_serv)
 {
 	switch (event) {
 	case VTY_SERV:
@@ -2701,7 +2701,7 @@ static void vty_event_serv(enum event event, struct vty_serv *vty_serv)
 	}
 }
 
-static void vty_event(enum event event, struct vty *vty)
+static void vty_event(enum vty_event event, struct vty *vty)
 {
 	switch (event) {
 #ifdef VTYSH

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -47,10 +47,10 @@ DEFINE_MTYPE_STATIC(LIB, ZCLIENT, "Zclient");
 DEFINE_MTYPE_STATIC(LIB, REDIST_INST, "Redistribution instance IDs");
 
 /* Zebra client events. */
-enum event { ZCLIENT_SCHEDULE, ZCLIENT_READ, ZCLIENT_CONNECT };
+enum zclient_event { ZCLIENT_SCHEDULE, ZCLIENT_READ, ZCLIENT_CONNECT };
 
 /* Prototype for event manager. */
-static void zclient_event(enum event, struct zclient *);
+static void zclient_event(enum zclient_event, struct zclient *);
 
 static void zebra_interface_if_set_value(struct stream *s,
 					 struct interface *ifp);
@@ -4038,7 +4038,7 @@ void zclient_redistribute_default(int command, struct zclient *zclient,
 		zebra_redistribute_default_send(command, zclient, afi, vrf_id);
 }
 
-static void zclient_event(enum event event, struct zclient *zclient)
+static void zclient_event(enum zclient_event event, struct zclient *zclient)
 {
 	switch (event) {
 	case ZCLIENT_SCHEDULE:

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -278,7 +278,7 @@ struct ospf_apiserver *ospf_apiserver_new(int fd_sync, int fd_async)
 	return new;
 }
 
-void ospf_apiserver_event(enum event event, int fd,
+void ospf_apiserver_event(enum ospf_apiserver_event event, int fd,
 			  struct ospf_apiserver *apiserv)
 {
 	switch (event) {
@@ -367,7 +367,7 @@ void ospf_apiserver_read(struct thread *thread)
 	struct ospf_apiserver *apiserv;
 	struct msg *msg;
 	int fd;
-	enum event event;
+	enum ospf_apiserver_event event;
 
 	apiserv = THREAD_ARG(thread);
 	fd = THREAD_FD(thread);
@@ -710,7 +710,7 @@ static int ospf_apiserver_send_msg(struct ospf_apiserver *apiserv,
 {
 	struct msg_fifo *fifo;
 	struct msg *msg2;
-	enum event event;
+	enum ospf_apiserver_event event;
 	int fd;
 
 	switch (msg->hdr.msgtype) {

--- a/ospfd/ospf_apiserver.h
+++ b/ospfd/ospf_apiserver.h
@@ -68,7 +68,7 @@ struct ospf_apiserver {
 	struct thread *t_async_write;
 };
 
-enum event {
+enum ospf_apiserver_event {
 	OSPF_APISERVER_ACCEPT,
 	OSPF_APISERVER_SYNC_READ,
 #ifdef USE_ASYNC_READ
@@ -88,7 +88,7 @@ extern int ospf_apiserver_init(void);
 extern void ospf_apiserver_term(void);
 extern struct ospf_apiserver *ospf_apiserver_new(int fd_sync, int fd_async);
 extern void ospf_apiserver_free(struct ospf_apiserver *apiserv);
-extern void ospf_apiserver_event(enum event event, int fd,
+extern void ospf_apiserver_event(enum ospf_apiserver_event event, int fd,
 				 struct ospf_apiserver *apiserv);
 extern int ospf_apiserver_serv_sock_family(unsigned short port, int family);
 extern void ospf_apiserver_accept(struct thread *thread);


### PR DESCRIPTION
See individual commits, but there are 3 cases of enum's called `enum event` in our code base.  Let's rename them to something a bit better named to reduce confusion in the future.