### PR TITLE
lib, vtysh: apply some polish to live-log feature

### DIFF
--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -21,6 +21,7 @@
 #ifndef _ZEBRA_FRR_H
 #define _ZEBRA_FRR_H
 
+#include "typesafe.h"
 #include "sigevent.h"
 #include "privs.h"
 #include "thread.h"
@@ -51,6 +52,14 @@ extern "C" {
  * Does nothing if -d isn't used.
  */
 #define FRR_DETACH_LATER	(1 << 6)
+
+PREDECL_DLIST(log_args);
+struct log_arg {
+	struct log_args_item itm;
+
+	char target[0];
+};
+DECLARE_DLIST(log_args, struct log_arg, itm);
 
 enum frr_cli_mode {
 	FRR_CLI_CLASSIC = 0,
@@ -88,7 +97,7 @@ struct frr_daemon_info {
 	const char *pathspace;
 	bool zpathspace;
 
-	const char *early_logging;
+	struct log_args_head early_logging[1];
 	const char *early_loglevel;
 
 	const char *proghelp;

--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -427,6 +427,22 @@ void command_setup_early_logging(const char *dest, const char *level)
 		set_log_file(&zt_file_cmdline, NULL, sep, nlevel);
 		return;
 	}
+	if (strcmp(type, "monitor") == 0 && sep) {
+		struct zlog_live_cfg cfg = {};
+		unsigned long fd;
+		char *endp;
+
+		sep++;
+		fd = strtoul(sep, &endp, 10);
+		if (!*sep || *endp) {
+			fprintf(stderr, "invalid monitor fd \"%s\"\n", sep);
+			exit(1);
+		}
+
+		zlog_live_open_fd(&cfg, nlevel, fd);
+		zlog_live_disown(&cfg);
+		return;
+	}
 
 	fprintf(stderr, "invalid log target \"%s\" (\"%s\")\n", type, dest);
 	exit(1);

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -401,7 +401,7 @@ void zlog_tls_buffer_flush(void)
 		return;
 
 	rcu_read_lock();
-	frr_each (zlog_targets, &zlog_targets, zt) {
+	frr_each_safe (zlog_targets, &zlog_targets, zt) {
 		if (!zt->logfn)
 			continue;
 
@@ -431,7 +431,7 @@ static void vzlog_notls(const struct xref_logmsg *xref, int prio,
 	msg->stackbufsz = sizeof(stackbuf);
 
 	rcu_read_lock();
-	frr_each (zlog_targets, &zlog_targets, zt) {
+	frr_each_safe (zlog_targets, &zlog_targets, zt) {
 		if (prio > zt->prio_min)
 			continue;
 		if (!zt->logfn)

--- a/lib/zlog_live.c
+++ b/lib/zlog_live.c
@@ -134,7 +134,7 @@ static void zlog_live_sigsafe(struct zlog_target *zt, const char *text,
 			      size_t len)
 {
 	struct zlt_live *zte = container_of(zt, struct zlt_live, zt);
-	struct zlog_live_hdr hdr[1];
+	struct zlog_live_hdr hdr[1] = {};
 	struct iovec iovs[2], *iov = iovs;
 	struct timespec ts;
 	int fd;
@@ -143,14 +143,12 @@ static void zlog_live_sigsafe(struct zlog_target *zt, const char *text,
 	if (fd < 0)
 		return;
 
-	clock_gettime(CLOCK_MONOTONIC, &ts);
+	clock_gettime(CLOCK_REALTIME, &ts);
 
 	hdr->ts_sec = ts.tv_sec;
 	hdr->ts_nsec = ts.tv_nsec;
 	hdr->prio = LOG_CRIT;
-	hdr->flags = 0;
 	hdr->textlen = len;
-	hdr->n_argpos = 0;
 
 	iov->iov_base = (char *)hdr;
 	iov->iov_len = sizeof(hdr);

--- a/lib/zlog_live.h
+++ b/lib/zlog_live.h
@@ -33,6 +33,8 @@ struct zlog_live_hdr {
 	int64_t pid;
 	int64_t tid;
 
+	/* number of lost messages due to best-effort non-blocking mode */
+	uint32_t lost_msgs;
 	/* syslog priority value */
 	uint32_t prio;
 	/* flags: currently unused */

--- a/lib/zlog_live.h
+++ b/lib/zlog_live.h
@@ -68,6 +68,7 @@ struct zlog_live_cfg {
 
 extern void zlog_live_open(struct zlog_live_cfg *cfg, int prio_min,
 			   int *other_fd);
+extern void zlog_live_open_fd(struct zlog_live_cfg *cfg, int prio_min, int fd);
 
 static inline bool zlog_live_is_null(struct zlog_live_cfg *cfg)
 {

--- a/lib/zlog_live.h
+++ b/lib/zlog_live.h
@@ -20,13 +20,40 @@
 #include "printfrr.h"
 
 struct zlog_live_hdr {
+	/* timestamp (CLOCK_REALTIME) */
 	uint64_t ts_sec;
 	uint32_t ts_nsec;
-	uint32_t prio;
-	uint32_t flags;
-	uint32_t textlen;
 
-	uint32_t arghdrlen;
+	/* length of zlog_live_hdr, including variable length bits and
+	 * possible future extensions - aka start of text
+	 */
+	uint32_t hdrlen;
+
+	/* process & thread ID, meaning depends on OS */
+	int64_t pid;
+	int64_t tid;
+
+	/* syslog priority value */
+	uint32_t prio;
+	/* flags: currently unused */
+	uint32_t flags;
+	/* length of message text - extra data (e.g. future key/value metadata)
+	 * may follow after it
+	 */
+	uint32_t textlen;
+	/* length of "[XXXXX-XXXXX][EC 0] " header; consumer may want to skip
+	 * over it if using the raw values below.  Note that this text may be
+	 * absent depending on "log error-category" and "log unique-id"
+	 * settings
+	 */
+	uint32_t texthdrlen;
+
+	/* xref unique identifier, "XXXXX-XXXXX\0" = 12 bytes */
+	char uid[12];
+	/* EC value */
+	uint32_t ec;
+
+	/* recorded printf formatting argument positions (variable length) */
 	uint32_t n_argpos;
 	struct fmt_outpos argpos[0];
 };

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3677,7 +3677,7 @@ static void vtysh_log_read(struct thread *thread)
 		buf.hdr.ts_nsec = ts.tv_nsec;
 		buf.hdr.prio = LOG_ERR;
 		buf.hdr.flags = 0;
-		buf.hdr.arghdrlen = 0;
+		buf.hdr.texthdrlen = 0;
 		buf.hdr.n_argpos = 0;
 	}
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -73,6 +73,7 @@ struct vtysh_client {
 
 	struct thread *log_reader;
 	int log_fd;
+	uint32_t lost_msgs;
 };
 
 static bool stderr_tty;
@@ -3654,6 +3655,15 @@ static void vtysh_log_read(struct thread *thread)
 	if (ret < 0 && ERRNO_IO_RETRY(errno))
 		return;
 
+	if (stderr_stdout_same) {
+#ifdef HAVE_RL_CLEAR_VISIBLE_LINE
+		rl_clear_visible_line();
+#else
+		puts("\r");
+#endif
+		fflush(stdout);
+	}
+
 	if (ret <= 0) {
 		struct timespec ts;
 
@@ -3679,15 +3689,15 @@ static void vtysh_log_read(struct thread *thread)
 		buf.hdr.flags = 0;
 		buf.hdr.texthdrlen = 0;
 		buf.hdr.n_argpos = 0;
-	}
+	} else {
+		int32_t lost_msgs = buf.hdr.lost_msgs - vclient->lost_msgs;
 
-	if (stderr_stdout_same) {
-#ifdef HAVE_RL_CLEAR_VISIBLE_LINE
-		rl_clear_visible_line();
-#else
-		puts("\r");
-#endif
-		fflush(stdout);
+		if (lost_msgs > 0) {
+			vclient->lost_msgs = buf.hdr.lost_msgs;
+			fprintf(stderr,
+				"%d log messages from %s lost (vtysh reading too slowly)\n",
+				lost_msgs, vclient->name);
+		}
 	}
 
 	text = buf.text + sizeof(buf.hdr.argpos[0]) * buf.hdr.n_argpos;


### PR DESCRIPTION
Two important bugfixes:
* [lib: fix log target removal when singlethreaded](https://github.com/FRRouting/frr/commit/d03440cab78605dcc21427127afdf78860d9916b)
* [lib: make live log sockets non-blocking](https://github.com/FRRouting/frr/commit/c9bc69578efbeecfa32fd3f70b2dd7bd6df03b58)

One ancillary bugfix:
* [lib: fix live log fields for crashlog](https://github.com/FRRouting/frr/commit/e69c4a01c1c283c6d55eb2ed2dc8478113e5ac32)

And the remaining commits are "polish"/improvements to the `terminal monitor` feature.