### PR TITLE
tools: frr-reload fix bgp neighbor and bgp instance deletion 

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -901,15 +901,11 @@ def bgp_remove_neighbor_cfg(lines_to_del, del_nbr_dict):
         lines_to_del.remove((ctx_keys, line))
 
 
-"""
-This method handles deletion of bgp peer group config.
-The objective is to delete config lines related to peers
-associated with the peer-group and move the peer-group
-config line to the end of the lines_to_del list.
-"""
-
-
 def delete_move_lines(lines_to_add, lines_to_del):
+    # This method handles deletion of bgp peer group config.
+    # The objective is to delete config lines related to peers
+    # associated with the peer-group and move the peer-group
+    # config line to the end of the lines_to_del list.
 
     bgp_delete_nbr_remote_as_line(lines_to_add)
 

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -873,6 +873,34 @@ def bgp_delete_nbr_remote_as_line(lines_to_add):
         lines_to_add.remove((ctx_keys, line))
 
 
+def bgp_remove_neighbor_cfg(lines_to_del, del_nbr_dict):
+
+    # This method handles deletion of bgp neighbor configs,
+    # if there is neighbor to peer-group cmd is in delete list.
+    # As 'no neighbor .* peer-group' deletes the neighbor,
+    # subsequent neighbor speciic config line deletion results
+    # in error.
+    lines_to_del_to_del = []
+
+    for (ctx_keys, line) in lines_to_del:
+        if (
+            ctx_keys[0].startswith("router bgp")
+            and line
+            and line.startswith("neighbor ")
+        ):
+            if ctx_keys[0] in del_nbr_dict:
+                for nbr in del_nbr_dict[ctx_keys[0]]:
+                    re_nbr_pg = re.search('neighbor (\S+) .*peer-group (\S+)', line)
+                    nb_exp = "neighbor %s .*" % nbr
+                    if not re_nbr_pg:
+                        re_nb = re.search(nb_exp, line)
+                        if re_nb:
+                            lines_to_del_to_del.append((ctx_keys, line))
+
+    for (ctx_keys, line) in lines_to_del_to_del:
+        lines_to_del.remove((ctx_keys, line))
+
+
 """
 This method handles deletion of bgp peer group config.
 The objective is to delete config lines related to peers
@@ -886,6 +914,7 @@ def delete_move_lines(lines_to_add, lines_to_del):
     bgp_delete_nbr_remote_as_line(lines_to_add)
 
     del_dict = dict()
+    del_nbr_dict = dict()
     # Stores the lines to move to the end of the pending list.
     lines_to_del_to_del = []
     # Stores the lines to move to end of the pending list.
@@ -969,6 +998,16 @@ def delete_move_lines(lines_to_add, lines_to_del):
             if re_nb_remoteas:
                 lines_to_del_to_app.append((ctx_keys, line))
 
+            # 'no neighbor peer [interface] peer-group <>' is in lines_to_del
+            # copy the neighbor and look for all config removal lines associated
+            # to neighbor and delete them from the lines_to_del
+            re_nbr_pg = re.search('neighbor (\S+) .*peer-group (\S+)', line)
+            if re_nbr_pg:
+                if ctx_keys[0] not in del_nbr_dict:
+                    del_nbr_dict[ctx_keys[0]] = list()
+                if re_nbr_pg.group(1) not in del_nbr_dict[ctx_keys[0]]:
+                    del_nbr_dict[ctx_keys[0]].append(re_nbr_pg.group(1))
+
             # {'router bgp 65001': {'PG': [], 'PG1': []},
             # 'router bgp 65001 vrf vrf1': {'PG': [], 'PG1': []}}
             if ctx_keys[0] not in del_dict:
@@ -981,6 +1020,8 @@ def delete_move_lines(lines_to_add, lines_to_del):
 
     if found_pg_del_cmd == False:
         bgp_delete_inst_move_line(lines_to_del)
+        if del_nbr_dict:
+            bgp_remove_neighbor_cfg(lines_to_del, del_nbr_dict)
         return (lines_to_add, lines_to_del)
 
     for (ctx_keys, line) in lines_to_del_to_app:


### PR DESCRIPTION
1) tools: frr-reload fix bgp nbr delete

When a bgp neighbor removed from associated to peer-group,
the neighbor is fully deleted, subsequent deletion of any
configuration related to the neighbor leads to failure
in frr-reload.

Fix: In frr-reload lines to delete check if any neighbor with
peer-group removal line is present, if so then remove any
further config deletion associated the neighbor needs to removed
from the lines to delete.

Testing Done:

**BEFORE FIX:**
-----------
```
2022-04-08 20:03:32,734  INFO: Executed "router bgp 4200000005  no neighbor swp5 interface peer-group UNDERLAY"
2022-04-08 20:03:32,892  INFO: Failed to execute router bgp 4200000005  no neighbor swp5 password SSSS
2022-04-08 20:03:33,050  INFO: Failed to execute router bgp 4200000005  no neighbor swp5 password
2022-04-08 20:03:33,218  INFO: Failed to execute router bgp 4200000005  no neighbor swp5
2022-04-08 20:03:33,354  INFO: Failed to execute router bgp 4200000005  no neighbor
2022-04-08 20:03:33,520  INFO: Failed to execute router bgp 4200000005  no
2022-04-08 20:03:33,521 ERROR: "router bgp 4200000005 --  no" we failed to remove this command
2022-04-08 20:03:33,521 ERROR: % Specify remote-as or peer-group commands first

2022-04-08 20:03:33,691  INFO: Failed to execute router bgp 4200000005  no neighbor swp5 advertisement-interval 0
2022-04-08 20:03:33,853  INFO: Failed to execute router bgp 4200000005  no neighbor swp5 advertisement-interval
2022-04-08 20:03:34,015  INFO: Failed to execute router bgp 4200000005  no neighbor swp5
2022-04-08 20:03:34,145  INFO: Failed to execute router bgp 4200000005  no neighbor
2022-04-08 20:03:34,326  INFO: Failed to execute router bgp 4200000005  no
2022-04-08 20:03:34,327 ERROR: "router bgp 4200000005 --  no" we failed to remove this command
2022-04-08 20:03:34,327 ERROR: % Specify remote-as or peer-group commands first
```

**AFTER FIX:**
----------
```
delete of numbered neighbor:

2022-04-08 19:52:17,204  INFO: Executed "router bgp 4200000005  no
neighbor 1.2.3.4 peer-group UNDERLAY"
2022-04-08 19:52:17,205  INFO: /var/run/frr/reload-GRFX1M.txt content

delete of unnumbered neighbor:
2022-04-08 20:00:02,952  INFO: Executed "router bgp 4200000005  no
neighbor swp5 interface peer-group UNDERLAY"
2022-04-08 20:00:02,953  INFO: /var/run/frr/reload-722C3P.txt content
```

2)
tools: fix bgp instances deletion in frr-reload

BGPd does not allow defualt instance deletion
in presence of bgp vrf instance;
frr-reload script fails if it has deletion order
of default instance followed by vrf instance.

Fix:
frr-reload scans lines_to_delete to look for
'router bgp' and 'router bgp vrf ...' line.
If both are present switch the order to delete
default instance at the end.

Testing Done:

**Before:**

```
  INFO: Loading Config object from file /etc/frr/frr.conf
  INFO: Loading Config object from vtysh show running
  INFO: Failed to execute no router bgp 40201 <-- Failed to delete
  INFO: Failed to execute no router bgp
  INFO: Failed to execute no router
 ERROR: "no router" we failed to remove this command
 ERROR: % Cannot delete default BGP instance. Dependent VRF instances exist

  INFO: Executed "no router bgp 40201 vrf bgp-test" <-- vrf instance deleted
  INFO: Loading Config object from vtysh show running
```

**After:**
  order of deletion switched

```
  INFO: Loading Config object from file /etc/frr/frr.conf
  INFO: Loading Config object from vtysh show running
  INFO: Executed "no router bgp 40201 vrf bgp-test"
  INFO: Executed "no router bgp 40201"
  INFO: Loading Config object from vtysh show running
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>