### PR TITLE
lib: Ensure order of operations is expected with SECONDS

### DIFF
--- a/lib/monotime.h
+++ b/lib/monotime.h
@@ -81,9 +81,9 @@ static inline time_t monotime(struct timeval *tvo)
 	return ts.tv_sec;
 }
 
-#define ONE_DAY_SECOND 60*60*24
-#define ONE_WEEK_SECOND ONE_DAY_SECOND*7
-#define ONE_YEAR_SECOND ONE_DAY_SECOND*365
+#define ONE_DAY_SECOND (60 * 60 * 24)
+#define ONE_WEEK_SECOND (ONE_DAY_SECOND * 7)
+#define ONE_YEAR_SECOND (ONE_DAY_SECOND * 365)
 
 /* the following two return microseconds, not time_t!
  *


### PR DESCRIPTION
These 3 values:
ONE_DAY_SECOND
ONE_WEEK_SECOND
ONE_YEAR_SECOND

Are defined based upon the number of seconds.  Unfortunately doing math
on these values say something like:

days = t->tv_sec / ONE_DAY_SECOND;

Once you go over about a day causes the order of operations to cause the multiplication
to get messed up:

204		if (!t)
(gdb) n
207		w = d = h = m = ms = 0;
(gdb) set t->tv_sec = ONE_DAY_SECOND + 30
(gdb) n
208		memset(buf, 0, size);
(gdb)
210		us = t->tv_usec;
(gdb)
211		if (us >= 1000) {
(gdb)
212			ms = us / 1000;
(gdb)
213			us %= 1000;
(gdb)
217		if (ms >= 1000) {
(gdb)
222		if (t->tv_sec > ONE_WEEK_SECOND) {
(gdb)
227		if (t->tv_sec > ONE_DAY_SECOND) {
(gdb)
228			d = t->tv_sec / ONE_DAY_SECOND;
(gdb) n
229			t->tv_sec -= d * ONE_DAY_SECOND;
(gdb) n
232		if (t->tv_sec >= HOUR_IN_SECONDS) {
(gdb) p d
$6 = 2073600
(gdb) p t->tv_sec
$7 = -179158953570
(gdb)

Converting to adding paranthesis around around the ONE_DAY_SECOND causes
the order of operations to work as expected.

Fixes: #10880
Signed-off-by: Donald Sharp <sharpd@nvidia.com>