### PR TITLE
pim6d: Adding "show ipv6 pim group-type" command

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -41,7 +41,6 @@
 #include "pim_addr.h"
 #include "pim_nht.h"
 
-
 #ifndef VTYSH_EXTRACT_PL
 #include "pimd/pim6_cmd_clippy.c"
 #endif
@@ -1190,6 +1189,29 @@ DEFPY (show_ipv6_pim_channel,
 	return CMD_SUCCESS;
 }
 
+DEFPY (show_ipv6_pim_ssm_range,
+       show_ipv6_pim_ssm_range_cmd,
+       "show ipv6 pim [vrf NAME] group-type [json$json]",
+       SHOW_STR
+       IPV6_STR
+       PIM_STR
+       VRF_CMD_HELP_STR
+       "PIM group type\n"
+       JSON_STR)
+{
+	struct vrf *v;
+	bool uj = !!json;
+
+	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
+
+	if (!v)
+		return CMD_WARNING;
+
+	ip_pim_ssm_show_group_range(v->info, vty, uj);
+
+	return CMD_SUCCESS;
+}
+
 DEFPY (show_ipv6_pim_interface,
        show_ipv6_pim_interface_cmd,
        "show ipv6 pim [vrf NAME] interface [detail|WORD]$interface [json$json]",
@@ -1627,6 +1649,7 @@ void pim_cmd_init(void)
 	install_element(VIEW_NODE, &show_ipv6_pim_state_cmd);
 	install_element(VIEW_NODE, &show_ipv6_pim_state_vrf_all_cmd);
 	install_element(VIEW_NODE, &show_ipv6_pim_channel_cmd);
+	install_element(VIEW_NODE, &show_ipv6_pim_ssm_range_cmd);
 	install_element(VIEW_NODE, &show_ipv6_pim_interface_cmd);
 	install_element(VIEW_NODE, &show_ipv6_pim_interface_vrf_all_cmd);
 	install_element(VIEW_NODE, &show_ipv6_pim_join_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5211,9 +5211,9 @@ DEFUN (no_ip_pim_ssm_prefix_list_name,
 	return CMD_WARNING_CONFIG_FAILED;
 }
 
-DEFUN (show_ip_pim_ssm_range,
+DEFPY (show_ip_pim_ssm_range,
        show_ip_pim_ssm_range_cmd,
-       "show ip pim [vrf NAME] group-type [json]",
+       "show ip pim [vrf NAME] group-type [json$json]",
        SHOW_STR
        IP_STR
        PIM_STR
@@ -5221,14 +5221,15 @@ DEFUN (show_ip_pim_ssm_range,
        "PIM group type\n"
        JSON_STR)
 {
-	int idx = 2;
-	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	bool uj = use_json(argc, argv);
+	struct vrf *v;
+	bool uj = !!json;
 
-	if (!vrf)
+	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
+
+	if (!v)
 		return CMD_WARNING;
 
-	ip_pim_ssm_show_group_range(vrf->info, vty, uj);
+	ip_pim_ssm_show_group_range(v->info, vty, uj);
 
 	return CMD_SUCCESS;
 }

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -2426,15 +2426,21 @@ void ip_pim_ssm_show_group_range(struct pim_instance *pim, struct vty *vty,
 	struct pim_ssm *ssm = pim->ssm_info;
 	const char *range_str =
 		ssm->plist_name ? ssm->plist_name : PIM_SSM_STANDARD_RANGE;
+	json_object *json;
 
 	if (uj) {
-		json_object *json;
-
 		json = json_object_new_object();
 		json_object_string_add(json, "ssmGroups", range_str);
-		vty_json(vty, json);
-	} else
+	} else {
+#if PIM_IPV == 6
+		if (!strcmp(range_str, PIM_SSM_STANDARD_RANGE))
+			vty_out(vty, "x: any valid scope");
+#endif
 		vty_out(vty, "SSM group range : %s\n", range_str);
+	}
+
+	if (uj)
+		vty_json(vty, json);
 }
 
 struct pnc_cache_walk_data {

--- a/pimd/pim_ssm.c
+++ b/pimd/pim_ssm.c
@@ -68,6 +68,7 @@ void pim_ssm_prefix_list_update(struct pim_instance *pim,
 	pim_ssm_range_reevaluate(pim);
 }
 
+#if PIM_IPV == 4
 static int pim_is_grp_standard_ssm(struct prefix *group)
 {
 	static int first = 1;
@@ -84,6 +85,13 @@ static int pim_is_grp_standard_ssm(struct prefix *group)
 
 	return prefix_match(&group_ssm, group);
 }
+#else
+static int pim_is_grp_standard_ssm(struct prefix *group)
+{
+	return ((group->u.prefix6.s6_addr32[0] & htonl(0xFFF00000)) ==
+	       htonl(0xFF300000)) && (group->prefixlen >= 32);
+}
+#endif
 
 int pim_is_grp_ssm(struct pim_instance *pim, pim_addr group_addr)
 {

--- a/pimd/pim_ssm.h
+++ b/pimd/pim_ssm.h
@@ -19,7 +19,12 @@
 #ifndef PIM_SSM_H
 #define PIM_SSM_H
 
+#if PIM_IPV == 4
 #define PIM_SSM_STANDARD_RANGE "232.0.0.0/8"
+#else
+#define PIM_SSM_STANDARD_RANGE "FF3x::/32"
+/* where x is any valid scope */
+#endif
 
 /* SSM error codes */
 enum pim_ssm_err {


### PR DESCRIPTION
Adding new CLI to display pim group-type.
Changing DEFUN too DEFPY for show ip pim [vrf NAME] group-type command

Note: Need more thinking on this.

Signed-off-by: Sai Gomathi N <nsaigomathi@vmware.com>