### PR TITLE
staticd: reorg, refactor and improve NHT code

### DIFF
--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -420,6 +420,11 @@ extern const char *family2str(int family);
 extern const char *safi2str(safi_t safi);
 extern const char *afi2str(afi_t afi);
 
+static inline afi_t prefix_afi(union prefixconstptr pu)
+{
+	return family2afi(pu.p->family);
+}
+
 /*
  * Check bit of the prefix.
  *

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -369,13 +369,11 @@ void static_install_nexthop(struct static_nexthop *nh)
 	switch (nh->type) {
 	case STATIC_IPV4_GATEWAY:
 	case STATIC_IPV6_GATEWAY:
-		if (!static_zebra_nh_update(nh))
-			static_zebra_nht_register(nh, true);
+		static_zebra_nht_register(nh, true);
 		break;
 	case STATIC_IPV4_GATEWAY_IFNAME:
 	case STATIC_IPV6_GATEWAY_IFNAME:
-		if (!static_zebra_nh_update(nh))
-			static_zebra_nht_register(nh, true);
+		static_zebra_nht_register(nh, true);
 		break;
 	case STATIC_BLACKHOLE:
 		static_install_path(pn);

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -176,9 +176,12 @@ static int route_notify_owner(ZAPI_CALLBACK_ARGS)
 
 	return 0;
 }
+
 static void zebra_connected(struct zclient *zclient)
 {
 	zclient_send_reg_requests(zclient, VRF_DEFAULT);
+
+	static_fixup_vrf_ids(vrf_info_lookup(VRF_DEFAULT));
 }
 
 /* API to check whether the configured nexthop address is

--- a/staticd/static_zebra.h
+++ b/staticd/static_zebra.h
@@ -33,7 +33,6 @@ extern void static_zebra_init(void);
 extern void static_zebra_stop(void);
 extern void static_zebra_vrf_register(struct vrf *vrf);
 extern void static_zebra_vrf_unregister(struct vrf *vrf);
-extern int static_zebra_nh_update(struct static_nexthop *nh);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- first, a little bit of cleanup
- then combine `update` and `register` functions since they're used in functionally common places anyway
- retry NHT registration if it failed previously
- and fix/initialize NHT for `VRF_DEFAULT` when zebra connection is established

Free bonus content: `prefix_afi()` in lib/prefix.h, shorthand to get `struct prefix *` → `afi_t`