### PR TITLE
pimd: Replace ALL_LIST_ELEMENTS_RO to ALL_LIST_ELEMENTS group_list it…

### DIFF
--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -118,7 +118,7 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp = ifp->info;
-		struct listnode *grpnode;
+		struct listnode *grpnode, *grp_nextnode;
 		struct gm_group *grp;
 		struct pim_ifchannel *ch, *ch_temp;
 
@@ -126,8 +126,8 @@ void igmp_source_forward_reevaluate_all(struct pim_instance *pim)
 			continue;
 
 		/* scan igmp groups */
-		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
-					  grp)) {
+		for (ALL_LIST_ELEMENTS(pim_ifp->gm_group_list, grpnode,
+				       grp_nextnode, grp)) {
 			struct listnode *srcnode;
 			struct gm_source *src;
 			int is_grp_ssm;


### PR DESCRIPTION
…eration

To reproduce:
```
ip pim ssm prefix-list pim-ssm-group
ip prefix-list pim-ssm-group seq 10 permit 238.4.0.0/16 ge 32 le 32
```

Assert:
```
pimd[645545]: pimd/pim_igmp.c:148: igmp_source_forward_reevaluate_all(): assertion ((srcnode)->data != NULL) failed
PIM[645545]: Received signal 6 at 1649140750 (si_addr 0x6e0009d9a9, PC 0x7fe5e3f95ce1); aborting...
PIM[645545]: /usr/local/lib/libfrr.so.0(zlog_backtrace_sigsafe+0x5e) [0x7fe5e41f2d7e]
PIM[645545]: /usr/local/lib/libfrr.so.0(zlog_signal+0xe6) [0x7fe5e41f2f56]
PIM[645545]: /usr/local/lib/libfrr.so.0(+0xc9412) [0x7fe5e421d412]
PIM[645545]: /lib/x86_64-linux-gnu/libpthread.so.0(+0x14140) [0x7fe5e4133140]
PIM[645545]: /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x141) [0x7fe5e3f95ce1]
PIM[645545]: /lib/x86_64-linux-gnu/libc.so.6(abort+0x123) [0x7fe5e3f7f537]
PIM[645545]: /usr/local/lib/libfrr.so.0(_zlog_assert_failed+0xd7) [0x7fe5e4246c37]
PIM[645545]: /usr/lib/frr/pimd(igmp_source_forward_reevaluate_all+0x230) [0x5638c65e3d90]
PIM[645545]: /usr/lib/frr/pimd(pim_prefix_list_update+0x53) [0x5638c65cbbf3]
PIM[645545]: /usr/local/lib/libfrr.so.0(prefix_list_entry_update_start+0x82) [0x7fe5e420a0a2]
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>