### PR TITLE
ospfd,ospf6d: Add missing newline for `graceful-restart prepare` CLI

### DIFF
--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -689,7 +689,7 @@ DEFPY(ospf6_graceful_restart_prepare, ospf6_graceful_restart_prepare_cmd,
       "graceful-restart prepare ipv6 ospf",
       "Graceful Restart commands\n"
       "Prepare upcoming graceful restart\n" IPV6_STR
-      "Prepare to restart the OSPFv3 process")
+      "Prepare to restart the OSPFv3 process\n")
 {
 	ospf6_gr_prepare();
 

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -730,7 +730,7 @@ DEFPY(graceful_restart_prepare, graceful_restart_prepare_cmd,
       "Graceful Restart commands\n"
       "Prepare upcoming graceful restart\n"
       IP_STR
-      "Prepare to restart the OSPF process")
+      "Prepare to restart the OSPF process\n")
 {
 	struct ospf *ospf;
 	struct listnode *node;


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>