### PR TITLE
lib, zebra, pimd: clean up/fix VRF DECLVAR macros

### DIFF
--- a/lib/vty.h
+++ b/lib/vty.h
@@ -266,6 +266,15 @@ static inline void vty_push_context(struct vty *vty, int node, uint64_t id)
 	struct structname *ptr = VTY_GET_CONTEXT(structname);                  \
 	VTY_CHECK_CONTEXT(ptr);
 
+#define VTY_DECLVAR_CONTEXT_VRF(vrfptr)                                        \
+	struct vrf *vrfptr;                                                    \
+	if (vty->node == CONFIG_NODE)                                          \
+		vrfptr = vrf_lookup_by_id(VRF_DEFAULT);                        \
+	else                                                                   \
+		vrfptr = VTY_GET_CONTEXT(vrf);                                 \
+	VTY_CHECK_CONTEXT(vrfptr);                                             \
+	MACRO_REQUIRE_SEMICOLON() /* end */
+
 /* XPath macros. */
 #define VTY_PUSH_XPATH(nodeval, value)                                         \
 	do {                                                                   \

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -660,8 +660,11 @@ DEFPY (ipv6_mld_group_watermark,
        "Configure group limit for watermark warning\n"
        "Group count to generate watermark warning\n")
 {
-	PIM_DECLVAR_CONTEXT(vrf, pim);
+	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
+
 	/* TBD Depends on MLD data structure changes */
+	(void)pim;
+
 	return CMD_SUCCESS;
 }
 
@@ -674,8 +677,11 @@ DEFPY (no_ipv6_mld_group_watermark,
        "Unconfigure group limit for watermark warning\n"
        IGNORED_IN_NO_STR)
 {
-	PIM_DECLVAR_CONTEXT(vrf, pim);
+	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
+
 	/* TBD Depends on MLD data structure changes */
+	(void)pim;
+
 	return CMD_SUCCESS;
 }
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4848,7 +4848,7 @@ DEFPY (ip_igmp_group_watermark,
        "Configure group limit for watermark warning\n"
        "Group count to generate watermark warning\n")
 {
-	PIM_DECLVAR_CONTEXT(vrf, pim);
+	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
 	pim->igmp_watermark_limit = limit;
 
 	return CMD_SUCCESS;
@@ -4863,7 +4863,7 @@ DEFPY (no_ip_igmp_group_watermark,
        "Unconfigure group limit for watermark warning\n"
        IGNORED_IN_NO_STR)
 {
-	PIM_DECLVAR_CONTEXT(vrf, pim);
+	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
 	pim->igmp_watermark_limit = 0;
 
 	return CMD_SUCCESS;

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -112,9 +112,9 @@ void show_multicast_interfaces(struct pim_instance *pim, struct vty *vty,
 /*
  * Special Macro to allow us to get the correct pim_instance;
  */
-#define PIM_DECLVAR_CONTEXT(A, B)                                              \
-	struct vrf *A = VTY_GET_CONTEXT(vrf);                                  \
-	struct pim_instance *B =                                               \
-		(vrf) ? vrf->info : pim_get_pim_instance(VRF_DEFAULT);         \
-	vrf = (vrf) ? vrf : pim->vrf
+#define PIM_DECLVAR_CONTEXT_VRF(vrfptr, pimptr)                                \
+	VTY_DECLVAR_CONTEXT_VRF(vrfptr);                                       \
+	struct pim_instance *pimptr = vrfptr->info;                            \
+	MACRO_REQUIRE_SEMICOLON() /* end */
+
 #endif /* PIM_CMD_COMMON_H */

--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -342,7 +342,7 @@ DEFUN (ip_router_id_in_vrf,
        "Manually set the router-id\n"
        "IP address to use for router-id\n")
 {
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 	int idx = 0;
 	struct prefix rid;
 
@@ -372,7 +372,7 @@ DEFUN (ipv6_router_id_in_vrf,
        "Manually set the IPv6 router-id\n"
        "IPV6 address to use for router-id\n")
 {
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 	int idx = 0;
 	struct prefix rid;
 
@@ -458,7 +458,7 @@ DEFUN (no_ip_router_id_in_vrf,
        "Remove the manually configured router-id\n"
        "IP address to use for router-id\n")
 {
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	struct prefix rid;
 
@@ -486,7 +486,7 @@ DEFUN (no_ipv6_router_id_in_vrf,
        "Remove the manually configured IPv6 router-id\n"
        "IPv6 address to use for router-id\n")
 {
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	struct prefix rid;
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -638,7 +638,7 @@ DEFPY_YANG (ip_protocol,
 	assert(proto);
 	assert(rmap);
 
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -672,7 +672,7 @@ DEFPY_YANG (no_ip_protocol,
 
 	assert(proto);
 
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -719,7 +719,7 @@ DEFPY_YANG (ipv6_protocol,
 	assert(rmap);
 	assert(proto);
 
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -753,7 +753,7 @@ DEFPY_YANG (no_ipv6_protocol,
 
 	assert(proto);
 
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -801,7 +801,7 @@ DEFPY_YANG (ip_protocol_nht_rmap,
 	assert(proto);
 	assert(rmap);
 
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -835,7 +835,7 @@ DEFPY_YANG (no_ip_protocol_nht_rmap,
 
 	assert(proto);
 
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -883,7 +883,7 @@ DEFPY_YANG (ipv6_protocol_nht_rmap,
 	assert(rmap);
 	assert(proto);
 
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -917,7 +917,7 @@ DEFPY_YANG (no_ipv6_protocol_nht_rmap,
 
 	assert(proto);
 
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -192,14 +192,10 @@ struct zebra_vrf {
 /*
  * special macro to allow us to get the correct zebra_vrf
  */
-#define ZEBRA_DECLVAR_CONTEXT(A, B)                                            \
-	struct vrf *A;                                                         \
-	if (vty->node == CONFIG_NODE)                                          \
-		A = vrf_lookup_by_id(VRF_DEFAULT);                             \
-	else                                                                   \
-		A = VTY_GET_CONTEXT(vrf);                                      \
-	VTY_CHECK_CONTEXT(A);                                                  \
-	struct zebra_vrf *B = A->info
+#define ZEBRA_DECLVAR_CONTEXT_VRF(vrfptr, zvrfptr)                             \
+	VTY_DECLVAR_CONTEXT_VRF(vrfptr);                                       \
+	struct zebra_vrf *zvrfptr = vrfptr->info;                              \
+	MACRO_REQUIRE_SEMICOLON() /* end */
 
 static inline vrf_id_t zvrf_id(struct zebra_vrf *zvrf)
 {

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1413,7 +1413,7 @@ DEFUN (ip_nht_default_route,
        "Filter Next Hop tracking route resolution\n"
        "Resolve via default route\n")
 {
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -1752,7 +1752,7 @@ DEFUN (no_ip_nht_default_route,
        "Filter Next Hop tracking route resolution\n"
        "Resolve via default route\n")
 {
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -1772,7 +1772,7 @@ DEFUN (ipv6_nht_default_route,
        "Filter Next Hop tracking route resolution\n"
        "Resolve via default route\n")
 {
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -1793,7 +1793,7 @@ DEFUN (no_ipv6_nht_default_route,
        "Filter Next Hop tracking route resolution\n"
        "Resolve via default route\n")
 {
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
@@ -2950,7 +2950,7 @@ DEFUN (vrf_vni_mapping,
 {
 	int filter = 0;
 
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	assert(vrf);
 	assert(zvrf);
@@ -2979,7 +2979,7 @@ DEFUN (no_vrf_vni_mapping,
 {
 	int filter = 0;
 
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 	vni_t vni = strtoul(argv[2]->arg, NULL, 10);
 
 	assert(vrf);
@@ -4395,7 +4395,7 @@ DEFUN(ip_table_range, ip_table_range_cmd,
       "Start Routing Table\n"
       "End Routing Table\n")
 {
-	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	ZEBRA_DECLVAR_CONTEXT_VRF(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;


### PR DESCRIPTION
There's a common pattern of "get VRF context for CLI node" here, which first got a helper macro in zebra that then permeated into pimd.

Unfortunately the pimd copy wasn't quite adjusted correctly and thus caused two coverity warnings (CID 1517453, CID 1517454).

Fix the PIM one, and clean up by providing a common base macro in `lib/vty.h`.

Also rename the macros (add `_VRF`) to make more clear what they do.