### PR TITLE
zebra: Don't send uninited data to kernel on FreeBSD

### DIFF
--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -136,7 +136,7 @@ static int if_ioctl_ipv6(unsigned long request, caddr_t buffer)
 void if_get_metric(struct interface *ifp)
 {
 #ifdef SIOCGIFMETRIC
-	struct ifreq ifreq;
+	struct ifreq ifreq = {};
 
 	ifreq_set_name(&ifreq, ifp);
 
@@ -153,7 +153,7 @@ void if_get_metric(struct interface *ifp)
 /* get interface MTU */
 void if_get_mtu(struct interface *ifp)
 {
-	struct ifreq ifreq;
+	struct ifreq ifreq = {};
 
 	ifreq_set_name(&ifreq, ifp);
 
@@ -410,8 +410,8 @@ int if_unset_prefix_ctx(const struct zebra_dplane_ctx *ctx)
 void if_get_flags(struct interface *ifp)
 {
 	int ret;
-	struct ifreq ifreqflags;
-	struct ifreq ifreqdata;
+	struct ifreq ifreqflags = {};
+	struct ifreq ifreqdata = {};
 
 	ifreq_set_name(&ifreqflags, ifp);
 	ifreq_set_name(&ifreqdata, ifp);


### PR DESCRIPTION
When running zebra w/ valgrind, it was noticed that there
was a bunch of passing uninitialized data to the kernel:

==38194== Syscall param ioctl(generic) points to uninitialised byte(s)
==38194==    at 0x4CDF88A: ioctl (in /lib/libc.so.7)
==38194==    by 0x49A4031: vrf_ioctl (vrf.c:860)
==38194==    by 0x2AFE29: vrf_if_ioctl (ioctl.c:91)
==38194==    by 0x2AFF39: if_get_mtu (ioctl.c:161)
==38194==    by 0x2B12C3: ifm_read (kernel_socket.c:653)
==38194==    by 0x2A7F76: interface_list (if_sysctl.c:129)
==38194==    by 0x2E9958: zebra_ns_enable (zebra_ns.c:127)
==38194==    by 0x2E9958: zebra_ns_init (zebra_ns.c:214)
==38194==    by 0x2B3F82: main (main.c:401)
==38194==  Address 0x7fc000967 is on thread 1's stack
==38194==  in frame #3, created by if_get_mtu (ioctl.c:155)
==38194==
==38194== Syscall param ioctl(generic) points to uninitialised byte(s)
==38194==    at 0x4CDF88A: ioctl (in /lib/libc.so.7)
==38194==    by 0x49A4031: vrf_ioctl (vrf.c:860)
==38194==    by 0x2AFE29: vrf_if_ioctl (ioctl.c:91)
==38194==    by 0x2AFED9: if_get_metric (ioctl.c:143)
==38194==    by 0x2B12CB: ifm_read (kernel_socket.c:655)
==38194==    by 0x2A7F76: interface_list (if_sysctl.c:129)
==38194==    by 0x2E9958: zebra_ns_enable (zebra_ns.c:127)
==38194==    by 0x2E9958: zebra_ns_init (zebra_ns.c:214)
==38194==    by 0x2B3F82: main (main.c:401)
==38194==  Address 0x7fc000967 is on thread 1's stack
==38194==  in frame #3, created by if_get_metric (ioctl.c:137)
==38194==
==38194== Syscall param ioctl(generic) points to uninitialised byte(s)
==38194==    at 0x4CDF88A: ioctl (in /lib/libc.so.7)
==38194==    by 0x49A4031: vrf_ioctl (vrf.c:860)
==38194==    by 0x2AFE29: vrf_if_ioctl (ioctl.c:91)
==38194==    by 0x2B052D: if_get_flags (ioctl.c:419)
==38194==    by 0x2B1CF1: ifam_read (kernel_socket.c:930)
==38194==    by 0x2A7F57: interface_list (if_sysctl.c:132)
==38194==    by 0x2E9958: zebra_ns_enable (zebra_ns.c:127)
==38194==    by 0x2E9958: zebra_ns_init (zebra_ns.c:214)
==38194==    by 0x2B3F82: main (main.c:401)
==38194==  Address 0x7fc000707 is on thread 1's stack
==38194==  in frame #3, created by if_get_flags (ioctl.c:411)

Valgrind is no longer reporting these issues.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>