### PR TITLE
isisd: enable BFD messaging debug when isis bfd is used

### DIFF
--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -2158,6 +2158,7 @@ DEFUN (debug_isis_bfd,
        PROTO_NAME " interaction with BFD\n")
 {
 	debug_bfd |= DEBUG_BFD;
+	bfd_protocol_integration_set_debug(true);
 	print_debug(vty, DEBUG_BFD, 1);
 
 	return CMD_SUCCESS;
@@ -2172,6 +2173,7 @@ DEFUN (no_debug_isis_bfd,
        PROTO_NAME " interaction with BFD\n")
 {
 	debug_bfd &= ~DEBUG_BFD;
+	bfd_protocol_integration_set_debug(false);
 	print_debug(vty, DEBUG_BFD, 0);
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
In addition to turning on isis bfd debugging traces, the internal
bfd messaging debug is also enabled. Reversely, when isis bfd traces
are off, the internal messaging debug traces are off too.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>