### PR TITLE
zebra: Do not complain if deletion fails

### DIFF
--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -282,6 +282,12 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 			continue;
 
 			/* Note any unexpected status returns */
+		case ZEBRA_ERR_RTNOEXIST:
+			if (cmd != RTM_DELETE)
+				flog_err(EC_LIB_SYSTEM_CALL,
+					 "%s: rtm_write() returned %d for command %d",
+					 __func__, error, cmd);
+			break;
 		default:
 			flog_err(
 				EC_LIB_SYSTEM_CALL,


### PR DESCRIPTION
When issuing a RTM_DELETE operation and the kernel tells
us that the route is already deleted, let's not complain
about the situation:

2022/03/19 02:40:34 ZEBRA: [EC 100663303] kernel_rtm: 2a10:cc42:1d51::/48: rtm_write() unexpectedly returned -4 for command RTM_DELETE

I can recreate this issue on freebsd by doing this:
a) create a route using sharpd
b) shutdown the nexthop's interface
c) remove the route using sharpd

This would also be true of pretty much any routing protocol's behavior.
Let's just not complain about the situation if a RTM_DELETE
operation is issued and FRR is told that the route does not
exist to delete.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>