### PR TITLE
lib: more printfrr bits (JSON key, prefix w/o len)

### DIFF
--- a/doc/developer/logging.rst
+++ b/doc/developer/logging.rst
@@ -163,6 +163,10 @@ Networking data types
    - :c:union:`prefixptr` (dereference to get :c:struct:`prefix`)
    - :c:union:`prefixconstptr` (dereference to get :c:struct:`prefix`)
 
+   Options:
+
+   ``%pFXh``: (address only) :frrfmtout:`1.2.3.0` / :frrfmtout:`fe80::1234`
+
 .. frrfmt:: %pPSG4 (struct prefix_sg *)
 
    :frrfmtout:`(*,1.2.3.4)`

--- a/lib/json.c
+++ b/lib/json.c
@@ -74,6 +74,19 @@ void json_object_string_addv(struct json_object *obj, const char *key,
 	json_object_object_add(obj, key, json_object_new_stringv(fmt, args));
 }
 
+void json_object_object_addv(struct json_object *parent,
+			     struct json_object *child, const char *keyfmt,
+			     va_list args)
+{
+	char *text, buf[256];
+
+	text = vasnprintfrr(MTYPE_TMP, buf, sizeof(buf), keyfmt, args);
+	json_object_object_add(parent, text, child);
+
+	if (text != buf)
+		XFREE(MTYPE_TMP, text);
+}
+
 void json_object_int_add(struct json_object *obj, const char *key, int64_t i)
 {
 	json_object_object_add(obj, key, json_object_new_int64(i));

--- a/lib/json.h
+++ b/lib/json.h
@@ -116,6 +116,28 @@ static inline struct json_object *json_object_new_stringf(const char *fmt, ...)
 	return ret;
 }
 
+/* NOTE: argument order differs! (due to varargs)
+ *   json_object_object_add(parent, key, child)
+ *   json_object_object_addv(parent, child, key, va)
+ *   json_object_object_addf(parent, child, key, ...)
+ * (would be weird to have the child inbetween the format string and args)
+ */
+PRINTFRR(3, 0)
+extern void json_object_object_addv(struct json_object *parent,
+				    struct json_object *child,
+				    const char *keyfmt, va_list args);
+PRINTFRR(3, 4)
+static inline void json_object_object_addf(struct json_object *parent,
+					   struct json_object *child,
+					   const char *keyfmt, ...)
+{
+	va_list args;
+
+	va_start(args, keyfmt);
+	json_object_object_addv(parent, child, keyfmt, args);
+	va_end(args);
+}
+
 #define JSON_STR "JavaScript Object Notation\n"
 
 /* NOTE: json-c lib has following commit 316da85 which

--- a/tests/lib/test_printfrr.c
+++ b/tests/lib/test_printfrr.c
@@ -207,6 +207,24 @@ int main(int argc, char **argv)
 	assert(strcmp(p, "test#5") == 0);
 	XFREE(MTYPE_TMP, p);
 
+	struct prefix pfx;
+
+	str2prefix("192.168.1.23/24", &pfx);
+	printchk("192.168.1.23/24", "%pFX", &pfx);
+	printchk("192.168.1.23", "%pFXh", &pfx);
+
+	str2prefix("2001:db8::1234/64", &pfx);
+	printchk("2001:db8::1234/64", "%pFX", &pfx);
+	printchk("2001:db8::1234", "%pFXh", &pfx);
+
+	pfx.family = AF_UNIX;
+	printchk("UNK prefix", "%pFX", &pfx);
+	printchk("{prefix.af=AF_UNIX}", "%pFXh", &pfx);
+
+	str2prefix_eth("02:ca:fe:f0:0d:1e/48", (struct prefix_eth *)&pfx);
+	printchk("02:ca:fe:f0:0d:1e/48", "%pFX", &pfx);
+	printchk("02:ca:fe:f0:0d:1e", "%pFXh", &pfx);
+
 	struct prefix_sg sg;
 	sg.src.s_addr = INADDR_ANY;
 	sg.grp.s_addr = INADDR_ANY;


### PR DESCRIPTION
* `json_object_object_addf()` to add an item to a JSON object/dict with a format string key
* `%pFXh` to print a prefix without prefix length