### PR TITLE
bgpd: Fix memory leak in subgroup_announce_check

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2207,6 +2207,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 			ret = route_map_apply(ROUTE_MAP_OUT(filter), p,
 					      &rmap_path);
 
+		bgp_attr_flush(&dummy_attr);
 		peer->rmap_type = 0;
 
 		if (ret == RMAP_DENYMATCH) {
@@ -2216,7 +2217,6 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 					peer->host, p,
 					ROUTE_MAP_OUT_NAME(filter));
 
-			bgp_attr_flush(&dummy_attr);
 			return false;
 		}
 	}


### PR DESCRIPTION
Flush dummy attr to release objects allocated by route-map.

Similar to #9620.