### PR TITLE
pimd: change default value of rp keep_alive_timer to 185 seconds

### DIFF
--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -148,7 +148,7 @@ module frr-pim {
       type uint16 {
         range "1..max";
       }
-      default "210";
+      default "185";
       description
         "RP keep alive Timer in seconds.";
     }


### PR DESCRIPTION
In order to be compliant with the code.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>