### PR TITLE
isisd: ldp cleaning issue on invalid sptree

### DIFF
--- a/isisd/isis_lfa.c
+++ b/isisd/isis_lfa.c
@@ -1646,6 +1646,11 @@ void isis_ldp_rlfa_handle_client_close(struct zapi_client_close_info *info)
 			     level++) {
 				struct isis_spftree *spftree;
 
+				if (!(area->is_type & level))
+					continue;
+				if (!area->spftree[tree][level - 1])
+					continue;
+
 				spftree = area->spftree[tree][level - 1];
 				isis_rlfa_list_clear(spftree);
 			}


### PR DESCRIPTION
That commit aim is to fix an invalid isis access to sptree when
lpd is stopping. isisd is running.

lpd and isisd are running. isis is L1 type configured.
isis_ldp_rlfa_handle_client_close function try to clear
uninitialized spftree.

Expected behavior: isisd not crashing and running.
isis_ldp_rlfa_handle_client_close not trying to clear spftree
that are not initializes due tio the configuration.

Fix: test the configured area's type avoiding to deleted
an unconfigured sptree. function isis_rlfa_handle_client_close
will be aligned on spftree_area_del function

Signed-off-by: Francois Dumontet <francois.dumontet@6wind.com>