### PR TITLE
lib: Convert prefix_master->str to a RB Tree

### DIFF
--- a/lib/plist_int.h
+++ b/lib/plist_int.h
@@ -28,6 +28,8 @@ extern "C" {
 
 struct pltrie_table;
 
+PREDECL_RBTREE_UNIQ(plist);
+
 struct prefix_list {
 	char *name;
 	char *desc;
@@ -37,13 +39,12 @@ struct prefix_list {
 	int count;
 	int rangecount;
 
+	struct plist_item plist_item;
+
 	struct prefix_list_entry *head;
 	struct prefix_list_entry *tail;
 
 	struct pltrie_table *trie;
-
-	struct prefix_list *next;
-	struct prefix_list *prev;
 };
 
 /* Each prefix-list's entry. */


### PR DESCRIPTION
The prefix_master->str data structure was a sorted
list of the prefix names.  Not that big of a deal
other than insertion and deletion is insanely expensive
when you have a large number of unique prefix-lists.

In my test config file that I discovered this,
I have 587 unique prefix lists spread out acros
~26k lines of prefix-lists.  When reading
this config file into FRR the read time goes
from 690 seconds to 650 seconds.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>