### PR TITLE
bgpd: add new line for prompt of "no router bgp"

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1486,7 +1486,7 @@ DEFUN (no_router_bgp,
 		}
 
 		if (bgp->l3vni) {
-			vty_out(vty, "%% Please unconfigure l3vni %u",
+			vty_out(vty, "%% Please unconfigure l3vni %u\n",
 				bgp->l3vni);
 			return CMD_WARNING_CONFIG_FAILED;
 		}


### PR DESCRIPTION
Simple prompt issue.
"no router bgp <ASN>" is ok, but "no router bgp" without <ASN> missed "\n".