### PR TITLE
tests: [PIMv6] Using generic names for PIM verification APIs

### DIFF
--- a/tests/topotests/lib/pim.py
+++ b/tests/topotests/lib/pim.py
@@ -960,7 +960,7 @@ def verify_join_state_and_timer(
 
 
 @retry(retry_timeout=120, diag_pct=0)
-def verify_ip_mroutes(
+def verify_mroutes(
     tgen,
     dut,
     src_address,
@@ -973,7 +973,7 @@ def verify_ip_mroutes(
 ):
     """
     Verify ip mroutes and make sure (*, G)/(S, G) is present in mroutes
-    by running "show ip pim upstream" cli
+    by running "show ip/ipv6 mroute" cli
 
     Parameters
     ----------
@@ -991,7 +991,7 @@ def verify_ip_mroutes(
     -----
     dut = "r1"
     group_address = "225.1.1.1"
-    result = verify_ip_mroutes(tgen, dut, src_address, group_address)
+    result = verify_mroutes(tgen, dut, src_address, group_address)
 
     Returns
     -------
@@ -1621,10 +1621,10 @@ def verify_pim_interface(
     return True
 
 
-def clear_ip_pim_interface_traffic(tgen, topo):
+def clear_pim_interface_traffic(tgen, topo):
     """
-    Clear ip pim interface traffice by running
-    "clear ip pim interface traffic" cli
+    Clear ip/ipv6 pim interface traffice by running
+    "clear ip/ipv6 pim interface traffic" cli
 
     Parameters
     ----------
@@ -1632,7 +1632,7 @@ def clear_ip_pim_interface_traffic(tgen, topo):
     Usage
     -----
 
-    result = clear_ip_pim_interface_traffic(tgen, topo)
+    result = clear_pim_interface_traffic(tgen, topo)
 
     Returns
     -------
@@ -1655,10 +1655,10 @@ def clear_ip_pim_interface_traffic(tgen, topo):
     return True
 
 
-def clear_ip_pim_interfaces(tgen, dut):
+def clear_pim_interfaces(tgen, dut):
     """
-    Clear ip pim interface by running
-    "clear ip pim interfaces" cli
+    Clear ip/ipv6 pim interface by running
+    "clear ip/ipv6 pim interfaces" cli
 
     Parameters
     ----------
@@ -1667,7 +1667,7 @@ def clear_ip_pim_interfaces(tgen, dut):
     Usage
     -----
 
-    result = clear_ip_pim_interfaces(tgen, dut)
+    result = clear_pim_interfaces(tgen, dut)
 
     Returns
     -------
@@ -1746,10 +1746,10 @@ def clear_ip_pim_interfaces(tgen, dut):
     return True
 
 
-def clear_ip_igmp_interfaces(tgen, dut):
+def clear_igmp_interfaces(tgen, dut):
     """
-    Clear ip igmp interfaces by running
-    "clear ip igmp interfaces" cli
+    Clear ip/ipv6 igmp interfaces by running
+    "clear ip/ipv6 igmp interfaces" cli
 
     Parameters
     ----------
@@ -1759,7 +1759,7 @@ def clear_ip_igmp_interfaces(tgen, dut):
     Usage
     -----
     dut = "r1"
-    result = clear_ip_igmp_interfaces(tgen, dut)
+    result = clear_igmp_interfaces(tgen, dut)
     Returns
     -------
     errormsg(str) or True
@@ -1826,9 +1826,9 @@ def clear_ip_igmp_interfaces(tgen, dut):
 
 
 @retry(retry_timeout=20)
-def clear_ip_mroute_verify(tgen, dut, expected=True):
+def clear_mroute_verify(tgen, dut, expected=True):
     """
-    Clear ip mroute by running "clear ip mroute" cli and verify
+    Clear ip/ipv6 mroute by running "clear ip/ipv6 mroute" cli and verify
     mroutes are up again after mroute clear
 
     Parameters
@@ -1840,7 +1840,7 @@ def clear_ip_mroute_verify(tgen, dut, expected=True):
     Usage
     -----
 
-    result = clear_ip_mroute_verify(tgen, dut)
+    result = clear_mroute_verify(tgen, dut)
 
     Returns
     -------
@@ -1926,9 +1926,9 @@ def clear_ip_mroute_verify(tgen, dut, expected=True):
     return True
 
 
-def clear_ip_mroute(tgen, dut=None):
+def clear_mroute(tgen, dut=None):
     """
-    Clear ip mroute by running "clear ip mroute" cli
+    Clear ip/ipv6 mroute by running "clear ip mroute" cli
 
     Parameters
     ----------
@@ -1937,7 +1937,7 @@ def clear_ip_mroute(tgen, dut=None):
 
     Usage
     -----
-    clear_ip_mroute(tgen, dut)
+    clear_mroute(tgen, dut)
     """
 
     logger.debug("Entering lib API: {}".format(sys._getframe().f_code.co_name))
@@ -2352,12 +2352,12 @@ def verify_pim_bsr(tgen, topo, dut, bsr_ip, expected=True):
 
 
 @retry(retry_timeout=60, diag_pct=0)
-def verify_ip_pim_upstream_rpf(
+def verify_pim_upstream_rpf(
     tgen, topo, dut, interface, group_addresses, rp=None, expected=True
 ):
     """
-    Verify IP PIM upstream rpf, config is verified
-    using "show ip pim neighbor" cli
+    Verify IP/IPv6 PIM upstream rpf, config is verified
+    using "show ip/ipv6 pim neighbor" cli
 
     Parameters
     ----------
@@ -2372,7 +2372,7 @@ def verify_ip_pim_upstream_rpf(
 
     Usage
     -----
-    result = verify_ip_pim_upstream_rpf(gen, topo, dut, interface,
+    result = verify_pim_upstream_rpf(gen, topo, dut, interface,
                                         group_addresses, rp=None)
 
     Returns
@@ -2552,11 +2552,11 @@ def enable_disable_pim_bsm(tgen, router, intf, enable=True):
 
 
 @retry(retry_timeout=60, diag_pct=0)
-def verify_ip_pim_join(
+def verify_pim_join(
     tgen, topo, dut, interface, group_addresses, src_address=None, expected=True
 ):
     """
-    Verify ip pim join by running "show ip pim join" cli
+    Verify ip/ipv6 pim join by running "show ip/ipv6 pim join" cli
 
     Parameters
     ----------
@@ -2573,7 +2573,7 @@ def verify_ip_pim_join(
     dut = "r1"
     interface = "r1-r0-eth0"
     group_address = "225.1.1.1"
-    result = verify_ip_pim_join(tgen, dut, star, group_address, interface)
+    result = verify_pim_join(tgen, dut, star, group_address, interface)
 
     Returns
     -------

--- a/tests/topotests/multicast_pim_bsm_topo1/test_mcast_pim_bsmp_01.py
+++ b/tests/topotests/multicast_pim_bsm_topo1/test_mcast_pim_bsmp_01.py
@@ -94,16 +94,16 @@ from lib.pim import (
     find_rp_from_bsrp_info,
     verify_pim_grp_rp_source,
     verify_pim_bsr,
-    verify_ip_mroutes,
+    verify_mroutes,
     verify_join_state_and_timer,
     verify_pim_state,
     verify_upstream_iif,
     verify_igmp_groups,
-    verify_ip_pim_upstream_rpf,
+    verify_pim_upstream_rpf,
     enable_disable_pim_unicast_bsm,
     enable_disable_pim_bsm,
-    clear_ip_mroute,
-    clear_ip_pim_interface_traffic,
+    clear_mroute,
+    clear_pim_interface_traffic,
     get_pim_interface_traffic,
     McastTesterHelper,
 )
@@ -373,9 +373,9 @@ def test_BSR_higher_prefer_ip_p0(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
     step("pre-configure BSM packet")
@@ -579,9 +579,9 @@ def test_BSR_CRP_with_blackhole_address_p1(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
     step("pre-configure BSM packet")
@@ -756,9 +756,9 @@ def test_new_router_fwd_p0(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
 
@@ -800,7 +800,7 @@ def test_new_router_fwd_p0(request):
     oil = "l1-r1-eth1"
 
     step("Verify mroute populated on l1")
-    result = verify_ip_mroutes(tgen, "l1", src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, "l1", src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     # Reload i1 and l1
@@ -854,7 +854,7 @@ def test_new_router_fwd_p0(request):
 
     # Verify ip mroute populated again
     step("Verify mroute again on l1 (lhr)")
-    result = verify_ip_mroutes(tgen, "l1", src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, "l1", src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("clear  BSM database before moving to next case")
@@ -897,9 +897,9 @@ def test_int_bsm_config_p1(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
 
@@ -937,7 +937,7 @@ def test_int_bsm_config_p1(request):
     src_addr = "*"
     oil = "i1-l1-eth1"
 
-    result = verify_ip_mroutes(tgen, "i1", src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, "i1", src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     # wait till bsm rp age out
@@ -946,7 +946,7 @@ def test_int_bsm_config_p1(request):
 
     # check if mroute uninstalled because of rp age out
     step("check if mroute uninstalled because of rp age out in i1")
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, "i1", src_addr, GROUP_ADDRESS, iif, oil, expected=False
     )
     assert (
@@ -981,7 +981,7 @@ def test_int_bsm_config_p1(request):
 
     # check if mroute still not installed because of rp not available
     step("check if mroute still not installed because of rp not available")
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, "i1", src_addr, GROUP_ADDRESS, iif, oil, expected=False
     )
     assert result is not True, (
@@ -1006,7 +1006,7 @@ def test_int_bsm_config_p1(request):
 
     # verify ip mroute populated
     step("Verify ip mroute")
-    result = verify_ip_mroutes(tgen, "i1", src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, "i1", src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     # Shut/No shut the bsm rpf interface and check mroute on lhr(l1)
@@ -1018,7 +1018,7 @@ def test_int_bsm_config_p1(request):
     iif = "l1-i1-eth0"
     oil = "l1-r1-eth1"
 
-    result = verify_ip_mroutes(tgen, "l1", src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, "l1", src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     step("clear  BSM database before moving to next case")
@@ -1058,9 +1058,9 @@ def test_static_rp_override_p1(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
 
@@ -1111,7 +1111,7 @@ def test_static_rp_override_p1(request):
     iif = "l1-i1-eth0"
     # Verify upstream rpf for 225.1.1.1 is chosen as rp1
     step("Verify upstream rpf for 225.1.1.1 is chosen as bsrp")
-    result = verify_ip_pim_upstream_rpf(tgen, topo, dut, iif, GROUP_ADDRESS, rp[group])
+    result = verify_pim_upstream_rpf(tgen, topo, dut, iif, GROUP_ADDRESS, rp[group])
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     # Configure a static rp for the group 225.1.1.1/32
@@ -1139,7 +1139,7 @@ def test_static_rp_override_p1(request):
 
     # Verify if upstream also reflects the static rp
     step("Verify upstream rpf for 225.1.1.1 is chosen as static in l1")
-    result = verify_ip_pim_upstream_rpf(tgen, topo, dut, iif, GROUP_ADDRESS, static_rp)
+    result = verify_pim_upstream_rpf(tgen, topo, dut, iif, GROUP_ADDRESS, static_rp)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     # delete static rp for the group 225.1.1.1/32
@@ -1167,7 +1167,7 @@ def test_static_rp_override_p1(request):
 
     # Verify upstream rpf for 225.1.1.1 is chosen as bsrp
     step("Verify upstream rpf for 225.1.1.1 is chosen as bsrp in l1")
-    result = verify_ip_pim_upstream_rpf(tgen, topo, dut, iif, GROUP_ADDRESS, rp[group])
+    result = verify_pim_upstream_rpf(tgen, topo, dut, iif, GROUP_ADDRESS, rp[group])
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     step("clear  BSM database before moving to next case")
@@ -1209,9 +1209,9 @@ def test_bsmp_stress_add_del_restart_p2(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
 
@@ -1339,7 +1339,7 @@ def test_bsmp_stress_add_del_restart_p2(request):
     iif = "l1-i1-eth0"
     src_addr = "*"
     oil = "l1-r1-eth1"
-    result = verify_ip_mroutes(tgen, "l1", src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, "l1", src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     write_test_footer(tc_name)
@@ -1377,9 +1377,9 @@ def test_BSM_timeout_p0(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     result = pre_config_to_bsm(
         tgen, topo, tc_name, "b1", "s1", "r1", "f1", "i1", "l1", "packet1"
@@ -1415,7 +1415,7 @@ def test_BSM_timeout_p0(request):
     iif = "l1-i1-eth0"
     src_addr = "*"
     oil = "l1-r1-eth1"
-    result = verify_ip_mroutes(tgen, dut, src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, dut, src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     # Verify join state and join timer
@@ -1485,7 +1485,7 @@ def test_BSM_timeout_p0(request):
 
     # Verify ip mroute is not installed
     step("Verify mroute not installed in l1")
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, dut, src_addr, GROUP_ADDRESS, iif, oil, expected=False
     )
     assert (
@@ -1534,9 +1534,9 @@ def test_iif_join_state_p0(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
 
@@ -1605,7 +1605,7 @@ def test_iif_join_state_p0(request):
     # Verify ip mroute
     src_addr = "*"
     step("Verify ip mroute in l1")
-    result = verify_ip_mroutes(tgen, dut, src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, dut, src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     # Make RP unreachanble in LHR
@@ -1642,7 +1642,7 @@ def test_iif_join_state_p0(request):
 
     # Verify mroute not installed
     step("Verify mroute not installed")
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, dut, src_addr, GROUP_ADDRESS, iif, oil, expected=False
     )
     assert (
@@ -1668,7 +1668,7 @@ def test_iif_join_state_p0(request):
 
     # Verify that (*,G) installed in mroute again
     iif = "l1-i1-eth0"
-    result = verify_ip_mroutes(tgen, dut, src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, dut, src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     step("clear  BSM database before moving to next case")

--- a/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
+++ b/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
@@ -77,14 +77,14 @@ from lib.pim import (
     find_rp_from_bsrp_info,
     verify_pim_grp_rp_source,
     verify_pim_bsr,
-    verify_ip_mroutes,
+    verify_mroutes,
     verify_join_state_and_timer,
     verify_pim_state,
     verify_upstream_iif,
     verify_igmp_groups,
-    verify_ip_pim_upstream_rpf,
-    clear_ip_mroute,
-    clear_ip_pim_interface_traffic,
+    verify_pim_upstream_rpf,
+    clear_mroute,
+    clear_pim_interface_traffic,
     McastTesterHelper,
 )
 from lib.topolog import logger
@@ -331,9 +331,9 @@ def test_starg_mroute_p0(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
 
@@ -402,7 +402,7 @@ def test_starg_mroute_p0(request):
     # Verify ip mroute
     step("Verify ip mroute in l1")
     src_addr = "*"
-    result = verify_ip_mroutes(tgen, dut, src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, dut, src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     # Remove the group rp mapping and send bsm
@@ -426,7 +426,7 @@ def test_starg_mroute_p0(request):
 
     # Verify mroute not installed
     step("Verify mroute not installed in l1")
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, dut, src_addr, GROUP_ADDRESS, iif, oil, retry_timeout=20, expected=False
     )
     assert (
@@ -442,7 +442,7 @@ def test_starg_mroute_p0(request):
 
     # Verify that (*,G) installed in mroute again
     iif = "l1-i1-eth0"
-    result = verify_ip_mroutes(tgen, dut, src_addr, GROUP_ADDRESS, iif, oil)
+    result = verify_mroutes(tgen, dut, src_addr, GROUP_ADDRESS, iif, oil)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     step("clear  BSM database before moving to next case")
@@ -483,9 +483,9 @@ def test_overlapping_group_p0(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
 
@@ -533,7 +533,7 @@ def test_overlapping_group_p0(request):
     iif = "l1-i1-eth0"
     # Verify upstream rpf for 225.1.1.1 is chosen as rp1
     step("Verify upstream rpf for 225.1.1.1 is chosen as rp1 in l1")
-    result = verify_ip_pim_upstream_rpf(tgen, topo, dut, iif, GROUP_ADDRESS, rp1)
+    result = verify_pim_upstream_rpf(tgen, topo, dut, iif, GROUP_ADDRESS, rp1)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     # Send BSR packet from b1 with rp for 225.1.1.1/32 removed
@@ -543,7 +543,7 @@ def test_overlapping_group_p0(request):
 
     # Verify upstream rpf for 225.1.1.1 is chosen as rp1
     step("Verify upstream rpf for 225.1.1.1 is chosen as rp2 in l1")
-    result = verify_ip_pim_upstream_rpf(tgen, topo, dut, iif, GROUP_ADDRESS, rp2)
+    result = verify_pim_upstream_rpf(tgen, topo, dut, iif, GROUP_ADDRESS, rp2)
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     # Verify IIF/OIL in pim state
@@ -589,9 +589,9 @@ def test_RP_priority_p0(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
 
@@ -716,9 +716,9 @@ def test_BSR_election_p0(request):
     write_test_header(tc_name)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():
@@ -836,9 +836,9 @@ def test_RP_hash_p0(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
 
@@ -929,9 +929,9 @@ def test_BSM_fragmentation_p1(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     reset_config_on_routers(tgen)
 
@@ -1047,9 +1047,9 @@ def test_RP_with_all_ip_octet_p1(request):
         pytest.skip(tgen.errors)
 
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("pre-configure BSM packet")
     result = pre_config_to_bsm(

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
@@ -69,15 +69,15 @@ from lib.common_config import (
 from lib.pim import (
     create_pim_config,
     create_igmp_config,
-    verify_ip_mroutes,
-    clear_ip_mroute,
-    clear_ip_pim_interface_traffic,
+    verify_mroutes,
+    clear_mroute,
+    clear_pim_interface_traffic,
     verify_pim_config,
     verify_upstream_iif,
     verify_multicast_traffic,
     verify_multicast_flag_state,
     verify_igmp_groups,
-    McastTesterHelper
+    McastTesterHelper,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -646,10 +646,10 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     check_router_status(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():
@@ -878,7 +878,7 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
     ]
 
     for data in input_dict_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -932,7 +932,7 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
     )
 
     for data in input_dict_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -942,7 +942,7 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
         )
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -951,9 +951,10 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
             data["oil"],
             expected=False,
         )
-        assert result is not True, (
-            "Testcase {} : Failed \n "
-            "mroutes are still present \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed \n " "mroutes are still present \n Error: {}".format(
+            tc_name, result
         )
 
     step("Configure local join on R2 for group range (227.1.1.1)")
@@ -1044,7 +1045,7 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
     ]
 
     for data in input_dict_r1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1053,9 +1054,10 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
             data["oil"],
             expected=False,
         )
-        assert result is not True, (
-            "Testcase {} : Failed \n "
-            "Mroutes are still present \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed \n " "mroutes are still present \n Error: {}".format(
+            tc_name, result
         )
 
     step("Remove local join from DR and Non DR node")
@@ -1098,7 +1100,7 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
     )
 
     for data in input_dict_r1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1107,13 +1109,14 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
             data["oil"],
             expected=False,
         )
-        assert result is not True, (
-            "Testcase {} : Failed \n "
-            "Mroutes are still present \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed \n " "mroutes are still present \n Error: {}".format(
+            tc_name, result
         )
 
     for data in input_dict_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1122,9 +1125,10 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
             data["oil"],
             expected=False,
         )
-        assert result is not True, (
-            "Testcase {} : Failed \n "
-            "Mroutes are still present \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed \n " "mroutes are still present \n Error: {}".format(
+            tc_name, result
         )
 
     write_test_footer(tc_name)

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_static_routes_topo1.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_static_routes_topo1.py
@@ -67,9 +67,9 @@ from lib.common_config import (
 from lib.pim import (
     create_pim_config,
     create_igmp_config,
-    verify_ip_mroutes,
-    clear_ip_mroute,
-    clear_ip_pim_interface_traffic,
+    verify_mroutes,
+    clear_mroute,
+    clear_pim_interface_traffic,
     verify_pim_config,
     verify_upstream_iif,
     verify_multicast_flag_state,
@@ -217,6 +217,7 @@ def teardown_module():
         "Testsuite end time: {}".format(time.asctime(time.localtime(time.time())))
     )
     logger.info("=" * 40)
+
 
 #####################################################
 #
@@ -693,10 +694,10 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     check_router_status(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():
@@ -752,7 +753,7 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
     ]
 
     for data in input_dict_r1_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -799,7 +800,7 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
     step("R1 has mroute with none OIL and upstream with Not Join")
 
     for data in input_dict_r1_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -849,7 +850,7 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
 
     for data in input_dict_r1_r2:
         if data["dut"] == "r1":
-            result = verify_ip_mroutes(
+            result = verify_mroutes(
                 tgen,
                 data["dut"],
                 data["src_address"],
@@ -883,7 +884,7 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
     )
 
     for data in input_dict_r1_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -892,9 +893,10 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
             data["oil"],
             expected=False,
         )
-        assert result is not True, (
-            "Testcase {} : Failed \n "
-            "mroutes are still present \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed \n " "mroutes are still present \n Error: {}".format(
+            tc_name, result
         )
 
     step("start FRR for all the nodes")
@@ -908,7 +910,7 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_r1_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_transit_router_topo3.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_transit_router_topo3.py
@@ -65,9 +65,9 @@ from lib.common_config import (
 from lib.pim import (
     create_pim_config,
     create_igmp_config,
-    verify_ip_mroutes,
-    clear_ip_mroute,
-    clear_ip_pim_interface_traffic,
+    verify_mroutes,
+    clear_mroute,
+    clear_pim_interface_traffic,
     verify_pim_config,
     verify_upstream_iif,
     verify_multicast_traffic,
@@ -665,10 +665,10 @@ def test_mroute_when_transit_router_present_between_rp_and_source_dr_p1(request)
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     check_router_status(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():
@@ -707,7 +707,7 @@ def test_mroute_when_transit_router_present_between_rp_and_source_dr_p1(request)
     ]
 
     for data in input_dict_r1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -743,7 +743,7 @@ def test_mroute_when_transit_router_present_between_rp_and_source_dr_p1(request)
     ]
 
     for data in input_dict_r5:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -808,7 +808,7 @@ def test_mroute_when_transit_router_present_between_rp_and_source_dr_p1(request)
     )
 
     for data in input_dict_r5:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],

--- a/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
+++ b/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
@@ -83,12 +83,12 @@ from lib.pim import (
     create_pim_config,
     create_igmp_config,
     verify_igmp_groups,
-    verify_ip_mroutes,
+    verify_mroutes,
     get_pim_interface_traffic,
     verify_upstream_iif,
-    verify_ip_pim_join,
-    clear_ip_mroute,
-    clear_ip_pim_interface_traffic,
+    verify_pim_join,
+    clear_mroute,
+    clear_pim_interface_traffic,
     verify_igmp_config,
     McastTesterHelper,
 )
@@ -337,7 +337,7 @@ def test_multicast_data_traffic_static_RP_send_join_then_traffic_p0(request):
     ]
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen, data["dut"], data["src_address"], IGMP_JOIN, data["iif"], data["oil"]
         )
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
@@ -369,7 +369,7 @@ def test_multicast_data_traffic_static_RP_send_join_then_traffic_p0(request):
     step("l1 sent PIM (S,G) join to f1 , verify using 'show ip pim join'")
     dut = "f1"
     interface = intf_f1_r2
-    result = verify_ip_pim_join(tgen, topo, dut, interface, IGMP_JOIN)
+    result = verify_pim_join(tgen, topo, dut, interface, IGMP_JOIN)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     write_test_footer(tc_name)
@@ -392,9 +392,9 @@ def test_multicast_data_traffic_static_RP_send_traffic_then_join_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure RP on R2 (loopback interface) for the" " group range 225.0.0.0/8")
 
@@ -453,7 +453,7 @@ def test_multicast_data_traffic_static_RP_send_traffic_then_join_p0(request):
     # previous 80 retries with 2s wait if we assume .5s per vtysh/show ip mroute runtime
     # (41 * (2 + .5)) == 102.
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -491,7 +491,7 @@ def test_multicast_data_traffic_static_RP_send_traffic_then_join_p0(request):
     step("l1 sent PIM (S,G) join to f1 , verify using 'show ip pim join'")
     dut = "f1"
     interface = "f1-r2-eth3"
-    result = verify_ip_pim_join(tgen, topo, dut, interface, IGMP_JOIN)
+    result = verify_pim_join(tgen, topo, dut, interface, IGMP_JOIN)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     write_test_footer(tc_name)
@@ -514,9 +514,9 @@ def test_clear_pim_neighbors_and_mroute_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP on c1 for group (225.1.1.1-5)")
     input_dict = {
@@ -558,13 +558,13 @@ def test_clear_pim_neighbors_and_mroute_p0(request):
     ]
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen, data["dut"], data["src_address"], IGMP_JOIN, data["iif"], data["oil"]
         )
         assert result is True, "Testcase{} : Failed Error: {}".format(tc_name, result)
 
     step("Clear mroutes on l1")
-    clear_ip_mroute(tgen, "l1")
+    clear_mroute(tgen, "l1")
 
     step(
         "After clear ip mroute (*,g) entries are re-populated again"
@@ -573,7 +573,7 @@ def test_clear_pim_neighbors_and_mroute_p0(request):
     )
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen, data["dut"], data["src_address"], IGMP_JOIN, data["iif"], data["oil"]
         )
         assert result is True, "Testcase{} : Failed Error: {}".format(tc_name, result)
@@ -607,9 +607,9 @@ def test_verify_mroute_when_same_receiver_in_FHR_LHR_and_RP_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure RP on R2 (loopback interface) for the" " group range 225.0.0.0/8")
 
@@ -684,7 +684,7 @@ def test_verify_mroute_when_same_receiver_in_FHR_LHR_and_RP_p0(request):
         {"dut": "f1", "src_address": source, "iif": "f1-i2-eth1", "oil": "f1-i8-eth2"},
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen, data["dut"], data["src_address"], IGMP_JOIN, data["iif"], data["oil"]
         )
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
@@ -709,9 +709,9 @@ def test_verify_mroute_when_same_receiver_joining_5_diff_sources_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP for (226.1.1.1-5) and (232.1.1.1-5)" " in c1")
 
@@ -837,7 +837,7 @@ def test_verify_mroute_when_same_receiver_joining_5_diff_sources_p0(request):
         },
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -874,7 +874,7 @@ def test_verify_mroute_when_same_receiver_joining_5_diff_sources_p0(request):
         },
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -923,7 +923,7 @@ def test_verify_mroute_when_same_receiver_joining_5_diff_sources_p0(request):
         },
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -996,7 +996,7 @@ def test_verify_mroute_when_same_receiver_joining_5_diff_sources_p0(request):
         },
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1026,9 +1026,9 @@ def test_verify_mroute_when_frr_is_transit_router_p2(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP for (226.1.1.1-5) in c2")
     input_dict = {
@@ -1074,7 +1074,7 @@ def test_verify_mroute_when_frr_is_transit_router_p2(request):
         {"dut": "c2", "src_address": source, "iif": "c2-f1-eth1", "oil": "c2-c1-eth0"},
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen, data["dut"], data["src_address"], IGMP_JOIN, data["iif"], data["oil"]
         )
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
@@ -1100,7 +1100,7 @@ def test_verify_mroute_when_frr_is_transit_router_p2(request):
         " router 'show ip mroute'"
     )
 
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, "c1", "*", IGMP_JOIN, "c1-c2-eth1", "c1-l1-eth0", expected=False
     )
     assert (
@@ -1129,9 +1129,9 @@ def test_verify_mroute_when_RP_unreachable_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure RP on FRR2 (loopback interface) for " "the group range 225.0.0.0/8")
 
@@ -1187,7 +1187,7 @@ def test_verify_mroute_when_RP_unreachable_p1(request):
         {"dut": "f1", "src_address": source, "iif": "f1-i2-eth1", "oil": "f1-i8-eth2"},
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen, data["dut"], data["src_address"], IGMP_JOIN, data["iif"], data["oil"]
         )
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
@@ -1201,7 +1201,7 @@ def test_verify_mroute_when_RP_unreachable_p1(request):
     sleep(20)
 
     step("Clear the mroute on f1")
-    clear_ip_mroute(tgen, "f1")
+    clear_mroute(tgen, "f1")
 
     step(
         "After Shut the RP interface and clear the mroute verify all "
@@ -1209,7 +1209,7 @@ def test_verify_mroute_when_RP_unreachable_p1(request):
         " 'show ip mroute' "
     )
 
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, "f1", "*", IGMP_JOIN, "f1-r2-eth3", "f1-i8-eth2", expected=False
     )
     assert (
@@ -1246,9 +1246,9 @@ def test_modify_igmp_query_timer_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Enable IGMP on FRR1 interface and send IGMP join (225.1.1.1)")
     result = app_helper.run_join("i1", IGMP_JOIN, "l1")
@@ -1290,7 +1290,7 @@ def test_modify_igmp_query_timer_p0(request):
         {"dut": "f1", "src_address": source, "iif": "f1-i2-eth1", "oil": "f1-r2-eth3"},
     ]
     for data in input_dict_4:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen, data["dut"], data["src_address"], IGMP_JOIN, data["iif"], data["oil"]
         )
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
@@ -1375,9 +1375,9 @@ def test_modify_igmp_max_query_response_timer_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Enable IGMP on FRR1 interface and send IGMP join (225.1.1.1)")
     result = app_helper.run_join("i1", IGMP_JOIN, "l1")
@@ -1440,7 +1440,7 @@ def test_modify_igmp_max_query_response_timer_p0(request):
         {"dut": "f1", "src_address": source, "iif": "f1-i2-eth1", "oil": "f1-r2-eth3"},
     ]
     for data in input_dict_5:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen, data["dut"], data["src_address"], IGMP_JOIN, data["iif"], data["oil"]
         )
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)

--- a/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
+++ b/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
@@ -81,13 +81,13 @@ from lib.pim import (
     create_pim_config,
     create_igmp_config,
     verify_igmp_groups,
-    verify_ip_mroutes,
+    verify_mroutes,
     get_pim_interface_traffic,
     verify_upstream_iif,
     verify_pim_neighbors,
     verify_pim_state,
-    clear_ip_mroute,
-    clear_ip_pim_interface_traffic,
+    clear_mroute,
+    clear_pim_interface_traffic,
     McastTesterHelper,
 )
 from lib.topolog import logger
@@ -273,9 +273,9 @@ def test_verify_mroute_and_traffic_when_pimd_restarted_p2(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP for (226.1.1.1-5) in c1")
     step("Configure static RP for (232.1.1.1-5) in c2")
@@ -365,7 +365,7 @@ def test_verify_mroute_and_traffic_when_pimd_restarted_p2(request):
         {"dut": "f1", "src_address": source, "iif": "f1-i2-eth1", "oil": "f1-i8-eth2"},
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -386,7 +386,7 @@ def test_verify_mroute_and_traffic_when_pimd_restarted_p2(request):
     start_router_daemons(tgen, "f1", ["pimd"])
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -434,7 +434,7 @@ def test_verify_mroute_and_traffic_when_pimd_restarted_p2(request):
         {"dut": "f1", "src_address": "*", "iif": "f1-c2-eth0", "oil": "f1-i8-eth2"}
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -448,7 +448,7 @@ def test_verify_mroute_and_traffic_when_pimd_restarted_p2(request):
         {"dut": "f1", "src_address": source, "iif": "f1-i2-eth1", "oil": "none"}
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -483,9 +483,9 @@ def test_verify_mroute_and_traffic_when_frr_restarted_p2(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP for (226.1.1.1-5) in c1")
     step("Configure static RP for (232.1.1.1-5) in c2")
@@ -575,7 +575,7 @@ def test_verify_mroute_and_traffic_when_frr_restarted_p2(request):
         {"dut": "f1", "src_address": source, "iif": "f1-i2-eth1", "oil": "f1-i8-eth2"},
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -596,7 +596,7 @@ def test_verify_mroute_and_traffic_when_frr_restarted_p2(request):
     start_router(tgen, "f1")
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -643,7 +643,7 @@ def test_verify_mroute_and_traffic_when_frr_restarted_p2(request):
         {"dut": "f1", "src_address": "*", "iif": "f1-c2-eth0", "oil": "f1-i8-eth2"}
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -657,7 +657,7 @@ def test_verify_mroute_and_traffic_when_frr_restarted_p2(request):
         {"dut": "f1", "src_address": source, "iif": "f1-i2-eth1", "oil": "none"}
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -692,9 +692,9 @@ def test_verify_SPT_switchover_when_RPT_and_SPT_path_is_different_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP for (226.1.1.1-5) and " "(232.1.1.1-5) in c2")
 
@@ -746,7 +746,7 @@ def test_verify_SPT_switchover_when_RPT_and_SPT_path_is_different_p0(request):
         " 'show ip mroute' and mroute OIL is towards RP."
     )
 
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen,
         "f1",
         "10.0.5.2",
@@ -756,7 +756,7 @@ def test_verify_SPT_switchover_when_RPT_and_SPT_path_is_different_p0(request):
     )
     assert result is True, "Testcase {} : " "Failed Error: {}".format(tc_name, result)
 
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, "f1", "10.0.5.2", _IGMP_JOIN_RANGE, "f1-i2-eth1", "f1-r2-eth3"
     )
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
@@ -773,7 +773,7 @@ def test_verify_SPT_switchover_when_RPT_and_SPT_path_is_different_p0(request):
         {"dut": "l1", "src_address": source, "iif": "l1-r2-eth4", "oil": "l1-i1-eth1"},
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -804,7 +804,7 @@ def test_verify_SPT_switchover_when_RPT_and_SPT_path_is_different_p0(request):
         {"dut": "c2", "src_address": source, "iif": "c2-f1-eth1", "oil": "none"}
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -844,9 +844,9 @@ def test_verify_mroute_after_shut_noshut_of_upstream_interface_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP for (226.1.1.1-5) in c1")
     step("Configure static RP for (232.1.1.1-5) in c2")
@@ -939,7 +939,7 @@ def test_verify_mroute_after_shut_noshut_of_upstream_interface_p1(request):
         {"dut": "f1", "src_address": source, "iif": "f1-i2-eth1", "oil": "f1-i8-eth2"},
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -968,7 +968,7 @@ def test_verify_mroute_after_shut_noshut_of_upstream_interface_p1(request):
     shutdown_bringup_interface(tgen, dut, intf, True)
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -991,7 +991,7 @@ def test_verify_mroute_after_shut_noshut_of_upstream_interface_p1(request):
     )
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1021,8 +1021,8 @@ def test_verify_mroute_after_shut_noshut_of_upstream_interface_p1(request):
     intf = "f1-r2-eth3"
     shutdown_bringup_interface(tgen, dut, intf, True)
 
-    clear_ip_mroute(tgen, "l1")
-    clear_ip_mroute(tgen, "l1")
+    clear_mroute(tgen, "l1")
+    clear_mroute(tgen, "l1")
 
     step(
         "After no shut, verify traffic resume to all the receivers"
@@ -1030,7 +1030,7 @@ def test_verify_mroute_after_shut_noshut_of_upstream_interface_p1(request):
     )
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1065,7 +1065,7 @@ def test_verify_mroute_after_shut_noshut_of_upstream_interface_p1(request):
     shutdown_bringup_interface(tgen, dut, intf_l1_c1, True)
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1079,7 +1079,7 @@ def test_verify_mroute_after_shut_noshut_of_upstream_interface_p1(request):
     app_helper.stop_all_hosts()
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1114,9 +1114,9 @@ def test_verify_mroute_when_receiver_is_outside_frr_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP on c1 for group range " "(226.1.1.1-5) and (232.1.1.1-5)")
 
@@ -1194,7 +1194,7 @@ def test_verify_mroute_when_receiver_is_outside_frr_p0(request):
         {"dut": "c2", "src_address": source, "iif": "c2-f1-eth1", "oil": "c2-i5-eth2"},
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1247,9 +1247,9 @@ def test_verify_mroute_when_FRR_is_FHR_and_LHR_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP for group range (226.1.1.1-5) and " "(232.1.1.1-5) on c1")
     _GROUP_RANGE = GROUP_RANGE_2 + GROUP_RANGE_3
@@ -1344,7 +1344,7 @@ def test_verify_mroute_when_FRR_is_FHR_and_LHR_p0(request):
         {"dut": "l1", "src_address": source, "iif": "l1-r2-eth4", "oil": "l1-i1-eth1"},
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1381,7 +1381,7 @@ def test_verify_mroute_when_FRR_is_FHR_and_LHR_p0(request):
         {"dut": "l1", "src_address": "*", "iif": "l1-c1-eth0", "oil": "l1-i1-eth1"},
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1404,7 +1404,7 @@ def test_verify_mroute_when_FRR_is_FHR_and_LHR_p0(request):
     ]
 
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1436,9 +1436,9 @@ def test_verify_mroute_when_5_different_receiver_joining_same_sources_p0(request
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP for (226.1.1.1-5) in c1")
     step("Configure static RP for (232.1.1.1-5) in c2")
@@ -1573,7 +1573,7 @@ def test_verify_mroute_when_5_different_receiver_joining_same_sources_p0(request
         {"dut": "f1", "src_address": source, "iif": "f1-r2-eth3", "oil": "f1-i8-eth2"},
     ]
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1601,7 +1601,7 @@ def test_verify_mroute_when_5_different_receiver_joining_same_sources_p0(request
         {"dut": "l1", "src_address": source, "iif": "l1-r2-eth4", "oil": "l1-i1-eth1"}
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1625,7 +1625,7 @@ def test_verify_mroute_when_5_different_receiver_joining_same_sources_p0(request
         {"dut": "f1", "src_address": source, "iif": "f1-r2-eth3", "oil": "f1-i8-eth2"}
     ]
     for data in input_dict:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1645,7 +1645,7 @@ def test_verify_mroute_when_5_different_receiver_joining_same_sources_p0(request
     )
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1674,9 +1674,9 @@ def test_verify_oil_iif_for_mroute_after_shut_noshut_source_interface_p1(request
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step("Configure static RP for (226.1.1.1-5) in c1")
     step("Configure static RP for (232.1.1.1-5) in c2")
@@ -1789,7 +1789,7 @@ def test_verify_oil_iif_for_mroute_after_shut_noshut_source_interface_p1(request
         },
     ]
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1814,7 +1814,7 @@ def test_verify_oil_iif_for_mroute_after_shut_noshut_source_interface_p1(request
         " 'show ip mroute' "
     )
 
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen,
         "f1",
         source_i2,

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
@@ -84,9 +84,9 @@ from lib.pim import (
     create_pim_config,
     create_igmp_config,
     verify_igmp_groups,
-    verify_ip_mroutes,
-    clear_ip_mroute,
-    clear_ip_pim_interface_traffic,
+    verify_mroutes,
+    clear_mroute,
+    clear_pim_interface_traffic,
     verify_igmp_config,
     verify_pim_config,
     verify_pim_interface,
@@ -371,9 +371,9 @@ def test_verify_oil_when_join_prune_sent_scenario_1_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step("Enable the PIM on all the interfaces of FRR1, FRR2, FRR3")
@@ -483,7 +483,7 @@ def test_verify_oil_when_join_prune_sent_scenario_1_p1(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -562,7 +562,7 @@ def test_verify_oil_when_join_prune_sent_scenario_1_p1(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_l1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -611,7 +611,7 @@ def test_verify_oil_when_join_prune_sent_scenario_1_p1(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_f1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -685,7 +685,7 @@ def test_verify_oil_when_join_prune_sent_scenario_1_p1(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_l1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -744,9 +744,9 @@ def test_verify_oil_when_join_prune_sent_scenario_2_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step("Removing FRR3 to simulate topo " "FHR(FRR1)---LHR(FRR2)")
@@ -835,7 +835,7 @@ def test_verify_oil_when_join_prune_sent_scenario_2_p1(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -873,7 +873,7 @@ def test_verify_oil_when_join_prune_sent_scenario_2_p1(request):
     ]
 
     for data in input_dict_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -907,7 +907,7 @@ def test_verify_oil_when_join_prune_sent_scenario_2_p1(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_l1_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -937,7 +937,7 @@ def test_verify_oil_when_join_prune_sent_scenario_2_p1(request):
     ]
 
     for data in input_dict_l1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -989,9 +989,9 @@ def test_shut_noshut_source_interface_when_upstream_cleared_from_LHR_p1(request)
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step("Enable the PIM on all the interfaces of FRR1, R2 and FRR3" " routers")
@@ -1076,7 +1076,7 @@ def test_shut_noshut_source_interface_when_upstream_cleared_from_LHR_p1(request)
     )
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1102,7 +1102,7 @@ def test_shut_noshut_source_interface_when_upstream_cleared_from_LHR_p1(request)
     )
 
     intf_f1_r2 = topo["routers"]["f1"]["links"]["r2"]["interface"]
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, "f1", source_i2, IGMP_JOIN_RANGE_1, intf_f1_i2, intf_f1_r2, expected=False
     )
     assert (
@@ -1135,7 +1135,7 @@ def test_shut_noshut_source_interface_when_upstream_cleared_from_LHR_p1(request)
     )
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1161,7 +1161,7 @@ def test_shut_noshut_source_interface_when_upstream_cleared_from_LHR_p1(request)
     )
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1196,9 +1196,9 @@ def test_shut_noshut_receiver_interface_when_upstream_cleared_from_LHR_p1(reques
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step("Enable the PIM on all the interfaces of FRR1, R2 and FRR3" " routers")
@@ -1278,7 +1278,7 @@ def test_shut_noshut_receiver_interface_when_upstream_cleared_from_LHR_p1(reques
     ]
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1328,7 +1328,7 @@ def test_shut_noshut_receiver_interface_when_upstream_cleared_from_LHR_p1(reques
     )
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1355,7 +1355,7 @@ def test_shut_noshut_receiver_interface_when_upstream_cleared_from_LHR_p1(reques
     )
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1388,9 +1388,9 @@ def test_verify_remove_add_igmp_config_to_receiver_interface_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step("Enable PIM on all routers")
@@ -1474,7 +1474,7 @@ def test_verify_remove_add_igmp_config_to_receiver_interface_p0(request):
     ]
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1566,7 +1566,7 @@ def test_verify_remove_add_igmp_config_to_receiver_interface_p0(request):
     )
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1684,7 +1684,7 @@ def test_verify_remove_add_igmp_config_to_receiver_interface_p0(request):
     ]
 
     for data in input_dict_l1_f1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -1736,7 +1736,7 @@ def test_verify_remove_add_igmp_config_to_receiver_interface_p0(request):
     iif = topo["routers"]["l1"]["links"]["i6"]["interface"]
     oil = topo["routers"]["l1"]["links"]["i1"]["interface"]
     source = source_i6
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, dut, source, IGMP_JOIN_RANGE_1, iif, oil, expected=False
     )
     assert (
@@ -1765,9 +1765,9 @@ def test_verify_remove_add_igmp_commands_when_pim_configured_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step("Enable PIM on all routers")
@@ -1851,7 +1851,7 @@ def test_verify_remove_add_igmp_commands_when_pim_configured_p0(request):
     ]
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -2063,9 +2063,9 @@ def test_verify_remove_add_pim_commands_when_igmp_configured_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step("Configure 'ip pim' on receiver interface on FRR1")
@@ -2253,9 +2253,9 @@ def test_pim_dr_priority_p0(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step("Configure 'ip pim' on receiver interface on FRR1")
@@ -2323,7 +2323,7 @@ def test_pim_dr_priority_p0(request):
     ]
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -2360,7 +2360,7 @@ def test_pim_dr_priority_p0(request):
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -2397,7 +2397,7 @@ def test_pim_dr_priority_p0(request):
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -2492,7 +2492,7 @@ def test_pim_dr_priority_p0(request):
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -2526,9 +2526,9 @@ def test_pim_hello_timer_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step("Configure 'ip pim' on receiver interface on FRR1")
@@ -2641,9 +2641,9 @@ def test_mroute_after_removing_RP_sending_IGMP_prune_p2(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step(
@@ -2740,7 +2740,7 @@ def test_mroute_after_removing_RP_sending_IGMP_prune_p2(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -2802,7 +2802,7 @@ def test_mroute_after_removing_RP_sending_IGMP_prune_p2(request):
     ]
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -2819,7 +2819,7 @@ def test_mroute_after_removing_RP_sending_IGMP_prune_p2(request):
         logger.info("Expected Behaviour: {}".format(result))
 
     for data in input_dict_sg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -2896,7 +2896,7 @@ def test_mroute_after_removing_RP_sending_IGMP_prune_p2(request):
         assert result is True, "Testcase {}: Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -2915,7 +2915,7 @@ def test_mroute_after_removing_RP_sending_IGMP_prune_p2(request):
     source_i2 = topo["routers"]["i6"]["links"]["l1"]["ipv4"].split("/")[0]
 
     for data in input_dict_sg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -2943,9 +2943,9 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step(
@@ -3052,7 +3052,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3133,7 +3133,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
     step("Verify mroute after Shut the link from LHR to RP from RP node")
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3150,7 +3150,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
         logger.info("Expected Behaviour: {}".format(result))
 
     for data in input_dict_sg_i1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3206,7 +3206,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
     step("Verify mroute  after No shut the link from LHR to RP from RP node")
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3217,7 +3217,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_sg_i2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3228,7 +3228,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_sg_i1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3282,7 +3282,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
     step("Verify mroute after Shut the link from FHR to RP from RP node")
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3293,7 +3293,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_sg_i1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3355,7 +3355,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
     step("Verify mroute after Noshut the link from FHR to RP from RP node")
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3366,7 +3366,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_sg_i2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3377,7 +3377,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_sg_i1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3432,7 +3432,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
     step("Verify mroute after Shut the link from FHR to RP from FHR node")
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3443,7 +3443,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_sg_i1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3503,7 +3503,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
     step("Verify mroute after No Shut the link from FHR to RP from FHR node")
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3514,7 +3514,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_sg_i2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3525,7 +3525,7 @@ def test_prune_sent_to_LHR_and_FHR_when_PIMnbr_down_p2(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_sg_i1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3579,9 +3579,9 @@ def test_mroute_flags_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step(
@@ -3688,7 +3688,7 @@ def test_mroute_flags_p1(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3740,9 +3740,9 @@ def test_verify_multicast_traffic_when_LHR_connected_to_RP_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step(
@@ -3859,7 +3859,7 @@ def test_verify_multicast_traffic_when_LHR_connected_to_RP_p1(request):
     ]
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3918,7 +3918,7 @@ def test_verify_multicast_traffic_when_LHR_connected_to_RP_p1(request):
     ]
 
     for data in input_dict_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3944,7 +3944,7 @@ def test_verify_multicast_traffic_when_LHR_connected_to_RP_p1(request):
     )
 
     for data in input_dict_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -3988,7 +3988,7 @@ def test_verify_multicast_traffic_when_LHR_connected_to_RP_p1(request):
     ]
 
     for data in input_dict_l1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -4013,7 +4013,7 @@ def test_verify_multicast_traffic_when_LHR_connected_to_RP_p1(request):
     )
 
     for data in input_dict_l1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -4063,7 +4063,7 @@ def test_verify_multicast_traffic_when_LHR_connected_to_RP_p1(request):
     ]
 
     for data in input_dict_r2_f1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -4088,7 +4088,7 @@ def test_verify_multicast_traffic_when_LHR_connected_to_RP_p1(request):
     )
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -4130,14 +4130,14 @@ def test_verify_multicast_traffic_when_LHR_connected_to_RP_p1(request):
     iif = topo["routers"]["r2"]["links"]["f1"]["interface"]
     oil = topo["routers"]["r2"]["links"]["i3"]["interface"]
 
-    result = verify_ip_mroutes(tgen, dut, src_address, _IGMP_JOIN_RANGE, iif, oil)
+    result = verify_mroutes(tgen, dut, src_address, _IGMP_JOIN_RANGE, iif, oil)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     src_address = source_i1
     iif = topo["routers"]["r2"]["links"]["l1"]["interface"]
     oil = topo["routers"]["r2"]["links"]["i3"]["interface"]
 
-    result = verify_ip_mroutes(
+    result = verify_mroutes(
         tgen, dut, src_address, _IGMP_JOIN_RANGE, iif, oil, expected=False
     )
     assert (
@@ -4156,7 +4156,7 @@ def test_verify_multicast_traffic_when_LHR_connected_to_RP_p1(request):
     )
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -4200,9 +4200,9 @@ def test_verify_multicast_traffic_when_FHR_connected_to_RP_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
     check_router_status(tgen)
 
     step(
@@ -4289,7 +4289,7 @@ def test_verify_multicast_traffic_when_FHR_connected_to_RP_p1(request):
     ]
 
     for data in input_dict_all:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -4333,7 +4333,7 @@ def test_verify_multicast_traffic_when_FHR_connected_to_RP_p1(request):
     ]
 
     for data in input_dict_l1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -4360,7 +4360,7 @@ def test_verify_multicast_traffic_when_FHR_connected_to_RP_p1(request):
     )
 
     for data in input_dict_l1:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -4399,7 +4399,7 @@ def test_verify_multicast_traffic_when_FHR_connected_to_RP_p1(request):
     ]
 
     for data in input_dict_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -4426,7 +4426,7 @@ def test_verify_multicast_traffic_when_FHR_connected_to_RP_p1(request):
     )
 
     for data in input_dict_r2:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -4471,7 +4471,7 @@ def test_verify_multicast_traffic_when_FHR_connected_to_RP_p1(request):
     ]
 
     for data in input_dict_all_star:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo4.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo4.py
@@ -73,10 +73,10 @@ from lib.common_config import (
 from lib.pim import (
     create_pim_config,
     create_igmp_config,
-    verify_ip_mroutes,
-    clear_ip_pim_interface_traffic,
+    verify_mroutes,
+    clear_pim_interface_traffic,
     verify_upstream_iif,
-    clear_ip_mroute,
+    clear_mroute,
     verify_pim_rp_info,
     get_pim_interface_traffic,
     McastTesterHelper,
@@ -273,9 +273,9 @@ def test_mroute_when_RP_reachable_default_route_p2(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step(
         "Remove c1-c2 connected link to simulate topo "
@@ -357,7 +357,7 @@ def test_mroute_when_RP_reachable_default_route_p2(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_sg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -373,7 +373,7 @@ def test_mroute_when_RP_reachable_default_route_p2(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -416,7 +416,7 @@ def test_mroute_when_RP_reachable_default_route_p2(request):
     step("Verify mroute not present after Delete of static routes on c1")
 
     for data in input_dict_sg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -448,7 +448,7 @@ def test_mroute_when_RP_reachable_default_route_p2(request):
         )
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -510,7 +510,7 @@ def test_mroute_when_RP_reachable_default_route_p2(request):
     step("Verify (s,g) populated after adding default route ")
 
     for data in input_dict_sg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -528,7 +528,7 @@ def test_mroute_when_RP_reachable_default_route_p2(request):
     step("Verify (*,g) populated after adding default route ")
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -562,9 +562,9 @@ def test_mroute_with_RP_default_route_all_nodes_p2(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step(
         "Remove c1-c2 connected link to simulate topo "
@@ -646,7 +646,7 @@ def test_mroute_with_RP_default_route_all_nodes_p2(request):
     step("Verify mroutes and iff upstream")
 
     for data in input_dict_sg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -662,7 +662,7 @@ def test_mroute_with_RP_default_route_all_nodes_p2(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -714,7 +714,7 @@ def test_mroute_with_RP_default_route_all_nodes_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -788,7 +788,7 @@ def test_mroute_with_RP_default_route_all_nodes_p2(request):
     step("Verify (s,g) populated after adding default route ")
 
     for data in input_dict_sg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -806,7 +806,7 @@ def test_mroute_with_RP_default_route_all_nodes_p2(request):
     step("Verify (*,g) populated after adding default route ")
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -840,9 +840,9 @@ def test_PIM_hello_tx_rx_p1(request):
 
     # Creating configuration from JSON
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
+    clear_mroute(tgen)
     reset_config_on_routers(tgen)
-    clear_ip_pim_interface_traffic(tgen, topo)
+    clear_pim_interface_traffic(tgen, topo)
 
     step(
         "Remove c1-c2 connected link to simulate topo "
@@ -923,7 +923,7 @@ def test_PIM_hello_tx_rx_p1(request):
 
     step("(*,G) and (S,G) created on f1 and node verify using 'show ip mroute'")
     for data in input_dict_sg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],
@@ -934,7 +934,7 @@ def test_PIM_hello_tx_rx_p1(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     for data in input_dict_starg:
-        result = verify_ip_mroutes(
+        result = verify_mroutes(
             tgen,
             data["dut"],
             data["src_address"],

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp.py
@@ -135,16 +135,16 @@ from lib.pim import (
     verify_igmp_groups,
     verify_upstream_iif,
     verify_join_state_and_timer,
-    verify_ip_mroutes,
+    verify_mroutes,
     verify_pim_neighbors,
     get_pim_interface_traffic,
     verify_pim_rp_info,
     verify_pim_state,
-    clear_ip_pim_interface_traffic,
-    clear_ip_igmp_interfaces,
-    clear_ip_pim_interfaces,
-    clear_ip_mroute,
-    clear_ip_mroute_verify,
+    clear_pim_interface_traffic,
+    clear_igmp_interfaces,
+    clear_pim_interfaces,
+    clear_mroute,
+    clear_mroute_verify,
     McastTesterHelper,
 )
 
@@ -419,7 +419,7 @@ def test_add_delete_static_RP_p0(request):
     result = verify_join_state_and_timer(tgen, dut, iif, STAR, GROUP_ADDRESS)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
     step("r1: Verify ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify ip pim join")
@@ -480,7 +480,7 @@ def test_add_delete_static_RP_p0(request):
     )
 
     step("r1: Verify ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert (
         result is not True
     ), "Testcase {} : Failed \n " "r1: mroutes are still present \n Error: {}".format(
@@ -531,8 +531,8 @@ def test_SPT_RPT_path_same_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     dut = "r1"
     intf = "r1-r3-eth2"
@@ -585,7 +585,7 @@ def test_SPT_RPT_path_same_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -598,7 +598,7 @@ def test_SPT_RPT_path_same_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) upstream IIF interface")
@@ -613,7 +613,7 @@ def test_SPT_RPT_path_same_p1(request):
 
     step("r2: Verify (*, G) ip mroutes")
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (S, G) upstream IIF interface")
@@ -626,7 +626,7 @@ def test_SPT_RPT_path_same_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -648,7 +648,7 @@ def test_SPT_RPT_path_same_p1(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r2-eth1"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     # Uncomment next line for debugging
@@ -683,8 +683,8 @@ def test_not_reachable_static_RP_p0(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     dut = "r1"
     intf = "r1-r3-eth2"
@@ -741,7 +741,7 @@ def test_not_reachable_static_RP_p0(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1 :Verify ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Make RP un-reachable")
@@ -811,7 +811,7 @@ def test_not_reachable_static_RP_p0(request):
     assert result is True, "Testcase{} : Failed Error: {}".format(tc_name, result)
 
     step("r1: (*, G) cleared from mroute table using show ip mroute")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert result is not True, (
         "Testcase {} : Failed \n "
         "r1: (*, G) are not cleared from mroute table \n Error: {}".format(
@@ -847,8 +847,8 @@ def test_add_RP_after_join_received_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on R1 interface")
     step("Configure r2 loopback interface as RP")
@@ -932,7 +932,7 @@ def test_add_RP_after_join_received_p1(request):
     )
 
     step("r1: Verify ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert (
         result is not True
     ), "Testcase {} : Failed \n " "r1: mroutes are still present\n Error: {}".format(
@@ -975,7 +975,7 @@ def test_add_RP_after_join_received_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1 : Verify ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
     logger.info("Expected behavior: %s", result)
 
@@ -1015,8 +1015,8 @@ def test_reachable_static_RP_after_join_p0(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface and send IGMP " "join (225.1.1.1) to r1")
     step("Configure r2 loopback interface as RP")
@@ -1084,7 +1084,7 @@ def test_reachable_static_RP_after_join_p0(request):
     )
 
     step("r1 : Verify ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert (
         result is not True
     ), "Testcase {} : Failed \n " "r1: mroutes are still present\n Error: {}".format(
@@ -1118,7 +1118,7 @@ def test_reachable_static_RP_after_join_p0(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1 : Verify ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
     logger.info("Expected behavior: %s", result)
 
@@ -1180,8 +1180,8 @@ def test_send_join_on_higher_preffered_rp_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface")
     step("Configure RP on r2 (loopback interface) for the group range " "224.0.0.0/4")
@@ -1273,7 +1273,7 @@ def test_send_join_on_higher_preffered_rp_p1(request):
 
     step("r1 : Verify ip mroutes")
     iif = "r1-r4-eth3"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1 : Verify PIM state")
@@ -1288,7 +1288,7 @@ def test_send_join_on_higher_preffered_rp_p1(request):
     result = verify_join_state_and_timer(tgen, dut, iif, STAR, GROUP_ADDRESS)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("r1 : Verify joinTx, pruneTx count before RP gets deleted")
     state_dict = {"r1": {"r1-r2-eth1": ["joinTx"], "r1-r4-eth3": ["pruneTx"]}}
@@ -1342,7 +1342,7 @@ def test_send_join_on_higher_preffered_rp_p1(request):
         "RP gets deleted"
     )
     iif = "r1-r2-eth1"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
     logger.info("Expected behavior: %s", result)
 
@@ -1417,8 +1417,8 @@ def test_RP_configured_as_LHR_1_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface")
     step("Configure RP on r1 (loopback interface) for the group range" " 224.0.0.0/4")
@@ -1560,7 +1560,7 @@ def test_RP_configured_as_LHR_1_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -1573,7 +1573,7 @@ def test_RP_configured_as_LHR_1_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -1594,7 +1594,7 @@ def test_RP_configured_as_LHR_1_p1(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     # Uncomment next line for debugging
@@ -1629,8 +1629,8 @@ def test_RP_configured_as_LHR_2_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface")
     step("Configure RP on r1 (loopback interface) for the group range" " 224.0.0.0/4")
@@ -1765,7 +1765,7 @@ def test_RP_configured_as_LHR_2_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -1778,7 +1778,7 @@ def test_RP_configured_as_LHR_2_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -1800,7 +1800,7 @@ def test_RP_configured_as_LHR_2_p1(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     # Uncomment next line for debugging
@@ -1835,8 +1835,8 @@ def test_RP_configured_as_FHR_1_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface")
     step("Configure RP on r2 (loopback interface) for the group range" " 225.1.1.0/24")
@@ -1972,7 +1972,7 @@ def test_RP_configured_as_FHR_1_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -1984,7 +1984,7 @@ def test_RP_configured_as_FHR_1_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -2006,7 +2006,7 @@ def test_RP_configured_as_FHR_1_p1(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     # Uncomment next line for debugging
@@ -2040,8 +2040,8 @@ def test_RP_configured_as_FHR_2_p2(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface")
     step("Configure RP on r2 (loopback interface) for the group range" " 225.1.1.0/24")
@@ -2178,7 +2178,7 @@ def test_RP_configured_as_FHR_2_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -2191,7 +2191,7 @@ def test_RP_configured_as_FHR_2_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -2213,7 +2213,7 @@ def test_RP_configured_as_FHR_2_p2(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     # Uncomment next line for debugging
@@ -2249,8 +2249,8 @@ def test_SPT_RPT_path_different_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface and send IGMP join (225.1.1.1) to r1")
     step("Configure RP on r2 (loopback interface) for the group range" " 224.0.0.0/4")
@@ -2288,7 +2288,7 @@ def test_SPT_RPT_path_different_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -2301,7 +2301,7 @@ def test_SPT_RPT_path_different_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) upstream IIF interface")
@@ -2316,7 +2316,7 @@ def test_SPT_RPT_path_different_p1(request):
 
     step("r2: Verify (*, G) ip mroutes")
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -2338,7 +2338,7 @@ def test_SPT_RPT_path_different_p1(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (S, G) upstream IIF interface")
@@ -2362,7 +2362,7 @@ def test_SPT_RPT_path_different_p1(request):
 
     step("r2: Verify (S, G) ip mroutes")
     oif = "none"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     # Uncomment next line for debugging
@@ -2400,8 +2400,8 @@ def test_clear_pim_configuration_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface")
     step("Configure RP on r2 (loopback interface) for the group range" " 224.0.0.0/4")
@@ -2444,19 +2444,19 @@ def test_clear_pim_configuration_p1(request):
 
     step("r1: Verify (*, G) ip mroutes")
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify IGMP groups timer restarted")
-    result = clear_ip_igmp_interfaces(tgen, dut)
+    result = clear_igmp_interfaces(tgen, dut)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify PIM neighbor timer restarted")
-    result = clear_ip_pim_interfaces(tgen, dut)
+    result = clear_pim_interfaces(tgen, dut)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify PIM mroute timer restarted")
-    result = clear_ip_mroute_verify(tgen, dut)
+    result = clear_mroute_verify(tgen, dut)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     # Uncomment next line for debugging
@@ -2493,8 +2493,8 @@ def test_restart_pimd_process_p2(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface and send IGMP join (225.1.1.1) to R1")
     step("Configure RP on r3 (loopback interface) for the group range" " 224.0.0.0/4")
@@ -2535,7 +2535,7 @@ def test_restart_pimd_process_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -2548,7 +2548,7 @@ def test_restart_pimd_process_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) upstream IIF interface")
@@ -2563,7 +2563,7 @@ def test_restart_pimd_process_p2(request):
 
     step("r2: Verify (*, G) ip mroutes")
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -2585,7 +2585,7 @@ def test_restart_pimd_process_p2(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     dut = "r1"
@@ -2594,7 +2594,7 @@ def test_restart_pimd_process_p2(request):
     logger.info("waiting for 10 sec to make sure old mroute time is higher")
     sleep(10)
     # Why do we then wait 60 seconds below before checking the routes?
-    uptime_before = verify_ip_mroutes(
+    uptime_before = verify_mroutes(
         tgen, dut, STAR, GROUP_ADDRESS, iif, oil, return_uptime=True, mwait=60
     )
     assert isinstance(uptime_before, dict), "Testcase{} : Failed Error: {}".format(
@@ -2611,7 +2611,7 @@ def test_restart_pimd_process_p2(request):
     sleep(5)
 
     # Why do we then wait 10 seconds below before checking the routes?
-    uptime_after = verify_ip_mroutes(
+    uptime_after = verify_mroutes(
         tgen, dut, STAR, GROUP_ADDRESS, iif, oil, return_uptime=True, mwait=10
     )
     assert isinstance(uptime_after, dict), "Testcase{} : Failed Error: {}".format(
@@ -2650,8 +2650,8 @@ def test_multiple_groups_same_RP_address_p2(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface and send IGMP join (225.1.1.1) to r1")
     step("Configure RP on r2 (loopback interface) for the group range" "225.1.1.0/24")
@@ -2701,7 +2701,7 @@ def test_multiple_groups_same_RP_address_p2(request):
 
     step("r1: Verify (*, G) ip mroutes")
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, group_address_list, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, group_address_list, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -2716,7 +2716,7 @@ def test_multiple_groups_same_RP_address_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) upstream IIF interface")
@@ -2731,7 +2731,7 @@ def test_multiple_groups_same_RP_address_p2(request):
 
     step("r2: Verify (*, G) ip mroutes")
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, group_address_list, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, group_address_list, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -2753,7 +2753,7 @@ def test_multiple_groups_same_RP_address_p2(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (S, G) upstream IIF interface")
@@ -2777,7 +2777,7 @@ def test_multiple_groups_same_RP_address_p2(request):
 
     step("r2: Verify (S, G) ip mroutes")
     oif = "none"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Delete RP configuration")
@@ -2844,7 +2844,7 @@ def test_multiple_groups_same_RP_address_p2(request):
 
     step("r1: Verify (*, G) ip mroutes")
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, group_address_list, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, group_address_list, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -2859,7 +2859,7 @@ def test_multiple_groups_same_RP_address_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) upstream IIF interface")
@@ -2874,7 +2874,7 @@ def test_multiple_groups_same_RP_address_p2(request):
 
     step("r2: Verify (*, G) ip mroutes")
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, group_address_list, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, group_address_list, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (S, G) upstream IIF interface")
@@ -2898,7 +2898,7 @@ def test_multiple_groups_same_RP_address_p2(request):
 
     step("r2: Verify (S, G) ip mroutes")
     oif = "none"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -2920,7 +2920,7 @@ def test_multiple_groups_same_RP_address_p2(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     write_test_footer(tc_name)
@@ -2955,8 +2955,8 @@ def test_multiple_groups_different_RP_address_p2(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Delete existing RP configuration")
     input_dict = {
@@ -3043,7 +3043,7 @@ def test_multiple_groups_different_RP_address_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_1, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_1, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -3058,9 +3058,7 @@ def test_multiple_groups_different_RP_address_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) upstream IIF interface")
@@ -3075,7 +3073,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r2: Verify (*, G) ip mroutes")
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_1, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_1, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (S, G) upstream IIF interface")
@@ -3098,9 +3096,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r2: Verify (S, G) ip mroutes")
     oif = "none"
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -3122,9 +3118,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) upstream IIF interface")
@@ -3139,7 +3133,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r1: Verify (*, G) ip mroutes")
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_2, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_2, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -3154,9 +3148,7 @@ def test_multiple_groups_different_RP_address_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r4: Verify (*, G) upstream IIF interface")
@@ -3171,7 +3163,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r4: Verify (*, G) ip mroutes")
     oif = "r4-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_2, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_2, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r4: Verify (S, G) upstream IIF interface")
@@ -3194,9 +3186,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r4: Verify (S, G) ip mroutes")
     oif = "none"
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -3215,9 +3205,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("Delete RP configuration")
@@ -3316,7 +3304,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r1: Verify (*, G) ip mroutes")
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_1, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_1, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -3331,9 +3319,7 @@ def test_multiple_groups_different_RP_address_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) upstream IIF interface")
@@ -3348,7 +3334,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r2: Verify (*, G) ip mroutes")
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_1, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_1, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (S, G) upstream IIF interface")
@@ -3371,9 +3357,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r2: Verify (S, G) ip mroutes")
     oif = "none"
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -3395,9 +3379,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_1, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) upstream IIF interface")
@@ -3412,7 +3394,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r1: Verify (*, G) ip mroutes")
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_2, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_2, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) upstream IIF interface")
@@ -3427,9 +3409,7 @@ def test_multiple_groups_different_RP_address_p2(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (S, G) ip mroutes")
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r4: Verify (*, G) upstream IIF interface")
@@ -3444,7 +3424,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r4: Verify (*, G) ip mroutes")
     oif = "r4-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_2, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS_LIST_2, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r4: Verify (S, G) upstream IIF interface")
@@ -3467,9 +3447,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r4: Verify (S, G) ip mroutes")
     oif = "none"
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (S, G) upstream IIF interface")
@@ -3491,9 +3469,7 @@ def test_multiple_groups_different_RP_address_p2(request):
 
     step("r3: Verify (S, G) ip mroutes")
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(
-        tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif
-    )
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, GROUP_ADDRESS_LIST_2, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     write_test_footer(tc_name)
@@ -3522,8 +3498,8 @@ def test_shutdown_primary_path_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     # Steps to execute
     step("Enable IGMP on r1 interface")
@@ -3552,14 +3528,14 @@ def test_shutdown_primary_path_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) ip mroutes")
     dut = "r2"
     iif = "lo"
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Shut the interface r1-r2-eth1 from R1 to R2")
@@ -3578,21 +3554,21 @@ def test_shutdown_primary_path_p1(request):
     dut = "r1"
     iif = "r1-r3-eth2"
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) ip mroutes")
     dut = "r2"
     iif = "lo"
     oif = "r2-r3-eth1"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (*, G) ip mroutes")
     dut = "r3"
     iif = "r3-r2-eth1"
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Shut the link from R1 to R3 from R3 node")
@@ -3609,7 +3585,7 @@ def test_shutdown_primary_path_p1(request):
     dut = "r1"
     iif = "r1-r3-eth2"
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert result is not True, (
         "Testcase {} : Failed \n "
         "r1: (*,G) mroutes are not cleared after shut of R1 to R3 link\n Error: {}".format(
@@ -3621,7 +3597,7 @@ def test_shutdown_primary_path_p1(request):
     dut = "r2"
     iif = "lo"
     oif = "r2-r3-eth1"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert result is not True, (
         "Testcase {} : Failed \n "
         "r2: (*,G) mroutes are not cleared after shut of R1 to R3 link\n Error: {}".format(
@@ -3633,7 +3609,7 @@ def test_shutdown_primary_path_p1(request):
     dut = "r3"
     iif = "r3-r2-eth1"
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert result is not True, (
         "Testcase {} : Failed \n "
         "r3: (*,G) mroutes are not cleared after shut of R1 to R3 link\n Error: {}".format(
@@ -3650,21 +3626,21 @@ def test_shutdown_primary_path_p1(request):
     dut = "r1"
     iif = "r1-r3-eth2"
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) ip mroutes")
     dut = "r2"
     iif = "lo"
     oif = "r2-r3-eth1"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r3: Verify (*, G) ip mroutes")
     dut = "r3"
     iif = "r3-r2-eth1"
     oif = "r3-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: No shutdown the link from R1 to R2 from R1 node")
@@ -3676,14 +3652,14 @@ def test_shutdown_primary_path_p1(request):
     dut = "r1"
     iif = "r1-r2-eth1"
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) ip mroutes")
     dut = "r2"
     iif = "lo"
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     write_test_footer(tc_name)
@@ -3711,8 +3687,8 @@ def test_delete_RP_shut_noshut_upstream_interface_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface")
     step("Configure RP on r2 (loopback interface) for the group range" " 224.0.0.0/4")
@@ -3740,14 +3716,14 @@ def test_delete_RP_shut_noshut_upstream_interface_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes created")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) ip mroutes created")
     dut = "r2"
     iif = "lo"
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Delete RP configuration")
@@ -3794,7 +3770,7 @@ def test_delete_RP_shut_noshut_upstream_interface_p1(request):
     dut = "r1"
     iif = "r1-r2-eth1"
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert result is not True, (
         "Testcase {} : Failed \n "
         "r1: (*,G) mroutes are not cleared after shut of R1 to R0 link\n Error: {}".format(
@@ -3806,7 +3782,7 @@ def test_delete_RP_shut_noshut_upstream_interface_p1(request):
     dut = "r2"
     iif = "lo"
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert result is not True, (
         "Testcase {} : Failed \n "
         "r2: (*,G) mroutes are not cleared after shut of R1 to R0 link\n Error: {}".format(
@@ -3840,8 +3816,8 @@ def test_delete_RP_shut_noshut_RP_interface_p1(request):
     step("Creating configuration from JSON")
     reset_config_on_routers(tgen)
     app_helper.stop_all_hosts()
-    clear_ip_mroute(tgen)
-    clear_ip_pim_interface_traffic(tgen, TOPO)
+    clear_mroute(tgen)
+    clear_pim_interface_traffic(tgen, TOPO)
 
     step("Enable IGMP on r1 interface")
     step("Configure RP on r2 (lo) for the group range" " 224.0.0.0/4")
@@ -3868,14 +3844,14 @@ def test_delete_RP_shut_noshut_RP_interface_p1(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r1: Verify (*, G) ip mroutes created")
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Verify (*, G) ip mroutes created")
     dut = "r2"
     iif = "lo"
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step("r2: Delete RP configuration")
@@ -3917,7 +3893,7 @@ def test_delete_RP_shut_noshut_RP_interface_p1(request):
     dut = "r1"
     iif = "r1-r2-eth1"
     oif = "r1-r0-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert result is not True, (
         "Testcase {} : Failed \n "
         "r1: (*,G) mroutes are not cleared after shut of R1 to R2 and R3 link\n Error: {}".format(
@@ -3929,7 +3905,7 @@ def test_delete_RP_shut_noshut_RP_interface_p1(request):
     dut = "r2"
     iif = "lo"
     oif = "r2-r1-eth0"
-    result = verify_ip_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
+    result = verify_mroutes(tgen, dut, STAR, GROUP_ADDRESS, iif, oif, expected=False)
     assert result is not True, (
         "Testcase {} : Failed \n "
         "r2: (*,G) mroutes are not cleared after shut of R1 to R2 and R3 link\n Error: {}".format(


### PR DESCRIPTION
1. Modified pim APIs name to generic one, same APIs would be used for PIMv4 and PIMv6
verifications
2. Modified all affacted scripts and ran multiple times locally to avoid CI failures

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>