### PR TITLE
lib: wheel's typo fix

### DIFF
--- a/lib/wheel.c
+++ b/lib/wheel.c
@@ -94,7 +94,7 @@ struct timer_wheel *wheel_init(struct thread_master *master, int period,
 	wheel->nexttime = period / slots;
 
 	wheel->wheel_slot_lists = XCALLOC(MTYPE_TIMER_WHEEL_LIST,
-					  slots * sizeof(struct listnode *));
+					  slots * sizeof(struct list *));
 	for (i = 0; i < slots; i++)
 		wheel->wheel_slot_lists[i] = list_new();
 


### PR DESCRIPTION
The wheel data structure is a array of list pointers
but the alloc for it is using the sizeof (struct listnode *)
as the amount to allocate.  Even though the (struct listnode *)
and (struct list *) sizes are the same, let's list the correct
values.

Signed-off-by: ron <lyq140hf2006@163.com>