### PR TITLE
bgpd: Fix crash for `show ip bgp vrf all all`

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12463,6 +12463,8 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
 					output_arg, show_flags,
 					rpki_target_state);
 	} else {
+		struct listnode *node;
+		struct bgp *abgp;
 		/* show <ip> bgp ipv4 all: AFI_IP, show <ip> bgp ipv6 all:
 		 * AFI_IP6 */
 
@@ -12474,66 +12476,80 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
 			afi = CHECK_FLAG(show_flags, BGP_SHOW_OPT_AFI_IP)
 				      ? AFI_IP
 				      : AFI_IP6;
-			FOREACH_SAFI (safi) {
-				if (!bgp_afi_safi_peer_exists(bgp, afi, safi))
-					continue;
+			for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, abgp)) {
+				FOREACH_SAFI (safi) {
+					if (!bgp_afi_safi_peer_exists(abgp, afi,
+								      safi))
+						continue;
 
-				if (uj) {
-					if (first)
-						first = false;
+					if (uj) {
+						if (first)
+							first = false;
+						else
+							vty_out(vty, ",\n");
+						vty_out(vty, "\"%s\":{\n",
+							get_afi_safi_str(afi,
+									 safi,
+									 true));
+					} else
+						vty_out(vty,
+							"\nFor address family: %s\n",
+							get_afi_safi_str(
+								afi, safi,
+								false));
+
+					if (community)
+						bgp_show_community(
+							vty, abgp, community,
+							exact_match, afi, safi,
+							show_flags);
 					else
-						vty_out(vty, ",\n");
-					vty_out(vty, "\"%s\":{\n",
-						get_afi_safi_str(afi, safi,
-								 true));
-				} else
-					vty_out(vty,
-						"\nFor address family: %s\n",
-						get_afi_safi_str(afi, safi,
-								 false));
-
-				if (community)
-					bgp_show_community(vty, bgp, community,
-							   exact_match, afi,
-							   safi, show_flags);
-				else
-					bgp_show(vty, bgp, afi, safi, sh_type,
-						 output_arg, show_flags,
-						 rpki_target_state);
-				if (uj)
-					vty_out(vty, "}\n");
+						bgp_show(vty, abgp, afi, safi,
+							 sh_type, output_arg,
+							 show_flags,
+							 rpki_target_state);
+					if (uj)
+						vty_out(vty, "}\n");
+				}
 			}
 		} else {
 			/* show <ip> bgp all: for each AFI and SAFI*/
-			FOREACH_AFI_SAFI (afi, safi) {
-				if (!bgp_afi_safi_peer_exists(bgp, afi, safi))
-					continue;
+			for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, abgp)) {
+				FOREACH_AFI_SAFI (afi, safi) {
+					if (!bgp_afi_safi_peer_exists(abgp, afi,
+								      safi))
+						continue;
 
-				if (uj) {
-					if (first)
-						first = false;
+					if (uj) {
+						if (first)
+							first = false;
+						else
+							vty_out(vty, ",\n");
+
+						vty_out(vty, "\"%s\":{\n",
+							get_afi_safi_str(afi,
+									 safi,
+									 true));
+					} else
+						vty_out(vty,
+							"\nFor address family: %s\n",
+							get_afi_safi_str(
+								afi, safi,
+								false));
+
+					if (community)
+						bgp_show_community(
+							vty, abgp, community,
+							exact_match, afi, safi,
+							show_flags);
 					else
-						vty_out(vty, ",\n");
-
-					vty_out(vty, "\"%s\":{\n",
-						get_afi_safi_str(afi, safi,
-								 true));
-				} else
-					vty_out(vty,
-						"\nFor address family: %s\n",
-						get_afi_safi_str(afi, safi,
-								 false));
-
-				if (community)
-					bgp_show_community(vty, bgp, community,
-							   exact_match, afi,
-							   safi, show_flags);
-				else
-					bgp_show(vty, bgp, afi, safi, sh_type,
-						 output_arg, show_flags,
-						 rpki_target_state);
-				if (uj)
-					vty_out(vty, "}\n");
+						bgp_show(vty, abgp, afi, safi,
+							 sh_type, output_arg,
+							 show_flags,
+							 rpki_target_state);
+					if (uj)
+						vty_out(vty, "}\n");
+				}
 			}
 		}
 		if (uj)


### PR DESCRIPTION
When `all` is specified BGP pointer is always NULL, we need to iterate over
all instances separately.

```
BGP[170822]: Received signal 11 at 1648199394 (si_addr 0x30, PC 0x562e96597090); aborting...
BGP[170822]: /usr/local/lib/libfrr.so.0(zlog_backtrace_sigsafe+0x5e) [0x7f378a57ff6e]
BGP[170822]: /usr/local/lib/libfrr.so.0(zlog_signal+0xe6) [0x7f378a580146]
BGP[170822]: /usr/local/lib/libfrr.so.0(+0xcd4c2) [0x7f378a5aa4c2]
BGP[170822]: /lib/x86_64-linux-gnu/libpthread.so.0(+0x14140) [0x7f378a33e140]
BGP[170822]: /usr/lib/frr/bgpd(bgp_afi_safi_peer_exists+0) [0x562e96597090]
BGP[170822]: /usr/lib/frr/bgpd(+0x15c3b8) [0x562e9654a3b8]
BGP[170822]: /usr/local/lib/libfrr.so.0(+0x75a9e) [0x7f378a552a9e]
BGP[170822]: /usr/local/lib/libfrr.so.0(cmd_execute_command+0x5d) [0x7f378a552e2d]
BGP[170822]: /usr/local/lib/libfrr.so.0(cmd_execute+0xc0) [0x7f378a553070]
BGP[170822]: /usr/local/lib/libfrr.so.0(+0xe3697) [0x7f378a5c0697]
BGP[170822]: /usr/local/lib/libfrr.so.0(+0xe3db1) [0x7f378a5c0db1]
BGP[170822]: /usr/local/lib/libfrr.so.0(+0xe6c30) [0x7f378a5c3c30]
BGP[170822]: /usr/local/lib/libfrr.so.0(thread_call+0x73) [0x7f378a5bb743]
BGP[170822]: /usr/local/lib/libfrr.so.0(frr_run+0xd0) [0x7f378a578750]
BGP[170822]: /usr/lib/frr/bgpd(main+0x344) [0x562e964cf3f4]
BGP[170822]: /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xea) [0x7f378a18bd0a]
BGP[170822]: /usr/lib/frr/bgpd(_start+0x2a) [0x562e964d10ea]
```

Fixes https://github.com/FRRouting/frr/issues/10876

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>