### PR TITLE
ospfd: Default route becomes stale  route in nbrs even after flush from originator

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2422,10 +2422,10 @@ void ospf_external_lsa_flush(struct ospf *ospf, uint8_t type,
 	    && !(CHECK_FLAG(lsa->flags, OSPF_LSA_LOCAL_XLT)))
 		ospf_nssa_lsa_flush(ospf, p);
 
-	/* Sweep LSA from Link State Retransmit List. */
-	ospf_ls_retransmit_delete_nbr_as(ospf, lsa);
-
 	if (!IS_LSA_MAXAGE(lsa)) {
+		/* Sweep LSA from Link State Retransmit List. */
+		ospf_ls_retransmit_delete_nbr_as(ospf, lsa);
+
 		/* Unregister LSA from Refresh queue. */
 		ospf_refresher_unregister_lsa(ospf, lsa);
 


### PR DESCRIPTION


Description:
	Default route is not getting flushed from neighbours though originator
        triggered flush and deleted LSA from its database. It become as stale
        LSA in  neighbours databse forever. This could seen in the following
        sequence of configurations with less than a second interval b/w configs.
        And this could happen only when originator shouldnt have default route
        in its rib so it originates default route only when configure with 'always'
        option.

        step-1:default-information originate always
        step-2:no default-information originate always
        step-3:default-information originate

        In step-1, default route will be originated to AS.
        In step-2, default route will be flushed to AS, but neighbours will be
                   discarding this update due to minlsainterval condition.
                   And it is expected that DUT need to keep send this update
                   until it receives the ack from neighbours by adding each
                   neighbour's retransmission list.
        In Step-3: It is deleting the lsas from nbr's retransmission list
                   by assuming it initiated the flush. This is cuasing to not
                   send the lsa update anymore to neighbours which makes
                   stale lsa in nbrs forever.

Fix:
        Allowed to delete the lsa from retransmission list only when lsa is
        not in maxage during flushing procedure.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>