### PR TITLE
tests: Make all commands logged

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1749,7 +1749,7 @@ class Router(Node):
                         daemon, self.logdir, self.name
                     )
 
-                cmdopt = "{} --log file:{}.log --log-level debug".format(
+                cmdopt = "{} --command-log-always --log file:{}.log --log-level debug".format(
                     daemon_opts, daemon
                 )
             if extra_opts:


### PR DESCRIPTION
Do not allow the test system to turn off the logging of commands
Some tests use the reload command that is accidently turning off
the logging.  Just force the tests to ignore it.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>