### PR TITLE
bgpd: Fix crash for `show ip bgp vrf all all neighbors 192.168.0.1 ...`

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13961,6 +13961,8 @@ DEFPY (show_ip_bgp_instance_neighbor_advertised_route,
 	int idx = 0;
 	bool first = true;
 	uint16_t show_flags = 0;
+	struct listnode *node;
+	struct bgp *abgp;
 
 	if (uj) {
 		argc--;
@@ -14012,42 +14014,52 @@ DEFPY (show_ip_bgp_instance_neighbor_advertised_route,
 	    || CHECK_FLAG(show_flags, BGP_SHOW_OPT_AFI_IP6)) {
 		afi = CHECK_FLAG(show_flags, BGP_SHOW_OPT_AFI_IP) ? AFI_IP
 								  : AFI_IP6;
-		FOREACH_SAFI (safi) {
-			if (!bgp_afi_safi_peer_exists(bgp, afi, safi))
-				continue;
+		for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, abgp)) {
+			FOREACH_SAFI (safi) {
+				if (!bgp_afi_safi_peer_exists(abgp, afi, safi))
+					continue;
 
-			if (uj) {
-				if (first)
-					first = false;
-				else
-					vty_out(vty, ",\n");
-				vty_out(vty, "\"%s\":",
-					get_afi_safi_str(afi, safi, true));
-			} else
-				vty_out(vty, "\nFor address family: %s\n",
-					get_afi_safi_str(afi, safi, false));
+				if (uj) {
+					if (first)
+						first = false;
+					else
+						vty_out(vty, ",\n");
+					vty_out(vty, "\"%s\":",
+						get_afi_safi_str(afi, safi,
+								 true));
+				} else
+					vty_out(vty,
+						"\nFor address family: %s\n",
+						get_afi_safi_str(afi, safi,
+								 false));
 
-			peer_adj_routes(vty, peer, afi, safi, type, rmap_name,
-					show_flags);
+				peer_adj_routes(vty, peer, afi, safi, type,
+						rmap_name, show_flags);
+			}
 		}
 	} else {
-		FOREACH_AFI_SAFI (afi, safi) {
-			if (!bgp_afi_safi_peer_exists(bgp, afi, safi))
-				continue;
+		for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, abgp)) {
+			FOREACH_AFI_SAFI (afi, safi) {
+				if (!bgp_afi_safi_peer_exists(abgp, afi, safi))
+					continue;
 
-			if (uj) {
-				if (first)
-					first = false;
-				else
-					vty_out(vty, ",\n");
-				vty_out(vty, "\"%s\":",
-					get_afi_safi_str(afi, safi, true));
-			} else
-				vty_out(vty, "\nFor address family: %s\n",
-					get_afi_safi_str(afi, safi, false));
+				if (uj) {
+					if (first)
+						first = false;
+					else
+						vty_out(vty, ",\n");
+					vty_out(vty, "\"%s\":",
+						get_afi_safi_str(afi, safi,
+								 true));
+				} else
+					vty_out(vty,
+						"\nFor address family: %s\n",
+						get_afi_safi_str(afi, safi,
+								 false));
 
-			peer_adj_routes(vty, peer, afi, safi, type, rmap_name,
-					show_flags);
+				peer_adj_routes(vty, peer, afi, safi, type,
+						rmap_name, show_flags);
+			}
 		}
 	}
 	if (uj)


### PR DESCRIPTION
When `all` is specified BGP pointer is always NULL, we need to iterate over
all instances separately.

```
Received signal 11 at 1648199394 (si_addr 0x30, PC 0x562e96597090); aborting...
 /usr/local/lib/libfrr.so.0(zlog_backtrace_sigsafe+0x5e) [0x7f378a57ff6e]
 /usr/local/lib/libfrr.so.0(zlog_signal+0xe6) [0x7f378a580146]
 /usr/local/lib/libfrr.so.0(+0xcd4c2) [0x7f378a5aa4c2]
 /lib/x86_64-linux-gnu/libpthread.so.0(+0x14140) [0x7f378a33e140]
 /usr/lib/frr/bgpd(bgp_afi_safi_peer_exists+0) [0x562e96597090]
 /usr/lib/frr/bgpd(+0x15c3b8) [0x562e9654a3b8]
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>