### PR TITLE
bgpd: remove unnecessary l3nhg knob for evpn-mh

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -2875,7 +2875,7 @@ static void bgp_evpn_l3nhg_zebra_add_v4_or_v6(struct bgp_evpn_es_vrf *es_vrf,
 
 static bool bgp_evpn_l3nhg_zebra_ok(struct bgp_evpn_es_vrf *es_vrf)
 {
-	if (!bgp_mh_info->host_routes_use_l3nhg && !bgp_mh_info->install_l3nhg)
+	if (!bgp_mh_info->host_routes_use_l3nhg)
 		return false;
 
 	/* Check socket. */
@@ -4948,7 +4948,6 @@ void bgp_evpn_mh_init(void)
 	/* config knobs - XXX add cli to control it */
 	bgp_mh_info->ead_evi_adv_for_down_links = true;
 	bgp_mh_info->consistency_checking = true;
-	bgp_mh_info->install_l3nhg = false;
 	bgp_mh_info->host_routes_use_l3nhg = BGP_EVPN_MH_USE_ES_L3NHG_DEF;
 	bgp_mh_info->suppress_l3_ecomm_on_inactive_es = true;
 	bgp_mh_info->bgp_evpn_nh_setup = true;

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -319,7 +319,6 @@ struct bgp_evpn_mh_info {
 	/* Enable ES consistency checking */
 	bool consistency_checking;
 	/* Use L3 NHGs for host routes in symmetric IRB */
-	bool install_l3nhg;
 	bool host_routes_use_l3nhg;
 	/* Some vendors are not generating the EAD-per-EVI route. This knob
 	 * can be turned off to activate a remote ES-PE when the EAD-per-ES


### PR DESCRIPTION
Remove unnecessary `install_l3nhg` knob because it has already
been controlled by the command: "[no$no] use-es-l3nhg".