### PR TITLE
*: standardize interface name maximum length

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "plist.h"
 #include "lib_errors.h"
 #include "network.h"
+#include "if.h"
 
 #include "babel_main.h"
 #include "babeld.h"
@@ -251,7 +252,7 @@ babel_get_myid(void)
     /* We failed to get a global EUI64 from the interfaces we were given.
      Let's try to find an interface with a MAC address. */
     for(i = 1; i < 256; i++) {
-        char buf[IF_NAMESIZE], *ifname;
+        char buf[INTERFACE_NAMSIZ], *ifname;
         unsigned char eui[8];
         ifname = if_indextoname(i, buf);
         if(ifname == NULL)

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -190,8 +190,8 @@ struct bfd_key {
 	uint16_t mhop;
 	struct in6_addr peer;
 	struct in6_addr local;
-	char ifname[MAXNAMELEN];
-	char vrfname[MAXNAMELEN];
+	char ifname[INTERFACE_NAMSIZ];
+	char vrfname[VRF_NAMSIZ];
 } __attribute__((packed));
 
 struct bfd_session_stats {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2440,7 +2440,7 @@ static inline uint32_t bgp_vrf_interfaces(struct bgp *bgp, bool active)
 	if (vrf == NULL)
 		return 0;
 	RB_FOREACH (ifp, if_name_head, &vrf->ifaces_by_name) {
-		if (strncmp(ifp->name, bgp->name, VRF_NAMSIZ) == 0)
+		if (strcmp(ifp->name, bgp->name) == 0)
 			continue;
 		if (!active || if_is_up(ifp))
 			count++;

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -352,7 +352,7 @@ struct iface_ldp_sync {
 
 struct iface {
 	RB_ENTRY(iface)		 entry;
-	char			 name[IF_NAMESIZE];
+	char			 name[INTERFACE_NAMSIZ];
 	ifindex_t		 ifindex;
 	struct if_addr_head	 addr_list;
 	struct in6_addr		 linklocal;
@@ -458,7 +458,7 @@ struct ldp_entity_stats {
 struct l2vpn_if {
 	RB_ENTRY(l2vpn_if)	 entry;
 	struct l2vpn		*l2vpn;
-	char			 ifname[IF_NAMESIZE];
+	char			 ifname[INTERFACE_NAMSIZ];
 	ifindex_t		 ifindex;
 	int			 operative;
 	uint8_t			 mac[ETH_ALEN];
@@ -475,7 +475,7 @@ struct l2vpn_pw {
 	int			 af;
 	union ldpd_addr		 addr;
 	uint32_t		 pwid;
-	char			 ifname[IF_NAMESIZE];
+	char			 ifname[INTERFACE_NAMSIZ];
 	ifindex_t		 ifindex;
 	bool			 enabled;
 	uint32_t		 remote_group;
@@ -507,7 +507,7 @@ struct l2vpn {
 	int			 type;
 	int			 pw_type;
 	int			 mtu;
-	char			 br_ifname[IF_NAMESIZE];
+	char			 br_ifname[INTERFACE_NAMSIZ];
 	ifindex_t		 br_ifindex;
 	struct l2vpn_if_head	 if_tree;
 	struct l2vpn_pw_head	 pw_tree;
@@ -629,7 +629,7 @@ struct kroute {
 };
 
 struct kaddr {
-	char			 ifname[IF_NAMESIZE];
+	char			 ifname[INTERFACE_NAMSIZ];
 	ifindex_t		 ifindex;
 	int			 af;
 	union ldpd_addr		 addr;
@@ -638,7 +638,7 @@ struct kaddr {
 };
 
 struct kif {
-	char			 ifname[IF_NAMESIZE];
+	char			 ifname[INTERFACE_NAMSIZ];
 	ifindex_t		 ifindex;
 	int			 flags;
 	int			 operative;
@@ -656,7 +656,7 @@ struct acl_check {
 /* control data structures */
 struct ctl_iface {
 	int			 af;
-	char			 name[IF_NAMESIZE];
+	char			 name[INTERFACE_NAMSIZ];
 	ifindex_t		 ifindex;
 	int			 state;
 	enum iface_type		 type;
@@ -667,7 +667,7 @@ struct ctl_iface {
 };
 
 struct ctl_disc_if {
-	char			 name[IF_NAMESIZE];
+	char			 name[INTERFACE_NAMSIZ];
 	int			 active_v4;
 	int			 active_v6;
 	int			 no_adj;
@@ -683,7 +683,7 @@ struct ctl_adj {
 	int			 af;
 	struct in_addr		 id;
 	enum hello_type		 type;
-	char			 ifname[IF_NAMESIZE];
+	char			 ifname[INTERFACE_NAMSIZ];
 	union ldpd_addr		 src_addr;
 	uint16_t		 holdtime;
 	uint16_t		 holdtime_remaining;
@@ -723,7 +723,7 @@ struct ctl_rt {
 struct ctl_pw {
 	uint16_t		 type;
 	char			 l2vpn_name[L2VPN_NAME_LEN];
-	char			 ifname[IF_NAMESIZE];
+	char			 ifname[INTERFACE_NAMSIZ];
 	uint32_t		 pwid;
 	struct in_addr		 lsr_id;
 	uint32_t		 local_label;
@@ -739,7 +739,7 @@ struct ctl_pw {
 };
 
 struct ctl_ldp_sync {
-	char			 name[IF_NAMESIZE];
+	char			 name[INTERFACE_NAMSIZ];
 	ifindex_t		 ifindex;
 	bool			 in_sync;
 	bool			 timer_running;

--- a/lib/if.h
+++ b/lib/if.h
@@ -103,7 +103,7 @@ enum zebra_link_type {
    #define IFNAMSIZ        16
 */
 
-#define INTERFACE_NAMSIZ      20
+#define INTERFACE_NAMSIZ      IFNAMSIZ
 #define INTERFACE_HWADDR_MAX  20
 
 typedef signed int ifindex_t;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3551,7 +3551,7 @@ enum zclient_send_status zebra_send_pw(struct zclient *zclient, int command,
 	stream_reset(s);
 
 	zclient_create_header(s, command, VRF_DEFAULT);
-	stream_write(s, pw->ifname, IF_NAMESIZE);
+	stream_write(s, pw->ifname, INTERFACE_NAMSIZ);
 	stream_putl(s, pw->ifindex);
 
 	/* Put type */
@@ -3598,7 +3598,7 @@ int zebra_read_pw_status_update(ZAPI_CALLBACK_ARGS, struct zapi_pw_status *pw)
 	s = zclient->ibuf;
 
 	/* Get data. */
-	stream_get(pw->ifname, s, IF_NAMESIZE);
+	stream_get(pw->ifname, s, INTERFACE_NAMSIZ);
 	STREAM_GETL(s, pw->ifindex);
 	STREAM_GETL(s, pw->status);
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -618,7 +618,7 @@ struct zapi_sr_policy {
 };
 
 struct zapi_pw {
-	char ifname[IF_NAMESIZE];
+	char ifname[INTERFACE_NAMSIZ];
 	ifindex_t ifindex;
 	int type;
 	int af;
@@ -631,7 +631,7 @@ struct zapi_pw {
 };
 
 struct zapi_pw_status {
-	char ifname[IF_NAMESIZE];
+	char ifname[INTERFACE_NAMSIZ];
 	ifindex_t ifindex;
 	uint32_t status;
 };

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -408,8 +408,7 @@ struct pbr_map_sequence *pbrms_lookup_unique(uint32_t unique, char *ifname,
 
 	RB_FOREACH (pbrm, pbr_map_entry_head, &pbr_maps) {
 		for (ALL_LIST_ELEMENTS_RO(pbrm->incoming, inode, pmi)) {
-			if (strncmp(pmi->ifp->name, ifname, INTERFACE_NAMSIZ)
-			    != 0)
+			if (strcmp(pmi->ifp->name, ifname) != 0)
 				continue;
 
 			if (ppmi)

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1040,7 +1040,7 @@ int zsend_pw_update(struct zserv *client, struct zebra_pw *pw)
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, ZEBRA_PW_STATUS_UPDATE, pw->vrf_id);
-	stream_write(s, pw->ifname, IF_NAMESIZE);
+	stream_write(s, pw->ifname, INTERFACE_NAMSIZ);
 	stream_putl(s, pw->ifindex);
 	stream_putl(s, pw->status);
 
@@ -2998,7 +2998,7 @@ static void zread_srv6_manager_request(ZAPI_HANDLER_ARGS)
 static void zread_pseudowire(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
-	char ifname[IF_NAMESIZE];
+	char ifname[INTERFACE_NAMSIZ];
 	ifindex_t ifindex;
 	int type;
 	int af;
@@ -3014,8 +3014,8 @@ static void zread_pseudowire(ZAPI_HANDLER_ARGS)
 	s = msg;
 
 	/* Get data. */
-	STREAM_GET(ifname, s, IF_NAMESIZE);
-	ifname[IF_NAMESIZE - 1] = '\0';
+	STREAM_GET(ifname, s, INTERFACE_NAMSIZ);
+	ifname[INTERFACE_NAMSIZ - 1] = '\0';
 	STREAM_GETL(s, ifindex);
 	STREAM_GETL(s, type);
 	STREAM_GETL(s, af);

--- a/zebra/zebra_pw.h
+++ b/zebra/zebra_pw.h
@@ -38,7 +38,7 @@ extern "C" {
 struct zebra_pw {
 	RB_ENTRY(zebra_pw) pw_entry, static_pw_entry;
 	vrf_id_t vrf_id;
-	char ifname[IF_NAMESIZE];
+	char ifname[INTERFACE_NAMSIZ];
 	ifindex_t ifindex;
 	int type;
 	int af;


### PR DESCRIPTION
Changes:
- Adjust the FRR interface maximum name length to OS maximum (see `lib/if.h`)
- Use FRR definition to declare all interface name buffers
- Fix some `strncmp` wrong usages

> **NOTE** there is one usage of `IF_NAMESIZE` left in `pimd/mtracebis.c` which was left unchanged on purpose. That file doesn't include any FRR header file.

This PR is a successor for #6840 , but simpler: it only fixes definition usage.