### PR TITLE
lib: Fix `terminal monitor` uninited memory usage on freebsd

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2033,6 +2033,7 @@ static int vtysh_do_pass_fd(struct vty *vty)
 	struct cmsghdr *cmh = CMSG_FIRSTHDR(&mh);
 	ssize_t ret;
 
+	memset(&u.buf, 0, sizeof(u.buf));
 	cmh->cmsg_level = SOL_SOCKET;
 	cmh->cmsg_type = SCM_RIGHTS;
 	cmh->cmsg_len = CMSG_LEN(sizeof(int));


### PR DESCRIPTION
When `terminal monitor` is issued I am seeing this for valgrind on freebsd:

2022/03/24 18:07:45 ZEBRA: [RHJDG-5FNSK][EC 100663304] can't open configuration file [/usr/local/etc/frr/zebra.conf]
==52993== Syscall param sendmsg(sendmsg.msg_control) points to uninitialised byte(s)
==52993==    at 0x4CE268A: _sendmsg (in /lib/libc.so.7)
==52993==    by 0x4B96245: ??? (in /lib/libthr.so.3)
==52993==    by 0x4CDF329: sendmsg (in /lib/libc.so.7)
==52993==    by 0x49A9994: vtysh_do_pass_fd (vty.c:2041)
==52993==    by 0x49A9994: vtysh_flush (vty.c:2070)
==52993==    by 0x499F4CE: thread_call (thread.c:2002)
==52993==    by 0x495D317: frr_run (libfrr.c:1196)
==52993==    by 0x2B4068: main (main.c:471)
==52993==  Address 0x7fc000864 is on thread 1's stack
==52993==  in frame #3, created by vtysh_flush (vty.c:2065)

Fix by initializing the memory to `0`

Signed-off-by: Donald Sharp <sharpd@nvidia.com>