### PR TITLE
pimd: remove pim_interface->options

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -123,7 +123,6 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 
 	pim_ifp = XCALLOC(MTYPE_PIM_INTERFACE, sizeof(*pim_ifp));
 
-	pim_ifp->options = 0;
 	pim_ifp->pim = ifp->vrf->info;
 	pim_ifp->mroute_vif_index = -1;
 

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -75,7 +75,6 @@ struct pim_interface {
 
 	bool igmp_enable : 1;
 
-	uint32_t options; /* bit vector */
 	ifindex_t mroute_vif_index;
 	struct pim_instance *pim;
 

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -242,8 +242,7 @@ void igmp_source_forward_stop(struct gm_source *source)
 /* This socket is used for TXing IGMP packets only, IGMP RX happens
  * in pim_mroute_msg()
  */
-static int igmp_sock_open(struct in_addr ifaddr, struct interface *ifp,
-			  uint32_t pim_options)
+static int igmp_sock_open(struct in_addr ifaddr, struct interface *ifp)
 {
 	int fd;
 	int join = 0;
@@ -1254,14 +1253,11 @@ struct gm_sock *pim_igmp_sock_add(struct list *igmp_sock_list,
 				  struct in_addr ifaddr, struct interface *ifp,
 				  bool mtrace_only)
 {
-	struct pim_interface *pim_ifp;
 	struct gm_sock *igmp;
 	struct sockaddr_in sin;
 	int fd;
 
-	pim_ifp = ifp->info;
-
-	fd = igmp_sock_open(ifaddr, ifp, pim_ifp->options);
+	fd = igmp_sock_open(ifaddr, ifp);
 	if (fd < 0) {
 		zlog_warn("Could not open IGMP socket for %pI4 on %s",
 			  &ifaddr, ifp->name);


### PR DESCRIPTION
I should've removed this in #10960.  It's a hazard in terms of forgetting to adjust PRs/other changes that might accidentally still reference the field.

---
Sorry about that :|