### PR TITLE
bgpd : use "assert" for one check on evpn-mh

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1273,9 +1273,9 @@ void bgp_evpn_mh_config_ead_export_rt(struct bgp *bgp,
 				}
 			}
 
-			if (node_to_del)
-				list_delete_node(bgp_mh_info->ead_es_export_rtl,
-						 node_to_del);
+			assert(node_to_del);
+			list_delete_node(bgp_mh_info->ead_es_export_rtl,
+					 node_to_del);
 		}
 	} else {
 		listnode_add_sort(bgp_mh_info->ead_es_export_rtl, ecomcfg);


### PR DESCRIPTION
"no ead-es-route-target export RT":
Since existance is already checked in `bgp_evpn_ead_es_rt_cmd`
with `bgp_evpn_rt_matches_existing()`, there MUST be a deleting
node in evpn's `bgp_mh_info->ead_es_export_rtl` list.

Just modify the check for deleting node to an `assert`.