### PR TITLE
docker: Adding support for ubi-8 images.

### DIFF
--- a/doc/developer/building-docker.rst
+++ b/doc/developer/building-docker.rst
@@ -109,6 +109,27 @@ No script, multi-arch (ex. amd64, arm64)::
 
 
 
+Building ubi 8 Image
+-----------------------
+
+Script::
+
+   ./docker/ubi-8/build.sh
+
+Script with params, an example could be this (all that info will go to docker label) ::
+
+   ./docker/ubi-8/build.sh  frr:ubi-8-my-test "$(git rev-parse --short=10 HEAD)" my_release my_name my_vendor
+
+No script::
+
+   docker build -f docker/ubi-8/Dockerfile .
+
+No script, multi-arch (ex. amd64, arm64)::
+
+   docker buildx build --platform linux/amd64,linux/arm64 -f docker/ubi-8/Dockerfile -t frr-ubi-8:latest .
+
+
+
 Building Ubuntu 18.04 Image
 ---------------------------
 

--- a/docker/ubi-8/Dockerfile
+++ b/docker/ubi-8/Dockerfile
@@ -1,0 +1,83 @@
+# This stage builds an rpm from the source
+FROM registry.access.redhat.com/ubi8/ubi:8.5 as ubi-8-builder
+
+RUN dnf -y update-minimal --security --sec-severity=Important --sec-severity=Critical
+
+RUN rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official \
+    && dnf config-manager --disableplugin subscription-manager --add-repo http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os \
+    && dnf config-manager --disableplugin subscription-manager --add-repo http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os \
+    && dnf config-manager --disableplugin subscription-manager --add-repo http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os
+
+RUN dnf install -qy https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && dnf install --enablerepo=* -qy rpm-build git autoconf pcre-devel \
+    systemd-devel automake libtool make  readline-devel  texinfo  \
+    net-snmp-devel  pkgconfig  groff pkgconfig  json-c-devel pam-devel  \
+    bison  flex  python3-pytest  c-ares-devel python3-devel python3-sphinx \
+    libcap-devel  platform-python-devel \
+    https://ci1.netdef.org/artifact/LIBYANG-LIBYANGV2/shared/build-2/CentOS-8-x86_64-Packages/libyang2-2.0.0.10.g2eb910e4-1.el8.x86_64.rpm \
+    https://ci1.netdef.org/artifact/LIBYANG-LIBYANGV2/shared/build-2/CentOS-8-x86_64-Packages/libyang2-devel-2.0.0.10.g2eb910e4-1.el8.x86_64.rpm \
+    https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-0.7.0-1.el7.centos.x86_64.rpm \
+    https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-devel-0.7.0-1.el7.centos.x86_64.rpm
+
+
+COPY . /src
+
+ARG PKGVER
+
+RUN echo '%_smp_mflags %( echo "-j$(/usr/bin/getconf _NPROCESSORS_ONLN)"; )' >> /root/.rpmmacros \
+    && cd /src \
+    && ./bootstrap.sh \
+    && ./configure \
+        --enable-rpki \
+        --enable-snmp=agentx \
+        --enable-numeric-version \
+        --with-pkg-extra-version="_palmetto_git$PKGVER" \
+    && make dist \
+    && cd / \
+    && mkdir -p /rpmbuild/{SOURCES,SPECS} \
+    && cp /src/frr*.tar.gz /rpmbuild/SOURCES \
+    && cp /src/redhat/frr.spec /rpmbuild/SPECS \
+    && rpmbuild \
+        --define "_topdir /rpmbuild" \
+        -ba /rpmbuild/SPECS/frr.spec
+
+# This stage installs frr from the rpm
+FROM registry.access.redhat.com/ubi8/ubi:8.5
+RUN dnf -y update-minimal --security --sec-severity=Important --sec-severity=Critical
+ARG FRR_IMAGE_TAG
+ARG FRR_RELEASE
+ARG FRR_NAME
+ARG FRR_VENDOR
+LABEL name=$FRR_NAME \
+      vendor=$FRR_VENDOR \
+      version=$FRR_IMAGE_TAG \
+      release=$FRR_RELEASE
+
+RUN rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official \
+    && dnf config-manager --disableplugin subscription-manager --add-repo http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os \
+    && dnf config-manager --disableplugin subscription-manager --add-repo http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os
+
+RUN dnf install -qy https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && mkdir -p /pkgs/rpm \
+    && dnf install --enablerepo=* -qy https://ci1.netdef.org/artifact/LIBYANG-LIBYANGV2/shared/build-2/CentOS-8-x86_64-Packages/libyang2-2.0.0.10.g2eb910e4-1.el8.x86_64.rpm \
+    https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-0.7.0-1.el7.centos.x86_64.rpm
+
+COPY --from=ubi-8-builder /rpmbuild/RPMS/ /pkgs/rpm/
+
+RUN dnf install -qy /pkgs/rpm/*/*.rpm \
+    && rm -rf /pkgs \
+# Own the config / PID files
+    && mkdir -p /var/run/frr \
+    && chown -R frr:frr /etc/frr /var/run/frr
+
+# Add tini because no CentOS8 package
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
+RUN chmod +x /sbin/tini
+
+# Simple init manager for reaping processes and forwarding signals
+ENTRYPOINT ["/sbin/tini", "--"]
+
+# Default CMD starts watchfrr
+COPY docker/ubi-8/docker-start /usr/lib/frr/docker-start
+CMD ["/usr/lib/frr/docker-start"]

--- a/docker/ubi-8/build.sh
+++ b/docker/ubi-8/build.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -e
+
+##
+# Package version needs to be decimal
+##
+DISTRO=ubi-8
+
+GITREV="$2"
+if [ -z "$GITREV" ];then
+	GITREV="$(git rev-parse --short=10 HEAD)"
+fi
+
+FRR_IMAGE_TAG="$1"
+if [ -z $FRR_IMAGE_TAG ];then
+	FRR_IMAGE_TAG="frr:ubi-8-$GITREV"
+fi
+PKGVER="$(printf '%u\n' 0x$GITREV)"
+
+FRR_RELEASE="$3"
+if [ -z $FRR_RELEASE ];then
+	FRR_RELEASE=$(git describe --tags --abbrev=0)
+fi
+
+FRR_NAME=$4
+if [ -z $FRR_NAME ];then
+	FRR_NAME=frr
+fi
+
+FRR_VENDOR=$5
+if [ -z $FRR_VENDOR ];then
+	FRR_VENDOR=frr
+fi
+
+docker build \
+	--cache-from="frr:$DISTRO-builder-$GITREV" \
+	--file=docker/$DISTRO/Dockerfile \
+	--build-arg="PKGVER=$PKGVER" \
+	--build-arg="FRR_IMAGE_TAG=$FRR_IMAGE_TAG" \
+	--build-arg="FRR_RELEASE=$FRR_RELEASE" \
+	--build-arg="FRR_NAME=$FRR_NAME" \
+	--build-arg="FRR_VENDOR=$FRR_VENDOR" \
+	--tag="$FRR_IMAGE_TAG" \
+	.
+

--- a/docker/ubi-8/docker-start
+++ b/docker/ubi-8/docker-start
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source /usr/lib/frr/frrcommon.sh
+/usr/lib/frr/watchfrr $(daemon_list)


### PR DESCRIPTION
- Create frr docker container based in new Red Hat Universal Base
  Images.

- This build a docker container based in ubi-8.
- Need to get the devel packages from centos-8 stream repos.
- Centos-8 stream repos added : base, appstream, powertools and epel

Signed-off-by: Javier Garcia <javier.martin.garcia@ibm.com>