### PR TITLE
pim6d: Removal of IPV6_HDRINCL option

### DIFF
--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -76,11 +76,6 @@ void pim_socket_ip_hdr(int fd)
 		if (setsockopt(fd, IPPROTO_IP, IP_HDRINCL, &on, sizeof(on)))
 			zlog_err("%s: Could not turn on IP_HDRINCL option: %m",
 				 __func__);
-#else
-		if (setsockopt(fd, IPPROTO_IPV6, IPV6_HDRINCL, &on, sizeof(on)))
-			zlog_err(
-				"%s: Could not turn on IPV6_HDRINCL option: %m",
-				__func__);
 #endif
 	}
 }


### PR DESCRIPTION
Removal of IPV6_HDRINCL option as the kernel would take care of IPv6 fragmentation.

Signed-off-by: Balaji Gurudoss <G_Balaji1@dell.com>