### PR TITLE
bgpd: Fix memory leak for bgp_notify_receive()

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1973,8 +1973,8 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
  */
 static int bgp_notify_receive(struct peer *peer, bgp_size_t size)
 {
-	struct bgp_notify outer;
-	struct bgp_notify inner;
+	struct bgp_notify outer = {};
+	struct bgp_notify inner = {};
 	bool hard_reset = false;
 
 	if (peer->notify.data) {
@@ -2039,12 +2039,13 @@ static int bgp_notify_receive(struct peer *peer, bgp_size_t size)
 		}
 
 		bgp_notify_print(peer, &inner, "received", hard_reset);
-		if (inner.data) {
+		if (inner.length) {
 			XFREE(MTYPE_BGP_NOTIFICATION, inner.data);
 			inner.length = 0;
 		}
 		if (outer.length) {
 			XFREE(MTYPE_BGP_NOTIFICATION, outer.data);
+			XFREE(MTYPE_BGP_NOTIFICATION, outer.raw_data);
 			outer.length = 0;
 		}
 	}


### PR DESCRIPTION
Initialize outer/inner bgp_notify structs to zero.

Free bgp_notify.raw_data after use.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>