### PR TITLE
Allow martians

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1603,11 +1603,12 @@ enum bgp_attr_parse_ret bgp_attr_nexthop_valid(struct peer *peer,
 					       struct attr *attr)
 {
 	in_addr_t nexthop_h;
+	struct bgp *bgp = peer->bgp;
 
 	nexthop_h = ntohl(attr->nexthop.s_addr);
 	if ((IPV4_NET0(nexthop_h) || IPV4_NET127(nexthop_h) ||
 	     !ipv4_unicast_valid(&attr->nexthop)) &&
-	    !BGP_DEBUG(allow_martians, ALLOW_MARTIANS)) {
+	    !bgp->allow_martian) {
 		uint8_t data[7]; /* type(2) + length(1) + nhop(4) */
 		char buf[INET_ADDRSTRLEN];
 

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -1809,40 +1809,6 @@ DEFUN (no_debug_bgp_zebra_prefix,
 	return CMD_SUCCESS;
 }
 
-DEFUN (debug_bgp_allow_martians,
-       debug_bgp_allow_martians_cmd,
-       "debug bgp allow-martians",
-       DEBUG_STR
-       BGP_STR
-       "BGP allow martian next hops\n")
-{
-	if (vty->node == CONFIG_NODE)
-		DEBUG_ON(allow_martians, ALLOW_MARTIANS);
-	else {
-		TERM_DEBUG_ON(allow_martians, ALLOW_MARTIANS);
-		vty_out(vty, "BGP allow_martian next hop debugging is on\n");
-	}
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_bgp_allow_martians,
-       no_debug_bgp_allow_martians_cmd,
-       "no debug bgp allow-martians",
-       NO_STR
-       DEBUG_STR
-       BGP_STR
-       "BGP allow martian next hops\n")
-{
-	if (vty->node == CONFIG_NODE)
-		DEBUG_OFF(allow_martians, ALLOW_MARTIANS);
-	else {
-		TERM_DEBUG_OFF(allow_martians, ALLOW_MARTIANS);
-		vty_out(vty, "BGP allow martian next hop debugging is off\n");
-	}
-	return CMD_SUCCESS;
-}
-
-
 /* debug bgp update-groups */
 DEFUN (debug_bgp_update_groups,
        debug_bgp_update_groups_cmd,
@@ -2438,8 +2404,6 @@ void bgp_debug_init(void)
 	install_element(CONFIG_NODE, &debug_bgp_update_cmd);
 	install_element(ENABLE_NODE, &debug_bgp_zebra_cmd);
 	install_element(CONFIG_NODE, &debug_bgp_zebra_cmd);
-	install_element(ENABLE_NODE, &debug_bgp_allow_martians_cmd);
-	install_element(CONFIG_NODE, &debug_bgp_allow_martians_cmd);
 	install_element(ENABLE_NODE, &debug_bgp_update_groups_cmd);
 	install_element(CONFIG_NODE, &debug_bgp_update_groups_cmd);
 	install_element(ENABLE_NODE, &debug_bgp_bestpath_prefix_cmd);
@@ -2503,8 +2467,6 @@ void bgp_debug_init(void)
 	install_element(CONFIG_NODE, &no_debug_bgp_update_cmd);
 	install_element(ENABLE_NODE, &no_debug_bgp_zebra_cmd);
 	install_element(CONFIG_NODE, &no_debug_bgp_zebra_cmd);
-	install_element(ENABLE_NODE, &no_debug_bgp_allow_martians_cmd);
-	install_element(CONFIG_NODE, &no_debug_bgp_allow_martians_cmd);
 	install_element(ENABLE_NODE, &no_debug_bgp_update_groups_cmd);
 	install_element(CONFIG_NODE, &no_debug_bgp_update_groups_cmd);
 	install_element(ENABLE_NODE, &no_debug_bgp_cmd);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -4423,6 +4423,24 @@ DEFUN (neighbor_remote_as,
 	return peer_remote_as_vty(vty, argv[idx_peer]->arg,
 				  argv[idx_remote_as]->arg);
 }
+
+DEFPY (bgp_allow_martian,
+       bgp_allow_martian_cmd,
+       "[no]$no bgp allow-martian-nexthop",
+       NO_STR
+       BGP_STR
+       "Allow Martian nexthops to be received in the NLRI from a peer\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+
+	if (no)
+		bgp->allow_martian = false;
+	else
+		bgp->allow_martian = true;
+
+	return CMD_SUCCESS;
+}
+
 /* Enable fast convergence of bgp sessions. If this is enabled, bgp
  * sessions do not wait for hold timer expiry to bring down the sessions
  * when nexthop becomes unreachable
@@ -17517,6 +17535,9 @@ int bgp_config_write(struct vty *vty)
 		if (CHECK_FLAG(bgp->flags, BGP_FLAG_SHUTDOWN))
 			vty_out(vty, " bgp shutdown\n");
 
+		if (bgp->allow_martian)
+			vty_out(vty, " bgp allow-martian-nexthop\n");
+
 		if (bgp->fast_convergence)
 			vty_out(vty, " bgp fast-convergence\n");
 
@@ -17859,6 +17880,8 @@ void bgp_vty_init(void)
 	/* bgp route-map delay-timer commands. */
 	install_element(CONFIG_NODE, &bgp_set_route_map_delay_timer_cmd);
 	install_element(CONFIG_NODE, &no_bgp_set_route_map_delay_timer_cmd);
+
+	install_element(BGP_NODE, &bgp_allow_martian_cmd);
 
 	/* bgp fast-convergence command */
 	install_element(BGP_NODE, &bgp_fast_convergence_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3126,6 +3126,7 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 
 	bgp_lock(bgp);
 
+	bgp->allow_martian = false;
 	bgp_process_queue_init(bgp);
 	bgp->heuristic_coalesce = true;
 	bgp->inst_type = inst_type;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -770,6 +770,8 @@ struct bgp {
 	struct timeval ebgprequirespolicywarning;
 #define FIFTEENMINUTE2USEC (int64_t)15 * 60 * 1000000
 
+	bool allow_martian;
+
 	QOBJ_FIELDS;
 };
 DECLARE_QOBJ_TYPE(bgp);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3365,6 +3365,12 @@ Debugging
    Display Listen sockets and the vrf that created them.  Useful for debugging of when
    listen is not working and this is considered a developer debug statement.
 
+.. clicmd:: debug bgp allow-martian
+
+   Enable or disable BGP accepting martian nexthops from a peer.  Please note
+   this is not an actual debug command and this command is also being deprecated
+   and will be removed soon.  The new command is :clicmd:`bgp allow-martian-nexthop`
+
 .. clicmd:: debug bgp bfd
 
    Enable or disable debugging for BFD events. This will show BFD integration
@@ -4005,6 +4011,12 @@ starting the daemon and the configuration gets saved, the option will persist
 unless removed from the configuration with the negating command prior to the
 configuration write operation.  At this point in time non SAFI_UNICAST BGP
 data is not properly withdrawn from zebra when this command is issued.
+
+.. clicmd:: bgp allow-martian-nexthop
+
+When a peer receives a martian nexthop as part of the NLRI for a route
+permit the nexthop to be used as such, instead of rejecting and resetting
+the connection.
 
 .. clicmd:: bgp send-extra-data zebra
 


### PR DESCRIPTION
Add the `bgp allow-martian` command under `router bgp X` to allow bgp to receive a NLRI with a nexthop that is a martian address.  Deprecate `debug bgp allow-martian` which is what originally did this