### PR TITLE
lib: rotate log file supplied by command line

### DIFF
--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -159,6 +159,7 @@ void zlog_rotate(void)
 {
 	zlog_file_rotate(&zt_file);
 	zlog_file_rotate(&zt_filterfile.parent);
+	zlog_file_rotate(&zt_file_cmdline);
 	hook_call(zlog_rotate);
 }
 


### PR DESCRIPTION
Call `zlog_file_rotate` for command file lines as well otherwise on `SIGUSR1` the old descriptor will still be used and no new log file will be created for the rotation.