### PR TITLE
pimd: send s,g,rpt prune while KA timer is running

### DIFF
--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -219,6 +219,11 @@ size_t pim_msg_get_jp_group_size(struct list *sources)
 				if (child->rpf.source_nexthop.interface &&
 					!pim_rpf_is_same(&up->rpf,
 						&child->rpf)) {
+					if (PIM_UPSTREAM_FLAG_TEST_SRC_IGMP(
+								up->flags)
+					    && !(child->t_ka_timer))
+						continue;
+
 					size += sizeof(pim_encoded_source);
 					PIM_UPSTREAM_FLAG_SET_SEND_SG_RPT_PRUNE(
 						child->flags);


### PR DESCRIPTION
Issue: (s,g) not getting timeout from R2 and R1.
                   Source
                      |
                      +
Client-----R1--------R2----Client
R1 is RP.

Root cause:
After stopping the traffic, KAT timer will expire in R2 and R1.
But R2 still send (S,G,RPT) prune towards RP even of there is no
traffic received. On receiving of (S,G,RPT) prune, R1 sends (S,G)
join towards R2. So both R1 and R2 will maintain the mroute entry,
which will never time out.

Fix:
LHR should send a (S,G,RPT) prune towards RP, when there is
traffic running and (S,G) path and (*,G) path are different.

Signed-off-by: sarita patra <saritap@vmware.com>