### PR TITLE
zebra: don't send RAs w/o LLv6 or on bridge-ports

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -490,9 +490,11 @@ static void rtadv_timer(struct thread *thread)
 
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
 		FOR_ALL_INTERFACES (vrf, ifp) {
-			if (if_is_loopback(ifp) || !if_is_operative(ifp)
-			    || (vrf_is_backend_netns()
-				&& ifp->vrf->vrf_id != zvrf->vrf->vrf_id))
+			if (if_is_loopback(ifp) || !if_is_operative(ifp) ||
+			    IS_ZEBRA_IF_BRIDGE_SLAVE(ifp) ||
+			    !connected_get_linklocal(ifp) ||
+			    (vrf_is_backend_netns() &&
+			     ifp->vrf->vrf_id != zvrf->vrf->vrf_id))
 				continue;
 
 			zif = ifp->info;


### PR DESCRIPTION
It's confusing for a user to see 'Tx RA failed' in the logs when
they've enabled RAs (either through interface config or BGP unnumbered)
on an interface that can't send them.  Let's avoid sending RAs on
interfaces that are bridge_slaves or don't have a link-local address,
since they are the two of the most common reasons for RA Tx failures.

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>