### PR TITLE
isisd: isis_dr_resign() trace braced with debug isis events

### DIFF
--- a/isisd/isis_dr.c
+++ b/isisd/isis_dr.c
@@ -217,7 +217,8 @@ int isis_dr_resign(struct isis_circuit *circuit, int level)
 {
 	uint8_t id[ISIS_SYS_ID_LEN + 2];
 
-	zlog_debug("isis_dr_resign l%d", level);
+	if (IS_DEBUG_EVENTS)
+		zlog_debug("isis_dr_resign l%d", level);
 
 	circuit->u.bc.is_dr[level - 1] = 0;
 	circuit->u.bc.run_dr_elect[level - 1] = 0;


### PR DESCRIPTION
debug isis events will also be used to not display isis_dr_resign()
event trace.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>