### PR TITLE
bfdd: fix wrong local address of display command

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -290,7 +290,6 @@ struct bfd_session {
 	struct peer_label *pl;
 
 	struct bfd_dplane_ctx *bdc;
-	struct sockaddr_any local_address;
 	struct interface *ifp;
 	struct vrf *vrf;
 

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -641,7 +641,6 @@ void bfd_recv_cb(struct thread *t)
 
 	/*
 	 * Multi hop: validate packet TTL.
-	 * Single hop: set local address that received the packet.
 	 */
 	if (is_mhop) {
 		if (ttl < bfd->mh_ttl) {
@@ -650,8 +649,6 @@ void bfd_recv_cb(struct thread *t)
 				 bfd->mh_ttl, ttl);
 			return;
 		}
-	} else if (bfd->local_address.sa_sin.sin_family == AF_UNSPEC) {
-		bfd->local_address = local;
 	}
 
 	bfd->stats.rx_ctrl_pkt++;

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -486,21 +486,12 @@ static void _display_peer_brief(struct vty *vty, struct bfd_session *bs)
 {
 	char addr_buf[INET6_ADDRSTRLEN];
 
-	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)) {
-		vty_out(vty, "%-10u", bs->discrs.my_discr);
-		inet_ntop(bs->key.family, &bs->key.local, addr_buf, sizeof(addr_buf));
-		vty_out(vty, " %-40s", addr_buf);
-		inet_ntop(bs->key.family, &bs->key.peer, addr_buf, sizeof(addr_buf));
-		vty_out(vty, " %-40s", addr_buf);
-		vty_out(vty, "%-15s\n", state_list[bs->ses_state].str);
-	} else {
-		vty_out(vty, "%-10u", bs->discrs.my_discr);
-		vty_out(vty, " %-40s", satostr(&bs->local_address));
-		inet_ntop(bs->key.family, &bs->key.peer, addr_buf, sizeof(addr_buf));
-		vty_out(vty, " %-40s", addr_buf);
-
-		vty_out(vty, "%-15s\n", state_list[bs->ses_state].str);
-	}
+	vty_out(vty, "%-10u", bs->discrs.my_discr);
+	inet_ntop(bs->key.family, &bs->key.local, addr_buf, sizeof(addr_buf));
+	vty_out(vty, " %-40s", addr_buf);
+	inet_ntop(bs->key.family, &bs->key.peer, addr_buf, sizeof(addr_buf));
+	vty_out(vty, " %-40s", addr_buf);
+	vty_out(vty, "%-15s\n", state_list[bs->ses_state].str);
 }
 
 static void _display_peer_brief_iter(struct hash_bucket *hb, void *arg)


### PR DESCRIPTION
Single-hop bfd configuration:
```
!
bfd
 peer 11.11.11.11
 exit
!
```

After single-hop bfd session is ok with `up` status,
change(remove, then add different/new *ip* with same
subnet) address on local interface, of course meanwhile
change remote machine's bfd peer ip to this new *ip*.

At this time this bfd session including rnd/rcv
packets and status is completely ok, but the command of
`show bfd peers brief` can't display correct local address,
which should be the new *ip*, but it wrongly displays
last used local address.

Currently single-hop `bs->local_address` is set by using
received packet's destination instead of using `getsockname()`
in `bfd_session_enable()`.

Since set `bfd->local_address.sa_sin.sin_family` to
`AF_UNSPEC` when removing ip address need tranverse many
failed session sockets to match this remove ip address,
just still update the local address when receiving good
packet of this single-hop bfd session.