### PR TITLE
tests: Fix test_multicast_pim_sm_topo3.py from generating a support b…

### DIFF
--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
@@ -3270,8 +3270,6 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
     intf_r2_l1 = topo["routers"]["r2"]["links"]["l1"]["interface"]
     shutdown_bringup_interface(tgen, "r2", intf_r2_l1, False)
 
-    app_helper.stop_host("i2")
-
     step("Verify RP info after Shut the link from FHR to RP from RP node")
     dut = "l1"
     rp_address = "1.0.5.17"
@@ -3421,8 +3419,6 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
     shutdown_bringup_interface(tgen, "l1", intf_l1_r2, False)
 
     step("Verify PIM Nbrs after Shut the link from FHR to RP from FHR node")
-
-    app_helper.stop_host("i6")
 
     step("Verify RP info after Shut the link from FHR to RP from FHR node")
     dut = "l1"

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
@@ -2834,9 +2834,7 @@ def test_mroute_after_removing_RP_sending_IGMP_prune_p2(request):
 
     intf_f1_i8 = topo["routers"]["f1"]["links"]["i8"]["interface"]
     input_traffic = {"f1": {"traffic_sent": [intf_f1_i8]}}
-    traffic_before = verify_multicast_traffic(
-        tgen, input_traffic, return_traffic=True, expected=False
-    )
+    traffic_before = verify_multicast_traffic(tgen, input_traffic, return_traffic=True)
     assert isinstance(traffic_before, dict), (
         "Testcase {} : Failed \n traffic_before is not dictionary \n "
         "Error: {}".format(tc_name, result)
@@ -2861,9 +2859,7 @@ def test_mroute_after_removing_RP_sending_IGMP_prune_p2(request):
 
     intf_f1_i8 = topo["routers"]["f1"]["links"]["i8"]["interface"]
     input_traffic = {"f1": {"traffic_sent": [intf_f1_i8]}}
-    traffic_after = verify_multicast_traffic(
-        tgen, input_traffic, return_traffic=True, expected=False
-    )
+    traffic_after = verify_multicast_traffic(tgen, input_traffic, return_traffic=True)
     assert isinstance(traffic_after, dict), (
         "Testcase {} : Failed \n traffic_after is not dictionary \n "
         "Error: {}".format(tc_name, result)


### PR DESCRIPTION
…undle

The test_multicast_pim_sm_topo3.py test is both spending extra time
looking for state that will never occurr but also generating a support
bundle when it doesn't find it.  Fix the test to come to the correct
solution faster.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>