### PR TITLE
pim6d: send IPv6 PIM packets

### DIFF
--- a/pimd/pim6_stubs.c
+++ b/pimd/pim6_stubs.c
@@ -54,37 +54,6 @@ void zclient_lookup_free(void)
 }
 
 /*
- * packet handling
- */
-int pim_msg_send(int fd, pim_addr src, pim_addr dst, uint8_t *pim_msg,
-		 int pim_msg_size, const char *ifname)
-{
-	return 0;
-}
-
-int pim_hello_send(struct interface *ifp, uint16_t holdtime)
-{
-	return -1;
-}
-
-void pim_hello_restart_now(struct interface *ifp)
-{
-}
-
-void pim_hello_restart_triggered(struct interface *ifp)
-{
-}
-
-int pim_sock_add(struct interface *ifp)
-{
-	return -1;
-}
-
-void pim_sock_delete(struct interface *ifp, const char *delete_message)
-{
-}
-
-/*
  * PIM register
  */
 void pim_register_join(struct pim_upstream *up)
@@ -121,12 +90,31 @@ struct bsgrp_node *pim_bsm_get_bsgrp_node(struct bsm_scope *scope,
 void pim_bsm_write_config(struct vty *vty, struct interface *ifp)
 {
 }
+
+int pim_bsm_process(struct interface *ifp, pim_sgaddr *sg, uint8_t *buf,
+		    uint32_t buf_size, bool no_fwd)
+{
+	return 0;
+}
+
 void pim_register_send(const uint8_t *buf, int buf_size, pim_addr src,
 		       struct pim_rpf *rpg, int null_register,
 		       struct pim_upstream *up)
 {
 }
+
 void pim_register_stop_send(struct interface *ifp, pim_sgaddr *sg, pim_addr src,
 			    pim_addr originator)
 {
+}
+
+int pim_register_recv(struct interface *ifp, pim_addr dest_addr,
+		      pim_addr src_addr, uint8_t *tlv_buf, int tlv_buf_size)
+{
+	return 0;
+}
+
+int pim_register_stop_recv(struct interface *ifp, uint8_t *buf, int buf_size)
+{
+	return 0;
 }

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -338,6 +338,7 @@ int pim_assert_build_msg(uint8_t *pim_msg, int buf_size, struct interface *ifp,
 			 uint32_t metric_preference, uint32_t route_metric,
 			 uint32_t rpt_bit_flag)
 {
+	struct pim_interface *pim_ifp = ifp->info;
 	uint8_t *buf_pastend = pim_msg + buf_size;
 	uint8_t *pim_msg_curr;
 	int pim_msg_size;
@@ -380,7 +381,9 @@ int pim_assert_build_msg(uint8_t *pim_msg, int buf_size, struct interface *ifp,
 	  Add PIM header
 	*/
 	pim_msg_size = pim_msg_curr - pim_msg;
-	pim_msg_build_header(pim_msg, pim_msg_size, PIM_MSG_TYPE_ASSERT, false);
+	pim_msg_build_header(pim_ifp->primary_address,
+			     qpim_all_pim_routers_addr, pim_msg, pim_msg_size,
+			     PIM_MSG_TYPE_ASSERT, false);
 
 	return pim_msg_size;
 }

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -187,9 +187,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 
 	ifp->info = pim_ifp;
 
-#if PIM_IPV == 4
 	pim_sock_reset(ifp);
-#endif
 
 	pim_if_add_vif(ifp, ispimreg, is_vxlan_term);
 	pim_ifp->pim->mcast_if_count++;
@@ -1751,7 +1749,6 @@ static int pim_ifp_down(struct interface *ifp)
 		*/
 		pim_if_addr_del_all(ifp);
 
-#if PIM_IPV == 4
 		/*
 		  pim_sock_delete() closes the socket, stops read and timer
 		  threads,
@@ -1760,7 +1757,6 @@ static int pim_ifp_down(struct interface *ifp)
 		if (ifp->info) {
 			pim_sock_delete(ifp, "link down");
 		}
-#endif
 	}
 
 	if (ifp->info) {

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -488,7 +488,9 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 
 		group_size = pim_msg_get_jp_group_size(group->sources);
 		if (group_size > packet_left) {
-			pim_msg_build_header(pim_msg, packet_size,
+			pim_msg_build_header(pim_ifp->primary_address,
+					     qpim_all_pim_routers_addr, pim_msg,
+					     packet_size,
 					     PIM_MSG_TYPE_JOIN_PRUNE, false);
 			if (pim_msg_send(pim_ifp->pim_sock_fd,
 					 pim_ifp->primary_address,
@@ -544,7 +546,9 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 		grp = (struct pim_jp_groups *)curr_ptr;
 		if (packet_left < sizeof(struct pim_jp_groups)
 		    || msg->num_groups == 255) {
-			pim_msg_build_header(pim_msg, packet_size,
+			pim_msg_build_header(pim_ifp->primary_address,
+					     qpim_all_pim_routers_addr, pim_msg,
+					     packet_size,
 					     PIM_MSG_TYPE_JOIN_PRUNE, false);
 			if (pim_msg_send(pim_ifp->pim_sock_fd,
 					 pim_ifp->primary_address,
@@ -564,8 +568,9 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 
 	if (!new_packet) {
 		// msg->num_groups = htons (msg->num_groups);
-		pim_msg_build_header(pim_msg, packet_size,
-				     PIM_MSG_TYPE_JOIN_PRUNE, false);
+		pim_msg_build_header(
+			pim_ifp->primary_address, qpim_all_pim_routers_addr,
+			pim_msg, packet_size, PIM_MSG_TYPE_JOIN_PRUNE, false);
 		if (pim_msg_send(pim_ifp->pim_sock_fd, pim_ifp->primary_address,
 				 qpim_all_pim_routers_addr, pim_msg,
 				 packet_size,

--- a/pimd/pim_msg.h
+++ b/pimd/pim_msg.h
@@ -216,8 +216,9 @@ static inline pim_sgaddr pim_sgaddr_from_iphdr(const void *iphdr)
 }
 #endif
 
-void pim_msg_build_header(uint8_t *pim_msg, size_t pim_msg_size,
-			  uint8_t pim_msg_type, bool no_fwd);
+void pim_msg_build_header(pim_addr src, pim_addr dst, uint8_t *pim_msg,
+			  size_t pim_msg_size, uint8_t pim_msg_type,
+			  bool no_fwd);
 uint8_t *pim_msg_addr_encode_ipv4_ucast(uint8_t *buf, struct in_addr addr);
 uint8_t *pim_msg_addr_encode_ipv4_group(uint8_t *buf, struct in_addr addr);
 

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -704,7 +704,9 @@ static int hello_send(struct interface *ifp, uint16_t holdtime)
 	assert(pim_msg_size >= PIM_PIM_MIN_LEN);
 	assert(pim_msg_size <= PIM_PIM_BUFSIZE_WRITE);
 
-	pim_msg_build_header(pim_msg, pim_msg_size, PIM_MSG_TYPE_HELLO, false);
+	pim_msg_build_header(pim_ifp->primary_address,
+			     qpim_all_pim_routers_addr, pim_msg, pim_msg_size,
+			     PIM_MSG_TYPE_HELLO, false);
 
 	if (pim_msg_send(pim_ifp->pim_sock_fd, pim_ifp->primary_address,
 			 qpim_all_pim_routers_addr, pim_msg, pim_msg_size,

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -88,7 +88,8 @@ void pim_register_stop_send(struct interface *ifp, pim_sgaddr *sg,
 	length = pim_encode_addr_ucast(b1, sg->src);
 	b1length += length;
 
-	pim_msg_build_header(buffer, b1length + PIM_MSG_REGISTER_STOP_LEN,
+	pim_msg_build_header(src, originator, buffer,
+			     b1length + PIM_MSG_REGISTER_STOP_LEN,
 			     PIM_MSG_TYPE_REG_STOP, false);
 
 	pinfo = (struct pim_interface *)ifp->info;
@@ -261,7 +262,8 @@ void pim_register_send(const uint8_t *buf, int buf_size, struct in_addr src,
 
 	memcpy(b1, (const unsigned char *)buf, buf_size);
 
-	pim_msg_build_header(buffer, buf_size + PIM_MSG_REGISTER_LEN,
+	pim_msg_build_header(src, rpg->rpf_addr.u.prefix4, buffer,
+			     buf_size + PIM_MSG_REGISTER_LEN,
 			     PIM_MSG_TYPE_REGISTER, false);
 
 	++pinfo->pim_ifstat_reg_send;

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -39,6 +39,7 @@ pim_common = \
 	pimd/pim_neighbor.c \
 	pimd/pim_nht.c \
 	pimd/pim_oil.c \
+	pimd/pim_pim.c \
 	pimd/pim_routemap.c \
 	pimd/pim_rp.c \
 	pimd/pim_rpf.c \
@@ -72,7 +73,6 @@ pimd_pimd_SOURCES = \
 	pimd/pim_msdp.c \
 	pimd/pim_msdp_packet.c \
 	pimd/pim_msdp_socket.c \
-	pimd/pim_pim.c \
 	pimd/pim_register.c \
 	pimd/pim_signals.c \
 	pimd/pim_zlookup.c \


### PR DESCRIPTION
Remaining bits necessary to get PIM packets sent out for IPv6. Manually tested & working.

NB: this PR is on top of PR #10677 