### PR TITLE
bgpd: Show `match script SCRIPT` in running config

### DIFF
--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -276,6 +276,7 @@ DECLARE_QOBJ_TYPE(route_map);
 #define IS_MATCH_LOCAL_PREF(C)                                                 \
 	(strmatch(C, "frr-bgp-route-map:match-local-preference"))
 #define IS_MATCH_ALIAS(C) (strmatch(C, "frr-bgp-route-map:match-alias"))
+#define IS_MATCH_SCRIPT(C) (strmatch(C, "frr-bgp-route-map:match-script"))
 #define IS_MATCH_ORIGIN(C)                                                     \
 	(strmatch(C, "frr-bgp-route-map:match-origin"))
 #define IS_MATCH_RPKI(C) (strmatch(C, "frr-bgp-route-map:rpki"))

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -635,6 +635,11 @@ void route_map_condition_show(struct vty *vty, const struct lyd_node *dnode,
 			yang_dnode_get_string(
 				dnode,
 				"./rmap-match-condition/frr-bgp-route-map:alias"));
+	} else if (IS_MATCH_SCRIPT(condition)) {
+		vty_out(vty, " match script %s\n",
+			yang_dnode_get_string(
+				dnode,
+				"./rmap-match-condition/frr-bgp-route-map:script"));
 	} else if (IS_MATCH_ORIGIN(condition)) {
 		vty_out(vty, " match origin %s\n",
 			yang_dnode_get_string(


### PR DESCRIPTION
Before:
```
route-map lua permit 10
exit
```

After:
```
route-map lua permit 10
 match script rm
exit
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>