### PR TITLE
bgpd: rfc8277 not yet supported

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3420,7 +3420,7 @@ enum bgp_attr_parse_ret bgp_attr_parse(struct peer *peer, struct attr *attr,
 	 * About Prefix-SID path attribute,
 	 * Label-Index TLV(type1) and The Originator SRGB TLV(type-3)
 	 * may only appear in a BGP Prefix-SID attribute attached to
-	 * IPv4/IPv6 Labeled Unicast prefixes ([RFC8277]).
+	 * IPv4/IPv6 Labeled Unicast prefixes ([RFC3107]).
 	 * It MUST be ignored when received for other BGP AFI/SAFI combinations.
 	 */
 	if (!attr->mp_nexthop_len || mp_update->safi != SAFI_LABELED_UNICAST)

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -128,8 +128,8 @@ Multiprotocol extensions enable BGP to carry routing information for multiple
 network layer protocols. BGP supports an Address Family Identifier (AFI) for
 IPv4 and IPv6. Support is also provided for multiple sets of per-AFI
 information via the BGP Subsequent Address Family Identifier (SAFI). FRR
-supports SAFIs for unicast information, labeled information (:rfc:`3107` and
-:rfc:`8277`), and Layer 3 VPN information (:rfc:`4364` and :rfc:`4659`).
+supports SAFIs for unicast information, labeled information (:rfc:`3107`),
+and Layer 3 VPN information (:rfc:`4364` and :rfc:`4659`).
 
 .. _bgp-route-selection:
 

--- a/doc/user/overview.rst
+++ b/doc/user/overview.rst
@@ -373,8 +373,6 @@ BGP
   :t:`BGP Administrative Shutdown Communication. J. Snijders, J. Heitz, J. Scudder. July 2017.`
 - :rfc:`8212`
   :t:`Default External BGP (EBGP) Route Propagation Behavior without Policies. J. Mauch, J. Snijders, G. Hankins. July 2017`
-- :rfc:`8277`
-  :t:`Using BGP to Bind MPLS Labels to Address Prefixes. E. Rosen. October 2017`
 - :rfc:`8654`
   :t:`Extended Message Support for BGP. R. Bush, K. Patel, D. Ward.  October 2019`
 - :rfc:`9003`


### PR DESCRIPTION
Remove the rfc8277 from the list of supported RFCs.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>