### PR TITLE
zebra: fix doc and default value of "func-bits" for SRv6

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -712,7 +712,7 @@ and this section also helps that case.
    Create a new locator. If the name of an existing locator is specified,
    move to specified locator's configuration node to change the settings it.
 
-.. clicmd:: prefix X:X::X:X/M [function-bits-length 32]
+.. clicmd:: prefix X:X::X:X/M [func-bits 32]
 
    Set the ipv6 prefix block of the locator. SRv6 locator is defined by
    RFC8986. The actual routing protocol specifies the locator and allocates a
@@ -732,7 +732,7 @@ and this section also helps that case.
    will be ``2001:db8:1:1:1::``)
 
    The function bits range is 16bits by default.  If operator want to change
-   function bits range, they can configure with ``function-bits-length``
+   function bits range, they can configure with ``func-bits``
    option.
 
 ::

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -354,8 +354,12 @@ static int zebra_sr_config(struct vty *vty)
 			inet_ntop(AF_INET6, &locator->prefix.prefix,
 				  str, sizeof(str));
 			vty_out(vty, "   locator %s\n", locator->name);
-			vty_out(vty, "    prefix %s/%u\n", str,
+			vty_out(vty, "    prefix %s/%u", str,
 				locator->prefix.prefixlen);
+			if (locator->function_bits_length)
+				vty_out(vty, " func-bits %u",
+					locator->function_bits_length);
+			vty_out(vty, "\n");
 			vty_out(vty, "   exit\n");
 			vty_out(vty, "   !\n");
 		}


### PR DESCRIPTION
This patch series properly fix default value handling of the optional parameter "func-bits" related to SRv6, typo in doc, vty output.