### PR TITLE
bgpd: Wait till at least one group is in sync with the RPKI server

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -67,6 +67,7 @@ static struct thread *t_rpki;
 
 DEFINE_MTYPE_STATIC(BGPD, BGP_RPKI_CACHE, "BGP RPKI Cache server");
 DEFINE_MTYPE_STATIC(BGPD, BGP_RPKI_CACHE_GROUP, "BGP RPKI Cache server group");
+DEFINE_MTYPE_STATIC(BGPD, BGP_RPKI_RTRLIB, "BGP RPKI RTRLib");
 
 #define POLLING_PERIOD_DEFAULT 3600
 #define EXPIRE_INTERVAL_DEFAULT 7200
@@ -156,17 +157,17 @@ static const struct route_map_rule_cmd route_match_rpki_cmd = {
 
 static void *malloc_wrapper(size_t size)
 {
-	return XMALLOC(MTYPE_BGP_RPKI_CACHE, size);
+	return XMALLOC(MTYPE_BGP_RPKI_RTRLIB, size);
 }
 
 static void *realloc_wrapper(void *ptr, size_t size)
 {
-	return XREALLOC(MTYPE_BGP_RPKI_CACHE, ptr, size);
+	return XREALLOC(MTYPE_BGP_RPKI_RTRLIB, ptr, size);
 }
 
 static void free_wrapper(void *ptr)
 {
-	XFREE(MTYPE_BGP_RPKI_CACHE, ptr);
+	XFREE(MTYPE_BGP_RPKI_RTRLIB, ptr);
 }
 
 static void init_tr_socket(struct cache *cache)
@@ -610,6 +611,7 @@ static int start(void)
 			   rpki_connection_status_cb, NULL);
 	if (ret == RTR_ERROR) {
 		RPKI_DEBUG("Init rtr_mgr failed.");
+		rtr_mgr_free(rtr_config);
 		return ERROR;
 	}
 
@@ -620,6 +622,14 @@ static int start(void)
 		rtr_mgr_free(rtr_config);
 		return ERROR;
 	}
+
+	/* Wait till at least one group is fully synchronized
+	 * with the server.
+	 * https://rtrlib.readthedocs.io/en/latest/development.html
+	 */
+	while (!rtr_mgr_conf_in_sync(rtr_config))
+		sleep(1);
+
 	rtr_is_running = 1;
 
 	XFREE(MTYPE_BGP_RPKI_CACHE_GROUP, groups);
@@ -902,9 +912,8 @@ static void free_cache(struct cache *cache)
 	if (cache->type == TCP) {
 		XFREE(MTYPE_BGP_RPKI_CACHE, cache->tr_config.tcp_config->host);
 		XFREE(MTYPE_BGP_RPKI_CACHE, cache->tr_config.tcp_config->port);
-		if (cache->tr_config.tcp_config->bindaddr)
-			XFREE(MTYPE_BGP_RPKI_CACHE,
-			      cache->tr_config.tcp_config->bindaddr);
+		XFREE(MTYPE_BGP_RPKI_CACHE,
+		      cache->tr_config.tcp_config->bindaddr);
 		XFREE(MTYPE_BGP_RPKI_CACHE, cache->tr_config.tcp_config);
 	}
 #if defined(FOUND_SSH)
@@ -916,9 +925,8 @@ static void free_cache(struct cache *cache)
 		      cache->tr_config.ssh_config->client_privkey_path);
 		XFREE(MTYPE_BGP_RPKI_CACHE,
 		      cache->tr_config.ssh_config->server_hostkey_path);
-		if (cache->tr_config.ssh_config->bindaddr)
-			XFREE(MTYPE_BGP_RPKI_CACHE,
-			      cache->tr_config.ssh_config->bindaddr);
+		XFREE(MTYPE_BGP_RPKI_CACHE,
+		      cache->tr_config.ssh_config->bindaddr);
 		XFREE(MTYPE_BGP_RPKI_CACHE, cache->tr_config.ssh_config);
 	}
 #endif


### PR DESCRIPTION
Memory leak happens when doing reset (stop/start) for RPKI quickly.

Before:
```
$ for x in $(seq 1 60); do vtysh -c 'con' -c 'rpki' -c 'rpki reset'; sleep 1; done
$ vtysh -c 'show memory | include RPKI'
BGP RPKI Cache server         :   849699 variable  84039224   849701  90872440
BGP RPKI Cache server group   :        0     48           0        1        56
```

After:
```
$ for x in $(seq 1 60); do vtysh -c 'con' -c 'rpki' -c 'rpki reset'; sleep 1; done
$ vtysh -c 'show memory | include RPKI'
BGP RPKI Cache server         :       12 variable       576       12       576
BGP RPKI Cache server group   :        0     48           0        1        56
BGP RPKI RTRLib               :   849657 variable  34438264   849659  41293240
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>