### PR TITLE
isis: fix crash in isis_spf_process_lsp

### DIFF
--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1114,10 +1114,15 @@ end:
 	else
 		fragnode = listnextnode(fragnode);
 
-	if (fragnode) {
+	while (fragnode) {
 		lsp = listgetdata(fragnode);
-		goto lspfragloop;
+		if (lsp->tlvs)
+			break;
+		fragnode = listnextnode(fragnode);
 	}
+
+	if (fragnode)
+		goto lspfragloop;
 
 	return ISIS_OK;
 }


### PR DESCRIPTION
> #0  raise (sig=<optimized out>) at ../sysdeps/unix/sysv/linux/raise.c:51
> #1  0x00007f48a576db78 in core_handler (signo=11, siginfo=0x7ffeee4f2b30, context=0x7ffeee4f2a00) at lib/sigevent.c:262
> #2  <signal handler called>
> #3  0x000055aded0d793a in isis_spf_process_lsp (spftree=0x55adee945120, lsp=0x55adee971800, cost=3, depth=1, root_sysid=0x55adee9451ac "", parent=0x55adee9474c0) at isisd/isis_spf.c:887
> #4  0x000055aded0d9bd1 in isis_spf_loop (spftree=0x55adee945120, root_sysid=0x55adee9451ac "") at isisd/isis_spf.c:1679
> #5  0x000055aded0d9fd1 in isis_run_spf (spftree=0x55adee945120) at isisd/isis_spf.c:1798
> #6  0x000055aded0bad65 in isis_spf_run_neighbors (spftree=0x55adee962220) at isisd/isis_lfa.c:1259
> #7  0x000055aded0bd896 in isis_spf_run_lfa (area=0x55adee95e200, spftree=0x55adee962220) at isisd/isis_lfa.c:2291
> #8  0x000055aded0da0f2 in isis_run_spf_with_protection (area=0x55adee95e200, spftree=0x55adee962220) at isisd/isis_spf.c:1817
> #9  0x000055aded0da350 in isis_run_spf_cb (thread=0x7ffeee4f3330) at isisd/isis_spf.c:1870
> #10 0x00007f48a5786dcc in thread_call (thread=0x7ffeee4f3330) at lib/thread.c:2002
> #11 0x00007f48a57213ee in frr_run (master=0x55adee6cdb40) at lib/libfrr.c:1196
> #12 0x000055aded0acda2 in main (argc=2, argv=0x7ffeee4f3548, envp=0x7ffeee4f3560) at isisd/isis_main.c:273

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>