### PR TITLE
bgpd: Add CLI knob to enable graceful restart for BGP notifications

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1435,12 +1435,17 @@ static void bgp_peer_send_gr_capability(struct stream *s, struct peer *peer,
 	restart_time = peer->bgp->restart_time;
 	if (peer->bgp->t_startup) {
 		SET_FLAG(restart_time, GRACEFUL_RESTART_R_BIT);
-		SET_FLAG(restart_time, GRACEFUL_RESTART_N_BIT);
 		SET_FLAG(peer->cap, PEER_CAP_GRACEFUL_RESTART_R_BIT_ADV);
-		SET_FLAG(peer->cap, PEER_CAP_GRACEFUL_RESTART_N_BIT_ADV);
-
 		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-			zlog_debug("[BGP_GR] Sending R-Bit/N-Bit for peer: %s",
+			zlog_debug("[BGP_GR] Sending R-Bit for peer: %s",
+				   peer->host);
+	}
+
+	if (CHECK_FLAG(peer->bgp->flags, BGP_FLAG_GRACEFUL_NOTIFICATION)) {
+		SET_FLAG(restart_time, GRACEFUL_RESTART_N_BIT);
+		SET_FLAG(peer->cap, PEER_CAP_GRACEFUL_RESTART_N_BIT_ADV);
+		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
+			zlog_debug("[BGP_GR] Sending N-Bit for peer: %s",
 				   peer->host);
 	}
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -488,6 +488,8 @@ struct bgp {
 #define BGP_FLAG_SUPPRESS_FIB_PENDING (1 << 26)
 #define BGP_FLAG_SUPPRESS_DUPLICATES (1 << 27)
 #define BGP_FLAG_PEERTYPE_MULTIPATH_RELAX (1 << 29)
+/* Indicate Graceful Restart support for BGP NOTIFICATION messages */
+#define BGP_FLAG_GRACEFUL_NOTIFICATION (1 << 30)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -947,6 +947,15 @@ However, it MUST defer route selection for an address family until it either.
    expires. The stale path timer is started when the router receives a Route-Refresh
    BoRR message.
 
+.. clicmd:: bgp graceful-restart notification
+
+   Indicate Graceful Restart support for BGP NOTIFICATION messages.
+
+   After changing this parameter, you have to reset the peers in order to advertise
+   N-bit in Graceful Restart capability.
+
+   Enabled by default.
+
 .. _bgp-per-peer-graceful-restart:
 
 BGP Per Peer Graceful Restart


### PR DESCRIPTION
N-bit flag should be exchanged in BGP OPEN messages, not only when the
bgpd is restarted/started.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>