### PR TITLE
lib: Prevent uninitialized bytes

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -239,7 +239,7 @@ void zlog_backtrace(int priority)
 {
 #ifdef HAVE_LIBUNWIND
 	char buf[100];
-	unw_cursor_t cursor;
+	unw_cursor_t cursor = {};
 	unw_context_t uc;
 	unw_word_t ip, off, sp;
 	Dl_info dlinfo;


### PR DESCRIPTION
When using zlog_backtrace I am seeing this:

==66286== Syscall param write(buf) points to uninitialised byte(s)
==66286==    at 0x4CDF48A: syscall (in /lib/libc.so.7)
==66286==    by 0x4A0D409: ??? (in /usr/local/lib/libunwind.so.8.0.1)
==66286==    by 0x4A0D694: ??? (in /usr/local/lib/libunwind.so.8.0.1)
==66286==    by 0x4A0E2F4: _ULx86_64_step (in /usr/local/lib/libunwind.so.8.0.1)
==66286==    by 0x49662DB: zlog_backtrace (log.c:250)
==66286==    by 0x2AFFA6: if_get_mtu (ioctl.c:163)
==66286==    by 0x2B2D9D: ifan_read (kernel_socket.c:457)
==66286==    by 0x2B2D9D: kernel_read (kernel_socket.c:1406)
==66286==    by 0x499F46E: thread_call (thread.c:2002)
==66286==    by 0x495D2B7: frr_run (libfrr.c:1196)
==66286==    by 0x2B4098: main (main.c:471)
==66286==  Address 0x7fc000000 is on thread 1's stack
==66286==  in frame #4, created by zlog_backtrace (log.c:239)
==66286==

Let's initialize some data

Signed-off-by: Donald Sharp <sharpd@nvidia.com>