### PR TITLE
bfdd: fix override between sessions

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -639,6 +639,14 @@ void bfd_recv_cb(struct thread *t)
 		return;
 	}
 
+	/* Ensure that existing good sessions are not overridden. */
+	if (!cp->discrs.remote_discr && bfd->ses_state != PTM_BFD_DOWN &&
+	    bfd->ses_state != PTM_BFD_ADM_DOWN) {
+		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
+			 "'remote discriminator' is zero, not overridden");
+		return;
+	}
+
 	/*
 	 * Multi hop: validate packet TTL.
 	 */


### PR DESCRIPTION
After two single-hop sessions (*no local address are configured*) on two
interfaces are UP, remove one address of one interface, both of them
(actually, quite independent sessions) come to be DOWN, not just one.

Consider two boxes: A with `a1` and `a2` adddress on two interfaces,
and B with `b1` and `b2`.
Two sessions are set up and ok: `s1` with <a1,b1> and `s2` with <a2,b2>.
After `a1` of A is removed, there is an unhappy coincidence:
1) On A: `s1` changes local address, and sends <a2,b1> packets with help
of route.
2) On B: correctly dropped <a2,b1> packets.
3) On A: `s1` sends <a2,b1> packets with zero remote descriminator to
initialize this session.
4) On B: wrongly regarded <a2,b1> packets with zero remote descriminator
as part of `s2`. Then `s2` will vibrate.

So the good sessions are overridden.

In this case, `bfd_key_lookup()` only focuses on the peer address for packets
with zero remote descriminator, it is not enough. According to RFC5880, state
of session needs to be taken into account:

```
If the Your Discriminator field is zero and the State field is not
Down or AdminDown, the packet MUST be discarded.
```

In this case, the <a2,b1> packets with zero remote descriminator won't take
effect until the current good sessions become bad.