### PR TITLE
pim6d: Modifying the mld group watermark command name

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -652,8 +652,8 @@ DEFPY (interface_no_ipv6_mld_query_interval,
 				    "frr-routing:ipv6");
 }
 
-DEFPY (mld_group_watermark,
-       mld_group_watermark_cmd,
+DEFPY (ipv6_mld_group_watermark,
+       ipv6_mld_group_watermark_cmd,
        "ipv6 mld watermark-warn (1-65535)$limit",
        IPV6_STR
        MLD_STR
@@ -665,8 +665,8 @@ DEFPY (mld_group_watermark,
 	return CMD_SUCCESS;
 }
 
-DEFPY (no_mld_group_watermark,
-       no_mld_group_watermark_cmd,
+DEFPY (no_ipv6_mld_group_watermark,
+       no_ipv6_mld_group_watermark_cmd,
        "no ipv6 mld watermark-warn [(1-65535)$limit]",
        NO_STR
        IPV6_STR
@@ -1628,10 +1628,10 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_ipv6_mld_query_interval_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ipv6_mld_query_interval_cmd);
-	install_element(CONFIG_NODE, &mld_group_watermark_cmd);
-	install_element(VRF_NODE, &mld_group_watermark_cmd);
-	install_element(CONFIG_NODE, &no_mld_group_watermark_cmd);
-	install_element(VRF_NODE, &no_mld_group_watermark_cmd);
+	install_element(CONFIG_NODE, &ipv6_mld_group_watermark_cmd);
+	install_element(VRF_NODE, &ipv6_mld_group_watermark_cmd);
+	install_element(CONFIG_NODE, &no_ipv6_mld_group_watermark_cmd);
+	install_element(VRF_NODE, &no_ipv6_mld_group_watermark_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_ipv6_mld_query_max_response_time_cmd);
 	install_element(INTERFACE_NODE,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4975,8 +4975,8 @@ DEFUN (no_ip_pim_packets,
 	return pim_process_no_pim_packet_cmd(vty);
 }
 
-DEFPY (igmp_group_watermark,
-       igmp_group_watermark_cmd,
+DEFPY (ip_igmp_group_watermark,
+       ip_igmp_group_watermark_cmd,
        "ip igmp watermark-warn (1-65535)$limit",
        IP_STR
        IGMP_STR
@@ -4989,8 +4989,8 @@ DEFPY (igmp_group_watermark,
 	return CMD_SUCCESS;
 }
 
-DEFPY (no_igmp_group_watermark,
-       no_igmp_group_watermark_cmd,
+DEFPY (no_ip_igmp_group_watermark,
+       no_ip_igmp_group_watermark_cmd,
        "no ip igmp watermark-warn [(1-65535)$limit]",
        NO_STR
        IP_STR
@@ -8422,10 +8422,10 @@ void pim_cmd_init(void)
 	install_element(VRF_NODE, &no_ip_pim_ecmp_rebalance_cmd);
 	install_element(CONFIG_NODE, &ip_pim_mlag_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_mlag_cmd);
-	install_element(CONFIG_NODE, &igmp_group_watermark_cmd);
-	install_element(VRF_NODE, &igmp_group_watermark_cmd);
-	install_element(CONFIG_NODE, &no_igmp_group_watermark_cmd);
-	install_element(VRF_NODE, &no_igmp_group_watermark_cmd);
+	install_element(CONFIG_NODE, &ip_igmp_group_watermark_cmd);
+	install_element(VRF_NODE, &ip_igmp_group_watermark_cmd);
+	install_element(CONFIG_NODE, &no_ip_igmp_group_watermark_cmd);
+	install_element(VRF_NODE, &no_ip_igmp_group_watermark_cmd);
 
 	install_element(INTERFACE_NODE, &interface_ip_igmp_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ip_igmp_cmd);

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -104,14 +104,6 @@ int gm_process_last_member_query_interval_cmd(struct vty *vty,
 int gm_process_no_last_member_query_interval_cmd(struct vty *vty);
 int pim_process_ssmpingd_cmd(struct vty *vty, enum nb_operation operation,
 			     const char *src_str);
-/*
- * Special Macro to allow us to get the correct pim_instance
- */
-#define PIM_DECLVAR_CONTEXT(A, B)                                              \
-	struct vrf *A = VTY_GET_CONTEXT(vrf);                                  \
-	struct pim_instance *B =                                               \
-		(vrf) ? vrf->info : pim_get_pim_instance(VRF_DEFAULT);         \
-	vrf = (vrf) ? vrf : pim->vrf
 
 /*
  * Special Macro to allow us to get the correct pim_instance;


### PR DESCRIPTION
Modifying the "mld_group_watermark_cmd" to "ipv6_mld_group_watermark_cmd"
and "igmp_group_watermark_cmd" to "ip_igmp_group_watermark_cmd" for consistency.
and also Removing the duplicate PIM_DECLVAR_CONTEXT macro.

Signed-off-by: Sai Gomathi N <nsaigomathi@vmware.com>