### PR TITLE
zebra: minor changes on "zebra_evpn_mac_gw_macip_add" function

### DIFF
--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -442,10 +442,8 @@ int zebra_evpn_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 
 	vxl = &zif->l2info.vxl;
 
-	if (zebra_evpn_mac_gw_macip_add(ifp, zevpn, ip, &mac, macaddr,
-					vxl->access_vlan, true)
-	    != 0)
-		return -1;
+	zebra_evpn_mac_gw_macip_add(ifp, zevpn, ip, &mac, macaddr,
+				    vxl->access_vlan, true);
 
 	return zebra_evpn_neigh_gw_macip_add(ifp, zevpn, ip, mac);
 }

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -2464,11 +2464,12 @@ int zebra_evpn_del_local_mac(struct zebra_evpn *zevpn, struct zebra_mac *mac,
 	return 0;
 }
 
-int zebra_evpn_mac_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
-				const struct ipaddr *ip,
-				struct zebra_mac **macp,
-				const struct ethaddr *macaddr, vlanid_t vlan_id,
-				bool def_gw)
+void zebra_evpn_mac_gw_macip_add(struct interface *ifp,
+				 struct zebra_evpn *zevpn,
+				 const struct ipaddr *ip,
+				 struct zebra_mac **macp,
+				 const struct ethaddr *macaddr,
+				 vlanid_t vlan_id, bool def_gw)
 {
 	struct zebra_mac *mac;
 	ns_id_t local_ns_id = NS_DEFAULT;
@@ -2488,13 +2489,13 @@ int zebra_evpn_mac_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 	SET_FLAG(mac->flags, ZEBRA_MAC_AUTO);
 	if (def_gw)
 		SET_FLAG(mac->flags, ZEBRA_MAC_DEF_GW);
+	else
+		SET_FLAG(mac->flags, ZEBRA_MAC_SVI);
 	mac->fwd_info.local.ifindex = ifp->ifindex;
 	mac->fwd_info.local.ns_id = local_ns_id;
 	mac->fwd_info.local.vid = vlan_id;
 
 	*macp = mac;
-
-	return 0;
 }
 
 void zebra_evpn_mac_svi_del(struct interface *ifp, struct zebra_evpn *zevpn)
@@ -2549,8 +2550,6 @@ void zebra_evpn_mac_svi_add(struct interface *ifp, struct zebra_evpn *zevpn)
 
 	mac = NULL;
 	zebra_evpn_mac_gw_macip_add(ifp, zevpn, NULL, &mac, &macaddr, 0, false);
-	if (mac)
-		SET_FLAG(mac->flags, ZEBRA_MAC_SVI);
 
 	new_bgp_ready = zebra_evpn_mac_is_ready_for_bgp(mac->flags);
 	zebra_evpn_mac_send_add_del_to_client(mac, old_bgp_ready,

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -278,11 +278,12 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf,
 				    bool dp_static, struct zebra_mac *mac);
 int zebra_evpn_del_local_mac(struct zebra_evpn *zevpn, struct zebra_mac *mac,
 			     bool clear_static);
-int zebra_evpn_mac_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
-				const struct ipaddr *ip,
-				struct zebra_mac **macp,
-				const struct ethaddr *macaddr, vlanid_t vlan_id,
-				bool def_gw);
+void zebra_evpn_mac_gw_macip_add(struct interface *ifp,
+				 struct zebra_evpn *zevpn,
+				 const struct ipaddr *ip,
+				 struct zebra_mac **macp,
+				 const struct ethaddr *macaddr,
+				 vlanid_t vlan_id, bool def_gw);
 void zebra_evpn_mac_svi_add(struct interface *ifp, struct zebra_evpn *zevpn);
 void zebra_evpn_mac_svi_del(struct interface *ifp, struct zebra_evpn *zevpn);
 void zebra_evpn_mac_ifp_del(struct interface *ifp);


### PR DESCRIPTION
Two minor changes:
    1) Change `zebra_evpn_mac_gw_macip_add()` 's return type to `void`.
    2) Since `zebra_evpn_mac_gw_macip_add()` has already `assert` the returned
    `mac`, the check of its return value makes no sense. And keep setting
    `mac->flags` inside `zebra_evpn_mac_gw_macip_add()` is more reasonable. So
    just move the setting `mac->flags` inside `zebra_evpn_mac_gw_macip_add()`.