### PR TITLE
pim6d: modify pim_rpf from struct prefix to pim_addr

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -571,7 +571,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 	struct route_node *rn;
 	struct route_node *rpnode;
 	struct bsgrp_node *bsgrp;
-	struct prefix nht_p;
+	pim_addr nht_p;
 	struct prefix g_all;
 	struct rp_info *rp_all;
 	struct pim_upstream *up;
@@ -617,12 +617,10 @@ void pim_bsm_clear(struct pim_instance *pim)
 		}
 
 		/* Deregister addr with Zebra NHT */
-		nht_p.family = AF_INET;
-		nht_p.prefixlen = IPV4_MAX_BITLEN;
-		nht_p.u.prefix4 = rp_info->rp.rpf_addr.u.prefix4;
+		nht_p = rp_info->rp.rpf_addr;
 
 		if (PIM_DEBUG_PIM_NHT_RP) {
-			zlog_debug("%s: Deregister RP addr %pFX with Zebra ",
+			zlog_debug("%s: Deregister RP addr %pPA with Zebra ",
 				   __func__, &nht_p);
 		}
 
@@ -634,7 +632,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 		rp_all = pim_rp_find_match_group(pim, &g_all);
 
 		if (rp_all == rp_info) {
-			pim_addr_to_prefix(&rp_all->rp.rpf_addr, PIMADDR_ANY);
+			rp_all->rp.rpf_addr = PIMADDR_ANY;
 			rp_all->i_am_rp = 0;
 		} else {
 			/* Delete the rp_info from rp-list */

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -624,7 +624,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 				   __func__, &nht_p);
 		}
 
-		pim_delete_tracked_nexthop(pim, &nht_p, NULL, rp_info);
+		pim_delete_tracked_nexthop(pim, nht_p, NULL, rp_info);
 
 		if (!pim_get_all_mcast_group(&g_all))
 			return;

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -635,9 +635,7 @@ void pim_if_addr_add(struct connected *ifc)
 			   with RNH address to receive update and add the
 			   interface as nexthop. */
 			memset(&rpf, 0, sizeof(struct pim_rpf));
-			rpf.rpf_addr.family = AF_INET;
-			rpf.rpf_addr.prefixlen = IPV4_MAX_BITLEN;
-			rpf.rpf_addr.u.prefix4 = ifc->address->u.prefix4;
+			rpf.rpf_addr = pim_addr_from_prefix(ifc->address);
 			pnc = pim_nexthop_cache_find(pim_ifp->pim, &rpf);
 			if (pnc)
 				pim_sendmsg_zebra_rnh(pim_ifp->pim, zclient,

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -685,8 +685,7 @@ static void on_ifjoin_prune_pending_timer(struct thread *t)
 				struct pim_rpf rpf;
 
 				rpf.source_nexthop.interface = ifp;
-				pim_addr_to_prefix(&rpf.rpf_addr,
-						   pim_ifp->primary_address);
+				rpf.rpf_addr = pim_ifp->primary_address;
 				pim_jp_agg_single_upstream_send(
 					&rpf, ch->upstream, 0);
 			}
@@ -751,7 +750,7 @@ static void check_recv_upstream(int is_join, struct interface *recv_ifp,
 		return;
 	}
 
-	rpf_addr = pim_addr_from_prefix(&up->rpf.rpf_addr);
+	rpf_addr = up->rpf.rpf_addr;
 
 	/* upstream directed to RPF'(S,G) ? */
 	if (pim_addr_cmp(upstream, rpf_addr)) {

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -110,7 +110,6 @@ pim_jp_agg_get_interface_upstream_switch_list(struct pim_rpf *rpf)
 	struct pim_interface *pim_ifp;
 	struct pim_iface_upstream_switch *pius;
 	struct listnode *node, *nnode;
-	pim_addr rpf_addr;
 
 	if (!ifp)
 		return NULL;
@@ -121,18 +120,16 @@ pim_jp_agg_get_interface_upstream_switch_list(struct pim_rpf *rpf)
 	if (!pim_ifp)
 		return NULL;
 
-	rpf_addr = pim_addr_from_prefix(&rpf->rpf_addr);
-
 	for (ALL_LIST_ELEMENTS(pim_ifp->upstream_switch_list, node, nnode,
 			       pius)) {
-		if (!pim_addr_cmp(pius->address, rpf_addr))
+		if (!pim_addr_cmp(pius->address, rpf->rpf_addr))
 			break;
 	}
 
 	if (!pius) {
 		pius = XCALLOC(MTYPE_PIM_JP_AGG_GROUP,
 			       sizeof(struct pim_iface_upstream_switch));
-		pius->address = rpf_addr;
+		pius->address = rpf->rpf_addr;
 		pius->us = list_new();
 		listnode_add_sort(pim_ifp->upstream_switch_list, pius);
 	}

--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -279,7 +279,7 @@ size_t pim_msg_build_jp_groups(struct pim_jp_groups *grp,
 			struct pim_rpf *rpf = pim_rp_g(pim, source->up->sg.grp);
 			bits = PIM_ENCODE_SPARSE_BIT | PIM_ENCODE_WC_BIT
 			       | PIM_ENCODE_RPT_BIT;
-			stosend = pim_addr_from_prefix(&rpf->rpf_addr);
+			stosend = rpf->rpf_addr;
 			/* Only Send SGRpt in case of *,G Join */
 			if (source->is_join)
 				up = source->up;

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -263,7 +263,7 @@ static void on_neighbor_jp_timer(struct thread *t)
 			   neigh->upstream_jp_agg->count);
 
 	rpf.source_nexthop.interface = neigh->interface;
-	pim_addr_to_prefix(&rpf.rpf_addr, neigh->source_addr);
+	rpf.rpf_addr = neigh->source_addr;
 	pim_joinprune_send(&rpf, neigh->upstream_jp_agg);
 
 	thread_add_timer(router->master, on_neighbor_jp_timer, neigh,

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -54,21 +54,21 @@ struct pim_nexthop_cache {
 };
 
 int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS);
-int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
+int pim_find_or_track_nexthop(struct pim_instance *pim, pim_addr *addr,
 			      struct pim_upstream *up, struct rp_info *rp,
 			      struct pim_nexthop_cache *out_pnc);
-void pim_delete_tracked_nexthop(struct pim_instance *pim, struct prefix *addr,
+void pim_delete_tracked_nexthop(struct pim_instance *pim, pim_addr *addr,
 				struct pim_upstream *up, struct rp_info *rp);
 struct pim_nexthop_cache *pim_nexthop_cache_find(struct pim_instance *pim,
 						 struct pim_rpf *rpf);
 uint32_t pim_compute_ecmp_hash(struct prefix *src, struct prefix *grp);
 int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
-			    struct pim_nexthop *nexthop, struct prefix *src,
+			    struct pim_nexthop *nexthop, pim_addr *src,
 			    struct prefix *grp, int neighbor_needed);
 void pim_sendmsg_zebra_rnh(struct pim_instance *pim, struct zclient *zclient,
 			   struct pim_nexthop_cache *pnc, int command);
-int pim_ecmp_fib_lookup_if_vif_index(struct pim_instance *pim,
-				     struct prefix *src, struct prefix *grp);
+int pim_ecmp_fib_lookup_if_vif_index(struct pim_instance *pim, pim_addr *src,
+				     struct prefix *grp);
 void pim_rp_nexthop_del(struct rp_info *rp_info);
 
 /* for RPF check on BSM message receipt */

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -54,20 +54,20 @@ struct pim_nexthop_cache {
 };
 
 int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS);
-int pim_find_or_track_nexthop(struct pim_instance *pim, pim_addr *addr,
+int pim_find_or_track_nexthop(struct pim_instance *pim, pim_addr addr,
 			      struct pim_upstream *up, struct rp_info *rp,
 			      struct pim_nexthop_cache *out_pnc);
-void pim_delete_tracked_nexthop(struct pim_instance *pim, pim_addr *addr,
+void pim_delete_tracked_nexthop(struct pim_instance *pim, pim_addr addr,
 				struct pim_upstream *up, struct rp_info *rp);
 struct pim_nexthop_cache *pim_nexthop_cache_find(struct pim_instance *pim,
 						 struct pim_rpf *rpf);
 uint32_t pim_compute_ecmp_hash(struct prefix *src, struct prefix *grp);
 int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
-			    struct pim_nexthop *nexthop, pim_addr *src,
+			    struct pim_nexthop *nexthop, pim_addr src,
 			    struct prefix *grp, int neighbor_needed);
 void pim_sendmsg_zebra_rnh(struct pim_instance *pim, struct zclient *zclient,
 			   struct pim_nexthop_cache *pnc, int command);
-int pim_ecmp_fib_lookup_if_vif_index(struct pim_instance *pim, pim_addr *src,
+int pim_ecmp_fib_lookup_if_vif_index(struct pim_instance *pim, pim_addr src,
 				     struct prefix *grp);
 void pim_rp_nexthop_del(struct rp_info *rp_info);
 

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -406,7 +406,7 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 			zlog_debug(
 				"%s: Deregister upstream %s addr %pPA with Zebra NHT",
 				__func__, up->sg_str, &old_upstream_addr);
-		pim_delete_tracked_nexthop(pim, &old_upstream_addr, up, NULL);
+		pim_delete_tracked_nexthop(pim, old_upstream_addr, up, NULL);
 	}
 
 	/* Update the upstream address */
@@ -558,12 +558,12 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 
 			pim_rp_check_interfaces(pim, rp_all);
 			pim_rp_refresh_group_to_rp_mapping(pim);
-			pim_find_or_track_nexthop(pim, &nht_p, NULL, rp_all,
+			pim_find_or_track_nexthop(pim, nht_p, NULL, rp_all,
 						  NULL);
 
 			if (!pim_ecmp_nexthop_lookup(pim,
 						     &rp_all->rp.source_nexthop,
-						     &nht_p, &rp_all->group, 1))
+						     nht_p, &rp_all->group, 1))
 				return PIM_RP_NO_PATH;
 			return PIM_SUCCESS;
 		}
@@ -655,8 +655,8 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 	if (PIM_DEBUG_PIM_NHT_RP)
 		zlog_debug("%s: NHT Register RP addr %pPA grp %pFX with Zebra ",
 			   __func__, &nht_p, &rp_info->group);
-	pim_find_or_track_nexthop(pim, &nht_p, NULL, rp_info, NULL);
-	if (!pim_ecmp_nexthop_lookup(pim, &rp_info->rp.source_nexthop, &nht_p,
+	pim_find_or_track_nexthop(pim, nht_p, NULL, rp_info, NULL);
+	if (!pim_ecmp_nexthop_lookup(pim, &rp_info->rp.source_nexthop, nht_p,
 				     &rp_info->group, 1))
 		return PIM_RP_NO_PATH;
 
@@ -748,7 +748,7 @@ int pim_rp_del(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 	if (PIM_DEBUG_PIM_NHT_RP)
 		zlog_debug("%s: Deregister RP addr %pPA with Zebra ", __func__,
 			   &nht_p);
-	pim_delete_tracked_nexthop(pim, &nht_p, NULL, rp_info);
+	pim_delete_tracked_nexthop(pim, nht_p, NULL, rp_info);
 
 	if (!pim_get_all_mcast_group(&g_all))
 		return PIM_RP_BAD_ADDRESS;
@@ -882,7 +882,7 @@ int pim_rp_change(struct pim_instance *pim, pim_addr new_rp_addr,
 		if (PIM_DEBUG_PIM_NHT_RP)
 			zlog_debug("%s: Deregister RP addr %pPA with Zebra ",
 				   __func__, &nht_p);
-		pim_delete_tracked_nexthop(pim, &nht_p, NULL, rp_info);
+		pim_delete_tracked_nexthop(pim, nht_p, NULL, rp_info);
 	}
 
 	pim_rp_nexthop_del(rp_info);
@@ -919,8 +919,8 @@ int pim_rp_change(struct pim_instance *pim, pim_addr new_rp_addr,
 		zlog_debug("%s: NHT Register RP addr %pPA grp %pFX with Zebra ",
 			   __func__, &nht_p, &rp_info->group);
 
-	pim_find_or_track_nexthop(pim, &nht_p, NULL, rp_info, NULL);
-	if (!pim_ecmp_nexthop_lookup(pim, &rp_info->rp.source_nexthop, &nht_p,
+	pim_find_or_track_nexthop(pim, nht_p, NULL, rp_info, NULL);
+	if (!pim_ecmp_nexthop_lookup(pim, &rp_info->rp.source_nexthop, nht_p,
 				     &rp_info->group, 1)) {
 		route_unlock_node(rn);
 		return PIM_RP_NO_PATH;
@@ -947,9 +947,9 @@ void pim_rp_setup(struct pim_instance *pim)
 
 		nht_p = rp_info->rp.rpf_addr;
 
-		pim_find_or_track_nexthop(pim, &nht_p, NULL, rp_info, NULL);
+		pim_find_or_track_nexthop(pim, nht_p, NULL, rp_info, NULL);
 		if (!pim_ecmp_nexthop_lookup(pim, &rp_info->rp.source_nexthop,
-					     &nht_p, &rp_info->group, 1))
+					     nht_p, &rp_info->group, 1))
 			if (PIM_DEBUG_PIM_NHT_RP)
 				zlog_debug(
 					"Unable to lookup nexthop for rp specified");
@@ -1024,9 +1024,10 @@ void pim_i_am_rp_re_evaluate(struct pim_instance *pim)
 						   __func__,
 						   &rp_info->rp.rpf_addr);
 				else
-					zlog_debug("%s: %pPA: i am no longer rp",
-						   __func__,
-						   &rp_info->rp.rpf_addr);
+					zlog_debug(
+						"%s: %pPA: i am no longer rp",
+						__func__,
+						&rp_info->rp.rpf_addr);
 			}
 		}
 	}
@@ -1081,10 +1082,10 @@ struct pim_rpf *pim_rp_g(struct pim_instance *pim, pim_addr group)
 			zlog_debug(
 				"%s: NHT Register RP addr %pPA grp %pFX with Zebra",
 				__func__, &nht_p, &rp_info->group);
-		pim_find_or_track_nexthop(pim, &nht_p, NULL, rp_info, NULL);
+		pim_find_or_track_nexthop(pim, nht_p, NULL, rp_info, NULL);
 		pim_rpf_set_refresh_time(pim);
 		(void)pim_ecmp_nexthop_lookup(pim, &rp_info->rp.source_nexthop,
-					      &nht_p, &rp_info->group, 1);
+					      nht_p, &rp_info->group, 1);
 		return (&rp_info->rp);
 	}
 
@@ -1288,8 +1289,7 @@ void pim_resolve_rp_nh(struct pim_instance *pim, struct pim_neighbor *nbr)
 
 		nht_p = rp_info->rp.rpf_addr;
 		memset(&pnc, 0, sizeof(struct pim_nexthop_cache));
-		if (!pim_find_or_track_nexthop(pim, &nht_p, NULL, rp_info,
-					       &pnc))
+		if (!pim_find_or_track_nexthop(pim, nht_p, NULL, rp_info, &pnc))
 			continue;
 
 		for (nh_node = pnc.nexthop; nh_node; nh_node = nh_node->next) {

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -84,7 +84,7 @@ int pim_rp_list_cmp(void *v1, void *v2)
 	/*
 	 * Sort by RP IP address
 	 */
-	ret = prefix_cmp(&rp1->rp.rpf_addr, &rp2->rp.rpf_addr);
+	ret = pim_addr_cmp(rp1->rp.rpf_addr, rp2->rp.rpf_addr);
 	if (ret)
 		return ret;
 
@@ -119,7 +119,7 @@ void pim_rp_init(struct pim_instance *pim)
 		XFREE(MTYPE_PIM_RP, rp_info);
 		return;
 	}
-	pim_addr_to_prefix(&rp_info->rp.rpf_addr, PIMADDR_ANY);
+	rp_info->rp.rpf_addr = PIMADDR_ANY;
 
 	listnode_add(pim->rp_list, rp_info);
 
@@ -149,12 +149,9 @@ static struct rp_info *pim_rp_find_prefix_list(struct pim_instance *pim,
 {
 	struct listnode *node;
 	struct rp_info *rp_info;
-	struct prefix rp_prefix;
-
-	pim_addr_to_prefix(&rp_prefix, rp);
 
 	for (ALL_LIST_ELEMENTS_RO(pim->rp_list, node, rp_info)) {
-		if (prefix_same(&rp_prefix, &rp_info->rp.rpf_addr) &&
+		if ((!pim_addr_cmp(rp, rp_info->rp.rpf_addr)) &&
 		    rp_info->plist && strcmp(rp_info->plist, plist) == 0) {
 			return rp_info;
 		}
@@ -189,11 +186,9 @@ static struct rp_info *pim_rp_find_exact(struct pim_instance *pim, pim_addr rp,
 {
 	struct listnode *node;
 	struct rp_info *rp_info;
-	struct prefix rp_prefix;
 
-	pim_addr_to_prefix(&rp_prefix, rp);
 	for (ALL_LIST_ELEMENTS_RO(pim->rp_list, node, rp_info)) {
-		if (prefix_same(&rp_prefix, &rp_info->rp.rpf_addr) &&
+		if ((!pim_addr_cmp(rp, rp_info->rp.rpf_addr)) &&
 		    prefix_same(&rp_info->group, group))
 			return rp_info;
 	}
@@ -344,11 +339,11 @@ static int pim_rp_check_interface_addrs(struct rp_info *rp_info,
 {
 	struct listnode *node;
 	struct pim_secondary_addr *sec_addr;
-	pim_addr rpf_addr;
+	struct prefix rpf_addr;
 
-	rpf_addr = pim_addr_from_prefix(&rp_info->rp.rpf_addr);
+	pim_addr_to_prefix(&rpf_addr, rp_info->rp.rpf_addr);
 
-	if (!pim_addr_cmp(pim_ifp->primary_address, rpf_addr))
+	if (!pim_addr_cmp(pim_ifp->primary_address, rp_info->rp.rpf_addr))
 		return 1;
 
 	if (!pim_ifp->sec_addr_list) {
@@ -356,7 +351,7 @@ static int pim_rp_check_interface_addrs(struct rp_info *rp_info,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->sec_addr_list, node, sec_addr)) {
-		if (prefix_same(&sec_addr->addr, &rp_info->rp.rpf_addr)) {
+		if (prefix_same(&sec_addr->addr, &rpf_addr)) {
 			return 1;
 		}
 	}
@@ -388,7 +383,6 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 	enum pim_rpf_result rpf_result;
 	pim_addr old_upstream_addr;
 	pim_addr new_upstream_addr;
-	struct prefix nht_p;
 
 	old_upstream_addr = up->upstream_addr;
 	pim_rp_set_upstream_addr(pim, &new_upstream_addr, up->sg.src,
@@ -408,12 +402,11 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 	 */
 	if (!pim_addr_is_any(old_upstream_addr)) {
 		/* Deregister addr with Zebra NHT */
-		pim_addr_to_prefix(&nht_p, old_upstream_addr);
 		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
-				"%s: Deregister upstream %s addr %pFX with Zebra NHT",
-				__func__, up->sg_str, &nht_p);
-		pim_delete_tracked_nexthop(pim, &nht_p, up, NULL);
+				"%s: Deregister upstream %s addr %pPA with Zebra NHT",
+				__func__, up->sg_str, &old_upstream_addr);
+		pim_delete_tracked_nexthop(pim, &old_upstream_addr, up, NULL);
 	}
 
 	/* Update the upstream address */
@@ -446,7 +439,7 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 	struct listnode *node, *nnode;
 	struct rp_info *tmp_rp_info;
 	char buffer[BUFSIZ];
-	struct prefix nht_p;
+	pim_addr nht_p;
 	struct route_node *rn = NULL;
 	struct pim_upstream *up;
 	bool upstream_updated = false;
@@ -456,7 +449,7 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 
 	rp_info = XCALLOC(MTYPE_PIM_RP, sizeof(*rp_info));
 
-	pim_addr_to_prefix(&rp_info->rp.rpf_addr, rp_addr);
+	rp_info->rp.rpf_addr = rp_addr;
 	prefix_copy(&rp_info->group, &group);
 	rp_info->rp_src = rp_src_flag;
 
@@ -482,8 +475,8 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 		 */
 		for (ALL_LIST_ELEMENTS(pim->rp_list, node, nnode,
 				       tmp_rp_info)) {
-			if (prefix_same(&rp_info->rp.rpf_addr,
-					&tmp_rp_info->rp.rpf_addr)) {
+			if (!pim_addr_cmp(rp_info->rp.rpf_addr,
+					  tmp_rp_info->rp.rpf_addr)) {
 				if (tmp_rp_info->plist)
 					pim_rp_del_config(pim, rp_addr, NULL,
 							  tmp_rp_info->plist);
@@ -519,8 +512,8 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 		for (ALL_LIST_ELEMENTS(pim->rp_list, node, nnode,
 				       tmp_rp_info)) {
 			if (tmp_rp_info->plist &&
-			    prefix_same(&rp_info->rp.rpf_addr,
-					&tmp_rp_info->rp.rpf_addr)) {
+			    (!pim_addr_cmp(rp_info->rp.rpf_addr,
+					   tmp_rp_info->rp.rpf_addr))) {
 				pim_rp_del_config(pim, rp_addr, NULL,
 						  tmp_rp_info->plist);
 			}
@@ -539,7 +532,7 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 			nht_p = rp_all->rp.rpf_addr;
 			if (PIM_DEBUG_PIM_NHT_RP)
 				zlog_debug(
-					"%s: NHT Register rp_all addr %pFX grp %pFX ",
+					"%s: NHT Register rp_all addr %pPA grp %pFX ",
 					__func__, &nht_p, &rp_all->group);
 
 			frr_each (rb_pim_upstream, &pim->upstream_head, up) {
@@ -660,7 +653,7 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 	/* Register addr with Zebra NHT */
 	nht_p = rp_info->rp.rpf_addr;
 	if (PIM_DEBUG_PIM_NHT_RP)
-		zlog_debug("%s: NHT Register RP addr %pFX grp %pFX with Zebra ",
+		zlog_debug("%s: NHT Register RP addr %pPA grp %pFX with Zebra ",
 			   __func__, &nht_p, &rp_info->group);
 	pim_find_or_track_nexthop(pim, &nht_p, NULL, rp_info, NULL);
 	if (!pim_ecmp_nexthop_lookup(pim, &rp_info->rp.source_nexthop, &nht_p,
@@ -698,7 +691,7 @@ int pim_rp_del(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 	struct prefix g_all;
 	struct rp_info *rp_info;
 	struct rp_info *rp_all;
-	struct prefix nht_p;
+	pim_addr nht_p;
 	struct route_node *rn;
 	bool was_plist = false;
 	struct rp_info *trp_info;
@@ -753,7 +746,7 @@ int pim_rp_del(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 	/* Deregister addr with Zebra NHT */
 	nht_p = rp_info->rp.rpf_addr;
 	if (PIM_DEBUG_PIM_NHT_RP)
-		zlog_debug("%s: Deregister RP addr %pFX with Zebra ", __func__,
+		zlog_debug("%s: Deregister RP addr %pPA with Zebra ", __func__,
 			   &nht_p);
 	pim_delete_tracked_nexthop(pim, &nht_p, NULL, rp_info);
 
@@ -769,7 +762,7 @@ int pim_rp_del(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 			 */
 			pim_addr rpf_addr;
 
-			rpf_addr = pim_addr_from_prefix(&rp_info->rp.rpf_addr);
+			rpf_addr = rp_info->rp.rpf_addr;
 			if (!pim_addr_cmp(up->upstream_addr, rpf_addr) &&
 			    pim_addr_is_any(up->sg.src)) {
 				struct prefix grp;
@@ -782,7 +775,7 @@ int pim_rp_del(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 				}
 			}
 		}
-		pim_addr_to_prefix(&rp_all->rp.rpf_addr, PIMADDR_ANY);
+		rp_all->rp.rpf_addr = PIMADDR_ANY;
 		rp_all->i_am_rp = 0;
 		return PIM_SUCCESS;
 	}
@@ -817,7 +810,7 @@ int pim_rp_del(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 		 */
 		pim_addr rpf_addr;
 
-		rpf_addr = pim_addr_from_prefix(&rp_info->rp.rpf_addr);
+		rpf_addr = rp_info->rp.rpf_addr;
 		if (!pim_addr_cmp(up->upstream_addr, rpf_addr) &&
 		    pim_addr_is_any(up->sg.src)) {
 			struct prefix grp;
@@ -851,7 +844,7 @@ int pim_rp_del(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 int pim_rp_change(struct pim_instance *pim, pim_addr new_rp_addr,
 		  struct prefix group, enum rp_source rp_src_flag)
 {
-	struct prefix nht_p;
+	pim_addr nht_p;
 	struct route_node *rn;
 	int result = 0;
 	struct rp_info *rp_info = NULL;
@@ -873,7 +866,7 @@ int pim_rp_change(struct pim_instance *pim, pim_addr new_rp_addr,
 		return result;
 	}
 
-	old_rp_addr = pim_addr_from_prefix(&rp_info->rp.rpf_addr);
+	old_rp_addr = rp_info->rp.rpf_addr;
 	if (!pim_addr_cmp(new_rp_addr, old_rp_addr)) {
 		if (rp_info->rp_src != rp_src_flag) {
 			rp_info->rp_src = rp_src_flag;
@@ -882,15 +875,12 @@ int pim_rp_change(struct pim_instance *pim, pim_addr new_rp_addr,
 		}
 	}
 
-	nht_p.family = PIM_AF;
-	nht_p.prefixlen = PIM_MAX_BITLEN;
-
 	/* Deregister old RP addr with Zebra NHT */
 
 	if (!pim_addr_is_any(old_rp_addr)) {
 		nht_p = rp_info->rp.rpf_addr;
 		if (PIM_DEBUG_PIM_NHT_RP)
-			zlog_debug("%s: Deregister RP addr %pFX with Zebra ",
+			zlog_debug("%s: Deregister RP addr %pPA with Zebra ",
 				   __func__, &nht_p);
 		pim_delete_tracked_nexthop(pim, &nht_p, NULL, rp_info);
 	}
@@ -899,7 +889,7 @@ int pim_rp_change(struct pim_instance *pim, pim_addr new_rp_addr,
 	listnode_delete(pim->rp_list, rp_info);
 	/* Update the new RP address*/
 
-	pim_addr_to_prefix(&rp_info->rp.rpf_addr, new_rp_addr);
+	rp_info->rp.rpf_addr = new_rp_addr;
 	rp_info->rp_src = rp_src_flag;
 	rp_info->i_am_rp = 0;
 
@@ -926,7 +916,7 @@ int pim_rp_change(struct pim_instance *pim, pim_addr new_rp_addr,
 	/* Register new RP addr with Zebra NHT */
 	nht_p = rp_info->rp.rpf_addr;
 	if (PIM_DEBUG_PIM_NHT_RP)
-		zlog_debug("%s: NHT Register RP addr %pFX grp %pFX with Zebra ",
+		zlog_debug("%s: NHT Register RP addr %pPA grp %pFX with Zebra ",
 			   __func__, &nht_p, &rp_info->group);
 
 	pim_find_or_track_nexthop(pim, &nht_p, NULL, rp_info, NULL);
@@ -949,7 +939,7 @@ void pim_rp_setup(struct pim_instance *pim)
 {
 	struct listnode *node;
 	struct rp_info *rp_info;
-	struct prefix nht_p;
+	pim_addr nht_p;
 
 	for (ALL_LIST_ELEMENTS_RO(pim->rp_list, node, rp_info)) {
 		if (pim_rpf_addr_is_inaddr_any(&rp_info->rp))
@@ -994,12 +984,9 @@ void pim_rp_check_on_if_add(struct pim_interface *pim_ifp)
 		if (pim_rp_check_interface_addrs(rp_info, pim_ifp)) {
 			i_am_rp_changed = true;
 			rp_info->i_am_rp = 1;
-			if (PIM_DEBUG_PIM_NHT_RP) {
-				char rp[PREFIX_STRLEN];
-				pim_addr_dump("<rp?>", &rp_info->rp.rpf_addr,
-					      rp, sizeof(rp));
-				zlog_debug("%s: %s: i am rp", __func__, rp);
-			}
+			if (PIM_DEBUG_PIM_NHT_RP)
+				zlog_debug("%s: %pPA: i am rp", __func__,
+					   &rp_info->rp.rpf_addr);
 		}
 	}
 
@@ -1032,16 +1019,14 @@ void pim_i_am_rp_re_evaluate(struct pim_instance *pim)
 		if (old_i_am_rp != rp_info->i_am_rp) {
 			i_am_rp_changed = true;
 			if (PIM_DEBUG_PIM_NHT_RP) {
-				char rp[PREFIX_STRLEN];
-				pim_addr_dump("<rp?>", &rp_info->rp.rpf_addr,
-					      rp, sizeof(rp));
-				if (rp_info->i_am_rp) {
-					zlog_debug("%s: %s: i am rp", __func__,
-						   rp);
-				} else {
-					zlog_debug("%s: %s: i am no longer rp",
-						   __func__, rp);
-				}
+				if (rp_info->i_am_rp)
+					zlog_debug("%s: %pPA: i am rp",
+						   __func__,
+						   &rp_info->rp.rpf_addr);
+				else
+					zlog_debug("%s: %pPA: i am no longer rp",
+						   __func__,
+						   &rp_info->rp.rpf_addr);
 			}
 		}
 	}
@@ -1088,13 +1073,13 @@ struct pim_rpf *pim_rp_g(struct pim_instance *pim, pim_addr group)
 	rp_info = pim_rp_find_match_group(pim, &g);
 
 	if (rp_info) {
-		struct prefix nht_p;
+		pim_addr nht_p;
 
 		/* Register addr with Zebra NHT */
 		nht_p = rp_info->rp.rpf_addr;
 		if (PIM_DEBUG_PIM_NHT_RP)
 			zlog_debug(
-				"%s: NHT Register RP addr %pFX grp %pFX with Zebra",
+				"%s: NHT Register RP addr %pPA grp %pFX with Zebra",
 				__func__, &nht_p, &rp_info->group);
 		pim_find_or_track_nexthop(pim, &nht_p, NULL, rp_info, NULL);
 		pim_rpf_set_refresh_time(pim);
@@ -1137,7 +1122,7 @@ int pim_rp_set_upstream_addr(struct pim_instance *pim, pim_addr *up,
 	}
 
 	if (pim_addr_is_any(source))
-		*up = pim_addr_from_prefix(&rp_info->rp.rpf_addr);
+		*up = rp_info->rp.rpf_addr;
 	else
 		*up = source;
 
@@ -1159,7 +1144,7 @@ int pim_rp_config_write(struct pim_instance *pim, struct vty *vty,
 		if (rp_info->rp_src == RP_SRC_BSR)
 			continue;
 
-		rp_addr = pim_addr_from_prefix(&rp_info->rp.rpf_addr);
+		rp_addr = rp_info->rp.rpf_addr;
 		if (rp_info->plist)
 			vty_out(vty,
 				"%s" PIM_AF_NAME
@@ -1215,10 +1200,10 @@ void pim_rp_show_information(struct pim_instance *pim, struct prefix *range,
 			 * entry for the previous RP
 			 */
 			if (prev_rp_info &&
-			    prefix_cmp(&prev_rp_info->rp.rpf_addr,
-				       &rp_info->rp.rpf_addr)) {
+			    (pim_addr_cmp(prev_rp_info->rp.rpf_addr,
+					  rp_info->rp.rpf_addr))) {
 				json_object_object_addf(
-					json, json_rp_rows, "%pFXh",
+					json, json_rp_rows, "%pPA",
 					&prev_rp_info->rp.rpf_addr);
 				json_rp_rows = NULL;
 			}
@@ -1227,7 +1212,7 @@ void pim_rp_show_information(struct pim_instance *pim, struct prefix *range,
 				json_rp_rows = json_object_new_array();
 
 			json_row = json_object_new_object();
-			json_object_string_addf(json_row, "rpAddress", "%pFXh",
+			json_object_string_addf(json_row, "rpAddress", "%pPA",
 						&rp_info->rp.rpf_addr);
 			if (rp_info->rp.source_nexthop.interface)
 				json_object_string_add(
@@ -1257,7 +1242,7 @@ void pim_rp_show_information(struct pim_instance *pim, struct prefix *range,
 
 			json_object_array_add(json_rp_rows, json_row);
 		} else {
-			vty_out(vty, "%-15pFXh  ", &rp_info->rp.rpf_addr);
+			vty_out(vty, "%-15pPA  ", &rp_info->rp.rpf_addr);
 
 			if (rp_info->plist)
 				vty_out(vty, "%-18s  ", rp_info->plist);
@@ -1284,7 +1269,7 @@ void pim_rp_show_information(struct pim_instance *pim, struct prefix *range,
 
 	if (json) {
 		if (prev_rp_info && json_rp_rows)
-			json_object_object_addf(json, json_rp_rows, "%pFXh",
+			json_object_object_addf(json, json_rp_rows, "%pPA",
 						&prev_rp_info->rp.rpf_addr);
 	}
 }
@@ -1294,7 +1279,7 @@ void pim_resolve_rp_nh(struct pim_instance *pim, struct pim_neighbor *nbr)
 	struct listnode *node = NULL;
 	struct rp_info *rp_info = NULL;
 	struct nexthop *nh_node = NULL;
-	struct prefix nht_p;
+	pim_addr nht_p;
 	struct pim_nexthop_cache pnc;
 
 	for (ALL_LIST_ELEMENTS_RO(pim->rp_list, node, rp_info)) {
@@ -1329,7 +1314,7 @@ void pim_resolve_rp_nh(struct pim_instance *pim, struct pim_neighbor *nbr)
 #endif
 			if (PIM_DEBUG_PIM_NHT_RP)
 				zlog_debug(
-					"%s: addr %pFXh new nexthop addr %pPAs interface %s",
+					"%s: addr %pPA new nexthop addr %pPAs interface %s",
 					__func__, &nht_p, &nbr->source_addr,
 					ifp1->name);
 		}

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -231,9 +231,9 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 	if ((pim_addr_is_any(up->sg.src) && I_am_RP(pim, up->sg.grp)) ||
 	    PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
 		neigh_needed = false;
-	pim_find_or_track_nexthop(pim, &up->upstream_addr, up, NULL, NULL);
-	if (!pim_ecmp_nexthop_lookup(pim, &rpf->source_nexthop, &src, &grp,
-				neigh_needed)) {
+	pim_find_or_track_nexthop(pim, up->upstream_addr, up, NULL, NULL);
+	if (!pim_ecmp_nexthop_lookup(pim, &rpf->source_nexthop, src, &grp,
+				     neigh_needed)) {
 		/* Route is Deleted in Zebra, reset the stored NH data */
 		pim_upstream_rpf_clear(pim, up);
 		pim_rpf_cost_change(pim, up, saved_mrib_route_metric);

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -203,11 +203,10 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 {
 	struct pim_rpf *rpf = &up->rpf;
 	struct pim_rpf saved;
-	struct prefix nht_p;
-	struct prefix src, grp;
+	pim_addr src;
+	struct prefix grp;
 	bool neigh_needed = true;
 	uint32_t saved_mrib_route_metric;
-	pim_addr rpf_addr;
 
 	if (PIM_UPSTREAM_FLAG_TEST_STATIC_IIF(up->flags))
 		return PIM_RPF_OK;
@@ -226,15 +225,13 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 		old->rpf_addr = saved.rpf_addr;
 	}
 
-	pim_addr_to_prefix(&nht_p, up->upstream_addr);
-
-	pim_addr_to_prefix(&src, up->upstream_addr); // RP or Src address
+	src = up->upstream_addr; // RP or Src address
 	pim_addr_to_prefix(&grp, up->sg.grp);
 
 	if ((pim_addr_is_any(up->sg.src) && I_am_RP(pim, up->sg.grp)) ||
 	    PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
 		neigh_needed = false;
-	pim_find_or_track_nexthop(pim, &nht_p, up, NULL, NULL);
+	pim_find_or_track_nexthop(pim, &up->upstream_addr, up, NULL, NULL);
 	if (!pim_ecmp_nexthop_lookup(pim, &rpf->source_nexthop, &src, &grp,
 				neigh_needed)) {
 		/* Route is Deleted in Zebra, reset the stored NH data */
@@ -243,8 +240,7 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 		return PIM_RPF_FAILURE;
 	}
 
-	rpf_addr = pim_rpf_find_rpf_addr(up);
-	pim_addr_to_prefix(&rpf->rpf_addr, rpf_addr);
+	rpf->rpf_addr = pim_rpf_find_rpf_addr(up);
 
 	if (pim_rpf_addr_is_inaddr_any(rpf) && PIM_DEBUG_ZEBRA) {
 		/* RPF'(S,G) not found */
@@ -287,7 +283,7 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 	}
 
 	/* detect change in RPF'(S,G) */
-	if (!prefix_same(&saved.rpf_addr, &rpf->rpf_addr) ||
+	if (pim_addr_cmp(saved.rpf_addr, rpf->rpf_addr) ||
 	    saved.source_nexthop.interface != rpf->source_nexthop.interface) {
 		pim_rpf_cost_change(pim, up, saved_mrib_route_metric);
 		return PIM_RPF_CHANGED;
@@ -321,7 +317,7 @@ void pim_upstream_rpf_clear(struct pim_instance *pim,
 			router->infinite_assert_metric.metric_preference;
 		up->rpf.source_nexthop.mrib_route_metric =
 			router->infinite_assert_metric.route_metric;
-		pim_addr_to_prefix(&up->rpf.rpf_addr, PIMADDR_ANY);
+		up->rpf.rpf_addr = PIMADDR_ANY;
 		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 	}
 }
@@ -375,15 +371,7 @@ static pim_addr pim_rpf_find_rpf_addr(struct pim_upstream *up)
 
 int pim_rpf_addr_is_inaddr_any(struct pim_rpf *rpf)
 {
-	pim_addr rpf_addr = pim_addr_from_prefix(&rpf->rpf_addr);
-
-	switch (rpf->rpf_addr.family) {
-	case AF_INET:
-	case AF_INET6:
-		return pim_addr_is_any(rpf_addr);
-	default:
-		return 0;
-	}
+	return pim_addr_is_any(rpf->rpf_addr);
 }
 
 int pim_rpf_is_same(struct pim_rpf *rpf1, struct pim_rpf *rpf2)
@@ -399,10 +387,10 @@ unsigned int pim_rpf_hash_key(const void *arg)
 	const struct pim_nexthop_cache *r = arg;
 
 #if PIM_IPV == 4
-	return jhash_1word(r->rpf.rpf_addr.u.prefix4.s_addr, 0);
+	return jhash_1word(r->rpf.rpf_addr.s_addr, 0);
 #else
-	return jhash2(r->rpf.rpf_addr.u.prefix6.s6_addr32,
-		      array_size(r->rpf.rpf_addr.u.prefix6.s6_addr32), 0);
+	return jhash2(r->rpf.rpf_addr.s6_addr32,
+		      array_size(r->rpf.rpf_addr.s6_addr32), 0);
 #endif
 }
 
@@ -413,5 +401,5 @@ bool pim_rpf_equal(const void *arg1, const void *arg2)
 	const struct pim_nexthop_cache *r2 =
 		(const struct pim_nexthop_cache *)arg2;
 
-	return prefix_same(&r1->rpf.rpf_addr, &r2->rpf.rpf_addr);
+	return (!pim_addr_cmp(r1->rpf.rpf_addr, r2->rpf.rpf_addr));
 }

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -49,7 +49,7 @@ struct pim_nexthop {
 
 struct pim_rpf {
 	struct pim_nexthop source_nexthop;
-	struct prefix rpf_addr; /* RPF'(S,G) */
+	pim_addr rpf_addr; /* RPF'(S,G) */
 };
 
 enum pim_rpf_result { PIM_RPF_OK = 0, PIM_RPF_CHANGED, PIM_RPF_FAILURE };

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -34,7 +34,7 @@ tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
 	struct pim_interface *pim_oif = oif->info;
 	int input_iface_vif_index = 0;
 	pim_addr vif_source;
-	struct prefix src, grp;
+	struct prefix grp;
 	struct pim_nexthop nexthop;
 	struct pim_upstream *up = NULL;
 
@@ -43,20 +43,19 @@ tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
 		return pim_channel_oil_add(pim, &sg, __func__);
 	}
 
-	pim_addr_to_prefix(&src, vif_source); // RP or Src addr
 	pim_addr_to_prefix(&grp, sg.grp);
 
 	up = pim_upstream_find(pim, &sg);
 	if (up) {
 		memcpy(&nexthop, &up->rpf.source_nexthop,
 		       sizeof(struct pim_nexthop));
-		pim_ecmp_nexthop_lookup(pim, &nexthop, &src, &grp, 0);
+		pim_ecmp_nexthop_lookup(pim, &nexthop, &vif_source, &grp, 0);
 		if (nexthop.interface)
 			input_iface_vif_index = pim_if_find_vifindex_by_ifindex(
 				pim, nexthop.interface->ifindex);
 	} else
-		input_iface_vif_index =
-			pim_ecmp_fib_lookup_if_vif_index(pim, &src, &grp);
+		input_iface_vif_index = pim_ecmp_fib_lookup_if_vif_index(
+			pim, &vif_source, &grp);
 
 	if (PIM_DEBUG_ZEBRA)
 		zlog_debug("%s: NHT %pSG vif_source %pPAs vif_index:%d",

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -49,13 +49,13 @@ tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
 	if (up) {
 		memcpy(&nexthop, &up->rpf.source_nexthop,
 		       sizeof(struct pim_nexthop));
-		pim_ecmp_nexthop_lookup(pim, &nexthop, &vif_source, &grp, 0);
+		pim_ecmp_nexthop_lookup(pim, &nexthop, vif_source, &grp, 0);
 		if (nexthop.interface)
 			input_iface_vif_index = pim_if_find_vifindex_by_ifindex(
 				pim, nexthop.interface->ifindex);
 	} else
-		input_iface_vif_index = pim_ecmp_fib_lookup_if_vif_index(
-			pim, &vif_source, &grp);
+		input_iface_vif_index =
+			pim_ecmp_fib_lookup_if_vif_index(pim, vif_source, &grp);
 
 	if (PIM_DEBUG_ZEBRA)
 		zlog_debug("%s: NHT %pSG vif_source %pPAs vif_index:%d",

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -270,7 +270,7 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 			zlog_debug(
 				"%s: Deregister upstream %s addr %pPA with Zebra NHT",
 				__func__, up->sg_str, &up->upstream_addr);
-		pim_delete_tracked_nexthop(pim, &up->upstream_addr, up, NULL);
+		pim_delete_tracked_nexthop(pim, up->upstream_addr, up, NULL);
 	}
 
 	XFREE(MTYPE_PIM_UPSTREAM, up);

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -317,7 +317,7 @@ void pim_upstream_update_join_desired(struct pim_instance *pim,
 				      struct pim_upstream *up);
 
 void pim_update_suppress_timers(uint32_t suppress_time);
-void pim_upstream_join_suppress(struct pim_upstream *up, struct prefix rpf,
+void pim_upstream_join_suppress(struct pim_upstream *up, pim_addr rpf,
 				int holdtime);
 
 void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -352,8 +352,8 @@ static void pim_vxlan_orig_mr_up_add(struct pim_vxlan_sg *vxlan_sg)
 		 * iif
 		 */
 		if (!PIM_UPSTREAM_FLAG_TEST_STATIC_IIF(up->flags)) {
-			pim_delete_tracked_nexthop(
-				vxlan_sg->pim, &up->upstream_addr, up, NULL);
+			pim_delete_tracked_nexthop(vxlan_sg->pim,
+						   up->upstream_addr, up, NULL);
 		}
 		/* We are acting FHR; clear out use_rpt setting if any */
 		pim_upstream_update_use_rpt(up, false /*update_mroute*/);

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -303,7 +303,6 @@ static void pim_vxlan_orig_mr_up_add(struct pim_vxlan_sg *vxlan_sg)
 	struct pim_upstream *up;
 	struct pim_interface *term_ifp;
 	int flags = 0;
-	struct prefix nht_p;
 	struct pim_instance *pim = vxlan_sg->pim;
 
 	if (vxlan_sg->up) {
@@ -353,9 +352,8 @@ static void pim_vxlan_orig_mr_up_add(struct pim_vxlan_sg *vxlan_sg)
 		 * iif
 		 */
 		if (!PIM_UPSTREAM_FLAG_TEST_STATIC_IIF(up->flags)) {
-			pim_addr_to_prefix(&nht_p, up->upstream_addr);
-			pim_delete_tracked_nexthop(vxlan_sg->pim, &nht_p, up,
-						   NULL);
+			pim_delete_tracked_nexthop(
+				vxlan_sg->pim, &up->upstream_addr, up, NULL);
 		}
 		/* We are acting FHR; clear out use_rpt setting if any */
 		pim_upstream_update_use_rpt(up, false /*update_mroute*/);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -255,7 +255,7 @@ void pim_zebra_update_all_interfaces(struct pim_instance *pim)
 			struct pim_rpf rpf;
 
 			rpf.source_nexthop.interface = ifp;
-			pim_addr_to_prefix(&rpf.rpf_addr, us->address);
+			rpf.rpf_addr = us->address;
 			pim_joinprune_send(&rpf, us->us);
 			pim_jp_agg_clear_group(us->us);
 		}
@@ -269,8 +269,8 @@ void pim_zebra_upstream_rpf_changed(struct pim_instance *pim,
 	if (old->source_nexthop.interface) {
 		struct pim_neighbor *nbr;
 
-		nbr = pim_neighbor_find_prefix(old->source_nexthop.interface,
-					       &old->rpf_addr);
+		nbr = pim_neighbor_find(old->source_nexthop.interface,
+					old->rpf_addr);
 		if (nbr)
 			pim_jp_agg_remove_group(nbr->upstream_jp_agg, up, nbr);
 


### PR DESCRIPTION
Modifying below structures from struct prefix to pim_addr

Modify "struct prefix rpf_addr" to "pim_addr rpf_addr".
Modify "struct pim_rpf rpf" in "struct pim_nexthop_cache".
Modify "struct pim_rpf rp" in "struct rp_info".
Modify "struct pim_rpf rpf" in "struct pim_upstream".

Signed-off-by: sarita patra <saritap@vmware.com>