### PR TITLE
pimd: Show group-type under `show ip pim rp-info`

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -505,9 +505,11 @@ cause great confusion.
    Display information about a S,G pair and how the RPF would be chosen. This
    is especially useful if there are ECMP's available from the RPF lookup.
 
-.. clicmd:: show ip pim rp-info
+.. clicmd:: show ip pim [vrf NAME] rp-info [A.B.C.D/M] [json]
 
    Display information about RP's that are configured on this router.
+
+   You can filter the output by specifying an arbitrary group.
 
 .. clicmd:: show ip pim rpf
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5340,39 +5340,56 @@ DEFUN (show_ip_pim_upstream_rpf,
 
 DEFUN (show_ip_pim_rp,
        show_ip_pim_rp_cmd,
-       "show ip pim [vrf NAME] rp-info [json]",
+       "show ip pim [vrf NAME] rp-info [A.B.C.D/M] [json]",
        SHOW_STR
        IP_STR
        PIM_STR
        VRF_CMD_HELP_STR
        "PIM RP information\n"
+       "Multicast Group range\n"
        JSON_STR)
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
 	bool uj = use_json(argc, argv);
+	struct prefix *range = NULL;
 
 	if (!vrf)
 		return CMD_WARNING;
 
-	pim_rp_show_information(vrf->info, vty, uj);
+	if (argv_find(argv, argc, "A.B.C.D/M", &idx)) {
+		range = prefix_new();
+		(void)str2prefix(argv[idx]->arg, range);
+		apply_mask(range);
+	}
+
+	pim_rp_show_information(vrf->info, range, vty, uj);
 
 	return CMD_SUCCESS;
 }
 
 DEFUN (show_ip_pim_rp_vrf_all,
        show_ip_pim_rp_vrf_all_cmd,
-       "show ip pim vrf all rp-info [json]",
+       "show ip pim vrf all rp-info [A.B.C.D/M] [json]",
        SHOW_STR
        IP_STR
        PIM_STR
        VRF_CMD_HELP_STR
        "PIM RP information\n"
+       "Multicast Group range\n"
        JSON_STR)
 {
+	int idx = 0;
 	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
+	struct prefix *range = NULL;
+
+	if (argv_find(argv, argc, "A.B.C.D/M", &idx)) {
+		range = prefix_new();
+		(void)str2prefix(argv[idx]->arg, range);
+		apply_mask(range);
+	}
 
 	if (uj)
 		vty_out(vty, "{ ");
@@ -5384,7 +5401,7 @@ DEFUN (show_ip_pim_rp_vrf_all,
 			first = false;
 		} else
 			vty_out(vty, "VRF: %s\n", vrf->name);
-		pim_rp_show_information(vrf->info, vty, uj);
+		pim_rp_show_information(vrf->info, range, vty, uj);
 	}
 	if (uj)
 		vty_out(vty, "}\n");

--- a/pimd/pim_rp.h
+++ b/pimd/pim_rp.h
@@ -78,8 +78,8 @@ struct pim_rpf *pim_rp_g(struct pim_instance *pim, pim_addr group);
 #define I_am_RP(P, G)  pim_rp_i_am_rp ((P), (G))
 #define RP(P, G)       pim_rp_g ((P), (G))
 
-void pim_rp_show_information(struct pim_instance *pim, struct vty *vty,
-			     bool uj);
+void pim_rp_show_information(struct pim_instance *pim, struct prefix *range,
+			     struct vty *vty, bool uj);
 void pim_resolve_rp_nh(struct pim_instance *pim, struct pim_neighbor *nbr);
 int pim_rp_list_cmp(void *v1, void *v2);
 struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,

--- a/pimd/pim_ssm.h
+++ b/pimd/pim_ssm.h
@@ -34,7 +34,7 @@ struct pim_ssm {
 
 void pim_ssm_prefix_list_update(struct pim_instance *pim,
 				struct prefix_list *plist);
-int pim_is_grp_ssm(struct pim_instance *pim, pim_addr group_addr);
+extern int pim_is_grp_ssm(struct pim_instance *pim, pim_addr group_addr);
 int pim_ssm_range_set(struct pim_instance *pim, vrf_id_t vrf_id,
 		      const char *plist_name);
 void *pim_ssm_init(void);


### PR DESCRIPTION
And filter by group for PIM.

```
exit1-debian-11# show ip pim rp-info
RP address       group/prefix-list   OIF               I am RP    Source   Group-Type
192.168.10.17    238.0.0.0/24        eth2              no         Static   ASM
192.168.10.110   232.0.0.0/24        eth2              no         Static   SSM
exit1-debian-11# show ip pim rp-info 238.0.0.0/24
RP address       group/prefix-list   OIF               I am RP    Source   Group-Type
192.168.10.17    238.0.0.0/24        eth2              no         Static   ASM
exit1-debian-11# show ip pim rp-info 238.0.0.0/24 json
{
  "192.168.10.17":[
    {
      "rpAddress":"192.168.10.17",
      "outboundInterface":"eth2",
      "iAmRP":false,
      "group":"238.0.0.0/24",
      "source":"Static",
      "groupType":"ASM"
    }
  ]
}
exit1-debian-11#
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>