### PR TITLE
zebra,staticd,*: SAFI_MULTICAST NHT groundwork

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -889,8 +889,9 @@ static void sendmsg_zebra_rnh(struct bgp_nexthop_cache *bnc, int command)
 			   zserv_command_string(command), &bnc->prefix,
 			   bnc->bgp->name_pretty);
 
-	ret = zclient_send_rnh(zclient, command, &bnc->prefix, exact_match,
-			       resolve_via_default, bnc->bgp->vrf_id);
+	ret = zclient_send_rnh(zclient, command, &bnc->prefix, SAFI_UNICAST,
+			       exact_match, resolve_via_default,
+			       bnc->bgp->vrf_id);
 	if (ret == ZCLIENT_SEND_FAILURE) {
 		flog_warn(EC_BGP_ZEBRA_SEND,
 			  "sendmsg_nexthop: zclient_send_message() failed");

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -768,9 +768,9 @@ static void zclient_connect(struct thread *t)
 }
 
 enum zclient_send_status zclient_send_rnh(struct zclient *zclient, int command,
-					  const struct prefix *p,
-					  bool connected,
-					  bool resolve_via_def, vrf_id_t vrf_id)
+					  const struct prefix *p, safi_t safi,
+					  bool connected, bool resolve_via_def,
+					  vrf_id_t vrf_id)
 {
 	struct stream *s;
 
@@ -779,7 +779,7 @@ enum zclient_send_status zclient_send_rnh(struct zclient *zclient, int command,
 	zclient_create_header(s, command, vrf_id);
 	stream_putc(s, (connected) ? 1 : 0);
 	stream_putc(s, (resolve_via_def) ? 1 : 0);
-	stream_putw(s, SAFI_UNICAST);
+	stream_putw(s, safi);
 	stream_putw(s, PREFIX_FAMILY(p));
 	stream_putc(s, p->prefixlen);
 	switch (PREFIX_FAMILY(p)) {

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1071,7 +1071,8 @@ extern enum zclient_send_status zclient_route_send(uint8_t, struct zclient *,
 						   struct zapi_route *);
 extern enum zclient_send_status
 zclient_send_rnh(struct zclient *zclient, int command, const struct prefix *p,
-		 bool connected, bool resolve_via_default, vrf_id_t vrf_id);
+		 safi_t safi, bool connected, bool resolve_via_default,
+		 vrf_id_t vrf_id);
 int zapi_nexthop_encode(struct stream *s, const struct zapi_nexthop *api_nh,
 			uint32_t api_flags, uint32_t api_message);
 extern int zapi_route_encode(uint8_t, struct stream *, struct zapi_route *);

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -155,8 +155,8 @@ void ospf6_zebra_import_default_route(struct ospf6 *ospf6, bool unreg)
 			   zserv_command_string(command), &prefix,
 			   ospf6->vrf_id);
 
-	if (zclient_send_rnh(zclient, command, &prefix, false, true,
-			     ospf6->vrf_id)
+	if (zclient_send_rnh(zclient, command, &prefix, SAFI_UNICAST, false,
+			     true, ospf6->vrf_id)
 	    == ZCLIENT_SEND_FAILURE)
 		flog_err(EC_LIB_ZAPI_SOCKET, "%s: zclient_send_rnh() failed",
 			 __func__);

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -485,7 +485,8 @@ void pbr_send_rnh(struct nexthop *nhop, bool reg)
 		break;
 	}
 
-	if (zclient_send_rnh(zclient, command, &p, false, false, nhop->vrf_id)
+	if (zclient_send_rnh(zclient, command, &p, SAFI_UNICAST, false, false,
+			     nhop->vrf_id)
 	    == ZCLIENT_SEND_FAILURE) {
 		zlog_warn("%s: Failure to send nexthop to zebra", __func__);
 	}

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -55,7 +55,7 @@ void pim_sendmsg_zebra_rnh(struct pim_instance *pim, struct zclient *zclient,
 	int ret;
 
 	p = &(pnc->rpf.rpf_addr);
-	ret = zclient_send_rnh(zclient, command, p, false, false,
+	ret = zclient_send_rnh(zclient, command, p, SAFI_UNICAST, false, false,
 			       pim->vrf->vrf_id);
 	if (ret == ZCLIENT_SEND_FAILURE)
 		zlog_warn("sendmsg_nexthop: zclient_send_message() failed");

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -631,7 +631,8 @@ void sharp_zebra_nexthop_watch(struct prefix *p, vrf_id_t vrf_id, bool import,
 	if (!watch)
 		command = ZEBRA_NEXTHOP_UNREGISTER;
 
-	if (zclient_send_rnh(zclient, command, p, connected, false, vrf_id)
+	if (zclient_send_rnh(zclient, command, p, SAFI_UNICAST, connected,
+			     false, vrf_id)
 	    == ZCLIENT_SEND_FAILURE)
 		zlog_warn("%s: Failure to send nexthop to zebra", __func__);
 }

--- a/staticd/static_nht.c
+++ b/staticd/static_nht.c
@@ -101,18 +101,15 @@ static void static_nht_update_safi(struct prefix *sp, struct prefix *nhp,
 	}
 }
 
-void static_nht_update(struct prefix *sp, struct prefix *nhp,
-		       uint32_t nh_num, afi_t afi, vrf_id_t nh_vrf_id)
+void static_nht_update(struct prefix *sp, struct prefix *nhp, uint32_t nh_num,
+		       afi_t afi, safi_t safi, vrf_id_t nh_vrf_id)
 {
 
 	struct vrf *vrf;
 
-	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-		static_nht_update_safi(sp, nhp, nh_num, afi, SAFI_UNICAST,
-				       vrf, nh_vrf_id);
-		static_nht_update_safi(sp, nhp, nh_num, afi, SAFI_MULTICAST,
-				       vrf, nh_vrf_id);
-	}
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
+		static_nht_update_safi(sp, nhp, nh_num, afi, safi, vrf,
+				       nh_vrf_id);
 }
 
 static void static_nht_reset_start_safi(struct prefix *nhp, afi_t afi,
@@ -166,16 +163,13 @@ static void static_nht_reset_start_safi(struct prefix *nhp, afi_t afi,
 	}
 }
 
-void static_nht_reset_start(struct prefix *nhp, afi_t afi, vrf_id_t nh_vrf_id)
+void static_nht_reset_start(struct prefix *nhp, afi_t afi, safi_t safi,
+			    vrf_id_t nh_vrf_id)
 {
 	struct vrf *vrf;
 
-	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-		static_nht_reset_start_safi(nhp, afi, SAFI_UNICAST,
-					    vrf, nh_vrf_id);
-		static_nht_reset_start_safi(nhp, afi, SAFI_MULTICAST,
-					    vrf, nh_vrf_id);
-	}
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
+		static_nht_reset_start_safi(nhp, afi, safi, vrf, nh_vrf_id);
 }
 
 static void static_nht_mark_state_safi(struct prefix *sp, afi_t afi,
@@ -212,7 +206,7 @@ static void static_nht_mark_state_safi(struct prefix *sp, afi_t afi,
 	route_unlock_node(rn);
 }
 
-void static_nht_mark_state(struct prefix *sp, vrf_id_t vrf_id,
+void static_nht_mark_state(struct prefix *sp, safi_t safi, vrf_id_t vrf_id,
 			   enum static_install_states state)
 {
 	struct vrf *vrf;
@@ -226,6 +220,5 @@ void static_nht_mark_state(struct prefix *sp, vrf_id_t vrf_id,
 	if (!vrf || !vrf->info)
 		return;
 
-	static_nht_mark_state_safi(sp, afi, SAFI_UNICAST, vrf, state);
-	static_nht_mark_state_safi(sp, afi, SAFI_MULTICAST, vrf, state);
+	static_nht_mark_state_safi(sp, afi, safi, vrf, state);
 }

--- a/staticd/static_nht.h
+++ b/staticd/static_nht.h
@@ -37,19 +37,21 @@ extern "C" {
  * vrf_id -> The vrf the nexthop is in.
  */
 extern void static_nht_update(struct prefix *sp, struct prefix *nhp,
-			      uint32_t nh_num, afi_t afi, vrf_id_t vrf_id);
+			      uint32_t nh_num, afi_t afi, safi_t safi,
+			      vrf_id_t vrf_id);
 
 /*
  * For the given tracked nexthop, nhp, mark all routes that use
  * this route as in starting state again.
  */
-extern void static_nht_reset_start(struct prefix *nhp, afi_t afi,
+extern void static_nht_reset_start(struct prefix *nhp, afi_t afi, safi_t safi,
 				   vrf_id_t nh_vrf_id);
 
 /*
  * For the given prefix, sp, mark it as in a particular state
  */
-extern void static_nht_mark_state(struct prefix *sp, vrf_id_t vrf_id,
+extern void static_nht_mark_state(struct prefix *sp, safi_t safi,
+				  vrf_id_t vrf_id,
 				  enum static_install_states state);
 
 /*

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -330,8 +330,8 @@ void static_zebra_nht_register(struct static_nexthop *nh, bool reg)
 	DEBUGD(&static_dbg_route, "%s nexthop(%pFX) for %pRN",
 	       reg ? "Registering" : "Unregistering", &p, rn);
 
-	if (zclient_send_rnh(zclient, cmd, &p, false, false, nh->nh_vrf_id)
-	    == ZCLIENT_SEND_FAILURE)
+	if (zclient_send_rnh(zclient, cmd, &p, SAFI_UNICAST, false, false,
+			     nh->nh_vrf_id) == ZCLIENT_SEND_FAILURE)
 		zlog_warn("%s: Failure to send nexthop to zebra", __func__);
 }
 /*

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1215,7 +1215,7 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 				p.family);
 			return;
 		}
-		rnh = zebra_add_rnh(&p, zvrf_id(zvrf), &exist);
+		rnh = zebra_add_rnh(&p, zvrf_id(zvrf), safi, &exist);
 		if (!rnh)
 			return;
 

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -768,7 +768,7 @@ static void zebra_rnh_clear_nhc_flag(struct zebra_vrf *zvrf, afi_t afi,
  * of a particular VRF and address-family or a specific prefix.
  */
 void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
-			struct prefix *p, safi_t safi)
+			const struct prefix *p, safi_t safi)
 {
 	struct route_table *rnh_table;
 	struct route_node *nrn;
@@ -803,7 +803,7 @@ void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 }
 
 void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, safi_t safi,
-			   struct vty *vty, struct prefix *p)
+			   struct vty *vty, const struct prefix *p)
 {
 	struct route_table *table;
 	struct route_node *rn;

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -802,13 +802,13 @@ void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 	}
 }
 
-void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
-			   struct prefix *p)
+void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, safi_t safi,
+			   struct vty *vty, struct prefix *p)
 {
 	struct route_table *table;
 	struct route_node *rn;
 
-	table = get_rnh_table(vrfid, afi, SAFI_UNICAST);
+	table = get_rnh_table(vrfid, afi, safi);
 	if (!table) {
 		if (IS_ZEBRA_DEBUG_NHT)
 			zlog_debug("print_rnhs: rnh table not found");

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1337,7 +1337,7 @@ static void print_rnh(struct route_node *rn, struct vty *vty)
 	vty_out(vty, "\n");
 }
 
-static int zebra_cleanup_rnh_client(vrf_id_t vrf_id, afi_t afi,
+static int zebra_cleanup_rnh_client(vrf_id_t vrf_id, afi_t afi, safi_t safi,
 				    struct zserv *client)
 {
 	struct route_table *ntable;
@@ -1352,7 +1352,7 @@ static int zebra_cleanup_rnh_client(vrf_id_t vrf_id, afi_t afi,
 			   zebra_route_string(client->proto), afi2str(afi));
 	}
 
-	ntable = get_rnh_table(vrf_id, afi, SAFI_UNICAST);
+	ntable = get_rnh_table(vrf_id, afi, safi);
 	if (!ntable) {
 		zlog_debug("cleanup_rnh_client: rnh table not found");
 		return -1;
@@ -1377,9 +1377,14 @@ static int zebra_client_cleanup_rnh(struct zserv *client)
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
 		zvrf = vrf->info;
 		if (zvrf) {
-			zebra_cleanup_rnh_client(zvrf_id(zvrf), AFI_IP, client);
+			zebra_cleanup_rnh_client(zvrf_id(zvrf), AFI_IP,
+						 SAFI_UNICAST, client);
+			zebra_cleanup_rnh_client(zvrf_id(zvrf), AFI_IP,
+						 SAFI_MULTICAST, client);
 			zebra_cleanup_rnh_client(zvrf_id(zvrf), AFI_IP6,
-						 client);
+						 SAFI_UNICAST, client);
+			zebra_cleanup_rnh_client(zvrf_id(zvrf), AFI_IP6,
+						 SAFI_MULTICAST, client);
 		}
 	}
 

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -132,13 +132,13 @@ static void zebra_rnh_store_in_routing_table(struct rnh *rnh)
 	route_unlock_node(rn);
 }
 
-struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid, bool *exists)
+struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid, safi_t safi,
+			  bool *exists)
 {
 	struct route_table *table;
 	struct route_node *rn;
 	struct rnh *rnh = NULL;
 	afi_t afi = family2afi(p->family);
-	safi_t safi = SAFI_UNICAST;
 
 	if (IS_ZEBRA_DEBUG_NHT) {
 		struct vrf *vrf = vrf_lookup_by_id(vrfid);
@@ -345,7 +345,7 @@ void zebra_register_rnh_pseudowire(vrf_id_t vrf_id, struct zebra_pw *pw,
 		return;
 
 	addr2hostprefix(pw->af, &pw->nexthop, &nh);
-	rnh = zebra_add_rnh(&nh, vrf_id, &exists);
+	rnh = zebra_add_rnh(&nh, vrf_id, SAFI_UNICAST, &exists);
 	if (!rnh)
 		return;
 

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -44,9 +44,9 @@ extern void zebra_register_rnh_pseudowire(vrf_id_t, struct zebra_pw *, bool *);
 extern void zebra_deregister_rnh_pseudowire(vrf_id_t, struct zebra_pw *);
 extern void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client);
 extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
-			       struct prefix *p, safi_t safi);
+			       const struct prefix *p, safi_t safi);
 extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, safi_t safi,
-				  struct vty *vty, struct prefix *p);
+				  struct vty *vty, const struct prefix *p);
 
 extern int rnh_resolve_via_default(struct zebra_vrf *zvrf, int family);
 

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -45,8 +45,8 @@ extern void zebra_deregister_rnh_pseudowire(vrf_id_t, struct zebra_pw *);
 extern void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client);
 extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 			       struct prefix *p, safi_t safi);
-extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
-				  struct prefix *p);
+extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, safi_t safi,
+				  struct vty *vty, struct prefix *p);
 
 extern int rnh_resolve_via_default(struct zebra_vrf *zvrf, int family);
 

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -31,7 +31,7 @@ extern "C" {
 
 extern void zebra_rnh_init(void);
 
-extern struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid,
+extern struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid, safi_t safi,
 				 bool *exists);
 extern struct rnh *zebra_lookup_rnh(struct prefix *p, vrf_id_t vrfid,
 				    safi_t safi);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1361,7 +1361,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
 
 DEFPY (show_ip_nht,
        show_ip_nht_cmd,
-       "show <ip$ipv4|ipv6$ipv6> <nht|import-check>$type [<A.B.C.D|X:X::X:X>$addr|vrf NAME$vrf_name [<A.B.C.D|X:X::X:X>$addr]|vrf all$vrf_all]",
+       "show <ip$ipv4|ipv6$ipv6> <nht|import-check>$type [<A.B.C.D|X:X::X:X>$addr|vrf NAME$vrf_name [<A.B.C.D|X:X::X:X>$addr]|vrf all$vrf_all] [mrib$mrib]",
        SHOW_STR
        IP_STR
        IP6_STR
@@ -1372,11 +1372,13 @@ DEFPY (show_ip_nht,
        VRF_CMD_HELP_STR
        "IPv4 Address\n"
        "IPv6 Address\n"
-       VRF_ALL_CMD_HELP_STR)
+       VRF_ALL_CMD_HELP_STR
+       "Show Multicast (MRIB) NHT state\n")
 {
 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
 	vrf_id_t vrf_id = VRF_DEFAULT;
 	struct prefix prefix, *p = NULL;
+	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;
 
 	if (vrf_all) {
 		struct vrf *vrf;
@@ -1385,8 +1387,8 @@ DEFPY (show_ip_nht,
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
 			if ((zvrf = vrf->info) != NULL) {
 				vty_out(vty, "\nVRF %s:\n", zvrf_name(zvrf));
-				zebra_print_rnh_table(zvrf_id(zvrf), afi, vty,
-						      NULL);
+				zebra_print_rnh_table(zvrf_id(zvrf), afi, safi,
+						      vty, NULL);
 			}
 		return CMD_SUCCESS;
 	}
@@ -1400,7 +1402,7 @@ DEFPY (show_ip_nht,
 			return CMD_WARNING;
 	}
 
-	zebra_print_rnh_table(vrf_id, afi, vty, p);
+	zebra_print_rnh_table(vrf_id, afi, safi, vty, p);
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
This is a whole bunch of groundwork towards getting NHT on SAFI_MULTICAST (which is currently just straight up b0rked.)

The primary change here is a whole bunch of passing around SAFI values, mostly "short-circuited" out to SAFI_UNICAST. However, since I had to touch staticd's NHT hash, I ended up moving it over to use a typesafe hash.