### PR TITLE
babeld: Rehook up interface up events

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -60,20 +60,9 @@ static void babel_interface_free (babel_interface_nfo *bi);
 
 static vector babel_enable_if;                 /* enable interfaces (by cmd). */
 
-int
-babel_interface_up (ZAPI_CALLBACK_ARGS)
+int babel_ifp_up(struct interface *ifp)
 {
-    struct stream *s = NULL;
-    struct interface *ifp = NULL;
-
     debugf(BABEL_DEBUG_IF, "receive a 'interface up'");
-
-    s = zclient->ibuf;
-    ifp = zebra_interface_state_read(s, vrf_id); /* it updates iflist */
-
-    if (ifp == NULL) {
-        return 0;
-    }
 
     interface_recalculate(ifp);
     return 0;
@@ -1233,11 +1222,6 @@ DEFUN (show_babel_parameters,
         config_show_distribute(vty, babel_ctx->distribute_ctx);
     }
     return CMD_SUCCESS;
-}
-
-int babel_ifp_up(struct interface *ifp)
-{
-	return 0;
 }
 
 void


### PR DESCRIPTION
When babeld was switched over to the zapi
interface up/down callbacks the interface up
event was not properly put back in.

Fixes: #10893
Signed-off-by: Donald Sharp <sharpd@nvidia.com>