### PR TITLE
pathd: bad order of nai adjacencies for ipv6

### DIFF
--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -527,7 +527,7 @@ DEFPY(srte_segment_list_segment, srte_segment_list_segment_cmd,
 					 adj_src_ipv4, adj_dst_ipv4,
 					 adj_src_ipv6, adj_dst_ipv6,
 					 adj_src_ipv4_str, adj_dst_ipv4_str,
-					 adj_dst_ipv6_str, adj_src_ipv6_str);
+					 adj_src_ipv6_str, adj_dst_ipv6_str);
 		if (status != CMD_SUCCESS)
 			return status;
 	} else {


### PR DESCRIPTION
The order of nai adjacencies ipv6 addresses was wrong.
The src and the destination addresses were swapped.
Change it.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>