### PR TITLE
pimd: assert fixes

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -2062,6 +2062,7 @@ static bool pim_upstream_sg_running_proc(struct pim_upstream *up)
 	if ((up->sptbit != PIM_UPSTREAM_SPTBIT_TRUE) &&
 	    (up->rpf.source_nexthop.interface)) {
 		pim_upstream_set_sptbit(up, up->rpf.source_nexthop.interface);
+		pim_upstream_update_could_assert(up);
 	}
 
 	return rv;


### PR DESCRIPTION
This PR addresses two problems in PIM Assert processing
Problem:
PIM assert message is not triggered even after receiving WRONGVIF notification because of Could_assert flag not set. Refer RFC section 4.6.1 of 7761. Only if PIM Assert messages are trigerred, the routers can sense that more than one upstream routers has valid forwarding state and the downstream routers would prune a duplicate path. Even if you receive a WRONGVIF notification, CouldAssert should be true for a router to trigger PIM Assert messages. 
CouldAssert(S,G,I) =
        SPTbit(S,G)==TRUE
        AND (RPF_interface(S) != I)
        AND (I in ( ( joins(*,G) (-) prunes(S,G,rpt) )
                    (+) ( pim_include(*,G) (-) pim_exclude(S,G) )
                    (-) lost_assert(*,G)
                    (+) joins(S,G) (+) pim_include(S,G) ) )
According to the above formula for Could assert, once SPTbit is set, Could_assert has to be reevaluated. Otherwise could assert will never be true and PIM assert messages would not kick in at all

Problem:
   Once Assert election is over and winner is elected, the downstream router has to prune from the upstream LOSER if it has joined already and have to join with upstream elected WINNER.  This is how duplcate could be stopped by PIM Assert mechanism

pim_rpf_update function takes care of changing the rpf_ch if the
existing one is PIM_IFASSERT_I_AM_LOSER
