### PR TITLE
pim6d: Adjust IPV6 secondary address list

### DIFF
--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -715,7 +715,7 @@ static void delete_from_neigh_addr(struct interface *ifp,
 		struct listnode *neigh_node;
 		struct pim_neighbor *neigh;
 
-		if (addr->family != AF_INET)
+		if (addr->family != PIM_AF)
 			continue;
 
 		/*

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -362,19 +362,16 @@ static void delete_prefix_list(struct pim_neighbor *neigh)
 #ifdef DUMP_PREFIX_LIST
 		struct listnode *p_node;
 		struct prefix *p;
-		char addr_str[10];
 		int list_size = neigh->prefix_list
 					? (int)listcount(neigh->prefix_list)
 					: -1;
 		int i = 0;
 		for (ALL_LIST_ELEMENTS_RO(neigh->prefix_list, p_node, p)) {
-			pim_inet4_dump("<addr?>", p->u.prefix4, addr_str,
-				       sizeof(addr_str));
 			zlog_debug(
-				"%s: DUMP_PREFIX_LIST neigh=%x prefix_list=%x prefix=%x addr=%s [%d/%d]",
+				"%s: DUMP_PREFIX_LIST neigh=%x prefix_list=%x prefix=%x addr=%pFX [%d/%d]",
 				__func__, (unsigned)neigh,
 				(unsigned)neigh->prefix_list, (unsigned)p,
-				addr_str, i, list_size);
+				p, i, list_size);
 			++i;
 		}
 #endif
@@ -717,7 +714,6 @@ static void delete_from_neigh_addr(struct interface *ifp,
 
 		if (addr->family != PIM_AF)
 			continue;
-
 		/*
 		  Scan neighbors
 		*/
@@ -727,15 +723,9 @@ static void delete_from_neigh_addr(struct interface *ifp,
 				struct prefix *p = pim_neighbor_find_secondary(
 					neigh, addr);
 				if (p) {
-					char addr_str[INET_ADDRSTRLEN];
-
-					pim_inet4_dump(
-						"<addr?>", addr->u.prefix4,
-						addr_str, sizeof(addr_str));
-
 					zlog_info(
-						"secondary addr %s recvd from neigh %pPA deleted from neigh %pPA on %s",
-						addr_str, &neigh_addr,
+						"secondary addr %pFX recvd from neigh %pPA deleted from neigh %pPA on %s",
+						addr, &neigh_addr,
 						&neigh->source_addr, ifp->name);
 
 					listnode_delete(neigh->prefix_list, p);


### PR DESCRIPTION
Within one Address List Hello option, all the addresses MUST be of
the same address family. It is not permitted to mix IPv4 and IPv6
addresses within the same message. In addition, the address family
of the fields in the message SHOULD be the same as the IP source and
destination addresses of the packet header.

Signed-off-by: sarita patra [saritap@vmware.com](mailto:saritap@vmware.com)