### PR TITLE
bgpd: Turn off thread when running `no bmp targets X`

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1619,6 +1619,8 @@ static void bmp_targets_put(struct bmp_targets *bt)
 	struct bmp *bmp;
 	struct bmp_active *ba;
 
+	THREAD_OFF(bt->t_stats);
+
 	frr_each_safe (bmp_actives, &bt->actives, ba)
 		bmp_active_put(ba);
 


### PR DESCRIPTION
Avoid use-after-free and prevent from crashing:

```
(gdb) bt
0  raise (sig=<optimized out>) at ../sysdeps/unix/sysv/linux/raise.c:50
1  0x00007f2a15c2c30d in core_handler (signo=11, siginfo=0x7fffb915e630, context=<optimized out>) at lib/sigevent.c:261
2  <signal handler called>
3  0x00007f2a156201e4 in bmp_stats (thread=<optimized out>) at bgpd/bgp_bmp.c:1330
4  0x00007f2a15c3d553 in thread_call (thread=thread@entry=0x7fffb915ebf0) at lib/thread.c:2001
5  0x00007f2a15bfa570 in frr_run (master=0x55c43a393ae0) at lib/libfrr.c:1196
6  0x000055c43930627c in main (argc=<optimized out>, argv=<optimized out>) at bgpd/bgp_main.c:519
(gdb)
```

Fixes https://github.com/FRRouting/frr/issues/10856

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>