### PR TITLE
bgpd: Metric not set with default route

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -818,6 +818,8 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 	assert(attr.aspath);
 
 	attr.local_pref = bgp->default_local_pref;
+	attr.med = 0;
+	attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC);
 
 	if ((afi == AFI_IP6) || peer_cap_enhe(peer, afi, safi)) {
 		/* IPv6 global nexthop must be included. */


### PR DESCRIPTION
Description:

Change is intended for fixing the below listed issue related to default-originate:

- When default route is originated using the neighbor default-originate cmd,
   MED is not set as part of the update message attribute.

Please check the commit for more details.

Co-authored-by: Abhinay Ramesh <rabhinay@vmware.com>
Signed-off-by: Iqra Siddiqui <imujeebsiddi@vmware.com>
