### PR TITLE
lib: Route-map failed for OSPF routes even for matching prefixes

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1799,12 +1799,11 @@ static struct list *route_map_get_index_list(struct route_node **rn,
 /*
  * This function returns the route-map index that best matches the prefix.
  */
-static struct route_map_index *route_map_get_index(struct route_map *map,
-						   const struct prefix *prefix,
-						   void *object,
-						   uint8_t *match_ret)
+static struct route_map_index *
+route_map_get_index(struct route_map *map, const struct prefix *prefix,
+		    void *object, enum route_map_cmd_result_t *match_ret)
 {
-	int ret = 0;
+	enum route_map_cmd_result_t ret = RMAP_NOMATCH;
 	struct list *candidate_rmap_list = NULL;
 	struct route_node *rn = NULL;
 	struct listnode *ln = NULL, *nn = NULL;
@@ -2559,7 +2558,7 @@ route_map_result_t route_map_apply_ext(struct route_map *map,
 	if ((!map->optimization_disabled)
 	    && (map->ipv4_prefix_table || map->ipv6_prefix_table)) {
 		index = route_map_get_index(map, prefix, match_object,
-					    (uint8_t *)&match_ret);
+					    &match_ret);
 		if (index) {
 			index->applied++;
 			if (rmap_debug)


### PR DESCRIPTION
This issue is applicable to other protocols as well.
When user has configured route-map, even though the prefixes are falling
under the permit rule, the prefixes were denied and were shown
as inactive route in zebra.

Reason being the parameter which is of type enum was passed to the api
route_map_get_index and was typecasted to uint8_t *.
This problem is visible in case of Big Endian systems because we are
accessing the most significant byte.

'match_ret' field is an enum in the caller and so it is of 4 bytes,
the typecasting it to 1 byte and passing it to the api made
the api to put the value in the most significant byte
which was already zero previously. Therefore the actual value
RMAP_NOMATCH which was 1 never gets reset in this case.
Therefore the api always returns 'RMAP_NOMATCH' and hence
the prefixes are always denied.

Fixes: #9782
Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>