### PR TITLE
bgpd: fix crash when using "show bgp vrf all all"

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12318,6 +12318,12 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
 	if (!idx)
 		return CMD_WARNING;
 
+	if (!bgp) {
+		vty_out(vty,
+			"Specified 'all' vrf's but this command currently only works per view/vrf\n");
+		return CMD_WARNING;
+	}
+
 	if (argv_find(argv, argc, "cidr-only", &idx))
 		sh_type = bgp_show_type_cidr_only;
 


### PR DESCRIPTION
"show bgp vrf all all" command causes bgpd to crash.
because bgp is NULL in bgp_vty_find_and_parse_afi_safi_bgp.

Fixes https://github.com/FRRouting/frr/issues/10876