### PR TITLE
bgpd: optimize "auto_rt" searching procedure for evpn

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5104,7 +5104,6 @@ int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 /*
  * Map the RTs (configured or automatically derived) of a VRF to the VRF.
  * The mapping will be used during route processing.
- * bgp_def: default bgp instance
  * bgp_vrf: specific bgp vrf instance on which RT is configured
  */
 void bgp_evpn_map_vrf_to_its_rts(struct bgp *bgp_vrf)

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -520,8 +520,10 @@ static void form_auto_rt(struct bgp *bgp, vni_t vni, struct list *rtl)
 	ecomadd = ecommunity_new();
 	ecommunity_add_val(ecomadd, &eval, false, false);
 	for (ALL_LIST_ELEMENTS_RO(rtl, node, ecom))
-		if (ecommunity_cmp(ecomadd, ecom))
+		if (ecommunity_cmp(ecomadd, ecom)) {
 			ecom_found = true;
+			break;
+		}
 
 	if (!ecom_found)
 		listnode_add_sort(rtl, ecomadd);
@@ -4556,6 +4558,7 @@ void evpn_rt_delete_auto(struct bgp *bgp, vni_t vni, struct list *rtl)
 		if (ecommunity_match(ecom, ecom_auto)) {
 			ecommunity_free(&ecom);
 			node_to_del = node;
+			break;
 		}
 	}
 

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -196,9 +196,8 @@ static int bgp_evpn_es_route_install(struct bgp *bgp,
 
 	/* Check if route entry is already present. */
 	for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next)
-		if (pi->extra
-				&& (struct bgp_path_info *)pi->extra->parent ==
-				parent_pi)
+		if (pi->extra &&
+		    (struct bgp_path_info *)pi->extra->parent == parent_pi)
 			break;
 
 	if (!pi) {
@@ -3841,13 +3840,13 @@ int bgp_evpn_remote_es_evi_del(struct bgp *bgp, struct bgpevpn *vpn,
 	es = bgp_evpn_es_find(&p->prefix.ead_addr.esi);
 	if (!es) {
 		if (BGP_DEBUG(evpn_mh, EVPN_MH_ES))
-			zlog_debug("del remote %s es %s evi %u vtep %pI4, NO es",
-				   p->prefix.ead_addr.eth_tag ? "ead-es"
-							      : "ead-evi",
-				   esi_to_str(&p->prefix.ead_addr.esi, buf,
-					      sizeof(buf)),
-				   vpn->vni,
-    			   &p->prefix.ead_addr.ip.ipaddr_v4);
+			zlog_debug(
+				"del remote %s es %s evi %u vtep %pI4, NO es",
+				p->prefix.ead_addr.eth_tag ? "ead-es"
+							   : "ead-evi",
+				esi_to_str(&p->prefix.ead_addr.esi, buf,
+					   sizeof(buf)),
+				vpn->vni, &p->prefix.ead_addr.ip.ipaddr_v4);
 		return 0;
 	}
 	es_evi = bgp_evpn_es_evi_find(es, vpn);


### PR DESCRIPTION
Two commits:

- bgpd: optimize "auto_rt" searching procedure for evpn
    
    RT value will be unique across different VNIs but the
    same across routers (in the same AS) for a particula
    VNI.
    
    It is unique, so add `break` for search procedure.

- bgpd: minor style change
    
    Correct two style places and one comment.
