### PR TITLE
bgpd: refactor type of srv6_locator_chunks list

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -523,7 +523,7 @@ static uint32_t alloc_new_sid(struct bgp *bgp, uint32_t index,
 			      struct in6_addr *sid_locator)
 {
 	struct listnode *node;
-	struct prefix_ipv6 *chunk;
+	struct srv6_locator_chunk *chunk;
 	struct in6_addr sid_buf;
 	bool alloced = false;
 	int label = 0;
@@ -532,8 +532,8 @@ static uint32_t alloc_new_sid(struct bgp *bgp, uint32_t index,
 		return false;
 
 	for (ALL_LIST_ELEMENTS_RO(bgp->srv6_locator_chunks, node, chunk)) {
-		*sid_locator = chunk->prefix;
-		sid_buf = chunk->prefix;
+		*sid_locator = chunk->prefix.prefix;
+		sid_buf = chunk->prefix.prefix;
 		if (index != 0) {
 			label = index << 12;
 			transpose_sid(&sid_buf, label, 64, 16);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -286,7 +286,7 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 {
 	int ret;
 	struct listnode *node, *nnode;
-	struct prefix_ipv6 *chunk;
+	struct srv6_locator_chunk *chunk;
 	struct bgp_srv6_function *func;
 	struct bgp *bgp_vrf;
 	struct in6_addr *tovpn_sid;
@@ -9316,7 +9316,7 @@ DEFPY (show_bgp_srv6,
 {
 	struct bgp *bgp;
 	struct listnode *node;
-	struct prefix_ipv6 *chunk;
+	struct srv6_locator_chunk *chunk;
 	struct bgp_srv6_function *func;
 	struct in6_addr *tovpn4_sid;
 	struct in6_addr *tovpn6_sid;
@@ -9331,7 +9331,7 @@ DEFPY (show_bgp_srv6,
 	vty_out(vty, "locator_name: %s\n", bgp->srv6_locator_name);
 	vty_out(vty, "locator_chunks:\n");
 	for (ALL_LIST_ELEMENTS_RO(bgp->srv6_locator_chunks, node, chunk)) {
-		prefix2str(chunk, buf, sizeof(buf));
+		prefix2str(&chunk->prefix, buf, sizeof(buf));
 		vty_out(vty, "- %s\n", buf);
 	}
 


### PR DESCRIPTION
Since additional information such as block_bits_length is needed to generate SIDs properly, the type of elements in srv6_locator_chunks list is extended from `struct prefix_ipv6 *` to `struct srv6_locator_chunk *`. Even in terms of variable name, `struct srv6_locator_chunk *` is appropriate.
