### PR TITLE
build: stick `-g` into LDFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -325,6 +325,9 @@ else
    fi
 fi
 
+dnl just stick -g into LDFLAGS, if we don't have it in CFLAGS it won't do much
+LDFLAGS="$LDFLAGS -g"
+
 AM_CONDITIONAL([DEV_BUILD], [test "$enable_dev_build" = "yes"])
 
 dnl always want these CFLAGS


### PR DESCRIPTION
Without `-g` in LDFLAGS we won't get debug info even if it's enabled in CFLAGS.  Since we're controlling debug info through CFLAGS, there's no harm in always having `-g` in LDFLAGS.

---

Not sure how/when this got broken, but anyway this is the reason we're missing proper debug info in a whole bunch of backtraces / bug reports :disappointed: 