### PR TITLE
bgpd: remove dead code

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3506,20 +3506,6 @@ void bgp_evpn_import_type2_route(struct bgp_path_info *pi, int import)
 				     &pi->net->p, pi, import);
 }
 
-/* Import the pi into vrf routing tables */
-void bgp_evpn_import_route_in_vrfs(struct bgp_path_info *pi, int import)
-{
-	struct bgp *bgp_evpn;
-
-	bgp_evpn = bgp_get_evpn();
-	if (!bgp_evpn)
-		return;
-
-	bgp_evpn_install_uninstall_table(bgp_evpn, AFI_L2VPN, SAFI_EVPN,
-					 &pi->net->p, pi, import, false /*vpn*/,
-					 true /*vrf*/);
-}
-
 /*
  * delete and withdraw all ipv4 and ipv6 routes in the vrf table as type-5
  * routes

--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -647,7 +647,6 @@ extern struct bgp_dest *
 bgp_global_evpn_node_lookup(struct bgp_table *table, afi_t afi, safi_t safi,
 			    const struct prefix_evpn *evp,
 			    struct prefix_rd *prd);
-extern void bgp_evpn_import_route_in_vrfs(struct bgp_path_info *pi, int import);
 extern void bgp_evpn_update_type2_route_entry(struct bgp *bgp,
 					      struct bgpevpn *vpn,
 					      struct bgp_node *rn,


### PR DESCRIPTION
`bgp_evpn_import_route_in_vrfs()` is special ( l2vpn ) form of
`install_uninstall_evpn_route() with `AFI_L2VPN` and `SAFI_EVPN` family.

No caller, just remove it.