### PR TITLE
pimd: Show group-type under `show ip pim rp-info`

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -505,9 +505,11 @@ cause great confusion.
    Display information about a S,G pair and how the RPF would be chosen. This
    is especially useful if there are ECMP's available from the RPF lookup.
 
-.. clicmd:: show ip pim rp-info
+.. clicmd:: show ip pim [vrf NAME] rp-info [A.B.C.D] [json]
 
    Display information about RP's that are configured on this router.
+
+   You can filter the output by specifying an arbitrary group.
 
 .. clicmd:: show ip pim rpf
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5313,39 +5313,50 @@ DEFUN (show_ip_pim_upstream_rpf,
 
 DEFUN (show_ip_pim_rp,
        show_ip_pim_rp_cmd,
-       "show ip pim [vrf NAME] rp-info [json]",
+       "show ip pim [vrf NAME] rp-info [A.B.C.D] [json]",
        SHOW_STR
        IP_STR
        PIM_STR
        VRF_CMD_HELP_STR
        "PIM RP information\n"
+       "Multicast Group address\n"
        JSON_STR)
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
 	bool uj = use_json(argc, argv);
+	struct in_addr group = {0};
 
 	if (!vrf)
 		return CMD_WARNING;
 
-	pim_rp_show_information(vrf->info, vty, uj);
+	if (argv_find(argv, argc, "A.B.C.D", &idx))
+		inet_pton(AF_INET, argv[idx]->arg, &group);
+
+	pim_rp_show_information(vrf->info, &group, vty, uj);
 
 	return CMD_SUCCESS;
 }
 
 DEFUN (show_ip_pim_rp_vrf_all,
        show_ip_pim_rp_vrf_all_cmd,
-       "show ip pim vrf all rp-info [json]",
+       "show ip pim vrf all rp-info [A.B.C.D] [json]",
        SHOW_STR
        IP_STR
        PIM_STR
        VRF_CMD_HELP_STR
        "PIM RP information\n"
+       "Multicast Group address\n"
        JSON_STR)
 {
+	int idx = 0;
 	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
+	struct in_addr group = {0};
+
+	if (argv_find(argv, argc, "A.B.C.D", &idx))
+		inet_pton(AF_INET, argv[idx]->arg, &group);
 
 	if (uj)
 		vty_out(vty, "{ ");
@@ -5357,7 +5368,7 @@ DEFUN (show_ip_pim_rp_vrf_all,
 			first = false;
 		} else
 			vty_out(vty, "VRF: %s\n", vrf->name);
-		pim_rp_show_information(vrf->info, vty, uj);
+		pim_rp_show_information(vrf->info, &group, vty, uj);
 	}
 	if (uj)
 		vty_out(vty, "}\n");

--- a/pimd/pim_rp.h
+++ b/pimd/pim_rp.h
@@ -80,8 +80,8 @@ struct pim_rpf *pim_rp_g(struct pim_instance *pim, pim_addr group);
 #define I_am_RP(P, G)  pim_rp_i_am_rp ((P), (G))
 #define RP(P, G)       pim_rp_g ((P), (G))
 
-void pim_rp_show_information(struct pim_instance *pim, struct vty *vty,
-			     bool uj);
+void pim_rp_show_information(struct pim_instance *pim, struct in_addr *group,
+			     struct vty *vty, bool uj);
 void pim_resolve_rp_nh(struct pim_instance *pim, struct pim_neighbor *nbr);
 int pim_rp_list_cmp(void *v1, void *v2);
 struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,

--- a/pimd/pim_ssm.h
+++ b/pimd/pim_ssm.h
@@ -34,7 +34,7 @@ struct pim_ssm {
 
 void pim_ssm_prefix_list_update(struct pim_instance *pim,
 				struct prefix_list *plist);
-int pim_is_grp_ssm(struct pim_instance *pim, pim_addr group_addr);
+extern int pim_is_grp_ssm(struct pim_instance *pim, pim_addr group_addr);
 int pim_ssm_range_set(struct pim_instance *pim, vrf_id_t vrf_id,
 		      const char *plist_name);
 void *pim_ssm_init(void);


### PR DESCRIPTION
```
spine1-debian-11# sh ip pim rp-info json
{
  "192.168.0.2":[
    {
      "rpAddress":"192.168.0.2",
      "outboundInterface":"eth1",
      "iAmRP":true,
      "group":"224.0.0.0/4",
      "source":"Static",
      "groupType":"ASM"
    }
  ]
}
spine1-debian-11# sh ip pim rp-info
RP address       group/prefix-list   OIF               I am RP    Source   Group-Type
192.168.0.2      224.0.0.0/4         eth1              yes        Static   ASM
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>