### PR TITLE
build: fix new gcc 11.2 warnings

### DIFF
--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -104,7 +104,7 @@ DEFPY(watch_nexthop_v6, watch_nexthop_v6_cmd,
 		p.family = AF_INET6;
 	} else {
 		type_import = true;
-		p = *(const struct prefix *)inhop;
+		prefix_copy(&p, inhop);
 	}
 
 	sharp_nh_tracker_get(&p);
@@ -149,7 +149,7 @@ DEFPY(watch_nexthop_v4, watch_nexthop_v4_cmd,
 	}
 	else {
 		type_import = true;
-		p = *(const struct prefix *)inhop;
+		prefix_copy(&p, inhop);
 	}
 
 	sharp_nh_tracker_get(&p);


### PR DESCRIPTION
Some recent improvement in GCC triggers 2 new warnings, and they're actual bugs (reading beyond end of prefix_ipv6 by accessing it as prefix, which is larger.)  Luckily it's only in sharpd.