### PR TITLE
zebra: minors changes on zebra_evpn_local_es_update()

### DIFF
--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -2332,7 +2332,6 @@ static int zebra_evpn_local_es_update(struct zebra_if *zif, esi_t *esi)
 	struct zebra_evpn_es *old_es = zif->es_info.es;
 	struct zebra_evpn_es *es;
 
-	memcpy(&zif->es_info.esi, esi, sizeof(*esi));
 	if (old_es && !memcmp(&old_es->esi, esi, sizeof(*esi)))
 		/* dup - nothing to be done */
 		return 0;
@@ -2344,17 +2343,15 @@ static int zebra_evpn_local_es_update(struct zebra_if *zif, esi_t *esi)
 	es = zebra_evpn_es_find(esi);
 	if (es) {
 		/* if it exists against another interface flag an error */
-		if (es->zif && es->zif != zif) {
-			memset(&zif->es_info.esi, 0, sizeof(*esi));
+		if (es->zif && es->zif != zif)
 			return -1;
-		}
 	} else {
 		/* create new es */
 		es = zebra_evpn_es_new(esi);
 	}
 
-	if (es)
-		zebra_evpn_es_local_info_set(es, zif);
+	memcpy(&zif->es_info.esi, esi, sizeof(*esi));
+	zebra_evpn_es_local_info_set(es, zif);
 
 	return 0;
 }


### PR DESCRIPTION
Two changes in `zebra_evpn_local_es_update()`:
    1) Since `es` must be created, so remove the `es` check before
    calling `zebra_evpn_es_local_info_set()`.
    2) Delay setting `zif->es_info.esi` and remove the annoying rollback
    (i.e. unset `zif->es_info.esi`) operation on failure.