### PR TITLE
zebra: [8.2] Allow system routes to recurse through themselves

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2209,7 +2209,8 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 			continue;
 		}
 
-		if (match->type == ZEBRA_ROUTE_CONNECT) {
+		if (match->type == ZEBRA_ROUTE_CONNECT ||
+		    (RIB_SYSTEM_ROUTE(match) && RSYSTEM_ROUTE(type))) {
 			/* Directly point connected route. */
 			newhop = match->nhe->nhg.nexthop;
 			if (newhop) {


### PR DESCRIPTION
Currently if a end user has something like this:

Routing entry for 192.168.212.1/32
  Known via "kernel", distance 0, metric 100, best
  Last update 00:07:50 ago
  * directly connected, ens5

Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

K>* 0.0.0.0/0 [0/100] via 192.168.212.1, ens5, src 192.168.212.19, 00:00:15
C>* 192.168.212.0/27 is directly connected, ens5, 00:07:50
K>* 192.168.212.1/32 [0/100] is directly connected, ens5, 00:07:50

And FRR does a link flap, it refigures the route and rejects the default
route:

2022/04/09 16:38:20 ZEBRA: [NZNZ4-7P54Y] default(0:254):0.0.0.0/0: Processing rn 0x56224dbb5b00
2022/04/09 16:38:20 ZEBRA: [ZJVZ4-XEGPF] default(0:254):0.0.0.0/0: Examine re 0x56224dbddc20 (kernel) status: Changed Installed flags: Selected dist 0 metric 100
2022/04/09 16:38:20 ZEBRA: [GG8QH-195KE] nexthop_active_update: re 0x56224dbddc20 nhe 0x56224dbdd950 (7), curr_nhe 0x56224dedb550
2022/04/09 16:38:20 ZEBRA: [T9JWA-N8HM5] nexthop_active_check: re 0x56224dbddc20, nexthop 192.168.212.1, via ens5
2022/04/09 16:38:20 ZEBRA: [M7EN1-55BTH]         nexthop_active: Route Type kernel has not turned on recursion
2022/04/09 16:38:20 ZEBRA: [HJ48M-MB610]         nexthop_active_check: Unable to find active nexthop
2022/04/09 16:38:20 ZEBRA: [JPJF4-TGCY5] default(0:254):0.0.0.0/0: After processing: old_selected 0x56224dbddc20 new_selected 0x0 old_fib 0x56224dbddc20 new_fib 0x0

So the 192.168.212.1 route is matched for the nexthop but it is not connected and
zebra treats it as a problem.  Modify the code such that if a system route
matches through another system route, then it should work imo.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>