### PR TITLE
ospf6d: fix crash when applying a route-map on a temporary route

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1440,6 +1440,7 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 	/* apply route-map */
 	if (ROUTEMAP(red)) {
 		troute.route_option = &tinfo;
+		troute.ospf6 = ospf6;
 		tinfo.ifindex = ifindex;
 		tinfo.tag = tag;
 


### PR DESCRIPTION
ospf6_routemap_rule_match_interface uses route->ospf6 field for matching
so we must fill the field in our temporary variable.

Fixes #10911.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>