### PR TITLE
bgpd: Warn user when an interface has no v6 LL address

### DIFF
--- a/bgpd/bgp_errors.c
+++ b/bgpd/bgp_errors.c
@@ -475,6 +475,12 @@ static struct log_ref ferr_bgp_err[] = {
 		.suggestion = "Get log files from router and open an issue",
 	},
 	{
+		.code = EC_BGP_NO_LL_ADDRESS_AVAILABLE,
+		.title = "BGP v6 peer with no LL address on outgoing interface",
+		.description = "BGP when using a v6 peer requires a v6 LL address to be configured on the outgoing interface as per RFC 4291 section 2.1",
+		.suggestion = "Add a v6 LL address to the outgoing interfaces as per RFC",
+	},
+	{
 		.code = END_FERR,
 	}
 };

--- a/bgpd/bgp_errors.h
+++ b/bgpd/bgp_errors.h
@@ -101,6 +101,7 @@ enum bgp_log_refs {
 	EC_BGP_ROUTER_ID_SAME,
 	EC_BGP_INVALID_BGP_INSTANCE,
 	EC_BGP_INVALID_ROUTE,
+	EC_BGP_NO_LL_ADDRESS_AVAILABLE,
 };
 
 extern void bgp_error_init(void);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -882,6 +882,12 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 			 */
 			if (!v6_ll_avail && if_is_loopback(ifp))
 				v6_ll_avail = true;
+			else {
+				flog_warn(
+					EC_BGP_NO_LL_ADDRESS_AVAILABLE,
+					"Interface: %s does not have a v6 LL address associated with it, waiting until one is created for it",
+					ifp->name);
+			}
 		} else
 		/* Link-local address. */
 		{


### PR DESCRIPTION
When BGP detects that a peering is using a global address but no v6 LL
address has been created for the interface that the global address is
on warn the user that something is amiss and they need to fix it.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>