### PR TITLE
pimd: Add additional IGMP stats (peak number of groups)

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1309,6 +1309,8 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 			pim_ifp->gm_group_list
 				? listcount(pim_ifp->gm_group_list)
 				: 0;
+		igmp_stats.peak_groups += pim_ifp->igmp_peak_group_count;
+
 
 		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, group_node,
 					  group)) {
@@ -1350,6 +1352,8 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 				    igmp_stats.unsupported);
 		json_object_int_add(json_row, "totalReceivedMessages",
 				    igmp_stats.total_recv_messages);
+		json_object_int_add(json_row, "peakGroups",
+				    igmp_stats.peak_groups);
 		json_object_int_add(json_row, "totalGroups",
 				    igmp_stats.total_groups);
 		json_object_int_add(json_row, "totalSourceGroups",
@@ -1399,6 +1403,8 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 			igmp_stats.general_queries_sent);
 		vty_out(vty, "group queries sent      : %u\n",
 			igmp_stats.group_queries_sent);
+		vty_out(vty, "peak groups             : %u\n",
+			igmp_stats.peak_groups);
 		vty_out(vty, "total groups            : %u\n",
 			igmp_stats.total_groups);
 		vty_out(vty, "total source groups     : %u\n",
@@ -4051,6 +4057,7 @@ DEFUN (clear_ip_pim_interface_traffic,
 		pim_ifp->pim_ifstat_bsm_tx = 0;
 		pim_ifp->igmp_ifstat_joins_sent = 0;
 		pim_ifp->igmp_ifstat_joins_failed = 0;
+		pim_ifp->igmp_peak_group_count = 0;
 	}
 
 	return CMD_SUCCESS;

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -191,6 +191,7 @@ struct pim_interface {
 
 	uint32_t igmp_ifstat_joins_sent;
 	uint32_t igmp_ifstat_joins_failed;
+	uint32_t igmp_peak_group_count;
 
 	struct {
 		bool enabled;

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -977,6 +977,8 @@ static void igmp_group_free(struct gm_group *group)
 
 static void igmp_group_count_incr(struct pim_interface *pim_ifp)
 {
+	uint32_t group_count = listcount(pim_ifp->gm_group_list);
+
 	++pim_ifp->pim->igmp_group_count;
 	if (pim_ifp->pim->igmp_group_count
 	    == pim_ifp->pim->igmp_watermark_limit) {
@@ -985,6 +987,9 @@ static void igmp_group_count_incr(struct pim_interface *pim_ifp)
 			pim_ifp->pim->igmp_group_count,
 			VRF_LOGNAME(pim_ifp->pim->vrf));
 	}
+
+	if (pim_ifp->igmp_peak_group_count < group_count)
+		pim_ifp->igmp_peak_group_count = group_count;
 }
 
 static void igmp_group_count_decr(struct pim_interface *pim_ifp)

--- a/pimd/pim_igmp_stats.c
+++ b/pimd/pim_igmp_stats.c
@@ -43,6 +43,7 @@ void igmp_stats_add(struct igmp_stats *a, struct igmp_stats *b)
 	a->mtrace_rsp += b->mtrace_rsp;
 	a->mtrace_req += b->mtrace_req;
 	a->unsupported += b->unsupported;
+	a->peak_groups += b->peak_groups;
 	a->total_groups += b->total_groups;
 	a->total_source_groups += b->total_source_groups;
 	a->joins_sent += b->joins_sent;

--- a/pimd/pim_igmp_stats.h
+++ b/pimd/pim_igmp_stats.h
@@ -33,6 +33,7 @@ struct igmp_stats {
 	uint32_t mtrace_rsp;
 	uint32_t mtrace_req;
 	uint32_t unsupported;
+	uint32_t peak_groups;
 	uint32_t total_groups;
 	uint32_t total_source_groups;
 	uint32_t joins_sent;

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -469,6 +469,7 @@ void pim_ifstat_reset(struct interface *ifp)
 	pim_ifp->pim_ifstat_bsm_invalid_sz = 0;
 	pim_ifp->igmp_ifstat_joins_sent = 0;
 	pim_ifp->igmp_ifstat_joins_failed = 0;
+	pim_ifp->igmp_peak_group_count = 0;
 }
 
 void pim_sock_reset(struct interface *ifp)


### PR DESCRIPTION
```
exit1-debian-11# sh ip igmp statistics interface eth2
IGMP statistics
Interface            : eth2
V1 query             : 0
V2 query             : 0
V3 query             : 25
V2 leave             : 0
V1 report            : 0
V2 report            : 0
V3 report            : 34
mtrace response      : 0
mtrace request       : 0
unsupported          : 0
joins failed         : 0
joins sent           : 13
general queries sent : 2
group queries sent   : 24
peak groups          : 9
total groups         : 4
total source groups  : 1
exit1-debian-11# sh ip igmp statistics interface eth2 json
{
  "eth2":{
    "name":"eth2",
    "queryV1":0,
    "queryV2":0,
    "queryV3":25,
    "leaveV2":0,
    "reportV1":0,
    "reportV2":0,
    "reportV3":34,
    "mtraceResponse":0,
    "mtraceRequest":0,
    "unsupported":0,
    "peakGroups":9,
    "totalGroups":4,
    "totalSourceGroups":1,
    "joinsFailed":0,
    "joinsSent":13,
    "generalQueriesSent":2,
    "groupQueriesSent":24
  }
}
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>