### PR TITLE
zebra: Fixup lua with new dplane ops

### DIFF
--- a/zebra/zebra_script.c
+++ b/zebra/zebra_script.c
@@ -331,6 +331,9 @@ void lua_pushzebra_dplane_ctx(lua_State *L, const struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_ADDR_UNINSTALL:
 	case DPLANE_OP_INTF_ADDR_ADD:
 	case DPLANE_OP_INTF_ADDR_DEL:
+	case DPLANE_OP_INTF_INSTALL:
+	case DPLANE_OP_INTF_UPDATE:
+	case DPLANE_OP_INTF_DELETE:
 		break;
 	case DPLANE_OP_NEIGH_INSTALL:
 	case DPLANE_OP_NEIGH_UPDATE:


### PR DESCRIPTION
Commit: 5d41413833 added 3 new dplane ops:

DPLANE_OP_INTF_INSTALL
DPLANE_OP_INTF_UPDATE
DPLANE_OP_INTF_DELETE

The build system does not build lua so zebra_script.c
was not updated.  Update of course!

Signed-off-by: Donald Sharp <sharpd@nvidia.com>