### PR TITLE
tools: Improve usage example for frrinit.sh

### DIFF
--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -128,7 +128,8 @@ reload)
 
 *)
 	echo "Usage:"
-	echo "    ${0} (start|stop|restart|force-reload|reload|status)"
+	echo "    ${0} <start|stop|restart|force-reload|reload|status> [namespace]"
+	echo "    ${0} stop namespace1"
 	exit 1
 	;;
 esac


### PR DESCRIPTION
```
root@spine1-debian-11:~/frr# /usr/lib/frr/frrinit.sh
Usage:
    /usr/lib/frr/frrinit.sh <start|stop|restart|force-reload|reload|status> [namespace]
    /usr/lib/frr/frrinit.sh stop namespace1
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>