### PR TITLE
pimd: Fix Null pointer dereference

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -582,12 +582,11 @@ int pim_process_no_rp_cmd(struct vty *vty, const char *rp_str,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	if (!yang_dnode_exists(vty->candidate_config->dnode, group_xpath)) {
+	group_dnode = yang_dnode_get(vty->candidate_config->dnode, group_xpath);
+	if (!group_dnode) {
 		vty_out(vty, "%% Unable to find specified RP\n");
 		return NB_OK;
 	}
-
-	group_dnode = yang_dnode_get(vty->candidate_config->dnode, group_xpath);
 
 	if (yang_is_last_list_dnode(group_dnode))
 		nb_cli_enqueue_change(vty, rp_xpath, NB_OP_DESTROY, NULL);


### PR DESCRIPTION
Fixing the below problem:
*** CID 1515041:  Null pointer dereferences  (NULL_RETURNS)
/pimd/pim_cmd_common.c: 592 in pim_process_no_rp_cmd()
586                     vty_out(vty, "%% Unable to find specified RP\n");
587                     return NB_OK;
588             }
589     
590             group_dnode = yang_dnode_get(vty->candidate_config->dnode, group_xpath);
591     
>>>     CID 1515041:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing a pointer that might be "NULL" "group_dnode" when calling "yang_is_last_list_dnode".
592             if (yang_is_last_list_dnode(group_dnode))
593                     nb_cli_enqueue_change(vty, rp_xpath, NB_OP_DESTROY, NULL);
594             else
595                     nb_cli_enqueue_change(vty, group_list_xpath, NB_OP_DESTROY,
596                                           group_str);

Although there is no NULL pointer dereference since
yang_dnode_exists is called before using the dnode but the tool is
complaining.
So removing the unnecessary yang_dnode_exists api call
and directly get the node and if node does not exists,
return.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>