### PR TITLE
critical fixes for grpc

### DIFF
--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -276,10 +276,10 @@ static LYD_FORMAT encoding2lyd_format(enum frr::Encoding encoding)
 }
 
 static int yang_dnode_edit(struct lyd_node *dnode, const std::string &path,
-			   const std::string &value)
+			   const char *value)
 {
-	LY_ERR err = lyd_new_path(dnode, ly_native_ctx, path.c_str(),
-				  value.c_str(), LYD_NEW_PATH_UPDATE, &dnode);
+	LY_ERR err = lyd_new_path(dnode, ly_native_ctx, path.c_str(), value,
+				  LYD_NEW_PATH_UPDATE, &dnode);
 	if (err != LY_SUCCESS) {
 		flog_warn(EC_LIB_LIBYANG, "%s: lyd_new_path() failed: %s",
 			  __func__, ly_errmsg(ly_native_ctx));
@@ -706,8 +706,8 @@ void HandleUnaryEditCandidate(
 
 	auto pvs = tag->request.update();
 	for (const frr::PathValue &pv : pvs) {
-		if (yang_dnode_edit(candidate_tmp->dnode, pv.path(), pv.value())
-		    != 0) {
+		if (yang_dnode_edit(candidate_tmp->dnode, pv.path(),
+				    pv.value().c_str()) != 0) {
 			nb_config_free(candidate_tmp);
 
 			tag->responder.Finish(

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -96,11 +96,11 @@ class Candidates
 	{
 		char errmsg[BUFSIZ] = {0};
 
-		_cdb.erase(c->id);
 		nb_config_free(c->config);
 		if (c->transaction)
 			nb_candidate_commit_abort(c->transaction, errmsg,
 						  sizeof(errmsg));
+		_cdb.erase(c->id);
 	}
 
 	struct candidate *get_candidate(uint32_t id)

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -1264,6 +1264,8 @@ static void *grpc_pthread_start(void *arg)
 	builder.AddListeningPort(server_address.str(),
 				 grpc::InsecureServerCredentials());
 	builder.RegisterService(service);
+	builder.AddChannelArgument(
+		GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS, 5000);
 	auto cq = builder.AddCompletionQueue();
 	s_cq = cq.get();
 	s_server = builder.BuildAndStart();

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -1,7 +1,7 @@
 //
+// Copyright (c) 2021-2022, LabN Consulting, L.L.C
 // Copyright (C) 2019  NetDEF, Inc.
 //                     Renato Westphal
-// Copyright (c) 2021, LabN Consulting, L.L.C
 //
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the Free
@@ -227,7 +227,6 @@ template <typename Q, typename S> class NewRpcState : RpcStateBase
 		pthread_mutex_unlock(&_tag->cmux);
 		return 0;
 	}
-	NewRpcState<Q, S> *orig;
 
 	const char *name;
 	grpc::ServerContext ctx;
@@ -238,12 +237,12 @@ template <typename Q, typename S> class NewRpcState : RpcStateBase
 
 	Candidates *cdb;
 	void (*callback)(NewRpcState<Q, S> *);
-	reqfunc_t requestf;
-	reqsfunc_t requestsf;
+	reqfunc_t requestf = NULL;
+	reqsfunc_t requestsf = NULL;
 
 	pthread_mutex_t cmux = PTHREAD_MUTEX_INITIALIZER;
 	pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
-	void *context;
+	void *context = 0;
 
 	CallState state = CREATE;
 };


### PR DESCRIPTION
Fix crashes in the grpc module

- Initialize RPC state instance vars to NULL before testing them for NULL.
- Was using a global std::unique_ptr<> and then NULLing it before we were done with the grpc server it was pointing at, the unique_ptr deletes the server when NULLed, which we didn't want.
- fix the shutdown code in general to be thread safe and actually delete the items drained from the queue.
- fix candidate early delete
 
fixes #9732, fixes #10578, closes #10073
