### PR TITLE
pimd: Show total received messages IGMP stats

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1348,6 +1348,8 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 				    igmp_stats.mtrace_req);
 		json_object_int_add(json_row, "unsupported",
 				    igmp_stats.unsupported);
+		json_object_int_add(json_row, "totalReceivedMessages",
+				    igmp_stats.total_recv_messages);
 		json_object_int_add(json_row, "totalGroups",
 				    igmp_stats.total_groups);
 		json_object_int_add(json_row, "totalSourceGroups",
@@ -1365,39 +1367,41 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 		vty_json(vty, json);
 	} else {
 		vty_out(vty, "IGMP statistics\n");
-		vty_out(vty, "Interface            : %s\n",
+		vty_out(vty, "Interface               : %s\n",
 			ifname ? ifname : "global");
-		vty_out(vty, "V1 query             : %u\n",
+		vty_out(vty, "V1 query                : %u\n",
 			igmp_stats.query_v1);
-		vty_out(vty, "V2 query             : %u\n",
+		vty_out(vty, "V2 query                : %u\n",
 			igmp_stats.query_v2);
-		vty_out(vty, "V3 query             : %u\n",
+		vty_out(vty, "V3 query                : %u\n",
 			igmp_stats.query_v3);
-		vty_out(vty, "V2 leave             : %u\n",
+		vty_out(vty, "V2 leave                : %u\n",
 			igmp_stats.leave_v2);
-		vty_out(vty, "V1 report            : %u\n",
+		vty_out(vty, "V1 report               : %u\n",
 			igmp_stats.report_v1);
-		vty_out(vty, "V2 report            : %u\n",
+		vty_out(vty, "V2 report               : %u\n",
 			igmp_stats.report_v2);
-		vty_out(vty, "V3 report            : %u\n",
+		vty_out(vty, "V3 report               : %u\n",
 			igmp_stats.report_v3);
-		vty_out(vty, "mtrace response      : %u\n",
+		vty_out(vty, "mtrace response         : %u\n",
 			igmp_stats.mtrace_rsp);
-		vty_out(vty, "mtrace request       : %u\n",
+		vty_out(vty, "mtrace request          : %u\n",
 			igmp_stats.mtrace_req);
-		vty_out(vty, "unsupported          : %u\n",
+		vty_out(vty, "unsupported             : %u\n",
 			igmp_stats.unsupported);
-		vty_out(vty, "joins failed         : %u\n",
+		vty_out(vty, "total received messages : %u\n",
+			igmp_stats.total_recv_messages);
+		vty_out(vty, "joins failed            : %u\n",
 			igmp_stats.joins_failed);
-		vty_out(vty, "joins sent           : %u\n",
+		vty_out(vty, "joins sent              : %u\n",
 			igmp_stats.joins_sent);
-		vty_out(vty, "general queries sent : %u\n",
+		vty_out(vty, "general queries sent    : %u\n",
 			igmp_stats.general_queries_sent);
-		vty_out(vty, "group queries sent   : %u\n",
+		vty_out(vty, "group queries sent      : %u\n",
 			igmp_stats.group_queries_sent);
-		vty_out(vty, "total groups         : %u\n",
+		vty_out(vty, "total groups            : %u\n",
 			igmp_stats.total_groups);
-		vty_out(vty, "total source groups  : %u\n",
+		vty_out(vty, "total source groups     : %u\n",
 			igmp_stats.total_source_groups);
 	}
 }

--- a/pimd/pim_igmp_stats.c
+++ b/pimd/pim_igmp_stats.c
@@ -49,4 +49,7 @@ void igmp_stats_add(struct igmp_stats *a, struct igmp_stats *b)
 	a->joins_failed += b->joins_failed;
 	a->general_queries_sent += b->general_queries_sent;
 	a->group_queries_sent += b->group_queries_sent;
+	a->total_recv_messages += b->query_v1 + b->query_v2 + b->query_v3 +
+				  b->report_v1 + b->report_v2 + b->report_v3 +
+				  b->leave_v2 + b->mtrace_rsp + b->mtrace_req;
 }

--- a/pimd/pim_igmp_stats.h
+++ b/pimd/pim_igmp_stats.h
@@ -39,6 +39,7 @@ struct igmp_stats {
 	uint32_t joins_failed;
 	uint32_t general_queries_sent;
 	uint32_t group_queries_sent;
+	uint32_t total_recv_messages;
 };
 
 #if PIM_IPV == 4


### PR DESCRIPTION
```
exit1-debian-11# do sh ip igmp statistics
IGMP statistics
Interface               : global
V1 query                : 0
V2 query                : 0
V3 query                : 3
V2 leave                : 0
V1 report               : 0
V2 report               : 0
V3 report               : 18
mtrace response         : 0
mtrace request          : 0
unsupported             : 0
total received messages : 21
joins failed            : 0
joins sent              : 16
general queries sent    : 6
group queries sent      : 3
total groups            : 4
total source groups     : 1
exit1-debian-11# do sh ip igmp statistics json
{
  "global":{
    "name":"global",
    "queryV1":0,
    "queryV2":0,
    "queryV3":4,
    "leaveV2":0,
    "reportV1":0,
    "reportV2":0,
    "reportV3":18,
    "mtraceResponse":0,
    "mtraceRequest":0,
    "unsupported":0,
    "totalReceivedMessage":22,
    "totalGroups":3,
    "totalSourceGroups":1,
    "joinsFailed":0,
    "joinsSent":16,
    "generalQueriesSent":6,
    "groupQueriesSent":4
  }
}
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>