### PR TITLE
bgpd: Do not fail when going from GR mode to GR

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1223,7 +1223,7 @@ int bgp_global_gr_init(struct bgp *bgp)
 		{
 		/*Event -> */
 		/*GLOBAL_GR_cmd*/ /*no_Global_GR_cmd*/
-			GLOBAL_INVALID,  GLOBAL_HELPER,
+			GLOBAL_GR,  GLOBAL_HELPER,
 		/*GLOBAL_DISABLE_cmd*/ /*no_Global_Disable_cmd*/
 			GLOBAL_DISABLE,  GLOBAL_INVALID
 		},


### PR DESCRIPTION
If you enter:

router bgp 325
  bgp graceful-restart
  bgp graceful-restart
!

The second command entered will fail.  This is not
something that should be failing as that it's a no-op.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>