### PR TITLE
pim6d: use ICMP6_FILTER instead of BPF on mroute

### DIFF
--- a/pimd/pim6_mroute_msg.c
+++ b/pimd/pim6_mroute_msg.c
@@ -45,17 +45,6 @@ int pim_mroute_set(struct pim_instance *pim, int enable)
 	int err;
 	int opt, data;
 	socklen_t data_len = sizeof(data);
-	static const struct sock_filter filter[] = {
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, 0),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0, 0, 1),
-		BPF_STMT(BPF_RET | BPF_K, 0xffff),
-		BPF_STMT(BPF_RET | BPF_K, 0),
-	};
-
-	static const struct sock_fprog bpf = {
-		.len = array_size(filter),
-		.filter = (struct sock_filter *)filter,
-	};
 
 	/*
 	 * We need to create the VRF table for the pim mroute_socket
@@ -133,10 +122,6 @@ int pim_mroute_set(struct pim_instance *pim, int enable)
 		zlog_warn(
 			"PIM-SM will not work properly on this platform, until the ability to receive the WHOLEPKT upcall");
 #endif
-		if (setsockopt(pim->mroute_socket, SOL_SOCKET, SO_ATTACH_FILTER, &bpf, sizeof(bpf))) {
-			zlog_warn("Failure to attach SO_ATTACH_FILTER on fd %d: %d %s",
-					pim->mroute_socket, errno, safe_strerror(errno));
-		}
 	}
 
 	return 0;


### PR DESCRIPTION
The ICMP6_FILTER option is always checked by the kernel, so the cost is taken whether or not anything is set there.  Use it instead of taking on additional cost with a BPF program.

---
Also adds a comment to explanation what's going on.