### PR TITLE
<Do not review>Pimv6 temporary build for v6 testing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -635,6 +635,8 @@ AC_ARG_ENABLE([isisd],
   AS_HELP_STRING([--disable-isisd], [do not build isisd]))
 AC_ARG_ENABLE([pimd],
   AS_HELP_STRING([--disable-pimd], [do not build pimd]))
+AC_ARG_ENABLE([pim6d],
+  AS_HELP_STRING([--disable-pim6d], [do not build pim6d]))
 AC_ARG_ENABLE([pbrd],
   AS_HELP_STRING([--disable-pbrd], [do not build pbrd]))
 AC_ARG_ENABLE([sharpd],
@@ -2079,6 +2081,22 @@ case "$host_os" in
 esac
 fi
 
+dnl ----------------------------------------
+dnl PIMv6 is only supported on linux for now
+dnl ----------------------------------------
+if test "$enable_pim6d" != "no"; then
+  AC_MSG_CHECKING([for pim6d OS support])
+  case "$host_os" in
+    linux*)
+      AC_MSG_RESULT([yes])
+      ;;
+    *)
+      AC_MSG_RESULT([no])
+      enable_pim6d="no"
+      ;;
+  esac
+fi
+
 dnl -------------------------------------
 dnl VRRP is only supported on linux
 dnl -------------------------------------
@@ -2711,6 +2729,7 @@ AM_CONDITIONAL([BABELD], [test "$enable_babeld" != "no"])
 AM_CONDITIONAL([OSPF6D], [test "$enable_ospf6d" != "no"])
 AM_CONDITIONAL([ISISD], [test "$enable_isisd" != "no"])
 AM_CONDITIONAL([PIMD], [test "$enable_pimd" != "no"])
+AM_CONDITIONAL([PIM6D], [test "$enable_pim6d" != "no"])
 AM_CONDITIONAL([PBRD], [test "$enable_pbrd" != "no"])
 AM_CONDITIONAL([SHARPD], [test "$enable_sharpd" = "yes"])
 AM_CONDITIONAL([STATICD], [test "$enable_staticd" != "no"])

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -102,6 +102,10 @@ void pim_router_init(void)
 	router->t_periodic = PIM_DEFAULT_T_PERIODIC;
 	router->multipath = MULTIPATH_NUM;
 
+#if PIM_IPV == 6
+	PIM_DO_DEBUG_MROUTE;
+	PIM_DO_DEBUG_MROUTE_DETAIL;
+#endif
 	/*
 	  RFC 4601: 4.6.3.  Assert Metrics
 

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -171,15 +171,13 @@ pimd_pimd_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=4
 pimd_pimd_LDADD = lib/libfrr.la $(LIBCAP)
 
 if PIMD
-if DEV_BUILD
 #
 # pim6d is only enabled for --enable-dev-build, and NOT installed currently
 # (change noinst_ to sbin_ below to install it.)
 #
-noinst_PROGRAMS += pimd/pim6d
+sbin_PROGRAMS += pimd/pim6d
 pimd_pim6d_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=6
 pimd_pim6d_LDADD = lib/libfrr.la $(LIBCAP)
-endif
 endif
 
 pimd_test_igmpv3_join_LDADD = lib/libfrr.la

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -170,7 +170,7 @@ clippy_scan += \
 pimd_pimd_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=4
 pimd_pimd_LDADD = lib/libfrr.la $(LIBCAP)
 
-if PIMD
+if PIM6D
 #
 # pim6d is only enabled for --enable-dev-build, and NOT installed currently
 # (change noinst_ to sbin_ below to install it.)

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -24,6 +24,7 @@
 %{!?with_pam:           %global  with_pam           0 }
 %{!?with_pbrd:          %global  with_pbrd          1 }
 %{!?with_pimd:          %global  with_pimd          1 }
+%{!?with_pim6d:         %global  with_pim6d         1 }
 %{!?with_vrrpd:         %global  with_vrrpd         1 }
 %{!?with_rtadv:         %global  with_rtadv         1 }
 %{!?with_watchfrr:      %global  with_watchfrr      1 }
@@ -81,6 +82,7 @@
 # if CentOS / RedHat and version < 7, then disable PIMd (too old, won't work)
 %if 0%{?rhel} && 0%{?rhel} < 7
     %global  with_pimd  0
+    %global  with_pim6d 0
 %endif
 
 # misc internal defines
@@ -100,6 +102,12 @@
     %define daemon_pimd pimd
 %else
     %define daemon_pimd ""
+%endif
+
+%if %{with_pim6d}
+    %define daemon_pim6d pim6d
+%else
+    %define daemon_pim6d ""
 %endif
 
 %if %{with_pbrd}
@@ -150,7 +158,7 @@
     %define daemon_pathd ""
 %endif
 
-%define all_daemons %{daemon_list} %{daemon_ldpd} %{daemon_pimd} %{daemon_nhrpd} %{daemon_eigrpd} %{daemon_babeld} %{daemon_watchfrr} %{daemon_pbrd} %{daemon_bfdd} %{daemon_vrrpd} %{daemon_pathd}
+%define all_daemons %{daemon_list} %{daemon_ldpd} %{daemon_pimd} %{daemon_pim6d} %{daemon_nhrpd} %{daemon_eigrpd} %{daemon_babeld} %{daemon_watchfrr} %{daemon_pbrd} %{daemon_bfdd} %{daemon_vrrpd} %{daemon_pathd}
 
 #release sub-revision (the two digits after the CONFDATE)
 %{!?release_rev:        %global  release_rev        01 }
@@ -341,6 +349,11 @@ routing state through standard SNMP MIBs.
     --enable-pimd \
 %else
     --disable-pimd \
+%endif
+%if %{with_pim6d}
+    --enable-pim6d \
+%else
+    --disable-pim6d \
 %endif
 %if %{with_pbrd}
     --enable-pbrd \
@@ -666,6 +679,9 @@ fi
 %if %{with_pimd}
     %{_sbindir}/pimd
 %endif
+%if %{with_pim6d}
+    %{_sbindir}/pim6d
+%endif
 %if %{with_pbrd}
     %{_sbindir}/pbrd
 %endif
@@ -779,6 +795,9 @@ sed -i 's/ -M rpki//' %{_sysconfdir}/frr/daemons
 
 
 %changelog
+* Tue Jun 21 2022 Mobashshera Rasool <mrasool@vmware.com> - %{version}
+- remove PIM6d from CentOS/RedHat 6 RPM packages (won't work - too old)
+
 * Tue Jun  7 2022 Donatas Abraitis <donatas@opensourcerouting.org> - %{version}
 
 * Tue Mar  1 2022 Jafar Al-Gharaibeh <jafar@atcorp.com> - 8.2


### PR DESCRIPTION
This change is temporarily done to enable pimv6 for testing purpose.

Please ignore it.

This PR contains all the required open PRs with pimv6 enabled.