### PR TITLE
bgpd: fix 'show bgp detail json' output

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14161,7 +14161,7 @@ DEFUN (show_ip_bgp_flowspec_routes_detailed,
 	struct bgp *bgp = NULL;
 	int idx = 0;
 	bool uj = use_json(argc, argv);
-	uint16_t show_flags = 0;
+	uint16_t show_flags = BGP_SHOW_OPT_DETAIL;
 
 	if (uj) {
 		argc--;


### PR DESCRIPTION
Include the BGP_SHOW_OPT_DETAIL flag in the 'detail' version of the
command.