### PR TITLE
vrrpd: Fix display of 'Master Advertisement interval'

### DIFF
--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -503,11 +503,11 @@ static void vrrp_show(struct vty *vty, struct vrrp_vrouter *vr)
 		       vr->accept_mode ? "Yes" : "No");
 	ttable_add_row(tt, "%s|%d ms", "Advertisement Interval",
 		       vr->advertisement_interval * CS2MS);
-	ttable_add_row(tt, "%s|%d ms",
-		       "Master Advertisement Interval (v4)",
+	ttable_add_row(tt, "%s|%d ms (stale)",
+		       "Master Advertisement Interval (v4) Rx",
 		       vr->v4->master_adver_interval * CS2MS);
-	ttable_add_row(tt, "%s|%d ms",
-		       "Master Advertisement Interval (v6)",
+	ttable_add_row(tt, "%s|%d ms (stale)",
+		       "Master Advertisement Interval (v6) Rx",
 		       vr->v6->master_adver_interval * CS2MS);
 	ttable_add_row(tt, "%s|%u", "Advertisements Tx (v4)",
 		       vr->v4->stats.adver_tx_cnt);


### PR DESCRIPTION
VRRP as per RFC 5798 'Master Advertisement interval' field refers to the
advertisement interval, we received the last time we got an Advertisement
from a peer who wasn't us, who was in the master state.
This could be clarified by making the field name 'Master Advertisement
interval (rx)',and when we're in the Master state, we put (stale) after the interval.

Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>