### PR TITLE
zebra: Note when the netlink DUMP command is interrupted

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1016,6 +1016,18 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 					return err;
 			}
 
+			/*
+			 * What is the right thing to do?  The kernel
+			 * is telling us that the dump request was interrupted
+			 * and we more than likely are out of luck and have
+			 * missed data from the kernel.  At this point in time
+			 * lets just note that this is happening.
+			 */
+			if (h->nlmsg_flags & NLM_F_DUMP_INTR)
+				flog_err(
+					EC_ZEBRA_NETLINK_BAD_SEQUENCE,
+					"netlink recvmsg: The Dump request was interrupted");
+
 			/* OK we got netlink message. */
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug(


### PR DESCRIPTION
There exists code paths in the linux kernel where a dump command
will be interrupted( I am not sure I understand what this really
means ) and the data sent back from the kernel is wrong or incomplete.

At this point in time I am not 100% certain what should be done, but
let's start noticing that this has happened so we can formulate a plan
or allow the end operator to know bad stuff is a foot at the circle K.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>