### PR TITLE
zebra: use "assert" instead of unnecessary check

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3273,7 +3273,7 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 
 	memcpy(&mac, RTA_DATA(tb[NDA_LLADDR]), ETH_ALEN);
 
-	if ((NDA_VLAN <= NDA_MAX) && tb[NDA_VLAN]) {
+	if (tb[NDA_VLAN]) {
 		vid_present = 1;
 		vid = *(uint16_t *)RTA_DATA(tb[NDA_VLAN]);
 		snprintf(vid_buf, sizeof(vid_buf), " VLAN %u", vid);

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -649,10 +649,9 @@ static int zebra_evpn_map_vlan_ns(struct ns *ns,
 	struct zebra_l2info_vxlan *vxl = NULL;
 	struct zebra_from_svi_param *in_param =
 		(struct zebra_from_svi_param *)_in_param;
-	int found = 0;
 
-	if (!in_param)
-		return NS_WALK_STOP;
+	assert(p_zevpn && in_param);
+
 	br_if = in_param->br_if;
 	zif = in_param->zif;
 	assert(zif);
@@ -676,17 +675,13 @@ static int zebra_evpn_map_vlan_ns(struct ns *ns,
 
 		if (!in_param->bridge_vlan_aware
 		    || vxl->access_vlan == in_param->vid) {
-			found = 1;
-			break;
+			zevpn = zebra_evpn_lookup(vxl->vni);
+			*p_zevpn = zevpn;
+			return NS_WALK_STOP;
 		}
 	}
-	if (!found)
-		return NS_WALK_CONTINUE;
 
-	zevpn = zebra_evpn_lookup(vxl->vni);
-	if (p_zevpn)
-		*p_zevpn = zevpn;
-	return NS_WALK_STOP;
+	return NS_WALK_CONTINUE;
 }
 
 /*
@@ -831,8 +826,7 @@ static int zvni_map_to_macvlan_ns(struct ns *ns,
 	struct interface *tmp_if = NULL;
 	struct zebra_if *zif;
 
-	if (!in_param)
-		return NS_WALK_STOP;
+	assert(in_param && p_ifp);
 
 	/* Identify corresponding VLAN interface. */
 	for (rn = route_top(zns->if_table); rn; rn = route_next(rn)) {
@@ -846,8 +840,7 @@ static int zvni_map_to_macvlan_ns(struct ns *ns,
 			continue;
 
 		if (zif->link == in_param->svi_if) {
-			if (p_ifp)
-				*p_ifp = tmp_if;
+			*p_ifp = tmp_if;
 			return NS_WALK_STOP;
 		}
 	}


### PR DESCRIPTION
Two minor commits:

- zebra: use "assert" instead of unnecessary check

Like `zvni_map_to_svi_ns()` for `ns_walk_func()`, just use "assert"
instead of unnecessary check.

Since these parameters for `ns_walk_func()`, e.g. `in_param` and others,
must not be NULL. So use `assert` to ensure the these parameters, and
remove those unnecessary checks.

- zebra: remove unnecessary check for parsing macfdb
    
Since `NDA_VLAN` is no longer mannually defined in header file,
the check for `NDA_VLAN` should be removed.