### PR TITLE
pimd: fix SNAFUs in debug flags

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6139,6 +6139,32 @@ DEFUN (no_debug_igmp_trace,
 }
 
 
+DEFUN (debug_igmp_trace_detail,
+       debug_igmp_trace_detail_cmd,
+       "debug igmp trace detail",
+       DEBUG_STR
+       DEBUG_IGMP_STR
+       DEBUG_IGMP_TRACE_STR
+       "detailed\n")
+{
+	PIM_DO_DEBUG_IGMP_TRACE_DETAIL;
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_debug_igmp_trace_detail,
+       no_debug_igmp_trace_detail_cmd,
+       "no debug igmp trace detail",
+       NO_STR
+       DEBUG_STR
+       DEBUG_IGMP_STR
+       DEBUG_IGMP_TRACE_STR
+       "detailed\n")
+{
+	PIM_DONT_DEBUG_IGMP_TRACE_DETAIL;
+	return CMD_SUCCESS;
+}
+
+
 DEFUN (debug_mroute,
        debug_mroute_cmd,
        "debug mroute",
@@ -8548,6 +8574,8 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &no_debug_igmp_packets_cmd);
 	install_element(ENABLE_NODE, &debug_igmp_trace_cmd);
 	install_element(ENABLE_NODE, &no_debug_igmp_trace_cmd);
+	install_element(ENABLE_NODE, &debug_igmp_trace_detail_cmd);
+	install_element(ENABLE_NODE, &no_debug_igmp_trace_detail_cmd);
 	install_element(ENABLE_NODE, &debug_mroute_cmd);
 	install_element(ENABLE_NODE, &debug_mroute_detail_cmd);
 	install_element(ENABLE_NODE, &no_debug_mroute_cmd);
@@ -8601,6 +8629,8 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_debug_igmp_packets_cmd);
 	install_element(CONFIG_NODE, &debug_igmp_trace_cmd);
 	install_element(CONFIG_NODE, &no_debug_igmp_trace_cmd);
+	install_element(CONFIG_NODE, &debug_igmp_trace_detail_cmd);
+	install_element(CONFIG_NODE, &no_debug_igmp_trace_detail_cmd);
 	install_element(CONFIG_NODE, &debug_mroute_cmd);
 	install_element(CONFIG_NODE, &debug_mroute_detail_cmd);
 	install_element(CONFIG_NODE, &no_debug_mroute_cmd);

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -70,18 +70,18 @@ int pim_debug_config_write(struct vty *vty)
 		++writes;
 	}
 
-	if (PIM_DEBUG_MROUTE) {
+	/* PIM_DEBUG_MROUTE catches _DETAIL too */
+	if (router->debugs & PIM_MASK_MROUTE) {
 		vty_out(vty, "debug mroute\n");
+		++writes;
+	}
+	if (PIM_DEBUG_MROUTE_DETAIL) {
+		vty_out(vty, "debug mroute detail\n");
 		++writes;
 	}
 
 	if (PIM_DEBUG_MTRACE) {
 		vty_out(vty, "debug mtrace\n");
-		++writes;
-	}
-
-	if (PIM_DEBUG_MROUTE_DETAIL_ONLY) {
-		vty_out(vty, "debug mroute detail\n");
 		++writes;
 	}
 
@@ -102,11 +102,12 @@ int pim_debug_config_write(struct vty *vty)
 		++writes;
 	}
 
-	if (PIM_DEBUG_PIM_TRACE) {
+	/* PIM_DEBUG_PIM_TRACE catches _DETAIL too */
+	if (router->debugs & PIM_MASK_PIM_TRACE) {
 		vty_out(vty, "debug pim trace\n");
 		++writes;
 	}
-	if (PIM_DEBUG_PIM_TRACE_DETAIL_ONLY) {
+	if (PIM_DEBUG_PIM_TRACE_DETAIL) {
 		vty_out(vty, "debug pim trace detail\n");
 		++writes;
 	}

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -65,8 +65,13 @@ int pim_debug_config_write(struct vty *vty)
 		vty_out(vty, "debug igmp packets\n");
 		++writes;
 	}
-	if (PIM_DEBUG_IGMP_TRACE) {
+	/* PIM_DEBUG_IGMP_TRACE catches _DETAIL too */
+	if (router->debugs & PIM_MASK_IGMP_TRACE) {
 		vty_out(vty, "debug igmp trace\n");
+		++writes;
+	}
+	if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
+		vty_out(vty, "debug igmp trace detail\n");
 		++writes;
 	}
 

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -157,23 +157,22 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 	(router->debugs & PIM_MASK_PIM_PACKETDUMP_SEND)
 #define PIM_DEBUG_PIM_PACKETDUMP_RECV                                          \
 	(router->debugs & PIM_MASK_PIM_PACKETDUMP_RECV)
-#define PIM_DEBUG_PIM_TRACE (router->debugs & PIM_MASK_PIM_TRACE)
+#define PIM_DEBUG_PIM_TRACE                                                    \
+	(router->debugs & (PIM_MASK_PIM_TRACE | PIM_MASK_PIM_TRACE_DETAIL))
 #define PIM_DEBUG_PIM_TRACE_DETAIL                                             \
-	(router->debugs & (PIM_MASK_PIM_TRACE_DETAIL | PIM_MASK_PIM_TRACE))
-#define PIM_DEBUG_PIM_TRACE_DETAIL_ONLY                                        \
 	(router->debugs & PIM_MASK_PIM_TRACE_DETAIL)
 #define PIM_DEBUG_IGMP_EVENTS (router->debugs & PIM_MASK_IGMP_EVENTS)
 #define PIM_DEBUG_IGMP_PACKETS (router->debugs & PIM_MASK_IGMP_PACKETS)
-#define PIM_DEBUG_IGMP_TRACE (router->debugs & PIM_MASK_IGMP_TRACE)
+#define PIM_DEBUG_IGMP_TRACE                                                   \
+	(router->debugs & (PIM_MASK_IGMP_TRACE | PIM_MASK_IGMP_TRACE_DETAIL))
 #define PIM_DEBUG_IGMP_TRACE_DETAIL                                            \
-	(router->debugs & (PIM_MASK_IGMP_TRACE_DETAIL | PIM_MASK_IGMP_TRACE))
+	(router->debugs & PIM_MASK_IGMP_TRACE_DETAIL)
 #define PIM_DEBUG_ZEBRA (router->debugs & PIM_MASK_ZEBRA)
 #define PIM_DEBUG_MLAG (router->debugs & PIM_MASK_MLAG)
 #define PIM_DEBUG_SSMPINGD (router->debugs & PIM_MASK_SSMPINGD)
-#define PIM_DEBUG_MROUTE (router->debugs & PIM_MASK_MROUTE)
-#define PIM_DEBUG_MROUTE_DETAIL                                                \
-	(router->debugs & (PIM_MASK_MROUTE_DETAIL | PIM_MASK_MROUTE))
-#define PIM_DEBUG_MROUTE_DETAIL_ONLY (router->debugs & PIM_MASK_MROUTE_DETAIL)
+#define PIM_DEBUG_MROUTE                                                       \
+	(router->debugs & (PIM_MASK_MROUTE | PIM_MASK_MROUTE_DETAIL))
+#define PIM_DEBUG_MROUTE_DETAIL (router->debugs & PIM_MASK_MROUTE_DETAIL)
 #define PIM_DEBUG_PIM_HELLO (router->debugs & PIM_MASK_PIM_HELLO)
 #define PIM_DEBUG_PIM_J_P (router->debugs & PIM_MASK_PIM_J_P)
 #define PIM_DEBUG_PIM_REG (router->debugs & PIM_MASK_PIM_REG)


### PR DESCRIPTION
The logic for enabling `detailed` versions was supposed to implicitly enable the "normal" debugs, but it got SNAFUd to be the other way around, "normal" enabling `detailed` instead.

Also `debug igmp trace detail` was straight up missing, i.e. no way to set `PIM_DEBUG_IGMP_TRACE_DETAIL`. (And the flag is used in 3 places.)