### PR TITLE
zebra: don't enqueue data with FPM socket closed

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1232,7 +1232,8 @@ static void fpm_process_queue(struct thread *t)
 		 * the output data in the STREAM_WRITEABLE
 		 * check above, so we can ignore the return
 		 */
-		(void)fpm_nl_enqueue(fnc, ctx);
+		if (fnc->socket != -1)
+			(void)fpm_nl_enqueue(fnc, ctx);
 
 		/* Account the processed entries. */
 		processed_contexts++;


### PR DESCRIPTION
Fix a crash that could happen if the socket closed in the middle of processing a batch of commands.

If the socket is closed during the `while` loop that drains the zebra data plane framework queued items the data structure `socket` field goes to `-1` and inside `fpm_nl_enqueue` the call `thread_add_write(..., fnc->socket, ...);` will `assert()`.