### PR TITLE
pimd: Remove pim_channel_oil_change_iif from header file

### DIFF
--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -197,9 +197,6 @@ struct channel_oil *pim_find_channel_oil(struct pim_instance *pim,
 					 pim_sgaddr *sg);
 struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 					pim_sgaddr *sg, const char *name);
-void pim_channel_oil_change_iif(struct pim_instance *pim,
-				struct channel_oil *c_oil, int input_vif_index,
-				const char *name);
 struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
 					const char *name);
 


### PR DESCRIPTION
pim_channel_oil_change_iif is sitting idly in .h file with no
definition.

The definition was removed but this wasn't. Hence removing it.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>