### PR TITLE
tests: Fix topotests crash when KeyError found

### DIFF
--- a/tests/topotests/lib/micronet_cli.py
+++ b/tests/topotests/lib/micronet_cli.py
@@ -110,7 +110,7 @@ def doline(unet, line, writef):
         args = oargs.split()
         if not args or (len(args) == 1 and args[0] == "*"):
             args = sorted(unet.hosts.keys())
-        hosts = [unet.hosts[x] for x in args]
+        hosts = [unet.hosts[x] for x in args if x in unet.hosts]
         for host in hosts:
             if cmd == "t" or cmd == "term":
                 host.run_in_window("bash", title="sh-%s" % host)
@@ -250,6 +250,8 @@ def cli(
     prompt=None,
     background=True,
 ):
+    logger = logging.getLogger("cli-client")
+
     if prompt is None:
         prompt = "unet> "
 


### PR DESCRIPTION
1. Handle KeyError
2. logger object is defined in main function and its not not accessible
   in other functions so defined it in local functions.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>