### PR TITLE
zebra: evpn revamp l3vni routermac db 

### DIFF
--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -124,9 +124,6 @@ struct zebra_mac {
 	/* List of neigh associated with this mac */
 	struct list *neigh_list;
 
-	/* list of hosts pointing to this remote RMAC */
-	struct host_rb_tree_entry host_rb;
-
 	/* List of nexthop associated with this RMAC */
 	struct list *nh_list;
 

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -127,6 +127,9 @@ struct zebra_mac {
 	/* list of hosts pointing to this remote RMAC */
 	struct host_rb_tree_entry host_rb;
 
+	/* List of nexthop associated with this RMAC */
+	struct list *nh_list;
+
 	/* Duplicate mac detection */
 	uint32_t dad_count;
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1382,8 +1382,6 @@ static int zl3vni_remote_rmac_add(struct zebra_l3vni *zl3vni,
 		zl3vni_rmac_install(zl3vni, zrmac);
 	}
 
-	rb_find_or_add_host(&zrmac->host_rb, host_prefix);
-
 	return 0;
 }
 
@@ -1396,20 +1394,7 @@ static void zl3vni_remote_rmac_del(struct zebra_l3vni *zl3vni,
 {
 	struct ipaddr ipv4_vtep;
 
-	rb_delete_host(&zrmac->host_rb, host_prefix);
-
-	if (RB_EMPTY(host_rb_tree_entry, &zrmac->host_rb)) {
-		/* uninstall from kernel */
-		zl3vni_rmac_uninstall(zl3vni, zrmac);
-
-		/* Send RMAC for FPM processing */
-		hook_call(zebra_rmac_update, zrmac, zl3vni, true,
-			  "RMAC deleted");
-
-		/* del the rmac entry */
-		zl3vni_rmac_del(zl3vni, zrmac);
-		/* if nh is already deleted fall back to one in the list */
-	} else if (!zl3vni_nh_lookup(zl3vni, vtep_ip)) {
+	if (!zl3vni_nh_lookup(zl3vni, vtep_ip)) {
 		memset(&ipv4_vtep, 0, sizeof(struct ipaddr));
 		ipv4_vtep.ipa_type = IPADDR_V4;
 		if (vtep_ip->ipa_type == IPADDR_V6)
@@ -1440,6 +1425,23 @@ static void zl3vni_remote_rmac_del(struct zebra_l3vni *zl3vni,
 
 			/* install rmac in kernel */
 			zl3vni_rmac_install(zl3vni, zrmac);
+		}
+
+		if (!listcount(zrmac->nh_list)) {
+			/* uninstall from kernel */
+			zl3vni_rmac_uninstall(zl3vni, zrmac);
+
+			/* Send RMAC for FPM processing */
+			hook_call(zebra_rmac_update, zrmac, zl3vni, true,
+				  "RMAC deleted");
+
+			if (IS_ZEBRA_DEBUG_VXLAN)
+				zlog_debug(
+					"L3VNI %u RMAC %pEA vtep_ip %pIA delete",
+					zl3vni->vni, &zrmac->macaddr, vtep_ip);
+
+			/* del the rmac entry */
+			zl3vni_rmac_del(zl3vni, zrmac);
 		}
 	}
 }

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -398,8 +398,12 @@ static void zl3vni_print_nh(struct zebra_neigh *n, struct vty *vty,
 static void zl3vni_print_rmac(struct zebra_mac *zrmac, struct vty *vty,
 			      json_object *json)
 {
+	char buf[INET6_ADDRSTRLEN];
 	char buf1[ETHER_ADDR_STRLEN];
 	char buf2[PREFIX_STRLEN];
+	struct listnode *node = NULL;
+	struct ipaddr *vtep = NULL;
+	json_object *json_nhs = NULL;
 	json_object *json_hosts = NULL;
 	struct host_rb_entry *hle;
 
@@ -414,11 +418,18 @@ static void zl3vni_print_rmac(struct zebra_mac *zrmac, struct vty *vty,
 			vty_out(vty, "    %pFX\n", &hle->p);
 	} else {
 		json_hosts = json_object_new_array();
+		json_nhs = json_object_new_array();
 		json_object_string_add(
 			json, "routerMac",
 			prefix_mac2str(&zrmac->macaddr, buf1, sizeof(buf1)));
 		json_object_string_addf(json, "vtepIp", "%pI4",
 					&zrmac->fwd_info.r_vtep_ip);
+		for (ALL_LIST_ELEMENTS_RO(zrmac->nh_list, node, vtep)) {
+			json_object_array_add(json_nhs,
+					      json_object_new_string(ipaddr2str(
+						      vtep, buf, sizeof(buf))));
+		}
+		json_object_object_add(json, "nexthops", json_nhs);
 		json_object_int_add(json, "refCount",
 				    rb_host_count(&zrmac->host_rb));
 		RB_FOREACH (hle, host_rb_tree_entry, &zrmac->host_rb)

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -398,46 +398,25 @@ static void zl3vni_print_nh(struct zebra_neigh *n, struct vty *vty,
 static void zl3vni_print_rmac(struct zebra_mac *zrmac, struct vty *vty,
 			      json_object *json)
 {
-	char buf[INET6_ADDRSTRLEN];
-	char buf1[ETHER_ADDR_STRLEN];
-	char buf2[PREFIX_STRLEN];
 	struct listnode *node = NULL;
 	struct ipaddr *vtep = NULL;
 	json_object *json_nhs = NULL;
-	json_object *json_hosts = NULL;
-	struct host_rb_entry *hle;
 
 	if (!json) {
-		vty_out(vty, "MAC: %s\n",
-			prefix_mac2str(&zrmac->macaddr, buf1, sizeof(buf1)));
+		vty_out(vty, "MAC: %pEA\n", &zrmac->macaddr);
 		vty_out(vty, " Remote VTEP: %pI4\n",
 			&zrmac->fwd_info.r_vtep_ip);
-		vty_out(vty, " Refcount: %d\n", rb_host_count(&zrmac->host_rb));
-		vty_out(vty, "  Prefixes:\n");
-		RB_FOREACH (hle, host_rb_tree_entry, &zrmac->host_rb)
-			vty_out(vty, "    %pFX\n", &hle->p);
 	} else {
-		json_hosts = json_object_new_array();
 		json_nhs = json_object_new_array();
-		json_object_string_add(
-			json, "routerMac",
-			prefix_mac2str(&zrmac->macaddr, buf1, sizeof(buf1)));
+		json_object_string_addf(json, "routerMac", "%pEA",
+					&zrmac->macaddr);
 		json_object_string_addf(json, "vtepIp", "%pI4",
 					&zrmac->fwd_info.r_vtep_ip);
 		for (ALL_LIST_ELEMENTS_RO(zrmac->nh_list, node, vtep)) {
-			json_object_array_add(json_nhs,
-					      json_object_new_string(ipaddr2str(
-						      vtep, buf, sizeof(buf))));
+			json_object_array_add(json_nhs, json_object_new_stringf(
+								"%pIA", vtep));
 		}
 		json_object_object_add(json, "nexthops", json_nhs);
-		json_object_int_add(json, "refCount",
-				    rb_host_count(&zrmac->host_rb));
-		RB_FOREACH (hle, host_rb_tree_entry, &zrmac->host_rb)
-			json_object_array_add(
-				json_hosts,
-				json_object_new_string(prefix2str(
-					&hle->p, buf2, sizeof(buf2))));
-		json_object_object_add(json, "prefixList", json_hosts);
 	}
 }
 
@@ -1216,7 +1195,6 @@ static struct zebra_mac *zl3vni_rmac_add(struct zebra_l3vni *zl3vni,
 	zrmac = hash_get(zl3vni->rmac_table, &tmp_rmac, zl3vni_rmac_alloc);
 	assert(zrmac);
 
-	RB_INIT(host_rb_tree_entry, &zrmac->host_rb);
 	zrmac->nh_list = list_new();
 	zrmac->nh_list->cmp = (int (*)(void *, void *))l3vni_rmac_nh_list_cmp;
 	zrmac->nh_list->del = (void (*)(void *))l3vni_rmac_nh_free;
@@ -1233,14 +1211,7 @@ static struct zebra_mac *zl3vni_rmac_add(struct zebra_l3vni *zl3vni,
 static int zl3vni_rmac_del(struct zebra_l3vni *zl3vni, struct zebra_mac *zrmac)
 {
 	struct zebra_mac *tmp_rmac;
-	struct host_rb_entry *hle;
 
-	while (!RB_EMPTY(host_rb_tree_entry, &zrmac->host_rb)) {
-		hle = RB_ROOT(host_rb_tree_entry, &zrmac->host_rb);
-
-		RB_REMOVE(host_rb_tree_entry, &zrmac->host_rb, hle);
-		XFREE(MTYPE_HOST_PREFIX, hle);
-	}
 	/* free the list of nh list*/
 	list_delete(&zrmac->nh_list);
 
@@ -1343,8 +1314,7 @@ static int zl3vni_rmac_uninstall(struct zebra_l3vni *zl3vni,
 /* handle rmac add */
 static int zl3vni_remote_rmac_add(struct zebra_l3vni *zl3vni,
 				  const struct ethaddr *rmac,
-				  const struct ipaddr *vtep_ip,
-				  const struct prefix *host_prefix)
+				  const struct ipaddr *vtep_ip)
 {
 	struct zebra_mac *zrmac = NULL;
 	struct ipaddr *vtep = NULL;
@@ -1356,8 +1326,8 @@ static int zl3vni_remote_rmac_add(struct zebra_l3vni *zl3vni,
 		zrmac = zl3vni_rmac_add(zl3vni, rmac);
 		if (!zrmac) {
 			zlog_debug(
-				"Failed to add RMAC %pEA L3VNI %u Remote VTEP %pIA, prefix %pFX",
-				rmac, zl3vni->vni, vtep_ip, host_prefix);
+				"Failed to add RMAC %pEA L3VNI %u Remote VTEP %pIA",
+				rmac, zl3vni->vni, vtep_ip);
 			return -1;
 		}
 		memset(&zrmac->fwd_info, 0, sizeof(zrmac->fwd_info));
@@ -1378,9 +1348,9 @@ static int zl3vni_remote_rmac_add(struct zebra_l3vni *zl3vni,
 				   &vtep_ip->ipaddr_v4)) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
-				"L3VNI %u Remote VTEP change(%pI4 -> %pIA) for RMAC %pEA, prefix %pFX",
+				"L3VNI %u Remote VTEP change(%pI4 -> %pIA) for RMAC %pEA",
 				zl3vni->vni, &zrmac->fwd_info.r_vtep_ip,
-				vtep_ip, rmac, host_prefix);
+				vtep_ip, rmac);
 
 		zrmac->fwd_info.r_vtep_ip = vtep_ip->ipaddr_v4;
 
@@ -1400,8 +1370,7 @@ static int zl3vni_remote_rmac_add(struct zebra_l3vni *zl3vni,
 /* handle rmac delete */
 static void zl3vni_remote_rmac_del(struct zebra_l3vni *zl3vni,
 				   struct zebra_mac *zrmac,
-				   struct ipaddr *vtep_ip,
-				   struct prefix *host_prefix)
+				   struct ipaddr *vtep_ip)
 {
 	struct ipaddr ipv4_vtep;
 
@@ -1429,10 +1398,10 @@ static void zl3vni_remote_rmac_del(struct zebra_l3vni *zl3vni,
 			zrmac->fwd_info.r_vtep_ip = vtep->ipaddr_v4;
 			if (IS_ZEBRA_DEBUG_VXLAN)
 				zlog_debug(
-					"L3VNI %u Remote VTEP nh change(%pIA -> %pI4) for RMAC %pEA, prefix %pFX",
+					"L3VNI %u Remote VTEP nh change(%pIA -> %pI4) for RMAC %pEA",
 					zl3vni->vni, &ipv4_vtep,
 					&zrmac->fwd_info.r_vtep_ip,
-					&zrmac->macaddr, host_prefix);
+					&zrmac->macaddr);
 
 			/* install rmac in kernel */
 			zl3vni_rmac_install(zl3vni, zrmac);
@@ -2343,7 +2312,7 @@ void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id, const struct ethaddr *rmac,
 	 * add the rmac - remote rmac to be installed is against the ipv4
 	 * nexthop address
 	 */
-	zl3vni_remote_rmac_add(zl3vni, rmac, &ipv4_vtep, host_prefix);
+	zl3vni_remote_rmac_add(zl3vni, rmac, &ipv4_vtep);
 }
 
 /* handle evpn vrf route delete */
@@ -2370,7 +2339,7 @@ void zebra_vxlan_evpn_vrf_route_del(vrf_id_t vrf_id,
 
 	/* delete the rmac entry */
 	if (zrmac)
-		zl3vni_remote_rmac_del(zl3vni, zrmac, vtep_ip, host_prefix);
+		zl3vni_remote_rmac_del(zl3vni, zrmac, vtep_ip);
 }
 
 void zebra_vxlan_print_specific_rmac_l3vni(struct vty *vty, vni_t l3vni,

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -62,6 +62,7 @@ DEFINE_MTYPE_STATIC(ZEBRA, ZL3VNI, "L3 VNI hash");
 DEFINE_MTYPE_STATIC(ZEBRA, L3VNI_MAC, "EVPN L3VNI MAC");
 DEFINE_MTYPE_STATIC(ZEBRA, L3NEIGH, "EVPN Neighbor");
 DEFINE_MTYPE_STATIC(ZEBRA, ZVXLAN_SG, "zebra VxLAN multicast group");
+DEFINE_MTYPE_STATIC(ZEBRA, EVPN_VTEP, "zebra VxLAN VTEP IP");
 
 DEFINE_HOOK(zebra_rmac_update,
 	    (struct zebra_mac * rmac, struct zebra_l3vni *zl3vni, bool delete,
@@ -196,6 +197,37 @@ static uint32_t rb_host_count(struct host_rb_tree_entry *hrbe)
 		count++;
 
 	return count;
+}
+
+static int l3vni_rmac_nh_list_cmp(void *p1, void *p2)
+{
+	const struct ipaddr *vtep_ip1 = p1;
+	const struct ipaddr *vtep_ip2 = p2;
+
+	return !ipaddr_cmp(vtep_ip1, vtep_ip2);
+}
+
+static void l3vni_rmac_nh_free(struct ipaddr *vtep_ip)
+{
+	XFREE(MTYPE_EVPN_VTEP, vtep_ip);
+}
+
+static void l3vni_rmac_nh_list_nh_delete(struct zebra_l3vni *zl3vni,
+					 struct zebra_mac *zrmac,
+					 struct ipaddr *vtep_ip)
+{
+	struct listnode *node = NULL, *nnode = NULL;
+	struct ipaddr *vtep = NULL;
+
+	for (ALL_LIST_ELEMENTS(zrmac->nh_list, node, nnode, vtep)) {
+		if (ipaddr_cmp(vtep, vtep_ip) == 0)
+			break;
+	}
+
+	if (node) {
+		l3vni_rmac_nh_free(vtep);
+		list_delete_node(zrmac->nh_list, node);
+	}
 }
 
 /*
@@ -1174,6 +1206,9 @@ static struct zebra_mac *zl3vni_rmac_add(struct zebra_l3vni *zl3vni,
 	assert(zrmac);
 
 	RB_INIT(host_rb_tree_entry, &zrmac->host_rb);
+	zrmac->nh_list = list_new();
+	zrmac->nh_list->cmp = (int (*)(void *, void *))l3vni_rmac_nh_list_cmp;
+	zrmac->nh_list->del = (void (*)(void *))l3vni_rmac_nh_free;
 
 	SET_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE);
 	SET_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE_RMAC);
@@ -1195,6 +1230,8 @@ static int zl3vni_rmac_del(struct zebra_l3vni *zl3vni, struct zebra_mac *zrmac)
 		RB_REMOVE(host_rb_tree_entry, &zrmac->host_rb, hle);
 		XFREE(MTYPE_HOST_PREFIX, hle);
 	}
+	/* free the list of nh list*/
+	list_delete(&zrmac->nh_list);
 
 	tmp_rmac = hash_release(zl3vni->rmac_table, zrmac);
 	XFREE(MTYPE_L3VNI_MAC, tmp_rmac);
@@ -1299,6 +1336,7 @@ static int zl3vni_remote_rmac_add(struct zebra_l3vni *zl3vni,
 				  const struct prefix *host_prefix)
 {
 	struct zebra_mac *zrmac = NULL;
+	struct ipaddr *vtep = NULL;
 
 	zrmac = zl3vni_rmac_lookup(zl3vni, rmac);
 	if (!zrmac) {
@@ -1313,6 +1351,11 @@ static int zl3vni_remote_rmac_add(struct zebra_l3vni *zl3vni,
 		}
 		memset(&zrmac->fwd_info, 0, sizeof(zrmac->fwd_info));
 		zrmac->fwd_info.r_vtep_ip = vtep_ip->ipaddr_v4;
+
+		vtep = XCALLOC(MTYPE_EVPN_VTEP, sizeof(struct ipaddr));
+		memcpy(vtep, vtep_ip, sizeof(struct ipaddr));
+		if (!listnode_add_sort_nodup(zrmac->nh_list, (void *)vtep))
+			XFREE(MTYPE_EVPN_VTEP, vtep);
 
 		/* Send RMAC for FPM processing */
 		hook_call(zebra_rmac_update, zrmac, zl3vni, false,
@@ -1330,6 +1373,11 @@ static int zl3vni_remote_rmac_add(struct zebra_l3vni *zl3vni,
 
 		zrmac->fwd_info.r_vtep_ip = vtep_ip->ipaddr_v4;
 
+		vtep = XCALLOC(MTYPE_EVPN_VTEP, sizeof(struct ipaddr));
+		memcpy(vtep, vtep_ip, sizeof(struct ipaddr));
+		if (!listnode_add_sort_nodup(zrmac->nh_list, (void *)vtep))
+			XFREE(MTYPE_EVPN_VTEP, vtep);
+
 		/* install rmac in kernel */
 		zl3vni_rmac_install(zl3vni, zrmac);
 	}
@@ -1343,8 +1391,11 @@ static int zl3vni_remote_rmac_add(struct zebra_l3vni *zl3vni,
 /* handle rmac delete */
 static void zl3vni_remote_rmac_del(struct zebra_l3vni *zl3vni,
 				   struct zebra_mac *zrmac,
+				   struct ipaddr *vtep_ip,
 				   struct prefix *host_prefix)
 {
+	struct ipaddr ipv4_vtep;
+
 	rb_delete_host(&zrmac->host_rb, host_prefix);
 
 	if (RB_EMPTY(host_rb_tree_entry, &zrmac->host_rb)) {
@@ -1357,6 +1408,39 @@ static void zl3vni_remote_rmac_del(struct zebra_l3vni *zl3vni,
 
 		/* del the rmac entry */
 		zl3vni_rmac_del(zl3vni, zrmac);
+		/* if nh is already deleted fall back to one in the list */
+	} else if (!zl3vni_nh_lookup(zl3vni, vtep_ip)) {
+		memset(&ipv4_vtep, 0, sizeof(struct ipaddr));
+		ipv4_vtep.ipa_type = IPADDR_V4;
+		if (vtep_ip->ipa_type == IPADDR_V6)
+			ipv4_mapped_ipv6_to_ipv4(&vtep_ip->ipaddr_v6,
+						 &ipv4_vtep.ipaddr_v4);
+		else
+			memcpy(&(ipv4_vtep.ipaddr_v4), &vtep_ip->ipaddr_v4,
+			       sizeof(struct in_addr));
+
+		/* remove nh from rmac's list */
+		l3vni_rmac_nh_list_nh_delete(zl3vni, zrmac, &ipv4_vtep);
+		/* delete nh is same as current selected, fall back to
+		 * one present in the list
+		 */
+		if (IPV4_ADDR_SAME(&zrmac->fwd_info.r_vtep_ip,
+				   &ipv4_vtep.ipaddr_v4) &&
+		    listcount(zrmac->nh_list)) {
+			struct ipaddr *vtep;
+
+			vtep = listgetdata(listhead(zrmac->nh_list));
+			zrmac->fwd_info.r_vtep_ip = vtep->ipaddr_v4;
+			if (IS_ZEBRA_DEBUG_VXLAN)
+				zlog_debug(
+					"L3VNI %u Remote VTEP nh change(%pIA -> %pI4) for RMAC %pEA, prefix %pFX",
+					zl3vni->vni, &ipv4_vtep,
+					&zrmac->fwd_info.r_vtep_ip,
+					&zrmac->macaddr, host_prefix);
+
+			/* install rmac in kernel */
+			zl3vni_rmac_install(zl3vni, zrmac);
+		}
 	}
 }
 
@@ -2273,8 +2357,7 @@ void zebra_vxlan_evpn_vrf_route_del(vrf_id_t vrf_id,
 
 	/* delete the rmac entry */
 	if (zrmac)
-		zl3vni_remote_rmac_del(zl3vni, zrmac, host_prefix);
-
+		zl3vni_remote_rmac_del(zl3vni, zrmac, vtep_ip, host_prefix);
 }
 
 void zebra_vxlan_print_specific_rmac_l3vni(struct vty *vty, vni_t l3vni,
@@ -2308,7 +2391,7 @@ void zebra_vxlan_print_specific_rmac_l3vni(struct vty *vty, vni_t l3vni,
 			vty_out(vty, "{}\n");
 		else
 			vty_out(vty,
-				"%% Requested RMAC doesn't exist in L3-VNI %u",
+				"%% Requested RMAC doesn't exist in L3-VNI %u\n",
 				l3vni);
 		return;
 	}


### PR DESCRIPTION
Remove host prefix mapping under RMAC instead use list of nexthops to keep track of its existence. 
    
**Problem**:
    In CLAG deployment there might be a situation where CLAG secondary sends individual ip as nexthop
    along with anycast mac as RMAC. This combination is updated in zebra's rmac cache.
    Upon recovery at clag secondary sends withdrawal of the incorrect rmac and nexthop mapping.
    The RMAC entry mapping to nh is not cleaned up properly in the zebra rmac cache.
    
**Fix**:
    Zebra rmac db needs to maintain a list of nexthops.  When a bgp withdrawal for rmac to nexthop mapping 
    is received, remove the old nexthop from the rmac's nh list and if the host reference still remains for
    the RMAC,fall back to the nexthop one remaining in the list.
    At most you expect two nexthops mapped to RMAC (in clag deployment).
 
 JSON change:
 ```
    Before change:
    --------------
    TORS1# show evpn rmac vni 4001 mac  44:38:39:ff:ff:01
    MAC: 44:38:39:ff:ff:01
     Remote VTEP: 36.0.0.11
     Refcount: 1
      Prefixes:
        [1]:[00:00:00:00:00:00:00:00:00:00]:[::]/352
    TORS1#
    TORS1# show evpn rmac vni 4001 mac 44:38:39:ff:ff:01 json
    {
      "routerMac":"44:38:39:ff:ff:01",
      "vtepIp":"36.0.0.11",
      "refCount":1,
      "localSequence":0,
      "remoteSequence":0,
      "prefixList":[
        "[1]:[00:00:00:00:00:00:00:00:00:00]:[::]\/352"
      ]
    }

     After change:
    -------------
    
    TORS1# show evpn rmac vni 4001 mac 44:38:39:ff:ff:01
    MAC: 44:38:39:ff:ff:01
     Remote VTEP: 36.0.0.11
    TORS1#
    TORS1# show evpn rmac vni 4001 mac 44:38:39:ff:ff:01 json
    {
      "routerMac":"44:38:39:ff:ff:01",
      "vtepIp":"36.0.0.11",
      "nexthops":[
        "36.0.0.11"
      ]
    }

 ```
 
   
Singed-off-by: Chirag Shah <chirag@nvidia.com>