### PR TITLE
zebra: optimization on the mac addition for evpn-mh

### DIFF
--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -2479,9 +2479,13 @@ void zebra_evpn_mac_gw_macip_add(struct interface *ifp,
 	if (zvrf && zvrf->zns)
 		local_ns_id = zvrf->zns->ns_id;
 
-	mac = zebra_evpn_mac_lookup(zevpn, macaddr);
-	if (!mac)
-		mac = zebra_evpn_mac_add(zevpn, macaddr);
+	if (!*macp) {
+		mac = zebra_evpn_mac_lookup(zevpn, macaddr);
+		if (!mac)
+			mac = zebra_evpn_mac_add(zevpn, macaddr);
+		*macp = mac;
+	} else
+		mac = *macp;
 
 	/* Set "local" forwarding info. */
 	zebra_evpn_mac_clear_fwd_info(mac);
@@ -2494,8 +2498,6 @@ void zebra_evpn_mac_gw_macip_add(struct interface *ifp,
 	mac->fwd_info.local.ifindex = ifp->ifindex;
 	mac->fwd_info.local.ns_id = local_ns_id;
 	mac->fwd_info.local.vid = vlan_id;
-
-	*macp = mac;
 }
 
 void zebra_evpn_mac_svi_del(struct interface *ifp, struct zebra_evpn *zevpn)
@@ -2548,7 +2550,6 @@ void zebra_evpn_mac_svi_add(struct interface *ifp, struct zebra_evpn *zevpn)
 				? true
 				: false;
 
-	mac = NULL;
 	zebra_evpn_mac_gw_macip_add(ifp, zevpn, NULL, &mac, &macaddr, 0, false);
 
 	new_bgp_ready = zebra_evpn_mac_is_ready_for_bgp(mac->flags);


### PR DESCRIPTION
When `zebra_evpn_mac_svi_add()` adds one found mac by                                                                                   
`zebra_evpn_mac_lookup()` and the found mac is without                           
svi flag, then call `zebra_evpn_mac_svi_add()` to create                         
one appropriate mac, but it will call `zebra_evpn_mac_lookup()`                  
the second time. So lookup twice, the procedure is redundant.                    
                                                                                 
Just an optimization for it, make sure only lookup once.                         
                                                                                 
Modify `zebra_evpn_mac_gw_macip_add()` to check the `macp`                       
parameter passed by caller, so it can distinguish whether                        
really need lookup or not.