### PR TITLE
ospf6d: observed crash in ospf6_decrement_retrans_count.

### DIFF
--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -132,6 +132,8 @@ void ospf6_lsdb_add(struct ospf6_lsa *lsa, struct ospf6_lsdb *lsdb)
 				(*lsdb->hook_add)(lsa);
 		}
 	} else {
+		lsa->retrans_count = old->retrans_count;
+
 		if (OSPF6_LSA_IS_CHANGED(old, lsa)) {
 			if (OSPF6_LSA_IS_MAXAGE(lsa)) {
 				if (lsdb->hook_remove) {


### PR DESCRIPTION
Problem:
ospf6d crash is observed when lsack is received from the neighbour for
AS External LSA.

RCA:
The crash is observed in ospf6_decrement_retrans_count while decrementing
retransmit counter for the LSA when lsack is recived. This is because in
ospf6_flood_interace when new LSA is being added to the neighbour's list
the incrementing is happening on the received LSA instead of the already
present LSA in scope DB which is already carrying counters.

when this new LSA replaces the old one, the already present counters are
not copied on the new LSA this creates counter mismatch which results in
a crash when lsack is recevied due to counter going to negative.

Fix:
The fix involves following changes.
   1. In ospf6_flood_interace when LSA is being added to retrans list
      check if there is alreday lsa in the scoped db and increment
      the counter on that if present.
   2. In ospf6_lsdb_add copy the retrans counter from old to new lsa
      when its being replaced.

Signed-off-by: Manoj Naragund <mnaragund@vmware.com>