### PR TITLE
vtysh: remove extraneous newline

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3204,7 +3204,7 @@ DEFUN (vtysh_write_terminal,
        "Skip \"Building configuration...\" header\n")
 {
 	unsigned int i;
-	char line[] = "do write terminal\n";
+	char line[] = "do write terminal";
 
 	if (!strcmp(argv[argc - 1]->arg, "no-header"))
 		argc--;
@@ -3283,7 +3283,7 @@ static void backup_config_file(const char *fbackup)
 int vtysh_write_config_integrated(void)
 {
 	unsigned int i;
-	char line[] = "do write terminal\n";
+	char line[] = "do write terminal";
 	FILE *fp;
 	int fd;
 #ifdef FRR_USER
@@ -3396,7 +3396,7 @@ DEFUN (vtysh_write_memory,
        "Write configuration to the file (same as write memory)\n")
 {
 	int ret = CMD_SUCCESS;
-	char line[] = "do write memory\n";
+	char line[] = "do write memory";
 	unsigned int i;
 
 	vty_out(vty, "Note: this version of vtysh never writes vtysh.conf\n");
@@ -3723,7 +3723,7 @@ DEFPY (vtysh_terminal_monitor,
        "Receive log messages to active VTY session\n"
        DAEMONS_STR)
 {
-	static const char line[] = "terminal monitor\n";
+	static const char line[] = "terminal monitor";
 	int ret_all = CMD_SUCCESS, ret, fd;
 	size_t i, ok = 0;
 
@@ -3775,7 +3775,7 @@ DEFPY (no_vtysh_terminal_monitor,
        "Receive log messages to active VTY session\n"
        DAEMONS_STR)
 {
-	static const char line[] = "no terminal monitor\n";
+	static const char line[] = "no terminal monitor";
 	int ret_all = CMD_SUCCESS, ret;
 	size_t i, ok = 0;
 


### PR DESCRIPTION
vtysh_client_execute() expects just a string without a newline; the newline is passed through and ends up in logging output where newlines are not quite wanted.