### PR TITLE
build: enable `-fms-extensions`

### DIFF
--- a/bgpd/bgp_community_alias.c
+++ b/bgpd/bgp_community_alias.c
@@ -18,6 +18,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "zebra.h"
+
 #include "memory.h"
 #include "lib/jhash.h"
 #include "frrstr.h"

--- a/configure.ac
+++ b/configure.ac
@@ -330,7 +330,21 @@ LDFLAGS="$LDFLAGS -g"
 
 AM_CONDITIONAL([DEV_BUILD], [test "$enable_dev_build" = "yes"])
 
+dnl -fms-extensions causes clang to have a built-in __wchar_t on OpenBSD,
+dnl which just straight up breaks compiling any code.
+dnl (2022-04-04 / OpenBSD 7 / clang 11.1.0)
+AH_VERBATIM([OpenBSD], [
+#ifdef __OpenBSD__
+#define __wchar_t __wchar_t_ignore
+#include <stdint.h>
+#undef __wchar_t
+#endif
+])
+
 dnl always want these CFLAGS
+AC_C_FLAG([-fms-extensions], [
+  AC_MSG_ERROR([$CC does not support unnamed struct fields (-fms-extensions)])
+])
 AC_C_FLAG([-fno-omit-frame-pointer])
 AC_C_FLAG([-funwind-tables])
 AC_C_FLAG([-Wall])

--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -897,6 +897,26 @@ necessary replacements.
 | u_long    | unsigned long            |
 +-----------+--------------------------+
 
+FRR also uses unnamed struct fields, enabled with ``-fms-extensions`` (cf.
+https://gcc.gnu.org/onlinedocs/gcc/Unnamed-Fields.html).  The following two
+patterns can/should be used where contextually appropriate:
+
+.. code-block:: c
+
+   struct outer {
+           struct inner;
+   };
+
+.. code-block:: c
+
+   struct outer {
+           union {
+                   struct inner;
+                   struct inner inner_name;
+           };
+   };
+
+
 .. _style-exceptions:
 
 Exceptions

--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -623,6 +623,8 @@ Please copy-paste this header verbatim. In particular:
 
 - Do not replace "This program" with "FRR"
 - Do not change the address of the FSF
+- keep ``#include <zebra.h>``.  The absolute first header included in any C
+  file **must** be either ``zebra.h`` or ``config.h`` (with HAVE_CONFIG_H guard)
 
 Adding Copyright Claims to Existing Files
 -----------------------------------------

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -22,8 +22,9 @@
  * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
  */
-#include <json-c/json_object.h>
+
 #include <zebra.h>
+#include <json-c/json_object.h>
 
 #ifdef CRYPTO_INTERNAL
 #include "md5.h"

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -3,6 +3,10 @@
  * For details, see http://sourceforge.net/projects/libb64
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "base64.h"
 
 static const int CHARS_PER_LINE = 72;

--- a/lib/command_py.c
+++ b/lib/command_py.c
@@ -28,6 +28,9 @@
  * setup & these trample over each other.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <Python.h>
 #include "structmember.h"
 #include <string.h>

--- a/lib/elf_py.c
+++ b/lib/elf_py.c
@@ -50,10 +50,10 @@
 
 #define PY_SSIZE_T_CLEAN
 
-#include <Python.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <Python.h>
 #include "structmember.h"
 #include <string.h>
 #include <stdlib.h>

--- a/nhrpd/linux.c
+++ b/nhrpd/linux.c
@@ -7,8 +7,9 @@
  * (at your option) any later version.
  */
 
-#include <errno.h>
 #include "zebra.h"
+
+#include <errno.h>
 #include <linux/if_packet.h>
 
 #include "nhrp_protocol.h"

--- a/pathd/path_ted.c
+++ b/pathd/path_ted.c
@@ -15,9 +15,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "stdlib.h"
-
 #include <zebra.h>
+
+#include <stdlib.h>
 
 #include "memory.h"
 #include "log.h"

--- a/zebra/zebra_script.c
+++ b/zebra/zebra_script.c
@@ -17,6 +17,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "zebra.h"
+
 #include "zebra_script.h"
 
 #ifdef HAVE_SCRIPTING


### PR DESCRIPTION
This eases incorporating fields from/"subclassing" another struct.