### PR TITLE
lib: Prevent crash after shutdown request

### DIFF
--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1568,8 +1568,10 @@ static void prefix_list_reset_afi(afi_t afi, int orf)
 	if (master == NULL)
 		return;
 
-	while ((plist = plist_pop(&master->str)))
+	while ((plist = plist_first(&master->str))) {
 		prefix_list_delete(plist);
+		plist_pop(&master->str);
+	}
 
 	master->recent = NULL;
 }


### PR DESCRIPTION
Recent commit e92508a741e03b8721ccb3424cbebe4d5476e9d changed
the prefix_master->str to a RB tree.  This introduced a condition
whnere on shutdown the prefix list was removed from the master list
and then operated on by passing around a name.  Which was then used
to lookup the prefix list again when we operated on the code.
This change to a RB Tree first deleted the item from the RB tree
first thus introducing this crash

Crash:
(gdb) bt
    index=0x556c07d59650, pentry=0x556c07d29380) at lib/routemap.c:2397
    arg=0x7ffdbf84bc60) at lib/hash.c:267
    event=RMAP_EVENT_PLIST_DELETED) at lib/routemap.c:2489

Grab the first item on the list, clean it and then remove it.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>