### PR TITLE
autoconf: do not .gitignore m4/ax_lua.m4

### DIFF
--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -3,6 +3,7 @@
 
 !ax_compare_version.m4
 !ax_cxx_compile_stdcxx.m4
+!ax_lua.m4
 !ax_prog_perl_modules.m4
 !ax_pthread.m4
 !ax_python.m4


### PR DESCRIPTION
The file m4/ax_lua.m4 needs to be a part of distribution, but it is not
inluded in the git repository by default becuase .gitignore file has a
wildcard for all *.m4 files, while individual files that must _not_ be
ignored are listed one by one as exceptions. ax_lua.m4 needs to be added
to this list of exceptions too.

One failure scenario is when you put a snapshot of the source tree in a
new git repository (e.g. the one used for a local CI/CD), this file is
not included in the repository, and subsequently build fails.

This commit adds the exception into m4/.gitignore file

Signed-off-by: Eugene Crosser <crosser@average.org>