### PR TITLE
bgpd: correct one flag name on comment for evpn-mh

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1688,7 +1688,7 @@ static bool bgp_evpn_is_macip_path(struct bgp_path_info *pi)
  * This is done indirectly by re-attempting an install of the
  * route in the associated VRFs. As a part of the VRF install use
  * of l3 NHG is evaluated and this results in the
- * attr.es_flag ATTR_ES_USE_L3_NHG being set or cleared.
+ * attr.es_flag ATTR_ES_L3_NHG_USE being set or cleared.
  */
 static void
 bgp_evpn_es_path_update_on_es_vrf_chg(struct bgp_evpn_es_vrf *es_vrf,


### PR DESCRIPTION
Correct flag name of `attr.es_flags` - ATTR_ES_L3_NHG_USE.

"bgp_path_info"s (Per "es-vrf") with this flag can use l3nhg.