### PR TITLE
pimd, pim6d: Spelling fixes

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -170,7 +170,7 @@ DEFPY (ipv6_pim_rp_keep_alive,
        "ipv6 pim rp keep-alive-timer (1-65535)$kat",
        IPV6_STR
        PIM_STR
-       "Rendevous Point\n"
+       "Rendezvous Point\n"
        "Keep alive Timer\n"
        "Seconds\n")
 {
@@ -183,7 +183,7 @@ DEFPY (no_ipv6_pim_rp_keep_alive,
        NO_STR
        IPV6_STR
        PIM_STR
-       "Rendevous Point\n"
+       "Rendezvous Point\n"
        "Keep alive Timer\n"
        IGNORED_IN_NO_STR)
 {

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4909,7 +4909,7 @@ DEFPY (ip_pim_rp_keep_alive,
        "ip pim rp keep-alive-timer (1-65535)$kat",
        IP_STR
        "pim multicast routing\n"
-       "Rendevous Point\n"
+       "Rendezvous Point\n"
        "Keep alive Timer\n"
        "Seconds\n")
 {
@@ -4922,7 +4922,7 @@ DEFUN (no_ip_pim_rp_keep_alive,
        NO_STR
        IP_STR
        "pim multicast routing\n"
-       "Rendevous Point\n"
+       "Rendezvous Point\n"
        "Keep alive Timer\n"
        IGNORED_IN_NO_STR)
 {
@@ -5062,7 +5062,7 @@ DEFPY (ip_pim_rp,
        "ip pim rp A.B.C.D$rp [A.B.C.D/M]$gp",
        IP_STR
        "pim multicast routing\n"
-       "Rendevous Point\n"
+       "Rendezvous Point\n"
        "ip address of RP\n"
        "Group Address range to cover\n")
 {
@@ -5090,7 +5090,7 @@ DEFPY (no_ip_pim_rp,
        NO_STR
        IP_STR
        "pim multicast routing\n"
-       "Rendevous Point\n"
+       "Rendezvous Point\n"
        "ip address of RP\n"
        "Group Address range to cover\n")
 {


### PR DESCRIPTION
Fix the below spelling
Rendevous --> Rendezvous.

Signed-off-by: Mobashshera Rasool