### PR TITLE
zebra: simplify one check for evpn-mh

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3370,7 +3370,9 @@ static int bgp_evpn_install_uninstall_table(struct bgp *bgp, afi_t afi,
 
 	assert(attr);
 
-	/* Only type-2, type-3, type-4 and type-5 are supported currently */
+	/* Only type-1, type-2, type-3, type-4 and type-5
+	 * are supported currently
+	 */
 	if (!(evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE
 	      || evp->prefix.route_type == BGP_EVPN_IMET_ROUTE
 	      || evp->prefix.route_type == BGP_EVPN_ES_ROUTE
@@ -3475,7 +3477,7 @@ static int bgp_evpn_install_uninstall_table(struct bgp *bgp, afi_t afi,
 		if (evp->prefix.route_type == BGP_EVPN_ES_ROUTE) {
 
 			/* we will match based on the entire esi to avoid
-			 * imoort of an es route for esi2 into esi1
+			 * import of an es route for esi2 into esi1
 			 */
 			es = bgp_evpn_es_find(&evp->prefix.es_addr.esi);
 			if (es && bgp_evpn_is_es_local(es))
@@ -6101,8 +6103,9 @@ bool bgp_evpn_is_prefix_nht_supported(const struct prefix *pfx)
 	 * EVPN routes should be marked as valid only if the nexthop is
 	 * reachable. Only if this happens, the route should be imported
 	 * (into VNI or VRF routing tables) and/or advertised.
-	 * Note: This is currently applied for EVPN type-2, type-3 and
-	 * type-5 routes. It may be tweaked later on for other routes, or
+	 * Note: This is currently applied for EVPN type-1, type-2,
+	 * type-3, type-4 and type-5 routes.
+	 * It may be tweaked later on for other routes, or
 	 * even removed completely when all routes are handled.
 	 */
 	if (pfx && pfx->family == AF_EVPN

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -287,7 +287,7 @@ static int bgp_evpn_es_route_uninstall(struct bgp *bgp, struct bgp_evpn_es *es,
 	return ret;
 }
 
-/* Install or unistall a Tyoe-4 route in the per-ES routing table */
+/* Install or unistall a Type-4 route in the per-ES routing table */
 int bgp_evpn_es_route_install_uninstall(struct bgp *bgp, struct bgp_evpn_es *es,
 		afi_t afi, safi_t safi, struct prefix_evpn *evp,
 		struct bgp_path_info *pi, int install)
@@ -378,7 +378,7 @@ int bgp_evpn_mh_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 			remote_pi = tmp_pi;
 	}
 
-	/* we don't expect to see a remote_ri at this point as
+	/* we don't expect to see a remote_pi at this point as
 	 * an ES route has {esi, vtep_ip} as the key in the ES-rt-table
 	 * in the VNI-rt-table.
 	 */

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -50,7 +50,9 @@ struct bgp_evpn_es_frag {
 	/* RD for this ES fragment */
 	struct prefix_rd prd;
 
-	/* Memory used for linking bgp_evpn_es_rd to bgp_evpn_es->rd_list */
+	/* Memory used for linking bgp_evpn_es_frag to
+	 * bgp_evpn_es->es_frag_list
+	 */
 	struct listnode es_listnode;
 
 	/* List of ES-EVIs associated with this fragment */
@@ -59,11 +61,11 @@ struct bgp_evpn_es_frag {
 
 /* Ethernet Segment entry -
  * - Local and remote ESs are maintained in a global RB tree,
- * bgp_mh_info->es_rb_tree using ESI as key
+ *   bgp_mh_info->es_rb_tree using ESI as key
  * - Local ESs are received from zebra (BGP_EVPNES_LOCAL)
  * - Remotes ESs are implicitly created (by reference) by a remote ES-EVI
  *   (BGP_EVPNES_REMOTE)
- * - An ES can be simulatenously LOCAL and REMOTE; infact all LOCAL ESs are
+ * - An ES can be simultaneously LOCAL and REMOTE; infact all LOCAL ESs are
  *   expected to have REMOTE ES peers.
  */
 struct bgp_evpn_es {
@@ -101,7 +103,7 @@ struct bgp_evpn_es {
 	 */
 	struct listnode pend_es_listnode;
 
-	/* [EVPNES_LOCAL] List of RDs for this ES (bgp_evpn_es_rd) */
+	/* [EVPNES_LOCAL] List of RDs for this ES (bgp_evpn_es_frag) */
 	struct list *es_frag_list;
 	struct bgp_evpn_es_frag *es_base_frag;
 

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3758,18 +3758,10 @@ static inline bool zebra_evpn_mh_is_all_uplinks_down(void)
 static void zebra_evpn_mh_uplink_oper_flags_update(struct zebra_if *zif,
 						   bool set)
 {
-	if (set) {
-		if (if_is_operative(zif->ifp)) {
-			if (!(zif->flags & ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP)) {
-				zif->flags |= ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP;
-				++zmh_info->uplink_oper_up_cnt;
-			}
-		} else {
-			if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP) {
-				zif->flags &= ~ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP;
-				if (zmh_info->uplink_oper_up_cnt)
-					--zmh_info->uplink_oper_up_cnt;
-			}
+	if (set && if_is_operative(zif->ifp)) {
+		if (!(zif->flags & ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP)) {
+			zif->flags |= ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP;
+			++zmh_info->uplink_oper_up_cnt;
 		}
 	} else {
 		if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK_OPER_UP) {


### PR DESCRIPTION
Two commits:
- zebra: simplify one check for evpn-mh
An simplification for one check in
 `zebra_evpn_mh_uplink_oper_flags_update()`.
- bgpd: fix a few comments for evpn-mh
Just correct a few comments on Type-1 and Type-4 of evpn-mh.