### PR TITLE
tools: Modify all_stop to actually try to stop all daemons

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -253,11 +253,11 @@ all_start() {
 all_stop() {
 	local pids reversed
 
-	daemon_list daemons disabled
-	[ "$1" = "--reallyall" ] && daemons="$daemons $disabled"
+	daemon_list enabled_daemons disabled_daemons
+	[ "$1" = "--reallyall" ] && enabled_daemons="$enabled_daemons $disabled_daemons"
 
 	reversed=""
-	for dmninst in $daemons; do
+	for dmninst in $enabled_daemons; do
 		reversed="$dmninst $reversed"
 	done
 


### PR DESCRIPTION
If a user enters:
/usr/lib/frr/frrinit.sh start
<modifies daemons file to remove a daemon from being used>
then calls:
/usr/lib/frr/frrinit.sh stop

The daemon(s) that are removed from the file are not stopped.

Apparently in shell scripting naming the variables the same
as the callee does not work as one would think.  Just renaming
the variable to something else solved the problem.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>