### PR TITLE
pimd: add source and group information in mroute json

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5952,6 +5952,10 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 
 			/* Find the inbound interface nested under the source,
 			 * create it if it doesn't exist */
+			json_object_string_add(json_source, "source",
+					       src_str);
+			json_object_string_add(json_source, "group",
+					       grp_str);
 			json_object_int_add(json_source, "installed",
 					    c_oil->installed);
 			json_object_int_add(json_source, "refCount",


### PR DESCRIPTION
source/group information now added for pruned entry

show ip mroute json command displays the source, group info
per oil, so for pruned group since the OIL is empty, it is not
showing.

Fix: Added the above information per source.

Signed-off-by: sarita patra <saritap@vmware.com>