### PR TITLE
bgpd, lib, pimd: Remove sockopt_cork

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -665,9 +665,6 @@ static void bgp_write_notify(struct peer *peer)
 
 	assert(stream_get_endp(s) >= BGP_HEADER_SIZE);
 
-	/* Stop collecting data within the socket */
-	sockopt_cork(peer->fd, 0);
-
 	/*
 	 * socket is in nonblocking mode, if we can't deliver the NOTIFY, well,
 	 * we only care about getting a clean shutdown at this point.

--- a/lib/sockunion.c
+++ b/lib/sockunion.c
@@ -351,21 +351,6 @@ int sockopt_ttl(int family, int sock, int ttl)
 	return 0;
 }
 
-/*
- * This function called setsockopt(.., TCP_CORK,...)
- * Which on linux is a no-op since it is enabled by
- * default and on BSD it uses TCP_NOPUSH to do
- * the same thing( which it was not configured to
- * use).  This cleanup of the api occurred on 8/1/17
- * I imagine if after more than 1 year of no-one
- * complaining, and a major upgrade release we
- * can deprecate and remove this function call
- */
-int sockopt_cork(int sock, int onoff)
-{
-	return 0;
-}
-
 int sockopt_minttl(int family, int sock, int minttl)
 {
 #ifdef IP_MINTTL

--- a/lib/sockunion.h
+++ b/lib/sockunion.h
@@ -95,7 +95,6 @@ extern int sockunion_bind(int sock, union sockunion *, unsigned short,
 			  union sockunion *);
 extern int sockopt_ttl(int family, int sock, int ttl);
 extern int sockopt_minttl(int family, int sock, int minttl);
-extern int sockopt_cork(int sock, int onoff);
 extern int sockunion_socket(const union sockunion *su);
 extern const char *inet_sutop(const union sockunion *su, char *str);
 extern enum connect_result sockunion_connect(int fd, const union sockunion *su,

--- a/pimd/pim_msdp_packet.c
+++ b/pimd/pim_msdp_packet.c
@@ -214,8 +214,6 @@ void pim_msdp_write(struct thread *thread)
 		return;
 	}
 
-	sockopt_cork(mp->fd, 1);
-
 	/* Nonblocking write until TCP output buffer is full  */
 	do {
 		int writenum;
@@ -279,8 +277,6 @@ void pim_msdp_write(struct thread *thread)
 		}
 	} while ((s = stream_fifo_head(mp->obuf)) != NULL);
 	pim_msdp_write_proceed_actions(mp);
-
-	sockopt_cork(mp->fd, 0);
 
 	if (PIM_DEBUG_MSDP_INTERNAL) {
 		zlog_debug("MSDP peer %s pim_msdp_write wrote %d packets",


### PR DESCRIPTION
sockopt_cork is a no-op function that was cleaned up
in 2017.  Since then it's still not being used.  At
this point in time there is little point in keeping a
dead function that will not be used because of vagaries
between platforms

Signed-off-by: Donald Sharp <sharpd@nvidia.com>