### PR TITLE
packaging: A couple of fixes for /var/log/frr

### DIFF
--- a/debian/frr.logrotate
+++ b/debian/frr.logrotate
@@ -4,7 +4,7 @@
         missingok
         compress
         rotate 14
-        create 640 frr frrvty
+        create 0640 frr frr
 
         postrotate
             pid=$(lsof -t -a -c /syslog/ /var/log/frr/* 2>/dev/null)

--- a/debian/frr.postinst
+++ b/debian/frr.postinst
@@ -16,7 +16,7 @@ adduser \
 	frr
 usermod -a -G frrvty frr
 
-mkdir -p /var/log/frr
+mkdir -m 0755 -p /var/log/frr
 mkdir -p /etc/frr
 
 

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -432,7 +432,8 @@ popd
 
 %install
 mkdir -p %{buildroot}%{_sysconfdir}/{frr,sysconfig,logrotate.d,pam.d,default} \
-         %{buildroot}%{_localstatedir}/log/frr %{buildroot}%{_infodir}
+         %{buildroot}%{_infodir}
+mkdir -m 0755 -p %{buildroot}%{_localstatedir}/log/frr
 make DESTDIR=%{buildroot} INSTALL="install -p" CP="cp -p" install
 
 # Remove this file, as it is uninstalled and causes errors when building on RH9
@@ -639,11 +640,11 @@ fi
 /usr/share/yang/*.yang
 %if 0%{?frr_user:1}
     %dir %attr(751,%{frr_user},%{frr_user}) %{configdir}
-    %dir %attr(750,%{frr_user},%{frr_user}) %{_localstatedir}/log/frr
+    %dir %attr(755,%{frr_user},%{frr_user}) %{_localstatedir}/log/frr
     %dir %attr(751,%{frr_user},%{frr_user}) %{rundir}
 %else
     %dir %attr(750,root,root) %{configdir}
-    %dir %attr(750,root,root) %{_localstatedir}/log/frr
+    %dir %attr(755,root,root) %{_localstatedir}/log/frr
     %dir %attr(750,root,root) %{rundir}
 %endif
 %{_infodir}/frr.info.gz
@@ -918,7 +919,7 @@ sed -i 's/ -M rpki//' %{_sysconfdir}/frr/daemons
 -    Add ability to show BGP routes from a particular table version
 -    Add support for for RFC 8050 (MRT add-path)
 -    Add SNMP support for MPLS VPN
--    Add `show bgp summary wide` command to show more detailed output 
+-    Add `show bgp summary wide` command to show more detailed output
      on wide terminals
 -    Add ability for peer-groups to have `ttl-security hops` configured
 -    Add support for conditional Advertisement

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1752,7 +1752,7 @@ if __name__ == "__main__":
 
     elif args.reload:
         if not os.path.isdir("/var/log/frr/"):
-            os.makedirs("/var/log/frr/")
+            os.makedirs("/var/log/frr/", mode=0o0755)
 
         logging.basicConfig(
             filename="/var/log/frr/frr-reload.log",


### PR DESCRIPTION
At the moment we set /var/log/frr permissions to 0750 (frr:frr), but the log
file is 0640 (root:adm) and that doesn't allow adm group to even open the
directory.

Also, when we do "log file /var/log/frr/something", permissions are set to
0640 (frr:frr), but when the logrotate kicks in, we have 0640 (frr:frrvty).

I believe we should have consistent permissions.

Related: https://github.com/FRRouting/frr/issues/10520

Any objections?