### PR TITLE
tests: skip grpc test if frr not installed

### DIFF
--- a/tests/lib/test_grpc.py
+++ b/tests/lib/test_grpc.py
@@ -13,6 +13,10 @@ class TestGRPC(object):
         'S["GRPC_TRUE"]=""\n' not in open("../config.status").readlines(),
         reason="GRPC not enabled",
     )
+    @pytest.mark.skipif(
+        not os.path.isdir("/usr/share/yang"),
+        reason="YANG models aren't installed in /usr/share/yang",
+    )
     def test_exits_cleanly(self):
         basedir = os.path.dirname(inspect.getsourcefile(type(self)))
         program = os.path.join(basedir, self.program)


### PR DESCRIPTION
it wants yang models installed which will only be there if frr has been
installed before, causing `make check` to fail when run on a system on
which frr has not been installed when GRPC is enabled (--enable-grpc)

Signed-off-by: Quentin Young <qlyoung@nvidia.com>