### PR TITLE
lib: Ensure an empty string does not get printed for host/domain

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -445,11 +445,15 @@ static bool full_cli;
 /* This function write configuration of this host. */
 static int config_write_host(struct vty *vty)
 {
-	if (cmd_hostname_get())
-		vty_out(vty, "hostname %s\n", cmd_hostname_get());
+	const char *name;
 
-	if (cmd_domainname_get())
-		vty_out(vty, "domainname %s\n", cmd_domainname_get());
+	name = cmd_hostname_get();
+	if (name && name[0] != '\0')
+		vty_out(vty, "hostname %s\n", name);
+
+	name = cmd_domainname_get();
+	if (name && name[0] != '\0')
+		vty_out(vty, "domainname %s\n", name);
 
 	/* The following are all configuration commands that are not sent to
 	 * watchfrr.  For instance watchfrr is hardcoded to log to syslog so


### PR DESCRIPTION
End operator is showing:
!
frr version 8.0.1
frr defaults traditional
hostname test.example.com
domainname

domainname should not be printed in this case at all.  I do not
see any mechanism in current code that this could happen, but
what do I know?  Put some extra stupid insurance in place
to prevent bad config from being generated.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>