### PR TITLE
doc: Fix the link that points to Slack invitation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ lists:
 
 For chat, we currently use [Slack](https://frrouting.slack.com). You can join
 by clicking the "Slack" link under the
-[Participate](https://frrouting.org/#participate) section of our website.
+[Participate](https://frrouting.org/community) section of our website.
 
 
 Contributing


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>