### PR TITLE
build: remove generated lib files during distclean

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -523,6 +523,11 @@ lib/clippy-command_parse.$(OBJEXT): lib/command_lex.h
 lib/lib_clippy-command_lex.$(OBJEXT): lib/command_parse.h
 lib/lib_clippy-command_parse.$(OBJEXT): lib/command_lex.h
 
+DISTCLEANFILES += lib/command_lex.h \
+		  lib/command_lex.c \
+		  lib/command_parse.h \
+		  lib/command_parse.c
+
 rt_enabled =
 
 if BABELD


### PR DESCRIPTION
Remove a couple of lex/yacc output files in lib/ during 'distclean' : command_parse.[ch] and command_lex.[ch] were not being removed. 
