### PR TITLE
yang: Fix the ipv6 multicast pattern in frr-route-types

### DIFF
--- a/yang/frr-route-types.yang
+++ b/yang/frr-route-types.yang
@@ -162,9 +162,7 @@ module frr-route-types {
   typedef ipv6-multicast-group-prefix {
     type inet:ipv6-prefix {
       pattern
-        '(((FF|ff)[0-9a-fA-F]{2}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(/((1[6-9])|([2-9][0-9])|(1[0-1][0-9])|(12[0-8])))';
-      pattern
-        '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(/.+)';
+	'(([fF]{2}[0-9a-fA-F]{2}):).*';
     }
     description
       "This type represents an IPv6 multicast group prefix,


### PR DESCRIPTION
The pattern defined for ipv6-multicast-group-prefix is wrong.
This is leading to mismatch for all the valid ipv6 multicast
addresses.

Issue:
areia(config)# ipv6 pim rp 2001:db8::1 ff00::/12
2022/03/07 16:01:20 PIM6: libyang: Invalid union value "ff00::/12" - no matching subtype found. (Schema location /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/frr-pim-rp:rp/static-rp/rp-list/group-list-or-prefix-list/group-list/group-list.)

The fix is taken from RFC 8294.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>