### PR TITLE
pimd: Changing PIM_OIF_FLAG_PROTO_IGMP to PIM_OIF_FLAG_PROTO_GM

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4065,8 +4065,8 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 					json_object_boolean_true_add(
 						json_ifp_out, "protocolPim");
 
-				if (c_oil->oif_flags[oif_vif_index]
-				    & PIM_OIF_FLAG_PROTO_IGMP)
+				if (c_oil->oif_flags[oif_vif_index] &
+				    PIM_OIF_FLAG_PROTO_GM)
 					json_object_boolean_true_add(
 						json_ifp_out, "protocolIgmp");
 
@@ -4110,8 +4110,8 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 					strlcpy(proto, "PIM", sizeof(proto));
 				}
 
-				if (c_oil->oif_flags[oif_vif_index]
-				    & PIM_OIF_FLAG_PROTO_IGMP) {
+				if (c_oil->oif_flags[oif_vif_index] &
+				    PIM_OIF_FLAG_PROTO_GM) {
 					strlcpy(proto, "IGMP", sizeof(proto));
 				}
 

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1166,7 +1166,7 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 						out_ifname,
 						(c_oil->oif_flags
 							 [oif_vif_index] &
-						 PIM_OIF_FLAG_PROTO_IGMP)
+						 PIM_OIF_FLAG_PROTO_GM)
 							? 'I'
 							: ' ',
 						(c_oil->oif_flags
@@ -1194,7 +1194,7 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 						out_ifname,
 						(c_oil->oif_flags
 							 [oif_vif_index] &
-						 PIM_OIF_FLAG_PROTO_IGMP)
+						 PIM_OIF_FLAG_PROTO_GM)
 							? 'I'
 							: ' ',
 						(c_oil->oif_flags

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -138,7 +138,7 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 	if (ch->upstream->channel_oil) {
 		uint32_t mask = PIM_OIF_FLAG_PROTO_PIM;
 		if (ch->upstream->flags & PIM_UPSTREAM_FLAG_MASK_SRC_IGMP)
-			mask |= PIM_OIF_FLAG_PROTO_IGMP;
+			mask |= PIM_OIF_FLAG_PROTO_GM;
 
 		/*
 		 * A S,G RPT channel can have an empty oil, we also
@@ -1227,14 +1227,13 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 				    == PREFIX_DENY) {
 					pim_channel_add_oif(
 						up->channel_oil, pim->regiface,
-						PIM_OIF_FLAG_PROTO_IGMP,
+						PIM_OIF_FLAG_PROTO_GM,
 						__func__);
 				}
 			}
 		} else
 			pim_channel_add_oif(up->channel_oil, pim->regiface,
-					PIM_OIF_FLAG_PROTO_IGMP,
-					__func__);
+					    PIM_OIF_FLAG_PROTO_GM, __func__);
 	}
 
 	return 1;

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -739,8 +739,8 @@ bool pim_mroute_allow_iif_in_oil(struct channel_oil *c_oil,
 	pim_ifp = ifp_out->info;
 	if (!pim_ifp)
 		return false;
-	if ((c_oil->oif_flags[oif_index] & PIM_OIF_FLAG_PROTO_IGMP) &&
-			PIM_I_am_DR(pim_ifp))
+	if ((c_oil->oif_flags[oif_index] & PIM_OIF_FLAG_PROTO_GM) &&
+	    PIM_I_am_DR(pim_ifp))
 		return true;
 
 	return false;

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -27,18 +27,18 @@ struct pim_interface;
 /*
  * Where did we get this (S,G) from?
  *
- * IGMP - Learned from IGMP
+ * GM - Learned from IGMP/MLD
  * PIM - Learned from PIM
  * SOURCE - Learned from Source multicast packet received
  * STAR - Inherited
  */
-#define PIM_OIF_FLAG_PROTO_IGMP   (1 << 0)
+#define PIM_OIF_FLAG_PROTO_GM     (1 << 0)
 #define PIM_OIF_FLAG_PROTO_PIM    (1 << 1)
 #define PIM_OIF_FLAG_PROTO_STAR   (1 << 2)
 #define PIM_OIF_FLAG_PROTO_VXLAN  (1 << 3)
-#define PIM_OIF_FLAG_PROTO_ANY                                 \
-	(PIM_OIF_FLAG_PROTO_IGMP | PIM_OIF_FLAG_PROTO_PIM      \
-	 | PIM_OIF_FLAG_PROTO_STAR | PIM_OIF_FLAG_PROTO_VXLAN)
+#define PIM_OIF_FLAG_PROTO_ANY                                                 \
+	(PIM_OIF_FLAG_PROTO_GM | PIM_OIF_FLAG_PROTO_PIM |                      \
+	 PIM_OIF_FLAG_PROTO_STAR | PIM_OIF_FLAG_PROTO_VXLAN)
 
 /* OIF is present in the OIL but must not be used for forwarding traffic */
 #define PIM_OIF_FLAG_MUTE         (1 << 4)

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -110,8 +110,8 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 	if (PIM_I_am_DR(pim_oif) || PIM_I_am_DualActive(pim_oif)) {
 		int result;
 
-		result = pim_channel_add_oif(*oilp, oif,
-					     PIM_OIF_FLAG_PROTO_IGMP, __func__);
+		result = pim_channel_add_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_GM,
+					     __func__);
 		if (result) {
 			if (PIM_DEBUG_MROUTE)
 				zlog_warn("%s: add_oif() failed with return=%d",
@@ -136,7 +136,7 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 				"%s: Failure to add local membership for %pSG",
 				__func__, &sg);
 
-		pim_channel_del_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_IGMP,
+		pim_channel_del_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_GM,
 				    __func__);
 		return false;
 	}
@@ -160,7 +160,7 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 	 fixes the issue without ill effect, similar to
 	 pim_forward_stop below.
 	*/
-	result = pim_channel_del_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_IGMP,
+	result = pim_channel_del_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_GM,
 				     __func__);
 	if (result) {
 		if (PIM_DEBUG_IGMP_TRACE)

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1838,7 +1838,7 @@ int pim_upstream_inherited_olist_decide(struct pim_instance *pim,
 				flag = PIM_OIF_FLAG_PROTO_STAR;
 			else {
 				if (PIM_IF_FLAG_TEST_PROTO_IGMP(ch->flags))
-					flag = PIM_OIF_FLAG_PROTO_IGMP;
+					flag = PIM_OIF_FLAG_PROTO_GM;
 				if (PIM_IF_FLAG_TEST_PROTO_PIM(ch->flags))
 					flag |= PIM_OIF_FLAG_PROTO_PIM;
 				if (starch)
@@ -2116,7 +2116,7 @@ void pim_upstream_add_lhr_star_pimreg(struct pim_instance *pim)
 			continue;
 
 		pim_channel_add_oif(up->channel_oil, pim->regiface,
-				    PIM_OIF_FLAG_PROTO_IGMP, __func__);
+				    PIM_OIF_FLAG_PROTO_GM, __func__);
 	}
 }
 
@@ -2161,18 +2161,17 @@ void pim_upstream_remove_lhr_star_pimreg(struct pim_instance *pim,
 
 		if (!nlist) {
 			pim_channel_del_oif(up->channel_oil, pim->regiface,
-					PIM_OIF_FLAG_PROTO_IGMP, __func__);
+					    PIM_OIF_FLAG_PROTO_GM, __func__);
 			continue;
 		}
 		pim_addr_to_prefix(&g, up->sg.grp);
 		apply_new = prefix_list_apply(np, &g);
 		if (apply_new == PREFIX_DENY)
 			pim_channel_add_oif(up->channel_oil, pim->regiface,
-					    PIM_OIF_FLAG_PROTO_IGMP,
-						__func__);
+					    PIM_OIF_FLAG_PROTO_GM, __func__);
 		else
 			pim_channel_del_oif(up->channel_oil, pim->regiface,
-					PIM_OIF_FLAG_PROTO_IGMP, __func__);
+					    PIM_OIF_FLAG_PROTO_GM, __func__);
 	}
 }
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -499,7 +499,7 @@ void pim_forward_start(struct pim_ifchannel *ch)
 			   ch->interface->name, &up->upstream_addr);
 
 	if (PIM_IF_FLAG_TEST_PROTO_IGMP(ch->flags))
-		mask = PIM_OIF_FLAG_PROTO_IGMP;
+		mask = PIM_OIF_FLAG_PROTO_GM;
 
 	if (PIM_IF_FLAG_TEST_PROTO_PIM(ch->flags))
 		mask |= PIM_OIF_FLAG_PROTO_PIM;


### PR DESCRIPTION
Modified marco name so that it can be reused in mld.

Signed-off-by: Abhishek N R <abnr@vmware.com>