### PR TITLE
zebra: adjust the warnings for ESI of evpn-mh

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3867,19 +3867,19 @@ DEFUN (bgp_evpn_advertise_type5,
 
 	if (!(afi == AFI_IP || afi == AFI_IP6)) {
 		vty_out(vty,
-			"%%only ipv4 or ipv6 address families are supported\n");
+			"%% Only ipv4 or ipv6 address families are supported\n");
 		return CMD_WARNING;
 	}
 
 	if (safi != SAFI_UNICAST) {
 		vty_out(vty,
-			"%%only ipv4 unicast or ipv6 unicast are supported\n");
+			"%% Only ipv4 unicast or ipv6 unicast are supported\n");
 		return CMD_WARNING;
 	}
 
 	if ((oly != OVERLAY_INDEX_TYPE_NONE)
 	    && (oly != OVERLAY_INDEX_GATEWAY_IP)) {
-		vty_out(vty, "%%Unknown overlay-index type specified\n");
+		vty_out(vty, "%% Unknown overlay-index type specified\n");
 		return CMD_WARNING;
 	}
 
@@ -4058,13 +4058,13 @@ DEFUN (no_bgp_evpn_advertise_type5,
 
 	if (!(afi == AFI_IP || afi == AFI_IP6)) {
 		vty_out(vty,
-			"%%only ipv4 or ipv6 address families are supported\n");
+			"%% Only ipv4 or ipv6 address families are supported\n");
 		return CMD_WARNING;
 	}
 
 	if (safi != SAFI_UNICAST) {
 		vty_out(vty,
-			"%%only ipv4 unicast or ipv6 unicast are supported\n");
+			"%% Only ipv4 unicast or ipv6 unicast are supported\n");
 		return CMD_WARNING;
 	}
 
@@ -4495,7 +4495,7 @@ DEFPY(show_bgp_l2vpn_evpn_es,
 
 	if (esi_str) {
 		if (!str_to_esi(esi_str, &esi)) {
-			vty_out(vty, "%%Malformed ESI\n");
+			vty_out(vty, "%% Malformed ESI\n");
 			return CMD_WARNING;
 		}
 		bgp_evpn_es_show_esi(vty, &esi, uj);
@@ -4517,7 +4517,7 @@ DEFPY(show_bgp_l2vpn_evpn_es_vrf, show_bgp_l2vpn_evpn_es_vrf_cmd,
 
 	if (esi_str) {
 		if (!str_to_esi(esi_str, &esi)) {
-			vty_out(vty, "%%Malformed ESI\n");
+			vty_out(vty, "%% Malformed ESI\n");
 			return CMD_WARNING;
 		}
 		bgp_evpn_es_vrf_show_esi(vty, &esi, uj);
@@ -5132,7 +5132,7 @@ DEFPY_HIDDEN(
 
 	if (esi_str) {
 		if (!str_to_esi(esi_str, &esi)) {
-			vty_out(vty, "%%Malformed ESI\n");
+			vty_out(vty, "%% Malformed ESI\n");
 			return CMD_WARNING;
 		}
 		esi_p = &esi;
@@ -5165,7 +5165,7 @@ DEFPY_HIDDEN(
 
 	if (esi_str) {
 		if (!str_to_esi(esi_str, &esi)) {
-			vty_out(vty, "%%Malformed ESI\n");
+			vty_out(vty, "%% Malformed ESI\n");
 			return CMD_WARNING;
 		}
 		esi_p = &esi;
@@ -5267,19 +5267,19 @@ DEFPY_HIDDEN(test_es_add,
 
 	bgp = bgp_get_evpn();
 	if (!bgp) {
-		vty_out(vty, "%%EVPN BGP instance not yet created\n");
+		vty_out(vty, "%% EVPN BGP instance not yet created\n");
 		return CMD_WARNING;
 	}
 
 	if (!str_to_esi(esi_str, &esi)) {
-		vty_out(vty, "%%Malformed ESI\n");
+		vty_out(vty, "%% Malformed ESI\n");
 		return CMD_WARNING;
 	}
 
 	if (no) {
 		ret = bgp_evpn_local_es_del(bgp, &esi);
 		if (ret == -1) {
-			vty_out(vty, "%%Failed to delete ES\n");
+			vty_out(vty, "%% Failed to delete ES\n");
 			return CMD_WARNING;
 		}
 	} else {
@@ -5292,7 +5292,7 @@ DEFPY_HIDDEN(test_es_add,
 		ret = bgp_evpn_local_es_add(bgp, &esi, vtep_ip, oper_up,
 					    EVPN_MH_DF_PREF_MIN, false);
 		if (ret == -1) {
-			vty_out(vty, "%%Failed to add ES\n");
+			vty_out(vty, "%% Failed to add ES\n");
 			return CMD_WARNING;
 		}
 	}
@@ -5316,25 +5316,25 @@ DEFPY_HIDDEN(test_es_vni_add,
 
 	bgp = bgp_get_evpn();
 	if (!bgp) {
-		vty_out(vty, "%%EVPN BGP instance not yet created\n");
+		vty_out(vty, "%% EVPN BGP instance not yet created\n");
 		return CMD_WARNING;
 	}
 
 	if (!str_to_esi(esi_str, &esi)) {
-		vty_out(vty, "%%Malformed ESI\n");
+		vty_out(vty, "%% Malformed ESI\n");
 		return CMD_WARNING;
 	}
 
 	if (no) {
 		ret = bgp_evpn_local_es_evi_del(bgp, &esi, vni);
 		if (ret == -1) {
-			vty_out(vty, "%%Failed to deref ES VNI\n");
+			vty_out(vty, "%% Failed to deref ES VNI\n");
 			return CMD_WARNING;
 		}
 	} else {
 		ret = bgp_evpn_local_es_evi_add(bgp, &esi, vni);
 		if (ret == -1) {
-			vty_out(vty, "%%Failed to ref ES VNI\n");
+			vty_out(vty, "%% Failed to ref ES VNI\n");
 			return CMD_WARNING;
 		}
 	}

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -934,12 +934,12 @@ static void bgp_clear_vty_error(struct vty *vty, struct peer *peer, afi_t afi,
 	switch (error) {
 	case BGP_ERR_AF_UNCONFIGURED:
 		vty_out(vty,
-			"%%BGP: Enable %s address family for the neighbor %s\n",
+			"%% BGP: Enable %s address family for the neighbor %s\n",
 			get_afi_safi_str(afi, safi, false), peer->host);
 		break;
 	case BGP_ERR_SOFT_RECONFIG_UNCONFIGURED:
 		vty_out(vty,
-			"%%BGP: Inbound soft reconfig for %s not possible as it\n      has neither refresh capability, nor inbound soft reconfig\n",
+			"%% BGP: Inbound soft reconfig for %s not possible as it\n      has neither refresh capability, nor inbound soft reconfig\n",
 			peer->host);
 		break;
 	default:
@@ -1086,7 +1086,7 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 			peer = peer_lookup(bgp, &su);
 			if (!peer) {
 				vty_out(vty,
-					"%%BGP: Unknown neighbor - \"%s\"\n",
+					"%% BGP: Unknown neighbor - \"%s\"\n",
 					arg);
 				return CMD_WARNING;
 			}
@@ -1113,7 +1113,7 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 		group = peer_group_lookup(bgp, arg);
 		if (!group) {
-			vty_out(vty, "%%BGP: No such peer-group %s\n", arg);
+			vty_out(vty, "%% BGP: No such peer-group %s\n", arg);
 			return CMD_WARNING;
 		}
 
@@ -1128,7 +1128,7 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 		if (!found)
 			vty_out(vty,
-				"%%BGP: No %s peer belonging to peer-group %s is configured\n",
+				"%% BGP: No %s peer belonging to peer-group %s is configured\n",
 				get_afi_safi_str(afi, safi, false), arg);
 
 		return CMD_SUCCESS;
@@ -1163,7 +1163,7 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 		if (!found)
 			vty_out(vty,
-				"%%BGP: No external %s peer is configured\n",
+				"%% BGP: No external %s peer is configured\n",
 				get_afi_safi_str(afi, safi, false));
 
 		return CMD_SUCCESS;
@@ -1200,7 +1200,7 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 		if (!found)
 			vty_out(vty,
-				"%%BGP: No %s peer is configured with AS %s\n",
+				"%% BGP: No %s peer is configured with AS %s\n",
 				get_afi_safi_str(afi, safi, false), arg);
 
 		return CMD_SUCCESS;

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3392,7 +3392,8 @@ DEFPY(zebra_evpn_es_id,
 			ret = zebra_evpn_es_type0_esi_update(zif, zero_esi);
 
 		if (ret == -1) {
-			vty_out(vty, "%%Failed to clear ES local id\n");
+			vty_out(vty,
+				"%% Failed to clear ES local id or ESI name\n");
 			return CMD_WARNING;
 		}
 	} else {
@@ -3404,13 +3405,14 @@ DEFPY(zebra_evpn_es_id,
 
 		if (esi_str) {
 			if (!str_to_esi(esi_str, &esi)) {
-				vty_out(vty, "%% Malformed ESI\n");
+				vty_out(vty, "%% Malformed ESI name\n");
 				return CMD_WARNING;
 			}
 			ret = zebra_evpn_es_type0_esi_update(zif, &esi);
 		} else {
 			if (!es_lid) {
-				vty_out(vty, "%%Specify local ES ID\n");
+				vty_out(vty,
+					"%% Specify ES local id or ESI name\n");
 				return CMD_WARNING;
 			}
 			ret = zebra_evpn_es_lid_update(zif, es_lid);

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3286,7 +3286,7 @@ DEFPY_HIDDEN(zebra_evpn_es_bypass, zebra_evpn_es_bypass_cmd,
 	} else {
 		if (!zebra_evpn_is_if_es_capable(zif)) {
 			vty_out(vty,
-				"%%DF bypass cannot be associated with this interface type\n");
+				"%% DF bypass cannot be associated with this interface type\n");
 			return CMD_WARNING;
 		}
 		zebra_evpn_es_bypass_cfg_update(zif, true);
@@ -3311,7 +3311,7 @@ DEFPY(zebra_evpn_es_pref, zebra_evpn_es_pref_cmd,
 	} else {
 		if (!zebra_evpn_is_if_es_capable(zif)) {
 			vty_out(vty,
-				"%%DF preference cannot be associated with this interface type\n");
+				"%% DF preference cannot be associated with this interface type\n");
 			return CMD_WARNING;
 		}
 		zebra_evpn_es_df_pref_update(zif, df_pref);
@@ -3341,25 +3341,26 @@ DEFPY(zebra_evpn_es_sys_mac,
 
 		ret = zebra_evpn_es_sys_mac_update(zif, &zero_mac);
 		if (ret == -1) {
-			vty_out(vty, "%%Failed to clear ES sysmac\n");
+			vty_out(vty, "%% Failed to clear ES sysmac\n");
 			return CMD_WARNING;
 		}
 	} else {
 
 		if (!zebra_evpn_is_if_es_capable(zif)) {
 			vty_out(vty,
-				"%%ESI cannot be associated with this interface type\n");
+				"%% ESI cannot be associated with this interface type\n");
 			return CMD_WARNING;
 		}
 
 		if  (!mac || is_zero_mac(&mac->eth_addr)) {
-			vty_out(vty, "%%ES sysmac value is invalid\n");
+			vty_out(vty, "%% ES sysmac value is invalid\n");
 			return CMD_WARNING;
 		}
 
 		ret = zebra_evpn_es_sys_mac_update(zif, &mac->eth_addr);
 		if (ret == -1) {
-			vty_out(vty, "%%ESI already exists on a different interface\n");
+			vty_out(vty,
+				"%% ESI already exists on a different interface\n");
 			return CMD_WARNING;
 		}
 	}
@@ -3399,7 +3400,7 @@ DEFPY(zebra_evpn_es_id,
 	} else {
 		if (!zebra_evpn_is_if_es_capable(zif)) {
 			vty_out(vty,
-				"%%ESI cannot be associated with this interface type\n");
+				"%% ESI cannot be associated with this interface type\n");
 			return CMD_WARNING;
 		}
 
@@ -3420,7 +3421,7 @@ DEFPY(zebra_evpn_es_id,
 
 		if (ret == -1) {
 			vty_out(vty,
-					"%%ESI already exists on a different interface\n");
+				"%% ESI already exists on a different interface\n");
 			return CMD_WARNING;
 		}
 	}


### PR DESCRIPTION
3 changes:

- zebra: adjust the warnings for ESI of evpn-mh
Since there are two kinds of ESI (Type-0 and Type-3),
the warnings should distinguish between the two cases.


- zebra: add whitespace after "%%" for prompt

- bgpd: add whitespace after "%%" for prompt