### PR TITLE
debian: add dependency on binutils for `strings`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,8 @@ Vcs-Git: https://github.com/FRRouting/frr.git -b debian/master
 
 Package: frr
 Architecture: linux-any
-Depends: iproute2 | iproute,
+Depends: binutils,
+         iproute2 | iproute,
          logrotate (>= 3.2-11),
          lsof,
          ${misc:Depends},


### PR DESCRIPTION
frrinit.sh script uses `strings` utility, that is a part of `binutils`
package on Debian(-alikes). This package may not be installed,
especially on a stripped-down system for a router. If the package is not
installed and `strings` command is missing, `frrinit.sh` will
malfunction.

This commit adds Debian dependency on the `binutils` package.

Similar changes are probably needed for non-debian packaging too.

Signed-off-by: Eugene Crosser <crosser@average.org>