### PR TITLE
bgpd: fix memory leak for evpn

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -861,9 +861,6 @@ struct aspath *aspath_parse(struct stream *s, size_t length, int use32bit)
 	/* If already same aspath exist then return it. */
 	find = hash_get(ashash, &as, aspath_hash_alloc);
 
-	/* bug! should not happen, let the daemon crash below */
-	assert(find);
-
 	/* if the aspath was already hashed free temporary memory. */
 	if (find->refcnt) {
 		assegment_free_all(as.segments);

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -184,7 +184,7 @@ community_list_insert(struct community_list_handler *ch, const char *name,
 	new->name_hash = bgp_clist_hash_key_community_list(new);
 
 	/* Save for later */
-	hash_get(cm->hash, new, hash_alloc_intern);
+	(void)hash_get(cm->hash, new, hash_alloc_intern);
 
 	/* If name is made by all digit character.  We treat it as
 	   number. */

--- a/bgpd/bgp_community_alias.c
+++ b/bgpd/bgp_community_alias.c
@@ -106,12 +106,12 @@ int bgp_community_alias_write(struct vty *vty)
 
 void bgp_ca_community_insert(struct community_alias *ca)
 {
-	hash_get(bgp_ca_community_hash, ca, bgp_community_alias_alloc);
+	(void)hash_get(bgp_ca_community_hash, ca, bgp_community_alias_alloc);
 }
 
 void bgp_ca_alias_insert(struct community_alias *ca)
 {
-	hash_get(bgp_ca_alias_hash, ca, bgp_community_alias_alloc);
+	(void)hash_get(bgp_ca_alias_hash, ca, bgp_community_alias_alloc);
 }
 
 void bgp_ca_community_delete(struct community_alias *ca)

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -167,10 +167,7 @@ static struct vrf_irt_node *vrf_import_rt_new(struct ecommunity_val *rt)
 	irt->vrfs = list_new();
 
 	/* Add to hash */
-	if (!hash_get(bgp_evpn->vrf_import_rt_hash, irt, hash_alloc_intern)) {
-		XFREE(MTYPE_BGP_EVPN_VRF_IMPORT_RT, irt);
-		return NULL;
-	}
+	(void)hash_get(bgp_evpn->vrf_import_rt_hash, irt, hash_alloc_intern);
 
 	return irt;
 }
@@ -272,10 +269,7 @@ static struct irt_node *import_rt_new(struct bgp *bgp,
 	irt->vnis = list_new();
 
 	/* Add to hash */
-	if (!hash_get(bgp->import_rt_hash, irt, hash_alloc_intern)) {
-		XFREE(MTYPE_BGP_EVPN_IMPORT_RT, irt);
-		return NULL;
-	}
+	(void)hash_get(bgp->import_rt_hash, irt, hash_alloc_intern);
 
 	return irt;
 }
@@ -5336,10 +5330,7 @@ struct bgpevpn *bgp_evpn_new(struct bgp *bgp, vni_t vni,
 	vpn->route_table = bgp_table_init(bgp, AFI_L2VPN, SAFI_EVPN);
 
 	/* Add to hash */
-	if (!hash_get(bgp->vnihash, vpn, hash_alloc_intern)) {
-		XFREE(MTYPE_BGP_EVPN, vpn);
-		return NULL;
-	}
+	(void)hash_get(bgp->vnihash, vpn, hash_alloc_intern);
 
 	bgp_evpn_remote_ip_hash_init(vpn);
 	bgp_evpn_link_to_vni_svi_hash(bgp, vpn);

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -6208,9 +6208,6 @@ static void bgp_evpn_remote_ip_hash_add(struct bgpevpn *vpn,
 	}
 
 	ip = hash_get(vpn->remote_ip_hash, &tmp, bgp_evpn_remote_ip_hash_alloc);
-	if (!ip)
-		return;
-
 	(void)listnode_add(ip->macip_path_list, pi);
 
 	bgp_evpn_remote_ip_process_nexthops(vpn, &ip->addr, true);
@@ -6343,7 +6340,7 @@ static void bgp_evpn_link_to_vni_svi_hash(struct bgp *bgp, struct bgpevpn *vpn)
 	if (vpn->svi_ifindex == 0)
 		return;
 
-	hash_get(bgp->vni_svi_hash, vpn, hash_alloc_intern);
+	(void)hash_get(bgp->vni_svi_hash, vpn, hash_alloc_intern);
 }
 
 static void bgp_evpn_unlink_from_vni_svi_hash(struct bgp *bgp,

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2271,7 +2271,7 @@ static int bgp_establish(struct peer *peer)
 	 * so the hash_release is the same for either.
 	 */
 	hash_release(peer->bgp->peerhash, peer);
-	hash_get(peer->bgp->peerhash, peer, hash_alloc_intern);
+	(void)hash_get(peer->bgp->peerhash, peer, hash_alloc_intern);
 
 	/* Start BFD peer if not already running. */
 	if (peer->bfd_config)

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -256,7 +256,7 @@ void bgp_keepalives_on(struct peer *peer)
 		holder.peer = peer;
 		if (!hash_lookup(peerhash, &holder)) {
 			struct pkat *pkat = pkat_new(peer);
-			hash_get(peerhash, pkat, hash_alloc_intern);
+			(void)hash_get(peerhash, pkat, hash_alloc_intern);
 			peer_lock(peer);
 		}
 		SET_FLAG(peer->thread_flags, PEER_THREAD_KEEPALIVES_ON);

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -539,7 +539,7 @@ static void bgp_accept(struct thread *thread)
 	peer = peer_create(&su, peer1->conf_if, peer1->bgp, peer1->local_as,
 			   peer1->as, peer1->as_type, NULL);
 	hash_release(peer->bgp->peerhash, peer);
-	hash_get(peer->bgp->peerhash, peer, hash_alloc_intern);
+	(void)hash_get(peer->bgp->peerhash, peer, hash_alloc_intern);
 
 	peer_xfer_config(peer, peer1);
 	bgp_peer_gr_flags_update(peer);

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -191,9 +191,6 @@ void bgp_tip_add(struct bgp *bgp, struct in_addr *tip)
 	tmp.addr = *tip;
 
 	addr = hash_get(bgp->tip_hash, &tmp, bgp_tip_hash_alloc);
-	if (!addr)
-		return;
-
 	addr->refcnt++;
 }
 

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -2350,7 +2350,7 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 		pbr_rule.action = bpa;
 		bpr = hash_get(bgp->pbr_rule_hash, &pbr_rule,
 			       bgp_pbr_rule_alloc_intern);
-		if (bpr && bpr->unique == 0) {
+		if (bpr->unique == 0) {
 			bpr->unique = ++bgp_pbr_action_counter_unique;
 			bpr->installed = false;
 			bpr->install_in_progress = false;
@@ -2359,7 +2359,7 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 		} else
 			bpr_found = true;
 		/* already installed */
-		if (bpr_found && bpr) {
+		if (bpr_found) {
 			struct bgp_path_info_extra *extra =
 				bgp_path_info_extra_get(path);
 
@@ -2376,7 +2376,7 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 		bgp_pbr_bpa_add(bpa);
 
 		/* ip rule add */
-		if (bpr && !bpr->installed)
+		if (!bpr->installed)
 			bgp_send_pbr_rule_action(bpa, bpr, true);
 
 		/* A previous entry may already exist

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -754,8 +754,6 @@ static struct update_group *update_group_create(struct peer_af *paf)
 
 	updgrp = hash_get(paf->peer->bgp->update_groups[paf->afid], &tmp,
 			  updgrp_hash_alloc);
-	if (!updgrp)
-		return NULL;
 	update_group_checkin(updgrp);
 
 	if (BGP_DEBUG(update_groups, UPDATE_GROUPS))

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1650,7 +1650,7 @@ void bgp_peer_conf_if_to_su_update(struct peer *peer)
 	/*
 	 * Since our su changed we need to del/add peer to the peerhash
 	 */
-	hash_get(peer->bgp->peerhash, peer, hash_alloc_intern);
+	(void)hash_get(peer->bgp->peerhash, peer, hash_alloc_intern);
 }
 
 void bgp_recalculate_afi_safi_bestpaths(struct bgp *bgp, afi_t afi, safi_t safi)
@@ -1737,7 +1737,7 @@ struct peer *peer_create(union sockunion *su, const char *conf_if,
 	peer = peer_lock(peer); /* bgp peer list reference */
 	peer->group = group;
 	listnode_add_sort(bgp->peer, peer);
-	hash_get(bgp->peerhash, peer, hash_alloc_intern);
+	(void)hash_get(bgp->peerhash, peer, hash_alloc_intern);
 
 	/* Adjust update-group coalesce timer heuristics for # peers. */
 	if (bgp->heuristic_coalesce) {

--- a/isisd/isis_lfa.c
+++ b/isisd/isis_lfa.c
@@ -267,8 +267,8 @@ void isis_lfa_excluded_ifaces_clear(struct isis_circuit *circuit, int level)
 void isis_lfa_excluded_iface_add(struct isis_circuit *circuit, int level,
 				 const char *ifname)
 {
-	hash_get(circuit->lfa_excluded_ifaces[level - 1], (char *)ifname,
-		 lfa_excl_interface_hash_alloc);
+	(void)hash_get(circuit->lfa_excluded_ifaces[level - 1], (char *)ifname,
+		       lfa_excl_interface_hash_alloc);
 }
 
 /**

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -527,14 +527,14 @@ static void vertex_add_parent_firsthop(struct hash_bucket *bucket, void *arg)
 	struct isis_vertex *vertex = arg;
 	struct isis_vertex *hop = bucket->data;
 
-	hash_get(vertex->firsthops, hop, hash_alloc_intern);
+	(void)hash_get(vertex->firsthops, hop, hash_alloc_intern);
 }
 
 static void vertex_update_firsthops(struct isis_vertex *vertex,
 				    struct isis_vertex *parent)
 {
 	if (vertex->d_N <= 2)
-		hash_get(vertex->firsthops, vertex, hash_alloc_intern);
+		(void)hash_get(vertex->firsthops, vertex, hash_alloc_intern);
 
 	if (vertex->d_N < 2 || !parent)
 		return;
@@ -606,8 +606,8 @@ isis_spf_add2tent(struct isis_spftree *spftree, enum vertextype vtype, void *id,
 			if (vertex->N.ip.sr.label != MPLS_INVALID_LABEL)
 				vertex->N.ip.sr.present = true;
 
-			hash_get(spftree->prefix_sids, vertex,
-				 hash_alloc_intern);
+			(void)hash_get(spftree->prefix_sids, vertex,
+				       hash_alloc_intern);
 		}
 	}
 

--- a/lib/command.c
+++ b/lib/command.c
@@ -315,7 +315,7 @@ void _install_element(enum node_type ntype, const struct cmd_element *cmd)
 		return;
 	}
 
-	assert(hash_get(cnode->cmd_hash, (void *)cmd, hash_alloc_intern));
+	(void)hash_get(cnode->cmd_hash, (void *)cmd, hash_alloc_intern);
 
 	if (cnode->graph_built || !defer_cli_tree) {
 		struct graph *graph = graph_new();

--- a/lib/ferr.c
+++ b/lib/ferr.c
@@ -86,7 +86,7 @@ void log_ref_add(struct log_ref *ref)
 
 	frr_with_mutex(&refs_mtx) {
 		while (ref[i].code != END_FERR) {
-			hash_get(refs, &ref[i], hash_alloc_intern);
+			(void)hash_get(refs, &ref[i], hash_alloc_intern);
 			i++;
 		}
 	}

--- a/lib/frrscript.c
+++ b/lib/frrscript.c
@@ -333,7 +333,7 @@ void frrscript_register_type_codec(struct frrscript_codec *codec)
 		assert(!"Type codec double-registered.");
 	}
 
-	assert(hash_get(codec_hash, &c, codec_alloc));
+	(void)hash_get(codec_hash, &c, codec_alloc);
 }
 
 void frrscript_register_type_codecs(struct frrscript_codec *codecs)
@@ -399,7 +399,7 @@ int frrscript_load(struct frrscript *fs, const char *function_name,
 	/* Add the Lua function state to frrscript */
 	struct lua_function_state key = {.name = function_name, .L = L};
 
-	hash_get(fs->lua_function_hash, &key, lua_function_alloc);
+	(void)hash_get(fs->lua_function_hash, &key, lua_function_alloc);
 
 	return 0;
 fail:

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -2216,7 +2216,8 @@ void nb_running_move_tree(const char *xpath_from, const char *xpath_to)
 		strlcpy(entry->xpath, newpath, sizeof(entry->xpath));
 		XFREE(MTYPE_TMP, newpath);
 
-		hash_get(running_config_entries, entry, hash_alloc_intern);
+		(void)hash_get(running_config_entries, entry,
+			       hash_alloc_intern);
 	}
 
 	list_delete(&entries);

--- a/nhrpd/reqid.c
+++ b/nhrpd/reqid.c
@@ -29,7 +29,7 @@ uint32_t nhrp_reqid_alloc(struct nhrp_reqid_pool *p, struct nhrp_reqid *r,
 		if (++p->next_request_id == 0)
 			p->next_request_id = 1;
 		r->cb = cb;
-		hash_get(p->reqid_hash, r, hash_alloc_intern);
+		(void)hash_get(p->reqid_hash, r, hash_alloc_intern);
 	}
 	return r->request_id;
 }

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1562,7 +1562,7 @@ static void
 ospf6_link_route_to_aggr(struct ospf6_external_aggr_rt *aggr,
 			struct ospf6_route *rt)
 {
-	hash_get(aggr->match_extnl_hash, rt, hash_alloc_intern);
+	(void)hash_get(aggr->match_extnl_hash, rt, hash_alloc_intern);
 	rt->aggr_route = aggr;
 }
 

--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -831,8 +831,8 @@ static void ospf6_gr_helper_support_set_per_routerid(struct ospf6 *ospf6,
 
 	} else {
 		/* Add the routerid to the enable router hash table */
-		hash_get(ospf6->ospf6_helper_cfg.enable_rtr_list, &temp,
-			 ospf6_enable_rtr_hash_alloc);
+		(void)hash_get(ospf6->ospf6_helper_cfg.enable_rtr_list, &temp,
+			       ospf6_enable_rtr_hash_alloc);
 	}
 }
 

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -595,7 +595,7 @@ static void ospf_link_ei_to_aggr(struct ospf_external_aggr_rt *aggr,
 			"%s: Linking extrenal route(%pI4/%d) to aggregator(%pI4/%d)",
 			__func__, &ei->p.prefix, ei->p.prefixlen,
 			&aggr->p.prefix, aggr->p.prefixlen);
-	hash_get(aggr->match_extnl_hash, ei, hash_alloc_intern);
+	(void)hash_get(aggr->match_extnl_hash, ei, hash_alloc_intern);
 	ei->aggr_route = aggr;
 }
 

--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -933,8 +933,8 @@ void ospf_gr_helper_support_set_per_routerid(struct ospf *ospf,
 
 	} else {
 		/* Add the routerid to the enable router hash table */
-		hash_get(ospf->enable_rtr_list, &temp,
-			 ospf_enable_rtr_hash_alloc);
+		(void)hash_get(ospf->enable_rtr_list, &temp,
+			       ospf_enable_rtr_hash_alloc);
 	}
 }
 

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -1463,14 +1463,6 @@ void ospf_sr_ri_lsa_update(struct ospf_lsa *lsa)
 		srn = (struct sr_node *)hash_get(OspfSR.neighbors,
 						 &lsah->adv_router,
 						 (void *)sr_node_new);
-		/* Sanity check */
-		if (srn == NULL) {
-			flog_err(
-				EC_OSPF_SR_NODE_CREATE,
-				"SR (%s): Abort! can't create SR node in hash table",
-				__func__);
-			return;
-		}
 		/* update LSA ID */
 		srn->instance = ntohl(lsah->id.s_addr);
 		/* Copy SRGB */
@@ -1581,14 +1573,6 @@ void ospf_sr_ext_link_lsa_update(struct ospf_lsa *lsa)
 	srn = (struct sr_node *)hash_get(OspfSR.neighbors,
 					 (void *)&(lsah->adv_router),
 					 (void *)sr_node_new);
-
-	/* Sanity check */
-	if (srn == NULL) {
-		flog_err(EC_OSPF_SR_NODE_CREATE,
-			 "SR (%s): Abort! can't create SR node in hash table",
-			 __func__);
-		return;
-	}
 
 	/* Initialize TLV browsing */
 	length = lsa->size - OSPF_LSA_HEADER_SIZE;
@@ -1814,15 +1798,6 @@ void ospf_sr_ext_prefix_lsa_update(struct ospf_lsa *lsa)
 	srn = (struct sr_node *)hash_get(OspfSR.neighbors,
 					 (void *)&(lsah->adv_router),
 					 (void *)sr_node_new);
-
-	/* Sanity check */
-	if (srn == NULL) {
-		flog_err(EC_OSPF_SR_NODE_CREATE,
-			 "SR (%s): Abort! can't create SR node in hash table",
-			 __func__);
-		return;
-	}
-
 	/* Initialize TLV browsing */
 	length = lsa->size - OSPF_LSA_HEADER_SIZE;
 	for (tlvh = TLV_HDR_TOP(lsah); length > 0 && tlvh;

--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -1041,8 +1041,9 @@ static int pbr_nht_individual_nexthop_vrf_handle(struct hash_bucket *b,
 						     nhrcvi.nhrc);
 					nhrcvi.nhrc->nexthop.vrf_id =
 						pbr_vrf_id(pnhi->pbr_vrf);
-					hash_get(pbr_nhrc_hash, nhrcvi.nhrc,
-						 hash_alloc_intern);
+					(void)hash_get(pbr_nhrc_hash,
+						       nhrcvi.nhrc,
+						       hash_alloc_intern);
 					pbr_send_rnh(&nhrcvi.nhrc->nexthop, true);
 				}
 			} while (nhrcvi.nhrc);
@@ -1087,7 +1088,8 @@ static void pbr_nht_nexthop_vrf_handle(struct hash_bucket *b, void *data)
 		if (pnhi.pnhc) {
 			pnhi.pnhc->nexthop.vrf_id = pbr_vrf_id(pbr_vrf);
 
-			hash_get(pnhgc->nhh, pnhi.pnhc, hash_alloc_intern);
+			(void)hash_get(pnhgc->nhh, pnhi.pnhc,
+				       hash_alloc_intern);
 		} else
 			pnhc->nexthop.vrf_id = pbr_vrf_id(pbr_vrf);
 
@@ -1141,11 +1143,11 @@ static void pbr_nht_nexthop_interface_handle(struct hash_bucket *b, void *data)
 		if (nhrc) {
 			hash_release(pbr_nhrc_hash, nhrc);
 			nhrc->nexthop.ifindex = ifp->ifindex;
-			hash_get(pbr_nhrc_hash, nhrc, hash_alloc_intern);
+			(void)hash_get(pbr_nhrc_hash, nhrc, hash_alloc_intern);
 		}
 		pnhi.pnhc->nexthop.ifindex = ifp->ifindex;
 
-		hash_get(pnhgc->nhh, pnhi.pnhc, hash_alloc_intern);
+		(void)hash_get(pnhgc->nhh, pnhi.pnhc, hash_alloc_intern);
 
 		pbr_map_check_interface_nh_group_change(pnhgc->name, ifp,
 							old_ifindex);
@@ -1290,7 +1292,7 @@ uint32_t pbr_nht_reserve_next_table_id(struct pbr_nexthop_group_cache *nhgc)
 	nhgc->table_id = pbr_next_unallocated_table_id;
 
 	/* Mark table id as allocated in id-indexed hash */
-	hash_get(pbr_nhg_allocated_id_hash, nhgc, hash_alloc_intern);
+	(void)hash_get(pbr_nhg_allocated_id_hash, nhgc, hash_alloc_intern);
 
 	/* Pre-compute the next unallocated table id */
 	pbr_nht_update_next_unallocated_table_id();

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -151,7 +151,7 @@ int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
 	}
 
 	if (up != NULL)
-		hash_get(pnc->upstream_hash, up, hash_alloc_intern);
+		(void)hash_get(pnc->upstream_hash, up, hash_alloc_intern);
 
 	if (CHECK_FLAG(pnc->flags, PIM_NEXTHOP_VALID)) {
 		if (out_pnc)

--- a/tests/lib/test_srcdest_table.c
+++ b/tests/lib/test_srcdest_table.c
@@ -160,7 +160,7 @@ static void test_state_add_route(struct test_state *test,
 	}
 
 	rn->info = (void *)0xdeadbeef;
-	hash_get(test->log, hash_entry, log_alloc);
+	(void)hash_get(test->log, hash_entry, log_alloc);
 };
 
 static void test_state_del_route(struct test_state *test,

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -654,7 +654,7 @@ struct vrrp_vrouter *vrrp_vrouter_create(struct interface *ifp, uint8_t vrid,
 
 	vrrp_set_advertisement_interval(vr, vd.advertisement_interval);
 
-	hash_get(vrrp_vrouters_hash, vr, hash_alloc_intern);
+	(void)hash_get(vrrp_vrouters_hash, vr, hash_alloc_intern);
 
 	return vr;
 }

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -1022,7 +1022,6 @@ struct zebra_evpn *zebra_evpn_add(vni_t vni)
 	memset(&tmp_zevpn, 0, sizeof(struct zebra_evpn));
 	tmp_zevpn.vni = vni;
 	zevpn = hash_get(zvrf->evpn_table, &tmp_zevpn, zebra_evpn_alloc);
-	assert(zevpn);
 
 	zebra_evpn_es_evi_init(zevpn);
 

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -1105,7 +1105,6 @@ struct zebra_mac *zebra_evpn_mac_add(struct zebra_evpn *zevpn,
 	memset(&tmp_mac, 0, sizeof(struct zebra_mac));
 	memcpy(&tmp_mac.macaddr, macaddr, ETH_ALEN);
 	mac = hash_get(zevpn->mac_table, &tmp_mac, zebra_evpn_mac_alloc);
-	assert(mac);
 
 	mac->zevpn = zevpn;
 	mac->dad_mac_auto_recovery_timer = NULL;

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -570,10 +570,7 @@ zebra_evpn_acc_vl_new(vlanid_t vid, struct interface *br_if)
 	acc_bd->mbr_zifs = list_new();
 
 	/* Add to hash */
-	if (!hash_get(zmh_info->evpn_vlan_table, acc_bd, hash_alloc_intern)) {
-		XFREE(MTYPE_ZACC_BD, acc_bd);
-		return NULL;
-	}
+	(void)hash_get(zmh_info->evpn_vlan_table, acc_bd, hash_alloc_intern);
 
 	/* check if an svi exists for the vlan */
 	if (br_if) {
@@ -1091,10 +1088,7 @@ static uint32_t zebra_evpn_nhid_alloc(struct zebra_evpn_es *es)
 		nh_id = id | EVPN_NHG_ID_TYPE_BIT;
 		/* Add to NHG hash */
 		es->nhg_id = nh_id;
-		if (!hash_get(zmh_info->nhg_table, es, hash_alloc_intern)) {
-			bf_release_index(zmh_info->nh_id_bitmap, id);
-			return 0;
-		}
+		(void)hash_get(zmh_info->nhg_table, es, hash_alloc_intern);
 	} else {
 		nh_id = id | EVPN_NH_ID_TYPE_BIT;
 	}
@@ -1361,10 +1355,7 @@ static struct zebra_evpn_l2_nh *zebra_evpn_l2_nh_alloc(struct in_addr vtep_ip)
 
 	nh = XCALLOC(MTYPE_L2_NH, sizeof(*nh));
 	nh->vtep_ip = vtep_ip;
-	if (!hash_get(zmh_info->nh_ip_table, nh, hash_alloc_intern)) {
-		XFREE(MTYPE_L2_NH, nh);
-		return NULL;
-	}
+	(void)hash_get(zmh_info->nh_ip_table, nh, hash_alloc_intern);
 
 	nh->nh_id = zebra_evpn_nhid_alloc(NULL);
 	if (!nh->nh_id) {

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -553,7 +553,6 @@ static struct zebra_neigh *zebra_evpn_neigh_add(struct zebra_evpn *zevpn,
 	memset(&tmp_n, 0, sizeof(struct zebra_neigh));
 	memcpy(&tmp_n.ip, ip, sizeof(struct ipaddr));
 	n = hash_get(zevpn->neigh_table, &tmp_n, zebra_evpn_neigh_alloc);
-	assert(n);
 
 	n->state = ZEBRA_NEIGH_INACTIVE;
 	n->zevpn = zevpn;

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1596,12 +1596,9 @@ static int zfpm_trigger_rmac_update(struct zebra_mac *rmac,
 			UNSET_FLAG(fpm_mac->fpm_flags, ZEBRA_MAC_UPDATE_FPM);
 			return 0;
 		}
-	} else {
+	} else
 		fpm_mac = hash_get(zfpm_g->fpm_mac_info_table, &key,
 				   zfpm_mac_info_alloc);
-		if (!fpm_mac)
-			return 0;
-	}
 
 	fpm_mac->r_vtep_ip.s_addr = rmac->fwd_info.r_vtep_ip.s_addr;
 	fpm_mac->zebra_flags = rmac->flags;

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -188,8 +188,6 @@ static int lsp_install(struct zebra_vrf *zvrf, mpls_label_t label,
 	/* Locate or allocate LSP entry. */
 	tmp_ile.in_label = label;
 	lsp = hash_get(lsp_table, &tmp_ile, lsp_alloc);
-	if (!lsp)
-		return -1;
 
 	/* For each active nexthop, create NHLFE. Note that we deliberately skip
 	 * recursive nexthops right now, because intermediate hops won't
@@ -2920,8 +2918,6 @@ int mpls_zapi_labels_process(bool add_p, struct zebra_vrf *zvrf,
 		/* Find or create LSP object */
 		tmp_ile.in_label = zl->local_label;
 		lsp = hash_get(lsp_table, &tmp_ile, lsp_alloc);
-		if (!lsp)
-			return -1;
 	}
 
 	/* Prep for route/FEC update if requested */
@@ -3199,8 +3195,6 @@ int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
 	/* Find or create LSP object */
 	tmp_ile.in_label = in_label;
 	lsp = hash_get(lsp_table, &tmp_ile, lsp_alloc);
-	if (!lsp)
-		return -1;
 
 	nhlfe = lsp_add_nhlfe(lsp, type, num_out_labels, out_labels, gtype,
 			      gate, ifindex, false /*backup*/);
@@ -3562,8 +3556,6 @@ int zebra_mpls_static_lsp_add(struct zebra_vrf *zvrf, mpls_label_t in_label,
 	/* Find or create LSP. */
 	tmp_ile.in_label = in_label;
 	lsp = hash_get(slsp_table, &tmp_ile, lsp_alloc);
-	if (!lsp)
-		return -1;
 
 	nhlfe = nhlfe_find(&lsp->nhlfe_list, ZEBRA_LSP_STATIC, gtype, gate,
 			   ifindex);

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -329,7 +329,7 @@ static int zebra_nhg_insert_id(struct nhg_hash_entry *nhe)
 		return -1;
 	}
 
-	hash_get(zrouter.nhgs_id, nhe, hash_alloc_intern);
+	(void)hash_get(zrouter.nhgs_id, nhe, hash_alloc_intern);
 
 	return 0;
 }

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1189,8 +1189,6 @@ static struct zebra_mac *zl3vni_rmac_add(struct zebra_l3vni *zl3vni,
 	memset(&tmp_rmac, 0, sizeof(struct zebra_mac));
 	memcpy(&tmp_rmac.macaddr, rmac, ETH_ALEN);
 	zrmac = hash_get(zl3vni->rmac_table, &tmp_rmac, zl3vni_rmac_alloc);
-	assert(zrmac);
-
 	zrmac->nh_list = list_new();
 	zrmac->nh_list->cmp = (int (*)(void *, void *))l3vni_rmac_nh_list_cmp;
 	zrmac->nh_list->del = (void (*)(void *))l3vni_rmac_nh_free;
@@ -1466,7 +1464,6 @@ static struct zebra_neigh *zl3vni_nh_add(struct zebra_l3vni *zl3vni,
 	memset(&tmp_n, 0, sizeof(struct zebra_neigh));
 	memcpy(&tmp_n.ip, ip, sizeof(struct ipaddr));
 	n = hash_get(zl3vni->nh_table, &tmp_n, zl3vni_nh_alloc);
-	assert(n);
 
 	RB_INIT(host_rb_tree_entry, &n->host_rb);
 
@@ -1696,7 +1693,6 @@ static struct zebra_l3vni *zl3vni_add(vni_t vni, vrf_id_t vrf_id)
 	tmp_zl3vni.vni = vni;
 
 	zl3vni = hash_get(zrouter.l3vni_table, &tmp_zl3vni, zl3vni_alloc);
-	assert(zl3vni);
 
 	zl3vni->vrf_id = vrf_id;
 	zl3vni->svi_if = NULL;
@@ -6039,11 +6035,6 @@ static struct zebra_vxlan_sg *zebra_vxlan_sg_add(struct zebra_vrf *zvrf,
 	}
 
 	vxlan_sg = zebra_vxlan_sg_new(zvrf, sg);
-	if (!vxlan_sg) {
-		if (parent)
-			zebra_vxlan_sg_do_deref(zvrf, sip, sg->grp);
-		return vxlan_sg;
-	}
 
 	zebra_vxlan_sg_send(zvrf, sg, vxlan_sg->sg_str,
 			ZEBRA_VXLAN_SG_ADD);


### PR DESCRIPTION
Two commits:
- bgpd: fix memory leak for evpn
    
    If `hash_get()` returns NULL, the list created with
    `list_new()` is not be freed.
    
    Since `hash_get()` should not fail, we don't need
    `list_delete()` and other boring `XFREE()`s for its
    failure case.
    
    Just ignore returning value of `hash_get()` in these
    cases.
    
-  *: remove the checking returned value for hash_get()
    
    Firstly, *keep no change* for `hash_get()` with NULL                                                                                                                     
    `alloc_func`.                                                                                                                                                            
                                                                                                                                                                             
    Only focus on cases with non-NULL `alloc_func` of                                                                                                                        
    `hash_get()`.
     
    Since `hash_get()` with non-NULL `alloc_func` parameter
    shall not fail, just ignore the returned value of it.
    The returned value must not be NULL.
    So in this case, remove the unnecessary checking NULL
    or not for the returned value and add `void` in front
    of it.
     
    Importantly, also *keep no change* for the two cases with
    non-NULL `alloc_func` -
    1) Use `assert(<returned_data> == <searching_data>)` to
       ensure it is a created node, not a found node.
       Refer to `isis_vertex_queue_insert()` of isisd, there
       are many examples of this case in isid.
    2) Use `<returned_data> != <searching_data>` to judge it
       is a found node, then free <searching_data>.
       Refer to `aspath_intern()` of bgpd, there are many
       examples of this case in bgpd.
     
    Here, <returned_data> is the returned value from `hash_get()`,
    and <searching_data> is the data, which is to be put into
    hash table.

