### PR TITLE
tests: Use XCALLOC instead of XMALLOC for threads

### DIFF
--- a/tests/lib/test_timer_correctness.c
+++ b/tests/lib/test_timer_correctness.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
 
 	prng = prng_new(0);
 
-	timers = XMALLOC(MTYPE_TMP, SCHEDULE_TIMERS * sizeof(*timers));
+	timers = XCALLOC(MTYPE_TMP, SCHEDULE_TIMERS * sizeof(*timers));
 
 	for (i = 0; i < SCHEDULE_TIMERS; i++) {
 		long interval_msec;
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
 	 * representing the expected "output" of the timers when they
 	 * are run. */
 	j = 0;
-	alarms = XMALLOC(MTYPE_TMP, timers_pending * sizeof(*alarms));
+	alarms = XCALLOC(MTYPE_TMP, timers_pending * sizeof(*alarms));
 	for (i = 0; i < SCHEDULE_TIMERS; i++) {
 		if (!timers[i])
 			continue;


### PR DESCRIPTION
Someone decided to do malloc testing over make check.

Fixes: #11120
Signed-off-by: Donald Sharp <sharpd@nvidia.com>