### PR TITLE
pimd: correct the show ip igmp sources output

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1523,7 +1523,7 @@ static void igmp_show_sources(struct pim_instance *pim, struct vty *vty,
 		json = json_object_new_object();
 	else
 		vty_out(vty,
-			"Interface        Address         Group           Source          Timer Fwd Uptime  \n");
+			"Interface        Group           Source          Timer Fwd Uptime  \n");
 
 	/* scan interfaces */
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {


### PR DESCRIPTION
```
frr(config-if)# ip igmp join 232.1.1.1 10.10.10.10
frr(config-if)# do sh ip igmp sources
Interface        Address         Group           Source          Timer Fwd Uptime
ens192           232.1.1.1       10.10.10.10     04:10   N 00:00:10
frr(config-if)#
```

The above output is misaligned and is having Address field which is not
required here.

Fixing it.

Output after fixing it:
```
frr# do sh ip igmp sources 
Interface        Group           Source          Timer Fwd Uptime  
ens192           232.1.1.1       10.10.10.10     03:38   N 00:19:49
frr# 
```

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>