### PR TITLE
pimd: make logs useful for input drops

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -55,18 +55,34 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 	struct pim_rpf *rpg;
 	pim_sgaddr sg;
 
-	rpg = pim_ifp ? RP(pim_ifp->pim, msg->msg_im_dst) : NULL;
+	memset(&sg, 0, sizeof(sg));
+	sg.src = msg->msg_im_src;
+	sg.grp = msg->msg_im_dst;
+
+	if (!pim_ifp) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug(
+				"%s: PIM not enabled on interface, dropping packet to %pSG",
+				ifp->name, &sg);
+		return 0;
+	}
+
+	rpg = RP(pim_ifp->pim, msg->msg_im_dst);
 	/*
 	 * If the incoming interface is unknown OR
 	 * the Interface type is SSM we don't need to
 	 * do anything here
 	 */
-	if (!rpg || pim_rpf_addr_is_inaddr_any(rpg)) {
-		if (PIM_DEBUG_MROUTE_DETAIL)
-			zlog_debug(
-				"%s: Interface is not configured correctly to handle incoming packet: Could be !pim_ifp, !SM, !RP",
-				__func__);
-
+	if (!rpg) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s: no RPF for packet to %pSG", ifp->name,
+				   &sg);
+		return 0;
+	}
+	if (pim_rpf_addr_is_inaddr_any(rpg)) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s: null RPF for packet to %pSG", ifp->name,
+				   &sg);
 		return 0;
 	}
 
@@ -75,22 +91,21 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 	 * us
 	 */
 	if (!pim_if_connected_to_source(ifp, msg->msg_im_src)) {
-		if (PIM_DEBUG_MROUTE_DETAIL)
+		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
-				"%s: Received incoming packet that doesn't originate on our seg",
-				__func__);
+				"%s: incoming packet to %pSG from non-connected source",
+				ifp->name, &sg);
 		return 0;
 	}
 
-	memset(&sg, 0, sizeof(sg));
-	sg.src = msg->msg_im_src;
-	sg.grp = msg->msg_im_dst;
-
 	if (!(PIM_I_am_DR(pim_ifp))) {
+		/* unlike the other debug messages, this one is further in the
+		 * "normal operation" category and thus under _DETAIL
+		 */
 		if (PIM_DEBUG_MROUTE_DETAIL)
 			zlog_debug(
-				"%s: Interface is not the DR blackholing incoming traffic for %pSG",
-				__func__, &sg);
+				"%s: not DR on interface, not forwarding traffic for %pSG",
+				ifp->name, &sg);
 
 		/*
 		 * We are not the DR, but we are still receiving packets


### PR DESCRIPTION
This path here is pretty far on top of the list of issues that operators will run into and have to debug when setting up PIM.  Make the log
messages actually tell what's going on.  Also escalate some from `debug mroute detail` to `debug mroute`.