### PR TITLE
pimd: introduce ip pim passive command

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -234,6 +234,10 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    and would like pim to use a specific source address associated with
    that interface.
 
+.. clicmd:: ip pim passive
+
+   Disable sending and receiving pim control packets on the interface.
+
 .. clicmd:: ip igmp
 
    Tell pim to receive IGMP reports and Query on this interface. The default

--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -158,6 +158,10 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    and would like pim to use a specific source address associated with
    that interface.
 
+.. clicmd:: ipv6 pim passive
+
+   Disable sending and receiving pim control packets on the interface.
+
 .. clicmd:: ipv6 mld
 
    Tell pim to receive MLD reports and Query on this interface. The default

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -41,7 +41,7 @@
 #include "pim_addr.h"
 #include "pim_nht.h"
 #include "pim_bsm.h"
-
+#include "pim_iface.h"
 
 #ifndef VTYSH_EXTRACT_PL
 #include "pimd/pim6_cmd_clippy.c"
@@ -216,21 +216,55 @@ DEFPY (no_ipv6_pim_register_suppress,
 
 DEFPY (interface_ipv6_pim,
        interface_ipv6_pim_cmd,
-       "ipv6 pim",
+       "ipv6 pim [passive$passive]",
        IPV6_STR
-       PIM_STR)
+       PIM_STR
+       "Disable exchange of protocol packets\n")
 {
-	return pim_process_ip_pim_cmd(vty);
+	int ret;
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct pim_interface *pim_ifp;
+
+	ret = pim_process_ip_pim_cmd(vty);
+
+	if (ret != NB_OK)
+		return ret;
+
+	pim_ifp = ifp->info;
+	if (!pim_ifp)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	if (passive)
+		pim_ifp->pim_passive_enable = true;
+
+	return CMD_SUCCESS;
 }
 
 DEFPY (interface_no_ipv6_pim,
        interface_no_ipv6_pim_cmd,
-       "no ipv6 pim",
+       "no ipv6 pim [passive$passive]",
        NO_STR
        IPV6_STR
-       PIM_STR)
+       PIM_STR
+       "Disable exchange of protocol packets\n")
 {
-	return pim_process_no_ip_pim_cmd(vty);
+	int ret;
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct pim_interface *pim_ifp;
+
+	ret = pim_process_no_ip_pim_cmd(vty);
+
+	if (ret != NB_OK)
+		return ret;
+
+	pim_ifp = ifp->info;
+	if (!pim_ifp)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	if (passive)
+		pim_ifp->pim_passive_enable = false;
+
+	return CMD_SUCCESS;
 }
 
 DEFPY (interface_ipv6_pim_drprio,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -222,20 +222,14 @@ DEFPY (interface_ipv6_pim,
        "Disable exchange of protocol packets\n")
 {
 	int ret;
-	VTY_DECLVAR_CONTEXT(interface, ifp);
-	struct pim_interface *pim_ifp;
 
 	ret = pim_process_ip_pim_cmd(vty);
 
 	if (ret != NB_OK)
 		return ret;
 
-	pim_ifp = ifp->info;
-	if (!pim_ifp)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	if (passive)
-		pim_ifp->pim_passive_enable = true;
+		return pim_process_ip_pim_passive_cmd(vty, true);
 
 	return CMD_SUCCESS;
 }
@@ -248,23 +242,10 @@ DEFPY (interface_no_ipv6_pim,
        PIM_STR
        "Disable exchange of protocol packets\n")
 {
-	int ret;
-	VTY_DECLVAR_CONTEXT(interface, ifp);
-	struct pim_interface *pim_ifp;
-
-	ret = pim_process_no_ip_pim_cmd(vty);
-
-	if (ret != NB_OK)
-		return ret;
-
-	pim_ifp = ifp->info;
-	if (!pim_ifp)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	if (passive)
-		pim_ifp->pim_passive_enable = false;
+		return pim_process_ip_pim_passive_cmd(vty, false);
 
-	return CMD_SUCCESS;
+	return pim_process_no_ip_pim_cmd(vty);
 }
 
 DEFPY (interface_ipv6_pim_drprio,

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -460,11 +460,12 @@ static int pim_assert_do(struct pim_ifchannel *ch,
 			   metric.metric_preference, metric.route_metric,
 			   PIM_FORCE_BOOLEAN(metric.rpt_bit_flag));
 	}
-	++pim_ifp->pim_ifstat_assert_send;
+	if (!pim_ifp->pim_passive_enable)
+		++pim_ifp->pim_ifstat_assert_send;
 
 	if (pim_msg_send(pim_ifp->pim_sock_fd, pim_ifp->primary_address,
 			 qpim_all_pim_routers_addr, pim_msg, pim_msg_size,
-			 ifp->name)) {
+			 ifp)) {
 		zlog_warn("%s: could not send PIM message on interface %s",
 			  __func__, ifp->name);
 		return -3;

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -303,6 +303,15 @@ int pim_assert_recv(struct interface *ifp, struct pim_neighbor *neigh,
 
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
+
+	if (pim_ifp->pim_passive_enable) {
+		if (PIM_DEBUG_PIM_PACKETS)
+			zlog_debug(
+				"skip receiving PIM message on passive interface %s",
+				ifp->name);
+		return 0;
+	}
+
 	++pim_ifp->pim_ifstat_assert_recv;
 
 	return dispatch_assert(ifp, msg_source_addr, sg.grp, msg_metric);

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -1300,6 +1300,14 @@ int pim_bsm_process(struct interface *ifp, pim_sgaddr *sg, uint8_t *buf,
 		return -1;
 	}
 
+	if (pim_ifp->pim_passive_enable) {
+		if (PIM_DEBUG_PIM_PACKETS)
+			zlog_debug(
+				"skip receiving PIM message on passive interface %s",
+				ifp->name);
+		return 0;
+	}
+
 	pim_ifp->pim_ifstat_bsm_rx++;
 	pim = pim_ifp->pim;
 	pim->bsm_rcvd++;

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -704,13 +704,15 @@ static bool pim_bsm_send_intf(uint8_t *buf, int len, struct interface *ifp,
 	}
 
 	if (pim_msg_send(pim_ifp->pim_sock_fd, pim_ifp->primary_address,
-			 dst_addr, buf, len, ifp->name)) {
+			 dst_addr, buf, len, ifp)) {
 		zlog_warn("%s: Could not send BSM message on interface: %s",
 			  __func__, ifp->name);
 		return false;
 	}
 
-	pim_ifp->pim_ifstat_bsm_tx++;
+	if (!pim_ifp->pim_passive_enable)
+		pim_ifp->pim_ifstat_bsm_tx++;
+
 	pim_ifp->pim->bsm_sent++;
 	return true;
 }

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5262,13 +5262,30 @@ DEFUN_HIDDEN (interface_ip_pim_sm,
 	return pim_process_ip_pim_cmd(vty);
 }
 
-DEFUN (interface_ip_pim,
+DEFPY (interface_ip_pim,
        interface_ip_pim_cmd,
-       "ip pim",
+       "ip pim [passive$passive]",
        IP_STR
-       PIM_STR)
+       PIM_STR
+       "Disable exchange of protocol packets\n")
 {
-	return pim_process_ip_pim_cmd(vty);
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct pim_interface *pim_ifp;
+	int ret;
+
+	ret = pim_process_ip_pim_cmd(vty);
+
+	if (ret != NB_OK)
+		return ret;
+
+	pim_ifp = ifp->info;
+	if (!pim_ifp)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	if (passive)
+		pim_ifp->pim_passive_enable = true;
+
+	return CMD_SUCCESS;
 }
 
 DEFUN_HIDDEN (interface_no_ip_pim_ssm,
@@ -5293,14 +5310,31 @@ DEFUN_HIDDEN (interface_no_ip_pim_sm,
 	return pim_process_no_ip_pim_cmd(vty);
 }
 
-DEFUN (interface_no_ip_pim,
+DEFPY (interface_no_ip_pim,
        interface_no_ip_pim_cmd,
-       "no ip pim",
+       "no ip pim [passive$passive]",
        NO_STR
        IP_STR
-       PIM_STR)
+       PIM_STR
+       "Disable exchange of protocol packets\n")
 {
-	return pim_process_no_ip_pim_cmd(vty);
+	int ret;
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct pim_interface *pim_ifp;
+
+	ret = pim_process_no_ip_pim_cmd(vty);
+
+	if (ret != NB_OK)
+		return ret;
+
+	pim_ifp = ifp->info;
+	if (!pim_ifp)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	if (passive)
+		pim_ifp->pim_passive_enable = false;
+
+	return CMD_SUCCESS;
 }
 
 /* boundaries */

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5269,8 +5269,6 @@ DEFPY (interface_ip_pim,
        PIM_STR
        "Disable exchange of protocol packets\n")
 {
-	VTY_DECLVAR_CONTEXT(interface, ifp);
-	struct pim_interface *pim_ifp;
 	int ret;
 
 	ret = pim_process_ip_pim_cmd(vty);
@@ -5278,12 +5276,8 @@ DEFPY (interface_ip_pim,
 	if (ret != NB_OK)
 		return ret;
 
-	pim_ifp = ifp->info;
-	if (!pim_ifp)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	if (passive)
-		pim_ifp->pim_passive_enable = true;
+		return pim_process_ip_pim_passive_cmd(vty, true);
 
 	return CMD_SUCCESS;
 }
@@ -5318,23 +5312,10 @@ DEFPY (interface_no_ip_pim,
        PIM_STR
        "Disable exchange of protocol packets\n")
 {
-	int ret;
-	VTY_DECLVAR_CONTEXT(interface, ifp);
-	struct pim_interface *pim_ifp;
-
-	ret = pim_process_no_ip_pim_cmd(vty);
-
-	if (ret != NB_OK)
-		return ret;
-
-	pim_ifp = ifp->info;
-	if (!pim_ifp)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	if (passive)
-		pim_ifp->pim_passive_enable = false;
+		return pim_process_ip_pim_passive_cmd(vty, false);
 
-	return CMD_SUCCESS;
+	return pim_process_no_ip_pim_cmd(vty);
 }
 
 /* boundaries */

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -2110,6 +2110,10 @@ void pim_show_interfaces_single(struct pim_instance *pim, struct vty *vty,
 						       sec_list);
 			}
 
+			if (pim_ifp->pim_passive_enable)
+				json_object_boolean_true_add(json_row,
+							     "passive");
+
 			/* PIM neighbors */
 			if (pim_ifp->pim_neighbor_list->count) {
 				json_pim_neighbors = json_object_new_object();
@@ -2276,6 +2280,12 @@ void pim_show_interfaces_single(struct pim_instance *pim, struct vty *vty,
 			} else {
 				vty_out(vty, "Address    : %pPAs\n", &ifaddr);
 			}
+
+			if (pim_ifp->pim_passive_enable)
+				vty_out(vty, "Passive    : %s\n",
+					(pim_ifp->pim_passive_enable) ? "yes"
+								      : "no");
+
 			vty_out(vty, "\n");
 
 			/* PIM neighbors */

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -352,6 +352,19 @@ int pim_process_ip_pim_cmd(struct vty *vty)
 				    FRR_PIM_AF_XPATH_VAL);
 }
 
+int pim_process_ip_pim_passive_cmd(struct vty *vty, bool enable)
+{
+	if (enable)
+		nb_cli_enqueue_change(vty, "./pim-passive-enable", NB_OP_MODIFY,
+				      "true");
+	else
+		nb_cli_enqueue_change(vty, "./pim-passive-enable", NB_OP_MODIFY,
+				      "false");
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
+				    FRR_PIM_AF_XPATH_VAL);
+}
+
 int pim_process_no_ip_pim_cmd(struct vty *vty)
 {
 	const struct lyd_node *mld_enable_dnode;

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -52,6 +52,7 @@ int pim_process_no_rp_plist_cmd(struct vty *vty, const char *rp_str,
 
 int pim_process_ip_pim_cmd(struct vty *vty);
 int pim_process_no_ip_pim_cmd(struct vty *vty);
+int pim_process_ip_pim_passive_cmd(struct vty *vty, bool enable);
 int pim_process_ip_pim_drprio_cmd(struct vty *vty, const char *drpriority_str);
 int pim_process_no_ip_pim_drprio_cmd(struct vty *vty);
 int pim_process_ip_pim_hello_cmd(struct vty *vty, const char *hello_str,

--- a/pimd/pim_hello.c
+++ b/pimd/pim_hello.c
@@ -125,6 +125,14 @@ int pim_hello_recv(struct interface *ifp, pim_addr src_addr, uint8_t *tlv_buf,
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
 
+	if (pim_ifp->pim_passive_enable) {
+		if (PIM_DEBUG_PIM_PACKETS)
+			zlog_debug(
+				"skip receiving PIM message on passive interface %s",
+				ifp->name);
+		return 0;
+	}
+
 	++pim_ifp->pim_ifstat_hello_recv;
 
 	/*

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -150,6 +150,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	       pim_ifp->gm_default_query_interval);
 
 	pim_ifp->pim_enable = pim;
+	pim_ifp->pim_passive_enable = false;
 #if PIM_IPV == 4
 	pim_ifp->igmp_enable = igmp;
 #endif

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -71,6 +71,7 @@ struct pim_secondary_addr {
 struct pim_interface {
 	bool pim_enable : 1;
 	bool pim_can_disable_join_suppression : 1;
+	bool pim_passive_enable : 1;
 
 	bool igmp_enable : 1;
 

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -164,6 +164,14 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 	pastend = tlv_buf + tlv_buf_size;
 	pim_ifp = ifp->info;
 
+	if (pim_ifp->pim_passive_enable) {
+		if (PIM_DEBUG_PIM_PACKETS)
+			zlog_debug(
+				"skip receiving PIM message on passive interface %s",
+				ifp->name);
+		return 0;
+	}
+
 	/*
 	  Parse ucast addr
 	*/

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -497,7 +497,7 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 					 pim_ifp->primary_address,
 					 qpim_all_pim_routers_addr, pim_msg,
 					 packet_size,
-					 rpf->source_nexthop.interface->name)) {
+					 rpf->source_nexthop.interface)) {
 				zlog_warn(
 					"%s: could not send PIM message on interface %s",
 					__func__,
@@ -535,8 +535,10 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 		packet_size += group_size;
 		pim_msg_build_jp_groups(grp, group, group_size);
 
-		pim_ifp->pim_ifstat_join_send += ntohs(grp->joins);
-		pim_ifp->pim_ifstat_prune_send += ntohs(grp->prunes);
+		if (!pim_ifp->pim_passive_enable) {
+			pim_ifp->pim_ifstat_join_send += ntohs(grp->joins);
+			pim_ifp->pim_ifstat_prune_send += ntohs(grp->prunes);
+		}
 
 		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
@@ -555,7 +557,7 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 					 pim_ifp->primary_address,
 					 qpim_all_pim_routers_addr, pim_msg,
 					 packet_size,
-					 rpf->source_nexthop.interface->name)) {
+					 rpf->source_nexthop.interface)) {
 				zlog_warn(
 					"%s: could not send PIM message on interface %s",
 					__func__,
@@ -574,8 +576,7 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 			pim_msg, packet_size, PIM_MSG_TYPE_JOIN_PRUNE, false);
 		if (pim_msg_send(pim_ifp->pim_sock_fd, pim_ifp->primary_address,
 				 qpim_all_pim_routers_addr, pim_msg,
-				 packet_size,
-				 rpf->source_nexthop.interface->name)) {
+				 packet_size, rpf->source_nexthop.interface)) {
 			zlog_warn(
 				"%s: could not send PIM message on interface %s",
 				__func__, rpf->source_nexthop.interface->name);

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -231,6 +231,12 @@ const struct frr_yang_module_info frr_pim_info = {
 			}
 		},
 		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/pim-passive-enable",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_pim_passive_enable_modify,
+			}
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/dr-priority",
 			.cbs = {
 				.modify = lib_interface_pim_address_family_dr_priority_modify,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -106,6 +106,8 @@ int lib_interface_pim_address_family_create(struct nb_cb_create_args *args);
 int lib_interface_pim_address_family_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_address_family_pim_enable_modify(
 	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_pim_passive_enable_modify(
+	struct nb_cb_modify_args *args);
 int lib_interface_pim_address_family_hello_interval_modify(
 	struct nb_cb_modify_args *args);
 int lib_interface_pim_address_family_hello_holdtime_modify(

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1624,6 +1624,32 @@ int lib_interface_pim_address_family_pim_enable_modify(struct nb_cb_modify_args 
 }
 
 /*
+ * XPath:
+ * /frr-interface:lib/interface/frr-pim:pim/address-family/pim-passive-enable
+ */
+int lib_interface_pim_address_family_pim_passive_enable_modify(
+	struct nb_cb_modify_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_ABORT:
+	case NB_EV_PREPARE:
+		break;
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		pim_ifp->pim_passive_enable =
+			yang_dnode_get_bool(args->dnode, NULL);
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/hello-interval
  */
 int lib_interface_pim_address_family_hello_interval_modify(

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -737,7 +737,7 @@ static int hello_send(struct interface *ifp, uint16_t holdtime)
 
 	if (pim_msg_send(pim_ifp->pim_sock_fd, pim_ifp->primary_address,
 			 qpim_all_pim_routers_addr, pim_msg, pim_msg_size,
-			 ifp->name)) {
+			 ifp)) {
 		if (PIM_DEBUG_PIM_HELLO) {
 			zlog_debug(
 				"%s: could not send PIM message on interface %s",
@@ -766,8 +766,10 @@ int pim_hello_send(struct interface *ifp, uint16_t holdtime)
 		return -1;
 	}
 
-	++pim_ifp->pim_ifstat_hello_sent;
-	PIM_IF_FLAG_SET_HELLO_SENT(pim_ifp->flags);
+	if (!pim_ifp->pim_passive_enable) {
+		++pim_ifp->pim_ifstat_hello_sent;
+		PIM_IF_FLAG_SET_HELLO_SENT(pim_ifp->flags);
+	}
 
 	return 0;
 }

--- a/pimd/pim_pim.h
+++ b/pimd/pim_pim.h
@@ -58,7 +58,7 @@ int pim_pim_packet(struct interface *ifp, uint8_t *buf, size_t len,
 		   pim_sgaddr sg);
 
 int pim_msg_send(int fd, pim_addr src, pim_addr dst, uint8_t *pim_msg,
-		 int pim_msg_size, const char *ifname);
+		 int pim_msg_size, struct interface *ifp);
 
 int pim_hello_send(struct interface *ifp, uint16_t holdtime);
 #endif /* PIM_PIM_H */

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -147,6 +147,14 @@ int pim_register_stop_recv(struct interface *ifp, uint8_t *buf, int buf_size)
 	bool handling_star = false;
 	int l;
 
+	if (pim_ifp->pim_passive_enable) {
+		if (PIM_DEBUG_PIM_PACKETS)
+			zlog_debug(
+				"skip receiving PIM message on passive interface %s",
+				ifp->name);
+		return 0;
+	}
+
 	++pim_ifp->pim_ifstat_reg_stop_recv;
 
 	memset(&sg, 0, sizeof(sg));

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -449,6 +449,14 @@ int pim_register_recv(struct interface *ifp, pim_addr dest_addr,
 	struct pim_instance *pim = pim_ifp->pim;
 	pim_addr rp_addr;
 
+	if (pim_ifp->pim_passive_enable) {
+		if (PIM_DEBUG_PIM_PACKETS)
+			zlog_debug(
+				"skip receiving PIM message on passive interface %s",
+				ifp->name);
+		return 0;
+	}
+
 #define PIM_MSG_REGISTER_BIT_RESERVED_LEN 4
 	ip_hdr = (tlv_buf + PIM_MSG_REGISTER_BIT_RESERVED_LEN);
 

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -100,14 +100,16 @@ void pim_register_stop_send(struct interface *ifp, pim_sgaddr *sg, pim_addr src,
 		return;
 	}
 	if (pim_msg_send(pinfo->pim_sock_fd, src, originator, buffer,
-			 b1length + PIM_MSG_REGISTER_STOP_LEN, ifp->name)) {
+			 b1length + PIM_MSG_REGISTER_STOP_LEN, ifp)) {
 		if (PIM_DEBUG_PIM_TRACE) {
 			zlog_debug(
 				"%s: could not send PIM register stop message on interface %s",
 				__func__, ifp->name);
 		}
 	}
-	++pinfo->pim_ifstat_reg_stop_send;
+
+	if (!pinfo->pim_passive_enable)
+		++pinfo->pim_ifstat_reg_stop_send;
 }
 
 static void pim_reg_stop_upstream(struct pim_instance *pim,
@@ -266,10 +268,11 @@ void pim_register_send(const uint8_t *buf, int buf_size, pim_addr src,
 	pim_msg_build_header(src, dst, buffer, buf_size + PIM_MSG_REGISTER_LEN,
 			     PIM_MSG_TYPE_REGISTER, false);
 
-	++pinfo->pim_ifstat_reg_send;
+	if (!pinfo->pim_passive_enable)
+		++pinfo->pim_ifstat_reg_send;
 
 	if (pim_msg_send(pinfo->pim_sock_fd, src, dst, buffer,
-			 buf_size + PIM_MSG_REGISTER_LEN, ifp->name)) {
+			 buf_size + PIM_MSG_REGISTER_LEN, ifp)) {
 		if (PIM_DEBUG_PIM_TRACE) {
 			zlog_debug(
 				"%s: could not send PIM register message on interface %s",

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -409,6 +409,11 @@ int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
 		++writes;
 	}
 
+	if (pim_ifp->pim_passive_enable) {
+		vty_out(vty, " " PIM_AF_NAME " pim passive\n");
+		++writes;
+	}
+
 	writes += pim_static_write_mroute(pim, vty, ifp);
 	pim_bsm_write_config(vty, ifp);
 	++writes;

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -334,6 +334,13 @@ module frr-pim {
         "Enable PIM flag on the interface.";
     }
 
+    leaf pim-passive-enable {
+      type boolean;
+      default "false";
+      description
+        "Disable exchange of protocol packets.";
+    }
+
     leaf hello-interval {
       type uint8 {
         range "1..max";


### PR DESCRIPTION
Added a new cli command "ip[v6] pim passive" in the interface context,
to disable sending of pim control packets on the interface.

Issue: #5403

Signed-off-by: sarita patra <saritap@vmware.com>