### PR TITLE
tests: Adding database info in the script to ease debug

### DIFF
--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
@@ -2113,6 +2113,14 @@ def test_ospfv3_type5_summary_tc46_p0(request):
         tc_name, result
     )
 
+    output = tgen.gears["r0"].vtysh_cmd(
+        "show ipv6 ospf6 database as-external json", isjson=True
+    )
+
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ipv6 ospf6 database as-external json", isjson=True
+    )
+
     result = verify_rib(
         tgen, "ipv6", dut, input_dict, protocol=protocol, expected=False
     )


### PR DESCRIPTION
Currently the test case test_ospfv3_type5_summary_tc46_p0 checks whether the route-calculation for Type-5 is fine or not.

Adding the "show ipv6 ospf6 database as-external json" output in the test script to narrow
down whether it is an LSA origination problem or route calculation problem when the test case fails.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>