### PR TITLE
zebra, bgpd: remove check returning value of RB_INSERT()

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1651,10 +1651,7 @@ static struct bgp_evpn_es *bgp_evpn_es_new(struct bgp *bgp, const esi_t *esi)
 	es->route_table = bgp_table_init(bgp, AFI_L2VPN, SAFI_EVPN);
 
 	/* Add to rb_tree */
-	if (RB_INSERT(bgp_es_rb_head, &bgp_mh_info->es_rb_tree, es)) {
-		XFREE(MTYPE_BGP_EVPN_ES, es);
-		return NULL;
-	}
+	RB_INSERT(bgp_es_rb_head, &bgp_mh_info->es_rb_tree, es);
 
 	/* Initialise the ES-EVI list */
 	es->es_evi_list = list_new();
@@ -2716,10 +2713,7 @@ static struct bgp_evpn_es_vrf *bgp_evpn_es_vrf_create(struct bgp_evpn_es *es,
 	es_vrf->bgp_vrf = bgp_vrf;
 
 	/* insert into the VRF-ESI rb tree */
-	if (RB_INSERT(bgp_es_vrf_rb_head, &bgp_vrf->es_vrf_rb_tree, es_vrf)) {
-		XFREE(MTYPE_BGP_EVPN_ES_VRF, es_vrf);
-		return NULL;
-	}
+	RB_INSERT(bgp_es_vrf_rb_head, &bgp_vrf->es_vrf_rb_tree, es_vrf);
 
 	/* add to the ES's VRF list */
 	listnode_init(&es_vrf->es_listnode, es_vrf);
@@ -3259,10 +3253,7 @@ static struct bgp_evpn_es_evi *bgp_evpn_es_evi_new(struct bgp_evpn_es *es,
 	es_evi->es_evi_vtep_list->cmp = bgp_evpn_es_evi_vtep_cmp;
 
 	/* insert into the VNI-ESI rb tree */
-	if (RB_INSERT(bgp_es_evi_rb_head, &vpn->es_evi_rb_tree, es_evi)) {
-		XFREE(MTYPE_BGP_EVPN_ES_EVI, es_evi);
-		return NULL;
-	}
+	RB_INSERT(bgp_es_evi_rb_head, &vpn->es_evi_rb_tree, es_evi);
 
 	/* add to the ES's VNI list */
 	listnode_init(&es_evi->es_listnode, es_evi);

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -113,10 +113,7 @@ static struct zebra_evpn_es_evi *zebra_evpn_es_evi_new(struct zebra_evpn_es *es,
 	es_evi->zevpn = zevpn;
 
 	/* insert into the EVPN-ESI rb tree */
-	if (RB_INSERT(zebra_es_evi_rb_head, &zevpn->es_evi_rb_tree, es_evi)) {
-		XFREE(MTYPE_ZES_EVI, es_evi);
-		return NULL;
-	}
+	RB_INSERT(zebra_es_evi_rb_head, &zevpn->es_evi_rb_tree, es_evi);
 
 	/* add to the ES's VNI list */
 	listnode_init(&es_evi->es_listnode, es_evi);
@@ -1776,10 +1773,7 @@ static struct zebra_evpn_es *zebra_evpn_es_new(const esi_t *esi)
 	esi_to_str(&es->esi, es->esi_str, sizeof(es->esi_str));
 
 	/* Add to rb_tree */
-	if (RB_INSERT(zebra_es_rb_head, &zmh_info->es_rb_tree, es)) {
-		XFREE(MTYPE_ZES, es);
-		return NULL;
-	}
+	RB_INSERT(zebra_es_rb_head, &zmh_info->es_rb_tree, es);
 
 	/* Initialise the ES-EVI list */
 	es->es_evi_list = list_new();


### PR DESCRIPTION
Two commits:
Since the `RB_INSERT()` is called after not found in RB tree, it MUST be ok and
and return zero. The check of returning value of `RB_INSERT()` is redundant,
just remove them.