### PR TITLE
zebra: fix missing vrf change of l2vni on vxlan interface

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5130,8 +5130,13 @@ int zebra_vxlan_if_update(struct interface *ifp, uint16_t chgflags)
 		zevpn_vxlan_if_set(zevpn, ifp, true /* set */);
 		vlan_if = zvni_map_to_svi(vxl->access_vlan,
 					  zif->brslave_info.br_if);
-		if (vlan_if)
+		if (vlan_if) {
 			zevpn->svi_if = vlan_if;
+			zevpn->vrf_id = vlan_if->vrf->vrf_id;
+			zl3vni = zl3vni_from_vrf(vlan_if->vrf->vrf_id);
+			if (zl3vni)
+				listnode_add_sort_nodup(zl3vni->l2vnis, zevpn);
+		}
 
 		/* Take further actions needed.
 		 * Note that if we are here, there is a change of interest.


### PR DESCRIPTION
The bounded vrf of `l2vni/zevpn` have wrong relation with the order
in which vxlan interface and svi interface are set.

If set vxlan interface with vlanid first, then set svi interface with
vrf, it is ok that vxlan interface will get correct `vrf` inherited
from svi. But reverse the set sequence (i.e. set svi first, then vxlan),
vxlan interface can't get correct `vrf`, becasue the handling of
`ZEBRA_VXLIF_VLAN_CHANGE` missed inheritting `vrf` by mistake.

```
host# do show  evpn vni 101
VNI: 101
Type: L2
Tenant VRF: vrf1
```

So update `vrf` ("Tenant VRF") of l2vni in `zebra_vxlan_if_update()`.