### PR TITLE
bgpd: Print hostname along with IP for most useful debug messages

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3433,9 +3433,9 @@ bool bgp_maximum_prefix_overflow(struct peer *peer, afi_t afi, safi_t safi,
 			return false;
 
 		zlog_info(
-			"%%MAXPFXEXCEED: No. of %s prefix received from %s %u exceed, limit %u",
-			get_afi_safi_str(afi, safi, false), peer->host, pcount,
-			peer->pmax[afi][safi]);
+			"%%MAXPFXEXCEED: No. of %s prefix received from %s(%s) %u exceed, limit %u",
+			get_afi_safi_str(afi, safi, false), peer->host,
+			bgp_peer_hostname(peer), pcount, peer->pmax[afi][safi]);
 		SET_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_PREFIX_LIMIT);
 
 		if (CHECK_FLAG(peer->af_flags[afi][safi],
@@ -3473,8 +3473,9 @@ bool bgp_maximum_prefix_overflow(struct peer *peer, afi_t afi, safi_t safi,
 
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug(
-					"%s Maximum-prefix restart timer started for %d secs",
-					peer->host, peer->v_pmax_restart);
+					"%s(%s) Maximum-prefix restart timer started for %d secs",
+					peer->host, bgp_peer_hostname(peer),
+					peer->v_pmax_restart);
 
 			BGP_TIMER_ON(peer->t_pmax_restart,
 				     bgp_maximum_prefix_restart_timer,

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2347,15 +2347,15 @@ void peer_nsf_stop(struct peer *peer)
 	if (peer->t_gr_restart) {
 		BGP_TIMER_OFF(peer->t_gr_restart);
 		if (bgp_debug_neighbor_events(peer))
-			zlog_debug("%s graceful restart timer stopped",
-				   peer->host);
+			zlog_debug("%s(%s) graceful restart timer stopped",
+				   peer->host, bgp_peer_hostname(peer));
 	}
 	if (peer->t_gr_stale) {
 		BGP_TIMER_OFF(peer->t_gr_stale);
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug(
-				"%s graceful restart stalepath timer stopped",
-				peer->host);
+				"%s(%s) graceful restart stalepath timer stopped",
+				peer->host, bgp_peer_hostname(peer));
 	}
 	bgp_clear_route_all(peer);
 }
@@ -4294,8 +4294,9 @@ static void peer_flag_modify_action(struct peer *peer, uint32_t flag)
 				BGP_TIMER_OFF(peer->t_pmax_restart);
 				if (bgp_debug_neighbor_events(peer))
 					zlog_debug(
-						"%s Maximum-prefix restart timer canceled",
-						peer->host);
+						"%s(%s) Maximum-prefix restart timer canceled",
+						peer->host,
+						bgp_peer_hostname(peer));
 			}
 
 			if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->status)) {
@@ -7185,8 +7186,9 @@ static bool peer_maximum_prefix_clear_overflow(struct peer *peer)
 	if (peer->t_pmax_restart) {
 		BGP_TIMER_OFF(peer->t_pmax_restart);
 		if (bgp_debug_neighbor_events(peer))
-			zlog_debug("%s Maximum-prefix restart timer cancelled",
-				   peer->host);
+			zlog_debug(
+				"%s(%s) Maximum-prefix restart timer cancelled",
+				peer->host, bgp_peer_hostname(peer));
 	}
 	BGP_EVENT_ADD(peer, BGP_Start);
 	return true;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2469,6 +2469,11 @@ static inline bool bgp_in_graceful_shutdown(struct bgp *bgp)
 	        !!CHECK_FLAG(bm->flags, BM_FLAG_GRACEFUL_SHUTDOWN));
 }
 
+static inline const char *bgp_peer_hostname(struct peer *peer)
+{
+	return peer->hostname ? peer->hostname : "Unknown";
+}
+
 /* For benefit of rfapi */
 extern struct peer *peer_new(struct bgp *bgp);
 


### PR DESCRIPTION
Examples:

```
%ADJCHANGE: neighbor 192.168.0.1(exit1-debian-11) in vrf default Up
192.168.0.1(exit1-debian-11) graceful restart stalepath timer expired
192.168.0.1(exit1-debian-11) sending route-refresh (BoRR) for IPv4/unicast
192.168.0.1(exit1-debian-11) graceful restart timer started for 120 sec
192.168.0.1(exit1-debian-11) graceful restart stalepath timer started for 120 sec
192.168.0.1(exit1-debian-11) graceful restart timer stopped
%MAXPFXEXCEED: No. of IPv4 Unicast prefix received from 192.168.0.1(exit1-debian-11) 9 exceed, limit 1
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>