### PR TITLE
lib, pimd: small cleanup in multicast addr helpers (SSM & co.)

### DIFF
--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -34,6 +34,8 @@ typedef struct in_addr pim_addr;
 #define PIM_MAX_BITLEN	IPV4_MAX_BITLEN
 #define PIM_AF_NAME     "ip"
 
+#define PIM_ADDR_FUNCNAME(name) ipv4_##name
+
 union pimprefixptr {
 	prefixtype(pimprefixptr, struct prefix,      p)
 	prefixtype(pimprefixptr, struct prefix_ipv4, p4)
@@ -52,6 +54,8 @@ typedef struct in6_addr pim_addr;
 #define PIM_AFI		AFI_IP6
 #define PIM_MAX_BITLEN	IPV6_MAX_BITLEN
 #define PIM_AF_NAME     "ipv6"
+
+#define PIM_ADDR_FUNCNAME(name) ipv6_##name
 
 union pimprefixptr {
 	prefixtype(pimprefixptr, struct prefix,      p)
@@ -99,6 +103,21 @@ static inline pim_addr pim_addr_from_prefix(union pimprefixconstptr in)
 
 	memcpy(&ret, in.p->u.val, sizeof(ret));
 	return ret;
+}
+
+static inline uint8_t pim_addr_scope(const pim_addr addr)
+{
+	return PIM_ADDR_FUNCNAME(mcast_scope)(&addr);
+}
+
+static inline bool pim_addr_nofwd(const pim_addr addr)
+{
+	return PIM_ADDR_FUNCNAME(mcast_nofwd)(&addr);
+}
+
+static inline bool pim_addr_ssm(const pim_addr addr)
+{
+	return PIM_ADDR_FUNCNAME(mcast_ssm)(&addr);
 }
 
 /* don't use this struct directly, use the pim_sgaddr typedef */

--- a/pimd/pim_ssm.c
+++ b/pimd/pim_ssm.c
@@ -70,19 +70,9 @@ void pim_ssm_prefix_list_update(struct pim_instance *pim,
 
 static int pim_is_grp_standard_ssm(struct prefix *group)
 {
-	static int first = 1;
-	static struct prefix group_ssm;
+	pim_addr addr = pim_addr_from_prefix(group);
 
-	if (first) {
-		if (!str2prefix(PIM_SSM_STANDARD_RANGE, &group_ssm))
-			flog_err(EC_LIB_DEVELOPMENT,
-				 "%s: Failure to Read Group Address: %s",
-				 __func__, PIM_SSM_STANDARD_RANGE);
-
-		first = 0;
-	}
-
-	return prefix_match(&group_ssm, group);
+	return pim_addr_ssm(addr);
 }
 
 int pim_is_grp_ssm(struct pim_instance *pim, pim_addr group_addr)


### PR DESCRIPTION
A little bit of cleanup and structure to get information about multicast addresses. Replaces the "is standard SSM" check in pimd. (The other two helpers for scope/nofwd are used in the MLD code.)