### PR TITLE
bgpd: Fix while(read()) for RPKI sync callback

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -369,7 +369,7 @@ static void bgpd_sync_callback(struct thread *thread)
 	thread_add_read(bm->master, bgpd_sync_callback, NULL, socket, &t_rpki);
 
 	if (atomic_load_explicit(&rtr_update_overflow, memory_order_seq_cst)) {
-		while (read(socket, &rec, sizeof(struct pfx_record) != -1))
+		while (read(socket, &rec, sizeof(struct pfx_record)) != -1)
 			;
 
 		atomic_store_explicit(&rtr_update_overflow, 0,


### PR DESCRIPTION
Bad formatting applied and it worked with small amount of prefixes (lurking).

With full BGP feed and full RPKI table, this causes infinity loop.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>