### PR TITLE
pim6d: Few fixes

### DIFF
--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -189,12 +189,12 @@ int main(int argc, char **argv, char **envp)
 #if 0
 	pim_bfd_init();
 	pim_mlag_init();
+#endif
 
 	hook_register(routing_conf_event,
 		      routing_control_plane_protocols_name_validate);
 
 	routing_control_plane_protocols_register_vrf_dependency();
-#endif
 
 	frr_config_fork();
 	frr_run(router->master);

--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -185,9 +185,6 @@ int main(int argc, char **argv, char **envp)
 	 */
 	pim_iface_init();
 
-	/* TODO PIM6: next line is temporary since pim_cmd_init is disabled */
-	if_cmd_init(NULL);
-
 	pim_zebra_init();
 #if 0
 	pim_bfd_init();


### PR DESCRIPTION
1. Removing duplicate if_cmd_init
2. Fix vrf initialisation in Northbound

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>