### PR TITLE
pim6d: Adding new Debug CLI for pimv6

### DIFF
--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -366,17 +366,9 @@ General multicast routing state
    Display total number of S,G mroutes and number of S,G mroutes
    installed into the kernel for all vrfs.
 
-PIMv6 Debug Commands
-====================
-
-The debugging subsystem for PIMv6 behaves in accordance with how FRR handles
-debugging. You can specify debugging at the enable CLI mode as well as the
-configure CLI mode. If you specify debug commands in the configuration cli
-mode, the debug commands can be persistent across restarts of the FRR pim6d if
-the config was written out.
-
 PIMv6 Clear Commands
 ====================
+
 Clear commands reset various variables.
 
 .. clicmd:: clear ipv6 mroute
@@ -392,3 +384,45 @@ Clear commands reset various variables.
 .. clicmd:: clear ipv6 pim oil
 
    Rescan PIMv6 OIL (output interface list).
+
+PIMv6 Debug Commands
+====================
+
+The debugging subsystem for PIMv6 behaves in accordance with how FRR handles
+debugging. You can specify debugging at the enable CLI mode as well as the
+configure CLI mode. If you specify debug commands in the configuration cli
+mode, the debug commands can be persistent across restarts of the FRR pim6d if
+the config was written out.
+
+.. clicmd:: debug pimv6 events
+
+   This turns on debugging for PIMv6 system events. Especially timers.
+
+.. clicmd:: debug pimv6 nht
+
+   This turns on debugging for PIMv6 nexthop tracking. It will display
+   information about RPF lookups and information about when a nexthop changes.
+
+.. clicmd:: debug pimv6 nht detail
+
+   This turns on debugging for PIMv6 nexthop in detail. This is not enabled
+   by default.
+
+.. clicmd:: debug pimv6 packet-dump
+
+   This turns on an extraordinary amount of data. Each pim packet sent and
+   received is dumped for debugging purposes. This should be considered a
+   developer only command.
+
+.. clicmd:: debug pimv6 packets
+
+   This turns on information about packet generation for sending and about
+   packet handling from a received packet.
+
+.. clicmd:: debug pimv6 trace
+
+   This traces pim code and how it is running.
+
+.. clicmd:: debug pimv6 zebra
+
+   This gathers data about events from zebra that come up through the ZAPI.

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -2114,6 +2114,37 @@ DEFPY (debug_pimv6_packetdump_recv,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_pimv6_trace,
+       debug_pimv6_trace_cmd,
+       "[no] debug pimv6 trace",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIMV6_STR
+       DEBUG_PIMV6_TRACE_STR)
+{
+	if (!no)
+		PIM_DO_DEBUG_PIM_TRACE;
+	else
+		PIM_DONT_DEBUG_PIM_TRACE;
+	return CMD_SUCCESS;
+}
+
+DEFPY (debug_pimv6_trace_detail,
+       debug_pimv6_trace_detail_cmd,
+       "[no] debug pimv6 trace detail",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIMV6_STR
+       DEBUG_PIMV6_TRACE_STR
+       "Detailed Information\n")
+{
+	if (!no)
+		PIM_DO_DEBUG_PIM_TRACE_DETAIL;
+	else
+		PIM_DONT_DEBUG_PIM_TRACE_DETAIL;
+	return CMD_SUCCESS;
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -2232,6 +2263,8 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_pimv6_packets_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_packetdump_send_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_packetdump_recv_cmd);
+	install_element(ENABLE_NODE, &debug_pimv6_trace_cmd);
+	install_element(ENABLE_NODE, &debug_pimv6_trace_detail_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
@@ -2240,4 +2273,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_pimv6_packets_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_packetdump_send_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_packetdump_recv_cmd);
+	install_element(CONFIG_NODE, &debug_pimv6_trace_cmd);
+	install_element(CONFIG_NODE, &debug_pimv6_trace_detail_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -2145,6 +2145,21 @@ DEFPY (debug_pimv6_trace_detail,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_pimv6_zebra,
+       debug_pimv6_zebra_cmd,
+       "[no] debug pimv6 zebra",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIMV6_STR
+       DEBUG_PIMV6_ZEBRA_STR)
+{
+	if (!no)
+		PIM_DO_DEBUG_ZEBRA;
+	else
+		PIM_DONT_DEBUG_ZEBRA;
+	return CMD_SUCCESS;
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -2265,6 +2280,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_pimv6_packetdump_recv_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_trace_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_trace_detail_cmd);
+	install_element(ENABLE_NODE, &debug_pimv6_zebra_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
@@ -2275,4 +2291,5 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_pimv6_packetdump_recv_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_trace_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_trace_detail_cmd);
+	install_element(CONFIG_NODE, &debug_pimv6_zebra_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -2082,6 +2082,38 @@ DEFPY (debug_pimv6_packets,
 						    vty);
 }
 
+DEFPY (debug_pimv6_packetdump_send,
+       debug_pimv6_packetdump_send_cmd,
+       "[no] debug pimv6 packet-dump send",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIMV6_STR
+       DEBUG_PIMV6_PACKETDUMP_STR
+       DEBUG_PIMV6_PACKETDUMP_SEND_STR)
+{
+	if (!no)
+		PIM_DO_DEBUG_PIM_PACKETDUMP_SEND;
+	else
+		PIM_DONT_DEBUG_PIM_PACKETDUMP_SEND;
+	return CMD_SUCCESS;
+}
+
+DEFPY (debug_pimv6_packetdump_recv,
+       debug_pimv6_packetdump_recv_cmd,
+       "[no] debug pimv6 packet-dump receive",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIMV6_STR
+       DEBUG_PIMV6_PACKETDUMP_STR
+       DEBUG_PIMV6_PACKETDUMP_RECV_STR)
+{
+	if (!no)
+		PIM_DO_DEBUG_PIM_PACKETDUMP_RECV;
+	else
+		PIM_DONT_DEBUG_PIM_PACKETDUMP_RECV;
+	return CMD_SUCCESS;
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -2198,10 +2230,14 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_pimv6_nht_det_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_events_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_packets_cmd);
+	install_element(ENABLE_NODE, &debug_pimv6_packetdump_send_cmd);
+	install_element(ENABLE_NODE, &debug_pimv6_packetdump_recv_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_det_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_events_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_packets_cmd);
+	install_element(CONFIG_NODE, &debug_pimv6_packetdump_send_cmd);
+	install_element(CONFIG_NODE, &debug_pimv6_packetdump_recv_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -2064,6 +2064,24 @@ DEFPY (debug_pimv6_events,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_pimv6_packets,
+       debug_pimv6_packets_cmd,
+       "[no] debug pimv6 packets [<hello$hello|joins$joins|register$registers>]",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIMV6_STR
+       DEBUG_PIMV6_PACKETS_STR
+       DEBUG_PIMV6_HELLO_PACKETS_STR
+       DEBUG_PIMV6_J_P_PACKETS_STR
+       DEBUG_PIMV6_PIM_REG_PACKETS_STR)
+{
+	if (!no)
+		return pim_debug_pim_packets_cmd(hello, joins, registers, vty);
+	else
+		return pim_no_debug_pim_packets_cmd(hello, joins, registers,
+						    vty);
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -2179,9 +2197,11 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_pimv6_nht_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_nht_det_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_events_cmd);
+	install_element(ENABLE_NODE, &debug_pimv6_packets_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_det_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_events_cmd);
+	install_element(CONFIG_NODE, &debug_pimv6_packets_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -49,6 +49,13 @@
 #include "pimd/pim6_cmd_clippy.c"
 #endif
 
+static struct cmd_node debug_node = {
+	.name = "debug",
+	.node = DEBUG_NODE,
+	.prompt = "",
+	.config_write = pim_debug_config_write,
+};
+
 DEFPY (ipv6_pim_joinprune_time,
        ipv6_pim_joinprune_time_cmd,
        "ipv6 pim join-prune-interval (1-65535)$jpi",
@@ -2163,6 +2170,8 @@ DEFPY (debug_pimv6_zebra,
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
+
+	install_node(&debug_node);
 
 	install_element(CONFIG_NODE, &ipv6_pim_joinprune_time_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_joinprune_time_cmd);

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -2004,6 +2004,19 @@ DEFPY (clear_ipv6_mroute_count,
 	return clear_ip_mroute_count_command(vty, name);
 }
 
+DEFPY (debug_pimv6,
+       debug_pimv6_cmd,
+       "[no] debug pimv6",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIMV6_STR)
+{
+	if (!no)
+		return pim_debug_pim_cmd();
+	else
+		return pim_no_debug_pim_cmd();
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -2115,4 +2128,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &clear_ipv6_mroute_cmd);
 	install_element(ENABLE_NODE, &clear_ipv6_pim_oil_cmd);
 	install_element(ENABLE_NODE, &clear_ipv6_mroute_count_cmd);
+	install_element(ENABLE_NODE, &debug_pimv6_cmd);
+
+	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -2049,6 +2049,21 @@ DEFPY (debug_pimv6_nht_det,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_pimv6_events,
+       debug_pimv6_events_cmd,
+       "[no] debug pimv6 events",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIMV6_STR
+       DEBUG_PIMV6_EVENTS_STR)
+{
+	if (!no)
+		PIM_DO_DEBUG_PIM_EVENTS;
+	else
+		PIM_DONT_DEBUG_PIM_EVENTS;
+	return CMD_SUCCESS;
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -2163,8 +2178,10 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_pimv6_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_nht_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_nht_det_cmd);
+	install_element(ENABLE_NODE, &debug_pimv6_events_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_det_cmd);
+	install_element(CONFIG_NODE, &debug_pimv6_events_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -43,6 +43,7 @@
 #include "pim_bsm.h"
 #include "pim_iface.h"
 #include "pim_zebra.h"
+#include "pim_instance.h"
 
 #ifndef VTYSH_EXTRACT_PL
 #include "pimd/pim6_cmd_clippy.c"
@@ -2017,6 +2018,37 @@ DEFPY (debug_pimv6,
 		return pim_no_debug_pim_cmd();
 }
 
+DEFPY (debug_pimv6_nht,
+       debug_pimv6_nht_cmd,
+       "[no] debug pimv6 nht",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIMV6_STR
+       "Nexthop Tracking\n")
+{
+	if (!no)
+		PIM_DO_DEBUG_PIM_NHT;
+	else
+		PIM_DONT_DEBUG_PIM_NHT;
+	return CMD_SUCCESS;
+}
+
+DEFPY (debug_pimv6_nht_det,
+       debug_pimv6_nht_det_cmd,
+       "[no] debug pimv6 nht detail",
+       NO_STR
+       DEBUG_STR
+       DEBUG_PIMV6_STR
+       "Nexthop Tracking\n"
+       "Detailed Information\n")
+{
+	if (!no)
+		PIM_DO_DEBUG_PIM_NHT_DETAIL;
+	else
+		PIM_DONT_DEBUG_PIM_NHT_DETAIL;
+	return CMD_SUCCESS;
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -2129,6 +2161,10 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &clear_ipv6_pim_oil_cmd);
 	install_element(ENABLE_NODE, &clear_ipv6_mroute_count_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_cmd);
+	install_element(ENABLE_NODE, &debug_pimv6_nht_cmd);
+	install_element(ENABLE_NODE, &debug_pimv6_nht_det_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
+	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
+	install_element(CONFIG_NODE, &debug_pimv6_nht_det_cmd);
 }

--- a/pimd/pim6_cmd.h
+++ b/pimd/pim6_cmd.h
@@ -56,6 +56,7 @@
 #define DEBUG_PIMV6_PACKETDUMP_SEND_STR "Dump sent packets\n"
 #define DEBUG_PIMV6_PACKETDUMP_RECV_STR "Dump received packets\n"
 #define DEBUG_PIMV6_TRACE_STR "PIMv6 internal daemon activity\n"
+#define DEBUG_PIMV6_ZEBRA_STR "ZEBRA protocol activity\n"
 
 void pim_cmd_init(void);
 

--- a/pimd/pim6_cmd.h
+++ b/pimd/pim6_cmd.h
@@ -46,6 +46,7 @@
 #define DEBUG_MLD_TRACE_STR "MLD internal daemon activity\n"
 #define CONF_SSMPINGD_STR "Enable ssmpingd operation\n"
 #define DEBUG_PIMV6_STR "PIMv6 protocol activity\n"
+#define DEBUG_PIMV6_EVENTS_STR "PIMv6 protocol events\n"
 
 void pim_cmd_init(void);
 

--- a/pimd/pim6_cmd.h
+++ b/pimd/pim6_cmd.h
@@ -45,6 +45,7 @@
 #define DEBUG_MLD_PACKETS_STR "MLD protocol packets\n"
 #define DEBUG_MLD_TRACE_STR "MLD internal daemon activity\n"
 #define CONF_SSMPINGD_STR "Enable ssmpingd operation\n"
+#define DEBUG_PIMV6_STR "PIMv6 protocol activity\n"
 
 void pim_cmd_init(void);
 

--- a/pimd/pim6_cmd.h
+++ b/pimd/pim6_cmd.h
@@ -52,6 +52,9 @@
 #define DEBUG_PIMV6_J_P_PACKETS_STR "PIMv6 Join/Prune protocol packets\n"
 #define DEBUG_PIMV6_PIM_REG_PACKETS_STR                                        \
 	"PIMv6 Register/Reg-Stop protocol packets\n"
+#define DEBUG_PIMV6_PACKETDUMP_STR "PIMv6 packet dump\n"
+#define DEBUG_PIMV6_PACKETDUMP_SEND_STR "Dump sent packets\n"
+#define DEBUG_PIMV6_PACKETDUMP_RECV_STR "Dump received packets\n"
 
 void pim_cmd_init(void);
 

--- a/pimd/pim6_cmd.h
+++ b/pimd/pim6_cmd.h
@@ -47,6 +47,11 @@
 #define CONF_SSMPINGD_STR "Enable ssmpingd operation\n"
 #define DEBUG_PIMV6_STR "PIMv6 protocol activity\n"
 #define DEBUG_PIMV6_EVENTS_STR "PIMv6 protocol events\n"
+#define DEBUG_PIMV6_PACKETS_STR "PIMv6 protocol packets\n"
+#define DEBUG_PIMV6_HELLO_PACKETS_STR "PIMv6 Hello protocol packets\n"
+#define DEBUG_PIMV6_J_P_PACKETS_STR "PIMv6 Join/Prune protocol packets\n"
+#define DEBUG_PIMV6_PIM_REG_PACKETS_STR                                        \
+	"PIMv6 Register/Reg-Stop protocol packets\n"
 
 void pim_cmd_init(void);
 

--- a/pimd/pim6_cmd.h
+++ b/pimd/pim6_cmd.h
@@ -55,6 +55,7 @@
 #define DEBUG_PIMV6_PACKETDUMP_STR "PIMv6 packet dump\n"
 #define DEBUG_PIMV6_PACKETDUMP_SEND_STR "Dump sent packets\n"
 #define DEBUG_PIMV6_PACKETDUMP_RECV_STR "Dump received packets\n"
+#define DEBUG_PIMV6_TRACE_STR "PIMv6 internal daemon activity\n"
 
 void pim_cmd_init(void);
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5707,26 +5707,18 @@ DEFUN (no_debug_ssmpingd,
 	return CMD_SUCCESS;
 }
 
-DEFUN (debug_pim_zebra,
+DEFPY (debug_pim_zebra,
        debug_pim_zebra_cmd,
-       "debug pim zebra",
-       DEBUG_STR
-       DEBUG_PIM_STR
-       DEBUG_PIM_ZEBRA_STR)
-{
-	PIM_DO_DEBUG_ZEBRA;
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_pim_zebra,
-       no_debug_pim_zebra_cmd,
-       "no debug pim zebra",
+       "[no] debug pim zebra",
        NO_STR
        DEBUG_STR
        DEBUG_PIM_STR
        DEBUG_PIM_ZEBRA_STR)
 {
-	PIM_DONT_DEBUG_ZEBRA;
+	if (!no)
+		PIM_DO_DEBUG_ZEBRA;
+	else
+		PIM_DONT_DEBUG_ZEBRA;
 	return CMD_SUCCESS;
 }
 
@@ -7763,7 +7755,6 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_ssmpingd_cmd);
 	install_element(ENABLE_NODE, &no_debug_ssmpingd_cmd);
 	install_element(ENABLE_NODE, &debug_pim_zebra_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_zebra_cmd);
 	install_element(ENABLE_NODE, &debug_pim_mlag_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_mlag_cmd);
 	install_element(ENABLE_NODE, &debug_pim_vxlan_cmd);
@@ -7809,7 +7800,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_ssmpingd_cmd);
 	install_element(CONFIG_NODE, &no_debug_ssmpingd_cmd);
 	install_element(CONFIG_NODE, &debug_pim_zebra_cmd);
-	install_element(CONFIG_NODE, &no_debug_pim_zebra_cmd);
 	install_element(CONFIG_NODE, &debug_pim_mlag_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_mlag_cmd);
 	install_element(CONFIG_NODE, &debug_pim_vxlan_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5522,41 +5522,17 @@ DEFUN (no_debug_pim_static,
 }
 
 
-DEFUN (debug_pim,
+DEFPY (debug_pim,
        debug_pim_cmd,
-       "debug pim",
-       DEBUG_STR
-       DEBUG_PIM_STR)
-{
-	PIM_DO_DEBUG_PIM_EVENTS;
-	PIM_DO_DEBUG_PIM_PACKETS;
-	PIM_DO_DEBUG_PIM_TRACE;
-	PIM_DO_DEBUG_MSDP_EVENTS;
-	PIM_DO_DEBUG_MSDP_PACKETS;
-	PIM_DO_DEBUG_BSM;
-	PIM_DO_DEBUG_VXLAN;
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_pim,
-       no_debug_pim_cmd,
-       "no debug pim",
+       "[no] debug pim",
        NO_STR
        DEBUG_STR
        DEBUG_PIM_STR)
 {
-	PIM_DONT_DEBUG_PIM_EVENTS;
-	PIM_DONT_DEBUG_PIM_PACKETS;
-	PIM_DONT_DEBUG_PIM_TRACE;
-	PIM_DONT_DEBUG_MSDP_EVENTS;
-	PIM_DONT_DEBUG_MSDP_PACKETS;
-
-	PIM_DONT_DEBUG_PIM_PACKETDUMP_SEND;
-	PIM_DONT_DEBUG_PIM_PACKETDUMP_RECV;
-	PIM_DONT_DEBUG_BSM;
-	PIM_DONT_DEBUG_VXLAN;
-
-	return CMD_SUCCESS;
+	if (!no)
+		return pim_debug_pim_cmd();
+	else
+		return pim_no_debug_pim_cmd();
 }
 
 DEFUN (debug_pim_nht,
@@ -7872,7 +7848,6 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_pim_static_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_static_cmd);
 	install_element(ENABLE_NODE, &debug_pim_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_cmd);
 	install_element(ENABLE_NODE, &debug_pim_nht_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_nht_cmd);
 	install_element(ENABLE_NODE, &debug_pim_nht_det_cmd);
@@ -7927,7 +7902,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_pim_static_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_static_cmd);
 	install_element(CONFIG_NODE, &debug_pim_cmd);
-	install_element(CONFIG_NODE, &no_debug_pim_cmd);
 	install_element(CONFIG_NODE, &debug_pim_nht_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_nht_cmd);
 	install_element(CONFIG_NODE, &debug_pim_nht_det_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5591,26 +5591,18 @@ DEFUN (no_debug_pim_nht_rp,
 	return CMD_SUCCESS;
 }
 
-DEFUN (debug_pim_events,
+DEFPY (debug_pim_events,
        debug_pim_events_cmd,
-       "debug pim events",
-       DEBUG_STR
-       DEBUG_PIM_STR
-       DEBUG_PIM_EVENTS_STR)
-{
-	PIM_DO_DEBUG_PIM_EVENTS;
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_pim_events,
-       no_debug_pim_events_cmd,
-       "no debug pim events",
+       "[no] debug pim events",
        NO_STR
        DEBUG_STR
        DEBUG_PIM_STR
        DEBUG_PIM_EVENTS_STR)
 {
-	PIM_DONT_DEBUG_PIM_EVENTS;
+	if (!no)
+		PIM_DO_DEBUG_PIM_EVENTS;
+	else
+		PIM_DONT_DEBUG_PIM_EVENTS;
 	return CMD_SUCCESS;
 }
 
@@ -7836,7 +7828,6 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_pim_nht_rp_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_nht_rp_cmd);
 	install_element(ENABLE_NODE, &debug_pim_events_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_events_cmd);
 	install_element(ENABLE_NODE, &debug_pim_packets_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_packets_cmd);
 	install_element(ENABLE_NODE, &debug_pim_packetdump_send_cmd);
@@ -7888,7 +7879,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_pim_nht_rp_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_nht_rp_cmd);
 	install_element(CONFIG_NODE, &debug_pim_events_cmd);
-	install_element(CONFIG_NODE, &no_debug_pim_events_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packets_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_packets_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packetdump_send_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5655,51 +5655,34 @@ DEFPY (debug_pim_packetdump_recv,
 	return CMD_SUCCESS;
 }
 
-DEFUN (debug_pim_trace,
+DEFPY (debug_pim_trace,
        debug_pim_trace_cmd,
-       "debug pim trace",
+       "[no] debug pim trace",
+       NO_STR
        DEBUG_STR
        DEBUG_PIM_STR
        DEBUG_PIM_TRACE_STR)
 {
-	PIM_DO_DEBUG_PIM_TRACE;
+	if (!no)
+		PIM_DO_DEBUG_PIM_TRACE;
+	else
+		PIM_DONT_DEBUG_PIM_TRACE;
 	return CMD_SUCCESS;
 }
 
-DEFUN (debug_pim_trace_detail,
+DEFPY (debug_pim_trace_detail,
        debug_pim_trace_detail_cmd,
-       "debug pim trace detail",
-       DEBUG_STR
-       DEBUG_PIM_STR
-       DEBUG_PIM_TRACE_STR
-       "Detailed Information\n")
-{
-	PIM_DO_DEBUG_PIM_TRACE_DETAIL;
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_pim_trace,
-       no_debug_pim_trace_cmd,
-       "no debug pim trace",
-       NO_STR
-       DEBUG_STR
-       DEBUG_PIM_STR
-       DEBUG_PIM_TRACE_STR)
-{
-	PIM_DONT_DEBUG_PIM_TRACE;
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_pim_trace_detail,
-       no_debug_pim_trace_detail_cmd,
-       "no debug pim trace detail",
+       "[no] debug pim trace detail",
        NO_STR
        DEBUG_STR
        DEBUG_PIM_STR
        DEBUG_PIM_TRACE_STR
        "Detailed Information\n")
 {
-	PIM_DONT_DEBUG_PIM_TRACE_DETAIL;
+	if (!no)
+		PIM_DO_DEBUG_PIM_TRACE_DETAIL;
+	else
+		PIM_DONT_DEBUG_PIM_TRACE_DETAIL;
 	return CMD_SUCCESS;
 }
 
@@ -7776,9 +7759,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_pim_packetdump_send_cmd);
 	install_element(ENABLE_NODE, &debug_pim_packetdump_recv_cmd);
 	install_element(ENABLE_NODE, &debug_pim_trace_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_trace_cmd);
 	install_element(ENABLE_NODE, &debug_pim_trace_detail_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_trace_detail_cmd);
 	install_element(ENABLE_NODE, &debug_ssmpingd_cmd);
 	install_element(ENABLE_NODE, &no_debug_ssmpingd_cmd);
 	install_element(ENABLE_NODE, &debug_pim_zebra_cmd);
@@ -7824,9 +7805,7 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_pim_packetdump_send_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packetdump_recv_cmd);
 	install_element(CONFIG_NODE, &debug_pim_trace_cmd);
-	install_element(CONFIG_NODE, &no_debug_pim_trace_cmd);
 	install_element(CONFIG_NODE, &debug_pim_trace_detail_cmd);
-	install_element(CONFIG_NODE, &no_debug_pim_trace_detail_cmd);
 	install_element(CONFIG_NODE, &debug_ssmpingd_cmd);
 	install_element(CONFIG_NODE, &no_debug_ssmpingd_cmd);
 	install_element(CONFIG_NODE, &debug_pim_zebra_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5606,58 +5606,21 @@ DEFPY (debug_pim_events,
 	return CMD_SUCCESS;
 }
 
-DEFUN (debug_pim_packets,
+DEFPY (debug_pim_packets,
        debug_pim_packets_cmd,
-       "debug pim packets [<hello|joins|register>]",
-       DEBUG_STR
+       "[no] debug pim packets [<hello$hello|joins$joins|register$registers>]",
+       NO_STR DEBUG_STR
        DEBUG_PIM_STR
        DEBUG_PIM_PACKETS_STR
        DEBUG_PIM_HELLO_PACKETS_STR
        DEBUG_PIM_J_P_PACKETS_STR
        DEBUG_PIM_PIM_REG_PACKETS_STR)
 {
-	int idx = 0;
-	if (argv_find(argv, argc, "hello", &idx)) {
-		PIM_DO_DEBUG_PIM_HELLO;
-		vty_out(vty, "PIM Hello debugging is on\n");
-	} else if (argv_find(argv, argc, "joins", &idx)) {
-		PIM_DO_DEBUG_PIM_J_P;
-		vty_out(vty, "PIM Join/Prune debugging is on\n");
-	} else if (argv_find(argv, argc, "register", &idx)) {
-		PIM_DO_DEBUG_PIM_REG;
-		vty_out(vty, "PIM Register debugging is on\n");
-	} else {
-		PIM_DO_DEBUG_PIM_PACKETS;
-		vty_out(vty, "PIM Packet debugging is on \n");
-	}
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_pim_packets,
-       no_debug_pim_packets_cmd,
-       "no debug pim packets [<hello|joins|register>]",
-       NO_STR
-       DEBUG_STR
-       DEBUG_PIM_STR
-       DEBUG_PIM_PACKETS_STR
-       DEBUG_PIM_HELLO_PACKETS_STR
-       DEBUG_PIM_J_P_PACKETS_STR
-       DEBUG_PIM_PIM_REG_PACKETS_STR)
-{
-	int idx = 0;
-	if (argv_find(argv, argc, "hello", &idx)) {
-		PIM_DONT_DEBUG_PIM_HELLO;
-		vty_out(vty, "PIM Hello debugging is off \n");
-	} else if (argv_find(argv, argc, "joins", &idx)) {
-		PIM_DONT_DEBUG_PIM_J_P;
-		vty_out(vty, "PIM Join/Prune debugging is off \n");
-	} else if (argv_find(argv, argc, "register", &idx)) {
-		PIM_DONT_DEBUG_PIM_REG;
-		vty_out(vty, "PIM Register debugging is off\n");
-	} else
-		PIM_DONT_DEBUG_PIM_PACKETS;
-
-	return CMD_SUCCESS;
+	if (!no)
+		return pim_debug_pim_packets_cmd(hello, joins, registers, vty);
+	else
+		return pim_no_debug_pim_packets_cmd(hello, joins, registers,
+						    vty);
 }
 
 
@@ -7829,7 +7792,6 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &no_debug_pim_nht_rp_cmd);
 	install_element(ENABLE_NODE, &debug_pim_events_cmd);
 	install_element(ENABLE_NODE, &debug_pim_packets_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_packets_cmd);
 	install_element(ENABLE_NODE, &debug_pim_packetdump_send_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_packetdump_send_cmd);
 	install_element(ENABLE_NODE, &debug_pim_packetdump_recv_cmd);
@@ -7880,7 +7842,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_debug_pim_nht_rp_cmd);
 	install_element(CONFIG_NODE, &debug_pim_events_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packets_cmd);
-	install_element(CONFIG_NODE, &no_debug_pim_packets_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packetdump_send_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_packetdump_send_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packetdump_recv_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5623,54 +5623,35 @@ DEFPY (debug_pim_packets,
 						    vty);
 }
 
-
-DEFUN (debug_pim_packetdump_send,
+DEFPY (debug_pim_packetdump_send,
        debug_pim_packetdump_send_cmd,
-       "debug pim packet-dump send",
-       DEBUG_STR
-       DEBUG_PIM_STR
-       DEBUG_PIM_PACKETDUMP_STR
-       DEBUG_PIM_PACKETDUMP_SEND_STR)
-{
-	PIM_DO_DEBUG_PIM_PACKETDUMP_SEND;
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_pim_packetdump_send,
-       no_debug_pim_packetdump_send_cmd,
-       "no debug pim packet-dump send",
+       "[no] debug pim packet-dump send",
        NO_STR
        DEBUG_STR
        DEBUG_PIM_STR
        DEBUG_PIM_PACKETDUMP_STR
        DEBUG_PIM_PACKETDUMP_SEND_STR)
 {
-	PIM_DONT_DEBUG_PIM_PACKETDUMP_SEND;
+	if (!no)
+		PIM_DO_DEBUG_PIM_PACKETDUMP_SEND;
+	else
+		PIM_DONT_DEBUG_PIM_PACKETDUMP_SEND;
 	return CMD_SUCCESS;
 }
 
-DEFUN (debug_pim_packetdump_recv,
+DEFPY (debug_pim_packetdump_recv,
        debug_pim_packetdump_recv_cmd,
-       "debug pim packet-dump receive",
-       DEBUG_STR
-       DEBUG_PIM_STR
-       DEBUG_PIM_PACKETDUMP_STR
-       DEBUG_PIM_PACKETDUMP_RECV_STR)
-{
-	PIM_DO_DEBUG_PIM_PACKETDUMP_RECV;
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_pim_packetdump_recv,
-       no_debug_pim_packetdump_recv_cmd,
-       "no debug pim packet-dump receive",
+       "[no] debug pim packet-dump receive",
        NO_STR
        DEBUG_STR
        DEBUG_PIM_STR
        DEBUG_PIM_PACKETDUMP_STR
        DEBUG_PIM_PACKETDUMP_RECV_STR)
 {
-	PIM_DONT_DEBUG_PIM_PACKETDUMP_RECV;
+	if (!no)
+		PIM_DO_DEBUG_PIM_PACKETDUMP_RECV;
+	else
+		PIM_DONT_DEBUG_PIM_PACKETDUMP_RECV;
 	return CMD_SUCCESS;
 }
 
@@ -7793,9 +7774,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_pim_events_cmd);
 	install_element(ENABLE_NODE, &debug_pim_packets_cmd);
 	install_element(ENABLE_NODE, &debug_pim_packetdump_send_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_packetdump_send_cmd);
 	install_element(ENABLE_NODE, &debug_pim_packetdump_recv_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_packetdump_recv_cmd);
 	install_element(ENABLE_NODE, &debug_pim_trace_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_trace_cmd);
 	install_element(ENABLE_NODE, &debug_pim_trace_detail_cmd);
@@ -7843,9 +7822,7 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_pim_events_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packets_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packetdump_send_cmd);
-	install_element(CONFIG_NODE, &no_debug_pim_packetdump_send_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packetdump_recv_cmd);
-	install_element(CONFIG_NODE, &no_debug_pim_packetdump_recv_cmd);
 	install_element(CONFIG_NODE, &debug_pim_trace_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_trace_cmd);
 	install_element(CONFIG_NODE, &debug_pim_trace_detail_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5535,51 +5535,34 @@ DEFPY (debug_pim,
 		return pim_no_debug_pim_cmd();
 }
 
-DEFUN (debug_pim_nht,
+DEFPY (debug_pim_nht,
        debug_pim_nht_cmd,
-       "debug pim nht",
-       DEBUG_STR
-       DEBUG_PIM_STR
-       "Nexthop Tracking\n")
-{
-	PIM_DO_DEBUG_PIM_NHT;
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_pim_nht,
-       no_debug_pim_nht_cmd,
-       "no debug pim nht",
+       "[no] debug pim nht",
        NO_STR
        DEBUG_STR
        DEBUG_PIM_STR
        "Nexthop Tracking\n")
 {
-	PIM_DONT_DEBUG_PIM_NHT;
+	if (!no)
+		PIM_DO_DEBUG_PIM_NHT;
+	else
+		PIM_DONT_DEBUG_PIM_NHT;
 	return CMD_SUCCESS;
 }
 
-DEFUN (debug_pim_nht_det,
+DEFPY (debug_pim_nht_det,
        debug_pim_nht_det_cmd,
-       "debug pim nht detail",
-       DEBUG_STR
-       DEBUG_PIM_STR
-       "Nexthop Tracking\n"
-       "Detailed Information\n")
-{
-	PIM_DO_DEBUG_PIM_NHT_DETAIL;
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_pim_nht_det,
-       no_debug_pim_nht_det_cmd,
-       "no debug pim nht detail",
+       "[no] debug pim nht detail",
        NO_STR
        DEBUG_STR
        DEBUG_PIM_STR
        "Nexthop Tracking\n"
        "Detailed Information\n")
 {
-	PIM_DONT_DEBUG_PIM_NHT_DETAIL;
+	if (!no)
+		PIM_DO_DEBUG_PIM_NHT_DETAIL;
+	else
+		PIM_DONT_DEBUG_PIM_NHT_DETAIL;
 	return CMD_SUCCESS;
 }
 
@@ -7849,9 +7832,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &no_debug_pim_static_cmd);
 	install_element(ENABLE_NODE, &debug_pim_cmd);
 	install_element(ENABLE_NODE, &debug_pim_nht_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_nht_cmd);
 	install_element(ENABLE_NODE, &debug_pim_nht_det_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_nht_det_cmd);
 	install_element(ENABLE_NODE, &debug_pim_nht_rp_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_nht_rp_cmd);
 	install_element(ENABLE_NODE, &debug_pim_events_cmd);
@@ -7903,9 +7884,7 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_debug_pim_static_cmd);
 	install_element(CONFIG_NODE, &debug_pim_cmd);
 	install_element(CONFIG_NODE, &debug_pim_nht_cmd);
-	install_element(CONFIG_NODE, &no_debug_pim_nht_cmd);
 	install_element(CONFIG_NODE, &debug_pim_nht_det_cmd);
-	install_element(CONFIG_NODE, &no_debug_pim_nht_det_cmd);
 	install_element(CONFIG_NODE, &debug_pim_nht_rp_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_nht_rp_cmd);
 	install_element(CONFIG_NODE, &debug_pim_events_cmd);

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -3673,3 +3673,28 @@ void clear_pim_statistics(struct pim_instance *pim)
 		pim_ifp->pim_ifstat_bsm_invalid_sz = 0;
 	}
 }
+
+int pim_debug_pim_cmd(void)
+{
+	PIM_DO_DEBUG_PIM_EVENTS;
+	PIM_DO_DEBUG_PIM_PACKETS;
+	PIM_DO_DEBUG_PIM_TRACE;
+	PIM_DO_DEBUG_MSDP_EVENTS;
+	PIM_DO_DEBUG_MSDP_PACKETS;
+	PIM_DO_DEBUG_BSM;
+	PIM_DO_DEBUG_VXLAN;
+	return CMD_SUCCESS;
+}
+
+int pim_no_debug_pim_cmd(void)
+{
+	PIM_DONT_DEBUG_PIM_EVENTS;
+	PIM_DONT_DEBUG_PIM_PACKETS;
+	PIM_DONT_DEBUG_PIM_TRACE;
+	PIM_DONT_DEBUG_MSDP_EVENTS;
+	PIM_DONT_DEBUG_MSDP_PACKETS;
+
+	PIM_DONT_DEBUG_PIM_PACKETDUMP_SEND;
+	PIM_DONT_DEBUG_PIM_PACKETDUMP_RECV;
+	return CMD_SUCCESS;
+}

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -3698,3 +3698,42 @@ int pim_no_debug_pim_cmd(void)
 	PIM_DONT_DEBUG_PIM_PACKETDUMP_RECV;
 	return CMD_SUCCESS;
 }
+
+int pim_debug_pim_packets_cmd(const char *hello, const char *joins,
+			      const char *registers, struct vty *vty)
+{
+	if (hello) {
+		PIM_DO_DEBUG_PIM_HELLO;
+		vty_out(vty, "PIM Hello debugging is on\n");
+	} else if (joins) {
+		PIM_DO_DEBUG_PIM_J_P;
+		vty_out(vty, "PIM Join/Prune debugging is on\n");
+	} else if (registers) {
+		PIM_DO_DEBUG_PIM_REG;
+		vty_out(vty, "PIM Register debugging is on\n");
+	} else {
+		PIM_DO_DEBUG_PIM_PACKETS;
+		vty_out(vty, "PIM Packet debugging is on\n");
+	}
+	return CMD_SUCCESS;
+}
+
+int pim_no_debug_pim_packets_cmd(const char *hello, const char *joins,
+				 const char *registers, struct vty *vty)
+{
+	if (hello) {
+		PIM_DONT_DEBUG_PIM_HELLO;
+		vty_out(vty, "PIM Hello debugging is off\n");
+	} else if (joins) {
+		PIM_DONT_DEBUG_PIM_J_P;
+		vty_out(vty, "PIM Join/Prune debugging is off\n");
+	} else if (registers) {
+		PIM_DONT_DEBUG_PIM_REG;
+		vty_out(vty, "PIM Register debugging is off\n");
+	} else {
+		PIM_DONT_DEBUG_PIM_PACKETS;
+		vty_out(vty, "PIM Packet debugging is off\n");
+	}
+
+	return CMD_SUCCESS;
+}

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -125,6 +125,8 @@ int clear_ip_mroute_count_command(struct vty *vty, const char *name);
 struct vrf *pim_cmd_lookup(struct vty *vty, const char *name);
 void clear_mroute(struct pim_instance *pim);
 void clear_pim_statistics(struct pim_instance *pim);
+int pim_debug_pim_cmd(void);
+int pim_no_debug_pim_cmd(void);
 
 /*
  * Special Macro to allow us to get the correct pim_instance;

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -127,6 +127,10 @@ void clear_mroute(struct pim_instance *pim);
 void clear_pim_statistics(struct pim_instance *pim);
 int pim_debug_pim_cmd(void);
 int pim_no_debug_pim_cmd(void);
+int pim_debug_pim_packets_cmd(const char *hello, const char *joins,
+			      const char *registers, struct vty *vty);
+int pim_no_debug_pim_packets_cmd(const char *hello, const char *joins,
+				 const char *registers, struct vty *vty);
 
 /*
  * Special Macro to allow us to get the correct pim_instance;


### PR DESCRIPTION
Adding the following debug clis for pimv6

[no] debug pimv6
[no] debug pimv6 nht
[no] debug pimv6 nht detail
[no] debug pimv6 events
[no] debug pimv6 packets
[no] debug_pimv6_packetdump_send_cmd
[no] debug_pimv6_packetdump_recv_cmd
[no] debug pimv6 trace
[no] debug pimv6 trace detail
[no] debug pimv6 zebra