### PR TITLE
tools: Print usage for frrinit.sh when running without arguments

### DIFF
--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -127,6 +127,8 @@ reload)
 	;;
 
 *)
-	log_failure_msg "Unknown command: $1" >&2
+	echo "Usage:"
+	echo "    ${0} (start|stop|restart|force-reload|reload|status)"
 	exit 1
+	;;
 esac


### PR DESCRIPTION
```
root@spine1-debian-11:~/frr# /usr/lib/frr/frrinit.sh
Usage:
    /usr/lib/frr/frrinit.sh (start|stop|restart|force-reload|reload|status)
```

Closes https://github.com/FRRouting/frr/issues/11034

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>