### PR TITLE
bgpd: Postpone sending EoR when `route-map delay-timer` is running

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -254,10 +254,11 @@ enum bgp_instance_type {
 };
 
 #define BGP_SEND_EOR(bgp, afi, safi)                                           \
-	(!CHECK_FLAG(bgp->flags, BGP_FLAG_GR_DISABLE_EOR)                      \
-	 && ((bgp->gr_info[afi][safi].t_select_deferral == NULL)               \
-	     || (bgp->gr_info[afi][safi].eor_required                          \
-		 == bgp->gr_info[afi][safi].eor_received)))
+	(!CHECK_FLAG(bgp->flags, BGP_FLAG_GR_DISABLE_EOR) &&                   \
+	 !bm->t_rmap_update &&                                                 \
+	 ((bgp->gr_info[afi][safi].t_select_deferral == NULL) ||               \
+	  (bgp->gr_info[afi][safi].eor_required ==                             \
+	   bgp->gr_info[afi][safi].eor_received)))
 
 /* BGP GR Global ds */
 


### PR DESCRIPTION
When a peer is configured with route-map (inboundd/outbound), and route-map
delay timer is configured `route-map delay-timer`, Graceful-Restart is
broken.

Rsstarter node sends EoR immediately after coallesce time expires which
leads to flushed routes in helper node until route-map timer expires and
resends all the routes.

A gap between EoR and route-map delay timer exists, routes flushed and,
the traffic can be blackholed.

Fixes https://github.com/FRRouting/frr/issues/10756

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>