### PR TITLE
ospfd: fix ospf default route wrongly sent back

### DIFF
--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1280,6 +1280,7 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	struct zapi_route api;
 	struct prefix_ipv4 p;
+	struct prefix pgen;
 	unsigned long ifindex;
 	struct in_addr nexthop;
 	struct external_info *ei;
@@ -1302,13 +1303,17 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 	if (IPV4_NET127(ntohl(p.prefix.s_addr)))
 		return 0;
 
+	pgen.family = p.family;
+	pgen.prefixlen = p.prefixlen;
+	pgen.u.prefix4 = p.prefix;
+
 	/* Re-destributed route is default route.
 	 * Here, route type is used as 'ZEBRA_ROUTE_KERNEL' for
 	 * updating ex-info. But in resetting (no default-info
 	 * originate)ZEBRA_ROUTE_MAX is used to delete the ex-info.
 	 * Resolved this inconsistency by maintaining same route type.
 	 */
-	if (is_default_prefix4(&p))
+	if ((is_default_prefix(&pgen)) && (api.type != ZEBRA_ROUTE_OSPF))
 		rt_type = DEFAULT_ROUTE;
 
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_REDISTRIBUTE))


### PR DESCRIPTION
That commit aim is to fix an invalid behavior when
default-information is activated on ospf router without always option.

Consider an ASBR with:
-one default route coming from ospf,
-and another default route coming from another deaemon (such BGP or static).

When the daemon bgp stops advertising its default route,
-ospf continues to advertise its previous default route (with aging 0),
-this may create default routing loops.

Expected behavior: is to update the removed external default route with
MAXAGING value.
Updating with MAXAGING value will notify the fact the route is currently
invalid. A later removal from ospf external LSA database will be made.

Analysis: all default routes have their type overwritten by a
DEFAULT_ROUTE type. Thus all default routes whatever its origin (ospf,
bgp, static...) is treated in a same way. But this is not pertinent for
ospf originated default routes.

Fix: avoid overwiting of route type when default route is ospf type.

Signed-off-by: Francois Dumontet francois.dumontet@6wind.com