### PR TITLE
bgpd: Fix continue/break change from old commit

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5376,10 +5376,10 @@ void bgp_clear_stale_route(struct peer *peer, afi_t afi, safi_t safi)
 						    bgp_attr_get_community(
 							    pi->attr),
 						    COMMUNITY_NO_LLGR))
-						break;
+						continue;
 					if (!CHECK_FLAG(pi->flags,
 							BGP_PATH_STALE))
-						break;
+						continue;
 
 					/*
 					 * If this is VRF leaked route
@@ -5409,9 +5409,9 @@ void bgp_clear_stale_route(struct peer *peer, afi_t afi, safi_t safi)
 				    !community_include(
 					    bgp_attr_get_community(pi->attr),
 					    COMMUNITY_NO_LLGR))
-					break;
+					continue;
 				if (!CHECK_FLAG(pi->flags, BGP_PATH_STALE))
-					break;
+					continue;
 				if (safi == SAFI_UNICAST &&
 				    (peer->bgp->inst_type ==
 					     BGP_INSTANCE_TYPE_VRF ||


### PR DESCRIPTION
Commit: ea47320b1d0eeaa56f945fa356da7e4ca7f2b0b2

Modified the bgp_clear_stale_route function to have
better indentation, but in the process changed some
`continue;` statements to `break;` which modified
the looping and caused stale paths to not always be
removed upon an update.

To reproduce:  A ---- B, setup with addpath and GR
One side has a prefix with nhop1 and nhop2, kill one
side and then resend the same prefix with nhop3,
paths nhop1 and 2 become stale and never removed.

Code inspection clearly shows that that `continue`
statements became `break` statements causing the
loop over all paths to stop prematurely.

The fix is to change the break back to continue
statements so the loop can continue instead of
stopping.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>