### PR TITLE
zebra: evpn disable remove l2vni from l3vni list

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1070,13 +1070,11 @@ static void zebra_evpn_vxlan_cleanup_all(struct hash_bucket *bucket, void *arg)
 {
 	struct zebra_evpn *zevpn = NULL;
 	struct zebra_l3vni *zl3vni = NULL;
-	struct zebra_vrf *zvrf = (struct zebra_vrf *)arg;
 
 	zevpn = (struct zebra_evpn *)bucket->data;
 
-	/* remove from l3-vni list */
-	if (zvrf->l3vni)
-		zl3vni = zl3vni_lookup(zvrf->l3vni);
+	/* remove l2vni from l2vni's tenant-vrf l3-vni list */
+	zl3vni = zl3vni_from_vrf(zevpn->vrf_id);
 	if (zl3vni)
 		listnode_delete(zl3vni->l2vnis, zevpn);
 


### PR DESCRIPTION
Upon 'no advertise-all-vni', cleanup l2vni from its tenant-vrf's l3vni list, instead of passed
zvrf->l3vni which will not be present in case of default instance.

Testing Done:
Before Fix:


```
TORC12(config-router-af)# advertise-all-vni
TORC12(config-router-af)# end
TORC12# show evpn vni 4001
VNI: 4001
  Type: L3
  Tenant VRF: vrf1
  Vxlan-Intf: vni4001
  State: Up
  Router MAC: 44:38:39:ff:ff:01
  L2 VNIs: 134217728 0 1000 1002 <-----
```

After Fix:

```
TORC12# show evpn vni 4001
VNI: 4001
  Type: L3
  Tenant VRF: vrf1
  Vxlan-Intf: vni4001
  State: Up
  Router MAC: 44:38:39:ff:ff:01
  L2 VNIs: 1000 1002
```
Signed-off-by: Chirag Shah <chirag@nvidia.com>