### PR TITLE
pimd: remove useless PIM_IF_* macros

### DIFF
--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -34,30 +34,7 @@
 #include "bfd.h"
 #include "pim_str.h"
 
-#define PIM_IF_MASK_PIM                             (1 << 0)
-#define PIM_IF_MASK_IGMP                            (1 << 1)
-#define PIM_IF_MASK_IGMP_LISTEN_ALLROUTERS          (1 << 2)
-#define PIM_IF_MASK_PIM_CAN_DISABLE_JOIN_SUPPRESSION (1 << 3)
-
 #define PIM_IF_IS_DELETED(ifp) ((ifp)->ifindex == IFINDEX_INTERNAL)
-
-#define PIM_IF_TEST_PIM(options) (PIM_IF_MASK_PIM & (options))
-#define PIM_IF_TEST_IGMP(options) (PIM_IF_MASK_IGMP & (options))
-#define PIM_IF_TEST_IGMP_LISTEN_ALLROUTERS(options) (PIM_IF_MASK_IGMP_LISTEN_ALLROUTERS & (options))
-#define PIM_IF_TEST_PIM_CAN_DISABLE_JOIN_SUPPRESSION(options)                  \
-	(PIM_IF_MASK_PIM_CAN_DISABLE_JOIN_SUPPRESSION & (options))
-
-#define PIM_IF_DO_PIM(options) ((options) |= PIM_IF_MASK_PIM)
-#define PIM_IF_DO_IGMP(options) ((options) |= PIM_IF_MASK_IGMP)
-#define PIM_IF_DO_IGMP_LISTEN_ALLROUTERS(options) ((options) |= PIM_IF_MASK_IGMP_LISTEN_ALLROUTERS)
-#define PIM_IF_DO_PIM_CAN_DISABLE_JOIN_SUPPRESSION(options)                    \
-	((options) |= PIM_IF_MASK_PIM_CAN_DISABLE_JOIN_SUPPRESSION)
-
-#define PIM_IF_DONT_PIM(options) ((options) &= ~PIM_IF_MASK_PIM)
-#define PIM_IF_DONT_IGMP(options) ((options) &= ~PIM_IF_MASK_IGMP)
-#define PIM_IF_DONT_IGMP_LISTEN_ALLROUTERS(options) ((options) &= ~PIM_IF_MASK_IGMP_LISTEN_ALLROUTERS)
-#define PIM_IF_DONT_PIM_CAN_DISABLE_JOIN_SUPPRESSION(options)                  \
-	((options) &= ~PIM_IF_MASK_PIM_CAN_DISABLE_JOIN_SUPPRESSION)
 
 #define PIM_I_am_DR(pim_ifp)                                                   \
 	!pim_addr_cmp((pim_ifp)->pim_dr_addr, (pim_ifp)->primary_address)
@@ -93,6 +70,11 @@ struct pim_secondary_addr {
 };
 
 struct pim_interface {
+	bool pim_enable : 1;
+	bool pim_can_disable_join_suppression : 1;
+
+	bool igmp_enable : 1;
+
 	uint32_t options; /* bit vector */
 	ifindex_t mroute_vif_index;
 	struct pim_instance *pim;

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1155,7 +1155,7 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 		return 0;
 	}
 
-	if (!PIM_IF_TEST_PIM(pim_ifp->options)) {
+	if (!pim_ifp->pim_enable) {
 		if (PIM_DEBUG_EVENTS)
 			zlog_debug("%s:%pSG PIM is not configured on this interface %s",
 				   __func__, sg, ifp->name);
@@ -1249,7 +1249,7 @@ void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg)
 	pim_ifp = ifp->info;
 	if (!pim_ifp)
 		return;
-	if (!PIM_IF_TEST_PIM(pim_ifp->options))
+	if (!pim_ifp->pim_enable)
 		return;
 
 	orig = ch = pim_ifchannel_find(ifp, sg);

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -255,17 +255,14 @@ static int igmp_sock_open(struct in_addr ifaddr, struct interface *ifp,
 	if (fd < 0)
 		return -1;
 
-	if (PIM_IF_TEST_IGMP_LISTEN_ALLROUTERS(pim_options)) {
-		if (inet_aton(PIM_ALL_ROUTERS, &group)) {
-			if (!pim_socket_join(fd, group, ifaddr, ifp->ifindex,
-					     pim_ifp))
-				++join;
-		} else {
-			zlog_warn(
-				"%s %s: IGMP socket fd=%d interface %pI4: could not solve %s to group address: errno=%d: %s",
-				__FILE__, __func__, fd, &ifaddr,
-				PIM_ALL_ROUTERS, errno, safe_strerror(errno));
-		}
+	if (inet_aton(PIM_ALL_ROUTERS, &group)) {
+		if (!pim_socket_join(fd, group, ifaddr, ifp->ifindex, pim_ifp))
+			++join;
+	} else {
+		zlog_warn(
+			"%s %s: IGMP socket fd=%d interface %pI4: could not solve %s to group address: errno=%d: %s",
+			__FILE__, __func__, fd, &ifaddr, PIM_ALL_ROUTERS, errno,
+			safe_strerror(errno));
 	}
 
 	/*

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -63,8 +63,7 @@ static void pim_if_membership_clear(struct interface *ifp)
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
 
-	if (PIM_IF_TEST_PIM(pim_ifp->options)
-	    && PIM_IF_TEST_IGMP(pim_ifp->options)) {
+	if (pim_ifp->pim_enable && pim_ifp->igmp_enable) {
 		return;
 	}
 
@@ -90,9 +89,9 @@ static void pim_if_membership_refresh(struct interface *ifp)
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
 
-	if (!PIM_IF_TEST_PIM(pim_ifp->options))
+	if (!pim_ifp->pim_enable)
 		return;
-	if (!PIM_IF_TEST_IGMP(pim_ifp->options))
+	if (!pim_ifp->igmp_enable)
 		return;
 
 	/*
@@ -143,7 +142,7 @@ static int pim_cmd_interface_add(struct interface *ifp)
 	if (!pim_ifp)
 		pim_ifp = pim_if_new(ifp, false, true, false, false);
 	else
-		PIM_IF_DO_PIM(pim_ifp->options);
+		pim_ifp->pim_enable = true;
 
 	pim_if_addr_add_all(ifp);
 	pim_if_membership_refresh(ifp);
@@ -159,7 +158,7 @@ static int pim_cmd_interface_delete(struct interface *ifp)
 	if (!pim_ifp)
 		return 1;
 
-	PIM_IF_DONT_PIM(pim_ifp->options);
+	pim_ifp->pim_enable = false;
 
 	pim_if_membership_clear(ifp);
 
@@ -169,7 +168,7 @@ static int pim_cmd_interface_delete(struct interface *ifp)
 	 */
 	pim_sock_delete(ifp, "pim unconfigured on interface");
 
-	if (!PIM_IF_TEST_IGMP(pim_ifp->options)) {
+	if (!pim_ifp->igmp_enable) {
 		pim_if_addr_del_all(ifp);
 		pim_if_delete(ifp);
 	}
@@ -360,8 +359,8 @@ static int pim_cmd_igmp_start(struct interface *ifp)
 		pim_ifp = pim_if_new(ifp, true, false, false, false);
 		need_startup = 1;
 	} else {
-		if (!PIM_IF_TEST_IGMP(pim_ifp->options)) {
-			PIM_IF_DO_IGMP(pim_ifp->options);
+		if (!pim_ifp->igmp_enable) {
+			pim_ifp->igmp_enable = true;
 			need_startup = 1;
 		}
 	}
@@ -2537,13 +2536,13 @@ int lib_interface_gmp_address_family_destroy(struct nb_cb_destroy_args *args)
 		if (!pim_ifp)
 			return NB_OK;
 
-		PIM_IF_DONT_IGMP(pim_ifp->options);
+		pim_ifp->igmp_enable = false;
 
 		pim_if_membership_clear(ifp);
 
 		pim_if_addr_del_all_igmp(ifp);
 
-		if (!PIM_IF_TEST_PIM(pim_ifp->options))
+		if (!pim_ifp->pim_enable)
 			pim_if_delete(ifp);
 	}
 
@@ -2594,13 +2593,13 @@ int lib_interface_gmp_address_family_enable_modify(
 			if (!pim_ifp)
 				return NB_ERR_INCONSISTENCY;
 
-			PIM_IF_DONT_IGMP(pim_ifp->options);
+			pim_ifp->igmp_enable = false;
 
 			pim_if_membership_clear(ifp);
 
 			pim_if_addr_del_all_igmp(ifp);
 
-			if (!PIM_IF_TEST_PIM(pim_ifp->options))
+			if (!pim_ifp->pim_enable)
 				pim_if_delete(ifp);
 		}
 	}

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -526,11 +526,8 @@ void pim_sock_reset(struct interface *ifp)
 		PIM_DEFAULT_PROPAGATION_DELAY_MSEC;
 	pim_ifp->pim_override_interval_msec =
 		PIM_DEFAULT_OVERRIDE_INTERVAL_MSEC;
-	if (PIM_DEFAULT_CAN_DISABLE_JOIN_SUPPRESSION) {
-		PIM_IF_DO_PIM_CAN_DISABLE_JOIN_SUPPRESSION(pim_ifp->options);
-	} else {
-		PIM_IF_DONT_PIM_CAN_DISABLE_JOIN_SUPPRESSION(pim_ifp->options);
-	}
+	pim_ifp->pim_can_disable_join_suppression =
+		PIM_DEFAULT_CAN_DISABLE_JOIN_SUPPRESSION;
 
 	/* neighbors without lan_delay */
 	pim_ifp->pim_number_of_nonlandelay_neighbors = 0;
@@ -702,8 +699,7 @@ static int hello_send(struct interface *ifp, uint16_t holdtime)
 			__func__, &qpim_all_pim_routers_addr, ifp->name,
 			holdtime, pim_ifp->pim_propagation_delay_msec,
 			pim_ifp->pim_override_interval_msec,
-			PIM_IF_TEST_PIM_CAN_DISABLE_JOIN_SUPPRESSION(
-				pim_ifp->options),
+			pim_ifp->pim_can_disable_join_suppression,
 			pim_ifp->pim_dr_priority, pim_ifp->pim_generation_id,
 			listcount(ifp->connected));
 
@@ -713,7 +709,7 @@ static int hello_send(struct interface *ifp, uint16_t holdtime)
 		pim_ifp->pim_dr_priority, pim_ifp->pim_generation_id,
 		pim_ifp->pim_propagation_delay_msec,
 		pim_ifp->pim_override_interval_msec,
-		PIM_IF_TEST_PIM_CAN_DISABLE_JOIN_SUPPRESSION(pim_ifp->options));
+		pim_ifp->pim_can_disable_join_suppression);
 	if (pim_tlv_size < 0) {
 		return -1;
 	}

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -289,7 +289,7 @@ static int pim_igmp_config_write(struct vty *vty, int writes,
 				 struct pim_interface *pim_ifp)
 {
 	/* IF ip igmp */
-	if (PIM_IF_TEST_IGMP(pim_ifp->options)) {
+	if (pim_ifp->igmp_enable) {
 		vty_out(vty, " ip igmp\n");
 		++writes;
 	}
@@ -361,7 +361,7 @@ int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
 {
 	struct pim_interface *pim_ifp = ifp->info;
 
-	if (PIM_IF_TEST_PIM(pim_ifp->options)) {
+	if (pim_ifp->pim_enable) {
 		vty_out(vty, " " PIM_AF_NAME " pim\n");
 		++writes;
 	}

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -1137,7 +1137,7 @@ void pim_vxlan_add_term_dev(struct pim_instance *pim,
 	/* enable pim on the term ifp */
 	pim_ifp = (struct pim_interface *)ifp->info;
 	if (pim_ifp) {
-		PIM_IF_DO_PIM(pim_ifp->options);
+		pim_ifp->pim_enable = true;
 		/* ifp is already oper up; activate it as a term dev */
 		if (pim_ifp->mroute_vif_index >= 0)
 			pim_vxlan_term_oif_update(pim, ifp);
@@ -1165,8 +1165,8 @@ void pim_vxlan_del_term_dev(struct pim_instance *pim)
 
 	pim_ifp = (struct pim_interface *)ifp->info;
 	if (pim_ifp) {
-		PIM_IF_DONT_PIM(pim_ifp->options);
-		if (!PIM_IF_TEST_IGMP(pim_ifp->options))
+		pim_ifp->pim_enable = false;
+		if (!pim_ifp->igmp_enable)
 			pim_if_delete(ifp);
 	}
 }


### PR DESCRIPTION
The only function these macros have is to make the code confusing. "PIM_IF_DO_PIM" sounds like it triggers some action, but it doesn't.

Replace with "bool" fields in struct pim_interface.

(Note: PIM_IF_*_IGMP_LISTEN_ALLROUTERS was always set, without any way to unset it.  It is completely removed now and always enabled.)

---
this is a purely mechanical/cleanup change and should have zero functional impact