### PR TITLE
pimd: Fixing pim coverity issues

### DIFF
--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -880,6 +880,12 @@ void pim_vxlan_mlag_update(bool enable, bool peer_state, uint32_t role,
 	 */
 	pim = pim_get_pim_instance(VRF_DEFAULT);
 
+	if (!pim) {
+		if (PIM_DEBUG_VXLAN)
+			zlog_debug("%s: Unable to find pim instance", __func__);
+		return;
+	}
+
 	if (enable)
 		vxlan_mlag.flags |= PIM_VXLAN_MLAGF_ENABLED;
 	else

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -166,6 +166,13 @@ static int pim_zebra_if_address_add(ZAPI_CALLBACK_ARGS)
 		struct pim_instance *pim;
 
 		pim = pim_get_pim_instance(vrf_id);
+		if (!pim) {
+			if (PIM_DEBUG_ZEBRA)
+				zlog_debug("%s: Unable to find pim instance",
+					   __func__);
+			return 0;
+		}
+
 		pim_ifp->pim = pim;
 
 		pim_rp_check_on_if_add(pim_ifp);

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -388,6 +388,12 @@ void zclient_lookup_read_pipe(struct thread *thread)
 	struct pim_zlookup_nexthop nexthop_tab[10];
 	struct in_addr l = {.s_addr = INADDR_ANY};
 
+	if (!pim) {
+		if (PIM_DEBUG_PIM_NHT_DETAIL)
+			zlog_debug("%s: Unable to find pim instance", __func__);
+		return;
+	}
+
 	zclient_lookup_nexthop_once(pim, nexthop_tab, 10, l);
 	thread_add_timer(router->master, zclient_lookup_read_pipe, zlookup, 60,
 			 &zlookup_read);


### PR DESCRIPTION
Fixing the below coverity issues.

________________________________________________________________________________________________________
*** CID 1515546:  Null pointer dereferences  (NULL_RETURNS)
/pimd/pim_zlookup.c: 391 in zclient_lookup_read_pipe()
     CID 1515546:  Null pointer dereferences  (NULL_RETURNS)
     Dereferencing a pointer that might be "NULL" "pim" when calling "zclient_lookup_nexthop_once".
391             zclient_lookup_nexthop_once(pim, nexthop_tab, 10, l);
________________________________________________________________________________________________________
*** CID 1515545:    (NULL_RETURNS)
/pimd/pim_vxlan.c: 902 in pim_vxlan_mlag_update()
     CID 1515545:    (NULL_RETURNS)
     Dereferencing a pointer that might be "NULL" "pim" when calling "pim_vxlan_set_peerlink_rif".
902                     pim_vxlan_set_peerlink_rif(pim, NULL);
________________________________________________________________________________________________________
/pimd/pim_vxlan.c: 900 in pim_vxlan_mlag_update()
     CID 1515545:    (NULL_RETURNS)
     Dereferencing a pointer that might be "NULL" "pim" when calling "pim_vxlan_set_peerlink_rif".
900                     pim_vxlan_set_peerlink_rif(pim, peerlink_rif);
901             else
902                     pim_vxlan_set_peerlink_rif(pim, NULL);
903     }