### PR TITLE
pim6d: Correct the show ip prefix-list display for pim6d

### DIFF
--- a/vtysh/extract.pl.in
+++ b/vtysh/extract.pl.in
@@ -116,9 +116,9 @@ sub scan_file {
 	}
         elsif ($file =~ /lib\/plist\.c$/) {
             if ($defun_array[1] =~ m/ipv6/) {
-                $protocol = "VTYSH_RIPNGD|VTYSH_OSPF6D|VTYSH_BGPD|VTYSH_ZEBRA|VTYSH_BABELD|VTYSH_ISISD|VTYSH_FABRICD";
+                $protocol = "VTYSH_RIPNGD|VTYSH_OSPF6D|VTYSH_BGPD|VTYSH_ZEBRA|VTYSH_PIM6D|VTYSH_BABELD|VTYSH_ISISD|VTYSH_FABRICD";
             } else {
-                $protocol = "VTYSH_RIPD|VTYSH_OSPFD|VTYSH_BGPD|VTYSH_ZEBRA|VTYSH_PIMD|VTYSH_PIM6D|VTYSH_EIGRPD|VTYSH_BABELD|VTYSH_ISISD|VTYSH_FABRICD";
+                $protocol = "VTYSH_RIPD|VTYSH_OSPFD|VTYSH_BGPD|VTYSH_ZEBRA|VTYSH_PIMD|VTYSH_EIGRPD|VTYSH_BABELD|VTYSH_ISISD|VTYSH_FABRICD";
             }
         }
         elsif ($file =~ /lib\/if_rmap\.c$/) {


### PR DESCRIPTION
Currently the PIM6d component is getting displayed under
"show ip prefix-list" instead of "show ipv6 prefix-list".

> frr(config)# do sh ip prefix-list 
> ZEBRA: ip prefix-list xyz: 1 entries
>    seq 5 permit any
> OSPF: ip prefix-list xyz: 1 entries
>    seq 5 permit any
> BGP: ip prefix-list xyz: 1 entries
>    seq 5 permit any
> PIM: ip prefix-list xyz: 1 entries
>    seq 5 permit any
> PIM6: ip prefix-list xyz: 1 entries
>    seq 5 permit any
> frr(config)#

> frr(config)# do sh ipv6 prefix-list detail 
> Prefix-list with the last deletion/insertion: abc
> ZEBRA: ipv6 prefix-list abc:
>    count: 1, range entries: 0, sequences: 5 - 5
>    seq 5 permit any (hit count: 0, refcount: 0)
> Prefix-list with the last deletion/insertion: abc
> OSPF6: ipv6 prefix-list abc:
>    count: 1, range entries: 0, sequences: 5 - 5
>    seq 5 permit any (hit count: 0, refcount: 0)
> Prefix-list with the last deletion/insertion: abc
> BGP: ipv6 prefix-list abc:
>    count: 1, range entries: 0, sequences: 5 - 5
>    seq 5 permit any (hit count: 0, refcount: 0)
> frr(config)# 
> 

Fixed it.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>