### PR TITLE
zebra: set ZEBRA_IFC_DOWN on connected routes for inactive interfaces

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -327,6 +327,8 @@ void connected_add_ipv4(struct interface *ifp, int flags,
 	/* If we get a notification from the kernel,
 	 * we can safely assume the address is known to the kernel */
 	SET_FLAG(ifc->conf, ZEBRA_IFC_QUEUED);
+	if (!if_is_operative(ifp))
+		SET_FLAG(ifc->conf, ZEBRA_IFC_DOWN);
 
 	/* Allocate new connected address. */
 	p = prefix_ipv4_new();
@@ -548,6 +550,8 @@ void connected_add_ipv6(struct interface *ifp, int flags,
 	/* If we get a notification from the kernel,
 	 * we can safely assume the address is known to the kernel */
 	SET_FLAG(ifc->conf, ZEBRA_IFC_QUEUED);
+	if (!if_is_operative(ifp))
+		SET_FLAG(ifc->conf, ZEBRA_IFC_DOWN);
 
 	/* Allocate new connected address. */
 	p = prefix_ipv6_new();


### PR DESCRIPTION
If you are in a situation where you have multiple addresses on an
interface, zebra creates one connected route for them.
The issue is that the rib entry is not created if addresses were
added before the interface was running.

We add the address to a running interface in a typical flow.
Therefore, we handle the route & rib creation within a single ADD event.
In the opposite case, we create the route entries without activating them.
These are considered to be active since ZEBRA_IFC_DOWN is not set.
On the following interface UP, we ignore the same ADDR_ADD as it overlaps
with the already `active` prefixes -> rib is never created.

The minimal reproducible setup:
-----------------------------------------
ip link add name dummy0 type dummy
ip addr flush dev dummy0
ip link set dummy0 down
ip addr add 192.168.1.7/24 dev dummy0
ip addr add 192.168.1.8/24 dev dummy0
ip link set dummy0 up
sudo vtysh -c 'show ip route' | grep dummy0

Signed-off-by: Volodymyr Huti <volodymyr.huti@gmail.com>

Fixes #10160 