### PR TITLE
bfdd: fix broken FSM in active mode

### DIFF
--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -678,7 +678,8 @@ static void bfdd_sessions_enable_interface(struct interface *ifp)
 		/* If Interface matches vrfname, then bypass iface check */
 		if (vrf_is_backend_netns() || strcmp(ifp->name, vrf->name)) {
 			/* Interface name mismatch. */
-			if (strcmp(ifp->name, bs->key.ifname))
+			if (bs->key.ifname[0] &&
+			    strcmp(ifp->name, bs->key.ifname))
 				continue;
 		}
 


### PR DESCRIPTION
With the simple BFD configuration -
(active mode, single hop, without other parameters)
```
!
bfd
 peer 11.11.11.11
 exit
!
```
The interface with 11.11.11.0/24 is a *virtual* interface,
which can be deleted.

After BFD FSM is created and session is ok, do these things:
1) delete this interface
2) create this interface
3) set same ip address in this interface

Now, everything seems completely restored because all configuration
is same. But bad thing happens, BFD session hang on "down" status -
```
root# show bfd peer 11.11.11.11
BFD Peer:
peer 11.11.11.11 vrf default
ID: 638815827
Remote ID: 0
Active mode
Status: down
Downtime: 3 second(s)
Diagnostics: path down <- caused by destroyed interface
Remote diagnostics: ok
```

With the interface creating, `bfdd_sessions_enable_interface()`
wrongly compares added interface with the created, even key of
this `bfd_session` isn't binded with any interface. So this
`bfd_session` will hang on "down" status for ever.

So skip the compare in this case (no interface in key) to wake up
this `bfd_session`.

Signed-off-by: anlan_cs <vic.lan@pica8.com>